### PR TITLE
fix(ad): guard tensor structural integer metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2165,6 +2165,17 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
             PASS_REGULAR_EXPRESSION "PASS: scaled-dot-attention K/V gradients match closed forms"
             FAIL_REGULAR_EXPRESSION "FAIL:")
     add_test(
+        NAME ad_structural_int_guard_runtime_smoke
+        COMMAND $<TARGET_FILE:eshkol-run>
+                -r "${CMAKE_CURRENT_SOURCE_DIR}/tests/integration/ad_structural_int_guard_test.esk"
+                -L"${CMAKE_CURRENT_BINARY_DIR}"
+    )
+    set_tests_properties(ad_structural_int_guard_runtime_smoke
+        PROPERTIES
+            TIMEOUT 300
+            PASS_REGULAR_EXPRESSION "PASS: AD dual tensor reduction axis raises catchable type error"
+            FAIL_REGULAR_EXPRESSION "FAIL:|Attempted to get int64 from non-int-storage cell|LLVM module verification failed|fatal signal")
+    add_test(
         NAME empty_collection_runtime_smoke
         COMMAND $<TARGET_FILE:eshkol-run>
                 -r "${CMAKE_CURRENT_SOURCE_DIR}/tests/collections/empty_collection_test.esk"

--- a/lib/backend/tensor_reduce_codegen.cpp
+++ b/lib/backend/tensor_reduce_codegen.cpp
@@ -44,6 +44,114 @@
 
 namespace eshkol {
 
+namespace {
+
+void emitStructuralIntErrorLocation(CodegenContext& ctx) {
+    uint32_t line = ctx.currentSourceLine();
+    if (line == 0) {
+        return;
+    }
+
+    llvm::Function* set_loc_fn = ctx.module().getFunction("eshkol_set_error_location");
+    if (!set_loc_fn) {
+        llvm::FunctionType* ft = llvm::FunctionType::get(
+            ctx.builder().getVoidTy(),
+            {ctx.builder().getPtrTy(), ctx.int32Type(), ctx.int32Type()},
+            false);
+        set_loc_fn = llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
+            "eshkol_set_error_location", &ctx.module());
+    }
+
+    const std::string& file = ctx.currentSourceFile();
+    llvm::Value* file_val = file.empty()
+        ? static_cast<llvm::Value*>(llvm::ConstantPointerNull::get(ctx.builder().getPtrTy()))
+        : static_cast<llvm::Value*>(ctx.builder().CreateGlobalString(file, "axis_int_file"));
+    ctx.builder().CreateCall(set_loc_fn, {
+        file_val,
+        llvm::ConstantInt::get(ctx.int32Type(), line),
+        llvm::ConstantInt::get(ctx.int32Type(), ctx.currentSourceColumn())});
+}
+
+llvm::Value* extractStructuralIntOrRaise(CodegenContext& ctx,
+                                         TaggedValueCodegen& tagged,
+                                         llvm::Value* value,
+                                         const char* proc_name,
+                                         const char* expected_type) {
+    if (!value) {
+        return llvm::ConstantInt::get(ctx.int64Type(), 0);
+    }
+
+    llvm::Type* value_type = value->getType();
+    if (value_type->isIntegerTy(64)) {
+        return value;
+    }
+    if (value_type->isIntegerTy()) {
+        return ctx.builder().CreateSExtOrTrunc(value, ctx.int64Type());
+    }
+
+    if (value_type != ctx.taggedValueType()) {
+        llvm::Function* func = ctx.builder().GetInsertBlock()->getParent();
+        llvm::BasicBlock* err_block = llvm::BasicBlock::Create(
+            ctx.context(), "axis_type_error", func);
+        ctx.builder().CreateBr(err_block);
+        ctx.builder().SetInsertPoint(err_block);
+        emitStructuralIntErrorLocation(ctx);
+
+        llvm::Function* type_error_fn = ctx.module().getFunction("eshkol_type_error");
+        if (!type_error_fn) {
+            llvm::FunctionType* ft = llvm::FunctionType::get(
+                ctx.builder().getVoidTy(),
+                {ctx.builder().getPtrTy(), ctx.builder().getPtrTy()},
+                false);
+            type_error_fn = llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
+                "eshkol_type_error", &ctx.module());
+            type_error_fn->setDoesNotReturn();
+        }
+
+        llvm::Value* proc = ctx.builder().CreateGlobalString(proc_name, "axis_int_proc");
+        llvm::Value* expected = ctx.builder().CreateGlobalString(expected_type, "axis_int_expected");
+        ctx.builder().CreateCall(type_error_fn, {proc, expected});
+        ctx.builder().CreateUnreachable();
+        return llvm::ConstantInt::get(ctx.int64Type(), 0);
+    }
+
+    llvm::Value* type_tag = tagged.getType(value);
+    llvm::Value* base_type = tagged.getBaseType(type_tag);
+    llvm::Value* is_int = ctx.builder().CreateICmpEQ(base_type,
+        llvm::ConstantInt::get(ctx.int8Type(), ESHKOL_VALUE_INT64));
+
+    llvm::Function* func = ctx.builder().GetInsertBlock()->getParent();
+    llvm::BasicBlock* ok_block = llvm::BasicBlock::Create(
+        ctx.context(), "axis_int_ok", func);
+    llvm::BasicBlock* err_block = llvm::BasicBlock::Create(
+        ctx.context(), "axis_type_error", func);
+    ctx.builder().CreateCondBr(is_int, ok_block, err_block);
+
+    ctx.builder().SetInsertPoint(err_block);
+    emitStructuralIntErrorLocation(ctx);
+    llvm::Function* type_error_fn = ctx.module().getFunction("eshkol_type_error_with_operand");
+    if (!type_error_fn) {
+        llvm::FunctionType* ft = llvm::FunctionType::get(
+            ctx.builder().getVoidTy(),
+            {ctx.builder().getPtrTy(), ctx.builder().getPtrTy(), ctx.builder().getPtrTy()},
+            false);
+        type_error_fn = llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
+            "eshkol_type_error_with_operand", &ctx.module());
+        type_error_fn->setDoesNotReturn();
+    }
+    llvm::Value* slot = ctx.builder().CreateAlloca(ctx.taggedValueType(), nullptr, "axis_err_slot");
+    ctx.builder().CreateStore(value, slot);
+    llvm::Value* proc = ctx.builder().CreateGlobalString(proc_name, "axis_int_proc");
+    llvm::Value* expected = ctx.builder().CreateGlobalString(expected_type, "axis_int_expected");
+    ctx.builder().CreateCall(type_error_fn, {proc, expected, slot});
+    ctx.builder().CreateUnreachable();
+
+    ctx.builder().SetInsertPoint(ok_block);
+    return tagged.unpackInt64(value);
+}
+
+} // namespace
+
 llvm::Value* TensorCodegen::adNodeFromTensorElementBits(llvm::Value* elem_bits, const std::string& name) {
     if (!autodiff_ || !elem_bits) {
         return nullptr;
@@ -1464,7 +1572,8 @@ llvm::Value* TensorCodegen::tensorReduceWithDim(const eshkol_operations_t* op) {
     llvm::Value* src_num_dims = ctx_.builder().CreateLoad(ctx_.int64Type(), src_num_dims_field_ptr);
 
     // Handle negative axis: if axis < 0, axis += rank
-    llvm::Value* axis_val = tagged_.safeExtractInt64(dimension_value);
+    llvm::Value* axis_val = extractStructuralIntOrRaise(
+        ctx_, tagged_, dimension_value, "tensor-reduce", "integer axis");
     llvm::Value* is_negative = ctx_.builder().CreateICmpSLT(axis_val, llvm::ConstantInt::get(ctx_.int64Type(), 0));
     llvm::Value* adjusted_axis = ctx_.builder().CreateAdd(axis_val, src_num_dims);
     axis_val = ctx_.builder().CreateSelect(is_negative, adjusted_axis, axis_val);
@@ -1508,7 +1617,8 @@ llvm::Value* TensorCodegen::emitAxisReduce(llvm::Value* tensor_val, llvm::Value*
         builder.CreateStructGEP(tensor_type, tensor_ptr, 1));
 
     // Handle negative axis: if axis < 0, axis += rank
-    llvm::Value* axis = tagged_.safeExtractInt64(axis_val);
+    llvm::Value* axis = extractStructuralIntOrRaise(
+        ctx_, tagged_, axis_val, "tensor-reduce-axis", "integer axis");
     llvm::Value* is_negative = builder.CreateICmpSLT(axis, llvm::ConstantInt::get(ctx_.int64Type(), 0));
     llvm::Value* adjusted = builder.CreateAdd(axis, src_num_dims);
     axis = builder.CreateSelect(is_negative, adjusted, axis);

--- a/lib/backend/tensor_shape_codegen.cpp
+++ b/lib/backend/tensor_shape_codegen.cpp
@@ -1477,6 +1477,108 @@ llvm::Value* TensorCodegen::reshape(const eshkol_operations_t* op) {
     llvm::Value* final_ndim = nullptr;
     llvm::Value* final_total = nullptr;
 
+    auto extract_structural_int = [&](llvm::Value* value,
+                                      const char* proc_name,
+                                      const char* expected_type) -> llvm::Value* {
+        auto set_error_location = [&]() {
+            uint32_t line = ctx_.currentSourceLine();
+            if (line == 0) {
+                return;
+            }
+
+            llvm::Function* set_loc_fn = ctx_.module().getFunction("eshkol_set_error_location");
+            if (!set_loc_fn) {
+                llvm::FunctionType* ft = llvm::FunctionType::get(
+                    ctx_.builder().getVoidTy(),
+                    {ctx_.builder().getPtrTy(), ctx_.int32Type(), ctx_.int32Type()},
+                    false);
+                set_loc_fn = llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
+                    "eshkol_set_error_location", &ctx_.module());
+            }
+
+            const std::string& file = ctx_.currentSourceFile();
+            llvm::Value* file_val = file.empty()
+                ? static_cast<llvm::Value*>(llvm::ConstantPointerNull::get(ctx_.builder().getPtrTy()))
+                : static_cast<llvm::Value*>(ctx_.builder().CreateGlobalString(file, "struct_int_file"));
+            ctx_.builder().CreateCall(set_loc_fn, {
+                file_val,
+                llvm::ConstantInt::get(ctx_.int32Type(), line),
+                llvm::ConstantInt::get(ctx_.int32Type(), ctx_.currentSourceColumn())});
+        };
+
+        if (!value) {
+            return llvm::ConstantInt::get(ctx_.int64Type(), 0);
+        }
+
+        llvm::Type* value_type = value->getType();
+        if (value_type->isIntegerTy(64)) {
+            return value;
+        }
+        if (value_type->isIntegerTy()) {
+            return ctx_.builder().CreateSExtOrTrunc(value, ctx_.int64Type());
+        }
+
+        if (value_type != ctx_.taggedValueType()) {
+            llvm::Function* func = ctx_.builder().GetInsertBlock()->getParent();
+            llvm::BasicBlock* err_block = llvm::BasicBlock::Create(
+                ctx_.context(), "reshape_dim_type_error", func);
+            ctx_.builder().CreateBr(err_block);
+            ctx_.builder().SetInsertPoint(err_block);
+            set_error_location();
+
+            llvm::Function* type_error_fn = ctx_.module().getFunction("eshkol_type_error");
+            if (!type_error_fn) {
+                llvm::FunctionType* ft = llvm::FunctionType::get(
+                    ctx_.builder().getVoidTy(),
+                    {ctx_.builder().getPtrTy(), ctx_.builder().getPtrTy()},
+                    false);
+                type_error_fn = llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
+                    "eshkol_type_error", &ctx_.module());
+                type_error_fn->setDoesNotReturn();
+            }
+
+            llvm::Value* proc = ctx_.builder().CreateGlobalString(proc_name, "struct_int_proc");
+            llvm::Value* expected = ctx_.builder().CreateGlobalString(expected_type, "struct_int_expected");
+            ctx_.builder().CreateCall(type_error_fn, {proc, expected});
+            ctx_.builder().CreateUnreachable();
+            return llvm::ConstantInt::get(ctx_.int64Type(), 0);
+        }
+
+        llvm::Value* type_tag = tagged_.getType(value);
+        llvm::Value* base_type = tagged_.getBaseType(type_tag);
+        llvm::Value* is_int = ctx_.builder().CreateICmpEQ(base_type,
+            llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_INT64));
+
+        llvm::Function* func = ctx_.builder().GetInsertBlock()->getParent();
+        llvm::BasicBlock* ok_block = llvm::BasicBlock::Create(
+            ctx_.context(), "reshape_dim_int_ok", func);
+        llvm::BasicBlock* err_block = llvm::BasicBlock::Create(
+            ctx_.context(), "reshape_dim_type_error", func);
+        ctx_.builder().CreateCondBr(is_int, ok_block, err_block);
+
+        ctx_.builder().SetInsertPoint(err_block);
+        set_error_location();
+        llvm::Function* type_error_fn = ctx_.module().getFunction("eshkol_type_error_with_operand");
+        if (!type_error_fn) {
+            llvm::FunctionType* ft = llvm::FunctionType::get(
+                ctx_.builder().getVoidTy(),
+                {ctx_.builder().getPtrTy(), ctx_.builder().getPtrTy(), ctx_.builder().getPtrTy()},
+                false);
+            type_error_fn = llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
+                "eshkol_type_error_with_operand", &ctx_.module());
+            type_error_fn->setDoesNotReturn();
+        }
+        llvm::Value* slot = ctx_.builder().CreateAlloca(ctx_.taggedValueType(), nullptr, "reshape_dim_err_slot");
+        ctx_.builder().CreateStore(value, slot);
+        llvm::Value* proc = ctx_.builder().CreateGlobalString(proc_name, "struct_int_proc");
+        llvm::Value* expected = ctx_.builder().CreateGlobalString(expected_type, "struct_int_expected");
+        ctx_.builder().CreateCall(type_error_fn, {proc, expected, slot});
+        ctx_.builder().CreateUnreachable();
+
+        ctx_.builder().SetInsertPoint(ok_block);
+        return tagged_.unpackInt64(value);
+    };
+
     // Get source tensor properties (needed for all paths)
     llvm::Value* src_elements_field_ptr = ctx_.builder().CreateStructGEP(tensor_type, src_ptr, 2);
     llvm::Value* src_elements_ptr = ctx_.builder().CreateLoad(ctx_.ptrType(), src_elements_field_ptr);
