### PR TITLE
fix(server): validate Content-Length headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1245,6 +1245,14 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tools/lsp/eshkol_lsp.cpp")
     install(TARGETS eshkol-lsp DESTINATION bin)
 endif()
 
+# ===== HTTP Request Utility Tests =====
+if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/web/content_length_parse_test.cpp")
+    add_executable(content_length_parse_test tests/web/content_length_parse_test.cpp)
+    target_compile_features(content_length_parse_test PRIVATE cxx_std_17)
+    target_include_directories(content_length_parse_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+    add_test(NAME content_length_parse_test COMMAND content_length_parse_test)
+endif()
+
 # ===== XLA Integration Tests =====
 if(ESHKOL_XLA_ENABLED AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/xla/xla_codegen_test.cpp")
     message(STATUS "Building XLA integration tests")

--- a/exe/eshkol-server.cpp
+++ b/exe/eshkol-server.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "eshkol/eshkol.h"
+#include "eshkol/http_request_utils.h"
 #include <eshkol/llvm_backend.h>
 #include <eshkol/logger.h>
 
@@ -241,6 +242,8 @@ struct HttpRequest {
     std::string path;
     std::unordered_map<std::string, std::string> headers;
     std::string body;
+    bool malformed = false;
+    std::string error_message;
 };
 
 HttpRequest parse_request(const std::string& raw) {
@@ -281,7 +284,12 @@ HttpRequest parse_request(const std::string& raw) {
     // Trim body to Content-Length if specified
     auto it = req.headers.find("Content-Length");
     if (it != req.headers.end()) {
-        size_t len = std::stoul(it->second);
+        size_t len = 0;
+        if (!eshkol_parse_content_length(it->second, len)) {
+            req.malformed = true;
+            req.error_message = "Invalid Content-Length";
+            return req;
+        }
         if (req.body.size() > len) {
             req.body = req.body.substr(0, len);
         }
@@ -393,8 +401,23 @@ void handle_client(socket_handle_t client_socket) {
             size_t cl_pos = request_data.find("Content-Length:");
             if (cl_pos != std::string::npos) {
                 size_t cl_end = request_data.find("\r\n", cl_pos);
+                if (cl_end == std::string::npos) {
+                    std::string response = build_response(400, "application/json",
+                        json_error("Invalid Content-Length"));
+                    send(client_socket, response.c_str(), static_cast<int>(response.size()), 0);
+                    close_socket(client_socket);
+                    return;
+                }
+
                 std::string cl_str = request_data.substr(cl_pos + 15, cl_end - cl_pos - 15);
-                size_t content_length = std::stoul(cl_str);
+                size_t content_length = 0;
+                if (!eshkol_parse_content_length(cl_str, content_length)) {
+                    std::string response = build_response(400, "application/json",
+                        json_error("Invalid Content-Length"));
+                    send(client_socket, response.c_str(), static_cast<int>(response.size()), 0);
+                    close_socket(client_socket);
+                    return;
+                }
                 size_t body_start = header_end + 4;
                 if (request_data.size() >= body_start + content_length) {
                     break;
@@ -412,6 +435,13 @@ void handle_client(socket_handle_t client_socket) {
 
     HttpRequest req = parse_request(request_data);
     std::string response;
+
+    if (req.malformed) {
+        response = build_response(400, "application/json", json_error(req.error_message));
+        send(client_socket, response.c_str(), static_cast<int>(response.size()), 0);
+        close_socket(client_socket);
+        return;
+    }
 
     // Handle CORS preflight
     if (req.method == "OPTIONS") {

--- a/inc/eshkol/http_request_utils.h
+++ b/inc/eshkol/http_request_utils.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cctype>
+#include <limits>
+#include <string>
+
+inline bool eshkol_parse_content_length(const std::string& raw_value, size_t& content_length) {
+    size_t start = 0;
+    while (start < raw_value.size() && std::isspace(static_cast<unsigned char>(raw_value[start]))) {
+        ++start;
+    }
+
+    size_t end = raw_value.size();
+    while (end > start && std::isspace(static_cast<unsigned char>(raw_value[end - 1]))) {
+        --end;
+    }
+
+    if (start == end) {
+        return false;
+    }
+
+    const std::string trimmed = raw_value.substr(start, end - start);
+    for (char ch : trimmed) {
+        if (!std::isdigit(static_cast<unsigned char>(ch))) {
+            return false;
+        }
+    }
+
+    try {
+        const unsigned long long parsed = std::stoull(trimmed);
+        if (parsed > static_cast<unsigned long long>(std::numeric_limits<size_t>::max())) {
+            return false;
+        }
+        content_length = static_cast<size_t>(parsed);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}

--- a/scripts/run_web_tests.sh
+++ b/scripts/run_web_tests.sh
@@ -143,6 +143,38 @@ PY
     return 127
 }
 
+http_raw_request() {
+    local host="$1"
+    local port="$2"
+    local request="$3"
+
+    if command -v python3 >/dev/null 2>&1; then
+        python3 - "$host" "$port" "$request" <<'PY'
+import socket
+import sys
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+request = sys.argv[3].encode("utf-8")
+
+with socket.create_connection((host, port), timeout=5) as sock:
+    sock.sendall(request)
+    sock.shutdown(socket.SHUT_WR)
+    chunks = []
+    while True:
+        data = sock.recv(4096)
+        if not data:
+            break
+        chunks.append(data)
+
+sys.stdout.write(b"".join(chunks).decode("utf-8", errors="replace"))
+PY
+        return
+    fi
+
+    return 127
+}
+
 echo "========================================="
 echo "  Eshkol Web/WASM Test Suite"
 echo "========================================="
@@ -221,6 +253,16 @@ if echo "$HEALTH" | grep -q '"status":"ok"'; then
     log_pass "health check"
 else
     log_fail "health check: $HEALTH"
+fi
+
+# Test: malformed Content-Length should return 400 without crashing the server
+printf "Testing %-45s " "invalid Content-Length handling"
+RAW_REQUEST=$'POST /compile HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: abc\r\n\r\n{"code":"(define x 1)"}'
+RESULT=$(http_raw_request "127.0.0.1" "$PORT" "$RAW_REQUEST" 2>/dev/null || echo "")
+if echo "$RESULT" | grep -q "400 Bad Request" && kill -0 "$SERVER_PID" 2>/dev/null; then
+    log_pass "invalid Content-Length"
+else
+    log_fail "invalid Content-Length: $RESULT"
 fi
 
 # Test: Compile simple function

--- a/tests/web/content_length_parse_test.cpp
+++ b/tests/web/content_length_parse_test.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <limits>
+#include <string>
+
+#include "eshkol/http_request_utils.h"
+
+namespace {
+
+int expect_true(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << std::endl;
+        return 1;
+    }
+    return 0;
+}
+
+} // namespace
+
+int main() {
+    size_t value = 0;
+
+    if (expect_true(eshkol_parse_content_length("0", value) && value == 0,
+                    "should parse zero")) return 1;
+    if (expect_true(eshkol_parse_content_length(" 42 ", value) && value == 42,
+                    "should trim surrounding whitespace")) return 1;
+    if (expect_true(!eshkol_parse_content_length("", value),
+                    "should reject empty header")) return 1;
+    if (expect_true(!eshkol_parse_content_length("abc", value),
+                    "should reject non-numeric header")) return 1;
+    if (expect_true(!eshkol_parse_content_length("12x", value),
+                    "should reject trailing garbage")) return 1;
+    if (expect_true(!eshkol_parse_content_length("-1", value),
+                    "should reject negative values")) return 1;
+
+    const std::string overflow = std::to_string(std::numeric_limits<unsigned long long>::max()) + "0";
+    if (expect_true(!eshkol_parse_content_length(overflow, value),
+                    "should reject overflowing values")) return 1;
+
+    std::cout << "PASS" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- validate `Content-Length` header values before converting them in `eshkol-server`
- return `400 Bad Request` for malformed or overflowing values instead of letting `std::stoul` terminate the process
- add a focused parser regression test plus a web test that checks malformed raw requests are rejected without crashing the server

## Testing
- `g++ -std=c++17 -Iinc tests/web/content_length_parse_test.cpp -o /tmp/content_length_parse_test && /tmp/content_length_parse_test`
- `bash -n scripts/run_web_tests.sh`