### PR TITLE
fix(cmake): export runtime transitive link deps + load-path regression test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1574,6 +1574,18 @@ if(LLVM_LIBRARY_DIRS)
     target_link_directories(eshkol-static PRIVATE ${LLVM_LIBRARY_DIRS})
 endif()
 
+# Propagate the runtime's transitive system link deps (Apple ImageIO/CoreGraphics/
+# CoreFoundation for image_io.c, Windows Gdiplus/Advapi32/Ntdll, libpng/jpeg/webp,
+# clang builtins) to the static/runtime libraries' PUBLIC interface. Previously
+# these lived only on the eshkol-run/eshkol-repl executables, so a downstream
+# consumer linking libeshkol-static.a directly (e.g. libnoesis-core) hit
+# "Undefined symbols: _CGImageDestinationCreateWithURL ..." and had to re-declare
+# the frameworks itself. The library should own its transitive link deps.
+if(ESHKOL_EXTRA_LINK_LIBS)
+    target_link_libraries(eshkol-runtime PUBLIC ${ESHKOL_EXTRA_LINK_LIBS})
+    target_link_libraries(eshkol-static PUBLIC ${ESHKOL_EXTRA_LINK_LIBS})
+endif()
+
 # Link BLAS libraries if available
 if(ESHKOL_BLAS_ENABLED AND BLAS_LIBRARIES)
     target_link_libraries(eshkol-runtime PUBLIC ${BLAS_LIBRARIES})

--- a/tests/load/fixtures/dep_mod.esk
+++ b/tests/load/fixtures/dep_mod.esk
@@ -1,0 +1,2 @@
+;; Fixture loaded by a cwd-relative (load ...) from a subdir path.
+(define (dep-answer) 42)

--- a/tests/load/load_relative_subdir_test.esk
+++ b/tests/load/load_relative_subdir_test.esk
@@ -1,0 +1,15 @@
+;;; Regression: cwd-relative (load "subdir/.../file.esk") from the repo root
+;;; must resolve WITHOUT mangling the path. On v1.2.3-scale this produced:
+;;;   - doubled extension:  dep_mod.esk -> dep_mod.esk.esk
+;;;   - dot->slash mangling: dep_mod.esk -> dep_mod/esk.esk
+;;; and then silently fell back to the interpreter under AOT. Fixed on master.
+;;; (Noesis NOESIS_TO_ESHKOL_link_and_loadpath_2026-06-24, issue #2.)
+;;;
+;;; Run from the repo root: eshkol-run -r tests/load/load_relative_subdir_test.esk
+(load "tests/load/fixtures/dep_mod.esk")
+
+(define pass (= (dep-answer) 42))
+(display (if pass "PASS: cwd-relative subdir load (no .esk.esk / dot-slash mangle)"
+                  "FAIL: cwd-relative subdir load"))
+(newline)
+(if (not pass) (exit 1))


### PR DESCRIPTION
Addresses issues #1 and #2 of Noesis's `link_and_loadpath` report (2026-06-24).

## #1 — Export the runtime's transitive link deps (the macOS image-I/O break)
`image_io.c` references Apple ImageIO/CoreGraphics/CoreFoundation; CMake added these (and the Windows/png/jpeg/webp/clang-builtins deps in `ESHKOL_EXTRA_LINK_LIBS`) only to the **executables**, not to `eshkol-static`/`eshkol-runtime`. A downstream consumer linking `libeshkol-static.a` directly (e.g. `libnoesis-core.dylib`) hit:
```
Undefined symbols: _CGImageDestinationCreateWithURL, _CGImageSourceCreateWithURL, ... (17 symbols)
```
and had to re-declare the frameworks in its own `FindEshkol.cmake`. Fix: propagate `ESHKOL_EXTRA_LINK_LIBS` to the libraries' **PUBLIC** interface, so consumers inherit the transitive deps. Verified: configure clean, `eshkol-static`/`eshkol-run` build/link fine.

## #2 — cwd-relative `(load "subdir/file.esk")` regression test
On v1.2.3-scale this mangled the path (doubled `.esk.esk`; dot→slash `.../file/esk.esk`) and silently fell back to the interpreter under AOT. **Already fixed on master** (confirmed: the exact repro resolves cleanly). This adds the requested regression test, `tests/load/load_relative_subdir_test.esk` — passes under `-r` and AOT.

## Not in this PR
Issue #3 (portable `libobjc` resolution, runtime LLVM libdir instead of the baked Cellar path, and the pre-stdlib JIT-link **hang** that should fail-fast) is the deeper mesh-portability item — being handled separately.