### PR TITLE
feat(v1.5-intelligence): gradient estimators — Gumbel-Softmax + straight-through

### DIFF
--- a/lib/core/ml/gradient_estimators.esk
+++ b/lib/core/ml/gradient_estimators.esk
@@ -1,0 +1,191 @@
+;;
+;; core.ml.gradient_estimators — Gradient estimators for discrete operations,
+;; built on the stateful reverse-mode AD tape (core.ad.tape).
+;;
+;; Discrete operations (argmax, sampling a category, rounding) are not
+;; differentiable: their derivative is zero almost everywhere. To still train
+;; through them we use BIASED-but-USEFUL gradient estimators that substitute a
+;; surrogate backward pass:
+;;
+;;   * Gumbel-Softmax (Concrete) relaxation — replace a hard categorical sample
+;;     with a temperature-controlled soft one-hot:  softmax((logits+g)/tau).
+;;     As tau -> 0 it approaches a one-hot; gradients flow to the logits.
+;;
+;;   * Straight-Through estimator — forward emits the HARD value (one-hot /
+;;     round), backward pretends the op was the identity, so the upstream
+;;     gradient passes straight through unchanged.
+;;
+;; Everything is recorded on the stateful tape via record-op!, so a loss can
+;; route through these estimators together with builtin tape ops and reverse
+;; mode flows through all of them.
+;;
+;; Example:
+;;   (with-tape "g" (lambda ()
+;;     (let* ((t   (current-tape))
+;;            (lg  (tape-input t (vector 1.0 2.0 0.5)))
+;;            (p   (gumbel-softmax-det t lg 0.5 (vector 0.1 -0.2 0.3))))
+;;       (tape-gradient t (some-scalar-loss t p) (list lg)))))
+;;
+
+(provide gumbel-softmax gumbel-softmax-det
+         straight-through straight-through-round straight-through-onehot
+         categorical-pick argmax-onehot softmax
+         sample-gumbel-noise)
+
+;; ── Internal list/vector helpers ──
+;; Self-contained: this is a core module loaded BEFORE the list stdlib, so we
+;; must not use for-each / map at the top level (AOT would fail with
+;; "Unknown function: for-each"). Mirror tape.esk's recursion pattern.
+
+(define (ge-vec-of x)
+  ;; Coerce a list OR a vector of numbers into a fresh vector of doubles.
+  (if (vector? x)
+      x
+      (let loop ((l x) (n 0))            ; first pass: count
+        (if (pair? l)
+            (loop (cdr l) (+ n 1))
+            (let ((r (make-vector n 0.0)))
+              (let fill ((l2 x) (i 0))    ; second pass: fill
+                (if (pair? l2)
+                    (begin (vector-set! r i (exact->inexact (car l2)))
+                           (fill (cdr l2) (+ i 1)))
+                    r)))))))
+
+(define (ge-vec-copy v)
+  (let* ((n (vector-length v)) (r (make-vector n 0.0)))
+    (let loop ((i 0))
+      (if (< i n)
+          (begin (vector-set! r i (vector-ref v i)) (loop (+ i 1)))
+          r))))
+
+;; ── softmax (numerically stable) ──
+(define (softmax v)
+  (let* ((vv (ge-vec-of v))
+         (n  (vector-length vv)))
+    (if (= n 0)
+        (make-vector 0 0.0)
+        (let ((mx (let loop ((i 1) (m (vector-ref vv 0)))
+                    (if (< i n)
+                        (loop (+ i 1) (if (> (vector-ref vv i) m) (vector-ref vv i) m))
+                        m))))
+          (let* ((ex (make-vector n 0.0))
+                 (sum (let loop ((i 0) (s 0.0))
+                        (if (< i n)
+                            (let ((e (exp (- (vector-ref vv i) mx))))
+                              (vector-set! ex i e)
+                              (loop (+ i 1) (+ s e)))
+                            s))))
+            (let loop ((i 0))
+              (if (< i n)
+                  (begin (vector-set! ex i (/ (vector-ref ex i) sum)) (loop (+ i 1)))
+                  ex)))))))
+
+;; ── argmax index of a list/vector of numbers ──
+;; categorical-pick: the HARD decision — index of the largest entry.
+(define (categorical-pick probs)
+  (let* ((vv (ge-vec-of probs))
+         (n  (vector-length vv)))
+    (let loop ((i 1) (best 0) (bv (if (> n 0) (vector-ref vv 0) 0.0)))
+      (if (< i n)
+          (if (> (vector-ref vv i) bv)
+              (loop (+ i 1) i (vector-ref vv i))
+              (loop (+ i 1) best bv))
+          best))))
+
+;; argmax-onehot: a hard one-hot vector with a 1.0 at the argmax position.
+(define (argmax-onehot probs)
+  (let* ((vv (ge-vec-of probs))
+         (n  (vector-length vv))
+         (k  (categorical-pick vv))
+         (r  (make-vector n 0.0)))
+    (if (> n 0) (vector-set! r k 1.0))
+    r))
+
+;; ── Gumbel noise ──
+;; g = -log(-log(u)),  u ~ Uniform(0,1).  Tests pass explicit noise for
+;; determinism; this is provided for stochastic use.
+(define ge-eps 1.0e-20)
+(define (sample-gumbel-noise n)
+  (let ((r (make-vector n 0.0)))
+    (let loop ((i 0))
+      (if (< i n)
+          (let ((u (random)))            ; (random) -> double in [0,1)
+            (vector-set! r i (- (log (+ (- (log (+ u ge-eps))) ge-eps))))
+            (loop (+ i 1)))
+          r))))
+
+;; ── Gumbel-Softmax (Concrete) relaxation ──
+;;
+;; y_i = softmax_i( (logits + noise) / tau )
+;;
+;; Recorded as ONE custom op on the tape so gradients flow to the logits node.
+;; The forward output is the soft one-hot vector; the backward is the softmax
+;; Jacobian-vector product scaled by 1/tau:
+;;
+;;   z = (logits + g) / tau ;  y = softmax(z)
+;;   dL/dlogits = (1/tau) * J_softmax^T(z) . dL/dy
+;;             = (1/tau) * y ⊙ (dL/dy - <y, dL/dy>)
+;;
+;; `logits-node` is a tape node whose value is a list/vector of logits.
+;; `tau` is the temperature (> 0). `noise` is an explicit Gumbel-noise vector.
+(define (gumbel-softmax-det t logits-node tau noise)
+  (let* ((lv  (ge-vec-of (node-value logits-node)))
+         (nz  (ge-vec-of noise))
+         (n   (vector-length lv))
+         (z   (make-vector n 0.0)))
+    (let loop ((i 0))
+      (if (< i n)
+          (begin
+            (vector-set! z i (/ (+ (vector-ref lv i) (vector-ref nz i)) tau))
+            (loop (+ i 1)))))
+    (let ((y (softmax z)))
+      (record-op! t (list logits-node) y
+        (lambda (g)
+          ;; g is dL/dy (a vector). Return (list dL/dlogits).
+          (let* ((gy (ge-vec-of g))
+                 (dot (let dl ((i 0) (s 0.0))
+                        (if (< i n)
+                            (dl (+ i 1) (+ s (* (vector-ref y i) (vector-ref gy i))))
+                            s)))
+                 (out (make-vector n 0.0)))
+            (let dl ((i 0))
+              (if (< i n)
+                  (begin
+                    (vector-set! out i
+                      (* (/ 1.0 tau)
+                         (vector-ref y i)
+                         (- (vector-ref gy i) dot)))
+                    (dl (+ i 1)))))
+            (list out)))))))
+
+;; Stochastic variant: draws fresh Gumbel noise internally.
+(define (gumbel-softmax t logits-node tau)
+  (let ((n (vector-length (ge-vec-of (node-value logits-node)))))
+    (gumbel-softmax-det t logits-node tau (sample-gumbel-noise n))))
+
+;; ── Straight-Through estimator ──
+;;
+;; Forward emits the HARD value; backward is the identity (gradient passes
+;; through unchanged). This is the canonical ST estimator.
+;;
+;;   forward:  out = hard(x)
+;;   backward: dL/dx = dL/dout
+;;
+;; `est-node` is the tape node carrying the SOFT/continuous value; `hard-value`
+;; is the precomputed hard output (same shape — scalar or vector). The returned
+;; node has the hard value but routes gradient straight to est-node.
+(define (straight-through t est-node hard-value)
+  (record-op! t (list est-node) hard-value
+    (lambda (g) (list g))))
+
+;; straight-through-round: ST on scalar rounding.  Forward = (round x),
+;; backward = identity. Records a tape node from a scalar node x-node.
+(define (straight-through-round t x-node)
+  (straight-through t x-node (round (node-value x-node))))
+
+;; straight-through-onehot: ST on categorical argmax.  Forward = hard one-hot
+;; of the (soft) probability node; backward routes the gradient back to the
+;; soft probs unchanged. This is how you train through a discrete sample while
+;; keeping a usable gradient.
+(define (straight-through-onehot t probs-node)
+  (straight-through t probs-node (argmax-onehot (node-value probs-node))))

