### PR TITLE
fix(agent): sqlite.esk requires core.strings for string-contains

### DIFF
--- a/lib/agent/sqlite.esk
+++ b/lib/agent/sqlite.esk
@@ -3,6 +3,7 @@
 ;; Bindings to agent_sqlite.c
 ;;
 (require core.capabilities)
+(require core.strings)        ; string-contains (SQL-injection guard in sqlite-exec-safe)
 
 (provide sqlite-exec-safe sqlite-open sqlite-close sqlite-exec
          sqlite-prepare sqlite-step sqlite-reset sqlite-finalize


### PR DESCRIPTION
sqlite-exec-safe's SQL-injection guard calls `string-contains` (sqlite.esk:78/80), but the file only `(require)`d `core.capabilities` — so `string-contains` was an unknown function at codegen. It's provided by `core.strings`; this adds the missing `(require core.strings)`. Resolves bug-PP. Verified: sqlite.esk now compiles cleanly (no "Unknown function"); the residual `_eshkol_sqlite_last_error` link symbol is the expected agent-FFI link step that a real `(require agent.sqlite)` program wires in.