### PR TITLE
fix(closure): share set!-mutated variables captured by multiple closures (assignment conversion) — ESH-0074

### DIFF
--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -10035,6 +10035,33 @@ private:
             builder->SetInsertPoint(tco_loop_bb);
         }
 
+        // ASSIGNMENT CONVERSION (ESH-0074): box set!-mutated parameters.
+        // Function parameters arrive as by-value Arguments. A parameter that is
+        // set!-mutated needs a mutable cell (alloca) so that (a) set! has a
+        // storage location to write to, and (b) any closures that capture it
+        // share ONE cell — the existing let-bound-alloca capture machinery
+        // (arena-move + multi-closure sharing) then applies automatically.
+        // This generalizes PR #50 (named-let loopvar) to all captured,
+        // set!-mutated bindings (make-counter, make-account sibling closures).
+        // Skip when TCO already promoted parameters to *_tco allocas (the
+        // self-recursive / named-let path keeps its own loopvar handling).
+        if (!use_tco && op->define_op.parameters && op->define_op.value) {
+            auto box_arg_it = function->arg_begin();
+            for (uint64_t i = 0; i < op->define_op.num_params && box_arg_it != function->arg_end(); ++i, ++box_arg_it) {
+                if (op->define_op.parameters[i].type == ESHKOL_VAR &&
+                    op->define_op.parameters[i].variable.id) {
+                    std::string pname = op->define_op.parameters[i].variable.id;
+                    if (astSetsVar(op->define_op.value, pname)) {
+                        AllocaInst* box = builder->CreateAlloca(tagged_value_type, nullptr, pname);
+                        builder->CreateStore(&(*box_arg_it), box);
+                        symbol_table[pname] = box;
+                        eshkol_debug("Assignment conversion: boxed set!-mutated param %s in %s",
+                                     pname.c_str(), func_name);
+                    }
+                }
+            }
+        }
+
         // RECURSIVE SHADOWING FIX: Register _func key BEFORE generating body
         // This allows recursive calls to shadow builtins (e.g., user's flatten vs tensor flatten)
         // The shadowing check at line 8120-8166 looks for func_name + "_func" in symbol tables
@@ -24237,6 +24264,27 @@ private:
             // Branch from entry to loop body
             builder->CreateBr(tco_loop_bb);
             builder->SetInsertPoint(tco_loop_bb);
+        }
+
+        // ASSIGNMENT CONVERSION (ESH-0074): box set!-mutated lambda parameters.
+        // Same rationale as codegenFunctionDefinition: a lambda parameter that is
+        // set!-mutated needs a mutable cell so set! works and so nested closures
+        // capturing it share ONE cell. Skip when TCO already promoted params to
+        // *_tco allocas (use_binding_tco re-binds params above).
+        if (!use_binding_tco && op->lambda_op.parameters && op->lambda_op.body) {
+            auto box_arg_it = lambda_func->arg_begin();
+            for (uint64_t i = 0; i < op->lambda_op.num_params && box_arg_it != lambda_func->arg_end(); ++i, ++box_arg_it) {
+                if (op->lambda_op.parameters[i].type == ESHKOL_VAR &&
+                    op->lambda_op.parameters[i].variable.id) {
+                    std::string pname = op->lambda_op.parameters[i].variable.id;
+                    if (astSetsVar(op->lambda_op.body, pname)) {
+                        AllocaInst* box = builder->CreateAlloca(tagged_value_type, nullptr, pname);
+                        builder->CreateStore(&(*box_arg_it), box);
+                        symbol_table[pname] = box;
+                        eshkol_debug("Assignment conversion: boxed set!-mutated lambda param %s", pname.c_str());
+                    }
+                }
+            }
         }
 
         // Generate lambda body

