### PR TITLE
fix(regions): route with-region body allocations into the region arena (ESH-0039)

### DIFF
--- a/inc/eshkol/backend/codegen_context.h
+++ b/inc/eshkol/backend/codegen_context.h
@@ -196,6 +196,19 @@ public:
     llvm::GlobalVariable* globalArena() { return global_arena_; }
     void setGlobalArena(llvm::GlobalVariable* arena) { global_arena_ = arena; }
 
+    /**
+     * Single accessor for "the arena that allocations should currently target".
+     *
+     * Every allocating codegen site is expected to read the live arena pointer
+     * through this slot rather than baking in __global_arena directly. Today the
+     * slot IS the __global_arena GlobalVariable: (with-region ...) and parallel
+     * workers temporarily overwrite its stored value with a region / per-thread
+     * sub-arena so that all ~200 arena_allocate* sites transparently retarget,
+     * and restore it on exit. Funneling through one accessor keeps any future
+     * allocating op from re-baking the region / thread bypass (ESH-0039).
+     */
+    llvm::GlobalVariable* currentArenaPtr() { return global_arena_; }
+
     /** Get/set arena scope depth */
     size_t arenaScopeDepth() const { return arena_scope_depth_; }
     void setArenaScopeDepth(size_t depth) { arena_scope_depth_ = depth; }

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -28508,6 +28508,27 @@ private:
         // Call region_push to make this the current region
         builder->CreateCall(region_push_fn, {region});
 
