### PR TITLE
fix(stdlib,signal): release sweep A — csv row order, fft chain, partial, pq comparator, string-copy, div, memory-store-audit

### DIFF
--- a/docs/reference/stdlib/collections.md
+++ b/docs/reference/stdlib/collections.md
@@ -7,10 +7,11 @@ Three pure-Scheme containers not otherwise in stdlib: a binary **min-heap** prio
 
 ## Priority queue (min-heap)
 
-### `(make-pq)`
-Create an empty min-heap ordered by numeric key ascending (smallest key pops first).
-
-> **Known issue.** The header comment advertises `(make-pq compare)` for a custom comparator, but `make-pq` takes **no arguments** and always uses the built-in `(- a b)` min-heap. Eshkol tolerates the extra argument silently, so `(make-pq my-cmp)` compiles and runs but the comparator is **ignored** (see Known issues below).
+### `(make-pq)` / `(make-pq compare)`
+Create an empty priority queue. With no argument it is a min-heap ordered by
+numeric key ascending (smallest key pops first). With a `compare` argument — a
+2-arg procedure returning `<0` / `0` / `>0` — the heap is ordered by that
+comparator; e.g. `(make-pq (lambda (a b) (- b a)))` gives a max-heap.
 
 ### `(pq-push! pq key item)`
 Insert `item` with priority `key`. Lower key = higher priority.
@@ -121,16 +122,17 @@ Edge cases: popping/peeking an empty deque → `Unhandled exception: deque-pop-f
 
 ## Known issues
 
-**`make-pq` ignores a comparator argument (min-heap only).** The header documents `(make-pq compare)`, but the definition is `(define (make-pq) …)` with the comparator hard-coded to `(- a b)`. Passing a comparator does not error but has no effect, so a max-heap cannot be built this way.
+None. (Historically `make-pq` ignored a comparator argument and always used the
+built-in `(- a b)` min-heap. `make-pq` now accepts an optional comparator:
 
 ```scheme
-;; repro.esk
 (require core.collections)
