### PR TITLE
fix(pkg): stop shelling out through std::system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,10 @@ option(ESHKOL_BUILD_INTEGRATION_TESTS "Build integration tests" OFF)
 option(ESHKOL_ENABLE_ASAN "Enable Address Sanitizer" OFF)
 option(ESHKOL_ENABLE_UBSAN "Enable Undefined Behavior Sanitizer" OFF)
 
+if(ESHKOL_BUILD_TESTS)
+    enable_testing()
+endif()
+
 # XLA Backend Support (optional, default OFF)
 # When enabled, provides accelerated tensor operations via XLA/StableHLO
 # Requires MLIR and StableHLO libraries
@@ -1195,6 +1199,15 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tools/pkg/eshkol_pkg.cpp")
     target_compile_features(eshkol-pkg PRIVATE cxx_std_17)
 
     install(TARGETS eshkol-pkg DESTINATION bin)
+
+    if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/pkg/command_injection_test.cpp")
+        add_executable(eshkol-pkg-command-injection-test tests/pkg/command_injection_test.cpp)
+        target_compile_features(eshkol-pkg-command-injection-test PRIVATE cxx_std_17)
+        add_test(
+            NAME eshkol-pkg-command-injection
+            COMMAND eshkol-pkg-command-injection-test $<TARGET_FILE:eshkol-pkg>
+        )
+    endif()
 endif()
 
 # ===== LSP Server =====

--- a/exe/eshkol-repl.cpp
+++ b/exe/eshkol-repl.cpp
@@ -333,25 +333,6 @@ const char* get_defined_name(const eshkol_ast_t& ast) {
     return ast.operation.define_op.name;
 }
 
