### PR TITLE
fix(hash): match compound (cons/list/vector) keys by structural equality (ESH-0064)

### DIFF
--- a/lib/core/runtime_hash_table.cpp
+++ b/lib/core/runtime_hash_table.cpp
@@ -87,6 +87,23 @@ uint64_t hash_tagged_value(const eshkol_tagged_value_t* value) {
                         hash ^= fnv1a_hash_u64(limbs[i]);
                         hash *= FNV_PRIME;
                     }
+                } else if (subtype == HEAP_SUBTYPE_CONS) {
+                    // Structural hash of a pair: combine hash(car) and hash(cdr)
+                    // recursively, so equal lists/pairs hash equal (ESH-0064).
+                    arena_tagged_cons_cell_t* cell =
+                        (arena_tagged_cons_cell_t*)value->data.ptr_val;
+                    eshkol_tagged_value_t car = arena_tagged_cons_get_tagged_value(cell, false);
+                    eshkol_tagged_value_t cdr = arena_tagged_cons_get_tagged_value(cell, true);
+                    hash ^= hash_tagged_value(&car); hash *= FNV_PRIME;
+                    hash ^= hash_tagged_value(&cdr); hash *= FNV_PRIME;
+                } else if (subtype == HEAP_SUBTYPE_VECTOR) {
+                    // Structural hash of a heterogeneous vector: [len:i64][elems...].
+                    int64_t len = *(int64_t*)(uintptr_t)value->data.ptr_val;
+                    eshkol_tagged_value_t* elems =
+                        (eshkol_tagged_value_t*)((uint8_t*)(uintptr_t)value->data.ptr_val + 8);
+                    for (int64_t i = 0; i < len; i++) {
+                        hash ^= hash_tagged_value(&elems[i]); hash *= FNV_PRIME;
+                    }
                 } else {
                     hash ^= fnv1a_hash_u64(value->data.ptr_val);
                 }
