### PR TITLE
fix(r7rs): apply-with-leading-args SIGSEGV, multi-arg vector-map, quasiquoted-vector (ESH-0150/0151/0154)

### DIFF
--- a/.swarm/tasks/ESH-0150.json
+++ b/.swarm/tasks/ESH-0150.json
@@ -1,0 +1,27 @@
+{
+  "id": "ESH-0150",
+  "title": "apply with leading args before the final list SIGSEGVs",
+  "status": "done",
+  "priority": "high",
+  "workstream": "r7rs-conformance",
+  "owner": "tsotchke",
+  "preferred_backend": "claude",
+  "goal": "R7RS apply prepends the leading args to the final list arg: (apply + 1 2 '(3 4 5)) must return 15. Previously CallApplyCodegen::apply hardcoded variables[1] as THE list and ignored any leading args, so it walked the integer 1 as a cons chain and SIGSEGV'd.",
+  "file_globs": [
+    "lib/backend/call_apply_codegen.cpp",
+    "tests/r7rs/reference_diff_fixes_test.esk"
+  ],
+  "root_cause": "CallApplyCodegen::apply used op->call_op.variables[1] as the argument list unconditionally. For (apply proc arg1 ... argN list) it must treat the LAST variadic arg as the list and prepend arg1..argN. The old code fed a non-list leading arg into the cons-walking machinery, dereferencing a raw integer as a pointer.",
+  "fix": "In apply(): take variables[num_vars-1] as the final list, then cons the leading args variables[1..num_vars-2] onto it in reverse order via create_cons_callback_ + ensureTagged. The fully-materialised list feeds every downstream path (builtin reductions, user functions, closures, captured procedures) unchanged.",
+  "acceptance": [
+    "(apply + 1 2 '(3 4 5)) => 15 under -r and AOT",
+    "apply with 0/1/2/3 leading args correct for builtins, user procs, captured procs",
+    "no SIGSEGV"
+  ],
+  "verification": [
+    "./build/eshkol-run tests/r7rs/reference_diff_fixes_test.esk -r",
+    "./build/eshkol-run tests/r7rs/reference_diff_fixes_test.esk -o /tmp/r7rs && /tmp/r7rs",
+    "bash scripts/run_sicp_smoke.sh"
+  ],
+  "blocked_by": []
+}

--- a/.swarm/tasks/ESH-0151.json
+++ b/.swarm/tasks/ESH-0151.json
@@ -1,0 +1,28 @@
+{
+  "id": "ESH-0151",
+  "title": "multi-arg vector-map/vector-for-each ignore extra vectors",
+  "status": "done",
+  "priority": "high",
+  "workstream": "r7rs-conformance",
+  "owner": "tsotchke",
+  "preferred_backend": "claude",
+  "goal": "R7RS vector-map/vector-for-each are variadic over N vectors, applying the proc to corresponding elements up to the shortest length. (vector-map + #(1 2 3) #(10 20 30)) must return #(11 22 33); previously returned the first vector unchanged because only variables[1] was consumed.",
+  "file_globs": [
+    "lib/backend/llvm_codegen.cpp",
+    "tests/r7rs/reference_diff_fixes_test.esk"
+  ],
+  "root_cause": "The vector-for-each and vector-map codegen in llvm_codegen.cpp only read op->call_op.variables[1] (a single vector) and had duplicated tensor/vector loop paths. Extra vector args were silently dropped, and the closure was called with one element.",
+  "fix": "Rewrote both to gather all N vector args (each may be a tensor or Scheme vector, resolved per-arg via a header-subtype diamond), compute the shortest length, and run a single alloca-counter loop that loads the i-th element from every source (via a per-element tensor/vector loadElem helper) and calls the closure with all N. vector-map stores each result into a fresh Scheme vector sized to the shortest length. Kept the alloca+store loop pattern (no PHI counters across codegenClosureCall).",
+  "acceptance": [
+    "(vector-map + #(1 2 3) #(10 20 30)) => #(11 22 33)",
+    "3-vector vector-map correct; iterates to shortest length",
+    "vector-for-each side effects over N vectors correct",
+    "single-vector cases unchanged"
+  ],
+  "verification": [
+    "./build/eshkol-run tests/r7rs/reference_diff_fixes_test.esk -r",
+    "./build/eshkol-run tests/features/r7rs_wave2_test.esk -r",
+    "bash scripts/run_sicp_smoke.sh"
+  ],
+  "blocked_by": []
+}

--- a/.swarm/tasks/ESH-0154.json
+++ b/.swarm/tasks/ESH-0154.json
@@ -1,0 +1,29 @@
+{
+  "id": "ESH-0154",
+  "title": "quasiquoted vector produces no output",
+  "status": "done",
+  "priority": "high",
+  "workstream": "r7rs-conformance",
+  "owner": "tsotchke",
+  "preferred_backend": "claude",
+  "goal": "R7RS: unquote/unquote-splicing inside a vector template must evaluate. `#(1 ,(+ 2 2) 3) must produce #(1 4 3); previously produced no output because the quasiquote data parser had no case for #( and the codegen had no vector-template handling.",
+  "file_globs": [
+    "lib/frontend/parser.cpp",
+    "lib/backend/llvm_codegen.cpp",
+    "lib/core/runtime_list_helpers.cpp",
+    "tests/r7rs/reference_diff_fixes_test.esk"
+  ],
+  "root_cause": "parse_quasiquoted_data_with_token had no TOKEN_VECTOR_START branch, so a #(...) inside quasiquote fell to parse_atom on the '#(' token and silently failed. codegenQuasiquote likewise had no vector case.",
+  "fix": "Parser: added a TOKEN_VECTOR_START case in parse_quasiquoted_data_with_token that parses each element as quasiquoted data (so ,expr / ,@expr become UNQUOTE(_SPLICING)_OP) and emits a 1-D TENSOR_OP. codegenQuasiquote: added a TENSOR_OP case that materialises the template as a list first (reusing the exact unquote/splice machinery as the list path) then vectorises via a new runtime helper eshkol_list_to_vector_sret, yielding a heterogeneous Scheme vector. Handles unquote, unquote-splicing, nested vectors, and empty vectors.",
+  "acceptance": [
+    "`#(1 ,(+ 2 2) 3) => #(1 4 3) under -r and AOT",
+    "unquote-splicing into a vector works",
+    "nested quasiquoted vectors work"
+  ],
+  "verification": [
+    "./build/eshkol-run tests/r7rs/reference_diff_fixes_test.esk -r",
+    "./build/eshkol-run tests/r7rs/reference_diff_fixes_test.esk -o /tmp/r7rs && /tmp/r7rs",
+    "bash scripts/run_sicp_smoke.sh"
+  ],
+  "blocked_by": []
+}

