### PR TITLE
fix(jit): AArch64 Branch26 range-extension for the in-process JITLink JIT

### DIFF
--- a/lib/repl/jitlink_branch26_range_extension.h
+++ b/lib/repl/jitlink_branch26_range_extension.h
@@ -45,9 +45,12 @@
 // therefore always within +/-128 MB of every call site in that section. (If a
 // single section ever exceeded 128 MB the stub could itself fall out of range,
 // but no individual Eshkol function approaches that; the pathology is the
-// aggregate .text size, which per-section placement defuses.) This is
-// format-agnostic: it works for ELF, COFF and Mach-O alike, and depends only on
-// the AArch64 JITLink edge kinds, not on any object-format specifics.
+// aggregate .text size, which per-section placement defuses.) The technique
+// depends only on the AArch64 JITLink edge kinds, but is applied ONLY on the
+// object formats where the large code model is incomplete -- ELF and COFF.
+// Mach-O (Apple arm64) is excluded: there CodeModel::Large already emits
+// correct far calls, and the Mach-O arm64 link pipeline's own stub/GOT builders
+// make an extra veneer pass redundant (and observably deadlock-prone).
 //
 // The pass runs in PostPrunePasses (before memory allocation), which is the only
 // phase where new stub blocks can still be given memory by the allocator -- the
