### PR TITLE
Add sanitizer fuzz harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,10 @@ CTestTestfile.cmake
 test-results/
 coverage/
 test_outputs/
+artifacts/sanitizer-fuzz/
+artifacts/*-fuzz/
+**/corpus.raw
+**/*.crash
 *_test_outputs/
 list_test_outputs/
 autodiff_test_outputs/

--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -1180,6 +1180,36 @@ oracles:
         severity: high
         label: Seeded 200-program fuzz run finds no cross-axis divergence
         action: ./scripts/run_differential_fuzz.sh --seed 42 --count 200
+
+  # Sanitizer-over-fuzzer cleanliness gate (adversarial campaign P7b).
+  # scripts/run_sanitizer_fuzz.sh builds/runs the deterministic
+  # differential fuzz seed plus tests/**/*.esk under ASan+UBSan on -r,
+  # AOT -O0, and AOT -O2, then emits kind:"sanitizer_fuzz" events to
+  # scripts/icc_traces/sanitizer_fuzz.jsonl.
+  - name: sanitizer-fuzz-clean
+    aliases: [sanitizer-fuzz, asan-ubsan-fuzz, adversarial-p7b]
+    requires:
+      - runtime_event:
+          event_kinds: [sanitizer_fuzz]
+          event_names: ["sanitizer_fuzz_selftest_esh0116"]
+          event_values: ["PASS"]
+        severity: high
+        label: Synthetic ESH-0116-class unterminated buffer repro trips the sanitizer harness
+        action: ./scripts/run_sanitizer_fuzz.sh --self-test-only
+      - runtime_event:
+          event_kinds: [sanitizer_fuzz]
+          event_names: ["sanitizer_fuzz_aot_coverage"]
+          event_values: ["PASS"]
+        severity: high
+        label: Sanitizer fuzz pass covers -r plus AOT -O0 and AOT -O2 axes
+        action: ./scripts/run_sanitizer_fuzz.sh
+      - runtime_event:
+          event_kinds: [sanitizer_fuzz]
+          event_names: ["sanitizer_fuzz_clean"]
+          event_values: ["PASS"]
+        severity: high
+        label: Full ASan+UBSan fuzz/tests corpus has zero sanitizer signatures
+        action: ./scripts/run_sanitizer_fuzz.sh
   # Adversarial pillar P2 — feature-pair composition matrix
   # (.swarm/ADVERSARIAL_TESTING_CAMPAIGN.md). scripts/run_edge_matrix.sh
   # runs the generated corpus in tests/edge_matrix/generated/ under both

--- a/.swarm/tasks/ESH-0160.json
+++ b/.swarm/tasks/ESH-0160.json
@@ -1,0 +1,22 @@
+{
+  "id": "ESH-0160",
+  "status": "open",
+  "priority": "high",
+  "workstream": "sanitizer-fuzz",
+  "title": "Sanitizer fuzz: AddressSanitizer container-overflow",
+  "goal": "Fix sanitizer finding from scripts/run_sanitizer_fuzz.sh. First repro: tests/ad/sweep_c_regressions_test.esk via r/run. Top frame: #0 0xADDR in ControlFlowCallbacks::registerFuncBindingWrapper(char const*, void*, void*) llvm_codegen.cpp:36354. Log: artifacts/sanitizer-fuzz/logs/206_r_211912727.err.",
+  "status_note": "OPEN. Dedup signature is sanitizer kind/subtype plus normalized top frame.",
+  "acceptance": [
+    "Root cause is fixed or explicitly classified with a narrower XKNOWN.",
+    "A minimal repro remains in tests/ or is added next to the affected corpus.",
+    "scripts/run_sanitizer_fuzz.sh no longer reports this signature."
+  ],
+  "blocked_by": [],
+  "file_globs": [
+    "tests/ad/sweep_c_regressions_test.esk"
+  ],
+  "sanitizer_signature": "AddressSanitizer\tcontainer-overflow\t#0 0xADDR in ControlFlowCallbacks::registerFuncBindingWrapper(char const*, void*, void*) llvm_codegen.cpp:36354",
+  "sanitizer_kind": "AddressSanitizer",
+  "sanitizer_subtype": "container-overflow",
+  "sanitizer_top_frame": "#0 0xADDR in ControlFlowCallbacks::registerFuncBindingWrapper(char const*, void*, void*) llvm_codegen.cpp:36354"
+}

--- a/.swarm/tasks/ESH-0161.json
+++ b/.swarm/tasks/ESH-0161.json
@@ -1,0 +1,22 @@
+{
+  "id": "ESH-0161",
+  "status": "open",
+  "priority": "high",
+  "workstream": "sanitizer-fuzz",
+  "title": "Sanitizer fuzz: UndefinedBehaviorSanitizer negation of -9223372036854775808 cannot be represented in type 'int64_t' (aka 'long long'); cast to an unsigned type to negate this value to itself",
+  "goal": "Fix sanitizer finding from scripts/run_sanitizer_fuzz.sh. First repro: tests/bignum/bignum_edge_cases_test.esk via r/run. Top frame: #0 0xADDR in eshkol_bignum_fits_int64 bignum.cpp:641. Log: artifacts/sanitizer-fuzz/logs/298_r_2816962780.err.",
+  "status_note": "OPEN. Dedup signature is sanitizer kind/subtype plus normalized top frame.",
+  "acceptance": [
+    "Root cause is fixed or explicitly classified with a narrower XKNOWN.",
+    "A minimal repro remains in tests/ or is added next to the affected corpus.",
+    "scripts/run_sanitizer_fuzz.sh no longer reports this signature."
+  ],
+  "blocked_by": [],
+  "file_globs": [
+    "tests/bignum/bignum_edge_cases_test.esk"
+  ],
+  "sanitizer_signature": "UndefinedBehaviorSanitizer\tnegation of -9223372036854775808 cannot be represented in type 'int64_t' (aka 'long long'); cast to an unsigned type to negate this value to itself\t#0 0xADDR in eshkol_bignum_fits_int64 bignum.cpp:641",
+  "sanitizer_kind": "UndefinedBehaviorSanitizer",
+  "sanitizer_subtype": "negation of -9223372036854775808 cannot be represented in type 'int64_t' (aka 'long long'); cast to an unsigned type to negate this value to itself",
+  "sanitizer_top_frame": "#0 0xADDR in eshkol_bignum_fits_int64 bignum.cpp:641"
+}

--- a/.swarm/tasks/ESH-0162.json
+++ b/.swarm/tasks/ESH-0162.json
@@ -1,0 +1,22 @@
+{
+  "id": "ESH-0162",
+  "status": "open",
+  "priority": "high",
+  "workstream": "sanitizer-fuzz",
+  "title": "Sanitizer fuzz: AddressSanitizer heap-use-after-free",
+  "goal": "Fix sanitizer finding from scripts/run_sanitizer_fuzz.sh. First repro: tests/edge_matrix/generated/pair243_quote__regions.esk via r/run. Top frame: #0 0xADDR in eshkol_deep_equal runtime_deep_equal.cpp:68. Log: artifacts/sanitizer-fuzz/logs/614_r_2370875467.err.",
+  "status_note": "OPEN. Dedup signature is sanitizer kind/subtype plus normalized top frame.",
+  "acceptance": [
+    "Root cause is fixed or explicitly classified with a narrower XKNOWN.",
+    "A minimal repro remains in tests/ or is added next to the affected corpus.",
+    "scripts/run_sanitizer_fuzz.sh no longer reports this signature."
+  ],
+  "blocked_by": [],
+  "file_globs": [
+    "tests/edge_matrix/generated/pair243_quote__regions.esk"
+  ],
+  "sanitizer_signature": "AddressSanitizer\theap-use-after-free\t#0 0xADDR in eshkol_deep_equal runtime_deep_equal.cpp:68",
+  "sanitizer_kind": "AddressSanitizer",
+  "sanitizer_subtype": "heap-use-after-free",
+  "sanitizer_top_frame": "#0 0xADDR in eshkol_deep_equal runtime_deep_equal.cpp:68"
+}

--- a/.swarm/tasks/ESH-0163.json
+++ b/.swarm/tasks/ESH-0163.json
@@ -1,0 +1,22 @@
+{
+  "id": "ESH-0163",
+  "status": "open",
+  "priority": "high",
+  "workstream": "sanitizer-fuzz",
+  "title": "Sanitizer fuzz: AddressSanitizer heap-buffer-overflow",
+  "goal": "Fix sanitizer finding from scripts/run_sanitizer_fuzz.sh. First repro: tests/stdlib/v12_consciousness_test.esk via r/run. Top frame: #0 0xADDR in display_tensor_recursive(__sFILE*, eshkol_tensor const*, unsigned long long, unsigned long long) runtime_display_hosted.cpp:672. Log: artifacts/sanitizer-fuzz/logs/1057_r_1980305526.err.",
+  "status_note": "OPEN. Dedup signature is sanitizer kind/subtype plus normalized top frame.",
+  "acceptance": [
+    "Root cause is fixed or explicitly classified with a narrower XKNOWN.",
+    "A minimal repro remains in tests/ or is added next to the affected corpus.",
+    "scripts/run_sanitizer_fuzz.sh no longer reports this signature."
+  ],
+  "blocked_by": [],
+  "file_globs": [
+    "tests/stdlib/v12_consciousness_test.esk"
+  ],
+  "sanitizer_signature": "AddressSanitizer\theap-buffer-overflow\t#0 0xADDR in display_tensor_recursive(__sFILE*, eshkol_tensor const*, unsigned long long, unsigned long long) runtime_display_hosted.cpp:672",
+  "sanitizer_kind": "AddressSanitizer",
+  "sanitizer_subtype": "heap-buffer-overflow",
+  "sanitizer_top_frame": "#0 0xADDR in display_tensor_recursive(__sFILE*, eshkol_tensor const*, unsigned long long, unsigned long long) runtime_display_hosted.cpp:672"
+}

--- a/.swarm/tasks/ESH-0164.json
+++ b/.swarm/tasks/ESH-0164.json
@@ -1,0 +1,22 @@
+{
+  "id": "ESH-0164",
+  "status": "open",
+  "priority": "high",
+  "workstream": "sanitizer-fuzz",
+  "title": "Sanitizer fuzz: AddressSanitizer heap-buffer-overflow",
+  "goal": "Fix sanitizer finding from scripts/run_sanitizer_fuzz.sh. First repro: tests/stress/found/string_nul_long_literal.esk via r/run. Top frame: #0 0xADDR in memcpy+0xADDR (libclang_rt.asan_osx_dynamic.dylib:arm64e+0xADDR). Log: artifacts/sanitizer-fuzz/logs/1080_r_3733549987.err.",
+  "status_note": "OPEN. Dedup signature is sanitizer kind/subtype plus normalized top frame.",
+  "acceptance": [
+    "Root cause is fixed or explicitly classified with a narrower XKNOWN.",
+    "A minimal repro remains in tests/ or is added next to the affected corpus.",
+    "scripts/run_sanitizer_fuzz.sh no longer reports this signature."
+  ],
+  "blocked_by": [],
+  "file_globs": [
+    "tests/stress/found/string_nul_long_literal.esk"
+  ],
+  "sanitizer_signature": "AddressSanitizer\theap-buffer-overflow\t#0 0xADDR in memcpy+0xADDR (libclang_rt.asan_osx_dynamic.dylib:arm64e+0xADDR)",
+  "sanitizer_kind": "AddressSanitizer",
+  "sanitizer_subtype": "heap-buffer-overflow",
+  "sanitizer_top_frame": "#0 0xADDR in memcpy+0xADDR (libclang_rt.asan_osx_dynamic.dylib:arm64e+0xADDR)"
+}

--- a/.swarm/tasks/ESH-0165.json
+++ b/.swarm/tasks/ESH-0165.json
@@ -1,0 +1,22 @@
+{
+  "id": "ESH-0165",
+  "status": "open",
+  "priority": "high",
+  "workstream": "sanitizer-fuzz",
+  "title": "Sanitizer fuzz: AddressSanitizer stack-buffer-overflow",
+  "goal": "Fix sanitizer finding from scripts/run_sanitizer_fuzz.sh. First repro: tests/v1_2_edge_cases/dotted_pair_reader_test.esk via aot-o2/run. Top frame: #0 0xADDR in eshkol_deep_equal runtime_deep_equal.cpp:27. Log: artifacts/sanitizer-fuzz/logs/1171_aot-o2_3462549093.run.err.",
+  "status_note": "OPEN. Dedup signature is sanitizer kind/subtype plus normalized top frame.",
+  "acceptance": [
+    "Root cause is fixed or explicitly classified with a narrower XKNOWN.",
+    "A minimal repro remains in tests/ or is added next to the affected corpus.",
+    "scripts/run_sanitizer_fuzz.sh no longer reports this signature."
+  ],
+  "blocked_by": [],
+  "file_globs": [
+    "tests/v1_2_edge_cases/dotted_pair_reader_test.esk"
+  ],
+  "sanitizer_signature": "AddressSanitizer\tstack-buffer-overflow\t#0 0xADDR in eshkol_deep_equal runtime_deep_equal.cpp:27",
+  "sanitizer_kind": "AddressSanitizer",
+  "sanitizer_subtype": "stack-buffer-overflow",
+  "sanitizer_top_frame": "#0 0xADDR in eshkol_deep_equal runtime_deep_equal.cpp:27"
+}

