### PR TITLE
docs: complete documentation refresh for v1.3.0-evolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,108 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0-evolve] - 2026-07-03
+
+The "evolve" release: full SICP coverage, exact nested/mixed-mode automatic
+differentiation, closure-semantics completion, every CI platform green, and a
+new permanent adversarial-testing infrastructure.
+
+Release gates (green on the release SHA): SICP full-book gate 88/88 probes under
+both `-r` and AOT (`scripts/run_sicp_smoke.sh`); CI 14/14 lanes including
+windows-arm64; ICC readiness oracle `v1.3-evolve` ready.
+
 ### Added
 
-- Started v1.3-evolve with parser-level string interpolation: string literals
-  can embed `~{expr}` forms, each expression is formatted with display
-  semantics, and `~~{` preserves a literal interpolation opener.
+- Parser-level string interpolation: string literals can embed `~{expr}` forms,
+  each formatted with display semantics; `~~{` preserves a literal opener.
+- Keyword formal support for function and lambda parameters (e.g. `#:scale scale`)
+  plus `let-match` destructuring bindings.
+- First R7RS library surface: `(import (scheme base))` and
+  `(define-library ... (export ...) (import ...) (begin ...))` lower onto the
+  module loader; import-set modifiers `only`/`except`/`rename`/prefix are wired.
+- SICP full-book corpus and smoke oracle: 88 probes across chapters 1-5 including
+  the metacircular, analyzing, lazy, and `amb` evaluators, the query system, and
+  the register-machine simulators, made a v1.3 gate (#85, #87, #102, #105-#109).
+- Native EAGLE linear-head training over the FFI bridge, with a durable
+  hash-chained memory store (#104); `core.memory` v0 content-addressed CRDT
+  event-log faculty (#61).
+- Adversarial testing infrastructure (permanent, ICC-wired): multi-path
+  differential harness + seeded fuzzer (#114), feature-pair edge matrix (#112),
+  AD finite-difference composition oracle (#111), and a stress harness with
+  RSS/time budgets (#115). A VM parity ratchet + manifest lands with the release
+  (#118). See `docs/TESTING.md` and `docs/VM_PARITY.md`.
+- Stdlib completeness: `take-right`/`drop-right`, `filter-map`, and `core.alist`
+  aggregated into `(require stdlib)` (#72, #76).
 
-- Added v1.3 keyword formal support for function and lambda parameters such as
-  `#:scale scale`, plus `let-match` destructuring bindings for day-to-day
-  pattern binding.
+### Fixed
 
-- Added the first v1.3 R7RS library surface: simple `(import (scheme base))`
-  and `(define-library ... (export ...) (import ...) (begin ...))` forms now
-  lower onto the existing module loader.
+Automatic differentiation
+- True nested/higher-order AD via perturbation tagging — nested scalar
+  derivatives are now exact instead of finite-difference approximations (#75).
+- Perturbation/tape state scoped across named-let TCO, giving exact iterated
+  higher-order AD (#84); runtime scalar nested gradients through a named inner
+  function (#95).
+- Mixed-mode vector-gradient-over-derivative: captured-parameter dependencies
+  propagate through the inner derivative onto the outer reverse tape (#113).
+- Centralized, type-checked tensor operand unpack — a type error instead of a
+  SIGSEGV on wrong-typed tensor-op inputs (#79); conv2d forward unified and
+  corrected (NCHW) across codegen and VM (#80); tensor structural integer
+  metadata guarded (#97).
+
+Language and closures
+- `set!`-mutated variables captured by multiple closures are now shared
+  (assignment conversion) (#83); local `letrec` closures get per-activation
+  instances instead of module-level globals (#89).
+- First-class / `apply`'d equality predicates return proper `#t`/`#f` booleans
+  (#86).
+- Quote-token dispatch fixed across `guard`/`case`/`match`/quasiquote clause
+  parsers (#117) and preserved in let-family body tails inside defines (#110).
+- Top-level constructor operands are evaluated exactly once (#116).
+- Macros expand inside internal-define (`letrec*`) bodies (#74); hash tables match
+  compound (cons/list/vector) keys by structural equality (#73).
+- R7RS numeric tower: exactness and promotion discipline, AD-visible `min`/`max`,
+  exact `expt` (#82).
+- R7RS string ops: first-class `string-map` procedure, `string->number` radix (#78).
+
+Memory and control
+- `with-region` body allocations routed into the region arena (#81).
+- Deep-CPS continuation chains run an O0 native cleanup to avoid SIGILL (#93).
+
+Platforms and toolchain
+- windows-arm64 build unbroken: portable `sincos` shim (#77), Windows x64
+  in-process JIT symbol gap (#70), AArch64 Branch26 range extension (#64).
+- Portable JIT/AOT link across the build mesh (objc + LLVM libdir + bounded
+  link timeout) (#71); runtime transitive link deps exported (#69).
+- GPU: bounded Metal command-buffer waits (#66), lazy GPU init + Jetson CUDA
+  GEMM (#68), tensor dtype hardening (#63); parallel-map logger lock race fixed
+  (#67).
+- AOT backend hardening: atomic object emission (#92), object-emit watchdog (#99),
+  interned error strings (#100), external-define body-scan pruning (#101).
+
+### Known Issues
+
+Deep-edge findings surfaced by the new adversarial harnesses; each has a minimal
+repro and a ledger entry under `.swarm/tasks/`. None block ordinary use.
+
+- Vector gradient-of-gradient silently returns zeros; use nested scalar
+  `derivative` for exact higher-order results (ESH-0096).
+- `hessian`/`laplacian` SIGSEGV when the evaluation point is a tensor literal
+  `#(...)` / `(tensor ...)` (ESH-0095).
+- Vector-param AD op combined with a captured local parameter fails LLVM
+  verification (`PtrToInt source must be pointer`) (ESH-0072, ESH-0097).
+- A closure created inside a named-let loop that `set!`s a global loses the
+  mutation (ESH-0094).
+- Deep non-tail recursion (~270k frames) dies with SIGILL and no diagnostic;
+  stdlib `sort`/`length`/`filter` are non-tail-recursive and fail on very large
+  inputs; mutual tail calls are not TCO'd (ESH-0098, ESH-0101, ESH-0102, ESH-0108).
+- Exact rational arithmetic degrades to double once a bignum is involved
+  (ESH-0105).
+- Long-form `(quasiquote x)`/`(unquote x)` and nested quasiquote (level >= 2)
+  are not fully wired (ESH-0104, ESH-0107).
+- JIT compile of a ~10k-deep nested expression uses excessive RSS/time; AOT is
+  unaffected (ESH-0103).
+- 27 bytecode-VM divergences and 351 VM parity gaps are documented and tracked
+  in the VM parity manifest (`tests/vm_parity/PARITY.tsv`, ships with #118).
 
 ## [1.2.3-scale] - 2026-05-25
 

--- a/COMPLETE_LANGUAGE_SPECIFICATION.md
+++ b/COMPLETE_LANGUAGE_SPECIFICATION.md
@@ -1,6 +1,6 @@
 # Eshkol Language - Complete Technical Specification
 
-**Version:** v1.2.1-scale
+**Version:** v1.3.0-evolve
 **Generated:** 2026-05-20
 **Status:** Comprehensive implementation documentation from source code
 
@@ -3854,7 +3854,7 @@ Keep original name (exported via `provide`)
 
 ## 26. Version Information
 
-**Current Version:** v1.2.1-scale
+**Current Version:** v1.3.0-evolve
 
 **Version History:**
 - v1.2.0-scale - Production readiness: model serialization, stable C ABI + Python bindings, per-thread arenas, 512 MB main-thread stack on Darwin, image I/O, plotting stdlib, actionable error messages with file:line:col + caret, JSON Schema validator (Draft 7 subset), R7RS-compliant scoping for stdlib redefines, --wasm self-contained emit, AD scalar derivative on inline lambdas, value-typed-capture LLVM verification, variadic-info hygiene on user redefines, 62-test edge-case suite + ASan/UBSan CI lane, 7 hardening fixes (subprocess injection, FFI AST injection, integer overflows, path traversal, ReDoS).
@@ -3964,7 +3964,7 @@ Dynamic binding of parameter objects. Parameters created with `make-parameter` a
 
 ## Conclusion
 
-This document provides a **complete** specification of the Eshkol programming language version v1.2.1-scale, documenting **every** feature, function, operator, and capability found in the implementation.
+This document provides a **complete** specification of the Eshkol programming language version v1.3.0-evolve, documenting **every** feature, function, operator, and capability found in the implementation.
 
 **Total Coverage:**
 - All 101 special forms and parser operations

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,6 +1,6 @@
 # Eshkol Design Document
 
-## v1.2.1-scale
+## v1.3.0-evolve
 
 Eshkol is a compiled programming language for scientific computing, machine learning, and cognitive architectures. It compiles Scheme (R7RS) source through LLVM to native binaries, combining Lisp's homoiconicity with deterministic arena-based memory, compiler-integrated automatic differentiation, and a consciousness engine built on unification, active inference, and global workspace theory.
 
@@ -50,7 +50,7 @@ Compilation command: `eshkol-run file.esk -o binary`
 
 ### Modular Code Generation
 
-The LLVM backend delegates to roughly thirty specialized modules via `std::function` callbacks. This inverts the typical dependency graph: modules call into main codegen rather than vice versa, enabling parallel development and incremental testing. Line counts below reflect the v1.2.1-scale tree.
+The LLVM backend delegates to roughly thirty specialized modules via `std::function` callbacks. This inverts the typical dependency graph: modules call into main codegen rather than vice versa, enabling parallel development and incremental testing. Line counts below reflect the v1.3.0-evolve tree.
 
 | Module | Lines | Responsibility |
 |:---|---:|:---|
@@ -306,4 +306,4 @@ The LLVM and VM backends share the same language semantics but use independent v
 
 ---
 
-*Eshkol v1.2.1-scale is a production compiler integrating automatic differentiation, deterministic memory management, homoiconic native code, GPU acceleration, cognitive computing primitives, and a dual backend architecture (LLVM + bytecode VM). The codebase ships with a 62-test edge-case regression suite, an ASan/UBSan CI lane, 555+ built-in functions, and 37 sub-suites passing end-to-end.*
+*Eshkol v1.3.0-evolve is a production compiler integrating automatic differentiation, deterministic memory management, homoiconic native code, GPU acceleration, cognitive computing primitives, and a dual backend architecture (LLVM + bytecode VM). The codebase ships with a 62-test edge-case regression suite, an ASan/UBSan CI lane, 555+ built-in functions, and 37 sub-suites passing end-to-end.*

--- a/ESHKOL_LANGUAGE_GUIDE.md
+++ b/ESHKOL_LANGUAGE_GUIDE.md
@@ -1034,7 +1034,7 @@ Map Eshkol names to C names:
 
 ```
 $ ./eshkol-repl
-Eshkol REPL v1.2.1-scale
+Eshkol REPL v1.3.0-evolve
 Type :help for assistance, :quit to exit
 
 eshkol> (define (square x) (* x x))
@@ -1391,5 +1391,5 @@ MIT License - Copyright (C) tsotchke
 ---
 
 <p align="center">
-<strong>Eshkol v1.2.1-scale</strong>: Where functional programming meets scientific computing, GPU acceleration, and machine consciousness.
+<strong>Eshkol v1.3.0-evolve</strong>: Where functional programming meets scientific computing, GPU acceleration, and machine consciousness.
 </p>

--- a/ESHKOL_QUICK_REFERENCE.md
+++ b/ESHKOL_QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Eshkol Quick Reference Card
 
-**v1.2.1-scale** -- 555+ built-in functions
+**v1.3.0-evolve** -- 555+ built-in functions
 
 ## Basics
 

--- a/ESHKOL_V1_LANGUAGE_REFERENCE.md
+++ b/ESHKOL_V1_LANGUAGE_REFERENCE.md
@@ -1,5 +1,5 @@
 # Eshkol Programming Language - Complete Reference
-## Version v1.2.1-scale
+## Version v1.3.0-evolve
 
 **A Comprehensive Guide to Every Feature in Pure Eshkol**
 
@@ -2290,7 +2290,7 @@ epsilon                       ; => 1e-15
 
 ## 22. Complete Function Index
 
-This section lists EVERY function, operator, and special form in Eshkol v1.2.1-scale.
+This section lists EVERY function, operator, and special form in Eshkol v1.3.0-evolve.
 
 ### 22.1 Special Forms (39)
 
@@ -2721,7 +2721,7 @@ call-with-values      ; Consume multiple values
 
 ## 23. Exact Arithmetic
 
-Eshkol v1.2.1-scale implements the full R7RS numeric tower with arbitrary-precision integers (bignums) and exact rational numbers, providing lossless arithmetic across the entire integer and rational domains.
+Eshkol v1.3.0-evolve implements the full R7RS numeric tower with arbitrary-precision integers (bignums) and exact rational numbers, providing lossless arithmetic across the entire integer and rational domains.
 
 ### 23.1 Arbitrary-Precision Integers (Bignums)
 
@@ -3062,7 +3062,7 @@ Bytevectors are fixed-length mutable sequences of bytes (unsigned 8-bit integers
 
 ## 27. Parallel Primitives
 
-Eshkol v1.2.1-scale provides data-parallel operations and futures for concurrent computation. Parallel primitives use arena-isolated worker threads with lock-free dispatch; no user-visible synchronisation is required.
+Eshkol v1.3.0-evolve provides data-parallel operations and futures for concurrent computation. Parallel primitives use arena-isolated worker threads with lock-free dispatch; no user-visible synchronisation is required.
 
 ### 27.1 Data-Parallel Operations
 
@@ -3748,7 +3748,7 @@ variable-name
 
 ## Complete Coverage Summary
 
-This reference documents the **ENTIRE** Eshkol language v1.2.1-scale:
+This reference documents the **ENTIRE** Eshkol language v1.3.0-evolve:
 
 - **39 Special Forms** -- All control structures, binding forms, continuations, and dynamic-wind
 - **350+ Built-in Functions** -- Arithmetic, comparisons, strings, I/O, bignums, rationals, complex

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Eshkol is a Scheme-based programming language that unifies functional programming with native automatic differentiation, providing a mathematically rigorous foundation for gradient-based optimization, numerical simulation, and machine learning research. Built on Homotopy Type Theory foundations and compiled to native code via LLVM, Eshkol delivers mathematical correctness and deterministic performance without sacrificing the elegance of homoiconic Lisp syntax.
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![Version](https://img.shields.io/badge/version-v1.2.3--scale-green.svg)](RELEASE_NOTES.md) [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](CMakeLists.txt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![Version](https://img.shields.io/badge/version-v1.3.0--evolve-green.svg)](RELEASE_NOTES.md) [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](CMakeLists.txt)
 
 <br>
 
@@ -113,7 +113,7 @@ The language embodies three fundamental principles that distinguish it from exis
 
 ### **1. Differentiation as a Language Primitive**
 
-Automatic differentiation is not a library feature—it is intrinsic to the language semantics. Eshkol provides three distinct AD modes (symbolic, forward-mode, reverse-mode) with native support for vector calculus operators (∇, ∇·, ∇×, ∇²) and arbitrary-depth gradient nesting through a sophisticated computational tape stack architecture.
+Automatic differentiation is not a library feature—it is intrinsic to the language semantics. Eshkol provides three distinct AD modes (symbolic, forward-mode, reverse-mode) with native support for vector calculus operators (∇, ∇·, ∇×, ∇²) and exact nested higher-order differentiation through a computational tape-stack architecture.
 
 ```scheme
 ;; Define any differentiable function
@@ -128,11 +128,11 @@ Automatic differentiation is not a library feature—it is intrinsic to the lang
   (gradient (lambda (p) (loss-function p training-data))
             initial-params))
 
-;; Nested gradients to arbitrary depth
-(define hessian-trace 
-  (trace (gradient (lambda (x) 
-                     (car (gradient f (vector x))))
-                   (vector x0))))
+;; Exact higher-order derivatives by nesting the scalar `derivative` operator.
+;; f(x) = x^3  ->  f''(2) = 6*2 = 12
+(derivative (lambda (x)
+              (derivative (lambda (y) (* y y y)) x))
+            2.0)   ;; => 12
 ```
 
 ### **2. Deterministic Memory Management**
@@ -596,6 +596,40 @@ Execute: `eshkol-run gradient.esk -o gradient && ./gradient`
 - **Hardening**: subprocess shell-injection fix, Python FFI AST-injection fix, integer-overflow guards (arena/KB/image), path-traversal defence, ReDoS protection, sanitizer-clean ASan/UBSan CI lane
 - **87-test edge/security suite**: regression coverage for symbol consistency, AD tape state, parser line tracking, stdlib symbol resolution, HTTP/server smoke behavior, and every fix in this release
 
+### v1.3.0-evolve Features
+
+**Evolve.** Full SICP coverage, exact nested/mixed-mode automatic differentiation,
+closure-semantics completion, every CI platform green, and a permanent
+adversarial-testing infrastructure.
+
+- **Full SICP support**: an 88-probe full-book gate (`tests/sicp/`,
+  `scripts/run_sicp_smoke.sh`) covering chapters 1-5 — including the metacircular,
+  analyzing, lazy, and `amb` nondeterministic evaluators, the query system, and
+  the register-machine simulators — passing under both `-r` (JIT) and AOT.
+- **Exact higher-order AD**: iterated/nested higher-order differentiation is now
+  exact (no finite-difference fallback) for scalar derivatives, and mixed-mode
+  vector-gradient-over-derivative composes correctly (#75, #84, #95, #113).
+- **Closure-semantics completion**: `set!`-mutated variables shared across multiple
+  closures (assignment conversion, #83), per-activation `letrec` closure instances
+  (#89), first-class / `apply`'d equality predicates return proper booleans (#86).
+- **Parser correctness**: quote-token dispatch fixed across `guard`/`case`/`match`/
+  quasiquote clause parsers and let-family body tails (#110, #117); constructor
+  operands evaluated exactly once (#116).
+- **R7RS numeric tower**: exactness and promotion discipline, AD-visible `min`/`max`
+  (#82).
+- **Platforms**: windows-arm64 build unbroken (#77); `with-region` body allocations
+  routed into the region arena (#81). CI is green across all 14 lanes.
+- **Native agent/ML substrate**: EAGLE linear-head training over the FFI bridge (#104).
+- **Adversarial testing infrastructure** (new, permanent): a multi-path differential
+  harness + fuzzer, a feature-pair edge matrix, an AD finite-difference oracle, and a
+  stress harness with RSS/time budgets — all wired into the ICC readiness oracle.
+  See [`docs/TESTING.md`](docs/TESTING.md).
+
+Some deep-edge findings surfaced by the new harnesses remain open and are tracked
+in the changelog's Known Issues section (e.g. vector gradient-of-gradient,
+`hessian`/`laplacian` on tensor points, deep non-tail recursion limits). See
+[CHANGELOG.md](CHANGELOG.md).
+
 ### Modern Language Features
 
 - **String interpolation** via `~{expr}` inside strings, with `~~{` for a literal opener
@@ -623,12 +657,12 @@ The **REPL** provides full compilation and execution via LLVM JIT:
 ```
 $ eshkol-repl
 
-Welcome to Eshkol REPL v1.2.3-scale
+Welcome to Eshkol REPL v1.3.0-evolve
 Type :help for commands, :quit to exit
 
-eshkol> (define (f x) (* x x x))
+eshkol> (define (f v) (let ((x (vref v 0))) (* x x x)))
 eshkol> (gradient f (vector 2.0))
-#(12.0)
+#(12)
 
 eshkol> :type (gradient f (vector 2.0))
 Vector<Float64, 1>
@@ -775,6 +809,8 @@ See **[CONTRIBUTING.md](CONTRIBUTING.md)** for development setup and coding stan
 | **[FAQ](docs/FAQ.md)** | Installation, troubleshooting, common questions |
 | **[Test Coverage](docs/TEST_COVERAGE.md)** | What the 37-suite gate verifies |
 | **[Known Issues](docs/KNOWN_ISSUES.md)** | Current limitations and v1.3+ items |
+| **[Testing & Adversarial Harnesses](docs/TESTING.md)** | SICP gate + the five adversarial harnesses and how to run them |
+| **[VM Parity](docs/VM_PARITY.md)** | Bytecode-VM vs native-codegen parity ratchet |
 | **[ROADMAP](ROADMAP.md)** | Canonical release plan |
 | **[Release Notes](RELEASE_NOTES.md)** | Per-release changelog |
 | **[SDNC Paper Artefact](docs/SDNC.md)** | Self-Differentiating Neural Computer |
@@ -796,7 +832,7 @@ Eshkol is released under the **MIT License**. For academic use, please cite:
 @software{eshkol2025,
   title = {Eshkol: A Programming Language for Mathematical Computing},
   author = {tsotchke},
-  version = {1.2.3-scale},
+  version = {1.3.0-evolve},
   year = {2026},
   url = {https://github.com/tsotchke/eshkol},
   note = {Scheme-based language with native automatic differentiation}
@@ -813,7 +849,7 @@ Eshkol is released under the **MIT License**. For academic use, please cite:
 - **Types**: HoTT-based gradual typing with dependent type support
 - **AD**: Forward/reverse/symbolic modes with nested computation
 - **Testing**: 528 self-reported tests across 37 suites with automated verification
-- **Platform**: macOS (Intel/Apple Silicon), Linux (x86_64/ARM64), Windows (native x86_64 via Visual Studio 2022 + LLVM 21)
+- **Platform**: macOS (Intel/Apple Silicon), Linux (x86_64/ARM64), Windows (x86_64 and ARM64 via Visual Studio 2022 + LLVM 21). CI is green across all 14 lanes, including windows-arm64.
 
 ---
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,6 +1,6 @@
-# Eshkol v1.2.1-scale API Reference
+# Eshkol v1.3.0-evolve API Reference
 
-**Version**: 1.2.1-scale
+**Version**: 1.3.0-evolve
 **Last Updated**: 2026-05-20
 **Audience**: Scientific Computing & AI Systems Programming
 

--- a/docs/ESHKOL_V1_ARCHITECTURE.md
+++ b/docs/ESHKOL_V1_ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Eshkol System Architecture Reference
 
-**Version**: v1.2.1-scale
-**Release**: v1.2.1-scale
+**Version**: v1.3.0-evolve
+**Release**: v1.3.0-evolve
 **Date**: May 2026
 **Status**: Production-ready compiler with GPU acceleration, consciousness engine, and exact arithmetic
 
@@ -1546,4 +1546,4 @@ v1.1 resolves several production issues in the interactive JIT:
 
 ---
 
-*This document reflects the v1.2.1-scale release. All claims are verified against actual source code. For questions or corrections, see [`CONTRIBUTING.md`](../CONTRIBUTING.md).*
+*This document reflects the v1.3.0-evolve release. All claims are verified against actual source code. For questions or corrections, see [`CONTRIBUTING.md`](../CONTRIBUTING.md).*

--- a/docs/FEATURE_MATRIX.md
+++ b/docs/FEATURE_MATRIX.md
@@ -107,8 +107,8 @@ This matrix documents all implemented and planned features for the Eshkol langua
 | Computational graphs | ✅ | Reverse | Tape-based |
 | Gradient computation | ✅ | Reverse | `gradient` |
 | Backpropagation | ✅ | Reverse | Full backward pass |
-| Nested gradients | ✅ | Reverse | Arbitrary depth |
-| Double backward | ✅ | Reverse | Second derivatives |
+| Nested gradients | ✅ / ⚠️ | Reverse | Exact via nested scalar `derivative`; vector gradient-of-gradient returns zeros (ESH-0096) |
+| Double backward | ✅ / ⚠️ | Reverse | Second derivatives via nested scalar `derivative`; `hessian` works on vector points (crashes on tensor points, ESH-0095) |
 | Jacobian matrices | ✅ | Reverse | `jacobian` |
 | Hessian matrices | ✅ | Reverse | `hessian` |
 | Tape stack (nesting) | ✅ | Reverse | 32-level depth |

--- a/docs/FEATURE_MATRIX.md
+++ b/docs/FEATURE_MATRIX.md
@@ -1,4 +1,4 @@
-# Eshkol v1.2.1-scale Feature Matrix
+# Eshkol v1.3.0-evolve Feature Matrix
 
 **Status Key**: ✅ Production | 🚧 In Progress | 📋 Planned | ❌ Not Planned
 
@@ -906,6 +906,6 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for development guidelines.
 ---
 
 **Last Updated**: 2026-05-20
-**Document Version**: 1.2.1-scale
+**Document Version**: 1.3.0-evolve
 
 For detailed API documentation, see [API_REFERENCE.md](API_REFERENCE.md)

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,4 +1,4 @@
-# Known Issues — Eshkol v1.2.1-scale
+# Known Issues — Eshkol v1.3.0-evolve
 
 **Status**: Production release
 
@@ -72,6 +72,42 @@ Top-level mutual recursion requires consecutive function defines. Interleaved no
 
 ---
 
+## Tracked Open Issues (v1.3.0-evolve)
+
+Edge-case findings surfaced by the adversarial-testing harnesses (see
+[TESTING.md](TESTING.md)). Each has a minimal repro and a ledger entry under
+`.swarm/tasks/ESH-*.json`. None block ordinary use; all are also listed in the
+[CHANGELOG](../CHANGELOG.md) Known Issues section.
+
+**Automatic differentiation**
+- Vector gradient-of-gradient silently returns zeros — use nested scalar
+  `derivative` for exact higher-order results (ESH-0096).
+- `hessian`/`laplacian` SIGSEGV when the evaluation point is a tensor literal
+  `#(...)` / `(tensor ...)`; a `(vector ...)` point works (ESH-0095).
+- Vector-param AD op combined with a captured local parameter fails LLVM
+  verification (`PtrToInt source must be pointer`) (ESH-0072, ESH-0097).
+
+**Recursion depth**
+- Deep non-tail recursion (~270k frames) dies with SIGILL and no diagnostic;
+  stdlib `sort`/`length`/`filter` are non-tail-recursive and fail on very large
+  inputs; mutual tail calls are not TCO'd (ESH-0098, ESH-0101, ESH-0102, ESH-0108).
+
+**Language edges**
+- A closure created inside a named-let loop that `set!`s a global loses the
+  mutation (ESH-0094).
+- Exact rational arithmetic degrades to double once a bignum is involved
+  (ESH-0105).
+- Long-form `(quasiquote x)`/`(unquote x)` and nested quasiquote (level >= 2)
+  are not fully wired (ESH-0104, ESH-0107).
+- JIT compile of a ~10k-deep nested expression uses excessive RSS/time; AOT is
+  unaffected (ESH-0103).
+
+**VM parity**
+- 27 bytecode-VM behavioral divergences and 351 parity gaps are documented and
+  tracked in `tests/vm_parity/PARITY.tsv` (see [VM_PARITY.md](VM_PARITY.md)).
+
+---
+
 ## Roadmap (Future Releases)
 
 These are planned features, not deficiencies in the current release:
@@ -81,7 +117,7 @@ These are planned features, not deficiencies in the current release:
 | Full R7RS library export filtering semantics | v1.3 | `define-library` and R7RS `import` forms, including `only`/`except`/`rename`/`prefix`, lower through the existing `require`/`provide` module system |
 | Visual debugger UI | v1.3 | GDB/LLDB on the DWARF data already emitted by `-g`; `--dump-ir` for IR-level inspection |
 | Full C callbacks from foreign threads | v1.3 | `extern` C function calls (in-thread) work; native HTTP, SQLite, subprocess, fs-watch FFI surfaces shipped in v1.2 |
-| Python bindings | v1.3 | File I/O or subprocess interop |
+| Extended Python bindings | v1.4 | Stable C FFI with pybind11 + NumPy zero-copy interop shipped in v1.2 |
 | Distributed computing | v1.3 | Single-machine thread pool with `parallel-map`/`parallel-fold`/`future` |
 | Multi-GPU dispatch | v1.3 | Single GPU (Metal or CUDA) chosen automatically by the cost model |
 | Vulkan compute shaders | v1.3 | Metal (macOS) + CUDA (Linux/Windows-with-NVIDIA) |

--- a/docs/STDLIB_V1_2_API.md
+++ b/docs/STDLIB_V1_2_API.md
@@ -1,10 +1,10 @@
 # Eshkol v1.2-scale Standard Library — API Reference
 
-**Version**: 1.2.1-scale (closeout 2026-05-20, base 2026-05-01)
+**Version**: 1.3.0-evolve (closeout 2026-05-20, base 2026-05-01)
 **Audience**: implementers and library authors writing against the v1.2-scale
 public stdlib surface.
 **Scope**: every module added or significantly expanded between v1.1.13-accelerate
-and v1.2.1-scale.
+and v1.3.0-evolve.
 
 This document is the canonical, source-verified reference for the new public
 surfaces shipped in v1.2-scale. Every signature, default, and edge case below
@@ -1688,7 +1688,7 @@ Prior to the v1.2 routing fix this raised a "consumer is not a procedure" or
 
 ### Which modules are auto-loaded by `(require stdlib)`?
 
-Inspect `lib/stdlib.esk` for the canonical list. As of v1.2.1-scale, the
+Inspect `lib/stdlib.esk` for the canonical list. As of v1.3.0-evolve, the
 auto-loaded set includes:
 
 - `core.io`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,136 @@
+# Testing & Adversarial Harnesses
+
+Eshkol's correctness is defended by two layers of automated tests:
+
+1. **Functional gates** — shell-driven suites in `scripts/` that build the
+   compiler and run corpora of `.esk` programs under both execution paths
+   (`-r` JIT and AOT). The flagship is the **SICP full-book gate**.
+2. **Adversarial harnesses** — five permanent harnesses introduced in
+   v1.3.0-evolve whose job is to *find* bugs, not just confirm known-good
+   behavior. Each emits [ICC](https://github.com/tsotchke) trace events that a
+   readiness oracle consumes, so a green release requires them to pass.
+
+All harnesses honor the `BUILD_DIR` environment variable (default `build/`), so
+you can point them at any built tree:
+
+```bash
+# Build the compiler + stdlib once
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --target eshkol-run stdlib -j
+```
+
+---
+
+## SICP full-book gate
+
+`scripts/run_sicp_smoke.sh` runs the corpus in `tests/sicp/` — 88 probes across
+SICP chapters 1-5, including the metacircular, analyzing, lazy, and `amb`
+nondeterministic evaluators, the query system, and the register-machine
+simulators — under both `-r` and AOT.
+
+```bash
+BUILD_DIR=build scripts/run_sicp_smoke.sh
+# => SICP smoke summary: 88/88 gate probes PASS; 0 xfail, 0 XPASS; 88 total.
+```
+
+The gate fails on any real failure, any stale XFAIL that now XPASSes, or any
+missing full-book system probe. Trace: `scripts/icc_traces/sicp_smoke.jsonl`.
+To add a probe, drop a self-checking `.esk` file in `tests/sicp/` and register
+it in the script's coverage manifest.
+
+---
+
+## The five adversarial harnesses
+
+The campaign design lives in `.swarm/ADVERSARIAL_TESTING_CAMPAIGN.md`; the ICC
+oracle wiring lives in `.icc/completion-oracles.yaml`.
+
+### P1 — Multi-path differential harness + fuzzer
+
+**What:** Eshkol has several execution paths that must agree on every
+deterministic program: identical program + identical input must produce an
+identical (exit code, normalized stdout) on every axis — `jit`, `jit-nocache`
+(`ESHKOL_JIT_CACHE=0`), `aot-o0`, and `aot-o2`. Any divergence is a bug by
+definition, so no external oracle is needed.
+
+```bash
+# Run the curated corpus across all native axes
+BUILD_DIR=build scripts/run_differential.sh
+
+# Seeded random fuzzing; divergent programs auto-shrink to a minimal repro
+scripts/run_differential_fuzz.sh --seed 1 --count 200
+```
+
+Corpus: `tests/differential/corpus/`. Shrunk repros land in
+`tests/differential/found/`. Generator: `scripts/gen_differential.py`.
+Trace: `scripts/icc_traces/differential_fuzz.jsonl` (`kind=differential_smoke`).
+
+### P2 — Feature-pair edge matrix
+
+**What:** generates programs that *compose* pairs of language features (AD ×
+closures, `set!` × TCO, quasiquote × match, …) and classifies each probe under
+both `-r` and AOT as `PASS`, `ASSERT-FAIL` (wrong value — a compiler bug),
+`CRASH`, `COMPILE-ERR`, or `HANG`.
+
+```bash
+BUILD_DIR=build scripts/run_edge_matrix.sh
+```
+
+Feature list: `tests/edge_matrix/FEATURES.md`. Generator:
+`tests/edge_matrix/gen_matrix.py` → `tests/edge_matrix/generated/`. Known,
+triaged failures are allowlisted in `tests/edge_matrix/KNOWN_FAILURES.txt`.
+Trace kind: `edge_matrix`.
+
+### P3 — AD finite-difference oracle
+
+**What:** every generated AD probe self-checks its analytic AD result against an
+in-language central finite difference, under both `-r` and AOT. This is the
+oracle that catches silent wrong-gradient regressions.
+
+```bash
+BUILD_DIR=build scripts/run_ad_oracle.sh
+```
+
+Generator: `tests/ad_oracle/gen_ad_oracle.py` → `tests/ad_oracle/generated/`.
+Emits pytest-style `PASSED …::<mode>` lines plus ICC events (`kind=ad_oracle`,
+oracle `ad-oracle` in `.icc/completion-oracles.yaml`).
+
+### P4 — Stress harness (RSS/time budgets)
+
+**What:** runs the programs in `tests/stress/budgets.tsv` under `-r` and/or AOT
+with explicit budgets asserted by the runner (not the program): a wall-time
+ceiling, a max-RSS ceiling, exit code 0, and a required stdout substring.
+
+```bash
+BUILD_DIR=build scripts/run_stress.sh
+```
+
+Budgets/data: `tests/stress/`. Trace kind: `stress_smoke`
+(`stress_suite_green` is the whole-sweep verdict). To add a case, add a data
+`.esk` file and a budget row in `tests/stress/budgets.tsv`.
+
+### P5 — VM parity ratchet
+
+**What:** makes the bytecode-VM's supported subset explicit and makes drift
+impossible to miss: `scripts/vm_parity_audit.py` extracts the native-codegen
+surface and the VM surface and fails if any codegen symbol is neither
+VM-supported nor consciously waived in `tests/vm_parity/PARITY.tsv`. A
+VM-vs-native differential over `tests/vm_parity/corpus/` then keeps shared
+symbols honest. Full write-up in [VM_PARITY.md](VM_PARITY.md).
+
+```bash
+BUILD_DIR=build scripts/run_vm_parity.sh
+```
+
+> The VM parity harness lands with the v1.3.0-evolve release (PR #118); the
+> other four harnesses are already on `master`.
+
+---
+
+## ICC readiness oracle
+
+Each harness writes JSON-L trace events under `scripts/icc_traces/`. The oracle
+definitions in `.icc/completion-oracles.yaml` map required event kinds/names to
+release gates (e.g. `stress-budget`, `ad-oracle`). A release is "ready" only
+when the required oracles report their green verdicts, which is how the
+adversarial layer is enforced rather than merely available.

--- a/docs/TEST_COVERAGE.md
+++ b/docs/TEST_COVERAGE.md
@@ -1,6 +1,6 @@
-# Eshkol v1.2-scale Test Coverage
+# Eshkol v1.3.0-evolve Test Coverage
 
-**Version**: v1.2-scale hardening checkpoint
+**Version**: v1.3.0-evolve
 **Last Updated**: 2026-05-20
 **Status**: 37 orchestrated suites, including the active v1.2 edge/security
 suite, at 100% pass rate on the verified release gates

--- a/docs/VM_PARITY.md
+++ b/docs/VM_PARITY.md
@@ -1,0 +1,90 @@
+# VM Parity Ratchet
+
+Eshkol ships two executable back ends:
+
+- the **native LLVM codegen** (`lib/backend/llvm_codegen.cpp`), used by
+  `eshkol-run` for both `-r` (JIT) and AOT builds; and
+- the **bytecode VM** (`lib/backend/vm_compiler.c`, `vm_native.c`,
+  `eshkol_vm.c`, `eshkol-vm-standalone`, the ESKB format and the `hosted-vm`
+  profile), used for the browser/WASM playground and embedded hosting.
+
+The VM implements a *subset* of the language. Before v1.3.0-evolve that subset
+was undeclared: nothing forced a decision when a feature landed in the codegen
+but not the VM, and nothing recorded which shared behaviors silently diverged.
+The **VM parity ratchet** makes the subset explicit and makes drift impossible
+to miss.
+
+> Status: the ratchet, manifest, and gate ship with the v1.3.0-evolve release
+> (PR #118 — `scripts/run_vm_parity.sh`, `scripts/vm_parity_audit.py`,
+> `tests/vm_parity/`). The numbers below are from the seeded manifest on the
+> release SHA.
+
+## The manifest
+
+`tests/vm_parity/PARITY.tsv` is `name<TAB>status<TAB>justification`, with three
+statuses:
+
+| status | meaning |
+|---|---|
+| `vm-supported` | the VM resolves the name / implements the op |
+| `native-only-justified` | conscious, permanent waiver (FFI, OALR regions, static type syntax, OS/process, parallel runtime, front-end module machinery) — justification mandatory |
+| `gap` | acknowledged hole **or a verified behavioral divergence** (rows referencing `found/*.esk` name symbols present on both surfaces that compute different answers) — justification mandatory |
+
+Seeded 2026-07-03 from the live extraction and hand-verified with probe runs on
+`eshkol-vm-standalone-test` vs native `-r`: **912 rows — 520 `vm-supported`,
+41 `native-only-justified`, 351 `gap`** (the gaps include 27 documented
+bytecode-VM behavioral divergences).
+
+## The ratchet workflow
+
+`scripts/vm_parity_audit.py` extracts two surfaces on every run:
+
+- **codegen surface** — every builtin the LLVM backend dispatches on
+  (`func_name == "…"`, `function_return_types[…]`, the `math_builtins` sets)
+  plus every member of the `eshkol_op_t` AST enum;
+- **VM surface** — every name the VM can resolve: the `BUILTINS[]` native table
+  in `eshkol_vm.c`, the special-form dispatch in `vm_compiler.c` /
+  `vm_parser.c`, and the Scheme prelude compiled into every VM
+  (`vm_prelude_source.h`).
+
+The audit **fails** if any codegen symbol is absent from *both* the VM surface
+and `PARITY.tsv`. So when you add a language feature:
+
+1. You add a builtin or AST op to the native codegen.
+2. `scripts/run_vm_parity.sh` (stage 1) fails with
+   `RATCHET <name>: … add VM support or a justified manifest row`.
+3. You either
+   - **teach the VM** — add the fid + name binding; the audit then passes with
+     no manifest change and the corpus differential keeps you honest; or
+   - **waive it consciously** — add a `PARITY.tsv` row with status
+     `native-only-justified` (permanent) or `gap` (acknowledged hole), each
+     requiring a justification.
+
+The audit also fails on stale `vm-supported` claims (a row naming a builtin the
+VM surface no longer contains) and on `gap` / `native-only-justified` rows with
+no justification.
+
+## The differential gate
+
+`scripts/run_vm_parity.sh` (honors `BUILD_DIR`, default `build/`) runs three
+stages:
+
+1. **AUDIT** — the ratchet above.
+2. **CORPUS** — a VM-vs-native differential over `tests/vm_parity/corpus/`
+   (programs inside the VM's verified subset) across axes:
+   - `native`  — `./build/eshkol-run -r f.esk`
+   - `vm-src`  — `./build/eshkol-vm-standalone-test f.esk`
+   - `vm-eskb` — emit ESKB via `--profile hosted-vm --emit-eskb`, then run it
+     through `eshkol-vm-standalone-test`.
+3. **Verdict** — any divergence outside the manifest is a failure.
+
+```bash
+BUILD_DIR=build scripts/run_vm_parity.sh
+```
+
+Verified behavioral divergences are recorded as `gap` rows referencing a repro
+under `tests/vm_parity/found/` (for example, the VM's `display` appends a
+newline per call). This turns "the VM is roughly compatible" into a precise,
+enforced, and continuously re-verified contract.
+
+See also [TESTING.md](TESTING.md) for the full adversarial-testing overview.

--- a/docs/breakdown/AUTODIFF.md
+++ b/docs/breakdown/AUTODIFF.md
@@ -301,16 +301,24 @@ Eshkol provides high-level vector calculus operators built on reverse-mode AD:
 
 ### Example: Higher-Order Derivatives
 
+Exact nested higher-order differentiation is done by nesting the **scalar**
+`derivative` operator (this is exact as of v1.3.0-evolve — see #75, #84, #95):
+
 ```scheme
-;; Second derivative: f''(x) = d²/dx² (x³)
-(gradient (lambda (v)
-            (gradient (lambda (w) 
-                        (let ((x (vref w 0)))
-                          (* x (* x x))))
-                      v))
-          (vector 2.0))
-;; Returns: #(12.0)  ; f''(2) = 6*2 = 12
+;; Second derivative: f''(x) = d²/dx² (x³) = 6x
+(derivative (lambda (x)
+              (derivative (lambda (y) (* y y y)) x))
+            2.0)
+;; Returns: 12   ; f''(2) = 6*2 = 12
 ```
+
+> **Known limitation (ESH-0096):** nesting the **vector** `gradient` operator —
+> a gradient-of-gradient over a `(vector …)` point — currently returns zeros
+> silently rather than the true second-order value. Use the scalar `derivative`
+> form above for higher-order results. Related open items: `hessian`/`laplacian`
+> SIGSEGV on tensor points (ESH-0095) and vector-param AD combined with a
+> captured local (ESH-0072/0097). These are tracked in `.swarm/tasks/` and the
+> [CHANGELOG](../../CHANGELOG.md) Known Issues section.
 
 ---
 

--- a/docs/breakdown/COMPILATION_GUIDE.md
+++ b/docs/breakdown/COMPILATION_GUIDE.md
@@ -1,4 +1,4 @@
-# Compilation Guide for Eshkol v1.2.1-scale
+# Compilation Guide for Eshkol v1.3.0-evolve
 
 ## Table of Contents
 - [Overview](#overview)

--- a/docs/breakdown/COMPILER_ARCHITECTURE.md
+++ b/docs/breakdown/COMPILER_ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# Compiler Architecture in Eshkol (v1.2.1-scale)
+# Compiler Architecture in Eshkol (v1.3.0-evolve)
 
 ## Table of Contents
 

--- a/docs/breakdown/GETTING_STARTED.md
+++ b/docs/breakdown/GETTING_STARTED.md
@@ -93,7 +93,7 @@ cmake --build build --config Release --parallel
 ```bash
 # Check compiler version
 build/eshkol-run --version
-# Expected: Eshkol Compiler v1.2.1-scale
+# Expected: Eshkol Compiler v1.3.0-evolve
 
 # Check REPL
 build/eshkol-repl

--- a/site/src/main.esk
+++ b/site/src/main.esk
@@ -374,7 +374,7 @@
         (let ((title (create-text "h1" "Build systems that think." left)))
           (web-add-class title "hero-title"))
 
-        (let ((sub (create-text "p" "Eshkol is R7RS Scheme on LLVM 21 with automatic differentiation as a compiler primitive and a 22-builtin neuro-symbolic stack. v1.2.1-scale ships the constructive proof that a six-layer transformer can be an interpreter — the Self-Differentiating Neural Computer." left)))
+        (let ((sub (create-text "p" "Eshkol is R7RS Scheme on LLVM 21 with automatic differentiation as a compiler primitive and a 22-builtin neuro-symbolic stack. v1.3.0-evolve ships the constructive proof that a six-layer transformer can be an interpreter — the Self-Differentiating Neural Computer." left)))
           (web-add-class sub "hero-sub"))
 
         ;; Install command
@@ -548,8 +548,8 @@
 
 (define (render-v12-features parent)
   (let ((section (create-section parent)))
-    (section-heading section "What's new in v1.2.1-scale")
-    (body-html section "<strong style='color:#a78bfa'>The production-readiness release.</strong> v1.1-accelerate proved the math (autodiff, tensors, the consciousness engine); v1.2.1-scale makes it shippable. Master suite exits 0 across 37 sub-suites and 528 self-reported tests; <code>tests/v1_2_edge_cases</code> carries 87 passing edge and security tests.")
+    (section-heading section "What's new in v1.3.0-evolve")
+    (body-html section "<strong style='color:#a78bfa'>Evolve.</strong> v1.3.0-evolve brings full SICP coverage (an 88/88 full-book gate under both JIT and AOT), exact nested/mixed-mode automatic differentiation, closure-semantics completion, and a green CI across all 14 platform lanes including windows-arm64 &mdash; backed by a new permanent adversarial-testing infrastructure (differential, edge-matrix, AD finite-difference oracle, stress, and VM-parity harnesses).")
 
     (let ((grid (create-grid-3 section)))
       (render-feature-card grid
@@ -1323,7 +1323,7 @@
 
         ;; Welcome message
         (web-set-inner-html output
-          "<span style='color:#7c3aed;font-weight:bold'>Eshkol Bytecode VM</span> <span style='color:#71717a'>v1.2.1-scale</span>\n<span style='color:#71717a'>83-opcode ISA | Arena memory (OALR) | R7RS Scheme</span>\n<span style='color:#71717a'>Type an expression and press Enter.</span>\n\n"))
+          "<span style='color:#7c3aed;font-weight:bold'>Eshkol Bytecode VM</span> <span style='color:#71717a'>v1.3.0-evolve</span>\n<span style='color:#71717a'>83-opcode ISA | Arena memory (OALR) | R7RS Scheme</span>\n<span style='color:#71717a'>Type an expression and press Enter.</span>\n\n"))
 
       ;; Terminal input area
       (let ((input-row (create-div terminal)))

--- a/site/static/content/api_reference.html
+++ b/site/static/content/api_reference.html
@@ -1,6 +1,6 @@
-<h1 id="eshkol-v1.2.1-scale-api-reference">Eshkol v1.2.1-scale API
+<h1 id="eshkol-v1.3.0-evolve-api-reference">Eshkol v1.3.0-evolve API
 Reference</h1>
-<p><strong>Version</strong>: 1.2.1-scale <strong>Last Updated</strong>:
+<p><strong>Version</strong>: 1.3.0-evolve <strong>Last Updated</strong>:
 2026-05-20 <strong>Audience</strong>: Scientific Computing &amp; AI
 Systems Programming</p>
 <p>This comprehensive reference documents all special forms, functions,

--- a/site/static/content/eshkol_language_guide.html
+++ b/site/static/content/eshkol_language_guide.html
@@ -1052,7 +1052,7 @@ detection</li>
 :history   Show command history</code></pre>
 <h3 id="example-session">Example Session</h3>
 <pre><code>$ ./eshkol-repl
-Eshkol REPL v1.2.1-scale
+Eshkol REPL v1.3.0-evolve
 Type :help for assistance, :quit to exit
 
 eshkol&gt; (define (square x) (* x x))
@@ -1602,6 +1602,6 @@ integration</label></li>
 <p>MIT License - Copyright (C) tsotchke</p>
 <hr />
 <p align="center">
-<strong>Eshkol v1.2.1-scale</strong>: Where functional programming meets
+<strong>Eshkol v1.3.0-evolve</strong>: Where functional programming meets
 scientific computing, GPU acceleration, and machine consciousness.
 </p>

--- a/site/static/content/eshkol_quick_reference.html
+++ b/site/static/content/eshkol_quick_reference.html
@@ -1,5 +1,5 @@
 <h1 id="eshkol-quick-reference-card">Eshkol Quick Reference Card</h1>
-<p><strong>v1.2.1-scale</strong> – 555+ built-in functions</p>
+<p><strong>v1.3.0-evolve</strong> – 555+ built-in functions</p>
 <h2 id="basics">Basics</h2>
 <pre class="scheme"><code>;; Variables
 (define x 42)

--- a/site/static/content/feature_matrix.html
+++ b/site/static/content/feature_matrix.html
@@ -1,4 +1,4 @@
-<h1 id="eshkol-v1.2.1-scale-feature-matrix">Eshkol v1.2.1-scale Feature
+<h1 id="eshkol-v1.3.0-evolve-feature-matrix">Eshkol v1.3.0-evolve Feature
 Matrix</h1>
 <p><strong>Status Key</strong>: ✅ Production | 🚧 In Progress | 📋
 Planned | ❌ Not Planned</p>
@@ -3985,6 +3985,6 @@ JAX/PyTorch (AD implementation insights) - Julia (technical computing
 design patterns)</p>
 <hr />
 <p><strong>Last Updated</strong>: 2026-05-20 <strong>Document
-Version</strong>: 1.2.1-scale</p>
+Version</strong>: 1.3.0-evolve</p>
 <p>For detailed API documentation, see <a
 href="API_REFERENCE.md">API_REFERENCE.md</a></p>

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Eshkol — R7RS Scheme on LLVM 21 with AD as a compiler primitive</title>
-  <meta name="description" content="Eshkol is R7RS Scheme compiled to native code via LLVM 21, with automatic differentiation as a compiler primitive and a 22-builtin neuro-symbolic stack. v1.2.1-scale ships the Self-Differentiating Neural Computer constructive proof: a six-layer transformer that is bit-identical to a bounded 83-instruction bytecode VM.">
+  <meta name="description" content="Eshkol is R7RS Scheme compiled to native code via LLVM 21, with automatic differentiation as a compiler primitive and a 22-builtin neuro-symbolic stack. v1.3.0-evolve ships the Self-Differentiating Neural Computer constructive proof: a six-layer transformer that is bit-identical to a bounded 83-instruction bytecode VM.">
   <meta property="og:title" content="Eshkol — R7RS Scheme with AD as a compiler primitive">
-  <meta property="og:description" content="Compiler-native automatic differentiation, zero garbage collection, heterogeneous GPU dispatch, and the SDNC constructive proof. v1.2.1-scale.">
+  <meta property="og:description" content="Compiler-native automatic differentiation, zero garbage collection, heterogeneous GPU dispatch, and the SDNC constructive proof. v1.3.0-evolve.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://eshkol.ai">
   <meta property="og:image" content="https://eshkol.ai/img/og-image.png">
@@ -15,7 +15,7 @@
   <meta property="og:image:alt" content="Eshkol logo — a stylized grape cluster">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Eshkol — R7RS Scheme with AD as a compiler primitive">
-  <meta name="twitter:description" content="Compiler-native automatic differentiation, zero garbage collection, heterogeneous GPU dispatch, and the SDNC constructive proof. v1.2.1-scale.">
+  <meta name="twitter:description" content="Compiler-native automatic differentiation, zero garbage collection, heterogeneous GPU dispatch, and the SDNC constructive proof. v1.3.0-evolve.">
   <meta name="twitter:image" content="https://eshkol.ai/img/og-image.png">
   <meta name="theme-color" content="#7c3aed">
   <link rel="icon" href="img/favicon.ico" sizes="any">


### PR DESCRIPTION
Complete documentation refresh for the v1.3.0-evolve release. Every claim was
verified against a fresh build of current master (LLVM JIT `-r` and AOT).

## Highlights
- **README**: version -> v1.3.0-evolve (badge, citation, REPL banner); new
  v1.3.0-evolve feature section; platform matrix now states 14/14 CI lanes
  including windows-arm64; SICP full-book support statement + gate links.
- **Corrected false AD examples** (they actually returned `#(0)`, not `#(12.0)`):
  - README REPL example and design-philosophy nested-gradient snippet.
  - `docs/breakdown/AUTODIFF.md` higher-order example now uses the exact nested
    scalar `derivative` form, with a note that vector gradient-of-gradient is
    open (ESH-0096).
  - `docs/FEATURE_MATRIX.md` nested-gradient / double-backward rows qualified.
- **CHANGELOG.md**: full `[1.3.0-evolve]` entry grouped by area (AD, language/
  closures, memory/control, platforms/toolchain) from the merged PR list, plus a
  Known Issues section distilled from the open `.swarm/tasks/` ledger.
- **New docs**: `docs/TESTING.md` (SICP gate + the five adversarial harnesses:
  differential, edge-matrix, AD oracle, stress, VM parity — how to run and
  extend, ICC oracle wiring) and `docs/VM_PARITY.md` (the parity ratchet).
- **Version sweep**: bumped current-version titles/headers across the reference
  docs and site to v1.3.0-evolve; left historical roadmap/release-history labels
  intact. `docs/KNOWN_ISSUES.md` gains a Tracked Open Issues (v1.3.0-evolve)
  section.
- **Site**: version token and "What's new" section updated.

## Verification (against a fresh build of master)
- SICP gate: `scripts/run_sicp_smoke.sh` -> 88/88 PASS (both `-r` and AOT).
- AD oracle: `scripts/run_ad_oracle.sh` -> gate PASS (46 passed, 34 xknown, 0 failed).
- Ran every documented quick-start example: hello (JIT + AOT `-o`), bytecode
  `-B` emit, `pow`, `derivative` (=12), vector `gradient` (=#(12)), nested scalar
  `derivative` (=12), `hessian` on a vector point (=#(#(48))), the README `train`
  example (=2).
- Confirmed the open-issue behaviors documented: vector grad-of-grad -> `#(0)`
  (ESH-0096), `hessian` on a tensor point -> SIGSEGV (ESH-0095).

## Coordination
Targets `master`. The VM-parity files (`tests/vm_parity/`) land with PR #118;
`docs/VM_PARITY.md` marks that dependency. No source/behavior changes here.
