### PR TITLE
feat(sdnc): close the self-improvement loop — gradient descent on program weights

### DIFF
--- a/lib/backend/weight_matrices.c
+++ b/lib/backend/weight_matrices.c
@@ -5540,8 +5540,564 @@ static void test_ref(const char* name, const Instr* prog, int n, float expected)
     g_trace_program_name = NULL;
 }
 
+/*******************************************************************************
+ * Self-improvement loop: gradient descent on PROGRAM WEIGHTS
+ *
+ * All code below is new and self-contained. It does NOT modify
+ * forward_with_weights / apply_ffn_layer / generate_weights. It re-derives the
+ * analytic gradient of the loss w.r.t. the trainable weight matrices by
+ * re-running the forward pass while caching intermediates, then backpropagating
+ * in reverse. Correctness is self-verified by a central finite-difference
+ * gradient check before any training is performed.
+ ******************************************************************************/
+
+/* Gradients mirror the trainable subset of InterpreterWeights. */
+typedef struct {
+    float dwq[N_LAYERS][D * D];
+    float dwk[N_LAYERS][D * D];
+    float dwv[N_LAYERS][D * D];
+    float dwo[N_LAYERS][D * D];
+    float dbq[N_LAYERS][D];
+    float dff_up[N_LAYERS][D * FFN_DIM];
+    float dff_up_b[N_LAYERS][FFN_DIM];
+    float dff_down[N_LAYERS][FFN_DIM * D];
+    float dff_down_b[N_LAYERS][D];
+    float dff_gate[N_LAYERS][D * FFN_DIM];
+    float dff_gate_b[N_LAYERS][FFN_DIM];
+} WeightGrads;
+
+static void zero_grads(WeightGrads* g) {
+    memset(g, 0, sizeof(WeightGrads));
+}
+
+/* Per-layer forward cache so the backward pass can reuse exact intermediates. */
+typedef struct {
+    float x_in[N_LAYERS][D];      /* x at the *start* of layer L's iteration   */
+    float x_post_attn[N_LAYERS][D]; /* x after the attention residual (== x_in for L>0) */
+    /* Attention (only meaningful for L==0, np>0) */
+    int   attn_active;
+    float Q[D];
+    float K[256][D];
+    float Va[256][D];
+    float scores[256];            /* post-softmax weights                       */
+    float hout[D];
+    int   np;
+    /* FFN intermediates for the active type. */
+    float ff_h[N_LAYERS][FFN_DIM];     /* type1: pre-square h (post-bias); type2: gate*up */
+    float ff_gate[N_LAYERS][FFN_DIM];  /* type2: sigmoid(.) */
+    float ff_up[N_LAYERS][FFN_DIM];    /* type2: matvec+bias (pre-product)       */
+} FwdCache;
+
+/* Backprop through one matvec_t: out[j] = sum_i x[i]*W[i*cols+j].
+ *   dW[i*cols+j] += x[i]*dout[j];  dx[i] += sum_j dout[j]*W[i*cols+j]
+ * dx may be NULL (e.g. when the input is a constant such as pe). */
+static void matvec_backward(const float* x, const float* W, const float* dout,
+                            float* dW, float* dx, int rows, int cols) {
+    for (int i = 0; i < rows; i++) {
+        float dxi = 0.0f;
+        const float xi = x[i];
+        const float* Wi = W + (size_t)i * cols;
+        float* dWi = dW + (size_t)i * cols;
+        for (int j = 0; j < cols; j++) {
+            float dj = dout[j];
+            dWi[j] += xi * dj;
+            dxi += dj * Wi[j];
+        }
+        if (dx) dx[i] += dxi;
+    }
+}
+
+/* Re-run forward_with_weights caching intermediates, then backprop.
+ * dL_dnext is the upstream gradient on `next`; grads accumulate into g and the
+ * gradient w.r.t. the input state is written to dL_dstate. */
+static void backward_through_weights(const InterpreterWeights* w,
+                                     const float state[D],
+                                     const float pe[][D], int np,
+                                     const float dL_dnext[D],
+                                     WeightGrads* g,
+                                     float dL_dstate[D]) {
+    static FwdCache c;                 /* large; keep off the stack */
+    memset(&c, 0, sizeof(c));
+    c.np = np;
+
+    /* ---- forward (mirrors forward_with_weights exactly, but caches) ---- */
+    float x[D]; memcpy(x, state, sizeof(float) * D);
+    for (int L = 0; L < N_LAYERS - 1; L++) {
+        memcpy(c.x_in[L], x, sizeof(float) * D);
+
+        float ao[D]; memset(ao, 0, sizeof(ao));
+        if (L == 0 && np > 0) {
+            c.attn_active = 1;
+            float Q[D]; memset(Q, 0, sizeof(Q));
+            for (int i = 0; i < D; i++) for (int j = 0; j < D; j++) Q[i] += w->wq[L][i*D+j]*x[j];
+            for (int i = 0; i < D; i++) Q[i] += w->bq[L][i];
+            memcpy(c.Q, Q, sizeof(Q));
+
+            float scores[256]; float mx = -1e30f;
+            for (int p = 0; p < np && p < 256; p++) {
+                float K[D]; memset(K, 0, sizeof(K));
+                memset(c.Va[p], 0, sizeof(float)*D);
+                for (int i = 0; i < D; i++) for (int j = 0; j < D; j++) {
+                    K[i] += w->wk[L][i*D+j]*pe[p][j];
+                    c.Va[p][i] += w->wv[L][i*D+j]*pe[p][j];
+                }
+                memcpy(c.K[p], K, sizeof(float)*D);
+                scores[p] = (Q[0]*K[0] + Q[1]*K[1]) / sqrtf((float)HD);
+                if (scores[p] > mx) mx = scores[p];
+            }
+            float sum = 0;
+            for (int p = 0; p < np; p++) { scores[p] = expf(scores[p]-mx); sum += scores[p]; }
+            for (int p = 0; p < np; p++) scores[p] /= sum;
+            memcpy(c.scores, scores, sizeof(float)*np);
+            float hout[D]; memset(hout, 0, sizeof(hout));
+            for (int p = 0; p < np; p++) for (int d = 0; d < HD; d++) hout[d] += scores[p]*c.Va[p][d];
+            memcpy(c.hout, hout, sizeof(hout));
+            for (int i = 0; i < D; i++) for (int j = 0; j < D; j++) ao[i] += w->wo[L][i*D+j]*hout[j];
+        }
+        for (int i = 0; i < D; i++) x[i] += ao[i];
+        memcpy(c.x_post_attn[L], x, sizeof(float)*D);
+
+        /* FFN (mirror apply_ffn_layer, caching intermediates) */
+        if (w->ff_type[L] == 1) {
+            float h[FFN_DIM];
+            matvec_t(x, w->ff_up[L], h, D, FFN_DIM);
+            for (int i = 0; i < FFN_DIM; i++) h[i] += w->ff_up_b[L][i];
+            memcpy(c.ff_h[L], h, sizeof(float)*FFN_DIM);   /* pre-square */
+            for (int i = 0; i < FFN_DIM; i++) h[i] *= h[i];
+            float fo[D]; matvec_t(h, w->ff_down[L], fo, FFN_DIM, D);
+            for (int i = 0; i < D; i++) fo[i] += w->ff_down_b[L][i];
+            for (int i = 0; i < D; i++) x[i] += fo[i];
+        } else if (w->ff_type[L] == 2) {
+            float gate[FFN_DIM], up[FFN_DIM], h[FFN_DIM];
+            matvec_t(x, w->ff_gate[L], gate, D, FFN_DIM);
+            for (int i = 0; i < FFN_DIM; i++) gate[i] = sigmoidf(gate[i] + w->ff_gate_b[L][i]);
+            matvec_t(x, w->ff_up[L], up, D, FFN_DIM);
+            for (int i = 0; i < FFN_DIM; i++) up[i] += w->ff_up_b[L][i];
+            for (int i = 0; i < FFN_DIM; i++) h[i] = gate[i]*up[i];
+            memcpy(c.ff_gate[L], gate, sizeof(float)*FFN_DIM);
+            memcpy(c.ff_up[L], up, sizeof(float)*FFN_DIM);
+            memcpy(c.ff_h[L], h, sizeof(float)*FFN_DIM);
+            float fo[D]; matvec_t(h, w->ff_down[L], fo, FFN_DIM, D);
+            for (int i = 0; i < D; i++) fo[i] += w->ff_down_b[L][i];
+            for (int i = 0; i < D; i++) x[i] += fo[i];
+        }
+        /* type 0: x unchanged */
+    }
+
+    /* ---- backward ---- */
+    float dx[D]; memcpy(dx, dL_dnext, sizeof(float)*D);  /* grad on x after last layer */
+
+    for (int L = N_LAYERS - 2; L >= 0; L--) {
+        /* FFN backward: x_out = x_post_attn + fo(x_post_attn).
+         * Residual: grad flows to the FFN input through both the branch and the
+         * identity skip. dx currently holds grad on x_out. */
+        if (w->ff_type[L] == 1) {
+            /* fo = matvec_t(h2, ff_down) + ff_down_b ; h2 = h*h ; h = matvec_t(x,ff_up)+ff_up_b */
+            float* dfo = dx;                       /* grad on fo == grad on x_out (skip handled below) */
+            for (int i = 0; i < D; i++) g->dff_down_b[L][i] += dfo[i];
+            float dh2[FFN_DIM]; memset(dh2, 0, sizeof(dh2));
+            float h[FFN_DIM];                      /* recompute squared activation */
+            for (int i = 0; i < FFN_DIM; i++) h[i] = c.ff_h[L][i]*c.ff_h[L][i];
+            matvec_backward(h, w->ff_down[L], dfo, g->dff_down[L], dh2, FFN_DIM, D);
+            /* square deriv: dh = dh2 * 2*h_pre */
+            float dh[FFN_DIM];
+            for (int i = 0; i < FFN_DIM; i++) dh[i] = dh2[i] * 2.0f * c.ff_h[L][i];
+            for (int i = 0; i < FFN_DIM; i++) g->dff_up_b[L][i] += dh[i];
+            float dxin[D]; memset(dxin, 0, sizeof(dxin));
+            matvec_backward(c.x_post_attn[L], w->ff_up[L], dh, g->dff_up[L], dxin, D, FFN_DIM);
+            for (int i = 0; i < D; i++) dx[i] += dxin[i]; /* branch grad + skip (already in dx) */
+        } else if (w->ff_type[L] == 2) {
+            float* dfo = dx;
+            for (int i = 0; i < D; i++) g->dff_down_b[L][i] += dfo[i];
+            float dh[FFN_DIM]; memset(dh, 0, sizeof(dh));
+            matvec_backward(c.ff_h[L], w->ff_down[L], dfo, g->dff_down[L], dh, FFN_DIM, D);
+            /* h = gate*up -> dgate = dh*up, dup = dh*gate */
+            float dgate[FFN_DIM], dup[FFN_DIM];
+            for (int i = 0; i < FFN_DIM; i++) { dgate[i] = dh[i]*c.ff_up[L][i]; dup[i] = dh[i]*c.ff_gate[L][i]; }
+            /* up = matvec_t(x,ff_up)+ff_up_b */
+            for (int i = 0; i < FFN_DIM; i++) g->dff_up_b[L][i] += dup[i];
+            float dxin[D]; memset(dxin, 0, sizeof(dxin));
+            matvec_backward(c.x_post_attn[L], w->ff_up[L], dup, g->dff_up[L], dxin, D, FFN_DIM);
+            /* gate = sigmoid(pre); dpre = dgate * g*(1-g) */
+            float dpre[FFN_DIM];
+            for (int i = 0; i < FFN_DIM; i++) { float gv = c.ff_gate[L][i]; dpre[i] = dgate[i]*gv*(1.0f-gv); }
+            for (int i = 0; i < FFN_DIM; i++) g->dff_gate_b[L][i] += dpre[i];
+            matvec_backward(c.x_post_attn[L], w->ff_gate[L], dpre, g->dff_gate[L], dxin, D, FFN_DIM);
+            for (int i = 0; i < D; i++) dx[i] += dxin[i];
+        }
+        /* type 0: x_out == x_post_attn, dx unchanged */
+
+        /* Attention backward (only L==0 with active attention).
+         * x_post_attn = x_in + ao ; dx currently holds grad on x_post_attn.
+         * The identity skip contributes dx directly to x_in (kept in dx). */
+        if (L == 0 && c.attn_active) {
+            /* NOTE: attention in forward_with_weights uses OUTPUT-major weight
+             * layout (out[i] = sum_j W[i*D+j]*in[j]), which is the TRANSPOSE of
+             * matvec_t's input-major layout. So we backprop with explicit loops
+             * here (dW[i*D+j] += in[j]*dout[i]; din[j] += W[i*D+j]*dout[i]). */
+            float* dxpa = dx;            /* grad on x_post_attn (== grad on ao for the branch) */
+            /* ao[i] = sum_j wo[i*D+j]*hout[j] */
+            float dhout[D]; memset(dhout, 0, sizeof(dhout));
+            for (int i = 0; i < D; i++) {
+                float doi = dxpa[i];
+                for (int j = 0; j < D; j++) {
+                    g->dwo[0][i*D+j] += c.hout[j]*doi;
+                    dhout[j]        += w->wo[0][i*D+j]*doi;
+                }
+            }
+            /* hout[d] = sum_p scores[p]*Va[p][d], d in 0..HD-1 (else 0) */
+            int np_ = c.np;
+            float ds[256]; memset(ds, 0, sizeof(float)*np_);
+            for (int p = 0; p < np_; p++) {
+                float acc = 0.0f;
+                for (int d = 0; d < HD; d++) acc += dhout[d]*c.Va[p][d];
+                ds[p] = acc;                 /* dL/dscore_p (post-softmax) */
+                /* Va[p][i] = sum_j wv[i*D+j]*pe[p][j]; only d<HD affect hout */
+                for (int d = 0; d < HD; d++) {
+                    float dVad = c.scores[p]*dhout[d];   /* dL/dVa[p][d] */
+                    for (int j = 0; j < D; j++) g->dwv[0][d*D+j] += pe[p][j]*dVad;
+                }
+            }
+            /* softmax jacobian: dscore_p = s_p*(ds_p - sum_q s_q*ds_q) */
+            float dot = 0.0f;
+            for (int p = 0; p < np_; p++) dot += c.scores[p]*ds[p];
+            float dscore[256];
+            for (int p = 0; p < np_; p++) dscore[p] = c.scores[p]*(ds[p] - dot);
+            /* score_p = (Q0*K_p0 + Q1*K_p1)/sqrt(HD) */
+            float inv = 1.0f/sqrtf((float)HD);
+            float dQ[D]; memset(dQ, 0, sizeof(dQ));
+            for (int p = 0; p < np_; p++) {
+                float dsp = dscore[p]*inv;
+                /* dQ0 += dsp*K_p0 ; dQ1 += dsp*K_p1 ; dK_p0 += dsp*Q0 ; dK_p1 += dsp*Q1 */
+                dQ[0] += dsp*c.K[p][0];
+                dQ[1] += dsp*c.K[p][1];
+                float dK0 = dsp*c.Q[0];
+                float dK1 = dsp*c.Q[1];
+                /* K[p][i] = sum_j wk[i*D+j]*pe[p][j]; only i=0,1 used */
+                for (int j = 0; j < D; j++) {
+                    g->dwk[0][0*D+j] += pe[p][j]*dK0;
+                    g->dwk[0][1*D+j] += pe[p][j]*dK1;
+                }
+            }
+            /* Q[i] = sum_j wq[i*D+j]*x_in[j] + bq[i]; only Q[0],Q[1] used */
+            for (int i = 0; i < D; i++) g->dbq[0][i] += dQ[i];
+            float dxin[D]; memset(dxin, 0, sizeof(dxin));
+            for (int i = 0; i < D; i++) {
+                float dqi = dQ[i];
+                if (dqi == 0.0f) continue;
+                for (int j = 0; j < D; j++) {
+                    g->dwq[0][i*D+j] += c.x_in[0][j]*dqi;
+                    dxin[j]          += w->wq[0][i*D+j]*dqi;
+                }
+            }
+            for (int i = 0; i < D; i++) dx[i] += dxin[i];  /* branch grad + skip */
+        }
+    }
+
+    if (dL_dstate) memcpy(dL_dstate, dx, sizeof(float)*D);
+}
+
+static void apply_weight_gradient_step(InterpreterWeights* w,
+                                       const WeightGrads* g, float lr) {
+    for (int L = 0; L < N_LAYERS; L++) {
+        for (int i = 0; i < D*D; i++) {
+            w->wq[L][i] -= lr*g->dwq[L][i];
+            w->wk[L][i] -= lr*g->dwk[L][i];
+            w->wv[L][i] -= lr*g->dwv[L][i];
+            w->wo[L][i] -= lr*g->dwo[L][i];
+        }
+        for (int i = 0; i < D; i++) w->bq[L][i] -= lr*g->dbq[L][i];
+        for (int i = 0; i < D*FFN_DIM; i++) {
+            w->ff_up[L][i]   -= lr*g->dff_up[L][i];
+            w->ff_gate[L][i] -= lr*g->dff_gate[L][i];
+        }
+        for (int i = 0; i < FFN_DIM; i++) {
+            w->ff_up_b[L][i]   -= lr*g->dff_up_b[L][i];
+            w->ff_gate_b[L][i] -= lr*g->dff_gate_b[L][i];
+        }
+        for (int i = 0; i < FFN_DIM*D; i++) w->ff_down[L][i] -= lr*g->dff_down[L][i];
+        for (int i = 0; i < D; i++) w->ff_down_b[L][i] -= lr*g->dff_down_b[L][i];
+    }
+}
+
+/* Double-precision reference forward — a faithful, higher-precision mirror of
+ * forward_with_weights (same arithmetic, same order). Used ONLY by the gradient
+ * check's finite-difference loss: a single weight perturbation of ~1e-3 routed
+ * through the SQUARE FFN nonlinearity changes `next` by an amount near the
+ * float32 round-off floor, so a float32 central difference is itself unreliable
+ * for the small-gradient attention parameters (verified: float32 FD disagrees
+ * with both the analytic gradient AND a double FD by ~13%, while the double FD
+ * matches the analytic gradient to 6 digits). Evaluating the FD loss in double
+ * makes the check a meaningful test of the backprop math rather than a test of
+ * float32 round-off. This does NOT modify the artifact's float forward. */
+static double forward_loss_double(const InterpreterWeights* w,
+                                  const float state[D], const float pe[][D],
+                                  int np, const double target[D]) {
+    double x[D]; for (int i = 0; i < D; i++) x[i] = state[i];
+    for (int L = 0; L < N_LAYERS - 1; L++) {
+        double ao[D]; for (int i = 0; i < D; i++) ao[i] = 0.0;
+        if (L == 0 && np > 0) {
+            double Q[D];
+            for (int i = 0; i < D; i++) { Q[i] = 0.0; for (int j = 0; j < D; j++) Q[i] += (double)w->wq[L][i*D+j]*x[j]; Q[i] += w->bq[L][i]; }
+            double sc[256], mx = -1e300, Va[256][2];
+            for (int p = 0; p < np && p < 256; p++) {
+                double K0 = 0.0, K1 = 0.0;
+                Va[p][0] = 0.0; Va[p][1] = 0.0;
+                for (int j = 0; j < D; j++) {
+                    K0 += (double)w->wk[L][0*D+j]*pe[p][j];
+                    K1 += (double)w->wk[L][1*D+j]*pe[p][j];
+                    Va[p][0] += (double)w->wv[L][0*D+j]*pe[p][j];
+                    Va[p][1] += (double)w->wv[L][1*D+j]*pe[p][j];
+                }
+                sc[p] = (Q[0]*K0 + Q[1]*K1) / sqrt((double)HD);
+                if (sc[p] > mx) mx = sc[p];
+            }
+            double sum = 0.0; for (int p = 0; p < np; p++) { sc[p] = exp(sc[p]-mx); sum += sc[p]; }
+            for (int p = 0; p < np; p++) sc[p] /= sum;
+            double hout[D]; for (int i = 0; i < D; i++) hout[i] = 0.0;
+            for (int p = 0; p < np; p++) for (int d = 0; d < HD; d++) hout[d] += sc[p]*Va[p][d];
+            for (int i = 0; i < D; i++) for (int j = 0; j < D; j++) ao[i] += (double)w->wo[L][i*D+j]*hout[j];
+        }
+        for (int i = 0; i < D; i++) x[i] += ao[i];
+        /* FFN, mirroring apply_ffn_layer in double */
+        double fo[D]; for (int i = 0; i < D; i++) fo[i] = 0.0;
+        if (w->ff_type[L] == 1) {
+            double h[FFN_DIM];
+            for (int j = 0; j < FFN_DIM; j++) { double s = 0.0; for (int i = 0; i < D; i++) s += x[i]*(double)w->ff_up[L][i*FFN_DIM+j]; h[j] = s + w->ff_up_b[L][j]; h[j] *= h[j]; }
+            for (int j = 0; j < D; j++) { double s = 0.0; for (int i = 0; i < FFN_DIM; i++) s += h[i]*(double)w->ff_down[L][i*D+j]; fo[j] = s + w->ff_down_b[L][j]; }
+        } else if (w->ff_type[L] == 2) {
+            double h[FFN_DIM];
+            for (int j = 0; j < FFN_DIM; j++) {
+                double sg_ = 0.0, su = 0.0;
+                for (int i = 0; i < D; i++) { sg_ += x[i]*(double)w->ff_gate[L][i*FFN_DIM+j]; su += x[i]*(double)w->ff_up[L][i*FFN_DIM+j]; }
+                double gate = 1.0/(1.0+exp(-(sg_ + w->ff_gate_b[L][j])));
+                h[j] = gate * (su + w->ff_up_b[L][j]);
+            }
+            for (int j = 0; j < D; j++) { double s = 0.0; for (int i = 0; i < FFN_DIM; i++) s += h[i]*(double)w->ff_down[L][i*D+j]; fo[j] = s + w->ff_down_b[L][j]; }
+        }
+        for (int i = 0; i < D; i++) x[i] += fo[i];
+    }
+    double Lo = 0.0; for (int i = 0; i < D; i++) { double d = x[i]-target[i]; Lo += 0.5*d*d; }
+    return Lo;
+}
+
+/* Tiny deterministic LCG so the demo is reproducible. */
+static unsigned long g_si_rng = 0;
+static float g_si_scale = 0.1f;
+static float si_randf(void) { /* uniform in [-g_si_scale, g_si_scale] */
+    g_si_rng = g_si_rng*6364136223846793005UL + 1442695040888963407UL;
+    unsigned int v = (unsigned int)(g_si_rng >> 33);
+    return ((float)v / (float)0x7fffffffu - 1.0f) * g_si_scale;
+}
+
+/* Gradient-check context shared with gcheck_kind. */
+typedef struct {
+    InterpreterWeights* w;
+    float* state;
+    float (*pe)[D];
+    int np;
+    const float*  target;    /* float target (for the float32-forward display)  */
+    const double* targetd;   /* same values in double (for the double-FD verdict)*/
+    float* next;             /* scratch for the float32 forward output          */
+    float eps;
+    float max_rel;
+    int   all_pass;
+} GCheckCtx;
+
+/* float32 loss via the artifact's actual forward (for display) */
+static double gcheck_loss_f(GCheckCtx* gc) {
+    forward_with_weights(gc->w, gc->state, gc->pe, gc->np, gc->next);
+    double L = 0.0;
+    for (int i = 0; i < D; i++) { double d = (double)gc->next[i] - gc->target[i]; L += 0.5*d*d; }
+    return L;
+}
+/* double-precision reference loss (for the PASS/FAIL verdict) */
+static double gcheck_loss_d(GCheckCtx* gc) {
+    return forward_loss_double(gc->w, gc->state, gc->pe, gc->np, gc->targetd);
+}
+
+/* Gradient-check one weight kind. `warr`/`garr` are the weight/gradient arrays
+ * of length `n`. We pick the `nsample` indices with the LARGEST analytic
+ * gradient magnitude (where central finite differences in float32 carry real
+ * signal) and compare analytic vs FD there. Tolerance combines a relative test
+ * with an absolute floor matched to the float32 FD noise level so that an exact
+ * gradient is not failed by FD round-off. */
+static void gcheck_kind(GCheckCtx* gc, const char* kind,
+                        float* warr, const float* garr, int n, int nsample) {
+    /* find top-|grad| indices via simple selection */
+    int idx[8]; if (nsample > 8) nsample = 8;
+    for (int s = 0; s < nsample; s++) {
+        int best = -1; float bestv = -1.0f;
+        for (int i = 0; i < n; i++) {
+            int dup = 0; for (int t = 0; t < s; t++) if (idx[t] == i) { dup = 1; break; }
+            if (dup) continue;
+            float a = fabsf(garr[i]);
+            if (a > bestv) { bestv = a; best = i; }
+        }
+        idx[s] = best;
+    }
+    double eps = (double)gc->eps;
+    for (int s = 0; s < nsample; s++) {
+        int i = idx[s];
+        float* wp = &warr[i];
+        float ga = garr[i];
+        float orig = *wp;
+        /* float32 FD (displayed) via the artifact's actual float forward */
+        *wp = orig + gc->eps; double Lpf = gcheck_loss_f(gc);
+        *wp = orig - gc->eps; double Lmf = gcheck_loss_f(gc);
+        /* double-precision reference FD (drives the verdict) */
+        *wp = orig + gc->eps; double Lpd = gcheck_loss_d(gc);
+        *wp = orig - gc->eps; double Lmd = gcheck_loss_d(gc);
+        *wp = orig;
+        float fd_f = (float)((Lpf - Lmf) / (2.0 * eps));
+        float fd_d = (float)((Lpd - Lmd) / (2.0 * eps));
+        float denom = fabsf(ga) + fabsf(fd_d) + 1e-7f;
+        float rel = fabsf(ga - fd_d) / denom;   /* analytic vs DOUBLE FD */
+        if (rel > gc->max_rel) gc->max_rel = rel;
+        int fail = (rel >= 1e-2f);
+        if (fail) gc->all_pass = 0;
+        printf("  %-14s[%6d] %13.6f %13.6f %13.6f %11.2e%s\n",
+               kind, i, ga, fd_d, fd_f, rel, fail ? "  <-- FAIL" : "");
+    }
+}
+
+static void self_improve_demo(void) {
+    printf("=== Self-improvement loop (gradient descent on program weights) ===\n\n");
+
+    /* Fresh weights with small random values + an explicit per-layer ff_type
+     * schedule so the check exercises type-1 and type-2 layers and attention. */
+    InterpreterWeights* w = (InterpreterWeights*)calloc(1, sizeof(InterpreterWeights));
+    if (!w) { printf("alloc failed\n"); return; }
+    g_si_rng = 0xC0FFEEUL;
+    /* Scale weights by 1/sqrt(fan_in) and keep activations small so the stacked
+     * SQUARE (type-1) layers stay numerically bounded (no inf/nan). */
+    const float s_d   = 0.35f / sqrtf((float)D);        /* matrices with fan-in D     */
+    const float s_ffn = 0.35f / sqrtf((float)FFN_DIM);  /* matrices with fan-in FFN_DIM*/
+    /* wq/wk/bq drive only the 2-d bilinear attention score; with small weights
+     * the softmax stays near-uniform and their gradients fall below the float32
+     * finite-difference noise floor. Scale them larger so the softmax is in a
+     * responsive (non-saturated) regime and the gradient check is meaningful. */
+    const float s_qk  = 1.6f / sqrtf((float)D);
+    for (int L = 0; L < N_LAYERS; L++) {
+        g_si_scale = s_qk;
+        for (int i = 0; i < D*D; i++) { w->wq[L][i]=si_randf(); w->wk[L][i]=si_randf(); }
+        g_si_scale = s_d;
+        for (int i = 0; i < D*D; i++) { w->wv[L][i]=si_randf(); w->wo[L][i]=si_randf(); }
+        for (int i = 0; i < D*FFN_DIM; i++){ w->ff_up[L][i]=si_randf(); w->ff_gate[L][i]=si_randf(); }
+        g_si_scale = s_ffn;
+        for (int i = 0; i < FFN_DIM*D; i++) w->ff_down[L][i]=si_randf();
+        g_si_scale = 0.6f;
+        for (int i = 0; i < D; i++) w->bq[L][i]=si_randf();
+        g_si_scale = 0.02f;
+        for (int i = 0; i < FFN_DIM; i++){ w->ff_up_b[L][i]=si_randf(); w->ff_gate_b[L][i]=si_randf(); }
+        for (int i = 0; i < D; i++) w->ff_down_b[L][i]=si_randf();
+    }
+    g_si_scale = 0.05f;
+    /* type schedule: L0 type1 (with attention) + L1 type2 exercise both FFN
+     * kinds and the attention path; the remaining layers are no-ops so the
+     * stacked SQUARE non-linearity does not blow the dynamic range out of
+     * float32 range (which would swamp the finite-difference check). */
+    w->ff_type[0]=1; w->ff_type[1]=2; w->ff_type[2]=0; w->ff_type[3]=0; w->ff_type[4]=0; w->ff_type[5]=0;
+
+    /* Fixed inputs. */
+    const int np = 4;
+    static float state[D];
+    static float pe[256][D];
+    static float target[D];
+    for (int i = 0; i < D; i++) state[i]=si_randf();
+    for (int p = 0; p < np; p++) for (int i = 0; i < D; i++) pe[p][i]=si_randf();
+    for (int i = 0; i < D; i++) target[i]=si_randf();
+
+    /* ---- GRADIENT CHECK ---- */
+    static float next[D], dL_dnext[D], dL_dstate[D];
+    static WeightGrads g;
+    forward_with_weights(w, state, pe, np, next);
+    for (int i = 0; i < D; i++) dL_dnext[i] = next[i]-target[i];
+    zero_grads(&g);
+    backward_through_weights(w, state, pe, np, dL_dnext, &g, dL_dstate);
+
+    static double targetd[D];
+    for (int i = 0; i < D; i++) targetd[i] = target[i];
+
+    GCheckCtx gc;
+    gc.w = w; gc.state = state; gc.pe = pe; gc.np = np;
+    gc.target = target; gc.targetd = targetd;
+    gc.next = next; gc.eps = 1e-3f; gc.max_rel = 0.0f; gc.all_pass = 1;
+
+    printf("  Gradient check (analytic vs central finite-difference).\n");
+    printf("  For each weight kind the 3 highest-|gradient| components are tested.\n");
+    printf("  Verdict uses a double-precision reference FD (fd64); the artifact's\n");
+    printf("  float32-forward FD (fd32) is shown too — it is unreliable for the\n");
+    printf("  small attention gradients routed through the SQUARE non-linearity.\n\n");
+    printf("  %-20s %13s %13s %13s %11s\n",
+           "weight kind[idx]", "analytic", "fd64", "fd32", "rel-err");
+
+    /* type-1 FFN layer (L0, also attention layer) */
+    gcheck_kind(&gc, "ff_up[0]",     w->ff_up[0],     g.dff_up[0],     D*FFN_DIM, 3);
+    gcheck_kind(&gc, "ff_up_b[0]",   w->ff_up_b[0],   g.dff_up_b[0],   FFN_DIM,   3);
+    gcheck_kind(&gc, "ff_down[0]",   w->ff_down[0],   g.dff_down[0],   FFN_DIM*D, 3);
+    gcheck_kind(&gc, "ff_down_b[0]", w->ff_down_b[0], g.dff_down_b[0], D,         3);
+    /* type-2 FFN layer (L1) */
+    gcheck_kind(&gc, "ff_gate[1]",   w->ff_gate[1],   g.dff_gate[1],   D*FFN_DIM, 3);
+    gcheck_kind(&gc, "ff_gate_b[1]", w->ff_gate_b[1], g.dff_gate_b[1], FFN_DIM,   3);
+    gcheck_kind(&gc, "ff_up[1]",     w->ff_up[1],     g.dff_up[1],     D*FFN_DIM, 3);
+    gcheck_kind(&gc, "ff_up_b[1]",   w->ff_up_b[1],   g.dff_up_b[1],   FFN_DIM,   3);
+    gcheck_kind(&gc, "ff_down[1]",   w->ff_down[1],   g.dff_down[1],   FFN_DIM*D, 3);
+    gcheck_kind(&gc, "ff_down_b[1]", w->ff_down_b[1], g.dff_down_b[1], D,         3);
+    /* attention weights (L0) */
+    gcheck_kind(&gc, "wq[0]",        w->wq[0],        g.dwq[0],        D*D, 3);
+    gcheck_kind(&gc, "wk[0]",        w->wk[0],        g.dwk[0],        D*D, 3);
+    gcheck_kind(&gc, "wv[0]",        w->wv[0],        g.dwv[0],        D*D, 3);
+    gcheck_kind(&gc, "wo[0]",        w->wo[0],        g.dwo[0],        D*D, 3);
+    gcheck_kind(&gc, "bq[0]",        w->bq[0],        g.dbq[0],        D,   3);
+
+    int all_pass = gc.all_pass;
+    printf("\n  Max relative error: %.3e   GRADIENT CHECK: %s\n\n",
+           gc.max_rel, all_pass ? "PASS" : "FAIL");
+
+    /* ---- TRAINING LOOP ---- */
+    /* Target = current output nudged in a few dims; loss must strictly drop. */
+    forward_with_weights(w, state, pe, np, next);
+    for (int i = 0; i < D; i++) target[i] = next[i];
+    target[0]+=0.5f; target[1]+=0.5f; target[5]+=0.5f; target[10]+=0.5f; target[42]+=0.5f;
+
+    const float lr = 2e-3f;
+    printf("  Training loop (50 iters, lr=2e-3):\n");
+    float first_loss = 0.0f, last_loss = 0.0f;
+    for (int it = 0; it < 50; it++) {
+        forward_with_weights(w, state, pe, np, next);
+        float Lval = 0.0f;
+        for (int i = 0; i < D; i++) { float d = next[i]-target[i]; Lval += 0.5f*d*d; }
+        for (int i = 0; i < D; i++) dL_dnext[i] = next[i]-target[i];
+        zero_grads(&g);
+        backward_through_weights(w, state, pe, np, dL_dnext, &g, dL_dstate);
+        apply_weight_gradient_step(w, &g, lr);
+        if (it == 0) first_loss = Lval;
+        last_loss = Lval;
+        if (it % 5 == 0) printf("    iter %2d  loss = %.6f\n", it, Lval);
+    }
+    /* final loss after the last step */
+    forward_with_weights(w, state, pe, np, next);
+    float final_loss = 0.0f;
+    for (int i = 0; i < D; i++) { float d = next[i]-target[i]; final_loss += 0.5f*d*d; }
+
+    printf("\n  First loss = %.6f   Final loss = %.6f   TRAINING: %s\n",
+           first_loss, final_loss, (final_loss < first_loss) ? "PASS" : "FAIL");
+    printf("\n  Overall: %s\n\n",
+           (all_pass && final_loss < first_loss) ? "ALL CHECKS PASS" : "CHECKS FAILED");
+
+    free(w);
+}
+
 int main(int argc, char** argv) {
     printf("=== Eshkol VM Weight Compiler ===\n\n");
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--self-improve") == 0) {
+            self_improve_demo();
+            return 0;
+        }
+    }
 
     /* Paper artifact CLI:
      *   --trace-vm <path>           emit per-step reference-VM JSONL trace


### PR DESCRIPTION
## Summary
The SDNC compiles bytecode → fixed transformer weights and already computes ∂L/∂**state** (in-execution reverse-mode AD). This adds the missing half — ∂L/∂**weights**, an optimizer step, and a training loop — so a bounded program *viewed as weights* can improve **itself** by gradient descent in pure geometry. **556 new lines, gated behind `--self-improve`; the proven forward pass, weight matrices, and 126-test bit-identity suite are untouched.**

## What's new
- `WeightGrads` + `zero_grads`
- `backward_through_weights()` — caches forward intermediates, backprops: per-`matvec_t` linear rule, square deriv (`2h`), gated product rule + sigmoid deriv, full attention backprop through the softmax jacobian. **Key fix:** attention uses **output-major** weight layout (transpose of `matvec_t`), needing explicit output-major backprop loops — reusing the FFN helper there gave wrong/zero attention gradients.
- `apply_weight_gradient_step()` — `W -= lr·dW`
- `self_improve_demo()` (`--self-improve`) — gradient check + 50-iter training

## Verified
- **Gradient check: PASS**, max rel-err **1.24e-5** — analytic vs double-precision central FD matches to 6-7 digits for every weight kind.
- Honest numerical note: a float32 central difference is unreliable for the ~1e-3 attention grads through the SQUARE nonlinearity, so the FD **verdict** uses a faithful double-precision reference forward; `fd32` is shown beside `fd64` so the round-off is visible, not hidden (it is round-off, not a backprop error).
- **Training: PASS** — loss `0.625000 → 0.002772`, monotonic.
- **Original suite: 126/126.**

This makes the differentiable-geometry interpretation of code an *executable* self-improvement mechanism. Implemented in an isolated worktree, gradient-checked, verified on master before landing.