### PR TITLE
fix(tensor): centralized type-checked operand unpack — no more SIGSEGV on wrong-typed tensor-op inputs (ESH-0069)

### DIFF
--- a/inc/eshkol/backend/tensor_codegen.h
+++ b/inc/eshkol/backend/tensor_codegen.h
@@ -1293,6 +1293,25 @@ private:
 
 public:
     /**
+     * Centralized, type-checked tensor-operand unpack (ESH-0069).
+     *
+     * Replaces the ad-hoc `IntToPtr(unpackInt64(v))` that every tensor op used
+     * to reinterpret its operand as an eshkol_tensor_t* without validation —
+     * which segfaulted when handed a vector/int/string. This emits a call to
+     * the runtime `eshkol_tensor_operand_checked`, which:
+     *   - returns the data pointer if the operand is already a tensor,
+     *   - coerces a homogeneous numeric vector to a fresh 1-D tensor,
+     *   - otherwise raises a clean, catchable type error (never segfaults).
+     *
+     * @param tensor_val The tagged operand value (from codegenAST).
+     * @param op_name    User-facing op name, used only for the error message.
+     * @return An i8* pointing at the validated tensor struct (eshkol_tensor_t*).
+     */
+    llvm::Value* unpackTensorOperandChecked(llvm::Value* tensor_val,
+                                            const char* op_name);
+
+public:
+    /**
      * Set callbacks for AST code generation.
      */
     void setCodegenCallbacks(

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -26042,9 +26042,22 @@ private:
             builder->CreateBr(merge_bb);
 
             // Plain tensor path (not callable)
+            // ESH-0069: route the plain (non-AD) operand through the centralized
+            // type-checked unpack so a vector/int/string raises a catchable type
+            // error (or a numeric vector is coerced) instead of segfaulting on a
+            // misread struct.
             builder->SetInsertPoint(plain_bb);
-            Value* plain_ptr_int = unpackInt64FromTaggedValue(input);
-            Value* plain_ptr = builder->CreateIntToPtr(plain_ptr_int, builder->getPtrTy());
+            Value* mm_slot = builder->CreateAlloca(tagged_value_type, nullptr, "mm_operand_slot");
+            builder->CreateStore(input, mm_slot);
+            Function* mm_chk = module->getFunction("eshkol_tensor_operand_checked");
+            if (!mm_chk) {
+                FunctionType* mm_chk_ty = FunctionType::get(
+                    builder->getPtrTy(), {builder->getPtrTy(), builder->getPtrTy()}, false);
+                mm_chk = Function::Create(mm_chk_ty, Function::ExternalLinkage,
+                                          "eshkol_tensor_operand_checked", module.get());
+            }
+            Value* mm_name = builder->CreateGlobalString("matmul", "mm_op_name");
+            Value* plain_ptr = builder->CreateCall(mm_chk, {mm_slot, mm_name});
             BasicBlock* plain_exit = builder->GetInsertBlock();
             builder->CreateBr(merge_bb);
 

--- a/lib/backend/tensor_activation_codegen.cpp
+++ b/lib/backend/tensor_activation_codegen.cpp
@@ -59,8 +59,7 @@ llvm::Value* TensorCodegen::tensorRelu(const eshkol_operations_t* op) {
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
     // Unpack tensor
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "relu");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     // Get tensor dimensions and elements
@@ -203,8 +202,7 @@ llvm::Value* TensorCodegen::tensorSigmoid(const eshkol_operations_t* op) {
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
     // Unpack tensor
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "sigmoid");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     // Get tensor dimensions and elements
@@ -581,8 +579,7 @@ llvm::Value* TensorCodegen::tensorSoftmax(const eshkol_operations_t* op) {
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
     // Unpack tensor
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "softmax");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     // Get tensor properties
@@ -902,8 +899,7 @@ llvm::Value* TensorCodegen::tensorGelu(const eshkol_operations_t* op) {
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
     // Unpack tensor
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "gelu");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     // Get tensor properties
@@ -1098,8 +1094,7 @@ llvm::Value* TensorCodegen::tensorLeakyRelu(const eshkol_operations_t* op) {
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
     // Unpack tensor
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "leaky-relu");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     // Get tensor properties
@@ -1235,8 +1230,7 @@ llvm::Value* TensorCodegen::tensorSilu(const eshkol_operations_t* op) {
     llvm::Value* arena_ptr = builder.CreateLoad(
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "silu");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* dims_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 0);
@@ -1346,8 +1340,7 @@ llvm::Value* TensorCodegen::tensorElu(const eshkol_operations_t* op) {
     llvm::Value* arena_ptr = builder.CreateLoad(
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "elu");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* dims_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 0);
@@ -1462,8 +1455,7 @@ llvm::Value* TensorCodegen::tensorSelu(const eshkol_operations_t* op) {
     llvm::Value* arena_ptr = builder.CreateLoad(
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "selu");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* dims_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 0);
@@ -1581,8 +1573,7 @@ llvm::Value* TensorCodegen::tensorMish(const eshkol_operations_t* op) {
     llvm::Value* arena_ptr = builder.CreateLoad(
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "mish");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* dims_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 0);
@@ -1711,8 +1702,7 @@ llvm::Value* TensorCodegen::tensorHardSwish(const eshkol_operations_t* op) {
     llvm::Value* arena_ptr = builder.CreateLoad(
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "hard-swish");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* dims_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 0);
@@ -1810,8 +1800,7 @@ llvm::Value* TensorCodegen::tensorHardSigmoid(const eshkol_operations_t* op) {
     llvm::Value* arena_ptr = builder.CreateLoad(
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "hard-sigmoid");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* dims_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 0);
@@ -1918,8 +1907,7 @@ llvm::Value* TensorCodegen::tensorSoftplus(const eshkol_operations_t* op) {
     llvm::Value* arena_ptr = builder.CreateLoad(
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "softplus");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* dims_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 0);
@@ -2046,8 +2034,7 @@ llvm::Value* TensorCodegen::tensorDropout(const eshkol_operations_t* op) {
     llvm::Value* arena_ptr = builder.CreateLoad(
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "dropout");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* dims_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 0);
@@ -2173,8 +2160,7 @@ llvm::Value* TensorCodegen::tensorCelu(const eshkol_operations_t* op) {
     llvm::Value* arena_ptr = builder.CreateLoad(
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "celu");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* dims_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 0);

--- a/lib/backend/tensor_codegen.cpp
+++ b/lib/backend/tensor_codegen.cpp
@@ -144,6 +144,70 @@ void TensorCodegen::attachLoopMetadata(llvm::BranchInst* backEdge,
     backEdge->setMetadata(llvm::LLVMContext::MD_loop, loopMD);
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// ESH-0069: Centralized, type-checked tensor-operand unpack.
+//
+// Single choke point that every tensor op routes its primary operand through,
+// replacing the historical `IntToPtr(unpackInt64(v))` that blindly reinterpreted
+// any operand as an eshkol_tensor_t* (segfaulting on a vector/int/string). The
+// actual validation/coercion/error logic lives in the runtime helper
+// `eshkol_tensor_operand_checked`, so there is exactly one source of truth and
+// the per-op codegen stays a single call.
+// ─────────────────────────────────────────────────────────────────────────────
+llvm::Value* TensorCodegen::unpackTensorOperandChecked(llvm::Value* tensor_val,
+                                                       const char* op_name) {
+    auto& b = ctx_.builder();
+
+    // Record the current source location so the runtime error formatter can
+    // prefix the message with "file:line:col:" (matches the arithmetic path).
+    uint32_t line = ctx_.currentSourceLine();
+    if (line != 0) {
+        llvm::Function* set_loc = ctx_.module().getFunction("eshkol_set_error_location");
+        if (!set_loc) {
+            llvm::FunctionType* ft = llvm::FunctionType::get(
+                b.getVoidTy(),
+                {ctx_.ptrType(), ctx_.int32Type(), ctx_.int32Type()},
+                false);
+            set_loc = llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
+                                             "eshkol_set_error_location", &ctx_.module());
+        }
+        const std::string& file = ctx_.currentSourceFile();
+        llvm::Value* file_str = file.empty()
+            ? static_cast<llvm::Value*>(llvm::ConstantPointerNull::get(ctx_.ptrType()))
+            : static_cast<llvm::Value*>(b.CreateGlobalString(file, "tensor_err_file"));
+        b.CreateCall(set_loc, {
+            file_str,
+            llvm::ConstantInt::get(ctx_.int32Type(), line),
+            llvm::ConstantInt::get(ctx_.int32Type(), ctx_.currentSourceColumn())});
+    }
+
+    // The operand must arrive as a 16-byte tagged value; store it to an alloca
+    // and hand the runtime helper its address (a by-value tagged-value struct
+    // zeroes across the IR→C ABI boundary).
+    if (tensor_val->getType() != ctx_.taggedValueType()) {
+        // A raw (untagged) scalar — e.g. an integer literal operand. Tag it as
+        // an INT64 (matching tensorArithmeticInternal / emitOperandTypeError);
+        // the runtime helper then reports a clean type error rather than
+        // dereferencing the value as a heap pointer. Never pack as a heap ptr:
+        // ESHKOL_GET_HEADER on a small integer would read out of bounds.
+        tensor_val = tagged_.packInt64(tensor_val, true);
+    }
+    llvm::Value* slot = b.CreateAlloca(ctx_.taggedValueType(), nullptr, "tensor_operand_slot");
+    b.CreateStore(tensor_val, slot);
+
+    llvm::Function* fn = ctx_.module().getFunction("eshkol_tensor_operand_checked");
+    if (!fn) {
+        // void* eshkol_tensor_operand_checked(const eshkol_tagged_value_t*, const char*)
+        llvm::FunctionType* ft = llvm::FunctionType::get(
+            ctx_.ptrType(), {ctx_.ptrType(), ctx_.ptrType()}, false);
+        fn = llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
+                                    "eshkol_tensor_operand_checked", &ctx_.module());
+    }
+    llvm::Value* name = b.CreateGlobalString(op_name ? op_name : "tensor-op",
+                                             "tensor_op_name");
+    return b.CreateCall(fn, {slot, name}, "tensor_ptr_checked");
+}
+
 // Note: All tensor implementations are complex and depend on:
 // - AST code generation for nested expressions
 // - Autodiff integration (dual numbers, AD nodes)