--- a/lib/backend/call_apply_codegen.cpp
+++ b/lib/backend/call_apply_codegen.cpp
@@ -65,8 +65,43 @@ Value* CallApplyCodegen::apply(const eshkol_operations_t* op) {
         eshkol_error("apply: codegen_ast_callback not set");
         return nullptr;
     }
-    Value* arg_list = codegen_ast_callback_(&op->call_op.variables[1], callback_context_);
+
+    // R7RS apply: (apply proc arg1 ... argN final-list). The LAST variadic
+    // argument is the list; every intermediate arg (arg1..argN) is prepended
+    // to that list. Historically this code assumed variables[1] was THE list
+    // and ignored any leading args, which SIGSEGV'd on (apply + 1 2 '(3 4 5))
+    // because it walked the integer `1` as a cons chain.
+    //
+    // Build the effective argument list here, once, by consing the leading
+    // args (in reverse) onto the final list. Every downstream path (builtin
+    // reductions, user functions, closures, captured procedures) then operates
+    // on the fully-materialised list unchanged.
+    const int num_vars = op->call_op.num_vars;
+    const int final_list_idx = num_vars - 1;
+
+    Value* arg_list = codegen_ast_callback_(&op->call_op.variables[final_list_idx],
+                                            callback_context_);
     if (!arg_list) return nullptr;
