### PR TITLE
v1.3: source-location prefix on runtime type errors (ESH-0039)

### DIFF
--- a/exe/eshkol-run.cpp
+++ b/exe/eshkol-run.cpp
@@ -3439,6 +3439,19 @@ int main(int argc, char **argv)
                 eshkol_info("JIT running: %s", filepath.c_str());
             }
 
+            // Set source context so runtime type errors carry a
+            // "file:line:col:" prefix (v1.3 source-span errors), matching
+            // the AOT path. Read the file text once for diagnostics.
+            {
+                std::ifstream src_stream(filepath);
+                if (src_stream.is_open()) {
+                    std::string src_text(
+                        (std::istreambuf_iterator<char>(src_stream)),
+                        std::istreambuf_iterator<char>());
+                    eshkol_set_source_context(filepath.c_str(), src_text.c_str());
+                }
+            }
+
             // Architectural fix for the per-form JIT module boundary class:
             //
             // Previously this loop compiled and executed each top-level form

--- a/inc/eshkol/backend/arithmetic_codegen.h
+++ b/inc/eshkol/backend/arithmetic_codegen.h
@@ -251,6 +251,13 @@ public:
      */
     void emitTypeError(const char* message);
 
+    /* Raise a type error naming the offending operand's runtime type
+     * ("expected <expected>, got <actual-type>"). `offending` must be a
+     * tagged value; it is stored to an alloca and passed by pointer (a
+     * 16-byte struct by value does not survive the C ABI boundary). */
+    void emitOperandTypeError(const char* proc_name, const char* expected_type,
+                              llvm::Value* offending);
+
     /**
      * Convert operand to dual number (promote constants to dual with zero tangent).
      * Public so other codegen modules can route non-arithmetic ops — modulo,

--- a/inc/eshkol/backend/arithmetic_codegen.h
+++ b/inc/eshkol/backend/arithmetic_codegen.h
@@ -298,6 +298,15 @@ private:
     llvm::Value* isADNode(llvm::Value* operand, llvm::Value* base_type);
 
     /**
+     * Emit a call to eshkol_set_error_location() using the codegen's current
+     * source location (file:line:col), so the runtime error formatter can
+     * prefix the message with the failing expression's source position.
+     * No-op (emits nothing) when no line is known. Only call this on a branch
+     * that is about to raise a type error — it must not touch the hot path.
+     */
+    void emitSetErrorLocation();
+
+    /**
      * Emit code to raise a divide-by-zero exception.
      * Creates an exception object and calls eshkol_raise().
      */

--- a/inc/eshkol/backend/codegen_context.h
+++ b/inc/eshkol/backend/codegen_context.h
@@ -239,6 +239,20 @@ public:
     llvm::GlobalVariable* outerAdNodeDepth() { return outer_ad_node_depth_; }
     void setOuterAdNodeDepth(llvm::GlobalVariable* var) { outer_ad_node_depth_ = var; }
 
+    // === Current Source Location (for runtime error prefixes, v1.3) ===
+    // The main codegen keeps these in sync with the AST node it is lowering
+    // (file path + the failing expression's line/column). Sub-codegens such
+    // as ArithmeticCodegen read them to emit a runtime error-location call
+    // so type errors carry a "file:line:col:" prefix.
+    const std::string& currentSourceFile() const { return current_source_file_; }
+    uint32_t currentSourceLine() const { return current_source_line_; }
+    uint32_t currentSourceColumn() const { return current_source_column_; }
+    void setCurrentSourceLocation(const std::string& file, uint32_t line, uint32_t column) {
+        current_source_file_ = file;
+        current_source_line_ = line;
+        current_source_column_ = column;
+    }
+
     // === Mode Flags ===
 
     bool isLibraryMode() const { return library_mode_; }
@@ -335,6 +349,11 @@ private:
     llvm::GlobalVariable* gradient_x_degree_ = nullptr;
     llvm::GlobalVariable* outer_ad_node_stack_ = nullptr;
     llvm::GlobalVariable* outer_ad_node_depth_ = nullptr;
+
+    // Current source location (for runtime error "file:line:col:" prefixes)
+    std::string current_source_file_;
+    uint32_t current_source_line_ = 0;
+    uint32_t current_source_column_ = 0;
 
     // Mode flags
     bool library_mode_ = false;

--- a/inc/eshkol/core/runtime.h
+++ b/inc/eshkol/core/runtime.h
@@ -194,6 +194,18 @@ void eshkol_type_error_with_operand(const char* proc_name,
                                     const char* expected_type,
                                     const eshkol_tagged_value_t* actual);
 
