### PR TITLE
fix(codegen): detect WebAssembly target at runtime, not by build flavor

### DIFF
--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -36095,34 +36095,35 @@ extern "C" {
 // WebAssembly target initialization flag
 static bool g_wasm_target_initialized = false;
 
-// Check if WebAssembly target is available at compile time by checking Targets.def
-// When building with StableHLO's LLVM (ESHKOL_XLA_FULL_MLIR), we need to check
-// what targets were configured. The lite build uses system LLVM17 which includes all targets.
-#ifdef ESHKOL_XLA_FULL_MLIR
-// StableHLO/MLIR LLVM build - WebAssembly target only available if CI is configured with it
-#define ESHKOL_HAS_WASM_TARGET 0
-#else
-// System LLVM17 includes all standard targets including WebAssembly
-#define ESHKOL_HAS_WASM_TARGET 1
-#endif
-
 static bool initialize_wasm_target() {
     if (g_wasm_target_initialized) return true;
 
-#if ESHKOL_HAS_WASM_TARGET
-    // Initialize WebAssembly target
-    LLVMInitializeWebAssemblyTargetInfo();
-    LLVMInitializeWebAssemblyTarget();
-    LLVMInitializeWebAssemblyTargetMC();
-    LLVMInitializeWebAssemblyAsmPrinter();
+    // Initialize every target this LLVM was actually built with, using the
+    // always-declared C++ TargetSelect API. We deliberately do NOT call the
+    // per-target C symbols (LLVMInitializeWebAssembly*) here: those are only
+    // declared when the WebAssembly target was compiled into LLVM, so calling
+    // them unconditionally fails to build against a reduced-target LLVM (some
+    // distro/MSYS2 packages configure only e.g. AArch64;ARM;RISCV;X86, and
+    // StableHLO/XLA LLVM builds may omit WebAssembly too). InitializeAll* is a
+    // no-op for targets not present and idempotent if already called elsewhere.
+    InitializeAllTargetInfos();
+    InitializeAllTargets();
+    InitializeAllTargetMCs();
+    InitializeAllAsmParsers();
+    InitializeAllAsmPrinters();
+
+    // Confirm WebAssembly is genuinely available in this build rather than
+    // assuming it from the build flavor. The downstream wasm emit path also
+    // looks the target up, but checking here gives a precise error early.
+    std::string lookup_error;
+    if (!TargetRegistry::lookupTarget("wasm32-unknown-unknown", lookup_error)) {
+        eshkol_error("WebAssembly target not available in this LLVM build "
+                     "(configured targets do not include WebAssembly): %s",
+                     lookup_error.c_str());
+        return false;
+    }
     g_wasm_target_initialized = true;
     return true;
-#else
-    // WebAssembly target not available in this LLVM build
-    // XLA builds using StableHLO LLVM need CI to enable WebAssembly target
-    eshkol_error("WebAssembly target not available. XLA build needs LLVM with WebAssembly enabled.");
-    return false;
-#endif
 }
 
 int eshkol_compile_llvm_ir_to_wasm(LLVMModuleRef module_ref, uint8_t** output_buffer, size_t* output_size) {


### PR DESCRIPTION
## Problem
`initialize_wasm_target()` hardcoded `ESHKOL_HAS_WASM_TARGET=1` for every non-XLA ("lite") build and unconditionally called the per-target C symbols `LLVMInitializeWebAssembly{TargetInfo,Target,TargetMC,AsmPrinter}`. Those symbols are only **declared** when the WebAssembly target was compiled into LLVM.

A reduced-target LLVM build omits them, so eshkol **fails to compile** against it. Observed concretely on the **MSYS2 ucrt64 `llvm-21` package**, which is configured with only `AArch64;ARM;RISCV;X86`:

```
error: use of undeclared identifier 'LLVMInitializeWebAssemblyTargetInfo'
```

The assumption baked into the comment — *"system LLVM includes all standard targets including WebAssembly"* — is false for such distributions.

## Fix
Replace the compile-time assumption with:
- the always-declared C++ `TargetSelect` API (`InitializeAllTargetInfos/Targets/TargetMCs/AsmParsers/AsmPrinters`) — the same pattern already used elsewhere in this file (≈L1215) and in the JIT/AOT path; and
- a runtime `TargetRegistry::lookupTarget("wasm32-unknown-unknown", …)` check.

This builds against **any** LLVM regardless of its configured target set, initializes whatever targets are present (idempotent), and errors gracefully only if wasm emission is actually requested on a build lacking the target. The downstream `eshkol_compile_llvm_ir_to_wasm` already looked the target up the same way, so initialization is now consistent with use.

The `ESHKOL_HAS_WASM_TARGET` macro and the four per-target C calls are removed.

## Verification
Full-target LLVM 21 (macOS arm64), unchanged behavior:
- `-r` smoke → `3`
- AOT smoke → `3`
- `--wasm` emit → valid `\0asm` module (magic `0061 736d`, 33 KB)

Found by the cross-platform `-r` validation campaign on a Windows-x64/MSYS2 host.