--- a/tests/closures/shared_mutable_capture_test.esk
+++ b/tests/closures/shared_mutable_capture_test.esk
@@ -1,0 +1,180 @@
+; ================================================================
+; Shared Mutable Capture Test Suite (ESH-0074)
+; A variable that is BOTH set!-mutated AND captured by two or more
+; closures must reference ONE shared mutable cell (assignment
+; conversion). Covers function-parameter and lambda-parameter
+; binding sites, nested and escaping closures, plus regression
+; guards for single-closure set! and the PR #50 named-let cases.
+; ================================================================
+
+(require stdlib)
+
+(define pass-count 0)
+(define fail-count 0)
+
+(define (test name expected actual)
+  (if (equal? expected actual)
+      (begin (set! pass-count (+ pass-count 1))
+             (display (string-append "PASS: " name "\n")))
+      (begin (set! fail-count (+ fail-count 1))
+             (display (string-append "FAIL: " name "\n"))
+             (display "  Expected: ") (display expected) (newline)
+             (display "  Actual:   ") (display actual) (newline))))
+
+; ================================================================
+; Section 1: make-counter — sibling lambdas over a set!-mutated param
+; ================================================================
+
+(define (make-counter n)
+  (cons (lambda () (set! n (+ n 1)) n)   ; inc
+        (lambda () n)))                    ; read
+
+(define c (make-counter 0))
+((car c))
+((car c))
+(test "make-counter: read sees both increments" 2 ((cdr c)))
+
+; Independent instances must not share state
+(define c2 (make-counter 100))
+((car c2))
+(test "make-counter: instance isolation (c still 2)" 2 ((cdr c)))
+(test "make-counter: instance isolation (c2 = 101)" 101 ((cdr c2)))
+
+; ================================================================
+; Section 2: make-account (SICP 3.1.1) — sibling internal-define
+;            closures over a shared set!-mutated parameter
+; ================================================================
+
+(define (make-account balance)
+  (define (withdraw amount)
+    (if (>= balance amount)
+        (begin (set! balance (- balance amount)) balance)
+        "Insufficient funds"))
+  (define (deposit amount)
+    (set! balance (+ balance amount))
+    balance)
+  (define (dispatch m)
+    (cond ((eq? m 'withdraw) withdraw)
+          ((eq? m 'deposit) deposit)
+          (else (error "Unknown request" m))))
+  dispatch)
+
+(define acc (make-account 100))
+(test "account-withdraw" 50 ((acc 'withdraw) 50))
+(test "account-deposit"  90 ((acc 'deposit) 40))
+(test "account-withdraw-2" 30 ((acc 'withdraw) 60))
+(test "account-deposit-2" 130 ((acc 'deposit) 100))
+
+; NOTE on cross-instance isolation of INTERNAL-DEFINE objects:
+; Two `make-account` instances built with *internal defines* currently alias
+; each other because internal-define functions (withdraw/deposit) are stored
+; in module-level globals (@letrecstar_*) that each call overwrites, and the
+; returned dispatcher captures the global's address. That is a SEPARATE,
+; pre-existing bug in the letrec local-function codegen path
+; (lib/backend/binding_codegen.cpp) — NOT the set!-mutated-shared-capture bug
+; (ESH-0074) fixed here. Instance isolation IS exercised below for the
+; constructs ESH-0074 covers: make-counter (param + sibling lambdas) and the
+; explicit let-lambda object form.
+
+; Explicit let-lambda object form: instance isolation works
+(define (make-account/lambda balance)
+  (let ((withdraw (lambda (amount) (set! balance (- balance amount)) balance))
+        (deposit  (lambda (amount) (set! balance (+ balance amount)) balance)))
+    (lambda (m)
+      (cond ((eq? m 'withdraw) withdraw)
+            ((eq? m 'deposit) deposit)))))
+
+(define la1 (make-account/lambda 100))
+(define la2 (make-account/lambda 100))
+(test "lambda-account la1 withdraw" 90 ((la1 'withdraw) 10))
+(test "lambda-account la2 isolated" 80 ((la2 'withdraw) 20))
+(test "lambda-account la1 unaffected" 91 ((la1 'deposit) 1))
+
+; ================================================================
+; Section 3: nested-closure-shared — inner closure mutates a var the
+;            outer closure also reads; both share the cell
+; ================================================================
+
+(define (make-nested x)
+  (lambda ()
+    (cons (lambda () (set! x (+ x 10)) x)
+          (lambda () x))))
+
+(define mk (make-nested 5))
+(define pair (mk))
+((car pair))
+((car pair))
+(test "nested-closure-shared" 25 ((cdr pair)))
+
+; ================================================================
+; Section 4: escaping-closure-shared — closures returned/stored and
+;            invoked after the defining frame has returned
+; ================================================================
+
+(define (make-pair-ops init)
+  (let ((get (lambda () init))
+        (set (lambda (v) (set! init v) init)))
+    (cons get set)))
+
+(define ops (make-pair-ops 7))
+(test "escaping-closure initial" 7 ((car ops)))
+((cdr ops) 42)
+(test "escaping-closure after set via sibling" 42 ((car ops)))
+
+; ================================================================
+; Section 5: REGRESSION — single-closure set! capture (must still work)
+; ================================================================
+
+(define (make-withdraw balance)
+  (lambda (amount)
+    (if (>= balance amount)
+        (begin (set! balance (- balance amount)) balance)
+        "Insufficient funds")))
+
+(define w (make-withdraw 100))
+(test "single-closure set! call 1" 60 (w 40))
+(test "single-closure set! call 2" 30 (w 30))
+
+(define (make-accumulator total)
+  (lambda (amount)
+    (set! total (+ total amount))
+    total))
+
+(define a (make-accumulator 5))
+(test "make-accumulator 1" 15 (a 10))
+(test "make-accumulator 2" 25 (a 10))
+
+; ================================================================
+; Section 6: REGRESSION — plain set! on a (non-captured) parameter
+; ================================================================
+
+(define (set-param x)
+  (set! x 5)
+  x)
+(test "set! on plain param" 5 (set-param 1))
+
+; ================================================================
+; Section 7: REGRESSION — named-let loop var captured in body (PR #50)
+; ================================================================
+
+(define (collect-closures)
+  (let loop ((i 0) (acc '()))
+    (if (>= i 3)
+        (reverse acc)
+        (loop (+ i 1) (cons (lambda () i) acc)))))
+
+(define cls (collect-closures))
+(test "named-let captured loopvar 0" 0 ((car cls)))
+(test "named-let captured loopvar 1" 1 ((car (cdr cls))))
+(test "named-let captured loopvar 2" 2 ((car (cdr (cdr cls)))))
+
+; ================================================================
+; Summary
+; ================================================================
+(newline)
+(display "==== Shared Mutable Capture Test Results ====") (newline)
+(display "Passed: ") (display pass-count) (newline)
+(display "Failed: ") (display fail-count) (newline)
+(if (= fail-count 0)
+    (begin (display "ALL TESTS PASSED") (newline))
+    (begin (display "SOME TESTS FAILED") (newline)))

--- a/tests/sicp/ch3_accounts.esk
+++ b/tests/sicp/ch3_accounts.esk
@@ -1,0 +1,106 @@
+; ================================================================
+; SICP Chapter 3.1.1 — Local State Variables (bank accounts)
+; Exercises the canonical "objects with local state" pattern: sibling
+; closures (withdraw/deposit) sharing a single set!-mutated `balance`.
+; Requires shared-mutable-capture (assignment conversion) — ESH-0074.
+; ================================================================
+
+(require stdlib)
+
+(define pass-count 0)
+(define fail-count 0)
+
+(define (test name expected actual)
+  (if (equal? expected actual)
+      (begin (set! pass-count (+ pass-count 1))
+             (display (string-append "PASS: " name "\n")))
+      (begin (set! fail-count (+ fail-count 1))
+             (display (string-append "FAIL: " name "\n"))
+             (display "  Expected: ") (display expected) (newline)
+             (display "  Actual:   ") (display actual) (newline))))
+
+; ---------------------------------------------------------------
+; make-withdraw (single closure over a set!-mutated parameter)
+; ---------------------------------------------------------------
+(define (make-withdraw balance)
+  (lambda (amount)
+    (if (>= balance amount)
+        (begin (set! balance (- balance amount)) balance)
+        "Insufficient funds")))
+
+(define W1 (make-withdraw 100))
+(test "make-withdraw call 1" 50 (W1 50))
+(test "make-withdraw call 2" 25 (W1 25))
+(test "make-withdraw insufficient" "Insufficient funds" (W1 60))
+
+; ---------------------------------------------------------------
+; make-account (message-passing object: sibling closures share balance)
+; ---------------------------------------------------------------
+(define (make-account balance)
+  (define (withdraw amount)
+    (if (>= balance amount)
+        (begin (set! balance (- balance amount)) balance)
+        "Insufficient funds"))
+  (define (deposit amount)
+    (set! balance (+ balance amount))
+    balance)
+  (define (dispatch m)
+    (cond ((eq? m 'withdraw) withdraw)
+          ((eq? m 'deposit) deposit)
+          (else (error "Unknown request -- MAKE-ACCOUNT" m))))
+  dispatch)
+
+(define acc (make-account 100))
+(test "account-withdraw" 50 ((acc 'withdraw) 50))
+(test "account-deposit"  90 ((acc 'deposit) 40))
+(test "account-withdraw-2" 30 ((acc 'withdraw) 60))
+(test "account-deposit-2" 130 ((acc 'deposit) 100))
+
+; ---------------------------------------------------------------
+; Independent accounts must keep independent state.
+; NOTE: The canonical INTERNAL-DEFINE make-account above currently aliases
+; balance across instances — a SEPARATE pre-existing bug in the letrec
+; local-function codegen (internal-define functions live in @letrecstar_*
+; module globals overwritten per call), NOT the ESH-0074 shared-mutable-
+; capture bug fixed here. Isolation is therefore verified using the explicit
+; let-lambda object form, which ESH-0074 fully supports.
+; ---------------------------------------------------------------
+(define (make-account/lambda balance)
+  (let ((withdraw (lambda (amount)
+                    (if (>= balance amount)
+                        (begin (set! balance (- balance amount)) balance)
+                        "Insufficient funds")))
+        (deposit  (lambda (amount)
+                    (set! balance (+ balance amount))
+                    balance)))
+    (lambda (m)
+      (cond ((eq? m 'withdraw) withdraw)
+            ((eq? m 'deposit) deposit)
+            (else (error "Unknown request -- MAKE-ACCOUNT" m))))))
+
+(define accL1 (make-account/lambda 100))
+(define accL2 (make-account/lambda 100))
+(test "lambda-account L1 withdraw" 60 ((accL1 'withdraw) 40))
+(test "lambda-account L2 independent" 70 ((accL2 'withdraw) 30))
+(test "lambda-account L1 unaffected" 80 ((accL1 'deposit) 20))
+
+; ---------------------------------------------------------------
+; make-accumulator (SICP 3.1.1 ex 3.1)
+; ---------------------------------------------------------------
+(define (make-accumulator total)
+  (lambda (amount)
+    (set! total (+ total amount))
+    total))
+
+(define A (make-accumulator 5))
+(test "accumulator 1" 15 (A 10))
+(test "accumulator 2" 25 (A 10))
+
+; ================================================================
+(newline)
+(display "==== SICP ch3 accounts results ====") (newline)
+(display "Passed: ") (display pass-count) (newline)
+(display "Failed: ") (display fail-count) (newline)
+(if (= fail-count 0)
+    (begin (display "ALL TESTS PASSED") (newline))
+    (begin (display "SOME TESTS FAILED") (newline)))


### PR DESCRIPTION
## Summary

A variable that is **both `set!`-mutated and captured by two or more closures** was not shared — each closure received a private by-value snapshot. This broke SICP §3.1.1 local-state objects (`make-account`'s sibling `withdraw`/`deposit` over a shared `balance`), the `make-counter` idiom, and the whole "local state / objects / message-passing" style. It also broke plain `set!` on a non-captured parameter.

```scheme
(define (make-counter n)
  (cons (lambda () (set! n (+ n 1)) n)   ; inc
        (lambda () n)))                    ; read
(define c (make-counter 0))
((car c)) ((car c))
(display ((cdr c)))   ; was 0, now 2
```

## Root cause

Let-bound variables are boxed into a single arena cell at capture time (the existing escape / arena-move path, shared across closures via the `CallInst` arena branch). But function- and lambda-**parameters** were stored as by-value LLVM `Argument`s. An `Argument` has no storage location, so:

1. `set!` had nowhere to write → `set!: variable 'x' is not mutable`.
2. The lazy arena-move (which only fires for `AllocaInst`) never ran, leaving every capturing closure with its own snapshot.

## Fix — classic assignment conversion

At each parameter binding site (`codegenFunctionDefinition` and `codegenLambda`), any parameter that is `set!`-mutated in the body (`astSetsVar`) is promoted to an `alloca` seeded from the incoming `Argument`, and the symbol table points at that alloca. The existing let-bound-alloca capture machinery (arena-move + multi-closure sharing) then applies unchanged, giving **one shared mutable cell** across the defining frame and every capturing closure.

This **generalizes PR #50** (named-let loopvar arena-move) to all `set!`-mutated captured bindings instead of adding a parallel path. TCO-promoted params (`*_tco`) keep their existing handling. Change is localized to the closure-capture / `set!` region of `lib/backend/llvm_codegen.cpp` (no autodiff/tape overlap; no new C runtime symbol, so no `repl_jit.cpp` change).

## Before / after

| case | before | after |
|------|--------|-------|
| `make-counter 0`; inc; inc; read | `0` | `2` |
| `(define (f x) (set! x 5) x) (f 1)` | ERROR "not mutable"; `1` | `5` |
| `ch3_accounts` `account-deposit` | expected 90, **actual 140** | **90** (all within-instance cases pass) |

## Verification (both pipelines: `eshkol-run -r` AND AOT `eshkol-run -o`)

- `tests/closures/shared_mutable_capture_test.esk` — 21/21 (make-counter, make-account, nested-closure-shared, escaping-closure-shared, + regression guards)
- `tests/sicp/ch3_accounts.esk` — 12/12
- `tests/closures/closure_edge_test.esk` — 40/40 (regression)
- `tests/tco/nested_tco_test.esk`, `tests/control_flow/tco_validation_test.esk` — PASS (regression)
- `scripts/run_icc_smoke.sh` — all closure and AD/gradient probes PASS (1 unrelated failure: `example_agent_compiles`, `examples/agent.esk` absent on master too)

## Out of scope (separate pre-existing bug)

Two `make-account` instances built with **internal defines** still alias each other's `balance`. That is a distinct, pre-existing bug in the **letrec local-function codegen**: internal-define functions live in `@letrecstar_*` module globals overwritten per activation, and the returned dispatcher captures the global's *address*. It is independent of this `set!`/capture fix (it reproduces even with a let-bound, non-`set!`-from-param `balance`). Instance isolation is covered in the tests here via the explicit let-lambda object form, which works correctly.

## Relation to #50

PR #50 narrowly arena-moved set!-mutated captures for named-let loop vars (`mutable_loop_captures_`). This PR applies the same assignment-conversion principle uniformly at the parameter binding site, so loops, sibling closures, nested closures, and escaping closures all share one cell through the same machinery.