+/*
+ * Source location for the *next* runtime error (v1.3 source-span errors).
+ *
+ * Codegen emits eshkol_set_error_location(file, line, col) on the type-error
+ * branch immediately before raising; the error formatter prepends a
+ * "file:line:col:" prefix to the message. `file` must be a stable C string
+ * (codegen emits a global). Thread-local. Cleared automatically is not
+ * required — the location is overwritten at the next error site.
+ */
+void eshkol_set_error_location(const char* file, uint32_t line, uint32_t column);
+void eshkol_clear_error_location(void);
+
 /* ============================================================================
  * Source-Span Stack Traces (v1.3)
  *

--- a/inc/eshkol/core/runtime.h
+++ b/inc/eshkol/core/runtime.h
@@ -186,9 +186,13 @@ const char* eshkol_format_value_type_tag(eshkol_tagged_value_t v);
  * this instead of eshkol_type_error so users see the concrete operand
  * type ("got string") rather than guessing which operand was wrong.
  */
+/* `actual` is passed by pointer: a 16-byte tagged-value struct passed by
+ * value does not survive the LLVM-IR → C ABI boundary reliably (it arrives
+ * zeroed, formatting as "null"). Codegen stores the operand to an alloca and
+ * passes its address. */
 void eshkol_type_error_with_operand(const char* proc_name,
                                     const char* expected_type,
-                                    eshkol_tagged_value_t actual);
+                                    const eshkol_tagged_value_t* actual);
 
 /* ============================================================================
  * Source-Span Stack Traces (v1.3)

--- a/lib/backend/arithmetic_codegen.cpp
+++ b/lib/backend/arithmetic_codegen.cpp
@@ -1839,18 +1839,44 @@ llvm::Value* ArithmeticCodegen::compare(llvm::Value* left, llvm::Value* right,
     // (Strict R7RS would reject CHAR; we follow the looser Lisp tradition
     // here because the alternative is a stdlib-wide audit and silent
     // error in real programs.)
+    // A heap pointer only counts as a number when its subtype is a numeric one
+    // (bignum or rational). Strings, vectors, pairs, etc. are also HEAP_PTR but
+    // are NOT numbers — treating them as numbers sent them down the double path
+    // where extractAsDouble coerces them to 0.0, so (= "a" 3) wrongly returned
+    // #f instead of raising. Read the subtype via a select-guarded address so a
+    // non-heap operand never dereferences a garbage pointer.
+    auto numericHeap = [&](llvm::Value* tagged, llvm::Value* is_heap) -> llvm::Value* {
+        auto& b = ctx_.builder();
+        llvm::Value* ptr = tagged_.unpackPtr(tagged);
+        llvm::Value* hdr = b.CreateGEP(ctx_.int8Type(), ptr,
+            llvm::ConstantInt::get(ctx_.int64Type(), -8));
+        llvm::Value* dummy = b.CreateAlloca(ctx_.int8Type(), nullptr, "nh_dummy");
+        // 0xFF is not a valid numeric subtype, so a non-heap operand reads a
+        // non-numeric sentinel and is correctly rejected.
+        b.CreateStore(llvm::ConstantInt::get(ctx_.int8Type(), 0xFF), dummy);
+        llvm::Value* addr = b.CreateSelect(is_heap, hdr, dummy);
+        llvm::Value* sub = b.CreateLoad(ctx_.int8Type(), addr, "nh_subtype");
+        llvm::Value* is_bn = b.CreateICmpEQ(sub,
+            llvm::ConstantInt::get(ctx_.int8Type(), HEAP_SUBTYPE_BIGNUM));
+        llvm::Value* is_rat = b.CreateICmpEQ(sub,
+            llvm::ConstantInt::get(ctx_.int8Type(), HEAP_SUBTYPE_RATIONAL));
+        return b.CreateAnd(is_heap, b.CreateOr(is_bn, is_rat));
+    };
+    llvm::Value* left_is_numeric_heap = numericHeap(left, left_is_heap);
+    llvm::Value* right_is_numeric_heap = numericHeap(right, right_is_heap);
+
     llvm::Value* left_is_number = ctx_.builder().CreateOr(
         ctx_.builder().CreateOr(
             ctx_.builder().CreateOr(
                 ctx_.builder().CreateOr(left_is_double, left_is_int),
-                ctx_.builder().CreateOr(left_is_heap, left_is_callable)),
+                ctx_.builder().CreateOr(left_is_numeric_heap, left_is_callable)),
             left_is_char),
         left_is_dual);
     llvm::Value* right_is_number = ctx_.builder().CreateOr(
         ctx_.builder().CreateOr(
             ctx_.builder().CreateOr(
                 ctx_.builder().CreateOr(right_is_double, right_is_int),
-                ctx_.builder().CreateOr(right_is_heap, right_is_callable)),
+                ctx_.builder().CreateOr(right_is_numeric_heap, right_is_callable)),
             right_is_char),
         right_is_dual);
     llvm::Value* both_numbers = ctx_.builder().CreateAnd(left_is_number, right_is_number);

--- a/lib/backend/arithmetic_codegen.cpp
+++ b/lib/backend/arithmetic_codegen.cpp
@@ -20,6 +20,8 @@
 #include <llvm/IR/Intrinsics.h>
 #include <llvm/Config/llvm-config.h>
 #include <eshkol/logger.h>
+#include <cstdio>
+#include <cstdint>
 
 // LLVM VERSION COMPATIBILITY
 #if LLVM_VERSION_MAJOR >= 21
@@ -2696,6 +2698,10 @@ void ArithmeticCodegen::emitOperandTypeError(const char* proc_name,
                                              const char* expected_type,
                                              llvm::Value* offending) {
     auto& b = ctx_.builder();
+    // Record the failing expression's source location so the runtime formatter
+    // can prefix the message with "file:line:col:". Covers both arithmetic and
+    // comparison type errors since both route through here.
+    emitSetErrorLocation();
     llvm::Function* fn = ctx_.module().getFunction("eshkol_type_error_with_operand");
     if (!fn) {
         // void eshkol_type_error_with_operand(const char*, const char*,
@@ -2720,6 +2726,35 @@ void ArithmeticCodegen::emitOperandTypeError(const char* proc_name,
     b.CreateCall(fn, {proc, exp, slot});
 }
 
+void ArithmeticCodegen::emitSetErrorLocation() {
+    uint32_t line = ctx_.currentSourceLine();
+    if (line == 0) {
+        return;  // No source location known — leave any prior location as-is.
+    }
+    uint32_t column = ctx_.currentSourceColumn();
+    const std::string& file = ctx_.currentSourceFile();
+
+    llvm::Function* set_loc_func = ctx_.module().getFunction("eshkol_set_error_location");
+    if (!set_loc_func) {
+        llvm::FunctionType* set_loc_type = llvm::FunctionType::get(
+            ctx_.builder().getVoidTy(),
+            {ctx_.builder().getPtrTy(),   // file
+             ctx_.int32Type(),            // line
+             ctx_.int32Type()},           // column
+            false);
+        set_loc_func = llvm::Function::Create(set_loc_type,
+            llvm::Function::ExternalLinkage, "eshkol_set_error_location", &ctx_.module());
+    }
+
+    llvm::Value* file_str = file.empty()
+        ? static_cast<llvm::Value*>(llvm::ConstantPointerNull::get(ctx_.builder().getPtrTy()))
+        : static_cast<llvm::Value*>(ctx_.builder().CreateGlobalString(file, "err_loc_file"));
+    ctx_.builder().CreateCall(set_loc_func, {
+        file_str,
+        llvm::ConstantInt::get(ctx_.int32Type(), line),
+        llvm::ConstantInt::get(ctx_.int32Type(), column)});
+}
+
 void ArithmeticCodegen::emitTypeError(const char* message) {
     llvm::Function* make_exc_func = ctx_.module().getFunction("eshkol_make_exception_with_header");
     if (!make_exc_func) {
@@ -2742,7 +2777,28 @@ void ArithmeticCodegen::emitTypeError(const char* message) {
         raise_func->setDoesNotReturn();
     }
 
-    llvm::Value* error_msg = ctx_.builder().CreateGlobalString(message);
+    // Prefix the message with the failing expression's source location
+    // ("file:line:col: ") when known. The location is a codegen-time
+    // constant, so we bake it straight into the message global.
+    std::string full_message;
+    uint32_t line = ctx_.currentSourceLine();
+    if (line > 0) {
+        const std::string& file = ctx_.currentSourceFile();
+        char prefix[320];
+        uint32_t column = ctx_.currentSourceColumn();
+        if (column > 0) {
+            std::snprintf(prefix, sizeof(prefix), "%s:%u:%u: ",
+                          file.empty() ? "<unknown>" : file.c_str(), line, column);
+        } else {
+            std::snprintf(prefix, sizeof(prefix), "%s:%u: ",
+                          file.empty() ? "<unknown>" : file.c_str(), line);
+        }
+        full_message = std::string(prefix) + message;
+    } else {
+        full_message = message;
+    }
+
+    llvm::Value* error_msg = ctx_.builder().CreateGlobalString(full_message);
     llvm::Value* exc = ctx_.builder().CreateCall(make_exc_func, {
         llvm::ConstantInt::get(ctx_.int32Type(), ESHKOL_EXCEPTION_TYPE_ERROR),
         error_msg

--- a/lib/backend/arithmetic_codegen.cpp
+++ b/lib/backend/arithmetic_codegen.cpp
@@ -1845,16 +1845,24 @@ llvm::Value* ArithmeticCodegen::compare(llvm::Value* left, llvm::Value* right,
     // where extractAsDouble coerces them to 0.0, so (= "a" 3) wrongly returned
     // #f instead of raising. Read the subtype via a select-guarded address so a
     // non-heap operand never dereferences a garbage pointer.
+    //
+    // The sentinel byte MUST be an entry-block alloca: compare() is frequently
+    // codegen'd inside a loop body (e.g. (>= j N) in a hot do-loop), and an
+    // alloca in the loop body re-allocates every iteration → stack overflow.
+    // Hoisting it to the entry block allocates exactly once per function.
+    llvm::Function* cmp_fn = ctx_.builder().GetInsertBlock()->getParent();
+    llvm::IRBuilder<> entry_builder(&cmp_fn->getEntryBlock(),
+                                    cmp_fn->getEntryBlock().begin());
+    llvm::Value* nh_dummy = entry_builder.CreateAlloca(ctx_.int8Type(), nullptr, "nh_dummy");
+    // 0xFF is not a valid numeric subtype, so a non-heap operand reads a
+    // non-numeric sentinel and is correctly rejected.
+    entry_builder.CreateStore(llvm::ConstantInt::get(ctx_.int8Type(), 0xFF), nh_dummy);
     auto numericHeap = [&](llvm::Value* tagged, llvm::Value* is_heap) -> llvm::Value* {
         auto& b = ctx_.builder();
         llvm::Value* ptr = tagged_.unpackPtr(tagged);
         llvm::Value* hdr = b.CreateGEP(ctx_.int8Type(), ptr,
             llvm::ConstantInt::get(ctx_.int64Type(), -8));
-        llvm::Value* dummy = b.CreateAlloca(ctx_.int8Type(), nullptr, "nh_dummy");
-        // 0xFF is not a valid numeric subtype, so a non-heap operand reads a
-        // non-numeric sentinel and is correctly rejected.
-        b.CreateStore(llvm::ConstantInt::get(ctx_.int8Type(), 0xFF), dummy);
-        llvm::Value* addr = b.CreateSelect(is_heap, hdr, dummy);
+        llvm::Value* addr = b.CreateSelect(is_heap, hdr, nh_dummy);
         llvm::Value* sub = b.CreateLoad(ctx_.int8Type(), addr, "nh_subtype");
         llvm::Value* is_bn = b.CreateICmpEQ(sub,
             llvm::ConstantInt::get(ctx_.int8Type(), HEAP_SUBTYPE_BIGNUM));

--- a/lib/backend/arithmetic_codegen.cpp
+++ b/lib/backend/arithmetic_codegen.cpp
@@ -1875,28 +1875,15 @@ llvm::Value* ArithmeticCodegen::compare(llvm::Value* left, llvm::Value* right,
     // that's NOT a number; if both are non-number, prefer the left (so the
     // error is deterministic).
     ctx_.builder().SetInsertPoint(type_error_path);
-    llvm::Function* type_error_op_func = ctx_.module().getFunction("eshkol_type_error_with_operand");
-    if (!type_error_op_func) {
-        llvm::FunctionType* error_op_type = llvm::FunctionType::get(
-            ctx_.builder().getVoidTy(),
-            {ctx_.builder().getPtrTy(),                // proc_name
-             ctx_.builder().getPtrTy(),                // expected_type
-             ctx_.taggedValueType()},                  // actual operand
-            false);
-        type_error_op_func = llvm::Function::Create(error_op_type, llvm::Function::ExternalLinkage,
-            "eshkol_type_error_with_operand", &ctx_.module());
-    }
     std::string op_name = (operation == "eq") ? "=" :
                           (operation == "lt") ? "<" :
                           (operation == "gt") ? ">" :
                           (operation == "le") ? "<=" : ">=";
-    llvm::Value* proc_name = ctx_.builder().CreateGlobalString(op_name, "cmp_proc_name");
-    llvm::Value* expected_type = ctx_.builder().CreateGlobalString("number", "cmp_expected_type");
     // Choose the operand to report: the left side if it's not numeric,
     // else the right side. Both are guaranteed non-numeric for at least
     // one branch since both_numbers is false here.
     llvm::Value* offending = ctx_.builder().CreateSelect(left_is_number, right, left, "cmp_offending");
-    ctx_.builder().CreateCall(type_error_op_func, {proc_name, expected_type, offending});
+    emitOperandTypeError(op_name.c_str(), "number", offending);
     llvm::Value* error_result = tagged_.packBool(ctx_.builder().getFalse());
     ctx_.builder().CreateBr(merge);
     llvm::BasicBlock* error_exit = ctx_.builder().GetInsertBlock();
@@ -2655,14 +2642,48 @@ void ArithmeticCodegen::guardHeapOperandsNumeric(llvm::Value* left,
     llvm::Value* all_ok = ctx_.builder().CreateAnd(l_ok, r_ok);
     ctx_.builder().CreateCondBr(all_ok, ok_blk, type_err_blk);
 
-    // Type error branch — non-returning
+    // Type error branch — non-returning. Report the concrete operand type via
+    // eshkol_type_error_with_operand ("expected …, got <actual-type>") instead
+    // of a generic message. Pick the offending side: the left operand if it
+    // failed its check, else the right (at least one is non-numeric here).
     ctx_.builder().SetInsertPoint(type_err_blk);
-    std::string msg = std::string(op_name) +
-        ": operand is not a number, vector, or tensor";
-    emitTypeError(msg.c_str());
+    llvm::Value* arith_offending =
+        ctx_.builder().CreateSelect(l_ok, right, left, "arith_offending");
+    emitOperandTypeError(op_name, "number, vector, or tensor", arith_offending);
+    // eshkol_type_error_with_operand raises (non-returning); keep the block
+    // well-formed with an unreachable terminator.
+    ctx_.builder().CreateUnreachable();
 
     // Continue in ok_blk
     ctx_.builder().SetInsertPoint(ok_blk);
+}
+
+void ArithmeticCodegen::emitOperandTypeError(const char* proc_name,
+                                             const char* expected_type,
+                                             llvm::Value* offending) {
+    auto& b = ctx_.builder();
+    llvm::Function* fn = ctx_.module().getFunction("eshkol_type_error_with_operand");
+    if (!fn) {
+        // void eshkol_type_error_with_operand(const char*, const char*,
+        //                                     const eshkol_tagged_value_t*)
+        llvm::FunctionType* ft = llvm::FunctionType::get(
+            b.getVoidTy(),
+            {b.getPtrTy(), b.getPtrTy(), b.getPtrTy()},
+            false);
+        fn = llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
+            "eshkol_type_error_with_operand", &ctx_.module());
+    }
+    // Pass the operand by pointer: a 16-byte tagged-value struct passed by
+    // value arrives zeroed across the LLVM-IR → C ABI boundary (formats as
+    // "null"). Store to an alloca and hand over its address.
+    if (offending->getType() != ctx_.taggedValueType()) {
+        offending = tagged_.packInt64(offending, true);
+    }
+    llvm::Value* slot = b.CreateAlloca(ctx_.taggedValueType(), nullptr, "operand_err_slot");
+    b.CreateStore(offending, slot);
+    llvm::Value* proc = b.CreateGlobalString(proc_name, "operr_proc");
+    llvm::Value* exp = b.CreateGlobalString(expected_type, "operr_expected");
+    b.CreateCall(fn, {proc, exp, slot});
 }
 
 void ArithmeticCodegen::emitTypeError(const char* message) {

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -17625,6 +17625,16 @@ private:
             return nullptr;
         }
 
+        // Only optimize NUMERIC comparisons. If either operand has a known
+        // non-numeric type (string, char, symbol, …), the fast int/float path
+        // below would coerce its raw value (e.g. a string pointer's bits) into
+        // a number and silently return a wrong #f. Fall through to the
+        // polymorphic path so compare() raises a proper type error instead.
+        if (!isNumericType(ctx_->hottTypes(), left.hott_type) ||
+            !isNumericType(ctx_->hottTypes(), right.hott_type)) {
+            return nullptr;
+        }
+
         // SAFETY CHECK: Don't optimize if values are tagged_value structs
         // These require runtime dispatch to extract the actual value
         if (left.llvm_value->getType() == tagged_value_type ||

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -8353,6 +8353,12 @@ private:
         if (ast->line > 0) {
             current_source_line = ast->line;
             current_source_column = ast->column;
+            // Mirror into CodegenContext so sub-codegens (e.g. ArithmeticCodegen)
+            // can emit a "file:line:col:" prefix on runtime type errors.
+            if (ctx_) {
+                ctx_->setCurrentSourceLocation(g_source_filepath,
+                                               ast->line, ast->column);
+            }
         }
 
         // DWARF DEBUG INFO: Set source location on builder for subsequent instructions

--- a/lib/core/runtime_errors_hosted.cpp
+++ b/lib/core/runtime_errors_hosted.cpp
@@ -131,9 +131,18 @@ const char* eshkol_format_value_type_tag(eshkol_tagged_value_t v) {
  */
 void eshkol_type_error_with_operand(const char* proc_name,
                                     const char* expected_type,
-                                    eshkol_tagged_value_t actual) {
+                                    const eshkol_tagged_value_t* actual) {
+    eshkol_tagged_value_t val;
+    if (actual) {
+        val = *actual;
+    } else {
+        val.type = ESHKOL_VALUE_NULL;
+        val.flags = 0;
+        val.reserved = 0;
+        val.data.int_val = 0;
+    }
     eshkol_type_error_with_value(proc_name, expected_type,
-                                 eshkol_format_value_type_tag(actual));
+                                 eshkol_format_value_type_tag(val));
 }
 
 }  // extern "C"

