### PR TITLE
fix(tensor,ml): release sweep B — tensor-load shape, tensor tanh, batch/layer-norm, creation type-check, gpu-reduce, tensor-pow

### DIFF
--- a/docs/reference/tensors/INDEX.md
+++ b/docs/reference/tensors/INDEX.md
@@ -31,16 +31,18 @@ LU/QR/SVD/Cholesky/solve/inverse/det, reductions, `conv1d`/`conv2d`/`conv3d`,
 `positional-encoding`, `dropout`, `softmax`, tensor-only activations, dtype
 casts, rect/disk pixel fills, and all three library modules.
 
-**Known-broken on this build (documented, not fixed here):**
+**Known limitations on this build:**
 
 | Operation | Issue |
 |-----------|-------|
-| `batch-norm`, `layer-norm` | garbage output (4-arg); SIGSEGV (5-arg `axis`) |
-| `tensor-load` | drops shape (`tensor-shape` → `(0)`); data/length survive |
-| `gpu-reduce` | returns empty `#()` instead of a scalar |
-| `tanh` | scalar-only; silently wrong on a tensor |
-| `tensor-pow` | needs a tensor exponent, not a scalar |
-| tensor creation | no element type-check; int+float args misread as shape |
+| tensor creation | no element type-check for non-numeric args (`(tensor 1.0 "x")` → garbage) |
+| type-guard text | reports raw doubles as `integer` |
+
+(The release sweep-B fixes landed: `batch-norm`/`layer-norm` handle scalar
+**and** per-feature tensor gamma/beta plus the 5-arg axis form; `tensor-load`
+round-trips the shape; `gpu-reduce` returns a scalar; scalar math like `tanh`
+maps elementwise over a tensor; `tensor-pow` accepts a scalar exponent; and
+`(tensor 1 2.5 3)` builds the obvious 1-D tensor.)
 
 ## GPU status in one line
 

--- a/docs/reference/tensors/gpu.md
+++ b/docs/reference/tensors/gpu.md
@@ -19,13 +19,13 @@ All five resolve as codegen builtins (`lib/backend/llvm_codegen.cpp`) in **both
 | `gpu-elementwise` | `(gpu-elementwise OP A B)` | ✅ `(gpu-elementwise + A A)` → elementwise sum. `OP` is a **bare** `+ - * /` token (also `add`/`tensor-add` spellings), not a quoted symbol |
 | `gpu-softmax` | `(gpu-softmax t)` | ✅ `(gpu-softmax (tensor 1.0 2.0 3.0))` → `#(0.0900306 0.244728 0.665241)` |
 | `gpu-transpose` | `(gpu-transpose A)` | ✅ 2×2 → `#((1 3) (2 4))` |
-| `gpu-reduce` | `(gpu-reduce OP t)` | ⚠ **returns empty `#()`** — the reduce-all path yields an empty tensor, not a scalar. `OP` is a bare `+ mean max min` token |
+| `gpu-reduce` | `(gpu-reduce OP t)` | ✅ full reduction to a **scalar** (`(gpu-reduce + (tensor 1.0 2.0 3.0 4.0))` → `10`). `OP` is a bare `+ mean max min` token |
 
 ```scheme
 (define A (reshape (tensor 1.0 2.0 3.0 4.0) (list 2 2)))
 (gpu-matmul A A)             ;; => #((7 10) (15 22))
 (gpu-elementwise + A A)      ;; => #((2 4) (6 8))
-(gpu-reduce + (tensor 1.0 2.0 3.0 4.0))  ;; => #()   ⚠ should be 10
+(gpu-reduce + (tensor 1.0 2.0 3.0 4.0))  ;; => 10
 ```
 
 Note: `gpu-elementwise`/`gpu-reduce` take the operator as a **bare identifier**
@@ -65,12 +65,12 @@ box. This contradicts the literal wording of ESH-0022/ESH-0023.
 
 | Task | Ledger claim | Observed on this build (Metal) |
 |------|--------------|--------------------------------|
-| **ESH-0022** | `gpu-matmul`/`gpu-elementwise`/`gpu-softmax`/`gpu-reduce`/`gpu-transpose` are "Unknown function" in both paths | ✅ all five **resolve** in `-r` and AOT; 4/5 compute correctly (`gpu-reduce` returns `#()`) |
+| **ESH-0022** | `gpu-matmul`/`gpu-elementwise`/`gpu-softmax`/`gpu-reduce`/`gpu-transpose` are "Unknown function" in both paths | ✅ all five **resolve and compute correctly** in `-r` and AOT (`gpu-reduce` now returns a scalar) |
 | **ESH-0023** | AOT-compiled binary runs matmul on CPU BLAS even in a GPU build | On **Metal**, AOT matmul dispatches to the GPU when the threshold is met (verified). The task was filed against **CUDA/RTX 3050**, which is not exercised here |
 
-Treat ESH-0022/0023 as **partly resolved**: what remains genuinely pending is
-(a) the `gpu-reduce` scalar path, and (b) low-level GPU-specific low-precision
-dtype builtins on non-Metal backends.
+Treat ESH-0022/0023 as **largely resolved**: `gpu-reduce` now returns a scalar
+(full reduction). What remains genuinely pending is low-level GPU-specific
+low-precision dtype builtins on non-Metal backends.
 
 ---
 

--- a/docs/reference/tensors/operations.md
+++ b/docs/reference/tensors/operations.md
@@ -142,21 +142,21 @@ The pooling ops are named `max-pool2d` / `avg-pool2d` (with the `2d` suffix).
 
 | Op | Signature | Status |
 |----|-----------|--------|
-| `batch-norm` | `(batch-norm input gamma beta epsilon [axis])` | ⚠ **BUG** — produces garbage denormals; 5-arg form SIGSEGVs |
-| `layer-norm` | `(layer-norm input gamma beta epsilon [axis])` | ⚠ **BUG** — same garbage-denormal / SIGSEGV failure |
+| `batch-norm` | `(batch-norm input gamma beta epsilon [axis])` | ✅ scalar **or** per-feature tensor gamma/beta; 4-arg and 5-arg (axis) forms |
+| `layer-norm` | `(layer-norm input gamma beta epsilon [axis])` | ✅ scalar **or** per-feature tensor gamma/beta; 4-arg and 5-arg (axis) forms |
 | `multi-head-attention` | `(multi-head-attention Q K V num-heads W_Q W_K W_V W_O [mask])` | ✅ forward pass runs (8–9 args) |
 | `embedding` | `(embedding indices weights)` | ✅ `idx #(0 2)`, 3×2 weights → the selected rows |
 | `positional-encoding` | `(positional-encoding max-len d-model)` | ✅ sinusoidal, exactly 2 args |
 | `dropout` | `(dropout tensor drop-prob)` | ✅ 2 args; `(dropout #(1 2 3) 0.0)` → `#(1 2 3)` |
 | `softmax` | `(softmax tensor [axis])` | ✅ `(softmax #(1 2 3))` → `#(0.0900306 0.244728 0.665241)` |
 
-> ⚠ **`batch-norm` and `layer-norm` are broken on this build.** The 4-argument
-> form writes int64 bit-patterns into the output buffer instead of computed
-> floats (`(layer-norm #(1.0 2.0 3.0 4.0) #(1.0 …) #(0.0 …) 1e-5)` →
-> `#(-8.8e-315 1.4e-314 …)`), and passing the optional 5th `axis` argument
-> **SIGSEGVs**. This is a codegen bug in both norms; do not rely on them for
-> training. **Attention backward** is also a passthrough stub in the tensor
-> backward pass — see
+> **`batch-norm` and `layer-norm` accept both a scalar and a per-feature
+> tensor for `gamma`/`beta`** and support the optional 5th `axis` argument.
+> `(layer-norm #(1.0 2.0 3.0 4.0) #(1.0 …) #(0.0 …) 1e-5)` normalizes to
+> `#(-1.3416 -0.4472 0.4472 1.3416)`. (Earlier builds mis-read a tensor
+> gamma/beta as a scalar — garbage denormals — and SIGSEGV'd on the axis form;
+> both are fixed.) **Attention backward** is still a passthrough stub in the
+> tensor backward pass — see
 > [../../breakdown/AUTODIFF.md](../../breakdown/AUTODIFF.md) "v1.1 AD
 > Extensions".
 
@@ -176,10 +176,11 @@ scalar argument:
 (relu -5.0)                      ;; ERROR: Type error in relu: expected tensor
 ```
 
-> **`tanh` is the exception — it is scalar-only.** `(tanh 0.0)` → `0`, but
-> `(tanh (tensor 0.0 1.0))` silently returns a wrong scalar (`1`) instead of a
-> tensor, because `tanh` dispatches to the scalar math path before the tensor
-> path. Use `tensor-apply`/elementwise for a tanh over a tensor.
+> **`tanh` and the other scalar math builtins now map elementwise over a
+> tensor.** `(tanh 0.0)` → `0` and `(tanh (tensor 0.0 1.0))` →
+> `#(0 0.761594)`. The same holds for `sin`/`cos`/`tan`/`exp`/`log`/`sqrt`/…
+> when handed a tensor. (Earlier builds reinterpreted the tensor pointer as a
+> scalar double and returned a silently-wrong scalar.)
 
 ---
 
@@ -205,10 +206,12 @@ guard tags any untagged scalar as INT64).
 
 > **Creation is not guarded.** `(tensor 1.0 "x" 3.0)` does *not* raise — it
 > reinterprets the string pointer as a double and yields garbage. Build tensors
-> from numeric literals only. Mixing integer and float arguments in
-> `tensor`/`make-tensor` can also trigger shape-mode misinterpretation
-> (leading integers are read as a shape); prefer all-float element lists or
-> `(make-tensor '(shape) fill)` with a quoted-list shape.
+> from numeric literals only. Mixing integer and float *numeric* arguments is
+> fine: `(tensor 1 2.5 3)` builds the obvious 1-D tensor `#(1 2.5 3)`. Leading
+> integers are treated as a shape prefix only when their product exactly
+> matches the number of remaining elements (e.g. `(tensor 2 2 1.0 2.0 3.0 4.0)`
+> → a 2×2 tensor); otherwise every argument is a 1-D element. (Earlier builds
+> raised a confusing "insufficient elements" error on `(tensor 1 2.5 3)`.)
 
 ---
 
@@ -234,26 +237,25 @@ at (1,1) use `1 1 3 3`.
 
 ```scheme
 (tensor-save "path.bin" t)   ;; arg order is (PATH TENSOR); returns #t
-(tensor-load "path.bin")     ;; ⚠ BUG — see below
+(tensor-load "path.bin")     ;; round-trips shape + data
 ```
 
 `tensor-save` writes a correct binary file (magic `TKSE`, IEEE-754 element
 bit-patterns) and returns `#t`. **The argument order is `(path, tensor)`.**
 
-> ⚠ **`tensor-load` loses the shape.** After a save/load round-trip the element
-> data and count survive (`tensor-length` → 4, `tensor-dtype` → `f64`) but the
-> shape metadata is dropped: the loaded tensor displays as `#()` and
-> `tensor-shape` returns `(0)`. The loader reads the shape header but never
-> copies the dimensions into the tensor's `dimensions[]` array. Round-trip is
-> effectively broken until this is fixed.
+> **`tensor-load` round-trips the shape.** After a save/load the shape, element
+> data, count and dtype all survive (`(tensor-shape (tensor-load …))` on a 2×2
+> save returns `(2 2)`). (Earlier builds allocated the `dimensions[]` array but
+> never copied the loaded dimensions into it, so `tensor-shape` reported `(0 …)`
+> and the tensor displayed as `#()`.)
 
 ---
 
 ## GPU-labeled builtins
 
 `gpu-matmul`, `gpu-elementwise`, `gpu-softmax`, `gpu-transpose`, `gpu-reduce`
-all **resolve** and run. See [gpu.md](gpu.md) for signatures, honest Metal/CUDA
-dispatch status, and the `gpu-reduce` empty-result caveat.
+all **resolve** and run (`gpu-reduce` returns a scalar). See [gpu.md](gpu.md)
+for signatures and honest Metal/CUDA dispatch status.
 
 ---
 
@@ -261,12 +263,7 @@ dispatch status, and the `gpu-reduce` empty-result caveat.
 
 | Operation | Issue |
 |-----------|-------|
