### PR TITLE
fix(strings): R7RS string-map first-class proc + string->number radix (ESH-0066)

### DIFF
--- a/inc/eshkol/core/bignum.h
+++ b/inc/eshkol/core/bignum.h
@@ -154,6 +154,12 @@ void eshkol_bignum_pow_tagged(arena_t* arena,
 void eshkol_string_to_number_tagged(arena_t* arena, const char* str,
     eshkol_tagged_value_t* result);
 
+/* Parse a string to a tagged number in an explicit radix (R7RS 6.2.6,
+ * (string->number string radix)). Radix 2..36; #b/#o/#d/#x prefixes
+ * override `radix`. Result is #f for malformed input. */
+void eshkol_string_to_number_radix_tagged(arena_t* arena, const char* str,
+    int64_t radix, eshkol_tagged_value_t* result);
+
 /* ===== Display ===== */
 
 /* Write decimal representation to file (for display/write) */

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -8948,6 +8948,30 @@ private:
         // NOTE: abs and other unary math functions are now handled at the top of this function
         // with proper closure wrapping (before function_table check)
 
+        // Character case-conversion builtins as first-class functions.
+        // char-upcase / char-downcase / char-foldcase are normally inlined at
+        // the call site (codegenAST dispatch), so the bare symbol failed to
+        // resolve with "Undefined variable: char-upcase" when passed as a
+        // value — e.g. (string-map char-upcase "abc") or (map char-downcase …).
+        // Wrap each in a tagged_value -> tagged_value closure (arity 1).
+        if (var_name == "char-upcase" || var_name == "char-downcase" ||
+            var_name == "char-foldcase") {
+            Function* builtin_func = createBuiltinCharFunction(var_name);
+            if (builtin_func) {
+                Value* func_ptr_int = builder->CreatePtrToInt(builtin_func, intptr_type);
+                Value* arena_ptr = builder->CreateLoad(PointerType::getUnqual(*context), global_arena);
+                uint64_t packed_info = 0 | (1 << 16);  // no captures, arity=1
+                Value* packed_info_val = sizeConst(packed_info);
+                Value* sexpr_ptr = intPtrConst(0);
+                uint64_t return_type_info_val = CLOSURE_RETURN_SCALAR | (1 << 8);
+                Value* return_type_info = intPtrConst(return_type_info_val);
+                Value* closure_name = ConstantPointerNull::get(PointerType::getUnqual(*context));
+                Value* closure_ptr = builder->CreateCall(getArenaAllocateClosureWithHeaderFunc(),
+                                                         {arena_ptr, func_ptr_int, packed_info_val, sexpr_ptr, return_type_info, closure_name});
+                return packPtrToTaggedValue(closure_ptr, ESHKOL_VALUE_CALLABLE);
+            }
+        }
+
         // eval as a first-class function (for (map eval sexps), etc.)
         // Generates a thunk that forwards to eshkol_eval_sret and wraps it in a closure.
         if (var_name == "eval") {
@@ -34001,6 +34025,56 @@ private:
         eshkol_debug("Created builtin predicate function: %s for predicate '%s'",
                     func_name.c_str(), pred_name.c_str());
 
+        return builtin_func;
+    }
+
+    // Create a tagged_value -> tagged_value wrapper for an ASCII character
+    // case-conversion builtin (char-upcase / char-downcase / char-foldcase)
+    // so it can be used as a first-class procedure. The body mirrors the
+    // inline codegen in codegenAST's char-upcase/char-downcase dispatch.
+    Function* createBuiltinCharFunction(const std::string& op_name) {
+        std::string func_name = "builtin_char_" + op_name;
+        for (char& c : func_name) { if (c == '-') c = '_'; }
+
+        auto existing_it = function_table.find(func_name);
+        if (existing_it != function_table.end()) {
+            return existing_it->second;
+        }
+
+        FunctionType* func_type = FunctionType::get(
+            tagged_value_type, {tagged_value_type}, false);
+        Function* builtin_func = Function::Create(
+            func_type, Function::ExternalLinkage, func_name, module.get());
+
+        IRBuilderBase::InsertPoint old_point = builder->saveIP();
+        BasicBlock* entry = BasicBlock::Create(*context, "entry", builtin_func);
+        builder->SetInsertPoint(entry);
+
+        Value* arg = &*builtin_func->arg_begin();
+        Value* ch = builder->CreateTrunc(unpackInt64FromTaggedValue(arg), int8_type);
+        Value* result;
+        if (op_name == "char-upcase") {
+            // 'a'..'z' -> subtract 32
+            Value* ge = builder->CreateICmpUGE(ch, ConstantInt::get(int8_type, 'a'));
+            Value* le = builder->CreateICmpULE(ch, ConstantInt::get(int8_type, 'z'));
+            Value* in_range = builder->CreateAnd(ge, le);
+            Value* conv = builder->CreateSub(ch, ConstantInt::get(int8_type, 32));
+            result = builder->CreateSelect(in_range, conv, ch);
+        } else {
+            // char-downcase / char-foldcase: 'A'..'Z' -> add 32 (ASCII identical)
+            Value* ge = builder->CreateICmpUGE(ch, ConstantInt::get(int8_type, 'A'));
+            Value* le = builder->CreateICmpULE(ch, ConstantInt::get(int8_type, 'Z'));
+            Value* in_range = builder->CreateAnd(ge, le);
+            Value* conv = builder->CreateAdd(ch, ConstantInt::get(int8_type, 32));
+            result = builder->CreateSelect(in_range, conv, ch);
+        }
+        builder->CreateRet(packCharToTaggedValue(builder->CreateZExt(result, int64_type)));
+
+        if (old_point.isSet()) {
+            builder->restoreIP(old_point);
+        }
+
+        registerContextFunction(func_name, builtin_func);
         return builtin_func;
     }
 

--- a/lib/backend/string_io_codegen.cpp
+++ b/lib/backend/string_io_codegen.cpp
@@ -631,8 +631,10 @@ llvm::Value* StringIOCodegen::stringToNumber(const eshkol_operations_t* op) {
         return tagged_.packNull();
     }
 
-    if (op->call_op.num_vars != 1) {
-        eshkol_warn("string->number requires exactly 1 argument");
+    // R7RS 6.2.6: (string->number string [radix]). The optional radix arg
+    // selects the base for the 2-arg form.
+    if (op->call_op.num_vars < 1 || op->call_op.num_vars > 2) {
+        eshkol_warn("string->number requires 1 or 2 arguments");
         return nullptr;
     }
 
@@ -644,11 +646,26 @@ llvm::Value* StringIOCodegen::stringToNumber(const eshkol_operations_t* op) {
     llvm::Value* ptr_int = tagged_.unpackInt64(str_arg);
     llvm::Value* str_ptr = ctx_.builder().CreateIntToPtr(ptr_int, ctx_.ptrType());
 
-    // Call eshkol_string_to_number_tagged(arena, str, result_ptr) which handles
-    // int64, bignum (for overflow), and double parsing
     llvm::Value* arena_ptr = ctx_.builder().CreateLoad(ctx_.ptrType(), ctx_.globalArena());
     llvm::Value* result_alloca = ctx_.builder().CreateAlloca(ctx_.taggedValueType());
 
+    if (op->call_op.num_vars == 2) {
+        // 2-arg form: pass the radix to the radix-aware runtime parser, which
+        // also handles #b/#o/#d/#x prefixes and rationals.
+        llvm::Value* radix_arg = codegen_ast_callback_(&op->call_op.variables[1], callback_context_);
+        if (!radix_arg) return nullptr;
+        llvm::Value* radix_i64 = tagged_.unpackInt64(radix_arg);
+
+        llvm::FunctionType* s2nr_type = llvm::FunctionType::get(ctx_.voidType(),
+            {ctx_.ptrType(), ctx_.ptrType(), ctx_.int64Type(), ctx_.ptrType()}, false);
+        llvm::FunctionCallee s2nr_fn = ctx_.module().getOrInsertFunction(
+            "eshkol_string_to_number_radix_tagged", s2nr_type);
+        ctx_.builder().CreateCall(s2nr_fn, {arena_ptr, str_ptr, radix_i64, result_alloca});
+        return ctx_.builder().CreateLoad(ctx_.taggedValueType(), result_alloca);
+    }
+
+    // 1-arg form: eshkol_string_to_number_tagged(arena, str, result_ptr) handles
+    // int64, bignum (for overflow), double, rational, and #-prefix parsing.
     llvm::FunctionType* s2n_type = llvm::FunctionType::get(ctx_.voidType(),
         {ctx_.ptrType(), ctx_.ptrType(), ctx_.ptrType()}, false);
     llvm::FunctionCallee s2n_fn = ctx_.module().getOrInsertFunction("eshkol_string_to_number_tagged", s2n_type);

--- a/lib/core/bignum.cpp
+++ b/lib/core/bignum.cpp
@@ -951,7 +951,10 @@ void eshkol_bignum_pow_tagged(arena_t* arena,
 
 /* ===== String Conversion ===== */
 
-void eshkol_string_to_number_tagged(arena_t* arena, const char* str,
+/* Parse a base-10 number (int64 / bignum / double / rational) from an
+ * already-whitespace-trimmed, prefix-stripped string. Internal helper.
+ * `start` must be non-NULL and non-empty. */
+static void eshkol_s2n_decimal(arena_t* arena, const char* start,
     eshkol_tagged_value_t* result) {
     /* R7RS: string->number returns #f if the string is not a valid number.
      * #f is represented as ESHKOL_VALUE_BOOL with data = 0. */
@@ -960,19 +963,6 @@ void eshkol_string_to_number_tagged(arena_t* arena, const char* str,
     false_val.flags = 0;
     false_val.reserved = 0;
     false_val.data.int_val = 0;
-
-    if (!str || !result) {
-        if (result) *result = false_val;
-        return;
-    }
-
-    /* Skip leading whitespace */
-    const char* start = str;
-    while (*start == ' ' || *start == '\t') start++;
-    if (*start == '\0') {
-        *result = false_val;
-        return;
-    }
 
     /* Scan for syntax markers: '/' (rational), '.', 'e'/'E' (float) */
     bool is_float = false;
@@ -1054,6 +1044,116 @@ void eshkol_string_to_number_tagged(arena_t* arena, const char* str,
 
     /* Not a valid number */
     *result = false_val;
+}
+
+/* Parse an integer (optional sign) or rational a/b in a non-decimal radix
+ * (2..36) from an already-trimmed, prefix-stripped string. R7RS: with an
+ * explicit non-decimal radix only exact integers and rationals are valid
+ * (no decimal-point / exponent floats). */
+static void eshkol_s2n_radix_int(arena_t* arena, const char* start, int radix,
+    eshkol_tagged_value_t* result) {
+    eshkol_tagged_value_t false_val = {};
+    false_val.type = ESHKOL_VALUE_BOOL;
+    false_val.flags = 0;
+    false_val.reserved = 0;
+    false_val.data.int_val = 0;
+
+    /* Locate an optional rational separator '/'. */
+    const char* slash = nullptr;
+    for (const char* q = start; *q; ++q) {
+        if (*q == '/') { slash = q; break; }
+    }
+
+    if (slash) {
+        /* Rational num/denom — both parsed in this radix. */
+        char* endptr = nullptr;
+        errno = 0;
+        long long num = strtoll(start, &endptr, radix);
+        if (endptr != slash || endptr == start || errno == ERANGE) {
+            *result = false_val;
+            return;
+        }
+        errno = 0;
+        long long denom = strtoll(slash + 1, &endptr, radix);
+        while (*endptr == ' ' || *endptr == '\t') endptr++;
+        if (endptr == slash + 1 || *endptr != '\0' || errno == ERANGE || denom == 0) {
+            *result = false_val;
+            return;
+        }
+        void* rat = eshkol_rational_create((void*)arena, (int64_t)num, (int64_t)denom);
+        if (rat) {
+            *result = eshkol_make_ptr((uint64_t)(void*)rat, ESHKOL_VALUE_HEAP_PTR);
+            result->flags = ESHKOL_VALUE_EXACT_FLAG;
+            return;
+        }
+        *result = false_val;
+        return;
+    }
+
+    /* Plain integer — MUST consume the entire string. */
+    char* endptr = nullptr;
+    errno = 0;
+    long long val = strtoll(start, &endptr, radix);
+    while (*endptr == ' ' || *endptr == '\t') endptr++;
+    if (endptr == start || *endptr != '\0' || errno == ERANGE) {
+        *result = false_val;
+        return;
+    }
+    *result = eshkol_make_int64((int64_t)val, true);
+}
+
+/* R7RS 6.2.6: (string->number string radix). Honors an explicit radix of
+ * 2/8/10/16 (any 2..36 accepted), and the #b/#o/#d/#x prefixes (which
+ * override the radix argument). Returns #f for malformed input. */
+void eshkol_string_to_number_radix_tagged(arena_t* arena, const char* str,
+    int64_t radix, eshkol_tagged_value_t* result) {
+    eshkol_tagged_value_t false_val = {};
+    false_val.type = ESHKOL_VALUE_BOOL;
+    false_val.flags = 0;
+    false_val.reserved = 0;
+    false_val.data.int_val = 0;
+
+    if (!str || !result) {
+        if (result) *result = false_val;
+        return;
+    }
+
+    /* Skip leading whitespace */
+    const char* start = str;
+    while (*start == ' ' || *start == '\t') start++;
+    if (*start == '\0') {
+        *result = false_val;
+        return;
+    }
+
+    /* Radix prefix #b/#o/#d/#x overrides the radix argument (R7RS 7.1.1). */
+    if (start[0] == '#' && start[1] != '\0') {
+        char c = (char)(start[1] | 0x20); /* lowercase */
+        if      (c == 'b') radix = 2;
+        else if (c == 'o') radix = 8;
+        else if (c == 'd') radix = 10;
+        else if (c == 'x') radix = 16;
+        else { *result = false_val; return; } /* #e/#i and unknown: unsupported here */
+        start += 2;
+        if (*start == '\0') { *result = false_val; return; }
+    }
+
+    if (radix < 2 || radix > 36) {
+        *result = false_val;
+        return;
+    }
+
+    if (radix == 10) {
+        eshkol_s2n_decimal(arena, start, result);
+    } else {
+        eshkol_s2n_radix_int(arena, start, (int)radix, result);
+    }
+}
+
+void eshkol_string_to_number_tagged(arena_t* arena, const char* str,
+    eshkol_tagged_value_t* result) {
+    /* 1-arg form: default radix 10, with #b/#o/#d/#x prefix support. */
+    eshkol_string_to_number_radix_tagged(arena, str, 10, result);
 }
 
 /* ===== Display ===== */

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -1115,6 +1115,7 @@ void ReplJITContext::registerRuntimeSymbols() {
     ADD_SYMBOL(eshkol_bignum_is_even);
     ADD_SYMBOL(eshkol_bignum_is_odd);
     ADD_SYMBOL(eshkol_string_to_number_tagged);
+    ADD_SYMBOL(eshkol_string_to_number_radix_tagged);
     ADD_SYMBOL(eshkol_rational_create);
     ADD_SYMBOL(eshkol_rational_to_double);
     ADD_SYMBOL(eshkol_rational_to_string);

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -349,6 +349,23 @@ probe pgo_pipeline_works 'cmake -DESHKOL_PGO=generate/use supports a profile-gui
      fi;
      exit 1'
 
+# ───────────────────────────────────────────────────────────────────
+# R7RS string-op edge cases (ESH-0066): string-map returns a string and
+# accepts first-class char builtins; string->number honors a radix. The
+# suite runs under BOTH -r (JIT) and AOT and must report zero failures.
+# ───────────────────────────────────────────────────────────────────
+probe string_edge_ops_r7rs 'string-map returns a string; string->number honors radix (-r + AOT)' \
+    'cd "$REPO_ROOT";
+     t="tests/string/string_edge_test.esk";
+     rout=$("$ESHKOL_RUN" -r "$t" 2>&1) || exit 1;
+     printf "%s" "$rout" | grep -qE "^FAIL:|Failed:[[:space:]]+[1-9]" && exit 1;
+     bin="/tmp/icc_string_edge.bin"; rm -f "$bin";
+     "$ESHKOL_RUN" "$t" -o "$bin" >/dev/null 2>&1 || exit 1;
+     aout=$("$bin" 2>&1) || exit 1;
+     printf "%s" "$aout" | grep -qE "^FAIL:|Failed:[[:space:]]+[1-9]" && exit 1;
+     rm -f "$bin";
+     exit 0'
+
 echo
 echo "Trace written: $TRACE_FILE"
 echo "Run: python3 ~/Desktop/infinite_context_coder/scripts/codebase_tool.py \\"

--- a/tests/string/string_edge_test.esk
+++ b/tests/string/string_edge_test.esk
@@ -1,0 +1,123 @@
+;; String Edge-Case Tests (ESH-0066)
+;; Regression coverage for two R7RS string ops fixed in this change:
+;;   (1) string-map must BUILD and RETURN a string (R7RS 6.7), and accept
+;;       a first-class char builtin such as char-upcase as its proc.
+;;   (2) string->number must honor the optional radix argument (R7RS 6.2.6)
+;;       and the #b/#o/#d/#x prefixes.
+;; Plus regression guards for the already-correct string ops.
+
+;; Test counter
+(define tests-passed 0)
+(define tests-failed 0)
+
+(define (test-case name expected actual)
+  (if (equal? expected actual)
+      (begin
+        (set! tests-passed (+ tests-passed 1))
+        (display "PASS: ") (display name) (display "\n"))
+      (begin
+        (set! tests-failed (+ tests-failed 1))
+        (display "FAIL: ") (display name)
+        (display " (expected ") (display expected)
+        (display ", got ") (display actual) (display ")\n"))))
+
+(display "=== STRING EDGE-CASE TESTS (ESH-0066) ===\n\n")
+
+;; ============================================================================
+;; Test: string-map (R7RS 6.7) — returns a string
+;; ============================================================================
+
+(display "--- string-map ---\n")
+
+;; ROOT BUG #1: char-upcase as a first-class proc; result must be "ABC".
+(test-case "string-map char-upcase" "ABC" (string-map char-upcase "abc"))
+(test-case "string-map char-downcase" "abc" (string-map char-downcase "ABC"))
+(test-case "string-map char-foldcase" "abc" (string-map char-foldcase "ABC"))
+;; identity via lambda
+(test-case "string-map identity" "hello" (string-map (lambda (c) c) "hello"))
+;; lambda wrapping a char builtin
+(test-case "string-map lambda upcase" "HELLO"
+           (string-map (lambda (c) (char-upcase c)) "hello"))
+;; empty string maps to empty string
+(test-case "string-map empty" "" (string-map char-upcase ""))
+;; result is a string (length preserved)
+(test-case "string-map length" 5 (string-length (string-map char-upcase "world")))
+
+;; char-upcase as a first-class value beyond string-map (map over a list)
+(test-case "map char-upcase list" (list #\A #\B)
+           (map char-upcase (list #\a #\b)))
+
+;; ============================================================================
+;; Test: string->number with radix (R7RS 6.2.6)
+;; ============================================================================
+
+(display "\n--- string->number radix ---\n")
+
+;; ROOT BUG #2: the 2-arg radix form was ignored.
+(test-case "s2n ff base 16" 255 (string->number "ff" 16))
+(test-case "s2n 1010 base 2" 10 (string->number "1010" 2))
+(test-case "s2n 777 base 8" 511 (string->number "777" 8))
+(test-case "s2n FF uppercase base 16" 255 (string->number "FF" 16))
+(test-case "s2n base 10 explicit" 42 (string->number "42" 10))
+;; invalid digit for radix -> #f
+(test-case "s2n z base 16 invalid" #f (string->number "z" 16))
+(test-case "s2n 2 base 2 invalid" #f (string->number "2" 2))
+(test-case "s2n empty radix" #f (string->number "" 16))
+;; negative numbers in a radix
+(test-case "s2n -ff base 16" -255 (string->number "-ff" 16))
+
+;; # prefixes (1-arg form) — radix from the literal prefix
+(test-case "s2n #xff prefix" 255 (string->number "#xff"))
+(test-case "s2n #b1010 prefix" 10 (string->number "#b1010"))
+(test-case "s2n #o777 prefix" 511 (string->number "#o777"))
+(test-case "s2n #d42 prefix" 42 (string->number "#d42"))
+
+;; ============================================================================
+;; Regression guards: already-correct string ops must be unaffected
+;; ============================================================================
+
+(display "\n--- regression guards ---\n")
+
+;; string->number 1-arg base 10 (unchanged path)
+(test-case "s2n plain int" 123 (string->number "123"))
+(test-case "s2n plain float" 3.5 (string->number "3.5"))
+(test-case "s2n not a number" #f (string->number "abc"))
+
+;; string-for-each still iterates (and is distinct from string-map)
+(define sfe-count 0)
+(string-for-each (lambda (c) (set! sfe-count (+ sfe-count 1))) "abcd")
+(test-case "string-for-each count" 4 sfe-count)
+
+;; substring: full, empty (start=end), and ordinary range
+(test-case "substring full" "hello" (substring "hello" 0 5))
+(test-case "substring empty" "" (substring "hello" 2 2))
+(test-case "substring range" "ell" (substring "hello" 1 4))
+
+;; string-ref, string-reverse, char-upcase scalar
+(test-case "string-ref" #\e (string-ref "hello" 1))
+(test-case "string-reverse" "olleh" (string-reverse "hello"))
+(test-case "char-upcase scalar" #\A (char-upcase #\a))
+
+;; number->string with radix (already correct)
+(test-case "number->string base 16" "ff" (number->string 255 16))
+(test-case "number->string base 2" "1010" (number->string 10 2))
+
+;; make-string fill + string-copy range
+(test-case "make-string fill" "aaa" (make-string 3 #\a))
+(test-case "string-copy range" "ell" (string-copy "hello" 1 4))
+
+;; round-trip: number->string then string->number with the same radix
+(test-case "radix round-trip"
+           255 (string->number (number->string 255 16) 16))
+
+;; ============================================================================
+;; Summary
+;; ============================================================================
+
+(display "\n=== Results ===\n")
+(display "Passed: ") (display tests-passed) (newline)
+(display "Failed: ") (display tests-failed) (newline)
+
+(if (= tests-failed 0)
+    (display "All tests passed!\n")
+    (display "Some tests failed!\n"))


### PR DESCRIPTION
## Summary

Fixes two real R7RS string-op gaps found by the edge-case campaign (ESH-0066):

1. **`(string-map char-upcase "abc")` returned `()` instead of `"ABC"`.**
   The `string-map` codegen already built/returned a string correctly, but
   `char-upcase` / `char-downcase` / `char-foldcase` were *inline-only*
   builtins with no first-class value form. Passing one as a procedure failed
   to resolve (`Undefined variable: char-upcase`) and the call collapsed to
   `()`. Added `createBuiltinCharFunction` (a `tagged_value -> tagged_value`
   wrapper doing ASCII case conversion, mirroring the inline codegen) plus a
   first-class dispatch block, following the existing pattern used for
   math / predicate / arithmetic builtins. This also makes
   `(map char-upcase …)` work.

2. **`(string->number "ff" 16)` returned `()` instead of `255`.**
   The optional radix form (R7RS 6.2.6) was rejected outright
   (`string->number requires exactly 1 argument`). Added
   `eshkol_string_to_number_radix_tagged` to the runtime (radix 2..36,
   integers + rationals, with `#b`/`#o`/`#d`/`#x` prefix override),
   refactored the existing decimal parser into a shared helper, routed the
   1-arg form through it (radix 10) so `#`-prefixes now work there too, and
   extended the codegen to accept the optional radix argument.

## Root cause

- Bug 1: char case-conversion ops were never registered as first-class
  values in the bare-symbol resolution path of `llvm_codegen.cpp`.
- Bug 2: `StringIOCodegen::stringToNumber` hard-required exactly one arg and
  the runtime parser was decimal-only.

Both fixes are general (no special-casing of test inputs).

## Before / after

| Expression | Before | After |
|---|---|---|
| `(string-map char-upcase "abc")` | `()` (Undefined variable) | `"ABC"` |
| `(string->number "ff" 16)` | `()` (arity warning) | `255` |
| `(string->number "1010" 2)` | `()` | `10` |
| `(string->number "777" 8)` | `()` | `511` |
| `(string->number "z" 16)` | `()` | `#f` |
| `(string->number "#xff")` | `#f`/`()` | `255` |
| `(map char-upcase (list #\a #\b))` | error | `(#\A #\B)` |

## Tests

- New `tests/string/string_edge_test.esk` — 36 cases (string-map single/
  identity/empty + first-class char builtins; string->number across radices,
  prefixes, and invalid-digit `#f`; plus regression guards for substring,
  string-ref, string-reverse, number->string-with-radix, make-string,
  string-copy range, string-for-each). **36/36 pass under both `-r` (JIT)
  and AOT.**
- Added `string_edge_ops_r7rs` ICC smoke probe gating both execution paths.
- `scripts/run_icc_smoke.sh`: all probes green except the unrelated
  pre-existing `example_agent_compiles` (its `examples/agent.esk` is untracked
  and absent from fresh worktrees).

## Files

- `lib/core/bignum.cpp`, `inc/eshkol/core/bignum.h` — radix-aware parser
- `lib/backend/string_io_codegen.cpp` — 2-arg `string->number` codegen
- `lib/backend/llvm_codegen.cpp` — first-class char builtins
- `lib/repl/repl_jit.cpp` — JIT symbol registration
- `scripts/run_icc_smoke.sh`, `tests/string/string_edge_test.esk`