### PR TITLE
docs: add platform sync workflow

### DIFF
--- a/docs/platform/BRANCHING_AND_GOVERNANCE.md
+++ b/docs/platform/BRANCHING_AND_GOVERNANCE.md
@@ -15,6 +15,19 @@ This document defines how the freestanding / platform program is run as a founde
   - long-lived incubator for freestanding, embedded, BSP, and toolchain work
   - all platform topic branches start here
 
+## Worktree model
+
+Recommended layout:
+
+- `~/Desktop/eshkol`
+  - `feature/v1.2-scale`
+- `~/Desktop/eshkol-platform`
+  - `feature/platform-freestanding`
+- optional extra worktrees
+  - active topic branches only
+
+The integration worktree should track `feature/platform-freestanding` directly. Topic branches should be short-lived and should not permanently replace the integration worktree.
+
 ## Topic branch model
 
 All implementation work should happen on short-lived topic branches off `feature/platform-freestanding`.
@@ -45,6 +58,8 @@ Topic branch rule:
 
 - merge or rebase `feature/v1.2-scale` into `feature/platform-freestanding` every 1-3 days while churn is high
 - never allow the platform branch to drift far from the main release line
+- prefer explicit merge commits for roadmap sync points so integration history stays auditable
+- use [SYNC_POLICY.md](SYNC_POLICY.md) as the operational rule for full vs selective roadmap sync
 
 ### Platform into mainline
 
@@ -54,6 +69,10 @@ Merge only when all are true:
 - relevant tests pass
 - the change is within the current release window's acceptable scope
 - no kernel-only artifacts are required to justify the change
+
+### Topic branches into platform
+
+Merge accepted topic branches into `feature/platform-freestanding` with explicit merge commits. This preserves the slice boundary in history and makes later audit, bisect, and rollback much safer.
 
 ### Kernel repo relationship
 
@@ -181,3 +200,6 @@ A change is not ready to merge if it changes any of the following without updati
 - test/CI requirements
 
 The doc set under `docs/platform/` is part of the program implementation, not optional commentary.
+
+Use [IMPLEMENTATION_WORKFLOW.md](IMPLEMENTATION_WORKFLOW.md) and [SLICE_CHECKLIST.md](SLICE_CHECKLIST.md) as the operating procedure for each topic branch.
+Use [SYNC_POLICY.md](SYNC_POLICY.md) for branch-to-branch convergence while roadmap and platform work proceed in parallel.

