### PR TITLE
feat(ad): stateful op-recording tape with custom-op backward closures (TAPE)

### DIFF
--- a/lib/core/ad/tape.esk
+++ b/lib/core/ad/tape.esk
@@ -34,7 +34,7 @@
          ;; stateful op-recording tape + custom ops
          with-tape current-tape make-tape
          tape-input tape-const node-value node-grad
-         record-op!
+         record-op! record-fd-op!
          tape-add tape-sub tape-mul tape-div
          tape-sin tape-cos tape-exp tape-log tape-neg
          tape-gradient tape-snapshot tape-restore)
@@ -106,6 +106,38 @@
   (let ((out (tape-register-node! t (vector out-value (val-zero-like out-value)))))
     (tape-record! t out inputs backward)
     out))
+
+;; ── Finite-difference custom op ──
+;; record-fd-op! records a custom op whose backward is computed by CENTRAL finite
+;; differences on `fwd`, so ANY scalar function of the inputs (free-energy, a BP
+;; step, a geodesic distance, …) is differentiable on the tape WITHOUT a
+;; hand-written backward. `fwd` takes the list of input VALUES (scalars) and
+;; returns a scalar. Returns the output node. Use when an analytic backward is
+;; unavailable or not worth deriving; prefer record-op! with an exact backward
+;; when you have one.
+(define tape-fd-eps 1.0e-6)
+
+(define (tape-reverse lst)
+  (let loop ((l lst) (acc '()))
+    (if (pair? l) (loop (cdr l) (cons (car l) acc)) acc)))
+
+(define (tape-list-set lst i v)   ; functional update of element i
+  (if (= i 0)
+      (cons v (cdr lst))
+      (cons (car lst) (tape-list-set (cdr lst) (- i 1) v))))
+
+(define (record-fd-op! t inputs fwd)
+  (let* ((vals (tape-map1 node-value inputs))
+         (out-val (fwd vals)))
+    (record-op! t inputs out-val
+      (lambda (g)
+        (let loop ((i 0) (vs vals) (acc '()))
+          (if (pair? vs)
+              (let* ((vp (tape-list-set vals i (+ (car vs) tape-fd-eps)))
+                     (vm (tape-list-set vals i (- (car vs) tape-fd-eps)))
+                     (d  (/ (- (fwd vp) (fwd vm)) (* 2.0 tape-fd-eps))))
+                (loop (+ i 1) (cdr vs) (cons (* g d) acc)))
+              (tape-reverse acc)))))))
 
 ;; ── Builtin ops (recorded with their backward rules) ──
 (define (tape-add t a b)

--- a/lib/core/ad/tape.esk
+++ b/lib/core/ad/tape.esk
@@ -37,6 +37,7 @@
          record-op! record-fd-op!
          tape-add tape-sub tape-mul tape-div
          tape-sin tape-cos tape-exp tape-log tape-neg
+         tape-square tape-sqrt tape-tanh tape-sigmoid tape-relu tape-pow
          tape-gradient tape-snapshot tape-restore)
 
 ;; ── Internal list helpers ──
@@ -185,6 +186,37 @@
   (let ((av (node-value a)))
     (record-op! t (list a) (- av)
                 (lambda (g) (list (- g))))))
+
+(define (tape-square t a)
+  (let ((av (node-value a)))
+    (record-op! t (list a) (* av av)
+                (lambda (g) (list (* g 2.0 av))))))
+
+(define (tape-sqrt t a)
+  (let* ((av (node-value a)) (ov (sqrt av)))
+    (record-op! t (list a) ov
+                (lambda (g) (list (/ g (* 2.0 ov)))))))   ; d/da sqrt = 1/(2*out)
+
+(define (tape-tanh t a)
+  (let* ((av (node-value a)) (ov (tanh av)))
+    (record-op! t (list a) ov
+                (lambda (g) (list (* g (- 1.0 (* ov ov))))))))  ; 1 - tanh^2
+
+(define (tape-sigmoid t a)
+  (let* ((av (node-value a)) (ov (/ 1.0 (+ 1.0 (exp (- av))))))
+    (record-op! t (list a) ov
+                (lambda (g) (list (* g ov (- 1.0 ov)))))))  ; out*(1-out)
+
+(define (tape-relu t a)
+  (let ((av (node-value a)))
+    (record-op! t (list a) (if (> av 0.0) av 0.0)
+                (lambda (g) (list (if (> av 0.0) g 0.0))))))
+
+;; tape-pow: a^p for a CONSTANT exponent p (a is a node, p a number).
+(define (tape-pow t a p)
+  (let ((av (node-value a)))
+    (record-op! t (list a) (expt av p)
+                (lambda (g) (list (* g p (expt av (- p 1.0))))))))
 
 ;; ── Reverse pass ──
 ;; Distribute a list of input-grads onto a list of input-nodes (pairwise).

--- a/lib/core/ad/tape.esk
+++ b/lib/core/ad/tape.esk
@@ -50,13 +50,30 @@
       (cons (f (car lst)) (tape-map1 f (cdr lst)))
       '()))
 
+;; ── Value helpers ──
+;; A tape VALUE (and its gradient) is either a number (scalar) or a vector of
+;; numbers (a tensor / embedding). All grad arithmetic goes through these so the
+;; tape handles scalar and tensor nodes uniformly — needed for embedding/encoder
+;; custom ops whose inputs and adjoints are vectors.
+(define (val-zero-like v)
+  (if (vector? v) (make-vector (vector-length v) 0.0) 0.0))
+(define (val-add a b)
+  (if (vector? a)
+      (let* ((n (vector-length a)) (r (make-vector n 0.0)))
+        (let loop ((i 0))
+          (if (< i n)
+              (begin (vector-set! r i (+ (vector-ref a i) (vector-ref b i)))
+                     (loop (+ i 1)))))
+        r)
+      (+ a b)))
+
 ;; ── Node ──
-;; A node is a mutable 2-slot vector: #(value grad). Created via the tape so it
-;; is registered for gradient zeroing.
+;; A node is a mutable 2-slot vector: #(value grad). value/grad may be scalars or
+;; vectors. Created via the tape so it is registered for gradient zeroing.
 (define (node-value n) (vector-ref n 0))
 (define (node-grad n) (vector-ref n 1))
 (define (node-grad-set! n g) (vector-set! n 1 g))
-(define (node-grad-add! n g) (vector-set! n 1 (+ (vector-ref n 1) g)))
+(define (node-grad-add! n g) (vector-set! n 1 (val-add (vector-ref n 1) g)))
 
 ;; ── Tape ──
 ;; A tape is a mutable 2-slot vector: #(ops nodes), each a list built by
@@ -76,8 +93,8 @@
   out)
 
 ;; Leaf nodes (gradient targets / constants).
-(define (tape-input t value) (tape-register-node! t (vector value 0.0)))
-(define (tape-const t value) (tape-register-node! t (vector value 0.0)))
+(define (tape-input t value) (tape-register-node! t (vector value (val-zero-like value))))
+(define (tape-const t value) (tape-register-node! t (vector value (val-zero-like value))))
 
 ;; ── Custom op ──
 ;; inputs   : list of input nodes
@@ -86,7 +103,7 @@
 ;;            The closure captures whatever forward context it needs.
 ;; Returns the new output node.
 (define (record-op! t inputs out-value backward)
-  (let ((out (tape-register-node! t (vector out-value 0.0))))
+  (let ((out (tape-register-node! t (vector out-value (val-zero-like out-value)))))
     (tape-record! t out inputs backward)
     out))
 
@@ -145,9 +162,10 @@
         (node-grad-add! (car ins) (car grads))
         (tape-distribute! (cdr ins) (cdr grads)))))
 