+
+    // Prepend any leading args (variables[1 .. num_vars-2]) onto the list, in
+    // reverse order so the first leading arg ends up at the head.
+    if (num_vars > 2) {
+        if (!create_cons_callback_) {
+            eshkol_error("apply: create_cons_callback not set (needed for leading args)");
+            return nullptr;
+        }
+        // Ensure the tail is a proper tagged value for cons cdr storage.
+        Value* current_list = tagged_.ensureTagged(arg_list);
+        for (int i = final_list_idx - 1; i >= 1; i--) {
+            Value* elem = codegen_ast_callback_(&op->call_op.variables[i], callback_context_);
+            if (!elem) return nullptr;
+            Value* elem_tagged = tagged_.ensureTagged(elem);
+            Value* cons_int = create_cons_callback_(elem_tagged, current_list, callback_context_);
+            current_list = tagged_.packHeapPtr(
+                ctx_.builder().CreateIntToPtr(cons_int, ctx_.ptrType()));
+        }
+        arg_list = current_list;
+    }
 
     // Safely extract i64 from possibly-tagged value
     Value* list_int = tagged_.safeExtractInt64(arg_list);

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -15951,78 +15951,110 @@ private:
         // Handles both Scheme vectors (16-byte tagged elements) and tensors (8-byte doubles)
         // Uses alloca pattern (not PHI) because codegenClosureCall creates 15+ basic blocks
         if (func_name == "vector-for-each") {
+            // R7RS: (vector-for-each proc vec1 vec2 ...) — variadic over N
+            // vectors, applying proc to corresponding elements up to the
+            // SHORTEST length. Accepts both Scheme vectors (16-byte tagged
+            // elems) and tensors (8-byte doubles), per-arg. alloca loop
+            // counter (not PHI) because codegenClosureCall creates many blocks.
+            if (op->call_op.num_vars < 2) {
+                eshkol_error("vector-for-each requires a procedure and at least one vector");
+                return nullptr;
+            }
             Value* func_val = codegenAST(&op->call_op.variables[0]);
             if (!func_val) return nullptr;
             func_val = ensureTaggedValue(func_val);
-            Value* vec_arg = codegenAST(&op->call_op.variables[1]);
-            if (!vec_arg) return nullptr;
-            vec_arg = ensureTaggedValue(vec_arg);
-            Value* vec_ptr_int = unpackInt64FromTaggedValue(vec_arg);
-            Value* vec_ptr = builder->CreateIntToPtr(vec_ptr_int, PointerType::getUnqual(*context));
             Function* cur_func = builder->GetInsertBlock()->getParent();
-            // Check header subtype at ptr-8 to distinguish tensor vs vector
-            Value* header_ptr = builder->CreateGEP(int8_type, vec_ptr, ConstantInt::get(int64_type, -8));
-            Value* subtype = builder->CreateLoad(int8_type, header_ptr);
-            Value* is_tensor = builder->CreateICmpEQ(subtype, ConstantInt::get(int8_type, HEAP_SUBTYPE_TENSOR));
-            BasicBlock* tensor_path = BasicBlock::Create(*context, "vfe_tensor", cur_func);
-            BasicBlock* vector_path = BasicBlock::Create(*context, "vfe_vector", cur_func);
+            int n_vecs = op->call_op.num_vars - 1;
+
+            // Per-vector element loader: yields the i-th element as a tagged
+            // value, branching on whether the source is a tensor or a vector.
+            auto loadElem = [&](Value* is_t, Value* elems, Value* base, Value* idx) -> Value* {
+                Function* f = builder->GetInsertBlock()->getParent();
+                BasicBlock* tb = BasicBlock::Create(*context, "velt_t", f);
+                BasicBlock* vb = BasicBlock::Create(*context, "velt_v", f);
+                BasicBlock* mb = BasicBlock::Create(*context, "velt_m", f);
+                builder->CreateCondBr(is_t, tb, vb);
+                builder->SetInsertPoint(tb);
+                Value* ep = builder->CreateGEP(int64_type, elems, idx);
+                Value* ei = builder->CreateLoad(int64_type, ep);
+                Value* et = packDoubleToTaggedValue(builder->CreateBitCast(ei, double_type));
+                builder->CreateBr(mb);
+                BasicBlock* tb_exit = builder->GetInsertBlock();
+                builder->SetInsertPoint(vb);
+                Value* eptr = builder->CreateGEP(tagged_value_type, base, idx);
+                Value* ev = builder->CreateLoad(tagged_value_type, eptr);
+                builder->CreateBr(mb);
+                BasicBlock* vb_exit = builder->GetInsertBlock();
+                builder->SetInsertPoint(mb);
+                PHINode* phi = builder->CreatePHI(tagged_value_type, 2);
+                phi->addIncoming(et, tb_exit);
+                phi->addIncoming(ev, vb_exit);
+                return phi;
+            };
+
+            std::vector<Value*> is_tensors(n_vecs), elems_ptrs(n_vecs),
+                                base_ptrs(n_vecs), lengths(n_vecs);
+            Value* nullp = ConstantPointerNull::get(PointerType::getUnqual(*context));
+            for (int a = 0; a < n_vecs; a++) {
+                Value* va = codegenAST(&op->call_op.variables[a + 1]);
+                if (!va) return nullptr;
+                va = ensureTaggedValue(va);
+                Value* vpi = unpackInt64FromTaggedValue(va);
+                Value* vp = builder->CreateIntToPtr(vpi, PointerType::getUnqual(*context));
+                Value* hdr = builder->CreateGEP(int8_type, vp, ConstantInt::get(int64_type, -8));
+                Value* st = builder->CreateLoad(int8_type, hdr);
+                Value* is_t = builder->CreateICmpEQ(st, ConstantInt::get(int8_type, HEAP_SUBTYPE_TENSOR));
+                BasicBlock* tb = BasicBlock::Create(*context, "vfe_at", cur_func);
+                BasicBlock* vb = BasicBlock::Create(*context, "vfe_av", cur_func);
+                BasicBlock* mb = BasicBlock::Create(*context, "vfe_am", cur_func);
+                builder->CreateCondBr(is_t, tb, vb);
+                builder->SetInsertPoint(tb);
+                Value* tlen = builder->CreateLoad(int64_type, builder->CreateStructGEP(tensor_type, vp, 3));
+                Value* telems = builder->CreateLoad(PointerType::getUnqual(*context), builder->CreateStructGEP(tensor_type, vp, 2));
+                builder->CreateBr(mb);
+                BasicBlock* tb_exit = builder->GetInsertBlock();
+                builder->SetInsertPoint(vb);
+                Value* vlen = builder->CreateLoad(int64_type, vp);
+                Value* vbase = builder->CreateGEP(int8_type, vp, ConstantInt::get(int64_type, 8));
+                builder->CreateBr(mb);
+                BasicBlock* vb_exit = builder->GetInsertBlock();
+                builder->SetInsertPoint(mb);
+                PHINode* len_phi = builder->CreatePHI(int64_type, 2);
+                len_phi->addIncoming(tlen, tb_exit); len_phi->addIncoming(vlen, vb_exit);
+                PHINode* elems_phi = builder->CreatePHI(PointerType::getUnqual(*context), 2);
+                elems_phi->addIncoming(telems, tb_exit); elems_phi->addIncoming(nullp, vb_exit);
+                PHINode* base_phi = builder->CreatePHI(PointerType::getUnqual(*context), 2);
+                base_phi->addIncoming(nullp, tb_exit); base_phi->addIncoming(vbase, vb_exit);
+                is_tensors[a] = is_t; lengths[a] = len_phi;
+                elems_ptrs[a] = elems_phi; base_ptrs[a] = base_phi;
+            }
+
+            // Iterate to the shortest length.
+            Value* min_len = lengths[0];
+            for (int a = 1; a < n_vecs; a++) {
+                Value* lt = builder->CreateICmpULT(lengths[a], min_len);
+                min_len = builder->CreateSelect(lt, lengths[a], min_len);
+            }
+
+            Value* idx_ptr = builder->CreateAlloca(int64_type, nullptr, "vfe_idx");
+            builder->CreateStore(ConstantInt::get(int64_type, 0), idx_ptr);
+            BasicBlock* cond_bb = BasicBlock::Create(*context, "vfe_cond", cur_func);
+            BasicBlock* body_bb = BasicBlock::Create(*context, "vfe_body", cur_func);
             BasicBlock* done_bb = BasicBlock::Create(*context, "vfe_done", cur_func);
-            builder->CreateCondBr(is_tensor, tensor_path, vector_path);
-            // === TENSOR PATH: elements are int64 bitpatterns of doubles ===
-            builder->SetInsertPoint(tensor_path);
-            {
-                // Tensor struct: {dims_ptr(0), num_dims(1), elements_ptr(2), total_elements(3)}
-                Value* elems_field = builder->CreateStructGEP(tensor_type, vec_ptr, 2);
-                Value* elems_ptr = builder->CreateLoad(PointerType::getUnqual(*context), elems_field);
-                Value* total_field = builder->CreateStructGEP(tensor_type, vec_ptr, 3);
-                Value* total_elems = builder->CreateLoad(int64_type, total_field);
-                Value* t_idx_ptr = builder->CreateAlloca(int64_type, nullptr, "vfe_t_idx");
-                builder->CreateStore(ConstantInt::get(int64_type, 0), t_idx_ptr);
-                BasicBlock* t_cond = BasicBlock::Create(*context, "vfe_t_cond", cur_func);
-                BasicBlock* t_body = BasicBlock::Create(*context, "vfe_t_body", cur_func);
-                BasicBlock* t_exit = BasicBlock::Create(*context, "vfe_t_exit", cur_func);
-                builder->CreateBr(t_cond);
-                builder->SetInsertPoint(t_cond);
-                Value* t_i = builder->CreateLoad(int64_type, t_idx_ptr);
-                builder->CreateCondBr(builder->CreateICmpUGE(t_i, total_elems), t_exit, t_body);
-                builder->SetInsertPoint(t_body);
-                Value* t_ci = builder->CreateLoad(int64_type, t_idx_ptr);
-                Value* e_ptr = builder->CreateGEP(int64_type, elems_ptr, t_ci);
-                Value* e_int = builder->CreateLoad(int64_type, e_ptr);
-                Value* e_dbl = builder->CreateBitCast(e_int, double_type);
-                Value* e_tagged = packDoubleToTaggedValue(e_dbl);
-                codegenClosureCall(func_val, {e_tagged}, "vector-for-each-tensor");
-                Value* t_next = builder->CreateAdd(t_ci, ConstantInt::get(int64_type, 1));
-                builder->CreateStore(t_next, t_idx_ptr);
-                builder->CreateBr(t_cond);
-                builder->SetInsertPoint(t_exit);
-                builder->CreateBr(done_bb);
-            }
-            // === VECTOR PATH: elements are tagged_value_type (16 bytes) ===
-            builder->SetInsertPoint(vector_path);
-            {
-                Value* vec_len = builder->CreateLoad(int64_type, vec_ptr, "vfe_len");
-                Value* elem_base = builder->CreateGEP(int8_type, vec_ptr, ConstantInt::get(int64_type, 8));
-                Value* v_idx_ptr = builder->CreateAlloca(int64_type, nullptr, "vfe_v_idx");
-                builder->CreateStore(ConstantInt::get(int64_type, 0), v_idx_ptr);
-                BasicBlock* v_cond = BasicBlock::Create(*context, "vfe_v_cond", cur_func);
-                BasicBlock* v_body = BasicBlock::Create(*context, "vfe_v_body", cur_func);
-                BasicBlock* v_exit = BasicBlock::Create(*context, "vfe_v_exit", cur_func);
-                builder->CreateBr(v_cond);
-                builder->SetInsertPoint(v_cond);
-                Value* v_i = builder->CreateLoad(int64_type, v_idx_ptr);
-                builder->CreateCondBr(builder->CreateICmpUGE(v_i, vec_len), v_exit, v_body);
-                builder->SetInsertPoint(v_body);
-                Value* v_ci = builder->CreateLoad(int64_type, v_idx_ptr);
-                Value* elem_ptr = builder->CreateGEP(tagged_value_type, elem_base, v_ci);
-                Value* elem = builder->CreateLoad(tagged_value_type, elem_ptr, "vfe_elem");
-                codegenClosureCall(func_val, {elem}, "vector-for-each-vector");
-                Value* v_next = builder->CreateAdd(v_ci, ConstantInt::get(int64_type, 1));
-                builder->CreateStore(v_next, v_idx_ptr);
-                builder->CreateBr(v_cond);
-                builder->SetInsertPoint(v_exit);
-                builder->CreateBr(done_bb);
-            }
+            builder->CreateBr(cond_bb);
+            builder->SetInsertPoint(cond_bb);
+            Value* i = builder->CreateLoad(int64_type, idx_ptr);
+            builder->CreateCondBr(builder->CreateICmpUGE(i, min_len), done_bb, body_bb);
+            builder->SetInsertPoint(body_bb);
+            Value* ci = builder->CreateLoad(int64_type, idx_ptr);
+            std::vector<Value*> call_args;
+            for (int a = 0; a < n_vecs; a++)
+                call_args.push_back(loadElem(is_tensors[a], elems_ptrs[a], base_ptrs[a], ci));
+            codegenClosureCall(func_val, call_args, "vector-for-each");
+            // Reload the counter — loadElem/codegenClosureCall create blocks.
+            Value* ci2 = builder->CreateLoad(int64_type, idx_ptr);
+            builder->CreateStore(builder->CreateAdd(ci2, ConstantInt::get(int64_type, 1)), idx_ptr);
+            builder->CreateBr(cond_bb);
             builder->SetInsertPoint(done_bb);
             return packNullToTaggedValue();
         }