@@ -85,10 +88,25 @@ public:
   void modifyPassConfig(llvm::orc::MaterializationResponsibility &,
                         llvm::jitlink::LinkGraph &G,
                         llvm::jitlink::PassConfiguration &Config) override {
-    // Only aarch64 needs this -- other targets either have working far-call
-    // code models or JITLink range extension.
-    if (G.getTargetTriple().getArch() != llvm::Triple::aarch64 &&
-        G.getTargetTriple().getArch() != llvm::Triple::aarch64_be)
+    const llvm::Triple &TT = G.getTargetTriple();
+
+    // Only aarch64 needs branch range extension at all -- other targets either
+    // have working far-call code models or native JITLink range extension.
+    if (TT.getArch() != llvm::Triple::aarch64 &&
+        TT.getArch() != llvm::Triple::aarch64_be)
+      return;
+
+    // Restrict to object formats where the AArch64 large code model is
+    // INCOMPLETE: ELF and COFF. On Mach-O (Apple arm64) `CodeModel::Large`
+    // already emits far calls correctly (movz/movk + blr, no Branch26), so the
+    // veneer is unnecessary there -- and worse, the Mach-O arm64 JITLink link
+    // pipeline runs its own PostPrune stub/GOT builders whose materialization
+    // our extra pass perturbs, wedging in-process JIT materialization
+    // (lookupLinkerMangled -> pthread_cond_wait). ELF/COFF are the real,
+    // tested problem scope (xavier = arm64-Linux/ELF). Gate on object format,
+    // not just arch.
+    if (TT.getObjectFormat() != llvm::Triple::ELF &&
+        TT.getObjectFormat() != llvm::Triple::COFF)
       return;
 
     // Escape hatch for debugging / measuring.

--- a/lib/repl/jitlink_branch26_range_extension.h
+++ b/lib/repl/jitlink_branch26_range_extension.h
@@ -1,0 +1,209 @@
+//
+// Copyright (C) tsotchke
+//
+// SPDX-License-Identifier: MIT
+//
+// AArch64 Branch26 range-extension plugin for the in-process ORC/JITLink JIT.
+//
+// Why this exists
+// ---------------
+// Eshkol's `eval`/`compile` route through the in-process JIT (LLJIT + JITLink),
+// NOT the AOT run-cache. When the large precompiled stdlib (>128 MB of .text on
+// arm64) is linked, an intra-object `bl`/`b` (AArch64 `Branch26PCRel`, range
+// +/-128 MB) can land out of range of its target. LLVM 21's JITLink has NO
+// automatic branch-range-extension for aarch64 (grep of
+// llvm/ExecutionEngine/JITLink finds no RangeExtension/branch-island pass), and
+// the AArch64 large code model is incomplete on ELF/COFF (it works only on
+// Mach-O, which is why macOS-arm64 never hit this). The result on arm64-Linux /
+// arm64-Windows is a hard link failure:
+//
+//   "relocation target ... is out of range of Branch26PCRel fixup"
+//
+// What this plugin does
+// ---------------------
+// It mirrors what static linkers (lld) do with veneers/thunks: for every
+// `Branch26PCRel` edge it inserts a *range-extension stub* and re-points the
+// edge at the stub. The stub is an absolute indirect jump materialised inline:
+//
+//     movz x16, #:abs_g0_nc:target
+//     movk x16, #:abs_g1_nc:target
+//     movk x16, #:abs_g2_nc:target
+//     movk x16, #:abs_g3   :target
+//     br   x16
+//
+// i.e. it loads the full 64-bit absolute target address into x16 via four
+// MOVZ/MOVK (resolved by JITLink `MoveWide16` edges at fixup time) and branches
+// to it. An absolute indirect branch reaches *any* address, so the
+// stub<->target distance is irrelevant.
+//
+// Placement / correctness
+// -----------------------
+// The only remaining range constraint is the caller -> stub `Branch26` itself.
+// We place each stub in the SAME `Section` as the calling block. The stdlib is
+// emitted with FunctionSections=true, so each function is its own section and
+// is far smaller than 128 MB; a stub appended to the caller's own section is
+// therefore always within +/-128 MB of every call site in that section. (If a
+// single section ever exceeded 128 MB the stub could itself fall out of range,
+// but no individual Eshkol function approaches that; the pathology is the
+// aggregate .text size, which per-section placement defuses.) This is
+// format-agnostic: it works for ELF, COFF and Mach-O alike, and depends only on
+// the AArch64 JITLink edge kinds, not on any object-format specifics.
+//
+// The pass runs in PostPrunePasses (before memory allocation), which is the only
+// phase where new stub blocks can still be given memory by the allocator -- the
+// same phase JITLink's own GOT/PLT builders use. Because addresses are not yet
+// assigned there, we cannot test individual edges for range; we therefore
+// veneer *every* Branch26 edge unconditionally. Stubs are deduplicated per
+// (section, target) so a function that calls the same callee many times shares
+// one stub. The cost is a handful of extra instructions per distinct callee per
+// section; this only fires on aarch64 and is dwarfed by JIT codegen time.
+
+#ifndef ESHKOL_JITLINK_BRANCH26_RANGE_EXTENSION_H
+#define ESHKOL_JITLINK_BRANCH26_RANGE_EXTENSION_H
+
+#include <llvm/ExecutionEngine/JITLink/JITLink.h>
+#include <llvm/ExecutionEngine/JITLink/aarch64.h>
+#include <llvm/ExecutionEngine/Orc/LinkGraphLinkingLayer.h>
+#include <llvm/ExecutionEngine/Orc/Core.h>
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/Support/Error.h>
+#include <llvm/TargetParser/Triple.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <iterator>
+#include <utility>
+#include <vector>
+
+namespace eshkol {
+
+/// ORC plugin that installs an AArch64 Branch26 range-extension pass into every
+/// JITLink LinkGraph. No-op on non-aarch64 targets.
+class Branch26RangeExtensionPlugin
+    : public llvm::orc::LinkGraphLinkingLayer::Plugin {
+public:
+  void modifyPassConfig(llvm::orc::MaterializationResponsibility &,
+                        llvm::jitlink::LinkGraph &G,
+                        llvm::jitlink::PassConfiguration &Config) override {
+    // Only aarch64 needs this -- other targets either have working far-call
+    // code models or JITLink range extension.
+    if (G.getTargetTriple().getArch() != llvm::Triple::aarch64 &&
+        G.getTargetTriple().getArch() != llvm::Triple::aarch64_be)
+      return;
+
+    // Escape hatch for debugging / measuring.
+    if (const char *Off = std::getenv("ESHKOL_JIT_NO_BRANCH26_VENEER"))
+      if (Off[0] == '1')
+        return;
+
+    Config.PostPrunePasses.push_back(
+        [](llvm::jitlink::LinkGraph &G) { return extendBranches(G); });
+  }
+
+  // Required overrides; this plugin tracks no per-resource state.
+  llvm::Error notifyFailed(llvm::orc::MaterializationResponsibility &) override {
+    return llvm::Error::success();
+  }
+  llvm::Error notifyRemovingResources(llvm::orc::JITDylib &,
+                                      llvm::orc::ResourceKey) override {
+    return llvm::Error::success();
+  }
+  void notifyTransferringResources(llvm::orc::JITDylib &,
+                                   llvm::orc::ResourceKey,
+                                   llvm::orc::ResourceKey) override {}
+
+private:
+  // movz x16,#0 ; movk x16,#0,lsl#16 ; movk x16,#0,lsl#32 ;
+  // movk x16,#0,lsl#48 ; br x16   (little-endian, imm fields zeroed)
+  static constexpr std::size_t kStubSize = 20;
+
+  static llvm::Error extendBranches(llvm::jitlink::LinkGraph &G) {
+    using namespace llvm::jitlink;
+
+    // Stub content template: the four MOVZ/MOVK imm16 fields are left zero and
+    // are filled in by JITLink via the MoveWide16 edges we attach below; the
+    // shift (LSL #0/16/32/48) is encoded in each instruction so JITLink writes
+    // the correct 16-bit slice of the absolute target address.
+    static const uint8_t StubTemplate[kStubSize] = {
+        0x10, 0x00, 0x80, 0xd2, // movz x16, #0,        (lsl #0)
+        0x10, 0x00, 0xa0, 0xf2, // movk x16, #0, lsl #16
+        0x10, 0x00, 0xc0, 0xf2, // movk x16, #0, lsl #32
+        0x10, 0x00, 0xe0, 0xf2, // movk x16, #0, lsl #48
+        0x00, 0x02, 0x1f, 0xd6, // br   x16
+    };
+
+    // Collect the work first. Re-pointing existing edges in place is fine, but
+    // we also create new blocks/symbols which can perturb iteration, so snapshot
+    // the (block, edge-index, target, addend) tuples to act on.
+    struct EdgeRef {
+      Block *B;
+      std::size_t EdgeIdx; // index into the block's edge list at snapshot time
+      Symbol *Target;
+      Edge::AddendT Addend;
+    };
+    std::vector<EdgeRef> Work;
+
+    for (auto *B : G.blocks()) {
+      std::size_t Idx = 0;
+      for (auto &E : B->edges()) {
+        if (E.getKind() == aarch64::Branch26PCRel)
+          Work.push_back({B, Idx, &E.getTarget(), E.getAddend()});
+        ++Idx;
+      }
+    }
+
+    if (Work.empty())
+      return llvm::Error::success();
+
+    // Dedup stubs per (section ordinal, target symbol). A stub is valid for any
+    // caller in the same section, and an absolute-jump stub does not depend on
+    // the call-site address, so one per (section, target) suffices.
+    llvm::DenseMap<std::pair<unsigned, Symbol *>, Symbol *> StubFor;
+
+    for (auto &W : Work) {
+      Section &Sec = W.B->getSection();
+      auto Key = std::make_pair(Sec.getOrdinal(), W.Target);
+
+      Symbol *Stub = nullptr;
+      auto It = StubFor.find(Key);
+      if (It != StubFor.end()) {
+        Stub = It->second;
+      } else {
+        // Create the stub block in the SAME section as the caller so the
+        // caller -> stub Branch26 is always in range.
+        Block &StubBlock = G.createContentBlock(
+            Sec,
+            llvm::ArrayRef<char>(reinterpret_cast<const char *>(StubTemplate),
+                                 kStubSize),
+            llvm::orc::ExecutorAddr(), /*Alignment=*/4, /*AlignmentOffset=*/0);
+
+        // Four MoveWide16 edges (offsets 0,4,8,12) fill the absolute target
+        // address into x16; the per-instruction LSL encodes which 16-bit slice.
+        // The original branch addend is folded into every slice's target so the
+        // stub jumps to exactly the same effective target the direct branch
+        // would have reached.
+        StubBlock.addEdge(aarch64::MoveWide16, 0, *W.Target, W.Addend);
+        StubBlock.addEdge(aarch64::MoveWide16, 4, *W.Target, W.Addend);
+        StubBlock.addEdge(aarch64::MoveWide16, 8, *W.Target, W.Addend);
+        StubBlock.addEdge(aarch64::MoveWide16, 12, *W.Target, W.Addend);
+
+        Stub = &G.addAnonymousSymbol(StubBlock, /*Offset=*/0, kStubSize,
+                                     /*IsCallable=*/true, /*IsLive=*/false);
+        StubFor[Key] = Stub;
+      }
+
+      // Re-point the original branch at the stub and zero the addend (the addend
+      // is now baked into the stub's absolute target).
+      auto EdgeIt = W.B->edges().begin();
+      std::advance(EdgeIt, W.EdgeIdx);
+      EdgeIt->setTarget(*Stub);
+      EdgeIt->setAddend(0);
+    }
+
+    return llvm::Error::success();
+  }
+};
+
+} // namespace eshkol
+
+#endif // ESHKOL_JITLINK_BRANCH26_RANGE_EXTENSION_H

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -20,7 +20,9 @@
 #include <llvm/ExecutionEngine/Orc/Core.h>
 #include <llvm/ExecutionEngine/Orc/ThreadSafeModule.h>
 #include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>
+#include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>  // JITLink-based layer (for Branch26 plugin)
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
+#include "jitlink_branch26_range_extension.h"  // AArch64 Branch26 range-extension plugin
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/IRBuilder.h>
@@ -601,6 +603,21 @@ void ReplJITContext::initializeJIT() {
     }
 
     jit_ = std::move(*jit_or_err);
+
+    // AArch64 Branch26 range-extension (cross-platform far-call fix for the
+    // in-process JIT path used by eval/compile). When the >128 MB stdlib is
+    // JIT-linked on arm64-ELF/COFF, intra-object `bl`/`b` (Branch26PCRel,
+    // +/-128 MB) can land out of range; LLVM 21 JITLink has no automatic branch
+    // range extension for aarch64 and the AArch64 large code model is incomplete
+    // outside Mach-O. This plugin veneers every Branch26 edge through an inline
+    // absolute-jump stub placed in the caller's own section. No-op off aarch64.
+    // The default LLJIT object layer on aarch64 IS the JITLink ObjectLinkingLayer
+    // (the Branch26 error is a JITLink diagnostic); guard the cast for safety on
+    // platforms/configs that fall back to RTDyld (where this fix is unnecessary).
+    if (auto *OLL = llvm::dyn_cast<llvm::orc::ObjectLinkingLayer>(
+            &jit_->getObjLinkingLayer())) {
+        OLL->addPlugin(std::make_shared<eshkol::Branch26RangeExtensionPlugin>());
+    }
 
     // Install a custom error reporter that suppresses "became defunct" messages.
     // These fire during JIT teardown when a resource tracker is invalidated while


### PR DESCRIPTION
## Problem
`eval`/`compile` route through the in-process ORC/JITLink JIT (not the AOT run-cache). When the >128 MB stdlib is JIT-linked on **arm64-ELF/COFF**, an intra-object `bl`/`b` (`Branch26PCRel`, ±128 MB) can land out of range of its target and the link aborts:
```
relocation target ... is out of range of Branch26PCRel fixup
```
LLVM 21's JITLink has **no** automatic branch-range-extension for aarch64 (a grep of `llvm/ExecutionEngine/JITLink` finds no RangeExtension/branch-island pass), and the AArch64 large code model is incomplete outside Mach-O — so the existing `CodeModel::Large` + `FunctionSections` mitigation (which fixes macOS/Mach-O) does **not** cover ELF/COFF. This is the residual that left `-r` `eval`/`compile` broken on arm64-Linux and arm64-Windows.

## Fix
Add an `ObjectLinkingLayer::Plugin` that veneers every `Branch26PCRel` edge through an inline absolute-jump stub placed in the **caller's own (per-function) section**:
```
movz x16, #:abs_g0_nc:target
movk x16, #:abs_g1_nc:target
movk x16, #:abs_g2_nc:target
movk x16, #:abs_g3   :target
br   x16
```
The four MOVZ/MOVK immediates are resolved by JITLink `MoveWide16` edges at fixup time, so the stub reaches any address; placing it in the caller's section keeps the caller→stub `Branch26` in range. This mirrors how static linkers (lld) create Branch26 thunks.

- Gated to **aarch64 only**; a no-op on other targets.
- `ESHKOL_JIT_NO_BRANCH26_VENEER=1` disables it (escape hatch).

New file `lib/repl/jitlink_branch26_range_extension.h`; wired into the JIT in `lib/repl/repl_jit.cpp`.

## Validation
The decisive validator is this PR's **`linux-arm64-lite`** CI lane (arm64-ELF — exactly where the bug reproduces): an `eval`/`compile`-using `-r` program must link without the `Branch26PCRel` error. macOS/Mach-O is unaffected (already mitigated by the large code model) and serves as the no-regression check.

> Note: drafted from a worktree agent's committed implementation that was interrupted by a session limit before it could open the PR; the commit itself is complete. Reviewer: confirm the arm64 CI lanes are green before merge.