### PR TITLE
fix(runtime): signal capability-denied operations

### DIFF
--- a/inc/eshkol/runtime_exports.h
+++ b/inc/eshkol/runtime_exports.h
@@ -66,6 +66,7 @@ void eshkol_capability_runtime_allow(const char* capability);
 int eshkol_capability_runtime_is_active();
 int eshkol_capability_runtime_allows(const char* capability);
 int eshkol_capability_runtime_allows_file_mode(const char* mode);
+void eshkol_capability_runtime_deny(const char* capability);
 
 }
 

--- a/lib/backend/system_codegen.cpp
+++ b/lib/backend/system_codegen.cpp
@@ -41,6 +41,15 @@ static llvm::Value* runtimeCapabilityAllowed(CodegenContext& ctx, const char* ca
         allowed, llvm::ConstantInt::get(ctx.int32Type(), 0));
 }
 
+static void runtimeCapabilityDeny(CodegenContext& ctx, const char* capability) {
+    llvm::FunctionType* fn_type = llvm::FunctionType::get(
+        ctx.voidType(), {ctx.ptrType()}, false);
+    llvm::FunctionCallee callee = ctx.module().getOrInsertFunction(
+        "eshkol_capability_runtime_deny", fn_type);
+    llvm::Value* capability_name = ctx.builder().CreateGlobalStringPtr(capability);
+    ctx.builder().CreateCall(callee, {capability_name});
+}
+
 SystemCodegen::SystemCodegen(CodegenContext& ctx, TaggedValueCodegen& tagged, MemoryCodegen& mem,
                              std::unordered_map<std::string, llvm::Function*>& function_table)
     : ctx_(ctx)