@@ -16031,36 +16063,89 @@ private:
         // Always returns a Scheme vector (tagged elements)
         // Uses alloca pattern (not PHI) because codegenClosureCall creates 15+ basic blocks
         if (func_name == "vector-map") {
+            // R7RS: (vector-map proc vec1 vec2 ...) — variadic over N vectors,
+            // applying proc to corresponding elements up to the SHORTEST length;
+            // returns a fresh Scheme vector (tagged elements). Accepts both
+            // Scheme vectors and tensors per-arg. alloca loop counter (not PHI).
+            if (op->call_op.num_vars < 2) {
+                eshkol_error("vector-map requires a procedure and at least one vector");
+                return nullptr;
+            }
             Value* func_val = codegenAST(&op->call_op.variables[0]);
             if (!func_val) return nullptr;
             func_val = ensureTaggedValue(func_val);
-            Value* vec_arg = codegenAST(&op->call_op.variables[1]);
-            if (!vec_arg) return nullptr;
-            vec_arg = ensureTaggedValue(vec_arg);
-            Value* vec_ptr_int = unpackInt64FromTaggedValue(vec_arg);
-            Value* vec_ptr = builder->CreateIntToPtr(vec_ptr_int, PointerType::getUnqual(*context));
             Function* cur_func = builder->GetInsertBlock()->getParent();
-            // Check header subtype at ptr-8
-            Value* header_ptr = builder->CreateGEP(int8_type, vec_ptr, ConstantInt::get(int64_type, -8));
-            Value* subtype = builder->CreateLoad(int8_type, header_ptr);
-            Value* is_tensor = builder->CreateICmpEQ(subtype, ConstantInt::get(int8_type, HEAP_SUBTYPE_TENSOR));
-            // Get length: tensor uses total_elements field, vector uses first int64
-            BasicBlock* tensor_len_bb = BasicBlock::Create(*context, "vm_tensor_len", cur_func);
-            BasicBlock* vector_len_bb = BasicBlock::Create(*context, "vm_vector_len", cur_func);
-            BasicBlock* len_merge_bb = BasicBlock::Create(*context, "vm_len_merge", cur_func);
-            builder->CreateCondBr(is_tensor, tensor_len_bb, vector_len_bb);
-            builder->SetInsertPoint(tensor_len_bb);
-            Value* t_total_field = builder->CreateStructGEP(tensor_type, vec_ptr, 3);
-            Value* t_len = builder->CreateLoad(int64_type, t_total_field);
-            builder->CreateBr(len_merge_bb);
-            builder->SetInsertPoint(vector_len_bb);
-            Value* v_len = builder->CreateLoad(int64_type, vec_ptr);
-            builder->CreateBr(len_merge_bb);
-            builder->SetInsertPoint(len_merge_bb);
-            PHINode* vec_len = builder->CreatePHI(int64_type, 2, "vm_len");
-            vec_len->addIncoming(t_len, tensor_len_bb);
-            vec_len->addIncoming(v_len, vector_len_bb);
-            // Allocate result vector (always Scheme vector)
+            int n_vecs = op->call_op.num_vars - 1;
+
+            auto loadElem = [&](Value* is_t, Value* elems, Value* base, Value* idx) -> Value* {
+                Function* f = builder->GetInsertBlock()->getParent();
+                BasicBlock* tb = BasicBlock::Create(*context, "vmelt_t", f);
+                BasicBlock* vb = BasicBlock::Create(*context, "vmelt_v", f);
+                BasicBlock* mb = BasicBlock::Create(*context, "vmelt_m", f);
+                builder->CreateCondBr(is_t, tb, vb);
+                builder->SetInsertPoint(tb);
+                Value* ep = builder->CreateGEP(int64_type, elems, idx);
+                Value* ei = builder->CreateLoad(int64_type, ep);
+                Value* et = packDoubleToTaggedValue(builder->CreateBitCast(ei, double_type));
+                builder->CreateBr(mb);
+                BasicBlock* tb_exit = builder->GetInsertBlock();
+                builder->SetInsertPoint(vb);
+                Value* eptr = builder->CreateGEP(tagged_value_type, base, idx);
+                Value* ev = builder->CreateLoad(tagged_value_type, eptr);
+                builder->CreateBr(mb);
+                BasicBlock* vb_exit = builder->GetInsertBlock();
+                builder->SetInsertPoint(mb);
+                PHINode* phi = builder->CreatePHI(tagged_value_type, 2);
+                phi->addIncoming(et, tb_exit);
+                phi->addIncoming(ev, vb_exit);
+                return phi;
+            };
+
+            std::vector<Value*> is_tensors(n_vecs), elems_ptrs(n_vecs),
+                                base_ptrs(n_vecs), lengths(n_vecs);
+            Value* nullp = ConstantPointerNull::get(PointerType::getUnqual(*context));
+            for (int a = 0; a < n_vecs; a++) {
+                Value* va = codegenAST(&op->call_op.variables[a + 1]);
+                if (!va) return nullptr;
+                va = ensureTaggedValue(va);
+                Value* vpi = unpackInt64FromTaggedValue(va);
+                Value* vp = builder->CreateIntToPtr(vpi, PointerType::getUnqual(*context));
+                Value* hdr = builder->CreateGEP(int8_type, vp, ConstantInt::get(int64_type, -8));
+                Value* st = builder->CreateLoad(int8_type, hdr);
+                Value* is_t = builder->CreateICmpEQ(st, ConstantInt::get(int8_type, HEAP_SUBTYPE_TENSOR));
+                BasicBlock* tb = BasicBlock::Create(*context, "vm_at", cur_func);
+                BasicBlock* vb = BasicBlock::Create(*context, "vm_av", cur_func);
+                BasicBlock* mb = BasicBlock::Create(*context, "vm_am", cur_func);
+                builder->CreateCondBr(is_t, tb, vb);
+                builder->SetInsertPoint(tb);
+                Value* tlen = builder->CreateLoad(int64_type, builder->CreateStructGEP(tensor_type, vp, 3));
+                Value* telems = builder->CreateLoad(PointerType::getUnqual(*context), builder->CreateStructGEP(tensor_type, vp, 2));
+                builder->CreateBr(mb);
+                BasicBlock* tb_exit = builder->GetInsertBlock();
+                builder->SetInsertPoint(vb);
+                Value* vlen = builder->CreateLoad(int64_type, vp);
+                Value* vbase = builder->CreateGEP(int8_type, vp, ConstantInt::get(int64_type, 8));
+                builder->CreateBr(mb);
+                BasicBlock* vb_exit = builder->GetInsertBlock();
+                builder->SetInsertPoint(mb);
+                PHINode* len_phi = builder->CreatePHI(int64_type, 2);
+                len_phi->addIncoming(tlen, tb_exit); len_phi->addIncoming(vlen, vb_exit);
+                PHINode* elems_phi = builder->CreatePHI(PointerType::getUnqual(*context), 2);
+                elems_phi->addIncoming(telems, tb_exit); elems_phi->addIncoming(nullp, vb_exit);
+                PHINode* base_phi = builder->CreatePHI(PointerType::getUnqual(*context), 2);
+                base_phi->addIncoming(nullp, tb_exit); base_phi->addIncoming(vbase, vb_exit);
+                is_tensors[a] = is_t; lengths[a] = len_phi;
+                elems_ptrs[a] = elems_phi; base_ptrs[a] = base_phi;
+            }
+
+            // Result length is the shortest of the inputs.
+            Value* vec_len = lengths[0];
+            for (int a = 1; a < n_vecs; a++) {
+                Value* lt = builder->CreateICmpULT(lengths[a], vec_len);
+                vec_len = builder->CreateSelect(lt, lengths[a], vec_len);
+            }
+
+            // Allocate result vector (always Scheme vector).
             Value* elem_size = builder->CreateMul(vec_len, ConstantInt::get(int64_type, 16));
             Value* alloc_size = builder->CreateAdd(elem_size, ConstantInt::get(int64_type, 8));
             Value* arena_ptr = getArenaPtr();
@@ -16072,68 +16157,29 @@ private:
                 ConstantInt::get(int64_type, 0)});
             builder->CreateStore(vec_len, new_vec);
             Value* new_elem_base = builder->CreateGEP(int8_type, new_vec, ConstantInt::get(int64_type, 8));
