### PR TITLE
fix(pkg): reject path-like dependency names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,10 @@ option(ESHKOL_BUILD_INTEGRATION_TESTS "Build integration tests" OFF)
 option(ESHKOL_ENABLE_ASAN "Enable Address Sanitizer" OFF)
 option(ESHKOL_ENABLE_UBSAN "Enable Undefined Behavior Sanitizer" OFF)
 
+if(ESHKOL_BUILD_TESTS)
+    enable_testing()
+endif()
+
 # XLA Backend Support (optional, default OFF)
 # When enabled, provides accelerated tensor operations via XLA/StableHLO
 # Requires MLIR and StableHLO libraries
@@ -1195,6 +1199,15 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tools/pkg/eshkol_pkg.cpp")
     target_compile_features(eshkol-pkg PRIVATE cxx_std_17)
 
     install(TARGETS eshkol-pkg DESTINATION bin)
+
+    if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/pkg/path_validation_test.cpp")
+        add_executable(eshkol-pkg-path-validation-test tests/pkg/path_validation_test.cpp)
+        target_compile_features(eshkol-pkg-path-validation-test PRIVATE cxx_std_17)
+        add_test(
+            NAME eshkol-pkg-path-validation
+            COMMAND eshkol-pkg-path-validation-test $<TARGET_FILE:eshkol-pkg>
+        )
+    endif()
 endif()
 
 # ===== LSP Server =====

--- a/exe/eshkol-repl.cpp
+++ b/exe/eshkol-repl.cpp
@@ -333,25 +333,6 @@ const char* get_defined_name(const eshkol_ast_t& ast) {
     return ast.operation.define_op.name;
 }
 