--- a/.swarm/tasks/ESH-0166.json
+++ b/.swarm/tasks/ESH-0166.json
@@ -1,0 +1,22 @@
+{
+  "id": "ESH-0166",
+  "status": "open",
+  "priority": "high",
+  "workstream": "sanitizer-fuzz",
+  "title": "Sanitizer fuzz: AddressSanitizer stack-buffer-overflow",
+  "goal": "Fix sanitizer finding from scripts/run_sanitizer_fuzz.sh. First repro: tests/v1_2_edge_cases/type_safety_test.esk via r/run. Top frame: #0 0xADDR in eshkol_type_error_with_operand runtime_errors_hosted.cpp:201. Log: artifacts/sanitizer-fuzz/logs/1227_r_2911697867.err.",
+  "status_note": "OPEN. Dedup signature is sanitizer kind/subtype plus normalized top frame.",
+  "acceptance": [
+    "Root cause is fixed or explicitly classified with a narrower XKNOWN.",
+    "A minimal repro remains in tests/ or is added next to the affected corpus.",
+    "scripts/run_sanitizer_fuzz.sh no longer reports this signature."
+  ],
+  "blocked_by": [],
+  "file_globs": [
+    "tests/v1_2_edge_cases/type_safety_test.esk"
+  ],
+  "sanitizer_signature": "AddressSanitizer\tstack-buffer-overflow\t#0 0xADDR in eshkol_type_error_with_operand runtime_errors_hosted.cpp:201",
+  "sanitizer_kind": "AddressSanitizer",
+  "sanitizer_subtype": "stack-buffer-overflow",
+  "sanitizer_top_frame": "#0 0xADDR in eshkol_type_error_with_operand runtime_errors_hosted.cpp:201"
+}

