### PR TITLE
Add execution profile model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1429,6 +1429,25 @@ if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/core/model_i
     add_test(NAME model_io_test COMMAND model_io_test)
 endif()
 
+if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/execution_profile_test.cpp")
+    add_executable(execution_profile_test tests/toolchain/execution_profile_test.cpp)
+    target_compile_features(execution_profile_test PRIVATE cxx_std_17)
+    target_include_directories(execution_profile_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/inc")
+    if(LLVM_INCLUDE_DIRS)
+        target_include_directories(execution_profile_test PRIVATE ${LLVM_INCLUDE_DIRS})
+    endif()
+    if(LLVM_LIBRARY_DIRS)
+        target_link_directories(execution_profile_test PRIVATE ${LLVM_LIBRARY_DIRS})
+    endif()
+    target_link_libraries(execution_profile_test PRIVATE
+        eshkol-static
+        ${ESHKOL_EXTRA_LINK_LIBS}
+        ${LLVM_LIBS_LIST}
+        ${LLVM_SYSTEM_LIBS_LIST}
+    )
+    add_test(NAME execution_profile_test COMMAND execution_profile_test)
+endif()
+
 if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/repl/assoc_eval_test.cpp")
     add_executable(assoc_eval_test tests/repl/assoc_eval_test.cpp)
     target_compile_features(assoc_eval_test PRIVATE cxx_std_17)

--- a/inc/eshkol/core/execution_profile.h
+++ b/inc/eshkol/core/execution_profile.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) tsotchke
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Execution profile model for hosted and freestanding compilation modes.
+ */
+#ifndef ESHKOL_CORE_EXECUTION_PROFILE_H
+#define ESHKOL_CORE_EXECUTION_PROFILE_H
+
+#include <string>
+#include <string_view>
+
+namespace eshkol::profile {
+
+enum class Backend {
+    Native,
+    Wasm,
+    Vm
+};
+
+enum class ExecutionProfile {
+    HostedNative,
+    HostedWasm,
+    HostedVm,
+    FreestandingKernelNative,
+    FreestandingMcuNative,
+    FreestandingVm
+};
+
+struct Info {
+    ExecutionProfile id;
+    const char* name;
+    Backend backend;
+    bool hosted;
+    bool freestanding;
+    bool experimental;
+    bool implies_compile_only;
+    bool implies_no_stdlib;
+    const char* target_triple;
+};
+
+struct Selection {
+    ExecutionProfile requested = ExecutionProfile::HostedNative;
+    bool explicit_request = false;
+    const char* explicit_target_triple = nullptr;
+    bool compile_only = false;
+    bool shared_lib = false;
+    bool wasm_flag = false;
+    bool no_stdlib = false;
+    bool eval_mode = false;
+    bool run_mode = false;
+    bool has_eskb_output = false;
+    bool has_linked_libs = false;
+};
+
+struct Resolution {
+    const Info* profile = nullptr;
+    bool compile_only = false;
+    bool no_stdlib = false;
+    bool wasm_output = false;
+    bool vm_only = false;
+    const char* target_triple = nullptr;
+    std::string error;
+};
+
+const Info* find(std::string_view name);
+const Info& get(ExecutionProfile profile);
+const char* name(ExecutionProfile profile);
+std::string supported_names();
+Resolution resolve(const Selection& selection);
+
+}  // namespace eshkol::profile
+
+#endif