-(define pq (make-pq (lambda (a b) (- b a))))  ; intended max-heap
+(define pq (make-pq (lambda (a b) (- b a))))  ; max-heap
 (pq-push! pq 1 'one)
 (pq-push! pq 9 'nine)
-(display (pq-pop! pq)) (newline)   ; want (9 . nine); actually (1 . one)
+(display (pq-pop! pq)) (newline)   ; (9 . nine)
 ```
 ```
-(1 . one)
+(9 . nine)
 ```
+)

--- a/docs/reference/stdlib/data_csv.md
+++ b/docs/reference/stdlib/data_csv.md
@@ -8,9 +8,7 @@ Pure-Eshkol CSV reader/writer. A parsed CSV is a **list of rows**, each row a
 Quoting follows the common convention: fields may be `"…"`-wrapped, and an
 embedded quote is escaped by doubling (`""`).
 
-> **Row-order bug:** `csv-parse` currently returns rows in **reverse** order.
-> This also corrupts [`core.data.dataframe`](data_dataframe.md). See
-> [Known issues](#known-issues).
+Rows come out in source (top-to-bottom) order.
 
 ## Functions
 
@@ -34,17 +32,16 @@ is an alias. An empty line gives `()`; an empty field becomes `()`.
 ()
 ```
 
-### `(csv-parse str)` — **returns rows reversed** (see [Known issues](#known-issues))
-Parse a whole CSV string into a list of rows. Blank lines are skipped.
+### `(csv-parse str)`
+Parse a whole CSV string into a list of rows, in source (top-to-bottom) order.
+Blank lines are skipped.
 
 ```scheme
 (display (csv-parse "a,b\n1,2\n3,4")) (newline)
 ```
 ```
-((3 4) (1 2) (a b))
+((a b) (1 2) (3 4))
 ```
-The expected result is `((a b) (1 2) (3 4))`; the rows come out in reverse
-because of a stale internal `reverse`.
 
 ### `(csv-parse-lines lines)`
 Parse an already-split list of line strings into rows (blank lines skipped).
@@ -107,18 +104,7 @@ Write rows to a file via `csv-stringify` + `write-file`.
 
 ## Known issues
 
-### `csv-parse` returns rows in reverse order
-`csv-parse` is implemented as
-`(csv-parse-lines (reverse (string-split str #\newline)))`. The `reverse` was
-needed when `string-split` returned fields right-to-left, but `string-split` now
-returns them **left-to-right** (confirmed: `(string-split "a\nb\nc" #\newline)`
-⇒ `(a b c)`). The leftover `reverse` therefore flips the row order.
-
-```scheme
-(require core.data.csv)
-(display (csv-parse "a,b\n1,2\n3,4")) (newline)
-;; => ((3 4) (1 2) (a b))   expected ((a b) (1 2) (3 4))
-```
-Impact: any consumer that treats the first row as a header (notably
-`csv-parse-typed` in [`core.data.dataframe`](data_dataframe.md)) gets the wrong
-header. Workaround: `(reverse (csv-parse s))`.
+None. (Historically `csv-parse` returned rows in reverse order because of a
+stale internal `reverse` left over from when `string-split` emitted fields
+right-to-left; `string-split` now returns them left-to-right and the `reverse`
+has been removed. Fixed in the stdlib/signal release sweep.)

--- a/docs/reference/stdlib/data_dataframe.md
+++ b/docs/reference/stdlib/data_dataframe.md
@@ -12,30 +12,23 @@ pair `(header . rows)`:
 `csv-parse-typed` adds type inference: numeric-looking fields become numbers,
 everything else stays a string.
 
-> **Broken through `csv-parse-typed`.** Because [`csv-parse`](data_csv.md)
-> returns rows reversed, `csv-parse-typed` picks the **last** CSV line as the
-> header, which breaks the accessors below. The accessors themselves are correct
-> when given a well-formed `(header . rows)` pair. See
-> [Known issues](#known-issues). The examples below build the frame by hand to
-> document intended behaviour.
-
 ## Functions
 
-### `(csv-parse-typed str)` — **header comes out wrong** (see [Known issues](#known-issues))
-Parse a CSV string into a `(header . typed-rows)` DataFrame; first row is meant
-to be the header, remaining rows get type inference.
+### `(csv-parse-typed str)`
+Parse a CSV string into a `(header . typed-rows)` DataFrame; the first row is the
+header, remaining rows get type inference.
 
 ```scheme
 (require core.data.dataframe)
 (display (csv-parse-typed "col\n42")) (newline)
 ```
 ```
-((42) (col))
+((col) (42))
 ```
-Expected `((col) (42))`; the header/row are swapped by the underlying
-`csv-parse` reversal.
+(Previously the header/row came out swapped because the underlying `csv-parse`
+returned rows reversed; that has been fixed.)
 
-For the remaining accessors, a correctly-shaped frame is built directly:
+The remaining accessors are illustrated on a directly-built frame:
 
 ```scheme
 (require core.data.dataframe)
@@ -137,19 +130,14 @@ Columns: name, age
 
 ## Known issues
 
-### `csv-parse-typed` picks the last CSV line as the header
-`csv-parse-typed` calls `csv-parse`, which returns rows reversed (see
-[`core.data.csv`](data_csv.md)), then takes `(car rows)` as the header. The
-header therefore becomes the last data line and subsequent lookups fail:
+None. (Historically `csv-parse-typed` picked the **last** CSV line as the header
+because the underlying `csv-parse` returned rows reversed. That reversal has been
+fixed in [`core.data.csv`](data_csv.md), so the header is now the first line:
 
 ```scheme
 (require core.data.dataframe)
 (define df (csv-parse-typed "name,age\nAlice,30\nBob,25"))
-(display (csv-header df)) (newline)          ; (Bob 25)   -- should be (name age)
-(display (csv-rows df)) (newline)            ; ((Alice 30) (name age))
-(csv-column df "age")                          ; ERROR: csv-column: unknown column
+(display (csv-header df)) (newline)          ; (name age)
+(display (csv-rows df)) (newline)            ; ((Alice 30) (Bob 25))
 ```
-Root cause is entirely in `csv-parse`; the DataFrame accessors are correct on a
-well-formed frame. Workaround until `csv-parse` is fixed: reconstruct the frame
-from a reversed parse, e.g. build `(cons header data)` yourself from
-`(reverse (csv-parse str))`.
+)

--- a/docs/reference/stdlib/functional_curry.md
+++ b/docs/reference/stdlib/functional_curry.md
@@ -77,35 +77,29 @@ Fixes the first argument of a ternary `f`; returns `(lambda (y z) (f x y z))`.
 ### `(partial f . args)`
 Generic partial application: fixes any number of leading arguments and returns a variadic procedure that appends the rest — `(lambda xs (apply f (append args xs)))`.
 
-**Do not use this procedure — it crashes (SIGBUS). See Known issues below.** Prefer `partial1`/`partial2`/`partial3` for fixed arities.
+```scheme
+(require stdlib)
+(display ((partial + 1 2 3) 4 5)) (newline)   ; (+ 1 2 3 4 5)
+(display ((partial * 2) 3 4)) (newline)        ; (* 2 3 4)
+```
+```
+15
+24
+```
 
-Edge cases: the fixed-arity variants (`partial1`/`partial2`/`partial3`) are safe and work as shown.
+Edge cases: the fixed-arity variants (`partial1`/`partial2`/`partial3`) are also available for fixed arities.
 
 ## Known issues
 
-### `partial` crashes with SIGBUS
-`partial` closes over the procedure argument and `apply`s it inside a nested variadic lambda; that pattern crashes the runtime.
+None. (Historically `partial` crashed with SIGBUS: it closes over the procedure
+argument and `apply`s it inside the returned lambda, and `apply` of a
+closure-**captured** procedure mis-read the capture slot as a tagged value —
+an invalid function pointer. The apply codegen now resolves a captured procedure
+through the normal variable path, so `(apply captured-proc …)` works. Minimal
+repro that used to crash:
 
 ```scheme
-(require stdlib)
-(display ((partial + 1 2 3) 4 5)) (newline)
+(define (f g) (lambda (x y) (apply g (list x y))))
+(display ((f +) 3 4)) (newline)   ; => 7
 ```
-```
-[Eshkol] fatal signal: SIGBUS (bus error) — terminating; output above is what made it to stdout before the crash
-```
-
-Minimal repro isolating the trigger — `apply` of a **captured** procedure inside a nested variadic lambda:
-
-```scheme
-(define (f g . args) (lambda xs (apply g (append args xs))))
-(display ((f + 1 2) 3 4)) (newline)   ; SIGBUS
-```
-
-The same shape with a *literal* operator instead of a captured one works fine, which pinpoints the fault to closing over the procedure:
-
-```scheme
-(define (f . args) (lambda xs (apply + (append args xs))))
-(display ((f 1 2) 3 4)) (newline)   ; => 10, no crash
-```
-
-Not yet ledgered in `.swarm/tasks/` at time of writing.
+)

--- a/docs/reference/stdlib/memory_store.md
+++ b/docs/reference/stdlib/memory_store.md
@@ -138,36 +138,27 @@ a b
 5
 ```
 
-### `(memory-store-audit path)` — currently unusable, see Known issues
-Intended to be a **streaming** O(n)-flat integrity audit that never builds the RGA:
-stream each line, re-derive its content hash, check its parent exists among
-previously-seen ids, discard. Would return `(ms-audit-v1 ok links forks)` or
+### `(memory-store-audit path)`
+A **streaming** O(n)-flat integrity audit that never builds the RGA: stream each
+line, re-derive its content hash, check its parent exists among previously-seen
+ids, discard. Returns `(ms-audit-v1 ok links forks)` on success, or
 `(line-number . reason)` with `reason` in `unparseable | hash-mismatch |
-orphan-parent`. **It cannot currently be called** — see below.
+orphan-parent` on the first problem.
+
+```scheme
+(require core.memory_store)
+(memory-store-audit "/path/to/events.log")
+;; => (ms-audit-v1 #t <links> <forks>)
+```
 
 ## Known issues
 
-- **`memory-store-audit` is uncallable (unresolved cross-module symbol).**
-  `memory-store-audit`'s body references `event-content-hash`, which is a private
-  helper defined in `core.memory` but **not in that module's `(provide …)` list**.
-  Across the module boundary the symbol does not resolve, so `memory-store-audit`
-  itself fails to generate and is reported as an unknown function at every call site.
-  All the *other* provided store functions work. Requiring `core.memory` explicitly
-  first does **not** help (the failure is at `memory_store`'s own compile time).
-  Repro:
-  ```scheme
-  (require core.memory_store)
-  (memory-store-audit "/tmp/events.log")
-  ```
-  Observed:
-  ```
-  error: Unknown function: memory-store-audit
-  ERROR: Failed to generate LLVM IR due to earlier code generation errors
-  Unhandled exception: called undefined function 'memory-store-audit'
-    (forward-referenced but never defined …)
-  ```
-  Likely fix (code, out of scope for docs): add `event-content-hash` to
-  `core.memory`'s `provide` block, or re-derive it inside `core.memory_store`.
+None. (Historically `memory-store-audit` was uncallable: its body references
+`event-content-hash`, which was defined in `core.memory` but omitted from that
+module's `(provide …)` list, so the symbol did not resolve across the module
+boundary and `memory-store-audit` failed to generate — reported as an unknown
+function at every call site. `event-content-hash` is now exported from
+`core.memory`, so the audit both generates and runs.)
   No matching ledger id found in `.swarm/tasks/` (`ESH-0072` and `ESH-0085` mention
   adjacent areas — AD closure capture and `sha256` symbol hygiene — but not this).
 

--- a/docs/reference/stdlib/operators_arithmetic.md
+++ b/docs/reference/stdlib/operators_arithmetic.md
@@ -3,7 +3,7 @@
 **Source**: [`lib/core/operators/arithmetic.esk`](../../../lib/core/operators/arithmetic.esk)
 **Require**: auto-loaded via `(require stdlib)`; or individually `(require core.operators.arithmetic)`
 
-Named binary wrappers around `+`, `-`, `*`, `/` so the operators can be passed as ordinary values to higher-order procedures.
+Named binary wrappers around `+`, `-`, `*`, `/` so the operators can be passed as ordinary values to higher-order procedures. The division wrapper is named **`divide`** (not `div`) — see Known issues for why.
 
 ## Functions
 
@@ -16,8 +16,8 @@ Named binary wrappers around `+`, `-`, `*`, `/` so the operators can be passed a
 ### `(mul x y)`
 `(* x y)`.
 
-### `(div x y)`
-Intended to be `(/ x y)`. **Broken — returns `()`. See Known issues.**
+### `(divide x y)`
+`(/ x y)`.
 
 ```scheme
 ;; arithmetic.esk
@@ -25,37 +25,30 @@ Intended to be `(/ x y)`. **Broken — returns `()`. See Known issues.**
 (display (add 3 4)) (newline)
 (display (sub 10 3)) (newline)
 (display (mul 6 7)) (newline)
+(display (divide 20 4)) (newline)
+(display (divide 7 2)) (newline)
 (display (map (lambda (p) (add (car p) (cdr p))) '((1 . 2) (3 . 4)))) (newline)
 ```
 ```
 7
 7
 42
+5
+7/2
 (3 7)
 ```
 
-Edge cases: `add`/`sub`/`mul` follow the full numeric tower of the underlying operators (ints, bignums, rationals, doubles). For division, use the built-in `/` directly instead of `div`.
+Edge cases: `add`/`sub`/`mul`/`divide` follow the full numeric tower of the underlying operators (ints, bignums, rationals, doubles).
 
 ## Known issues
 
-### `div` returns `()` for scalar arguments
-The name `div` collides with a codegen-recognized tensor-arithmetic operation (`lib/backend/llvm_codegen.cpp:5470`; see also `lib/backend/tensor_arith_codegen.cpp`), so a scalar call is dispatched to the wrong path and yields the empty list instead of a quotient.
-
-```scheme
-(require stdlib)
-(display (div 20 4)) (newline)   ; expected 5
-(display (div 7 2)) (newline)    ; expected 7/2
-```
-```
-()
-()
-```
-
-For comparison, the same expression through `/` (or through a user-defined wrapper whose name is not `div`) works:
-
-```scheme
-(display (/ 20 4)) (newline)                       ; => 5
-(define (mydiv a b) (/ a b)) (display (mydiv 20 4)) ; => 5
-```
+None. (The division wrapper used to be named `div` and returned `()` for scalar
+arguments. Root cause: a function named `div` is emitted as a *weak external*
+symbol whose bare name collides with the C standard library's `div()`; the
+dynamic linker coalesced the two and bound callers to libc `div(int,int)->div_t`,
+so the 16-byte tagged-value ABI was misread and the result came back as the empty
+list. `add`/`sub`/`mul` have no such libc collision, which is why only `div` was
+affected. The wrapper was renamed to `divide` to avoid the collision. For scalar
+division you can also use the built-in `/` directly.)
 
 Workaround: call `/` directly, or wrap it under a different name. Not yet ledgered in `.swarm/tasks/` at time of writing.

--- a/docs/reference/stdlib/signal_fft.md
+++ b/docs/reference/stdlib/signal_fft.md
@@ -43,17 +43,41 @@ Edge cases: same power-of-2 requirement as `fft`.
 
 ## Known issues
 
-### Chaining `fft` → `ifft` inside one compiled function returns garbage
+### `fft` → `ifft` round-trip in a user/library function — works
 
-At the REPL top level, `fft` and `ifft` each work and round-trip correctly. But when the result of `fft` is fed into `ifft` **within the body of a user- or library-defined function**, the round-trip is corrupted — the first element becomes a huge number (~5e9) and the rest collapse to a constant. `fft` alone inside a function is fine; it is the `fft`→`ifft` chain that breaks.
+The `fft`→`ifft` round-trip inside a user- or library-defined function now
+returns the original signal (up to ~1e-18 imaginary noise):
 
 ```scheme
-;; repro.esk
 (require signal.fft)
 (define (roundtrip a) (ifft (fft a)))
 (display (roundtrip #(1.0 2.0 3.0 4.0))) (newline)
+;; => #(1 2+5.72e-18i 3 4-5.72e-18i)   ; ~ #(1 2 3 4)
 ```
+
+### Open: `fft`→`ifft` chain **inside a precompiled (`--shared-lib`) function** corrupts
+
+There is a remaining, distinct codegen bug: a function that is *compiled into a
+precompiled shared library* (e.g. the stdlib `fast-convolve` in
+[`signal.filters`](signal_filters.md#known-issues)) and chains `fft`→`ifft`
+returns garbage — the first element becomes a huge number (~5e9), the rest
+collapse to `-8`. The identical source called from an ordinary (JIT/AOT main)
+module works, as does `fft` alone, complex-multiply, division, and `ifft`'s
+conjugate/scale halves in isolation; only the full `fft`→`ifft` data-flow chain
+inside a `--shared-lib`/`OptNone` function fails. Minimal repro (compile as a
+shared library, then require it):
+
+```scheme
+;; onlyfft.esk, built with:  eshkol-run --shared-lib -o onlyfft onlyfft.esk
+(provide fft ifft chain)
+;; ... fft/ifft from lib/signal/fft.esk ...
+(define (chain a) (ifft (fft a)))
+;; (chain #(1.0 2.0 3.0 4.0)) => #(5.1e+09 -8-8i -8 -8+8i)  ; expected ~#(1 2 3 4)
 ```
-#(4.96616e+09 -8-8i -8 -8+8i)      ;; expected ~ #(1 2 3 4)
-```
-This is the direct cause of the `fast-convolve` corruption documented in [`signal.filters`](signal_filters.md#known-issues). Workaround: keep `fft` and `ifft` in separate top-level steps, or use direct-time-domain `convolve`.
+
+This is the direct cause of the `fast-convolve` corruption in
+[`signal.filters`](signal_filters.md#known-issues). It is a compiler bug (not a
+library bug), so it is reported here rather than worked around in Scheme.
+Workaround for now: keep `fft`/`ifft` in ordinary (non-`--shared-lib`) code, e.g.
+run the chain from your own module or the REPL rather than through the precompiled
+`fast-convolve`.

--- a/docs/reference/stdlib/signal_fft.md
+++ b/docs/reference/stdlib/signal_fft.md
@@ -55,7 +55,7 @@ returns the original signal (up to ~1e-18 imaginary noise):
 ;; => #(1 2+5.72e-18i 3 4-5.72e-18i)   ; ~ #(1 2 3 4)
 ```
 
-### Open: `fft`→`ifft` chain **inside a precompiled (`--shared-lib`) function** corrupts
+### Open (tracked as ESH-0115): `fft`→`ifft` chain **inside a precompiled (`--shared-lib`) function** corrupts
 
 There is a remaining, distinct codegen bug: a function that is *compiled into a
 precompiled shared library* (e.g. the stdlib `fast-convolve` in

--- a/docs/reference/stdlib/signal_filters.md
+++ b/docs/reference/stdlib/signal_filters.md
@@ -175,5 +175,5 @@ because `fast-convolve` lives in the **precompiled stdlib shared library**, it
 hits the precompiled `fft`→`ifft` chaining corruption documented in
 [`signal.fft`](signal_fft.md#known-issues) (an identical `fast-convolve` compiled
 in ordinary user code — even with `(require stdlib)` — works). This is a compiler
-bug, not a library bug, so it is reported rather than worked around in Scheme.
-Workaround: use the direct-time-domain `convolve`.
+bug (tracked as **ESH-0115**), not a library bug, so it is reported rather than
+worked around in Scheme. Workaround: use the direct-time-domain `convolve`.

--- a/docs/reference/stdlib/signal_filters.md
+++ b/docs/reference/stdlib/signal_filters.md
@@ -170,4 +170,10 @@ Evaluate `H(e^{jω}) = B/A` at `n-points` frequencies from 0 to π. Returns `(ma
 #(1 3 6 9 12 9 5)                     ;; convolve — correct
 #(6.1741e+09 -8 -8 -8 -8 -8 -8)       ;; fast-convolve — garbage
 ```
-Root cause: `fast-convolve` computes `(ifft (fft …))` inside its (compiled) body, which triggers the `fft`→`ifft` chaining corruption documented in [`signal.fft`](signal_fft.md#known-issues). Workaround: use `convolve`.
+Root cause: `fast-convolve` computes `(ifft (fft …))` inside its body, and
+because `fast-convolve` lives in the **precompiled stdlib shared library**, it
+hits the precompiled `fft`→`ifft` chaining corruption documented in
+[`signal.fft`](signal_fft.md#known-issues) (an identical `fast-convolve` compiled
+in ordinary user code — even with `(require stdlib)` — works). This is a compiler
+bug, not a library bug, so it is reported rather than worked around in Scheme.
+Workaround: use the direct-time-domain `convolve`.

--- a/docs/reference/stdlib/strings.md
+++ b/docs/reference/stdlib/strings.md
@@ -73,18 +73,23 @@ Reverse the characters of `str`.
 cba
 ```
 
-### `(string-copy str)` — **BROKEN for the 1-argument form** (see [Known issues](#known-issues))
-Intended: return a fresh copy of `str`. In practice the name resolves to a
-codegen builtin that mis-handles the single-argument call and returns `()`.
+### `(string-copy str [start [end]])`
+Return a fresh copy of `str`, optionally of the codepoint range `[start, end)`
+(R7RS). The 1- and 2-argument forms default the missing bounds to `start=0` and
+`end=(string-length str)`.
 
 ```scheme
-(display (string-copy "hello")) (newline)
+(display (string-copy "hello")) (newline)     ; whole string
+(display (string-copy "hello" 2)) (newline)   ; from index 2
+(display (string-copy "hello" 1 4)) (newline) ; [1,4)
 ```
 ```
-()
+hello
+llo
+ell
 ```
-The R7RS three-argument form `(string-copy str start end)` does work (it is a
-`substring` alias) but emits a spurious type warning.
+(The optional `start`/`end` forms may still emit a harmless gradual-typing
+arity note; the result is correct.)
 
 ### `(string-repeat str n)`
 Concatenate `n` copies of `str`. `n <= 0` gives `""`.
@@ -214,18 +219,13 @@ search functions so a char needle is accepted. Not intended for direct use.
 
 ## Known issues
 
-### `string-copy` (1-arg) returns `()` and warns
-`(string-copy s)` resolves to a codegen builtin
-(`lib/backend/llvm_codegen.cpp:13536`) that delegates a single-argument call to
-`substring`, which requires exactly three arguments. The result is `()` plus a
-spurious `WARNING: substring requires exactly 3 arguments`.
-
-```scheme
-(require core.strings)
-(display (string-copy "hello")) (newline)
-;; => ()   (with "substring requires exactly 3 arguments" on stderr)
-```
-Workaround: use `(substring s 0 (string-length s))` directly, which works.
+### `string-copy` (1-arg) — fixed
+Historically `(string-copy s)` delegated to `substring`, which required exactly
+three arguments, so the single-argument call returned `()` with a spurious
+`WARNING: substring requires exactly 3 arguments`. `string-copy` now has its own
+codegen path that defaults the missing bounds (`start=0`, `end=length`), so the
+1-, 2-, and 3-argument R7RS forms all work. (The 2-/3-arg forms may still emit a
+harmless gradual-typing arity note.)
 
 ### Embedded NUL: builtin search truncates, stdlib search does not
 The builtins `string-index` and `string-contains?` use C `strstr`-style search

--- a/inc/eshkol/backend/string_io_codegen.h
+++ b/inc/eshkol/backend/string_io_codegen.h
@@ -92,6 +92,16 @@ public:
     llvm::Value* substring(const eshkol_operations_t* op);
 
     /**
+     * Copy a string: R7RS (string-copy s [start [end]]).
+     * The 1- and 2-argument forms default the missing bounds to
+     * start=0 and end=(string-length s), unlike `substring` which
+     * requires all three.  Fixes the 1-arg form returning `()`.
+     * @param op The operation AST node
+     * @return Fresh string as tagged value
+     */
+    llvm::Value* stringCopy(const eshkol_operations_t* op);
+
+    /**
      * Compare strings: (string=? s1 s2), (string<? s1 s2), etc.
      * @param op The operation AST node
      * @param cmp_type One of "eq", "lt", "gt", "le", "ge"
@@ -422,6 +432,15 @@ private:
      * @return Raw i64 value suitable for GEP indices
      */
     llvm::Value* ensureRawInt64(llvm::Value* val, const std::string& name = "raw_idx");
+
+    /**
+     * Shared implementation for substring / string-copy.
+     * @param str_ptr Raw char* to the source string (already unpacked).
+     * @param start   Start codepoint index, or nullptr to default to 0.
+     * @param end     End codepoint index, or nullptr to default to (length).
+     * @return Fresh string as tagged value.
+     */
+    llvm::Value* substringImpl(llvm::Value* str_ptr, llvm::Value* start, llvm::Value* end);
 
     // Callbacks for AST code generation (set by main codegen)
     using CodegenASTFunc = llvm::Value* (*)(const void* ast, void* context);

--- a/lib/backend/call_apply_codegen.cpp
+++ b/lib/backend/call_apply_codegen.cpp
@@ -229,7 +229,26 @@ Value* CallApplyCodegen::apply(const eshkol_operations_t* op) {
                 // Has captures - fall through to closure path
             }
 
-            // Load from storage if needed
+            // CAPTURED-PROCEDURE FIX: when the procedure is a plain variable
+            // that is NOT an LLVM Function*, re-evaluate it through the normal
+            // codegen path.  A closure captured into the enclosing lambda has
+            // its symbol-table entry pointing at the *capture slot* (a ptr
+            // parameter), not at a tagged value.  The old code only loaded
+            // GlobalVariable / AllocaInst storage, so a captured procedure
+            // arrived at applyClosure as a raw pointer, which was then read as
+            // a tagged value → invalid function pointer → SIGBUS
+            // (e.g. `(define (f g) (lambda (x y) (apply g (list x y))))`).
+            // codegenVariable already resolves captures, allocas, and globals
+            // uniformly into a proper tagged closure value.
+            if (!isa<Function>(func_value)) {
+                Value* resolved = codegen_ast_callback_(func_arg, callback_context_);
+                if (resolved) {
+                    return applyClosure(resolved, list_int);
+                }
+            }
+
+            // Load from storage if needed (fallback: Function* with captures,
+            // or callback resolution failed)
             if (isa<GlobalVariable>(func_value)) {
                 func_value = ctx_.builder().CreateLoad(
                     cast<GlobalVariable>(func_value)->getValueType(), func_value);

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -13594,8 +13594,9 @@ private:
         if (func_name == "list->string") return strio_->listToString(op);
         // R7RS string-copy: copy a string (optionally with start/end)
         if (func_name == "string-copy") {
-            // Delegate to substring with full range if no start/end given
-            return strio_->substring(op);
+            // R7RS (string-copy s [start [end]]): the 1- and 2-arg forms
+            // default the missing bounds, unlike substring (exactly 3).
+            return strio_->stringCopy(op);
         }
         // R7RS string-copy!: copy characters between strings
         if (func_name == "string-copy!") {

--- a/lib/backend/string_io_codegen.cpp
+++ b/lib/backend/string_io_codegen.cpp
@@ -451,6 +451,14 @@ llvm::Value* StringIOCodegen::substring(const eshkol_operations_t* op) {
     llvm::Value* ptr_int = tagged_.unpackInt64(str_arg);
     llvm::Value* str_ptr = ctx_.builder().CreateIntToPtr(ptr_int, ctx_.ptrType());
 
+    return substringImpl(str_ptr, start, end);
+}
+
+// Shared substring/string-copy core.  start==nullptr defaults to 0 and
+// end==nullptr defaults to the string's codepoint length.
+llvm::Value* StringIOCodegen::substringImpl(llvm::Value* str_ptr,
+                                            llvm::Value* start,
+                                            llvm::Value* end) {
     // Get string length for upper bound check.
     //
     // Use eshkol_utf8_strlen — codepoint count via the string's header
@@ -475,6 +483,10 @@ llvm::Value* StringIOCodegen::substring(const eshkol_operations_t* op) {
             "eshkol_utf8_strlen", &ctx_.module());
     }
     llvm::Value* str_len = ctx_.builder().CreateCall(utf8_strlen_func, {str_ptr}, "str_len");
+
+    // Default missing bounds (string-copy 1- and 2-arg forms).
+    if (!start) start = llvm::ConstantInt::get(ctx_.int64Type(), 0);
+    if (!end)   end = str_len;
 
     // Bounds validation: start >= 0, end >= start, end <= string_length
     llvm::Value* start_negative = ctx_.builder().CreateICmpSLT(start,
@@ -531,6 +543,53 @@ llvm::Value* StringIOCodegen::substring(const eshkol_operations_t* op) {
     llvm::Value* new_str = ctx_.builder().CreateCall(utf8_substr_func, {str_ptr, start, end, arena_ptr});
 
     return tagged_.packHeapPtr(new_str);
+}
+
+// R7RS (string-copy s [start [end]]).  Unlike substring, the start/end
+// bounds are optional: 1-arg copies the whole string, 2-arg copies from
+// start to the end.  Previously (string-copy s) was delegated to
+// substring, which required exactly 3 args and returned () with a
+// spurious warning.
+llvm::Value* StringIOCodegen::stringCopy(const eshkol_operations_t* op) {
+    if (!codegen_ast_callback_ || !codegen_typed_ast_callback_) {
+        eshkol_warn("StringIOCodegen::stringCopy - callbacks not set");
+        return tagged_.packNull();
+    }
+
+    if (op->call_op.num_vars < 1 || op->call_op.num_vars > 3) {
+        eshkol_warn("string-copy requires 1 to 3 arguments");
+        return nullptr;
+    }
+
+    // Source string
+    llvm::Value* str_arg = codegen_ast_callback_(&op->call_op.variables[0], callback_context_);
+    if (!str_arg) return nullptr;
+    llvm::Value* ptr_int = tagged_.unpackInt64(str_arg);
+    llvm::Value* str_ptr = ctx_.builder().CreateIntToPtr(ptr_int, ctx_.ptrType());
+
+    // Optional start (nullptr => default 0 inside substringImpl)
+    llvm::Value* start = nullptr;
+    if (op->call_op.num_vars >= 2) {
+        void* start_tv_ptr = codegen_typed_ast_callback_(&op->call_op.variables[1], callback_context_);
+        if (!start_tv_ptr) return nullptr;
+        llvm::Value* start_raw = *reinterpret_cast<llvm::Value**>(start_tv_ptr);
+        if (!start_raw) return nullptr;
+        start = ensureRawInt64(start_raw, "string_copy_start");
+        if (!start) return nullptr;
+    }
+
+    // Optional end (nullptr => default string length inside substringImpl)
+    llvm::Value* end = nullptr;
+    if (op->call_op.num_vars >= 3) {
+        void* end_tv_ptr = codegen_typed_ast_callback_(&op->call_op.variables[2], callback_context_);
+        if (!end_tv_ptr) return nullptr;
+        llvm::Value* end_raw = *reinterpret_cast<llvm::Value**>(end_tv_ptr);
+        if (!end_raw) return nullptr;
+        end = ensureRawInt64(end_raw, "string_copy_end");
+        if (!end) return nullptr;
+    }
+
+    return substringImpl(str_ptr, start, end);
 }
 
 llvm::Value* StringIOCodegen::stringCompare(const eshkol_operations_t* op, const std::string& cmp_type) {

--- a/lib/core/collections.esk
+++ b/lib/core/collections.esk
@@ -55,8 +55,15 @@
 ;; to scalar `-` for numeric priorities.
 ;; ---------------------------------------------------------------------------
 
-(define (make-pq)
-  (vector (make-vector 16 #f) 0 (lambda (a b) (- a b))))
+;; (make-pq)          -> min-heap using scalar `-` as the comparator
+;; (make-pq compare)  -> heap ordered by `compare` (2-arg fn returning
+;;                       <0 / 0 / >0); e.g. (lambda (a b) (- b a)) for a max-heap.
+(define (make-pq . rest)
+  (vector (make-vector 16 #f)
+          0
+          (if (null? rest)
+              (lambda (a b) (- a b))
+              (car rest))))
 
 (define (pq-data pq)    (vector-ref pq 0))
 (define (pq-size pq)    (vector-ref pq 1))

--- a/lib/core/data/csv.esk
+++ b/lib/core/data/csv.esk
@@ -57,8 +57,10 @@
   (csv-split-fields line))
 
 ;;; csv-parse: Parse a CSV string into a list of rows (each row is a list of fields)
+;;; string-split returns lines left-to-right, so no reverse is needed;
+;;; a stale (reverse ...) here previously flipped the row order.
 (define (csv-parse str)
-  (csv-parse-lines (reverse (string-split str #\newline))))
+  (csv-parse-lines (string-split str #\newline)))
 
 (define (csv-parse-lines lines)
   (if (null? lines)

--- a/lib/core/memory.esk
+++ b/lib/core/memory.esk
@@ -36,7 +36,11 @@
   memory-fold-lww
   memory-event?
   memory-event-id memory-event-prev memory-event-vclock
-  memory-event-node memory-event-type memory-event-payload)
+  memory-event-node memory-event-type memory-event-payload
+  ;; Re-derives an event's content hash from its body fields.  Exported
+  ;; so cross-module consumers (notably core.memory_store's streaming
+  ;; memory-store-audit) can verify integrity without rebuilding the RGA.
+  event-content-hash)
 
 ;; ===== Event: (mem-ev-v1 id prev-hash vclock node type payload) =====
 (define (memory-event? ev)

--- a/lib/core/operators/arithmetic.esk
+++ b/lib/core/operators/arithmetic.esk
@@ -1,9 +1,15 @@
 ;;; core/operators/arithmetic.esk
 ;;; First-class wrappers for arithmetic operators
 
-(provide add sub mul div)
+(provide add sub mul divide)
 
 (define (add x y) (+ x y))
 (define (sub x y) (- x y))
 (define (mul x y) (* x y))
-(define (div x y) (/ x y))
+;; NOTE: the division alias is `divide`, NOT `div`.  A function named
+;; `div` is emitted as a weak external symbol whose bare name collides
+;; with the C standard library's `div()`; the dynamic linker coalesces
+;; the two and binds callers to libc `div(int,int)->div_t`, corrupting
+;; the result (returns ()).  `divide` avoids the collision entirely.
+;; For scalar division you can also use the built-in `/` directly.
+(define (divide x y) (/ x y))

--- a/tests/stdlib/sweep_a_regressions_test.esk
+++ b/tests/stdlib/sweep_a_regressions_test.esk
@@ -1,0 +1,114 @@
+;; tests/stdlib/sweep_a_regressions_test.esk
+;;
+;; Release-blocking sweep A regressions (stdlib + signal).
+;; Covers, with exact expected values, the bugs fixed in
+;; fix(stdlib,signal): release sweep A.  Run on BOTH -r and AOT.
+;;
+;;   1. csv-parse row order (was reversed)
+;;   2. fft -> ifft roundtrip inside a function (documented signal_fft repro)
+;;   3. partial / apply-of-captured-procedure (was SIGBUS)
+;;   4. make-pq honours its comparator (was min-heap only)
+;;   5. string-copy 1-arg (was returning ())
+;;   6. divide alias — scalar division (div collided with libc div(); renamed)
+;;   7. memory-store-audit callable + correct (event-content-hash now provided)
+
+(require stdlib)
+(require core.data.csv)
+(require core.collections)
+(require core.strings)
+(require signal.fft)
+(require core.memory)
+(require core.sexp)
+(require core.memory_store)
+
+(define passed 0)
+(define failed 0)
+
+(define (check label want got)
+  (if (equal? want got)
+      (begin
+        (set! passed (+ passed 1))
+        (display label) (display ": PASS") (newline))
+      (begin
+        (set! failed (+ failed 1))
+        (display label) (display ": FAIL want=")
+        (display want) (display " got=") (display got) (newline))))
+
+;; -----------------------------------------------------------------
+;; 1. csv-parse — rows must come out in source (top-to-bottom) order
+;; -----------------------------------------------------------------
+(check "csv-parse row order"
+       '(("a" "b") ("1" "2") ("3" "4"))
+       (csv-parse "a,b\n1,2\n3,4"))
+
+;; -----------------------------------------------------------------
+;; 2. fft -> ifft roundtrip inside a function (documented repro).
+;;    Compare rounded real parts; imaginary parts are ~1e-18 noise.
+;; -----------------------------------------------------------------
+(define (roundtrip a) (ifft (fft a)))
+(define (round-reals v)
+  ;; list of exact rounded real parts (avoids vector/tensor equal? mismatch)
+  (let loop ((i (- (vector-length v) 1)) (acc '()))
+    (if (< i 0)
+        acc
+        (loop (- i 1)
+              (cons (inexact->exact (round (real-part (vref v i)))) acc)))))
+(check "fft->ifft roundtrip (real parts)"
+       '(1 2 3 4)
+       (round-reals (roundtrip #(1.0 2.0 3.0 4.0))))
+
+;; -----------------------------------------------------------------
+;; 3. partial — apply of a captured procedure inside a closure
+;; -----------------------------------------------------------------
+(check "partial (+ 1 2 3) then 4 5" 15 ((partial + 1 2 3) 4 5))
+(check "partial (* 2) then 3 4"     24 ((partial * 2) 3 4))
+
+;; -----------------------------------------------------------------
+;; 4. make-pq — comparator is honoured (max-heap via (lambda (a b) (- b a)))
+;; -----------------------------------------------------------------
+(define maxpq (make-pq (lambda (a b) (- b a))))
+(pq-push! maxpq 1 'one)
+(pq-push! maxpq 9 'nine)
+(pq-push! maxpq 5 'five)
+(check "make-pq max-heap pop" '(9 . nine) (pq-pop! maxpq))
+(define minpq (make-pq))          ;; default min-heap
+(pq-push! minpq 5 'five)
+(pq-push! minpq 2 'two)
+(check "make-pq default min-heap pop" '(2 . two) (pq-pop! minpq))
+
+;; -----------------------------------------------------------------
+;; 5. string-copy — 1-arg returns a fresh copy (was ())
+;; -----------------------------------------------------------------
+(check "string-copy 1-arg"      "hello" (string-copy "hello"))
+(check "string-copy 2-arg"      "llo"   (string-copy "hello" 2))
+(check "string-copy 3-arg"      "ell"   (string-copy "hello" 1 4))
+
+;; -----------------------------------------------------------------
+;; 6. divide — scalar division (renamed from div; div hit libc div())
+;; -----------------------------------------------------------------
+(check "divide exact int"   5   (divide 20 4))
+(check "divide -> rational" #t  (= (divide 7 2) (/ 7 2)))
+
+;; -----------------------------------------------------------------
+;; 7. memory-store-audit — now callable and correct on a valid log
+;; -----------------------------------------------------------------
+(define audit-path (path-join (temp-directory) "eshkol-sweep-a-audit.log"))
+(if (file-exists? audit-path) (delete-file audit-path) #t)
+(let* ((log (make-memory-log "nodeA"))
+       (e1 (memory-append! log 'note "first"))
+       (e2 (memory-append! log 'note "second"))
+       (port (open-output-file audit-path)))
+  (write-string (string-append (sexp->canonical-string e1) "\n") port)
+  (write-string (string-append (sexp->canonical-string e2) "\n") port)
+  (close-port port))
+(check "memory-store-audit ok chain"
+       '(ms-audit-v1 #t 2 0)
+       (memory-store-audit audit-path))
+
+;; -----------------------------------------------------------------
+(newline)
+(display "sweep-a regressions: ") (display passed) (display " passed, ")
+(display failed) (display " failed") (newline)
+(if (= failed 0)
+    (begin (display "ALL PASS") (newline))
+    (begin (display "SOME FAILED") (newline)))


### PR DESCRIPTION
Release-blocking bug sweep — Group A (stdlib + signal). Each fix at the architectural root, verified on BOTH `-r` (JIT) and AOT. SICP gate 88/88; regression suite `tests/stdlib/sweep_a_regressions_test.esk` 12/12 on both paths.

## Fixed (root causes)

1. **csv-parse row order** — dropped a stale `(reverse …)` left over from when `string-split` emitted fields right-to-left. Also un-breaks `csv-parse-typed`/dataframe headers (were taking the last CSV line as the header).
   - before `((3 4) (1 2) (a b))` → after `((a b) (1 2) (3 4))`.

2. **`partial` SIGBUS → codegen root fix.** `(apply g …)` where `g` is a **captured** procedure crashed: `CallApplyCodegen::apply` only loaded `GlobalVariable`/`AllocaInst` storage, so a captured proc (symbol-table entry = pointer to the capture slot) reached `applyClosure` as a raw pointer, read as a tagged value → invalid function pointer → SIGBUS. Now re-evaluates a non-`Function` procedure operand through the normal variable codegen path. Fixes `partial` and the whole apply-of-captured class.
   - `((partial + 1 2 3) 4 5)` → `15`.

3. **make-pq comparator** — accepts an optional comparator (rest arg), defaulting to the `(- a b)` min-heap. `(make-pq (lambda (a b) (- b a)))` is now a real max-heap.

4. **string-copy 1-/2-arg** — new `StringIOCodegen::stringCopy` defaults missing bounds via a shared `substringImpl`; `(string-copy s [start [end]])` works for all arities (was `()` + warning for 1-arg).

5. **`div` → `divide` (libc symbol collision).** A function named `div` is emitted as a **weak external** symbol whose bare name collides with the C stdlib `div()`; the dynamic linker coalesced them and bound callers to libc `div(int,int)->div_t`, so the 16-byte tagged-value ABI was misread and `(div a b)` returned `()`. `add`/`sub`/`mul` have no libc counterpart (hence only `div` broke). Renamed the alias to `divide`; scalar division works on both paths. (This was **not** the tensor-div collision the issue text guessed — root cause is libc.)

6. **memory-store-audit uncallable** — `event-content-hash` was defined in `core.memory` but omitted from its `(provide …)`, so it didn't resolve across the module boundary and the audit failed to generate. Exported it; audit now returns `(ms-audit-v1 #t links forks)`.

## Reported, not worked around (compiler bug)

7. **fft chain (tracked as ESH-0115).** The documented `signal_fft` roundtrip repro (`(ifft (fft a))` in a user function) **now works**. A distinct, pre-existing codegen bug remains: a function compiled into a **precompiled `--shared-lib`** (e.g. stdlib `fast-convolve`) that chains `fft`→`ifft` corrupts (first element ~5e9, rest `-8`), while the identical source in ordinary user code — even with `(require stdlib)` — works. Isolated: `fft` alone, complex-multiply, double/int division, and `ifft`'s conjugate/scale halves all work in isolation precompiled; only the full `fft`→`ifft` data-flow chain inside an `OptNone`/`--shared-lib` function fails. Per the compiler-bug policy this is reported precisely (see `signal_fft.md` / `signal_filters.md`, tagged **ESH-0115**) rather than papered over in Scheme. Minimal repro:
   ```scheme
   ;; onlyfft.esk, built:  eshkol-run --shared-lib -o onlyfft onlyfft.esk
   (provide fft ifft chain)
   ;; ... fft/ifft from lib/signal/fft.esk ...
   (define (chain a) (ifft (fft a)))
   ;; (chain #(1.0 2.0 3.0 4.0)) => #(5.1e+09 -8-8i -8 -8+8i)   expected ~#(1 2 3 4)
   ```

## Verification
- `tests/stdlib/sweep_a_regressions_test.esk`: 12/12 on `-r` and AOT.
- `scripts/run_sicp_smoke.sh`: 88/88.
- `scripts/run_icc_smoke.sh`: all green except the pre-existing `example_agent_compiles` (its target `examples/agent.esk` does not exist in the tree — unrelated to this change).

## Notes
- Rebased onto current `master` (docs PRs #120–125 merged); the `docs/reference/stdlib/` Known-Issue removals are applied on top of the merged pages.
- The deferred fft→ifft-in-shared-lib codegen bug is tracked as **ESH-0115**.
