### PR TITLE
fix(macros): expand macros inside internal-define (letrec*) bodies (ESH-0062)

### DIFF
--- a/lib/frontend/macro_expander.cpp
+++ b/lib/frontend/macro_expander.cpp
@@ -196,6 +196,7 @@ eshkol_ast_t MacroExpander::expandNode(const eshkol_ast_t& ast) {
             case ESHKOL_LET_OP:
             case ESHKOL_LET_STAR_OP:
             case ESHKOL_LETREC_OP:
+            case ESHKOL_LETREC_STAR_OP:
                 if (op->let_op.num_bindings > 0 && op->let_op.bindings) {
                     eshkol_ast_t* new_bindings = new eshkol_ast_t[op->let_op.num_bindings];
                     for (uint64_t i = 0; i < op->let_op.num_bindings; i++) {
@@ -595,6 +596,7 @@ bool MacroExpander::findRepeatedBinding(const eshkol_ast_t& ast,
         case ESHKOL_LET_OP:
         case ESHKOL_LET_STAR_OP:
         case ESHKOL_LETREC_OP:
+        case ESHKOL_LETREC_STAR_OP:
             for (uint64_t i = 0; i < op->let_op.num_bindings; i++) {
                 if (findRepeatedBinding(op->let_op.bindings[i], bindings, binding_name)) {
                     return true;
@@ -762,6 +764,7 @@ eshkol_ast_t MacroExpander::substituteBindingsAtIndex(const eshkol_ast_t& ast,
         case ESHKOL_LET_OP:
         case ESHKOL_LET_STAR_OP:
         case ESHKOL_LETREC_OP:
+        case ESHKOL_LETREC_STAR_OP:
             if (op->let_op.num_bindings > 0 && op->let_op.bindings) {
                 op->let_op.bindings = new eshkol_ast_t[op->let_op.num_bindings];
                 for (uint64_t i = 0; i < ast.operation.let_op.num_bindings; i++) {
@@ -1024,6 +1027,7 @@ eshkol_ast_t MacroExpander::substituteBindings(const eshkol_ast_t& ast,
             case ESHKOL_LET_OP:
             case ESHKOL_LET_STAR_OP:
             case ESHKOL_LETREC_OP:
+            case ESHKOL_LETREC_STAR_OP:
                 if (op->let_op.num_bindings > 0 && op->let_op.bindings) {
                     eshkol_ast_t* new_bindings = new eshkol_ast_t[op->let_op.num_bindings];
                     for (uint64_t i = 0; i < op->let_op.num_bindings; i++) {

--- a/tests/macros/macro_in_nested_define_test.esk
+++ b/tests/macros/macro_in_nested_define_test.esk
@@ -1,0 +1,38 @@
+;;; tests/macros/macro_in_nested_define_test.esk
+;;; ESH-0062: a top-level define-syntax macro must be usable inside internal
+;;; (nested) define bodies. Was broken — transformInternalDefinesToLetrec emits
+;;; ESHKOL_LETREC_STAR_OP, which the MacroExpander's recursion switch did not
+;;; handle, so macros inside internal-define bodies were never expanded
+;;; ("Unknown function"). Found via the SICP stream corpus (cons-stream in a
+;;; helper). let/lambda/begin bodies were unaffected.
+(define pass 0)(define fail 0)
+(define (chk label v)
+  (display "  [") (display (if v "PASS" "FAIL")) (display "] ") (display label) (newline)
+  (if v (set! pass (+ pass 1)) (set! fail (+ fail 1))))
+
+(define-syntax sq (syntax-rules () ((_ x) (* x x))))
+
+;; macro in an internal define's VALUE
+(define (a) (define z (sq 5)) z)
+(chk "macro in internal-define value" (= (a) 25))
+
+;; macro in an internal define's FUNCTION body
+(define (b) (define (inner y) (sq y)) (inner 6))
+(chk "macro in internal-define fn body" (= (b) 36))
+
+;; the SICP trigger: cons-stream (a macro) inside a nested helper define
+(define-syntax cons-stream (syntax-rules () ((_ h t) (cons h (delay t)))))
+(define (ints n) (cons-stream n (ints (+ n 1))))
+(define (sref s n) (if (= n 0) (car s) (sref (force (cdr s)) (- n 1))))
+(define (partial-sums s)
+  (define (rec s acc) (cons-stream (+ acc (car s)) (rec (force (cdr s)) (+ acc (car s)))))
+  (rec s 0))
+(chk "cons-stream in internal-define helper" (= (sref (partial-sums (ints 1)) 4) 15))
+
+;; control: macro in a flat body / let / lambda still works
+(define (c y) (sq y))
+(chk "macro in flat fn body (control)" (= (c 7) 49))
+(chk "macro in let body (control)" (= (let ((y 8)) (sq y)) 64))
+
+(display "Passed: ")(display pass)(newline)
+(display "Failed: ")(display fail)(newline)


### PR DESCRIPTION
Found via the SICP stream corpus. A top-level `define-syntax` macro used inside an internal/nested `(define …)` body was never expanded ("Unknown function").

**Root cause:** internal defines are lowered by `transformInternalDefinesToLetrec` to **`ESHKOL_LETREC_STAR_OP`**, but the `MacroExpander`'s AST-recursion switches only handled `LET_OP`/`LET_STAR_OP`/`LETREC_OP` — so `LETREC_STAR_OP` fell through to `default` and its binding values + body were never walked for macro calls. (`let`/`lambda`/`begin` bodies were unaffected — only internal defines broke.)

**Fix:** add `ESHKOL_LETREC_STAR_OP` alongside `LETREC_OP` in all four expander recursion sites (shares the `let_op` layout). `cons-stream` and any macro now work inside internal-define helpers.

**Verified:** `tests/macros/macro_in_nested_define_test.esk` 5/5 (internal-define value + fn body, `cons-stream` in a nested helper → 15, flat/let controls); existing macros suite 6/0.