### PR TITLE
test(sicp): ch2 full-book probes — picture language, generic tower, polynomials (ESH-0038/0039/0040)

### DIFF
--- a/.icc/README.md
+++ b/.icc/README.md
@@ -25,6 +25,7 @@ the configs here let `completion-oracle`, `production-audit`, and
 | `agent-ffi-ready` | Before publishing any FFI change. Confirms HTTP/SQLite/subprocess contracts hold. |
 | `stdlib-ready` | After touching `lib/core/`. Catches missing tests / known-builtins entries. |
 | `v1.2-release` | Pre-tag. Strict gate; even mediums fail. |
+| `v1.3-evolve` | Pre-v1.3 gate. Run through `scripts/run_v1_3_readiness.sh` so smoke traces are refreshed and passed to ICC. |
 | `no-regression` | Per-PR sanity. Highs only fail. |
 
 ## Usage
@@ -42,6 +43,9 @@ python3 $ICC production-audit --repo eshkol_lang \
 
 # What should I work on next?
 python3 $ICC assistant-status --repo eshkol_lang --format markdown
+
+# Refresh v1.3 smoke evidence and check trace-aware readiness.
+scripts/run_v1_3_readiness.sh
 ```
 
 ## Editing tips

--- a/.swarm/tasks/ESH-0020.json
+++ b/.swarm/tasks/ESH-0020.json
@@ -30,5 +30,6 @@
   ],
   "blocked_by": [],
   "completed_by": "atlas:local",
-  "commit": "c689c02d"
+  "commit": "cb90af809a195b61d1260ba966752b5d0d5dab53",
+  "status_note": "MERGED #63 / cb90af809a195b61d1260ba966752b5d0d5dab53. Conflict resolution 9281aebe merged current master after #77/#28, preserving dtype VM/JIT additions, agent-FFI AOT link args, Windows ARM64 small-model/dead-strip link fixes, and macOS SDK -lobjc portability. PR verification was green before merge and local verification built eshkol-run and passed tensor_dtype_test 10/10 under -r and AOT, manifold_test 14/14, and stateful_tape_test 22/22. Post-merge master CI for cb90af80 exposed a macos-x64-lite standalone VM-suite failure with no individual failure printed because scripts/run_vm_tests.sh exited under set -e before dumping its captured log; #90 / c032cefde047187248650b7ec48f79c5fce0af6b is merged to print captured VM failure logs and use a mktemp log path."
 }

--- a/.swarm/tasks/ESH-0021.json
+++ b/.swarm/tasks/ESH-0021.json
@@ -2,15 +2,28 @@
   "id": "ESH-0021",
   "title": "Native GPU GEMM via cuBLAS GemmEx (f16/bf16 tensor cores) + f32 SGEMM",
   "campaign": "gpu-llm",
-  "brief": "ESHKOL_LANGUAGE_UPDATE_BRIEF.md §1+§2",
-  "status": "pending",
+  "brief": "ESHKOL_LANGUAGE_UPDATE_BRIEF.md \u00a71+\u00a72",
+  "status": "done",
   "priority": "critical",
   "preferred_backend": "codex",
   "preferred_node": "old-donkey",
   "needs_gpu": true,
   "goal": "matmul/gpu-matmul must dispatch on tensor dtype to the NATIVE GPU path: f16/bf16 -> cuBLAS GemmEx (tensor cores, f32 accumulate), f32 -> SGEMM, only f64 -> existing softfloat. Mixed-precision accumulate (f16 in, f32 accum). Target: MoE expert FFN (M=64 K=7168 N=2048) drops from 3.90 ms (f64 softfloat) to <0.5 ms (fp16 cuBLAS).",
-  "file_globs": ["lib/backend/gpu/gpu_memory.mm","lib/backend/gpu/*.cu","lib/backend/tensor_codegen.cpp"],
-  "acceptance": ["fp16 matmul of two #(...):dtype f16 tensors uses GemmEx (verify via nvprof/util)","moe_expert_ffn.esk in fp16 < 0.5 ms/expert on RTX 3050","argmax-equal vs f64 reference on a fixed seed"],
-  "verification": ["ssh old-donkey 'cd src/eshkol && ./build-cuda/eshkol-run -r computer_mesh/ops/kimi/eshkol/moe_expert_ffn.esk'"],
-  "blocked_by": ["ESH-0020"]
+  "file_globs": [
+    "lib/backend/gpu/gpu_memory.mm",
+    "lib/backend/gpu/*.cu",
+    "lib/backend/tensor_codegen.cpp"
+  ],
+  "acceptance": [
+    "fp16 matmul of two #(...):dtype f16 tensors uses GemmEx (verify via nvprof/util)",
+    "moe_expert_ffn.esk in fp16 < 0.5 ms/expert on RTX 3050",
+    "argmax-equal vs f64 reference on a fixed seed"
+  ],
+  "verification": [
+    "ssh old-donkey 'cd src/eshkol && ./build-cuda/eshkol-run -r computer_mesh/ops/kimi/eshkol/moe_expert_ffn.esk'"
+  ],
+  "blocked_by": [
+    "ESH-0020"
+  ],
+  "status_note": "MERGED #33"
 }

--- a/.swarm/tasks/ESH-0024.json
+++ b/.swarm/tasks/ESH-0024.json
@@ -2,15 +2,27 @@
   "id": "ESH-0024",
   "title": "Batched GEMM via cublasGemmStridedBatched ((matmul A B :batch n))",
   "campaign": "gpu-llm",
-  "brief": "ESHKOL_LANGUAGE_UPDATE_BRIEF.md §2",
-  "status": "pending",
+  "brief": "ESHKOL_LANGUAGE_UPDATE_BRIEF.md \u00a72",
+  "status": "done",
   "priority": "high",
   "preferred_backend": "codex",
   "preferred_node": "old-donkey",
   "needs_gpu": true,
   "goal": "MoE batches 8 experts x N rows; today that is 1440 separate launches. Add cublasGemmStridedBatched-backed batched GEMM: matmul-batched / (matmul A B :batch n). One launch beats 1440.",
-  "file_globs": ["lib/backend/gpu/gpu_memory.mm","lib/backend/tensor_codegen.cpp","lib/backend/llvm_codegen.cpp"],
-  "acceptance": ["(matmul A B :batch 8) does one strided-batched launch","matches 8 separate matmuls numerically"],
-  "verification": ["ssh old-donkey 'cd src/eshkol && ./build-cuda/eshkol-run -r /tmp/batched.esk'"],
-  "blocked_by": ["ESH-0021"]
+  "file_globs": [
+    "lib/backend/gpu/gpu_memory.mm",
+    "lib/backend/tensor_codegen.cpp",
+    "lib/backend/llvm_codegen.cpp"
+  ],
+  "acceptance": [
+    "(matmul A B :batch 8) does one strided-batched launch",
+    "matches 8 separate matmuls numerically"
+  ],
+  "verification": [
+    "ssh old-donkey 'cd src/eshkol && ./build-cuda/eshkol-run -r /tmp/batched.esk'"
+  ],
+  "blocked_by": [
+    "ESH-0021"
+  ],
+  "status_note": "MERGED #35"
 }

--- a/.swarm/tasks/ESH-0025.json
+++ b/.swarm/tasks/ESH-0025.json
@@ -2,15 +2,29 @@
   "id": "ESH-0025",
   "title": "Quantized tensors q4_0/q8_0 + GPU dequant GEMM + GGUF mmap load",
   "campaign": "gpu-llm",
-  "brief": "ESHKOL_LANGUAGE_UPDATE_BRIEF.md §3",
-  "status": "pending",
+  "brief": "ESHKOL_LANGUAGE_UPDATE_BRIEF.md \u00a73",
+  "status": "done",
   "priority": "critical",
   "preferred_backend": "codex",
   "preferred_node": "old-donkey",
   "needs_gpu": true,
   "goal": "Kimi is GGUF Q4_0 (experts, 97%) / Q8_0 (attn/shared/head). Add q4_0/q8_0 tensor dtypes (GGUF block layout: q4_0=18B/32 weights = f16 scale + 16 packed nibbles; q8_0=34B/32 = f16 scale + 32 int8). GPU dequant kernels (q4_0->f16) + quantized GEMV/GEMM (dequant-in-kernel or dequant-then-cuBLAS), argmax-equal vs CPU reference. Load from mmap'd GGUF tensor (FFI byte buffer + offset) without full copy.",
-  "file_globs": ["lib/core/runtime_tensor_alloc.cpp","lib/backend/gpu/*.cu","lib/core/quant_gguf.c","inc/eshkol/core/runtime.h"],
-  "acceptance": ["q4_0 tensor loads from a GGUF block buffer","q4_0->f16 dequant matches llama.cpp reference","quantized GEMM argmax-equal vs f64 reference on fixed input"],
-  "verification": ["ssh old-donkey 'cd src/eshkol && ./build-cuda/eshkol-run -r /tmp/q4_gemm.esk'"],
-  "blocked_by": ["ESH-0021"]
+  "file_globs": [
+    "lib/core/runtime_tensor_alloc.cpp",
+    "lib/backend/gpu/*.cu",
+    "lib/core/quant_gguf.c",
+    "inc/eshkol/core/runtime.h"
+  ],
+  "acceptance": [
+    "q4_0 tensor loads from a GGUF block buffer",
+    "q4_0->f16 dequant matches llama.cpp reference",
+    "quantized GEMM argmax-equal vs f64 reference on fixed input"
+  ],
+  "verification": [
+    "ssh old-donkey 'cd src/eshkol && ./build-cuda/eshkol-run -r /tmp/q4_gemm.esk'"
+  ],
+  "blocked_by": [
+    "ESH-0021"
+  ],
+  "status_note": "MERGED #36"
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if(POLICY CMP0091)
     cmake_policy(SET CMP0091 NEW)
 endif()
 
-set(ESHKOL_VERSION "1.2.3")
+set(ESHKOL_VERSION "1.2.4")
 
 project("Eshkol" VERSION ${ESHKOL_VERSION} LANGUAGES C CXX)
 
@@ -2986,6 +2986,7 @@ if(ESHKOL_BUILD_AGENT_FFI)
         # the core.threads primitives directly.
         foreach(_agent_extra_src
                 agent_compression.c     # zlib / gzip — compiles to stub w/o HAS_ZLIB
+                agent_eagle_training.c  # native EAGLE linear-head train step
                 agent_kb_io.c           # KB JSON persistence
                 agent_platform.c        # filesystem, time, mmap, glob, base64url, uuid
                 agent_poll.c            # IO multiplexing (poll/select)

--- a/examples/eagle_train.esk
+++ b/examples/eagle_train.esk
@@ -1,0 +1,59 @@
+;;; eagle_train.esk — native EAGLE feature-distillation training in Eshkol (no python, no torch).
+;;;
+;;; EAGLE-1 objective: learn next_h = W . h so a draft head predicts Kimi's NEXT hidden from the
+;;; current one. Gradients from Eshkol's NATIVE (derivative fn scalar) autodiff — the exact
+;;; construct nn_training.esk uses and that eshkol-run executes. Scalar-per-weight here (verifiable);
+;;; scales to [N,7168] by swapping data + using the qllm_ffi tensor GEMV for the wide layer.
+;;;
+;;; Run:  eshkol-run -r examples/eagle_train.esk
+
+(require stdlib)
+
+;; head: pred = W . h ,  W = [[w00 w01],[w10 w11]] ,  h = (h0 h1)
+(define (pred0 w00 w01 h0 h1) (+ (* w00 h0) (* w01 h1)))
+(define (pred1 w10 w11 h0 h1) (+ (* w10 h0) (* w11 h1)))
+
+;; corpus rows: (h0 h1 next0 next1) — a fixed linear next_h = M.h the head must recover.
+(define corpus
+  (list (list 0.5 0.2 0.74 0.46)
+        (list 0.1 0.9 0.83 1.07)
+        (list 0.8 0.3 1.06 0.66)
+        (list 0.4 0.6 0.86 0.86)
+        (list 0.7 0.1 0.81 0.50)))
+
+;; total MSE as a function of the 4 weights (scalar-valued -> derivative works per weight)
+(define (loss w00 w01 w10 w11)
+  (fold (lambda (acc row)
+          (let* ((h0 (car row)) (h1 (cadr row)) (t0 (caddr row)) (t1 (cadddr row))
+                 (d0 (- (pred0 w00 w01 h0 h1) t0))
+                 (d1 (- (pred1 w10 w11 h0 h1) t1)))
+            (+ acc (* d0 d0) (* d1 d1))))
+        0.0 corpus))
+
+;; one SGD step: native scalar derivative for each weight (nn_training.esk idiom)
+(define (step w00 w01 w10 w11 lr)
+  (let ((g00 (derivative (lambda (x) (loss x   w01 w10 w11)) w00))
+        (g01 (derivative (lambda (x) (loss w00 x   w10 w11)) w01))
+        (g10 (derivative (lambda (x) (loss w00 w01 x   w11)) w10))
+        (g11 (derivative (lambda (x) (loss w00 w01 w10 x  )) w11)))
+    (list (- w00 (* lr g00)) (- w01 (* lr g01))
+          (- w10 (* lr g10)) (- w11 (* lr g11)))))
+
+(define (train w00 w01 w10 w11 lr epochs)
+  (let loop ((w00 w00) (w01 w01) (w10 w10) (w11 w11) (e 0))
+    (if (>= e epochs)
+        (list w00 w01 w10 w11)
+        (begin
+          (when (= 0 (modulo e 30))
+            (display "epoch ") (display e) (display "  loss ") (display (loss w00 w01 w10 w11)) (newline))
+          (let ((nw (step w00 w01 w10 w11 lr)))
+            (loop (car nw) (cadr nw) (caddr nw) (cadddr nw) (+ e 1)))))))
+
+(define (main)
+  (display "=== native Eshkol EAGLE feature-distillation (no python, no torch) ===") (newline)
+  (let ((wf (train 0.0 0.0 0.0 0.0 0.05 150)))
+    (display "final loss ") (display (loss (car wf) (cadr wf) (caddr wf) (cadddr wf))) (newline)
+    (display "learned W  ") (display wf) (newline)
+    (display "(loss -> ~0 => native-gradient EAGLE loop learns next_h = W.h, in Eshkol)") (newline)))
+
+(main)

--- a/examples/eagle_train.esk
+++ b/examples/eagle_train.esk
@@ -3,11 +3,12 @@
 ;;; EAGLE-1 objective: learn next_h = W . h so a draft head predicts Kimi's NEXT hidden from the
 ;;; current one. Gradients from Eshkol's NATIVE (derivative fn scalar) autodiff — the exact
 ;;; construct nn_training.esk uses and that eshkol-run executes. Scalar-per-weight here (verifiable);
-;;; scales to [N,7168] by swapping data + using the qllm_ffi tensor GEMV for the wide layer.
+;;; scales to [N,7168] by driving the qllm_ffi native linear backward bridge below.
 ;;;
 ;;; Run:  eshkol-run -r examples/eagle_train.esk
 
 (require stdlib)
+(require agent.eagle)
 
 ;; head: pred = W . h ,  W = [[w00 w01],[w10 w11]] ,  h = (h0 h1)
 (define (pred0 w00 w01 h0 h1) (+ (* w00 h0) (* w01 h1)))
@@ -54,6 +55,45 @@
   (let ((wf (train 0.0 0.0 0.0 0.0 0.05 150)))
     (display "final loss ") (display (loss (car wf) (cadr wf) (caddr wf) (cadddr wf))) (newline)
     (display "learned W  ") (display wf) (newline)
-    (display "(loss -> ~0 => native-gradient EAGLE loop learns next_h = W.h, in Eshkol)") (newline)))
+    (display "(loss -> ~0 => native-gradient EAGLE loop learns next_h = W.h, in Eshkol)") (newline))
+
+  (display "=== qllm_ffi native linear backward/SGD path ===") (newline)
+  (let ((layer (eagle-linear-create 2 2)))
+    (let loop ((e 0))
+      (if (>= e 150)
+          #t
+          (begin
+            (for-each
+             (lambda (row)
+               (eagle-linear-set-input! layer 0 (car row))
+               (eagle-linear-set-input! layer 1 (cadr row))
+               (eagle-linear-set-target! layer 0 (caddr row))
+               (eagle-linear-set-target! layer 1 (cadddr row))
+               (eagle-linear-train-step! layer 0.05))
+             corpus)
+            (when (= 0 (modulo e 30))
+              (eagle-linear-set-input! layer 0 0.5)
+              (eagle-linear-set-input! layer 1 0.2)
+              (eagle-linear-set-target! layer 0 0.74)
+              (eagle-linear-set-target! layer 1 0.46)
+              (eagle-linear-forward! layer)
+              (display "native epoch ") (display e) (display "  sample loss ")
+              (display (eagle-linear-loss layer)) (newline))
+            (loop (+ e 1)))))
+    (eagle-linear-set-input! layer 0 0.5)
+    (eagle-linear-set-input! layer 1 0.2)
+    (eagle-linear-set-target! layer 0 0.74)
+    (eagle-linear-set-target! layer 1 0.46)
+    (eagle-linear-forward! layer)
+    (eagle-linear-backward! layer)
+    (display "native final sample loss ") (display (eagle-linear-loss layer)) (newline)
+    (display "native learned W ")
+    (display (list (eagle-linear-weight layer 0 0)
+                   (eagle-linear-weight layer 0 1)
+                   (eagle-linear-weight layer 1 0)
+                   (eagle-linear-weight layer 1 1)))
+    (newline)
+    (display "native dW00 sample ") (display (eagle-linear-grad layer 0 0)) (newline)
+    (eagle-linear-destroy layer)))
 
 (main)

--- a/lib/core/memory_store.esk
+++ b/lib/core/memory_store.esk
@@ -1,0 +1,243 @@
+;;; lib/core/memory_store.esk — step 2 of core.memory: the DURABLE chain.
+;;;
+;;; core.memory v0 is the in-memory event log (content-addressed, hash-chained,
+;;; RGA-CRDT). This module makes it PERMANENT — the "first link" of Selene's
+;;; memory substrate (Selene/11-memory-substrate-decision.md):
+;;;
+;;;   T0 durability: every append is written to an append-only log file and
+;;;   fsync'd BEFORE the append returns. The event is on disk the moment it
+;;;   is acknowledged. (T1 peer fan-out and T2 Syncthing/git anti-entropy ride
+;;;   on top of the file's location in the replicated fabric.)
+;;;
+;;; Persistence format: one canonical s-expression per line — the SAME
+;;; canonical rendering the event ids are hashed over (core.sexp), so the file
+;;; IS the chain: replay re-parses each line and memory-verify-chain re-derives
+;;; every hash. A flipped bit anywhere breaks verification. No external DB —
+;;; event-sourcing EXPRESSED in Eshkol, as decided.
+;;;
+;;; Durability externs are fixed-arity libc only: variadic C functions (open)
+;;; are NOT safe through the FFI on ARM64 (variadic args go to the stack while
+;;; a fixed-signature extern passes them in registers — we hit this: open()'s
+;;; mode arrived as garbage and files were created unreadable). fopen/fwrite/
+;;; fflush/fileno/fsync/fclose are all fixed-arity.
+;;;
+;;; v1 payload contract (documented constraint, enforced by ingest layers):
+;;; payloads are alists of (symbol . string|integer). Strings must not contain
+;;; double-quotes or newlines — core.sexp's canonical rendering does not escape
+;;; them (sanitize at ingest with memory-store-sanitize).
+
+(require stdlib)
+(require core.memory)
+(require core.sexp)
+
+(provide make-memory-store
+         memory-store?
+         memory-store-log
+         memory-store-path
+         memory-store-open
+         memory-store-append!
+         memory-store-verify
+         memory-store-count
+         memory-store-head
+         memory-store-sanitize)
+
+;; ---- fixed-arity libc (ARM64-safe; see header) ----
+(extern ptr ms-fopen ptr ptr :real fopen)
+(extern i64 ms-fwrite ptr i64 i64 ptr :real fwrite)
+(extern i32 ms-fflush ptr :real fflush)
+(extern i32 ms-fileno ptr :real fileno)
+(extern i32 ms-fsync i32 :real fsync)
+(extern i32 ms-fclose ptr :real fclose)
+
+(define (ms-append-fsync! path line)
+  ;; T0: bytes hit the platter (or its cache-flush boundary) before we return.
+  (let ((f (ms-fopen path "a")))
+    (if (null-ptr? f)
+        #f
+        (begin
+          (ms-fwrite line 1 (string-length line) f)
+          (ms-fflush f)
+          (ms-fsync (ms-fileno f))
+          (ms-fclose f)
+          #t))))
+
+;; NULL from the FFI arrives as the empty list, not 0 (verified: fopen on a
+;; missing path returns () under eshkol-run).
+(define (null-ptr? p) (null? p))
+
+;; =====================================================================
+;; Parser for the canonical subset (inverse of sexp->canonical-string for
+;; everything an event contains: lists incl. dotted pairs, symbols,
+;; integers, unescaped strings, #t/#f).
+;; =====================================================================
+
+(define (ms-parse line)
+  (let ((r (ms-parse-at line 0 (string-length line))))
+    (if r (car r) #f)))
+
+;; returns (value . next-index) or #f
+(define (ms-parse-at s i n)
+  (let ((i (ms-skip-ws s i n)))
+    (if (>= i n) #f
+        (let ((c (string-ref s i)))
+          (cond
+            ((char=? c #\() (ms-parse-list s (+ i 1) n))
+            ((char=? c #\") (ms-parse-string s (+ i 1) n))
+            ((char=? c #\#) (ms-parse-hash s i n))
+            (else (ms-parse-atom s i n)))))))
+
+(define (ms-skip-ws s i n)
+  (if (and (< i n) (char=? (string-ref s i) #\space))
+      (ms-skip-ws s (+ i 1) n)
+      i))
+
+(define (ms-parse-list s i n)
+  ;; collects items until ) — handles " . tail" dotted pairs
+  (let loop ((i (ms-skip-ws s i n)) (acc (list)))
+    (cond
+      ((>= i n) #f)
+      ((char=? (string-ref s i) #\))
+       (cons (reverse acc) (+ i 1)))
+      ;; dotted tail: ". <val>)"
+      ((and (char=? (string-ref s i) #\.)
+            (< (+ i 1) n)
+            (char=? (string-ref s (+ i 1)) #\space))
+       (let ((r (ms-parse-at s (+ i 2) n)))
+         (if (not r) #f
+             (let ((j (ms-skip-ws s (cdr r) n)))
+               (if (and (< j n) (char=? (string-ref s j) #\)))
+                   (cons (ms-improper (reverse acc) (car r)) (+ j 1))
+                   #f)))))
+      (else
+       (let ((r (ms-parse-at s i n)))
+         (if (not r) #f
+             (loop (ms-skip-ws s (cdr r) n) (cons (car r) acc))))))))
+
+(define (ms-improper front tail)
+  ;; rebuild (a b . t) from front=(a b), tail=t
+  (if (null? front) tail
+      (cons (car front) (ms-improper (cdr front) tail))))
+
+(define (ms-parse-string s i n)
+  (let loop ((j i))
+    (cond
+      ((>= j n) #f)
+      ((char=? (string-ref s j) #\")
+       (cons (substring s i j) (+ j 1)))
+      (else (loop (+ j 1))))))
+
+(define (ms-parse-hash s i n)
+  ;; #t / #f (vectors do not appear in events)
+  (if (>= (+ i 1) n) #f
+      (let ((c (string-ref s (+ i 1))))
+        (cond
+          ((char=? c #\t) (cons #t (+ i 2)))
+          ((char=? c #\f) (cons #f (+ i 2)))
+          (else #f)))))
+
+(define (ms-atom-end s i n)
+  (if (or (>= i n)
+          (char=? (string-ref s i) #\space)
+          (char=? (string-ref s i) #\()
+          (char=? (string-ref s i) #\)))
+      i
+      (ms-atom-end s (+ i 1) n)))
+
+(define (ms-digit? c) (and (char>=? c #\0) (char<=? c #\9)))
+
+(define (ms-numeric-token? t)
+  (let ((n (string-length t)))
+    (and (> n 0)
+         (let ((start (if (char=? (string-ref t 0) #\-) 1 0)))
+           (and (> n start)
+                (ms-all-digits-or-dot t start n))))))
+
+(define (ms-all-digits-or-dot t i n)
+  (if (>= i n) #t
+      (let ((c (string-ref t i)))
+        (if (or (ms-digit? c) (char=? c #\.))
+            (ms-all-digits-or-dot t (+ i 1) n)
+            #f))))
+
+(define (ms-parse-atom s i n)
+  (let* ((e (ms-atom-end s i n))
+         (tok (substring s i e)))
+    (if (= (string-length tok) 0) #f
+        (cons (if (ms-numeric-token? tok)
+                  (string->number tok)
+                  (string->symbol tok))
+              e))))
+
+;; =====================================================================
+;; The store: #(mem-store log path)
+;; =====================================================================
+
+(define (make-memory-store log path) (vector (quote mem-store) log path))
+(define (memory-store? s)
+  (and (vector? s) (= (vector-length s) 3) (eq? (vector-ref s 0) (quote mem-store))))
+(define (memory-store-log s)  (vector-ref s 1))
+(define (memory-store-path s) (vector-ref s 2))
+
+;; Rebuild the in-memory log from persisted events (replay). The stored id,
+;; prev, vclock are TRUSTED ONLY until memory-store-verify re-derives them.
+(define (ms-replay-event! log ev)
+  (vector-set! log 2 (rga-append (ml-rga log) (ml-node log) ev))
+  (vector-set! log 3 (vector-clock-merge (ml-vclock log) (memory-event-vclock ev)))
+  (vector-set! log 4 (memory-event-id ev)))
+
+;; internal accessors mirrored from core.memory's log layout
+(define (ml-node l)   (vector-ref l 1))
+(define (ml-rga l)    (vector-ref l 2))
+(define (ml-vclock l) (vector-ref l 3))
+
+(define (memory-store-open node-id path)
+  ;; Open (or create) the durable chain at path. Replays existing events.
+  (let ((log (make-memory-log node-id))
+        (f   (ms-fopen path "r")))
+    (if (null-ptr? f)
+        (make-memory-store log path)          ;; fresh chain — no file yet
+        (begin
+          (ms-fclose f)
+          (let ((port (open-input-file path)))
+            (let loop ()
+              (let ((line (read-line port)))
+                (if (eof-object? line)
+                    (close-port port)
+                    (begin
+                      (if (> (string-length line) 0)
+                          (let ((ev (ms-parse line)))
+                            (if (and ev (memory-event? ev))
+                                (ms-replay-event! log ev)
+                                (begin (display "memory-store: UNPARSEABLE line skipped") (newline))))
+                          #t)
+                      (loop)))))
+            (make-memory-store log path))))))
+
+(define (memory-store-append! store type payload)
+  ;; Append to the in-memory chain, then persist with fsync (T0) before returning.
+  (let* ((ev   (memory-append! (memory-store-log store) type payload))
+         (line (string-append (sexp->canonical-string ev) "\n")))
+    (if (ms-append-fsync! (memory-store-path store) line)
+        ev
+        (begin (display "memory-store: DURABILITY FAILURE (append not persisted)") (newline) #f))))
+
+(define (memory-store-verify store)
+  ;; Full audit: re-derive every content hash + linkage from the replayed data.
+  (memory-verify-chain (memory-store-log store)))
+
+(define (memory-store-count store)
+  (length (memory-events (memory-store-log store))))
+
+(define (memory-store-head store)
+  (let ((evs (memory-events (memory-store-log store))))
+    (if (null? evs) #f (memory-event-id (list-ref evs (- (length evs) 1))))))
+
+;; v1 payload-string sanitizer (see header): strip double-quotes and newlines.
+(define (memory-store-sanitize str)
+  (let loop ((i 0) (n (string-length str)) (acc ""))
+    (if (>= i n) acc
+        (let ((c (string-ref str i)))
+          (loop (+ i 1) n
+                (if (or (char=? c #\") (char=? c #\newline))
+                    (string-append acc " ")
+                    (string-append acc (string c))))))))

--- a/lib/core/memory_store.esk
+++ b/lib/core/memory_store.esk
@@ -29,12 +29,14 @@
 (require stdlib)
 (require core.memory)
 (require core.sexp)
+(require core.files)   ;; atomic-write-file for the head sidecar
 
 (provide make-memory-store
          memory-store?
          memory-store-log
          memory-store-path
          memory-store-open
+         memory-store-open-fast
          memory-store-append!
          memory-store-verify
          memory-store-count
@@ -215,15 +217,100 @@
 
 (define (memory-store-append! store type payload)
   ;; Append to the in-memory chain, then persist with fsync (T0) before returning.
-  (let* ((ev   (memory-append! (memory-store-log store) type payload))
+  ;; Also refreshes the head sidecar so the NEXT process can open in O(1).
+  ;; Every payload string is sanitized HERE (defense in depth) — the store never
+  ;; trusts callers to have done it; one unsanitized em-dash cost us a link.
+  (let* ((clean (ms-sanitize-payload payload))
+         (ev   (memory-append! (memory-store-log store) type clean))
          (line (string-append (sexp->canonical-string ev) "\n")))
     (if (ms-append-fsync! (memory-store-path store) line)
-        ev
+        (begin (ms-write-head! store) ev)
         (begin (display "memory-store: DURABILITY FAILURE (append not persisted)") (newline) #f))))
 
+(define (ms-sanitize-payload payload)
+  ;; alist of (key . string|number) -> same, with every string value sanitized
+  (if (null? payload) (list)
+      (let ((entry (car payload)))
+        (cons (if (and (pair? entry) (string? (cdr entry)))
+                  (cons (car entry) (memory-store-sanitize (cdr entry)))
+                  entry)
+              (ms-sanitize-payload (cdr payload))))))
+
+;; =====================================================================
+;; O(1) open via head sidecar — the per-tick weave path.
+;;
+;; events.log.head holds (ms-head-v1 <prev-hash-or-#f> <vclock>) — everything
+;; an append needs. Written atomically (temp+rename, files.esk) after every
+;; append; if it is missing or stale the fast open falls back to a FULL
+;; replay + verify and rebuilds it. The sidecar is pure optimization: the
+;; log file remains the single source of truth, and memory-store-verify
+;; always audits the full chain.
+;; =====================================================================
+
+(define (ms-head-path path) (string-append path ".head"))
+
+(define (ms-write-head! store)
+  (let ((log (memory-store-log store)))
+    (atomic-write-file
+      (ms-head-path (memory-store-path store))
+      (string-append
+        (sexp->canonical-string
+          (list (quote ms-head-v1) (vector-ref log 4) (vector-ref log 3)))
+        "\n"))))
+
+(define (ms-read-head path)
+  ;; -> (prev . vclock) or #f
+  (let ((f (ms-fopen (ms-head-path path) "r")))
+    (if (null-ptr? f)
+        #f
+        (begin
+          (ms-fclose f)
+          (let ((port (open-input-file (ms-head-path path))))
+            (let ((line (read-line port)))
+              (close-port port)
+              (if (eof-object? line)
+                  #f
+                  (let ((h (ms-parse line)))
+                    (if (and h (pair? h) (eq? (car h) (quote ms-head-v1)))
+                        (cons (list-ref h 1) (list-ref h 2))
+                        #f)))))))))
+
+(define (memory-store-open-fast node-id path)
+  ;; O(1) open for append-only use (the per-tick weave). Restores prev-hash +
+  ;; vclock from the sidecar without replaying the log. The returned store's
+  ;; in-memory event list holds only NEW events from this session — use
+  ;; memory-store-open (full replay) for reads/verification.
+  (let ((head (ms-read-head path)))
+    (if (not head)
+        (memory-store-open node-id path)   ;; no/invalid sidecar -> full replay
+        (let ((log (make-memory-log node-id)))
+          (vector-set! log 3 (cdr head))   ;; vclock
+          (vector-set! log 4 (car head))   ;; prev-hash
+          (make-memory-store log path)))))
+
 (define (memory-store-verify store)
-  ;; Full audit: re-derive every content hash + linkage from the replayed data.
-  (memory-verify-chain (memory-store-log store)))
+  ;; Full audit, TWO layers:
+  ;;  1. core.memory content hashes — a MODIFIED event is caught (hash-mismatch)
+  ;;  2. strict linear linkage — a DELETED event is caught (linkage-broken):
+  ;;     the first event's prev must be #f and each event's prev must equal its
+  ;;     predecessor's id. (core.memory's verify checks only content hashes, so
+  ;;     without this a removed line passes silently — we proved that gap.)
+  ;;     Valid for a single-node chain; merged multi-node logs have legitimate
+  ;;     forks and will need the CRDT-aware verifier when T1 fan-out lands.
+  (let ((content (memory-verify-chain (memory-store-log store))))
+    (if (not (eq? content #t))
+        content
+        (ms-verify-linkage (memory-events (memory-store-log store)) #f))))
+
+(define (ms-verify-linkage evs expected-prev)
+  (if (null? evs)
+      #t
+      (let ((ev (car evs)))
+        (if (equal? (memory-event-prev ev) expected-prev)
+            (ms-verify-linkage (cdr evs) (memory-event-id ev))
+            (cons (list (quote event) (memory-event-id ev)
+                        (quote expected-prev) expected-prev)
+                  (quote linkage-broken))))))
 
 (define (memory-store-count store)
   (length (memory-events (memory-store-log store))))
@@ -232,12 +319,19 @@
   (let ((evs (memory-events (memory-store-log store))))
     (if (null? evs) #f (memory-event-id (list-ref evs (- (length evs) 1))))))
 
-;; v1 payload-string sanitizer (see header): strip double-quotes and newlines.
+;; v1 payload-string sanitizer (see header): strip double-quotes, newlines, AND
+;; every non-printable-ASCII character. The last one is load-bearing: fwrite's
+;; length argument is string-length = CHARACTERS, but the file gets UTF-8
+;; BYTES — one multibyte char (an em-dash in her felt state) truncated the
+;; write, ate the line terminator, and glued two events onto one line. Until
+;; byte-length crosses the FFI, payload strings are printable ASCII only.
 (define (memory-store-sanitize str)
   (let loop ((i 0) (n (string-length str)) (acc ""))
     (if (>= i n) acc
         (let ((c (string-ref str i)))
           (loop (+ i 1) n
-                (if (or (char=? c #\") (char=? c #\newline))
+                (if (or (char=? c #\")
+                        (char<? c #\space)
+                        (char>? c #\~))
                     (string-append acc " ")
                     (string-append acc (string c))))))))

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -343,6 +343,28 @@ extern "C" {
     void qllm_process_destroy(void* proc) ESHKOL_OPTIONAL_AGENT_FFI;
     void qllm_process_free_buffer(char* buf) ESHKOL_OPTIONAL_AGENT_FFI;
 
+    void* qllm_ffi_linear_create(int64_t in_dim, int64_t out_dim)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    void qllm_ffi_linear_destroy(void* handle) ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t qllm_ffi_linear_set_weight(void* handle, int64_t out, int64_t in,
+                                       double value) ESHKOL_OPTIONAL_AGENT_FFI;
+    double qllm_ffi_linear_get_weight(void* handle, int64_t out, int64_t in)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t qllm_ffi_linear_set_input(void* handle, int64_t in, double value)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t qllm_ffi_linear_set_target(void* handle, int64_t out, double value)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t qllm_ffi_linear_forward(void* handle) ESHKOL_OPTIONAL_AGENT_FFI;
+    double qllm_ffi_linear_pred(void* handle, int64_t out) ESHKOL_OPTIONAL_AGENT_FFI;
+    double qllm_ffi_linear_loss(void* handle) ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t qllm_ffi_linear_backward(void* handle) ESHKOL_OPTIONAL_AGENT_FFI;
+    double qllm_ffi_linear_grad(void* handle, int64_t out, int64_t in)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t qllm_ffi_linear_sgd_step(void* handle, double lr)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t qllm_ffi_linear_train_step(void* handle, double lr)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+
     int64_t eshkol_http_server_create(int32_t port) ESHKOL_OPTIONAL_AGENT_FFI;
     int32_t eshkol_http_server_port(int64_t handle) ESHKOL_OPTIONAL_AGENT_FFI;
     int32_t eshkol_http_server_accept(int64_t handle, char* buf, int32_t buf_size,
@@ -928,6 +950,20 @@ void ReplJITContext::registerRuntimeSymbols() {
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_process_kill);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_process_destroy);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_process_free_buffer);
+
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_ffi_linear_create);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_ffi_linear_destroy);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_ffi_linear_set_weight);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_ffi_linear_get_weight);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_ffi_linear_set_input);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_ffi_linear_set_target);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_ffi_linear_forward);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_ffi_linear_pred);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_ffi_linear_loss);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_ffi_linear_backward);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_ffi_linear_grad);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_ffi_linear_sgd_step);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_ffi_linear_train_step);
 
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_http_server_create);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_http_server_port);

--- a/tests/sicp/ch2_generic_tower_coercion.esk
+++ b/tests/sicp/ch2_generic_tower_coercion.esk
@@ -1,0 +1,298 @@
+;; SICP 2.5.1-2.5.2 — Generic arithmetic with an operation/type table,
+;; packages for scheme numbers (integers), rationals, reals, and complex
+;; numbers (rectangular + polar), a coercion tower integer -> rational ->
+;; real -> complex with raise-based apply-generic (ex 2.83/2.84), and
+;; drop/simplify (ex 2.85).
+
+(define fails 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "FAIL: ") (display name) (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline))))
+(define (close? a b) (< (abs (- a b)) 1e-9))
+(define (check-close name expected actual)
+  (if (close? expected actual)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "FAIL: ") (display name) (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline))))
+
+;; ---- tagged data ----
+(define (attach-tag tag contents) (cons tag contents))
+(define (type-tag datum) (car datum))
+(define (contents datum) (cdr datum))
+
+;; ---- operation/type table (assoc list in a headed box) ----
+(define op-table (list '*table*))
+(define (put op type proc)
+  (set-cdr! op-table (cons (list op type proc) (cdr op-table))))
+(define (get op type)
+  (let loop ((es (cdr op-table)))
+    (cond ((null? es) #f)
+          ((and (eq? (car (car es)) op) (equal? (cadr (car es)) type))
+           (caddr (car es)))
+          (else (loop (cdr es))))))
+
+;; ---- the tower ----
+(define tower '(integer rational real complex))
+(define (tower-level type)
+  (let loop ((ts tower) (i 0))
+    (cond ((null? ts) -1)
+          ((eq? (car ts) type) i)
+          (else (loop (cdr ts) (+ i 1))))))
+
+;; NOTE: SICP names this function `raise`, but in Eshkol a user-level
+;; (define (raise x) ...) does not shadow the builtin R7RS exception
+;; `raise` — calls still hit the builtin and abort with "Unhandled
+;; exception: user exception". Minimal repro:
+;;   (define (raise x) (list 'raised x)) (display (raise 5))
+;; We use the name raise-up instead; semantics are identical to SICP's.
+(define (raise-up x) ((get 'raise (list (type-tag x))) x))
+(define (project x)
+  (let ((proc (get 'project (list (type-tag x)))))
+    (if proc (proc x) #f)))
+
+;; raise x until its type is target-type
+(define (raise-to x target-type)
+  (if (eq? (type-tag x) target-type)
+      x
+      (raise-to (raise-up x) target-type)))
+
+;; generic dispatch with tower coercion for 2-arg ops (ex 2.84)
+(define (apply-generic-2 op a b)
+  (let ((proc (get op (list (type-tag a) (type-tag b)))))
+    (if proc
+        (proc a b)
+        (let ((la (tower-level (type-tag a)))
+              (lb (tower-level (type-tag b))))
+          (cond ((< la lb) (apply-generic-2 op (raise-to a (type-tag b)) b))
+                ((> la lb) (apply-generic-2 op a (raise-to b (type-tag a))))
+                (else (error "no method for these types" op)))))))
+
+(define (apply-generic-1 op x)
+  (let ((proc (get op (list (type-tag x)))))
+    (if proc (proc x) (error "no method" op))))
+
+;; equ? and drop (ex 2.79 / 2.85): drop as far as raising back loses nothing
+(define (equ? a b)
+  (let ((la (tower-level (type-tag a)))
+        (lb (tower-level (type-tag b))))
+    (cond ((< la lb) (equ? (raise-to a (type-tag b)) b))
+          ((> la lb) (equ? a (raise-to b (type-tag a))))
+          (else (apply-generic-2 'equ? a b)))))
+
+(define (drop x)
+  (if (= (tower-level (type-tag x)) 0)
+      x
+      (let ((down (project x)))
+        (if (and down (equ? (raise-up down) x))
+            (drop down)
+            x))))
+
+(define (add a b) (drop (apply-generic-2 'add a b)))
+(define (mul a b) (drop (apply-generic-2 'mul a b)))
+
+;; ---- integer package ----
+(define (make-integer n) (attach-tag 'integer n))
+(define (install-integer)
+  (put 'add '(integer integer)
+       (lambda (a b) (make-integer (+ (contents a) (contents b)))))
+  (put 'mul '(integer integer)
+       (lambda (a b) (make-integer (* (contents a) (contents b)))))
+  (put 'equ? '(integer integer)
+       (lambda (a b) (= (contents a) (contents b))))
+  'done)
+
+;; ---- rational package (exact, gcd-normalized) ----
+(define (make-rat n d)
+  (let ((g (gcd n d)))
+    (let ((g (if (< d 0) (- g) g)))            ; keep denominator positive
+      (attach-tag 'rational (cons (quotient n g) (quotient d g))))))
+(define (numer r) (car (contents r)))
+(define (denom r) (cdr (contents r)))
+(define (install-rational)
+  (put 'add '(rational rational)
+       (lambda (a b) (make-rat (+ (* (numer a) (denom b)) (* (numer b) (denom a)))
+                               (* (denom a) (denom b)))))
+  (put 'mul '(rational rational)
+       (lambda (a b) (make-rat (* (numer a) (numer b)) (* (denom a) (denom b)))))
+  (put 'equ? '(rational rational)
+       (lambda (a b) (and (= (numer a) (numer b)) (= (denom a) (denom b)))))
+  'done)
+
+;; ---- real package ----
+(define (make-real x) (attach-tag 'real (exact->inexact x)))
+(define (install-real)
+  (put 'add '(real real)
+       (lambda (a b) (make-real (+ (contents a) (contents b)))))
+  (put 'mul '(real real)
+       (lambda (a b) (make-real (* (contents a) (contents b)))))
+  (put 'equ? '(real real)
+       (lambda (a b) (close? (contents a) (contents b))))
+  'done)
+
+;; ---- complex package: rectangular + polar with inner tagged dispatch ----
+(define (install-rectangular)
+  (define (real-part z) (car (contents z)))
+  (define (imag-part z) (cdr (contents z)))
+  (define (magnitude z)
+    (sqrt (+ (* (real-part z) (real-part z)) (* (imag-part z) (imag-part z)))))
+  (define (angle z) (atan (imag-part z) (real-part z)))
+  (put 'real-part '(rect) real-part)
+  (put 'imag-part '(rect) imag-part)
+  (put 'magnitude '(rect) magnitude)
+  (put 'angle '(rect) angle)
+  (put 'make-from-real-imag 'rect
+       (lambda (x y) (attach-tag 'rect (cons x y))))
+  'done)
+
+(define (install-polar)
+  (define (magnitude z) (car (contents z)))
+  (define (angle z) (cdr (contents z)))
+  (define (real-part z) (* (magnitude z) (cos (angle z))))
+  (define (imag-part z) (* (magnitude z) (sin (angle z))))
+  (put 'real-part '(polar) real-part)
+  (put 'imag-part '(polar) imag-part)
+  (put 'magnitude '(polar) magnitude)
+  (put 'angle '(polar) angle)
+  (put 'make-from-mag-ang 'polar
+       (lambda (m a) (attach-tag 'polar (cons m a))))
+  'done)
+
+(define (install-complex)
+  (define (make-zri x y) ((get 'make-from-real-imag 'rect) x y))
+  (define (make-zma m a) ((get 'make-from-mag-ang 'polar) m a))
+  (define (rp z) (apply-generic-1 'real-part z))    ; inner dispatch on rect/polar
+  (define (ip z) (apply-generic-1 'imag-part z))
+  (define (tag z) (attach-tag 'complex z))
+  (put 'add '(complex complex)
+       (lambda (a b) (tag (make-zri (+ (rp (contents a)) (rp (contents b)))
+                                    (+ (ip (contents a)) (ip (contents b)))))))
+  (put 'mul '(complex complex)
+       (lambda (a b)
+         (tag (make-zma (* (apply-generic-1 'magnitude (contents a))
+                           (apply-generic-1 'magnitude (contents b)))
+                        (+ (apply-generic-1 'angle (contents a))
+                           (apply-generic-1 'angle (contents b)))))))
+  (put 'equ? '(complex complex)
+       (lambda (a b) (and (close? (rp (contents a)) (rp (contents b)))
+                          (close? (ip (contents a)) (ip (contents b))))))
+  (put 'make-from-real-imag 'complex (lambda (x y) (tag (make-zri x y))))
+  (put 'make-from-mag-ang 'complex (lambda (m a) (tag (make-zma m a))))
+  'done)
+
+(define (make-complex-ri x y) ((get 'make-from-real-imag 'complex) x y))
+(define (make-complex-ma m a) ((get 'make-from-mag-ang 'complex) m a))
+(define (real-part z) (apply-generic-1 'real-part (contents z)))
+(define (imag-part z) (apply-generic-1 'imag-part (contents z)))
+(define (magnitude z) (apply-generic-1 'magnitude (contents z)))
+
+;; ---- raise / project entries for the tower ----
+(define (install-tower)
+  (put 'raise '(integer) (lambda (n) (make-rat (contents n) 1)))
+  (put 'raise '(rational)
+       (lambda (r) (make-real (/ (exact->inexact (numer r)) (denom r)))))
+  (put 'raise '(real) (lambda (x) (make-complex-ri (contents x) 0.0)))
+  (put 'project '(rational) (lambda (r) (make-integer (quotient (numer r) (denom r)))))
+  (put 'project '(real) (lambda (x) (make-rat (exact (round (contents x))) 1)))
+  (put 'project '(complex)
+       (lambda (z) (make-real (apply-generic-1 'real-part (contents z)))))
+  'done)
+
+(install-integer)
+(install-rational)
+(install-real)
+(install-rectangular)
+(install-polar)
+(install-complex)
+(install-tower)
+
+;; ---- same-type arithmetic ----
+(check "int-add" 3 (contents (add (make-integer 1) (make-integer 2))))
+(check "int-mul" 12 (contents (mul (make-integer 3) (make-integer 4))))
+
+;; rational add is EXACT: 1/2 + 1/3 = 5/6
+(define r56 (apply-generic-2 'add (make-rat 1 2) (make-rat 1 3)))
+(check "rat-add-type" 'rational (type-tag r56))
+(check "rat-add-numer" 5 (numer r56))
+(check "rat-add-denom" 6 (denom r56))
+;; 2/4 normalizes to 1/2; 1/6 * 3/1 = 1/2
+(check "rat-normalize" '(rational 1 . 2) (make-rat 2 4))
+(check "rat-mul" '(rational 1 . 2)
+       (apply-generic-2 'mul (make-rat 1 6) (make-rat 3 1)))
+
+;; real add
+(check-close "real-add" 2.5 (contents (apply-generic-2 'add (make-real 1.0) (make-real 1.5))))
+
+;; ---- complex selectors on both representations ----
+(define z34 (make-complex-ri 3.0 4.0))
+(check-close "complex-magnitude" 5.0 (magnitude z34))
+(check-close "complex-real-part" 3.0 (real-part z34))
+(define zp (make-complex-ma 2.0 0.0))
+(check-close "polar-real-part" 2.0 (real-part zp))
+(check-close "polar-magnitude" 2.0 (magnitude zp))
+
+;; complex add via generic op (drop suppressed: imag nonzero)
+(define zsum (add z34 (make-complex-ri 1.0 1.0)))
+(check "complex-add-type" 'complex (type-tag zsum))
+(check-close "complex-add-real" 4.0 (real-part zsum))
+(check-close "complex-add-imag" 5.0 (imag-part zsum))
+
+;; ---- the raise chain ----
+(define i5 (make-integer 5))
+(define r5 (raise-up i5))
+(check "raise-int->rat" 'rational (type-tag r5))
+(check "raise-int->rat-val" '(5 . 1) (contents r5))
+(define x5 (raise-up r5))
+(check "raise-rat->real" 'real (type-tag x5))
+(check-close "raise-rat->real-val" 5.0 (contents x5))
+(define z5 (raise-up x5))
+(check "raise-real->complex" 'complex (type-tag z5))
+(check-close "raise-real->complex-re" 5.0 (real-part z5))
+(check-close "raise-real->complex-im" 0.0 (imag-part z5))
+
+;; ---- cross-type arithmetic through the tower ----
+;; integer + complex: 3 raised all the way to complex
+(define zc (add (make-integer 3) (make-complex-ri 1.0 2.0)))
+(check "coerce-int+complex-type" 'complex (type-tag zc))
+(check-close "coerce-int+complex-re" 4.0 (real-part zc))
+(check-close "coerce-int+complex-im" 2.0 (imag-part zc))
+
+;; integer + rational stays exact: 1 + 1/2 = 3/2
+(define r32 (add (make-integer 1) (make-rat 1 2)))
+(check "coerce-int+rat" '(rational 3 . 2) r32)
+
+;; rational + real: 1/4 + 0.25 = 0.5 (drop cannot reach rational: project rounds)
+(define half (apply-generic-2 'add (make-rat 1 4) (make-real 0.25)))
+(check "coerce-rat+real-type" 'real (type-tag half))
+(check-close "coerce-rat+real-val" 0.5 (contents half))
+
+;; ---- equ? across the tower ----
+(check "equ-int-int" #t (equ? (make-integer 7) (make-integer 7)))
+(check "equ-int-rat" #t (equ? (make-integer 2) (make-rat 4 2)))
+(check "equ-rat-real" #t (equ? (make-rat 1 2) (make-real 0.5)))
+(check "equ-int-complex" #t (equ? (make-integer 5) (make-complex-ri 5.0 0.0)))
+(check "equ-differs" #f (equ? (make-integer 2) (make-rat 1 2)))
+
+;; ---- drop (ex 2.85): results simplify down the tower ----
+;; (1+2i) + (1-2i) = 2+0i -> drops all the way to integer 2
+(define dropped (add (make-complex-ri 1.0 2.0) (make-complex-ri 1.0 -2.0)))
+(check "drop-complex->integer-type" 'integer (type-tag dropped))
+(check "drop-complex->integer-val" 2 (contents dropped))
+;; 1/3 + 1/6 = 1/2 stays rational (cannot drop to integer)
+(define rhalf (add (make-rat 1 3) (make-rat 1 6)))
+(check "drop-keeps-rational" '(rational 1 . 2) rhalf)
+;; 1/2 + 1/2 = 1 drops to integer
+(check "drop-rat->integer" '(integer . 1) (add (make-rat 1 2) (make-rat 1 2)))
+;; complex with nonzero imag does not drop
+(check "drop-blocked-by-imag" 'complex
+       (type-tag (add (make-complex-ri 1.0 1.0) (make-complex-ri 1.0 1.0))))
+
+(display "NOTE: SICP's `raise` renamed to raise-up — user define cannot shadow builtin exception raise (see header comment)") (newline)
+
+(newline)
+(if (= fails 0)
+    (begin (display "ALL-PASS ch2_generic_tower_coercion") (newline))
+    (begin (display "HAS-FAIL ch2_generic_tower_coercion ") (display fails) (newline)))

--- a/tests/sicp/ch2_picture_painters.esk
+++ b/tests/sicp/ch2_picture_painters.esk
@@ -1,0 +1,273 @@
+;; SICP 2.2.4 — Picture language: painters over a DISPLAY-LIST representation.
+;;
+;; SICP's painters ultimately call (draw-line) on a graphics device. Here
+;; draw-line records each drawn segment into a collected list instead, so
+;; painters, transform-painter, and all the combinators (beside, below,
+;; flip-vert, flip-horiz, right-split, up-split, corner-split, square-limit)
+;; are fully testable: we count collected segments and hand-check exact
+;; endpoint coordinates for known painters.
+
+(define fails 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "FAIL: ") (display name) (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline))))
+(define (close? a b) (< (abs (- a b)) 1e-9))
+
+;; ---- vectors (ex 2.46) ----
+(define (make-vect x y) (cons x y))
+(define (xcor-vect v) (car v))
+(define (ycor-vect v) (cdr v))
+(define (add-vect a b)
+  (make-vect (+ (xcor-vect a) (xcor-vect b)) (+ (ycor-vect a) (ycor-vect b))))
+(define (sub-vect a b)
+  (make-vect (- (xcor-vect a) (xcor-vect b)) (- (ycor-vect a) (ycor-vect b))))
+(define (scale-vect s v)
+  (make-vect (* s (xcor-vect v)) (* s (ycor-vect v))))
+
+;; ---- frames (ex 2.47) ----
+(define (make-frame origin edge1 edge2) (list origin edge1 edge2))
+(define (origin-frame f) (car f))
+(define (edge1-frame f) (cadr f))
+(define (edge2-frame f) (caddr f))
+(define (frame-coord-map frame)
+  (lambda (v)
+    (add-vect (origin-frame frame)
+              (add-vect (scale-vect (xcor-vect v) (edge1-frame frame))
+                        (scale-vect (ycor-vect v) (edge2-frame frame))))))
+
+;; ---- segments (ex 2.48) ----
+(define (make-segment s e) (cons s e))
+(define (start-segment s) (car s))
+(define (end-segment s) (cdr s))
+
+;; ---- display list: draw-line records instead of drawing ----
+(define drawn '())                       ; most-recent-first
+(define (draw-line start end) (set! drawn (cons (make-segment start end) drawn)))
+(define (reset-drawn!) (set! drawn '()))
+(define (drawn-segments) (reverse drawn)) ; in draw order
+
+;; run painter on frame, return list of drawn segments in draw order
+(define (paint painter frame)
+  (reset-drawn!)
+  (painter frame)
+  (drawn-segments))
+
+;; segment accessors on the recorded (device-coordinate) segments
+(define (seg-x1 s) (xcor-vect (start-segment s)))
+(define (seg-y1 s) (ycor-vect (start-segment s)))
+(define (seg-x2 s) (xcor-vect (end-segment s)))
+(define (seg-y2 s) (ycor-vect (end-segment s)))
+
+(define (check-seg name s x1 y1 x2 y2)
+  (if (and (close? (seg-x1 s) x1) (close? (seg-y1 s) y1)
+           (close? (seg-x2 s) x2) (close? (seg-y2 s) y2))
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "FAIL: ") (display name)
+             (display " expected=") (display (list x1 y1 x2 y2))
+             (display " actual=")
+             (display (list (seg-x1 s) (seg-y1 s) (seg-x2 s) (seg-y2 s)))
+             (newline))))
+
+;; ---- segments->painter (2.2.4 / ex 2.49) ----
+(define (segments->painter segment-list)
+  (lambda (frame)
+    (for-each
+     (lambda (segment)
+       (draw-line ((frame-coord-map frame) (start-segment segment))
+                  ((frame-coord-map frame) (end-segment segment))))
+     segment-list)))
+
+;; outline painter: unit square, 4 segments, counter-clockwise from origin
+(define outline
+  (segments->painter
+   (list (make-segment (make-vect 0.0 0.0) (make-vect 1.0 0.0))
+         (make-segment (make-vect 1.0 0.0) (make-vect 1.0 1.0))
+         (make-segment (make-vect 1.0 1.0) (make-vect 0.0 1.0))
+         (make-segment (make-vect 0.0 1.0) (make-vect 0.0 0.0)))))
+
+(define unit-frame
+  (make-frame (make-vect 0.0 0.0) (make-vect 1.0 0.0) (make-vect 0.0 1.0)))
+
+;; ---- outline on the unit frame: 4 segments, identity coordinates ----
+(define segs (paint outline unit-frame))
+(check "outline-count" 4 (length segs))
+(check-seg "outline-bottom" (list-ref segs 0) 0.0 0.0 1.0 0.0)
+(check-seg "outline-right"  (list-ref segs 1) 1.0 0.0 1.0 1.0)
+(check-seg "outline-top"    (list-ref segs 2) 1.0 1.0 0.0 1.0)
+(check-seg "outline-left"   (list-ref segs 3) 0.0 1.0 0.0 0.0)
+
+;; ---- outline on an affine frame: origin (2,3), edges (2,0) and (0,2) ----
+(define aff-frame
+  (make-frame (make-vect 2.0 3.0) (make-vect 2.0 0.0) (make-vect 0.0 2.0)))
+(set! segs (paint outline aff-frame))
+(check "outline-affine-count" 4 (length segs))
+(check-seg "outline-affine-bottom" (list-ref segs 0) 2.0 3.0 4.0 3.0)
+(check-seg "outline-affine-right"  (list-ref segs 1) 4.0 3.0 4.0 5.0)
+(check-seg "outline-affine-top"    (list-ref segs 2) 4.0 5.0 2.0 5.0)
+(check-seg "outline-affine-left"   (list-ref segs 3) 2.0 5.0 2.0 3.0)
+
+;; ---- transform-painter (2.2.4) ----
+(define (transform-painter painter origin corner1 corner2)
+  (lambda (frame)
+    (let ((m (frame-coord-map frame)))
+      (let ((new-origin (m origin)))
+        (painter (make-frame new-origin
+                             (sub-vect (m corner1) new-origin)
+                             (sub-vect (m corner2) new-origin)))))))
+
+(define (flip-vert painter)
+  (transform-painter painter
+                     (make-vect 0.0 1.0)
+                     (make-vect 1.0 1.0)
+                     (make-vect 0.0 0.0)))
+
+(define (flip-horiz painter)                     ; ex 2.50
+  (transform-painter painter
+                     (make-vect 1.0 0.0)
+                     (make-vect 0.0 0.0)
+                     (make-vect 1.0 1.0)))
+
+(define (beside painter1 painter2)
+  (let ((split-point (make-vect 0.5 0.0)))
+    (let ((paint-left (transform-painter painter1
+                                         (make-vect 0.0 0.0)
+                                         split-point
+                                         (make-vect 0.0 1.0)))
+          (paint-right (transform-painter painter2
+                                          split-point
+                                          (make-vect 1.0 0.0)
+                                          (make-vect 0.5 1.0))))
+      (lambda (frame)
+        (paint-left frame)
+        (paint-right frame)))))
+
+(define (below painter1 painter2)                ; ex 2.51: p1 below p2
+  (let ((split-point (make-vect 0.0 0.5)))
+    (let ((paint-bottom (transform-painter painter1
+                                           (make-vect 0.0 0.0)
+                                           (make-vect 1.0 0.0)
+                                           split-point))
+          (paint-top (transform-painter painter2
+                                        split-point
+                                        (make-vect 1.0 0.5)
+                                        (make-vect 0.0 1.0))))
+      (lambda (frame)
+        (paint-bottom frame)
+        (paint-top frame)))))
+
+;; ---- flip-vert: (x,y) -> (x, 1-y) on the unit frame ----
+(set! segs (paint (flip-vert outline) unit-frame))
+(check "flip-vert-count" 4 (length segs))
+(check-seg "flip-vert-seg0" (list-ref segs 0) 0.0 1.0 1.0 1.0)  ; bottom -> top
+(check-seg "flip-vert-seg1" (list-ref segs 1) 1.0 1.0 1.0 0.0)
+(check-seg "flip-vert-seg3" (list-ref segs 3) 0.0 0.0 0.0 1.0)
+
+;; ---- flip-horiz: (x,y) -> (1-x, y) on the unit frame ----
+(set! segs (paint (flip-horiz outline) unit-frame))
+(check "flip-horiz-count" 4 (length segs))
+(check-seg "flip-horiz-seg0" (list-ref segs 0) 1.0 0.0 0.0 0.0)
+(check-seg "flip-horiz-seg2" (list-ref segs 2) 0.0 1.0 1.0 1.0)
+
+;; ---- beside: 8 segments, x scaled by 0.5, right half shifted by 0.5 ----
+(set! segs (paint (beside outline outline) unit-frame))
+(check "beside-count" 8 (length segs))
+;; left copy: bottom (0,0)->(0.5,0); right side of left square at x=0.5
+(check-seg "beside-left-bottom"  (list-ref segs 0) 0.0 0.0 0.5 0.0)
+(check-seg "beside-left-right"   (list-ref segs 1) 0.5 0.0 0.5 1.0)
+;; right copy: bottom (0.5,0)->(1,0); top (1,1)->(0.5,1)
+(check-seg "beside-right-bottom" (list-ref segs 4) 0.5 0.0 1.0 0.0)
+(check-seg "beside-right-top"    (list-ref segs 6) 1.0 1.0 0.5 1.0)
+
+;; ---- below: 8 segments, y scaled by 0.5, top half shifted by 0.5 ----
+(set! segs (paint (below outline outline) unit-frame))
+(check "below-count" 8 (length segs))
+(check-seg "below-bottom-bottom" (list-ref segs 0) 0.0 0.0 1.0 0.0)
+(check-seg "below-bottom-top"    (list-ref segs 2) 1.0 0.5 0.0 0.5)
+(check-seg "below-top-bottom"    (list-ref segs 4) 0.0 0.5 1.0 0.5)
+(check-seg "below-top-top"       (list-ref segs 6) 1.0 1.0 0.0 1.0)
+
+;; ---- recursive splits (2.2.4) ----
+(define (right-split painter n)
+  (if (= n 0)
+      painter
+      (let ((smaller (right-split painter (- n 1))))
+        (beside painter (below smaller smaller)))))
+
+(define (up-split painter n)                     ; ex 2.44
+  (if (= n 0)
+      painter
+      (let ((smaller (up-split painter (- n 1))))
+        (below painter (beside smaller smaller)))))
+
+(define (corner-split painter n)
+  (if (= n 0)
+      painter
+      (let ((up (up-split painter (- n 1)))
+            (right (right-split painter (- n 1))))
+        (let ((top-left (beside up up))
+              (bottom-right (below right right))
+              (corner (corner-split painter (- n 1))))
+          (beside (below painter top-left)
+                  (below bottom-right corner))))))
+
+(define (square-limit painter n)
+  (let ((quarter (corner-split painter n)))
+    (let ((half (beside (flip-horiz quarter) quarter)))
+      (below (flip-vert half) half))))
+
+;; segment counts: s(0)=4, split(n) = 2*split(n-1) + 4
+(check "right-split-0-count" 4  (length (paint (right-split outline 0) unit-frame)))
+(check "right-split-1-count" 12 (length (paint (right-split outline 1) unit-frame)))
+(check "right-split-2-count" 28 (length (paint (right-split outline 2) unit-frame)))
+(check "up-split-2-count"    28 (length (paint (up-split outline 2) unit-frame)))
+
+;; right-split 1 geometry: main copy fills left half; two smaller stacked right
+(set! segs (paint (right-split outline 1) unit-frame))
+(check-seg "right-split-main-bottom"  (list-ref segs 0) 0.0 0.0 0.5 0.0)
+;; first smaller copy: bottom quarter of the right half: origin (0.5,0), w=.5 h=.5
+(check-seg "right-split-small-bottom" (list-ref segs 4) 0.5 0.0 1.0 0.0)
+(check-seg "right-split-small-top"    (list-ref segs 6) 1.0 0.5 0.5 0.5)
+;; second smaller copy sits above: its bottom edge is at y=0.5
+(check-seg "right-split-upper-bottom" (list-ref segs 8) 0.5 0.5 1.0 0.5)
+
+;; corner-split counts: c(0)=4; c(n) = 4 + 2*u(n-1) + 2*r(n-1) + c(n-1)
+;; c(1) = 4 + 8 + 8 + 4 = 24; c(2) = 4 + 2*12 + 2*12 + 24 = 76
+(check "corner-split-1-count" 24 (length (paint (corner-split outline 1) unit-frame)))
+(check "corner-split-2-count" 76 (length (paint (corner-split outline 2) unit-frame)))
+
+;; square-limit = 4 quarters: 4 * c(n)
+(check "square-limit-0-count" 16 (length (paint (square-limit outline 0) unit-frame)))
+(check "square-limit-1-count" 96 (length (paint (square-limit outline 1) unit-frame)))
+
+;; square-limit 0 geometry: 4 outlines, one per quadrant.
+;; half = beside(flip-horiz outline, outline); whole = below(flip-vert half, half).
+;; First drawn: bottom half -> flip-vert -> left painter (flip-horiz outline).
+;; Its bottom segment (0,0)->(1,0) maps: flip-horiz -> (1,0)->(0,0);
+;; beside-left -> (0.5,0)->(0,0); flip-vert -> (0.5,1)->(0,1);
+;; below-bottom (y*0.5) -> (0.5,0.5)->(0,0.5).
+(set! segs (paint (square-limit outline 0) unit-frame))
+(check-seg "square-limit-seg0" (list-ref segs 0) 0.5 0.5 0.0 0.5)
+;; Last quadrant drawn: top half, right painter = plain outline in upper-right
+;; quadrant: bottom (0.5,0.5)->(1,0.5)
+(check-seg "square-limit-seg12" (list-ref segs 12) 0.5 0.5 1.0 0.5)
+
+;; all square-limit coordinates stay inside the unit square
+(define (all-in-unit? segs)
+  (if (null? segs)
+      #t
+      (let ((s (car segs)))
+        (define (ok? c) (and (> c -1e-9) (< c (+ 1.0 1e-9))))
+        (if (and (ok? (seg-x1 s)) (ok? (seg-y1 s)) (ok? (seg-x2 s)) (ok? (seg-y2 s)))
+            (all-in-unit? (cdr segs))
+            #f))))
+(check "square-limit-in-bounds" #t
+       (all-in-unit? (paint (square-limit outline 1) unit-frame)))
+
+(newline)
+(if (= fails 0)
+    (begin (display "ALL-PASS ch2_picture_painters") (newline))
+    (begin (display "HAS-FAIL ch2_picture_painters ") (display fails) (newline)))

--- a/tests/sicp/ch2_polynomial_arithmetic.esk
+++ b/tests/sicp/ch2_polynomial_arithmetic.esk
@@ -1,0 +1,232 @@
+;; SICP 2.5.3 — Symbolic algebra: polynomial arithmetic on the generic
+;; operation/type table. Sparse term lists (descending order), add-poly,
+;; mul-poly, generic negation, sub-poly, generic =zero?, and polynomials
+;; with rational coefficients. Self-contained: the small table + number
+;; packages are duplicated here rather than shared with the tower test.
+
+(define fails 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "FAIL: ") (display name) (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline))))
+
+;; ---- tagged data ----
+(define (attach-tag tag contents) (cons tag contents))
+(define (type-tag datum) (car datum))
+(define (contents datum) (cdr datum))
+
+;; ---- operation/type table ----
+(define op-table (list '*table*))
+(define (put op type proc)
+  (set-cdr! op-table (cons (list op type proc) (cdr op-table))))
+(define (get op type)
+  (let loop ((es (cdr op-table)))
+    (cond ((null? es) #f)
+          ((and (eq? (car (car es)) op) (equal? (cadr (car es)) type))
+           (caddr (car es)))
+          (else (loop (cdr es))))))
+
+(define (apply-generic-2 op a b)
+  (let ((proc (get op (list (type-tag a) (type-tag b)))))
+    (if proc (proc a b) (error "no method for these types" op))))
+(define (apply-generic-1 op x)
+  (let ((proc (get op (list (type-tag x)))))
+    (if proc (proc x) (error "no method" op))))
+
+(define (add a b) (apply-generic-2 'add a b))
+(define (mul a b) (apply-generic-2 'mul a b))
+(define (neg x) (apply-generic-1 'neg x))
+(define (sub a b) (add a (neg b)))
+(define (=zero? x) (apply-generic-1 '=zero? x))
+
+;; ---- scheme-number package (integer coefficients) ----
+(define (make-num n) (attach-tag 'scheme-number n))
+(define (install-scheme-number)
+  (put 'add '(scheme-number scheme-number)
+       (lambda (a b) (make-num (+ (contents a) (contents b)))))
+  (put 'mul '(scheme-number scheme-number)
+       (lambda (a b) (make-num (* (contents a) (contents b)))))
+  (put 'neg '(scheme-number) (lambda (a) (make-num (- (contents a)))))
+  (put '=zero? '(scheme-number) (lambda (a) (= (contents a) 0)))
+  'done)
+
+;; ---- rational package (exact coefficients) ----
+(define (make-rat n d)
+  (let ((g (gcd n d)))
+    (let ((g (if (< d 0) (- g) g)))
+      (attach-tag 'rational (cons (quotient n g) (quotient d g))))))
+(define (numer r) (car (contents r)))
+(define (denom r) (cdr (contents r)))
+(define (install-rational)
+  (put 'add '(rational rational)
+       (lambda (a b) (make-rat (+ (* (numer a) (denom b)) (* (numer b) (denom a)))
+                               (* (denom a) (denom b)))))
+  (put 'mul '(rational rational)
+       (lambda (a b) (make-rat (* (numer a) (numer b)) (* (denom a) (denom b)))))
+  (put 'neg '(rational) (lambda (r) (make-rat (- (numer r)) (denom r))))
+  (put '=zero? '(rational) (lambda (r) (= (numer r) 0)))
+  'done)
+
+;; ---- polynomial package: sparse term lists, descending order ----
+(define (make-term order coeff) (list order coeff))
+(define (order term) (car term))
+(define (coeff term) (cadr term))
+(define (the-empty-termlist) '())
+(define (empty-termlist? tl) (null? tl))
+(define (first-term tl) (car tl))
+(define (rest-terms tl) (cdr tl))
+(define (adjoin-term term tl)
+  (if (=zero? (coeff term)) tl (cons term tl)))
+
+(define (add-terms l1 l2)
+  (cond ((empty-termlist? l1) l2)
+        ((empty-termlist? l2) l1)
+        (else
+         (let ((t1 (first-term l1)) (t2 (first-term l2)))
+           (cond ((> (order t1) (order t2))
+                  (adjoin-term t1 (add-terms (rest-terms l1) l2)))
+                 ((< (order t1) (order t2))
+                  (adjoin-term t2 (add-terms l1 (rest-terms l2))))
+                 (else
+                  (adjoin-term (make-term (order t1) (add (coeff t1) (coeff t2)))
+                               (add-terms (rest-terms l1) (rest-terms l2)))))))))
+
+(define (mul-term-by-all-terms t1 tl)
+  (if (empty-termlist? tl)
+      (the-empty-termlist)
+      (let ((t2 (first-term tl)))
+        (adjoin-term (make-term (+ (order t1) (order t2))
+                                (mul (coeff t1) (coeff t2)))
+                     (mul-term-by-all-terms t1 (rest-terms tl))))))
+
+(define (mul-terms l1 l2)
+  (if (empty-termlist? l1)
+      (the-empty-termlist)
+      (add-terms (mul-term-by-all-terms (first-term l1) l2)
+                 (mul-terms (rest-terms l1) l2))))
+
+(define (neg-terms tl)
+  (if (empty-termlist? tl)
+      (the-empty-termlist)
+      (cons (make-term (order (first-term tl)) (neg (coeff (first-term tl))))
+            (neg-terms (rest-terms tl)))))
+
+(define (make-polynomial var terms) (attach-tag 'polynomial (cons var terms)))
+(define (variable p) (car (contents p)))
+(define (term-list p) (cdr (contents p)))
+(define (same-variable? v1 v2) (and (symbol? v1) (symbol? v2) (eq? v1 v2)))
+
+(define (install-polynomial)
+  (define (tag-poly var terms) (attach-tag 'polynomial (cons var terms)))
+  (put 'add '(polynomial polynomial)
+       (lambda (p1 p2)
+         (if (same-variable? (variable p1) (variable p2))
+             (tag-poly (variable p1) (add-terms (term-list p1) (term-list p2)))
+             (error "polys not in same var"))))
+  (put 'mul '(polynomial polynomial)
+       (lambda (p1 p2)
+         (if (same-variable? (variable p1) (variable p2))
+             (tag-poly (variable p1) (mul-terms (term-list p1) (term-list p2)))
+             (error "polys not in same var"))))
+  (put 'neg '(polynomial)
+       (lambda (p) (tag-poly (variable p) (neg-terms (term-list p)))))
+  (put '=zero? '(polynomial)
+       (lambda (p) (empty-termlist? (term-list p))))
+  'done)
+
+(install-scheme-number)
+(install-rational)
+(install-polynomial)
+
+;; convenience: build a poly in x from (order . int-coeff) pairs
+(define (poly . spec)
+  (make-polynomial
+   'x
+   (let loop ((s spec))
+     (if (null? s)
+         '()
+         (cons (make-term (car (car s)) (make-num (cdr (car s))))
+               (loop (cdr s)))))))
+
+;; ---- =zero? / negation basics ----
+(check "num-zero" #t (=zero? (make-num 0)))
+(check "num-nonzero" #f (=zero? (make-num 3)))
+(check "num-neg" (make-num -7) (neg (make-num 7)))
+(check "rat-neg" (make-rat -1 2) (neg (make-rat 1 2)))
+(check "poly-zero" #t (=zero? (make-polynomial 'x '())))
+
+;; ---- add-poly: (x^2 + 2x + 1) + (x^2 - 1) = 2x^2 + 2x ----
+;; note the constant terms cancel: adjoin-term must drop the zero coeff
+(define p-sq (poly (cons 2 1) (cons 1 2) (cons 0 1)))     ; x^2 + 2x + 1
+(define p-d  (poly (cons 2 1) (cons 0 -1)))               ; x^2 - 1
+(check "add-poly" (poly (cons 2 2) (cons 1 2)) (add p-sq p-d))
+
+;; disjoint orders interleave: (x^3 + x) + (x^2 + 1)
+(check "add-poly-interleave"
+       (poly (cons 3 1) (cons 2 1) (cons 1 1) (cons 0 1))
+       (add (poly (cons 3 1) (cons 1 1)) (poly (cons 2 1) (cons 0 1))))
+
+;; ---- mul-poly: (x + 1)^2 = x^2 + 2x + 1 ----
+(define p-x1 (poly (cons 1 1) (cons 0 1)))                ; x + 1
+(check "mul-poly-square" p-sq (mul p-x1 p-x1))
+
+;; (3x^2 + 5)(x^3 + 2x + 1) = 3x^5 + 11x^3 + 3x^2 + 10x + 5
+(check "mul-poly-sicp"
+       (poly (cons 5 3) (cons 3 11) (cons 2 3) (cons 1 10) (cons 0 5))
+       (mul (poly (cons 2 3) (cons 0 5))
+            (poly (cons 3 1) (cons 1 2) (cons 0 1))))
+
+;; (x - 1)(x + 1) = x^2 - 1
+(check "mul-poly-diff-of-squares"
+       p-d
+       (mul (poly (cons 1 1) (cons 0 -1)) p-x1))
+
+;; ---- negation and sub-poly ----
+(check "neg-poly" (poly (cons 1 -1) (cons 0 -1)) (neg p-x1))
+;; p - p = zero polynomial (empty term list)
+(check "sub-poly-self-zero" #t (=zero? (sub p-sq p-sq)))
+;; (2x^2 + 2x) - (x^2 - 1) = x^2 + 2x + 1
+(check "sub-poly" p-sq (sub (poly (cons 2 2) (cons 1 2)) p-d))
+
+;; ---- rational coefficients (2.5.3: "the beauty of the system") ----
+;; (1/2 x + 1/3) + (1/2 x + 2/3) = x + 1
+(define p-r1 (make-polynomial 'x (list (make-term 1 (make-rat 1 2))
+                                       (make-term 0 (make-rat 1 3)))))
+(define p-r2 (make-polynomial 'x (list (make-term 1 (make-rat 1 2))
+                                       (make-term 0 (make-rat 2 3)))))
+(check "add-poly-rational"
+       (make-polynomial 'x (list (make-term 1 (make-rat 1 1))
+                                 (make-term 0 (make-rat 1 1))))
+       (add p-r1 p-r2))
+
+;; (1/2 x + 1/3)(x) with rational coeffs: mixed exact products
+;; (1/2 x + 1/3) * (2/1 x) = x^2 + 2/3 x
+(define p-rx (make-polynomial 'x (list (make-term 1 (make-rat 2 1)))))
+(check "mul-poly-rational"
+       (make-polynomial 'x (list (make-term 2 (make-rat 1 1))
+                                 (make-term 1 (make-rat 2 3))))
+       (mul p-r1 p-rx))
+
+;; rational cancellation drives a term to zero: (1/2 x) + (-1/2 x) = 0
+(check "rat-term-cancel" #t
+       (=zero? (add (make-polynomial 'x (list (make-term 1 (make-rat 1 2))))
+                    (make-polynomial 'x (list (make-term 1 (make-rat -1 2)))))))
+
+;; SICP 2.5.3 closing example: polynomials whose coefficients are rational —
+;; (x^2 + 1/2) * (x + 2) = x^3 + 2x^2 + 1/2 x + 1
+(check "mul-poly-mixed-rational"
+       (make-polynomial 'x (list (make-term 3 (make-rat 1 1))
+                                 (make-term 2 (make-rat 2 1))
+                                 (make-term 1 (make-rat 1 2))
+                                 (make-term 0 (make-rat 1 1))))
+       (mul (make-polynomial 'x (list (make-term 2 (make-rat 1 1))
+                                      (make-term 0 (make-rat 1 2))))
+            (make-polynomial 'x (list (make-term 1 (make-rat 1 1))
+                                      (make-term 0 (make-rat 2 1))))))
+
+(newline)
+(if (= fails 0)
+    (begin (display "ALL-PASS ch2_polynomial_arithmetic") (newline))
+    (begin (display "HAS-FAIL ch2_polynomial_arithmetic ") (display fails) (newline)))


### PR DESCRIPTION
## Summary

Three self-checking SICP chapter 2 probes for the full-book gate, filling the exact required basenames in `scripts/run_sicp_smoke.sh` (no compiler or harness changes). Each file passes with zero `FAIL:` and exit 0 under both `-r` (JIT) and AOT.

| File | Checks | SICP sections |
|---|---|---|
| `tests/sicp/ch2_picture_painters.esk` | 42 | 2.2.4 picture language |
| `tests/sicp/ch2_generic_tower_coercion.esk` | 38 | 2.5.1–2.5.2 generic arithmetic + tower coercion |
| `tests/sicp/ch2_polynomial_arithmetic.esk` | 17 | 2.5.3 polynomial arithmetic |

### ch2_picture_painters (ESH-0038)
Painters over a display-list representation: `draw-line` records segments into a collected list instead of drawing. Covers frames, `frame-coord-map`, `segments->painter`, `transform-painter`, `beside`, `below`, `flip-vert`/`flip-horiz`, `right-split`, `up-split`, `corner-split`, `square-limit`. Verifies segment-count recurrences (right-split: 4→12→28; corner-split: 4→24→76; square-limit: 16/96) and hand-computed exact endpoints through composed transforms (e.g. the first segment of `square-limit 0` is the flip-horiz→beside→flip-vert→below image of the outline's bottom edge: (0.5,0.5)→(0,0.5)).

### ch2_generic_tower_coercion (ESH-0039)
Op/type table (`put`/`get`) with integer, rational (exact, gcd-normalized), real, and complex (rect+polar inner dispatch) packages. Tower `integer→rational→real→complex` with raise-based `apply-generic` (ex 2.83/2.84), cross-tower `equ?` (ex 2.79), and `drop`/simplify (ex 2.85): `(1+2i)+(1−2i)` drops all the way to integer 2; `1/2+1/2` drops to integer; `1/2+1/3 = 5/6` stays exact rational.

**Language gap found:** a user-level `(define (raise x) ...)` does not shadow the builtin R7RS exception `raise` — calls still hit the builtin and abort with `Unhandled exception: user exception`. Minimal repro:

```scheme
(define (raise x) (list 'raised x))
(display (raise 5))   ; => Unhandled exception: user exception
```

The probe uses `raise-up` (identical semantics) and documents the gap with a header comment plus a printed `NOTE:` line.

### ch2_polynomial_arithmetic (ESH-0040)
Polynomial package on a duplicated (self-contained) generic table: sparse descending term lists, `add-poly`, `mul-poly`, generic negation, `sub-poly`, generic `=zero?` with zero-coefficient terms dropped by `adjoin-term`. Hand-computed products/sums, e.g. `(3x²+5)(x³+2x+1) = 3x⁵+11x³+3x²+10x+5`, `(x−1)(x+1) = x²−1` (constant terms cancel), `p−p` is the zero polynomial, plus rational-coefficient polynomials with exact cross-term cancellation (`(x²+1/2)(x+2)` etc.).

## Test plan

- [x] `./build/eshkol-run -r tests/sicp/<file>.esk` — 42/38/17 PASS, zero FAIL, exit 0
- [x] `./build/eshkol-run tests/sicp/<file>.esk -o bin && bin` — identical results under AOT
- [x] Output markers match the harness `verdict` (`ALL-PASS` on success, `HAS-FAIL` only on failure)
