### PR TITLE
fix(closure): value-capture TCO loop vars in map (bug-RR, high severity)

### DIFF
--- a/lib/backend/map_codegen.cpp
+++ b/lib/backend/map_codegen.cpp
@@ -19,6 +19,17 @@ using namespace llvm;
 
 namespace eshkol {
 
+// True if `v` is a named-let / TCO loop-variable alloca (named "<name>_tco").
+// codegenLambda captures such allocas BY VALUE (its is_let_alloca gate excludes
+// the "_tco" suffix), so map's capture setup must load the value rather than
+// pack the alloca address — see bug-RR.
+static bool isTcoLoopAlloca(Value* v) {
+    AllocaInst* a = dyn_cast_or_null<AllocaInst>(v);
+    if (!a) return false;
+    std::string name = a->getName().str();
+    return name.size() >= 4 && name.compare(name.size() - 4, 4, "_tco") == 0;
+}
+
 MapCodegen::MapCodegen(CodegenContext& ctx, TaggedValueCodegen& tagged)
     : ctx_(ctx), tagged_(tagged) {}
 
@@ -423,7 +434,20 @@ void MapCodegen::loadCapturedValues(
             bool needs_ptr_packing = isa<AllocaInst>(storage) || isa<GlobalVariable>(storage) ||
                 (storage->getType()->isPointerTy() && !isa<Argument>(storage));
 
-            if (needs_ptr_packing) {
+            if (isTcoLoopAlloca(storage)) {
+                // bug-RR: TCO loop-var allocas (named "<v>_tco") are captured BY VALUE by
+                // codegenLambda (its is_let_alloca gate excludes "_tco" → single-load body).
+                // Pack the *value*, not the alloca address — otherwise the lambda returns
+                // the pointer (garbage). Mirrors the value-capture convention exactly.
+                Function* current_func = ctx_.builder().GetInsertBlock()->getParent();
+                IRBuilder<> entry_builder(&current_func->getEntryBlock(), current_func->getEntryBlock().begin());
+                AllocaInst* temp_alloca = entry_builder.CreateAlloca(ctx_.taggedValueType(), nullptr, var_name + "_capture_storage");
+                Value* loaded = ctx_.builder().CreateLoad(ctx_.taggedValueType(), storage, var_name + "_val");
+                ctx_.builder().CreateStore(loaded, temp_alloca);
+                args.push_back(temp_alloca);
+                eshkol_debug("Map: value-captured TCO loop var '%s' for lambda '%s'",
+                            var_name.c_str(), lambda_name.c_str());
+            } else if (needs_ptr_packing) {
                 Function* current_func = ctx_.builder().GetInsertBlock()->getParent();
                 IRBuilder<> entry_builder(&current_func->getEntryBlock(), current_func->getEntryBlock().begin());
                 AllocaInst* temp_alloca = entry_builder.CreateAlloca(ctx_.taggedValueType(), nullptr, var_name + "_capture_storage");
@@ -467,7 +491,18 @@ void MapCodegen::loadCapturedValues(
                 bool needs_ptr_packing = isa<AllocaInst>(var_storage) || isa<GlobalVariable>(var_storage) ||
                     (var_storage->getType()->isPointerTy() && !isa<Argument>(var_storage));
 
-                if (needs_ptr_packing) {
+                if (isTcoLoopAlloca(var_storage)) {
+                    // bug-RR: TCO loop-var alloca captured BY VALUE by codegenLambda — load
+                    // the value, don't pack the address (see found-path above).
+                    Function* current_func = ctx_.builder().GetInsertBlock()->getParent();
+                    IRBuilder<> entry_builder(&current_func->getEntryBlock(), current_func->getEntryBlock().begin());
+                    AllocaInst* temp_alloca = entry_builder.CreateAlloca(ctx_.taggedValueType(), nullptr, var_name + "_capture_storage");
+                    Value* loaded = ctx_.builder().CreateLoad(ctx_.taggedValueType(), var_storage, var_name + "_val");
+                    ctx_.builder().CreateStore(loaded, temp_alloca);
+                    args.push_back(temp_alloca);
+                    eshkol_debug("Map: value-captured TCO loop var '%s' for lambda '%s'",
+                                var_name.c_str(), lambda_name.c_str());
+                } else if (needs_ptr_packing) {
                     Function* current_func = ctx_.builder().GetInsertBlock()->getParent();
                     IRBuilder<> entry_builder(&current_func->getEntryBlock(), current_func->getEntryBlock().begin());
                     AllocaInst* temp_alloca = entry_builder.CreateAlloca(ctx_.taggedValueType(), nullptr, var_name + "_capture_storage");


### PR DESCRIPTION
## Summary
A `lambda` closing over a **named-let loop variable** and passed to `map` silently captured garbage (a pointer). The filed repro returned `((<ptr>) (<ptr>))` instead of `((0) (1))` — silent wrong results, high severity.

## Root cause
A capture-convention **mismatch** between two codegen sites:
- `codegenLambda`'s `is_let_alloca` gate treats TCO loop-var allocas (named `<v>_tco`) as **value** captures — the lambda body does a single load of its `captured_v` arg.
- `MapCodegen::loadCapturedValues` packed **every** alloca's *address* (`ptrtoint`) into the capture slot (the mutable/let-bound convention).

So the loop-var lambda received the alloca's **address** and returned it as an int — the garbage. let-bound/global captures (which genuinely want pointer sharing) and the same closure called *directly* (not via map) were unaffected — which is why it hid behind the map path.

## Fix
Mirror `codegenLambda`'s gate in map's capture setup: `isTcoLoopAlloca()` detects the `_tco` suffix and **loads the value** into the capture slot instead of packing the address — in both the capture-key and fallback resolution paths.

## Verified
- Report repro → `((0) (1))`; loop-var+map → `(0 1)`
- Regressions unchanged: let-capture+map `(5 5)`, global-capture+map `(7 7)`, direct loop-var closure `(0 1)`
- 129/130 closures+lists+scheme tests pass; the 1 failure (`closure_edge_test`'s `set!` counter) is **pre-existing on master** and unrelated