### PR TITLE
numeric: R7RS exactness + promotion discipline (ESH-0065)

### DIFF
--- a/inc/eshkol/eshkol.h
+++ b/inc/eshkol/eshkol.h
@@ -1082,6 +1082,12 @@ static inline eshkol_display_opts_t eshkol_display_default_opts(void) {
     return opts;
 }
 
+// R7RS flonum external representation (+inf.0 / -inf.0 / +nan.0). Single
+// source of truth shared by display/write/number->string/logic printing.
+// Defined in runtime_display_hosted.cpp.
+int  eshkol_format_double(char* buf, size_t n, double v);
+void eshkol_fprint_double(void* file, double v);
+
 // Main display functions (implemented in arena_memory.cpp)
 void eshkol_display_value(const eshkol_tagged_value_t* value);
 void eshkol_display_value_opts(const eshkol_tagged_value_t* value, eshkol_display_opts_t* opts);

--- a/lib/backend/arithmetic_codegen.cpp
+++ b/lib/backend/arithmetic_codegen.cpp
@@ -2048,11 +2048,14 @@ llvm::Value* ArithmeticCodegen::pow(llvm::Value* base, llvm::Value* exponent) {
         llvm::Value* base_is_exact = ctx_.builder().CreateOr(base_is_int, base_is_heap);
         llvm::Value* exp_is_int = ctx_.builder().CreateICmpEQ(exp_base,
             llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_INT64));
-        llvm::Value* both_exact_int = ctx_.builder().CreateAnd(base_is_exact, exp_is_int);
-        llvm::Value* exp_val = tagged_.unpackInt64(exponent);
-        llvm::Value* exp_non_neg = ctx_.builder().CreateICmpSGE(exp_val,
-            llvm::ConstantInt::get(ctx_.int64Type(), 0));
-        llvm::Value* use_exact = ctx_.builder().CreateAnd(both_exact_int, exp_non_neg);
+        // R7RS exactness preservation for integer exponentiation. We route to
+        // the exact runtime whenever both operands are exact integers,
+        // REGARDLESS of the exponent's sign:
+        //   * non-negative exponent -> exact integer (int64 / bignum)
+        //   * negative exponent     -> exact rational 1/base^|n|  (e.g. 2^-2 = 1/4)
+        // eshkol_bignum_pow_tagged owns the sign discipline and the rational
+        // construction; it falls back to an inexact double only on overflow.
+        llvm::Value* use_exact = ctx_.builder().CreateAnd(base_is_exact, exp_is_int);
         ctx_.builder().CreateCondBr(use_exact, exact_path, regular_path);
 
         // Exact integer exponentiation via runtime

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -19080,16 +19080,32 @@ private:
         return builder->CreateOr(is_double, is_complex);
     }
 
-    // Conditionally coerce an exact tagged value to its inexact (double)
+    // Conditionally coerce an EXACT tagged value to its inexact (double)
     // representation. When `cond` is false the value is returned unchanged;
