### PR TITLE
Harden build and shell test harnesses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1442,6 +1442,55 @@ if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/repl/assoc_e
     )
 endif()
 
+if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/windows_suite_surface_test.cpp")
+    add_executable(windows_suite_surface_test tests/toolchain/windows_suite_surface_test.cpp)
+    target_compile_features(windows_suite_surface_test PRIVATE cxx_std_17)
+    add_test(
+        NAME windows_suite_surface_test
+        COMMAND windows_suite_surface_test "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+endif()
+
+if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/aggregate_shell_suite_surface_test.cpp")
+    add_executable(aggregate_shell_suite_surface_test
+        tests/toolchain/aggregate_shell_suite_surface_test.cpp)
+    target_compile_features(aggregate_shell_suite_surface_test PRIVATE cxx_std_17)
+    add_test(
+        NAME aggregate_shell_suite_surface_test
+        COMMAND aggregate_shell_suite_surface_test "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+endif()
+
+if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/debian_package_surface_test.cpp")
+    add_executable(debian_package_surface_test
+        tests/toolchain/debian_package_surface_test.cpp)
+    target_compile_features(debian_package_surface_test PRIVATE cxx_std_17)
+    add_test(
+        NAME debian_package_surface_test
+        COMMAND debian_package_surface_test "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+endif()
+
+if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/docker_build_surface_test.cpp")
+    add_executable(docker_build_surface_test
+        tests/toolchain/docker_build_surface_test.cpp)
+    target_compile_features(docker_build_surface_test PRIVATE cxx_std_17)
+    add_test(
+        NAME docker_build_surface_test
+        COMMAND docker_build_surface_test "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+endif()
+
+if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/macos_build_surface_test.cpp")
+    add_executable(macos_build_surface_test
+        tests/toolchain/macos_build_surface_test.cpp)
+    target_compile_features(macos_build_surface_test PRIVATE cxx_std_17)
+    add_test(
+        NAME macos_build_surface_test
+        COMMAND macos_build_surface_test "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+endif()
+
 # ===== SDNC Paper Artifact: weight_matrices ===================================
 # The paper "The Self-Differentiating Neural Computer: Computable Transformers
 # via Analytical Weight Construction" (tsotchke 2026) reports a 2.8M-parameter

--- a/benchmarks/gpu_matmul_bench.sh
+++ b/benchmarks/gpu_matmul_bench.sh
@@ -9,36 +9,139 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 BUILD_DIR="$PROJECT_DIR/build"
 ESHKOL_RUN="$BUILD_DIR/eshkol-run"
 TMPDIR="${TMPDIR:-/tmp}"
+TMPDIR="${TMPDIR%/}"
+if [ -z "$TMPDIR" ]; then
+    TMPDIR="/"
+fi
 
-SIZES=(4096 8000 12000 16000 20000 24000 28000 32000 36000 40000)
+fail_benchmark_path() {
+    local label="$1"
+    local value="$2"
 
-echo "====================================================================="
-echo "  GPU MATMUL BENCHMARK — All Tiers"
-echo "  M2 Ultra · 76 GPU cores · 128 ALUs/core"
-echo "  All dispatched to GPU via ESHKOL_GPU_MATMUL_THRESHOLD=1"
-echo "====================================================================="
-echo ""
+    echo "unsupported GPU benchmark $label: $value" >&2
+    exit 1
+}
 
-run_bench() {
-    local PRECISION="$1"
-    local KERNEL="$2"
-    local LABEL="$3"
+require_benchmark_tmpdir() {
+    local path="$1"
 
-    echo "--- $LABEL ---"
+    case "$path" in
+        /*)
+            ;;
+        *)
+            fail_benchmark_path "temporary directory" "$path"
+            ;;
+    esac
 
-    for N in "${SIZES[@]}"; do
-        BENCH_SRC="$TMPDIR/eshkol_gpu_bench_${N}.esk"
-        BENCH_BIN="$TMPDIR/eshkol_gpu_bench_${N}"
+    if [ "$path" = "/" ]; then
+        fail_benchmark_path "temporary directory" "$path"
+    fi
 
-        cat > "$BENCH_SRC" << 'HEREDOC_END'
+    case "$path" in
+        *//*|*/..|*/../*|*/.|*/./*|*[!A-Za-z0-9._/-]*)
+            fail_benchmark_path "temporary directory" "$path"
+            ;;
+    esac
+
+    if [ -L "$path" ] || [ ! -d "$path" ] || [ ! -w "$path" ]; then
+        echo "GPU benchmark temporary directory missing, symlinked, or not writable: $path" >&2
+        exit 1
+    fi
+}
+
+require_benchmark_size() {
+    local value="$1"
+
+    case "$value" in
+        ""|*[!0-9]*)
+            fail_benchmark_path "matrix size" "$value"
+            ;;
+    esac
+
+    if [ "$value" -le 0 ]; then
+        fail_benchmark_path "matrix size" "$value"
+    fi
+}
+
+require_benchmark_work_dir() {
+    local path="$1"
+
+    case "$path" in
+        "$TMPDIR"/eshkol_gpu_bench.*)
+            ;;
+        *)
+            fail_benchmark_path "work directory" "$path"
+            ;;
+    esac
+
+    if [ -L "$path" ] || [ ! -d "$path" ] || [ ! -w "$path" ]; then
+        echo "GPU benchmark work directory missing, symlinked, or not writable: $path" >&2
+        exit 1
+    fi
+}
+
+require_benchmark_artifact_path() {
+    local label="$1"
+    local path="$2"
+
+    require_benchmark_work_dir "$BENCH_WORK_DIR"
+
+    case "$path" in
+        "$BENCH_WORK_DIR"/*)
+            ;;
+        *)
+            fail_benchmark_path "$label" "$path"
+            ;;
+    esac
+
+    case "$path" in
+        */|*//*|*/..|*/../*|*/.|*/./*|*[!A-Za-z0-9._/-]*)
+            fail_benchmark_path "$label" "$path"
+            ;;
+    esac
+
+    if [ -L "$path" ] || { [ -e "$path" ] && [ ! -f "$path" ]; }; then
+        echo "GPU benchmark $label exists but is not a regular non-symlinked file: $path" >&2
+        exit 1
+    fi
+}
+
+remove_benchmark_artifact() {
+    local path="$1"
+
+    require_benchmark_artifact_path "artifact" "$path"
+    if [ -e "$path" ]; then
+        rm -f -- "$path"
+    fi
+}
+
+cleanup_benchmark_work_dir() {
+    if [ -z "${BENCH_WORK_DIR:-}" ]; then
+        return
+    fi
+
+    require_benchmark_work_dir "$BENCH_WORK_DIR"
+    find "$BENCH_WORK_DIR" -mindepth 1 -maxdepth 1 -type f -delete
+    rmdir "$BENCH_WORK_DIR" 2>/dev/null || true
+}
+
+write_benchmark_source() {
+    local n="$1"
+    local path="$2"
+
+    require_benchmark_size "$n"
+    require_benchmark_artifact_path "source file" "$path"
+    if [ -e "$path" ]; then
+        echo "GPU benchmark source file already exists: $path" >&2
+        exit 1
+    fi
+
+    cat > "$path" << HEREDOC_END
 (require stdlib)
-HEREDOC_END
-
-        cat >> "$BENCH_SRC" << HEREDOC_END
-(define n $N)
+(define n $n)
 (define a (random-tensor (list n n)))
 (define b (random-tensor (list n n)))
-;; GPU shader warmup — first matmul compiles/caches the pipeline
+;; GPU shader warmup - first matmul compiles/caches the pipeline
 (matmul a b)
 (define elapsed (time-it (lambda () (matmul a b)) 1))
 (define flops (* 2.0 n n n))
@@ -66,20 +169,57 @@ HEREDOC_END
 (newline)
 HEREDOC_END
 
+    if [ -L "$path" ] || [ ! -f "$path" ] || [ ! -s "$path" ]; then
+        echo "GPU benchmark source file was not produced as a regular non-symlinked file: $path" >&2
+        exit 1
+    fi
+}
+
+require_benchmark_tmpdir "$TMPDIR"
+BENCH_WORK_DIR="$(mktemp -d "$TMPDIR/eshkol_gpu_bench.XXXXXX")"
+require_benchmark_work_dir "$BENCH_WORK_DIR"
+trap cleanup_benchmark_work_dir EXIT
+
+SIZES=(4096 8000 12000 16000 20000 24000 28000 32000 36000 40000)
+
+echo "====================================================================="
+echo "  GPU MATMUL BENCHMARK — All Tiers"
+echo "  M2 Ultra · 76 GPU cores · 128 ALUs/core"
+echo "  All dispatched to GPU via ESHKOL_GPU_MATMUL_THRESHOLD=1"
+echo "====================================================================="
+echo ""
+
+run_bench() {
+    local PRECISION="$1"
+    local KERNEL="$2"
+    local LABEL="$3"
+
+    echo "--- $LABEL ---"
+
+    for N in "${SIZES[@]}"; do
+        require_benchmark_size "$N"
+        BENCH_SRC="$BENCH_WORK_DIR/eshkol_gpu_bench_${N}.esk"
+        BENCH_BIN="$BENCH_WORK_DIR/eshkol_gpu_bench_${N}"
+        write_benchmark_source "$N" "$BENCH_SRC"
+
         if ! "$ESHKOL_RUN" "$BENCH_SRC" -L"$BUILD_DIR" -o "$BENCH_BIN" 2>/dev/null; then
             echo "  FAIL ${N}x${N} (compilation failed)"
-            rm -f "$BENCH_SRC"
+            remove_benchmark_artifact "$BENCH_SRC"
             continue
         fi
 
+        require_benchmark_artifact_path "compiled binary" "$BENCH_BIN"
+        set +e
         ESHKOL_GPU_MATMUL_THRESHOLD=1 ESHKOL_GPU_PRECISION="$PRECISION" ESHKOL_SF64_KERNEL="$KERNEL" "$BENCH_BIN"
         EXIT_CODE=$?
+        set -e
 
         if [ "$EXIT_CODE" -ne 0 ]; then
             echo "  FAIL ${N}x${N} (exit code $EXIT_CODE)"
         fi
 
-        rm -f "$BENCH_SRC" "$BENCH_BIN"
+        remove_benchmark_artifact "$BENCH_SRC"
+        remove_benchmark_artifact "$BENCH_BIN"
     done
     echo ""
 }

--- a/benchmarks/matmul_extreme.sh
+++ b/benchmarks/matmul_extreme.sh
@@ -15,6 +15,184 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 BUILD_DIR="$PROJECT_DIR/build"
 ESHKOL_RUN="$BUILD_DIR/eshkol-run"
 TMPDIR="${TMPDIR:-/tmp}"
+TMPDIR="${TMPDIR%/}"
+if [ -z "$TMPDIR" ]; then
+    TMPDIR="/"
+fi
+
+fail_benchmark_path() {
+    local label="$1"
+    local value="$2"
+
+    echo "unsupported extreme benchmark $label: $value" >&2
+    exit 1
+}
+
+require_benchmark_tmpdir() {
+    local path="$1"
+
+    case "$path" in
+        /*)
+            ;;
+        *)
+            fail_benchmark_path "temporary directory" "$path"
+            ;;
+    esac
+
+    if [ "$path" = "/" ]; then
+        fail_benchmark_path "temporary directory" "$path"
+    fi
+
+    case "$path" in
+        *//*|*/..|*/../*|*/.|*/./*|*[!A-Za-z0-9._/-]*)
+            fail_benchmark_path "temporary directory" "$path"
+            ;;
+    esac
+
+    if [ -L "$path" ] || [ ! -d "$path" ] || [ ! -w "$path" ]; then
+        echo "Extreme benchmark temporary directory missing, symlinked, or not writable: $path" >&2
+        exit 1
+    fi
+}
+
+require_benchmark_size() {
+    local value="$1"
+
+    case "$value" in
+        ""|*[!0-9]*)
+            fail_benchmark_path "matrix size" "$value"
+            ;;
+    esac
+
+    if [ "$value" -le 0 ]; then
+        fail_benchmark_path "matrix size" "$value"
+    fi
+}
+
+require_benchmark_decimal() {
+    local label="$1"
+    local value="$2"
+
+    case "$value" in
+        ""|.|*[!0-9.]*|*.*.*)
+            fail_benchmark_path "$label" "$value"
+            ;;
+    esac
+}
+
+require_benchmark_work_dir() {
+    local path="$1"
+
+    case "$path" in
+        "$TMPDIR"/eshkol_extreme_bench.*)
+            ;;
+        *)
+            fail_benchmark_path "work directory" "$path"
+            ;;
+    esac
+
+    if [ -L "$path" ] || [ ! -d "$path" ] || [ ! -w "$path" ]; then
+        echo "Extreme benchmark work directory missing, symlinked, or not writable: $path" >&2
+        exit 1
+    fi
+}
+
+require_benchmark_artifact_path() {
+    local label="$1"
+    local path="$2"
+
+    require_benchmark_work_dir "$BENCH_WORK_DIR"
+
+    case "$path" in
+        "$BENCH_WORK_DIR"/*)
+            ;;
+        *)
+            fail_benchmark_path "$label" "$path"
+            ;;
+    esac
+
+    case "$path" in
+        */|*//*|*/..|*/../*|*/.|*/./*|*[!A-Za-z0-9._/-]*)
+            fail_benchmark_path "$label" "$path"
+            ;;
+    esac
+
+    if [ -L "$path" ] || { [ -e "$path" ] && [ ! -f "$path" ]; }; then
+        echo "Extreme benchmark $label exists but is not a regular non-symlinked file: $path" >&2
+        exit 1
+    fi
+}
+
+remove_benchmark_artifact() {
+    local path="$1"
+
+    require_benchmark_artifact_path "artifact" "$path"
+    if [ -e "$path" ]; then
+        rm -f -- "$path"
+    fi
+}
+
+cleanup_benchmark_work_dir() {
+    if [ -z "${BENCH_WORK_DIR:-}" ]; then
+        return
+    fi
+
+    require_benchmark_work_dir "$BENCH_WORK_DIR"
+    find "$BENCH_WORK_DIR" -mindepth 1 -maxdepth 1 -type f -delete
+    rmdir "$BENCH_WORK_DIR" 2>/dev/null || true
+}
+
+write_benchmark_source() {
+    local n="$1"
+    local mem_gb="$2"
+    local path="$3"
+
+    require_benchmark_size "$n"
+    require_benchmark_decimal "memory size" "$mem_gb"
+    require_benchmark_artifact_path "source file" "$path"
+    if [ -e "$path" ]; then
+        echo "Extreme benchmark source file already exists: $path" >&2
+        exit 1
+    fi
+
+    cat > "$path" << HEREDOC_END
+(require stdlib)
+(define n $n)
+(define a (random-tensor (list n n)))
+(define b (random-tensor (list n n)))
+(define elapsed (time-it (lambda () (matmul a b)) 1))
+(define flops (* 2.0 n n n))
+(define gflops (/ flops (* (/ elapsed 1e9) 1e9)))
+(display "  ${n}x${n}  ${mem_gb} GB  ")
+(cond
+  ((>= elapsed 1e12)
+   (display (number->string (round (/ elapsed 1e9) 0.01)))
+   (display " s"))
+  ((>= elapsed 1e9)
+   (display (number->string (round (/ elapsed 1e6) 0.1)))
+   (display " ms"))
+  (else
+   (display (number->string (round (/ elapsed 1e3) 0.1)))
+   (display " us")))
+(display "  @ ")
+(if (>= gflops 1000)
+    (begin (display (number->string (round (/ gflops 1000.0) 0.001)))
+           (display " TFLOPS"))
+    (begin (display (number->string (round gflops 0.1)))
+           (display " GFLOPS")))
+(newline)
+HEREDOC_END
+
+    if [ -L "$path" ] || [ ! -f "$path" ] || [ ! -s "$path" ]; then
+        echo "Extreme benchmark source file was not produced as a regular non-symlinked file: $path" >&2
+        exit 1
+    fi
+}
+
+require_benchmark_tmpdir "$TMPDIR"
+BENCH_WORK_DIR="$(mktemp -d "$TMPDIR/eshkol_extreme_bench.XXXXXX")"
+require_benchmark_work_dir "$BENCH_WORK_DIR"
+trap cleanup_benchmark_work_dir EXIT
 
 echo "====================================================================="
 echo "  EXTREME MATMUL BENCHMARK — SYSTEM LIMIT STRESS TEST"
@@ -47,50 +225,25 @@ for N in "${SIZES[@]}"; do
     fi
 
     # Generate single-size benchmark using time-it from stdlib
-    BENCH_SRC="$TMPDIR/eshkol_bench_${N}.esk"
-    BENCH_BIN="$TMPDIR/eshkol_bench_${N}"
-
-    cat > "$BENCH_SRC" << 'HEREDOC_END'
-(require stdlib)
-HEREDOC_END
-
-    cat >> "$BENCH_SRC" << HEREDOC_END
-(define n $N)
-(define a (random-tensor (list n n)))
-(define b (random-tensor (list n n)))
-(define elapsed (time-it (lambda () (matmul a b)) 1))
-(define flops (* 2.0 n n n))
-(define gflops (/ flops (* (/ elapsed 1e9) 1e9)))
-(display "  ${N}x${N}  ${MEM_GB} GB  ")
-(cond
-  ((>= elapsed 1e12)
-   (display (number->string (round (/ elapsed 1e9) 0.01)))
-   (display " s"))
-  ((>= elapsed 1e9)
-   (display (number->string (round (/ elapsed 1e6) 0.1)))
-   (display " ms"))
-  (else
-   (display (number->string (round (/ elapsed 1e3) 0.1)))
-   (display " us")))
-(display "  @ ")
-(if (>= gflops 1000)
-    (begin (display (number->string (round (/ gflops 1000.0) 0.001)))
-           (display " TFLOPS"))
-    (begin (display (number->string (round gflops 0.1)))
-           (display " GFLOPS")))
-(newline)
-HEREDOC_END
+    require_benchmark_size "$N"
+    require_benchmark_decimal "memory size" "$MEM_GB"
+    BENCH_SRC="$BENCH_WORK_DIR/eshkol_bench_${N}.esk"
+    BENCH_BIN="$BENCH_WORK_DIR/eshkol_bench_${N}"
+    write_benchmark_source "$N" "$MEM_GB" "$BENCH_SRC"
 
     # Compile
     if ! "$ESHKOL_RUN" "$BENCH_SRC" -L"$BUILD_DIR" -o "$BENCH_BIN" 2>/dev/null; then
         echo "  FAIL ${N}x${N} (compilation failed)"
-        rm -f "$BENCH_SRC"
+        remove_benchmark_artifact "$BENCH_SRC"
         continue
     fi
 
     # Run (no timeout — let it take as long as needed)
+    require_benchmark_artifact_path "compiled binary" "$BENCH_BIN"
+    set +e
     "$BENCH_BIN"
     EXIT_CODE=$?
+    set -e
 
     if [ "$EXIT_CODE" -ne 0 ]; then
         if [ "$EXIT_CODE" -eq 137 ]; then
@@ -101,7 +254,8 @@ HEREDOC_END
     fi
 
     # Cleanup
-    rm -f "$BENCH_SRC" "$BENCH_BIN"
+    remove_benchmark_artifact "$BENCH_SRC"
+    remove_benchmark_artifact "$BENCH_BIN"
 done
 
 echo ""

--- a/cmake/RunSuite.cmake
+++ b/cmake/RunSuite.cmake
@@ -6,14 +6,61 @@ if(NOT DEFINED NEGATIVE_MODE)
     set(NEGATIVE_MODE "none")
 endif()
 
+function(eshkol_require_directory label path)
+    if(NOT IS_ABSOLUTE "${path}")
+        message(FATAL_ERROR "${label} must be absolute: ${path}")
+    endif()
+
+    if(IS_SYMLINK "${path}")
+        message(FATAL_ERROR "${label} must not be a symlink: ${path}")
+    endif()
+
+    if(NOT IS_DIRECTORY "${path}")
+        message(FATAL_ERROR "${label} must be an existing directory: ${path}")
+    endif()
+endfunction()
+
+function(eshkol_require_regular_file label path)
+    if(IS_SYMLINK "${path}")
+        message(FATAL_ERROR "${label} must not be a symlink: ${path}")
+    endif()
+
+    if(NOT EXISTS "${path}")
+        message(FATAL_ERROR "${label} not found: ${path}")
+    endif()
+
+    if(IS_DIRECTORY "${path}")
+        message(FATAL_ERROR "${label} must be a regular file: ${path}")
+    endif()
+endfunction()
+
+function(eshkol_require_suite_name value)
+    if("${value}" STREQUAL "" OR NOT "${value}" MATCHES "^[A-Za-z0-9_.-]+$")
+        message(FATAL_ERROR "unsupported suite name: ${value}")
+    endif()
+endfunction()
+
+function(eshkol_require_test_glob value)
+    if("${value}" STREQUAL "")
+        message(FATAL_ERROR "TEST_GLOB must not be empty")
+    endif()
+
+    if(IS_ABSOLUTE "${value}" OR "${value}" MATCHES "(^|/)\\.\\.(/|$)")
+        message(FATAL_ERROR "unsupported TEST_GLOB: ${value}")
+    endif()
+endfunction()
+
+eshkol_require_directory("PROJECT_ROOT" "${PROJECT_ROOT}")
+eshkol_require_directory("BUILD_DIR" "${BUILD_DIR}")
+eshkol_require_suite_name("${SUITE_NAME}")
+eshkol_require_test_glob("${TEST_GLOB}")
+
 set(ESHKOL_RUN "${BUILD_DIR}/eshkol-run${EXECUTABLE_SUFFIX}")
 if(NOT EXISTS "${ESHKOL_RUN}")
     set(ESHKOL_RUN "${BUILD_DIR}/eshkol-run")
 endif()
 
-if(NOT EXISTS "${ESHKOL_RUN}")
-    message(FATAL_ERROR "eshkol-run not found at ${BUILD_DIR}")
-endif()
+eshkol_require_regular_file("eshkol-run" "${ESHKOL_RUN}")
 
 file(GLOB TEST_FILES LIST_DIRECTORIES false "${PROJECT_ROOT}/${TEST_GLOB}")
 if(NOT TEST_FILES)
@@ -44,6 +91,14 @@ function(eshkol_find_output out_var output_base)
         "${output_base}"
     )
     foreach(candidate IN LISTS candidates)
+        if(IS_SYMLINK "${candidate}")
+            message(FATAL_ERROR "suite output executable must not be a symlink: ${candidate}")
+        endif()
+
+        if(IS_DIRECTORY "${candidate}")
+            message(FATAL_ERROR "suite output executable must be a regular file: ${candidate}")
+        endif()
+
         if(EXISTS "${candidate}")
             set(${out_var} "${candidate}" PARENT_SCOPE)
             return()
@@ -59,6 +114,7 @@ set(fail_count 0)
 message(STATUS "Running Eshkol suite ${SUITE_NAME}")
 
 foreach(test_file IN LISTS TEST_FILES)
+    eshkol_require_regular_file("suite test file" "${test_file}")
     file(RELATIVE_PATH TEST_RELATIVE_PATH "${PROJECT_ROOT}" "${test_file}")
     string(REGEX REPLACE "[^A-Za-z0-9_.-]" "_" TEST_WORK_ID "${TEST_RELATIVE_PATH}")
     set(TEST_WORK_DIR "${SUITE_OUTPUT_ROOT}/${TEST_WORK_ID}")

--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -2,13 +2,13 @@ function(eshkol_add_suite_test suite_name test_glob)
     add_test(
         NAME suite-${suite_name}
         COMMAND
-            ${CMAKE_COMMAND}
-            -DPROJECT_ROOT=${CMAKE_SOURCE_DIR}
-            -DBUILD_DIR=${CMAKE_BINARY_DIR}
-            -DEXECUTABLE_SUFFIX=${CMAKE_EXECUTABLE_SUFFIX}
-            -DSUITE_NAME=${suite_name}
-            -DTEST_GLOB=${test_glob}
-            -P ${CMAKE_SOURCE_DIR}/cmake/RunSuite.cmake
+            "${CMAKE_COMMAND}"
+            "-DPROJECT_ROOT=${CMAKE_SOURCE_DIR}"
+            "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
+            "-DEXECUTABLE_SUFFIX=${CMAKE_EXECUTABLE_SUFFIX}"
+            "-DSUITE_NAME=${suite_name}"
+            "-DTEST_GLOB=${test_glob}"
+            -P "${CMAKE_SOURCE_DIR}/cmake/RunSuite.cmake"
     )
     set_tests_properties(suite-${suite_name} PROPERTIES LABELS "suite")
 endfunction()
@@ -17,14 +17,14 @@ function(eshkol_add_negative_suite_test suite_name test_glob negative_mode)
     add_test(
         NAME suite-${suite_name}
         COMMAND
-            ${CMAKE_COMMAND}
-            -DPROJECT_ROOT=${CMAKE_SOURCE_DIR}
-            -DBUILD_DIR=${CMAKE_BINARY_DIR}
-            -DEXECUTABLE_SUFFIX=${CMAKE_EXECUTABLE_SUFFIX}
-            -DSUITE_NAME=${suite_name}
-            -DTEST_GLOB=${test_glob}
-            -DNEGATIVE_MODE=${negative_mode}
-            -P ${CMAKE_SOURCE_DIR}/cmake/RunSuite.cmake
+            "${CMAKE_COMMAND}"
+            "-DPROJECT_ROOT=${CMAKE_SOURCE_DIR}"
+            "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
+            "-DEXECUTABLE_SUFFIX=${CMAKE_EXECUTABLE_SUFFIX}"
+            "-DSUITE_NAME=${suite_name}"
+            "-DTEST_GLOB=${test_glob}"
+            "-DNEGATIVE_MODE=${negative_mode}"
+            -P "${CMAKE_SOURCE_DIR}/cmake/RunSuite.cmake"
     )
     set_tests_properties(suite-${suite_name} PROPERTIES LABELS "suite")
 endfunction()

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -14,6 +14,44 @@ VERSION="${1:-1.1.0}"
 BUILD_DIR="build"
 PACKAGE_NAME="eshkol"
 
+fail() {
+    echo "Error: $1" >&2
+    exit 1
+}
+
+validate_package_version() {
+    local version="$1"
+
+    case "$version" in
+        ""|*/*|*\\*|*..*|*[!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.+:~-]*)
+            fail "unsafe Debian package version: $version"
+            ;;
+    esac
+
+    if [ "${#version}" -gt 128 ]; then
+        fail "Debian package version is too long: $version"
+    fi
+}
+
+require_regular_executable() {
+    local label="$1"
+    local path="$2"
+
+    if [ -L "$path" ] || ! test -f "$path" || ! test -s "$path" || ! test -x "$path"; then
+        fail "$label missing, empty, symlinked, or not executable: $path"
+    fi
+}
+
+require_regular_package_file() {
+    local path="$1"
+
+    if [ -L "$path" ] || ! test -f "$path" || ! test -s "$path"; then
+        fail "generated Debian package missing, empty, symlinked, or not a regular file: $path"
+    fi
+}
+
+validate_package_version "$VERSION"
+
 echo "Building Debian package for ${PACKAGE_NAME} v${VERSION}"
 
 # Ensure we're in the project root
@@ -22,11 +60,13 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_ROOT"
 
 # Build if not already built
-if [ ! -f "${BUILD_DIR}/eshkol-run" ]; then
+ESHKOL_RUN="${BUILD_DIR}/eshkol-run"
+if ! test -e "$ESHKOL_RUN"; then
     echo "Building project..."
     cmake -B "${BUILD_DIR}" -G Ninja -DCMAKE_BUILD_TYPE=Release
     cmake --build "${BUILD_DIR}" --parallel
 fi
+require_regular_executable "eshkol-run" "$ESHKOL_RUN"
 
 # Generate .deb package using CPack
 echo "Generating Debian package..."
@@ -38,13 +78,13 @@ cpack -G DEB \
 # Find the generated package (CPack outputs to _packages/ subdirectory)
 DEB_FILE=$(find . -name "*.deb" -type f 2>/dev/null | head -1)
 if [ -z "$DEB_FILE" ]; then
-    echo "Error: No .deb file generated"
-    exit 1
+    fail "No .deb file generated"
 fi
+require_regular_package_file "$DEB_FILE"
 
 # Move to project root with standardized name
 ARCH=$(dpkg --print-architecture 2>/dev/null || echo "amd64")
 OUTPUT_NAME="${PACKAGE_NAME}_${VERSION}_${ARCH}.deb"
-mv "$DEB_FILE" "../${OUTPUT_NAME}"
+mv -- "$DEB_FILE" "../${OUTPUT_NAME}"
 
 echo "Successfully created: ${OUTPUT_NAME}"

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -24,6 +24,59 @@ OUTPUT_DIR="./dist"
 NO_CACHE=""
 BUILD_TYPE="release"
 
+fail() {
+    echo "Error: $1" >&2
+    exit 1
+}
+
+validate_package_version() {
+    local version="$1"
+
+    case "$version" in
+        ""|*/*|*\\*|*..*|*[!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.+:~-]*)
+            fail "unsafe Docker artifact version: $version"
+            ;;
+    esac
+
+    if [ "${#version}" -gt 128 ]; then
+        fail "Docker artifact version is too long: $version"
+    fi
+}
+
+require_output_directory() {
+    local label="$1"
+    local path="$2"
+
+    if [ -L "$path" ]; then
+        fail "$label must not be a symlink: $path"
+    fi
+
+    mkdir -p "$path"
+
+    if [ -L "$path" ] || [ ! -d "$path" ]; then
+        fail "$label missing or symlinked after creation: $path"
+    fi
+}
+
+remove_package_stage() {
+    local stage="$1"
+    local root="$2"
+
+    case "$stage" in
+        "$root"/.pkg.*)
+            ;;
+        *)
+            fail "refusing to remove unexpected Docker package stage path: $stage"
+            ;;
+    esac
+
+    if [ -L "$stage" ] || { [ -e "$stage" ] && [ ! -d "$stage" ]; }; then
+        fail "refusing to remove non-directory or symlinked Docker package stage: $stage"
+    fi
+
+    rm -rf -- "$stage"
+}
+
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -54,6 +107,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+validate_package_version "$VERSION"
+
 # Get project root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
@@ -80,11 +135,30 @@ echo "Version: $VERSION"
 echo "Build type: $BUILD_TYPE"
 
 # Create output directory
-mkdir -p "$OUTPUT_DIR"
+require_output_directory "Docker artifact output directory" "$OUTPUT_DIR"
+
+require_docker_container_name() {
+    local value="$1"
+
+    case "$value" in
+        ""|.*|*/*|*[!A-Za-z0-9_.-]*)
+            echo "Unsafe Docker container name: $value" >&2
+            exit 1
+            ;;
+    esac
+}
+
+remove_build_container() {
+    local container_name="$1"
+
+    require_docker_container_name "$container_name"
+    docker container rm --force "$container_name" 2>/dev/null || true
+}
 
 # Docker image name
 IMAGE_NAME="eshkol-builder-debian-${ARCH}"
 CONTAINER_NAME="eshkol-build-${ARCH}-$$"
+require_docker_container_name "$CONTAINER_NAME"
 
 # Check if we need to set up QEMU for cross-platform builds
 HOST_ARCH=$(uname -m)
@@ -108,7 +182,7 @@ docker build \
 
 # Create and run container
 echo "Running build in container..."
-docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+remove_build_container "$CONTAINER_NAME"
 docker create --platform "$PLATFORM" --name "$CONTAINER_NAME" "$IMAGE_NAME"
 
 # Extract artifacts
@@ -116,7 +190,8 @@ echo "Extracting artifacts..."
 
 # Create arch-specific output directory
 ARCH_OUTPUT="$OUTPUT_DIR/linux-${ARCH_NAME}"
-mkdir -p "$ARCH_OUTPUT"
+require_output_directory "Docker architecture artifact directory" "$ARCH_OUTPUT"
+ARCH_OUTPUT="$(cd "$ARCH_OUTPUT" && pwd -P)"
 
 # Copy binaries
 docker cp "$CONTAINER_NAME:/app/build/eshkol-run" "$ARCH_OUTPUT/" 2>/dev/null || echo "Warning: eshkol-run not found"
@@ -134,25 +209,25 @@ fi
 # Create tarball
 echo "Creating tarball..."
 TARBALL_NAME="eshkol-${VERSION}-linux-${ARCH_NAME}.tar.gz"
+PKG_STAGE="$(mktemp -d "$ARCH_OUTPUT/.pkg.XXXXXX")"
 (
-    cd "$ARCH_OUTPUT"
-    mkdir -p pkg/bin pkg/lib pkg/share/eshkol
-    cp eshkol-run pkg/bin/ 2>/dev/null || true
-    cp eshkol-repl pkg/bin/ 2>/dev/null || true
-    cp stdlib.o pkg/lib/ 2>/dev/null || true
-    cp libeshkol-static.a pkg/lib/ 2>/dev/null || true
-    cp "$PROJECT_ROOT/lib/stdlib.esk" pkg/share/eshkol/ 2>/dev/null || true
+    mkdir -p "$PKG_STAGE/bin" "$PKG_STAGE/lib" "$PKG_STAGE/share/eshkol"
+    cp "$ARCH_OUTPUT/eshkol-run" "$PKG_STAGE/bin/" 2>/dev/null || true
+    cp "$ARCH_OUTPUT/eshkol-repl" "$PKG_STAGE/bin/" 2>/dev/null || true
+    cp "$ARCH_OUTPUT/stdlib.o" "$PKG_STAGE/lib/" 2>/dev/null || true
+    cp "$ARCH_OUTPUT/libeshkol-static.a" "$PKG_STAGE/lib/" 2>/dev/null || true
+    cp "$PROJECT_ROOT/lib/stdlib.esk" "$PKG_STAGE/share/eshkol/" 2>/dev/null || true
     if [ -d "$PROJECT_ROOT/lib/core" ]; then
-        cp -r "$PROJECT_ROOT/lib/core" pkg/share/eshkol/
+        cp -r "$PROJECT_ROOT/lib/core" "$PKG_STAGE/share/eshkol/"
     fi
-    cp "$PROJECT_ROOT/README.md" pkg/ 2>/dev/null || true
-    cp "$PROJECT_ROOT/LICENSE" pkg/ 2>/dev/null || true
-    tar -czvf "$TARBALL_NAME" -C pkg .
-    rm -rf pkg
+    cp "$PROJECT_ROOT/README.md" "$PKG_STAGE/" 2>/dev/null || true
+    cp "$PROJECT_ROOT/LICENSE" "$PKG_STAGE/" 2>/dev/null || true
+    tar -czvf "$ARCH_OUTPUT/$TARBALL_NAME" -C "$PKG_STAGE" .
 )
+remove_package_stage "$PKG_STAGE" "$ARCH_OUTPUT"
 
 # Cleanup container
-docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+remove_build_container "$CONTAINER_NAME"
 
 echo ""
 echo "Build complete! Artifacts in: $ARCH_OUTPUT"

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -28,6 +28,89 @@ UNIVERSAL=false
 TARGET_ARCH="native"
 CLEAN=false
 
+fail() {
+    echo "Error: $1" >&2
+    exit 1
+}
+
+validate_package_version() {
+    local version="$1"
+
+    case "$version" in
+        ""|*/*|*\\*|*..*|*[!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.+:~-]*)
+            fail "unsafe macOS artifact version: $version"
+            ;;
+    esac
+
+    if [ "${#version}" -gt 128 ]; then
+        fail "macOS artifact version is too long: $version"
+    fi
+}
+
+validate_target_arch() {
+    local arch="$1"
+
+    case "$arch" in
+        native|arm64|x86_64)
+            ;;
+        *)
+            fail "unsupported macOS target architecture: $arch"
+            ;;
+    esac
+}
+
+require_output_directory() {
+    local label="$1"
+    local path="$2"
+
+    if [ -L "$path" ]; then
+        fail "$label must not be a symlink: $path"
+    fi
+
+    mkdir -p "$path"
+
+    if [ -L "$path" ] || [ ! -d "$path" ]; then
+        fail "$label missing or symlinked after creation: $path"
+    fi
+}
+
+remove_build_directory() {
+    local path="$1"
+
+    case "$path" in
+        build-arm64|build-x86_64)
+            ;;
+        *)
+            fail "refusing to remove unexpected macOS build directory: $path"
+            ;;
+    esac
+
+    if [ -L "$path" ] || { [ -e "$path" ] && [ ! -d "$path" ]; }; then
+        fail "refusing to remove non-directory or symlinked macOS build path: $path"
+    fi
+
+    rm -rf -- "$path"
+}
+
+remove_package_stage() {
+    local stage="$1"
+    local root="$2"
+
+    case "$stage" in
+        "$root"/.pkg.*)
+            ;;
+        *)
+            fail "refusing to remove unexpected macOS package stage path: $stage"
+            ;;
+    esac
+
+    if [ -L "$stage" ] || { [ -e "$stage" ] && [ ! -d "$stage" ]; }; then
+        fail "refusing to remove non-directory or symlinked macOS package stage: $stage"
+    fi
+
+    rm -rf -- "$stage"
+}
+
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -62,6 +145,9 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+validate_package_version "$VERSION"
+validate_target_arch "$TARGET_ARCH"
+
 # Get project root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