--- a/lib/core/execution_profile.cpp
+++ b/lib/core/execution_profile.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) tsotchke
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+#include <eshkol/core/execution_profile.h>
+
+#include <array>
+
+namespace eshkol::profile {
+
+namespace {
+
+constexpr std::array<Info, 6> kProfiles = {{
+    {ExecutionProfile::HostedNative, "hosted-native", Backend::Native, true, false, false, false, false, nullptr},
+    {ExecutionProfile::HostedWasm, "hosted-wasm", Backend::Wasm, true, false, false, false, false, "wasm32-unknown-unknown"},
+    {ExecutionProfile::HostedVm, "hosted-vm", Backend::Vm, true, false, true, false, false, nullptr},
+    {ExecutionProfile::FreestandingKernelNative, "freestanding-kernel-native", Backend::Native, false, true, true, true, true, nullptr},
+    {ExecutionProfile::FreestandingMcuNative, "freestanding-mcu-native", Backend::Native, false, true, true, true, true, nullptr},
+    {ExecutionProfile::FreestandingVm, "freestanding-vm", Backend::Vm, false, true, true, false, true, nullptr},
+}};
+
+}  // namespace
+
+const Info* find(std::string_view query) {
+    for (const auto& profile : kProfiles) {
+        if (query == profile.name) {
+            return &profile;
+        }
+    }
+    return nullptr;
+}
+
+const Info& get(ExecutionProfile profile) {
+    for (const auto& info : kProfiles) {
+        if (info.id == profile) {
+            return info;
+        }
+    }
+    return kProfiles.front();
+}
+
+const char* name(ExecutionProfile profile) {
+    return get(profile).name;
+}
+
+std::string supported_names() {
+    std::string names;
+    for (size_t i = 0; i < kProfiles.size(); ++i) {
+        if (i > 0) {
+            names += ", ";
+        }
+        names += kProfiles[i].name;
+    }
+    return names;
+}
+
+Resolution resolve(const Selection& selection) {
+    Resolution resolved;
+    resolved.profile = &get(selection.requested);
+    resolved.compile_only = selection.compile_only;
+    resolved.no_stdlib = selection.no_stdlib;
+    resolved.wasm_output = selection.wasm_flag;
+    resolved.target_triple = selection.explicit_target_triple
+                                 ? selection.explicit_target_triple
+                                 : resolved.profile->target_triple;
+
+    if (!selection.explicit_request) {
+        if (resolved.profile->id == ExecutionProfile::HostedWasm) {
+            resolved.wasm_output = true;
+        }
+        return resolved;
+    }
+
+    switch (resolved.profile->id) {
+    case ExecutionProfile::HostedNative:
+        if (selection.wasm_flag) {
+            resolved.error = "--profile hosted-native cannot be combined with --wasm";
+        }
+        break;
+
+    case ExecutionProfile::HostedWasm:
+        if (selection.eval_mode || selection.run_mode) {
+            resolved.error = "--profile hosted-wasm does not support JIT eval/run";
+            break;
+        }
+        if (selection.shared_lib) {
+            resolved.error = "--profile hosted-wasm cannot be combined with --shared-lib";
+            break;
+        }
+        if (selection.has_linked_libs) {
+            resolved.error = "--profile hosted-wasm cannot be combined with --lib";
+            break;
+        }
+        resolved.wasm_output = true;
+        break;
+
+    case ExecutionProfile::HostedVm:
+        if (!selection.has_eskb_output) {
+            resolved.error = "--profile hosted-vm requires --emit-eskb <path>";
+            break;
+        }
+        if (selection.eval_mode || selection.run_mode) {
+            resolved.error = "--profile hosted-vm does not support JIT eval/run";
+            break;
+        }
+        if (selection.shared_lib) {
+            resolved.error = "--profile hosted-vm cannot be combined with --shared-lib";
+            break;
+        }
+        if (selection.wasm_flag) {
+            resolved.error = "--profile hosted-vm cannot be combined with --wasm";
+            break;
+        }
+        if (selection.has_linked_libs) {
+            resolved.error = "--profile hosted-vm cannot be combined with --lib";
+            break;
+        }
+        resolved.vm_only = true;
+        resolved.wasm_output = false;
+        resolved.target_triple = nullptr;
+        break;
+
+    case ExecutionProfile::FreestandingKernelNative:
+    case ExecutionProfile::FreestandingMcuNative:
+        if (selection.eval_mode || selection.run_mode) {
+            resolved.error = "--profile ";
+            resolved.error += resolved.profile->name;
+            resolved.error += " does not support JIT eval/run";
+            break;
+        }
+        if (selection.shared_lib) {
+            resolved.error = "--profile ";
+            resolved.error += resolved.profile->name;
+            resolved.error += " cannot be combined with --shared-lib";
+            break;
+        }
+        if (selection.wasm_flag) {
+            resolved.error = "--profile ";
+            resolved.error += resolved.profile->name;
+            resolved.error += " cannot be combined with --wasm";
+            break;
+        }
+        if (selection.has_linked_libs) {
+            resolved.error = "--profile ";
+            resolved.error += resolved.profile->name;
+            resolved.error += " cannot be combined with --lib";
+            break;
+        }
+        if (!selection.explicit_target_triple) {
+            resolved.error = "--profile ";
+            resolved.error += resolved.profile->name;
+            resolved.error += " requires --target <triple>";
+            break;
+        }
+        resolved.compile_only = true;
+        resolved.no_stdlib = true;
+        resolved.wasm_output = false;
+        break;
+
+    case ExecutionProfile::FreestandingVm:
+        if (!selection.has_eskb_output) {
+            resolved.error = "--profile freestanding-vm requires --emit-eskb <path>";
+            break;
+        }
+        if (selection.eval_mode || selection.run_mode) {
+            resolved.error = "--profile freestanding-vm does not support JIT eval/run";
+            break;
+        }
+        if (selection.shared_lib) {
+            resolved.error = "--profile freestanding-vm cannot be combined with --shared-lib";
+            break;
+        }
+        if (selection.wasm_flag) {
+            resolved.error = "--profile freestanding-vm cannot be combined with --wasm";
+            break;
+        }
+        if (selection.has_linked_libs) {
+            resolved.error = "--profile freestanding-vm cannot be combined with --lib";
+            break;
+        }
+        resolved.no_stdlib = true;
+        resolved.vm_only = true;
+        resolved.wasm_output = false;
+        resolved.target_triple = nullptr;
+        break;
+    }
+
+    return resolved;
+}
+
+}  // namespace eshkol::profile

