### PR TITLE
ESH-0024: batched f16/bf16 cuBLAS GemmStridedBatched (MoE multi-expert GEMM)

### DIFF
--- a/inc/eshkol/backend/gpu/gpu_memory.h
+++ b/inc/eshkol/backend/gpu/gpu_memory.h
@@ -466,6 +466,13 @@ int eshkol_gpu_layernorm_backward_f64(
 void eshkol_matmul_dispatch(const double* A, const double* B, double* C,
                              uint64_t M, uint64_t K, uint64_t N, int32_t dtype);
 
+/* Batched matmul dispatch (ESH-0024): `batch` independent GEMMs C[b]=A[b]·B[b].
+ * f16/bf16 take the cublasGemmStridedBatched tensor-core path on CUDA (one
+ * launch for all experts); other dtypes use the CPU batched f64 path. */
+void eshkol_batch_matmul_dispatch(const double* a, const double* b, double* c,
+                                  int64_t batch, int64_t M, int64_t K, int64_t N,
+                                  int32_t dtype);
+
 #ifdef __cplusplus
 }
 #endif

--- a/inc/eshkol/backend/gpu/gpu_memory.h
+++ b/inc/eshkol/backend/gpu/gpu_memory.h
@@ -460,8 +460,11 @@ int eshkol_gpu_layernorm_backward_f64(
  * @param K Columns of A / Rows of B
  * @param N Columns of B and C
  */
+/* dtype is the result tensor's element dtype (eshkol_tensor_dtype_t code:
+ * 0=f64, 1=f32, 2=f16, 3=bf16, 4=i8). f16/bf16 take the cuBLAS GemmEx
+ * tensor-core path on CUDA (ESH-0021); other dtypes use the f64 dispatch. */
 void eshkol_matmul_dispatch(const double* A, const double* B, double* C,
-                             uint64_t M, uint64_t K, uint64_t N);
+                             uint64_t M, uint64_t K, uint64_t N, int32_t dtype);
 
 #ifdef __cplusplus
 }

