### PR TITLE
fix(codegen): release sweep D — user-global symbol mangling (libc collisions), char preservation through apply/write

### DIFF
--- a/lib/backend/binding_codegen.cpp
+++ b/lib/backend/binding_codegen.cpp
@@ -49,8 +49,42 @@ static std::string replVarStorageSymbolName(const std::string& name) {
     return out;
 }
 
-static std::string bindingStorageName(const std::string& name, bool is_repl) {
-    return is_repl ? replVarStorageSymbolName(name) : name;
+// User-program globals must never be emitted under their raw Scheme name, or a
+// name like `free`/`malloc`/`exit` collides with the C runtime symbol at
+// JIT/AOT link (SIGBUS at teardown) and a name like `log`/`sin` clashes with an
+// in-module libm function declaration (LLVM auto-renames, `set!` and reads end
+// up on different `@log.N` slots -> lost mutations on cached-JIT/AOT). Mangle
+// so the symbol can never equal a C/libm symbol. See ESH-0092/0103. Must stay
+// byte-identical to llvm_codegen.cpp::userGlobalStorageName so the pre-declared
+// storage and the define/store paths agree on the same GlobalVariable.
+//   is_repl   -> private REPL storage (hot-reload aware)
+//   is_public -> raw name (library `provide` bindings / `:external` refs that
+//                bind cross-object to stdlib.o)
+//   otherwise -> `eshkol_g_`-prefixed, encoded.
+static std::string userGlobalStorageName(const std::string& name,
+                                         bool is_repl, bool is_public) {
+    if (is_repl) {
+        return replVarStorageSymbolName(name);
+    }
+    if (is_public) {
+        return name;
+    }
+    std::string out = "eshkol_g_";
+    char encoded[4];
+    for (unsigned char ch : name) {
+        if (std::isalnum(ch)) {
+            out.push_back(static_cast<char>(ch));
+        } else {
+            std::snprintf(encoded, sizeof(encoded), "_%02X", ch);
+            out += encoded;
+        }
+    }
+    return out;
+}
+
+static std::string bindingStorageName(const std::string& name, bool is_repl,
+                                      bool is_public) {
+    return userGlobalStorageName(name, is_repl, is_public);
 }
 
 static void emitReplVarMarker(CodegenContext& ctx, const std::string& name) {
@@ -150,7 +184,7 @@ Value* BindingCodegen::storeBinding(
 
     if (is_global) {
         bool is_repl = isReplMode(repl_mode_);
-        std::string storage_name = bindingStorageName(name, is_repl);
+        std::string storage_name = bindingStorageName(name, is_repl, /*is_public=*/false);
         // Create or get GlobalVariable
         GlobalVariable* gv = ctx_.module().getNamedGlobal(storage_name);
         if (!gv) {
@@ -268,7 +302,11 @@ Value* BindingCodegen::define(const eshkol_operations_t* op) {
          current_name.starts_with("__eshkol_lib_init_chunk_"));
     bool is_repl = isReplMode(repl_mode_);
     bool is_main = current && current->getName() == "main";
-    const std::string var_storage_name = bindingStorageName(var_name, is_repl);
+    // Library `provide` bindings (compiled inside __eshkol_lib_init*) keep their
+    // raw public name for cross-object linking; genuine user globals are mangled
+    // so they can never collide with a C/libm symbol (ESH-0092/0103).
+    const std::string var_storage_name =
+        bindingStorageName(var_name, is_repl, is_lib_init);
     GlobalVariable* existing_global = ctx_.module().getNamedGlobal(var_storage_name);
     // Top-level defines in main should always be global, not local
     bool use_global = !current || is_global_init || is_lib_init || is_repl || is_main;
@@ -299,7 +337,7 @@ Value* BindingCodegen::define(const eshkol_operations_t* op) {
                         false,
                         is_lib_init ? GlobalValue::LinkOnceODRLinkage : GlobalValue::ExternalLinkage,
                         zero_init,
-                        var_name
+                        var_storage_name
                     );
                     gv->setAlignment(Align(16));
                 }
@@ -415,7 +453,7 @@ Value* BindingCodegen::define(const eshkol_operations_t* op) {
                     false,
                     is_lib_init ? GlobalValue::LinkOnceODRLinkage : GlobalValue::ExternalLinkage,
                     zero_init,
-                    var_name
+                    var_storage_name
                 );
                 gv->setAlignment(Align(16));
             }
@@ -1319,9 +1357,13 @@ Value* BindingCodegen::lookupVariable(const std::string& name) {
         }
     }
 
-    // Check module globals. In REPL mode the LLVM symbol is deliberately
-    // private so user variables can shadow host/runtime function names.
-    const std::string storage_name = bindingStorageName(name, isReplMode(repl_mode_));
+    // Check module globals. The user-variable LLVM symbol is deliberately
+    // mangled (REPL: __repl_storage_*, otherwise: eshkol_g_*) so a user
+    // variable can shadow a host/runtime function name without colliding
+    // (ESH-0092/0103). Try the mangled name first, then fall back to the raw
+    // name which backs library `provide` / `:external` public bindings.
+    const std::string storage_name =
+        bindingStorageName(name, isReplMode(repl_mode_), /*is_public=*/false);
     GlobalVariable* gv = ctx_.module().getNamedGlobal(storage_name);
     if (gv) {
         return gv;

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -780,6 +780,42 @@ namespace {
         return out;
     }
 
+    // Compute the LLVM symbol name used to back a top-level user variable's
+    // storage. User-program globals MUST NOT be emitted under their raw Scheme
+    // name: a name like `free`/`malloc`/`exit` would collide with the C runtime
+    // symbol at JIT/AOT link (calling data as code -> SIGBUS at teardown), and a
+    // name like `log`/`sin` would clash with an in-module libm function
+    // declaration (LLVM auto-renames the GlobalVariable, and two creation sites
+    // then produce two distinct `@log.N` slots — a `set!` writes one while a
+    // read sees the other, so mutations are silently lost on cached-JIT/AOT).
+    // Mangling the symbol removes the whole collision class. See ESH-0092/0103.
+    //
+    //   is_repl   -> private REPL storage (`__repl_storage_*`, hot-reload aware)
+    //   is_public -> raw name (library `provide` bindings and `:external`
+    //                references, which must bind cross-object to stdlib.o)
+    //   otherwise -> `eshkol_g_`-prefixed, encoded so it can never equal a
+    //                C/libm symbol.
+    static std::string userGlobalStorageName(const std::string& name,
+                                             bool is_repl, bool is_public) {
+        if (is_repl) {
+            return replVarStorageSymbolName(name);
+        }
+        if (is_public) {
+            return name;
+        }
+        std::string out = "eshkol_g_";
+        char encoded[4];
+        for (unsigned char ch : name) {
+            if (std::isalnum(ch)) {
+                out.push_back(static_cast<char>(ch));
+            } else {
+                std::snprintf(encoded, sizeof(encoded), "_%02X", ch);
+                out += encoded;
+            }
+        }
+        return out;
+    }
+
     static void seedTypeCheckerWithReplFunctions(
         eshkol::hott::TypeChecker& type_checker,
         eshkol::hott::TypeEnvironment& type_env) {
@@ -2590,10 +2626,14 @@ public:
                 if (asts_to_use[i].type == ESHKOL_OP && asts_to_use[i].operation.op == ESHKOL_DEFINE_OP &&
                     !asts_to_use[i].operation.define_op.is_function) {
                     const char* var_name = asts_to_use[i].operation.define_op.name;
-                    std::string storage_name = var_name ? std::string(var_name) : std::string();
-                    if (g_repl_mode_enabled && var_name) {
-                        storage_name = replVarStorageSymbolName(var_name);
-                    }
+                    // `:external` references and library `provide` bindings keep
+                    // their raw public name so they bind cross-object to
+                    // stdlib.o; genuine user globals are mangled (ESH-0092/0103).
+                    bool is_public_pre =
+                        asts_to_use[i].operation.define_op.is_external || library_mode;
+                    std::string storage_name = var_name
+                        ? userGlobalStorageName(var_name, g_repl_mode_enabled, is_public_pre)
+                        : std::string();
                     if (var_name && !module->getNamedGlobal(storage_name)) {
                         GlobalVariable* global_var = nullptr;
                         if (g_repl_mode_enabled) {
@@ -11645,7 +11685,10 @@ private:
                         global_var = dyn_cast<GlobalVariable>(sym_it->second);
                     }
                     if (!global_var) {
-                        global_var = module->getNamedGlobal(var_name);
+                        // Mangle user globals so `free`/`log`/... never collide
+                        // with a C/libm symbol (ESH-0092/0103).
+                        global_var = module->getNamedGlobal(
+                            userGlobalStorageName(var_name, is_repl_eval, library_mode));
                     }
                     if (global_var) {
                         // Use existing pre-declared global variable
@@ -11655,10 +11698,8 @@ private:
                         GlobalValue::LinkageTypes linkage = is_repl_eval
                             ? GlobalValue::WeakAnyLinkage
                             : GlobalValue::InternalLinkage;
-                        std::string global_name = var_name;
-                        if (is_repl_eval) {
-                            global_name = replVarStorageSymbolName(var_name);
-                        }
+                        std::string global_name =
+                            userGlobalStorageName(var_name, is_repl_eval, library_mode);
 
                         global_var = new GlobalVariable(
                             *module,
@@ -11774,7 +11815,9 @@ private:
                 // Normal function context
                 // CRITICAL FIX: Check if there's a pre-declared GlobalVariable for this name
                 // If so, store to that instead of creating an AllocaInst
-                GlobalVariable* pre_declared_global = module->getNamedGlobal(var_name);
+                // (user globals are mangled — ESH-0092/0103).
+                GlobalVariable* pre_declared_global = module->getNamedGlobal(
+                    userGlobalStorageName(var_name, g_repl_mode_enabled, library_mode));
                     if (pre_declared_global) {
                         // Store to the pre-declared global variable
                         Value* store_value = value;
@@ -11953,7 +11996,7 @@ private:
                     false,
                     GlobalValue::WeakAnyLinkage,
                     func_ptr, // Initialize with actual function address
-                    var_name
+                    userGlobalStorageName(var_name, g_repl_mode_enabled, library_mode)
                 );
                 symbol_table[var_name] = variable;
                 global_symbol_table[var_name] = variable; // Also store in global table
@@ -11978,7 +12021,7 @@ private:
                     false,
                     GlobalValue::WeakAnyLinkage,
                     init_value,  // Always valid Constant now
-                    var_name
+                    userGlobalStorageName(var_name, g_repl_mode_enabled, library_mode)
                 );
                 symbol_table[var_name] = variable;
                 global_symbol_table[var_name] = variable; // Also store in global table

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -7514,6 +7514,11 @@ private:
         // VECTOR_PTR FIX: Handle vector pointers when extracting from cons cells
         Value* car_is_vector_ptr = builder->CreateICmpEQ(car_base_type,
             ConstantInt::get(int8_type, ESHKOL_VALUE_HEAP_PTR));
+        // CHAR FIX (ESH-0099): a character in a cons cell must be re-tagged as
+        // CHAR, not demoted to INT64 by the default path below. Without this,
+        // (apply f (list #\a)) delivers the raw codepoint 97 to f.
+        Value* car_is_char = builder->CreateICmpEQ(car_base_type,
+            ConstantInt::get(int8_type, ESHKOL_VALUE_CHAR));
 
         Function* current_func = builder->GetInsertBlock()->getParent();
         BasicBlock* null_car = BasicBlock::Create(*context, "car_extract_null", current_func);
@@ -7532,6 +7537,8 @@ private:
         BasicBlock* hash_ptr_car = BasicBlock::Create(*context, "car_extract_hash_ptr", current_func);
         BasicBlock* check_vector_ptr = BasicBlock::Create(*context, "car_check_vector_ptr", current_func);
         BasicBlock* vector_ptr_car = BasicBlock::Create(*context, "car_extract_vector_ptr", current_func);
+        BasicBlock* check_char = BasicBlock::Create(*context, "car_check_char", current_func);
+        BasicBlock* char_car = BasicBlock::Create(*context, "car_extract_char", current_func);
         BasicBlock* int_car = BasicBlock::Create(*context, "car_extract_int", current_func);
         BasicBlock* merge_car = BasicBlock::Create(*context, "car_merge", current_func);
 
@@ -7637,7 +7644,7 @@ private:
 
         // VECTOR_PTR FIX: Handle vector pointers when extracting from cons cells
         builder->SetInsertPoint(check_vector_ptr);
-        builder->CreateCondBr(car_is_vector_ptr, vector_ptr_car, int_car);
+        builder->CreateCondBr(car_is_vector_ptr, vector_ptr_car, check_char);
 
         builder->SetInsertPoint(vector_ptr_car);
         Value* car_vector_ptr = builder->CreateCall(getTaggedConsGetPtrFunc(), {cons_ptr, is_car});
@@ -7647,6 +7654,16 @@ private:
         builder->CreateBr(merge_car);
         BasicBlock* vector_ptr_exit = builder->GetInsertBlock();
 
+        // CHAR FIX (ESH-0099): extract codepoint and re-tag as CHAR.
+        builder->SetInsertPoint(check_char);
+        builder->CreateCondBr(car_is_char, char_car, int_car);
+
+        builder->SetInsertPoint(char_car);
+        Value* car_char = builder->CreateCall(getTaggedConsGetInt64Func(), {cons_ptr, is_car});
+        Value* tagged_char = packCharToTaggedValue(car_char);
+        builder->CreateBr(merge_car);
+        BasicBlock* char_exit = builder->GetInsertBlock();
+
         builder->SetInsertPoint(int_car);
         Value* car_int64 = builder->CreateCall(getTaggedConsGetInt64Func(), {cons_ptr, is_car});
         Value* tagged_int64 = packInt64ToTaggedValue(car_int64, true);
@@ -7654,7 +7671,7 @@ private:
         BasicBlock* int_exit = builder->GetInsertBlock();
 
         builder->SetInsertPoint(merge_car);
-        PHINode* car_tagged_phi = builder->CreatePHI(tagged_value_type, 10);
+        PHINode* car_tagged_phi = builder->CreatePHI(tagged_value_type, 11);
         car_tagged_phi->addIncoming(tagged_null, null_exit);
         car_tagged_phi->addIncoming(tagged_double, double_exit);
         car_tagged_phi->addIncoming(tagged_cons_ptr, cons_ptr_exit);
@@ -7664,6 +7681,7 @@ private:
         car_tagged_phi->addIncoming(tagged_bool, bool_exit);
         car_tagged_phi->addIncoming(tagged_hash_ptr, hash_ptr_exit);
         car_tagged_phi->addIncoming(tagged_vector_ptr, vector_ptr_exit);
+        car_tagged_phi->addIncoming(tagged_char, char_exit);
         car_tagged_phi->addIncoming(tagged_int64, int_exit);
 
         return car_tagged_phi;
@@ -7852,6 +7870,12 @@ private:
             ConstantInt::get(int8_type, ESHKOL_VALUE_HEAP_PTR));
         Value* car_is_vector = builder->CreateICmpEQ(car_base_type,
             ConstantInt::get(int8_type, ESHKOL_VALUE_HEAP_PTR));
+        // CHAR FIX (ESH-0099): a character stored in a cons cell must be
+        // re-extracted as a CHAR-tagged value, not silently demoted to INT64
+        // (which is what the default int path below does). Without this,
+        // (apply f (list #\a)) delivers the raw codepoint 97 to f.
+        Value* car_is_char = builder->CreateICmpEQ(car_base_type,
+            ConstantInt::get(int8_type, ESHKOL_VALUE_CHAR));
 
         // NULL FIX: Add null_block for NULL values
         BasicBlock* null_block = BasicBlock::Create(*context, "extract_null", current_func);
@@ -7869,6 +7893,8 @@ private:
         BasicBlock* hash_block = BasicBlock::Create(*context, "extract_hash", current_func);
         BasicBlock* check_vector = BasicBlock::Create(*context, "extract_check_vector", current_func);
         BasicBlock* vector_block = BasicBlock::Create(*context, "extract_vector", current_func);
+        BasicBlock* check_char = BasicBlock::Create(*context, "extract_check_char", current_func);
+        BasicBlock* char_block = BasicBlock::Create(*context, "extract_char", current_func);
         BasicBlock* int_block = BasicBlock::Create(*context, "extract_int", current_func);
         BasicBlock* merge_block = BasicBlock::Create(*context, "extract_merge", current_func);
 
@@ -7952,7 +7978,7 @@ private:
 
         // VECTOR_PTR FIX: Handle vector pointers (MIGRATION: output as HEAP_PTR)
         builder->SetInsertPoint(check_vector);
-        builder->CreateCondBr(car_is_vector, vector_block, int_block);
+        builder->CreateCondBr(car_is_vector, vector_block, check_char);
 
         builder->SetInsertPoint(vector_block);
         Value* car_vector = builder->CreateCall(getTaggedConsGetPtrFunc(), {cons_ptr, is_car_flag});
@@ -7960,6 +7986,17 @@ private:
         Value* tagged_vector = packPtrToTaggedValue(builder->CreateIntToPtr(car_vector, builder->getPtrTy()), ESHKOL_VALUE_HEAP_PTR);
         builder->CreateBr(merge_block);
         BasicBlock* vector_exit = builder->GetInsertBlock();
+
+        // CHAR FIX (ESH-0099): extract the codepoint and re-tag as CHAR so the
+        // character survives (apply f (list #\a)) and other cons-list unpacking.
+        builder->SetInsertPoint(check_char);
+        builder->CreateCondBr(car_is_char, char_block, int_block);
+
+        builder->SetInsertPoint(char_block);
+        Value* car_char = builder->CreateCall(getTaggedConsGetInt64Func(), {cons_ptr, is_car_flag});
+        Value* tagged_char = packCharToTaggedValue(car_char);
+        builder->CreateBr(merge_block);
+        BasicBlock* char_exit = builder->GetInsertBlock();
 
         // Extract int64 car and pack into tagged value
         builder->SetInsertPoint(int_block);
@@ -7970,7 +8007,7 @@ private:
 
         // Merge: return tagged value struct
         builder->SetInsertPoint(merge_block);
-        PHINode* car_tagged_phi = builder->CreatePHI(tagged_value_type, 9);
+        PHINode* car_tagged_phi = builder->CreatePHI(tagged_value_type, 10);
         // NULL FIX: Add null_exit as incoming
         car_tagged_phi->addIncoming(tagged_null, null_exit);
         car_tagged_phi->addIncoming(tagged_double, double_exit);
@@ -7980,6 +8017,7 @@ private:
         car_tagged_phi->addIncoming(tagged_closure, closure_exit);
         car_tagged_phi->addIncoming(tagged_hash, hash_exit);
         car_tagged_phi->addIncoming(tagged_vector, vector_exit);
+        car_tagged_phi->addIncoming(tagged_char, char_exit);
         car_tagged_phi->addIncoming(tagged_int64, int_exit);
 
         return car_tagged_phi;

--- a/lib/backend/vm_parser.c
+++ b/lib/backend/vm_parser.c
@@ -427,6 +427,14 @@ static Node* parse_sexp(void) {
             if (i < 62 && (*src_ptr == '+' || *src_ptr == '-')) buf[i++] = *src_ptr++;
             while (isdigit(*src_ptr) && i < 63) buf[i++] = *src_ptr++;
         }
+        /* Null-terminate the integer part BEFORE any atoll below. Without this
+         * the rational-literal branch called atoll(buf) on a buffer whose tail
+         * was still uninitialized stack memory, so atoll kept consuming any
+         * garbage digit bytes after the real ones -> a corrupted numerator
+         * (e.g. 1/3 parsed with num != 1). It only surfaced when the stack
+         * garbage happened to be a digit, making it a memory-layout-dependent
+         * heisenbug. The non-rational path re-terminates below (harmless). */
+        buf[i] = 0;
         /* Check for rational literal: digits/digits */
         if (*src_ptr == '/' && isdigit(src_ptr[1])) {
             int64_t num = atoll(buf);

--- a/tests/codegen/sweep_d_regressions_test.esk
+++ b/tests/codegen/sweep_d_regressions_test.esk
@@ -1,0 +1,104 @@
+;; Codegen Test: release sweep D regressions (ESH-0092 / ESH-0103 / ESH-0099)
+;;
+;; Item 1 (ESH-0092 / ESH-0103): user top-level globals must not be emitted
+;;   under their raw C/libm symbol name.
+;;   - A name matching a linked libc symbol (free, malloc, exit, ...) used to
+;;     override the C definition and SIGBUS at teardown.
+;;   - A name matching an in-module libm declaration (log, sin, ...) used to be
+;;     auto-renamed by LLVM into two distinct slots, so a set! inside a function
+;;     wrote one slot while a top-level read saw the other -> lost mutation on
+;;     cached-JIT / AOT (correct only with ESHKOL_JIT_CACHE=0).
+;;   These are exercised by defining variables with exactly those names, mutating
+;;   them from within functions, and checking both the values AND that the
+;;   process exits cleanly (the SIGBUS was a teardown crash, so reaching the
+;;   summary at all is part of the regression guard).
+;;
+;; Item 2 (ESH-0099): a character carried through apply (cons-list argument
+;;   unpacking) and read back from a quoted-literal list must keep its CHAR tag
+;;   instead of degrading to the raw integer codepoint.
+;;
+;; Runs identically on -r (JIT) and AOT.
+
+(require stdlib)
+
+(define tests-passed 0)
+(define tests-failed 0)
+
+(define (test-case name expected actual)
+  (if (equal? expected actual)
+      (begin
+        (set! tests-passed (+ tests-passed 1))
+        (display "PASS: ") (display name) (display "\n"))
+      (begin
+        (set! tests-failed (+ tests-failed 1))
+        (display "FAIL: ") (display name)
+        (display " (expected ") (write expected)
+        (display ", got ") (write actual) (display ")\n"))))
+
+;; ============================================================================
+;; Item 1: user globals shadowing C / libm symbols
+;; ============================================================================
+
+(display "=== Global symbol-collision safety (ESH-0092/0103) ===\n")
+
+;; libc-colliding names: value + clean teardown (SIGBUS class)
+(define free 10)
+(define malloc 20)
+(define exit 30)
+(define time 40)
+(test-case "libc-named globals read back" (list 10 20 30 40)
+           (list free malloc exit time))
+
+;; libm-colliding names mutated from inside a function: the write must be
+;; visible to a later read (the ESH-0103 lost-mutation class).
+(define log '())
+(define sin 0)
+(define (note! x) (set! log (cons x log)))
+(define (spin!) (set! sin (+ sin 1)))
+(note! 'a)
+(note! 'b)
+(spin!)
+(spin!)
+(spin!)
+(test-case "set! on libm-named list global" (list 'b 'a) log)
+(test-case "set! on libm-named int global" 3 sin)
+
+;; libc-colliding name that also holds a lambda value
+(define malloc2 (lambda (n) (* n n)))
+(test-case "lambda-valued libc-ish global" 49 (malloc2 7))
+
+;; ============================================================================
+;; Item 2: CHAR tag preserved through apply and quoted lists (ESH-0099)
+;; ============================================================================
+
+(display "=== Char preservation (ESH-0099) ===\n")
+
+;; EM-5: apply must deliver #\a (not 97) to the callee.
+(test-case "apply lambda preserves char" #\a
+           (apply (lambda (x) x) (list #\a)))
+(test-case "apply multi-arg preserves chars" (list #\a #\b)
+           (apply (lambda (x y) (list x y)) (list #\a #\b)))
+(define (id x) x)
+(test-case "apply named fn preserves char" #\z
+           (apply id (list #\z)))
+
+;; car / map over a runtime char list keep the CHAR tag
+(test-case "car of char list" #\q (car (list #\q)))
+(test-case "map identity over chars" (list #\a #\b)
+           (map (lambda (c) c) (list #\a #\b)))
+
+;; EM-7: char read from a quoted-literal list writes as #\a, not '#'
+(test-case "char? of quoted-list car" #t (char? (car '(#\a))))
+(test-case "quoted-list char round-trips" #\a (car '(#\a)))
+
+;; ============================================================================
+;; Summary
+;; ============================================================================
+
+(display "\n=== Test Summary ===\n")
+(display "Passed: ") (display tests-passed) (display "\n")
+(display "Failed: ") (display tests-failed) (display "\n")
+
+(if (= tests-failed 0)
+    (begin (display "All tests passed!\n") 0)
+    (begin (display "Some tests failed!\n") 1))


### PR DESCRIPTION
## Release-blocking bug sweep — Group D: symbol linkage + chars

Two root fixes surfaced by the SICP / edge-matrix / differential campaigns.

### 1. User top-level globals collided with C/libm symbols (ESH-0092, ESH-0103)

User `(define …)` top-level globals were emitted under their **raw Scheme name**
with external linkage. Two failure modes:

- **SIGBUS at teardown (ESH-0092):** a global named after a linked libc symbol
  (`free`, `malloc`, `exit`, …) overrode the C definition at JIT/AOT link. The
  program ran, then the runtime's own `free()`/`exit()` resolved to the user's
  data and crashed. `(define free 0)(display (+ free 1))` printed `1` then died
  with fatal SIGBUS on both `-r` and AOT.

- **Silently-lost mutations (ESH-0103):** a global named after an in-module libm
  declaration (`log`, `sin`, …) made LLVM auto-rename the `GlobalVariable`. The
  pre-declaration pass and the define/store pass then each created a distinct
  `@log.N` slot, so a `set!` inside a function wrote one slot while a top-level
  read saw the other. `(define log '())(define (note! x)(set! log (cons x log)))`
  gave `()` on cached-JIT and both AOT paths, correct only with
  `ESHKOL_JIT_CACHE=0`.

  **ESH-0103 is name-dependent → same root as ESH-0092.** Renaming `log`→`mylog`
  is correct on every path; only libc/libm-colliding names break.

**Root fix:** a `userGlobalStorageName()` helper mangles genuine user-program
globals to an `eshkol_g_`-prefixed encoded symbol (or the private
`__repl_storage_*` name in REPL mode) so they can never equal a C/libm symbol.
Library `provide` bindings and `:external` references keep their raw public name
for cross-object linking to `stdlib.o`. Every global create/lookup site in the
pre-declaration pass, `BindingCodegen`, and `codegenVariableDefinition` routes
through the helper so the storage slot is unique and consistent across `-r`,
run-cache, AOT and stdlib.o. `extern`/FFI (`:real`) declarations are unaffected
and still bind real C symbols.

### 2. CHAR tag lost through apply / cons-list unpacking (ESH-0099)

The cons-car extractors that build `apply` arguments (`extractCarAsTaggedValue`)
and other cons-list unpacking (`extractConsCarAsTaggedValue`) dispatched on
null/double/heap-ptr/lambda/closure/bool/vector then defaulted everything else
to INT64. A character element lost its CHAR tag:

    (apply (lambda (x) x) (list #\a))   =>  97      ; should be #\a

**Root fix:** an explicit CHAR case in both extractors reads the codepoint and
re-tags via `packCharToTaggedValue`, mirroring the existing bool handling.
Characters now survive `apply`, `car`, and `map` over runtime char lists on `-r`
and AOT. (EM-7 — writing a char read from a quoted-literal list — already
produced `#\a` on this revision and is guarded by the new test.)

### Tests / gates

- New `tests/codegen/sweep_d_regressions_test.esk` — 11/11 on `-r` **and** AOT.
- `run_icc_smoke.sh`: green except the pre-existing `example_agent_compiles`
  (the `examples/agent.esk` file is absent from this revision; fails identically
  on the base).
- `run_sicp_smoke.sh`: **88/88**.
- `run_differential.sh`: **240/240** axis pairs agree; differential finding 003
  flips to agreement (`(a)` on cached-JIT, uncached-JIT and AOT).
- Existing apply/char suites (`tests/lists/apply_*`, `tests/features/char_*`,
  `tests/v1_2_edge_cases/unicode_char_test`) all pass.