### PR TITLE
test(sicp): ch3.5 full-book stream probes — acceleration, power series, signals, monte-carlo (ESH-0042..0045)

### DIFF
--- a/tests/sicp/ch3_stream_acceleration.esk
+++ b/tests/sicp/ch3_stream_acceleration.esk
@@ -1,0 +1,88 @@
+;; SICP 3.5.3 — Exploiting the Stream Paradigm: sequence acceleration.
+;; pi-summands / pi-stream (Leibniz series), euler-transform, make-tableau,
+;; accelerated-sequence.  Verifies that raw partial sums converge slowly,
+;; the Euler transform converges much faster, and the tableau-accelerated
+;; sequence converges spectacularly fast — and that the accuracy ordering
+;; raw < euler < accelerated holds.
+
+(define fails 0)
+(define (check name ok)
+  (if ok (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1)) (display "FAIL: ") (display name) (newline))))
+
+;; ---- stream primitives (3.5.1) ----
+(define-syntax cons-stream (syntax-rules () ((_ a b) (cons a (delay b)))))
+(define (stream-car s) (car s))
+(define (stream-cdr s) (force (cdr s)))
+(define the-empty-stream '())
+(define (stream-null? s) (null? s))
+(define (stream-ref s n) (if (= n 0) (stream-car s) (stream-ref (stream-cdr s) (- n 1))))
+(define (stream-map proc s)
+  (if (stream-null? s) the-empty-stream
+      (cons-stream (proc (stream-car s)) (stream-map proc (stream-cdr s)))))
+(define (stream-take s n)
+  (if (= n 0) '() (cons (stream-car s) (stream-take (stream-cdr s) (- n 1)))))
+(define (add-streams s1 s2)
+  (cond ((stream-null? s1) s2)
+        ((stream-null? s2) s1)
+        (else (cons-stream (+ (stream-car s1) (stream-car s2))
+                           (add-streams (stream-cdr s1) (stream-cdr s2))))))
+(define (scale-stream s factor) (stream-map (lambda (x) (* x factor)) s))
+(define (partial-sums s)
+  (cons-stream (stream-car s) (add-streams (stream-cdr s) (partial-sums s))))
+
+(define pi 3.141592653589793)
+(define (square x) (* x x))
+
+;; ---- Leibniz pi stream (3.5.3) ----
+(define (pi-summands n)
+  (cons-stream (/ 1.0 n) (stream-map - (pi-summands (+ n 2)))))
+(define pi-stream (scale-stream (partial-sums (pi-summands 1)) 4.0))
+
+;; first few partial sums, hand-computed:
+;;   S0 = 4,  S1 = 4(1 - 1/3) = 2.666...,  S2 = 4(1 - 1/3 + 1/5) = 3.466...
+(define (close? a b tol) (< (abs (- a b)) tol))
+(check "pi-stream-s0" (close? (stream-ref pi-stream 0) 4.0 1e-12))
+(check "pi-stream-s1" (close? (stream-ref pi-stream 1) 2.666666666666667 1e-12))
+(check "pi-stream-s2" (close? (stream-ref pi-stream 2) 3.466666666666667 1e-12))
+
+;; raw series converges slowly: 8 terms is still >0.1 away from pi
+;; (S7 = 3.017071817071818, error ~0.1245)
+(define raw-err (abs (- (stream-ref pi-stream 7) pi)))
+(check "raw-converges-slowly" (> raw-err 0.1))
+
+;; ---- Euler transform (ex: S_{n+1} - (S_{n+1}-S_n)^2 / (S_{n-1} - 2 S_n + S_{n+1})) ----
+(define (euler-transform s)
+  (let ((s0 (stream-ref s 0))
+        (s1 (stream-ref s 1))
+        (s2 (stream-ref s 2)))
+    (cons-stream (- s2 (/ (square (- s2 s1)) (+ s0 (* -2.0 s1) s2)))
+                 (euler-transform (stream-cdr s)))))
+
+;; first euler term hand-computed: s0=4, s1=8/3, s2=52/15 ->
+;;   s2 - (s2-s1)^2/(s0-2 s1+s2) = 52/15 - (4/5)^2/(2.4) = 19/6 = 3.1666...
+(check "euler-term-0" (close? (stream-ref (euler-transform pi-stream) 0)
+                              3.166666666666667 1e-12))
+
+;; 8th euler-transformed term is within 1e-3 of pi (~3.4e-4 off)
+(define euler-err (abs (- (stream-ref (euler-transform pi-stream) 7) pi)))
+(check "euler-8th-within-1e-3" (< euler-err 1e-3))
+
+;; ---- tableau: repeatedly accelerated sequence ----
+(define (make-tableau transform s)
+  (cons-stream s (make-tableau transform (transform s))))
+(define (accelerated-sequence transform s)
+  (stream-map stream-car (make-tableau transform s)))
+
+;; super-acceleration: 8th term is within 1e-10 of pi
+(define accel-err (abs (- (stream-ref (accelerated-sequence euler-transform pi-stream) 7) pi)))
+(check "accelerated-8th-within-1e-10" (< accel-err 1e-10))
+
+;; accuracy strictly improves: raw < euler < accelerated
+(check "ordering-raw-worse-than-euler" (> raw-err euler-err))
+(check "ordering-euler-worse-than-accel" (> euler-err accel-err))
+
+(newline)
+(if (= fails 0)
+    (begin (display "ALL-PASS ch3_stream_acceleration") (newline))
+    (begin (display "HAS-FAIL ch3_stream_acceleration ") (display fails) (newline)))

--- a/tests/sicp/ch3_stream_power_series.esk
+++ b/tests/sicp/ch3_stream_power_series.esk
@@ -1,0 +1,111 @@
+;; SICP 3.5.2 exercises 3.59-3.61 — power series as streams.
+;; integrate-series, exp-series (its own integral), mutually-recursive
+;; sine-series / cosine-series, mul-series, and the identity
+;; sin^2 x + cos^2 x = 1 checked coefficient-by-coefficient.
+
+(define fails 0)
+(define (check name ok)
+  (if ok (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1)) (display "FAIL: ") (display name) (newline))))
+(define (close? a b) (< (abs (- a b)) 1e-12))
+
+;; ---- stream primitives (3.5.1) ----
+(define-syntax cons-stream (syntax-rules () ((_ a b) (cons a (delay b)))))
+(define (stream-car s) (car s))
+(define (stream-cdr s) (force (cdr s)))
+(define the-empty-stream '())
+(define (stream-null? s) (null? s))
+(define (stream-ref s n) (if (= n 0) (stream-car s) (stream-ref (stream-cdr s) (- n 1))))
+(define (stream-map proc s)
+  (if (stream-null? s) the-empty-stream
+      (cons-stream (proc (stream-car s)) (stream-map proc (stream-cdr s)))))
+(define (stream-take s n)
+  (if (= n 0) '() (cons (stream-car s) (stream-take (stream-cdr s) (- n 1)))))
+(define (add-streams s1 s2)
+  (cond ((stream-null? s1) s2)
+        ((stream-null? s2) s1)
+        (else (cons-stream (+ (stream-car s1) (stream-car s2))
+                           (add-streams (stream-cdr s1) (stream-cdr s2))))))
+(define (scale-stream s factor) (stream-map (lambda (x) (* x factor)) s))
+
+;; compare the first n coefficients of a series against a list, within 1e-12
+(define (coeffs-close? s expected)
+  (if (null? expected) #t
+      (and (close? (stream-car s) (car expected))
+           (coeffs-close? (stream-cdr s) (cdr expected)))))
+
+;; ---- ex 3.59a: integrate-series ----
+;; series a0 + a1 x + a2 x^2 + ...  ->  a0 x + (a1/2) x^2 + (a2/3) x^3 + ...
+;; (the constant term of the integral is supplied separately via cons-stream)
+(define (integrate-series s)
+  (define (iter s n)
+    (cons-stream (/ (stream-car s) n) (iter (stream-cdr s) (+ n 1.0))))
+  (iter s 1.0))
+
+;; integral of 1 + x + x^2 + ... has coefficients 1, 1/2, 1/3, 1/4, ...
+(define ones (cons-stream 1.0 ones))
+(check "integrate-ones"
+       (coeffs-close? (integrate-series ones)
+                      (list 1.0 0.5 0.3333333333333333 0.25 0.2)))
+
+;; ---- ex 3.59b: exp-series is its own integral ----
+(define exp-series (cons-stream 1.0 (integrate-series exp-series)))
+
+;; e^x = 1 + x + x^2/2 + x^3/6 + x^4/24 + x^5/120 + ...
+(check "exp-series-coeffs"
+       (coeffs-close? exp-series
+                      (list 1.0 1.0 0.5
+                            0.16666666666666666
+                            0.041666666666666664
+                            0.008333333333333333)))
+
+;; ---- mutually recursive sine / cosine series ----
+(define cosine-series (cons-stream 1.0 (scale-stream (integrate-series sine-series) -1.0)))
+(define sine-series (cons-stream 0.0 (integrate-series cosine-series)))
+
+;; sin x = x - x^3/6 + x^5/120 - ...
+(check "sine-series-coeffs"
+       (coeffs-close? sine-series
+                      (list 0.0 1.0 0.0
+                            -0.16666666666666666
+                            0.0
+                            0.008333333333333333)))
+;; cos x = 1 - x^2/2 + x^4/24 - ...
+(check "cosine-series-coeffs"
+       (coeffs-close? cosine-series
+                      (list 1.0 0.0 -0.5 0.0
+                            0.041666666666666664
+                            0.0)))
+
+;; ---- ex 3.60: mul-series ----
+(define (mul-series s1 s2)
+  (cons-stream (* (stream-car s1) (stream-car s2))
+               (add-streams (scale-stream (stream-cdr s2) (stream-car s1))
+                            (mul-series (stream-cdr s1) s2))))
+
+;; sin^2 x + cos^2 x = 1: coefficients 1, 0, 0, 0, 0, 0
+(define pythagorean
+  (add-streams (mul-series sine-series sine-series)
+               (mul-series cosine-series cosine-series)))
+(check "sin2-plus-cos2-is-one"
+       (coeffs-close? pythagorean (list 1.0 0.0 0.0 0.0 0.0 0.0)))
+
+;; ---- evaluating a truncated series ----
+(define (eval-series s x n)
+  (define (iter s xk k acc)
+    (if (= k n) acc
+        (iter (stream-cdr s) (* xk x) (+ k 1) (+ acc (* (stream-car s) xk)))))
+  (iter s 1.0 0 0.0))
+
+;; sum of the first 12 terms of exp-series at x=1 is within ~1/12! of e
+(define e 2.718281828459045)
+(check "exp-series-at-1-approx-e"
+       (< (abs (- (eval-series exp-series 1.0 12) e)) 1e-7))
+;; sine series at pi/6 -> 0.5
+(check "sine-series-at-pi-over-6"
+       (< (abs (- (eval-series sine-series 0.5235987755982988 12) 0.5)) 1e-9))
+
+(newline)
+(if (= fails 0)
+    (begin (display "ALL-PASS ch3_stream_power_series") (newline))
+    (begin (display "HAS-FAIL ch3_stream_power_series ") (display fails) (newline)))

--- a/tests/sicp/ch3_stream_random_monte_carlo.esk
+++ b/tests/sicp/ch3_stream_random_monte_carlo.esk
@@ -1,0 +1,83 @@
+;; SICP 3.5.5 — modularity of functional programs: streams of random numbers,
+;; the Cesaro coprimality experiment, monte-carlo as a stream of running
+;; ratios, and estimating pi.  Uses a DETERMINISTIC seeded Lehmer LCG
+;; (x' = 16807 x mod 2147483647) so every value below is exact and
+;; reproducible, not statistical.
+
+(define fails 0)
+(define (check name ok)
+  (if ok (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1)) (display "FAIL: ") (display name) (newline))))
+(define (close? a b tol) (< (abs (- a b)) tol))
+
+;; ---- stream primitives (3.5.1) ----
+(define-syntax cons-stream (syntax-rules () ((_ a b) (cons a (delay b)))))
+(define (stream-car s) (car s))
+(define (stream-cdr s) (force (cdr s)))
+(define the-empty-stream '())
+(define (stream-null? s) (null? s))
+(define (stream-ref s n) (if (= n 0) (stream-car s) (stream-ref (stream-cdr s) (- n 1))))
+(define (stream-map proc s)
+  (if (stream-null? s) the-empty-stream
+      (cons-stream (proc (stream-car s)) (stream-map proc (stream-cdr s)))))
+(define (stream-take s n)
+  (if (= n 0) '() (cons (stream-car s) (stream-take (stream-cdr s) (- n 1)))))
+
+;; ---- deterministic random stream (Lehmer / Park-Miller LCG) ----
+(define (rand-update x) (remainder (* x 16807) 2147483647))
+(define random-seed 42)
+(define random-numbers
+  (cons-stream (rand-update random-seed)
+               (stream-map rand-update random-numbers)))
+
+;; determinism probe: the first three draws are exactly these
+(check "lcg-first"  (= (stream-ref random-numbers 0) 705894))
+(check "lcg-second" (= (stream-ref random-numbers 1) 1126542223))
+(check "lcg-third"  (= (stream-ref random-numbers 2) 1579310009))
+
+;; ---- Cesaro experiment: P(gcd(r1, r2) = 1) = 6/pi^2 ----
+(define (my-gcd a b) (if (= b 0) a (my-gcd b (remainder a b))))
+(define (map-successive-pairs f s)
+  (cons-stream (f (stream-car s) (stream-car (stream-cdr s)))
+               (map-successive-pairs f (stream-cdr (stream-cdr s)))))
+(define cesaro-stream
+  (map-successive-pairs (lambda (r1 r2) (= (my-gcd r1 r2) 1)) random-numbers))
+
+;; first trial: gcd(705894, 1126542223) — deterministic outcome
+(check "cesaro-first-trial-deterministic"
+       (eq? (stream-car cesaro-stream) (= (my-gcd 705894 1126542223) 1)))
+
+;; ---- monte-carlo as a stream of running ratios ----
+(define (monte-carlo experiment-stream passed failed)
+  (define (next passed failed)
+    (cons-stream (/ (* 1.0 passed) (+ passed failed))
+                 (monte-carlo (stream-cdr experiment-stream) passed failed)))
+  (if (stream-car experiment-stream)
+      (next (+ passed 1) failed)
+      (next passed (+ failed 1))))
+
+(define ratio-stream (monte-carlo cesaro-stream 0 0))
+;; running ratio is always a probability
+(define r100 (stream-ref ratio-stream 99))
+(check "ratio-is-probability" (and (>= r100 0.0) (<= r100 1.0)))
+
+;; ---- pi from the stream ----
+(define pi-estimate-stream
+  (stream-map (lambda (p) (sqrt (/ 6.0 p))) ratio-stream))
+
+(define pi 3.141592653589793)
+(define pi-after-2000 (stream-ref pi-estimate-stream 1999))
+
+;; the seeded LCG makes this EXACT: after 2000 trials the estimate is
+;; precisely this value (hard-coded from a reference run), and it lands
+;; inside the precomputed interval around pi
+(check "pi-estimate-exact-deterministic"
+       (close? pi-after-2000 3.1715415191530525 1e-12))
+(check "pi-estimate-in-interval"
+       (and (> pi-after-2000 3.10) (< pi-after-2000 3.20)))
+(check "pi-estimate-near-pi" (< (abs (- pi-after-2000 pi)) 0.05))
+
+(newline)
+(if (= fails 0)
+    (begin (display "ALL-PASS ch3_stream_random_monte_carlo") (newline))
+    (begin (display "HAS-FAIL ch3_stream_random_monte_carlo ") (display fails) (newline)))

--- a/tests/sicp/ch3_stream_signal_systems.esk
+++ b/tests/sicp/ch3_stream_signal_systems.esk
@@ -1,0 +1,110 @@
+;; SICP 3.5.3-3.5.4 — streams as signals.
+;; integral of a stream (scaled running sums), the RC circuit model
+;; (ex 3.73), zero-crossings of a sensor signal (ex 3.74), and the
+;; delayed-integral solver for dy/dt = y reaching y(1) ~ e (3.5.4).
+
+(define fails 0)
+(define (check name ok)
+  (if ok (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1)) (display "FAIL: ") (display name) (newline))))
+(define (close? a b) (< (abs (- a b)) 1e-9))
+
+;; ---- stream primitives (3.5.1) ----
+(define-syntax cons-stream (syntax-rules () ((_ a b) (cons a (delay b)))))
+(define (stream-car s) (car s))
+(define (stream-cdr s) (force (cdr s)))
+(define the-empty-stream '())
+(define (stream-null? s) (null? s))
+(define (stream-ref s n) (if (= n 0) (stream-car s) (stream-ref (stream-cdr s) (- n 1))))
+(define (stream-map proc s)
+  (if (stream-null? s) the-empty-stream
+      (cons-stream (proc (stream-car s)) (stream-map proc (stream-cdr s)))))
+(define (stream-take s n)
+  (if (= n 0) '() (cons (stream-car s) (stream-take (stream-cdr s) (- n 1)))))
+(define (add-streams s1 s2)
+  (cond ((stream-null? s1) s2)
+        ((stream-null? s2) s1)
+        (else (cons-stream (+ (stream-car s1) (stream-car s2))
+                           (add-streams (stream-cdr s1) (stream-cdr s2))))))
+(define (scale-stream s factor) (stream-map (lambda (x) (* x factor)) s))
+(define (list->stream lst)
+  (if (null? lst) the-empty-stream
+      (cons-stream (car lst) (list->stream (cdr lst)))))
+(define ones (cons-stream 1.0 ones))
+
+;; ---- integral of a stream (3.5.3) ----
+;; int = initial, initial + dt*x0, initial + dt*(x0+x1), ...
+(define (integral integrand initial-value dt)
+  (define int
+    (cons-stream initial-value
+                 (add-streams (scale-stream integrand dt) int)))
+  int)
+
+;; integral of the constant signal 1.0 with dt=0.1 from 0: 0, 0.1, 0.2, 0.3, ...
+(define ramp (integral ones 0.0 0.1))
+(check "integral-ramp-0" (close? (stream-ref ramp 0) 0.0))
+(check "integral-ramp-1" (close? (stream-ref ramp 1) 0.1))
+(check "integral-ramp-2" (close? (stream-ref ramp 2) 0.2))
+(check "integral-ramp-10" (close? (stream-ref ramp 10) 1.0))
+;; integral of the ramp t (values 0, 0.1, 0.2, ...) approximates t^2/2:
+;; term 10 = dt * (0 + 0.1 + ... + 0.9) = 0.1 * 4.5 = 0.45
+(check "integral-of-ramp" (close? (stream-ref (integral ramp 0.0 0.1) 10) 0.45))
+
+;; ---- RC circuit (ex 3.73): v = R i + (1/C) integral(i) + v0 ----
+(define (RC R C dt)
+  (lambda (i v0)
+    (add-streams (scale-stream i R)
+                 (integral (scale-stream i (/ 1.0 C)) v0 dt))))
+
+;; R=5 ohms, C=1 farad, dt=0.5, constant current i=1A, v0=1V:
+;;   v[k] = 5*1 + (1 + 0.5*k) = 6.0, 6.5, 7.0, 7.5, ...   (hand-computed)
+(define RC1 (RC 5.0 1.0 0.5))
+(define rc-response (RC1 ones 1.0))
+(check "rc-response-0" (close? (stream-ref rc-response 0) 6.0))
+(check "rc-response-1" (close? (stream-ref rc-response 1) 6.5))
+(check "rc-response-2" (close? (stream-ref rc-response 2) 7.0))
+(check "rc-response-3" (close? (stream-ref rc-response 3) 7.5))
+
+;; ---- zero crossings (ex 3.74) ----
+(define (sign-change-detector cur last)
+  (cond ((and (< last 0.0) (>= cur 0.0)) 1)
+        ((and (>= last 0.0) (< cur 0.0)) -1)
+        (else 0)))
+(define (make-zero-crossings input last-value)
+  (if (stream-null? input) the-empty-stream
+      (cons-stream (sign-change-detector (stream-car input) last-value)
+                   (make-zero-crossings (stream-cdr input) (stream-car input)))))
+
+;; the book's sample sense-data and its exact crossing pattern
+(define sense-data
+  (list->stream (list 1.0 2.0 1.5 1.0 0.5 -0.1 -2.0 -3.0 -2.0 -0.5 0.2 3.0 4.0)))
+(define zero-crossings (make-zero-crossings sense-data 0.0))
+(check "zero-crossings-pattern"
+       (equal? (stream-take zero-crossings 13)
+               '(0 0 0 0 0 -1 0 0 0 0 1 0 0)))
+
+;; ---- delayed integral + solve (3.5.4): dy/dt = y, y(0) = 1 ----
+(define (integral-delayed delayed-integrand initial-value dt)
+  (define int
+    (cons-stream initial-value
+                 (let ((integrand (force delayed-integrand)))
+                   (add-streams (scale-stream integrand dt) int))))
+  int)
+
+(define (solve f y0 dt)
+  (define y (integral-delayed (delay dy) y0 dt))
+  (define dy (stream-map f y))
+  y)
+
+;; Euler steps: y(1) after 1000 steps of dt=0.001 is (1.001)^1000 = 2.71692...
+;; which is within 1e-2 of e = 2.71828...
+(define e 2.718281828459045)
+(define y-at-1 (stream-ref (solve (lambda (y) y) 1.0 0.001) 1000))
+(check "solve-dy=y-reaches-e" (< (abs (- y-at-1 e)) 1e-2))
+;; and it is the exact Euler value, not something else that happens to be close
+(check "solve-exact-euler-value" (< (abs (- y-at-1 2.716923932235896)) 1e-9))
+
+(newline)
+(if (= fails 0)
+    (begin (display "ALL-PASS ch3_stream_signal_systems") (newline))
+    (begin (display "HAS-FAIL ch3_stream_signal_systems ") (display fails) (newline)))


### PR DESCRIPTION
Four self-checking SICP 3.5 stream probes under tests/sicp/, each passing both -r (JIT) and AOT with zero FAIL: lines.

## Files

- **ch3_stream_acceleration.esk** (SICP 3.5.3, 9 checks) — pi-summands / pi-stream (Leibniz), euler-transform, make-tableau + accelerated-sequence. Hand-checked tolerances: raw 8th partial sum >0.1 from pi (err 0.1245), Euler-transformed 8th term within 1e-3 (err 3.4e-4), tableau-accelerated 8th term within 1e-10 (err 1.5e-14); asserts the strict accuracy ordering raw < euler < accelerated.
- **ch3_stream_power_series.esk** (SICP 3.5.2 ex 3.59-3.61, 7 checks) — integrate-series, exp-series as its own integral, mutually-recursive sine/cosine series, mul-series. First 6 coefficients of exp/sin/cos verified exactly (as doubles, 1e-12); sin^2 + cos^2 = 1 + 0x + 0x^2 + ... over 6 coefficients; truncated exp-series at 1.0 within 1e-7 of e; sine series at pi/6 gives 0.5.
- **ch3_stream_signal_systems.esk** (SICP 3.5.3-3.5.4, 12 checks) — integral of a stream (ramp + integral-of-ramp hand-computed), RC circuit model ex 3.73 (R=5, C=1, dt=0.5, unit current, v0=1 -> 6.0, 6.5, 7.0, 7.5 hand-computed), zero-crossings ex 3.74 on the book's sense-data with the exact (0 0 0 0 0 -1 0 0 0 0 1 0 0) pattern, and the delayed-integral solve for dy/dt=y from y0=1: y(1) after 1000 steps at dt=0.001 within 1e-2 of e, with the exact iterated-Euler double 2.716923932235896 asserted at 1e-9. The delayed self-reference form (internal define + (delay dy) forward reference) works as-is; no explicit-generator fallback was needed.
- **ch3_stream_random_monte_carlo.esk** (SICP 3.5.5, 8 checks) — deterministic seeded Lehmer LCG (x' = 16807x mod 2147483647, seed 42) as a self-referential stream, first three draws asserted exactly; Cesaro coprimality trials via map-successive-pairs; monte-carlo as a stream of running ratios; pi estimate after N=2000 trials asserted to the exact reproducible double 3.1715415191530525 (1e-12) plus interval (3.10, 3.20).

## Notes

- Reuses the cons-stream/delay/force representation from tests/sicp/ch3_streams.esk; double literals throughout the numeric streams.
- No language gaps hit: top-level mutual recursion through delayed stream cdrs, internal-define self-referential streams, and the delay/force forward-reference solve all work in both -r and AOT.
- 36 checks total, zero FAIL: in both modes.