-    // when true an already-inexact value is left as-is and an exact one is
-    // converted via extractAsDouble (the single exact->inexact path).
+    // when true an exact int64/bignum/rational is converted via extractAsDouble
+    // (the single exact->inexact path).
+    //
+    // Crucially the coercion only fires for *genuinely exact* results
+    // (INT64 / HEAP_PTR bignum / rational). A DUAL number (forward-mode AD)
+    // is already an inexact float carrying a tangent — routing it through
+    // extractAsDouble would strip the derivative and break AD through min/max.
+    // DOUBLE and COMPLEX are already inexact, so leaving them untouched is
+    // both correct and avoids needless work.
     Value* coerceToInexactIf(Value* result, Value* cond) {
+        // Restrict contagion to exact results; duals/doubles/complex pass through.
+        Value* base = getBaseType(getTaggedValueType(result));
+        Value* is_int = builder->CreateICmpEQ(base,
+            ConstantInt::get(int8_type, ESHKOL_VALUE_INT64));
+        Value* is_heap = builder->CreateICmpEQ(base,
+            ConstantInt::get(int8_type, ESHKOL_VALUE_HEAP_PTR));
+        Value* result_is_exact = builder->CreateOr(is_int, is_heap);
+        Value* do_coerce = builder->CreateAnd(cond, result_is_exact);
+
         Function* mf = builder->GetInsertBlock()->getParent();
         BasicBlock* coerce_bb = BasicBlock::Create(*context, "contagion_coerce", mf);
         BasicBlock* keep_bb = BasicBlock::Create(*context, "contagion_keep", mf);
         BasicBlock* merge_bb = BasicBlock::Create(*context, "contagion_merge", mf);
-        builder->CreateCondBr(cond, coerce_bb, keep_bb);
+        builder->CreateCondBr(do_coerce, coerce_bb, keep_bb);
 
         builder->SetInsertPoint(coerce_bb);
         // extractAsDouble is an identity for doubles and a faithful conversion

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -18221,6 +18221,66 @@ private:
             reg_phi->addIncoming(tagged_regular_result, rational_exit);
             reg_phi->addIncoming(float_result, float_exit);
             tagged_regular_result = reg_phi;
+        } else if (func_name == "sqrt" || func_name == "log") {
+            // R7RS 6.2.6 numeric-tower promotion: the square root (and natural
+            // log) of a NEGATIVE EXACT real is not a real number — it promotes
+            // into the complex domain instead of producing an IEEE NaN:
+            //     (sqrt -4) => +2.0i        (log -1) => 0+pi i
+            // Promotion is exactness-aware: an inexact (double) negative keeps
+            // IEEE semantics (NaN / -inf) so the documented floating-point
+            // behaviour and the infinity/NaN regression suite are preserved.
+            // This is the single architectural site where the real->complex
+            // domain boundary lives for these unary functions.
+            Value* arg_is_int = builder->CreateICmpEQ(arg_base_type,
+                ConstantInt::get(int8_type, ESHKOL_VALUE_INT64));
+            Value* arg_is_heap = builder->CreateICmpEQ(arg_base_type,
+                ConstantInt::get(int8_type, ESHKOL_VALUE_HEAP_PTR));
+            Value* arg_is_exact = builder->CreateOr(arg_is_int, arg_is_heap);
+            // extractAsDouble handles int64 / double / bignum / rational and
+            // may create internal blocks — call it before branching.
+            Value* arg_double = arith_->extractAsDouble(arg_tagged);
+            Value* is_negative = builder->CreateFCmpOLT(arg_double,
+                ConstantFP::get(double_type, 0.0));
+            Value* promote = builder->CreateAnd(arg_is_exact, is_negative);
+
+            Function* mf = builder->GetInsertBlock()->getParent();
+            BasicBlock* promote_bb = BasicBlock::Create(*context, (func_name + "_promote_complex").c_str(), mf);
+            BasicBlock* real_bb = BasicBlock::Create(*context, (func_name + "_real_domain").c_str(), mf);
+            BasicBlock* promo_merge = BasicBlock::Create(*context, (func_name + "_promo_merge").c_str(), mf);
+            builder->CreateCondBr(promote, promote_bb, real_bb);
+
+            // Complex-promotion path: x < 0, so |x| = -x.
+            builder->SetInsertPoint(promote_bb);
+            Value* abs_arg = builder->CreateFNeg(arg_double, "abs_arg");
+            Value* cx_re;
+            Value* cx_im;
+            if (func_name == "sqrt") {
+                // sqrt(-|x|) = 0 + sqrt(|x|) i
+                cx_re = ConstantFP::get(double_type, 0.0);
+                cx_im = builder->CreateCall(function_table["sqrt"], {abs_arg}, "promote_sqrt");
+            } else {
+                // log(-|x|) = log(|x|) + pi i  (principal branch)
+                cx_re = builder->CreateCall(function_table["log"], {abs_arg}, "promote_log");
+                cx_im = ConstantFP::get(double_type, 3.14159265358979323846);
+            }
+            Value* promoted_complex = createComplexNumber(cx_re, cx_im);
+            Value* promoted_tagged = packComplexToTagged(promoted_complex);
+            builder->CreateBr(promo_merge);
+            BasicBlock* promote_exit = builder->GetInsertBlock();
+
+            // Real-domain path: ordinary libm computation (non-negative input,
+            // or an inexact double which keeps IEEE NaN/inf behaviour).
+            builder->SetInsertPoint(real_bb);
+            Value* real_result = builder->CreateCall(function_table[func_name], {arg_double}, (func_name + "_real").c_str());
+            Value* real_tagged = packDoubleToTaggedValue(real_result);
+            builder->CreateBr(promo_merge);
+            BasicBlock* real_exit = builder->GetInsertBlock();
+
+            builder->SetInsertPoint(promo_merge);
+            PHINode* promo_phi = builder->CreatePHI(tagged_value_type, 2, (func_name + "_promo_result").c_str());
+            promo_phi->addIncoming(promoted_tagged, promote_exit);
+            promo_phi->addIncoming(real_tagged, real_exit);
+            tagged_regular_result = promo_phi;
         } else {
             // Non-rounding functions: always compute on double
             Value* arg_is_double = builder->CreateICmpEQ(arg_base_type,
@@ -18981,11 +19041,20 @@ private:
         if (!result) return nullptr;
         result = ensureTaggedValue(result);
 
+        // R7RS inexactness CONTAGION: "if any argument is inexact, then the
+        // result will also be inexact" (R7RS 6.2.6, max/min note). min/max
+        // SELECT one of their operands rather than computing a new value, so a
+        // chosen exact operand must still be coerced to inexact when *any*
+        // argument was inexact. Track inexactness across the whole reduction.
+        Value* any_inexact = isInexactTagged(result);
+
         // Fold min/max across all arguments using polymorphic arithmetic
         for (uint64_t i = 1; i < op->call_op.num_vars; i++) {
             Value* arg = codegenAST(&op->call_op.variables[i]);
             if (!arg) return nullptr;
             arg = ensureTaggedValue(arg);
+
+            any_inexact = builder->CreateOr(any_inexact, isInexactTagged(arg));
 
             if (is_min) {
                 result = arith_->min(result, arg);
@@ -18994,7 +19063,51 @@ private:
             }
         }
 
-        return result;  // Return tagged value (preserves bignum/int/double type)
+        // Apply contagion: coerce the (possibly exact) selected result to
+        // inexact when any argument along the way was inexact.
+        return coerceToInexactIf(result, any_inexact);
+    }
+
+    // R7RS exactness probe: a value is inexact iff it is a flonum (DOUBLE) or
+    // a complex number (always inexact in Eshkol). int64 / bignum / rational
+    // are exact. Returns an i1.
+    Value* isInexactTagged(Value* tagged) {
+        Value* base = getBaseType(getTaggedValueType(tagged));
+        Value* is_double = builder->CreateICmpEQ(base,
+            ConstantInt::get(int8_type, ESHKOL_VALUE_DOUBLE));
+        Value* is_complex = builder->CreateICmpEQ(base,
+            ConstantInt::get(int8_type, ESHKOL_VALUE_COMPLEX));
+        return builder->CreateOr(is_double, is_complex);
+    }
+
+    // Conditionally coerce an exact tagged value to its inexact (double)
+    // representation. When `cond` is false the value is returned unchanged;
+    // when true an already-inexact value is left as-is and an exact one is
+    // converted via extractAsDouble (the single exact->inexact path).
+    Value* coerceToInexactIf(Value* result, Value* cond) {
+        Function* mf = builder->GetInsertBlock()->getParent();
+        BasicBlock* coerce_bb = BasicBlock::Create(*context, "contagion_coerce", mf);
+        BasicBlock* keep_bb = BasicBlock::Create(*context, "contagion_keep", mf);
+        BasicBlock* merge_bb = BasicBlock::Create(*context, "contagion_merge", mf);
+        builder->CreateCondBr(cond, coerce_bb, keep_bb);
+
+        builder->SetInsertPoint(coerce_bb);
+        // extractAsDouble is an identity for doubles and a faithful conversion
+        // for int64/bignum/rational — exactly the exact->inexact coercion.
+        Value* as_double = arith_->extractAsDouble(result);
+        Value* coerced = packDoubleToTaggedValue(as_double);
+        builder->CreateBr(merge_bb);
+        BasicBlock* coerce_exit = builder->GetInsertBlock();
+
+        builder->SetInsertPoint(keep_bb);
+        builder->CreateBr(merge_bb);
+        BasicBlock* keep_exit = builder->GetInsertBlock();
+
+        builder->SetInsertPoint(merge_bb);
+        PHINode* phi = builder->CreatePHI(tagged_value_type, 2, "contagion_result");
+        phi->addIncoming(coerced, coerce_exit);
+        phi->addIncoming(result, keep_exit);
+        return phi;
     }
 
     // MIGRATED: Delegates to ArithmeticCodegen

--- a/lib/backend/string_io_codegen.cpp
+++ b/lib/backend/string_io_codegen.cpp
@@ -762,6 +762,19 @@ llvm::Value* StringIOCodegen::numberToString(const eshkol_operations_t* op) {
     // Get snprintf function
     llvm::Function* snprintf_func = ctx_.funcs().getSnprintf();
 
+    // R7RS flonum formatter: int eshkol_format_double(char* buf, size_t n,
+    // double v). Emits +inf.0 / -inf.0 / +nan.0 for non-finite flonums and
+    // "%g" otherwise — the single source of truth shared with display/write.
+    llvm::Module* n2s_mod = ctx_.builder().GetInsertBlock()->getParent()->getParent();
+    llvm::Function* format_double_func = n2s_mod->getFunction("eshkol_format_double");
+    if (!format_double_func) {
+        llvm::FunctionType* fd_ft = llvm::FunctionType::get(
+            llvm::Type::getInt32Ty(ctx_.context()),
+            {ctx_.ptrType(), ctx_.sizeType(), ctx_.doubleType()}, false);
+        format_double_func = llvm::Function::Create(fd_ft,
+            llvm::Function::ExternalLinkage, "eshkol_format_double", n2s_mod);
+    }
+
     llvm::Value* raw_val = tv->llvm_value;
 
     // For tagged values, we need runtime type checking since the value
@@ -828,9 +841,8 @@ llvm::Value* StringIOCodegen::numberToString(const eshkol_operations_t* op) {
         // Format as double
         ctx_.builder().SetInsertPoint(double_block);
         llvm::Value* double_val = ctx_.builder().CreateBitCast(data_i64, ctx_.doubleType());
-        llvm::Value* fmt_double = createString("%g");
         llvm::Value* dbl_written = ctx_.builder().CreateCall(
-            snprintf_func, {buf, buf_size, fmt_double, double_val});
+            format_double_func, {buf, buf_size, double_val});
         truncate_header(dbl_written);
         ctx_.builder().CreateBr(merge_block);
         llvm::BasicBlock* double_exit = ctx_.builder().GetInsertBlock();
@@ -862,9 +874,8 @@ llvm::Value* StringIOCodegen::numberToString(const eshkol_operations_t* op) {
             } else if (!raw_val->getType()->isDoubleTy()) {
                 double_val = ctx_.builder().CreateSIToFP(raw_val, ctx_.doubleType());
             }
-            llvm::Value* fmt = createString("%g");
             llvm::Value* written = ctx_.builder().CreateCall(
-                snprintf_func, {buf, buf_size, fmt, double_val});
+                format_double_func, {buf, buf_size, double_val});
             truncate_header(written);
         } else {
             // Format as integer

--- a/lib/core/bignum.cpp
+++ b/lib/core/bignum.cpp
@@ -907,9 +907,12 @@ void eshkol_bignum_pow_tagged(arena_t* arena,
         return;
     }
 
-    /* Check if both operands are exact integers (INT64 or HEAP_PTR bignum) */
+    /* Check if both operands are exact integers (INT64 or genuine bignum).
+     * Use ESHKOL_IS_BIGNUM (subtype-checked) rather than a bare HEAP_PTR test
+     * so a rational base is NOT misread as a bignum — it falls to the inexact
+     * double path instead of producing garbage. */
     bool base_is_int = (base->type == ESHKOL_VALUE_INT64);
-    bool base_is_bignum = (base->type == ESHKOL_VALUE_HEAP_PTR && base->data.ptr_val != 0);
+    bool base_is_bignum = ESHKOL_IS_BIGNUM(*base);
     bool exp_is_int = (exponent->type == ESHKOL_VALUE_INT64);
 
     /* Only use exact path if base is exact integer and exponent is non-negative int */
@@ -937,6 +940,42 @@ void eshkol_bignum_pow_tagged(arena_t* arena,
             result->flags = ESHKOL_VALUE_EXACT_FLAG;
         }
         return;
+    }
+
+    /* R7RS exactness: an exact integer base raised to a NEGATIVE exact integer
+     * exponent yields an EXACT RATIONAL 1/base^|n| (e.g. (expt 2 -2) => 1/4),
+     * NOT an inexact double. Falls through to the inexact double path on
+     * overflow (denominator does not fit int64) — the rational substrate is
+     * currently int64/int64. */
+    if ((base_is_int || base_is_bignum) && exp_is_int && exponent->data.int_val < 0) {
+        /* |exponent|, overflow-safe even for INT64_MIN (unsigned negation) */
+        uint64_t mag = (uint64_t)0 - (uint64_t)exponent->data.int_val;
+
+        eshkol_bignum_t* bn_base = base_is_bignum
+            ? (eshkol_bignum_t*)(void*)base->data.ptr_val
+            : eshkol_bignum_from_int64(arena, base->data.int_val);
+        if (bn_base) {
+            eshkol_bignum_t* p = eshkol_bignum_pow(arena, bn_base, mag);
+            int64_t denom;
+            if (p && eshkol_bignum_fits_int64(p, &denom)) {
+                if (denom == 0) {
+                    /* (expt 0 -n): 1/0 is undefined. */
+                    eshkol_exception_t* exc = eshkol_make_exception(
+                        ESHKOL_EXCEPTION_DIVIDE_BY_ZERO,
+                        "expt: 0 raised to a negative power");
+                    eshkol_raise(exc);
+                    *result = eshkol_make_int64(0, true);
+                    return;
+                }
+                /* eshkol_rational_create normalises the sign and GCD-reduces,
+                 * so 1/(-8) becomes -1/8 and 1/4 stays 1/4. */
+                void* rat = eshkol_rational_create(arena, 1, denom);
+                *result = eshkol_make_ptr((uint64_t)(void*)rat, ESHKOL_VALUE_HEAP_PTR);
+                result->flags = ESHKOL_VALUE_EXACT_FLAG;
+                return;
+            }
+        }
+        /* overflow: fall through to inexact double pow() below */
     }
 
     /* Fallback: convert both to double and use pow() */

