### PR TITLE
fix(sqlite): sqlite-step returns a boolean (terminate step loops at SQLITE_DONE)

### DIFF
--- a/lib/agent/sqlite.esk
+++ b/lib/agent/sqlite.esk
@@ -89,7 +89,11 @@
   (capability-require! 'ffi 'sqlite-prepare)
   (sqlite-prepare-raw handle sql))
 
-(define (sqlite-step stmt) (sqlite-step-raw stmt))
+;; Return #t iff a row is available (SQLITE_ROW); #f at SQLITE_DONE or on error.
+;; The raw FFI returns the integer result code (100=ROW, 101=DONE), and BOTH are
+;; truthy in Scheme — so the canonical (let loop () (if (sqlite-step s) ... (loop)))
+;; would never terminate. Map to a boolean so the step-loop idiom works.
+(define (sqlite-step stmt) (= (sqlite-step-raw stmt) SQLITE_ROW))
 (define (sqlite-reset stmt) (sqlite-reset-raw stmt))
 (define (sqlite-finalize stmt) (sqlite-finalize-raw stmt))
 


### PR DESCRIPTION
Found while verifying bug-PP (which is already resolved). `sqlite-step` returned the raw FFI code (100=ROW, 101=DONE); both are truthy, so `(let loop () (if (sqlite-step s) … (loop)))` never terminated and over-read past the last row. Now returns `#t` iff SQLITE_ROW. Verified: CREATE/INSERT/SELECT round-trip prints exactly the inserted rows and stops.