### PR TITLE
fix(backend): intern repeated error strings

### DIFF
--- a/inc/eshkol/backend/codegen_context.h
+++ b/inc/eshkol/backend/codegen_context.h
@@ -163,6 +163,9 @@ public:
     /** Get or create an interned string global (legacy, no header) */
     llvm::GlobalVariable* internString(const std::string& str);
 
+    /** Get or create an interned C string pointer (legacy, no header) */
+    llvm::Value* internCString(const std::string& str);
+
     /** Check if a string is already interned */
     llvm::GlobalVariable* lookupInternedString(const std::string& str);
 

--- a/lib/backend/arithmetic_codegen.cpp
+++ b/lib/backend/arithmetic_codegen.cpp
@@ -2768,8 +2768,8 @@ void ArithmeticCodegen::emitOperandTypeError(const char* proc_name,
     }
     llvm::Value* slot = b.CreateAlloca(ctx_.taggedValueType(), nullptr, "operand_err_slot");
     b.CreateStore(offending, slot);
-    llvm::Value* proc = b.CreateGlobalString(proc_name, "operr_proc");
-    llvm::Value* exp = b.CreateGlobalString(expected_type, "operr_expected");
+    llvm::Value* proc = ctx_.internCString(proc_name);
+    llvm::Value* exp = ctx_.internCString(expected_type);
     b.CreateCall(fn, {proc, exp, slot});
 }
 
@@ -2795,7 +2795,7 @@ void ArithmeticCodegen::emitSetErrorLocation() {
 
     llvm::Value* file_str = file.empty()
         ? static_cast<llvm::Value*>(llvm::ConstantPointerNull::get(ctx_.builder().getPtrTy()))
-        : static_cast<llvm::Value*>(ctx_.builder().CreateGlobalString(file, "err_loc_file"));
+        : ctx_.internCString(file);
     ctx_.builder().CreateCall(set_loc_func, {
         file_str,
         llvm::ConstantInt::get(ctx_.int32Type(), line),

--- a/lib/backend/codegen_context.cpp
+++ b/lib/backend/codegen_context.cpp
@@ -127,6 +127,11 @@ llvm::GlobalVariable* CodegenContext::internString(const std::string& str) {
     return global_str;
 }
 
+llvm::Value* CodegenContext::internCString(const std::string& str) {
+    llvm::GlobalVariable* global_str = internString(str);
+    return builder_.CreatePointerCast(global_str, llvm::PointerType::get(context_, 0));
+}
+
 llvm::GlobalVariable* CodegenContext::lookupInternedString(const std::string& str) {
     auto it = interned_strings_.find(str);
     return (it != interned_strings_.end()) ? it->second : nullptr;

--- a/lib/backend/tensor_codegen.cpp
+++ b/lib/backend/tensor_codegen.cpp
@@ -174,7 +174,7 @@ llvm::Value* TensorCodegen::unpackTensorOperandChecked(llvm::Value* tensor_val,
         const std::string& file = ctx_.currentSourceFile();
         llvm::Value* file_str = file.empty()
             ? static_cast<llvm::Value*>(llvm::ConstantPointerNull::get(ctx_.ptrType()))
-            : static_cast<llvm::Value*>(b.CreateGlobalString(file, "tensor_err_file"));
+            : ctx_.internCString(file);
         b.CreateCall(set_loc, {
             file_str,
             llvm::ConstantInt::get(ctx_.int32Type(), line),
@@ -203,8 +203,7 @@ llvm::Value* TensorCodegen::unpackTensorOperandChecked(llvm::Value* tensor_val,
         fn = llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
                                     "eshkol_tensor_operand_checked", &ctx_.module());
     }
-    llvm::Value* name = b.CreateGlobalString(op_name ? op_name : "tensor-op",
-                                             "tensor_op_name");
+    llvm::Value* name = ctx_.internCString(op_name ? op_name : "tensor-op");
     return b.CreateCall(fn, {slot, name}, "tensor_ptr_checked");
 }
 


### PR DESCRIPTION
## Summary
- adds `CodegenContext::internCString()` for shared raw C string constants
- switches repeated arithmetic/tensor error source strings, proc names, and expected-type strings to the existing codegen string pool

## ESH-0088 Impact
This is a partial pressure reduction, not the full broad-import/module-cache fix.

On the `services.plugins.plugin-loader` reduction using `--dump-ir` before object emission:

- before: `globals=40027`, private string constants `38313`, IR size `341M`
- after: `globals=25760`, private string constants `24046`, IR size `339M`

The same repro still times out in `pass_manager.run` under a 90s object-emission watchdog, so the remaining fix is still the broader module/source-inlining and code-size strategy. This PR removes a large class of duplicate C string globals without changing runtime error text.

## Verification
- `cmake --build build --target eshkol-run -j 8`
- `env LC_ALL=C LANG=C BUILD_DIR=build bash tests/v1_3_edge_cases/source_span_type_error_test.sh`
- `env LC_ALL=C LANG=C BUILD_DIR=build bash tests/v1_2_edge_cases/object_emit_phase_trace_test.sh`
- `git diff --check`
- ICC readiness: `status=ready`, `score=100`, `completion=complete`

## Follow-up
ESH-0088 still needs the architectural mitigation: extern-only precompiled module declarations and/or a module object cache for broad user imports. Downstream reduced repros point at `services.api-client` and `services.plugins.plugin-loader` JSON/runtime boundary bodies as the smallest production triggers.