--- a/tests/toolchain/execution_profile_test.cpp
+++ b/tests/toolchain/execution_profile_test.cpp
@@ -1,0 +1,123 @@
+#include <eshkol/core/execution_profile.h>
+
+#include <iostream>
+#include <string>
+
+namespace {
+
+int fail(const std::string& message) {
+    std::cerr << "FAIL: " << message << std::endl;
+    return 1;
+}
+
+}  // namespace
+
+int main() {
+    using namespace eshkol::profile;
+
+    if (const Info* info = find("hosted-native"); !info || info->id != ExecutionProfile::HostedNative) {
+        return fail("failed to resolve hosted-native profile");
+    }
+
+    if (find("not-a-profile") != nullptr) {
+        return fail("unexpectedly resolved an invalid profile name");
+    }
+
+    {
+        Selection selection;
+        selection.requested = ExecutionProfile::HostedWasm;
+        Resolution resolved = resolve(selection);
+        if (!resolved.profile || resolved.profile->id != ExecutionProfile::HostedWasm) {
+            return fail("legacy wasm selection did not resolve to hosted-wasm");
+        }
+        if (!resolved.wasm_output || std::string(resolved.target_triple ? resolved.target_triple : "") != "wasm32-unknown-unknown") {
+            return fail("legacy wasm selection did not set wasm output and target triple");
+        }
+    }
+
+    {
+        Selection selection;
+        selection.requested = ExecutionProfile::HostedNative;
+        selection.explicit_request = true;
+        selection.wasm_flag = true;
+        Resolution resolved = resolve(selection);
+        if (resolved.error.empty()) {
+            return fail("explicit hosted-native + --wasm should fail");
+        }
+    }
+
+    {
+        Selection selection;
+        selection.requested = ExecutionProfile::HostedVm;
+        selection.explicit_request = true;
+        Resolution resolved = resolve(selection);
+        if (resolved.error.empty()) {
+            return fail("hosted-vm without --emit-eskb should fail");
+        }
+    }
+
+    {
+        Selection selection;
+        selection.requested = ExecutionProfile::HostedVm;
+        selection.explicit_request = true;
+        selection.has_eskb_output = true;
+        Resolution resolved = resolve(selection);
+        if (!resolved.error.empty() || !resolved.vm_only) {
+            return fail("hosted-vm with --emit-eskb should resolve to vm-only mode");
+        }
+    }
+
+    {
+        Selection selection;
+        selection.requested = ExecutionProfile::FreestandingKernelNative;
+        selection.explicit_request = true;
+        Resolution resolved = resolve(selection);
+        if (resolved.error.empty()) {
+            return fail("freestanding-kernel-native without explicit target should fail");
+        }
+    }
+
+    {
+        Selection selection;
+        selection.requested = ExecutionProfile::FreestandingKernelNative;
+        selection.explicit_request = true;
+        selection.explicit_target_triple = "x86_64-unknown-linux-gnu";
+        Resolution resolved = resolve(selection);
+        if (!resolved.error.empty()) {
+            return fail("freestanding-kernel-native should resolve cleanly");
+        }
+        if (!resolved.compile_only || !resolved.no_stdlib) {
+            return fail("freestanding-kernel-native should imply compile-only and no-stdlib");
+        }
+        if (std::string(resolved.target_triple ? resolved.target_triple : "") !=
+            "x86_64-unknown-linux-gnu") {
+            return fail("freestanding-kernel-native should preserve explicit target triple");
+        }
+    }
+
+    {
+        Selection selection;
+        selection.requested = ExecutionProfile::FreestandingKernelNative;
+        selection.explicit_request = true;
+        selection.explicit_target_triple = "x86_64-unknown-linux-gnu";
+        selection.shared_lib = true;
+        Resolution resolved = resolve(selection);
+        if (resolved.error.empty()) {
+            return fail("freestanding-kernel-native + --shared-lib should fail");
+        }
+    }
+
+    {
+        Selection selection;
+        selection.requested = ExecutionProfile::FreestandingVm;
+        selection.explicit_request = true;
+        selection.has_eskb_output = true;
+        Resolution resolved = resolve(selection);
+        if (!resolved.error.empty() || !resolved.vm_only || !resolved.no_stdlib) {
+            return fail("freestanding-vm should resolve to vm-only mode and imply no-stdlib");
+        }
+    }
+
+    std::cout << "PASS" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a first-class execution profile metadata model for hosted, wasm, VM, and freestanding modes
- add resolution rules for profile/flag combinations without wiring CLI behavior yet
- register and add a focused execution_profile_test

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
- cmake --build build --target execution_profile_test
- ctest --output-on-failure --test-dir build -R execution_profile_test
- cmake --build build --target all
- ctest --output-on-failure --test-dir build