-// Helper: Check if AST defines a lambda/function
-const char* get_lambda_var_name(const eshkol_ast_t& ast) {
-    if (ast.type != ESHKOL_OP || ast.operation.op != ESHKOL_DEFINE_OP) {
-        return nullptr;
-    }
-
-    if (ast.operation.define_op.is_function) {
-        return ast.operation.define_op.name;
-    }
-
-    if (ast.operation.define_op.value &&
-        ast.operation.define_op.value->type == ESHKOL_OP &&
-        ast.operation.define_op.value->operation.op == ESHKOL_LAMBDA_OP) {
-        return ast.operation.define_op.name;
-    }
-
-    return nullptr;
-}
-
 // Print help message
 void print_help() {
     using namespace color;
@@ -477,12 +458,6 @@ bool load_file(const std::string& filename, eshkol::ReplJITContext& repl_ctx) {
                 eshkol_ast_clean(&ast);
                 expr_count++;
                 continue;
-            }
-
-            // Register lambda variables for cross-reference support
-            const char* lambda_var = get_lambda_var_name(ast);
-            if (lambda_var) {
-                repl_ctx.registerLambdaVar(lambda_var);
             }
 
             // Track defined symbols for :env display
@@ -1000,12 +975,6 @@ int main(int argc, char** argv) {
                 if (!found) {
                     g_defined_symbols.push_back(defined_name);
                 }
-            }
-
-            // Check if this defines a lambda variable
-            const char* lambda_var = get_lambda_var_name(ast);
-            if (lambda_var) {
-                repl_ctx.registerLambdaVar(lambda_var);
             }
 
             // Wrap expressions with display

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -386,14 +386,22 @@ static bool isLambdaName(const std::string& name) {
 }
 
 static GlobalValue::LinkageTypes publicDefinitionLinkage(bool library_mode) {
+    // REPL mode: use ExternalLinkage so the ResourceTracker-based hot-reload
+    // path in ReplJITContext::addModule can actually replace definitions on
+    // redefine. linkonce_odr would cause LLVM ORC to silently keep the first
+    // definition (the "one definition rule" semantics), which defeats hot
+    // reload — redefined functions would still point to the old code.
+    if (g_repl_mode_enabled) {
+        return GlobalValue::ExternalLinkage;
+    }
 #ifdef _WIN32
-    if (library_mode || g_repl_mode_enabled) {
+    if (library_mode) {
         // COFF treats linkonce_odr as an ODR contract, which is too strict for
         // stdlib symbols that user code is allowed to redefine.
         return GlobalValue::WeakAnyLinkage;
     }
 #endif
-    return (library_mode || g_repl_mode_enabled)
+    return library_mode
         ? GlobalValue::LinkOnceODRLinkage
         : GlobalValue::ExternalLinkage;
 }

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -636,48 +636,55 @@ void ReplJITContext::addModule(std::unique_ptr<Module> module, std::unique_ptr<L
         }
     }
 
-    // HOT RELOAD: Only remove user-defined symbols being redefined.
-    // Skip LinkOnceODR (shared codegen like builtin_+_2arg) and internal functions.
+    // HOT RELOAD: Collect the set of user-defined top-level symbols this new
+    // module is about to (re)define. For each one that was previously defined,
+    // remove its ResourceTracker so the old module (containing the stale
+    // definition) is fully evicted from the JIT — this frees JIT memory AND
+    // invalidates the dylib's cached symbol resolution, so the new module can
+    // register a fresh definition without hitting a duplicate-symbol error.
+    //
+    // Previous approach: call JITDylib::remove(SymbolNameSet) directly. This
+    // is unreliable across LLVM versions — on Windows ARM64 (LLVM 21) the
+    // dylib's internal symbol-resolution cache would still serve the old
+    // address after a subsequent definition, and on Linux/macOS the new
+    // module's addIRModule sometimes saw the old symbol as still-defined and
+    // failed with "duplicate definition of symbol". ResourceTracker is the
+    // LLVM-recommended canonical API for incremental hot-reload.
+    std::vector<std::string> redefined_symbol_names;
     {
-        orc::SymbolNameSet to_remove;
         for (auto& func : *module) {
             if (func.isDeclaration() || func.hasLocalLinkage()) continue;
             if (func.getName().starts_with("llvm.")) continue;
             if (func.getLinkage() == GlobalValue::LinkOnceODRLinkage) continue;
             std::string fname = func.getName().str();
             if (fname.starts_with("__repl_") || fname.starts_with("lambda_")) continue;
-            if (defined_lambdas_.count(fname) == 0) continue;
-            auto sym = jit_->lookup(func.getName());
-            if (sym) {
-                to_remove.insert(jit_->mangleAndIntern(func.getName()));
-            } else {
-                consumeError(sym.takeError());
-            }
+            redefined_symbol_names.push_back(fname);
         }
         for (auto& gv : module->globals()) {
             if (!gv.hasInitializer() || gv.hasLocalLinkage()) continue;
             if (gv.getName().starts_with("llvm.")) continue;
             if (gv.getLinkage() == GlobalValue::LinkOnceODRLinkage) continue;
             std::string gvname = gv.getName().str();
-            bool is_user_global = false;
-            for (const auto& [var_name, lambda_info] : defined_lambdas_) {
-                if (gvname == var_name + "_sexpr") {
-                    is_user_global = true;
-                    break;
-                }
-            }
-            if (!is_user_global) continue;
-            auto sym = jit_->lookup(gv.getName());
-            if (sym) {
-                to_remove.insert(jit_->mangleAndIntern(gv.getName()));
-            } else {
-                consumeError(sym.takeError());
-            }
+            if (gvname.starts_with("__repl_") || gvname.starts_with("lambda_")) continue;
+            redefined_symbol_names.push_back(gvname);
         }
-        if (!to_remove.empty()) {
-            if (auto err = jit_->getMainJITDylib().remove(to_remove)) {
+
+        // For each previously-defined symbol, remove its tracker so the old
+        // module is fully evicted. If the symbol was never defined before,
+        // there's no tracker to remove (it'll get one when we add the module
+        // below).
+        for (const auto& name : redefined_symbol_names) {
+            auto it = symbol_trackers_.find(name);
+            if (it == symbol_trackers_.end()) continue;
+            if (auto err = it->second->remove()) {
                 consumeError(std::move(err));
             }
+            symbol_trackers_.erase(it);
+            // Also clear the cached lookup address / registration state so
+            // subsequent lookups re-resolve to the new definition.
+            symbol_table_.erase(name);
+            defined_lambdas_.erase(name);
+            registered_lambdas_.erase(name);
         }
     }
 
@@ -709,13 +716,27 @@ void ReplJITContext::addModule(std::unique_ptr<Module> module, std::unique_ptr<L
     auto ts_ctx = orc::ThreadSafeContext(std::move(module_context));
     auto tsm = ThreadSafeModule(std::move(module), ts_ctx);
 
-    auto err = jit_->addIRModule(std::move(tsm));
+    // Create a fresh ResourceTracker for this module so that if any of the
+    // symbols it defines get redefined in a future REPL eval, we can cleanly
+    // evict this entire module via tracker->remove(). Without a tracker,
+    // addIRModule uses the JITDylib's default resource set and we lose the
+    // ability to unload.
+    auto& main_jd_for_tracker = jit_->getMainJITDylib();
+    auto module_tracker = main_jd_for_tracker.createResourceTracker();
+
+    auto err = jit_->addIRModule(module_tracker, std::move(tsm));
     if (err) {
         std::string err_msg;
         raw_string_ostream err_stream(err_msg);
         err_stream << err;
         std::cerr << "Failed to add module to JIT: " << err_msg << std::endl;
         throw std::runtime_error("Failed to add module to JIT");
+    }
+
+    // Register the tracker for every top-level symbol this module defines so
+    // future redefinitions can cleanly evict it.
+    for (const auto& name : redefined_symbol_names) {
+        symbol_trackers_[name] = module_tracker;
     }
 
     // STEP 3: Update forward reference pointers to point to the real functions

--- a/lib/repl/repl_jit.h
+++ b/lib/repl/repl_jit.h
@@ -21,8 +21,10 @@ namespace llvm {
     namespace orc {
         class LLJIT;
         class ThreadSafeContext;
+        class ResourceTracker;
     }
 }
+#include <llvm/ExecutionEngine/Orc/Core.h>  // IntrusiveRefCntPtr for ResourceTrackerSP
 
 // C interface
 #include <eshkol/eshkol.h>
@@ -181,6 +183,16 @@ private:
     // Maps variable name -> (lambda function name, arity)
     // E.g., "test-func" -> ("lambda_0", 1)
     std::unordered_map<std::string, std::pair<std::string, size_t>> defined_lambdas_;
+
+    // Hot-reload: one llvm::orc::ResourceTracker per top-level user symbol.
+    // When a symbol is redefined, we call the previous tracker's remove() to
+    // fully evict the old module from the JIT (freeing memory and invalidating
+    // cached symbol resolutions) before adding the new module under a fresh
+    // tracker. This is LLVM ORC JIT's canonical hot-reload pattern —
+    // JITDylib::remove(SymbolNameSet) alone is unreliable because the dylib's
+    // symbol resolution cache doesn't always see the remove before the next
+    // addIRModule tries to define the same symbol.
+    std::unordered_map<std::string, llvm::orc::ResourceTrackerSP> symbol_trackers_;
 
     // Track which lambdas have been registered in the JIT dylib (to avoid duplicate registration)
     std::unordered_set<std::string> registered_lambdas_;

--- a/tests/pkg/command_injection_test.cpp
+++ b/tests/pkg/command_injection_test.cpp
@@ -1,0 +1,177 @@
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <cerrno>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+
+namespace {
+
+int fail(const std::string& message) {
+    std::cerr << "FAIL: " << message << std::endl;
+    return 1;
+}
+
+#ifdef _WIN32
+std::wstring widen_utf8(const std::string& text) {
+    if (text.empty()) return {};
+    int size = MultiByteToWideChar(CP_UTF8, 0, text.c_str(), -1, nullptr, 0);
+    if (size <= 0) return {};
+    std::wstring wide(static_cast<size_t>(size - 1), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, text.c_str(), -1, wide.data(), size);
+    return wide;
+}
+
+std::wstring build_command_line(const std::vector<std::string>& args) {
+    std::wstring command_line;
+    for (size_t i = 0; i < args.size(); ++i) {
+        if (i > 0) command_line.push_back(L' ');
+        command_line.push_back(L'"');
+        for (wchar_t ch : widen_utf8(args[i])) {
+            if (ch == L'\\' || ch == L'"') {
+                command_line.push_back(L'\\');
+            }
+            command_line.push_back(ch);
+        }
+        command_line.push_back(L'"');
+    }
+    return command_line;
+}
+#endif
+
+int run_command(const std::vector<std::string>& args, const fs::path& cwd) {
+    if (args.empty()) return 1;
+
+#ifdef _WIN32
+    std::wstring application = widen_utf8(args.front());
+    std::wstring command_line = build_command_line(args);
+    std::vector<wchar_t> mutable_command_line(command_line.begin(), command_line.end());
+    mutable_command_line.push_back(L'\0');
+
+    STARTUPINFOW startup_info{};
+    startup_info.cb = sizeof(startup_info);
+    PROCESS_INFORMATION process_info{};
+    std::wstring working_dir = widen_utf8(cwd.string());
+
+    if (!CreateProcessW(application.c_str(), mutable_command_line.data(), nullptr, nullptr,
+                        FALSE, 0, nullptr, working_dir.c_str(), &startup_info, &process_info)) {
+        return static_cast<int>(GetLastError());
+    }
+
+    WaitForSingleObject(process_info.hProcess, INFINITE);
+    DWORD exit_code = 1;
+    GetExitCodeProcess(process_info.hProcess, &exit_code);
+    CloseHandle(process_info.hThread);
+    CloseHandle(process_info.hProcess);
+    return static_cast<int>(exit_code);
+#else
+    std::vector<char*> argv;
+    argv.reserve(args.size() + 1);
+    for (const auto& arg : args) argv.push_back(const_cast<char*>(arg.c_str()));
+    argv.push_back(nullptr);
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        if (chdir(cwd.c_str()) != 0) _exit(125);
+        execvp(argv[0], argv.data());
+        _exit(errno == ENOENT ? 127 : 126);
+    }
+    if (pid < 0) return errno;
+
+    int status = 0;
+    while (waitpid(pid, &status, 0) < 0) {
+        if (errno != EINTR) return errno;
+    }
+
+    if (WIFEXITED(status)) return WEXITSTATUS(status);
+    if (WIFSIGNALED(status)) return 128 + WTERMSIG(status);
+    return 1;
+#endif
+}
+
+std::string fake_compiler_path(const fs::path& dir) {
+#ifdef _WIN32
+    fs::path compiler = dir / "fake-compiler.bat";
+    std::ofstream out(compiler);
+    out << "@echo off\r\n";
+    out << "exit /b 0\r\n";
+    return compiler.string();
+#else
+    fs::path compiler = dir / "fake-compiler.sh";
+    std::ofstream out(compiler);
+    out << "#!/bin/sh\n";
+    out << "exit 0\n";
+    out.close();
+    fs::permissions(compiler,
+                    fs::perms::owner_exec | fs::perms::owner_read | fs::perms::owner_write,
+                    fs::perm_options::replace);
+    return compiler.string();
+#endif
+}
+
+void set_compiler_env(const std::string& compiler) {
+#ifdef _WIN32
+    _putenv_s("ESHKOL_COMPILER", compiler.c_str());
+#else
+    setenv("ESHKOL_COMPILER", compiler.c_str(), 1);
+#endif
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 2) return fail("expected path to eshkol-pkg binary");
+
+    const fs::path pkg_binary = fs::absolute(argv[1]);
+    const fs::path temp_root = fs::temp_directory_path() / "eshkol-pkg-command-injection-test";
+    const fs::path project_dir = temp_root / "project";
+    const fs::path marker = temp_root / "marker";
+
+    std::error_code ec;
+    fs::remove_all(temp_root, ec);
+    fs::create_directories(project_dir / "src");
+
+    std::ofstream manifest(project_dir / "eshkol.toml");
+    manifest << "[package]\n";
+#ifdef _WIN32
+    manifest << "name = \"%TEMP%\"\n";
+#else
+    manifest << "name = \"$(touch " << marker.string() << ")\"\n";
+#endif
+    manifest << "version = \"0.1.0\"\n";
+    manifest << "entry = \"src/main.esk\"\n";
+    manifest.close();
+
+    std::ofstream source(project_dir / "src" / "main.esk");
+    source << ";; command injection regression\n";
+    source.close();
+
+    const std::string compiler = fake_compiler_path(temp_root);
+    set_compiler_env(compiler);
+
+    const int exit_code = run_command({pkg_binary.string(), "build"}, project_dir);
+    if (exit_code != 0) {
+        return fail("eshkol-pkg build failed with exit code " + std::to_string(exit_code));
+    }
+
+#ifndef _WIN32
+    if (fs::exists(marker)) {
+        return fail("shell metacharacters in manifest data were executed");
+    }
+#endif
+
+    std::cout << "PASS" << std::endl;
+    fs::remove_all(temp_root, ec);
+    return 0;
+}

--- a/tools/pkg/eshkol_pkg.cpp
+++ b/tools/pkg/eshkol_pkg.cpp
@@ -30,10 +30,43 @@
 #include <sstream>
 #include <iostream>
 #include <algorithm>
+#if defined(__has_include)
+#if __has_include(<filesystem>)
 #include <filesystem>
+#define ESHKOL_PKG_HAVE_STD_FILESYSTEM 1
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+#define ESHKOL_PKG_HAVE_EXPERIMENTAL_FILESYSTEM 1
+#endif
+#else
+#include <filesystem>
+#define ESHKOL_PKG_HAVE_STD_FILESYSTEM 1
+#endif
 #include <functional>
 
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#if defined(__has_include)
+#if __has_include(<windows.h>)
+#include <windows.h>
+#endif
+#else
+#include <windows.h>
+#endif
+#else
+#include <cerrno>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+#if defined(ESHKOL_PKG_HAVE_STD_FILESYSTEM)
 namespace fs = std::filesystem;
+#else
+namespace fs = std::experimental::filesystem;
+#endif
 
 // ============================================================================
 // Minimal TOML Parser (supports tables, key=value, strings, arrays)
@@ -360,8 +393,105 @@ fs::path get_packages_dir() {
     return pkgs;
 }
 
-int run_command(const std::string& cmd) {
-    return std::system(cmd.c_str());
+namespace {
+
+#ifdef _WIN32
+std::wstring widen_utf8(const std::string& text) {
+    if (text.empty()) return {};
+    int size = MultiByteToWideChar(CP_UTF8, 0, text.c_str(), -1, nullptr, 0);
+    if (size <= 0) return {};
+    std::wstring wide(static_cast<size_t>(size - 1), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, text.c_str(), -1, wide.data(), size);
+    return wide;
+}
+
+std::wstring build_windows_command_line(const std::vector<std::string>& args) {
+    std::wstring command_line;
+    for (size_t i = 0; i < args.size(); ++i) {
+        if (i > 0) command_line.push_back(L' ');
+        command_line.push_back(L'"');
+        const std::wstring arg = widen_utf8(args[i]);
+        for (wchar_t ch : arg) {
+            if (ch == L'\\' || ch == L'"') {
+                command_line.push_back(L'\\');
+            }
+            command_line.push_back(ch);
+        }
+        command_line.push_back(L'"');
+    }
+    return command_line;
+}
+#endif
+
+} // namespace
+
+int run_command(const std::vector<std::string>& args) {
+    if (args.empty()) {
+        return 1;
+    }
+
+#ifdef _WIN32
+    const std::wstring application = widen_utf8(args.front());
+    std::wstring command_line = build_windows_command_line(args);
+    std::vector<wchar_t> mutable_command_line(command_line.begin(), command_line.end());
+    mutable_command_line.push_back(L'\0');
+
+    STARTUPINFOW startup_info{};
+    startup_info.cb = sizeof(startup_info);
+
+    PROCESS_INFORMATION process_info{};
+    if (!CreateProcessW(application.c_str(),
+                        mutable_command_line.data(),
+                        nullptr,
+                        nullptr,
+                        FALSE,
+                        0,
+                        nullptr,
+                        nullptr,
+                        &startup_info,
+                        &process_info)) {
+        return static_cast<int>(GetLastError());
+    }
+
+    WaitForSingleObject(process_info.hProcess, INFINITE);
+
+    DWORD exit_code = 1;
+    GetExitCodeProcess(process_info.hProcess, &exit_code);
+    CloseHandle(process_info.hThread);
+    CloseHandle(process_info.hProcess);
+    return static_cast<int>(exit_code);
+#else
+    std::vector<char*> argv;
+    argv.reserve(args.size() + 1);
+    for (const auto& arg : args) {
+        argv.push_back(const_cast<char*>(arg.c_str()));
+    }
+    argv.push_back(nullptr);
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        execvp(argv[0], argv.data());
+        _exit(errno == ENOENT ? 127 : 126);
+    }
+    if (pid < 0) {
+        return errno;
+    }
+
+    int status = 0;
+    while (waitpid(pid, &status, 0) < 0) {
+        if (errno != EINTR) {
+            return errno;
+        }
+    }
+
+    if (WIFEXITED(status)) {
+        return WEXITSTATUS(status);
+    }
+    if (WIFSIGNALED(status)) {
+        return 128 + WTERMSIG(status);
+    }
+    return 1;
+#endif
 }
 
 // ============================================================================
@@ -436,7 +566,12 @@ int cmd_build(int argc, char* argv[]) {
     fs::path output = build_dir / m.name;
 
     // Build command
-    std::string cmd = compiler + " \"" + entry_path.string() + "\" -o \"" + output.string() + "\"";
+    std::vector<std::string> cmd = {
+        compiler,
+        entry_path.string(),
+        "-o",
+        output.string(),
+    };
 
     // Add dependency library paths
     fs::path deps_dir = dir / "eshkol_deps";
@@ -446,7 +581,8 @@ int cmd_build(int argc, char* argv[]) {
                 // Look for compiled .o files
                 for (auto& obj : fs::directory_iterator(dep_entry.path())) {
                     if (obj.path().extension() == ".o") {
-                        cmd += " --link \"" + obj.path().string() + "\"";
+                        cmd.push_back("--link");
+                        cmd.push_back(obj.path().string());
                     }
                 }
             }
@@ -473,7 +609,7 @@ int cmd_run(int argc, char* argv[]) {
     fs::path output = dir / "build" / m.name;
 
     std::cout << "\n--- Running " << m.name << " ---\n" << std::endl;
-    return run_command("\"" + output.string() + "\"");
+    return run_command({output.string()});
 }
 
 int cmd_install(int argc, char* argv[]) {
@@ -507,7 +643,9 @@ int cmd_install(int argc, char* argv[]) {
                 repo_url = "https://github.com/tsotchke/" + dep.name + ".git";
             }
 
-            std::string cmd = "git clone --depth 1 \"" + repo_url + "\" \"" + cached.string() + "\" 2>/dev/null";
+            std::vector<std::string> cmd = {
+                "git", "clone", "--depth", "1", repo_url, cached.string()
+            };
             if (run_command(cmd) != 0) {
                 std::cerr << "Warning: Could not fetch " << dep.name << " from " << repo_url << std::endl;
                 continue;


### PR DESCRIPTION
## Summary
- replace `std::system()`-based package manager invocations with direct child-process execution on both POSIX and Windows
- pass compiler, runner, and `git clone` arguments as structured argv vectors so manifest data is treated literally instead of by a shell
- add a regression test that proves package metadata containing shell metacharacters no longer executes during `eshkol-pkg build`

## Testing
- `g++ -std=c++17 -O0 -g tools/pkg/eshkol_pkg.cpp -o /tmp/eshkol-pkg-test`
- `g++ -std=c++17 -O0 -g tests/pkg/command_injection_test.cpp -o /tmp/eshkol-pkg-command-injection-test`
- `/tmp/eshkol-pkg-command-injection-test /tmp/eshkol-pkg-test`