### PR TITLE
feat(stdlib): take-right/drop-right, filter-map, core.alist (ESH-0063)

### DIFF
--- a/lib/core/alist.esk
+++ b/lib/core/alist.esk
@@ -1,0 +1,23 @@
+;;; core/alist.esk
+;;; Association-list helpers (structural, equal?-keyed via assoc).
+;;; Fills the eshkol-agent stdlib gap (alist-ref / alist-ref-or / alist-set
+;;; were redefined locally across several modules — see ESH-0063).
+
+(provide alist-ref alist-ref-or alist-set)
+
+;;; alist-ref: value for key, or raise if absent.
+(define (alist-ref alist key)
+  (let ((p (assoc key alist)))
+    (if p (cdr p) (error "alist-ref: key not found" key))))
+
+;;; alist-ref-or: value for key, or default if absent.
+(define (alist-ref-or alist key default)
+  (let ((p (assoc key alist)))
+    (if p (cdr p) default)))
+
+;;; alist-set: functional update — replace the binding for key if present,
+;;; otherwise append it. Returns a new alist; the input is not mutated.
+(define (alist-set alist key value)
+  (cond ((null? alist) (list (cons key value)))
+        ((equal? (car (car alist)) key) (cons (cons key value) (cdr alist)))
+        (else (cons (car alist) (alist-set (cdr alist) key value)))))

--- a/lib/core/list/higher_order.esk
+++ b/lib/core/list/higher_order.esk
@@ -1,7 +1,17 @@
 ;;; core/list/higher_order.esk
 ;;; Higher-order list functions
 
-(provide map1 map2 map3 fold fold-left foldl fold-right foldr for-each any every)
+(provide map1 map2 map3 fold fold-left foldl fold-right foldr for-each any every filter-map)
+
+;;; filter-map: Apply fn to each element, keep the non-#f results (SRFI-1).
+;;; (filter-map (lambda (x) (if (odd? x) (* x x) #f)) '(1 2 3)) => (1 9)
+(define (filter-map fn lst)
+  (if (null? lst)
+      '()
+      (let ((v (fn (car lst))))
+        (if v
+            (cons v (filter-map fn (cdr lst)))
+            (filter-map fn (cdr lst))))))
 
 ;;; map1: Apply proc to each element of a single list
 ;;; (map1 double '(1 2 3)) => (2 4 6)

--- a/lib/core/list/transform.esk
+++ b/lib/core/list/transform.esk
@@ -1,7 +1,7 @@
 ;;; core/list/transform.esk
 ;;; List transformation functions
 
-(provide take drop append reverse filter unzip partition list-copy)
+(provide take drop take-right drop-right append reverse filter unzip partition list-copy)
 ;;; Note: remove is kept as a builtin for performance
 
 ;;; take: Return first n elements of a list
@@ -15,6 +15,14 @@
   (if (or (<= n 0) (null? lst))
       lst
       (drop (cdr lst) (- n 1))))
+
+;;; take-right: Return the last n elements of a list (SRFI-1).
+(define (take-right lst n)
+  (drop lst (- (length lst) n)))
+
+;;; drop-right: Return all but the last n elements of a list (SRFI-1).
+(define (drop-right lst n)
+  (take lst (- (length lst) n)))
 
 ;;; append: Concatenate any number of lists (R7RS §6.4)
 ;;; (append)           => ()


### PR DESCRIPTION
Adds the genuinely-missing stdlib helpers from the eshkol-agent stdlib-gap report (verified against source), removing downstream local redefinitions:
- `core.list.transform`: **take-right**, **drop-right** (SRFI-1)
- `core.list.higher_order`: **filter-map** (SRFI-1)
- **`core.alist`** (new): **alist-ref**, **alist-ref-or**, **alist-set**

Verified `-r`: all correct at boundaries.

Triage notes: `string-split` is already a codegen builtin (report's 'missing' was wrong); `fold-left`/`fold-right`/`take`/`drop`/`any`/`every` already exist in `core.list` (downstream adoption gap). The remaining report items — `hash-table?` predicate and compound-key hashing (ESH-0064) — are separate codegen/runtime tasks.