### PR TITLE
fix(parser): preserve quoted datum in let-family body tails inside defines (ESH-0091)

### DIFF
--- a/lib/frontend/parser.cpp
+++ b/lib/frontend/parser.cpp
@@ -3866,33 +3866,12 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
                         break;
                     }
 
-                    eshkol_ast_t expr;
-                    if (token.type == TOKEN_LPAREN) {
-                        expr = parse_list(tokenizer);
-                    } else if (token.type == TOKEN_QUOTE) {
-                        // (define (f ...) 'x) — quoted datum in body.
-                        eshkol_ast_t quoted = parse_quoted_data(tokenizer);
-                        expr.type = ESHKOL_OP;
-                        expr.operation.op = ESHKOL_QUOTE_OP;
-                        expr.operation.call_op.func = nullptr;
-                        expr.operation.call_op.num_vars = 1;
-                        expr.operation.call_op.variables = new eshkol_ast_t[1];
-                        expr.operation.call_op.variables[0] = quoted;
-                    } else if (token.type == TOKEN_BACKQUOTE) {
-                        // (define (f ...) `(...)) — quasiquoted datum in
-                        // body. Without this branch the parser would fall to
-                        // parse_atom(TOKEN_BACKQUOTE), corrupting the token
-                        // stream and silently producing the wrong body AST.
-                        eshkol_ast_t inner = parse_quasiquoted_data(tokenizer);
-                        expr.type = ESHKOL_OP;
-                        expr.operation.op = ESHKOL_QUASIQUOTE_OP;
-                        expr.operation.call_op.func = nullptr;
-                        expr.operation.call_op.num_vars = 1;
-                        expr.operation.call_op.variables = new eshkol_ast_t[1];
-                        expr.operation.call_op.variables[0] = inner;
-                    } else {
-                        expr = parse_atom(token);
-                    }
+                    // Push the token back and let parse_expression handle it.
+                    // Manual LPAREN/atom dispatch here dropped quote,
+                    // quasiquote and #(...) vector tokens (ESH-0091 family);
+                    // parse_expression covers every expression-position token.
+                    tokenizer.pushBack(token);
+                    eshkol_ast_t expr = parse_expression(tokenizer);
                     body_expressions.push_back(expr);
                 }
                 
@@ -4403,31 +4382,11 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
                     return ast;
                 }
 
-                eshkol_ast_t expr;
-                if (token.type == TOKEN_LPAREN) {
-                    expr = parse_list(tokenizer);
-                } else if (token.type == TOKEN_QUOTE) {
-                    // Handle quoted expressions in lambda body: (lambda () 'ok)
-                    eshkol_ast_t quoted = parse_quoted_data(tokenizer);
-                    expr.type = ESHKOL_OP;
-                    expr.operation.op = ESHKOL_QUOTE_OP;
-                    expr.operation.call_op.func = nullptr;
-                    expr.operation.call_op.num_vars = 1;
-                    expr.operation.call_op.variables = new eshkol_ast_t[1];
-                    expr.operation.call_op.variables[0] = quoted;
-                } else if (token.type == TOKEN_BACKQUOTE) {
-                    // Handle quasiquoted expressions in lambda body: (lambda () `expr)
-                    // Already uses parse_quasiquoted_data — this path is correct.
-                    eshkol_ast_t inner = parse_quasiquoted_data(tokenizer);
-                    expr.type = ESHKOL_OP;
-                    expr.operation.op = ESHKOL_QUASIQUOTE_OP;
-                    expr.operation.call_op.func = nullptr;
-                    expr.operation.call_op.num_vars = 1;
-                    expr.operation.call_op.variables = new eshkol_ast_t[1];
-                    expr.operation.call_op.variables[0] = inner;
-                } else {
-                    expr = parse_atom(token);
-                }
+                // Push the token back and let parse_expression handle it —
+                // covers quote, quasiquote, #(...) vectors and every other
+                // expression-position token (ESH-0091 family).
+                tokenizer.pushBack(token);
+                eshkol_ast_t expr = parse_expression(tokenizer);
                 body_expressions.push_back(expr);
             }
 
@@ -4612,21 +4571,23 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
                     return ast;
                 }
                 
-                eshkol_ast_t expr;
-                if (token.type == TOKEN_LPAREN) {
-                    expr = parse_list(tokenizer);
-                } else {
-                    expr = parse_atom(token);
-                }
-                
+                // Push the token back and let parse_expression handle it.
+                // Manual LPAREN/atom dispatch here dropped quote, quasiquote
+                // and #(...) vector tokens in let-family body positions
+                // (ESH-0091): 'ok became parse_atom(TOKEN_QUOTE) → INVALID,
+                // invalidating the whole let and leaving the datum tokens to
+                // be re-parsed as spurious sibling expressions.
+                tokenizer.pushBack(token);
+                eshkol_ast_t expr = parse_expression(tokenizer);
+
                 if (expr.type == ESHKOL_INVALID) {
                     ast.type = ESHKOL_INVALID;
                     return ast;
                 }
-                
+
                 body_expressions.push_back(expr);
             }
