### PR TITLE
fix(repl): load stdlib assoc in eval fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1253,6 +1253,19 @@ if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/web/content_
     add_test(NAME content_length_parse_test COMMAND content_length_parse_test)
 endif()
 
+if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/repl/assoc_eval_test.cpp")
+    add_executable(assoc_eval_test tests/repl/assoc_eval_test.cpp)
+    target_compile_features(assoc_eval_test PRIVATE cxx_std_17)
+    add_dependencies(assoc_eval_test stdlib)
+    add_test(
+        NAME assoc_eval_test
+        COMMAND assoc_eval_test
+                $<TARGET_FILE:eshkol-run>
+                ${CMAKE_CURRENT_SOURCE_DIR}
+                ${STDLIB_OUTPUT}
+    )
+endif()
+
 # ===== XLA Integration Tests =====
 if(ESHKOL_XLA_ENABLED AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/xla/xla_codegen_test.cpp")
     message(STATUS "Building XLA integration tests")

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -1218,13 +1218,15 @@ bool ReplJITContext::loadModule(const std::string& module_name, bool allow_preco
     // Store module exports for visibility checking
     module_exports_[module_name] = exported_symbols;
 
-    // Mark private symbols (defined but not exported) - only if module has provide
+    // Mark private symbols (defined but not exported) - only if module has provide.
+    // Delay registering them with codegen until after the module finishes compiling
+    // so internal forward references still work while loading the module itself.
+    std::vector<std::string> private_symbols_to_register;
     if (has_provide) {
         for (const auto& sym : defined_symbols) {
             if (exported_symbols.find(sym) == exported_symbols.end()) {
                 private_symbols_.insert(sym);
-                // Register with codegen so variable lookups will fail for private symbols
-                eshkol_repl_register_private_symbol(sym.c_str());
+                private_symbols_to_register.push_back(sym);
             }
         }
     }
@@ -1262,6 +1264,11 @@ bool ReplJITContext::loadModule(const std::string& module_name, bool allow_preco
         } catch (const std::exception& e) {
             std::cerr << "     error: " << e.what() << std::endl;
         }
+    }
+
+    for (const auto& sym : private_symbols_to_register) {
+        // Register after module compilation so only external accesses are blocked.
+        eshkol_repl_register_private_symbol(sym.c_str());
     }
 
     // Clean up ASTs

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -1134,7 +1134,11 @@ bool ReplJITContext::loadStdlib() {
     }
 
     // Fallback: JIT compile from source (slowest but always correct)
-    return loadModule("stdlib", false);
+    const bool was_loading_stdlib_from_source = loading_stdlib_from_source_;
+    loading_stdlib_from_source_ = true;
+    const bool loaded = loadModule("stdlib", false);
+    loading_stdlib_from_source_ = was_loading_stdlib_from_source;
+    return loaded;
 }
 
 bool ReplJITContext::loadModule(const std::string& module_name) {
@@ -1148,7 +1152,8 @@ bool ReplJITContext::loadModule(const std::string& module_name, bool allow_preco
     }
 
     // For stdlib or core.* modules, use precompiled stdlib.o if available
-    if (allow_precompiled_stdlib && (module_name == "stdlib" || module_name.find("core.") == 0)) {
+    if (allow_precompiled_stdlib && !loading_stdlib_from_source_ &&
+        (module_name == "stdlib" || module_name.find("core.") == 0)) {
         // Try to load via stdlib.o (which includes all core modules)
         if (loadStdlib()) {
             return true;

--- a/lib/repl/repl_jit.h
+++ b/lib/repl/repl_jit.h
@@ -211,6 +211,10 @@ private:
     // is accessible in subsequent evaluations
     void* shared_arena_;
 
+    // Tracks when stdlib is being loaded from source so nested `core.*`
+    // requires do not recurse back through the precompiled-stdlib path.
+    bool loading_stdlib_from_source_ = false;
+
     // REPL HOT RELOAD: Heap-allocated 16-byte tagged_value storage for every
     // user-defined top-level variable. The codegen emits @<name> as a pure
     // external declaration plus a __repl_var_<name> marker; addModule scans

--- a/tests/repl/assoc_eval_test.cpp
+++ b/tests/repl/assoc_eval_test.cpp
@@ -1,0 +1,243 @@
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <cstdio>
+#include <cstdlib>
+#else
+#include <cerrno>
+#include <cstdlib>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+
+namespace {
+
+struct ProcessResult {
+    int exit_code = 1;
+    std::string output;
+};
+
+int fail(const std::string& message) {
+    std::cerr << "FAIL: " << message << std::endl;
+    return 1;
+}
+
+#ifdef _WIN32
+std::string quote_arg(const std::string& arg) {
+    std::string quoted = "\"";
+    for (char ch : arg) {
+        if (ch == '\\' || ch == '"') {
+            quoted.push_back('\\');
+        }
+        quoted.push_back(ch);
+    }
+    quoted.push_back('"');
+    return quoted;
+}
+
+ProcessResult run_process_capture(const std::vector<std::string>& args,
+                                  const fs::path& cwd,
+                                  const fs::path& lib_dir,
+                                  bool set_eshkol_path) {
+    if (args.empty()) return {};
+
+    if (set_eshkol_path) {
+        _putenv_s("ESHKOL_PATH", lib_dir.string().c_str());
+    } else {
+        _putenv_s("ESHKOL_PATH", "");
+    }
+
+    const fs::path previous_cwd = fs::current_path();
+    fs::current_path(cwd);
+
+    std::string command;
+    for (size_t i = 0; i < args.size(); ++i) {
+        if (i > 0) command.push_back(' ');
+        command += quote_arg(args[i]);
+    }
+    command += " 2>&1";
+
+    FILE* pipe = _popen(command.c_str(), "r");
+    ProcessResult result;
+    if (!pipe) {
+        fs::current_path(previous_cwd);
+        return result;
+    }
+
+    char buffer[4096];
+    while (fgets(buffer, sizeof(buffer), pipe)) {
+        result.output += buffer;
+    }
+
+    result.exit_code = _pclose(pipe);
+    fs::current_path(previous_cwd);
+    return result;
+}
+#else
+ProcessResult run_process_capture(const std::vector<std::string>& args,
+                                  const fs::path& cwd,
+                                  const fs::path& lib_dir,
+                                  bool set_eshkol_path) {
+    if (args.empty()) return {};
+
+    int pipefd[2];
+    if (pipe(pipefd) != 0) {
+        return {};
+    }
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        close(pipefd[0]);
+        dup2(pipefd[1], STDOUT_FILENO);
+        dup2(pipefd[1], STDERR_FILENO);
+        close(pipefd[1]);
+
+        if (chdir(cwd.c_str()) != 0) {
+            _exit(125);
+        }
+
+        if (set_eshkol_path) {
+            setenv("ESHKOL_PATH", lib_dir.string().c_str(), 1);
+        } else {
+            unsetenv("ESHKOL_PATH");
+        }
+
+        std::vector<char*> argv;
+        argv.reserve(args.size() + 1);
+        for (const auto& arg : args) {
+            argv.push_back(const_cast<char*>(arg.c_str()));
+        }
+        argv.push_back(nullptr);
+
+        execvp(argv[0], argv.data());
+        _exit(errno == ENOENT ? 127 : 126);
+    }
+
+    close(pipefd[1]);
+    ProcessResult result;
+    char buffer[4096];
+    ssize_t count = 0;
+    while ((count = read(pipefd[0], buffer, sizeof(buffer))) > 0) {
+        result.output.append(buffer, static_cast<size_t>(count));
+    }
+    close(pipefd[0]);
+
+    int status = 0;
+    while (waitpid(pid, &status, 0) < 0) {
+        if (errno != EINTR) {
+            result.exit_code = errno;
+            return result;
+        }
+    }
+
+    if (WIFEXITED(status)) {
+        result.exit_code = WEXITSTATUS(status);
+    } else if (WIFSIGNALED(status)) {
+        result.exit_code = 128 + WTERMSIG(status);
+    }
+
+    return result;
+}
+#endif
+
+bool output_has_assoc_success(const std::string& output) {
+    return output.find("(W1 . 1)") != std::string::npos;
+}
+
+bool output_has_forward_ref_failure(const std::string& output) {
+    return output.find("called a forward-referenced function that was never defined") !=
+           std::string::npos;
+}
+
+int assert_assoc_eval(const std::string& label,
+                      const ProcessResult& result,
+                      bool expect_success) {
+    if (expect_success) {
+        if (result.exit_code != 0) {
+            return fail(label + " exited with code " + std::to_string(result.exit_code) +
+                        "\n" + result.output);
+        }
+        if (!output_has_assoc_success(result.output)) {
+            return fail(label + " did not print assoc result\n" + result.output);
+        }
+        if (output_has_forward_ref_failure(result.output)) {
+            return fail(label + " still hit forward-reference failure\n" + result.output);
+        }
+    } else {
+        if (!output_has_forward_ref_failure(result.output)) {
+            return fail(label + " was expected to miss stdlib and fail\n" + result.output);
+        }
+    }
+    return 0;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 4) {
+        return fail("expected: <eshkol-run> <source-root> <stdlib.o>");
+    }
+
+    const fs::path run_binary = fs::absolute(argv[1]);
+    const fs::path source_root = fs::absolute(argv[2]);
+    const fs::path stdlib_object = fs::absolute(argv[3]);
+    const fs::path lib_dir = source_root / "lib";
+
+    if (!fs::exists(run_binary)) {
+        return fail("eshkol-run binary not found: " + run_binary.string());
+    }
+    if (!fs::exists(lib_dir)) {
+        return fail("lib directory not found: " + lib_dir.string());
+    }
+    if (!fs::exists(stdlib_object)) {
+        return fail("stdlib.o not found: " + stdlib_object.string());
+    }
+
+    const std::vector<std::string> assoc_eval = {
+        run_binary.string(),
+        "-e",
+        "(display (assoc \"W1\" (list (cons \"W1\" 1))))"
+    };
+
+    const fs::path build_dir = run_binary.parent_path();
+    ProcessResult precompiled = run_process_capture(assoc_eval, build_dir, lib_dir, true);
+    if (int rc = assert_assoc_eval("precompiled-stdlib eval", precompiled, true)) {
+        return rc;
+    }
+
+    std::error_code ec;
+    const fs::path temp_root = fs::temp_directory_path() / "eshkol-assoc-eval-test";
+    fs::remove_all(temp_root, ec);
+    fs::create_directories(temp_root / "bin", ec);
+    if (ec) {
+        return fail("failed to create temp directory: " + ec.message());
+    }
+
+    const fs::path isolated_binary = temp_root / "bin" / run_binary.filename();
+    fs::copy_file(run_binary, isolated_binary, fs::copy_options::overwrite_existing, ec);
+    if (ec) {
+        return fail("failed to copy eshkol-run for source fallback test: " + ec.message());
+    }
+
+    ProcessResult source_fallback = run_process_capture(
+        {isolated_binary.string(), "-e", assoc_eval[2]}, temp_root / "bin", lib_dir, true);
+    if (int rc = assert_assoc_eval("source-fallback eval", source_fallback, true)) {
+        return rc;
+    }
+
+    ProcessResult no_stdlib = run_process_capture(
+        {isolated_binary.string(), "-n", "-e", assoc_eval[2]}, temp_root / "bin", lib_dir, false);
+    if (int rc = assert_assoc_eval("no-stdlib eval", no_stdlib, false)) {
+        return rc;
+    }
+
+    fs::remove_all(temp_root, ec);
+    std::cout << "PASS" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- prevent nested `core.*` requires from re-entering the precompiled stdlib path while `stdlib.esk` is being source-loaded in eval mode
- add an end-to-end regression test for `eshkol-run -e` that exercises both precompiled stdlib loading and source fallback for `assoc`
- keep `--no-stdlib` behavior unchanged as a negative control in the new test

## Testing
- cmake -S . -B build
- cmake --build build --target assoc_eval_test stdlib
- ctest --test-dir build --output-on-failure -R assoc_eval_test