--- a/docs/platform/IMPLEMENTATION_WORKFLOW.md
+++ b/docs/platform/IMPLEMENTATION_WORKFLOW.md
@@ -1,0 +1,175 @@
+# Implementation Workflow
+
+## Purpose
+
+This document defines the working procedure for implementing the freestanding / platform program at production quality while the main roadmap continues in parallel.
+
+The goal is to keep platform work:
+
+- isolated from release-critical churn
+- continuously integrable
+- fully documented
+- testable at each slice boundary
+
+## Working Topology
+
+Use a dedicated worktree layout.
+
+- `~/Desktop/eshkol`
+  - primary roadmap worktree
+  - branch: `feature/v1.2-scale`
+- `~/Desktop/eshkol-platform`
+  - platform integration worktree
+  - branch: `feature/platform-freestanding`
+- optional topic worktrees
+  - created as needed for short-lived topic branches
+  - removed after merge
+
+This layout keeps the release branch, the platform integration branch, and any active topic slice physically separate.
+
+## Branch Roles
+
+- `feature/v1.2-scale`
+  - release integration branch
+  - source of truth for current roadmap work
+- `feature/platform-freestanding`
+  - platform integration branch
+  - accumulates accepted platform slices
+- `topic/platform-*`
+  - short-lived implementation branches
+  - each owns one bounded slice
+
+Do not implement freestanding work directly on `feature/platform-freestanding` unless the change is trivial and administrative. Use a topic branch by default.
+
+## Topic Slice Lifecycle
+
+Every platform slice follows the same lifecycle.
+
+1. Confirm the slice boundary.
+   The work must map cleanly to one subsystem or one bounded cross-cutting change.
+2. Confirm the architectural contract.
+   If the change affects profiles, syntax, runtime family boundaries, BSP contracts, or repo boundaries, record the decision first in `DECISIONS.md`.
+3. Cut a topic branch from `feature/platform-freestanding`.
+   Use `topic/platform-...` naming.
+4. Implement the slice.
+   Keep changes focused. Avoid mixing opportunistic refactors with platform semantics.
+5. Update docs in the same branch.
+   Any change to public or cross-subsystem behavior updates the relevant docs in `docs/platform/`.
+6. Add or update tests.
+   Every accepted slice adds verification for the new behavior or constraint.
+7. Validate locally.
+   Run the narrowest useful build and tests first, then the broader checks required by the slice.
+8. Commit the slice cleanly.
+   Use a message that describes the subsystem and behavior change.
+9. Merge into `feature/platform-freestanding` with an explicit merge commit.
+   The merge commit is the integration marker for the slice.
+10. Decide whether the slice is safe to merge back to the roadmap branch now or later.
+
+## Merge Discipline
+
+### Roadmap syncs into platform
+
+Merge `feature/v1.2-scale` into `feature/platform-freestanding` regularly. Use explicit merge commits so platform sync points are visible in history.
+
+Use [SYNC_POLICY.md](SYNC_POLICY.md) for the exact cadence, hotspot rules, and merge-back criteria.
+
+Recommended cadence:
+
+- daily while shared compiler/runtime files are churning heavily
+- every 2-3 days during lower churn
+- immediately after a major roadmap change in overlapping files
+
+### Topic branches into platform
+
+Merge accepted topic branches into `feature/platform-freestanding` with `--no-ff`.
+
+Reasons:
+
+- preserves slice boundaries
+- keeps integration history legible
+- makes rollback and bisect easier
+
+### Platform back into roadmap
+
+Only merge platform work back into `feature/v1.2-scale` when all are true:
+
+- hosted behavior is preserved
+- the slice has targeted tests
+- the slice fits the current release window
+- the slice does not depend on downstream kernel artifacts
+- the docs reflect the new state
+
+## Validation Expectations
+
+Validation is slice-specific, but these rules are global.
+
+- every slice must have at least one direct verification path
+- hosted regressions are treated as release blockers
+- freestanding work may begin with smoke coverage, but no slice merges without at least one concrete test or executable verification step
+- CI expectations must be documented before a slice becomes required for merge-back
+
+For examples:
+
+- profile changes require parser/resolution tests
+- LLVM path changes require codegen or link verification
+- runtime boundary changes require symbol hygiene checks
+- BSP changes require QEMU smoke tests once the BSP framework exists
+
+## Commit Standards
+
+Commit messages should be subsystem-scoped and descriptive.
+
+Good examples:
+
+- `toolchain: add execution profile model`
+- `runtime: split hosted and freestanding bootstrap surface`
+- `docs: add platform program documentation`
+
+Avoid vague commits such as:
+
+- `wip`
+- `more platform work`
+- `fix stuff`
+
+## Documentation Standards
+
+A slice is incomplete if it changes any of the following without updating docs:
+
+- execution profile semantics
+- runtime family boundaries
+- validation requirements
+- merge policy
+- target support expectations
+- kernel handoff criteria
+
+At minimum, update:
+
+- the relevant detailed doc
+- `README.md` in `docs/platform/` if the program status changes materially
+- `DECISIONS.md` if the change establishes or revises a boundary decision
+
+## Escalation Rules
+
+If a task starts expanding beyond its slice boundary:
+
+- stop broadening the branch
+- record the issue
+- create a follow-up topic branch instead of silently absorbing unrelated work
+
+This is especially important in:
+
+- `llvm_codegen.cpp`
+- runtime core files
+- VM core
+- build system integration
+
+## Definition of Done for a Slice
+
+A platform slice is done only when all are true:
+
+- implementation is complete for the scoped behavior
+- docs are updated
+- tests or executable validation exist
+- the branch is clean
+- the slice is merged into `feature/platform-freestanding`
+- any deferred follow-up is recorded explicitly

--- a/docs/platform/README.md
+++ b/docs/platform/README.md
@@ -40,8 +40,11 @@ Read in this order:
 2. [ARCHITECTURE.md](ARCHITECTURE.md)
 3. [ROADMAP_ALIGNMENT.md](ROADMAP_ALIGNMENT.md)
 4. [BRANCHING_AND_GOVERNANCE.md](BRANCHING_AND_GOVERNANCE.md)
-5. [WORKSTREAMS.md](WORKSTREAMS.md)
-6. [MILESTONES_AND_EXIT_CRITERIA.md](MILESTONES_AND_EXIT_CRITERIA.md)
+5. [SYNC_POLICY.md](SYNC_POLICY.md)
+6. [IMPLEMENTATION_WORKFLOW.md](IMPLEMENTATION_WORKFLOW.md)
+7. [SLICE_CHECKLIST.md](SLICE_CHECKLIST.md)
+8. [WORKSTREAMS.md](WORKSTREAMS.md)
+9. [MILESTONES_AND_EXIT_CRITERIA.md](MILESTONES_AND_EXIT_CRITERIA.md)
 
 Use the remaining docs as operational references while implementation proceeds.
 