--- a/lib/backend/gpu/gpu_memory.mm
+++ b/lib/backend/gpu/gpu_memory.mm
@@ -3487,7 +3487,10 @@ int eshkol_gpu_should_use(size_t num_elements) {
 }
 
 void eshkol_matmul_dispatch(const double* A, const double* B, double* C,
-                             uint64_t M, uint64_t K, uint64_t N) {
+                             uint64_t M, uint64_t K, uint64_t N, int32_t /*dtype*/) {
+    // dtype currently ignored on Metal (no f16 tensor-core GEMM path yet; a
+    // Metal-shader f16 GEMM is a separate follow-up). Storage is already f64
+    // precision-reduced for the logical dtype, so the f64 path stays correct.
     // Lazy GPU init — ensures g_active_backend is set before threshold check
     if (!g_gpu_initialized.load(std::memory_order_acquire)) {
         eshkol_gpu_init();

--- a/lib/backend/gpu/gpu_memory.mm
+++ b/lib/backend/gpu/gpu_memory.mm
@@ -3526,6 +3526,16 @@ void eshkol_matmul_dispatch(const double* A, const double* B, double* C,
     eshkol_matmul_f64(A, B, C, M, K, N);
 }
 
+void eshkol_batch_matmul_dispatch(const double* a, const double* b, double* c,
+                                  int64_t batch, int64_t M, int64_t K, int64_t N,
+                                  int32_t /*dtype*/) {
+    // Metal: no f16 tensor-core batched GEMM path yet (follow-up); use the CPU
+    // batched f64 path. dtype ignored (storage already precision-reduced).
+    extern void eshkol_batch_matmul_f64(const double*, const double*, double*,
+                                        int64_t, int64_t, int64_t, int64_t);
+    eshkol_batch_matmul_f64(a, b, c, batch, M, K, N);
+}
+
 int eshkol_gpu_elementwise_f64(EshkolGPUBuffer* a, EshkolGPUBuffer* b,
                                 EshkolGPUBuffer* out, uint64_t n,
                                 EshkolElementwiseOp op) {

--- a/lib/backend/gpu/gpu_memory_cuda.cpp
+++ b/lib/backend/gpu/gpu_memory_cuda.cpp
@@ -300,6 +300,56 @@ static int cuda_matmul_f16_from_f64(const double* A, const double* B, double* C,
     return rc;
 }
 
+// Batched f16 cuBLAS GemmEx (tensor cores) — the MoE multi-expert win
+// (ESH-0024). Computes `batch` independent row-major GEMMs C[b]=A[b]·B[b] in a
+// single cublasGemmStridedBatchedEx launch (16F operands, 32F accumulate),
+// beating one launch per expert. Same f64<->half conversion + column-major swap
+// as cuda_matmul_f16_from_f64. Returns 0 on success, -1 on failure (caller
+// falls back to the CPU batched f64 path).
+static int cuda_batch_matmul_f16_from_f64(const double* a, const double* b, double* c,
+                                          int64_t batch, int64_t M, int64_t K, int64_t N) {
+    if (!g_cublas_handle || !a || !b || !c || batch <= 0) return -1;
+    const size_t aN = (size_t)batch * M * K;
+    const size_t bN = (size_t)batch * K * N;
+    const size_t cN = (size_t)batch * M * N;
+
+    std::vector<__half> hA(aN), hB(bN), hC(cN);
+    for (size_t i = 0; i < aN; i++) hA[i] = __float2half((float)a[i]);
+    for (size_t i = 0; i < bN; i++) hB[i] = __float2half((float)b[i]);
+
+    __half *dA = nullptr, *dB = nullptr, *dC = nullptr;
+    int rc = -1;
+    do {
+        if (cudaMalloc(&dA, aN * sizeof(__half)) != cudaSuccess) break;
+        if (cudaMalloc(&dB, bN * sizeof(__half)) != cudaSuccess) break;
+        if (cudaMalloc(&dC, cN * sizeof(__half)) != cudaSuccess) break;
+        if (cudaMemcpy(dA, hA.data(), aN * sizeof(__half), cudaMemcpyHostToDevice) != cudaSuccess) break;
+        if (cudaMemcpy(dB, hB.data(), bN * sizeof(__half), cudaMemcpyHostToDevice) != cudaSuccess) break;
+
+        const float alpha = 1.0f, beta = 0.0f;
+        cublasStatus_t st = cublasGemmStridedBatchedEx(
+            g_cublas_handle, CUBLAS_OP_N, CUBLAS_OP_N,
+            (int)N, (int)M, (int)K,
+            &alpha,
+            dB, CUDA_R_16F, (int)N, (long long)(K * N),
+            dA, CUDA_R_16F, (int)K, (long long)(M * K),
+            &beta,
+            dC, CUDA_R_16F, (int)N, (long long)(M * N),
+            (int)batch, CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+        if (st != CUBLAS_STATUS_SUCCESS) break;
+        if (cudaStreamSynchronize(g_cuda_stream) != cudaSuccess) break;
+        if (cudaMemcpy(hC.data(), dC, cN * sizeof(__half), cudaMemcpyDeviceToHost) != cudaSuccess) break;
+
+        for (size_t i = 0; i < cN; i++) c[i] = (double)__half2float(hC[i]);
+        rc = 0;
+    } while (0);
+
+    if (dA) cudaFree(dA);
+    if (dB) cudaFree(dB);
+    if (dC) cudaFree(dC);
+    return rc;
+}
+
 static int cuda_wrap_host(void* host_ptr, size_t size_bytes, EshkolGPUBuffer* out) {
     cudaError_t err = cudaHostRegister(host_ptr, size_bytes, cudaHostRegisterMapped);
     if (err == cudaSuccess) {
@@ -622,6 +672,24 @@ void eshkol_matmul_dispatch(const double* A, const double* B, double* C,
 
     extern void eshkol_matmul_f64(const double*, const double*, double*, uint64_t, uint64_t, uint64_t);
     eshkol_matmul_f64(A, B, C, M, K, N);
+}
+
+extern "C" void eshkol_batch_matmul_f64(const double*, const double*, double*,
+                                        int64_t, int64_t, int64_t, int64_t);
+
+// Batched matmul dispatch (ESH-0024). f16/bf16 + CUDA → strided GemmEx (one
+// launch for all `batch` GEMMs); else the CPU batched f64 path. dtype codes:
+// 2=f16, 3=bf16.
+void eshkol_batch_matmul_dispatch(const double* a, const double* b, double* c,
+                                  int64_t batch, int64_t M, int64_t K, int64_t N,
+                                  int32_t dtype) {
+    if ((dtype == 2 || dtype == 3) && g_active_backend == ESHKOL_GPU_CUDA) {
+        if (cuda_batch_matmul_f16_from_f64(a, b, c, batch, M, K, N) == 0) {
+            return;
+        }
+        // GemmStridedBatched failed — fall through to the f64 path.
+    }
+    eshkol_batch_matmul_f64(a, b, c, batch, M, K, N);
 }
 
 int eshkol_gpu_elementwise_f64(EshkolGPUBuffer* a, EshkolGPUBuffer* b,

--- a/lib/backend/gpu/gpu_memory_cuda.cpp
+++ b/lib/backend/gpu/gpu_memory_cuda.cpp
@@ -26,6 +26,8 @@
 #define ESHKOL_GPU_CUDA_AVAILABLE 1
 #include <cuda_runtime.h>
 #include <cublas_v2.h>
+#include <cuda_fp16.h>
+#include <vector>
 
 // Forward declarations for real CUDA kernel launchers (in gpu_cuda_kernels.cu)
 extern "C" int cuda_launch_elementwise_f64(const double* a, const double* b, double* out,
@@ -247,6 +249,55 @@ static int cuda_matmul_f32(EshkolGPUBuffer* A, EshkolGPUBuffer* B, EshkolGPUBuff
 
     cudaStreamSynchronize(g_cuda_stream);
     return (status == CUBLAS_STATUS_SUCCESS) ? 0 : -1;
+}
+
+// f16 cuBLAS GemmEx (tensor cores) — the GPU-LLM fast path (ESH-0021).
+// Tensor storage is f64 bit patterns even for f16-dtype tensors, so we convert
+// f64 -> half on the host (CUDA __float2half is host-callable), run GemmEx with
+// 16F operands and 32F accumulate (the standard LLM combo), then convert the
+// f16 result back to f64. Mirrors cuda_matmul_f32's column-major swap: row-major
+// C = A·B is computed as cuBLAS column-major C^T(N×M) = B^T·A^T.
+// Returns 0 on success; any failure returns -1 so the caller falls back to f64.
+static int cuda_matmul_f16_from_f64(const double* A, const double* B, double* C,
+                                    uint64_t M, uint64_t K, uint64_t N) {
+    if (!g_cublas_handle || !A || !B || !C) return -1;
+    const size_t aN = (size_t)M * K, bN = (size_t)K * N, cN = (size_t)M * N;
+
+    std::vector<__half> hA(aN), hB(bN), hC(cN);
+    for (size_t i = 0; i < aN; i++) hA[i] = __float2half((float)A[i]);
+    for (size_t i = 0; i < bN; i++) hB[i] = __float2half((float)B[i]);
+
+    __half *dA = nullptr, *dB = nullptr, *dC = nullptr;
+    int rc = -1;
+    do {
+        if (cudaMalloc(&dA, aN * sizeof(__half)) != cudaSuccess) break;
+        if (cudaMalloc(&dB, bN * sizeof(__half)) != cudaSuccess) break;
+        if (cudaMalloc(&dC, cN * sizeof(__half)) != cudaSuccess) break;
+        if (cudaMemcpy(dA, hA.data(), aN * sizeof(__half), cudaMemcpyHostToDevice) != cudaSuccess) break;
+        if (cudaMemcpy(dB, hB.data(), bN * sizeof(__half), cudaMemcpyHostToDevice) != cudaSuccess) break;
+
+        const float alpha = 1.0f, beta = 0.0f;
+        cublasStatus_t st = cublasGemmEx(
+            g_cublas_handle, CUBLAS_OP_N, CUBLAS_OP_N,
+            (int)N, (int)M, (int)K,
+            &alpha,
+            dB, CUDA_R_16F, (int)N,
+            dA, CUDA_R_16F, (int)K,
+            &beta,
+            dC, CUDA_R_16F, (int)N,
+            CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+        if (st != CUBLAS_STATUS_SUCCESS) break;
+        if (cudaStreamSynchronize(g_cuda_stream) != cudaSuccess) break;
+        if (cudaMemcpy(hC.data(), dC, cN * sizeof(__half), cudaMemcpyDeviceToHost) != cudaSuccess) break;
+
+        for (size_t i = 0; i < cN; i++) C[i] = (double)__half2float(hC[i]);
+        rc = 0;
+    } while (0);
+
+    if (dA) cudaFree(dA);
+    if (dB) cudaFree(dB);
+    if (dC) cudaFree(dC);
+    return rc;
 }
 
 static int cuda_wrap_host(void* host_ptr, size_t size_bytes, EshkolGPUBuffer* out) {
@@ -532,8 +583,19 @@ int eshkol_gpu_should_use(size_t num_elements) {
 }
 
 void eshkol_matmul_dispatch(const double* A, const double* B, double* C,
-                             uint64_t M, uint64_t K, uint64_t N) {
+                             uint64_t M, uint64_t K, uint64_t N, int32_t dtype) {
     size_t num_elements = M * N;
+
+    // GPU-LLM fast path (ESH-0021): f16/bf16-dtype operands go through cuBLAS
+    // GemmEx (16F operands, 32F accumulate, tensor cores). Tensor-core GEMM
+    // wins even at modest sizes, so this bypasses the f64 element threshold.
+    // dtype codes: 2=f16, 3=bf16 (see eshkol_tensor_dtype_t).
+    if ((dtype == 2 || dtype == 3) && g_active_backend == ESHKOL_GPU_CUDA) {
+        if (cuda_matmul_f16_from_f64(A, B, C, M, K, N) == 0) {
+            return;
+        }
+        // GemmEx failed — fall through to the f64 path below.
+    }
 
     if (eshkol_gpu_should_use(num_elements)) {
         EshkolGPUBuffer buf_a{};

--- a/lib/backend/gpu/gpu_memory_stub.cpp
+++ b/lib/backend/gpu/gpu_memory_stub.cpp
@@ -338,8 +338,10 @@ int eshkol_gpu_normalize_f64(EshkolGPUBuffer* in, EshkolGPUBuffer* out,
 // ===== Runtime Integration =====
 
 void eshkol_matmul_dispatch(const double* A, const double* B, double* C,
-                             uint64_t M, uint64_t K, uint64_t N) {
-    // GPU not available — dispatch directly to BLAS/SIMD via eshkol_matmul_f64
+                             uint64_t M, uint64_t K, uint64_t N, int32_t /*dtype*/) {
+    // GPU not available — dispatch directly to BLAS/SIMD via eshkol_matmul_f64.
+    // dtype is ignored (no tensor-core path without a GPU); storage is already
+    // f64 precision-reduced for the logical dtype, so this stays correct.
     eshkol_matmul_f64(A, B, C, M, K, N);
 }
 

--- a/lib/backend/gpu/gpu_memory_stub.cpp
+++ b/lib/backend/gpu/gpu_memory_stub.cpp
@@ -345,6 +345,17 @@ void eshkol_matmul_dispatch(const double* A, const double* B, double* C,
     eshkol_matmul_f64(A, B, C, M, K, N);
 }
 
+extern "C" void eshkol_batch_matmul_f64(const double*, const double*, double*,
+                                        int64_t, int64_t, int64_t, int64_t);
+
+void eshkol_batch_matmul_dispatch(const double* a, const double* b, double* c,
+                                  int64_t batch, int64_t M, int64_t K, int64_t N,
+                                  int32_t /*dtype*/) {
+    // No GPU — CPU batched f64 path (dtype ignored; storage already
+    // precision-reduced for the logical dtype).
+    eshkol_batch_matmul_f64(a, b, c, batch, M, K, N);
+}
+
 // ===== Backward Pass GPU Stubs =====
 
 int eshkol_gpu_conv2d_backward_input_f64(

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -26012,15 +26012,22 @@ private:
                 builder->getPtrTy(),   // C
                 int64_type,            // M
                 int64_type,            // K
-                int64_type             // N
+                int64_type,            // N
+                builder->getInt32Ty()  // dtype (eshkol_tensor_dtype_t)
             };
             FunctionType* func_type = FunctionType::get(builder->getVoidTy(), params, false);
             matmul_func = Function::Create(func_type, Function::ExternalLinkage,
                                            "eshkol_matmul_dispatch", module.get());
         }
 
-        // Call the runtime matmul dispatch (routes to GPU or CPU BLAS)
-        builder->CreateCall(matmul_func, {a_elems, b_elems, c_elems, M, K, N});
+        // Result dtype (set by dtype propagation, ESH-0020) routes f16/bf16
+        // operands to the cuBLAS GemmEx tensor-core path (ESH-0021).
+        Value* mm_dtype_i64 = builder->CreateLoad(int64_type,
+            builder->CreateStructGEP(tensor_type, result_ptr, 4));
+        Value* mm_dtype = builder->CreateTrunc(mm_dtype_i64, builder->getInt32Ty());
+
+        // Call the runtime matmul dispatch (routes to GPU GemmEx / GPU / CPU BLAS)
+        builder->CreateCall(matmul_func, {a_elems, b_elems, c_elems, M, K, N, mm_dtype});
         if (after_matmul_compute) {
             builder->CreateBr(after_matmul_compute);
             builder->SetInsertPoint(after_matmul_compute);

--- a/lib/backend/tensor_extras_codegen.cpp
+++ b/lib/backend/tensor_extras_codegen.cpp
@@ -1885,18 +1885,28 @@ llvm::Value* TensorCodegen::batchMatmul(const eshkol_operations_t* op) {
         llvm::ConstantInt::get(ctx_.int64Type(), (int64_t)sizeof(double)));
     llvm::Value* result_elems = builder.CreateCall(arena_alloc, {arena_ptr, elems_bytes}, "bmm_elems");
 
-    // Call C runtime: void eshkol_batch_matmul_f64(
+    // Propagate element dtype to the result so f16/bf16 batched matmul takes
+    // the cublasGemmStridedBatched tensor-core path (ESH-0024).
+    emitDtypePropagateBinary(result_ptr, a_ptr, b_ptr);
+    llvm::Type* tt_bmm = ctx_.tensorType();
+    llvm::Value* bmm_dtype = builder.CreateTrunc(
+        builder.CreateLoad(ctx_.int64Type(),
+            builder.CreateStructGEP(tt_bmm, result_ptr, 4)),
+        ctx_.int32Type());
+
+    // Call C runtime: void eshkol_batch_matmul_dispatch(
     //     const double* a, const double* b, double* c,
-    //     int64_t batch, int64_t M, int64_t K, int64_t N)
+    //     int64_t batch, int64_t M, int64_t K, int64_t N, int32_t dtype)
     auto* bmm_ft = llvm::FunctionType::get(ctx_.voidType(),
         {ctx_.ptrType(), ctx_.ptrType(), ctx_.ptrType(),
-         ctx_.int64Type(), ctx_.int64Type(), ctx_.int64Type(), ctx_.int64Type()}, false);
-    llvm::Function* bmm_fn = ctx_.module().getFunction("eshkol_batch_matmul_f64");
+         ctx_.int64Type(), ctx_.int64Type(), ctx_.int64Type(), ctx_.int64Type(),
+         ctx_.int32Type()}, false);
+    llvm::Function* bmm_fn = ctx_.module().getFunction("eshkol_batch_matmul_dispatch");
     if (!bmm_fn) {
         bmm_fn = llvm::Function::Create(bmm_ft, llvm::Function::ExternalLinkage,
-            "eshkol_batch_matmul_f64", &ctx_.module());
+            "eshkol_batch_matmul_dispatch", &ctx_.module());
     }
-    builder.CreateCall(bmm_fn, {a_elems, b_elems, result_elems, batch, M_dim, K_dim, N_dim});
+    builder.CreateCall(bmm_fn, {a_elems, b_elems, result_elems, batch, M_dim, K_dim, N_dim, bmm_dtype});
 
     // Populate result tensor struct
     llvm::Type* tensor_type = ctx_.tensorType();


### PR DESCRIPTION
## Summary
`batch-matmul` on f16/bf16 tensors now runs all `batch` GEMMs in a **single `cublasGemmStridedBatchedEx` launch** (16F operands, 32F accumulate, tensor cores) instead of one launch per matrix — the MoE multi-expert win (8 experts × N rows in one launch beats 1440). Stacks on ESH-0021 (#33).

## How
- **`cuda_batch_matmul_f16_from_f64`** (gpu_memory_cuda.cpp): f64→half, one `cublasGemmStridedBatchedEx` over the whole batch (strides M·K / K·N / M·N), half→f64. Same column-major swap as the single GemmEx.
- **`eshkol_batch_matmul_dispatch`**: f16/bf16 + CUDA → strided GemmEx, else the CPU batched f64 path. stub/Metal ignore dtype (Metal batched-f16 shader is a follow-up).
- **codegen**: `batch-matmul` propagates the operands' dtype to the result and threads it into the dispatch (same pattern as ESH-0021).

## Verified on RTX 3090 (cosbox)
- Compiles cleanly; batched f16 matmul correct across all batches: `(batch-matmul f16 f16)` of 4×ones(8×8) → every element `8`, `dtype=f16` (incl. last batch/last element → strided launch covers all batches).

## No regression
- macOS build clean; batch-matmul dtype propagates (f64→f64, f16→f16); CUDA-only code `#ifdef`-guarded.

Note: stacked on #33 — diff collapses to the ESH-0024 changes once #33 merges.