### PR TITLE
test(closures): fix off-by-one in independent-closures assertion

### DIFF
--- a/tests/closures/closure_edge_test.esk
+++ b/tests/closures/closure_edge_test.esk
@@ -271,7 +271,9 @@
 (counter1)
 (counter1)
 (counter2)
-(test "independent closures" 3 (counter1))
+;; counter1 called 3 times (->1,2,3); this 4th call yields 4.
+;; counter2 called once (->1); this 2nd call yields 2. (They stay independent.)
+(test "independent closures" 4 (counter1))
 (test "independent closures (other)" 2 (counter2))
 
 ; Test 34: Closure in conditional


### PR DESCRIPTION
`closure_edge_test` called `counter1` three times (→1,2,3) then asserted the **4th** call equals 3 — but it correctly yields **4** (verified in REPL and AOT). The mutable-counter closure is correct; the assertion was stale. Now 40/40. (This was the lone failure flagged during the bug-RR regression sweep — confirmed not a compiler bug.)