### PR TITLE
docs(reference): complete stdlib API reference (v1.3.0)

### DIFF
--- a/docs/STDLIB_V1_2_API.md
+++ b/docs/STDLIB_V1_2_API.md
@@ -1,16 +1,19 @@
-# Eshkol v1.2-scale Standard Library — API Reference
+# Eshkol Standard Library — v1.2-scale surfaces (API Reference)
 
-**Version**: 1.3.0-evolve (closeout 2026-05-20, base 2026-05-01)
-**Audience**: implementers and library authors writing against the v1.2-scale
-public stdlib surface.
-**Scope**: every module added or significantly expanded between v1.1.13-accelerate
-and v1.3.0-evolve.
+**Version**: current as of 1.3.0-evolve (original v1.2 surfaces closed out
+2026-05-20, base 2026-05-01)
+**Audience**: implementers and library authors writing against the public
+stdlib surface.
+**Scope**: this document covers the modules added or significantly expanded in
+the v1.2-scale cycle. For the **complete, per-module v1.3.0 stdlib API
+reference** — every provided symbol of every module with run-verified examples
+— see [`reference/stdlib/INDEX.md`](reference/stdlib/INDEX.md).
 
-This document is the canonical, source-verified reference for the new public
-surfaces shipped in v1.2-scale. Every signature, default, and edge case below
-is read directly from the implementing `.esk`, `.c`, or `.cpp` file; every
-example exercises only symbols listed in the corresponding `(provide …)` block
-or in the codegen builtin table. Where a feature listed in
+This document is a source-verified reference for the v1.2-scale public
+surfaces, still current in v1.3.0-evolve. Every signature, default, and edge
+case below is read directly from the implementing `.esk`, `.c`, or `.cpp` file;
+every example exercises only symbols listed in the corresponding `(provide …)`
+block or in the codegen builtin table. Where a feature listed in
 [`CHANGELOG.md`](../CHANGELOG.md) under the v1.2 "finalises the v1.2 stdlib"
 line does not exist under its CHANGELOG name, the actual file and module name
 are given inline.
@@ -1688,7 +1691,7 @@ Prior to the v1.2 routing fix this raised a "consumer is not a procedure" or
 
 ### Which modules are auto-loaded by `(require stdlib)`?
 
-Inspect `lib/stdlib.esk` for the canonical list. As of v1.3.0-evolve, the
+Inspect `lib/stdlib.esk` for the canonical list. As of v1.2.1-scale, the
 auto-loaded set includes:
 
 - `core.io`

--- a/docs/reference/stdlib/INDEX.md
+++ b/docs/reference/stdlib/INDEX.md
@@ -1,0 +1,84 @@
+# Eshkol Standard Library — v1.3.0 API Reference Index
+
+Complete module-by-function map of the Eshkol standard library. Every symbol
+below links to a per-module reference page in this directory; every documented
+function was verified by compiling and running it with `eshkol-run … -r`.
+
+See [module-system.md](module-system.md) for how `require` resolution,
+`(require stdlib)`, and `stdlib.o` precompilation work. The v1.2-scale surface
+notes remain in [../../STDLIB_V1_2_API.md](../../STDLIB_V1_2_API.md).
+
+**Modules: 58** (plus `stdlib` itself and the module system page) — **provided symbols: 638** (plus stdlib-level helpers in [stdlib_extras.md](stdlib_extras.md)).
+
+*Auto* = loaded automatically by `(require stdlib)`; otherwise the module must be required individually.
+
+| Module | Auto | Reference | Provided symbols |
+|---|---|---|---|
+| [`core.ad.tape`](../../../lib/core/ad/tape.esk) | no | [ad_tape.md](ad_tape.md) | `ad-tape-new` `ad-const` `ad-var` `ad-add` `ad-sub` `ad-mul` `ad-div` `ad-sin` `ad-cos` `ad-exp` `ad-log` `ad-sqrt` `ad-neg` `ad-abs` `ad-relu` `ad-sigmoid` `ad-tanh` `ad-backward` `ad-gradient` `ad-node-value` `with-tape` `current-tape` `make-tape` `tape-input` `tape-const` `node-value` `node-grad` `record-op!` `record-fd-op!` `tape-add` `tape-sub` `tape-mul` `tape-div` `tape-sin` `tape-cos` `tape-exp` `tape-log` `tape-neg` `tape-square` `tape-sqrt` `tape-tanh` `tape-sigmoid` `tape-relu` `tape-pow` `tape-gradient` `tape-snapshot` `tape-restore` |
+| [`core.alist`](../../../lib/core/alist.esk) | yes | [alist.md](alist.md) | `alist-ref` `alist-ref-or` `alist-set` |
+| [`core.argparse`](../../../lib/core/argparse.esk) | no | [argparse.md](argparse.md) | `parse-args` `arg-get` `arg-positional` `arg-has?` `argparse-help` |
+| [`core.cache`](../../../lib/core/cache.esk) | no | [cache.md](cache.md) | `make-lru-cache` `lru-get` `lru-get/default` `lru-set!` `lru-has?` `lru-delete!` `lru-size` `lru-capacity` `lru-clear!` `memoize` `memoize/cap` `memoize1` `memoize1/cap` `memoize2` `memoize2/cap` |
+| [`core.capabilities`](../../../lib/core/capabilities.esk) | yes | [capabilities.md](capabilities.md) | `capability-install-policy!` `capability-clear-policy!` `capability-policy` `capability-policy-active?` `capability-allowed?` `capability-require!` |
+| [`core.channels`](../../../lib/core/channels.esk) | no | [channels.md](channels.md) | `make-channel` `channel?` `channel-capacity` `channel-len` `channel-closed?` `channel-send!` `channel-recv!` `channel-try-send!` `channel-try-recv!` `channel-close!` `channel-closed-sentinel` |
+| [`core.collections`](../../../lib/core/collections.esk) | no | [collections.md](collections.md) | `make-pq` `pq-push!` `pq-pop!` `pq-peek` `pq-size` `pq-empty?` `make-set` `set-add!` `set-remove!` `set-contains?` `set-size` `set->list` `set-clear!` `set-union` `set-intersect` `set-difference` `make-deque` `deque-push-front!` `deque-push-back!` `deque-pop-front!` `deque-pop-back!` `deque-peek-front` `deque-peek-back` `deque-size` `deque-empty?` `deque->list` |
+| [`core.control.trampoline`](../../../lib/core/control/trampoline.esk) | yes | [control_trampoline.md](control_trampoline.md) | `trampoline` `bounce` `done` |
+| [`core.data.base64`](../../../lib/core/data/base64.esk) | yes | [data_base64.md](data_base64.md) | `base64-encode` `base64-decode` `base64-encode-string` `base64-decode-string` `string->bytes` `bytes->string` `base64-char-at` `base64-value` `string->bytes-helper` `base64-encode-helper` `base64-decode-helper` `base64-remove-padding` |
+| [`core.data.csv`](../../../lib/core/data/csv.esk) | yes | [data_csv.md](data_csv.md) | `csv-parse` `csv-parse-file` `csv-stringify` `csv-write-file` `csv-parse-line` `csv-parse-lines` `csv-split-fields` `csv-stringify-row` |
+| [`core.data.dataframe`](../../../lib/core/data/dataframe.esk) | yes | [data_dataframe.md](data_dataframe.md) | `csv-parse-typed` `csv-header` `csv-rows` `csv-column` `csv-column-idx` `csv-select` `csv-filter` `csv-map-column` `csv-row-count` `csv-col-count` `csv-describe` |
+| [`core.distributed`](../../../lib/core/distributed.esk) | no | [distributed.md](distributed.md) | `lamport-zero` `lamport-tick` `lamport-merge` `lamport-recv` `lamport-before?` `vector-clock-empty` `vector-clock-ref` `vector-clock-set` `vector-clock-tick` `vector-clock-merge` `vector-clock-compare` `vector-clock-before?` `vector-clock-after?` `vector-clock-concurrent?` `vector-clock-equal?` `vector-clock-nodes` `make-g-counter` `g-counter-counts` `g-counter-inc` `g-counter-value` `g-counter-merge` `make-pn-counter` `pn-counter-positive` `pn-counter-negative` `pn-counter-inc` `pn-counter-dec` `pn-counter-value` `pn-counter-merge` `make-or-set` `or-set-adds` `or-set-removes` `or-set-clock` `or-set-add` `or-set-remove` `or-set-member?` `or-set-elements` `or-set-merge` `make-lww-register` `lww-register-value` `lww-register-timestamp` `lww-register-writer` `lww-register-deleted?` `lww-register-present?` `lww-register-set` `lww-register-delete` `lww-register-merge` `make-lww-map` `lww-map-entries` `lww-map-set` `lww-map-remove` `lww-map-ref` `lww-map-contains?` `lww-map-visible-entries` `lww-map-merge` `make-rga` `rga-root-id` `rga-entries` `rga-clock` `rga-entry-id` `rga-entry-prev` `rga-entry-value` `rga-entry-deleted?` `rga-insert-after` `rga-append` `rga-delete` `rga-values` `rga-last-id` `rga-merge` |
+| [`core.dnc`](../../../lib/core/dnc.esk) | no | [dnc.md](dnc.md) | `make-dnc-memory` `dnc-content-address` `dnc-loc-address` `dnc-read` `dnc-write!` `dnc-alloc-weights` `dnc-read-grad` `dnc-memory?` |
+| [`core.files`](../../../lib/core/files.esk) | yes | [files.md](files.md) | `path-directory` `with-atomic-output-file` `atomic-write-file` |
+| [`core.functional.compose`](../../../lib/core/functional/compose.esk) | yes | [functional_compose.md](functional_compose.md) | `compose` `compose3` `identity` `constantly` |
+| [`core.functional.curry`](../../../lib/core/functional/curry.esk) | yes | [functional_curry.md](functional_curry.md) | `curry2` `curry3` `uncurry2` `partial1` `partial2` `partial3` `partial` |
+| [`core.functional.flip`](../../../lib/core/functional/flip.esk) | yes | [functional_flip.md](functional_flip.md) | `flip` |
+| [`core.http_server`](../../../lib/core/http_server.esk) | no | [http_server.md](http_server.md) | `http-request-line` `http-request-method` `http-request-target` `http-request-path` `http-request-query` `http-request-version` `http-request-header` `http-request-content-length` `http-request-body` `http-request-body-too-large?` `http-max-request-body-size` `http-response` `http-response?` `http-response-status` `http-response-content-type` `http-response-body` `http-route` `http-route-request` `http-standard-response` `http-server-respond-response` `http-server-respond-standard` |
+| [`core.io`](../../../lib/core/io.esk) | yes | [io.md](io.md) | `print` `println` |
+| [`core.json`](../../../lib/core/json.esk) | yes | [json.md](json.md) | `json-parse` `json-try-parse` `json-parse-result?` `json-result-ok?` `json-result-value` `json-result-error` `json-stringify` `json-read` `json-write` `json-get` `json-get-in` `json-array-ref` `hash-table->alist` `alist->hash-table` `alist->json` `json-write-file` `alist-write-json` `json-read-file` |
+| [`core.json_schema`](../../../lib/core/json_schema.esk) | yes | [json_schema.md](json_schema.md) | `json-schema-valid?` `json-schema-validate` |
+| [`core.list.compound`](../../../lib/core/list/compound.esk) | yes | [list_compound.md](list_compound.md) | `caar` `cadr` `cdar` `cddr` `caaar` `caadr` `cadar` `caddr` `cdaar` `cdadr` `cddar` `cdddr` `caaaar` `caaadr` `caadar` `caaddr` `cadaar` `cadadr` `caddar` `cadddr` `cdaaar` `cdaadr` `cdadar` `cdaddr` `cddaar` `cddadr` `cdddar` `cddddr` `first` `second` `third` `fourth` `fifth` `sixth` `seventh` `eighth` `ninth` `tenth` |
+| [`core.list.convert`](../../../lib/core/list/convert.esk) | yes | [list_convert.md](list_convert.md) | `list->vector` `vector->list` |
+| [`core.list.generate`](../../../lib/core/list/generate.esk) | yes | [list_generate.md](list_generate.md) | `iota` `iota-from` `iota-step` `repeat` `make-list` `range` `zip` |
+| [`core.list.higher_order`](../../../lib/core/list/higher_order.esk) | yes | [list_higher_order.md](list_higher_order.md) | `map1` `map2` `map3` `fold` `fold-left` `foldl` `fold-right` `foldr` `for-each` `any` `every` `filter-map` |
+| [`core.list.query`](../../../lib/core/list/query.esk) | yes | [list_query.md](list_query.md) | `count-if` `find` `length` |
+| [`core.list.search`](../../../lib/core/list/search.esk) | yes | [list_search.md](list_search.md) | `member` `member?` `memq` `memv` `assoc` `assq` `assv` `list-ref` `list-tail` `list-set!` |
+| [`core.list.sort`](../../../lib/core/list/sort.esk) | yes | [list_sort.md](list_sort.md) | `sort` |
+| [`core.list.transform`](../../../lib/core/list/transform.esk) | yes | [list_transform.md](list_transform.md) | `take` `drop` `take-right` `drop-right` `append` `reverse` `filter` `unzip` `partition` `list-copy` |
+| [`core.logging`](../../../lib/core/logging.esk) | no | [logging.md](logging.md) | `log-debug` `log-info` `log-warn` `log-error` `log-set-level!` `log-set-output!` `log-with-trace!` `log-level` `log-output-port` |
+| [`core.logic.boolean`](../../../lib/core/logic/boolean.esk) | yes | [logic_boolean.md](logic_boolean.md) | `negate` `all?` `none?` |
+| [`core.logic.predicates`](../../../lib/core/logic/predicates.esk) | yes | [logic_predicates.md](logic_predicates.md) | `is-zero?` `is-positive?` `is-negative?` `is-even?` `is-odd?` |
+| [`core.logic.types`](../../../lib/core/logic/types.esk) | yes | [logic_types.md](logic_types.md) | `is-null?` `is-pair?` |
+| [`core.manifold`](../../../lib/core/manifold.esk) | yes | [manifold.md](manifold.md) | `make-euclidean-manifold` `make-hyperbolic-manifold` `make-spherical-manifold` `manifold-exp-map` `manifold-log-map` `manifold-distance` `manifold-parallel-transport` `manifold-curvature` `manifold-dimension` `manifold-type` `metric-component` `manifold-metric` `manifold-metric-inverse` `christoffel-symbol` `manifold-christoffel` `manifold-sectional-curvature` `manifold-scalar-curvature` `ricci-component` `manifold-ricci` `riemann-component` |
+| [`core.memory`](../../../lib/core/memory.esk) | no | [memory.md](memory.md) | `make-memory-log` `memory-append!` `memory-events` `memory-merge` `memory-verify-chain` `memory-verify-events` `memory-fold-lww` `memory-event?` `memory-event-id` `memory-event-prev` `memory-event-vclock` `memory-event-node` `memory-event-type` `memory-event-payload` |
+| [`core.memory_store`](../../../lib/core/memory_store.esk) | no | [memory_store.md](memory_store.md) | `make-memory-store` `memory-store?` `memory-store-log` `memory-store-path` `memory-store-open` `memory-store-open-fast` `memory-store-append!` `memory-store-verify` `memory-store-audit` `memory-store-count` `memory-store-head` `memory-store-sanitize` |
+| [`core.merkle`](../../../lib/core/merkle.esk) | no | [merkle.md](merkle.md) | `fnv1a-64` `hash->hex` `merkle-leaf` `merkle-leaf?` `merkle-inode?` `merkle-root` `merkle-data` `merkle-tree` `merkle-tree-with-hash` `merkle-leaves` `merkle-proof` `merkle-verify` `make-cas` `make-cas-with-hash` `cas?` `cas-put!` `cas-get` `cas-has?` `cas-size` `cas-keys` |
+| [`core.metrics`](../../../lib/core/metrics.esk) | no | [metrics.md](metrics.md) | `make-counter` `counter-inc!` `counter-add!` `make-gauge` `gauge-set!` `gauge-inc!` `gauge-dec!` `make-histogram` `histogram-observe!` `histogram-buckets` `metrics-register!` `metrics-render` `metrics-reset!` `metric-name` `metric-help` `metric-kind` |
+| [`core.ml.gradient_estimators`](../../../lib/core/ml/gradient_estimators.esk) | no | [ml_gradient_estimators.md](ml_gradient_estimators.md) | `gumbel-softmax` `gumbel-softmax-det` `straight-through` `straight-through-round` `straight-through-onehot` `categorical-pick` `argmax-onehot` `softmax` `sample-gumbel-noise` |
+| [`core.ml.neurosymbolic`](../../../lib/core/ml/neurosymbolic.esk) | no | [ml_neurosymbolic.md](ml_neurosymbolic.md) | `make-embedding-table` `emb-dim` `embed!` `vdot` `soft-unify` `soft-unify-loss` `soft-unify-train!` `kb-attention` `kb-retrieve` |
+| [`core.msgpack`](../../../lib/core/msgpack.esk) | no | [msgpack.md](msgpack.md) | `msgpack-null` `msgpack-null?` `msgpack-map` `msgpack-map?` `msgpack-map-entries` `msgpack-encode` `msgpack-decode` `msgpack-decode-prefix` `msgpack-bytes->bytevector` `msgpack-bytevector->bytes` |
+| [`core.numeric_extras`](../../../lib/core/numeric_extras.esk) | yes | [numeric_extras.md](numeric_extras.md) | `exact-integer-sqrt` |
+| [`core.operators.arithmetic`](../../../lib/core/operators/arithmetic.esk) | yes | [operators_arithmetic.md](operators_arithmetic.md) | `add` `sub` `mul` `div` |
+| [`core.operators.compare`](../../../lib/core/operators/compare.esk) | yes | [operators_compare.md](operators_compare.md) | `lt` `gt` `le` `ge` `eq` |
+| [`core.plot`](../../../lib/core/plot.esk) | yes | [plot.md](plot.md) | `sparkline` `bar-chart` `histogram` |
+| [`core.reflection`](../../../lib/core/reflection.esk) | yes | [reflection.md](reflection.md) | `describe` `type-name` |
+| [`core.sdnc`](../../../lib/core/sdnc.esk) | no | [sdnc.md](sdnc.md) | `sdnc-program` `sdnc-run` `sdnc-weight-grad` `sdnc-params` `sdnc-set-params!` `sdnc-improve!` `sdnc?` |
+| [`core.sexp`](../../../lib/core/sexp.esk) | yes | [sexp.md](sexp.md) | `sexp->string` `sexp->canonical-string` |
+| [`core.streams`](../../../lib/core/streams.esk) | yes | [streams.md](streams.md) | `stream-null` `stream-null?` `stream-pair?` `stream?` `stream-cons` `stream-car` `stream-cdr` `stream-take` `stream-drop` `stream-ref` `stream-map` `stream-filter` `stream-for-each` `stream-zip` `stream-append` `stream-iterate` `stream-from` `stream-take-while` `stream-drop-while` `stream-length` `stream->list` `list->stream` |
+| [`core.strings`](../../../lib/core/strings.esk) | yes | [strings.md](strings.md) | `string-join` `string-trim` `string-trim-left` `string-trim-right` `string-replace` `string-reverse` `string-copy` `string-repeat` `string-starts-with?` `string-ends-with?` `string-starts-with` `string-ends-with` `string-index` `string-last-index` `string-contains` `string-contains?` `string-count` `string-find` `string-upcase` `string-downcase` `string-split-ordered` |
+| [`core.testing`](../../../lib/core/testing.esk) | no | [testing.md](testing.md) | `register-test` `check-equal?` `check-true` `check-false` `check-approx` `check-raises` `run-tests` `reset-tests!` `*tests*` `*test-pass-count*` `*test-fail-count*` `*current-test-fails*` `*current-test-name*` |
+| [`core.threads`](../../../lib/core/threads.esk) | no | [threads.md](threads.md) | `make-mutex` `mutex-lock!` `mutex-trylock!` `mutex-unlock!` `mutex-destroy!` `with-mutex` `make-condvar` `condvar-wait!` `condvar-signal!` `condvar-broadcast!` `condvar-destroy!` `make-thread` `thread-join` `thread?` `thread-result-ready?` |
+| [`core.url`](../../../lib/core/url.esk) | yes | [url.md](url.md) | `url-encode` `url-decode` `base64url-encode` `base64url-decode` |
+| [`math`](../../../lib/math.esk) | no | [math.md](math.md) | `mat-ref` `tensor-copy` `det` `inv` `solve` `cross` `dot` `normalize` `mat-vec-mul` `power-iteration` `integrate` `newton` `variance` `std` `covariance` |
+| [`ml.activations`](../../../lib/ml/activations.esk) | no | [ml_activations.md](ml_activations.md) | `relu-scalar` `sigmoid-scalar` `tanh-scalar` `softplus-scalar` `silu` `swish` `mish` `normalize-minmax` `normalize-zscore` |
+| [`ml.optimization`](../../../lib/ml/optimization.esk) | yes | [ml_optimization.md](ml_optimization.md) | `gradient-descent` `adam` `l-bfgs` `conjugate-gradient` `line-search` `tensor-dot` `tensor-norm` |
+| [`signal.fft`](../../../lib/signal/fft.esk) | yes | [signal_fft.md](signal_fft.md) | `fft` `ifft` |
+| [`signal.filters`](../../../lib/signal/filters.esk) | yes | [signal_filters.md](signal_filters.md) | `hamming-window` `hann-window` `blackman-window` `kaiser-window` `apply-window` `convolve` `fast-convolve` `fir-filter` `iir-filter` `butterworth-lowpass` `butterworth-highpass` `butterworth-bandpass` `frequency-response` |
+
+## Not covered here
+
+- `core.test-module` (`lib/core/test-module.esk`) and `ml.nested_test_module`
+  (`lib/ml/nested_test_module.esk`) are module-loader test fixtures, not user API.
+- `lib/agent/*` (HTTP client, sqlite, subprocess, regex, crypto/sha256, terminal, …)
+  is the agent-FFI domain, documented separately from the stdlib reference.
+- `stdlib`-level helpers (`random-tensor`, `time-it`, `time-ns`, keyword-argument
+  internals, …) are covered in [stdlib_extras.md](stdlib_extras.md).
+