-            // Branch to tensor or vector iteration
-            BasicBlock* tensor_loop_bb = BasicBlock::Create(*context, "vm_tensor_loop", cur_func);
-            BasicBlock* vector_loop_bb = BasicBlock::Create(*context, "vm_vector_loop", cur_func);
+
+            Value* idx_ptr = builder->CreateAlloca(int64_type, nullptr, "vm_idx");
+            builder->CreateStore(ConstantInt::get(int64_type, 0), idx_ptr);
+            BasicBlock* cond_bb = BasicBlock::Create(*context, "vm_cond", cur_func);
+            BasicBlock* body_bb = BasicBlock::Create(*context, "vm_body", cur_func);
             BasicBlock* done_bb = BasicBlock::Create(*context, "vm_done", cur_func);
-            builder->CreateCondBr(is_tensor, tensor_loop_bb, vector_loop_bb);
-            // === TENSOR PATH ===
-            builder->SetInsertPoint(tensor_loop_bb);
-            {
-                Value* elems_field = builder->CreateStructGEP(tensor_type, vec_ptr, 2);
-                Value* elems_ptr = builder->CreateLoad(PointerType::getUnqual(*context), elems_field);
-                Value* t_idx_ptr = builder->CreateAlloca(int64_type, nullptr, "vm_t_idx");
-                builder->CreateStore(ConstantInt::get(int64_type, 0), t_idx_ptr);
-                BasicBlock* t_cond = BasicBlock::Create(*context, "vm_t_cond", cur_func);
-                BasicBlock* t_body = BasicBlock::Create(*context, "vm_t_body", cur_func);
-                BasicBlock* t_exit = BasicBlock::Create(*context, "vm_t_exit", cur_func);
-                builder->CreateBr(t_cond);
-                builder->SetInsertPoint(t_cond);
-                Value* t_i = builder->CreateLoad(int64_type, t_idx_ptr);
-                builder->CreateCondBr(builder->CreateICmpUGE(t_i, vec_len), t_exit, t_body);
-                builder->SetInsertPoint(t_body);
-                Value* t_ci = builder->CreateLoad(int64_type, t_idx_ptr);
-                Value* e_ptr = builder->CreateGEP(int64_type, elems_ptr, t_ci);
-                Value* e_int = builder->CreateLoad(int64_type, e_ptr);
-                Value* e_dbl = builder->CreateBitCast(e_int, double_type);
-                Value* e_tagged = packDoubleToTaggedValue(e_dbl);
-                Value* t_result = codegenClosureCall(func_val, {e_tagged}, "vector-map-tensor");
-                Value* t_result_tagged = ensureTaggedValue(t_result);
-                Value* t_new_elem_ptr = builder->CreateGEP(tagged_value_type, new_elem_base, t_ci);
-                builder->CreateStore(t_result_tagged, t_new_elem_ptr);
-                Value* t_next = builder->CreateAdd(t_ci, ConstantInt::get(int64_type, 1));
-                builder->CreateStore(t_next, t_idx_ptr);
-                builder->CreateBr(t_cond);
-                builder->SetInsertPoint(t_exit);
-                builder->CreateBr(done_bb);
-            }
-            // === VECTOR PATH ===
-            builder->SetInsertPoint(vector_loop_bb);
-            {
-                Value* v_elem_base = builder->CreateGEP(int8_type, vec_ptr, ConstantInt::get(int64_type, 8));
-                Value* v_idx_ptr = builder->CreateAlloca(int64_type, nullptr, "vm_v_idx");
-                builder->CreateStore(ConstantInt::get(int64_type, 0), v_idx_ptr);
-                BasicBlock* v_cond = BasicBlock::Create(*context, "vm_v_cond", cur_func);
-                BasicBlock* v_body = BasicBlock::Create(*context, "vm_v_body", cur_func);
-                BasicBlock* v_exit = BasicBlock::Create(*context, "vm_v_exit", cur_func);
-                builder->CreateBr(v_cond);
-                builder->SetInsertPoint(v_cond);
-                Value* v_i = builder->CreateLoad(int64_type, v_idx_ptr);
-                builder->CreateCondBr(builder->CreateICmpUGE(v_i, vec_len), v_exit, v_body);
-                builder->SetInsertPoint(v_body);
-                Value* v_ci = builder->CreateLoad(int64_type, v_idx_ptr);
-                Value* elem_ptr = builder->CreateGEP(tagged_value_type, v_elem_base, v_ci);
-                Value* elem = builder->CreateLoad(tagged_value_type, elem_ptr, "vm_elem");
-                Value* v_result = codegenClosureCall(func_val, {elem}, "vector-map-vector");
-                Value* v_result_tagged = ensureTaggedValue(v_result);
-                Value* v_new_elem_ptr = builder->CreateGEP(tagged_value_type, new_elem_base, v_ci);
-                builder->CreateStore(v_result_tagged, v_new_elem_ptr);
-                Value* v_next = builder->CreateAdd(v_ci, ConstantInt::get(int64_type, 1));
-                builder->CreateStore(v_next, v_idx_ptr);
-                builder->CreateBr(v_cond);
-                builder->SetInsertPoint(v_exit);
-                builder->CreateBr(done_bb);
-            }
+            builder->CreateBr(cond_bb);
+            builder->SetInsertPoint(cond_bb);
+            Value* i = builder->CreateLoad(int64_type, idx_ptr);
+            builder->CreateCondBr(builder->CreateICmpUGE(i, vec_len), done_bb, body_bb);
+            builder->SetInsertPoint(body_bb);
+            Value* ci = builder->CreateLoad(int64_type, idx_ptr);
+            std::vector<Value*> call_args;
+            for (int a = 0; a < n_vecs; a++)
+                call_args.push_back(loadElem(is_tensors[a], elems_ptrs[a], base_ptrs[a], ci));
+            Value* result = codegenClosureCall(func_val, call_args, "vector-map");
+            Value* result_tagged = ensureTaggedValue(result);
+            // Reload the counter — loadElem/codegenClosureCall create blocks.
+            Value* ci2 = builder->CreateLoad(int64_type, idx_ptr);
+            Value* new_elem_ptr = builder->CreateGEP(tagged_value_type, new_elem_base, ci2);
+            builder->CreateStore(result_tagged, new_elem_ptr);
+            builder->CreateStore(builder->CreateAdd(ci2, ConstantInt::get(int64_type, 1)), idx_ptr);
+            builder->CreateBr(cond_bb);
             builder->SetInsertPoint(done_bb);
             return packPtrToTaggedValue(new_vec, ESHKOL_VALUE_HEAP_PTR);
         }
