### PR TITLE
fix(types): skip body scans for external defines

### DIFF
--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -2523,18 +2523,24 @@ public:
             
             // Step 1: Create function declarations FIRST (including nested functions)
             for (size_t i = 0; i < num_asts_to_use; i++) {
+                bool is_external_define =
+                    asts_to_use[i].type == ESHKOL_OP &&
+                    asts_to_use[i].operation.op == ESHKOL_DEFINE_OP &&
+                    asts_to_use[i].operation.define_op.is_external;
                 if (asts_to_use[i].type == ESHKOL_OP && asts_to_use[i].operation.op == ESHKOL_DEFINE_OP) {
                     if (asts_to_use[i].operation.define_op.is_function) {
                         // Create function declaration for top-level function
                         createFunctionDeclaration(&asts_to_use[i]);
                         // Also recursively declare any nested functions inside this function
-                        if (asts_to_use[i].operation.define_op.value) {
+                        if (!is_external_define && asts_to_use[i].operation.define_op.value) {
                             declareNestedFunctions(asts_to_use[i].operation.define_op.value);
                         }
                     }
                 }
                 // Also check for nested functions in non-function top-level expressions
-                declareNestedFunctions(&asts_to_use[i]);
+                if (!is_external_define) {
+                    declareNestedFunctions(&asts_to_use[i]);
+                }
             }
             eshkol_debug("Created all function declarations (including nested)");
 
@@ -4464,6 +4470,7 @@ private:
             // Look for (define var (lambda ...)) patterns
             if (asts[i].type == ESHKOL_OP &&
                 asts[i].operation.op == ESHKOL_DEFINE_OP &&
+                !asts[i].operation.define_op.is_external &&
                 !asts[i].operation.define_op.is_function) {
 
                 const char* var_name = asts[i].operation.define_op.name;

--- a/lib/types/type_checker.cpp
+++ b/lib/types/type_checker.cpp
@@ -2217,6 +2217,32 @@ TypeCheckResult TypeChecker::synthesizeDefine(eshkol_ast_t* expr) {
         return errorAt(expr, "Define without name");
     }
 
+    if (def.is_external) {
+        if (def.is_function) {
+            std::vector<TypeId> param_types;
+            for (size_t i = 0; i < def.num_params; i++) {
+                if (def.parameters && def.parameters[i].type == ESHKOL_VAR &&
+                    def.parameters[i].variable.id) {
+                    TypeId param_type = BuiltinTypes::Value;
+                    if (def.param_types && def.param_types[i]) {
+                        param_type = resolveType(def.param_types[i]);
+                    }
+                    param_types.push_back(param_type);
+                }
+            }
+
+            TypeId return_type = def.return_type
+                ? resolveType(def.return_type)
+                : BuiltinTypes::Value;
+            TypeId func_type = env_.makeFunctionType(param_types, return_type,
+                                                      def.is_variadic);
+            ctx_.bind(def.name, func_type);
+        } else {
+            ctx_.bind(def.name, BuiltinTypes::Value);
+        }
+        return TypeCheckResult::ok(BuiltinTypes::Null);
+    }
+
     TypeCheckResult value_type = TypeCheckResult::ok(BuiltinTypes::Value);
 
     if (def.is_function) {

--- a/tests/v1_2_edge_cases/precompiled_external_body_prune_test.sh
+++ b/tests/v1_2_edge_cases/precompiled_external_body_prune_test.sh
@@ -4,11 +4,23 @@ set -euo pipefail
 
 ESHKOL_RUN="${1:-${ESHKOL_RUN:-}}"
 if [ -z "$ESHKOL_RUN" ]; then
-    if [ -x "./build/eshkol-run" ]; then
-        ESHKOL_RUN="./build/eshkol-run"
-    elif [ -x "./build-verify/eshkol-run" ]; then
-        ESHKOL_RUN="./build-verify/eshkol-run"
-    else
+    # Honour $BUILD_DIR (CI passes it via the matrix: build-asan / build-xla /
+    # build-cuda) so non-default lanes locate their eshkol-run instead of
+    # falling through to a missing ./build/eshkol-run. Resolve relative to the
+    # repo root, matching the sibling shell tests in this directory.
+    ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+    for candidate in \
+        "$ROOT/${BUILD_DIR:-build}/eshkol-run" \
+        "$ROOT/build/eshkol-run" \
+        "$ROOT/build-verify/eshkol-run" \
+        "./build/eshkol-run" \
+        "./build-verify/eshkol-run"; do
+        if [ -x "$candidate" ]; then
+            ESHKOL_RUN="$candidate"
+            break
+        fi
+    done
+    if [ -z "$ESHKOL_RUN" ]; then
         echo "FAIL: precompiled_external_body_prune_test could not locate eshkol-run" >&2
         exit 1
     fi

--- a/tests/v1_2_edge_cases/precompiled_external_body_prune_test.sh
+++ b/tests/v1_2_edge_cases/precompiled_external_body_prune_test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# ESH-0088: precompiled-module external declarations must not typecheck bodies.
+set -euo pipefail
+
+ESHKOL_RUN="${1:-${ESHKOL_RUN:-}}"
+if [ -z "$ESHKOL_RUN" ]; then
+    if [ -x "./build/eshkol-run" ]; then
+        ESHKOL_RUN="./build/eshkol-run"
+    elif [ -x "./build-verify/eshkol-run" ]; then
+        ESHKOL_RUN="./build-verify/eshkol-run"
+    else
+        echo "FAIL: precompiled_external_body_prune_test could not locate eshkol-run" >&2
+        exit 1
+    fi
+fi
+
+if [ ! -x "$ESHKOL_RUN" ]; then
+    echo "FAIL: precompiled_external_body_prune_test eshkol-run is not executable: $ESHKOL_RUN" >&2
+    exit 1
+fi
+
+case "$ESHKOL_RUN" in
+    /*) ;;
+    */*) ESHKOL_RUN="$(cd "$(dirname "$ESHKOL_RUN")" && pwd)/$(basename "$ESHKOL_RUN")" ;;
+    *) ESHKOL_RUN="$(command -v "$ESHKOL_RUN")" ;;
+esac
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-external-prune.XXXXXX")"
+case "$tmpdir" in
+    "${TMPDIR:-/tmp}"/eshkol-external-prune.*) ;;
+    *) echo "FAIL: unsafe tmpdir: $tmpdir" >&2; exit 1 ;;
+esac
+trap 'rm -rf "$tmpdir"' EXIT
+
+mkdir -p "$tmpdir/lib/core"
+
+fixture_runner="$tmpdir/eshkol-run"
+cp "$ESHKOL_RUN" "$fixture_runner"
+chmod +x "$fixture_runner"
+
+cat > "$tmpdir/lib/stdlib.esk" <<'EOF_STDLIB'
+(require core.external_probe)
+EOF_STDLIB
+
+cat > "$tmpdir/lib/core/external_probe.esk" <<'EOF_MODULE'
+(provide external-bad-body)
+
+(define (external-bad-body x)
+  (+ x "not-a-number"))
+EOF_MODULE
+
+cat > "$tmpdir/use_external_probe.esk" <<'EOF_USE'
+(require core.external_probe)
+(define (main) (external-bad-body 1))
+EOF_USE
+
+# The filename is what marks the library as precompiled; compile-only mode does
+# not link this dummy object.
+: > "$tmpdir/stdlib.o"
+
+set +e
+(
+    cd "$tmpdir"
+    "$fixture_runner" --strict-types --compile-only \
+        use_external_probe.esk stdlib.o \
+        -o use_external_probe.o
+) > "$tmpdir/compile.log" 2>&1
+status=$?
+set -e
+
+if [ "$status" -ne 0 ]; then
+    echo "FAIL: external precompiled body was scanned during compile-only" >&2
+    cat "$tmpdir/compile.log" >&2
+    exit 1
+fi
+
+if grep -Eq "not-a-number|external-bad-body.*body type|Type errors detected" "$tmpdir/compile.log"; then
+    echo "FAIL: external precompiled body leaked into typechecking diagnostics" >&2
+    cat "$tmpdir/compile.log" >&2
+    exit 1
+fi
+
+if [ ! -s "$tmpdir/use_external_probe.o" ]; then
+    echo "FAIL: compile-only did not produce an object" >&2
+    cat "$tmpdir/compile.log" >&2
+    exit 1
+fi
+
+echo "PASS: precompiled_external_body_prune_test"


