### PR TITLE
test(vm): print standalone VM failure logs

### DIFF
--- a/scripts/run_vm_tests.sh
+++ b/scripts/run_vm_tests.sh
@@ -11,15 +11,21 @@ if [ ! -x "$VM" ]; then
     exit 2
 fi
 
-OUT_TMP="${TMPDIR:-/tmp}/eshkol_vm_standalone_tests.log"
+OUT_TMP="$(mktemp "${TMPDIR:-/tmp}/eshkol_vm_standalone_tests.XXXXXX.log")"
+cleanup_output() {
+    rm -f -- "$OUT_TMP"
+}
+trap cleanup_output EXIT
 
 echo "========================================="
 echo "  Eshkol Bytecode VM Standalone Tests"
 echo "========================================="
 echo ""
 
+set +e
 ESHKOL_VM_NO_DISASM=1 "$VM" >"$OUT_TMP" 2>&1
 rc=$?
+set -e
 
 if [ "$rc" -eq 0 ]; then
     if grep -q "Source tests: " "$OUT_TMP"; then


### PR DESCRIPTION
## Summary
- makes `scripts/run_vm_tests.sh` print the captured standalone VM log when `eshkol-vm-standalone-test` exits nonzero
- switches the wrapper log from a fixed `/tmp/eshkol_vm_standalone_tests.log` path to a per-run `mktemp` path

## Context
- `macos-x64-lite` on current master `cb90af809a195b61d1260ba966752b5d0d5dab53` fails in the VM suite, but the wrapper exits under `set -e` before printing the VM log
- the same hidden VM-suite failure also appears on PR #88 because #88 is based on that master commit

## Verification
- `bash -n scripts/run_vm_tests.sh`
- `BUILD_DIR=build scripts/run_vm_tests.sh` on clean `cb90af80` worktree: `Source tests: 53/53 passed`
- simulated failing VM wrapper exits nonzero and prints captured log:
  - `VM_FAIL_LINE`
  - `Source tests: 52/53 passed`
  - `Passed: 0`
  - `Failed: 1`