@@ -329,9 +393,8 @@ llvm::Value* TensorCodegen::tensorGet(const eshkol_operations_t* op) {
 
     const uint64_t num_indices = op->call_op.num_vars - 1;
 
-    // Extract tensor pointer
-    llvm::Value* tensor_ptr_int = tagged_.safeExtractInt64(tensor_val);
-    llvm::Value* tensor_ptr = ctx_.builder().CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    // Extract tensor pointer (type-checked: ESH-0069)
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "tensor-get");
 
     // Load tensor metadata
     llvm::StructType* tensor_type = ctx_.tensorType();
@@ -676,11 +739,9 @@ llvm::Value* TensorCodegen::tensorSet(const eshkol_operations_t* op) {
     llvm::Value* new_value = codegenAST(&op->call_op.variables[op->call_op.num_vars - 1]);
     if (!tensor_val || !new_value) return nullptr;
 
-    // Extract the tensor pointer from the tagged value
-    llvm::Value* tensor_ptr_int = tagged_.safeExtractInt64(tensor_val);
-
+    // Extract the tensor pointer from the tagged value (type-checked: ESH-0069)
     llvm::StructType* tensor_type = ctx_.tensorType();
-    llvm::Value* tensor_ptr = ctx_.builder().CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "tensor-set!");
 
     // Calculate linear index from multi-dimensional indices
     llvm::Value* linear_index = llvm::ConstantInt::get(ctx_.int64Type(), 0);
@@ -835,7 +896,7 @@ llvm::Value* TensorCodegen::tensorSet(const eshkol_operations_t* op) {
     llvm::Value* val_bits = ctx_.builder().CreateBitCast(val_double, ctx_.int64Type());
     ctx_.builder().CreateStore(val_bits, elem_ptr);
 
-    return tensor_ptr_int; // Return the tensor
+    return tagged_.packHeapPtr(tensor_ptr); // Return the (validated) tensor
 }
 
 // Shared codegen for tensor-rect-fill! / tensor-disk-fill!. Both
@@ -1116,9 +1177,8 @@ llvm::Value* TensorCodegen::tensorToVector(const eshkol_operations_t* op) {
     llvm::Value* arena_ptr = builder.CreateLoad(
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
-    // Unpack tensor
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    // Unpack tensor (type-checked: ESH-0069)
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "tensor->vector");
 
     // Get tensor fields
     llvm::Type* tensor_type = ctx_.tensorType();
@@ -1193,8 +1253,7 @@ llvm::Value* TensorCodegen::tensorVar(const eshkol_operations_t* op) {
     llvm::Value* tensor_val = codegenAST(&op->call_op.variables[0]);
     auto& builder = ctx_.builder();
 
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "tensor-var");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* elems_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 2);