@@ -75,7 +161,8 @@ echo "Host architecture: $HOST_ARCH"
 eshkol_activate_llvm_toolchain
 LLVM_PATH="${ESHKOL_LLVM_ROOT}"
 
-mkdir -p "$OUTPUT_DIR"
+require_output_directory "macOS artifact output directory" "$OUTPUT_DIR"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd -P)"
 
 # Function to build for a specific architecture
 build_arch() {
@@ -85,7 +172,7 @@ build_arch() {
     echo "Building for architecture: $arch"
 
     if [ "$CLEAN" = true ] && [ -d "$build_dir" ]; then
-        rm -rf "$build_dir"
+        remove_build_directory "$build_dir"
     fi
 
     # Set architecture-specific flags
@@ -137,7 +224,8 @@ create_package() {
     echo "Creating package: $output_name"
 
     local pkg_dir="$OUTPUT_DIR/${output_name}"
-    mkdir -p "$pkg_dir"
+    require_output_directory "macOS package output directory" "$pkg_dir"
+    pkg_dir="$(cd "$pkg_dir" && pwd -P)"
 
     # Copy binaries
     cp "$build_dir/eshkol-run" "$pkg_dir/"
@@ -146,17 +234,19 @@ create_package() {
 
     # Create tarball
     local tarball="$OUTPUT_DIR/eshkol-${VERSION}-${output_name}.tar.gz"
+    local pkg_stage
+    pkg_stage="$(mktemp -d "$pkg_dir/.pkg.XXXXXX")"
     (
-        mkdir -p "$pkg_dir/pkg/bin" "$pkg_dir/pkg/lib" "$pkg_dir/pkg/share/eshkol"
-        cp "$build_dir/eshkol-run" "$pkg_dir/pkg/bin/"
-        cp "$build_dir/eshkol-repl" "$pkg_dir/pkg/bin/"
-        cp "$build_dir/stdlib.o" "$pkg_dir/pkg/lib/"
-        cp lib/stdlib.esk "$pkg_dir/pkg/share/eshkol/"
-        [ -d lib/core ] && cp -r lib/core "$pkg_dir/pkg/share/eshkol/"
-        cp README.md LICENSE "$pkg_dir/pkg/" 2>/dev/null || true
-        tar -czvf "$tarball" -C "$pkg_dir/pkg" .
-        rm -rf "$pkg_dir/pkg"
+        mkdir -p "$pkg_stage/bin" "$pkg_stage/lib" "$pkg_stage/share/eshkol"
+        cp "$build_dir/eshkol-run" "$pkg_stage/bin/"
+        cp "$build_dir/eshkol-repl" "$pkg_stage/bin/"
+        cp "$build_dir/stdlib.o" "$pkg_stage/lib/"
+        cp lib/stdlib.esk "$pkg_stage/share/eshkol/"
+        [ -d lib/core ] && cp -r lib/core "$pkg_stage/share/eshkol/"
+        cp README.md LICENSE "$pkg_stage/" 2>/dev/null || true
+        tar -czvf "$tarball" -C "$pkg_stage" .
     )
+    remove_package_stage "$pkg_stage" "$pkg_dir"
 
     echo "Created: $tarball"
 }
@@ -166,7 +256,8 @@ create_universal() {
     echo "Creating universal binary..."
 
     local universal_dir="$OUTPUT_DIR/macos-universal"
-    mkdir -p "$universal_dir"
+    require_output_directory "macOS universal artifact directory" "$universal_dir"
+    universal_dir="$(cd "$universal_dir" && pwd -P)"
 
     # Use lipo to combine arm64 and x86_64 binaries
     for binary in eshkol-run eshkol-repl; do
@@ -188,19 +279,21 @@ create_universal() {
 
     # Create tarball
     local tarball="$OUTPUT_DIR/eshkol-${VERSION}-macos-universal.tar.gz"
+    local pkg_stage
+    pkg_stage="$(mktemp -d "$universal_dir/.pkg.XXXXXX")"
     (
-        mkdir -p "$universal_dir/pkg/bin" "$universal_dir/pkg/lib" "$universal_dir/pkg/share/eshkol"
-        cp "$universal_dir/eshkol-run" "$universal_dir/pkg/bin/"
-        cp "$universal_dir/eshkol-repl" "$universal_dir/pkg/bin/"
+        mkdir -p "$pkg_stage/bin" "$pkg_stage/lib" "$pkg_stage/share/eshkol"
+        cp "$universal_dir/eshkol-run" "$pkg_stage/bin/"
+        cp "$universal_dir/eshkol-repl" "$pkg_stage/bin/"
         # Include both arch-specific stdlib.o files
-        cp "$universal_dir/stdlib-arm64.o" "$universal_dir/pkg/lib/" 2>/dev/null || true
-        cp "$universal_dir/stdlib-x86_64.o" "$universal_dir/pkg/lib/" 2>/dev/null || true
-        cp lib/stdlib.esk "$universal_dir/pkg/share/eshkol/"
-        [ -d lib/core ] && cp -r lib/core "$universal_dir/pkg/share/eshkol/"
-        cp README.md LICENSE "$universal_dir/pkg/" 2>/dev/null || true
-        tar -czvf "$tarball" -C "$universal_dir/pkg" .
-        rm -rf "$universal_dir/pkg"
+        cp "$universal_dir/stdlib-arm64.o" "$pkg_stage/lib/" 2>/dev/null || true
+        cp "$universal_dir/stdlib-x86_64.o" "$pkg_stage/lib/" 2>/dev/null || true
+        cp lib/stdlib.esk "$pkg_stage/share/eshkol/"
+        [ -d lib/core ] && cp -r lib/core "$pkg_stage/share/eshkol/"
+        cp README.md LICENSE "$pkg_stage/" 2>/dev/null || true
+        tar -czvf "$tarball" -C "$pkg_stage" .
     )
+    remove_package_stage "$pkg_stage" "$universal_dir"
 
     echo "Created: $tarball"
 }

--- a/scripts/make-docker.sh
+++ b/scripts/make-docker.sh
@@ -17,6 +17,15 @@ BUILD_DIR="${1:-./dist}"
 VERSION="${2:-1.0.0}"
 TYPE="${3:-release}"
 
+case "$TYPE" in
+    release|debug)
+        ;;
+    *)
+        echo "Unsupported Docker build type: $TYPE" >&2
+        exit 1
+        ;;
+esac
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_ROOT"
@@ -28,6 +37,25 @@ echo "  Type: $TYPE"
 echo ""
 
 mkdir -p "$BUILD_DIR"
+
+require_docker_name() {
+    local value="$1"
+    local label="$2"
+
+    case "$value" in
+        ""|.*|*/*|*[!A-Za-z0-9_.-]*)
+            echo "Unsafe Docker $label: $value" >&2
+            exit 1
+            ;;
+    esac
+}
+
+remove_build_container() {
+    local name="$1"
+
+    require_docker_name "$name" "container name"
+    docker container rm --force "$name" 2>/dev/null || true
+}
 
 # Determine host architecture for platform selection
 HOST_ARCH=$(uname -m)
@@ -57,6 +85,8 @@ for os_dir in docker/*/; do
         arch="${platform#linux/}"
         image_name="eshkol_${os}_${TYPE}_${arch}"
         container_name="eshkol_build_${os}_${TYPE}_${arch}_$$"
+        require_docker_name "$image_name" "image name"
+        require_docker_name "$container_name" "container name"
 
         echo ""
         echo "=== Building $os ($arch) ==="
@@ -75,7 +105,7 @@ for os_dir in docker/*/; do
 
         # Create container and extract artifacts
         echo "Extracting artifacts..."
-        docker rm -f "$container_name" 2>/dev/null || true
+        remove_build_container "$container_name"
         container_id=$(docker create --platform "$platform" --name "$container_name" "$image_name")
 
         # Create output directory
@@ -95,7 +125,7 @@ for os_dir in docker/*/; do
         fi
 
         # Cleanup
-        docker rm -f "$container_name" 2>/dev/null || true
+        remove_build_container "$container_name"
 
         # List outputs
         echo "  Artifacts in $out_dir:"

--- a/scripts/run_all_tests.ps1
+++ b/scripts/run_all_tests.ps1
@@ -126,7 +126,7 @@ function Resolve-BuildDirectory {
             (Join-Path $resolvedCandidate "Release"),
             (Join-Path $resolvedCandidate "Debug")
         )) {
-            if (Test-Path (Join-Path $binDir "eshkol-run.exe")) {
+            if (Test-RegularFile -Path (Join-Path $binDir "eshkol-run.exe")) {
                 return [pscustomobject]@{
                     RootDir   = $resolvedCandidate
                     BinaryDir = $binDir
@@ -181,9 +181,83 @@ function New-OutputBase {
     Join-Path $dir $safeName
 }
 
+function Get-RegularFileItem {
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return $null
+    }
+
+    try {
+        $item = Get-Item -LiteralPath $Path -Force -ErrorAction Stop
+    } catch [System.Management.Automation.ItemNotFoundException] {
+        return $null
+    } catch [System.Management.Automation.DriveNotFoundException] {
+        return $null
+    }
+
+    if ($item.PSIsContainer) {
+        return $null
+    }
+    if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        return $null
+    }
+
+    return $item
+}
+
+function Test-RegularFile {
+    param([string]$Path)
+
+    return ($null -ne (Get-RegularFileItem -Path $Path))
+}
+
+function Remove-RegularFileIfPresent {
+    param([string[]]$Path)
+
+    foreach ($entry in $Path) {
+        if ([string]::IsNullOrWhiteSpace($entry)) {
+            continue
+        }
+
+        try {
+            $item = Get-Item -LiteralPath $entry -Force -ErrorAction Stop
+        } catch [System.Management.Automation.ItemNotFoundException] {
+            continue
+        } catch [System.Management.Automation.DriveNotFoundException] {
+            continue
+        }
+
+        if ($item.PSIsContainer) {
+            throw "Refusing to remove directory artifact: $entry"
+        }
+        if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+            throw "Refusing to remove reparse-point artifact: $entry"
+        }
+
+        Remove-Item -LiteralPath $item.FullName -Force -ErrorAction Stop
+    }
+}
+
+function Start-RegularFileProcess {
+    param(
+        [string]$FilePath,
+        [string[]]$ArgumentList = @(),
+        [string]$WorkingDirectory,
+        [string]$RedirectStandardOutput,
+        [string]$RedirectStandardError
+    )
+
+    if (-not (Test-RegularFile -Path $FilePath)) {
+        throw "Refusing to start missing or non-regular executable: $FilePath"
+    }
+
+    return Start-Process -FilePath $FilePath -ArgumentList $ArgumentList -WorkingDirectory $WorkingDirectory -RedirectStandardOutput $RedirectStandardOutput -RedirectStandardError $RedirectStandardError -PassThru
+}
+
 function Get-Text {
     param([string]$Path)
-    if (-not (Test-Path $Path)) {
+    if (-not (Test-RegularFile -Path $Path)) {
         return ""
     }
     return [System.IO.File]::ReadAllText($Path)
@@ -388,7 +462,7 @@ function Invoke-EshkolCompile {
     )
 
     $exePath = $OutputBase + ".exe"
-    Remove-Item $exePath, $OutputBase -Force -ErrorAction SilentlyContinue
+    Remove-RegularFileIfPresent -Path @($exePath, $OutputBase)
 
     $args = @("-L", $BuildDir, "-o", $OutputBase)
     if ($ExtraArgs.Count -gt 0) {
@@ -401,7 +475,7 @@ function Invoke-EshkolCompile {
     [pscustomobject]@{
         ExitCode = $captured.ExitCode
         TimedOut = $captured.TimedOut
-        Success  = ($captured.ExitCode -eq 0 -and (Test-Path $exePath))
+        Success  = ($captured.ExitCode -eq 0 -and (Test-RegularFile -Path $exePath))
         StdOut   = $captured.StdOut
         StdErr   = $captured.StdErr
         Output   = $captured.Output
@@ -569,7 +643,7 @@ function Invoke-ModulesSuite {
 
         if ($source -match ";;; Expected: Error") {
             $hasCompileError = (-not $compile.Success) -or ($compile.Output -match "(?i)error:")
-            if ($hasCompileError -and (-not (Test-Path $compile.ExePath))) {
+            if ($hasCompileError -and (-not (Test-RegularFile -Path $compile.ExePath))) {
                 Format-TestStatus $testName "PASS (expected compile error)" Green
                 Add-Pass $suite
                 continue
@@ -912,13 +986,16 @@ function Invoke-CppTypeSuite {
         Sort-Object Name -Descending |
         ForEach-Object { Join-Path $_.FullName "bin\llvm-config.exe" }
     foreach ($candidate in $llvmCandidates) {
-        if ($candidate -and (Test-Path $candidate)) {
+        if ($candidate -and (Test-RegularFile -Path $candidate)) {
             $llvmConfig = $candidate
             break
         }
     }
     if (-not $llvmConfig) {
-        $llvmConfig = (Get-Command "llvm-config.exe" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1)
+        $llvmCommand = (Get-Command "llvm-config.exe" -ErrorAction SilentlyContinue | Select-Object -First 1)
+        if ($llvmCommand -and (Test-RegularFile -Path $llvmCommand.Source)) {
+            $llvmConfig = $llvmCommand.Source
+        }
     }
     if (-not $llvmConfig) {
         Add-Skip $suite "llvm-config.exe not found; skipping C++ type tests."
@@ -928,7 +1005,7 @@ function Invoke-CppTypeSuite {
 
     $llvmBinDir = Split-Path -Parent $llvmConfig
     $clangxx = Join-Path $llvmBinDir "clang++.exe"
-    if (-not (Test-Path $clangxx)) {
+    if (-not (Test-RegularFile -Path $clangxx)) {
         Add-Skip $suite "clang++.exe not found next to llvm-config.exe; skipping C++ type tests."
         Show-SuiteSummary $suite "C++ Test Results Summary"
         return $suite
@@ -965,14 +1042,14 @@ function Invoke-CppTypeSuite {
     )
 
     foreach ($testFile in $tests) {
-        if (-not (Test-Path $testFile)) {
+        if (-not (Test-RegularFile -Path $testFile)) {
             continue
         }
 
         $testName = [System.IO.Path]::GetFileNameWithoutExtension($testFile)
         $outputBase = New-OutputBase -TempRoot $script:TempRoot -SuiteName "cpp_type" -TestName $testName
         $exePath = $outputBase + ".exe"
-        Remove-Item $exePath -Force -ErrorAction SilentlyContinue
+        Remove-RegularFileIfPresent -Path @($exePath)
 
         Write-Host ("Compiling {0,-40} " -f ($testName + "...")) -NoNewline
         $args = @(
@@ -1025,7 +1102,7 @@ function Invoke-WebSuite {
     Write-Section "Eshkol Web/WASM Test Suite"
     $suite = New-SuiteState "web"
 
-    if (-not (Test-Path $script:EshkolServer)) {
+    if (-not (Test-RegularFile -Path $script:EshkolServer)) {
         Write-Host "Building eshkol-server..." -ForegroundColor Yellow
         $buildArgs = @("--build", $script:BuildDir)
         if ($script:BuildConfig) {
@@ -1033,7 +1110,7 @@ function Invoke-WebSuite {
         }
         $buildArgs += @("--target", "eshkol-server", "--parallel")
         & cmake @buildArgs
-        if ($LASTEXITCODE -ne 0 -or -not (Test-Path $script:EshkolServer)) {
+        if ($LASTEXITCODE -ne 0 -or -not (Test-RegularFile -Path $script:EshkolServer)) {
             Add-Fail $suite "eshkol-server build"
             Show-SuiteSummary $suite
             return $suite
@@ -1048,7 +1125,7 @@ function Invoke-WebSuite {
         $args = @("--wasm", "-o", $wasmPath, $testFile)
         $compile = Invoke-ProcessCapture -FilePath $script:EshkolRun -Arguments $args -WorkingDirectory $script:BuildDir
 
-        if ($compile.ExitCode -eq 0 -and (Test-Path $wasmPath)) {
+        if ($compile.ExitCode -eq 0 -and (Test-RegularFile -Path $wasmPath)) {
             $bytes = [System.IO.File]::ReadAllBytes($wasmPath)
             if ($bytes.Length -ge 4 -and $bytes[0] -eq 0x00 -and $bytes[1] -eq 0x61 -and $bytes[2] -eq 0x73 -and $bytes[3] -eq 0x6D) {
                 Format-TestStatus $testName "PASS" Green
@@ -1066,13 +1143,13 @@ function Invoke-WebSuite {
 
     $serverStdout = Join-Path $script:TempRoot "eshkol-server.stdout.log"
     $serverStderr = Join-Path $script:TempRoot "eshkol-server.stderr.log"
-    Remove-Item $serverStdout, $serverStderr -Force -ErrorAction SilentlyContinue
+    Remove-RegularFileIfPresent -Path @($serverStdout, $serverStderr)
     $port = 19876
-    $server = Start-Process -FilePath $script:EshkolServer -ArgumentList @("--port", "$port") -WorkingDirectory $script:ProjectRoot -RedirectStandardOutput $serverStdout -RedirectStandardError $serverStderr -PassThru
+    $server = Start-RegularFileProcess -FilePath $script:EshkolServer -ArgumentList @("--port", "$port") -WorkingDirectory $script:ProjectRoot -RedirectStandardOutput $serverStdout -RedirectStandardError $serverStderr
     Start-Sleep -Seconds 2
     $server.Refresh()
     if ($server.HasExited) {
-        if (Test-Path $serverStderr) {
+        if (Test-RegularFile -Path $serverStderr) {
             Show-ProcessFailureDetails -TestName "eshkol-server" -Phase "startup" -Result ([pscustomobject]@{
                 StdOut = Get-Text $serverStdout
                 StdErr = Get-Text $serverStderr
@@ -1131,7 +1208,7 @@ function Invoke-XlaSuite {
     $suite = New-SuiteState "xla"
 
     $xlaBin = Join-Path $script:BinaryDir "xla_codegen_test.exe"
-    if (Test-Path $xlaBin) {
+    if (Test-RegularFile -Path $xlaBin) {
         $run = Invoke-ProcessCapture -FilePath $xlaBin -WorkingDirectory $script:ProjectRoot
         if ($run.ExitCode -eq 0) {
             Add-Pass $suite
@@ -1211,11 +1288,11 @@ function Ensure-BuildArtifacts {
         $path = Join-Path $script:BinaryDir ($target + ".exe")
         if ($target -eq "stdlib") {
             $path = Join-Path $script:BuildDir "stdlib.o"
-            if (-not (Test-Path $path)) {
+            if (-not (Test-RegularFile -Path $path)) {
                 $path = Join-Path $script:BinaryDir "stdlib.o"
             }
         }
-        if (-not (Test-Path $path)) {
+        if (-not (Test-RegularFile -Path $path)) {
             $missingTargets += $target
         }
     }

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -34,9 +34,71 @@ declare -a FAILED_SUITES
 declare -a SKIPPED_SUITES
 declare -a ALL_FAILURES  # "suite: test_name (reason)" entries
 
+cleanup_tests_tmpdir() {
+    local path="${TMPDIR_TESTS:-}"
+
+    if [ -z "$path" ]; then
+        return
+    fi
+
+    case "$path" in
+        /tmp/*|/private/tmp/*|/var/folders/*|/private/var/folders/*)
+            ;;
+        *)
+            echo "Refusing to remove unexpected test temp directory: $path" >&2
+            return
+            ;;
+    esac
+
+    if [ -L "$path" ] || { [ -e "$path" ] && [ ! -d "$path" ]; }; then
+        echo "Refusing to remove non-directory or symlinked test temp path: $path" >&2
+        return
+    fi
+
+    rm -rf -- "$path"
+}
+
+require_regular_executable() {
+    local label="$1"
+    local path="$2"
+
+    if [ -L "$path" ] || ! test -f "$path" || ! test -s "$path" || ! test -x "$path"; then
+        echo -e "${RED}Error: $label missing, empty, symlinked, or not executable: $path${NC}"
+        exit 1
+    fi
+}
+
+validate_suite_script() {
+    local path="$1"
+
+    if ! test -e "$path"; then
+        return 1
+    fi
+
+    if [ -L "$path" ] || ! test -f "$path" || ! test -s "$path"; then
+        echo -e "${RED}Error: suite script missing, empty, symlinked, or not a regular file: $path${NC}"
+        return 2
+    fi
+
+    return 0
+}
+
+run_suite_script() {
+    local path="$1"
+    local status
+
+    validate_suite_script "$path"
+    status=$?
+    if [ "$status" -ne 0 ]; then
+        return 126
+    fi
+
+    bash "$path"
+}
+
 # Temp directory for captured output
 TMPDIR_TESTS=$(mktemp -d)
-trap "rm -rf '$TMPDIR_TESTS'" EXIT
+trap cleanup_tests_tmpdir EXIT
 
 # Test scripts to run (in order)
 TEST_SCRIPTS=(
@@ -94,10 +156,7 @@ if [ ! -d "$BUILD_DIR" ]; then
 fi
 
 # Check if compiler exists
-if [ ! -f "$BUILD_DIR/eshkol-run" ]; then
-    echo -e "${RED}Error: eshkol-run not found. Run make first.${NC}"
-    exit 1
-fi
+require_regular_executable "eshkol-run" "$BUILD_DIR/eshkol-run"
 
 echo "Running all test suites..."
 echo ""
@@ -184,10 +243,17 @@ for script in "${TEST_SCRIPTS[@]}"; do
     suite_name="${suite_name#run_}"
     suite_name="${suite_name%_tests}"
 
-    if [ ! -f "$script_path" ]; then
+    validate_suite_script "$script_path"
+    suite_script_status=$?
+    if [ "$suite_script_status" -eq 1 ]; then
         echo -e "${YELLOW}-- Skipping $script (not found)${NC}"
         SKIPPED_SUITES+=("$suite_name")
         ((SUITES_SKIP++)) || true
+        continue
+    fi
+    if [ "$suite_script_status" -ne 0 ]; then
+        FAILED_SUITES+=("$suite_name")
+        ((SUITES_FAIL++)) || true
         continue
     fi
 
@@ -197,7 +263,7 @@ for script in "${TEST_SCRIPTS[@]}"; do
 
     # Capture output while still displaying it
     output_file="$TMPDIR_TESTS/${suite_name}.log"
-    bash "$script_path" 2>&1 | tee "$output_file"
+    run_suite_script "$script_path" 2>&1 | tee "$output_file"
     suite_exit=${PIPESTATUS[0]}
 
     if [ $suite_exit -eq 0 ]; then

--- a/scripts/run_all_tests_with_output.sh
+++ b/scripts/run_all_tests_with_output.sh
@@ -58,18 +58,68 @@ if [ ! -d "$BUILD_DIR" ]; then
     exit 1
 fi
 
+cleanup_output_log() {
+    local path="${OUTPUT_LOG:-}"
+
+    if [ -z "$path" ]; then
+        return
+    fi
+
+    if [ -L "$path" ] || { [ -e "$path" ] && ! test -f "$path"; }; then
+        echo "Refusing to remove non-file or symlinked output log path: $path" >&2
+        return
+    fi
+
+    rm -f -- "$path"
+}
+
+require_regular_executable() {
+    local label="$1"
+    local path="$2"
+
+    if [ -L "$path" ] || ! test -f "$path" || ! test -s "$path" || ! test -x "$path"; then
+        echo -e "${RED}Error: $label missing, empty, symlinked, or not executable: $path${NC}"
+        exit 1
+    fi
+}
+
+validate_suite_script() {
+    local path="$1"
+
+    if ! test -e "$path"; then
+        return 1
+    fi
+
+    if [ -L "$path" ] || ! test -f "$path" || ! test -s "$path"; then
+        echo -e "${RED}Error: suite script missing, empty, symlinked, or not a regular file: $path${NC}"
+        return 2
+    fi
+
+    return 0
+}
+
+run_suite_script() {
+    local path="$1"
+    local status
+
+    validate_suite_script "$path"
+    status=$?
+    if [ "$status" -ne 0 ]; then
+        return 126
+    fi
+
+    bash "$path"
+}
+
 # Check if compiler exists
-if [ ! -f "$BUILD_DIR/eshkol-run" ]; then
-    echo -e "${RED}Error: eshkol-run not found. Run make first.${NC}"
-    exit 1
-fi
+require_regular_executable "eshkol-run" "$BUILD_DIR/eshkol-run"
 
 echo "Running all test suites with full output..."
 echo ""
 
 # Create temp file for output
 OUTPUT_LOG=$(mktemp)
-trap "rm -f $OUTPUT_LOG" EXIT
+trap cleanup_output_log EXIT
 
 # Run each test suite
 for script in "${TEST_SCRIPTS[@]}"; do
@@ -78,8 +128,15 @@ for script in "${TEST_SCRIPTS[@]}"; do
     suite_name="${suite_name#run_}"
     suite_name="${suite_name%_tests}"
 
-    if [ ! -f "$script_path" ]; then
+    validate_suite_script "$script_path"
+    suite_script_status=$?
+    if [ "$suite_script_status" -eq 1 ]; then
         echo -e "${YELLOW}⚠ Skipping $script (not found)${NC}"
+        continue
+    fi
+    if [ "$suite_script_status" -ne 0 ]; then
+        FAILED_SUITES+=("$suite_name")
+        ((SUITES_FAIL++))
         continue
     fi
 
@@ -90,7 +147,7 @@ for script in "${TEST_SCRIPTS[@]}"; do
     echo ""
 
     # Run with full output, capture exit code
-    if bash "$script_path" 2>&1 | tee "$OUTPUT_LOG"; then
+    if run_suite_script "$script_path" 2>&1 | tee "$OUTPUT_LOG"; then
         echo ""
         echo -e "${GREEN}═══ $suite_name: PASSED ═══${NC}"
         PASSED_SUITES+=("$suite_name")

--- a/scripts/run_autodiff_tests_with_output.sh
+++ b/scripts/run_autodiff_tests_with_output.sh
@@ -5,6 +5,9 @@
 
 set +e  # Don't exit on error, we want to see all failures
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/test_output_helpers.sh"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -23,11 +26,11 @@ RUNTIME_FAIL=0
 
 # Output directory
 OUTPUT_DIR="autodiff_test_outputs"
-mkdir -p "$OUTPUT_DIR"
+test_output_prepare_dir "$OUTPUT_DIR"
 
 # Results file
 RESULTS_FILE="$OUTPUT_DIR/autodiff_results_summary.txt"
-> "$RESULTS_FILE"  # Clear file
+test_output_reset_file "$RESULTS_FILE" "$OUTPUT_DIR" "test results file"
 
 # Results arrays
 declare -a FAILED_TESTS

--- a/scripts/run_complex_tests_with_output.sh
+++ b/scripts/run_complex_tests_with_output.sh
@@ -5,6 +5,9 @@
 
 set +e  # Don't exit on error, we want to see all failures
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/test_output_helpers.sh"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -20,11 +23,11 @@ RUNTIME_FAIL=0
 
 # Output directory
 OUTPUT_DIR="complex_test_outputs"
-mkdir -p "$OUTPUT_DIR"
+test_output_prepare_dir "$OUTPUT_DIR"
 
 # Results file
 RESULTS_FILE="$OUTPUT_DIR/complex_results_summary.txt"
-> "$RESULTS_FILE"  # Clear file
+test_output_reset_file "$RESULTS_FILE" "$OUTPUT_DIR" "test results file"
 
 # Results arrays
 declare -a FAILED_TESTS

--- a/scripts/run_examples_tests.sh
+++ b/scripts/run_examples_tests.sh
@@ -26,43 +26,52 @@ declare -a COMPILE_FAILURES
 declare -a RUNTIME_FAILURES
 declare -a RUNTIME_ERRORS
 
-# Output directory for logs
-LOG_DIR="/tmp/eshkol_examples_test"
-mkdir -p "$LOG_DIR"
+print_examples_banner() {
+    echo "========================================="
+    echo "  Eshkol Examples Test Suite"
+    echo "========================================="
+    echo ""
+}
 
 # Honour $BUILD_DIR (CI passes it via the matrix: build / build-xla /
 # build-cuda / build-asan); fall back to "build" for plain local runs.
 BUILD_DIR="${BUILD_DIR:-build}"
 
-echo "========================================="
-echo "  Eshkol Examples Test Suite"
-echo "========================================="
-echo ""
+cleanup_example_artifacts() {
+    rm -f a.out a.out.tmp.o
+}
 
-# Ensure build directory exists
-if [ ! -d "$BUILD_DIR" ]; then
-    echo -e "${RED}Error: build directory '$BUILD_DIR' not found. Run cmake first.${NC}"
-    exit 1
-fi
+ensure_examples_build() {
+    if [ ! -d "$BUILD_DIR" ]; then
+        echo -e "${RED}Error: build directory '$BUILD_DIR' not found. Run cmake first.${NC}"
+        exit 1
+    fi
 
-# Check if compiler exists
-if [ ! -f "$BUILD_DIR/eshkol-run" ]; then
-    echo -e "${RED}Error: eshkol-run not found in '$BUILD_DIR'. Run make first.${NC}"
-    exit 1
-fi
+    if [ ! -f "$BUILD_DIR/eshkol-run" ]; then
+        echo -e "${RED}Error: eshkol-run not found in '$BUILD_DIR'. Run make first.${NC}"
+        exit 1
+    fi
 
-# Check if stdlib exists
-if [ ! -f "$BUILD_DIR/stdlib.o" ]; then
-    echo -e "${YELLOW}Warning: stdlib.o not found in $BUILD_DIR. Building...${NC}"
-    cmake --build "$BUILD_DIR" --target stdlib
-fi
+    if [ ! -f "$BUILD_DIR/stdlib.o" ]; then
+        echo -e "${YELLOW}Warning: stdlib.o not found in $BUILD_DIR. Building...${NC}"
+        cmake --build "$BUILD_DIR" --target stdlib
+    fi
+}
 
-echo "Testing all .esk files in examples/ directory..."
-echo "Log files will be saved to: $LOG_DIR"
-echo ""
+example_should_skip() {
+    local test_name="$1"
 
-# Check if examples directory exists and has .esk files
-if [ ! -d "examples" ] || [ -z "$(ls -A examples/*.esk 2>/dev/null)" ]; then
+    case "$test_name" in
+        selene_*|qllm_*|agent.esk|consciousness_*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+print_empty_examples_summary() {
     echo "No examples found in examples/ directory. Skipping."
     echo ""
     echo "========================================="
@@ -71,7 +80,23 @@ if [ ! -d "examples" ] || [ -z "$(ls -A examples/*.esk 2>/dev/null)" ]; then
     echo "Total Examples:     0"
     echo "Pass Rate: N/A (no examples to test)"
     echo ""
-    rm -f a.out a.out.tmp.o
+}
+
+# Output directory for logs
+LOG_DIR="/tmp/eshkol_examples_test"
+mkdir -p "$LOG_DIR"
+
+print_examples_banner
+ensure_examples_build
+
+echo "Testing all .esk files in examples/ directory..."
+echo "Log files will be saved to: $LOG_DIR"
+echo ""
+
+# Check if examples directory exists and has .esk files
+if [ ! -d "examples" ] || [ -z "$(ls -A examples/*.esk 2>/dev/null)" ]; then
+    print_empty_examples_summary
+    cleanup_example_artifacts
     exit 0
 fi
 
@@ -85,13 +110,14 @@ for test_file in examples/*.esk; do
     test_name=$(basename "$test_file")
 
     # Skip proprietary/unreleased examples
-    case "$test_name" in
-        selene_*|qllm_*|agent.esk|consciousness_*) printf "SKIP (proprietary)\n"; continue ;;
-    esac
+    if example_should_skip "$test_name"; then
+        printf "SKIP (proprietary)\n"
+        continue
+    fi
     printf "[%3d/%3d] %-50s " "$CURRENT" "$TOTAL" "$test_name"
 
     # Clean up stale temp files before each test
-    rm -f a.out a.out.tmp.o
+    cleanup_example_artifacts
 
     # Log file for this example
     compile_log="$LOG_DIR/${test_name%.esk}_compile.log"
@@ -207,7 +233,7 @@ echo "To view runtime output:  cat $LOG_DIR/<example>_run.log"
 echo ""
 
 # Clean up
-rm -f a.out a.out.tmp.o
+cleanup_example_artifacts
 
 # Exit with appropriate code
 if [ $COMPILE_FAIL -eq 0 ] && [ $RUNTIME_FAIL -eq 0 ]; then

--- a/scripts/run_features_tests_with_output.sh
+++ b/scripts/run_features_tests_with_output.sh
@@ -8,6 +8,7 @@ set +e  # Don't exit on error, we want to see all failures
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
+source "$SCRIPT_DIR/test_output_helpers.sh"
 
 # Colors for output
 RED='\033[0;31m'
@@ -27,11 +28,11 @@ RUNTIME_FAIL=0
 
 # Output directory
 OUTPUT_DIR="features_test_outputs"
-mkdir -p "$OUTPUT_DIR"
+test_output_prepare_dir "$OUTPUT_DIR"
 
 # Results file
 RESULTS_FILE="$OUTPUT_DIR/features_results_summary.txt"
-> "$RESULTS_FILE"  # Clear file
+test_output_reset_file "$RESULTS_FILE" "$OUTPUT_DIR" "test results file"
 
 # Results arrays
 declare -a FAILED_TESTS

--- a/scripts/run_json_tests_with_output.sh
+++ b/scripts/run_json_tests_with_output.sh
@@ -5,6 +5,9 @@
 
 set +e  # Don't exit on error, we want to see all failures
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/test_output_helpers.sh"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -20,11 +23,11 @@ RUNTIME_FAIL=0
 
 # Output directory
 OUTPUT_DIR="json_test_outputs"
-mkdir -p "$OUTPUT_DIR"
+test_output_prepare_dir "$OUTPUT_DIR"
 
 # Results file
 RESULTS_FILE="$OUTPUT_DIR/json_results_summary.txt"
-> "$RESULTS_FILE"  # Clear file
+test_output_reset_file "$RESULTS_FILE" "$OUTPUT_DIR" "test results file"
 
 # Results arrays
 declare -a FAILED_TESTS

--- a/scripts/run_list_tests_with_output.sh
+++ b/scripts/run_list_tests_with_output.sh
@@ -5,6 +5,9 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/test_output_helpers.sh"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -19,11 +22,11 @@ COMPILE_FAIL=0
 
 # Output directory
 OUTPUT_DIR="list_test_outputs"
-mkdir -p "$OUTPUT_DIR"
+test_output_prepare_dir "$OUTPUT_DIR"
 
 # Results file
 RESULTS_FILE="$OUTPUT_DIR/test_results_summary.txt"
-> "$RESULTS_FILE"  # Clear file
+test_output_reset_file "$RESULTS_FILE" "$OUTPUT_DIR" "test results file"
 
 # Results arrays
 declare -a FAILED_TESTS
@@ -62,7 +65,9 @@ for test_file in tests/lists/*.esk; do
     printf "Testing %-50s " "$test_name"
     
     # Clear output file
-    > "$output_file"
+    test_output_reset_file "$output_file" "$OUTPUT_DIR" "list test output file"
+    compile_output_file="${output_file}.compile"
+    test_output_reset_file "$compile_output_file" "$OUTPUT_DIR" "list compile output file"
     
     # Add header to output file
     echo "========================================" >> "$output_file"
@@ -72,7 +77,7 @@ for test_file in tests/lists/*.esk; do
     echo "" >> "$output_file"
     
     # Try to compile
-    if ./$BUILD_DIR/eshkol-run -L./$BUILD_DIR "$test_file" > "${output_file}.compile" 2>&1; then
+    if ./"$BUILD_DIR"/eshkol-run -L./"$BUILD_DIR" "$test_file" > "$compile_output_file" 2>&1; then
         # Compilation succeeded, try to run
         echo "COMPILATION: SUCCESS" >> "$output_file"
         echo "" >> "$output_file"
@@ -88,14 +93,14 @@ for test_file in tests/lists/*.esk; do
                 ((FAIL++))
                 
                 # Add to summary
-                echo "❌ $test_name - RUNTIME ERROR" >> "$RESULTS_FILE"
+                test_output_append_line "$RESULTS_FILE" "$OUTPUT_DIR" "❌ $test_name - RUNTIME ERROR"
             else
                 echo -e "${GREEN}✅ PASS${NC}"
                 echo "STATUS: PASS" >> "$output_file"
                 ((PASS++))
                 
                 # Add to summary
-                echo "✅ $test_name - PASS" >> "$RESULTS_FILE"
+                test_output_append_line "$RESULTS_FILE" "$OUTPUT_DIR" "✅ $test_name - PASS"
             fi
         else
             echo -e "${RED}❌ RUNTIME FAIL${NC}"
@@ -104,23 +109,23 @@ for test_file in tests/lists/*.esk; do
             ((FAIL++))
             
             # Add to summary
-            echo "❌ $test_name - RUNTIME FAIL" >> "$RESULTS_FILE"
+            test_output_append_line "$RESULTS_FILE" "$OUTPUT_DIR" "❌ $test_name - RUNTIME FAIL"
         fi
     else
         echo -e "${RED}❌ COMPILE FAIL${NC}"
         echo "COMPILATION: FAILED" >> "$output_file"
         echo "" >> "$output_file"
-        cat "${output_file}.compile" >> "$output_file"
+        cat "$compile_output_file" >> "$output_file"
         FAILED_TESTS+=("$test_name")
         ((COMPILE_FAIL++))
         ((FAIL++))
         
         # Add to summary
-        echo "❌ $test_name - COMPILE FAIL" >> "$RESULTS_FILE"
+        test_output_append_line "$RESULTS_FILE" "$OUTPUT_DIR" "❌ $test_name - COMPILE FAIL"
     fi
     
     # Clean up compile output
-    rm -f "${output_file}.compile"
+    rm -f -- "$compile_output_file"
 done
 
 echo ""
@@ -135,15 +140,15 @@ echo -e "  Runtime Errors:   ${#RUNTIME_ERRORS[@]}"
 echo ""
 
 # Add summary to results file
-echo "" >> "$RESULTS_FILE"
-echo "=========================================" >> "$RESULTS_FILE"
-echo "SUMMARY" >> "$RESULTS_FILE"
-echo "=========================================" >> "$RESULTS_FILE"
-echo "Total Tests: $(( PASS + FAIL ))" >> "$RESULTS_FILE"
-echo "Passed: $PASS" >> "$RESULTS_FILE"
-echo "Failed: $FAIL" >> "$RESULTS_FILE"
-echo "  Compile Failures: $COMPILE_FAIL" >> "$RESULTS_FILE"
-echo "  Runtime Errors: ${#RUNTIME_ERRORS[@]}" >> "$RESULTS_FILE"
+test_output_append_line "$RESULTS_FILE" "$OUTPUT_DIR" ""
+test_output_append_line "$RESULTS_FILE" "$OUTPUT_DIR" "========================================="
+test_output_append_line "$RESULTS_FILE" "$OUTPUT_DIR" "SUMMARY"
+test_output_append_line "$RESULTS_FILE" "$OUTPUT_DIR" "========================================="
+test_output_append_line "$RESULTS_FILE" "$OUTPUT_DIR" "Total Tests: $(( PASS + FAIL ))"
+test_output_append_line "$RESULTS_FILE" "$OUTPUT_DIR" "Passed: $PASS"
+test_output_append_line "$RESULTS_FILE" "$OUTPUT_DIR" "Failed: $FAIL"
+test_output_append_line "$RESULTS_FILE" "$OUTPUT_DIR" "  Compile Failures: $COMPILE_FAIL"
+test_output_append_line "$RESULTS_FILE" "$OUTPUT_DIR" "  Runtime Errors: ${#RUNTIME_ERRORS[@]}"
 
 if [ $FAIL -gt 0 ]; then
     echo "Failed Tests:"
@@ -166,7 +171,7 @@ TOTAL=$(( PASS + FAIL ))
 if [ $TOTAL -gt 0 ]; then
     PASS_RATE=$(( PASS * 100 / TOTAL ))
     echo "Pass Rate: ${PASS_RATE}%"
-    echo "Pass Rate: ${PASS_RATE}%" >> "$RESULTS_FILE"
+    test_output_append_line "$RESULTS_FILE" "$OUTPUT_DIR" "Pass Rate: ${PASS_RATE}%"
 fi
 
 echo ""

--- a/scripts/run_memory_tests_with_output.sh
+++ b/scripts/run_memory_tests_with_output.sh
@@ -9,6 +9,7 @@ set +e  # Don't exit on error, we want to see all failures
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
+source "$SCRIPT_DIR/test_output_helpers.sh"
 
 # Colors for output
 RED='\033[0;31m'
@@ -28,11 +29,11 @@ RUNTIME_FAIL=0
 
 # Output directory
 OUTPUT_DIR="memory_test_outputs"
-mkdir -p "$OUTPUT_DIR"
+test_output_prepare_dir "$OUTPUT_DIR"
 
 # Results file
 RESULTS_FILE="$OUTPUT_DIR/memory_results_summary.txt"
-> "$RESULTS_FILE"  # Clear file
+test_output_reset_file "$RESULTS_FILE" "$OUTPUT_DIR" "test results file"
 
 # Results arrays
 declare -a FAILED_TESTS

--- a/scripts/run_ml_tests_with_output.sh
+++ b/scripts/run_ml_tests_with_output.sh
@@ -8,6 +8,7 @@ set +e  # Don't exit on error, we want to see all failures
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
+source "$SCRIPT_DIR/test_output_helpers.sh"
 
 # Colors for output
 RED='\033[0;31m'
@@ -27,11 +28,11 @@ RUNTIME_FAIL=0
 
 # Output directory
 OUTPUT_DIR="ml_test_outputs"
-mkdir -p "$OUTPUT_DIR"
+test_output_prepare_dir "$OUTPUT_DIR"
 
 # Results file
 RESULTS_FILE="$OUTPUT_DIR/ml_results_summary.txt"
-> "$RESULTS_FILE"  # Clear file
+test_output_reset_file "$RESULTS_FILE" "$OUTPUT_DIR" "test results file"
 
 # Results arrays
 declare -a FAILED_TESTS

--- a/scripts/run_modules_tests_with_output.sh
+++ b/scripts/run_modules_tests_with_output.sh
@@ -9,6 +9,7 @@ set +e  # Don't exit on error, we want to see all failures
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
+source "$SCRIPT_DIR/test_output_helpers.sh"
 
 # Colors for output
 RED='\033[0;31m'
@@ -28,11 +29,11 @@ RUNTIME_FAIL=0
 
 # Output directory
 OUTPUT_DIR="modules_test_outputs"
-mkdir -p "$OUTPUT_DIR"
+test_output_prepare_dir "$OUTPUT_DIR"
 
 # Results file
 RESULTS_FILE="$OUTPUT_DIR/modules_results_summary.txt"
-> "$RESULTS_FILE"  # Clear file
+test_output_reset_file "$RESULTS_FILE" "$OUTPUT_DIR" "test results file"
 
 # Results arrays
 declare -a FAILED_TESTS

--- a/scripts/run_neural_tests_with_output.sh
+++ b/scripts/run_neural_tests_with_output.sh
@@ -8,6 +8,7 @@ set +e  # Don't exit on error, we want to see all failures
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
+source "$SCRIPT_DIR/test_output_helpers.sh"
 
 # Colors for output
 RED='\033[0;31m'
@@ -27,11 +28,11 @@ RUNTIME_FAIL=0
 
 # Output directory
 OUTPUT_DIR="neural_test_outputs"
-mkdir -p "$OUTPUT_DIR"
+test_output_prepare_dir "$OUTPUT_DIR"
 
 # Results file
 RESULTS_FILE="$OUTPUT_DIR/neural_results_summary.txt"
-> "$RESULTS_FILE"  # Clear file
+test_output_reset_file "$RESULTS_FILE" "$OUTPUT_DIR" "test results file"
 
 # Results arrays
 declare -a FAILED_TESTS

--- a/scripts/run_parser_tests_with_output.sh
+++ b/scripts/run_parser_tests_with_output.sh
@@ -9,6 +9,7 @@ set +e  # Don't exit on error, we want to see all failures
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
+source "$SCRIPT_DIR/test_output_helpers.sh"
 
 # Colors for output
 RED='\033[0;31m'
@@ -28,11 +29,11 @@ RUNTIME_FAIL=0
 
 # Output directory
 OUTPUT_DIR="parser_test_outputs"
-mkdir -p "$OUTPUT_DIR"
+test_output_prepare_dir "$OUTPUT_DIR"
 
 # Results file
 RESULTS_FILE="$OUTPUT_DIR/parser_results_summary.txt"
-> "$RESULTS_FILE"  # Clear file
+test_output_reset_file "$RESULTS_FILE" "$OUTPUT_DIR" "test results file"
 
 # Results arrays
 declare -a FAILED_TESTS

--- a/scripts/run_repl_tests_with_output.sh
+++ b/scripts/run_repl_tests_with_output.sh
@@ -11,6 +11,7 @@ set +e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
+source "$SCRIPT_DIR/test_output_helpers.sh"
 
 # Colors for output
 RED='\033[0;31m'
@@ -25,11 +26,11 @@ FAIL=0
 
 # Output directory
 OUTPUT_DIR="repl_test_outputs"
-mkdir -p "$OUTPUT_DIR"
+test_output_prepare_dir "$OUTPUT_DIR"
 
 # Results file
 RESULTS_FILE="$OUTPUT_DIR/repl_results_summary.txt"
-> "$RESULTS_FILE"
+test_output_reset_file "$RESULTS_FILE" "$OUTPUT_DIR" "test results file"
 
 # Results arrays
 declare -a FAILED_TESTS

--- a/scripts/run_stdlib_tests_with_output.sh
+++ b/scripts/run_stdlib_tests_with_output.sh
@@ -8,6 +8,7 @@ set +e  # Don't exit on error, we want to see all failures
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
+source "$SCRIPT_DIR/test_output_helpers.sh"
 
 # Colors for output
 RED='\033[0;31m'
@@ -27,11 +28,11 @@ RUNTIME_FAIL=0
 
 # Output directory
 OUTPUT_DIR="stdlib_test_outputs"
-mkdir -p "$OUTPUT_DIR"
+test_output_prepare_dir "$OUTPUT_DIR"
 
 # Results file
 RESULTS_FILE="$OUTPUT_DIR/stdlib_results_summary.txt"
-> "$RESULTS_FILE"  # Clear file
+test_output_reset_file "$RESULTS_FILE" "$OUTPUT_DIR" "test results file"
 
 # Results arrays
 declare -a FAILED_TESTS

--- a/scripts/run_system_tests_with_output.sh
+++ b/scripts/run_system_tests_with_output.sh
@@ -8,6 +8,7 @@ set +e  # Don't exit on error, we want to see all failures
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
+source "$SCRIPT_DIR/test_output_helpers.sh"
 
 # Colors for output
 RED='\033[0;31m'
@@ -27,11 +28,11 @@ RUNTIME_FAIL=0
 
 # Output directory
 OUTPUT_DIR="system_test_outputs"
-mkdir -p "$OUTPUT_DIR"
+test_output_prepare_dir "$OUTPUT_DIR"
 
 # Results file
 RESULTS_FILE="$OUTPUT_DIR/system_results_summary.txt"
-> "$RESULTS_FILE"  # Clear file
+test_output_reset_file "$RESULTS_FILE" "$OUTPUT_DIR" "test results file"
 
 # Results arrays
 declare -a FAILED_TESTS

--- a/scripts/run_tco_tests.sh
+++ b/scripts/run_tco_tests.sh
@@ -33,6 +33,26 @@ run_with_timeout() {
     fi
 }
 
+cleanup_temp_bin() {
+    local path="$1"
+
+    case "$path" in
+        /tmp/tco_test_*)
+            ;;
+        *)
+            echo "Refusing to remove unexpected TCO temp binary path: $path" >&2
+            return 1
+            ;;
+    esac
+
+    if [ -L "$path" ] || { [ -e "$path" ] && [ ! -f "$path" ]; }; then
+        echo "Refusing to remove non-file or symlinked TCO temp binary path: $path" >&2
+        return 1
+    fi
+
+    rm -f -- "$path"
+}
+
 # Counters
 PASS=0
 FAIL=0
@@ -93,7 +113,7 @@ for test_file in "$TCO_TEST_DIR"/*.esk; do
         echo "    Compile output: $COMPILE_OUTPUT"
         ((FAIL++)) || true
         FAILED_TESTS+=("$test_name (compile)")
-        rm -f "$TEMP_BIN"
+        cleanup_temp_bin "$TEMP_BIN"
         continue
     fi
 
@@ -115,7 +135,7 @@ for test_file in "$TCO_TEST_DIR"/*.esk; do
     RUN_OUTPUT=$(run_with_timeout 60 "$TEMP_BIN" 2>&1)
     RUN_EXIT=$?
 
-    rm -f "$TEMP_BIN"
+    cleanup_temp_bin "$TEMP_BIN"
 
     if [ $RUN_EXIT -ne 0 ]; then
         echo -e "${RED}RUNTIME FAIL (exit $RUN_EXIT)${NC}"

--- a/scripts/run_types_tests_with_output.sh
+++ b/scripts/run_types_tests_with_output.sh
@@ -8,6 +8,7 @@ set +e  # Don't exit on error, we want to see all failures
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
+source "$SCRIPT_DIR/test_output_helpers.sh"
 
 # Colors for output
 RED='\033[0;31m'
@@ -27,11 +28,11 @@ RUNTIME_FAIL=0
 
 # Output directory
 OUTPUT_DIR="types_test_outputs"
-mkdir -p "$OUTPUT_DIR"
+test_output_prepare_dir "$OUTPUT_DIR"
 
 # Results file
 RESULTS_FILE="$OUTPUT_DIR/types_results_summary.txt"
-> "$RESULTS_FILE"  # Clear file
+test_output_reset_file "$RESULTS_FILE" "$OUTPUT_DIR" "test results file"
 
 # Results arrays
 declare -a FAILED_TESTS

--- a/scripts/run_xla_tests.sh
+++ b/scripts/run_xla_tests.sh
@@ -28,10 +28,40 @@ declare -a FAILED_TESTS
 declare -a SKIPPED_TESTS
 declare -a RUNTIME_ERRORS
 
-echo "========================================="
-echo "  Eshkol XLA/StableHLO Integration Tests"
-echo "========================================="
-echo ""
+print_xla_banner() {
+    echo "========================================="
+    echo "  Eshkol XLA/StableHLO Integration Tests"
+    echo "========================================="
+    echo ""
+}
+
+build_cache_enables_xla() {
+    local build_dir="$1"
+
+    [ -f "$build_dir/CMakeCache.txt" ] &&
+        grep -qE "ESHKOL_(USE_)?XLA(_ENABLED)?:BOOL=ON" "$build_dir/CMakeCache.txt"
+}
+
+cleanup_xla_binary_artifacts() {
+    rm -f a.out a.out.tmp.o
+}
+
+cleanup_xla_temp_artifacts() {
+    cleanup_xla_binary_artifacts
+    rm -f /tmp/xla_test_output.txt /tmp/xla_compile.log /tmp/xla_perf_output.txt /tmp/xla_perf_test.esk
+}
+
+select_timeout_command() {
+    if command -v timeout >/dev/null 2>&1; then
+        printf '%s\n' timeout
+    elif command -v gtimeout >/dev/null 2>&1; then
+        printf '%s\n' gtimeout
+    else
+        return 1
+    fi
+}
+
+print_xla_banner
 
 # Determine which build directory to use
 # Override with: BUILD_DIR=build ./scripts/run_xla_tests.sh
@@ -43,8 +73,7 @@ if [ -n "$BUILD_DIR" ]; then
         echo -e "${RED}Error: Specified BUILD_DIR=$BUILD_DIR not found or missing eshkol-run.${NC}"
         exit 1
     fi
-    if [ -f "$BUILD_DIR/CMakeCache.txt" ] && \
-       grep -qE "ESHKOL_(USE_)?XLA(_ENABLED)?:BOOL=ON" "$BUILD_DIR/CMakeCache.txt"; then
+    if build_cache_enables_xla "$BUILD_DIR"; then
         XLA_ENABLED="yes"
     fi
     echo -e "${GREEN}Using build directory: $BUILD_DIR${NC}"
@@ -53,8 +82,7 @@ else
     for candidate in build-xla build; do
         if [ -d "$candidate" ] && [ -f "$candidate/eshkol-run" ]; then
             BUILD_DIR="$candidate"
-            if [ -f "$candidate/CMakeCache.txt" ] && \
-               grep -qE "ESHKOL_(USE_)?XLA(_ENABLED)?:BOOL=ON" "$candidate/CMakeCache.txt"; then
+            if build_cache_enables_xla "$candidate"; then
                 XLA_ENABLED="yes"
             fi
             break
@@ -86,7 +114,7 @@ XLA_TEST_BIN="$BUILD_DIR/xla_codegen_test"
 
 if [ -f "$XLA_TEST_BIN" ]; then
     echo "Running XLA C++ unit tests..."
-    if $XLA_TEST_BIN; then
+    if "$XLA_TEST_BIN"; then
         echo -e "${GREEN}✅ C++ Unit Tests: PASS${NC}"
         ((PASS++)) || true
     else
@@ -132,10 +160,10 @@ else
         printf "Testing %-45s " "$test_name"
 
         # Clean up stale temp files
-        rm -f a.out a.out.tmp.o
+        cleanup_xla_binary_artifacts
 
         # Try to compile
-        if ./$BUILD_DIR/eshkol-run "$test_file" -L./$BUILD_DIR > /tmp/xla_compile.log 2>&1; then
+        if "$BUILD_DIR/eshkol-run" "$test_file" -L"$BUILD_DIR" > /tmp/xla_compile.log 2>&1; then
             # Compilation succeeded, try to run
             if ./a.out > /tmp/xla_test_output.txt 2>&1; then
                 # Check for FAIL markers in output (from test assertions)
@@ -189,22 +217,14 @@ ESKEOF
 
 printf "Testing %-45s " "performance_sanity"
 
-if ./$BUILD_DIR/eshkol-run /tmp/xla_perf_test.esk -L./$BUILD_DIR > /tmp/xla_compile.log 2>&1; then
+if "$BUILD_DIR/eshkol-run" /tmp/xla_perf_test.esk -L"$BUILD_DIR" > /tmp/xla_compile.log 2>&1; then
     start_time=$(python3 -c "import time; print(int(time.time() * 1000))" 2>/dev/null || date +%s%3N)
-    TIMEOUT_CMD="timeout"
-    if ! command -v timeout &>/dev/null; then
-        if command -v gtimeout &>/dev/null; then
-            TIMEOUT_CMD="gtimeout"
-        else
-            TIMEOUT_CMD=""
-        fi
-    fi
-    if [ -n "$TIMEOUT_CMD" ]; then
-        PERF_RUN="$TIMEOUT_CMD 60 ./a.out"
+    if TIMEOUT_CMD="$(select_timeout_command)"; then
+        PERF_RUN=("$TIMEOUT_CMD" 60 ./a.out)
     else
-        PERF_RUN="./a.out"
+        PERF_RUN=(./a.out)
     fi
-    if $PERF_RUN > /tmp/xla_perf_output.txt 2>&1; then
+    if "${PERF_RUN[@]}" > /tmp/xla_perf_output.txt 2>&1; then
         end_time=$(python3 -c "import time; print(int(time.time() * 1000))" 2>/dev/null || date +%s%3N)
         elapsed=$((end_time - start_time))
         echo -e "${GREEN}✅ PASS${NC} (${elapsed}ms)"
@@ -280,7 +300,7 @@ else
 fi
 
 # Clean up
-rm -f /tmp/xla_test_output.txt /tmp/xla_compile.log /tmp/xla_perf_output.txt a.out
+cleanup_xla_temp_artifacts
 
 # Exit with appropriate code
 if [ $FAIL -eq 0 ]; then

--- a/scripts/test-homebrew.sh
+++ b/scripts/test-homebrew.sh
@@ -55,6 +55,38 @@ source "${SCRIPT_DIR}/lib/llvm21-env.sh"
 
 echo -e "${YELLOW}=== Homebrew Formula Test ===${NC}"
 
+require_homebrew_test_file() {
+    local path="$1"
+
+    case "$path" in
+        /tmp/eshkol-test.*.esk)
+            ;;
+        *)
+            echo "Unsafe Homebrew test source path: $path" >&2
+            exit 1
+            ;;
+    esac
+
+    if [ -L "$path" ] || { [ -e "$path" ] && [ ! -f "$path" ]; }; then
+        echo "Homebrew test source path must be a regular non-symlinked file: $path" >&2
+        exit 1
+    fi
+}
+
+write_homebrew_test_file() {
+    local path="$1"
+
+    require_homebrew_test_file "$path"
+    printf '%s\n' '(display "Hello from Homebrew test!")' > "$path"
+}
+
+remove_homebrew_test_file() {
+    local path="$1"
+
+    require_homebrew_test_file "$path"
+    rm -f -- "$path"
+}
+
 LLVM_FORMULA="llvm@${ESHKOL_REQUIRED_LLVM_MAJOR}"
 
 # Check for Homebrew
@@ -135,7 +167,7 @@ if [ "$LOCAL_TEST" = true ]; then
     # Run a quick test
     echo -e "${YELLOW}Running quick test...${NC}"
     TEST_FILE=$(mktemp /tmp/eshkol-test.XXXXXX.esk)
-    echo '(display "Hello from Homebrew test!")' > "$TEST_FILE"
+    write_homebrew_test_file "$TEST_FILE"
 
     if "$BUILD_DIR/eshkol-run" "$TEST_FILE" -L"$BUILD_DIR"; then
         if [ -f "a.out" ]; then
@@ -148,7 +180,7 @@ if [ "$LOCAL_TEST" = true ]; then
         echo -e "  ${RED}[FAIL]${NC} Compilation failed"
     fi
 
-    rm -f "$TEST_FILE"
+    remove_homebrew_test_file "$TEST_FILE"
 
     # Cleanup
     rm -rf "$BUILD_DIR"

--- a/scripts/test_output_helpers.sh
+++ b/scripts/test_output_helpers.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+test_output_fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+test_output_reject_unsafe_path() {
+    local label="$1"
+    local path="$2"
+
+    case "$path" in
+        ""|/*|..|../*|*/../*|*/..|*$'\n'*|*$'\r'*)
+            test_output_fail "unsafe $label path: $path"
+            ;;
+    esac
+}
+
+test_output_prepare_dir() {
+    local dir="$1"
+
+    test_output_reject_unsafe_path "test output directory" "$dir"
+
+    if [ -L "$dir" ]; then
+        test_output_fail "test output directory must not be a symlink: $dir"
+    fi
+
+    mkdir -p -- "$dir" || test_output_fail "failed to create test output directory: $dir"
+
+    if [ -L "$dir" ] || [ ! -d "$dir" ]; then
+        test_output_fail "test output directory missing or symlinked after creation: $dir"
+    fi
+}
+
+test_output_require_file() {
+    local file="$1"
+    local dir="$2"
+    local label="${3:-test output file}"
+
+    test_output_reject_unsafe_path "$label" "$file"
+
+    case "$file" in
+        "$dir"/*)
+            ;;
+        *)
+            test_output_fail "$label must stay under test output directory: $file"
+            ;;
+    esac
+
+    if [ -L "$file" ]; then
+        test_output_fail "$label must not be a symlink: $file"
+    fi
+}
+
+test_output_reset_file() {
+    local file="$1"
+    local dir="$2"
+    local label="${3:-test output file}"
+
+    test_output_require_file "$file" "$dir" "$label"
+    : > "$file" || test_output_fail "failed to reset $label: $file"
+
+    if [ -L "$file" ] || [ ! -f "$file" ]; then
+        test_output_fail "$label missing or symlinked after reset: $file"
+    fi
+}
+
+test_output_append_line() {
+    local file="$1"
+    local dir="$2"
+    local line="$3"
+
+    test_output_require_file "$file" "$dir" "test results file"
+    printf '%s\n' "$line" >> "$file" || test_output_fail "failed to append test result: $file"
+}

--- a/tests/toolchain/aggregate_shell_suite_surface_test.cpp
+++ b/tests/toolchain/aggregate_shell_suite_surface_test.cpp
@@ -1,0 +1,108 @@
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+std::string read_file(const fs::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    return buffer.str();
+}
+
+bool expect_contains(const std::string& haystack, const std::string& needle,
+                     const std::string& label) {
+    if (haystack.find(needle) == std::string::npos) {
+        std::cerr << "missing: " << label << "\nneedle: " << needle << std::endl;
+        return false;
+    }
+    return true;
+}
+
+bool expect_not_contains(const std::string& haystack, const std::string& needle,
+                         const std::string& label) {
+    if (haystack.find(needle) != std::string::npos) {
+        std::cerr << "unexpected: " << label << "\nneedle: " << needle
+                  << std::endl;
+        return false;
+    }
+    return true;
+}
+
+int fail(const std::string& message) {
+    std::cerr << "FAIL: " << message << std::endl;
+    return 1;
+}
+
+bool check_aggregate_runner(const std::string& script, const std::string& label) {
+    bool ok = true;
+
+    ok = ok &&
+         expect_contains(script, "require_regular_executable()",
+                         label + " declares a regular executable guard") &&
+         expect_contains(script, "! test -f \"$path\" || ! test -s \"$path\" || ! test -x \"$path\"",
+                         label + " rejects non-regular executable paths") &&
+         expect_contains(script, "BUILD_DIR=\"${BUILD_DIR:-build}\"",
+                         label + " honors a configurable build directory") &&
+         expect_contains(script, "require_regular_executable \"eshkol-run\" \"$BUILD_DIR/eshkol-run\"",
+                         label + " validates the compiler executable before running suites") &&
+         expect_contains(script, "validate_suite_script()",
+                         label + " declares a suite script validator") &&
+         expect_contains(script, "if ! test -e \"$path\"; then",
+                         label + " treats absent suite scripts separately from unsafe scripts") &&
+         expect_contains(script, "! test -f \"$path\" || ! test -s \"$path\"",
+                         label + " rejects empty, symlinked, or non-regular suite scripts") &&
+         expect_contains(script, "run_suite_script()",
+                         label + " declares a suite launcher wrapper") &&
+         expect_contains(script, "validate_suite_script \"$path\"",
+                         label + " revalidates suite scripts inside the launcher") &&
+         expect_contains(script, "run_suite_script \"$script_path\"",
+                         label + " launches suites through the validated wrapper");
+
+    ok = ok &&
+         expect_not_contains(script, "if [ ! -f \"build/eshkol-run\" ]",
+                             label + " must not use a plain compiler file probe") &&
+         expect_not_contains(script, "if [ ! -f \"$script_path\" ]",
+                             label + " must not use a plain suite script file probe") &&
+         expect_not_contains(script, "bash \"$script_path\"",
+                             label + " must not launch suite scripts without the wrapper");
+
+    return ok;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        return fail("usage: aggregate_shell_suite_surface_test <source-root>");
+    }
+
+    const fs::path source_root = argv[1];
+    const fs::path aggregate_runner = source_root / "scripts" / "run_all_tests.sh";
+    const fs::path verbose_runner =
+        source_root / "scripts" / "run_all_tests_with_output.sh";
+
+    if (!fs::exists(aggregate_runner)) {
+        return fail("run_all_tests.sh not found under source root");
+    }
+    if (!fs::exists(verbose_runner)) {
+        return fail("run_all_tests_with_output.sh not found under source root");
+    }
+
+    bool ok = true;
+    ok = check_aggregate_runner(read_file(aggregate_runner), "aggregate shell runner") && ok;
+    ok = check_aggregate_runner(read_file(verbose_runner), "verbose aggregate shell runner") &&
+         ok;
+
+    if (!ok) {
+        return 1;
+    }
+
+    std::cout << "PASS" << std::endl;
+    return 0;
+}

--- a/tests/toolchain/debian_package_surface_test.cpp
+++ b/tests/toolchain/debian_package_surface_test.cpp
@@ -1,0 +1,90 @@
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+std::string read_file(const fs::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    return buffer.str();
+}
+
+bool expect_contains(const std::string& haystack, const std::string& needle,
+                     const std::string& label) {
+    if (haystack.find(needle) == std::string::npos) {
+        std::cerr << "missing: " << label << "\nneedle: " << needle << std::endl;
+        return false;
+    }
+    return true;
+}
+
+bool expect_not_contains(const std::string& haystack, const std::string& needle,
+                         const std::string& label) {
+    if (haystack.find(needle) != std::string::npos) {
+        std::cerr << "unexpected: " << label << "\nneedle: " << needle
+                  << std::endl;
+        return false;
+    }
+    return true;
+}
+
+int fail(const std::string& message) {
+    std::cerr << "FAIL: " << message << std::endl;
+    return 1;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        return fail("usage: debian_package_surface_test <source-root>");
+    }
+
+    const fs::path source_root = argv[1];
+    const fs::path script_path = source_root / "scripts" / "build-deb.sh";
+    if (!fs::exists(script_path)) {
+        return fail("build-deb.sh not found under source root");
+    }
+
+    const std::string script = read_file(script_path);
+    bool ok = true;
+
+    ok = ok &&
+         expect_contains(script, "validate_package_version()",
+                         "Debian package script declares version validation") &&
+         expect_contains(script, "unsafe Debian package version",
+                         "Debian package script rejects unsafe version text") &&
+         expect_contains(script, "validate_package_version \"$VERSION\"",
+                         "Debian package script validates the user-supplied version") &&
+         expect_contains(script, "require_regular_executable()",
+                         "Debian package script declares executable validation") &&
+         expect_contains(script, "if ! test -e \"$ESHKOL_RUN\"; then",
+                         "Debian package script only builds when eshkol-run is absent") &&
+         expect_contains(script, "require_regular_executable \"eshkol-run\" \"$ESHKOL_RUN\"",
+                         "Debian package script validates the built compiler executable") &&
+         expect_contains(script, "require_regular_package_file()",
+                         "Debian package script declares package artifact validation") &&
+         expect_contains(script, "require_regular_package_file \"$DEB_FILE\"",
+                         "Debian package script validates the generated package artifact") &&
+         expect_contains(script, "mv -- \"$DEB_FILE\" \"../${OUTPUT_NAME}\"",
+                         "Debian package script moves the generated package with option termination");
+
+    ok = ok &&
+         expect_not_contains(script, "[ ! -f \"${BUILD_DIR}/eshkol-run\" ]",
+                             "Debian package script should not use a plain compiler file probe") &&
+         expect_not_contains(script, "mv \"$DEB_FILE\"",
+                             "Debian package script should not move the package without option termination");
+
+    if (!ok) {
+        return 1;
+    }
+
+    std::cout << "PASS" << std::endl;
+    return 0;
+}

--- a/tests/toolchain/docker_build_surface_test.cpp
+++ b/tests/toolchain/docker_build_surface_test.cpp
@@ -1,0 +1,98 @@
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+std::string read_file(const fs::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    return buffer.str();
+}
+
+bool expect_contains(const std::string& haystack, const std::string& needle,
+                     const std::string& label) {
+    if (haystack.find(needle) == std::string::npos) {
+        std::cerr << "missing: " << label << "\nneedle: " << needle << std::endl;
+        return false;
+    }
+    return true;
+}
+
+bool expect_not_contains(const std::string& haystack, const std::string& needle,
+                         const std::string& label) {
+    if (haystack.find(needle) != std::string::npos) {
+        std::cerr << "unexpected: " << label << "\nneedle: " << needle
+                  << std::endl;
+        return false;
+    }
+    return true;
+}
+
+int fail(const std::string& message) {
+    std::cerr << "FAIL: " << message << std::endl;
+    return 1;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        return fail("usage: docker_build_surface_test <source-root>");
+    }
+
+    const fs::path source_root = argv[1];
+    const fs::path script_path = source_root / "scripts" / "build-docker.sh";
+    if (!fs::exists(script_path)) {
+        return fail("build-docker.sh not found under source root");
+    }
+
+    const std::string script = read_file(script_path);
+    bool ok = true;
+
+    ok = ok &&
+         expect_contains(script, "validate_package_version()",
+                         "Docker build script declares version validation") &&
+         expect_contains(script, "unsafe Docker artifact version",
+                         "Docker build script rejects unsafe version text") &&
+         expect_contains(script, "validate_package_version \"$VERSION\"",
+                         "Docker build script validates the user-supplied version") &&
+         expect_contains(script, "require_output_directory()",
+                         "Docker build script declares output directory validation") &&
+         expect_contains(script, "require_output_directory \"Docker artifact output directory\" \"$OUTPUT_DIR\"",
+                         "Docker build script validates the output root") &&
+         expect_contains(script, "require_output_directory \"Docker architecture artifact directory\" \"$ARCH_OUTPUT\"",
+                         "Docker build script validates the architecture output directory") &&
+         expect_contains(script, "ARCH_OUTPUT=\"$(cd \"$ARCH_OUTPUT\" && pwd -P)\"",
+                         "Docker build script canonicalizes the architecture output directory") &&
+         expect_contains(script, "remove_package_stage()",
+                         "Docker build script declares guarded package-stage cleanup") &&
+         expect_contains(script, "\"$root\"/.pkg.*",
+                         "Docker build script restricts package-stage removal to .pkg staging dirs") &&
+         expect_contains(script, "PKG_STAGE=\"$(mktemp -d \"$ARCH_OUTPUT/.pkg.XXXXXX\")\"",
+                         "Docker build script creates a unique package staging directory") &&
+         expect_contains(script, "tar -czvf \"$ARCH_OUTPUT/$TARBALL_NAME\" -C \"$PKG_STAGE\" .",
+                         "Docker build script tars from the validated package staging directory") &&
+         expect_contains(script, "remove_package_stage \"$PKG_STAGE\" \"$ARCH_OUTPUT\"",
+                         "Docker build script removes only the guarded package staging directory");
+
+    ok = ok &&
+         expect_not_contains(script, "mkdir -p pkg/bin pkg/lib pkg/share/eshkol",
+                             "Docker build script should not stage into a fixed pkg directory") &&
+         expect_not_contains(script, "tar -czvf \"$TARBALL_NAME\" -C pkg .",
+                             "Docker build script should not tar from a fixed pkg directory") &&
+         expect_not_contains(script, "rm -rf pkg",
+                             "Docker build script should not remove a fixed pkg directory");
+
+    if (!ok) {
+        return 1;
+    }
+
+    std::cout << "PASS" << std::endl;
+    return 0;
+}

--- a/tests/toolchain/macos_build_surface_test.cpp
+++ b/tests/toolchain/macos_build_surface_test.cpp
@@ -1,0 +1,110 @@
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+std::string read_file(const fs::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    return buffer.str();
+}
+
+bool expect_contains(const std::string& haystack, const std::string& needle,
+                     const std::string& label) {
+    if (haystack.find(needle) == std::string::npos) {
+        std::cerr << "missing: " << label << "\nneedle: " << needle << std::endl;
+        return false;
+    }
+    return true;
+}
+
+bool expect_not_contains(const std::string& haystack, const std::string& needle,
+                         const std::string& label) {
+    if (haystack.find(needle) != std::string::npos) {
+        std::cerr << "unexpected: " << label << "\nneedle: " << needle
+                  << std::endl;
+        return false;
+    }
+    return true;
+}
+
+int fail(const std::string& message) {
+    std::cerr << "FAIL: " << message << std::endl;
+    return 1;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        return fail("usage: macos_build_surface_test <source-root>");
+    }
+
+    const fs::path source_root = argv[1];
+    const fs::path script_path = source_root / "scripts" / "build-macos.sh";
+    if (!fs::exists(script_path)) {
+        return fail("build-macos.sh not found under source root");
+    }
+
+    const std::string script = read_file(script_path);
+    bool ok = true;
+
+    ok = ok &&
+         expect_contains(script, "validate_package_version()",
+                         "macOS build script declares version validation") &&
+         expect_contains(script, "unsafe macOS artifact version",
+                         "macOS build script rejects unsafe version text") &&
+         expect_contains(script, "validate_target_arch()",
+                         "macOS build script declares architecture validation") &&
+         expect_contains(script, "validate_target_arch \"$TARGET_ARCH\"",
+                         "macOS build script validates the user-supplied architecture") &&
+         expect_contains(script, "require_output_directory()",
+                         "macOS build script declares output directory validation") &&
+         expect_contains(script, "require_output_directory \"macOS artifact output directory\" \"$OUTPUT_DIR\"",
+                         "macOS build script validates the output root") &&
+         expect_contains(script, "OUTPUT_DIR=\"$(cd \"$OUTPUT_DIR\" && pwd -P)\"",
+                         "macOS build script canonicalizes the output directory") &&
+         expect_contains(script, "remove_build_directory()",
+                         "macOS build script declares guarded clean-build removal") &&
+         expect_contains(script, "remove_build_directory \"$build_dir\"",
+                         "macOS build script uses the guarded build-directory cleanup") &&
+         expect_contains(script, "remove_package_stage()",
+                         "macOS build script declares guarded package-stage cleanup") &&
+         expect_contains(script, "\"$root\"/.pkg.*",
+                         "macOS build script restricts package-stage removal to .pkg staging dirs") &&
+         expect_contains(script, "pkg_stage=\"$(mktemp -d \"$pkg_dir/.pkg.XXXXXX\")\"",
+                         "macOS build script creates unique per-arch package staging") &&
+         expect_contains(script, "pkg_stage=\"$(mktemp -d \"$universal_dir/.pkg.XXXXXX\")\"",
+                         "macOS build script creates unique universal package staging") &&
+         expect_contains(script, "tar -czvf \"$tarball\" -C \"$pkg_stage\" .",
+                         "macOS build script tars from the validated package staging directory") &&
+         expect_contains(script, "remove_package_stage \"$pkg_stage\" \"$pkg_dir\"",
+                         "macOS build script removes guarded per-arch package staging") &&
+         expect_contains(script, "remove_package_stage \"$pkg_stage\" \"$universal_dir\"",
+                         "macOS build script removes guarded universal package staging");
+
+    ok = ok &&
+         expect_not_contains(script, "rm -rf \"$build_dir\"",
+                             "macOS build script should not remove build dirs without the guard helper") &&
+         expect_not_contains(script, "tar -czvf \"$tarball\" -C \"$pkg_dir/pkg\" .",
+                             "macOS build script should not tar from fixed per-arch pkg staging") &&
+         expect_not_contains(script, "tar -czvf \"$tarball\" -C \"$universal_dir/pkg\" .",
+                             "macOS build script should not tar from fixed universal pkg staging") &&
+         expect_not_contains(script, "rm -rf \"$pkg_dir/pkg\"",
+                             "macOS build script should not remove fixed per-arch pkg staging") &&
+         expect_not_contains(script, "rm -rf \"$universal_dir/pkg\"",
+                             "macOS build script should not remove fixed universal pkg staging");
+
+    if (!ok) {
+        return 1;
+    }
+
+    std::cout << "PASS" << std::endl;
+    return 0;
+}

--- a/tests/toolchain/windows_suite_surface_test.cpp
+++ b/tests/toolchain/windows_suite_surface_test.cpp
@@ -1,0 +1,114 @@
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+std::string read_file(const fs::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    return buffer.str();
+}
+
+bool expect_contains(const std::string& haystack, const std::string& needle,
+                     const std::string& label) {
+    if (haystack.find(needle) == std::string::npos) {
+        std::cerr << "missing: " << label << "\nneedle: " << needle << std::endl;
+        return false;
+    }
+    return true;
+}
+
+bool expect_not_contains(const std::string& haystack, const std::string& needle,
+                         const std::string& label) {
+    if (haystack.find(needle) != std::string::npos) {
+        std::cerr << "unexpected: " << label << "\nneedle: " << needle
+                  << std::endl;
+        return false;
+    }
+    return true;
+}
+
+int fail(const std::string& message) {
+    std::cerr << "FAIL: " << message << std::endl;
+    return 1;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        return fail("usage: windows_suite_surface_test <source-root>");
+    }
+
+    const fs::path source_root = argv[1];
+    const fs::path script_path = source_root / "scripts" / "run_all_tests.ps1";
+    if (!fs::exists(script_path)) {
+        return fail("run_all_tests.ps1 not found under source root");
+    }
+
+    const std::string script = read_file(script_path);
+    bool ok = true;
+
+    ok = ok &&
+         expect_contains(script, "function Get-RegularFileItem",
+                         "Windows suite declares regular-file resolver") &&
+         expect_contains(script, "Get-Item -LiteralPath $Path -Force -ErrorAction Stop",
+                         "Windows suite resolves file candidates without wildcard expansion") &&
+         expect_contains(script, "function Test-RegularFile",
+                         "Windows suite declares regular-file predicate") &&
+         expect_contains(script,
+                         "($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0",
+                         "Windows suite rejects reparse-point file artifacts") &&
+         expect_contains(script, "function Remove-RegularFileIfPresent",
+                         "Windows suite declares guarded output cleanup") &&
+         expect_contains(script, "Remove-Item -LiteralPath $item.FullName -Force -ErrorAction Stop",
+                         "Windows suite cleanup removes only the resolved regular file") &&
+         expect_contains(script, "function Start-RegularFileProcess",
+                         "Windows suite declares guarded process launcher") &&
+         expect_contains(script, "Refusing to start missing or non-regular executable",
+                         "Windows suite guarded launcher rejects non-regular executables") &&
+         expect_contains(script, "Test-RegularFile -Path (Join-Path $binDir \"eshkol-run.exe\")",
+                         "Windows suite build resolver requires a regular eshkol-run.exe") &&
+         expect_contains(script, "Remove-RegularFileIfPresent -Path @($exePath, $OutputBase)",
+                         "Windows suite compile cleanup rejects non-regular output artifacts") &&
+         expect_contains(script,
+                         "Success  = ($captured.ExitCode -eq 0 -and (Test-RegularFile -Path $exePath))",
+                         "Windows suite compile success requires a regular executable") &&
+         expect_contains(script, "Test-RegularFile -Path $compile.ExePath",
+                         "Windows suite expected-error path checks regular executables") &&
+         expect_contains(script, "Test-RegularFile -Path $llvmCommand.Source",
+                         "Windows suite PATH llvm-config fallback rejects non-regular commands") &&
+         expect_contains(script, "Test-RegularFile -Path $script:EshkolServer",
+                         "Windows suite server runner requires a regular executable") &&
+         expect_contains(script, "Start-RegularFileProcess -FilePath $script:EshkolServer",
+                         "Windows suite starts the web server through the guarded launcher") &&
+         expect_contains(script, "Test-RegularFile -Path $wasmPath",
+                         "Windows suite WASM validation requires a regular output file") &&
+         expect_contains(script, "Remove-RegularFileIfPresent -Path @($serverStdout, $serverStderr)",
+                         "Windows suite server-log cleanup rejects non-regular artifacts") &&
+         expect_contains(script, "Test-RegularFile -Path $xlaBin",
+                         "Windows suite XLA binary probe requires a regular executable") &&
+         expect_contains(script, "Test-RegularFile -Path $path",
+                         "Windows suite build-artifact probes require regular files");
+
+    ok = ok &&
+         expect_not_contains(script, "Test-Path ",
+                             "Windows suite should not use plain Test-Path artifact probes") &&
+         expect_not_contains(script, "Remove-Item $",
+                             "Windows suite should not remove variable paths without the guard helper") &&
+         expect_not_contains(script, "$server = Start-Process",
+                             "Windows suite should not start the web server without the guard helper");
+
+    if (!ok) {
+        return 1;
+    }
+
+    std::cout << "PASS" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- harden aggregate shell test runners, package/build scripts, benchmark harnesses, and CMake suite helpers against unsafe path handling
- add shared shell output helper wrappers
- add five source-surface tests for Windows, aggregate shell, Debian package, Docker package, and macOS package harness contracts

## Scope notes
This is the second merge-back slice from the platform branch. It intentionally excludes BSP Docker/QEMU scripts and BSP surface tests; those stay with the later reference-BSP merge-back candidate.

## Validation
- bash -n on changed shell scripts
- cmake --build build --target windows_suite_surface_test aggregate_shell_suite_surface_test debian_package_surface_test docker_build_surface_test macos_build_surface_test
- ctest -R 'windows_suite_surface_test|aggregate_shell_suite_surface_test|debian_package_surface_test|docker_build_surface_test|macos_build_surface_test'
- cmake --build build --target all
- ctest --output-on-failure