### PR TITLE
fix(ad): multi-variable gradient on a list input (SIGSEGV)

### DIFF
--- a/lib/backend/autodiff_codegen.cpp
+++ b/lib/backend/autodiff_codegen.cpp
@@ -2219,6 +2219,41 @@ llvm::Value* AutodiffCodegen::codegenDerivativeMonolith(const eshkol_operations_
 }
 
 
+// Robustly determine the differentiable (value) arity of a resolved gradient
+// target function. The gradient call sites below decide whether to pass the
+// whole dual vector as ONE argument (vector-input functions) or to unpack N
+// individual dual elements (multi-parameter functions). They originally relied
+// solely on function_arity_table_, but that lookup is unreliable: a reverse-mode
+// variant is regenerated on every gradient call (e.g. g-sum-sq__rv393) and its
+// base key may never be registered, so the lookup returns 0/1 and a 2-arg
+// function gets called with a single arg — LLVM rejects it with "Incorrect
+// number of arguments passed to called function!".
+//
+// The concrete llvm::Function signature is the source of truth. Captures are
+// appended last by resolveGradientCaptures and carry a "captured_" name prefix,
+// so the leading non-capture params are exactly the differentiable value params:
+//   - no captures      -> every LLVM param is a value param (use getNumParams)
+//   - captures present  -> trust the arity table (which excludes captures), and
+//                          fall back to the leading non-capture count if the
+//                          table missed.
+static uint64_t adResolveValueArity(llvm::Function* func_ptr, uint64_t table_arity) {
+    if (!func_ptr) return table_arity;
+    uint64_t leading_non_capture = 0;
+    bool saw_capture = false;
+    for (auto& arg : func_ptr->args()) {
+        if (std::string(arg.getName()).rfind("captured_", 0) == 0) { saw_capture = true; break; }
+        ++leading_non_capture;
+    }
+    if (!saw_capture) {
+        // No captures: every LLVM parameter is a differentiable value parameter.
+        return func_ptr->getFunctionType()->getNumParams();
+    }
+    // Captures present: the arity table excludes captures and is authoritative;
+    // fall back to the leading non-capture param count only when it missed.
+    return table_arity ? table_arity : leading_non_capture;
+}
+
+
 llvm::Value* AutodiffCodegen::gradientHigherOrder(const eshkol_operations_t* op) {
     using namespace llvm;
 
@@ -3143,8 +3178,43 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
     Value* grad_subtype = ctx_.builder().CreateLoad(ctx_.int8Type(), grad_header_ptr);
     Value* is_vec_subtype_grad = ctx_.builder().CreateICmpEQ(grad_subtype, ConstantInt::get(ctx_.int8Type(), HEAP_SUBTYPE_VECTOR));
     Value* is_tensor_subtype_grad = ctx_.builder().CreateICmpEQ(grad_subtype, ConstantInt::get(ctx_.int8Type(), HEAP_SUBTYPE_TENSOR));
+    Value* is_cons_subtype_grad = ctx_.builder().CreateICmpEQ(grad_subtype, ConstantInt::get(ctx_.int8Type(), HEAP_SUBTYPE_CONS));
+    BasicBlock* grad_check_cons = BasicBlock::Create(ctx_.context(), "grad_check_cons", current_func);
+    BasicBlock* grad_list_to_svec = BasicBlock::Create(ctx_.context(), "grad_list_to_svec", current_func);
     BasicBlock* grad_check_tensor = BasicBlock::Create(ctx_.context(), "grad_check_tensor", current_func);
-    ctx_.builder().CreateCondBr(is_vec_subtype_grad, scheme_vector_input, grad_check_tensor);
+    ctx_.builder().CreateCondBr(is_vec_subtype_grad, scheme_vector_input, grad_check_cons);
+
+    // A (list …) input is a cons cell (HEAP_SUBTYPE_CONS): convert it to a
+    // Scheme vector so it goes through the same path as a (vector …) input.
+    // Without this, a multi-parameter gradient on a list crashed — the cons
+    // cell fell through to the vector path and was misread as [length][elems].
+    ctx_.builder().SetInsertPoint(grad_check_cons);
+    ctx_.builder().CreateCondBr(is_cons_subtype_grad, grad_list_to_svec, grad_check_tensor);
+
+    ctx_.builder().SetInsertPoint(grad_list_to_svec);
+    {
+        // Entry-block alloca for the list head so a gradient inside a runtime
+        // loop doesn't re-allocate each iteration.
+        llvm::IRBuilder<> entryB(&current_func->getEntryBlock(),
+                                 current_func->getEntryBlock().begin());
+        Value* list_slot = entryB.CreateAlloca(ctx_.taggedValueType(), nullptr, "grad_list_head");
+        ctx_.builder().CreateStore(vector_val, list_slot);
+        Value* l2s_arena = ctx_.builder().CreateLoad(
+            PointerType::getUnqual(ctx_.context()), ctx_.globalArena());
+        llvm::Function* l2s_fn = ctx_.module().getFunction("eshkol_list_to_svec");
+        if (!l2s_fn) {
+            llvm::FunctionType* l2s_ty = llvm::FunctionType::get(
+                ctx_.builder().getPtrTy(),
+                {ctx_.builder().getPtrTy(), ctx_.builder().getPtrTy()}, false);
+            l2s_fn = llvm::Function::Create(l2s_ty, llvm::Function::ExternalLinkage,
+                "eshkol_list_to_svec", &ctx_.module());
+        }
+        Value* svec_from_list = ctx_.builder().CreateCall(l2s_fn, {l2s_arena, list_slot});
+        Value* svec_from_list_int = ctx_.builder().CreatePtrToInt(svec_from_list, ctx_.int64Type());
+        Value* svec_from_list_tagged = tagged_.packPtr(svec_from_list_int, ESHKOL_VALUE_HEAP_PTR);
+        ctx_.builder().CreateStore(svec_from_list_tagged, svec_input_ptr);
+        ctx_.builder().CreateBr(scheme_vector_input);
+    }
 
     // Check for TENSOR subtype — convert to Scheme vector ONLY for multi-param functions.
     // For single-param functions, tensor input works correctly with reverse-mode AD.
@@ -3399,6 +3469,9 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
         if (svec_arity_it != function_arity_table_->end()) {
             svec_func_arity = svec_arity_it->second;
         }
+        // Trust the resolved function signature over the (regeneration-fragile)
+        // arity table so multi-param functions are not called with one arg.
+        svec_func_arity = adResolveValueArity(func_ptr, svec_func_arity);
         if (svec_func_arity > 1) {
             // Multi-param: unpack dual vector elements as individual tagged value args
             for (uint64_t p = 0; p < svec_func_arity; p++) {
@@ -3851,6 +3924,9 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
         if (scalar_arity_it != function_arity_table_->end()) {
             scalar_func_arity = scalar_arity_it->second;
         }
+        // Trust the resolved function signature over the (regeneration-fragile)
+        // arity table so multi-param functions are not called with one arg.
+        scalar_func_arity = adResolveValueArity(func_ptr, scalar_func_arity);
         if (scalar_func_arity > 1) {
             // Multi-param function on scalar path: pass all AD nodes as individual args
             for (uint64_t p = 0; p < scalar_func_arity; p++) {
@@ -3920,6 +3996,9 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
     if (arity_it != function_arity_table_->end()) {
         func_arity = arity_it->second;
     }
+    // Trust the resolved function signature over the (regeneration-fragile)
+    // arity table so multi-param functions are not called with one arg.
+    func_arity = adResolveValueArity(func_ptr, func_arity);
 
     if (func_arity > 1) {
         // Multi-parameter function: unpack AD tensor elements as individual tagged args

--- a/lib/core/runtime_list_helpers.cpp
+++ b/lib/core/runtime_list_helpers.cpp
@@ -73,6 +73,41 @@ void eshkol_list_reverse_tagged(arena_t* arena,
     }
 }
 
+// Convert a tagged cons-list to a Scheme vector (HEAP_SUBTYPE_VECTOR) so the
+// gradient/jacobian dispatch can treat a (list …) input identically to a
+// (vector …) input. Multi-parameter reverse/forward-mode gradient previously
+// SIGSEGV'd on a list input because the cons cell fell through to the vector
+// path and was misread as [length][elements]. Returns the vector DATA pointer
+// (length at offset 0, 16-byte tagged elements at offset 8; header with
+// HEAP_SUBTYPE_VECTOR at -8), or nullptr on failure. The list head is passed
+// by pointer (ABI-safe: avoids 16-byte struct-by-value across the C boundary).
+void* eshkol_list_to_svec(arena_t* arena, const eshkol_tagged_value_t* head_tv) {
+    if (!arena || !head_tv) return nullptr;
+
+    int64_t n = 0;
+    eshkol_tagged_value_t cur = *head_tv;
+    while (tagged_is_cons(&cur)) {
+        n++;
+        cur = ((arena_tagged_cons_cell_t*)(uintptr_t)cur.data.ptr_val)->cdr;
+    }
+
+    void* vec = arena_allocate_vector_with_header(arena, (size_t)n);
+    if (!vec) return nullptr;
+    *(int64_t*)vec = n;  // length at offset 0
+    eshkol_tagged_value_t* elems =
+        (eshkol_tagged_value_t*)((char*)vec + sizeof(int64_t));
+
+    cur = *head_tv;
+    int64_t i = 0;
+    while (tagged_is_cons(&cur) && i < n) {
+        arena_tagged_cons_cell_t* cell =
+            (arena_tagged_cons_cell_t*)(uintptr_t)cur.data.ptr_val;
+        elems[i++] = cell->car;
+        cur = cell->cdr;
+    }
+    return vec;
+}
+
 // ===== STACK OVERFLOW PROTECTION =====
 
 // Per-thread recursion depth counter.


### PR DESCRIPTION
## Summary
Fixes the blocker from `AD_MULTIVAR_GRADIENT_BUG.md`: `(gradient (lambda (x y) (+ (* x x) (* y y))) (list 3.0 4.0))` SIGSEGV'd. Scalar gradient, `derivative`, and **vector**-input multi-param gradient already worked — only a **list** input crashed.

## Root cause
A `(list …)` input is a cons cell (`HEAP_PTR` + `HEAP_SUBTYPE_CONS`), which is neither `VECTOR` nor `TENSOR`, so the gradient input dispatch fell through to the vector path and misread the cons cell as `[length][elements]` → null+8 deref (`EXC_BAD_ACCESS address=0x8`).

## Fix
- **Layer 1 (arity)** — `adResolveValueArity()` derives the differentiable value-arity from the concrete `llvm::Function` signature (leading non-`captured_` params) instead of the regeneration-fragile `function_arity_table_` (a reverse-mode variant `g__rv<n>` regenerates per call and misses the base key → a 2-arg fn called with one packed arg → LLVM verifier error). Applied at gradient's 3 call sites. *(Incorporates the partial patch left in the bug report's worktree.)*
- **Layer 2 (the crash)** — new runtime `eshkol_list_to_svec` walks the cons chain into a Scheme vector; the gradient dispatch gains a `HEAP_SUBTYPE_CONS` branch that converts a list input and routes it through the working `scheme_vector_input` path (the exact path a vector input takes).

## Verified
- `(gradient fsq (list 3.0 4.0))` → `#(6 8)`, repro's end marker prints (no crash)
- scalar gradient/derivative + vector-input multi-param gradient unchanged
- **autodiff suite 54/54**, no regression

## Remaining for the full `vm_ad_test.esk` gate (scoped follow-up)
`laplacian`/`hessian`/`directional-derivative` on **multi-parameter** functions (e.g. 3-arg `g-sum-sq`) still need the same treatment: hessian passes the input as a single tensor arg (fine for single-param vector functions, wrong for multi-param), and — per the existing code comment — reverse-mode passing AD-nodes as separate args crashes dispatch, so they need the **forward-mode rework** gradient already has. This is a larger, separate change; this PR fixes the primary gradient blocker that Noesis `core/01-tape` (∇loss over many params) depends on.