--- a/docs/reference/stdlib/ad_tape.md
+++ b/docs/reference/stdlib/ad_tape.md
@@ -1,0 +1,256 @@
+# `core.ad.tape` — reverse-mode automatic differentiation (Wengert tape + custom ops)
+
+**Source**: [`lib/core/ad/tape.esk`](../../../lib/core/ad/tape.esk)
+**Require**: `(require core.ad.tape)` — **NOT** auto-loaded via `(require stdlib)`; require it explicitly. The stateful pure-Scheme layer (`with-tape`, `tape-mul`, …) is defined in this file and fails with *"called undefined function 'with-tape'"* if the module is not required. The low-level `ad-*` layer is codegen builtins and works even without the require, but require it anyway for clarity.
+
+This module provides **two independent reverse-mode AD systems**:
+
+1. **Low-level Wengert tape** (`ad-*`) — codegen builtins backed by native C. Fast, but only supports the fixed set of builtin ops. Every op takes the **tape as its first argument**.
+2. **Stateful op-recording tape** (`with-tape` / `tape-*` / `record-op!`) — pure Scheme in this file. Each op is recorded with an explicit backward **closure**, so a single loss can route through builtin ops *and* hand-written custom ops (with exact or finite-difference backward), and reverse mode flows through all of them. Node values and gradients may be **scalars or vectors** (embeddings/tensors) uniformly. This is the keystone that makes reasoning ops (soft-unify, BP steps, free energy, encoder forward) differentiable.
+
+A **node** in the stateful tape is a mutable 2-slot vector `#(value grad)`. A **tape** is a mutable `#(ops nodes)` where `ops` is stored in reverse-chronological order (already the reverse-topological order the backward pass needs).
+
+---
+
+## Low-level Wengert tape (`ad-*` builtins)
+
+All `ad-*` ops take the tape first. Nodes carry a forward value; `ad-backward` seeds the output adjoint to 1 and propagates; `ad-gradient` then reads the accumulated adjoint at a node.
+
+### `(ad-tape-new)`
+Create a fresh low-level tape handle.
+
+### `(ad-var tape value)`
+Create a differentiable **variable** node (a gradient target) with the given scalar value.
+
+### `(ad-const tape value)`
+Create a **constant** node (value, no gradient accumulation as a target).
+
+### `(ad-node-value tape node)` / `(ad-value tape node)`
+Read a node's forward value. **Takes the tape as the first argument** — `(ad-node-value node)` with one arg silently returns `()`. `ad-value` is a builtin alias.
+
+### `(ad-add tape a b)` `(ad-sub tape a b)` `(ad-mul tape a b)` `(ad-div tape a b)`
+Binary arithmetic ops between two nodes; return a new node.
+
+### `(ad-sin tape a)` `(ad-cos tape a)` `(ad-exp tape a)` `(ad-log tape a)` `(ad-sqrt tape a)` `(ad-neg tape a)` `(ad-abs tape a)` `(ad-relu tape a)` `(ad-sigmoid tape a)` `(ad-tanh tape a)`
+Unary ops on a node; return a new node.
+
+### `(ad-backward tape output-node)`
+Run the reverse pass from `output-node` (seeds its adjoint to 1.0).
+
+### `(ad-gradient tape node)`
+Read the accumulated gradient at `node` after `ad-backward`. (Builtin aliases `ad-gradient-of`, `ad-value-of`, and `ad-pow`/`ad-tape-length`/`ad-tape-release` also exist but are outside this module's `provide` block; see [Extra builtins](#extra-builtins-not-in-provide).)
+
+```scheme
+;; adlow.esk
+(require core.ad.tape)
+(define tp (ad-tape-new))
+(define x (ad-var tp 2.0))
+(define y (ad-mul tp x x))          ; y = x^2
+(ad-backward tp y)
+(display "y=")(display (ad-node-value tp y))
+(display " dy/dx=")(display (ad-gradient tp x))(newline)
+
+(define t2 (ad-tape-new))
+(define a (ad-var t2 0.5))
+(define s (ad-add t2 (ad-sin t2 a) (ad-exp t2 a)))  ; sin a + exp a
+(ad-backward t2 s)
+(display "s=")(display (ad-node-value t2 s))
+(display " ds/da=")(display (ad-gradient t2 a))(newline)
+```
+```
+y=4 dy/dx=4
+s=2.12815 ds/da=2.5263
+```
+(dy/dx = 2x = 4; ds/da = cos 0.5 + exp 0.5 = 2.5263.)
+
+Edge case: **arg order matters.** Calling `ad-node-value`/`ad-value` with only the node (omitting the tape) returns `()` rather than erroring.
+
+---
+
+## Stateful op-recording tape
+
+### `(make-tape)`
+Create a fresh stateful tape. **Takes zero arguments.** Returns `#(ops nodes)` (both initially `'()`).
+
+### `(with-tape name thunk)`
+Bind a fresh tape as the dynamic *current tape* for the duration of `(thunk)`, then restore the previous current tape and return the thunk's result. `name` is a label (string) for readability only. Signature is `(with-tape name thunk)` — the thunk takes **no** arguments and typically calls `(current-tape)` to get the tape.
+
+### `(current-tape)`
+Return the tape currently installed by `with-tape`, or `#f` outside any `with-tape` scope.
+
+```scheme
+;; withtape.esk
+(require core.ad.tape)
+(display (with-tape "demo"
+  (lambda ()
+    (let* ((t (current-tape))
+           (x (tape-input t 3.0))
+           (y (tape-mul t x x)))          ; x^2
+      (tape-gradient t y (list x))))))    ; => (6)
+(newline)
+(display "outside: ")(display (current-tape))(newline)
+```
+```
+(6)
+outside: #f
+```
+
+### `(tape-input t value)`
+Create a **leaf node** (a gradient target) with `value` (scalar or vector). Registers it with the tape.
+
+### `(tape-const t value)`
+Create a leaf node used as a constant (same representation as `tape-input`; you simply don't ask for its gradient).
+
+### `(node-value node)` / `(node-grad node)`
+Read a node's forward value / its accumulated gradient. Unlike the low-level `ad-node-value`, these take **only the node** (a node is a plain `#(value grad)` vector). `node-grad` is meaningful after `tape-gradient` has run.
+
+### `(record-op! t inputs out-value backward)` — keystone
+Record a **custom op** on the tape.
+- `inputs` — list of input nodes.
+- `out-value` — the already-computed forward output value (scalar or vector).
+- `backward` — a closure `(lambda (grad-out) -> list-of-input-grads)`, returning one gradient per input node, in the **same order** as `inputs`. The closure captures whatever forward context it needs.
+Returns the new output node. This is what lets any op whose backward is not a plain builtin composition participate in reverse mode.
+
+```scheme
+;; recordop.esk — custom softplus op mixed with builtin mul/add
+(require core.ad.tape)
+(define (softplus v) (log (+ 1.0 (exp v))))
+(define (sigmoid v)  (/ 1.0 (+ 1.0 (exp (- v)))))
+(define g
+  (with-tape "loss"
+    (lambda ()
+      (let* ((t (current-tape))
+             (x (tape-input t 1.5))
+             (y (tape-input t 0.5))
+             (m (tape-mul t x y))                     ; builtin op (recorded)
+             (s (let ((mv (node-value m)))
+                  (record-op! t (list m) (softplus mv) ; CUSTOM op
+                              (lambda (gr) (list (* gr (sigmoid mv)))))))
+             (y2 (tape-mul t y y))
+             (loss (tape-add t s y2)))                ; softplus(x*y) + y^2
+        (tape-gradient t loss (list x y))))))
+(display g)(newline)
+```
+```
+(0.339589 2.01877)
+```
+(Matches central finite differences of `softplus(x*y)+y^2` at `(1.5, 0.5)`: `d/dx = sigmoid(xy)*y`, `d/dy = sigmoid(xy)*x + 2y`; verified in `tests/ad/stateful_tape_test.esk`.)
+
+Custom ops also handle **vector-valued** nodes — `out-value` and each returned gradient may be a vector (used for embedding/tensor ops):
+```scheme
+;; a tensor dot-product custom op: grad_a = b, grad_b = a
+(record-op! t (list na nb) (vdot av bv)
+  (lambda (gr) (list (scale-vec gr bv) (scale-vec gr av))))
+```
+
+### `(record-fd-op! t inputs fwd)`
+Record a custom op whose backward is computed by **central finite differences** on `fwd`. `fwd` takes the list of input **values** (scalars) and returns a scalar. Use when an analytic backward is unavailable or not worth deriving (e.g. differentiating through belief-propagation reconvergence / free energy). Prefer `record-op!` with an exact backward when you have one. Step size `tape-fd-eps = 1e-6`.
+
+```scheme
+;; recordfd.esk — differentiate an arbitrary scalar fn with no hand backward
+(require core.ad.tape)
+(define (fn vals)
+  (let ((x (car vals)) (y (cadr vals)))
+    (+ (* (* x x) y) (sin x))))          ; x^2*y + sin x
+(display
+  (with-tape "fd"
+    (lambda ()
+      (let* ((t (current-tape))
+             (x (tape-input t 2.0))
+             (y (tape-input t 3.0))
+             (fo (record-fd-op! t (list x y) fn)))
+        (tape-gradient t fo (list x y))))))   ; expect (2xy+cos x, x^2) = (12+cos2, 4)
+(newline)
+```
+```
+(11.5839 4)
+```
+
+### Builtin recorded ops (with backward rules)
+Each returns a new output node; each takes the **tape first**.
+
+| Op | Signature | Forward | d/dinput |
+|----|-----------|---------|----------|
+| `tape-add` | `(tape-add t a b)` | `a+b` | `(g, g)` |
+| `tape-sub` | `(tape-sub t a b)` | `a-b` | `(g, -g)` |
+| `tape-mul` | `(tape-mul t a b)` | `a*b` | `(g*b, g*a)` |
+| `tape-div` | `(tape-div t a b)` | `a/b` | `(g/b, -g*a/b^2)` |
+| `tape-sin` | `(tape-sin t a)` | `sin a` | `g*cos a` |
+| `tape-cos` | `(tape-cos t a)` | `cos a` | `-g*sin a` |
+| `tape-exp` | `(tape-exp t a)` | `exp a` | `g*exp a` |
+| `tape-log` | `(tape-log t a)` | `log a` | `g/a` |
+| `tape-neg` | `(tape-neg t a)` | `-a` | `-g` |
+| `tape-square` | `(tape-square t a)` | `a*a` | `2*g*a` |
+| `tape-sqrt` | `(tape-sqrt t a)` | `sqrt a` | `g/(2*sqrt a)` |
+| `tape-tanh` | `(tape-tanh t a)` | `tanh a` | `g*(1-tanh^2)` |
+| `tape-sigmoid` | `(tape-sigmoid t a)` | `1/(1+e^-a)` | `g*out*(1-out)` |
+| `tape-relu` | `(tape-relu t a)` | `max(a,0)` | `g if a>0 else 0` |
+| `tape-pow` | `(tape-pow t a p)` | `a^p` (**p is a constant number, not a node**) | `g*p*a^(p-1)` |
+
+```scheme
+;; buops.esk
+(require core.ad.tape)
+(define (g1 opf x0)
+  (with-tape "o" (lambda ()
+    (let* ((t (current-tape)) (x (tape-input t x0)) (o (opf t x)))
+      (list (node-value o) (car (tape-gradient t o (list x))))))))
+(display "square@3 (val grad) ")(display (g1 tape-square 3.0))(newline)
+(display "sqrt@4 ")(display (g1 tape-sqrt 4.0))(newline)
+(display "tanh@0 ")(display (g1 tape-tanh 0.0))(newline)
+(display "sigmoid@0 ")(display (g1 tape-sigmoid 0.0))(newline)
+(display "relu@2 ")(display (g1 tape-relu 2.0))(newline)
+(display "relu@-2 ")(display (g1 tape-relu -2.0))(newline)
+;; tape-pow: p is a plain number
+(display "pow(3,2) ")(display (with-tape "p" (lambda ()
+  (let* ((t (current-tape)) (x (tape-input t 3.0)) (o (tape-pow t x 2.0)))
+    (list (node-value o) (car (tape-gradient t o (list x))))))))(newline)
+```
+```
+square@3 (val grad) (9 6)
+sqrt@4 (2 0.25)
+tanh@0 (0 1)
+sigmoid@0 (0.5 0.25)
+relu@2 (2 1)
+relu@-2 (0 0)
+pow(3,2) (9 6)
+```
+
+### `(tape-gradient t output targets)`
+Run reverse mode from `output` (zeros all node grads, seeds `output` adjoint to 1.0, walks recorded ops in reverse order), then return the list of gradients at the `targets` nodes, in order. Can be called repeatedly (it re-zeros each time). Handles tensor adjoints unconditionally; skips only zero scalar adjoints.
+
+### `(tape-snapshot t)`
+Return a list of the current node **values** (in tape-node order) for later replay.
+
+### `(tape-restore t snapshot)`
+Write the snapshot values back into the tape's nodes; returns the tape.
+
+```scheme
+;; snap.esk
+(require core.ad.tape)
+(define ts (make-tape))
+(define nx (tape-input ts 3.0))
+(define snap (tape-snapshot ts))
+(vector-set! nx 0 99.0)          ; clobber the node value
+(tape-restore ts snap)
+(display (node-value nx))(newline)   ; restored to 3
+```
+```
+3
+```
+
+## Extra builtins (not in `provide`)
+These low-level builtins exist in codegen but are outside this module's `provide` block; they appear in `tests/vm/ad_tape_lowlevel_regression.esk`:
+- `(ad-pow tape a p-node)` — power on the low-level tape (`p` here is a **node**, e.g. `(ad-const tape 3.0)`), distinct from stateful `tape-pow` whose `p` is a number.
+- `(ad-value-of tape node)`, `(ad-gradient-of tape node)` — aliases of `ad-value` / `ad-gradient`.
+- `(ad-tape-length tape)` — number of nodes recorded.
+- `(ad-tape-release tape)` — release the low-level tape; idempotent (safe to call twice).
+
+## Internal helpers (provided but user-facing use is uncommon)
+`node-value` and `node-grad` are the documented accessors. The following are used internally by the module and generally not called directly: the `tape-*` list helpers, `val-*` value helpers, and `node-grad-set!/add!` are **not** exported.
+
+## Related ledger entries
+- The stateful tape + custom-op backward is the **TAPE** feature (memory: *"Stateful AD tape + custom-op backward"*, PR #48). Gotcha recorded there: the tape is pure Scheme because C has no closure invoker; and core modules cannot use `for-each`/`map` (AOT would fail), which is why this file carries its own `tape-for-each`/`tape-map1`.
+- The native `gradient`/`hessian`/`jacobian` **operators** (a *separate* AD system from this tape) have open/closed issues **ESH-0067, ESH-0070, ESH-0071, ESH-0072, ESH-0078, ESH-0081, ESH-0095, ESH-0096, ESH-0097**. Those do **not** affect this tape module — verified independently here.
+
+## Verification note
+Full acceptance suite `tests/ad/stateful_tape_test.esk` (22/22), `tests/ad/free_energy_ad_test.esk` (2/2), `tests/vm/ad_tape_lowlevel_regression.esk`, and `tests/stdlib/v12_ad_tape_test.esk` all pass under `eshkol-run -r`.

--- a/docs/reference/stdlib/alist.md
+++ b/docs/reference/stdlib/alist.md
@@ -1,0 +1,63 @@
+# `core.alist` — association-list helpers
+
+**Source**: [`lib/core/alist.esk`](../../../lib/core/alist.esk)
+**Require**: auto-loaded via `(require stdlib)`; or individually `(require core.alist)`
+
+Structural helpers over association lists (lists of `(key . value)` pairs), keyed by `equal?` via `assoc`. Consolidates helpers that were previously redefined ad hoc across agent modules (see the source note referencing ESH-0063; no such task file is present in this worktree's `.swarm/tasks/`).
+
+## Functions
+
+### `(alist-ref alist key)`
+Returns the value bound to `key`, or **raises an error** if the key is absent. Uses `assoc`, so keys are matched with `equal?`.
+
+```scheme
+;; alist.esk
+(require stdlib)
+(define a '((x . 1) (y . 2) (z . 3)))
+(display (alist-ref a 'y)) (newline)
+```
+```
+2
+```
+
+Edge cases: a missing key raises `"alist-ref: key not found"`:
+
+```scheme
+(require stdlib)
+(display (alist-ref '((a . 1)) 'missing)) (newline)
+```
+```
+Unhandled exception: alist-ref: key not found
+```
+
+### `(alist-ref-or alist key default)`
+Like `alist-ref`, but returns `default` instead of raising when the key is absent.
+
+```scheme
+(require stdlib)
+(define a '((x . 1) (y . 2) (z . 3)))
+(display (alist-ref-or a 'q 99)) (newline)   ; absent -> default
+(display (alist-ref-or a 'x 99)) (newline)   ; present
+```
+```
+99
+1
+```
+
+### `(alist-set alist key value)`
+Functional update: returns a **new** alist with `key` bound to `value`, replacing an existing binding in place or appending a new one at the end. The input list is not mutated.
+
+```scheme
+(require stdlib)
+(define a '((x . 1) (y . 2) (z . 3)))
+(display (alist-set a 'y 20)) (newline)   ; replace existing
+(display (alist-set a 'w 4)) (newline)    ; append new
+(display a) (newline)                     ; original unchanged
+```
+```
+((x . 1) (y . 20) (z . 3))
+((x . 1) (y . 2) (z . 3) (w . 4))
+((x . 1) (y . 2) (z . 3))
+```
+
+Edge cases: on an empty alist, `alist-set` returns a one-element list `((key . value))`. Replacement matches the first key equal to `key`.

--- a/docs/reference/stdlib/argparse.md
+++ b/docs/reference/stdlib/argparse.md
@@ -1,0 +1,76 @@
+# `core.argparse` — minimal CLI argument parser
+
+**Source**: [`lib/core/argparse.esk`](../../../lib/core/argparse.esk)
+**Require**: `(require core.argparse)` — **NOT** auto-loaded via `stdlib`; require it explicitly.
+
+A small long-flag parser. You supply a **spec** — a list of positional 4-tuples `(name type default desc)` — and an **argv** list of strings. `parse-args` returns a parsed result `(flags-alist positionals)` from which you read typed values. Type ∈ `'string 'integer 'number 'boolean`.
+
+Flag conventions:
+- `--name value` — long flag, value is the next token
+- `--name=value` — long flag, inline value
+- `--name` — boolean flag → `#t`
+- `--no-name` — boolean negation → `#f`
+- `--` — end-of-options; everything after is positional
+- Unknown flags are collected as positional strings (caller decides to reject or forward).
+
+> For docs and tests, pass a **literal argv list** rather than `(command-line)`, so output is deterministic.
+
+## Functions
+
+### `(parse-args argv spec)`
+Parse `argv` against `spec`. Returns `(flags positionals)` where `flags` is an alist of `(name . value)` seeded with the spec defaults and `positionals` is a list of leftover strings in original order.
+
+### `(arg-get parsed key)`
+Look up a flag value by its symbol key (e.g. `'--name`). Returns the (already type-converted) value or `#f` if absent from the alist.
+
+### `(arg-positional parsed)`
+Return the list of positional arguments.
+
+### `(arg-has? parsed key)`
+`#t` if `key`'s value is neither `#f` nor `'()` — a convenience truthiness check.
+
+### `(argparse-help progname spec)`
+Return a formatted usage/help string built from the spec descriptions.
+
+```scheme
+;; argparse.esk
+(require core.argparse)
+(define spec
+  (list (list '--name    'string  "World" "Your name")
+        (list '--count   'integer 1       "How many")
+        (list '--verbose 'boolean #f      "Verbose")))
+(define a (parse-args
+            (list "--name" "Ada" "--count=3" "--verbose" "pos1" "extra")
+            spec))
+(display (arg-get a '--name)) (newline)      ; Ada
+(display (arg-get a '--count)) (newline)     ; 3 (integer)
+(display (arg-get a '--verbose)) (newline)   ; #t
+(display (arg-positional a)) (newline)       ; (pos1 extra)
+(display (arg-has? a '--missing)) (newline)  ; #f
+;; --no- negation and defaults
+(define b (parse-args (list "--no-verbose") spec))
+(display (arg-get b '--verbose)) (newline)   ; #f
+(display (arg-get b '--name)) (newline)      ; World (default)
+;; end-of-options
+(define c (parse-args (list "--" "--name" "x") spec))
+(display (arg-positional c)) (newline)       ; (--name x)
+(display (argparse-help "myprog" spec))
+```
+```
+Ada
+3
+#t
+(pos1 extra)
+#f
+#f
+World
+(--name x)
+Usage: myprog [OPTIONS] [ARGS...]
+
+Options:
+  --name <string>    Your name
+  --count <integer>    How many
+  --verbose <boolean>    Verbose
+```
+
+Edge cases: a `boolean` value via `=`/next-token treats `"false"` and `"0"` as `#f`, anything else as `#t`. `integer`/`number` conversion uses `string->number`, so a non-numeric value yields `#f` (no error). A long flag with no following value (e.g. trailing `--name`) leaves the default in place. Unknown flags such as `--frob` fall through to the positionals list unchanged.

--- a/docs/reference/stdlib/cache.md
+++ b/docs/reference/stdlib/cache.md
@@ -1,0 +1,99 @@
+# `core.cache` — bounded LRU cache and memoizers
+
+**Source**: [`lib/core/cache.esk`](../../../lib/core/cache.esk)
+**Require**: `(require core.cache)` — **NOT** auto-loaded via `stdlib`; require it explicitly.
+
+A bounded least-recently-used cache plus memoizers built on it. Internally a cache is a vector `#(capacity counter-box hash-table)`; each entry is `(cons value timestamp)`. Reads and writes bump a monotonic counter; eviction walks the table for the lowest timestamp (O(n) evict, constant-time hit — fine for hundreds-to-thousands of entries).
+
+## Functions
+
+### `(make-lru-cache capacity)`
+Create a cache bounded to `capacity` (a positive integer). Errors otherwise.
+
+### `(lru-capacity cache)`
+The configured maximum.
+
+### `(lru-size cache)`
+Current entry count.
+
+### `(lru-has? cache key)`
+`#t`/`#f`. Does **not** touch the timestamp.
+
+### `(lru-get cache key)`
+Return the cached value, or `#f` on miss. Bumps the entry's timestamp on a hit. Use `lru-get/default` when `#f` is a valid stored value.
+
+### `(lru-get/default cache key default)`
+Like `lru-get` but returns `default` on miss (still touches on hit).
+
+### `(lru-set! cache key value)`
+Insert or update `key`. On a new key at capacity, evicts the least-recently-used entry first.
+
+### `(lru-delete! cache key)`
+Remove `key`; returns `#t` if it was present, `#f` otherwise.
+
+### `(lru-clear! cache)`
+Drop all entries.
+
+```scheme
+;; cache.esk
+(require core.cache)
+(define c (make-lru-cache 2))
+(lru-set! c 'a 1)
+(lru-set! c 'b 2)
+(display (lru-get c 'a)) (newline)      ; 1 (touches a, so b is now oldest)
+(lru-set! c 'd 4)                        ; at capacity -> evict b
+(display (lru-has? c 'b)) (newline)      ; #f
+(display (lru-has? c 'a)) (newline)      ; #t
+(display (lru-get c 'zzz)) (newline)     ; miss -> #f
+(display (lru-get/default c 'zzz -1)) (newline) ; -1
+(display (lru-size c)) (newline)         ; 2
+(display (lru-delete! c 'a)) (newline)   ; #t
+(display (lru-delete! c 'a)) (newline)   ; #f
+```
+```
+1
+#f
+#t
+#f
+-1
+2
+#t
+#f
+```
+
+Edge cases: `(make-lru-cache -1)` (or `0`, or a non-integer) → `Unhandled exception: make-lru-cache: capacity must be a positive integer`.
+
+## Memoizers
+
+Memoizers wrap a function and cache results in an LRU cache (default capacity 1024). Because hash-table keys compare by identity, variadic memoization is not supported; use the fixed-arity helpers below. (The correctness of a memoizer's captured mutable `cache` relates to the closure-capture fix tracked in **ESH-0074**; these helpers mutate the cache vector in place, which is safe.)
+
+### `(memoize1 fn)` / `(memoize1/cap fn capacity)`
+Memoize a **1-argument** function. Key is the single argument (compared with the cache's hash-table).
+
+### `(memoize2 fn)` / `(memoize2/cap fn capacity)`
+Memoize a **2-argument** function. The pair `(x y)` is encoded into a string key (`display` of each arg joined by a NUL byte) so structurally-equal argument pairs hit. Best for scalars: numbers, symbols, strings, booleans.
+
+### `(memoize fn)` / `(memoize/cap fn capacity)`
+Aliases for `memoize1` / `memoize1/cap`.
+
+```scheme
+;; cache.esk
+(require core.cache)
+(define calls 0)
+(define f (memoize (lambda (x) (set! calls (+ calls 1)) (* x x))))
+(display (f 5)) (newline)   ; 25
+(display (f 5)) (newline)   ; 25 (cached; fn not re-run)
+(display calls) (newline)   ; 1
+(define g (memoize2 (lambda (a b) (+ a b))))
+(display (g 3 4)) (newline) ; 7
+(display (g 3 4)) (newline) ; 7 (cached)
+```
+```
+25
+25
+1
+7
+7
+```
+
+Edge cases: `memoize2`'s key uses `display`, so two values that render identically (e.g. the string `"1"` and the number `1`) would collide. For mutable/complex arguments, pre-hash to a scalar yourself.

--- a/docs/reference/stdlib/capabilities.md
+++ b/docs/reference/stdlib/capabilities.md
@@ -1,0 +1,70 @@
+# `core.capabilities` — process-local capability policy
+
+**Source**: [`lib/core/capabilities.esk`](../../../lib/core/capabilities.esk)
+**Require**: auto-loaded via `(require stdlib)`; or individually `(require core.capabilities)`
+
+A process-local allow-list gate for hosted/agent surfaces. By default there is **no policy** (`#f`), so all capability checks pass and existing programs run unchanged. Installing an allow-list makes the policy *active*: any capability not in the list is denied. Core hosted capabilities include `file-read`, `file-write`, `env-read`, `env-write`, `subprocess`, `shell`, and `network`. The Scheme layer mirrors the allow-list into the C runtime via `extern` hooks so native operations honor the same policy. Related tasks: `.swarm/tasks/ESH-0076` ("Capability-denied getenv/file ops return #f silently", done) and `.swarm/tasks/ESH-0077` ("CTest for the --emit-object + libeshkol-static.a manual-link AOT path (getenv + capability)").
+
+> Note: the provided symbols use the full `capability-` prefix (`capability-install-policy!`, `capability-clear-policy!`, `capability-policy`, `capability-policy-active?`, `capability-allowed?`, `capability-require!`).
+
+## Functions
+
+### `(capability-install-policy! allow-list)`
+Installs `allow-list`, a list of capability symbols, and activates the policy (deny-by-default for anything not listed). Also syncs the list into the C runtime. Raises if `allow-list` is not a list of symbols. Mutating (`!`).
+
+### `(capability-clear-policy!)`
+Removes the active policy, restoring the default allow-all behavior, and clears the runtime mirror. Mutating (`!`).
+
+### `(capability-policy)`
+Returns the current allow-list when a policy is active, or `#f` when no policy is installed.
+
+### `(capability-policy-active?)`
+Returns `#t` if a policy is currently installed, else `#f`.
+
+### `(capability-allowed? capability . context)`
+Returns `#t` if `capability` (a symbol) is permitted under the current policy. With no active policy, always `#t`. Extra `context` arguments are accepted and ignored.
+
+### `(capability-require! capability . context)`
+Returns `#t` if `capability` is allowed; otherwise raises `"capability denied"`. Use it to gate an operation.
+
+```scheme
+;; capabilities.esk
+(require stdlib)
+(display (capability-policy-active?)) (newline)      ; no policy yet
+(display (capability-policy)) (newline)
+(display (capability-allowed? 'file-read)) (newline)  ; allow-all by default
+(capability-install-policy! '(file-read network))
+(display (capability-policy-active?)) (newline)
+(display (capability-policy)) (newline)
+(display (capability-allowed? 'file-read)) (newline)  ; listed
+(display (capability-allowed? 'file-write)) (newline) ; not listed -> denied
+(display (capability-require! 'network)) (newline)    ; allowed -> #t
+(capability-clear-policy!)
+(display (capability-policy-active?)) (newline)
+(display (capability-allowed? 'file-write)) (newline) ; allow-all again
+```
+```
+#f
+#f
+#t
+#t
+(file-read network)
+#t
+#f
+#t
+#f
+#t
+```
+
+Requiring a denied capability raises:
+
+```scheme
+(require stdlib)
+(capability-install-policy! '(file-read))
+(display (capability-require! 'file-write)) (newline)
+```
+```
+Unhandled exception: capability denied
+```
+
+Edge cases: installing an empty allow-list `'()` still activates the policy (and, since the list is empty, denies everything). `capability-install-policy!` requires every element to be a symbol; passing a non-symbol or non-list raises `"capability-install-policy!: expected a list of symbols"`. The policy is process-local state and persists across calls until cleared.

--- a/docs/reference/stdlib/channels.md
+++ b/docs/reference/stdlib/channels.md
@@ -1,0 +1,76 @@
+# `core.channels` — Go-style bounded CSP channels
+
+**Source**: [`lib/core/channels.esk`](../../../lib/core/channels.esk)
+**Require**: `(require core.channels)` — **NOT** auto-loaded via `stdlib`; require it explicitly. (It internally pulls in `stdlib` and `core.threads`.)
+
+Bounded, blocking channels built on `core.threads` mutex + condvar. A channel is a fixed-capacity ring buffer; blocking `channel-send!`/`channel-recv!` are the default, with non-blocking `channel-try-send!`/`channel-try-recv!` for poll-style use. A channel is a length-10 vector tagged `'eshkol-channel`.
+
+Once **closed**: `channel-send!` errors, `channel-recv!` drains any buffered items then returns the closed-sentinel forever, and all waiters are woken.
+
+> This pure-Scheme module is the precursor to the planned native channel primitive tracked in **ESH-0016** ("Channel API on the work-stealing thread pool", v1.4 concurrency foundation, status: active), which will add `ESHKOL_VALUE_CHANNEL` as a tagged-value subtype with lock-free SPSC/bounded/unbounded backends. Until then, use this module and drive concurrency via `parallel-map` / `parallel-execute` (see `core.threads`).
+
+## Functions
+
+### `(make-channel cap)`
+Create an open, empty channel with integer capacity `cap` (must be `>= 1`). You are responsible for eventually calling `channel-close!` so blocked receivers can drain.
+
+### `(channel? ch)`
+Predicate: length-10 vector tagged `'eshkol-channel`.
+
+### `(channel-capacity ch)`
+The configured capacity (no locking).
+
+### `(channel-len ch)`
+Current number of buffered items (takes the lock).
+
+### `(channel-closed? ch)`
+`#t` if the channel has been closed (takes the lock).
+
+### `(channel-send! ch val)`
+Blocking send. Blocks while the buffer is full; **errors** if the channel is closed.
+
+### `(channel-recv! ch)`
+Blocking receive. Blocks while empty and open. Returns `(channel-closed-sentinel)` once the channel is closed AND drained — test with `eq?`.
+
+### `(channel-try-send! ch val)`
+Non-blocking send. Returns `#t` if delivered, `#f` if the buffer is full or the channel is closed.
+
+### `(channel-try-recv! ch)`
+Non-blocking receive. Returns the value if available; `(channel-closed-sentinel)` if closed AND drained; `#f` if open but empty.
+
+### `(channel-close! ch)`
+Mark closed and wake all waiters. Idempotent.
+
+### `(channel-closed-sentinel)`
+Returns the unique sentinel object that `channel-recv!`/`channel-try-recv!` yield on a closed+drained channel. Compare with `eq?`.
+
+```scheme
+;; channels.esk
+(require core.channels)
+(define ch (make-channel 2))
+(display (channel? ch)) (newline)
+(display (channel-capacity ch)) (newline)
+(channel-send! ch 'a)
+(channel-send! ch 'b)
+(display (channel-try-send! ch 'c)) (newline)   ; buffer full -> #f
+(display (channel-len ch)) (newline)
+(display (channel-recv! ch)) (newline)           ; a
+(display (channel-try-recv! ch)) (newline)       ; b
+(display (channel-try-recv! ch)) (newline)       ; open + empty -> #f
+(channel-close! ch)
+(display (eq? (channel-recv! ch) (channel-closed-sentinel))) (newline) ; #t
+(display (channel-try-send! ch 'x)) (newline)    ; closed -> #f
+```
+```
+#t
+2
+#f
+2
+a
+b
+#f
+#t
+#f
+```
+
+Edge cases: `(make-channel 0)` → `Unhandled exception: make-channel: capacity must be >= 1`. `channel-send!` on a closed channel → `Unhandled exception: channel-send!: send on closed channel`. Keep examples bounded — `channel-recv!` on an open, empty channel blocks forever without another thread sending.

--- a/docs/reference/stdlib/collections.md
+++ b/docs/reference/stdlib/collections.md
@@ -1,0 +1,136 @@
+# `core.collections` — priority queue, hash set, and deque
+
+**Source**: [`lib/core/collections.esk`](../../../lib/core/collections.esk)
+**Require**: `(require core.collections)` — **NOT** auto-loaded via `stdlib`; require it explicitly.
+
+Three pure-Scheme containers not otherwise in stdlib: a binary **min-heap** priority queue (`#(data size compare)`), a **hash set** (thin wrapper over `make-hash-table`), and a two-list **deque** (`#(front back)`).
+
+## Priority queue (min-heap)
+
+### `(make-pq)`
+Create an empty min-heap ordered by numeric key ascending (smallest key pops first).
+
+> **Known issue.** The header comment advertises `(make-pq compare)` for a custom comparator, but `make-pq` takes **no arguments** and always uses the built-in `(- a b)` min-heap. Eshkol tolerates the extra argument silently, so `(make-pq my-cmp)` compiles and runs but the comparator is **ignored** (see Known issues below).
+
+### `(pq-push! pq key item)`
+Insert `item` with priority `key`. Lower key = higher priority.
+
+### `(pq-pop! pq)`
+Remove and return the min-key entry as a cons `(key . item)`. Errors if empty. (Note: the source header comment says `(values key item)`, but the actual return is a **cons pair**.)
+
+### `(pq-peek pq)`
+Return the min-key entry `(key . item)` without removing it. Errors if empty.
+
+### `(pq-size pq)`
+Current element count.
+
+### `(pq-empty? pq)`
+`#t` if empty.
+
+```scheme
+;; collections.esk
+(require core.collections)
+(define pq (make-pq))
+(pq-push! pq 5 'five)
+(pq-push! pq 1 'one)
+(pq-push! pq 3 'three)
+(display (pq-size pq)) (newline)   ; 3
+(display (pq-peek pq)) (newline)   ; (1 . one)
+(display (pq-pop! pq)) (newline)   ; (1 . one)
+(display (pq-pop! pq)) (newline)   ; (3 . three)
+(display (pq-empty? pq)) (newline) ; #f
+```
+```
+3
+(1 . one)
+(1 . one)
+(3 . three)
+#f
+```
+
+Edge cases: `pq-pop!`/`pq-peek` on an empty queue → `Unhandled exception: pq-pop!: priority queue is empty` (resp. `pq-peek: ...`).
+
+## Hash set
+
+A set of `equal?`-keyed elements (backed by `make-hash-table`). Add is idempotent.
+
+### `(make-set)` — empty set.
+### `(set-add! s x)` — insert `x`.
+### `(set-remove! s x)` — remove; returns `#t` if present, `#f` otherwise.
+### `(set-contains? s x)` — membership `#t`/`#f`.
+### `(set-size s)` — element count.
+### `(set->list s)` — elements as a list (unspecified order).
+### `(set-clear! s)` — empty the set.
+### `(set-union a b)` / `(set-intersect a b)` / `(set-difference a b)` — return a **fresh** set; inputs unmodified. `set-difference` is `a \ b`.
+
+```scheme
+;; collections.esk
+(require core.collections)
+(define a (make-set)) (set-add! a 1) (set-add! a 2)
+(define b (make-set)) (set-add! b 2) (set-add! b 3)
+(set-add! a 1)                                   ; idempotent
+(display (set-size a)) (newline)                 ; 2
+(display (set-contains? a 1)) (newline)          ; #t
+(display (sort (set->list (set-union a b)) <)) (newline)
+(display (sort (set->list (set-intersect a b)) <)) (newline)
+(display (sort (set->list (set-difference a b)) <)) (newline)
+```
+```
+2
+#t
+(1 2 3)
+(2)
+(1)
+```
+
+## Deque (double-ended queue)
+
+O(1) amortised at both ends. Represented as `#(front back)` — pops from the empty side pay an O(n) rebalance.
+
+### `(make-deque)` — empty deque.
+### `(deque-push-front! dq x)` / `(deque-push-back! dq x)` — add to either end.
+### `(deque-pop-front! dq)` / `(deque-pop-back! dq)` — remove and return from either end; error if empty.
+### `(deque-peek-front dq)` / `(deque-peek-back dq)` — inspect without removing; error if empty. (No `!` — these do not mutate.)
+### `(deque-size dq)` / `(deque-empty? dq)` — count / emptiness.
+### `(deque->list dq)` — front-to-back list.
+
+```scheme
+;; collections.esk
+(require core.collections)
+(define dq (make-deque))
+(deque-push-back! dq 1) (deque-push-back! dq 2) (deque-push-front! dq 0)
+(display (deque->list dq)) (newline)       ; (0 1 2)
+(display (deque-size dq)) (newline)        ; 3
+(display (deque-peek-front dq)) (newline)  ; 0
+(display (deque-peek-back dq)) (newline)   ; 2
+(display (deque-pop-front! dq)) (newline)  ; 0
+(display (deque-pop-back! dq)) (newline)   ; 2
+(display (deque->list dq)) (newline)       ; (1)
+```
+```
+(0 1 2)
+3
+0
+2
+0
+2
+(1)
+```
+
+Edge cases: popping/peeking an empty deque → `Unhandled exception: deque-pop-front!: deque is empty` (resp. the matching message per op).
+
+## Known issues
+
+**`make-pq` ignores a comparator argument (min-heap only).** The header documents `(make-pq compare)`, but the definition is `(define (make-pq) …)` with the comparator hard-coded to `(- a b)`. Passing a comparator does not error but has no effect, so a max-heap cannot be built this way.
+
+```scheme
+;; repro.esk
+(require core.collections)
+(define pq (make-pq (lambda (a b) (- b a))))  ; intended max-heap
+(pq-push! pq 1 'one)
+(pq-push! pq 9 'nine)
+(display (pq-pop! pq)) (newline)   ; want (9 . nine); actually (1 . one)
+```
+```
+(1 . one)
+```

--- a/docs/reference/stdlib/control_trampoline.md
+++ b/docs/reference/stdlib/control_trampoline.md
@@ -1,0 +1,54 @@
+# `core.control.trampoline` — bounded-stack recursion via thunks
+
+**Source**: [`lib/core/control/trampoline.esk`](../../../lib/core/control/trampoline.esk)
+**Require**: auto-loaded via `(require stdlib)`; or individually `(require core.control.trampoline)`
+
+A trampoline drives CPS-style recursion in constant stack space. Instead of calling itself directly, a function returns a **thunk** (a zero-argument procedure) in tail position; `trampoline` loops, invoking each returned thunk until a non-procedure value appears. This sidesteps deep native call stacks — useful for mutual recursion, which is not currently TCO'd (see `.swarm/tasks/ESH-0102`: "Mutual tail calls are not TCO'd: ping-pong recursion crashes at ~300-500k depth").
+
+## Functions
+
+### `(trampoline thunk)`
+Calls `thunk`, then repeatedly re-invokes the result as long as it is a procedure, returning the first non-procedure value. Runs as a `do` loop, so stack depth stays constant regardless of logical recursion depth.
+
+```scheme
+;; trampoline.esk
+(require stdlib)
+(define (even-cps n)
+  (if (= n 0) (done #t)
+      (bounce (lambda () (odd-cps (- n 1))))))
+(define (odd-cps n)
+  (if (= n 0) (done #f)
+      (bounce (lambda () (even-cps (- n 1))))))
+(display (trampoline (lambda () (even-cps 100000)))) (newline)
+(display (trampoline (lambda () (odd-cps 7)))) (newline)
+```
+```
+#t
+#t
+```
+
+Edge cases: because the loop condition is `(not (procedure? result))`, a computation whose genuine final value is itself a procedure would be re-invoked instead of returned — wrap such a value so the terminal value is not a procedure.
+
+### `(bounce thunk)`
+Marks a thunk as the next trampoline step. It is the **identity function** — it simply returns the thunk it is given. Provided for readability at recursion sites; `(bounce (lambda () ...))` is equivalent to `(lambda () ...)`.
+
+```scheme
+(require stdlib)
+(display (procedure? (bounce (lambda () 1)))) (newline)
+```
+```
+#t
+```
+
+### `(done value)`
+Marks a final value. Also the **identity function** — `(done x)` is exactly `x`. Provided so recursion sites read symmetrically with `bounce`; the trampoline stops on any non-procedure, whether or not it was wrapped with `done`.
+
+```scheme
+(require stdlib)
+(display (done 42)) (newline)
+```
+```
+42
+```
+
+Edge cases: since `done` returns its argument verbatim, `(done some-procedure)` does **not** shield a procedure value from being trampolined.

--- a/docs/reference/stdlib/data_base64.md
+++ b/docs/reference/stdlib/data_base64.md
@@ -1,0 +1,148 @@
+# `core.data.base64` — Base64 encoding/decoding
+
+**Source**: [`lib/core/data/base64.esk`](../../../lib/core/data/base64.esk)
+**Require**: `(require core.data.base64)` — auto-loaded via `(require stdlib)`.
+
+Pure-Eshkol standard Base64 (RFC 4648 §4, `+`/`/` alphabet, `=` padding). The
+byte representation is a Scheme **list of integers 0–255**; the text
+representation is a string. URL-safe Base64 (`-`/`_`, no padding) lives in
+[`core.url`](url.md) as `base64url-encode`/`base64url-decode`. This module is
+also summarised in [`docs/STDLIB_V1_2_API.md`](../../STDLIB_V1_2_API.md).
+
+## Functions
+
+### `(base64-encode bytes)`
+Encode a list of byte values (0–255) into a Base64 string, with `=` padding.
+
+```scheme
+(require core.data.base64)
+(display (base64-encode '(77 97 110))) (newline)   ; "Man"
+(display (base64-encode '(77 97)))     (newline)   ; "Ma"  -> one '='
+(display (base64-encode '(77)))        (newline)   ; "M"   -> two '='
+(display (base64-encode '()))          (newline)   ; empty
+```
+```
+TWFu
+TWE=
+TQ==
+
+```
+
+### `(base64-decode str)`
+Decode a Base64 string back into a list of byte values. Padding is stripped
+first via `base64-remove-padding`.
+
+```scheme
+(display (base64-decode "TWFu")) (newline)
+(display (base64-decode ""))     (newline)
+```
+```
+(77 97 110)
+()
+```
+
+### `(base64-encode-string str)`
+Encode a string: `(base64-encode (string->bytes str))`.
+
+```scheme
+(display (base64-encode-string "Hello")) (newline)
+```
+```
+SGVsbG8=
+```
+
+### `(base64-decode-string str)`
+Decode a Base64 string to a string: `(bytes->string (base64-decode str))`.
+
+```scheme
+(display (base64-decode-string "SGVsbG8=")) (newline)
+(display (base64-decode-string (base64-encode-string "The quick brown fox"))) (newline)
+```
+```
+Hello
+The quick brown fox
+```
+
+### `(string->bytes str)`
+Convert a string to a list of its byte values (via `char->integer`).
+
+```scheme
+(display (string->bytes "AB")) (newline)   ; (65 66)
+```
+```
+(65 66)
+```
+
+### `(bytes->string bytes)`
+Convert a list of byte values to a string.
+
+```scheme
+(display (bytes->string '(65 66 67))) (newline)   ; "ABC"
+```
+```
+ABC
+```
+
+### `(base64-char-at index)`
+Return the alphabet character for a 6-bit value (0–63): `A`..`Z`, `a`..`z`,
+`0`..`9`, `+`, `/`.
+
+```scheme
+(display (base64-char-at 0))  (newline)   ; A
+(display (base64-char-at 62)) (newline)   ; +
+```
+```
+A
++
+```
+
+### `(base64-value ch)`
+Inverse of `base64-char-at`: the 6-bit value of a Base64 char. `=` and any
+unrecognised char map to `0`.
+
+```scheme
+(display (base64-value #\A)) (newline)   ; 0
+(display (base64-value #\/)) (newline)   ; 63
+```
+```
+0
+63
+```
+
+### `(base64-remove-padding str)`
+Strip trailing `=` characters from a Base64 string.
+
+```scheme
+(display (base64-remove-padding "SGVsbG8=")) (newline)   ; "SGVsbG8"
+```
+```
+SGVsbG8
+```
+
+### Internal helpers
+These are `provide`d but are the recursive workhorses behind the public API;
+you normally will not call them directly.
+
+- `(string->bytes-helper str pos len)` — tail of `string->bytes`; collects bytes
+  from `pos` to `len`. `(string->bytes-helper "Hi" 0 2)` ⇒ `(72 105)`.
+- `(base64-encode-helper bytes result)` — accumulator loop behind
+  `base64-encode`. `(base64-encode-helper '(77 97 110) "")` ⇒ `TWFu`.
+- `(base64-decode-helper str pos len result)` — accumulator loop behind
+  `base64-decode`. `(base64-decode-helper "TWFu" 0 4 '())` ⇒ `(77 97 110)`.
+
+## Binary round-trip
+
+Arbitrary bytes — including `0` (NUL) and the high range `253`–`255` — survive a
+`base64-encode` → `base64-decode` round-trip at the byte-list level:
+
+```scheme
+(require core.data.base64)
+(display (base64-decode (base64-encode '(0 1 2 253 254 255)))) (newline)
+```
+```
+(0 1 2 253 254 255)
+```
+The NUL byte also survives an encode step from a byte list containing it
+(`(base64-encode '(72 0 105))` ⇒ `SABp`, which decodes back to `(72 0 105)`).
+
+No bugs observed in this module.

--- a/docs/reference/stdlib/data_csv.md
+++ b/docs/reference/stdlib/data_csv.md
@@ -1,0 +1,124 @@
+# `core.data.csv` — CSV parsing and generation
+
+**Source**: [`lib/core/data/csv.esk`](../../../lib/core/data/csv.esk)
+**Require**: `(require core.data.csv)` — auto-loaded via `(require stdlib)`.
+
+Pure-Eshkol CSV reader/writer. A parsed CSV is a **list of rows**, each row a
+**list of field values** (strings; an empty field is represented as `()`).
+Quoting follows the common convention: fields may be `"…"`-wrapped, and an
+embedded quote is escaped by doubling (`""`).
+
+> **Row-order bug:** `csv-parse` currently returns rows in **reverse** order.
+> This also corrupts [`core.data.dataframe`](data_dataframe.md). See
+> [Known issues](#known-issues).
+
+## Functions
+
+### `(csv-split-fields line)` / `(csv-parse-line line)`
+Split one line into a list of field values, honouring quotes. `csv-parse-line`
+is an alias. An empty line gives `()`; an empty field becomes `()`.
+
+```scheme
+(require core.data.csv)
+(display (csv-split-fields "a,b,c")) (newline)
+(display (csv-split-fields "a,\"b,c\",d")) (newline)      ; quoted comma
+(display (csv-split-fields "\"he said \"\"hi\"\"\",x")) (newline)  ; escaped quote
+(display (csv-split-fields "a,,c")) (newline)             ; empty field -> ()
+(display (csv-split-fields "")) (newline)                 ; empty line -> ()
+```
+```
+(a b c)
+(a b,c d)
+(he said "hi" x)
+(a () c)
+()
+```
+
+### `(csv-parse str)` — **returns rows reversed** (see [Known issues](#known-issues))
+Parse a whole CSV string into a list of rows. Blank lines are skipped.
+
+```scheme
+(display (csv-parse "a,b\n1,2\n3,4")) (newline)
+```
+```
+((3 4) (1 2) (a b))
+```
+The expected result is `((a b) (1 2) (3 4))`; the rows come out in reverse
+because of a stale internal `reverse`.
+
+### `(csv-parse-lines lines)`
+Parse an already-split list of line strings into rows (blank lines skipped).
+Preserves the order of the `lines` argument.
+
+```scheme
+(display (csv-parse-lines '("a,b" "1,2"))) (newline)
+```
+```
+((a b) (1 2))
+```
+
+### `(csv-parse-file filename)`
+Read a file with `read-file` and parse it. Returns `()` if the file cannot be
+read. Inherits the reversed-row behaviour of `csv-parse`.
+
+```scheme
+;; after (csv-write-file f '(("a" "b") ("1" "2")))
+(display (csv-parse-file f)) (newline)
+```
+```
+((1 2) (a b))
+```
+
+### `(csv-stringify-row row)`
+Convert one row (list of fields) to a CSV line. Fields containing a comma,
+quote, or newline are quoted and inner quotes doubled. `()` fields become
+empty; numbers are rendered with `number->string`.
+
+```scheme
+(display (csv-stringify-row '("a" "b" "c"))) (newline)
+(display (csv-stringify-row '("has,comma" "plain"))) (newline)
+(display (csv-stringify-row '(1 2 3))) (newline)
+```
+```
+a,b,c
+"has,comma",plain
+1,2,3
+```
+
+### `(csv-stringify rows)`
+Convert a list of rows to a multi-line CSV string (rows joined with `\n`). This
+is the inverse of `csv-parse` **only if you account for the parse reversal** —
+`csv-stringify` itself preserves the order you give it.
+
+```scheme
+(display (csv-stringify '(("a" "b") ("1" "2")))) (newline)
+```
+```
+a,b
+1,2
+```
+
+### `(csv-write-file filename rows)`
+Write rows to a file via `csv-stringify` + `write-file`.
+
+```scheme
+(csv-write-file "/tmp/out.csv" '(("a" "b") ("1" "2")))
+```
+
+## Known issues
+
+### `csv-parse` returns rows in reverse order
+`csv-parse` is implemented as
+`(csv-parse-lines (reverse (string-split str #\newline)))`. The `reverse` was
+needed when `string-split` returned fields right-to-left, but `string-split` now
+returns them **left-to-right** (confirmed: `(string-split "a\nb\nc" #\newline)`
+⇒ `(a b c)`). The leftover `reverse` therefore flips the row order.
+
+```scheme
+(require core.data.csv)
+(display (csv-parse "a,b\n1,2\n3,4")) (newline)
+;; => ((3 4) (1 2) (a b))   expected ((a b) (1 2) (3 4))
+```
+Impact: any consumer that treats the first row as a header (notably
+`csv-parse-typed` in [`core.data.dataframe`](data_dataframe.md)) gets the wrong
+header. Workaround: `(reverse (csv-parse s))`.

--- a/docs/reference/stdlib/data_dataframe.md
+++ b/docs/reference/stdlib/data_dataframe.md
@@ -1,0 +1,155 @@
+# `core.data.dataframe` — columnar operations over CSV data
+
+**Source**: [`lib/core/data/dataframe.esk`](../../../lib/core/data/dataframe.esk)
+**Require**: `(require core.data.dataframe)` — auto-loaded via `(require stdlib)`.
+
+DataFrame layer on top of [`core.data.csv`](data_csv.md). A **DataFrame** is a
+pair `(header . rows)`:
+
+- `header` — a list of column-name strings
+- `rows` — a list of rows, each a list of typed values
+
+`csv-parse-typed` adds type inference: numeric-looking fields become numbers,
+everything else stays a string.
+
+> **Broken through `csv-parse-typed`.** Because [`csv-parse`](data_csv.md)
+> returns rows reversed, `csv-parse-typed` picks the **last** CSV line as the
+> header, which breaks the accessors below. The accessors themselves are correct
+> when given a well-formed `(header . rows)` pair. See
+> [Known issues](#known-issues). The examples below build the frame by hand to
+> document intended behaviour.
+
+## Functions
+
+### `(csv-parse-typed str)` — **header comes out wrong** (see [Known issues](#known-issues))
+Parse a CSV string into a `(header . typed-rows)` DataFrame; first row is meant
+to be the header, remaining rows get type inference.
+
+```scheme
+(require core.data.dataframe)
+(display (csv-parse-typed "col\n42")) (newline)
+```
+```
+((42) (col))
+```
+Expected `((col) (42))`; the header/row are swapped by the underlying
+`csv-parse` reversal.
+
+For the remaining accessors, a correctly-shaped frame is built directly:
+
+```scheme
+(require core.data.dataframe)
+(define df (cons '("name" "age")
+                 '(("Alice" 30) ("Bob" 25) ("Cy" 40))))
+```
+
+### `(csv-header df)` / `(csv-rows df)`
+`car` and `cdr` of the frame: the column-name list and the row list.
+
+```scheme
+(display (csv-header df)) (newline)
+(display (csv-rows df)) (newline)
+```
+```
+(name age)
+((Alice 30) (Bob 25) (Cy 40))
+```
+
+### `(csv-row-count df)` / `(csv-col-count df)`
+Number of data rows / number of columns.
+
+```scheme
+(display (csv-row-count df)) (newline)   ; 3
+(display (csv-col-count df)) (newline)   ; 2
+```
+```
+3
+2
+```
+
+### `(csv-column-idx df name)`
+0-based index of the named column, or `-1` if not present.
+
+```scheme
+(display (csv-column-idx df "age")) (newline)   ; 1
+(display (csv-column-idx df "zzz")) (newline)   ; -1
+```
+```
+1
+-1
+```
+
+### `(csv-column df name)`
+Extract a column by name as a list of values. **Errors** (`csv-column: unknown
+column`) if the name is absent.
+
+```scheme
+(display (csv-column df "age")) (newline)   ; (30 25 40)
+```
+```
+(30 25 40)
+```
+
+### `(csv-select df names)`
+Project the named columns into a **new DataFrame** whose header is `names`.
+Errors on any unknown column name.
+
+```scheme
+(display (csv-select df '("age"))) (newline)
+```
+```
+((age) (30) (25) (40))
+```
+
+### `(csv-filter df pred)`
+Keep rows for which `(pred row)` is true; returns a new DataFrame (same header).
+`pred` receives the row as a list of values.
+
+```scheme
+(display (csv-filter df (lambda (row) (> (cadr row) 25)))) (newline)
+```
+```
+((name age) (Alice 30) (Cy 40))
+```
+
+### `(csv-map-column df name f)`
+Apply `f` to every value in the named column, returning a new DataFrame. If the
+column is unknown the frame is returned unchanged (no error).
+
+```scheme
+(display (csv-map-column df "age" (lambda (a) (+ a 1)))) (newline)
+```
+```
+((name age) (Alice 31) (Bob 26) (Cy 41))
+```
+
+### `(csv-describe df)`
+Print a one-line shape summary and the column names to stdout. Returns an
+unspecified value; used for its side effect.
+
+```scheme
+(csv-describe df)
+```
+```
+DataFrame: 3 rows x 2 columns
+Columns: name, age
+```
+
+## Known issues
+
+### `csv-parse-typed` picks the last CSV line as the header
+`csv-parse-typed` calls `csv-parse`, which returns rows reversed (see
+[`core.data.csv`](data_csv.md)), then takes `(car rows)` as the header. The
+header therefore becomes the last data line and subsequent lookups fail:
+
+```scheme
+(require core.data.dataframe)
+(define df (csv-parse-typed "name,age\nAlice,30\nBob,25"))
+(display (csv-header df)) (newline)          ; (Bob 25)   -- should be (name age)
+(display (csv-rows df)) (newline)            ; ((Alice 30) (name age))
+(csv-column df "age")                          ; ERROR: csv-column: unknown column
+```
+Root cause is entirely in `csv-parse`; the DataFrame accessors are correct on a
+well-formed frame. Workaround until `csv-parse` is fixed: reconstruct the frame
+from a reversed parse, e.g. build `(cons header data)` yourself from
+`(reverse (csv-parse str))`.

--- a/docs/reference/stdlib/distributed.md
+++ b/docs/reference/stdlib/distributed.md
@@ -1,0 +1,386 @@
+# `core.distributed` — logical clocks and CRDTs
+
+**Source**: [`lib/core/distributed.esk`](../../../lib/core/distributed.esk)
+**Require**: `(require core.distributed)` — must be required individually (not auto-loaded by `(require stdlib)`).
+
+Pure value-level distributed-systems primitives: Lamport clocks, vector clocks, and
+a family of state-based CRDTs (G/PN counters, observed-remove set, last-writer-wins
+register and map, and an RGA sequence). They are intentionally independent of
+sockets/async I/O so they can back local simulations now and networked replication
+later. Every CRDT `*-merge` is commutative, associative, and idempotent, and value
+tie-breaks use `sexp->canonical-string` so equal-timestamp merges converge
+deterministically.
+
+All examples below were run with `(require core.distributed)`.
+
+## Lamport clocks
+
+A Lamport clock is just an integer.
+
+### `(lamport-zero)`
+Returns `0`, the initial clock.
+
+### `(lamport-tick clock [amount])`
+Advance `clock` by `amount` (default `1`). `amount` must be non-negative or it
+`error`s (`lamport-tick: expected a non-negative amount`).
+
+### `(lamport-merge a b)`
+Returns `max(a, b)`.
+
+### `(lamport-recv local remote)`
+Receive rule: `max(local, remote) + 1`.
+
+### `(lamport-before? a b)`
+Returns `#t` iff `a < b`.
+
+```scheme
+;; distributed.esk
+(require core.distributed)
+(display (lamport-zero))          (newline)
+(display (lamport-tick 4))        (newline)
+(display (lamport-tick 4 3))      (newline)
+(display (lamport-merge 2 7))     (newline)
+(display (lamport-recv 2 7))      (newline)
+(display (lamport-before? 3 4))   (newline)
+```
+```
+0
+5
+7
+7
+8
+#t
+```
+
+## Vector clocks
+
+Representation: an alist of `(node counter)`. Nodes are compared with `equal?`, so
+symbols, strings, and small numeric IDs all work.
+
+### `(vector-clock-empty)`
+Returns `'()`.
+
+### `(vector-clock-ref clock node)`
+Counter for `node`, or `0` if absent.
+
+### `(vector-clock-set clock node counter)`
+Return a clock with `node` set to `counter`.
+
+### `(vector-clock-tick clock node [amount])`
+Increment `node`'s counter by `amount` (default `1`). `amount` must be non-negative
+or it `error`s.
+
+### `(vector-clock-merge a b)`
+Pairwise max of the two clocks.
+
+### `(vector-clock-nodes clock)`
+List of node ids in the clock.
+
+### `(vector-clock-compare a b)`
+Returns one of `'before`, `'after`, `'equal`, `'concurrent`.
+
+### `(vector-clock-before? a b)` / `(vector-clock-after? a b)` / `(vector-clock-concurrent? a b)` / `(vector-clock-equal? a b)`
+Boolean shortcuts over `vector-clock-compare`.
+
+```scheme
+;; distributed.esk
+(require core.distributed)
+(define vc0 (vector-clock-empty))
+(define vc2 (vector-clock-tick (vector-clock-tick vc0 'a) 'a 2))
+(define vcb (vector-clock-tick vc0 'b))
+(define vcm (vector-clock-merge vc2 vcb))
+(display vc2)                                  (newline)
+(display (vector-clock-ref vc2 'a))           (newline)
+(display (vector-clock-ref vc2 'z))           (newline)
+(display vcm)                                  (newline)
+(display (vector-clock-nodes vcm))            (newline)
+(display (vector-clock-compare vc2 vcm))      (newline)
+(display (vector-clock-before? vc2 vcm))      (newline)
+(display (vector-clock-concurrent? vc2 vcb))  (newline)
+```
+```
+((a 3))
+3
+0
+((a 3) (b 1))
+(a b)
+before
+#t
+#t
+```
+
+## G-counter (grow-only)
+
+Representation: `(vector 'g-counter <vector-clock>)`.
+
+### `(make-g-counter)`
+Fresh zero counter.
+
+### `(g-counter-counts counter)`
+The underlying per-node vector clock.
+
+### `(g-counter-inc counter node [amount])`
+Return a counter with `node`'s increment raised by `amount` (default `1`,
+non-negative or `error`).
+
+### `(g-counter-value counter)`
+Sum of all per-node counts.
+
+### `(g-counter-merge a b)`
+Pairwise-max merge.
+
+```scheme
+;; distributed.esk
+(require core.distributed)
+(define g  (g-counter-inc (make-g-counter) 'a 2))
+(define gb (g-counter-inc (make-g-counter) 'b 5))
+(display (g-counter-counts g))                    (newline)
+(display (g-counter-value g))                     (newline)
+(display (g-counter-value (g-counter-merge g gb))) (newline)
+```
+```
+((a 2))
+2
+7
+```
+
+## PN-counter (increment/decrement)
+
+Representation: `(vector 'pn-counter <positive g-counter> <negative g-counter>)`.
+
+### `(make-pn-counter)`
+Fresh counter (both halves zero).
+
+### `(pn-counter-positive counter)` / `(pn-counter-negative counter)`
+The increment / decrement G-counter halves.
+
+### `(pn-counter-inc counter node [amount])` / `(pn-counter-dec counter node [amount])`
+Bump the positive / negative half by `amount` (default `1`, non-negative or `error`).
+
+### `(pn-counter-value counter)`
+`value(positive) - value(negative)`.
+
+### `(pn-counter-merge a b)`
+Merge each half independently.
+
+```scheme
+;; distributed.esk
+(require core.distributed)
+(define pn  (pn-counter-dec (pn-counter-inc (make-pn-counter) 'a 5) 'a 1))
+(define pnb (pn-counter-inc (make-pn-counter) 'b 3))
+(display (pn-counter-value pn))                       (newline)
+(display (pn-counter-value (pn-counter-merge pn pnb))) (newline)
+```
+```
+4
+3
+```
+
+## OR-set (observed-remove set)
+
+Representation: `#(or-set adds removals clock)`. Adds are `(value dot)` entries;
+removals are dots. A value is visible while at least one of its add-dots has not
+been removed — so a concurrent add that a remove never observed survives.
+
+### `(make-or-set)`
+Fresh empty set.
+
+### `(or-set-adds set)` / `(or-set-removes set)` / `(or-set-clock set)`
+Field accessors (add entries, removed dots, and the writer vector clock).
+
+### `(or-set-add set node value)`
+Add `value` tagged with a fresh dot from `node`; ticks the clock.
+
+### `(or-set-remove set value)`
+Remove all currently-observed dots of `value`.
+
+### `(or-set-member? set value)`
+Is `value` currently visible?
+
+### `(or-set-elements set)`
+List of visible values.
+
+### `(or-set-merge a b)`
+Union of adds and removals, merged clocks.
+
+```scheme
+;; distributed.esk
+(require core.distributed)
+(define os  (or-set-add (make-or-set) 'a 'task))
+(define osb (or-set-add (make-or-set) 'b 'task))
+(display (or-set-adds os))                          (newline)
+(display (or-set-clock os))                         (newline)
+(display (or-set-member? os 'task))                 (newline)
+(display (or-set-elements os))                      (newline)
+(display (or-set-member? (or-set-remove os 'task) 'task)) (newline)
+(display (or-set-member? (or-set-merge os osb) 'task))    (newline)
+```
+```
+((task (a 1)))
+((a 1))
+#t
+(task)
+#f
+#t
+```
+
+## LWW-register (last-writer-wins)
+
+Representation: `(vector 'lww-register value timestamp writer deleted?)`. Later
+timestamp wins; ties break on writer (canonical-string order), then delete-over-live,
+then value.
+
+### `(make-lww-register value timestamp writer)`
+Construct a live register.
+
+### `(lww-register-value r)` / `(lww-register-timestamp r)` / `(lww-register-writer r)` / `(lww-register-deleted? r)`
+Field accessors.
+
+### `(lww-register-present? r)`
+`#t` unless the register is a tombstone.
+
+### `(lww-register-set r value timestamp writer)`
+Return a new register with the given value/timestamp/writer (a plain write, not a
+merge — the caller supplies a monotone timestamp).
+
+### `(lww-register-delete r timestamp writer)`
+Return a tombstone register at the given timestamp.
+
+### `(lww-register-merge a b)`
+Return whichever of `a`/`b` is newer by the tie-break rules.
+
+```scheme
+;; distributed.esk
+(require core.distributed)
+(define r  (make-lww-register 'old 1 'a))
+(define r2 (lww-register-set r 'new 2 'a))
+(display (lww-register-value r))                      (newline)
+(display (lww-register-present? r))                   (newline)
+(display (lww-register-value (lww-register-merge r r2))) (newline)
+(define rd (lww-register-delete r2 3 'a))
+(display (lww-register-deleted? rd))                 (newline)
+(display (lww-register-present? rd))                 (newline)
+```
+```
+old
+#t
+new
+#t
+#f
+```
+
+## LWW-map
+
+Representation: `(vector 'lww-map <alist of (key register)>)`. Each key's value is
+an LWW-register, so per-key writes/removes/merges follow LWW rules.
+
+### `(make-lww-map)`
+Fresh empty map.
+
+### `(lww-map-entries map)`
+Raw `(key register)` alist (registers included, tombstones and all).
+
+### `(lww-map-set map key value timestamp writer)`
+Set `key` to `value` at `timestamp`/`writer`.
+
+### `(lww-map-remove map key timestamp writer)`
+Tombstone `key` at `timestamp`/`writer`.
+
+### `(lww-map-ref map key [default])`
+Visible value for `key`, else `default` (else `#f`). Tombstoned keys return
+`default`.
+
+### `(lww-map-contains? map key)`
+Is `key` present (not tombstoned)?
+
+### `(lww-map-visible-entries map)`
+List of `(key value)` for visible keys only.
+
+### `(lww-map-merge a b)`
+Per-key register merge.
+
+```scheme
+;; distributed.esk
+(require core.distributed)
+(define m  (lww-map-set (make-lww-map) 'mode 'draft 1 'a))
+(define m2 (lww-map-set m 'mode 'final 2 'b))
+(display (lww-map-entries m))                         (newline)
+(display (lww-map-ref m 'mode))                       (newline)
+(display (lww-map-ref m 'missing 'DEF))               (newline)
+(display (lww-map-contains? m 'mode))                 (newline)
+(display (lww-map-ref (lww-map-merge m m2) 'mode))    (newline)
+(display (lww-map-visible-entries m2))                (newline)
+```
+```
+((mode #(lww-register draft 1 a #f)))
+draft
+DEF
+#t
+final
+((mode final))
+```
+
+## RGA (replicated growable array — ordered sequence CRDT)
+
+Representation: `#(rga entries clock)`. Entries are `(id prev-id value deleted?)`.
+Inserts reference the previous entry's id; deletes tombstone so stale replicas can
+never reintroduce a removed element during merge. Concurrent inserts at the same
+position order deterministically by `(counter, node)`.
+
+### `(rga-root-id)`
+The sentinel root id `(rga-root 0)` — use as `prev-id` to insert at the head.
+
+### `(make-rga)`
+Fresh empty sequence.
+
+### `(rga-entries rga)` / `(rga-clock rga)`
+Field accessors (raw entry list incl. tombstones; the writer vector clock).
+
+### `(rga-entry-id e)` / `(rga-entry-prev e)` / `(rga-entry-value e)` / `(rga-entry-deleted? e)`
+Accessors for a single entry.
+
+### `(rga-insert-after rga node prev-id value)`
+Insert `value` from `node` after the entry with id `prev-id`; ticks the clock.
+
+### `(rga-append rga node value)`
+Insert `value` after the current visible tail (`rga-last-id`).
+
+### `(rga-delete rga id)`
+Tombstone the entry with `id`.
+
+### `(rga-values rga)`
+Visible values in sequence order.
+
+### `(rga-last-id rga)`
+Id of the last visible entry (or `(rga-root 0)` if empty).
+
+### `(rga-merge a b)`
+Union entries (tombstones win) and merge clocks.
+
+```scheme
+;; distributed.esk
+(require core.distributed)
+(define r1 (rga-append (make-rga) 'a 'alpha))
+(define aid (rga-last-id r1))
+(define r2 (rga-append r1 'a 'beta))
+(display (rga-root-id))       (newline)
+(display (rga-entries r1))    (newline)
+(display (rga-values r2))     (newline)
+(display (rga-last-id r2))    (newline)
+(display (rga-values (rga-delete r2 aid))) (newline)
+;; concurrent head inserts converge deterministically:
+(define rl (rga-insert-after (make-rga) 'a (rga-root-id) 'left))
+(define rr (rga-insert-after (make-rga) 'b (rga-root-id) 'right))
+(display (rga-values (rga-merge rr rl))) (newline)
+```
+```
+(rga-root 0)
+(((a 1) (rga-root 0) alpha #f))
+(alpha beta)
+(a 2)
+(beta)
+(left right)
+```
+
+Notes: `rga-values`/`rga-last-id` are O(n) tree walks over the entry list; deletes
+persist as tombstones, so `rga-entries` grows even as `rga-values` shrinks.

--- a/docs/reference/stdlib/dnc.md
+++ b/docs/reference/stdlib/dnc.md
@@ -1,0 +1,87 @@
+# `core.dnc` — differentiable external memory (NTM/DNC head)
+
+**Source**: [`lib/core/dnc.esk`](../../../lib/core/dnc.esk)
+**Require**: `(require core.dnc)` — **NOT** auto-loaded via `(require stdlib)`. Note: the functions are **native codegen builtins** (heap subtype `HEAP_SUBTYPE_DNC`), so they actually resolve even without the require; require it anyway for clarity and portability. The `.esk` file only carries the `provide` list.
+
+A learnable external memory bank of `N` rows × `W` columns that can be read and written **with gradients**. Addressing is by content (cosine similarity → softmax) or by location, controlled by a temperature `beta`: at high `beta` it behaves as a **bit-exact addressable store** (verified round-trip), at low `beta` it is smooth and differentiable (learnable). All vectors are Eshkol `#(...)` float vectors. The math mirrors `lib/backend/diff_memory_prototype.c` byte-for-byte (the C oracle / source of truth).
+
+## Functions
+
+### `(make-dnc-memory N W)`
+Create an `N`×`W` memory bank, zeroed, usage counters at 0. Returns an opaque DNC handle.
+
+### `(dnc-memory? x)`
+Predicate: `#t` iff `x` is a DNC memory handle.
+
+```scheme
+;; dnc-basic.esk
+(require core.dnc)
+(define mem (make-dnc-memory 64 8))
+(display (dnc-memory? mem))(newline)
+(display (dnc-memory? 42))(newline)
+```
+```
+#t
+#f
+```
+
+### `(dnc-content-address mem key beta)`
+Content-based addressing. `key` is a length-`W` `#(...)` vector; returns a length-`N` weight vector `softmax(beta * cosine(key, row_i))`. Higher `beta` sharpens toward the nearest row.
+
+### `(dnc-loc-address addr beta N)`
+Location-based addressing. Returns a length-`N` weight vector that is an indicator "bump" at integer address `addr` (sharp at high `beta`). Note `N` is passed explicitly here (it is not read from a memory handle).
+
+### `(dnc-read mem wvec)`
+Read: given a length-`N` weight vector `wvec`, returns the length-`W` weighted combination of memory rows.
+
+### `(dnc-write! mem wvec erase add)`
+NTM-style erase/add write (mutates `mem`). `wvec` is length-`N` (where to write), `erase` and `add` are length-`W`. A full-ones `erase` makes the write a pure overwrite (`write == add`). Returns `mem`.
+
+```scheme
+;; dnc-roundtrip.esk — write to a location, read it back (bit-exact at high beta)
+(require core.dnc)
+(define N 64)(define W 4)
+(define mem (make-dnc-memory N W))
+(define beta 10000.0)
+(define w (dnc-loc-address 3 beta N))       ; address row 3
+(dnc-write! mem w (make-vector W 1.0) (vector 1.0 2.0 3.0 4.0))
+(display (dnc-read mem (dnc-loc-address 3 beta N)))(newline)
+```
+```
+#(1 2 3 4)
+```
+
+### `(dnc-alloc-weights mem beta)`
+Return a length-`N` allocation weighting over the **least-used** rows (dynamic memory allocation à la DNC). Sharper at higher `beta`.
+
+### `(dnc-read-grad mem key target beta)`
+Exact gradient of the content-addressed read loss. Returns a **pair** `(dkey . dmem)` where `dkey` is length-`W` (gradient w.r.t. the query key) and `dmem` is length-`N*W` (gradient w.r.t. the memory contents), for the loss `0.5 * ||read(content-address(key)) - target||^2`. Agrees with central finite differences to ~1e-6 (the C oracle reaches ~9.6e-9).
+
+```scheme
+;; dnc-grad.esk
+(require core.dnc)
+(define N 8)(define W 4)
+(define mem (make-dnc-memory N W))
+(dnc-write! mem (dnc-loc-address 0 10000.0 N) (make-vector W 1.0) (vector 0.5 -0.5 0.2 0.1))
+(define key (vector 0.3 -0.5 0.2 0.8))
+(define target (vector 1.0 -1.0 0.5 0.0))
+(define gp (dnc-read-grad mem key target 2.0))
+(display "pair? ")(display (pair? gp))(newline)
+(display "dkey len ")(display (vector-length (car gp)))(newline)
+(display "dmem len ")(display (vector-length (cdr gp)))(newline)
+```
+```
+pair? #t
+dkey len 4
+dmem len 32
+```
+
+## Typical use — SGD learning on the key
+The acceptance test `tests/dnc/dnc_test.esk` uses `dnc-read-grad` in a gradient-descent loop; `key -= lr * dkey` strictly decreases the read loss (observed 20068.5 → 5709.45 over 100 steps), and at high `beta` write→read is bit-exact (round-trip error < 1e-5).
+
+## Edge cases
+- Length mismatches (e.g. a `key` not of length `W`) raise inside the native op; the acceptance test deliberately does not exercise the raising path inline to avoid aborting the suite.
+- `dnc-memory?` on any non-DNC value returns `#f` (does not error).
+
+## Verification note
+`tests/dnc/dnc_test.esk` passes 11/11 under `eshkol-run -r` (bit-exact round-trip, gradient-vs-FD < 1e-3, SGD loss decrease). No `.swarm` ledger issues reference the DNC builtins.

--- a/docs/reference/stdlib/files.md
+++ b/docs/reference/stdlib/files.md
@@ -1,0 +1,54 @@
+# `core.files` — file-system convenience helpers
+
+**Source**: [`lib/core/files.esk`](../../../lib/core/files.esk)
+**Require**: auto-loaded via `(require stdlib)`; or individually `(require core.files)`
+
+Path helpers and atomic file writes. Atomic writes go through a temp file in the destination's directory that is renamed over the target only after the writer succeeds, so a reader never observes a partially written file. The examples below write to `/tmp` and clean up.
+
+## Functions
+
+### `(path-directory path)`
+Returns the directory component of `path`. Handles both `/` and `\` separators. Special cases: a path with no separator returns `"."`; a root-anchored path returns `"/"`; a Windows drive prefix like `C:\...` returns the `"C:\"` root.
+
+```scheme
+;; files.esk
+(require stdlib)
+(display (path-directory "/tmp/foo/bar.txt")) (newline)
+(display (path-directory "bar.txt")) (newline)
+(display (path-directory "/etc")) (newline)
+```
+```
+/tmp/foo
+.
+/
+```
+
+### `(atomic-write-file path contents)`
+Convenience wrapper: atomically writes the string `contents` to `path`, returning `#t` on success and `#f` on setup/rename failure. Internally calls `with-atomic-output-file`.
+
+```scheme
+(require stdlib)
+(display (atomic-write-file "/tmp/eshkol-doc-test.txt" "hello atomic\n")) (newline)
+(display (read-file "/tmp/eshkol-doc-test.txt"))
+(delete-file "/tmp/eshkol-doc-test.txt")
+```
+```
+#t
+hello atomic
+```
+
+### `(with-atomic-output-file path proc)`
+Opens a temp file in `path`'s directory, calls `(proc port)`, closes the port, then renames the temp over `path`. Returns `proc`'s value when the rename succeeds; returns `#f` if the temp file could not be created or the rename failed. If `proc` raises, the temp file is deleted and the original exception is re-raised.
+
+```scheme
+(require stdlib)
+(with-atomic-output-file "/tmp/eshkol-doc-test2.txt"
+  (lambda (port) (write-string "line1\n" port) 'ok))
+(display (read-file "/tmp/eshkol-doc-test2.txt"))
+(delete-file "/tmp/eshkol-doc-test2.txt")
+```
+```
+line1
+```
+
+Edge cases: the atomic guarantee relies on the temp file living in the same directory as the destination (same filesystem) so the rename is atomic — `path-directory` is used to place it there. On writer exceptions the partial temp file is removed before the exception propagates. Capability-gated file operations may cause the underlying open/rename to fail (see `core.capabilities`); the relevant denial behavior is tracked in `.swarm/tasks/ESH-0076` ("Capability-denied getenv/file ops return #f silently — make denial distinguishable", status: done).

--- a/docs/reference/stdlib/functional_compose.md
+++ b/docs/reference/stdlib/functional_compose.md
@@ -1,0 +1,61 @@
+# `core.functional.compose` — function-composition combinators
+
+**Source**: [`lib/core/functional/compose.esk`](../../../lib/core/functional/compose.esk)
+**Require**: auto-loaded via `(require stdlib)`; or individually `(require core.functional.compose)`
+
+Small combinators for building new procedures out of existing ones: right-to-left composition plus two trivial building blocks (`identity`, `constantly`).
+
+## Functions
+
+### `(compose f g)`
+Returns a new unary procedure `(lambda (x) (f (g x)))` — `g` runs first, then `f`. Both `f` and `g` must be unary.
+
+```scheme
+;; compose.esk
+(require stdlib)
+(define inc (lambda (x) (+ x 1)))
+(define dbl (lambda (x) (* x 2)))
+(display ((compose inc dbl) 5)) (newline)   ; inc(dbl(5))
+```
+```
+11
+```
+
+Edge cases: strictly unary — the returned procedure takes exactly one argument. Composing procedures of other arities produces a procedure that fails when called.
+
+### `(compose3 f g h)`
+Three-way composition: `(lambda (x) (f (g (h x))))`, applied right-to-left. All three must be unary.
+
+```scheme
+(require stdlib)
+(define inc (lambda (x) (+ x 1)))
+(define dbl (lambda (x) (* x 2)))
+(display ((compose3 inc dbl inc) 5)) (newline)  ; inc(dbl(inc(5)))
+```
+```
+13
+```
+
+### `(identity x)`
+Returns its argument unchanged. Useful as a default/no-op transform.
+
+```scheme
+(require stdlib)
+(display (identity 42)) (newline)
+```
+```
+42
+```
+
+### `(constantly x)`
+Returns a unary procedure that ignores its argument and always yields `x`.
+
+```scheme
+(require stdlib)
+(display ((constantly 7) 999)) (newline)
+```
+```
+7
+```
+
+Edge cases: the returned procedure is unary; it discards whatever it is passed.

--- a/docs/reference/stdlib/functional_curry.md
+++ b/docs/reference/stdlib/functional_curry.md
@@ -1,0 +1,111 @@
+# `core.functional.curry` — currying and partial application
+
+**Source**: [`lib/core/functional/curry.esk`](../../../lib/core/functional/curry.esk)
+**Require**: auto-loaded via `(require stdlib)`; or individually `(require core.functional.curry)`
+
+Converts multi-argument procedures into chains of single-argument procedures (`curry2`/`curry3`), reverses that (`uncurry2`), and fixes leading arguments (`partial1`/`partial2`/`partial3`/`partial`).
+
+## Functions
+
+### `(curry2 f)`
+Curries a binary `f` into `(lambda (x) (lambda (y) (f x y)))`. Apply one argument at a time.
+
+```scheme
+;; curry.esk
+(require stdlib)
+(display (((curry2 +) 3) 4)) (newline)
+```
+```
+7
+```
+
+### `(curry3 f)`
+Curries a ternary `f` into a three-deep chain: `(((( curry3 f) x) y) z)`.
+
+```scheme
+(require stdlib)
+(display ((((curry3 +) 1) 2) 3)) (newline)
+```
+```
+6
+```
+
+### `(uncurry2 f)`
+Inverse of `curry2`: takes a curried binary `f` and returns an ordinary two-argument procedure `(lambda (x y) ((f x) y))`.
+
+```scheme
+(require stdlib)
+(display ((uncurry2 (curry2 -)) 10 3)) (newline)
+```
+```
+7
+```
+
+### `(partial1 f x)`
+Fixes the sole argument of a unary `f`, returning a **zero-argument thunk**. Call it with no arguments to force evaluation.
+
+```scheme
+(require stdlib)
+(display ((partial1 + 5))) (newline)   ; thunk -> (+ 5)
+```
+```
+5
+```
+
+### `(partial2 f x)`
+Fixes the first argument of a binary `f`; returns `(lambda (y) (f x y))`.
+
+```scheme
+(require stdlib)
+(display ((partial2 - 10) 3)) (newline)   ; (- 10 3)
+```
+```
+7
+```
+
+### `(partial3 f x)`
+Fixes the first argument of a ternary `f`; returns `(lambda (y z) (f x y z))`.
+
+```scheme
+(require stdlib)
+(display ((partial3 + 1) 2 3)) (newline)  ; (+ 1 2 3)
+```
+```
+6
+```
+
+### `(partial f . args)`
+Generic partial application: fixes any number of leading arguments and returns a variadic procedure that appends the rest — `(lambda xs (apply f (append args xs)))`.
+
+**Do not use this procedure — it crashes (SIGBUS). See Known issues below.** Prefer `partial1`/`partial2`/`partial3` for fixed arities.
+
+Edge cases: the fixed-arity variants (`partial1`/`partial2`/`partial3`) are safe and work as shown.
+
+## Known issues
+
+### `partial` crashes with SIGBUS
+`partial` closes over the procedure argument and `apply`s it inside a nested variadic lambda; that pattern crashes the runtime.
+
+```scheme
+(require stdlib)
+(display ((partial + 1 2 3) 4 5)) (newline)
+```
+```
+[Eshkol] fatal signal: SIGBUS (bus error) — terminating; output above is what made it to stdout before the crash
+```
+
+Minimal repro isolating the trigger — `apply` of a **captured** procedure inside a nested variadic lambda:
+
+```scheme
+(define (f g . args) (lambda xs (apply g (append args xs))))
+(display ((f + 1 2) 3 4)) (newline)   ; SIGBUS
+```
+
+The same shape with a *literal* operator instead of a captured one works fine, which pinpoints the fault to closing over the procedure:
+
+```scheme
+(define (f . args) (lambda xs (apply + (append args xs))))
+(display ((f 1 2) 3 4)) (newline)   ; => 10, no crash
+```
+
+Not yet ledgered in `.swarm/tasks/` at time of writing.

--- a/docs/reference/stdlib/functional_flip.md
+++ b/docs/reference/stdlib/functional_flip.md
@@ -1,0 +1,22 @@
+# `core.functional.flip` — argument-swapping combinator
+
+**Source**: [`lib/core/functional/flip.esk`](../../../lib/core/functional/flip.esk)
+**Require**: auto-loaded via `(require stdlib)`; or individually `(require core.functional.flip)`
+
+A single combinator that reverses the argument order of a binary procedure.
+
+## Functions
+
+### `(flip f)`
+Returns `(lambda (x y) (f y x))` — a binary procedure that calls `f` with its two arguments swapped. Handy for turning a non-commutative operator around.
+
+```scheme
+;; flip.esk
+(require stdlib)
+(display ((flip -) 3 10)) (newline)   ; (- 10 3)
+```
+```
+7
+```
+
+Edge cases: strictly binary. The returned procedure takes exactly two arguments.

--- a/docs/reference/stdlib/http_server.md
+++ b/docs/reference/stdlib/http_server.md
@@ -1,0 +1,127 @@
+# `core.http_server` — pure-Scheme HTTP request parsing, responses, and routing
+
+**Source**: [`lib/core/http_server.esk`](../../../lib/core/http_server.esk)
+**Require**: `(require core.http_server)` — **NOT** auto-loaded via `stdlib`; require it explicitly. (It internally pulls in `core.strings` and `core.metrics`.)
+
+The pure-Scheme HTTP layer: parse a raw request **string**, build/inspect response tuples, and route requests to handlers with built-in `/health`, `/ready`, `/metrics` fallbacks. The low-level socket server (`http-server-create`, `http-server-accept`, `http-server-respond`) is a set of **native generated builtins** — this module wraps them but the parsing/routing helpers here work on plain strings and need no live socket.
+
+> Not to be confused with `lib/agent/http_server.esk` (the agent socket server). This document covers only the core pure-Scheme parser module.
+
+A **response** is a 3-element list `(status content-type body)`. A **route** is a 3-element list `(method path handler)` where `handler` is `(lambda (request) …)` returning a response.
+
+## Constants
+
+### `http-max-request-body-size`
+Maximum accepted request body in bytes. Value: `10485760` (10 MiB).
+
+## Request parsing
+
+All request accessors take the raw request **string**. They tolerate both `\r\n` and `\n` line endings and degrade gracefully (returning `""` / `#f`) on malformed input rather than erroring.
+
+### `(http-request-line request)` — the first line verbatim.
+### `(http-request-method request)` — the method token (e.g. `"GET"`), or `""`.
+### `(http-request-target request)` — the request target incl. query (e.g. `"/a?x=1"`).
+### `(http-request-path request)` — target with the query stripped.
+### `(http-request-query request)` — the query string after `?`, or `""`.
+### `(http-request-version request)` — e.g. `"HTTP/1.1"`, or `""`.
+### `(http-request-header request name)` — header value by (case-insensitive) name, or `#f`. `name` may be a string or symbol.
+### `(http-request-content-length request)` — numeric `Content-Length`, or `#f` if absent/invalid.
+### `(http-request-body request)` — everything after the header/body separator, or `""`.
+### `(http-request-body-too-large? request)` — `#t` if the declared or actual body exceeds `http-max-request-body-size`.
+
+```scheme
+;; http.esk
+(require core.http_server)
+(define req
+  "GET /api/items?page=2&q=x HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\n\r\nhello")
+(display (http-request-method req)) (newline)          ; GET
+(display (http-request-target req)) (newline)          ; /api/items?page=2&q=x
+(display (http-request-path req)) (newline)            ; /api/items
+(display (http-request-query req)) (newline)           ; page=2&q=x
+(display (http-request-version req)) (newline)         ; HTTP/1.1
+(display (http-request-header req "host")) (newline)   ; localhost (case-insensitive)
+(display (http-request-header req "missing")) (newline); #f
+(display (http-request-content-length req)) (newline)  ; 5
+(display (http-request-body req)) (newline)            ; hello
+(display (http-request-body-too-large? req)) (newline) ; #f
+```
+```
+GET
+/api/items?page=2&q=x
+/api/items
+page=2&q=x
+HTTP/1.1
+localhost
+#f
+5
+hello
+#f
+```
+
+## Responses
+
+### `(http-response status content-type body)` — build the `(status content-type body)` tuple.
+### `(http-response? x)` — `#t` if `x` is a proper 3+ element list (the tuple shape).
+### `(http-response-status r)` / `(http-response-content-type r)` / `(http-response-body r)` — accessors.
+
+```scheme
+;; http.esk
+(require core.http_server)
+(define r (http-response 200 "text/plain" "OK"))
+(display (http-response? r)) (newline)               ; #t
+(display (http-response? 5)) (newline)               ; #f
+(display (http-response-status r)) (newline)         ; 200
+(display (http-response-content-type r)) (newline)   ; text/plain
+(display (http-response-body r)) (newline)           ; OK
+```
+```
+#t
+#f
+200
+text/plain
+OK
+```
+
+## Routing
+
+### `(http-route method path handler)`
+Build a route tuple. `method`/`path` are matched exactly (string `=`); `handler` takes the request string and returns a response.
+
+### `(http-route-request request routes [ready?])`
+Route `request` through `routes` (a list of route tuples). Runs the first matching handler (wrapped so a raised error or non-response becomes a 500); if none match, falls back to `http-standard-response`. Malformed `Content-Length` short-circuits to 400 and an over-size body to 413. Optional `ready?` (default `#t`) controls the `/ready` fallback.
+
+### `(http-standard-response request [ready?])`
+Built-in responses for `/health` (`200 OK`), `/ready` (`200 READY` or `500 NOT READY`), and `/metrics` (`200`, body = `(metrics-render)`). Returns `400` for empty method/path, `405` for a non-GET on a standard path, and `404` otherwise.
+
+```scheme
+;; http.esk
+(require core.http_server)
+(define routes
+  (list (http-route "GET" "/api/items"
+                    (lambda (rq) (http-response 200 "application/json" "[]")))))
+(define req "GET /api/items HTTP/1.1\r\nHost: x\r\n\r\n")
+(display (http-route-request req routes)) (newline)
+(display (http-standard-response "GET /health HTTP/1.1\r\nHost: x\r\n\r\n")) (newline)
+(display (http-standard-response "GET /nope HTTP/1.1\r\nHost: x\r\n\r\n")) (newline)
+```
+```
+(200 application/json [])
+(200 text/plain OK
+)
+(404 text/plain Not Found
+)
+```
+
+(The `/metrics` standard response body is whatever `core.metrics`' `metrics-render` produces; it is empty when no metrics are registered.)
+
+## Socket-bound helpers
+
+These two wrap the native `http-server-respond` builtin and therefore require a live server handle from `http-server-create` / `http-server-accept`. They cannot be exercised without an actual socket, so no standalone run is shown.
+
+### `(http-server-respond-response handle response)`
+Send a response tuple over the given server `handle`. Returns `#t`.
+
+### `(http-server-respond-standard handle request [ready?])`
+Compute `(http-standard-response request ready?)` and send it over `handle`.
+
+Edge cases: request accessors never raise on malformed input — a garbage string yields `""`/`#f` from the parsers. A handler that throws or returns a non-response is converted by `http-route-request` into `500 Internal Server Error`.

--- a/docs/reference/stdlib/io.md
+++ b/docs/reference/stdlib/io.md
@@ -1,0 +1,31 @@
+# `core.io` — first-class output wrappers
+
+**Source**: [`lib/core/io.esk`](../../../lib/core/io.esk)
+**Require**: auto-loaded via `(require stdlib)`; or individually `(require core.io)`
+
+Named wrappers around `display` so output can be used as a first-class procedure (e.g. with `for-each`).
+
+## Functions
+
+### `(print x)`
+`(display x)` — writes `x` to standard output with no trailing newline. Returns unspecified.
+
+### `(println x)`
+`(display x)` followed by `(newline)`.
+
+```scheme
+;; io.esk
+(require stdlib)
+(print "hello") (newline)
+(println "world")
+(for-each println '(1 2 3))
+```
+```
+hello
+world
+1
+2
+3
+```
+
+Edge cases: `print`/`println` take exactly one argument and use `display` semantics (human-readable, strings unquoted) rather than `write` semantics.

--- a/docs/reference/stdlib/json.md
+++ b/docs/reference/stdlib/json.md
@@ -1,0 +1,202 @@
+# `core.json` — JSON parsing and serialization
+
+**Source**: [`lib/core/json.esk`](../../../lib/core/json.esk)
+**Require**: `(require core.json)` — auto-loaded via `(require stdlib)`.
+
+Pure-Eshkol JSON reader/writer. Value mapping:
+
+| JSON | Eshkol |
+|------|--------|
+| object | hash-table |
+| array | list |
+| string | string |
+| number | integer or real |
+| `true` / `false` | `#t` / `#f` |
+| `null` | `'()` |
+
+Because both JSON `null` and "unparseable input" map to `'()`, use
+`json-try-parse` (Result-typed) when you must distinguish them. This module is
+also summarised in [`docs/STDLIB_V1_2_API.md`](../../STDLIB_V1_2_API.md). No bugs
+were observed.
+
+## Parsing
+
+### `(json-parse str)`
+Permissive parser: returns the parsed value, or a degenerate `'()` on malformed
+or partial input (cannot signal failure). Kept for backwards compat.
+
+```scheme
+(require core.json)
+(display (json-parse "42")) (newline)
+(display (json-parse "-3.14")) (newline)
+(display (json-parse "\"hi\"")) (newline)
+(display (json-parse "true")) (newline)
+(display (json-parse "null")) (newline)
+(display (json-parse "[1,[2,3],4]")) (newline)
+```
+```
+42
+-3.14
+hi
+#t
+()
+(1 (2 3) 4)
+```
+
+### `(json-try-parse str)` — Result-typed
+Returns a **Result**: `(json-ok . value)` on success, `(json-err . "reason")` on
+failure. Does structural balance checking and rejects trailing garbage, so it
+catches partial input that `json-parse` would silently accept.
+
+```scheme
+(define r (json-try-parse "{\"k\":1}"))
+(display (json-result-ok? r)) (newline)                 ; #t
+(display (json-result-error (json-try-parse "{\"k\":"))) (newline)
+(display (json-result-error (json-try-parse ""))) (newline)
+(display (json-result-error (json-try-parse "42 xyz"))) (newline)
+```
+```
+#t
+json-try-parse: missing closing brace
+json-try-parse: empty input
+json-try-parse: trailing garbage after JSON value
+```
+
+### `(json-parse-result? r)` / `(json-result-ok? r)` / `(json-result-value r)` / `(json-result-error r)`
+Predicates and accessors for the Result type. `json-parse-result?` recognises
+either tag; `json-result-ok?` is true only for `(json-ok . _)`.
+`json-result-value` extracts the value (errors on an Err); `json-result-error`
+extracts the message (errors on an Ok).
+
+```scheme
+(define r (json-try-parse "{\"k\":1}"))
+(display (json-parse-result? r)) (newline)          ; #t
+(display (hash-table? (json-result-value r))) (newline)  ; #t
+```
+```
+#t
+#t
+```
+
+## Accessors
+
+### `(json-get obj key [default])`
+Look up `key` in a parsed object (hash-table). Returns `#f` if absent, or the
+supplied `default`.
+
+```scheme
+(define obj (json-parse "{\"a\":1,\"b\":\"x\"}"))
+(display (json-get obj "a")) (newline)          ; 1
+(display (json-get obj "z")) (newline)          ; #f
+(display (json-get obj "z" 99)) (newline)       ; 99
+```
+```
+1
+#f
+99
+```
+
+### `(json-array-ref arr idx)`
+Index into a parsed array (list) — thin wrapper over `list-ref`.
+
+```scheme
+(display (json-array-ref '(10 20 30) 1)) (newline)   ; 20
+```
+```
+20
+```
+
+### `(json-get-in obj keys)`
+Follow a path of keys into nested objects/arrays. String keys index
+hash-tables; integer keys index lists. Returns `#f` if any step fails.
+
+```scheme
+(display (json-get-in (json-parse "{\"a\":{\"b\":[1,2,3]}}") '("a" "b" 2))) (newline)
+```
+```
+3
+```
+
+## Serialization
+
+### `(json-stringify value)`
+Serialize an Eshkol value to a JSON string. Handles numbers, strings, booleans,
+`'()`→`null`, symbols→strings, lists→arrays, hash-tables→objects, and **alists**
+(lists of `(key . value)` cons cells with string/symbol keys)→objects.
+
+```scheme
+(display (json-stringify 42)) (newline)
+(display (json-stringify "hi")) (newline)
+(display (json-stringify '(1 2 3))) (newline)
+(display (json-stringify #t)) (newline)
+(display (json-stringify '())) (newline)
+(display (json-stringify '(("a" . 1) ("b" . 2)))) (newline)
+```
+```
+42
+"hi"
+[1,2,3]
+true
+null
+{"a":1,"b":2}
+```
+
+### `(alist->json alist)`
+Convenience: serialize an association list as a JSON object (via a hash-table).
+Note key order is hash-table order, not insertion order.
+
+```scheme
+(display (alist->json '(("name" . "test") ("value" . 42)))) (newline)
+```
+```
+{"name":"test","value":42}
+```
+
+## Hash-table / alist conversion
+
+### `(hash-table->alist ht)` / `(alist->hash-table alist)`
+Convert between a hash-table and an alist of `(key . value)` pairs.
+
+```scheme
+(define ht (alist->hash-table '(("a" . 1) ("b" . 2))))
+(display (hash-ref ht "a" #f)) (newline)            ; 1
+(display (hash-table->alist ht)) (newline)          ; order is hash order
+```
+```
+1
+((b . 2) (a . 1))
+```
+
+## File / port I/O
+
+### `(json-write value target)`
+Write `value` as JSON to `target`, which may be an output port or a path string.
+Returns `#t` on success, `#f` otherwise.
+
+### `(json-write-file filename data)`
+Write `data` as JSON to a file (opens/closes the file).
+
+### `(alist-write-json filename alist)`
+Write an alist as a JSON object to a file.
+
+### `(json-read source)`
+Read and parse JSON from an input port or a path string. Ports are left open;
+paths are opened and closed.
+
+### `(json-read-file filename)`
+Open a file, read all lines, parse the concatenation as JSON, and close.
+
+```scheme
+(define ht (alist->hash-table '(("a" . 1) ("b" . 2))))
+(json-write-file "/tmp/d.json" ht)
+(display (json-get (json-read-file "/tmp/d.json") "a")) (newline)   ; 1
+(json-write '(("x" . 10)) "/tmp/e.json")
+(display (json-get (json-read "/tmp/e.json") "x")) (newline)        ; 10
+(alist-write-json "/tmp/f.json" '(("q" . 7)))
+(display (json-get (json-read-file "/tmp/f.json") "q")) (newline)   ; 7
+```
+```
+1
+10
+7
+```

--- a/docs/reference/stdlib/json_schema.md
+++ b/docs/reference/stdlib/json_schema.md
@@ -1,0 +1,107 @@
+# `core.json_schema` — JSON Schema (Draft 7 subset) validator
+
+**Source**: [`lib/core/json_schema.esk`](../../../lib/core/json_schema.esk)
+**Require**: `(require core.json_schema)` — auto-loaded via `(require stdlib)`.
+
+Validates values produced by [`core.json`](json.md)'s `json-parse` against a
+schema that is itself expressed as parsed JSON (hash-tables / lists). This module
+is also summarised in [`docs/STDLIB_V1_2_API.md`](../../STDLIB_V1_2_API.md). No
+bugs were observed.
+
+**Supported keywords**: `type` (single or list of
+`object|array|string|number|integer|boolean|null`), `properties`, `required`,
+`additionalProperties` (`#f` rejects extras), `items`, `minItems`/`maxItems`,
+`minLength`/`maxLength`, `minimum`/`maximum`,
+`exclusiveMinimum`/`exclusiveMaximum`, `enum`, `const`, `pattern` (substring
+containment, **not** full regex), `oneOf`, `anyOf`, `allOf`, `not`. A boolean
+schema `#t` always passes and `#f` always fails.
+
+Error strings carry a JSON-pointer-style path; the top-level path is `""`, so
+top-level errors read as `": message"`.
+
+## Functions
+
+### `(json-schema-valid? schema value)`
+Return `#t` if `value` conforms to `schema`, else `#f`.
+
+```scheme
+(require core.json_schema)
+(require core.json)
+(define (sch s) (json-parse s))
+(display (json-schema-valid? (sch "{\"type\":\"integer\"}") 42)) (newline)
+(display (json-schema-valid? (sch "{\"type\":\"integer\"}") "x")) (newline)
+(display (json-schema-valid? (sch "{\"type\":[\"integer\",\"string\"]}") "x")) (newline)
+```
+```
+#t
+#f
+#t
+```
+
+### `(json-schema-validate schema value)`
+Return a **list of error strings** (empty ⇒ valid). Each string is
+`"<path>: <message>"`.
+
+```scheme
+(display (json-schema-validate (sch "{\"type\":\"integer\"}") "x")) (newline)
+(display (json-schema-validate
+   (sch "{\"type\":\"object\",\"required\":[\"age\"]}")
+   (json-parse "{\"name\":\"x\"}"))) (newline)
+(display (json-schema-validate
+   (sch "{\"type\":\"array\",\"items\":{\"type\":\"integer\"}}")
+   (json-parse "[1,\"x\",3]"))) (newline)
+(display (json-schema-validate (sch "{\"minimum\":10,\"maximum\":20}") 5)) (newline)
+(display (json-schema-validate (sch "{\"minLength\":3}") "ab")) (newline)
+```
+```
+(: expected integer, got string)
+(/age: missing required property)
+(/1: expected integer, got string)
+(: value < minimum=10)
+(: string shorter than minLength=3)
+```
+
+### Keyword coverage examples
+
+Object properties, `additionalProperties: false`, combinators, `enum`/`const`,
+and `pattern` (substring match) all validate as expected:
+
+```scheme
+(display (json-schema-valid?
+  (sch "{\"type\":\"object\",\"properties\":{\"age\":{\"type\":\"integer\"}},\"required\":[\"age\"]}")
+  (json-parse "{\"age\":30}"))) (newline)                         ; #t
+(display (json-schema-validate
+  (sch "{\"type\":\"object\",\"properties\":{\"a\":{}},\"additionalProperties\":false}")
+  (json-parse "{\"a\":1,\"b\":2}"))) (newline)                    ; (/b: additional property not allowed)
+(display (json-schema-valid? (sch "{\"pattern\":\"@\"}") "a@b")) (newline)   ; #t (substring)
+(display (json-schema-valid? (sch "{\"enum\":[1,2,3]}") 2)) (newline)         ; #t
+(display (json-schema-valid? (sch "{\"const\":5}") 5)) (newline)              ; #t
+(display (json-schema-valid? (sch "{\"oneOf\":[{\"type\":\"integer\"},{\"type\":\"string\"}]}") 5)) (newline)  ; #t
+(display (json-schema-valid? (sch "{\"anyOf\":[{\"type\":\"integer\"},{\"type\":\"string\"}]}") "x")) (newline) ; #t
+(display (json-schema-valid? (sch "{\"not\":{\"type\":\"string\"}}") 5)) (newline)  ; #t
+```
+```
+#t
+(/b: additional property not allowed)
+#t
+#t
+#t
+#t
+#t
+#t
+```
+
+### Boolean schemas
+
+```scheme
+(display (json-schema-valid? #t 42)) (newline)          ; #t (always valid)
+(display (json-schema-validate #f 42)) (newline)        ; rejected
+```
+```
+#t
+(: schema is `false` — value rejected)
+```
+
+Edge cases: `pattern` is substring containment only — `"^v"` would require the
+literal characters `^v` to appear, since no regex engine is used. The `"number"`
+type accepts both integers and reals; `"integer"` is the strict subset.

--- a/docs/reference/stdlib/list_compound.md
+++ b/docs/reference/stdlib/list_compound.md
@@ -1,0 +1,67 @@
+# `core.list.compound` — compound `car`/`cdr` accessors and positional selectors
+
+**Source**: [`lib/core/list/compound.esk`](../../../lib/core/list/compound.esk)
+**Require**: `(require core.list.compound)` — auto-loaded by `(require stdlib)`.
+
+Simple compositions of `car`/`cdr`. Every two-, three-, and four-level `c[ad]+r`
+combination is provided, plus the ordinal selectors `first` … `tenth`. Reading
+right-to-left, each `a` means `car` and each `d` means `cdr` (e.g. `caddr` =
+`(car (cdr (cdr x)))`).
+
+## Functions
+
+### `(caar x)` `(cadr x)` `(cdar x)` `(cddr x)`
+Two-level accessors. `cadr` is "second element", `cddr` is "the list past the
+first two".
+
+### `(caaar x)` … `(cdddr x)`
+All eight three-level combinations.
+
+### `(caaaar x)` … `(cddddr x)`
+All sixteen four-level combinations.
+
+```scheme
+;; compound.esk
+(require core.list.compound)
+(define nested '((1 2) (3 4) (5 6)))
+(define deep '(((a b) (c d)) ((e f) (g h))))
+(define lst '(10 20 30 40 50 60 70 80 90 100))
+(display (caar nested)) (newline)     ; car of car
+(display (cadr lst)) (newline)        ; second
+(display (cddr nested)) (newline)     ; drop first two
+(display (caddr lst)) (newline)       ; third
+(display (cadddr lst)) (newline)      ; fourth
+(display (caaar deep)) (newline)      ; car^3
+```
+```
+1
+20
+((5 6))
+30
+40
+a
+```
+
+### `(first x)` `(second x)` `(third x)` `(fourth x)` `(fifth x)` `(sixth x)` `(seventh x)` `(eighth x)` `(ninth x)` `(tenth x)`
+Ordinal element selectors (1-based). `first` = `car`, `second` = `cadr`, …,
+`tenth` returns the tenth element. Implemented as compositions, so `fifth`
+onward chain through `cddddr`.
+
+```scheme
+;; ordinals.esk
+(require core.list.compound)
+(define lst '(10 20 30 40 50 60 70 80 90 100))
+(display (first lst)) (display " ") (display (second lst)) (display " ") (display (third lst)) (newline)
+(display (fourth lst)) (display " ") (display (fifth lst)) (display " ") (display (sixth lst)) (newline)
+(display (seventh lst)) (display " ") (display (eighth lst)) (display " ") (display (ninth lst)) (display " ") (display (tenth lst)) (newline)
+```
+```
+10 20 30
+40 50 60
+70 80 90 100
+```
+
+Edge cases: these are unguarded compositions of `car`/`cdr`. Applying an
+accessor deeper than the structure allows (e.g. `(caddr '(1))` or
+`(fifth '(1 2 3))`) reduces to taking `car`/`cdr` of `'()`, which is a runtime
+error in the underlying `car`/`cdr` — there is no bounds checking here.

--- a/docs/reference/stdlib/list_compound.md
+++ b/docs/reference/stdlib/list_compound.md
@@ -15,10 +15,63 @@ Two-level accessors. `cadr` is "second element", `cddr` is "the list past the
 first two".
 
 ### `(caaar x)` … `(cdddr x)`
-All eight three-level combinations.
+All eight three-level combinations (read right-to-left):
+`caaar` `(car (car (car x)))`, `caadr` `(car (car (cdr x)))`,
+`cadar` `(car (cdr (car x)))`, `caddr` `(car (cdr (cdr x)))`,
+`cdaar` `(cdr (car (car x)))`, `cdadr` `(cdr (car (cdr x)))`,
+`cddar` `(cdr (cdr (car x)))`, `cdddr` `(cdr (cdr (cdr x)))`.
+
+```scheme
+;; three-level.esk
+(require core.list.compound)
+(define x '(((1 2) (3 4)) ((5 6) (7 8)) ((9 10) (11 12)) ((13 14) (15 16))))
+(display (cdaar x)) (newline)
+(display (caadr x)) (newline)
+(display (cadar x)) (newline)
+(display (cdadr x)) (newline)
+(display (cddar x)) (newline)
+```
+```
+(2)
+(5 6)
+(3 4)
+((7 8))
+()
+```
 
 ### `(caaaar x)` … `(cddddr x)`
-All sixteen four-level combinations.
+All sixteen four-level combinations:
+`caaaar` `caaadr` `caadar` `caaddr` `cadaar` `cadadr` `caddar` `cadddr`
+`cdaaar` `cdaadr` `cdadar` `cdaddr` `cddaar` `cddadr` `cdddar` `cddddr` —
+each expands to the corresponding four-deep `car`/`cdr` chain, rightmost
+letter applied first.
+
+```scheme
+;; four-level.esk
+(require core.list.compound)
+(define x '(((1 2) (3 4)) ((5 6) (7 8)) ((9 10) (11 12)) ((13 14) (15 16))))
+(define y '((a b c d) (e f g h) (i j k l) (m n o p)))
+(display (caaadr x)) (newline)
+(display (cadadr x)) (newline)
+(display (cdaadr x)) (newline)
+(display (cddadr x)) (newline)
+(display (cdadar x)) (newline)
+(display (cdaddr y)) (newline)
+(display (caaddr y)) (newline)
+(display (cdddar y)) (newline)
+(display (cddddr y)) (newline)
+```
+```
+5
+(7 8)
+(6)
+()
+(4)
+(j k l)
+i
+(d)
+()
+```
 
 ```scheme
 ;; compound.esk
@@ -65,3 +118,20 @@ Edge cases: these are unguarded compositions of `car`/`cdr`. Applying an
 accessor deeper than the structure allows (e.g. `(caddr '(1))` or
 `(fifth '(1 2 3))`) reduces to taking `car`/`cdr` of `'()`, which is a runtime
 error in the underlying `car`/`cdr` — there is no bounds checking here.
+
+### Known issues
+
+Taking `cdr` of a **non-pair atom** mid-chain crashes with SIGSEGV rather
+than a clean runtime error. Verified repro:
+
+```scheme
+(require core.list.compound)
+(define x '((1 2 3) (4 5 6)))
+(display (cdaar x))   ; caar = 1 (an integer); cdr of 1 → SIGSEGV
+```
+```
+[Eshkol] fatal signal: SIGSEGV (segmentation fault) — terminating; output above is what made it to stdout before the crash
+```
+
+This is the general car/cdr-of-non-pair behavior, not specific to this
+module; deep accessors just make it easy to hit.

--- a/docs/reference/stdlib/list_convert.md
+++ b/docs/reference/stdlib/list_convert.md
@@ -1,0 +1,45 @@
+# `core.list.convert` — list ↔ vector conversion
+
+**Source**: [`lib/core/list/convert.esk`](../../../lib/core/list/convert.esk)
+**Require**: `(require core.list.convert)` — auto-loaded by `(require stdlib)`.
+
+Two conversions between proper lists and Eshkol vectors. Note that `#(...)`
+literals are Eshkol *tensors* (homogeneous doubles) while `(vector ...)`
+produces heterogeneous tagged-value vectors; `vector->list` works on both via
+`vector-ref`/`vector-length`.
+
+## Functions
+
+### `(list->vector lst)`
+Allocates a fresh vector of `(length lst)` slots (initialised to `#f`) and fills
+it left-to-right from the list. Returns the vector.
+
+```scheme
+;; convert.esk
+(require core.list.convert)
+(display (list->vector '(1 2 3))) (newline)
+(display (list->vector '())) (newline)
+```
+```
+#(1 2 3)
+#()
+```
+
+Edge cases: empty list returns an empty vector `#()`.
+
+### `(vector->list vec)`
+Builds a list from vector elements in index order by folding from the last
+index down (so the result order matches the vector). Returns a proper list.
+
+```scheme
+;; v2l.esk
+(require core.list.convert)
+(display (vector->list #(4 5 6))) (newline)
+(display (vector->list #())) (newline)
+```
+```
+(4 5 6)
+()
+```
+
+Edge cases: empty vector returns `'()`.

--- a/docs/reference/stdlib/list_generate.md
+++ b/docs/reference/stdlib/list_generate.md
@@ -1,0 +1,93 @@
+# `core.list.generate` — list constructors and number ranges
+
+**Source**: [`lib/core/list/generate.esk`](../../../lib/core/list/generate.esk)
+**Require**: `(require core.list.generate)` — auto-loaded by `(require stdlib)`.
+Internally depends on `core.list.query` (for `length`, used by `make-list`).
+
+Constructors for numeric ranges (`iota`, `range`) and simple list building
+(`repeat`, `make-list`, `zip`). All produce freshly allocated proper lists.
+
+## Functions
+
+### `(iota count)`
+Returns `(0 1 … count-1)`. Built tail-recursively from the top down.
+
+### `(iota-from count start)`
+Returns `count` consecutive integers starting at `start`:
+`(start start+1 … start+count-1)`. Note arg order: **count first, start second**.
+
+### `(iota-step count start step)`
+Returns `count` numbers `(start start+step start+2·step …)`.
+
+```scheme
+;; generate.esk
+(require core.list.generate)
+(display (iota 5)) (newline)
+(display (iota-from 5 1)) (newline)
+(display (iota-step 5 0 2)) (newline)
+```
+```
+(0 1 2 3 4)
+(1 2 3 4 5)
+(0 2 4 6 8)
+```
+
+Edge cases: `count <= 0` yields `'()`.
+
+### `(repeat n x)`
+Returns a list of `n` copies of `x`. `n <= 0` yields `'()`.
+
+### `(make-list . args)`
+Dual-mode constructor:
+- **2 args where the first is a non-negative integer** → `(make-list n fill)`
+  builds `n` copies of `fill` (delegates to `repeat`).
+- **otherwise** → variadic: returns the argument list as-is.
+
+```scheme
+;; makelist.esk
+(require core.list.generate)
+(display (repeat 3 'x)) (newline)
+(display (make-list 3 'a)) (newline)   ; mode 1: n + fill
+(display (make-list 1 2 3)) (newline)  ; mode 2: variadic
+```
+```
+(x x x)
+(a a a)
+(1 2 3)
+```
+
+Note: because of the dual-mode heuristic, `(make-list 2 'z)` is ambiguous with
+the variadic reading but resolves to mode 1 (two copies of `z`) since `2` is a
+non-negative integer and there are exactly two args. To force the literal
+two-element list `(2 z)` you cannot use `make-list`; use `(list 2 'z)`.
+
+### `(range start end)`
+Returns integers from `start` up to but **excluding** `end`. `start >= end`
+yields `'()`. Non-tail-recursive (see Known issues).
+
+### `(zip lst1 lst2)`
+Combines two lists element-wise into a list of two-element lists. Stops at the
+shorter of the two.
+
+```scheme
+;; range-zip.esk
+(require core.list.generate)
+(display (range 0 5)) (newline)
+(display (range 2 2)) (newline)
+(display (zip '(a b c) '(1 2 3))) (newline)
+(display (zip '(a b) '(1 2 3))) (newline)   ; stops at shorter
+```
+```
+(0 1 2 3 4)
+()
+((a 1) (b 2) (c 3))
+((a 1) (b 2))
+```
+
+### Known issues
+
+`range` and `zip` are non-tail-recursive (they `cons` before recursing), so they
+inherit the stdlib depth ceiling documented in
+[`list_query.md`](list_query.md) and [`list_transform.md`](list_transform.md):
+generating a multi-hundred-thousand-element range in a single call can SIGILL.
+`iota` / `iota-from` / `iota-step` are tail-recursive and safe well past 1M.

--- a/docs/reference/stdlib/list_higher_order.md
+++ b/docs/reference/stdlib/list_higher_order.md
@@ -1,0 +1,119 @@
+# `core.list.higher_order` — map / fold / for-each / any / every
+
+**Source**: [`lib/core/list/higher_order.esk`](../../../lib/core/list/higher_order.esk)
+**Require**: `(require core.list.higher_order)` — auto-loaded by `(require stdlib)`.
+
+Classic higher-order list operations. The map family is arity-suffixed
+(`map1`/`map2`/`map3`) rather than variadic. The fold family provides every
+common spelling (`fold`, `fold-left`, `foldl`, `fold-right`, `foldr`) as aliases
+around two real implementations.
+
+## Functions
+
+### `(map1 proc lst)`
+Maps a 1-argument `proc` over one list.
+
+### `(map2 proc lst1 lst2)`
+Maps a 2-argument `proc` over two lists element-wise; stops at the shorter list.
+
+### `(map3 proc lst1 lst2 lst3)`
+Maps a 3-argument `proc` over three lists element-wise; stops at the shortest.
+
+```scheme
+;; maps.esk
+(require core.list.higher_order)
+(display (map1 (lambda (x) (* x x)) '(1 2 3))) (newline)
+(display (map2 + '(1 2 3) '(10 20 30))) (newline)
+(display (map3 (lambda (a b c) (+ a b c)) '(1 2) '(10 20) '(100 200))) (newline)
+```
+```
+(1 4 9)
+(11 22 33)
+(111 222)
+```
+
+### `(fold proc init lst)` / `(fold-left proc init lst)` / `(foldl proc init lst)`
+Left fold. `proc` is called as `(proc acc elt)` — **accumulator first, element
+second** — left to right. `fold-left` and `foldl` are exact synonyms of `fold`.
+Tail-recursive (safe on very long lists).
+
+### `(fold-right proc init lst)` / `(foldr proc init lst)`
+Right fold. `proc` is called as `(proc elt acc)` — **element first, accumulator
+second** — right to left. `foldr` is a synonym of `fold-right`. Non-tail-recursive.
+
+```scheme
+;; folds.esk
+(require core.list.higher_order)
+(display (fold + 0 '(1 2 3 4))) (newline)
+(display (fold-left cons '() '(1 2 3))) (newline)   ; (proc acc elt)
+(display (foldl - 0 '(1 2 3))) (newline)            ; ((0-1)-2)-3
+(display (fold-right cons '() '(1 2 3))) (newline)  ; rebuilds list
+(display (foldr - 0 '(1 2 3))) (newline)            ; 1-(2-(3-0))
+```
+```
+10
+(((() . 1) . 2) . 3)
+-6
+(1 2 3)
+2
+```
+
+Note the differing argument order between the left and right families:
+`fold`/`foldl` pass `(acc elt)`; `fold-right`/`foldr` pass `(elt acc)`.
+
+### `(for-each proc lst)`
+Applies `proc` to each element for effect, left to right. Returns `#f` on the
+empty list (its return value is otherwise unspecified — do not rely on it).
+
+```scheme
+;; foreach.esk
+(require core.list.higher_order)
+(for-each (lambda (x) (display x) (display "-")) '(a b c)) (newline)
+```
+```
+a-b-c-
+```
+
+### `(any pred lst)`
+Returns `#t` as soon as any element satisfies `pred`, else `#f`. (Returns a plain
+boolean, not the satisfying value.)
+
+### `(every pred lst)`
+Returns `#t` if every element satisfies `pred` (vacuously `#t` on `'()`), else `#f`.
+
+### `(filter-map fn lst)`
+Applies `fn` to each element and keeps only the truthy results (SRFI-1). Combines
+`map` + `filter` in one pass.
+
+```scheme
+;; any-every-fm.esk
+(require core.list.higher_order)
+(display (any even? '(1 3 4 5))) (newline)
+(display (every even? '(2 4 6))) (newline)
+(display (filter-map (lambda (x) (if (odd? x) (* x x) #f)) '(1 2 3))) (newline)
+```
+```
+#t
+#t
+(1 9)
+```
+
+Edge cases (verified): `(filter-map fn '())` → `'()`;
+`(filter-map (lambda (x) #f) '(1 2 3))` → `'()`;
+`(any pred '())` → `#f`; `(every pred '())` → `#t`.
+
+### Known issues — depth ceiling
+
+`map1`/`map2`/`map3`, `fold-right`/`foldr`, and `filter-map` are all
+non-tail-recursive (they `cons` or apply `proc` around the recursive call), so
+they hit the same silent-SIGILL ceiling as `length`/`filter`
+(see [`list_query.md`](list_query.md), ESH-0108). Observed on this machine:
+
+| op | passes | SIGILLs (rc 132, no output) |
+| --- | --- | --- |
+| `map1` (with closure) | ~200k | 300,000 |
+| `fold-right` | — | 250,000 |
+
+The **left folds** `fold`/`fold-left`/`foldl` are tail-recursive and complete on
+1,000,000-element lists (`(fold + 0 (iota 1000000))` → `499999500000`). Prefer
+them, or reverse-then-cons, when processing very long lists.

--- a/docs/reference/stdlib/list_query.md
+++ b/docs/reference/stdlib/list_query.md
@@ -1,0 +1,67 @@
+# `core.list.query` — list length and predicate queries
+
+**Source**: [`lib/core/list/query.esk`](../../../lib/core/list/query.esk)
+**Require**: `(require core.list.query)` — auto-loaded by `(require stdlib)`.
+
+Small query helpers over proper lists. `last` and `last-pair` are **not** here —
+they are kept as builtins for performance.
+
+## Functions
+
+### `(count-if pred lst)`
+Returns the number of elements for which `(pred elt)` is truthy.
+
+### `(find pred lst)`
+Returns the first element satisfying `pred`, or `#f` if none match.
+
+### `(length lst)`
+Returns the number of elements in a proper list.
+
+```scheme
+;; query.esk
+(require core.list.query)
+(display (count-if even? '(1 2 3 4 5 6))) (newline)
+(display (find even? '(1 3 5 6 7))) (newline)
+(display (find even? '(1 3 5))) (newline)
+(display (length '(a b c d))) (newline)
+(display (length '())) (newline)
+```
+```
+3
+6
+#f
+4
+0
+```
+
+Edge cases: on `'()`, `count-if` → `0`, `find` → `#f`, `length` → `0`.
+
+### Known issues — depth ceiling (ESH-0108)
+
+**`length` is non-tail-recursive** (`(+ 1 (length (cdr lst)))`), so it consumes
+one native stack frame per element. On large lists it SIGILLs (exit code 132)
+with **no diagnostic** — the runtime's `ESHKOL_MAX_RECURSION_DEPTH=100000` guard
+only covers C runtime list helpers, not stdlib user functions, so this failure
+mode is a silent trap rather than a "maximum recursion depth exceeded" message.
+
+Observed thresholds (JIT, `-r`, this machine):
+
+| `length` input | result |
+| --- | --- |
+| 400,000 | `400000` (ok) |
+| 500,000 | SIGILL, rc 132, no output |
+
+Repro:
+```scheme
+(require core.list.query)
+(require core.list.generate)
+(display (length (iota 500000))) (newline)   ; => SIGILL (rc 132)
+```
+
+`count-if` shares the same non-tail shape (plus a predicate call per frame, so it
+fails earlier — around ~250–300k). Tracked as **ESH-0108** ("stdlib
+length/filter are non-tail-recursive: SIGILL without diagnostic on ~500k+
+lists"). This is a docs-only note; no code changed. If you must measure very
+long lists, fold a counter with a tail-recursive `fold`/`fold-left`
+(see [`list_higher_order.md`](list_higher_order.md)) instead:
+`(fold (lambda (acc _) (+ acc 1)) 0 lst)`.

--- a/docs/reference/stdlib/list_search.md
+++ b/docs/reference/stdlib/list_search.md
@@ -1,0 +1,95 @@
+# `core.list.search` — membership, association, and positional access
+
+**Source**: [`lib/core/list/search.esk`](../../../lib/core/list/search.esk)
+**Require**: `(require core.list.search)` — auto-loaded by `(require stdlib)`.
+
+R7RS-style membership (`member`/`memq`/`memv`), association-list lookup
+(`assoc`/`assq`/`assv`), and positional access (`list-ref`/`list-tail`/`list-set!`).
+The `equal?`-style variants use an internal type-dispatching comparator
+(`list-search-equal?`) that compares strings with `string=?`, numbers with `=`,
+chars with `char=?`, symbols/booleans with `eq?`, and falls back to `equal?`.
+
+## Functions
+
+### `(member x lst)`
+Returns the sublist beginning at the first element `equal?`-comparable to `x`,
+or `#f` if not found.
+
+### `(member? x lst)`
+Boolean convenience wrapper: `#t` if `x` is present, else `#f`.
+
+### `(memq x lst)` / `(memv x lst)`
+Like `member` but compare with `eq?` (`memq`) or `eqv?` (`memv`).
+
+```scheme
+;; member.esk
+(require core.list.search)
+(display (member 3 '(1 2 3 4 5))) (newline)
+(display (member 9 '(1 2 3))) (newline)
+(display (member? 3 '(1 2 3))) (newline)
+(display (memq 'c '(a b c d))) (newline)
+(display (memv 2 '(1 2 3))) (newline)
+```
+```
+(3 4 5)
+#f
+#t
+(c d)
+(2 3)
+```
+
+### `(assoc key alist)`
+Returns the first `(key . …)` pair whose car is `equal?`-comparable to `key`, or
+`#f`. `alist` is a list of pairs.
+
+### `(assq key alist)` / `(assv key alist)`
+Like `assoc` but compare keys with `eq?` (`assq`) or `eqv?` (`assv`).
+
+```scheme
+;; assoc.esk
+(require core.list.search)
+(display (assoc 'b '((a 1) (b 2) (c 3)))) (newline)
+(display (assq 'c '((a 1) (b 2) (c 3)))) (newline)
+(display (assv 2 '((1 one) (2 two)))) (newline)
+```
+```
+(b 2)
+(c 3)
+(2 two)
+```
+
+### `(list-ref lst n)`
+Returns the `n`th element (0-indexed). Note arg order: **list first, index
+second**.
+
+### `(list-tail lst n)`
+Returns the sublist starting at index `n` (0-indexed). `n <= 0` returns the whole
+list.
+
+### `(list-set! lst n val)`
+Mutates the `n`th pair's car to `val` in place (via `set-car!` on
+`(list-tail lst n)`). Returns the result of `set-car!` (do not rely on it); the
+effect is the mutation.
+
+```scheme
+;; positional.esk
+(require core.list.search)
+(display (list-ref '(a b c d) 2)) (newline)
+(display (list-tail '(a b c d) 2)) (newline)
+(define x (list 1 2 3))
+(list-set! x 1 99)
+(display x) (newline)
+```
+```
+c
+(c d)
+(1 99 3)
+```
+
+Note: `list-set!` mutates, so its target must be a mutable list built with
+`list`/`cons` (not shared with a quoted literal you also read elsewhere).
+
+Edge cases: `member`/`memq`/`memv`/`assoc`/`assq`/`assv` return `#f` on `'()` or
+when the key is absent. `list-ref`/`list-tail` are unguarded — indexing past the
+end reduces to `(car '())` / `(cdr '())` (runtime error). All of these are
+tail-recursive and safe on long lists.

--- a/docs/reference/stdlib/list_sort.md
+++ b/docs/reference/stdlib/list_sort.md
@@ -1,0 +1,68 @@
+# `core.list.sort` — merge sort
+
+**Source**: [`lib/core/list/sort.esk`](../../../lib/core/list/sort.esk)
+**Require**: `(require core.list.sort)` — auto-loaded by `(require stdlib)`.
+
+A single `sort` function implementing top-down merge sort with a user-supplied
+comparator. Not stable-guaranteed by contract, but the merge favours the left
+half on ties (`less?` strictly-less test), which preserves input order for equal
+keys in practice.
+
+## Functions
+
+### `(sort lst less?)`
+Returns a new list containing the elements of `lst` ordered by the binary
+predicate `less?`. Note arg order: **list first, comparator second**.
+
+**Comparator contract**: `less?` is called as `(less? a b)` and must return a
+truthy value when `a` should come *before* `b`. Passing `<` sorts ascending;
+passing `>` sorts descending.
+
+```scheme
+;; sort.esk
+(require core.list.sort)
+(display (sort '(3 1 4 1 5 9 2 6) <)) (newline)
+(display (sort '(3 1 4 1 5 9 2 6) >)) (newline)
+(display (sort '() <)) (newline)
+(display (sort '(42) <)) (newline)
+```
+```
+(1 1 2 3 4 5 6 9)
+(9 6 5 4 3 2 1 1)
+()
+(42)
+```
+
+Edge cases: `'()` sorts to `'()`, a singleton sorts to itself.
+
+To sort strings, supply a string comparator explicitly — `string<?` is **not**
+auto-loaded into the default namespace, so `(sort strs string<?)` errors with
+`Undefined variable: string<?` unless you have brought it into scope. Define your
+own or require the string module that provides it.
+
+### Known issues — recursion depth is O(n) (ESH-0098)
+
+The recursion **control depth grows linearly with list length**, not
+logarithmically, because `sort` recurses on `(take-n mid …)` / `(drop-n mid …)`
+and those helpers plus `merge` are themselves non-tail-recursive. Consequences on
+this machine:
+
+| `sort` input | result |
+| --- | --- |
+| 50,000 | sorted (ok) |
+| 100,000 | `Unhandled exception: maximum recursion depth (100000) exceeded` (rc 1) |
+
+Repro:
+```scheme
+(require core.list.sort)
+(require core.list.generate)
+(display (car (sort (iota 100000) <))) (newline)
+;; => Unhandled exception: maximum recursion depth (100000) exceeded
+```
+
+Unlike `length`/`filter` (which SIGILL silently), `sort` fails through the C
+runtime list helpers, so it hits the `ESHKOL_MAX_RECURSION_DEPTH=100000` guard
+and reports a clean diagnostic with exit code 1. The task note also records a
+~983MB RSS peak sorting 50k. Tracked as **ESH-0098** ("stdlib sort recursion
+depth is O(n): cannot sort >= ~100k elements"). Docs-only note; no code changed.
+For >~50k elements, sort a vector or chunk the input.

--- a/docs/reference/stdlib/list_transform.md
+++ b/docs/reference/stdlib/list_transform.md
@@ -1,0 +1,138 @@
+# `core.list.transform` — slicing, concatenation, filtering, partitioning
+
+**Source**: [`lib/core/list/transform.esk`](../../../lib/core/list/transform.esk)
+**Require**: `(require core.list.transform)` — auto-loaded by `(require stdlib)`.
+
+Structural list transforms: `take`/`drop` and their right-hand counterparts,
+variadic `append`, tail-recursive `reverse`, `filter`, `unzip`, `partition`, and
+`list-copy`. (`remove` is kept as a builtin for performance and is not defined
+here.)
+
+## Functions
+
+### `(take lst n)`
+Returns the first `n` elements. Note arg order: **list first, count second**.
+`n <= 0` or a shorter list returns fewer elements (no error).
+
+### `(drop lst n)`
+Returns the list with the first `n` elements removed. `n` past the end returns
+`'()`.
+
+```scheme
+;; takedrop.esk
+(require core.list.transform)
+(display (take '(1 2 3 4 5) 3)) (newline)
+(display (drop '(1 2 3 4 5) 3)) (newline)
+(display (take '(1 2) 5)) (newline)   ; n > length: clamps
+(display (drop '(1 2) 5)) (newline)   ; n > length: '()
+```
+```
+(1 2 3)
+(4 5)
+(1 2)
+()
+```
+
+### `(take-right lst n)`
+Returns the **last** `n` elements (SRFI-1), computed as `(drop lst (- (length lst) n))`.
+
+### `(drop-right lst n)`
+Returns all **but** the last `n` elements, computed as `(take lst (- (length lst) n))`.
+
+```scheme
+;; takedropright.esk
+(require core.list.transform)
+(display (take-right '(1 2 3 4 5) 2)) (newline)
+(display (drop-right '(1 2 3 4 5) 2)) (newline)
+```
+```
+(4 5)
+(1 2 3)
+```
+
+Edge cases (verified against issue #72): both clamp gracefully because they
+route through `take`/`drop`, which guard on `<= n 0`:
+
+| call | result |
+| --- | --- |
+| `(take-right '(1 2 3) 5)` (n > len) | `(1 2 3)` |
+| `(take-right '(1 2 3) 0)` | `()` |
+| `(take-right '() 2)` | `()` |
+| `(drop-right '(1 2 3) 5)` (n > len) | `()` |
+| `(drop-right '(1 2 3) 0)` | `(1 2 3)` |
+| `(drop-right '() 2)` | `()` |
+
+### `(append . lists)`
+Concatenates any number of lists (R7RS §6.4). `(append)` → `'()`; `(append a)`
+returns `a` as-is (last arg is not copied); the last argument may be any datum
+(improper tails allowed).
+
+```scheme
+;; append.esk
+(require core.list.transform)
+(display (append '(1 2) '(3 4) '(5 6))) (newline)
+(display (append)) (newline)
+(display (append '(1 2))) (newline)
+```
+```
+(1 2 3 4 5 6)
+()
+(1 2)
+```
+
+### `(reverse lst)`
+Reverses a list. Tail-recursive (accumulator style) — safe on very long lists.
+
+### `(filter pred lst)`
+Returns the elements satisfying `pred`, in order.
+
+### `(unzip pairs)`
+Inverse of `zip`: splits a list of two-element lists into a two-element list
+`(firsts seconds)`.
+
+### `(partition pred lst)`
+Returns `(matching non-matching)` — a two-element list of the elements that
+satisfy and fail `pred`, each in original order.
+
+### `(list-copy lst)`
+Returns a fresh shallow copy of `lst` (R7RS).
+
+```scheme
+;; misc.esk
+(require core.list.transform)
+(display (reverse '(1 2 3))) (newline)
+(display (filter even? '(1 2 3 4 5 6))) (newline)
+(display (unzip '((a 1) (b 2) (c 3)))) (newline)
+(display (partition even? '(1 2 3 4 5 6))) (newline)
+(display (list-copy '(1 2 3))) (newline)
+```
+```
+(3 2 1)
+(2 4 6)
+((a b c) (1 2 3))
+((2 4 6) (1 3 5))
+(1 2 3)
+```
+
+Edge cases: `filter`/`unzip`/`partition`/`list-copy` all return `'()` (or
+`(() ())` for the two-output ones) on empty input.
+
+### Known issues — depth ceiling (ESH-0108)
+
+`filter`, `take`, `list-copy`, and `append` (via `append-2`) are
+non-tail-recursive: they `cons` around the recursive call, one native stack frame
+per element, and SIGILL (rc 132) with **no diagnostic** on large inputs (the
+`ESHKOL_MAX_RECURSION_DEPTH=100000` runtime guard does not cover stdlib user
+functions). Observed on this machine:
+
+| op | passes | SIGILLs (rc 132, no output) |
+| --- | --- | --- |
+| `filter` (with predicate closure) | 200,000 | 250,000 |
+| `append` (single big left arg) | 500,000 | (larger) |
+| `list-copy` | 300,000 | (larger) |
+
+`reverse` is tail-recursive and completes on 1,000,000-element lists.
+`take-right`/`drop-right` additionally call `length` (also non-tail — see
+[`list_query.md`](list_query.md)), so their ceiling is bounded by `length`'s
+(~500k). Tracked as **ESH-0108**. Docs-only note; no code changed. For very long
+lists, build with tail-recursive primitives or reverse-and-cons.

--- a/docs/reference/stdlib/logging.md
+++ b/docs/reference/stdlib/logging.md
@@ -1,0 +1,51 @@
+# `core.logging` — structured JSON-Lines logging
+
+**Source**: [`lib/core/logging.esk`](../../../lib/core/logging.esk)
+**Require**: `(require core.logging)` — **NOT** auto-loaded via `stdlib`; require it explicitly. (It internally pulls in `core.json`.)
+
+Each log call emits a single JSON object on one line (JSON-Lines), so `jq`/Datadog/Elastic can parse without multi-line reassembly. Every record carries `ts`, `level`, `msg`, and (when scoped) `trace_id`; extra `fields` are appended. A level threshold and output sink are held in module-global state.
+
+`fields` is a list of key/value entries. Because Eshkol's reader parses `'("k" . "v")` as a proper 3-element list rather than a dotted pair, use the **2-list form** `(list "k" v)` — the portable form. Values may be strings, numbers, booleans, symbols, or `null`; anything else is rendered via `write` into a quoted string. Reserved keys (`ts`, `level`, `msg`, `trace_id`) in `fields` raise an error.
+
+## Functions
+
+### `(log-debug msg [fields])` / `(log-info msg [fields])` / `(log-warn msg [fields])` / `(log-error msg [fields])`
+Emit a record at that level if the current level threshold permits. `fields` is optional.
+
+### `(log-set-level! level)`
+Set the minimum level to emit: `'debug` < `'info` < `'warn` < `'error`. Invalid level → error.
+
+### `(log-level)`
+Return the current threshold symbol.
+
+### `(log-set-output! sink)`
+Route output. `sink` may be an output port, a path **string** (opened for writing, owned/closed by the logger on the next `log-set-output!`), or `#f` to reset to `current-output-port`.
+
+### `(log-output-port)`
+Return the current effective output port (the configured sink, or `current-output-port` when unset).
+
+### `(log-with-trace! trace-id thunk)`
+Run `thunk` with `trace_id` bound to `trace-id` for every log call inside it; the previous trace id is restored afterward (even on raise, via `dynamic-wind`).
+
+```scheme
+;; logging.esk
+(require core.logging)
+(display (log-level)) (newline)         ; info (default)
+(log-set-level! 'debug)
+(define p (open-output-string))          ; capture deterministically
+(log-set-output! p)
+(log-info "hello" (list (list "k" 1) (list "flag" #t)))
+(log-warn "careful")
+(log-with-trace! "trace-xyz"
+  (lambda () (log-error "boom" (list (list "code" 500)))))
+(display (get-output-string p))
+```
+```
+info
+{"ts":"2026-07-03T21:03:42.097Z","level":"info","msg":"hello","k":1,"flag":true}
+{"ts":"2026-07-03T21:03:42.098Z","level":"warn","msg":"careful"}
+{"ts":"2026-07-03T21:03:42.098Z","level":"error","msg":"boom","trace_id":"trace-xyz","code":500}
+```
+(The `ts` values are wall-clock and will differ per run; the rest is exact.)
+
+Edge cases: `(log-set-level! 'trace)` → `Unhandled exception: log-set-level!: invalid level`. A `fields` entry using a reserved key (e.g. `(list "msg" "x")`) raises `log: field key is reserved`. `log-output-port` returns a port object, which `display`s as `#<unknown>` — it is meant for passing to port operations, not printing.

--- a/docs/reference/stdlib/logic_boolean.md
+++ b/docs/reference/stdlib/logic_boolean.md
@@ -1,0 +1,52 @@
+# `core.logic.boolean` — boolean combinators for predicates
+
+**Source**: [`lib/core/logic/boolean.esk`](../../../lib/core/logic/boolean.esk)
+**Require**: auto-loaded via `(require stdlib)`; or individually `(require core.logic.boolean)`
+
+Combinators that build new predicates from existing ones and apply them across lists.
+
+## Functions
+
+### `(negate pred)`
+Returns a predicate that yields the logical negation of `pred`: `(lambda (x) (not (pred x)))`.
+
+```scheme
+;; boolean.esk
+(require stdlib)
+(display ((negate is-even?) 3)) (newline)
+```
+```
+#t
+```
+
+### `(all? pred lst)`
+Returns `#t` if every element of `lst` satisfies `pred`, else `#f`. Recursive; short-circuits via `and`.
+
+```scheme
+(require stdlib)
+(display (all? is-positive? '(1 2 3))) (newline)
+(display (all? is-positive? '(1 -2 3))) (newline)
+(display (all? is-positive? '())) (newline)
+```
+```
+#t
+#f
+#t
+```
+
+Edge cases: vacuously `#t` on the empty list.
+
+### `(none? pred lst)`
+Returns `#t` if **no** element satisfies `pred`. Implemented as `(all? (negate pred) lst)`.
+
+```scheme
+(require stdlib)
+(display (none? is-negative? '(1 2 3))) (newline)
+(display (none? is-even? '(2 4))) (newline)
+```
+```
+#t
+#f
+```
+
+Edge cases: vacuously `#t` on the empty list.

--- a/docs/reference/stdlib/logic_predicates.md
+++ b/docs/reference/stdlib/logic_predicates.md
@@ -1,0 +1,44 @@
+# `core.logic.predicates` — numeric predicates as first-class values
+
+**Source**: [`lib/core/logic/predicates.esk`](../../../lib/core/logic/predicates.esk)
+**Require**: auto-loaded via `(require stdlib)`; or individually `(require core.logic.predicates)`
+
+Named, first-class wrappers around the built-in numeric tests, so they can be passed to higher-order procedures (`map`, `filter`, `all?`, `negate`, …). Each returns `#t`/`#f`.
+
+## Functions
+
+### `(is-zero? x)`
+`(zero? x)` — true when `x` equals 0.
+
+### `(is-positive? x)`
+`(> x 0)`.
+
+### `(is-negative? x)`
+`(< x 0)`.
+
+### `(is-even? x)`
+`(even? x)`.
+
+### `(is-odd? x)`
+`(odd? x)`.
+
+```scheme
+;; predicates.esk
+(require stdlib)
+(display (is-zero? 0)) (newline)
+(display (is-positive? 5)) (newline)
+(display (is-negative? -3)) (newline)
+(display (is-even? 4)) (newline)
+(display (is-odd? 7)) (newline)
+(display (filter is-even? '(1 2 3 4 5 6))) (newline)
+```
+```
+#t
+#t
+#t
+#t
+#t
+(2 4 6)
+```
+
+Edge cases: these delegate directly to the numeric builtins, so they inherit the builtins' behavior on non-integers (`is-even?`/`is-odd?` expect integers) and across the numeric tower.

--- a/docs/reference/stdlib/logic_types.md
+++ b/docs/reference/stdlib/logic_types.md
@@ -1,0 +1,31 @@
+# `core.logic.types` — type-checking predicates as first-class values
+
+**Source**: [`lib/core/logic/types.esk`](../../../lib/core/logic/types.esk)
+**Require**: auto-loaded via `(require stdlib)`; or individually `(require core.logic.types)`
+
+First-class wrappers around the built-in type tests, for use with higher-order procedures.
+
+## Functions
+
+### `(is-null? x)`
+`(null? x)` — true when `x` is the empty list `'()`.
+
+### `(is-pair? x)`
+`(pair? x)` — true when `x` is a cons cell.
+
+```scheme
+;; types.esk
+(require stdlib)
+(display (is-null? '())) (newline)
+(display (is-null? '(1))) (newline)
+(display (is-pair? '(1 2))) (newline)
+(display (is-pair? '())) (newline)
+```
+```
+#t
+#f
+#t
+#f
+```
+
+Edge cases: `is-null?` is true only for the empty list; `is-pair?` is false for the empty list (a list of length 0 is not a pair).

--- a/docs/reference/stdlib/manifold.md
+++ b/docs/reference/stdlib/manifold.md
@@ -1,0 +1,315 @@
+# `core.manifold` — Riemannian manifolds for geometric ML
+
+**Source**: [`lib/core/manifold.esk`](../../../lib/core/manifold.esk)
+**Require**: `(require core.manifold)` — auto-loaded via `(require stdlib)` (it is listed in `lib/stdlib.esk`), but the examples below `(require core.manifold)` explicitly so they stand alone.
+
+Constructors and operations for three constant-curvature Riemannian spaces:
+Euclidean (flat, K=0), Hyperbolic Poincaré ball (K=−1), and Spherical (K=+1,
+stereographic). It provides the geometric-ML primitives (exponential/logarithmic
+maps, geodesic distance, parallel transport) plus a full closed-form differential-
+geometry surface (metric, inverse metric, Christoffel symbols, sectional/scalar
+curvature, Ricci and Riemann tensors). Pure Scheme over the core math builtins, so
+it runs identically under REPL/JIT and AOT.
+
+## Data model
+
+- **A manifold** is a 2-element vector `#(type dim)` where `type` is one of the symbols
+  `euclidean`, `hyperbolic`, `spherical`. Do not construct it by hand — use the
+  constructors below. Inspect with `manifold-type` / `manifold-dimension`.
+- **Points and tangent vectors** are 1-D numeric vectors. Use `#(...)` (vector literal)
+  or `(vector ...)` / `(make-vector n x)`. Both forms verified to work. See
+  [Known issues](#known-issues) — passing a plain `list` silently returns a wrong result.
+- **Matrices** returned by `manifold-metric`, `manifold-metric-inverse`, `manifold-ricci`
+  are vectors of row-vectors (index `(vector-ref (vector-ref M i) j)` for entry `M[i][j]`).
+- The **rank-3 Christoffel tensor** from `manifold-christoffel` is indexed `[k][i][j]`
+  (a vector of `k` slices, each an `n×n` matrix).
+
+## Functions
+
+### `(make-euclidean-manifold dim)` / `(make-hyperbolic-manifold dim)` / `(make-spherical-manifold dim)`
+Construct a manifold of the given integer dimension. Hyperbolic is the Poincaré ball
+model (K=−1); spherical is the stereographic model (K=+1); Euclidean is flat (K=0).
+Returns the `#(type dim)` object.
+
+```scheme
+;; example.esk
+(require core.manifold)
+(define H (make-hyperbolic-manifold 3))
+(display (manifold-type H)) (newline)
+(display (manifold-dimension H)) (newline)
+```
+```
+hyperbolic
+3
+```
+
+### `(manifold-type m)`
+Returns the type symbol (`euclidean` / `hyperbolic` / `spherical`).
+
+### `(manifold-dimension m)`
+Returns the integer dimension.
+
+### `(manifold-curvature m)`
+Returns the constant sectional curvature K as a float: `-1.0` hyperbolic, `1.0`
+spherical, `0.0` euclidean.
+
+```scheme
+(require core.manifold)
+(display (manifold-curvature (make-hyperbolic-manifold 3))) (newline)
+(display (manifold-curvature (make-euclidean-manifold 3)))  (newline)
+(display (manifold-curvature (make-spherical-manifold 3)))  (newline)
+```
+```
+-1
+0
+1
+```
+
+### `(manifold-distance m a b)`
+Geodesic distance between points `a` and `b`. Hyperbolic uses the Poincaré `arccosh`
+formula; spherical uses `acos` of the normalized dot product (clamped to [−1,1]);
+Euclidean is the L2 norm of `a−b`.
+
+```scheme
+(require core.manifold)
+(define a #(0.1 0.2 0.0))
+(define b #(0.3 -0.1 0.0))
+(display (manifold-distance (make-hyperbolic-manifold 3) a b)) (newline)
+(display (manifold-distance (make-euclidean-manifold 3)  a b)) (newline)
+(display (manifold-distance (make-spherical-manifold 3)  a b)) (newline)
+```
+```
+0.761342
+0.360555
+1.4289
+```
+
+Edge case: `(manifold-distance m x x)` returns `0.0` (and for spherical, points with
+tiny norm are guarded by `mf-eps`). Passing lists instead of vectors does not crash but
+returns a wrong value — see [Known issues](#known-issues).
+
+### `(manifold-exp-map m base v)`
+Exponential map: move from point `base` along tangent vector `v`, returning the endpoint
+point. Hyperbolic uses Möbius addition with the `tanh` scaling; spherical uses the
+great-circle `cos/sin` formula; Euclidean is `base + v`. A near-zero tangent returns
+`base` unchanged.
+
+```scheme
+(require core.manifold)
+(define H (make-hyperbolic-manifold 3))
+(define a #(0.1 0.2 0.0))
+(define v #(0.05 -0.03 0.02))
+(display (vector-ref (manifold-exp-map H a v) 0)) (newline)
+```
+```
+0.150424
+```
+
+### `(manifold-log-map m base p)`
+Logarithmic map: the tangent vector at `base` pointing toward `p` (inverse of
+`manifold-exp-map`). Euclidean is `p − base`. Returns the zero vector when `p` coincides
+with `base`.
+
+```scheme
+(require core.manifold)
+(define H (make-hyperbolic-manifold 3))
+(define a #(0.1 0.2 0.0))
+(define v #(0.05 -0.03 0.02))
+;; exp then log round-trips back to v
+(display (vector-ref (manifold-log-map H a (manifold-exp-map H a v)) 0)) (newline)
+```
+```
+0.05
+```
+
+### `(manifold-parallel-transport m base-a base-b v)`
+Transport tangent vector `v` from `base-a` to `base-b`. Euclidean is the identity;
+hyperbolic rescales by the ratio of conformal factors λ_a/λ_b (first-order gyro
+transport); spherical removes the component of `v` along `base-b` (projection). Returns
+the transported vector.
+
+```scheme
+(require core.manifold)
+(define H (make-hyperbolic-manifold 3))
+(define a #(0.1 0.2 0.0))
+(define b #(0.3 -0.1 0.0))
+(define v #(0.05 -0.03 0.02))
+(display (vector-ref (manifold-parallel-transport H a b v) 0)) (newline)
+```
+```
+0.0473684
+```
+
+Note: the source comments this as a first-order approximation for encoder use; exact
+gyro-transport is a documented refinement, not implemented.
+
+### `(manifold-sectional-curvature m)`
+Sectional curvature — equal to `manifold-curvature` for these constant-curvature spaces.
+Takes only the manifold (constant across all points/planes).
+
+```scheme
+(require core.manifold)
+(display (manifold-sectional-curvature (make-hyperbolic-manifold 3))) (newline)
+```
+```
+-1
+```
+
+### `(manifold-scalar-curvature m)`
+Scalar curvature R = K·n·(n−1), where n is the dimension. Takes only the manifold.
+
+```scheme
+(require core.manifold)
+(display (manifold-scalar-curvature (make-hyperbolic-manifold 3))) (newline)  ; -1*3*2
+(display (manifold-scalar-curvature (make-euclidean-manifold 3)))  (newline)
+(display (manifold-scalar-curvature (make-spherical-manifold 3)))  (newline)
+```
+```
+-6
+0
+6
+```
+
+### `(metric-component m x i j)`
+Single metric-tensor entry g_ij at point `x`. All three spaces are conformally flat:
+g_ij = λ(x)²·δ_ij, where λ = 1 (euclidean), 2/(1−‖x‖²) (hyperbolic), 2/(1+‖x‖²)
+(spherical). Off-diagonal entries are 0.
+
+```scheme
+(require core.manifold)
+(define H (make-hyperbolic-manifold 3))
+(display (metric-component H #(0.1 0.2 0.0) 0 0)) (newline)
+```
+```
+4.43213
+```
+
+### `(manifold-metric m x)`
+Full n×n metric tensor at `x` as a vector of row-vectors. For n ≥ 48 the rows are
+materialized in parallel via `parallel-map`.
+
+```scheme
+(require core.manifold)
+(define H (make-hyperbolic-manifold 3))
+(display (vector-ref (vector-ref (manifold-metric H #(0.1 0.2 0.0)) 0) 0)) (newline)
+```
+```
+4.43213
+```
+
+### `(manifold-metric-inverse m x)`
+Full n×n inverse metric g^ij at `x` (diagonal 1/λ², off-diagonal 0), same vector-of-rows
+layout.
+
+```scheme
+(require core.manifold)
+(define H (make-hyperbolic-manifold 3))
+(display (vector-ref (vector-ref (manifold-metric-inverse H #(0.1 0.2 0.0)) 0) 0)) (newline)
+```
+```
+0.225625
+```
+
+### `(christoffel-symbol m x i j k)`
+Single Christoffel symbol Γ^k_ij at `x` (connection coefficient). Closed form for
+conformally-flat metrics: Γ^k_ij = δ_ik ∂_j lnλ + δ_jk ∂_i lnλ − δ_ij ∂_k lnλ.
+Symmetric in the lower indices i,j. Zero everywhere for Euclidean. Argument order is
+`i j k` (lower, lower, upper).
+
+```scheme
+(require core.manifold)
+(define H (make-hyperbolic-manifold 3))
+(display (christoffel-symbol H #(0.1 0.2 0.0) 0 0 0)) (newline)
+(display (christoffel-symbol (make-euclidean-manifold 3) #(0.1 0.2 0.0) 0 1 0)) (newline)
+```
+```
+0.210526
+0
+```
+
+### `(manifold-christoffel m x)`
+Full rank-3 Christoffel tensor at `x`, indexed `[k][i][j]` (a length-n vector of n×n
+matrix slices). For n ≥ 48 the k-slices are built in parallel.
+
+```scheme
+(require core.manifold)
+(define H (make-hyperbolic-manifold 3))
+(display (vector-length (manifold-christoffel H #(0.1 0.2 0.0)))) (newline)
+```
+```
+3
+```
+
+### `(ricci-component m x i j)`
+Single Ricci-tensor entry. Einstein form for constant curvature: Ric_ij = K·(n−1)·g_ij.
+
+```scheme
+(require core.manifold)
+(define H (make-hyperbolic-manifold 3))
+(display (ricci-component H #(0.1 0.2 0.0) 0 0)) (newline)  ; -1*2*g_00
+```
+```
+-8.86427
+```
+
+### `(manifold-ricci m x)`
+Full n×n Ricci tensor at `x` as a vector of row-vectors.
+
+```scheme
+(require core.manifold)
+(define H (make-hyperbolic-manifold 3))
+(display (vector-ref (vector-ref (manifold-ricci H #(0.1 0.2 0.0)) 0) 0)) (newline)
+```
+```
+-8.86427
+```
+
+### `(riemann-component m x i j k l)`
+Single Riemann-curvature-tensor entry. Constant-curvature form:
+R_ijkl = K·(g_ik·g_jl − g_il·g_jk). Takes four lower indices i,j,k,l.
+
+```scheme
+(require core.manifold)
+(define H (make-hyperbolic-manifold 3))
+(display (riemann-component H #(0.1 0.2 0.0) 0 1 0 1)) (newline)  ; = -λ⁴
+```
+```
+-19.6438
+```
+
+## Known issues
+
+### Points must be vectors, not lists (silently wrong, cross-ref ESH-0069)
+
+All operations index points with `vector-ref` / `vector-length`. Passing a plain `list`
+does not crash but produces a **wrong** result:
+
+```scheme
+(require core.manifold)
+(define H (make-hyperbolic-manifold 3))
+;; list form — WRONG
+(display (manifold-distance H (list 0.1 0.2 0.0) (list 0.3 -0.1 0.0))) (newline)
+;; vector form — correct
+(display (manifold-distance H (vector 0.1 0.2 0.0) (vector 0.3 -0.1 0.0))) (newline)
+```
+```
+0.251314
+0.761342
+```
+
+The correct distance is `0.761342`; the list form silently returns `0.251314`. This is
+the same "no type error on non-vector/non-tensor geometric input" class tracked by
+[ESH-0069](../../../.swarm/tasks/ESH-0069.json) (*"Tensor ops SIGSEGV on non-tensor
+(vector) input instead of raising a type error"* — here it is silent-wrong rather than a
+crash). Always pass `#(...)`, `(vector ...)`, or `(make-vector n x)` points.
+
+## Notes
+
+- The full regression suite for this module lives at
+  [`tests/manifold/manifold_test.esk`](../../../tests/manifold/manifold_test.esk) (exp/log
+  round-trip, curvature closed forms, Christoffel symmetry, parallel materializers at
+  dim ≥ 48). Additional geometric-surface coverage is in
+  [`tests/vm/geometric_surface_regression.esk`](../../../tests/vm/geometric_surface_regression.esk).
+- The internal `mf-*` helpers (`mf-dot`, `mf-mobius-add`, `mf-lambda`, `mf-build-matrix`,
+  `mf-build-rank3`, …) are not exported and are not part of the public API.
+- All 20 provided symbols were verified by running under the `-r` (REPL/JIT) path.

--- a/docs/reference/stdlib/math.md
+++ b/docs/reference/stdlib/math.md
@@ -1,0 +1,191 @@
+# `math` — linear algebra, numerical methods, and statistics
+
+**Source**: [`lib/math.esk`](../../../lib/math.esk)
+**Require**: `(require math)` — **must be required individually**. Despite operating on the same tensor/vector data as the auto-loaded signal/ml modules, `math` is **NOT** pulled in by `(require stdlib)` (there is no `(require math)` line in `lib/stdlib.esk`). Calling `dot` etc. after only `(require stdlib)` fails with *"called undefined function 'dot'"*.
+
+Numerical algorithms implemented in Eshkol itself: matrix determinant/inverse/solve (Gaussian / Gauss-Jordan elimination with partial pivoting), 3-D cross product, dot/normalize, power-iteration eigenvalue estimate, Simpson integration, Newton root-finding, and variance/std/covariance statistics.
+
+## Data model — everything is a tensor/vector written `#(...)`
+
+Matrices are **flat** tensors in row-major order: an n×n matrix is a length-n² tensor, and `n` is passed explicitly. Vectors are `#(...)` literals (or the result of `make-vector`/`vector`). Elements are read with `vref` and are treated as `double`.
+
+> **Do not pass lists.** These functions index with `vref` and length with `vector-length`; a Scheme `(list …)` is a different heap layout and is misread → **SIGSEGV**. See [Known issues](#known-issues).
+
+Constants `pi`, `e`, `epsilon` (`1e-15`) are defined internally but are **not** in the `provide` list, so user code cannot reference them after `(require math)`.
+
+## Functions
+
+### `(mat-ref M cols row col)`
+Element at `(row, col)` of a matrix `M` stored flat with `cols` columns. Computes `(vref M (+ (* row cols) col))`.
+
+```scheme
+(require math)
+(display (mat-ref #(1.0 2.0 3.0 4.0) 2 1 0)) (newline)
+```
+```
+3
+```
+
+### `(tensor-copy T)`
+Returns a fresh mutable `make-vector` copy of tensor/vector `T` (used internally so the elimination routines don't clobber the caller's data).
+
+```scheme
+(display (tensor-copy #(1.0 2.0 3.0))) (newline)
+```
+```
+#(1 2 3)
+```
+
+### `(det M n)`
+Determinant of the `n`×`n` matrix `M` (flat, row-major) via Gaussian elimination with partial pivoting, O(n³). Returns a `double`. A singular matrix (pivot below `epsilon`) yields `0.0`.
+
+```scheme
+(display (det #(4.0 3.0 6.0 3.0) 2)) (newline)
+```
+```
+-6
+```
+
+### `(inv M n)`
+Inverse of the `n`×`n` matrix `M` via Gauss-Jordan elimination. Returns the inverse as a flat vector, or `#f` if singular.
+
+```scheme
+(display (inv #(4.0 7.0 2.0 6.0) 2)) (newline)
+(display (inv #(1.0 2.0 2.0 4.0) 2)) (newline)   ;; singular
+```
+```
+#(0.6 -0.7 -0.2 0.4)
+#f
+```
+
+### `(solve A b n)`
+Solve `A x = b` for the `n`-vector `x` (LU / Gaussian elimination with partial pivoting). `A` is flat `n`×`n`, `b` is length `n`. Returns `x`, or `#f` if singular.
+
+```scheme
+(display (solve #(2.0 1.0 1.0 3.0) #(3.0 5.0) 2)) (newline)
+```
+```
+#(0.8 1.4)
+```
+
+### `(cross u v)`
+3-D cross product `u × v`. Both must be length-3 vectors; returns a length-3 vector.
+
+```scheme
+(display (cross #(1.0 0.0 0.0) #(0.0 1.0 0.0))) (newline)
+```
+```
+#(0 0 1)
+```
+
+### `(dot u v)`
+Dot product of two vectors (loops to `(vector-length u)`; if `v` is shorter it reads out of bounds).
+
+```scheme
+(display (dot #(1.0 2.0 3.0) #(4.0 5.0 6.0))) (newline)
+```
+```
+32
+```
+
+Edge cases: passing lists SIGSEGVs — see [Known issues](#known-issues).
+
+### `(normalize v)`
+Unit vector in the direction of `v` (divides by `norm`). If `‖v‖ < epsilon` the input is returned unchanged (avoids divide-by-zero).
+
+```scheme
+(display (normalize #(3.0 4.0))) (newline)
+(display (normalize #(0.0 0.0))) (newline)   ;; zero vector returned as-is
+```
+```
+#(0.6 0.8)
+#(0 0)
+```
+
+### `(mat-vec-mul A x rows cols)`
+Matrix-vector product `A·x`. `A` is flat `rows`×`cols`, `x` is length `cols`; returns length `rows`.
+
+```scheme
+(display (mat-vec-mul #(1.0 2.0 3.0 4.0) #(1.0 1.0) 2 2)) (newline)
+```
+```
+#(3 7)
+```
+
+### `(power-iteration A n max-iters tolerance)`
+Estimate the dominant eigenvalue of the `n`×`n` matrix `A` by the power method, stopping after `max-iters` or when successive Rayleigh quotients differ by less than `tolerance`.
+
+```scheme
+(display (power-iteration #(2.0 0.0 0.0 3.0) 2 100 1e-9)) (newline)
+```
+```
+3
+```
+
+### `(integrate f a b n)`
+Numerical integral of `f` over `[a, b]` using Simpson's rule with `n` intervals (`n` should be even).
+
+```scheme
+(display (integrate (lambda (x) (* x x)) 0.0 1.0 100)) (newline)
+```
+```
+0.333333
+```
+
+### `(newton f df x0 tolerance max-iters)`
+Newton–Raphson root of `f` with derivative `df`, starting from `x0`. Stops when `|x_{k+1} − x_k| < tolerance`, on `max-iters`, or if `|df| < epsilon` (returns current `x`).
+
+```scheme
+(display (newton (lambda (x) (- (* x x) 2.0))
+                 (lambda (x) (* 2.0 x))
+                 1.0 1e-10 100)) (newline)
+```
+```
+1.41421
+```
+
+### `(variance v)`
+Population variance of vector `v` (divides by `len`, not `len−1`). Uses `tensor-mean` for the mean.
+
+```scheme
+(display (variance #(1.0 2.0 3.0 4.0 5.0))) (newline)
+```
+```
+2
+```
+
+### `(std v)`
+Standard deviation, `(sqrt (variance v))`.
+
+```scheme
+(display (std #(1.0 2.0 3.0 4.0 5.0))) (newline)
+```
+```
+1.41421
+```
+
+### `(covariance u v)`
+Population covariance of `u` and `v` (divides by `len` of `u`).
+
+```scheme
+(display (covariance #(1.0 2.0 3.0) #(4.0 5.0 6.0))) (newline)
+```
+```
+0.666667
+```
+
+## Known issues
+
+### Passing a list where a tensor/vector is expected → SIGSEGV
+
+All `math` functions index with `vref`/`vector-length`, which assume the tensor/vector heap layout. A Scheme list is a cons chain with a different layout; reading it as a tensor dereferences garbage and crashes. This is the tensor-op-on-non-tensor class tracked as **ESH-0069** ("Tensor ops SIGSEGV on non-tensor (vector) input instead of raising a type error").
+
+```scheme
+;; repro.esk
+(require math)
+(display (dot (list 1.0 2.0 3.0) (list 4.0 5.0 6.0))) (newline)
+```
+```
+[Eshkol] fatal signal: SIGSEGV (segmentation fault) — terminating
+```
+Workaround: always pass `#(...)` literals or the result of `(vector …)` / `(make-vector …)`, never `(list …)`.

--- a/docs/reference/stdlib/memory.md
+++ b/docs/reference/stdlib/memory.md
@@ -1,0 +1,147 @@
+# `core.memory` — append-only, content-addressed, CRDT-merged event log
+
+**Source**: [`lib/core/memory.esk`](../../../lib/core/memory.esk)
+**Require**: `(require core.memory)` — must be required individually (not auto-loaded by `(require stdlib)`). Pulls in `agent.crypto` (for `sha256`), `core.distributed`, and `core.merkle`.
+
+An in-memory event-log faculty for a distributed intelligence, composed from verified
+core primitives. Each event is immutable and **content-addressed**: its id is the
+`sha256` of the `sexp->canonical-string` of its body (everything except the id). The
+body embeds the previous event's hash, so the log is also a **hash chain** — tampering
+any field breaks the recomputed id. The log itself is an RGA (a convergent
+append-only sequence CRDT from `core.distributed`), so two nodes can append
+independently and `memory-merge` is conflict-free (commutative, idempotent,
+associative) with dedup-by-id inherent to the RGA.
+
+**Event shape**: a list `(mem-ev-v1 id prev-hash vclock node type payload)`.
+**Log shape**: a mutable vector `#(mem-log node-id rga vclock prev-hash)`.
+
+This module works under both `eshkol-run -r` (JIT) and AOT.
+
+## Functions
+
+### `(make-memory-log node-id)`
+Create an empty log owned by `node-id` (any `equal?`-comparable value; symbols are
+typical). Takes exactly **one** argument.
+
+### `(memory-append! log type payload)`
+Append an event of `type` carrying `payload`. Ticks the log's vector clock,
+computes the content hash, chains it to the previous id, and RGA-appends. **Mutates**
+`log` and **returns the new event**. Argument order is `(log type payload)`.
+
+### `(memory-events log)`
+Ordered list of events (RGA convergent order).
+
+### `(memory-event? ev)`
+Predicate: is `ev` a `mem-ev-v1` event?
+
+### `(memory-event-id ev)` / `(memory-event-prev ev)` / `(memory-event-vclock ev)` / `(memory-event-node ev)` / `(memory-event-type ev)` / `(memory-event-payload ev)`
+Event field accessors. `-id` is the sha256 hex string, `-prev` is the predecessor id
+(or `#f` for the first event), `-vclock` is the vector clock at append time.
+
+```scheme
+;; memory.esk
+(require core.memory)
+(define la (make-memory-log 'node-A))
+(define e1 (memory-append! la 'episodic '(saw cat)))
+(memory-append! la 'fact  '(cat is-a animal))
+(memory-append! la 'value (cons 'mood 0.7))
+(display (memory-event? e1))          (newline)
+(display (memory-event-id e1))        (newline)
+(display (memory-event-prev e1))      (newline)
+(display (memory-event-vclock e1))    (newline)
+(display (memory-event-node e1))      (newline)
+(display (memory-event-type e1))      (newline)
+(display (memory-event-payload e1))   (newline)
+(display (length (memory-events la))) (newline)
+```
+```
+#t
+e118a18ab8d6942308f0c9a221511a46a4fdb22566446351825217156fa39bf5
+#f
+((node-A 1))
+node-A
+episodic
+(saw cat)
+3
+```
+
+### `(memory-verify-events events)`
+Recompute each event's id from its body and check integrity. Returns `#t` if all
+events verify, else `(offending-event . reason)` where `reason` is one of
+`not-an-event`, `no-id`, `hash-mismatch`. Works on single-node and merged logs
+(content-integrity is independent of interleave order).
+
+### `(memory-verify-chain log)`
+Convenience: `(memory-verify-events (memory-events log))`.
+
+```scheme
+;; memory.esk
+(require core.memory)
+(define la (make-memory-log 'node-A))
+(define good (memory-append! la 'episodic '(saw cat)))
+(display (memory-verify-chain la)) (newline)
+;; forge an event that keeps the id but mutates the payload:
+(define tampered (list 'mem-ev-v1 (memory-event-id good) (memory-event-prev good)
+                       (memory-event-vclock good) (memory-event-node good)
+                       (memory-event-type good) 'TAMPERED))
+(display (memory-verify-events (list tampered))) (newline)
+```
+```
+#t
+((mem-ev-v1 e118a18ab8d6942308f0c9a221511a46a4fdb22566446351825217156fa39bf5 #f ((node-A 1)) node-A episodic TAMPERED) . hash-mismatch)
+```
+
+### `(memory-merge a b)`
+Conflict-free merge of two logs: RGA union (dedup-by-id inherent) plus vector-clock
+merge. Commutative, idempotent, associative, and lossless. Returns a new log; the
+result still verifies via `memory-verify-chain`.
+
+```scheme
+;; memory.esk
+(require core.memory)
+(define la (make-memory-log 'node-A))
+(define lb (make-memory-log 'node-B))
+(memory-append! la 'episodic '(saw cat))
+(memory-append! la 'fact     '(cat is-a animal))
+(memory-append! lb 'episodic '(heard dog))
+(define m (memory-merge la lb))
+(display (length (memory-events m))) (newline)   ; lossless: 2 + 1
+(display (memory-verify-chain m))    (newline)
+```
+```
+3
+#t
+```
+
+### `(memory-fold-lww log key)`
+Fold `value`-typed events whose payload is `(key . value)` into an LWW register,
+using append order as the timestamp, and return the last-written value for `key`
+(or `#f` if none). Since events are totally ordered (including post-merge), this is
+"last write wins" over the log.
+
+```scheme
+;; memory.esk
+(require core.memory)
+(define la (make-memory-log 'node-A))
+(memory-append! la 'value (cons 'mood 0.7))
+(memory-append! la 'value (cons 'mood 0.9))
+(display (memory-fold-lww la 'mood))          (newline)
+(display (memory-fold-lww la 'nonexistent))   (newline)
+```
+```
+0.9
+#f
+```
+
+Edge cases: `memory-verify-events` on `'()` returns `#t`. `memory-fold-lww` on a
+missing key returns `#f`.
+
+## Known issues
+
+- **Benign type warning**: requiring `core.memory` prints one gradual-typing warning
+  from `memory-fold-lww`'s inner loop and continues normally:
+  ```
+  [WARN] Type warning: argument 3 of 'loop': expected Boolean, got Vector (line 122:24)
+  ```
+  This does not affect results (the LWW fold returns the correct value, as shown
+  above). No ledger id found in `.swarm/tasks/`.

--- a/docs/reference/stdlib/memory_store.md
+++ b/docs/reference/stdlib/memory_store.md
@@ -1,0 +1,176 @@
+# `core.memory_store` — durable, hash-chained event store on disk
+
+**Source**: [`lib/core/memory_store.esk`](../../../lib/core/memory_store.esk)
+**Require**: `(require core.memory_store)` — must be required individually (not auto-loaded by `(require stdlib)`). Pulls in `core.memory`, `core.sexp`, and `core.files`.
+
+Step 2 of `core.memory`: makes the in-memory event log **permanent**. Every append is
+written to an append-only log file and `fsync`'d **before the append returns** (T0
+durability), using fixed-arity libc externs (`fopen`/`fwrite`/`fflush`/`fileno`/
+`fsync`/`fclose`) — variadic `open` is unsafe across the FFI on ARM64. The
+persistence format is **one canonical s-expression per line** — the same rendering
+the event ids are hashed over — so the file *is* the chain: replay re-parses each
+line and re-derives every hash; a flipped bit anywhere breaks verification. No
+external DB.
+
+**Store shape**: `#(mem-store log path)`, where `log` is a `core.memory` log vector.
+
+An O(1)-open **head sidecar** (`<path>.head`, holding
+`(ms-head-v1 <prev-hash> <vclock>)`) is written atomically after each append and used
+by `memory-store-open-fast`; it is pure optimization — the log file remains the single
+source of truth.
+
+**v1 payload contract**: payloads are alists of `(symbol . string|integer)`. Strings
+must be printable ASCII with no double-quotes or newlines — `core.sexp`'s canonical
+rendering does not escape them. `memory-store-append!` sanitizes string values
+automatically (defense in depth); `memory-store-sanitize` is exposed for ingest.
+
+## Functions
+
+### `(make-memory-store log path)`
+Wrap an existing `core.memory` `log` and a file `path` into a store vector. Low-level
+constructor; most callers use `memory-store-open`.
+
+### `(memory-store? s)`
+Predicate: is `s` a `mem-store` vector?
+
+### `(memory-store-log s)` / `(memory-store-path s)`
+Accessors: the underlying `core.memory` log, and the file path.
+
+### `(memory-store-open node-id path)`
+Open (or create) the durable chain at `path` for `node-id`, **replaying** all existing
+events into an in-memory log (full RGA rebuild). If the file does not exist, returns
+a fresh store. Unparseable lines are skipped with a warning. Argument order is
+`(node-id path)`.
+
+### `(memory-store-append! store type payload)`
+Append an event of `type` with `payload` (a `(symbol . string|integer)` alist):
+sanitize string values, append to the in-memory chain, then persist + `fsync` before
+returning, and refresh the head sidecar. Returns the new event, or `#f` (with a
+`DURABILITY FAILURE` message) if the disk write failed. Argument order is
+`(store type payload)`.
+
+### `(memory-store-count store)`
+Number of events currently in the store's in-memory log.
+
+### `(memory-store-head store)`
+Content-id (hex string) of the last event in the in-memory log, or `#f` if empty.
+
+### `(memory-store-verify store)`
+Full two-layer audit of the loaded chain: (1) `core.memory` content hashes catch a
+**modified** event (`hash-mismatch`); (2) strict linear linkage catches a **deleted**
+event (`linkage-broken`) — the first event's `prev` must be `#f` and each event's
+`prev` must equal its predecessor's id. Returns `#t` or a failure descriptor. Valid
+for single-node chains; merged multi-node logs have legitimate forks.
+
+```scheme
+;; memory_store.esk  (writes to /tmp/events.log)
+(require core.memory_store)
+(define P "/tmp/events.log")
+(define st (memory-store-open 'node-A P))
+(display (memory-store? st))                              (newline)
+(memory-store-append! st 'episodic (list (cons 'note "hello world")))
+(memory-store-append! st 'fact     (list (cons 'k 42)))
+(display (memory-store-count st))                         (newline)
+(display (memory-store-verify st))                        (newline)
+;; reopen from disk (replay) sees the same events and verifies:
+(define st2 (memory-store-open 'node-A P))
+(display (memory-store-count st2))                        (newline)
+(display (memory-store-verify st2))                       (newline)
+```
+```
+#t
+2
+#t
+2
+#t
+```
+
+The resulting file is one canonical event per line (ids are content-derived):
+```
+(mem-ev-v1 "909f8d2c…" #f ((node-A 1)) node-A episodic ((note . "hello world")))
+(mem-ev-v1 "882b173f…" "909f8d2c…" ((node-A 2)) node-A fact ((k . 42)))
+```
+and the sidecar `events.log.head`:
+```
+(ms-head-v1 "882b173f…" ((node-A 2)))
+```
+
+### `(memory-store-open-fast node-id path)`
+Fast open for **append-only** use (the per-tick weave): restore `prev-hash` + vclock
+from the sidecar, then validate against the file tail (a plain line scan, no hashing);
+if the sidecar is stale it heals from the tail with a warning. **The returned store's
+in-memory event list holds only NEW events appended in this session** — use
+`memory-store-open` (full replay) for reads. Falls back to full open if there is no
+sidecar or no file.
+
+```scheme
+;; memory_store.esk
+(require core.memory_store)
+(define P "/tmp/events.log")            ; from the example above (2 events on disk)
+(define st (memory-store-open-fast 'node-A P))
+(display (memory-store? st))            (newline)
+(memory-store-append! st 'value (list (cons 'x "y")))
+(display (memory-store-count st))      (newline)   ; only NEW events this session
+(define full (memory-store-open 'node-A P))
+(display (memory-store-count full))    (newline)   ; full replay sees all
+```
+```
+#t
+1
+3
+```
+
+### `(memory-store-sanitize str)`
+Return `str` with every double-quote, control char, and non-printable/non-ASCII byte
+replaced by a space. Load-bearing: `fwrite`'s length argument is `string-length`
+(characters), but the file gets UTF-8 **bytes**, so one multibyte char (e.g. an
+em-dash) truncated a write and glued two events onto one line. Until byte-length
+crosses the FFI, payload strings are printable ASCII only.
+
+```scheme
+;; memory_store.esk
+(require core.memory_store)
+(display (memory-store-sanitize "a\"b"))            (newline)
+(display (string-length (memory-store-sanitize "clean"))) (newline)
+```
+```
+a b
+5
+```
+
+### `(memory-store-audit path)` — currently unusable, see Known issues
+Intended to be a **streaming** O(n)-flat integrity audit that never builds the RGA:
+stream each line, re-derive its content hash, check its parent exists among
+previously-seen ids, discard. Would return `(ms-audit-v1 ok links forks)` or
+`(line-number . reason)` with `reason` in `unparseable | hash-mismatch |
+orphan-parent`. **It cannot currently be called** — see below.
+
+## Known issues
+
+- **`memory-store-audit` is uncallable (unresolved cross-module symbol).**
+  `memory-store-audit`'s body references `event-content-hash`, which is a private
+  helper defined in `core.memory` but **not in that module's `(provide …)` list**.
+  Across the module boundary the symbol does not resolve, so `memory-store-audit`
+  itself fails to generate and is reported as an unknown function at every call site.
+  All the *other* provided store functions work. Requiring `core.memory` explicitly
+  first does **not** help (the failure is at `memory_store`'s own compile time).
+  Repro:
+  ```scheme
+  (require core.memory_store)
+  (memory-store-audit "/tmp/events.log")
+  ```
+  Observed:
+  ```
+  error: Unknown function: memory-store-audit
+  ERROR: Failed to generate LLVM IR due to earlier code generation errors
+  Unhandled exception: called undefined function 'memory-store-audit'
+    (forward-referenced but never defined …)
+  ```
+  Likely fix (code, out of scope for docs): add `event-content-hash` to
+  `core.memory`'s `provide` block, or re-derive it inside `core.memory_store`.
+  No matching ledger id found in `.swarm/tasks/` (`ESH-0072` and `ESH-0085` mention
+  adjacent areas — AD closure capture and `sha256` symbol hygiene — but not this).
+
+- **Durability externs / NULL convention.** `fopen` failure returns `'()` from the
+  FFI (not `0`); the module's `null-ptr?` checks `null?` accordingly. This is by
+  design, noted here because it affects anyone extending the module.

--- a/docs/reference/stdlib/merkle.md
+++ b/docs/reference/stdlib/merkle.md
@@ -1,0 +1,184 @@
+# `core.merkle` — FNV-1a hashing, Merkle trees, content-addressable storage
+
+**Source**: [`lib/core/merkle.esk`](../../../lib/core/merkle.esk)
+**Require**: `(require core.merkle)` — must be required individually (not auto-loaded by `(require stdlib)`).
+
+Pure-Eshkol Merkle trees and a content-addressable store (CAS). The default hash is
+**FNV-1a 64-bit** (the inner loop is in `lib/core/merkle.c` for correct `uint64_t`
+overflow semantics) — fast and well-distributed for in-process content addressing
+but **not cryptographically secure**. For tamper resistance, pass a crypto hash
+(e.g. `agent.crypto`'s `sha256`) via the optional `hash-fn` argument to
+`merkle-leaf`, `merkle-tree-with-hash`, `merkle-verify`, or `make-cas-with-hash`.
+
+Tree representation:
+- leaf  → `(vector 'merkle-leaf hash data)`
+- inode → `(vector 'merkle-inode hash left right)`
+
+Odd levels duplicate the last node (Bitcoin convention) so every inode has two
+children.
+
+## Hash
+
+### `(fnv1a-64 str)`
+FNV-1a 64-bit hash of the UTF-8 bytes of `str`. Returns the uint64 bit pattern as an
+int64 — it **may be negative**; only equality and hex rendering matter for content
+addressing. Deterministic for a given input.
+
+```scheme
+;; merkle.esk
+(require core.merkle)
+(display (hash->hex (fnv1a-64 "hello"))) (newline)
+(display (hash->hex (fnv1a-64 "a")))     (newline)   ; spec vector 0xaf63dc4c8601ec8c
+```
+```
+a430d84680aabd0b
+af63dc4c8601ec8c
+```
+
+Edge case: `(hash->hex (fnv1a-64 ""))` = `"cbf29ce484222325"` (the FNV offset basis).
+
+### `(hash->hex h)`
+Render a 64-bit hash `h` as a 16-char lowercase hex string.
+
+```scheme
+(require core.merkle)
+(display (string-length (hash->hex (fnv1a-64 "x")))) (newline)
+```
+```
+16
+```
+
+## Merkle tree
+
+### `(merkle-leaf data [hash-fn])`
+Wrap a string `data` as a leaf node. Optional second arg is the hash function
+(defaults to `fnv1a-64`). `data` must be a string.
+
+### `(merkle-leaf? n)` / `(merkle-inode? n)`
+Type predicates. `merkle-leaf?` is true for a leaf vector, `merkle-inode?` for an
+internal node.
+
+```scheme
+;; merkle.esk
+(require core.merkle)
+(define lf (merkle-leaf "data"))
+(display (merkle-leaf? lf))  (newline)
+(display (merkle-inode? lf)) (newline)
+(display (merkle-data lf))   (newline)
+```
+```
+#t
+#f
+data
+```
+
+### `(merkle-data n)`
+Original data string of a leaf node. **Errors** (`merkle-data: not a leaf node`) if
+`n` is an inode.
+
+### `(merkle-root n)`
+Hash at the top of the tree, or the leaf's own hash if `n` is a leaf. Errors if `n`
+is not a merkle node.
+
+### `(merkle-tree data-list)` / `(merkle-tree-with-hash data-list hash-fn)`
+Build a Merkle tree from a list of strings. `merkle-tree` uses FNV-1a;
+`merkle-tree-with-hash` takes an explicit hash function. Returns the root node.
+An **empty list errors** (`cannot build tree from empty list`).
+
+```scheme
+;; merkle.esk
+(require core.merkle)
+(define t (merkle-tree (list "alice" "bob" "carol" "dave")))
+(display (hash->hex (merkle-root t))) (newline)
+(display (merkle-leaves t))           (newline)
+```
+```
+115bb5e7e82ae101
+(alice bob carol dave)
+```
+
+Determinism: same data → same root; different **order** → different root.
+
+### `(merkle-leaves tree)`
+Walk the tree left-to-right, returning the list of leaf data strings. An
+odd-one-out duplicated leaf is counted once.
+
+### `(merkle-proof tree index)`
+Inclusion proof for the leaf at `index`: a list of `(sibling-hash . side)` pairs
+from leaf up to root (`side` is `'left` or `'right`). Do not reverse it — this is
+the order `merkle-verify` consumes.
+
+### `(merkle-verify root-hash leaf-data proof [hash-fn])`
+Verify that `leaf-data` is included under `root-hash` given `proof`. Returns `#t`
+on a valid proof, `#f` otherwise. `hash-fn` defaults to `fnv1a-64` and must match
+the one the tree was built with.
+
+```scheme
+;; merkle.esk
+(require core.merkle)
+(define t  (merkle-tree (list "alice" "bob" "carol" "dave")))
+(define p0 (merkle-proof t 0))
+(display p0)                                        (newline)
+(display (merkle-verify (merkle-root t) "alice" p0)) (newline)
+(display (merkle-verify (merkle-root t) "MALLORY" p0)) (newline)
+```
+```
+((21748447695211092 . right) (5625647597590589385 . right))
+#t
+#f
+```
+
+Edge case: an empty proof `'()` verifies only if `(hash-fn leaf-data)` equals
+`root-hash` directly (i.e. a single-leaf tree).
+
+## Content-addressable store (CAS)
+
+A CAS is `(vector 'eshkol-cas hash-fn hash-table)`. Keys are 16-char hex content
+hashes; storing identical data yields the same key (dedup).
+
+### `(make-cas)` / `(make-cas-with-hash hash-fn)`
+Create a CAS using the default FNV-1a hash, or an explicit hash function.
+
+### `(cas? c)`
+Predicate: is `c` a CAS handle?
+
+### `(cas-put! c data)`
+Store `data`, returning its content hash as a 16-char hex string. Mutates the store.
+
+### `(cas-get c hash)`
+Retrieve the data stored under `hash`, or `#f` if absent.
+
+### `(cas-has? c hash)`
+Predicate: does `c` contain an entry for `hash`?
+
+### `(cas-size c)`
+Number of distinct objects stored.
+
+### `(cas-keys c)`
+List of all stored content hashes.
+
+```scheme
+;; merkle.esk
+(require core.merkle)
+(define c (make-cas))
+(display (cas? c))       (newline)
+(display (cas-size c))   (newline)
+(define h (cas-put! c "payload"))
+(display h)              (newline)
+(display (cas-get c h))  (newline)
+(display (cas-has? c h)) (newline)
+(display (cas-keys c))   (newline)
+(display (cas-get c "0000000000000000")) (newline)   ; absent
+```
+```
+#t
+0
+cfb8a9d063b5e9e5
+payload
+#t
+(cfb8a9d063b5e9e5)
+#f
+```
+
+Edge case: `cas-get` of an absent hash returns `#f`; a duplicate `cas-put!` of the
+same data returns the same hash and does not grow the store.

--- a/docs/reference/stdlib/metrics.md
+++ b/docs/reference/stdlib/metrics.md
@@ -1,0 +1,103 @@
+# `core.metrics` — Prometheus-compatible counters, gauges, histograms
+
+**Source**: [`lib/core/metrics.esk`](../../../lib/core/metrics.esk)
+**Require**: `(require core.metrics)` — **NOT** auto-loaded via `stdlib`; require it explicitly.
+
+Prometheus-style metric primitives with a global registry that renders to the Prometheus text exposition format. A metric is a vector `#(name help label-keys kind state)`; `state` is a hash-table keyed by the joined label-value string. Every metric registers itself on creation, so `(metrics-render)` walks all of them. Designed to feed a `/metrics` endpoint (see `core.http_server`).
+
+> REPL note: requiring this module prints a few harmless `error: Unknown function: length` diagnostics to **stderr** during compile. They are a REPL forward-reference artifact only — `length` resolves at runtime, all functions execute correctly, and no exception is raised. Ignore them (they do not appear in AOT builds' program output).
+
+Labels: pass label **keys** at creation (a list of strings) and matching label **values** on each update (in the same order). Use `'()` for an unlabelled metric.
+
+## Constructors & accessors
+
+### `(make-counter name help label-keys)`
+Create a monotonic counter. `name` must match `[a-zA-Z_:][a-zA-Z0-9_:]*`; each label key must match `[a-zA-Z_][a-zA-Z0-9_]*`.
+
+### `(make-gauge name help label-keys)`
+Create a gauge (value may rise or fall).
+
+### `(make-histogram name help label-keys buckets)`
+Create a histogram. `buckets` is a list of strictly-increasing numeric upper bounds; a `+Inf` bucket is added at render time.
+
+### `(metric-name m)` / `(metric-help m)` / `(metric-kind m)`
+Accessors. `metric-kind` returns the symbol `'counter` or `'gauge` for those; for a histogram it returns the **list** `(histogram (bucket …))`, not a bare symbol.
+
+## Counter
+
+### `(counter-inc! m label-vals)`
+Increment by 1 for the given label values.
+
+### `(counter-add! m label-vals n)`
+Add `n` (must be `>= 0`). Negative → error.
+
+## Gauge
+
+### `(gauge-set! m label-vals v)` — set to `v`.
+### `(gauge-inc! m label-vals)` / `(gauge-dec! m label-vals)` — ±1.
+
+## Histogram
+
+### `(histogram-observe! m label-vals value)`
+Record `value`: increments every bucket whose upper bound `>= value`, plus the count and sum. `value` must be numeric.
+
+### `(histogram-buckets m)`
+Return the bucket bounds list.
+
+## Registry
+
+### `(metrics-register! m)`
+Add a metric to the global registry (constructors call this automatically).
+
+### `(metrics-render)`
+Return the full Prometheus text-format string of all registered metrics.
+
+### `(metrics-reset!)`
+Zero counters and histograms; **gauges retain** their value (a gauge represents live state, not a rate).
+
+```scheme
+;; metrics.esk
+(require core.metrics)
+(define reqs (make-counter "eshkol_requests_total" "Total requests" (list "path")))
+(counter-inc! reqs (list "/a"))
+(counter-add! reqs (list "/a") 4)
+(counter-inc! reqs (list "/b"))
+(define g (make-gauge "eshkol_inflight" "In flight" (list)))
+(gauge-set! g (list) 10) (gauge-inc! g (list)) (gauge-dec! g (list))
+(define h (make-histogram "eshkol_latency" "Latency" (list "path") (list 0.1 0.5 1.0)))
+(histogram-observe! h (list "/a") 0.07)
+(histogram-observe! h (list "/a") 0.3)
+(histogram-observe! h (list "/a") 2.0)
+(display (metric-kind reqs)) (newline)
+(display (metric-kind h)) (newline)
+(display (metrics-render))
+```
+```
+counter
+(histogram (0.1 0.5 1))
+# HELP eshkol_requests_total Total requests
+# TYPE eshkol_requests_total counter
+eshkol_requests_total{path="/b"} 1
+eshkol_requests_total{path="/a"} 5
+# HELP eshkol_inflight In flight
+# TYPE eshkol_inflight gauge
+eshkol_inflight 10
+# HELP eshkol_latency Latency
+# TYPE eshkol_latency histogram
+eshkol_latency_bucket{path="/a",le="0.1"} 1
+eshkol_latency_bucket{path="/a",le="0.5"} 2
+eshkol_latency_bucket{path="/a",le="1"} 2
+eshkol_latency_bucket{path="/a",le="+Inf"} 3
+eshkol_latency_count{path="/a"} 3
+eshkol_latency_sum{path="/a"} 2.37
+```
+
+After `(metrics-reset!)` the counter and histogram series drop out of the render output while the gauge line `eshkol_inflight 10` remains.
+
+Edge cases (all raise `Unhandled exception`):
+- label value count ≠ declared label keys → `metric label value count does not match label keys`
+- `counter-add!` with `n < 0` → `counter-add!: counters only increment`
+- invalid metric name (e.g. `"9bad"`) → `metric name must match [a-zA-Z_:][a-zA-Z0-9_:]*`
+- non-increasing histogram buckets → `histogram buckets must be strictly increasing`
+
+(Timestamps and label ordering in output are deterministic; the example above is exact verbatim output.)

--- a/docs/reference/stdlib/ml_activations.md
+++ b/docs/reference/stdlib/ml_activations.md
@@ -1,0 +1,125 @@
+# `ml.activations` — activation functions and normalization
+
+**Source**: [`lib/ml/activations.esk`](../../../lib/ml/activations.esk)
+**Require**: `(require ml.activations)` — **must be required individually**. It is **NOT** auto-loaded by `(require stdlib)` (only `ml.optimization` is). (The header comment in the source says `(require ml)`, but the actual require name derived from the path `lib/ml/activations.esk` is `ml.activations`.)
+
+Two families: **scalar** activations that operate on a single number (`relu-scalar`, `sigmoid-scalar`, `tanh-scalar`, `softplus-scalar`), and **tensor** activations/normalizers that operate on a tensor written `#(...)` (`silu`, `swish`, `mish`, `normalize-minmax`, `normalize-zscore`).
+
+## Scalar activations
+
+### `(relu-scalar x)`
+`max(x, 0)`.
+
+```scheme
+(require ml.activations)
+(display (relu-scalar -2.0)) (newline)
+(display (relu-scalar 3.0)) (newline)
+```
+```
+0
+3
+```
+
+### `(sigmoid-scalar x)`
+`1 / (1 + e^{−x})`.
+
+```scheme
+(display (sigmoid-scalar 0.0)) (newline)
+```
+```
+0.5
+```
+
+### `(tanh-scalar x)`
+Hyperbolic tangent, computed as `(e^{2x} − 1)/(e^{2x} + 1)`.
+
+```scheme
+(display (tanh-scalar 1.0)) (newline)
+```
+```
+0.761594
+```
+
+### `(softplus-scalar x)`
+`log(1 + e^x)`, with a numerically stable pass-through (`x` returned directly for `x > 20`).
+
+```scheme
+(display (softplus-scalar 0.0)) (newline)
+```
+```
+0.693147
+```
+
+## Tensor activations
+
+These take a tensor `#(...)` and return a tensor, using SIMD tensor ops internally.
+
+### `(silu tensor)`
+Sigmoid Linear Unit, `x · sigmoid(x)` (elementwise).
+
+```scheme
+(display (silu #(1.0 2.0 3.0))) (newline)
+```
+```
+#(0.731059 1.76159 2.85772)
+```
+
+### `(swish tensor beta)`
+Swish, `x · sigmoid(beta·x)` (elementwise). With `beta = 1` it equals `silu`.
+
+```scheme
+(display (swish #(1.0 2.0 3.0) 1.0)) (newline)
+```
+```
+#(0.731059 1.76159 2.85772)
+```
+
+### `(mish tensor)`
+Intended: Mish, `x · tanh(softplus(x))`. **Currently broken** — see [Known issues](#known-issues).
+
+## Normalization
+
+### `(normalize-minmax tensor)`
+Min-max normalization to `[0, 1]`; if all elements are equal the tensor is returned unchanged.
+
+```scheme
+(display (normalize-minmax #(1.0 2.0 3.0 4.0))) (newline)
+```
+```
+#(0 0.333333 0.666667 1)
+```
+
+### `(normalize-zscore tensor)`
+Z-score standardization (subtract mean, divide by std); if std is 0 only the mean is subtracted.
+
+```scheme
+(display (normalize-zscore #(1.0 2.0 3.0 4.0))) (newline)
+```
+```
+#(-1.34164 -0.447214 0.447214 1.34164)
+```
+
+## Internal helpers (not in `provide`)
+
+`tensor-from-scalar`, `clip`, and `dropout` are defined in the module but are not exported.
+
+## Known issues
+
+### `mish` fails — `tensor-apply` rejects user-defined functions
+
+`mish` is implemented with `(tensor-apply tensor softplus-scalar)`, but the `tensor-apply` builtin only accepts a **named builtin** function (e.g. `sin`, `cos`, `+`), not a user/library-defined Scheme procedure like `softplus-scalar`. Calling `mish` errors; because the failure surfaces at module compile time, the error banner prints even when `mish` is never called.
+
+```scheme
+;; repro.esk
+(require ml.activations)
+(display (mish #(1.0 2.0 3.0))) (newline)
+```
+```
+ERROR: tensor-apply: function argument must be a named function (e.g., sin, cos, +)
+Unhandled exception: Type error in tensor-apply: expected tensor, got integer
+```
+No workaround within this module — compute `x · tanh(softplus(x))` manually per element instead.
+
+### Tensor activations require tensor input
+
+Like the rest of the tensor stack, `silu`/`swish`/`normalize-*` assume a `HEAP_SUBTYPE_TENSOR` operand; passing a heterogeneous vector or non-tensor can misread memory (tracked as ESH-0069). Use `#(...)` literals.

--- a/docs/reference/stdlib/ml_gradient_estimators.md
+++ b/docs/reference/stdlib/ml_gradient_estimators.md
@@ -1,0 +1,105 @@
+# `core.ml.gradient_estimators` — gradient estimators for discrete operations
+
+**Source**: [`lib/core/ml/gradient_estimators.esk`](../../../lib/core/ml/gradient_estimators.esk)
+**Require**: `(require core.ml.gradient_estimators)` — **NOT** auto-loaded via `(require stdlib)`. This is a pure-Scheme module; using its functions without the require fails with *"called undefined function"*. It is built on the stateful tape, so also `(require core.ad.tape)`. **Name-collision caveat:** `softmax` here shadows a native tensor `softmax` builtin — without the require, `(softmax v)` resolves to the *builtin* tensor op (same result for a plain vector); with the require you get this module's numerically-stable Scheme `softmax`.
+
+Discrete operations (argmax, categorical sampling, rounding) have zero derivative almost everywhere, so you cannot train through them directly. This module provides **biased-but-useful estimators** that substitute a surrogate backward pass, all recorded on the [`core.ad.tape`](ad_tape.md) via `record-op!` so a loss can route through them alongside builtin tape ops:
+
+- **Gumbel-Softmax (Concrete)** — replace a hard categorical sample with a temperature-controlled soft one-hot `softmax((logits+g)/tau)`. As `tau → 0` it approaches a one-hot; gradients flow to the logits.
+- **Straight-Through** — forward emits the *hard* value (one-hot / round), backward pretends the op was the identity so the upstream gradient passes straight through.
+
+## Functions
+
+### `(softmax v)`
+Numerically-stable softmax of a list **or** vector of numbers; returns a fresh vector summing to 1. Empty input returns a length-0 vector.
+
+### `(categorical-pick probs)`
+The **hard** decision: return the integer index of the largest entry (argmax). Accepts a list or vector.
+
+### `(argmax-onehot probs)`
+Return a hard one-hot vector with `1.0` at the argmax position (length = input length).
+
+```scheme
+;; ge-basic.esk
+(require core.ad.tape)
+(require core.ml.gradient_estimators)
+(display "softmax ")(display (softmax (vector 1.0 2.0 0.5)))(newline)
+(display "pick ")(display (categorical-pick (vector 0.1 0.9 0.3)))(newline)
+(display "onehot ")(display (argmax-onehot (vector 0.1 0.9 0.3)))(newline)
+```
+```
+softmax #(0.231224 0.628532 0.140244)
+pick 1
+onehot #(0 1 0)
+```
+
+### `(sample-gumbel-noise n)`
+Draw a length-`n` vector of Gumbel noise `g = -log(-log(u))`, `u ~ Uniform(0,1)`. **Nondeterministic** (uses `(random)`); tests pass explicit noise for reproducibility.
+
+### `(gumbel-softmax-det t logits-node tau noise)`
+**Deterministic** Gumbel-Softmax recorded as one custom op on tape `t`. `logits-node` is a tape node whose value is a logit vector, `tau > 0` the temperature, `noise` an explicit Gumbel-noise vector. Forward output is the soft one-hot `softmax((logits+noise)/tau)`; the backward is the softmax Jacobian-vector product scaled by `1/tau`, so gradients flow to `logits-node`. Returns the output node.
+
+### `(gumbel-softmax t logits-node tau)`
+Stochastic variant of the above — draws fresh Gumbel noise internally (matching the logits length), then delegates to `gumbel-softmax-det`.
+
+```scheme
+;; ge-gumbel.esk — output is a valid distribution; grad flows to logits
+(require core.ad.tape)
+(require core.ml.gradient_estimators)
+(define noise (vector 0.10 -0.20 0.30 0.05))
+(define p
+  (with-tape "g"
+    (lambda ()
+      (let* ((t  (current-tape))
+             (lg (tape-input t (vector 1.0 2.0 0.5 0.0)))
+             (gs (gumbel-softmax-det t lg 0.5 noise)))
+        (node-value gs)))))
+(display p)(newline)
+(display "sum=")
+(display (let ((n (vector-length p)))
+  (let loop ((i 0)(s 0.0)) (if (< i n) (loop (+ i 1) (+ s (vector-ref p i))) s))))(newline)
+```
+```
+#(0.174628 0.70815 0.0958377 0.0213843)
+sum=1
+```
+
+### `(straight-through t est-node hard-value)`
+Generic straight-through op. Forward emits `hard-value` (precomputed, same shape as the node — scalar or vector); backward is the identity, routing the gradient straight to `est-node`. Returns the output node.
+
+### `(straight-through-round t x-node)`
+Straight-through on scalar rounding: forward `= (round (node-value x-node))`, backward `= identity`.
+
+### `(straight-through-onehot t probs-node)`
+Straight-through on categorical argmax: forward `= argmax-onehot` of the (soft) probability node's value, backward routes the gradient back to the soft probs unchanged. This is how you train through a discrete sample while keeping a usable gradient.
+
+```scheme
+;; ge-st.esk — forward is the hard value; backward passes gradient through
+(require core.ad.tape)
+(require core.ml.gradient_estimators)
+(define oh
+  (with-tape "st"
+    (lambda ()
+      (let* ((t (current-tape))
+             (x (tape-input t (vector 0.1 0.7 0.2))))
+        (node-value (straight-through-onehot t x))))))
+(display "onehot ")(display oh)(newline)
+(define r
+  (with-tape "str"
+    (lambda ()
+      (let* ((t (current-tape)) (x (tape-input t 2.3)))
+        (node-value (straight-through-round t x))))))
+(display "round(2.3) ")(display r)(newline)
+```
+```
+onehot #(0 1 0)
+round(2.3) 2
+```
+
+## Edge cases
+- `softmax` of an empty vector returns a length-0 vector (no error).
+- These estimators are **biased by design** — that is the point; the gumbel-softmax gradient matches finite differences of the *soft* loss (rel err < 1e-2, per the acceptance test), not of the hard discrete op.
+- `gumbel-softmax` / `sample-gumbel-noise` are nondeterministic; use the `-det` variants with explicit noise for reproducible output.
+
+## Verification note
+`tests/ml/gradient_estimators_test.esk` passes 16/16 under `eshkol-run -r`: gumbel-softmax is a valid distribution, its gradient matches central finite differences (rel<1e-2), straight-through forward equals the hard value, and both ST and gumbel-softmax training loops drive the argmax to the target class (`p[target] > 0.8` end-to-end). No `.swarm` ledger issues reference these functions.

--- a/docs/reference/stdlib/ml_neurosymbolic.md
+++ b/docs/reference/stdlib/ml_neurosymbolic.md
@@ -1,0 +1,89 @@
+# `core.ml.neurosymbolic` — differentiable symbol embeddings + soft unification
+
+**Source**: [`lib/core/ml/neurosymbolic.esk`](../../../lib/core/ml/neurosymbolic.esk)
+**Require**: `(require core.ml.neurosymbolic)` — **NOT** auto-loaded via `(require stdlib)`. Pure-Scheme module; calling its functions without the require fails with *"called undefined function 'make-embedding-table'"*. It internally `(require core.ad.tape)`s, so the tape is pulled in transitively.
+
+The neuro-symbolic bridge. The consciousness engine's `unify` is an exact boolean match; **soft unification** replaces that with a **differentiable** similarity in `[0,1]` over learnable per-symbol embedding vectors, so a system can *learn* which symbols should unify (cat≈feline, cat≉rock) rather than only test syntactic identity. Built on [`core.ad.tape`](ad_tape.md): embeddings are parameters, each soft-unify is a tape forward (dot → sigmoid), and `tape-gradient` + SGD update the embeddings.
+
+An **embedding table** is `#(dim entries)` where `entries` is a mutable alist `(sym . vector)`. Embeddings are initialised to small, **symbol-deterministic** values (a hash of the printed symbol seeds a small LCG), so distinct symbols start distinct with no RNG dependency.
+
+## Functions
+
+### `(make-embedding-table dim)`
+Create an empty embedding table with `dim`-dimensional embeddings.
+
+### `(emb-dim tbl)`
+Return the embedding dimension.
+
+### `(embed! tbl sym)`
+Return `sym`'s (mutable) embedding vector, **creating** it (deterministically seeded) on first access. The returned vector is the live table entry — mutating it mutates the table (this is how training updates embeddings in place).
+
+### `(vdot a b)`
+Dot product of two equal-length numeric vectors. (Exported helper.)
+
+```scheme
+;; ns-basic.esk
+(require core.ml.neurosymbolic)
+(define tbl (make-embedding-table 8))
+(display "dim ")(display (emb-dim tbl))(newline)
+(define e (embed! tbl 'cat))
+(display "emb len ")(display (vector-length e))(newline)
+(display "vdot(e,e) ")(display (vdot e e))(newline)
+```
+```
+dim 8
+emb len 8
+vdot(e,e) 2.41432
+```
+
+### `(soft-unify tbl a b)`
+Differentiable unification confidence `sigmoid(<emb a, emb b> / sqrt(dim))` in `[0,1]`. Creates embeddings for `a`/`b` if new.
+
+### `(soft-unify-loss tbl a b target)`
+Squared error `(soft-unify(a,b) - target)^2`.
+
+### `(soft-unify-train! tbl a b target lr)`
+One differentiable SGD step that pushes `soft-unify(a,b)` toward `target` by updating **both** embeddings in place (via the tape). Returns the loss **before** the update.
+
+```scheme
+;; ns-train.esk — learn that cat unifies with feline
+(require core.ml.neurosymbolic)
+(define tbl (make-embedding-table 8))
+(display "before ")(display (soft-unify tbl 'cat 'feline))(newline)
+(let loop ((i 0))
+  (if (< i 200) (begin (soft-unify-train! tbl 'cat 'feline 1.0 0.5) (loop (+ i 1)))))
+(display "after  ")(display (soft-unify tbl 'cat 'feline))(newline)
+```
+```
+before 0.443577
+after  0.960393
+```
+
+### `(kb-attention tbl keys query)`
+Differentiable retrieval: the `query` symbol attends over the `keys` (a list of symbols) by scaled-dot-product similarity, softmaxed. Returns an **alist** `(key . attention-weight)` whose weights sum to 1. As the embeddings are trained, the query routes to related keys — a neural query over a symbolic store.
+
+### `(kb-retrieve tbl keys query)`
+Argmax over `kb-attention`: return the single key the query attends to most.
+
+```scheme
+;; ns-kb.esk
+(require core.ml.neurosymbolic)
+(define tbl (make-embedding-table 8))
+;; train cat<->feline so a 'feline query routes to 'cat
+(let loop ((i 0))
+  (if (< i 200) (begin (soft-unify-train! tbl 'cat 'feline 1.0 0.5) (loop (+ i 1)))))
+(display (kb-attention tbl (list 'cat 'dog 'rock) 'feline))(newline)
+(display (kb-retrieve tbl (list 'cat 'dog 'rock) 'feline))(newline)
+```
+```
+((cat . 0.87199) (dog . 0.00842293) (rock . 0.119587))
+cat
+```
+
+## Edge cases
+- `embed!` returns the **live** table vector, not a copy — this is intentional (training mutates it). Copy it if you need a snapshot.
+- Embedding init is deterministic per symbol name, so `soft-unify` of fresh symbols is reproducible across runs (the "before" value above is stable).
+- Not exported (internal helpers, not for direct use): `ns-make-vec`, `ns-reverse`, `ns-scale`, `ns-sub!`, `ns-assq`, `ns-init`.
+
+## Verification note
+All functions verified under `eshkol-run -r` (outputs above are verbatim); `soft-unify` rises from 0.443577 toward 0.960393 after 200 training steps toward target 1.0, and `kb-retrieve` correctly routes a `feline` query to the trained `cat` key. No `.swarm` ledger issues reference these functions.

--- a/docs/reference/stdlib/ml_optimization.md
+++ b/docs/reference/stdlib/ml_optimization.md
@@ -1,0 +1,98 @@
+# `ml.optimization` — gradient-based optimizers
+
+**Source**: [`lib/ml/optimization.esk`](../../../lib/ml/optimization.esk)
+**Require**: `(require ml.optimization)` — also **auto-loaded** by `(require stdlib)`.
+
+Unconstrained optimizers that minimize a scalar objective `f: vector → scalar`, using the built-in `gradient` function (forward-mode AD). Provides gradient descent, Adam, L-BFGS, and nonlinear conjugate gradient, plus a backtracking line search and two small tensor helpers. All points and gradients are vectors written `#(...)`.
+
+Optimizer functions take the objective and start point positionally, then accept hyper-parameters as an **optional positional tail** (`. opts`) — pass them in order (e.g. `lr`, then `max-iter`, then `tol`); omitted ones fall back to defaults.
+
+## Tensor helpers
+
+### `(tensor-dot a b)`
+Dot product of two vectors.
+
+```scheme
+(require ml.optimization)
+(display (tensor-dot #(1.0 2.0 3.0) #(4.0 5.0 6.0))) (newline)
+```
+```
+32
+```
+
+### `(tensor-norm v)`
+L2 norm, `(sqrt (tensor-dot v v))`.
+
+```scheme
+(display (tensor-norm #(3.0 4.0))) (newline)
+```
+```
+5
+```
+
+## Optimizers
+
+All examples minimize `f(x,y) = x² + y²` (minimum at the origin):
+
+```scheme
+(define (quad v) (let ((x (vref v 0)) (y (vref v 1))) (+ (* x x) (* y y))))
+```
+
+### `(gradient-descent f x0 [lr [max-iter [tol]]])`
+Basic gradient descent. Defaults: `lr = 0.01`, `max-iter = 1000`, `tol = 1e-8` (on gradient norm). Returns the optimized point.
+
+```scheme
+(display (gradient-descent quad #(5.0 5.0) 0.1 1000 1e-8)) (newline)
+```
+```
+#(3.10827e-09 3.10827e-09)
+```
+
+### `(adam f x0 [lr [beta1 [beta2]]])`
+Adam (adaptive moment estimation). Optional tail sets `lr` (default `0.001`), `beta1` (`0.9`), `beta2` (`0.999`); `epsilon = 1e-8`, `max-iter = 1000`, `tol = 1e-8` are fixed internally.
+
+```scheme
+(display (adam quad #(5.0 5.0) 0.1)) (newline)
+```
+```
+#(4.7806e-11 4.7806e-11)
+```
+
+### `(l-bfgs f x0 [max-iter [tol [m]]])`
+Limited-memory BFGS with two-loop recursion, Armijo line search, and a curvature safeguard. Defaults: `max-iter = 200`, `tol = 1e-8`, history size `m = 10`.
+
+```scheme
+(display (l-bfgs quad #(5.0 5.0))) (newline)
+```
+```
+#(0 0)
+```
+
+### `(conjugate-gradient f x0 [max-iter [tol [restart-interval]]])`
+Nonlinear conjugate gradient (Fletcher–Reeves) with periodic restart. Defaults: `max-iter = 200`, `tol = 1e-8`, `restart-interval = (vector-length x0)`.
+
+```scheme
+(display (conjugate-gradient quad #(5.0 5.0))) (newline)
+```
+```
+#(0 0)
+```
+
+### `(line-search f x d grad [alpha0 [c1 [rho]]])`
+Backtracking line search returning a step size `alpha` satisfying the Armijo condition `f(x + α·d) ≤ f(x) + c1·α·gradᵀd`. Defaults: `alpha0 = 1.0`, `c1 = 1e-4`, `rho = 0.5`, and a fixed `max-iter = 30` (returns the current `alpha` if not satisfied).
+
+```scheme
+(display (line-search quad #(1.0 1.0) #(-1.0 -1.0) #(2.0 2.0))) (newline)
+```
+```
+1
+```
+
+## Internal helpers (not in `provide`)
+
+`vec-add`, `vec-sub`, `vec-scale`, `vec-neg`, `vec-zeros`, `vec-sq`, `adam-apply-update`, and `l-bfgs-direction` are elementwise vector utilities used by the optimizers and are not exported.
+
+## Notes / caveats
+
+- Inputs must be vectors (`#(...)`); like the rest of the tensor stack, passing a list will misread memory (see ESH-0069). All examples above run cleanly under both `-r` and via `(require stdlib)`.
+- `gradient` is forward-mode AD; the objective `f` must be differentiable through the operations it uses.

--- a/docs/reference/stdlib/module-system.md
+++ b/docs/reference/stdlib/module-system.md
@@ -1,0 +1,147 @@
+# Module system — `require`, `provide`, and `stdlib.o` precompilation
+
+This page documents how the Eshkol standard library is packaged and loaded:
+how `(require ...)` resolves a module name to a file, what `(require stdlib)`
+does versus requiring an individual module, and how the precompiled
+`stdlib.o` / `stdlib.bc` artifacts change loading. Source of record:
+[`exe/eshkol-run.cpp`](../../../exe/eshkol-run.cpp) and
+[`lib/stdlib.esk`](../../../lib/stdlib.esk).
+
+---
+
+## `provide` and `require`
+
+Every stdlib module declares its public surface with a `(provide sym ...)`
+form near the top of the file. Only provided symbols are importable by other
+modules; everything else is module-private.
+
+```scheme
+;;; lib/core/list/transform.esk
+(provide take drop take-right drop-right append reverse filter
+         unzip partition list-copy)
+```
+
+A consumer pulls the module in with `(require <module-name>)`:
+
+```scheme
+(require core.list.transform)
+(display (take (list 1 2 3 4 5) 2)) (newline)   ;; => (1 2)
+```
+
+## Module-name → file resolution
+
+`resolve_module_path` (eshkol-run.cpp) maps a dotted module name to a file:
+
+- **Dotted names** have each `.` rewritten to `/` and `.esk` appended:
+  - `core.strings`   → `lib/core/strings.esk`
+  - `core.list.transform` → `lib/core/list/transform.esk`
+  - `core.ad.tape`   → `lib/core/ad/tape.esk`
+  - `signal.fft`     → `lib/signal/fft.esk`
+  - `ml.optimization`→ `lib/ml/optimization.esk`
+  - `math`           → `lib/math.esk`
+- **Path literals** — a string beginning with `/`, `./`, `../`, containing a
+  `/`, or ending in `.esk` — are treated verbatim (no dot→slash rewrite). This
+  is what makes `(load "some/dir.v2/file.esk")` work even when a directory name
+  contains a dot (e.g. macOS `$TMPDIR` like `/var/folders/<hash>.<r>/T`).
+
+### Search order
+
+For each resolved `path_part`, the loader tries, in order:
+
+1. the requiring file's directory (`base_dir`);
+2. the current working directory / project root (so a project-rooted module
+   like `src.core.x` resolves against `./src/...`, matching the JIT resolver);
+3. the library directory `lib/` (auto-discovered relative to the `eshkol-run`
+   binary and the cwd);
+4. **directory-as-module**: if `lib/web.esk` is absent, `lib/web/web.esk` then
+   `lib/web/index.esk` are tried, so `(require web)` can find a package entry
+   point;
+5. each colon-separated (`;` on Windows) entry of `$ESHKOL_PATH`. Empty
+   segments, missing directories, and non-directory entries are silently
+   skipped (flagged only in debug mode).
+
+The first match wins and its canonical path is used.
+
+## `(require stdlib)` vs individual modules
+
+`(require stdlib)` loads [`lib/stdlib.esk`](../../../lib/stdlib.esk), which is
+a curated re-export hub — it simply `(require ...)`s a fixed set of core
+modules and defines a handful of top-level helpers. Requiring it is a
+convenience: you get the whole auto-loaded surface in one line.
+
+**Auto-loaded via `(require stdlib)`** (read from `lib/stdlib.esk`):
+
+`core.io`, `core.operators.arithmetic`, `core.operators.compare`,
+`core.numeric_extras`, `core.logic.predicates`, `core.logic.types`,
+`core.logic.boolean`, `core.functional.compose`, `core.functional.curry`,
+`core.functional.flip`, `core.control.trampoline`, `core.list.compound`,
+`core.list.generate`, `core.list.transform`, `core.list.query`,
+`core.list.sort`, `core.list.higher_order`, `core.list.search`,
+`core.list.convert`, `core.strings`, `core.alist`, `core.files`,
+`core.capabilities`, `core.sexp`, `core.json`, `core.data.csv`,
+`core.data.dataframe`, `core.data.base64`, `core.plot`, `core.reflection`,
+`core.url`, `core.streams`, `core.json_schema`, `signal.fft`, `signal.filters`,
+`core.manifold`, `ml.optimization`.
+
+`stdlib.esk` also defines directly: `random-tensor`, `random-normal-tensor`,
+`current-time-us`, `time-ns`, `time-us`, `time-it`, and the internal keyword
+helpers `__keyword-member?` / `__keyword-args-validate` / `__keyword-arg`.
+
+**NOT auto-loaded** — must be required individually (non-exhaustive):
+`core.testing`, `core.cache`, `core.threads`, `core.channels`,
+`core.collections`, `core.metrics`, `core.logging`, `core.argparse`,
+`core.memory`, `core.memory_store`, `core.merkle`, `core.distributed`,
+`core.msgpack`, `core.ad.tape`, `core.dnc`, `core.sdnc`,
+`core.ml.gradient_estimators`, `core.ml.neurosymbolic`, `core.http_server`,
+`core.reflection`'s siblings under other trees, `ml.activations`.
+
+> `core.testing` is deliberately excluded from `stdlib.esk`. Baking it into the
+> precompiled `stdlib.o` triggers the symbol-renamer / external-declaration
+> path that currently mis-handles a precompiled module's mutable internal state
+> (the `*tests*` / counter globals), producing duplicate `_*tests*` symbols in
+> the user `.o`. Require it explicitly with `(require core.testing)`.
+
+## `stdlib.o` / `stdlib.bc` precompilation
+
+The whole auto-loaded set is compiled ahead of time into `build/stdlib.o`
+(native object) and `build/stdlib.bc` (LLVM bitcode) via the `--shared-lib`
+build path. These artifacts let both the JIT (`-r`) and AOT compiler skip
+re-codegen of ~440 stdlib functions on every run.
+
+- When `stdlib.o` (or `libstdlib.o`) is linked (auto-linked if not supplied
+  explicitly), the loader calls `collect_all_submodules("stdlib", ...)`, which
+  parses `lib/stdlib.esk` and recursively every module it requires, marking the
+  **entire transitive set** as *precompiled*.
+- In `process_requires`, a module found in the precompiled set is **not**
+  code-generated from source again. Instead its `.esk` is parsed only to
+  recover the function/type **declarations** (signatures, export list, return
+  types); the actual machine code comes from `stdlib.o`. This is the "strip the
+  bodies, keep the decls" path.
+- If `stdlib.o` is linked but its `.esk` sources cannot be found (e.g. the
+  object was installed without the accompanying `lib/` tree),
+  `collect_all_submodules` adds nothing, and the loader **fails loudly** rather
+  than silently re-loading `core.*` from source and producing duplicate symbols
+  at link time.
+
+### `core.*` fallthrough
+
+Any required module that is *not* in the precompiled set is loaded and compiled
+from its `.esk` source in the normal way (bodies included), then linked
+alongside `stdlib.o`. This is why requiring a non-auto-loaded module such as
+`core.cache` or `core.testing` works even though it is absent from `stdlib.o`:
+it simply falls through to the from-source path. The historical hazard is a
+module that is *partially* in both worlds — the precompiled discovery walks the
+transitive `require` graph specifically to avoid a submodule being compiled
+from source while its parent is precompiled (which double-defines symbols).
+
+## Running the examples in this reference
+
+Every example in this reference was executed with the JIT runner:
+
+```sh
+eshkol-run path/to/example.esk -r
+```
+
+The `-r` flag runs the program via the JIT (using the cached `stdlib` object);
+`-o out` instead produces a native binary. `-n` / `--no-stdlib` disables
+auto-linking of `stdlib.o`.

--- a/docs/reference/stdlib/msgpack.md
+++ b/docs/reference/stdlib/msgpack.md
@@ -1,0 +1,140 @@
+# `core.msgpack` — MessagePack wire-format substrate
+
+**Source**: [`lib/core/msgpack.esk`](../../../lib/core/msgpack.esk)
+**Require**: `(require core.msgpack)` — auto-loaded via `(require stdlib)`.
+
+Pure-Eshkol [MessagePack](https://msgpack.org/) encoder/decoder covering the
+deterministic value subset used by the distributed/CRDT track: `null`, booleans,
+exact integers across the signed/unsigned 8/16/32-bit encodings, UTF-8 strings,
+binary bytevectors, list arrays, and explicit maps. Encoded output is a
+**bytevector**. No bugs were observed.
+
+Because a Scheme list already means "array", maps use a distinct wrapper value
+(`msgpack-map`) so they are not confused with arrays.
+
+## Value constructors / predicates
+
+### `(msgpack-null)` / `(msgpack-null? value)`
+The MessagePack null sentinel (the symbol `msgpack-null`) and its predicate.
+
+```scheme
+(require core.msgpack)
+(display (msgpack-null)) (newline)                 ; msgpack-null
+(display (msgpack-null? (msgpack-null))) (newline) ; #t
+(display (msgpack-null? 5)) (newline)              ; #f
+```
+```
+msgpack-null
+#t
+#f
+```
+
+### `(msgpack-map entries)` / `(msgpack-map? value)` / `(msgpack-map-entries value)`
+`msgpack-map` wraps a list of `(key value)` two-element lists into a map value.
+`msgpack-map?` recognises it; `msgpack-map-entries` extracts the entry list
+(errors on a non-map).
+
+```scheme
+(define m (msgpack-map (list (list "a" 1) (list "b" 2))))
+(display (msgpack-map? m)) (newline)               ; #t
+(display (msgpack-map-entries m)) (newline)        ; ((a 1) (b 2))
+```
+```
+#t
+((a 1) (b 2))
+```
+
+## Encoding / decoding
+
+### `(msgpack-encode value)`
+Encode a value to a **bytevector**. Accepts `msgpack-null`, booleans, integers
+(in the supported 32-bit signed/unsigned range), strings, bytevectors, lists
+(arrays), and `msgpack-map` values. Integers outside range, or unsupported
+types, raise an error.
+
+### `(msgpack-decode bv)`
+Decode a bytevector holding exactly one object; errors if trailing bytes remain.
+
+```scheme
+(display (msgpack-decode (msgpack-encode 42))) (newline)
+(display (msgpack-decode (msgpack-encode -5))) (newline)
+(display (msgpack-decode (msgpack-encode 100000))) (newline)
+(display (msgpack-decode (msgpack-encode -100000))) (newline)
+(display (msgpack-decode (msgpack-encode #t))) (newline)
+(display (msgpack-decode (msgpack-encode "hello"))) (newline)
+(display (msgpack-decode (msgpack-encode '(1 2 3)))) (newline)
+```
+```
+42
+-5
+100000
+-100000
+#t
+hello
+(1 2 3)
+```
+
+Maps and the null sentinel round-trip too:
+
+```scheme
+(define m (msgpack-map (list (list "a" 1) (list "b" 2))))
+(define dm (msgpack-decode (msgpack-encode m)))
+(display (msgpack-map? dm)) (newline)                       ; #t
+(display (msgpack-map-entries dm)) (newline)                ; ((a 1) (b 2))
+(display (msgpack-null? (msgpack-decode (msgpack-encode (msgpack-null))))) (newline)  ; #t
+```
+```
+#t
+((a 1) (b 2))
+#t
+```
+
+### `(msgpack-decode-prefix bv)`
+Decode the first object from a bytevector and return `(value next-position)`
+without requiring the whole buffer to be consumed — for streaming/framed input.
+
+```scheme
+(display (msgpack-decode-prefix (msgpack-encode 7))) (newline)   ; (7 1)
+```
+```
+(7 1)
+```
+
+## Bytevector <-> byte-list conversion
+
+### `(msgpack-bytes->bytevector bytes)` / `(msgpack-bytevector->bytes bv)`
+Convert between a list of byte integers (0–255) and a bytevector. Handy for
+inspecting the wire format. `msgpack-bytes->bytevector` errors on any element
+outside `[0,255]`.
+
+```scheme
+(display (bytevector? (msgpack-bytes->bytevector '(1 2 3)))) (newline)       ; #t
+(display (msgpack-bytevector->bytes (msgpack-encode 42))) (newline)         ; (42) -> positive fixint
+(display (msgpack-bytevector->bytes (msgpack-encode "ab"))) (newline)       ; (162 97 98) -> fixstr
+```
+```
+#t
+(42)
+(162 97 98)
+```
+
+## Binary round-trip
+
+Bytevectors — including NUL (`0`) and high bytes — survive encode/decode:
+
+```scheme
+(display (msgpack-bytevector->bytes
+          (msgpack-decode (msgpack-encode (msgpack-bytes->bytevector '(0 255 128)))))) (newline)
+```
+```
+(0 255 128)
+```
+
+### Internal helpers
+Not part of the public API but present in the source (wire-format primitives):
+`msgpack-require-byte`, `msgpack-require-available`, `msgpack-u16-bytes`,
+`msgpack-u32-bytes`, `msgpack-read-u16`, `msgpack-read-u32`, `msgpack-encode-int`,
+`msgpack-encode-bin-bytes`, `msgpack-encode-string`, `msgpack-encode-array`,
+`msgpack-encode-map-value`, `msgpack-encode-value`, `msgpack-decode-at`,
+`msgpack-decode-bin`, `msgpack-decode-string`, `msgpack-decode-array-elements`,
+`msgpack-decode-map-entries`.

--- a/docs/reference/stdlib/numeric_extras.md
+++ b/docs/reference/stdlib/numeric_extras.md
@@ -1,0 +1,45 @@
+# `core.numeric_extras` — R7RS 6.2.6 numeric helpers
+
+**Source**: [`lib/core/numeric_extras.esk`](../../../lib/core/numeric_extras.esk)
+**Require**: auto-loaded via `(require stdlib)`; or individually `(require core.numeric_extras)`
+
+Pure-Scheme implementations of R7RS §6.2.6 numeric procedures built on the existing numeric tower, so bignum inputs work transparently. Part of the R7RS final-mile work tracked in `.swarm/tasks/ESH-0003` ("R7RS final-mile: raise-continuable, error-object? family, exact-integer-sqrt, char-ci=? family").
+
+## Functions
+
+### `(exact-integer-sqrt k)`
+For an exact non-negative integer `k`, returns **two values** `s` and `r` such that `k = s*s + r` and `k < (s+1)*(s+1)` — i.e. `s` is the integer square root and `r` the remainder. Uses Newton iteration; converges for fixnums and bignums alike. Because it returns multiple values, consume it with `call-with-values` (or `let-values`).
+
+```scheme
+;; numeric.esk
+(require stdlib)
+(define (show k)
+  (call-with-values (lambda () (exact-integer-sqrt k))
+    (lambda (s r)
+      (display k) (display " -> s=") (display s)
+      (display " r=") (display r) (newline))))
+(show 0) (show 1) (show 2) (show 4) (show 5) (show 17) (show 100) (show 99)
+```
+```
+0 -> s=0 r=0
+1 -> s=1 r=0
+2 -> s=1 r=1
+4 -> s=2 r=0
+5 -> s=2 r=1
+17 -> s=4 r=1
+100 -> s=10 r=0
+99 -> s=9 r=18
+```
+
+Bignum input is handled exactly:
+
+```scheme
+(require stdlib)
+(call-with-values (lambda () (exact-integer-sqrt (expt 10 50)))
+  (lambda (s r) (display s) (display " r=") (display r) (newline)))
+```
+```
+10000000000000000000000000 r=0
+```
+
+Edge cases: a negative argument raises an error (`"exact-integer-sqrt: argument must be non-negative"`). The result is exact; there is no rounding.

--- a/docs/reference/stdlib/operators_arithmetic.md
+++ b/docs/reference/stdlib/operators_arithmetic.md
@@ -1,0 +1,61 @@
+# `core.operators.arithmetic` — first-class arithmetic operators
+
+**Source**: [`lib/core/operators/arithmetic.esk`](../../../lib/core/operators/arithmetic.esk)
+**Require**: auto-loaded via `(require stdlib)`; or individually `(require core.operators.arithmetic)`
+
+Named binary wrappers around `+`, `-`, `*`, `/` so the operators can be passed as ordinary values to higher-order procedures.
+
+## Functions
+
+### `(add x y)`
+`(+ x y)`.
+
+### `(sub x y)`
+`(- x y)`.
+
+### `(mul x y)`
+`(* x y)`.
+
+### `(div x y)`
+Intended to be `(/ x y)`. **Broken — returns `()`. See Known issues.**
+
+```scheme
+;; arithmetic.esk
+(require stdlib)
+(display (add 3 4)) (newline)
+(display (sub 10 3)) (newline)
+(display (mul 6 7)) (newline)
+(display (map (lambda (p) (add (car p) (cdr p))) '((1 . 2) (3 . 4)))) (newline)
+```
+```
+7
+7
+42
+(3 7)
+```
+
+Edge cases: `add`/`sub`/`mul` follow the full numeric tower of the underlying operators (ints, bignums, rationals, doubles). For division, use the built-in `/` directly instead of `div`.
+
+## Known issues
+
+### `div` returns `()` for scalar arguments
+The name `div` collides with a codegen-recognized tensor-arithmetic operation (`lib/backend/llvm_codegen.cpp:5470`; see also `lib/backend/tensor_arith_codegen.cpp`), so a scalar call is dispatched to the wrong path and yields the empty list instead of a quotient.
+
+```scheme
+(require stdlib)
+(display (div 20 4)) (newline)   ; expected 5
+(display (div 7 2)) (newline)    ; expected 7/2
+```
+```
+()
+()
+```
+
+For comparison, the same expression through `/` (or through a user-defined wrapper whose name is not `div`) works:
+
+```scheme
+(display (/ 20 4)) (newline)                       ; => 5
+(define (mydiv a b) (/ a b)) (display (mydiv 20 4)) ; => 5
+```
+
+Workaround: call `/` directly, or wrap it under a different name. Not yet ledgered in `.swarm/tasks/` at time of writing.

--- a/docs/reference/stdlib/operators_compare.md
+++ b/docs/reference/stdlib/operators_compare.md
@@ -1,0 +1,49 @@
+# `core.operators.compare` — first-class comparison operators
+
+**Source**: [`lib/core/operators/compare.esk`](../../../lib/core/operators/compare.esk)
+**Require**: auto-loaded via `(require stdlib)`; or individually `(require core.operators.compare)`
+
+Named binary wrappers around `<`, `>`, `<=`, `>=`, `=`, so the comparison operators can be passed as ordinary procedures. All return proper `#t`/`#f` booleans, including when `apply`'d — the raw-int leakage tracked in `.swarm/tasks/ESH-0079` (status: done — "First-class / apply'd builtin equality predicates return raw int (0/1) or () instead of #f/#t") does not affect these wrappers.
+
+## Functions
+
+### `(lt x y)`
+`(< x y)`.
+
+### `(gt x y)`
+`(> x y)`.
+
+### `(le x y)`
+`(<= x y)`.
+
+### `(ge x y)`
+`(>= x y)`.
+
+### `(eq x y)`
+Numeric equality `(= x y)` — **not** `eq?` identity. Compares numbers by value.
+
+```scheme
+;; compare.esk
+(require stdlib)
+(display (lt 3 5)) (newline)
+(display (gt 3 5)) (newline)
+(display (le 5 5)) (newline)
+(display (ge 4 5)) (newline)
+(display (eq 5 5)) (newline)
+(display (eq 5 6)) (newline)
+;; usable first-class / via apply
+(display (apply eq '(5 5))) (newline)
+(display (apply lt '(3 5))) (newline)
+```
+```
+#t
+#f
+#t
+#f
+#t
+#f
+#t
+#t
+```
+
+Edge cases: `eq` is value equality on numbers (delegates to `=`); do not confuse it with the identity predicate `eq?`. The wrappers are strictly binary.

--- a/docs/reference/stdlib/plot.md
+++ b/docs/reference/stdlib/plot.md
@@ -1,0 +1,56 @@
+# `core.plot` — terminal plotting (sparklines, bar charts, histograms)
+
+**Source**: [`lib/core/plot.esk`](../../../lib/core/plot.esk)
+**Require**: `(require core.plot)` — **auto-loaded** via `stdlib` (listed in `lib/stdlib.esk`), so `(require stdlib)` is enough; requiring it directly also works.
+
+Pure-Eshkol terminal visualisations using Unicode block characters `▁▂▃▄▅▆▇█`. `sparkline` returns a string; `bar-chart` and `histogram` print directly to standard output.
+
+## Functions
+
+### `(sparkline data)`
+Map a list of numbers to a compact string of block characters (8 levels, scaled between the data's min and max). Returns `""` for the empty list; a constant series maps to the mid-level block `▄`.
+
+```scheme
+;; plot.esk
+(require core.plot)
+(display (sparkline (list 1 4 2 8 5 3 7))) (newline)
+(display (sparkline (list))) (newline)       ; empty -> ""
+(display (sparkline (list 5 5 5))) (newline)  ; constant -> mid-level
+```
+```
+▁▄▂█▅▃▇
+
+▄▄▄
+```
+
+### `(bar-chart entries)`
+Print a horizontal bar chart. `entries` is a list of `(label value)` 2-lists. Bars are 30 cells wide, scaled to the max value, filled with `█` and padded with `░`; the numeric value is shown at the right. Labels are left-padded to 8 columns. Returns `'()`.
+
+```scheme
+;; plot.esk
+(require core.plot)
+(bar-chart (list (list "Alpha" 10) (list "Beta" 25) (list "Gamma" 15)))
+```
+```
+Alpha    ████████████░░░░░░░░░░░░░░░░░░  10
+Beta     ██████████████████████████████  25
+Gamma    ██████████████████░░░░░░░░░░░░  15
+```
+
+### `(histogram data n-bins)`
+Print a frequency histogram of `data` split into `n-bins` equal-width buckets between min and max. Each row shows the `[lo, hi)` range (last bin is inclusive of the max), a run of `█`, and the count. Returns `'()` for empty data or `n-bins <= 0`.
+
+```scheme
+;; plot.esk
+(require core.plot)
+(histogram (list 1 2 2 3 3 3 4 4 5) 5)
+```
+```
+[1, 1.8) █ 1
+[1.8, 2.6) ██ 2
+[2.6, 3.4) ███ 3
+[3.4, 4.2) ██ 2
+[4.2, 5) █ 1
+```
+
+Edge cases: `sparkline` on `'()` → `""`. `bar-chart`/`histogram` on `'()` → `'()` (nothing printed). `histogram` with `n-bins <= 0` → `'()`. Ranges are formatted to ~6 characters via truncation, so very precise bounds are shortened. Min/max use non-tail recursion (safe up to ~10K elements per the source note).

--- a/docs/reference/stdlib/reflection.md
+++ b/docs/reference/stdlib/reflection.md
@@ -1,0 +1,69 @@
+# `core.reflection` — runtime value reflection
+
+**Source**: [`lib/core/reflection.esk`](../../../lib/core/reflection.esk)
+**Require**: auto-loaded via `(require stdlib)`; or individually `(require core.reflection)`
+
+Runtime introspection helpers (task #170). `type-name` classifies a value with a single symbol; `describe` produces a human-readable string. Both dispatch over the standard type predicates.
+
+Related: `procedure-arity` is **not** defined here — it is a codegen builtin implemented in `lib/backend/llvm_codegen.cpp` (see `codegenProcedureArity`, dispatched at ~line 13447). It returns the fixed parameter count of a procedure and is used internally by `describe`. `record-fields` is documented in the source as **deferred** (field names are not embedded in runtime record values) and is not provided.
+
+## Functions
+
+### `(type-name value)`
+Returns one type-tag symbol: `null`, `boolean`, `integer`, `real`, `string`, `symbol`, `char`, `pair`, `vector`, `procedure`, or `unknown`. Note the dispatch order puts `null` and `boolean` before the numeric checks.
+
+```scheme
+;; reflection.esk
+(require stdlib)
+(display (type-name 42)) (newline)
+(display (type-name 3.14)) (newline)
+(display (type-name "hi")) (newline)
+(display (type-name 'foo)) (newline)
+(display (type-name #t)) (newline)
+(display (type-name '())) (newline)
+(display (type-name '(1 2))) (newline)
+(display (type-name (vector 1 2))) (newline)
+(display (type-name car)) (newline)
+```
+```
+integer
+real
+string
+symbol
+boolean
+null
+pair
+vector
+procedure
+```
+
+### `(describe value)`
+Returns a descriptive string. Format varies by type: atoms show their value; strings show length and quoted text; pairs and vectors show their size; procedures show their arity (via `procedure-arity`).
+
+```scheme
+(require stdlib)
+(display (describe 42)) (newline)
+(display (describe 3.14)) (newline)
+(display (describe "hi")) (newline)
+(display (describe 'foo)) (newline)
+(display (describe #t)) (newline)
+(display (describe '())) (newline)
+(display (describe (list 1 2 3))) (newline)
+(display (describe (vector 'a 'b))) (newline)
+(display (describe (lambda (x y) x))) (newline)
+(display (describe car)) (newline)
+```
+```
+integer: 42
+real: 3.14
+string[2]: "hi"
+symbol: foo
+boolean: #t
+null
+pair (length 3)
+vector[2]
+procedure: arity=2
+procedure: arity=1
+```
+
+Edge cases: the docstring in the source shows the pair/vector forms with their contents appended (e.g. `pair (length 3): (1 2 3)`), but the implementation emits only the size prefix (`pair (length 3)`, `vector[2]`) — the contents are not included. A value matching no predicate returns the symbol/string `unknown`.

--- a/docs/reference/stdlib/sdnc.md
+++ b/docs/reference/stdlib/sdnc.md
@@ -1,0 +1,78 @@
+# `core.sdnc` — self-improving DNC weight-program (bytecode-VM-as-transformer θ)
+
+**Source**: [`lib/core/sdnc.esk`](../../../lib/core/sdnc.esk)
+**Require**: `(require core.sdnc)` — **NOT** auto-loaded via `(require stdlib)`. The functions are **native codegen builtins** (heap subtype for the SDNC handle) and resolve even without the require; require it anyway for clarity. The `.esk` file only carries the `provide` list.
+
+Exposes a **trainable weight-program θ** — a genuine transformer forward pass plus its exact weight-gradient — so programs can do gradient-based self-improvement on real SDNC weights from Eshkol. The weight kernels (forward / backward-through-weights / SGD step) mirror `lib/backend/weight_matrices.c` byte-for-byte (see `lib/core/sdnc_core.h`). All vectors are Eshkol `#(...)` float vectors.
+
+## Functions
+
+### `(sdnc-program name)`
+Create a named, reproducible weight set θ. Same `name` ⇒ same initial weights. Returns an opaque SDNC handle.
+
+### `(sdnc? x)`
+Predicate: `#t` iff `x` is an SDNC handle.
+
+### `(sdnc-params θ)`
+Return the flattened trainable weight vector (a long `#(...)`; e.g. length 12,220,416 for the default program — the full transformer weight set).
+
+### `(sdnc-set-params! θ vec)`
+Write a flat weight vector back into θ (must match the `sdnc-params` length). Returns θ. Round-trips exactly with `sdnc-params`.
+
+### `(sdnc-run θ input)`
+Transformer forward pass. `input` is a `D`-dim `#(...)` vector (D=256 for the default program); returns the `D`-dim output vector. **Deterministic** — running twice on the same input gives bit-identical output.
+
+### `(sdnc-weight-grad θ input target)`
+Exact gradient `dL/dWEIGHTS` of the loss between `sdnc-run(θ, input)` and `target`. Returns a flat vector whose length **equals** `(vector-length (sdnc-params θ))` — this invariant is the key contract for plugging θ into an external optimizer.
+
+### `(sdnc-improve! θ data steps lr)`
+Run `steps` of SGD on the weights with learning rate `lr`. `data` is a single `(cons input target)` example. Mutates and returns θ; the loss on the example decreases.
+
+```scheme
+;; sdnc.esk
+(require core.sdnc)
+(define (sqnorm v)
+  (let ((n (vector-length v)))
+    (let loop ((i 0) (acc 0.0))
+      (if (< i n) (loop (+ i 1) (+ acc (* (vector-ref v i) (vector-ref v i)))) (* 0.5 acc)))))
+(define (vsub a b)
+  (let* ((n (vector-length a)) (o (make-vector n 0.0)))
+    (let loop ((i 0)) (if (< i n) (begin (vector-set! o i (- (vector-ref a i) (vector-ref b i))) (loop (+ i 1))) o))))
+
+(define th (sdnc-program "fib"))
+(display "sdnc? ")(display (sdnc? th))(newline)
+(define p0 (sdnc-params th))
+(display "params length ")(display (vector-length p0))(newline)
+
+(define input (make-vector 256 0.0))
+(vector-set! input 0 1.0)(vector-set! input 1 0.5)
+(define out (sdnc-run th input))
+(display "run length ")(display (vector-length out))(newline)
+
+;; reachable target = forward(input) nudged, so loss > 0
+(define target (let* ((n (vector-length out)) (o (make-vector n 0.0)))
+  (let loop ((i 0)) (if (< i n) (begin (vector-set! o i (vector-ref out i)) (loop (+ i 1))) o))))
+(vector-set! target 0 (+ (vector-ref target 0) 0.5))
+(define g (sdnc-weight-grad th input target))
+(display "grad length == params length ")(display (= (vector-length g) (vector-length p0)))(newline)
+
+(define (loss-now) (sqnorm (vsub (sdnc-run th input) target)))
+(define before (loss-now))
+(sdnc-improve! th (cons input target) 30 0.01)
+(display "loss ")(display before)(display " -> ")(display (loss-now))(newline)
+```
+```
+sdnc? #t
+params length 12220416
+run length 256
+grad length == params length #t
+loss 0.125 -> 0.030797
+```
+
+## Edge cases
+- `sdnc?` on a non-SDNC value returns `#f` (does not error).
+- `sdnc-run` is deterministic; `(sqnorm (vsub (sdnc-run θ x) (sdnc-run θ x)))` is exactly `0.0`.
+- `sdnc-set-params!` expects a vector of exactly `(sdnc-params θ)` length.
+
+## Verification note
+`tests/sdnc/sdnc_api_test.esk` passes 13/13 under `eshkol-run -r`: handle/predicate, params length > 1000, params round-trip, deterministic 256-dim forward, `sdnc-weight-grad` length == `sdnc-params` length, and `sdnc-improve!` loss decrease (observed 0.25 → 0.0616 in the suite's setup). This design is described in memory as *"VM-as-transformer memory-ops design"*. No `.swarm` ledger issues reference the SDNC builtins.

--- a/docs/reference/stdlib/sexp.md
+++ b/docs/reference/stdlib/sexp.md
@@ -1,0 +1,78 @@
+# `core.sexp` — S-expression rendering (display + canonical/write form)
+
+**Source**: [`lib/core/sexp.esk`](../../../lib/core/sexp.esk)
+**Require**: `(require core.sexp)` — must be required individually (not auto-loaded by `(require stdlib)`).
+
+A correct s-expression pretty-printer that handles proper lists, improper/dotted
+lists, atoms (string, symbol, number, boolean, char, null), and vectors. It exists
+because the naive user walk of an s-expression crashes with `cdr: argument is not
+a pair` the moment the structure contains a dotted pair (alists are everywhere in
+R7RS). It provides two renderings: a human `display`-style form and a `write`-style
+**canonical** form suitable for hashing / on-disk storage. Unknown objects render
+as `#<object>`.
+
+Note: `#(...)` literals in Eshkol are homogeneous double *tensors*, not
+heterogeneous vectors — build a heterogeneous vector with `(vector 1 "two" 'three)`.
+Both renderers handle either.
+
+## Functions
+
+### `(sexp->string s)`
+Display-style rendering: strings appear **without** surrounding quotes, chars
+without the `#\` prefix. Use for human-readable output. Returns a string.
+
+```scheme
+;; sexp.esk
+(require core.sexp)
+(display (sexp->string '(a b c)))            (newline)
+(display (sexp->string '(a . b)))            (newline)
+(display (sexp->string '(mood . 0.7)))       (newline)
+(display (sexp->string "hello"))             (newline)
+(display (sexp->string #\x))                 (newline)
+(display (sexp->string (vector 1 "two" 'three))) (newline)
+(display (sexp->string '()))                 (newline)
+```
+```
+(a b c)
+(a . b)
+(mood . 0.7)
+hello
+x
+#(1 two three)
+()
+```
+
+Edge cases: `'()` renders as `"()"`. A dotted pair renders `(a . b)`. Improper
+list tails render with ` . ` (e.g. `(a (b c) . d)`).
+
+### `(sexp->canonical-string s)`
+Write-style **canonical** rendering: strings are wrapped in double-quotes and chars
+prefixed with `#\`. This is the form whose bytes are hashed for content-addressing
+in `core.memory` / `core.memory_store`, so it must be stable. Returns a string.
+
+```scheme
+;; sexp.esk
+(require core.sexp)
+(display (sexp->canonical-string '(a "b" c)))         (newline)
+(display (sexp->canonical-string "hello"))            (newline)
+(display (sexp->canonical-string '(mood . "sad")))    (newline)
+(display (sexp->canonical-string (vector 1 "two" 'three))) (newline)
+(display (sexp->canonical-string #t))                 (newline)
+(display (sexp->canonical-string '(a (b c) . d)))     (newline)
+```
+```
+(a "b" c)
+"hello"
+(mood . "sad")
+#(1 "two" three)
+#t
+(a (b c) . d)
+```
+
+Edge cases:
+- **No escaping.** The canonical renderer does *not* escape embedded double-quotes
+  or newlines inside strings. Downstream durable stores (`core.memory_store`) must
+  sanitize payload strings first (see `memory-store-sanitize`) or the on-disk line
+  format breaks.
+- Booleans render `#t` / `#f`; numbers via `number->string`; symbols via
+  `symbol->string`; anything unrecognized renders `#<object>`.

--- a/docs/reference/stdlib/signal_fft.md
+++ b/docs/reference/stdlib/signal_fft.md
@@ -1,0 +1,59 @@
+# `signal.fft` — Fast Fourier Transform and inverse
+
+**Source**: [`lib/signal/fft.esk`](../../../lib/signal/fft.esk)
+**Require**: `(require signal.fft)` — also **auto-loaded** by `(require stdlib)`.
+
+Discrete Fourier transform (`fft`) and its inverse (`ifft`), radix-2 Cooley–Tukey decimation-in-time. Input is a vector of real (or complex) numbers; output is a vector of complex numbers.
+
+> **Note — these names resolve to a codegen builtin.** The `.esk` source in this module defines Scheme implementations, but `fft` and `ifft` are also compiler intrinsics (`codegenFFT` in `lib/backend/llvm_codegen.cpp`), and the builtin takes precedence. The observable behavior documented here (power-of-2 requirement, complex-vector output, tensor **and** vector inputs accepted) is that of the native builtin. `(require signal.fft)` is still the supported way to make the names available in portable source.
+
+## Functions
+
+### `(fft x)`
+Forward DFT of vector `x`. Length must be a power of 2. Real inputs are treated as complex with zero imaginary part; output is always a complex vector.
+
+```scheme
+(require signal.fft)
+(display (fft #(1.0 2.0 3.0 4.0))) (newline)
+```
+```
+#(10 -2+2i -2 -2-2i)
+```
+
+Edge cases: a non-power-of-2 length aborts the program with a printed error (from the native builtin) rather than raising a catchable condition:
+
+```scheme
+(display (fft #(1.0 2.0 3.0))) (newline)
+```
+```
+Error: FFT requires input length to be a power of 2
+```
+
+### `(ifft x)`
+Inverse DFT. Length must be a power of 2. Returns a complex vector; `ifft ∘ fft` recovers the input (up to ~1e-17 floating-point round-off in the imaginary parts).
+
+```scheme
+(display (ifft (fft #(1.0 2.0 3.0 4.0)))) (newline)
+```
+```
+#(1 2+5.72119e-18i 3 4-5.72119e-18i)
+```
+
+Edge cases: same power-of-2 requirement as `fft`.
+
+## Known issues
+
+### Chaining `fft` → `ifft` inside one compiled function returns garbage
+
+At the REPL top level, `fft` and `ifft` each work and round-trip correctly. But when the result of `fft` is fed into `ifft` **within the body of a user- or library-defined function**, the round-trip is corrupted — the first element becomes a huge number (~5e9) and the rest collapse to a constant. `fft` alone inside a function is fine; it is the `fft`→`ifft` chain that breaks.
+
+```scheme
+;; repro.esk
+(require signal.fft)
+(define (roundtrip a) (ifft (fft a)))
+(display (roundtrip #(1.0 2.0 3.0 4.0))) (newline)
+```
+```
+#(4.96616e+09 -8-8i -8 -8+8i)      ;; expected ~ #(1 2 3 4)
+```
+This is the direct cause of the `fast-convolve` corruption documented in [`signal.filters`](signal_filters.md#known-issues). Workaround: keep `fft` and `ifft` in separate top-level steps, or use direct-time-domain `convolve`.

--- a/docs/reference/stdlib/signal_filters.md
+++ b/docs/reference/stdlib/signal_filters.md
@@ -1,0 +1,173 @@
+# `signal.filters` — windows, convolution, FIR/IIR filters, Butterworth design
+
+**Source**: [`lib/signal/filters.esk`](../../../lib/signal/filters.esk)
+**Require**: `(require signal.filters)` — also **auto-loaded** by `(require stdlib)`. Internally requires `signal.fft`.
+
+Digital-signal-processing primitives: window functions (Hamming, Hann, Blackman, Kaiser), windowing, direct and FFT-based convolution, FIR and IIR filtering, Butterworth low/high/band-pass design, and frequency response. All signals are real-valued vectors written `#(...)`; filter coefficient sets are returned as `(b-coeffs . a-coeffs)` pairs.
+
+## Window functions
+
+### `(hamming-window N)`
+Length-`N` Hamming window, `w[n] = 0.54 − 0.46·cos(2πn/(N−1))`.
+
+```scheme
+(require signal.filters)
+(display (hamming-window 5)) (newline)
+```
+```
+#(0.08 0.54 1 0.54 0.08)
+```
+
+### `(hann-window N)`
+Length-`N` Hann (Hanning) window, `w[n] = 0.5·(1 − cos(2πn/(N−1)))`.
+
+```scheme
+(display (hann-window 5)) (newline)
+```
+```
+#(0 0.5 1 0.5 0)
+```
+
+### `(blackman-window N)`
+Length-`N` Blackman window, `w[n] = 0.42 − 0.5·cos(2πn/(N−1)) + 0.08·cos(4πn/(N−1))`.
+
+```scheme
+(display (blackman-window 5)) (newline)
+```
+```
+#(-1.38778e-17 0.34 1 0.34 -1.38778e-17)
+```
+
+### `(kaiser-window N beta)`
+Length-`N` Kaiser window with shape parameter `beta`; uses an internal 25-term series for the modified Bessel function `I₀`.
+
+```scheme
+(display (kaiser-window 5 4.0)) (newline)
+```
+```
+#(0.0884805 0.633432 1 0.633432 0.0884805)
+```
+
+### `(apply-window signal window)`
+Element-wise product of `signal` and `window` (they should be the same length; the loop runs to `(vector-length signal)`).
+
+```scheme
+(display (apply-window #(1.0 1.0 1.0 1.0 1.0) (hamming-window 5))) (newline)
+```
+```
+#(0.08 0.54 1 0.54 0.08)
+```
+
+## Convolution
+
+### `(convolve a b)`
+Direct time-domain convolution. Output length `len(a) + len(b) − 1`.
+
+```scheme
+(display (convolve #(1.0 2.0 3.0) #(1.0 1.0))) (newline)
+```
+```
+#(1 3 5 3)
+```
+
+### `(fast-convolve a b)`
+FFT-based convolution, intended to be O(N log N) (zero-pads both signals to the next power of 2, multiplies spectra, inverse-transforms, takes real parts). **Currently broken — returns garbage.** See [Known issues](#known-issues); use `convolve` instead.
+
+```scheme
+(display (fast-convolve #(1.0 2.0 3.0) #(1.0 1.0))) (newline)
+```
+```
+#(5.23552e+09 -8 -8 -8)      ;; expected #(1 3 5 3)
+```
+
+## FIR / IIR filters
+
+### `(fir-filter coeffs signal)`
+FIR filter: `y[n] = Σ_k coeffs[k]·signal[n−k]`. Output length equals `signal`.
+
+```scheme
+(display (fir-filter #(0.5 0.5) #(1.0 2.0 3.0 4.0))) (newline)
+```
+```
+#(0.5 1.5 2.5 3.5)
+```
+
+### `(iir-filter b-coeffs a-coeffs signal)`
+IIR filter, Direct Form I: `y[n] = (1/a[0])·(Σ_k b[k]·x[n−k] − Σ_{k≥1} a[k]·y[n−k])`.
+
+```scheme
+;; one-pole lowpass y[n] = x[n] + 0.5 y[n-1]
+(display (iir-filter #(1.0) #(1.0 -0.5) #(1.0 0.0 0.0 0.0))) (newline)
+```
+```
+#(1 0.5 0.25 0.125)
+```
+
+## Butterworth design
+
+Each design routine returns coefficients as a `(b-coeffs . a-coeffs)` cons pair (bandpass returns a two-element list of such pairs to be cascaded). Cutoffs are normalized: `1.0` = Nyquist.
+
+### `(butterworth-lowpass order cutoff)`
+Design an `order`-th Butterworth lowpass (bilinear transform of the analog prototype, DC-gain normalized). Returns `(b . a)`.
+
+```scheme
+(display (butterworth-lowpass 2 0.5)) (newline)
+```
+```
+(#(0.292893 0.585786 0.292893) . #(1 -1.38778e-16 0.171573))
+```
+
+### `(butterworth-highpass order cutoff)`
+Highpass via the lowpass-to-highpass spectral inversion (`z → −z` on the numerator). Returns `(b . a)`.
+
+```scheme
+(display (butterworth-highpass 2 0.5)) (newline)
+```
+```
+(#(0.292893 -0.585786 0.292893) . #(1 -1.38778e-16 0.171573))
+```
+
+### `(butterworth-bandpass order low-cutoff high-cutoff)`
+Bandpass as a lowpass+highpass cascade. Returns a **list of two** `(b . a)` pairs `(list lp hp)`; apply them in sequence to a signal.
+
+```scheme
+(display (butterworth-bandpass 2 0.2 0.6)) (newline)
+```
+```
+((#(0.391336 0.782672 0.391336) . #(1 0.369527 0.195816)) (#(0.638946 -1.27789 0.638946) . #(1 1.14298 0.412802)))
+```
+
+## Frequency response
+
+### `(frequency-response b-coeffs a-coeffs n-points)`
+Evaluate `H(e^{jω}) = B/A` at `n-points` frequencies from 0 to π. Returns `(magnitudes . phases)` as a cons of two vectors.
+
+```scheme
+(define lp (butterworth-lowpass 2 0.5))
+(display (frequency-response (car lp) (cdr lp) 4)) (newline)
+```
+```
+(#(1 0.948683 0.316228 0) . #(0 -0.886077 -2.25552 0))
+```
+
+## Internal helpers (not in `provide`)
+
+`window-ratio`, `bessel-i0`, `next-power-of-2`, `zero-pad-vector`, `complex-vector-real`, `butterworth-poles`, `bilinear-transform`, `poly-from-roots`, `real-part-vector` are defined in the module for use by the exported functions but are not part of the `provide` list.
+
+## Known issues
+
+### `fast-convolve` returns garbage
+
+`fast-convolve` produces completely wrong output — the first element is a huge number (~5e9) and the remaining elements collapse to a negative constant — whereas the direct `convolve` is correct.
+
+```scheme
+;; repro.esk
+(require signal.filters)
+(display (convolve      #(1.0 2.0 3.0 4.0 5.0) #(1.0 1.0 1.0))) (newline)
+(display (fast-convolve #(1.0 2.0 3.0 4.0 5.0) #(1.0 1.0 1.0))) (newline)
+```
+```
+#(1 3 6 9 12 9 5)                     ;; convolve — correct
+#(6.1741e+09 -8 -8 -8 -8 -8 -8)       ;; fast-convolve — garbage
+```
+Root cause: `fast-convolve` computes `(ifft (fft …))` inside its (compiled) body, which triggers the `fft`→`ifft` chaining corruption documented in [`signal.fft`](signal_fft.md#known-issues). Workaround: use `convolve`.

--- a/docs/reference/stdlib/stdlib_extras.md
+++ b/docs/reference/stdlib/stdlib_extras.md
@@ -1,0 +1,101 @@
+# `stdlib` extras — random tensors, timing, keyword-arg support
+
+**Source**: [`lib/stdlib.esk`](../../../lib/stdlib.esk)
+**Require**: `(require stdlib)` — these are defined **directly in `lib/stdlib.esk`** (not a separate module), so they are always available whenever `stdlib` is loaded.
+
+Beyond re-exporting the core modules, `lib/stdlib.esk` defines a handful of top-level helpers: random tensor constructors, high-precision timing utilities, and the internal keyword-argument support functions the parser lowers `#:key` calls onto.
+
+## Random tensors
+
+### `(random-tensor dims)`
+Uniform-random tensor with shape `dims` (a **list** of dimension sizes). Wraps `(apply rand dims)`.
+
+```scheme
+(require stdlib)
+(display (vector-length (random-tensor (list 3)))) (newline)   ;; illustrative: values are random
+```
+```
+3
+```
+
+### `(random-normal-tensor dims)`
+Standard-normal random tensor with shape `dims` (a list). Wraps `(apply randn dims)`. A `(list 2 2)` shape yields a 4-element (flattened) tensor.
+
+```scheme
+(display (vector-length (random-normal-tensor (list 2 2)))) (newline)   ;; illustrative
+```
+```
+4
+```
+
+> `dims` must be a **list** (it is `apply`d as the argument list to `rand`/`randn`), e.g. `(list 3)` or `(list 2 2)` — not a bare number.
+
+## Timing utilities
+
+All derive from the built-in `current-time-ns`. Outputs below are illustrative (wall-clock, nondeterministic); the examples display booleans so they are reproducible.
+
+### `(current-time-us)`
+Current Unix time in microseconds, `(/ (current-time-ns) 1000.0)`.
+
+```scheme
+(display (> (current-time-us) 0.0)) (newline)
+```
+```
+#t
+```
+
+### `(time-ns thunk)`
+Run `thunk` once, return elapsed nanoseconds.
+
+```scheme
+(display (> (time-ns (lambda () (+ 1 2))) 0)) (newline)
+```
+```
+#t
+```
+
+### `(time-us thunk)`
+Run `thunk` once, return elapsed microseconds (`time-ns / 1000`).
+
+```scheme
+(display (>= (time-us (lambda () (+ 1 2))) 0.0)) (newline)
+```
+```
+#t
+```
+
+### `(time-it thunk iterations)`
+Run `thunk` `iterations` times, return the **average** time per call in nanoseconds.
+
+```scheme
+(display (>= (time-it (lambda () (+ 1 2)) 100) 0.0)) (newline)
+```
+```
+#t
+```
+
+## Keyword-argument support (internal)
+
+`__keyword-member?`, `__keyword-args-validate`, and `__keyword-arg` are **internal parser-support functions** — you do not call them directly. When you write a call with keyword arguments, the parser lowers the keyword formals through these helpers at function/lambda entry. A user call like `(f #:scale 2)` reaches the callee as a variadic tail `(#:scale 2)`, and `__keyword-arg` looks up the value by key (with `__keyword-args-validate` / `__keyword-member?` checking the keyword is expected and has a value).
+
+The user-facing feature is ordinary keyword arguments:
+
+```scheme
+;; example.esk
+(define (scale-it x #:scale s)
+  (* x s))
+(display (scale-it 10 #:scale 3)) (newline)
+```
+```
+30
+```
+
+Signatures of the internal helpers, for reference:
+
+- `(__keyword-member? key keys)` → `#t`/`#f` — is `key` in the list `keys`.
+- `(__keyword-args-validate args keys)` → `#t` or raises — every keyword in the `(key val …)` tail `args` must be in `keys` and have a following value.
+- `(__keyword-arg args key)` → the value paired with `key` in `args`, or raises if missing.
+
+## Auto-load note
+
+`lib/stdlib.esk` re-exports the core modules plus `signal.fft`, `signal.filters`, `core.manifold`, and `ml.optimization`. It does **not** require `math`, `ml.activations`, or `core.testing` — those must be required individually (see their respective pages).

--- a/docs/reference/stdlib/streams.md
+++ b/docs/reference/stdlib/streams.md
@@ -1,0 +1,171 @@
+# `core.streams` — SRFI 41 lazy streams
+
+**Source**: [`lib/core/streams.esk`](../../../lib/core/streams.esk)
+**Require**: `(require core.streams)` — auto-loaded by `(require stdlib)`.
+Internally depends on `core.list.transform`.
+
+Lazy (possibly infinite) streams built on Eshkol's memoised `delay`/`force`
+promises. A stream is either `stream-null` (the empty list) or a pair
+`(head . tail-promise)`. Each tail is forced at most once, so repeated traversal
+does not recompute.
+
+**Important — no `stream-cons` macro.** Eshkol has no `define-syntax`, so SRFI 41's
+implicit-delay macro form is unavailable. **The caller must wrap the tail in
+`(delay …)` explicitly:**
+
+```scheme
+(define ones (stream-cons 1 (delay ones)))
+(define (from n) (stream-cons n (delay (from (+ n 1)))))
+```
+
+The recursive reference is captured as a closure by `delay`'s lambda expansion,
+so cyclic definitions like `ones` work.
+
+## Constants
+
+### `stream-null`
+The empty stream. Value: `'()`.
+
+## Predicates
+
+### `(stream-null? s)` — `#t` iff `s` is the empty stream.
+### `(stream-pair? s)` — `#t` iff `s` is a non-empty stream (a pair).
+### `(stream? s)` — `#t` iff `s` is `'()` or a pair.
+
+## Construction / access
+
+### `(stream-cons head tail-promise)`
+Builds a stream cell. `tail-promise` must already be a `(delay …)` (see above).
+
+### `(stream-car s)` — the head element.
+### `(stream-cdr s)` — forces and returns the tail stream.
+
+## Indexing / slicing
+
+### `(stream-take s n)`
+Returns a **list** (not a stream) of the first `n` elements; terminates early on
+`stream-null`.
+
+### `(stream-drop s n)`
+Returns the stream with the first `n` elements dropped (a stream).
+
+### `(stream-ref s n)`
+Returns the `n`th element (0-indexed).
+
+```scheme
+;; basics.esk
+(require core.streams)
+(define ones (stream-cons 1 (delay ones)))
+(define (from n) (stream-cons n (delay (from (+ n 1)))))
+(display (stream-take ones 5)) (newline)
+(display (stream-take (from 10) 4)) (newline)
+(display (stream-car (from 7))) (newline)
+(display (stream-ref (stream-from 0) 5)) (newline)
+(display (stream-take (stream-drop (stream-from 0) 10) 3)) (newline)
+```
+```
+(1 1 1 1 1)
+(10 11 12 13)
+7
+5
+(10 11 12)
+```
+
+## Higher-order
+
+### `(stream-map f s)`
+Lazy map: returns a new stream of `(f x)` for each element.
+
+### `(stream-filter pred s)`
+Lazy filter: returns a new stream of the elements satisfying `pred`.
+
+### `(stream-for-each f s)`
+Strict: applies `f` to each element for effect, walking until `stream-null`.
+Returns `'()`.
+
+### `(stream-zip s1 s2)`
+Lazy: stream of two-element lists `(a b)`; terminates when **either** input is
+exhausted.
+
+### `(stream-append s1 s2)`
+Lazy: the elements of `s1` followed by `s2`.
+
+```scheme
+;; higher.esk
+(require core.streams)
+(display (stream-take (stream-map (lambda (x) (* x x)) (stream-from 1)) 5)) (newline)
+(display (stream-take (stream-filter even? (stream-from 1)) 5)) (newline)
+(display (stream-take (stream-zip (stream-from 0) (stream-from 100)) 3)) (newline)
+(display (stream-take (stream-append (list->stream '(1 2)) (list->stream '(3 4))) 4)) (newline)
+(stream-for-each (lambda (x) (display x) (display " ")) (list->stream '(a b c))) (newline)
+```
+```
+(1 4 9 16 25)
+(2 4 6 8 10)
+((0 100) (1 101) (2 102))
+(1 2 3 4)
+a b c 
+```
+
+## Generators
+
+### `(stream-iterate f x)`
+Infinite stream `x, (f x), (f (f x)), …`.
+
+### `(stream-from n)`
+Infinite stream `n, n+1, n+2, …`.
+
+### `(stream-take-while pred s)`
+Returns a **stream** of the leading elements satisfying `pred`.
+
+### `(stream-drop-while pred s)`
+Returns the stream after dropping the leading elements satisfying `pred`.
+
+```scheme
+;; gen.esk
+(require core.streams)
+(display (stream-take (stream-iterate (lambda (x) (* x 2)) 1) 6)) (newline)
+(display (stream->list (stream-take-while (lambda (x) (< x 5)) (stream-from 0)))) (newline)
+(display (stream-take (stream-drop-while (lambda (x) (< x 5)) (stream-from 0)) 3)) (newline)
+```
+```
+(1 2 4 8 16 32)
+(0 1 2 3 4)
+(5 6 7)
+```
+
+Note: `stream-take-while` returns a **stream**, so displaying it directly shows a
+promise tail — `(display (stream-take-while … ))` prints `(0 . #<promise>)`. Wrap
+it in `stream->list` (or `stream-take`) to realise the elements, as shown above.
+
+## Conversions
+
+### `(stream-length s)`
+Number of elements. **Only terminates on finite streams** — calling it on an
+infinite stream loops forever by design.
+
+### `(stream->list s)`
+Realises a finite stream into a list. Same caveat: infinite streams loop forever.
+
+### `(list->stream lst)`
+Converts a list into a (finite) stream.
+
+```scheme
+;; conv.esk
+(require core.streams)
+(display (stream->list (list->stream '(1 2 3)))) (newline)
+(display (stream-length (list->stream '(a b c d)))) (newline)
+```
+```
+(1 2 3)
+4
+```
+
+Edge cases (verified): `(stream-take stream-null 3)` → `'()`;
+`(stream-drop '() 3)` → `'()`; `(stream-null? stream-null)` → `#t`.
+
+Depth note: `stream->list` and `stream-length` are non-tail-recursive
+(`stream->list`) / tail-recursive (`stream-length`); realising a very long finite
+stream via `stream->list` is subject to the same stdlib depth ceiling as
+`length`/`filter` (see [`list_query.md`](list_query.md)). Prefer bounded
+`stream-take`/`stream-ref` when the stream is large or infinite.

--- a/docs/reference/stdlib/strings.md
+++ b/docs/reference/stdlib/strings.md
@@ -1,0 +1,268 @@
+# `core.strings` — extended string utilities
+
+**Source**: [`lib/core/strings.esk`](../../../lib/core/strings.esk)
+**Require**: `(require core.strings)` — auto-loaded via `(require stdlib)`.
+
+Pure-Scheme helpers for joining, trimming, replacing, searching, casing and
+splitting strings. Everything here is built on the codegen builtins
+`substring`, `string-length`, `string-ref`, `string=?` and `string-split`.
+
+> **Builtin vs. stdlib shadowing (important).** Several names in this module —
+> `string-index`, `string-contains?`, `string-upcase`, `string-downcase`,
+> `string-split` — are *also* codegen builtins (see
+> `lib/backend/llvm_codegen.cpp`). When you call one of those names **directly
+> from user code**, the builtin wins and the stdlib definition below is not
+> used. The two implementations agree on ASCII text but **diverge on embedded
+> NUL bytes** — see [Known issues](#known-issues).
+
+All examples were run with `build/eshkol-run <file> -r`.
+
+## Functions
+
+### `(string-join lst delim)`
+Concatenate the strings in `lst`, inserting `delim` between elements. Empty
+list gives `""`; single element gives that element with no delimiter.
+
+```scheme
+(require core.strings)
+(display (string-join '("a" "b" "c") ",")) (newline)
+(display (string-join '() ",")) (newline)
+(display (string-join '("only") ",")) (newline)
+```
+```
+a,b,c
+
+only
+```
+
+### `(string-trim str)` / `(string-trim-left str)` / `(string-trim-right str)`
+Remove ASCII whitespace (space, tab, `\n`, `\r`) from both ends / the left /
+the right. An all-whitespace string trims to `""`.
+
+```scheme
+(display (string-trim "   hi there  ")) (newline)
+(display (string-trim-left "  hi")) (newline)
+(display (string-trim-right "hi  ")) (newline)
+```
+```
+hi there
+hi
+hi
+```
+
+### `(string-replace str old new)`
+Replace every occurrence of substring `old` with `new`. Implemented as
+`(string-join (string-split str old) new)`.
+
+```scheme
+(display (string-replace "hello world" "o" "0")) (newline)
+(display (string-replace "aaa" "a" "bb")) (newline)
+```
+```
+hell0 w0rld
+bbbbbb
+```
+
+### `(string-reverse str)`
+Reverse the characters of `str`.
+
+```scheme
+(display (string-reverse "abc")) (newline)
+```
+```
+cba
+```
+
+### `(string-copy str)` — **BROKEN for the 1-argument form** (see [Known issues](#known-issues))
+Intended: return a fresh copy of `str`. In practice the name resolves to a
+codegen builtin that mis-handles the single-argument call and returns `()`.
+
+```scheme
+(display (string-copy "hello")) (newline)
+```
+```
+()
+```
+The R7RS three-argument form `(string-copy str start end)` does work (it is a
+`substring` alias) but emits a spurious type warning.
+
+### `(string-repeat str n)`
+Concatenate `n` copies of `str`. `n <= 0` gives `""`.
+
+```scheme
+(display (string-repeat "ab" 3)) (newline)
+(display (string-repeat "x" 0)) (newline)
+```
+```
+ababab
+
+```
+
+### `(string-starts-with? str prefix)` / `(string-ends-with? str suffix)`
+Predicate: does `str` begin / end with `prefix` / `suffix`? The prefix/suffix
+argument may be a string **or a single char** (converted via `string`).
+
+```scheme
+(display (string-starts-with? "hello" "he")) (newline)
+(display (string-ends-with?   "hello" "lo")) (newline)
+(display (string-starts-with? "hello" #\h)) (newline)
+```
+```
+#t
+#t
+#t
+```
+
+### `(string-starts-with str prefix)` / `(string-ends-with str suffix)`
+Non-`?` aliases kept for backwards compatibility; behaviour is identical to the
+`?` predicates above.
+
+### `(string-index str substr)`
+Index of the first occurrence of `substr` in `str`, or `-1` if absent. `substr`
+may be a char. **NUL-truncating when called directly** (see Known issues).
+
+```scheme
+(display (string-index "hello" "ll")) (newline)
+(display (string-index "hello" "z"))  (newline)
+```
+```
+2
+-1
+```
+Edge cases: empty needle returns `0`; empty haystack with a non-empty needle
+returns `-1`; needle longer than haystack returns `-1`.
+
+### `(string-last-index str substr)`
+Index of the **last** occurrence of `substr`, or `-1`.
+
+```scheme
+(display (string-last-index "abcabc" "bc")) (newline)
+```
+```
+4
+```
+
+### `(string-contains str substr)` / `(string-contains? str substr)`
+Boolean "does `str` contain `substr`?". `string-contains` is the stdlib
+function `(>= (string-index …) 0)`; `string-contains?` is a **codegen builtin**.
+On ASCII they agree; on embedded NUL they diverge (Known issues).
+
+```scheme
+(display (string-contains  "hello" "ell")) (newline)
+(display (string-contains? "hello" "z"))   (newline)
+```
+```
+#t
+#f
+```
+Edge cases: empty needle returns `#t`.
+
+### `(string-count str substr)`
+Count non-overlapping occurrences of `substr` in `str`. Empty needle returns
+`0`. This is a pure-Scheme stdlib function (no builtin), so it is **NUL-safe**.
+
+```scheme
+(display (string-count "aaaa" "aa")) (newline)
+(display (string-count "abcabc" "bc")) (newline)
+```
+```
+2
+2
+```
+
+### `(string-find haystack needle)`
+Like `string-index` but returns `#f` (not `-1`) when the needle is absent —
+composes cleanly with `(if (string-find …) …)`. Calls the stdlib
+`string-index`, so it is NUL-safe.
+
+```scheme
+(display (string-find "hello" "ll")) (newline)
+(display (string-find "hello" "z"))  (newline)
+```
+```
+2
+#f
+```
+
+### `(string-upcase str)` / `(string-downcase str)`
+ASCII case conversion (`a`–`z` ⇄ `A`–`Z`); non-letters pass through. These names
+are codegen builtins.
+
+```scheme
+(display (string-upcase   "Hello World 123")) (newline)
+(display (string-downcase "Hello World 123")) (newline)
+```
+```
+HELLO WORLD 123
+hello world 123
+```
+
+### `(string-split-ordered str delim)`
+Backwards-compatible alias for the builtin `(string-split str delim)`, which now
+returns fields in left-to-right order. `delim` is a char.
+
+```scheme
+(display (string-split-ordered "a,b,c" #\,)) (newline)
+```
+```
+(a b c)
+```
+
+### `string-needle` (internal helper)
+`(string-needle x)` returns `(string x)` if `x` is a char, else `x`. Used by the
+search functions so a char needle is accepted. Not intended for direct use.
+
+## Known issues
+
+### `string-copy` (1-arg) returns `()` and warns
+`(string-copy s)` resolves to a codegen builtin
+(`lib/backend/llvm_codegen.cpp:13536`) that delegates a single-argument call to
+`substring`, which requires exactly three arguments. The result is `()` plus a
+spurious `WARNING: substring requires exactly 3 arguments`.
+
+```scheme
+(require core.strings)
+(display (string-copy "hello")) (newline)
+;; => ()   (with "substring requires exactly 3 arguments" on stderr)
+```
+Workaround: use `(substring s 0 (string-length s))` directly, which works.
+
+### Embedded NUL: builtin search truncates, stdlib search does not
+The builtins `string-index` and `string-contains?` use C `strstr`-style search
+that stops at the first NUL byte, so they cannot find anything past a NUL. The
+pure-Scheme stdlib functions `string-find`, `string-contains`, and
+`string-count` use `substring`/`string=?` (which honour the string header
+length) and are NUL-safe. `string-length` and `substring` themselves preserve
+NUL bytes. This produces an observable disagreement on the same input:
+
+```scheme
+(require core.strings)
+(define s (list->string (list #\a (integer->char 0) #\b)))  ; "a\0b", length 3
+(display (string-index s "b"))     (newline)  ; -1  (builtin, NUL-truncated)
+(display (string-contains? s "b")) (newline)  ; #f  (builtin, NUL-truncated)
+(display (string-find s "b"))      (newline)  ; 2   (stdlib, NUL-safe)
+(display (string-contains s "b"))  (newline)  ; #t  (stdlib, NUL-safe)
+(display (string-count s "b"))     (newline)  ; 1   (stdlib, NUL-safe)
+```
+```
+-1
+#f
+2
+#t
+1
+```
+See also **ESH-0099** (open): string *literals* that contain a `\x0;` NUL escape
+and exceed 512 source bytes decode to the wrong length/content — a separate
+literal-intern bug in the corruption family, distinct from the search-truncation
+above.
+
+### Char needle to the builtin `string-index` SIGSEGVs
+Passing a char (rather than a string) needle directly to the builtin
+`string-index` crashes. The stdlib functions (`string-count`, `string-find`,
+the `*-with?` predicates) handle a char needle correctly via `string-needle`.
+
+```scheme
+(require core.strings)
+(display (string-index "hello" #\l)) (newline)   ; SIGSEGV
+```
+Workaround: pass a one-character string, e.g. `(string-index "hello" "l")`.

--- a/docs/reference/stdlib/testing.md
+++ b/docs/reference/stdlib/testing.md
@@ -1,0 +1,94 @@
+# `core.testing` — minimal test framework
+
+**Source**: [`lib/core/testing.esk`](../../../lib/core/testing.esk)
+**Require**: `(require core.testing)` — **must be required individually**. It is **NOT** auto-loaded by `(require stdlib)`.
+
+A function-based (not macro-based) test framework: register named tests whose bodies call `check-*` assertions, then `(run-tests)` executes them in source order, prints a per-test and summary report, and returns `#t`/`#f`.
+
+## Why it isn't part of `stdlib`
+
+Baking `core.testing` into the precompiled `stdlib.o` triggers the symbol-renamer / external-declaration path that currently mis-handles a precompiled module's mutable internal state, producing a **duplicate `_*tests*`** symbol in the user's object file. To avoid that, `lib/stdlib.esk` deliberately omits it (see the comment block there) and users must `(require core.testing)` explicitly.
+
+The API is procedures, not macros, on purpose: Eshkol's `define-syntax` does not propagate macro definitions across the precompiled-stdlib boundary (the parser has already expanded `testing.esk` before user code is read), so a macro-based `(define-test …)` would not expand in user source. Wrap check forms in your own `(lambda () …)` thunk to register a test.
+
+## Functions
+
+### `(register-test name thunk)`
+Append a test: `name` is a string, `thunk` is a zero-argument procedure whose body runs the `check-*` assertions. Tests are stored newest-first and replayed in source order by `run-tests`.
+
+### `(check-equal? actual expected)`
+Structural equality (dispatches on string/number/boolean/char/symbol/null, falling back to `equal?`). On mismatch prints `FAIL: expected …, got …` and increments the fail counters.
+
+### `(check-true v)` / `(check-false v)`
+Assert `v` is truthy / false respectively.
+
+### `(check-approx actual expected tol)`
+Float equality within `tol`: passes when `|actual − expected| < tol`.
+
+### `(check-raises thunk)`
+Assert that calling `thunk` raises (via `guard`). If the thunk returns normally, that is a failure.
+
+### `(run-tests)`
+Run every registered test in source order, printing `[test] <name> … OK` / `… FAIL (n check(s))` per test and a final summary. Resets the pass/fail counters at the start. Returns `#t` if all passed, `#f` otherwise.
+
+### `(reset-tests!)`
+Clear the registry and all counters, and reset the runtime logic/predicate registry (safe even when the consciousness engine isn't loaded).
+
+Full run:
+
+```scheme
+;; example.esk
+(require core.testing)
+(register-test "addition"
+  (lambda () (check-equal? (+ 2 2) 4) (check-true (> 5 3))))
+(register-test "approx"
+  (lambda () (check-approx 3.14159 3.14 0.01)))
+(register-test "raises"
+  (lambda () (check-raises (lambda () (error "boom")))))
+(register-test "failing"
+  (lambda () (check-equal? 1 2) (check-false #t)))
+(run-tests)
+```
+```
+  [test] addition … OK
+  [test] approx … OK
+  [test] raises … OK
+  [test] failing    FAIL: expected 2, got 1
+    FAIL: expected false, got #t
+ … FAIL (2 check(s))
+
+=== Test summary ===
+  Passed: 4
+  Failed: 2
+  RESULT: FAILURES
+```
+
+## Exported state variables
+
+These are `provide`d so tooling can inspect results after `(run-tests)`:
+
+- `*tests*` — the registry, a list of `(name thunk)` pairs (stored newest-first).
+- `*test-pass-count*` — number of `check-*` assertions that passed in the last run.
+- `*test-fail-count*` — number that failed (plus one per test whose thunk raised).
+- `*current-test-fails*` — failing checks in the currently running test (reset per test).
+- `*current-test-name*` — name of the currently running test.
+
+```scheme
+(require core.testing)
+(register-test "t" (lambda () (check-equal? (+ 1 1) 2)))
+(run-tests)
+(display "pass=") (display *test-pass-count*) (newline)
+```
+```
+  [test] t … OK
+
+=== Test summary ===
+  Passed: 1
+  Failed: 0
+  RESULT: OK
+pass=1
+```
+
+## Internal helpers (not in `provide`)
+
+`record-check!` and `testing-equal?` are used by the `check-*` procedures and are not exported.

--- a/docs/reference/stdlib/threads.md
+++ b/docs/reference/stdlib/threads.md
@@ -1,0 +1,94 @@
+# `core.threads` — mutexes, condition variables, and thread handles
+
+**Source**: [`lib/core/threads.esk`](../../../lib/core/threads.esk)
+**Require**: `(require core.threads)` — **NOT** auto-loaded via `stdlib`; require it explicitly.
+
+Thread-coordination primitives in three families: **recursive POSIX mutexes** (`pthread_mutex_t`), **condition variables** (`pthread_cond_t`), and **thread handles** built on top of `(future thunk)` so a thunk runs concurrently on a thread-pool worker while `thread-join` blocks for its result. Mutex/condvar objects are opaque C pointers; a thread handle is a length-2 vector `#('eshkol-thread <future>)`.
+
+> Concurrency note: the closure-capture correctness that makes `make-thread` safe (a `set!`-mutated variable shared across the spawner and worker) was the subject of **ESH-0074** ("set!-mutated variable captured by MULTIPLE closures is not shared", status: done — general assignment-conversion fix following PR #50). Keep worker thunks self-contained and prefer returning values over mutating shared captures.
+
+## Functions
+
+### `(make-mutex)`
+Create a recursive POSIX mutex. Returns an opaque pointer. Recursive means re-locking from the *same* thread does not deadlock (SRFI-18 semantics). You own the lifetime — call `mutex-destroy!` or rely on process exit.
+
+### `(mutex-lock! m)`
+Block until the mutex is acquired. Returns `0` on success or an errno on failure.
+
+### `(mutex-trylock! m)`
+Non-blocking lock attempt. Returns `0` if acquired, `EBUSY` (16 on macOS/Linux) if held by another thread. Because the mutex is recursive, a re-lock from the same thread succeeds with `0`.
+
+### `(mutex-unlock! m)`
+Release the mutex. Returns `0` on success.
+
+### `(mutex-destroy! m)`
+Destroy and free the mutex. Do not use `m` afterward.
+
+### `(with-mutex m thunk)`
+Acquire `m`, invoke `(thunk)`, release `m` before returning — even if `thunk` raises (the error is re-raised after unlock). Returns the thunk's value.
+
+```scheme
+;; threads.esk
+(require core.threads)
+(define m (make-mutex))
+(display (mutex-lock! m)) (newline)
+(display (mutex-trylock! m)) (newline)   ; recursive re-lock, same thread
+(display (mutex-unlock! m)) (newline)
+(display (mutex-unlock! m)) (newline)
+(display (with-mutex m (lambda () (+ 1 2)))) (newline)
+(mutex-destroy! m)
+```
+```
+0
+0
+0
+0
+3
+```
+
+### `(make-condvar)`
+Create a POSIX condition variable. Returns an opaque pointer.
+
+### `(condvar-wait! c m)`
+Atomically release mutex `m`, block until `c` is signalled, reacquire `m` before returning. `m` MUST be held by this thread on entry. (Used internally by `core.channels`; a bare producer/consumer example would block, so none is shown here.)
+
+### `(condvar-signal! c)`
+Wake one thread waiting on `c`.
+
+### `(condvar-broadcast! c)`
+Wake all threads waiting on `c`.
+
+### `(condvar-destroy! c)`
+Destroy and free the condition variable.
+
+### `(make-thread thunk)`
+Spawn `thunk` on a thread-pool worker; returns a thread handle. The thunk runs concurrently with the spawner. Pass the *thunk itself* (a 0-arg callable) — do not call it.
+
+### `(thread? h)`
+Predicate: is `h` a handle from `make-thread`? (A length-2 vector tagged `'eshkol-thread`.)
+
+### `(thread-result-ready? h)`
+Non-blocking check: has the worker finished? Returns `#f` for non-thread values.
+
+### `(thread-join h)`
+Block until the thunk completes; return its result. Memoised (a second join returns the cached result). Joining a non-thread returns the value unchanged (per R7RS `force`).
+
+```scheme
+;; threads.esk
+(require core.threads)
+(define t (make-thread (lambda () (* 6 7))))
+(display (thread? t)) (newline)
+(display (thread? 5)) (newline)
+(display (thread-join t)) (newline)
+(display (thread-result-ready? t)) (newline)
+(display (thread-join 99)) (newline)     ; non-thread -> returned as-is
+```
+```
+#t
+#f
+42
+#t
+99
+```
+
+Edge cases: `mutex-lock!`/`unlock!` return errno-style integers, not booleans. `thread-result-ready?` and `thread-join` on non-thread values are total (no error). Do not `condvar-wait!` without holding the paired mutex.

--- a/docs/reference/stdlib/url.md
+++ b/docs/reference/stdlib/url.md
@@ -1,0 +1,86 @@
+# `core.url` — URL percent-encoding and base64url
+
+**Source**: [`lib/core/url.esk`](../../../lib/core/url.esk)
+**Require**: `(require core.url)` — auto-loaded via `(require stdlib)`.
+
+RFC 3986 percent-encoding for URL components, plus URL-safe Base64 (RFC 4648 §5).
+Non-ASCII codepoints are encoded as their UTF-8 byte sequence. The `base64url-*`
+functions build on [`core.data.base64`](data_base64.md); this module is also
+summarised in [`docs/STDLIB_V1_2_API.md`](../../STDLIB_V1_2_API.md). No bugs were
+observed.
+
+## Functions
+
+### `(url-encode str)`
+Percent-encode every byte except the RFC 3986 unreserved set
+`[A-Za-z0-9-_.~]`. Hex digits are uppercase. Multi-byte UTF-8 characters are
+encoded byte-by-byte.
+
+```scheme
+(require core.url)
+(display (url-encode "hello world")) (newline)
+(display (url-encode "abcXYZ012-_.~")) (newline)     ; unreserved, unchanged
+(display (url-encode "a+b&c=d/e?f")) (newline)
+(display (url-encode "café")) (newline)              ; UTF-8
+```
+```
+hello%20world
+abcXYZ012-_.~
+a%2Bb%26c%3Dd%2Fe%3Ff
+caf%C3%A9
+```
+Edge case: `(url-encode "")` ⇒ `""`.
+
+### `(url-decode str)`
+Reverse of `url-encode`. Each `%XX` triple becomes the byte `0xXX`; a literal
+`+` decodes to a space (legacy form-encoding); everything else passes through.
+UTF-8 byte sequences are re-combined into codepoints.
+
+```scheme
+(display (url-decode "hello%20world")) (newline)
+(display (url-decode "a+b")) (newline)               ; '+' -> space
+(display (url-decode (url-encode "key=value&x=1 2"))) (newline)   ; round-trip
+(display (url-decode (url-encode "café"))) (newline)
+```
+```
+hello world
+a b
+key=value&x=1 2
+café
+```
+
+### `(base64url-encode str)`
+Encode a string as URL-safe Base64: standard Base64 with `+`→`-`, `/`→`_`, and
+trailing `=` padding stripped. Used for JWTs, CSRF tokens, and hashes carried in
+query strings or path segments.
+
+```scheme
+(display (base64url-encode "Hello")) (newline)          ; no padding
+(display (base64url-encode "subjects?_d=1")) (newline)  ; note '_' for '/'
+(display (base64url-encode "Ma")) (newline)             ; would be "TWE=" in std
+```
+```
+SGVsbG8
+c3ViamVjdHM_X2Q9MQ
+TWE
+```
+
+### `(base64url-decode str)`
+Reverse of `base64url-encode`. Restores padding and the `-`→`+`, `_`→`/`
+substitutions, then delegates to `base64-decode-string`. Accepts both the
+canonical unpadded form and a padded form.
+
+```scheme
+(display (base64url-decode (base64url-encode "The quick brown fox jumps"))) (newline)
+```
+```
+The quick brown fox jumps
+```
+
+### Internal helpers
+Not part of the public surface but present in the source: `byte->hex2`,
+`url-unreserved?`, `encode-codepoint`, `hex-digit?`, `hex-digit->int`,
+`url-read-byte`, `utf8-combine`, `b64url-strip-padding`,
+`b64url-restore-padding`, `b64url-replace-encode`, `b64url-replace-decode`.
+These implement the byte-level encoding/decoding and UTF-8 recombination behind
+the four exported functions; they are not `provide`d for direct use.


### PR DESCRIPTION
## Summary

Complete, run-verified API reference for the Eshkol standard library at v1.3.0-evolve, under `docs/reference/stdlib/`:

- **59 pages**: 58 module references + `module-system.md` + `INDEX.md`
- **58 modules / 638 provided symbols** — every symbol in every `(provide …)` block of `lib/core/**`, `lib/math.esk`, `lib/signal/*`, `lib/ml/*` documented, plus stdlib-level helpers (`random-tensor`, `time-it`, `time-ns`, keyword-arg internals) in `stdlib_extras.md`
- **Every example was executed** against `build/eshkol-run … -r`; outputs are pasted verbatim. Edge cases (empty input, wrong type, depth limits) were actually tested, not inferred.
- `INDEX.md` carries the complete module × function table with auto-load status (`(require stdlib)` vs individual requires).
- `module-system.md` documents require resolution order, dotted-name → path mapping, `$ESHKOL_PATH`, `stdlib.o`/`stdlib.bc` precompilation, `collect_all_submodules` precompiled-set discovery, and the core.* from-source fallthrough.
- `docs/STDLIB_V1_2_API.md` retitled to reflect v1.3 currency and cross-linked to the new reference (content unchanged otherwise).

Priority zero-doc clusters from the ICC inventory are now covered: `core.memory`, `core.memory_store`, `core.ad.tape` (incl. `record-op!` custom-op backward closures), `core.dnc`/`core.sdnc`, `core.streams`, `core.sexp`, `core.distributed`, `core.merkle`.

## Behaviors found during verification (documented under "Known issues", not fixed here)

- `csv-parse` returns rows **reversed** (stale `reverse` over the now left-to-right `string-split`); breaks `csv-parse-typed` header detection in `core.data.dataframe`
- `memory-store-audit` uncallable: depends on `event-content-hash`, which `core.memory` does not provide
- `div` (`core.operators.arithmetic`) returns `()` for scalars — name collides with the codegen tensor "div" op
- `partial` SIGBUS: `apply` of a captured procedure inside a nested variadic lambda
- `string-copy` 1-arg form returns `()` (builtin delegates to 3-arg `substring`)
- Embedded NUL: builtin `string-index`/`string-contains?` truncate at NUL; pure-Scheme `string-find`/`string-contains`/`string-count` are NUL-safe
- Non-tail stdlib list ops (`length`, `filter`, `map1`, `fold-right`, `count-if`, …) die with **silent SIGILL** at 200k–500k elements (ESH-0108 / ESH-0101); `sort` hits the 100k recursion guard with a clean diagnostic (ESH-0098)
- `fft`→`ifft` chained inside a function body corrupts results (root cause of broken `fast-convolve`); top-level round-trip is fine
- `mish` (`ml.activations`) errors: `tensor-apply` only accepts builtin function names
- tensor/geometric ops on list inputs: `dot` SIGSEGV, `manifold-distance` silently wrong (ESH-0069)
- `make-pq` ignores its comparator (hard-coded min-heap); `pq-pop!` returns a cons, not `(values …)` as its header claims

## Verification

- Coverage check: script cross-checked every `(provide …)` symbol against its doc page — 0 missing across all 58 modules
- All examples run against the current master build (`eshkol-run -r`, perl alarm-wrapped)