### PR TITLE
docs(platform): Windows 11 x64 KVM guest scaffolding for mesh testing

### DIFF
--- a/docs/platform/WINDOWS_X86_KVM.md
+++ b/docs/platform/WINDOWS_X86_KVM.md
@@ -1,0 +1,79 @@
+# Windows 11 x64 test VM on Linux KVM (old-donkey / cosbox)
+
+Status as of 2026-07-03: **scaffolding provisioned on old-donkey; awaiting a
+Windows 11 installer ISO** (manual download step below). No VM has been booted
+yet.
+
+The mesh has no native Windows x64 CI runner. jack-blupc covers Windows x64
+bare-metal, but a KVM guest on the Linux x64 nodes gives us a reproducible,
+snapshotable Windows environment for release testing.
+
+## Host inventory
+
+| Host | KVM | QEMU | OVMF (secure boot) | swtpm | Free disk | Fit |
+|------|-----|------|--------------------|-------|-----------|-----|
+| old-donkey | yes (user in `kvm`,`libvirt`) | 8.2.2 | yes (`OVMF_*_4M.ms.fd`) | yes | 358 G | **primary** |
+| cosbox | yes (device present, user NOT in `kvm` group) | 8.2.2 + virt-install | yes | untested | 21 G (96% full) | fallback only |
+
+old-donkey note: outbound HTTPS to `github.com` and `vlscppe.microsoft.com`
+is blocked from this host; general internet (e.g. `microsoft.com`) works.
+Transfer files over SSH/scp from another mesh node when needed.
+
+## What is already provisioned (old-donkey)
+
+```
+~/vms/win11-x64/
+  win11.qcow2        # 80 G thin qcow2 system disk (empty)
+  OVMF_VARS.fd       # writable UEFI vars, copied from OVMF_VARS_4M.ms.fd
+  start-win11.sh     # launch script (same as scripts/platform/start-win11-kvm.sh)
+```
+
+The launch script (`scripts/platform/start-win11-kvm.sh`) boots a q35 machine
+with KVM acceleration, secure-boot OVMF, an emulated TPM 2.0 (swtpm) — the
+Windows 11 hardware requirements — plus an AHCI disk and e1000 NIC so the
+stock Windows installer needs no extra drivers. It forwards guest SSH to host
+port 22222 and serves the console on VNC display `:11` (localhost only).
+
+## Remaining manual steps
+
+1. **Download the installer ISO** (requires an interactive browser; Microsoft's
+   download API rejects non-browser sessions):
+   - Visit <https://www.microsoft.com/en-us/software-download/windows11>
+   - Select "Windows 11 (multi-edition ISO for x64 devices)", language
+     "English (United States)", and download (~6.5 GB).
+   - Copy it to the host: `scp Win11_*.iso old-donkey:~/vms/win11-x64/`
+2. **First boot / install**:
+   ```
+   ssh old-donkey
+   cd ~/vms/win11-x64
+   ./start-win11.sh ~/vms/win11-x64/Win11_*.iso
+   ```
+   Tunnel VNC from your workstation: `ssh -L 5911:localhost:5911 old-donkey`,
+   then connect a VNC client to `localhost:5911`. Press a key at the "Press any
+   key to boot from CD" prompt.
+3. **Inside Windows**: complete setup (a local account is fine), then
+   - `Settings > System > Optional features > OpenSSH Server` (or
+     `Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0`), start the
+     `sshd` service and set it to automatic. The guest is then reachable with
+     `ssh -p 22222 <user>@localhost` from old-donkey.
+4. **Toolchain for Eshkol CI-equivalent runs** (mirrors `.github/workflows/ci.yml`):
+   - Visual Studio 2022 Build Tools with the "Desktop development with C++"
+     workload, CMake, Git.
+   - LLVM SDK: `clang+llvm-21.1.8-x86_64-pc-windows-msvc.tar.xz` from
+     `https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.8`,
+     extracted to `C:\src\` (exactly what CI's "Install LLVM SDK" step does).
+   - Configure/build/test with the same commands as the `windows-*` CI lanes
+     (`-G 'Visual Studio 17 2022' -A x64 -T ClangCL`, then
+     `scripts\run_all_tests.ps1 -BuildDir .\build -SkipConfigureBuild`).
+5. **Optional performance**: install the virtio-win driver ISO
+   (<https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/>) and
+   switch the disk to `if=virtio` / NIC to `virtio-net-pci` in the launch
+   script after drivers are in.
+6. **Snapshot before experiments**: `qemu-img snapshot -c clean-install
+   ~/vms/win11-x64/win11.qcow2` (with the VM shut down).
+
+## cosbox caveats
+
+cosbox has the QEMU/OVMF stack but `tyr` is not in the `kvm` group (needs
+`sudo usermod -aG kvm tyr` + re-login) and the disk is 96% full — clear space
+before hosting a VM there.

--- a/scripts/platform/start-win11-kvm.sh
+++ b/scripts/platform/start-win11-kvm.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Launch the Windows 11 x64 KVM guest on old-donkey (or any Linux KVM host
+# with OVMF + swtpm installed). First boot: pass the installer ISO as $1.
+#
+#   ./start-win11.sh ~/vms/win11-x64/Win11_25H2_English_x64.iso   # install
+#   ./start-win11.sh                                              # normal boot
+#
+# Console: VNC on localhost:5911 (tunnel with `ssh -L 5911:localhost:5911 old-donkey`).
+# After install, enable OpenSSH Server inside Windows for headless use.
+set -euo pipefail
+
+VMDIR="$HOME/vms/win11-x64"
+ISO="${1:-}"
+
+# Software TPM 2.0 (Windows 11 hard requirement)
+mkdir -p "$VMDIR/tpm"
+if ! pgrep -f "swtpm socket.*$VMDIR/tpm" >/dev/null; then
+    swtpm socket --tpm2 \
+        --tpmstate dir="$VMDIR/tpm" \
+        --ctrl type=unixio,path="$VMDIR/tpm/swtpm-sock" \
+        --daemon
+fi
+
+ISO_ARGS=()
+if [ -n "$ISO" ]; then
+    ISO_ARGS+=(-drive "file=$ISO,media=cdrom,if=none,id=cd0" -device "usb-storage,drive=cd0")
+fi
+
+exec qemu-system-x86_64 \
+    -machine q35,accel=kvm,smm=on \
+    -cpu host \
+    -smp 8 -m 16G \
+    -global driver=cfi.pflash01,property=secure,value=on \
+    -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.ms.fd \
+    -drive if=pflash,format=raw,file="$VMDIR/OVMF_VARS.fd" \
+    -chardev socket,id=chrtpm,path="$VMDIR/tpm/swtpm-sock" \
+    -tpmdev emulator,id=tpm0,chardev=chrtpm \
+    -device tpm-tis,tpmdev=tpm0 \
+    -drive "file=$VMDIR/win11.qcow2,if=ide,format=qcow2,discard=unmap" \
+    -device usb-ehci -device usb-tablet \
+    -nic user,model=e1000,hostfwd=tcp::22222-:22 \
+    -vga std \
+    -vnc 127.0.0.1:11 \
+    "${ISO_ARGS[@]}"


### PR DESCRIPTION
Adds the launch script and runbook for a Windows 11 x64 QEMU/KVM test guest on the Linux x64 mesh nodes.

- `scripts/platform/start-win11-kvm.sh`: q35/KVM with secure-boot OVMF and swtpm TPM 2.0 (Windows 11 hardware requirements), stock-driver devices (AHCI + e1000), guest SSH forwarded to host :22222, VNC console on localhost:11.
- `docs/platform/WINDOWS_X86_KVM.md`: host inventory (old-donkey primary: kvm+libvirt groups, OVMF/swtpm present, 358G free; cosbox fallback with caveats), what is already provisioned on old-donkey (80G qcow2, MS UEFI vars, script installed), and the exact remaining manual steps — the installer ISO requires an interactive browser download, and the in-guest toolchain mirrors the windows CI lanes (VS2022 Build Tools + ClangCL + LLVM 21.1.8 SDK at C:\src).

Status: scaffolding is live on old-donkey; no VM booted yet (awaiting ISO).