### PR TITLE
feat(sdnc/dnc): native .esk API — differentiable memory (core.dnc) + SDNC weight-programs (core.sdnc)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1391,9 +1391,11 @@ set(ESHKOL_BACKEND_RUNTIME_SRC
 
 set(ESHKOL_RUNTIME_SUPPORT_SRC
   lib/bridge/tensor_backward.cpp
+  lib/core/dnc_api.c
   lib/core/image_io.c
   lib/core/inference.cpp
   lib/core/kb_persistence.cpp
+  lib/core/sdnc_api.c
   lib/core/logic.cpp
   lib/core/logic_builtins.cpp
   lib/core/merkle.c

--- a/exe/eshkol-run.cpp
+++ b/exe/eshkol-run.cpp
@@ -2662,6 +2662,21 @@ static void update_ast_references(eshkol_ast_t* ast,
                 case ESHKOL_MAKE_WORKSPACE_OP:
                 case ESHKOL_WS_REGISTER_OP:
                 case ESHKOL_WS_STEP_OP:
+                case ESHKOL_DNC_MAKE_OP:
+                case ESHKOL_DNC_CONTENT_ADDR_OP:
+                case ESHKOL_DNC_LOC_ADDR_OP:
+                case ESHKOL_DNC_READ_OP:
+                case ESHKOL_DNC_WRITE_OP:
+                case ESHKOL_DNC_ALLOC_WEIGHTS_OP:
+                case ESHKOL_DNC_READ_GRAD_OP:
+                case ESHKOL_DNC_PRED_OP:
+                case ESHKOL_SDNC_PROGRAM_OP:
+                case ESHKOL_SDNC_RUN_OP:
+                case ESHKOL_SDNC_WEIGHT_GRAD_OP:
+                case ESHKOL_SDNC_PARAMS_OP:
+                case ESHKOL_SDNC_SET_PARAMS_OP:
+                case ESHKOL_SDNC_IMPROVE_OP:
+                case ESHKOL_SDNC_PRED_OP:
                     // Consciousness-engine ops use call_op semantics — they
                     // codegen as direct function calls with the same arg
                     // shape as ESHKOL_CALL_OP.

--- a/inc/eshkol/backend/system_codegen.h
+++ b/inc/eshkol/backend/system_codegen.h
@@ -385,6 +385,25 @@ public:
     llvm::Value* wsRegisterBuiltin(const eshkol_operations_t* op);
     llvm::Value* wsStepBuiltin(const eshkol_operations_t* op);
 
+    /* Differentiable external memory (core.dnc) */
+    llvm::Value* dncMakeBuiltin(const eshkol_operations_t* op);
+    llvm::Value* dncContentAddressBuiltin(const eshkol_operations_t* op);
+    llvm::Value* dncLocAddressBuiltin(const eshkol_operations_t* op);
+    llvm::Value* dncReadBuiltin(const eshkol_operations_t* op);
+    llvm::Value* dncWriteBuiltin(const eshkol_operations_t* op);
+    llvm::Value* dncAllocWeightsBuiltin(const eshkol_operations_t* op);
+    llvm::Value* dncReadGradBuiltin(const eshkol_operations_t* op);
+    llvm::Value* dncPredBuiltin(const eshkol_operations_t* op);
+
+    /* SDNC weight-program (core.sdnc) */
+    llvm::Value* sdncProgramBuiltin(const eshkol_operations_t* op);
+    llvm::Value* sdncRunBuiltin(const eshkol_operations_t* op);
+    llvm::Value* sdncWeightGradBuiltin(const eshkol_operations_t* op);
+    llvm::Value* sdncParamsBuiltin(const eshkol_operations_t* op);
+    llvm::Value* sdncSetParamsBuiltin(const eshkol_operations_t* op);
+    llvm::Value* sdncImproveBuiltin(const eshkol_operations_t* op);
+    llvm::Value* sdncPredBuiltin(const eshkol_operations_t* op);
+
     /* Reverse-mode AD tape */
     llvm::Value* adTapeNew(const eshkol_operations_t* op);
     llvm::Value* adTapeRelease(const eshkol_operations_t* op);

--- a/inc/eshkol/eshkol.h
+++ b/inc/eshkol/eshkol.h
@@ -357,7 +357,9 @@ typedef enum {
     HEAP_SUBTYPE_PROMISE         = 18,  // Lazy promise (delay/force with memoization)
     HEAP_SUBTYPE_RATIONAL        = 19,  // Exact rational number (numerator/denominator)
     HEAP_SUBTYPE_PRNG            = 20,  // Isolated pseudo-random number generator state
-    // Reserved: 21-255 for future heap types
+    HEAP_SUBTYPE_DNC             = 21,  // Differentiable external memory (NTM/DNC head)
+    HEAP_SUBTYPE_SDNC            = 22,  // SDNC weight-program handle (bytecode-VM-as-transformer θ)
+    // Reserved: 23-255 for future heap types
 } heap_subtype_t;
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -1464,6 +1466,23 @@ typedef enum {
     ESHKOL_INCLUDE_OP,               // (include "file" ...) - transformed at parse time
     ESHKOL_SYNTAX_ERROR_OP,          // (syntax-error "msg" datum ...) - handled at parse time
     ESHKOL_KB_QUERY_PREFIX_OP,       // (kb-query-prefix kb pattern) -> list of substs (pattern arity ≤ fact arity)
+    // ===== Differentiable external memory (core.dnc) — appended to preserve ABI =====
+    ESHKOL_DNC_MAKE_OP,              // (make-dnc-memory N W) -> mem opaque handle
+    ESHKOL_DNC_CONTENT_ADDR_OP,     // (dnc-content-address mem key beta) -> length-N wvec
+    ESHKOL_DNC_LOC_ADDR_OP,         // (dnc-loc-address addr beta N) -> length-N wvec
+    ESHKOL_DNC_READ_OP,             // (dnc-read mem wvec) -> length-W row
+    ESHKOL_DNC_WRITE_OP,            // (dnc-write! mem wvec erase add) -> mem
+    ESHKOL_DNC_ALLOC_WEIGHTS_OP,    // (dnc-alloc-weights mem beta) -> length-N wvec
+    ESHKOL_DNC_READ_GRAD_OP,        // (dnc-read-grad mem key target beta) -> (dkey . dmem)
+    ESHKOL_DNC_PRED_OP,             // (dnc-memory? x) -> bool
+    // ===== SDNC weight-program θ (core.sdnc) — appended to preserve ABI =====
+    ESHKOL_SDNC_PROGRAM_OP,         // (sdnc-program name) -> θ opaque handle
+    ESHKOL_SDNC_RUN_OP,             // (sdnc-run θ input) -> output vector
+    ESHKOL_SDNC_WEIGHT_GRAD_OP,     // (sdnc-weight-grad θ input target) -> flat ∂L/∂weights
+    ESHKOL_SDNC_PARAMS_OP,          // (sdnc-params θ) -> vector of flattened trainable weights
+    ESHKOL_SDNC_SET_PARAMS_OP,      // (sdnc-set-params! θ vec) -> θ
+    ESHKOL_SDNC_IMPROVE_OP,         // (sdnc-improve! θ data steps lr) -> θ
+    ESHKOL_SDNC_PRED_OP,            // (sdnc? x) -> bool
 } eshkol_op_t;
 
 struct eshkol_ast;

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -1594,6 +1594,23 @@ public:
         function_return_types["make-workspace"] = BuiltinTypes::Value;
         function_return_types["ws-register!"] = BuiltinTypes::Boolean;
         function_return_types["ws-step!"] = BuiltinTypes::Value;
+        // Differentiable external memory (core.dnc)
+        function_return_types["make-dnc-memory"] = BuiltinTypes::Value;
+        function_return_types["dnc-content-address"] = BuiltinTypes::Value;
+        function_return_types["dnc-loc-address"] = BuiltinTypes::Value;
+        function_return_types["dnc-read"] = BuiltinTypes::Value;
+        function_return_types["dnc-write!"] = BuiltinTypes::Value;
+        function_return_types["dnc-alloc-weights"] = BuiltinTypes::Value;
+        function_return_types["dnc-read-grad"] = BuiltinTypes::Value;
+        function_return_types["dnc-memory?"] = BuiltinTypes::Boolean;
+        // SDNC weight-program (core.sdnc)
+        function_return_types["sdnc-program"] = BuiltinTypes::Value;
+        function_return_types["sdnc-run"] = BuiltinTypes::Value;
+        function_return_types["sdnc-weight-grad"] = BuiltinTypes::Value;
+        function_return_types["sdnc-params"] = BuiltinTypes::Value;
+        function_return_types["sdnc-set-params!"] = BuiltinTypes::Value;
+        function_return_types["sdnc-improve!"] = BuiltinTypes::Value;
+        function_return_types["sdnc?"] = BuiltinTypes::Boolean;
         // Reverse-mode AD tape
         function_return_types["ad-tape-new"] = BuiltinTypes::Value;
         function_return_types["ad-tape-release"] = BuiltinTypes::Value;
@@ -9331,6 +9348,21 @@ private:
             {ESHKOL_MAKE_WORKSPACE_OP,      "make-workspace"},
             {ESHKOL_WS_REGISTER_OP,         "ws-register!"},
             {ESHKOL_WS_STEP_OP,             "ws-step!"},
+            {ESHKOL_DNC_MAKE_OP,            "make-dnc-memory"},
+            {ESHKOL_DNC_CONTENT_ADDR_OP,    "dnc-content-address"},
+            {ESHKOL_DNC_LOC_ADDR_OP,        "dnc-loc-address"},
+            {ESHKOL_DNC_READ_OP,            "dnc-read"},
+            {ESHKOL_DNC_WRITE_OP,           "dnc-write!"},
+            {ESHKOL_DNC_ALLOC_WEIGHTS_OP,   "dnc-alloc-weights"},
+            {ESHKOL_DNC_READ_GRAD_OP,       "dnc-read-grad"},
+            {ESHKOL_DNC_PRED_OP,            "dnc-memory?"},
+            {ESHKOL_SDNC_PROGRAM_OP,        "sdnc-program"},
+            {ESHKOL_SDNC_RUN_OP,            "sdnc-run"},
+            {ESHKOL_SDNC_WEIGHT_GRAD_OP,    "sdnc-weight-grad"},
+            {ESHKOL_SDNC_PARAMS_OP,         "sdnc-params"},
+            {ESHKOL_SDNC_SET_PARAMS_OP,     "sdnc-set-params!"},
+            {ESHKOL_SDNC_IMPROVE_OP,        "sdnc-improve!"},
+            {ESHKOL_SDNC_PRED_OP,           "sdnc?"},
         };
         return m;
     }
@@ -9733,6 +9765,36 @@ private:
                 return logic_workspace_->codegenWSRegister(op);
             case ESHKOL_WS_STEP_OP:
                 return logic_workspace_->codegenWSStep(op);
+            case ESHKOL_DNC_MAKE_OP:
+                return system_->dncMakeBuiltin(op);
+            case ESHKOL_DNC_CONTENT_ADDR_OP:
+                return system_->dncContentAddressBuiltin(op);
+            case ESHKOL_DNC_LOC_ADDR_OP:
+                return system_->dncLocAddressBuiltin(op);
+            case ESHKOL_DNC_READ_OP:
+                return system_->dncReadBuiltin(op);
+            case ESHKOL_DNC_WRITE_OP:
+                return system_->dncWriteBuiltin(op);
+            case ESHKOL_DNC_ALLOC_WEIGHTS_OP:
+                return system_->dncAllocWeightsBuiltin(op);
+            case ESHKOL_DNC_READ_GRAD_OP:
+                return system_->dncReadGradBuiltin(op);
+            case ESHKOL_DNC_PRED_OP:
+                return system_->dncPredBuiltin(op);
+            case ESHKOL_SDNC_PROGRAM_OP:
+                return system_->sdncProgramBuiltin(op);
+            case ESHKOL_SDNC_RUN_OP:
+                return system_->sdncRunBuiltin(op);
+            case ESHKOL_SDNC_WEIGHT_GRAD_OP:
+                return system_->sdncWeightGradBuiltin(op);
+            case ESHKOL_SDNC_PARAMS_OP:
+                return system_->sdncParamsBuiltin(op);
+            case ESHKOL_SDNC_SET_PARAMS_OP:
+                return system_->sdncSetParamsBuiltin(op);
+            case ESHKOL_SDNC_IMPROVE_OP:
+                return system_->sdncImproveBuiltin(op);
+            case ESHKOL_SDNC_PRED_OP:
+                return system_->sdncPredBuiltin(op);
             case ESHKOL_FACT_PRED_OP:
                 return codegenFactPred(op);
             case ESHKOL_FACTOR_GRAPH_PRED_OP:
@@ -22392,6 +22454,11 @@ private:
             "make-factor-graph", "fg-add-factor!", "fg-infer!",
             "free-energy", "expected-free-energy",
             "make-workspace", "ws-register!", "ws-step!",
+            "make-dnc-memory", "dnc-content-address", "dnc-loc-address",
+            "dnc-read", "dnc-write!", "dnc-alloc-weights", "dnc-read-grad",
+            "dnc-memory?",
+            "sdnc-program", "sdnc-run", "sdnc-weight-grad", "sdnc-params",
+            "sdnc-set-params!", "sdnc-improve!", "sdnc?",
             "ad-tape-new", "ad-tape-release", "ad-const", "ad-var",
             "ad-add", "ad-sub", "ad-mul", "ad-div",
             "ad-sin", "ad-cos", "ad-exp", "ad-log", "ad-sqrt",
@@ -23514,6 +23581,21 @@ private:
                     case ESHKOL_MAKE_WORKSPACE_OP:
                     case ESHKOL_WS_REGISTER_OP:
                     case ESHKOL_WS_STEP_OP:
+                    case ESHKOL_DNC_MAKE_OP:
+                    case ESHKOL_DNC_CONTENT_ADDR_OP:
+                    case ESHKOL_DNC_LOC_ADDR_OP:
+                    case ESHKOL_DNC_READ_OP:
+                    case ESHKOL_DNC_WRITE_OP:
+                    case ESHKOL_DNC_ALLOC_WEIGHTS_OP:
+                    case ESHKOL_DNC_READ_GRAD_OP:
+                    case ESHKOL_DNC_PRED_OP:
+                    case ESHKOL_SDNC_PROGRAM_OP:
+                    case ESHKOL_SDNC_RUN_OP:
+                    case ESHKOL_SDNC_WEIGHT_GRAD_OP:
+                    case ESHKOL_SDNC_PARAMS_OP:
+                    case ESHKOL_SDNC_SET_PARAMS_OP:
+                    case ESHKOL_SDNC_IMPROVE_OP:
+                    case ESHKOL_SDNC_PRED_OP:
                     case ESHKOL_MAKE_PARAMETER_OP:    // call_op holding the init expr (parse-transformed)
                     case ESHKOL_EXTERN_OP:
                         for (uint64_t i = 0; i < op->call_op.num_vars; i++) {

--- a/lib/backend/system_codegen.cpp
+++ b/lib/backend/system_codegen.cpp
@@ -1642,8 +1642,15 @@ static llvm::Value* callArenaTaggedFunc(CodegenContext& ctx, TaggedValueCodegen&
     std::vector<llvm::Value*> call_args;
     call_args.push_back(arena);
     for (auto* a : args) {
+        // CRITICAL: ensure each argument is a tagged value before storing into a
+        // tagged-value slot. Literal ints/doubles come back from the codegen
+        // callback as raw i64/double; storing those untagged would scribble the
+        // value's low byte into the tagged_value type field (observed as
+        // make-dnc-memory seeing N=0/W=0 from literal args). Mirrors how
+        // codegenMakeWorkspace wraps every arg with ensureTagged().
+        llvm::Value* tv = tagged.ensureTagged(a);
         llvm::Value* slot = builder.CreateAlloca(ctx.taggedValueType());
-        builder.CreateStore(a, slot);
+        builder.CreateStore(tv, slot);
         call_args.push_back(slot);
     }
     call_args.push_back(result_ptr);
@@ -1688,6 +1695,18 @@ llvm::Value* SystemCodegen::method_name(const eshkol_operations_t* op) { \
     return callArenaTaggedFunc(ctx_, tagged_, c_func_name, 1, {a}); \
 }
 
+#define CE_FOUR_ARG(method_name, c_func_name) \
+llvm::Value* SystemCodegen::method_name(const eshkol_operations_t* op) { \
+    if (op->call_op.num_vars != 4) return tagged_.packNull(); \
+    if (!codegen_ast_callback_) return tagged_.packNull(); \
+    llvm::Value* a = codegen_ast_callback_(&op->call_op.variables[0], callback_context_); \
+    llvm::Value* b = codegen_ast_callback_(&op->call_op.variables[1], callback_context_); \
+    llvm::Value* c = codegen_ast_callback_(&op->call_op.variables[2], callback_context_); \
+    llvm::Value* d = codegen_ast_callback_(&op->call_op.variables[3], callback_context_); \
+    if (!a || !b || !c || !d) return tagged_.packNull(); \
+    return callArenaTaggedFunc(ctx_, tagged_, c_func_name, 4, {a, b, c, d}); \
+}
+
 /* Logic engine */
 CE_ZERO_ARG(makeSubstitution, "eshkol_make_substitution_tagged")
 CE_ZERO_ARG(makeKbBuiltin, "eshkol_make_kb_tagged")
@@ -1709,9 +1728,29 @@ CE_TWO_ARG(makeWorkspaceBuiltin, "eshkol_make_workspace_tagged")
 CE_THREE_ARG(wsRegisterBuiltin, "eshkol_ws_register_tagged")
 CE_ONE_ARG(wsStepBuiltin, "eshkol_ws_step_tagged")
 
+/* Differentiable external memory (core.dnc) */
+CE_TWO_ARG(dncMakeBuiltin, "eshkol_dnc_make_tagged")
+CE_THREE_ARG(dncContentAddressBuiltin, "eshkol_dnc_content_address_tagged")
+CE_THREE_ARG(dncLocAddressBuiltin, "eshkol_dnc_loc_address_tagged")
+CE_TWO_ARG(dncReadBuiltin, "eshkol_dnc_read_tagged")
+CE_FOUR_ARG(dncWriteBuiltin, "eshkol_dnc_write_tagged")
+CE_TWO_ARG(dncAllocWeightsBuiltin, "eshkol_dnc_alloc_weights_tagged")
+CE_FOUR_ARG(dncReadGradBuiltin, "eshkol_dnc_read_grad_tagged")
+CE_ONE_ARG(dncPredBuiltin, "eshkol_dnc_pred_tagged")
+
+/* SDNC weight-program (core.sdnc) */
+CE_ONE_ARG(sdncProgramBuiltin, "eshkol_sdnc_program_tagged")
+CE_TWO_ARG(sdncRunBuiltin, "eshkol_sdnc_run_tagged")
+CE_THREE_ARG(sdncWeightGradBuiltin, "eshkol_sdnc_weight_grad_tagged")
+CE_ONE_ARG(sdncParamsBuiltin, "eshkol_sdnc_params_tagged")
+CE_TWO_ARG(sdncSetParamsBuiltin, "eshkol_sdnc_set_params_tagged")
+CE_FOUR_ARG(sdncImproveBuiltin, "eshkol_sdnc_improve_tagged")
+CE_ONE_ARG(sdncPredBuiltin, "eshkol_sdnc_pred_tagged")
+
 #undef CE_ZERO_ARG
 #undef CE_ONE_ARG
 #undef CE_TWO_ARG
+#undef CE_FOUR_ARG
 #undef CE_THREE_ARG
 
 /* Reverse-mode AD tape — all use sret pattern from system_builtins */

--- a/lib/core/dnc.esk
+++ b/lib/core/dnc.esk
@@ -1,0 +1,30 @@
+;;
+;; core.dnc — differentiable external memory (NTM/DNC head)
+;;
+;; A learnable external memory bank (N rows x W cols) that can be read and
+;; written with gradients, addressed by content (cosine + softmax) and by
+;; location, with a temperature knob (beta): bit-exact at high beta (verified
+;; addressable store) and smooth/differentiable at low beta (learning).
+;;
+;; All operations below are native builtins (HEAP_SUBTYPE_DNC handle); the math
+;; mirrors lib/backend/diff_memory_prototype.c byte-for-byte (the C oracle).
+;; Vectors are Eshkol #(...) float vectors.
+;;
+;;   (make-dnc-memory N W)              -> mem   N x W bank, zeroed, usage=0
+;;   (dnc-content-address mem key beta) -> #(..) length-N softmax(beta*cos)
+;;   (dnc-loc-address addr beta N)      -> #(..) length-N indicator bump
+;;   (dnc-read mem wvec)                -> #(..) length-W weighted row
+;;   (dnc-write! mem wvec erase add)    -> mem   NTM erase/add write
+;;   (dnc-alloc-weights mem beta)       -> #(..) length-N least-used weights
+;;   (dnc-read-grad mem key target beta)-> (dkey . dmem) exact gradient
+;;   (dnc-memory? x)                    -> bool
+;;
+
+(provide make-dnc-memory
+         dnc-content-address
+         dnc-loc-address
+         dnc-read
+         dnc-write!
+         dnc-alloc-weights
+         dnc-read-grad
+         dnc-memory?)

--- a/lib/core/dnc_api.c
+++ b/lib/core/dnc_api.c
@@ -1,0 +1,419 @@
+/*
+ * DNC Runtime API — expose a differentiable external memory (NTM/DNC head) as
+ * pure-Eshkol builtins so programs can build a learnable Mneme/dKB read & write
+ * head addressed by content (cosine + softmax) and location, with a temperature
+ * knob (bit-exact at high beta, smooth/differentiable at low beta).
+ *
+ * Builtins (registered in parser.cpp / llvm_codegen.cpp / system_codegen.cpp /
+ * type_checker.cpp / eshkol-run.cpp):
+ *   (make-dnc-memory N W)              -> mem    opaque handle (HEAP_SUBTYPE_DNC)
+ *   (dnc-content-address mem key beta) -> #(...) length-N weight vector
+ *   (dnc-loc-address addr beta N)      -> #(...) length-N weight vector
+ *   (dnc-read mem wvec)                -> #(...) length-W read row
+ *   (dnc-write! mem wvec erase add)    -> mem    (NTM erase/add, returns handle)
+ *   (dnc-alloc-weights mem beta)       -> #(...) length-N least-used weights
+ *   (dnc-read-grad mem key target beta)-> (dkey . dmem)  exact backprop gradient
+ *   (dnc-memory? x)                    -> bool
+ *
+ * The addressing/read/write/backprop math lives in lib/core/dnc_core.h, a
+ * byte-for-byte mirror of the standalone artifact lib/backend/diff_memory_prototype.c.
+ * Vectors crossing the .esk boundary are Eshkol #(...) tensors (homogeneous
+ * doubles, HEAP_SUBTYPE_TENSOR), matching the workspace/inference convention.
+ *
+ * Copyright (C) tsotchke
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include <eshkol/eshkol.h>
+
+#include "dnc_core.h"
+
+/* Arena handle (defined in arena_memory.h; only used by pointer here). */
+typedef struct arena arena_t;
+
+extern void* arena_allocate_with_header(arena_t* arena, size_t data_size,
+                                        uint8_t subtype, uint8_t flags);
+extern void* arena_allocate_aligned(arena_t* arena, size_t size, size_t alignment);
+extern void  eshkol_runtime_fatal(eshkol_exception_type_t type, const char* fmt, ...);
+
+/* ===== Handle =====
+ * Stored small in the arena; points to calloc'd mem/usage so a large bank never
+ * goes through the arena. Owns its own dimensions so .esk can size the bank. */
+typedef struct {
+    int     N;
+    int     W;
+    double* mem;     /* N*W row-major */
+    double* usage;   /* N */
+} DncHandle;
+
+/* Tensor layout mirroring #(...) literals (see workspace.cpp / inference.cpp). */
+typedef struct dnc_tensor_layout {
+    uint64_t* dimensions;
+    uint64_t  num_dimensions;
+    int64_t*  elements;       /* double bit patterns as int64 */
+    uint64_t  total_elements;
+} dnc_tensor_layout_t;
+
+/* ===== Helpers ===== */
+static DncHandle* dnc_extract_handle(const eshkol_tagged_value_t* tv) {
+    if (!tv || tv->type != ESHKOL_VALUE_HEAP_PTR || !tv->data.ptr_val) return NULL;
+    void* ptr = (void*)(uintptr_t)tv->data.ptr_val;
+    eshkol_object_header_t* hdr = ESHKOL_GET_HEADER(ptr);
+    if (hdr->subtype != HEAP_SUBTYPE_DNC) return NULL;
+    return (DncHandle*)ptr;
+}
+
+static int dnc_get_int(const eshkol_tagged_value_t* tv, int dflt) {
+    if (!tv) return dflt;
+    uint8_t t = tv->type & 0x0F;
+    if (t == ESHKOL_VALUE_INT64)  return (int)tv->data.int_val;
+    if (t == ESHKOL_VALUE_DOUBLE) return (int)tv->data.double_val;
+    return dflt;
+}
+
+static double dnc_get_double(const eshkol_tagged_value_t* tv, double dflt) {
+    if (!tv) return dflt;
+    uint8_t t = tv->type & 0x0F;
+    if (t == ESHKOL_VALUE_DOUBLE) return tv->data.double_val;
+    if (t == ESHKOL_VALUE_INT64)  return (double)tv->data.int_val;
+    return dflt;
+}
+
+/* Read a #(...) tensor (or heterogeneous vector) into a freshly malloc'd double
+ * buffer; sets *out_len. Returns NULL on type error. Caller frees. */
+static double* dnc_read_vector(const eshkol_tagged_value_t* tv, int64_t* out_len) {
+    *out_len = 0;
+    if (!tv || tv->type != ESHKOL_VALUE_HEAP_PTR || !tv->data.ptr_val) return NULL;
+    void* ptr = (void*)(uintptr_t)tv->data.ptr_val;
+    eshkol_object_header_t* hdr = ESHKOL_GET_HEADER(ptr);
+
+    if (hdr->subtype == HEAP_SUBTYPE_TENSOR) {
+        dnc_tensor_layout_t* t = (dnc_tensor_layout_t*)ptr;
+        int64_t n = (int64_t)t->total_elements;
+        if (n <= 0 || !t->elements) return NULL;
+        double* buf = (double*)malloc((size_t)n * sizeof(double));
+        if (!buf) return NULL;
+        for (int64_t i = 0; i < n; i++) {
+            union { double d; int64_t i; } u;
+            u.i = t->elements[i];
+            buf[i] = u.d;
+        }
+        *out_len = n;
+        return buf;
+    }
+
+    if (hdr->subtype == HEAP_SUBTYPE_VECTOR) {
+        int64_t n = *(int64_t*)ptr;
+        if (n <= 0) return NULL;
+        eshkol_tagged_value_t* elems =
+            (eshkol_tagged_value_t*)((uint8_t*)ptr + sizeof(int64_t));
+        double* buf = (double*)malloc((size_t)n * sizeof(double));
+        if (!buf) return NULL;
+        for (int64_t i = 0; i < n; i++) {
+            uint8_t et = elems[i].type & 0x0F;
+            if (et == ESHKOL_VALUE_DOUBLE)      buf[i] = elems[i].data.double_val;
+            else if (et == ESHKOL_VALUE_INT64)  buf[i] = (double)elems[i].data.int_val;
+            else                                buf[i] = 0.0;
+        }
+        *out_len = n;
+        return buf;
+    }
+    return NULL;
+}
+
+/* Allocate a #(...) tensor of `len` doubles into the arena and store in result. */
+static void dnc_make_tensor(arena_t* arena, const double* data, int len,
+                            eshkol_tagged_value_t* result) {
+    memset(result, 0, sizeof(*result));
+    if (!arena || !data || len <= 0) { result->type = ESHKOL_VALUE_NULL; return; }
+
+    dnc_tensor_layout_t* t = (dnc_tensor_layout_t*)arena_allocate_with_header(
+        arena, sizeof(dnc_tensor_layout_t), HEAP_SUBTYPE_TENSOR, 0);
+    if (!t) { result->type = ESHKOL_VALUE_NULL; return; }
+    t->num_dimensions = 1;
+    t->total_elements = (uint64_t)len;
+    t->dimensions = (uint64_t*)arena_allocate_aligned(arena, sizeof(uint64_t), 8);
+    if (t->dimensions) t->dimensions[0] = (uint64_t)len;
+    t->elements = (int64_t*)arena_allocate_aligned(arena, (size_t)len * sizeof(int64_t), 8);
+    if (!t->elements) { result->type = ESHKOL_VALUE_NULL; return; }
+    for (int i = 0; i < len; i++) {
+        union { double d; int64_t i; } u;
+        u.d = data[i];
+        t->elements[i] = u.i;
+    }
+    result->type = ESHKOL_VALUE_HEAP_PTR;
+    result->data.ptr_val = (uint64_t)(uintptr_t)t;
+}
+
+/* ===== (make-dnc-memory N W) -> mem ===== */
+void eshkol_dnc_make_tagged(arena_t* arena,
+                            const eshkol_tagged_value_t* n_tv,
+                            const eshkol_tagged_value_t* w_tv,
+                            eshkol_tagged_value_t* result) {
+    if (!result) return;
+    memset(result, 0, sizeof(*result));
+    if (!arena) { result->type = ESHKOL_VALUE_NULL; return; }
+
+    int N = dnc_get_int(n_tv, 0);
+    int W = dnc_get_int(w_tv, 0);
+    if (N <= 0 || W <= 0) {
+        eshkol_runtime_fatal(ESHKOL_EXCEPTION_RANGE_ERROR,
+            "make-dnc-memory: N and W must be positive (got N=%d W=%d)", N, W);
+        result->type = ESHKOL_VALUE_NULL;
+        return;
+    }
+
+    DncHandle* h = (DncHandle*)arena_allocate_with_header(
+        arena, sizeof(DncHandle), HEAP_SUBTYPE_DNC, 0);
+    if (!h) { result->type = ESHKOL_VALUE_NULL; return; }
+    h->N = N; h->W = W;
+    h->mem = (double*)calloc((size_t)N * W, sizeof(double));   /* zeroed bank */
+    h->usage = (double*)calloc((size_t)N, sizeof(double));     /* usage = 0 */
+    if (!h->mem || !h->usage) {
+        free(h->mem); free(h->usage);
+        result->type = ESHKOL_VALUE_NULL; return;
+    }
+
+    result->type = ESHKOL_VALUE_HEAP_PTR;
+    result->data.ptr_val = (uint64_t)(uintptr_t)h;
+}
+
+/* ===== (dnc-content-address mem key beta) -> length-N wvec ===== */
+void eshkol_dnc_content_address_tagged(arena_t* arena,
+                                       const eshkol_tagged_value_t* mem_tv,
+                                       const eshkol_tagged_value_t* key_tv,
+                                       const eshkol_tagged_value_t* beta_tv,
+                                       eshkol_tagged_value_t* result) {
+    if (!result) return;
+    memset(result, 0, sizeof(*result));
+    DncHandle* h = dnc_extract_handle(mem_tv);
+    if (!h) { eshkol_runtime_fatal(ESHKOL_EXCEPTION_TYPE_ERROR,
+        "dnc-content-address: first argument is not a dnc-memory"); result->type = ESHKOL_VALUE_NULL; return; }
+
+    int64_t klen = 0;
+    double* key = dnc_read_vector(key_tv, &klen);
+    if (!key) { eshkol_runtime_fatal(ESHKOL_EXCEPTION_TYPE_ERROR,
+        "dnc-content-address: key must be a numeric vector"); result->type = ESHKOL_VALUE_NULL; return; }
+    if (klen != h->W) {
+        free(key);
+        eshkol_runtime_fatal(ESHKOL_EXCEPTION_RANGE_ERROR,
+            "dnc-content-address: key length %lld != memory width W=%d",
+            (long long)klen, h->W);
+        result->type = ESHKOL_VALUE_NULL; return;
+    }
+    double beta = dnc_get_double(beta_tv, 1.0);
+
+    double* w = (double*)malloc((size_t)h->N * sizeof(double));
+    if (!w) { free(key); result->type = ESHKOL_VALUE_NULL; return; }
+    dnc_content_weights(h->mem, h->N, h->W, key, beta, w);
+    dnc_make_tensor(arena, w, h->N, result);
+    free(key); free(w);
+}
+
+/* ===== (dnc-loc-address addr beta N) -> length-N wvec ===== */
+void eshkol_dnc_loc_address_tagged(arena_t* arena,
+                                   const eshkol_tagged_value_t* addr_tv,
+                                   const eshkol_tagged_value_t* beta_tv,
+                                   const eshkol_tagged_value_t* n_tv,
+                                   eshkol_tagged_value_t* result) {
+    if (!result) return;
+    memset(result, 0, sizeof(*result));
+    double addr = dnc_get_double(addr_tv, 0.0);
+    double beta = dnc_get_double(beta_tv, 1.0);
+    int N = dnc_get_int(n_tv, 0);
+    if (N <= 0) {
+        eshkol_runtime_fatal(ESHKOL_EXCEPTION_RANGE_ERROR,
+            "dnc-loc-address: N must be positive (got %d)", N);
+        result->type = ESHKOL_VALUE_NULL; return;
+    }
+    double* w = (double*)malloc((size_t)N * sizeof(double));
+    if (!w) { result->type = ESHKOL_VALUE_NULL; return; }
+    dnc_loc_weights(addr, beta, N, w);
+    dnc_make_tensor(arena, w, N, result);
+    free(w);
+}
+
+/* ===== (dnc-read mem wvec) -> length-W row ===== */
+void eshkol_dnc_read_tagged(arena_t* arena,
+                            const eshkol_tagged_value_t* mem_tv,
+                            const eshkol_tagged_value_t* w_tv,
+                            eshkol_tagged_value_t* result) {
+    if (!result) return;
+    memset(result, 0, sizeof(*result));
+    DncHandle* h = dnc_extract_handle(mem_tv);
+    if (!h) { eshkol_runtime_fatal(ESHKOL_EXCEPTION_TYPE_ERROR,
+        "dnc-read: first argument is not a dnc-memory"); result->type = ESHKOL_VALUE_NULL; return; }
+
+    int64_t wlen = 0;
+    double* w = dnc_read_vector(w_tv, &wlen);
+    if (!w) { eshkol_runtime_fatal(ESHKOL_EXCEPTION_TYPE_ERROR,
+        "dnc-read: wvec must be a numeric vector"); result->type = ESHKOL_VALUE_NULL; return; }
+    if (wlen != h->N) {
+        free(w);
+        eshkol_runtime_fatal(ESHKOL_EXCEPTION_RANGE_ERROR,
+            "dnc-read: wvec length %lld != memory rows N=%d", (long long)wlen, h->N);
+        result->type = ESHKOL_VALUE_NULL; return;
+    }
+    double* rd = (double*)malloc((size_t)h->W * sizeof(double));
+    if (!rd) { free(w); result->type = ESHKOL_VALUE_NULL; return; }
+    dnc_read_mem(h->mem, h->N, h->W, w, rd);
+    dnc_make_tensor(arena, rd, h->W, result);
+    free(w); free(rd);
+}
+
+/* ===== (dnc-write! mem wvec erase add) -> mem ===== */
+void eshkol_dnc_write_tagged(arena_t* arena,
+                             const eshkol_tagged_value_t* mem_tv,
+                             const eshkol_tagged_value_t* w_tv,
+                             const eshkol_tagged_value_t* erase_tv,
+                             const eshkol_tagged_value_t* add_tv,
+                             eshkol_tagged_value_t* result) {
+    if (!result) return;
+    memset(result, 0, sizeof(*result));
+    (void)arena;
+    DncHandle* h = dnc_extract_handle(mem_tv);
+    if (!h) { eshkol_runtime_fatal(ESHKOL_EXCEPTION_TYPE_ERROR,
+        "dnc-write!: first argument is not a dnc-memory"); result->type = ESHKOL_VALUE_NULL; return; }
+
+    int64_t wlen = 0, elen = 0, alen = 0;
+    double* w = dnc_read_vector(w_tv, &wlen);
+    double* erase = dnc_read_vector(erase_tv, &elen);
+    double* add = dnc_read_vector(add_tv, &alen);
+    if (!w || !erase || !add) {
+        free(w); free(erase); free(add);
+        eshkol_runtime_fatal(ESHKOL_EXCEPTION_TYPE_ERROR,
+            "dnc-write!: wvec/erase/add must be numeric vectors");
+        result->type = ESHKOL_VALUE_NULL; return;
+    }
+    if (wlen != h->N) {
+        free(w); free(erase); free(add);
+        eshkol_runtime_fatal(ESHKOL_EXCEPTION_RANGE_ERROR,
+            "dnc-write!: wvec length %lld != memory rows N=%d", (long long)wlen, h->N);
+        result->type = ESHKOL_VALUE_NULL; return;
+    }
+    if (elen != h->W || alen != h->W) {
+        free(w); free(erase); free(add);
+        eshkol_runtime_fatal(ESHKOL_EXCEPTION_RANGE_ERROR,
+            "dnc-write!: erase/add length must equal memory width W=%d (got %lld/%lld)",
+            h->W, (long long)elen, (long long)alen);
+        result->type = ESHKOL_VALUE_NULL; return;
+    }
+    dnc_write_mem(h->mem, h->usage, h->N, h->W, w, erase, add);
+    free(w); free(erase); free(add);
+
+    /* Return the handle for chaining. */
+    result->type = ESHKOL_VALUE_HEAP_PTR;
+    result->data.ptr_val = (uint64_t)(uintptr_t)h;
+}
+
+/* ===== (dnc-alloc-weights mem beta) -> length-N wvec ===== */
+void eshkol_dnc_alloc_weights_tagged(arena_t* arena,
+                                     const eshkol_tagged_value_t* mem_tv,
+                                     const eshkol_tagged_value_t* beta_tv,
+                                     eshkol_tagged_value_t* result) {
+    if (!result) return;
+    memset(result, 0, sizeof(*result));
+    DncHandle* h = dnc_extract_handle(mem_tv);
+    if (!h) { eshkol_runtime_fatal(ESHKOL_EXCEPTION_TYPE_ERROR,
+        "dnc-alloc-weights: first argument is not a dnc-memory"); result->type = ESHKOL_VALUE_NULL; return; }
+    double beta = dnc_get_double(beta_tv, 1.0);
+    double* w = (double*)malloc((size_t)h->N * sizeof(double));
+    if (!w) { result->type = ESHKOL_VALUE_NULL; return; }
+    dnc_alloc_weights(h->usage, h->N, beta, w);
+    dnc_make_tensor(arena, w, h->N, result);
+    free(w);
+}
+
+/* ===== (dnc-read-grad mem key target beta) -> (dkey . dmem) ===== */
+extern void* arena_allocate_cons_with_header(arena_t* arena);
+
+void eshkol_dnc_read_grad_tagged(arena_t* arena,
+                                 const eshkol_tagged_value_t* mem_tv,
+                                 const eshkol_tagged_value_t* key_tv,
+                                 const eshkol_tagged_value_t* target_tv,
+                                 const eshkol_tagged_value_t* beta_tv,
+                                 eshkol_tagged_value_t* result) {
+    if (!result) return;
+    memset(result, 0, sizeof(*result));
+    DncHandle* h = dnc_extract_handle(mem_tv);
+    if (!h) { eshkol_runtime_fatal(ESHKOL_EXCEPTION_TYPE_ERROR,
+        "dnc-read-grad: first argument is not a dnc-memory"); result->type = ESHKOL_VALUE_NULL; return; }
+
+    int64_t klen = 0, tlen = 0;
+    double* key = dnc_read_vector(key_tv, &klen);
+    double* target = dnc_read_vector(target_tv, &tlen);
+    if (!key || !target) {
+        free(key); free(target);
+        eshkol_runtime_fatal(ESHKOL_EXCEPTION_TYPE_ERROR,
+            "dnc-read-grad: key/target must be numeric vectors");
+        result->type = ESHKOL_VALUE_NULL; return;
+    }
+    if (klen != h->W || tlen != h->W) {
+        free(key); free(target);
+        eshkol_runtime_fatal(ESHKOL_EXCEPTION_RANGE_ERROR,
+            "dnc-read-grad: key/target length must equal memory width W=%d (got %lld/%lld)",
+            h->W, (long long)klen, (long long)tlen);
+        result->type = ESHKOL_VALUE_NULL; return;
+    }
+    double beta = dnc_get_double(beta_tv, 1.0);
+
+    int N = h->N, W = h->W;
+    double* grad_key = (double*)malloc((size_t)W * sizeof(double));
+    double* grad_mem = (double*)malloc((size_t)N * W * sizeof(double));
+    double* s     = (double*)malloc((size_t)N * sizeof(double));
+    double* wv    = (double*)malloc((size_t)N * sizeof(double));
+    double* rd    = (double*)malloc((size_t)W * sizeof(double));
+    double* dread = (double*)malloc((size_t)W * sizeof(double));
+    double* dw    = (double*)malloc((size_t)N * sizeof(double));
+    double* ds    = (double*)malloc((size_t)N * sizeof(double));
+    if (!grad_key||!grad_mem||!s||!wv||!rd||!dread||!dw||!ds) {
+        free(key);free(target);free(grad_key);free(grad_mem);
+        free(s);free(wv);free(rd);free(dread);free(dw);free(ds);
+        result->type = ESHKOL_VALUE_NULL; return;
+    }
+
+    dnc_loss_and_grads(h->mem, N, W, key, target, beta,
+                       grad_key, grad_mem, s, wv, rd, dread, dw, ds);
+
+    /* Build (dkey . dmem): dkey = length-W tensor, dmem = length-(N*W) tensor. */
+    eshkol_tagged_value_t dkey_tv, dmem_tv;
+    dnc_make_tensor(arena, grad_key, W, &dkey_tv);
+    dnc_make_tensor(arena, grad_mem, N * W, &dmem_tv);
+
+    void* cellp = arena_allocate_cons_with_header(arena);
+    if (!cellp) {
+        free(key);free(target);free(grad_key);free(grad_mem);
+        free(s);free(wv);free(rd);free(dread);free(dw);free(ds);
+        result->type = ESHKOL_VALUE_NULL; return;
+    }
+    /* arena_tagged_cons_cell_t layout: { eshkol_tagged_value_t car; eshkol_tagged_value_t cdr; }
+     * after the object header. We access fields via the known offsets used by
+     * the runtime list helpers: car first, cdr second. */
+    eshkol_tagged_value_t* car = (eshkol_tagged_value_t*)cellp;
+    eshkol_tagged_value_t* cdr = car + 1;
+    *car = dkey_tv;
+    *cdr = dmem_tv;
+
+    free(key);free(target);free(grad_key);free(grad_mem);
+    free(s);free(wv);free(rd);free(dread);free(dw);free(ds);
+
+    result->type = ESHKOL_VALUE_HEAP_PTR;
+    result->data.ptr_val = (uint64_t)(uintptr_t)cellp;
+}
+
+/* ===== (dnc-memory? x) -> bool ===== */
+void eshkol_dnc_pred_tagged(arena_t* arena,
+                            const eshkol_tagged_value_t* x_tv,
+                            eshkol_tagged_value_t* result) {
+    if (!result) return;
+    (void)arena;
+    memset(result, 0, sizeof(*result));
+    result->type = ESHKOL_VALUE_BOOL;
+    result->data.int_val = dnc_extract_handle(x_tv) ? 1 : 0;
+}

--- a/lib/core/dnc_core.h
+++ b/lib/core/dnc_core.h
@@ -1,0 +1,208 @@
+/*
+ * DNC Core — shared differentiable-external-memory math.
+ *
+ * Self-contained header exposing the addressing/read/write/backprop math of
+ * lib/backend/diff_memory_prototype.c (the standalone NTM/DNC de-risking
+ * artifact) so the Eshkol runtime (lib/core/dnc_api.c) can drive a
+ * differentiable external memory — content addressing (cosine + softmax),
+ * location addressing (indicator bump), NTM erase/add write, least-used
+ * allocation, and hand-derived backprop through read + content addressing —
+ * on real memory banks from .esk.
+ *
+ * The functions here are byte-for-byte mirrors of the static functions in
+ * lib/backend/diff_memory_prototype.c, GENERALISED from its compile-time
+ * N=64,W=8 to runtime row/col counts (so a .esk caller can size the bank).
+ * At the prototype's N=64,W=8 they reduce to exactly the same arithmetic, in
+ * the same order, so the .esk builtins reproduce the prototype's own main()
+ * oracle bit-for-bit (the "C is source of truth" dylib rule).
+ *
+ * Keeping this in a standalone header (rather than un-static'ing symbols in a
+ * separate link unit that has its own main()) means the diff_memory_prototype
+ * executable and its three acceptance checks build entirely unchanged.
+ *
+ * Copyright (C) tsotchke
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef ESHKOL_DNC_CORE_H
+#define ESHKOL_DNC_CORE_H
+
+#include <stddef.h>
+#include <math.h>
+
+/* sigmoid (double) mirroring diff_memory_prototype.c's sigmoidd saturation. */
+static inline double dnc_sigmoidd(double x) {
+    if (x > 40.0) return 1.0;
+    if (x < -40.0) return 0.0;
+    return 1.0 / (1.0 + exp(-x));
+}
+
+/* Generalized indicator bump at integer address k, evaluated at x.
+ * Identical in form to diff_memory_prototype.c's indicator(); beta plays SCALE. */
+static inline double dnc_indicator(double x, double k, double beta) {
+    return dnc_sigmoidd(beta * (x - k + 0.5)) - dnc_sigmoidd(beta * (x - k - 0.5));
+}
+
+/* Numerically stable softmax of logits[n] into out[n] (mirror softmax). */
+static inline void dnc_softmax(const double *logits, int n, double *out) {
+    double m = logits[0];
+    for (int i = 1; i < n; i++) if (logits[i] > m) m = logits[i];
+    double s = 0.0;
+    for (int i = 0; i < n; i++) { out[i] = exp(logits[i] - m); s += out[i]; }
+    for (int i = 0; i < n; i++) out[i] /= s;
+}
+
+/* Location addressing: indicator bump over N rows, normalized (mirror loc_weights). */
+static inline void dnc_loc_weights(double addr, double beta, int N, double *w) {
+    for (int i = 0; i < N; i++) w[i] = dnc_indicator(addr, (double)i, beta);
+    double s = 0.0;
+    for (int i = 0; i < N; i++) s += w[i];
+    if (s > 1e-300) for (int i = 0; i < N; i++) w[i] /= s;
+}
+
+/* cosine_sim over n dims (mirror cosine_sim). */
+static inline double dnc_cosine_sim(const double *a, const double *b, int n) {
+    double dot = 0.0, na = 0.0, nb = 0.0;
+    for (int i = 0; i < n; i++) { dot += a[i]*b[i]; na += a[i]*a[i]; nb += b[i]*b[i]; }
+    double denom = sqrt(na) * sqrt(nb) + 1e-12;
+    return dot / denom;
+}
+
+/* Content addressing: softmax(beta * cosine(key, row_i)) over N rows
+ * (mirror content_weights). mem is row-major N x W. */
+static inline void dnc_content_weights(const double *mem, int N, int W,
+                                       const double *key, double beta, double *w) {
+    /* logits buffer is caller-free: compute into w then softmax in place via tmp. */
+    /* Use a local VLA-free scheme: store logits into w, then softmax(w,...). */
+    for (int i = 0; i < N; i++) w[i] = beta * dnc_cosine_sim(key, &mem[(size_t)i*W], W);
+    /* softmax in place: */
+    double m = w[0];
+    for (int i = 1; i < N; i++) if (w[i] > m) m = w[i];
+    double s = 0.0;
+    for (int i = 0; i < N; i++) { w[i] = exp(w[i] - m); s += w[i]; }
+    for (int i = 0; i < N; i++) w[i] /= s;
+}
+
+/* read = sum_i w_i * mem[i] (mirror read_mem). out length W. */
+static inline void dnc_read_mem(const double *mem, int N, int W,
+                                const double *w, double *out) {
+    for (int j = 0; j < W; j++) {
+        double acc = 0.0;
+        for (int i = 0; i < N; i++) acc += w[i] * mem[(size_t)i*W + j];
+        out[j] = acc;
+    }
+}
+
+/* NTM erase/add: mem[i] = mem[i]*(1 - w_i*erase) + w_i*add; usage[i]+=w_i
+ * (mirror write_mem). */
+static inline void dnc_write_mem(double *mem, double *usage, int N, int W,
+                                 const double *w, const double *erase, const double *add) {
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < W; j++) {
+            double *cell = &mem[(size_t)i*W + j];
+            *cell = (*cell) * (1.0 - w[i]*erase[j]) + w[i]*add[j];
+        }
+        usage[i] += w[i];
+    }
+}
+
+/* Allocation: softmax(-beta * usage) (mirror alloc_weights). */
+static inline void dnc_alloc_weights(const double *usage, int N, double beta, double *w) {
+    for (int i = 0; i < N; i++) w[i] = -beta * usage[i];
+    dnc_softmax(w, N, w);
+}
+
+/* Loss-only forward for finite-diff parity (mirror loss_only). target length W. */
+static inline double dnc_loss_only(const double *mem, int N, int W,
+                                   const double *key, const double *target, double beta,
+                                   double *w_scratch, double *rd_scratch) {
+    dnc_content_weights(mem, N, W, key, beta, w_scratch);
+    dnc_read_mem(mem, N, W, w_scratch, rd_scratch);
+    double L = 0.0;
+    for (int j = 0; j < W; j++) { double e = rd_scratch[j]-target[j]; L += 0.5*e*e; }
+    return L;
+}
+
+/* Backprop through L = 0.5 * sum_j (read_j - target_j)^2, read = sum_i w_i M_i,
+ * w = softmax(beta * cosine(key, M_i)). Fills grad_key[W] = dL/dkey and the full
+ * grad_mem[N*W] = dL/dM (row-major). Returns L. Mirror loss_and_grads, extended
+ * from the prototype's single-row grad_row to the full memory gradient (each row
+ * enters BOTH the read and its own similarity term — identical per-row formula).
+ *
+ * Scratch arrays (caller-allocated, never freed here): s[N], wv[N], rd[W],
+ * dread[W], dw[N], ds[N]. */
+static inline double dnc_loss_and_grads(const double *mem, int N, int W,
+                                        const double *key, const double *target, double beta,
+                                        double *grad_key, double *grad_mem,
+                                        double *s, double *wv, double *rd,
+                                        double *dread, double *dw, double *ds) {
+    /* ---- forward ---- */
+    for (int i = 0; i < N; i++) s[i] = dnc_cosine_sim(key, &mem[(size_t)i*W], W);
+    for (int i = 0; i < N; i++) wv[i] = beta * s[i];
+    dnc_softmax(wv, N, wv);            /* wv now = softmax(beta*s) */
+    dnc_read_mem(mem, N, W, wv, rd);
+
+    double L = 0.0;
+    for (int j = 0; j < W; j++) {
+        double e = rd[j] - target[j];
+        L += 0.5 * e * e;
+        dread[j] = e;
+    }
+
+    /* dL/dw_i = sum_j dread_j * M[i][j] */
+    for (int i = 0; i < N; i++) {
+        double acc = 0.0;
+        for (int j = 0; j < W; j++) acc += dread[j] * mem[(size_t)i*W + j];
+        dw[i] = acc;
+    }
+
+    /* Through softmax: dL/dlogit_k = w_k*(dw_k - sum_i w_i dw_i); dL/ds_k = beta*that */
+    double wdotdw = 0.0;
+    for (int i = 0; i < N; i++) wdotdw += wv[i] * dw[i];
+    for (int k = 0; k < N; k++) ds[k] = beta * wv[k] * (dw[k] - wdotdw);
+
+    /* ---- dL/dkey via cosine sims (mirror prototype) ---- */
+    double na = 0.0;
+    for (int t = 0; t < W; t++) na += key[t]*key[t];
+    double sqrt_na = sqrt(na);
+    for (int t = 0; t < W; t++) grad_key[t] = 0.0;
+    for (int i = 0; i < N; i++) {
+        double dot = 0.0, nbi = 0.0;
+        const double *Mi = &mem[(size_t)i*W];
+        for (int t = 0; t < W; t++) { dot += key[t]*Mi[t]; nbi += Mi[t]*Mi[t]; }
+        double sqrt_nbi = sqrt(nbi);
+        double denom = sqrt_na * sqrt_nbi + 1e-12;
+        double inv_denom = 1.0 / denom;
+        double dsqrt_na_term = (sqrt_na > 1e-300) ? (sqrt_nbi / sqrt_na) : 0.0;
+        for (int t = 0; t < W; t++) {
+            double ddot = Mi[t];
+            double ddenom = dsqrt_na_term * key[t];
+            double dsi_dkeyt = ddot * inv_denom - dot * ddenom * inv_denom * inv_denom;
+            grad_key[t] += ds[i] * dsi_dkeyt;
+        }
+    }
+
+    /* ---- dL/dM for every row (mirror prototype's single-row formula) ----
+     * Row r enters BOTH the read (read = sum_i w_i M_i) and similarity s_r. */
+    for (int r = 0; r < N; r++) {
+        const double *Mr = &mem[(size_t)r*W];
+        double *gr = &grad_mem[(size_t)r*W];
+        double dot = 0.0, nbr = 0.0;
+        for (int t = 0; t < W; t++) { dot += key[t]*Mr[t]; nbr += Mr[t]*Mr[t]; }
+        double sqrt_nbr = sqrt(nbr);
+        double denom = sqrt_na * sqrt_nbr + 1e-12;
+        double inv_denom = 1.0 / denom;
+        double dsqrt_nb_term = (sqrt_nbr > 1e-300) ? (sqrt_na / sqrt_nbr) : 0.0;
+        for (int t = 0; t < W; t++) {
+            double ddot = key[t];
+            double ddenom = dsqrt_nb_term * Mr[t];
+            double dsr_dMt = ddot * inv_denom - dot * ddenom * inv_denom * inv_denom;
+            gr[t] = dread[t] * wv[r]      /* read path */
+                  + ds[r] * dsr_dMt;       /* sim path  */
+        }
+    }
+
+    return L;
+}
+
+#endif /* ESHKOL_DNC_CORE_H */

--- a/lib/core/sdnc.esk
+++ b/lib/core/sdnc.esk
@@ -1,0 +1,30 @@
+;;
+;; core.sdnc — SDNC weight-program (bytecode-VM-as-transformer θ)
+;;
+;; Exposes a trainable weight-program θ so programs can do geometric recursive
+;; self-improvement on real SDNC weights from .esk: a genuine transformer
+;; forward (sdnc-run) and exact weight-gradient (sdnc-weight-grad), plus the
+;; flat trainable parameter vector (sdnc-params / sdnc-set-params!) so an
+;; external optimizer can drive it.
+;;
+;; The weight kernels (forward / backward_through_weights / SGD step) mirror
+;; lib/backend/weight_matrices.c byte-for-byte (see lib/core/sdnc_core.h).
+;; Vectors are Eshkol #(...) float vectors.
+;;
+;;   (sdnc-program name)               -> θ      named, reproducible weight set
+;;   (sdnc-run θ input)                -> #(..)  D-dim forward output
+;;   (sdnc-weight-grad θ input target) -> #(..)  flat dL/dWEIGHTS
+;;                                                (= (sdnc-params θ) length)
+;;   (sdnc-params θ)                   -> #(..)  flattened trainable weights
+;;   (sdnc-set-params! θ vec)          -> θ      write weights back
+;;   (sdnc-improve! θ data steps lr)   -> θ      SGD on weights, returns θ
+;;   (sdnc? x)                         -> bool
+;;
+
+(provide sdnc-program
+         sdnc-run
+         sdnc-weight-grad
+         sdnc-params
+         sdnc-set-params!
+         sdnc-improve!
+         sdnc?)

--- a/lib/core/sdnc_api.c
+++ b/lib/core/sdnc_api.c
@@ -1,0 +1,444 @@
+/*
+ * SDNC Runtime API — expose the bytecode-VM-as-transformer weight-program (θ)
+ * as pure-Eshkol builtins so programs can do geometric recursive
+ * self-improvement on real weight-programs from .esk.
+ *
+ * Builtins (registered in parser.cpp / llvm_codegen.cpp / system_codegen.cpp /
+ * type_checker.cpp / eshkol-run.cpp):
+ *   (sdnc-program name)             -> θ        opaque handle (HEAP_SUBTYPE_SDNC)
+ *   (sdnc-run θ input)              -> #(...)   D-dim forward output (real matvec)
+ *   (sdnc-weight-grad θ input target) -> #(...) flat ∂L/∂WEIGHTS (backprop),
+ *                                               length == (sdnc-params θ) length
+ *   (sdnc-params θ)                 -> #(...)   flattened trainable weights
+ *   (sdnc-set-params! θ vec)        -> θ        write flattened weights back
+ *   (sdnc-improve! θ data steps lr) -> θ        SGD on weights, returns θ
+ *   (sdnc? x)                       -> bool
+ *
+ * The trainable core math (forward / backward_through_weights /
+ * apply_weight_gradient_step / param flatten) lives in lib/core/sdnc_core.h, a
+ * byte-for-byte mirror of the SDNC paper artifact's weight kernels in
+ * lib/backend/weight_matrices.c (which is a standalone executable with file-
+ * static functions + its own main() — including it into the runtime would
+ * collide with the already-linked vm_*.c units, so the kernels are mirrored).
+ *
+ * The forward / backward here are the SAME float arithmetic, in the SAME order,
+ * as forward_with_weights / backward_through_weights in weight_matrices.c, so
+ * sdnc-run and sdnc-weight-grad genuinely compute the SDNC weight-program's
+ * forward output and exact weight gradient — no stubs.
+ *
+ * Copyright (C) tsotchke
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include <eshkol/eshkol.h>
+
+#include "sdnc_core.h"
+
+/* Arena handle (defined in arena_memory.h; only used by pointer here). */
+typedef struct arena arena_t;
+
+extern void* arena_allocate_with_header(arena_t* arena, size_t data_size,
+                                        uint8_t subtype, uint8_t flags);
+extern void* arena_allocate_aligned(arena_t* arena, size_t size, size_t alignment);
+extern void  eshkol_runtime_fatal(eshkol_exception_type_t type, const char* fmt, ...);
+
+/* ===== Handle =====
+ * Stored small in the arena; points to a calloc'd weight set so the large
+ * SdncWeights never goes through the arena. Owns the position embeddings used by
+ * forward/backward (set up deterministically per program). */
+#define SDNC_NP 4
+typedef struct {
+    SdncWeights* w;
+    int          np;
+    float        pe[256][SDNC_D];
+} SdncHandle;
+
+/* Tensor layout mirroring #(...) literals. */
+typedef struct sdnc_tensor_layout {
+    uint64_t* dimensions;
+    uint64_t  num_dimensions;
+    int64_t*  elements;
+    uint64_t  total_elements;
+} sdnc_tensor_layout_t;
+
+/* ===== Param flatten/unflatten (canonical order, mirror SdncWeights) ===== */
+static size_t sdnc_param_count(void) {
+    const int D = SDNC_D, N = SDNC_N_LAYERS, F = SDNC_FFN_DIM;
+    return (size_t)N * ( (size_t)4*D*D + D + 2*(size_t)D*F + 2*F + (size_t)F*D + D );
+}
+
+typedef void (*sdnc_param_visit_cb)(size_t idx, float* slot, void* ud);
+static void sdnc_visit_params(SdncWeights* w, sdnc_param_visit_cb cb, void* ud) {
+    const int D = SDNC_D, N = SDNC_N_LAYERS, F = SDNC_FFN_DIM;
+    size_t idx = 0;
+    for (int L = 0; L < N; L++) {
+        for (int i = 0; i < D*D; i++) cb(idx++, &w->wq[L][i], ud);
+        for (int i = 0; i < D*D; i++) cb(idx++, &w->wk[L][i], ud);
+        for (int i = 0; i < D*D; i++) cb(idx++, &w->wv[L][i], ud);
+        for (int i = 0; i < D*D; i++) cb(idx++, &w->wo[L][i], ud);
+        for (int i = 0; i < D; i++)   cb(idx++, &w->bq[L][i], ud);
+        for (int i = 0; i < D*F; i++) cb(idx++, &w->ff_up[L][i], ud);
+        for (int i = 0; i < F; i++)   cb(idx++, &w->ff_up_b[L][i], ud);
+        for (int i = 0; i < F*D; i++) cb(idx++, &w->ff_down[L][i], ud);
+        for (int i = 0; i < D; i++)   cb(idx++, &w->ff_down_b[L][i], ud);
+        for (int i = 0; i < D*F; i++) cb(idx++, &w->ff_gate[L][i], ud);
+        for (int i = 0; i < F; i++)   cb(idx++, &w->ff_gate_b[L][i], ud);
+    }
+}
+
+/* Same canonical visit over a SdncGrads (the gradient struct mirrors the
+ * trainable weight subset, field-for-field). */
+static void sdnc_visit_grads(SdncGrads* g, sdnc_param_visit_cb cb, void* ud) {
+    const int D = SDNC_D, N = SDNC_N_LAYERS, F = SDNC_FFN_DIM;
+    size_t idx = 0;
+    for (int L = 0; L < N; L++) {
+        for (int i = 0; i < D*D; i++) cb(idx++, &g->dwq[L][i], ud);
+        for (int i = 0; i < D*D; i++) cb(idx++, &g->dwk[L][i], ud);
+        for (int i = 0; i < D*D; i++) cb(idx++, &g->dwv[L][i], ud);
+        for (int i = 0; i < D*D; i++) cb(idx++, &g->dwo[L][i], ud);
+        for (int i = 0; i < D; i++)   cb(idx++, &g->dbq[L][i], ud);
+        for (int i = 0; i < D*F; i++) cb(idx++, &g->dff_up[L][i], ud);
+        for (int i = 0; i < F; i++)   cb(idx++, &g->dff_up_b[L][i], ud);
+        for (int i = 0; i < F*D; i++) cb(idx++, &g->dff_down[L][i], ud);
+        for (int i = 0; i < D; i++)   cb(idx++, &g->dff_down_b[L][i], ud);
+        for (int i = 0; i < D*F; i++) cb(idx++, &g->dff_gate[L][i], ud);
+        for (int i = 0; i < F; i++)   cb(idx++, &g->dff_gate_b[L][i], ud);
+    }
+}
+
+/* ===== Helpers ===== */
+static SdncHandle* sdnc_extract_handle(const eshkol_tagged_value_t* tv) {
+    if (!tv || tv->type != ESHKOL_VALUE_HEAP_PTR || !tv->data.ptr_val) return NULL;
+    void* ptr = (void*)(uintptr_t)tv->data.ptr_val;
+    eshkol_object_header_t* hdr = ESHKOL_GET_HEADER(ptr);
+    if (hdr->subtype != HEAP_SUBTYPE_SDNC) return NULL;
+    return (SdncHandle*)ptr;
+}
+
+static int sdnc_get_int(const eshkol_tagged_value_t* tv, int dflt) {
+    if (!tv) return dflt;
+    uint8_t t = tv->type & 0x0F;
+    if (t == ESHKOL_VALUE_INT64)  return (int)tv->data.int_val;
+    if (t == ESHKOL_VALUE_DOUBLE) return (int)tv->data.double_val;
+    return dflt;
+}
+static double sdnc_get_double(const eshkol_tagged_value_t* tv, double dflt) {
+    if (!tv) return dflt;
+    uint8_t t = tv->type & 0x0F;
+    if (t == ESHKOL_VALUE_DOUBLE) return tv->data.double_val;
+    if (t == ESHKOL_VALUE_INT64)  return (double)tv->data.int_val;
+    return dflt;
+}
+
+/* Read a #(...) tensor (or heterogeneous vector) into a float buffer of length
+ * `want` (pad with 0, truncate as needed). Returns number of source elements
+ * read, or -1 on type error. */
+static int sdnc_read_vector_into(const eshkol_tagged_value_t* tv, float* dst, int want) {
+    for (int i = 0; i < want; i++) dst[i] = 0.0f;
+    if (!tv || tv->type != ESHKOL_VALUE_HEAP_PTR || !tv->data.ptr_val) return -1;
+    void* ptr = (void*)(uintptr_t)tv->data.ptr_val;
+    eshkol_object_header_t* hdr = ESHKOL_GET_HEADER(ptr);
+    if (hdr->subtype == HEAP_SUBTYPE_TENSOR) {
+        sdnc_tensor_layout_t* t = (sdnc_tensor_layout_t*)ptr;
+        int n = (int)t->total_elements;
+        if (n <= 0 || !t->elements) return -1;
+        int m = n < want ? n : want;
+        for (int i = 0; i < m; i++) {
+            union { double d; int64_t i; } u;
+            u.i = t->elements[i];
+            dst[i] = (float)u.d;
+        }
+        return n;
+    }
+    if (hdr->subtype == HEAP_SUBTYPE_VECTOR) {
+        int64_t n = *(int64_t*)ptr;
+        if (n <= 0) return -1;
+        eshkol_tagged_value_t* elems =
+            (eshkol_tagged_value_t*)((uint8_t*)ptr + sizeof(int64_t));
+        int m = (int)n < want ? (int)n : want;
+        for (int i = 0; i < m; i++) {
+            uint8_t et = elems[i].type & 0x0F;
+            if (et == ESHKOL_VALUE_DOUBLE)     dst[i] = (float)elems[i].data.double_val;
+            else if (et == ESHKOL_VALUE_INT64) dst[i] = (float)elems[i].data.int_val;
+        }
+        return (int)n;
+    }
+    return -1;
+}
+
+static void sdnc_make_tensor_f(arena_t* arena, const float* data, int len,
+                               eshkol_tagged_value_t* result) {
+    memset(result, 0, sizeof(*result));
+    if (!arena || !data || len <= 0) { result->type = ESHKOL_VALUE_NULL; return; }
+    sdnc_tensor_layout_t* t = (sdnc_tensor_layout_t*)arena_allocate_with_header(
+        arena, sizeof(sdnc_tensor_layout_t), HEAP_SUBTYPE_TENSOR, 0);
+    if (!t) { result->type = ESHKOL_VALUE_NULL; return; }
+    t->num_dimensions = 1;
+    t->total_elements = (uint64_t)len;
+    t->dimensions = (uint64_t*)arena_allocate_aligned(arena, sizeof(uint64_t), 8);
+    if (t->dimensions) t->dimensions[0] = (uint64_t)len;
+    t->elements = (int64_t*)arena_allocate_aligned(arena, (size_t)len * sizeof(int64_t), 8);
+    if (!t->elements) { result->type = ESHKOL_VALUE_NULL; return; }
+    for (int i = 0; i < len; i++) {
+        union { double d; int64_t i; } u;
+        u.d = (double)data[i];
+        t->elements[i] = u.i;
+    }
+    result->type = ESHKOL_VALUE_HEAP_PTR;
+    result->data.ptr_val = (uint64_t)(uintptr_t)t;
+}
+
+/* Deterministic, name-dependent position embeddings (the "program"). Mirrors
+ * the random pe in self_improve_demo but seeded by a name hash so each named
+ * program is distinct and reproducible. */
+static void sdnc_setup_program(SdncHandle* h, unsigned long seed) {
+    SdncRng r; r.state = 0x5EEDF00DUL ^ seed; r.scale = 0.1f;
+    h->np = SDNC_NP;
+    for (int p = 0; p < h->np; p++)
+        for (int i = 0; i < SDNC_D; i++) h->pe[p][i] = sdnc_randf(&r);
+}
+
+static unsigned long sdnc_name_hash(const eshkol_tagged_value_t* name_tv) {
+    /* FNV-1a over the string payload if a string is supplied; else 0. */
+    unsigned long hsh = 1469598103934665603UL;
+    if (name_tv && name_tv->type == ESHKOL_VALUE_HEAP_PTR && name_tv->data.ptr_val) {
+        const char* s = (const char*)(uintptr_t)name_tv->data.ptr_val;
+        eshkol_object_header_t* hdr = ESHKOL_GET_HEADER((void*)(uintptr_t)name_tv->data.ptr_val);
+        if (hdr->subtype == HEAP_SUBTYPE_STRING) {
+            for (const char* p = s; *p; p++) { hsh ^= (unsigned char)*p; hsh *= 1099511628211UL; }
+        }
+    }
+    return hsh;
+}
+
+/* ===== (sdnc-program name) -> θ ===== */
+void eshkol_sdnc_program_tagged(arena_t* arena,
+                                const eshkol_tagged_value_t* name_tv,
+                                eshkol_tagged_value_t* result) {
+    if (!result) return;
+    memset(result, 0, sizeof(*result));
+    if (!arena) { result->type = ESHKOL_VALUE_NULL; return; }
+
+    SdncHandle* h = (SdncHandle*)arena_allocate_with_header(
+        arena, sizeof(SdncHandle), HEAP_SUBTYPE_SDNC, 0);
+    if (!h) { result->type = ESHKOL_VALUE_NULL; return; }
+    h->w = (SdncWeights*)calloc(1, sizeof(SdncWeights));
+    if (!h->w) { result->type = ESHKOL_VALUE_NULL; return; }
+    sdnc_init_weights(h->w);
+    sdnc_setup_program(h, sdnc_name_hash(name_tv));
+
+    result->type = ESHKOL_VALUE_HEAP_PTR;
+    result->data.ptr_val = (uint64_t)(uintptr_t)h;
+}
+
+/* ===== (sdnc-run θ input) -> #(...) D-dim output ===== */
+void eshkol_sdnc_run_tagged(arena_t* arena,
+                            const eshkol_tagged_value_t* theta,
+                            const eshkol_tagged_value_t* input_tv,
+                            eshkol_tagged_value_t* result) {
+    if (!result) return;
+    memset(result, 0, sizeof(*result));
+    SdncHandle* h = sdnc_extract_handle(theta);
+    if (!h || !h->w) { eshkol_runtime_fatal(ESHKOL_EXCEPTION_TYPE_ERROR,
+        "sdnc-run: first argument is not an sdnc program"); result->type = ESHKOL_VALUE_NULL; return; }
+
+    float state[SDNC_D];
+    if (sdnc_read_vector_into(input_tv, state, SDNC_D) < 0) {
+        eshkol_runtime_fatal(ESHKOL_EXCEPTION_TYPE_ERROR,
+            "sdnc-run: input must be a numeric vector");
+        result->type = ESHKOL_VALUE_NULL; return;
+    }
+    float next[SDNC_D];
+    sdnc_forward(h->w, state, h->pe, h->np, next);
+    sdnc_make_tensor_f(arena, next, SDNC_D, result);
+}
+
+/* ===== (sdnc-weight-grad θ input target) -> flat ∂L/∂weights ===== */
+struct sdnc_grad_flatten_ctx { float* dst; size_t n; };
+static void sdnc_grad_flatten_cb(size_t idx, float* slot, void* ud) {
+    struct sdnc_grad_flatten_ctx* fc = (struct sdnc_grad_flatten_ctx*)ud;
+    if (idx < fc->n) fc->dst[idx] = *slot;
+}
+
+void eshkol_sdnc_weight_grad_tagged(arena_t* arena,
+                                    const eshkol_tagged_value_t* theta,
+                                    const eshkol_tagged_value_t* input_tv,
+                                    const eshkol_tagged_value_t* target_tv,
+                                    eshkol_tagged_value_t* result) {
+    if (!result) return;
+    memset(result, 0, sizeof(*result));
+    SdncHandle* h = sdnc_extract_handle(theta);
+    if (!h || !h->w) { eshkol_runtime_fatal(ESHKOL_EXCEPTION_TYPE_ERROR,
+        "sdnc-weight-grad: first argument is not an sdnc program"); result->type = ESHKOL_VALUE_NULL; return; }
+
+    float state[SDNC_D], target[SDNC_D];
+    if (sdnc_read_vector_into(input_tv, state, SDNC_D) < 0 ||
+        sdnc_read_vector_into(target_tv, target, SDNC_D) < 0) {
+        eshkol_runtime_fatal(ESHKOL_EXCEPTION_TYPE_ERROR,
+            "sdnc-weight-grad: input/target must be numeric vectors");
+        result->type = ESHKOL_VALUE_NULL; return;
+    }
+
+    /* Forward to get read, dL/dnext for L = 1/2 ||next - target||^2. */
+    float next[SDNC_D], dL_dnext[SDNC_D];
+    sdnc_forward(h->w, state, h->pe, h->np, next);
+    for (int i = 0; i < SDNC_D; i++) dL_dnext[i] = next[i] - target[i];
+
+    SdncGrads*    g     = (SdncGrads*)calloc(1, sizeof(SdncGrads));
+    SdncFwdCache* cache = (SdncFwdCache*)calloc(1, sizeof(SdncFwdCache));
+    if (!g || !cache) { free(g); free(cache); result->type = ESHKOL_VALUE_NULL; return; }
+
+    sdnc_zero_grads(g);
+    sdnc_backward(h->w, state, h->pe, h->np, dL_dnext, g, NULL, cache);
+
+    size_t n = sdnc_param_count();
+    float* flat = (float*)malloc(n * sizeof(float));
+    if (!flat) { free(g); free(cache); result->type = ESHKOL_VALUE_NULL; return; }
+    struct sdnc_grad_flatten_ctx fc; fc.dst = flat; fc.n = n;
+    sdnc_visit_grads(g, sdnc_grad_flatten_cb, &fc);
+
+    sdnc_make_tensor_f(arena, flat, (int)n, result);
+    free(flat); free(g); free(cache);
+}
+
+/* ===== (sdnc-params θ) -> #(...) ===== */
+struct sdnc_pflatten_ctx { float* dst; size_t n; };
+static void sdnc_pflatten_cb(size_t idx, float* slot, void* ud) {
+    struct sdnc_pflatten_ctx* fc = (struct sdnc_pflatten_ctx*)ud;
+    if (idx < fc->n) fc->dst[idx] = *slot;
+}
+void eshkol_sdnc_params_tagged(arena_t* arena,
+                               const eshkol_tagged_value_t* theta,
+                               eshkol_tagged_value_t* result) {
+    if (!result) return;
+    memset(result, 0, sizeof(*result));
+    SdncHandle* h = sdnc_extract_handle(theta);
+    if (!arena || !h || !h->w) { result->type = ESHKOL_VALUE_NULL; return; }
+    size_t n = sdnc_param_count();
+    float* flat = (float*)malloc(n * sizeof(float));
+    if (!flat) { result->type = ESHKOL_VALUE_NULL; return; }
+    struct sdnc_pflatten_ctx fc; fc.dst = flat; fc.n = n;
+    sdnc_visit_params(h->w, sdnc_pflatten_cb, &fc);
+    sdnc_make_tensor_f(arena, flat, (int)n, result);
+    free(flat);
+}
+
+/* ===== (sdnc-set-params! θ vec) -> θ ===== */
+struct sdnc_unflatten_ctx { const float* src; size_t n; };
+static void sdnc_unflatten_cb(size_t idx, float* slot, void* ud) {
+    struct sdnc_unflatten_ctx* uc = (struct sdnc_unflatten_ctx*)ud;
+    if (idx < uc->n) *slot = uc->src[idx];
+}
+void eshkol_sdnc_set_params_tagged(arena_t* arena,
+                                   const eshkol_tagged_value_t* theta,
+                                   const eshkol_tagged_value_t* vec,
+                                   eshkol_tagged_value_t* result) {
+    if (!result) return;
+    memset(result, 0, sizeof(*result));
+    (void)arena;
+    SdncHandle* h = sdnc_extract_handle(theta);
+    if (!h || !h->w) { result->type = ESHKOL_VALUE_NULL; return; }
+    size_t n = sdnc_param_count();
+    float* buf = (float*)malloc(n * sizeof(float));
+    if (!buf) { result->type = ESHKOL_VALUE_NULL; return; }
+    int got = sdnc_read_vector_into(vec, buf, (int)n);
+    if (got < 0) {
+        free(buf);
+        eshkol_runtime_fatal(ESHKOL_EXCEPTION_TYPE_ERROR,
+            "sdnc-set-params!: vec must be a numeric vector");
+        result->type = ESHKOL_VALUE_NULL; return;
+    }
+    struct sdnc_unflatten_ctx uc; uc.src = buf; uc.n = n;
+    sdnc_visit_params(h->w, sdnc_unflatten_cb, &uc);
+    free(buf);
+    result->type = ESHKOL_VALUE_HEAP_PTR;
+    result->data.ptr_val = (uint64_t)(uintptr_t)h;
+}
+
+/* ===== (sdnc-improve! θ data steps lr) -> θ =====
+ * `data` is a (input . target) cons; if not a cons, input=data and target=
+ * forward(input) nudged so the loss is a non-trivial decreasing objective.
+ * Runs `steps` SGD steps at learning-rate lr, returns the (mutated) handle. */
+void eshkol_sdnc_improve_tagged(arena_t* arena,
+                                const eshkol_tagged_value_t* theta,
+                                const eshkol_tagged_value_t* data_tv,
+                                const eshkol_tagged_value_t* steps_tv,
+                                const eshkol_tagged_value_t* lr_tv,
+                                eshkol_tagged_value_t* result) {
+    if (!result) return;
+    memset(result, 0, sizeof(*result));
+    (void)arena;
+    SdncHandle* h = sdnc_extract_handle(theta);
+    if (!h || !h->w) { result->type = ESHKOL_VALUE_NULL; return; }
+
+    int steps = sdnc_get_int(steps_tv, 1);
+    if (steps < 0) steps = 0;
+    float lr = (float)sdnc_get_double(lr_tv, 0.002);
+
+    float state[SDNC_D], target[SDNC_D];
+    int have_target = 0;
+
+    /* If data is a cons (input . target), read both. */
+    if (data_tv && data_tv->type == ESHKOL_VALUE_HEAP_PTR && data_tv->data.ptr_val) {
+        eshkol_object_header_t* hdr = ESHKOL_GET_HEADER((void*)(uintptr_t)data_tv->data.ptr_val);
+        if (hdr->subtype == HEAP_SUBTYPE_CONS) {
+            eshkol_tagged_value_t* car = (eshkol_tagged_value_t*)(uintptr_t)data_tv->data.ptr_val;
+            eshkol_tagged_value_t* cdr = car + 1;
+            if (sdnc_read_vector_into(car, state, SDNC_D) >= 0 &&
+                sdnc_read_vector_into(cdr, target, SDNC_D) >= 0) {
+                have_target = 1;
+            }
+        } else {
+            /* data is a plain input vector */
+            if (sdnc_read_vector_into(data_tv, state, SDNC_D) >= 0) {
+                /* synthesize a reachable target: forward then nudge */
+                sdnc_forward(h->w, state, h->pe, h->np, target);
+                target[0]+=0.5f; target[1]+=0.5f; target[5]+=0.5f;
+                target[10]+=0.5f; target[42]+=0.5f;
+                have_target = 1;
+            }
+        }
+    }
+    if (!have_target) {
+        /* No usable data: deterministic self-improve objective. */
+        SdncRng r; r.state = 0x1234ABCDUL; r.scale = 0.1f;
+        for (int i = 0; i < SDNC_D; i++) state[i] = sdnc_randf(&r);
+        sdnc_forward(h->w, state, h->pe, h->np, target);
+        target[0]+=0.5f; target[1]+=0.5f; target[5]+=0.5f;
+        target[10]+=0.5f; target[42]+=0.5f;
+    }
+
+    SdncGrads*    g     = (SdncGrads*)calloc(1, sizeof(SdncGrads));
+    SdncFwdCache* cache = (SdncFwdCache*)calloc(1, sizeof(SdncFwdCache));
+    if (!g || !cache) { free(g); free(cache); result->type = ESHKOL_VALUE_NULL; return; }
+
+    float next[SDNC_D], dL_dnext[SDNC_D];
+    for (int it = 0; it < steps; it++) {
+        sdnc_forward(h->w, state, h->pe, h->np, next);
+        for (int i = 0; i < SDNC_D; i++) dL_dnext[i] = next[i] - target[i];
+        sdnc_zero_grads(g);
+        sdnc_backward(h->w, state, h->pe, h->np, dL_dnext, g, NULL, cache);
+        sdnc_apply_grad_step(h->w, g, lr);
+    }
+    free(g); free(cache);
+
+    result->type = ESHKOL_VALUE_HEAP_PTR;
+    result->data.ptr_val = (uint64_t)(uintptr_t)h;
+}
+
+/* ===== (sdnc? x) -> bool ===== */
+void eshkol_sdnc_pred_tagged(arena_t* arena,
+                             const eshkol_tagged_value_t* x_tv,
+                             eshkol_tagged_value_t* result) {
+    if (!result) return;
+    (void)arena;
+    memset(result, 0, sizeof(*result));
+    result->type = ESHKOL_VALUE_BOOL;
+    result->data.int_val = sdnc_extract_handle(x_tv) ? 1 : 0;
+}

--- a/lib/core/sdnc_core.h
+++ b/lib/core/sdnc_core.h
@@ -1,0 +1,422 @@
+/*
+ * SDNC Core — shared bytecode-VM-as-transformer weight math.
+ *
+ * Self-contained header exposing the trainable core of
+ * lib/backend/weight_matrices.c (the SDNC paper artifact) so that the
+ * Eshkol runtime (lib/core/sdnc_api.c) can drive the self-improvement loop
+ * — forward -> loss -> backward_through_weights -> apply_weight_gradient_step —
+ * on real program weights theta from .esk.
+ *
+ * The struct layout (InterpreterWeights / WeightGrads) and the forward /
+ * backward / gradient-step math here are byte-for-byte mirrors of the
+ * definitions in lib/backend/weight_matrices.c. They depend ONLY on the weight
+ * structs, the model constants below, and libm — they touch NONE of the
+ * standalone artifact's VM globals (g_frames, g_heap, ...). Keeping them in a
+ * standalone header (rather than un-static'ing symbols that live in a separate
+ * link unit with its own main()) means the `weight_matrices` executable and its
+ * 127-test suite build entirely unchanged.
+ *
+ * Copyright (C) tsotchke
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef ESHKOL_SDNC_CORE_H
+#define ESHKOL_SDNC_CORE_H
+
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+/* ---- Model constants (mirror weight_matrices.c) ---- */
+#ifndef SDNC_D
+#define SDNC_D 256
+#endif
+#ifndef SDNC_HD
+#define SDNC_HD 2
+#endif
+#ifndef SDNC_N_LAYERS
+#define SDNC_N_LAYERS 6
+#endif
+#ifndef SDNC_FFN_DIM
+#define SDNC_FFN_DIM 2304
+#endif
+
+/* Local short aliases used inside this header only. */
+#define D       SDNC_D
+#define HD      SDNC_HD
+#define N_LAYERS SDNC_N_LAYERS
+#define FFN_DIM SDNC_FFN_DIM
+
+/* ---- Trainable weights (mirror of InterpreterWeights' trainable subset
+ *      plus the per-layer ff_type schedule) ---- */
+typedef struct {
+    float wq[N_LAYERS][D * D];
+    float wk[N_LAYERS][D * D];
+    float wv[N_LAYERS][D * D];
+    float wo[N_LAYERS][D * D];
+    float bq[N_LAYERS][D];
+    float ff_up[N_LAYERS][D * FFN_DIM];
+    float ff_up_b[N_LAYERS][FFN_DIM];
+    float ff_down[N_LAYERS][FFN_DIM * D];
+    float ff_down_b[N_LAYERS][D];
+    float ff_gate[N_LAYERS][D * FFN_DIM];
+    float ff_gate_b[N_LAYERS][FFN_DIM];
+    int   ff_type[N_LAYERS];  /* 0=noop, 1=standard+square, 2=gated+sigmoid */
+} SdncWeights;
+
+/* ---- Gradients: mirror the trainable subset of SdncWeights ---- */
+typedef struct {
+    float dwq[N_LAYERS][D * D];
+    float dwk[N_LAYERS][D * D];
+    float dwv[N_LAYERS][D * D];
+    float dwo[N_LAYERS][D * D];
+    float dbq[N_LAYERS][D];
+    float dff_up[N_LAYERS][D * FFN_DIM];
+    float dff_up_b[N_LAYERS][FFN_DIM];
+    float dff_down[N_LAYERS][FFN_DIM * D];
+    float dff_down_b[N_LAYERS][D];
+    float dff_gate[N_LAYERS][D * FFN_DIM];
+    float dff_gate_b[N_LAYERS][FFN_DIM];
+} SdncGrads;
+
+/* Per-layer forward cache so the backward pass reuses exact intermediates. */
+typedef struct {
+    float x_in[N_LAYERS][D];
+    float x_post_attn[N_LAYERS][D];
+    int   attn_active;
+    float Q[D];
+    float K[256][D];
+    float Va[256][D];
+    float scores[256];
+    float hout[D];
+    int   np;
+    float ff_h[N_LAYERS][FFN_DIM];
+    float ff_gate[N_LAYERS][FFN_DIM];
+    float ff_up[N_LAYERS][FFN_DIM];
+} SdncFwdCache;
+
+/* ===================================================================== */
+
+static inline float sdnc_sigmoidf(float x) {
+    if (x > 20.0f) return 1.0f;
+    if (x < -20.0f) return 0.0f;
+    return 1.0f / (1.0f + expf(-x));
+}
+
+static inline void sdnc_matvec_t(const float* x, const float* W, float* out,
+                                 int rows, int cols) {
+    memset(out, 0, cols * sizeof(float));
+    for (int i = 0; i < rows; i++)
+        for (int j = 0; j < cols; j++)
+            out[j] += x[i] * W[i * cols + j];
+}
+
+/* Apply a single FFN layer via actual weight matrices (W @ x + b).
+ * type 0 (noop), 1 (SQUARE), 2 (gated sigmoid). Mirrors apply_ffn_layer. */
+static inline void sdnc_apply_ffn_layer(const SdncWeights* w, int L, float x[D]) {
+    float fo[D]; memset(fo, 0, sizeof(fo));
+    if (w->ff_type[L] == 1) {
+        float h[FFN_DIM];
+        sdnc_matvec_t(x, w->ff_up[L], h, D, FFN_DIM);
+        for (int i = 0; i < FFN_DIM; i++) h[i] += w->ff_up_b[L][i];
+        for (int i = 0; i < FFN_DIM; i++) h[i] *= h[i]; /* SQUARE */
+        sdnc_matvec_t(h, w->ff_down[L], fo, FFN_DIM, D);
+        for (int i = 0; i < D; i++) fo[i] += w->ff_down_b[L][i];
+    } else if (w->ff_type[L] == 2) {
+        float gate[FFN_DIM], up[FFN_DIM], h[FFN_DIM];
+        sdnc_matvec_t(x, w->ff_gate[L], gate, D, FFN_DIM);
+        for (int i = 0; i < FFN_DIM; i++) gate[i] = sdnc_sigmoidf(gate[i] + w->ff_gate_b[L][i]);
+        sdnc_matvec_t(x, w->ff_up[L], up, D, FFN_DIM);
+        for (int i = 0; i < FFN_DIM; i++) up[i] += w->ff_up_b[L][i];
+        for (int i = 0; i < FFN_DIM; i++) h[i] = gate[i] * up[i];
+        sdnc_matvec_t(h, w->ff_down[L], fo, FFN_DIM, D);
+        for (int i = 0; i < D; i++) fo[i] += w->ff_down_b[L][i];
+    }
+    for (int i = 0; i < D; i++) x[i] += fo[i];
+}
+
+/* Forward pass through layers 0..N_LAYERS-2 (layer 5 is backward-only).
+ * Mirrors forward_with_weights. */
+static inline void sdnc_forward(const SdncWeights* w,
+                                const float state[D],
+                                const float pe[][D], int np,
+                                float next[D]) {
+    float x[D]; memcpy(x, state, sizeof(float)*D);
+    for (int L = 0; L < N_LAYERS - 1; L++) {
+        float ao[D]; memset(ao, 0, sizeof(ao));
+        if (L == 0 && np > 0) {
+            float Q[D]; memset(Q, 0, sizeof(Q));
+            for (int i=0;i<D;i++) for(int j=0;j<D;j++) Q[i]+=w->wq[L][i*D+j]*x[j];
+            for (int i=0;i<D;i++) Q[i]+=w->bq[L][i];
+            float scores[256]; float mx=-1e30f;
+            float Va[256][D];
+            for (int p=0; p<np&&p<256; p++) {
+                float K[D]; memset(K,0,sizeof(K));
+                memset(Va[p],0,sizeof(Va[p]));
+                for(int i=0;i<D;i++) for(int j=0;j<D;j++) {
+                    K[i]+=w->wk[L][i*D+j]*pe[p][j];
+                    Va[p][i]+=w->wv[L][i*D+j]*pe[p][j];
+                }
+                scores[p]=(Q[0]*K[0]+Q[1]*K[1])/sqrtf((float)HD);
+                if(scores[p]>mx) mx=scores[p];
+            }
+            float sum=0;
+            for(int p=0;p<np;p++){scores[p]=expf(scores[p]-mx);sum+=scores[p];}
+            for(int p=0;p<np;p++) scores[p]/=sum;
+            float hout[D]; memset(hout,0,sizeof(hout));
+            for(int p=0;p<np;p++) for(int d=0;d<HD;d++) hout[d]+=scores[p]*Va[p][d];
+            for(int i=0;i<D;i++) for(int j=0;j<D;j++) ao[i]+=w->wo[L][i*D+j]*hout[j];
+        }
+        for(int i=0;i<D;i++) x[i]+=ao[i];
+        sdnc_apply_ffn_layer(w, L, x);
+    }
+    memcpy(next, x, sizeof(float)*D);
+}
+
+static inline void sdnc_zero_grads(SdncGrads* g) { memset(g, 0, sizeof(SdncGrads)); }
+
+/* Backprop through one matvec_t. dx may be NULL. Mirrors matvec_backward. */
+static inline void sdnc_matvec_backward(const float* x, const float* W,
+                                        const float* dout,
+                                        float* dW, float* dx, int rows, int cols) {
+    for (int i = 0; i < rows; i++) {
+        float dxi = 0.0f;
+        const float xi = x[i];
+        const float* Wi = W + (size_t)i * cols;
+        float* dWi = dW + (size_t)i * cols;
+        for (int j = 0; j < cols; j++) {
+            float dj = dout[j];
+            dWi[j] += xi * dj;
+            dxi += dj * Wi[j];
+        }
+        if (dx) dx[i] += dxi;
+    }
+}
+
+/* Re-run forward caching intermediates, then backprop. Accumulates into g and
+ * writes grad w.r.t. input state to dL_dstate (may be NULL).
+ * Mirrors backward_through_weights. */
+static inline void sdnc_backward(const SdncWeights* w,
+                                 const float state[D],
+                                 const float pe[][D], int np,
+                                 const float dL_dnext[D],
+                                 SdncGrads* g,
+                                 float dL_dstate[D],
+                                 SdncFwdCache* cache) {
+    SdncFwdCache* cp = cache;
+    memset(cp, 0, sizeof(*cp));
+    SdncFwdCache* c_ = cp;
+#define c (*c_)
+    c.np = np;
+
+    float x[D]; memcpy(x, state, sizeof(float) * D);
+    for (int L = 0; L < N_LAYERS - 1; L++) {
+        memcpy(c.x_in[L], x, sizeof(float) * D);
+        float ao[D]; memset(ao, 0, sizeof(ao));
+        if (L == 0 && np > 0) {
+            c.attn_active = 1;
+            float Q[D]; memset(Q, 0, sizeof(Q));
+            for (int i = 0; i < D; i++) for (int j = 0; j < D; j++) Q[i] += w->wq[L][i*D+j]*x[j];
+            for (int i = 0; i < D; i++) Q[i] += w->bq[L][i];
+            memcpy(c.Q, Q, sizeof(Q));
+            float scores[256]; float mx = -1e30f;
+            for (int p = 0; p < np && p < 256; p++) {
+                float K[D]; memset(K, 0, sizeof(K));
+                memset(c.Va[p], 0, sizeof(float)*D);
+                for (int i = 0; i < D; i++) for (int j = 0; j < D; j++) {
+                    K[i] += w->wk[L][i*D+j]*pe[p][j];
+                    c.Va[p][i] += w->wv[L][i*D+j]*pe[p][j];
+                }
+                memcpy(c.K[p], K, sizeof(float)*D);
+                scores[p] = (Q[0]*K[0] + Q[1]*K[1]) / sqrtf((float)HD);
+                if (scores[p] > mx) mx = scores[p];
+            }
+            float sum = 0;
+            for (int p = 0; p < np; p++) { scores[p] = expf(scores[p]-mx); sum += scores[p]; }
+            for (int p = 0; p < np; p++) scores[p] /= sum;
+            memcpy(c.scores, scores, sizeof(float)*np);
+            float hout[D]; memset(hout, 0, sizeof(hout));
+            for (int p = 0; p < np; p++) for (int d = 0; d < HD; d++) hout[d] += scores[p]*c.Va[p][d];
+            memcpy(c.hout, hout, sizeof(hout));
+            for (int i = 0; i < D; i++) for (int j = 0; j < D; j++) ao[i] += w->wo[L][i*D+j]*hout[j];
+        }
+        for (int i = 0; i < D; i++) x[i] += ao[i];
+        memcpy(c.x_post_attn[L], x, sizeof(float)*D);
+
+        if (w->ff_type[L] == 1) {
+            float h[FFN_DIM];
+            sdnc_matvec_t(x, w->ff_up[L], h, D, FFN_DIM);
+            for (int i = 0; i < FFN_DIM; i++) h[i] += w->ff_up_b[L][i];
+            memcpy(c.ff_h[L], h, sizeof(float)*FFN_DIM);
+            for (int i = 0; i < FFN_DIM; i++) h[i] *= h[i];
+            float fo[D]; sdnc_matvec_t(h, w->ff_down[L], fo, FFN_DIM, D);
+            for (int i = 0; i < D; i++) fo[i] += w->ff_down_b[L][i];
+            for (int i = 0; i < D; i++) x[i] += fo[i];
+        } else if (w->ff_type[L] == 2) {
+            float gate[FFN_DIM], up[FFN_DIM], h[FFN_DIM];
+            sdnc_matvec_t(x, w->ff_gate[L], gate, D, FFN_DIM);
+            for (int i = 0; i < FFN_DIM; i++) gate[i] = sdnc_sigmoidf(gate[i] + w->ff_gate_b[L][i]);
+            sdnc_matvec_t(x, w->ff_up[L], up, D, FFN_DIM);
+            for (int i = 0; i < FFN_DIM; i++) up[i] += w->ff_up_b[L][i];
+            for (int i = 0; i < FFN_DIM; i++) h[i] = gate[i]*up[i];
+            memcpy(c.ff_gate[L], gate, sizeof(float)*FFN_DIM);
+            memcpy(c.ff_up[L], up, sizeof(float)*FFN_DIM);
+            memcpy(c.ff_h[L], h, sizeof(float)*FFN_DIM);
+            float fo[D]; sdnc_matvec_t(h, w->ff_down[L], fo, FFN_DIM, D);
+            for (int i = 0; i < D; i++) fo[i] += w->ff_down_b[L][i];
+            for (int i = 0; i < D; i++) x[i] += fo[i];
+        }
+    }
+
+    float dx[D]; memcpy(dx, dL_dnext, sizeof(float)*D);
+    for (int L = N_LAYERS - 2; L >= 0; L--) {
+        if (w->ff_type[L] == 1) {
+            float* dfo = dx;
+            for (int i = 0; i < D; i++) g->dff_down_b[L][i] += dfo[i];
+            float dh2[FFN_DIM]; memset(dh2, 0, sizeof(dh2));
+            float h[FFN_DIM];
+            for (int i = 0; i < FFN_DIM; i++) h[i] = c.ff_h[L][i]*c.ff_h[L][i];
+            sdnc_matvec_backward(h, w->ff_down[L], dfo, g->dff_down[L], dh2, FFN_DIM, D);
+            float dh[FFN_DIM];
+            for (int i = 0; i < FFN_DIM; i++) dh[i] = dh2[i] * 2.0f * c.ff_h[L][i];
+            for (int i = 0; i < FFN_DIM; i++) g->dff_up_b[L][i] += dh[i];
+            float dxin[D]; memset(dxin, 0, sizeof(dxin));
+            sdnc_matvec_backward(c.x_post_attn[L], w->ff_up[L], dh, g->dff_up[L], dxin, D, FFN_DIM);
+            for (int i = 0; i < D; i++) dx[i] += dxin[i];
+        } else if (w->ff_type[L] == 2) {
+            float* dfo = dx;
+            for (int i = 0; i < D; i++) g->dff_down_b[L][i] += dfo[i];
+            float dh[FFN_DIM]; memset(dh, 0, sizeof(dh));
+            sdnc_matvec_backward(c.ff_h[L], w->ff_down[L], dfo, g->dff_down[L], dh, FFN_DIM, D);
+            float dgate[FFN_DIM], dup[FFN_DIM];
+            for (int i = 0; i < FFN_DIM; i++) { dgate[i] = dh[i]*c.ff_up[L][i]; dup[i] = dh[i]*c.ff_gate[L][i]; }
+            for (int i = 0; i < FFN_DIM; i++) g->dff_up_b[L][i] += dup[i];
+            float dxin[D]; memset(dxin, 0, sizeof(dxin));
+            sdnc_matvec_backward(c.x_post_attn[L], w->ff_up[L], dup, g->dff_up[L], dxin, D, FFN_DIM);
+            float dpre[FFN_DIM];
+            for (int i = 0; i < FFN_DIM; i++) { float gv = c.ff_gate[L][i]; dpre[i] = dgate[i]*gv*(1.0f-gv); }
+            for (int i = 0; i < FFN_DIM; i++) g->dff_gate_b[L][i] += dpre[i];
+            sdnc_matvec_backward(c.x_post_attn[L], w->ff_gate[L], dpre, g->dff_gate[L], dxin, D, FFN_DIM);
+            for (int i = 0; i < D; i++) dx[i] += dxin[i];
+        }
+
+        if (L == 0 && c.attn_active) {
+            float* dxpa = dx;
+            float dhout[D]; memset(dhout, 0, sizeof(dhout));
+            for (int i = 0; i < D; i++) {
+                float doi = dxpa[i];
+                for (int j = 0; j < D; j++) {
+                    g->dwo[0][i*D+j] += c.hout[j]*doi;
+                    dhout[j]        += w->wo[0][i*D+j]*doi;
+                }
+            }
+            int np_ = c.np;
+            float ds[256]; memset(ds, 0, sizeof(float)*np_);
+            for (int p = 0; p < np_; p++) {
+                float acc = 0.0f;
+                for (int d = 0; d < HD; d++) acc += dhout[d]*c.Va[p][d];
+                ds[p] = acc;
+                for (int d = 0; d < HD; d++) {
+                    float dVad = c.scores[p]*dhout[d];
+                    for (int j = 0; j < D; j++) g->dwv[0][d*D+j] += pe[p][j]*dVad;
+                }
+            }
+            float dot = 0.0f;
+            for (int p = 0; p < np_; p++) dot += c.scores[p]*ds[p];
+            float dscore[256];
+            for (int p = 0; p < np_; p++) dscore[p] = c.scores[p]*(ds[p] - dot);
+            float inv = 1.0f/sqrtf((float)HD);
+            float dQ[D]; memset(dQ, 0, sizeof(dQ));
+            for (int p = 0; p < np_; p++) {
+                float dsp = dscore[p]*inv;
+                dQ[0] += dsp*c.K[p][0];
+                dQ[1] += dsp*c.K[p][1];
+                float dK0 = dsp*c.Q[0];
+                float dK1 = dsp*c.Q[1];
+                for (int j = 0; j < D; j++) {
+                    g->dwk[0][0*D+j] += pe[p][j]*dK0;
+                    g->dwk[0][1*D+j] += pe[p][j]*dK1;
+                }
+            }
+            for (int i = 0; i < D; i++) g->dbq[0][i] += dQ[i];
+            float dxin[D]; memset(dxin, 0, sizeof(dxin));
+            for (int i = 0; i < D; i++) {
+                float dqi = dQ[i];
+                if (dqi == 0.0f) continue;
+                for (int j = 0; j < D; j++) {
+                    g->dwq[0][i*D+j] += c.x_in[0][j]*dqi;
+                    dxin[j]          += w->wq[0][i*D+j]*dqi;
+                }
+            }
+            for (int i = 0; i < D; i++) dx[i] += dxin[i];
+        }
+    }
+    if (dL_dstate) memcpy(dL_dstate, dx, sizeof(float)*D);
+#undef c
+}
+
+/* SGD step. Mirrors apply_weight_gradient_step. */
+static inline void sdnc_apply_grad_step(SdncWeights* w, const SdncGrads* g, float lr) {
+    for (int L = 0; L < N_LAYERS; L++) {
+        for (int i = 0; i < D*D; i++) {
+            w->wq[L][i] -= lr*g->dwq[L][i];
+            w->wk[L][i] -= lr*g->dwk[L][i];
+            w->wv[L][i] -= lr*g->dwv[L][i];
+            w->wo[L][i] -= lr*g->dwo[L][i];
+        }
+        for (int i = 0; i < D; i++) w->bq[L][i] -= lr*g->dbq[L][i];
+        for (int i = 0; i < D*FFN_DIM; i++) {
+            w->ff_up[L][i]   -= lr*g->dff_up[L][i];
+            w->ff_gate[L][i] -= lr*g->dff_gate[L][i];
+        }
+        for (int i = 0; i < FFN_DIM; i++) {
+            w->ff_up_b[L][i]   -= lr*g->dff_up_b[L][i];
+            w->ff_gate_b[L][i] -= lr*g->dff_gate_b[L][i];
+        }
+        for (int i = 0; i < FFN_DIM*D; i++) w->ff_down[L][i] -= lr*g->dff_down[L][i];
+        for (int i = 0; i < D; i++) w->ff_down_b[L][i] -= lr*g->dff_down_b[L][i];
+    }
+}
+
+/* Deterministic LCG (mirror si_randf) for reproducible weight init. */
+typedef struct { unsigned long state; float scale; } SdncRng;
+static inline float sdnc_randf(SdncRng* r) {
+    r->state = r->state*6364136223846793005UL + 1442695040888963407UL;
+    unsigned int v = (unsigned int)(r->state >> 33);
+    return ((float)v / (float)0x7fffffffu - 1.0f) * r->scale;
+}
+
+/* Initialise a fresh weight set exactly like self_improve_demo: small random
+ * weights with 1/sqrt(fan-in) scaling and the L0=type1(+attn), L1=type2 FFN
+ * schedule that keeps the stacked SQUARE non-linearity numerically bounded and
+ * makes the self-improvement loss strictly decrease. */
+static inline void sdnc_init_weights(SdncWeights* w) {
+    memset(w, 0, sizeof(*w));
+    SdncRng r; r.state = 0xC0FFEEUL; r.scale = 0.1f;
+    const float s_d   = 0.35f / sqrtf((float)D);
+    const float s_ffn = 0.35f / sqrtf((float)FFN_DIM);
+    const float s_qk  = 1.6f / sqrtf((float)D);
+    for (int L = 0; L < N_LAYERS; L++) {
+        r.scale = s_qk;
+        for (int i = 0; i < D*D; i++) { w->wq[L][i]=sdnc_randf(&r); w->wk[L][i]=sdnc_randf(&r); }
+        r.scale = s_d;
+        for (int i = 0; i < D*D; i++) { w->wv[L][i]=sdnc_randf(&r); w->wo[L][i]=sdnc_randf(&r); }
+        for (int i = 0; i < D*FFN_DIM; i++){ w->ff_up[L][i]=sdnc_randf(&r); w->ff_gate[L][i]=sdnc_randf(&r); }
+        r.scale = s_ffn;
+        for (int i = 0; i < FFN_DIM*D; i++) w->ff_down[L][i]=sdnc_randf(&r);
+        r.scale = 0.6f;
+        for (int i = 0; i < D; i++) w->bq[L][i]=sdnc_randf(&r);
+        r.scale = 0.02f;
+        for (int i = 0; i < FFN_DIM; i++){ w->ff_up_b[L][i]=sdnc_randf(&r); w->ff_gate_b[L][i]=sdnc_randf(&r); }
+        for (int i = 0; i < D; i++) w->ff_down_b[L][i]=sdnc_randf(&r);
+    }
+    w->ff_type[0]=1; w->ff_type[1]=2; w->ff_type[2]=0;
+    w->ff_type[3]=0; w->ff_type[4]=0; w->ff_type[5]=0;
+}
+
+#undef D
+#undef HD
+#undef N_LAYERS
+#undef FFN_DIM
+
+#endif /* ESHKOL_SDNC_CORE_H */

--- a/lib/frontend/parser.cpp
+++ b/lib/frontend/parser.cpp
@@ -1369,6 +1369,23 @@ static eshkol_op_t get_operator_type(const std::string& op) {
     if (op == "kb-assert!") return ESHKOL_KB_ASSERT_OP;
     if (op == "kb-query") return ESHKOL_KB_QUERY_OP;
     if (op == "kb-query-prefix") return ESHKOL_KB_QUERY_PREFIX_OP;
+    // Differentiable external memory (core.dnc)
+    if (op == "make-dnc-memory") return ESHKOL_DNC_MAKE_OP;
+    if (op == "dnc-content-address") return ESHKOL_DNC_CONTENT_ADDR_OP;
+    if (op == "dnc-loc-address") return ESHKOL_DNC_LOC_ADDR_OP;
+    if (op == "dnc-read") return ESHKOL_DNC_READ_OP;
+    if (op == "dnc-write!") return ESHKOL_DNC_WRITE_OP;
+    if (op == "dnc-alloc-weights") return ESHKOL_DNC_ALLOC_WEIGHTS_OP;
+    if (op == "dnc-read-grad") return ESHKOL_DNC_READ_GRAD_OP;
+    if (op == "dnc-memory?") return ESHKOL_DNC_PRED_OP;
+    // SDNC weight-program (core.sdnc)
+    if (op == "sdnc-program") return ESHKOL_SDNC_PROGRAM_OP;
+    if (op == "sdnc-run") return ESHKOL_SDNC_RUN_OP;
+    if (op == "sdnc-weight-grad") return ESHKOL_SDNC_WEIGHT_GRAD_OP;
+    if (op == "sdnc-params") return ESHKOL_SDNC_PARAMS_OP;
+    if (op == "sdnc-set-params!") return ESHKOL_SDNC_SET_PARAMS_OP;
+    if (op == "sdnc-improve!") return ESHKOL_SDNC_IMPROVE_OP;
+    if (op == "sdnc?") return ESHKOL_SDNC_PRED_OP;
     if (op == "logic-var?") return ESHKOL_LOGIC_VAR_PRED_OP;
     if (op == "substitution?") return ESHKOL_SUBSTITUTION_PRED_OP;
     if (op == "kb?") return ESHKOL_KB_PRED_OP;
@@ -9253,7 +9270,8 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
             ast.operation.call_op.variables = new eshkol_ast_t[1];
             ast.operation.call_op.variables[0] = elements[0];
         } else if ((ast.operation.op >= ESHKOL_UNIFY_OP && ast.operation.op <= ESHKOL_WORKSPACE_PRED_OP) ||
-                    ast.operation.op == ESHKOL_KB_QUERY_PREFIX_OP) {
+                    ast.operation.op == ESHKOL_KB_QUERY_PREFIX_OP ||
+                    (ast.operation.op >= ESHKOL_DNC_MAKE_OP && ast.operation.op <= ESHKOL_SDNC_PRED_OP)) {
             // Neuro-symbolic consciousness engine operations
             // All use call_op structure: func=nullptr, variables=arguments
             // kb-query-prefix sits outside the contiguous UNIFY_OP..WORKSPACE_PRED_OP

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -540,6 +540,18 @@ void ReplJITContext::initializeJIT() {
     }
     // Ensure PIC relocation model (matches stdlib.o compilation)
     jtmb->setRelocationModel(Reloc::PIC_);
+    // CRITICAL: Use the Large code model on AArch64 so JIT-linked stdlib.bc
+    // (hundreds of functions, >128 MB span once materialised) does not overflow
+    // the ±128 MB Branch26 (BL/B) PC-relative range. The AOT batch compiler
+    // already selects CodeModel::Large for AArch64 (see llvm_codegen.cpp); the
+    // JIT must match or cross-function calls into stdlib fail to materialise
+    // ("relocation target ... is out of range of Branch26PCRel fixup").
+    {
+        const llvm::Triple& jt = jtmb->getTargetTriple();
+        if (jt.isAArch64()) {
+            jtmb->setCodeModel(llvm::CodeModel::Large);
+        }
+    }
     // CRITICAL: Match the batch compiler's optimization level (CodeGenOptLevel::None = -O0).
     // JITTargetMachineBuilder::detectHost() defaults to CodeGenOptLevel::Default (-O2),
     // which causes LLVM to generate different struct argument stack layouts on ARM64.

--- a/lib/types/type_checker.cpp
+++ b/lib/types/type_checker.cpp
@@ -930,6 +930,21 @@ TypeCheckResult TypeChecker::synthesizeOperation(eshkol_ast_t* expr) {
         case ESHKOL_FG_UPDATE_CPT_OP:
         case ESHKOL_MAKE_WORKSPACE_OP:
         case ESHKOL_WS_STEP_OP:
+        case ESHKOL_DNC_MAKE_OP:
+        case ESHKOL_DNC_CONTENT_ADDR_OP:
+        case ESHKOL_DNC_LOC_ADDR_OP:
+        case ESHKOL_DNC_READ_OP:
+        case ESHKOL_DNC_WRITE_OP:
+        case ESHKOL_DNC_ALLOC_WEIGHTS_OP:
+        case ESHKOL_DNC_READ_GRAD_OP:
+        case ESHKOL_DNC_PRED_OP:
+        case ESHKOL_SDNC_PROGRAM_OP:
+        case ESHKOL_SDNC_RUN_OP:
+        case ESHKOL_SDNC_WEIGHT_GRAD_OP:
+        case ESHKOL_SDNC_PARAMS_OP:
+        case ESHKOL_SDNC_SET_PARAMS_OP:
+        case ESHKOL_SDNC_IMPROVE_OP:
+        case ESHKOL_SDNC_PRED_OP:
             return TypeCheckResult::ok(BuiltinTypes::Value);
 
         // Memory management — return Value (identity-like wrappers)

--- a/tests/dnc/dnc_test.esk
+++ b/tests/dnc/dnc_test.esk
@@ -1,0 +1,165 @@
+;;; core.dnc — differentiable external memory acceptance test.
+;;;
+;;; Mirrors the three checks in lib/backend/diff_memory_prototype.c (the C
+;;; oracle, source of truth):
+;;;   CHECK 1 — exactness at high beta: write distinct vectors to integer
+;;;             addresses then read them back; bit-exact round-trip.
+;;;   CHECK 2 — gradient check: dnc-read-grad agrees with central finite
+;;;             differences to ~1e-6 (the oracle achieves ~9.6e-9).
+;;;   CHECK 3 — learning: SGD on the key strictly decreases the loss.
+;;;
+;;; Must pass under both `eshkol-run -r FILE` (JIT) and AOT.
+
+(define pass-count 0)
+(define fail-count 0)
+
+(define (check name ok)
+  (if ok
+      (begin (set! pass-count (+ pass-count 1))
+             (display "  ok   ") (display name) (newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "  FAIL ") (display name) (newline))))
+
+;; ----- helpers (work on #(...) float vectors) -----
+(define (vsub a b)            ; a - b, length-W
+  (let* ((n (vector-length a))
+         (out (make-vector n 0.0)))
+    (let loop ((i 0))
+      (if (< i n)
+          (begin (vector-set! out i (- (vector-ref a i) (vector-ref b i)))
+                 (loop (+ i 1)))
+          out))))
+
+(define (sqnorm v)           ; 0.5 * ||v||^2
+  (let ((n (vector-length v)))
+    (let loop ((i 0) (acc 0.0))
+      (if (< i n)
+          (loop (+ i 1) (+ acc (* (vector-ref v i) (vector-ref v i))))
+          (* 0.5 acc)))))
+
+(define (loss mem key target beta)
+  (sqnorm (vsub (dnc-read mem (dnc-content-address mem key beta)) target)))
+
+(define (max-abs-diff a b)
+  (let ((n (vector-length a)))
+    (let loop ((i 0) (m 0.0))
+      (if (< i n)
+          (let ((d (abs (- (vector-ref a i) (vector-ref b i)))))
+            (loop (+ i 1) (if (> d m) d m)))
+          m))))
+
+;; ===================================================================
+;; CHECK 0 — handle + predicate sanity
+;; ===================================================================
+(define N 64)
+(define W 8)
+(define mem (make-dnc-memory N W))
+(check "make-dnc-memory returns a handle" (not (eq? mem #f)))
+(check "dnc-memory? on memory" (dnc-memory? mem))
+(check "dnc-memory? on non-memory" (not (dnc-memory? 42)))
+
+;; ===================================================================
+;; CHECK 1 — exactness at high beta (bit-identity property)
+;; Write distinct W-vectors to integer addresses 0..M-1 (M=40 > 16),
+;; full-erase so write == add, then read back by integer address.
+;; ===================================================================
+(define beta-hi 10000.0)
+(define M 40)
+(define full-erase (make-vector W 1.0))
+
+;; write loop: addr a gets vector [a*W+j ...]*0.5 - 7
+(let wloop ((a 0))
+  (if (< a M)
+      (let ((wvec (dnc-loc-address a beta-hi N))
+            (add (make-vector W 0.0)))
+        (let jl ((j 0))
+          (if (< j W)
+              (begin (vector-set! add j (- (* (+ (* a W) j) 0.5) 7.0)) (jl (+ j 1)))))
+        (dnc-write! mem wvec full-erase add)
+        (wloop (+ a 1)))))
+
+;; read back and measure max error
+(define max-err
+  (let rloop ((a 0) (m 0.0))
+    (if (< a M)
+        (let* ((wvec (dnc-loc-address a beta-hi N))
+               (rd (dnc-read mem wvec))
+               (expected (make-vector W 0.0)))
+          (let jl ((j 0))
+            (if (< j W)
+                (begin (vector-set! expected j (- (* (+ (* a W) j) 0.5) 7.0)) (jl (+ j 1)))))
+          (let ((e (max-abs-diff rd expected)))
+            (rloop (+ a 1) (if (> e m) e m))))
+        m)))
+
+(display "  CHECK 1 max round-trip error: ") (display max-err) (newline)
+(check "CHECK 1: write->read bit-exact at high beta (< 1e-5)" (< max-err 1e-5))
+
+;; ===================================================================
+;; CHECK 2 — gradient check at beta=2.0.
+;; dnc-read-grad gives (dkey . dmem); compare dkey against central FD.
+;; ===================================================================
+(define beta 2.0)
+;; A separate small memory with known nonzero content (rows already written above
+;; via loc-address are sparse; use the populated mem for a meaningful gradient).
+(define key (vector 0.3 -0.5 0.2 0.8 -0.1 0.4 -0.7 0.6))
+(define target (vector 1.0 -1.0 0.5 0.0 0.2 -0.3 0.9 -0.4))
+
+(define grad-pair (dnc-read-grad mem key target beta))
+(define dkey (car grad-pair))
+(define dmem (cdr grad-pair))
+(check "dnc-read-grad returns a pair" (pair? grad-pair))
+(check "dkey length == W" (= (vector-length dkey) W))
+(check "dmem length == N*W" (= (vector-length dmem) (* N W)))
+
+;; central finite differences on the key
+(define h 1e-4)
+(define max-rel
+  (let loop ((t 0) (m 0.0))
+    (if (< t W)
+        (let* ((saved (vector-ref key t)))
+          (vector-set! key t (+ saved h))
+          (let ((Lp (loss mem key target beta)))
+            (vector-set! key t (- saved h))
+            (let ((Lm (loss mem key target beta)))
+              (vector-set! key t saved)
+              (let* ((fd (/ (- Lp Lm) (* 2.0 h)))
+                     (an (vector-ref dkey t))
+                     (den (max 1e-8 (max (abs fd) (abs an))))
+                     (rel (/ (abs (- fd an)) den)))
+                (loop (+ t 1) (if (> rel m) rel m))))))
+        m)))
+
+(display "  CHECK 2 max rel grad error (dkey vs central FD): ") (display max-rel) (newline)
+(check "CHECK 2: dnc-read-grad agrees with central FD (< 1e-3)" (< max-rel 1e-3))
+
+;; ===================================================================
+;; CHECK 3 — learning: SGD on the key strictly decreases the loss.
+;; ===================================================================
+(define lkey (vector 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1))
+(define first-loss (loss mem lkey target beta))
+(define lr 0.5)
+(let sgd ((step 0))
+  (if (< step 100)
+      (let* ((gp (dnc-read-grad mem lkey target beta))
+             (gk (car gp)))
+        (let jl ((j 0))
+          (if (< j W)
+              (begin (vector-set! lkey j (- (vector-ref lkey j) (* lr (vector-ref gk j))))
+                     (jl (+ j 1)))))
+        (sgd (+ step 1)))))
+(define last-loss (loss mem lkey target beta))
+(display "  CHECK 3 loss: ") (display first-loss) (display " -> ") (display last-loss) (newline)
+(check "CHECK 3: SGD on key decreases loss" (< last-loss first-loss))
+
+;; ===================================================================
+;; Error handling: length mismatch must raise, predicate stays sound.
+;; (We do not catch here — just confirm well-formed calls succeed; the
+;; mismatch path is validated separately to avoid aborting the suite.)
+;; ===================================================================
+(check "content-address length-N output" (= (vector-length (dnc-content-address mem key beta)) N))
+(check "alloc-weights length-N output"   (= (vector-length (dnc-alloc-weights mem beta)) N))
+
+(newline)
+(display "Passed: ") (display pass-count)
+(display " / Failed: ") (display fail-count) (newline)

--- a/tests/sdnc/sdnc_api_test.esk
+++ b/tests/sdnc/sdnc_api_test.esk
@@ -1,0 +1,95 @@
+;;; core.sdnc — SDNC weight-program builtins acceptance test.
+;;;
+;;; Exercises the pure-Eshkol SDNC API that exposes the bytecode-VM-as-
+;;; transformer weight-program θ (kernels mirror lib/backend/weight_matrices.c
+;;; in lib/core/sdnc_core.h):
+;;;
+;;;   (sdnc-program name)               -> θ opaque handle
+;;;   (sdnc-run θ input)                -> #(...) D-dim forward output
+;;;   (sdnc-weight-grad θ input target) -> #(...) flat dL/dWEIGHTS
+;;;   (sdnc-params θ) / (sdnc-set-params! θ vec)
+;;;   (sdnc-improve! θ data steps lr)   -> θ
+;;;
+;;; Spec must-haves: sdnc-weight-grad length == sdnc-params length;
+;;; sdnc-run deterministic; one sdnc-improve! run shows loss decrease.
+;;; Must pass under both `eshkol-run -r FILE` (JIT) and AOT.
+
+(define pass-count 0)
+(define fail-count 0)
+(define (check name ok)
+  (if ok
+      (begin (set! pass-count (+ pass-count 1))
+             (display "  ok   ") (display name) (newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "  FAIL ") (display name) (newline))))
+
+(define (sqnorm v)
+  (let ((n (vector-length v)))
+    (let loop ((i 0) (acc 0.0))
+      (if (< i n)
+          (loop (+ i 1) (+ acc (* (vector-ref v i) (vector-ref v i))))
+          (* 0.5 acc)))))
+
+(define (vsub a b)
+  (let* ((n (vector-length a)) (out (make-vector n 0.0)))
+    (let loop ((i 0))
+      (if (< i n)
+          (begin (vector-set! out i (- (vector-ref a i) (vector-ref b i))) (loop (+ i 1)))
+          out))))
+
+;; 1. sdnc-program returns a handle
+(define t (sdnc-program "fib"))
+(check "sdnc-program returns a handle" (not (eq? t #f)))
+(check "sdnc? on program" (sdnc? t))
+(check "sdnc? on non-program" (not (sdnc? 42)))
+
+;; 2. sdnc-params is a long vector
+(define p0 (sdnc-params t))
+(check "sdnc-params is a vector" (vector? p0))
+(check "sdnc-params length > 1000" (> (vector-length p0) 1000))
+
+;; 3. roundtrip set-params! / params
+(sdnc-set-params! t p0)
+(define p1 (sdnc-params t))
+(check "roundtrip length matches" (= (vector-length p0) (vector-length p1)))
+(check "roundtrip entry 0"   (= (vector-ref p0 0) (vector-ref p1 0)))
+(check "roundtrip entry 100" (= (vector-ref p0 100) (vector-ref p1 100)))
+
+;; 4. sdnc-run is deterministic and D-dim
+(define input (make-vector 256 0.0))
+(vector-set! input 0 1.0)
+(vector-set! input 1 0.5)
+(define out-a (sdnc-run t input))
+(define out-b (sdnc-run t input))
+(check "sdnc-run output length == 256" (= (vector-length out-a) 256))
+(check "sdnc-run deterministic (run twice equal)"
+       (= (sqnorm (vsub out-a out-b)) 0.0))
+
+;; copy a (possibly tensor) vector into a fresh mutable make-vector buffer
+(define (vcopy src)
+  (let* ((n (vector-length src)) (out (make-vector n 0.0)))
+    (let loop ((i 0))
+      (if (< i n)
+          (begin (vector-set! out i (vector-ref src i)) (loop (+ i 1)))
+          out))))
+
+;; 5. sdnc-weight-grad length == sdnc-params length (the key invariant)
+(define target (vcopy (sdnc-run t input)))   ; reachable target = forward(input)
+(vector-set! target 0 (+ (vector-ref target 0) 0.5))  ; nudge so loss > 0
+(vector-set! target 5 (+ (vector-ref target 5) 0.5))
+(define g (sdnc-weight-grad t input target))
+(check "sdnc-weight-grad is a vector" (vector? g))
+(check "sdnc-weight-grad length == sdnc-params length"
+       (= (vector-length g) (vector-length p0)))
+
+;; 6. one sdnc-improve! run shows loss decrease.
+(define (loss-now) (sqnorm (vsub (sdnc-run t input) target)))
+(define loss-before (loss-now))
+(sdnc-improve! t (cons input target) 30 0.01)
+(define loss-after (loss-now))
+(display "  loss: ") (display loss-before) (display " -> ") (display loss-after) (newline)
+(check "sdnc-improve! decreases loss" (< loss-after loss-before))
+
+(newline)
+(display "Passed: ") (display pass-count)
+(display " / Failed: ") (display fail-count) (newline)


### PR DESCRIPTION
Implements Noesis's `NOESIS_TO_ESHKOL_sdnc_esk_api_spec` — the two builtin families, registered the way `core.manifold` dispatches, with pure-Scheme `.esk` wrappers.

## Family A — `core.dnc` (differentiable external memory; wraps `diff_memory_prototype.c` #53)
`make-dnc-memory`, `dnc-content-address`, `dnc-loc-address`, `dnc-read`, `dnc-write!`, `dnc-alloc-weights`, `dnc-read-grad`, `dnc-memory?`

## Family B — `core.sdnc` (weight-program self-improvement; wraps `weight_matrices.c` #51)
`sdnc-program`, `sdnc-run`, `sdnc-weight-grad`, `sdnc-params`, `sdnc-set-params!`, `sdnc-improve!`, `sdnc?`

## Verification (both `-r` and AOT, `ESHKOL_JIT_CACHE=0`)
- `tests/dnc/dnc_test.esk`: **11/11** -r + AOT (identical numbers)
- `tests/sdnc/sdnc_api_test.esk`: **13/13** -r + AOT
- DNC write→read **bit-exact at high β (round-trip = 0.0)**; `dnc-read-grad` vs central finite-diff **max rel err 2.77e-9** (matches the C oracle's own 9.6e-9)
- DNC learning loss 20068.5 → 5709.45 (decreases)
- SDNC `(vector-length (sdnc-params θ))` == `(vector-length (sdnc-weight-grad …))` = 12,220,416; `sdnc-improve!` loss 0.25 → 0.062
- `diff_memory_prototype` oracle still `OVERALL: ALL PASS`; standalone executables + their suites build unchanged
- length-mismatch raises a clean Eshkol RANGE_ERROR (not a crash)

## Notes for review
- Includes a `callArenaTaggedFunc` root-fix: it now `ensureTagged()`s each arg before storing into a tagged-value slot — literal int/double args previously scribbled the low byte into the tagged_value `type` field (affected every CE_*_ARG builtin incl. DNC/SDNC/AD tape). Stateful-tape suite still 22/0 after.
- Also carries the AArch64 large-code-model JIT change (overlaps #57 — reconcile at merge).
- Known orthogonal pre-existing bug: `vector-set!` on a tensor returned by a builtin segfaults (tensor-mutation codegen); tests copy into a `make-vector` buffer first.