### PR TITLE
docs(reference): complete language-core reference (v1.3.0)

### DIFF
--- a/docs/reference/language/INDEX.md
+++ b/docs/reference/language/INDEX.md
@@ -1,0 +1,58 @@
+# Eshkol Language Core Reference
+
+Complete reference for the Eshkol language core, targeting **v1.3.0-evolve**.
+
+Every example in these documents was executed against a fresh build of the compiler
+(`cmake --build build --target eshkol-run stdlib`) and the shown output is the real
+program output. Examples are run with the JIT runner:
+
+```sh
+eshkol-run -r file.esk        # JIT-run a file
+eshkol-run -e '(display (+ 2 3))'   # JIT-evaluate one expression
+eshkol-run file.esk -o binary # ahead-of-time (AOT) compile to a native binary
+```
+
+Unless noted otherwise, behaviour described here is that of the **native code path**
+(the LLVM JIT used by `-r`, and AOT). Where the separate bytecode VM backend differs,
+it is called out explicitly.
+
+## Contents
+
+| # | Area | File |
+|---|------|------|
+| 1 | Definitions, `lambda`, `let`-family, `letrec`, named `let`, `begin` | [special-forms.md](special-forms.md) |
+| 2 | `set!`, closure capture, lexical scope, shadowing | [binding-mutation-and-scope.md](binding-mutation-and-scope.md) |
+| 3 | `quote`, `quasiquote`, `unquote`, `unquote-splicing` | [quote-and-quasiquote.md](quote-and-quasiquote.md) |
+| 4 | Booleans and type predicates | [booleans-and-predicates.md](booleans-and-predicates.md) |
+| 5 | `if`, `cond`, `case`, `when`, `unless`, `do`, `and`, `or` | [control-flow.md](control-flow.md) |
+| 6 | Tail-call guarantees | [tail-calls.md](tail-calls.md) |
+| 7 | `raise`, `guard`, `error`, `with-exception-handler` | [error-handling.md](error-handling.md) |
+| 8 | `call/cc`, `dynamic-wind` | [continuations.md](continuations.md) |
+| 9 | `match` | [pattern-matching.md](pattern-matching.md) |
+| 10 | `values`, `call-with-values`, `let-values` | [multiple-values.md](multiple-values.md) |
+| 11 | Function parameters: variadic, keyword args, `apply` | [functions-and-parameters.md](functions-and-parameters.md) |
+| 12 | Modules: `require`/`provide`, `load`, `define-library`/`import` | [modules.md](modules.md) |
+| 13 | Characters, strings, symbols, string interpolation `~{}` | [strings-chars-symbols.md](strings-chars-symbols.md) |
+| 14 | Numeric tower: exact/inexact/rational/bignum/complex | [numeric-tower.md](numeric-tower.md) |
+| 15 | Capability policy (`core.capabilities`) | [capabilities.md](capabilities.md) |
+
+## Known-issue conventions
+
+Open defects are tracked in the project ledger (`.swarm/tasks/ESH-*.json`). Where a
+form has a documented defect, the reference links it inline as, e.g., **ESH-0104**.
+These are documented honestly as *Known Issues* — they are real, reproducible, and not
+worked around in the examples.
+
+Consolidated list of language-core known issues referenced here:
+
+| Ledger | Summary |
+|--------|---------|
+| ESH-0090 | A user `(define (raise …) …)` cannot shadow the builtin `raise`. |
+| ESH-0092 | Top-level globals are emitted as raw C symbols; a name colliding with libc (e.g. `free`) crashes at teardown (SIGBUS). |
+| ESH-0104 | Long forms `(quasiquote …)`/`(unquote …)`/`(unquote-splicing …)` are not wired; only the reader sugar ``` ` ``` `,` `,@` evaluate. |
+| ESH-0105 | Exact rational arithmetic silently degrades to `double` (or `0`) once a bignum operand is involved. |
+| ESH-0106 | `'sym` reader sugar inside a `guard` form (clause body or `raise` argument) is compiled as a variable reference. |
+| ESH-0107 | Nested `quasiquote` (level ≥ 2) collapses to `()`. |
+| ESH-0108 | stdlib `length`/`filter` are non-tail-recursive; they crash (SIGILL) on very large lists. |
+| ESH-0101 / ESH-0102 | Differential findings around `guard` value corruption / optimization-level-dependent crashes. |
+| — | Mutual tail recursion is **not** optimized; ping-pong recursion crashes around 500k depth (self tail recursion is fully optimized). |