-| `batch-norm`, `layer-norm` | garbage denormal output (4-arg); SIGSEGV (5-arg `axis`) |
-| `tensor-load` | drops shape metadata (`tensor-shape` → `(0)`, displays `#()`); data/length survive |
-| `gpu-reduce` | returns empty `#()` instead of a scalar ([gpu.md](gpu.md)) |
-| `tanh` | scalar-only; silently wrong on a tensor argument |
-| `tensor-pow` | requires a **tensor** exponent, not a scalar |
-| tensor creation | no element type-check (`(tensor 1.0 "x")` → garbage); int+float args misread as shape |
+| tensor creation | no element type-check for non-numeric args (`(tensor 1.0 "x")` → garbage) — build tensors from numeric literals only |
 | type-guard text | reports raw doubles as `integer` |
 | attention/embedding backward | passthrough stubs (see AUTODIFF.md) |
 

--- a/inc/eshkol/backend/tensor_codegen.h
+++ b/inc/eshkol/backend/tensor_codegen.h
@@ -1192,6 +1192,27 @@ private:
                                        const std::string& name);
 
     /**
+     * Emit the numeric (non-autodiff) batch-norm / layer-norm path as a call to
+     * the eshkol_tensor_normalize_apply runtime kernel. The kernel decodes
+     * gamma/beta from tagged values, so it handles BOTH a scalar (broadcast)
+     * and a per-feature tensor correctly — the old inline codegen only handled
+     * scalars and produced garbage (or SIGSEGV) on tensor gamma/beta.
+     *   input_val    : the tagged input tensor
+     *   gamma_val    : tagged (or raw) gamma — scalar or tensor
+     *   beta_val     : tagged (or raw) beta  — scalar or tensor
+     *   epsilon_d    : epsilon as a double LLVM value
+     *   group_len    : elements per normalization group (i64)
+     *   inner_stride : stride between group members (i64)
+     * Returns the packed tagged result tensor.
+     */
+    llvm::Value* emitNumericNormalize(llvm::Value* input_val,
+                                      llvm::Value* gamma_val,
+                                      llvm::Value* beta_val,
+                                      llvm::Value* epsilon_d,
+                                      llvm::Value* group_len,
+                                      llvm::Value* inner_stride);
+
+    /**
      * Coerce a numeric value to a runtime double.
      *
      * - tagged values: dispatches at runtime on type-tag (INT64 → SIToFP,

--- a/inc/eshkol/model_io.h
+++ b/inc/eshkol/model_io.h
@@ -27,6 +27,29 @@ void eshkol_model_load_tagged(arena_t* arena,
                               const eshkol_tagged_value_t* path_tv,
                               eshkol_tagged_value_t* result);
 
+/* Numeric batch-norm / layer-norm kernel. gamma_tv / beta_tv are decoded as
+ * either a scalar (broadcast) or a per-feature tensor. group_len / inner_stride
+ * describe the normalization grouping (see model_io.cpp). Returns a new tensor
+ * (eshkol_tensor_t*) or NULL on error. */
+void* eshkol_tensor_normalize_apply(arena_t* arena,
+                                    const eshkol_tagged_value_t* input_tv,
+                                    int64_t group_len,
+                                    int64_t inner_stride,
+                                    const eshkol_tagged_value_t* gamma_tv,
+                                    const eshkol_tagged_value_t* beta_tv,
+                                    double epsilon);
+
+/* Elementwise base ^ scalar exponent. Returns a new tensor or NULL. */
+void* eshkol_tensor_pow_scalar(arena_t* arena,
+                               const eshkol_tagged_value_t* base_tv,
+                               double exponent);
+
+/* Elementwise libm unary map over a tensor (op codes mirror
+ * codegenMathFunction). Returns a new tensor or NULL. */
+void* eshkol_tensor_map_libm(arena_t* arena,
+                             const eshkol_tagged_value_t* in_tv,
+                             int32_t op);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -16177,10 +16177,23 @@ private:
                 eshkol_error("gpu-reduce supports +, mean, max, and min");
                 return nullptr;
             }
-            Value* tensor_val = codegenAST(&op->call_op.variables[1]);
-            if (!tensor_val) return nullptr;
-            Value* axis = packInt64ToTaggedValue(ConstantInt::get(int64_type, -1), true);
-            return tensor_->emitAxisReduce(tensor_val, axis, op_code);
+            // gpu-reduce is a FULL reduction to a scalar. Routing it through
+            // emitAxisReduce(axis = -1) returned a reduced-RANK tensor (rank-0
+            // for a 1-D input) that displays as #() rather than the scalar
+            // result. Route to the whole-tensor reduction functions instead,
+            // which return a proper scalar.
+            eshkol_operations_t reduce_sub = *op;
+            reduce_sub.call_op.num_vars = 1;
+            reduce_sub.call_op.variables = &op->call_op.variables[1];
+            switch (op_code) {
+                case 0: return tensor_->tensorSum(&reduce_sub);
+                case 1: return tensor_->tensorMean(&reduce_sub);
+                case 2: return tensor_->tensorMax(&reduce_sub);
+                case 3: return tensor_->tensorMin(&reduce_sub);
+                default: break;
+            }
+            eshkol_error("gpu-reduce supports +, mean, max, and min");
+            return nullptr;
         }
 
         // MIGRATED: Tensor arithmetic - now delegated to TensorCodegen
@@ -18880,6 +18893,62 @@ private:
         BasicBlock* regular_path = BasicBlock::Create(*context, (func_name + "_regular_path").c_str(), current_func);
         BasicBlock* merge = BasicBlock::Create(*context, (func_name + "_merge").c_str(), current_func);
 
+        // TENSOR OPERAND PATH: a scalar math builtin applied to a *tensor* must
+        // map elementwise and return a tensor. The scalar machinery below would
+        // otherwise reinterpret the tensor pointer's bits as a double and return
+        // a silently-wrong scalar (e.g. `(tanh (tensor 0.0 1.0))` => 1). Dispatch
+        // on the operand's runtime type to the elementwise libm kernel.
+        int32_t tensor_op_code = -1;
+        if      (func_name == "sin")   tensor_op_code = 0;
+        else if (func_name == "cos")   tensor_op_code = 1;
+        else if (func_name == "tan")   tensor_op_code = 2;
+        else if (func_name == "asin")  tensor_op_code = 3;
+        else if (func_name == "acos")  tensor_op_code = 4;
+        else if (func_name == "atan")  tensor_op_code = 5;
+        else if (func_name == "sinh")  tensor_op_code = 6;
+        else if (func_name == "cosh")  tensor_op_code = 7;
+        else if (func_name == "tanh")  tensor_op_code = 8;
+        else if (func_name == "asinh") tensor_op_code = 9;
+        else if (func_name == "acosh") tensor_op_code = 10;
+        else if (func_name == "atanh") tensor_op_code = 11;
+        else if (func_name == "exp")   tensor_op_code = 12;
+        else if (func_name == "exp2")  tensor_op_code = 13;
+        else if (func_name == "log")   tensor_op_code = 14;
+        else if (func_name == "log2")  tensor_op_code = 15;
+        else if (func_name == "log10") tensor_op_code = 16;
+        else if (func_name == "sqrt")  tensor_op_code = 17;
+        else if (func_name == "cbrt")  tensor_op_code = 18;
+        else if (func_name == "fabs")  tensor_op_code = 19;
+        else if (func_name == "floor") tensor_op_code = 20;
+        else if (func_name == "ceil")  tensor_op_code = 21;
+        else if (func_name == "trunc") tensor_op_code = 22;
+        else if (func_name == "round") tensor_op_code = 23;
+
+        BasicBlock* math_done = nullptr;
+        Value* math_result_slot = nullptr;
+        if (tensor_op_code >= 0) {
+            BasicBlock* math_tensor_path = BasicBlock::Create(*context, (func_name + "_tensor_path").c_str(), current_func);
+            BasicBlock* math_scalar_entry = BasicBlock::Create(*context, (func_name + "_scalar_entry").c_str(), current_func);
+            math_done = BasicBlock::Create(*context, (func_name + "_tensor_done").c_str(), current_func);
+            math_result_slot = builder->CreateAlloca(tagged_value_type, nullptr, (func_name + "_tensor_result").c_str());
+
+            Value* arg_is_tensor = isHeapSubtype(arg_tagged, HEAP_SUBTYPE_TENSOR);
+            builder->CreateCondBr(arg_is_tensor, math_tensor_path, math_scalar_entry);
+
+            builder->SetInsertPoint(math_tensor_path);
+            Value* arg_slot = builder->CreateAlloca(tagged_value_type, nullptr, (func_name + "_tensor_arg").c_str());
+            builder->CreateStore(arg_tagged, arg_slot);
+            Value* arena_ptr_t = builder->CreateLoad(ptr_type, global_arena);
+            FunctionType* map_ft = FunctionType::get(ptr_type, {ptr_type, ptr_type, int32_type}, false);
+            FunctionCallee map_fn = module->getOrInsertFunction("eshkol_tensor_map_libm", map_ft);
+            Value* mapped = builder->CreateCall(map_fn, {arena_ptr_t, arg_slot,
+                ConstantInt::get(int32_type, tensor_op_code)});
+            builder->CreateStore(packPtrToTaggedValue(mapped, ESHKOL_VALUE_HEAP_PTR), math_result_slot);
+            builder->CreateBr(math_done);
+
+            builder->SetInsertPoint(math_scalar_entry);
+        }
+
         // First check for AD node (reverse-mode AD)
         builder->CreateCondBr(arg_is_ad_node, ad_node_path, check_dual);
 
@@ -19184,6 +19253,14 @@ private:
         result_phi->addIncoming(tagged_dual_result, dual_path);   // Dual number path (forward-mode AD)
         result_phi->addIncoming(tagged_regular_result, regular_exit);  // Regular computation
 
+        // If a tensor-operand fast path was emitted, merge the scalar result
+        // with the elementwise-tensor result through math_done.
+        if (math_done) {
+            builder->CreateStore(result_phi, math_result_slot);
+            builder->CreateBr(math_done);
+            builder->SetInsertPoint(math_done);
+            return builder->CreateLoad(tagged_value_type, math_result_slot);
+        }
         return result_phi;
     }
 

--- a/lib/backend/tensor_conv_codegen.cpp
+++ b/lib/backend/tensor_conv_codegen.cpp
@@ -1317,6 +1317,39 @@ bool TensorCodegen::emitTensorADNormalizeDispatch(llvm::Value* src_elems,
     return true;
 }
 
