### PR TITLE
fix(codegen): evaluate top-level constructor operands exactly once (ESH-0098)

### DIFF
--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -5495,6 +5495,56 @@ private:
         return typed_val.llvm_value;
     }
     
+    // Read the HoTT type inferred for an AST node during the type-checking phase
+    // WITHOUT emitting any LLVM IR.
+    //
+    // SINGLE-EVAL FIX (ESH-0098): The typed-builtin branches below (list, vector,
+    // cons, car, cdr, vector-ref, addr-of) used to call codegenTypedAST() on their
+    // operand ASTs purely to recover an element/pointee type, then call
+    // codegenAST(ast) to actually build the value — which re-generated those same
+    // operands. That double-generated any side-effecting operand (e.g.
+    // (list (bump!)) called bump! twice; (vector ...) twice per element). The value
+    // builders (CollectionCodegen::list, codegenVector, ...) already evaluate each
+    // operand exactly once, so for type recovery we must NOT emit IR again. The
+    // type checker (run over every top-level form before codegen) annotates each
+    // sub-expression's inferred_hott_type, so we read that directly. Falls back to
+    // the generic Value type when a node was not type-checked (0), which is safe.
+    eshkol::hott::TypeId inferredHottType(const eshkol_ast_t* ast) const {
+        if (ast && ast->inferred_hott_type != 0) {
+            return eshkol::hott::TypeId::unpack(ast->inferred_hott_type);
+        }
+        return eshkol::hott::BuiltinTypes::Value;
+    }
+
+    // Recover the element type of a collection expression WITHOUT emitting IR.
+    // The type checker records only the base List/Vector type in inferred_hott_type
+    // (element precision is not packed), so for accessors like car/cdr/vector-ref we
+    // recover the element type directly from a nested constructor's operand types.
+    // Returns the generic Value type when it cannot be determined cheaply. Used by
+    // the SINGLE-EVAL FIX (ESH-0098) to avoid re-generating the collection operand.
+    eshkol::hott::TypeId inferredElementTypeOf(const eshkol_ast_t* coll_ast) const {
+        if (coll_ast && coll_ast->type == ESHKOL_OP &&
+            coll_ast->operation.op == ESHKOL_CALL_OP &&
+            coll_ast->operation.call_op.func &&
+            coll_ast->operation.call_op.func->type == ESHKOL_VAR &&
+            coll_ast->operation.call_op.func->variable.id) {
+            std::string fn = coll_ast->operation.call_op.func->variable.id;
+            if (fn == "list" || fn == "vector" || fn == "cons") {
+                uint64_t n = coll_ast->operation.call_op.num_vars;
+                uint64_t take = (fn == "cons" && n > 0) ? 1 : n;
+                std::vector<eshkol::hott::TypeId> element_types;
+                for (uint64_t i = 0; i < take; i++) {
+                    element_types.push_back(
+                        inferredHottType(&coll_ast->operation.call_op.variables[i]));
+                }
+                if (!element_types.empty()) {
+                    return ctx_->hottTypes().inferListElementType(element_types);
+                }
+            }
+        }
+        return eshkol::hott::BuiltinTypes::Value;
+    }
+
     // Create TypedValue from AST node
     TypedValue codegenTypedAST(const eshkol_ast_t* ast) {
         if (!ast) return TypedValue();
@@ -5617,11 +5667,13 @@ private:
                     // Operations that return cons pointers (or null for empty list)
                     // HoTT PARAMETERIZED TYPES: Track element types for List<T>
                     if (func_name == "list") {
-                        // Infer element type from list arguments
+                        // Infer element type from list arguments.
+                        // SINGLE-EVAL FIX (ESH-0098): read pre-computed types, do NOT
+                        // re-generate operands here (codegenAST below builds them once).
                         std::vector<eshkol::hott::TypeId> element_types;
                         for (uint64_t i = 0; i < ast->operation.call_op.num_vars; i++) {
-                            TypedValue arg_typed = codegenTypedAST(&ast->operation.call_op.variables[i]);
-                            element_types.push_back(arg_typed.hott_type);
+                            element_types.push_back(
+                                inferredHottType(&ast->operation.call_op.variables[i]));
                         }
                         eshkol::hott::TypeId elem_type = ctx_->hottTypes().inferListElementType(element_types);
                         auto list_type = ctx_->hottTypes().makeListType(elem_type);
@@ -5639,11 +5691,12 @@ private:
                     }
 
                     if (func_name == "cons") {
-                        // For cons, first arg determines element type
+                        // For cons, first arg determines element type.
+                        // SINGLE-EVAL FIX (ESH-0098): read pre-computed type, do NOT
+                        // re-generate the operand here (codegenAST below builds it once).
                         eshkol::hott::TypeId elem_type = eshkol::hott::BuiltinTypes::Value;
                         if (ast->operation.call_op.num_vars > 0) {
-                            TypedValue first_arg = codegenTypedAST(&ast->operation.call_op.variables[0]);
-                            elem_type = first_arg.hott_type;
+                            elem_type = inferredHottType(&ast->operation.call_op.variables[0]);
                         }
                         auto list_type = ctx_->hottTypes().makeListType(elem_type);
 
@@ -5660,13 +5713,12 @@ private:
                     }
 
                     if (func_name == "cdr") {
-                        // Preserve element type from the input list
+                        // Preserve element type from the input list.
+                        // SINGLE-EVAL FIX (ESH-0098): recover element type without
+                        // re-generating the list operand (codegenAST builds it once).
                         eshkol::hott::TypeId elem_type = eshkol::hott::BuiltinTypes::Value;
                         if (ast->operation.call_op.num_vars > 0) {
-                            TypedValue list_arg = codegenTypedAST(&ast->operation.call_op.variables[0]);
-                            if (list_arg.hasParameterizedType()) {
-                                elem_type = list_arg.elementType();
-                            }
+                            elem_type = inferredElementTypeOf(&ast->operation.call_op.variables[0]);
                         }
                         auto list_type = ctx_->hottTypes().makeListType(elem_type);
 
@@ -5683,13 +5735,12 @@ private:
                     }
 
                     if (func_name == "car") {
-                        // car returns the element type from the list
+                        // car returns the element type from the list.
+                        // SINGLE-EVAL FIX (ESH-0098): recover element type without
+                        // re-generating the list operand (codegenAST builds it once).
                         eshkol::hott::TypeId elem_type = eshkol::hott::BuiltinTypes::Value;
                         if (ast->operation.call_op.num_vars > 0) {
-                            TypedValue list_arg = codegenTypedAST(&ast->operation.call_op.variables[0]);
-                            if (list_arg.hasParameterizedType()) {
-                                elem_type = list_arg.elementType();
-                            }
+                            elem_type = inferredElementTypeOf(&ast->operation.call_op.variables[0]);
                         }
                         Value* val = codegenAST(ast);
                         if (!val) return TypedValue();
@@ -5702,11 +5753,13 @@ private:
                     // Operations that return scheme vector pointers
                     // HoTT PARAMETERIZED TYPES: Track element types for Vector<T>
                     if (func_name == "vector") {
-                        // Infer element type from vector arguments
+                        // Infer element type from vector arguments.
+                        // SINGLE-EVAL FIX (ESH-0098): read pre-computed types, do NOT
+                        // re-generate operands here (codegenAST below builds them once).
                         std::vector<eshkol::hott::TypeId> element_types;
                         for (uint64_t i = 0; i < ast->operation.call_op.num_vars; i++) {
-                            TypedValue arg_typed = codegenTypedAST(&ast->operation.call_op.variables[i]);
-                            element_types.push_back(arg_typed.hott_type);
+                            element_types.push_back(
+                                inferredHottType(&ast->operation.call_op.variables[i]));
                         }
                         eshkol::hott::TypeId elem_type = ctx_->hottTypes().inferListElementType(element_types);
                         auto vec_type = ctx_->hottTypes().makeVectorType(elem_type);
@@ -5725,13 +5778,12 @@ private:
                     }
 
                     if (func_name == "vector-ref") {
-                        // vector-ref returns the element type from the vector
+                        // vector-ref returns the element type from the vector.
+                        // SINGLE-EVAL FIX (ESH-0098): recover element type without
+                        // re-generating the vector operand (codegenAST builds it once).
                         eshkol::hott::TypeId elem_type = eshkol::hott::BuiltinTypes::Value;
                         if (ast->operation.call_op.num_vars > 0) {
-                            TypedValue vec_arg = codegenTypedAST(&ast->operation.call_op.variables[0]);
-                            if (vec_arg.hasParameterizedType()) {
-                                elem_type = vec_arg.elementType();
-                            }
+                            elem_type = inferredElementTypeOf(&ast->operation.call_op.variables[0]);
                         }
                         Value* val = codegenAST(ast);
                         if (!val) return TypedValue();
@@ -5848,10 +5900,11 @@ private:
                         return makeLowLevelTypedValue(val, intrinsic_info->return_type);
                     }
                     if (func_name == "addr-of") {
+                        // SINGLE-EVAL FIX (ESH-0098): recover pointee type without
+                        // re-generating the operand (codegenAST builds it once).
                         eshkol::hott::TypeId pointee_type = eshkol::hott::BuiltinTypes::Value;
                         if (ast->operation.call_op.num_vars == 1) {
-                            TypedValue target = codegenTypedAST(&ast->operation.call_op.variables[0]);
-                            pointee_type = target.hott_type;
+                            pointee_type = inferredHottType(&ast->operation.call_op.variables[0]);
                         }
                         auto ptr_type_info = ctx_->hottTypes().makePointerType(pointee_type);
 

--- a/tests/codegen/toplevel_single_eval_test.esk
+++ b/tests/codegen/toplevel_single_eval_test.esk
@@ -1,0 +1,121 @@
+;; Codegen Test: constructor operands evaluate EXACTLY once (ESH-0098)
+;;
+;; Regression guard for the bug where TOP-LEVEL (list e) evaluated e twice and
+;; (vector e) evaluated e twice-per-element, because the typed-builtin codegen
+;; path re-generated operand IR for type inference AND for the value build. The
+;; value builders already evaluate each operand once, so effectful operands like
+;; (bump!) must fire exactly once per occurrence -- at top level AND inside
+;; function bodies, on both -r (JIT) and AOT.
+
+(require stdlib)
+
+(define tests-passed 0)
+(define tests-failed 0)
+
+(define (test-case name expected actual)
+  (if (equal? expected actual)
+      (begin
+        (set! tests-passed (+ tests-passed 1))
+        (display "PASS: ") (display name) (display "\n"))
+      (begin
+        (set! tests-failed (+ tests-failed 1))
+        (display "FAIL: ") (display name)
+        (display " (expected ") (display expected)
+        (display ", got ") (display actual) (display ")\n"))))
+
+;; ============================================================================
+;; TOP-LEVEL constructors -- one shared effectful counter, reset between cases
+;; ============================================================================
+
+(display "=== Top-level constructor single-eval ===\n")
+
+(define counter 0)
+(define (tick!) (set! counter (+ counter 1)) counter)
+
+;; (list e): e must fire exactly once, and the stored value is that first eval.
+(set! counter 0)
+(define tl-list (list (tick!)))
+(test-case "toplevel list count" 1 counter)
+(test-case "toplevel list value" 1 (car tl-list))
+
+;; (vector a b): each operand once, left-to-right, stored values are 1 then 2.
+(set! counter 0)
+(define tl-vec (vector (tick!) (tick!)))
+(test-case "toplevel vector count" 2 counter)
+(test-case "toplevel vector v0" 1 (vector-ref tl-vec 0))
+(test-case "toplevel vector v1" 2 (vector-ref tl-vec 1))
+
+;; (cons e '()): the car operand fires once.
+(set! counter 0)
+(define tl-cons (cons (tick!) '()))
+(test-case "toplevel cons count" 1 counter)
+(test-case "toplevel cons value" 1 (car tl-cons))
+
+;; Multi-element list: exactly one fire per element.
+(set! counter 0)
+(define tl-list3 (list (tick!) (tick!) (tick!)))
+(test-case "toplevel list3 count" 3 counter)
+
+;; Nested constructors: each leaf operand fires exactly once.
+(set! counter 0)
+(define tl-nested (list (vector (tick!)) (tick!)))
+(test-case "toplevel nested count" 2 counter)
+
+;; Accessor over a fresh constructor must NOT re-run the constructor operand.
+(set! counter 0)
+(define tl-accessed (car (list (tick!))))
+(test-case "toplevel car-of-list count" 1 counter)
+(test-case "toplevel car-of-list value" 1 tl-accessed)
+
+;; ============================================================================
+;; INSIDE FUNCTION BODIES -- same guarantees
+;; ============================================================================
+
+(display "=== In-function constructor single-eval ===\n")
+
+(define (fn-list-count)
+  (define n 0)
+  (define (bump!) (set! n (+ n 1)) n)
+  (define xs (list (bump!)))
+  n)
+(test-case "in-fn list count" 1 (fn-list-count))
+
+(define (fn-vector-count)
+  (define n 0)
+  (define (bump!) (set! n (+ n 1)) n)
+  (define v (vector (bump!) (bump!)))
+  n)
+(test-case "in-fn vector count" 2 (fn-vector-count))
+
+(define (fn-cons-count)
+  (define n 0)
+  (define (bump!) (set! n (+ n 1)) n)
+  (define c (cons (bump!) '()))
+  n)
+(test-case "in-fn cons count" 1 (fn-cons-count))
+
+(define (fn-vector-value)
+  (define n 0)
+  (define (bump!) (set! n (+ n 1)) n)
+  (define v (vector (bump!) (bump!)))
+  (vector-ref v 0))
+(test-case "in-fn vector first value" 1 (fn-vector-value))
+
+(define (fn-nested-count)
+  (define n 0)
+  (define (bump!) (set! n (+ n 1)) n)
+  (define x (list (vector (bump!)) (bump!) (bump!)))
+  n)
+(test-case "in-fn nested count" 3 (fn-nested-count))
+
+;; ============================================================================
+;; Summary
+;; ============================================================================
+
+(display "\n=== Test Summary ===\n")
+(display "Passed: ") (display tests-passed) (display "\n")
+(display "Failed: ") (display tests-failed) (display "\n")
+
+(if (= tests-failed 0)
+    (begin (display "All tests passed!\n") 0)
+    (begin (display "Some tests failed!\n") 1))


### PR DESCRIPTION
## Summary

Fixes ESH-0098: at top level, `(list e)` evaluated `e` twice and `(vector e)` evaluated each operand twice; the same defect affected `cons`, `car`, `cdr`, `vector-ref`, and `addr-of`, and it fired inside function bodies too.

```scheme
(define n 0)
(define (bump!) (set! n (+ n 1)) n)
(define xs (list (bump!)))   ;; before: n=2  → after: n=1
(define v  (vector (bump!))) ;; before: n=2  → after: n=1
```

With a fresh counter, `(vector a b)` even stored the *second* evaluation's values (`#(3 4)` instead of `#(1 2)`) — now `#(1 2)`.

## Root cause

`codegenTypedAST` handles the builtin constructors/accessors by (1) calling `codegenTypedAST()` on each operand **purely to recover an element/pointee type** for HoTT `List<T>`/`Vector<T>` tracking, then (2) calling `codegenAST(ast)` to actually build the value. The value builders (`CollectionCodegen::list`, `codegenVector`, …) already evaluate every operand exactly once, so step (1) re-generated the operand IR — duplicating any side effect (`bump!` emitted twice; the first result discarded, the second stored).

## Fix

Recover operand types **without emitting IR**. The type checker runs over every form before codegen and annotates each sub-expression's `inferred_hott_type`. Two new non-emitting helpers read that:

- `inferredHottType(ast)` — unpacks the pre-computed type, falling back to the generic `Value` type when a node wasn't type-checked (safe).
- `inferredElementTypeOf(coll_ast)` — recovers a collection's element type from a nested constructor's operand types, preserving `(car (list 1 2 3))` element precision for the accessor branches.

`codegenAST(ast)` remains the single evaluation of the operands. Applied to `list`, `vector`, `cons`, `car`, `cdr`, `vector-ref`, `addr-of`. String/hash/tensor constructors were audited and already fall through to a single `codegenAST` (no change needed).

## Tests

`tests/codegen/toplevel_single_eval_test.esk` — effectful counters through list/vector/cons/nested constructors and accessors, at top level **and** inside functions, asserting exact evaluation counts and stored values. 16/16 pass on both `-r` and AOT.

## Verification

- New test: 16/16 on `-r` and AOT
- Codegen suite: 3/3
- ICC smoke (`run_icc_smoke.sh`): all real checks pass, incl. all AD gradient probes (confirms element-type precision preserved). The single `example_agent_compiles` miss is a missing untracked local file in the fresh worktree, not a regression — it compiles fine under this build.
- SICP smoke: 88/88 (`-r` + AOT)