--- a/docs/reference/language/binding-mutation-and-scope.md
+++ b/docs/reference/language/binding-mutation-and-scope.md
@@ -1,0 +1,109 @@
+# Binding, Mutation, and Scope
+
+## Lexical scope
+
+Eshkol is lexically scoped. A free variable in a `lambda` body refers to the
+binding in the closest enclosing lexical scope at the point the `lambda` is
+written, and that binding is *captured* by the resulting closure.
+
+```scheme
+(define (make-adder n) (lambda (x) (+ x n)))
+(define add5 (make-adder 5))
+(define add10 (make-adder 10))
+(display (add5 1)) (newline)
+(display (add10 1)) (newline)
+```
+```
+6
+11
+```
+Each call to `make-adder` produces a closure over its own `n`.
+
+## `set!`
+
+```
+(set! var value)
+```
+Mutates an existing binding. `set!` does not create a binding — the variable must
+already be bound in some enclosing scope. Returns an unspecified value; use it for
+effect.
+
+```scheme
+(define (make-counter)
+  (let ((n 0))
+    (lambda () (set! n (+ n 1)) n)))
+(define c1 (make-counter))
+(define c2 (make-counter))
+(display (c1)) (display " ") (display (c1)) (display " ") (display (c2)) (newline)
+```
+```
+1 2 1
+```
+`c1` and `c2` each own their own `n`.
+
+## Shared mutable capture
+
+When two or more closures capture the *same* mutable variable, they share one
+cell: a `set!` through one closure is visible through the others. This memory
+model is guaranteed (the fix for the multi-closure shared-capture family, ESH-0074,
+made this reliable).
+
+```scheme
+(define (make-pair)
+  (let ((v 0))
+    (list (lambda () v)          ; reader
+          (lambda (x) (set! v x))))) ; writer
+(define p (make-pair))
+((cadr p) 42)      ; write through the writer
+(display ((car p))) (newline)   ; read through the reader
+```
+```
+42
+```
+
+The same guarantee holds for closures created in separate `letrec` activations —
+each activation gets its own shared cell, isolated from other activations
+(see the `counter-factory` example in
+[special-forms.md](special-forms.md#per-activation-instance-isolation-fixed-esh-0075)).
+
+## Shadowing
+
+User bindings shadow one another normally following lexical scope. There are two
+documented exceptions where shadowing does **not** work as expected:
+
+### Known issue — `raise` cannot be shadowed (ESH-0090)
+
+A user definition named `raise` does not intercept calls; they still reach the
+builtin R7RS exception primitive.
+
+```scheme
+(define (raise x) (list 'my-raise x))
+(display (raise 42)) (newline)
+```
+```
+Unhandled exception: user exception
+```
+The call hit the builtin `raise` (which threw), not the user procedure. Choose a
+different name (e.g. `raise*`) until this is fixed.
+
+### Known issue — top-level names colliding with libc symbols (ESH-0092)
+
+Top-level `define`d globals are emitted as raw C symbols. A top-level name that
+matches a libc symbol corrupts that symbol. The program can appear to work and
+then crash at teardown.
+
+```scheme
+(define free 0)
+(set! free (+ free 1))
+(display free) (newline)
+```
+```
+1
+
+[Eshkol] fatal signal: SIGBUS (bus error) — terminating; …
+```
+The displayed value `1` is correct, but the process dies with SIGBUS because
+`free` aliases libc's `free`. The related **ESH-0103** covers a global named `log`
+whose `set!` is silently lost on cached-JIT/AOT. Avoid libc names
+(`free`, `log`, `read`, `write`, `open`, `time`, `exit`, …) for top-level globals;
+locals inside a `let`/`lambda` are unaffected.

--- a/docs/reference/language/booleans-and-predicates.md
+++ b/docs/reference/language/booleans-and-predicates.md
@@ -1,0 +1,92 @@
+# Booleans and Predicates
+
+## Boolean literals
+
+`#t` (true) and `#f` (false). In conditional contexts, **every value except `#f`
+is truthy** — including `0`, `""`, and `'()`.
+
+```scheme
+(display (list #t #f)) (newline)
+(display (if 0 'truthy 'falsy)) (newline)   ; 0 is truthy
+```
+```
+(#t #f)
+truthy
+```
+
+## `not`
+
+```
+(not obj)   ; => #t iff obj is #f, else #f
+```
+```scheme
+(display (not #f)) (newline)
+(display (not 0)) (newline)
+```
+```
+#t
+#f
+```
+
+## Booleans are first-class
+
+Booleans can be stored, passed, returned, and mapped over like any other value.
+
+```scheme
+(define b #t)
+(display (if b 'yes 'no)) (newline)
+(display (map (lambda (v) (not v)) (list #t #f #t))) (newline)
+(display (eq? #t #t)) (newline)
+```
+```
+yes
+(#f #t #f)
+#t
+```
+
+## Type predicates
+
+The core R7RS type predicates are available and each returns `#t`/`#f`. They are
+LLVM-inline builtins in the native path.
+
+| Predicate | True when the argument is… |
+|-----------|----------------------------|
+| `boolean?` | a boolean |
+| `null?` | the empty list `'()` |
+| `pair?` | a cons pair |
+| `list?` | a proper list |
+| `number?` | any number |
+| `integer?` | an integer |
+| `real?` | a real number |
+| `rational?` | a rational |
+| `complex?` | a complex number |
+| `string?` | a string |
+| `char?` | a character |
+| `symbol?` | a symbol |
+| `procedure?` | a procedure |
+| `vector?` | a vector |
+
+```scheme
+(display (list (null? '()) (pair? '(1)) (number? 3)
+               (string? "a") (symbol? 'x) (procedure? car))) (newline)
+```
+```
+(#t #t #t #t #t #t)
+```
+
+## Equality
+
+- `eq?` — identity / pointer equality (interned symbols, small integers, booleans).
+- `eqv?` — like `eq?` but reliable across numbers and characters.
+- `equal?` — deep structural equality (recurses into pairs, strings, vectors).
+
+```scheme
+(display (eq? 'a 'a)) (newline)
+(display (equal? '(1 2 3) (list 1 2 3))) (newline)
+(display (equal? "abc" "abc")) (newline)
+```
+```
+#t
+#t
+#t
+```

--- a/docs/reference/language/capabilities.md
+++ b/docs/reference/language/capabilities.md
@@ -1,0 +1,95 @@
+# Capability Policy (`core.capabilities`)
+
+Eshkol has a process-local capability policy that gates host-facing operations
+(file, environment, subprocess, shell, network). It is provided by the
+`core.capabilities` module.
+
+```scheme
+(require core.capabilities)
+```
+
+## Default behaviour
+
+The default policy is **inactive** (`#f`): no checks are performed and existing
+programs run unchanged. Installing an allow-list makes the policy **active**, and
+from then on every capability *not* in the list is denied by default.
+
+Core hosted capability symbols:
+
+| Symbol | Governs |
+|--------|---------|
+| `file-read` | reading files |
+| `file-write` | writing/creating/deleting files |
+| `env-read` | reading environment variables (`get-environment-variable`) |
+| `env-write` | setting environment variables |
+| `subprocess` | spawning subprocesses |
+| `shell` | shell execution |
+| `network` | network access |
+
+## API
+
+| Procedure | Effect |
+|-----------|--------|
+| `(capability-install-policy! allow-list)` | Activate a policy from a list of capability **symbols**. Errors if the argument is not a list of symbols. |
+| `(capability-clear-policy!)` | Deactivate the policy; checks allow by default again. |
+| `(capability-policy)` | Return the current allow-list, or `#f` if inactive. |
+| `(capability-policy-active?)` | `#t` iff a policy is currently active. |
+| `(capability-allowed? cap)` | `#t` if `cap` is permitted under the current policy (always `#t` when inactive). |
+| `(capability-require! cap)` | Return `#t` if allowed; otherwise `raise` an error. |
+
+## Example
+
+```scheme
+(require core.capabilities)
+(display (capability-policy-active?)) (newline)   ; #f initially
+(capability-install-policy! '(file-read env-read))
+(display (capability-policy-active?)) (newline)   ; now active
+(display (capability-allowed? 'file-read)) (newline)
+(display (capability-allowed? 'network)) (newline)
+(capability-clear-policy!)
+(display (capability-allowed? 'network)) (newline)  ; allowed again
+```
+```
+#f
+#t
+#t
+#f
+#t
+```
+
+## The `getenv` / `env-read` story
+
+`get-environment-variable` (alias `getenv`) is gated on the `env-read` capability.
+The gate is enforced in the runtime for both the JIT and AOT paths.
+
+With no policy, it reads normally:
+```scheme
+(display (get-environment-variable "HOME")) (newline)   ; => the value
+```
+
+Under an **active** policy that does not grant `env-read`, the read is denied:
+the runtime prints a diagnostic to stderr and the call returns `#f`; execution
+continues (it is not a catchable exception).
+```scheme
+(require core.capabilities)
+(capability-install-policy! '(file-read))   ; env-read NOT granted
+(display (get-environment-variable "HOME")) (newline)
+(display "after") (newline)
+```
+```
+capability denied: env-read
+#f
+after
+```
+
+Granting `env-read` restores access:
+```scheme
+(require core.capabilities)
+(capability-install-policy! '(env-read))
+(display (get-environment-variable "HOME")) (newline)   ; => the value
+```
+
+File operations (`file-read`/`file-write`), subprocess, shell, and network entry
+points follow the same pattern: when a policy is active and the relevant
+capability is absent, the operation is denied and returns a benign value rather
+than performing the effect.

--- a/docs/reference/language/continuations.md
+++ b/docs/reference/language/continuations.md
@@ -1,0 +1,89 @@
+# Continuations: `call/cc` and `dynamic-wind`
+
+## `call/cc` / `call-with-current-continuation`
+
+```
+(call/cc proc)
+(call-with-current-continuation proc)   ; same thing
+```
+Captures the current continuation and passes it as a one-argument escape
+procedure `k` to `proc`. Calling `(k v)` returns `v` to the point where `call/cc`
+was invoked.
+
+### Escape (upward) continuations
+
+```scheme
+(display (call/cc (lambda (k) (+ 1 (k 42))))) (newline)
+(display (+ 1 (call-with-current-continuation (lambda (k) (k 10) 999)))) (newline)
+```
+```
+42
+11
+```
+In the first line, `(k 42)` abandons the pending `(+ 1 …)` and returns `42`
+directly. In the second, `(k 10)` escapes before `999` is reached, so the outer
+`(+ 1 …)` sees `10`.
+
+### Re-invocable (multi-shot) continuations
+
+A captured continuation can be stored and invoked more than once — it is a full
+re-entrant continuation, not merely a one-shot escape.
+
+```scheme
+(define k #f)
+(define n 0)
+(display (+ 1 (call/cc (lambda (c) (set! k c) 0))))
+(newline)
+(set! n (+ n 1))
+(if (< n 3) (k n))     ; re-invoke the saved continuation
+(display "done") (newline)
+```
+```
+1
+2
+3
+done
+```
+Re-invoking `k` re-enters the `(+ 1 …)` context repeatedly with successive values,
+demonstrating multi-shot behaviour.
+
+### Known limitation — deep CPS chains (ESH-0080)
+
+Very deep continuation-passing chains (e.g. the SICP ch4 `amb` nondeterministic
+search) can crash with SIGILL beyond a moderate depth (reported around n ≳ 16 for
+that workload). Ordinary escape and modest re-entrant use are fine; do not rely on
+extremely deep continuation chaining.
+
+## `dynamic-wind`
+
+```
+(dynamic-wind before thunk after)
+```
+Calls `before`, then `thunk`, then `after`. `after` is guaranteed to run when
+control leaves `thunk` — including when a continuation escapes out of it.
+
+```scheme
+(dynamic-wind
+  (lambda () (display "before "))
+  (lambda () (display "during "))
+  (lambda () (display "after ")))
+(newline)
+```
+```
+before during after 
+```
+
+`after` runs even on a non-local exit via a continuation:
+
+```scheme
+(call/cc (lambda (k)
+  (dynamic-wind
+    (lambda () (display "in "))
+    (lambda () (k 'escaped))    ; escape out of the middle thunk
+    (lambda () (display "out ")))))
+(newline)
+```
+```
+in out 
+```
+The `out` guard runs during the escape.

--- a/docs/reference/language/control-flow.md
+++ b/docs/reference/language/control-flow.md
@@ -1,0 +1,118 @@
+# Control Flow
+
+## `if`
+
+```
+(if test consequent)             ; one-armed
+(if test consequent alternate)   ; two-armed
+```
+Every value except `#f` is truthy. A one-armed `if` whose test is false returns an
+unspecified value.
+
+```scheme
+(if (> 3 2) (display "one-armed-if\n"))
+(display (if (= 1 2) 'a 'b)) (newline)
+```
+```
+one-armed-if
+b
+```
+
+## `cond`
+
+```
+(cond (test body …) …
+      (else body …))
+```
+Evaluates each `test` in order; runs the body of the first true clause. `else` is
+the catch-all.
+
+```scheme
+(display (cond ((= 1 2) 'a) ((= 1 1) 'b) (else 'c))) (newline)
+```
+```
+b
+```
+
+### Known issue — `=>` clause not supported
+
+The R7RS `(test => proc)` clause form is **not** supported; `=>` is parsed as a
+variable reference.
+
+```scheme
+(display (cond (42 => (lambda (v) (* v 2))) (else 'z))) (newline)
+```
+```
+error: Undefined variable: =>
+```
+**Workaround:** bind the test value explicitly:
+`(let ((v 42)) (cond (v ((lambda (x) (* x 2)) v)) (else 'z)))`.
+
+## `case`
+
+```
+(case key ((datum …) body …) …
+          (else body …))
+```
+Compares `key` (with `eqv?`) against each list of data.
+
+```scheme
+(display (case 3 ((1 2) 'low) ((3 4) 'mid) (else 'hi))) (newline)
+```
+```
+mid
+```
+
+The `=>` clause form of `case` is likewise **not supported** (same limitation as
+`cond`).
+
+## `when` / `unless`
+
+```
+(when test body …)     ; run body if test is true
+(unless test body …)   ; run body if test is false
+```
+```scheme
+(when (> 3 2) (display "when-yes") (newline))
+(unless (> 2 3) (display "unless-yes") (newline))
+```
+```
+when-yes
+unless-yes
+```
+
+## `do`
+
+```
+(do ((var init step) …)
+    (test result …)
+  command …)
+```
+Iterates: each `var` starts at `init` and is updated to `step` each pass; when
+`test` becomes true the `result` expressions run and the last is returned.
+
+```scheme
+(do ((i 0 (+ i 1)) (s 0 (+ s i))) ((= i 5) (display s) (newline)))
+```
+```
+10
+```
+
+## `and` / `or`
+
+```
+(and expr …)   ; left-to-right; returns first #f, else the last value; (and) => #t
+(or  expr …)   ; left-to-right; returns first truthy value, else #f; (or) => #f
+```
+Both short-circuit.
+
+```scheme
+(display (and 1 2 3)) (newline)
+(display (or #f #f 5)) (newline)
+(display (and)) (display " ") (display (or)) (newline)
+```
+```
+3
+5
+#t #f
+```

--- a/docs/reference/language/error-handling.md
+++ b/docs/reference/language/error-handling.md
@@ -1,0 +1,125 @@
+# Error Handling
+
+## `raise`
+
+```
+(raise obj)
+```
+Raises `obj` as an exception. Any value may be raised — a symbol, number, string,
+list, or an error object built with `error`.
+
+```scheme
+(define sym 'boom)
+(display (guard (e (#t (list 'caught e))) (raise sym))) (newline)
+(display (guard (e (#t (list 'caught e))) (raise 42)))  (newline)
+(display (guard (e (#t (list 'caught e))) (raise (list 'my-error "detail")))) (newline)
+```
+```
+(caught boom)
+(caught 42)
+(caught (my-error detail))
+```
+
+## `guard`
+
+```
+(guard (var clause …) body …)
+```
+Evaluates `body`. If an exception is raised, `var` is bound to the raised object
+and the `clause`s are tried like a `cond` (each `(test result …)`, optional
+`else`). The value of the matching clause becomes the value of the `guard` form.
+
+```scheme
+(display (guard (e ((symbol? e) (list 'sym e))
+                   ((string? e) (list 'str e))
+                   (else (list 'other e)))
+  (raise "oops"))) (newline)
+```
+```
+(str oops)
+```
+
+### Known issue — `'sym` sugar inside `guard` (ESH-0106)
+
+Inside a `guard` form, the `'` reader sugar is compiled as a variable reference,
+both in clause bodies and in a `raise` argument.
+
+```scheme
+;; WRONG: 'boom is read as a variable
+(guard (e (#t e)) (raise 'boom))   ; => error: Undefined variable: boom
+```
+**Always use the explicit `(quote …)` form inside `guard`:**
+```scheme
+(display (guard (e (#t e)) (raise (quote boom)))) (newline)  ; => boom
+```
+
+### Known issues — differential `guard` findings (ESH-0101 / ESH-0102)
+
+The project's differential/adversarial harness has open findings around `guard`:
+value corruption across clause paths (ESH-0101) and an optimization-level-dependent
+crash when a displayed `guard` catching a `raise` is followed by a second `guard`
+form (ESH-0102, reported at `-O1`/`-O2`/`-O3`). Simple two-`guard` programs run
+correctly at `-O0`/JIT and in many `-O2` cases; treat heavy `guard` nesting under
+aggressive optimization as not-yet-hardened and test at your target `-O` level.
+
+## `error`
+
+```
+(error message irritant …)
+```
+Constructs and raises an error object carrying a message string and zero or more
+irritants. In the native code path the caught object is **opaque**: it can be
+caught and re-raised but prints as `#<exception>`.
+
+```scheme
+(display (guard (e (#t (list 'caught e))) (error "bad thing" 1 2))) (newline)
+```
+```
+(caught #<exception>)
+```
+
+### Known limitation — error-object accessors (native path)
+
+`error-object?`, `error-object-message`, and `error-object-irritants` are
+implemented in the **bytecode VM backend** but are **not available in the native
+LLVM path** (`-r` / AOT), where they report `Unknown function`. If you need to
+inspect message/irritants in native code, `raise` a structured value you control
+(e.g. `(raise (list 'my-error "message" irritants))`) and destructure it in the
+`guard` clause.
+
+## `with-exception-handler`
+
+```
+(with-exception-handler handler thunk)
+```
+Installs `handler` for the dynamic extent of `thunk`. This form **works** in the
+native path.
+
+```scheme
+(display
+  (with-exception-handler
+    (lambda (e) (display "handler ") 100)
+    (lambda () (+ 1 (raise-continuable 'warn)))))
+```
+The above uses `raise-continuable`, which is **not available** in the native path
+(`Unknown function`); it is VM-only. `with-exception-handler` combined with a plain
+`raise` (non-continuable, escaping) works in native code.
+
+## The capability-denied signal
+
+When a capability policy is active (see [capabilities.md](capabilities.md)),
+attempting a denied operation does not raise a catchable exception in the usual
+sense — the runtime prints a diagnostic to stderr and the operation returns a
+benign value (`#f`/null), letting the program continue.
+
+```scheme
+(require core.capabilities)
+(capability-install-policy! '(file-read))     ; env-read NOT allowed
+(display (get-environment-variable "HOME")) (newline)
+(display "after") (newline)
+```
+```
+capability denied: env-read
+#f
+after
+```

--- a/docs/reference/language/functions-and-parameters.md
+++ b/docs/reference/language/functions-and-parameters.md
@@ -1,0 +1,106 @@
+# Functions and Parameters
+
+See [special-forms.md](special-forms.md) for `define`/`lambda` basics. This page
+covers parameter list features and application.
+
+## Fixed-arity procedures
+
+```scheme
+(define (add a b) (+ a b))
+(display (add 3 4)) (newline)
+```
+```
+7
+```
+
+## Variadic (rest) parameters
+
+A dotted tail parameter collects any extra arguments into a list.
+
+```scheme
+(define (sum . args) (apply + args))
+(display (sum 1 2 3 4 5)) (newline)
+
+(define (f a b . rest) (list a b rest))
+(display (f 1 2 3 4 5)) (newline)
+```
+```
+15
+(1 2 (3 4 5))
+```
+
+A `lambda` whose entire formal list is a single symbol receives all arguments as
+one list:
+
+```scheme
+(display ((lambda args args) 1 2 3)) (newline)
+```
+```
+(1 2 3)
+```
+
+## `apply`
+
+```
+(apply proc arg … arg-list)
+```
+Calls `proc` with the leading args followed by the elements of the final list.
+
+```scheme
+(display (apply + 1 2 (list 3 4 5))) (newline)
+```
+```
+15
+```
+
+## Keyword arguments (`#:name`)
+
+Formals of the form `#:name binding` declare **keyword parameters**. Callers pass
+them as `#:name value`. Keyword arguments may appear in any order and mix with
+positional parameters and a rest parameter.
+
+```scheme
+(define (weighted x #:scale scale #:offset offset)
+  (+ (* x scale) offset))
+(display (weighted 10 #:offset 2 #:scale 4)) (newline)  ; reordered
+
+(define kw-lambda
+  (lambda (#:left left #:right right) (+ left right)))
+(display (kw-lambda #:right 23 #:left 19)) (newline)
+
+(define (mixed positional #:scale scale) (+ positional scale))
+(display (mixed 19 #:scale 23)) (newline)
+```
+```
+42
+42
+42
+```
+
+Keyword formals coexist with an explicit rest parameter:
+
+```scheme
+(define (explicit-rest positional #:scale scale . rest)
+  (+ (* positional scale) (length rest)))
+```
+
+### Keyword-argument limitations
+
+- **Keyword parameters are required.** There is no default-value syntax. Writing
+  `(define (g #:k (k "default")) …)` fails to parse:
+  `error: keyword formal requires a parameter name`. A caller that omits a
+  declared keyword gets a runtime error.
+- Each keyword formal is `#:kw name` — the keyword token immediately followed by
+  the local parameter name that receives its value.
+
+## Curried definition sugar is not supported
+
+`(define ((f x) y) …)` does not parse. Use an explicit returned `lambda`:
+
+```scheme
+(define (adder x) (lambda (y) (+ x y)))
+(display ((adder 3) 4)) (newline)
+```
+```
+7
+```

--- a/docs/reference/language/modules.md
+++ b/docs/reference/language/modules.md
@@ -1,0 +1,101 @@
+# Modules
+
+Eshkol supports two complementary module styles: a lightweight `provide`/`require`
+pair, and R7RS `define-library`/`import`. Both resolve module names to source
+files on a search path. `load` includes a file inline.
+
+Search path for module resolution:
+1. the current working directory,
+2. directories passed with `-I DIR`,
+3. the compiler's bundled `lib/` directory,
+4. entries in the `$ESHKOL_PATH` environment variable.
+
+## `provide` / `require`
+
+```
+(provide name …)     ; in the providing file: export these names
+(require module)      ; in the consuming file: load module and import its provides
+```
+A module name maps to a file path: `core.list.transform` → `core/list/transform.esk`,
+`greet` → `greet.esk`.
+
+`greet.esk`:
+```scheme
+(provide greet)
+(define (greet who) (string-append "Hello, " who))
+```
+`main.esk`:
+```scheme
+(require greet)
+(display (greet "World")) (newline)
+```
+Run with the directory on the search path:
+```sh
+eshkol-run -r main.esk -I .
+```
+```
+Hello, World
+```
+
+The standard library is required the same way:
+```scheme
+(require stdlib)                 ; whole standard library
+(require core.list.transform)   ; a single stdlib submodule (e.g. filter, map)
+(require core.capabilities)      ; capability policy API
+```
+
+## `define-library` / `export` / `import`
+
+```
+(define-library (name …)
+  (export name …)
+  (import lib …)     ; optional
+  (begin definition …))
+```
+`import` resolves a library name to a file the same way `require` does. A library
+`(geo)` is looked up as `geo.esk`; `(my math)` is looked up as `my/math.esk`.
+
+`geo.esk`:
+```scheme
+(define-library (geo)
+  (export area)
+  (begin (define (area r) (* 3 r r))))
+```
+`main.esk` (in the same directory):
+```scheme
+(import (geo))
+(display (area 2)) (newline)
+```
+```
+12
+```
+
+### Note — `define-library` and `import` in the same file
+
+`import` resolves from the **filesystem**, not from a `define-library` written
+earlier in the same file. Put a `define-library` in its own file and `import` it
+from another. (If you write both in one file, the `begin` body still executes and
+defines its names at top level, but the `import` line will report the module as not
+found on the path.)
+
+## `load`
+
+```
+(load "path.esk")
+```
+Reads and evaluates a file inline in the current top-level environment — no
+export/import boundary. Handy for scripts and REPL-style composition.
+
+`lib.esk`:
+```scheme
+(provide double)
+(define (double x) (* 2 x))
+```
+`main.esk`:
+```scheme
+(load "lib.esk")
+(display (double 21)) (newline)
+```
+```
+42
+```

--- a/docs/reference/language/multiple-values.md
+++ b/docs/reference/language/multiple-values.md
@@ -1,0 +1,58 @@
+# Multiple Values
+
+## `values`
+
+```
+(values obj …)
+```
+Produces zero or more values. A single-value `values` behaves like the plain
+value; multiple values must be received by `call-with-values` or `let-values`.
+
+## `call-with-values`
+
+```
+(call-with-values producer consumer)
+```
+Calls `producer` (a thunk) and applies `consumer` to the values it produced.
+
+```scheme
+(call-with-values
+  (lambda () (values 1 2 3))
+  (lambda (a b c) (display (+ a b c)) (newline)))
+```
+```
+6
+```
+
+## `let-values`
+
+```
+(let-values (((var …) producer) …) body …)
+```
+Binds the values returned by each `producer` to the corresponding variables, then
+evaluates `body`.
+
+```scheme
+(define (divmod a b) (values (quotient a b) (remainder a b)))
+(let-values (((q r) (divmod 17 5)))
+  (display q) (display " ") (display r) (newline))
+```
+```
+3 2
+```
+
+## Known issue — `define-values` is not supported
+
+The top-level `define-values` binding form does not work: the names it should
+bind are reported as undefined.
+
+```scheme
+(define-values (x y) (values 10 20))
+(display (+ x y)) (newline)
+```
+```
+error: Undefined variable: y
+error: Undefined variable: x
+```
+**Workaround:** use `let-values` for multiple-value destructuring, or `call-with-values`
+with an explicit consumer.

--- a/docs/reference/language/numeric-tower.md
+++ b/docs/reference/language/numeric-tower.md
@@ -1,0 +1,130 @@
+# The Numeric Tower
+
+Eshkol implements a Scheme-style numeric tower with several representations that
+arithmetic automatically promotes between:
+
+- **fixnums** — machine integers,
+- **bignums** — arbitrary-precision integers (automatic on overflow),
+- **rationals** — exact `p/q` (written `1/3`),
+- **inexact reals** — IEEE-754 doubles (written `1.5`, `3.0`),
+- **complex** — `a+bi` (type tag 7, heap-allocated `{real, imag}`).
+
+## Exactness
+
+`exact?` and `inexact?` classify a number. Integers and rationals are exact;
+doubles are inexact.
+
+```scheme
+(display (list (exact? 1/2) (inexact? 1.5))) (newline)
+(display (/ 6 3)) (display " exact=") (display (exact? (/ 6 3))) (newline)
+```
+```
+(#t #t)
+2 exact=#t
+```
+
+Conversions: `exact->inexact` (a.k.a. `inexact`), `inexact->exact` (a.k.a. `exact`).
+```scheme
+(display (exact->inexact 1/4)) (newline)
+```
+```
+0.25
+```
+
+> **Display convention:** an inexact value with no fractional part prints without a
+> decimal point — `(+ 1.0 2)` prints `3`, and `(+ 1/2 0.5)` prints `1` — but it is
+> still inexact (`(inexact? (+ 1/2 0.5))` ⇒ `#t`).
+
+## Integers and bignums
+
+Integer arithmetic promotes to bignum automatically; there is no overflow.
+
+```scheme
+(display (expt 2 100)) (newline)
+(display (* 99999999999999999999 99999999999999999999)) (newline)
+(display (list (quotient 17 5) (remainder 17 5) (modulo -7 3) (gcd 12 18) (lcm 4 6))) (newline)
+```
+```
+1267650600228229401496703205376
+9999999999999999999800000000000000000001
+(3 2 2 6 12)
+```
+
+## Rationals
+
+Division of exact integers that do not divide evenly yields an exact rational,
+kept in lowest terms.
+
+```scheme
+(display (/ 7 2)) (newline)
+(display (+ 1/3 1/6)) (newline)        ; => 1/2
+(display (* 2/3 3/4)) (newline)        ; => 1/2
+(display (list (numerator 3/4) (denominator 3/4))) (newline)
+```
+```
+7/2
+1/2
+1/2
+(3 4)
+```
+
+## Inexact reals
+
+```scheme
+(display (list (floor 3.7) (ceiling 3.2) (round 2.5) (truncate -3.7))) (newline)
+(display (sqrt 16)) (display " ") (display (sqrt 2)) (newline)
+```
+```
+(3 4 2 -3)
+4 1.41421
+```
+`(round 2.5)` ⇒ `2`: rounding is round-half-to-even (banker's rounding).
+
+## Complex numbers
+
+```scheme
+(display (make-rectangular 3 4)) (newline)
+(display (magnitude (make-rectangular 3 4))) (newline)
+(display (sqrt -1)) (newline)
+```
+```
+3+4i
+5
++i
+```
+
+## Contagion (mixed-type arithmetic)
+
+Combining an exact operand with an inexact one yields an inexact result (R7RS
+contagion): exact + inexact → inexact.
+
+```scheme
+(display (+ 1.0 2)) (newline)     ; 3 (inexact)
+(display (+ 1/2 0.5)) (newline)   ; 1 (inexact)
+```
+```
+3
+1
+```
+
+## Known issue — rationals degrade near the bignum boundary (ESH-0105)
+
+Exact rational arithmetic silently loses exactness — or returns a wrong value —
+once a **bignum** operand is involved, instead of producing an exact result or
+signalling an error.
+
+```scheme
+(display (* 1/3 99999999999999999999)) (newline)   ; expected 33333333333333333333
+(display (+ 1/3 (expt 10 30))) (newline)            ; expected 3000…0001/3
+(display (/ 1 (expt 10 19))) (newline)              ; expected exact 1/10000000000000000000
+```
+```
+0
+1000000000000000000000000000000
+1e-19
+```
+Observed: `(* 1/3 <bignum>)` returns `0`; `(+ 1/3 <bignum>)` drops the fraction;
+`(/ 1 (expt 10 19))` degrades to an inexact double (`1e-19`) whereas
+`(/ 1 (expt 10 18))` is still an exact rational. Keep rational computations within
+the fixnum range for exact results, or convert deliberately with
+`exact->inexact` when you want doubles.

--- a/docs/reference/language/pattern-matching.md
+++ b/docs/reference/language/pattern-matching.md
@@ -1,0 +1,79 @@
+# Pattern Matching: `match`
+
+```
+(match subject clause …)
+```
+where each clause is `(pattern body …)`. Clauses are tried top-to-bottom; the
+body of the first matching pattern is evaluated and returned. Variables in the
+pattern are bound in the body.
+
+## Supported patterns
+
+| Pattern | Matches |
+|---------|---------|
+| `_` | anything (wildcard), binds nothing |
+| `var` | anything, binds `var` |
+| literal (`5`, `"s"`) | that literal value |
+| `(list p …)` | a list of exactly that many elements, matching each `p` |
+| `(cons p1 p2)` | a pair, `p1` = car, `p2` = cdr |
+| `(? pred)` | any value for which `(pred value)` is true |
+| `(? pred var)` | as above, and binds `var` |
+
+## Examples
+
+```scheme
+(define (f v) (match v ((list a b) (+ a b)) (_ -1)))
+(display (f (list 10 20))) (newline)
+(display (f (list 1 2 3))) (newline)
+```
+```
+30
+-1
+```
+
+Predicate patterns dispatch on type. The built-in R7RS predicates
+(`number?`, `string?`, `symbol?`, `pair?`, `null?`, …) work directly:
+
+```scheme
+(define (classify v)
+  (match v
+    ((? number?) "number")
+    ((? string?) "string")
+    ((? symbol?) "symbol")
+    ((? pair?)   "pair")
+    (_           "other")))
+(display (classify 42)) (newline)
+(display (classify "x")) (newline)
+(display (classify (quote foo))) (newline)
+```
+```
+number
+string
+symbol
+```
+
+`cons` destructuring:
+
+```scheme
+(display (match (list 1 2 3) ((cons h t) h) (_ 0))) (newline)
+```
+```
+1
+```
+
+## Known issue — apostrophe-quote in the subject position
+
+Using `'datum` as the `match` **subject** hangs silently. Use the explicit
+`(quote datum)` form instead:
+
+```scheme
+;; hangs:   (match 'foo ((? symbol?) "sym") (_ "other"))
+;; works:
+(display (match (quote foo) ((? symbol?) "sym") (_ "other"))) (newline)
+```
+```
+sym
+```
+This is the same quote-dispatch family as the `guard` issue (ESH-0106). The
+project's `match` predicate test suite (`(? pred)` patterns, wildcard, list/cons
+destructuring, multi-clause dispatch) passes 21/21 with this convention.

--- a/docs/reference/language/quote-and-quasiquote.md
+++ b/docs/reference/language/quote-and-quasiquote.md
@@ -1,0 +1,92 @@
+# Quote and Quasiquote
+
+## `quote`
+
+```
+(quote datum)
+'datum          ; reader sugar, identical to (quote datum)
+```
+Returns `datum` unevaluated. **Both spellings work identically.**
+
+```scheme
+(display '(1 2 3)) (newline)
+(display 'sym) (newline)
+(display (quote (a b c))) (newline)
+```
+```
+(1 2 3)
+sym
+(a b c)
+```
+
+## `quasiquote` / `unquote` / `unquote-splicing`
+
+```
+`template        ; quasiquote
+,expr            ; unquote — evaluate expr and insert its value
+,@expr           ; unquote-splicing — splice the elements of a list value
+```
+A quasiquoted template is like `quote`, except that `,expr` is replaced by the
+value of `expr`, and `,@expr` splices a list's elements into the surrounding list.
+
+```scheme
+(define x 5)
+(display `(a ,x b)) (newline)
+(display `(1 ,@(list 2 3) 4)) (newline)
+```
+```
+(a 5 b)
+(1 2 3 4)
+```
+
+## Known Issues
+
+### ESH-0104 — long forms are not wired
+
+Only the reader sugar (``` ` ```, `,`, `,@`) is interpreted. The written-out
+long forms `(quasiquote …)`, `(unquote …)`, `(unquote-splicing …)` are treated as
+plain data and left unsubstituted.
+
+```scheme
+(define x 5)
+(display (quasiquote (a (unquote x) b))) (newline)
+```
+```
+(a (unquote x) b)
+```
+Expected (R7RS 4.2.8): `(a 5 b)`. **Workaround:** use the reader sugar
+``` `(a ,x b) ```, which evaluates correctly. `quote`'s long form `(quote …)` is
+unaffected — it works.
+
+### ESH-0107 — nested quasiquote collapses to `()`
+
+Any `quasiquote` nested inside another `quasiquote` (level ≥ 2) evaluates to `()`.
+
+```scheme
+(display `a) (newline)        ; single level: correct
+(display ``a) (newline)       ; nested: wrong
+(display `(a `(b ,(+ 1 1)))) (newline)
+```
+```
+a
+()
+(a ())
+```
+Single-level quasiquote/unquote/unquote-splicing are correct; only nesting is
+affected.
+
+### ESH-0106 — `'sym` sugar inside `guard` is misread
+
+The `'` reader sugar anywhere inside a `guard` form (clause bodies **and** the
+`raise` argument) is compiled as a *variable reference* rather than a quoted
+symbol.
+
+```scheme
+(display (guard (e (#t 'sym)) (raise 1))) (newline)
+```
+```
+error: Undefined variable: sym
+()
+```
+**Workaround:** use the explicit `(quote sym)` form inside `guard`, which works
+everywhere. See [error-handling.md](error-handling.md).

--- a/docs/reference/language/special-forms.md
+++ b/docs/reference/language/special-forms.md
@@ -1,0 +1,174 @@
+# Special Forms: definitions, `lambda`, `let`-family, `begin`
+
+## `define`
+
+```
+(define name value)
+(define (name arg …) body …)          ; function-definition sugar
+(define (name arg … . rest) body …)   ; variadic
+```
+
+Binds `name` in the enclosing scope. The function-definition sugar
+`(define (f x) …)` is equivalent to `(define f (lambda (x) …))`.
+
+```scheme
+(define pi 3.14159)
+(define (square x) (* x x))
+(display (square 9)) (newline)
+```
+```
+81
+```
+
+Internal `define`s at the start of a body are treated as `letrec*` bindings
+(R7RS semantics): they may refer to each other and are collected only while they
+are *consecutive* at the start of the body.
+
+```scheme
+(define (f)
+  (define a 1)
+  (define b (+ a 1))   ; may reference the previous define
+  (+ a b))
+(display (f)) (newline)
+```
+```
+3
+```
+
+### Known issues / non-support
+
+- **Curried definition sugar is not supported.** `(define ((adder x) y) …)`
+  fails to parse: `error: expected function name in define`. Write the explicit
+  nested `lambda` instead: `(define (adder x) (lambda (y) (+ x y)))`.
+- **ESH-0092** — top-level `define`d globals are emitted as raw C symbols. A
+  top-level name that collides with a libc symbol (e.g. `free`, `log`) corrupts
+  the process; `(define free 0)` runs but crashes with **SIGBUS** at teardown.
+  Avoid libc names for top-level globals. See
+  [binding-mutation-and-scope.md](binding-mutation-and-scope.md).
+
+## `lambda`
+
+```
+(lambda (arg …) body …)
+(lambda (arg … . rest) body …)   ; rest collects extra args into a list
+(lambda args body …)             ; all args collected into a single list
+```
+
+```scheme
+(display ((lambda (x y) (+ x y)) 3 4)) (newline)
+(display ((lambda args args) 1 2 3)) (newline)
+```
+```
+7
+(1 2 3)
+```
+
+See [functions-and-parameters.md](functions-and-parameters.md) for variadic and
+keyword-argument formals.
+
+## `begin`
+
+```
+(begin expr …)
+```
+Evaluates each `expr` in order and returns the value of the last.
+
+```scheme
+(begin (display "a") (display "b") (newline))
+```
+```
+ab
+```
+
+## `let`
+
+```
+(let ((var init) …) body …)
+```
+All `init` expressions are evaluated in the *enclosing* scope; the new bindings
+are visible only in `body`.
+
+```scheme
+(define x 10)
+(let ((a 1) (b 2)) (display (+ a b x)) (newline))
+```
+```
+13
+```
+
+## `let*`
+
+```
+(let* ((var init) …) body …)
+```
+Like `let`, but each `init` can see the bindings established by the earlier
+clauses.
+
+```scheme
+(let* ((a 1) (b (+ a 1))) (display b) (newline))
+```
+```
+2
+```
+
+## `letrec` and `letrec*`
+
+```
+(letrec ((var init) …) body …)
+(letrec* ((var init) …) body …)
+```
+All names are in scope for every `init`, enabling mutual recursion. Use for
+locally-defined recursive procedures.
+
+```scheme
+(letrec ((ev? (lambda (n) (if (= n 0) #t (od? (- n 1)))))
+         (od? (lambda (n) (if (= n 0) #f (ev? (- n 1))))))
+  (display (ev? 10)) (newline))
+```
+```
+#t
+```
+
+### Per-activation instance isolation (fixed, ESH-0075)
+
+Each activation of an enclosing procedure produces a **fresh** set of `letrec`
+closures with independent captured state. Previously, local `letrec`/internal-define
+functions were stored in module-level globals and multiple closure instances
+aliased each other's state; this is fixed.
+
+```scheme
+(define (counter-factory)
+  (letrec ((count 0)
+           (inc (lambda () (set! count (+ count 1)) count)))
+    inc))
+(define a (counter-factory))
+(define b (counter-factory))
+(display (a)) (display (a)) (display (b)) (newline)
+```
+```
+121
+```
+`a` counts `1`, `2`; `b` is independent and counts `1`. (Before the fix the two
+would have shared one backing counter.)
+
+## Named `let` (loop)
+
+```
+(let name ((var init) …) body …)
+```
+Defines a local recursive procedure `name` bound to the loop, immediately called
+with the `init` values. Tail-recursive calls to `name` are fully optimized (see
+[tail-calls.md](tail-calls.md)).
+
+```scheme
+(define (count-up n)
+  (let loop ((i 0) (acc '()))
+    (if (= i n) (reverse acc) (loop (+ i 1) (cons i acc)))))
+(display (count-up 5)) (newline)
+```
+```
+(0 1 2 3 4)
+```
+
+Named-let captures are passed as per-call arguments, which makes the loop
+thread-safe and correct across parallel execution.

--- a/docs/reference/language/strings-chars-symbols.md
+++ b/docs/reference/language/strings-chars-symbols.md
@@ -1,0 +1,109 @@
+# Characters, Strings, and Symbols
+
+## Characters
+
+Character literals use the `#\` prefix.
+
+| Literal | Character |
+|---------|-----------|
+| `#\a` | the letter a |
+| `#\A` | the letter A |
+| `#\space` | space |
+| `#\newline` | newline |
+| `#\tab` | tab |
+
+```scheme
+(display #\a) (newline)
+(display (char->integer #\A)) (newline)
+(display (integer->char 97)) (newline)
+(display (char-upcase #\a)) (newline)
+(display (list (char-alphabetic? #\x) (char-numeric? #\5))) (newline)
+```
+```
+a
+65
+a
+A
+(#t #t)
+```
+
+Comparison predicates: `char=?`, `char<?`, `char>?`, `char<=?`, `char>=?`
+(and case-insensitive `char-ci=?` etc.).
+
+## Strings
+
+Strings are sequences of characters. Common operations:
+
+```scheme
+(display (string-append "foo" "bar")) (newline)
+(display (string-length "hello")) (newline)
+(display (substring "hello world" 0 5)) (newline)
+(display (string-ref "abc" 1)) (newline)
+(display (list (string=? "a" "a") (string<? "a" "b"))) (newline)
+```
+```
+foobar
+5
+hello
+b
+(#t #t)
+```
+
+Conversions between strings, lists, symbols, and numbers:
+
+```scheme
+(display (string->list "abc")) (newline)
+(display (list->string (list #\x #\y))) (newline)
+(display (string->number "42")) (newline)
+(display (number->string 3.5)) (newline)
+(display (string->symbol "hello")) (newline)
+(display (symbol->string 'foo)) (newline)
+```
+```
+(a b c)
+xy
+42
+3.5
+hello
+foo
+```
+
+> Strings may contain embedded NUL bytes; string length and output are tracked by
+> the string header's stored size (not C `strlen`), so binary payloads round-trip
+> through `display`.
+
+## String interpolation `~{ }`
+
+Inside a string literal, `~{expr}` is replaced by the displayed value of `expr`,
+evaluated in the current scope. Any expression is allowed.
+
+```scheme
+(define who "Ada")
+(define n 42)
+(display "Hi ~{who}, n=~{n}, 2+2=~{(+ 2 2)}") (newline)
+```
+```
+Hi Ada, n=42, 2+2=4
+```
+
+## Symbols
+
+Symbols are interned identifiers. `'name` (or `(quote name)`) yields a symbol.
+
+```scheme
+(display 'foo) (newline)
+(display (symbol? 'foo)) (newline)
+(display (symbol=? 'a 'a)) (newline)
+(display (eq? 'a 'a)) (newline)   ; interned: eq? works
+```
+```
+foo
+#t
+#t
+#t
+```
+
+> Note the quote-in-`guard` limitation (ESH-0106): inside a `guard` form use
+> `(quote name)` rather than `'name`. See
+> [error-handling.md](error-handling.md) and
+> [quote-and-quasiquote.md](quote-and-quasiquote.md).

--- a/docs/reference/language/tail-calls.md
+++ b/docs/reference/language/tail-calls.md
@@ -1,0 +1,62 @@
+# Tail-Call Optimization (TCO)
+
+Eshkol performs proper tail-call optimization for **self-recursion** and for
+tail calls within a single procedure (including named `let` loops). A tail call
+reuses the current stack frame, so deep self-recursion runs in constant stack
+space.
+
+## What is a tail position
+
+An expression is in tail position when its value is the value of the whole
+procedure body — nothing further is computed after it returns. In particular:
+
+- the last expression of a `lambda`/`define` body, `let`/`let*`/`letrec` body,
+  `begin`, `when`/`unless` body;
+- the `consequent` and `alternate` of an `if` in tail position;
+- the body of the selected `cond`/`case`/`match` clause in tail position;
+- the recursive call of a named `let` loop.
+
+A call is **not** in tail position if its result is consumed by another operation,
+e.g. `(+ 1 (f n))` — the `(+ 1 …)` runs after `f` returns.
+
+## Self tail recursion is optimized
+
+```scheme
+(define (loop i n) (if (>= i n) i (loop (+ i 1) n)))
+(display (loop 0 5000000)) (newline)
+```
+```
+5000000
+```
+Five million iterations complete without stack growth. Named-`let` loops behave
+the same way (their loop call is a tail call).
+
+## Known limitation — mutual tail recursion is NOT optimized
+
+Tail calls **between** two procedures (ping-pong / mutual recursion) are *not*
+turned into jumps; each call consumes stack. Such programs work up to a moderate
+depth and then crash (SIGILL, stack exhaustion).
+
+```scheme
+(define (ev? n) (if (= n 0) #t (od? (- n 1))))
+(define (od? n) (if (= n 0) #f (ev? (- n 1))))
+(display (ev? 400000)) (newline)   ; works
+```
+```
+#t
+```
+The same program at `(ev? 500000)` crashes:
+```
+[process exits with signal SIGILL, return code 132]
+```
+Measured threshold: fine at 400k, crashes at 500k+. **Workaround:** fold mutually
+recursive state machines into a single self-recursive procedure that dispatches on
+a state argument, or use an explicit loop with an accumulator.
+
+## Related known issue — non-tail stdlib list procedures (ESH-0108)
+
+Some stdlib list procedures are themselves non-tail-recursive and will exhaust the
+stack on very large inputs *even though your call to them is in tail position*.
+`length` and `filter` are implemented as `(+ 1 (length (cdr lst)))`-style
+non-tail recursion and crash (SIGILL, no diagnostic) around 500k–1M elements;
+`map`, `reverse`, and `fold-left` are tail-safe to at least 1M.


### PR DESCRIPTION
Complete language-core reference: docs/reference/language/ (16 files — special forms, binding/scope/closure memory model, quote/quasiquote, predicates, control flow, TCO, error handling, continuations, match, multiple values, functions/keywords, modules, strings/chars/symbols, numeric tower, capabilities). Every example executed against a fresh master build (-r, AOT spot-checks). Known open issues linked inline to .swarm ledger entries; R7RS gaps found during verification are documented honestly (cond/case =>, define-values, curried define, error-object? family absent in native path) rather than papered over. Docs-only; no source changes. (Re-opened against the correct repo — an earlier PR was accidentally opened against the corporation mirror.)