--- a/lib/backend/tensor_conv_codegen.cpp
+++ b/lib/backend/tensor_conv_codegen.cpp
@@ -75,8 +75,7 @@ llvm::Value* TensorCodegen::maxPool2d(const eshkol_operations_t* op) {
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
     // Unpack input tensor
-    llvm::Value* input_ptr_int = tagged_.unpackInt64(input_val);
-    llvm::Value* input_ptr = builder.CreateIntToPtr(input_ptr_int, ctx_.ptrType());
+    llvm::Value* input_ptr = unpackTensorOperandChecked(input_val, "max-pool2d");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     // Load input tensor properties
@@ -368,8 +367,7 @@ llvm::Value* TensorCodegen::avgPool2d(const eshkol_operations_t* op) {
     llvm::Value* arena_ptr = builder.CreateLoad(
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
-    llvm::Value* input_ptr_int = tagged_.unpackInt64(input_val);
-    llvm::Value* input_ptr = builder.CreateIntToPtr(input_ptr_int, ctx_.ptrType());
+    llvm::Value* input_ptr = unpackTensorOperandChecked(input_val, "avg-pool2d");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* dims_field = builder.CreateStructGEP(tensor_type, input_ptr, 0);
@@ -645,8 +643,7 @@ llvm::Value* TensorCodegen::conv1d(const eshkol_operations_t* op) {
     llvm::Type* tensor_type = ctx_.tensorType();
 
     // Unpack input tensor
-    llvm::Value* input_ptr_int = tagged_.unpackInt64(input_val);
-    llvm::Value* input_ptr = builder.CreateIntToPtr(input_ptr_int, ctx_.ptrType());
+    llvm::Value* input_ptr = unpackTensorOperandChecked(input_val, "conv1d");
     llvm::Value* in_dims_field = builder.CreateStructGEP(tensor_type, input_ptr, 0);
     llvm::Value* in_dims = builder.CreateLoad(ctx_.ptrType(), in_dims_field);
     llvm::Value* in_ndim_field = builder.CreateStructGEP(tensor_type, input_ptr, 1);
@@ -665,8 +662,7 @@ llvm::Value* TensorCodegen::conv1d(const eshkol_operations_t* op) {
     llvm::Value* batch_size = builder.CreateSDiv(in_total, in_len);
 
     // Unpack kernel tensor (1D)
-    llvm::Value* kernel_ptr_int = tagged_.unpackInt64(kernel_val);
-    llvm::Value* kernel_ptr = builder.CreateIntToPtr(kernel_ptr_int, ctx_.ptrType());
+    llvm::Value* kernel_ptr = unpackTensorOperandChecked(kernel_val, "conv1d");
     llvm::Value* k_total_field = builder.CreateStructGEP(tensor_type, kernel_ptr, 3);
     llvm::Value* k_len = builder.CreateLoad(ctx_.int64Type(), k_total_field);
     llvm::Value* k_elems_field = builder.CreateStructGEP(tensor_type, kernel_ptr, 2);
@@ -863,8 +859,7 @@ llvm::Value* TensorCodegen::conv2d(const eshkol_operations_t* op) {
     llvm::Type* tensor_type = ctx_.tensorType();
 
     // Unpack input tensor
-    llvm::Value* input_ptr_int = tagged_.unpackInt64(input_val);
-    llvm::Value* input_ptr = builder.CreateIntToPtr(input_ptr_int, ctx_.ptrType());
+    llvm::Value* input_ptr = unpackTensorOperandChecked(input_val, "conv2d");
     llvm::Value* in_dims_field = builder.CreateStructGEP(tensor_type, input_ptr, 0);
     llvm::Value* in_dims = builder.CreateLoad(ctx_.ptrType(), in_dims_field);
     llvm::Value* in_ndim_field = builder.CreateStructGEP(tensor_type, input_ptr, 1);
@@ -886,8 +881,7 @@ llvm::Value* TensorCodegen::conv2d(const eshkol_operations_t* op) {
     llvm::Value* batch_size = builder.CreateSDiv(in_total, spatial_in);
 
     // Unpack kernel tensor (2D: kH x kW)
-    llvm::Value* kernel_ptr_int = tagged_.unpackInt64(kernel_val);
-    llvm::Value* kernel_ptr = builder.CreateIntToPtr(kernel_ptr_int, ctx_.ptrType());
+    llvm::Value* kernel_ptr = unpackTensorOperandChecked(kernel_val, "conv2d");
     llvm::Value* k_dims_field = builder.CreateStructGEP(tensor_type, kernel_ptr, 0);
     llvm::Value* k_dims = builder.CreateLoad(ctx_.ptrType(), k_dims_field);
     llvm::Value* k_ndim_field = builder.CreateStructGEP(tensor_type, kernel_ptr, 1);
@@ -1538,8 +1532,7 @@ llvm::Value* TensorCodegen::batchNorm(const eshkol_operations_t* op) {
     llvm::Type* tensor_type = ctx_.tensorType();
 
     // Unpack input tensor
-    llvm::Value* input_ptr_int = tagged_.unpackInt64(input_val);
-    llvm::Value* input_ptr = builder.CreateIntToPtr(input_ptr_int, ctx_.ptrType());
+    llvm::Value* input_ptr = unpackTensorOperandChecked(input_val, "batch-norm");
     llvm::Value* in_dims_field = builder.CreateStructGEP(tensor_type, input_ptr, 0);
     llvm::Value* in_dims = builder.CreateLoad(ctx_.ptrType(), in_dims_field);
     llvm::Value* in_ndim_field = builder.CreateStructGEP(tensor_type, input_ptr, 1);
@@ -1868,8 +1861,7 @@ llvm::Value* TensorCodegen::layerNorm(const eshkol_operations_t* op) {
     llvm::Type* tensor_type = ctx_.tensorType();
 
     // Unpack input tensor
-    llvm::Value* input_ptr_int = tagged_.unpackInt64(input_val);
-    llvm::Value* input_ptr = builder.CreateIntToPtr(input_ptr_int, ctx_.ptrType());
+    llvm::Value* input_ptr = unpackTensorOperandChecked(input_val, "layer-norm");
     llvm::Value* in_dims_field = builder.CreateStructGEP(tensor_type, input_ptr, 0);
     llvm::Value* in_dims = builder.CreateLoad(ctx_.ptrType(), in_dims_field);
     llvm::Value* in_ndim_field = builder.CreateStructGEP(tensor_type, input_ptr, 1);

--- a/lib/backend/tensor_extras_codegen.cpp
+++ b/lib/backend/tensor_extras_codegen.cpp
@@ -63,8 +63,7 @@ llvm::Value* TensorCodegen::tile(const eshkol_operations_t* op) {
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
     // Unpack input tensor
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "tile");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* dims_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 0);
@@ -208,8 +207,7 @@ llvm::Value* TensorCodegen::pad(const eshkol_operations_t* op) {
     llvm::Value* fill_bits = builder.CreateBitCast(fill_double, ctx_.int64Type());
 
     // Unpack input tensor
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "pad");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* dims_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 0);
@@ -359,8 +357,7 @@ llvm::Value* TensorCodegen::tensorMin(const eshkol_operations_t* op) {
 
     auto& builder = ctx_.builder();
 
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "tensor-min");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* elems_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 2);
@@ -485,8 +482,7 @@ llvm::Value* TensorCodegen::tensorMax(const eshkol_operations_t* op) {
 
     auto& builder = ctx_.builder();
 
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "tensor-max");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* elems_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 2);
@@ -607,8 +603,7 @@ llvm::Value* TensorCodegen::tensorArgmin(const eshkol_operations_t* op) {
         if (!axis_val) return nullptr;
         // Emit call to eshkol_xla_argreduce(arena, data, total, shape, rank, axis, is_max=0)
         auto& builder = ctx_.builder();
-        llvm::Value* ptr_int = tagged_.safeExtractInt64(tensor_val);
-        llvm::Value* ptr = builder.CreateIntToPtr(ptr_int, ctx_.ptrType());
+        llvm::Value* ptr = unpackTensorOperandChecked(tensor_val, "tensor-argmin");
         llvm::StructType* ttype = ctx_.tensorType();
         llvm::Value* elems = builder.CreateLoad(ctx_.ptrType(), builder.CreateStructGEP(ttype, ptr, 2));
         llvm::Value* total = builder.CreateLoad(ctx_.int64Type(), builder.CreateStructGEP(ttype, ptr, 3));
@@ -631,8 +626,7 @@ llvm::Value* TensorCodegen::tensorArgmin(const eshkol_operations_t* op) {
 
     auto& builder = ctx_.builder();
 
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "tensor-argmin");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* elems_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 2);
@@ -699,8 +693,7 @@ llvm::Value* TensorCodegen::tensorArgmax(const eshkol_operations_t* op) {
         llvm::Value* axis_val = codegenAST(&op->call_op.variables[1]);
         if (!axis_val) return nullptr;
         auto& builder = ctx_.builder();
-        llvm::Value* ptr_int = tagged_.safeExtractInt64(tensor_val);
-        llvm::Value* ptr = builder.CreateIntToPtr(ptr_int, ctx_.ptrType());
+        llvm::Value* ptr = unpackTensorOperandChecked(tensor_val, "tensor-argmax");
         llvm::StructType* ttype = ctx_.tensorType();
         llvm::Value* elems = builder.CreateLoad(ctx_.ptrType(), builder.CreateStructGEP(ttype, ptr, 2));
         llvm::Value* total = builder.CreateLoad(ctx_.int64Type(), builder.CreateStructGEP(ttype, ptr, 3));
@@ -723,8 +716,7 @@ llvm::Value* TensorCodegen::tensorArgmax(const eshkol_operations_t* op) {
 
     auto& builder = ctx_.builder();
 
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "tensor-argmax");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* elems_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 2);
@@ -791,8 +783,7 @@ llvm::Value* TensorCodegen::tensorCov(const eshkol_operations_t* op) {
     auto& builder = ctx_.builder();
 
     // Unpack x tensor
-    llvm::Value* x_ptr_int = tagged_.unpackInt64(x_val);
-    llvm::Value* x_ptr = builder.CreateIntToPtr(x_ptr_int, ctx_.ptrType());
+    llvm::Value* x_ptr = unpackTensorOperandChecked(x_val, "tensor-cov");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* x_elems_field = builder.CreateStructGEP(tensor_type, x_ptr, 2);
@@ -801,8 +792,7 @@ llvm::Value* TensorCodegen::tensorCov(const eshkol_operations_t* op) {
     llvm::Value* x_total = builder.CreateLoad(ctx_.int64Type(), x_total_field);
 
     // Unpack y tensor
-    llvm::Value* y_ptr_int = tagged_.unpackInt64(y_val);
-    llvm::Value* y_ptr = builder.CreateIntToPtr(y_ptr_int, ctx_.ptrType());
+    llvm::Value* y_ptr = unpackTensorOperandChecked(y_val, "tensor-cov");
 
     llvm::Value* y_elems_field = builder.CreateStructGEP(tensor_type, y_ptr, 2);
     llvm::Value* y_elems = builder.CreateLoad(ctx_.ptrType(), y_elems_field);
@@ -899,8 +889,7 @@ llvm::Value* TensorCodegen::tensorCorrcoef(const eshkol_operations_t* op) {
     auto& builder = ctx_.builder();
 
     // Unpack x tensor
-    llvm::Value* x_ptr_int = tagged_.unpackInt64(x_val);
-    llvm::Value* x_ptr = builder.CreateIntToPtr(x_ptr_int, ctx_.ptrType());
+    llvm::Value* x_ptr = unpackTensorOperandChecked(x_val, "tensor-corrcoef");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* x_elems_field = builder.CreateStructGEP(tensor_type, x_ptr, 2);
@@ -909,8 +898,7 @@ llvm::Value* TensorCodegen::tensorCorrcoef(const eshkol_operations_t* op) {
     llvm::Value* x_total = builder.CreateLoad(ctx_.int64Type(), x_total_field);
 
     // Unpack y tensor
-    llvm::Value* y_ptr_int = tagged_.unpackInt64(y_val);
-    llvm::Value* y_ptr = builder.CreateIntToPtr(y_ptr_int, ctx_.ptrType());
+    llvm::Value* y_ptr = unpackTensorOperandChecked(y_val, "tensor-corrcoef");
 
     llvm::Value* y_elems_field = builder.CreateStructGEP(tensor_type, y_ptr, 2);
     llvm::Value* y_elems = builder.CreateLoad(ctx_.ptrType(), y_elems_field);
@@ -1046,8 +1034,7 @@ llvm::Value* TensorCodegen::conv3d(const eshkol_operations_t* op) {
     }
 
     // Unpack input tensor
-    llvm::Value* input_ptr_int = tagged_.unpackInt64(input_val);
-    llvm::Value* input_ptr = builder.CreateIntToPtr(input_ptr_int, ctx_.ptrType());
+    llvm::Value* input_ptr = unpackTensorOperandChecked(input_val, "conv3d");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* in_dims_field = builder.CreateStructGEP(tensor_type, input_ptr, 0);
@@ -1058,8 +1045,7 @@ llvm::Value* TensorCodegen::conv3d(const eshkol_operations_t* op) {
     llvm::Value* in_elems = builder.CreateLoad(ctx_.ptrType(), in_elems_field);
 
     // Unpack kernel tensor
-    llvm::Value* kernel_ptr_int = tagged_.unpackInt64(kernel_val);
-    llvm::Value* kernel_ptr = builder.CreateIntToPtr(kernel_ptr_int, ctx_.ptrType());
+    llvm::Value* kernel_ptr = unpackTensorOperandChecked(kernel_val, "conv3d");
 
     llvm::Value* k_dims_field = builder.CreateStructGEP(tensor_type, kernel_ptr, 0);
     llvm::Value* k_dims_ptr = builder.CreateLoad(ctx_.ptrType(), k_dims_field);
@@ -1430,8 +1416,7 @@ llvm::Value* TensorCodegen::emitTensorUnaryOp(llvm::Value* tensor_val,
     llvm::Value* arena_ptr = builder.CreateLoad(
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr     = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr     = unpackTensorOperandChecked(tensor_val, op_name.c_str());
     llvm::Type*  tensor_type    = ctx_.tensorType();
 
     // Load shape metadata
@@ -1666,8 +1651,7 @@ llvm::Value* TensorCodegen::tensorScale(const eshkol_operations_t* op) {
     llvm::Value* arena_ptr = builder.CreateLoad(
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr     = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "tensor-scale");
     llvm::Type*  tensor_type    = ctx_.tensorType();
 
     // Load shape metadata
@@ -1839,9 +1823,9 @@ llvm::Value* TensorCodegen::batchMatmul(const eshkol_operations_t* op) {
     llvm::Value* arena_ptr = builder.CreateLoad(
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
-    // Unpack tensor pointers
-    llvm::Value* a_ptr = builder.CreateIntToPtr(tagged_.unpackInt64(a_val), ctx_.ptrType());
-    llvm::Value* b_ptr = builder.CreateIntToPtr(tagged_.unpackInt64(b_val), ctx_.ptrType());
+    // Unpack tensor pointers (type-checked: ESH-0069)
+    llvm::Value* a_ptr = unpackTensorOperandChecked(a_val, "batch-matmul");
+    llvm::Value* b_ptr = unpackTensorOperandChecked(b_val, "batch-matmul");
     llvm::Type*  tt    = ctx_.tensorType();
 
     // Load A dims: [batch, M, K]

--- a/lib/backend/tensor_reduce_codegen.cpp
+++ b/lib/backend/tensor_reduce_codegen.cpp
@@ -325,6 +325,19 @@ llvm::Value* TensorCodegen::tensorArithmeticInternal(llvm::Value* arg1, llvm::Va
     // === TENSOR PATH ===
     ctx_.builder().SetInsertPoint(tensor_path);
 
+    // ESH-0069: validate/coerce both operands ONCE here so every downstream
+    // path (XLA, SIMD, scalar) receives a genuine tensor. A non-tensor,
+    // non-numeric-vector operand raises a catchable type error instead of
+    // segfaulting when rawTensorArithmetic* reinterprets it as a struct; a
+    // homogeneous numeric vector is coerced to a 1-D tensor.
+    {
+        std::string arith_name = "tensor-" + operation;
+        llvm::Value* a1_ptr = unpackTensorOperandChecked(arg1, arith_name.c_str());
+        llvm::Value* a2_ptr = unpackTensorOperandChecked(arg2, arith_name.c_str());
+        arg1 = tagged_.packHeapPtr(a1_ptr);
+        arg2 = tagged_.packHeapPtr(a2_ptr);
+    }
+
 #ifdef ESHKOL_XLA_ENABLED
     // ===== XLA DISPATCH FOR LARGE TENSORS =====
     // Dispatch hierarchy: XLA (≥100K elements) → SIMD → scalar
@@ -481,10 +494,8 @@ llvm::Value* TensorCodegen::tensorDot(const eshkol_operations_t* op) {
 
     // === TENSOR PATH ===
     ctx_.builder().SetInsertPoint(tensor_block);
-    llvm::Value* tensor_a_ptr_int = tagged_.unpackInt64(val_a);
-    llvm::Value* tensor_a_ptr = ctx_.builder().CreateIntToPtr(tensor_a_ptr_int, ctx_.ptrType());
-    llvm::Value* tensor_b_ptr_int = tagged_.unpackInt64(val_b);
-    llvm::Value* tensor_b_ptr = ctx_.builder().CreateIntToPtr(tensor_b_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_a_ptr = unpackTensorOperandChecked(val_a, "tensor-dot");
+    llvm::Value* tensor_b_ptr = unpackTensorOperandChecked(val_b, "tensor-dot");
 
     llvm::StructType* tensor_type = ctx_.tensorType();
 
@@ -1068,9 +1079,6 @@ llvm::Value* TensorCodegen::tensorApply(const eshkol_operations_t* op) {
     llvm::Value* tensor_val = codegenAST(&op->call_op.variables[0]);
     if (!tensor_val) return nullptr;
 
-    // Extract the tensor pointer from the tagged value
-    llvm::Value* tensor_ptr_int = tagged_.safeExtractInt64(tensor_val);
-
     // Get function to apply — supports named arithmetic/math functions
     eshkol_ast_t* func_ast = &op->call_op.variables[1];
     if (func_ast->type != ESHKOL_VAR) {
@@ -1081,7 +1089,7 @@ llvm::Value* TensorCodegen::tensorApply(const eshkol_operations_t* op) {
     std::string func_name = func_ast->variable.id;
 
     llvm::StructType* tensor_type = ctx_.tensorType();
-    llvm::Value* tensor_ptr = ctx_.builder().CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "tensor-apply");
 
     // Create result tensor with same dimensions using arena
     llvm::Value* apply_arena_ptr = ctx_.builder().CreateLoad(
@@ -1281,8 +1289,7 @@ llvm::Value* TensorCodegen::tensorReduceAll(const eshkol_operations_t* op) {
 
     // === TENSOR PATH ===
     ctx_.builder().SetInsertPoint(tensor_block);
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(src_val);
-    llvm::Value* tensor_ptr = ctx_.builder().CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(src_val, "tensor-reduce-all");
 
     llvm::StructType* tensor_type = ctx_.tensorType();
     llvm::Value* elements_field_ptr = ctx_.builder().CreateStructGEP(tensor_type, tensor_ptr, 2);
@@ -1438,9 +1445,8 @@ llvm::Value* TensorCodegen::tensorReduceWithDim(const eshkol_operations_t* op) {
         op_code = 0;
     }
 
-    // Extract tensor pointer
-    llvm::Value* tensor_ptr_int = tagged_.safeExtractInt64(tensor_val);
-    llvm::Value* tensor_ptr = ctx_.builder().CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    // Extract tensor pointer (type-checked: ESH-0069)
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "tensor-reduce");
 
     llvm::StructType* tensor_type = ctx_.tensorType();
 
@@ -1488,8 +1494,7 @@ llvm::Value* TensorCodegen::emitAxisReduce(llvm::Value* tensor_val, llvm::Value*
     // Returns a tagged tensor pointer (reduced along the given axis).
     auto& builder = ctx_.builder();
 
-    llvm::Value* tensor_ptr_int = tagged_.safeExtractInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "tensor-reduce-axis");
     llvm::StructType* tensor_type = ctx_.tensorType();
 
     // Extract tensor fields
@@ -1776,8 +1781,7 @@ llvm::Value* TensorCodegen::tensorSum(const eshkol_operations_t* op) {
 
     // === TENSOR PATH ===
     ctx_.builder().SetInsertPoint(tensor_block);
-    llvm::Value* src_ptr_int = tagged_.unpackInt64(src_val);
-    llvm::Value* src_ptr = ctx_.builder().CreateIntToPtr(src_ptr_int, ctx_.ptrType());
+    llvm::Value* src_ptr = unpackTensorOperandChecked(src_val, "tensor-sum");
 
     llvm::Value* src_elements_field_ptr = ctx_.builder().CreateStructGEP(tensor_type, src_ptr, 2);
     llvm::Value* src_elements_ptr = ctx_.builder().CreateLoad(ctx_.ptrType(), src_elements_field_ptr);
@@ -2055,8 +2059,7 @@ llvm::Value* TensorCodegen::tensorMean(const eshkol_operations_t* op) {
 
     // === TENSOR PATH ===
     ctx_.builder().SetInsertPoint(tensor_block);
-    llvm::Value* src_ptr_int = tagged_.unpackInt64(src_val);
-    llvm::Value* src_ptr = ctx_.builder().CreateIntToPtr(src_ptr_int, ctx_.ptrType());
+    llvm::Value* src_ptr = unpackTensorOperandChecked(src_val, "tensor-mean");
 
     llvm::Value* src_elements_field_ptr = ctx_.builder().CreateStructGEP(tensor_type, src_ptr, 2);
     llvm::Value* src_elements_ptr = ctx_.builder().CreateLoad(ctx_.ptrType(), src_elements_field_ptr);

--- a/lib/backend/tensor_shape_codegen.cpp
+++ b/lib/backend/tensor_shape_codegen.cpp
@@ -61,8 +61,7 @@ llvm::Value* TensorCodegen::squeeze(const eshkol_operations_t* op) {
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
     // Unpack input tensor
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "squeeze");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     // Load tensor properties
@@ -215,8 +214,7 @@ llvm::Value* TensorCodegen::unsqueeze(const eshkol_operations_t* op) {
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
     // Unpack input tensor
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "unsqueeze");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     // Load tensor properties
@@ -331,8 +329,7 @@ llvm::Value* TensorCodegen::flatten(const eshkol_operations_t* op) {
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
     // Unpack input tensor
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "flatten");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     // Load tensor properties
@@ -398,8 +395,7 @@ llvm::Value* TensorCodegen::concatenate(const eshkol_operations_t* op) {
     llvm::Value* first_tensor = codegenAST(&op->call_op.variables[1]);
     if (!first_tensor) return nullptr;
 
-    llvm::Value* first_ptr_int = tagged_.unpackInt64(first_tensor);
-    llvm::Value* first_ptr = builder.CreateIntToPtr(first_ptr_int, ctx_.ptrType());
+    llvm::Value* first_ptr = unpackTensorOperandChecked(first_tensor, "concatenate");
 
     llvm::Value* first_dims_field = builder.CreateStructGEP(tensor_type, first_ptr, 0);
     llvm::Value* first_dims_ptr = builder.CreateLoad(ctx_.ptrType(), first_dims_field);
@@ -418,8 +414,7 @@ llvm::Value* TensorCodegen::concatenate(const eshkol_operations_t* op) {
     for (size_t i = 1; i < op->call_op.num_vars; ++i) {
         llvm::Value* t = codegenAST(&op->call_op.variables[i]);
         if (!t) return nullptr;
-        llvm::Value* t_ptr_int = tagged_.unpackInt64(t);
-        llvm::Value* t_ptr = builder.CreateIntToPtr(t_ptr_int, ctx_.ptrType());
+        llvm::Value* t_ptr = unpackTensorOperandChecked(t, "concatenate");
         tensor_ptrs.push_back(t_ptr);
 
         // Add this tensor's dimension along axis
@@ -626,8 +621,7 @@ llvm::Value* TensorCodegen::stack(const eshkol_operations_t* op) {
     llvm::Value* first_tensor = codegenAST(&op->call_op.variables[1]);
     if (!first_tensor) return nullptr;
 
-    llvm::Value* first_ptr_int = tagged_.unpackInt64(first_tensor);
-    llvm::Value* first_ptr = builder.CreateIntToPtr(first_ptr_int, ctx_.ptrType());
+    llvm::Value* first_ptr = unpackTensorOperandChecked(first_tensor, "stack");
 
     llvm::Value* first_dims_field = builder.CreateStructGEP(tensor_type, first_ptr, 0);
     llvm::Value* first_dims_ptr = builder.CreateLoad(ctx_.ptrType(), first_dims_field);
@@ -714,8 +708,7 @@ llvm::Value* TensorCodegen::stack(const eshkol_operations_t* op) {
     for (size_t i = 1; i < op->call_op.num_vars; ++i) {
         llvm::Value* t = codegenAST(&op->call_op.variables[i]);
         if (!t) return nullptr;
-        llvm::Value* t_ptr_int = tagged_.unpackInt64(t);
-        llvm::Value* t_ptr = builder.CreateIntToPtr(t_ptr_int, ctx_.ptrType());
+        llvm::Value* t_ptr = unpackTensorOperandChecked(t, "stack");
 
         llvm::Value* t_elems_field = builder.CreateStructGEP(tensor_type, t_ptr, 2);
         llvm::Value* t_elems = builder.CreateLoad(ctx_.ptrType(), t_elems_field);
@@ -783,8 +776,7 @@ llvm::Value* TensorCodegen::split(const eshkol_operations_t* op) {
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
     // Unpack input tensor
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "split");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* dims_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 0);
@@ -982,8 +974,7 @@ llvm::Value* TensorCodegen::slice(const eshkol_operations_t* op) {
         llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
 
     // Unpack input tensor
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(tensor_val);
-    llvm::Value* tensor_ptr = builder.CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "slice");
     llvm::Type* tensor_type = ctx_.tensorType();
 
     llvm::Value* elems_field = builder.CreateStructGEP(tensor_type, tensor_ptr, 2);
@@ -1025,16 +1016,11 @@ llvm::Value* TensorCodegen::tensorShape(const eshkol_operations_t* op) {
         return nullptr;
     }
 
-    llvm::Value* tensor_ptr_int = codegenAST(&op->call_op.variables[0]);
-    if (!tensor_ptr_int) return nullptr;
-
-    // Extract the raw pointer value if it's a tagged value
-    if (tensor_ptr_int->getType() == ctx_.taggedValueType()) {
-        tensor_ptr_int = tagged_.unpackInt64(tensor_ptr_int);
-    }
+    llvm::Value* tensor_val = codegenAST(&op->call_op.variables[0]);
+    if (!tensor_val) return nullptr;
 
     llvm::StructType* tensor_type = ctx_.tensorType();
-    llvm::Value* tensor_ptr = ctx_.builder().CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(tensor_val, "tensor-shape");
 
     // Load num_dimensions
     llvm::Value* num_dims_field_ptr = ctx_.builder().CreateStructGEP(tensor_type, tensor_ptr, 1);
@@ -1152,12 +1138,7 @@ llvm::Value* TensorCodegen::tensorLength(const eshkol_operations_t* op) {
     llvm::Value* arg = codegenAST(&op->call_op.variables[0]);
     if (!arg) return nullptr;
 
-    // Extract raw pointer from tagged value
-    if (arg->getType() == ctx_.taggedValueType()) {
-        arg = tagged_.unpackInt64(arg);
-    }
-
-    llvm::Value* tensor_ptr = ctx_.builder().CreateIntToPtr(arg, ctx_.ptrType());
+    llvm::Value* tensor_ptr = unpackTensorOperandChecked(arg, "tensor-length");
 
     // Field 3 of tensor struct is total_elements (int64)
     llvm::Value* total_field = ctx_.builder().CreateStructGEP(ctx_.tensorType(), tensor_ptr, 3);
@@ -1178,8 +1159,11 @@ llvm::Value* TensorCodegen::transpose(const eshkol_operations_t* op) {
 
     llvm::StructType* tensor_type = ctx_.tensorType();
 
-    // Check type - transpose only works with native tensors, not Scheme vectors
-    llvm::Value* is_tensor = tagged_.isTensor(src_tensor);
+    // ESH-0069: validate/coerce the operand up front. A non-tensor now raises a
+    // catchable type error (a homogeneous numeric vector is coerced) instead of
+    // the legacy behavior of silently returning null via the error_block below.
+    llvm::Value* src_ptr = unpackTensorOperandChecked(src_tensor, "transpose");
+    llvm::Value* is_tensor = llvm::ConstantInt::getTrue(ctx_.context());
 
     llvm::Function* current_func = ctx_.builder().GetInsertBlock()->getParent();
     llvm::BasicBlock* tensor_block = llvm::BasicBlock::Create(ctx_.context(), "transpose_tensor", current_func);
@@ -1197,10 +1181,8 @@ llvm::Value* TensorCodegen::transpose(const eshkol_operations_t* op) {
     ctx_.builder().CreateStore(error_result, result_alloca);
     ctx_.builder().CreateBr(exit_block);
 
-    // Tensor path - proceed with normal transpose
+    // Tensor path - proceed with normal transpose (src_ptr validated above)
     ctx_.builder().SetInsertPoint(tensor_block);
-    llvm::Value* ptr_int = tagged_.unpackInt64(src_tensor);
-    llvm::Value* src_ptr = ctx_.builder().CreateIntToPtr(ptr_int, ctx_.ptrType());
 
     // Get source tensor properties
     llvm::Value* src_dims_field_ptr = ctx_.builder().CreateStructGEP(tensor_type, src_ptr, 0);
@@ -1475,8 +1457,7 @@ llvm::Value* TensorCodegen::reshape(const eshkol_operations_t* op) {
 
     // === TENSOR PATH: Use existing tensor directly ===
     ctx_.builder().SetInsertPoint(tensor_block);
-    llvm::Value* tensor_ptr_int = tagged_.unpackInt64(src_val);
-    llvm::Value* direct_tensor_ptr = ctx_.builder().CreateIntToPtr(tensor_ptr_int, ctx_.ptrType());
+    llvm::Value* direct_tensor_ptr = unpackTensorOperandChecked(src_val, "reshape");
     ctx_.builder().CreateBr(type_merge);
     llvm::BasicBlock* tensor_exit_block = ctx_.builder().GetInsertBlock();
 

--- a/lib/core/runtime_tensor_alloc.cpp
+++ b/lib/core/runtime_tensor_alloc.cpp
@@ -15,6 +15,92 @@
 
 extern "C" {
 
+/* Raise a catchable type error reporting the operand's actual runtime type.
+ * Declared here (rather than including runtime.h) to keep this freestanding-
+ * adjacent translation unit's include surface small. ABI-stable symbol. */
+void eshkol_type_error_with_operand(const char* proc_name,
+                                    const char* expected_type,
+                                    const eshkol_tagged_value_t* actual);
+
+/*
+ * Centralized, type-checked tensor-operand unpack (ESH-0069).
+ *
+ * Every tensor op (activations, conv/pool, reductions, shape ops, …) must route
+ * its primary tensor operand through this single helper instead of blindly
+ * reinterpreting the operand pointer as an eshkol_tensor_t*. Behavior:
+ *
+ *   (a) operand is already a tensor (HEAP_SUBTYPE_TENSOR or legacy TENSOR_PTR)
+ *       -> return its data pointer unchanged (zero-copy, hot path).
+ *   (b) operand is a homogeneous numeric vector (HEAP_SUBTYPE_VECTOR whose every
+ *       element is an int64 or double) -> coerce to a fresh 1-D tensor.
+ *   (c) anything else (int, string, bool, null, pair, non-numeric/heterogeneous
+ *       vector, …) -> raise a clean, catchable type error via
+ *       eshkol_type_error_with_operand and never touch the struct.
+ *
+ * This makes it structurally impossible for a tensor op to segfault on a
+ * wrong-typed operand: it either gets a valid tensor or the program sees a
+ * catchable condition. `op_name` is used only for the error message.
+ *
+ * Returns the eshkol_tensor_t* (as void*) on success; on the error path it does
+ * not return (the type error raises). The trailing `return nullptr` keeps the
+ * compiler happy and is never reached.
+ */
+void* eshkol_tensor_operand_checked(const eshkol_tagged_value_t* val,
+                                    const char* op_name) {
+    if (val) {
+        /* Consolidated HEAP_PTR form: dispatch on the object-header subtype. */
+        if (val->type == ESHKOL_VALUE_HEAP_PTR && val->data.ptr_val) {
+            void* ptr = (void*)(uintptr_t)val->data.ptr_val;
+            const eshkol_object_header_t* hdr = ESHKOL_GET_HEADER(ptr);
+            if (hdr) {
+                if (hdr->subtype == HEAP_SUBTYPE_TENSOR) {
+                    return ptr;  /* already a tensor — zero-copy fast path */
+                }
+                if (hdr->subtype == HEAP_SUBTYPE_VECTOR) {
+                    /* Coerce a *homogeneous numeric* vector to a 1-D tensor.
+                     * Layout: [len:i64][eshkol_tagged_value_t elems...]. */
+                    char* v = (char*)ptr;
+                    int64_t len = *(int64_t*)v;
+                    if (len < 0) len = 0;
+                    const eshkol_tagged_value_t* elems =
+                        (const eshkol_tagged_value_t*)(v + sizeof(int64_t));
+                    for (int64_t i = 0; i < len; i++) {
+                        uint8_t bt = (uint8_t)(elems[i].type & 0x0F);
+                        if (bt != ESHKOL_VALUE_INT64 && bt != ESHKOL_VALUE_DOUBLE) {
+                            /* heterogeneous / non-numeric vector — not coercible */
+                            eshkol_type_error_with_operand(
+                                op_name, "tensor or numeric vector", val);
+                            return nullptr;  /* not reached */
+                        }
+                    }
+                    arena_t* arena = get_global_arena();
+                    eshkol_tensor_t* t =
+                        arena_allocate_tensor_full(arena, 1, (uint64_t)len);
+                    if (!t) return nullptr;
+                    if (t->dimensions) t->dimensions[0] = (uint64_t)len;
+                    for (int64_t i = 0; i < len; i++) {
+                        const eshkol_tagged_value_t* e = &elems[i];
+                        double d = ((e->type & 0x0F) == ESHKOL_VALUE_DOUBLE)
+                                       ? e->data.double_val
+                                       : (double)e->data.int_val;
+                        std::memcpy(&t->elements[i], &d, sizeof(double));
+                    }
+                    return t;
+                }
+            }
+        }
+        /* Legacy direct TENSOR_PTR type tag. */
+        if (val->type == ESHKOL_VALUE_TENSOR_PTR && val->data.ptr_val) {
+            return (void*)(uintptr_t)val->data.ptr_val;
+        }
+    }
+
+    /* Not a tensor and not a coercible numeric vector: clean, catchable error
+     * instead of a segfault from misreading the struct. */
+    eshkol_type_error_with_operand(op_name, "tensor", val);
+    return nullptr;  /* not reached (type error raises) */
+}
+
 eshkol_tensor_t* arena_allocate_tensor_with_header(arena_t* arena) {
     if (!arena) {
         eshkol_error("Invalid arena for tensor allocation");

--- a/site/static/eshkol-runtime.js
+++ b/site/static/eshkol-runtime.js
@@ -330,6 +330,7 @@ class EshkolRuntime {
                 eshkol_tensor_result_dtype_binary: (r) => r,
                 eshkol_tensor_result_dtype_unary: (r) => r,
                 eshkol_type_error_with_operand: () => { throw new Error('Eshkol type error (WASM stub)'); },
+                eshkol_tensor_operand_checked: () => 0,
                 eshkol_set_error_location: () => {},
                 eshkol_lambda_registry_init: () => {},
                 eshkol_lambda_registry_add: () => {},

--- a/tests/ml/tensor_type_guard_test.esk
+++ b/tests/ml/tensor_type_guard_test.esk
@@ -1,0 +1,113 @@
+;; ESH-0069 — Tensor-op type-safety guard regression suite.
+;;
+;; Every tensor op routes its primary operand through the centralized
+;; TensorCodegen::unpackTensorOperandChecked helper (runtime:
+;; eshkol_tensor_operand_checked). That helper:
+;;   - returns the data pointer for a genuine tensor (zero-copy),
+;;   - coerces a homogeneous numeric vector to a 1-D tensor,
+;;   - otherwise raises a CATCHABLE type error (eshkol_type_error_with_operand)
+;;     instead of misreading the struct and SIGSEGV-ing.
+;;
+;; Before this fix, (softmax (vector 1.0 2.0 3.0)) and (softmax "x") segfaulted.
+;; This suite asserts: (a) wrong-typed operands raise a guardable error and do
+;; NOT crash, (b) homogeneous numeric vectors coerce, (c) valid tensors still
+;; compute correctly. Runs under both -r (JIT) and AOT.
+
+(require stdlib)
+
+(display "=== ESH-0069 Tensor Type-Guard Suite ===") (newline)
+
+(define pass-count 0)
+(define fail-count 0)
+
+(define (check name cond)
+  (if cond
+      (begin (set! pass-count (+ pass-count 1))
+             (display "PASS: ") (display name) (newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "FAIL: ") (display name) (newline))))
+
+;; Valid tensors used throughout.
+(define t4 (reshape (vector 1.0 2.0 3.0 4.0) 4))      ; 1-D, 4 elements
+(define m22 (reshape (vector 1.0 2.0 3.0 4.0) 2 2))   ; 2-D, 2x2
+
+;; ---------------------------------------------------------------------------
+;; (1) VALID tensor inputs still produce correct results
+;; ---------------------------------------------------------------------------
+(check "valid: tensor-length t4 = 4"        (= (tensor-length t4) 4))
+(check "valid: tensor-sum t4 = 10"          (= (tensor-sum t4) 10.0))
+(check "valid: relu returns a tensor"       (tensor? (relu t4)))
+(check "valid: softmax returns a tensor"    (tensor? (softmax t4)))
+(check "valid: sigmoid returns a tensor"    (tensor? (sigmoid t4)))
+(check "valid: gelu returns a tensor"       (tensor? (gelu t4)))
+(check "valid: transpose returns a tensor"  (tensor? (transpose m22)))
+(check "valid: flatten returns a tensor"    (tensor? (flatten m22)))
+(check "valid: matmul returns a tensor"     (tensor? (matmul m22 m22)))
+
+;; ---------------------------------------------------------------------------
+;; (2) Homogeneous numeric vectors are coerced (no crash, correct shape)
+;; ---------------------------------------------------------------------------
+(check "coerce: softmax (vector ...) -> tensor"  (tensor? (softmax (vector 1.0 2.0 3.0))))
+(check "coerce: relu (vector ...) -> tensor"     (tensor? (relu (vector -1.0 2.0 -3.0))))
+(check "coerce: tensor-length (vector 1 2 3)=3"  (= (tensor-length (vector 1.0 2.0 3.0)) 3))
+
+;; ---------------------------------------------------------------------------
+;; (3) Non-tensor operands raise a CATCHABLE type error (NOT a segfault).
+;;     guard returns #t when the body raised; #f when it completed normally.
+;; ---------------------------------------------------------------------------
+;; Activation family (unary)
+(check "reject: relu on string"          (guard (exn (#t #t)) (relu "x") #f))
+(check "reject: sigmoid on string"       (guard (exn (#t #t)) (sigmoid "x") #f))
+(check "reject: softmax on string"       (guard (exn (#t #t)) (softmax "x") #f))
+(check "reject: softmax on int"          (guard (exn (#t #t)) (softmax 5) #f))
+(check "reject: gelu on string"          (guard (exn (#t #t)) (gelu "x") #f))
+(check "reject: leaky-relu on string"    (guard (exn (#t #t)) (leaky-relu "x") #f))
+(check "reject: silu on string"          (guard (exn (#t #t)) (silu "x") #f))
+(check "reject: elu on string"           (guard (exn (#t #t)) (elu "x") #f))
+(check "reject: selu on string"          (guard (exn (#t #t)) (selu "x") #f))
+(check "reject: mish on string"          (guard (exn (#t #t)) (mish "x") #f))
+(check "reject: softplus on string"      (guard (exn (#t #t)) (softplus "x") #f))
+(check "reject: gelu on non-numeric vec" (guard (exn (#t #t)) (gelu (vector "a" "b")) #f))
+
+;; Reductions / statistics
+(check "reject: tensor-sum on string"    (guard (exn (#t #t)) (tensor-sum "x") #f))
+(check "reject: tensor-mean on string"   (guard (exn (#t #t)) (tensor-mean "x") #f))
+(check "reject: tensor-min on string"    (guard (exn (#t #t)) (tensor-min "x") #f))
+(check "reject: tensor-max on string"    (guard (exn (#t #t)) (tensor-max "x") #f))
+(check "reject: tensor-argmin on string" (guard (exn (#t #t)) (tensor-argmin "x") #f))
+(check "reject: tensor-argmax on string" (guard (exn (#t #t)) (tensor-argmax "x") #f))
+(check "reject: tensor-var on string"    (guard (exn (#t #t)) (tensor-var "x") #f))
+(check "reject: tensor-std on string"    (guard (exn (#t #t)) (tensor-std "x") #f))
+
+;; Shape ops
+(check "reject: transpose on string"     (guard (exn (#t #t)) (transpose "x") #f))
+(check "reject: flatten on string"       (guard (exn (#t #t)) (flatten "x") #f))
+(check "reject: squeeze on string"       (guard (exn (#t #t)) (squeeze "x") #f))
+(check "reject: reshape on string"       (guard (exn (#t #t)) (reshape "x" 2) #f))
+(check "reject: tensor-shape on string"  (guard (exn (#t #t)) (tensor-shape "x") #f))
+(check "reject: tensor-length on string" (guard (exn (#t #t)) (tensor-length "x") #f))
+
+;; Convolution / pooling / normalization (string in the input position)
+(check "reject: max-pool2d on string"    (guard (exn (#t #t)) (max-pool2d "x" 2 2) #f))
+(check "reject: avg-pool2d on string"    (guard (exn (#t #t)) (avg-pool2d "x" 2 2) #f))
+(check "reject: conv1d on string"        (guard (exn (#t #t)) (conv1d "x" "y" 1) #f))
+(check "reject: conv2d on string"        (guard (exn (#t #t)) (conv2d "x" "y" 1) #f))
+
+;; Linear algebra / binary / access
+(check "reject: matmul lhs string"       (guard (exn (#t #t)) (matmul "x" m22) #f))
+(check "reject: matmul rhs string"       (guard (exn (#t #t)) (matmul m22 "x") #f))
+(check "reject: tensor-dot string"       (guard (exn (#t #t)) (tensor-dot "x" t4) #f))
+(check "reject: tensor-add string"       (guard (exn (#t #t)) (tensor-add "x" t4) #f))
+(check "reject: tensor-scale string"     (guard (exn (#t #t)) (tensor-scale "x" 2.0) #f))
+(check "reject: tensor-get string"       (guard (exn (#t #t)) (tensor-get "x" 0) #f))
+(check "reject: tensor->vector string"   (guard (exn (#t #t)) (tensor->vector "x") #f))
+
+;; ---------------------------------------------------------------------------
+;; Summary
+;; ---------------------------------------------------------------------------
+(newline)
+(display "Passed: ") (display pass-count) (newline)
+(display "Failed: ") (display fail-count) (newline)
+(if (= fail-count 0)
+    (begin (display "ALL TESTS PASSED") (newline))
+    (begin (display "SOME TESTS FAILED") (newline)))

--- a/web/eshkol-repl.js
+++ b/web/eshkol-repl.js
@@ -296,6 +296,7 @@ class EshkolRepl {
                 eshkol_tensor_result_dtype_binary: (r) => r,
                 eshkol_tensor_result_dtype_unary: (r) => r,
                 eshkol_type_error_with_operand: () => { throw new Error('Eshkol type error (WASM stub)'); },
+                eshkol_tensor_operand_checked: () => 0,
                 eshkol_set_error_location: () => {},
                 eshkol_deep_equal: (a, b) => false,
                 eshkol_display_value: (val) => {},


### PR DESCRIPTION
## Summary

Tensor ops assumed their operand was a `HEAP_SUBTYPE_TENSOR` and reinterpreted the operand pointer as an `eshkol_tensor_t*` **without validating the type**. Given a heterogeneous vector, an int, or a string they misread the struct and **SIGSEGV'd** instead of raising a type error.

Confirmed before: `(softmax (reshape (vector 0 0 0 0) 4))` worked, but `(softmax (vector 1.0 2.0 3.0))` and `(softmax "x")` **crashed**. The flaw was shared across the whole tensor-op family.

## Architectural fix (single choke point — not per-op patches)

- **Runtime** `eshkol_tensor_operand_checked(tagged, op_name)` (`lib/core/runtime_tensor_alloc.cpp`):
  - real tensor → return its data pointer (zero-copy hot path)
  - homogeneous **numeric vector** → coerce to a fresh 1-D tensor
  - anything else (int / string / bool / null / pair / non-numeric or heterogeneous vector) → raise a **clean, catchable** type error via `eshkol_type_error_with_operand` and never touch the struct
- **Codegen** `TensorCodegen::unpackTensorOperandChecked(value, op_name)` emits the call (with source-location wiring for `file:line:col` diagnostics) and replaces the ad-hoc `IntToPtr(unpackInt64(v))` unpacks.

After this it is **structurally impossible** for a tensor op to segfault on a wrong-typed operand.

## Ops routed through the helper

Activations (relu, sigmoid, softmax, gelu, leaky-relu, silu, elu, selu, mish, hard-swish, hard-sigmoid, softplus, dropout, celu); unary math via `emitTensorUnaryOp` (neg/abs/sqrt/exp/log/sin/cos); reductions & stats (tensor-sum/mean/min/max/argmin/argmax/var/std/reduce/reduce-all/apply, axis-reduce); tensor-dot; elementwise arithmetic + pow/maximum/minimum + scale (via the `tensorArithmeticInternal` tensor-path) and batch-matmul; conv1d/conv2d/conv3d; max-pool2d/avg-pool2d; batch-norm/layer-norm; shape ops (reshape, transpose, flatten, squeeze, unsqueeze, split, slice, tensor-shape, tensor-length); tensor-get / tensor-set! / tensor->vector; cov / corrcoef; and the plain-operand path of `matmul` in `llvm_codegen.cpp`.

## Before / after

| input | before | after |
|---|---|---|
| `(softmax (vector 1.0 2.0 3.0))` | SIGSEGV | `#(0.090 0.245 0.665)` (numeric vector coerced) |
| `(softmax "x")` / `(softmax 5)` | SIGSEGV | catchable type error |
| `(softmax (reshape … 4))` | OK | OK (unchanged) |

## Tests

`tests/ml/tensor_type_guard_test.esk` — 49 checks: valid tensors still compute correctly, numeric vectors coerce, and every op given a vector/int/string raises a `guard`-catchable error and does **not** crash.

- `eshkol-run -r tests/ml/tensor_type_guard_test.esk` → **49/49 PASS**
- AOT (`eshkol-run … -o bin && ./bin`) → **49/49 PASS**
- ICC smoke: all tensor/AD probes green (matmul/conv2d/batch-norm/layer-norm/attention gradient flow, model serialization, image-io) — confirming no regression.