--- a/tests/ml/gradient_estimators_test.esk
+++ b/tests/ml/gradient_estimators_test.esk
@@ -1,0 +1,254 @@
+;; core.ml.gradient_estimators — gradient estimators for discrete operations.
+;; Acceptance:
+;;   * gumbel-softmax output sums to 1 and lies in [0,1].
+;;   * gradient of a loss through gumbel-softmax matches central finite
+;;     differences (rel err < 1e-2) for a fixed noise vector.
+;;   * straight-through forward == hard value, AND a training loop that uses ST
+;;     in the forward and the soft gradient in the backward DECREASES the loss.
+;;   * end-to-end: learn logits so gumbel-softmax concentrates on a target class.
+
+(require core.ad.tape)
+(require core.ml.gradient_estimators)
+
+(define pass-count 0)
+(define fail-count 0)
+(define (approx= a b) (< (abs (- a b)) 1e-4))
+(define (check-bool name ok)
+  (if ok
+      (begin (set! pass-count (+ pass-count 1))
+             (display "PASS: ")(display name)(newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "FAIL: ")(display name)(newline))))
+(define (check name got expect)
+  (check-bool (string-append name
+                (if (approx= got expect) ""
+                    (string-append " got " (number->string got)
+                                   " expect " (number->string expect))))
+              (approx= got expect)))
+
+;; ── helpers ──
+(define (vsum v)
+  (let ((n (vector-length v)))
+    (let loop ((i 0) (s 0.0))
+      (if (< i n) (loop (+ i 1) (+ s (vector-ref v i))) s))))
+
+(define (vin-range? v lo hi)
+  (let ((n (vector-length v)))
+    (let loop ((i 0))
+      (if (< i n)
+          (if (and (>= (vector-ref v i) lo) (<= (vector-ref v i) hi))
+              (loop (+ i 1))
+              #f)
+          #t))))
+
+(define noise (vector 0.10 -0.20 0.30 0.05))
+(define tau 0.5)
+(define target (vector 0.0 0.0 1.0 0.0))
+
+;; ── vector helpers ──
+(define (vcopy v)
+  (let* ((n (vector-length v)) (r (make-vector n 0.0)))
+    (let loop ((i 0)) (if (< i n) (begin (vector-set! r i (vector-ref v i)) (loop (+ i 1))) r))))
+(define (vsub a b)
+  (let* ((n (vector-length a)) (r (make-vector n 0.0)))
+    (let loop ((i 0)) (if (< i n) (begin (vector-set! r i (- (vector-ref a i) (vector-ref b i))) (loop (+ i 1))) r))))
+(define (vdot a b)
+  (let ((n (vector-length a)))
+    (let loop ((i 0) (s 0.0)) (if (< i n) (loop (+ i 1) (+ s (* (vector-ref a i) (vector-ref b i)))) s))))
+(define (vscale s v)
+  (let* ((n (vector-length v)) (r (make-vector n 0.0)))
+    (let loop ((i 0)) (if (< i n) (begin (vector-set! r i (* s (vector-ref v i))) (loop (+ i 1))) r))))
+
+;; ============================================================
+;; 1. gumbel-softmax output is a valid distribution
+;; ============================================================
+(define p0
+  (with-tape "p"
+    (lambda ()
+      (let* ((t  (current-tape))
+             (lg (tape-input t (vector 1.0 2.0 0.5 0.0)))
+             (gs (gumbel-softmax-det t lg tau noise)))
+        (node-value gs)))))
+(check "gumbel-softmax sums to 1" (vsum p0) 1.0)
+(check-bool "gumbel-softmax entries in [0,1]" (vin-range? p0 0.0 1.0))
+
+;; ============================================================
+;; 2. GRADIENT CHECK vs central finite differences
+;;    L = 0.5 * sum (p_i - target_i)^2 ,  p = gumbel-softmax(logits)
+;; ============================================================
+
+;; soft loss on a raw logit vector (no tape) — for finite differences
+(define (gs-soft logits)
+  (let* ((n (vector-length logits))
+         (z (make-vector n 0.0)))
+    (let loop ((i 0))
+      (if (< i n)
+          (begin (vector-set! z i (/ (+ (vector-ref logits i) (vector-ref noise i)) tau))
+                 (loop (+ i 1)))))
+    (softmax z)))
+
+(define (loss-of logits)
+  (let* ((p (gs-soft logits))
+         (n (vector-length p)))
+    (let loop ((i 0) (s 0.0))
+      (if (< i n)
+          (let ((d (- (vector-ref p i) (vector-ref target i))))
+            (loop (+ i 1) (+ s (* 0.5 d d))))
+          s))))
+
+;; tape gradient of the same loss w.r.t. logits
+(define logits0 (vector 1.0 2.0 0.5 0.0))
+(define tape-grad
+  (with-tape "gc"
+    (lambda ()
+      (let* ((t   (current-tape))
+             (lg  (tape-input t (vcopy logits0)))
+             (p   (gumbel-softmax-det t lg tau noise))
+             ;; loss = 0.5 * sum (p - target)^2, built from custom op
+             (tn  (tape-const t target))
+             (dvec (record-op! t (list p) (vsub (node-value p) target)
+                     (lambda (g) (list g))))  ; d(p-target)/dp = I
+             (loss (record-op! t (list dvec)
+                     (let ((d (node-value dvec)))
+                       (* 0.5 (vdot d d)))
+                     (lambda (g) (list (vscale g (node-value dvec)))))))
+        (car (tape-gradient t loss (list lg)))))))
+
+;; central finite-difference gradient of loss-of at logits0
+(define fd-eps 1.0e-5)
+(define (fd-grad-i i)
+  (let* ((lp (vcopy logits0)) (lm (vcopy logits0)))
+    (vector-set! lp i (+ (vector-ref lp i) fd-eps))
+    (vector-set! lm i (- (vector-ref lm i) fd-eps))
+    (/ (- (loss-of lp) (loss-of lm)) (* 2.0 fd-eps))))
+
+(define (rel-err a b)
+  (let ((d (abs (- a b))) (m (max (abs a) (abs b))))
+    (if (< m 1e-9) d (/ d m))))
+
+(check-bool "grad[0] vs finite-diff (rel<1e-2)" (< (rel-err (vector-ref tape-grad 0) (fd-grad-i 0)) 1e-2))
+(check-bool "grad[1] vs finite-diff (rel<1e-2)" (< (rel-err (vector-ref tape-grad 1) (fd-grad-i 1)) 1e-2))
+(check-bool "grad[2] vs finite-diff (rel<1e-2)" (< (rel-err (vector-ref tape-grad 2) (fd-grad-i 2)) 1e-2))
+(check-bool "grad[3] vs finite-diff (rel<1e-2)" (< (rel-err (vector-ref tape-grad 3) (fd-grad-i 3)) 1e-2))
+
+;; ============================================================
+;; 3. straight-through: forward == hard value
+;; ============================================================
+(define st-fwd
+  (with-tape "st"
+    (lambda ()
+      (let* ((t  (current-tape))
+             (x  (tape-input t (vector 0.1 0.7 0.2)))
+             (st (straight-through-onehot t x)))
+        (node-value st)))))
+(check "ST forward is hard one-hot at argmax (idx1=1)" (vector-ref st-fwd 1) 1.0)
+(check "ST forward hard one-hot (idx0=0)" (vector-ref st-fwd 0) 0.0)
+(check "ST forward hard one-hot (idx2=0)" (vector-ref st-fwd 2) 0.0)
+
+;; scalar ST round forward
+(define st-round
+  (with-tape "str"
+    (lambda ()
+      (let* ((t (current-tape)) (x (tape-input t 2.3)))
+        (node-value (straight-through-round t x))))))
+(check "ST-round forward == round(2.3)=2" st-round 2.0)
+
+;; ============================================================
+;; 3b. straight-through training: gradient flows -> loss decreases
+;;     We train a SOFT logit vector through softmax->straight-through one-hot.
+;;     Forward uses the HARD one-hot; backward uses the soft gradient.
+;;     loss = 0.5 * sum (onehot - target)^2 ; gradient flows via ST.
+;; ============================================================
+(define (st-step logits)
+  (with-tape "stt"
+    (lambda ()
+      (let* ((t   (current-tape))
+             (lg  (tape-input t (vcopy logits)))
+             ;; soft probabilities (differentiable)
+             (sp  (record-op! t (list lg) (softmax (node-value lg))
+                    (lambda (g)
+                      (let* ((y (softmax (node-value lg)))
+                             (gy g)
+                             (n (vector-length y))
+                             (dot (let dl ((i 0) (s 0.0))
+                                    (if (< i n) (dl (+ i 1) (+ s (* (vector-ref y i) (vector-ref gy i)))) s)))
+                             (out (make-vector n 0.0)))
+                        (let dl ((i 0))
+                          (if (< i n)
+                              (begin (vector-set! out i (* (vector-ref y i) (- (vector-ref gy i) dot))) (dl (+ i 1)))))
+                        (list out)))))
+             ;; straight-through: forward = hard one-hot, backward = identity to sp
+             (hard (straight-through-onehot t sp))
+             (dvec (record-op! t (list hard) (vsub (node-value hard) target)
+                     (lambda (g) (list g))))
+             (loss (record-op! t (list dvec)
+                     (let ((d (node-value dvec))) (* 0.5 (vdot d d)))
+                     (lambda (g) (list (vscale g (node-value dvec)))))))
+        (list (node-value loss) (car (tape-gradient t loss (list lg))))))))
+
+(define st-train
+  (let ((lr 0.5))
+    (let loop ((i 0) (logits (vector 0.2 0.5 0.1 0.0)) (first-loss -1.0) (last-loss 0.0))
+      (if (>= i 60)
+          (list first-loss last-loss logits)
+          (let* ((r    (st-step logits))
+                 (loss (car r))
+                 (grad (cadr r))
+                 (new  (let* ((n (vector-length logits)) (o (make-vector n 0.0)))
+                         (let g ((j 0))
+                           (if (< j n)
+                               (begin (vector-set! o j (- (vector-ref logits j) (* lr (vector-ref grad j)))) (g (+ j 1)))
+                               o)))))
+            (loop (+ i 1) new (if (< first-loss 0.0) loss first-loss) loss))))))
+
+(check-bool "ST training: loss decreases (first > last)"
+            (> (car st-train) (cadr st-train)))
+(check-bool "ST training: argmax becomes target (class 2)"
+            (= (categorical-pick (caddr st-train)) 2))
+
+;; ============================================================
+;; 4. end-to-end: learn logits so gumbel-softmax concentrates on target class
+;;    loss = 0.5 * sum (gs(logits) - target)^2
+;; ============================================================
+(define (gs-step logits)
+  (with-tape "e2e"
+    (lambda ()
+      (let* ((t    (current-tape))
+             (lg   (tape-input t (vcopy logits)))
+             (p    (gumbel-softmax-det t lg tau noise))
+             (dvec (record-op! t (list p) (vsub (node-value p) target)
+                     (lambda (g) (list g))))
+             (loss (record-op! t (list dvec)
+                     (let ((d (node-value dvec))) (* 0.5 (vdot d d)))
+                     (lambda (g) (list (vscale g (node-value dvec)))))))
+        (list (node-value loss) (car (tape-gradient t loss (list lg))) (node-value p))))))
+
+(define gs-train
+  (let ((lr 2.0))
+    (let loop ((i 0) (logits (vector 0.0 0.0 0.0 0.0)) (first-loss -1.0) (last-loss 0.0) (lastp target))
+      (if (>= i 200)
+          (list first-loss last-loss lastp)
+          (let* ((r    (gs-step logits))
+                 (loss (car r))
+                 (grad (cadr r))
+                 (p    (caddr r))
+                 (new  (let* ((n (vector-length logits)) (o (make-vector n 0.0)))
+                         (let g ((j 0))
+                           (if (< j n)
+                               (begin (vector-set! o j (- (vector-ref logits j) (* lr (vector-ref grad j)))) (g (+ j 1)))
+                               o)))))
+            (loop (+ i 1) new (if (< first-loss 0.0) loss first-loss) loss p))))))
+
+(check-bool "gumbel-softmax e2e: loss decreases (first > last)"
+            (> (car gs-train) (cadr gs-train)))
+(check-bool "gumbel-softmax e2e: distribution concentrates on target (class 2)"
+            (= (categorical-pick (caddr gs-train)) 2))
+(check-bool "gumbel-softmax e2e: p[target] > 0.8"
+            (> (vector-ref (caddr gs-train) 2) 0.8))
+
+;; ── categorical-pick sanity ──
+(check "categorical-pick argmax" (exact->inexact (categorical-pick (vector 0.1 0.9 0.3 0.2))) 1.0)
+
+(newline)
+(display "Passed: ")(display pass-count)(newline)
+(display "Failed: ")(display fail-count)(newline)


### PR DESCRIPTION
Third v1.5 primitive (pure Scheme on `core.ad.tape`): gradients through **discrete** operations — the enabler for differentiable logic / hard attention. `gumbel-softmax` (Concrete relaxation, exact softmax-JVP backward) + `straight-through` (hard forward, identity backward) + helpers. **16/16 REPL + AOT**: gradient-checked vs finite differences; ST training decreases loss and drives argmax to target; gumbel demo concentrates on the target class.