--- a/lib/core/logic.cpp
+++ b/lib/core/logic.cpp
@@ -17,6 +17,9 @@
 #include <atomic>
 #include <mutex>
 
+/* eshkol_fprint_double (R7RS flonum external representation +inf.0/-inf.0/
+ * +nan.0) is declared in <eshkol/eshkol.h>, included above. */
+
 /* ===== Logic Variable Registry ===== */
 
 /* Global variable name registry. Thread-safe via mutex (protects g_var_names array)
@@ -861,7 +864,7 @@ extern "C" void eshkol_display_substitution(const eshkol_substitution_t* s, void
                 fprintf(f, "%lld", (long long)term->data.int_val);
                 break;
             case ESHKOL_VALUE_DOUBLE:
-                fprintf(f, "%g", term->data.double_val);
+                eshkol_fprint_double(f, term->data.double_val);
                 break;
             case ESHKOL_VALUE_BOOL:
                 fprintf(f, "%s", term->data.int_val ? "#t" : "#f");
@@ -919,7 +922,7 @@ extern "C" void eshkol_display_fact(const eshkol_fact_t* fact, void* file) {
                 fprintf(f, "%lld", (long long)arg->data.int_val);
                 break;
             case ESHKOL_VALUE_DOUBLE:
-                fprintf(f, "%g", arg->data.double_val);
+                eshkol_fprint_double(f, arg->data.double_val);
                 break;
             case ESHKOL_VALUE_BOOL:
                 fprintf(f, "%s", arg->data.int_val ? "#t" : "#f");

--- a/lib/core/runtime_display_hosted.cpp
+++ b/lib/core/runtime_display_hosted.cpp
@@ -15,6 +15,35 @@
 
 #include <cstdio>
 #include <cstring>
+#include <cmath>
+
+// ===== R7RS FLONUM EXTERNAL REPRESENTATION =====
+// Single source of truth for rendering an IEEE double as text. R7RS (6.2.6 /
+// 7.1.1) mandates the special external representations +inf.0 / -inf.0 /
+// +nan.0 for the non-finite flonums; plain "%g" (which prints "inf"/"nan")
+// is NOT readable back by the reader. Every double-formatting site — display,
+// write, number->string, logic-term printing — routes through this so the
+// representation is consistent everywhere it matters.
+//
+// Finite values keep the existing "%g" shortest-round-trip-ish convention to
+// avoid perturbing the large body of existing output.
+extern "C" int eshkol_format_double(char* buf, size_t n, double v) {
+    if (std::isnan(v)) {
+        return snprintf(buf, n, "+nan.0");
+    }
+    if (std::isinf(v)) {
+        return snprintf(buf, n, v < 0.0 ? "-inf.0" : "+inf.0");
+    }
+    return snprintf(buf, n, "%g", v);
+}
+
+// Convenience wrapper: print a double to a FILE* in R7RS external form.
+// Typed as void* in the public header so eshkol.h need not pull in <cstdio>.
+extern "C" void eshkol_fprint_double(void* file, double v) {
+    char tmp[64];
+    eshkol_format_double(tmp, sizeof(tmp), v);
+    fputs(tmp, file ? (FILE*)file : stdout);
+}
 
 // ===== UNIFIED DISPLAY IMPLEMENTATION =====
 // Single source of truth for displaying all Eshkol values
@@ -305,7 +334,7 @@ void eshkol_display_value_opts(const eshkol_tagged_value_t* value, eshkol_displa
             break;
 
         case ESHKOL_VALUE_DOUBLE:
-            fprintf(get_output(opts), "%g", value->data.double_val);
+            eshkol_fprint_double(get_output(opts), value->data.double_val);
             break;
 
         case ESHKOL_VALUE_BOOL:
@@ -364,14 +393,33 @@ void eshkol_display_value_opts(const eshkol_tagged_value_t* value, eshkol_displa
             if (parts) {
                 double re = parts[0];
                 double im = parts[1];
+                FILE* cf = get_output(opts);
+                char rbuf[64];
                 if (im == 0.0) {
-                    fprintf(get_output(opts), "%g", re);
-                } else if (re == 0.0) {
-                    fprintf(get_output(opts), "%gi", im);
-                } else if (im < 0.0) {
-                    fprintf(get_output(opts), "%g%gi", re, im);
+                    // Purely real complex: print just the real part.
+                    eshkol_format_double(rbuf, sizeof(rbuf), re);
+                    fputs(rbuf, cf);
                 } else {
-                    fprintf(get_output(opts), "%g+%gi", re, im);
+                    // R7RS external repr: <real>±<imag>i, with the real part
+                    // omitted when it is zero and the ±i shorthand for ±1.
+                    if (re != 0.0) {
+                        eshkol_format_double(rbuf, sizeof(rbuf), re);
+                        fputs(rbuf, cf);
+                    }
+                    if (im == 1.0) {
+                        fputs("+i", cf);
+                    } else if (im == -1.0) {
+                        fputs("-i", cf);
+                    } else {
+                        char ibuf[64];
+                        eshkol_format_double(ibuf, sizeof(ibuf), im);
+                        // Guarantee an explicit sign on the imaginary part.
+                        if (ibuf[0] != '+' && ibuf[0] != '-') {
+                            fputc('+', cf);
+                        }
+                        fputs(ibuf, cf);
+                        fputc('i', cf);
+                    }
                 }
             } else {
                 fprintf(get_output(opts), "0");
@@ -624,7 +672,7 @@ static void display_tensor_recursive(FILE* out, const eshkol_tensor_t* tensor,
             int64_t bits = tensor->elements[offset + i];
             double value;
             memcpy(&value, &bits, sizeof(double));
-            fprintf(out, "%g", value);
+            eshkol_fprint_double(out, value);
         }
         fprintf(out, ")");
         return;

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -762,6 +762,8 @@ void ReplJITContext::registerRuntimeSymbols() {
 
     // Deep equality
     ADD_SYMBOL(eshkol_deep_equal);
+    ADD_SYMBOL(eshkol_format_double);
+    ADD_SYMBOL(eshkol_fprint_double);
     ADD_SYMBOL(eshkol_display_value);
     ADD_SYMBOL(eshkol_lambda_registry_init);
     ADD_SYMBOL(eshkol_lambda_registry_destroy);

--- a/scripts/run_web_tests.sh
+++ b/scripts/run_web_tests.sh
@@ -319,7 +319,7 @@ echo ""
 # Test: Health Check
 printf "Testing %-45s " "health endpoint"
 HEALTH=$(http_get "http://localhost:$PORT/health" 2>/dev/null || echo "")
-if echo "$HEALTH" | grep -q '"status":"ok"'; then
+if grep -q '"status":"ok"' <<< "$HEALTH"; then
     log_pass "health check"
 else
     log_fail "health check: $HEALTH"
@@ -329,7 +329,7 @@ fi
 printf "Testing %-45s " "invalid Content-Length handling"
 RAW_REQUEST=$'POST /compile HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: abc\r\n\r\n{"code":"(define x 1)"}'
 RESULT=$(http_raw_request "127.0.0.1" "$PORT" "$RAW_REQUEST" 2>/dev/null || echo "")
-if echo "$RESULT" | grep -q "400 Bad Request" && kill -0 "$SERVER_PID" 2>/dev/null; then
+if grep -q "400 Bad Request" <<< "$RESULT" && kill -0 "$SERVER_PID" 2>/dev/null; then
     log_pass "invalid Content-Length"
 else
     log_fail "invalid Content-Length: $RESULT"
@@ -339,7 +339,7 @@ fi
 printf "Testing %-45s " "compile simple function"
 RESULT=$(http_post_json "http://localhost:$PORT/compile" \
     '{"code":"(define (square x) (* x x))","session_id":"test1"}' 2>/dev/null || echo "")
-if echo "$RESULT" | grep -q '"success":true'; then
+if grep -q '"success":true' <<< "$RESULT"; then
     log_pass "simple compile"
 else
     log_fail "simple compile: $RESULT"
@@ -349,7 +349,7 @@ fi
 printf "Testing %-45s " "compile with web externals"
 RESULT=$(http_post_json "http://localhost:$PORT/compile" \
     '{"code":"(extern i32 web-get-body :real web_get_body)\n(define (test) (web-get-body))","session_id":"test2"}' 2>/dev/null || echo "")
-if echo "$RESULT" | grep -q '"success":true'; then
+if grep -q '"success":true' <<< "$RESULT"; then
     log_pass "web externals"
 else
     log_fail "web externals: $RESULT"
@@ -359,7 +359,7 @@ fi
 printf "Testing %-45s " "compile math functions"
 RESULT=$(http_post_json "http://localhost:$PORT/compile" \
     '{"code":"(define (circle-area r) (* 3.14159 (* r r)))","session_id":"test3"}' 2>/dev/null || echo "")
-if echo "$RESULT" | grep -q '"success":true'; then
+if grep -q '"success":true' <<< "$RESULT"; then
     log_pass "math functions"
 else
     log_fail "math functions: $RESULT"
@@ -369,7 +369,7 @@ fi
 printf "Testing %-45s " "error handling"
 RESULT=$(http_post_json "http://localhost:$PORT/compile" \
     '{"code":"(define incomplete","session_id":"test4"}' 2>/dev/null || echo "")
-if echo "$RESULT" | grep -q '"success":false'; then
+if grep -q '"success":false' <<< "$RESULT"; then
     log_pass "error handling"
 else
     log_fail "expected error for invalid code"
@@ -378,7 +378,7 @@ fi
 # Test: Static file serving - index.html
 printf "Testing %-45s " "static: index.html"
 RESULT=$(http_get "http://localhost:$PORT/" 2>/dev/null || echo "")
-if echo "$RESULT" | grep -q "Eshkol REPL"; then
+if grep -q "Eshkol REPL" <<< "$RESULT"; then
     log_pass "index.html"
 else
     log_fail "index.html not served"
@@ -387,7 +387,7 @@ fi
 # Test: Static file serving - style.css
 printf "Testing %-45s " "static: style.css"
 RESULT=$(http_get "http://localhost:$PORT/style.css" 2>/dev/null || echo "")
-if echo "$RESULT" | grep -q "Eshkol REPL Styles"; then
+if grep -q "Eshkol REPL Styles" <<< "$RESULT"; then
     log_pass "style.css"
 else
     log_fail "style.css not served"
@@ -396,7 +396,7 @@ fi
 # Test: Static file serving - eshkol-repl.js
 printf "Testing %-45s " "static: eshkol-repl.js"
 RESULT=$(http_get "http://localhost:$PORT/eshkol-repl.js" 2>/dev/null || echo "")
-if echo "$RESULT" | grep -q "class EshkolRepl"; then
+if grep -q "class EshkolRepl" <<< "$RESULT"; then
     log_pass "eshkol-repl.js"
 else
     log_fail "eshkol-repl.js not served"
@@ -406,7 +406,7 @@ fi
 printf "Testing %-45s " "WASM binary response"
 RESULT=$(http_post_json "http://localhost:$PORT/compile" \
     '{"code":"(define x 42)","session_id":"test5"}' 2>/dev/null || echo "")
-if echo "$RESULT" | grep -q '"wasm":"AGFzbQ'; then
+if grep -q '"wasm":"AGFzbQ' <<< "$RESULT"; then
     log_pass "WASM binary (base64)"
 else
     log_fail "no valid WASM in response"
@@ -416,7 +416,7 @@ fi
 printf "Testing %-45s " "multiple definitions"
 RESULT=$(http_post_json "http://localhost:$PORT/compile" \
     '{"code":"(define a 1)\n(define b 2)\n(define (add x y) (+ x y))","session_id":"test6"}' 2>/dev/null || echo "")
-if echo "$RESULT" | grep -q '"success":true'; then
+if grep -q '"success":true' <<< "$RESULT"; then
     log_pass "multiple definitions"
 else
     log_fail "multiple definitions: $RESULT"
@@ -425,7 +425,7 @@ fi
 # Test: 404 handling
 printf "Testing %-45s " "404 handling"
 RESULT=$(http_get "http://localhost:$PORT/nonexistent" 2>/dev/null || echo "")
-if echo "$RESULT" | grep -qi "not found\|404"; then
+if grep -qi "not found\|404" <<< "$RESULT"; then
     log_pass "404 handling"
 else
     log_fail "404 not handled correctly"
@@ -435,7 +435,7 @@ fi
 printf "Testing %-45s " "session ID in response"
 RESULT=$(http_post_json "http://localhost:$PORT/compile" \
     '{"code":"(define y 0)","session_id":"mysession"}' 2>/dev/null || echo "")
-if echo "$RESULT" | grep -q '"session_id":"mysession"'; then
+if grep -q '"session_id":"mysession"' <<< "$RESULT"; then
     log_pass "session ID"
 else
     log_fail "session ID not returned"

--- a/site/static/eshkol-runtime.js
+++ b/site/static/eshkol-runtime.js
@@ -331,6 +331,8 @@ class EshkolRuntime {
                 eshkol_tensor_result_dtype_unary: (r) => r,
                 eshkol_type_error_with_operand: () => { throw new Error('Eshkol type error (WASM stub)'); },
                 eshkol_tensor_operand_checked: () => 0,
+                eshkol_format_double: () => 0,
+                eshkol_fprint_double: () => 0,
                 eshkol_set_error_location: () => {},
                 eshkol_lambda_registry_init: () => {},
                 eshkol_lambda_registry_add: () => {},

--- a/tests/numeric/numeric_tower_edge_test.esk
+++ b/tests/numeric/numeric_tower_edge_test.esk
@@ -1,0 +1,148 @@
+; Numeric-tower R7RS conformance edge cases (ESH-0065)
+;
+; Covers the four root gaps fixed in this change plus regression guards for
+; the numeric-tower behaviour that was already correct:
+;   1. (sqrt -4) / (sqrt -1) promote a negative EXACT real to the complex
+;      domain instead of returning NaN (R7RS 6.2.6).
+;   2. max/min apply inexactness CONTAGION: any inexact argument makes the
+;      result inexact.
+;   3. exact base ^ negative exact-integer exponent yields an exact rational.
+;   4. number->string / display emit +inf.0 / -inf.0 / +nan.0.
+
+(require stdlib)
+
+(display "TEST: Numeric tower R7RS edge cases") (newline)
+
+; ─── 1. sqrt of a negative EXACT real promotes to complex ──────────────────
+; (sqrt -4) => +2.0i : real part 0, imaginary part 2.0
+(display (if (= (real-part (sqrt -4)) 0.0) "PASS" "FAIL"))
+(display ": (sqrt -4) real-part is 0.0") (newline)
+(display (if (= (imag-part (sqrt -4)) 2.0) "PASS" "FAIL"))
+(display ": (sqrt -4) imag-part is 2.0 (complex +2.0i, not NaN)") (newline)
+(display (if (not (nan? (imag-part (sqrt -4)))) "PASS" "FAIL"))
+(display ": (sqrt -4) is not NaN") (newline)
+
+; (sqrt -1) => +i : imaginary part 1.0
+(display (if (= (imag-part (sqrt -1)) 1.0) "PASS" "FAIL"))
+(display ": (sqrt -1) imag-part is 1.0 (complex +i)") (newline)
+(display (if (= (real-part (sqrt -1)) 0.0) "PASS" "FAIL"))
+(display ": (sqrt -1) real-part is 0.0") (newline)
+
+; (sqrt -9) => +3.0i
+(display (if (= (imag-part (sqrt -9)) 3.0) "PASS" "FAIL"))
+(display ": (sqrt -9) imag-part is 3.0") (newline)
+
+; Positive sqrt is unaffected (stays a real)
+(display (if (= (sqrt 16) 4.0) "PASS" "FAIL"))
+(display ": (sqrt 16) = 4.0 (real path intact)") (newline)
+
+; log of a negative EXACT real promotes to complex: log(-1) = 0 + pi i
+(display (if (< (abs (- (imag-part (log -1)) 3.141592653589793)) 1e-12) "PASS" "FAIL"))
+(display ": (log -1) imag-part is pi (complex)") (newline)
+
+; ─── 2. max/min inexactness contagion ──────────────────────────────────────
+; (max 1 2.0) => 2.0 (inexact, because one argument is inexact)
+(display (if (= (max 1 2.0) 2.0) "PASS" "FAIL"))
+(display ": (max 1 2.0) = 2.0") (newline)
+(display (if (inexact? (max 1 2.0)) "PASS" "FAIL"))
+(display ": (max 1 2.0) is inexact (contagion)") (newline)
+
+; (min 1.0 2) => 1.0 (inexact)
+(display (if (= (min 1.0 2) 1.0) "PASS" "FAIL"))
+(display ": (min 1.0 2) = 1.0") (newline)
+(display (if (inexact? (min 1.0 2)) "PASS" "FAIL"))
+(display ": (min 1.0 2) is inexact (contagion)") (newline)
+
+; Contagion also fires when the inexact arg is NOT the one selected.
+(display (if (inexact? (max 5 1.0)) "PASS" "FAIL"))
+(display ": (max 5 1.0) is inexact even though 5 is selected") (newline)
+(display (if (inexact? (min 0.0 7)) "PASS" "FAIL"))
+(display ": (min 0.0 7) is inexact even though 0.0 is selected") (newline)
+
+; All-exact stays exact.
+(display (if (exact? (max 3 5)) "PASS" "FAIL"))
+(display ": (max 3 5) is exact (no inexact args)") (newline)
+(display (if (exact? (min 3 5)) "PASS" "FAIL"))
+(display ": (min 3 5) is exact (no inexact args)") (newline)
+
+; ─── 3. exact base ^ negative exact integer = exact rational ───────────────
+; (expt 2 -2) => 1/4 (exact)
+(display (if (= (expt 2 -2) 1/4) "PASS" "FAIL"))
+(display ": (expt 2 -2) = 1/4") (newline)
+(display (if (exact? (expt 2 -2)) "PASS" "FAIL"))
+(display ": (expt 2 -2) is exact") (newline)
+(display (if (rational? (expt 2 -2)) "PASS" "FAIL"))
+(display ": (expt 2 -2) is rational") (newline)
+
+; (expt 3 -2) => 1/9 ; (expt 2 -3) => 1/8
+(display (if (= (expt 3 -2) 1/9) "PASS" "FAIL"))
+(display ": (expt 3 -2) = 1/9") (newline)
+(display (if (= (expt 2 -3) 1/8) "PASS" "FAIL"))
+(display ": (expt 2 -3) = 1/8") (newline)
+
+; Negative base sign discipline: (expt -2 -2) = 1/4 ; (expt -2 -3) = -1/8
+(display (if (= (expt -2 -2) 1/4) "PASS" "FAIL"))
+(display ": (expt -2 -2) = 1/4") (newline)
+(display (if (= (expt -2 -3) -1/8) "PASS" "FAIL"))
+(display ": (expt -2 -3) = -1/8") (newline)
+
+; Non-negative exact expt still exact integer (regression guard).
+(display (if (= (expt 2 10) 1024) "PASS" "FAIL"))
+(display ": (expt 2 10) = 1024 (exact)") (newline)
+(display (if (exact? (expt 2 10)) "PASS" "FAIL"))
+(display ": (expt 2 10) is exact") (newline)
+
+; ─── 4. number->string / display of inf / -inf / nan ───────────────────────
+(display (if (string=? (number->string (/ 1.0 0.0)) "+inf.0") "PASS" "FAIL"))
+(display ": (number->string (/ 1.0 0.0)) = \"+inf.0\"") (newline)
+(display (if (string=? (number->string (/ -1.0 0.0)) "-inf.0") "PASS" "FAIL"))
+(display ": (number->string (/ -1.0 0.0)) = \"-inf.0\"") (newline)
+(display (if (string=? (number->string +nan.0) "+nan.0") "PASS" "FAIL"))
+(display ": (number->string +nan.0) = \"+nan.0\"") (newline)
+(display (if (string=? (number->string +inf.0) "+inf.0") "PASS" "FAIL"))
+(display ": (number->string +inf.0) = \"+inf.0\"") (newline)
+; finite doubles keep their ordinary representation (no regression)
+(display (if (string=? (number->string 3.5) "3.5") "PASS" "FAIL"))
+(display ": (number->string 3.5) = \"3.5\" (finite unchanged)") (newline)
+
+; Visible display of an infinity (eyeball line; should read +inf.0)
+(display "display of (/ 1.0 0.0): ") (display (/ 1.0 0.0)) (newline)
+
+; ─── Regression guards: already-correct numeric-tower behaviour ────────────
+; int64 -> bignum overflow promotion
+(display (if (= (expt 2 64) 18446744073709551616) "PASS" "FAIL"))
+(display ": (expt 2 64) bignum overflow exact") (newline)
+(display (if (> (expt 2 100) 0) "PASS" "FAIL"))
+(display ": (expt 2 100) positive bignum") (newline)
+
+; banker's rounding (round half to even)
+(display (if (= (round 2.5) 2.0) "PASS" "FAIL"))
+(display ": (round 2.5) = 2.0 (round half to even)") (newline)
+(display (if (= (round 3.5) 4.0) "PASS" "FAIL"))
+(display ": (round 3.5) = 4.0 (round half to even)") (newline)
+(display (if (= (round 0.5) 0.0) "PASS" "FAIL"))
+(display ": (round 0.5) = 0.0 (round half to even)") (newline)
+
+; rational reduction
+(display (if (= 2/4 1/2) "PASS" "FAIL"))
+(display ": 2/4 reduces to 1/2") (newline)
+(display (if (= (numerator 6/9) 2) "PASS" "FAIL"))
+(display ": (numerator 6/9) = 2 (reduced)") (newline)
+(display (if (= (denominator 6/9) 3) "PASS" "FAIL"))
+(display ": (denominator 6/9) = 3 (reduced)") (newline)
+
+; modulo / remainder sign conventions
+(display (if (= (modulo -7 3) 2) "PASS" "FAIL"))
+(display ": (modulo -7 3) = 2") (newline)
+(display (if (= (remainder -7 3) -1) "PASS" "FAIL"))
+(display ": (remainder -7 3) = -1") (newline)
+(display (if (= (modulo 7 -3) -2) "PASS" "FAIL"))
+(display ": (modulo 7 -3) = -2") (newline)
+
+; bignum bitwise
+(display (if (= (bitwise-and 12 10) 8) "PASS" "FAIL"))
+(display ": (bitwise-and 12 10) = 8") (newline)
+(display (if (= (bitwise-or 12 10) 14) "PASS" "FAIL"))
+(display ": (bitwise-or 12 10) = 14") (newline)
+
+(display "DONE: numeric tower edge cases") (newline)

--- a/web/eshkol-repl.js
+++ b/web/eshkol-repl.js
@@ -297,6 +297,8 @@ class EshkolRepl {
                 eshkol_tensor_result_dtype_unary: (r) => r,
                 eshkol_type_error_with_operand: () => { throw new Error('Eshkol type error (WASM stub)'); },
                 eshkol_tensor_operand_checked: () => 0,
+                eshkol_format_double: () => 0,
+                eshkol_fprint_double: () => 0,
                 eshkol_set_error_location: () => {},
                 eshkol_deep_equal: (a, b) => false,
                 eshkol_display_value: (val) => {},


### PR DESCRIPTION
## ESH-0065 — Numeric-tower R7RS conformance

Fixes four numeric-tower edge cases, handled as the tower's **exactness + promotion discipline** (single architectural sites, not one-off patches). Eshkol already had the bignum/rational/complex substrate; this wires the domain/exactness boundaries correctly.

### Root gaps → fixes

| # | Before | After | Where |
|---|--------|-------|-------|
| 1 | `(sqrt -4)` → `nan` | `(sqrt -4)` → `+2.0i`, `(sqrt -1)` → `+i`, `(log -1)` → `0+pi i` | `codegenMathFunction` (the one unary-math site) |
| 2 | `(max 1 2.0)` → exact `2` | `(max 1 2.0)` → inexact `2.0`; `(min 1.0 2)` → `1.0` | `codegenMinMax` contagion layer |
| 3 | `(expt 2 -2)` → inexact `0.25` | `(expt 2 -2)` → exact `1/4`; `(expt -2 -3)` → `-1/8` | `ArithmeticCodegen::pow` + `eshkol_bignum_pow_tagged` |
| 4 | `(display (/ 1.0 0.0))` → `inf` | `+inf.0` / `-inf.0` / `+nan.0` | `eshkol_format_double` (single double formatter) |

### Architectural notes
- **sqrt/log promotion is exactness-aware**: a negative *exact* real promotes to complex; an inexact (double) negative keeps IEEE NaN/-inf. This satisfies R7RS for the exact-arg cases while preserving the existing `infinity_nan_test` expectations (`(sqrt -1.0)` → NaN) and IEEE fast paths.
- **Contagion is a reusable layer** (`isInexactTagged` / `coerceToInexactIf`) applied across the whole min/max reduction, not a per-op hack.
- **Exact expt** drops the non-negative-exponent gate; the runtime owns sign discipline and rational construction, falling back to double only on int64 denominator overflow. Bignum-base detection tightened to `ESHKOL_IS_BIGNUM` so a rational base is no longer misread.
- **One double formatter** (`eshkol_format_double` / `eshkol_fprint_double`) is the single source of truth for display / write / `number->string` / logic-term printing. Finite doubles keep the existing `%g` convention (no regression); complex display now uses R7RS sign/±i form.

### Verification
- New `tests/numeric/numeric_tower_edge_test.esk` (43 checks): **43 PASS / 0 FAIL** in both `-r` (JIT) and AOT.
- Existing numeric suite green (0 FAIL): `infinity_nan`, `mixed_exact_inexact`, `complex_edge`, `rounding_edge`, `rational_edge`, `integer_boundary`.
- `scripts/run_icc_smoke.sh`: **28/29 PASS**. The lone failure (`example_agent_compiles`) is pre-existing/environmental — `examples/agent.esk` exists on neither this branch nor `master`.

Files changed: `inc/eshkol/eshkol.h`, `lib/backend/{arithmetic_codegen,llvm_codegen,string_io_codegen}.cpp`, `lib/core/{bignum,logic,runtime_display_hosted}.cpp`, `lib/repl/repl_jit.cpp`, `tests/numeric/numeric_tower_edge_test.esk`.

Do not merge — review requested.