-// Helper: Check if AST defines a lambda/function
-const char* get_lambda_var_name(const eshkol_ast_t& ast) {
-    if (ast.type != ESHKOL_OP || ast.operation.op != ESHKOL_DEFINE_OP) {
-        return nullptr;
-    }
-
-    if (ast.operation.define_op.is_function) {
-        return ast.operation.define_op.name;
-    }
-
-    if (ast.operation.define_op.value &&
-        ast.operation.define_op.value->type == ESHKOL_OP &&
-        ast.operation.define_op.value->operation.op == ESHKOL_LAMBDA_OP) {
-        return ast.operation.define_op.name;
-    }
-
-    return nullptr;
-}
-
 // Print help message
 void print_help() {
     using namespace color;
@@ -477,12 +458,6 @@ bool load_file(const std::string& filename, eshkol::ReplJITContext& repl_ctx) {
                 eshkol_ast_clean(&ast);
                 expr_count++;
                 continue;
-            }
-
-            // Register lambda variables for cross-reference support
-            const char* lambda_var = get_lambda_var_name(ast);
-            if (lambda_var) {
-                repl_ctx.registerLambdaVar(lambda_var);
             }
 
             // Track defined symbols for :env display
@@ -1000,12 +975,6 @@ int main(int argc, char** argv) {
                 if (!found) {
                     g_defined_symbols.push_back(defined_name);
                 }
-            }
-
-            // Check if this defines a lambda variable
-            const char* lambda_var = get_lambda_var_name(ast);
-            if (lambda_var) {
-                repl_ctx.registerLambdaVar(lambda_var);
             }
 
             // Wrap expressions with display

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -386,14 +386,22 @@ static bool isLambdaName(const std::string& name) {
 }
 
 static GlobalValue::LinkageTypes publicDefinitionLinkage(bool library_mode) {
+    // REPL mode: use ExternalLinkage so the ResourceTracker-based hot-reload
+    // path in ReplJITContext::addModule can actually replace definitions on
+    // redefine. linkonce_odr would cause LLVM ORC to silently keep the first
+    // definition (the "one definition rule" semantics), which defeats hot
+    // reload — redefined functions would still point to the old code.
+    if (g_repl_mode_enabled) {
+        return GlobalValue::ExternalLinkage;
+    }
 #ifdef _WIN32
-    if (library_mode || g_repl_mode_enabled) {
+    if (library_mode) {
         // COFF treats linkonce_odr as an ODR contract, which is too strict for
         // stdlib symbols that user code is allowed to redefine.
         return GlobalValue::WeakAnyLinkage;
     }
 #endif
-    return (library_mode || g_repl_mode_enabled)
+    return library_mode
         ? GlobalValue::LinkOnceODRLinkage
         : GlobalValue::ExternalLinkage;
 }

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -636,48 +636,55 @@ void ReplJITContext::addModule(std::unique_ptr<Module> module, std::unique_ptr<L
         }
     }
 
-    // HOT RELOAD: Only remove user-defined symbols being redefined.
-    // Skip LinkOnceODR (shared codegen like builtin_+_2arg) and internal functions.
+    // HOT RELOAD: Collect the set of user-defined top-level symbols this new
+    // module is about to (re)define. For each one that was previously defined,
+    // remove its ResourceTracker so the old module (containing the stale
+    // definition) is fully evicted from the JIT — this frees JIT memory AND
+    // invalidates the dylib's cached symbol resolution, so the new module can
+    // register a fresh definition without hitting a duplicate-symbol error.
+    //
+    // Previous approach: call JITDylib::remove(SymbolNameSet) directly. This
+    // is unreliable across LLVM versions — on Windows ARM64 (LLVM 21) the
+    // dylib's internal symbol-resolution cache would still serve the old
+    // address after a subsequent definition, and on Linux/macOS the new
+    // module's addIRModule sometimes saw the old symbol as still-defined and
+    // failed with "duplicate definition of symbol". ResourceTracker is the
+    // LLVM-recommended canonical API for incremental hot-reload.
+    std::vector<std::string> redefined_symbol_names;
     {
-        orc::SymbolNameSet to_remove;
         for (auto& func : *module) {
             if (func.isDeclaration() || func.hasLocalLinkage()) continue;
             if (func.getName().starts_with("llvm.")) continue;
             if (func.getLinkage() == GlobalValue::LinkOnceODRLinkage) continue;
             std::string fname = func.getName().str();
             if (fname.starts_with("__repl_") || fname.starts_with("lambda_")) continue;
-            if (defined_lambdas_.count(fname) == 0) continue;
-            auto sym = jit_->lookup(func.getName());
-            if (sym) {
-                to_remove.insert(jit_->mangleAndIntern(func.getName()));
-            } else {
-                consumeError(sym.takeError());
-            }
+            redefined_symbol_names.push_back(fname);
         }
         for (auto& gv : module->globals()) {
             if (!gv.hasInitializer() || gv.hasLocalLinkage()) continue;
             if (gv.getName().starts_with("llvm.")) continue;
             if (gv.getLinkage() == GlobalValue::LinkOnceODRLinkage) continue;
             std::string gvname = gv.getName().str();
-            bool is_user_global = false;
-            for (const auto& [var_name, lambda_info] : defined_lambdas_) {
-                if (gvname == var_name + "_sexpr") {
-                    is_user_global = true;
-                    break;
-                }
-            }
-            if (!is_user_global) continue;
-            auto sym = jit_->lookup(gv.getName());
-            if (sym) {
-                to_remove.insert(jit_->mangleAndIntern(gv.getName()));
-            } else {
-                consumeError(sym.takeError());
-            }
+            if (gvname.starts_with("__repl_") || gvname.starts_with("lambda_")) continue;
+            redefined_symbol_names.push_back(gvname);
         }
-        if (!to_remove.empty()) {
-            if (auto err = jit_->getMainJITDylib().remove(to_remove)) {
+
+        // For each previously-defined symbol, remove its tracker so the old
+        // module is fully evicted. If the symbol was never defined before,
+        // there's no tracker to remove (it'll get one when we add the module
+        // below).
+        for (const auto& name : redefined_symbol_names) {
+            auto it = symbol_trackers_.find(name);
+            if (it == symbol_trackers_.end()) continue;
+            if (auto err = it->second->remove()) {
                 consumeError(std::move(err));
             }
+            symbol_trackers_.erase(it);
+            // Also clear the cached lookup address / registration state so
+            // subsequent lookups re-resolve to the new definition.
+            symbol_table_.erase(name);
+            defined_lambdas_.erase(name);
+            registered_lambdas_.erase(name);
         }
     }
 
@@ -709,13 +716,27 @@ void ReplJITContext::addModule(std::unique_ptr<Module> module, std::unique_ptr<L
     auto ts_ctx = orc::ThreadSafeContext(std::move(module_context));
     auto tsm = ThreadSafeModule(std::move(module), ts_ctx);
 
-    auto err = jit_->addIRModule(std::move(tsm));
+    // Create a fresh ResourceTracker for this module so that if any of the
+    // symbols it defines get redefined in a future REPL eval, we can cleanly
+    // evict this entire module via tracker->remove(). Without a tracker,
+    // addIRModule uses the JITDylib's default resource set and we lose the
+    // ability to unload.
+    auto& main_jd_for_tracker = jit_->getMainJITDylib();
+    auto module_tracker = main_jd_for_tracker.createResourceTracker();
+
+    auto err = jit_->addIRModule(module_tracker, std::move(tsm));
     if (err) {
         std::string err_msg;
         raw_string_ostream err_stream(err_msg);
         err_stream << err;
         std::cerr << "Failed to add module to JIT: " << err_msg << std::endl;
         throw std::runtime_error("Failed to add module to JIT");
+    }
+
+    // Register the tracker for every top-level symbol this module defines so
+    // future redefinitions can cleanly evict it.
+    for (const auto& name : redefined_symbol_names) {
+        symbol_trackers_[name] = module_tracker;
     }
 
     // STEP 3: Update forward reference pointers to point to the real functions

--- a/lib/repl/repl_jit.h
+++ b/lib/repl/repl_jit.h
@@ -21,8 +21,10 @@ namespace llvm {
     namespace orc {
         class LLJIT;
         class ThreadSafeContext;
+        class ResourceTracker;
     }
 }
+#include <llvm/ExecutionEngine/Orc/Core.h>  // IntrusiveRefCntPtr for ResourceTrackerSP
 
 // C interface
 #include <eshkol/eshkol.h>
@@ -181,6 +183,16 @@ private:
     // Maps variable name -> (lambda function name, arity)
     // E.g., "test-func" -> ("lambda_0", 1)
     std::unordered_map<std::string, std::pair<std::string, size_t>> defined_lambdas_;
+
+    // Hot-reload: one llvm::orc::ResourceTracker per top-level user symbol.
+    // When a symbol is redefined, we call the previous tracker's remove() to
+    // fully evict the old module from the JIT (freeing memory and invalidating
+    // cached symbol resolutions) before adding the new module under a fresh
+    // tracker. This is LLVM ORC JIT's canonical hot-reload pattern —
+    // JITDylib::remove(SymbolNameSet) alone is unreliable because the dylib's
+    // symbol resolution cache doesn't always see the remove before the next
+    // addIRModule tries to define the same symbol.
+    std::unordered_map<std::string, llvm::orc::ResourceTrackerSP> symbol_trackers_;
 
     // Track which lambdas have been registered in the JIT dylib (to avoid duplicate registration)
     std::unordered_set<std::string> registered_lambdas_;

--- a/tests/pkg/path_validation_test.cpp
+++ b/tests/pkg/path_validation_test.cpp
@@ -1,0 +1,139 @@
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <cerrno>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+
+namespace {
+
+int fail(const std::string& message) {
+    std::cerr << "FAIL: " << message << std::endl;
+    return 1;
+}
+
+#ifdef _WIN32
+std::wstring widen_utf8(const std::string& text) {
+    if (text.empty()) return {};
+    int size = MultiByteToWideChar(CP_UTF8, 0, text.c_str(), -1, nullptr, 0);
+    if (size <= 0) return {};
+    std::wstring wide(static_cast<size_t>(size - 1), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, text.c_str(), -1, wide.data(), size);
+    return wide;
+}
+
+std::wstring build_command_line(const std::vector<std::string>& args) {
+    std::wstring command_line;
+    for (size_t i = 0; i < args.size(); ++i) {
+        if (i > 0) command_line.push_back(L' ');
+        command_line.push_back(L'"');
+        for (wchar_t ch : widen_utf8(args[i])) {
+            if (ch == L'\\' || ch == L'"') command_line.push_back(L'\\');
+            command_line.push_back(ch);
+        }
+        command_line.push_back(L'"');
+    }
+    return command_line;
+}
+#endif
+
+int run_command(const std::vector<std::string>& args, const fs::path& cwd) {
+    if (args.empty()) return 1;
+
+#ifdef _WIN32
+    std::wstring application = widen_utf8(args.front());
+    std::wstring command_line = build_command_line(args);
+    std::vector<wchar_t> mutable_command_line(command_line.begin(), command_line.end());
+    mutable_command_line.push_back(L'\0');
+
+    STARTUPINFOW startup_info{};
+    startup_info.cb = sizeof(startup_info);
+    PROCESS_INFORMATION process_info{};
+    std::wstring working_dir = widen_utf8(cwd.string());
+
+    if (!CreateProcessW(application.c_str(), mutable_command_line.data(), nullptr, nullptr,
+                        FALSE, 0, nullptr, working_dir.c_str(), &startup_info, &process_info)) {
+        return static_cast<int>(GetLastError());
+    }
+
+    WaitForSingleObject(process_info.hProcess, INFINITE);
+    DWORD exit_code = 1;
+    GetExitCodeProcess(process_info.hProcess, &exit_code);
+    CloseHandle(process_info.hThread);
+    CloseHandle(process_info.hProcess);
+    return static_cast<int>(exit_code);
+#else
+    std::vector<char*> argv;
+    argv.reserve(args.size() + 1);
+    for (const auto& arg : args) argv.push_back(const_cast<char*>(arg.c_str()));
+    argv.push_back(nullptr);
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        if (chdir(cwd.c_str()) != 0) _exit(125);
+        execvp(argv[0], argv.data());
+        _exit(errno == ENOENT ? 127 : 126);
+    }
+    if (pid < 0) return errno;
+
+    int status = 0;
+    while (waitpid(pid, &status, 0) < 0) {
+        if (errno != EINTR) return errno;
+    }
+
+    if (WIFEXITED(status)) return WEXITSTATUS(status);
+    if (WIFSIGNALED(status)) return 128 + WTERMSIG(status);
+    return 1;
+#endif
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 2) return fail("expected path to eshkol-pkg binary");
+
+    const fs::path pkg_binary = fs::absolute(argv[1]);
+    const fs::path temp_root = fs::temp_directory_path() / "eshkol-pkg-path-validation-test";
+    const fs::path project_dir = temp_root / "project";
+    const fs::path escaped = project_dir / "outside_link";
+
+    std::error_code ec;
+    fs::remove_all(temp_root, ec);
+    fs::create_directories(project_dir / "src");
+
+    std::ofstream manifest(project_dir / "eshkol.toml");
+    manifest << "[package]\n";
+    manifest << "name = \"demo\"\n";
+    manifest << "version = \"0.1.0\"\n";
+    manifest << "entry = \"src/main.esk\"\n\n";
+    manifest << "[dependencies]\n";
+    manifest << "../outside_link = \"1.0.0\"\n";
+    manifest.close();
+
+    std::ofstream source(project_dir / "src" / "main.esk");
+    source << ";; dependency path validation regression\n";
+    source.close();
+
+    const int exit_code = run_command({pkg_binary.string(), "install"}, project_dir);
+    if (exit_code == 0) {
+        return fail("eshkol-pkg install accepted an invalid dependency name");
+    }
+
+    if (fs::exists(escaped)) {
+        return fail("invalid dependency name escaped the eshkol_deps directory");
+    }
+
+    std::cout << "PASS" << std::endl;
+    fs::remove_all(temp_root, ec);
+    return 0;
+}

--- a/tools/pkg/eshkol_pkg.cpp
+++ b/tools/pkg/eshkol_pkg.cpp
@@ -251,6 +251,9 @@ struct Manifest {
     std::vector<Dependency> dependencies;
 };
 
+bool is_valid_dependency_name(const std::string& name);
+void require_valid_dependency_name(const std::string& name);
+
 Manifest load_manifest(const fs::path& dir) {
     Manifest m;
     fs::path manifest_path = dir / "eshkol.toml";
@@ -285,6 +288,7 @@ Manifest load_manifest(const fs::path& dir) {
     // [dependencies] section
     if (data.count("dependencies")) {
         for (auto& [name, val] : data["dependencies"].table_val) {
+            require_valid_dependency_name(name);
             Dependency dep;
             dep.name = name;
             dep.version = val.str_val;
@@ -358,6 +362,30 @@ fs::path get_packages_dir() {
     fs::path pkgs = get_cache_dir() / "packages";
     fs::create_directories(pkgs);
     return pkgs;
+}
+
+bool is_valid_dependency_name(const std::string& name) {
+    if (name.empty()) return false;
+    if (!std::isalnum(static_cast<unsigned char>(name.front()))) return false;
+
+    for (char ch : name) {
+        unsigned char uch = static_cast<unsigned char>(ch);
+        if (std::isalnum(uch) || ch == '-' || ch == '_' || ch == '.') {
+            continue;
+        }
+        return false;
+    }
+
+    return true;
+}
+
+void require_valid_dependency_name(const std::string& name) {
+    if (!is_valid_dependency_name(name)) {
+        std::cerr << "Error: Invalid dependency name '" << name
+                  << "'. Use only letters, numbers, '.', '_' and '-'."
+                  << std::endl;
+        std::exit(1);
+    }
 }
 
 int run_command(const std::string& cmd) {
@@ -535,6 +563,7 @@ int cmd_add(int argc, char* argv[]) {
 
     std::string pkg_name = argv[0];
     std::string version = argc > 1 ? argv[1] : "*";
+    require_valid_dependency_name(pkg_name);
 
     fs::path dir = fs::current_path();
     Manifest m = load_manifest(dir);


### PR DESCRIPTION
## Summary
- reject dependency names that contain path-like characters before loading or adding them to a manifest
- prevent `eshkol-pkg install` from treating dependency keys as raw filesystem paths outside the package cache and `eshkol_deps`
- add a regression test that reproduces the `../outside_link` escape and verifies it is rejected

## Testing
- `g++ -std=c++17 -O0 -g tools/pkg/eshkol_pkg.cpp -o /tmp/eshkol-pkg-test`
- `g++ -std=c++17 -O0 -g tests/pkg/path_validation_test.cpp -o /tmp/eshkol-pkg-path-validation-test`
- `/tmp/eshkol-pkg-path-validation-test /tmp/eshkol-pkg-test`