--- a/.swarm/tasks/ESH-0167.json
+++ b/.swarm/tasks/ESH-0167.json
@@ -1,0 +1,22 @@
+{
+  "id": "ESH-0167",
+  "status": "open",
+  "priority": "high",
+  "workstream": "sanitizer-fuzz",
+  "title": "Sanitizer fuzz: AddressSanitizer heap-buffer-overflow",
+  "goal": "Fix sanitizer finding from scripts/run_sanitizer_fuzz.sh. First repro: tests/vm/vm_system_test.esk via r/run. Top frame: #0 0xADDR in eshkol_display_value_opts runtime_display_hosted.cpp:219. Log: artifacts/sanitizer-fuzz/logs/1289_r_50244341.err.",
+  "status_note": "OPEN. Dedup signature is sanitizer kind/subtype plus normalized top frame.",
+  "acceptance": [
+    "Root cause is fixed or explicitly classified with a narrower XKNOWN.",
+    "A minimal repro remains in tests/ or is added next to the affected corpus.",
+    "scripts/run_sanitizer_fuzz.sh no longer reports this signature."
+  ],
+  "blocked_by": [],
+  "file_globs": [
+    "tests/vm/vm_system_test.esk"
+  ],
+  "sanitizer_signature": "AddressSanitizer\theap-buffer-overflow\t#0 0xADDR in eshkol_display_value_opts runtime_display_hosted.cpp:219",
+  "sanitizer_kind": "AddressSanitizer",
+  "sanitizer_subtype": "heap-buffer-overflow",
+  "sanitizer_top_frame": "#0 0xADDR in eshkol_display_value_opts runtime_display_hosted.cpp:219"
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1245,33 +1245,33 @@ if(NOT APPLE)
     if(WIN32 AND ESHKOL_CUDA_DEVICE_RUNTIME)
         eshkol_append_host_runtime_link_arg("${ESHKOL_CUDA_DEVICE_RUNTIME}")
     endif()
+endif()
 
-    # ── Sanitizer link-flag propagation ──────────────────────────────
-    # When libeshkol-static is built with -fsanitize=address /
-    # -fsanitize=undefined / -fsanitize=thread / -fsanitize=memory,
-    # its objects emit unresolved references to the sanitizer runtime
-    # (__asan_*, __ubsan_*, __tsan_*, __msan_*). User programs that
-    # link against libeshkol-static must therefore also pull in the
-    # sanitizer runtimes — otherwise `ld` fails with `undefined
-    # reference to __asan_report_storeN` etc.
-    #
-    # eshkol-run drives the user link step, and reads
-    # ESHKOL_HOST_RUNTIME_LINK_ARGS from build_config.h to compose
-    # that command line. Append the sanitizer flags here so the user
-    # link automatically picks them up; nothing is added on a
-    # non-sanitized build.
-    if(ESHKOL_ENABLE_ASAN)
-        eshkol_append_host_runtime_link_arg("-fsanitize=address")
-    endif()
-    if(ESHKOL_ENABLE_UBSAN)
-        eshkol_append_host_runtime_link_arg("-fsanitize=undefined")
-    endif()
-    if(ESHKOL_ENABLE_TSAN)
-        eshkol_append_host_runtime_link_arg("-fsanitize=thread")
-    endif()
-    if(ESHKOL_ENABLE_MSAN)
-        eshkol_append_host_runtime_link_arg("-fsanitize=memory")
-    endif()
+# ── Sanitizer link-flag propagation ──────────────────────────────
+# When libeshkol-static is built with -fsanitize=address /
+# -fsanitize=undefined / -fsanitize=thread / -fsanitize=memory,
+# its objects emit unresolved references to the sanitizer runtime
+# (__asan_*, __ubsan_*, __tsan_*, __msan_*). User programs that
+# link against libeshkol-static must therefore also pull in the
+# sanitizer runtimes — otherwise `ld` fails with `undefined
+# reference to __asan_report_storeN` etc.
+#
+# eshkol-run drives the user link step, and reads
+# ESHKOL_HOST_RUNTIME_LINK_ARGS from build_config.h to compose
+# that command line. Append the sanitizer flags here so the user
+# link automatically picks them up; nothing is added on a
+# non-sanitized build.
+if(ESHKOL_ENABLE_ASAN)
+    eshkol_append_host_runtime_link_arg("-fsanitize=address")
+endif()
+if(ESHKOL_ENABLE_UBSAN)
+    eshkol_append_host_runtime_link_arg("-fsanitize=undefined")
+endif()
+if(ESHKOL_ENABLE_TSAN)
+    eshkol_append_host_runtime_link_arg("-fsanitize=thread")
+endif()
+if(ESHKOL_ENABLE_MSAN)
+    eshkol_append_host_runtime_link_arg("-fsanitize=memory")
 endif()
 
 if(DEFINED ESHKOL_GENERATED_INCLUDE_DIR)

--- a/SANITIZER_FUZZ_REPORT.md
+++ b/SANITIZER_FUZZ_REPORT.md
@@ -1,0 +1,439 @@
+# Sanitizer Fuzz Report
+
+- Started: `2026-07-04T02:51:12Z`
+- Finished: `2026-07-04T04:44:04Z`
+- Build: `build-asan-ubsan`
+- Corpus files: `1363`
+- Run records: `6572`
+- Axes: `-r`, `AOT -O0 compile/run`, `AOT -O2 compile/run`
+- Generated differential fuzz: seed `42`, count `200`
+- ASAN_OPTIONS: `detect_leaks=0:halt_on_error=1:abort_on_error=1:print_stacktrace=1:strict_string_checks=1:detect_stack_use_after_return=0:symbolize=1`
+- UBSAN_OPTIONS: `print_stacktrace=1:halt_on_error=1:abort_on_error=1`
+- Raw logs: `artifacts/sanitizer-fuzz`
+- ICC trace: `scripts/icc_traces/sanitizer_fuzz.jsonl`
+
+## Teeth Check
+
+- Status: `PASS`
+- Summary: Synthetic unterminated numeric buffer repro emitted a sanitizer report rc=134
+- Synthetic repro: `artifacts/sanitizer-fuzz/self-test/esh0116_unterminated_numeric_buffer.c`
+- Synthetic stderr: `artifacts/sanitizer-fuzz/self-test/run.err`
+
+## Coverage
+
+- Status: `PASS`
+- Summary: -r runs=1363, AOT -O0 runs=1243, AOT -O2 runs=1240
+- Records by axis/phase/rc:
+  - `aot-o0/compile rc=0`: `1243`
+  - `aot-o0/compile rc=1`: `32`
+  - `aot-o0/compile rc=124`: `1`
+  - `aot-o0/compile rc=134`: `87`
+  - `aot-o0/run rc=0`: `1217`
+  - `aot-o0/run rc=1`: `13`
+  - `aot-o0/run rc=124`: `1`
+  - `aot-o0/run rc=132`: `5`
+  - `aot-o0/run rc=134`: `5`
+  - `aot-o0/run rc=138`: `1`
+  - `aot-o0/run rc=139`: `1`
+  - `aot-o2/compile rc=0`: `1240`
+  - `aot-o2/compile rc=1`: `31`
+  - `aot-o2/compile rc=124`: `5`
+  - `aot-o2/compile rc=134`: `87`
+  - `aot-o2/run rc=0`: `1217`
+  - `aot-o2/run rc=1`: `13`
+  - `aot-o2/run rc=124`: `1`
+  - `aot-o2/run rc=132`: `2`
+  - `aot-o2/run rc=134`: `6`
+  - `aot-o2/run rc=139`: `1`
+  - `r/run rc=0`: `1224`
+  - `r/run rc=1`: `37`
+  - `r/run rc=124`: `2`
+  - `r/run rc=132`: `5`
+  - `r/run rc=134`: `93`
+  - `r/run rc=138`: `1`
+  - `r/run rc=139`: `1`
+
+## Findings
+
+| Task | Kind | Type | Hits | Top frame | First repro |
+|---|---|---|---:|---|---|
+| `ESH-0160` | `AddressSanitizer` | `container-overflow` | 339 | `#0 0xADDR in ControlFlowCallbacks::registerFuncBindingWrapper(char const*, void*, void*) llvm_codegen.cpp:36354` | `tests/ad/sweep_c_regressions_test.esk` |
+| `ESH-0161` | `UndefinedBehaviorSanitizer` | `negation of -9223372036854775808 cannot be represented in type 'int64_t' (aka 'long long'); cast to an unsigned type to negate this value to itself` | 6 | `#0 0xADDR in eshkol_bignum_fits_int64 bignum.cpp:641` | `tests/bignum/bignum_edge_cases_test.esk` |
+| `ESH-0162` | `AddressSanitizer` | `heap-use-after-free` | 3 | `#0 0xADDR in eshkol_deep_equal runtime_deep_equal.cpp:68` | `tests/edge_matrix/generated/pair243_quote__regions.esk` |
+| `ESH-0163` | `AddressSanitizer` | `heap-buffer-overflow` | 6 | `#0 0xADDR in display_tensor_recursive(__sFILE*, eshkol_tensor const*, unsigned long long, unsigned long long) runtime_display_hosted.cpp:672` | `tests/stdlib/v12_consciousness_test.esk` |
+| `ESH-0164` | `AddressSanitizer` | `heap-buffer-overflow` | 8 | `#0 0xADDR in memcpy+0xADDR (libclang_rt.asan_osx_dynamic.dylib:arm64e+0xADDR)` | `tests/stress/found/string_nul_long_literal.esk` |
+| `ESH-0165` | `AddressSanitizer` | `stack-buffer-overflow` | 1 | `#0 0xADDR in eshkol_deep_equal runtime_deep_equal.cpp:27` | `tests/v1_2_edge_cases/dotted_pair_reader_test.esk` |
+| `ESH-0166` | `AddressSanitizer` | `stack-buffer-overflow` | 2 | `#0 0xADDR in eshkol_type_error_with_operand runtime_errors_hosted.cpp:201` | `tests/v1_2_edge_cases/type_safety_test.esk` |
+| `ESH-0167` | `AddressSanitizer` | `heap-buffer-overflow` | 1 | `#0 0xADDR in eshkol_display_value_opts runtime_display_hosted.cpp:219` | `tests/vm/vm_system_test.esk` |
+
+### ESH-0160
+
+- Kind: `AddressSanitizer`
+- Type: `container-overflow`
+- Hits: `339`
+- Top frame: `#0 0xADDR in ControlFlowCallbacks::registerFuncBindingWrapper(char const*, void*, void*) llvm_codegen.cpp:36354`
+- Summary: `SUMMARY: AddressSanitizer: container-overflow llvm_codegen.cpp:36354 in ControlFlowCallbacks::registerFuncBindingWrapper(char const*, void*, void*)`
+- First repro: `tests/ad/sweep_c_regressions_test.esk` via `r/run` rc `134`
+- Repro command: `ASAN_OPTIONS='detect_leaks=0:halt_on_error=1:abort_on_error=1:print_stacktrace=1:strict_string_checks=1:detect_stack_use_after_return=0:symbolize=1' UBSAN_OPTIONS='print_stacktrace=1:halt_on_error=1:abort_on_error=1' build-asan-ubsan/eshkol-run -r tests/ad/sweep_c_regressions_test.esk`
+- First log: `artifacts/sanitizer-fuzz/logs/206_r_211912727.err`
+- Additional samples:
+  - `tests/ad/sweep_c_regressions_test.esk` via `r/run`, log `artifacts/sanitizer-fuzz/logs/206_r_211912727.err`
+  - `tests/ad/sweep_c_regressions_test.esk` via `aot-o0/compile`, log `artifacts/sanitizer-fuzz/logs/206_aot-o0_211912727.compile.err`
+  - `tests/ad/sweep_c_regressions_test.esk` via `aot-o2/compile`, log `artifacts/sanitizer-fuzz/logs/206_aot-o2_211912727.compile.err`
+  - `tests/ad_oracle/generated/ad_oracle_deriv_01.esk` via `r/run`, log `artifacts/sanitizer-fuzz/logs/215_r_579100824.err`
+
+```text
+==25845==ERROR: AddressSanitizer: container-overflow on address 0x62100015f500 at pc 0x00010043007c bp 0x00016fc79c30 sp 0x00016fc79c28
+READ of size 8 at 0x62100015f500 thread T0
+    #0 0x100430078 in ControlFlowCallbacks::registerFuncBindingWrapper(char const*, void*, void*) llvm_codegen.cpp:36354
+    #1 0x100306628 in eshkol::BindingCodegen::define(eshkol_operation const*) binding_codegen.cpp:373
+    #2 0x1004df4a0 in EshkolLLVMCodeGen::codegenDefine(eshkol_ast const*) llvm_codegen.cpp:10419
+    #3 0x100417f38 in EshkolLLVMCodeGen::codegenAST(eshkol_ast const*) llvm_codegen.cpp:8893
+    #4 0x1003c2918 in EshkolLLVMCodeGen::generateIR(eshkol_ast const*, unsigned long) llvm_codegen.cpp:2758
+    #5 0x1003bbd20 in eshkol_generate_llvm_ir llvm_codegen.cpp:36747
+    #6 0x100e04734 in main eshkol-run.cpp:4244
+    #7 0x193b88270  (<unknown module>)
+
+0x62100015f500 is located 0 bytes inside of 4048-byte region [0x62100015f500,0x6210001604d0)
+allocated by thread T0 here:
+    #0 0x103e5fe94 in _Znwm+0x74 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x63e94)
+    #1 0x10043914c in std::__1::deque<TypedValue, std::__1::allocator<TypedValue>>::__add_back_capacity() deque:2163
+    #2 0x10043327c in std::__1::deque<TypedValue, std::__1::allocator<TypedValue>>::push_back(TypedValue&&) deque:1567
+    #3 0x10042c464 in ControlFlowCallbacks::codegenTypedASTWrapper(void const*, void*) llvm_codegen.cpp:36301
+    #4 0x10072aadc in eshkol::StringIOCodegen::display(eshkol_operation const*) string_io_codegen.cpp:1859
+    #5 0x10052c910 in EshkolLLVMCodeGen::codegenCall(eshkol_operation const*) llvm_codegen.cpp:13951
+    #6 0x1004e05b8 in EshkolLLVMCodeGen::codegenOperation(eshkol_operation const*) llvm_codegen.cpp:10098
+    #7 0x1004181d0 in EshkolLLVMCodeGen::codegenAST(eshkol_ast const*) llvm_codegen.cpp:8895
+    #8 0x100570124 in EshkolLLVMCodeGen::codegenSequence(eshkol_operation const*) llvm_codegen.cpp:23084
+    #9 0x1004e0574 in EshkolLLVMCodeGen::codegenOperation(eshkol_operation const*) llvm_codegen.cpp:10101
+    #10 0x1004181d0 in EshkolLLVMCodeGen::codegenAST(eshkol_ast const*) llvm_codegen.cpp:8895
+    #11 0x1004f0044 in EshkolLLVMCodeGen::codegenFunctionDefinition(eshkol_ast const*) llvm_codegen.cpp:10612
+    #12 0x1004df150 in EshkolLLVMCodeGen::codegenDefine(eshkol_ast const*) llvm_codegen.cpp:10392
+    #13 0x100417f38 in EshkolLLVMCodeGen::codegenAST(eshkol_ast const*) llvm_codegen.cpp:8893
+    #14 0x1003c1e94 in EshkolLLVMCodeGen::generateIR(eshkol_ast const*, unsigned long) llvm_codegen.cpp:2702
+    #15 0x1003bbd20 in eshkol_generate_llvm_ir llvm_codegen.cpp:36747
+    #16 0x100e04734 in main eshkol-run.cpp:4244
+    #17 0x193b88270  (<unknown module>)
+
+HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_container_overflow=0.
+If you suspect a false positive see also: https://github.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow.
+SUMMARY: AddressSanitizer: container-overflow llvm_codegen.cpp:36354 in ControlFlowCallbacks::registerFuncBindingWrapper(char const*, void*, void*)
+Shadow bytes around the buggy address:
+```
+
+### ESH-0161
+
+- Kind: `UndefinedBehaviorSanitizer`
+- Type: `negation of -9223372036854775808 cannot be represented in type 'int64_t' (aka 'long long'); cast to an unsigned type to negate this value to itself`
+- Hits: `6`
+- Top frame: `#0 0xADDR in eshkol_bignum_fits_int64 bignum.cpp:641`
+- Summary: `SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ./lib/core/bignum.cpp:641:29 in`
+- First repro: `tests/bignum/bignum_edge_cases_test.esk` via `r/run` rc `134`
+- Repro command: `ASAN_OPTIONS='detect_leaks=0:halt_on_error=1:abort_on_error=1:print_stacktrace=1:strict_string_checks=1:detect_stack_use_after_return=0:symbolize=1' UBSAN_OPTIONS='print_stacktrace=1:halt_on_error=1:abort_on_error=1' build-asan-ubsan/eshkol-run -r tests/bignum/bignum_edge_cases_test.esk`
+- First log: `artifacts/sanitizer-fuzz/logs/298_r_2816962780.err`
+- Additional samples:
+  - `tests/bignum/bignum_edge_cases_test.esk` via `aot-o0/run`, log `artifacts/sanitizer-fuzz/logs/298_aot-o0_2816962780.run.err`
+  - `tests/bignum/bignum_edge_cases_test.esk` via `aot-o2/run`, log `artifacts/sanitizer-fuzz/logs/298_aot-o2_2816962780.run.err`
+  - `tests/numeric/critical_regression_test.esk` via `r/run`, log `artifacts/sanitizer-fuzz/logs/930_r_2652083108.err`
+  - `tests/numeric/critical_regression_test.esk` via `aot-o0/run`, log `artifacts/sanitizer-fuzz/logs/930_aot-o0_2652083108.run.err`
+
+```text
+./lib/core/bignum.cpp:641:29: runtime error: negation of -9223372036854775808 cannot be represented in type 'int64_t' (aka 'long long'); cast to an unsigned type to negate this value to itself
+    #0 0x103e3e0b4 in eshkol_bignum_fits_int64 bignum.cpp:641
+    #1 0x103e3f204 in eshkol_bignum_binary_tagged bignum.cpp:803
+    #2 0x103e282f8 in main+0xac8 (run-42814376ec591ac31d83e7998a18df607eb164384982eb2ae6aafc5bb9f859a7:arm64+0x10159c2f8)
+    #3 0x193b88270  (<unknown module>)
+
+SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ./lib/core/bignum.cpp:641:29 in
+```
+
+### ESH-0162
+
+- Kind: `AddressSanitizer`
+- Type: `heap-use-after-free`
+- Hits: `3`
+- Top frame: `#0 0xADDR in eshkol_deep_equal runtime_deep_equal.cpp:68`
+- Summary: `SUMMARY: AddressSanitizer: heap-use-after-free runtime_deep_equal.cpp:68 in eshkol_deep_equal`
+- First repro: `tests/edge_matrix/generated/pair243_quote__regions.esk` via `r/run` rc `134`
+- Repro command: `ASAN_OPTIONS='detect_leaks=0:halt_on_error=1:abort_on_error=1:print_stacktrace=1:strict_string_checks=1:detect_stack_use_after_return=0:symbolize=1' UBSAN_OPTIONS='print_stacktrace=1:halt_on_error=1:abort_on_error=1' build-asan-ubsan/eshkol-run -r tests/edge_matrix/generated/pair243_quote__regions.esk`
+- First log: `artifacts/sanitizer-fuzz/logs/614_r_2370875467.err`
+- Additional samples:
+  - `tests/edge_matrix/generated/pair243_quote__regions.esk` via `aot-o0/run`, log `artifacts/sanitizer-fuzz/logs/614_aot-o0_2370875467.run.err`
+  - `tests/edge_matrix/generated/pair243_quote__regions.esk` via `aot-o2/run`, log `artifacts/sanitizer-fuzz/logs/614_aot-o2_2370875467.run.err`
+
+```text
+==8477==ERROR: AddressSanitizer: heap-use-after-free on address 0x625000002908 at pc 0x000102359efc bp 0x00016f056190 sp 0x00016f056188
+READ of size 1 at 0x625000002908 thread T0
+    #0 0x102359ef8 in eshkol_deep_equal runtime_deep_equal.cpp:68
+    #1 0x10234383c in edge-chk+0x9c (run-c3957f9868169cf49823d9acbb1d214fa26c7763af4e1a5247e3695739d0331c:arm64+0x10159b83c)
+    #2 0x102343bf4 in edge-check-g2134+0x150 (run-c3957f9868169cf49823d9acbb1d214fa26c7763af4e1a5247e3695739d0331c:arm64+0x10159bbf4)
+
+0x625000002908 is located 8 bytes inside of 8192-byte region [0x625000002900,0x625000004900)
+freed by thread T0 here:
+    #0 0x102ec8d40 in free+0x98 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x54d40)
+    #1 0x102354400 in arena_destroy runtime_arena_core.cpp:174
+    #2 0x102361988 in region_destroy runtime_regions.cpp:200
+    #3 0x102343b74 in edge-check-g2134+0xd0 (run-c3957f9868169cf49823d9acbb1d214fa26c7763af4e1a5247e3695739d0331c:arm64+0x10159bb74)
+
+previously allocated by thread T0 here:
+    #0 0x102ec8c04 in malloc+0x94 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x54c04)
+    #1 0x102354020 in create_arena_block(unsigned long) runtime_arena_core.cpp:60
+    #2 0x102353df0 in arena_create runtime_arena_core.cpp:94
+    #3 0x102361610 in region_create runtime_regions.cpp:155
+    #4 0x102343ac0 in edge-check-g2134+0x1c (run-c3957f9868169cf49823d9acbb1d214fa26c7763af4e1a5247e3695739d0331c:arm64+0x10159bac0)
+
+SUMMARY: AddressSanitizer: heap-use-after-free runtime_deep_equal.cpp:68 in eshkol_deep_equal
+Shadow bytes around the buggy address:
+  0x625000002680: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x625000002700: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x625000002780: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x625000002800: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x625000002880: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+=>0x625000002900: fd[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd fd
+  0x625000002980: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
+  0x625000002a00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
+  0x625000002a80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
+  0x625000002b00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
+  0x625000002b80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
+Shadow byte legend (one shadow byte represents 8 application bytes):
+  Addressable:           00
+  Partially addressable: 01 02 03 04 05 06 07
+```
+
+### ESH-0163
+
+- Kind: `AddressSanitizer`
+- Type: `heap-buffer-overflow`
+- Hits: `6`
+- Top frame: `#0 0xADDR in display_tensor_recursive(__sFILE*, eshkol_tensor const*, unsigned long long, unsigned long long) runtime_display_hosted.cpp:672`
+- Summary: `SUMMARY: AddressSanitizer: heap-buffer-overflow runtime_display_hosted.cpp:672 in display_tensor_recursive(__sFILE*, eshkol_tensor const*, unsigned long long, unsigned long long)`
+- First repro: `tests/stdlib/v12_consciousness_test.esk` via `r/run` rc `134`
+- Repro command: `ASAN_OPTIONS='detect_leaks=0:halt_on_error=1:abort_on_error=1:print_stacktrace=1:strict_string_checks=1:detect_stack_use_after_return=0:symbolize=1' UBSAN_OPTIONS='print_stacktrace=1:halt_on_error=1:abort_on_error=1' build-asan-ubsan/eshkol-run -r tests/stdlib/v12_consciousness_test.esk`
+- First log: `artifacts/sanitizer-fuzz/logs/1057_r_1980305526.err`
+- Additional samples:
+  - `tests/stdlib/v12_consciousness_test.esk` via `aot-o0/run`, log `artifacts/sanitizer-fuzz/logs/1057_aot-o0_1980305526.run.err`
+  - `tests/stdlib/v12_consciousness_test.esk` via `aot-o2/run`, log `artifacts/sanitizer-fuzz/logs/1057_aot-o2_1980305526.run.err`
+  - `tests/vm/vm_kb_tensor_test.esk` via `r/run`, log `artifacts/sanitizer-fuzz/logs/1288_r_1592037548.err`
+  - `tests/vm/vm_kb_tensor_test.esk` via `aot-o0/run`, log `artifacts/sanitizer-fuzz/logs/1288_aot-o0_1592037548.run.err`
+
+```text
+==67725==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x631000114800 at pc 0x0001062b64b8 bp 0x00016b131fd0 sp 0x00016b131fc8
+READ of size 8 at 0x631000114800 thread T0
+    #0 0x1062b64b4 in display_tensor_recursive(__sFILE*, eshkol_tensor const*, unsigned long long, unsigned long long) runtime_display_hosted.cpp:672
+    #1 0x1062b4008 in eshkol_display_value_opts runtime_display_hosted.cpp
+    #2 0x1062b37fc in eshkol_display_value runtime_display_hosted.cpp:161
+    #3 0x106265520 in main+0xbd8 (run-518e0514618815b085ab030890c94b4f3e9eaeadc35281a8489752284b77fe4c:arm64+0x101599520)
+    #4 0x193b88270  (<unknown module>)
+
+0x631000114800 is located 0 bytes after 65536-byte region [0x631000104800,0x631000114800)
+allocated by thread T0 here:
+    #0 0x107124c04 in malloc+0x94 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x54c04)
+    #1 0x106275e0c in create_arena_block(unsigned long) runtime_arena_core.cpp:60
+    #2 0x10627670c in arena_allocate_aligned runtime_arena_core.cpp:235
+    #3 0x106265194 in main+0x84c (run-518e0514618815b085ab030890c94b4f3e9eaeadc35281a8489752284b77fe4c:arm64+0x101599194)
+    #4 0x193b88270  (<unknown module>)
+
+SUMMARY: AddressSanitizer: heap-buffer-overflow runtime_display_hosted.cpp:672 in display_tensor_recursive(__sFILE*, eshkol_tensor const*, unsigned long long, unsigned long long)
+Shadow bytes around the buggy address:
+  0x631000114580: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x631000114600: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x631000114680: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x631000114700: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x631000114780: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+=>0x631000114800:[fa]fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x631000114880: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x631000114900: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x631000114980: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x631000114a00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x631000114a80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+Shadow byte legend (one shadow byte represents 8 application bytes):
+  Addressable:           00
+  Partially addressable: 01 02 03 04 05 06 07
+  Heap left redzone:       fa
+  Freed heap region:       fd
+  Stack left redzone:      f1
+  Stack mid redzone:       f2
+```
+
+### ESH-0164
+
+- Kind: `AddressSanitizer`
+- Type: `heap-buffer-overflow`
+- Hits: `8`
+- Top frame: `#0 0xADDR in memcpy+0xADDR (libclang_rt.asan_osx_dynamic.dylib:arm64e+0xADDR)`
+- Summary: `SUMMARY: AddressSanitizer: heap-buffer-overflow (libclang_rt.asan_osx_dynamic.dylib:arm64e+0xADDR) in memcpy+0xADDR`
+- First repro: `tests/stress/found/string_nul_long_literal.esk` via `r/run` rc `134`
+- Repro command: `ASAN_OPTIONS='detect_leaks=0:halt_on_error=1:abort_on_error=1:print_stacktrace=1:strict_string_checks=1:detect_stack_use_after_return=0:symbolize=1' UBSAN_OPTIONS='print_stacktrace=1:halt_on_error=1:abort_on_error=1' build-asan-ubsan/eshkol-run -r tests/stress/found/string_nul_long_literal.esk`
+- First log: `artifacts/sanitizer-fuzz/logs/1080_r_3733549987.err`
+- Additional samples:
+  - `tests/stress/found/string_nul_long_literal.esk` via `r/run`, log `artifacts/sanitizer-fuzz/logs/1080_r_3733549987.err`
+  - `tests/stress/found/string_nul_long_literal.esk` via `aot-o0/compile`, log `artifacts/sanitizer-fuzz/logs/1080_aot-o0_3733549987.compile.err`
+  - `tests/stress/found/string_nul_long_literal.esk` via `aot-o2/compile`, log `artifacts/sanitizer-fuzz/logs/1080_aot-o2_3733549987.compile.err`
+  - `tests/stress/parser_string_5k_escapes.esk` via `r/run`, log `artifacts/sanitizer-fuzz/logs/1091_r_2046740991.err`
+
+```text
+==70165==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6020000e88d1 at pc 0x000103eeeda8 bp 0x00016fbd8b80 sp 0x00016fbd8330
+READ of size 300 at 0x6020000e88d1 thread T0
+    #0 0x103eeeda4 in memcpy+0x3fc (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x52da4)
+    #1 0x193e39404 in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::__init(char const*, unsigned long)+0x7c (libc++.1.dylib:arm64e+0x19404)
+    #2 0x1004b7e70 in EshkolLLVMCodeGen::codegenAST(eshkol_ast const*) llvm_codegen.cpp:8883
+    #3 0x1004d6ee8 in EshkolLLVMCodeGen::codegenTypedAST(eshkol_ast const*) llvm_codegen.cpp:6028
+    #4 0x1004cc458 in ControlFlowCallbacks::codegenTypedASTWrapper(void const*, void*) llvm_codegen.cpp:36301
+    #5 0x1003a6468 in eshkol::BindingCodegen::define(eshkol_operation const*) binding_codegen.cpp:336
+    #6 0x10057f4a0 in EshkolLLVMCodeGen::codegenDefine(eshkol_ast const*) llvm_codegen.cpp:10419
+    #7 0x1004b7f38 in EshkolLLVMCodeGen::codegenAST(eshkol_ast const*) llvm_codegen.cpp:8893
+    #8 0x100462918 in EshkolLLVMCodeGen::generateIR(eshkol_ast const*, unsigned long) llvm_codegen.cpp:2758
+    #9 0x10045bd20 in eshkol_generate_llvm_ir llvm_codegen.cpp:36747
+    #10 0x100ea4734 in main eshkol-run.cpp:4244
+    #11 0x193b88270  (<unknown module>)
+
+0x6020000e88d1 is located 0 bytes after 1-byte region [0x6020000e88d0,0x6020000e88d1)
+allocated by thread T0 here:
+    #0 0x103ee9cb8 in strdup+0x11c (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x4dcb8)
+    #1 0x100ad3ea4 in eshkol::MacroExpander::copyAst(eshkol_ast const&) macro_expander.cpp:1194
+    #2 0x100acffac in eshkol::MacroExpander::expandNode(eshkol_ast const&) macro_expander.cpp:147
+    #3 0x100ad0f1c in eshkol::MacroExpander::expandNode(eshkol_ast const&) macro_expander.cpp:183
+    #4 0x100acf5dc in eshkol::MacroExpander::expandAll(std::__1::vector<eshkol_ast, std::__1::allocator<eshkol_ast>> const&) macro_expander.cpp:74
+    #5 0x10045c9a0 in EshkolLLVMCodeGen::generateIR(eshkol_ast const*, unsigned long) llvm_codegen.cpp:2130
+    #6 0x10045bd20 in eshkol_generate_llvm_ir llvm_codegen.cpp:36747
+    #7 0x100ea4734 in main eshkol-run.cpp:4244
+    #8 0x193b88270  (<unknown module>)
+
+SUMMARY: AddressSanitizer: heap-buffer-overflow (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x52da4) in memcpy+0x3fc
+Shadow bytes around the buggy address:
+  0x6020000e8600: fa fa 00 00 fa fa 00 00 fa fa 06 fa fa fa 02 fa
+  0x6020000e8680: fa fa 00 00 fa fa 06 fa fa fa 02 fa fa fa 00 fa
+  0x6020000e8700: fa fa 06 fa fa fa 00 00 fa fa 02 fa fa fa 02 fa
+  0x6020000e8780: fa fa 00 03 fa fa 06 fa fa fa 05 fa fa fa 02 fa
+  0x6020000e8800: fa fa 02 fa fa fa 02 fa fa fa 02 fa fa fa 00 00
+=>0x6020000e8880: fa fa 06 fa fa fa 00 03 fa fa[01]fa fa fa 00 fa
+  0x6020000e8900: fa fa 04 fa fa fa 00 fa fa fa 00 06 fa fa 05 fa
+```
+
+### ESH-0165
+
+- Kind: `AddressSanitizer`
+- Type: `stack-buffer-overflow`
+- Hits: `1`
+- Top frame: `#0 0xADDR in eshkol_deep_equal runtime_deep_equal.cpp:27`
+- Summary: `SUMMARY: AddressSanitizer: stack-buffer-overflow runtime_deep_equal.cpp:27 in eshkol_deep_equal`
+- First repro: `tests/v1_2_edge_cases/dotted_pair_reader_test.esk` via `aot-o2/run` rc `134`
+- Repro command: `ASAN_OPTIONS='detect_leaks=0:halt_on_error=1:abort_on_error=1:print_stacktrace=1:strict_string_checks=1:detect_stack_use_after_return=0:symbolize=1' UBSAN_OPTIONS='print_stacktrace=1:halt_on_error=1:abort_on_error=1' build-asan-ubsan/eshkol-run -O2 tests/v1_2_edge_cases/dotted_pair_reader_test.esk -o /tmp/eshkol-sanitize-repro.bin`
+- First log: `artifacts/sanitizer-fuzz/logs/1171_aot-o2_3462549093.run.err`
+- Additional samples:
+
+```text
+==91318==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x00016ceea6e8 at pc 0x0001044cd6c4 bp 0x00016ceea530 sp 0x00016ceea528
+READ of size 1 at 0x00016ceea6e8 thread T0
+    #0 0x1044cd6c0 in eshkol_deep_equal runtime_deep_equal.cpp:27
+    #1 0x1044aea74 in check+0xb0 (1171_aot-o2_3462549093.bin:arm64+0x10159aa74)
+    #2 0x1044b7f2c in main+0x630c (1171_aot-o2_3462549093.bin:arm64+0x1015a3f2c)
+    #3 0x193b88270  (<unknown module>)
+
+Address 0x00016ceea6e8 is located in stack of thread T0 at offset 424 in frame
+    #0 0x1044cc514 in eshkol_deep_equal runtime_deep_equal.cpp:18
+
+  This frame has 4 object(s):
+    [32, 48) 'car1' (line 76)
+    [64, 80) 'car2' (line 77)
+    [96, 112) 'cdr1' (line 80)
+    [128, 144) 'cdr2' (line 81) <== Memory access at offset 424 overflows this variable
+HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
+      (longjmp and C++ exceptions *are* supported)
+SUMMARY: AddressSanitizer: stack-buffer-overflow runtime_deep_equal.cpp:27 in eshkol_deep_equal
+Shadow bytes around the buggy address:
+  0x00016ceea400: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x00016ceea480: 00 00 00 00 f1 f1 f1 f1 00 00 00 00 00 00 00 00
+  0x00016ceea500: 00 00 00 00 00 00 00 00 f1 f1 f1 f1 f8 f8 f2 f2
+  0x00016ceea580: f8 f8 f2 f2 f8 f8 f2 f2 f8 f8 f3 f3 00 00 00 00
+  0x00016ceea600: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+=>0x00016ceea680: 00 00 00 00 00 00 00 00 f2 f2 f2 f2 f2[f2]f2 f2
+  0x00016ceea700: 00 f3 f3 f3 00 00 00 00 00 00 00 00 00 00 00 00
+  0x00016ceea780: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x00016ceea800: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x00016ceea880: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x00016ceea900: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+Shadow byte legend (one shadow byte represents 8 application bytes):
+  Addressable:           00
+  Partially addressable: 01 02 03 04 05 06 07
+  Heap left redzone:       fa
+  Freed heap region:       fd
+  Stack left redzone:      f1
+```
+
+### ESH-0166
+
+- Kind: `AddressSanitizer`
+- Type: `stack-buffer-overflow`
+- Hits: `2`
+- Top frame: `#0 0xADDR in eshkol_type_error_with_operand runtime_errors_hosted.cpp:201`
+- First repro: `tests/v1_2_edge_cases/type_safety_test.esk` via `r/run` rc `138`
+- Repro command: `ASAN_OPTIONS='detect_leaks=0:halt_on_error=1:abort_on_error=1:print_stacktrace=1:strict_string_checks=1:detect_stack_use_after_return=0:symbolize=1' UBSAN_OPTIONS='print_stacktrace=1:halt_on_error=1:abort_on_error=1' build-asan-ubsan/eshkol-run -r tests/v1_2_edge_cases/type_safety_test.esk`
+- First log: `artifacts/sanitizer-fuzz/logs/1227_r_2911697867.err`
+- Additional samples:
+  - `tests/v1_2_edge_cases/type_safety_test.esk` via `aot-o0/run`, log `artifacts/sanitizer-fuzz/logs/1227_aot-o0_2911697867.run.err`
+
+```text
+==98752==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x00016b7f1530 at pc 0x000105bfcb68 bp 0x00016b7f14f0 sp 0x00016b7f14e8
+READ of size 8 at 0x00016b7f1530 thread T0
+    #0 0x105bfcb64 in eshkol_type_error_with_operand runtime_errors_hosted.cpp:201
+    #1 0x105baaa80 in main+0x1d9c (run-110d8c53cf0ac460d0647a2053c1e60d968faf93581af056599981dd1f9acc66:arm64+0x10159ea80)
+    #2 0x193b88270  (<unknown module>)
+
+Address 0x00016b7f1530 is located in stack of thread T0 at offset 400 in frame
+    #0 0x100000000d  (<unknown module>)
+
+
+[Eshkol] fatal signal: SIGBUS (bus error) — terminating; output above is what made it to stdout before the crash
+```
+
+### ESH-0167
+
+- Kind: `AddressSanitizer`
+- Type: `heap-buffer-overflow`
+- Hits: `1`
+- Top frame: `#0 0xADDR in eshkol_display_value_opts runtime_display_hosted.cpp:219`
+- Summary: `SUMMARY: AddressSanitizer: heap-buffer-overflow runtime_display_hosted.cpp:219 in eshkol_display_value_opts`
+- First repro: `tests/vm/vm_system_test.esk` via `r/run` rc `134`
+- Repro command: `ASAN_OPTIONS='detect_leaks=0:halt_on_error=1:abort_on_error=1:print_stacktrace=1:strict_string_checks=1:detect_stack_use_after_return=0:symbolize=1' UBSAN_OPTIONS='print_stacktrace=1:halt_on_error=1:abort_on_error=1' build-asan-ubsan/eshkol-run -r tests/vm/vm_system_test.esk`
+- First log: `artifacts/sanitizer-fuzz/logs/1289_r_50244341.err`
+- Additional samples:
+
+```text
+==12238==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x631000ce47f8 at pc 0x000104a2da4c bp 0x00016bdf52d0 sp 0x00016bdf52c8
+READ of size 1 at 0x631000ce47f8 thread T0
+    #0 0x104a2da48 in eshkol_display_value_opts runtime_display_hosted.cpp:219
+    #1 0x104a2cc24 in eshkol_display_value runtime_display_hosted.cpp:161
+    #2 0x1079f43e4  (<unknown module>)
+    #3 0x104c31ccc in eshkol::ReplJITContext::executeBatch(std::__1::vector<eshkol_ast, std::__1::allocator<eshkol_ast>>&, bool) repl_jit.cpp:2977
+    #4 0x104c8abc0 in main eshkol-run.cpp:3825
+    #5 0x193b88270  (<unknown module>)
+
+0x631000ce47f8 is located 8 bytes before 65536-byte region [0x631000ce4800,0x631000cf4800)
+allocated by thread T0 here:
+    #0 0x107cd4c04 in malloc+0x94 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x54c04)
+    #1 0x1049da21c in create_arena_block(unsigned long) runtime_arena_core.cpp:60
+    #2 0x1049dab1c in arena_allocate_aligned runtime_arena_core.cpp:235
+    #3 0x1079f4330  (<unknown module>)
+    #4 0x104c31ccc in eshkol::ReplJITContext::executeBatch(std::__1::vector<eshkol_ast, std::__1::allocator<eshkol_ast>>&, bool) repl_jit.cpp:2977
+    #5 0x104c8abc0 in main eshkol-run.cpp:3825
+    #6 0x193b88270  (<unknown module>)
+
+SUMMARY: AddressSanitizer: heap-buffer-overflow runtime_display_hosted.cpp:219 in eshkol_display_value_opts
+Shadow bytes around the buggy address:
+  0x631000ce4500: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x631000ce4580: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x631000ce4600: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x631000ce4680: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x631000ce4700: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+=>0x631000ce4780: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa[fa]
+  0x631000ce4800: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x631000ce4880: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x631000ce4900: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x631000ce4980: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x631000ce4a00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+Shadow byte legend (one shadow byte represents 8 application bytes):
+  Addressable:           00
+  Partially addressable: 01 02 03 04 05 06 07
+  Heap left redzone:       fa
+```

--- a/lib/core/memory_store.esk
+++ b/lib/core/memory_store.esk
@@ -217,16 +217,32 @@
             (make-memory-store log path))))))
 
 (define (memory-store-append! store type payload)
-  ;; Append to the in-memory chain, then persist with fsync (T0) before returning.
-  ;; Also refreshes the head sidecar so the NEXT process can open in O(1).
-  ;; Every payload string is sanitized HERE (defense in depth) — the store never
-  ;; trusts callers to have done it; one unsanitized em-dash cost us a link.
+  ;; PERSIST-BEFORE-ADVANCE (durability-critical). The in-memory head is advanced
+  ;; ONLY AFTER the fsync succeeds. Earlier this advanced first (via memory-append!)
+  ;; then fsync'd — so when the disk filled (ENOSPC, 2026-07-04) the fsync failed but
+  ;; the in-memory head had already moved to an event that never hit disk; the next
+  ;; successful append then referenced that never-persisted parent -> an orphan-parent
+  ;; scar in her chain. Computing the event WITHOUT mutating, persisting, then
+  ;; advancing only on success keeps in-memory and disk in lockstep: a failed write
+  ;; leaves the chain exactly as it was, so the next append links correctly.
+  ;; Payload sanitized HERE (defense in depth — one unsanitized em-dash cost a link).
   (let* ((clean (ms-sanitize-payload payload))
-         (ev   (memory-append! (memory-store-log store) type clean))
-         (line (string-append (sexp->canonical-string ev) "\n")))
+         (log   (memory-store-log store))
+         (node  (ml-node log))
+         (vc    (vector-clock-tick (ml-vclock log) node))
+         (prev  (vector-ref log 4))
+         (id    (event-content-hash node prev vc type clean))
+         (ev    (list (quote mem-ev-v1) id prev vc node type clean))
+         (line  (string-append (sexp->canonical-string ev) "\n")))
     (if (ms-append-fsync! (memory-store-path store) line)
-        (begin (ms-write-head! store) ev)
-        (begin (display "memory-store: DURABILITY FAILURE (append not persisted)") (newline) #f))))
+        (begin                                   ;; persisted — NOW advance in-memory
+          (vector-set! log 2 (rga-append (ml-rga log) node ev))
+          (vector-set! log 3 vc)
+          (vector-set! log 4 id)
+          (ms-write-head! store)
+          ev)
+        (begin (display "memory-store: DURABILITY FAILURE (append not persisted; chain unchanged)")
+               (newline) #f))))
 
 (define (ms-sanitize-payload payload)
   ;; alist of (key . string|number) -> same, with every string value sanitized

--- a/scripts/build-sanitizer.sh
+++ b/scripts/build-sanitizer.sh
@@ -52,6 +52,12 @@ cmake .. \
 
 make -j"$(sysctl -n hw.ncpu 2>/dev/null || nproc)" eshkol-run stdlib
 
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    ASAN_EXAMPLE_OPTIONS="detect_leaks=0:abort_on_error=0"
+else
+    ASAN_EXAMPLE_OPTIONS="detect_leaks=1:abort_on_error=0"
+fi
+
 cat <<EOF
 
 =========================================
@@ -59,7 +65,7 @@ cat <<EOF
 =========================================
 
 Run tests with:
-  (cd ${BUILD_DIR} && ASAN_OPTIONS='detect_leaks=1:abort_on_error=0' \\
+  (cd ${BUILD_DIR} && ASAN_OPTIONS='${ASAN_EXAMPLE_OPTIONS}' \\
                      UBSAN_OPTIONS='print_stacktrace=1' \\
                      ./eshkol-run ../tests/v1_2_edge_cases/hardening_path_test.esk)
 

--- a/scripts/run_sanitizer_fuzz.sh
+++ b/scripts/run_sanitizer_fuzz.sh
@@ -20,6 +20,8 @@ SKIP_BUILD=0
 SELF_TEST_ONLY=0
 NO_GENERATED=0
 LIMIT=0
+MAX_ARTIFACTS_GB="${ESHKOL_FUZZ_MAX_GB:-2}"
+MAX_RETAINED_CRASHES="${ESHKOL_FUZZ_MAX_RETAINED_CRASHES:-200}"
 
 usage() {
     cat <<'EOF'
@@ -40,6 +42,9 @@ Options:
   --no-generated           Do not generate additional differential fuzz programs.
   --timeout SEC            Per process timeout (default: 90).
   --limit N                Run only the first N corpus files (debugging only).
+  --max-artifacts-gb N     Hard cap for sanitizer-fuzz work dir (default: 2,
+                           env: ESHKOL_FUZZ_MAX_GB).
+  --max-retained-crashes N Cap retained sanitizer logs/repros (default: 200).
   --task-base N            First ESH id to allocate for sanitizer findings (default: 160).
   --self-test-only         Run only the synthetic ESH-0116-class sanitizer check.
   -h, --help               Show this help.
@@ -58,6 +63,8 @@ while [ $# -gt 0 ]; do
         --no-generated) NO_GENERATED=1; shift ;;
         --timeout) TIMEOUT_RUN="$2"; shift 2 ;;
         --limit) LIMIT="$2"; shift 2 ;;
+        --max-artifacts-gb) MAX_ARTIFACTS_GB="$2"; shift 2 ;;
+        --max-retained-crashes) MAX_RETAINED_CRASHES="$2"; shift 2 ;;
         --task-base) TASK_BASE="$2"; shift 2 ;;
         --self-test-only) SELF_TEST_ONLY=1; shift ;;
         -h|--help) usage; exit 0 ;;