-;; Zero every node's gradient (so gradient can be called repeatedly).
+;; Zero every node's gradient (so gradient can be called repeatedly). The zero
+;; matches the node's value shape (0.0 for scalars, a zero vector for tensors).
 (define (tape-zero-grads! t)
-  (tape-for-each (lambda (n) (node-grad-set! n 0.0)) (tape-nodes t)))
+  (tape-for-each (lambda (n) (node-grad-set! n (val-zero-like (node-value n)))) (tape-nodes t)))
 
 ;; tape-gradient: reverse-mode from `output`, then read gradients at `targets`.
 ;; `targets` is a list of nodes; returns a list of gradients in the same order.
@@ -160,7 +178,8 @@
              (ins (cadr op))
              (backward (caddr op))
              (g (node-grad out)))
-        (if (not (= g 0.0))
+        ;; process tensor adjoints unconditionally; skip only zero scalars
+        (if (or (vector? g) (not (= g 0.0)))
             (tape-distribute! ins (backward g)))))
     (tape-ops t))            ; reverse-chronological (prepended) = reverse topo order
   (tape-map1 node-grad targets))

--- a/lib/core/ad/tape.esk
+++ b/lib/core/ad/tape.esk
@@ -20,7 +20,32 @@
          ad-add ad-sub ad-mul ad-div
          ad-sin ad-cos ad-exp ad-log ad-sqrt
          ad-neg ad-abs ad-relu ad-sigmoid ad-tanh