+        // ESH-0039: Route ALL body allocations into the region's arena.
+        //
+        // Every allocating codegen site loads the live arena pointer from the
+        // single currentArenaPtr() slot (the __global_arena GlobalVariable). The
+        // runtime's region machinery (region_create / region_pop ->
+        // region_destroy) is correct, but codegen never pointed allocations at
+        // the region arena, so body cons / make-vector / etc. landed in the
+        // global arena and region_pop freed an empty region -> unbounded RSS
+        // growth (Noesis OOM, exit 137).
+        //
+        // Fix: temporarily overwrite the current-arena slot with region->arena
+        // for the duration of the body, then restore the previous value after
+        // region_pop. region->arena is the FIRST field of eshkol_region_t, so it
+        // lives at offset 0 of the region pointer returned by region_create.
+        GlobalVariable* arena_slot = ctx_ ? ctx_->currentArenaPtr() : global_arena;
+        Value* saved_arena = builder->CreateLoad(
+            PointerType::getUnqual(*context), arena_slot, "saved_arena_before_region");
+        Value* region_arena = builder->CreateLoad(
+            PointerType::getUnqual(*context), region, "region_arena");
+        builder->CreateStore(region_arena, arena_slot);
+
         // Evaluate body expressions - last one is the result
         Value* result = nullptr;
         for (uint64_t i = 0; i < op->with_region_op.num_body_exprs; i++) {
@@ -28533,6 +28554,12 @@ private:
 
         // Call region_pop (this destroys the region and frees all its memory)
         builder->CreateCall(region_pop_fn, {});
+
+        // ESH-0039: Restore the previous arena slot now that the region is gone.
+        // Allocations after the region must NOT target the (now-freed) region
+        // arena. region_escape above already copied the result into the parent /
+        // global arena (region_escape is slot-independent), so it survives.
+        builder->CreateStore(saved_arena, arena_slot);
 
         if (!result) {
             result = packNullToTaggedValue();

--- a/lib/core/arena_memory.h
+++ b/lib/core/arena_memory.h
@@ -59,11 +59,25 @@ struct arena {
     size_t alignment;              // Memory alignment requirement
     void* mutex;                   // Optional mutex for thread-safe access (platform-specific)
     bool thread_safe;              // Whether this arena uses mutex locking
+    bool bounded;                  // ESH-0039/v1.8: if set, allocation NEVER grows
+                                   // the arena (no new-block malloc); requests that
+                                   // overflow the fixed capacity return NULL instead.
 };
 
 // Arena management functions
 arena_t* arena_create(size_t default_block_size);
 arena_t* arena_create_threadsafe(size_t default_block_size);  // Thread-safe variant with mutex
+
+/* ESH-0039 / v1.8 embedded seam: bounded, no-grow arena.
+ *
+ * Creates an arena with a single fixed-capacity block. Allocation never mallocs
+ * a new block: once the capacity is exhausted, arena_allocate* returns NULL.
+ * This is the signature the v1.8 embedded / bounded-memory target needs so that
+ * a region (or a worker subarena) can be given a hard memory ceiling. The hosted
+ * implementation still malloc()s the single backing block once; a freestanding
+ * build can swap the backing buffer without changing this contract. */
+arena_t* arena_create_bounded(size_t capacity);
+
 void arena_destroy(arena_t* arena);
 
 // Thread-safety control
@@ -461,6 +475,11 @@ typedef struct eshkol_hash_table {
     eshkol_tagged_value_t* keys;          // Array of keys (tagged values)
     eshkol_tagged_value_t* values;        // Array of values (tagged values)
     uint8_t* status;                      // Entry status array (EMPTY/OCCUPIED/DELETED)
+    arena_t* home_arena;                  // ESH-0039: arena the table was created in.
+                                          // Resize re-allocates the backing arrays here
+                                          // (NOT the transient region arena that happens
+                                          // to be active during a set!) so a table created
+                                          // outside a (with-region ...) survives region_pop.
 } eshkol_hash_table_t;
 
 // Initial capacity for new hash tables

--- a/lib/core/runtime_arena_core.cpp
+++ b/lib/core/runtime_arena_core.cpp
@@ -103,8 +103,24 @@ arena_t* arena_create(size_t default_block_size) {
     arena->alignment = DEFAULT_ALIGNMENT;
     arena->mutex = nullptr;
     arena->thread_safe = false;
+    arena->bounded = false;
 
     eshkol_debug("Created arena with default block size %zu", default_block_size);
+    return arena;
+}
+
+// ESH-0039 / v1.8: bounded, no-grow arena.
+// Single fixed-capacity block; allocation never grows the arena. When the
+// capacity is exhausted, arena_allocate* returns NULL (see the `bounded` guard
+// in arena_allocate_aligned) rather than malloc'ing a new block. This is the
+// embedded / hard-ceiling seam for v1.8; the hosted impl simply reuses
+// arena_create for the one-shot backing block.
+arena_t* arena_create_bounded(size_t capacity) {
+    if (capacity < 1024) capacity = 1024;
+    arena_t* arena = arena_create(capacity);
+    if (!arena) return nullptr;
+    arena->bounded = true;
+    eshkol_debug("Created bounded arena with capacity %zu", capacity);
     return arena;
 }
 
@@ -124,6 +140,7 @@ arena_t* arena_create_threadsafe(size_t default_block_size) {
 
     arena->mutex = mutex;
     arena->thread_safe = true;
+    arena->bounded = false;
 
     eshkol_debug("Created thread-safe arena with default block size %zu", default_block_size);
     return arena;
@@ -202,6 +219,14 @@ void* arena_allocate_aligned(arena_t* arena, size_t size, size_t alignment) {
     size_t current_used = align_block_offset(block, block->used, alignment);
 
     if (current_used + aligned_size > block->size) {
+        // ESH-0039 / v1.8: bounded arenas never grow — a request that overflows
+        // the fixed capacity fails instead of malloc'ing a new block.
+        if (arena->bounded) {
+            eshkol_warn("Bounded arena exhausted: request %zu bytes exceeds remaining capacity",
+                        aligned_size);
+            arena_unlock(arena);
+            return nullptr;
+        }
         // Need a new block
         size_t min_block_size = aligned_size + alignment - 1;
         size_t new_block_size = (min_block_size > arena->default_block_size) ?

--- a/lib/core/runtime_hash_table.cpp
+++ b/lib/core/runtime_hash_table.cpp
@@ -185,6 +185,7 @@ eshkol_hash_table_t* arena_allocate_hash_table(arena_t* arena, size_t initial_ca
     table->capacity = initial_capacity;
     table->size = 0;
     table->tombstones = 0;
+    table->home_arena = arena;  // ESH-0039: remember where the table lives
 
     return table;
 }
@@ -234,6 +235,7 @@ eshkol_hash_table_t* arena_hash_table_create_with_header(arena_t* arena) {
     table->capacity = initial_capacity;
     table->size = 0;
     table->tombstones = 0;
+    table->home_arena = arena;  // ESH-0039: remember where the table lives
 
     return table;
 }
@@ -278,6 +280,12 @@ struct hash_table_lock_guard {
 };
 
 static bool hash_table_resize(arena_t* arena, eshkol_hash_table_t* table, size_t new_capacity) {
+    // ESH-0039: grow the backing arrays in the arena the table was BORN in, not
+    // whatever transient region arena is active during this set!. Otherwise a
+    // table created outside a (with-region ...) would have its arrays reallocated
+    // into the region arena and freed (corrupted) at region_pop.
+    if (table->home_arena) arena = table->home_arena;
+
     eshkol_tagged_value_t* new_keys = (eshkol_tagged_value_t*)
         arena_allocate_zeroed(arena, sizeof(eshkol_tagged_value_t) * new_capacity);
     eshkol_tagged_value_t* new_values = (eshkol_tagged_value_t*)

--- a/tests/v1_3_edge_cases/with_region_reclaims_test.esk
+++ b/tests/v1_3_edge_cases/with_region_reclaims_test.esk
@@ -1,0 +1,111 @@
+;; with_region_reclaims_test.esk — ESH-0039 regression pin.
+;;
+;; (with-region ...) must actually RECLAIM the allocations made in its body.
+;; Before ESH-0039 the LLVM backend emitted every arena_allocate* against the
+;; global arena GlobalVariable, so a (with-region 'j (make-vector 1000 i)) loop
+;; leaked every vector into the never-freed global arena -> RSS climbed ~4GB per
+;; epoch -> jetsam/OOM (exit 137) on Noesis training. The runtime region
+;; machinery (region_create / region_pop -> region_destroy) was correct but was
+;; never targeted by codegen.
+;;
+;; The fix routes body allocations into the region's arena (codegenWithRegion
+;; overwrites the single currentArenaPtr() slot with region->arena for the body
+;; and restores it after region_pop), so region_pop frees the body garbage.
+;;
+;; This .esk file verifies CORRECTNESS / lifetime invariants. The BOUNDED-RSS
+;; assertion (the actual OOM fix) is checked by the companion harness
+;; with_region_reclaims_test.sh, which compares peak RSS of the region loop
+;; against the no-region baseline.
+
+(define passed 0)
+(define failed 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "PASS: ") (display name) (newline)
+             (set! passed (+ passed 1)))
+      (begin (display "FAIL: ") (display name)
+             (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline)
+             (set! failed (+ failed 1)))))
+
+;; ─── 1. The result of a region body escapes correctly ───────────────────────
+;; region_escape copies the body's result value into the parent/global arena
+;; before the region is destroyed, so it stays valid afterwards.
+(define escaped
+  (with-region 'r1
+    (+ 40 2)))
+(check "region body result escapes (scalar)" 42 escaped)
+
+(define escaped-vec
+  (with-region 'r2
+    (let ((v (make-vector 3 7)))
+      (vector-set! v 1 11)
+      v)))
+(check "region body result escapes (vector elem 0)" 7 (vector-ref escaped-vec 0))
+(check "region body result escapes (vector elem 1)" 11 (vector-ref escaped-vec 1))
+
+;; ─── 2. Reclaim: a big loop of region allocations must complete ──────────────
+;; Each iteration allocates a 1000-element vector inside a region that is then
+;; popped. Pre-fix this OOM'd; post-fix the region arena is freed each pop so
+;; the loop runs in bounded memory. We only assert it RUNS to completion and
+;; returns the sentinel (RSS boundedness is the .sh harness's job).
+(define (region-vec-loop i n)
+  (if (>= i n)
+      'done
+      (begin
+        (with-region 'j
+          (make-vector 1000 i))
+        (region-vec-loop (+ i 1) n))))
+(check "region make-vector loop reclaims and completes" 'done
+       (region-vec-loop 0 50000))
+
+;; ─── 3. Reclaim: cons-churn inside a region ─────────────────────────────────
+;; Build and discard large lists inside regions; must complete without growing
+;; unbounded. Returns the last computed length so we also confirm correctness.
+(define (build-list i acc)
+  (if (>= i 0)
+      (build-list (- i 1) (cons i acc))
+      acc))
+(define (cons-churn-loop i n last-len)
+  (if (>= i n)
+      last-len
+      (cons-churn-loop
+        (+ i 1) n
+        (with-region 'churn
+          (length (build-list 500 '()))))))
+(check "region cons-churn loop reclaims and completes" 501
+       (cons-churn-loop 0 50000 0))
+
+;; ─── 4. Boundary: outer hash-table mutations inside a region survive pop ─────
+;; The hash table is created OUTSIDE the region (its home arena is the global
+;; arena). Mutating it inside a region must NOT place its backing store in the
+;; region arena (which region_pop would free). We insert enough keys to force a
+;; resize while inside the region, then read them back AFTER the region is gone.
+(define ht (make-hash-table))
+(hash-set! ht 'pre 1)            ; mutate before any region
+
+(with-region 'mut
+  (let loop ((k 0))
+    (if (< k 100)
+        (begin
+          (hash-set! ht k (* k 10))   ; forces several resizes inside the region
+          (loop (+ k 1)))
+        'ok)))
+
+;; After region_pop: the table and all entries must still be intact.
+(check "outer-hash key set BEFORE region survives" 1 (hash-ref ht 'pre 'missing))
+(check "outer-hash key set INSIDE region survives (low)"  0   (hash-ref ht 0 'missing))
+(check "outer-hash key set INSIDE region survives (mid)"  500 (hash-ref ht 50 'missing))
+(check "outer-hash key set INSIDE region survives (high)" 990 (hash-ref ht 99 'missing))
+(check "outer-hash count survives region_pop" 101 (hash-count ht))
+
+;; Further mutation after the region must still work (table not corrupted).
+(hash-set! ht 'post 2)
+(check "outer-hash mutable after region_pop" 2 (hash-ref ht 'post 'missing))
+
+;; ─── Summary ────────────────────────────────────────────────────────────────
+(display "Results: ") (display passed) (display " passed, ")
+(display failed) (display " failed") (newline)
+(if (= failed 0)
+    (begin (display "PASS: with_region_reclaims_test") (newline) (exit 0))
+    (begin (display "FAIL: with_region_reclaims_test") (newline) (exit 1)))

--- a/tests/v1_3_edge_cases/with_region_reclaims_test.sh
+++ b/tests/v1_3_edge_cases/with_region_reclaims_test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# ESH-0039: (with-region ...) must RECLAIM its body allocations.
+#
+# This harness measures PEAK RSS of two equivalent workloads:
+#   (a) region:    a loop of (with-region 'j (make-vector 1000 i))
+#   (b) baseline:  the same loop WITHOUT with-region
+#
+# Pre-fix the region loop bypassed region_pop's free and leaked every vector
+# into the global arena, so (a) >= (b) and both climbed multi-GB until OOM.
+# Post-fix (a) must be BOUNDED and materially lower than (b).
+#
+# Pass criteria:
+#   - region peak RSS < REGION_CEIL_MB              (bounded, not GB-scale)
+#   - region peak RSS < baseline peak RSS / 2       (materially lower)
+set -euo pipefail
+
+ESHKOL_RUN="${1:-${ESHKOL_RUN:-}}"
+if [ -z "$ESHKOL_RUN" ]; then
+    for cand in ./build/eshkol-run ./build-verify/eshkol-run; do
+        [ -x "$cand" ] && ESHKOL_RUN="$cand" && break
+    done
+fi
+if [ -z "${ESHKOL_RUN:-}" ] || [ ! -x "$ESHKOL_RUN" ]; then
+    echo "FAIL: with_region_reclaims_test could not locate eshkol-run" >&2
+    exit 1
+fi
+
+# Resolve the build dir holding stdlib.o (next to eshkol-run).
+BUILD_DIR="$(cd "$(dirname "$ESHKOL_RUN")" && pwd)"
+
+ITERS="${ESH0039_ITERS:-200000}"
+REGION_CEIL_MB="${ESH0039_REGION_CEIL_MB:-512}"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat > "$tmpdir/region.esk" <<EOF
+(define (loop i n)
+  (if (< i n) (begin (with-region 'j (make-vector 1000 i)) (loop (+ i 1) n)) 'done))
+(display (loop 0 $ITERS)) (newline)
+EOF
+
+cat > "$tmpdir/baseline.esk" <<EOF
+(define (loop i n)
+  (if (< i n) (begin (make-vector 1000 i) (loop (+ i 1) n)) 'done))
+(display (loop 0 $ITERS)) (newline)
+EOF
+
+compile() {  # src out
+    if ! "$ESHKOL_RUN" "$1" -o "$2" -L"$BUILD_DIR" > "$tmpdir/compile.log" 2>&1; then
+        echo "FAIL: compile of $1 failed" >&2; cat "$tmpdir/compile.log" >&2; exit 1
+    fi
+}
+
+compile "$tmpdir/region.esk"   "$tmpdir/region"
+compile "$tmpdir/baseline.esk" "$tmpdir/baseline"
+
+# peak_rss_mb <binary> -> echoes integer MB (portable macOS/Linux)
+peak_rss_mb() {
+    local bin="$1" tf="$tmpdir/time.txt" raw os
+    os="$(uname -s)"
+    if [ "$os" = "Darwin" ]; then
+        /usr/bin/time -l "$bin" >/dev/null 2>"$tf" || true
+        raw="$(grep -E 'maximum resident set size' "$tf" | awk '{print $1}')"
+        echo $(( raw / 1024 / 1024 ))          # macOS reports BYTES
+    else
+        /usr/bin/time -v "$bin" >/dev/null 2>"$tf" || true
+        raw="$(grep -E 'Maximum resident set size' "$tf" | awk -F': ' '{print $2}')"
+        echo $(( raw / 1024 ))                  # Linux reports KiB
+    fi
+}
+
+region_mb="$(peak_rss_mb "$tmpdir/region")"
+baseline_mb="$(peak_rss_mb "$tmpdir/baseline")"
+
+echo "ESH-0039 peak RSS over $ITERS iters: region=${region_mb}MB baseline=${baseline_mb}MB (ceil=${REGION_CEIL_MB}MB)"
+
+rc=0
+if [ "$region_mb" -ge "$REGION_CEIL_MB" ]; then
+    echo "FAIL: region peak RSS ${region_mb}MB is not bounded (>= ${REGION_CEIL_MB}MB)" >&2
+    rc=1
+fi
+if [ "$region_mb" -ge $(( baseline_mb / 2 )) ]; then
+    echo "FAIL: region peak RSS ${region_mb}MB not materially below baseline ${baseline_mb}MB" >&2
+    rc=1
+fi
+
+if [ "$rc" -eq 0 ]; then
+    echo "PASS: with_region_reclaims_test.sh (region reclaims; bounded RSS)"
+fi
+exit "$rc"


### PR DESCRIPTION
## ESH-0039: `(with-region …)` now reclaims its body allocations

### Problem (HIGH severity — active OOM on Noesis training)
`(with-region …)` reclaimed **nothing**. The LLVM backend emits every
`arena_allocate*` against the single `__global_arena` slot, so body
`cons` / `make-vector` / closure / tape allocations landed in the
never-freed global arena while `region_pop` freed an *empty* region. RSS
climbed monotonically (~4 GB/epoch, 13→47 GB) until jetsam/OOM (exit 137).
The runtime region machinery (`region_create` / `region_pop` →
`region_destroy`) was correct but was never targeted by codegen.

### Routing mechanism
All ~202 allocating codegen sites read the live arena pointer from one
`GlobalVariable` (`__global_arena`). `codegenWithRegion` now, on region
entry, **saves** that slot's value and **stores `region->arena`** (offset 0
of the region struct returned by `region_create`) into it for the body,
then **restores** the saved value after `region_pop`. Every existing alloc
site therefore targets the region's arena transparently, and `region_pop`
frees the body garbage.

Arena selection is funneled through one accessor,
`CodegenContext::currentArenaPtr()`, so no future allocating op can re-bake
the bypass. `arena_push_scope` / `arena_pop_scope` are honored transitively
— they already read the same slot, so inside a region they scope the region
arena.

### Boundary preservation (no regression)
A hash table created **outside** a region must survive `region_pop` even
when mutated inside it. `hash_table_set` only touches the arena on *resize*,
so the table now records its `home_arena` at creation and resize
re-allocates the backing arrays there (not the transient region arena).
Immediate values copied into pre-existing slots were always safe.

### v1.8 embedded seam
Adds `arena_create_bounded(capacity)` — a single-block, no-grow arena that
returns `NULL` on overflow instead of `malloc`'ing a new block. This is the
bounded-memory signature v1.8 needs to give a region/worker a hard ceiling.

### Verification
| Check | Result |
|---|---|
| `with_region_reclaims_test.esk` (AOT) | **11/11** |
| `with_region_reclaims_test.esk` (`-r`) | **11/11** |
| `with_region_reclaims_test.sh` peak RSS (200k iters) | **region 41 MB vs baseline 3153 MB** (was 6605 MB pre-fix) |
| autodiff suite | **54/54** |
| parallel suite (isolated) | **7/7** |
| v1_2: `parallel_hash_table_mutation_test`, `parallel_ad_worker_init_test` | PASS |

The `.esk` test covers result-escape, region `make-vector` reclaim,
cons-churn reclaim, and outer-hash-survives-`region_pop`. The `.sh` harness
asserts bounded + materially-lower peak RSS vs the no-region baseline.

> Known unrelated failure: `v1_2_edge_cases/bug_regression_test` (a
> `;; mode: jit` test) fails on `parallel-map: workers not registered
> (stdlib not loaded?)` — a JIT cold-path worker-registration fragility in
> code this PR does not touch (`g_parallel_map_worker == NULL`). The
> isolated parallel suite passes 7/7 and `parallel_hash_table_mutation_test`
> passes, confirming parallel-map itself works under this change.

### Follow-up (out of scope here)
Per-thread subarena routing for parallel workers *in JIT codegen*: the
runtime already provides per-thread arenas (`arena_create_thread_local` /
`eshkol_thread_init_worker`); routing generated worker allocations to them
requires making the shared arena slot thread-local, a broader ABI change
deferred to avoid AOT/JIT risk.
