### PR TITLE
fix(predicates): first-class/apply'd equality predicates return booleans (ESH-0079)

### DIFF
--- a/inc/eshkol/backend/call_apply_codegen.h
+++ b/inc/eshkol/backend/call_apply_codegen.h
@@ -222,6 +222,18 @@ public:
     }
 
     /**
+     * Callback type for resolving a comparison / equality / unary predicate
+     * builtin (=, <, >, <=, >=, eq?, eqv?, equal?, even?, …) to its first-class
+     * wrapper Function* (tagged_value… -> tagged_value). Returns nullptr if the
+     * name has no such wrapper. Used by apply so `(apply = …)` / `(apply eq? …)`
+     * return proper booleans instead of falling through to "Unknown function".
+     */
+    using GetBuiltinPredicateCallback = llvm::Function* (*)(const std::string& name, void* context);
+    void setGetBuiltinPredicateCallback(GetBuiltinPredicateCallback callback) {
+        get_builtin_predicate_callback_ = callback;
+    }
+
+    /**
      * Callback type for applying builtin functions with runtime argument list.
      * Used for tensor/vector functions that need special handling in apply.
      * @param func_name Name of the builtin function (rand, randn, zeros, ones, etc.)
@@ -285,6 +297,8 @@ private:
 
     // Builtin arithmetic callback
     GetBuiltinArithmeticCallback get_builtin_arithmetic_callback_ = nullptr;
+    // Builtin comparison/equality/predicate wrapper resolver (for apply)
+    GetBuiltinPredicateCallback get_builtin_predicate_callback_ = nullptr;
 
     // Apply builtin callback for tensor/vector functions
     ApplyBuiltinCallback apply_builtin_callback_ = nullptr;

--- a/lib/backend/call_apply_codegen.cpp
+++ b/lib/backend/call_apply_codegen.cpp
@@ -265,6 +265,20 @@ Value* CallApplyCodegen::apply(const eshkol_operations_t* op) {
             }
         }
 
+        // Comparison / equality / unary-predicate builtins (=, <, >, <=, >=,
+        // eq?, eqv?, equal?, even?, …). These are codegen-inline at direct
+        // call sites and have no module function by their raw name, so apply
+        // missed them and returned () (and, for =, the SICP metacircular
+        // evaluator's (apply = …) silently took every base case). Resolve the
+        // first-class wrapper Function* and apply it like any user function so
+        // the result is a proper boolean.
+        if (get_builtin_predicate_callback_) {
+            if (llvm::Function* wrapper =
+                    get_builtin_predicate_callback_(func_name, callback_context_)) {
+                return applyUserFunction(wrapper, list_int);
+            }
+        }
+
         // Then ask the main codegen to emit a REPL forward-reference
         // indirect call (__repl_fwd_<name>). This is exactly what
         // direct calls do for cross-batch / cross-load functions —

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -767,6 +767,8 @@ namespace ControlFlowCallbacks {
     static bool isSelfTailRecursiveWrapper(const void* lambda_op, const char* func_name, void* context);
     // Wrapper for getting builtin arithmetic functions (for CallApplyCodegen)
     static llvm::Function* getBuiltinArithmeticWrapper(const std::string& op, void* context);
+    // Wrapper for resolving comparison/equality/predicate builtins (for apply)
+    static llvm::Function* getBuiltinPredicateWrapper(const std::string& name, void* context);
     // Wrapper for applying tensor/vector builtin functions
     static llvm::Value* applyBuiltinWrapper(const std::string& func_name, const std::vector<llvm::Value*>& args, llvm::Value* arg_count, void* context);
     // Bug P (2026-04-23): wrapper for forward-ref apply (cross-file user defines)
@@ -799,6 +801,7 @@ class EshkolLLVMCodeGen {
     friend void ControlFlowCallbacks::popFunctionContextWrapper(void* context);
     friend bool ControlFlowCallbacks::isSelfTailRecursiveWrapper(const void* lambda_op, const char* func_name, void* context);
     friend llvm::Function* ControlFlowCallbacks::getBuiltinArithmeticWrapper(const std::string& op, void* context);
+    friend llvm::Function* ControlFlowCallbacks::getBuiltinPredicateWrapper(const std::string& name, void* context);
     friend llvm::Value* ControlFlowCallbacks::applyBuiltinWrapper(const std::string& func_name, const std::vector<llvm::Value*>& args, llvm::Value* arg_count, void* context);
     friend llvm::Value* ControlFlowCallbacks::applyForwardRefWrapper(const std::string& func_name, llvm::Value* list_int, void* context);
     friend llvm::Value* ControlFlowCallbacks::closureCallWithInfoWrapper(llvm::Value* closure, const std::vector<llvm::Value*>& args, const char* info, void* context);
@@ -3535,6 +3538,7 @@ private:
         call_apply_->setGetConsAccessorCallback(ControlFlowCallbacks::getConsAccessorWrapper);
         call_apply_->setCreateConsCallback(ControlFlowCallbacks::consCreateWrapper);
         call_apply_->setGetBuiltinArithmeticCallback(ControlFlowCallbacks::getBuiltinArithmeticWrapper);
+        call_apply_->setGetBuiltinPredicateCallback(ControlFlowCallbacks::getBuiltinPredicateWrapper);
         call_apply_->setApplyBuiltinCallback(ControlFlowCallbacks::applyBuiltinWrapper);
         call_apply_->setApplyForwardRefCallback(ControlFlowCallbacks::applyForwardRefWrapper);
         eshkol_debug("Created CallApplyCodegen with callbacks");
@@ -8961,6 +8965,27 @@ private:
                 Value* closure_ptr = builder->CreateCall(getArenaAllocateClosureWithHeaderFunc(),
                                                          {arena_ptr, func_ptr_int, packed_info_val, sexpr_ptr, return_type_info, closure_name});
                 // Pack as CALLABLE (subtype CLOSURE is in header)
+                return packPtrToTaggedValue(closure_ptr, ESHKOL_VALUE_CALLABLE);
+            }
+        }
+
+        // Identity/equality predicates as first-class functions - wrap in closure.
+        // eq? / eqv? / equal? are normally codegen-inline (codegenEq/Eqv/Equal),
+        // so the bare symbol had no callable closure: `(car (list eq?))` and
+        // `(apply eq? …)` failed. Wrap each as an arity-2 boolean-returning closure.
+        if (var_name == "eq?" || var_name == "eqv?" || var_name == "equal?") {
+            Function* builtin_func = createBuiltinEqualityFunction(var_name);
+            if (builtin_func) {
+                Value* func_ptr_int = builder->CreatePtrToInt(builtin_func, intptr_type);
+                Value* arena_ptr = builder->CreateLoad(PointerType::getUnqual(*context), global_arena);
+                uint64_t packed_info = 0 | (2 << 16);  // no captures, arity=2
+                Value* packed_info_val = sizeConst(packed_info);
+                Value* sexpr_ptr = intPtrConst(0);
+                uint64_t return_type_info_val = CLOSURE_RETURN_SCALAR | (2 << 8);
+                Value* return_type_info = intPtrConst(return_type_info_val);
+                Value* closure_name = ConstantPointerNull::get(PointerType::getUnqual(*context));
+                Value* closure_ptr = builder->CreateCall(getArenaAllocateClosureWithHeaderFunc(),
+                                                         {arena_ptr, func_ptr_int, packed_info_val, sexpr_ptr, return_type_info, closure_name});
                 return packPtrToTaggedValue(closure_ptr, ESHKOL_VALUE_CALLABLE);
             }
         }
@@ -21914,7 +21939,12 @@ private:
 
         Value* arg1 = typedValueToTaggedValue(tv1);
         Value* arg2 = typedValueToTaggedValue(tv2);
+        return emitEqTagged(arg1, arg2);
+    }
 
+    // eq? logic operating on two already-tagged values (shared by codegenEq and
+    // the first-class / apply'd eq? wrapper). Returns a packed boolean.
+    Value* emitEqTagged(Value* arg1, Value* arg2) {
         // Get types
         Value* type1 = getTaggedValueType(arg1);
         Value* type2 = getTaggedValueType(arg2);
@@ -21975,7 +22005,12 @@ private:
 
         Value* arg1 = typedValueToTaggedValue(tv1);
         Value* arg2 = typedValueToTaggedValue(tv2);
+        return emitEqvTagged(arg1, arg2);
+    }
 
+    // eqv? logic operating on two already-tagged values (shared by codegenEqv and
+    // the first-class / apply'd eqv? wrapper). Returns a packed boolean.
+    Value* emitEqvTagged(Value* arg1, Value* arg2) {
         // Get types
         Value* type1 = getTaggedValueType(arg1);
         Value* type2 = getTaggedValueType(arg2);
@@ -22075,7 +22110,12 @@ private:
 
         Value* arg1 = typedValueToTaggedValue(tv1);
         Value* arg2 = typedValueToTaggedValue(tv2);
+        return emitEqualTagged(arg1, arg2);
+    }
 
+    // equal? logic operating on two already-tagged values (shared by codegenEqual
+    // and the first-class / apply'd equal? wrapper). Returns a packed boolean.
+    Value* emitEqualTagged(Value* arg1, Value* arg2) {
         // Use the runtime deep equality function for all comparisons
         // This handles all edge cases: nested lists, empty lists (NULL vs CONS_PTR with null), etc.
         Value* arg1_ptr = builder->CreateAlloca(tagged_value_type, nullptr, "equal_arg1");
@@ -32715,6 +32755,12 @@ private:
                 return createBuiltinComparisonFunction(func_name);
             }
 
+            // Handle identity/equality predicates as first-class functions
+            // (for map/filter/apply with eq?/eqv?/equal?).
+            if (func_name == "eq?" || func_name == "eqv?" || func_name == "equal?") {
+                return createBuiltinEqualityFunction(func_name);
+            }
+
             // Handle predicates as first-class functions (for filter, etc.)
             if (func_name == "even?" || func_name == "odd?" || func_name == "zero?" ||
                 func_name == "positive?" || func_name == "negative?" || func_name == "null?" ||
@@ -33990,8 +34036,12 @@ private:
             eshkol_error("Unknown comparison operation: %s", operation.c_str());
             cmp_result = ConstantInt::get(int1_type, 0);
         }
-        Value* int_result = builder->CreateZExt(cmp_result, int64_type);
-        Value* dbl_tagged_result = packInt64ToTaggedValue(int_result, true);
+        // R7RS comparison predicates must yield a proper boolean (#t/#f), not
+        // the raw int 0/1.  The bignum path above already returns ESHKOL_VALUE_BOOL
+        // (eshkol_bignum_compare_tagged); pack the double path as a boolean too so
+        // first-class / apply'd use of =, <, >, <=, >= returns #t/#f.  (Direct
+        // call sites are unaffected — they go through ArithmeticCodegen::compare.)
+        Value* dbl_tagged_result = packBoolToTaggedValue(cmp_result);
         builder->CreateBr(cmp_done);
         BasicBlock* dbl_exit = builder->GetInsertBlock();
 
@@ -34014,6 +34064,57 @@ private:
         eshkol_debug("Created builtin comparison function: %s for operation '%s'",
                     func_name.c_str(), operation.c_str());
 
+        return builtin_func;
+    }
+
+    // Create a (tagged_value, tagged_value) -> tagged_value wrapper for an
+    // identity/equality predicate (eq?, eqv?, equal?) so it can be used as a
+    // first-class value or via apply. These are normally codegen-inline
+    // (codegenEq/Eqv/Equal); without a wrapper, `(car (list eq?))` and
+    // `(apply eq? …)` had no callable closure. The body delegates to the same
+    // emitEq*Tagged helpers the inline path uses, so semantics stay identical.
+    Function* createBuiltinEqualityFunction(const std::string& pred_name) {
+        std::string func_name = "builtin_eqpred_" + pred_name;
+        for (char& c : func_name) {
+            if (c == '?') c = 'Q';
+            else if (c == '=') c = 'E';
+        }
+
+        auto existing_it = function_table.find(func_name);
+        if (existing_it != function_table.end()) {
+            return existing_it->second;
+        }
+
+        std::vector<Type*> param_types = {tagged_value_type, tagged_value_type};
+        FunctionType* func_type = FunctionType::get(tagged_value_type, param_types, false);
+        Function* builtin_func = Function::Create(
+            func_type, Function::ExternalLinkage, func_name, module.get());
+
+        IRBuilderBase::InsertPoint old_point = builder->saveIP();
+        BasicBlock* entry = BasicBlock::Create(*context, "entry", builtin_func);
+        builder->SetInsertPoint(entry);
+
+        auto arg_it = builtin_func->arg_begin();
+        Value* arg1 = &*arg_it++;
+        Value* arg2 = &*arg_it;
+
+        Value* result;
+        if (pred_name == "eq?") {
+            result = emitEqTagged(arg1, arg2);
+        } else if (pred_name == "eqv?") {
+            result = emitEqvTagged(arg1, arg2);
+        } else {  // equal?
+            result = emitEqualTagged(arg1, arg2);
+        }
+        builder->CreateRet(result);
+
+        if (old_point.isSet()) {
+            builder->restoreIP(old_point);
+        }
+
+        registerContextFunction(func_name, builtin_func);
+        eshkol_debug("Created builtin equality function: %s for predicate '%s'",
+                    func_name.c_str(), pred_name.c_str());
         return builtin_func;
     }
 
@@ -35282,6 +35383,23 @@ namespace ControlFlowCallbacks {
     llvm::Function* getBuiltinArithmeticWrapper(const std::string& op, void* context) {
         auto* codegen = static_cast<EshkolLLVMCodeGen*>(context);
         return codegen->createBuiltinArithmeticFunction(op, 2);
+    }
+
+    llvm::Function* getBuiltinPredicateWrapper(const std::string& name, void* context) {
+        auto* codegen = static_cast<EshkolLLVMCodeGen*>(context);
+        if (name == "<" || name == ">" || name == "<=" || name == ">=" || name == "=") {
+            return codegen->createBuiltinComparisonFunction(name);
+        }
+        if (name == "eq?" || name == "eqv?" || name == "equal?") {
+            return codegen->createBuiltinEqualityFunction(name);
+        }
+        if (name == "even?" || name == "odd?" || name == "zero?" ||
+            name == "positive?" || name == "negative?" || name == "null?" ||
+            name == "pair?" || name == "nan?" || name == "infinite?" ||
+            name == "finite?") {
+            return codegen->createBuiltinPredicateFunction(name);
+        }
+        return nullptr;
     }
 
     llvm::Value* applyForwardRefWrapper(const std::string& func_name, llvm::Value* list_int, void* context) {

--- a/tests/predicates/firstclass_predicate_test.esk
+++ b/tests/predicates/firstclass_predicate_test.esk
@@ -1,0 +1,119 @@
+; ================================================================
+; First-class / apply'd predicate booleans (ESH-0079)
+; ----------------------------------------------------------------
+; A builtin equality/identity predicate (=, eq?, eqv?, equal?) invoked
+; as a FIRST-CLASS value (extracted from a list) or via `apply` used to
+; return the raw integer 0/1 (or () for apply) instead of #f/#t.
+; DIRECT named calls were correct, and the comparison wrapper for `<`
+; happened to be coerced to a boolean downstream while `=` was not.
+; Since only #f is falsy in Scheme, a `0` result is TRUTHY, silently
+; breaking higher-order predicate use (filter/map/apply) and the SICP
+; ch4 metacircular evaluator.
+;
+; Root cause: createBuiltinComparisonFunction packed the (common) double
+; path as INT64 (0/1) while its bignum path returned ESHKOL_VALUE_BOOL;
+; and eq?/eqv?/equal? had no first-class wrapper at all, so the apply
+; path returned () ("Unknown function").
+;
+; This test exercises =, eq?, eqv?, equal?, <, >, <=, >= each:
+;   (a) direct named call
+;   (b) first-class (extracted from a list)
+;   (c) via apply
+; plus a higher-order filter/apply-with-= case. Booleans only.
+; ================================================================
+
+(require stdlib)
+
+(define pass-count 0)
+(define fail-count 0)
+
+(define (test name expected actual)
+  (if (equal? expected actual)
+      (begin (set! pass-count (+ pass-count 1))
+             (display (string-append "PASS: " name "\n")))
+      (begin (set! fail-count (+ fail-count 1))
+             (display (string-append "FAIL: " name "\n"))
+             (display "  Expected: ") (display expected) (newline)
+             (display "  Actual:   ") (display actual) (newline))))
+
+; First-class extractions (from a list)
+(define fc=  (car (list =)))
+(define fc<  (car (list <)))
+(define fc>  (car (list >)))
+(define fc<= (car (list <=)))
+(define fc>= (car (list >=)))
+(define fc-eq?    (car (list eq?)))
+(define fc-eqv?   (car (list eqv?)))
+(define fc-equal? (car (list equal?)))
+
+; ---------------------------------------------------------------
+; = (numeric equality)
+; ---------------------------------------------------------------
+(test "= direct true"   #t (= 2 2))
+(test "= direct false"  #f (= 2 0))
+(test "= fc true"       #t (fc= 2 2))
+(test "= fc false"      #f (fc= 2 0))
+(test "= apply true"    #t (apply = (list 2 2)))
+(test "= apply false"   #f (apply = (list 2 0)))
+; the bug surfaced as a truthy 0 — assert the result is a real boolean
+(test "= fc is boolean (not 0)" #t (eq? (fc= 2 0) #f))
+
+; ---------------------------------------------------------------
+; < > <= >=  (comparison — must not regress)
+; ---------------------------------------------------------------
+(test "< direct"  #t (< 1 2))
+(test "< fc"      #t (fc< 1 2))
+(test "< fc false" #f (fc< 2 1))
+(test "< apply"   #t (apply < (list 1 2)))
+(test "> direct"  #t (> 2 1))
+(test "> fc"      #t (fc> 2 1))
+(test "> apply"   #f (apply > (list 1 2)))
+(test "<= fc"     #t (fc<= 2 2))
+(test "<= apply"  #t (apply <= (list 2 2)))
+(test ">= fc"     #f (fc>= 1 2))
+(test ">= apply"  #t (apply >= (list 2 2)))
+
+; ---------------------------------------------------------------
+; eq? eqv? equal?  (identity / equality predicates)
+; ---------------------------------------------------------------
+(test "eq? direct"   #t (eq? 'a 'a))
+(test "eq? fc true"  #t (fc-eq? 'a 'a))
+(test "eq? fc false" #f (fc-eq? 'a 'b))
+(test "eq? apply"    #t (apply eq? (list 'a 'a)))
+
+(test "eqv? direct"   #t (eqv? 2 2))
+(test "eqv? fc true"  #t (fc-eqv? 2 2))
+(test "eqv? fc false" #f (fc-eqv? 2 3))
+(test "eqv? apply"    #t (apply eqv? (list 2 2)))
+
+(test "equal? direct"   #t (equal? (list 1 2) (list 1 2)))
+(test "equal? fc true"  #t (fc-equal? (list 1 2) (list 1 2)))
+(test "equal? fc false" #f (fc-equal? (list 1 2) (list 1 3)))
+(test "equal? apply"    #t (apply equal? (list (list 1 2) (list 1 2))))
+
+; ---------------------------------------------------------------
+; Higher-order use: filter / apply with =
+; ---------------------------------------------------------------
+(test "filter with first-class ="
+      (list 2 2)
+      (filter (lambda (x) (fc= x 2)) (list 1 2 2 3)))
+(test "filter with apply'd ="
+      (list 2 2)
+      (filter (lambda (x) (apply = (list x 2))) (list 1 2 2 3)))
+
+; SICP ch4 metacircular shape: primitive = applied via apply, tested vs #f
+(define (apply-primitive op args) (apply op args))
+(define (fact n)
+  (if (not (eq? (apply-primitive = (list n 0)) #f))
+      1
+      (* n (fact (- n 1)))))
+(test "SICP metacircular fact 5" 120 (fact 5))
+
+; ================================================================
+(newline)
+(display "==== first-class predicate results ====") (newline)
+(display "Passed: ") (display pass-count) (newline)
+(display "Failed: ") (display fail-count) (newline)
+(if (= fail-count 0)
+    (begin (display "ALL TESTS PASSED") (newline))
+    (begin (display "SOME TESTS FAILED") (newline)))


### PR DESCRIPTION
## Summary

A builtin equality/identity predicate (`=`, `eq?`, `eqv?`, `equal?`) invoked as a **first-class value** (extracted from a list / passed around) or via **`apply`** returned the raw integer `0`/`1` — or `()` for `apply` — instead of the boolean `#f`/`#t`. Direct named calls were correct, and `<` first-class happened to print `#t`. Since only `#f` is falsy in Scheme, a `0` result is **truthy**, silently breaking higher-order predicate use (filter/map/apply with `=`) and the SICP ch4 metacircular evaluator: `(if (not (eq? (= n 0) #f)) ...)` always took the base case, so `fact 5` → `1`.

## Root cause — why `=` differed from `<`

`=`, `<`, `>`, `<=`, `>=` share one first-class wrapper, `createBuiltinComparisonFunction`. Its **bignum** path returned `ESHKOL_VALUE_BOOL`, but its **common double path** packed the result as an `INT64` tagged value (`zext i1 → i64`, INT64 tag) — i.e. `{INT64, 0/1}`. The two wrappers (`builtin_cmp_L` for `<`, `builtin_cmp_E` for `=`) are byte-for-byte identical in packing; `<` only printed `#t` because downstream return-type tracking coerced its result back to a boolean, while `=` was not coerced and printed `0/1`. The wrapper itself was wrong for both.

Separately, `eq?`/`eqv?`/`equal?` are codegen-inline (`codegenEq/Eqv/Equal`) and had **no first-class wrapper at all**, so `(car (list eq?))` had no callable closure and `(apply eq? …)` fell through to `apply: Unknown function` → `()`. And the `apply` path never handled comparison/equality/predicate builtins.

## Fix (architectural root)

1. **`createBuiltinComparisonFunction`**: pack the double path as a boolean (`packBoolToTaggedValue`), matching the bignum path and R7RS — comparison predicates yield `#t`/`#f`, not `0`/`1`.
2. **eq?/eqv?/equal? first-class**: factored the inline bodies into `emitEqTagged` / `emitEqvTagged` / `emitEqualTagged` (semantics unchanged) and added `createBuiltinEqualityFunction`, wired into `codegenVariable` and `resolveLambdaFunction`.
3. **`apply`**: added `GetBuiltinPredicateCallback`, which resolves the first-class wrapper `Function*` for `=, <, >, <=, >=, eq?, eqv?, equal?, even?, …` and applies it via `applyUserFunction`, returning a proper boolean.

No new C runtime symbols (wrappers reuse already-registered `eshkol_deep_equal`/`eshkol_bignum_compare_tagged`), so no `repl_jit.cpp` change needed.

## Before / after (repro, both `-r` and AOT)

| expr | before | after |
|------|--------|-------|
| `(= 2 0)` direct | `#f` | `#f` |
| `(cmp 2 0)` where `cmp=(car (list =))` | `0` (truthy!) | `#f` |
| `(cmp 2 2)` | `1` | `#t` |
| `(apply = (list 2 0))` | `()` | `#f` |
| `(apply eq? (list 'a 'a))` | `()` | `#t` |
| `(lt 1 2)` where `lt=(car (list <))` | `#t` | `#t` (now a real bool from the wrapper) |
| SICP metacircular `fact 5` | `1` | `120` |

## Verification

- `tests/predicates/firstclass_predicate_test.esk` (new): `=`, `eq?`, `eqv?`, `equal?`, `<`, `>`, `<=`, `>=` each tested direct / first-class / via apply, plus filter+apply-with-`=` and the SICP metacircular shape — **33/33 pass on both `-r` and AOT**.
- Regression sanity: direct comparisons, `sort … <`, `map`, `assoc`, `member`, and **bignum** comparisons (`expt 10 30`) unchanged on both paths.
- `scripts/run_icc_smoke.sh`: green except `example_agent_compiles`, which is a pre-existing **environmental** failure — `examples/agent.esk` is untracked and absent from clean worktrees (unrelated to this change).

## SICP harness coordination

`tests/sicp/ch4_metacircular.esk` is added by #85 and does not exist on this branch. This change makes the metacircular `fact 5 = 120` program pass (verified with the same shape), so the **xfail marker on ch4_metacircular in #85 can be removed** once both land.