### PR TITLE
fix(ad): runtime scalar nested gradients

### DIFF
--- a/lib/backend/autodiff_codegen.cpp
+++ b/lib/backend/autodiff_codegen.cpp
@@ -2926,6 +2926,42 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
                     point_val = pt_phi;
                 }
 
+                AllocaInst* rt_result_slot = ctx_.builder().CreateAlloca(
+                    ctx_.taggedValueType(), nullptr, "grad_rt_result");
+
+                Value* rt_point_base = tagged_.getBaseType(tagged_.getType(point_val));
+                Value* rt_point_is_double = ctx_.builder().CreateICmpEQ(rt_point_base,
+                    ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_DOUBLE));
+                Value* rt_point_is_int = ctx_.builder().CreateICmpEQ(rt_point_base,
+                    ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_INT64));
+                Value* rt_point_is_dual = ctx_.builder().CreateICmpEQ(rt_point_base,
+                    ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_DUAL_NUMBER));
+                Value* rt_point_is_scalar = ctx_.builder().CreateOr(
+                    ctx_.builder().CreateOr(rt_point_is_double, rt_point_is_int), rt_point_is_dual);
+
+                BasicBlock* grad_rt_scalar_fwd = BasicBlock::Create(
+                    ctx_.context(), "grad_rt_scalar_fwd", current_func);
+                BasicBlock* grad_rt_collection = BasicBlock::Create(
+                    ctx_.context(), "grad_rt_collection", current_func);
+                BasicBlock* grad_rt_done = BasicBlock::Create(
+                    ctx_.context(), "grad_rt_done", current_func);
+                ctx_.builder().CreateCondBr(rt_point_is_scalar, grad_rt_scalar_fwd, grad_rt_collection);
+
+                ctx_.builder().SetInsertPoint(grad_rt_scalar_fwd);
+                Value* rt_fwd_level = nullptr;
+                Value* rt_fwd_seed = seedForwardAndPush(point_val, &rt_fwd_level);
+                Value* rt_fwd_call = closure_call_callback_(closure_val,
+                    std::vector<Value*>{rt_fwd_seed}, "autodiff", callback_context_);
+                if (!rt_fwd_call) {
+                    eshkol_error("gradient: failed to call runtime scalar function");
+                    return nullptr;
+                }
+                Value* rt_fwd_result = popAndExtractForward(rt_fwd_call, rt_fwd_level);
+                ctx_.builder().CreateStore(rt_fwd_result, rt_result_slot);
+                ctx_.builder().CreateBr(grad_rt_done);
+
+                ctx_.builder().SetInsertPoint(grad_rt_collection);
+
                 // Check input type - handle Scheme vector (HEAP_PTR with HEAP_SUBTYPE_VECTOR), tensor (TENSOR_PTR), or scalar
                 // M1 Migration: Use consolidated HEAP_PTR type with subtype dispatch
                 Value* input_type = tagged_.getType(point_val);
@@ -3232,7 +3268,12 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
 
                 ctx_.builder().SetInsertPoint(dim_end);
                 Value* result_int = ctx_.builder().CreatePtrToInt(typed_result, ctx_.int64Type());
-                return tagged_.packPtr(result_int, ESHKOL_VALUE_HEAP_PTR);
+                Value* result_tagged = tagged_.packPtr(result_int, ESHKOL_VALUE_HEAP_PTR);
+                ctx_.builder().CreateStore(result_tagged, rt_result_slot);
+                ctx_.builder().CreateBr(grad_rt_done);
+
+                ctx_.builder().SetInsertPoint(grad_rt_done);
+                return ctx_.builder().CreateLoad(ctx_.taggedValueType(), rt_result_slot);
             } // end if (closure_val)
 
         }

--- a/tests/v1_2_edge_cases/dual_scalar_compare_test.esk
+++ b/tests/v1_2_edge_cases/dual_scalar_compare_test.esk
@@ -238,6 +238,22 @@
          ;; comparison no longer signals a type error.
          (and (number? g) (not (eqv? g +inf.0)) (not (eqv? g -inf.0)))))
 
+;; ─── Case 6 ────────────────────────────────────────────────────────
+;; A gradient target that is a function parameter takes the runtime
+;; closure path.  That scalar path must preserve an outer perturbation
+;; level when nested, not rebuild a fixed e1-only dual.
+(define (shifted-cubic x) (+ (* x x x) x))
+(define (gradient-through-function-parameter f x) (gradient f x))
+
+(check "gradient through runtime function parameter at scalar point"
+       (< (abs (- (gradient-through-function-parameter shifted-cubic 2.0) 13.0)) 1e-10))
+(check "nested derivative of runtime function-parameter gradient"
+       (< (abs (- (derivative
+                    (lambda (x) (gradient-through-function-parameter shifted-cubic x))
+                    2.0)
+                  12.0))
+          1e-10))
+
 ;; ─── Summary ───────────────────────────────────────────────────────
 (display "Results: ") (display passed) (display " passed, ")
 (display failed) (display " failed") (newline)


### PR DESCRIPTION
## Summary
- fixes runtime scalar nested gradients for the named/inner-gradient path
- updates the dual scalar comparison regression coverage

## Verification
- ICC readiness before and after: `ready`, score `100`
- `cmake --build build --target eshkol-run`
- `build/eshkol-run -r tests/v1_2_edge_cases/dual_scalar_compare_test.esk -Lbuild` => 47 passed, 0 failed

Implemented and pushed by the ESH-0078 swarm worker in commit `31c83dc826b00563534be6856801454860d779b7`.