@@ -1565,6 +1667,28 @@ llvm::Value* TensorCodegen::reshape(const eshkol_operations_t* op) {
             list_to_dims_fn = llvm::Function::Create(list_to_dims_ft,
                 llvm::Function::ExternalLinkage, "eshkol_cons_list_to_dims", &ctx_.module());
         }
+        {
+            uint32_t line = ctx_.currentSourceLine();
+            if (line != 0) {
+                llvm::Function* set_loc_fn = ctx_.module().getFunction("eshkol_set_error_location");
+                if (!set_loc_fn) {
+                    llvm::FunctionType* set_loc_ft = llvm::FunctionType::get(
+                        ctx_.builder().getVoidTy(),
+                        {ctx_.builder().getPtrTy(), ctx_.int32Type(), ctx_.int32Type()},
+                        false);
+                    set_loc_fn = llvm::Function::Create(set_loc_ft, llvm::Function::ExternalLinkage,
+                        "eshkol_set_error_location", &ctx_.module());
+                }
+                const std::string& file = ctx_.currentSourceFile();
+                llvm::Value* file_val = file.empty()
+                    ? static_cast<llvm::Value*>(llvm::ConstantPointerNull::get(ctx_.builder().getPtrTy()))
+                    : static_cast<llvm::Value*>(ctx_.builder().CreateGlobalString(file, "reshape_list_file"));
+                ctx_.builder().CreateCall(set_loc_fn, {
+                    file_val,
+                    llvm::ConstantInt::get(ctx_.int32Type(), line),
+                    llvm::ConstantInt::get(ctx_.int32Type(), ctx_.currentSourceColumn())});
+            }
+        }
         llvm::Value* list_ndim = ctx_.builder().CreateCall(
             list_to_dims_fn,
             {cons_ptr, list_dims_array, llvm::ConstantInt::get(ctx_.int64Type(), 16)},
@@ -1586,10 +1710,8 @@ llvm::Value* TensorCodegen::reshape(const eshkol_operations_t* op) {
 
         // SINGLE PATH: Treat as 1D reshape
         ctx_.builder().SetInsertPoint(single_path);
-        llvm::Value* single_dim = dim_arg;
-        if (single_dim->getType() == ctx_.taggedValueType()) {
-            single_dim = tagged_.unpackInt64(single_dim);
-        }
+        llvm::Value* single_dim = extract_structural_int(
+            dim_arg, "reshape", "integer dimension");
         // Allocate 1-element dims array
         llvm::Value* single_arena = ctx_.builder().CreateLoad(
             llvm::PointerType::get(ctx_.context(), 0), ctx_.globalArena());
@@ -1638,9 +1760,7 @@ llvm::Value* TensorCodegen::reshape(const eshkol_operations_t* op) {
         for (uint64_t i = 1; i < op->call_op.num_vars; i++) {
             llvm::Value* dim = codegenAST(&op->call_op.variables[i]);
             if (!dim) return nullptr;
-            if (dim->getType() == ctx_.taggedValueType()) {
-                dim = tagged_.unpackInt64(dim);
-            }
+            dim = extract_structural_int(dim, "reshape", "integer dimension");
             llvm::Value* dim_slot = ctx_.builder().CreateGEP(
                 ctx_.int64Type(), multi_dims_array,
                 llvm::ConstantInt::get(ctx_.int64Type(), i - 1));

--- a/lib/core/runtime_tensor_math.cpp
+++ b/lib/core/runtime_tensor_math.cpp
@@ -16,6 +16,10 @@
 // These helpers are called from LLVM-generated code through extern "C" names.
 // They operate on raw double arrays in row-major order.
 
+extern "C" void eshkol_type_error_with_operand(const char* proc_name,
+                                                const char* expected_type,
+                                                const eshkol_tagged_value_t* actual);
+
 // LU decomposition with partial pivoting (in-place).
 // A is n x n row-major, piv[i] stores the row swapped with row i.
 // Returns the sign of the permutation (+1 or -1), or 0 if singular.
@@ -364,7 +368,12 @@ extern "C" int64_t eshkol_cons_list_to_dims(
         (const arena_tagged_cons_cell_t*)cons_ptr;
 
     while (current != NULL && count < max_dims) {
-        dims_out[count] = arena_tagged_cons_get_int64(current, false);
+        if (current->car.type != ESHKOL_VALUE_INT64) {
+            eshkol_type_error_with_operand("reshape", "integer dimension", &current->car);
+            return count;
+        }
+
+        dims_out[count] = current->car.data.int_val;
         count++;
 
         uint8_t cdr_type = arena_tagged_cons_get_type(current, true);

--- a/tests/integration/ad_structural_int_guard_test.esk
+++ b/tests/integration/ad_structural_int_guard_test.esk
@@ -1,0 +1,48 @@
+;; ESH-0081: tensor shape dimensions and reduction axes are structural integer
+;; metadata. AD dual values must raise catchable type errors instead of being
+;; detached or silently coerced.
+
+(require stdlib)
+
+(display "TEST: AD structural integer guards") (newline)
+
+(display
+  (if (guard (exn (#t #t))
+        (gradient
+          (lambda (d)
+            (tensor-sum (reshape (vector 1.0 2.0) (list (vector-ref d 0)))))
+          (vector 2.0))
+        #f)
+      "PASS" "FAIL"))
+(display ": AD dual reshape list dimension raises catchable type error") (newline)
+
+(display
+  (if (guard (exn (#t #t))
+        (gradient
+          (lambda (d)
+            (tensor-sum (reshape (vector 1.0 2.0) (vector-ref d 0))))
+          (vector 2.0))
+        #f)
+      "PASS" "FAIL"))
+(display ": AD dual reshape direct dimension raises catchable type error") (newline)
+
+(display
+  (if (guard (exn (#t #t))
+        (gradient
+          (lambda (d)
+            (tensor-sum (reshape (vector 1.0 2.0) 1 (vector-ref d 0))))
+          (vector 2.0))
+        #f)
+      "PASS" "FAIL"))
+(display ": AD dual reshape multi dimension raises catchable type error") (newline)
+
+(display
+  (if (guard (exn (#t #t))
+        (gradient
+          (lambda (d)
+            (tensor-sum (tensor-sum (reshape (vector 1.0 2.0) 1 2)
+                                    (vector-ref d 0))))
+          (vector 1.0))
+        #f)
+      "PASS" "FAIL"))
+(display ": AD dual tensor reduction axis raises catchable type error") (newline)


### PR DESCRIPTION
## Summary
- rejects AD dual/non-int values used as structural tensor metadata
- makes reshape direct/list/multi dims and reduction axes raise catchable type errors instead of hitting the old non-catchable storage-cell path
- adds a focused AD structural-int guard smoke that covers reshape dims and reduction axis

## Verification
- ICC before/after: `ready`, score `100`
- `cmake -S . -B build -DESHKOL_GPU_ENABLED=OFF`
- `cmake --build build --target eshkol-run -j8`
- `build/eshkol-run -r tests/integration/ad_structural_int_guard_test.esk`
- `build/eshkol-run tests/integration/ad_structural_int_guard_test.esk`
- `./a.out`
- `ctest --test-dir build -R ad_structural_int_guard_runtime_smoke --output-on-failure`

Note: the broader existing `tests/integration/autodiff_tensor_test.esk` still fails on current `origin/master` before these cases at line 392 with `tensor-sum: expected tensor, got ad-node`; this PR keeps that unrelated failure out of scope and verifies the new structural metadata guard with a focused test.
