### PR TITLE
fix(logger): lock-free log-level fast path to stop parallel-map worker SIGABRT

### DIFF
--- a/lib/core/logger.cpp
+++ b/lib/core/logger.cpp
@@ -36,6 +36,7 @@
 #endif
 
 #include <mutex>
+#include <atomic>
 #include <string>
 #include <ctime>
 #include <cstring>
@@ -62,7 +63,17 @@
 // ============================================================================
 
 static std::mutex g_log_mutex;
-static eshkol_logger_t g_max_level = ESHKOL_NOTICE;
+// Atomic so the hot-path level check (the early-return in every eshkol_printf /
+// eshkol_log_with_location) needs NO lock. This matters for correctness, not
+// just speed: arena_create() emits an eshkol_debug() on every arena creation,
+// including each worker thread's first-touch arena in eshkol_thread_init_worker.
+// When N worker threads start concurrently (cold parallel-map), having them all
+// take g_log_mutex purely to read the level was the first concurrent lock of a
+// statically-initialized std::mutex from multiple threads at once — which races
+// the platform's lazy first-lock initialization on Darwin and intermittently
+// threw "mutex lock failed: Invalid argument" (SIGABRT). A suppressed log must
+// not lock at all.
+static std::atomic<eshkol_logger_t> g_max_level{ESHKOL_NOTICE};
 static eshkol_log_format_t g_log_format = ESHKOL_LOG_TEXT;
 static FILE* g_log_file = nullptr;
 static bool g_color_enabled = true;
@@ -276,13 +287,11 @@ static void output_json(eshkol_logger_t level, const char* msg,
 extern "C" {
 
 void eshkol_set_logger_level(eshkol_logger_t level) {
-    std::lock_guard<std::mutex> lock(g_log_mutex);
-    g_max_level = level;
+    g_max_level.store(level, std::memory_order_relaxed);
 }
 
 eshkol_logger_t eshkol_get_logger_level(void) {
-    std::lock_guard<std::mutex> lock(g_log_mutex);
-    return g_max_level;
+    return g_max_level.load(std::memory_order_relaxed);
 }
 
 void eshkol_set_log_format(eshkol_log_format_t format) {
@@ -331,10 +340,8 @@ void eshkol_set_timestamps(bool enabled) {
 }
 
 void eshkol_printf(eshkol_logger_t level, const char* msg, ...) {
-    {
-        std::lock_guard<std::mutex> lock(g_log_mutex);
-        if (level > g_max_level) return;
-    }
+    // Lock-free fast path: a suppressed log must take no lock (see g_max_level).
+    if (level > g_max_level.load(std::memory_order_relaxed)) return;
 
     va_list ap;
     va_start(ap, msg);
@@ -363,10 +370,8 @@ void eshkol_log_with_location(eshkol_logger_t level,
                                int line,
                                const char* func,
                                const char* msg, ...) {
-    {
-        std::lock_guard<std::mutex> lock(g_log_mutex);
-        if (level > g_max_level) return;
-    }
+    // Lock-free fast path: a suppressed log must take no lock (see g_max_level).
+    if (level > g_max_level.load(std::memory_order_relaxed)) return;
 
     va_list ap;
     va_start(ap, msg);
@@ -408,10 +413,8 @@ void eshkol_log_with_location(eshkol_logger_t level,
 }
 
 void eshkol_log_structured(eshkol_logger_t level, const char* msg, ...) {
-    {
-        std::lock_guard<std::mutex> lock(g_log_mutex);
-        if (level > g_max_level) return;
-    }
+    // Lock-free fast path: a suppressed log must take no lock (see g_max_level).
+    if (level > g_max_level.load(std::memory_order_relaxed)) return;
 
     va_list ap;
     va_start(ap, msg);
@@ -475,10 +478,8 @@ void eshkol_log_close(void) {
 }
 
 void eshkol_stacktrace(eshkol_logger_t level) {
-    {
-        std::lock_guard<std::mutex> lock(g_log_mutex);
-        if (level > g_max_level) return;
-    }
+    // Lock-free fast path: a suppressed log must take no lock (see g_max_level).
+    if (level > g_max_level.load(std::memory_order_relaxed)) return;
 
 #if defined(_WIN32)
     std::lock_guard<std::mutex> lock(g_log_mutex);


### PR DESCRIPTION
## Problem
The ICC probe `per_thread_arena_works` (and `tests/parallel`) intermittently aborted (exit 134):
```
libc++abi: terminating due to uncaught exception of type std::system_error: mutex lock failed: Invalid argument
```
Backtrace:
```
thread_pool_worker_entry → eshkol_thread_init_worker → arena_create → eshkol_printf → (throws)
```
`arena_create()` emits an `eshkol_debug()` on every arena creation — including the per-thread arena each worker builds in `eshkol_thread_init_worker`. But `eshkol_printf` took `g_log_mutex` **purely to read `g_max_level`** for its early-return level check, *even when the level is suppressed and nothing prints*. So N worker threads starting concurrently (a cold `parallel-map`) all took `g_log_mutex` at once — the first concurrent lock of a statically-initialized `std::mutex` from multiple threads, which races the platform's lazy first-lock init on Darwin and intermittently throws EINVAL. Reproduced at ~22% (9/40 AOT runs).

## Fix
Make `g_max_level` a `std::atomic` and do the suppressed-level early-return with a **relaxed load and no lock**, in all four log entry points. A suppressed log now takes no lock at all, so worker init never contends `g_log_mutex` — removing the race at its root (and it's faster on every log call). Setter/getter become lock-free atomic store/load.

## Verification
- **60/60 AOT + 30/30 `-r`** clean (was 9/40 aborts).
- `tests/parallel/parallel_map_test`, `parallel_ad_worker_init_test`, `threads_mutex_concurrency_test` all pass.
- ICC `per_thread_arena_works` is the probe this fixes.