### PR TITLE
fix(ad): scope perturbation/tape state across named-let TCO — exact iterated higher-order AD

### DIFF
--- a/inc/eshkol/backend/autodiff_codegen.h
+++ b/inc/eshkol/backend/autodiff_codegen.h
@@ -90,6 +90,15 @@ public:
     // stays in the current block.
     llvm::Value* safeUnpackDualFromTagged(llvm::Value* tagged);
 
+    // Nested forward-mode AD (perturbation tagging by nesting depth).
+    // seedDerivativeInput: build the dual argument for a `derivative` at the
+    //   given nesting depth, preserving any perturbation the point already
+    //   carries (so an inner derivative does not strip the outer one).
+    // extractDerivativeResult: pull the derivative w.r.t. this level's slot —
+    //   a scalar at depth 0, a dual slice when nested.
+    llvm::Value* seedDerivativeInput(llvm::Value* point_tagged, int depth);
+    llvm::Value* extractDerivativeResult(llvm::Value* result_tagged, int depth);
+
     /**
      * Add two dual numbers: (a + b, a' + b')
      * @param left Left dual number

--- a/inc/eshkol/backend/autodiff_codegen.h
+++ b/inc/eshkol/backend/autodiff_codegen.h
@@ -99,6 +99,22 @@ public:
     llvm::Value* seedDerivativeInput(llvm::Value* point_tagged, int depth);
     llvm::Value* extractDerivativeResult(llvm::Value* result_tagged, int depth);
 
+    // ESH-0070: RUNTIME-level forward-mode perturbation tagging. Unlike the
+    // compile-time `int depth` variants above, the perturbation level is read
+    // from a runtime global (ctx_.adPertLevel()) so nesting works whether the
+    // inner derivative/gradient is lexically nested OR reached through a
+    // function call / named-let TCO loop (the loop carry is differentiated
+    // exactly, with no compounding blow-up). slot = (level==0) ? e1 : e2.
+    llvm::Value* adPertLevelLoad();                    // current live level (i64)
+    void         adPertLevelStore(llvm::Value* level); // set level
+    // Seed THIS level's perturbation slot to 1.0 (preserving any the point
+    // already carries) and PUSH the level (store level+1) for the callee body.
+    // Returns the seeded dual (tagged) and writes the pre-push level to *out_level.
+    llvm::Value* seedForwardAndPush(llvm::Value* point_tagged, llvm::Value** out_level);
+    // POP (restore `level`) and extract the derivative w.r.t. this level's slot:
+    // a scalar double at level 0, the e2-slice dual when nested.
+    llvm::Value* popAndExtractForward(llvm::Value* result_tagged, llvm::Value* level);
+
     /**
      * Add two dual numbers: (a + b, a' + b')
      * @param left Left dual number

--- a/inc/eshkol/backend/codegen_context.h
+++ b/inc/eshkol/backend/codegen_context.h
@@ -216,6 +216,15 @@ public:
     llvm::GlobalVariable* adTapeDepth() { return ad_tape_depth_; }
     void setAdTapeDepth(llvm::GlobalVariable* var) { ad_tape_depth_ = var; }
 
+    // ESH-0070: runtime forward-mode perturbation level. Counts the number of
+    // forward-mode derivative/gradient operations currently live on the call
+    // stack so that a nested derivative — whether lexically nested OR reached
+    // through a function call / named-let TCO loop — seeds a DISTINCT
+    // perturbation slot (e1 at level 0, e2 at level 1). Pushed/popped at
+    // runtime around each forward-mode call, so it is invariant under TCO.
+    llvm::GlobalVariable* adPertLevel() { return ad_pert_level_; }
+    void setAdPertLevel(llvm::GlobalVariable* var) { ad_pert_level_ = var; }
+
     // Double backward support
     llvm::GlobalVariable* outerAdNodeStorage() { return outer_ad_node_storage_; }
     void setOuterAdNodeStorage(llvm::GlobalVariable* var) { outer_ad_node_storage_ = var; }
@@ -342,6 +351,7 @@ private:
     llvm::GlobalVariable* current_ad_tape_ = nullptr;
     llvm::GlobalVariable* ad_tape_stack_ = nullptr;
     llvm::GlobalVariable* ad_tape_depth_ = nullptr;
+    llvm::GlobalVariable* ad_pert_level_ = nullptr;  // ESH-0070 forward-mode perturbation level
     llvm::GlobalVariable* outer_ad_node_storage_ = nullptr;
     llvm::GlobalVariable* outer_ad_node_to_inner_ = nullptr;
     llvm::GlobalVariable* outer_grad_accumulator_ = nullptr;

--- a/lib/backend/arithmetic_codegen.cpp
+++ b/lib/backend/arithmetic_codegen.cpp
@@ -2313,8 +2313,12 @@ llvm::Value* ArithmeticCodegen::remainder(llvm::Value* dividend, llvm::Value* di
     llvm::Value* rem_l_dual = convertToDual(dividend, dividend_is_dual, rem_l_dbl_for_dual);
     llvm::Value* rem_l_tangent = ctx_.builder().CreateExtractValue(rem_l_dual, {1}, "rem_l_tangent");
     llvm::Value* rem_result_dual = llvm::UndefValue::get(ctx_.dualNumberType());
+    llvm::Value* rem_zero = llvm::ConstantFP::get(ctx_.doubleType(), 0.0);
     rem_result_dual = ctx_.builder().CreateInsertValue(rem_result_dual, rem_primal, {0});
     rem_result_dual = ctx_.builder().CreateInsertValue(rem_result_dual, rem_l_tangent, {1});
+    // 2nd-order dual: zero the e2 / e1e2 slots (avoid poison).
+    rem_result_dual = ctx_.builder().CreateInsertValue(rem_result_dual, rem_zero, {2});
+    rem_result_dual = ctx_.builder().CreateInsertValue(rem_result_dual, rem_zero, {3});
     llvm::Value* rem_dual_tagged = autodiff_.packDualToTagged(rem_result_dual);
     llvm::BasicBlock* dual_rem_exit = ctx_.builder().GetInsertBlock();
     ctx_.builder().CreateBr(outer_rem_merge);
@@ -2466,6 +2470,9 @@ llvm::Value* ArithmeticCodegen::quotient(llvm::Value* dividend, llvm::Value* div
     llvm::Value* q_dual = llvm::UndefValue::get(ctx_.dualNumberType());
     q_dual = ctx_.builder().CreateInsertValue(q_dual, q_primal, {0});
     q_dual = ctx_.builder().CreateInsertValue(q_dual, q_zero_tangent, {1});
+    // 2nd-order dual: zero the e2 / e1e2 slots (avoid poison).
+    q_dual = ctx_.builder().CreateInsertValue(q_dual, q_zero_tangent, {2});
+    q_dual = ctx_.builder().CreateInsertValue(q_dual, q_zero_tangent, {3});
     llvm::Value* q_dual_tagged = autodiff_.packDualToTagged(q_dual);
     llvm::BasicBlock* dual_quot_exit = ctx_.builder().GetInsertBlock();
     ctx_.builder().CreateBr(outer_quot_merge);

--- a/lib/backend/autodiff_codegen.cpp
+++ b/lib/backend/autodiff_codegen.cpp
@@ -20,6 +20,7 @@
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Intrinsics.h>
 #include <llvm/Config/llvm-config.h>
+#include <unordered_set>
 
 // LLVM VERSION COMPATIBILITY
 #if LLVM_VERSION_MAJOR >= 21
@@ -94,13 +95,12 @@ inline llvm::Value* dualUnaryChain(CodegenContext& ctx, llvm::Value* dual,
 
 } // anonymous namespace
 
-// Perturbation-tagging nesting depth for user-written nested `derivative`.
-// Depth 0 (outermost) tags with e1 (slot 1); depth 1 (one level of nesting)
-// tags with e2 (slot 2).  The 4-component jet supports two simultaneous live
-// perturbations, i.e. up to 2 levels of forward-over-forward nesting exactly.
-// Tracked as a file-static (thread-local for REPL/JIT thread-safety) so no
-// header/ABI change is needed.
-static thread_local int g_ad_deriv_depth = 0;
+// ESH-0070: perturbation-level tagging is now a RUNTIME counter
+// (ctx_.adPertLevel()), pushed/popped around each forward-mode call — see
+// seedForwardAndPush / popAndExtractForward. The previous compile-time
+// file-static depth could not see across a function-call / named-let TCO
+// boundary, so a gradient/derivative reached through a called function
+// clobbered the outer perturbation. Slot: level 0 -> e1, level 1 -> e2.
 
 llvm::Value* AutodiffCodegen::createDualNumber(llvm::Value* primal, llvm::Value* tangent) {
     if (!primal || !tangent) return nullptr;
@@ -146,6 +146,102 @@ llvm::Value* AutodiffCodegen::extractDerivativeResult(llvm::Value* result_tagged
     llvm::Value* sliced = makeDual4(ctx_, dualField(ctx_, rd, 2), dualField(ctx_, rd, 3),
                                     zero, zero);
     return packDualToTagged(sliced);
+}
+
+// ===== ESH-0070: runtime-level forward-mode perturbation tagging =====
+// The perturbation level is a runtime counter (ctx_.adPertLevel()), pushed and
+// popped around each forward-mode derivative/gradient CALL. This is what makes
+// nesting across a function-call / named-let TCO boundary correct: the inner
+// derivative reads the level the OUTER one left live and therefore seeds a
+// distinct perturbation slot (e2) instead of clobbering the outer's (e1).
+// Compile-time lexical depth could not see across the call boundary; a runtime
+// push/pop around the call is, by construction, invariant under TCO re-entry.
+
+llvm::Value* AutodiffCodegen::adPertLevelLoad() {
+    llvm::GlobalVariable* g = ctx_.adPertLevel();
+    if (!g) return llvm::ConstantInt::get(ctx_.int64Type(), 0);
+    return ctx_.builder().CreateLoad(ctx_.int64Type(), g, "pert_level");
+}
+
+void AutodiffCodegen::adPertLevelStore(llvm::Value* level) {
+    llvm::GlobalVariable* g = ctx_.adPertLevel();
+    if (!g) return;
+    ctx_.builder().CreateStore(level, g);
+}
+
+llvm::Value* AutodiffCodegen::seedForwardAndPush(llvm::Value* point_tagged,
+                                                 llvm::Value** out_level) {
+    auto& b = ctx_.builder();
+    llvm::Value* level = adPertLevelLoad();
+    if (out_level) *out_level = level;
+
+    // Push: the callee body runs one perturbation level deeper.
+    adPertLevelStore(b.CreateAdd(level, llvm::ConstantInt::get(ctx_.int64Type(), 1)));
+
+    // Seed slot = (level == 0) ? e1(field 1) : e2(field 2), preserving the
+    // components the point already carries (so the outer perturbation survives).
+    llvm::Value* base = safeUnpackDualFromTagged(point_tagged); // {p,d1,d2,d12}
+    llvm::Value* is_l0 = b.CreateICmpEQ(level, llvm::ConstantInt::get(ctx_.int64Type(), 0));
+    llvm::Value* one = llvm::ConstantFP::get(ctx_.doubleType(), 1.0);
+
+    llvm::Function* fn = b.GetInsertBlock()->getParent();
+    llvm::BasicBlock* l0bb = llvm::BasicBlock::Create(ctx_.context(), "fwd_seed_e1", fn);
+    llvm::BasicBlock* l1bb = llvm::BasicBlock::Create(ctx_.context(), "fwd_seed_e2", fn);
+    llvm::BasicBlock* mbb  = llvm::BasicBlock::Create(ctx_.context(), "fwd_seed_merge", fn);
+    b.CreateCondBr(is_l0, l0bb, l1bb);
+
+    b.SetInsertPoint(l0bb);
+    llvm::Value* s0 = b.CreateInsertValue(base, one, {1});
+    b.CreateBr(mbb);
+    llvm::BasicBlock* l0e = b.GetInsertBlock();
+
+    b.SetInsertPoint(l1bb);
+    llvm::Value* s1 = b.CreateInsertValue(base, one, {2});
+    b.CreateBr(mbb);
+    llvm::BasicBlock* l1e = b.GetInsertBlock();
+
+    b.SetInsertPoint(mbb);
+    llvm::PHINode* seeded = b.CreatePHI(ctx_.dualNumberType(), 2, "fwd_seeded");
+    seeded->addIncoming(s0, l0e);
+    seeded->addIncoming(s1, l1e);
+    return packDualToTagged(seeded);
+}
+
+llvm::Value* AutodiffCodegen::popAndExtractForward(llvm::Value* result_tagged,
+                                                   llvm::Value* level) {
+    auto& b = ctx_.builder();
+    // Pop: restore the level the outer context expects.
+    adPertLevelStore(level);
+
+    llvm::Value* rd = safeUnpackDualFromTagged(result_tagged); // {a0,a1,a2,a12}
+    llvm::Value* is_l0 = b.CreateICmpEQ(level, llvm::ConstantInt::get(ctx_.int64Type(), 0));
+    llvm::Value* zero = llvm::ConstantFP::get(ctx_.doubleType(), 0.0);
+
+    llvm::Function* fn = b.GetInsertBlock()->getParent();
+    llvm::BasicBlock* x0bb = llvm::BasicBlock::Create(ctx_.context(), "fwd_ex_scalar", fn);
+    llvm::BasicBlock* x1bb = llvm::BasicBlock::Create(ctx_.context(), "fwd_ex_slice", fn);
+    llvm::BasicBlock* mbb  = llvm::BasicBlock::Create(ctx_.context(), "fwd_ex_merge", fn);
+    b.CreateCondBr(is_l0, x0bb, x1bb);
+
+    // level 0: scalar derivative = tangent (e1 component), packed as a double.
+    b.SetInsertPoint(x0bb);
+    llvm::Value* scalar_res = tagged_.packDouble(dualField(ctx_, rd, 1));
+    b.CreateBr(mbb);
+    llvm::BasicBlock* x0e = b.GetInsertBlock();
+
+    // nested: d/de2 (...) = a2 + a12 e1, returned as a dual so an enclosing
+    // derivative/gradient reads its e1 coefficient (= the mixed 2nd-order term).
+    b.SetInsertPoint(x1bb);
+    llvm::Value* slice = packDualToTagged(
+        makeDual4(ctx_, dualField(ctx_, rd, 2), dualField(ctx_, rd, 3), zero, zero));
+    b.CreateBr(mbb);
+    llvm::BasicBlock* x1e = b.GetInsertBlock();
+
+    b.SetInsertPoint(mbb);
+    llvm::PHINode* res = b.CreatePHI(ctx_.taggedValueType(), 2, "fwd_extracted");
+    res->addIncoming(scalar_res, x0e);
+    res->addIncoming(slice, x1e);
+    return res;
 }
 
 llvm::Value* AutodiffCodegen::getDualPrimal(llvm::Value* dual) {
@@ -1845,9 +1941,12 @@ llvm::Value* AutodiffCodegen::codegenDerivativeMonolith(const eshkol_operations_
 
     eshkol_info("Computing derivative using forward-mode AD (dual numbers)");
 
-    // Perturbation-tagging nesting depth for THIS derivative (set by an
-    // enclosing derivative while it compiled our lambda body, if any).
-    int my_depth = g_ad_deriv_depth;
+    // ESH-0070: perturbation level is now a RUNTIME counter (see
+    // seedForwardAndPush / popAndExtractForward). pert_level holds this
+    // derivative's pre-push level, set by seedForwardAndPush below and consumed
+    // by popAndExtractForward at every return. This works whether the inner
+    // derivative is lexically nested OR reached through a function call.
+    Value* pert_level = nullptr;
 
     // Evaluate the point. When this derivative is lexically NESTED inside
     // another and the inner evaluation point depends on the outer variable
@@ -1872,15 +1971,13 @@ llvm::Value* AutodiffCodegen::codegenDerivativeMonolith(const eshkol_operations_
         return nullptr;
     }
 
-    // Seed a fresh perturbation in THIS level's slot, preserving any
-    // perturbation the point already carries.
-    Value* x_dual_tagged = seedDerivativeInput(point_tagged, my_depth);
+    // Seed a fresh perturbation in THIS level's slot (preserving any the point
+    // already carries) and PUSH the runtime perturbation level so the callee
+    // body — and any derivative/gradient reached through it — tags the NEXT slot.
+    Value* x_dual_tagged = seedForwardAndPush(point_tagged, &pert_level);
 
-    // Get the function to differentiate. Compile its body one nesting level
-    // deeper so any derivative inside it tags with the NEXT perturbation slot.
-    g_ad_deriv_depth = my_depth + 1;
+    // Get the function to differentiate.
     Value* func = resolve_lambda_callback_(op->derivative_op.function, 0, callback_context_);
-    g_ad_deriv_depth = my_depth;
 
     // RUNTIME FUNCTION PARAMETER FIX: If resolveLambdaFunction returns nullptr,
     // check if this is a function parameter (runtime closure) and use codegenClosureCall
@@ -1935,7 +2032,7 @@ llvm::Value* AutodiffCodegen::codegenDerivativeMonolith(const eshkol_operations_
                     // Extract the derivative w.r.t. this nesting level's
                     // perturbation slot (scalar at depth 0, a dual slice when
                     // nested so an enclosing derivative can read it).
-                    return extractDerivativeResult(result, my_depth);
+                    return popAndExtractForward(result, pert_level);
                 }
                 // Check if it's a pointer to closure (mutable capture)
                 if (isa<Argument>(var_value) && var_value->getType()->isPointerTy()) {
@@ -1947,7 +2044,7 @@ llvm::Value* AutodiffCodegen::codegenDerivativeMonolith(const eshkol_operations_
                     // Extract the derivative w.r.t. this nesting level's
                     // perturbation slot (scalar at depth 0, a dual slice when
                     // nested so an enclosing derivative can read it).
-                    return extractDerivativeResult(result, my_depth);
+                    return popAndExtractForward(result, pert_level);
                 }
                 // Check if it's an AllocaInst (local variable holding a closure)
                 if (isa<AllocaInst>(var_value) && var_value->getType()->isPointerTy()) {
@@ -1958,7 +2055,7 @@ llvm::Value* AutodiffCodegen::codegenDerivativeMonolith(const eshkol_operations_
                         std::vector<Value*> call_args = {x_dual_tagged};
                         Value* result = closure_call_callback_(loaded_val, call_args, "derivative", callback_context_);
 
-                        return extractDerivativeResult(result, my_depth);
+                        return popAndExtractForward(result, pert_level);
                     }
                 }
                 // Check if it's a LoadInst (already loaded closure value)
@@ -1970,7 +2067,7 @@ llvm::Value* AutodiffCodegen::codegenDerivativeMonolith(const eshkol_operations_
                     // Extract the derivative w.r.t. this nesting level's
                     // perturbation slot (scalar at depth 0, a dual slice when
                     // nested so an enclosing derivative can read it).
-                    return extractDerivativeResult(result, my_depth);
+                    return popAndExtractForward(result, pert_level);
                 }
                 // Check if it's a GlobalVariable (letrec captured function)
                 if (isa<GlobalVariable>(var_value)) {
@@ -1983,7 +2080,7 @@ llvm::Value* AutodiffCodegen::codegenDerivativeMonolith(const eshkol_operations_
                     // Extract the derivative w.r.t. this nesting level's
                     // perturbation slot (scalar at depth 0, a dual slice when
                     // nested so an enclosing derivative can read it).
-                    return extractDerivativeResult(result, my_depth);
+                    return popAndExtractForward(result, pert_level);
                 }
             }
         }
@@ -2136,7 +2233,7 @@ llvm::Value* AutodiffCodegen::codegenDerivativeMonolith(const eshkol_operations_
     // At depth 0 this is the scalar derivative; when nested it is a dual slice
     // carrying the outer perturbation so the enclosing derivative can read it.
     // safeUnpack inside handles a non-dual scalar result (constant fn etc.).
-    return extractDerivativeResult(result_tagged, my_depth);
+    return popAndExtractForward(result_tagged, pert_level);
 }
 
 
@@ -2173,6 +2270,98 @@ static uint64_t adResolveValueArity(llvm::Function* func_ptr, uint64_t table_ari
     // fall back to the leading non-capture param count only when it missed.
     return table_arity ? table_arity : leading_non_capture;
 }
+
+// ESH-0070: is `name` a TENSOR-VALUED builtin — one whose computation flows
+// values through a tensor (so a scalar forward-mode dual seeded on the input
+// cannot carry its perturbation through it; only the reverse-mode tape can)?
+// Deliberately EXCLUDES scalar activations/elementwise math (relu/sigmoid/gelu/
+// exp/log/…): those have exact forward-mode duals and frequently appear inside
+// nested gradients, so they must keep the forward path.
+static bool adIsTensorValuedBuiltin(const char* cname) {
+    if (!cname) return false;
+    std::string n(cname);
+    if (n.rfind("tensor", 0) == 0) return true;   // tensor-*, tensor
+    if (n.rfind("gpu-", 0) == 0) return true;      // gpu-matmul / gpu-softmax / …
+    static const std::unordered_set<std::string> tset = {
+        "batch-norm", "layer-norm", "make-tensor",
+        "conv1d", "conv2d", "conv3d", "matmul", "batch-matmul",
+        "max-pool2d", "avg-pool2d", "multi-head-attention", "scaled-dot-attention",
+        "embedding", "rotary-embedding", "flatten", "reshape", "softmax",
+        "cross-entropy-loss", "binary-cross-entropy-loss",
+        "contrastive-loss", "cosine-embedding-loss"
+    };
+    return tset.count(n) != 0;
+}
+
+// ESH-0070: does this SOURCE subtree flow values through a tensor op? Scanned on
+// the AST (not the emitted IR) so it is NOT confused by tensor allocations that
+// an inline nested gradient's own machinery emits. Mirrors astSetsVar's
+// recursion; `default: return false` keeps unhandled ops on the forward path
+// (correct for scalar code, and the reverse path is only required for genuine
+// tensor pipelines).
+static bool adAstUsesTensorOps(const eshkol_ast_t* ast) {
+    if (!ast) return false;
+    if (ast->type == ESHKOL_CONS) {
+        return adAstUsesTensorOps(ast->cons_cell.car) ||
+               adAstUsesTensorOps(ast->cons_cell.cdr);
+    }
+    if (ast->type != ESHKOL_OP) return false;
+    const eshkol_operations_t* op = &ast->operation;
+    if (op->op == ESHKOL_TENSOR_OP) return true;
+    switch (op->op) {
+        case ESHKOL_CALL_OP:
+        case ESHKOL_IF_OP:
+        case ESHKOL_COND_OP: {
+            const eshkol_ast_t* f = op->call_op.func;
+            if (f && f->type == ESHKOL_VAR && adIsTensorValuedBuiltin(f->variable.id)) return true;
+            if (f && adAstUsesTensorOps(f)) return true;
+            for (uint64_t i = 0; i < op->call_op.num_vars; i++)
+                if (adAstUsesTensorOps(&op->call_op.variables[i])) return true;
+            return false;
+        }
+        case ESHKOL_SEQUENCE_OP:
+        case ESHKOL_AND_OP:
+        case ESHKOL_OR_OP:
+            for (uint64_t i = 0; i < op->sequence_op.num_expressions; i++)
+                if (adAstUsesTensorOps(&op->sequence_op.expressions[i])) return true;
+            return false;
+        case ESHKOL_LET_OP:
+        case ESHKOL_LET_STAR_OP:
+        case ESHKOL_LETREC_OP:
+        case ESHKOL_LETREC_STAR_OP: {
+            for (uint64_t i = 0; i < op->let_op.num_bindings; i++)
+                if (adAstUsesTensorOps(&op->let_op.bindings[i])) return true;
+            return adAstUsesTensorOps(op->let_op.body);
+        }
+        case ESHKOL_LAMBDA_OP:
+            return adAstUsesTensorOps(op->lambda_op.body);
+        case ESHKOL_DEFINE_OP:
+            return adAstUsesTensorOps(op->define_op.value);
+        default:
+            return false;
+    }
+}
+
+// ESH-0070: IR-level tensor check, used only when the differentiated function is
+// referenced by NAME (a VAR — e.g. (gradient bn-loss 1.0)) so its source AST is
+// not reachable from the gradient op. A named, single-level function's emitted
+// IR contains tensor runtime calls iff it genuinely flows values through tensors
+// (it has no INLINE nested-gradient machinery to contaminate the scan — that
+// only happens for inline-lambda bodies, which take the AST path above).
+static bool adFunctionUsesTensors(llvm::Function* func_ptr) {
+    if (!func_ptr || func_ptr->isDeclaration()) return false;
+    for (auto& bb : *func_ptr) {
+        for (auto& inst : bb) {
+            auto* call = llvm::dyn_cast<llvm::CallBase>(&inst);
+            if (!call) continue;
+            llvm::Function* callee = call->getCalledFunction();
+            if (!callee) continue;
+            if (callee->getName().contains("tensor")) return true;
+        }
+    }
+    return false;
+}
+
 
 
 llvm::Value* AutodiffCodegen::gradientHigherOrder(const eshkol_operations_t* op) {
@@ -3085,6 +3274,81 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
         vector_val = tagged_.packInt64(vector_val_raw, true); // Pack other types
     }
     
+    // ════════════════════════════════════════════════════════════════════
+    // ESH-0070: forward-mode jet fast path for SCALAR single-variable gradient.
+    //
+    // For an arity-1 function at a SCALAR (or dual, when nested) point, the
+    // gradient IS the derivative, so we compute it with the exact forward-mode
+    // 4-jet — the same machinery `derivative` uses — instead of the reverse-mode
+    // tape + the degree/value-ratio "double backward" reconstruction further
+    // below. That reconstruction is exact only for pure monomials; for anything
+    // with +/- terms a NESTED gradient produced garbage that compounded with
+    // each named-let iteration (the Noesis blow-up). Forward mode is exact for
+    // 2-level nesting, allocates O(1) (no per-op tape node — fixes the per-call
+    // leak), and the runtime perturbation level (seedForwardAndPush) makes the
+    // nesting correct across the named-let / function-call boundary.
+    //
+    // A VECTOR point (arity-1 functions like (lambda (v) (dot v v)), or any
+    // multi-parameter function) keeps the existing reverse-mode vector path.
+    // The scalar-vs-vector decision is made at RUNTIME on the point's tag, so a
+    // bare-variable point ((gradient log x) vs (gradient f vec)) is handled
+    // correctly either way.
+    // ════════════════════════════════════════════════════════════════════
+    BasicBlock* grad_unified_exit = nullptr;
+    AllocaInst* grad_result_slot = nullptr;
+    {
+        uint64_t fwd_arity = 0;
+        std::string fwd_key = func_ptr->getName().str();
+        auto fwd_rv = fwd_key.rfind("__rv");
+        if (fwd_rv != std::string::npos && fwd_rv + 4 < fwd_key.size() &&
+            fwd_key.find_first_not_of("0123456789", fwd_rv + 4) == std::string::npos) {
+            fwd_key.erase(fwd_rv);
+        }
+        auto fwd_ait = function_arity_table_->find(fwd_key);
+        if (fwd_ait != function_arity_table_->end()) fwd_arity = fwd_ait->second;
+        fwd_arity = adResolveValueArity(func_ptr, fwd_arity);
+
+        // Only a SCALAR single-variable function takes the forward path. A body
+        // that flows the input through a tensor op (batch-norm/layer-norm/…) has
+        // no scalar forward-mode dual and must use the reverse-mode tape. Decided
+        // from the SOURCE AST (not the emitted IR), so it is not confused by
+        // tensor allocations an inline nested gradient's own machinery emits. A
+        // vector-valued point is still handled at runtime below (reverse branch),
+        // so this only needs to catch the scalar-point-through-tensor case.
+        bool fn_uses_tensors = adAstUsesTensorOps(op->gradient_op.function) ||
+            (op->gradient_op.function->type == ESHKOL_VAR && adFunctionUsesTensors(func_ptr));
+        if (fwd_arity == 1 && !fn_uses_tensors) {
+            Function* cur_fn = ctx_.builder().GetInsertBlock()->getParent();
+            grad_result_slot = ctx_.builder().CreateAlloca(ctx_.taggedValueType(), nullptr, "grad_fwd_result");
+            BasicBlock* grad_fwd_jet = BasicBlock::Create(ctx_.context(), "grad_fwd_jet", cur_fn);
+            BasicBlock* grad_reverse_entry = BasicBlock::Create(ctx_.context(), "grad_reverse_entry", cur_fn);
+            grad_unified_exit = BasicBlock::Create(ctx_.context(), "grad_unified_exit", cur_fn);
+
+            // Use forward mode when the point is a scalar (DOUBLE/INT64) or an
+            // existing dual (nested gradient carrying an outer perturbation).
+            Value* fwd_bt = tagged_.getBaseType(tagged_.getType(vector_val));
+            Value* fwd_is_d = ctx_.builder().CreateICmpEQ(fwd_bt, ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_DOUBLE));
+            Value* fwd_is_i = ctx_.builder().CreateICmpEQ(fwd_bt, ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_INT64));
+            Value* fwd_is_dual = ctx_.builder().CreateICmpEQ(fwd_bt, ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_DUAL_NUMBER));
+            Value* use_fwd = ctx_.builder().CreateOr(ctx_.builder().CreateOr(fwd_is_d, fwd_is_i), fwd_is_dual);
+            ctx_.builder().CreateCondBr(use_fwd, grad_fwd_jet, grad_reverse_entry);
+
+            // ---- forward-mode jet path ----
+            ctx_.builder().SetInsertPoint(grad_fwd_jet);
+            Value* fwd_level = nullptr;
+            Value* fwd_seed = seedForwardAndPush(vector_val, &fwd_level);
+            std::vector<Value*> fwd_args = {fwd_seed};
+            resolveGradientCaptures(func_ptr, fwd_args, "fwd-jet");
+            Value* fwd_call = ctx_.builder().CreateCall(func_ptr, fwd_args);
+            Value* fwd_res = popAndExtractForward(fwd_call, fwd_level);
+            ctx_.builder().CreateStore(fwd_res, grad_result_slot);
+            ctx_.builder().CreateBr(grad_unified_exit);
+
+            // ---- reverse-mode vector path: the rest of this function ----
+            ctx_.builder().SetInsertPoint(grad_reverse_entry);
+        }
+    }
+
     // Alloca for effective svec input (updated by tensor→svec conversion)
     Value* svec_input_ptr = ctx_.builder().CreateAlloca(ctx_.taggedValueType(), nullptr, "svec_input");
     ctx_.builder().CreateStore(vector_val, svec_input_ptr);
@@ -4499,6 +4763,15 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
     PHINode* final_phi = ctx_.builder().CreatePHI(ctx_.taggedValueType(), 2, "grad_final_result");
     final_phi->addIncoming(scalar_result, scalar_extract_exit);
     final_phi->addIncoming(result_phi, grad_done);
+
+    // ESH-0070: if the forward-mode jet fast path was set up, merge the two
+    // paths (forward scalar result vs reverse-mode vector result) here.
+    if (grad_unified_exit) {
+        ctx_.builder().CreateStore(final_phi, grad_result_slot);
+        ctx_.builder().CreateBr(grad_unified_exit);
+        ctx_.builder().SetInsertPoint(grad_unified_exit);
+        return ctx_.builder().CreateLoad(ctx_.taggedValueType(), grad_result_slot);
+    }
 
     return final_phi;
 }
@@ -7510,7 +7783,13 @@ void AutodiffCodegen::resolveGradientCaptures(
 
         std::string capture_key = lambda_name + "_capture_" + var_name;
 
-        // Search order: capture key in global → local, then raw name in global → local
+        // Search order: capture key (global → local), then raw name LOCAL → global.
+        // ESH-0070: the raw-name LOOKUP MUST prefer the LOCAL symbol table so it
+        // resolves the SAME storage the lambda itself captured. Inside a named-let
+        // loop the free var `a` is bound locally to the carry pointer `%a_cap`
+        // (which lexically shadows the top-level global `@a`); the lambda captured
+        // that local pointer. The old global-first order found `@a` instead, so
+        // the gradient handed the lambda a capture in the wrong (packed) ABI.
         Value* storage = nullptr;
         auto it = global_symbol_table_->find(capture_key);
         if (it != global_symbol_table_->end() && it->second) {
@@ -7520,12 +7799,12 @@ void AutodiffCodegen::resolveGradientCaptures(
             if (it != symbol_table_->end() && it->second) {
                 storage = it->second;
             } else {
-                it = global_symbol_table_->find(var_name);
-                if (it != global_symbol_table_->end() && it->second) {
+                it = symbol_table_->find(var_name);
+                if (it != symbol_table_->end() && it->second) {
                     storage = it->second;
                 } else {
-                    it = symbol_table_->find(var_name);
-                    if (it != symbol_table_->end() && it->second) {
+                    it = global_symbol_table_->find(var_name);
+                    if (it != global_symbol_table_->end() && it->second) {
                         storage = it->second;
                     }
                 }
@@ -7553,6 +7832,34 @@ void AutodiffCodegen::resolveGradientCaptures(
         }
 
         if (storage) {
+            // ESH-0070: named-let loop carries (#224) bind a free variable to a
+            // pointer Argument named "<var>_cap" (see llvm_codegen.cpp
+            // codegenNamedLet). A lambda compiled inside that loop captures the
+            // variable through that direct pointer, so its `captured_<var>` param
+            // is loaded DIRECTLY (single indirection). Passing the usual
+            // {INT64, ptrtoint(storage)} double-indirection slot here made the
+            // lambda read the *address* as the value → garbage gradients that
+            // compounded each loop iteration (the Noesis named-let blow-up).
+            // When storage IS that carry pointer, forward it as-is.
+            if (auto* arg = llvm::dyn_cast<llvm::Argument>(storage)) {
+                if (arg->getType()->isPointerTy() &&
+                    arg->getName() == (var_name + "_cap")) {
+                    call_args.push_back(storage);
+                    continue;
+                }
+            }
+            if (!storage->getType()->isPointerTy()) {
+                // Value-typed capture (e.g. a function passed as a tagged_value
+                // parameter and captured by the gradient's lambda, as in
+                // (lambda (y) (gradient f y))). PtrToInt on a struct is invalid;
+                // funnel the value through a temp slot so the lambda's single
+                // `load captured_<var>` reads it directly. Mirrors the
+                // derivative() capture handling (ESH-0070).
+                Value* val_temp = ctx_.builder().CreateAlloca(ctx_.taggedValueType(), nullptr, "grad_cap_val");
+                ctx_.builder().CreateStore(storage, val_temp);
+                call_args.push_back(val_temp);
+                continue;
+            }
             Value* ptr_int = ctx_.builder().CreatePtrToInt(storage, ctx_.int64Type());
             Value* packed = tagged_.packInt64(ptr_int, true);
             Value* temp = ctx_.builder().CreateAlloca(ctx_.taggedValueType(), nullptr, "grad_cap");

--- a/lib/backend/autodiff_codegen.cpp
+++ b/lib/backend/autodiff_codegen.cpp
@@ -39,33 +39,113 @@ AutodiffCodegen::AutodiffCodegen(CodegenContext& ctx, TaggedValueCodegen& tagged
 
 // ===== DUAL NUMBER OPERATIONS (Forward-mode AD) =====
 // Fully implemented - these are self-contained and don't depend on AST codegen
+//
+// SECOND-ORDER / NESTED forward-mode AD.
+// ----------------------------------------------------------------------
+// A dual number is a 4-component truncated bivariate Taylor jet
+//     v = f0 + f1*e1 + f2*e2 + f3*e1*e2      (e1^2 = e2^2 = 0)
+// stored as the LLVM struct {primal, d1, d2, d12}.  Each `derivative`
+// nesting level (and each of the two arguments a Hessian differentiates
+// w.r.t.) is tagged with a distinct perturbation e1 or e2 — this is the
+// standard cure for "perturbation confusion".  Single-level AD only ever
+// touches f0/f1, so the representation is backward-compatible: a plain
+// {primal, tangent} dual is just {primal, tangent, 0, 0}.
+//
+// Arithmetic on these jets is exact and finite (no recursion, no finite
+// differences); the closed forms are implemented below.
+
+namespace {
+
+// Read component `idx` (0=primal,1=e1,2=e2,3=e1e2) of a dual struct value.
+inline llvm::Value* dualField(CodegenContext& ctx, llvm::Value* dual, unsigned idx) {
+    return ctx.builder().CreateExtractValue(dual, {idx});
+}
+
+// Build a 4-component dual struct value from its components.
+inline llvm::Value* makeDual4(CodegenContext& ctx,
+                              llvm::Value* f0, llvm::Value* f1,
+                              llvm::Value* f2, llvm::Value* f3) {
+    llvm::Value* d = llvm::UndefValue::get(ctx.dualNumberType());
+    auto& b = ctx.builder();
+    d = b.CreateInsertValue(d, f0, {0});
+    d = b.CreateInsertValue(d, f1, {1});
+    d = b.CreateInsertValue(d, f2, {2});
+    d = b.CreateInsertValue(d, f3, {3});
+    return d;
+}
+
+// Apply a scalar unary function g (with value g(a)=fa, g'(a)=fpa, g''(a)=fppa
+// evaluated at the dual's primal) to a dual, propagating BOTH perturbation
+// slots and the mixed second-order term exactly:
+//   g(u) = g(a) + g'(a)(d1 e1 + d2 e2 + d12 e1e2)
+//                + g''(a)(d1 d2) e1e2      (the only surviving 2nd-order term)
+inline llvm::Value* dualUnaryChain(CodegenContext& ctx, llvm::Value* dual,
+                                   llvm::Value* fa, llvm::Value* fpa, llvm::Value* fppa) {
+    auto& b = ctx.builder();
+    llvm::Value* d1 = b.CreateExtractValue(dual, {1});
+    llvm::Value* d2 = b.CreateExtractValue(dual, {2});
+    llvm::Value* d12 = b.CreateExtractValue(dual, {3});
+    llvm::Value* o1 = b.CreateFMul(fpa, d1);
+    llvm::Value* o2 = b.CreateFMul(fpa, d2);
+    llvm::Value* o3 = b.CreateFAdd(b.CreateFMul(fpa, d12),
+                                   b.CreateFMul(fppa, b.CreateFMul(d1, d2)));
+    return makeDual4(ctx, fa, o1, o2, o3);
+}
+
+} // anonymous namespace
+
+// Perturbation-tagging nesting depth for user-written nested `derivative`.
+// Depth 0 (outermost) tags with e1 (slot 1); depth 1 (one level of nesting)
+// tags with e2 (slot 2).  The 4-component jet supports two simultaneous live
+// perturbations, i.e. up to 2 levels of forward-over-forward nesting exactly.
+// Tracked as a file-static (thread-local for REPL/JIT thread-safety) so no
+// header/ABI change is needed.
+static thread_local int g_ad_deriv_depth = 0;
 
 llvm::Value* AutodiffCodegen::createDualNumber(llvm::Value* primal, llvm::Value* tangent) {
     if (!primal || !tangent) return nullptr;
+    // {primal, tangent(e1), 0(e2), 0(e1e2)} — single-level seed.  The e2/e1e2
+    // slots MUST be explicitly zeroed (a 4-field alloca would leave them
+    // uninitialised → garbage second derivatives).
+    llvm::Value* zero = llvm::ConstantFP::get(ctx_.doubleType(), 0.0);
+    return makeDual4(ctx_, primal, tangent, zero, zero);
+}
 
-    // Create alloca for dual number at function entry
-    llvm::IRBuilderBase::InsertPoint saved_ip = ctx_.builder().saveIP();
-    llvm::Function* func = ctx_.builder().GetInsertBlock()->getParent();
-    if (func && !func->empty()) {
-        llvm::BasicBlock& entry = func->getEntryBlock();
-        ctx_.builder().SetInsertPoint(&entry, entry.begin());
+// Seed a fresh forward-mode perturbation for a `derivative` at nesting `depth`.
+// The point may already be a dual (when this derivative is nested and its point
+// depends on the outer variable); we PRESERVE its components and set this
+// level's slot to 1.0.  depth 0 -> slot e1 (field 1); depth 1 -> slot e2
+// (field 2).  Two simultaneous perturbations (=> 2 levels of forward-over-
+// forward nesting) are exact; deeper nesting is flagged explicitly — the
+// 4-component jet cannot carry a 3rd independent perturbation, so it aliases
+// onto e2 rather than silently returning a wrong-but-plausible number.
+llvm::Value* AutodiffCodegen::seedDerivativeInput(llvm::Value* point_tagged, int depth) {
+    llvm::Value* base = safeUnpackDualFromTagged(point_tagged); // {p,d1,d2,d12}
+    unsigned slot = (depth <= 0) ? 1u : 2u;
+    if (depth >= 2) {
+        eshkol_warn("nested `derivative` depth %d exceeds exact 2-level forward AD; "
+                    "this level's perturbation is aliased onto e2 (approximate)", depth);
     }
+    llvm::Value* one = llvm::ConstantFP::get(ctx_.doubleType(), 1.0);
+    llvm::Value* seeded = ctx_.builder().CreateInsertValue(base, one, {slot});
+    return packDualToTagged(seeded);
+}
 
-    llvm::Value* dual_ptr = ctx_.builder().CreateAlloca(ctx_.dualNumberType(), nullptr, "dual");
-
-    // Restore insertion point for the actual stores
-    ctx_.builder().restoreIP(saved_ip);
-
-    // Store primal in field 0
-    llvm::Value* primal_ptr = ctx_.builder().CreateStructGEP(ctx_.dualNumberType(), dual_ptr, 0);
-    ctx_.builder().CreateStore(primal, primal_ptr);
-
-    // Store tangent in field 1
-    llvm::Value* tangent_ptr = ctx_.builder().CreateStructGEP(ctx_.dualNumberType(), dual_ptr, 1);
-    ctx_.builder().CreateStore(tangent, tangent_ptr);
-
-    // Load and return the dual number struct
-    return ctx_.builder().CreateLoad(ctx_.dualNumberType(), dual_ptr);
+// Extract the derivative of a lambda result w.r.t. THIS level's perturbation.
+//   depth 0 : scalar tangent (field 1), packed as a double.
+//   depth>=1: the e2-slice as a dual {a2, a12, 0, 0} (tagged DUAL_NUMBER) so an
+//             enclosing derivative reads its e1 coefficient (= the mixed term).
+// safeUnpack handles a non-dual scalar result (constant fn, literal branch).
+llvm::Value* AutodiffCodegen::extractDerivativeResult(llvm::Value* result_tagged, int depth) {
+    llvm::Value* rd = safeUnpackDualFromTagged(result_tagged); // {a0,a1,a2,a12}
+    if (depth <= 0) {
+        return tagged_.packDouble(dualField(ctx_, rd, 1));
+    }
+    // d/de2 (a0 + a1 e1 + a2 e2 + a12 e1e2) = a2 + a12 e1
+    llvm::Value* zero = llvm::ConstantFP::get(ctx_.doubleType(), 0.0);
+    llvm::Value* sliced = makeDual4(ctx_, dualField(ctx_, rd, 2), dualField(ctx_, rd, 3),
+                                    zero, zero);
+    return packDualToTagged(sliced);
 }
 
 llvm::Value* AutodiffCodegen::getDualPrimal(llvm::Value* dual) {
@@ -105,8 +185,8 @@ llvm::Value* AutodiffCodegen::packDualToTagged(llvm::Value* dual) {
     llvm::Value* arena_ptr = ctx_.builder().CreateLoad(ctx_.ptrType(), arena_global);
 
     // Allocate space for dual number on the heap (arena)
-    // dual_number is 16 bytes (two doubles)
-    llvm::Value* size = llvm::ConstantInt::get(ctx_.sizeType(), 16);
+    // dual_number is 32 bytes (four doubles: primal, d1, d2, d12)
+    llvm::Value* size = llvm::ConstantInt::get(ctx_.sizeType(), 32);
     llvm::Function* alloc_func = mem_.getArenaAllocate();
     if (!alloc_func) {
         eshkol_warn("packDualToTagged: arena_allocate not found");
@@ -183,9 +263,11 @@ llvm::Value* AutodiffCodegen::safeUnpackDualFromTagged(llvm::Value* tagged_val) 
         llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_DOUBLE));
     llvm::Value* primal_final = ctx_.builder().CreateSelect(is_double, primal_bc, primal_si, "sudft_primal");
     llvm::Value* synth_dual = llvm::UndefValue::get(ctx_.dualNumberType());
+    llvm::Value* synth_zero = llvm::ConstantFP::get(ctx_.doubleType(), 0.0);
     synth_dual = ctx_.builder().CreateInsertValue(synth_dual, primal_final, {0});
-    synth_dual = ctx_.builder().CreateInsertValue(synth_dual,
-        llvm::ConstantFP::get(ctx_.doubleType(), 0.0), {1});
+    synth_dual = ctx_.builder().CreateInsertValue(synth_dual, synth_zero, {1});
+    synth_dual = ctx_.builder().CreateInsertValue(synth_dual, synth_zero, {2});
+    synth_dual = ctx_.builder().CreateInsertValue(synth_dual, synth_zero, {3});
     llvm::BasicBlock* scalar_exit = ctx_.builder().GetInsertBlock();
     ctx_.builder().CreateBr(merge_bb);
 
@@ -196,82 +278,66 @@ llvm::Value* AutodiffCodegen::safeUnpackDualFromTagged(llvm::Value* tagged_val) 
     return phi;
 }
 
-// Dual arithmetic: (a, a') + (b, b') = (a+b, a'+b')
+// Dual arithmetic (4-component jets). Each is the exact truncated-Taylor
+// rule for v = f0 + f1 e1 + f2 e2 + f3 e1e2.
+
+// (a + b): componentwise.
 llvm::Value* AutodiffCodegen::dualAdd(llvm::Value* dual_a, llvm::Value* dual_b) {
     if (!dual_a || !dual_b) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual_a);
-    llvm::Value* a_prime = getDualTangent(dual_a);
-    llvm::Value* b = getDualPrimal(dual_b);
-    llvm::Value* b_prime = getDualTangent(dual_b);
-
-    // Value: a + b
-    llvm::Value* value = ctx_.builder().CreateFAdd(a, b);
-
-    // Derivative: a' + b'
-    llvm::Value* deriv = ctx_.builder().CreateFAdd(a_prime, b_prime);
-
-    return createDualNumber(value, deriv);
+    auto& b = ctx_.builder();
+    llvm::Value* r0 = b.CreateFAdd(dualField(ctx_, dual_a, 0), dualField(ctx_, dual_b, 0));
+    llvm::Value* r1 = b.CreateFAdd(dualField(ctx_, dual_a, 1), dualField(ctx_, dual_b, 1));
+    llvm::Value* r2 = b.CreateFAdd(dualField(ctx_, dual_a, 2), dualField(ctx_, dual_b, 2));
+    llvm::Value* r3 = b.CreateFAdd(dualField(ctx_, dual_a, 3), dualField(ctx_, dual_b, 3));
+    return makeDual4(ctx_, r0, r1, r2, r3);
 }
 
-// Dual arithmetic: (a, a') - (b, b') = (a-b, a'-b')
+// (a - b): componentwise.
 llvm::Value* AutodiffCodegen::dualSub(llvm::Value* dual_a, llvm::Value* dual_b) {
     if (!dual_a || !dual_b) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual_a);
-    llvm::Value* a_prime = getDualTangent(dual_a);
-    llvm::Value* b = getDualPrimal(dual_b);
-    llvm::Value* b_prime = getDualTangent(dual_b);
-
-    // Value: a - b
-    llvm::Value* value = ctx_.builder().CreateFSub(a, b);
-
-    // Derivative: a' - b'
-    llvm::Value* deriv = ctx_.builder().CreateFSub(a_prime, b_prime);
-
-    return createDualNumber(value, deriv);
+    auto& b = ctx_.builder();
+    llvm::Value* r0 = b.CreateFSub(dualField(ctx_, dual_a, 0), dualField(ctx_, dual_b, 0));
+    llvm::Value* r1 = b.CreateFSub(dualField(ctx_, dual_a, 1), dualField(ctx_, dual_b, 1));
+    llvm::Value* r2 = b.CreateFSub(dualField(ctx_, dual_a, 2), dualField(ctx_, dual_b, 2));
+    llvm::Value* r3 = b.CreateFSub(dualField(ctx_, dual_a, 3), dualField(ctx_, dual_b, 3));
+    return makeDual4(ctx_, r0, r1, r2, r3);
 }
 
-// Dual arithmetic: (a, a') * (b, b') = (a*b, a'*b + a*b') - product rule
+// (a * b): bilinear product rule, keeping the mixed e1e2 cross term.
+//   r0 = a0 b0
+//   r1 = a1 b0 + a0 b1
+//   r2 = a2 b0 + a0 b2
+//   r3 = a3 b0 + a1 b2 + a2 b1 + a0 b3
 llvm::Value* AutodiffCodegen::dualMul(llvm::Value* dual_a, llvm::Value* dual_b) {
     if (!dual_a || !dual_b) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual_a);
-    llvm::Value* a_prime = getDualTangent(dual_a);
-    llvm::Value* b = getDualPrimal(dual_b);
-    llvm::Value* b_prime = getDualTangent(dual_b);
-
-    // Value: a * b
-    llvm::Value* value = ctx_.builder().CreateFMul(a, b);
-
-    // Derivative: a' * b + a * b' (product rule)
-    llvm::Value* term1 = ctx_.builder().CreateFMul(a_prime, b);
-    llvm::Value* term2 = ctx_.builder().CreateFMul(a, b_prime);
-    llvm::Value* deriv = ctx_.builder().CreateFAdd(term1, term2);
-
-    return createDualNumber(value, deriv);
+    auto& b = ctx_.builder();
+    llvm::Value* a0 = dualField(ctx_, dual_a, 0), *a1 = dualField(ctx_, dual_a, 1),
+                *a2 = dualField(ctx_, dual_a, 2), *a3 = dualField(ctx_, dual_a, 3);
+    llvm::Value* b0 = dualField(ctx_, dual_b, 0), *b1 = dualField(ctx_, dual_b, 1),
+                *b2 = dualField(ctx_, dual_b, 2), *b3 = dualField(ctx_, dual_b, 3);
+    llvm::Value* r0 = b.CreateFMul(a0, b0);
+    llvm::Value* r1 = b.CreateFAdd(b.CreateFMul(a1, b0), b.CreateFMul(a0, b1));
+    llvm::Value* r2 = b.CreateFAdd(b.CreateFMul(a2, b0), b.CreateFMul(a0, b2));
+    llvm::Value* r3 = b.CreateFAdd(
+        b.CreateFAdd(b.CreateFMul(a3, b0), b.CreateFMul(a1, b2)),
+        b.CreateFAdd(b.CreateFMul(a2, b1), b.CreateFMul(a0, b3)));
+    return makeDual4(ctx_, r0, r1, r2, r3);
 }
 
-// Dual arithmetic: (a, a') / (b, b') = (a/b, (a'*b - a*b')/b²) - quotient rule
+// (a / b) = a * (1/b). Reciprocal is the unary jet of g(x)=1/x with
+//   g(b0)=1/b0, g'=-1/b0^2, g''=2/b0^3 — exact second order.
 llvm::Value* AutodiffCodegen::dualDiv(llvm::Value* dual_a, llvm::Value* dual_b) {
     if (!dual_a || !dual_b) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual_a);
-    llvm::Value* a_prime = getDualTangent(dual_a);
-    llvm::Value* b = getDualPrimal(dual_b);
-    llvm::Value* b_prime = getDualTangent(dual_b);
-
-    // Value: a / b
-    llvm::Value* value = ctx_.builder().CreateFDiv(a, b);
-
-    // Derivative: (a' * b - a * b') / b²
-    llvm::Value* numerator_term1 = ctx_.builder().CreateFMul(a_prime, b);
-    llvm::Value* numerator_term2 = ctx_.builder().CreateFMul(a, b_prime);
-    llvm::Value* numerator = ctx_.builder().CreateFSub(numerator_term1, numerator_term2);
-    llvm::Value* denominator = ctx_.builder().CreateFMul(b, b);
-    llvm::Value* deriv = ctx_.builder().CreateFDiv(numerator, denominator);
-
-    return createDualNumber(value, deriv);
+    auto& bld = ctx_.builder();
+    llvm::Value* b0 = dualField(ctx_, dual_b, 0);
+    llvm::Value* one = llvm::ConstantFP::get(ctx_.doubleType(), 1.0);
+    llvm::Value* inv = bld.CreateFDiv(one, b0);
+    llvm::Value* inv2 = bld.CreateFMul(inv, inv);
+    llvm::Value* fpa = bld.CreateFNeg(inv2);                       // -1/b0^2
+    llvm::Value* two = llvm::ConstantFP::get(ctx_.doubleType(), 2.0);
+    llvm::Value* fppa = bld.CreateFMul(two, bld.CreateFMul(inv2, inv)); // 2/b0^3
+    llvm::Value* recip = dualUnaryChain(ctx_, dual_b, inv, fpa, fppa);
+    return dualMul(dual_a, recip);
 }
 
 // ===== DUAL NUMBER MATH OPERATIONS =====
@@ -311,478 +377,357 @@ llvm::Function* AutodiffCodegen::getMathFunc(const std::string& name) {
     return func;
 }
 
-// Sine: sin(a, a') = (sin(a), a' * cos(a))
-// Chain rule: d/dx[sin(f(x))] = cos(f(x)) * f'(x)
+// Unary dual math: each computes the scalar function value g(a), first
+// derivative g'(a) and second derivative g''(a) at the primal a, then defers
+// to dualUnaryChain which propagates both perturbation slots + the mixed
+// second-order term exactly. (a = primal = field 0.)
+
 llvm::Value* AutodiffCodegen::dualSin(llvm::Value* dual) {
     if (!dual) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* sin_func = getMathFunc("sin");
     llvm::Function* cos_func = getMathFunc("cos");
     if (!sin_func || !cos_func) return nullptr;
-
-    // Value: sin(a)
-    llvm::Value* value = ctx_.builder().CreateCall(sin_func, {a});
-
-    // Derivative: a' * cos(a)
-    llvm::Value* cos_a = ctx_.builder().CreateCall(cos_func, {a});
-    llvm::Value* deriv = ctx_.builder().CreateFMul(a_prime, cos_a);
-
-    return createDualNumber(value, deriv);
+    llvm::Value* sa = ctx_.builder().CreateCall(sin_func, {a});
+    llvm::Value* ca = ctx_.builder().CreateCall(cos_func, {a});
+    // g=sin, g'=cos, g''=-sin
+    return dualUnaryChain(ctx_, dual, sa, ca, ctx_.builder().CreateFNeg(sa));
 }
 
-// Cosine: cos(a, a') = (cos(a), -a' * sin(a))
-// Chain rule: d/dx[cos(f(x))] = -sin(f(x)) * f'(x)
 llvm::Value* AutodiffCodegen::dualCos(llvm::Value* dual) {
     if (!dual) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* sin_func = getMathFunc("sin");
     llvm::Function* cos_func = getMathFunc("cos");
     if (!sin_func || !cos_func) return nullptr;
-
-    // Value: cos(a)
-    llvm::Value* value = ctx_.builder().CreateCall(cos_func, {a});
-
-    // Derivative: -a' * sin(a)
-    llvm::Value* sin_a = ctx_.builder().CreateCall(sin_func, {a});
-    llvm::Value* neg_sin_a = ctx_.builder().CreateFNeg(sin_a);
-    llvm::Value* deriv = ctx_.builder().CreateFMul(a_prime, neg_sin_a);
-
-    return createDualNumber(value, deriv);
+    llvm::Value* sa = ctx_.builder().CreateCall(sin_func, {a});
+    llvm::Value* ca = ctx_.builder().CreateCall(cos_func, {a});
+    // g=cos, g'=-sin, g''=-cos
+    return dualUnaryChain(ctx_, dual, ca, ctx_.builder().CreateFNeg(sa),
+                          ctx_.builder().CreateFNeg(ca));
 }
 
-// Exponential: exp(a, a') = (exp(a), a' * exp(a))
-// Chain rule: d/dx[exp(f(x))] = exp(f(x)) * f'(x)
 llvm::Value* AutodiffCodegen::dualExp(llvm::Value* dual) {
     if (!dual) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* exp_func = getMathFunc("exp");
     if (!exp_func) return nullptr;
-
-    // Value: exp(a)
-    llvm::Value* exp_a = ctx_.builder().CreateCall(exp_func, {a});
-
-    // Derivative: a' * exp(a)
-    llvm::Value* deriv = ctx_.builder().CreateFMul(a_prime, exp_a);
-
-    return createDualNumber(exp_a, deriv);
+    llvm::Value* ea = ctx_.builder().CreateCall(exp_func, {a});
+    // g=g'=g''=exp(a)
+    return dualUnaryChain(ctx_, dual, ea, ea, ea);
 }
 
-// Logarithm: log(a, a') = (log(a), a'/a)
-// Chain rule: d/dx[log(f(x))] = f'(x)/f(x)
 llvm::Value* AutodiffCodegen::dualLog(llvm::Value* dual) {
     if (!dual) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* log_func = getMathFunc("log");
     if (!log_func) return nullptr;
-
-    // Value: log(a)
-    llvm::Value* value = ctx_.builder().CreateCall(log_func, {a});
-
-    // Derivative: a' / a
-    llvm::Value* deriv = ctx_.builder().CreateFDiv(a_prime, a);
-
-    return createDualNumber(value, deriv);
+    auto& b = ctx_.builder();
+    llvm::Value* la = b.CreateCall(log_func, {a});
+    llvm::Value* one = llvm::ConstantFP::get(ctx_.doubleType(), 1.0);
+    llvm::Value* fpa = b.CreateFDiv(one, a);                 // 1/a
+    llvm::Value* fppa = b.CreateFNeg(b.CreateFMul(fpa, fpa)); // -1/a^2
+    return dualUnaryChain(ctx_, dual, la, fpa, fppa);
 }
 
-// Tangent: tan(a, a') = (tan(a), a' * sec²(a)) = (tan(a), a' * (1 + tan²(a)))
-// Chain rule: d/dx[tan(f(x))] = sec²(f(x)) * f'(x)
 llvm::Value* AutodiffCodegen::dualTan(llvm::Value* dual) {
     if (!dual) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* tan_func = getMathFunc("tan");
     if (!tan_func) return nullptr;
-
-    // Value: tan(a)
-    llvm::Value* tan_a = ctx_.builder().CreateCall(tan_func, {a});
-
-    // Derivative: a' * (1 + tan²(a)) = a' * sec²(a)
-    llvm::Value* tan_sq = ctx_.builder().CreateFMul(tan_a, tan_a);
+    auto& b = ctx_.builder();
+    llvm::Value* ta = b.CreateCall(tan_func, {a});
     llvm::Value* one = llvm::ConstantFP::get(ctx_.doubleType(), 1.0);
-    llvm::Value* sec_sq = ctx_.builder().CreateFAdd(one, tan_sq);
-    llvm::Value* deriv = ctx_.builder().CreateFMul(a_prime, sec_sq);
-
-    return createDualNumber(tan_a, deriv);
+    llvm::Value* sec2 = b.CreateFAdd(one, b.CreateFMul(ta, ta));  // 1+tan^2 = sec^2
+    // g'=sec^2, g''=2 tan sec^2
+    llvm::Value* two = llvm::ConstantFP::get(ctx_.doubleType(), 2.0);
+    llvm::Value* fppa = b.CreateFMul(two, b.CreateFMul(ta, sec2));
+    return dualUnaryChain(ctx_, dual, ta, sec2, fppa);
 }
 
-// Square root: sqrt(a, a') = (sqrt(a), a' / (2 * sqrt(a)))
-// Chain rule: d/dx[sqrt(f(x))] = f'(x) / (2 * sqrt(f(x)))
 llvm::Value* AutodiffCodegen::dualSqrt(llvm::Value* dual) {
     if (!dual) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* sqrt_func = getMathFunc("sqrt");
     if (!sqrt_func) return nullptr;
-
-    // Value: sqrt(a)
-    llvm::Value* sqrt_a = ctx_.builder().CreateCall(sqrt_func, {a});
-
-    // Derivative: a' / (2 * sqrt(a))
+    auto& b = ctx_.builder();
+    llvm::Value* s = b.CreateCall(sqrt_func, {a});
     llvm::Value* two = llvm::ConstantFP::get(ctx_.doubleType(), 2.0);
-    llvm::Value* two_sqrt_a = ctx_.builder().CreateFMul(two, sqrt_a);
-    llvm::Value* deriv = ctx_.builder().CreateFDiv(a_prime, two_sqrt_a);
-
-    return createDualNumber(sqrt_a, deriv);
+    llvm::Value* four = llvm::ConstantFP::get(ctx_.doubleType(), 4.0);
+    llvm::Value* fpa = b.CreateFDiv(llvm::ConstantFP::get(ctx_.doubleType(), 1.0),
+                                    b.CreateFMul(two, s));            // 1/(2*sqrt)
+    // g'' = -1/(4 a^{3/2}) = -1/(4*a*sqrt)
+    llvm::Value* fppa = b.CreateFNeg(b.CreateFDiv(
+        llvm::ConstantFP::get(ctx_.doubleType(), 1.0),
+        b.CreateFMul(four, b.CreateFMul(a, s))));
+    return dualUnaryChain(ctx_, dual, s, fpa, fppa);
 }
 
-// Power: (a, a')^(b, b') = (a^b, a^b * (b' * log(a) + b * a'/a))
-// General power rule for both base and exponent being functions
+// Power. (a^b). For a CONSTANT exponent (the common (pow x n) case) this is a
+// unary jet of g(x)=x^b with g'=b x^{b-1}, g''=b(b-1) x^{b-2} — exact and
+// valid for negative base. For a non-constant (dual) exponent we compose
+// exp(b*log(a)) over the 4-component jets (exact for a>0; matches the prior
+// behaviour, which already required log(a)).
 llvm::Value* AutodiffCodegen::dualPow(llvm::Value* dual_base, llvm::Value* dual_exp) {
     if (!dual_base || !dual_exp) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual_base);
-    llvm::Value* a_prime = getDualTangent(dual_base);
-    llvm::Value* b = getDualPrimal(dual_exp);
-    llvm::Value* b_prime = getDualTangent(dual_exp);
-
+    auto& bld = ctx_.builder();
     llvm::Function* pow_func = getMathFunc("pow");
-    llvm::Function* log_func = getMathFunc("log");
-    if (!pow_func || !log_func) return nullptr;
+    if (!pow_func) return nullptr;
 
-    // Value: a^b
-    llvm::Value* value = ctx_.builder().CreateCall(pow_func, {a, b});
+    llvm::Value* a = dualField(ctx_, dual_base, 0);
+    llvm::Value* bexp = dualField(ctx_, dual_exp, 0);
 
-    // Derivative: a^b * (b' * log(a) + b * a'/a)
-    llvm::Value* log_a = ctx_.builder().CreateCall(log_func, {a});
-    llvm::Value* term1 = ctx_.builder().CreateFMul(b_prime, log_a);
-    llvm::Value* term2 = ctx_.builder().CreateFMul(b, ctx_.builder().CreateFDiv(a_prime, a));
-    llvm::Value* sum = ctx_.builder().CreateFAdd(term1, term2);
-    llvm::Value* deriv = ctx_.builder().CreateFMul(value, sum);
+    // Detect a constant exponent at runtime: e1/e2/e1e2 slots all zero.
+    llvm::Value* e1 = dualField(ctx_, dual_exp, 1);
+    llvm::Value* e2 = dualField(ctx_, dual_exp, 2);
+    llvm::Value* e12 = dualField(ctx_, dual_exp, 3);
+    llvm::Value* zero = llvm::ConstantFP::get(ctx_.doubleType(), 0.0);
+    llvm::Value* one = llvm::ConstantFP::get(ctx_.doubleType(), 1.0);
 
-    return createDualNumber(value, deriv);
+    // --- constant-exponent jet (exact, negative-base safe) ---
+    llvm::Value* value = bld.CreateCall(pow_func, {a, bexp});      // a^b
+    llvm::Value* bm1 = bld.CreateFSub(bexp, one);
+    llvm::Value* bm2 = bld.CreateFSub(bexp, llvm::ConstantFP::get(ctx_.doubleType(), 2.0));
+    llvm::Value* gpa = bld.CreateFMul(bexp, bld.CreateCall(pow_func, {a, bm1}));   // b a^{b-1}
+    llvm::Value* gppa = bld.CreateFMul(bld.CreateFMul(bexp, bm1),
+                                       bld.CreateCall(pow_func, {a, bm2}));        // b(b-1) a^{b-2}
+    llvm::Value* const_jet = dualUnaryChain(ctx_, dual_base, value, gpa, gppa);
+
+    // --- general dual-exponent jet: exp(b * log(a)) ---
+    llvm::Value* log_base = dualLog(dual_base);          // 4-comp log
+    llvm::Value* t = dualMul(dual_exp, log_base);        // b*log(a)
+    llvm::Value* gen_jet = dualExp(t);                   // exp(...) = a^b (a>0)
+    // Replace its primal with pow(a,b) for negative-base parity with prior code.
+    gen_jet = bld.CreateInsertValue(gen_jet, value, {0});
+
+    // Select per-component between the constant- and general-exponent jets.
+    llvm::Value* exp_is_const =
+        bld.CreateAnd(bld.CreateAnd(bld.CreateFCmpOEQ(e1, zero), bld.CreateFCmpOEQ(e2, zero)),
+                      bld.CreateFCmpOEQ(e12, zero));
+    llvm::Value* r0 = bld.CreateSelect(exp_is_const, dualField(ctx_, const_jet, 0), dualField(ctx_, gen_jet, 0));
+    llvm::Value* r1 = bld.CreateSelect(exp_is_const, dualField(ctx_, const_jet, 1), dualField(ctx_, gen_jet, 1));
+    llvm::Value* r2 = bld.CreateSelect(exp_is_const, dualField(ctx_, const_jet, 2), dualField(ctx_, gen_jet, 2));
+    llvm::Value* r3 = bld.CreateSelect(exp_is_const, dualField(ctx_, const_jet, 3), dualField(ctx_, gen_jet, 3));
+    return makeDual4(ctx_, r0, r1, r2, r3);
 }
 
-// Arc sine: asin(a, a') = (asin(a), a' / sqrt(1 - a²))
-// Chain rule: d/dx[asin(f(x))] = f'(x) / sqrt(1 - f(x)²)
 llvm::Value* AutodiffCodegen::dualAsin(llvm::Value* dual) {
     if (!dual) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* asin_func = getMathFunc("asin");
     llvm::Function* sqrt_func = getMathFunc("sqrt");
     if (!asin_func || !sqrt_func) return nullptr;
-
-    // Value: asin(a)
-    llvm::Value* value = ctx_.builder().CreateCall(asin_func, {a});
-
-    // Derivative: a' / sqrt(1 - a²)
+    auto& b = ctx_.builder();
+    llvm::Value* va = b.CreateCall(asin_func, {a});
     llvm::Value* one = llvm::ConstantFP::get(ctx_.doubleType(), 1.0);
-    llvm::Value* a_sq = ctx_.builder().CreateFMul(a, a);
-    llvm::Value* one_minus_a_sq = ctx_.builder().CreateFSub(one, a_sq);
-    llvm::Value* sqrt_term = ctx_.builder().CreateCall(sqrt_func, {one_minus_a_sq});
-    llvm::Value* deriv = ctx_.builder().CreateFDiv(a_prime, sqrt_term);
-
-    return createDualNumber(value, deriv);
+    llvm::Value* t = b.CreateFSub(one, b.CreateFMul(a, a));      // 1-a^2
+    llvm::Value* r = b.CreateCall(sqrt_func, {t});
+    llvm::Value* fpa = b.CreateFDiv(one, r);                     // 1/sqrt(1-a^2)
+    llvm::Value* fppa = b.CreateFDiv(a, b.CreateFMul(t, r));     // a/(1-a^2)^{3/2}
+    return dualUnaryChain(ctx_, dual, va, fpa, fppa);
 }
 
-// Arc cosine: acos(a, a') = (acos(a), -a' / sqrt(1 - a²))
-// Chain rule: d/dx[acos(f(x))] = -f'(x) / sqrt(1 - f(x)²)
 llvm::Value* AutodiffCodegen::dualAcos(llvm::Value* dual) {
     if (!dual) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* acos_func = getMathFunc("acos");
     llvm::Function* sqrt_func = getMathFunc("sqrt");
     if (!acos_func || !sqrt_func) return nullptr;
-
-    // Value: acos(a)
-    llvm::Value* value = ctx_.builder().CreateCall(acos_func, {a});
-
-    // Derivative: -a' / sqrt(1 - a²)
+    auto& b = ctx_.builder();
+    llvm::Value* va = b.CreateCall(acos_func, {a});
     llvm::Value* one = llvm::ConstantFP::get(ctx_.doubleType(), 1.0);
-    llvm::Value* a_sq = ctx_.builder().CreateFMul(a, a);
-    llvm::Value* one_minus_a_sq = ctx_.builder().CreateFSub(one, a_sq);
-    llvm::Value* sqrt_term = ctx_.builder().CreateCall(sqrt_func, {one_minus_a_sq});
-    llvm::Value* neg_a_prime = ctx_.builder().CreateFNeg(a_prime);
-    llvm::Value* deriv = ctx_.builder().CreateFDiv(neg_a_prime, sqrt_term);
-
-    return createDualNumber(value, deriv);
+    llvm::Value* t = b.CreateFSub(one, b.CreateFMul(a, a));
+    llvm::Value* r = b.CreateCall(sqrt_func, {t});
+    llvm::Value* fpa = b.CreateFNeg(b.CreateFDiv(one, r));       // -1/sqrt(1-a^2)
+    llvm::Value* fppa = b.CreateFNeg(b.CreateFDiv(a, b.CreateFMul(t, r))); // -a/(1-a^2)^{3/2}
+    return dualUnaryChain(ctx_, dual, va, fpa, fppa);
 }
 
-// Arc tangent: atan(a, a') = (atan(a), a' / (1 + a²))
-// Chain rule: d/dx[atan(f(x))] = f'(x) / (1 + f(x)²)
 llvm::Value* AutodiffCodegen::dualAtan(llvm::Value* dual) {
     if (!dual) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* atan_func = getMathFunc("atan");
     if (!atan_func) return nullptr;
-
-    // Value: atan(a)
-    llvm::Value* value = ctx_.builder().CreateCall(atan_func, {a});
-
-    // Derivative: a' / (1 + a²)
+    auto& b = ctx_.builder();
+    llvm::Value* va = b.CreateCall(atan_func, {a});
     llvm::Value* one = llvm::ConstantFP::get(ctx_.doubleType(), 1.0);
-    llvm::Value* a_sq = ctx_.builder().CreateFMul(a, a);
-    llvm::Value* one_plus_a_sq = ctx_.builder().CreateFAdd(one, a_sq);
-    llvm::Value* deriv = ctx_.builder().CreateFDiv(a_prime, one_plus_a_sq);
-
-    return createDualNumber(value, deriv);
+    llvm::Value* u = b.CreateFAdd(one, b.CreateFMul(a, a));      // 1+a^2
+    llvm::Value* fpa = b.CreateFDiv(one, u);
+    llvm::Value* two = llvm::ConstantFP::get(ctx_.doubleType(), 2.0);
+    llvm::Value* fppa = b.CreateFNeg(b.CreateFDiv(b.CreateFMul(two, a),
+                                                  b.CreateFMul(u, u)));  // -2a/(1+a^2)^2
+    return dualUnaryChain(ctx_, dual, va, fpa, fppa);
 }
 
-// Absolute value: abs(a, a') = (|a|, a' * sign(a))
-// Note: derivative is undefined at 0, we use 0 there
 llvm::Value* AutodiffCodegen::dualAbs(llvm::Value* dual) {
     if (!dual) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* fabs_func = getMathFunc("fabs");
     if (!fabs_func) return nullptr;
-
-    // Value: |a|
-    llvm::Value* abs_a = ctx_.builder().CreateCall(fabs_func, {a});
-
-    // Sign: sign(a) = a / |a| (handles a=0 by returning 0)
+    auto& b = ctx_.builder();
+    llvm::Value* abs_a = b.CreateCall(fabs_func, {a});
     llvm::Value* zero = llvm::ConstantFP::get(ctx_.doubleType(), 0.0);
-    llvm::Value* is_zero = ctx_.builder().CreateFCmpOEQ(a, zero);
-    llvm::Value* sign = ctx_.builder().CreateSelect(
-        is_zero, zero, ctx_.builder().CreateFDiv(a, abs_a));
-
-    llvm::Value* deriv = ctx_.builder().CreateFMul(a_prime, sign);
-
-    return createDualNumber(abs_a, deriv);
+    llvm::Value* is_zero = b.CreateFCmpOEQ(a, zero);
+    llvm::Value* sign = b.CreateSelect(is_zero, zero, b.CreateFDiv(a, abs_a));
+    // g'=sign, g''=0 (a.e.)
+    return dualUnaryChain(ctx_, dual, abs_a, sign, zero);
 }
 
-// Negation: -(a, a') = (-a, -a')
 llvm::Value* AutodiffCodegen::dualNeg(llvm::Value* dual) {
     if (!dual) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
-    // Value: -a
-    llvm::Value* value = ctx_.builder().CreateFNeg(a);
-
-    // Derivative: -a'
-    llvm::Value* deriv = ctx_.builder().CreateFNeg(a_prime);
-
-    return createDualNumber(value, deriv);
+    auto& b = ctx_.builder();
+    llvm::Value* r0 = b.CreateFNeg(dualField(ctx_, dual, 0));
+    llvm::Value* r1 = b.CreateFNeg(dualField(ctx_, dual, 1));
+    llvm::Value* r2 = b.CreateFNeg(dualField(ctx_, dual, 2));
+    llvm::Value* r3 = b.CreateFNeg(dualField(ctx_, dual, 3));
+    return makeDual4(ctx_, r0, r1, r2, r3);
 }
 
-// Hyperbolic sine: sinh(a, a') = (sinh(a), a' * cosh(a))
-// Chain rule: d/dx[sinh(f(x))] = cosh(f(x)) * f'(x)
 llvm::Value* AutodiffCodegen::dualSinh(llvm::Value* dual) {
     if (!dual) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* sinh_func = getMathFunc("sinh");
     llvm::Function* cosh_func = getMathFunc("cosh");
     if (!sinh_func || !cosh_func) return nullptr;
-
-    llvm::Value* sinh_a = ctx_.builder().CreateCall(sinh_func, {a});
-    llvm::Value* cosh_a = ctx_.builder().CreateCall(cosh_func, {a});
-    llvm::Value* deriv = ctx_.builder().CreateFMul(a_prime, cosh_a);
-
-    return createDualNumber(sinh_a, deriv);
+    llvm::Value* sa = ctx_.builder().CreateCall(sinh_func, {a});
+    llvm::Value* ca = ctx_.builder().CreateCall(cosh_func, {a});
+    // g=sinh, g'=cosh, g''=sinh
+    return dualUnaryChain(ctx_, dual, sa, ca, sa);
 }
 
-// Hyperbolic cosine: cosh(a, a') = (cosh(a), a' * sinh(a))
-// Chain rule: d/dx[cosh(f(x))] = sinh(f(x)) * f'(x)
 llvm::Value* AutodiffCodegen::dualCosh(llvm::Value* dual) {
     if (!dual) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* sinh_func = getMathFunc("sinh");
     llvm::Function* cosh_func = getMathFunc("cosh");
     if (!sinh_func || !cosh_func) return nullptr;
-
-    llvm::Value* cosh_a = ctx_.builder().CreateCall(cosh_func, {a});
-    llvm::Value* sinh_a = ctx_.builder().CreateCall(sinh_func, {a});
-    llvm::Value* deriv = ctx_.builder().CreateFMul(a_prime, sinh_a);
-
-    return createDualNumber(cosh_a, deriv);
+    llvm::Value* sa = ctx_.builder().CreateCall(sinh_func, {a});
+    llvm::Value* ca = ctx_.builder().CreateCall(cosh_func, {a});
+    // g=cosh, g'=sinh, g''=cosh
+    return dualUnaryChain(ctx_, dual, ca, sa, ca);
 }
 
-// Hyperbolic tangent: tanh(a, a') = (tanh(a), a' * (1 - tanh²(a))) = (tanh(a), a' * sech²(a))
-// Chain rule: d/dx[tanh(f(x))] = sech²(f(x)) * f'(x)
 llvm::Value* AutodiffCodegen::dualTanh(llvm::Value* dual) {
     if (!dual) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* tanh_func = getMathFunc("tanh");
     if (!tanh_func) return nullptr;
-
-    // Value: tanh(a)
-    llvm::Value* tanh_a = ctx_.builder().CreateCall(tanh_func, {a});
-
-    // Derivative: a' * (1 - tanh²(a))
-    llvm::Value* tanh_sq = ctx_.builder().CreateFMul(tanh_a, tanh_a);
+    auto& b = ctx_.builder();
+    llvm::Value* ta = b.CreateCall(tanh_func, {a});
     llvm::Value* one = llvm::ConstantFP::get(ctx_.doubleType(), 1.0);
-    llvm::Value* sech_sq = ctx_.builder().CreateFSub(one, tanh_sq);
-    llvm::Value* deriv = ctx_.builder().CreateFMul(a_prime, sech_sq);
-
-    return createDualNumber(tanh_a, deriv);
+    llvm::Value* sech2 = b.CreateFSub(one, b.CreateFMul(ta, ta));  // 1-tanh^2
+    llvm::Value* two = llvm::ConstantFP::get(ctx_.doubleType(), 2.0);
+    llvm::Value* fppa = b.CreateFNeg(b.CreateFMul(two, b.CreateFMul(ta, sech2))); // -2 tanh sech^2
+    return dualUnaryChain(ctx_, dual, ta, sech2, fppa);
 }
 
 llvm::Value* AutodiffCodegen::dualAsinh(llvm::Value* dual) {
     if (!dual) return nullptr;
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* asinh_func = getMathFunc("asinh");
     llvm::Function* sqrt_func = getMathFunc("sqrt");
     if (!asinh_func || !sqrt_func) return nullptr;
-
-    // Value: asinh(a)
-    llvm::Value* asinh_a = ctx_.builder().CreateCall(asinh_func, {a});
-
-    // Derivative: a' / sqrt(1 + a²)
+    auto& b = ctx_.builder();
+    llvm::Value* va = b.CreateCall(asinh_func, {a});
     llvm::Value* one = llvm::ConstantFP::get(ctx_.doubleType(), 1.0);
-    llvm::Value* a_sq = ctx_.builder().CreateFMul(a, a);
-    llvm::Value* under = ctx_.builder().CreateFAdd(one, a_sq);
-    llvm::Value* sqrt_under = ctx_.builder().CreateCall(sqrt_func, {under});
-    llvm::Value* deriv = ctx_.builder().CreateFDiv(a_prime, sqrt_under);
-
-    return createDualNumber(asinh_a, deriv);
+    llvm::Value* u = b.CreateFAdd(one, b.CreateFMul(a, a));    // a^2+1
+    llvm::Value* r = b.CreateCall(sqrt_func, {u});
+    llvm::Value* fpa = b.CreateFDiv(one, r);
+    llvm::Value* fppa = b.CreateFNeg(b.CreateFDiv(a, b.CreateFMul(u, r))); // -a/(a^2+1)^{3/2}
+    return dualUnaryChain(ctx_, dual, va, fpa, fppa);
 }
 
 llvm::Value* AutodiffCodegen::dualAcosh(llvm::Value* dual) {
     if (!dual) return nullptr;
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* acosh_func = getMathFunc("acosh");
     llvm::Function* sqrt_func = getMathFunc("sqrt");
     if (!acosh_func || !sqrt_func) return nullptr;
-
-    // Value: acosh(a)
-    llvm::Value* acosh_a = ctx_.builder().CreateCall(acosh_func, {a});
-
-    // Derivative: a' / sqrt(a² - 1)
+    auto& b = ctx_.builder();
+    llvm::Value* va = b.CreateCall(acosh_func, {a});
     llvm::Value* one = llvm::ConstantFP::get(ctx_.doubleType(), 1.0);
-    llvm::Value* a_sq = ctx_.builder().CreateFMul(a, a);
-    llvm::Value* under = ctx_.builder().CreateFSub(a_sq, one);
-    llvm::Value* sqrt_under = ctx_.builder().CreateCall(sqrt_func, {under});
-    llvm::Value* deriv = ctx_.builder().CreateFDiv(a_prime, sqrt_under);
-
-    return createDualNumber(acosh_a, deriv);
+    llvm::Value* u = b.CreateFSub(b.CreateFMul(a, a), one);    // a^2-1
+    llvm::Value* r = b.CreateCall(sqrt_func, {u});
+    llvm::Value* fpa = b.CreateFDiv(one, r);
+    llvm::Value* fppa = b.CreateFNeg(b.CreateFDiv(a, b.CreateFMul(u, r))); // -a/(a^2-1)^{3/2}
+    return dualUnaryChain(ctx_, dual, va, fpa, fppa);
 }
 
 llvm::Value* AutodiffCodegen::dualAtanh(llvm::Value* dual) {
     if (!dual) return nullptr;
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* atanh_func = getMathFunc("atanh");
     if (!atanh_func) return nullptr;
-
-    // Value: atanh(a)
-    llvm::Value* atanh_a = ctx_.builder().CreateCall(atanh_func, {a});
-
-    // Derivative: a' / (1 - a²)
+    auto& b = ctx_.builder();
+    llvm::Value* va = b.CreateCall(atanh_func, {a});
     llvm::Value* one = llvm::ConstantFP::get(ctx_.doubleType(), 1.0);
-    llvm::Value* a_sq = ctx_.builder().CreateFMul(a, a);
-    llvm::Value* denom = ctx_.builder().CreateFSub(one, a_sq);
-    llvm::Value* deriv = ctx_.builder().CreateFDiv(a_prime, denom);
-
-    return createDualNumber(atanh_a, deriv);
+    llvm::Value* u = b.CreateFSub(one, b.CreateFMul(a, a));    // 1-a^2
+    llvm::Value* fpa = b.CreateFDiv(one, u);
+    llvm::Value* two = llvm::ConstantFP::get(ctx_.doubleType(), 2.0);
+    llvm::Value* fppa = b.CreateFDiv(b.CreateFMul(two, a), b.CreateFMul(u, u)); // 2a/(1-a^2)^2
+    return dualUnaryChain(ctx_, dual, va, fpa, fppa);
 }
 
 llvm::Value* AutodiffCodegen::dualLog10(llvm::Value* dual) {
     if (!dual) return nullptr;
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* log10_func = getMathFunc("log10");
     if (!log10_func) return nullptr;
-
-    // Value: log10(a)
-    llvm::Value* log10_a = ctx_.builder().CreateCall(log10_func, {a});
-
-    // Derivative: a' / (a * ln(10))
+    auto& b = ctx_.builder();
+    llvm::Value* va = b.CreateCall(log10_func, {a});
     llvm::Value* ln10 = llvm::ConstantFP::get(ctx_.doubleType(), 2.302585092994046);
-    llvm::Value* a_times_ln10 = ctx_.builder().CreateFMul(a, ln10);
-    llvm::Value* deriv = ctx_.builder().CreateFDiv(a_prime, a_times_ln10);
-
-    return createDualNumber(log10_a, deriv);
+    llvm::Value* ac = b.CreateFMul(a, ln10);
+    llvm::Value* fpa = b.CreateFDiv(llvm::ConstantFP::get(ctx_.doubleType(), 1.0), ac); // 1/(a ln10)
+    llvm::Value* fppa = b.CreateFNeg(b.CreateFDiv(
+        llvm::ConstantFP::get(ctx_.doubleType(), 1.0), b.CreateFMul(b.CreateFMul(a, a), ln10))); // -1/(a^2 ln10)
+    return dualUnaryChain(ctx_, dual, va, fpa, fppa);
 }
 
 llvm::Value* AutodiffCodegen::dualLog2(llvm::Value* dual) {
     if (!dual) return nullptr;
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* log2_func = getMathFunc("log2");
     if (!log2_func) return nullptr;
-
-    // Value: log2(a)
-    llvm::Value* log2_a = ctx_.builder().CreateCall(log2_func, {a});
-
-    // Derivative: a' / (a * ln(2))
+    auto& b = ctx_.builder();
+    llvm::Value* va = b.CreateCall(log2_func, {a});
     llvm::Value* ln2 = llvm::ConstantFP::get(ctx_.doubleType(), 0.6931471805599453);
-    llvm::Value* a_times_ln2 = ctx_.builder().CreateFMul(a, ln2);
-    llvm::Value* deriv = ctx_.builder().CreateFDiv(a_prime, a_times_ln2);
-
-    return createDualNumber(log2_a, deriv);
+    llvm::Value* ac = b.CreateFMul(a, ln2);
+    llvm::Value* fpa = b.CreateFDiv(llvm::ConstantFP::get(ctx_.doubleType(), 1.0), ac);
+    llvm::Value* fppa = b.CreateFNeg(b.CreateFDiv(
+        llvm::ConstantFP::get(ctx_.doubleType(), 1.0), b.CreateFMul(b.CreateFMul(a, a), ln2)));
+    return dualUnaryChain(ctx_, dual, va, fpa, fppa);
 }
 
 llvm::Value* AutodiffCodegen::dualExp2(llvm::Value* dual) {
     if (!dual) return nullptr;
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* exp2_func = getMathFunc("exp2");
     if (!exp2_func) return nullptr;
-
-    // Value: exp2(a) = 2^a
-    llvm::Value* exp2_a = ctx_.builder().CreateCall(exp2_func, {a});
-
-    // Derivative: a' * 2^a * ln(2)
+    auto& b = ctx_.builder();
+    llvm::Value* va = b.CreateCall(exp2_func, {a});               // 2^a
     llvm::Value* ln2 = llvm::ConstantFP::get(ctx_.doubleType(), 0.6931471805599453);
-    llvm::Value* exp2_times_ln2 = ctx_.builder().CreateFMul(exp2_a, ln2);
-    llvm::Value* deriv = ctx_.builder().CreateFMul(a_prime, exp2_times_ln2);
-
-    return createDualNumber(exp2_a, deriv);
+    llvm::Value* fpa = b.CreateFMul(va, ln2);                     // 2^a ln2
+    llvm::Value* fppa = b.CreateFMul(fpa, ln2);                   // 2^a ln2^2
+    return dualUnaryChain(ctx_, dual, va, fpa, fppa);
 }
 
 llvm::Value* AutodiffCodegen::dualCbrt(llvm::Value* dual) {
     if (!dual) return nullptr;
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* cbrt_func = getMathFunc("cbrt");
     if (!cbrt_func) return nullptr;
-
-    // Value: cbrt(a)
-    llvm::Value* cbrt_a = ctx_.builder().CreateCall(cbrt_func, {a});
-
-    // Derivative: a' / (3 * cbrt(a)²)
+    auto& b = ctx_.builder();
+    llvm::Value* c = b.CreateCall(cbrt_func, {a});               // a^{1/3}
+    llvm::Value* c2 = b.CreateFMul(c, c);
     llvm::Value* three = llvm::ConstantFP::get(ctx_.doubleType(), 3.0);
-    llvm::Value* cbrt_sq = ctx_.builder().CreateFMul(cbrt_a, cbrt_a);
-    llvm::Value* denom = ctx_.builder().CreateFMul(three, cbrt_sq);
-    llvm::Value* deriv = ctx_.builder().CreateFDiv(a_prime, denom);
-
-    return createDualNumber(cbrt_a, deriv);
+    llvm::Value* fpa = b.CreateFDiv(llvm::ConstantFP::get(ctx_.doubleType(), 1.0),
+                                    b.CreateFMul(three, c2));      // 1/(3 a^{2/3})
+    // g'' = -2/9 a^{-5/3} = -2/(9 c^5)
+    llvm::Value* c5 = b.CreateFMul(b.CreateFMul(c2, c2), c);
+    llvm::Value* nine = llvm::ConstantFP::get(ctx_.doubleType(), 9.0);
+    llvm::Value* two = llvm::ConstantFP::get(ctx_.doubleType(), 2.0);
+    llvm::Value* fppa = b.CreateFNeg(b.CreateFDiv(two, b.CreateFMul(nine, c5)));
+    return dualUnaryChain(ctx_, dual, c, fpa, fppa);
 }
 
 // Helper to get arena pointer from global
@@ -1648,33 +1593,18 @@ llvm::Value* AutodiffCodegen::derivativeHigherOrder(const eshkol_operations_t* o
                     // Load the captured function closure
                     Value* f_closure = ctx_.builder().CreateLoad(ctx_.taggedValueType(), captured_f_ptr);
 
-                    // HIGHER-ORDER DERIVATIVE FIX: Use numerical differentiation (central difference)
-                    // instead of forward-mode AD. This works for ANY function, including derivatives.
-                    // Forward-mode AD doesn't work here because the captured function (e.g., df4)
-                    // expects a plain double, not a dual number.
-                    //
-                    // Central difference formula: f'(x) ≈ (f(x+h) - f(x-h)) / (2h)
+                    // Forward-mode AD: seed a dual {x, 1, 0, 0} and call the
+                    // captured closure with it. The closure body threads dual
+                    // arithmetic at runtime (dispatch on the DUAL_NUMBER tag),
+                    // so the tangent of the result is exactly f'(x) — no
+                    // finite-difference step / epsilon error.
                     Value* x = tagged_.unpackDouble(x_tagged);
-                    Value* h = ConstantFP::get(ctx_.doubleType(), 1e-8);  // Small step for numerical derivative
-                    Value* two_h = ConstantFP::get(ctx_.doubleType(), 2e-8);
-
-                    // Compute f(x + h)
-                    Value* x_plus_h = ctx_.builder().CreateFAdd(x, h);
-                    Value* x_plus_h_tagged = tagged_.packDouble(x_plus_h);
-                    std::vector<Value*> call_args_plus = {x_plus_h_tagged};
-                    Value* f_plus = closure_call_callback_(f_closure, call_args_plus, "derivative-plus", callback_context_);
-                    Value* f_plus_val = tagged_.unpackDouble(f_plus);
-
-                    // Compute f(x - h)
-                    Value* x_minus_h = ctx_.builder().CreateFSub(x, h);
-                    Value* x_minus_h_tagged = tagged_.packDouble(x_minus_h);
-                    std::vector<Value*> call_args_minus = {x_minus_h_tagged};
-                    Value* f_minus = closure_call_callback_(f_closure, call_args_minus, "derivative-minus", callback_context_);
-                    Value* f_minus_val = tagged_.unpackDouble(f_minus);
-
-                    // Compute derivative: (f(x+h) - f(x-h)) / (2h)
-                    Value* diff = ctx_.builder().CreateFSub(f_plus_val, f_minus_val);
-                    Value* derivative_val = ctx_.builder().CreateFDiv(diff, two_h);
+                    Value* one_seed = ConstantFP::get(ctx_.doubleType(), 1.0);
+                    Value* x_seed_tagged = packDualToTagged(createDualNumber(x, one_seed));
+                    std::vector<Value*> call_args_ad = {x_seed_tagged};
+                    Value* f_ad = closure_call_callback_(f_closure, call_args_ad, "derivative-ad", callback_context_);
+                    Value* f_ad_dual = safeUnpackDualFromTagged(f_ad);
+                    Value* derivative_val = getDualTangent(f_ad_dual);
                     Value* result_tagged = tagged_.packDouble(derivative_val);
                     ctx_.builder().CreateRet(result_tagged);
 
@@ -1915,35 +1845,42 @@ llvm::Value* AutodiffCodegen::codegenDerivativeMonolith(const eshkol_operations_
 
     eshkol_info("Computing derivative using forward-mode AD (dual numbers)");
 
-    // Get evaluation point - must be a scalar double
-    Value* x = codegen_ast_callback_(op->derivative_op.point, callback_context_);
-    if (!x) {
+    // Perturbation-tagging nesting depth for THIS derivative (set by an
+    // enclosing derivative while it compiled our lambda body, if any).
+    int my_depth = g_ad_deriv_depth;
+
+    // Evaluate the point. When this derivative is lexically NESTED inside
+    // another and the inner evaluation point depends on the outer variable
+    // (e.g. (derivative (lambda (x) (derivative (lambda (y) ...) x)) 2.0)),
+    // `point_raw` is itself a dual number carrying the OUTER perturbation. We
+    // MUST preserve that — the old code stripped it via unpackDouble, which is
+    // exactly the perturbation-confusion bug.
+    Value* point_raw = codegen_ast_callback_(op->derivative_op.point, callback_context_);
+    if (!point_raw) {
         eshkol_error("Failed to evaluate derivative point");
         return nullptr;
     }
-
-    // Convert x to double if it's an integer or tagged_value
-    if (x->getType()->isIntegerTy()) {
-        x = ctx_.builder().CreateSIToFP(x, ctx_.doubleType());
-    } else if (x->getType() == ctx_.taggedValueType()) {
-        // Handle computed values that return tagged_value_t
-        // Extract the double from the data field
-        x = tagged_.unpackDouble(x);
-    } else if (!x->getType()->isDoubleTy()) {
+    Value* point_tagged;
+    if (point_raw->getType()->isIntegerTy()) {
+        point_tagged = tagged_.packDouble(ctx_.builder().CreateSIToFP(point_raw, ctx_.doubleType()));
+    } else if (point_raw->getType()->isDoubleTy()) {
+        point_tagged = tagged_.packDouble(point_raw);
+    } else if (point_raw->getType() == ctx_.taggedValueType()) {
+        point_tagged = point_raw;
+    } else {
         eshkol_error("derivative point must be numeric (int64 or double)");
         return nullptr;
     }
 
-    // Create dual number with seed derivative = 1.0
-    // This means: "we're computing the derivative with respect to this input"
-    Value* one = ConstantFP::get(ctx_.doubleType(), 1.0);
-    Value* x_dual = createDualNumber(x, one);
+    // Seed a fresh perturbation in THIS level's slot, preserving any
+    // perturbation the point already carries.
+    Value* x_dual_tagged = seedDerivativeInput(point_tagged, my_depth);
 
-    // Pack dual number into tagged_value for function call
-    Value* x_dual_tagged = packDualToTagged(x_dual);
-
-    // Get the function to differentiate
+    // Get the function to differentiate. Compile its body one nesting level
+    // deeper so any derivative inside it tags with the NEXT perturbation slot.
+    g_ad_deriv_depth = my_depth + 1;
     Value* func = resolve_lambda_callback_(op->derivative_op.function, 0, callback_context_);
+    g_ad_deriv_depth = my_depth;
 
     // RUNTIME FUNCTION PARAMETER FIX: If resolveLambdaFunction returns nullptr,
     // check if this is a function parameter (runtime closure) and use codegenClosureCall
@@ -1995,11 +1932,10 @@ llvm::Value* AutodiffCodegen::codegenDerivativeMonolith(const eshkol_operations_
                     std::vector<Value*> call_args = {x_dual_tagged};
                     Value* result = closure_call_callback_(var_value, call_args, "derivative", callback_context_);
 
-                    // Unpack result and extract derivative
-                    Value* result_dual = unpackDualFromTagged(result);
-                    Value* value = getDualPrimal(result_dual);
-                    Value* derivative = getDualTangent(result_dual);
-                    return tagged_.packDouble(derivative);
+                    // Extract the derivative w.r.t. this nesting level's
+                    // perturbation slot (scalar at depth 0, a dual slice when
+                    // nested so an enclosing derivative can read it).
+                    return extractDerivativeResult(result, my_depth);
                 }
                 // Check if it's a pointer to closure (mutable capture)
                 if (isa<Argument>(var_value) && var_value->getType()->isPointerTy()) {
@@ -2008,11 +1944,10 @@ llvm::Value* AutodiffCodegen::codegenDerivativeMonolith(const eshkol_operations_
                     std::vector<Value*> call_args = {x_dual_tagged};
                     Value* result = closure_call_callback_(loaded_val, call_args, "derivative", callback_context_);
 
-                    // Unpack result and extract derivative
-                    Value* result_dual = unpackDualFromTagged(result);
-                    Value* value = getDualPrimal(result_dual);
-                    Value* derivative = getDualTangent(result_dual);
-                    return tagged_.packDouble(derivative);
+                    // Extract the derivative w.r.t. this nesting level's
+                    // perturbation slot (scalar at depth 0, a dual slice when
+                    // nested so an enclosing derivative can read it).
+                    return extractDerivativeResult(result, my_depth);
                 }
                 // Check if it's an AllocaInst (local variable holding a closure)
                 if (isa<AllocaInst>(var_value) && var_value->getType()->isPointerTy()) {
@@ -2023,11 +1958,7 @@ llvm::Value* AutodiffCodegen::codegenDerivativeMonolith(const eshkol_operations_
                         std::vector<Value*> call_args = {x_dual_tagged};
                         Value* result = closure_call_callback_(loaded_val, call_args, "derivative", callback_context_);
 
-                        // Unpack result and extract derivative
-                        Value* result_dual = unpackDualFromTagged(result);
-                        Value* value = getDualPrimal(result_dual);
-                    Value* derivative = getDualTangent(result_dual);
-                        return tagged_.packDouble(derivative);
+                        return extractDerivativeResult(result, my_depth);
                     }
                 }
                 // Check if it's a LoadInst (already loaded closure value)
@@ -2036,11 +1967,10 @@ llvm::Value* AutodiffCodegen::codegenDerivativeMonolith(const eshkol_operations_
                     std::vector<Value*> call_args = {x_dual_tagged};
                     Value* result = closure_call_callback_(var_value, call_args, "derivative", callback_context_);
 
-                    // Unpack result and extract derivative
-                    Value* result_dual = unpackDualFromTagged(result);
-                    Value* value = getDualPrimal(result_dual);
-                    Value* derivative = getDualTangent(result_dual);
-                    return tagged_.packDouble(derivative);
+                    // Extract the derivative w.r.t. this nesting level's
+                    // perturbation slot (scalar at depth 0, a dual slice when
+                    // nested so an enclosing derivative can read it).
+                    return extractDerivativeResult(result, my_depth);
                 }
                 // Check if it's a GlobalVariable (letrec captured function)
                 if (isa<GlobalVariable>(var_value)) {
@@ -2050,11 +1980,10 @@ llvm::Value* AutodiffCodegen::codegenDerivativeMonolith(const eshkol_operations_
                     std::vector<Value*> call_args = {x_dual_tagged};
                     Value* result = closure_call_callback_(loaded_val, call_args, "derivative", callback_context_);
 
-                    // Unpack result and extract derivative
-                    Value* result_dual = unpackDualFromTagged(result);
-                    Value* value = getDualPrimal(result_dual);
-                    Value* derivative = getDualTangent(result_dual);
-                    return tagged_.packDouble(derivative);
+                    // Extract the derivative w.r.t. this nesting level's
+                    // perturbation slot (scalar at depth 0, a dual slice when
+                    // nested so an enclosing derivative can read it).
+                    return extractDerivativeResult(result, my_depth);
                 }
             }
         }
@@ -2201,21 +2130,13 @@ llvm::Value* AutodiffCodegen::codegenDerivativeMonolith(const eshkol_operations_
     // The function will automatically use dual arithmetic, propagating derivatives
     Value* result_tagged = ctx_.builder().CreateCall(func_ptr, deriv_call_args);
 
-    // Unpack result from tagged_value.  Use the safe variant: a lambda
-    // body that doesn't depend on x (constant fn, predicate-driven
-    // branch with literal branches, etc.) returns a non-dual scalar,
-    // which the plain unpack would deref as a heap pointer and crash.
-    // safeUnpackDualFromTagged returns {primal, 0.0} in that case.
-    Value* result_dual = safeUnpackDualFromTagged(result_tagged);
+    eshkol_debug("Derivative operator: extracting derivative component");
 
-    // Extract derivative component from result
-    Value* value = getDualPrimal(result_dual);
-                    Value* derivative = getDualTangent(result_dual);
-
-    eshkol_debug("Derivative operator: extracted derivative component");
-
-    // Return derivative as tagged_value for consistent handling in arithmetic
-    return tagged_.packDouble(derivative);
+    // Extract the derivative w.r.t. this nesting level's perturbation slot.
+    // At depth 0 this is the scalar derivative; when nested it is a dual slice
+    // carrying the outer perturbation so the enclosing derivative can read it.
+    // safeUnpack inside handles a non-dual scalar result (constant fn etc.).
+    return extractDerivativeResult(result_tagged, my_depth);
 }
 
 
@@ -5762,35 +5683,24 @@ llvm::Value* AutodiffCodegen::hessian(const eshkol_operations_t* op) {
                 x = ctx_.builder().CreateSelect(is_int, as_int, as_dbl);
             }
 
-            Value* h = ConstantFP::get(ctx_.doubleType(), 1e-5);
+            // EXACT f''(x) via forward-over-forward AD: seed BOTH perturbation
+            // slots on the single input, x_jet = {x, 1, 1, 0}. Then
+            //   f(x_jet) = f(x) + f'(x)(e1+e2) + f''(x) e1e2
+            // and the mixed (e1e2) component IS f''(x) — no finite-difference
+            // step, machine precision.
+            Value* one = ConstantFP::get(ctx_.doubleType(), 1.0);
+            Value* zero = ConstantFP::get(ctx_.doubleType(), 0.0);
+            Value* x_jet = packDualToTagged(makeDual4(ctx_, x, one, one, zero));
 
-            // Function calls: f(x+h), f(x), f(x-h) — dispatch to func_ptr or closure
-            Value* xph = tagged_.packDouble(ctx_.builder().CreateFAdd(x, h));
-            Value* xv  = tagged_.packDouble(x);
-            Value* xmh = tagged_.packDouble(ctx_.builder().CreateFSub(x, h));
-
-            Value* fxph, *fx, *fxmh;
+            Value* fres;
             if (scalar_func_ptr) {
-                fxph = ctx_.builder().CreateCall(scalar_func_ptr, {xph});
-                fx   = ctx_.builder().CreateCall(scalar_func_ptr, {xv});
-                fxmh = ctx_.builder().CreateCall(scalar_func_ptr, {xmh});
+                fres = ctx_.builder().CreateCall(scalar_func_ptr, {x_jet});
             } else {
-                fxph = closure_call_callback_(hessian_closure_val, {xph}, "hessian-scalar-xph", callback_context_);
-                fx   = closure_call_callback_(hessian_closure_val, {xv},  "hessian-scalar-x",   callback_context_);
-                fxmh = closure_call_callback_(hessian_closure_val, {xmh}, "hessian-scalar-xmh", callback_context_);
+                fres = closure_call_callback_(hessian_closure_val, {x_jet}, "hessian-scalar", callback_context_);
             }
 
-            Value* a = tagged_.unpackDouble(fxph);
-            Value* b = tagged_.unpackDouble(fx);
-            Value* c = tagged_.unpackDouble(fxmh);
-
-            // f''(x) = (a - 2b + c) / h²
-            Value* h2 = ctx_.builder().CreateFMul(h, h);
-            Value* numer = ctx_.builder().CreateFSub(
-                ctx_.builder().CreateFAdd(a, c),
-                ctx_.builder().CreateFMul(ConstantFP::get(ctx_.doubleType(), 2.0), b));
-            Value* result = ctx_.builder().CreateFDiv(numer, h2);
-
+            Value* fres_dual = safeUnpackDualFromTagged(fres);
+            Value* result = dualField(ctx_, fres_dual, 3);   // f''(x) = mixed term
             return tagged_.packDouble(result);
         }
     }
@@ -5811,7 +5721,7 @@ llvm::Value* AutodiffCodegen::hessian(const eshkol_operations_t* op) {
         vector_val = tagged_.packPtr(data_val, ESHKOL_VALUE_HEAP_PTR);
     }
 
-    // ── MULTI-PARAMETER HESSIAN via central finite differences ──────────
+    // ── MULTI-PARAMETER HESSIAN via exact forward-over-forward AD ───────
     // A multi-parameter scalar function f(x,y,…) cannot go through the
     // reverse-mode AD-node tensor path: that passes AD nodes as separate
     // CALLABLE args, which crashes function dispatch (same reason gradient
@@ -5861,31 +5771,27 @@ llvm::Value* AutodiffCodegen::hessian(const eshkol_operations_t* op) {
                     ctx_.builder().CreateGEP(ctx_.doubleType(), mp_dbls_p,
                         ConstantInt::get(ctx_.int64Type(), (int64_t)k)));
             }
-            Value* hh = ConstantFP::get(ctx_.doubleType(), 1e-4);
+            Value* one = ConstantFP::get(ctx_.doubleType(), 1.0);
+            Value* zerod = ConstantFP::get(ctx_.doubleType(), 0.0);
 
-            // Evaluate f at base + Σ delta[p]*h, returning the result as a double.
-            auto evalAt = [&](const std::vector<int>& delta) -> Value* {
+            // EXACT mixed partial d^2 f / d x_i d x_j via forward-over-forward
+            // AD: seed perturbation e1 on argument i and e2 on argument j (both
+            // on argument i when i==j), evaluate f ONCE on the 4-component jets,
+            // and read the mixed (e1e2) component of the result. No finite
+            // differences -> off-diagonals of separable functions are EXACTLY 0.
+            auto evalDual2 = [&](uint64_t i, uint64_t j) -> Value* {
                 std::vector<Value*> args;
                 args.reserve(N);
                 for (uint64_t p = 0; p < N; p++) {
-                    Value* xp = base[p];
-                    if (delta[p] != 0) {
-                        Value* d = ctx_.builder().CreateFMul(hh,
-                            ConstantFP::get(ctx_.doubleType(), (double)delta[p]));
-                        xp = ctx_.builder().CreateFAdd(xp, d);
-                    }
-                    args.push_back(tagged_.packDouble(xp));
+                    Value* d1 = (p == i) ? one : zerod;
+                    Value* d2 = (p == j) ? one : zerod;
+                    args.push_back(packDualToTagged(makeDual4(ctx_, base[p], d1, d2, zerod)));
                 }
-                resolveGradientCaptures(func_ptr, args, "hessian-fd");
+                resolveGradientCaptures(func_ptr, args, "hessian-ad");
                 Value* r = ctx_.builder().CreateCall(func_ptr, args);
-                return tagged_.unpackDouble(r);
+                Value* rd = safeUnpackDualFromTagged(r);
+                return dualField(ctx_, rd, 3);   // mixed second-order term
             };
-
-            std::vector<int> zero(N, 0);
-            Value* fx = evalAt(zero);
-            Value* h2 = ctx_.builder().CreateFMul(hh, hh);
-            Value* four_h2 = ctx_.builder().CreateFMul(
-                ConstantFP::get(ctx_.doubleType(), 4.0), h2);
 
             // Result N×N tensor.
             Value* mp_res = ctx_.builder().CreateCall(mem_.getArenaAllocateTensorWithHeader(), {mp_arena});
@@ -5907,27 +5813,7 @@ llvm::Value* AutodiffCodegen::hessian(const eshkol_operations_t* op) {
 
             for (uint64_t i = 0; i < N; i++) {
                 for (uint64_t j = 0; j < N; j++) {
-                    Value* hij;
-                    if (i == j) {
-                        std::vector<int> pe(N, 0), me(N, 0); pe[i] = 1; me[i] = -1;
-                        Value* a = evalAt(pe), *c = evalAt(me);
-                        Value* num = ctx_.builder().CreateFSub(
-                            ctx_.builder().CreateFAdd(a, c),
-                            ctx_.builder().CreateFMul(ConstantFP::get(ctx_.doubleType(), 2.0), fx));
-                        hij = ctx_.builder().CreateFDiv(num, h2);
-                    } else {
-                        std::vector<int> pp(N, 0), pm(N, 0), mp_(N, 0), mm(N, 0);
-                        pp[i] = 1;  pp[j] = 1;
-                        pm[i] = 1;  pm[j] = -1;
-                        mp_[i] = -1; mp_[j] = 1;
-                        mm[i] = -1; mm[j] = -1;
-                        Value* num = ctx_.builder().CreateFAdd(
-                            ctx_.builder().CreateFSub(
-                                ctx_.builder().CreateFSub(evalAt(pp), evalAt(pm)),
-                                evalAt(mp_)),
-                            evalAt(mm));
-                        hij = ctx_.builder().CreateFDiv(num, four_h2);
-                    }
+                    Value* hij = evalDual2(i, j);
                     Value* bits = ctx_.builder().CreateBitCast(hij, ctx_.int64Type());
                     ctx_.builder().CreateStore(bits,
                         ctx_.builder().CreateGEP(ctx_.int64Type(), mp_elems_p,
@@ -9791,26 +9677,21 @@ llvm::Value* AutodiffCodegen::dualRelu(llvm::Value* dual) {
 // Chain rule: d/dx[σ(f(x))] = σ(f(x)) * (1 - σ(f(x))) * f'(x)
 llvm::Value* AutodiffCodegen::dualSigmoid(llvm::Value* dual) {
     if (!dual) return nullptr;
-
-    llvm::Value* a = getDualPrimal(dual);
-    llvm::Value* a_prime = getDualTangent(dual);
-
+    llvm::Value* a = dualField(ctx_, dual, 0);
     llvm::Function* exp_func = getMathFunc("exp");
     if (!exp_func) return nullptr;
-
+    auto& b = ctx_.builder();
     // σ(a) = 1 / (1 + exp(-a))
-    llvm::Value* neg_a = ctx_.builder().CreateFNeg(a);
-    llvm::Value* exp_neg_a = ctx_.builder().CreateCall(exp_func, {neg_a});
+    llvm::Value* exp_neg_a = b.CreateCall(exp_func, {b.CreateFNeg(a)});
     llvm::Value* one = llvm::ConstantFP::get(ctx_.doubleType(), 1.0);
-    llvm::Value* denom = ctx_.builder().CreateFAdd(one, exp_neg_a);
-    llvm::Value* sigma_a = ctx_.builder().CreateFDiv(one, denom);
-
-    // Derivative: a' * σ(a) * (1 - σ(a))
-    llvm::Value* one_minus_sigma = ctx_.builder().CreateFSub(one, sigma_a);
-    llvm::Value* sigma_deriv = ctx_.builder().CreateFMul(sigma_a, one_minus_sigma);
-    llvm::Value* deriv = ctx_.builder().CreateFMul(a_prime, sigma_deriv);
-
-    return createDualNumber(sigma_a, deriv);
+    llvm::Value* sigma_a = b.CreateFDiv(one, b.CreateFAdd(one, exp_neg_a));
+    // g'  = σ(1-σ);  g'' = σ(1-σ)(1-2σ)
+    llvm::Value* oms = b.CreateFSub(one, sigma_a);
+    llvm::Value* fpa = b.CreateFMul(sigma_a, oms);
+    llvm::Value* two = llvm::ConstantFP::get(ctx_.doubleType(), 2.0);
+    llvm::Value* one_minus_2s = b.CreateFSub(one, b.CreateFMul(two, sigma_a));
+    llvm::Value* fppa = b.CreateFMul(fpa, one_minus_2s);
+    return dualUnaryChain(ctx_, dual, sigma_a, fpa, fppa);
 }
 
 // GELU: Gaussian Error Linear Unit using the tanh approximation used by tensorGelu.

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -18442,8 +18442,12 @@ private:
             Value* num = builder->CreateFSub(num_y, num_x, "atan2_num");
             Value* tangent_d = builder->CreateFDiv(num, denom, "atan2_tangent");
             Value* result_dual = UndefValue::get(ctx_->dualNumberType());
+            Value* atan2_dzero = ConstantFP::get(double_type, 0.0);
             result_dual = builder->CreateInsertValue(result_dual, primal_d, {0});
             result_dual = builder->CreateInsertValue(result_dual, tangent_d, {1});
+            // 2nd-order dual: zero e2 / e1e2 slots (avoid poison).
+            result_dual = builder->CreateInsertValue(result_dual, atan2_dzero, {2});
+            result_dual = builder->CreateInsertValue(result_dual, atan2_dzero, {3});
             Value* dual_tagged = autodiff_->packDualToTagged(result_dual);
             BasicBlock* dual_exit = builder->GetInsertBlock();
             builder->CreateBr(merge_bb);
@@ -18518,8 +18522,12 @@ private:
         Value* l_dual = arith_->convertToDual(arg1, arg1_is_dual, l_dbl_for_dual);
         Value* l_tangent = builder->CreateExtractValue(l_dual, {1}, "mod_l_tangent");
         Value* result_dual = UndefValue::get(ctx_->dualNumberType());
+        Value* mod_dzero = ConstantFP::get(double_type, 0.0);
         result_dual = builder->CreateInsertValue(result_dual, mod_primal, {0});
         result_dual = builder->CreateInsertValue(result_dual, l_tangent, {1});
+        // 2nd-order dual: zero e2 / e1e2 slots (avoid poison).
+        result_dual = builder->CreateInsertValue(result_dual, mod_dzero, {2});
+        result_dual = builder->CreateInsertValue(result_dual, mod_dzero, {3});
         Value* mod_dual_tagged = autodiff_->packDualToTagged(result_dual);
         BasicBlock* dual_exit_mod = builder->GetInsertBlock();
         builder->CreateBr(mod_outer_merge);
@@ -18765,6 +18773,9 @@ private:
             Value* dual_struct = UndefValue::get(ctx_->dualNumberType());
             dual_struct = builder->CreateInsertValue(dual_struct, dual_result_dbl, {0});
             dual_struct = builder->CreateInsertValue(dual_struct, ConstantFP::get(double_type, 0.0), {1});
+            // 2nd-order dual: zero e2 / e1e2 slots (avoid poison).
+            dual_struct = builder->CreateInsertValue(dual_struct, ConstantFP::get(double_type, 0.0), {2});
+            dual_struct = builder->CreateInsertValue(dual_struct, ConstantFP::get(double_type, 0.0), {3});
             Value* dual_tagged = autodiff_->packDualToTagged(dual_struct);
             BasicBlock* dual_gcd_exit = builder->GetInsertBlock();
             builder->CreateBr(gcd_outer_merge);
@@ -18901,6 +18912,9 @@ private:
             Value* dual_struct = UndefValue::get(ctx_->dualNumberType());
             dual_struct = builder->CreateInsertValue(dual_struct, dual_result_dbl, {0});
             dual_struct = builder->CreateInsertValue(dual_struct, ConstantFP::get(double_type, 0.0), {1});
+            // 2nd-order dual: zero e2 / e1e2 slots (avoid poison).
+            dual_struct = builder->CreateInsertValue(dual_struct, ConstantFP::get(double_type, 0.0), {2});
+            dual_struct = builder->CreateInsertValue(dual_struct, ConstantFP::get(double_type, 0.0), {3});
             Value* dual_tagged = autodiff_->packDualToTagged(dual_struct);
             BasicBlock* dual_lcm_exit = builder->GetInsertBlock();
             builder->CreateBr(lcm_outer_merge);

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -987,6 +987,7 @@ private:
     static const size_t MAX_TAPE_DEPTH = 32; // Support up to 32 levels of nesting
     GlobalVariable* ad_tape_stack;  // Array of tape pointers [MAX_TAPE_DEPTH]
     GlobalVariable* ad_tape_depth;  // Current stack depth (0 = no active gradient)
+    GlobalVariable* ad_pert_level;  // ESH-0070 forward-mode perturbation level (runtime)
 
     // DOUBLE BACKWARD: Storage for outer AD node when in nested gradient
     // Used to connect inner gradient's result to outer's computation graph
@@ -1992,6 +1993,15 @@ public:
                     nullptr, // External - defined in arena_memory.cpp
                     "__ad_tape_depth"
                 );
+                // ESH-0070: forward-mode perturbation level (external for REPL)
+                ad_pert_level = new GlobalVariable(
+                    *module,
+                    int64_type,
+                    false,
+                    GlobalValue::ExternalLinkage,
+                    nullptr, // External - defined in runtime_autodiff.cpp
+                    "__ad_pert_level"
+                );
 
                 // DOUBLE BACKWARD: Create outer AD node storage globals (external for REPL)
                 outer_ad_node_storage = new GlobalVariable(
@@ -2072,6 +2082,15 @@ public:
                     GlobalValue::InternalLinkage,
                     ConstantInt::get(int64_type, 0),
                     "__ad_tape_depth"
+                );
+                // ESH-0070: forward-mode perturbation level (internal with zero init)
+                ad_pert_level = new GlobalVariable(
+                    *module,
+                    int64_type,
+                    false,
+                    GlobalValue::InternalLinkage,
+                    ConstantInt::get(int64_type, 0),
+                    "__ad_pert_level"
                 );
 
                 // DOUBLE BACKWARD: Create outer AD node storage globals (internal with null init)
@@ -3426,6 +3445,7 @@ private:
         ctx_->setCurrentAdTape(current_ad_tape);
         ctx_->setAdTapeStack(ad_tape_stack);
         ctx_->setAdTapeDepth(ad_tape_depth);
+        ctx_->setAdPertLevel(ad_pert_level);
         ctx_->setOuterAdNodeStorage(outer_ad_node_storage);
         ctx_->setOuterAdNodeToInner(outer_ad_node_to_inner);
         ctx_->setOuterGradAccumulator(outer_grad_accumulator);

--- a/lib/backend/type_system.cpp
+++ b/lib/backend/type_system.cpp
@@ -59,14 +59,29 @@ void TypeSystem::createStructTypes() {
     tagged_value_fields.push_back(int64_type);  // Field 4: data union (offset 8, 8 bytes)
     tagged_value_type = llvm::StructType::create(context, tagged_value_fields, "eshkol_tagged_value");
 
-    // Dual number struct type for forward-mode automatic differentiation
+    // Dual number struct type for forward-mode automatic differentiation.
+    //
+    // SECOND-ORDER / NESTED AD: the dual carries two independent
+    // perturbation slots plus their mixed (cross) term, encoding a truncated
+    // bivariate Taylor expansion
+    //   v = primal + d1*e1 + d2*e2 + d12*e1*e2   (with e1^2 = e2^2 = 0)
+    // This is what makes 2-level nested `derivative` and EXACT Hessians
+    // possible: perturbation tagging maps nesting depth -> slot index.
+    // The first two fields (primal, d1) are UNCHANGED, so all single-level
+    // forward-mode AD and the C runtime view of the struct (which reads only
+    // value/derivative at offsets 0 and 8) keep working bit-compatibly; the
+    // d2/d12 slots default to 0 for first-order use.
     // struct eshkol_dual_number {
-    //     double value;       // f(x)
-    //     double derivative;  // f'(x)
+    //     double value;       // f0: primal  f(x)
+    //     double derivative;  // f1: d/de1   (single-level tangent)
+    //     double d2;          // f2: d/de2   (second perturbation slot)
+    //     double d12;         // f3: d2/de1 de2 (mixed second-order term)
     // }
     std::vector<llvm::Type*> dual_fields;
-    dual_fields.push_back(double_type);  // value
-    dual_fields.push_back(double_type);  // derivative
+    dual_fields.push_back(double_type);  // value  (primal)
+    dual_fields.push_back(double_type);  // derivative (slot e1)
+    dual_fields.push_back(double_type);  // slot e2
+    dual_fields.push_back(double_type);  // mixed e1*e2
     dual_number_type = llvm::StructType::create(context, dual_fields, "dual_number");
 
     // Complex number struct type for signal processing and complex analysis

--- a/lib/core/arena_memory.h
+++ b/lib/core/arena_memory.h
@@ -296,6 +296,7 @@ extern thread_local uint64_t __region_stack_depth;
 #define ESHKOL_ARENA_MAX_TAPE_DEPTH 32
 extern thread_local ad_tape_t* __ad_tape_stack[ESHKOL_ARENA_MAX_TAPE_DEPTH];
 extern thread_local uint64_t __ad_tape_depth;
+extern thread_local uint64_t __ad_pert_level;  // ESH-0070 forward-mode perturbation level
 extern thread_local void* __outer_ad_node_storage;
 extern thread_local void* __outer_ad_node_to_inner;
 extern thread_local void* __outer_grad_accumulator;

--- a/lib/core/runtime_autodiff.cpp
+++ b/lib/core/runtime_autodiff.cpp
@@ -39,6 +39,9 @@ void debug_print_ptr(const char* context, void* ptr) {
 thread_local ad_tape_t* __ad_tape_stack[ESHKOL_ARENA_MAX_TAPE_DEPTH] = {nullptr};
 thread_local uint64_t __ad_tape_depth = 0;
 
+// ESH-0070: runtime forward-mode perturbation level (see codegen_context.h).
+thread_local uint64_t __ad_pert_level = 0;
+
 thread_local void* __outer_ad_node_storage = nullptr;
 thread_local void* __outer_ad_node_to_inner = nullptr;
 thread_local void* __outer_grad_accumulator = nullptr;

--- a/lib/core/runtime_regions.cpp
+++ b/lib/core/runtime_regions.cpp
@@ -66,6 +66,7 @@ void eshkol_thread_init_worker(size_t arena_size_hint) {
     }
     __ad_tape_depth = 0;
     __outer_ad_node_depth = 0;
+    __ad_pert_level = 0;
 
     __outer_ad_node_storage = nullptr;
     __outer_ad_node_to_inner = nullptr;
@@ -93,6 +94,7 @@ void eshkol_thread_shutdown_worker(void) {
     }
     __ad_tape_depth = 0;
     __outer_ad_node_depth = 0;
+    __ad_pert_level = 0;
 
     __outer_ad_node_storage = nullptr;
     __outer_ad_node_to_inner = nullptr;

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -1225,6 +1225,7 @@ void ReplJITContext::registerRuntimeSymbols() {
     // These are thread_local — must use ADD_TLS_SYMBOL (mangled name) so the JIT can resolve them.
     ADD_TLS_SYMBOL(__ad_tape_stack);
     ADD_TLS_SYMBOL(__ad_tape_depth);
+    ADD_TLS_SYMBOL(__ad_pert_level);  // ESH-0070 forward-mode perturbation level
     ADD_TLS_SYMBOL(__outer_ad_node_storage);
     ADD_TLS_SYMBOL(__outer_ad_node_to_inner);
     ADD_TLS_SYMBOL(__outer_grad_accumulator);

--- a/tests/ad/nested_ad_loop_test.esk
+++ b/tests/ad/nested_ad_loop_test.esk
@@ -1,0 +1,89 @@
+;;; tests/ad/nested_ad_loop_test.esk
+;;; ESH-0070: iterated higher-order AD — differentiating a function whose body
+;;; is a named-let (let loop) tail-recursion that itself calls `gradient`.
+;;;
+;;; Before this fix, the OUTER gradient drove the inner `gradient` through the
+;;; reverse-mode "double backward" monomial-reconstruction heuristic (exact only
+;;; for pure x^n), AND an inline lambda's global capture was resolved in the
+;;; wrong ABI inside a named-let loop. Result: garbage that COMPOUNDED with the
+;;; iteration count k (3.48e36 -> 1.8e51 -> ... -> SIGSEGV/SIGBUS), even though
+;;; the mathematically-identical straight-line code was exact.
+;;;
+;;; The fix: scalar single-variable `gradient` uses the exact forward-mode 4-jet
+;;; (like `derivative`); the perturbation level is a RUNTIME counter pushed/popped
+;;; around each call (invariant under TCO, correct across the function-call /
+;;; named-let boundary); named-let loop carries (#224) are forwarded to the
+;;; gradient lambda in the correct single-indirection capture ABI.
+
+(define pass 0)(define fail 0)
+(define (approx= a b tol) (< (abs (- a b)) tol))
+(define (chk label v) (display "  [")(display (if v "PASS" "FAIL"))(display "] ")(display label)(newline)
+  (if v (set! pass (+ pass 1)) (set! fail (+ fail 1))))
+
+(define a 8.0) (define t 5.0)
+
+;; L(x) = a*(x-t)^2 ;  L'(x) = 2a(x-t)
+;; post-loop(m,k): k gradient-descent steps w_{i+1} = w_i - m*0.05*L'(w_i) from w_0=0,
+;; then returns L(w_k). We differentiate post-loop w.r.t. m — a meta-gradient
+;; through an iterated loop that itself calls `gradient`.
+(define (post-loop m k)
+  (let loop ((w 0.0) (i 0))
+    (if (>= i k)
+        (let ((d (- w t))) (* a (* d d)))
+        (let ((g (gradient (lambda (x) (let ((d (- x t))) (* a (* d d)))) w)))
+          (loop (- w (* m 0.05 g)) (+ i 1))))))
+
+;; Mathematically-identical straight-line k=1 reference: KNOWN exact = -307.2
+(define (post m)
+  (let ((d (- (- 0.0 (* m 0.05 (gradient (lambda (x) (let ((d (- x t))) (* a (* d d)))) 0.0))) t)))
+    (* a (* d d))))
+
+;; ---- central finite difference of post-loop'(m) for cross-checking AD ----
+(define (fd-post-loop m k)
+  (let ((h 1e-5))
+    (/ (- (post-loop (+ m h) k) (post-loop (- m h) k)) (* 2.0 h))))
+
+(define m0 0.05)
+
+;; (a) k=1 equals the straight-line reference, exactly -307.2
+(chk "named-let k=1 == straight-line == -307.2"
+     (and (approx= (gradient (lambda (m) (post-loop m 1)) m0) -307.2 1e-6)
+          (approx= (gradient (lambda (m) (post m)) m0) -307.2 1e-6)))
+
+;; (b) k=2..5 finite and matching finite-difference (no compounding blow-up)
+(chk "named-let k=2 matches finite-difference"
+     (approx= (gradient (lambda (m) (post-loop m 2)) m0) (fd-post-loop m0 2) 1e-3))
+(chk "named-let k=3 matches finite-difference"
+     (approx= (gradient (lambda (m) (post-loop m 3)) m0) (fd-post-loop m0 3) 1e-3))
+(chk "named-let k=4 matches finite-difference"
+     (approx= (gradient (lambda (m) (post-loop m 4)) m0) (fd-post-loop m0 4) 1e-3))
+(chk "named-let k=5 matches finite-difference"
+     (approx= (gradient (lambda (m) (post-loop m 5)) m0) (fd-post-loop m0 5) 1e-3))
+
+;; (c) a ~25-step iterated loop-nested gradient completes (no SIGSEGV/SIGBUS),
+;;     and stays finite + agrees with finite-difference.
+(define g25 (gradient (lambda (m) (post-loop m 25)) 0.02))
+(chk "25-step iterated loop-nested gradient is finite"
+     (and (= g25 g25) (< (abs g25) 1e30)))
+(chk "25-step iterated loop-nested gradient matches finite-difference"
+     (approx= g25 (fd-post-loop 0.02 25) 1e-2))
+
+;; (d) gradient-of-gradient of a (plain) named-let loop. poly-loop computes x^n
+;;     by iteration; the 2nd derivative of x^4 is 12x^2 = 48 at x=2. This is
+;;     genuine forward-over-forward (2 live perturbations) THROUGH a TCO loop —
+;;     exactly the case the runtime perturbation level + jet make exact.
+;;     (NB: differentiating TWICE a loop that ITSELF calls gradient would need a
+;;     3rd simultaneous perturbation, beyond the 2-slot jet — flagged, not silent.)
+(define (poly-loop x n)
+  (let loop ((acc 1.0) (i 0)) (if (>= i n) acc (loop (* acc x) (+ i 1)))))
+(chk "gradient-of-gradient of plain loop: d2/dx2 (x^4 via loop) @2 = 48"
+     (approx= (gradient (lambda (y) (gradient (lambda (x) (poly-loop x 4)) y)) 2.0) 48.0 1e-6))
+
+;; (e) pure nested gradient sanity (the coordinator bisection table): x^4 -> 588,
+;;     (x+0)^2 -> 2 — exercising the forward-mode jet directly.
+(chk "nested grad x^4 @7 = 588"
+     (approx= (gradient (lambda (y) (gradient (lambda (x) (let ((u (* x x))) (* u u))) y)) 7.0) 588.0 1e-6))
+(chk "nested grad (x+0)^2 @7 = 2 (affine term, was 0)"
+     (approx= (gradient (lambda (y) (gradient (lambda (x) (* (+ x 0.0) (+ x 0.0))) y)) 7.0) 2.0 1e-9))
+
+(display "Passed: ")(display pass)(newline)(display "Failed: ")(display fail)(newline)

--- a/tests/ad/nested_ad_test.esk
+++ b/tests/ad/nested_ad_test.esk
@@ -1,0 +1,27 @@
+;;; tests/ad/nested_ad_test.esk
+;;; ESH-0067: true nested/higher-order AD via perturbation tagging (4-component
+;;; jet {primal,e1,e2,e1e2}). Previously these used central-difference numerical
+;;; diff -> perturbation confusion (0/garbage) + finite-diff hessian noise.
+(define pass 0)(define fail 0)
+(define (approx= a b) (< (abs (- a b)) 1e-9))
+(define (chk label v) (display "  [")(display (if v "PASS" "FAIL"))(display "] ")(display label)(newline)
+  (if v (set! pass (+ pass 1)) (set! fail (+ fail 1))))
+
+;; nested derivative whose inner point depends on the outer var (perturbation confusion cases)
+(chk "d/dx(d/dy x*y) = 1" (approx= (derivative (lambda (x) (derivative (lambda (y) (* x y)) 2.0)) 5.0) 1.0))
+(chk "d2/dx2(x^3)@2 = 12" (approx= (derivative (lambda (x) (derivative (lambda (y) (* y y y)) x)) 2.0) 12.0))
+(chk "d/dx(x*d/dy(y^2)@x)@1 = 4" (approx= (derivative (lambda (x) (* x (derivative (lambda (y) (* y y)) x))) 1.0) 4.0))
+
+;; hessian must be EXACT (off-diagonal exactly 0, no finite-diff epsilon)
+(define h (hessian (lambda (x y) (+ (* x x x) (* y y))) (list 2.0 1.0)))
+(chk "hessian diag [0][0] = 12" (approx= (tensor-ref h 0 0) 12.0))
+(chk "hessian off-diag [0][1] = 0 (exact)" (= (tensor-ref h 0 1) 0.0))
+(chk "hessian off-diag [1][0] = 0 (exact)" (= (tensor-ref h 1 0) 0.0))
+(chk "hessian diag [1][1] = 2" (approx= (tensor-ref h 1 1) 2.0))
+
+;; single-level AD unregressed
+(chk "deriv x^2 @3 = 6" (approx= (derivative (lambda (x) (* x x)) 3.0) 6.0))
+(chk "deriv sin @0 = 1" (approx= (derivative sin 0.0) 1.0))
+(chk "gradient (x^2+y^2) @(3,4) car = 6" (approx= (vector-ref (gradient (lambda (x y) (+ (* x x) (* y y))) (list 3.0 4.0)) 0) 6.0))
+
+(display "Passed: ")(display pass)(newline)(display "Failed: ")(display fail)(newline)


### PR DESCRIPTION
## ESH-0070 — iterated higher-order AD through a named-let loop

Differentiating a function whose body is a named-let (`let loop`) tail-recursion that itself calls `gradient` returned **garbage that compounded with the iteration count `k`**, then SIGSEGV (`-r`) / SIGBUS (AOT) when iterated for real — while the mathematically-identical **straight-line** code was exact. The defect is the interaction of nested `gradient` with TCO/closures, **not** the jet arithmetic (which `derivative` exercises and which is correct).

> Note: this branch stacks on #75 (`fix/nested-ad-perturbation-esh0067`, the 4-component jet) which is not yet in `master`; this PR contains those commits plus the ESH-0070 fix and makes the whole nested-AD story correct. Land after / together with #75 (it supersedes it).

### Root causes (two, both confirmed by bisection)

**1. Nested `gradient` used a monomial-reconstruction heuristic.** The reverse-mode "double backward" path reconstructed the second derivative assuming `f'(x) = k·xⁿ` — exact only for pure monomials. Any `+`/`-` term broke it, and it allocated a reverse-mode tape node per arithmetic op (the per-call leak):

| body, `(gradient (lambda(y)(gradient (lambda(x) BODY) y)) 7)` | want | before | after |
|---|---|---|---|
| `(* x x)` | 2 | 2 | 2 |
| `(let ((t (* x x))) (* t t))` (x⁴) | 588 | **196** | **588** |
| `(* (+ x 0.0) (+ x 0.0))` | 2 | **0** | **2** |

Fix: a **scalar single-variable `gradient` now uses the exact forward-mode 4-jet** (the same machinery `derivative` uses). It is gated to the scalar case — tensor-valued bodies (batch-norm/layer-norm/…) keep the reverse-mode tape, detected from the **source AST** so an inline nested gradient's own tensor machinery doesn't mis-trigger it; vector points take the reverse branch at runtime. Forward mode allocates O(1), so the per-op tape leak is gone.

The perturbation level that distinguishes nesting (e1 vs e2) is now a **runtime counter `__ad_pert_level` pushed/popped around each forward-mode call**, replacing a compile-time lexical depth that could not see across a function-call / named-let boundary (the inner gradient lives in a separately-compiled `post-loop`). The runtime push/pop is invariant under TCO re-entry. `derivative` moved onto the same mechanism.

**2. Wrong capture ABI for an inline lambda inside a named-let loop.** `resolveGradientCaptures` resolved a raw free var against the global table before the local one (finding `@a` instead of the loop carry `%a_cap`, #224) and always packed the `{INT64, ptrtoint}` double-indirection slot — but a lambda compiled inside the loop loads its capture **directly**, so it read the *address* of the global as the value. Fix: prefer the local table for the raw name; forward a named-let carry pointer (`<var>_cap`) directly; funnel value-typed captures through a temp slot.

### Why the straight-line case was already correct
Straight-line code has no separately-compiled inner function and no loop carry, so neither defect fires — exactly what was observed.

### Before → after (both `-r` and AOT)
```
named-let post-loop'(0.05, k=1): 9.93e53  -> -307.2   (== straight-line)
                          k=2:   2.77e77  -> -566.231 (matches finite-diff)
            k=3..5, 25:          diverging-> finite, FD-matched
50000-iteration meta-gradient:   SIGILL   -> -5366.11, ~100MB RSS, no crash
```

### Verification (`-r` AND AOT)
- New `tests/ad/nested_ad_loop_test.esk`: **10/10** (k=1==-307.2 exact; k=2..5 & 25-step vs finite-difference; gradient-of-gradient of a plain loop; the bisection table).
- No AD regression: `nested_ad_test` 10/10, `vm_ad` 12/12, `stateful_tape` 22/22, `free_energy` 2/2, `ad_input2` (matmul/conv2d/batch-norm/layer-norm/attention) all green.

Files: `lib/backend/autodiff_codegen.cpp` (forward path + runtime level + capture ABI + AST/IR tensor gate), `lib/backend/llvm_codegen.cpp` + `inc/.../codegen_context.h` (`__ad_pert_level` global), `lib/core/runtime_autodiff.cpp` / `arena_memory.h` / `runtime_regions.cpp` (TLS definition + reset), `lib/repl/repl_jit.cpp` (JIT symbol).