### PR TITLE
feat(stdlib): aggregate core.alist into (require stdlib)

### DIFF
--- a/lib/stdlib.esk
+++ b/lib/stdlib.esk
@@ -37,6 +37,9 @@
 ;;; Strings - extended string utilities
 (require core.strings)
 
+;;; Alists - association-list helpers (alist-ref / alist-ref-or / alist-set)
+(require core.alist)
+
 ;;; Files - atomic writes and path helpers
 (require core.files)
 


### PR DESCRIPTION
eshkol-agent open-item #3: core.alist (alist-ref/-or/-set, ESH-0063) existed as a module but wasn't in stdlib.esk, so consumers needed an explicit (require core.alist). Adds it alongside the other list/data modules. Verified: (require stdlib) now exposes alist-ref. Lets downstream drop the redundant explicit requires.