@@ -53,6 +56,12 @@ Use the remaining docs as operational references while implementation proceeds.
   - how the platform program fits `v1.2` through `v1.8`
 - [BRANCHING_AND_GOVERNANCE.md](BRANCHING_AND_GOVERNANCE.md)
   - branch roles, merge policy, founder-led decision process, delegation rules
+- [SYNC_POLICY.md](SYNC_POLICY.md)
+  - roadmap-to-platform sync cadence, hotspot files, merge-back criteria, full vs selective sync
+- [IMPLEMENTATION_WORKFLOW.md](IMPLEMENTATION_WORKFLOW.md)
+  - worktree layout, topic-branch lifecycle, merge flow, validation expectations
+- [SLICE_CHECKLIST.md](SLICE_CHECKLIST.md)
+  - release-quality checklist for every platform change slice
 - [ARCHITECTURE.md](ARCHITECTURE.md)
   - technical architecture for profiles, runtimes, backends, BSPs, and kernel handoff
 - [WORKSTREAMS.md](WORKSTREAMS.md)

--- a/docs/platform/SLICE_CHECKLIST.md
+++ b/docs/platform/SLICE_CHECKLIST.md
@@ -1,0 +1,59 @@
+# Slice Checklist
+
+Use this checklist for every platform topic branch before merge.
+
+## 1. Scope
+
+- the branch owns one bounded subsystem change
+- the branch name follows `topic/platform-*`
+- unrelated roadmap work is not mixed into the branch
+- unrelated cleanup is deferred unless required by the slice
+
+## 2. Architecture
+
+- the slice matches an approved workstream
+- any boundary decision is recorded in `DECISIONS.md`
+- profile semantics are explicit, not implied by existing hosted behavior
+- hosted and freestanding expectations are both considered
+
+## 3. Implementation
+
+- files changed are consistent with the slice boundary
+- dangerous behavior is gated by profile or explicit configuration
+- hosted defaults are preserved unless the slice intentionally changes them
+- error paths and invalid combinations are handled explicitly
+
+## 4. Documentation
+
+- the relevant platform doc is updated
+- `docs/platform/README.md` is updated if program status changed
+- command-line or user-facing behavior changes are documented where users will find them
+- deferred follow-up work is recorded rather than left implicit
+
+## 5. Verification
+
+- the narrowest relevant build target was run
+- direct tests for the new behavior were run
+- failures from invalid combinations are covered when applicable
+- manual verification steps are written down if automation does not exist yet
+
+## 6. Integration
+
+- branch is clean before merge
+- commits are coherent and message quality is acceptable
+- merge into `feature/platform-freestanding` uses an explicit merge commit
+- merge-back to `feature/v1.2-scale` is evaluated explicitly, not assumed
+
+## 7. Release Safety
+
+- hosted behavior has not regressed
+- the slice does not silently expand platform support claims beyond documented support tiers
+- experimental behavior is labeled as experimental
+- kernel-only artifacts are not used to justify compiler/runtime merges
+
+## 8. After Merge
+
+- integration branch status is clean
+- any follow-up topic branches are named and scoped
+- milestone progress is updated if the slice changes program status materially
+- remaining risks are recorded if the slice leaves known limitations in place

