### PR TITLE
docs(reference): runtime, agent/FFI, and tooling reference (v1.3.0)

### DIFF
--- a/docs/platform/BUILD_NOTES.md
+++ b/docs/platform/BUILD_NOTES.md
@@ -1,0 +1,115 @@
+# Per-Platform Build Notes
+
+Eshkol builds with CMake (3.14+), a C17 / C++20 toolchain (GCC 11+ or Clang 14+),
+and **LLVM 21**. LLVM discovery is handled by `cmake/LLVMToolchain.cmake`
+(`eshkol_find_lite_llvm`), which probes Homebrew `llvm@21` prefixes and Windows
+SDK paths and validates the major version (`eshkol_validate_llvm_major` errors on
+mismatch).
+
+Baseline build:
+
+```sh
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j
+```
+
+Useful targets: `eshkol-run` (compiler/JIT driver), `eshkol-repl`,
+`eshkol-vm-standalone`, and `stdlib` (precompiled standard library object).
+
+> **Discrepancy (report only):** the top-level `README.md` Prerequisites section
+> still lists "LLVM 17" in one place while the rest of the repo (CI, other README
+> sections, `cmake/LLVMToolchain.cmake`) requires **LLVM 21**. The authoritative
+> requirement is LLVM 21.
+
+## macOS (Apple Silicon + x86_64)
+
+```sh
+brew install llvm@21 cmake ninja readline pcre2 sqlite
+export LLVM_CONFIG="$(brew --prefix llvm@21)/bin/llvm-config"
+cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j
+```
+
+- Apple Silicon is CI runner `macos-14`; Intel is `macos-15-intel`.
+- BLAS uses the Apple **Accelerate** framework (AMX path, ~1100 GFLOPS),
+  auto-detected by CMake.
+- GPU uses **Metal** + MetalPerformanceShaders (`ESHKOL_GPU_METAL_ENABLED`),
+  with the SF64 Metal shader embedded from `lib/backend/gpu/metal_softfloat.h`.
+
+## Linux (x86_64 + arm64)
+
+Install LLVM 21 from apt.llvm.org plus dev libraries:
+
+```sh
+# llvm-21 llvm-21-dev lld-21 libreadline-dev pkg-config libssl-dev
+# libncurses-dev libpcre2-dev libsqlite3-dev libpng/jpeg/webp-dev
+sudo ln -sf "$(command -v ld.lld-21)" /usr/local/bin/ld.lld   # AArch64 links use lld
+cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j$(nproc)
+```
+
+- CUDA is auto-detected via `find_package(CUDAToolkit)`; when present, CMake
+  selects a compatible `nvcc` host compiler and defines `ESHKOL_GPU_CUDA_ENABLED`.
+
+## Windows x86_64 (MSYS2 / MinGW64)
+
+Native MinGW64 build (originally contributed in PR #9). Not a hosted CI lane;
+validated via `scripts/remote_windows_verify.sh --suite-only` against a cached
+MSYS/UCRT build (`windows-lite` mode). The MinGW CMake path differs from the MSVC
+path (`WIN32 AND NOT MINGW` uses `find_package(LLVM CONFIG REQUIRED)` + the MSVC
+static runtime).
+
+## Windows arm64 (VS2022 + ClangCL)
+
+Built natively on `windows-11-arm`:
+
+```
+cmake -B build -G "Visual Studio 17 2022" -A ARM64 -T ClangCL
+```
+
+Downloads the LLVM 21.1.8 aarch64 Windows SDK. Three layered fixes made this
+platform build and run (culminating in **PR #77**,
+`fix/windows-arm64-sincos-portable`):
+
+1. A **portable `sincos` shim** (MSVC has no `sincos`).
+2. **AOT codegen**: use the *small* code model with `FunctionSections` +
+   `DataSections` and `/OPT:REF,/OPT:ICF` dead-stripping instead of the Large
+   code model — Large corrupts aarch64-COFF SEH `.pdata`/`.xdata` and breaks
+   `_setjmpex`/longjmp unwinding used by `raise`/`guard`/`dynamic-wind`.
+3. **JIT**: scope the windows-arm64 executable triple correctly.
+
+These were verified on CI (no local arm64-Windows machine).
+
+## NixOS on Jetson (CUDA)
+
+See `nix/jetson/README.md`. Target: Jetson AGX Xavier, NixOS, L4T R35.6.4
+(driver CUDA 11.4 max, GPU sm_72 / Volta):
+
+```sh
+NIXPKGS_ALLOW_UNFREE=1 nix-shell nix/jetson/shell.nix \
+  --run 'bash nix/jetson/build.sh'   # -> build-cuda/eshkol-run
+```
+
+Non-trivial because NixOS 25.11 dropped CUDA 11 / gcc ≤ 11. Resolution: build
+host C++ with clang-21, compile `.cu` kernels with nvcc 11.8 from pinned nixpkgs
+24.05 (`cudaPackages_11`), and use gcc11 only as the nvcc host compiler. Three
+runtime gotchas: force the gcc14 libdir to the front of `libstdc++` search; put
+`/run/opengl-driver/lib` first on `LD_LIBRARY_PATH` (else `cudaErrorStubLibrary`
+/ error 34 from the stub `libcuda.so.1`); use L4T-native cuBLAS 11.6. Verified
+GEMM ~21 GFLOPS on GPU vs ~1.7 on CPU (~12×) via
+`tests/gpu/jetson_gemm_bench.esk`.
+
+## GPU / backend selection at runtime
+
+The compiled binary contains **all** code paths (scalar / NEON / AVX / cBLAS /
+GPU); backend selection is a runtime cost-model decision in
+`lib/backend/blas_backend.cpp`. Key gates:
+
+| Env var | Effect | Default |
+|---------|--------|---------|
+| `ESHKOL_GPU_ENABLED` (CMake) | Compile in Metal (macOS) / CUDA (Linux/Win) | ON |
+| `ESHKOL_GPU_MATMUL_THRESHOLD` | Element count above which matmul goes to GPU (set `1` to force) | 100000 |
+| `ESHKOL_GPU_PRECISION` | `exact` (sf64), `high` (df64), `fast` (f32) | `exact` |
+| `ESHKOL_GPU_VERBOSE` | Log GPU dispatch decisions | off |
+| `ESHKOL_BLAS_THRESHOLD` / `ESHKOL_XLA_THRESHOLD` | CPU BLAS / XLA dispatch thresholds | see [env vars](../reference/runtime/environment-variables.md) |
+
+`ESHKOL_XLA_ENABLED` is a CMake option (default OFF) requiring a StableHLO/LLVM
+bundle (`-DSTABLEHLO_ROOT`).

--- a/docs/platform/CI_LANES.md
+++ b/docs/platform/CI_LANES.md
@@ -1,0 +1,52 @@
+# CI Lane Matrix
+
+Continuous integration for Eshkol runs from `.github/workflows/ci.yml`. All
+**14 lanes** live in two matrix jobs: `unix-matrix` (11 lanes) and
+`windows-matrix` (3 lanes). Global env pins `LLVM_MAJOR=21` and the Windows SDK
+at `WINDOWS_LLVM_SDK_VERSION=21.1.8`.
+
+| # | Lane | Runner (OS/arch) | build dir | XLA | GPU | What it does |
+|---|------|------------------|-----------|-----|-----|--------------|
+| 1 | `linux-x64-lite` | ubuntu-22.04 (x64) | `build` | off | off | Full AOT+JIT suite (`run_all_tests.sh`), WASM-import check, uploads `eshkol-linux-x64` |
+| 2 | `linux-arm64-lite` | ubuntu-22.04-arm | `build` | off | off | `run_all_tests.sh`, WASM check, uploads `eshkol-linux-arm64` |
+| 3 | `linux-x64-xla` | ubuntu-22.04 | `build-xla` | on | off | `run_xla_tests.sh` |
+| 4 | `linux-arm64-xla` | ubuntu-22.04-arm | `build-xla` | on | off | `run_xla_tests.sh` |
+| 5 | `linux-x64-cuda` | ubuntu-22.04 | `build-cuda` | off | on | `run_gpu_tests.sh` (CUDA) |
+| 6 | `linux-arm64-cuda` | ubuntu-22.04-arm | `build-cuda` | off | on | `run_gpu_tests.sh` (CUDA) |
+| 7 | `macos-arm64-lite` | macos-14 (Apple Silicon) | `build` | off | off | `run_all_tests.sh`, WASM check, uploads `eshkol-macos-arm64` |
+| 8 | `macos-x64-lite` | macos-15-intel (x86_64) | `build` | off | off | `run_all_tests.sh`, WASM check, uploads `eshkol-macos-x64` |
+| 9 | `macos-arm64-xla` | macos-14 | `build-xla` | on | off | `run_xla_tests.sh` |
+| 10 | `macos-x64-xla` | macos-15-intel | `build-xla` | on | off | `run_xla_tests.sh` |
+| 11 | `linux-x64-asan-ubsan` | ubuntu-22.04 | `build-asan` | off | off | ASan+UBSan build, `run_v1_2_edge_cases_tests.sh` (TSan/MSan deferred) |
+| 12 | `windows-arm64-lite` | windows-11-arm | `build` | off | off | VS2022 `-A ARM64 -T ClangCL`, `run_all_tests.ps1 -Mode windows-lite`, uploads `eshkol-windows-arm64` |
+| 13 | `windows-arm64-xla` | windows-11-arm | `build-xla` | on | off | builds `xla_codegen_test`, `-Mode xla` |
+| 14 | `windows-arm64-cuda` | windows-11-arm | `build-cuda` | off | on | `-Mode gpu` |
+
+## Lane groups
+
+- **lite** (1,2,7,8,12) — the baseline AOT + JIT test suite per OS/arch; these
+  are the lanes that upload release binaries.
+- **xla** (3,4,9,10,13) — build with `-DESHKOL_XLA_ENABLED=ON` and run the XLA
+  codegen/runtime tests.
+- **cuda** (5,6,14) — build with the CUDA backend and run GPU tests.
+- **asan-ubsan** (11) — sanitizer build over the v1.2 edge-case suite.
+
+## Notes and gotchas
+
+- **Windows x86_64 is not a hosted CI lane.** It is validated off-runner on a
+  developer's machine via `scripts/remote_windows_verify.sh --suite-only`
+  against a cached MSYS/UCRT build (`windows-lite` mode). Release packaging still
+  builds hosted x64.
+- The `windows-matrix` runs `max-parallel: 2`; all Windows lanes download the
+  official LLVM 21.1.8 aarch64 Windows SDK (cached under
+  `C:\src\clang+llvm-...-aarch64-pc-windows-msvc`) and build with
+  `ESHKOL_BUILD_TESTS=OFF`.
+- Linux lanes symlink `ld.lld-21` → `ld.lld` because codegen passes
+  `-fuse-ld=lld` for AArch64 Linux links.
+- Concurrency **does not cancel on `master`** — the release gate wants the full
+  matrix signal even when commits land quickly.
+- Per the project rule, treat the non-required xla/asan/cuda lanes as
+  first-class: a green "required" set can still hide a regression that only one
+  of these lanes catches.
+
+Other workflows: `pages.yml` (docs site) and `release.yml` (release packaging).

--- a/docs/reference/agent/INDEX.md
+++ b/docs/reference/agent/INDEX.md
@@ -1,0 +1,40 @@
+# Agent & FFI Reference
+
+The `agent.*` modules are Eshkol's hosted, capability-gated surface for talking
+to the outside world — HTTP, databases, subprocesses, cryptography, the terminal,
+git, and native training. They are built on the [FFI](ffi.md) `extern`
+mechanism and link native C runtimes (`qllm_*`, `eshkol_*`). Load one with
+`(require agent.<name>)`.
+
+## Foundations
+
+- [FFI](ffi.md) — the `extern` / `:real` declaration syntax, the type-keyword →
+  C ABI mapping, tagged-value boundary conversion, and how `requires_agent_ffi`
+  drives **transitive** agent-FFI linking for AOT binaries (vs JIT resolution).
+- [Capabilities](capabilities.md) — the process-local allow-list policy and which
+  agent operation requires which capability.
+
+## Modules
+
+| Module | Doc | Summary |
+|--------|-----|---------|
+| `agent.http`, `agent.http-server` | [http](http.md) | HTTP client (GET/POST, SSE), HTTP/Unix-socket/WebSocket server |
+| `agent.sqlite` | [sqlite](sqlite.md) | Embedded SQLite: connections, prepared statements, `with-db`/`with-statement` |
+| `agent.subprocess` | [subprocess](subprocess.md) | Process spawning (shell + injection-safe argv), ownership/cleanup contract (#94) |
+| `agent.crypto` | [crypto](crypto.md) | SHA-256, HMAC, random bytes/hex, UUIDv4, base64url |
+| `agent.eagle` | [eagle](eagle.md) | Native linear-head training (`qllm_ffi_linear_*`, PR #104) |
+| `core.memory`, `core.memory-store` | [memory faculty](memory-faculty.md) | Content-addressed, CRDT-merged event log |
+| `agent.regex`, `agent.glob`, `agent.fs-watch`, `agent.keychain`, `agent.terminal`, `agent.git-ffi`, `agent.layout` | [platform utilities](platform-utilities.md) | Regex (PCRE2), globbing, file watching, secret store, terminal/TUI, git, layout |
+
+## Cross-cutting notes
+
+- **AOT vs JIT**: always verify agent-FFI code under AOT, not just `-r` — the JIT
+  resolves symbols from the host process, while AOT depends on the link-args scan
+  firing. See [FFI § AOT linking](ffi.md).
+- **Capabilities off by default**: with no policy installed everything is
+  permitted; installing one is deny-by-default. See [capabilities](capabilities.md).
+
+## See also
+
+- [Runtime reference](../runtime/INDEX.md) — CLI, environment variables, memory,
+  parallelism, JIT.

--- a/docs/reference/agent/capabilities.md
+++ b/docs/reference/agent/capabilities.md
@@ -1,0 +1,64 @@
+# `core.capabilities` — Capability Policy
+
+A process-local allow-list that gates hosted/agent side effects. **Off by
+default**: with no policy installed, every operation is allowed and existing
+v1.2 programs run unchanged. Once you install a policy, it is *deny-by-default* —
+only the capabilities you list are permitted.
+
+```scheme
+(require core.capabilities)
+```
+
+Source: `lib/core/capabilities.esk`. Runtime symbols:
+`eshkol_capability_runtime_clear`, `eshkol_capability_runtime_begin_install`,
+`eshkol_capability_runtime_allow`.
+
+## API
+
+| Procedure | Signature | Description |
+|-----------|-----------|-------------|
+| `capability-install-policy!` | `(capability-install-policy! allow-list)` | Install an allow-list of capability **symbols**; activates deny-by-default. `error`s unless given a list of symbols |
+| `capability-clear-policy!` | `(capability-clear-policy!)` | Remove the policy; back to allow-all |
+| `capability-policy` | `(capability-policy)` | The active allow-list, or `#f` if none |
+| `capability-policy-active?` | `(capability-policy-active?)` | `#t`/`#f` |
+| `capability-allowed?` | `(capability-allowed? cap . context)` | `#t` if `cap` permitted under current policy |
+| `capability-require!` | `(capability-require! cap . context)` | Assert `cap`; raises if denied |
+
+Installing a policy mirrors the allow-list into the C runtime
+(`capability-sync-runtime!` → `…begin-install` then one `…allow` per symbol) so
+that native-side checks see the same policy.
+
+## Core capability symbols
+
+`file-read`, `file-write`, `env-read`, `env-write`, `subprocess`, `shell`,
+`network`.
+
+## Which agent operations check which capability
+
+| Operation | Capability required (when a policy is active) |
+|-----------|-----------------------------------------------|
+| `agent.http` requests (`http-get`/`http-post`/`http-request`/`http-stream-open`) | `network` |
+| `agent.subprocess` argv spawns (`process-spawn-argv`, `run-argv…`) | `subprocess` |
+| `agent.subprocess` shell spawns (`process-spawn-shell`, `run-command…`) | `shell` |
+| `agent.git-ffi` (shells out to `git`) | `shell` / `subprocess` |
+| File I/O builtins | `file-read` / `file-write` |
+| Environment access | `env-read` / `env-write` |
+
+The HTTP client calls `(capability-require! 'network url)` on every request, so
+denying `network` blocks outbound HTTP even if the module is loaded.
+
+## Example
+
+```scheme
+(require core.capabilities)
+(require agent.http)
+
+;; Allow only network; deny subprocess/shell/file-write.
+(capability-install-policy! '(network))
+
+(capability-allowed? 'network)     ;; => #t
+(capability-allowed? 'shell)       ;; => #f
+;; (run-command "rm -rf /")        ;; would raise: shell capability denied
+
+(capability-clear-policy!)         ;; back to allow-all
+```

--- a/docs/reference/agent/crypto.md
+++ b/docs/reference/agent/crypto.md
@@ -1,0 +1,57 @@
+# `agent.crypto` — Hashing, Randomness, and Base64URL
+
+Cryptographic primitives and encodings used by the agent surface (JWT signing,
+content-addressing, token generation). Backed by C runtime symbols
+(`eshkol_sha256`, `eshkol_hmac_sha256`, `eshkol_random_bytes`,
+`eshkol_random_hex`) declared through the [FFI `extern`](ffi.md) mechanism.
+
+```scheme
+(require agent.crypto)
+```
+
+Source: `lib/agent/crypto.esk`.
+
+## Provided procedures
+
+| Procedure | Signature | Returns |
+|-----------|-----------|---------|
+| `sha256` | `(sha256 data)` | 64-char lowercase hex digest string |
+| `hmac-sha256` | `(hmac-sha256 key data)` | hex digest string |
+| `random-bytes` | `(random-bytes len)` | string of `len` random bytes |
+| `random-hex` | `(random-hex hex-len)` | hex string of `hex-len` hex chars |
+| `uuid-v4` | `(uuid-v4)` | RFC-4122 v4 UUID string |
+| `base64url-encode` | `(base64url-encode data)` | base64url string, no padding |
+| `base64url-decode` | `(base64url-decode url-str)` | decoded byte string |
+
+`data` / `key` are byte strings (Eshkol strings are length-tagged byte buffers,
+so binary payloads are fine). `base64url-encode` takes a **string** (bytes-as-string),
+not a byte list — it delegates to `base64-encode-string`, strips `=` padding, and
+maps `+/` to `-_`. `base64url-decode` re-pads and reverses the mapping.
+
+## Verified examples
+
+```scheme
+(require agent.crypto)
+(display (sha256 "hello")) (newline)
+;; => 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+
+(display (base64url-encode "hi?")) (newline)
+;; => aGk_
+```
+
+```
+$ eshkol-run -r sha.esk
+2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+```
+
+Both `-r` (JIT) and AOT builds resolve the crypto C symbols; because other
+faculties (e.g. the [memory faculty](memory-faculty.md)) call `sha256`
+internally, the transitive agent-FFI link scan pulls `eshkol_sha256` into AOT
+binaries automatically (see [FFI & AOT linking](ffi.md)).
+
+## Notes
+
+- `sha256` returns the hex string, not raw bytes. For raw digest bytes call the
+  underlying `sha256-raw` (`:real eshkol_sha256`) directly.
+- `base64url` is padding-free (JWT-style). Round-tripping through
+  `base64url-decode` yields the original byte string.

--- a/docs/reference/agent/eagle.md
+++ b/docs/reference/agent/eagle.md
@@ -1,0 +1,72 @@
+# `agent.eagle` — Native Linear-Head Training (EAGLE)
+
+A native, dependency-free fully-connected linear layer with mean-squared-error
+loss and plain SGD — no Python/PyTorch. Used for feature-distillation training
+of a linear head. Introduced in PR #104.
+
+```scheme
+(require agent.eagle)
+```
+
+Source: `lib/agent/eagle.esk`. C implementation:
+`lib/agent/c/agent_eagle_training.c`. C ABI symbols: `qllm_ffi_linear_*`.
+
+The layer computes `y = W · x` (row-major weights, shape `out×in`, **no bias**),
+MSE loss over the outputs, gradient `grad = (2/out_dim)·(pred − target)·xᵀ`, and
+`W -= lr·grad` on an SGD step. A handle is an opaque pointer you must destroy.
+
+## API
+
+| Procedure | Signature | Description |
+|-----------|-----------|-------------|
+| `eagle-linear-create` | `(eagle-linear-create in-dim out-dim)` | New layer; returns handle |
+| `eagle-linear-destroy` | `(eagle-linear-destroy h)` | Free the layer |
+| `eagle-linear-set-weight!` | `(eagle-linear-set-weight! h out in value)` | Set `W[out][in]` |
+| `eagle-linear-weight` | `(eagle-linear-weight h out in)` | Get `W[out][in]` |
+| `eagle-linear-set-input!` | `(eagle-linear-set-input! h in value)` | Set input `x[in]` |
+| `eagle-linear-set-target!` | `(eagle-linear-set-target! h out value)` | Set target `t[out]` |
+| `eagle-linear-forward!` | `(eagle-linear-forward! h)` | Compute `pred = W·x` |
+| `eagle-linear-pred` | `(eagle-linear-pred h out)` | Read prediction `pred[out]` |
+| `eagle-linear-loss` | `(eagle-linear-loss h)` | MSE over outputs |
+| `eagle-linear-backward!` | `(eagle-linear-backward! h)` | Compute gradients |
+| `eagle-linear-grad` | `(eagle-linear-grad h out in)` | Read `grad[out][in]` |
+| `eagle-linear-sgd-step!` | `(eagle-linear-sgd-step! h lr)` | `W -= lr·grad` |
+| `eagle-linear-train-step!` | `(eagle-linear-train-step! h lr)` | forward + backward + sgd in one call |
+
+The wrappers add capability checks and translate C return codes into errors
+(`eagle-check`). Dimensions are validated (max `1<<20`, overflow-guarded).
+
+## Underlying C ABI
+
+| C symbol | Signature |
+|----------|-----------|
+| `qllm_ffi_linear_create` | `void*(int64 in_dim, int64 out_dim)` |
+| `qllm_ffi_linear_destroy` | `void(void*)` |
+| `qllm_ffi_linear_set_weight` | `int32(void*, int64 out, int64 in, double)` (0 ok / -1 OOB) |
+| `qllm_ffi_linear_get_weight` | `double(void*, int64 out, int64 in)` |
+| `qllm_ffi_linear_set_input` | `int32(void*, int64 in, double)` |
+| `qllm_ffi_linear_set_target` | `int32(void*, int64 out, double)` |
+| `qllm_ffi_linear_forward` | `int32(void*)` |
+| `qllm_ffi_linear_pred` | `double(void*, int64 out)` |
+| `qllm_ffi_linear_loss` | `double(void*)` |
+| `qllm_ffi_linear_backward` | `int32(void*)` |
+| `qllm_ffi_linear_grad` | `double(void*, int64 out, int64 in)` |
+| `qllm_ffi_linear_sgd_step` | `int32(void*, double lr)` |
+| `qllm_ffi_linear_train_step` | `int32(void*, double lr)` |
+
+## Verified example
+
+```scheme
+(require agent.eagle)
+(define h (eagle-linear-create 2 1))
+(eagle-linear-set-weight! h 0 0 0.5)
+(eagle-linear-set-weight! h 0 1 -0.5)
+(eagle-linear-set-input! h 0 1.0)
+(eagle-linear-set-input! h 1 2.0)
+(eagle-linear-forward! h)
+(display (eagle-linear-pred h 0)) (newline)   ;; => -0.5   (0.5*1 + -0.5*2)
+(eagle-linear-destroy h)
+```
+
+A training loop repeatedly sets inputs/targets and calls `eagle-linear-train-step!`
+with a learning rate until `eagle-linear-loss` converges.

--- a/docs/reference/agent/ffi.md
+++ b/docs/reference/agent/ffi.md
@@ -1,0 +1,122 @@
+# Foreign Function Interface (FFI)
+
+Eshkol calls C functions through the `extern` declaration. This is the mechanism
+every `agent.*` module uses to bind to its C runtime (`qllm_*`, `eshkol_*`).
+
+## `extern` syntax
+
+```
+(extern <ret-type> <eshkol-name> <arg-type>* [<modifier>]*)
+```
+
+- **Return type** (required symbol) comes first.
+- **Eshkol-visible name** (required symbol) comes second — this is the name your
+  code calls.
+- Zero or more **parameter type** symbols follow, until `)` or a `:`-modifier.
+- Trailing `:`-modifiers must come last.
+
+Parsed at `lib/frontend/parser.cpp` (extern form ~8480-8565; modifier tail
+~1590-1645).
+
+### Modifiers
+
+| Modifier | Effect |
+|----------|--------|
+| `:real <sym>` (alias `:extern-symbol <sym>`) | The actual C symbol to link. If omitted, the Eshkol name is used verbatim as the C symbol. |
+| `:weak` | Weak linkage. |
+| `:no-return` | Function does not return. |
+
+There is a sibling form `(extern-var …)` for external global variables (accepts
+only `:real` / `:extern-symbol`).
+
+### Example
+
+```scheme
+(extern i32  sha256-raw  ptr i64 ptr i64 :real eshkol_sha256)
+(extern ptr  qllm-http-get  ptr i32     :real qllm_http_get)
+(extern void process-destroy-raw  ptr   :real qllm_process_destroy)
+```
+
+## Type keywords → C ABI
+
+`mapStringToType` (`lib/backend/llvm_codegen.cpp` ~23089-23108), matched
+case-sensitively:
+
+| Keyword | C / LLVM type |
+|---------|---------------|
+| `void` | void |
+| `i32` / `int` | i32 |
+| `i64` / `long` | i64 |
+| `f32` / `float` | float (f32) |
+| `f64` / `double` | double (f64) |
+| `ptr` / `char*` / `string` | pointer |
+| `...` | variadic marker |
+| *(anything else)* | defaults to i64 (with a warning) |
+
+## Tagged-value boundary conversion
+
+Eshkol values are 16-byte tagged values (see the [memory model](../runtime/memory-model.md)).
+At the FFI boundary the compiler unboxes/reboxes automatically:
+
+**Arguments (Eshkol → C):**
+
+- integer params ← `unpackInt64FromTaggedValue`
+- `double`/`f64` params ← `unpackDoubleFromTaggedValue`
+- `ptr` params ← int payload → `IntToPtr` (a **string** is passed as the raw
+  pointer to its NUL-terminated payload)
+- boolean ← truncated to `i1`
+
+**Return values (C → Eshkol):**
+
+| C return | Repacked as |
+|----------|-------------|
+| `i32` | `SIToFP` → tagged **double** (so error codes compare with `= < >`) |
+| `i64` | tagged **int** (used for opaque handles) |
+| `f32`/`f64` | tagged **double** |
+| `ptr` | tagged `HEAP_PTR` |
+
+Because a returned `ptr` is an opaque handle, to turn an FFI-returned `char*` into
+an Eshkol string you call `(ptr->string p)`, which allocates a header'd Eshkol
+string and copies the bytes. Modules that return C-owned buffers wrap this
+(e.g. `process-owned-c-string->string` in `agent.subprocess`, which copies then
+frees the C buffer).
+
+> Because `i32` returns are repacked as doubles, an FFI status code of `-1`
+> compares correctly with numeric predicates; do not assume it stays an exact
+> integer.
+
+## Requiring agent FFI and AOT linking
+
+Two questions decide whether a compiled binary links the agent C runtime:
+
+1. **Does the program use agent FFI?** `requires_agent_ffi` (in
+   `exe/eshkol-run.cpp`) scans top-level `(require …)` forms. Any module whose
+   name starts with `agent.` → yes. Otherwise it resolves each required module to
+   a file and **recurses transitively**: a program that only does
+   `(require core.memory)` still links agent FFI because `core.memory` internally
+   `(require agent.crypto)`. (The scan is text-based and conservative — false
+   positives only cost a few extra linked libs.)
+
+2. **What gets linked?** When agent FFI is needed, the compiler splices
+   `ESHKOL_HOST_AGENT_FFI_LINK_ARGS` into the link command. That macro
+   (`cmake/build_config.h.in`, assembled in `CMakeLists.txt`) force-loads
+   `libeshkol-agent-ffi.a` (`-Wl,-force_load,…` on Apple; `--whole-archive`
+   elsewhere) and appends the C dependencies that were found at configure time:
+   **libcurl** (HTTP), **sqlite3**, **pcre2** (regex), **ncurses** (terminal),
+   and OpenSSL/Security frameworks (crypto). If those libraries were not
+   available at build time, the macro is empty and calls fall through to
+   runtime "unavailable" stubs.
+
+### JIT (`-r`) vs AOT resolution
+
+- Under **`-r` / `-e`**, the JIT host (`eshkol-run` / `eshkol-repl`) is *itself*
+  linked against `libeshkol-agent-ffi.a` and force-references every agent symbol
+  via weak declarations (`ESHKOL_AGENT_FFI_SYMBOL`, `lib/repl/repl_jit.cpp`).
+  The ORC JIT resolves `(extern …)` calls to these in-process symbols with
+  `dlsym`. A stripped host simply leaves them null.
+- Under **AOT**, the produced binary must contain the archive + deps, which is
+  exactly what the `ESHKOL_HOST_AGENT_FFI_LINK_ARGS` splice provides.
+
+Practical implication: always verify agent-FFI code under **AOT**, not just
+`-r` — the JIT can resolve a symbol the AOT link would miss if the link-args
+scan didn't fire.

--- a/docs/reference/agent/http.md
+++ b/docs/reference/agent/http.md
@@ -1,0 +1,86 @@
+# `agent.http` and `agent.http-server` — HTTP Client & Server
+
+## Client — `agent.http`
+
+```scheme
+(require agent.http)
+```
+
+Source: `lib/agent/http.esk`. C symbols: `qllm_http_*` (libcurl-backed).
+
+### Lifecycle
+
+| Procedure | Signature |
+|-----------|-----------|
+| `http-init` | `(http-init)` → `#t` on success |
+| `http-shutdown` | `(http-shutdown)` |
+| `http-has-ssl?` | `(http-has-ssl?)` → `#t` if TLS available |
+
+### Requests
+
+| Procedure | Signature | Returns |
+|-----------|-----------|---------|
+| `http-get` | `(http-get url [timeout-ms])` | `(status . body-string)` or `#f` |
+| `http-post` | `(http-post url headers body [timeout-ms])` | `(status . body-string)` or `#f` |
+| `http-request` | `(http-request method url headers body [timeout-ms])` | dispatches GET/POST |
+
+- `headers` is a list of `(name . value)` pairs; `body` is a string.
+- Default timeout is `30000` ms.
+- Every request calls `(capability-require! 'network url)` — a `network`
+  capability policy (if active) is enforced here (see [capabilities](capabilities.md)).
+- URLs and header values are validated (`http-safe-string?`) to reject control
+  characters / injection.
+
+### SSE streaming
+
+| Procedure | Signature |
+|-----------|-----------|
+| `http-stream-open` | `(http-stream-open url headers body [timeout-ms])` → stream or `#f` |
+| `http-stream-next` | `(http-stream-next stream [timeout-ms])` → `(type . data)` or `#f` |
+| `http-stream-done?` | `(http-stream-done? stream)` |
+| `http-stream-close` | `(http-stream-close stream)` |
+| `sse-event-type` / `sse-event-data` / `sse-event-free` | event accessors |
+
+### Known limitations (report inline)
+
+- `http-post` currently routes through the JSON convenience FFI
+  (`qllm_http_post_json`) and only forwards the `Authorization` or `x-api-key`
+  header; arbitrary custom headers are not yet marshaled through the full FFI.
+- `http-stream-next` returns a placeholder `("message" . "")` pending full SSE
+  event-struct field access. Treat SSE as experimental.
+
+## Server — `agent.http-server`
+
+```scheme
+(require agent.http-server)
+```
+
+Source: `lib/agent/http_server.esk`. C symbols: `eshkol_http_server_*`,
+`eshkol_unix_socket_*`, `eshkol_ws_*`. Handles are `i64`.
+
+### HTTP server
+
+| Procedure | Signature |
+|-----------|-----------|
+| `http-server-create` | `(http-server-create port)` → handle |
+| `http-server-port` | `(http-server-port handle)` → bound port (useful with port 0) |
+| `http-server-accept` | `(http-server-accept handle buffer-size timeout-ms)` |
+| `http-server-respond` | `(http-server-respond handle status content-type body)` |
+| `http-server-close` | `(http-server-close handle)` |
+
+### Unix domain socket & WebSocket
+
+| Procedure | Signature |
+|-----------|-----------|
+| `unix-socket-connect` | `(unix-socket-connect path)` → fd |
+| `ws-wrap-fd` | `(ws-wrap-fd fd)` → ws handle |
+| `ws-send-text` | `(ws-send-text handle data)` |
+| `ws-send-binary` | `(ws-send-binary handle data)` |
+| `ws-receive` | `(ws-receive handle buffer-size timeout-ms)` → `(frame-type . data)` |
+| `ws-close` | `(ws-close handle)` |
+
+Frame-type constants from `ws-receive`: `WS-FRAME-TEXT`, `WS-FRAME-BINARY`,
+`WS-FRAME-CLOSE`, `WS-FRAME-PING`, `WS-FRAME-PONG`.
+
+The server can be protected with a bearer token via the `ESHKOL_SERVER_TOKEN`
+environment variable.

--- a/docs/reference/agent/memory-faculty.md
+++ b/docs/reference/agent/memory-faculty.md
@@ -1,0 +1,80 @@
+# Memory Faculty — `core.memory` and `core.memory-store`
+
+An append-only, content-addressed, CRDT-merged **event log** for a distributed
+agent. It is composed entirely from verified core primitives — `sha256`
+(content-addressing, from [`agent.crypto`](crypto.md)), canonical s-expression
+rendering (`core.sexp`), and the RGA / LWW-register / vector-clock CRDTs from
+`core.distributed`.
+
+Two layers ship:
+
+- `core.memory` — the in-memory event-log faculty (v0).
+- `core.memory-store` — a durable, fsync'd, replayable event log with a hash
+  chain and head file.
+
+Both run under `eshkol-run -r` (JIT) **and** AOT. Because the faculty calls
+`sha256` internally, the transitive [agent-FFI link scan](ffi.md) pulls
+`eshkol_sha256` into AOT binaries automatically.
+
+---
+
+## `core.memory` — In-memory event log
+
+```scheme
+(require core.memory)
+```
+
+Source: `lib/core/memory.esk`.
+
+An **event** is immutable and content-addressed: its id is the `sha256` of the
+canonical rendering of its body (everything except the id). The body embeds the
+`prev` hash, so the log is also a hash chain — tampering with any field breaks
+the id. The log itself is an RGA (a convergent append-only ordered-sequence
+CRDT), so two nodes can append independently and `memory-merge` is conflict-free
+(commutative, idempotent, associative) with dedup-by-id inherent to the RGA.
+
+| Procedure | Signature | Description |
+|-----------|-----------|-------------|
+| `make-memory-log` | `(make-memory-log node-id)` | New empty log for a node |
+| `memory-append!` | `(memory-append! log type payload)` | Append an event; returns the event |
+| `memory-events` | `(memory-events log)` | Events in RGA order |
+| `memory-merge` | `(memory-merge a b)` | Conflict-free merge of two logs |
+| `memory-verify-chain` | `(memory-verify-chain log)` | Verify the hash chain |
+| `memory-verify-events` | `(memory-verify-events events)` | Verify a list of events |
+| `memory-fold-lww` | `(memory-fold-lww log key)` | Last-writer-wins fold over a key |
+
+### Event accessors
+
+`memory-event?`, `memory-event-id`, `memory-event-prev`, `memory-event-vclock`,
+`memory-event-node`, `memory-event-type`, `memory-event-payload`.
+
+Identity ("soul") and episodic ("anamnesis") memory are simply event *types* in
+one log.
+
+---
+
+## `core.memory-store` — Durable event store
+
+```scheme
+(require core.memory-store)
+```
+
+Source: `lib/core/memory-store.esk`. Adds fsync'd append-to-file, a `.head`
+pointer file, replay-on-open, and linkage verification. Uses fixed-arity libc
+externs (`fopen`/`fwrite`/`fflush`/`fileno`/`fsync`/`fclose`) for ARM64-safe
+FFI.
+
+| Procedure | Signature |
+|-----------|-----------|
+| `make-memory-store` | `(make-memory-store log path)` |
+| `memory-store-open` | `(memory-store-open node-id path)` — open + replay |
+| `memory-store-open-fast` | `(memory-store-open-fast node-id path)` — open via head file |
+| `memory-store-append!` | `(memory-store-append! store type payload)` |
+| `memory-store-verify` | `(memory-store-verify store)` — verify chain linkage |
+| `memory-store-count` | `(memory-store-count store)` |
+| `memory-store-head` | `(memory-store-head store)` |
+| `memory-store?` / `memory-store-log` / `memory-store-path` | accessors |
+| `memory-store-sanitize` | payload sanitizer |
+
+Durable content-addressed storage (`core.merkle` CAS) and network fan-out
+(git / Syncthing) are the planned step-2 layers on top of this store.

--- a/docs/reference/agent/platform-utilities.md
+++ b/docs/reference/agent/platform-utilities.md
@@ -1,0 +1,121 @@
+# Platform Utility Modules
+
+Smaller `agent.*` modules for filesystem watching, globbing, secrets,
+terminal control, git, regular expressions, and layout. Each is loaded with
+`(require agent.<name>)`.
+
+---
+
+## `agent.regex` — PCRE2 Regular Expressions
+
+Source: `lib/agent/regex.esk`. C symbols: `eshkol_regex_*` (PCRE2). A compiled
+pattern is an opaque `i64` handle — free it with `regex-free`.
+
+| Procedure | Signature | Returns |
+|-----------|-----------|---------|
+| `regex-compile` | `(regex-compile pattern [flags…])` | handle |
+| `regex-match` | `(regex-match handle subject)` | first match string / `#f` |
+| `regex-match?` | `(regex-match? handle subject)` | `#t`/`#f` |
+| `regex-match-all` | `(regex-match-all handle subject [max])` | list of matches |
+| `regex-replace` | `(regex-replace handle subject replacement)` | new string |
+| `regex-match-groups` | `(regex-match-groups handle subject)` | capture groups |
+| `regex-group` | `(regex-group match-groups idx)` | one group |
+| `regex-named-group-number` | `(regex-named-group-number handle name)` | group index |
+| `regex-free` | `(regex-free handle)` | |
+
+Flag constants: `REGEX_CASELESS`, `REGEX_MULTILINE`, `REGEX_DOTALL`.
+
+```scheme
+(require agent.regex)
+(define rx (regex-compile "a(b+)c"))
+(display (regex-match? rx "xabbbcx")) (newline)   ;; => #t
+(regex-free rx)
+```
+
+---
+
+## `agent.glob` — Filename Globbing
+
+Source: `lib/agent/glob.esk`.
+
+| Procedure | Signature |
+|-----------|-----------|
+| `glob-files` | `(glob-files pattern directory max-results)` → list of paths |
+| `glob-files-sorted` | `(glob-files-sorted pattern directory max-results)` → sorted list |
+
+---
+
+## `agent.fs-watch` — Directory Watching
+
+Source: `lib/agent/fs-watch.esk`. Poll-based; spawns a helper process.
+
+| Procedure | Signature |
+|-----------|-----------|
+| `fs-watch-start` | `(fs-watch-start directory callback-file)` → pid |
+| `fs-watch-poll` | `(fs-watch-poll callback-file)` → changes |
+| `fs-watch-stop` | `(fs-watch-stop pid)` |
+
+---
+
+## `agent.keychain` — OS Secret Store
+
+Source: `lib/agent/keychain.esk`. Wraps the platform keychain/credential store.
+
+| Procedure | Signature |
+|-----------|-----------|
+| `keychain-get` | `(keychain-get account)` |
+| `keychain-set!` | `(keychain-set! account value)` |
+| `keychain-delete` | `(keychain-delete account)` |
+| `keychain-has?` | `(keychain-has? account)` → `#t`/`#f` |
+
+---
+
+## `agent.terminal` — Terminal Control (TUI)
+
+Source: `lib/agent/terminal.esk`. C symbols: `term-*-raw`. Raw/cooked mode,
+cursor control, key input.
+
+| Group | Procedures |
+|-------|-----------|
+| Lifecycle | `term-init` (→ `#t`), `term-shutdown`, `term-raw-mode`, `term-cooked-mode` |
+| Geometry | `term-width`, `term-height`, `term-resized?` |
+| Input | `term-read-key`, `term-read-key-timeout ms` |
+| Output | `term-clear`, `term-move-to row col`, `term-cursor-pos` (→ `(row . col)`), `term-show-cursor`, `term-hide-cursor`, `term-write str`, `term-flush`, `term-set-title title` |
+
+Key constants: `KEY_UP KEY_DOWN KEY_LEFT KEY_RIGHT KEY_HOME KEY_END
+KEY_BACKSPACE KEY_DELETE KEY_TAB KEY_ENTER KEY_ESCAPE KEY_PAGE_UP KEY_PAGE_DOWN
+KEY_F1 KEY_F2 KEY_F3 KEY_F4`.
+
+---
+
+## `agent.git-ffi` — Git Helpers
+
+Source: `lib/agent/git-ffi.esk`. **Not** a libgit2 binding — a thin wrapper that
+shells out to the `git` CLI via `system`, capturing output through a temp file.
+Each helper returns parsed output; `git-run` returns `(exit-code . output)`.
+
+| Procedure | Signature |
+|-----------|-----------|
+| `git-run` | `(git-run cwd . args)` → `(rc . output)` |
+| `git-is-repo?` | `(git-is-repo? cwd)` → `#t`/`#f` |
+| `git-root` | `(git-root cwd)` → path / `#f` |
+| `git-branch-current` | `(git-branch-current cwd)` → name / `#f` |
+| `git-status` | `(git-status cwd)` → `git status --short` text |
+| `git-diff-stat` | `(git-diff-stat cwd)` → `git diff --stat` text |
+| `git-log-oneline` | `(git-log-oneline cwd count)` → oneline log text |
+
+Because it invokes `git` through a shell, it is subject to `subprocess`/`shell`
+[capabilities](capabilities.md) when a policy is active.
+
+---
+
+## `agent.layout` — Box Layout
+
+Source: `lib/agent/layout.esk`. Simple flexbox-style row/column layout for TUIs.
+
+| Procedure | Signature |
+|-----------|-----------|
+| `layout-compute` | compute bounds for a tree |
+| `layout-box` | `(layout-box direction width children)` |
+| `layout-text` | `(layout-text text width)` |
+| `layout-node-bounds` | `(layout-node-bounds node)` |

--- a/docs/reference/agent/sqlite.md
+++ b/docs/reference/agent/sqlite.md
@@ -1,0 +1,83 @@
+# `agent.sqlite` — Embedded SQLite
+
+Thin, safe bindings over the bundled SQLite C library. Handles are opaque `i64`
+integers (a database connection or a prepared statement).
+
+```scheme
+(require agent.sqlite)
+```
+
+Source: `lib/agent/sqlite.esk`. C symbols: `eshkol_sqlite_*`.
+
+## Connection lifecycle
+
+| Procedure | Signature | Notes |
+|-----------|-----------|-------|
+| `sqlite-open` | `(sqlite-open path)` | Returns handle `>= 0`, or negative on error |
+| `sqlite-close` | `(sqlite-close handle)` | |
+| `with-db` | `(with-db path fn)` | Opens, calls `(fn db)`, closes on exit via `dynamic-wind`; `error`s if open fails |
+
+## Statement lifecycle
+
+| Procedure | Signature |
+|-----------|-----------|
+| `sqlite-prepare` | `(sqlite-prepare db sql)` → stmt handle (negative on error) |
+| `sqlite-step` | `(sqlite-step stmt)` → `#t` if a row is available (`SQLITE_ROW`) |
+| `sqlite-reset` | `(sqlite-reset stmt)` |
+| `sqlite-finalize` | `(sqlite-finalize stmt)` |
+| `with-statement` | `(with-statement db sql fn)` — prepares, `(fn stmt)`, finalizes on exit |
+
+## Direct execution
+
+| Procedure | Signature | Notes |
+|-----------|-----------|-------|
+| `sqlite-exec` | `(sqlite-exec handle sql)` | Execute SQL without a result cursor |
+| `sqlite-exec-safe` | `(sqlite-exec-safe handle sql)` | Guarded variant |
+
+## Binding parameters (1-indexed)
+
+`sqlite-bind-text`, `sqlite-bind-int`, `sqlite-bind-double`, `sqlite-bind-null`
+— each `(… stmt idx value)`.
+
+## Reading columns (0-indexed)
+
+`sqlite-column-text`, `sqlite-column-int`, `sqlite-column-double`,
+`sqlite-column-count`, `sqlite-column-name`, `sqlite-column-type`.
+
+`sqlite-column-text` allocates a buffer sized from `sqlite-column-bytes-raw`, so
+dynamically-sized TEXT/BLOB columns are read in full (this fixed an earlier
+fixed-buffer truncation bug — see session-persistence work).
+
+## Metadata
+
+| Procedure | Returns |
+|-----------|---------|
+| `sqlite-last-error` | error string (via a 1024-byte scratch buffer) |
+| `sqlite-last-insert-rowid` | rowid `i64` |
+| `sqlite-changes` | rows affected |
+
+## Constants
+
+`SQLITE_ROW`, `SQLITE_DONE`.
+
+## Verified example
+
+```scheme
+(require agent.sqlite)
+(with-db "/tmp/demo.db"
+  (lambda (db)
+    (sqlite-exec db "CREATE TABLE t(id INTEGER, name TEXT)")
+    (with-statement db "INSERT INTO t VALUES(?,?)"
+      (lambda (s)
+        (sqlite-bind-int s 1 1)
+        (sqlite-bind-text s 2 "alice")
+        (sqlite-step s)))
+    (with-statement db "SELECT name FROM t WHERE id=?"
+      (lambda (s)
+        (sqlite-bind-int s 1 1)
+        (when (sqlite-step s)
+          (display (sqlite-column-text s 0)) (newline))))))
+```
+
+AOT binaries link the SQLite objects automatically when a required module uses
+`agent.sqlite` (see [FFI & AOT linking](ffi.md)).

--- a/docs/reference/agent/subprocess.md
+++ b/docs/reference/agent/subprocess.md
@@ -1,0 +1,80 @@
+# `agent.subprocess` — Process Spawning
+
+Spawn, drive, and reap child processes. Two families exist: **shell** spawns
+(`process-spawn-shell`, `run-command`) which pass a command string to `/bin/sh
+-c`, and **argv** spawns (`process-spawn-argv`, `run-argv`) which exec a program
+directly with no shell — safe against shell injection (#190).
+
+```scheme
+(require agent.subprocess)
+```
+
+Source: `lib/agent/subprocess.esk`. C symbols: `qllm_process_*`.
+
+## Ownership & cleanup contract (#94)
+
+A process handle is an opaque pointer. **You own it until you call
+`process-destroy`.** The lifecycle is:
+
+1. spawn → handle
+2. drive (`process-write-stdin`, `process-read-*`, `process-wait`)
+3. `process-destroy` — frees the handle and reaps the child
+
+The `process-read-all-*` calls return an owned C buffer that the binding copies
+into an Eshkol string and then frees via `qllm_process_free_buffer`; you do not
+free it yourself. The high-level `run-command`/`run-argv` wrappers always
+`process-destroy` on every exit path (success, timeout-kill, spawn failure), so
+they never leak. If you use the low-level API directly, you must call
+`process-destroy` yourself — including after a timeout, where the pattern is
+`process-kill` → `process-wait 5000` → `process-destroy`.
+
+## Low-level API
+
+| Procedure | Signature |
+|-----------|-----------|
+| `process-spawn` | `(process-spawn command cwd)` → handle or `#f` |
+| `process-spawn-shell` | `(process-spawn-shell command cwd)` |
+| `process-spawn-argv` | `(process-spawn-argv argv cwd)` — `argv` is `(prog arg…)` |
+| `process-write-stdin` | `(process-write-stdin proc data)` |
+| `process-close-stdin` | `(process-close-stdin proc)` |
+| `process-read-stdout` | `(process-read-stdout proc max-bytes)` |
+| `process-read-stderr` | `(process-read-stderr proc max-bytes)` |
+| `process-read-all-stdout` | `(process-read-all-stdout proc max-bytes)` |
+| `process-read-all-stderr` | `(process-read-all-stderr proc max-bytes)` |
+| `process-wait` | `(process-wait proc timeout-ms)` → `0` exited, `1` timed out |
+| `process-running?` | `(process-running? proc)` |
+| `process-exit-code` | `(process-exit-code proc)` |
+| `process-pid` | `(process-pid proc)` — for trace IDs / external observability |
+| `process-kill` | `(process-kill proc [signal])` |
+| `process-destroy` | `(process-destroy proc)` — **required** |
+
+## Convenience wrappers
+
+| Procedure | Signature | Returns |
+|-----------|-----------|---------|
+| `run-command` | `(run-command command [cwd] [timeout-ms])` | exit code (int); `-1` spawn fail |
+| `run-command-capture` | `(run-command-capture command [cwd] [timeout-ms] [max-output])` | alist `((exit-code . N)(stdout . s)(stderr . s))` |
+| `run-argv` | `(run-argv argv [cwd] [timeout-ms])` | exit code |
+| `run-argv-capture` | `(run-argv-capture argv [cwd] [timeout-ms] [max-output])` | alist |
+
+Defaults: `cwd` = `"."`, `timeout-ms` = `30000`, `max-output` = `4194304`
+(4 MiB). On timeout the child is killed and `run-*-capture` reports exit code
+`124` with a `[Process timed out …]` note appended to stderr. The `-capture`
+wrappers spawn with stdin wired to `/dev/null` (no unused pipe).
+
+## Argv safety
+
+`run-argv`/`run-argv-capture` and `process-spawn-argv` never invoke a shell, so
+metacharacters in arguments are inert. Prefer them over the shell variants for
+untrusted input. `process-argv-check-args` rejects format-string-shaped args.
+
+## Sandbox limits (env)
+
+`process-spawn` honors resource caps from the environment when set:
+`ESHKOL_SUBPROC_CPU_SEC`, `ESHKOL_SUBPROC_MEM_MB`, `ESHKOL_SUBPROC_NOFILE`,
+`ESHKOL_SUBPROC_NPROC` (see [environment variables](../runtime/environment-variables.md)).
+
+## Capabilities
+
+Subprocess spawning is gated by the `subprocess` / `shell` capabilities when a
+policy is active — see [capabilities](capabilities.md).

--- a/docs/reference/runtime/INDEX.md
+++ b/docs/reference/runtime/INDEX.md
@@ -1,0 +1,41 @@
+# Runtime Reference
+
+Reference documentation for the Eshkol runtime and toolchain (v1.3.0-evolve).
+
+## Tools
+
+- [`eshkol-run`](eshkol-run.md) — the compiler & JIT driver: every CLI flag
+  (AOT, `-r`/`-e` JIT, `-c`/`--emit-object`, `-s` shared lib, `-w` WASM,
+  `--profile`, `--target`, `-O`, `--dump-ast`/`--dump-ir`, `--debug-info`, …).
+- [`eshkol-repl`](eshkol-repl.md) — interactive REPL and the `--machine`
+  warm-worker **EREPL** protocol (READY/DONE/FAIL framing).
+- [`eshkol-vm-standalone`](eshkol-vm-standalone.md) — the bytecode VM, the
+  **ESKB** binary format, `--emit-eskb`, and `--require-vm-entry[-zero-arg]`.
+
+## Runtime concepts
+
+- [Environment variables](environment-variables.md) — the full user-facing set:
+  JIT/run cache, search paths, resource limits, parallelism, backends, subprocess
+  sandbox.
+- [Memory model](memory-model.md) — 16-byte tagged values, the arena allocator,
+  the hybrid global/per-thread model, and `with-region` semantics (incl. the
+  PR #81 reclamation fix).
+- [Parallelism & threading](parallelism.md) — `parallel-map`/`-fold`/`-filter`/
+  `-execute`, `future`/`force`, the work-stealing pool, the serialized-state
+  pattern, and the AD-mode-flag limitation.
+- [JIT internals](jit-internals.md) — the run cache, the stdlib object cache, and
+  the Large code model / arm64 Branch26 veneer.
+
+## See also
+
+- [Agent / FFI reference](../agent/INDEX.md)
+- [Platform reference](../../platform/) — [CI lanes](../../platform/CI_LANES.md),
+  [build notes](../../platform/BUILD_NOTES.md),
+  [target matrix](../../platform/TARGET_SUPPORT_MATRIX.md).
+
+## Notes / discrepancies observed
+
+- The binary reports `v1.2.4-scale` (`eshkol-run --version`) while this
+  documentation campaign targets **v1.3.0-evolve**.
+- `--help` says `-e` "prints the result," but a bare value expression is **not**
+  auto-printed — use `display`. (See [`eshkol-run`](eshkol-run.md).)

--- a/docs/reference/runtime/environment-variables.md
+++ b/docs/reference/runtime/environment-variables.md
@@ -1,0 +1,97 @@
+# Environment Variables
+
+User-facing environment variables read by the Eshkol runtime and toolchain.
+Boolean flags accept truthy/falsey spellings (`1`/`0`, `true`/`false`,
+`on`/`off`, `yes`/`no`) unless noted.
+
+## JIT & run cache
+
+| Variable | Effect | Default |
+|----------|--------|---------|
+| `ESHKOL_JIT_CACHE` | Persistent AOT run cache for `-r`; disable with `0`/`false`/`off`/`no`. When on, `-r` compiles the file once to a standalone binary and re-execs the cached one on later runs. | enabled |
+| `ESHKOL_JIT_CACHE_DIR` | Run-cache directory. | `$XDG_CACHE_HOME/eshkol/jit` or `$HOME/.cache/eshkol/jit` (Unix); `%LOCALAPPDATA%\eshkol\jit` (Windows); else temp |
+| `ESHKOL_JIT_CACHE_TRACE` | Print `[jit-cache] <hit\|miss\|bypass>` to stderr. | off |
+| `ESHKOL_JIT_COMPILE_THREADS` | ORC compile-thread count (accepts 1-64). More threads reduce materialization-lock contention (which serializes parallel-map workers) at higher memory cost. | `hardware_concurrency()/2`, clamped to [1,16] |
+| `ESHKOL_JIT_NO_BRANCH26_VENEER` | Disable the arm64 Branch26 range-extension veneer in the JIT linker (escape hatch). | off (veneer on) |
+
+See [JIT internals](jit-internals.md) for details, including cache-key
+invalidation and the stdlib object cache.
+
+## Module & library search paths
+
+| Variable | Effect |
+|----------|--------|
+| `ESHKOL_PATH` | Module/include search path for `require`. |
+| `ESHKOL_LIB_DIR` | Directory to locate the precompiled stdlib / runtime libraries. |
+| `ESHKOL_PROJECT_ROOT` | Project root used for relative paths in exception/backtrace reporting. |
+
+## Resource limits
+
+Read by `lib/core/resource_limits.cpp`. Size vars accept `K`/`M`/`G` suffixes.
+
+| Variable | Effect | Default |
+|----------|--------|---------|
+| `ESHKOL_MAX_HEAP` | Max heap bytes (soft limit at 80%). | 1 GiB |
+| `ESHKOL_MAX_STACK` | Max interpreter stack depth. | 100000 |
+| `ESHKOL_STACK_SIZE` | OS `RLIMIT_STACK` target (min 1 MiB). | 512 MB |
+| `ESHKOL_MAX_STRING_LEN` | Max string length. | 100 MiB |
+| `ESHKOL_MAX_TENSOR_ELEMS` | Max tensor element count. | 1e9 |
+| `ESHKOL_TIMEOUT_MS` | Max execution time (ms). | 30000 |
+| `ESHKOL_VM_MAX_INSN` | VM runaway-instruction guard. | 10000000 |
+| `ESHKOL_ENFORCE_LIMITS` | Enforce hard limits (abort on exceed). | true |
+| `ESHKOL_LIMIT_WARNINGS` | Emit soft-limit warnings. | true |
+
+## Parallelism & threading
+
+| Variable | Effect | Default |
+|----------|--------|---------|
+| `ESHKOL_PARALLEL_DISABLE` | `1` forces sequential fallback for parallel primitives. | off |
+| `ESHKOL_PARALLEL_ENABLE` | Legacy toggle; `0` disables parallelism. | on |
+| `ESHKOL_PARALLEL_NO_WARMUP` | `1` skips the single-item ORC warmup before dispatching workers. | off |
+| `ESHKOL_DISABLE_WORK_STEALING` | Set (non-`0`) to use the legacy queue instead of per-worker work-stealing deques. | work-stealing on |
+| `ESHKOL_WORKER_STACK_BYTES` | Per-worker pthread stack size (floored at `PTHREAD_STACK_MIN`). | 16 MB |
+| `ESHKOL_DEBUG_PAR` | Print pool/task metrics. | off |
+
+See [parallelism & threading](parallelism.md).
+
+## Native link / object emission (AOT)
+
+| Variable | Effect | Default |
+|----------|--------|---------|
+| `ESHKOL_LINK_TIMEOUT_SECONDS` | AOT native-link timeout (`0` = unbounded). | 300 |
+| `ESHKOL_OBJECT_EMIT_TIMEOUT_SECONDS` | Object-emit timeout. | 0 (unbounded) |
+
+## GPU / BLAS / XLA backends
+
+| Variable | Effect | Default |
+|----------|--------|---------|
+| `ESHKOL_GPU_THRESHOLD` / `ESHKOL_GPU_MATMUL_THRESHOLD` | Min element count to dispatch to GPU (set `1` to force GPU). | 100000 |
+| `ESHKOL_GPU_PRECISION` | `exact` (sf64) / `high` (df64) / `fast` (f32). | `exact` |
+| `ESHKOL_GPU_VERBOSE` | GPU dispatch logging. | off |
+| `ESHKOL_BLAS_THRESHOLD` | Min size to use the CPU BLAS backend. | 64 |
+| `ESHKOL_XLA_THRESHOLD` | Min size to use the XLA backend. | 100000 |
+
+More GPU tuning vars (`ESHKOL_GPU_PEAK_GFLOPS`, `ESHKOL_GPU_WAIT_TIMEOUT`,
+`ESHKOL_ENABLE_TENSORCORE`, `ESHKOL_BLAS_PEAK_GFLOPS`, `ESHKOL_OZAKI_*`) exist for
+backend benchmarking — see [platform build notes](../../platform/BUILD_NOTES.md).
+
+## Agent subprocess sandbox
+
+Resource caps applied to children spawned by [`agent.subprocess`](../agent/subprocess.md).
+
+| Variable | Effect | Default |
+|----------|--------|---------|
+| `ESHKOL_SUBPROC_CPU_SEC` | `RLIMIT_CPU` seconds. | 300 |
+| `ESHKOL_SUBPROC_MEM_MB` | `RLIMIT_AS` (virtual memory) MB. | 4096 |
+| `ESHKOL_SUBPROC_NOFILE` | `RLIMIT_NOFILE` (file descriptors). | 1024 |
+| `ESHKOL_SUBPROC_NPROC` | `RLIMIT_NPROC` (processes per user). | 512 |
+
+## Server & misc
+
+| Variable | Effect | Default |
+|----------|--------|---------|
+| `ESHKOL_SERVER_TOKEN` | Auth token for `agent.http-server` / `eshkol-server`. | unset |
+| `ESHKOL_VERBOSE` | Verbose logging (`=1`). | off |
+| `ESHKOL_ARENA_POISON` | Poison freed arena memory (debug); set non-`0`. | off |
+| `ESHKOL_VM_NO_DISASM` | Suppress the VM disassembly dump in `eshkol-vm-standalone`. | off |
+| `ESHKOL_DUMP_BC` / `ESHKOL_DUMP_REPL_IR` | Dump bitcode / REPL IR (debug). | off |

--- a/docs/reference/runtime/eshkol-repl.md
+++ b/docs/reference/runtime/eshkol-repl.md
@@ -1,0 +1,67 @@
+# `eshkol-repl` — Interactive REPL & Warm-Worker Protocol
+
+`eshkol-repl` is the interactive read-eval-print loop built on the same in-process
+LLVM JIT that powers `eshkol-run -r`. It also exposes a **machine-driven mode**
+(`--machine`) for use as a long-running, JIT-warm worker by sister projects.
+
+## Options
+
+```
+Usage: eshkol-repl [OPTIONS]
+
+  --stdlib, -s    Load standard library on startup
+  --machine, -m   Machine-driven mode: emits EREPL READY/DONE/FAIL framing on
+                  stderr; suppresses banner / prompts; implies --stdlib.
+  --help, -h      Show this help message
+```
+
+Interactively, forms are read (newline-terminated with balanced parens),
+evaluated, and results printed. See `repl_utils.h` for the built-in help topics
+(e.g. `with-region [name] [size] body ...`).
+
+## Machine mode (EREPL protocol)
+
+`--machine` turns the REPL into a warm worker: it loads the stdlib and JIT once,
+then evaluates forms sent on stdin without ever paying the cold-start cost again.
+Framing sentinels go to **stderr** so the program's own output on **stdout**
+stays clean.
+
+### Protocol
+
+1. Spawn `eshkol-repl --machine`.
+2. Read **stderr** until `EREPL READY` — the JIT and stdlib are warm. This is
+   emitted exactly **once** after initialization.
+3. Send one top-level form on **stdin** (newline-terminated, balanced parens).
+4. Read the form's output on **stdout** until you see `EREPL DONE` (success) or
+   `EREPL FAIL` (error) on **stderr**. One of these is emitted **once per
+   top-level form**.
+5. Repeat step 3-4 for each subsequent form.
+
+Each sentinel ends with `\n` and an explicit flush. `EREPL FAIL` is emitted when
+a form raises or fails to parse; the `DONE`/`FAIL` sentinel is written *after*
+cleanup so any exception text has already flushed to stdout.
+
+### Example session (conceptual)
+
+```
+spawn:   eshkol-repl --machine
+stderr:  EREPL READY
+stdin:   (display (* 6 7))(newline)
+stdout:  42
+stderr:  EREPL DONE
+stdin:   (car '())
+stdout:  <error text>
+stderr:  EREPL FAIL
+```
+
+This is the mechanism that answers the JIT cold-start cost for embedding
+projects: cold `eshkol-run -r` re-pays JIT setup each invocation, whereas a
+persistent `eshkol-repl --machine` worker has a marginal per-form cost of
+roughly zero.
+
+## Related
+
+- [JIT internals](jit-internals.md) — the stdlib object cache and code-model
+  behavior that make warm evaluation fast.
+- [`eshkol-run`](eshkol-run.md) — `-r` / `-e` one-shot JIT execution and the
+  persistent run cache.

--- a/docs/reference/runtime/eshkol-run.md
+++ b/docs/reference/runtime/eshkol-run.md
@@ -1,0 +1,131 @@
+# `eshkol-run` — Compiler & JIT Driver
+
+`eshkol-run` is the primary entry point: it compiles `.esk` source to native
+code (AOT), evaluates or runs it in-process via the LLVM JIT, emits object files
+/ shared libraries / WebAssembly / VM bytecode, and dumps ASTs and IR.
+
+```
+Usage: eshkol-run [options] <input.esk|input.o> [input.esk|input.o]
+       eshkol-run -e '<expression>'   (JIT evaluate expression)
+       eshkol-run -r <file.esk>       (JIT run file)
+```
+
+Reported version: `Eshkol Compiler v1.2.4-scale` (`--version`).
+
+## Modes at a glance
+
+| Mode | Invocation | Effect |
+|------|-----------|--------|
+| AOT compile + link | `eshkol-run in.esk -o out` | Produce a native executable |
+| Object only | `eshkol-run -c in.esk -o in.o` | Emit an object file, no link |
+| Shared library | `eshkol-run -s in.esk -o libin.so` | Emit a shared library |
+| JIT run | `eshkol-run -r in.esk` | Compile in-memory and run immediately |
+| JIT eval | `eshkol-run -e '(expr)'` | Evaluate one expression in-process |
+| WebAssembly | `eshkol-run -w in.esk -o in.wasm` | Emit `.wasm` |
+| VM bytecode | `eshkol-run --profile hosted-vm -B out.eskb in.esk` | Emit ESKB |
+
+Multiple `.esk`/`.o` inputs may be given and are linked together.
+
+## Full flag reference
+
+### Output & compilation
+
+| Flag | Alias | Meaning |
+|------|-------|---------|
+| `--output FILE` | `-o` | Output path (executable, object, `.so`, `.wasm`, per mode) |
+| `--compile-only` | `-c` | Compile to an intermediate object file (no link) |
+| `--emit-object` | | Alias for `--compile-only` |
+| `--shared-lib` | `-s` | Compile to a shared library |
+| `-fPIC` | | Accepted for build-system compatibility (no-op flag) |
+| `--wasm` | `-w` | Compile to WebAssembly (`.wasm`) |
+| `--no-stdlib` | `-n` | Do not auto-load the standard library |
+
+### JIT execution
+
+| Flag | Alias | Meaning |
+|------|-------|---------|
+| `--run FILE` | `-r` | JIT-run a file (compile in memory, execute) |
+| `--eval 'EXPR'` | `-e` | JIT-evaluate a single expression |
+
+### Optimization & debugging
+
+| Flag | Alias | Meaning |
+|------|-------|---------|
+| `--optimize N` | `-O` | LLVM optimization level: `0` none, `1` basic, `2` full, `3` aggressive |
+| `--debug` | `-d` | Add debugging information inside the program |
+| `--debug-info` | `-g` | Emit DWARF debug info (source-level lldb/gdb) |
+| `--dump-ast` | `-a` | Dump the AST to a `.ast` file |
+| `--dump-ir` | `-i` | Dump LLVM IR to a `.ll` file |
+
+### Type checking
+
+| Flag | Meaning |
+|------|---------|
+| `--strict-types` | Type errors become fatal (default: gradual — warnings only) |
+| `--unsafe` | Skip all type checks |
+
+### Search paths
+
+| Flag | Alias | Meaning |
+|------|-------|---------|
+| `-I DIR` | | Add a source/module search path |
+| `--lib NAME` | `-l` | Link a shared library into the executable |
+| `--lib-path DIR` | `-L` | Add a directory to the library search path |
+| `-D NAME[=VALUE]` | | Accepted for build-system compatibility (no-op) |
+
+### Targets & profiles
+
+| Flag | Meaning |
+|------|---------|
+| `--target TRIPLE` | Set the LLVM target triple (cross-compilation) |
+| `--profile NAME` | Execution profile (see below) |
+| `--emit-eskb FILE` / `-B FILE` | Emit Eshkol VM bytecode (ESKB); requires a VM profile |
+| `--require-vm-entry NAME` | Require a named VM entry in the emitted ESKB (VM profile only) |
+| `--require-vm-entry-zero-arg NAME` | Require a named zero-argument VM entry in the emitted ESKB |
+
+**Profiles:** `hosted-native`, `hosted-wasm`, `hosted-vm`,
+`freestanding-kernel-native`, `freestanding-mcu-native`, `freestanding-vm`,
+`embedded-vm`. See [`eshkol-vm-standalone`](eshkol-vm-standalone.md) for the ESKB
+format and the VM profiles, and the [platform target matrix](../../platform/TARGET_SUPPORT_MATRIX.md)
+for what each profile guarantees.
+
+### Info
+
+| Flag | Alias | Meaning |
+|------|-------|---------|
+| `--help` | `-h` | Print help |
+| `--version` | | Print version |
+
+## Verified examples
+
+```sh
+$ eshkol-run -r hello.esk                 # JIT run
+42
+
+$ eshkol-run -e '(display (+ 2 3))'       # JIT eval, explicit output
+5
+
+$ eshkol-run hello.esk -o hello && ./hello # AOT compile + run
+hi
+
+$ eshkol-run -c hello.esk -o hello.o      # object only  (25 KB .o)
+$ eshkol-run -r hello.esk --dump-ir       # also writes hello.ll to CWD
+$ eshkol-run -r hello.esk --dump-ast      # also writes hello.ast to CWD
+```
+
+> **Discrepancy (report only):** `--help` describes `-e` as "JIT evaluate an
+> expression and print the result," but `eshkol-run -e '(+ 2 3)'` produces **no**
+> output — the resulting value is not auto-printed. Use `display` explicitly
+> (`-e '(display (+ 2 3))'`). Side effects and definitions do run.
+
+`--dump-ir` / `--dump-ast` write `<source-basename>.ll` / `.ast` into the current
+working directory.
+
+## Related
+
+- [Environment variables](environment-variables.md) — `ESHKOL_JIT_CACHE`,
+  search paths, resource limits, and more.
+- [JIT internals](jit-internals.md) — run cache, stdlib object cache, code-model
+  notes.
+- [`eshkol-repl`](eshkol-repl.md) — interactive REPL and the `--machine`
+  warm-worker protocol.

--- a/docs/reference/runtime/eshkol-vm-standalone.md
+++ b/docs/reference/runtime/eshkol-vm-standalone.md
@@ -1,0 +1,100 @@
+# `eshkol-vm-standalone` — Bytecode VM & ESKB Format
+
+`eshkol-vm-standalone` is the standalone bytecode virtual machine. It runs
+compiled Eshkol bytecode (`.eskb`) files, and can also compile-and-run `.esk`
+source directly. It is the execution engine for the VM profiles
+(`hosted-vm`, `freestanding-vm`, `embedded-vm`) that `eshkol-run --emit-eskb`
+targets.
+
+## Invoking the VM
+
+It uses a hand-rolled argv parser (there is **no** `--help`):
+
+```
+eshkol-vm-standalone [--trace] [--emit-eskb PATH] <input.eskb | input.esk> [program args...]
+```
+
+| Token | Effect |
+|-------|--------|
+| `<file>.eskb` | Load and run the bytecode chunk |
+| `<file>.esk` | Compile the source and run it |
+| `--trace` | Enable per-instruction VM tracing |
+| `--emit-eskb PATH` | Emit bytecode to `PATH` |
+| `--` | Treat the rest of argv as positional |
+| *(no args)* | Run the built-in VM self-tests |
+
+Everything from the input file onward is passed to the program as its command
+line. Set `ESHKOL_VM_NO_DISASM=1` to suppress the disassembly dump.
+
+### Verified example
+
+```sh
+# Emit bytecode from source (VM profile required):
+$ eshkol-run --profile hosted-vm -B out.eskb prog.esk
+[ESKB] Wrote 17130 bytes to out.eskb (3 functions, 4198 instructions, 735 constants)
+[ESKB] Emitted bytecode to out.eskb
+
+# Run it on the standalone VM:
+$ eshkol-vm-standalone out.eskb
+[ESKB] Loaded out.eskb: 4141 instructions, 735 constants
+=== Eshkol VM — running out.eskb ===
+3
+=== Execution complete ===
+```
+
+## Emitting ESKB with `eshkol-run`
+
+Bytecode emission is done by `eshkol-run` under a VM profile:
+
+```
+eshkol-run --profile <hosted-vm|freestanding-vm|embedded-vm> --emit-eskb OUT.eskb INPUT.esk
+```
+
+`--emit-eskb` (short form `-B`) requires a VM profile. VM profiles set the
+backend to the VM and **forbid** JIT eval/run, `--shared-lib`, `--wasm`, and
+`--lib`. `embedded-vm` additionally forbids `--target` and hardens admission:
+host-only native policy, and it rejects string constants and desktop native
+calls (so the bytecode is portable to a constrained embedded VM).
+
+### Entry-point admission gates
+
+After emission you can assert that the produced bytecode exposes named entry
+points; on failure the emitted file is deleted and the command errors.
+
+| Flag | Meaning |
+|------|---------|
+| `--require-vm-entry NAME` | Re-load the emitted ESKB and require a function named `NAME` exists |
+| `--require-vm-entry-zero-arg NAME` | Require `NAME` exists as a **zero-argument** entry with no upvalues |
+
+Both require a VM profile plus `--emit-eskb`.
+
+## ESKB binary format
+
+ESKB ("Eshkol Bytecode") is a section-based binary using LEB128 variable-length
+encoding. Defined in `lib/backend/eskb_format.h`.
+
+- **Magic** `0x45534B42` = ASCII `"ESKB"`; **version** `1`.
+- **16-byte header**: `magic`, `version`, `flags`, `checksum` (CRC32, polynomial
+  `0xEDB88320`, over everything after the header).
+- **Flags**: `LITTLE_ENDIAN` (0x01), `DEBUG_INFO` (0x02).
+- **Sections** (`{u8 id, u32 size}` descriptors): `CONST` (0), `CODE` (1),
+  `META`/debug (2), `SYMB`/export table (3).
+- **Constant tags**: NIL 0, INT64 1, F64 2, BOOL 3, STRING 6.
+
+Two emit variants exist: `eshkol_emit_eskb` (desktop — keeps the desktop builtin
+preamble) and `eshkol_emit_eskb_embedded` (omits the preamble and rejects
+bytecode that still reaches the desktop native table). `--profile embedded-vm`
+selects the embedded variant.
+
+> Note: the same `"ESKB"` 4-character code is also used by an unrelated
+> knowledge-base persistence file format (v2) in `lib/core/kb_persistence.cpp`;
+> that is not VM bytecode.
+
+## Related
+
+- [`eshkol-run`](eshkol-run.md) — the `--profile` / `--emit-eskb` /
+  `--require-vm-entry` flags.
+- [Platform target matrix](../../platform/TARGET_SUPPORT_MATRIX.md) — artifact
+  expectations for the VM profiles.
+- `ESHKOL_VM_MAX_INSN` in [environment variables](environment-variables.md) —
+  the VM runaway-instruction guard.

--- a/docs/reference/runtime/jit-internals.md
+++ b/docs/reference/runtime/jit-internals.md
@@ -1,0 +1,78 @@
+# JIT Internals
+
+Both `eshkol-run -r`/`-e` and `eshkol-repl` run code in-process through an LLVM
+ORC JIT. This page documents the parts a user needs to understand and control:
+the persistent **run cache**, the **stdlib object cache**, and platform-specific
+**code-model** behavior.
+
+## Run cache (`-r`)
+
+When `ESHKOL_JIT_CACHE` is enabled (the default), `eshkol-run -r <file>` compiles
+the file once to a standalone native binary, stores it, and on subsequent runs
+re-execs the cached binary — turning repeat `-r` invocations into near-instant
+launches.
+
+- **Location**: `ESHKOL_JIT_CACHE_DIR`, else `$XDG_CACHE_HOME/eshkol/jit` /
+  `$HOME/.cache/eshkol/jit` (Unix), `%LOCALAPPDATA%\eshkol\jit` (Windows), else a
+  temp dir. Cached binaries are named `run-<key><exe-suffix>`.
+- **Cache key / invalidation**: a SHA-256 over a schema tag, the canonical source
+  path **and source bytes**, the Eshkol version, the LLVM version, the
+  `eshkol-run` binary fingerprint (size + mtime), the relevant flags
+  (`--no-stdlib`, `--strict-types`, `--unsafe`, `-O`, `--target`), the
+  `stdlib.bc`/`stdlib.o` fingerprints, and all include/lib/linked-lib flags. Any
+  change to any of these misses the cache and recompiles.
+- **Bypass**: the cache is skipped when disabled, when the source uses `eval` or
+  `compile` (these need the in-process JIT bridge that a plain AOT binary lacks),
+  when the self path can't be found, or when the cache dir can't be created.
+- **Pruning**: entries older than 30 days are removed, then the oldest are
+  evicted until the cache is ≤ 1 GiB.
+- **Tracing**: `ESHKOL_JIT_CACHE_TRACE=1` prints `[jit-cache] hit|miss|bypass`
+  to stderr.
+- Cached binaries inherit the parent's actually-loaded library directories on
+  their library search path so they can find `libLLVM` etc.
+
+## Stdlib object cache
+
+The standard library is ~55 MB of IR. Compiling it through SelectionDAG on every
+launch cost ~58 s. Instead, the JIT SelectionDAG-compiles the stdlib to an object
+file **exactly once** — keyed on the `stdlib.bc` content hash plus the process
+triple (`stdlib-jit-v2-<hash>-<triple>.o`) — using the JIT's exact
+`TargetMachine` configuration (host CPU, PIC, `CodeModel::Large`,
+`OptLevel::None`, per-function/per-data sections). Later runs `addObjectFile` the
+cached object, skipping IR parse/clone/SelectionDAG entirely. It is emitted with
+`FunctionSections`/`DataSections` so the JIT linker can insert range-extension
+stubs. This is why warm `-r`/REPL startup is fast (~2-3 s) despite the stdlib
+size.
+
+> The `OptLevel::None` and exact ABI match are deliberate: an earlier mismatch
+> produced 3-argument struct corruption. Do not "optimize" the stdlib object
+> emission without re-checking the ABI.
+
+## Large code model & arm64 Branch26 veneer
+
+The stdlib (~58 MB of IR) can be JIT-linked more than 128 MB away from runtime
+symbols, exceeding the AArch64 `Branch26` (`bl`, ±128 MB) range. Two mechanisms
+handle this:
+
+1. The JIT sets `CodeModel::Large` so calls are emitted as far calls
+   (`movz`/`movk` + `blr`). This fixed a regression where the growing stdlib
+   broke *all* `-r` on arm64 (even `(+ 2 3)`) while AOT stayed fine.
+2. On ELF/COFF arm64 the JIT installs a `Branch26RangeExtensionPlugin` on the
+   JITLink object-linking layer that veneers every out-of-range Branch26 edge
+   through an inline absolute-jump stub. It is a no-op off arm64 and on Mach-O
+   (where `CodeModel::Large` already emits correct far calls). Disable it with
+   `ESHKOL_JIT_NO_BRANCH26_VENEER=1`.
+
+## Compile threads
+
+`ESHKOL_JIT_COMPILE_THREADS` sets the ORC compile-thread count (default
+`hardware_concurrency()/2`, clamped to [1,16]; accepts 1-64). Higher counts
+reduce the materialization-lock contention that otherwise serializes
+`parallel-map` workers behind a single compile thread — at the cost of memory
+(each thread holds its own `LLVMContext` and a cloned module). See
+[parallelism](parallelism.md).
+
+## Related
+
+- [Environment variables](environment-variables.md)
+- [`eshkol-run`](eshkol-run.md) / [`eshkol-repl`](eshkol-repl.md)

--- a/docs/reference/runtime/memory-model.md
+++ b/docs/reference/runtime/memory-model.md
@@ -1,0 +1,109 @@
+# Memory Model — Tagged Values, Arenas, and Regions
+
+Eshkol uses **arena (region-based) memory management**, not a garbage collector.
+Allocation is O(1) bump-pointer; reclamation is bulk and deterministic at region
+exit. This is a deliberate design choice for real-time, financial, and embedded
+workloads where latency predictability matters — Eshkol will never have a GC.
+
+## Tagged values (16 bytes)
+
+Every Eshkol value is a fixed-width tagged value (`inc/eshkol/eshkol.h`):
+
+```c
+typedef struct eshkol_tagged_value {
+    uint8_t  type;      // eshkol_value_type_t
+    uint8_t  flags;     // exactness + other flags
+    uint16_t reserved;
+    union { int64_t int_val; double double_val; uint64_t ptr_val; uint64_t raw_val; } data;
+} eshkol_tagged_value_t;   // 16 bytes (asserted <= 16)
+```
+
+The layout is `{type:8, flags:8, reserved:16, data:64}`; natural alignment pads
+the struct to 16 bytes. A cons cell stores two full 16-byte tagged values (car,
+cdr). Type tags include int, double, bool, char, complex, heap-ptr, logic-var,
+dual-number, etc.; the `flags` byte carries exactness for the numeric tower.
+
+Heap objects (vectors, tensors, strings, records) are prefixed with an 8-byte
+`eshkol_object_header_t` that records a subtype and flags — the value's `data`
+field is a pointer to the payload after the header.
+
+## Arena allocator
+
+The arena API lives in `lib/core/arena_memory.h` (impl in `lib/core/`).
+
+| Function | Purpose |
+|----------|---------|
+| `arena_create(block_size)` | New growable arena |
+| `arena_create_threadsafe(size)` | Mutex-guarded arena (the global arena) |
+| `arena_create_bounded(capacity)` | Single fixed block, no-grow (embedded seam); returns NULL on overflow |
+| `arena_allocate(a, n)` / `_aligned` / `_zeroed` | Bump-pointer allocation |
+| `arena_allocate_with_header(a, n, subtype, flags)` | Allocate a header'd heap object |
+| `arena_push_scope(a)` / `arena_pop_scope(a)` | LIFO sub-scope save/restore |
+| `arena_reset(a)` | Reset to empty |
+| `arena_destroy(a)` | Free the arena |
+
+### Hybrid arena model
+
+- A single **global arena** (created at 64 KiB, thread-safe) backs the main
+  thread.
+- Each **parallel worker** gets its own **per-thread arena** (1 MB block, lazily
+  allocated) via `arena_create_thread_local` — zero cross-thread contention.
+  `arena_merge_to_parent` publishes results back.
+
+## Regions and `with-region`
+
+Regions are lexically-scoped arenas layered on top of the allocator
+(`lib/core/runtime_regions.cpp`). A thread-local region stack tracks the active
+region; allocations route to the current region's arena and are reclaimed when
+the region exits.
+
+### Surface syntax
+
+```scheme
+(with-region body ...)              ; anonymous region
+(with-region 'name body ...)        ; named region
+(with-region ('name size) body ...) ; named region + size hint (bytes)
+```
+
+At least one body expression is required. The value of the last body expression
+is returned; because the region's arena is freed on exit, a returned heap value
+is **deep-copied out** into the parent/global arena so it survives (the "escape"
+mechanism). The compiler emits `region_create` → `region_push` → *body* →
+`region_pop`; `region_pop` destroys the region arena, reclaiming everything
+allocated inside.
+
+```scheme
+;; Allocations inside the body are freed at region exit; the result escapes.
+(define total
+  (with-region ('scratch 65536)
+    (let loop ((i 0) (acc 0))
+      (if (= i 1000000)
+          acc
+          (loop (+ i 1) (+ acc i))))))
+```
+
+### Region reclamation fix (PR #81 / ESH-0039)
+
+Before this fix, `with-region` reclaimed **nothing**: the LLVM backend emitted
+every allocation against the single global-arena global variable, so a body's
+cons/vector/closure/tape allocations landed in the never-freed global arena while
+`region_pop` freed an empty region. Long-running loops grew RSS unboundedly
+(~4 GB/epoch → OOM). The fix routes all body allocations through the region arena
+by swapping the arena slot on region entry and restoring it after `region_pop`
+(all ~200 allocation sites now target the region arena transparently, funneled
+through `currentArenaPtr()`; `arena_push_scope`/`pop_scope` honor the same slot).
+Boundary preservation: objects created *outside* a region record their `home_arena`
+so they survive `region_pop` even if mutated inside it (e.g. a hash table resized
+inside a region re-allocates its backing arrays in its home arena). Measured: peak
+RSS over 200k iterations dropped from ~3153 MB to ~42 MB.
+
+> **Known follow-up:** per-thread sub-arena routing for parallel workers in the
+> JIT codegen path is deferred — it requires making the shared arena slot
+> thread-local, a broader ABI change.
+
+## Stack and depth limits
+
+- Region stack depth is bounded (`MAX_REGION_DEPTH`); overflow raises an error.
+- The AD tape stack (`MAX_TAPE_DEPTH = 32`) is thread-local.
+- See [environment variables](environment-variables.md) for `ESHKOL_MAX_HEAP`,
+  `ESHKOL_MAX_STACK`, `ESHKOL_STACK_SIZE`, and `ESHKOL_WORKER_STACK_BYTES`.

--- a/docs/reference/runtime/parallelism.md
+++ b/docs/reference/runtime/parallelism.md
@@ -1,0 +1,85 @@
+# Parallelism & Threading
+
+Eshkol provides data-parallel primitives backed by a work-stealing thread pool
+with per-thread arenas. The compiled binary contains both parallel and
+sequential code paths; the runtime chooses at dispatch time and can be forced to
+run sequentially.
+
+## Primitives
+
+| Form | Signature | Returns |
+|------|-----------|---------|
+| `parallel-map` | `(parallel-map fn list)` | list of `(fn item)` |
+| `parallel-fold` | `(parallel-fold fn init list)` | folded value (`(fn acc item)`); sequential for non-associative ops |
+| `parallel-filter` | `(parallel-filter pred list)` | filtered list |
+| `parallel-execute` | `(parallel-execute thunks)` | runs a set of thunks, returns their results |
+
+### Futures / promises
+
+| Form | Purpose |
+|------|---------|
+| `(future expr)` | Spawn a lazy future; returns a handle |
+| `(future-ready? h)` | Non-blocking readiness check |
+| `(force x)` | Force a future **or** an R7RS promise (`delay`) to its value |
+
+`force` handles both R7RS promises (heap `PROMISE` subtype) and lazy futures.
+
+Parallel workers are runtime-registered by the stdlib; if the stdlib is not
+loaded you get "workers not registered (stdlib not loaded?)". A lazy `dlsym`
+fallback resolves them when possible.
+
+## Thread pool
+
+- **Threads**: default `std::thread::hardware_concurrency()` (fallback 4).
+- **Per-thread arenas**: each worker allocates into its own 1 MB thread-local
+  arena — zero contention (see [memory model](memory-model.md)).
+- **Work-stealing**: on by default; each worker has its own deque (4096 initial
+  capacity) with epoch-based reclamation and randomized victim selection. Set
+  `ESHKOL_DISABLE_WORK_STEALING` to fall back to the legacy shared queue.
+- **Worker stack**: 16 MB per worker by default; override with
+  `ESHKOL_WORKER_STACK_BYTES` (floored at `PTHREAD_STACK_MIN`).
+
+## Serialized state pattern
+
+Parallel work must be **read-only over shared state**. Workers execute closure
+bytecode in isolated VM/arena snapshots and publish returned values back to the
+main heap; **any closure that may mutate shared VM state is run through a
+serialized fallback on the main VM.** In the native (LLVM) path the same
+discipline appears as result-publication-by-pointer: each task writes its result
+into a pre-allocated slot (`result_ptr`) with no arena allocation during the
+parallel phase — arena allocation happens only in the sequential result-assembly
+phase afterward.
+
+Practical rule: make the mapped/folded function pure. Thread an accumulator as a
+loop variable rather than `set!`-ing a shared cell from inside parallel work.
+
+## JIT warmup
+
+Under the JIT, `parallel-map` runs `item[0]` on the calling thread first to force
+ORC materialization of the whole transitive symbol set before dispatching workers
+— otherwise every worker races on ORC's single materialization lock. Skip it with
+`ESHKOL_PARALLEL_NO_WARMUP=1`. Raising `ESHKOL_JIT_COMPILE_THREADS` also relieves
+that lock contention (see [JIT internals](jit-internals.md)).
+
+## Controlling parallelism
+
+| Variable | Effect |
+|----------|--------|
+| `ESHKOL_PARALLEL_DISABLE=1` | Force sequential inlined loop |
+| `ESHKOL_PARALLEL_ENABLE=0` | Legacy disable |
+| `ESHKOL_PARALLEL_NO_WARMUP=1` | Skip the ORC warmup pass |
+| `ESHKOL_DISABLE_WORK_STEALING` | Use the legacy queue |
+| `ESHKOL_WORKER_STACK_BYTES` | Per-worker stack size |
+| `ESHKOL_DEBUG_PAR` | Print pool/task metrics |
+
+## Known limitation — AD mode flag is a global
+
+Automatic-differentiation state is *mostly* thread-isolated: the AD tape stack
+(`__ad_tape_stack`, depth 32) is `thread_local`. However the `__ad_mode_active`
+flag is a plain global, not thread-local, so one worker enabling AD mode can be
+observed by another worker. **Do not run automatic differentiation
+(`gradient`/`jacobian`/etc.) inside parallel workers** — compute gradients on the
+main thread and parallelize only the pure numeric work.
+
+For measured speedups and tuning, see
+`docs/PARALLEL_MAP_PERFORMANCE_ANALYSIS.md`.


### PR DESCRIPTION
Adds the RUNTIME / AGENT-FFI / TOOLING reference documentation for v1.3.0-evolve. Every flag and module was verified by running `eshkol-run`, `eshkol-repl`, and `eshkol-vm-standalone`; all code examples were executed.

## New: docs/reference/runtime/
- **eshkol-run.md** — complete CLI: `-r`/`-e`/`-o`/`-c`/`--emit-object`/`-s`/`-w`/`-B`/`--dump-ast`/`--dump-ir`/`-I`/`-l`/`-L`/`-O`/`--target`/`--profile`/`--require-vm-entry[-zero-arg]`/`--debug-info`/`--strict-types`/`--unsafe`/`--no-stdlib`.
- **eshkol-repl.md** — REPL + `--machine` warm-worker **EREPL** protocol (READY/DONE/FAIL framing).
- **eshkol-vm-standalone.md** — bytecode VM, ESKB binary format, `--emit-eskb`, entry-admission gates.
- **environment-variables.md** — full user-facing set (JIT/run cache, search paths, resource limits, parallelism, backends, subprocess sandbox).
- **memory-model.md** — 16-byte tagged values, arena allocator, hybrid global/per-thread model, `with-region` + PR #81 reclamation fix.
- **parallelism.md** — `parallel-map`/`-fold`/`-filter`/`-execute`, `future`/`force`, work-stealing pool, serialized-state pattern, AD-mode-flag limitation.
- **jit-internals.md** — run cache (key/invalidation/pruning), stdlib object cache, Large code model + arm64 Branch26 veneer, compile threads.

## New: docs/reference/agent/
- **ffi.md** — `extern`/`:real` syntax, type→C-ABI mapping, tagged-value boundary conversion, transitive `requires_agent_ffi` AOT linking vs JIT resolution.
- **http.md**, **sqlite.md**, **subprocess.md** (#94 ownership), **crypto.md**, **eagle.md** (`qllm_ffi_linear_*`, #104), **memory-faculty.md**, **platform-utilities.md** (regex/glob/fs-watch/keychain/terminal/git/layout), **capabilities.md**.

## Extended: docs/platform/
- **CI_LANES.md** — the 14-lane CI matrix (11 unix + 3 windows), lane groups, gotchas.
- **BUILD_NOTES.md** — per-platform build (macOS/Linux/Windows x64 MSYS2/windows-arm64 cross incl. PR #77), NixOS/Jetson, LLVM 21, GPU/backend gates.

## Discrepancies found (reported, not fixed)
- Binary reports `v1.2.4-scale`; campaign targets v1.3.0-evolve.
- `eshkol-run --help` says `-e` prints the result, but bare values are not auto-printed (must use `display`).
- Top-level `README.md` Prerequisites still lists LLVM 17 in one place; the authoritative requirement is LLVM 21 (CI, cmake/LLVMToolchain.cmake).
- `agent.http` `http-post` currently forwards only `Authorization`/`x-api-key` headers (routes via JSON FFI); SSE `http-stream-next` returns a placeholder.