--- a/lib/core/runtime_errors_hosted.cpp
+++ b/lib/core/runtime_errors_hosted.cpp
@@ -18,7 +18,66 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <cstdint>
+
+/*
+ * Current error source location (v1.3 source-span errors).
+ *
+ * Codegen emits a call to eshkol_set_error_location(file, line, col) on the
+ * type-error branch immediately before raising, so the formatter can prefix
+ * the message with "file:line:col:". Thread-local so concurrent workers don't
+ * clobber one another. The file pointer is a static global string emitted by
+ * codegen (stable for the program's lifetime); we hold the pointer, not a copy.
+ *
+ * Hot paths never touch this: it is only written on an error branch that is
+ * about to abort, and only read inside the error formatter.
+ */
+#ifdef __clang__
+#  define ESHKOL_TLS __thread
+#elif defined(__GNUC__)
+#  define ESHKOL_TLS __thread
+#elif defined(_MSC_VER)
+#  define ESHKOL_TLS __declspec(thread)
+#else
+#  define ESHKOL_TLS
+#endif
+
+static ESHKOL_TLS const char* g_error_loc_file = nullptr;
+static ESHKOL_TLS uint32_t g_error_loc_line = 0;
+static ESHKOL_TLS uint32_t g_error_loc_column = 0;
+
 extern "C" {
+
+void eshkol_set_error_location(const char* file, uint32_t line, uint32_t column) {
+    g_error_loc_file = file;
+    g_error_loc_line = line;
+    g_error_loc_column = column;
+}
+
+void eshkol_clear_error_location(void) {
+    g_error_loc_file = nullptr;
+    g_error_loc_line = 0;
+    g_error_loc_column = 0;
+}
+
+/* Render the current "file:line:col: " prefix into `buf`. Returns the number
+ * of bytes written (0 if no location is set). The trailing space is included
+ * so callers can concatenate the message directly. */
+static size_t eshkol_format_error_location_prefix(char* buf, size_t buflen) {
+    if (g_error_loc_line == 0 || buflen == 0) {
+        return 0;
+    }
+    int n;
+    const char* file = g_error_loc_file ? g_error_loc_file : "<unknown>";
+    if (g_error_loc_column > 0) {
+        n = std::snprintf(buf, buflen, "%s:%u:%u: ",
+                          file, g_error_loc_line, g_error_loc_column);
+    } else {
+        n = std::snprintf(buf, buflen, "%s:%u: ", file, g_error_loc_line);
+    }
+    if (n < 0) return 0;
+    return (size_t)n < buflen ? (size_t)n : buflen - 1;
+}
 
 void eshkol_runtime_fatal(eshkol_exception_type_t type, const char* fmt, ...) {
     char buf[512];
@@ -51,13 +110,18 @@ void eshkol_type_error(const char* proc_name, const char* expected_type) {
 
 void eshkol_type_error_with_value(const char* proc_name, const char* expected_type,
                                   const char* actual_type) {
-    eshkol_error("Type error in %s: expected %s, got %s",
+    char prefix[320];
+    eshkol_format_error_location_prefix(prefix, sizeof(prefix));
+
+    eshkol_error("%sType error in %s: expected %s, got %s",
+                 prefix,
                  proc_name ? proc_name : "<unknown>",
                  expected_type ? expected_type : "<type>",
                  actual_type ? actual_type : "<unknown>");
 
     eshkol_runtime_fatal(ESHKOL_EXCEPTION_TYPE_ERROR,
-                         "Type error in %s: expected %s, got %s",
+                         "%sType error in %s: expected %s, got %s",
+                         prefix,
                          proc_name ? proc_name : "<unknown>",
                          expected_type ? expected_type : "<type>",
                          actual_type ? actual_type : "<unknown>");

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -150,6 +150,7 @@ extern "C" {
     void eshkol_type_error(const char* proc_name, const char* expected_type);
     void eshkol_type_error_with_value(const char* proc_name, const char* expected_type,
                                        const char* actual_type);
+    void eshkol_set_error_location(const char* file, uint32_t line, uint32_t column);
     int64_t eshkol_shapes_equal(const int64_t* shape_a, const int64_t* shape_b, int64_t rank);
     void eshkol_batch_matmul_f64(const double* a, const double* b, double* c,
                                   int64_t batch, int64_t M, int64_t K, int64_t N);
@@ -1014,6 +1015,12 @@ void ReplJITContext::registerRuntimeSymbols() {
     };
     symbols[ES.intern("eshkol_type_error_with_value")] = {
         orc::ExecutorAddr::fromPtr((void*)&::eshkol_type_error_with_value),
+        JITSymbolFlags::Callable | JITSymbolFlags::Exported
+    };
+    // Source-span error location (v1.3): set right before a type error is
+    // raised so the formatter can prefix "file:line:col:".
+    symbols[ES.intern("eshkol_set_error_location")] = {
+        orc::ExecutorAddr::fromPtr((void*)&::eshkol_set_error_location),
         JITSymbolFlags::Callable | JITSymbolFlags::Exported
     };
 

--- a/site/static/eshkol-runtime.js
+++ b/site/static/eshkol-runtime.js
@@ -329,6 +329,7 @@ class EshkolRuntime {
                 eshkol_type_error: () => { throw new Error('Eshkol type error (WASM stub)'); },
                 eshkol_tensor_result_dtype_binary: (r) => r,
                 eshkol_tensor_result_dtype_unary: (r) => r,
+                eshkol_type_error_with_operand: () => { throw new Error('Eshkol type error (WASM stub)'); },
                 eshkol_lambda_registry_init: () => {},
                 eshkol_lambda_registry_add: () => {},
                 eshkol_lambda_registry_lookup: () => 0,

--- a/site/static/eshkol-runtime.js
+++ b/site/static/eshkol-runtime.js
@@ -330,6 +330,7 @@ class EshkolRuntime {
                 eshkol_tensor_result_dtype_binary: (r) => r,
                 eshkol_tensor_result_dtype_unary: (r) => r,
                 eshkol_type_error_with_operand: () => { throw new Error('Eshkol type error (WASM stub)'); },
+                eshkol_set_error_location: () => {},
                 eshkol_lambda_registry_init: () => {},
                 eshkol_lambda_registry_add: () => {},
                 eshkol_lambda_registry_lookup: () => 0,

--- a/tests/v1_3_edge_cases/operand_type_error_test.esk
+++ b/tests/v1_3_edge_cases/operand_type_error_test.esk
@@ -1,0 +1,25 @@
+;; mode: jit
+;; Operand-type-aware error messages (v1.3 #40).
+;; Arithmetic and comparison on non-numeric operands must RAISE a type error
+;; naming the actual operand type — not return a wrong value or a generic msg.
+;;
+;; This file is `mode: jit`: each error case aborts, so it documents expected
+;; behaviour rather than asserting via check-equal? (a raised error halts).
+;; The companion shell check greps the messages. Here we exercise the valid
+;; paths to guarantee no regression, then show one erroring form.
+
+;; --- valid arithmetic still computes ---
+(display "add: ")   (display (+ 1 2 3))        (newline)   ; 6
+(display "mul: ")   (display (* 2.5 4))        (newline)   ; 10.0
+(display "big: ")   (display (= (expt 2 100) (expt 2 100))) (newline)  ; #t
+(display "rat: ")   (display (< 1/3 1/2))      (newline)   ; #t
+
+;; --- valid comparisons still compute ---
+(display "eq:  ")   (display (= 3 3))          (newline)   ; #t
+(display "lt:  ")   (display (< 1 2))          (newline)   ; #t
+(display "ge:  ")   (display (>= 3 9))         (newline)   ; #f
+
+;; --- char accepted by numeric comparison (codepoint) ---
+(display "chr: ")   (display (= #\A 65))       (newline)   ; #t
+
+(display "DONE")(newline)

--- a/tests/v1_3_edge_cases/source_span_type_error_test.sh
+++ b/tests/v1_3_edge_cases/source_span_type_error_test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# ESH-0039: runtime type errors must carry a "file:line:col:" source-location
+# prefix pointing at the failing expression.
+set -euo pipefail
+
+ESHKOL_RUN="${1:-${ESHKOL_RUN:-}}"
+if [ -z "$ESHKOL_RUN" ]; then
+    if [ -x "./build/eshkol-run" ]; then
+        ESHKOL_RUN="./build/eshkol-run"
+    elif [ -x "./build-verify/eshkol-run" ]; then
+        ESHKOL_RUN="./build-verify/eshkol-run"
+    else
+        echo "FAIL: source_span_type_error_test could not locate eshkol-run" >&2
+        exit 1
+    fi
+fi
+
+if [ ! -x "$ESHKOL_RUN" ]; then
+    echo "FAIL: source_span_type_error_test eshkol-run is not executable: $ESHKOL_RUN" >&2
+    exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+src="$tmpdir/span.esk"
+bin="$tmpdir/span"
+
+# The (+ x "bad") application is on line 1; the operator opens at column 14.
+printf '(define (f x) (+ x "bad"))\n(f 1)\n' > "$src"
+
+# --- AOT path -------------------------------------------------------------
+if ! "$ESHKOL_RUN" "$src" -o "$bin" -L./build > "$tmpdir/compile.log" 2>&1; then
+    echo "FAIL: AOT compile failed" >&2
+    cat "$tmpdir/compile.log" >&2
+    exit 1
+fi
+
+# Binary must exit non-zero (unhandled type error) and print a prefixed message.
+set +e
+"$bin" > "$tmpdir/out" 2> "$tmpdir/err"
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+    echo "FAIL: AOT binary exited 0 but a type error was expected" >&2
+    exit 1
+fi
+
+# Expect: "<...>span.esk:1:<col>: ...Type error.../...operand is not a number..."
+if ! grep -Eq 'span\.esk:1:[0-9]+: ' "$tmpdir/err"; then
+    echo "FAIL: AOT type error message lacks the 'file:line:col:' prefix" >&2
+    echo "  got: $(cat "$tmpdir/err")" >&2
+    exit 1
+fi
+
+echo "PASS: source_span_type_error_test (AOT) -> $(cat "$tmpdir/err")"
+exit 0

--- a/web/eshkol-repl.js
+++ b/web/eshkol-repl.js
@@ -295,6 +295,7 @@ class EshkolRepl {
                 eshkol_type_error: () => { throw new Error('Eshkol type error (WASM stub)'); },
                 eshkol_tensor_result_dtype_binary: (r) => r,
                 eshkol_tensor_result_dtype_unary: (r) => r,
+                eshkol_type_error_with_operand: () => { throw new Error('Eshkol type error (WASM stub)'); },
                 eshkol_deep_equal: (a, b) => false,
                 eshkol_display_value: (val) => {},
 

--- a/web/eshkol-repl.js
+++ b/web/eshkol-repl.js
@@ -296,6 +296,7 @@ class EshkolRepl {
                 eshkol_tensor_result_dtype_binary: (r) => r,
                 eshkol_tensor_result_dtype_unary: (r) => r,
                 eshkol_type_error_with_operand: () => { throw new Error('Eshkol type error (WASM stub)'); },
+                eshkol_set_error_location: () => {},
                 eshkol_deep_equal: (a, b) => false,
                 eshkol_display_value: (val) => {},
 


### PR DESCRIPTION
## Summary
Runtime type errors now carry the failing expression's **`file:line:col:`** prefix:

```
span.esk:1:20: Type error in +: expected number, vector, or tensor, got string
c.esk:1:4: Type error in =: expected number, got string
```

Covers **both arithmetic and comparison** via a single `emitSetErrorLocation()` call inside `ArithmeticCodegen::emitOperandTypeError` (both paths route through it). `CodegenContext` mirrors each AST node's file/line/column as codegen lowers it; a thread-local runtime location (`eshkol_set_error_location`/`_clear`) is prepended by the formatter in `eshkol_type_error_with_value`. Hot paths never touch it — written only on the about-to-abort branch.

## Stacked on #30
This builds on the operand-type-error work (PR #30). The diff will collapse to just the ESH-0039 changes once #30 merges.

## Scope note
Full multi-frame tracebacks (frame push/pop) are **deliberately not wired**: pop coverage across the ~46 scattered `CreateRet` sites + TCO can't be proven correct, so it stays a documented follow-up. A correct single-line source location beats a corrupt traceback. (Dropped an "AOT-link" change from the original draft that was a worktree-build artifact — it would have wrongly made every AOT binary link host LLVM.)

## Verified
- Source spans on arithmetic + comparison (AOT and JIT)
- Valid code unaffected; error_handling / types / gpu suites pass
- WASM import check passes (`eshkol_set_error_location` stubbed in both JS glue files)
- `source_span_type_error_test.sh` passes