### PR TITLE
Refactor lambda code generation and type inference.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ x86/
 [Bb]uild*/
 [Dd]ebug*/
 [Rr]elease*/
+.cache/
 
 # CMake generated files
 CMakeCache.txt

--- a/include/backend/codegen/closures.h
+++ b/include/backend/codegen/closures.h
@@ -31,7 +31,7 @@ bool codegen_generate_closure(CodegenContext* context, const AstNode* node);
  * @param node The call AST node
  * @return true on success, false on failure
  */
-bool codegen_generate_closure_call(CodegenContext* context, const AstNode* node);
+bool codegen_generate_closure_constructor(CodegenContext* context, const AstNode* node);
 
 /**
  * @brief Helper function to detect if a node is a function composition

--- a/include/backend/codegen/context.h
+++ b/include/backend/codegen/context.h
@@ -152,15 +152,9 @@ BindingSystem* codegen_context_get_binding_system(CodegenContext* context);
  * @param context The code generator context
  * @return The function position
  */
-long codegen_context_get_function_position(CodegenContext* context);
+uint64_t codegen_context_pop_queue(CodegenContext* context);
 
-/**
- * @brief Set the function position for the context
- * 
- * @param context The code generator context
- * @param position The function position
- */
-void codegen_context_set_function_position(CodegenContext* context, long position);
+void codegen_context_push_queue(CodegenContext* context, uint64_t lambda_id);
 
 #ifdef __cplusplus
 }

--- a/include/frontend/binding/binding.h
+++ b/include/frontend/binding/binding.h
@@ -12,6 +12,7 @@
 #include "core/memory.h"
 #include "core/string_table.h"
 #include "core/diagnostics.h"
+#include "frontend/ast/core/ast_core.h"
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -90,12 +91,23 @@ typedef struct {
 } EnvironmentTable;
 
 /**
- * @brief Binding system structure
+  * @brief Definitions table structure
+*/
+typedef struct {
+    uint64_t* ids;             /**< Definition IDs */
+    uint64_t* binding_ids;     /**< Binding IDs */
+    AstNode** nodes;           /**< Node of the definition*/
+    size_t count;              /**< Number of definitions */
+    size_t capacity;           /**< Capacity of the definitions table */
+} DefinitionsTable;
+
+/** @brief Binding system structure
  */
 typedef struct {
     Arena* arena;              /**< Arena allocator */
     DiagnosticContext* diag;   /**< Diagnostic context */
     BindingTable binding_table; /**< Binding table */
+    DefinitionsTable def_table; /**< Definitions table */
     ScopeStack scope_stack;    /**< Scope stack */
     LambdaTable lambda_table;  /**< Lambda table */
     EnvironmentTable env_table; /**< Environment table */
@@ -104,6 +116,7 @@ typedef struct {
     uint64_t next_scope_id;    /**< Next scope ID to assign */
     uint64_t next_lambda_id;   /**< Next lambda ID to assign */
     uint64_t next_env_id;      /**< Next environment ID to assign */
+    uint64_t next_def_id;      /**< Next definition ID to assign */
 } BindingSystem;
 
 /**
@@ -345,6 +358,26 @@ bool binding_system_analyze_captures(BindingSystem* system, const struct AstNode
 bool binding_system_analyze_lambda_captures(BindingSystem* system, 
                                           const struct AstNode* lambda, 
                                           uint64_t lambda_id);
+
+/**
+ * @brief Bind a node to the given binding
+ * 
+ * @param system The binding system
+ * @param bind_id The id of the binding
+ * @param node The node that the bind defines
+ * @return The ID of the new definition, or 0 on failure
+ */ 
+uint64_t binding_system_register_define(BindingSystem* system, uint64_t bind_id, AstNode* node);
+
+
+/**
+ * @brief Retrieve a node from the given binding
+ * 
+ * @param system The binding system
+ * @param bind_id The id of the binding
+ * @return The node of the definition 
+ */ 
+AstNode* binding_system_get_definition(BindingSystem* system, uint64_t bind_id);
 
 #ifdef __cplusplus
 }