@@ -150,6 +167,34 @@ bool hash_keys_equal(const eshkol_tagged_value_t* a, const eshkol_tagged_value_t
             if (subtype_a == HEAP_SUBTYPE_BIGNUM) {
                 return eshkol_bignum_compare((const eshkol_bignum_t*)a->data.ptr_val,
                                              (const eshkol_bignum_t*)b->data.ptr_val) == 0;
+            }
+
+            if (subtype_a == HEAP_SUBTYPE_CONS) {
+                // Structural pair equality, recursing through hash_keys_equal so
+                // hash and equality stay consistent (ESH-0064). Compound keys
+                // (e.g. SICP data-directed (op . type) keys) now match by value.
+                arena_tagged_cons_cell_t* ca = (arena_tagged_cons_cell_t*)a->data.ptr_val;
+                arena_tagged_cons_cell_t* cb = (arena_tagged_cons_cell_t*)b->data.ptr_val;
+                eshkol_tagged_value_t car_a = arena_tagged_cons_get_tagged_value(ca, false);
+                eshkol_tagged_value_t car_b = arena_tagged_cons_get_tagged_value(cb, false);
+                if (!hash_keys_equal(&car_a, &car_b)) return false;
+                eshkol_tagged_value_t cdr_a = arena_tagged_cons_get_tagged_value(ca, true);
+                eshkol_tagged_value_t cdr_b = arena_tagged_cons_get_tagged_value(cb, true);
+                return hash_keys_equal(&cdr_a, &cdr_b);
+            }
+
+            if (subtype_a == HEAP_SUBTYPE_VECTOR) {
+                int64_t len_a = *(int64_t*)(uintptr_t)a->data.ptr_val;
+                int64_t len_b = *(int64_t*)(uintptr_t)b->data.ptr_val;
+                if (len_a != len_b) return false;
+                eshkol_tagged_value_t* ea =
+                    (eshkol_tagged_value_t*)((uint8_t*)(uintptr_t)a->data.ptr_val + 8);
+                eshkol_tagged_value_t* eb =
+                    (eshkol_tagged_value_t*)((uint8_t*)(uintptr_t)b->data.ptr_val + 8);
+                for (int64_t i = 0; i < len_a; i++) {
+                    if (!hash_keys_equal(&ea[i], &eb[i])) return false;
+                }
+                return true;
             }
 
             return a->data.ptr_val == b->data.ptr_val;

--- a/tests/collections/hash_compound_key_test.esk
+++ b/tests/collections/hash_compound_key_test.esk
@@ -1,0 +1,43 @@
+;;; tests/collections/hash_compound_key_test.esk
+;;; ESH-0064: hash tables must match compound (cons/list/vector) keys by
+;;; structural equality, not pointer identity. Was broken (only strings/bignums
+;;; were structural); found via the SICP data-directed-programming corpus.
+(define pass 0)(define fail 0)
+(define (chk label v)
+  (display "  [") (display (if v "PASS" "FAIL")) (display "] ") (display label) (newline)
+  (if v (set! pass (+ pass 1)) (set! fail (+ fail 1))))
+
+(define t (make-hash-table))
+
+;; cons key — two freshly-consed equal keys must match
+(hash-set! t (cons 'area 'circle) 314)
+(chk "cons key matches by value" (= (hash-ref t (cons 'area 'circle) -1) 314))
+(chk "different cons key misses" (eq? (hash-ref t (cons 'area 'square) 'NF) 'NF))
+
+;; list key (nested)
+(hash-set! t (list 1 2 3) 'abc)
+(chk "list key matches by value" (eq? (hash-ref t (list 1 2 3) 'NF) 'abc))
+(chk "different list key misses" (eq? (hash-ref t (list 1 2) 'NF) 'NF))
+
+;; vector key
+(hash-set! t (vector 7 8) 'vv)
+(chk "vector key matches by value" (eq? (hash-ref t (vector 7 8) 'NF) 'vv))
+
+;; nested compound key
+(hash-set! t (cons (list 'a 'b) "x") 99)
+(chk "nested compound key matches" (= (hash-ref t (cons (list 'a 'b) "x") -1) 99))
+
+;; string/scalar keys still work (no regression)
+(hash-set! t "str" 1)
+(chk "string key still works" (= (hash-ref t "str" -1) 1))
+(hash-set! t 42 'forty-two)
+(chk "int key still works" (eq? (hash-ref t 42 'NF) 'forty-two))
+
+;; SICP data-directed put/get pattern
+(define (put op type item) (hash-set! t (cons op type) item))
+(define (get op type) (hash-ref t (cons op type) #f))
+(put 'mul 'matrix (lambda (a b) (* a b)))
+(chk "SICP data-directed get returns stored proc" (= ((get 'mul 'matrix) 6 7) 42))
+
+(display "Passed: ")(display pass)(newline)
+(display "Failed: ")(display fail)(newline)


### PR DESCRIPTION
Found via the SICP data-directed-programming corpus. Hash tables matched **string/bignum** keys structurally but fell through to **pointer identity** for cons/list/vector keys — so a freshly-consed equal key never matched a stored one. Broke equal?-keyed tables with compound keys (SICP 2.4.3 data-directed programming + 2.5 generic arithmetic, which key on `(op . type)` → every lookup returned #f).

**Fix (both sides, kept consistent):**
- `hash_tagged_value`: structurally hash `HEAP_SUBTYPE_CONS` (combine car+cdr hashes recursively) and `HEAP_SUBTYPE_VECTOR` (combine element hashes).
- `hash_keys_equal`: structurally compare cons (recurse car/cdr) and vector (length + elements), recursing through `hash_keys_equal` itself — so hash and equality stay consistent and `1` vs `1.0` remain distinct keys (avoids a plain deep-equal delegation's int/double conflation). Tensor keys keep identity in both (consistent).

**Verified:** `tests/collections/hash_compound_key_test.esk` 9/9 (cons/list/vector match by value, different keys miss, nested compound, string/int unaffected, SICP put/get works). ICC smoke 29/0, collections regression clean.