@@ -84,19 +91,64 @@ esac
 
 LOG_DIR="$WORK_ROOT_ABS/logs"
 BIN_DIR="$WORK_ROOT_ABS/bin"
+TMP_DIR="$WORK_ROOT_ABS/tmp"
+REPRO_DIR="$WORK_ROOT_ABS/repros"
 GENERATED_DIR="$WORK_ROOT_ABS/generated-differential"
 RUNS_TSV="$WORK_ROOT_ABS/runs.tsv"
 SELF_TSV="$WORK_ROOT_ABS/selftest.tsv"
 CORPUS_RAW="$WORK_ROOT_ABS/corpus.raw"
 CORPUS_LIST="$WORK_ROOT_ABS/corpus.txt"
+AOT_BIN="$BIN_DIR/aot-test.bin"
+RETAINED_SIGNATURES="$WORK_ROOT_ABS/retained-signatures.txt"
 ESHKOL_RUN="$BUILD_DIR_ABS/eshkol-run"
 TASK_DIR="$REPO_ROOT/.swarm/tasks"
 STARTED_AT="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 
-mkdir -p "$LOG_DIR" "$BIN_DIR" "$GENERATED_DIR" "$(dirname "$TRACE_FILE_ABS")" "$TASK_DIR"
-: > "$RUNS_TSV"
-: > "$SELF_TSV"
-: > "$TRACE_FILE_ABS"
+case "$MAX_RETAINED_CRASHES" in
+    ''|*[!0-9]*)
+        echo "run_sanitizer_fuzz.sh: --max-retained-crashes must be a non-negative integer: $MAX_RETAINED_CRASHES" >&2
+        exit 2
+        ;;
+esac
+
+if ! MAX_ARTIFACTS_KB="$(python3 - "$MAX_ARTIFACTS_GB" <<'PY'
+import math
+import sys
+
+try:
+    gb = float(sys.argv[1])
+except ValueError:
+    print("invalid", file=sys.stderr)
+    raise SystemExit(1)
+
+if not math.isfinite(gb) or gb <= 0:
+    print("invalid", file=sys.stderr)
+    raise SystemExit(1)
+
+print(max(1, int(math.ceil(gb * 1024 * 1024))))
+PY
+)"; then
+    echo "run_sanitizer_fuzz.sh: --max-artifacts-gb must be a positive number: $MAX_ARTIFACTS_GB" >&2
+    exit 2
+fi
+
+cleanup_sanitizer_fuzz() {
+    rm -rf "$BIN_DIR" "$TMP_DIR" "$GENERATED_DIR"
+    rm -rf "$WORK_ROOT_ABS/self-test"
+    rm -f "$CORPUS_RAW" "$CORPUS_LIST" "$RUNS_TSV" "$SELF_TSV" "$RETAINED_SIGNATURES" "$AOT_BIN"
+}
+trap cleanup_sanitizer_fuzz EXIT
+
+rm -rf "$LOG_DIR" "$REPRO_DIR" "$BIN_DIR" "$TMP_DIR" "$GENERATED_DIR"
+rm -f "$CORPUS_RAW" "$AOT_BIN"
+if ! mkdir -p "$LOG_DIR" "$REPRO_DIR" "$BIN_DIR" "$TMP_DIR" "$GENERATED_DIR" "$(dirname "$TRACE_FILE_ABS")" "$TASK_DIR"; then
+    echo "run_sanitizer_fuzz.sh: failed to create sanitizer-fuzz work directories under $WORK_ROOT_ABS" >&2
+    exit 2
+fi
+: > "$RUNS_TSV" || exit 2
+: > "$SELF_TSV" || exit 2
+: > "$TRACE_FILE_ABS" || exit 2
+: > "$RETAINED_SIGNATURES" || exit 2
 
 if [ "$(uname -s)" = "Darwin" ]; then
     DEFAULT_ASAN_OPTIONS="detect_leaks=0:halt_on_error=1:abort_on_error=1:print_stacktrace=1:strict_string_checks=1:detect_stack_use_after_return=0:symbolize=1"
