### PR TITLE
fix(link): portable JIT/AOT link across the mesh (objc + LLVM libdir + bounded link timeout)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1893,6 +1893,16 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tools/pkg/eshkol_pkg.cpp")
             COMMAND eshkol-pkg-command-injection-test $<TARGET_FILE:eshkol-pkg>
         )
     endif()
+
+    if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/pkg/subprocess_timeout_test.cpp")
+        add_executable(eshkol-pkg-subprocess-timeout-test tests/pkg/subprocess_timeout_test.cpp)
+        target_compile_features(eshkol-pkg-subprocess-timeout-test PRIVATE cxx_std_17)
+        target_include_directories(eshkol-pkg-subprocess-timeout-test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+        add_test(
+            NAME eshkol-pkg-subprocess-timeout
+            COMMAND eshkol-pkg-subprocess-timeout-test
+        )
+    endif()
 endif()
 
 # ===== LSP Server =====

--- a/exe/eshkol-run.cpp
+++ b/exe/eshkol-run.cpp
@@ -111,8 +111,113 @@ static void append_space_separated_link_args(const char* raw_args,
     }
 }
 
+#if !defined(_WIN32)
+// Run a fixed, trusted command and capture its trimmed stdout. Returns empty on
+// any failure. Used only for runtime toolchain probes (xcrun, llvm-config) with
+// no user-controlled input, so popen() is safe here.
+static std::string captureCommandOutput(const std::string& command) {
+    FILE* pipe = popen(command.c_str(), "r");
+    if (!pipe) {
+        return {};
+    }
+    std::string output;
+    char buffer[512];
+    while (std::fgets(buffer, sizeof(buffer), pipe)) {
+        output += buffer;
+    }
+    int status = pclose(pipe);
+    if (status != 0) {
+        return {};
+    }
+    while (!output.empty() &&
+           (output.back() == '\n' || output.back() == '\r' || output.back() == ' ')) {
+        output.pop_back();
+    }
+    return output;
+}
+
+// Resolve the LLVM library directory at RUNTIME rather than trusting the
+// absolute Homebrew Cellar path baked into ESHKOL_HOST_LLVM_LINK_ARGS at build
+// time. That baked path (e.g. /opt/homebrew/Cellar/llvm/21.1.7/lib) does not
+// exist on a host whose LLVM is a different patch/prefix, so the link fails
+// with "search path '...' not found" / "library 'LLVM-NN' not found" and the
+// binary can't JIT off-builder (Noesis hit this copying atlas's binary to enki).
+//
+// We try `llvm-config --libdir` (and the versioned `llvm-config-NN`) from PATH,
+// then common prefixes. Returns empty if nothing resolves, in which case the
+// caller falls back to the baked path. The result is cached.
+static const std::string& resolveLlvmLibDir() {
+    static const std::string cached = [] {
+        const std::string major = std::to_string(LLVM_VERSION_MAJOR);
+        std::vector<std::string> probes = {
+            "llvm-config-" + major + " --libdir 2>/dev/null",
+            "llvm-config --libdir 2>/dev/null",
+        };
+        for (const auto& cmd : probes) {
+            std::string dir = captureCommandOutput(cmd);
+            std::error_code ec;
+            if (!dir.empty() && std::filesystem::is_directory(dir, ec)) {
+                return dir;
+            }
+        }
+        // Known prefixes as a last resort before the baked path.
+        std::vector<std::string> candidates = {
+            "/opt/homebrew/opt/llvm/lib",
+            "/opt/homebrew/opt/llvm@" + major + "/lib",
+            "/usr/local/opt/llvm/lib",
+            "/usr/local/opt/llvm@" + major + "/lib",
+            "/usr/lib/llvm-" + major + "/lib",
+        };
+        for (const auto& dir : candidates) {
+            std::error_code ec;
+            if (std::filesystem::is_directory(dir, ec)) {
+                return dir;
+            }
+        }
+        return std::string{};
+    }();
+    return cached;
+}
+#endif
+
 static void append_host_llvm_link_args(std::vector<std::string>& link_args) {
+#if defined(_WIN32)
     append_space_separated_link_args(ESHKOL_HOST_LLVM_LINK_ARGS, link_args);
+#else
+    // Prepend a runtime-resolved LLVM -L (and rpath on ELF) so the libdir is
+    // searched BEFORE the build-time absolute Cellar path baked into
+    // ESHKOL_HOST_LLVM_LINK_ARGS. This makes a binary built on one host link
+    // against the LLVM present on a different host (different patch/prefix).
+    // The baked args are still spliced afterwards as a fallback.
+    const std::string& runtime_libdir = resolveLlvmLibDir();
+    if (!runtime_libdir.empty()) {
+        link_args.emplace_back("-L" + runtime_libdir);
+#  if !defined(__APPLE__)
+        // ELF: a -L alone leaves no runtime search path; add an rpath so the
+        // resulting binary can find libLLVM.so at run time (mirrors CMake).
+        link_args.emplace_back("-Wl,-rpath," + runtime_libdir);
+#  endif
+    }
+    append_space_separated_link_args(ESHKOL_HOST_LLVM_LINK_ARGS, link_args);
+#endif
+}
+
+// Bounded wait for the native link / cached-compile subprocesses. A hung `ld`
+// (e.g. a misconfigured search path on a non-builder host) must never wedge the
+// process: on expiry the child is killed and the caller fails fast — to the
+// interpreter for the `-r` JIT path, or to a clean link error for AOT. 0 means
+// "unbounded"; ESHKOL_LINK_TIMEOUT_SECONDS overrides the default. The default is
+// generous because a legitimate link of the 58 MB stdlib can take tens of
+// seconds on a cold host.
+static unsigned int link_subprocess_timeout_seconds() {
+    if (const char* raw = std::getenv("ESHKOL_LINK_TIMEOUT_SECONDS")) {
+        char* end = nullptr;
+        long parsed = std::strtol(raw, &end, 10);
+        if (end && *end == '\0' && parsed >= 0) {
+            return static_cast<unsigned int>(parsed);
+        }
+    }
+    return 300; // 5 minutes
 }
 
 namespace {
@@ -580,7 +685,19 @@ std::optional<int> tryRunFromPersistentJitCache(const char* argv0,
     compile_args.emplace_back("-o");
     compile_args.push_back(temp_binary.string());
 
-    int compile_status = eshkol::pkg::run_subprocess(compile_args);
+    // Bound the cached-binary build. The child runs the full AOT compile +
+    // native link; if its linker hangs (the child bounds its own link too, but
+    // belt-and-suspenders here covers any other stall), kill it and return
+    // nullopt so the caller fails fast to the interpreter rather than wedging
+    // the whole `-r` invocation. This is the architectural guarantee Noesis
+    // asked for: a JIT-link problem must never hang, only fall back.
+    int compile_status = eshkol::pkg::run_subprocess(
+        compile_args, nullptr, link_subprocess_timeout_seconds());
+    if (compile_status == eshkol::pkg::SUBPROCESS_TIMEOUT) {
+        std::filesystem::remove(temp_binary, ec);
+        jitCacheTrace("compile-timeout", std::to_string(link_subprocess_timeout_seconds()));
+        return std::nullopt;
+    }
     if (compile_status != 0) {
         std::filesystem::remove(temp_binary, ec);
         jitCacheTrace("compile-failed", std::to_string(compile_status));
@@ -4378,6 +4495,15 @@ int main(int argc, char **argv)
         link_args.emplace_back("CoreGraphics");
         link_args.emplace_back("-framework");
         link_args.emplace_back("CoreFoundation");
+        // Add the macOS SDK lib dir so `-lobjc` resolves portably (libobjc.tbd
+        // lives in <sdk>/usr/lib). Resolved at runtime, never hardcoded, so a
+        // freshly-built binary links on any mac regardless of the builder host.
+        {
+            const std::string sdk_lib = eshkol::platform::macos_sdk_lib_dir();
+            if (!sdk_lib.empty()) {
+                link_args.emplace_back("-L" + sdk_lib);
+            }
+        }
         link_args.emplace_back("-lobjc");  // Objective-C runtime
 #endif
 
@@ -4465,7 +4591,12 @@ int main(int argc, char **argv)
         }
 
         eshkol_info("Linking object files: %s", link_cmd.c_str());
-        int result = eshkol::platform::run_command(link_args);
+        // Use the shell-free, killable subprocess launcher with a bounded wait.
+        // A hung linker (e.g. an unresolved -L search path on a non-builder
+        // host) would otherwise block forever via std::system(); the timeout
+        // turns that into a reported link failure instead of an infinite hang.
+        int result = eshkol::pkg::run_subprocess(
+            link_args, nullptr, link_subprocess_timeout_seconds());
 
         // Clean up temp object files (mkstemp-created files in TMPDIR)
         for (const auto &compiled_file : compiled_files) {
@@ -4475,6 +4606,13 @@ int main(int argc, char **argv)
             }
         }
 
+        if (result == eshkol::pkg::SUBPROCESS_TIMEOUT) {
+            eshkol_error("Linking timed out after %u seconds and was aborted "
+                         "(set ESHKOL_LINK_TIMEOUT_SECONDS to adjust)",
+                         link_subprocess_timeout_seconds());
+            eshkol_runtime_shutdown(ESHKOL_SHUTDOWN_ERROR);
+            return 1;
+        }
         if (result != 0) {
             eshkol_error("Linking failed with exit code %d", result);
             eshkol_runtime_shutdown(ESHKOL_SHUTDOWN_ERROR);

--- a/inc/eshkol/pkg/subprocess.h
+++ b/inc/eshkol/pkg/subprocess.h
@@ -24,9 +24,19 @@
  *   126 — execvp returned with EACCES / similar
  *   127 — execvp returned with ENOENT (program not found)
  *   128+sig — child died via signal sig (POSIX only)
+ *   124 — child exceeded the caller-supplied timeout and was killed
+ *         (matches GNU coreutils `timeout(1)`)
  *
  * Both the production code and tests share this single implementation so
  * security-relevant fixes only have to be made in one place.
+ *
+ * Timeouts
+ * --------
+ * `run_subprocess` accepts an optional `timeout_seconds`. The default (0)
+ * preserves the historical unbounded wait. A positive value bounds the wait:
+ * on expiry the child is killed and SUBPROCESS_TIMEOUT (124) is returned, so a
+ * stuck downstream tool (e.g. a hung `ld` on a misconfigured host) can never
+ * wedge the parent — the caller fails fast instead of blocking forever.
  */
 
 #ifndef ESHKOL_PKG_SUBPROCESS_H
@@ -43,12 +53,17 @@
 #  include <windows.h>
 #else
 #  include <cerrno>
+#  include <csignal>
+#  include <ctime>
 #  include <sys/types.h>
 #  include <sys/wait.h>
 #  include <unistd.h>
 #endif
 
 namespace eshkol::pkg {
+
+// Returned when a bounded wait expires and the child is killed.
+constexpr int SUBPROCESS_TIMEOUT = 124;
 
 #ifdef _WIN32
 
@@ -108,7 +123,8 @@ inline std::wstring build_windows_command_line(const std::vector<std::string>& a
 // platform — all elements are passed verbatim, so manifest data can never
 // inject commands.
 inline int run_subprocess(const std::vector<std::string>& args,
-                          const std::filesystem::path* cwd = nullptr) {
+                          const std::filesystem::path* cwd = nullptr,
+                          unsigned int timeout_seconds = 0) {
     if (args.empty()) {
         return 1;
     }
@@ -146,7 +162,18 @@ inline int run_subprocess(const std::vector<std::string>& args,
         return static_cast<int>(GetLastError());
     }
 
-    WaitForSingleObject(process_info.hProcess, INFINITE);
+    const DWORD wait_ms =
+        timeout_seconds == 0 ? INFINITE : timeout_seconds * 1000u;
+    DWORD wait_result = WaitForSingleObject(process_info.hProcess, wait_ms);
+    if (wait_result == WAIT_TIMEOUT) {
+        // Stuck child: terminate it and report a bounded-wait timeout so the
+        // caller can fail fast rather than block forever.
+        TerminateProcess(process_info.hProcess, 1);
+        WaitForSingleObject(process_info.hProcess, INFINITE);
+        CloseHandle(process_info.hThread);
+        CloseHandle(process_info.hProcess);
+        return SUBPROCESS_TIMEOUT;
+    }
     DWORD exit_code = 1;
     GetExitCodeProcess(process_info.hProcess, &exit_code);
     CloseHandle(process_info.hThread);
@@ -173,9 +200,45 @@ inline int run_subprocess(const std::vector<std::string>& args,
     }
 
     int status = 0;
-    while (waitpid(pid, &status, 0) < 0) {
-        if (errno != EINTR) {
-            return errno;
+    if (timeout_seconds == 0) {
+        // Historical unbounded wait.
+        while (waitpid(pid, &status, 0) < 0) {
+            if (errno != EINTR) {
+                return errno;
+            }
+        }
+    } else {
+        // Bounded wait: poll with WNOHANG until the child exits or the deadline
+        // passes, then SIGKILL a stuck child and reap it. Polling (rather than
+        // SIGCHLD/alarm) keeps this header free of process-wide signal state,
+        // which matters because run_subprocess is called from a long-lived host
+        // process that installs its own handlers.
+        const struct timespec poll_interval = {0, 10 * 1000 * 1000}; // 10ms
+        const auto deadline =
+            std::time(nullptr) + static_cast<std::time_t>(timeout_seconds);
+        bool timed_out = false;
+        for (;;) {
+            pid_t r = waitpid(pid, &status, WNOHANG);
+            if (r == pid) {
+                break; // child exited
+            }
+            if (r < 0) {
+                if (errno == EINTR) continue;
+                return errno;
+            }
+            // r == 0: still running.
+            if (std::time(nullptr) >= deadline) {
+                timed_out = true;
+                break;
+            }
+            nanosleep(&poll_interval, nullptr);
+        }
+        if (timed_out) {
+            kill(pid, SIGKILL);
+            // Reap so we don't leak a zombie.
+            while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {
+            }
+            return SUBPROCESS_TIMEOUT;
         }
     }
 

--- a/inc/eshkol/platform_runtime.h
+++ b/inc/eshkol/platform_runtime.h
@@ -30,6 +30,11 @@ std::string llc_executable();
 std::string executable_suffix();
 std::string static_library_name(std::string_view stem);
 std::vector<std::string> host_runtime_link_args();
+// On macOS, the resolved SDK library directory (<sdk>/usr/lib) discovered at
+// runtime via `xcrun --show-sdk-path`. Adding it to the linker search path lets
+// a bare `-lobjc` resolve on any mac, not just the builder. Empty on non-macOS
+// or when xcrun is unavailable.
+std::string macos_sdk_lib_dir();
 std::filesystem::path with_executable_suffix(const std::filesystem::path& path);
 std::string shell_quote(std::string_view argument);
 int run_command(const std::vector<std::string>& arguments);

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -34,7 +34,9 @@
 #include <eshkol/logger.h>
 #include <eshkol/platform_runtime.h>
 #include <eshkol/runtime_exports.h>
+#include <eshkol/pkg/subprocess.h>
 #include "../core/arena_memory.h"
+#include <cstdlib>
 
 #ifdef ESHKOL_LLVM_BACKEND_ENABLED
 
@@ -42,6 +44,20 @@ namespace eshkol { class CodegenContext; }
 extern "C" void eshkol_register_tensorcore_builtins(eshkol::CodegenContext*);
 
 namespace {
+
+// Bounded wait for the AOT native link. Mirrors eshkol-run.cpp: a hung linker
+// must never wedge the process. 0 = unbounded; ESHKOL_LINK_TIMEOUT_SECONDS
+// overrides the 5-minute default.
+unsigned int link_subprocess_timeout_seconds() {
+    if (const char* raw = std::getenv("ESHKOL_LINK_TIMEOUT_SECONDS")) {
+        char* end = nullptr;
+        long parsed = std::strtol(raw, &end, 10);
+        if (end && *end == '\0' && parsed >= 0) {
+            return static_cast<unsigned int>(parsed);
+        }
+    }
+    return 300;
+}
 
 void append_host_runtime_link_args(std::vector<std::string>& link_args) {
 #ifdef _WIN32
@@ -35958,6 +35974,15 @@ int eshkol_compile_llvm_ir_to_executable(LLVMModuleRef module_ref, const char* f
         link_args.emplace_back("CoreGraphics");
         link_args.emplace_back("-framework");
         link_args.emplace_back("CoreFoundation");
+        // Resolve libobjc portably via the macOS SDK lib dir (see
+        // eshkol-run.cpp): a bare -lobjc misses the default search path on a
+        // freshly-built binary on a non-builder host.
+        {
+            const std::string sdk_lib = eshkol::platform::macos_sdk_lib_dir();
+            if (!sdk_lib.empty()) {
+                link_args.emplace_back("-L" + sdk_lib);
+            }
+        }
         link_args.emplace_back("-lobjc");
 #endif
 
@@ -36026,11 +36051,20 @@ int eshkol_compile_llvm_ir_to_executable(LLVMModuleRef module_ref, const char* f
         }
 
         eshkol_info("Linking executable: %s", link_cmd.c_str());
-        int result = eshkol::platform::run_command(link_args);
+        // Shell-free, killable link with a bounded wait so a hung linker fails
+        // fast instead of blocking forever.
+        int result = eshkol::pkg::run_subprocess(
+            link_args, nullptr, link_subprocess_timeout_seconds());
 
         // Clean up temporary object file
         std::remove(temp_obj.c_str());
 
+        if (result == eshkol::pkg::SUBPROCESS_TIMEOUT) {
+            eshkol_error("Linking timed out after %u seconds and was aborted "
+                         "(set ESHKOL_LINK_TIMEOUT_SECONDS to adjust)",
+                         link_subprocess_timeout_seconds());
+            return -1;
+        }
         if (result != 0) {
             eshkol_error("Linking failed with exit code %d", result);
             return -1;

--- a/lib/core/platform_runtime.cpp
+++ b/lib/core/platform_runtime.cpp
@@ -339,6 +339,40 @@ std::vector<std::string> host_runtime_link_args() {
     return args;
 }
 
+std::string macos_sdk_lib_dir() {
+#ifdef __APPLE__
+    static const std::string cached = [] {
+        // Trusted fixed command, no user input — popen is safe.
+        FILE* pipe = popen("xcrun --show-sdk-path 2>/dev/null", "r");
+        if (!pipe) {
+            return std::string{};
+        }
+        std::string out;
+        char buffer[512];
+        while (std::fgets(buffer, sizeof(buffer), pipe)) {
+            out += buffer;
+        }
+        int status = pclose(pipe);
+        while (!out.empty() &&
+               (out.back() == '\n' || out.back() == '\r' || out.back() == ' ')) {
+            out.pop_back();
+        }
+        if (status != 0 || out.empty()) {
+            return std::string{};
+        }
+        std::filesystem::path lib_dir = std::filesystem::path(out) / "usr" / "lib";
+        std::error_code ec;
+        if (!std::filesystem::is_directory(lib_dir, ec)) {
+            return std::string{};
+        }
+        return lib_dir.string();
+    }();
+    return cached;
+#else
+    return {};
+#endif
+}
+
 std::filesystem::path with_executable_suffix(const std::filesystem::path& path) {
     if (path.empty()) {
         return {};

--- a/tests/pkg/subprocess_timeout_test.cpp
+++ b/tests/pkg/subprocess_timeout_test.cpp
@@ -1,0 +1,82 @@
+// Regression test for the bounded-wait timeout in
+// inc/eshkol/pkg/subprocess.h.
+//
+// Before this fix, run_subprocess() always waited unboundedly
+// (waitpid(pid, &status, 0) on POSIX, WaitForSingleObject(..., INFINITE) on
+// Windows). A hung child — e.g. a stuck `ld` on a host whose link search path
+// is misconfigured — wedged the whole process, so the `-r` JIT path never
+// reached its interpreter fallback (Noesis observed this as eshkol-run sitting
+// at 0% CPU indefinitely). The fix adds an optional timeout: on expiry the
+// child is killed and SUBPROCESS_TIMEOUT (124) is returned so callers fail
+// fast.
+//
+// This test asserts:
+//   1. A child that sleeps far longer than the timeout is killed promptly and
+//      returns SUBPROCESS_TIMEOUT.
+//   2. A child that finishes within the timeout returns its real exit code.
+//   3. timeout==0 preserves the historical unbounded (here: prompt) wait.
+
+#include <eshkol/pkg/subprocess.h>
+
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+int fail(const std::string& message) {
+    std::cerr << "FAIL: " << message << std::endl;
+    return 1;
+}
+
+#ifdef _WIN32
+const std::vector<std::string> kSleepLong = {"cmd", "/c", "ping", "127.0.0.1",
+                                             "-n", "30", ">nul"};
+const std::vector<std::string> kQuick = {"cmd", "/c", "exit", "0"};
+#else
+const std::vector<std::string> kSleepLong = {"/bin/sleep", "30"};
+const std::vector<std::string> kQuick = {"/bin/sh", "-c", "exit 0"};
+#endif
+
+} // namespace
+
+int main() {
+    using namespace std::chrono;
+
+    // 1. Hung child must be killed within the bound, not after 30s.
+    {
+        auto start = steady_clock::now();
+        int rc = eshkol::pkg::run_subprocess(kSleepLong, nullptr, /*timeout=*/1);
+        auto elapsed = duration_cast<milliseconds>(steady_clock::now() - start).count();
+        if (rc != eshkol::pkg::SUBPROCESS_TIMEOUT) {
+            return fail("expected SUBPROCESS_TIMEOUT from a hung child, got " +
+                        std::to_string(rc));
+        }
+        if (elapsed > 10000) {
+            return fail("bounded wait took too long: " + std::to_string(elapsed) +
+                        "ms (timeout not enforced?)");
+        }
+    }
+
+    // 2. A child that completes within the bound returns its real exit code.
+    {
+        int rc = eshkol::pkg::run_subprocess(kQuick, nullptr, /*timeout=*/30);
+        if (rc != 0) {
+            return fail("expected exit 0 from a quick child, got " +
+                        std::to_string(rc));
+        }
+    }
+
+    // 3. timeout==0 keeps the historical behaviour for a quick child.
+    {
+        int rc = eshkol::pkg::run_subprocess(kQuick, nullptr, /*timeout=*/0);
+        if (rc != 0) {
+            return fail("expected exit 0 with unbounded wait, got " +
+                        std::to_string(rc));
+        }
+    }
+
+    std::cout << "PASS: subprocess timeout" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes Noesis report issue #3 (`NOESIS_TO_ESHKOL_link_and_loadpath_2026-06-24.md`): a freshly-built or freshly-copied `eshkol-run` could not JIT/AOT-link on a mesh host that was not the builder. It fell back to the (~3.6× slower) interpreter, and sometimes **hung** at startup instead of falling back. All three sub-problems are root-caused and fixed; verified cross-host on `enki` (Homebrew LLVM 21.1.0, a different patch than the builder's 21.1.7).

## Root causes & fixes

### 1. `-lobjc` not found off-builder
The macOS link block emitted a bare `-lobjc`; on some hosts the default linker search path misses libobjc (`ld: library 'objc' not found`). Now `eshkol::platform::macos_sdk_lib_dir()` resolves the SDK lib dir at runtime via `xcrun --show-sdk-path` and we add `-L<sdk>/usr/lib` before `-lobjc`. Resolved, never hardcoded.

### 2. Builder's absolute LLVM Cellar path baked into the link line
`append_host_llvm_link_args` spliced `ESHKOL_HOST_LLVM_LINK_ARGS`, which CMake fills with the builder's `-L/opt/homebrew/Cellar/llvm/<patch>/lib` and `-lLLVM-NN`. On a host with a different LLVM patch/prefix the link fails (`search path '...' not found`, `library 'LLVM-NN' not found`). The function now resolves the LLVM libdir at **runtime** (`llvm-config --libdir` / `llvm-config-NN`, then known prefixes) and prepends it (plus rpath on ELF) so it is searched **before** the baked path; the baked path remains only as a fallback.

### 3. JIT-link could hang instead of failing fast
`run_subprocess` waited unboundedly (`waitpid(..., 0)` / `WaitForSingleObject(..., INFINITE)`). A stuck `ld` wedged the process so the `-r` path never reached the interpreter fallback (Noesis saw eshkol-run at 0% CPU indefinitely). Added a bounded-wait timeout to `run_subprocess` (kills the child and returns `SUBPROCESS_TIMEOUT`=124 on expiry) and applied it to both link subprocesses — the AOT link + cached-compile re-invocation in `eshkol-run.cpp`, and the parallel link in `llvm_codegen.cpp`. Default 300s; `ESHKOL_LINK_TIMEOUT_SECONDS` overrides. On timeout the `-r` path returns `nullopt` and falls back to the interpreter; the AOT path reports a clean link error. `timeout==0` preserves the prior unbounded behaviour for all other callers.

**Env-var sensitivity (Noesis's "why does a downstream env var affect the pre-stdlib phase"):** red herring. The JIT cache key hashes only source + flags + libs, never `NOESIS_W44_*`. The full-vs-small difference was the unbounded link wait manifesting nondeterministically (a slow/stuck `ld`), not data size touching the pre-stdlib phase. The bounded timeout removes the hang regardless.

## Cross-host verification (enki, LLVM 21.1.0)

Before (enki, master binary), persistent JIT cache:
```
[jit-cache] miss ...
ld: library 'objc' not found
ERROR: Linking failed with exit code 256
[jit-cache] compile-failed 1   -> interpreter fallback
```

After (atlas-built **fixed** binary run on enki):
```
[jit-cache] miss ...
ld: warning: search path '/opt/homebrew/Cellar/llvm/21.1.7/lib' not found   (now just a warning)
[jit-cache] store ...   -> compiled, linked, ran  ->  5
```
The cached compiled binary on enki links `libobjc.A.dylib` and `libLLVM.dylib (current version 21.1.0 — enki's LLVM)` and runs standalone.

Fail-fast (enki, `ESHKOL_LINK_TIMEOUT_SECONDS=1`):
```
[jit-cache] compile-timeout 1   -> interpreter fallback -> 5   (5.8s, no hang)
```

## Tests
- New `tests/pkg/subprocess_timeout_test.cpp` (ctest `eshkol-pkg-subprocess-timeout`): bounded-wait kills a hung child and returns `SUBPROCESS_TIMEOUT`; quick child returns its real code; `timeout==0` unbounded path works. Passes on atlas and enki.
- Existing pkg tests, codegen, and control-flow suites pass on atlas.
