### PR TITLE
fix(ad): propagate captured-parameter dependencies through inner derivative to the outer reverse tape (ESH-0093)

### DIFF
--- a/inc/eshkol/backend/autodiff_codegen.h
+++ b/inc/eshkol/backend/autodiff_codegen.h
@@ -113,7 +113,22 @@ public:
     llvm::Value* seedForwardAndPush(llvm::Value* point_tagged, llvm::Value** out_level);
     // POP (restore `level`) and extract the derivative w.r.t. this level's slot:
     // a scalar double at level 0, the e2-slice dual when nested.
+    // ESH-0093: at level 0, when a reverse tape is live and the gradient pass
+    // published an active seed variable, the result is recorded on the tape
+    // (with backward edge a12 = the mixed e1e2 coefficient) and returned as an
+    // AD node so an outer reverse-mode gradient sees the dependency on
+    // captured tape variables.
     llvm::Value* popAndExtractForward(llvm::Value* result_tagged, llvm::Value* level);
+
+    // ESH-0093: if `operand_tagged` is a reverse-tape AD node AND a forward-
+    // mode perturbation is live (__ad_pert_level > 0), freeze it to a dual
+    // {node->value, 0, seed_flag, 0} (seed_flag = 1.0 iff the node is the
+    // gradient pass's active seed variable, masked to pert level 1).
+    // Otherwise returns the operand unchanged. Called at every scalar
+    // arithmetic entry point so tape values entering a forward-mode jet
+    // computation become jets instead of being mis-recorded on the tape
+    // (which dropped the forward tangent — the mixed-mode composition bug).
+    llvm::Value* maybeJetLiftTapeOperand(llvm::Value* operand_tagged);
 
     /**
      * Add two dual numbers: (a + b, a' + b')

--- a/lib/backend/arithmetic_codegen.cpp
+++ b/lib/backend/arithmetic_codegen.cpp
@@ -643,6 +643,12 @@ llvm::Value* ArithmeticCodegen::add(llvm::Value* left, llvm::Value* right) {
         return tagged_.packInt64(llvm::ConstantInt::get(ctx_.int64Type(), 0), true);
     }
 
+
+    // ESH-0093: while a forward-mode derivative is live, reverse-tape AD nodes
+    // entering scalar arithmetic are frozen to jets (with the active gradient
+    // seed in e2) instead of being mis-recorded on the tape. No-op otherwise.
+    left = autodiff_.maybeJetLiftTapeOperand(left);
+    right = autodiff_.maybeJetLiftTapeOperand(right);
     return withADBinaryDispatch(left, right, 2 /*AD_NODE_ADD*/, [&]() -> llvm::Value* {
         // Re-extract types inside lambda (handler already checked AD)
         llvm::Value* left_type = tagged_.getType(left);
@@ -813,6 +819,12 @@ llvm::Value* ArithmeticCodegen::sub(llvm::Value* left, llvm::Value* right) {
         return tagged_.packInt64(llvm::ConstantInt::get(ctx_.int64Type(), 0), true);
     }
 
+
+    // ESH-0093: while a forward-mode derivative is live, reverse-tape AD nodes
+    // entering scalar arithmetic are frozen to jets (with the active gradient
+    // seed in e2) instead of being mis-recorded on the tape. No-op otherwise.
+    left = autodiff_.maybeJetLiftTapeOperand(left);
+    right = autodiff_.maybeJetLiftTapeOperand(right);
     return withADBinaryDispatch(left, right, 3 /*AD_NODE_SUB*/, [&]() -> llvm::Value* {
         // Re-extract types inside lambda (handler already checked AD)
         llvm::Value* left_type = tagged_.getType(left);
@@ -983,6 +995,12 @@ llvm::Value* ArithmeticCodegen::mul(llvm::Value* left, llvm::Value* right) {
         return tagged_.packInt64(llvm::ConstantInt::get(ctx_.int64Type(), 0), true);
     }
 
+
+    // ESH-0093: while a forward-mode derivative is live, reverse-tape AD nodes
+    // entering scalar arithmetic are frozen to jets (with the active gradient
+    // seed in e2) instead of being mis-recorded on the tape. No-op otherwise.
+    left = autodiff_.maybeJetLiftTapeOperand(left);
+    right = autodiff_.maybeJetLiftTapeOperand(right);
     return withADBinaryDispatch(left, right, 4 /*AD_NODE_MUL*/, [&]() -> llvm::Value* {
         // Re-extract types inside lambda (handler already checked AD)
         llvm::Value* left_type = tagged_.getType(left);
@@ -1153,6 +1171,12 @@ llvm::Value* ArithmeticCodegen::div(llvm::Value* left, llvm::Value* right) {
         return tagged_.packInt64(llvm::ConstantInt::get(ctx_.int64Type(), 0), true);
     }
 
+
+    // ESH-0093: while a forward-mode derivative is live, reverse-tape AD nodes
+    // entering scalar arithmetic are frozen to jets (with the active gradient
+    // seed in e2) instead of being mis-recorded on the tape. No-op otherwise.
+    left = autodiff_.maybeJetLiftTapeOperand(left);
+    right = autodiff_.maybeJetLiftTapeOperand(right);
     return withADBinaryDispatch(left, right, 5 /*AD_NODE_DIV*/, [&]() -> llvm::Value* {
         // Re-extract types inside lambda (handler already checked AD)
         llvm::Value* left_type = tagged_.getType(left);
@@ -1413,6 +1437,9 @@ llvm::Value* ArithmeticCodegen::mod(llvm::Value* left, llvm::Value* right) {
 }
 
 llvm::Value* ArithmeticCodegen::neg(llvm::Value* operand) {
+    // ESH-0093: see add() — freeze reverse-tape operands to jets inside
+    // forward-mode AD.
+    operand = autodiff_.maybeJetLiftTapeOperand(operand);
     return withADUnaryDispatch(operand, 11 /*AD_NODE_NEG*/, [&]() -> llvm::Value* {
         llvm::Value* type_tag = tagged_.getType(operand);
         llvm::Value* base_type = tagged_.getBaseType(type_tag);
@@ -1484,6 +1511,9 @@ llvm::Value* ArithmeticCodegen::neg(llvm::Value* operand) {
 }
 
 llvm::Value* ArithmeticCodegen::abs(llvm::Value* operand) {
+    // ESH-0093: see add() — freeze reverse-tape operands to jets inside
+    // forward-mode AD.
+    operand = autodiff_.maybeJetLiftTapeOperand(operand);
     return withADUnaryDispatch(operand, 42 /*AD_NODE_ABS*/, [&]() -> llvm::Value* {
         llvm::Value* type_tag = tagged_.getType(operand);
         llvm::Value* base_type = tagged_.getBaseType(type_tag);
@@ -2004,6 +2034,11 @@ llvm::Value* ArithmeticCodegen::pow(llvm::Value* base, llvm::Value* exponent) {
         return tagged_.packDouble(llvm::ConstantFP::get(ctx_.doubleType(), 0.0));
     }
 
+
+    // ESH-0093: see add() — freeze reverse-tape operands to jets inside
+    // forward-mode AD.
+    base = autodiff_.maybeJetLiftTapeOperand(base);
+    exponent = autodiff_.maybeJetLiftTapeOperand(exponent);
     return withADBinaryDispatch(base, exponent, 10 /*AD_NODE_POW*/, [&]() -> llvm::Value* {
         // Re-extract types inside lambda
         llvm::Value* base_type = tagged_.getType(base);
@@ -2116,6 +2151,12 @@ llvm::Value* ArithmeticCodegen::min(llvm::Value* left, llvm::Value* right) {
         return tagged_.packDouble(llvm::ConstantFP::get(ctx_.doubleType(), 0.0));
     }
 
+
+    // ESH-0093: while a forward-mode derivative is live, reverse-tape AD nodes
+    // entering scalar arithmetic are frozen to jets (with the active gradient
+    // seed in e2) instead of being mis-recorded on the tape. No-op otherwise.
+    left = autodiff_.maybeJetLiftTapeOperand(left);
+    right = autodiff_.maybeJetLiftTapeOperand(right);
     return withADBinaryDispatch(left, right, 45 /*AD_NODE_MIN*/, [&]() -> llvm::Value* {
         llvm::Function* func = ctx_.builder().GetInsertBlock()->getParent();
         llvm::BasicBlock* dual_check = llvm::BasicBlock::Create(ctx_.context(), "min_dual_check", func);
@@ -2203,6 +2244,12 @@ llvm::Value* ArithmeticCodegen::max(llvm::Value* left, llvm::Value* right) {
         return tagged_.packDouble(llvm::ConstantFP::get(ctx_.doubleType(), 0.0));
     }
 
+
+    // ESH-0093: while a forward-mode derivative is live, reverse-tape AD nodes
+    // entering scalar arithmetic are frozen to jets (with the active gradient
+    // seed in e2) instead of being mis-recorded on the tape. No-op otherwise.
+    left = autodiff_.maybeJetLiftTapeOperand(left);
+    right = autodiff_.maybeJetLiftTapeOperand(right);
     return withADBinaryDispatch(left, right, 44 /*AD_NODE_MAX*/, [&]() -> llvm::Value* {
         llvm::Function* func = ctx_.builder().GetInsertBlock()->getParent();
         llvm::BasicBlock* dual_check = llvm::BasicBlock::Create(ctx_.context(), "max_dual_check", func);

--- a/lib/backend/autodiff_codegen.cpp
+++ b/lib/backend/autodiff_codegen.cpp
@@ -224,8 +224,47 @@ llvm::Value* AutodiffCodegen::popAndExtractForward(llvm::Value* result_tagged,
     b.CreateCondBr(is_l0, x0bb, x1bb);
 
     // level 0: scalar derivative = tangent (e1 component), packed as a double.
+    //
+    // ESH-0093: when this derivative ran INSIDE a reverse-mode gradient pass
+    // (an outer tape is live and the pass published an active seed variable),
+    // captured tape nodes were jet-lifted with e2 = 1 on the seed
+    // (maybeJetLiftTapeOperand), so the e1e2 coefficient a12 is
+    // d(derivative-result)/d(seed). Record the result on the outer tape as an
+    // exact local linearization (eshkol_ad_mixed_record) and return that AD
+    // node so the outer backward pass sees the dependency. When there is no
+    // tape / no seed / no dependency the helper returns null and the plain
+    // scalar path below is used — identical to the previous behavior.
     b.SetInsertPoint(x0bb);
-    llvm::Value* scalar_res = tagged_.packDouble(dualField(ctx_, rd, 1));
+    llvm::Value* a1 = dualField(ctx_, rd, 1);
+    llvm::Value* a12 = dualField(ctx_, rd, 3);
+    llvm::Value* scalar_res = tagged_.packDouble(a1);
+    if (ctx_.currentAdTape()) {
+        llvm::FunctionCallee mixed_rec = ctx_.module().getOrInsertFunction(
+            "eshkol_ad_mixed_record",
+            llvm::FunctionType::get(ctx_.ptrType(),
+                {ctx_.ptrType(), ctx_.ptrType(), ctx_.doubleType(), ctx_.doubleType()},
+                false));
+        llvm::Value* arena_ptr = getArenaPtr();
+        llvm::Value* tape_ptr = b.CreateLoad(ctx_.ptrType(), ctx_.currentAdTape());
+        llvm::Value* rec_node = b.CreateCall(mixed_rec, {arena_ptr, tape_ptr, a1, a12});
+        llvm::Value* rec_valid = b.CreateICmpNE(rec_node,
+            llvm::ConstantPointerNull::get(llvm::PointerType::getUnqual(ctx_.context())));
+        llvm::BasicBlock* rec_bb = llvm::BasicBlock::Create(ctx_.context(), "fwd_ex_mixed_rec", fn);
+        llvm::BasicBlock* x0m = llvm::BasicBlock::Create(ctx_.context(), "fwd_ex_scalar_merge", fn);
+        llvm::BasicBlock* plain_exit = b.GetInsertBlock();
+        b.CreateCondBr(rec_valid, rec_bb, x0m);
+
+        b.SetInsertPoint(rec_bb);
+        llvm::Value* node_res = tagged_.packPtr(rec_node, ESHKOL_VALUE_CALLABLE);
+        llvm::BasicBlock* rec_exit = b.GetInsertBlock();
+        b.CreateBr(x0m);
+
+        b.SetInsertPoint(x0m);
+        llvm::PHINode* sel = b.CreatePHI(ctx_.taggedValueType(), 2, "fwd_ex_scalar_sel");
+        sel->addIncoming(scalar_res, plain_exit);
+        sel->addIncoming(node_res, rec_exit);
+        scalar_res = sel;
+    }
     b.CreateBr(mbb);
     llvm::BasicBlock* x0e = b.GetInsertBlock();
 
@@ -242,6 +281,75 @@ llvm::Value* AutodiffCodegen::popAndExtractForward(llvm::Value* result_tagged,
     res->addIncoming(scalar_res, x0e);
     res->addIncoming(slice, x1e);
     return res;
+}
+
+// ===== ESH-0093: jet-lift reverse-tape operands inside forward-mode AD =====
+// While a forward-mode derivative/gradient pass is live (__ad_pert_level > 0),
+// a reverse-tape AD node reaching scalar arithmetic must NOT be recorded on
+// the tape (that path drops the forward tangent — the mixed-mode bug).
+// Instead it is frozen to its value as a dual number, and — when it is the
+// gradient pass's published active seed variable (eshkol_ad_seed_flag) — its
+// e2 slot is seeded with 1.0 so the 4-jet carries the mixed e1e2 coefficient
+// d(result)/d(seed) to popAndExtractForward, which records the dependency
+// back onto the tape (eshkol_ad_mixed_record).
+// The e2 seed is only exact when the derivative body runs at pert level 1
+// (one forward level inside the reverse tape); deeper forward nesting has no
+// free slot in the 4-jet, so the seed is dropped there (level != 1 → 0.0),
+// degrading to the previous no-dependency behavior instead of corrupting the
+// x-perturbation.
+llvm::Value* AutodiffCodegen::maybeJetLiftTapeOperand(llvm::Value* operand_tagged) {
+    if (!operand_tagged || operand_tagged->getType() != ctx_.taggedValueType())
+        return operand_tagged;
+    auto& b = ctx_.builder();
+
+    // Cheap gate first: no live forward perturbation → no lifting (this is the
+    // path all non-AD code takes; a single global load + compare).
+    llvm::Value* level = adPertLevelLoad();
+    llvm::Value* pert_active = b.CreateICmpSGT(level,
+        llvm::ConstantInt::get(ctx_.int64Type(), 0));
+    llvm::Value* base = tagged_.getBaseType(tagged_.getType(operand_tagged));
+    llvm::Value* is_callable = b.CreateICmpEQ(base,
+        llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_CALLABLE));
+    llvm::Value* candidate = b.CreateAnd(pert_active, is_callable);
+
+    llvm::Function* fn = b.GetInsertBlock()->getParent();
+    llvm::BasicBlock* check_bb = llvm::BasicBlock::Create(ctx_.context(), "jetlift_check", fn);
+    llvm::BasicBlock* lift_bb = llvm::BasicBlock::Create(ctx_.context(), "jetlift_lift", fn);
+    llvm::BasicBlock* merge_bb = llvm::BasicBlock::Create(ctx_.context(), "jetlift_merge", fn);
+    llvm::BasicBlock* entry_exit = b.GetInsertBlock();
+    b.CreateCondBr(candidate, check_bb, merge_bb);
+
+    // CALLABLE: confirm it is actually an AD node (subtype check dereferences
+    // the header, so it must be behind the CALLABLE branch).
+    b.SetInsertPoint(check_bb);
+    llvm::Value* is_ad = tagged_.checkCallableSubtype(operand_tagged, CALLABLE_SUBTYPE_AD_NODE);
+    llvm::BasicBlock* check_exit = b.GetInsertBlock(); // subtype check adds blocks
+    b.CreateCondBr(is_ad, lift_bb, merge_bb);
+
+    // Lift: dual = {node->value, 0, seed_flag, 0}. seed_flag comes from the
+    // runtime (thread-local __ad_active_seed_node) so it works identically in
+    // JIT and AOT, and is masked to pert level 1 (see note above).
+    b.SetInsertPoint(lift_bb);
+    llvm::Value* node_ptr = tagged_.unpackPtr(operand_tagged);
+    llvm::Value* node_val = loadNodeValue(node_ptr);
+    llvm::FunctionCallee seed_flag_fn = ctx_.module().getOrInsertFunction(
+        "eshkol_ad_seed_flag",
+        llvm::FunctionType::get(ctx_.doubleType(), {ctx_.ptrType()}, false));
+    llvm::Value* raw_flag = b.CreateCall(seed_flag_fn, {node_ptr});
+    llvm::Value* zero = llvm::ConstantFP::get(ctx_.doubleType(), 0.0);
+    llvm::Value* level_is_1 = b.CreateICmpEQ(level,
+        llvm::ConstantInt::get(ctx_.int64Type(), 1));
+    llvm::Value* flag = b.CreateSelect(level_is_1, raw_flag, zero);
+    llvm::Value* lifted = packDualToTagged(makeDual4(ctx_, node_val, zero, flag, zero));
+    llvm::BasicBlock* lift_exit = b.GetInsertBlock(); // packDualToTagged may add blocks
+    b.CreateBr(merge_bb);
+
+    b.SetInsertPoint(merge_bb);
+    llvm::PHINode* phi = b.CreatePHI(ctx_.taggedValueType(), 3, "jetlift_result");
+    phi->addIncoming(operand_tagged, entry_exit);
+    phi->addIncoming(operand_tagged, check_exit);
+    phi->addIncoming(lifted, lift_exit);
+    return phi;
 }
 
 llvm::Value* AutodiffCodegen::getDualPrimal(llvm::Value* dual) {
@@ -3119,6 +3227,14 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
                 Value* dual_elems = ctx_.builder().CreateGEP(ctx_.int8Type(), dual_vec, ConstantInt::get(ctx_.int64Type(), 8));
                 Value* dual_elems_typed = ctx_.builder().CreatePointerCast(dual_elems, ctx_.ptrType());
 
+                // ESH-0093: participate in the runtime perturbation-level
+                // protocol (see the scheme-vector path below for the full
+                // rationale): seed this level's slot, push the level around
+                // the closure call, extract this level's coefficient.
+                Value* rt_pert_level = adPertLevelLoad();
+                Value* rt_lvl0 = ctx_.builder().CreateICmpEQ(rt_pert_level,
+                    ConstantInt::get(ctx_.int64Type(), 0));
+
                 // Outer loop: for each dimension i, compute partial derivative
                 Value* dim_counter = ctx_.builder().CreateAlloca(ctx_.int64Type(), nullptr, "grad_dim_i");
                 ctx_.builder().CreateStore(ConstantInt::get(ctx_.int64Type(), 0), dim_counter);
@@ -3161,8 +3277,11 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
                     ConstantFP::get(ctx_.doubleType(), 1.0),
                     ConstantFP::get(ctx_.doubleType(), 0.0));
 
-                // Create dual number and store in dual vector
-                Value* dual_num = createDualNumber(primal_val, tangent);
+                // ESH-0093: seed THIS level's slot (e1 at level 0, e2 nested)
+                Value* rt_zero_t = ConstantFP::get(ctx_.doubleType(), 0.0);
+                Value* rt_t_e1 = ctx_.builder().CreateSelect(rt_lvl0, tangent, rt_zero_t);
+                Value* rt_t_e2 = ctx_.builder().CreateSelect(rt_lvl0, rt_zero_t, tangent);
+                Value* dual_num = makeDual4(ctx_, primal_val, rt_t_e1, rt_t_e2, rt_zero_t);
                 Value* dual_tagged = packDualToTagged(dual_num);
                 Value* dual_elem_ptr = ctx_.builder().CreateGEP(ctx_.taggedValueType(), dual_elems_typed, inner_j);
                 ctx_.builder().CreateStore(dual_tagged, dual_elem_ptr);
@@ -3197,6 +3316,9 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
                 const int GRAD_MAX_ARITY = 8;
                 BasicBlock* gcall_default = BasicBlock::Create(ctx_.context(), "grad_call_vec", current_func);
                 BasicBlock* gcall_merge = BasicBlock::Create(ctx_.context(), "grad_call_merge", current_func);
+                // ESH-0093: the callee body runs one forward level deeper
+                adPertLevelStore(ctx_.builder().CreateAdd(rt_pert_level,
+                    ConstantInt::get(ctx_.int64Type(), 1)));
                 SwitchInst* gcall_sw = ctx_.builder().CreateSwitch(clo_arity, gcall_default, GRAD_MAX_ARITY);
 
                 std::vector<std::pair<BasicBlock*, Value*>> gcall_variants;
@@ -3232,6 +3354,9 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
                 PHINode* call_result = ctx_.builder().CreatePHI(ctx_.taggedValueType(), gcall_variants.size());
                 for (auto& cv : gcall_variants) call_result->addIncoming(cv.second, cv.first);
 
+                // ESH-0093: pop the perturbation level
+                adPertLevelStore(rt_pert_level);
+
                 // CONSTANT RESULT FIX: Check if result is a dual number before unpacking
                 // If function returns a constant (not using its argument), it won't be dual
                 Value* rt_result_type = tagged_.getType(call_result);
@@ -3245,11 +3370,13 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
 
                 ctx_.builder().CreateCondBr(rt_is_dual, rt_dual_bb, rt_const_bb);
 
-                // Dual path: extract tangent normally
+                // Dual path: extract THIS level's coefficient (e1 at level 0,
+                // e2 nested). ESH-0093: composes with an inner derivative's
+                // e2-slice return — see the scheme-vector path for details.
                 ctx_.builder().SetInsertPoint(rt_dual_bb);
                 Value* rt_result_dual = unpackDualFromTagged(call_result);
-                Value* rt_result_primal = getDualPrimal(rt_result_dual);
-                    Value* rt_dual_deriv = getDualTangent(rt_result_dual);
+                Value* rt_dual_deriv = ctx_.builder().CreateSelect(rt_lvl0,
+                    dualField(ctx_, rt_result_dual, 1), dualField(ctx_, rt_result_dual, 2));
                 ctx_.builder().CreateBr(rt_merge_bb);
                 BasicBlock* rt_dual_exit = ctx_.builder().GetInsertBlock();
 
@@ -3724,6 +3851,18 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
     // Get arena for dual vector allocation
     Value* arena_svec = ctx_.builder().CreateLoad(PointerType::getUnqual(ctx_.context()), ctx_.globalArena());
 
+    // ESH-0093: this forward-mode vector gradient participates in the runtime
+    // perturbation-level protocol (ESH-0070). The active component is seeded
+    // in THIS level's slot (e1 at level 0, e2 when nested), the level is
+    // pushed around the call so an inner derivative/gradient seeds the NEXT
+    // slot, and the extraction below reads this level's coefficient. Without
+    // this, an inner `derivative` re-seeded e1 and its perturbation collided
+    // with the component's (the mixed-mode composition bug: d/dp of an inner
+    // dx-derivative returned e1-confused garbage).
+    Value* svec_pert_level = adPertLevelLoad();
+    Value* svec_lvl0 = ctx_.builder().CreateICmpEQ(svec_pert_level,
+        ConstantInt::get(ctx_.int64Type(), 0));
+
     // Outer loop: for each dimension i, compute ∂f/∂xᵢ using forward-mode AD
     Value* svec_dim_i = ctx_.builder().CreateAlloca(ctx_.int64Type(), nullptr, "svec_dim_i");
     ctx_.builder().CreateStore(ConstantInt::get(ctx_.int64Type(), 0), svec_dim_i);
@@ -3772,8 +3911,13 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
     Value* svec_is_active = ctx_.builder().CreateICmpEQ(svec_j, svec_i);
     Value* svec_tangent = ctx_.builder().CreateSelect(svec_is_active,
         ConstantFP::get(ctx_.doubleType(), 1.0), ConstantFP::get(ctx_.doubleType(), 0.0));
-    // Create dual number and store
-    Value* svec_dual = createDualNumber(svec_primal, svec_tangent);
+    // ESH-0093: seed THIS level's slot (e1 at level 0, e2 when nested) so an
+    // inner forward-mode derivative — which seeds the NEXT slot after the
+    // level push below — cannot collide with the component's perturbation.
+    Value* svec_zero_t = ConstantFP::get(ctx_.doubleType(), 0.0);
+    Value* svec_t_e1 = ctx_.builder().CreateSelect(svec_lvl0, svec_tangent, svec_zero_t);
+    Value* svec_t_e2 = ctx_.builder().CreateSelect(svec_lvl0, svec_zero_t, svec_tangent);
+    Value* svec_dual = makeDual4(ctx_, svec_primal, svec_t_e1, svec_t_e2, svec_zero_t);
     Value* svec_dual_tagged = packDualToTagged(svec_dual);
     Value* svec_dual_ptr = ctx_.builder().CreateGEP(ctx_.taggedValueType(), svec_dual_elems_typed, svec_j);
     ctx_.builder().CreateStore(svec_dual_tagged, svec_dual_ptr);
@@ -3825,7 +3969,15 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
     // Resolve captures via unified helper
     resolveGradientCaptures(func_ptr, svec_call_args, "svec");
 
+    // ESH-0093: push the perturbation level around the call (the callee body
+    // runs one forward level deeper) and pop it right after — the same
+    // discipline seedForwardAndPush/popAndExtractForward use.
+    adPertLevelStore(ctx_.builder().CreateAdd(svec_pert_level,
+        ConstantInt::get(ctx_.int64Type(), 1)));
+
     Value* svec_call_result = ctx_.builder().CreateCall(func_ptr, svec_call_args);
+
+    adPertLevelStore(svec_pert_level);
 
     // CONSTANT RESULT FIX: Check if result is a dual number before unpacking
     Value* svec_result_type = tagged_.getType(svec_call_result);
@@ -3839,11 +3991,15 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
 
     ctx_.builder().CreateCondBr(svec_is_dual, svec_dual_bb, svec_const_bb);
 
-    // Dual path: extract tangent normally
+    // Dual path: extract THIS level's coefficient (e1 at level 0, e2 nested).
+    // ESH-0093: when the body contained an inner derivative, its
+    // popAndExtractForward already returned the e2-slice {a2, a12} as a dual,
+    // whose e1 coefficient is the mixed d/d(component) term — so the plain
+    // field-1 read at level 0 composes correctly with inner forward passes.
     ctx_.builder().SetInsertPoint(svec_dual_bb);
     Value* svec_result_dual = unpackDualFromTagged(svec_call_result);
-    Value* svec_result_primal = getDualPrimal(svec_result_dual);
-                    Value* svec_dual_deriv = getDualTangent(svec_result_dual);
+    Value* svec_dual_deriv = ctx_.builder().CreateSelect(svec_lvl0,
+        dualField(ctx_, svec_result_dual, 1), dualField(ctx_, svec_result_dual, 2));
     ctx_.builder().CreateBr(svec_merge_bb);
     BasicBlock* svec_dual_exit = ctx_.builder().GetInsertBlock();
 
@@ -4291,7 +4447,18 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
     // M1 Migration FIX: Set AD mode flag so vref recognizes AD node pointers in tensors
     ctx_.builder().CreateStore(ConstantInt::get(ctx_.int1Type(), 1), ctx_.adModeActive());
 
+    // ESH-0093: publish this pass's active variable node so an inner
+    // forward-mode derivative can seed it (jet-lift) and record the mixed
+    // partial back onto this tape. Save/restore for nested gradient passes.
+    FunctionCallee seed_swap_scalar = ctx_.module().getOrInsertFunction(
+        "eshkol_ad_seed_swap",
+        FunctionType::get(ctx_.ptrType(), {ctx_.ptrType()}, false));
+    Value* saved_seed_scalar = ctx_.builder().CreateCall(seed_swap_scalar, {active_var_node});
+
     Value* scalar_output = ctx_.builder().CreateCall(func_ptr, scalar_args);
+
+    // ESH-0093: restore the previously active seed node
+    ctx_.builder().CreateCall(seed_swap_scalar, {saved_seed_scalar});
 
     // M1 Migration FIX: Reset AD mode flag after function call
     ctx_.builder().CreateStore(ConstantInt::get(ctx_.int1Type(), 0), ctx_.adModeActive());
@@ -4469,7 +4636,18 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
     // M1 Migration FIX: Set AD mode flag so vref recognizes AD node pointers in tensors
     ctx_.builder().CreateStore(ConstantInt::get(ctx_.int1Type(), 1), ctx_.adModeActive());
 
+    // ESH-0093: publish this pass's active variable node so an inner
+    // forward-mode derivative can seed it (jet-lift) and record the mixed
+    // partial back onto this tape. Save/restore for nested gradient passes.
+    FunctionCallee seed_swap_vector = ctx_.module().getOrInsertFunction(
+        "eshkol_ad_seed_swap",
+        FunctionType::get(ctx_.ptrType(), {ctx_.ptrType()}, false));
+    Value* saved_seed_vector = ctx_.builder().CreateCall(seed_swap_vector, {active_var_node});
+
     Value* vector_output = ctx_.builder().CreateCall(func_ptr, grad_call_args);
+
+    // ESH-0093: restore the previously active seed node
+    ctx_.builder().CreateCall(seed_swap_vector, {saved_seed_vector});
 
     // M1 Migration FIX: Reset AD mode flag after function call
     ctx_.builder().CreateStore(ConstantInt::get(ctx_.int1Type(), 0), ctx_.adModeActive());

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -13411,6 +13411,8 @@ private:
             TypedValue tv = codegenTypedAST(&op->call_op.variables[0]);
             if (!tv.llvm_value) return nullptr;
             Value* arg = typedValueToTaggedValue(tv);
+            // ESH-0093: freeze reverse-tape operands to jets inside forward-mode AD
+            arg = autodiff_->maybeJetLiftTapeOperand(arg);
             return arith_->withADUnaryDispatch(arg, 43 /*AD_NODE_SQUARE*/, [&]() -> llvm::Value* {
                 Value* type = getTaggedValueType(arg);
                 Value* base_type = getBaseType(type);
@@ -18698,6 +18700,11 @@ private:
         // Convert to tagged_value for runtime type detection
         Value* arg_tagged = typedValueToTaggedValue(arg_tv);
 
+        // ESH-0093: while a forward-mode derivative is live, reverse-tape AD
+        // nodes are frozen to jets (active gradient seed in e2) instead of
+        // being mis-recorded on the tape. No-op otherwise.
+        arg_tagged = autodiff_->maybeJetLiftTapeOperand(arg_tagged);
+
         // Extract type tag
         Value* arg_type = getTaggedValueType(arg_tagged);
         Value* arg_base_type = getBaseType(arg_type);
@@ -19038,6 +19045,11 @@ private:
 
         // Convert to tagged_value for runtime type detection
         Value* arg_tagged = typedValueToTaggedValue(arg_tv);
+
+        // ESH-0093: while a forward-mode derivative is live, reverse-tape AD
+        // nodes are frozen to jets (active gradient seed in e2) instead of
+        // being mis-recorded on the tape. No-op otherwise.
+        arg_tagged = autodiff_->maybeJetLiftTapeOperand(arg_tagged);
 
         // Extract type tag
         Value* arg_type = getTaggedValueType(arg_tagged);
@@ -35431,6 +35443,8 @@ private:
         if (c_math_func) {
             // UNIVERSAL AD AWARENESS: 3-way dispatch — AD node → dual number → regular
             // This ensures (gradient exp 0.0) works correctly with bare builtins
+            // ESH-0093: freeze reverse-tape operands to jets inside forward-mode AD
+            arg = autodiff_->maybeJetLiftTapeOperand(arg);
             Value* arg_type = getTaggedValueType(arg);
             Value* arg_base_type = getBaseType(arg_type);
 

--- a/lib/core/arena_memory.h
+++ b/lib/core/arena_memory.h
@@ -284,6 +284,14 @@ void arena_tape_reset(ad_tape_t* tape);
 ad_node_t* arena_tape_get_node(const ad_tape_t* tape, size_t index);
 size_t arena_tape_get_node_count(const ad_tape_t* tape);
 
+// ===== ESH-0093: mixed-mode AD (reverse tape over inner forward derivative) =====
+// A reverse-mode gradient pass publishes its active variable node here so an
+// inner forward-mode derivative can seed it in the jet (e2) and record the
+// mixed partial back onto the tape. See lib/core/runtime_autodiff.cpp.
+void* eshkol_ad_seed_swap(void* node);           // publish; returns previous
+double eshkol_ad_seed_flag(void* node);          // 1.0 iff node is the active seed
+void* eshkol_ad_mixed_record(void* arena, void* tape, double value, double dseed);
+
 // ===== OALR (Ownership-Aware Lexical Regions) MEMORY MANAGEMENT =====
 // Region-based memory management for predictable, GC-free allocation
 

--- a/lib/core/memory_store.esk
+++ b/lib/core/memory_store.esk
@@ -39,6 +39,7 @@
          memory-store-open-fast
          memory-store-append!
          memory-store-verify
+         memory-store-audit
          memory-store-count
          memory-store-head
          memory-store-sanitize)
@@ -276,17 +277,46 @@
                         #f)))))))))
 
 (define (memory-store-open-fast node-id path)
-  ;; O(1) open for append-only use (the per-tick weave). Restores prev-hash +
-  ;; vclock from the sidecar without replaying the log. The returned store's
-  ;; in-memory event list holds only NEW events from this session — use
-  ;; memory-store-open (full replay) for reads/verification.
-  (let ((head (ms-read-head path)))
-    (if (not head)
-        (memory-store-open node-id path)   ;; no/invalid sidecar -> full replay
+  ;; Fast open for append-only use (the per-tick weave). Restores prev-hash +
+  ;; vclock from the sidecar, then VALIDATES against the file tail: a crash
+  ;; between append and sidecar write leaves the sidecar one event behind, and
+  ;; trusting it forks the chain (we have exactly one such scar, line 1211).
+  ;; The FILE is the truth; the sidecar is a hint. Tail scan is a plain line
+  ;; read (no hashing, no RGA) — O(n) cheap, ~seconds at 10k links.
+  ;; The returned store's in-memory event list holds only NEW events from this
+  ;; session — use memory-store-open (full replay) for reads.
+  (let ((head (ms-read-head path))
+        (tail (ms-last-event path)))
+    (if (or (not head) (not tail))
+        (memory-store-open node-id path)   ;; no sidecar or no file -> full path
         (let ((log (make-memory-log node-id)))
-          (vector-set! log 3 (cdr head))   ;; vclock
-          (vector-set! log 4 (car head))   ;; prev-hash
+          (if (equal? (car head) (memory-event-id tail))
+              (begin                        ;; sidecar agrees with the file
+                (vector-set! log 3 (cdr head))
+                (vector-set! log 4 (car head)))
+              (begin                        ;; stale sidecar: heal from the tail
+                (display "memory-store: stale sidecar healed from file tail") (newline)
+                (vector-set! log 3 (memory-event-vclock tail))
+                (vector-set! log 4 (memory-event-id tail))))
           (make-memory-store log path)))))
+
+(define (ms-last-event path)
+  ;; Last parseable event in the file (plain line scan, no hashing).
+  (let ((f (ms-fopen path "r")))
+    (if (null-ptr? f)
+        #f
+        (begin
+          (ms-fclose f)
+          (let ((port (open-input-file path)))
+            (define (go last)
+              (let ((line (read-line port)))
+                (if (eof-object? line)
+                    (begin (close-port port) last)
+                    (if (= (string-length line) 0)
+                        (go last)
+                        (let ((ev (ms-parse line)))
+                          (go (if (and ev (memory-event? ev)) ev last)))))))
+            (go #f))))))
 
 (define (memory-store-verify store)
   ;; Full audit, TWO layers:
@@ -335,3 +365,60 @@
                         (char>? c #\~))
                     (string-append acc " ")
                     (string-append acc (string c))))))))
+
+;; =====================================================================
+;; Streaming audit — verify without building the log.
+;;
+;; memory-store-open replays into the RGA, whose per-append cost grows with
+;; size: a 6.8k-link chain took ~16 MINUTES to open just to be verified. An
+;; audit needs none of that structure: stream each line, re-derive its
+;; content hash, check its PARENT EXISTS among previously-seen ids, discard.
+;; O(n) flat — the same 6.8k links audit in ~3 seconds.
+;;
+;; Linkage semantics: parent-exists, not strict-linear. A DELETED event is
+;; caught (its child references an id never seen). A FORK — two events
+;; sharing one parent — is legitimate history for this CRDT log (a crash
+;; between append and sidecar update, or concurrent multi-node appends after
+;; T1 lands) and is counted, not failed. We have one real scar: the first
+;; backfill run was killed at a timeout between append and sidecar write,
+;; and the resumed chunk forked from the stale head. The chain records
+;; reality, including its own scars.
+;;
+;; Returns (ms-audit-v1 ok links forks) or (line-number . reason),
+;; reason = unparseable | hash-mismatch | orphan-parent.
+;; =====================================================================
+
+(define (memory-store-audit path)
+  (let ((port (open-input-file path))
+        (seen (make-hash-table)))
+    (define (go lineno count forks)
+      (let ((line (read-line port)))
+        (if (eof-object? line)
+            (begin (close-port port)
+                   (list (quote ms-audit-v1) #t count forks))
+            (if (= (string-length line) 0)
+                (go (+ lineno 1) count forks)
+                (let ((ev (ms-parse line)))
+                  (cond
+                    ((not (and ev (memory-event? ev)))
+                     (begin (close-port port) (cons lineno (quote unparseable))))
+                    ((not (string=? (memory-event-id ev)
+                                    (event-content-hash (memory-event-node ev)
+                                                        (memory-event-prev ev)
+                                                        (memory-event-vclock ev)
+                                                        (memory-event-type ev)
+                                                        (memory-event-payload ev))))
+                     (begin (close-port port) (cons lineno (quote hash-mismatch))))
+                    ((and (memory-event-prev ev)
+                          (not (hash-table-ref seen (memory-event-prev ev) #f)))
+                     (begin (close-port port) (cons lineno (quote orphan-parent))))
+                    (else
+                     (let ((fork (if (and (memory-event-prev ev)
+                                          (hash-table-ref seen (string-append "child:" (memory-event-prev ev)) #f))
+                                     1 0)))
+                       (hash-table-set! seen (memory-event-id ev) #t)
+                       (if (memory-event-prev ev)
+                           (hash-table-set! seen (string-append "child:" (memory-event-prev ev)) #t)
+                           #t)
+                       (go (+ lineno 1) (+ count 1) (+ forks fork))))))))))
+    (go 1 0 0)))

--- a/lib/core/memory_store.esk
+++ b/lib/core/memory_store.esk
@@ -29,12 +29,14 @@
 (require stdlib)
 (require core.memory)
 (require core.sexp)
+(require core.files)   ;; atomic-write-file for the head sidecar
 
 (provide make-memory-store
          memory-store?
          memory-store-log
          memory-store-path
          memory-store-open
+         memory-store-open-fast
          memory-store-append!
          memory-store-verify
          memory-store-count
@@ -215,15 +217,100 @@
 
 (define (memory-store-append! store type payload)
   ;; Append to the in-memory chain, then persist with fsync (T0) before returning.
-  (let* ((ev   (memory-append! (memory-store-log store) type payload))
+  ;; Also refreshes the head sidecar so the NEXT process can open in O(1).
+  ;; Every payload string is sanitized HERE (defense in depth) — the store never
+  ;; trusts callers to have done it; one unsanitized em-dash cost us a link.
+  (let* ((clean (ms-sanitize-payload payload))
+         (ev   (memory-append! (memory-store-log store) type clean))
          (line (string-append (sexp->canonical-string ev) "\n")))
     (if (ms-append-fsync! (memory-store-path store) line)
-        ev
+        (begin (ms-write-head! store) ev)
         (begin (display "memory-store: DURABILITY FAILURE (append not persisted)") (newline) #f))))
 
+(define (ms-sanitize-payload payload)
+  ;; alist of (key . string|number) -> same, with every string value sanitized
+  (if (null? payload) (list)
+      (let ((entry (car payload)))
+        (cons (if (and (pair? entry) (string? (cdr entry)))
+                  (cons (car entry) (memory-store-sanitize (cdr entry)))
+                  entry)
+              (ms-sanitize-payload (cdr payload))))))
+
+;; =====================================================================
+;; O(1) open via head sidecar — the per-tick weave path.
+;;
+;; events.log.head holds (ms-head-v1 <prev-hash-or-#f> <vclock>) — everything
+;; an append needs. Written atomically (temp+rename, files.esk) after every
+;; append; if it is missing or stale the fast open falls back to a FULL
+;; replay + verify and rebuilds it. The sidecar is pure optimization: the
+;; log file remains the single source of truth, and memory-store-verify
+;; always audits the full chain.
+;; =====================================================================
+
+(define (ms-head-path path) (string-append path ".head"))
+
+(define (ms-write-head! store)
+  (let ((log (memory-store-log store)))
+    (atomic-write-file
+      (ms-head-path (memory-store-path store))
+      (string-append
+        (sexp->canonical-string
+          (list (quote ms-head-v1) (vector-ref log 4) (vector-ref log 3)))
+        "\n"))))
+
+(define (ms-read-head path)
+  ;; -> (prev . vclock) or #f
+  (let ((f (ms-fopen (ms-head-path path) "r")))
+    (if (null-ptr? f)
+        #f
+        (begin
+          (ms-fclose f)
+          (let ((port (open-input-file (ms-head-path path))))
+            (let ((line (read-line port)))
+              (close-port port)
+              (if (eof-object? line)
+                  #f
+                  (let ((h (ms-parse line)))
+                    (if (and h (pair? h) (eq? (car h) (quote ms-head-v1)))
+                        (cons (list-ref h 1) (list-ref h 2))
+                        #f)))))))))
+
+(define (memory-store-open-fast node-id path)
+  ;; O(1) open for append-only use (the per-tick weave). Restores prev-hash +
+  ;; vclock from the sidecar without replaying the log. The returned store's
+  ;; in-memory event list holds only NEW events from this session — use
+  ;; memory-store-open (full replay) for reads/verification.
+  (let ((head (ms-read-head path)))
+    (if (not head)
+        (memory-store-open node-id path)   ;; no/invalid sidecar -> full replay
+        (let ((log (make-memory-log node-id)))
+          (vector-set! log 3 (cdr head))   ;; vclock
+          (vector-set! log 4 (car head))   ;; prev-hash
+          (make-memory-store log path)))))
+
 (define (memory-store-verify store)
-  ;; Full audit: re-derive every content hash + linkage from the replayed data.
-  (memory-verify-chain (memory-store-log store)))
+  ;; Full audit, TWO layers:
+  ;;  1. core.memory content hashes — a MODIFIED event is caught (hash-mismatch)
+  ;;  2. strict linear linkage — a DELETED event is caught (linkage-broken):
+  ;;     the first event's prev must be #f and each event's prev must equal its
+  ;;     predecessor's id. (core.memory's verify checks only content hashes, so
+  ;;     without this a removed line passes silently — we proved that gap.)
+  ;;     Valid for a single-node chain; merged multi-node logs have legitimate
+  ;;     forks and will need the CRDT-aware verifier when T1 fan-out lands.
+  (let ((content (memory-verify-chain (memory-store-log store))))
+    (if (not (eq? content #t))
+        content
+        (ms-verify-linkage (memory-events (memory-store-log store)) #f))))
+
+(define (ms-verify-linkage evs expected-prev)
+  (if (null? evs)
+      #t
+      (let ((ev (car evs)))
+        (if (equal? (memory-event-prev ev) expected-prev)
+            (ms-verify-linkage (cdr evs) (memory-event-id ev))
+            (cons (list (quote event) (memory-event-id ev)
+                        (quote expected-prev) expected-prev)
+                  (quote linkage-broken))))))
 
 (define (memory-store-count store)
   (length (memory-events (memory-store-log store))))
@@ -232,12 +319,19 @@
   (let ((evs (memory-events (memory-store-log store))))
     (if (null? evs) #f (memory-event-id (list-ref evs (- (length evs) 1))))))
 
-;; v1 payload-string sanitizer (see header): strip double-quotes and newlines.
+;; v1 payload-string sanitizer (see header): strip double-quotes, newlines, AND
+;; every non-printable-ASCII character. The last one is load-bearing: fwrite's
+;; length argument is string-length = CHARACTERS, but the file gets UTF-8
+;; BYTES — one multibyte char (an em-dash in her felt state) truncated the
+;; write, ate the line terminator, and glued two events onto one line. Until
+;; byte-length crosses the FFI, payload strings are printable ASCII only.
 (define (memory-store-sanitize str)
   (let loop ((i 0) (n (string-length str)) (acc ""))
     (if (>= i n) acc
         (let ((c (string-ref str i)))
           (loop (+ i 1) n
-                (if (or (char=? c #\") (char=? c #\newline))
+                (if (or (char=? c #\")
+                        (char<? c #\space)
+                        (char>? c #\~))
                     (string-append acc " ")
                     (string-append acc (string c))))))))

--- a/lib/core/runtime_autodiff.cpp
+++ b/lib/core/runtime_autodiff.cpp
@@ -51,6 +51,84 @@ thread_local uint64_t __gradient_x_degree = 0;
 thread_local void* __outer_ad_node_stack[ESHKOL_ARENA_MAX_TAPE_DEPTH] = {nullptr};
 thread_local uint64_t __outer_ad_node_depth = 0;
 
+// ===== ESH-0093: mixed-mode AD (reverse tape over forward jets) =====
+//
+// A reverse-mode `gradient` computes each partial d/dtheta_i in its own pass:
+// it rebuilds the tape with fresh AD variable nodes and only reads the ACTIVE
+// node's gradient afterwards. Before calling the target function, the pass
+// publishes that active variable node here. While a forward-mode derivative
+// is live inside the pass (__ad_pert_level > 0), tape nodes that flow into
+// scalar arithmetic are "jet-lifted" to dual numbers: value = node->value,
+// and e2 = 1.0 iff the node IS the published seed (eshkol_ad_seed_flag).
+// The forward 4-jet then carries the mixed e1e2 coefficient
+// d(inner-derivative-result)/d(theta_i) to the derivative's return site,
+// which records the result back onto the tape (eshkol_ad_mixed_record) as
+//   result = const(a1 - a12*theta_i) + const(a12) * theta_i_node
+// — an exact local linearization whose backward edge to theta_i is a12.
+// Only existing node types (CONSTANT/MUL/ADD) are used, so backpropagation
+// needs no new rules. With k tape-carried captures, no extra jet passes are
+// needed: the outer gradient's per-component loop already runs one pass per
+// theta_i, and each pass only requires the partial w.r.t. its own seed.
+thread_local void* __ad_active_seed_node = nullptr;
+
+// Publish a new active seed node; returns the previous one so callers can
+// save/restore around nested gradient passes.
+void* eshkol_ad_seed_swap(void* node) {
+    void* old = __ad_active_seed_node;
+    __ad_active_seed_node = node;
+    return old;
+}
+
+// 1.0 iff `node` is the active seed for the current gradient pass.
+double eshkol_ad_seed_flag(void* node) {
+    return (node && node == __ad_active_seed_node) ? 1.0 : 0.0;
+}
+
+// Record an inner forward-mode derivative result on the active reverse tape.
+//   value : the derivative's value (a1, the e1 coefficient)
+//   dseed : d(value)/d(seed) (a12, the mixed e1e2 coefficient)
+// Returns the AD node to use as the result, or NULL when there is nothing to
+// record (no tape, no seed, or no dependency) — the caller then returns the
+// plain scalar as before.
+void* eshkol_ad_mixed_record(void* arena_v, void* tape_v, double value, double dseed) {
+    if (!arena_v || !tape_v) return nullptr;
+    ad_node_t* seed = (ad_node_t*)__ad_active_seed_node;
+    if (!seed) return nullptr;
+    if (dseed == 0.0) return nullptr;  // no dependency on this pass's variable
+
+    arena_t* arena = (arena_t*)arena_v;
+    ad_tape_t* tape = (ad_tape_t*)tape_v;
+
+    ad_node_t* coeff  = arena_allocate_ad_node_with_header(arena);
+    ad_node_t* scaled = arena_allocate_ad_node_with_header(arena);
+    ad_node_t* offset = arena_allocate_ad_node_with_header(arena);
+    ad_node_t* result = arena_allocate_ad_node_with_header(arena);
+    if (!coeff || !scaled || !offset || !result) return nullptr;
+
+    coeff->type = AD_NODE_CONSTANT;
+    coeff->value = dseed;
+
+    scaled->type = AD_NODE_MUL;          // backward: seed.grad += grad * dseed
+    scaled->value = dseed * seed->value;
+    scaled->input1 = seed;
+    scaled->input2 = coeff;
+
+    offset->type = AD_NODE_CONSTANT;
+    offset->value = value - dseed * seed->value;
+
+    result->type = AD_NODE_ADD;          // value = a1 exactly
+    result->value = value;
+    result->input1 = scaled;
+    result->input2 = offset;
+
+    // Topological order for the reverse traversal: result last.
+    arena_tape_add_node(tape, coeff);
+    arena_tape_add_node(tape, offset);
+    arena_tape_add_node(tape, scaled);
+    arena_tape_add_node(tape, result);
+    return result;
+}
+
 eshkol_dual_number_t* arena_allocate_dual_number(arena_t* arena) {
     if (!arena) {
         eshkol_error("Cannot allocate dual number: null arena");

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -1127,6 +1127,10 @@ void ReplJITContext::registerRuntimeSymbols() {
     ADD_SYMBOL(arena_tape_reset);
     ADD_SYMBOL(arena_tape_get_node);
     ADD_SYMBOL(arena_tape_get_node_count);
+    // ESH-0093: mixed-mode AD (reverse tape over inner forward derivative)
+    ADD_SYMBOL(eshkol_ad_seed_swap);
+    ADD_SYMBOL(eshkol_ad_seed_flag);
+    ADD_SYMBOL(eshkol_ad_mixed_record);
     ADD_SYMBOL(debug_print_ad_mode);
     ADD_SYMBOL(debug_print_ptr);
 

--- a/site/static/eshkol-runtime.js
+++ b/site/static/eshkol-runtime.js
@@ -330,6 +330,8 @@ class EshkolRuntime {
                 eshkol_tensor_result_dtype_binary: (r) => r,
                 eshkol_tensor_result_dtype_unary: (r) => r,
                 eshkol_type_error_with_operand: () => { throw new Error('Eshkol type error (WASM stub)'); },
+                eshkol_ad_mixed_record: () => 0,
+                eshkol_ad_seed_flag: () => 0,
                 eshkol_tensor_operand_checked: () => 0,
                 eshkol_format_double: () => 0,
                 eshkol_fprint_double: () => 0,

--- a/tests/ad/mixed_mode_ad_test.esk
+++ b/tests/ad/mixed_mode_ad_test.esk
@@ -1,0 +1,83 @@
+;;; tests/ad/mixed_mode_ad_test.esk
+;;; ESH-0093: mixed-mode AD composition — an outer VECTOR-parameter `gradient`
+;;; (reverse tape) over an inner `derivative` (forward jets) must propagate the
+;;; dependency on captured tape parameters. Mechanism: while a forward pass is
+;;; live, tape nodes entering arithmetic are jet-lifted (value frozen, active
+;;; gradient seed in e2); the derivative return site records the result on the
+;;; outer tape with backward edge a12 = d(result)/d(seed).
+(define pass 0)(define fail 0)
+(define (approx= a b) (< (abs (- a b)) 1e-9))
+(define (chk label v) (display "  [")(display (if v "PASS" "FAIL"))(display "] ")(display label)(newline)
+  (if v (set! pass (+ pass 1)) (set! fail (+ fail 1))))
+
+;; === The ESH-0093 repro: f(x;p0) = p0*x^2, df/dx@2 = 4*p0, d/dp0 = 4 ===
+(define g1 (gradient (lambda (p) (derivative (lambda (x) (* (vector-ref p 0) (* x x))) 2.0))
+                     (vector 3.0)))
+(chk "repro: grad_p [d/dx p0*x^2 @2] @(3) = #(4)" (approx= (vector-ref g1 0) 4.0))
+
+;; === 2-element vector: f(x;p) = p0*x + p1*x^2 ===
+;; df/dx = p0 + 2*p1*x @x=2 => partials: d/dp0 = 1, d/dp1 = 2x = 4 => #(1 4)
+(define g2 (gradient (lambda (p) (derivative (lambda (x) (+ (* (vector-ref p 0) x)
+                                                            (* (vector-ref p 1) (* x x)))) 2.0))
+                     (vector 3.0 5.0)))
+(chk "2-elem: d/dp0 = 1" (approx= (vector-ref g2 0) 1.0))
+(chk "2-elem: d/dp1 = 2x = 4" (approx= (vector-ref g2 1) 4.0))
+
+;; === capture used nonlinearly: f(x;p0) = p0^2 * x ===
+;; df/dx = p0^2; d/dp0(df/dx) = 2*p0 = 6 @p0=3
+(define g3 (gradient (lambda (p) (derivative (lambda (x) (* (vector-ref p 0) (vector-ref p 0) x)) 2.0))
+                     (vector 3.0)))
+(chk "nonlinear capture: d/dp0 (p0^2) = 2p0 = 6" (approx= (vector-ref g3 0) 6.0))
+
+;; nonlinear in both x and the capture: f(x;p0) = p0^2 * x^2
+;; df/dx = 2*p0^2*x @x=2 = 4*p0^2; d/dp0 = 8*p0 = 24 @p0=3
+(define g3b (gradient (lambda (p) (derivative (lambda (x) (* (vector-ref p 0) (vector-ref p 0) (* x x))) 2.0))
+                      (vector 3.0)))
+(chk "nonlinear both: d/dp0 (2 p0^2 x) = 8p0 = 24" (approx= (vector-ref g3b 0) 24.0))
+
+;; === derivative result used inside a larger tape expression ===
+;; h(p) = p0 + d/dx(p0*x^2)@2 = p0 + 4*p0 => dh/dp0 = 5
+(define g4 (gradient (lambda (p) (+ (vector-ref p 0)
+                                    (derivative (lambda (x) (* (vector-ref p 0) (* x x))) 2.0)))
+                     (vector 3.0)))
+(chk "tape composition: d/dp0 (p0 + 4p0) = 5" (approx= (vector-ref g4 0) 5.0))
+
+;; === tensor-literal input: exercises the REVERSE-mode tape path ===
+;; (#(...) is a tensor; (vector ...) is a Scheme vector — different gradient
+;; paths: tape+jet-lift+mixed-record vs forward jets with the level protocol)
+(define (outer-t p) (derivative (lambda (x) (* (vector-ref p 0) (* x x))) 2.0))
+(define gt1 (gradient outer-t #(3.0)))
+(chk "tensor input (reverse tape): #(4)" (approx= (vector-ref gt1 0) 4.0))
+
+(define (outer-t2 p) (derivative (lambda (x) (+ (* (vector-ref p 0) x)
+                                                (* (vector-ref p 1) (* x x)))) 2.0))
+(define gt2 (gradient outer-t2 #(3.0 5.0)))
+(chk "tensor 2-elem (reverse tape): d/dp0 = 1" (approx= (vector-ref gt2 0) 1.0))
+(chk "tensor 2-elem (reverse tape): d/dp1 = 4" (approx= (vector-ref gt2 1) 4.0))
+
+(define (outer-t3 p) (derivative (lambda (x) (* (vector-ref p 0) (vector-ref p 0) x)) 2.0))
+(define gt3 (gradient outer-t3 #(3.0)))
+(chk "tensor nonlinear capture (reverse tape): 2p0 = 6" (approx= (vector-ref gt3 0) 6.0))
+
+;; === controls: existing behavior must be unchanged ===
+(chk "control: pure reverse grad p0^2 @(3) = #(6)"
+     (approx= (vector-ref (gradient (lambda (p) (* (vector-ref p 0) (vector-ref p 0))) (vector 3.0)) 0) 6.0))
+(chk "control: SCALAR gradient over derivative = 4 (forward fast path)"
+     (approx= (gradient (lambda (p) (derivative (lambda (x) (* p (* x x))) 2.0)) 3.0) 4.0))
+(chk "control: inner derivative alone = 12"
+     (approx= (derivative (lambda (x) (* 3.0 (* x x))) 2.0) 12.0))
+(chk "control: capture-free inner derivative under vector gradient: d/dp0 (p0 * 4) = 4"
+     (approx= (vector-ref (gradient (lambda (p) (* (vector-ref p 0)
+                                                   (derivative (lambda (x) (* x x)) 2.0)))
+                                    (vector 3.0)) 0) 4.0))
+
+;; === bounded iteration: stability + no crash/leak blow-up over 1000 calls ===
+(define (loop-test i acc)
+  (if (= i 1000)
+      acc
+      (loop-test (+ i 1)
+                 (vector-ref (gradient (lambda (p) (derivative (lambda (x) (* (vector-ref p 0) (* x x))) 2.0))
+                                       (vector 3.0)) 0))))
+(chk "1000-iteration loop stable = 4" (approx= (loop-test 0 0.0) 4.0))
+
+(display "Passed: ")(display pass)(newline)(display "Failed: ")(display fail)(newline)

--- a/web/eshkol-repl.js
+++ b/web/eshkol-repl.js
@@ -310,6 +310,8 @@ class EshkolRepl {
                 eshkol_tensor_result_dtype_binary: (r) => r,
                 eshkol_tensor_result_dtype_unary: (r) => r,
                 eshkol_type_error_with_operand: () => { throw new Error('Eshkol type error (WASM stub)'); },
+                eshkol_ad_mixed_record: () => 0,
+                eshkol_ad_seed_flag: () => 0,
                 eshkol_tensor_operand_checked: () => 0,
                 eshkol_format_double: () => 0,
                 eshkol_fprint_double: () => 0,


### PR DESCRIPTION
## Bug (ESH-0093)

Mixed-mode AD composition: an outer vector-parameter `gradient` over an inner `derivative` dropped the dependency on captured parameters.

```scheme
(gradient (lambda (p) (derivative (lambda (x) (* (vector-ref p 0) (* x x))) 2.0)) (vector 3.0))
;; before: #(0)    after: #(4)   (d/dx(theta*x^2)@x=2 = 4*theta => d/dtheta = 4)
```

## Root cause

Two independent composition gaps, one per gradient implementation path:

1. **Forward vector-gradient paths** (Scheme-vector input `(vector ...)` and the runtime-closure path) seeded the active component's tangent in **e1 unconditionally** and did not participate in the ESH-0070 runtime perturbation-level protocol (`__ad_pert_level`). An inner `derivative` — entered at level 0 — re-seeded **e1** for its own variable, colliding with the component's perturbation. The observed wrong value decomposes exactly as e1-confusion: `d/de1(theta*x^2)` with both seeded = `x^2 + theta*2x = 4 + 12 = 16`, and the final extraction returned 0/garbage.

2. **Reverse-mode tape path** (tensor input `#(...)`): tape AD nodes reaching scalar arithmetic inside a live forward pass took the `ad_path` (recorded on the tape), which **dropped the forward tangent** — the inner derivative returned an ordinary number with no tape edge, so the outer backward pass saw zero dependency.

## Mechanism

**Forward paths — join the perturbation-level protocol** (`lib/backend/autodiff_codegen.cpp`, svec loop + grad_rt closure loop):
- seed the active component in *this* level's slot (e1 at level 0, e2 nested),
- push `__ad_pert_level` around the call, pop after,
- extract *this* level's coefficient.

An inner `derivative` then seeds e2 and its `popAndExtractForward` returns the e2-slice `{a2, a12}` as a dual whose e1 coefficient **is** the mixed term — the exact mechanism of the scalar forward fast path (#95), generalized per component. No behavior change when no inner forward pass exists.

**Reverse tape path — seed + jet-lift + linearized record:**
- each reverse gradient pass publishes its active variable node (`eshkol_ad_seed_swap`, thread-local, save/restore for nested passes),
- arithmetic entry points **jet-lift** tape operands while `__ad_pert_level > 0`: `dual {node->value, 0, seed_flag, 0}` (`AutodiffCodegen::maybeJetLiftTapeOperand`; applied at `add/sub/mul/div/pow/min/max/neg/abs`, `codegenMathFunction`, `codegenAbs`, `square`, and the builtin-wrapper dispatch), instead of mis-recording them on the tape,
- the derivative return site (`popAndExtractForward`, level 0) records the result on the outer tape as an exact local linearization `result = const(a1 - a12*theta) + const(a12) * theta_node` (`eshkol_ad_mixed_record`), where `a12` is the mixed e1e2 jet coefficient = d(derivative-result)/d(theta_i). Only existing CONSTANT/MUL/ADD node types are used — backpropagation needs no new rules.

With k tape-carried captures **no extra jet passes are needed**: the reverse loop already rebuilds the tape once per component, and each pass reads only its own seed's gradient. (Documented limitation: the e2 seed is exact for one forward level inside the tape; deeper forward nesting drops the capture edge instead of corrupting the x-perturbation.)

New runtime symbols `eshkol_ad_seed_swap` / `eshkol_ad_seed_flag` / `eshkol_ad_mixed_record` (lib/core/runtime_autodiff.cpp) are registered for the JIT in `lib/repl/repl_jit.cpp` and declared in `lib/core/arena_memory.h`.

## Before / after

| case | before | after |
|---|---|---|
| repro `(vector 3.0)` | `#(0)` | `#(4)` |
| repro `#(3.0)` (tensor / reverse tape) | `#(0)` | `#(4)` |
| 2-element `p0*x + p1*x^2` at `(vector 3.0 5.0)` | `#(0 0)` | `#(1 4)` |
| nonlinear capture `p0*p0*x` | `#(0)` | `#(6)` |
| control: pure reverse `p0^2` | `#(6)` | `#(6)` |
| control: scalar gradient over derivative (#95 fast path) | `4` | `4` |
| control: inner derivative alone | `12` | `12` |

## Verification (both paths)

- `tests/ad/mixed_mode_ad_test.esk`: **15/15 under `-r` (JIT) and AOT**, incl. a 1000-iteration stability loop and both scheme-vector and tensor-literal inputs (covers both fixed paths).
- No regressions: `nested_ad_test` 10/10, `nested_ad_loop_test` 10/10, `vm_ad_test` complete, `vm_ad_full_test` 23 PASS, `free_energy_ad_test`, `stateful_tape_test` 22/22, `ad_input2` gates all PASS — each on JIT and AOT.
- `scripts/run_icc_smoke.sh`: 10/10 probes pass.