@@ -106,6 +158,39 @@ fi
 DEFAULT_UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:abort_on_error=1"
 export ASAN_OPTIONS="${ASAN_OPTIONS:-$DEFAULT_ASAN_OPTIONS}"
 export UBSAN_OPTIONS="${UBSAN_OPTIONS:-$DEFAULT_UBSAN_OPTIONS}"
+
+PEAK_ARTIFACT_KB=0
+RETAINED_OUT=""
+RETAINED_ERR=""
+
+artifact_usage_kb() {
+    if [ ! -d "$WORK_ROOT_ABS" ]; then
+        echo 0
+        return
+    fi
+    du -sk "$WORK_ROOT_ABS" 2>/dev/null | awk '{print $1 + 0}'
+}
+
+format_kb() {
+    awk -v kb="$1" 'BEGIN {
+        if (kb >= 1048576) printf "%.2f GiB", kb / 1048576;
+        else if (kb >= 1024) printf "%.1f MiB", kb / 1024;
+        else printf "%d KiB", kb;
+    }'
+}
+
+check_disk_budget() {
+    local context="$1"
+    local used
+    used="$(artifact_usage_kb)"
+    if [ "$used" -gt "$PEAK_ARTIFACT_KB" ]; then
+        PEAK_ARTIFACT_KB="$used"
+    fi
+    if [ "$used" -gt "$MAX_ARTIFACTS_KB" ]; then
+        echo "run_sanitizer_fuzz.sh: artifact budget exceeded during $context: $WORK_ROOT_ABS uses $(format_kb "$used") > cap $(format_kb "$MAX_ARTIFACTS_KB") (--max-artifacts-gb $MAX_ARTIFACTS_GB, env ESHKOL_FUZZ_MAX_GB). Aborting." >&2
+        exit 3
+    fi
+}
 
 run_guarded() {
     LC_ALL=C LANG=C perl -MPOSIX=':sys_wait_h' -e '
@@ -144,6 +229,106 @@ append_run() {
 
 path_hash() {
     printf '%s' "$1" | cksum | awk '{print $1}'
+}
+
+has_sanitizer_report() {
+    grep -E 'ERROR: AddressSanitizer:|runtime error:|UndefinedBehaviorSanitizer:DEADLYSIGNAL|SUMMARY: AddressSanitizer:|SUMMARY: UndefinedBehaviorSanitizer:' "$@" >/dev/null 2>&1
+}
+
+sanitizer_top_frame() {
+    python3 - "$REPO_ROOT" "$@" <<'PY'
+import os
+import re
+import sys
+
+repo_root = os.path.abspath(sys.argv[1])
+paths = sys.argv[2:]
+lines = []
+for path in paths:
+    try:
+        with open(path, "r", errors="replace") as f:
+            lines.extend(f.read().splitlines())
+    except OSError:
+        pass
+
+start = None
+for i, line in enumerate(lines):
+    if (
+        "ERROR: AddressSanitizer:" in line
+        or "UndefinedBehaviorSanitizer:DEADLYSIGNAL" in line
+        or ("runtime error:" in line and "SUMMARY:" not in line)
+        or "SUMMARY: AddressSanitizer:" in line
+        or "SUMMARY: UndefinedBehaviorSanitizer:" in line
+    ):
+        start = i
+        break
+
+if start is None:
+    raise SystemExit(1)
+
+top = ""
+for line in lines[start : start + 90]:
+    if re.match(r"\s*#0\b", line):
+        top = line.strip()
+        break
+if not top:
+    for line in lines[start : start + 90]:
+        if "SUMMARY:" in line:
+            top = line.strip()
+            break
+if not top:
+    top = lines[start].strip()
+
+top = top.replace(repo_root, ".")
+top = re.sub(r"0x[0-9a-fA-F]+", "0xADDR", top)
+top = re.sub(r"\s+", " ", top)
+print(top[:240])
+PY
+}
+
+retain_sanitizer_logs() {
+    local src="$1" axis="$2" phase="$3" idx="$4" out="$5" err="$6"
+    local top sig_hash src_hash retained_count base repro
+
+    RETAINED_OUT=""
+    RETAINED_ERR=""
+
+    if ! has_sanitizer_report "$out" "$err"; then
+        rm -f "$out" "$err"
+        return
+    fi
+
+    top="$(sanitizer_top_frame "$out" "$err" || true)"
+    if [ -z "$top" ]; then
+        top="unknown sanitizer signature"
+    fi
+
+    if grep -Fx -- "$top" "$RETAINED_SIGNATURES" >/dev/null 2>&1; then
+        rm -f "$out" "$err"
+        return
+    fi
+
+    retained_count="$(wc -l < "$RETAINED_SIGNATURES" | tr -d ' ')"
+    if [ "$retained_count" -ge "$MAX_RETAINED_CRASHES" ]; then
+        rm -f "$out" "$err"
+        return
+    fi
+
+    sig_hash="$(path_hash "$top")"
+    src_hash="$(path_hash "$src")"
+    RETAINED_OUT="$LOG_DIR/${idx}_${axis}_${phase}_${sig_hash}_${src_hash}.out"
+    RETAINED_ERR="$LOG_DIR/${idx}_${axis}_${phase}_${sig_hash}_${src_hash}.err"
+    mv "$out" "$RETAINED_OUT"
+    mv "$err" "$RETAINED_ERR"
+    printf '%s\n' "$top" >> "$RETAINED_SIGNATURES"
+
+    base="$(basename "$src")"
+    repro="$REPRO_DIR/${sig_hash}_${src_hash}_${base}.crash"
+    if [ ! -f "$repro" ]; then
+        cp "$src" "$repro" 2>/dev/null || true
+    fi
+
+    check_disk_budget "retaining sanitizer repro for ${src#$REPO_ROOT/}"
 }
 
 run_self_test() {
@@ -193,6 +378,8 @@ C
         -fno-omit-frame-pointer "$src" -o "$bin" >"$cout" 2>"$cerr"
     local crc=$?
     if [ "$crc" -ne 0 ] || [ ! -x "$bin" ]; then
+        rm -f "$bin"
+        rm -rf "$bin.dSYM"
         {
             printf 'status\tFAIL\n'
             printf 'summary\tSynthetic sanitizer repro failed to compile rc=%s\n' "$crc"
@@ -205,6 +392,8 @@ C
 
     run_guarded 15 "$bin" >"$out" 2>"$err"
     local rrc=$?
+    rm -f "$bin"
+    rm -rf "$bin.dSYM"
     if grep -E 'ERROR: AddressSanitizer:|runtime error:|SUMMARY: UndefinedBehaviorSanitizer:' "$out" "$err" >/dev/null 2>&1; then
         {
             printf 'status\tPASS\n'
@@ -228,44 +417,50 @@ collect_corpus() {
     : > "$CORPUS_RAW"
     if [ "$NO_GENERATED" -eq 0 ] && [ "$COUNT" -gt 0 ]; then
         python3 scripts/gen_differential.py \
-            --seed "$SEED" --count "$COUNT" --emit-only "$GENERATED_DIR"
-        find "$GENERATED_DIR" -type f -name '*.esk' -print >> "$CORPUS_RAW"
+            --seed "$SEED" --count "$COUNT" --emit-only "$GENERATED_DIR" || exit 2
+        find "$GENERATED_DIR" -type f -name '*.esk' -print >> "$CORPUS_RAW" || exit 2
     fi
-    find "$REPO_ROOT/tests" -type f -name '*.esk' -print >> "$CORPUS_RAW"
-    sort -u "$CORPUS_RAW" > "$CORPUS_LIST"
+    find "$REPO_ROOT/tests" -type f -name '*.esk' -print >> "$CORPUS_RAW" || exit 2
+    sort -u "$CORPUS_RAW" > "$CORPUS_LIST" || exit 2
 }
 
 run_r_axis() {
     local src="$1" idx="$2"
     local h out err rc
     h="$(path_hash "$src")"
-    out="$LOG_DIR/${idx}_r_${h}.out"
-    err="$LOG_DIR/${idx}_r_${h}.err"
+    out="$TMP_DIR/${idx}_r_${h}.out"
+    err="$TMP_DIR/${idx}_r_${h}.err"
     run_guarded "$TIMEOUT_RUN" "$ESHKOL_RUN" -r "$src" >"$out" 2>"$err"
     rc=$?
-    append_run "$src" "r" "run" "$rc" "$out" "$err"
+    retain_sanitizer_logs "$src" "r" "run" "$idx" "$out" "$err"
+    append_run "$src" "r" "run" "$rc" "$RETAINED_OUT" "$RETAINED_ERR"
 }
 
 run_aot_axis() {
     local src="$1" idx="$2" axis="$3" opt="$4"
     local h bin cout cerr out err crc rrc
     h="$(path_hash "$src")"
-    bin="$BIN_DIR/${idx}_${axis}_${h}.bin"
-    cout="$LOG_DIR/${idx}_${axis}_${h}.compile.out"
-    cerr="$LOG_DIR/${idx}_${axis}_${h}.compile.err"
-    out="$LOG_DIR/${idx}_${axis}_${h}.run.out"
-    err="$LOG_DIR/${idx}_${axis}_${h}.run.err"
+    bin="$AOT_BIN"
+    cout="$TMP_DIR/${idx}_${axis}_${h}.compile.out"
+    cerr="$TMP_DIR/${idx}_${axis}_${h}.compile.err"
+    out="$TMP_DIR/${idx}_${axis}_${h}.run.out"
+    err="$TMP_DIR/${idx}_${axis}_${h}.run.err"
 
+    rm -f "$bin"
     run_guarded "$TIMEOUT_RUN" "$ESHKOL_RUN" "$opt" "$src" -o "$bin" >"$cout" 2>"$cerr"
     crc=$?
-    append_run "$src" "$axis" "compile" "$crc" "$cout" "$cerr"
+    retain_sanitizer_logs "$src" "$axis" "compile" "$idx" "$cout" "$cerr"
+    append_run "$src" "$axis" "compile" "$crc" "$RETAINED_OUT" "$RETAINED_ERR"
     if [ "$crc" -ne 0 ] || [ ! -x "$bin" ]; then
+        rm -f "$bin"
         return
     fi
 
     run_guarded "$TIMEOUT_RUN" "$bin" >"$out" 2>"$err"
     rrc=$?
-    append_run "$src" "$axis" "run" "$rrc" "$out" "$err"
+    retain_sanitizer_logs "$src" "$axis" "run" "$idx" "$out" "$err"
+    append_run "$src" "$axis" "run" "$rrc" "$RETAINED_OUT" "$RETAINED_ERR"
+    rm -f "$bin"
 }
 
 write_report() {
@@ -615,16 +810,12 @@ with open(report_path, "w") as f:
     f.write("- Generated differential fuzz: seed `%s`, count `%s`\n" % (seed, count))
     f.write("- ASAN_OPTIONS: `%s`\n" % asan_options)
     f.write("- UBSAN_OPTIONS: `%s`\n" % ubsan_options)
-    f.write("- Raw logs: `%s`\n" % rel(work_root))
+    f.write("- Retained sanitizer artifacts: `%s`\n" % rel(work_root))
     f.write("- ICC trace: `%s`\n\n" % rel(trace_file))
 
     f.write("## Teeth Check\n\n")
     f.write("- Status: `%s`\n" % self_status)
     f.write("- Summary: %s\n" % self_summary)
-    if self_data.get("source"):
-        f.write("- Synthetic repro: `%s`\n" % rel(self_data["source"]))
-    if self_data.get("stderr"):
-        f.write("- Synthetic stderr: `%s`\n" % rel(self_data["stderr"]))
     f.write("\n")
 
     f.write("## Coverage\n\n")
@@ -701,14 +892,24 @@ echo "  repo: $REPO_ROOT"
 echo "  build: $BUILD_DIR_ABS"
 echo "  report: $REPORT_ABS"
 echo "  logs: $WORK_ROOT_ABS"
+echo "  artifact cap: $(format_kb "$MAX_ARTIFACTS_KB")"
+echo "  retained crash cap: $MAX_RETAINED_CRASHES"
 echo
 
+check_disk_budget "startup"
 run_self_test
+check_disk_budget "self-test"
 
 if [ "$SELF_TEST_ONLY" -eq 1 ]; then
     FINISHED_AT="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
     write_report "$FINISHED_AT" 0
-    exit $?
+    report_rc=$?
+    check_disk_budget "report"
+    cleanup_sanitizer_fuzz
+    final_artifact_kb="$(artifact_usage_kb)"
+    [ "$final_artifact_kb" -gt "$PEAK_ARTIFACT_KB" ] && PEAK_ARTIFACT_KB="$final_artifact_kb"
+    echo "Artifact usage: final=$(format_kb "$final_artifact_kb") peak=$(format_kb "$PEAK_ARTIFACT_KB") cap=$(format_kb "$MAX_ARTIFACTS_KB")"
+    exit "$report_rc"
 fi
 
 if [ "$SKIP_BUILD" -eq 0 ]; then
@@ -721,6 +922,7 @@ if [ ! -x "$ESHKOL_RUN" ]; then
 fi
 
 collect_corpus
+check_disk_budget "corpus collection"
 TOTAL_SOURCES=$(wc -l < "$CORPUS_LIST" | tr -d ' ')
 echo "Corpus: $TOTAL_SOURCES unique .esk files"
 if [ "$LIMIT" -gt 0 ]; then
@@ -735,12 +937,16 @@ while IFS= read -r src; do
     if [ "$LIMIT" -gt 0 ] && [ "$idx" -gt "$LIMIT" ]; then
         break
     fi
+    check_disk_budget "before corpus file $idx (${src#$REPO_ROOT/})"
     if [ $((idx % 25)) -eq 1 ]; then
         printf '  [%d/%d] %s\n' "$idx" "$TOTAL_SOURCES" "${src#$REPO_ROOT/}"
     fi
     run_r_axis "$src" "$idx"
+    check_disk_budget "after corpus file $idx -r"
     run_aot_axis "$src" "$idx" "aot-o0" "-O0"
+    check_disk_budget "after corpus file $idx AOT -O0"
     run_aot_axis "$src" "$idx" "aot-o2" "-O2"
+    check_disk_budget "after corpus file $idx AOT -O2"
 done < "$CORPUS_LIST"
 
 if [ "$LIMIT" -gt 0 ] && [ "$LIMIT" -lt "$TOTAL_SOURCES" ]; then
@@ -751,4 +957,10 @@ fi
 
 FINISHED_AT="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 write_report "$FINISHED_AT" "$TOTAL_REPORTED"
-exit $?
+report_rc=$?
+check_disk_budget "report"
+cleanup_sanitizer_fuzz
+final_artifact_kb="$(artifact_usage_kb)"
+[ "$final_artifact_kb" -gt "$PEAK_ARTIFACT_KB" ] && PEAK_ARTIFACT_KB="$final_artifact_kb"
+echo "Artifact usage: final=$(format_kb "$final_artifact_kb") peak=$(format_kb "$PEAK_ARTIFACT_KB") cap=$(format_kb "$MAX_ARTIFACTS_KB")"
+exit "$report_rc"

--- a/scripts/run_sanitizer_fuzz.sh
+++ b/scripts/run_sanitizer_fuzz.sh
@@ -1,0 +1,754 @@
+#!/usr/bin/env bash
+# run_sanitizer_fuzz.sh - ASan/UBSan oracle over differential and test corpora.
+#
+# The differential harness checks semantic agreement. This harness is additive:
+# it ignores ordinary compile/runtime failures unless a sanitizer emits a report.
+
+set -u
+cd "$(dirname "$0")/.."
+
+REPO_ROOT="$(pwd)"
+BUILD_DIR="build-asan-ubsan"
+REPORT="SANITIZER_FUZZ_REPORT.md"
+WORK_ROOT="artifacts/sanitizer-fuzz"
+TRACE_FILE="scripts/icc_traces/sanitizer_fuzz.jsonl"
+SEED=42
+COUNT=200
+TIMEOUT_RUN=90
+TASK_BASE=160
+SKIP_BUILD=0
+SELF_TEST_ONLY=0
+NO_GENERATED=0
+LIMIT=0
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/run_sanitizer_fuzz.sh [options]
+
+Builds or reuses build-asan-ubsan, runs every tests/**/*.esk input plus a
+deterministic generated differential fuzz corpus through -r and AOT, and writes
+SANITIZER_FUZZ_REPORT.md with ASan/UBSan reports deduped by top frame.
+
+Options:
+  --skip-build             Reuse the existing sanitizer build.
+  --build-dir DIR          Sanitizer build directory to use (default: build-asan-ubsan).
+  --report PATH            Markdown report path (default: SANITIZER_FUZZ_REPORT.md).
+  --work-dir DIR           Log/work directory (default: artifacts/sanitizer-fuzz).
+  --trace-file PATH        ICC trace path (default: scripts/icc_traces/sanitizer_fuzz.jsonl).
+  --seed N                 Seed for generated differential programs (default: 42).
+  --count N                Generated differential program count (default: 200).
+  --no-generated           Do not generate additional differential fuzz programs.
+  --timeout SEC            Per process timeout (default: 90).
+  --limit N                Run only the first N corpus files (debugging only).
+  --task-base N            First ESH id to allocate for sanitizer findings (default: 160).
+  --self-test-only         Run only the synthetic ESH-0116-class sanitizer check.
+  -h, --help               Show this help.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --skip-build) SKIP_BUILD=1; shift ;;
+        --build-dir) BUILD_DIR="$2"; shift 2 ;;
+        --report) REPORT="$2"; shift 2 ;;
+        --work-dir) WORK_ROOT="$2"; shift 2 ;;
+        --trace-file) TRACE_FILE="$2"; shift 2 ;;
+        --seed) SEED="$2"; shift 2 ;;
+        --count) COUNT="$2"; shift 2 ;;
+        --no-generated) NO_GENERATED=1; shift ;;
+        --timeout) TIMEOUT_RUN="$2"; shift 2 ;;
+        --limit) LIMIT="$2"; shift 2 ;;
+        --task-base) TASK_BASE="$2"; shift 2 ;;
+        --self-test-only) SELF_TEST_ONLY=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "run_sanitizer_fuzz.sh: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+case "$BUILD_DIR" in
+    /*) BUILD_DIR_ABS="$BUILD_DIR" ;;
+    *) BUILD_DIR_ABS="$REPO_ROOT/$BUILD_DIR" ;;
+esac
+case "$REPORT" in
+    /*) REPORT_ABS="$REPORT" ;;
+    *) REPORT_ABS="$REPO_ROOT/$REPORT" ;;
+esac
+case "$WORK_ROOT" in
+    /*) WORK_ROOT_ABS="$WORK_ROOT" ;;
+    *) WORK_ROOT_ABS="$REPO_ROOT/$WORK_ROOT" ;;
+esac
+case "$TRACE_FILE" in
+    /*) TRACE_FILE_ABS="$TRACE_FILE" ;;
+    *) TRACE_FILE_ABS="$REPO_ROOT/$TRACE_FILE" ;;
+esac
+
+LOG_DIR="$WORK_ROOT_ABS/logs"
+BIN_DIR="$WORK_ROOT_ABS/bin"
+GENERATED_DIR="$WORK_ROOT_ABS/generated-differential"
+RUNS_TSV="$WORK_ROOT_ABS/runs.tsv"
+SELF_TSV="$WORK_ROOT_ABS/selftest.tsv"
+CORPUS_RAW="$WORK_ROOT_ABS/corpus.raw"
+CORPUS_LIST="$WORK_ROOT_ABS/corpus.txt"
+ESHKOL_RUN="$BUILD_DIR_ABS/eshkol-run"
+TASK_DIR="$REPO_ROOT/.swarm/tasks"
+STARTED_AT="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+mkdir -p "$LOG_DIR" "$BIN_DIR" "$GENERATED_DIR" "$(dirname "$TRACE_FILE_ABS")" "$TASK_DIR"
+: > "$RUNS_TSV"
+: > "$SELF_TSV"
+: > "$TRACE_FILE_ABS"
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    DEFAULT_ASAN_OPTIONS="detect_leaks=0:halt_on_error=1:abort_on_error=1:print_stacktrace=1:strict_string_checks=1:detect_stack_use_after_return=0:symbolize=1"
+else
+    DEFAULT_ASAN_OPTIONS="detect_leaks=1:halt_on_error=1:abort_on_error=1:print_stacktrace=1:strict_string_checks=1:detect_stack_use_after_return=0:symbolize=1"
+fi
+DEFAULT_UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:abort_on_error=1"
+export ASAN_OPTIONS="${ASAN_OPTIONS:-$DEFAULT_ASAN_OPTIONS}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-$DEFAULT_UBSAN_OPTIONS}"
+
+run_guarded() {
+    LC_ALL=C LANG=C perl -MPOSIX=':sys_wait_h' -e '
+        my $seconds = shift;
+        my $pid = fork();
+        die "fork failed: $!" unless defined $pid;
+        if ($pid == 0) {
+            setpgrp(0, 0);
+            exec @ARGV or exit 127;
+        }
+        local $SIG{ALRM} = sub {
+            kill "TERM", -$pid;
+            select undef, undef, undef, 0.5;
+            kill "KILL", -$pid;
+            exit 124;
+        };
+        alarm $seconds;
+        waitpid($pid, 0);
+        my $status = $?;
+        alarm 0;
+        if (WIFEXITED($status)) {
+            exit WEXITSTATUS($status);
+        }
+        if (WIFSIGNALED($status)) {
+            exit 128 + WTERMSIG($status);
+        }
+        exit 125;
+    ' \
+        "$1" "${@:2}"
+}
+
+append_run() {
+    local src="$1" axis="$2" phase="$3" rc="$4" out="$5" err="$6"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$src" "$axis" "$phase" "$rc" "$out" "$err" >> "$RUNS_TSV"
+}
+
+path_hash() {
+    printf '%s' "$1" | cksum | awk '{print $1}'
+}
+
+run_self_test() {
+    local d="$WORK_ROOT_ABS/self-test"
+    local src="$d/esh0116_unterminated_numeric_buffer.c"
+    local bin="$d/esh0116_unterminated_numeric_buffer"
+    local cout="$d/compile.out"
+    local cerr="$d/compile.err"
+    local out="$d/run.out"
+    local err="$d/run.err"
+    local cc_bin="${CC:-cc}"
+    mkdir -p "$d"
+
+    cat > "$src" <<'C'
+#include <stddef.h>
+#include <stdio.h>
+
+__attribute__((noinline))
+static long parse_digits_like_atoll(const char *buf) {
+    long value = 0;
+    for (size_t i = 0; buf[i] >= '0' && buf[i] <= '9'; i++) {
+        value = value * 10 + (buf[i] - '0');
+    }
+    return value;
+}
+
+int main(void) {
+    char buf[4] = {'1', '2', '3', '4'};
+    volatile long parsed = parse_digits_like_atoll(buf);
+    printf("%ld\n", parsed);
+    return 0;
+}
+C
+
+    if ! command -v "$cc_bin" >/dev/null 2>&1; then
+        {
+            printf 'status\tSKIP\n'
+            printf 'summary\tC compiler not found: %s\n' "$cc_bin"
+            printf 'source\t%s\n' "$src"
+            printf 'stdout\t%s\n' "$out"
+            printf 'stderr\t%s\n' "$err"
+        } > "$SELF_TSV"
+        return
+    fi
+
+    "$cc_bin" -O1 -g -fsanitize=address,undefined -fno-sanitize-recover=all \
+        -fno-omit-frame-pointer "$src" -o "$bin" >"$cout" 2>"$cerr"
+    local crc=$?
+    if [ "$crc" -ne 0 ] || [ ! -x "$bin" ]; then
+        {
+            printf 'status\tFAIL\n'
+            printf 'summary\tSynthetic sanitizer repro failed to compile rc=%s\n' "$crc"
+            printf 'source\t%s\n' "$src"
+            printf 'stdout\t%s\n' "$cout"
+            printf 'stderr\t%s\n' "$cerr"
+        } > "$SELF_TSV"
+        return
+    fi
+
+    run_guarded 15 "$bin" >"$out" 2>"$err"
+    local rrc=$?
+    if grep -E 'ERROR: AddressSanitizer:|runtime error:|SUMMARY: UndefinedBehaviorSanitizer:' "$out" "$err" >/dev/null 2>&1; then
+        {
+            printf 'status\tPASS\n'
+            printf 'summary\tSynthetic unterminated numeric buffer repro emitted a sanitizer report rc=%s\n' "$rrc"
+            printf 'source\t%s\n' "$src"
+            printf 'stdout\t%s\n' "$out"
+            printf 'stderr\t%s\n' "$err"
+        } > "$SELF_TSV"
+    else
+        {
+            printf 'status\tFAIL\n'
+            printf 'summary\tSynthetic unterminated numeric buffer repro did not emit a sanitizer report rc=%s\n' "$rrc"
+            printf 'source\t%s\n' "$src"
+            printf 'stdout\t%s\n' "$out"
+            printf 'stderr\t%s\n' "$err"
+        } > "$SELF_TSV"
+    fi
+}
+
+collect_corpus() {
+    : > "$CORPUS_RAW"
+    if [ "$NO_GENERATED" -eq 0 ] && [ "$COUNT" -gt 0 ]; then
+        python3 scripts/gen_differential.py \
+            --seed "$SEED" --count "$COUNT" --emit-only "$GENERATED_DIR"
+        find "$GENERATED_DIR" -type f -name '*.esk' -print >> "$CORPUS_RAW"
+    fi
+    find "$REPO_ROOT/tests" -type f -name '*.esk' -print >> "$CORPUS_RAW"
+    sort -u "$CORPUS_RAW" > "$CORPUS_LIST"
+}
+
+run_r_axis() {
+    local src="$1" idx="$2"
+    local h out err rc
+    h="$(path_hash "$src")"
+    out="$LOG_DIR/${idx}_r_${h}.out"
+    err="$LOG_DIR/${idx}_r_${h}.err"
+    run_guarded "$TIMEOUT_RUN" "$ESHKOL_RUN" -r "$src" >"$out" 2>"$err"
+    rc=$?
+    append_run "$src" "r" "run" "$rc" "$out" "$err"
+}
+
+run_aot_axis() {
+    local src="$1" idx="$2" axis="$3" opt="$4"
+    local h bin cout cerr out err crc rrc
+    h="$(path_hash "$src")"
+    bin="$BIN_DIR/${idx}_${axis}_${h}.bin"
+    cout="$LOG_DIR/${idx}_${axis}_${h}.compile.out"
+    cerr="$LOG_DIR/${idx}_${axis}_${h}.compile.err"
+    out="$LOG_DIR/${idx}_${axis}_${h}.run.out"
+    err="$LOG_DIR/${idx}_${axis}_${h}.run.err"
+
+    run_guarded "$TIMEOUT_RUN" "$ESHKOL_RUN" "$opt" "$src" -o "$bin" >"$cout" 2>"$cerr"
+    crc=$?
+    append_run "$src" "$axis" "compile" "$crc" "$cout" "$cerr"
+    if [ "$crc" -ne 0 ] || [ ! -x "$bin" ]; then
+        return
+    fi
+
+    run_guarded "$TIMEOUT_RUN" "$bin" >"$out" 2>"$err"
+    rrc=$?
+    append_run "$src" "$axis" "run" "$rrc" "$out" "$err"
+}
+
+write_report() {
+    local finished_at="$1" total_sources="$2"
+    python3 - "$REPORT_ABS" "$RUNS_TSV" "$SELF_TSV" "$TRACE_FILE_ABS" \
+        "$TASK_DIR" "$TASK_BASE" "$REPO_ROOT" "$BUILD_DIR_ABS" "$SEED" "$COUNT" \
+        "$total_sources" "$STARTED_AT" "$finished_at" "$ASAN_OPTIONS" \
+        "$UBSAN_OPTIONS" "$WORK_ROOT_ABS" <<'PY'
+import collections
+import datetime
+import json
+import os
+import re
+import sys
+
+(
+    report_path,
+    runs_tsv,
+    self_tsv,
+    trace_file,
+    task_dir,
+    task_base,
+    repo_root,
+    build_dir,
+    seed,
+    count,
+    total_sources,
+    started_at,
+    finished_at,
+    asan_options,
+    ubsan_options,
+    work_root,
+) = sys.argv[1:]
+
+task_base = int(task_base)
+total_sources = int(total_sources)
+
+def rel(path):
+    path = os.path.abspath(path)
+    root = os.path.abspath(repo_root)
+    if path == root:
+        return "."
+    if path.startswith(root + os.sep):
+        return path[len(root) + 1 :]
+    return path
+
+def md(s):
+    return str(s).replace("|", "\\|").replace("\n", " ")
+
+def read_text(path):
+    try:
+        with open(path, "r", errors="replace") as f:
+            return f.read()
+    except OSError:
+        return ""
+
+def normalize_frame(line):
+    s = line.strip().replace(os.path.abspath(repo_root), ".")
+    s = re.sub(r"0x[0-9a-fA-F]+", "0xADDR", s)
+    s = re.sub(r"\s+", " ", s)
+    return s[:240]
+
+def report_starts(lines):
+    starts = []
+    for i, line in enumerate(lines):
+        if "ERROR: AddressSanitizer:" in line:
+            m = re.search(r"ERROR: AddressSanitizer:\s*([^ ]+)", line)
+            starts.append((i, "AddressSanitizer", m.group(1) if m else "error", line.strip()))
+        elif "UndefinedBehaviorSanitizer:DEADLYSIGNAL" in line:
+            starts.append((i, "UndefinedBehaviorSanitizer", "DEADLYSIGNAL", line.strip()))
+        elif "runtime error:" in line and "SUMMARY:" not in line:
+            msg = re.sub(r"^.*runtime error:\s*", "", line.strip())
+            starts.append((i, "UndefinedBehaviorSanitizer", msg[:160], line.strip()))
+
+    if starts:
+        return starts
+
+    for i, line in enumerate(lines):
+        if "SUMMARY: AddressSanitizer:" in line:
+            m = re.search(r"SUMMARY: AddressSanitizer:\s*([^ ]+)", line)
+            starts.append((i, "AddressSanitizer", m.group(1) if m else "summary", line.strip()))
+        elif "SUMMARY: UndefinedBehaviorSanitizer:" in line:
+            starts.append((i, "UndefinedBehaviorSanitizer", "summary", line.strip()))
+    return starts
+
+def extract_reports(text):
+    lines = text.splitlines()
+    reports = []
+    for start, kind, subtype, headline in report_starts(lines):
+        chunk = lines[start : min(len(lines), start + 90)]
+        top = ""
+        summary = ""
+        for line in chunk:
+            if re.match(r"\s*#0\b", line):
+                top = normalize_frame(line)
+                break
+        for line in chunk:
+            if "SUMMARY:" in line:
+                summary = normalize_frame(line)
+                if not top:
+                    top = summary
+                break
+        if not top:
+            top = normalize_frame(headline)
+        snippet = "\n".join(line.rstrip() for line in chunk[:36]).replace(os.path.abspath(repo_root), ".")
+        reports.append(
+            {
+                "kind": kind,
+                "subtype": subtype,
+                "top_frame": top,
+                "summary": summary,
+                "snippet": snippet[:6000],
+            }
+        )
+    return reports
+
+def read_tsv(path):
+    rows = []
+    if not os.path.exists(path):
+        return rows
+    with open(path, "r", errors="replace") as f:
+        for line in f:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) >= 6:
+                rows.append(
+                    {
+                        "source": parts[0],
+                        "axis": parts[1],
+                        "phase": parts[2],
+                        "rc": parts[3],
+                        "stdout": parts[4],
+                        "stderr": parts[5],
+                    }
+                )
+    return rows
+
+def read_self(path):
+    data = {}
+    if not os.path.exists(path):
+        return data
+    with open(path, "r", errors="replace") as f:
+        for line in f:
+            key, sep, value = line.rstrip("\n").partition("\t")
+            if sep:
+                data[key] = value
+    return data
+
+runs = read_tsv(runs_tsv)
+self_data = read_self(self_tsv)
+groups = collections.OrderedDict()
+run_counts = collections.Counter((row["axis"], row["phase"], row["rc"]) for row in runs)
+aot_o0_runs = sum(1 for row in runs if row["axis"] == "aot-o0" and row["phase"] == "run")
+aot_o2_runs = sum(1 for row in runs if row["axis"] == "aot-o2" and row["phase"] == "run")
+r_runs = sum(1 for row in runs if row["axis"] == "r" and row["phase"] == "run")
+coverage_problems = []
+if total_sources > 0 and r_runs == 0:
+    coverage_problems.append("no -r records were produced")
+if total_sources > 0 and aot_o0_runs == 0:
+    coverage_problems.append("no AOT -O0 binaries were run")
+if total_sources > 0 and aot_o2_runs == 0:
+    coverage_problems.append("no AOT -O2 binaries were run")
+coverage_status = "PASS" if not coverage_problems else "FAIL"
+coverage_summary = (
+    "-r runs=%d, AOT -O0 runs=%d, AOT -O2 runs=%d"
+    % (r_runs, aot_o0_runs, aot_o2_runs)
+)
+if coverage_problems:
+    coverage_summary += "; " + "; ".join(coverage_problems)
+
+for row in runs:
+    for stream in ("stdout", "stderr"):
+        log_path = row[stream]
+        text = read_text(log_path)
+        if not text:
+            continue
+        for rep in extract_reports(text):
+            key = "\t".join([rep["kind"], rep["subtype"], rep["top_frame"]])
+            group = groups.setdefault(
+                key,
+                {
+                    "kind": rep["kind"],
+                    "subtype": rep["subtype"],
+                    "top_frame": rep["top_frame"],
+                    "summary": rep["summary"],
+                    "hits": 0,
+                    "samples": [],
+                    "snippets": [],
+                    "task_id": "",
+                    "signature": key,
+                },
+            )
+            group["hits"] += 1
+            if len(group["samples"]) < 5:
+                group["samples"].append(
+                    {
+                        "source": rel(row["source"]),
+                        "axis": row["axis"],
+                        "phase": row["phase"],
+                        "rc": row["rc"],
+                        "log": rel(log_path),
+                    }
+                )
+            if len(group["snippets"]) < 1:
+                group["snippets"].append(rep["snippet"])
+
+existing_by_signature = {}
+if os.path.isdir(task_dir):
+    for name in sorted(os.listdir(task_dir)):
+        if not re.match(r"ESH-\d{4}\.json$", name):
+            continue
+        path = os.path.join(task_dir, name)
+        try:
+            with open(path, "r", errors="replace") as f:
+                data = json.load(f)
+        except Exception:
+            continue
+        sig = data.get("sanitizer_signature")
+        if sig:
+            existing_by_signature[sig] = data.get("id", name[:-5])
+
+def next_task_id(used):
+    n = task_base
+    while True:
+        tid = "ESH-%04d" % n
+        if tid not in used and not os.path.exists(os.path.join(task_dir, tid + ".json")):
+            return tid
+        n += 1
+
+used_task_ids = set(existing_by_signature.values())
+for group in groups.values():
+    if group["signature"] in existing_by_signature:
+        group["task_id"] = existing_by_signature[group["signature"]]
+        continue
+    tid = next_task_id(used_task_ids)
+    used_task_ids.add(tid)
+    group["task_id"] = tid
+    sample = group["samples"][0] if group["samples"] else {}
+    task = {
+        "id": tid,
+        "status": "open",
+        "priority": "high",
+        "workstream": "sanitizer-fuzz",
+        "title": "Sanitizer fuzz: %s %s" % (group["kind"], group["subtype"]),
+        "goal": (
+            "Fix sanitizer finding from scripts/run_sanitizer_fuzz.sh. "
+            "First repro: %(source)s via %(axis)s/%(phase)s. "
+            "Top frame: %(top)s. Log: %(log)s."
+            % {
+                "source": sample.get("source", ""),
+                "axis": sample.get("axis", ""),
+                "phase": sample.get("phase", ""),
+                "top": group["top_frame"],
+                "log": sample.get("log", ""),
+            }
+        ),
+        "status_note": "OPEN. Dedup signature is sanitizer kind/subtype plus normalized top frame.",
+        "acceptance": [
+            "Root cause is fixed or explicitly classified with a narrower XKNOWN.",
+            "A minimal repro remains in tests/ or is added next to the affected corpus.",
+            "scripts/run_sanitizer_fuzz.sh no longer reports this signature.",
+        ],
+        "blocked_by": [],
+        "file_globs": [sample.get("source", "tests/**/*.esk")],
+        "sanitizer_signature": group["signature"],
+        "sanitizer_kind": group["kind"],
+        "sanitizer_subtype": group["subtype"],
+        "sanitizer_top_frame": group["top_frame"],
+    }
+    with open(os.path.join(task_dir, tid + ".json"), "w") as f:
+        json.dump(task, f, indent=2)
+        f.write("\n")
+
+events = []
+self_status = self_data.get("status", "FAIL")
+self_summary = self_data.get("summary", "self-test metadata missing")
+events.append(
+    {
+        "kind": "sanitizer_fuzz",
+        "name": "sanitizer_fuzz_selftest_esh0116",
+        "value": self_status,
+        "snippet": self_summary,
+        "confidence": 0.95,
+    }
+)
+events.append(
+    {
+        "kind": "sanitizer_fuzz",
+        "name": "sanitizer_fuzz_aot_coverage",
+        "value": coverage_status,
+        "snippet": coverage_summary,
+        "confidence": 0.95,
+    }
+)
+
+if groups:
+    for group in groups.values():
+        sample = group["samples"][0] if group["samples"] else {}
+        events.append(
+            {
+                "kind": "sanitizer_fuzz",
+                "name": "sanitizer_fuzz_finding_%s" % group["task_id"].lower().replace("-", "_"),
+                "value": "FAIL",
+                "snippet": "%s %s at %s first_repro=%s"
+                % (group["kind"], group["subtype"], group["top_frame"], sample.get("source", "")),
+                "confidence": 0.95,
+            }
+        )
+
+clean_value = "PASS" if not groups else "FAIL"
+events.append(
+    {
+        "kind": "sanitizer_fuzz",
+        "name": "sanitizer_fuzz_clean",
+        "value": clean_value,
+        "snippet": "%d unique sanitizer signatures across %d run records"
+        % (len(groups), len(runs)),
+        "confidence": 0.95,
+    }
+)
+with open(trace_file, "w") as f:
+    for event in events:
+        f.write(json.dumps(event, sort_keys=True) + "\n")
+
+def command_for(sample):
+    source = sample.get("source", "")
+    axis = sample.get("axis", "")
+    phase = sample.get("phase", "")
+    runner = rel(os.path.join(build_dir, "eshkol-run"))
+    if axis == "r":
+        return "%s -r %s" % (runner, source)
+    if axis == "aot-o0":
+        return "%s -O0 %s -o /tmp/eshkol-sanitize-repro.bin" % (runner, source)
+    if axis == "aot-o2":
+        return "%s -O2 %s -o /tmp/eshkol-sanitize-repro.bin" % (runner, source)
+    if phase == "run":
+        return "/tmp/eshkol-sanitize-repro.bin"
+    return "%s %s" % (axis, source)
+
+with open(report_path, "w") as f:
+    f.write("# Sanitizer Fuzz Report\n\n")
+    f.write("- Started: `%s`\n" % started_at)
+    f.write("- Finished: `%s`\n" % finished_at)
+    f.write("- Build: `%s`\n" % rel(build_dir))
+    f.write("- Corpus files: `%d`\n" % total_sources)
+    f.write("- Run records: `%d`\n" % len(runs))
+    f.write("- Axes: `-r`, `AOT -O0 compile/run`, `AOT -O2 compile/run`\n")
+    f.write("- Generated differential fuzz: seed `%s`, count `%s`\n" % (seed, count))
+    f.write("- ASAN_OPTIONS: `%s`\n" % asan_options)
+    f.write("- UBSAN_OPTIONS: `%s`\n" % ubsan_options)
+    f.write("- Raw logs: `%s`\n" % rel(work_root))
+    f.write("- ICC trace: `%s`\n\n" % rel(trace_file))
+
+    f.write("## Teeth Check\n\n")
+    f.write("- Status: `%s`\n" % self_status)
+    f.write("- Summary: %s\n" % self_summary)
+    if self_data.get("source"):
+        f.write("- Synthetic repro: `%s`\n" % rel(self_data["source"]))
+    if self_data.get("stderr"):
+        f.write("- Synthetic stderr: `%s`\n" % rel(self_data["stderr"]))
+    f.write("\n")
+
+    f.write("## Coverage\n\n")
+    f.write("- Status: `%s`\n" % coverage_status)
+    f.write("- Summary: %s\n" % coverage_summary)
+    if run_counts:
+        f.write("- Records by axis/phase/rc:\n")
+        for (axis, phase, rc), n in sorted(run_counts.items()):
+            f.write("  - `%s/%s rc=%s`: `%d`\n" % (axis, phase, rc, n))
+    f.write("\n")
+
+    f.write("## Findings\n\n")
+    if not groups:
+        f.write("No ASan/UBSan reports were observed in corpus logs.\n\n")
+    else:
+        f.write("| Task | Kind | Type | Hits | Top frame | First repro |\n")
+        f.write("|---|---|---|---:|---|---|\n")
+        for group in groups.values():
+            sample = group["samples"][0] if group["samples"] else {}
+            f.write(
+                "| `%s` | `%s` | `%s` | %d | `%s` | `%s` |\n"
+                % (
+                    group["task_id"],
+                    md(group["kind"]),
+                    md(group["subtype"]),
+                    group["hits"],
+                    md(group["top_frame"]),
+                    md(sample.get("source", "")),
+                )
+            )
+        f.write("\n")
+
+        for group in groups.values():
+            sample = group["samples"][0] if group["samples"] else {}
+            f.write("### %s\n\n" % group["task_id"])
+            f.write("- Kind: `%s`\n" % group["kind"])
+            f.write("- Type: `%s`\n" % group["subtype"])
+            f.write("- Hits: `%d`\n" % group["hits"])
+            f.write("- Top frame: `%s`\n" % group["top_frame"])
+            if group["summary"]:
+                f.write("- Summary: `%s`\n" % group["summary"])
+            f.write("- First repro: `%s` via `%s/%s` rc `%s`\n" % (
+                sample.get("source", ""),
+                sample.get("axis", ""),
+                sample.get("phase", ""),
+                sample.get("rc", ""),
+            ))
+            f.write("- Repro command: `ASAN_OPTIONS='%s' UBSAN_OPTIONS='%s' %s`\n" % (
+                asan_options,
+                ubsan_options,
+                command_for(sample),
+            ))
+            f.write("- First log: `%s`\n" % sample.get("log", ""))
+            if group["samples"]:
+                f.write("- Additional samples:\n")
+                for s in group["samples"][1:]:
+                    f.write("  - `%s` via `%s/%s`, log `%s`\n" % (
+                        s.get("source", ""),
+                        s.get("axis", ""),
+                        s.get("phase", ""),
+                        s.get("log", ""),
+                    ))
+            if group["snippets"]:
+                f.write("\n```text\n%s\n```\n" % group["snippets"][0])
+            f.write("\n")
+
+if self_status != "PASS" or coverage_status != "PASS" or groups:
+    sys.exit(1)
+PY
+}
+
+echo "Sanitizer fuzz harness"
+echo "  repo: $REPO_ROOT"
+echo "  build: $BUILD_DIR_ABS"
+echo "  report: $REPORT_ABS"
+echo "  logs: $WORK_ROOT_ABS"
+echo
+
+run_self_test
+
+if [ "$SELF_TEST_ONLY" -eq 1 ]; then
+    FINISHED_AT="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    write_report "$FINISHED_AT" 0
+    exit $?
+fi
+
+if [ "$SKIP_BUILD" -eq 0 ]; then
+    CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-RelWithDebInfo}" scripts/build-sanitizer.sh asan+ubsan
+fi
+
+if [ ! -x "$ESHKOL_RUN" ]; then
+    echo "run_sanitizer_fuzz.sh: missing executable: $ESHKOL_RUN" >&2
+    exit 2
+fi
+
+collect_corpus
+TOTAL_SOURCES=$(wc -l < "$CORPUS_LIST" | tr -d ' ')
+echo "Corpus: $TOTAL_SOURCES unique .esk files"
+if [ "$LIMIT" -gt 0 ]; then
+    echo "Debug limit: first $LIMIT files"
+fi
+echo "Axes: -r, AOT -O0, AOT -O2"
+echo
+
+idx=0
+while IFS= read -r src; do
+    idx=$((idx + 1))
+    if [ "$LIMIT" -gt 0 ] && [ "$idx" -gt "$LIMIT" ]; then
+        break
+    fi
+    if [ $((idx % 25)) -eq 1 ]; then
+        printf '  [%d/%d] %s\n' "$idx" "$TOTAL_SOURCES" "${src#$REPO_ROOT/}"
+    fi
+    run_r_axis "$src" "$idx"
+    run_aot_axis "$src" "$idx" "aot-o0" "-O0"
+    run_aot_axis "$src" "$idx" "aot-o2" "-O2"
+done < "$CORPUS_LIST"
+
+if [ "$LIMIT" -gt 0 ] && [ "$LIMIT" -lt "$TOTAL_SOURCES" ]; then
+    TOTAL_REPORTED="$LIMIT"
+else
+    TOTAL_REPORTED="$TOTAL_SOURCES"
+fi
+
+FINISHED_AT="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+write_report "$FINISHED_AT" "$TOTAL_REPORTED"
+exit $?


### PR DESCRIPTION
## Summary
- add an ASan/UBSan sanitizer-over-fuzzer harness for generated differential fuzz plus tests/**/*.esk across -r, AOT -O0, and AOT -O2
- propagate sanitizer link flags into AOT user links so sanitized macOS builds link generated binaries correctly
- add the sanitizer-fuzz ICC oracle, full report, and ESH-0160 through ESH-0167 finding tasks

## Verification
- bash -n scripts/run_sanitizer_fuzz.sh
- bash -n scripts/build-sanitizer.sh
- scripts/build-sanitizer.sh asan+ubsan
- scripts/run_sanitizer_fuzz.sh --skip-build (expected nonzero: 8 sanitizer signatures found and filed)