-         ad-backward ad-gradient ad-node-value)
+         ad-backward ad-gradient ad-node-value
+         with-tape current-tape tape-gradient)
+
+;; ── Dynamic "current tape" (with-tape / current-tape) ──
+;; Opens a fresh tape, binds it as the current tape for the dynamic extent of
+;; `thunk`, and restores the previous current tape afterward. Higher-level ops
+;; (and record-op!, once added) record onto (current-tape). `name` is retained
+;; for debugging / snapshot labelling.
+(define *eshkol-current-tape* #f)
+
+(define (current-tape) *eshkol-current-tape*)
+
+(define (with-tape name thunk)
+  (let ((prev *eshkol-current-tape*)
+        (tape (ad-tape-new)))
+    (set! *eshkol-current-tape* tape)
+    (let ((result (thunk)))
+      (set! *eshkol-current-tape* prev)
+      result)))
+
+;; tape-gradient: run reverse mode from `output` on `tape`, then read the
+;; accumulated gradient at each target node. `targets` is a list of node ids;
+;; returns a list of gradients in the same order.
+(define (tape-gradient tape output targets)
+  (ad-backward tape output)
+  (map (lambda (t) (ad-gradient tape t)) targets))
 
 ;; Note: ad-value is exposed as a codegen builtin alias for ad-node-value
 ;; (see llvm_codegen.cpp). This gives the user-facing name `ad-value`

--- a/lib/core/ad/tape.esk
+++ b/lib/core/ad/tape.esk
@@ -1,19 +1,29 @@
 ;;
-;; core.ad.tape — Reverse-mode automatic differentiation via Wengert tape
+;; core.ad.tape — Reverse-mode automatic differentiation
 ;;
-;; Usage:
-;;   (define tape (ad-tape-new))
-;;   (define x (ad-var tape 2.0))
-;;   (define y (ad-mul tape x x))    ; y = x^2
-;;   (ad-backward tape y)            ; propagate gradients
-;;   (ad-gradient tape x)            ; => 4.0 (dy/dx = 2x = 4)
+;; Two layers:
 ;;
-;; The tape records the computation graph during the forward pass.
-;; ad-backward runs reverse-mode differentiation from the output node.
-;; ad-gradient reads the accumulated gradient for any input variable.
+;; 1. Low-level Wengert tape (codegen builtins, fast, builtin ops only):
+;;      (define tape (ad-tape-new))
+;;      (define x (ad-var tape 2.0))
+;;      (define y (ad-mul tape x x))    ; y = x^2
+;;      (ad-backward tape y)
+;;      (ad-gradient tape x)            ; => 4.0
 ;;
-;; Operations: ad-add, ad-sub, ad-mul, ad-div, ad-sin, ad-cos,
-;;   ad-exp, ad-log, ad-sqrt, ad-neg, ad-abs, ad-relu, ad-sigmoid, ad-tanh
+;; 2. Stateful op-recording tape with CUSTOM ops (this file, pure Scheme):
+;;      (with-tape "loss" (lambda ()
+;;        (let* ((t (current-tape))
+;;               (x (tape-input t 3.0))
+;;               (y (tape-mul t x x))               ; builtin op (recorded)
+;;               (z (record-op! t (list y) (f (node-value y))   ; CUSTOM op
+;;                     (lambda (g) (list (* g (df (node-value y))))))))
+;;          (tape-gradient t z (list x)))))
+;;
+;; The stateful tape records every op with an explicit backward CLOSURE, so a
+;; loss can route through builtin AND hand-written custom ops on one tape, and
+;; reverse-mode flows through all of them. This is what unblocks differentiating
+;; reasoning ops (soft-unify, bp-message, encoder-forward, …) whose backward
+;; passes are not plain builtin compositions.
 ;;
 
 (provide ad-tape-new ad-const ad-var
@@ -21,32 +31,163 @@
          ad-sin ad-cos ad-exp ad-log ad-sqrt
          ad-neg ad-abs ad-relu ad-sigmoid ad-tanh
          ad-backward ad-gradient ad-node-value
-         with-tape current-tape tape-gradient)
+         ;; stateful op-recording tape + custom ops
+         with-tape current-tape make-tape
+         tape-input tape-const node-value node-grad
+         record-op!
+         tape-add tape-sub tape-mul tape-div
+         tape-sin tape-cos tape-exp tape-log tape-neg
+         tape-gradient tape-snapshot tape-restore)
+
+;; ── Internal list helpers ──
+;; Self-contained (this is a core module loaded before the list stdlib, so we
+;; don't depend on for-each / map being available).
+(define (tape-for-each f lst)
+  (if (pair? lst)
+      (begin (f (car lst)) (tape-for-each f (cdr lst)))))
+(define (tape-map1 f lst)
+  (if (pair? lst)
+      (cons (f (car lst)) (tape-map1 f (cdr lst)))
+      '()))
+
+;; ── Node ──
+;; A node is a mutable 2-slot vector: #(value grad). Created via the tape so it
+;; is registered for gradient zeroing.
+(define (node-value n) (vector-ref n 0))
+(define (node-grad n) (vector-ref n 1))
+(define (node-grad-set! n g) (vector-set! n 1 g))
+(define (node-grad-add! n g) (vector-set! n 1 (+ (vector-ref n 1) g)))
+
+;; ── Tape ──
+;; A tape is a mutable 2-slot vector: #(ops nodes), each a list built by
+;; prepending (so `ops` is in reverse-chronological order — exactly the reverse
+;; topological order needed for the backward pass).
+;; An op is a list: (output-node input-nodes backward-closure).
+(define (make-tape) (vector '() '()))
+(define (tape-ops t) (vector-ref t 0))
+(define (tape-nodes t) (vector-ref t 1))
+
+(define (tape-register-node! t n)
+  (vector-set! t 1 (cons n (vector-ref t 1)))
+  n)
+
+(define (tape-record! t out ins backward)
+  (vector-set! t 0 (cons (list out ins backward) (vector-ref t 0)))
+  out)
+
+;; Leaf nodes (gradient targets / constants).
+(define (tape-input t value) (tape-register-node! t (vector value 0.0)))
+(define (tape-const t value) (tape-register-node! t (vector value 0.0)))
+
+;; ── Custom op ──
+;; inputs   : list of input nodes
+;; out-value: the forward output value (already computed)
+;; backward : (lambda (grad-out) -> list-of-input-grads), same length/order as inputs.
+;;            The closure captures whatever forward context it needs.
+;; Returns the new output node.
+(define (record-op! t inputs out-value backward)
+  (let ((out (tape-register-node! t (vector out-value 0.0))))
+    (tape-record! t out inputs backward)
+    out))
+
+;; ── Builtin ops (recorded with their backward rules) ──
+(define (tape-add t a b)
+  (let ((av (node-value a)) (bv (node-value b)))
+    (record-op! t (list a b) (+ av bv)
+                (lambda (g) (list g g)))))
+
+(define (tape-sub t a b)
+  (let ((av (node-value a)) (bv (node-value b)))
+    (record-op! t (list a b) (- av bv)
+                (lambda (g) (list g (- g))))))
+
+(define (tape-mul t a b)
+  (let ((av (node-value a)) (bv (node-value b)))
+    (record-op! t (list a b) (* av bv)
+                (lambda (g) (list (* g bv) (* g av))))))
+
+(define (tape-div t a b)
+  (let ((av (node-value a)) (bv (node-value b)))
+    (record-op! t (list a b) (/ av bv)
+                (lambda (g) (list (/ g bv)
+                                  (- (/ (* g av) (* bv bv))))))))
+
+(define (tape-sin t a)
+  (let ((av (node-value a)))
+    (record-op! t (list a) (sin av)
+                (lambda (g) (list (* g (cos av)))))))
+
+(define (tape-cos t a)
+  (let ((av (node-value a)))
+    (record-op! t (list a) (cos av)
+                (lambda (g) (list (* g (- (sin av))))))))
+
+(define (tape-exp t a)
+  (let ((av (node-value a)))
+    (record-op! t (list a) (exp av)
+                (lambda (g) (list (* g (exp av)))))))
+
+(define (tape-log t a)
+  (let ((av (node-value a)))
+    (record-op! t (list a) (log av)
+                (lambda (g) (list (/ g av))))))
+
+(define (tape-neg t a)
+  (let ((av (node-value a)))
+    (record-op! t (list a) (- av)
+                (lambda (g) (list (- g))))))
+
+;; ── Reverse pass ──
+;; Distribute a list of input-grads onto a list of input-nodes (pairwise).
+(define (tape-distribute! ins grads)
+  (if (and (pair? ins) (pair? grads))
+      (begin
+        (node-grad-add! (car ins) (car grads))
+        (tape-distribute! (cdr ins) (cdr grads)))))
+
+;; Zero every node's gradient (so gradient can be called repeatedly).
+(define (tape-zero-grads! t)
+  (tape-for-each (lambda (n) (node-grad-set! n 0.0)) (tape-nodes t)))
+
+;; tape-gradient: reverse-mode from `output`, then read gradients at `targets`.
+;; `targets` is a list of nodes; returns a list of gradients in the same order.
+(define (tape-gradient t output targets)
+  (tape-zero-grads! t)
+  (node-grad-set! output 1.0)
+  (tape-for-each
+    (lambda (op)
+      (let* ((out (car op))
+             (ins (cadr op))
+             (backward (caddr op))
+             (g (node-grad out)))
+        (if (not (= g 0.0))
+            (tape-distribute! ins (backward g)))))
+    (tape-ops t))            ; reverse-chronological (prepended) = reverse topo order
+  (tape-map1 node-grad targets))
+
+;; ── snapshot / restore ──
+;; Capture the current node VALUES (for replay); restore writes them back.
+(define (tape-snapshot t)
+  (tape-map1 node-value (tape-nodes t)))
+
+(define (tape-restore t snapshot)
+  (let loop ((ns (tape-nodes t)) (vs snapshot))
+    (if (and (pair? ns) (pair? vs))
+        (begin
+          (vector-set! (car ns) 0 (car vs))
+          (loop (cdr ns) (cdr vs)))))
+  t)
 
 ;; ── Dynamic "current tape" (with-tape / current-tape) ──
-;; Opens a fresh tape, binds it as the current tape for the dynamic extent of
-;; `thunk`, and restores the previous current tape afterward. Higher-level ops
-;; (and record-op!, once added) record onto (current-tape). `name` is retained
-;; for debugging / snapshot labelling.
 (define *eshkol-current-tape* #f)
-
 (define (current-tape) *eshkol-current-tape*)
-
 (define (with-tape name thunk)
   (let ((prev *eshkol-current-tape*)
-        (tape (ad-tape-new)))
+        (tape (make-tape)))
     (set! *eshkol-current-tape* tape)
     (let ((result (thunk)))
       (set! *eshkol-current-tape* prev)
       result)))
 
-;; tape-gradient: run reverse mode from `output` on `tape`, then read the
-;; accumulated gradient at each target node. `targets` is a list of node ids;
-;; returns a list of gradients in the same order.
-(define (tape-gradient tape output targets)
-  (ad-backward tape output)
-  (map (lambda (t) (ad-gradient tape t)) targets))
-
 ;; Note: ad-value is exposed as a codegen builtin alias for ad-node-value
-;; (see llvm_codegen.cpp). This gives the user-facing name `ad-value`
-;; alongside the historical internal name `ad-node-value`.
+;; (see llvm_codegen.cpp).

--- a/tests/ad/free_energy_ad_test.esk
+++ b/tests/ad/free_energy_ad_test.esk
@@ -1,0 +1,48 @@
+;; FE-AD: differentiable variational free energy via the stateful tape.
+;; Demonstrates that a factor graph's free energy is differentiable w.r.t. its CPT
+;; parameters using record-fd-op! — the learning gate for the active-inference /
+;; consciousness layer (v1.5-intelligence). The gradient routes through BP
+;; reconvergence, which has no closed-form backward here, so the finite-difference
+;; custom op is exactly the right tool.
+
+(require core.ad.tape)
+
+(define pass-count 0)
+(define fail-count 0)
+(define (approx= a b) (< (abs (- a b)) 1e-2))
+(define (check name got expect)
+  (if (approx= got expect)
+      (begin (set! pass-count (+ pass-count 1)) (display "PASS: ")(display name)(newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "FAIL: ")(display name)(display " got ")(display got)
+             (display " expect ")(display expect)(newline))))
+
+(define fg (make-factor-graph 2 #(2 2)))
+(fg-add-factor! fg #(0) #(-0.3567 -1.2040))
+(fg-add-factor! fg #(0 1) #(-0.1054 -2.3026 -1.6094 -0.2231))
+(define obs #(#(0 0)))
+
+;; forward: set CPT[0,0]=p, reconverge belief propagation, return free energy
+(define (fe-of vals)
+  (fg-update-cpt! fg 0 (vector (car vals) -1.2040))
+  (fg-infer! fg 30)
+  (free-energy fg obs))
+
+(define g
+  (with-tape "free-energy"
+    (lambda ()
+      (let* ((t (current-tape))
+             (p (tape-input t -0.3567))
+             (out (record-fd-op! t (list p) fe-of)))
+        (tape-gradient t out (list p))))))
+
+;; coarse-scale central difference for an independent reference
+(define (fe-at p) (begin (fg-update-cpt! fg 0 (vector p -1.2040)) (fg-infer! fg 30) (free-energy fg obs)))
+(define ref (/ (- (fe-at -0.3467) (fe-at -0.3667)) 0.02))
+
+(check "dFE/dCPT is nonzero" (if (> (abs (car g)) 0.1) 1.0 0.0) 1.0)
+(check "dFE/dCPT matches finite differences" (car g) ref)
+
+(newline)
+(display "Passed: ")(display pass-count)(newline)
+(display "Failed: ")(display fail-count)(newline)

--- a/tests/ad/stateful_tape_test.esk
+++ b/tests/ad/stateful_tape_test.esk
@@ -94,6 +94,24 @@
 (check "tensor custom grad_b[0]" (vector-ref (cadr gv) 0) 1.0)
 (check "tensor custom grad_b[2]" (vector-ref (cadr gv) 2) 3.0)
 
+;; finite-difference custom op: differentiate an arbitrary scalar fn with no
+;; hand-written backward, mixed with a builtin op. loss = (x^2*y + sin x) + y*y.
+(define (fn vals)
+  (let ((x (car vals)) (y (cadr vals)))
+    (+ (* (* x x) y) (sin x))))
+(define gfd
+  (with-tape "fd"
+    (lambda ()
+      (let* ((t (current-tape))
+             (x (tape-input t 2.0))
+             (y (tape-input t 3.0))
+             (fo (record-fd-op! t (list x y) fn))
+             (yy (tape-mul t y y))
+             (loss (tape-add t fo yy)))
+        (tape-gradient t loss (list x y))))))
+(check "fd-op grad x (2xy+cos x)" (car gfd)  (+ 12.0 (cos 2.0)))
+(check "fd-op+builtin grad y (x^2+2y)" (cadr gfd) 10.0)
+
 ;; snapshot / restore
 (define ts (make-tape))
 (define nx (tape-input ts 3.0))

--- a/tests/ad/stateful_tape_test.esk
+++ b/tests/ad/stateful_tape_test.esk
@@ -120,6 +120,45 @@
 (tape-restore ts snap)
 (check "snapshot/restore" (node-value nx) 3.0)
 
+;; builtin activation ops + their backward rules
+(define (op1-grad opf x0)
+  (with-tape "op"
+    (lambda ()
+      (let* ((t (current-tape)) (x (tape-input t x0)) (o (opf t x)))
+        (car (tape-gradient t o (list x)))))))
+(check "tape-square grad (2x at 3)"  (op1-grad tape-square 3.0)  6.0)
+(check "tape-sqrt grad (1/2sqrt at 4)" (op1-grad tape-sqrt 4.0)  0.25)
+(check "tape-tanh grad (1-tanh^2 at 0)" (op1-grad tape-tanh 0.0) 1.0)
+(check "tape-sigmoid grad (.25 at 0)" (op1-grad tape-sigmoid 0.0) 0.25)
+(check "tape-relu grad (1 at 2)"     (op1-grad tape-relu 2.0)    1.0)
+(check "tape-relu grad (0 at -2)"    (op1-grad tape-relu -2.0)   0.0)
+
+;; end-to-end learning: gradient descent fits y = w*x + b to y = 2x + 1
+(define lr 0.03)
+(define (gd-of x0 y0 wv bv)
+  (with-tape "fit"
+    (lambda ()
+      (let* ((t (current-tape))
+             (wn (tape-input t wv)) (bn (tape-input t bv))
+             (pred (tape-add t (tape-mul t wn (tape-const t x0)) bn))
+             (loss (tape-square t (tape-sub t pred (tape-const t y0)))))
+        (tape-gradient t loss (list wn bn))))))
+(define fit
+  (let ((xs (list 0.0 1.0 2.0 3.0)) (ys (list 1.0 3.0 5.0 7.0)))
+    (let train ((i 0) (w 0.0) (b 0.0))
+      (if (>= i 400)
+          (list w b)
+          (let ((grads (let loop ((xl xs) (yl ys) (dw 0.0) (db 0.0))
+                         (if (pair? xl)
+                             (let ((g (gd-of (car xl) (car yl) w b)))
+                               (loop (cdr xl) (cdr yl) (+ dw (car g)) (+ db (cadr g))))
+                             (list dw db)))))
+            (train (+ i 1)
+                   (- w (* lr (car grads)))
+                   (- b (* lr (cadr grads)))))))))
+(check "trained w -> 2" (car fit)  2.0)
+(check "trained b -> 1" (cadr fit) 1.0)
+
 (newline)
 (display "Passed: ")(display pass-count)(newline)
 (display "Failed: ")(display fail-count)(newline)

--- a/tests/ad/stateful_tape_test.esk
+++ b/tests/ad/stateful_tape_test.esk
@@ -1,0 +1,84 @@
+;; Stateful AD tape with custom-op backward closures (TAPE feature).
+;; Acceptance: a scalar loss routes through builtin AND custom ops; gradients are
+;; correct (verified against finite differences) and snapshot/restore replays.
+
+(require core.ad.tape)
+
+(define pass-count 0)
+(define fail-count 0)
+(define (approx= a b) (< (abs (- a b)) 1e-4))
+(define (check name got expect)
+  (if (approx= got expect)
+      (begin (set! pass-count (+ pass-count 1))
+             (display "PASS: ")(display name)(newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "FAIL: ")(display name)
+             (display " got ")(display got)(display " expect ")(display expect)(newline))))
+
+(define (softplus v) (log (+ 1.0 (exp v))))
+(define (sigmoid v)  (/ 1.0 (+ 1.0 (exp (- v)))))
+
+;; loss(x,y) = softplus(x*y) + y*y  — builtin mul/add + CUSTOM softplus
+(define (tape-grad x0 y0)
+  (with-tape "loss"
+    (lambda ()
+      (let* ((t (current-tape))
+             (x (tape-input t x0))
+             (y (tape-input t y0))
+             (m (tape-mul t x y))
+             (s (let ((mv (node-value m)))
+                  (record-op! t (list m) (softplus mv)
+                              (lambda (g) (list (* g (sigmoid mv)))))))
+             (y2 (tape-mul t y y))
+             (loss (tape-add t s y2)))
+        (tape-gradient t loss (list x y))))))
+
+(define (loss-fn x y) (+ (softplus (* x y)) (* y y)))
+(define (fd-x x y) (/ (- (loss-fn (+ x 1e-6) y) (loss-fn (- x 1e-6) y)) 2e-6))
+(define (fd-y x y) (/ (- (loss-fn x (+ y 1e-6)) (loss-fn x (- y 1e-6))) 2e-6))
+
+(define g (tape-grad 1.5 0.5))
+(check "custom-op grad x vs finite-diff" (car g)  (fd-x 1.5 0.5))
+(check "custom-op grad y vs finite-diff" (cadr g) (fd-y 1.5 0.5))
+
+;; builtin-only sanity: grad of x^2 + y^2 at (3,4) = (6,8)
+(define gb
+  (with-tape "b"
+    (lambda ()
+      (let* ((t (current-tape))
+             (x (tape-input t 3.0))
+             (y (tape-input t 4.0))
+             (f (tape-add t (tape-mul t x x) (tape-mul t y y))))
+        (tape-gradient t f (list x y))))))
+(check "builtin grad x" (car gb) 6.0)
+(check "builtin grad y" (cadr gb) 8.0)
+
+;; multi-input custom op: sqdist(a,b) = (a-b)^2 -> grad (2(a-b), -2(a-b))
+(define gm
+  (with-tape "m"
+    (lambda ()
+      (let* ((t (current-tape))
+             (a (tape-input t 5.0))
+             (b (tape-input t 2.0))
+             (d (let ((av (node-value a)) (bv (node-value b)))
+                  (record-op! t (list a b) (* (- av bv) (- av bv))
+                              (lambda (gr) (list (* gr 2.0 (- av bv))
+                                                 (* gr -2.0 (- av bv))))))))
+        (tape-gradient t d (list a b))))))
+(check "multi-input custom grad a" (car gm)  6.0)
+(check "multi-input custom grad b" (cadr gm) -6.0)
+
+;; current-tape is #f outside any with-tape
+(check "current-tape #f outside scope" (if (current-tape) 1.0 0.0) 0.0)
+
+;; snapshot / restore
+(define ts (make-tape))
+(define nx (tape-input ts 3.0))
+(define snap (tape-snapshot ts))
+(vector-set! nx 0 99.0)
+(tape-restore ts snap)
+(check "snapshot/restore" (node-value nx) 3.0)
+
+(newline)
+(display "Passed: ")(display pass-count)(newline)
+(display "Failed: ")(display fail-count)(newline)

--- a/tests/ad/stateful_tape_test.esk
+++ b/tests/ad/stateful_tape_test.esk
@@ -71,6 +71,29 @@
 ;; current-tape is #f outside any with-tape
 (check "current-tape #f outside scope" (if (current-tape) 1.0 0.0) 0.0)
 
+;; tensor-valued custom op: dot(a,b) over embeddings; grad_a = b, grad_b = a.
+(define (scale-vec s v)
+  (let* ((n (vector-length v)) (r (make-vector n 0.0)))
+    (let loop ((i 0)) (if (< i n) (begin (vector-set! r i (* s (vector-ref v i))) (loop (+ i 1)))))
+    r))
+(define (vdot a b)
+  (let ((n (vector-length a)))
+    (let loop ((i 0) (s 0.0)) (if (< i n) (loop (+ i 1) (+ s (* (vector-ref a i) (vector-ref b i)))) s))))
+(define gv
+  (with-tape "tensor"
+    (lambda ()
+      (let* ((t (current-tape))
+             (a (tape-input t (vector 1.0 2.0 3.0)))
+             (b (tape-input t (vector 4.0 5.0 6.0)))
+             (av (node-value a)) (bv (node-value b))
+             (out (record-op! t (list a b) (vdot av bv)
+                    (lambda (gr) (list (scale-vec gr bv) (scale-vec gr av))))))
+        (tape-gradient t out (list a b))))))
+(check "tensor custom grad_a[0]" (vector-ref (car gv) 0)  4.0)
+(check "tensor custom grad_a[2]" (vector-ref (car gv) 2)  6.0)
+(check "tensor custom grad_b[0]" (vector-ref (cadr gv) 0) 1.0)
+(check "tensor custom grad_b[2]" (vector-ref (cadr gv) 2) 3.0)
+
 ;; snapshot / restore
 (define ts (make-tape))
 (define nx (tape-input ts 3.0))


### PR DESCRIPTION
## Summary
Implements the full **stateful AD tape with custom-op backward closures** (`STATEFUL_TAPE_REQUEST.md`) — the single biggest enabler for the Noesis learning layer. Pure-Scheme, self-contained in `lib/core/ad/tape.esk`.

## API
- `(with-tape name thunk)` / `(current-tape)` — dynamic tape scope
- `(make-tape)`, `(tape-input t v)`, `(tape-const t v)`
- **`(record-op! t inputs out-value backward)`** — custom op: inputs + forward value + a backward **closure** (`grad-out -> list of input grads`)
- `tape-add/sub/mul/div/sin/cos/exp/log/neg` — builtin ops recorded with backward rules
- `(tape-gradient t output targets)` — reverse mode; grads at targets in order
- `(tape-snapshot t)` / `(tape-restore t snap)`

## Why this design
Backward passes are Scheme closures, so custom reasoning ops (soft-unify, bp-message, encoder-forward, …) are differentiable **without** expressing them as builtin compositions — and **without** threading closures through the delicate C `ad_backward` pass. A native-C-tape custom op remains a future perf optimization (Noesis prioritizes correctness to unblock the learning layer).

## Acceptance — `tests/ad/stateful_tape_test.esk`, **8/8 (REPL + AOT)**
- Scalar loss through builtin `mul`/`add` **AND** a custom `softplus` op → gradients match central finite differences
- Multi-input custom op (`sqdist`) gradients correct
- builtin-only sanity (x²+y² → (6,8)); `current-tape` scoping; snapshot/restore

Supersedes the earlier increment-1 scoping-only version on this branch.