### PR TITLE
fix: close 5 P0 memory-safety / UB ship-blockers (production audit)

### DIFF
--- a/lib/backend/arithmetic_codegen.cpp
+++ b/lib/backend/arithmetic_codegen.cpp
@@ -2367,6 +2367,19 @@ llvm::Value* ArithmeticCodegen::remainder(llvm::Value* dividend, llvm::Value* di
 
     // Safe integer remainder
     ctx_.builder().SetInsertPoint(int_safe_bb);
+    // Audit M4 (P0): INT64_MIN % -1 is undefined behavior in LLVM (SIGFPE on
+    // x86). The mathematical remainder is 0, and SRem(x, 1) == 0, so sanitize
+    // the divisor to 1 in exactly that case — no UB op is ever emitted and the
+    // result is correct. All other inputs are unchanged.
+    {
+        llvm::Value* rem_is_min = ctx_.builder().CreateICmpEQ(a_int,
+            llvm::ConstantInt::get(ctx_.int64Type(), INT64_MIN));
+        llvm::Value* rem_is_neg1 = ctx_.builder().CreateICmpEQ(b_int,
+            llvm::ConstantInt::get(ctx_.int64Type(), -1));
+        b_int = ctx_.builder().CreateSelect(
+            ctx_.builder().CreateAnd(rem_is_min, rem_is_neg1),
+            llvm::ConstantInt::get(ctx_.int64Type(), 1), b_int);
+    }
     llvm::Value* int_result = ctx_.builder().CreateSRem(a_int, b_int, "srem_result");
     llvm::Value* int_tagged = tagged_.packInt64(int_result, true);
     ctx_.builder().CreateBr(merge);
@@ -2505,6 +2518,19 @@ llvm::Value* ArithmeticCodegen::quotient(llvm::Value* dividend, llvm::Value* div
 
     // Safe integer division
     ctx_.builder().SetInsertPoint(int_safe_bb);
+    // Audit M4 (P0): INT64_MIN / -1 is undefined behavior in LLVM (SIGFPE on
+    // x86; the true quotient 2^63 is unrepresentable). Sanitize the divisor to 1
+    // in that single case so no UB op is emitted; SDiv(INT64_MIN, 1) == INT64_MIN,
+    // the defined 2's-complement wrapped result. All other inputs unchanged.
+    {
+        llvm::Value* q_is_min = ctx_.builder().CreateICmpEQ(a_int,
+            llvm::ConstantInt::get(ctx_.int64Type(), INT64_MIN));
+        llvm::Value* q_is_neg1 = ctx_.builder().CreateICmpEQ(b_int,
+            llvm::ConstantInt::get(ctx_.int64Type(), -1));
+        b_int = ctx_.builder().CreateSelect(
+            ctx_.builder().CreateAnd(q_is_min, q_is_neg1),
+            llvm::ConstantInt::get(ctx_.int64Type(), 1), b_int);
+    }
     llvm::Value* int_result = ctx_.builder().CreateSDiv(a_int, b_int, "sdiv_result");
     llvm::Value* int_tagged = tagged_.packInt64(int_result, true);
     ctx_.builder().CreateBr(merge);

--- a/lib/backend/eshkol_compiler.c
+++ b/lib/backend/eshkol_compiler.c
@@ -3925,9 +3925,19 @@ static void execute_chunk(FuncChunk* chunk) {
             int count = ins.operand;
             int32_t ptr = HALLOC(); if (ptr < 0) break;
             heap[ptr].type = HEAP_VECTOR;
-            heap[ptr].vector.len = count;
-            for (int i = count - 1; i >= 0; i--)
-                heap[ptr].vector.items[i] = POP();
+            /* P0: vector.items[] is a fixed 64-slot inline array. `count` comes
+               straight from the instruction operand, so a vector/struct literal
+               with >64 elements would write past items[] into the next heap
+               object. Clamp the stored count to capacity; still POP the full
+               count so the operand stack stays balanced. */
+            const int cap = (int)(sizeof(heap[ptr].vector.items) /
+                                  sizeof(heap[ptr].vector.items[0]));
+            int stored = count > cap ? cap : count;
+            heap[ptr].vector.len = stored;
+            for (int i = count - 1; i >= 0; i--) {
+                Value v = POP();
+                if (i < stored) heap[ptr].vector.items[i] = v;
+            }
             PUSH(((Value){.type=VAL_VECTOR,.as.ptr=ptr}));
             break;
         }

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -5178,7 +5178,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 502: { /* unify(subst, a, b) — bind a to b in substitution (copy-on-extend) */
         Value b_val = vm_pop(vm), a_val = vm_pop(vm), s_val = vm_pop(vm);
-        if (s_val.as.ptr >= 0 && vm->heap.objects[s_val.as.ptr]->type == HEAP_SUBST) {
+        if (is_heap_type(vm, s_val, HEAP_SUBST)) {
             VmSubstitution* subst = (VmSubstitution*)vm->heap.objects[s_val.as.ptr]->opaque.ptr;
             if (subst && a_val.type == VAL_INT) {
                 /* Treat a_val as logic var ID, bind it to b_val */
@@ -5224,7 +5224,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     case 503: { /* walk(term, subst) */
         Value subst_val = vm_pop(vm), term_val = vm_pop(vm);
         /* Walk resolves variables through substitution chains */
-        if (subst_val.as.ptr >= 0 && vm->heap.objects[subst_val.as.ptr]->type == HEAP_SUBST) {
+        if (is_heap_type(vm, subst_val, HEAP_SUBST)) {
             VmSubstitution* s = (VmSubstitution*)vm->heap.objects[subst_val.as.ptr]->opaque.ptr;
             if (s && term_val.type == VAL_INT) {
                 /* Check if term is a var_id that has a binding */
@@ -5251,7 +5251,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     case 504: { /* walk-deep — recursive walk through substitution chains */
         Value subst_val = vm_pop(vm), term_val = vm_pop(vm);
         /* Walk repeatedly until term no longer resolves */
-        if (subst_val.as.ptr >= 0 && vm->heap.objects[subst_val.as.ptr]->type == HEAP_SUBST) {
+        if (is_heap_type(vm, subst_val, HEAP_SUBST)) {
             VmSubstitution* s = (VmSubstitution*)vm->heap.objects[subst_val.as.ptr]->opaque.ptr;
             Value resolved = term_val;
             int depth = 0;
@@ -5295,7 +5295,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 511: { /* kb-assert!(kb, fact) — store fact in the KB */
         Value fact_val = vm_pop(vm), kb_val = vm_pop(vm);
-        if (kb_val.as.ptr >= 0 && vm->heap.objects[kb_val.as.ptr]->type == HEAP_KB) {
+        if (is_heap_type(vm, kb_val, HEAP_KB)) {
             VmKnowledgeBase* kb_obj = (VmKnowledgeBase*)vm->heap.objects[kb_val.as.ptr]->opaque.ptr;
             if (kb_obj && kb_obj->n_facts < kb_obj->capacity) {
                 VmFact* f = (VmFact*)vm_alloc(&vm->heap.regions, sizeof(VmFact));
@@ -5319,7 +5319,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
         Value pattern_datum;
         int has_pattern = vm_kb_extract_fact_datum(vm, pattern, &pattern_datum);
         if (!has_pattern) pattern_datum = pattern;
-        if (kb_val.as.ptr >= 0 && vm->heap.objects[kb_val.as.ptr]->type == HEAP_KB) {
+        if (is_heap_type(vm, kb_val, HEAP_KB)) {
             VmKnowledgeBase* kb_obj = (VmKnowledgeBase*)vm->heap.objects[kb_val.as.ptr]->opaque.ptr;
             if (kb_obj) {
                 Value result = NIL_VAL;
@@ -5386,7 +5386,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 522: { /* fg-add-factor!(fg, var_indices, cpt) */
         Value cpt = vm_pop(vm), vars = vm_pop(vm), fg_val = vm_pop(vm);
-        if (fg_val.as.ptr >= 0 && vm->heap.objects[fg_val.as.ptr]->type == HEAP_FACTOR_GRAPH) {
+        if (is_heap_type(vm, fg_val, HEAP_FACTOR_GRAPH)) {
             VmFactorGraph* fg = (VmFactorGraph*)vm->heap.objects[fg_val.as.ptr]->opaque.ptr;
             if (fg) {
                 /* Extract var_indices from either a tensor `#(0 1)` or a
@@ -5415,7 +5415,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
                 }
                 /* Extract CPT data from tensor or list */
                 double* cpt_data = NULL;
-                if (cpt.as.ptr >= 0 && vm->heap.objects[cpt.as.ptr]->type == HEAP_TENSOR) {
+                if (is_heap_type(vm, cpt, HEAP_TENSOR)) {
                     VmTensor* t = (VmTensor*)vm->heap.objects[cpt.as.ptr]->opaque.ptr;
                     if (t) cpt_data = t->data;
                 }
@@ -5436,7 +5436,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 523: { /* fg-infer!(fg, max_iters, tolerance) */
         Value tol = vm_pop(vm), iters = vm_pop(vm), fg_val = vm_pop(vm);
-        if (fg_val.as.ptr >= 0 && vm->heap.objects[fg_val.as.ptr]->type == HEAP_FACTOR_GRAPH) {
+        if (is_heap_type(vm, fg_val, HEAP_FACTOR_GRAPH)) {
             VmFactorGraph* fg = (VmFactorGraph*)vm->heap.objects[fg_val.as.ptr]->opaque.ptr;
             if (fg) {
                 int converged = vm_fg_infer(&vm->heap.regions, fg, (int)as_number(iters), as_number(tol));
@@ -5449,9 +5449,9 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 524: { /* fg-update-cpt!(fg, factor_idx, new_cpt_tensor) */
         Value cpt = vm_pop(vm), idx = vm_pop(vm), fg_val = vm_pop(vm);
-        if (fg_val.as.ptr >= 0 && vm->heap.objects[fg_val.as.ptr]->type == HEAP_FACTOR_GRAPH) {
+        if (is_heap_type(vm, fg_val, HEAP_FACTOR_GRAPH)) {
             VmFactorGraph* fg = (VmFactorGraph*)vm->heap.objects[fg_val.as.ptr]->opaque.ptr;
-            if (fg && cpt.as.ptr >= 0 && vm->heap.objects[cpt.as.ptr]->type == HEAP_TENSOR) {
+            if (fg && is_heap_type(vm, cpt, HEAP_TENSOR)) {
                 VmTensor* t = (VmTensor*)vm->heap.objects[cpt.as.ptr]->opaque.ptr;
                 if (t) vm_fg_update_cpt(fg, (int)as_number(idx), t->data, (int)t->total);
             }
@@ -5461,7 +5461,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 525: { /* free-energy(fg, observations) */
         Value obs = vm_pop(vm), fg_val = vm_pop(vm);
-        if (fg_val.as.ptr >= 0 && vm->heap.objects[fg_val.as.ptr]->type == HEAP_FACTOR_GRAPH) {
+        if (is_heap_type(vm, fg_val, HEAP_FACTOR_GRAPH)) {
             VmFactorGraph* fg = (VmFactorGraph*)vm->heap.objects[fg_val.as.ptr]->opaque.ptr;
             if (fg) {
                 /* Parse observations.  Canonical Eshkol form is a flat
@@ -5504,7 +5504,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 526: { /* expected-free-energy(fg, action_var, action_state) */
         Value state = vm_pop(vm), var = vm_pop(vm), fg_val = vm_pop(vm);
-        if (fg_val.as.ptr >= 0 && vm->heap.objects[fg_val.as.ptr]->type == HEAP_FACTOR_GRAPH) {
+        if (is_heap_type(vm, fg_val, HEAP_FACTOR_GRAPH)) {
             VmFactorGraph* fg = (VmFactorGraph*)vm->heap.objects[fg_val.as.ptr]->opaque.ptr;
             if (fg) {
                 double efe = vm_expected_free_energy(&vm->heap.regions, fg, (int)as_number(var), (int)as_number(state));
@@ -5521,7 +5521,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
                  * After observing, re-run fg-infer! to propagate the evidence.
                  * Ref: Standard factor graph evidence clamping (Kschischang et al. 2001). */
         Value state_val = vm_pop(vm), var_val = vm_pop(vm), fg_val = vm_pop(vm);
-        if (fg_val.as.ptr >= 0 && vm->heap.objects[fg_val.as.ptr]->type == HEAP_FACTOR_GRAPH) {
+        if (is_heap_type(vm, fg_val, HEAP_FACTOR_GRAPH)) {
             VmFactorGraph* fg = (VmFactorGraph*)vm->heap.objects[fg_val.as.ptr]->opaque.ptr;
             if (fg) {
                 int var_id = (int)as_number(var_val);
@@ -5568,7 +5568,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 542: { /* ws-register!(ws, name, closure) */
         Value closure = vm_pop(vm), name_val = vm_pop(vm), ws_val = vm_pop(vm);
-        if (ws_val.as.ptr >= 0 && vm->heap.objects[ws_val.as.ptr]->type == HEAP_WORKSPACE) {
+        if (is_heap_type(vm, ws_val, HEAP_WORKSPACE)) {
             VmWorkspace* ws = (VmWorkspace*)vm->heap.objects[ws_val.as.ptr]->opaque.ptr;
             if (ws) {
                 const char* name = "module";
@@ -5589,7 +5589,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 543: { /* ws-step!(ws) — invoke module closures via closure bridge */
         Value ws_val = vm_pop(vm);
-        if (ws_val.as.ptr >= 0 && vm->heap.objects[ws_val.as.ptr]->type == HEAP_WORKSPACE) {
+        if (is_heap_type(vm, ws_val, HEAP_WORKSPACE)) {
             VmWorkspace* ws = (VmWorkspace*)vm->heap.objects[ws_val.as.ptr]->opaque.ptr;
             if (ws && ws->content) {
                 /* Build content tensor */
@@ -5640,7 +5640,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 544: { /* ws-get-content */
         Value ws_val = vm_pop(vm);
-        if (ws_val.as.ptr >= 0 && vm->heap.objects[ws_val.as.ptr]->type == HEAP_WORKSPACE) {
+        if (is_heap_type(vm, ws_val, HEAP_WORKSPACE)) {
             VmWorkspace* ws = (VmWorkspace*)vm->heap.objects[ws_val.as.ptr]->opaque.ptr;
             if (ws && ws->content) {
                 /* Return content as tensor */
@@ -5662,8 +5662,8 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 545: { /* ws-set-content!(ws, tensor) */
         Value tensor_val = vm_pop(vm), ws_val = vm_pop(vm);
-        if (ws_val.as.ptr >= 0 && vm->heap.objects[ws_val.as.ptr]->type == HEAP_WORKSPACE &&
-            tensor_val.as.ptr >= 0 && vm->heap.objects[tensor_val.as.ptr]->type == HEAP_TENSOR) {
+        if (is_heap_type(vm, ws_val, HEAP_WORKSPACE) &&
+            is_heap_type(vm, tensor_val, HEAP_TENSOR)) {
             VmWorkspace* ws = (VmWorkspace*)vm->heap.objects[ws_val.as.ptr]->opaque.ptr;
             VmTensor* t = (VmTensor*)vm->heap.objects[tensor_val.as.ptr]->opaque.ptr;
             if (ws && t && t->data) {
@@ -5679,7 +5679,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 546: { /* ws-get-dim */
         Value ws_val = vm_pop(vm);
-        if (ws_val.as.ptr >= 0 && vm->heap.objects[ws_val.as.ptr]->type == HEAP_WORKSPACE) {
+        if (is_heap_type(vm, ws_val, HEAP_WORKSPACE)) {
             VmWorkspace* ws = (VmWorkspace*)vm->heap.objects[ws_val.as.ptr]->opaque.ptr;
             vm_push(vm, INT_VAL(ws ? ws->dim : 0));
         } else {
@@ -5689,7 +5689,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 547: { /* ws-get-step-count */
         Value ws_val = vm_pop(vm);
-        if (ws_val.as.ptr >= 0 && vm->heap.objects[ws_val.as.ptr]->type == HEAP_WORKSPACE) {
+        if (is_heap_type(vm, ws_val, HEAP_WORKSPACE)) {
             VmWorkspace* ws = (VmWorkspace*)vm->heap.objects[ws_val.as.ptr]->opaque.ptr;
             vm_push(vm, INT_VAL(ws ? ws->step_count : 0));
         } else {
@@ -8225,7 +8225,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 651: { /* multi-value-ref(mv, idx) — extract from multi-value container */
         Value idx = vm_pop(vm), mv = vm_pop(vm);
-        if (mv.as.ptr >= 0 && vm->heap.objects[mv.as.ptr]->type == HEAP_MULTI_VALUE) {
+        if (is_heap_type(vm, mv, HEAP_MULTI_VALUE)) {
             VmMultiValue* mvobj = (VmMultiValue*)vm->heap.objects[mv.as.ptr]->opaque.ptr;
             int i = (int)as_number(idx);
             if (mvobj && i >= 0 && i < mvobj->count) {
@@ -8275,7 +8275,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 661: { /* hash-ref(ht, key, default) */
         Value dflt = vm_pop(vm), key = vm_pop(vm), ht_val = vm_pop(vm);
-        if (ht_val.as.ptr >= 0 && vm->heap.objects[ht_val.as.ptr]->type == HEAP_HASH) {
+        if (is_heap_type(vm, ht_val, HEAP_HASH)) {
             VmHashTable* ht = (VmHashTable*)vm->heap.objects[ht_val.as.ptr]->opaque.ptr;
             void* result = vm_ht_ref(ht, (void*)(uintptr_t)key.as.i, (void*)(uintptr_t)dflt.as.i);
             vm_push(vm, INT_VAL((int64_t)(intptr_t)result));
@@ -8284,7 +8284,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 662: { /* hash-set!(ht, key, value) */
         Value val = vm_pop(vm), key = vm_pop(vm), ht_val = vm_pop(vm);
-        if (ht_val.as.ptr >= 0 && vm->heap.objects[ht_val.as.ptr]->type == HEAP_HASH) {
+        if (is_heap_type(vm, ht_val, HEAP_HASH)) {
             VmHashTable* ht = (VmHashTable*)vm->heap.objects[ht_val.as.ptr]->opaque.ptr;
             vm_ht_set(&vm->heap.regions, ht, (void*)(uintptr_t)key.as.i, (void*)(uintptr_t)val.as.i);
         }
@@ -8293,7 +8293,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 663: { /* hash-delete!(ht, key) */
         Value key = vm_pop(vm), ht_val = vm_pop(vm);
-        if (ht_val.as.ptr >= 0 && vm->heap.objects[ht_val.as.ptr]->type == HEAP_HASH) {
+        if (is_heap_type(vm, ht_val, HEAP_HASH)) {
             VmHashTable* ht = (VmHashTable*)vm->heap.objects[ht_val.as.ptr]->opaque.ptr;
             vm_ht_remove(ht, (void*)(uintptr_t)key.as.i);
         }
@@ -8302,7 +8302,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 664: { /* hash-has-key?(ht, key) */
         Value key = vm_pop(vm), ht_val = vm_pop(vm);
-        if (ht_val.as.ptr >= 0 && vm->heap.objects[ht_val.as.ptr]->type == HEAP_HASH) {
+        if (is_heap_type(vm, ht_val, HEAP_HASH)) {
             VmHashTable* ht = (VmHashTable*)vm->heap.objects[ht_val.as.ptr]->opaque.ptr;
             vm_push(vm, BOOL_VAL(vm_ht_has_key(ht, (void*)(uintptr_t)key.as.i)));
         } else vm_push(vm, BOOL_VAL(0));
@@ -8310,7 +8310,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 665: { /* hash-keys */
         Value ht_val = vm_pop(vm);
-        if (ht_val.as.ptr >= 0 && vm->heap.objects[ht_val.as.ptr]->type == HEAP_HASH) {
+        if (is_heap_type(vm, ht_val, HEAP_HASH)) {
             VmHashTable* ht = (VmHashTable*)vm->heap.objects[ht_val.as.ptr]->opaque.ptr;
             if (ht) {
                 Value result = NIL_VAL;
@@ -8333,7 +8333,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 666: { /* hash-values */
         Value ht_val = vm_pop(vm);
-        if (ht_val.as.ptr >= 0 && vm->heap.objects[ht_val.as.ptr]->type == HEAP_HASH) {
+        if (is_heap_type(vm, ht_val, HEAP_HASH)) {
             VmHashTable* ht = (VmHashTable*)vm->heap.objects[ht_val.as.ptr]->opaque.ptr;
             if (ht) {
                 Value result = NIL_VAL;
@@ -8356,7 +8356,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 667: { /* hash-count */
         Value ht_val = vm_pop(vm);
-        if (ht_val.as.ptr >= 0 && vm->heap.objects[ht_val.as.ptr]->type == HEAP_HASH) {
+        if (is_heap_type(vm, ht_val, HEAP_HASH)) {
             VmHashTable* ht = (VmHashTable*)vm->heap.objects[ht_val.as.ptr]->opaque.ptr;
             vm_push(vm, INT_VAL(ht ? vm_ht_count(ht) : 0));
         } else vm_push(vm, INT_VAL(0));
@@ -8364,7 +8364,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 668: { /* hash-table-copy(ht) — shallow copy of hash table */
         Value ht_val = vm_pop(vm);
-        if (ht_val.as.ptr >= 0 && vm->heap.objects[ht_val.as.ptr]->type == HEAP_HASH) {
+        if (is_heap_type(vm, ht_val, HEAP_HASH)) {
             VmHashTable* ht = (VmHashTable*)vm->heap.objects[ht_val.as.ptr]->opaque.ptr;
             if (ht) {
                 VmHashTable* copy = vm_ht_make(&vm->heap.regions);
@@ -8379,7 +8379,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 669: { /* hash-clear! */
         Value ht_val = vm_pop(vm);
-        if (ht_val.as.ptr >= 0 && vm->heap.objects[ht_val.as.ptr]->type == HEAP_HASH) {
+        if (is_heap_type(vm, ht_val, HEAP_HASH)) {
             VmHashTable* ht = (VmHashTable*)vm->heap.objects[ht_val.as.ptr]->opaque.ptr;
             if (ht) vm_ht_clear(ht);
         }
@@ -8405,7 +8405,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 681: { /* bytevector-length */
         Value bv_val = vm_pop(vm);
-        if (bv_val.as.ptr >= 0 && vm->heap.objects[bv_val.as.ptr]->type == HEAP_BYTEVECTOR) {
+        if (is_heap_type(vm, bv_val, HEAP_BYTEVECTOR)) {
             VmBytevector* bv = (VmBytevector*)vm->heap.objects[bv_val.as.ptr]->opaque.ptr;
             vm_push(vm, INT_VAL(vm_bv_length(bv)));
         } else vm_push(vm, INT_VAL(0));
@@ -8413,7 +8413,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 682: { /* bytevector-u8-ref(bv, k) */
         Value k = vm_pop(vm), bv_val = vm_pop(vm);
-        if (bv_val.as.ptr >= 0 && vm->heap.objects[bv_val.as.ptr]->type == HEAP_BYTEVECTOR) {
+        if (is_heap_type(vm, bv_val, HEAP_BYTEVECTOR)) {
             VmBytevector* bv = (VmBytevector*)vm->heap.objects[bv_val.as.ptr]->opaque.ptr;
             vm_push(vm, INT_VAL(vm_bv_u8_ref(bv, (int)as_number(k))));
         } else vm_push(vm, INT_VAL(0));
@@ -8421,7 +8421,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 683: { /* bytevector-u8-set!(bv, k, byte) */
         Value byte = vm_pop(vm), k = vm_pop(vm), bv_val = vm_pop(vm);
-        if (bv_val.as.ptr >= 0 && vm->heap.objects[bv_val.as.ptr]->type == HEAP_BYTEVECTOR) {
+        if (is_heap_type(vm, bv_val, HEAP_BYTEVECTOR)) {
             VmBytevector* bv = (VmBytevector*)vm->heap.objects[bv_val.as.ptr]->opaque.ptr;
             vm_bv_u8_set(bv, (int)as_number(k), (int)as_number(byte));
         }
@@ -8430,9 +8430,9 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 684: { /* bytevector-append(a, b) */
         Value b_val = vm_pop(vm), a_val = vm_pop(vm);
-        VmBytevector* a = (a_val.as.ptr >= 0 && vm->heap.objects[a_val.as.ptr]->type == HEAP_BYTEVECTOR)
+        VmBytevector* a = (is_heap_type(vm, a_val, HEAP_BYTEVECTOR))
             ? (VmBytevector*)vm->heap.objects[a_val.as.ptr]->opaque.ptr : NULL;
-        VmBytevector* b = (b_val.as.ptr >= 0 && vm->heap.objects[b_val.as.ptr]->type == HEAP_BYTEVECTOR)
+        VmBytevector* b = (is_heap_type(vm, b_val, HEAP_BYTEVECTOR))
             ? (VmBytevector*)vm->heap.objects[b_val.as.ptr]->opaque.ptr : NULL;
         if (a && b) {
             VmBytevector* r = vm_bv_append(&vm->heap.regions, a, b);
@@ -8443,8 +8443,8 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 685: { /* bytevector-copy!(to, at, from) — copy bytes from src into dst */
         Value from_val = vm_pop(vm), at_val = vm_pop(vm), to_val = vm_pop(vm);
-        if (to_val.as.ptr >= 0 && vm->heap.objects[to_val.as.ptr]->type == HEAP_BYTEVECTOR &&
-            from_val.as.ptr >= 0 && vm->heap.objects[from_val.as.ptr]->type == HEAP_BYTEVECTOR) {
+        if (is_heap_type(vm, to_val, HEAP_BYTEVECTOR) &&
+            is_heap_type(vm, from_val, HEAP_BYTEVECTOR)) {
             VmBytevector* to_bv = (VmBytevector*)vm->heap.objects[to_val.as.ptr]->opaque.ptr;
             VmBytevector* from_bv = (VmBytevector*)vm->heap.objects[from_val.as.ptr]->opaque.ptr;
             int at = (int)as_number(at_val);
@@ -8465,7 +8465,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 687: { /* bytevector-copy(bv) */
         Value bv_val = vm_pop(vm);
-        if (bv_val.as.ptr >= 0 && vm->heap.objects[bv_val.as.ptr]->type == HEAP_BYTEVECTOR) {
+        if (is_heap_type(vm, bv_val, HEAP_BYTEVECTOR)) {
             VmBytevector* bv = (VmBytevector*)vm->heap.objects[bv_val.as.ptr]->opaque.ptr;
             VmBytevector* r = vm_bv_copy(&vm->heap.regions, bv, 0, bv->len);
             if (r) { VM_PUSH_HEAP_OPAQUE(vm, HEAP_BYTEVECTOR, VAL_BYTEVECTOR, r); break; }
@@ -8475,7 +8475,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 688: { /* utf8->string(bv) */
         Value bv_val = vm_pop(vm);
-        if (bv_val.as.ptr >= 0 && vm->heap.objects[bv_val.as.ptr]->type == HEAP_BYTEVECTOR) {
+        if (is_heap_type(vm, bv_val, HEAP_BYTEVECTOR)) {
             VmBytevector* bv = (VmBytevector*)vm->heap.objects[bv_val.as.ptr]->opaque.ptr;
             if (bv) {
                 VmString* s = vm_string_new(&vm->heap.regions, (const char*)bv->data, bv->len);
@@ -8526,7 +8526,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 701: { /* parameter-ref */
         Value p_val = vm_pop(vm);
-        if (p_val.as.ptr >= 0 && vm->heap.objects[p_val.as.ptr]->type == HEAP_PARAMETER) {
+        if (is_heap_type(vm, p_val, HEAP_PARAMETER)) {
             VmParameter* p = (VmParameter*)vm->heap.objects[p_val.as.ptr]->opaque.ptr;
             void* v = vm_param_ref(p);
             vm_push(vm, INT_VAL((int64_t)(intptr_t)v));
@@ -8535,7 +8535,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 702: { /* parameterize-push(param, value) */
         Value val = vm_pop(vm), p_val = vm_pop(vm);
-        if (p_val.as.ptr >= 0 && vm->heap.objects[p_val.as.ptr]->type == HEAP_PARAMETER) {
+        if (is_heap_type(vm, p_val, HEAP_PARAMETER)) {
             VmParameter* p = (VmParameter*)vm->heap.objects[p_val.as.ptr]->opaque.ptr;
             vm_param_push(&vm->heap.regions, p, (void*)(uintptr_t)val.as.i);
         }
@@ -8544,7 +8544,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 703: { /* parameterize-pop(param) */
         Value p_val = vm_pop(vm);
-        if (p_val.as.ptr >= 0 && vm->heap.objects[p_val.as.ptr]->type == HEAP_PARAMETER) {
+        if (is_heap_type(vm, p_val, HEAP_PARAMETER)) {
             VmParameter* p = (VmParameter*)vm->heap.objects[p_val.as.ptr]->opaque.ptr;
             vm_param_pop(p);
         }
@@ -8571,7 +8571,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 711: { /* error-message */
         Value e_val = vm_pop(vm);
-        if (e_val.as.ptr >= 0 && vm->heap.objects[e_val.as.ptr]->type == HEAP_ERROR) {
+        if (is_heap_type(vm, e_val, HEAP_ERROR)) {
             VmError* e = (VmError*)vm->heap.objects[e_val.as.ptr]->opaque.ptr;
             VmString* s = vm_string_from_cstr(&vm->heap.regions, e ? e->message : "");
             if (s) { VM_PUSH_HEAP_OPAQUE(vm, HEAP_STRING, VAL_STRING, s); break; }
@@ -8581,7 +8581,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 712: { /* error-type */
         Value e_val = vm_pop(vm);
-        if (e_val.as.ptr >= 0 && vm->heap.objects[e_val.as.ptr]->type == HEAP_ERROR) {
+        if (is_heap_type(vm, e_val, HEAP_ERROR)) {
             VmError* e = (VmError*)vm->heap.objects[e_val.as.ptr]->opaque.ptr;
             VmString* s = vm_string_from_cstr(&vm->heap.regions, e ? e->type : "");
             if (s) { VM_PUSH_HEAP_OPAQUE(vm, HEAP_STRING, VAL_STRING, s); break; }
@@ -11111,7 +11111,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
 
     case 1800: { /* kb-count(kb) → integer (number of facts) */
         Value kb_val = vm_pop(vm);
-        if (kb_val.as.ptr >= 0 && vm->heap.objects[kb_val.as.ptr]->type == HEAP_KB) {
+        if (is_heap_type(vm, kb_val, HEAP_KB)) {
             VmKnowledgeBase* kb = (VmKnowledgeBase*)vm->heap.objects[kb_val.as.ptr]->opaque.ptr;
             if (kb) { vm_push(vm, INT_VAL(kb->n_facts)); break; }
         }
@@ -11122,7 +11122,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     case 1801: { /* kb-retract!(kb, fact) -> #t or #f
                   * Remove first structurally matching fact from KB. */
         Value fact_val = vm_pop(vm), kb_val = vm_pop(vm);
-        if (kb_val.as.ptr >= 0 && vm->heap.objects[kb_val.as.ptr]->type == HEAP_KB) {
+        if (is_heap_type(vm, kb_val, HEAP_KB)) {
             VmKnowledgeBase* kb = (VmKnowledgeBase*)vm->heap.objects[kb_val.as.ptr]->opaque.ptr;
             Value target_datum;
             int has_target_datum = vm_kb_extract_fact_datum(vm, fact_val, &target_datum);
@@ -11147,7 +11147,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
     case 1802: { /* kb-count-predicate(kb, predicate) -> integer */
         Value predicate = vm_pop(vm), kb_val = vm_pop(vm);
         int count = 0;
-        if (kb_val.as.ptr >= 0 && vm->heap.objects[kb_val.as.ptr]->type == HEAP_KB) {
+        if (is_heap_type(vm, kb_val, HEAP_KB)) {
             VmKnowledgeBase* kb = (VmKnowledgeBase*)vm->heap.objects[kb_val.as.ptr]->opaque.ptr;
             if (kb) {
                 for (int i = 0; i < kb->n_facts; i++)
@@ -11164,7 +11164,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
 
     case 1810: { /* fg-marginal(fg, var-idx) -> tensor of belief probabilities */
         Value idx_val = vm_pop(vm), fg_val = vm_pop(vm);
-        if (fg_val.as.ptr >= 0 && vm->heap.objects[fg_val.as.ptr]->type == HEAP_FACTOR_GRAPH) {
+        if (is_heap_type(vm, fg_val, HEAP_FACTOR_GRAPH)) {
             VmFactorGraph* fg = (VmFactorGraph*)vm->heap.objects[fg_val.as.ptr]->opaque.ptr;
             int var = (int)as_number(idx_val);
             if (fg && var >= 0 && var < fg->num_vars) {
@@ -11189,7 +11189,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
 
     case 1811: { /* fg-entropy(fg, var-idx) -> scalar entropy H = -sum p*log(p) */
         Value idx_val = vm_pop(vm), fg_val = vm_pop(vm);
-        if (fg_val.as.ptr >= 0 && vm->heap.objects[fg_val.as.ptr]->type == HEAP_FACTOR_GRAPH) {
+        if (is_heap_type(vm, fg_val, HEAP_FACTOR_GRAPH)) {
             VmFactorGraph* fg = (VmFactorGraph*)vm->heap.objects[fg_val.as.ptr]->opaque.ptr;
             int var = (int)as_number(idx_val);
             if (fg && var >= 0 && var < fg->num_vars) {
@@ -11209,7 +11209,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
 
     case 1812: { /* fg-total-entropy(fg) -> sum of variable marginal entropies */
         Value fg_val = vm_pop(vm);
-        if (fg_val.as.ptr >= 0 && vm->heap.objects[fg_val.as.ptr]->type == HEAP_FACTOR_GRAPH) {
+        if (is_heap_type(vm, fg_val, HEAP_FACTOR_GRAPH)) {
             VmFactorGraph* fg = (VmFactorGraph*)vm->heap.objects[fg_val.as.ptr]->opaque.ptr;
             if (fg) {
                 double entropy = 0.0;

--- a/lib/backend/xla/xla_runtime.cpp
+++ b/lib/backend/xla/xla_runtime.cpp
@@ -187,6 +187,10 @@ extern "C" void* eshkol_xla_elementwise(
     }
 
     // CPU fallback
+    // P0: binary ops (ADD/SUB/MUL/DIV, op_code 0-3) dereference b_data; the GPU
+    // path above already treats b_data as nullable, so guard the CPU path too
+    // rather than dereferencing NULL.
+    if (op_code <= 3 && !b_data) return nullptr;
     switch (op_code) {
         case 0: // ADD
             for (int64_t i = 0; i < total_elements; i++) out[i] = a_data[i] + b_data[i];


### PR DESCRIPTION
## Summary
A whole-codebase production-readiness audit — **ICC** static analysis (`production-audit`, `audit-patterns c-stub-bodies`) feeding a **multi-agent adversarial review** (29 agents) — found 5 user-reachable **P0 ship-blockers**. All fixed here, each using the file's existing hardened sibling as the canonical pattern.

| P0 | Defect | Fix |
|---|---|---|
| 1 | `vm_native.c`: ~50 sites guarded heap access with only `X.as.ptr >= 0` (no upper bound) → `(hash-ref 999999999 k d)` reads `heap.objects[]` OOB | all 50 → `is_heap_type(vm, X, HEAP_T)` (adds `< next_free` + type check) |
| 2 | `OP_VEC_CREATE`: unchecked `count` into fixed 64-slot `vector.items[]` → heap OOB write on a >64-element literal | clamp stored count to capacity; still POP the full count |
| 3 | xla `eshkol_xla_elementwise` CPU fallback derefs `b_data` for binary ops with no NULL check | guard `op_code <= 3 && !b_data` |
| 4/5 | `quotient`/`remainder`: raw `SDiv`/`SRem` → UB/SIGFPE on `INT64_MIN / -1` | sanitize divisor to 1 in that case: `SRem(x,1)=0`, `SDiv(INT64_MIN,1)=INT64_MIN` |

## Verified
- Builds clean; `(quotient INT64_MIN -1)` → `-9223372036854775808`, `(remainder INT64_MIN -1)` → `0` (no SIGFPE)
- **autodiff suite 54/54**, no regression
- The 16 ICC static unsafe-string candidates were **adversarially dismissed** as provably bounded (compile-time-constant sources) — no real string-overflow vulns

## Follow-up (audit backlog)
22 P1 (XLA rank>16 stack guards, multi-value `floor/`/`truncate/` layout bugs, `string-repeat` int-overflow, parser DoS loops, f16-GEMM `bad_alloc` across the C ABI, GEMM 64→32 dim truncation, GPU backward NULL guards, `rmdir-recursive` symlink traversal) + 21 P2 — tracked from the audit report for follow-up PRs.