@@ -92,6 +101,7 @@ llvm::Value* SystemCodegen::getenv(const eshkol_operations_t* op) {
     ctx_.builder().CreateCondBr(capability_ok, call_block, denied_block);
 
     ctx_.builder().SetInsertPoint(denied_block);
+    runtimeCapabilityDeny(ctx_, "env-read");
     llvm::Value* denied_val = tagged_.packBool(
         llvm::ConstantInt::getFalse(ctx_.context()));
     ctx_.builder().CreateBr(final_merge_block);
@@ -209,6 +219,7 @@ llvm::Value* SystemCodegen::setenv(const eshkol_operations_t* op) {
     ctx_.builder().CreateCondBr(capability_ok, call_block, denied_block);
 
     ctx_.builder().SetInsertPoint(denied_block);
+    runtimeCapabilityDeny(ctx_, "env-write");
     llvm::Value* denied_val = tagged_.packBool(
         llvm::ConstantInt::getFalse(ctx_.context()));
     ctx_.builder().CreateBr(merge_block);
@@ -267,6 +278,7 @@ llvm::Value* SystemCodegen::unsetenv(const eshkol_operations_t* op) {
     ctx_.builder().CreateCondBr(capability_ok, call_block, denied_block);
 
     ctx_.builder().SetInsertPoint(denied_block);
+    runtimeCapabilityDeny(ctx_, "env-write");
     llvm::Value* denied_val = tagged_.packBool(
         llvm::ConstantInt::getFalse(ctx_.context()));
     ctx_.builder().CreateBr(merge_block);

--- a/lib/core/image_io.c
+++ b/lib/core/image_io.c
@@ -855,8 +855,11 @@ int write_image_native(const char*, const double*, int, int, int, const char*) {
 } // namespace
 
 double* eshkol_image_read(const char* path, int* out_w, int* out_h, int* out_c) {
-    if (!path || !out_w || !out_h || !out_c ||
-        eshkol_capability_runtime_allows("file-read") == 0) {
+    if (!path || !out_w || !out_h || !out_c) {
+        return nullptr;
+    }
+    if (eshkol_capability_runtime_allows("file-read") == 0) {
+        eshkol_capability_runtime_deny("file-read");
         return nullptr;
     }
     return read_image_native(path, out_w, out_h, out_c);
@@ -864,8 +867,11 @@ double* eshkol_image_read(const char* path, int* out_w, int* out_h, int* out_c) 
 
 int eshkol_image_write(const char* path, const double* data,
                        int w, int h, int channels, const char* format) {
-    if (!path || !data || !valid_dimensions(w, h, channels) ||
-        eshkol_capability_runtime_allows("file-write") == 0) {
+    if (!path || !data || !valid_dimensions(w, h, channels)) {
+        return -1;
+    }
+    if (eshkol_capability_runtime_allows("file-write") == 0) {
+        eshkol_capability_runtime_deny("file-write");
         return -1;
     }
     return write_image_native(path, data, w, h, channels, format);

--- a/lib/core/runtime_exports_hosted.cpp
+++ b/lib/core/runtime_exports_hosted.cpp
@@ -47,6 +47,7 @@ std::uint64_t g_drand48_state = 0x1234ABCD330EULL;
 std::mutex g_capability_mutex;
 bool g_capability_policy_active = false;
 std::unordered_set<std::string> g_capability_allow_list;
+std::unordered_set<std::string> g_capability_denials_reported;
 
 #ifdef _WIN32
 struct windows_dirent_shim {
@@ -119,9 +120,9 @@ bool runtime_capability_allows(const char* capability) {
     return g_capability_allow_list.find(capability) != g_capability_allow_list.end();
 }
 
-bool runtime_file_mode_allows(const char* mode) {
+const char* runtime_file_mode_missing_capability(const char* mode) {
     if (mode == nullptr || mode[0] == '\0') {
-        return false;
+        return "file-read";
     }
 
     bool needs_read = mode[0] == 'r';
@@ -134,20 +135,36 @@ bool runtime_file_mode_allows(const char* mode) {
     }
 
     if (needs_read && !runtime_capability_allows("file-read")) {
-        return false;
+        return "file-read";
     }
     if (needs_write && !runtime_capability_allows("file-write")) {
-        return false;
+        return "file-write";
     }
-    return true;
+    return nullptr;
 }
 
-void deny_file_capability() {
-    errno = EACCES;
+bool runtime_file_mode_allows(const char* mode) {
+    return runtime_file_mode_missing_capability(mode) == nullptr;
 }
 
-void deny_capability() {
+void report_capability_denied(const char* capability) {
     errno = EACCES;
+    const char* name = (capability != nullptr && capability[0] != '\0')
+        ? capability
+        : "unknown";
+
+    bool should_report = false;
+    {
+        std::lock_guard<std::mutex> lock(g_capability_mutex);
+        should_report = g_capability_denials_reported.insert(name).second;
+    }
+    if (should_report) {
+        std::fprintf(stderr, "capability denied: %s\n", name);
+    }
+}
+
+void deny_capability(const char* capability) {
+    report_capability_denied(capability);
 }
 
 } // namespace
@@ -274,7 +291,7 @@ extern "C" char* eshkol_getenv(const char* name) {
         return nullptr;
     }
     if (!runtime_capability_allows("env-read")) {
-        deny_capability();
+        deny_capability("env-read");
         return nullptr;
     }
 
@@ -287,7 +304,7 @@ extern "C" int eshkol_setenv(const char* name, const char* value, int overwrite)
         return -1;
     }
     if (!runtime_capability_allows("env-write")) {
-        deny_capability();
+        deny_capability("env-write");
         return -1;
     }
 
@@ -307,7 +324,7 @@ extern "C" int eshkol_unsetenv(const char* name) {
         return -1;
     }
     if (!runtime_capability_allows("env-write")) {
-        deny_capability();
+        deny_capability("env-write");
         return -1;
     }
 
@@ -359,13 +376,17 @@ extern "C" int eshkol_capability_runtime_allows_file_mode(const char* mode) {
     return runtime_file_mode_allows(mode) ? 1 : 0;
 }
 
+extern "C" void eshkol_capability_runtime_deny(const char* capability) {
+    deny_capability(capability);
+}
+
 extern "C" FILE* eshkol_fopen(const char* path, const char* mode) {
     if (path == nullptr || mode == nullptr) {
         errno = EINVAL;
         return nullptr;
     }
-    if (!runtime_file_mode_allows(mode)) {
-        deny_file_capability();
+    if (const char* missing = runtime_file_mode_missing_capability(mode)) {
+        deny_capability(missing);
         return nullptr;
     }
 
@@ -389,9 +410,12 @@ extern "C" int eshkol_access(const char* path, int mode) {
     }
     const bool needs_write = (mode & 2) != 0;
     const bool needs_read = !needs_write || ((mode & 4) != 0);
-    if ((needs_read && !runtime_capability_allows("file-read")) ||
-        (needs_write && !runtime_capability_allows("file-write"))) {
-        deny_file_capability();
+    if (needs_read && !runtime_capability_allows("file-read")) {
+        deny_capability("file-read");
+        return -1;
+    }
+    if (needs_write && !runtime_capability_allows("file-write")) {
+        deny_capability("file-write");
         return -1;
     }
 
@@ -409,7 +433,7 @@ extern "C" int eshkol_remove(const char* path) {
         return -1;
     }
     if (!runtime_capability_allows("file-write")) {
-        deny_file_capability();
+        deny_capability("file-write");
         return -1;
     }
 
@@ -423,7 +447,7 @@ extern "C" int eshkol_rename(const char* old_path, const char* new_path) {
         return -1;
     }
     if (!runtime_capability_allows("file-write")) {
-        deny_file_capability();
+        deny_capability("file-write");
         return -1;
     }
 
@@ -438,7 +462,7 @@ extern "C" int eshkol_mkdir(const char* path, int mode) {
         return -1;
     }
     if (!runtime_capability_allows("file-write")) {
-        deny_file_capability();
+        deny_capability("file-write");
         return -1;
     }
 
@@ -457,7 +481,7 @@ extern "C" int eshkol_rmdir(const char* path) {
         return -1;
     }
     if (!runtime_capability_allows("file-write")) {
-        deny_file_capability();
+        deny_capability("file-write");
         return -1;
     }
 
@@ -475,7 +499,7 @@ extern "C" int eshkol_chdir(const char* path) {
         return -1;
     }
     if (!runtime_capability_allows("file-read")) {
-        deny_file_capability();
+        deny_capability("file-read");
         return -1;
     }
 
@@ -493,7 +517,7 @@ extern "C" int eshkol_stat(const char* path, void* buf) {
         return -1;
     }
     if (!runtime_capability_allows("file-read")) {
-        deny_file_capability();
+        deny_capability("file-read");
         return -1;
     }
 
@@ -507,7 +531,7 @@ extern "C" void* eshkol_opendir(const char* path) {
         return nullptr;
     }
     if (!runtime_capability_allows("file-read")) {
-        deny_file_capability();
+        deny_capability("file-read");
         return nullptr;
     }
 

--- a/lib/core/system_builtins.c
+++ b/lib/core/system_builtins.c
@@ -98,6 +98,7 @@ extern void* arena_allocate(void* arena, size_t size);
 extern char* arena_allocate_string_with_header(void* arena, size_t length);
 extern void* arena_allocate_cons_with_header(void* arena);
 extern int eshkol_capability_runtime_allows(const char* capability);
+extern void eshkol_capability_runtime_deny(const char* capability);
 
 /* Tagged value layout MUST match LLVM IR: {i8, i8, i16, i32, i64} = 16 bytes.
  * The i32 is explicit padding — this matches the LLVM struct exactly so that
@@ -197,7 +198,7 @@ static const char* sys_extract_string(eshkol_sysbuiltin_value_t v) {
 
 static int sys_require_capability(const char* capability) {
     if (eshkol_capability_runtime_allows(capability)) return 1;
-    errno = EACCES;
+    eshkol_capability_runtime_deny(capability);
     return 0;
 }
 

--- a/tests/toolchain/static_link_getenv_capability_test.sh
+++ b/tests/toolchain/static_link_getenv_capability_test.sh
@@ -100,6 +100,22 @@ cat > "$WORK_TMP/getenv_denied.esk" <<'ESK'
       (exit 0)))
 ESK
 
+cat > "$WORK_TMP/getenv_missing_allowed.esk" <<'ESK'
+(require stdlib)
+(require core.capabilities)
+
+(capability-install-policy! (list 'env-read))
+(define got (getenv "ESHKOL_STATIC_LINK_GETENV_MISSING_PROBE"))
+
+(if got
+    (begin
+      (display "FAIL: static link missing getenv returned value") (newline)
+      (exit 1))
+    (begin
+      (display "PASS: static link missing getenv returns false") (newline)
+      (exit 0)))
+ESK
+
 path_separator() {
     case "$(uname -s)" in
         MINGW*|MSYS*|CYGWIN*) printf ';' ;;
@@ -226,18 +242,35 @@ run_probe() {
 
 ALLOWED_OBJ="$WORK_TMP/getenv_allowed.o"
 DENIED_OBJ="$WORK_TMP/getenv_denied.o"
+MISSING_OBJ="$WORK_TMP/getenv_missing_allowed.o"
 ALLOWED_EXE="$WORK_TMP/getenv_allowed${EXE_SUFFIX}"
 DENIED_EXE="$WORK_TMP/getenv_denied${EXE_SUFFIX}"
+MISSING_EXE="$WORK_TMP/getenv_missing_allowed${EXE_SUFFIX}"
 
 compile_probe "$WORK_TMP/getenv_allowed.esk" "$ALLOWED_OBJ" "$WORK_TMP/compile_allowed.log"
 compile_probe "$WORK_TMP/getenv_denied.esk" "$DENIED_OBJ" "$WORK_TMP/compile_denied.log"
+compile_probe "$WORK_TMP/getenv_missing_allowed.esk" "$MISSING_OBJ" "$WORK_TMP/compile_missing.log"
 
 link_probe "$ALLOWED_OBJ" "$ALLOWED_EXE" "$WORK_TMP/link_allowed.log"
 link_probe "$DENIED_OBJ" "$DENIED_EXE" "$WORK_TMP/link_denied.log"
+link_probe "$MISSING_OBJ" "$MISSING_EXE" "$WORK_TMP/link_missing.log"
 
 run_probe "$ALLOWED_EXE" "PASS: static link getenv reads set var" "$WORK_TMP/run_allowed.log"
 run_probe "$DENIED_EXE" "PASS: static link capability policy denies getenv" "$WORK_TMP/run_denied.log"
+run_probe "$MISSING_EXE" "PASS: static link missing getenv returns false" "$WORK_TMP/run_missing.log"
+
+if ! grep -q "capability denied: env-read" "$WORK_TMP/run_denied.log"; then
+    echo "--- denied run log ---" >&2
+    sed -n '1,160p' "$WORK_TMP/run_denied.log" >&2
+    fail "denied getenv did not emit env-read diagnostic"
+fi
+if grep -q "capability denied:" "$WORK_TMP/run_missing.log"; then
+    echo "--- missing run log ---" >&2
+    sed -n '1,160p' "$WORK_TMP/run_missing.log" >&2
+    fail "allowed missing getenv emitted a denial diagnostic"
+fi
 
 cat "$WORK_TMP/run_allowed.log"
 cat "$WORK_TMP/run_denied.log"
+cat "$WORK_TMP/run_missing.log"
 echo "PASS: static_link_getenv_capability_test"

--- a/tests/v1_2_edge_cases/capability_denied_signal_test.sh
+++ b/tests/v1_2_edge_cases/capability_denied_signal_test.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# ESH-0076: capability-denied runtime operations must be distinguishable from
+# ordinary absent values while preserving the existing false/null return shape.
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+RUN="$ROOT/${BUILD_DIR:-build}/eshkol-run"
+
+if [ ! -x "$RUN" ]; then
+    echo "SKIP: $RUN not built"
+    exit 0
+fi
+
+WORK=$(mktemp -d -t eshkol_capability_denied_signal.XXXXXX)
+trap 'rm -rf "$WORK"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+cat > "$WORK/env_read_absent.esk" <<'EOF'
+(require stdlib)
+(require core.capabilities)
+
+(capability-install-policy! (list 'env-read))
+(if (getenv "ESHKOL_CAPABILITY_DENIED_SIGNAL_ABSENT")
+    (begin
+      (display "FAIL: absent getenv returned value") (newline)
+      (exit 1))
+    (begin
+      (display "PASS: allowed absent getenv returns false") (newline)
+      (exit 0)))
+EOF
+
+cat > "$WORK/env_and_file_denied.esk" <<'EOF'
+(require stdlib)
+(require core.capabilities)
+
+(capability-install-policy! '())
+(define env-denied (not (getenv "ESHKOL_CAPABILITY_DENIED_SIGNAL_ABSENT")))
+(define file-denied (not (file-exists? "/tmp/eshkol_capability_denied_signal_missing")))
+
+(if (and env-denied file-denied)
+    (begin
+      (display "PASS: denied operations preserve false return values") (newline)
+      (exit 0))
+    (begin
+      (display "FAIL: denied operation returned allowed value") (newline)
+      (exit 1)))
+EOF
+
+ALLOWED_LOG="$WORK/env_read_absent.log"
+DENIED_LOG="$WORK/env_and_file_denied.log"
+
+if ! env LC_ALL=C LANG=C ESHKOL_PATH=. "$RUN" -r "$WORK/env_read_absent.esk" >"$ALLOWED_LOG" 2>&1; then
+    sed -n '1,160p' "$ALLOWED_LOG" >&2
+    fail "allowed absent getenv probe failed"
+fi
+grep -q "PASS: allowed absent getenv returns false" "$ALLOWED_LOG" ||
+    fail "allowed absent getenv probe did not pass"
+if grep -q "capability denied:" "$ALLOWED_LOG"; then
+    sed -n '1,160p' "$ALLOWED_LOG" >&2
+    fail "allowed absent getenv emitted a denial diagnostic"
+fi
+
+if ! env LC_ALL=C LANG=C ESHKOL_PATH=. "$RUN" -r "$WORK/env_and_file_denied.esk" >"$DENIED_LOG" 2>&1; then
+    sed -n '1,160p' "$DENIED_LOG" >&2
+    fail "denied capability probe failed"
+fi
+grep -q "PASS: denied operations preserve false return values" "$DENIED_LOG" ||
+    fail "denied capability probe did not pass"
+grep -q "capability denied: env-read" "$DENIED_LOG" ||
+    fail "denied getenv did not emit env-read diagnostic"
+grep -q "capability denied: file-read" "$DENIED_LOG" ||
+    fail "denied file metadata did not emit file-read diagnostic"
+
+cat "$ALLOWED_LOG"
+cat "$DENIED_LOG"
+echo "PASS: capability_denied_signal_test"


### PR DESCRIPTION
## Summary
- emits one-time runtime diagnostics like `capability denied: env-read` for denied capability checks
- preserves existing return values (`#f`, null, or `-1`) so callers keep current control flow
- wires the signal through generated env operations, hosted runtime wrappers, C system builtins, and image I/O
- adds a focused edge-case shell regression plus static-link coverage distinguishing denied getenv from allowed-but-missing getenv

## Verification
- ICC readiness: `ready`, score `100`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target eshkol-run -j 8`
- `bash -n tests/v1_2_edge_cases/capability_denied_signal_test.sh tests/toolchain/static_link_getenv_capability_test.sh`
- `env LC_ALL=C LANG=C BUILD_DIR=build perl -e 'alarm 180; exec @ARGV' bash tests/v1_2_edge_cases/capability_denied_signal_test.sh`
- `env LC_ALL=C LANG=C ESHKOL_JIT_CACHE_DIR=/private/tmp/eshkol-esh0076-jit perl -e 'alarm 240; exec @ARGV' ./build/eshkol-run -r tests/v1_2_edge_cases/capability_policy_test.esk`
- `cmake --build build --target stdlib -j 8`
- `env LC_ALL=C LANG=C perl -e 'alarm 300; exec @ARGV' bash tests/toolchain/static_link_getenv_capability_test.sh build/eshkol-run . build`
- `env LC_ALL=C LANG=C BUILD_DIR=build perl -e 'alarm 360; exec @ARGV' bash scripts/run_v1_2_edge_cases_tests.sh` => 93/93 PASS
- `git diff --check`