--- a/include/frontend/parser/parser_core.h
+++ b/include/frontend/parser/parser_core.h
@@ -46,7 +46,7 @@ typedef struct {
  * @param lexer Lexer
  * @return A new parser, or NULL on failure
  */
-Parser* parser_create(Arena* arena, StringTable* strings, DiagnosticContext* diag, Lexer* lexer);
+Parser* parser_create(BindingSystem* binding_system, Arena* arena, StringTable* strings, DiagnosticContext* diag, Lexer* lexer);
 
 /**
  * @brief Parse a program

--- a/include/frontend/type_inference/context.h
+++ b/include/frontend/type_inference/context.h
@@ -13,6 +13,7 @@
 #include "core/type_conversion.h"
 #include "frontend/ast/ast.h"
 #include "core/diagnostics.h"
+#include "frontend/binding/binding.h"
 #include <stdbool.h>
 
 /**
@@ -27,7 +28,7 @@ typedef struct TypeInferenceContext TypeInferenceContext;
  * @param diagnostics Diagnostic context for error reporting
  * @return Type inference context
  */
-TypeInferenceContext* type_inference_context_create(Arena* arena, DiagnosticContext* diagnostics);
+TypeInferenceContext* type_inference_context_create(BindingSystem* binding_system, Arena* arena, DiagnosticContext* diagnostics);
 
 /**
  * @brief Add a node to the context with its inferred type
@@ -99,5 +100,10 @@ Arena* type_inference_get_arena(TypeInferenceContext* context);
  * @return Diagnostic context
  */
 DiagnosticContext* type_inference_get_diagnostics(TypeInferenceContext* context);
+
+/**
+* @brief Get the binding system from the context
+*/
+BindingSystem* type_inference_get_binding_system(TypeInferenceContext* context);
 
 #endif /* ESHKOL_TYPE_INFERENCE_CONTEXT_H */

--- a/src/backend/codegen/compiler.c
+++ b/src/backend/codegen/compiler.c
@@ -163,7 +163,7 @@ int codegen_compile_and_execute(CodegenContext* context, const char* c_file, cha
     
     // Create command to compile the C file
     char compile_cmd[1024];
-    snprintf(compile_cmd, sizeof(compile_cmd), "gcc -I%s -o %s %s", include_path, temp_executable, c_file);
+    snprintf(compile_cmd, sizeof(compile_cmd), "gcc -I%s -o %s %s %s", include_path, temp_executable, c_file, "../src/core/utils/closure.c");
     
     // Free allocated memory
     free(source_dir);

--- a/src/backend/codegen/definitions.c
+++ b/src/backend/codegen/definitions.c
@@ -266,7 +266,7 @@ bool codegen_generate_lambda(CodegenContext* context, const AstNode* node) {
     assert(node->type == AST_LAMBDA);
     
     // Use the implementation from closures.c
-    return codegen_generate_closure(context, node);
+    return codegen_generate_closure_constructor(context, node);
 }
 
 /**

--- a/src/backend/codegen/definitions.c
+++ b/src/backend/codegen/definitions.c
@@ -208,7 +208,7 @@ bool codegen_generate_variable_def(CodegenContext* context, const AstNode* node)
     DiagnosticContext* diagnostics = codegen_context_get_diagnostics(context);
     
     // Check node type
-    if (node->type != AST_VARIABLE_DEF) {
+    if ((node->type != AST_DEFINE) && (node->type != AST_VARIABLE_DEF)) {
         char debug_msg[256];
         snprintf(debug_msg, sizeof(debug_msg), "Expected AST_DEFINE node, got node type %d", node->type);
         diagnostic_error(diagnostics, node->line, node->column, debug_msg);

--- a/src/backend/codegen/definitions.c
+++ b/src/backend/codegen/definitions.c
@@ -7,6 +7,7 @@
 #include "backend/codegen/expressions.h"
 #include "backend/codegen/type_conversion.h"
 #include "backend/codegen/closures.h"
+#include "frontend/ast/core/ast_core.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -207,7 +208,7 @@ bool codegen_generate_variable_def(CodegenContext* context, const AstNode* node)
     DiagnosticContext* diagnostics = codegen_context_get_diagnostics(context);
     
     // Check node type
-    if (node->type != AST_DEFINE) {
+    if (node->type != AST_VARIABLE_DEF) {
         char debug_msg[256];
         snprintf(debug_msg, sizeof(debug_msg), "Expected AST_DEFINE node, got node type %d", node->type);
         diagnostic_error(diagnostics, node->line, node->column, debug_msg);

--- a/src/backend/codegen/program.c
+++ b/src/backend/codegen/program.c
@@ -8,6 +8,7 @@
 #include "backend/codegen/expressions.h"
 #include "backend/codegen/type_conversion.h"
 #include "frontend/ast/ast.h"
+#include "frontend/ast/core/ast_core.h"
 #include "frontend/type_inference/type_inference.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -106,6 +107,8 @@ static bool codegen_generate_forward_declarations(CodegenContext* context, const
     // Generate forward declarations
     fprintf(output, "// Forward declarations\n");
     
+    size_t lambda_count = 1;
+
     for (size_t i = 0; i < program->as.program.expr_count; i++) {
         if (program->as.program.exprs[i]->type == AST_FUNCTION_DEF) {
             // Get function node
@@ -178,11 +181,16 @@ static bool codegen_generate_forward_declarations(CodegenContext* context, const
             }
             
             fprintf(output, ");\n");
-        }
+            const AstNode* body_node = func_node->as.function_def.body;
+            if(body_node->type == AST_LAMBDA) {
+              fprintf(output, "void* lambda_%lu(EshkolEnvironment* env, void** args);\n" , lambda_count++);
+         }
     }
+
+  }
     
     fprintf(output, "\n");
-    
+    fprintf(output, "EshkolEnvironment *env = NULL;");
     return true;
 }
 
@@ -377,7 +385,7 @@ bool codegen_generate_program(CodegenContext* context, const AstNode* program) {
         diagnostic_error(diagnostics, 0, 0, "Failed to generate program header");
         return false;
     }
-    
+
     // Generate forward declarations
     diagnostic_debug(diagnostics, 0, 0, "Generating forward declarations");
     if (!codegen_generate_forward_declarations(context, program)) {
@@ -385,7 +393,7 @@ bool codegen_generate_program(CodegenContext* context, const AstNode* program) {
         return false;
     }
     
-    // Generate expressions
+   // Generate expressions
     snprintf(debug_msg, sizeof(debug_msg), "Generating expressions (%zu total)", program->as.program.expr_count);
     diagnostic_debug(diagnostics, 0, 0, debug_msg);
     
@@ -478,14 +486,15 @@ bool codegen_generate_program(CodegenContext* context, const AstNode* program) {
         snprintf(debug_msg, sizeof(debug_msg), "Successfully generated expression %zu", i);
         diagnostic_debug(diagnostics, 0, 0, debug_msg);
     }
-    
+
+        
     // Generate main function if needed
     diagnostic_debug(diagnostics, 0, 0, "Generating main function if needed");
     if (!codegen_generate_main_function(context, program)) {
         diagnostic_error(diagnostics, 0, 0, "Failed to generate main function");
         return false;
     }
-    
+
     diagnostic_debug(diagnostics, 0, 0, "Program generation completed successfully");
     return true;
 }

--- a/src/backend/codegen/program.c
+++ b/src/backend/codegen/program.c
@@ -32,6 +32,7 @@ static bool codegen_generate_program_header(CodegenContext* context) {
     fprintf(output, "#include <string.h>\n\n");
     fprintf(output, "#include \"core/vector.h\"\n");
     fprintf(output, "#include \"core/memory.h\"\n");
+    fprintf(output, "#include \"core/closure.h\"\n");
     fprintf(output, "#include \"core/autodiff.h\"\n\n");
     
     // Define minimal Arena implementation

--- a/src/frontend/binding/core/binding_core.c
+++ b/src/frontend/binding/core/binding_core.c
@@ -64,13 +64,21 @@ BindingSystem* binding_system_create(Arena* arena, DiagnosticContext* diag) {
     system->env_table.count = 0;
     system->env_table.capacity = 0;
     
+    // Initialize definitions tables
+    system->def_table.ids = NULL;
+    system->def_table.binding_ids = NULL;
+    system->def_table.nodes = NULL;
+    system->def_table.count = 0;
+    system->def_table.capacity = 0;
+
     // Initialize IDs
     system->current_scope_id = 0;
     system->next_binding_id = 1; // Start at 1, 0 is reserved for "not found"
     system->next_scope_id = 1;   // Start at 1, 0 is reserved for "global scope"
     system->next_lambda_id = 1;  // Start at 1, 0 is reserved for "not found"
     system->next_env_id = 1;     // Start at 1, 0 is reserved for "global environment"
-    
+    system->next_def_id = 1;     // Start at 1, 0 is reserved for "not found" 
+
     // Create global scope
     if (!binding_system_enter_scope(system)) {
         return NULL;

--- a/src/frontend/binding/core/binding_management.c
+++ b/src/frontend/binding/core/binding_management.c
@@ -3,6 +3,7 @@
  * @brief Binding management for the binding system
  */
 
+#include "frontend/ast/core/ast_core.h"
 #include "frontend/binding/binding.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -226,4 +227,79 @@ uint64_t binding_system_resolve_binding_in_scope(BindingSystem* system, StringId
     
     // Binding not found
     return 0;
+}
+
+/**
+ * @brief Bind a node to the given binding
+ * 
+ * @param system The binding system
+ * @param bind_id The id of the binding
+ * @param node The node that the bind defines
+ * @return The ID of the new definition, or 0 on failure
+ */ 
+uint64_t binding_system_register_define(BindingSystem* system, uint64_t bind_id, AstNode* node) {
+  assert(system != NULL);
+  assert(node != NULL);
+  assert(bind_id != 0);
+
+  // Print debug
+  printf("Registering define: %lu of node %lu\n", bind_id, node->line);
+  // Check if we need to resize the definitions table
+  if(system->def_table.count >= system->def_table.capacity) {
+    // Calculate new capacity
+    size_t new_capacity = system->def_table.capacity == 0 ? 16 : system->def_table.capacity * 2;
+
+    uint64_t* new_ids = arena_alloc(system->arena, sizeof(uint64_t) * new_capacity);
+    uint64_t* new_binding_ids = arena_alloc(system->arena, sizeof(uint64_t) * new_capacity);
+    AstNode** new_nodes = arena_alloc(system->arena, sizeof(AstNode*) * new_capacity);
+
+    if(!new_ids || !new_nodes || !new_binding_ids) {
+      return 0;
+    }
+
+    // Copy old data
+    for(size_t i = 0; i < system->def_table.count; i++) {
+      new_ids[i] = system->def_table.ids[i];
+      new_binding_ids[i] = system->def_table.binding_ids[i];
+      new_nodes[i] = system->def_table.nodes[i];
+    }
+
+    // Update definitions table
+    system->def_table.ids = new_ids;
+    system->def_table.binding_ids = new_binding_ids;
+    system->def_table.nodes = new_nodes;
+    system->def_table.capacity = new_capacity;
+  }
+
+  // Create new definition
+  uint64_t def_id = system->next_def_id++;
+  system->def_table.ids[system->def_table.count] = def_id;
+  system->def_table.binding_ids[system->def_table.count] = bind_id;
+  system->def_table.nodes[system->def_table.count] = node;
+  system->def_table.count++;
+  return def_id;
+}
+
+
+/**
+ * @brief Retrieve a node from the given binding
+ * 
+ * @param system The binding system
+ * @param bind_id The id of the binding
+ * @return The node of the definition 
+ */ 
+AstNode* binding_system_get_definition(BindingSystem* system, uint64_t bind_id) {
+  assert(system != NULL);
+  assert(bind_id != 0);
+
+  // Search for binding
+  for(size_t i = 0; i < system->def_table.count; i++) {
+    if(system->def_table.binding_ids[i] == bind_id) {
+      // Found binding
+      return system->def_table.nodes[i];
+    }
+  }
+
+  // Binding not found
+  return NULL;
 }

--- a/src/frontend/binding/core/binding_management.c
+++ b/src/frontend/binding/core/binding_management.c
@@ -242,8 +242,6 @@ uint64_t binding_system_register_define(BindingSystem* system, uint64_t bind_id,
   assert(node != NULL);
   assert(bind_id != 0);
 
-  // Print debug
-  printf("Registering define: %lu of node %lu\n", bind_id, node->line);
   // Check if we need to resize the definitions table
   if(system->def_table.count >= system->def_table.capacity) {
     // Calculate new capacity

--- a/src/frontend/parser/parser_core.c
+++ b/src/frontend/parser/parser_core.c
@@ -4,6 +4,7 @@
  */
 
 #include "frontend/parser/parser_core.h"
+#include "frontend/binding/binding.h"
 #include "frontend/parser/parser_helpers.h"
 #include "frontend/parser/parser_error.h"
 #include "frontend/parser/parser_expressions.h"
@@ -22,7 +23,7 @@
  * @param lexer Lexer
  * @return A new parser, or NULL on failure
  */
-Parser* parser_create(Arena* arena, StringTable* strings, DiagnosticContext* diag, Lexer* lexer) {
+Parser* parser_create(BindingSystem* binding_system, Arena* arena, StringTable* strings, DiagnosticContext* diag, Lexer* lexer) {
     assert(arena != NULL);
     assert(strings != NULL);
     assert(diag != NULL);
@@ -41,7 +42,7 @@ Parser* parser_create(Arena* arena, StringTable* strings, DiagnosticContext* dia
     parser->panic_mode = false;
     
     // Initialize binding system
-    parser->bindings = binding_system_create(arena, diag);
+    parser->bindings = binding_system;
     if (!parser->bindings) {
         return NULL;
     }

--- a/src/frontend/parser/parser_define.c
+++ b/src/frontend/parser/parser_define.c
@@ -172,9 +172,10 @@ AstNode* parser_parse_define(Parser* parser, size_t line, size_t column) {
             parser_error(parser, "Failed to add binding");
             return NULL;
         }
-
-        binding_system_register_define(parser->bindings, binding_id, body);
-        return ast_create_function_def(parser->arena, name, params, param_nodes, param_count, NULL, body, line, column);
+    
+        AstNode* function_def = ast_create_function_def(parser->arena, name, params, param_nodes, param_count, NULL, body, line, column);
+        binding_system_register_define(parser->bindings, binding_id, function_def);
+        return function_def;
     } else {
         parser_error(parser, "Expected variable name or function definition");
         return NULL;

--- a/src/frontend/type_inference/context.c
+++ b/src/frontend/type_inference/context.c
@@ -10,6 +10,7 @@
 #include "core/type_comparison.h"
 #include "core/type_conversion.h"
 #include "frontend/ast/ast.h"
+#include "frontend/binding/binding.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -22,6 +23,7 @@
 struct TypeInferenceContext {
     Arena* arena;                // Arena for allocations 
     DiagnosticContext* diagnostics; // Diagnostic context for error reporting 
+    BindingSystem* binding_system; // Binding system for symbol resolution
     AstNode** nodes;             // Array of AST nodes 
     Type** inferred_types;       // Array of inferred types 
     size_t capacity;             // Capacity of the arrays 
@@ -42,7 +44,7 @@ struct TypeInferenceContext {
 /**
  * @brief Create a type inference context
  */
-TypeInferenceContext* type_inference_context_create(Arena* arena, DiagnosticContext* diagnostics) {
+TypeInferenceContext* type_inference_context_create(BindingSystem* binding_system, Arena* arena, DiagnosticContext* diagnostics) {
     assert(arena != NULL);
     
     // Allocate context
@@ -58,7 +60,8 @@ TypeInferenceContext* type_inference_context_create(Arena* arena, DiagnosticCont
     context->explicit_count = 0;
     context->signature_capacity = 128;
     context->signature_count = 0;
-    
+    context->binding_system = binding_system;
+
     // Allocate arrays
     context->nodes = arena_alloc(arena, context->capacity * sizeof(AstNode*));
     if (!context->nodes) return NULL;
@@ -309,4 +312,12 @@ Arena* type_inference_get_arena(TypeInferenceContext* context) {
 DiagnosticContext* type_inference_get_diagnostics(TypeInferenceContext* context) {
     assert(context != NULL);
     return context->diagnostics;
+}
+
+/**
+* @brief Get the binding system from the context
+*/
+BindingSystem* type_inference_get_binding_system(TypeInferenceContext* context) {
+    assert(context != NULL);
+    return context->binding_system;
 }

--- a/src/frontend/type_inference/inference.c
+++ b/src/frontend/type_inference/inference.c
@@ -275,7 +275,8 @@ static Type* infer_call(TypeInferenceContext* context, AstNode* node) {
           // Go upwards in the AST to find if we're not calling in our own definition
           while (current_node && current_node->type != AST_PROGRAM) {
             if (current_node == binded_node) {
-              return type_any_create(arena);
+              // Assume the function result is the default float type
+              return type_float_create(arena, FLOAT_SIZE_32);
             }
             current_node = current_node->parent;
           }

--- a/src/frontend/type_inference/inference.c
+++ b/src/frontend/type_inference/inference.c
@@ -4,9 +4,11 @@
  */
 
 #include "frontend/type_inference/inference.h"
+#include "backend/codegen/context.h"
 #include "frontend/type_inference/context.h"
 #include "core/memory.h"
 #include "core/type.h"
+#include "frontend/binding/binding.h"
 #include "core/type_creation.h"
 #include "core/type_comparison.h"
 #include "core/type_conversion.h"
@@ -96,8 +98,12 @@ static Type* infer_nil_literal(TypeInferenceContext* context, AstNode* node) {
  */
 static Type* infer_identifier(TypeInferenceContext* context, AstNode* node) {
     assert(node->type == AST_IDENTIFIER);
+
     Arena* arena = type_inference_get_arena(context);
-    
+
+    // Get binding system
+    BindingSystem* binding_system = type_inference_get_binding_system(context);
+
     // Check if the identifier name contains special characters
     const char* name = node->as.identifier.name;
     for (size_t i = 0; name[i] != '\0'; i++) {
@@ -106,9 +112,13 @@ static Type* infer_identifier(TypeInferenceContext* context, AstNode* node) {
             // Special identifiers like operators are not variables
             return type_any_create(arena);
         }
+    } 
+
+    void* function_signature = type_inference_get_function_signature(context, name);
+    if (function_signature) {
+      return type_integer_create(arena, INT_SIZE_32);
     }
-    
-     
+
     // Vector operations
     if (strstr(name, "vector") || 
         strstr(name, "gradient") || 
@@ -252,7 +262,22 @@ static Type* infer_call(TypeInferenceContext* context, AstNode* node) {
     // Check if it's an operator call
     if (node->as.call.callee->type == AST_IDENTIFIER) {
         const char* op_name = node->as.call.callee->as.identifier.name;
+
+        BindingSystem* binding_system = type_inference_get_binding_system(context);
         
+        // Resolve the identifier in the binding system
+        uint64_t binding_id = binding_system_resolve_binding(binding_system, op_name);
+        printf("Resolved binding ID %lu for %s\n", binding_id, op_name);
+        if (binding_id != 0) {
+          AstNode* binded_node = binding_system_get_definition(binding_system, binding_id);
+          if(binded_node) {
+            return type_inference_infer_node(context, binded_node);
+          }
+        }
+        void* function_signature = type_inference_get_function_signature(context, op_name);
+        if (function_signature) {
+          return type_integer_create(arena, INT_SIZE_32);
+        }
         // Handle string-append and number->string operations
         if (strcmp(op_name, "string-append") == 0) {
             return type_string_create(arena);
@@ -424,10 +449,15 @@ static Type* infer_call(TypeInferenceContext* context, AstNode* node) {
     // Regular function call
     // Infer the type of the callee
     Type* callee_type = type_inference_infer_node(context, node->as.call.callee);
-    
+
     // If the callee is a function, return its return type
     if (callee_type->kind == TYPE_FUNCTION) {
-        return callee_type->function.return_type;
+        if (callee_type->function.param_count == node->as.call.arg_count) {
+          return callee_type->function.return_type;
+        }
+        
+        //TODO: Partial function application could be implemented here
+        return callee_type;
     }
     
     // Default to float

--- a/src/frontend/type_inference/type_inference.c
+++ b/src/frontend/type_inference/type_inference.c
@@ -4,6 +4,7 @@
  */
 
 #include "frontend/type_inference/type_inference.h"
+#include "frontend/binding/binding.h"
 #include "frontend/type_inference/context.h"
 #include "frontend/type_inference/inference.h"
 #include "frontend/type_inference/conversion.h"
@@ -22,11 +23,11 @@
 /**
  * @brief Initialize the type inference system
  */
-TypeInferenceContext* type_inference_init(Arena* arena, DiagnosticContext* diagnostics) {
+TypeInferenceContext* type_inference_init(BindingSystem* binding_system, Arena* arena, DiagnosticContext* diagnostics) {
     assert(arena != NULL);
     
     // Create the type inference context
-    TypeInferenceContext* context = type_inference_context_create(arena, diagnostics);
+    TypeInferenceContext* context = type_inference_context_create(binding_system, arena, diagnostics);
     if (!context) return NULL;
     
     return context;

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 #include "core/memory.h"
 #include "core/string_table.h"
 #include "core/diagnostics.h"
+#include "frontend/binding/binding.h"
 #include "frontend/lexer/lexer.h"
 #include "frontend/parser/parser.h"
 #include "frontend/type_inference/type_inference.h"
@@ -197,8 +198,10 @@ int main(int argc, char** argv) {
         return 1;
     }
     
+    BindingSystem* binding_system = binding_system_create(arena, diag);
+
     // Initialize parser
-    Parser* parser = parser_create(arena, strings, diag, lexer);
+    Parser* parser = parser_create(binding_system, arena, strings, diag, lexer);
     if (!parser) {
         fprintf(stderr, "Error: Failed to create parser\n");
         arena_destroy(arena);
@@ -228,7 +231,7 @@ int main(int argc, char** argv) {
     }
     
     // Initialize type inference context
-    TypeInferenceContext* type_context = type_inference_context_create(arena, diag);
+    TypeInferenceContext* type_context = type_inference_context_create(binding_system, arena, diag);
     if (!type_context) {
         fprintf(stderr, "Error: Failed to create type inference context\n");
         arena_destroy(arena);

--- a/tests/unit/test_codegen.c
+++ b/tests/unit/test_codegen.c
@@ -7,6 +7,7 @@
 #include "frontend/ast/ast.h"
 #include "core/memory.h"
 #include "core/diagnostics.h"
+#include "frontend/binding/binding.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -24,8 +25,11 @@ static void test_codegen_context_create(void) {
     DiagnosticContext* diag = diagnostic_context_create(arena);
     assert(diag != NULL);
     
+    // Create binding system
+    BindingSystem* binding_system = binding_system_create(arena, diag);
+
     // Create type inference context
-    TypeInferenceContext* type_context = type_inference_context_create(arena, diag);
+    TypeInferenceContext* type_context = type_inference_context_create(binding_system, arena, diag);
     assert(type_context != NULL);
     
     // Create code generator context
@@ -54,12 +58,15 @@ static void test_codegen_generate_simple(void) {
     DiagnosticContext* diag = diagnostic_context_create(arena);
     assert(diag != NULL);
     
+    // Create binding system
+    BindingSystem* binding_system = binding_system_create(arena, diag);
+
     // Create a simple AST (just a number literal)
     AstNode* ast = ast_create_number(arena, 42.0, 1, 1);
     assert(ast != NULL);
     
     // Create type inference context
-    TypeInferenceContext* type_context = type_inference_context_create(arena, diag);
+    TypeInferenceContext* type_context = type_inference_context_create(binding_system, arena, diag);
     assert(type_context != NULL);
     
     // Create code generator context
@@ -132,9 +139,12 @@ static void test_codegen_generate_typed_function(void) {
     // Create program with the function definition
     AstNode* program = ast_create_program(arena, &func_def, 1, 1, 1);
     assert(program != NULL);
-    
+   
+    // Create binding system
+    BindingSystem* binding_system = binding_system_create(arena, diag);
+
     // Create type inference context
-    TypeInferenceContext* type_context = type_inference_context_create(arena, diag);
+    TypeInferenceContext* type_context = type_inference_context_create(binding_system, arena, diag);
     assert(type_context != NULL);
     
     // Create code generator context


### PR DESCRIPTION
These changes aim towards getting basic lambda usage compiling, by doing the following:
* Fix the code generation of lambda definitions. This is done by splitting the process into two AST passes, first pass generates the C procedures for each closure, in the order of the lambda call. Each lambda id is queued in the context, so the second pass can correctly link each generated call to the previously generated definition
* Introduce a symbolic table and getters/setters for it, so we can determine where a given symbol is defined in the AST. This allows, among further developing of the type system implementation, to lazily infer the type of an identifier that is being called. This is especially needed for lambdas as we need to be aware of their parameters and return type when performing operations on them.

The data structures that I used are a bit rudimentary, as my main focus was to get closer to getting the lambda examples functional. When this all works as intended, it should get us closer to getting function composition going.