### PR TITLE
test(sicp): ch4 full-book evaluator probes — derived forms, analyzing, lazy, amb, parser, query (ESH-0046/0047/0029/0048/0049/0030)

### DIFF
--- a/tests/sicp/ch4_amb_evaluator.esk
+++ b/tests/sicp/ch4_amb_evaluator.esk
@@ -1,0 +1,200 @@
+;; SICP 4.3.3 — the amb EVALUATOR: a metacircular evaluator in which every
+;; evaluation takes TWO continuations, (succeed val fail) and (fail), so that
+;; `amb` expressions create choice points and `require` triggers backtracking
+;; through the interpreted program.  Host CPS is the implementation vehicle,
+;; but amb/require/backtracking live IN the evaluated language.
+;;
+;; Search sizes are kept small on purpose: deep host-CPS continuation chains
+;; SIGILL past roughly depth 13..15 (tracked as ESH-0080, see ch4_amb.esk);
+;; the dwelling puzzle is therefore 3 people / 3 floors and the Pythagorean
+;; search runs over 1..6.
+;;
+;; NOTE: base env binds comparison primitives to boolean-normalizing wrapper
+;; lambdas — ESH-0078 workaround, see ch4_metacircular_full.esk.
+(define fails 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "FAIL: ") (display name) (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline))))
+
+(define (tagged? exp tag) (and (pair? exp) (eq? (car exp) tag)))
+(define (lookup var env)
+  (if (null? env) (error "unbound" var)
+      (let loop ((vars (caar env)) (vals (cdar env)))
+        (cond ((null? vars) (lookup var (cdr env)))
+              ((eq? (car vars) var) (car vals))
+              (else (loop (cdr vars) (cdr vals)))))))
+(define (define-var! var val env)
+  (set-car! (car env) (cons var (caar env)))
+  (set-cdr! (car env) (cons val (cdar env))))
+
+;; ---- ambeval: exp env succeed fail ----
+;;   succeed : (value fail-continuation) -> answer
+;;   fail    : () -> answer   (backtrack to most recent choice point)
+(define (ambeval exp env succeed fail)
+  (cond ((number? exp) (succeed exp fail))
+        ((boolean? exp) (succeed exp fail))
+        ((symbol? exp) (succeed (lookup exp env) fail))
+        ((tagged? exp 'quote) (succeed (cadr exp) fail))
+        ((tagged? exp 'lambda) (succeed (list 'closure (cadr exp) (caddr exp) env) fail))
+        ((tagged? exp 'if)
+         (ambeval (cadr exp) env
+                  (lambda (pv fail2)
+                    (if (not (eq? pv #f))
+                        (ambeval (caddr exp) env succeed fail2)
+                        (if (null? (cdddr exp))
+                            (succeed 'ok fail2)
+                            (ambeval (cadddr exp) env succeed fail2))))
+                  fail))
+        ((tagged? exp 'define)
+         (ambeval (caddr exp) env
+                  (lambda (val fail2)
+                    (define-var! (cadr exp) val env)
+                    (succeed 'ok fail2))
+                  fail))
+        ((tagged? exp 'begin) (eval-sequence (cdr exp) env succeed fail))
+        ((tagged? exp 'amb) (try-choices (cdr exp) env succeed fail))
+        ((tagged? exp 'require)
+         (ambeval (cadr exp) env
+                  (lambda (pv fail2)
+                    (if (not (eq? pv #f)) (succeed 'ok fail2) (fail2)))
+                  fail))
+        (else
+         (ambeval (car exp) env
+                  (lambda (proc fail2)
+                    (eval-operands (cdr exp) env
+                                   (lambda (args fail3)
+                                     (amb-apply proc args succeed fail3))
+                                   fail2))
+                  fail))))
+
+;; amb choice points: try each choice in order; the fail continuation handed
+;; to each branch retries the REMAINING choices — this is the backtracking.
+(define (try-choices choices env succeed fail)
+  (if (null? choices)
+      (fail)
+      (ambeval (car choices) env succeed
+               (lambda () (try-choices (cdr choices) env succeed fail)))))
+
+(define (eval-sequence exps env succeed fail)
+  (cond ((null? exps) (succeed 'ok fail))
+        ((null? (cdr exps)) (ambeval (car exps) env succeed fail))
+        (else (ambeval (car exps) env
+                       (lambda (v fail2) (eval-sequence (cdr exps) env succeed fail2))
+                       fail))))
+
+(define (eval-operands exps env succeed fail)
+  (if (null? exps)
+      (succeed '() fail)
+      (ambeval (car exps) env
+               (lambda (v fail2)
+                 (eval-operands (cdr exps) env
+                                (lambda (vs fail3) (succeed (cons v vs) fail3))
+                                fail2))
+               fail)))
+
+(define (amb-apply proc args succeed fail)
+  (cond ((procedure? proc) (succeed (apply proc args) fail))
+        ((tagged? proc 'closure)
+         (ambeval (caddr proc)
+                  (cons (cons (cadr proc) args) (cadddr proc))
+                  succeed fail))
+        (else (error "not-applicable" proc))))
+
+;; ---- driver loop equivalents ----
+(define (all-values exp env)
+  (let ((acc '()))
+    (ambeval exp env
+             (lambda (v next) (set! acc (cons v acc)) (next))  ; force backtrack
+             (lambda () 'exhausted))
+    (reverse acc)))
+(define (first-value exp env)
+  (ambeval exp env (lambda (v next) v) (lambda () 'none)))
+
+(define (base-env)
+  (list (cons (list '+ '- '* '= '< '> 'not 'even 'distinct3 'list3)
+              (list + - *
+                    (lambda (a b) (if (= a b) #t #f))
+                    (lambda (a b) (if (< a b) #t #f))
+                    (lambda (a b) (if (> a b) #t #f))
+                    (lambda (x) (if (eq? x #f) #t #f))
+                    (lambda (n) (if (= (modulo n 2) 0) #t #f))
+                    (lambda (a b c)
+                      (if (= a b) #f (if (= a c) #f (if (= b c) #f #t))))
+                    (lambda (a b c) (list a b c))))))
+
+;; ---- amb basics ----
+(check "amb enumerates in order" '(1 2 3) (all-values '(amb 1 2 3) (base-env)))
+(check "amb first value" 1 (first-value '(amb 1 2 3) (base-env)))
+(check "amb of no choices fails" 'none (first-value '(amb) (base-env)))
+(check "nested amb cross product" '(11 21 12 22)
+       (all-values '(begin (define a (amb 1 2))
+                           (define b (amb 10 20))
+                           (+ a b))
+                   (base-env)))
+
+;; ---- require + backtracking ----
+(check "require filters" '(2 4)
+       (all-values '(begin (define x (amb 1 2 3 4 5))
+                           (require (even x))
+                           x)
+                   (base-env)))
+(check "unsatisfiable require -> none" 'none
+       (first-value '(begin (define x (amb 1 2 3))
+                            (require (> x 5))
+                            x)
+                    (base-env)))
+(check "backtrack across choice points" '(2 3 0)
+       (first-value '(begin (define a (amb 1 2 3))
+                            (define b (amb 1 2 3))
+                            (require (> b a))
+                            (require (= (+ a b) 5))
+                            (list3 a b 0))
+                    (base-env)))
+;; sanity check on the list3 result shape used above
+(check "backtrack result shape" '((2 3 0))
+       (all-values '(begin (define a (amb 2))
+                           (define b (amb 3))
+                           (list3 a b 0))
+                   (base-env)))
+
+;; ---- multiple dwelling, simplified to 3 people / 3 floors ----
+;; Baker does not live on the top floor; Cooper does not live on the bottom
+;; floor; Fletcher lives on neither the top nor the bottom floor; all live on
+;; distinct floors.  Unique solution: baker=1 cooper=3 fletcher=2.
+(define dwelling
+  '(begin
+     (define baker (amb 1 2 3))
+     (define cooper (amb 1 2 3))
+     (define fletcher (amb 1 2 3))
+     (require (distinct3 baker cooper fletcher))
+     (require (not (= baker 3)))
+     (require (not (= cooper 1)))
+     (require (not (= fletcher 3)))
+     (require (not (= fletcher 1)))
+     (list3 baker cooper fletcher)))
+(check "dwelling unique solution" '((1 3 2)) (all-values dwelling (base-env)))
+(check "dwelling first solution" '(1 3 2) (first-value dwelling (base-env)))
+
+;; ---- Pythagorean triple over a small range (ESH-0080: keep it shallow) ----
+(define pyth-env (base-env))
+;; an-integer-between defined IN the evaluated language: recursion happens
+;; lazily inside the second amb choice, exactly as in SICP 4.3.1.
+(first-value '(define an-integer-between
+                (lambda (lo hi)
+                  (begin (require (not (> lo hi)))
+                         (amb lo (an-integer-between (+ lo 1) hi)))))
+             pyth-env)
+(check "pythagorean triples in 1..6" '((3 4 5))
+       (all-values '(begin
+                      (define i (an-integer-between 1 6))
+                      (define j (an-integer-between i 6))
+                      (define k (an-integer-between j 6))
+                      (require (= (+ (* i i) (* j j)) (* k k)))
+                      (list3 i j k))
+                   pyth-env))
+
+(display "ch4 amb evaluator: ")
+(display (if (= fails 0) "ALL PASS" (cons fails 'FAILS))) (newline)

--- a/tests/sicp/ch4_amb_parser.esk
+++ b/tests/sicp/ch4_amb_parser.esk
@@ -1,0 +1,145 @@
+;; SICP 4.3.2 — nondeterministic natural-language parsing.  A parser is a
+;; nondeterministic procedure (input succeed fail) where
+;;   succeed : (tree remaining-input retry) -> answer
+;;   fail    : () -> answer
+;; maybe-extend-* first yields the unextended phrase and, on backtracking,
+;; tries to absorb another prepositional phrase — this is exactly the amb
+;; choice in the book's parser, with the unparsed input threaded through the
+;; continuations instead of a mutable *unparsed* global.
+;;
+;; Sentences are kept short: deep host-CPS chains SIGILL past roughly depth
+;; 13..15 (ESH-0080, see ch4_amb.esk); an 8-word sentence stays well under it.
+(define fails 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "FAIL: ") (display name) (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline))))
+
+;; ---- the tiny grammar ----
+(define nouns '(noun student professor cat class))
+(define verbs '(verb studies lectures eats sleeps))
+(define articles '(article the a))
+(define prepositions '(prep for to in by with))
+
+(define (parse-word word-list)
+  (lambda (input succeed fail)
+    (if (and (pair? input) (memq (car input) (cdr word-list)))
+        (succeed (list (car word-list) (car input)) (cdr input) fail)
+        (fail))))
+(define parse-article (parse-word articles))
+(define parse-noun (parse-word nouns))
+(define parse-verb (parse-word verbs))
+(define parse-prep (parse-word prepositions))
+
+(define (parse-simple-noun-phrase input succeed fail)
+  (parse-article input
+    (lambda (art rest f1)
+      (parse-noun rest
+        (lambda (n rest2 f2)
+          (succeed (list 'simple-noun-phrase art n) rest2 f2))
+        f1))
+    fail))
+
+(define (parse-prepositional-phrase input succeed fail)
+  (parse-prep input
+    (lambda (p rest f1)
+      (parse-noun-phrase rest
+        (lambda (np rest2 f2)
+          (succeed (list 'prep-phrase p np) rest2 f2))
+        f1))
+    fail))
+
+(define (parse-noun-phrase input succeed fail)
+  (parse-simple-noun-phrase input
+    (lambda (np rest f1) (maybe-extend-noun-phrase np rest succeed f1))
+    fail))
+;; amb choice: yield the phrase as-is; on retry, extend it with one more PP.
+(define (maybe-extend-noun-phrase np input succeed fail)
+  (succeed np input
+    (lambda ()
+      (parse-prepositional-phrase input
+        (lambda (pp rest f2)
+          (maybe-extend-noun-phrase (list 'noun-phrase np pp) rest succeed f2))
+        fail))))
+
+(define (parse-verb-phrase input succeed fail)
+  (parse-verb input
+    (lambda (v rest f1) (maybe-extend-verb-phrase v rest succeed f1))
+    fail))
+(define (maybe-extend-verb-phrase vp input succeed fail)
+  (succeed vp input
+    (lambda ()
+      (parse-prepositional-phrase input
+        (lambda (pp rest f2)
+          (maybe-extend-verb-phrase (list 'verb-phrase vp pp) rest succeed f2))
+        fail))))
+
+;; a sentence must consume the ENTIRE input (the book's (require (null? ...)))
+(define (parse-sentence input succeed fail)
+  (parse-noun-phrase input
+    (lambda (np rest f1)
+      (parse-verb-phrase rest
+        (lambda (vp rest2 f2)
+          (if (null? rest2)
+              (succeed (list 'sentence np vp) rest2 f2)
+              (f2)))
+        f1))
+    fail))
+
+;; drive the backtracking to enumerate ALL parses
+(define (all-parses words)
+  (let ((acc '()))
+    (parse-sentence words
+      (lambda (tree rest retry) (set! acc (cons tree acc)) (retry))
+      (lambda () 'done))
+    (reverse acc)))
+
+;; ---- unambiguous sentences ----
+(check "the cat eats"
+       '((sentence (simple-noun-phrase (article the) (noun cat)) (verb eats)))
+       (all-parses '(the cat eats)))
+(check "a professor studies"
+       '((sentence (simple-noun-phrase (article a) (noun professor)) (verb studies)))
+       (all-parses '(a professor studies)))
+(check "the cat sleeps in the class"
+       '((sentence (simple-noun-phrase (article the) (noun cat))
+                   (verb-phrase (verb sleeps)
+                                (prep-phrase (prep in)
+                                             (simple-noun-phrase (article the) (noun class))))))
+       (all-parses '(the cat sleeps in the class)))
+
+;; ---- non-sentences yield no parses ----
+(check "unknown word" '() (all-parses '(the dog eats)))
+(check "trailing junk rejected" '() (all-parses '(the cat eats the)))
+(check "empty input" '() (all-parses '()))
+
+;; ---- prepositional attachment ambiguity ----
+;; "the professor lectures to the student with the cat" has exactly two
+;; parses: [lectures to the student] [with the cat] (the professor uses the
+;; cat to lecture) vs. lectures to [the student with the cat].
+(define np-prof '(simple-noun-phrase (article the) (noun professor)))
+(define np-student '(simple-noun-phrase (article the) (noun student)))
+(define np-cat '(simple-noun-phrase (article the) (noun cat)))
+(define pp-with-cat (list 'prep-phrase '(prep with) np-cat))
+(define parse-a                       ; both PPs attach to the verb phrase
+  (list 'sentence np-prof
+        (list 'verb-phrase
+              (list 'verb-phrase '(verb lectures)
+                    (list 'prep-phrase '(prep to) np-student))
+              pp-with-cat)))
+(define parse-b                       ; "with the cat" attaches to the student
+  (list 'sentence np-prof
+        (list 'verb-phrase '(verb lectures)
+              (list 'prep-phrase '(prep to)
+                    (list 'noun-phrase np-student pp-with-cat)))))
+(define ambiguous-parses
+  (all-parses '(the professor lectures to the student with the cat)))
+(check "ambiguous sentence has 2 parses" 2 (length ambiguous-parses))
+(check "parse 1: VP attachment" parse-a (car ambiguous-parses))
+(check "parse 2: NP attachment" parse-b (cadr ambiguous-parses))
+(check "both parses enumerated exactly" (list parse-a parse-b) ambiguous-parses)
+
+(display "ch4 amb parser: ")
+(display (if (= fails 0) "ALL PASS" (cons fails 'FAILS))) (newline)

--- a/tests/sicp/ch4_analyzing_evaluator.esk
+++ b/tests/sicp/ch4_analyzing_evaluator.esk
@@ -1,0 +1,134 @@
+;; SICP 4.1.7 — the analyzing evaluator.  `analyze` walks an expression ONCE
+;; and returns an execution procedure (a host closure taking only an
+;; environment); running the program is then pure execution with no further
+;; syntactic analysis.  A global analyze-count instruments `analyze` so the
+;; analysis/execution separation is directly observable.
+;;
+;; NOTE: the base environment binds comparison primitives to boolean-normalizing
+;; wrapper lambdas — required to work around ESH-0078 (first-class builtin
+;; predicates return raw 0/1 instead of #f/#t). See ch4_metacircular_full.esk.
+(define fails 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "FAIL: ") (display name) (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline))))
+
+(define (tagged? exp tag) (and (pair? exp) (eq? (car exp) tag)))
+(define (lookup var env)
+  (if (null? env) (error "unbound" var)
+      (let loop ((vars (caar env)) (vals (cdar env)))
+        (cond ((null? vars) (lookup var (cdr env)))
+              ((eq? (car vars) var) (car vals))
+              (else (loop (cdr vars) (cdr vals)))))))
+(define (define-var! var val env)
+  (set-car! (car env) (cons var (caar env)))
+  (set-cdr! (car env) (cons val (cdar env))))
+(define (set-var! var val env)
+  (let loop ((vars (caar env)) (vals (cdar env)))
+    (cond ((null? vars) (set-var! var val (cdr env)))
+          ((eq? (car vars) var) (set-car! vals val))
+          (else (loop (cdr vars) (cdr vals))))))
+
+;; ---- analyze: expression -> execution procedure (host closure over env) ----
+(define analyze-count 0)
+(define (analyze exp)
+  (set! analyze-count (+ analyze-count 1))
+  (cond ((number? exp) (lambda (env) exp))                       ; self-evaluating
+        ((boolean? exp) (lambda (env) exp))
+        ((symbol? exp) (lambda (env) (lookup exp env)))          ; variable
+        ((tagged? exp 'quote)
+         (let ((q (cadr exp))) (lambda (env) q)))
+        ((tagged? exp 'if)
+         (let ((pproc (analyze (cadr exp)))
+               (cproc (analyze (caddr exp)))
+               (aproc (if (null? (cdddr exp))
+                          (lambda (env) 'ok)
+                          (analyze (cadddr exp)))))
+           (lambda (env)
+             (if (not (eq? (pproc env) #f)) (cproc env) (aproc env)))))
+        ((tagged? exp 'lambda)
+         (let ((params (cadr exp)) (bproc (analyze (caddr exp))))
+           (lambda (env) (list 'closure params bproc env))))
+        ((tagged? exp 'define)
+         (let ((var (cadr exp)) (vproc (analyze (caddr exp))))
+           (lambda (env) (define-var! var (vproc env) env) 'ok)))
+        ((tagged? exp 'set!)
+         (let ((var (cadr exp)) (vproc (analyze (caddr exp))))
+           (lambda (env) (set-var! var (vproc env) env) 'ok)))
+        ((tagged? exp 'begin) (analyze-sequence (cdr exp)))
+        (else                                                    ; application
+         (let ((fproc (analyze (car exp)))
+               (aprocs (map analyze (cdr exp))))
+           (lambda (env)
+             (execute-application (fproc env)
+                                  (map (lambda (ap) (ap env)) aprocs)))))))
+
+(define (analyze-sequence exps)
+  (define (sequentially p1 p2) (lambda (env) (p1 env) (p2 env)))
+  (define (loop first rest)
+    (if (null? rest) first
+        (loop (sequentially first (car rest)) (cdr rest))))
+  (if (null? exps)
+      (lambda (env) 'ok)
+      (loop (analyze (car exps)) (map analyze (cdr exps)))))
+
+(define (execute-application proc args)
+  (cond ((procedure? proc) (apply proc args))
+        ((tagged? proc 'closure)
+         ((caddr proc)                      ; stored ANALYZED body — no re-analysis
+          (cons (cons (cadr proc) args) (cadddr proc))))
+        (else (error "not-applicable" proc))))
+
+(define (aeval exp env) ((analyze exp) env))
+
+(define (base-env)
+  (list (cons (list '+ '- '* '= '< '> 'cons 'car 'cdr 'null?)
+              (list + - *
+                    (lambda (a b) (if (= a b) #t #f))
+                    (lambda (a b) (if (< a b) #t #f))
+                    (lambda (a b) (if (> a b) #t #f))
+                    cons car cdr
+                    (lambda (x) (if (null? x) #t #f))))))
+(define e (base-env))
+
+;; ---- each analyzable expression type ----
+(check "self-eval number" 42 (aeval '42 e))
+(check "self-eval boolean" #t (aeval '#t e))
+(check "quote" 'hello (aeval '(quote hello) e))
+(check "quote list" '(1 2 3) (aeval '(quote (1 2 3)) e))
+(aeval '(define v 11) e)
+(check "variable" 11 (aeval 'v e))
+(check "if consequent" 'yes (aeval '(if (< 1 2) 'yes 'no) e))
+(check "if alternative" 'no (aeval '(if (< 2 1) 'yes 'no) e))
+(check "lambda + application" 36 (aeval '((lambda (x) (* x x)) 6) e))
+(aeval '(define counter 0) e)
+(aeval '(set! counter (+ counter 5)) e)
+(aeval '(set! counter (+ counter 5)) e)
+(check "define/set!" 10 (aeval 'counter e))
+(check "begin sequencing" 3
+       (aeval '(begin (set! counter 1) (set! counter (+ counter 2)) counter) e))
+(check "application of primitive" 12 (aeval '(+ 5 7) e))
+
+;; ---- recursive programs through the analyzed evaluator ----
+(aeval '(define fact (lambda (n) (if (= n 0) 1 (* n (fact (- n 1)))))) e)
+(define c0 analyze-count)
+(check "fact 5" 120 (aeval '(fact 5) e))
+;; analyzing '(fact 5) costs exactly 3 analyze calls (application, fact, 5);
+;; the 6 recursive executions of fact's body must trigger NO further analysis.
+(check "execution does not re-analyze" 3 (- analyze-count c0))
+(aeval '(define fib (lambda (n) (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))) e)
+(check "fib 10" 55 (aeval '(fib 10) e))
+
+;; ---- analysis/execution separation: analyze once, run at two arguments ----
+(define sq-exec (analyze '(lambda (x) (* x x))))   ; analysis happens HERE
+(define sq (sq-exec e))                            ; execution yields the closure
+(define c1 analyze-count)
+(check "analyzed sq at 3" 9 (execute-application sq (list 3)))
+(check "analyzed sq at 7" 49 (execute-application sq (list 7)))
+(check "no analysis during either run" c1 analyze-count)
+(check "analysis did happen" #t (> analyze-count 0))
+
+(display "ch4 analyzing evaluator: ")
+(display (if (= fails 0) "ALL PASS" (cons fails 'FAILS))) (newline)

--- a/tests/sicp/ch4_lazy_evaluator.esk
+++ b/tests/sicp/ch4_lazy_evaluator.esk
@@ -1,0 +1,135 @@
+;; SICP 4.2 — lazy (normal-order) evaluator.  Compound procedures receive
+;; DELAYED operands: thunks (list 'thunk exp env) forced on demand by
+;; actual-value, with memoization (thunk mutated in place to
+;; (evaluated-thunk result) so the underlying expression runs at most once).
+;; Primitives are strict.  Covers the book's motivating cases:
+;;   * (try 0 (/ 1 0)) = 1 — the division is never performed
+;;   * unless as an ordinary PROCEDURE
+;;   * memoization observed via a side-effect counter forced exactly once
+;;   * an infinite lazy list built from cons-as-lambda (SICP 4.2.3)
+;;
+;; NOTE: base env binds comparison primitives to boolean-normalizing wrapper
+;; lambdas — ESH-0078 workaround, see ch4_metacircular_full.esk.
+(define fails 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "FAIL: ") (display name) (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline))))
+
+(define (tagged? exp tag) (and (pair? exp) (eq? (car exp) tag)))
+(define (lookup var env)
+  (if (null? env) (error "unbound" var)
+      (let loop ((vars (caar env)) (vals (cdar env)))
+        (cond ((null? vars) (lookup var (cdr env)))
+              ((eq? (car vars) var) (car vals))
+              (else (loop (cdr vars) (cdr vals)))))))
+(define (define-var! var val env)
+  (set-car! (car env) (cons var (caar env)))
+  (set-cdr! (car env) (cons val (cdar env))))
+(define (set-var! var val env)
+  (let loop ((vars (caar env)) (vals (cdar env)))
+    (cond ((null? vars) (set-var! var val (cdr env)))
+          ((eq? (car vars) var) (set-car! vals val))
+          (else (loop (cdr vars) (cdr vals))))))
+
+;; ---- thunks with memoization ----
+(define (delay-it exp env) (list 'thunk exp env))
+(define (thunk? obj) (tagged? obj 'thunk))
+(define (evaluated-thunk? obj) (tagged? obj 'evaluated-thunk))
+(define (force-it obj)
+  (cond ((thunk? obj)
+         (let ((result (actual-value (cadr obj) (caddr obj))))
+           (set-car! obj 'evaluated-thunk)   ; memoize: mutate thunk in place
+           (set-car! (cdr obj) result)
+           (set-cdr! (cdr obj) '())          ; drop exp/env so it can never rerun
+           result))
+        ((evaluated-thunk? obj) (cadr obj))
+        (else obj)))
+(define (actual-value exp env) (force-it (leval exp env)))
+
+;; ---- the lazy evaluator ----
+(define (leval exp env)
+  (cond ((number? exp) exp)
+        ((boolean? exp) exp)
+        ((symbol? exp) (lookup exp env))
+        ((tagged? exp 'quote) (cadr exp))
+        ((tagged? exp 'if)                   ; predicate is forced; branches lazy
+         (if (not (eq? (actual-value (cadr exp) env) #f))
+             (leval (caddr exp) env)
+             (if (null? (cdddr exp)) 'ok (leval (cadddr exp) env))))
+        ((tagged? exp 'define) (define-var! (cadr exp) (leval (caddr exp) env) env) 'ok)
+        ((tagged? exp 'set!) (set-var! (cadr exp) (leval (caddr exp) env) env) 'ok)
+        ((tagged? exp 'lambda) (list 'closure (cadr exp) (caddr exp) env))
+        ((tagged? exp 'begin) (let loop ((es (cdr exp)) (r 'ok))
+                                (if (null? es) r (loop (cdr es) (leval (car es) env)))))
+        (else (lapply (actual-value (car exp) env) (cdr exp) env))))
+(define (lapply proc operand-exps env)
+  (cond ((procedure? proc)                   ; primitives: strict (forced args)
+         (apply proc (map (lambda (a) (actual-value a env)) operand-exps)))
+        ((tagged? proc 'closure)             ; compound: DELAYED args
+         (leval (caddr proc)
+                (cons (cons (cadr proc)
+                            (map (lambda (a) (delay-it a env)) operand-exps))
+                      (cadddr proc))))
+        (else (error "not-applicable" proc))))
+
+(define (base-env)
+  (list (cons (list '+ '- '* '/ '= '< '> 'cons 'car 'cdr 'null?)
+              (list + - * /
+                    (lambda (a b) (if (= a b) #t #f))
+                    (lambda (a b) (if (< a b) #t #f))
+                    (lambda (a b) (if (> a b) #t #f))
+                    cons car cdr
+                    (lambda (x) (if (null? x) #t #f))))))
+(define e (base-env))
+
+;; ---- SICP 4.2.1: (try 0 (/ 1 0)) — the division must never run ----
+(leval '(define try (lambda (a b) (if (= a 0) 1 b))) e)
+(check "try 0 (/ 1 0) = 1" 1 (actual-value '(try 0 (/ 1 0)) e))
+(check "try 1 forces b" 7 (actual-value '(try 1 7) e))
+;; side-effect proof that the unused operand is truly never evaluated:
+(leval '(define ran 0) e)
+(check "try 0 with set! operand" 1 (actual-value '(try 0 (set! ran 1)) e))
+(check "unused operand never ran" 0 (actual-value 'ran e))
+
+;; ---- unless as an ordinary procedure (SICP 4.2.2) ----
+(leval '(define unless (lambda (condition usual exceptional)
+                         (if condition exceptional usual))) e)
+(check "unless takes exceptional lazily" 'safe
+       (actual-value '(unless (= 0 0) (/ 1 0) (quote safe)) e))
+(check "unless takes usual branch" 2
+       (actual-value '(unless (= 5 0) (/ 10 5) 999) e))
+
+;; ---- memoization: side-effect counter forced exactly once ----
+(leval '(define count 0) e)
+(leval '(define bump (lambda (ignored)
+                       (begin (set! count (+ count 1)) count))) e)
+(leval '(define twice (lambda (x) (+ x x))) e)
+;; x is referenced twice in (+ x x); with memoized thunks bump runs ONCE.
+(check "twice (bump 0) = 2" 2 (actual-value '(twice (bump 0)) e))
+(check "bump forced exactly once" 1 (actual-value 'count e))
+;; an argument that is never used forces nothing at all:
+(leval '(define const-9 (lambda (ignored) 9)) e)
+(check "unused arg not forced" 9 (actual-value '(const-9 (bump 0)) e))
+(check "counter still 1" 1 (actual-value 'count e))
+
+;; ---- infinite lazy list via cons-as-lambda (SICP 4.2.3) ----
+(leval '(define lcons (lambda (x y) (lambda (m) (m x y)))) e)
+(leval '(define lcar (lambda (z) (z (lambda (p q) p)))) e)
+(leval '(define lcdr (lambda (z) (z (lambda (p q) q)))) e)
+;; ints-from would loop forever under applicative order; lazily it terminates
+;; because the recursive call sits in a delayed operand position.
+(leval '(define ints-from (lambda (n) (lcons n (ints-from (+ n 1))))) e)
+(leval '(define ints (ints-from 1)) e)
+(check "lazy list 1st" 1 (actual-value '(lcar ints) e))
+(check "lazy list 2nd" 2 (actual-value '(lcar (lcdr ints)) e))
+(check "lazy list 3rd" 3 (actual-value '(lcar (lcdr (lcdr ints))) e))
+;; lazy map over the infinite list, sampled at the 3rd element
+(leval '(define lmap (lambda (f s) (lcons (f (lcar s)) (lmap f (lcdr s))))) e)
+(check "lazy map sample" 30
+       (actual-value '(lcar (lcdr (lcdr (lmap (lambda (k) (* 10 k)) ints)))) e))
+
+(display "ch4 lazy evaluator: ")
+(display (if (= fails 0) "ALL PASS" (cons fails 'FAILS))) (newline)

--- a/tests/sicp/ch4_metacircular_derived_forms.esk
+++ b/tests/sicp/ch4_metacircular_derived_forms.esk
@@ -1,0 +1,176 @@
+;; SICP 4.1.2 — derived expressions in the metacircular evaluator.
+;; cond, let, and, or, and named let are NOT primitive evaluator cases:
+;; each is lowered BY SYNTACTIC TRANSFORMATION into the kernel language
+;; (if / lambda / define / begin / quote / set!) and then re-evaluated.
+;;   cond      -> nested if chain (else clause -> final alternative)
+;;   let       -> ((lambda (vars...) body) inits...)
+;;   and       -> nested if, returning the last operand's value
+;;   or        -> (let ((t e1)) (if t t (or rest...)))  [value-returning]
+;;   named let -> ((lambda () (begin (define name (lambda vars body)) (name inits...))))
+;;
+;; NOTE: the base environment binds comparison primitives to boolean-normalizing
+;; wrapper lambdas — required to work around ESH-0078 (first-class builtin
+;; predicates return raw 0/1 instead of #f/#t). See ch4_metacircular_full.esk.
+(define fails 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "FAIL: ") (display name) (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline))))
+
+(define (tagged? exp tag) (and (pair? exp) (eq? (car exp) tag)))
+(define (lookup var env)
+  (if (null? env) (error "unbound" var)
+      (let loop ((vars (caar env)) (vals (cdar env)))
+        (cond ((null? vars) (lookup var (cdr env)))
+              ((eq? (car vars) var) (car vals))
+              (else (loop (cdr vars) (cdr vals)))))))
+(define (define-var! var val env)
+  (set-car! (car env) (cons var (caar env)))
+  (set-cdr! (car env) (cons val (cdar env))))
+(define (set-var! var val env)
+  (let loop ((vars (caar env)) (vals (cdar env)))
+    (cond ((null? vars) (set-var! var val (cdr env)))
+          ((eq? (car vars) var) (set-car! vals val))
+          (else (loop (cdr vars) (cdr vals))))))
+
+;; ---- syntactic transformations (SICP 4.1.2) ----
+(define (seq->exp seq)
+  (cond ((null? seq) (list 'quote 'ok))
+        ((null? (cdr seq)) (car seq))
+        (else (cons 'begin seq))))
+
+;; cond -> if chain
+(define (cond->if clauses)
+  (if (null? clauses)
+      (list 'quote 'cond-fell-through)
+      (let ((clause (car clauses)))
+        (if (eq? (car clause) 'else)
+            (seq->exp (cdr clause))
+            (list 'if (car clause)
+                  (seq->exp (cdr clause))
+                  (cond->if (cdr clauses)))))))
+
+;; let -> lambda application
+(define (let->exp exp)
+  (let ((bindings (cadr exp)) (body (cddr exp)))
+    (cons (list 'lambda (map (lambda (b) (car b)) bindings) (seq->exp body))
+          (map (lambda (b) (cadr b)) bindings))))
+
+;; named let -> define+call inside an applied thunk (letrec-style loop)
+(define (named-let->exp exp)
+  (let ((name (cadr exp)) (bindings (caddr exp)) (body (cdddr exp)))
+    (list (list 'lambda '()
+                (list 'begin
+                      (list 'define name
+                            (list 'lambda (map (lambda (b) (car b)) bindings)
+                                  (seq->exp body)))
+                      (cons name (map (lambda (b) (cadr b)) bindings)))))))
+
+;; and -> nested if (value of last operand when all true)
+(define (and->if args)
+  (cond ((null? args) #t)
+        ((null? (cdr args)) (car args))
+        (else (list 'if (car args) (and->if (cdr args)) #f))))
+
+;; or -> nested if via a let-bound temp (value-returning, single evaluation)
+(define (or->if args)
+  (cond ((null? args) #f)
+        ((null? (cdr args)) (car args))
+        (else (list 'let (list (list 'or-tmp-var (car args)))
+                    (list 'if 'or-tmp-var 'or-tmp-var (or->if (cdr args)))))))
+
+;; ---- kernel evaluator + derived-form dispatch ----
+(define (meval exp env)
+  (cond ((number? exp) exp)
+        ((boolean? exp) exp)
+        ((symbol? exp) (lookup exp env))
+        ((tagged? exp 'quote) (cadr exp))
+        ((tagged? exp 'if) (if (not (eq? (meval (cadr exp) env) #f))
+                               (meval (caddr exp) env)
+                               (if (null? (cdddr exp)) 'ok (meval (cadddr exp) env))))
+        ((tagged? exp 'define) (define-var! (cadr exp) (meval (caddr exp) env) env) 'ok)
+        ((tagged? exp 'set!) (set-var! (cadr exp) (meval (caddr exp) env) env) 'ok)
+        ((tagged? exp 'lambda) (list 'closure (cadr exp) (caddr exp) env))
+        ((tagged? exp 'begin) (let loop ((es (cdr exp)) (r 'ok))
+                                (if (null? es) r (loop (cdr es) (meval (car es) env)))))
+        ;; derived forms: transform, then evaluate the transformed expression
+        ((tagged? exp 'cond) (meval (cond->if (cdr exp)) env))
+        ((tagged? exp 'let) (meval (if (symbol? (cadr exp))
+                                       (named-let->exp exp)
+                                       (let->exp exp))
+                                   env))
+        ((tagged? exp 'and) (meval (and->if (cdr exp)) env))
+        ((tagged? exp 'or) (meval (or->if (cdr exp)) env))
+        (else (mapply (meval (car exp) env)
+                      (map (lambda (a) (meval a env)) (cdr exp))))))
+(define (mapply proc args)
+  (cond ((procedure? proc) (apply proc args))
+        ((tagged? proc 'closure)
+         (meval (caddr proc)
+                (cons (cons (cadr proc) args) (cadddr proc))))
+        (else (error "not-applicable" proc))))
+
+(define (base-env)
+  (list (cons (list '+ '- '* '= '< '> 'cons 'car 'cdr 'null?)
+              (list + - *
+                    (lambda (a b) (if (= a b) #t #f))
+                    (lambda (a b) (if (< a b) #t #f))
+                    (lambda (a b) (if (> a b) #t #f))
+                    cons car cdr
+                    (lambda (x) (if (null? x) #t #f))))))
+
+(define e (base-env))
+
+;; ---- pure transformation shape checks ----
+(check "and->if shape" '(if p q #f) (and->if '(p q)))
+(check "or->if shape" '(let ((or-tmp-var p)) (if or-tmp-var or-tmp-var q))
+       (or->if '(p q)))
+(check "let->exp shape" '((lambda (a) (+ a 1)) 2) (let->exp '(let ((a 2)) (+ a 1))))
+(check "cond->if shape" '(if c1 r1 (if c2 r2 r3))
+       (cond->if '((c1 r1) (c2 r2) (else r3))))
+
+;; ---- cond in the evaluated language ----
+(meval '(define x 2) e)
+(check "cond first clause" 'pos (meval '(cond ((> x 0) 'pos) (else 'neg)) e))
+(check "cond middle clause" 'two
+       (meval '(cond ((= x 1) 'one) ((= x 2) 'two) (else 'many)) e))
+(check "cond else clause" 'many
+       (meval '(cond ((= x 1) 'one) ((= x 9) 'nine) (else 'many)) e))
+(check "cond multi-expr body" 9
+       (meval '(cond ((> x 0) (define y 3) (* y y)) (else 0)) e))
+
+;; ---- let in the evaluated language ----
+(check "let simple" 7 (meval '(let ((a 3) (b 4)) (+ a b)) e))
+(check "let shadowing" 25 (meval '(let ((a 3)) (let ((a 5)) (* a a))) e))
+(check "let multi-expr body" 10 (meval '(let ((a 1)) (set! a (+ a 9)) a) e))
+(meval '(define fact (lambda (n) (if (= n 0) 1 (* n (fact (- n 1)))))) e)
+(check "let-bound fact" 120 (meval '(let ((n 5)) (fact n)) e))
+
+;; ---- and / or short-circuit + value semantics ----
+(check "and empty" #t (meval '(and) e))
+(check "and returns last value" 3 (meval '(and 1 2 3) e))
+(check "and stops at false" #f (meval '(and 1 #f 3) e))
+(meval '(define flag 0) e)
+(meval '(and #f (set! flag 1)) e)
+(check "and short-circuits side effect" 0 (meval 'flag e))
+(check "or empty" #f (meval '(or) e))
+(check "or all false" #f (meval '(or #f #f) e))
+(check "or returns first true value" 42 (meval '(or #f 42 (set! flag 2)) e))
+(check "or short-circuits side effect" 0 (meval 'flag e))
+(check "or first operand" 7 (meval '(or 7 (set! flag 3)) e))
+(check "or side effect still 0" 0 (meval 'flag e))
+
+;; ---- named let as letrec-style loop ----
+(check "named-let sum 1..10" 55
+       (meval '(let loop ((i 1) (acc 0))
+                 (if (> i 10) acc (loop (+ i 1) (+ acc i)))) e))
+(check "named-let fact" 120
+       (meval '(let f ((n 5)) (if (= n 0) 1 (* n (f (- n 1))))) e))
+(check "named-let list build" '(3 2 1)
+       (meval '(let loop ((i 1) (acc (quote ())))
+                 (if (> i 3) acc (loop (+ i 1) (cons i acc)))) e))
+
+(display "ch4 metacircular derived forms: ")
+(display (if (= fails 0) "ALL PASS" (cons fails 'FAILS))) (newline)

--- a/tests/sicp/ch4_query_system.esk
+++ b/tests/sicp/ch4_query_system.esk
@@ -1,0 +1,208 @@
+;; SICP 4.4 — a query-language subset: an assertion database, pattern
+;; matching over (? var) patterns, simple queries, `and` queries, and RULES
+;; applied by full unification with renaming.
+;;
+;; Representations:
+;;   * variables    : (? x); rule application renames to (? <id> x)
+;;   * frames       : alists ((var-key . value) ...), var-key = (cdr var)
+;;   * frame streams: plain lists (the database is finite)
+;; instantiation walks a query replacing bound variables (following chains
+;; through renamed rule variables) so results are verified exactly as lists.
+(define fails 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "FAIL: ") (display name) (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline))))
+
+;; ---- variables and frames ----
+(define (var? x) (and (pair? x) (eq? (car x) '?)))
+(define (binding-in-frame var frame)
+  (let loop ((f frame))
+    (cond ((null? f) #f)
+          ((equal? (cdr var) (car (car f))) (car f))
+          (else (loop (cdr f))))))
+(define (extend var val frame) (cons (cons (cdr var) val) frame))
+
+;; ---- pattern matching (assertions contain no variables) ----
+(define (pattern-match pat dat frame)
+  (cond ((eq? frame 'failed) 'failed)
+        ((var? pat) (extend-if-consistent pat dat frame))
+        ((and (pair? pat) (pair? dat))
+         (pattern-match (cdr pat) (cdr dat)
+                        (pattern-match (car pat) (car dat) frame)))
+        ((equal? pat dat) frame)
+        (else 'failed)))
+(define (extend-if-consistent var dat frame)
+  (let ((b (binding-in-frame var frame)))
+    (if b
+        (pattern-match (cdr b) dat frame)
+        (extend var dat frame))))
+
+;; ---- unification (rule conclusions DO contain variables) ----
+(define (unify-match p1 p2 frame)
+  (cond ((eq? frame 'failed) 'failed)
+        ((equal? p1 p2) frame)
+        ((var? p1) (extend-if-possible p1 p2 frame))
+        ((var? p2) (extend-if-possible p2 p1 frame))
+        ((and (pair? p1) (pair? p2))
+         (unify-match (cdr p1) (cdr p2)
+                      (unify-match (car p1) (car p2) frame)))
+        (else 'failed)))
+(define (extend-if-possible var val frame)
+  (let ((b (binding-in-frame var frame)))
+    (cond (b (unify-match (cdr b) val frame))
+          ((var? val)
+           (let ((b2 (binding-in-frame val frame)))
+             (if b2
+                 (unify-match var (cdr b2) frame)
+                 (extend var val frame))))
+          ((depends-on? val var frame) 'failed)   ; occur check
+          (else (extend var val frame)))))
+(define (depends-on? exp var frame)
+  (cond ((var? exp)
+         (if (equal? (cdr exp) (cdr var))
+             #t
+             (let ((b (binding-in-frame exp frame)))
+               (if b (depends-on? (cdr b) var frame) #f))))
+        ((pair? exp)
+         (if (depends-on? (car exp) var frame)
+             #t
+             (depends-on? (cdr exp) var frame)))
+        (else #f)))
+
+;; ---- database ----
+(define THE-ASSERTIONS
+  '((job alyssa (computer programmer))
+    (job ben (computer wizard))
+    (job lem (accounting scrivener))
+    (salary alyssa 40000)
+    (salary ben 60000)
+    (salary lem 25000)
+    (son adam cain)
+    (son cain enoch)
+    (son enoch irad)
+    (son irad mehujael)))
+
+;; a rule: (rule <conclusion> <body>)
+(define THE-RULES
+  (list '(rule (grandson (? g) (? s))
+               (and (son (? g) (? f)) (son (? f) (? s))))))
+
+;; ---- the query evaluator: frames-in, frames-out ----
+(define (q-flatmap f lst)
+  (if (null? lst) '() (append (f (car lst)) (q-flatmap f (cdr lst)))))
+(define (keep-frames fs)
+  (cond ((null? fs) '())
+        ((eq? (car fs) 'failed) (keep-frames (cdr fs)))
+        (else (cons (car fs) (keep-frames (cdr fs))))))
+
+(define (qeval query frames)
+  (if (and (pair? query) (eq? (car query) 'and))
+      (conjoin (cdr query) frames)
+      (simple-query query frames)))
+(define (conjoin conjuncts frames)
+  (if (null? conjuncts)
+      frames
+      (conjoin (cdr conjuncts) (qeval (car conjuncts) frames))))
+(define (simple-query query frames)
+  (q-flatmap (lambda (frame)
+               (append (find-assertions query frame)
+                       (apply-rules query frame)))
+             frames))
+(define (find-assertions query frame)
+  (keep-frames (map (lambda (a) (pattern-match query a frame)) THE-ASSERTIONS)))
+(define (apply-rules query frame)
+  (q-flatmap (lambda (rule) (apply-a-rule rule query frame)) THE-RULES))
+
+;; rule application: rename the rule's variables uniquely, unify the query
+;; with the renamed conclusion, then evaluate the renamed body in that frame.
+(define rule-counter 0)
+(define (rename-variables exp id)
+  (cond ((var? exp) (cons '? (cons id (cdr exp))))
+        ((pair? exp) (cons (rename-variables (car exp) id)
+                           (rename-variables (cdr exp) id)))
+        (else exp)))
+(define (apply-a-rule rule query frame)
+  (set! rule-counter (+ rule-counter 1))
+  (let ((r (rename-variables rule rule-counter)))
+    (let ((unified (unify-match query (cadr r) frame)))
+      (if (eq? unified 'failed)
+          '()
+          (qeval (caddr r) (list unified))))))
+
+;; ---- instantiation ----
+(define (instantiate exp frame)
+  (cond ((var? exp)
+         (let ((b (binding-in-frame exp frame)))
+           (if b (instantiate (cdr b) frame) exp)))
+        ((pair? exp) (cons (instantiate (car exp) frame)
+                           (instantiate (cdr exp) frame)))
+        (else exp)))
+(define (run-query query)
+  (map (lambda (frame) (instantiate query frame))
+       (qeval query (list '()))))
+
+;; ---- pattern-matching unit checks ----
+;; frame keys are (cdr var), i.e. the list (x) for the variable (? x)
+(check "match binds var" '(((x) . ben))
+       (pattern-match '(job (? x) (computer wizard)) '(job ben (computer wizard)) '()))
+(check "match nested var" '(((type) . programmer) ((x) . alyssa))
+       (pattern-match '(job (? x) (computer (? type)))
+                      '(job alyssa (computer programmer)) '()))
+(check "match constant mismatch" 'failed
+       (pattern-match '(job ben (? t)) '(job lem (accounting scrivener)) '()))
+(check "match consistent rebinding" 'failed
+       (pattern-match '(pair (? x) (? x)) '(pair a b) '()))
+(check "match same var twice ok" '(((x) . a))
+       (pattern-match '(pair (? x) (? x)) '(pair a a) '()))
+
+;; ---- unification unit checks ----
+(check "unify var-to-var then ground" '(((y) . c) ((x) ? y))
+       (unify-match '(f (? x) c) '(f (? y) (? y)) '()))
+(check "unify occur-check fails" 'failed
+       (unify-match '(? x) '(f (? x)) '()))
+
+;; ---- simple queries ----
+(check "simple query, two matches"
+       '((job alyssa (computer programmer)) (job ben (computer wizard)))
+       (run-query '(job (? x) (computer (? type)))))
+(check "simple query, constant + var"
+       '((salary ben 60000))
+       (run-query '(salary ben (? amount))))
+(check "simple query, no matches" '() (run-query '(job nobody (? t))))
+(check "simple query, all salaries"
+       '((salary alyssa 40000) (salary ben 60000) (salary lem 25000))
+       (run-query '(salary (? p) (? a))))
+
+;; ---- and queries ----
+(check "and query joins on shared var"
+       '((and (job alyssa (computer programmer)) (salary alyssa 40000))
+         (and (job ben (computer wizard)) (salary ben 60000)))
+       (run-query '(and (job (? p) (computer (? t))) (salary (? p) (? a)))))
+(check "and query with constant filter"
+       '((and (job ben (computer wizard)) (salary ben 60000)))
+       (run-query '(and (job (? p) (computer wizard)) (salary (? p) (? a)))))
+(check "and query, empty join" '()
+       (run-query '(and (job (? p) (accounting scrivener)) (job (? p) (computer (? t))))))
+
+;; ---- rules: grandson via two son facts + unification ----
+(check "rule enumerates all grandsons"
+       '((grandson adam enoch) (grandson cain irad) (grandson enoch mehujael))
+       (run-query '(grandson (? g) (? s))))
+(check "rule with bound first arg"
+       '((grandson adam enoch))
+       (run-query '(grandson adam (? who))))
+(check "rule with bound second arg"
+       '((grandson cain irad))
+       (run-query '(grandson (? who) irad)))
+(check "rule fully ground, true" '((grandson adam enoch))
+       (run-query '(grandson adam enoch)))
+(check "rule fully ground, false" '() (run-query '(grandson adam irad)))
+(check "and query mixing rule and assertion"
+       '((and (grandson adam enoch) (son enoch irad)))
+       (run-query '(and (grandson adam (? s)) (son (? s) irad))))
+
+(display "ch4 query system: ")
+(display (if (= fails 0) "ALL PASS" (cons fails 'FAILS))) (newline)


### PR DESCRIPTION
Adds the six SICP Chapter 4 full-book gate probes to tests/sicp/. All are self-contained, self-checking (PASS:/FAIL: lines, exit 0 iff all pass), and pass under BOTH the JIT (-r) and AOT.

- ch4_metacircular_derived_forms.esk (25 checks) — SICP 4.1.2: cond/let/and/or/named-let lowered by syntactic transformation into the kernel evaluator, plus pure transformation shape checks; verifies short-circuit and value-returning and/or, let-bound fact, named-let loops in the evaluated language.
- ch4_analyzing_evaluator.esk (18 checks) — SICP 4.1.7: analyze-once evaluator returning execution procedures; covers self-eval, quote, variable, if, lambda, define, set!, begin, application; fact 5 = 120, fib 10 = 55; an analyze-count instrument proves execution triggers no re-analysis (analyze a lambda once, run at two arguments).
- ch4_lazy_evaluator.esk (14 checks) — SICP 4.2: normal-order evaluator with memoized thunks; (try 0 (/ 1 0)) = 1 with the division provably never run (plus a set!-operand side-effect proof), unless as a procedure, side-effect counter forced exactly once, infinite lazy list via cons-as-lambda and a lazy map over it.
- ch4_amb_evaluator.esk (11 checks) — SICP 4.3.3: metacircular amb evaluator with success/fail continuations; amb choice points, require, backtracking; multiple dwelling simplified to 3 people / 3 floors (unique solution (1 3 2) verified via all-values), an-integer-between defined in the evaluated language, Pythagorean triple search over 1..6.
- ch4_amb_parser.esk (10 checks) — SICP 4.3.2: nondeterministic parser over a tiny grammar; parses "the cat eats"; enumerates exactly the 2 parses of "the professor lectures to the student with the cat" (VP vs NP attachment) with both trees checked exactly; rejects non-sentences.
- ch4_query_system.esk (20 checks) — SICP 4.4: assertions DB, (? var) pattern matching, simple and `and` queries, and rules applied by full unification with variable renaming and occur check; genealogy grandson rule verified exactly (all instantiations, bound-arg, fully ground, and a rule+assertion `and` join). Frames are alists, frame streams plain lists.

Known-gap accommodations (no new gaps found):
- ESH-0078: base environments bind comparison primitives to boolean-normalizing wrapper lambdas (same as ch4_metacircular_full.esk).
- ESH-0080: searches and sentences kept shallow to stay under the deep-CPS SIGILL cap (same as ch4_amb.esk).

Verified via scripts/run_sicp_smoke.sh --allow-incomplete: 56/88 gate probes PASS (was 44/88); all 12 new probe runs (6 files x {r, aot}) PASS; remaining FAILs are missing-coverage placeholders for ch2/ch3/ch5 systems owned by other work.