### PR TITLE
feat(core.memory): v0 append-only content-addressed CRDT event-log faculty (+ transitive agent-FFI AOT fix)

### DIFF
--- a/exe/eshkol-run.cpp
+++ b/exe/eshkol-run.cpp
@@ -2079,20 +2079,10 @@ static bool requires_stdlib(const std::vector<eshkol_ast_t>& asts)
 // link command so symbols like qllm_http_get / eshkol_sqlite_* /
 // qllm_process_* resolve in the produced binary. Programs that don't
 // touch agent.* don't pay the libcurl/sqlite/pcre2 link cost.
-static bool requires_agent_ffi(const std::vector<eshkol_ast_t>& asts)
-{
-    for (const auto& ast : asts) {
-        if (ast.type == ESHKOL_OP && ast.operation.op == ESHKOL_REQUIRE_OP) {
-            for (uint64_t i = 0; i < ast.operation.require_op.num_modules; i++) {
-                std::string module_name = ast.operation.require_op.module_names[i];
-                if (module_name.find("agent.") == 0) {
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
-}
+// Defined after resolve_module_path / g_lib_dir (it now follows transitive
+// requires through resolved module files, so it needs both).
+static bool requires_agent_ffi(const std::vector<eshkol_ast_t>& asts,
+                               const std::string& base_dir);
 
 // Find the library base directory (lib/)
 static std::string find_lib_dir()
@@ -2224,6 +2214,68 @@ static std::string resolve_module_path(const std::string& module_name, const std
 
 // Global library directory (cached)
 static std::string g_lib_dir;
+
+// Does a module source file (or anything it transitively `require`s) pull in an
+// agent.* module? Text-scans `(require …)` clauses and recurses into resolved
+// module files. This is how a faculty like core.memory — which uses sha256 via
+// (require agent.crypto) INTERNALLY — gets the agent-FFI link args spliced into
+// an AOT build of a program that only requires core.memory (not agent.* directly).
+// A false positive merely links a few extra libs; correctness is preserved.
+static bool file_requires_agent_ffi(const std::string& path,
+                                    std::set<std::string>& visited)
+{
+    std::error_code ec;
+    std::string canon = std::filesystem::weakly_canonical(path, ec).string();
+    if (canon.empty()) canon = path;
+    if (!visited.insert(canon).second) return false;
+
+    std::string text = readFileBytes(std::filesystem::path(path));
+    if (text.empty()) return false;
+    std::string base_dir = std::filesystem::path(path).parent_path().string();
+    if (base_dir.empty()) base_dir = ".";
+
+    size_t pos = 0;
+    while ((pos = text.find("(require", pos)) != std::string::npos) {
+        pos += 8;  // past "(require"
+        size_t close = text.find(')', pos);
+        if (close == std::string::npos) break;
+        std::string clause = text.substr(pos, close - pos);
+        pos = close;
+        // Tokenise the require clause on whitespace; strip stray quote/paren chars.
+        std::stringstream ts(clause);
+        std::string tok;
+        while (ts >> tok) {
+            while (!tok.empty() && (tok.front() == '(' || tok.front() == '\'' ||
+                                    tok.front() == '"'))
+                tok.erase(tok.begin());
+            while (!tok.empty() && (tok.back() == ')' || tok.back() == '"'))
+                tok.pop_back();
+            if (tok.empty()) continue;
+            if (tok.rfind("agent.", 0) == 0) return true;
+            std::string mp = resolve_module_path(tok, base_dir, g_lib_dir);
+            if (!mp.empty() && file_requires_agent_ffi(mp, visited)) return true;
+        }
+    }
+    return false;
+}
+
+static bool requires_agent_ffi(const std::vector<eshkol_ast_t>& asts,
+                               const std::string& base_dir)
+{
+    if (g_lib_dir.empty()) g_lib_dir = find_lib_dir();
+    std::set<std::string> visited;
+    for (const auto& ast : asts) {
+        if (ast.type == ESHKOL_OP && ast.operation.op == ESHKOL_REQUIRE_OP) {
+            for (uint64_t i = 0; i < ast.operation.require_op.num_modules; i++) {
+                std::string module_name = ast.operation.require_op.module_names[i];
+                if (module_name.rfind("agent.", 0) == 0) return true;
+                std::string mp = resolve_module_path(module_name, base_dir, g_lib_dir);
+                if (!mp.empty() && file_requires_agent_ffi(mp, visited)) return true;
+            }
+        }
+    }
+    return false;
+}
 
 // Recursively discover all modules that a library requires.
 // Used to mark all sub-modules of a pre-compiled library as pre-compiled.
@@ -3773,7 +3825,12 @@ int main(int argc, char **argv)
     // (require agent.…) into the inlined module ASTs, after which the
     // top-level require op is gone and the AST scanner can no longer
     // tell agent-using programs from plain ones.
-    bool needs_agent_ffi = requires_agent_ffi(asts);
+    std::string agent_scan_base_dir = ".";
+    if (!source_files.empty()) {
+        std::string p = std::filesystem::path(source_files[0]).parent_path().string();
+        if (!p.empty()) agent_scan_base_dir = p;
+    }
+    bool needs_agent_ffi = requires_agent_ffi(asts, agent_scan_base_dir);
 
     for (const auto &source_file : source_files) {
         std::filesystem::path source_path(source_file);

--- a/lib/core/memory.esk
+++ b/lib/core/memory.esk
@@ -1,0 +1,125 @@
+;;; lib/core/memory.esk — append-only, content-addressed, CRDT-merged event log
+;;;
+;;; core.memory v0: an in-memory event-log faculty for a distributed intelligence,
+;;; composed entirely from existing, verified core primitives:
+;;;   - sha256                  (agent.crypto)      — content-addressing
+;;;   - sexp->canonical-string  (core.sexp/stdlib)  — stable canonical rendering
+;;;   - RGA / LWW / vector-clock (core.distributed) — the CRDT layer
+;;;
+;;; An event is immutable and content-addressed: its id is the sha256 of the
+;;; canonical rendering of its body (everything except the id). The body embeds
+;;; the prev-hash, so the log is also a hash chain — tampering any field breaks
+;;; the id. The log itself is an RGA (a convergent, append-only ordered-sequence
+;;; CRDT), so two nodes can append independently and `memory-merge` is
+;;; conflict-free (commutative, idempotent, associative) with dedup-by-id inherent
+;;; to the RGA.
+;;;
+;;; Identity (soul) and episodic (anamnesis) memory become event *types* in one
+;;; log. Durable content-addressed storage (core.merkle CAS), fsync, and network
+;;; fan-out (git/Syncthing) are step 2; this v0 is pure in-memory and works under
+;;; both `eshkol-run -r` (JIT) and AOT.
+
+(require stdlib)
+(require agent.crypto)        ; sha256
+(require core.distributed)    ; make-rga rga-append rga-values rga-merge,
+                              ; make-lww-register lww-register-set/-value,
+                              ; vector-clock-empty/-tick/-merge/-compare
+(require core.merkle)         ; make-cas-with-hash — durable CAS, wired in step 2
+
+(provide
+  make-memory-log
+  memory-append!
+  memory-events
+  memory-merge
+  memory-verify-chain
+  memory-verify-events
+  memory-fold-lww
+  memory-event?
+  memory-event-id memory-event-prev memory-event-vclock
+  memory-event-node memory-event-type memory-event-payload)
+
+;; ===== Event: (mem-ev-v1 id prev-hash vclock node type payload) =====
+(define (memory-event? ev)
+  (and (pair? ev) (eq? (car ev) (quote mem-ev-v1))))
+(define (memory-event-id ev)      (list-ref ev 1))
+(define (memory-event-prev ev)    (list-ref ev 2))
+(define (memory-event-vclock ev)  (list-ref ev 3))
+(define (memory-event-node ev)    (list-ref ev 4))
+(define (memory-event-type ev)    (list-ref ev 5))
+(define (memory-event-payload ev) (list-ref ev 6))
+
+;; Content hash = sha256 of the canonical rendering of the body sans id.
+;; (Same pattern as hiereia/soul.esk's hash-chain; the canonicalizer is the one
+;; shared core.sexp implementation, so soul and memory can never drift.)
+(define (event-content-hash node prev vclock type payload)
+  (sha256 (sexp->canonical-string (list node prev vclock type payload))))
+
+;; ===== Log: #(mem-log node-id rga vclock prev-hash) [mutable] =====
+(define (make-memory-log node-id)
+  (vector (quote mem-log) node-id (make-rga) (vector-clock-empty) #f))
+(define (ml-node l)   (vector-ref l 1))
+(define (ml-rga l)    (vector-ref l 2))
+(define (ml-vclock l) (vector-ref l 3))
+(define (ml-prev l)   (vector-ref l 4))
+
+;; Append an experience-event: tick the vclock, hash+chain, RGA-append.
+(define (memory-append! log type payload)
+  (let* ((node (ml-node log))
+         (vc   (vector-clock-tick (ml-vclock log) node))
+         (prev (ml-prev log))
+         (id   (event-content-hash node prev vc type payload))
+         (ev   (list (quote mem-ev-v1) id prev vc node type payload)))
+    (vector-set! log 2 (rga-append (ml-rga log) node ev))
+    (vector-set! log 3 vc)
+    (vector-set! log 4 id)
+    ev))
+
+;; Ordered list of events (RGA convergent order).
+(define (memory-events log) (rga-values (ml-rga log)))
+
+;; Conflict-free merge: RGA union (dedup-by-id inherent) + vclock merge.
+;; Commutative, idempotent, associative; loses no event.
+(define (memory-merge a b)
+  (let ((m (make-memory-log (ml-node a))))
+    (vector-set! m 2 (rga-merge (ml-rga a) (ml-rga b)))
+    (vector-set! m 3 (vector-clock-merge (ml-vclock a) (ml-vclock b)))
+    m))
+
+;; Integrity: recompute every event's id from its body; tampering any field
+;; (incl. prev-hash) changes the recompute and is caught. Works on single-node
+;; AND merged logs (content-integrity is independent of interleave order).
+;; Returns #t, or (offending-event . reason).
+(define (memory-verify-events events)
+  (if (null? events)
+      #t
+      (let* ((ev (car events))
+             (recomputed (event-content-hash (memory-event-node ev)
+                                             (memory-event-prev ev)
+                                             (memory-event-vclock ev)
+                                             (memory-event-type ev)
+                                             (memory-event-payload ev))))
+        (cond
+          ((not (memory-event? ev))                          (cons ev (quote not-an-event)))
+          ((not (string? (memory-event-id ev)))              (cons ev (quote no-id)))
+          ((not (string=? recomputed (memory-event-id ev)))  (cons ev (quote hash-mismatch)))
+          (else (memory-verify-events (cdr events)))))))
+
+(define (memory-verify-chain log)
+  (memory-verify-events (memory-events log)))
+
+;; Fold 'value-type events for `key` into an LWW register; payload = (key . value).
+;; Append order is the LWW timestamp (events are totally ordered, incl. post-merge).
+(define (memory-fold-lww log key)
+  (let loop ((evs (memory-events log)) (ts 0) (reg #f))
+    (if (null? evs)
+        (if reg (lww-register-value reg) #f)
+        (let ((ev (car evs)))
+          (if (and (eq? (memory-event-type ev) (quote value))
+                   (pair? (memory-event-payload ev))
+                   (equal? (car (memory-event-payload ev)) key))
+              (let ((v (cdr (memory-event-payload ev))))
+                (loop (cdr evs) (+ ts 1)
+                      (if reg
+                          (lww-register-set reg v ts (memory-event-node ev))
+                          (make-lww-register v ts (memory-event-node ev)))))
+              (loop (cdr evs) (+ ts 1) reg))))))

--- a/tests/memory/memory_test.esk
+++ b/tests/memory/memory_test.esk
@@ -1,0 +1,80 @@
+;;; tests/memory/memory_test.esk — core.memory v0 (event-log faculty)
+;;; Verifies: hash-chain integrity + tamper detection, CRDT merge laws
+;;; (commutative / idempotent / associative / lossless), causal vs concurrent
+;;; clocks, and LWW value folding. Must pass identically under -r and AOT.
+(require stdlib)
+(require core.distributed)   ; vector-clock-before? for the clock assertions
+(require core.memory)
+
+(define pc (vector 0 0))     ; (passed failed) — vector counter (set!-free at top level)
+(define (chk label v)
+  (display "  [") (display (if v "PASS" "FAIL")) (display "] ") (display label) (newline)
+  (if v (vector-set! pc 0 (+ 1 (vector-ref pc 0)))
+        (vector-set! pc 1 (+ 1 (vector-ref pc 1)))))
+
+;; set equality over event-id lists (avoids depending on a sort)
+(define (subset? xs ys) (or (null? xs) (and (member (car xs) ys) (subset? (cdr xs) ys))))
+(define (set-equal? xs ys) (and (= (length xs) (length ys)) (subset? xs ys) (subset? ys xs)))
+(define (event-ids log) (map memory-event-id (memory-events log)))
+
+(define (run)
+  (display "=== CORE.MEMORY v0 GATE ===") (newline)
+
+  ;; --- 1. append + integrity ---
+  (define la (make-memory-log (quote node-A)))
+  (memory-append! la (quote episodic) (quote (saw cat)))
+  (memory-append! la (quote fact)     (quote (cat is-a animal)))
+  (memory-append! la (quote value)    (cons (quote mood) 0.7))
+  (chk "append 3 events" (= (length (memory-events la)) 3))
+  (chk "verify-chain on clean log = #t" (eq? (memory-verify-chain la) #t))
+
+  ;; --- 2. tamper detection (same id, mutated payload) ---
+  (let* ((good (car (memory-events la)))
+         (tampered (list (quote mem-ev-v1)
+                         (memory-event-id good) (memory-event-prev good)
+                         (memory-event-vclock good) (memory-event-node good)
+                         (memory-event-type good) (quote TAMPERED)))
+         (vr (memory-verify-events (list tampered))))
+    (chk "tamper detected -> (offending . hash-mismatch)"
+         (and (pair? vr) (eq? (cdr vr) (quote hash-mismatch)))))
+
+  ;; --- 3. CRDT merge laws ---
+  ;; NB: merges are computed INLINE inside each (chk ...), not bound with an
+  ;; internal (define m (memory-merge ...)), because an internal define's
+  ;; initializer is evaluated before the later (memory-append!) statements run —
+  ;; which would merge still-empty logs. Inline keeps them at check-time.
+  (define lb (make-memory-log (quote node-B)))
+  (memory-append! lb (quote episodic) (quote (heard dog)))
+  (memory-append! lb (quote fact)     (quote (dog is-a animal)))
+  (define lc (make-memory-log (quote node-C)))
+  (memory-append! lc (quote observation) (quote (weather sunny)))
+  (chk "merge commutative (same id set)"
+       (set-equal? (event-ids (memory-merge la lb)) (event-ids (memory-merge lb la))))
+  (chk "merge lossless (|a|+|b| events)"
+       (= (length (memory-events (memory-merge la lb)))
+          (+ (length (memory-events la)) (length (memory-events lb)))))
+  (chk "merge idempotent (merge(a,a) == a)"
+       (set-equal? (event-ids (memory-merge la la)) (event-ids la)))
+  (chk "merge associative"
+       (set-equal? (event-ids (memory-merge (memory-merge la lb) lc))
+                   (event-ids (memory-merge la (memory-merge lb lc)))))
+  (chk "merged log still verifies (content-integrity survives interleave)"
+       (eq? (memory-verify-chain (memory-merge la lb)) #t))
+
+  ;; --- 4. causal vs concurrent clocks ---
+  (let ((a1 (memory-event-vclock (car (memory-events la))))
+        (a2 (memory-event-vclock (cadr (memory-events la))))
+        (b1 (memory-event-vclock (car (memory-events lb)))))
+    (chk "causal: a1 before a2" (vector-clock-before? a1 a2))
+    (chk "concurrent: A-event and B-event unordered"
+         (and (not (vector-clock-before? a1 b1)) (not (vector-clock-before? b1 a1)))))
+
+  ;; --- 5. LWW value fold (last write wins) ---
+  (memory-append! la (quote value) (cons (quote mood) 0.9))
+  (chk "fold-lww picks last value (0.9)" (= (memory-fold-lww la (quote mood)) 0.9))
+  (chk "fold-lww missing key = #f" (eq? (memory-fold-lww la (quote nonexistent)) #f))
+
+  (display "Passed: ") (display (vector-ref pc 0)) (newline)
+  (display "Failed: ") (display (vector-ref pc 1)) (newline))
+
+(run)


### PR DESCRIPTION
**core.memory v0** — the permanent, distributed-memory faculty (per Selene's memory-substrate decision): an append-only, content-addressed, Merkle-CRDT event log. ~80% composition of existing verified primitives, not greenfield.

## Composed from
- `sha256` (agent.crypto) — content-addressing
- `sexp->canonical-string` (core.sexp) — stable canonical rendering (already shared, so soul.esk + core.memory can't drift)
- RGA / LWW-register / vector-clock (core.distributed) — the CRDT layer

## Model
Each event is immutable + content-addressed: `id = sha256(canonical(body sans id))`, and the body embeds `prev-hash` → the log is also a hash chain (tampering any field breaks the id). The log is an RGA (convergent append-only sequence CRDT) → two nodes append independently and `memory-merge` is conflict-free. Identity (soul) and episodic (anamnesis) memory become event *types* in one log. v0 is in-memory; durable CAS (core.merkle) + fsync + git/Syncthing fan-out are step 2.

## Surface
`make-memory-log`, `memory-append!`, `memory-events`, `memory-merge`, `memory-verify-chain`/`-events`, `memory-fold-lww`, + event accessors.

## Tests — `tests/memory/memory_test.esk`: **12/12 under both `-r` and AOT**
hash-chain integrity + tamper detection; CRDT merge laws (commutative / idempotent / associative / lossless); causal-vs-concurrent vector clocks; LWW value fold.

## Also: transitive agent-FFI AOT fix
`requires_agent_ffi` now follows requires through resolved module files, so a program that only `(require core.memory)` — which uses `agent.crypto` (sha256) **internally** — gets the agent-FFI link args spliced into its AOT build *and* the `-r` run-cache build. Previously only the main file's direct `(require agent.*)` was detected, so core.memory failed to link `_eshkol_sha256` under AOT.

## Resolved spec open-questions
1. CAS surface = `make-cas-with-hash` + `cas-put!`/`cas-get`/`cas-has?` (no `cas-root`).
2. `sexp->canonical-string` already lives in `core.sexp` — no promotion needed (soul + memory share it).
3. RGA merge is lossless + convergent; dedup-by entry-id `(node,counter)` is inherent — no extra guard.
4. Vector-clocks suffice for v0 (HLC only if wall-clock ordering is later needed).

Step 2 (durable CAS + fan-out + SQL/vector projections) follows once v0 is green.