### PR TITLE
test(sicp): ch5 full-book machine probes — stack, recursion, GC, explicit-control, compiler (ESH-0050/0051/0031/0032/0033)

### DIFF
--- a/tests/sicp/ch5_compiler.esk
+++ b/tests/sicp/ch5_compiler.esk
@@ -1,0 +1,392 @@
+;; SICP Chapter 5.5 — the compiler.  Compiles self-evaluating expressions,
+;; quotations, variables, definitions (incl. (define (f x) ...) shorthand),
+;; if, lambda, and applications (primitive AND compiled compound procedures)
+;; into the register-machine instruction language with target registers and
+;; linkage descriptors (next / return / a label), then executes the emitted
+;; sequences on the register-machine simulator from
+;; ch5_register_machine_stack.esk.  Register preservation is conservative
+;; (always save/restore continue/env/proc/argl around subexpression code)
+;; instead of the book's needs/modifies preserving analysis — the emitted
+;; code is correct, just not minimal.
+(define fails 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "FAIL: ") (display name) (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline))))
+
+;; ======================= register-machine simulator =======================
+(define (make-regs names)
+  (map (lambda (n) (cons n 0)) names))
+(define (reg-cell regs name)
+  (let loop ((rs regs))
+    (cond ((null? rs) (error "no register" name))
+          ((eq? (caar rs) name) (car rs))
+          (else (loop (cdr rs))))))
+(define (get-reg regs name) (cdr (reg-cell regs name)))
+(define (set-reg! regs name v) (set-cdr! (reg-cell regs name) v))
+
+(define (op-lookup ops name)
+  (let loop ((os ops))
+    (cond ((null? os) (error "no op" name))
+          ((eq? (caar os) name) (cdar os))
+          (else (loop (cdr os))))))
+
+(define (build-labels instrs)
+  (let loop ((is instrs) (i 0) (acc '()))
+    (cond ((null? is) (reverse acc))
+          ((symbol? (car is)) (loop (cdr is) (+ i 1) (cons (cons (car is) i) acc)))
+          (else (loop (cdr is) (+ i 1) acc)))))
+(define (label-index labels name)
+  (let loop ((ls labels))
+    (cond ((null? ls) (error "no label" name))
+          ((eq? (caar ls) name) (cdar ls))
+          (else (loop (cdr ls))))))
+
+(define (list->vec lst)
+  (let* ((n (length lst)) (v (make-vector n)))
+    (let loop ((i 0) (xs lst))
+      (if (null? xs) v (begin (vector-set! v i (car xs)) (loop (+ i 1) (cdr xs)))))))
+
+(define (eval-operand op regs labels)
+  (cond ((eq? (car op) 'const) (cadr op))
+        ((eq? (car op) 'reg) (get-reg regs (cadr op)))
+        ((eq? (car op) 'label) (label-index labels (cadr op)))
+        (else (error "bad operand" op))))
+
+(define (eval-opexp form regs ops labels)
+  (let ((proc (op-lookup ops (cadr form)))
+        (vals (map (lambda (a) (eval-operand a regs labels)) (cddr form))))
+    (apply proc vals)))
+
+;; Returns (list regs pushes max-depth final-depth).
+(define (run-machine reg-names ops instrs)
+  (let ((regs (make-regs reg-names))
+        (labels (build-labels instrs))
+        (code (list->vec instrs))
+        (n (length instrs)))
+    (let run ((pc 0) (flag #f) (stack '()) (depth 0) (pushes 0) (maxd 0))
+      (if (>= pc n)
+          (list regs pushes maxd depth)
+          (let ((ins (vector-ref code pc)))
+            (cond
+              ((symbol? ins) (run (+ pc 1) flag stack depth pushes maxd))
+              ((eq? (car ins) 'assign)
+               (let ((target (cadr ins)) (expr (caddr ins)))
+                 (set-reg! regs target
+                           (if (eq? (car expr) 'op)
+                               (eval-opexp expr regs ops labels)
+                               (eval-operand expr regs labels)))
+                 (run (+ pc 1) flag stack depth pushes maxd)))
+              ((eq? (car ins) 'test)
+               (run (+ pc 1) (eval-opexp (cadr ins) regs ops labels)
+                    stack depth pushes maxd))
+              ((eq? (car ins) 'branch)
+               (if (not (eq? flag #f))
+                   (run (label-index labels (cadr (cadr ins))) flag stack depth pushes maxd)
+                   (run (+ pc 1) flag stack depth pushes maxd)))
+              ((eq? (car ins) 'goto)
+               (let ((dest (cadr ins)))
+                 (if (eq? (car dest) 'label)
+                     (run (label-index labels (cadr dest)) flag stack depth pushes maxd)
+                     (run (get-reg regs (cadr dest)) flag stack depth pushes maxd))))
+              ((eq? (car ins) 'save)
+               (let ((d (+ depth 1)))
+                 (run (+ pc 1) flag
+                      (cons (get-reg regs (cadr ins)) stack)
+                      d (+ pushes 1) (max maxd d))))
+              ((eq? (car ins) 'restore)
+               (if (null? stack) (error "restore on empty stack" ins) #f)
+               (set-reg! regs (cadr ins) (car stack))
+               (run (+ pc 1) flag (cdr stack) (- depth 1) pushes maxd))
+              ((eq? (car ins) 'perform)
+               (eval-opexp (cadr ins) regs ops labels)
+               (run (+ pc 1) flag stack depth pushes maxd))
+              (else (error "bad instruction" ins))))))))
+
+(define (result-regs r) (car r))
+(define (result-depth r) (cadddr r))
+
+;; ======================= environment model =======================
+(define (make-frame vars vals)
+  (cons 'frame
+        (let loop ((a vars) (b vals))
+          (cond ((null? a) '())
+                ((null? b) (error "too few arguments" vars))
+                (else (cons (cons (car a) (car b)) (loop (cdr a) (cdr b))))))))
+(define (extend-env vars vals env) (cons (make-frame vars vals) env))
+(define (lookup-var var env)
+  (if (null? env)
+      (error "unbound variable" var)
+      (let scan ((bs (cdr (car env))))
+        (cond ((null? bs) (lookup-var var (cdr env)))
+              ((eq? (caar bs) var) (cdar bs))
+              (else (scan (cdr bs)))))))
+(define (define-var! var val env)
+  (let ((frame (car env)))
+    (let scan ((bs (cdr frame)))
+      (cond ((null? bs) (set-cdr! frame (cons (cons var val) (cdr frame))))
+            ((eq? (caar bs) var) (set-cdr! (car bs) val))
+            (else (scan (cdr bs)))))))
+(define (make-global-env)
+  (extend-env
+   '(+ - * = <)
+   (list (list 'primitive +)
+         (list 'primitive -)
+         (list 'primitive *)
+         (list 'primitive (lambda (a b) (if (= a b) #t #f)))
+         (list 'primitive (lambda (a b) (if (< a b) #t #f))))
+   '()))
+
+;; ======================= runtime operations =======================
+(define (tagged? e tag) (if (pair? e) (eq? (car e) tag) #f))
+(define machine-ops
+  (list
+   (cons 'lookup-variable-value (lambda (var env) (lookup-var var env)))
+   (cons 'define-variable! (lambda (var val env) (define-var! var val env)))
+   (cons 'extend-environment (lambda (vars vals env) (extend-env vars vals env)))
+   (cons 'false? (lambda (v) (if (eq? v #f) #t #f)))
+   (cons 'make-compiled-procedure (lambda (entry env) (list 'compiled-procedure entry env)))
+   (cons 'compiled-procedure-entry (lambda (p) (cadr p)))
+   (cons 'compiled-procedure-env (lambda (p) (caddr p)))
+   (cons 'primitive-procedure? (lambda (p) (tagged? p 'primitive)))
+   (cons 'apply-primitive-procedure (lambda (p args) (apply (cadr p) args)))
+   (cons 'list (lambda (v) (list v)))
+   (cons 'cons (lambda (a d) (cons a d)))))
+
+;; ======================= the compiler =======================
+(define label-counter 0)
+(define (new-label base)
+  (set! label-counter (+ label-counter 1))
+  (string->symbol (string-append base (number->string label-counter))))
+
+;; linkage: 'next | 'return | <label symbol>
+(define (end-with-linkage linkage seq)
+  (cond ((eq? linkage 'next) seq)
+        ((eq? linkage 'return) (append seq '((goto (reg continue)))))
+        (else (append seq (list (list 'goto (list 'label linkage)))))))
+
+(define (self-evaluating? e) (or (number? e) (string? e) (boolean? e)))
+
+(define (comp exp-in target linkage)
+  (cond ((self-evaluating? exp-in) (compile-self-eval exp-in target linkage))
+        ((symbol? exp-in) (compile-variable exp-in target linkage))
+        ((tagged? exp-in 'quote) (compile-quoted exp-in target linkage))
+        ((tagged? exp-in 'define) (compile-definition exp-in target linkage))
+        ((tagged? exp-in 'if) (compile-if exp-in target linkage))
+        ((tagged? exp-in 'lambda) (compile-lambda exp-in target linkage))
+        ((pair? exp-in) (compile-application exp-in target linkage))
+        (else (error "compile: unknown expression type" exp-in))))
+
+(define (compile-self-eval e target linkage)
+  (end-with-linkage linkage
+    (list (list 'assign target (list 'const e)))))
+
+(define (compile-quoted e target linkage)
+  (end-with-linkage linkage
+    (list (list 'assign target (list 'const (cadr e))))))
+
+(define (compile-variable e target linkage)
+  (end-with-linkage linkage
+    (list (list 'assign target
+                (list 'op 'lookup-variable-value (list 'const e) '(reg env))))))
+
+(define (definition-variable e)
+  (if (symbol? (cadr e)) (cadr e) (car (cadr e))))
+(define (definition-value e)
+  (if (symbol? (cadr e))
+      (caddr e)
+      (cons 'lambda (cons (cdr (cadr e)) (cddr e)))))
+
+(define (compile-definition e target linkage)
+  (append
+   (comp (definition-value e) 'val 'next)
+   (end-with-linkage linkage
+     (list (list 'perform (list 'op 'define-variable!
+                                (list 'const (definition-variable e))
+                                '(reg val) '(reg env)))
+           (list 'assign target '(const ok))))))
+
+(define (compile-if e target linkage)
+  (let ((f-branch (new-label "false-branch"))
+        (after-if (new-label "after-if")))
+    (let ((consequent-linkage (if (eq? linkage 'next) after-if linkage)))
+      (append
+       (comp (cadr e) 'val 'next)                       ; predicate -> val
+       (list (list 'test (list 'op 'false? '(reg val)))
+             (list 'branch (list 'label f-branch)))
+       (comp (caddr e) target consequent-linkage)       ; consequent
+       (list f-branch)
+       (comp (cadddr e) target linkage)                 ; alternative
+       (list after-if)))))
+
+(define (compile-lambda e target linkage)
+  (let ((entry (new-label "entry"))
+        (after-lambda (new-label "after-lambda")))
+    (append
+     (end-with-linkage (if (eq? linkage 'next) after-lambda linkage)
+       (list (list 'assign target
+                   (list 'op 'make-compiled-procedure
+                         (list 'label entry) '(reg env)))))
+     (list entry
+           '(assign env (op compiled-procedure-env (reg proc)))
+           (list 'assign 'env
+                 (list 'op 'extend-environment
+                       (list 'const (cadr e)) '(reg argl) '(reg env))))
+     (compile-sequence (cddr e) 'val 'return)
+     (list after-lambda))))
+
+(define (compile-sequence seq target linkage)
+  (if (null? (cdr seq))
+      (comp (car seq) target linkage)
+      (append (comp (car seq) target 'next)
+              (compile-sequence (cdr seq) target linkage))))
+
+;; Applications.  Conservative preservation: continue is saved across
+;; operator+operand evaluation and restored before the call; env is saved
+;; around the operator and around every operand; proc is saved across the
+;; arglist construction; argl is saved around every non-last operand.
+(define (compile-application e target linkage)
+  (if (not (eq? target 'val))
+      (error "application target must be val" target)
+      #f)
+  (append
+   '((save continue))
+   '((save env))
+   (comp (car e) 'proc 'next)                           ; operator -> proc
+   '((restore env))
+   '((save proc))
+   (construct-arglist (cdr e))
+   '((restore proc))
+   '((restore continue))
+   (compile-procedure-call linkage)))
+
+(define (construct-arglist operands)
+  (if (null? operands)
+      '((assign argl (const ())))
+      (let build ((rev-ops (reverse operands)) (first #t) (acc '()))
+        ;; rev-ops walks the operands right-to-left; the rightmost operand's
+        ;; block executes FIRST (it initializes argl), so each later block is
+        ;; appended AFTER the accumulated code.
+        (if (null? rev-ops)
+            acc
+            (build (cdr rev-ops) #f
+                   (append
+                    acc
+                    (if first '() '((save argl)))
+                    '((save env))
+                    (comp (car rev-ops) 'val 'next)
+                    '((restore env))
+                    (if first
+                        '((assign argl (op list (reg val))))
+                        '((restore argl)
+                          (assign argl (op cons (reg val) (reg argl)))))))))))
+
+(define (compile-procedure-call linkage)
+  (let ((prim-branch (new-label "primitive-branch"))
+        (comp-branch (new-label "compiled-branch"))
+        (after-call (new-label "after-call")))
+    (append
+     (list (list 'test '(op primitive-procedure? (reg proc)))
+           (list 'branch (list 'label prim-branch))
+           comp-branch)
+     (if (eq? linkage 'return)
+         '((assign val (op compiled-procedure-entry (reg proc)))
+           (goto (reg val)))
+         (list (list 'assign 'continue
+                     (list 'label (if (eq? linkage 'next) after-call linkage)))
+               '(assign val (op compiled-procedure-entry (reg proc)))
+               '(goto (reg val))))
+     ;; primitive branch: with 'next linkage it falls through to after-call;
+     ;; with return/label linkage end-with-linkage emits the jump.
+     (list prim-branch
+           '(assign val (op apply-primitive-procedure (reg proc) (reg argl))))
+     (end-with-linkage (if (eq? linkage 'next) 'next linkage) '())
+     (list after-call))))
+
+;; ======================= execution harness =======================
+;; Compile a list of top-level expressions into ONE program and run it in a
+;; FRESH global environment; returns (cons final-val final-stack-depth).
+;; One program per run because a compiled procedure's entry point is an
+;; instruction index that is only meaningful inside its own program.
+(define (compile-and-run exprs)
+  (let ((code
+         (let loop ((es exprs))
+           (if (null? es)
+               '()
+               (append (comp (car es) 'val 'next) (loop (cdr es)))))))
+    (let ((res (run-machine
+                '(env val proc argl continue)
+                machine-ops
+                (cons (list 'assign 'env (list 'const (make-global-env))) code))))
+      (cons (get-reg (result-regs res) 'val)
+            (result-depth res)))))
+(define (compile-eval exprs) (car (compile-and-run exprs)))
+
+;; ---- straight-line code ----
+(check "compiled self-eval" 42 (compile-eval (list 42)))
+(check "compiled quote" 'hello (compile-eval (list ''hello)))
+(check "compiled primitive application (+ 1 2)" 3
+       (compile-eval (list '(+ 1 2))))
+(check "compiled nested application" 14
+       (compile-eval (list '(* (+ 1 6) 2))))
+(check "compiled define + variable" 7
+       (compile-eval (list '(define x 7) 'x)))
+
+;; ---- conditionals select correctly ----
+(check "compiled if selects consequent" 'yes
+       (compile-eval (list '(if (< 1 2) (quote yes) (quote no)))))
+(check "compiled if selects alternative" 'no
+       (compile-eval (list '(if (< 2 1) (quote yes) (quote no)))))
+(check "compiled if literal #f" 2 (compile-eval (list '(if #f 1 2))))
+(check "compiled if as operand" 30
+       (compile-eval (list '(* 3 (if (= 1 1) 10 20)))))
+
+;; ---- compiled lambda / compound procedures ----
+(check "compiled ((lambda (n) (* n n)) 4)" 16
+       (compile-eval (list '((lambda (n) (* n n)) 4))))
+(check "compiled (define (sq x) (* x x)); (sq 5)" 25
+       (compile-eval (list '(define (sq x) (* x x)) '(sq 5))))
+(check "compiled two-arg compound" 7
+       (compile-eval (list '(define (sub a b) (- a b)) '(sub 10 3))))
+(check "compiled compound calling compound" 81
+       (compile-eval (list '(define (sq x) (* x x))
+                           '(define (quart y) (sq (sq y)))
+                           '(quart 3))))
+
+;; ---- recursion through compiled code (return linkage + full call protocol)
+(let ((r (compile-and-run
+          (list '(define (cfact n) (if (= n 1) 1 (* n (cfact (- n 1)))))
+                '(cfact 5)))))
+  (check "compiled recursive factorial (cfact 5)" 120 (car r))
+  (check "compiled cfact stack balanced at halt" 0 (cdr r)))
+
+;; ---- structural check: compiled if contains test / branch / label in order
+(define if-seq (comp '(if (< 1 2) 1 2) 'val 'next))
+(define (find-index pred seq start)
+  (let loop ((i 0) (s seq))
+    (cond ((null? s) -1)
+          ((and (>= i start) (pred (car s))) i)
+          (else (loop (+ i 1) (cdr s))))))
+(define ti (find-index (lambda (ins) (tagged? ins 'test)) if-seq 0))
+(define bi (find-index (lambda (ins) (tagged? ins 'branch)) if-seq 0))
+(define li (find-index (lambda (ins) (symbol? ins)) if-seq 0))
+(check "compiled if has a test instruction" #t (if (>= ti 0) #t #f))
+(check "compiled if has a branch instruction" #t (if (> bi ti) #t #f))
+(check "compiled if has a label after the branch" #t (if (> li bi) #t #f))
+(check "compiled if branch targets the false branch label" #t
+       (let ((target (cadr (cadr (list-ref if-seq bi)))))
+         (if (>= (find-index (lambda (ins) (eq? ins target)) if-seq bi) 0) #t #f)))
+
+;; target-register discipline: compiling to a different target lands there
+(define to-proc (comp 42 'proc 'next))
+(check "compile honors target register" 'proc (cadr (car to-proc)))
+;; linkage discipline: return linkage ends with (goto (reg continue))
+(define ret-seq (comp 42 'val 'return))
+(check "return linkage emits (goto (reg continue))" '(goto (reg continue))
+       (list-ref ret-seq (- (length ret-seq) 1)))
+
+(display "ch5 compiler: ")
+(display (if (= fails 0) "ALL PASS" (cons fails 'FAILS))) (newline)
+(if (> fails 0) (error "failures" fails) #t)

--- a/tests/sicp/ch5_explicit_control_evaluator.esk
+++ b/tests/sicp/ch5_explicit_control_evaluator.esk
@@ -1,0 +1,422 @@
+;; SICP Chapter 5.4 — the explicit-control evaluator as a register machine.
+;; The register-machine simulator (stack-instrumented, from
+;; ch5_register_machine_stack.esk) runs the book's eval-dispatch/apply-dispatch
+;; controller over registers exp/env/val/proc/argl/continue/unev with
+;; save/restore stack discipline.  Implemented dispatch: self-evaluating,
+;; variable, quote, if, lambda, begin/sequence, definition, and application
+;; with both primitive and compound procedures over a frame-list environment
+;; model.  Omitted forms (set!, cond, let) are not needed by these probes.
+(define fails 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "FAIL: ") (display name) (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline))))
+
+;; ======================= register-machine simulator =======================
+(define (make-regs names)
+  (map (lambda (n) (cons n 0)) names))
+(define (reg-cell regs name)
+  (let loop ((rs regs))
+    (cond ((null? rs) (error "no register" name))
+          ((eq? (caar rs) name) (car rs))
+          (else (loop (cdr rs))))))
+(define (get-reg regs name) (cdr (reg-cell regs name)))
+(define (set-reg! regs name v) (set-cdr! (reg-cell regs name) v))
+
+(define (op-lookup ops name)
+  (let loop ((os ops))
+    (cond ((null? os) (error "no op" name))
+          ((eq? (caar os) name) (cdar os))
+          (else (loop (cdr os))))))
+
+(define (build-labels instrs)
+  (let loop ((is instrs) (i 0) (acc '()))
+    (cond ((null? is) (reverse acc))
+          ((symbol? (car is)) (loop (cdr is) (+ i 1) (cons (cons (car is) i) acc)))
+          (else (loop (cdr is) (+ i 1) acc)))))
+(define (label-index labels name)
+  (let loop ((ls labels))
+    (cond ((null? ls) (error "no label" name))
+          ((eq? (caar ls) name) (cdar ls))
+          (else (loop (cdr ls))))))
+
+(define (list->vec lst)
+  (let* ((n (length lst)) (v (make-vector n)))
+    (let loop ((i 0) (xs lst))
+      (if (null? xs) v (begin (vector-set! v i (car xs)) (loop (+ i 1) (cdr xs)))))))
+
+(define (eval-operand op regs labels)
+  (cond ((eq? (car op) 'const) (cadr op))
+        ((eq? (car op) 'reg) (get-reg regs (cadr op)))
+        ((eq? (car op) 'label) (label-index labels (cadr op)))
+        (else (error "bad operand" op))))
+
+(define (eval-opexp form regs ops labels)
+  (let ((proc (op-lookup ops (cadr form)))
+        (vals (map (lambda (a) (eval-operand a regs labels)) (cddr form))))
+    (apply proc vals)))
+
+;; Returns (list regs pushes max-depth final-depth).
+(define (run-machine reg-names ops instrs)
+  (let ((regs (make-regs reg-names))
+        (labels (build-labels instrs))
+        (code (list->vec instrs))
+        (n (length instrs)))
+    (let run ((pc 0) (flag #f) (stack '()) (depth 0) (pushes 0) (maxd 0))
+      (if (>= pc n)
+          (list regs pushes maxd depth)
+          (let ((ins (vector-ref code pc)))
+            (cond
+              ((symbol? ins) (run (+ pc 1) flag stack depth pushes maxd))
+              ((eq? (car ins) 'assign)
+               (let ((target (cadr ins)) (expr (caddr ins)))
+                 (set-reg! regs target
+                           (if (eq? (car expr) 'op)
+                               (eval-opexp expr regs ops labels)
+                               (eval-operand expr regs labels)))
+                 (run (+ pc 1) flag stack depth pushes maxd)))
+              ((eq? (car ins) 'test)
+               (run (+ pc 1) (eval-opexp (cadr ins) regs ops labels)
+                    stack depth pushes maxd))
+              ((eq? (car ins) 'branch)
+               (if (not (eq? flag #f))
+                   (run (label-index labels (cadr (cadr ins))) flag stack depth pushes maxd)
+                   (run (+ pc 1) flag stack depth pushes maxd)))
+              ((eq? (car ins) 'goto)
+               (let ((dest (cadr ins)))
+                 (if (eq? (car dest) 'label)
+                     (run (label-index labels (cadr dest)) flag stack depth pushes maxd)
+                     (run (get-reg regs (cadr dest)) flag stack depth pushes maxd))))
+              ((eq? (car ins) 'save)
+               (let ((d (+ depth 1)))
+                 (run (+ pc 1) flag
+                      (cons (get-reg regs (cadr ins)) stack)
+                      d (+ pushes 1) (max maxd d))))
+              ((eq? (car ins) 'restore)
+               (if (null? stack) (error "restore on empty stack" ins) #f)
+               (set-reg! regs (cadr ins) (car stack))
+               (run (+ pc 1) flag (cdr stack) (- depth 1) pushes maxd))
+              ((eq? (car ins) 'perform)
+               (eval-opexp (cadr ins) regs ops labels)
+               (run (+ pc 1) flag stack depth pushes maxd))
+              (else (error "bad instruction" ins))))))))
+
+(define (result-regs r) (car r))
+(define (result-depth r) (cadddr r))
+
+;; ======================= environment model =======================
+;; env = list of frames; frame = (cons 'frame binding-list); binding = (var . val)
+(define (make-frame vars vals)
+  (cons 'frame
+        (let loop ((a vars) (b vals))
+          (cond ((null? a) '())
+                ((null? b) (error "too few arguments" vars))
+                (else (cons (cons (car a) (car b)) (loop (cdr a) (cdr b))))))))
+(define (extend-env vars vals env) (cons (make-frame vars vals) env))
+(define (lookup-var var env)
+  (if (null? env)
+      (error "unbound variable" var)
+      (let scan ((bs (cdr (car env))))
+        (cond ((null? bs) (lookup-var var (cdr env)))
+              ((eq? (caar bs) var) (cdar bs))
+              (else (scan (cdr bs)))))))
+(define (define-var! var val env)
+  (let ((frame (car env)))
+    (let scan ((bs (cdr frame)))
+      (cond ((null? bs) (set-cdr! frame (cons (cons var val) (cdr frame))))
+            ((eq? (caar bs) var) (set-cdr! (car bs) val))
+            (else (scan (cdr bs)))))))
+
+(define (make-global-env)
+  (extend-env
+   '(+ - * = <)
+   (list (list 'primitive +)
+         (list 'primitive -)
+         (list 'primitive *)
+         (list 'primitive (lambda (a b) (if (= a b) #t #f)))
+         (list 'primitive (lambda (a b) (if (< a b) #t #f))))
+   '()))
+
+;; ======================= evaluator operations =======================
+(define (tagged? e tag) (if (pair? e) (eq? (car e) tag) #f))
+
+(define ece-ops
+  (list
+   (cons 'self-eval?
+         (lambda (e) (if (or (number? e) (string? e) (boolean? e)) #t #f)))
+   (cons 'variable? (lambda (e) (if (symbol? e) #t #f)))
+   (cons 'lookup-variable-value (lambda (var env) (lookup-var var env)))
+   (cons 'quoted? (lambda (e) (tagged? e 'quote)))
+   (cons 'text-of-quotation (lambda (e) (cadr e)))
+   (cons 'if? (lambda (e) (tagged? e 'if)))
+   (cons 'if-predicate (lambda (e) (cadr e)))
+   (cons 'if-consequent (lambda (e) (caddr e)))
+   (cons 'if-alternative
+         (lambda (e) (if (null? (cdddr e)) #f (cadddr e))))
+   (cons 'true? (lambda (v) (if (eq? v #f) #f #t)))
+   (cons 'lambda? (lambda (e) (tagged? e 'lambda)))
+   (cons 'lambda-parameters (lambda (e) (cadr e)))
+   (cons 'lambda-body (lambda (e) (cddr e)))
+   (cons 'make-procedure
+         (lambda (params body env) (list 'procedure params body env)))
+   (cons 'definition? (lambda (e) (tagged? e 'define)))
+   (cons 'definition-variable
+         (lambda (e) (if (symbol? (cadr e)) (cadr e) (car (cadr e)))))
+   (cons 'definition-value
+         (lambda (e)
+           (if (symbol? (cadr e))
+               (caddr e)
+               (cons 'lambda (cons (cdr (cadr e)) (cddr e))))))
+   (cons 'define-variable!
+         (lambda (var val env) (define-var! var val env)))
+   (cons 'begin? (lambda (e) (tagged? e 'begin)))
+   (cons 'begin-actions (lambda (e) (cdr e)))
+   (cons 'first-exp (lambda (seq) (car seq)))
+   (cons 'last-exp? (lambda (seq) (if (null? (cdr seq)) #t #f)))
+   (cons 'rest-exps (lambda (seq) (cdr seq)))
+   (cons 'application? (lambda (e) (if (pair? e) #t #f)))
+   (cons 'operator (lambda (e) (car e)))
+   (cons 'operands (lambda (e) (cdr e)))
+   (cons 'empty-arglist (lambda () '()))
+   (cons 'no-operands? (lambda (os) (if (null? os) #t #f)))
+   (cons 'first-operand (lambda (os) (car os)))
+   (cons 'last-operand? (lambda (os) (if (null? (cdr os)) #t #f)))
+   (cons 'rest-operands (lambda (os) (cdr os)))
+   (cons 'adjoin-arg (lambda (v argl) (append argl (list v))))
+   (cons 'primitive-procedure? (lambda (p) (tagged? p 'primitive)))
+   (cons 'compound-procedure? (lambda (p) (tagged? p 'procedure)))
+   (cons 'apply-primitive-procedure
+         (lambda (p args) (apply (cadr p) args)))
+   (cons 'procedure-parameters (lambda (p) (cadr p)))
+   (cons 'procedure-body (lambda (p) (caddr p)))
+   (cons 'procedure-environment (lambda (p) (cadddr p)))
+   (cons 'extend-environment
+         (lambda (vars vals env) (extend-env vars vals env)))))
+
+;; ======================= the controller (SICP 5.4) =======================
+(define ece-controller
+  '((assign continue (label ece-done))
+    eval-dispatch
+    (test (op self-eval? (reg exp)))
+    (branch (label ev-self-eval))
+    (test (op variable? (reg exp)))
+    (branch (label ev-variable))
+    (test (op quoted? (reg exp)))
+    (branch (label ev-quoted))
+    (test (op definition? (reg exp)))
+    (branch (label ev-definition))
+    (test (op if? (reg exp)))
+    (branch (label ev-if))
+    (test (op lambda? (reg exp)))
+    (branch (label ev-lambda))
+    (test (op begin? (reg exp)))
+    (branch (label ev-begin))
+    (test (op application? (reg exp)))
+    (branch (label ev-application))
+    (goto (label unknown-expression-type))
+
+    ev-self-eval
+    (assign val (reg exp))
+    (goto (reg continue))
+    ev-variable
+    (assign val (op lookup-variable-value (reg exp) (reg env)))
+    (goto (reg continue))
+    ev-quoted
+    (assign val (op text-of-quotation (reg exp)))
+    (goto (reg continue))
+    ev-lambda
+    (assign unev (op lambda-parameters (reg exp)))
+    (assign exp (op lambda-body (reg exp)))
+    (assign val (op make-procedure (reg unev) (reg exp) (reg env)))
+    (goto (reg continue))
+
+    ev-application
+    (save continue)
+    (save env)
+    (assign unev (op operands (reg exp)))
+    (save unev)
+    (assign exp (op operator (reg exp)))
+    (assign continue (label ev-appl-did-operator))
+    (goto (label eval-dispatch))
+    ev-appl-did-operator
+    (restore unev)
+    (restore env)
+    (assign argl (op empty-arglist))
+    (assign proc (reg val))
+    (test (op no-operands? (reg unev)))
+    (branch (label apply-dispatch))
+    (save proc)
+    ev-appl-operand-loop
+    (save argl)
+    (assign exp (op first-operand (reg unev)))
+    (test (op last-operand? (reg unev)))
+    (branch (label ev-appl-last-arg))
+    (save env)
+    (save unev)
+    (assign continue (label ev-appl-accumulate-arg))
+    (goto (label eval-dispatch))
+    ev-appl-accumulate-arg
+    (restore unev)
+    (restore env)
+    (restore argl)
+    (assign argl (op adjoin-arg (reg val) (reg argl)))
+    (assign unev (op rest-operands (reg unev)))
+    (goto (label ev-appl-operand-loop))
+    ev-appl-last-arg
+    (assign continue (label ev-appl-accum-last-arg))
+    (goto (label eval-dispatch))
+    ev-appl-accum-last-arg
+    (restore argl)
+    (assign argl (op adjoin-arg (reg val) (reg argl)))
+    (restore proc)
+    (goto (label apply-dispatch))
+
+    apply-dispatch
+    (test (op primitive-procedure? (reg proc)))
+    (branch (label primitive-apply))
+    (test (op compound-procedure? (reg proc)))
+    (branch (label compound-apply))
+    (goto (label unknown-procedure-type))
+    primitive-apply
+    (assign val (op apply-primitive-procedure (reg proc) (reg argl)))
+    (restore continue)
+    (goto (reg continue))
+    compound-apply
+    (assign unev (op procedure-parameters (reg proc)))
+    (assign env (op procedure-environment (reg proc)))
+    (assign env (op extend-environment (reg unev) (reg argl) (reg env)))
+    (assign unev (op procedure-body (reg proc)))
+    (goto (label ev-sequence))
+
+    ev-begin
+    (assign unev (op begin-actions (reg exp)))
+    (save continue)
+    (goto (label ev-sequence))
+    ev-sequence
+    (assign exp (op first-exp (reg unev)))
+    (test (op last-exp? (reg unev)))
+    (branch (label ev-sequence-last-exp))
+    (save unev)
+    (save env)
+    (assign continue (label ev-sequence-continue))
+    (goto (label eval-dispatch))
+    ev-sequence-continue
+    (restore env)
+    (restore unev)
+    (assign unev (op rest-exps (reg unev)))
+    (goto (label ev-sequence))
+    ev-sequence-last-exp
+    (restore continue)
+    (goto (label eval-dispatch))
+
+    ev-if
+    (save exp)
+    (save env)
+    (save continue)
+    (assign continue (label ev-if-decide))
+    (assign exp (op if-predicate (reg exp)))
+    (goto (label eval-dispatch))
+    ev-if-decide
+    (restore continue)
+    (restore env)
+    (restore exp)
+    (test (op true? (reg val)))
+    (branch (label ev-if-consequent))
+    ev-if-alternative
+    (assign exp (op if-alternative (reg exp)))
+    (goto (label eval-dispatch))
+    ev-if-consequent
+    (assign exp (op if-consequent (reg exp)))
+    (goto (label eval-dispatch))
+
+    ev-definition
+    (assign unev (op definition-variable (reg exp)))
+    (save unev)
+    (assign exp (op definition-value (reg exp)))
+    (save env)
+    (save continue)
+    (assign continue (label ev-definition-1))
+    (goto (label eval-dispatch))
+    ev-definition-1
+    (restore continue)
+    (restore env)
+    (restore unev)
+    (perform (op define-variable! (reg unev) (reg val) (reg env)))
+    (assign val (const ok))
+    (goto (reg continue))
+
+    unknown-expression-type
+    (assign val (const unknown-expression-type-error))
+    (goto (label ece-done))
+    unknown-procedure-type
+    (assign val (const unknown-procedure-type-error))
+    (goto (label ece-done))
+    ece-done))
+
+;; drive one expression through the machine; returns (val . final-stack-depth)
+(define (machine-eval expr env)
+  (let ((res (run-machine
+              '(exp env val proc argl continue unev)
+              ece-ops
+              (append (list (list 'assign 'exp (list 'const expr))
+                            (list 'assign 'env (list 'const env)))
+                      ece-controller))))
+    (cons (get-reg (result-regs res) 'val)
+          (result-depth res))))
+(define (ece-eval expr env) (car (machine-eval expr env)))
+
+;; ======================= the probes =======================
+(define genv (make-global-env))
+
+(check "ece self-evaluating number" 42 (ece-eval 42 genv))
+(check "ece self-evaluating string" "hi" (ece-eval "hi" genv))
+(check "ece quote" 'hello (ece-eval '(quote hello) genv))
+(check "ece quoted list" '(1 2 3) (ece-eval '(quote (1 2 3)) genv))
+
+(check "ece definition returns ok" 'ok (ece-eval '(define x 7) genv))
+(check "ece variable lookup" 7 (ece-eval 'x genv))
+(check "ece primitive variable lookup" #t
+       (tagged? (ece-eval '+ genv) 'primitive))
+
+(check "ece if true branch" 1 (ece-eval '(if #t 1 2) genv))
+(check "ece if false branch" 2 (ece-eval '(if #f 1 2) genv))
+(check "ece if with computed predicate" 'yes
+       (ece-eval '(if (< 1 2) (quote yes) (quote no)) genv))
+(check "ece if computed false predicate" 'no
+       (ece-eval '(if (< 2 1) (quote yes) (quote no)) genv))
+
+(check "ece primitive application" 3 (ece-eval '(+ 1 2) genv))
+(check "ece nested application" 14 (ece-eval '(* (+ 1 6) 2) genv))
+
+(check "ece lambda creates compound procedure" #t
+       (tagged? (ece-eval '(lambda (x) x) genv) 'procedure))
+(check "ece ((lambda (x) (* x x)) 4)" 16
+       (ece-eval '((lambda (x) (* x x)) 4) genv))
+(check "ece two-arg lambda" 7
+       (ece-eval '((lambda (a b) (- a b)) 10 3) genv))
+(check "ece lexical capture" 30
+       (ece-eval '(((lambda (a) (lambda (b) (* a b))) 5) 6) genv))
+
+(check "ece begin sequence" 3 (ece-eval '(begin 1 2 3) genv))
+(check "ece begin with side effect" 99
+       (ece-eval '(begin (define y 99) y) genv))
+
+;; recursive factorial through the machine (define, then apply)
+(check "ece define fact" 'ok
+       (ece-eval '(define fact
+                    (lambda (n) (if (= n 1) 1 (* n (fact (- n 1))))))
+                 genv))
+(let ((r (machine-eval '(fact 4) genv)))
+  (check "ece recursive fact 4" 24 (car r))
+  (check "ece fact 4 stack balanced at halt" 0 (cdr r)))
+(check "ece recursive fact 6" 720 (ece-eval '(fact 6) genv))
+
+;; shorthand define form (define (sq x) ...)
+(check "ece shorthand define" 'ok (ece-eval '(define (sq z) (* z z)) genv))
+(check "ece shorthand define call" 25 (ece-eval '(sq 5) genv))
+
+(display "ch5 explicit control evaluator: ")
+(display (if (= fails 0) "ALL PASS" (cons fails 'FAILS))) (newline)
+(if (> fails 0) (error "failures" fails) #t)

--- a/tests/sicp/ch5_register_machine_recursive.esk
+++ b/tests/sicp/ch5_register_machine_recursive.esk
@@ -1,0 +1,178 @@
+;; SICP Chapter 5.1.4 (fig 5.12) — the doubly-recursive Fibonacci machine.
+;; Uses the stack-instrumented simulator: save/restore of continue/n/val,
+;; (assign r (label l)) return points, (goto (reg continue)) dispatch.
+;; Asserts fib 8 = 21, fib 10 = 55, and that the deeper computation performs
+;; strictly more stack pushes (exercise 5.29 territory).
+(define fails 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "FAIL: ") (display name) (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline))))
+
+;; ---- register file: a-list of (name . value), mutated with set-cdr! ----
+(define (make-regs names)
+  (map (lambda (n) (cons n 0)) names))
+(define (reg-cell regs name)
+  (let loop ((rs regs))
+    (cond ((null? rs) (error "no register" name))
+          ((eq? (caar rs) name) (car rs))
+          (else (loop (cdr rs))))))
+(define (get-reg regs name) (cdr (reg-cell regs name)))
+(define (set-reg! regs name v) (set-cdr! (reg-cell regs name) v))
+
+;; ---- operation table ----
+(define (op-lookup ops name)
+  (let loop ((os ops))
+    (cond ((null? os) (error "no op" name))
+          ((eq? (caar os) name) (cdar os))
+          (else (loop (cdr os))))))
+
+;; ---- label table ----
+(define (build-labels instrs)
+  (let loop ((is instrs) (i 0) (acc '()))
+    (cond ((null? is) (reverse acc))
+          ((symbol? (car is)) (loop (cdr is) (+ i 1) (cons (cons (car is) i) acc)))
+          (else (loop (cdr is) (+ i 1) acc)))))
+(define (label-index labels name)
+  (let loop ((ls labels))
+    (cond ((null? ls) (error "no label" name))
+          ((eq? (caar ls) name) (cdar ls))
+          (else (loop (cdr ls))))))
+
+(define (list->vec lst)
+  (let* ((n (length lst)) (v (make-vector n)))
+    (let loop ((i 0) (xs lst))
+      (if (null? xs) v (begin (vector-set! v i (car xs)) (loop (+ i 1) (cdr xs)))))))
+
+;; operand: (const v) | (reg r) | (label l)
+(define (eval-operand op regs labels)
+  (cond ((eq? (car op) 'const) (cadr op))
+        ((eq? (car op) 'reg) (get-reg regs (cadr op)))
+        ((eq? (car op) 'label) (label-index labels (cadr op)))
+        (else (error "bad operand" op))))
+
+(define (eval-opexp form regs ops labels)
+  (let ((proc (op-lookup ops (cadr form)))
+        (vals (map (lambda (a) (eval-operand a regs labels)) (cddr form))))
+    (apply proc vals)))
+
+;; ---- machine loop with stack + statistics ----
+;; Returns (list regs pushes max-depth final-depth).
+(define (run-machine reg-names ops instrs)
+  (let ((regs (make-regs reg-names))
+        (labels (build-labels instrs))
+        (code (list->vec instrs))
+        (n (length instrs)))
+    (let run ((pc 0) (flag #f) (stack '()) (depth 0) (pushes 0) (maxd 0))
+      (if (>= pc n)
+          (list regs pushes maxd depth)
+          (let ((ins (vector-ref code pc)))
+            (cond
+              ((symbol? ins) (run (+ pc 1) flag stack depth pushes maxd))
+              ((eq? (car ins) 'assign)
+               (let ((target (cadr ins)) (expr (caddr ins)))
+                 (set-reg! regs target
+                           (if (eq? (car expr) 'op)
+                               (eval-opexp expr regs ops labels)
+                               (eval-operand expr regs labels)))
+                 (run (+ pc 1) flag stack depth pushes maxd)))
+              ((eq? (car ins) 'test)
+               (run (+ pc 1) (eval-opexp (cadr ins) regs ops labels)
+                    stack depth pushes maxd))
+              ((eq? (car ins) 'branch)
+               (if (not (eq? flag #f))
+                   (run (label-index labels (cadr (cadr ins))) flag stack depth pushes maxd)
+                   (run (+ pc 1) flag stack depth pushes maxd)))
+              ((eq? (car ins) 'goto)
+               (let ((dest (cadr ins)))
+                 (if (eq? (car dest) 'label)
+                     (run (label-index labels (cadr dest)) flag stack depth pushes maxd)
+                     (run (get-reg regs (cadr dest)) flag stack depth pushes maxd))))
+              ((eq? (car ins) 'save)
+               (let ((d (+ depth 1)))
+                 (run (+ pc 1) flag
+                      (cons (get-reg regs (cadr ins)) stack)
+                      d (+ pushes 1) (max maxd d))))
+              ((eq? (car ins) 'restore)
+               (if (null? stack) (error "restore on empty stack" ins) #f)
+               (set-reg! regs (cadr ins) (car stack))
+               (run (+ pc 1) flag (cdr stack) (- depth 1) pushes maxd))
+              (else (error "bad instruction" ins))))))))
+
+(define (result-regs r) (car r))
+(define (result-pushes r) (cadr r))
+(define (result-maxd r) (caddr r))
+(define (result-depth r) (cadddr r))
+
+(define ops
+  (list (cons '+ +) (cons '- -)
+        (cons '< (lambda (a b) (if (< a b) #t #f)))))
+
+;; ---- the Fibonacci machine (SICP fig 5.12) ----
+(define (run-fib n)
+  (run-machine
+   '(n val continue)
+   ops
+   (list
+    (list 'assign 'n (list 'const n))
+    '(assign continue (label fib-done))
+    'fib-loop
+    '(test (op < (reg n) (const 2)))
+    '(branch (label immediate-answer))
+    ;; set up to compute Fib(n-1)
+    '(save continue)
+    '(assign continue (label afterfib-n-1))
+    '(save n)
+    '(assign n (op - (reg n) (const 1)))
+    '(goto (label fib-loop))
+    'afterfib-n-1
+    '(restore n)
+    '(restore continue)
+    ;; set up to compute Fib(n-2)
+    '(assign n (op - (reg n) (const 2)))
+    '(save continue)
+    '(assign continue (label afterfib-n-2))
+    '(save val)                       ; save Fib(n-1)
+    '(goto (label fib-loop))
+    'afterfib-n-2
+    '(assign n (reg val))             ; n contains Fib(n-2)
+    '(restore val)                    ; val contains Fib(n-1)
+    '(restore continue)
+    '(assign val (op + (reg val) (reg n)))
+    '(goto (reg continue))
+    'immediate-answer
+    '(assign val (reg n))
+    '(goto (reg continue))
+    'fib-done)))
+
+(define r8 (run-fib 8))
+(define r10 (run-fib 10))
+
+(check "fib machine: fib 8" 21 (get-reg (result-regs r8) 'val))
+(check "fib machine: fib 10" 55 (get-reg (result-regs r10) 'val))
+(check "fib machine: fib 1" 1
+       (get-reg (result-regs (run-fib 1)) 'val))
+(check "fib machine: fib 0" 0
+       (get-reg (result-regs (run-fib 0)) 'val))
+(check "pushes(fib 10) > pushes(fib 8)" #t
+       (if (> (result-pushes r10) (result-pushes r8)) #t #f))
+(check "max-depth(fib 10) > max-depth(fib 8)" #t
+       (if (> (result-maxd r10) (result-maxd r8)) #t #f))
+(check "fib 8 stack balanced at halt" 0 (result-depth r8))
+(check "fib 10 stack balanced at halt" 0 (result-depth r10))
+;; exercise 5.29(a): max depth of the tree-recursive machine is 2(n-1), n>=1
+(check "fib 8 max depth = 2(n-1) = 14" 14 (result-maxd r8))
+(check "fib 10 max depth = 2(n-1) = 18" 18 (result-maxd r10))
+;; exercise 5.29(b): pushes obey S(n) = S(n-1) + S(n-2) + k; here k = 4
+;; (2 pushes before each of the two recursive calls); S(0) = S(1) = 0
+(check "fib 8 push count = 132" 132 (result-pushes r8))
+(check "fib 10 push count = 352" 352 (result-pushes r10))
+(check "pushes obey S(10) = S(9) + S(8) + 4" #t
+       (let ((s9 (result-pushes (run-fib 9))))
+         (if (= (result-pushes r10) (+ s9 (result-pushes r8) 4)) #t #f)))
+
+(display "ch5 register machine recursive: ")
+(display (if (= fails 0) "ALL PASS" (cons fails 'FAILS))) (newline)
+(if (> fails 0) (error "failures" fails) #t)

--- a/tests/sicp/ch5_register_machine_stack.esk
+++ b/tests/sicp/ch5_register_machine_stack.esk
@@ -1,0 +1,206 @@
+;; SICP Chapter 5.1.4/5.2 — register machine with a stack.
+;; Extends the ch5_register_machine.esk simulator with save/restore
+;; instructions, (assign r (label l)) so `continue` can hold return points,
+;; (goto (reg r)) through such values, and stack statistics: total push count
+;; and maximum depth, plus (perform (op initialize-stack)) which resets both
+;; the stack and its statistics.  Runs the book's RECURSIVE factorial machine
+;; and asserts the exact push count / max depth from exercise 5.14:
+;; for n, pushes = 2(n-1) and max-depth = 2(n-1).
+(define fails 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "FAIL: ") (display name) (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline))))
+
+;; ---- register file: a-list of (name . value), mutated with set-cdr! ----
+(define (make-regs names)
+  (map (lambda (n) (cons n 0)) names))
+(define (reg-cell regs name)
+  (let loop ((rs regs))
+    (cond ((null? rs) (error "no register" name))
+          ((eq? (caar rs) name) (car rs))
+          (else (loop (cdr rs))))))
+(define (get-reg regs name) (cdr (reg-cell regs name)))
+(define (set-reg! regs name v) (set-cdr! (reg-cell regs name) v))
+
+;; ---- operation table ----
+(define (op-lookup ops name)
+  (let loop ((os ops))
+    (cond ((null? os) (error "no op" name))
+          ((eq? (caar os) name) (cdar os))
+          (else (loop (cdr os))))))
+
+;; ---- label table: maps a label symbol to its index in the instr vector ----
+(define (build-labels instrs)
+  (let loop ((is instrs) (i 0) (acc '()))
+    (cond ((null? is) (reverse acc))
+          ((symbol? (car is)) (loop (cdr is) (+ i 1) (cons (cons (car is) i) acc)))
+          (else (loop (cdr is) (+ i 1) acc)))))
+(define (label-index labels name)
+  (let loop ((ls labels))
+    (cond ((null? ls) (error "no label" name))
+          ((eq? (caar ls) name) (cdar ls))
+          (else (loop (cdr ls))))))
+
+;; instrs as a vector for O(1) pc indexing
+(define (list->vec lst)
+  (let* ((n (length lst)) (v (make-vector n)))
+    (let loop ((i 0) (xs lst))
+      (if (null? xs) v (begin (vector-set! v i (car xs)) (loop (+ i 1) (cdr xs)))))))
+
+;; evaluate an operand: (const v) | (reg r) | (label l)
+(define (eval-operand op regs labels)
+  (cond ((eq? (car op) 'const) (cadr op))
+        ((eq? (car op) 'reg) (get-reg regs (cadr op)))
+        ((eq? (car op) 'label) (label-index labels (cadr op)))
+        (else (error "bad operand" op))))
+
+;; evaluate (op name arg...) form -> applies the op proc to operand values
+(define (eval-opexp form regs ops labels)
+  (let ((proc (op-lookup ops (cadr form)))
+        (vals (map (lambda (a) (eval-operand a regs labels)) (cddr form))))
+    (apply proc vals)))
+
+;; ---- the machine loop, with stack + statistics ----
+;; Returns (list regs pushes max-depth final-depth).
+(define (run-machine reg-names ops instrs)
+  (let ((regs (make-regs reg-names))
+        (labels (build-labels instrs))
+        (code (list->vec instrs))
+        (n (length instrs)))
+    (let run ((pc 0) (flag #f) (stack '()) (depth 0) (pushes 0) (maxd 0))
+      (if (>= pc n)
+          (list regs pushes maxd depth)               ; halted
+          (let ((ins (vector-ref code pc)))
+            (cond
+              ((symbol? ins) (run (+ pc 1) flag stack depth pushes maxd)) ; label
+              ((eq? (car ins) 'assign)
+               (let ((target (cadr ins)) (expr (caddr ins)))
+                 (set-reg! regs target
+                           (if (eq? (car expr) 'op)
+                               (eval-opexp expr regs ops labels)
+                               (eval-operand expr regs labels)))
+                 (run (+ pc 1) flag stack depth pushes maxd)))
+              ((eq? (car ins) 'test)
+               (run (+ pc 1) (eval-opexp (cadr ins) regs ops labels)
+                    stack depth pushes maxd))
+              ((eq? (car ins) 'branch)
+               (if (not (eq? flag #f))
+                   (run (label-index labels (cadr (cadr ins))) flag stack depth pushes maxd)
+                   (run (+ pc 1) flag stack depth pushes maxd)))
+              ((eq? (car ins) 'goto)
+               (let ((dest (cadr ins)))
+                 (if (eq? (car dest) 'label)
+                     (run (label-index labels (cadr dest)) flag stack depth pushes maxd)
+                     (run (get-reg regs (cadr dest)) flag stack depth pushes maxd))))
+              ((eq? (car ins) 'save)
+               (let ((d (+ depth 1)))
+                 (run (+ pc 1) flag
+                      (cons (get-reg regs (cadr ins)) stack)
+                      d (+ pushes 1) (max maxd d))))
+              ((eq? (car ins) 'restore)
+               (if (null? stack) (error "restore on empty stack" ins) #f)
+               (set-reg! regs (cadr ins) (car stack))
+               (run (+ pc 1) flag (cdr stack) (- depth 1) pushes maxd))
+              ((eq? (car ins) 'perform)
+               (let ((form (cadr ins)))
+                 (if (eq? (cadr form) 'initialize-stack)
+                     (run (+ pc 1) flag '() 0 0 0)     ; reset stack AND statistics
+                     (begin (eval-opexp form regs ops labels)
+                            (run (+ pc 1) flag stack depth pushes maxd)))))
+              (else (error "bad instruction" ins))))))))
+
+(define (result-regs r) (car r))
+(define (result-pushes r) (cadr r))
+(define (result-maxd r) (caddr r))
+(define (result-depth r) (cadddr r))
+
+;; standard ops (boolean-normalizing wrappers)
+(define ops
+  (list (cons '* *) (cons '+ +) (cons '- -)
+        (cons '= (lambda (a b) (if (= a b) #t #f)))
+        (cons '> (lambda (a b) (if (> a b) #t #f)))))
+
+;; ---- the book's recursive factorial machine (SICP 5.1.4, fig 5.11) ----
+(define (run-fact n)
+  (run-machine
+   '(n val continue)
+   ops
+   (list
+    (list 'assign 'n (list 'const n))
+    '(assign continue (label fact-done))
+    'fact-loop
+    '(test (op = (reg n) (const 1)))
+    '(branch (label base-case))
+    '(save continue)
+    '(save n)
+    '(assign n (op - (reg n) (const 1)))
+    '(assign continue (label after-fact))
+    '(goto (label fact-loop))
+    'after-fact
+    '(restore n)
+    '(restore continue)
+    '(assign val (op * (reg n) (reg val)))
+    '(goto (reg continue))
+    'base-case
+    '(assign val (const 1))
+    '(goto (reg continue))
+    'fact-done)))
+
+(define f5 (run-fact 5))
+(check "recursive fact machine: fact 5" 120 (get-reg (result-regs f5) 'val))
+(check "fact 5 push count = 2(n-1) = 8" 8 (result-pushes f5))
+(check "fact 5 max depth = 2(n-1) = 8" 8 (result-maxd f5))
+(check "fact 5 stack balanced at halt" 0 (result-depth f5))
+
+(define f1 (run-fact 1))
+(check "recursive fact machine: fact 1" 1 (get-reg (result-regs f1) 'val))
+(check "fact 1 push count = 0" 0 (result-pushes f1))
+(check "fact 1 max depth = 0" 0 (result-maxd f1))
+
+(define f6 (run-fact 6))
+(check "recursive fact machine: fact 6" 720 (get-reg (result-regs f6) 'val))
+(check "fact 6 push count = 10" 10 (result-pushes f6))
+(check "fact 6 max depth = 10" 10 (result-maxd f6))
+
+;; ---- initialize-stack: resets contents and statistics ----
+(define init-test
+  (run-machine
+   '(a)
+   ops
+   (list
+    '(assign a (const 42))
+    '(save a)
+    '(save a)
+    '(save a)
+    '(perform (op initialize-stack))
+    '(save a)
+    'done)))
+(check "initialize-stack resets push count" 1 (result-pushes init-test))
+(check "initialize-stack resets max depth" 1 (result-maxd init-test))
+(check "initialize-stack resets contents" 1 (result-depth init-test))
+
+;; iterative factorial (from ch5_register_machine.esk) still runs — no stack use
+(define it5
+  (run-machine
+   '(n product counter)
+   ops
+   (list
+    '(assign n (const 5))
+    '(assign product (const 1))
+    '(assign counter (const 1))
+    'loop
+    '(test (op > (reg counter) (reg n)))
+    '(branch (label done))
+    '(assign product (op * (reg product) (reg counter)))
+    '(assign counter (op + (reg counter) (const 1)))
+    '(goto (label loop))
+    'done)))
+(check "iterative fact 5 unchanged" 120 (get-reg (result-regs it5) 'product))
+(check "iterative fact 5 uses no stack" 0 (result-pushes it5))
+
+(display "ch5 register machine stack: ")
+(display (if (= fails 0) "ALL PASS" (cons fails 'FAILS))) (newline)
+(if (> fails 0) (error "failures" fails) #t)

--- a/tests/sicp/ch5_storage_gc.esk
+++ b/tests/sicp/ch5_storage_gc.esk
@@ -1,0 +1,187 @@
+;; SICP Chapter 5.3 — memory as vectors, and a stop-and-copy garbage collector.
+;; List structure lives in two vectors, the-cars/the-cdrs, addressed by a free
+;; pointer.  Pointers are typed tag.index pairs: (pair . i) indexes the
+;; vectors, (number . k) is an immediate, (empty . 0) is nil,
+;; (broken-heart . 0) marks an evacuated cell whose forwarding pointer sits in
+;; the old the-cdrs slot.  cons/car/cdr/pair? are implemented over
+;; vector-ref/vector-set!, then a stop-and-copy collector with root registers
+;; evacuates live cells into fresh semispace vectors.
+(define fails 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "FAIL: ") (display name) (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline))))
+
+;; SICP names the allocation register `free`, but a top-level (define free ...)
+;; collides with the libc symbol `free` under both JIT and AOT linking and the
+;; runtime SIGBUSes at teardown, so this file names it `freeptr`.
+(display "NOTE: global named `free` collides with libc free() (teardown SIGBUS); using `freeptr` — see (define free 0) minimal repro")
+(newline)
+
+;; ---- the memory ----
+(define mem-size 32)
+(define the-cars (make-vector mem-size 0))
+(define the-cdrs (make-vector mem-size 0))
+(define freeptr 0)
+
+;; ---- typed pointers ----
+(define (make-number k) (cons 'number k))
+(define nil-ptr (cons 'empty 0))
+(define (ptr-tag p) (car p))
+(define (ptr-idx p) (cdr p))
+(define (vpair? p) (eq? (ptr-tag p) 'pair))
+(define (vnumber? p) (eq? (ptr-tag p) 'number))
+(define (vnull? p) (eq? (ptr-tag p) 'empty))
+(define (vnum p)
+  (if (vnumber? p) (ptr-idx p) (error "not a number pointer" p)))
+
+;; ---- cons/car/cdr over the vectors (SICP 5.3.1) ----
+(define (vcons a d)
+  (if (>= freeptr mem-size) (error "memory exhausted" freeptr) #f)
+  (vector-set! the-cars freeptr a)
+  (vector-set! the-cdrs freeptr d)
+  (let ((p (cons 'pair freeptr)))
+    (set! freeptr (+ freeptr 1))
+    p))
+(define (vcar p)
+  (if (vpair? p) (vector-ref the-cars (ptr-idx p)) (error "vcar: not a pair" p)))
+(define (vcdr p)
+  (if (vpair? p) (vector-ref the-cdrs (ptr-idx p)) (error "vcdr: not a pair" p)))
+(define (vset-car! p v)
+  (if (vpair? p) (vector-set! the-cars (ptr-idx p) v) (error "vset-car!" p)))
+
+;; ---- stop-and-copy collector (SICP 5.3.2) ----
+;; Takes the list of root pointers (the machine's root registers); returns the
+;; relocated roots.  Evacuated old cells get a broken-heart in the-cars and
+;; the forwarding pointer in the-cdrs; a scan pointer sweeps new memory
+;; relocating everything it references; finally the semispaces are flipped.
+(define (gc roots)
+  (let ((new-cars (make-vector mem-size 0))
+        (new-cdrs (make-vector mem-size 0))
+        (new-free 0))
+    (define (relocate p)
+      (if (and (pair? p) (vpair? p))
+          (let ((old-i (ptr-idx p)))
+            (let ((old-car (vector-ref the-cars old-i)))
+              (if (and (pair? old-car) (eq? (ptr-tag old-car) 'broken-heart))
+                  (vector-ref the-cdrs old-i)          ; already moved: forward
+                  (let ((ni new-free))
+                    (vector-set! new-cars ni old-car)
+                    (vector-set! new-cdrs ni (vector-ref the-cdrs old-i))
+                    (set! new-free (+ new-free 1))
+                    (vector-set! the-cars old-i (cons 'broken-heart 0))
+                    (let ((np (cons 'pair ni)))
+                      (vector-set! the-cdrs old-i np)  ; forwarding pointer
+                      np)))))
+          p))                                          ; immediates move as-is
+    (let ((new-roots (map relocate roots)))
+      (let scan ((i 0))
+        (if (< i new-free)
+            (begin
+              (vector-set! new-cars i (relocate (vector-ref new-cars i)))
+              (vector-set! new-cdrs i (relocate (vector-ref new-cdrs i)))
+              (scan (+ i 1)))
+            #t))
+      ;; flip semispaces
+      (set! the-cars new-cars)
+      (set! the-cdrs new-cdrs)
+      (set! freeptr new-free)
+      new-roots)))
+
+;; ================= basic memory-model checks =================
+(define p1 (vcons (make-number 10) (make-number 20)))
+(check "vcons allocates at index 0" 0 (ptr-idx p1))
+(check "free pointer advanced" 1 freeptr)
+(check "vcar reads the-cars" 10 (vnum (vcar p1)))
+(check "vcdr reads the-cdrs" 20 (vnum (vcdr p1)))
+(check "vpair? on pair pointer" #t (vpair? p1))
+(check "vpair? on number pointer" #f (vpair? (make-number 5)))
+(check "vpair? on nil pointer" #f (vpair? nil-ptr))
+(vset-car! p1 (make-number 11))
+(check "vset-car! mutates cell" 11 (vnum (vcar p1)))
+
+;; a proper list (1 2 3) built in vector memory
+(define l3 (vcons (make-number 1)
+                  (vcons (make-number 2)
+                         (vcons (make-number 3) nil-ptr))))
+(check "list in vector memory: car" 1 (vnum (vcar l3)))
+(check "list in vector memory: cadr" 2 (vnum (vcar (vcdr l3))))
+(check "list in vector memory: caddr" 3 (vnum (vcar (vcdr (vcdr l3)))))
+(check "list in vector memory: null tail" #t (vnull? (vcdr (vcdr (vcdr l3)))))
+
+;; ================= GC scenario =================
+;; Rebuild memory from scratch so cell counts are exact.
+(set! the-cars (make-vector mem-size 0))
+(set! the-cdrs (make-vector mem-size 0))
+(set! freeptr 0)
+
+(define s  (vcons (make-number 1) (make-number 2)))  ; idx 0: shared cell
+(define g1 (vcons (make-number 7) (make-number 8)))  ; idx 1: garbage
+(define x  (vcons s s))                              ; idx 2: car and cdr share s
+(define g2 (vcons (make-number 9) g1))               ; idx 3: garbage (refs g1)
+(define y  (vcons (make-number 3) x))                ; idx 4: root
+
+(check "pre-GC free pointer = 5 cells" 5 freeptr)
+(check "pre-GC shared structure reads" 1 (vnum (vcar (vcar (vcdr y)))))
+
+;; collect with y as the sole root register
+(define new-roots (gc (list y)))
+(define y2 (car new-roots))
+
+;; live data intact after collection
+(check "post-GC root is a pair" #t (vpair? y2))
+(check "post-GC y car" 3 (vnum (vcar y2)))
+(define x2 (vcdr y2))
+(check "post-GC x reachable" #t (vpair? x2))
+(check "post-GC shared cell car" 1 (vnum (vcar (vcar x2))))
+(check "post-GC shared cell cdr" 2 (vnum (vcdr (vcar x2))))
+
+;; sharing preserved: x's car and cdr are the SAME new cell (single copy)
+(check "sharing preserved (one copy of shared cell)" #t
+       (equal? (vcar x2) (vcdr x2)))
+
+;; free pointer equals exact live-cell count: y, x, s = 3 (g1, g2 reclaimed)
+(check "post-GC free pointer = 3 live cells" 3 freeptr)
+
+;; breadth-first copy order: root y first, then x, then s
+(check "root copied to index 0" 0 (ptr-idx y2))
+(check "x copied to index 1" 1 (ptr-idx x2))
+(check "shared cell copied to index 2" 2 (ptr-idx (vcar x2)))
+
+;; allocation continues correctly after the flip
+(define z (vcons (make-number 42) y2))
+(check "post-GC allocation goes to index 3" 3 (ptr-idx z))
+(check "post-GC allocated cell readable" 42 (vnum (vcar z)))
+(check "post-GC allocated cell links live data" 3 (vnum (vcar (vcdr z))))
+
+;; second collection with extra root: everything now live stays live
+(define roots2 (gc (list z y2)))
+(check "second GC keeps 4 live cells" 4 freeptr)
+(check "second GC preserves data" 42 (vnum (vcar (car roots2))))
+(check "second GC shares y between roots" #t
+       (equal? (vcdr (car roots2)) (cadr roots2)))
+(check "second GC sharing under x still intact" #t
+       (let ((x3 (vcdr (cadr roots2))))
+         (equal? (vcar x3) (vcdr x3))))
+
+;; a cyclic structure survives collection (forwarding pointers stop the loop)
+(set! the-cars (make-vector mem-size 0))
+(set! the-cdrs (make-vector mem-size 0))
+(set! freeptr 0)
+(define c1 (vcons (make-number 1) nil-ptr))
+(define c2 (vcons (make-number 2) c1))
+;; close the cycle: cdr of c1 points back to c2
+(vector-set! the-cdrs (ptr-idx c1) c2)
+(define cyc-roots (gc (list c2)))
+(define c2n (car cyc-roots))
+(check "cycle: both cells survive" 2 freeptr)
+(check "cycle: c2 car" 2 (vnum (vcar c2n)))
+(check "cycle: c1 reachable" 1 (vnum (vcar (vcdr c2n))))
+(check "cycle: cdr of c1 points back to c2 (same cell)" #t
+       (equal? (vcdr (vcdr c2n)) c2n))
+
+(display "ch5 storage gc: ")
+(display (if (= fails 0) "ALL PASS" (cons fails 'FAILS))) (newline)
+(if (> fails 0) (error "failures" fails) #t)


### PR DESCRIPTION
Five self-checking SICP Chapter 5 probes under `tests/sicp/`, each verified under both `-r` (JIT) and AOT. All print `PASS:`/`FAIL:` per check and exit nonzero on any failure, matching the `run_sicp_smoke.sh` contract.

## Files

1. **`ch5_register_machine_stack.esk`** (15 checks) — extends the 5.2 simulator with `save`/`restore`, label-valued `assign`, `(goto (reg continue))`, `perform`, and stack statistics (push count, max depth, `initialize-stack` reset). Runs the book's recursive-factorial machine (fig 5.11): fact 5 = 120 with exactly 2(n-1) = 8 pushes and max depth 8; fact 6 = 720 with 10/10; stack balanced at halt.
2. **`ch5_register_machine_recursive.esk`** (13 checks) — the doubly-recursive Fibonacci machine (fig 5.12): fib 8 = 21, fib 10 = 55, pushes(fib 10) = 352 > pushes(fib 8) = 132, max depth = 2(n-1), and the push recurrence S(n) = S(n-1) + S(n-2) + 4.
3. **`ch5_storage_gc.esk`** (35 checks) — 5.3 vector memory model (`the-cars`/`the-cdrs`, typed tag.index pointers, cons/car/cdr/pair? over `vector-ref`/`vector-set!`) plus a stop-and-copy collector with root registers, broken hearts, and forwarding pointers. Asserts live data intact, sharing preserved (single copy of a shared cell), free pointer = exact live-cell count (5 -> 3), post-flip allocation, a second collection, and cycle survival.
4. **`ch5_explicit_control_evaluator.esk`** (25 checks) — the 5.4 eval-dispatch/apply-dispatch controller as data on the simulator: self-eval, variable, quote, if, lambda, begin/ev-sequence, definition (incl. shorthand), applications with primitive and compound procedures over a frame-list environment. `((lambda (x) (* x x)) 4)` = 16, recursive fact 4 = 24 with balanced stack. Omitted forms (`set!`, `cond`, `let`) noted in the header; not needed by the probes.
5. **`ch5_compiler.esk`** (21 checks) — the 5.5 compiler for self-eval/quote/variable/define/if/lambda/application with target registers and next/return/label linkage, conservative save-restore preservation, and the FULL compiled-procedure call protocol (entry points as label values, return-linkage tail calls). Compiled `(+ 1 2)` = 3, if selects correctly, `(define (sq x) (* x x))` then `(sq 5)` = 25, compound-calls-compound, recursive `cfact 5` = 120, and structural test/branch/label ordering checks on the emitted sequence.

## Language gap found (worked around, not blocking)

A top-level global whose name collides with a libc symbol shadows the C function at JIT/AOT link and the runtime SIGBUSes at teardown:

```scheme
(define free 0)          ; also (define malloc 0)
(display (+ free 1))     ; prints 1, then fatal SIGBUS at exit (both -r and AOT)
```

SICP names the GC allocation register `free`; `ch5_storage_gc.esk` uses `freeptr` instead and prints a `NOTE:` line documenting the collision. User globals should presumably be name-mangled rather than emitted as raw C symbols.