+llvm::Value* TensorCodegen::emitNumericNormalize(llvm::Value* input_val,
+                                                 llvm::Value* gamma_val,
+                                                 llvm::Value* beta_val,
+                                                 llvm::Value* epsilon_d,
+                                                 llvm::Value* group_len,
+                                                 llvm::Value* inner_stride) {
+    auto& builder = ctx_.builder();
+    auto* ptrTy = ctx_.ptrType();
+    auto* i64Ty = ctx_.int64Type();
+    auto* dblTy = ctx_.doubleType();
+    auto* tvTy = ctx_.taggedValueType();
+
+    llvm::Value* arena = builder.CreateLoad(ptrTy, ctx_.globalArena());
+
+    // Store the tagged input/gamma/beta into stack slots so the runtime can
+    // decode them (scalar vs tensor) from a pointer.
+    llvm::Value* in_slot = builder.CreateAlloca(tvTy, nullptr, "norm_in_tv");
+    builder.CreateStore(tagged_.ensureTagged(input_val), in_slot);
+    llvm::Value* gamma_slot = builder.CreateAlloca(tvTy, nullptr, "norm_gamma_tv");
+    builder.CreateStore(tagged_.ensureTagged(gamma_val), gamma_slot);
+    llvm::Value* beta_slot = builder.CreateAlloca(tvTy, nullptr, "norm_beta_tv");
+    builder.CreateStore(tagged_.ensureTagged(beta_val), beta_slot);
+
+    llvm::FunctionType* fn_type = llvm::FunctionType::get(ptrTy,
+        {ptrTy, ptrTy, i64Ty, i64Ty, ptrTy, ptrTy, dblTy}, false);
+    llvm::FunctionCallee callee =
+        ctx_.module().getOrInsertFunction("eshkol_tensor_normalize_apply", fn_type);
+    llvm::Value* result = builder.CreateCall(callee,
+        {arena, in_slot, group_len, inner_stride, gamma_slot, beta_slot, epsilon_d},
+        "norm_result");
+    return tagged_.packHeapPtr(result);
+}
+
 llvm::Value* TensorCodegen::batchNorm(const eshkol_operations_t* op) {
     // batch-norm: (batch-norm input gamma beta epsilon [axis])
     // Simplified batch normalization for inference
@@ -1363,12 +1396,45 @@ llvm::Value* TensorCodegen::batchNorm(const eshkol_operations_t* op) {
         else if (eps_arg->getType()->isIntegerTy(64)) eps_d = builder.CreateSIToFP(eps_arg, ctx_.doubleType());
 
         llvm::Value* arena = builder.CreateLoad(ctx_.ptrType(), ctx_.globalArena());
-        auto* ptrTy = ctx_.ptrType();
-        auto* i64Ty = ctx_.int64Type();
-        auto* dblTy = ctx_.doubleType();
+        (void)arena;
+        llvm::Function* current_func = builder.GetInsertBlock()->getParent();
+
+        // Normalize the axis (negative → from the end) and compute the length
+        // of the normalization axis plus the inner stride (product of the dims
+        // after the axis), matching emitTensorADNormalizeDispatch's grouping.
+        llvm::Value* is_negative_axis = builder.CreateICmpSLT(axis,
+            llvm::ConstantInt::get(ctx_.int64Type(), 0));
+        llvm::Value* normalized_axis = builder.CreateSelect(is_negative_axis,
+            builder.CreateAdd(axis, rank), axis);
+        llvm::Value* axis_len = builder.CreateLoad(ctx_.int64Type(),
+            builder.CreateGEP(ctx_.int64Type(), dims, normalized_axis));
+
+        llvm::Value* one_i64 = llvm::ConstantInt::get(ctx_.int64Type(), 1);
+        llvm::Value* inner_stride_alloca = builder.CreateAlloca(ctx_.int64Type(), nullptr, "bn_axis_inner_stride");
+        llvm::Value* stride_i_alloca = builder.CreateAlloca(ctx_.int64Type(), nullptr, "bn_axis_stride_i");
+        builder.CreateStore(one_i64, inner_stride_alloca);
+        builder.CreateStore(builder.CreateAdd(normalized_axis, one_i64), stride_i_alloca);
+        llvm::BasicBlock* stride_cond = llvm::BasicBlock::Create(ctx_.context(), "bn_axis_stride_cond", current_func);
+        llvm::BasicBlock* stride_body = llvm::BasicBlock::Create(ctx_.context(), "bn_axis_stride_body", current_func);
+        llvm::BasicBlock* stride_done = llvm::BasicBlock::Create(ctx_.context(), "bn_axis_stride_done", current_func);
+        builder.CreateBr(stride_cond);
+
+        builder.SetInsertPoint(stride_cond);
+        llvm::Value* stride_i = builder.CreateLoad(ctx_.int64Type(), stride_i_alloca);
+        builder.CreateCondBr(builder.CreateICmpULT(stride_i, rank), stride_body, stride_done);
+
+        builder.SetInsertPoint(stride_body);
+        llvm::Value* stride_dim = builder.CreateLoad(ctx_.int64Type(),
+            builder.CreateGEP(ctx_.int64Type(), dims, stride_i));
+        llvm::Value* old_stride = builder.CreateLoad(ctx_.int64Type(), inner_stride_alloca);
+        builder.CreateStore(builder.CreateMul(old_stride, stride_dim), inner_stride_alloca);
+        builder.CreateStore(builder.CreateAdd(stride_i, one_i64), stride_i_alloca);
+        builder.CreateBr(stride_cond);
+
+        builder.SetInsertPoint(stride_done);
+        llvm::Value* inner_stride = builder.CreateLoad(ctx_.int64Type(), inner_stride_alloca);
 
         if (autodiff_) {
-            llvm::Function* current_func = builder.GetInsertBlock()->getParent();
             llvm::BasicBlock* ad_done = llvm::BasicBlock::Create(ctx_.context(), "bn_axis_ad_done", current_func);
             llvm::BasicBlock* merge_block = llvm::BasicBlock::Create(ctx_.context(), "bn_axis_merge", current_func);
 
@@ -1382,38 +1448,6 @@ llvm::Value* TensorCodegen::batchNorm(const eshkol_operations_t* op) {
             llvm::Value* elems_size = builder.CreateMul(total,
                 llvm::ConstantInt::get(ctx_.int64Type(), sizeof(double)));
             llvm::Value* result_elems = builder.CreateCall(arena_alloc, {arena, elems_size}, "bn_axis_ad_elems");
-
-            llvm::Value* is_negative_axis = builder.CreateICmpSLT(axis,
-                llvm::ConstantInt::get(ctx_.int64Type(), 0));
-            llvm::Value* normalized_axis = builder.CreateSelect(is_negative_axis,
-                builder.CreateAdd(axis, rank), axis);
-            llvm::Value* axis_len = builder.CreateLoad(ctx_.int64Type(),
-                builder.CreateGEP(ctx_.int64Type(), dims, normalized_axis));
-
-            llvm::Value* one_i64 = llvm::ConstantInt::get(ctx_.int64Type(), 1);
-            llvm::Value* inner_stride_alloca = builder.CreateAlloca(ctx_.int64Type(), nullptr, "bn_axis_inner_stride");
-            llvm::Value* stride_i_alloca = builder.CreateAlloca(ctx_.int64Type(), nullptr, "bn_axis_stride_i");
-            builder.CreateStore(one_i64, inner_stride_alloca);
-            builder.CreateStore(builder.CreateAdd(normalized_axis, one_i64), stride_i_alloca);
-            llvm::BasicBlock* stride_cond = llvm::BasicBlock::Create(ctx_.context(), "bn_axis_stride_cond", current_func);
-            llvm::BasicBlock* stride_body = llvm::BasicBlock::Create(ctx_.context(), "bn_axis_stride_body", current_func);
-            llvm::BasicBlock* stride_done = llvm::BasicBlock::Create(ctx_.context(), "bn_axis_stride_done", current_func);
-            builder.CreateBr(stride_cond);
-
-            builder.SetInsertPoint(stride_cond);
-            llvm::Value* stride_i = builder.CreateLoad(ctx_.int64Type(), stride_i_alloca);
-            builder.CreateCondBr(builder.CreateICmpULT(stride_i, rank), stride_body, stride_done);
-
-            builder.SetInsertPoint(stride_body);
-            llvm::Value* stride_dim = builder.CreateLoad(ctx_.int64Type(),
-                builder.CreateGEP(ctx_.int64Type(), dims, stride_i));
-            llvm::Value* old_stride = builder.CreateLoad(ctx_.int64Type(), inner_stride_alloca);
-            builder.CreateStore(builder.CreateMul(old_stride, stride_dim), inner_stride_alloca);
-            builder.CreateStore(builder.CreateAdd(stride_i, one_i64), stride_i_alloca);
-            builder.CreateBr(stride_cond);
-
-            builder.SetInsertPoint(stride_done);
-            llvm::Value* inner_stride = builder.CreateLoad(ctx_.int64Type(), inner_stride_alloca);
             builder.CreateStore(result_dims, builder.CreateStructGEP(ttype, result_ptr, 0));
             builder.CreateStore(rank, builder.CreateStructGEP(ttype, result_ptr, 1));
             builder.CreateStore(result_elems, builder.CreateStructGEP(ttype, result_ptr, 2));
@@ -1423,12 +1457,9 @@ llvm::Value* TensorCodegen::batchNorm(const eshkol_operations_t* op) {
                 inner_stride, gamma_d, gamma_val, beta_d, beta_val, eps_d, eps_arg,
                 ad_done, "bn_axis");
 
-            llvm::FunctionType* fn_type = llvm::FunctionType::get(ptrTy,
-                {ptrTy, ptrTy, i64Ty, ptrTy, i64Ty, i64Ty, dblTy, dblTy, dblTy}, false);
-            llvm::FunctionCallee callee = ctx_.module().getOrInsertFunction("eshkol_xla_normalize", fn_type);
-            llvm::Value* numeric_result = builder.CreateCall(callee,
-                {arena, elems, total, dims, rank, axis, gamma_d, beta_d, eps_d}, "bn_axis_numeric_result");
-            llvm::Value* numeric_packed = tagged_.packHeapPtr(numeric_result);
+            // Numeric path — runtime kernel handles scalar OR tensor gamma/beta.
+            llvm::Value* numeric_packed = emitNumericNormalize(input_val, gamma_val,
+                beta_val, eps_d, axis_len, inner_stride);
             builder.CreateBr(merge_block);
             llvm::BasicBlock* numeric_exit = builder.GetInsertBlock();
 
@@ -1444,12 +1475,8 @@ llvm::Value* TensorCodegen::batchNorm(const eshkol_operations_t* op) {
             return result_phi;
         }
 
-        llvm::FunctionType* fn_type = llvm::FunctionType::get(ptrTy,
-            {ptrTy, ptrTy, i64Ty, ptrTy, i64Ty, i64Ty, dblTy, dblTy, dblTy}, false);
-        llvm::FunctionCallee callee = ctx_.module().getOrInsertFunction("eshkol_xla_normalize", fn_type);
-        llvm::Value* result = builder.CreateCall(callee,
-            {arena, elems, total, dims, rank, axis, gamma_d, beta_d, eps_d}, "bn_axis_result");
-        return tagged_.packHeapPtr(result);
+        return emitNumericNormalize(input_val, gamma_val, beta_val, eps_d,
+            axis_len, inner_stride);
     }
 
     auto& builder = ctx_.builder();
@@ -1523,129 +1550,37 @@ llvm::Value* TensorCodegen::batchNorm(const eshkol_operations_t* op) {
     builder.CreateStore(total_elements, r_total_field);
 
     llvm::Function* current_func = builder.GetInsertBlock()->getParent();
-    llvm::BasicBlock* exit_block = llvm::BasicBlock::Create(ctx_.context(), "bn_exit", current_func);
-    emitTensorADNormalizeDispatch(input_elems, result_elems, total_elements,
-        total_elements, llvm::ConstantInt::get(ctx_.int64Type(), 1),
-        gamma, gamma_val, beta, beta_val, epsilon, eps_arg, exit_block, "bn");
+    // batch-norm 4-arg normalizes over the whole tensor as one group.
+    llvm::Value* bn_group_len = total_elements;
+    llvm::Value* bn_inner_stride = llvm::ConstantInt::get(ctx_.int64Type(), 1);
 
-    // First pass: compute mean
-    llvm::Value* mean = builder.CreateAlloca(ctx_.doubleType(), nullptr, "bn_mean");
-    llvm::Value* var = builder.CreateAlloca(ctx_.doubleType(), nullptr, "bn_var");
-    llvm::Value* sum = builder.CreateAlloca(ctx_.doubleType(), nullptr, "bn_sum");
-    llvm::Value* idx = builder.CreateAlloca(ctx_.int64Type(), nullptr, "bn_idx");
+    if (autodiff_) {
+        llvm::BasicBlock* ad_done = llvm::BasicBlock::Create(ctx_.context(), "bn_ad_done", current_func);
+        llvm::BasicBlock* merge_block = llvm::BasicBlock::Create(ctx_.context(), "bn_merge", current_func);
+        emitTensorADNormalizeDispatch(input_elems, result_elems, total_elements,
+            bn_group_len, bn_inner_stride, gamma, gamma_val, beta, beta_val,
+            epsilon, eps_arg, ad_done, "bn");
+        // Numeric path (dispatch leaves the builder at its numeric_path). The
+        // runtime kernel decodes gamma/beta as scalar OR per-feature tensor.
+        llvm::Value* numeric_packed = emitNumericNormalize(input_val, gamma_val,
+            beta_val, epsilon, bn_group_len, bn_inner_stride);
+        builder.CreateBr(merge_block);
+        llvm::BasicBlock* numeric_exit = builder.GetInsertBlock();
 
-    builder.CreateStore(llvm::ConstantFP::get(ctx_.doubleType(), 0.0), sum);
-    builder.CreateStore(llvm::ConstantInt::get(ctx_.int64Type(), 0), idx);
+        builder.SetInsertPoint(ad_done);
+        llvm::Value* ad_packed = tagged_.packHeapPtr(result_ptr);
+        builder.CreateBr(merge_block);
+        llvm::BasicBlock* ad_exit = builder.GetInsertBlock();
 
-    llvm::BasicBlock* mean_cond = llvm::BasicBlock::Create(ctx_.context(), "bn_mean_cond", current_func);
-    llvm::BasicBlock* mean_body = llvm::BasicBlock::Create(ctx_.context(), "bn_mean_body", current_func);
-    llvm::BasicBlock* mean_done = llvm::BasicBlock::Create(ctx_.context(), "bn_mean_done", current_func);
+        builder.SetInsertPoint(merge_block);
+        llvm::PHINode* result_phi = builder.CreatePHI(ctx_.taggedValueType(), 2, "bn_result_phi");
+        result_phi->addIncoming(ad_packed, ad_exit);
+        result_phi->addIncoming(numeric_packed, numeric_exit);
+        return result_phi;
+    }
 
-    builder.CreateBr(mean_cond);
-
-    builder.SetInsertPoint(mean_cond);
-    llvm::Value* curr_idx = builder.CreateLoad(ctx_.int64Type(), idx);
-    llvm::Value* mean_cmp = builder.CreateICmpSLT(curr_idx, total_elements);
-    builder.CreateCondBr(mean_cmp, mean_body, mean_done);
-
-    builder.SetInsertPoint(mean_body);
-    curr_idx = builder.CreateLoad(ctx_.int64Type(), idx);
-    llvm::Value* elem_ptr = builder.CreateGEP(ctx_.int64Type(), input_elems, curr_idx);
-    llvm::Value* elem_bits = builder.CreateLoad(ctx_.int64Type(), elem_ptr);
-    llvm::Value* elem = builder.CreateBitCast(elem_bits, ctx_.doubleType());
-    llvm::Value* curr_sum = builder.CreateLoad(ctx_.doubleType(), sum);
-    llvm::Value* new_sum = builder.CreateFAdd(curr_sum, elem);
-    builder.CreateStore(new_sum, sum);
-    llvm::Value* next_idx = builder.CreateAdd(curr_idx, llvm::ConstantInt::get(ctx_.int64Type(), 1));
-    builder.CreateStore(next_idx, idx);
-    builder.CreateBr(mean_cond);
-
-    builder.SetInsertPoint(mean_done);
-    llvm::Value* final_sum = builder.CreateLoad(ctx_.doubleType(), sum);
-    llvm::Value* total_fp = builder.CreateSIToFP(total_elements, ctx_.doubleType());
-    llvm::Value* mean_val = builder.CreateFDiv(final_sum, total_fp);
-    builder.CreateStore(mean_val, mean);
-
-    // Second pass: compute variance
-    builder.CreateStore(llvm::ConstantFP::get(ctx_.doubleType(), 0.0), sum);
-    builder.CreateStore(llvm::ConstantInt::get(ctx_.int64Type(), 0), idx);
-
-    llvm::BasicBlock* var_cond = llvm::BasicBlock::Create(ctx_.context(), "bn_var_cond", current_func);
-    llvm::BasicBlock* var_body = llvm::BasicBlock::Create(ctx_.context(), "bn_var_body", current_func);
-    llvm::BasicBlock* var_done = llvm::BasicBlock::Create(ctx_.context(), "bn_var_done", current_func);
-
-    builder.CreateBr(var_cond);
-
-    builder.SetInsertPoint(var_cond);
-    curr_idx = builder.CreateLoad(ctx_.int64Type(), idx);
-    llvm::Value* var_cmp = builder.CreateICmpSLT(curr_idx, total_elements);
-    builder.CreateCondBr(var_cmp, var_body, var_done);
-
-    builder.SetInsertPoint(var_body);
-    curr_idx = builder.CreateLoad(ctx_.int64Type(), idx);
-    elem_ptr = builder.CreateGEP(ctx_.int64Type(), input_elems, curr_idx);
-    elem_bits = builder.CreateLoad(ctx_.int64Type(), elem_ptr);
-    elem = builder.CreateBitCast(elem_bits, ctx_.doubleType());
-    mean_val = builder.CreateLoad(ctx_.doubleType(), mean);
-    llvm::Value* diff = builder.CreateFSub(elem, mean_val);
-    llvm::Value* sq_diff = builder.CreateFMul(diff, diff);
-    curr_sum = builder.CreateLoad(ctx_.doubleType(), sum);
-    new_sum = builder.CreateFAdd(curr_sum, sq_diff);
-    builder.CreateStore(new_sum, sum);
-    next_idx = builder.CreateAdd(curr_idx, llvm::ConstantInt::get(ctx_.int64Type(), 1));
-    builder.CreateStore(next_idx, idx);
-    builder.CreateBr(var_cond);
-
-    builder.SetInsertPoint(var_done);
-    final_sum = builder.CreateLoad(ctx_.doubleType(), sum);
-    llvm::Value* var_val = builder.CreateFDiv(final_sum, total_fp);
-    builder.CreateStore(var_val, var);
-
-    // Third pass: normalize and scale
-    builder.CreateStore(llvm::ConstantInt::get(ctx_.int64Type(), 0), idx);
-
-    // Compute std = sqrt(var + eps)
-    llvm::Value* var_plus_eps = builder.CreateFAdd(var_val, epsilon);
-    llvm::Function* sqrt_func = ESHKOL_GET_INTRINSIC(&ctx_.module(), llvm::Intrinsic::sqrt, {ctx_.doubleType()});
-    llvm::Value* std_val = builder.CreateCall(sqrt_func, {var_plus_eps});
-
-    llvm::BasicBlock* norm_cond = llvm::BasicBlock::Create(ctx_.context(), "bn_norm_cond", current_func);
-    llvm::BasicBlock* norm_body = llvm::BasicBlock::Create(ctx_.context(), "bn_norm_body", current_func);
-    llvm::BasicBlock* norm_done = llvm::BasicBlock::Create(ctx_.context(), "bn_norm_done", current_func);
-
-    builder.CreateBr(norm_cond);
-
-    builder.SetInsertPoint(norm_cond);
-    curr_idx = builder.CreateLoad(ctx_.int64Type(), idx);
-    llvm::Value* norm_cmp = builder.CreateICmpSLT(curr_idx, total_elements);
-    builder.CreateCondBr(norm_cmp, norm_body, norm_done);
-
-    builder.SetInsertPoint(norm_body);
-    curr_idx = builder.CreateLoad(ctx_.int64Type(), idx);
-    elem_ptr = builder.CreateGEP(ctx_.int64Type(), input_elems, curr_idx);
-    elem_bits = builder.CreateLoad(ctx_.int64Type(), elem_ptr);
-    elem = builder.CreateBitCast(elem_bits, ctx_.doubleType());
-    mean_val = builder.CreateLoad(ctx_.doubleType(), mean);
-
-    // y = gamma * (x - mean) / std + beta
-    llvm::Value* centered = builder.CreateFSub(elem, mean_val);
-    llvm::Value* normalized = builder.CreateFDiv(centered, std_val);
-    llvm::Value* scaled = builder.CreateFMul(normalized, gamma);
-    llvm::Value* shifted = builder.CreateFAdd(scaled, beta);
-
-    llvm::Value* out_ptr = builder.CreateGEP(ctx_.int64Type(), result_elems, curr_idx);
-    llvm::Value* out_bits = builder.CreateBitCast(shifted, ctx_.int64Type());
-    builder.CreateStore(out_bits, out_ptr);
-
-    next_idx = builder.CreateAdd(curr_idx, llvm::ConstantInt::get(ctx_.int64Type(), 1));
-    builder.CreateStore(next_idx, idx);
-    builder.CreateBr(norm_cond);
-
-    builder.SetInsertPoint(norm_done);
-    builder.CreateBr(exit_block);
-
-    builder.SetInsertPoint(exit_block);
-    return tagged_.packHeapPtr(result_ptr);
+    return emitNumericNormalize(input_val, gamma_val, beta_val, epsilon,
+        bn_group_len, bn_inner_stride);
 }
 
 llvm::Value* TensorCodegen::layerNorm(const eshkol_operations_t* op) {
@@ -1694,12 +1629,44 @@ llvm::Value* TensorCodegen::layerNorm(const eshkol_operations_t* op) {
         else if (eps_arg->getType()->isIntegerTy(64)) eps_d = builder.CreateSIToFP(eps_arg, ctx_.doubleType());
 
         llvm::Value* arena = builder.CreateLoad(ctx_.ptrType(), ctx_.globalArena());
-        auto* ptrTy = ctx_.ptrType();
-        auto* i64Ty = ctx_.int64Type();
-        auto* dblTy = ctx_.doubleType();
+        (void)arena;
+        llvm::Function* current_func = builder.GetInsertBlock()->getParent();
+
+        // Normalize the axis and compute axis length + inner stride (matching
+        // emitTensorADNormalizeDispatch's grouping).
+        llvm::Value* is_negative_axis = builder.CreateICmpSLT(axis,
+            llvm::ConstantInt::get(ctx_.int64Type(), 0));
+        llvm::Value* normalized_axis = builder.CreateSelect(is_negative_axis,
+            builder.CreateAdd(axis, rank), axis);
+        llvm::Value* axis_len = builder.CreateLoad(ctx_.int64Type(),
+            builder.CreateGEP(ctx_.int64Type(), dims, normalized_axis));
+
+        llvm::Value* one_i64 = llvm::ConstantInt::get(ctx_.int64Type(), 1);
+        llvm::Value* inner_stride_alloca = builder.CreateAlloca(ctx_.int64Type(), nullptr, "ln_axis_inner_stride");
+        llvm::Value* stride_i_alloca = builder.CreateAlloca(ctx_.int64Type(), nullptr, "ln_axis_stride_i");
+        builder.CreateStore(one_i64, inner_stride_alloca);
+        builder.CreateStore(builder.CreateAdd(normalized_axis, one_i64), stride_i_alloca);
+        llvm::BasicBlock* stride_cond = llvm::BasicBlock::Create(ctx_.context(), "ln_axis_stride_cond", current_func);
+        llvm::BasicBlock* stride_body = llvm::BasicBlock::Create(ctx_.context(), "ln_axis_stride_body", current_func);
+        llvm::BasicBlock* stride_done = llvm::BasicBlock::Create(ctx_.context(), "ln_axis_stride_done", current_func);
+        builder.CreateBr(stride_cond);
+
+        builder.SetInsertPoint(stride_cond);
+        llvm::Value* stride_i = builder.CreateLoad(ctx_.int64Type(), stride_i_alloca);
+        builder.CreateCondBr(builder.CreateICmpULT(stride_i, rank), stride_body, stride_done);
+
+        builder.SetInsertPoint(stride_body);
+        llvm::Value* stride_dim = builder.CreateLoad(ctx_.int64Type(),
+            builder.CreateGEP(ctx_.int64Type(), dims, stride_i));
+        llvm::Value* old_stride = builder.CreateLoad(ctx_.int64Type(), inner_stride_alloca);
+        builder.CreateStore(builder.CreateMul(old_stride, stride_dim), inner_stride_alloca);
+        builder.CreateStore(builder.CreateAdd(stride_i, one_i64), stride_i_alloca);
+        builder.CreateBr(stride_cond);
+
+        builder.SetInsertPoint(stride_done);
+        llvm::Value* inner_stride = builder.CreateLoad(ctx_.int64Type(), inner_stride_alloca);
 
         if (autodiff_) {
-            llvm::Function* current_func = builder.GetInsertBlock()->getParent();
             llvm::BasicBlock* ad_done = llvm::BasicBlock::Create(ctx_.context(), "ln_axis_ad_done", current_func);
             llvm::BasicBlock* merge_block = llvm::BasicBlock::Create(ctx_.context(), "ln_axis_merge", current_func);
 
@@ -1713,38 +1680,6 @@ llvm::Value* TensorCodegen::layerNorm(const eshkol_operations_t* op) {
             llvm::Value* elems_size = builder.CreateMul(total,
                 llvm::ConstantInt::get(ctx_.int64Type(), sizeof(double)));
             llvm::Value* result_elems = builder.CreateCall(arena_alloc, {arena, elems_size}, "ln_axis_ad_elems");
-
-            llvm::Value* is_negative_axis = builder.CreateICmpSLT(axis,
-                llvm::ConstantInt::get(ctx_.int64Type(), 0));
-            llvm::Value* normalized_axis = builder.CreateSelect(is_negative_axis,
-                builder.CreateAdd(axis, rank), axis);
-            llvm::Value* axis_len = builder.CreateLoad(ctx_.int64Type(),
-                builder.CreateGEP(ctx_.int64Type(), dims, normalized_axis));
-
-            llvm::Value* one_i64 = llvm::ConstantInt::get(ctx_.int64Type(), 1);
-            llvm::Value* inner_stride_alloca = builder.CreateAlloca(ctx_.int64Type(), nullptr, "ln_axis_inner_stride");
-            llvm::Value* stride_i_alloca = builder.CreateAlloca(ctx_.int64Type(), nullptr, "ln_axis_stride_i");
-            builder.CreateStore(one_i64, inner_stride_alloca);
-            builder.CreateStore(builder.CreateAdd(normalized_axis, one_i64), stride_i_alloca);
-            llvm::BasicBlock* stride_cond = llvm::BasicBlock::Create(ctx_.context(), "ln_axis_stride_cond", current_func);
-            llvm::BasicBlock* stride_body = llvm::BasicBlock::Create(ctx_.context(), "ln_axis_stride_body", current_func);
-            llvm::BasicBlock* stride_done = llvm::BasicBlock::Create(ctx_.context(), "ln_axis_stride_done", current_func);
-            builder.CreateBr(stride_cond);
-
-            builder.SetInsertPoint(stride_cond);
-            llvm::Value* stride_i = builder.CreateLoad(ctx_.int64Type(), stride_i_alloca);
-            builder.CreateCondBr(builder.CreateICmpULT(stride_i, rank), stride_body, stride_done);
-
-            builder.SetInsertPoint(stride_body);
-            llvm::Value* stride_dim = builder.CreateLoad(ctx_.int64Type(),
-                builder.CreateGEP(ctx_.int64Type(), dims, stride_i));
-            llvm::Value* old_stride = builder.CreateLoad(ctx_.int64Type(), inner_stride_alloca);
-            builder.CreateStore(builder.CreateMul(old_stride, stride_dim), inner_stride_alloca);
-            builder.CreateStore(builder.CreateAdd(stride_i, one_i64), stride_i_alloca);
-            builder.CreateBr(stride_cond);
-
-            builder.SetInsertPoint(stride_done);
-            llvm::Value* inner_stride = builder.CreateLoad(ctx_.int64Type(), inner_stride_alloca);
             builder.CreateStore(result_dims, builder.CreateStructGEP(ttype, result_ptr, 0));
             builder.CreateStore(rank, builder.CreateStructGEP(ttype, result_ptr, 1));
             builder.CreateStore(result_elems, builder.CreateStructGEP(ttype, result_ptr, 2));
@@ -1754,12 +1689,9 @@ llvm::Value* TensorCodegen::layerNorm(const eshkol_operations_t* op) {
                 inner_stride, gamma_d, gamma_val, beta_d, beta_val, eps_d, eps_arg,
                 ad_done, "ln_axis");
 
-            llvm::FunctionType* fn_type = llvm::FunctionType::get(ptrTy,
-                {ptrTy, ptrTy, i64Ty, ptrTy, i64Ty, i64Ty, dblTy, dblTy, dblTy}, false);
-            llvm::FunctionCallee callee = ctx_.module().getOrInsertFunction("eshkol_xla_normalize", fn_type);
-            llvm::Value* numeric_result = builder.CreateCall(callee,
-                {arena, elems, total, dims, rank, axis, gamma_d, beta_d, eps_d}, "ln_axis_numeric_result");
-            llvm::Value* numeric_packed = tagged_.packHeapPtr(numeric_result);
+            // Numeric path — runtime kernel handles scalar OR tensor gamma/beta.
+            llvm::Value* numeric_packed = emitNumericNormalize(input_val, gamma_val,
+                beta_val, eps_d, axis_len, inner_stride);
             builder.CreateBr(merge_block);
             llvm::BasicBlock* numeric_exit = builder.GetInsertBlock();
 
@@ -1775,12 +1707,8 @@ llvm::Value* TensorCodegen::layerNorm(const eshkol_operations_t* op) {
             return result_phi;
         }
 
-        llvm::FunctionType* fn_type = llvm::FunctionType::get(ptrTy,
-            {ptrTy, ptrTy, i64Ty, ptrTy, i64Ty, i64Ty, dblTy, dblTy, dblTy}, false);
-        llvm::FunctionCallee callee = ctx_.module().getOrInsertFunction("eshkol_xla_normalize", fn_type);
-        llvm::Value* result = builder.CreateCall(callee,
-            {arena, elems, total, dims, rank, axis, gamma_d, beta_d, eps_d}, "ln_axis_result");
-        return tagged_.packHeapPtr(result);
+        return emitNumericNormalize(input_val, gamma_val, beta_val, eps_d,
+            axis_len, inner_stride);
     }
 
     auto& builder = ctx_.builder();
@@ -1851,146 +1779,38 @@ llvm::Value* TensorCodegen::layerNorm(const eshkol_operations_t* op) {
     llvm::Value* last_dim_ptr = builder.CreateGEP(ctx_.int64Type(), in_dims, last_dim_idx);
     llvm::Value* feature_size = builder.CreateLoad(ctx_.int64Type(), last_dim_ptr);
 
-    // batch_size = total_elements / feature_size
-    llvm::Value* batch_size = builder.CreateUDiv(total_elements, feature_size);
-    llvm::Value* feature_fp = builder.CreateSIToFP(feature_size, ctx_.doubleType());
-
     llvm::Function* current_func = builder.GetInsertBlock()->getParent();
-    llvm::BasicBlock* exit_block = llvm::BasicBlock::Create(ctx_.context(), "ln_exit", current_func);
-    emitTensorADNormalizeDispatch(input_elems, result_elems, total_elements,
-        feature_size, llvm::ConstantInt::get(ctx_.int64Type(), 1),
-        gamma, gamma_val, beta, beta_val, epsilon, eps_arg, exit_block, "ln");
+    // layer-norm 4-arg normalizes over the last dimension (features) per sample.
+    llvm::Value* ln_group_len = feature_size;
+    llvm::Value* ln_inner_stride = llvm::ConstantInt::get(ctx_.int64Type(), 1);
 
-    llvm::Function* sqrt_func = ESHKOL_GET_INTRINSIC(
-        &ctx_.module(), llvm::Intrinsic::sqrt, {ctx_.doubleType()});
+    if (autodiff_) {
+        llvm::BasicBlock* ad_done = llvm::BasicBlock::Create(ctx_.context(), "ln_ad_done", current_func);
+        llvm::BasicBlock* merge_block = llvm::BasicBlock::Create(ctx_.context(), "ln_merge", current_func);
+        emitTensorADNormalizeDispatch(input_elems, result_elems, total_elements,
+            ln_group_len, ln_inner_stride, gamma, gamma_val, beta, beta_val,
+            epsilon, eps_arg, ad_done, "ln");
+        // Numeric path (dispatch leaves the builder at its numeric_path). The
+        // runtime kernel decodes gamma/beta as scalar OR per-feature tensor.
+        llvm::Value* numeric_packed = emitNumericNormalize(input_val, gamma_val,
+            beta_val, epsilon, ln_group_len, ln_inner_stride);
+        builder.CreateBr(merge_block);
+        llvm::BasicBlock* numeric_exit = builder.GetInsertBlock();
 
-    // Allocas for loop variables
-    llvm::Value* batch_idx = builder.CreateAlloca(ctx_.int64Type(), nullptr, "ln_batch_idx");
-    llvm::Value* feat_idx = builder.CreateAlloca(ctx_.int64Type(), nullptr, "ln_feat_idx");
-    llvm::Value* ln_sum = builder.CreateAlloca(ctx_.doubleType(), nullptr, "ln_sum");
-    llvm::Value* ln_mean = builder.CreateAlloca(ctx_.doubleType(), nullptr, "ln_mean");
+        builder.SetInsertPoint(ad_done);
+        llvm::Value* ad_packed = tagged_.packHeapPtr(result_ptr);
+        builder.CreateBr(merge_block);
+        llvm::BasicBlock* ad_exit = builder.GetInsertBlock();
 
-    builder.CreateStore(llvm::ConstantInt::get(ctx_.int64Type(), 0), batch_idx);
+        builder.SetInsertPoint(merge_block);
+        llvm::PHINode* result_phi = builder.CreatePHI(ctx_.taggedValueType(), 2, "ln_result_phi");
+        result_phi->addIncoming(ad_packed, ad_exit);
+        result_phi->addIncoming(numeric_packed, numeric_exit);
+        return result_phi;
+    }
 
-    // === Outer loop: iterate over samples ===
-    llvm::BasicBlock* batch_cond = llvm::BasicBlock::Create(ctx_.context(), "ln_batch_cond", current_func);
-    llvm::BasicBlock* batch_body = llvm::BasicBlock::Create(ctx_.context(), "ln_batch_body", current_func);
-    llvm::BasicBlock* batch_done = llvm::BasicBlock::Create(ctx_.context(), "ln_batch_done", current_func);
-
-    builder.CreateBr(batch_cond);
-
-    builder.SetInsertPoint(batch_cond);
-    llvm::Value* bi = builder.CreateLoad(ctx_.int64Type(), batch_idx);
-    builder.CreateCondBr(builder.CreateICmpULT(bi, batch_size), batch_body, batch_done);
-
-    builder.SetInsertPoint(batch_body);
-    llvm::Value* base_offset = builder.CreateMul(bi, feature_size);
-
-    // --- Pass 1: Compute mean for this sample ---
-    builder.CreateStore(llvm::ConstantFP::get(ctx_.doubleType(), 0.0), ln_sum);
-    builder.CreateStore(llvm::ConstantInt::get(ctx_.int64Type(), 0), feat_idx);
-
-    llvm::BasicBlock* mean_cond = llvm::BasicBlock::Create(ctx_.context(), "ln_mean_cond", current_func);
-    llvm::BasicBlock* mean_body = llvm::BasicBlock::Create(ctx_.context(), "ln_mean_body", current_func);
-    llvm::BasicBlock* mean_done = llvm::BasicBlock::Create(ctx_.context(), "ln_mean_done", current_func);
-
-    builder.CreateBr(mean_cond);
-
-    builder.SetInsertPoint(mean_cond);
-    llvm::Value* fi = builder.CreateLoad(ctx_.int64Type(), feat_idx);
-    builder.CreateCondBr(builder.CreateICmpULT(fi, feature_size), mean_body, mean_done);
-
-    builder.SetInsertPoint(mean_body);
-    llvm::Value* elem_offset = builder.CreateAdd(base_offset, fi);
-    llvm::Value* elem_ptr = builder.CreateGEP(ctx_.int64Type(), input_elems, elem_offset);
-    llvm::Value* elem_bits = builder.CreateLoad(ctx_.int64Type(), elem_ptr);
-    llvm::Value* elem = builder.CreateBitCast(elem_bits, ctx_.doubleType());
-    llvm::Value* cur_sum = builder.CreateLoad(ctx_.doubleType(), ln_sum);
-    builder.CreateStore(builder.CreateFAdd(cur_sum, elem), ln_sum);
-    builder.CreateStore(builder.CreateAdd(fi, llvm::ConstantInt::get(ctx_.int64Type(), 1)), feat_idx);
-    builder.CreateBr(mean_cond);
-
-    builder.SetInsertPoint(mean_done);
-    llvm::Value* sum_val = builder.CreateLoad(ctx_.doubleType(), ln_sum);
-    llvm::Value* mean_val = builder.CreateFDiv(sum_val, feature_fp);
-    builder.CreateStore(mean_val, ln_mean);
-
-    // --- Pass 2: Compute variance for this sample ---
-    builder.CreateStore(llvm::ConstantFP::get(ctx_.doubleType(), 0.0), ln_sum);
-    builder.CreateStore(llvm::ConstantInt::get(ctx_.int64Type(), 0), feat_idx);
-
-    llvm::BasicBlock* var_cond = llvm::BasicBlock::Create(ctx_.context(), "ln_var_cond", current_func);
-    llvm::BasicBlock* var_body = llvm::BasicBlock::Create(ctx_.context(), "ln_var_body", current_func);
-    llvm::BasicBlock* var_done = llvm::BasicBlock::Create(ctx_.context(), "ln_var_done", current_func);
-
-    builder.CreateBr(var_cond);
-
-    builder.SetInsertPoint(var_cond);
-    fi = builder.CreateLoad(ctx_.int64Type(), feat_idx);
-    builder.CreateCondBr(builder.CreateICmpULT(fi, feature_size), var_body, var_done);
-
-    builder.SetInsertPoint(var_body);
-    elem_offset = builder.CreateAdd(base_offset, fi);
-    elem_ptr = builder.CreateGEP(ctx_.int64Type(), input_elems, elem_offset);
-    elem_bits = builder.CreateLoad(ctx_.int64Type(), elem_ptr);
-    elem = builder.CreateBitCast(elem_bits, ctx_.doubleType());
-    mean_val = builder.CreateLoad(ctx_.doubleType(), ln_mean);
-    llvm::Value* diff = builder.CreateFSub(elem, mean_val);
-    llvm::Value* sq_diff = builder.CreateFMul(diff, diff);
-    cur_sum = builder.CreateLoad(ctx_.doubleType(), ln_sum);
-    builder.CreateStore(builder.CreateFAdd(cur_sum, sq_diff), ln_sum);
-    builder.CreateStore(builder.CreateAdd(fi, llvm::ConstantInt::get(ctx_.int64Type(), 1)), feat_idx);
-    builder.CreateBr(var_cond);
-
-    builder.SetInsertPoint(var_done);
-    llvm::Value* var_sum = builder.CreateLoad(ctx_.doubleType(), ln_sum);
-    llvm::Value* var_val = builder.CreateFDiv(var_sum, feature_fp);
-    llvm::Value* var_plus_eps = builder.CreateFAdd(var_val, epsilon);
-    llvm::Value* std_val = builder.CreateCall(sqrt_func, {var_plus_eps});
-
-    // --- Pass 3: Normalize, scale, and shift for this sample ---
-    builder.CreateStore(llvm::ConstantInt::get(ctx_.int64Type(), 0), feat_idx);
-
-    llvm::BasicBlock* norm_cond = llvm::BasicBlock::Create(ctx_.context(), "ln_norm_cond", current_func);
-    llvm::BasicBlock* norm_body = llvm::BasicBlock::Create(ctx_.context(), "ln_norm_body", current_func);
-    llvm::BasicBlock* norm_done = llvm::BasicBlock::Create(ctx_.context(), "ln_norm_done", current_func);
-
-    builder.CreateBr(norm_cond);
-
-    builder.SetInsertPoint(norm_cond);
-    fi = builder.CreateLoad(ctx_.int64Type(), feat_idx);
-    builder.CreateCondBr(builder.CreateICmpULT(fi, feature_size), norm_body, norm_done);
-
-    builder.SetInsertPoint(norm_body);
-    elem_offset = builder.CreateAdd(base_offset, fi);
-    elem_ptr = builder.CreateGEP(ctx_.int64Type(), input_elems, elem_offset);
-    elem_bits = builder.CreateLoad(ctx_.int64Type(), elem_ptr);
-    elem = builder.CreateBitCast(elem_bits, ctx_.doubleType());
-    mean_val = builder.CreateLoad(ctx_.doubleType(), ln_mean);
-
-    // y = gamma * (x - mean) / std + beta
-    llvm::Value* centered = builder.CreateFSub(elem, mean_val);
-    llvm::Value* normalized = builder.CreateFDiv(centered, std_val);
-    llvm::Value* scaled = builder.CreateFMul(normalized, gamma);
-    llvm::Value* shifted = builder.CreateFAdd(scaled, beta);
-
-    llvm::Value* out_ptr = builder.CreateGEP(ctx_.int64Type(), result_elems, elem_offset);
-    llvm::Value* out_bits = builder.CreateBitCast(shifted, ctx_.int64Type());
-    builder.CreateStore(out_bits, out_ptr);
-
-    builder.CreateStore(builder.CreateAdd(fi, llvm::ConstantInt::get(ctx_.int64Type(), 1)), feat_idx);
-    builder.CreateBr(norm_cond);
-
-    builder.SetInsertPoint(norm_done);
-    // Advance to next sample
-    builder.CreateStore(builder.CreateAdd(bi, llvm::ConstantInt::get(ctx_.int64Type(), 1)), batch_idx);
-    builder.CreateBr(batch_cond);
-
-    builder.SetInsertPoint(batch_done);
-    builder.CreateBr(exit_block);
-
-    builder.SetInsertPoint(exit_block);
-    return tagged_.packHeapPtr(result_ptr);
+    return emitNumericNormalize(input_val, gamma_val, beta_val, epsilon,
+        ln_group_len, ln_inner_stride);
 }
 
 llvm::Value* TensorCodegen::extractAsDouble(llvm::Value* tagged_val) {

--- a/lib/backend/tensor_extras_codegen.cpp
+++ b/lib/backend/tensor_extras_codegen.cpp
@@ -1609,7 +1609,47 @@ llvm::Value* TensorCodegen::tensorPow(const eshkol_operations_t* op) {
     llvm::Value* a = codegenAST(&op->call_op.variables[0]);
     llvm::Value* b = codegenAST(&op->call_op.variables[1]);
     if (!a || !b) return nullptr;
-    return tensorArithmeticInternal(a, b, "pow");
+
+    auto& builder = ctx_.builder();
+    a = tagged_.ensureTagged(a);
+    b = tagged_.ensureTagged(b);
+
+    // The exponent may be a tensor (elementwise/broadcast, via the SIMD path) OR
+    // a scalar. The old code always routed through tensorArithmeticInternal,
+    // whose operand check rejected a scalar exponent with a spurious
+    // "expected tensor" error. Dispatch on the exponent's runtime type so a
+    // scalar exponent is broadcast across the base tensor instead.
+    llvm::Value* b_is_tensor = tagged_.isTensor(b);
+    llvm::Function* current_func = builder.GetInsertBlock()->getParent();
+    llvm::BasicBlock* tensor_exp = llvm::BasicBlock::Create(ctx_.context(), "tpow_tensor_exp", current_func);
+    llvm::BasicBlock* scalar_exp = llvm::BasicBlock::Create(ctx_.context(), "tpow_scalar_exp", current_func);
+    llvm::BasicBlock* merge = llvm::BasicBlock::Create(ctx_.context(), "tpow_merge", current_func);
+    llvm::Value* result_alloca = builder.CreateAlloca(ctx_.taggedValueType(), nullptr, "tpow_result");
+    builder.CreateCondBr(b_is_tensor, tensor_exp, scalar_exp);
+
+    // Tensor exponent: existing SIMD/broadcast elementwise pow.
+    builder.SetInsertPoint(tensor_exp);
+    llvm::Value* tensor_result = tensorArithmeticInternal(a, b, "pow");
+    builder.CreateStore(tensor_result, result_alloca);
+    builder.CreateBr(merge);
+
+    // Scalar exponent: broadcast via the runtime kernel.
+    builder.SetInsertPoint(scalar_exp);
+    llvm::Value* base_ptr = unpackTensorOperandChecked(a, "tensor-pow");
+    llvm::Value* base_slot = builder.CreateAlloca(ctx_.taggedValueType(), nullptr, "tpow_base_tv");
+    builder.CreateStore(tagged_.packHeapPtr(base_ptr), base_slot);
+    llvm::Value* exp_d = extractAsDouble(b);
+    llvm::Value* arena = builder.CreateLoad(ctx_.ptrType(), ctx_.globalArena());
+    llvm::FunctionType* fn_type = llvm::FunctionType::get(ctx_.ptrType(),
+        {ctx_.ptrType(), ctx_.ptrType(), ctx_.doubleType()}, false);
+    llvm::FunctionCallee callee =
+        ctx_.module().getOrInsertFunction("eshkol_tensor_pow_scalar", fn_type);
+    llvm::Value* scalar_result = builder.CreateCall(callee, {arena, base_slot, exp_d}, "tpow_scalar_result");
+    builder.CreateStore(tagged_.packHeapPtr(scalar_result), result_alloca);
+    builder.CreateBr(merge);
+
+    builder.SetInsertPoint(merge);
+    return builder.CreateLoad(ctx_.taggedValueType(), result_alloca);
 }
 
 llvm::Value* TensorCodegen::tensorMaximum(const eshkol_operations_t* op) {

--- a/lib/core/model_io.cpp
+++ b/lib/core/model_io.cpp
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <bit>
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -454,6 +455,206 @@ extern "C" void eshkol_tensor_load_tagged(arena_t* arena,
     eshkol_tensor_t* tensor = nullptr;
     if (!tensor_from_record(arena, records.front(), &tensor)) return;
     *result = make_heap_ptr(tensor);
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+ * Normalization (batch-norm / layer-norm) — numeric path
+ *
+ * Single robust implementation shared by both norms. It decodes gamma and
+ * beta from tagged values so it transparently handles BOTH a scalar
+ * (broadcast to every feature) and a per-feature tensor. The previous
+ * codegen extracted gamma/beta with unpackDouble() which reinterpreted a
+ * TENSOR pointer's bits as a scalar double (→ garbage denormals), and the
+ * 5-arg axis path passed those scalars to eshkol_xla_normalize which expected
+ * `const double*` pointers (→ SIGSEGV on wild dereference). Centralizing the
+ * decode here fixes both.
+ *
+ * Grouping mirrors emitTensorADNormalizeDispatch exactly so the numeric and
+ * autodiff paths agree:
+ *   group_count = total / group_len
+ *   for each group g: inner = g % inner_stride, outer = g / inner_stride,
+ *   base = outer*group_len*inner_stride + inner; element k of the group is at
+ *   base + k*inner_stride. gamma/beta are indexed by k (the feature position).
+ * ═══════════════════════════════════════════════════════════════════ */
+namespace {
+
+/* Decode a tagged value used as gamma/beta into either a scalar broadcast
+ * value or a pointer to a tensor's element array. */
+struct NormParam {
+    const int64_t* elems = nullptr;  /* non-null => per-feature tensor bits */
+    int64_t        len   = 0;        /* number of tensor elements */
+    double         scalar = 0.0;     /* used when elems == nullptr */
+};
+
+NormParam decode_norm_param(const eshkol_tagged_value_t* tv, double dflt) {
+    NormParam p;
+    p.scalar = dflt;
+    if (!tv) return p;
+    if (tagged_is_tensor(tv)) {
+        const auto* t = reinterpret_cast<const eshkol_tensor_t*>(tv->data.ptr_val);
+        if (t && t->elements && t->total_elements > 0) {
+            p.elems = t->elements;
+            p.len = static_cast<int64_t>(t->total_elements);
+        }
+        return p;
+    }
+    const uint8_t base = tv->type & 0x3F;
+    if (base == ESHKOL_VALUE_DOUBLE) {
+        p.scalar = tv->data.double_val;
+    } else if (base == ESHKOL_VALUE_INT64) {
+        p.scalar = static_cast<double>(tv->data.int_val);
+    }
+    return p;
+}
+
+inline double norm_param_at(const NormParam& p, int64_t k) {
+    if (p.elems) {
+        int64_t idx = (p.len == 1) ? 0 : (k % p.len);
+        return std::bit_cast<double>(p.elems[idx]);
+    }
+    return p.scalar;
+}
+
+} // namespace
+
+extern "C" void* eshkol_tensor_normalize_apply(
+    arena_t* arena,
+    const eshkol_tagged_value_t* input_tv,
+    int64_t group_len,
+    int64_t inner_stride,
+    const eshkol_tagged_value_t* gamma_tv,
+    const eshkol_tagged_value_t* beta_tv,
+    double epsilon) {
+    if (!arena || !input_tv || !tagged_is_tensor(input_tv)) return nullptr;
+    const auto* in = reinterpret_cast<const eshkol_tensor_t*>(input_tv->data.ptr_val);
+    if (!in || !in->elements) return nullptr;
+
+    const int64_t total = static_cast<int64_t>(in->total_elements);
+    const int64_t rank = static_cast<int64_t>(in->num_dimensions);
+    if (total <= 0) return nullptr;
+    if (group_len <= 0) group_len = total;
+    if (inner_stride <= 0) inner_stride = 1;
+    if (group_len > total) group_len = total;
+    if (total % group_len != 0) return nullptr;  /* malformed grouping */
+
+    eshkol_tensor_t* out = arena_allocate_tensor_full(
+        arena, static_cast<uint64_t>(rank), static_cast<uint64_t>(total));
+    if (!out || !out->elements) return nullptr;
+    for (int64_t i = 0; i < rank; i++) out->dimensions[i] = in->dimensions[i];
+
+    NormParam gamma = decode_norm_param(gamma_tv, 1.0);
+    NormParam beta  = decode_norm_param(beta_tv, 0.0);
+
+    const int64_t* src = in->elements;
+    int64_t* dst = out->elements;
+    const int64_t group_count = total / group_len;
+    const double count = static_cast<double>(group_len);
+
+    for (int64_t g = 0; g < group_count; g++) {
+        const int64_t inner = group_len == 0 ? 0 : (g % inner_stride);
+        const int64_t outer = g / inner_stride;
+        const int64_t base = outer * group_len * inner_stride + inner;
+
+        double mean = 0.0;
+        for (int64_t k = 0; k < group_len; k++) {
+            mean += std::bit_cast<double>(src[base + k * inner_stride]);
+        }
+        mean /= count;
+        double var = 0.0;
+        for (int64_t k = 0; k < group_len; k++) {
+            double d = std::bit_cast<double>(src[base + k * inner_stride]) - mean;
+            var += d * d;
+        }
+        var /= count;
+        const double inv_std = 1.0 / std::sqrt(var + epsilon);
+        for (int64_t k = 0; k < group_len; k++) {
+            const int64_t idx = base + k * inner_stride;
+            double norm = (std::bit_cast<double>(src[idx]) - mean) * inv_std;
+            double val = norm_param_at(gamma, k) * norm + norm_param_at(beta, k);
+            dst[idx] = std::bit_cast<int64_t>(val);
+        }
+    }
+    return out;
+}
+
+/* Elementwise application of a scalar libm unary function across a tensor.
+ * Backs the tensor-operand path of the scalar math builtins (sin/cos/tanh/…):
+ * previously those reinterpreted a tensor pointer as a scalar double and
+ * returned a silently-wrong scalar. op codes mirror codegenMathFunction. */
+extern "C" void* eshkol_tensor_map_libm(arena_t* arena,
+                                        const eshkol_tagged_value_t* in_tv,
+                                        int32_t op) {
+    if (!arena || !in_tv || !tagged_is_tensor(in_tv)) return nullptr;
+    const auto* in = reinterpret_cast<const eshkol_tensor_t*>(in_tv->data.ptr_val);
+    if (!in || !in->elements) return nullptr;
+
+    const int64_t total = static_cast<int64_t>(in->total_elements);
+    const int64_t rank = static_cast<int64_t>(in->num_dimensions);
+    if (total <= 0) return nullptr;
+
+    eshkol_tensor_t* out = arena_allocate_tensor_full(
+        arena, static_cast<uint64_t>(rank), static_cast<uint64_t>(total));
+    if (!out || !out->elements) return nullptr;
+    for (int64_t i = 0; i < rank; i++) out->dimensions[i] = in->dimensions[i];
+
+    for (int64_t i = 0; i < total; i++) {
+        double x = std::bit_cast<double>(in->elements[i]);
+        double y;
+        switch (op) {
+            case 0:  y = std::sin(x);   break;
+            case 1:  y = std::cos(x);   break;
+            case 2:  y = std::tan(x);   break;
+            case 3:  y = std::asin(x);  break;
+            case 4:  y = std::acos(x);  break;
+            case 5:  y = std::atan(x);  break;
+            case 6:  y = std::sinh(x);  break;
+            case 7:  y = std::cosh(x);  break;
+            case 8:  y = std::tanh(x);  break;
+            case 9:  y = std::asinh(x); break;
+            case 10: y = std::acosh(x); break;
+            case 11: y = std::atanh(x); break;
+            case 12: y = std::exp(x);   break;
+            case 13: y = std::exp2(x);  break;
+            case 14: y = std::log(x);   break;
+            case 15: y = std::log2(x);  break;
+            case 16: y = std::log10(x); break;
+            case 17: y = std::sqrt(x);  break;
+            case 18: y = std::cbrt(x);  break;
+            case 19: y = std::fabs(x);  break;
+            case 20: y = std::floor(x); break;
+            case 21: y = std::ceil(x);  break;
+            case 22: y = std::trunc(x); break;
+            case 23: y = std::rint(x);  break;  /* round half to even */
+            default: y = x;             break;
+        }
+        out->elements[i] = std::bit_cast<int64_t>(y);
+    }
+    return out;
+}
+
+/* Elementwise tensor ^ scalar. tensor-pow's SIMD path requires a tensor
+ * exponent; this backs the scalar-exponent broadcast so `(tensor-pow t 2.0)`
+ * works instead of raising a spurious "expected tensor" type error. */
+extern "C" void* eshkol_tensor_pow_scalar(arena_t* arena,
+                                          const eshkol_tagged_value_t* base_tv,
+                                          double exponent) {
+    if (!arena || !base_tv || !tagged_is_tensor(base_tv)) return nullptr;
+    const auto* in = reinterpret_cast<const eshkol_tensor_t*>(base_tv->data.ptr_val);
+    if (!in || !in->elements) return nullptr;
+
+    const int64_t total = static_cast<int64_t>(in->total_elements);
+    const int64_t rank = static_cast<int64_t>(in->num_dimensions);
+    if (total <= 0) return nullptr;
+
+    eshkol_tensor_t* out = arena_allocate_tensor_full(
+        arena, static_cast<uint64_t>(rank), static_cast<uint64_t>(total));
+    if (!out || !out->elements) return nullptr;
+    for (int64_t i = 0; i < rank; i++) out->dimensions[i] = in->dimensions[i];
+    for (int64_t i = 0; i < total; i++) {
+        double x = std::bit_cast<double>(in->elements[i]);
+        out->elements[i] = std::bit_cast<int64_t>(std::pow(x, exponent));
+    }
+    return out;
 }
 
 extern "C" void eshkol_model_save_tagged(arena_t* arena,

--- a/lib/core/system_builtins.c
+++ b/lib/core/system_builtins.c
@@ -4895,7 +4895,14 @@ static eshkol_sysbuiltin_value_t eshkol_builtin_tensor_load_v(eshkol_sysbuiltin_
     void* arena = get_global_arena();
     if (!arena) { fclose(f); return sys_make_null(); }
     eshkol_tensor_t_ffi* t = (eshkol_tensor_t_ffi*)arena_allocate_tensor_full(arena, ndims, (uint64_t)total);
-    if (!t || !t->elements) { fclose(f); return sys_make_null(); }
+    if (!t || !t->elements || !t->dimensions) { fclose(f); return sys_make_null(); }
+    /* Restore the shape: arena_allocate_tensor_full sizes the dimensions[]
+     * array but leaves it uninitialized. Without this copy the loaded tensor
+     * has num_dimensions=ndims but zeroed dims → tensor-shape reports (0 0…)
+     * and display shows #(). Round-trip must preserve the exact shape. */
+    for (uint32_t i = 0; i < ndims; i++) {
+        t->dimensions[i] = (uint64_t)shape[i];
+    }
     if ((int64_t)fread(t->elements, 8, (size_t)total, f) != total) {
         fclose(f);
         return sys_make_null();

--- a/lib/frontend/parser.cpp
+++ b/lib/frontend/parser.cpp
@@ -7699,23 +7699,24 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
                 };
 
                 if (first_non_dimension > 0 && first_non_dimension < operands.size()) {
+                    // A run of leading integers followed by non-integer operands
+                    // is only a shape prefix when the product of those integers
+                    // exactly matches the number of remaining (element) operands
+                    // (e.g. `(tensor 2 2 1.0 2.0 3.0 4.0)`). When it does not
+                    // match — the classic case being a mixed int+float element
+                    // list like `(tensor 1 2.5 3)` — the leading integers are NOT
+                    // a shape: treat every operand as a 1-D element. Previously
+                    // this misread the leading ints as dimensions and raised a
+                    // confusing "insufficient elements" error.
                     dimension_count = first_non_dimension;
-                    if (!compute_product(dimension_count, &total_elements)) {
-                        PARSE_ERROR_AT(token, "tensor dimensions overflow");
-                        ast.type = ESHKOL_INVALID;
-                        return ast;
-                    }
+                    uint64_t candidate_total = 0;
                     const uint64_t provided_elements =
                         (uint64_t)(operands.size() - dimension_count);
-                    if (provided_elements != total_elements) {
-                        PARSE_ERROR_AT(token,
-                            "tensor has insufficient elements: expected %llu, got %llu",
-                            (unsigned long long)total_elements,
-                            (unsigned long long)provided_elements);
-                        ast.type = ESHKOL_INVALID;
-                        return ast;
+                    if (compute_product(dimension_count, &candidate_total) &&
+                        candidate_total == provided_elements) {
+                        total_elements = candidate_total;
+                        use_explicit_dimensions = true;
                     }
-                    use_explicit_dimensions = true;
                 } else if (first_non_dimension == operands.size() && !operands.empty()) {
                     for (size_t candidate_count = 1; candidate_count <= operands.size();
                          candidate_count++) {

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -1146,6 +1146,9 @@ void ReplJITContext::registerRuntimeSymbols() {
     ADD_SYMBOL(eshkol_tensor_load_tagged);
     ADD_SYMBOL(eshkol_model_save_tagged);
     ADD_SYMBOL(eshkol_model_load_tagged);
+    ADD_SYMBOL(eshkol_tensor_normalize_apply);
+    ADD_SYMBOL(eshkol_tensor_pow_scalar);
+    ADD_SYMBOL(eshkol_tensor_map_libm);
     ADD_SYMBOL(eshkol_shapes_equal);
     ADD_SYMBOL(eshkol_broadcast_elementwise_f64);
     ADD_SYMBOL(eshkol_batch_matmul_f64);

--- a/tests/ml/sweep_b_regressions_test.esk
+++ b/tests/ml/sweep_b_regressions_test.esk
@@ -13,6 +13,11 @@
 ;;;
 ;;; Any failure prints an "error:" line so the ML harness (scripts/run_ml_tests.sh)
 ;;; flags it. Exercises the same source under both -r (JIT) and AOT.
+;;;
+;;; NOTE: bindings that must happen in a specific ORDER (e.g. tensor-save
+;;; before tensor-load) use let* so evaluation order is guaranteed — R7RS
+;;; internal defines interleaved with side-effecting expressions are not
+;;; ordered and would let the load run before the save.
 
 (define fails 0)
 
@@ -25,23 +30,29 @@
              (display "error: FAIL ") (display name) (newline))))
 
 ;; Compare a tensor's elements (via tensor-ref) against an expected list.
+;; Returns #f (never crashes) if t is not a tensor.
 (define (tensor-approx? t expected)
-  (let loop ((i 0) (e expected))
-    (cond ((null? e) #t)
-          ((approx? (tensor-ref t i) (car e)) (loop (+ i 1) (cdr e)))
-          (else #f))))
+  (and (tensor? t)
+       (let loop ((i 0) (e expected))
+         (cond ((null? e) #t)
+               ((approx? (tensor-ref t i) (car e)) (loop (+ i 1) (cdr e)))
+               (else #f)))))
+
+;; Shape equality that is null-safe (never crashes on a failed load).
+(define (shape-is? t expected)
+  (and (tensor? t) (equal? (tensor-shape t) expected)))
 
 ;; --- 1. tensor-load round-trips the shape ---
-(let ()
-  (define t (reshape (tensor 1.0 2.0 3.0 4.0) (list 2 2)))
-  (tensor-save "/tmp/sweep_b_rt.bin" t)
-  (define loaded (tensor-load "/tmp/sweep_b_rt.bin"))
-  (check "tensor-load-shape" (equal? (tensor-shape loaded) (list 2 2)))
+(let* ((t (reshape (tensor 1.0 2.0 3.0 4.0) (list 2 2)))
+       (_s1 (tensor-save "/tmp/sweep_b_rt.bin" t))
+       (loaded (tensor-load "/tmp/sweep_b_rt.bin"))
+       (v (reshape (tensor 5.0 6.0 7.0 8.0 9.0 10.0) (list 2 3)))
+       (_s2 (tensor-save "/tmp/sweep_b_rt2.bin" v))
+       (lv (tensor-load "/tmp/sweep_b_rt2.bin")))
+  (check "tensor-save-2x2" (eq? _s1 #t))
+  (check "tensor-load-shape" (shape-is? loaded (list 2 2)))
   (check "tensor-load-values" (tensor-approx? loaded (list 1.0 2.0 3.0 4.0)))
-  (define v (reshape (tensor 5.0 6.0 7.0 8.0 9.0 10.0) (list 2 3)))
-  (tensor-save "/tmp/sweep_b_rt2.bin" v)
-  (define lv (tensor-load "/tmp/sweep_b_rt2.bin"))
-  (check "tensor-load-shape-2x3" (equal? (tensor-shape lv) (list 2 3))))
+  (check "tensor-load-shape-2x3" (shape-is? lv (list 2 3))))
 
 ;; --- 2. scalar math on a tensor maps elementwise ---
 (let ()
@@ -54,8 +65,7 @@
 ;; --- 3. batch-norm / layer-norm ---
 ;; [1,2,3,4]: mean=2.5, var=1.25, std=sqrt(1.25+1e-5) ->
 ;;   normalized = [-1.341636, -0.447212, 0.447212, 1.341636]
-(let ()
-  (define norm (list -1.341636 -0.447212 0.447212 1.341636))
+(let ((norm (list -1.341636 -0.447212 0.447212 1.341636)))
   (check "layer-norm-4arg-scalar"
          (tensor-approx? (layer-norm (tensor 1.0 2.0 3.0 4.0) 1.0 0.0 0.00001) norm))
   (check "batch-norm-4arg-scalar"
@@ -78,12 +88,11 @@
          (tensor-approx? (batch-norm (tensor 1.0 2.0 3.0 4.0) 1.0 0.0 0.00001 0) norm)))
 
 ;; --- 4. tensor creation: mixed int+float => 1-D, shape syntax preserved ---
-(let ()
-  (define m (tensor 1 2.5 3))
-  (check "creation-mixed-shape" (equal? (tensor-shape m) (list 3)))
+(let ((m (tensor 1 2.5 3))
+      (s (tensor 2 2 1.0 2.0 3.0 4.0)))
+  (check "creation-mixed-shape" (shape-is? m (list 3)))
   (check "creation-mixed-values" (tensor-approx? m (list 1.0 2.5 3.0)))
-  (define s (tensor 2 2 1.0 2.0 3.0 4.0))
-  (check "creation-shaped" (equal? (tensor-shape s) (list 2 2))))
+  (check "creation-shaped" (shape-is? s (list 2 2))))
 
 ;; --- 5. gpu-reduce returns a scalar ---
 (let ()

--- a/tests/ml/sweep_b_regressions_test.esk
+++ b/tests/ml/sweep_b_regressions_test.esk
@@ -1,0 +1,104 @@
+;;; Release sweep B — tensor/ML regression tests
+;;;
+;;; Locks in the fixes for the Group-B release-blocking bugs:
+;;;   1. tensor-load must round-trip the SHAPE (not just the data)
+;;;   2. scalar math (tanh/sin/exp/...) on a TENSOR maps elementwise, not
+;;;      silently-wrong-scalar
+;;;   3. batch-norm / layer-norm: 4-arg (scalar AND tensor gamma/beta) and
+;;;      5-arg (axis) produce correct values (no garbage denormals / SIGSEGV)
+;;;   4. tensor creation with mixed int+float args builds the obvious 1-D
+;;;      tensor instead of misreading a leading int as a shape
+;;;   5. gpu-reduce returns a scalar (not #())
+;;;   6. tensor-pow accepts a scalar exponent (broadcast), not only a tensor
+;;;
+;;; Any failure prints an "error:" line so the ML harness (scripts/run_ml_tests.sh)
+;;; flags it. Exercises the same source under both -r (JIT) and AOT.
+
+(define fails 0)
+
+(define (approx? a b) (< (abs (- a b)) 0.001))
+
+(define (check name ok)
+  (if ok
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! fails (+ fails 1))
+             (display "error: FAIL ") (display name) (newline))))
+
+;; Compare a tensor's elements (via tensor-ref) against an expected list.
+(define (tensor-approx? t expected)
+  (let loop ((i 0) (e expected))
+    (cond ((null? e) #t)
+          ((approx? (tensor-ref t i) (car e)) (loop (+ i 1) (cdr e)))
+          (else #f))))
+
+;; --- 1. tensor-load round-trips the shape ---
+(let ()
+  (define t (reshape (tensor 1.0 2.0 3.0 4.0) (list 2 2)))
+  (tensor-save "/tmp/sweep_b_rt.bin" t)
+  (define loaded (tensor-load "/tmp/sweep_b_rt.bin"))
+  (check "tensor-load-shape" (equal? (tensor-shape loaded) (list 2 2)))
+  (check "tensor-load-values" (tensor-approx? loaded (list 1.0 2.0 3.0 4.0)))
+  (define v (reshape (tensor 5.0 6.0 7.0 8.0 9.0 10.0) (list 2 3)))
+  (tensor-save "/tmp/sweep_b_rt2.bin" v)
+  (define lv (tensor-load "/tmp/sweep_b_rt2.bin"))
+  (check "tensor-load-shape-2x3" (equal? (tensor-shape lv) (list 2 3))))
+
+;; --- 2. scalar math on a tensor maps elementwise ---
+(let ()
+  (check "tanh-scalar" (approx? (tanh 0.0) 0.0))
+  (check "tanh-tensor" (tensor-approx? (tanh (tensor 0.0 1.0)) (list 0.0 0.7615941)))
+  (check "sin-tensor"  (tensor-approx? (sin (tensor 0.0)) (list 0.0)))
+  (check "exp-tensor"  (tensor-approx? (exp (tensor 0.0 1.0)) (list 1.0 2.7182818)))
+  (check "sqrt-tensor" (tensor-approx? (sqrt (tensor 4.0 9.0)) (list 2.0 3.0))))
+
+;; --- 3. batch-norm / layer-norm ---
+;; [1,2,3,4]: mean=2.5, var=1.25, std=sqrt(1.25+1e-5) ->
+;;   normalized = [-1.341636, -0.447212, 0.447212, 1.341636]
+(let ()
+  (define norm (list -1.341636 -0.447212 0.447212 1.341636))
+  (check "layer-norm-4arg-scalar"
+         (tensor-approx? (layer-norm (tensor 1.0 2.0 3.0 4.0) 1.0 0.0 0.00001) norm))
+  (check "batch-norm-4arg-scalar"
+         (tensor-approx? (batch-norm (tensor 1.0 2.0 3.0 4.0) 1.0 0.0 0.00001) norm))
+  (check "layer-norm-4arg-tensor-gb"
+         (tensor-approx?
+           (layer-norm (tensor 1.0 2.0 3.0 4.0)
+                       (tensor 1.0 1.0 1.0 1.0) (tensor 0.0 0.0 0.0 0.0) 0.00001)
+           norm))
+  ;; per-feature gamma/beta: gamma=[1,2,3,4] beta=[10,20,30,40]
+  (check "layer-norm-per-feature"
+         (tensor-approx?
+           (layer-norm (tensor 1.0 2.0 3.0 4.0)
+                       (tensor 1.0 2.0 3.0 4.0) (tensor 10.0 20.0 30.0 40.0) 0.00001)
+           (list 8.658364 19.105576 31.341636 45.366544)))
+  ;; 5-arg axis form must not SIGSEGV and gives the 1-D result on axis 0
+  (check "layer-norm-5arg-axis"
+         (tensor-approx? (layer-norm (tensor 1.0 2.0 3.0 4.0) 1.0 0.0 0.00001 0) norm))
+  (check "batch-norm-5arg-axis"
+         (tensor-approx? (batch-norm (tensor 1.0 2.0 3.0 4.0) 1.0 0.0 0.00001 0) norm)))
+
+;; --- 4. tensor creation: mixed int+float => 1-D, shape syntax preserved ---
+(let ()
+  (define m (tensor 1 2.5 3))
+  (check "creation-mixed-shape" (equal? (tensor-shape m) (list 3)))
+  (check "creation-mixed-values" (tensor-approx? m (list 1.0 2.5 3.0)))
+  (define s (tensor 2 2 1.0 2.0 3.0 4.0))
+  (check "creation-shaped" (equal? (tensor-shape s) (list 2 2))))
+
+;; --- 5. gpu-reduce returns a scalar ---
+(let ()
+  (check "gpu-reduce-sum"  (approx? (gpu-reduce + (tensor 1.0 2.0 3.0 4.0)) 10.0))
+  (check "gpu-reduce-mean" (approx? (gpu-reduce mean (tensor 1.0 2.0 3.0 4.0)) 2.5))
+  (check "gpu-reduce-max"  (approx? (gpu-reduce max (tensor 1.0 5.0 3.0)) 5.0))
+  (check "gpu-reduce-min"  (approx? (gpu-reduce min (tensor 4.0 2.0 3.0)) 2.0)))
+
+;; --- 6. tensor-pow accepts scalar exponent (and still a tensor exponent) ---
+(let ()
+  (check "tensor-pow-scalar" (tensor-approx? (tensor-pow (tensor 2.0 3.0) 2.0) (list 4.0 9.0)))
+  (check "tensor-pow-tensor" (tensor-approx? (tensor-pow (tensor 2.0 3.0) (tensor 2.0 3.0)) (list 4.0 27.0))))
+
+(newline)
+(if (= fails 0)
+    (display "ALL SWEEP-B REGRESSIONS PASS")
+    (begin (display "error: ") (display fails) (display " sweep-B regression(s) FAILED")))
+(newline)


### PR DESCRIPTION
Release-blocking sweep (Group B: tensor/ML). Root-cause fixes for the verified findings documented against PR #124's tensor/AD reference. Every fix verified under **both `-r` (JIT) and AOT**.

## Fixes

1. **tensor-load dropped the shape.** `eshkol_builtin_tensor_load` allocated the `dimensions[]` array but never copied the loaded shape into it, so a round-trip kept the data/count but reported `tensor-shape` as `(0 …)` and displayed `#()`. Now copies the shape header into `dimensions[]`.

2. **Scalar math on a tensor was silently wrong.** `codegenMathFunction` (sin/cos/tan/tanh/exp/log/sqrt/… and rounding) had no tensor path — a tensor operand fell through to the scalar code, which reinterpreted the tensor pointer's bits as a double and returned a wrong scalar (`(tanh (tensor 0.0 1.0))` → `1`). Added a runtime tensor check that dispatches to a new elementwise `eshkol_tensor_map_libm` kernel (returns a tensor). Fixed uniformly across all sibling scalar-math builtins.

3. **batch-norm / layer-norm: garbage (4-arg) + SIGSEGV (5-arg axis).** The 4-arg path read gamma/beta with `unpackDouble` (a tensor pointer reinterpreted as a scalar → garbage denormals); the 5-arg path passed those scalars to `eshkol_xla_normalize`, which expects `const double*` (→ wild-pointer SIGSEGV). Both norms' numeric paths now route through a new `eshkol_tensor_normalize_apply` kernel that decodes gamma/beta as scalar **or** per-feature tensor; the autodiff path is preserved and PHI-merged.

4. **Tensor creation misread mixed int+float args as a shape.** `(tensor 1 2.5 3)` raised a confusing "insufficient elements" error because leading integers were treated as a shape prefix. Leading integers are now a shape only when their product matches the remaining element count; otherwise all operands are 1-D elements. `(tensor 2 2 1.0 2.0 3.0 4.0)` still builds a 2×2.

5. **gpu-reduce returned `#()`.** It routed through `emitAxisReduce(axis = -1)`, yielding a reduced-rank (rank-0) tensor that displays as `#()`. Now routes to the whole-tensor reductions and returns a proper scalar.

6. **tensor-pow required a tensor exponent.** A scalar exponent hit the operand check and raised "expected tensor". Now dispatches on the exponent's runtime type; a scalar exponent broadcasts via `eshkol_tensor_pow_scalar`.

## Tests / gates

- New `tests/ml/sweep_b_regressions_test.esk` — 23 checks with hand-computed exact values, green under `-r` and AOT.
- `scripts/run_ad_oracle.sh`: **46 pass / 34 xknown / 0 fail** (unchanged baseline).
- `scripts/run_sicp_smoke.sh`: **88/88**.
- `scripts/run_ml_tests.sh`: **42/42**.
- Docs (`docs/reference/tensors/{INDEX,operations,gpu}.md`) updated to drop the now-fixed known-issue notes.