-            
+
             if (body_expressions.empty()) {
                 PARSE_ERROR_AT(token, "let body cannot be empty");
                 ast.type = ESHKOL_INVALID;
@@ -4888,12 +4849,10 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
                     return ast;
                 }
 
-                eshkol_ast_t expr;
-                if (token.type == TOKEN_LPAREN) {
-                    expr = parse_list(tokenizer);
-                } else {
-                    expr = parse_atom(token);
-                }
+                // Push back + parse_expression: manual LPAREN/atom dispatch
+                // dropped quote/quasiquote/#(...) tokens (ESH-0091 family).
+                tokenizer.pushBack(token);
+                eshkol_ast_t expr = parse_expression(tokenizer);
 
                 if (expr.type == ESHKOL_INVALID) {
                     ast.type = ESHKOL_INVALID;

--- a/tests/parser/quoted_let_tail_test.esk
+++ b/tests/parser/quoted_let_tail_test.esk
@@ -1,0 +1,154 @@
+;; Parser Test: quoted datum in let-family body tails (ESH-0091)
+;;
+;; A quote/quasiquote/vector literal in tail position of a let-family body
+;; inside a define or lambda used to lose its quote: the let-body loop
+;; dispatched only on LPAREN/atom, so TOKEN_QUOTE fell into parse_atom,
+;; invalidated the whole let, and the datum tokens were re-parsed as
+;; spurious sibling expressions ("Undefined variable: ok" / call to a).
+
+(require stdlib)
+
+(define tests-passed 0)
+(define tests-failed 0)
+
+(define (test-case name expected actual)
+  (if (equal? expected actual)
+      (begin
+        (set! tests-passed (+ tests-passed 1))
+        (display "PASS: ") (display name) (display "\n"))
+      (begin
+        (set! tests-failed (+ tests-failed 1))
+        (display "FAIL: ") (display name)
+        (display " (expected ") (display expected)
+        (display ", got ") (display actual) (display ")\n"))))
+
+;; ============================================================
+;; Quoted symbol tails inside define
+;; ============================================================
+
+(define (f-let) (let ((x 1)) 'ok))
+(test-case "define + let + 'symbol tail" 'ok (f-let))
+
+(define (f-let*) (let* ((x 1) (y x)) 'ok))
+(test-case "define + let* + 'symbol tail" 'ok (f-let*))
+
+(define (f-letrec) (letrec ((x 1)) 'ok))
+(test-case "define + letrec + 'symbol tail" 'ok (f-letrec))
+
+(define (f-letrec*) (letrec* ((x 1)) 'ok))
+(test-case "define + letrec* + 'symbol tail" 'ok (f-letrec*))
+
+(define (f-named) (let loop ((i 0)) (if (< i 2) (loop (+ i 1)) 'done)))
+(test-case "define + named-let + 'symbol via if" 'done (f-named))
+
+(define (f-named-tail) (let loop ((i 0)) 'ok))
+(test-case "define + named-let + 'symbol tail" 'ok (f-named-tail))
+
+;; ============================================================
+;; Quoted list tails inside define
+;; ============================================================
+
+(define (g-let) (let ((x 1)) '(a b)))
+(test-case "define + let + '(list) tail" (list 'a 'b) (g-let))
+
+(define (g-let*) (let* ((x 1)) '(a b c)))
+(test-case "define + let* + '(list) tail" (list 'a 'b 'c) (g-let*))
+
+(define (g-letrec) (letrec ((x 1)) '(1 2 3)))
+(test-case "define + letrec + '(list) tail" (list 1 2 3) (g-letrec))
+
+(define (g-empty) (let ((x 1)) '()))
+(test-case "define + let + '() tail" '() (g-empty))
+
+;; ============================================================
+;; Same shapes inside lambda
+;; ============================================================
+
+(define l-let (lambda () (let ((x 1)) 'ok)))
+(test-case "lambda + let + 'symbol tail" 'ok (l-let))
+
+(define l-let* (lambda () (let* ((x 1)) '(a b))))
+(test-case "lambda + let* + '(list) tail" (list 'a 'b) (l-let*))
+
+(define l-letrec (lambda () (letrec ((x 1)) 'ok)))
+(test-case "lambda + letrec + 'symbol tail" 'ok (l-letrec))
+
+(define l-named (lambda () (let loop ((i 0)) '(x y))))
+(test-case "lambda + named-let + '(list) tail" (list 'x 'y) (l-named))
+
+;; Direct quote tails in lambda/define bodies (no let)
+(define l-direct (lambda () 'direct))
+(test-case "lambda + 'symbol body" 'direct (l-direct))
+
+(define (d-direct) '(p q))
+(test-case "define + '(list) body" (list 'p 'q) (d-direct))
+
+;; ============================================================
+;; Quasiquote tail
+;; ============================================================
+
+(define (qq-tail) (let ((x 5)) `(a ,x)))
+(test-case "define + let + quasiquote tail" (list 'a 5) (qq-tail))
+
+(define qq-lambda (lambda () (let* ((y 7)) `(v ,y ,(+ y 1)))))
+(test-case "lambda + let* + quasiquote tail" (list 'v 7 8) (qq-lambda))
+
+;; ============================================================
+;; Vector literal tail
+;; ============================================================
+
+(define (vec-tail) (let ((x 1)) #(1 2)))
+(define vt (vec-tail))
+(test-case "define + let + #(1 2) tail: ref 0" 1 (vector-ref vt 0))
+(test-case "define + let + #(1 2) tail: ref 1" 2 (vector-ref vt 1))
+
+;; ============================================================
+;; Multi-expression body ending in a quote
+;; ============================================================
+
+(define (multi-tail)
+  (let ((x 1))
+    (display "")
+    (+ x 1)
+    'last))
+(test-case "define + let + multi-expr body ending in quote" 'last (multi-tail))
+
+(define (multi-tail-list)
+  (let* ((x 1) (y 2))
+    (+ x y)
+    '(r s)))
+(test-case "define + let* + multi-expr body ending in '(list)" (list 'r 's) (multi-tail-list))
+
+;; ============================================================
+;; Nested lets with quoted tails
+;; ============================================================
+
+(define (nested)
+  (let ((a 1))
+    (let ((b 2))
+      'inner)))
+(test-case "define + nested lets + 'symbol tail" 'inner (nested))
+
+(define (nested-mixed)
+  (let ((a 1))
+    (let* ((b 2))
+      (letrec ((c 3))
+        '(deep tail)))))
+(test-case "define + nested let/let*/letrec + '(list) tail" (list 'deep 'tail) (nested-mixed))
+
+;; let-values body tail (same fix family)
+(define (lv-tail)
+  (let-values (((a b) (values 1 2)))
+    'lv-ok))
+(test-case "define + let-values + 'symbol tail" 'lv-ok (lv-tail))
+
+;; ============================================================
+;; Summary
+;; ============================================================
+
+(display "\n=== Results ===\n")
+(display "Passed: ") (display tests-passed) (display "\n")
+(display "Failed: ") (display tests-failed) (display "\n")
+(if (= tests-failed 0)
+    (display "ALL TESTS PASSED\n")
+    (display "SOME TESTS FAILED\n"))


### PR DESCRIPTION
## Root cause

The body-expression loops in `lib/frontend/parser.cpp` for the let family
(`let`/`let*`/`letrec`/`letrec*`/named `let`), `lambda`, `define`, and
`let-values`/`let*-values` hand-rolled token dispatch:

```cpp
if (token.type == TOKEN_LPAREN) {
    expr = parse_list(tokenizer);
} else {
    expr = parse_atom(token);
}
```

A `TOKEN_QUOTE` / `TOKEN_BACKQUOTE` / `TOKEN_VECTOR_START` in body position
fell into `parse_atom`, which cannot handle those tokens and returned
`ESHKOL_INVALID`. The let-body loop then invalidated the **entire let** and
returned, leaving the datum tokens unconsumed — so the enclosing define body
re-parsed them as spurious sibling expressions. The define body became
`SEQUENCE_OP [INVALID, VAR ok]` with no LET node at all.

Same bug family as the PR #229-era or/and arg dispatch fix.

## Before

```scheme
(define (f) (let ((x 1)) 'ok))   (display (f))   ; "Undefined variable: ok" + SIGSEGV
(define (g) (let ((x 1)) '(a b))) (display (g))  ; "Unknown function: a"
(display (let ((x 1)) 'ok))                      ; silently printed NOTHING (exit 0)
```

## After

All three print `ok` / `(a b)` / `ok` under both `-r` (JIT) and AOT.

## Fix

Route every body-position token through the proven `pushBack` +
`parse_expression` pattern in four loops (let-family, lambda, define,
let-values). This also removes the bolt-on `TOKEN_QUOTE`/`TOKEN_BACKQUOTE`
special cases the define and lambda loops carried, and fixes `#(...)` vector
literals in those positions as a side effect. Net -67 lines of dispatch code.

Note: the same latent manual-dispatch pattern still exists in
guard/case/match/do body loops (out of scope here, same one-line fix each).

## Verification (all under both -r and AOT)

- New `tests/parser/quoted_let_tail_test.esk`: 25/25 PASS
  (quote symbol/list/empty-list, quasiquote, `#(1 2)` vector tails across
  let/let*/letrec/letrec*/named-let inside define and lambda, multi-expression
  bodies ending in a quote, nested lets, let-values)
- `scripts/run_sicp_smoke.sh`: all 22 implemented SICP programs pass both
  modes (44 PASSED); remaining gate FAILs are the pre-existing missing
  full-book probe backlog (ESH-0065+), unchanged
- `tests/tco/nested_tco_test.esk`: 7/7 PASS
- `tests/closures/closure_edge_test.esk` 40/40,
  `tests/closures/shared_mutable_capture_test.esk` 24/24,
  `tests/let_values_closure_capture.esk` PASS
- `scripts/run_icc_smoke.sh`: exit 0, all oracle checks green
- Full `tests/parser/` sweep: only pre-existing failures remain
  (`sexpr_test.esk` nested-vector-length, `test_shadowing_fix.esk`) —
  both reproduce identically on the unpatched master build