### PR TITLE
Fix Windows generated link arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -847,9 +847,12 @@ macro(eshkol_append_host_runtime_link_arg item)
             endif()
         else()
             set(_eshkol_runtime_link_arg "${item}")
-            if(NOT _eshkol_runtime_link_arg MATCHES "^-" AND
-               NOT _eshkol_runtime_link_arg MATCHES "[/\\\\]" AND
-               NOT _eshkol_runtime_link_arg MATCHES "\\.(a|so|dylib|lib)$")
+            if(WIN32 AND _eshkol_runtime_link_arg MATCHES "^[A-Za-z0-9_.-]+\\.lib$")
+                string(REGEX REPLACE "\\.lib$" "" _eshkol_runtime_link_arg "${_eshkol_runtime_link_arg}")
+                set(_eshkol_runtime_link_arg "-l${_eshkol_runtime_link_arg}")
+            elseif(NOT _eshkol_runtime_link_arg MATCHES "^-" AND
+                   NOT _eshkol_runtime_link_arg MATCHES "[/\\\\]" AND
+                   NOT _eshkol_runtime_link_arg MATCHES "\\.(a|so|dylib|lib)$")
                 set(_eshkol_runtime_link_arg "-l${_eshkol_runtime_link_arg}")
             endif()
         endif()

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -32439,12 +32439,15 @@ int eshkol_compile_llvm_ir_to_object(LLVMModuleRef module_ref, const char* filen
         //     per ABI). Range overflow doesn't bite there.
         std::optional<llvm::CodeModel::Model> code_model;
 #if LLVM_VERSION_MAJOR >= 21
-        const std::string& triple_str_for_cm = cached_triple.str();
+        const bool use_large_aarch64_code_model = cached_triple.getArch() == Triple::aarch64 &&
+                                                  !cached_triple.isOSWindows();
 #else
         const std::string& triple_str_for_cm = g_cached_target_triple;
+        const Triple triple_for_cm(triple_str_for_cm);
+        const bool use_large_aarch64_code_model = triple_for_cm.getArch() == Triple::aarch64 &&
+                                                  !triple_for_cm.isOSWindows();
 #endif
-        if (triple_str_for_cm.find("aarch64") != std::string::npos ||
-            triple_str_for_cm.find("arm64") != std::string::npos) {
+        if (use_large_aarch64_code_model) {
             code_model = llvm::CodeModel::Large;
         }
 
@@ -32644,6 +32647,7 @@ int eshkol_compile_llvm_ir_to_executable(LLVMModuleRef module_ref, const char* f
 #if defined(__APPLE__)
             link_args.emplace_back("-Wl,-force_load," + runtime_lib_path.generic_string());
 #elif defined(_WIN32)
+            link_args.emplace_back("-Xlinker");
             link_args.emplace_back("/WHOLEARCHIVE:" + runtime_lib_path.generic_string());
 #else
             link_args.emplace_back("-Wl,--whole-archive");


### PR DESCRIPTION
This PR fixes Windows CI blockers seen on the pending mergeback PRs. It forwards the generated /WHOLEARCHIVE runtime archive argument through clang++ with -Xlinker, converts bare Windows .lib runtime dependencies such as Advapi32.lib into driver-friendly -lAdvapi32, and limits the AArch64 large code model workaround to non-Windows targets so Windows ARM64 COFF/SEH emission does not inherit the Linux-specific setting.

Local validation:
- cmake -S . -B build -DESHKOL_BUILD_TESTS=ON -DBUILD_REPL=ON
- cmake --build build --target eshkol-run stdlib
- build/eshkol-run -r tests/v1_2_edge_cases/repl_stdlib_fold_abi_test.esk
- cmake --build build
- ctest --output-on-failure --test-dir build