--- a/docs/platform/SYNC_POLICY.md
+++ b/docs/platform/SYNC_POLICY.md
@@ -1,0 +1,160 @@
+# Sync Policy
+
+## Purpose
+
+This document defines how `feature/v1.2-scale` and `feature/platform-freestanding` stay convergent while both streams are active.
+
+The policy is intentionally asymmetric:
+
+- `feature/v1.2-scale` is the roadmap source branch
+- `feature/platform-freestanding` regularly absorbs roadmap progress
+- platform work merges back to the roadmap branch only when a slice is stable and release-safe
+
+## Core Rules
+
+- never sync from a dirty worktree
+- sync only from committed, reviewable changes
+- prefer explicit merge commits for branch-to-branch sync points
+- use topic branches only for bounded platform slices, not for ongoing roadmap sync
+- treat sync as operational work, not as an afterthought at release time
+
+## Default Direction
+
+The default direction is:
+
+- `feature/v1.2-scale` -> `feature/platform-freestanding`
+
+Do this regularly so the platform branch reflects the current compiler, runtime, build, and release work.
+
+The reverse direction is selective:
+
+- `feature/platform-freestanding` -> `feature/v1.2-scale`
+
+Do this only when a platform slice:
+
+- preserves hosted behavior
+- has been validated
+- fits the current release scope
+- does not require downstream kernel artifacts to justify its merge
+
+## Sync Cadence
+
+Use this cadence unless there is a reason to tighten it further.
+
+- daily while shared files are changing heavily
+- every 2-3 days during lower churn
+- immediately before or after work in shared hotspot files
+- immediately after a major roadmap slice becomes stable and committed
+
+Do not let the branches drift for more than a week if both streams are active.
+
+## Hotspot Files
+
+Sync before touching or merging around these areas when possible:
+
+- `CMakeLists.txt`
+- `lib/core/runtime*`
+- `lib/core/arena_memory*`
+- `lib/backend/llvm_codegen.cpp`
+- `exe/eshkol-run.cpp`
+- `docs/platform/*`
+
+These files produce disproportionate merge friction and should be kept as current as possible on the platform branch.
+
+## Sync Modes
+
+### Full roadmap sync
+
+Use a full sync when the roadmap branch contains coherent, stable work that the platform branch should absorb as-is.
+
+Example:
+
+```bash
+git -C ~/Desktop/eshkol-platform checkout feature/platform-freestanding
+git -C ~/Desktop/eshkol-platform merge --no-ff feature/v1.2-scale -m "merge: sync v1.2-scale into platform"
+```
+
+Use this as the default mode once the roadmap slice is ready.
+
+### Selective roadmap sync
+
+Use a selective sync when `feature/v1.2-scale` contains unfinished, experimental, or destabilizing work that the platform branch should not absorb yet.
+
+Options:
+
+- cherry-pick a finished roadmap commit
+- merge a narrower roadmap topic branch
+- delay the sync until the roadmap work stabilizes
+
+Selective sync is the exception, not the default.
+
+## When To Sync
+
+Sync `feature/v1.2-scale` into `feature/platform-freestanding` when any of the following is true:
+
+- a meaningful roadmap slice is complete and committed
+- the roadmap build becomes stable after churn in shared files
+- platform work is about to enter a shared hotspot file
+- the branches have been diverging for several days
+
+For the current program, the next likely sync point is when the active roadmap build is stable enough to merge without dragging obvious breakage into the platform branch.
+
+## Merge-Back Criteria
+
+A platform slice is eligible to merge back into `feature/v1.2-scale` only when:
+
+- the slice has already landed on `feature/platform-freestanding`
+- relevant validation passed on the integration branch
+- hosted defaults are unchanged or intentionally and explicitly revised
+- platform docs are current
+- the slice is useful to the roadmap now rather than merely future-facing
+
+If those conditions are not met, keep the slice on the platform branch and continue forward there.
+
+## Topic Branch Relationship
+
+Platform topic branches should be cut from the current `feature/platform-freestanding` head, not from `feature/v1.2-scale`.
+
+Sequence:
+
+1. sync roadmap into platform if needed
+2. cut `topic/platform-*` from updated `feature/platform-freestanding`
+3. implement and validate the slice
+4. merge the topic branch back into `feature/platform-freestanding`
+5. decide explicitly whether the result should merge back to `feature/v1.2-scale`
+
+This keeps platform slice history independent from roadmap sync history.
+
+## History Policy
+
+- use merge commits for `v1.2-scale` -> `platform-freestanding`
+- use merge commits for `topic/platform-*` -> `platform-freestanding`
+- rebase only unpublished personal topic branches if needed
+- do not rewrite shared branch history as part of ordinary sync work
+
+This keeps integration history auditable and reduces confusion when multiple streams are active.
+
+## Failure Handling
+
+If a sync produces conflicts:
+
+- resolve them on the receiving branch
+- keep the source branch untouched
+- validate immediately after the merge
+- record any new boundary issue in `DECISIONS.md` if the conflict exposed a real architectural ambiguity
+
+If the roadmap branch is temporarily unstable:
+
+- do not force the platform branch to absorb it immediately
+- wait for the roadmap slice to stabilize or sync selectively
+
+## Operational Summary
+
+Use this as the default operating rule:
+
+- roadmap work lands on `feature/v1.2-scale`
+- stable roadmap work is merged into `feature/platform-freestanding` frequently
+- platform slices land through `topic/platform-*`
+- only stable, validated, release-safe platform slices merge back to `feature/v1.2-scale`
+
+This is how the two streams stay convergent without forcing the platform program to move at the same granularity as day-to-day roadmap churn.


### PR DESCRIPTION
## Summary
- add explicit sync policy for roadmap/platform convergence
- add platform implementation workflow and slice checklist
- link the workflow docs from platform README and governance docs

## Scope notes
This is intentionally the first small merge-back slice from the platform branch. It excludes implemented-feature status docs, BSP/runtime inventory docs, command-line behavior changes, and branch-local sync maps so main only gets process docs that are true before platform code lands.

## Validation
- git diff --check