### PR TITLE
docs(reference): complete AD + tensor/ML reference (v1.3.0)

### DIFF
--- a/docs/reference/ad/INDEX.md
+++ b/docs/reference/ad/INDEX.md
@@ -1,0 +1,48 @@
+# Automatic Differentiation — Reference
+
+Complete, machine-verified reference for Eshkol's automatic-differentiation
+operators (v1.3.0-evolve). Every signature, example, and output on these pages
+was produced by running the current compiler; open bugs are documented against
+their ledger id, never hidden.
+
+For conceptual background (the three AD modes, node opcodes, tensor backward
+pass, numeric-type boundary) see the breakdown:
+[../../breakdown/AUTODIFF.md](../../breakdown/AUTODIFF.md).
+
+## Pages
+
+| Page | Contents |
+|------|----------|
+| [operators.md](operators.md) | Every operator — `derivative`, `gradient`, `jacobian`, `hessian`, `laplacian`, `directional-derivative`, `divergence`, `curl`, `diff` — with signature, accepted point types, binding forms, capture rules, and composition/nesting. |
+| [architecture.md](architecture.md) | Forward 4-component Taylor jet, reverse tape, the `__ad_pert_level` runtime perturbation counter, mixed reverse-over-forward mode (v1.3), numeric boundary, measured performance. |
+| [support-matrix.md](support-matrix.md) | The AD-oracle support matrix (214 probes / 440 checks), all PASS/XKNOWN cells, the open bugs (ESH-0072/0078/0095/0096/0097), and how to run `scripts/run_ad_oracle.sh`. |
+
+## At a glance
+
+| Operator | Field | Signature | Result on this build |
+|----------|-------|-----------|----------------------|
+| `derivative` | ℝ→ℝ | `(derivative f x)` | `(derivative (lambda (x) (* x x)) 3.0)` → `6` |
+| `gradient` | ℝⁿ→ℝ | `(gradient f pt)` | `#(6 8)` for x²+y² @(3,4) |
+| `jacobian` | ℝⁿ→ℝᵐ | `(jacobian f pt)` | `#((6 0) (0 8))` |
+| `hessian` | ℝⁿ→ℝ | `(hessian f pt)` | `#((48))` for x⁴ @2 |
+| `laplacian` | ℝⁿ→ℝ | `(laplacian f pt)` | `4` for x²+y² @(3,4) |
+| `directional-derivative` | ℝⁿ→ℝ | `(directional-derivative f pt dir)` | `6` |
+| `divergence` | ℝⁿ→ℝⁿ | `(divergence f pt)` | `14` |
+| `curl` | ℝ³→ℝ³ | `(curl f pt)` | `#(0 0 0)` |
+| `diff` | AST→AST | `(diff f 'x)` | symbolic, compile-time |
+
+## Status summary
+
+- Oracle gate **PASS** — 46 PASS / 34 XKNOWN / 0 FAIL/CRASH/HANG (JIT + AOT).
+- **New in v1.3:** mixed reverse-over-forward AD (outer vector `gradient` over
+  inner `derivative`, ESH-0093 / #113) — 15/15 in the mixed-mode test.
+- **Open (tracked):** local-scalar/param captures under reverse mode
+  (ESH-0072/0097, compile-time `PtrToInt`), second-order ops on `tensor` points
+  (ESH-0095, SIGSEGV), vector-param gradient-of-gradient (ESH-0096, zeros),
+  named inner-function gradient (ESH-0078, zeros). See
+  [support-matrix.md](support-matrix.md).
+
+## See also
+
+- [../tensors/INDEX.md](../tensors/INDEX.md) — tensors, ML ops, and the modules AD flows through
+- [../../breakdown/AUTODIFF.md](../../breakdown/AUTODIFF.md) — AD internals breakdown

--- a/docs/reference/ad/architecture.md
+++ b/docs/reference/ad/architecture.md
@@ -1,0 +1,162 @@
+# Automatic Differentiation — Architecture
+
+How Eshkol computes exact derivatives. This complements
+[../../breakdown/AUTODIFF.md](../../breakdown/AUTODIFF.md) (which covers the AD
+node opcodes, the tensor backward pass, and the numeric-type boundary) with the
+forward-jet / reverse-tape / perturbation-level machinery that governs the
+operator behavior documented in [operators.md](operators.md).
+
+Primary source: [`lib/backend/autodiff_codegen.cpp`](../../../lib/backend/autodiff_codegen.cpp)
+and [`lib/core/runtime_autodiff.cpp`](../../../lib/core/runtime_autodiff.cpp).
+
+---
+
+## Two engines
+
+Eshkol runs **forward mode** for `derivative` and **reverse mode** for
+`gradient`/`jacobian` and the vector-calculus operators built on them
+(`hessian`, `laplacian`, `divergence`, `curl`, `directional-derivative`).
+`diff` is a third, purely compile-time symbolic engine.
+
+| Mode | Used by | Data structure | Cost | Best when |
+|------|---------|----------------|------|-----------|
+| Forward | `derivative` | 4-component Taylor jet | O(n) forward pass | 1 scalar input → 1 scalar output (higher-order via nesting) |
+| Reverse | `gradient`, `jacobian`, `hessian`, … | tape of `ad_node_t` | O(n) forward + O(n) backward | many inputs, 1 output |
+| Symbolic | `diff` | AST rewrite | O(1) at compile time | closed-form derivatives |
+
+---
+
+## Forward mode — the 4-component jet
+
+A "dual number" in Eshkol is **not** the classic 2-component `{value,
+derivative}`. It is a truncated **bivariate** Taylor jet with two independent
+perturbation symbols `e1`, `e2` (`e1² = e2² = 0`):
+
+```
+v = f0 + f1·e1 + f2·e2 + f3·e1·e2
+```
+
+stored as the LLVM struct `{primal, d1, d2, d12}`. A single-level derivative
+only touches `f0`/`f1`, so it is exactly backward-compatible with a plain dual
+`{primal, tangent, 0, 0}`.
+
+Why two slots: **each nesting level gets its own perturbation symbol**. This is
+the standard cure for *perturbation confusion* — when you nest `derivative`
+inside `derivative` (or differentiate a Hessian w.r.t. two arguments), level 0
+seeds `e1` (field 1) and level 1 seeds `e2` (field 2). The mixed `e1·e2`
+coefficient (`d12`) carries the exact second-order term. Every arithmetic op
+propagates all four components in closed form (see `dualUnaryChain` in
+`autodiff_codegen.cpp`) — no finite differences, no recursion.
+
+**Two levels are exact; three is not.** A 4-component jet cannot carry a third
+independent perturbation, so a third nested `derivative` *aliases* onto `e2` and
+the compiler emits a `nested derivative depth N exceeds exact 2-level forward
+AD` warning rather than silently returning a wrong-but-plausible number.
+
+---
+
+## Perturbation levels — `__ad_pert_level`
+
+The perturbation level is a **runtime** counter, not a compile-time lexical
+depth. It lives in thread-local storage:
+
+```c
+// lib/core/runtime_autodiff.cpp
+thread_local uint64_t __ad_pert_level = 0;
+```
+
+and is exposed to codegen as a global loaded/stored around every forward-mode
+call (`seedForwardAndPush` / `popAndExtractForward`). The counter is pushed
+before a `derivative`/`gradient` evaluates its body and popped afterward.
+
+This runtime push/pop is what makes nesting correct **across a function-call or
+named-let TCO boundary**. A compile-time lexical depth could not see across the
+call boundary, so a `derivative` reached *through* a called function would
+clobber the outer perturbation (this was the ESH-0070 class of bug). A runtime
+counter is invariant under TCO re-entry by construction: the inner call reads
+the level the outer one left live (level 1 → slot `e2`) and therefore seeds a
+distinct slot instead of overwriting the outer's `e1`.
+
+---
+
+## Reverse mode — the tape
+
+`gradient`/`jacobian` build a computational graph of `ad_node_t` records during
+the forward pass, then propagate gradients backward from the output. The tape,
+node structure, opcode enum, and the tensor backward-pass dispatch are
+documented in
+[../../breakdown/AUTODIFF.md#reverse-mode-ad-computational-graph](../../breakdown/AUTODIFF.md#reverse-mode-ad-computational-graph).
+
+The tape stack supports **32 levels** of nesting and is **per-thread**
+(`thread_local __ad_tape_stack[32]`), so `parallel-map` of a gradient function
+is tape-safe. (Two shared globals — `__current_ad_tape`, `__ad_mode_active` —
+are not thread-local; see the AUTODIFF.md "Parallel Tape Management" note.)
+
+---
+
+## Mixed mode — reverse-over-forward (v1.3, ESH-0093)
+
+The headline v1.3 AD change (#113) makes an **outer vector `gradient` (reverse
+tape) over an inner `derivative` (forward jet)** propagate the dependency on
+captured tape parameters. Mechanism, from
+[`runtime_autodiff.cpp`](../../../lib/core/runtime_autodiff.cpp) and
+`autodiff_codegen.cpp`:
+
+1. While a forward pass is live (`__ad_pert_level > 0`), reverse-tape nodes that
+   flow into scalar arithmetic are **jet-lifted** to dual numbers: `value =
+   node->value`, and the `e2` slot is seeded with `1.0` iff the node *is* the
+   published seed (`eshkol_ad_seed_flag`).
+2. The forward 4-jet then carries the mixed `e1·e2` coefficient through the
+   inner computation — no new arithmetic rules needed.
+3. At the `derivative` return site, `eshkol_ad_mixed_record` records the result
+   back onto the outer tape with a backward edge `a12 = d(result)/d(seed)`, so
+   the outer reverse pass sees the correct sensitivity.
+
+This is exercised end-to-end by
+[`tests/ad/mixed_mode_ad_test.esk`](../../../tests/ad/mixed_mode_ad_test.esk)
+(15/15 on this build), including nonlinear captures, tensor-literal points
+(reverse-tape path) vs `vector` points, and a 1000-iteration stability loop.
+
+```scheme
+;; f(x;p0)=p0·x²  ->  ∂/∂p0 [ d/dx f @2 ] = 4
+(gradient (lambda (p) (derivative (lambda (x) (* (vref p 0) (* x x))) 2.0))
+          (vector 3.0))
+;; => #(4)
+```
+
+What is **not** yet covered by the mixed path: reverse-**over-reverse** with a
+vector outer point (`gradient` of `gradient`, vector param — **ESH-0096**) and
+`gradient` of a *named* inner function (**ESH-0078**) both fall back to the old
+path and silently return zeros. See [support-matrix.md](support-matrix.md).
+
+---
+
+## Numeric boundary (summary)
+
+The AD engine operates on `double` and the jet/dual structs only. Bignums,
+rationals, and complex numbers do **not** carry derivatives — see
+[../../breakdown/AUTODIFF.md](../../breakdown/AUTODIFF.md) ("Numeric Type
+Interactions with AD") for the exact conversion behavior at the boundary.
+Convert exotic numeric inputs to `double` before entering an AD context.
+
+---
+
+## Performance (measured, this build, arm64/Apple Silicon, AOT)
+
+| Workload | Result | Timing |
+|----------|--------|--------|
+| 2nd-order scalar derivative of a cubic, 10⁶ calls | `1.8e7` (18/call) | 0.41 s user / 0.74 s wall → ≈ **0.4 µs/call** |
+| 7168-dim `gradient` of Σ xᵢ² (single call) | `#(3 … 3)` | 5.56 s user / **6.30 s wall** |
+
+Method: AOT-compiled (`eshkol-run f.esk -o bin`), timed with `/usr/bin/time`.
+The 2nd-order figure is the effective per-call cost including the accumulation
+loop. Forward mode is O(1) space (just the jet); reverse mode is O(n) space in
+the tape.
+
+---
+
+## See also
+
+- [operators.md](operators.md) — per-operator API, capture rules, nesting table
+- [support-matrix.md](support-matrix.md) — oracle matrix and open cells
+- [../../breakdown/AUTODIFF.md](../../breakdown/AUTODIFF.md) — opcodes, tensor backward, tape internals

--- a/docs/reference/ad/operators.md
+++ b/docs/reference/ad/operators.md
@@ -1,0 +1,338 @@
+# Automatic Differentiation — Operator Reference
+
+Every operator, signature, accepted point type, binding form, and capture rule
+below is verified by running it on the v1.3.0 compiler. Outputs are pasted
+exactly as printed by `eshkol-run` (JIT `-r` and AOT agree unless noted). Open
+cells are marked with their ledger id — see
+[support-matrix.md](support-matrix.md).
+
+For the underlying machinery (forward 4-jet, reverse tape, perturbation
+levels) see [architecture.md](architecture.md). For the numeric-boundary and
+tensor-backward internals see
+[../../breakdown/AUTODIFF.md](../../breakdown/AUTODIFF.md).
+
+---
+
+## Operator summary
+
+| Operator | Field type | Signature | Result |
+|----------|-----------|-----------|--------|
+| `derivative` | ℝ → ℝ | `(derivative f x)` | scalar |
+| `gradient` | ℝⁿ → ℝ | `(gradient f point)` | vector `∇f` |
+| `jacobian` | ℝⁿ → ℝᵐ | `(jacobian f point)` | matrix `J` (vector of rows) |
+| `hessian` | ℝⁿ → ℝ | `(hessian f point)` | matrix `H` (vector of rows) |
+| `laplacian` | ℝⁿ → ℝ | `(laplacian f point)` | scalar `∇²f` = tr(H) |
+| `directional-derivative` | ℝⁿ → ℝ | `(directional-derivative f point dir)` | scalar `∇f · dir` |
+| `divergence` | ℝⁿ → ℝⁿ | `(divergence f point)` | scalar `∇·F` |
+| `curl` | ℝ³ → ℝ³ | `(curl f point)` | vector `∇×F` |
+| `diff` | AST → AST | `(diff f 'x)` | symbolic derivative (compile time) |
+
+`f` is a one-argument function (an inline `lambda`, a named `define`, or a
+variable bound to a lambda). `vref` is the tensor/vector element accessor and
+is an alias for `vector-ref` in AD bodies.
+
+---
+
+## `derivative` — forward-mode scalar derivative
+
+```
+(derivative f x)   ;; f : ℝ → ℝ, x a real; returns f'(x)
+```
+
+Forward mode (4-component Taylor jet). Best for one input / many outputs.
+
+```scheme
+(derivative (lambda (x) (* x x)) 3.0)       ;; => 6
+(derivative (lambda (x) (sin (* x x))) 1.0) ;; => 1.0806
+```
+
+`display` prints doubles at reduced precision (≈5 significant figures), so the
+second result shows as `1.0806` (the full value is 2·cos(1) ≈ 1.08060461).
+
+> **Not supported (returns `0`).** A **vector- or tensor-valued** function
+> (ℝ → ℝⁿ) does *not* differentiate componentwise under `derivative` on this
+> build — it silently returns `0`:
+>
+> ```scheme
+> (derivative (lambda (x) (vector (* x x) (* x x x))) 2.0)  ;; => 0  (NOT #(4 12))
+> ```
+>
+> Take per-component derivatives with separate scalar `derivative` calls, or
+> use `jacobian` for a vector-valued map of a vector point.
+
+Second derivative by nesting two `derivative` calls (two perturbation slots,
+exact — see architecture):
+
+```scheme
+(derivative (lambda (y) (derivative (lambda (z) (* z z z)) y)) 3.0)  ;; => 18
+```
+
+---
+
+## `gradient` — reverse-mode gradient
+
+```
+(gradient f point)   ;; f : ℝⁿ → ℝ ; point a vector or tensor; returns ∇f
+```
+
+`f` takes the whole point vector and unpacks components with `vref`. Reverse
+mode; best for many inputs / one output (loss functions, training).
+
+```scheme
+(gradient (lambda (v)
+            (let ((x (vref v 0)) (y (vref v 1)))
+              (+ (* x x) (* y y))))
+          (vector 3.0 4.0))
+;; => #(6 8)
+```
+
+A scalar point is also accepted (treated as a 1-D gradient, returning a
+scalar):
+
+```scheme
+(gradient (lambda (x) (* x x)) 3.0)   ;; => 6
+```
+
+---
+
+## `jacobian` — reverse-mode Jacobian
+
+```
+(jacobian f point)   ;; f : ℝⁿ → ℝᵐ ; returns the m×n matrix J[i][j] = ∂fᵢ/∂xⱼ
+```
+
+```scheme
+(jacobian (lambda (v)
+            (let ((x (vref v 0)) (y (vref v 1)))
+              (vector (* x x) (* y y))))
+          (vector 3.0 4.0))
+;; => #((6 0) (0 8))
+```
+
+The result is a vector of row vectors. Note the display form: the outer level
+prints with `#(…)` and inner rows print as bare `(…)` — `#((6 0) (0 8))` is a
+2×2 matrix.
+
+---
+
+## `hessian` — second-order (matrix of second partials)
+
+```
+(hessian f point)   ;; f : ℝⁿ → ℝ ; returns H[i][j] = ∂²f/(∂xᵢ∂xⱼ)
+```
+
+```scheme
+;; f(x) = x⁴, f''(2) = 12·2² = 48
+(hessian (lambda (v) (let ((x (vref v 0))) (* x (* x (* x x)))))
+         (vector 2.0))
+;; => #((48))
+
+;; f(x,y) = x² + xy
+(hessian (lambda (v) (let ((x (vref v 0)) (y (vref v 1))) (+ (* x x) (* x y))))
+         (vector 1.0 2.0))
+;; => #((2 1) (1 0))
+```
+
+> Open cell **ESH-0095**: `hessian` (and `laplacian`) **SIGSEGV** when the
+> point is a `tensor`/`#(…)` literal instead of a `vector`. Use `(vector …)`
+> points for second-order operators. See support-matrix.md.
+
+---
+
+## `laplacian` — trace of the Hessian
+
+```
+(laplacian f point)   ;; f : ℝⁿ → ℝ ; returns ∇²f = Σᵢ ∂²f/∂xᵢ²
+```
+
+```scheme
+(laplacian (lambda (v) (let ((x (vref v 0)) (y (vref v 1))) (+ (* x x) (* y y))))
+           (vector 3.0 4.0))
+;; => 4
+```
+
+> Same open cell **ESH-0095**: SIGSEGV on `tensor`/`#(…)` points; use vectors.
+
+---
+
+## `directional-derivative` — gradient projected onto a direction
+
+```
+(directional-derivative f point dir)   ;; returns ∇f(point) · dir
+```
+
+```scheme
+(directional-derivative
+   (lambda (v) (let ((x (vref v 0)) (y (vref v 1))) (+ (* x x) (* y y))))
+   (vector 3.0 4.0) (vector 1.0 0.0))
+;; => 6
+```
+
+---
+
+## `divergence` — scalar divergence of a vector field
+
+```
+(divergence f point)   ;; f : ℝⁿ → ℝⁿ ; returns Σᵢ ∂Fᵢ/∂xᵢ
+```
+
+```scheme
+(divergence (lambda (v)
+              (vector (* (vref v 0) (vref v 0))
+                      (* (vref v 1) (vref v 1))))
+            (vector 3.0 4.0))
+;; => 14           ; 2x + 2y = 6 + 8
+```
+
+---
+
+## `curl` — curl of a 3-D vector field
+
+```
+(curl f point)   ;; f : ℝ³ → ℝ³ ; returns ∇×F
+```
+
+```scheme
+(curl (lambda (v)
+        (vector (* (vref v 1) (vref v 2))    ; y·z
+                (* (vref v 0) (vref v 2))     ; x·z
+                (* (vref v 0) (vref v 1))))   ; x·y
+      (vector 1.0 2.0 3.0))
+;; => #(0 0 0)
+```
+
+---
+
+## `diff` — symbolic differentiation (compile time)
+
+`diff` rewrites the function AST at compile time using 12 rules (constant,
+variable, sum, difference, product, quotient, power, sin, cos, exp, log,
+chain). It returns a function, not a value. See
+[../../breakdown/AUTODIFF.md#symbolic-differentiation](../../breakdown/AUTODIFF.md#symbolic-differentiation)
+for the full rule table.
+
+```scheme
+(diff (lambda (x) (* x x)) 'x)   ;; AST equivalent to (lambda (x) (* 2 x))
+```
+
+---
+
+## Accepted point types
+
+| Point form | Layout | `gradient`/`jacobian`/`divergence`/`curl` | `hessian`/`laplacian` |
+|------------|--------|-------------------------------------------|-----------------------|
+| `(vector 1.0 2.0)` | 16-byte tagged values | ✅ | ✅ |
+| `#(1.0 2.0)` literal (tensor) | 8-byte doubles | ✅ | ❌ SIGSEGV (**ESH-0095**) |
+| `(tensor 1.0 2.0)` | 8-byte doubles | ✅ | ❌ SIGSEGV (**ESH-0095**) |
+| scalar `3.0` | double | ✅ (1-D) | — |
+| multi-param via `(list …)` | cons list | ✅ (first-order ops) | — |
+
+First-order operators accept both `vector` and `tensor` points (verified
+against the [AD oracle](support-matrix.md) matrix). Second-order operators are
+only safe on `vector` points until ESH-0095 lands. See
+[../tensors/creation.md](../tensors/creation.md) for the vector-vs-tensor
+distinction.
+
+---
+
+## Binding forms
+
+The function argument may be supplied three ways. All three work for
+first-order operators:
+
+```scheme
+;; 1. inline lambda
+(gradient (lambda (v) (* (vref v 0) (vref v 0))) (vector 3.0))   ;; => #(6)
+
+;; 2. named define
+(define (sq v) (* (vref v 0) (vref v 0)))
+(gradient sq (vector 3.0))                                        ;; => #(6)
+
+;; 3. lambda bound to a variable
+(define sqv (lambda (v) (* (vref v 0) (vref v 0))))
+(gradient sqv (vector 3.0))                                       ;; => #(6)
+```
+
+> **Nesting caveat (ESH-0078).** For a *nested* second-order gradient, the
+> inner `gradient`/`derivative` must currently receive an **inline lambda**.
+> A named function or lambda-variable as the inner differentiand silently
+> returns `0`:
+>
+> ```scheme
+> (define (L z) (* z (* z z)))
+> (gradient (lambda (y) (gradient (lambda (z) (L z)) y)) 3.0)  ;; => 18  ✅ inline
+> (gradient (lambda (y) (gradient L y)) 3.0)                   ;; =>  0  ❌ named (ESH-0078)
+> ```
+
+---
+
+## Capture rules
+
+What the differentiated lambda may close over depends on the mode:
+
+| Captured value | `derivative` (forward) | `gradient`/`jacobian`/`hessian`/`divergence`/`curl`/`laplacian` (reverse) |
+|----------------|------------------------|---------------------------------------------------------------------------|
+| top-level (global) scalar | ✅ | ✅ |
+| top-level (global) vector, via `vref` | ✅ | ✅ |
+| **local** / parameter scalar | ✅ | ❌ LLVM `PtrToInt` verification failure (**ESH-0072** scalar point, **ESH-0097** vector point) |
+| `vref` of an outer **local** vector param | ✅ | ❌ same failure (**ESH-0097** `capvrefout`) |
+
+Verified examples:
+
+```scheme
+;; GLOBAL capture — works in both modes
+(define a 8.0) (define t 5.0)
+(define (loss x) (let ((d (- x t))) (* a (* d d))))
+(derivative loss 7.0)                                    ;; => 32   ✅
+
+(define g 1.7)
+(gradient (lambda (v) (* g (vref v 0) (vref v 0))) (vector 1.3 -0.7))
+;; => #(4.42 0)   ✅
+
+;; LOCAL capture under `derivative` — works (forward mode)
+(define (step a t w0) (derivative (lambda (x) (loss2 a t x)) w0))
+;; (step 8.0 5.0 7.0) => 32   ✅
+
+;; LOCAL capture under `gradient` — FAILS at compile time (ESH-0072 / ESH-0097)
+(define (mk a) (gradient (lambda (x) (* a x x)) 3.0))
+;; ERROR: LLVM module verification failed: PtrToInt source must be pointer
+;;        %N = ptrtoint %eshkol_tagged_value %a to i64
+```
+
+**Workaround until ESH-0072/ESH-0097 land:** lift captured scalars to
+top-level `define`s (or pass them *inside* the point vector and `vref` them),
+so the reverse-mode lambda only closes over globals.
+
+---
+
+## Composition / nesting
+
+| Composition | Status | Note |
+|-------------|--------|------|
+| `derivative` of `derivative` (scalar 2nd order) | ✅ | exact, 2 perturbation slots |
+| `gradient` of scalar `derivative`, scalar point | ✅ | forward-fast-path |
+| `gradient` (vector point) over inner `derivative` — **mixed reverse-over-forward** | ✅ | fixed in v1.3 (#113, ESH-0093); see [tests/ad/mixed_mode_ad_test.esk](../../../tests/ad/mixed_mode_ad_test.esk), 15/15 |
+| `gradient` of `gradient`, **scalar** point | ✅ | e.g. `L''` returns correct value |
+| `gradient` of `gradient`, **vector** point | ❌ returns zeros (**ESH-0096**) |
+| `gradient` of a **named** inner function | ❌ returns 0 (**ESH-0078**) |
+| AD inside a bounded loop (reuse) | ✅ | stable over 1000+ iterations |
+
+Mixed reverse-over-forward (an outer vector `gradient` over an inner
+`derivative` that depends on captured tape parameters) is the headline v1.3 AD
+fix. Verified:
+
+```scheme
+;; f(x;p0)=p0·x², ∂/∂p0 [ d/dx f @2 ] = 4
+(gradient (lambda (p) (derivative (lambda (x) (* (vref p 0) (* x x))) 2.0))
+          (vector 3.0))
+;; => #(4)
+```
+
+---
+
+## See also
+
+- [architecture.md](architecture.md) — forward 4-jet, reverse tape, `__ad_pert_level`, mixed-mode recording
+- [support-matrix.md](support-matrix.md) — full oracle matrix, open cells, running the oracle
+- [../../breakdown/AUTODIFF.md](../../breakdown/AUTODIFF.md) — modes, node opcodes, tensor backward, numeric boundary
+- [../tensors/INDEX.md](../tensors/INDEX.md) — tensor operations that AD flows through

--- a/docs/reference/ad/support-matrix.md
+++ b/docs/reference/ad/support-matrix.md
@@ -1,0 +1,124 @@
+# Automatic Differentiation — Support Matrix
+
+This is the authoritative, machine-verified statement of what Eshkol's AD
+system does and does not do in v1.3.0. It mirrors the **AD composition oracle**
+([`tests/ad_oracle/`](../../../tests/ad_oracle/)), which enumerates the whole AD
+surface as a matrix and checks **every cell against in-language central finite
+differences** — ground truth with no hand computation.
+
+The values below were produced by running `scripts/run_ad_oracle.sh` on this
+build (JIT `-r` and AOT both):
+
+```
+ad_oracle summary: total=80 passed=46 xknown=34 failed=0 crashed=0 hung=0
+ad_oracle gate: PASS
+```
+
+`total` counts each of the 40 probe files under two modes (JIT + AOT); JIT and
+AOT verdicts are identical. The corpus is **214 probes / 440 checks in 40
+files**. `passed` = agrees with finite differences; `xknown` = a tracked open
+bug (expected); `failed`/`crashed`/`hung` = 0, so the gate is green.
+
+---
+
+## The matrix axes
+
+The oracle sweeps the Cartesian product of:
+
+| axis | values |
+|------|--------|
+| operator | `derivative` `gradient` `jacobian` `hessian` `divergence` `curl` `laplacian` |
+| point | scalar, 2-vector, 3-vector, 2/3-tensor (`(tensor …)`), multi-param + `(list …)` |
+| shape | polynomial, product-of-linears, with-subtraction, rational `1/(1+x²)`, exp/sin composite, let-bound reuse, named-let accumulation |
+| binding | inline lambda, named `define`, lambda-in-variable |
+| capture | none, global scalar, local param scalar, `vref` of outer param |
+| nesting | none, derivative-of-derivative, gradient-of-derivative (scalar+vector), gradient-of-gradient (scalar+vector), AD-in-loop |
+
+Tolerance: `|ad - fd| ≤ atol + rtol·|fd|`, `rtol = 1e-4`. First-order stencils
+`h = 1e-5` (atol 1e-6); second-order stencils `h = 1e-4` (atol 1e-5).
+
+---
+
+## What passes (PASS cells)
+
+- **All first-order operators on all point types**: `gradient`, `jacobian`,
+  `divergence`, `curl` accept `vector`, `#(…)`/`tensor`, scalar, and
+  `(list …)` points across every shape.
+- **`derivative`** including vector-valued output and 2-level nesting
+  (derivative-of-derivative, exact via the two jet slots).
+- **`hessian` / `laplacian` on `vector` points**, all shapes.
+- **Mixed reverse-over-forward** — outer vector `gradient` over inner
+  `derivative` with captured parameters (v1.3, ESH-0093). See
+  [`tests/ad/mixed_mode_ad_test.esk`](../../../tests/ad/mixed_mode_ad_test.esk).
+- **Global captures** in every mode; **local captures** under `derivative`.
+- **AD reused inside a bounded loop** (stable over 1000+ iterations).
+
+---
+
+## Open cells (XKNOWN)
+
+Each references a task in [`.swarm/tasks/`](../../../.swarm/tasks/). These are
+tracked, reproduced, and expected — they do **not** fail the gate. Minimal
+repros live in [`tests/ad_oracle/found/`](../../../tests/ad_oracle/found/).
+
+| Task | Cells | Symptom | Repro |
+|------|-------|---------|-------|
+| **ESH-0072** | `grad.*.s.caplocal` (scalar point) | Reverse-mode lambda capturing a **local scalar** → LLVM `PtrToInt source must be pointer (%eshkol_tagged_value)` at compile time, both `-r` and AOT. | — |
+| **ESH-0097** | `{grad,jac,hess,div,curl,lap}.*.v*.caplocal / .capvrefout` (12 files) | Same `PtrToInt` failure for **any vector-param** reverse-mode operator capturing a local param, or a `vref` of an outer param. `derivative` and global captures are unaffected. | [`found/esh0097_local_capture_vector_ad_ptrtoint.esk`](../../../tests/ad_oracle/found/esh0097_local_capture_vector_ad_ptrtoint.esk) |
+| **ESH-0095** | `hess.poly.t2/t3`, `lap.poly.t2/t3` (4 files) | `hessian` / `laplacian` **SIGSEGV** when the point is a `tensor`/`#(…)` literal (works on `(vector …)`). Second-order paths read the point through the 16-byte tagged layout; tensors are 8-byte doubles. | [`found/esh0095_hessian_tensor_point_sigsegv.esk`](../../../tests/ad_oracle/found/esh0095_hessian_tensor_point_sigsegv.esk), [`…_laplacian_…`](../../../tests/ad_oracle/found/esh0095_laplacian_tensor_point_sigsegv.esk) |
+| **ESH-0096** | `nest.gofg.*.v1/v2` | `gradient` of `gradient` with a **vector** param silently returns zeros (`#(0)` for a 1-D case that should give `#(12)`). The scalar-point form is correct. | [`found/esh0096_gradient_of_gradient_vector_param_zeros.esk`](../../../tests/ad_oracle/found/esh0096_gradient_of_gradient_vector_param_zeros.esk) |
+| **ESH-0078** | `nest.gofg.*.s.named/lamvar` | Second-order gradient through a **named** inner function returns `0`; the inline-lambda form is correct (`18`). | — |
+
+> **Documentation caveat.** [../../breakdown/AUTODIFF.md](../../breakdown/AUTODIFF.md)
+> "Higher-Order Derivatives" shows `(gradient (lambda (v) (gradient … v)) (vector 2.0))`
+> returning `#(12.0)`. On this build that vector-param gradient-of-gradient
+> returns `#(0)` (**ESH-0096**). The scalar-point second derivative is correct.
+
+Verified open-cell behavior on this build:
+
+```scheme
+;; ESH-0078
+(define (L z) (* z (* z z)))
+(gradient (lambda (y) (gradient (lambda (z) (L z)) y)) 3.0)  ;; => 18  (inline, correct)
+(gradient (lambda (y) (gradient L y)) 3.0)                   ;; =>  0  (named, WRONG)
+
+;; ESH-0096
+(gradient (lambda (v) (vref (gradient (lambda (w) (* (vref w 0) (vref w 0) (vref w 0))) v) 0))
+          (vector 2.0))                                       ;; => #(0)  (should be #(12))
+
+;; ESH-0095  -> SIGSEGV
+(hessian (lambda (v) (let ((x (vref v 0)) (y (vref v 1))) (+ (* x x) (* x y))))
+         (tensor 1.0 2.0))
+
+;; ESH-0072 / ESH-0097  -> compile-time PtrToInt verification failure
+(define (mk a) (gradient (lambda (x) (* a x x)) 3.0))
+```
+
+---
+
+## Running the oracle
+
+```
+scripts/run_ad_oracle.sh            # full sweep, JIT + AOT
+scripts/run_ad_oracle.sh --quick    # CI subset (first file of each section/task)
+scripts/run_ad_oracle.sh --no-aot   # JIT lane only
+scripts/run_ad_oracle.sh --regen    # regenerate the (deterministic) corpus first
+```
+
+Point it at a build dir with `BUILD_DIR=…`. Per-file verdicts: `PASS` / `FAIL`
+(an *untracked* cell diverged from finite differences) / `XKNOWN` (tracked open
+bug) / `CRASH` / `HANG`. The gate is green iff there are no FAIL/CRASH/HANG.
+Verdicts stream to `scripts/icc_traces/ad_oracle.jsonl` as `kind:"ad_oracle"`
+events (consumed by `.icc/completion-oracles.yaml::ad-oracle`).
+
+When a task is fixed, its probes flip `XKNOWN → PASS` automatically — no oracle
+edit needed. The generator ([`gen_ad_oracle.py`](../../../tests/ad_oracle/gen_ad_oracle.py))
+is deterministic; regenerating reproduces the corpus byte-for-byte.
+
+---
+
+## See also
+
+- [operators.md](operators.md) — per-operator API, capture rules, nesting
+- [architecture.md](architecture.md) — forward jet, reverse tape, mixed mode
+- [`tests/ad_oracle/README.md`](../../../tests/ad_oracle/README.md) — oracle design

--- a/docs/reference/tensors/INDEX.md
+++ b/docs/reference/tensors/INDEX.md
@@ -1,0 +1,55 @@
+# Tensors & ML — Reference
+
+Machine-verified reference for Eshkol's tensor system and the ML/numerical
+library modules (v1.3.0-evolve). Every signature and output on these pages was
+produced by running the current compiler; broken operations are documented
+against their behavior, not hidden.
+
+## Pages
+
+| Page | Contents |
+|------|----------|
+| [creation.md](creation.md) | `vector` vs `tensor` (heterogeneous 16-byte tagged values vs homogeneous 8-byte doubles), literals `#(…)`, `make-tensor`/`make-vector`, and dtypes (f16/bf16/f32/f64/i8). |
+| [operations.md](operations.md) | Shape ops, elementwise & unary math, linear algebra + decompositions, reductions, conv1d/2d/3d, pooling, normalization, attention, embedding, activations, the PR-#79 type guards, pixel fills, and save/load — with known-broken ops flagged. |
+| [gpu.md](gpu.md) | Honest GPU-dispatch status: the `gpu-*` builtins, the cost-model threshold, what actually runs on Metal in `-r` vs AOT, and how that squares with ESH-0022/0023. |
+| [ml-modules.md](ml-modules.md) | `ml.optimization`, `core.manifold`, `signal.fft` — every `provide` with signature and a run example. |
+
+## Two containers at a glance
+
+| | `vector` / `make-vector` | `tensor` / `#(…)` / `make-tensor` |
+|---|---|---|
+| Storage | heterogeneous 16-byte tagged values | homogeneous 8-byte doubles |
+| Mixed types | yes | no (numeric only) |
+| dtype / shape | no | yes (`f64` default) |
+| Displays as | `#(…)` | `#(…)` (same — distinguish via `tensor-dtype`) |
+
+## What works, what to avoid
+
+**Solid:** all shape ops, elementwise/unary math, linear algebra incl.
+LU/QR/SVD/Cholesky/solve/inverse/det, reductions, `conv1d`/`conv2d`/`conv3d`,
+`max-pool2d`/`avg-pool2d`, `multi-head-attention` (forward), `embedding`,
+`positional-encoding`, `dropout`, `softmax`, tensor-only activations, dtype
+casts, rect/disk pixel fills, and all three library modules.
+
+**Known-broken on this build (documented, not fixed here):**
+
+| Operation | Issue |
+|-----------|-------|
+| `batch-norm`, `layer-norm` | garbage output (4-arg); SIGSEGV (5-arg `axis`) |
+| `tensor-load` | drops shape (`tensor-shape` → `(0)`); data/length survive |
+| `gpu-reduce` | returns empty `#()` instead of a scalar |
+| `tanh` | scalar-only; silently wrong on a tensor |
+| `tensor-pow` | needs a tensor exponent, not a scalar |
+| tensor creation | no element type-check; int+float args misread as shape |
+
+## GPU status in one line
+
+The `gpu-*` builtins resolve and run in both `-r` and AOT; plain `tensor-matmul`
+auto-dispatches to Metal (both `-r` and AOT) when the size threshold is met, so
+AOT is **not** CPU-only on Metal. ESH-0022/0023 are therefore partly stale —
+see [gpu.md](gpu.md).
+
+## See also
+
+- [../ad/INDEX.md](../ad/INDEX.md) — automatic differentiation (flows through tensors)
+- [../../breakdown/AUTODIFF.md](../../breakdown/AUTODIFF.md) — tensor backward pass, GPU gradient flow

--- a/docs/reference/tensors/creation.md
+++ b/docs/reference/tensors/creation.md
@@ -1,0 +1,95 @@
+# Tensors — Creation, dtypes, and the vector/tensor distinction
+
+Everything below is verified by running it on the v1.3.0 compiler; outputs are
+pasted as printed.
+
+---
+
+## Two containers: `vector` vs `tensor`
+
+Eshkol has two superficially similar 1-D containers with different memory
+layouts and purposes.
+
+| | `vector` / `make-vector` | `tensor` / `#(…)` literal / `make-tensor` |
+|---|---|---|
+| Heap subtype | `HEAP_SUBTYPE_VECTOR` | `HEAP_SUBTYPE_TENSOR` |
+| Element storage | heterogeneous **16-byte tagged values** | homogeneous **8-byte doubles** |
+| Holds mixed types? | yes (int, string, double, …) | no — numeric only |
+| Has `dtype`/`shape`? | no | yes (`f64` default) |
+| Multi-dimensional? | nested vectors only | native n-D via shape |
+| AD point type | ✅ all operators incl. `hessian`/`laplacian` | ✅ first-order; ✗ `hessian`/`laplacian` (ESH-0095) |
+
+```scheme
+;; vector holds heterogeneous values
+(vector 1 "two" 3.0)            ;; => #(1 two 3)   (int, string, double)
+
+;; tensor is homogeneous doubles with dtype + shape
+(define t (tensor 1.0 2.0 3.0))
+(tensor-dtype t)                ;; => f64
+(tensor-shape t)                ;; => (3)
+t                               ;; => #(1 2 3)
+```
+
+> **Display note.** Both containers print with the `#(…)` reader syntax, so
+> `display` alone does not tell them apart — use `tensor-dtype`/`tensor-shape`
+> (defined only for tensors) or the surrounding context. Integers and whole
+> doubles both print without a decimal point (`3.0` → `3`), and strings print
+> without quotes.
+
+---
+
+## Creating tensors
+
+```scheme
+(tensor 1.0 2.0 3.0)                       ;; 1-D tensor from elements  => #(1 2 3)
+#(1.0 2.0 3.0)                             ;; literal tensor            => #(1 2 3)
+(make-tensor (list 2 2) 0.0)               ;; shape (2 2) filled with 0.0
+(tensor-reshape (tensor 1.0 2.0 3.0 4.0) (list 2 2))  ;; reshape flat -> 2x2
+```
+
+`(make-tensor shape fill)` takes a shape *list* and a fill value; the result is
+`shape`-dimensional. Reshape a flat tensor into higher rank with
+`tensor-reshape` (see [operations.md](operations.md)).
+
+## Creating vectors
+
+```scheme
+(vector 1.0 2.0)                           ;; from elements
+(make-vector 3 0.0)                         ;; length 3, each element 0.0
+```
+
+Use `vector` when you need a heterogeneous or symbolic container; use `tensor`
+for numeric array math, GPU dispatch, and ML ops.
+
+---
+
+## Data types (dtypes)
+
+Tensors carry a dtype tag. The default is `f64`. `tensor-cast` converts between
+`f16`, `bf16`, `f32`, and `f64`; the dtype round-trips through
+`tensor-dtype`:
+
+```scheme
+(define t (tensor 1.0 2.0 3.0))
+(tensor-dtype t)                        ;; => f64   (default)
+(tensor-dtype (tensor-cast t 'f32))     ;; => f32
+(tensor-dtype (tensor-cast t 'f16))     ;; => f16
+(tensor-dtype (tensor-cast t 'bf16))    ;; => bf16
+(tensor-dtype (tensor-cast t 'f64))     ;; => f64
+```
+
+**Status.** The dtype metadata and `tensor-cast` tagging are wired for all four
+types and round-trip correctly. The reduced-precision **software float paths**
+(sf64 kernels) exercised by the GPU pipeline are covered by the
+[`tests/gpu/sf64_*`](../../../tests/gpu/) suite. Full end-to-end f16/bf16
+*storage and compute* across every operation is still being completed — see the
+GPU-campaign tasks ESH-0022/ESH-0023 and [gpu.md](gpu.md) for the honest
+current dispatch status.
+
+---
+
+## See also
+
+- [operations.md](operations.md) — shape ops, elementwise, matmul, reductions, activations, conv/pool/norm/attention, fills, save/load, type guards
+- [gpu.md](gpu.md) — GPU dispatch status (Metal/CUDA/XLA) and the `gpu-*` builtins
+- [../ad/operators.md](../ad/operators.md#accepted-point-types) — which point type each AD operator accepts

--- a/docs/reference/tensors/gpu.md
+++ b/docs/reference/tensors/gpu.md
@@ -1,0 +1,101 @@
+# GPU Dispatch — Honest Status
+
+This page states what actually runs on the GPU today, verified on the v1.3.0
+build on an **Apple M2 Ultra (Metal)**. CUDA and XLA notes are marked as such.
+The GPU-campaign ledger tasks **ESH-0022** and **ESH-0023** describe an older
+state ("`gpu-*` are Unknown function", "AOT runs CPU BLAS only") that is
+**partly stale** on this build — see below.
+
+---
+
+## The `gpu-*` builtins
+
+All five resolve as codegen builtins (`lib/backend/llvm_codegen.cpp`) in **both
+`-r` (JIT) and AOT** — none are "Unknown function" on this build.
+
+| Builtin | Signature | Result |
+|---------|-----------|--------|
+| `gpu-matmul` | `(gpu-matmul A B)` | ✅ `#((7 10) (15 22))` for `[[1,2],[3,4]]²`; probes Metal |
+| `gpu-elementwise` | `(gpu-elementwise OP A B)` | ✅ `(gpu-elementwise + A A)` → elementwise sum. `OP` is a **bare** `+ - * /` token (also `add`/`tensor-add` spellings), not a quoted symbol |
+| `gpu-softmax` | `(gpu-softmax t)` | ✅ `(gpu-softmax (tensor 1.0 2.0 3.0))` → `#(0.0900306 0.244728 0.665241)` |
+| `gpu-transpose` | `(gpu-transpose A)` | ✅ 2×2 → `#((1 3) (2 4))` |
+| `gpu-reduce` | `(gpu-reduce OP t)` | ⚠ **returns empty `#()`** — the reduce-all path yields an empty tensor, not a scalar. `OP` is a bare `+ mean max min` token |
+
+```scheme
+(define A (reshape (tensor 1.0 2.0 3.0 4.0) (list 2 2)))
+(gpu-matmul A A)             ;; => #((7 10) (15 22))
+(gpu-elementwise + A A)      ;; => #((2 4) (6 8))
+(gpu-reduce + (tensor 1.0 2.0 3.0 4.0))  ;; => #()   ⚠ should be 10
+```
+
+Note: `gpu-elementwise`/`gpu-reduce` take the operator as a **bare identifier**
+(`+`, not `'+`); a quoted symbol raises the "requires (gpu-… <op> …)" error.
+
+---
+
+## What actually runs on the GPU
+
+The GPU is engaged through a **cost model**, not just the `gpu-*` names. Plain
+`tensor-matmul`/`matmul` and the `gpu-*` aliases share the same dispatch in
+`lib/core/blas_backend.cpp`:
+
+- Dispatch is gated by `ESHKOL_GPU_MATMUL_THRESHOLD` (default
+  `1000000000` output elements). Below threshold → CPU BLAS/Accelerate; at or
+  above → **Metal**.
+- The Metal device is **probed and autotuned on the first matmul in both `-r`
+  and AOT** (prints ~20 `[GPU] …` config lines, including the Ozaki-II GEMM
+  pipeline). This happens even for a 2×2 — the probe fires, but small compute
+  stays on the CPU under the default threshold.
+- Forcing `ESHKOL_GPU_MATMUL_THRESHOLD=0` engages the **Metal Ozaki-II GEMM**
+  and returns correct results in **both `-r` and the AOT binary** (verified: a
+  256×256 AOT matmul prints the Metal banner and computes on-GPU).
+
+```sh
+# Force GPU dispatch for smaller matmuls
+ESHKOL_GPU_MATMUL_THRESHOLD=0 ./build/eshkol-run -r matmul.esk
+```
+
+**Bottom line for Metal:** GPU matmul is functional and dispatches in *both*
+JIT and AOT when the size threshold is met — AOT is **not** CPU-only on this
+box. This contradicts the literal wording of ESH-0022/ESH-0023.
+
+---
+
+## Ledger status vs. observed
+
+| Task | Ledger claim | Observed on this build (Metal) |
+|------|--------------|--------------------------------|
+| **ESH-0022** | `gpu-matmul`/`gpu-elementwise`/`gpu-softmax`/`gpu-reduce`/`gpu-transpose` are "Unknown function" in both paths | ✅ all five **resolve** in `-r` and AOT; 4/5 compute correctly (`gpu-reduce` returns `#()`) |
+| **ESH-0023** | AOT-compiled binary runs matmul on CPU BLAS even in a GPU build | On **Metal**, AOT matmul dispatches to the GPU when the threshold is met (verified). The task was filed against **CUDA/RTX 3050**, which is not exercised here |
+
+Treat ESH-0022/0023 as **partly resolved**: what remains genuinely pending is
+(a) the `gpu-reduce` scalar path, and (b) low-level GPU-specific low-precision
+dtype builtins on non-Metal backends.
+
+---
+
+## CUDA / XLA
+
+- **CUDA**: the CUDA runtime and cost-model dispatch exist
+  (`lib/backend/*gpu*`, GPU-campaign PRs), and lazy-init was made
+  reachable-from-language in the cross-platform campaign. ESH-0023's specific
+  observation (compiled binary at ~11% GPU util, CPU BLAS in the CUDA build)
+  was measured on an RTX 3050 and is **not re-verified here** — treat CUDA AOT
+  GPU dispatch as unconfirmed on this build.
+- **XLA/StableHLO**: an optional AOT lane (`ESHKOL_LLVM_DIS`/StableHLO config in
+  CMake). It is a build-time backend option, not a per-op runtime dispatch, and
+  is not exercised by the examples on this page.
+
+For end-to-end GPU tests and benchmarks see
+[`tests/gpu/`](../../../tests/gpu/) (matmul/reduce/transpose/softmax/elementwise
+correctness, `sf64_*` software-float kernels, CUDA host-sync regression) and
+[`benchmarks/`](../../../benchmarks/) (`gpu_matmul_bench.sh`,
+`gpu_vs_cpu_bench.esk`, `matmul_extreme.sh`).
+
+---
+
+## See also
+
+- [operations.md](operations.md) — `tensor-matmul` and the full op surface
+- [creation.md](creation.md#data-types-dtypes) — dtypes (f16/bf16/f32/f64/i8)
+- [../../breakdown/AUTODIFF.md](../../breakdown/AUTODIFF.md) — GPU gradient flow (backward pass dispatch)

--- a/docs/reference/tensors/ml-modules.md
+++ b/docs/reference/tensors/ml-modules.md
@@ -1,0 +1,114 @@
+# ML / Numerical Library Modules
+
+Three library modules built on the tensor and autodiff primitives. Unlike the
+tensor builtins, these require an explicit `(require …)`. Every `provide` is
+listed with its signature and a verified run example (outputs pasted as
+printed).
+
+---
+
+## `ml.optimization` — gradient-based optimizers
+
+```scheme
+(require ml.optimization)
+```
+
+**Provides:** `gradient-descent` `adam` `l-bfgs` `conjugate-gradient`
+`line-search` `tensor-dot` `tensor-norm`
+
+Optimizers operate on **`vector`** points and use the builtin `gradient`.
+`tensor-dot`/`tensor-norm` here are module-level vector helpers (they shadow the
+tensor builtins of the same name inside the module).
+
+| Function | Signature |
+|----------|-----------|
+| `gradient-descent` | `(gradient-descent f x0 [lr=0.01] [max-iter=1000] [tol=1e-8])` |
+| `adam` | `(adam f x0 [lr=0.001] [beta1=0.9] [beta2=0.999])` — max-iter fixed 1000, tol 1e-8 |
+| `l-bfgs` | `(l-bfgs f x0 . opts)` |
+| `conjugate-gradient` | `(conjugate-gradient f x0 . opts)` |
+| `line-search` | `(line-search f x d grad [alpha0=1.0] [c1=1e-4] [rho=0.5])` |
+| `tensor-dot` | `(tensor-dot a b)` |
+| `tensor-norm` | `(tensor-norm v)` |
+
+```scheme
+;; minimize f(v) = (v0-3)² + (v1-5)², start at (0,0)
+(define (f v)
+  (+ (* (- (vref v 0) 3.0) (- (vref v 0) 3.0))
+     (* (- (vref v 1) 5.0) (- (vref v 1) 5.0))))
+
+(gradient-descent f (vector 0.0 0.0))       ;; => #(3 5)
+(adam f (vector 0.0 0.0) 0.1)               ;; => #(3 5)   (lr=0.1)
+(tensor-dot (vector 1.0 2.0 3.0) (vector 4.0 5.0 6.0))  ;; => 32
+```
+
+> `adam`'s default learning rate is `0.001`; with the fixed 1000-iteration cap
+> that under-converges on this quadratic (returns ≈`#(0.92 0.96)`). Pass a
+> larger `lr` (e.g. `0.1`) to converge. `gradient-descent` converges with its
+> defaults.
+
+---
+
+## `core.manifold` — Riemannian geometry
+
+```scheme
+(require core.manifold)
+```
+
+**Provides:** `make-euclidean-manifold` `make-hyperbolic-manifold`
+`make-spherical-manifold` `manifold-exp-map` `manifold-log-map`
+`manifold-distance` `manifold-parallel-transport` `manifold-curvature`
+`manifold-dimension` `manifold-type` `metric-component` `manifold-metric`
+`manifold-metric-inverse` `christoffel-symbol` `manifold-christoffel`
+`manifold-sectional-curvature` `manifold-scalar-curvature` `ricci-component`
+`manifold-ricci` `riemann-component`
+
+| Function | Signature |
+|----------|-----------|
+| `make-euclidean-manifold` / `make-hyperbolic-manifold` / `make-spherical-manifold` | `(make-…-manifold dim)` |
+| `manifold-type` | `(manifold-type m)` → `euclidean` / `hyperbolic` / `spherical` |
+| `manifold-dimension` | `(manifold-dimension m)` |
+| `manifold-curvature` | `(manifold-curvature m)` → `0` / `-1` / `1` |
+| `manifold-distance` | `(manifold-distance m a b)` |
+| `manifold-exp-map` | `(manifold-exp-map m base v)` |
+
+```scheme
+(define e (make-euclidean-manifold 3))
+(define h (make-hyperbolic-manifold 2))
+(manifold-type e)         ;; => euclidean
+(manifold-dimension e)    ;; => 3
+(manifold-curvature h)    ;; => -1
+```
+
+Curvatures: euclidean `0`, hyperbolic `-1`, spherical `1`. The module also
+exposes the metric tensor, Christoffel symbols, and sectional/scalar/Ricci/
+Riemann curvature accessors listed above.
+
+---
+
+## `signal.fft` — Fast Fourier Transform
+
+```scheme
+(require signal.fft)
+```
+
+**Provides:** `fft` `ifft`
+
+Radix-2 Cooley-Tukey. `fft` accepts a real or complex `vector` whose length is a
+**power of 2** and returns a complex-valued vector; `ifft` inverts it.
+
+```scheme
+(define s (vector 1.0 2.0 3.0 4.0))
+(fft s)          ;; => #(10 -2+2i -2 -2-2i)
+(ifft (fft s))   ;; => #(1 2+5.72119e-18i 3 4-5.72119e-18i)
+```
+
+The forward transform is exact; the inverse round-trips to the input up to a
+~1e-18 imaginary residue (floating-point round-off).
+
+---
+
+## See also
+
+- [operations.md](operations.md) — the tensor builtins these modules build on
+- [../ad/operators.md](../ad/operators.md) — the `gradient` the optimizers call
+- [creation.md](creation.md) — vector vs tensor

--- a/docs/reference/tensors/operations.md
+++ b/docs/reference/tensors/operations.md
@@ -1,0 +1,283 @@
+# Tensor Operations Reference
+
+Signatures and outputs below are verified on the v1.3.0 compiler. Every tensor
+operation is a **codegen builtin** — no `(require …)` is needed for anything on
+this page (the library modules are separate; see
+[ml-modules.md](ml-modules.md)). Outputs are pasted as printed by `display`
+(whole doubles print without a decimal point, e.g. `3.0` → `3`).
+
+Known-broken operations are called out inline with a **⚠ BUG** marker and
+summarized in [Known limitations](#known-limitations).
+
+---
+
+## Shape operations
+
+| Op | Signature | Example → output |
+|----|-----------|------------------|
+| `tensor-shape` | `(tensor-shape t)` | 2×3 → `(2 3)` |
+| `tensor-reshape` / `reshape` | `(tensor-reshape t shape-list)` | `(reshape (tensor 1.0 2.0 3.0 4.0) (list 2 2))` → `#((1 2) (3 4))` |
+| `tensor-transpose` / `transpose` | `(tensor-transpose t)` | 2×3 → `#((1 4) (2 5) (3 6))` |
+| `tensor-length` | `(tensor-length t)` | total element count → `4` |
+| `tensor-ref` | `(tensor-ref t i)` | flat index → `20` |
+| `tensor-get` | `(tensor-get t i j …)` | multi-index → `3` |
+| `tensor-set!` / `tensor-set` | `(tensor-set! t i v)` | mutates in place → `#(1 99 3)` |
+| `tensor-data` | `(tensor-data t)` | underlying data → `#(1 2 3)` |
+| `tensor-dtype` | `(tensor-dtype t)` | → `f64` |
+
+`tensor-reshape` and `reshape` take the shape as a **list** (`(list 2 2)` or
+`'(2 2)`).
+
+---
+
+## Elementwise & unary math
+
+All binary elementwise ops require two tensors of matching shape and return a
+new tensor:
+
+```scheme
+(tensor-add (tensor 1.0 2.0) (tensor 3.0 4.0))   ;; => #(4 6)
+(tensor-sub (tensor 5.0 5.0) (tensor 1.0 2.0))   ;; => #(4 3)
+(tensor-mul (tensor 2.0 3.0) (tensor 4.0 5.0))   ;; => #(8 15)
+(tensor-div (tensor 8.0 6.0) (tensor 2.0 2.0))   ;; => #(4 3)
+(tensor-maximum (tensor 1.0 5.0) (tensor 3.0 2.0)) ;; => #(3 5)
+(tensor-minimum (tensor 1.0 5.0) (tensor 3.0 2.0)) ;; => #(1 2)
+```
+
+Scalar-broadcast and unary:
+
+```scheme
+(tensor-scale (tensor 1.0 2.0 3.0) 10.0)   ;; => #(10 20 30)
+(tensor-neg (tensor 1.0 -2.0))             ;; => #(-1 2)
+(tensor-abs (tensor -1.0 2.0 -3.0))        ;; => #(1 2 3)
+(tensor-exp (tensor 0.0 1.0))              ;; => #(1 2.71828)
+(tensor-log (tensor 1.0 2.71828))          ;; => #(0 1)
+(tensor-sqrt (tensor 4.0 9.0))             ;; => #(2 3)
+(tensor-sin (tensor 0.0))                  ;; => #(0)
+(tensor-cos (tensor 0.0))                  ;; => #(1)
+```
+
+> **`tensor-pow` takes a tensor exponent, not a scalar** — it is fully
+> element-wise:
+>
+> ```scheme
+> (tensor-pow (tensor 2.0 3.0) (tensor 2.0 2.0))  ;; => #(4 9)
+> (tensor-pow (tensor 2.0 3.0) 2.0)               ;; ERROR: expected tensor, got integer
+> ```
+
+---
+
+## Linear algebra
+
+| Op | Signature | Example → output |
+|----|-----------|------------------|
+| `tensor-dot` | `(tensor-dot a b)` | `#(1 2 3)·#(4 5 6)` → `32` |
+| `tensor-matmul` / `matmul` | `(tensor-matmul A B)` | 2×2·2×2 → `#((19 22) (43 50))` |
+| `batch-matmul` | `(batch-matmul A B)` | batched (2 args) → batched product |
+| `tensor-norm` | `(tensor-norm v)` | `#(3 4)` → `5` |
+| `tensor-inverse` | `(tensor-inverse A)` | 2×2 inverse |
+| `tensor-det` | `(tensor-det A)` | → `10` |
+| `tensor-solve` | `(tensor-solve A b)` | solves `Ax=b` → `#(2 3)` |
+| `tensor-cholesky` | `(tensor-cholesky A)` | lower-triangular `L` |
+| `tensor-lu` | `(tensor-lu A)` | **list** `(LU pivot sign)` |
+| `tensor-qr` | `(tensor-qr A)` | **list** `(Q R)` |
+| `tensor-svd` | `(tensor-svd A)` | **list** `(U S V)` |
+| `tensor-cast` | `(tensor-cast t 'f32)` | dtype conversion (see [creation.md](creation.md#data-types-dtypes)) |
+
+The three decompositions return **lists of tensors**, e.g.
+`(tensor-svd A)` → `(U S V)`. `matmul` (and `gpu-matmul`) route through the
+cost-model dispatch and may run on the GPU (see [gpu.md](gpu.md));
+`batch-matmul` is a separate CPU path.
+
+```scheme
+(tensor-matmul (reshape (tensor 1.0 2.0 3.0 4.0) (list 2 2))
+               (reshape (tensor 5.0 6.0 7.0 8.0) (list 2 2)))
+;; => #((19 22) (43 50))
+```
+
+---
+
+## Reductions
+
+| Op | Signature | Example → output |
+|----|-----------|------------------|
+| `tensor-sum` | `(tensor-sum t)` | `#(1 2 3 4)` → `10` |
+| `tensor-mean` | `(tensor-mean t)` | → `2.5` |
+| `tensor-max` / `tensor-min` | `(tensor-max t)` | `#(1 5 3)` → `5` / `1` |
+| `tensor-argmax` / `tensor-argmin` | `(tensor-argmax t)` | → `1` / `0` |
+| `tensor-std` | `(tensor-std t)` | population (÷N) → `1.11803` |
+| `tensor-var` | `(tensor-var t)` | population (÷N) → `1.25` |
+| `tensor-reduce` | `(tensor-reduce t proc init)` | `(tensor-reduce t + 0.0)` → `10` |
+| `tensor-reduce-all` | `(tensor-reduce-all t proc init)` | → `10` |
+| `tensor-cov` | `(tensor-cov a b)` | two 1-D tensors → `0.666667` |
+| `tensor-corrcoef` | `(tensor-corrcoef a b)` | two 1-D tensors → `1` |
+
+`tensor-std`/`tensor-var` use the **population** normalization (divide by N).
+`tensor-cov`/`tensor-corrcoef` take **two 1-D tensors** (not one 2-D matrix).
+
+---
+
+## Convolution & pooling
+
+| Op | Signature | Status |
+|----|-----------|--------|
+| `conv1d` | `(conv1d input kernel stride)` | ✅ `(conv1d #(1 2 3 4 5) #(1 1) 1)` → `#(3 5 7 9)` |
+| `conv2d` | `(conv2d input kernel stride)` | ✅ single scalar `stride`, VALID padding, batch-preserving (PR #80 unified VM/codegen) |
+| `conv3d` | `(conv3d input kernel)` | ✅ (no stride argument) |
+| `max-pool2d` | `(max-pool2d input kernel-size stride)` | ✅ 4×4 `2 2` → `#((6 8) (14 16))` |
+| `avg-pool2d` | `(avg-pool2d input kernel-size stride)` | ✅ 4×4 `2 2` → `#((3.5 5.5) (11.5 13.5))` |
+
+```scheme
+;; 3×3 ⊛ 2×2 diagonal kernel, stride 1, VALID padding
+(conv2d (reshape (make-tensor (list 3 3) 1.0) (list 3 3))
+        (reshape (tensor 1.0 0.0 0.0 1.0) (list 2 2)) 1)
+;; => #((2 2) (2 2))
+```
+
+The pooling ops are named `max-pool2d` / `avg-pool2d` (with the `2d` suffix).
+
+---
+
+## Normalization, attention, embedding
+
+| Op | Signature | Status |
+|----|-----------|--------|
+| `batch-norm` | `(batch-norm input gamma beta epsilon [axis])` | ⚠ **BUG** — produces garbage denormals; 5-arg form SIGSEGVs |
+| `layer-norm` | `(layer-norm input gamma beta epsilon [axis])` | ⚠ **BUG** — same garbage-denormal / SIGSEGV failure |
+| `multi-head-attention` | `(multi-head-attention Q K V num-heads W_Q W_K W_V W_O [mask])` | ✅ forward pass runs (8–9 args) |
+| `embedding` | `(embedding indices weights)` | ✅ `idx #(0 2)`, 3×2 weights → the selected rows |
+| `positional-encoding` | `(positional-encoding max-len d-model)` | ✅ sinusoidal, exactly 2 args |
+| `dropout` | `(dropout tensor drop-prob)` | ✅ 2 args; `(dropout #(1 2 3) 0.0)` → `#(1 2 3)` |
+| `softmax` | `(softmax tensor [axis])` | ✅ `(softmax #(1 2 3))` → `#(0.0900306 0.244728 0.665241)` |
+
+> ⚠ **`batch-norm` and `layer-norm` are broken on this build.** The 4-argument
+> form writes int64 bit-patterns into the output buffer instead of computed
+> floats (`(layer-norm #(1.0 2.0 3.0 4.0) #(1.0 …) #(0.0 …) 1e-5)` →
+> `#(-8.8e-315 1.4e-314 …)`), and passing the optional 5th `axis` argument
+> **SIGSEGVs**. This is a codegen bug in both norms; do not rely on them for
+> training. **Attention backward** is also a passthrough stub in the tensor
+> backward pass — see
+> [../../breakdown/AUTODIFF.md](../../breakdown/AUTODIFF.md) "v1.1 AD
+> Extensions".
+
+---
+
+## Activations
+
+Most activations are **tensor-only** and raise a catchable type error on a
+scalar argument:
+
+```scheme
+(relu (tensor -1.0 2.0 -3.0))    ;; => #(0 2 0)
+(sigmoid (tensor 0.0))           ;; => #(0.5)
+(gelu (tensor 0.0 1.0))          ;; => #(0 0.841192)
+(leaky-relu (tensor -2.0 3.0))   ;; => #(-0.02 3)   (α = 0.01)
+(silu (tensor 0.0 1.0))          ;; => #(0 0.731059)
+(relu -5.0)                      ;; ERROR: Type error in relu: expected tensor
+```
+
+> **`tanh` is the exception — it is scalar-only.** `(tanh 0.0)` → `0`, but
+> `(tanh (tensor 0.0 1.0))` silently returns a wrong scalar (`1`) instead of a
+> tensor, because `tanh` dispatches to the scalar math path before the tensor
+> path. Use `tensor-apply`/elementwise for a tanh over a tensor.
+
+---
+
+## Type guards (PR #79)
+
+Every tensor operation routes its operands through a single runtime choke point
+(`eshkol_tensor_operand_checked`, `lib/backend/tensor_codegen.cpp`). A
+wrong-typed operand raises a **catchable** exception (not a crash), naming the
+op and the offending type:
+
+```scheme
+(tensor-add (tensor 1.0 2.0) "not-a-tensor")
+;; ERROR: Type error in tensor-add: expected tensor, got string   (and raises)
+
+(guard (e (#t (display "caught") (newline)))
+  (tensor-add (tensor 1.0 2.0) "not-a-tensor"))
+;; prints: caught
+```
+
+The exception is catchable via `guard` and `with-exception-handler`. One
+cosmetic caveat: a raw **double** operand is reported as `got integer` (the
+guard tags any untagged scalar as INT64).
+
+> **Creation is not guarded.** `(tensor 1.0 "x" 3.0)` does *not* raise — it
+> reinterprets the string pointer as a double and yields garbage. Build tensors
+> from numeric literals only. Mixing integer and float arguments in
+> `tensor`/`make-tensor` can also trigger shape-mode misinterpretation
+> (leading integers are read as a shape); prefer all-float element lists or
+> `(make-tensor '(shape) fill)` with a quoted-list shape.
+
+---
+
+## Pixel fills
+
+Native C-runtime fills for 2-D/3-D framebuffers (~7 µs/frame for compose-heavy
+rendering):
+
+```scheme
+;; half-open rectangle [row0,row1) × [col0,col1)
+(tensor-rect-fill! fb 1 1 3 3 9.0)   ;; fills the 2×2 block at (1,1)
+
+;; filled disk of given radius centered at (cy,cx)
+(tensor-disk-fill! fb 2 2 1 7.0)     ;; radius-1 disk centered at (2,2)
+```
+
+Note the rectangle's **exclusive** upper bounds: to fill a 2×2 block starting
+at (1,1) use `1 1 3 3`.
+
+---
+
+## Save / load
+
+```scheme
+(tensor-save "path.bin" t)   ;; arg order is (PATH TENSOR); returns #t
+(tensor-load "path.bin")     ;; ⚠ BUG — see below
+```
+
+`tensor-save` writes a correct binary file (magic `TKSE`, IEEE-754 element
+bit-patterns) and returns `#t`. **The argument order is `(path, tensor)`.**
+
+> ⚠ **`tensor-load` loses the shape.** After a save/load round-trip the element
+> data and count survive (`tensor-length` → 4, `tensor-dtype` → `f64`) but the
+> shape metadata is dropped: the loaded tensor displays as `#()` and
+> `tensor-shape` returns `(0)`. The loader reads the shape header but never
+> copies the dimensions into the tensor's `dimensions[]` array. Round-trip is
+> effectively broken until this is fixed.
+
+---
+
+## GPU-labeled builtins
+
+`gpu-matmul`, `gpu-elementwise`, `gpu-softmax`, `gpu-transpose`, `gpu-reduce`
+all **resolve** and run. See [gpu.md](gpu.md) for signatures, honest Metal/CUDA
+dispatch status, and the `gpu-reduce` empty-result caveat.
+
+---
+
+## Known limitations
+
+| Operation | Issue |
+|-----------|-------|
+| `batch-norm`, `layer-norm` | garbage denormal output (4-arg); SIGSEGV (5-arg `axis`) |
+| `tensor-load` | drops shape metadata (`tensor-shape` → `(0)`, displays `#()`); data/length survive |
+| `gpu-reduce` | returns empty `#()` instead of a scalar ([gpu.md](gpu.md)) |
+| `tanh` | scalar-only; silently wrong on a tensor argument |
+| `tensor-pow` | requires a **tensor** exponent, not a scalar |
+| tensor creation | no element type-check (`(tensor 1.0 "x")` → garbage); int+float args misread as shape |
+| type-guard text | reports raw doubles as `integer` |
+| attention/embedding backward | passthrough stubs (see AUTODIFF.md) |
+
+These are current-build facts, reported for honesty — none are fixed by this
+documentation.
+
+---
+
+## See also
+
+- [creation.md](creation.md) — vector vs tensor, dtypes
+- [gpu.md](gpu.md) — GPU dispatch honest status
+- [ml-modules.md](ml-modules.md) — `ml.optimization`, `core.manifold`, `signal.fft`
+- [../ad/INDEX.md](../ad/INDEX.md) — autodiff through tensor operations


### PR DESCRIPTION
## Summary

Adds a complete, **machine-verified** reference for Eshkol's autodiff and
tensor/ML surface under `docs/reference/`, built on the truth-fixed
`docs/breakdown/AUTODIFF.md` (#111) without contradicting it. Every signature,
example, and output was produced by running the v1.3.0 compiler (JIT `-r` and
AOT); open bugs are documented against their ledger ids, never aspirational.

### `docs/reference/ad/`
- **operators.md** — `derivative`, `gradient`, `jacobian`, `hessian`,
  `laplacian`, `directional-derivative`, `divergence`, `curl`, `diff`:
  signatures, accepted point types (scalar/vector/tensor/multi-param), binding
  forms, capture rules, and composition/nesting.
- **architecture.md** — the forward 4-component Taylor jet (`{primal,d1,d2,d12}`,
  two perturbation slots, perturbation-confusion cure), the runtime
  `__ad_pert_level` counter, reverse tape, the v1.3 mixed reverse-over-forward
  mode (#113 / ESH-0093), numeric boundary, and measured performance.
- **support-matrix.md** — mirrors the AD composition oracle (214 probes / 440
  checks): gate PASS at 46 PASS / 34 XKNOWN / 0 FAIL, all open cells
  (ESH-0072/0078/0095/0096/0097), and how to run `scripts/run_ad_oracle.sh`.
- **INDEX.md**

### `docs/reference/tensors/`
- **creation.md** — `vector` (heterogeneous 16-byte tagged) vs `tensor`
  (homogeneous 8-byte doubles), literals, `make-tensor`/`make-vector`, dtypes
  (f16/bf16/f32/f64/i8).
- **operations.md** — shape ops, elementwise/unary, linalg + LU/QR/SVD/Cholesky,
  reductions, conv1d/2d/3d, pooling, normalization, attention, embedding,
  activations, PR-#79 type guards, pixel fills, save/load. Known-broken ops
  flagged inline.
- **gpu.md** — honest Metal/CUDA/XLA status; the `gpu-*` builtins; cost-model
  threshold; ESH-0022/0023 reconciliation.
- **ml-modules.md** — `ml.optimization`, `core.manifold`, `signal.fft`: every
  `provide` with signature + run example.
- **INDEX.md**

## Verification

- Built `eshkol-run` + `stdlib` from this branch's code (identical to
  `origin/master` — the intervening commits touch only test/infra, no `lib/`).
- AD oracle: `total=80 passed=46 xknown=34 failed=0 crashed=0 hung=0`, gate PASS
  (JIT + AOT identical).
- Mixed-mode AD test (ESH-0093 / #113): 15/15.
- Every example on every page re-run against the branch binary; outputs pasted.

## Discrepancies found while verifying (reported, not fixed here)

- **ESH-0078 not fully fixed** despite the ledger marking it merged via #95:
  `(gradient (lambda (y) (gradient L y)) 3.0)` still returns `0` for a *named*
  inner function (inline lambda returns the correct `18`).
- **AUTODIFF.md "Higher-Order Derivatives"** shows the vector-param
  gradient-of-gradient returning `#(12.0)`; it returns `#(0)` on this build
  (ESH-0096). Noted as a caveat in support-matrix.md.
- **Vector/tensor-valued `derivative` returns `0`** (ℝ→ℝⁿ not supported), though
  AUTODIFF.md:482 shows it working.
- **`batch-norm` / `layer-norm`**: garbage denormal output (4-arg); SIGSEGV
  (5-arg `axis`).
- **`tensor-load`** drops shape metadata (`tensor-shape` → `(0)`; data/length
  survive); `tensor-save` arg order is `(path, tensor)`.
- **`gpu-reduce`** returns empty `#()` instead of a scalar.
- **`tanh`** is scalar-only and silently wrong on a tensor (all other
  activations are tensor-only).
- **`tensor-pow`** needs a tensor exponent, not a scalar.
- **ESH-0022/0023 partly stale**: the `gpu-*` builtins resolve in `-r` and AOT,
  and Metal matmul dispatches in both modes when the threshold is met — AOT is
  not CPU-only on Metal.
- Tensor creation has no element type-check; int+float args in
  `tensor`/`make-tensor` get misread as a shape.