### PR DESCRIPTION
## Summary
- skips HoTT body synthesis for `DEFINE_OP.is_external` declarations imported from precompiled modules
- skips nested-function and top-level lambda body scans for external declarations during LLVM setup
- adds a compile-only regression that marks a fixture module precompiled and proves strict type checking does not inspect its intentionally bad body

## Verification
- `cmake --build build --target eshkol-run -j 8`
- `env LC_ALL=C LANG=C BUILD_DIR=build bash tests/v1_2_edge_cases/precompiled_external_body_prune_test.sh`
- `env LC_ALL=C LANG=C BUILD_DIR=build bash tests/v1_2_edge_cases/object_emit_phase_trace_test.sh`
- `env LC_ALL=C LANG=C BUILD_DIR=build bash tests/v1_3_edge_cases/source_span_type_error_test.sh`
- `bash -n tests/v1_2_edge_cases/precompiled_external_body_prune_test.sh`
- `git diff --check`
- ICC readiness: `ready`, score `100`

## ESH-0088 Note
This is front-end/declaration pruning, not the full broad-import/code-size fix. The `services.plugins.plugin-loader` reduction still times out in `pass_manager.run`; with #100 included it reports `functions=1312`, `definitions=1042`, `globals=25760`, `basic_blocks=193833`, and `instructions=2011505`.
