### PR TITLE
ESH-0025b: dequant-q4_0 / dequant-q8_0 builtins (bytevector → tensor)

### DIFF
--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -1677,6 +1677,8 @@ public:
         function_return_types["bytevector-u8-ref"] = BuiltinTypes::Int64;
         function_return_types["bytevector-copy"] = BuiltinTypes::Value;
         function_return_types["bytevector-append"] = BuiltinTypes::Value;
+        function_return_types["dequant-q4_0"] = BuiltinTypes::Tensor;
+        function_return_types["dequant-q8_0"] = BuiltinTypes::Tensor;
         function_return_types["bytevector?"] = BuiltinTypes::Boolean;
         function_return_types["utf8->string"] = BuiltinTypes::String;
         function_return_types["string->utf8"] = BuiltinTypes::Value;
@@ -14748,6 +14750,54 @@ private:
             return packNullToTaggedValue();
         }
 
+        if (func_name == "dequant-q4_0" || func_name == "dequant-q8_0") {
+            // (dequant-q4_0 bytevector n) / (dequant-q8_0 bytevector n)
+            // Dequantize n weights of GGUF q4_0/q8_0 blocks (held in a
+            // bytevector) into a 1-D f64 tensor — lets Eshkol consume Kimi's
+            // quantized weights directly, feeding the f16 GemmEx path.
+            if (op->call_op.num_vars != 2) {
+                eshkol_error("%s requires (bytevector count)", func_name.c_str());
+                return nullptr;
+            }
+            TypedValue bv_tv = codegenTypedAST(&op->call_op.variables[0]);
+            TypedValue n_tv  = codegenTypedAST(&op->call_op.variables[1]);
+            if (!bv_tv.llvm_value || !n_tv.llvm_value) return nullptr;
+            Value* bv = typedValueToTaggedValue(bv_tv);
+            Value* n  = unpackInt64FromTaggedValue(typedValueToTaggedValue(n_tv));
+            Value* bv_ptr = builder->CreateIntToPtr(
+                builder->CreateExtractValue(bv, {4}), PointerType::getUnqual(*context));
+            // Bytevector data lives after the 8-byte length header.
+            Value* blocks = builder->CreateGEP(int8_type, bv_ptr,
+                ConstantInt::get(int64_type, 8));
+
+            Value* arena_ptr = builder->CreateLoad(PointerType::getUnqual(*context), global_arena);
+            Value* tensor = builder->CreateCall(mem->getArenaAllocateTensorWithHeader(), {arena_ptr});
+            // 1-D dims = [n]
+            Value* dims = builder->CreateCall(mem->getArenaAllocate(),
+                {arena_ptr, ConstantInt::get(int64_type, sizeof(uint64_t))});
+            builder->CreateStore(n, dims);
+            builder->CreateStore(dims, builder->CreateStructGEP(tensor_type, tensor, 0));
+            builder->CreateStore(ConstantInt::get(int64_type, 1),
+                builder->CreateStructGEP(tensor_type, tensor, 1));
+            builder->CreateStore(n, builder->CreateStructGEP(tensor_type, tensor, 3));
+            // elements: n int64 (double bit patterns)
+            Value* elems_size = builder->CreateMul(n, ConstantInt::get(int64_type, sizeof(int64_t)));
+            Value* elems = builder->CreateCall(mem->getArenaAllocate(), {arena_ptr, elems_size});
+            builder->CreateStore(elems, builder->CreateStructGEP(tensor_type, tensor, 2));
+            // void eshkol_dequant_q4_0/q8_0(const uint8_t* blocks, int64_t* out, int64_t n)
+            const char* rt = (func_name == "dequant-q4_0") ? "eshkol_dequant_q4_0"
+                                                           : "eshkol_dequant_q8_0";
+            Function* deq = module->getFunction(rt);
+            if (!deq) {
+                FunctionType* ft = FunctionType::get(builder->getVoidTy(),
+                    {PointerType::getUnqual(*context), PointerType::getUnqual(*context), int64_type}, false);
+                deq = Function::Create(ft, Function::ExternalLinkage, rt, module.get());
+            }
+            builder->CreateCall(deq, {blocks, elems, n});
+            Value* t_int = builder->CreatePtrToInt(tensor, int64_type);
+            return packPtrToTaggedValue(t_int, ESHKOL_VALUE_HEAP_PTR);
+        }
+
         if (func_name == "bytevector?") {
             TypedValue tv = codegenTypedAST(&op->call_op.variables[0]);
             if (!tv.llvm_value) return nullptr;
@@ -22238,6 +22288,7 @@ private:
             "bytevector-u8-ref", "bytevector-u8-set!",
             "bytevector-copy", "bytevector-copy!", "bytevector-append",
             "bytevector?", "utf8->string", "string->utf8",
+            "dequant-q4_0", "dequant-q8_0",
             // System
             "exit", "emergency-exit", "command-line",
             "getenv", "get-environment-variable",

--- a/tests/quant/dequant_test.esk
+++ b/tests/quant/dequant_test.esk
@@ -1,0 +1,34 @@
+;;; GGUF q4_0/q8_0 dequant builtin tests (ESH-0025b)
+(define pass-count 0)
+(define fail-count 0)
+(define (check name got expect)
+  (if (= got expect)
+      (begin (set! pass-count (+ pass-count 1)) (display "PASS: ") (display name) (newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "FAIL: ") (display name) (display " got ") (display got)
+             (display " expect ") (display expect) (newline))))
+
+;; q8_0: 2-byte f16 scale + 32 int8.  d=1.0 = 0x3C00 (LE 0x00,0x3C)
+(define bv8 (make-bytevector 34 0))
+(bytevector-u8-set! bv8 1 #x3C)
+(bytevector-u8-set! bv8 2 5)
+(bytevector-u8-set! bv8 3 10)
+(bytevector-u8-set! bv8 4 100)
+(define t8 (dequant-q8_0 bv8 32))
+(check "q8_0 d=1 q[0]=5"   (tensor-ref t8 0) 5)
+(check "q8_0 d=1 q[1]=10"  (tensor-ref t8 1) 10)
+(check "q8_0 d=1 q[2]=100" (tensor-ref t8 2) 100)
+(bytevector-u8-set! bv8 1 #x40)   ; d=2.0
+(define t8b (dequant-q8_0 bv8 32))
+(check "q8_0 d=2 q[0]=10"  (tensor-ref t8b 0) 10)
+(check "q8_0 d=2 q[2]=200" (tensor-ref t8b 2) 200)
+
+;; q4_0: 2-byte d + 16 packed-nibble bytes.  x[j]=d*((qs&0xF)-8), x[j+16]=d*((qs>>4)-8)
+(define bv4 (make-bytevector 18 0))
+(bytevector-u8-set! bv4 1 #x3C)   ; d=1.0
+(bytevector-u8-set! bv4 2 #x3C)   ; low=12 -> x0=4 ; high=3 -> x16=-5
+(define t4 (dequant-q4_0 bv4 32))
+(check "q4_0 low nibble x[0]=4"   (tensor-ref t4 0) 4)
+(check "q4_0 high nibble x[16]=-5" (tensor-ref t4 16) -5)
+
+(display "=== dequant: ")(display pass-count)(display " passed, ")(display fail-count)(display " failed ===")(newline)


### PR DESCRIPTION
## Summary
User-callable dequant builtins wiring the merged GGUF dequant runtime (ESH-0025, #36) so Eshkol can consume Kimi's quantized weights directly:
```scheme
(dequant-q4_0 bytevector n)  ; n weights of q4_0 blocks -> 1-D f64 tensor
(dequant-q8_0 bytevector n)
```

## How
The bytevector holds the packed GGUF block layout (the byte buffer an mmap'd weight tensor exposes). Codegen reads its data (past the 8-byte length header), allocates an n-element f64 tensor, and calls `eshkol_dequant_q4_0/q8_0` into the element buffer. The result feeds the f16 cuBLAS GemmEx path (ESH-0021). Registered in `function_return_types` (Tensor), the known-builtins list, and the bytevector codegen dispatch.

## Verified
`tests/quant/dequant_test.esk` → **7/7 PASS**: q8_0 (d=1.0 → [5,10,100]; d=2.0 → [10,20,200]), q4_0 low/high nibble unpack with −8 offset (x[0]=4, x[16]=−5).

## Follow-up
GGUF mmap loader (zero-copy FFI byte buffer + offset) and in-kernel dequant GEMM.