### PR TITLE
ESH-0021: f16/bf16 cuBLAS GemmEx tensor-core matmul

### DIFF
--- a/inc/eshkol/backend/gpu/gpu_memory.h
+++ b/inc/eshkol/backend/gpu/gpu_memory.h
@@ -460,8 +460,11 @@ int eshkol_gpu_layernorm_backward_f64(
  * @param K Columns of A / Rows of B
  * @param N Columns of B and C
  */
+/* dtype is the result tensor's element dtype (eshkol_tensor_dtype_t code:
+ * 0=f64, 1=f32, 2=f16, 3=bf16, 4=i8). f16/bf16 take the cuBLAS GemmEx
+ * tensor-core path on CUDA (ESH-0021); other dtypes use the f64 dispatch. */
 void eshkol_matmul_dispatch(const double* A, const double* B, double* C,
-                             uint64_t M, uint64_t K, uint64_t N);
+                             uint64_t M, uint64_t K, uint64_t N, int32_t dtype);
 
 #ifdef __cplusplus
 }

--- a/lib/backend/gpu/gpu_memory.mm
+++ b/lib/backend/gpu/gpu_memory.mm
@@ -3487,7 +3487,10 @@ int eshkol_gpu_should_use(size_t num_elements) {
 }
 
 void eshkol_matmul_dispatch(const double* A, const double* B, double* C,
-                             uint64_t M, uint64_t K, uint64_t N) {
+                             uint64_t M, uint64_t K, uint64_t N, int32_t /*dtype*/) {
+    // dtype currently ignored on Metal (no f16 tensor-core GEMM path yet; a
+    // Metal-shader f16 GEMM is a separate follow-up). Storage is already f64
+    // precision-reduced for the logical dtype, so the f64 path stays correct.
     // Lazy GPU init — ensures g_active_backend is set before threshold check
     if (!g_gpu_initialized.load(std::memory_order_acquire)) {
         eshkol_gpu_init();

--- a/lib/backend/gpu/gpu_memory_cuda.cpp
+++ b/lib/backend/gpu/gpu_memory_cuda.cpp
@@ -26,6 +26,8 @@
 #define ESHKOL_GPU_CUDA_AVAILABLE 1
 #include <cuda_runtime.h>
 #include <cublas_v2.h>
+#include <cuda_fp16.h>
+#include <vector>
 
 // Forward declarations for real CUDA kernel launchers (in gpu_cuda_kernels.cu)
 extern "C" int cuda_launch_elementwise_f64(const double* a, const double* b, double* out,
@@ -247,6 +249,55 @@ static int cuda_matmul_f32(EshkolGPUBuffer* A, EshkolGPUBuffer* B, EshkolGPUBuff
 
     cudaStreamSynchronize(g_cuda_stream);
     return (status == CUBLAS_STATUS_SUCCESS) ? 0 : -1;
+}
+
+// f16 cuBLAS GemmEx (tensor cores) — the GPU-LLM fast path (ESH-0021).
+// Tensor storage is f64 bit patterns even for f16-dtype tensors, so we convert
+// f64 -> half on the host (CUDA __float2half is host-callable), run GemmEx with
+// 16F operands and 32F accumulate (the standard LLM combo), then convert the
+// f16 result back to f64. Mirrors cuda_matmul_f32's column-major swap: row-major
+// C = A·B is computed as cuBLAS column-major C^T(N×M) = B^T·A^T.
+// Returns 0 on success; any failure returns -1 so the caller falls back to f64.
+static int cuda_matmul_f16_from_f64(const double* A, const double* B, double* C,
+                                    uint64_t M, uint64_t K, uint64_t N) {
+    if (!g_cublas_handle || !A || !B || !C) return -1;
+    const size_t aN = (size_t)M * K, bN = (size_t)K * N, cN = (size_t)M * N;
+
+    std::vector<__half> hA(aN), hB(bN), hC(cN);
+    for (size_t i = 0; i < aN; i++) hA[i] = __float2half((float)A[i]);
+    for (size_t i = 0; i < bN; i++) hB[i] = __float2half((float)B[i]);
+
+    __half *dA = nullptr, *dB = nullptr, *dC = nullptr;
+    int rc = -1;
+    do {
+        if (cudaMalloc(&dA, aN * sizeof(__half)) != cudaSuccess) break;
+        if (cudaMalloc(&dB, bN * sizeof(__half)) != cudaSuccess) break;
+        if (cudaMalloc(&dC, cN * sizeof(__half)) != cudaSuccess) break;
+        if (cudaMemcpy(dA, hA.data(), aN * sizeof(__half), cudaMemcpyHostToDevice) != cudaSuccess) break;
+        if (cudaMemcpy(dB, hB.data(), bN * sizeof(__half), cudaMemcpyHostToDevice) != cudaSuccess) break;
+
+        const float alpha = 1.0f, beta = 0.0f;
+        cublasStatus_t st = cublasGemmEx(
+            g_cublas_handle, CUBLAS_OP_N, CUBLAS_OP_N,
+            (int)N, (int)M, (int)K,
+            &alpha,
+            dB, CUDA_R_16F, (int)N,
+            dA, CUDA_R_16F, (int)K,
+            &beta,
+            dC, CUDA_R_16F, (int)N,
+            CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+        if (st != CUBLAS_STATUS_SUCCESS) break;
+        if (cudaStreamSynchronize(g_cuda_stream) != cudaSuccess) break;
+        if (cudaMemcpy(hC.data(), dC, cN * sizeof(__half), cudaMemcpyDeviceToHost) != cudaSuccess) break;
+
+        for (size_t i = 0; i < cN; i++) C[i] = (double)__half2float(hC[i]);
+        rc = 0;
+    } while (0);
+
+    if (dA) cudaFree(dA);
+    if (dB) cudaFree(dB);
+    if (dC) cudaFree(dC);
+    return rc;
 }
 
 static int cuda_wrap_host(void* host_ptr, size_t size_bytes, EshkolGPUBuffer* out) {
@@ -532,8 +583,19 @@ int eshkol_gpu_should_use(size_t num_elements) {
 }
 
 void eshkol_matmul_dispatch(const double* A, const double* B, double* C,
-                             uint64_t M, uint64_t K, uint64_t N) {
+                             uint64_t M, uint64_t K, uint64_t N, int32_t dtype) {
     size_t num_elements = M * N;
+
+    // GPU-LLM fast path (ESH-0021): f16/bf16-dtype operands go through cuBLAS
+    // GemmEx (16F operands, 32F accumulate, tensor cores). Tensor-core GEMM
+    // wins even at modest sizes, so this bypasses the f64 element threshold.
+    // dtype codes: 2=f16, 3=bf16 (see eshkol_tensor_dtype_t).
+    if ((dtype == 2 || dtype == 3) && g_active_backend == ESHKOL_GPU_CUDA) {
+        if (cuda_matmul_f16_from_f64(A, B, C, M, K, N) == 0) {
+            return;
+        }
+        // GemmEx failed — fall through to the f64 path below.
+    }
 
     if (eshkol_gpu_should_use(num_elements)) {
         EshkolGPUBuffer buf_a{};

--- a/lib/backend/gpu/gpu_memory_stub.cpp
+++ b/lib/backend/gpu/gpu_memory_stub.cpp
@@ -338,8 +338,10 @@ int eshkol_gpu_normalize_f64(EshkolGPUBuffer* in, EshkolGPUBuffer* out,
 // ===== Runtime Integration =====
 
 void eshkol_matmul_dispatch(const double* A, const double* B, double* C,
-                             uint64_t M, uint64_t K, uint64_t N) {
-    // GPU not available — dispatch directly to BLAS/SIMD via eshkol_matmul_f64
+                             uint64_t M, uint64_t K, uint64_t N, int32_t /*dtype*/) {
+    // GPU not available — dispatch directly to BLAS/SIMD via eshkol_matmul_f64.
+    // dtype is ignored (no tensor-core path without a GPU); storage is already
+    // f64 precision-reduced for the logical dtype, so this stays correct.
     eshkol_matmul_f64(A, B, C, M, K, N);
 }
 

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -26012,15 +26012,22 @@ private:
                 builder->getPtrTy(),   // C
                 int64_type,            // M
                 int64_type,            // K
-                int64_type             // N
+                int64_type,            // N
+                builder->getInt32Ty()  // dtype (eshkol_tensor_dtype_t)
             };
             FunctionType* func_type = FunctionType::get(builder->getVoidTy(), params, false);
             matmul_func = Function::Create(func_type, Function::ExternalLinkage,
                                            "eshkol_matmul_dispatch", module.get());
         }
 
-        // Call the runtime matmul dispatch (routes to GPU or CPU BLAS)
-        builder->CreateCall(matmul_func, {a_elems, b_elems, c_elems, M, K, N});
+        // Result dtype (set by dtype propagation, ESH-0020) routes f16/bf16
+        // operands to the cuBLAS GemmEx tensor-core path (ESH-0021).
+        Value* mm_dtype_i64 = builder->CreateLoad(int64_type,
+            builder->CreateStructGEP(tensor_type, result_ptr, 4));
+        Value* mm_dtype = builder->CreateTrunc(mm_dtype_i64, builder->getInt32Ty());
+
+        // Call the runtime matmul dispatch (routes to GPU GemmEx / GPU / CPU BLAS)
+        builder->CreateCall(matmul_func, {a_elems, b_elems, c_elems, M, K, N, mm_dtype});
         if (after_matmul_compute) {
             builder->CreateBr(after_matmul_compute);
             builder->SetInsertPoint(after_matmul_compute);


### PR DESCRIPTION
## Summary
The GPU-LLM campaign's core perf win (brief §1/§2): `matmul` on **f16/bf16** tensors now dispatches to **cuBLAS GemmEx** (16F operands, 32F accumulate, tensor cores) on CUDA, instead of the ~10×-slower f64-softfloat path. Builds directly on the ESH-0020 dtype propagation.

## How
- **`cuda_matmul_f16_from_f64`** (gpu_memory_cuda.cpp): host f64→half conversion → `cublasGemmEx(CUDA_R_16F, …, CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP)` → half→f64 result. Mirrors the existing `cuda_matmul_f32` column-major swap (row-major C=A·B as cuBLAS C^T=B^T·A^T).
- **dtype-threaded dispatch**: `eshkol_matmul_dispatch` takes the result tensor's dtype (set by ESH-0020 propagation); f16/bf16 → GemmEx on CUDA (bypassing the f64 element threshold — tensor cores win at modest sizes too). All three backends (cuda/stub/metal) + header + `codegenMatmul` updated.
- Storage stays f64 bit patterns (ESH-0020 invariant); conversion happens at the GPU boundary. CUDA-only code is `#ifdef`-guarded — Metal/stub ignore dtype and keep the (correct) f64 path; a Metal f16-GEMM shader is a noted follow-up.

## Verified on real hardware (RTX 3090, cosbox)
- Compiles cleanly with nvcc/cuBLAS.
- CUDA GPU path active (gpu_diagnostic "GPU path tests" PASS at 50×50+).
- f16 tensor-core matmul correct: ones(64×64)→`64`; row-index pattern→`C[10,0]=704` (= 11×64); `tensor-dtype` of result = `f16`.

## No regression
- macOS build clean; f64 matmul unchanged (=12); GPU suite 13/13 on Metal.

## Follow-ups (campaign)
ESH-0024 batched GEMM (`cublasGemmStridedBatched` — the MoE multi-expert win), ESH-0025 q4_0/q8_0 quant, and the §5 runtime/compiler split for AOT GPU inference.