@@ -21103,6 +21149,62 @@ private:
         // not reach here because it's wrapped by the parser as a list, but a
         // bare `,expr` at the very top of a quasiquote does.
         if (ast->type == ESHKOL_OP) {
+            // Quasiquoted vector template: `#(1 ,(+ 2 2) 3). The parser emits a
+            // 1-D TENSOR_OP whose elements are quasiquoted data (possibly
+            // UNQUOTE / UNQUOTE_SPLICING). Materialise a list first — reusing
+            // the exact unquote/splice machinery as the list path — then
+            // vectorise it via eshkol_list_to_vector_sret. Result is a
+            // heterogeneous Scheme vector, per R7RS.
+            if (ast->operation.op == ESHKOL_TENSOR_OP) {
+                uint64_t n = ast->operation.tensor_op.total_elements;
+                const eshkol_ast_t* elems = ast->operation.tensor_op.elements;
+                Value* acc = packNullToTaggedValue();
+                for (int64_t i = (int64_t)n - 1; i >= 0; --i) {
+                    const eshkol_ast_t* elem = &elems[i];
+                    if (elem->type == ESHKOL_OP &&
+                        elem->operation.op == ESHKOL_UNQUOTE_SPLICING_OP) {
+                        Value* spliced = packNullToTaggedValue();
+                        if (elem->operation.call_op.num_vars > 0) {
+                            spliced = codegenAST(&elem->operation.call_op.variables[0]);
+                        }
+                        Value* spliced_tagged = ensureTaggedValue(spliced);
+                        Value* acc_tagged = ensureTaggedValue(acc);
+                        Value* out_slot = builder->CreateAlloca(tagged_value_type);
+                        Value* lhs_slot = builder->CreateAlloca(tagged_value_type);
+                        Value* rhs_slot = builder->CreateAlloca(tagged_value_type);
+                        builder->CreateStore(spliced_tagged, lhs_slot);
+                        builder->CreateStore(acc_tagged, rhs_slot);
+                        llvm::FunctionCallee append_fn =
+                            module->getOrInsertFunction("eshkol_append_tagged_sret",
+                                FunctionType::get(Type::getVoidTy(*context),
+                                    {PointerType::getUnqual(*context),
+                                     PointerType::getUnqual(*context),
+                                     PointerType::getUnqual(*context)}, false));
+                        builder->CreateCall(append_fn, {out_slot, lhs_slot, rhs_slot});
+                        acc = builder->CreateLoad(tagged_value_type, out_slot);
+                    } else {
+                        Value* elem_val = codegenQuasiquote(elem);
+                        Value* cons_int =
+                            codegenTaggedArenaConsCellFromTaggedValue(
+                                ensureTaggedValue(elem_val),
+                                ensureTaggedValue(acc));
+                        acc = packPtrToTaggedValue(
+                            builder->CreateIntToPtr(cons_int, builder->getPtrTy()),
+                            ESHKOL_VALUE_HEAP_PTR);
+                    }
+                }
+                // Convert the materialised list to a Scheme vector.
+                Value* list_slot = builder->CreateAlloca(tagged_value_type);
+                Value* vec_slot = builder->CreateAlloca(tagged_value_type);
+                builder->CreateStore(ensureTaggedValue(acc), list_slot);
+                llvm::FunctionCallee l2v_fn =
+                    module->getOrInsertFunction("eshkol_list_to_vector_sret",
+                        FunctionType::get(Type::getVoidTy(*context),
+                            {PointerType::getUnqual(*context),
+                             PointerType::getUnqual(*context)}, false));
+                builder->CreateCall(l2v_fn, {vec_slot, list_slot});
+                return builder->CreateLoad(tagged_value_type, vec_slot);
+            }
             if (ast->operation.op == ESHKOL_UNQUOTE_OP) {
                 if (ast->operation.call_op.num_vars > 0) {
                     return codegenAST(&ast->operation.call_op.variables[0]);

--- a/lib/core/runtime_list_helpers.cpp
+++ b/lib/core/runtime_list_helpers.cpp
@@ -354,6 +354,53 @@ void eshkol_append_tagged_sret(eshkol_tagged_value_t* out,
     *out = result;
 }
 
+/* Convert a proper tagged-cons list into a heterogeneous Scheme vector
+ * (HEAP_SUBTYPE_VECTOR). Layout matches the codegen `list->vector` / vector
+ * literal path: an 8-byte length header at offset 0 followed by N 16-byte
+ * tagged elements. Used by quasiquote-vector codegen (`#(1 ,x 3)`), where the
+ * template is first materialised as a list (so unquote/unquote-splicing reuse
+ * the existing list machinery) and then vectorised here. Result is written to
+ * *out; an empty/absent list yields a zero-length vector. */
+void eshkol_list_to_vector_sret(eshkol_tagged_value_t* out,
+                                const eshkol_tagged_value_t* list_tv) {
+    if (!out) return;
+    set_null_tagged(out);
+
+    int64_t n = 0;
+    if (list_tv) {
+        eshkol_tagged_value_t cur = *list_tv;
+        while (tagged_is_cons(&cur)) {
+            n++;
+            auto* src = (arena_tagged_cons_cell_t*)(uintptr_t)cur.data.ptr_val;
+            cur = src->cdr;
+        }
+    }
+
+    arena_t* arena = get_global_arena();
+    size_t alloc_size = (size_t)n * sizeof(eshkol_tagged_value_t) + 8;
+    void* vec = arena_allocate_with_header(arena, alloc_size, HEAP_SUBTYPE_VECTOR, 0);
+    if (!vec) return;
+
+    *(int64_t*)vec = n;
+    eshkol_tagged_value_t* elems =
+        (eshkol_tagged_value_t*)((char*)vec + 8);
+
+    if (list_tv) {
+        eshkol_tagged_value_t cur = *list_tv;
+        int64_t i = 0;
+        while (tagged_is_cons(&cur) && i < n) {
+            auto* src = (arena_tagged_cons_cell_t*)(uintptr_t)cur.data.ptr_val;
+            elems[i++] = src->car;
+            cur = src->cdr;
+        }
+    }
+
+    out->type = ESHKOL_VALUE_HEAP_PTR;
+    out->flags = 0;
+    out->reserved = 0;
+    out->data.ptr_val = (uint64_t)(uintptr_t)vec;
+}
+
 void eshkol_raise_index_oob(const char* op_name, int64_t idx, int64_t length) {
     eshkol_runtime_fatal(ESHKOL_EXCEPTION_ERROR,
                          "%s: index %lld out of bounds (length=%lld)",

--- a/lib/frontend/parser.cpp
+++ b/lib/frontend/parser.cpp
@@ -2098,6 +2098,38 @@ static eshkol_ast_t parse_quasiquoted_data_with_token(SchemeTokenizer& tokenizer
     if (token.type == TOKEN_LPAREN) {
         // Parse a list without requiring a symbol as first element
         return parse_quasiquoted_list_internal(tokenizer);
+    } else if (token.type == TOKEN_VECTOR_START) {
+        // Quasiquoted vector: `#(1 ,(+ 2 2) 3). R7RS §4.2.8 allows unquote /
+        // unquote-splicing inside a vector template. Parse each element as
+        // quasiquoted data (so ,expr / ,@expr become UNQUOTE(_SPLICING)_OP)
+        // and store them as a 1-D TENSOR_OP. codegenQuasiquote recognises the
+        // TENSOR_OP and materialises a Scheme vector, evaluating the unquotes.
+        std::vector<eshkol_ast_t> elements;
+        while (true) {
+            Token elem_token = tokenizer.nextToken();
+            if (elem_token.type == TOKEN_RPAREN) break;
+            if (elem_token.type == TOKEN_EOF) {
+                PARSE_ERROR_AT(elem_token,
+                    "unexpected end of input in quasiquoted vector #(...)");
+                return {.type = ESHKOL_INVALID};
+            }
+            eshkol_ast_t elem = parse_quasiquoted_data_with_token(tokenizer, elem_token);
+            if (elem.type == ESHKOL_INVALID) return elem;
+            elements.push_back(elem);
+        }
+        eshkol_ast_t ast = {};
+        ast.type = ESHKOL_OP;
+        ast.operation.op = ESHKOL_TENSOR_OP;
+        ast.operation.tensor_op.num_dimensions = 1;
+        ast.operation.tensor_op.dimensions = new uint64_t[1];
+        ast.operation.tensor_op.dimensions[0] = elements.size();
+        ast.operation.tensor_op.total_elements = elements.size();
+        ast.operation.tensor_op.elements =
+            elements.empty() ? nullptr : new eshkol_ast_t[elements.size()];
+        for (size_t i = 0; i < elements.size(); i++) {
+            ast.operation.tensor_op.elements[i] = elements[i];
+        }
+        return ast;
     } else if (token.type == TOKEN_COMMA) {
         // Unquote: ,expr escapes back to full expression mode. R7RS §4.2.8
         // says the body of an unquote is evaluated, so parse it the same way

--- a/tests/r7rs/reference_diff_fixes_test.esk
+++ b/tests/r7rs/reference_diff_fixes_test.esk
@@ -1,0 +1,59 @@
+;;; tests/r7rs/reference_diff_fixes_test.esk
+;;; R7RS conformance fixes found by the P7a reference-Scheme differential
+;;; (verified against chibi-scheme). Covers three bugs:
+;;;   ESH-0150 apply with leading args before the final list (was SIGSEGV)
+;;;   ESH-0151 multi-arg vector-map / vector-for-each (extra vectors ignored)
+;;;   ESH-0154 quasiquoted vector `#(...) with embedded unquote (no output)
+(require stdlib)
+
+(define pass 0)(define fail 0)
+(define (chk label v)
+  (display "  [") (display (if v "PASS" "FAIL")) (display "] ") (display label) (newline)
+  (if v (set! pass (+ pass 1)) (set! fail (+ fail 1))))
+
+(display "=== ESH-0150: apply with leading args ===") (newline)
+;; R7RS: (apply proc arg1 ... argN list) prepends arg1..argN onto list.
+(chk "apply + 0 leading"  (= (apply + '(3 4 5)) 12))
+(chk "apply + 1 leading"  (= (apply + 1 '(3 4 5)) 13))
+(chk "apply + 2 leading"  (= (apply + 1 2 '(3 4 5)) 15))
+(chk "apply + 3 leading"  (= (apply + 1 2 3 '(4 5)) 15))
+(chk "apply * leading"    (= (apply * 2 3 '(4)) 24))
+(chk "apply max leading"  (= (apply max 5 '(1 9 3)) 9))
+(chk "apply cons leading" (equal? (apply cons 1 '(2)) (cons 1 2)))
+(chk "apply list leading" (equal? (apply list 1 2 '(3 4)) '(1 2 3 4)))
+(chk "apply empty tail"   (= (apply + 1 2 3 '()) 6))
+(define (sub3 a b c) (- a b c))
+(chk "apply user fn"      (= (apply sub3 10 '(3 2)) 5))
+(chk "apply user fn 2lead" (= (apply sub3 10 3 '(2)) 5))
+(define (make-adder n) (lambda args (apply + n args)))
+(chk "apply captured proc" (= ((make-adder 100) 1 2 3) 106))
+
+(display "=== ESH-0151: multi-arg vector-map / vector-for-each ===") (newline)
+;; vector-map/quasiquote-vector produce R7RS (heterogeneous) Scheme vectors,
+;; which are equal? to (vector ...) but NOT to #(...) tensor literals (an
+;; Eshkol extension holding homogeneous doubles). Compare against (vector ...).
+(chk "vector-map 1 vec"   (equal? (vector-map (lambda (x) (* x x)) #(1 2 3)) (vector 1 4 9)))
+(chk "vector-map 2 vecs"  (equal? (vector-map + #(1 2 3) #(10 20 30)) (vector 11 22 33)))
+(chk "vector-map 3 vecs"  (equal? (vector-map + #(1 2 3) #(10 20 30) #(100 200 300)) (vector 111 222 333)))
+(chk "vector-map shortest" (equal? (vector-map * #(1 2 3 4) #(2 2 2)) (vector 2 4 6)))
+(chk "vector-map over (vector ...)" (equal? (vector-map + (vector 1 2) (vector 3 4)) (vector 4 6)))
+(define fe-sum 0)
+(vector-for-each (lambda (a b) (set! fe-sum (+ fe-sum (* a b)))) #(1 2 3) #(4 5 6))
+(chk "vector-for-each 2 vecs (dot product)" (= fe-sum 32))
+(define fe1 0)
+(vector-for-each (lambda (x) (set! fe1 (+ fe1 x))) #(1 2 3 4))
+(chk "vector-for-each 1 vec" (= fe1 10))
+
+(display "=== ESH-0154: quasiquoted vector ===") (newline)
+(define qv 4)
+(chk "qq vector unquote var"  (equal? `#(1 ,qv 3) (vector 1 4 3)))
+(chk "qq vector unquote expr" (equal? `#(1 ,(+ 2 2) ,(* 3 3)) (vector 1 4 9)))
+(chk "qq vector no unquote"   (equal? `#(1 2 3) (vector 1 2 3)))
+(chk "qq vector splice"       (equal? `#(1 ,@(list 2 3) 4) (vector 1 2 3 4)))
+(chk "qq vector nested"       (equal? `#(a #(1 ,(+ 1 1)) c) (vector 'a (vector 1 2) 'c)))
+(chk "qq vector symbols+unquote" (equal? `#(x ,qv z) (vector 'x 4 'z)))
+(chk "qq empty vector"        (equal? `#() (vector)))
+
+(display "Passed: ")(display pass)(newline)
+(display "Failed: ")(display fail)(newline)
+(if (> fail 0) (begin (display "^FAIL: ")(display fail)(display " checks failed")(newline)))


### PR DESCRIPTION
P7a reference-Scheme differential findings (PR #140), verified vs chibi-scheme.

- **ESH-0150** `(apply + 1 2 '(3 4 5))` SIGSEGV → 15: call_apply_codegen took variables[1] as the list, ignoring leading args; now conses leading args onto the final list arg.
- **ESH-0151** multi-arg `vector-map`/`vector-for-each` dropped extra vectors → now variadic to shortest length.
- **ESH-0154** quasiquoted vector ``#(1 ,(+ 2 2) 3)`` no output → parser+codegen+runtime handle vector templates.

Verified -r + AOT. SICP 88/88, differential 246/246, autodiff 54/54, list 129/129. New tests/r7rs/reference_diff_fixes_test.esk (26 checks).