### PR TITLE
feat(ad): P1 runtime Taylor tower + arbitrary-order derivative^n (closes ESH-0118)

### DIFF
--- a/.swarm/tasks/ESH-0186.json
+++ b/.swarm/tasks/ESH-0186.json
@@ -1,0 +1,48 @@
+{
+  "id": "ESH-0186",
+  "title": "AD Taylor-tower P1: HEAP_SUBTYPE_TAYLOR runtime heap tower + derivative^n (univariate) + epoch-tag scaffold",
+  "status": "done",
+  "priority": "high",
+  "workstream": "ad-taylor-tower/P1-runtime-tower",
+  "goal": "Implement the runtime heap tower per docs/design/AD_TAYLOR_TOWER.md sec 4-5. Add HEAP_SUBTYPE_TAYLOR tagged heap subtype with esh_taylor_t header (order_k, flags with COEFF_MASK+EPOCH_TAG bitfields, coeff storage). New lib/core/runtime_taylor.c with the recurrence kernels driven by the shared taylor_recurrences.def X-macro table (sec 5b). Wire derivative^n (univariate) through the tower for order>=3. Seed epoch tags in flags for perturbation-confusion safety (sec 5a). This closes ESH-0118 (derivative^n=0 for n>=3).",
+  "file_globs": [
+    "lib/core/runtime_taylor.c",
+    "lib/core/taylor_recurrences.def",
+    "lib/backend/autodiff_codegen.cpp",
+    "lib/backend/arithmetic_codegen.cpp",
+    "lib/backend/llvm_codegen.cpp",
+    "lib/frontend/parser.cpp",
+    "inc/eshkol/**"
+  ],
+  "acceptance": [
+    "scripts/run_ad_depth.sh: derivative^d PASS to d=8 -> closes ESH-0118",
+    "nested-AD perturbation-confusion suite PASS (analytic-answer nested derivative/gradient cases)",
+    "taylor_recurrences.def is the single source of truth for the primitives (sec 5b)",
+    "AD oracle 56/56 and SICP 88/88 unchanged; JET4/JET8 hot path unchanged",
+    "icc readiness ad_depth criterion PASS after regenerating scripts/icc_traces"
+  ],
+  "blocked_by": ["ESH-0185"],
+  "campaign_payoff": "Arbitrary-order univariate derivatives become exact; removes the fixed-2-level jet ceiling.",
+  "delivered": {
+    "representation": "HEAP_SUBTYPE_TAYLOR=23 + esh_taylor_t{order_k,flags,c[]} (inc/eshkol/eshkol.h); flags carry COEFF_MASK[0..7] + EPOCH_TAG[16..31].",
+    "runtime_kernel": "lib/core/runtime_taylor.c: add/sub/mul/div/pow + neg/exp/log/sin/cos/tan/sqrt/abs/sinh/cosh/tanh recurrences ported from the POC, explicit fma() FP-contraction (design sec 6a), epoch-tagged operand normalisation (sec 5a). Tagged dispatch: eshkol_is_taylor_tagged / eshkol_taylor_binary_tagged / eshkol_taylor_unary_tagged; seed/extract/coeffs/shift helpers.",
+    "codegen_dispatch": "Taylor operands intercepted before the heap/tensor path in +,-,*,/,pow (arithmetic_codegen.cpp) and in the unary math builtins exp/log/sin/cos/tan/sqrt/fabs/sinh/cosh/tanh (llvm_codegen.cpp codegenMathFunction); extractAsDouble coerces a tower to c[0]; findFreeVariablesImpl handles the new ops.",
+    "api": "(taylor f x k) -> list of K+1 coefficients; (derivative-n f x k) -> f^(k)(x)=k!*c[k]. k may be a runtime value. Nested `derivative` chains of depth>=3 are detected and routed through derivative-n (order<=2 stays byte-for-byte on the existing 4-comp jet).",
+    "tests": "tests/ad/taylor_tower_test.esk (52 checks: x^5, sin, exp, log(1+x), 1/(1-x) to n=8 + taylor coeffs + nested-safety + high-order), PASS under both -r and AOT."
+  },
+  "remainder": [
+    "((derivative-n k) f) curried / (derivative f #:order k) keyword sugar not added (direct (derivative-n f x k) form shipped instead).",
+    "Full cross-variable perturbation confusion at order>=3 (a foreign-epoch tower is lifted to its c[0] constant per design sec 5a; order<=2 cross terms remain exact on the jet). Unified confusion model across tiers is P3 (ESH-0188).",
+    "P2 compile-time-K monomorphization / unrolled-IR emitter (ESH-0187) — the taylor_recurrences.def IR_EMIT column is reserved for it.",
+    "COEFF_RATIONAL/COEFF_TENSOR coefficient types are laid out in flags but are P6/P7."
+  ],
+  "verifications": [
+    {
+      "sweep": "P1",
+      "date": "2026-07-04",
+      "branch": "feat/ad-taylor-p1-runtime-tower",
+      "verdict": "closed",
+      "evidence": "taylor_tower_test.esk 52/52 PASS (-r + AOT), derivative^n exact to n=8 for x^5/sin/exp/log(1+x)/1/(1-x). Nested derivative^d PASS to d=8 (x^8 d3=336, exp d5=1). AD oracle 56/56 PASS; depth oracle regenerated."
+    }
+  ]
+}

--- a/AD_DEPTH_REPORT.md
+++ b/AD_DEPTH_REPORT.md
@@ -11,15 +11,30 @@ Every AD value is swept at nesting depth **d = 1..8** and checked against a **cl
 
 | composition | capture | MCD | tracked |
 |---|---|---|---|
-| deriv | capnone | 2 | ESH-0118 |
-| deriv | glob | 2 | ESH-0118 |
-| deriv | localparam | 1 | ESH-0122 |
-| deriv | vecref | 1 | ESH-0122 |
-| gofd | vecref | 1 | ESH-0117 |
-| gradn | capnone | 2 | ESH-0118 |
+| deriv | capnone | 8 | ESH-0118 |
+| deriv | glob | 8 | ESH-0118 |
+| deriv | localparam | 8 | ESH-0122 |
+| deriv | vecref | 8 | ESH-0122 |
+| gofd | vecref | 2 | ESH-0117 |
+| gradn | capnone | 3 | ESH-0118 |
 | gradn | vecref | 1 | ESH-0122 |
 | hessod | vecref | 0 | ESH-0121 |
 | jacod | vecref | 0 | ESH-0120 |
+
+## ✅ Improvements over baseline (fix landed)
+
+- `gofd.mono.v2.inline.vecref`: max-depth **2** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
+- `gofd.mono.v2.named.vecref`: max-depth **2** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
+- `gofd.mono.v3.inline.vecref`: max-depth **2** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
+- `gofd.mono.v3.named.vecref`: max-depth **2** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
+- `gofd.poly.v2.inline.vecref`: max-depth **2** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
+- `gofd.poly.v2.named.vecref`: max-depth **2** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
+- `gofd.poly.v3.inline.vecref`: max-depth **2** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
+- `gofd.poly.v3.named.vecref`: max-depth **2** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
+- `gradn.expc.s.inline.capnone`: max-depth **3** > baseline **2** (update BASELINE in ad_depth_report.py once confirmed)
+- `gradn.expc.s.named.capnone`: max-depth **3** > baseline **2** (update BASELINE in ad_depth_report.py once confirmed)
+- `gradn.mono.s.inline.capnone`: max-depth **3** > baseline **2** (update BASELINE in ad_depth_report.py once confirmed)
+- `gradn.mono.s.named.capnone`: max-depth **3** > baseline **2** (update BASELINE in ad_depth_report.py once confirmed)
 
 ## Per-cell depth tables
 
@@ -28,78 +43,78 @@ Every AD value is swept at nesting depth **d = 1..8** and checked against a **cl
 
 | cell | lane | d1 | d2 | d3 | d4 | d5 | d6 | d7 | d8 | MCD |
 |---|---|---|---|---|---|---|---|---|---|---|
-| `deriv.expc.s.inline.capnone` | jit | P | P | F | F | F | F | F | F | **2** |
-| `deriv.expc.s.inline.capnone` | aot | P | P | F | F | F | F | F | F | **2** |
-| `deriv.expc.s.inline.glob` | jit | P | P | F | F | F | F | F | F | **2** |
-| `deriv.expc.s.inline.glob` | aot | P | P | F | F | F | F | F | F | **2** |
-| `deriv.expc.s.inline.localparam` | jit | P | F | F | F | F | F | F | F | **1** |
-| `deriv.expc.s.inline.localparam` | aot | P | F | F | F | F | F | F | F | **1** |
-| `deriv.expc.s.inline.vecref` | jit | P | F | F | F | F | F | F | F | **1** |
-| `deriv.expc.s.inline.vecref` | aot | P | F | F | F | F | F | F | F | **1** |
-| `deriv.expc.s.lamvar.capnone` | jit | P | P | F | F | F | F | F | F | **2** |
-| `deriv.expc.s.lamvar.capnone` | aot | P | P | F | F | F | F | F | F | **2** |
-| `deriv.expc.s.named.capnone` | jit | P | P | F | F | F | F | F | F | **2** |
-| `deriv.expc.s.named.capnone` | aot | P | P | F | F | F | F | F | F | **2** |
-| `deriv.mono.s.inline.capnone` | jit | P | P | F | F | F | F | F | F | **2** |
-| `deriv.mono.s.inline.capnone` | aot | P | P | F | F | F | F | F | F | **2** |
-| `deriv.mono.s.inline.glob` | jit | P | P | F | F | F | F | F | F | **2** |
-| `deriv.mono.s.inline.glob` | aot | P | P | F | F | F | F | F | F | **2** |
-| `deriv.mono.s.inline.localparam` | jit | P | F | F | F | F | F | F | F | **1** |
-| `deriv.mono.s.inline.localparam` | aot | P | F | F | F | F | F | F | F | **1** |
-| `deriv.mono.s.inline.vecref` | jit | P | F | F | F | F | F | F | F | **1** |
-| `deriv.mono.s.inline.vecref` | aot | P | F | F | F | F | F | F | F | **1** |
-| `deriv.mono.s.lamvar.capnone` | jit | P | P | F | F | F | F | F | F | **2** |
-| `deriv.mono.s.lamvar.capnone` | aot | P | P | F | F | F | F | F | F | **2** |
-| `deriv.mono.s.named.capnone` | jit | P | P | F | F | F | F | F | F | **2** |
-| `deriv.mono.s.named.capnone` | aot | P | P | F | F | F | F | F | F | **2** |
-| `deriv.poly.s.inline.capnone` | jit | P | P | F | F | F | F | F | F | **2** |
-| `deriv.poly.s.inline.capnone` | aot | P | P | F | F | F | F | F | F | **2** |
-| `deriv.poly.s.lamvar.capnone` | jit | P | P | F | F | F | F | F | F | **2** |
-| `deriv.poly.s.lamvar.capnone` | aot | P | P | F | F | F | F | F | F | **2** |
-| `deriv.poly.s.named.capnone` | jit | P | P | F | F | F | F | F | F | **2** |
-| `deriv.poly.s.named.capnone` | aot | P | P | F | F | F | F | F | F | **2** |
-| `deriv.sinc.s.inline.capnone` | jit | P | P | F | F | F | F | F | F | **2** |
-| `deriv.sinc.s.inline.capnone` | aot | P | P | F | F | F | F | F | F | **2** |
-| `deriv.sinc.s.lamvar.capnone` | jit | P | P | F | F | F | F | F | F | **2** |
-| `deriv.sinc.s.lamvar.capnone` | aot | P | P | F | F | F | F | F | F | **2** |
-| `deriv.sinc.s.named.capnone` | jit | P | P | F | F | F | F | F | F | **2** |
-| `deriv.sinc.s.named.capnone` | aot | P | P | F | F | F | F | F | F | **2** |
+| `deriv.expc.s.inline.capnone` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.expc.s.inline.capnone` | aot | P | P | P | P | P | P | P | P | **8** |
+| `deriv.expc.s.inline.glob` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.expc.s.inline.glob` | aot | P | P | P | P | P | P | P | P | **8** |
+| `deriv.expc.s.inline.localparam` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.expc.s.inline.localparam` | aot | P | P | P | P | P | P | P | P | **8** |
+| `deriv.expc.s.inline.vecref` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.expc.s.inline.vecref` | aot | P | P | P | P | P | P | P | P | **8** |
+| `deriv.expc.s.lamvar.capnone` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.expc.s.lamvar.capnone` | aot | P | P | P | P | P | P | P | P | **8** |
+| `deriv.expc.s.named.capnone` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.expc.s.named.capnone` | aot | P | P | P | P | P | P | P | P | **8** |
+| `deriv.mono.s.inline.capnone` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.mono.s.inline.capnone` | aot | P | P | P | P | P | P | P | P | **8** |
+| `deriv.mono.s.inline.glob` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.mono.s.inline.glob` | aot | P | P | P | P | P | P | P | P | **8** |
+| `deriv.mono.s.inline.localparam` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.mono.s.inline.localparam` | aot | P | P | P | P | P | P | P | P | **8** |
+| `deriv.mono.s.inline.vecref` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.mono.s.inline.vecref` | aot | P | P | P | P | P | P | P | P | **8** |
+| `deriv.mono.s.lamvar.capnone` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.mono.s.lamvar.capnone` | aot | P | P | P | P | P | P | P | P | **8** |
+| `deriv.mono.s.named.capnone` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.mono.s.named.capnone` | aot | P | P | P | P | P | P | P | P | **8** |
+| `deriv.poly.s.inline.capnone` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.poly.s.inline.capnone` | aot | P | P | P | P | P | P | P | P | **8** |
+| `deriv.poly.s.lamvar.capnone` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.poly.s.lamvar.capnone` | aot | P | P | P | P | P | P | P | P | **8** |
+| `deriv.poly.s.named.capnone` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.poly.s.named.capnone` | aot | P | P | P | P | P | P | P | P | **8** |
+| `deriv.sinc.s.inline.capnone` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.sinc.s.inline.capnone` | aot | P | P | P | P | P | P | P | P | **8** |
+| `deriv.sinc.s.lamvar.capnone` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.sinc.s.lamvar.capnone` | aot | P | P | P | P | P | P | P | P | **8** |
+| `deriv.sinc.s.named.capnone` | jit | P | P | P | P | P | P | P | P | **8** |
+| `deriv.sinc.s.named.capnone` | aot | P | P | P | P | P | P | P | P | **8** |
 
 ### gofd
 
 | cell | lane | d1 | d2 | d3 | d4 | d5 | d6 | d7 | d8 | MCD |
 |---|---|---|---|---|---|---|---|---|---|---|
-| `gofd.mono.v2.inline.vecref` | jit | P | F | F | F | F | F | F | F | **1** |
-| `gofd.mono.v2.inline.vecref` | aot | P | F | F | F | F | F | F | F | **1** |
-| `gofd.mono.v2.named.vecref` | jit | P | F | F | F | F | F | F | F | **1** |
-| `gofd.mono.v2.named.vecref` | aot | P | F | F | F | F | F | F | F | **1** |
-| `gofd.mono.v3.inline.vecref` | jit | P | F | F | F | F | F | F | F | **1** |
-| `gofd.mono.v3.inline.vecref` | aot | P | F | F | F | F | F | F | F | **1** |
-| `gofd.mono.v3.named.vecref` | jit | P | F | F | F | F | F | F | F | **1** |
-| `gofd.mono.v3.named.vecref` | aot | P | F | F | F | F | F | F | F | **1** |
-| `gofd.poly.v2.inline.vecref` | jit | P | F | F | F | F | F | F | F | **1** |
-| `gofd.poly.v2.inline.vecref` | aot | P | F | F | F | F | F | F | F | **1** |
-| `gofd.poly.v2.named.vecref` | jit | P | F | F | F | F | F | F | F | **1** |
-| `gofd.poly.v2.named.vecref` | aot | P | F | F | F | F | F | F | F | **1** |
-| `gofd.poly.v3.inline.vecref` | jit | P | F | F | F | F | F | F | F | **1** |
-| `gofd.poly.v3.inline.vecref` | aot | P | F | F | F | F | F | F | F | **1** |
-| `gofd.poly.v3.named.vecref` | jit | P | F | F | F | F | F | F | F | **1** |
-| `gofd.poly.v3.named.vecref` | aot | P | F | F | F | F | F | F | F | **1** |
+| `gofd.mono.v2.inline.vecref` | jit | P | P | F | F | F | F | F | F | **2** |
+| `gofd.mono.v2.inline.vecref` | aot | P | P | F | F | F | F | F | F | **2** |
+| `gofd.mono.v2.named.vecref` | jit | P | P | F | F | F | F | F | F | **2** |
+| `gofd.mono.v2.named.vecref` | aot | P | P | F | F | F | F | F | F | **2** |
+| `gofd.mono.v3.inline.vecref` | jit | P | P | F | F | F | F | F | F | **2** |
+| `gofd.mono.v3.inline.vecref` | aot | P | P | F | F | F | F | F | F | **2** |
+| `gofd.mono.v3.named.vecref` | jit | P | P | F | F | F | F | F | F | **2** |
+| `gofd.mono.v3.named.vecref` | aot | P | P | F | F | F | F | F | F | **2** |
+| `gofd.poly.v2.inline.vecref` | jit | P | P | F | F | F | F | F | F | **2** |
+| `gofd.poly.v2.inline.vecref` | aot | P | P | F | F | F | F | F | F | **2** |
+| `gofd.poly.v2.named.vecref` | jit | P | P | F | F | F | F | F | F | **2** |
+| `gofd.poly.v2.named.vecref` | aot | P | P | F | F | F | F | F | F | **2** |
+| `gofd.poly.v3.inline.vecref` | jit | P | P | F | F | F | F | F | F | **2** |
+| `gofd.poly.v3.inline.vecref` | aot | P | P | F | F | F | F | F | F | **2** |
+| `gofd.poly.v3.named.vecref` | jit | P | P | F | F | F | F | F | F | **2** |
+| `gofd.poly.v3.named.vecref` | aot | P | P | F | F | F | F | F | F | **2** |
 
 ### gradn
 
 | cell | lane | d1 | d2 | d3 | d4 | d5 | d6 | d7 | d8 | MCD |
 |---|---|---|---|---|---|---|---|---|---|---|
-| `gradn.expc.s.inline.capnone` | jit | P | P | F | F | F | F | F | F | **2** |
-| `gradn.expc.s.inline.capnone` | aot | P | P | F | F | F | F | F | F | **2** |
-| `gradn.expc.s.named.capnone` | jit | P | P | F | F | F | F | F | F | **2** |
-| `gradn.expc.s.named.capnone` | aot | P | P | F | F | F | F | F | F | **2** |
-| `gradn.mono.s.inline.capnone` | jit | P | P | F | F | F | F | F | F | **2** |
-| `gradn.mono.s.inline.capnone` | aot | P | P | F | F | F | F | F | F | **2** |
+| `gradn.expc.s.inline.capnone` | jit | P | P | P | F | F | F | F | F | **3** |
+| `gradn.expc.s.inline.capnone` | aot | P | P | P | F | F | F | F | F | **3** |
+| `gradn.expc.s.named.capnone` | jit | P | P | P | F | F | F | F | F | **3** |
+| `gradn.expc.s.named.capnone` | aot | P | P | P | F | F | F | F | F | **3** |
+| `gradn.mono.s.inline.capnone` | jit | P | P | P | F | F | F | F | F | **3** |
+| `gradn.mono.s.inline.capnone` | aot | P | P | P | F | F | F | F | F | **3** |
 | `gradn.mono.s.inline.vecref` | jit | P | F | F | F | F | F | F | F | **1** |
 | `gradn.mono.s.inline.vecref` | aot | P | F | F | F | F | F | F | F | **1** |
-| `gradn.mono.s.named.capnone` | jit | P | P | F | F | F | F | F | F | **2** |
-| `gradn.mono.s.named.capnone` | aot | P | P | F | F | F | F | F | F | **2** |
+| `gradn.mono.s.named.capnone` | jit | P | P | P | F | F | F | F | F | **3** |
+| `gradn.mono.s.named.capnone` | aot | P | P | P | F | F | F | F | F | **3** |
 
 ### hessod
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1508,6 +1508,7 @@ set(ESHKOL_RUNTIME_CORE_SRC
   lib/core/runtime_shared_memory.cpp
   lib/core/runtime_string.cpp
   lib/core/runtime_tagged_cons.cpp
+  lib/core/runtime_taylor.c
   lib/core/runtime_tensor_alloc.cpp
   lib/core/runtime_tensor_dtype.cpp
   lib/core/runtime_tensor_quant.cpp

--- a/docs/design/AD_TAYLOR_TOWER.md
+++ b/docs/design/AD_TAYLOR_TOWER.md
@@ -1,0 +1,485 @@
+# Eshkol Arbitrary-Order Automatic Differentiation — Taylor-Tower Design
+
+**Status:** proposal (design + Phase-0 POC landed; P1–P12 tracked in the ledger)
+**Supersedes ceiling:** ESH-0118 (forward jet fixed at 2 perturbation levels → `derivative^n`/`gradient^n` = 0 for n ≥ 3)
+**Builds on / subsumes:** PR #138 (8-component jet for reverse-over-nested-forward, ESH-0117)
+**Author:** tsotchke
+**Target:** post-v1.3.0-evolve (not a tag blocker — #138 already handles the reported order-≤2 nested case)
+**Ledger:** ESH-0185 (P0, done) · ESH-0186..0197 (P1..P12, open)
+
+---
+
+## 0. Decision (TL;DR)
+
+Adopt **univariate truncated-Taylor arithmetic** (a coefficient array to order K, computed via closed recurrences) as the single computational kernel for all high-order AD. Layer the following on top of that one kernel — and, per the "build in full" mandate, ship every layer as a real, gated phase rather than deferring any of them:
+
+1. **Compile-time-K monomorphization as the primary path** — when the requested order is a literal at the call site (the overwhelmingly common case in a compiler), emit the entire tower as unrolled, stack-allocated, branch-free SSA IR. **Zero heap allocation in AD hot loops.** Runtime-K heap towers are the correctness fallback for dynamic order.
+2. **Perturbation-confusion safety** — each active differentiation context gets a distinct epoch **tag** carried in the tower's reserved `flags` word, so nested `derivative`/`gradient` cannot silently cross-contaminate (§5a).
+3. **Exact-coefficient towers** — a coefficient-type flag (`double` vs `rational`/`bignum`) is designed into the layout now, so high-order derivatives of polynomial/rational functions can be *exact*, reusing Eshkol's rational dispatch (§4, Phase P6).
+4. **One FP-contraction policy across both tiers** — the unrolled-IR tier and the runtime-loop tier use the *same* contraction rule so `mono ≡ runtime` is bit-exact-achievable (§6a).
+5. **Tensor-valued towers** — tower coefficients generalize from scalars to tensors so high-order AD covers the ML path (conv2d / attention / batchnorm / layernorm gradients). Built, not deferred (Phase P7).
+6. **Griewank–Utke–Walther (GUW) directional interpolation** for arbitrary-order *multivariate* mixed partials (Phase P4), and **Taylor models** (validated AD with rigorous interval remainder) as a later phase (P8).
+7. **Self-verifying recurrence table** — the shared X-macro table `taylor_recurrences.def` generates the emitter, the runtime kernel, *and* a per-primitive analytic d=8 correctness test, so adding a primitive auto-adds its gate (§5b).
+8. **Structural back-compat** — order ≤ 2 keeps the existing 4-component jet byte-for-byte; the tower is a separate tagged representation selected only when order ≥ 3 is requested.
+9. **Frontier differentiable programming** — after the numeric kernel is complete, P9–P12 lift it through Eshkol control flow, memory-efficient high-order reverse, user-facing series numerics, and sparse high-order tensors. That makes AD a property of the language, not just a property of scalar kernels.
+
+This is the JAX-`jet` / Griewank & Walther approach, specialized to exploit that Eshkol is an AOT compiler rather than a runtime tracer, and hardened with perturbation tags, exact coefficients, tensor coefficients, validated (Taylor-model) arithmetic, and full differentiable-programming integration.
+
+---
+
+## 1. Problem
+
+Eshkol forward-mode AD uses a fixed **4-component jet**:
+
+```
+{ value, d1·e1, d2·e2, d12·e1·e2 }   // exactly TWO perturbation levels
+```
+
+So `derivative^n` / `gradient^n` return an exact **0** at order ≥ 3 (ESH-0118, found by the P6a depth oracle, PR #133). PR #138 extended the live jet to **8 components** (adding a third ε level) to fix reverse-over-nested-forward (ESH-0117), but 8 = 2³ is the **hyper-dual wall**: each additional order *doubles* the struct. It cannot scale to arbitrary order.
+
+We need exact derivatives to arbitrary order n, without exponential blowup, without regressing the order-≤2 hot path or the mixed-mode/reverse work in PRs #37/#39/#48/#84/#95/#113/#117/#138, and without the silent-wrong-nested-gradient trap (§5a).
+
+---
+
+## 2. Goals & non-goals
+
+**Goals**
+- Exact (to machine precision, or *bit-exact* on the rational/bignum path) `derivative^n` for arbitrary n.
+- Exact `gradient`, `hessian`, `laplacian`, `directional` (order ≤ 2 unchanged; higher via GUW).
+- **Correct nested differentiation** — no perturbation confusion, ever (§5a).
+- No heap allocation on the common (literal-order) path.
+- Order ≤ 2 semantics and performance strictly unchanged.
+- Coverage of the ML AD path (tensor-valued towers) and rigorous enclosures (Taylor models).
+- Every phase independently verifiable against the P6a oracle (`scripts/run_ad_depth.sh`, to d=8) and wired into the ICC release oracle.
+
+**Non-goals (explicit)**
+- Complex-domain Taylor / multicomplex — out of scope.
+- Dense high-order *mixed* tensor *storage* API beyond GUW recovery remains a non-goal for the dense case; P12 adds sparse storage/recovery for structurally sparse tensors.
+
+---
+
+## 3. Alternatives considered
+
+| Approach | Order-K cost | Verdict |
+|---|---|---|
+| **Nested dual / hyper-dual** | **2^K** components | Rejected — exponential; PR #138's 8-jet is already the 2³ wall |
+| **Multicomplex** | ~2^K | Rejected — exponential, analytic-only |
+| **Symbolic differentiation** | blows up | Rejected — not viable in a numeric compiler |
+| **Finite differences** | cheap | Rejected — catastrophic cancellation at high order, inexact |
+| **Truncated Taylor-mode** | **K+1** coeffs, O(K²) ops | **CHOSEN** — closed recurrences, exact, standard (Griewank & Walther Ch. 13; JAX `jax.experimental.jet`) |
+
+Taylor-mode is the only exact method that is polynomial (not exponential) in the order. This is settled AD theory; the design work is the *Eshkol integration*, below.
+
+---
+
+## 4. Representation
+
+Selected by requested order and whether that order is a compile-time literal:
+
+| Tier | When | Storage | Recurrences |
+|---|---|---|---|
+| `AD_JET4` (existing) | order ≤ 2 | 4-field struct — **hot path, unchanged** | existing |
+| `AD_JET8` (PR #138) | reverse-over-nested-forward, transitional | 8-field struct | existing; **subsumed in Phase 3** |
+| `AD_TAYLOR` **stack** (primary new) | order ≥ 3, **K literal at call site** | `[K+1 x double]` alloca / SSA values — **no heap** | **unrolled** straight-line IR |
+| `AD_TAYLOR` **heap** (fallback) | order dynamic (K not statically known) | `HEAP_SUBTYPE_TAYLOR` arena block | runtime loops |
+
+**Heap layout** (mirrors `HEAP_SUBTYPE_TENSOR`, which stores homogeneous doubles as int64 bitpatterns). The coefficient-type flag (enhancement #2) and the perturbation tag (enhancement #1) are designed into the header **now**, so no re-layout is needed when P6/P7 land:
+
+```c
+// arena block behind a tagged HEAP_PTR with subtype HEAP_SUBTYPE_TAYLOR
+typedef struct {
+    uint32_t order_k;      // K: highest coefficient index (series has K+1 entries)
+    uint32_t flags;        // packed: see bitfield below
+    // coefficient storage follows, laid out per (flags & COEFF_MASK):
+    //   COEFF_F64      : double        c[K+1]        (default, fast)
+    //   COEFF_RATIONAL : esh_value_t   c[K+1]        (tagged rational/bignum, EXACT — P6)
+    //   COEFF_TENSOR   : esh_value_t   c[K+1]        (each a HEAP_SUBTYPE_TENSOR ptr — P7)
+    // (accessed through helpers; never raw-indexed across coeff types)
+    union { double f64[/*K+1*/]; uint64_t bits[/*K+1*/]; } c;
+} esh_taylor_t;
+```
+
+`flags` bitfield (the reserved word is now fully specified — see §5a for the tag):
+
+```
+bits [0..7]   COEFF_MASK    coefficient type: 0=F64, 1=RATIONAL, 2=TENSOR   (enh #2, #4)
+bits [8..15]  RESERVED0     (dtype/rank hint for TENSOR coeffs; 0 otherwise)
+bits [16..31] EPOCH_TAG     perturbation-confusion tag of the owning
+                            differentiation context (enh #1, §5a)
+```
+
+Series semantics: `f(x₀ + t) = Σ_{k=0..K} c_k · t^k`, hence `f^(n)(x₀) = n! · c_n`.
+
+**Tagged-value integration:** a Taylor value is a tagged `HEAP_PTR` with subtype `HEAP_SUBTYPE_TAYLOR` (new heap subtype constant). The tag byte / heap-subtype dispatch already exists for tensors, vectors, complex, bignum, rational — this adds one more. The 16-byte tagged value's data field `{4}` holds the arena pointer (per [[reference-architecture]]).
+
+**Why runtime-K in the tag, but compile-time-K preferred:** K lives in the struct so dynamic-order calls work; but the *primary* path never allocates this struct — see §6.
+
+---
+
+## 5. The recurrence kernel
+
+For input series `u`, `w` → result series `s`, all O(K) or O(K²):
+
+```
+mul   s = u*w        : s_k = Σ_{j=0..k} u_j · w_{k-j}                       (Cauchy convolution)
+div   s = u/w        : s_k = ( u_k − Σ_{j=1..k} w_j · s_{k-j} ) / w_0
+exp   s = exp(u)     : s_k = (1/k) Σ_{j=1..k} j · u_j · s_{k-j}
+log   s = log(u)     : s_k = ( u_k − (1/k) Σ_{j=1..k-1} j · s_j · u_{k-j} ) / u_0
+sin/cos (coupled)    : s_k = (1/k) Σ_{j=1..k} j · u_j · c_{k-j}
+                       c_k = −(1/k) Σ_{j=1..k} j · u_j · s_{k-j}
+pow   s = u^r        : s_k = (1/(k·u_0)) Σ_{j=1..k} (j·r − (k−j)) · u_j · s_{k-j}
+sqrt, tan, atan, tanh, exp2, expm1, log1p : derived from the above / their own linear recurrences
+```
+
+Add/sub/scale are elementwise. Constants seed `c = {value, 0, 0, …}`; the differentiation variable seeds `c = {x₀, 1, 0, …}`.
+
+All recurrences above are **verified numerically in the Phase-0 POC** (`tests/ad_taylor_poc/taylor_poc.c`) to d=8 at rel-err < 1e-12 (see §15).
+
+### 5a. Perturbation-confusion safety (enhancement #1)
+
+Nested differentiation such as
+
+```scheme
+(derivative (lambda (x) ((derivative g) x)))
+```
+
+is the classic **perturbation-confusion** trap: if the inner and outer differentiations share a perturbation, the outer derivative silently absorbs the inner one and you get a *wrong* gradient with no error. This is the Siskind–Pearlmutter problem; JAX solves it with per-trace *levels*. Eshkol adopts the same discipline, mechanized through the tower header:
+
+- **Epoch tags.** Every dynamically-active differentiation context is assigned a distinct 16-bit **epoch tag** (a monotonically increasing counter per nesting entry, wrapping is a hard error). The tag is written into `flags[16..31]` (§4) of every tower seeded within that context. Compile-time-monomorphized towers carry the tag as an immediate constant in the emitted IR (a `constexpr` level id per lexical `derivative` site), so there is no runtime counter on the hot path.
+- **Tag-gated combination.** Binary ops (`mul`, `div`, …) only *combine perturbations* of towers whose epoch tag equals the current context's tag. A tower carrying a **foreign** tag (an inner or outer level) is treated as a **constant** with respect to the current level: its order-≥1 coefficients are not differentiated at this level — the op uses only its `c[0]` value, exactly as a plain scalar would be. This is precisely JAX's "lift a value from an outer trace as a constant."
+- **Seeding & extraction.** `seedDerivativeInput` stamps the current tag; `extractDerivativeResult` asserts the extracted tower's tag matches the requesting context and refuses (compile error for literal order; runtime trap for dynamic) on mismatch, so a leaked inner tower can never be silently read as an outer result.
+- **Interaction with JET4/JET8.** The existing e1/e2 (and #138 e3) perturbation levels are the tag mechanism at orders ≤ 2 already; the tower generalizes the same idea to n levels. During P3, JET8's implicit levels are re-expressed as explicit tags so there is one confusion model across all tiers.
+
+**Gate:** a dedicated nested-AD confusion suite — `(derivative (λ(x) (* x ((derivative (λ(y) (* x y))) 2))))` and friends — whose analytic answers are known, plus the existing P6a nested cells to d=8. A confusion bug shows up as an off-by-a-term derivative and is caught by the analytic reference.
+
+### 5b. Self-verifying recurrence table (enhancement #5)
+
+The recurrences live in a single X-macro table, **`taylor_recurrences.def`**, which is the *only* source of truth. It is consumed three ways:
+
+```c
+// taylor_recurrences.def  — one line per primitive
+//   TAYLOR_OP(name, arity, RUNTIME_BODY, IR_EMIT_BODY, TEST_FN, TEST_X0, TEST_ORDER)
+TAYLOR_OP(exp, 1, TR_EXP_LOOP, TR_EXP_EMIT, exp,        0.5, 8)
+TAYLOR_OP(log, 1, TR_LOG_LOOP, TR_LOG_EMIT, log,        1.3, 8)
+TAYLOR_OP(sin, 1, TR_SIN_LOOP, TR_SIN_EMIT, sin,        0.7, 8)
+// ... etc
+```
+
+Three expansions of the same table:
+1. **Runtime kernel** (`runtime_taylor.c`) — expands `RUNTIME_BODY` into the heap-loop implementation.
+2. **IR emitter** (`autodiff_codegen.cpp`) — expands `IR_EMIT_BODY` into the unrolled LLVM builder calls.
+3. **Auto-generated test** (`taylor_recurrences_test.c`, generated at build) — for each row, seeds `x` at `TEST_X0`, runs the tower to `TEST_ORDER`, and compares `k!·c_k` against `k`-th finite-order derivative of the C-library `TEST_FN` (obtained via a high-precision reference: exact for polynomials/rationals, and via the *coupled* analytic derivative pattern for transcendentals) at rel-err < 1e-12.
+
+Consequence: **adding a primitive is a one-line table edit that automatically adds its d=8 correctness gate.** You cannot merge a recurrence without its test.
+
+---
+
+## 6. Compile-time-K monomorphization (primary path)
+
+The Eshkol-specific win. Because we compile ahead-of-time and `derivative^n` / `((derivative-n k) f)` almost always has a **literal** k at the call site:
+
+- Codegen detects a compile-time-constant order K.
+- It allocates the tower as an LLVM `[K+1 x double]` on the stack (or as SSA values) — **no arena, no heap**.
+- Each recurrence is **fully unrolled** into straight-line IR (the sums become explicit FMA chains — see §6a). No loops, no branches, no dispatch inside the AD computation.
+- The epoch tag (§5a) is an IR immediate, so perturbation safety costs nothing at runtime here.
+- Result: for constant K the entire n-th-derivative computation is branch-free numeric IR — competitive with or faster than a runtime tracer like JAX.
+
+**Fallback:** when K is genuinely dynamic (e.g. `((derivative-n user-input) f)`), emit a call into the runtime heap-tower kernels (§4 heap tier, §5 loops).
+
+**Correctness invariant (a gate):** for every K, the monomorphized result must equal the runtime result **bit-for-bit** — see the contraction policy below, which is what makes bit-exactness achievable rather than merely tight-ULP.
+
+### 6a. FP-contraction policy (enhancement #3)
+
+The convolution sums in §5 are dot products, and whether the compiler fuses `a*b + c` into a single `fma` changes the last bit. If the unrolled IR tier fused while the runtime-loop tier did not (or vice-versa), `mono(K)` and `runtime(K)` would differ by a few ULP and the metamorphic gate could only be a tolerance, not equality. Policy, applied to **both** tiers identically:
+
+- **Emit explicit `llvm.fma.f64` for every multiply-accumulate in the convolution recurrences, in both the unrolled IR and the runtime kernel** (the runtime kernel is compiled with the same explicit `fma` calls — via `std::fma` / `fma()` — not left to the C compiler's `-ffp-contract` default). Reduction order is fixed to ascending `j` in both tiers.
+- Equivalently stated as the single knob: **contraction ON and identical** across tiers, associativity fixed. (The alternative — `-ffp-contract=off` in both — is documented as the fallback if a target lacks fast `fma`; it also yields bit-exactness because neither tier then fuses.)
+- Because both tiers now perform the *same* operations in the *same* order, `mono(K) ≡ runtime(K)` is **bit-exact**, and that is the P2 gate. Should a target ever be unable to honor identical contraction (e.g. a soft-float lib without `fma`), the gate degrades to a documented `≤ 2 ULP` bound and CI records which mode is in force.
+
+**Files:** `lib/backend/autodiff_codegen.cpp` (the emitter + dispatch; extends `makeDual4`/`dualAdd`/`dualMul`/`dualField`/`seedDerivativeInput`/`extractDerivativeResult`), `lib/core/runtime_autodiff.cpp` + new `lib/core/runtime_taylor.c` (runtime kernels), `taylor_recurrences.def` (shared table, §5b).
+
+---
+
+## 7. Multivariate / mixed partials (Phase P4)
+
+Full dense order-n derivative tensors in m variables are O(mⁿ) — inherently large. We use the **pragmatic split**, with the *complete* method built as a real phase:
+
+- **`derivative^n` (univariate):** the tower directly. `f^(n) = n!·c_n`.
+- **`gradient` / first-order multivariate:** existing forward/reverse (unchanged).
+- **`hessian`, `laplacian`, order-2 mixed:** existing e1/e2 `AD_JET4` nesting (unchanged, fast).
+- **Order ≥ 3 mixed partials:** **Griewank–Utke–Walther (2000)** — recover the full symmetric derivative tensor by propagating **univariate Taylor series along a set of directions** `f(x + t·v_i)` and interpolating. This adds *no new AD primitives*: it is orchestration + a linear solve over the same kernel.
+
+**The hook that makes GUW additive (in the kernel from day one):** expose
+
+```
+taylor_propagate(f, x, direction v, K)  ->  series of f along v
+```
+
+as the public primitive. Given it, the GUW interpolation layer (P4) drops in without touching the kernel. Directional derivatives `∂^n f(x + t·v)` are a plain univariate tower along v.
+
+---
+
+## 8. Reverse-over-Taylor (high-order gradients, Phase P5)
+
+`gradient` of a high-order scalar quantity (e.g. `∇` of a Laplacian) = the existing reverse tape with **tower-valued primals and adjoints**. The tape's forward pass records tower primals; the backward pass propagates tower adjoints. Perturbation tags (§5a) keep the reverse level distinct from the forward tower levels.
+
+This is the **highest-risk** piece (reverse mode has crash history — [[project_ad_multivar_operators]] — and the pure-Scheme tape `lib/core/ad/tape.esk` has AOT constraints: no `for-each`/`map` in core modules — [[project_stateful_ad_tape]]). It lands behind its own oracle, AOT-verified.
+
+---
+
+## 9. Exact-coefficient towers (enhancement #2, Phase P6)
+
+Eshkol already carries a full exact numeric tower — rationals and bignums with contagion rules ([[project_bignum_dispatch_pattern]]). For polynomial and rational functions the Taylor coefficients are themselves *exact rationals*, so high-order derivatives can be returned with **zero floating error** — a differentiator that no double-only AD framework offers.
+
+- The `COEFF_MASK` field (§4) selects the coefficient type. `COEFF_RATIONAL` stores each `c_k` as a tagged `esh_value_t` (rational or bignum) rather than a raw double.
+- The recurrences of §5 are reused verbatim, but the multiply-accumulate dispatches through `arith_->{mul,add,sub,div}` (the exact numeric tower) instead of `fma`. `div`/`pow` stay exact when the divisor is rational; `exp`/`log`/`sin`/`cos` fall back to `COEFF_F64` (they are transcendental — no exact rational series), with a clear predicate `taylor-exact?` telling the user which regime they are in.
+- **Contagion:** seeding an exact input (`(taylor f (exact x0) k)`) yields exact coefficients through the whole polynomial/rational subgraph; the first transcendental op demotes to `COEFF_F64` with a recorded flag, matching Eshkol's existing exactness-contagion semantics.
+- **Gate:** exact reference derivatives of `x^p`, `p(x)/q(x)` computed with the rational tower must match a symbolic/bignum oracle **bit-for-bit** (not just 1e-12), plus the `numeric_depth` exactness-contagion suite extended with a `taylor` column.
+
+---
+
+## 10. Tensor-valued towers (enhancement #4, Phase P7)
+
+The AD smoke tests already exercise `conv2d` / attention / batchnorm / layernorm **gradients**; high-order AD must cover this ML path, not just scalars. We therefore generalize tower coefficients from scalars to **tensors**.
+
+- `COEFF_TENSOR` (§4) makes each `c_k` a `HEAP_SUBTYPE_TENSOR` value; `RESERVED0` records the shared dtype/rank hint. All coefficients of one tower share a shape.
+- **Elementwise ops** (`add`, `sub`, `scale`, and `exp`/`log`/`sin`/`cos` applied elementwise) lift directly: the recurrence structure is unchanged, only the per-coefficient scalar op becomes the corresponding tensor op.
+- **`mul` → the appropriate bilinear tensor contraction.** Where the underlying primal op is a matmul, the Cauchy convolution's `u_j · w_{k-j}` becomes a matmul; where it is a **conv2d**, it becomes conv2d (`mul→conv where appropriate`); attention/batchnorm/layernorm decompose into these plus elementwise ops. The convolution *over series index k* is orthogonal to the tensor contraction *over spatial/feature axes* — they compose cleanly, reusing `lib/backend/tensor_conv_codegen.cpp` / `tensor_extras_codegen.cpp` for the inner op ([[project_tensor_op_codegen_path.md]]).
+- **GPU:** tensor-coefficient towers ride the existing Metal/CUDA tensor path; the series loop stays on host, the per-index tensor op dispatches to device.
+- **Gate:** high-order derivatives of `conv2d`/attention/batchnorm/layernorm vs. a finite-difference-checked reference and vs. the existing first-order tensor-AD results at order 1 (must agree). Wired into the AD smoke harness.
+
+---
+
+## 11. Taylor models — validated AD (enhancement #6, Phase P8)
+
+A **Taylor model** is a Taylor polynomial plus a rigorous **interval remainder** `[lo, hi]` that provably encloses the truncation error over a domain box, giving *guaranteed* enclosure bounds — the basis of validated numerics, rigorous ODE integration, and verified global optimization.
+
+- Representation extends the tower with an interval remainder term: `TM = (Σ c_k t^k) ⊕ R`, `R` an interval. Interval endpoints use directed rounding (round-down for `lo`, round-up for `hi`) — Eshkol's rounding-mode control is a prerequisite this phase adds.
+- Each recurrence in §5 gets an **interval-remainder rule**: `mul` composes the polynomial parts by Cauchy convolution and bounds the discarded high-order tail into `R` with outward rounding; `div`/`exp`/`log`/`sin`/`cos` use the Lagrange/Cauchy remainder bounded over the domain box. This is standard Makino–Berz Taylor-model arithmetic, layered on the existing kernel.
+- API: `(taylor-model f x domain k) -> (coeffs . remainder-interval)`; `taylor-model-enclosure` returns a guaranteed `[lo,hi]` for `f` over the box.
+- **Gate:** for functions with known exact ranges, the returned enclosure must **contain** the true range (soundness), and its width must shrink as k grows (tightness) — checked against analytic bounds and against a brute-force fine-grid sampling that must always fall inside the enclosure.
+
+---
+
+## 12. Integration & back-compat
+
+- **Dispatch order (perf-preserving):** scalar / `AD_JET4` first, `AD_JET8` next, `AD_TAYLOR` last. A tower only appears when order ≥ 3 is explicitly requested, so the hot path is never burdened.
+- **New-numeric-type checklist** (per [[reference-bugs-fixed]]): add the `HEAP_SUBTYPE_TAYLOR` case to `arith_->{add,sub,mul,div,pow, exp,log,sin,cos,…}`, `compare`/`abs`, `convertTo*`, `findFreeVariablesImpl`, `number->string`, and the type checker. Missing any one silently corrupts.
+- **JET4 unchanged; JET8 subsumed in P3:** keep #138's 8-jet behind its tests until reverse-over-nested-forward parity holds on the tower, then remove the special case. No churn on freshly-merged code.
+- **Arena/tape interop:** the stateful tape must accept tower values; verified **AOT**, not just `-r`.
+
+---
+
+## 13. Eshkol API surface
+
+```scheme
+(derivative f)                 ; 1st derivative — unchanged
+((derivative-n k) f)           ; k-th derivative via tower (k literal → monomorphized)
+(derivative f #:order k)       ; equivalent keyword form
+(taylor f x k)                 ; returns the K+1 Taylor coefficients as a tensor/list
+(taylor-exact? series)         ; #t if coeffs are exact rational/bignum (P6)
+(gradient f) (hessian f)       ; unchanged (order ≤ 2)
+(laplacian f) (directional f v); unchanged
+(hessian-n f order) ...        ; arbitrary mixed partials — P4 (GUW)
+(taylor-model f x domain k)    ; validated enclosure (poly + remainder interval) — P8
+```
+
+All double-path results are exact to machine precision; the rational/bignum path (P6) is bit-exact; the Taylor-model path (P8) returns rigorous enclosures. `taylor` exposes the tower as a first-class value (useful for series methods, ODE integrators, etc.).
+
+---
+
+## Frontier: differentiable programming (Phases P9-P12)
+
+P0-P8 make the Taylor tower the single arbitrary-order AD kernel. P9-P12 make that kernel a language facility: derivative operators can cross ordinary Scheme control flow, the reverse tape can scale to deep high-order graphs, users can program directly with series values, and multivariate recovery can exploit sparsity instead of materializing dense tensors by default. The target is a true differentiable-programming language, where loops, branches, closures, list combinators, ODE solvers, and sparse tensor workflows are differentiable when their semantics admit it.
+
+### P9. Differentiable control flow
+
+**Motivation:** Real Eshkol programs do not look like straight-line scalar kernels. They use `if`/`cond`/`case`, named-let loops, recursion, closures, higher-order calls, `map`, and `fold`. AD must be robust through those constructs, including nested derivative operators, or the tower remains only a numeric-kernel differentiator.
+
+**Representation / algorithm sketch:** Tower values flow through SSA phis, loop-carried variables, closure captures, and higher-order call boundaries as ordinary tagged values. The epoch tag already reserved in `flags[16..31]` (§4, §5a) is the control-flow invariant: a tower seeded by the active derivative context keeps its tag across branches, tail calls, closure environments, and list combinators; a foreign-tag tower is lifted as a constant in the current context. This prevents perturbation confusion when an inner `derivative` is invoked inside a loop body, branch arm, recursive call, or mapped closure.
+
+- **Tail calls / loops:** self tail calls and mutual-TCO lower to jumps/trampolines that carry tower values and the current epoch as part of the normal value environment. No new epoch is allocated for an iteration; only entering a new derivative operator creates a tag. Loop-carried towers become ordinary phi values for the stack-tier path, or heap tower pointers for dynamic K.
+- **Branch selection:** AD differentiates the branch actually selected by the primal predicate, giving the derivative of the corresponding piece of a piecewise function. At a kink where branch predicates switch, the default policy is a deterministic differentiability error unless both arms agree through the requested order. A future opt-in keyword can request a documented subgradient policy for convex primitives, but silent arbitrary branch derivatives are forbidden.
+- **Recursion and closures:** closure environments may capture tower values; extraction asserts the requesting epoch. Recursive calls pass tagged towers through the same ABI as scalars/heap values. Mutual recursion inherits the mutual-TCO discipline so differentiating structurally recursive programs does not regress into stack growth when the original program is tail-recursive.
+- **Named-let and `map`/`fold`:** named-let lowers to the same loop/TCO path. `map` differentiates each closure application independently while preserving the caller epoch; `fold` differentiates the recurrence over its accumulator, so the accumulator may itself be a tower or a container of towers.
+
+**Integration points:** `lib/backend/control_flow_codegen.cpp` for branch and loop phis; `lib/backend/tail_call_codegen.cpp` for self/mutual TCO; `lib/backend/call_apply_codegen.cpp` and `lib/backend/function_codegen.cpp` for closure calls/captures; `lib/backend/map_codegen.cpp` and `lib/core/list/*.esk` for list combinators; `lib/backend/autodiff_codegen.cpp`, `lib/core/runtime_autodiff.cpp`, and `lib/core/runtime_taylor.c` for seeding/extraction and tower dispatch.
+
+**ICC/oracle gate:** extend `scripts/run_ad_depth.sh` with a control-flow oracle differentiating programs with data-dependent loops and branches to d=8 vs analytic references. The suite must include branch-selected polynomials, loop trip counts depending on primal data but fixed around the evaluation point, named-let recurrence examples, recursive/tail-recursive functions, nested derivatives inside branches, and `map`/`fold` closures. `scripts/run_control_flow_tests.sh`, `scripts/run_recursion_depth.sh`, and `scripts/run_tco_tests.sh` remain green; ICC records the new `ad_control_flow_depth` criterion.
+
+**Risk note:** Piecewise functions are not differentiable at every point. The dangerous failure mode is silently returning the derivative of one arm at a kink, so the default kink policy is explicit error unless arm derivatives agree through K or an opt-in subgradient policy is declared. The other major risk is epoch leakage through closures; extraction assertions and foreign-tag-as-constant semantics catch it.
+
+### P10. Checkpointed high-order reverse
+
+**Motivation:** P5 reverse-over-Taylor makes high-order gradients possible, but a naive tower-valued tape stores O(tape*K) primal coefficient data. That is unacceptable for deep graphs, long loops, and ML workloads. High-order reverse needs checkpointing/rematerialization so memory scales with a controlled budget.
+
+**Representation / algorithm sketch:** Adapt Griewank binomial checkpointing to a tower-valued tape. Instead of retaining every tower primal for every operation, the tape stores checkpoints at scheduled cut points: the primal inputs, epoch tag, tower order K, coefficient type, and enough AOT-stable closure/function identity to replay the segment. During the reverse sweep, missing tower primals are rematerialized by replaying the forward segment under the same epoch and FP-contraction policy, then tower adjoints propagate normally. The schedule is deterministic and part of the tape metadata, so replayed tower coefficients match the original forward pass bit-exactly when P2's contraction policy applies.
+
+For the pure-Scheme tape (`lib/core/ad/tape.esk`), the checkpoint schedule must respect the existing AOT constraints: no reliance on host tracing, no unsupported `for-each`/`map` in core modules, and no runtime-only closures that cannot be regenerated by AOT. The checkpoint planner is therefore represented as explicit tape records and counted loops, not as higher-order Scheme iteration.
+
+**Integration points:** `lib/core/ad/tape.esk` for checkpoint records and rematerialization schedule; `lib/core/runtime_autodiff.cpp` for reverse entry/exit and memory accounting; `lib/core/runtime_taylor.c` for tower replay kernels; `lib/backend/autodiff_codegen.cpp` for AOT emission of replayable segments; benchmark/oracle wiring in `scripts/run_ad_depth.sh` and ICC memory criteria.
+
+**ICC/oracle gate:** a high-order reverse oracle runs a deep scalar graph and a loop-expanded graph at d=8, compares gradients against the dense-tape baseline and analytic references, and enforces a fixed memory budget that the naive O(tape*K) tape would exceed. The gate records max tape bytes, rematerialization count, and gradient agreement.
+
+**Risk note:** Rematerialization is only valid for pure, deterministic segments. Effects, nondeterministic primitives, mutation not represented in the tape, or divergent FP contraction can make replay differ from the forward pass. The phase must conservatively disable checkpointing for impure segments and fall back to the dense tape with an explicit budget failure when no safe schedule exists.
+
+### P11. Tower-based user numerics
+
+**Motivation:** Once the tower is first-class, users should be able to program with Taylor series directly: Taylor-series ODE integration, series-based root finding and function inversion, and analytic continuation. This exposes the same kernel that powers AD as a general numerical method, not an internal-only derivative representation.
+
+**Representation / algorithm sketch:** `taylor` returns an opaque series value backed by the same tower layout and recurrences (§4-§5). User methods consume and produce those series through public accessors rather than raw coefficient storage. ODE integration seeds a tower for time and recursively solves for the coefficients of `y(t+h)` from `y' = f(t,y)`. Root finding and function inversion use series Newton/Lagrange-style updates over tower values. Analytic continuation advances by repeated local Taylor expansions, optionally using P8 Taylor-model remainders to choose step sizes and validate enclosures.
+
+**API sketch:**
+
+```scheme
+(define s (taylor (lambda (x) (/ 1 (- 1 x))) 0.0 8))
+(taylor-coeff s 4)                         ; coefficient c_4
+(taylor-eval s 0.25)                       ; evaluate the truncated series
+
+(taylor-ode (lambda (t y) (* -1.0 y))
+            1.0 #:t0 0.0 #:h 0.1 #:order 8 #:steps 10)
+
+(taylor-root (lambda (x) (- (* x x) 2.0))
+             #:x0 1.0 #:order 8 #:tol 1e-12)
+
+(taylor-invert (lambda (x) (+ x (* x x)))
+               #:around 0.0 #:order 8)
+
+(analytic-continue (lambda (x) (/ 1 (- 1 x)))
+                   #:from 0.0 #:to 0.5 #:order 8)
+```
+
+**Integration points:** `lib/math/ode.esk` for ODE-facing APIs; `lib/math/special.esk` and `lib/math.esk` for root/inversion/continuation exports; `lib/backend/autodiff_codegen.cpp`, `lib/core/runtime_taylor.c`, and `taylor_recurrences.def` for series operations; `docs/API_REFERENCE.md` once the APIs move from design to implementation.
+
+**ICC/oracle gate:** an ODE/root-find oracle verifies that `y'=-y, y(0)=1` converges to `exp(-t)` as order/step refinement increases, that `x^2-2` converges to `sqrt(2)`, and that inversion examples compose back to identity through order d=8. ICC records the new `ad_user_numerics` criterion.
+
+**Risk note:** A public series API can freeze internal representation too early. The API must expose opaque series operations and documented coefficient access, not raw tower headers. Analytic continuation can cross singularities; Taylor-model validation or explicit radius/domain guards must reject unsafe steps rather than returning plausible nonsense.
+
+### P12. Sparse high-order tensors
+
+**Motivation:** P4 GUW recovery can produce arbitrary-order multivariate mixed partials, but dense storage is O(m^n). Many Eshkol workloads are partially separable: sparse Hessians, banded Jacobian structure, local stencil functions, and ML blocks where only a small subset of mixed partials is nonzero. The GUW layer should exploit that structure instead of forcing dense tensors.
+
+**Representation / algorithm sketch:** Add a sparse GUW recovery mode over the same `taylor_propagate(f, x, v, K)` primitive (§7). A conservative structural pass builds a variable-interaction hypergraph from codegen/type information and optional runtime probes. Seed directions are then selected using star-coloring / Walther-style sparse derivative compression so one directional Taylor propagation recovers multiple structurally independent mixed partials. Recovered entries are stored in a CSR/CSF-like format keyed by sorted multi-index:
+
+```
+order_offsets[n]        ; range of sparse entries for derivative order n
+multi_index_ids[]       ; canonical sorted variable multi-index per entry
+values[]                ; coefficient / tensor value
+```
+
+For Hessians this degenerates to standard sparse symmetric CSR. For order > 2, the same idea becomes compressed sparse fiber storage over canonical multi-indices. The algorithm must be conservative: an uncertain dependency is treated as possibly nonzero, which may reduce compression but cannot drop a true derivative.
+
+**Integration points:** P4's GUW orchestration in `lib/backend/autodiff_codegen.cpp` and `lib/core/runtime_taylor.c`; dependency/free-variable analysis in `findFreeVariablesImpl` and the type/codegen environment; sparse tensor interop where available in tensor codegen; tests in the AD depth and metamorphic harnesses.
+
+**ICC/oracle gate:** a sparse Hessian oracle for partially separable functions compares sparse recovery to dense GUW/Hessian recovery through order d, verifies identical nonzero values and conservative structural zeros, and records propagation count savings. Higher-order sparse tensor examples compare against dense recovery for small m,n where dense is still tractable.
+
+**Risk note:** The main correctness risk is a false structural zero. Sparsity detection must be conservative, with dense fallback and metamorphic dense-vs-sparse comparisons on small cases. The main performance risk is coloring overhead dominating small problems; the sparse path should require either an explicit user request or an estimated win.
+
+---
+
+## 14. Phased implementation plan
+
+Each phase gated by `scripts/run_ad_depth.sh` (derivative^d / gradient^d to d=8) and wired into the ICC oracle (`ad_depth` criterion). Ledger ids in the last column.
+
+| Phase | Deliverable | Gate | ESH |
+|---|---|---|---|
+| **P0** | Standalone C POC (§15): univariate recurrences `t_mul/t_div/t_exp/t_log/t_sincos/t_pow`, x⁵ & sin & exp & 1/(1-x) & log(1+x) to d=8 | rel-err < 1e-12 vs analytic; exits 0 | **ESH-0185** (done) |
+| **P1** | `HEAP_SUBTYPE_TAYLOR` + runtime heap tower + `derivative^n` (univariate) + epoch-tag scaffold (§5a) in `flags` | `derivative^d` PASS to d=8 → **closes ESH-0118**; nested-AD confusion suite PASS; nothing deprecated | **ESH-0186** |
+| **P2** | Compile-time-K monomorphization (unrolled stack towers) + one FP-contraction policy (§6a) | correctness PASS + no heap in AD loop + metamorphic `mono(K) ≡ runtime(K)` **bit-exact** | **ESH-0187** |
+| **P3** | Subsume `AD_JET8`: route reverse-over-nested-forward through the tower; re-express levels as explicit tags; remove 8-comp special case | #138's tests still PASS; JET4 retained; confusion model unified | **ESH-0188** |
+| **P4** | GUW multivariate layer: `gradient^n` / mixed partials to arbitrary order via `taylor_propagate` + interpolation | `gradient^d` PASS to d=8 | **ESH-0189** |
+| **P5** | Reverse-over-Taylor + tower-aware tape (high-order gradients) | reverse high-order oracle PASS, AOT-verified | **ESH-0190** |
+| **P6** | Exact-coefficient towers (`COEFF_RATIONAL`, §9) | rational/bignum derivatives **bit-exact** vs symbolic oracle; exactness-contagion suite PASS | **ESH-0191** |
+| **P7** | Tensor-valued towers (`COEFF_TENSOR`, §10): conv2d/attention/batchnorm/layernorm high-order AD | ML AD smoke PASS; order-1 agrees with existing tensor-AD; FD-checked | **ESH-0192** |
+| **P8** | Taylor models (§11): validated AD with rigorous interval remainder | enclosure soundness (contains true range) + tightness (width ↓ in k) | **ESH-0193** |
+| **P9** | Differentiable control flow: towers through loops, conditionals, recursion, closures, named-let, `map`/`fold`; perturbation-safe nested derivative contexts | data-dependent loop/branch oracle PASS to d=8 vs analytic; kink policy enforced; TCO/control-flow suites PASS | **ESH-0194** |
+| **P10** | Checkpointed high-order reverse: Griewank binomial checkpointing/rematerialization for tower-valued tapes | high-order reverse on deep graph PASS to d=8 within memory budget; agrees with dense tape/analytic oracle | **ESH-0195** |
+| **P11** | Tower-based user numerics: Taylor-series ODE integration, series root finding/inversion, analytic continuation APIs | ODE/root/inversion examples converge to analytic solution; ICC `ad_user_numerics` PASS | **ESH-0196** |
+| **P12** | Sparse high-order tensors: sparse GUW mixed-partial recovery via star-coloring/Walther seed selection and CSR/CSF-like storage | sparse Hessian/partial tensor matches dense recovery through d; propagation-count savings recorded | **ESH-0197** |
+
+Also: the self-verifying recurrence table (§5b) is introduced in P1 and every subsequent phase adds its primitives *through* the table, so each new primitive auto-adds a d=8 gate.
+
+---
+
+## 15. Testing & verification
+
+- **P6a depth oracle** (`run_ad_depth.sh`) to d=8 is the primary gate at every phase; regenerate `scripts/icc_traces` then confirm via `icc readiness`.
+- **Self-generated per-primitive tests** (§5b): every row of `taylor_recurrences.def` yields a d=8 analytic test automatically.
+- **Metamorphic laws:** `mono(K) ≡ runtime(K)` (bit-exact, §6a); `taylor(f,x,k)[n]·n! == derivative^n(f,x)`; linearity/product/chain identities across orders. Wired into `.icc/…/metamorphic.jsonl`.
+- **Nested-AD confusion suite** (§5a): analytic-answer nested `derivative`/`gradient` cases.
+- **Analytic references:** x^p, exp, log, sin/cos, rational functions — closed-form derivatives to d=8.
+- **Exactness (P6):** bit-exact vs bignum/symbolic oracle.
+- **Tensor (P7):** FD-checked conv2d/attention/batchnorm/layernorm; order-1 agreement with existing tensor-AD.
+- **Enclosure (P8):** soundness + tightness vs analytic bounds and grid sampling.
+- **Differentiable control flow (P9):** data-dependent loops/branches, named-let, recursion, nested derivative-in-branch cases, and `map`/`fold` closures to d=8 vs analytic references.
+- **Checkpointed reverse (P10):** deep high-order reverse graph within a fixed memory budget; dense-vs-checkpointed gradient agreement and rematerialization accounting.
+- **User numerics (P11):** ODE/root/inversion examples converge to analytic answers as order/step refinement increases.
+- **Sparse tensors (P12):** sparse Hessian/higher tensor recovery matches dense GUW on tractable cases; structural-zero detection is conservative.
+- **Regression:** AD oracle 56/56, SICP 88/88, no perturbation-confusion regressions from the existing suites.
+- **No AD-hot-loop allocation:** benchmark asserting zero arena growth for literal-K derivatives (P2).
+
+### Phase-0 POC (delivered in this PR)
+
+`tests/ad_taylor_poc/taylor_poc.c` — self-contained C, no repo deps; `tests/ad_taylor_poc/run.sh` compiles it with `cc` and runs it (exit 0 iff all checks pass). It implements `t_mul` (Cauchy convolution), `t_div`, `t_exp`, `t_log`, `t_sincos` (coupled), and `t_pow`, seeds `x = {x₀, 1, 0, …}`, and computes:
+
+- `x⁵` (via `t_pow`, cross-checked via repeated `t_mul`) at x₀ = 2.0
+- `sin(x)` / `cos(x)` (coupled) at x₀ = 0.0
+- `exp(x)` at x₀ = 0.5
+- `1/(1-x)` (via `t_sub` + `t_div`) at x₀ = 0.5
+- `log(1+x)` (via `t_add` + `t_log`) at x₀ = 0.0
+
+comparing `k!·c_k` against closed-form analytic derivatives for k = 0..8 at rel-err < 1e-12 (63/63 checks pass).
+
+**Expected — x⁵ at x₀ = 2.0** (`f^(k) = k!·c_k`):
+
+| k | c_k | f^(k) |
+|---|---|---|
+| 0 | 32 | 32 |
+| 1 | 80 | 80 |
+| 2 | 80 | 160 |
+| 3 | 40 | 240 |
+| 4 | 10 | 240 |
+| 5 | 1 | 120 |
+| 6 | 0 | 0 |
+| 7 | 0 | 0 |
+| 8 | 0 | 0 |
+
+**Expected — sin(x) at x₀ = 0:** derivatives cycle 0, 1, 0, −1, 0, 1, 0, −1, 0 for k = 0..8.
+
+Both confirmed by the POC run.
+
+---
+
+## 16. Risk ledger
+
+| Risk | Mitigation |
+|---|---|
+| **Perturbation confusion (silent-wrong nested gradients)** | epoch tags in `flags`, tag-gated combination, extraction assert (§5a); dedicated confusion suite |
+| Heap churn in AD hot loops | P2 monomorphization is the primary path; heap only for dynamic K |
+| Two tiers drift | shared `taylor_recurrences.def` (self-verifying, §5b); metamorphic `mono≡runtime` gate |
+| `mono ≢ runtime` at the bit level | one FP-contraction policy across both tiers (§6a); explicit `fma`, fixed reduction order |
+| Reverse-over-tower bugs | isolated to P5, own oracle, AOT-verified, extra review |
+| Dispatch-surface growth | strict ordering; tower absent unless order ≥ 3 requested |
+| JET8 churn | subsumed only in P3 after parity, not preemptively |
+| Exact-coeff blowup (bignum size at high K) | opt-in `COEFF_RATIONAL`; predicate `taylor-exact?`; transcendental demotion to F64 |
+| Tensor-tower memory/compute cost | shares tensor path + GPU dispatch; series loop on host |
+| Taylor-model unsoundness (remainder too tight) | outward-rounded interval arithmetic; grid-sampling containment gate |
+| Control-flow AD at kinks | default differentiability error unless branch derivatives agree through K or an explicit subgradient policy is requested |
+| Epoch leakage through closures/HOFs | epoch tag travels in tower flags; foreign-tag towers are constants; extraction asserts the requesting epoch |
+| Checkpoint replay drift | checkpoint only pure deterministic segments; replay uses the same contraction policy; dense-tape fallback for impure segments |
+| User numeric APIs ossify internals | expose opaque series operations, not raw tower headers |
+| Sparse tensor false zeros | conservative dependency analysis; dense fallback; dense-vs-sparse oracle on small cases |
+| Numerical stability of div/log/pow at high K near singularities | documented domain guards; NaN/Inf propagation tested (numeric_depth oracle) |
+
+---
+
+## 17. Open questions / future work
+
+- Dense high-order mixed tensor *storage* API remains future; P12 covers sparse storage/recovery only.
+- Optional monomorphization of small dynamic K∈{3,4} if profiles justify.
+- Complex-domain towers / multicomplex — out of scope for now.
+- Taylor-model-based rigorous ODE integrator and verified global optimizer built on P8 — future application layer.
+
+---
+
+*Phase-0 POC committed at `tests/ad_taylor_poc/`; P1–P12 filed in the ledger as ESH-0186..0197 (post-v1.3). Each phase carries its own ICC/oracle gate per §14.*

--- a/inc/eshkol/backend/arithmetic_codegen.h
+++ b/inc/eshkol/backend/arithmetic_codegen.h
@@ -238,6 +238,12 @@ public:
     llvm::Value* emitBignumCompareCall(llvm::Value* left, llvm::Value* right, int op_code);
     llvm::Value* emitIsBignumCheck(llvm::Value* left, llvm::Value* right);
 
+    // === Taylor-tower dispatch helpers (ESH-0186) ===
+    llvm::Value* emitIsTaylorCheck(llvm::Value* left, llvm::Value* right);
+    llvm::Value* emitIsTaylorSingle(llvm::Value* v);
+    llvm::Value* emitTaylorBinaryCall(llvm::Value* left, llvm::Value* right, int op_code);
+    llvm::Value* emitTaylorUnaryCall(llvm::Value* in, int op_code);
+
     // === Rational dispatch helpers ===
 
     llvm::Value* emitIsRationalCheck(llvm::Value* left, llvm::Value* right);

--- a/inc/eshkol/backend/autodiff_codegen.h
+++ b/inc/eshkol/backend/autodiff_codegen.h
@@ -327,6 +327,31 @@ public:
     /** Monolith derivative fallback (runtime function parameter dispatch) */
     llvm::Value* codegenDerivativeMonolith(const eshkol_operations_t* op);
 
+    // === Arbitrary-order Taylor-tower AD (ESH-0186, P1) ===
+    // (taylor f x k) -> list of K+1 coefficients; (derivative-n f x k) -> k!*c[k].
+    // Both reuse codegenDerivativeMonolith's call/capture machinery; the tower
+    // mode below re-points seedForwardAndPush / popAndExtractForward at the
+    // heap-tower runtime kernel (lib/core/runtime_taylor.c) instead of the jet.
+    llvm::Value* taylorSeries(const eshkol_operations_t* op);  // ESHKOL_TAYLOR_OP
+    llvm::Value* derivativeN(const eshkol_operations_t* op);   // ESHKOL_DERIVATIVE_N_OP
+    enum class TowerMode { NONE, DERIV_N, COEFFS };
+    TowerMode adTowerMode_ = TowerMode::NONE;   // set only during a tower-API call
+    llvm::Value* adTowerOrder_ = nullptr;       // i32 requested order k (runtime value)
+    // Shared seed+call+extract core for the tower API and the nested-derivative
+    // rewrite. `order_i32` is the requested order; `mode` selects extraction.
+    llvm::Value* taylorApiCore(const struct eshkol_ast* function_ast,
+                               const struct eshkol_ast* point_ast,
+                               llvm::Value* order_i32, TowerMode mode);
+    // Detect a pure repeated-univariate `derivative` chain
+    // (derivative (lambda (z1) (derivative (lambda (z2) ... base ...) z1)) x)
+    // of total depth D. Returns D and the innermost base function + outermost
+    // point when the whole chain threads a single variable; 0 otherwise. Used to
+    // route depth>=3 nests (which the 2-level jet returns 0 for, ESH-0118)
+    // through the arbitrary-order tower while leaving depth<=2 on the jet.
+    int detectPureDerivChain(const eshkol_operations_t* op,
+                             const struct eshkol_ast** innermost_func,
+                             const struct eshkol_ast** outer_point);
+
     // === Tape Management ===
 
     /**

--- a/inc/eshkol/eshkol.h
+++ b/inc/eshkol/eshkol.h
@@ -164,6 +164,32 @@ typedef struct eshkol_dual_number {
 ESHKOL_STATIC_ASSERT(sizeof(eshkol_dual_number_t) == 16,
                      "Dual number must be 16 bytes for cache efficiency");
 
+// ───────────────────────────────────────────────────────────────────────────
+// TAYLOR TOWER  (arbitrary-order forward-mode AD — ESH-0186, docs/design/AD_TAYLOR_TOWER.md)
+// ───────────────────────────────────────────────────────────────────────────
+// A univariate truncated-Taylor series carried as its coefficient array:
+//     f(x0 + t) = sum_{k=0..K} c[k] * t^k        =>   f^(n)(x0) = n! * c[n].
+// Stored behind a tagged HEAP_PTR with subtype HEAP_SUBTYPE_TAYLOR. Mirrors
+// HEAP_SUBTYPE_TENSOR's homogeneous-double storage: the header is followed by
+// (order_k + 1) doubles. `flags` reserves a coefficient-type field and a
+// perturbation-confusion EPOCH tag so nested `derivative` levels never mix
+// (§5a). Differentiating the variable seeds {x0, 1, 0, ...}.
+typedef struct esh_taylor {
+    uint32_t order_k;   // highest coefficient index K (series has K+1 entries)
+    uint32_t flags;     // packed: COEFF_MASK[0..7] | RESERVED0[8..15] | EPOCH_TAG[16..31]
+    double   c[];       // coefficient storage c[0..order_k] (COEFF_F64)
+} esh_taylor_t;
+
+// esh_taylor_t.flags bitfield accessors (§4 of the design).
+#define ESH_TAYLOR_COEFF_MASK    0x000000FFu  // coefficient type: 0=F64 (P6 adds RATIONAL/TENSOR)
+#define ESH_TAYLOR_COEFF_F64     0u
+#define ESH_TAYLOR_EPOCH_SHIFT   16u
+#define ESH_TAYLOR_EPOCH_MASK    0xFFFF0000u  // perturbation-confusion tag (bits 16..31)
+#define ESH_TAYLOR_GET_EPOCH(fl) (((fl) & ESH_TAYLOR_EPOCH_MASK) >> ESH_TAYLOR_EPOCH_SHIFT)
+#define ESH_TAYLOR_MK_FLAGS(coeff, epoch) \
+    (((uint32_t)(coeff) & ESH_TAYLOR_COEFF_MASK) | \
+     (((uint32_t)(epoch) << ESH_TAYLOR_EPOCH_SHIFT) & ESH_TAYLOR_EPOCH_MASK))
+
 // Complex number for signal processing, FFT, and general complex analysis
 // Stores real and imaginary components as IEEE 754 double-precision floats
 typedef struct eshkol_complex_number {
@@ -359,7 +385,8 @@ typedef enum {
     HEAP_SUBTYPE_PRNG            = 20,  // Isolated pseudo-random number generator state
     HEAP_SUBTYPE_DNC             = 21,  // Differentiable external memory (NTM/DNC head)
     HEAP_SUBTYPE_SDNC            = 22,  // SDNC weight-program handle (bytecode-VM-as-transformer θ)
-    // Reserved: 23-255 for future heap types
+    HEAP_SUBTYPE_TAYLOR          = 23,  // Truncated-Taylor tower for arbitrary-order AD (ESH-0186)
+    // Reserved: 24-255 for future heap types
 } heap_subtype_t;
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -1420,6 +1447,8 @@ typedef enum {
     ESHKOL_CURL_OP,
     ESHKOL_LAPLACIAN_OP,
     ESHKOL_DIRECTIONAL_DERIV_OP,
+    ESHKOL_TAYLOR_OP,           // (taylor f x k) - K+1 Taylor coefficients (ESH-0186)
+    ESHKOL_DERIVATIVE_N_OP,     // (derivative-n f x k) - arbitrary-order n-th derivative (ESH-0186)
     // HoTT Type System operators
     ESHKOL_TYPE_ANNOTATION_OP,  // (: name type) - standalone type declaration
     ESHKOL_FORALL_OP,           // (forall (a b) type) - polymorphic type
@@ -1637,6 +1666,11 @@ typedef struct eshkol_operation {
             struct eshkol_ast *point;       // Point to evaluate derivative at
             uint8_t mode;                   // 0=forward, 1=reverse, 2=auto (for future use)
         } derivative_op;
+        struct {
+            struct eshkol_ast *function;    // Function to differentiate (univariate)
+            struct eshkol_ast *point;       // Point x0 to evaluate at
+            struct eshkol_ast *order;       // Requested order k (may be a runtime value)
+        } taylor_op;                        // shared by ESHKOL_TAYLOR_OP / ESHKOL_DERIVATIVE_N_OP
         struct {
             struct eshkol_ast *function;    // Scalar field function: ℝⁿ → ℝ
             struct eshkol_ast *point;       // Point to evaluate gradient at

--- a/lib/backend/arithmetic_codegen.cpp
+++ b/lib/backend/arithmetic_codegen.cpp
@@ -530,6 +530,100 @@ llvm::Value* ArithmeticCodegen::emitBignumCompareCall(llvm::Value* left, llvm::V
     return ctx_.builder().CreateLoad(ctx_.taggedValueType(), result_alloca, "bn_cmp_result");
 }
 
+// === Taylor-tower Runtime Dispatch (ESH-0186) ===
+// Mirrors the bignum dispatch: a runtime predicate + out-param binary/unary
+// kernels in lib/core/runtime_taylor.c. A Taylor tower is a HEAP_PTR with
+// subtype HEAP_SUBTYPE_TAYLOR; it MUST be intercepted before the generic
+// vector/tensor heap path (which would misread its storage).
+
+// int eshkol_is_taylor_tagged(const tagged_value_t*)
+static llvm::Function* getIsTaylorTaggedFunc(CodegenContext& ctx) {
+    llvm::Function* func = ctx.module().getFunction("eshkol_is_taylor_tagged");
+    if (!func) {
+        llvm::FunctionType* fn_type = llvm::FunctionType::get(
+            ctx.int32Type(), {ctx.ptrType()}, false);
+        func = llvm::Function::Create(fn_type,
+            llvm::Function::ExternalLinkage, "eshkol_is_taylor_tagged", &ctx.module());
+    }
+    return func;
+}
+
+// void eshkol_taylor_binary_tagged(arena, left*, right*, i32 op, result*)
+static llvm::Function* getTaylorBinaryTaggedFunc(CodegenContext& ctx) {
+    llvm::Function* func = ctx.module().getFunction("eshkol_taylor_binary_tagged");
+    if (!func) {
+        llvm::FunctionType* fn_type = llvm::FunctionType::get(
+            llvm::Type::getVoidTy(ctx.context()),
+            {ctx.ptrType(), ctx.ptrType(), ctx.ptrType(),
+             ctx.int32Type(), ctx.ptrType()}, false);
+        func = llvm::Function::Create(fn_type,
+            llvm::Function::ExternalLinkage, "eshkol_taylor_binary_tagged", &ctx.module());
+    }
+    return func;
+}
+
+// void eshkol_taylor_unary_tagged(arena, in*, i32 op, result*)
+static llvm::Function* getTaylorUnaryTaggedFunc(CodegenContext& ctx) {
+    llvm::Function* func = ctx.module().getFunction("eshkol_taylor_unary_tagged");
+    if (!func) {
+        llvm::FunctionType* fn_type = llvm::FunctionType::get(
+            llvm::Type::getVoidTy(ctx.context()),
+            {ctx.ptrType(), ctx.ptrType(), ctx.int32Type(), ctx.ptrType()}, false);
+        func = llvm::Function::Create(fn_type,
+            llvm::Function::ExternalLinkage, "eshkol_taylor_unary_tagged", &ctx.module());
+    }
+    return func;
+}
+
+llvm::Value* ArithmeticCodegen::emitIsTaylorCheck(llvm::Value* left, llvm::Value* right) {
+    llvm::Function* fn = ctx_.builder().GetInsertBlock()->getParent();
+    llvm::IRBuilder<> eb(&fn->getEntryBlock(), fn->getEntryBlock().begin());
+    llvm::Value* la = eb.CreateAlloca(ctx_.taggedValueType(), nullptr, "twr_chk_l");
+    llvm::Value* ra = eb.CreateAlloca(ctx_.taggedValueType(), nullptr, "twr_chk_r");
+    ctx_.builder().CreateStore(left, la);
+    ctx_.builder().CreateStore(right, ra);
+    llvm::Function* is_t = getIsTaylorTaggedFunc(ctx_);
+    llvm::Value* l_is = ctx_.builder().CreateCall(is_t, {la}, "l_is_twr");
+    llvm::Value* r_is = ctx_.builder().CreateCall(is_t, {ra}, "r_is_twr");
+    llvm::Value* any = ctx_.builder().CreateOr(l_is, r_is);
+    return ctx_.builder().CreateICmpNE(any, llvm::ConstantInt::get(ctx_.int32Type(), 0), "any_twr");
+}
+
+llvm::Value* ArithmeticCodegen::emitIsTaylorSingle(llvm::Value* v) {
+    llvm::Function* fn = ctx_.builder().GetInsertBlock()->getParent();
+    llvm::IRBuilder<> eb(&fn->getEntryBlock(), fn->getEntryBlock().begin());
+    llvm::Value* a = eb.CreateAlloca(ctx_.taggedValueType(), nullptr, "twr_chk1");
+    ctx_.builder().CreateStore(v, a);
+    llvm::Value* is_t = ctx_.builder().CreateCall(getIsTaylorTaggedFunc(ctx_), {a}, "is_twr1");
+    return ctx_.builder().CreateICmpNE(is_t, llvm::ConstantInt::get(ctx_.int32Type(), 0), "is_twr1b");
+}
+
+llvm::Value* ArithmeticCodegen::emitTaylorBinaryCall(llvm::Value* left, llvm::Value* right, int op_code) {
+    llvm::Function* fn = ctx_.builder().GetInsertBlock()->getParent();
+    llvm::IRBuilder<> eb(&fn->getEntryBlock(), fn->getEntryBlock().begin());
+    llvm::Value* la = eb.CreateAlloca(ctx_.taggedValueType(), nullptr, "twr_l");
+    llvm::Value* ra = eb.CreateAlloca(ctx_.taggedValueType(), nullptr, "twr_r");
+    llvm::Value* res = eb.CreateAlloca(ctx_.taggedValueType(), nullptr, "twr_res");
+    ctx_.builder().CreateStore(left, la);
+    ctx_.builder().CreateStore(right, ra);
+    ctx_.builder().CreateCall(getTaylorBinaryTaggedFunc(ctx_), {
+        getArenaPtr(ctx_), la, ra,
+        llvm::ConstantInt::get(ctx_.int32Type(), op_code), res});
+    return ctx_.builder().CreateLoad(ctx_.taggedValueType(), res, "twr_binres");
+}
+
+llvm::Value* ArithmeticCodegen::emitTaylorUnaryCall(llvm::Value* in, int op_code) {
+    llvm::Function* fn = ctx_.builder().GetInsertBlock()->getParent();
+    llvm::IRBuilder<> eb(&fn->getEntryBlock(), fn->getEntryBlock().begin());
+    llvm::Value* ia = eb.CreateAlloca(ctx_.taggedValueType(), nullptr, "twr_in");
+    llvm::Value* res = eb.CreateAlloca(ctx_.taggedValueType(), nullptr, "twr_ures");
+    ctx_.builder().CreateStore(in, ia);
+    ctx_.builder().CreateCall(getTaylorUnaryTaggedFunc(ctx_), {
+        getArenaPtr(ctx_), ia,
+        llvm::ConstantInt::get(ctx_.int32Type(), op_code), res});
+    return ctx_.builder().CreateLoad(ctx_.taggedValueType(), res, "twr_unres");
+}
+
 // === Rational Codegen Helpers ===
 
 // Declare eshkol_is_rational_tagged_ptr(val*) -> i32
@@ -677,6 +771,16 @@ llvm::Value* ArithmeticCodegen::add(llvm::Value* left, llvm::Value* right) {
         llvm::BasicBlock* merge = llvm::BasicBlock::Create(ctx_.context(), "add_merge", func);
 
         // Check bignum first via safe runtime call
+        // ESH-0186: intercept Taylor towers before the heap/tensor path.
+        llvm::BasicBlock* add_taylor_path = llvm::BasicBlock::Create(ctx_.context(), "add_taylor", func);
+        llvm::BasicBlock* add_after_taylor = llvm::BasicBlock::Create(ctx_.context(), "add_after_taylor", func);
+        ctx_.builder().CreateCondBr(emitIsTaylorCheck(left, right), add_taylor_path, add_after_taylor);
+        ctx_.builder().SetInsertPoint(add_taylor_path);
+        llvm::Value* add_twr = emitTaylorBinaryCall(left, right, 0);
+        ctx_.builder().CreateBr(merge);
+        llvm::BasicBlock* add_twr_exit = ctx_.builder().GetInsertBlock();
+        ctx_.builder().SetInsertPoint(add_after_taylor);
+
         llvm::Value* any_bignum = emitIsBignumCheck(left, right);
         llvm::BasicBlock* check_rational = llvm::BasicBlock::Create(ctx_.context(), "add_check_rational", func);
         ctx_.builder().CreateCondBr(any_bignum, bignum_path, check_rational);
@@ -797,7 +901,8 @@ llvm::Value* ArithmeticCodegen::add(llvm::Value* left, llvm::Value* right) {
 
         // Merge all non-AD paths
         ctx_.builder().SetInsertPoint(merge);
-        llvm::PHINode* phi = ctx_.builder().CreatePHI(ctx_.taggedValueType(), 8, "add_result");
+        llvm::PHINode* phi = ctx_.builder().CreatePHI(ctx_.taggedValueType(), 9, "add_result");
+        phi->addIncoming(add_twr, add_twr_exit);
         phi->addIncoming(bn_add_tagged, bignum_exit);
         phi->addIncoming(rat_add_tagged, rational_exit);
         phi->addIncoming(vec_result, vector_exit);
@@ -853,6 +958,16 @@ llvm::Value* ArithmeticCodegen::sub(llvm::Value* left, llvm::Value* right) {
         llvm::BasicBlock* merge = llvm::BasicBlock::Create(ctx_.context(), "sub_merge", func);
 
         // Check bignum first via safe runtime call
+        // ESH-0186: intercept Taylor towers before the heap/tensor path.
+        llvm::BasicBlock* sub_taylor_path = llvm::BasicBlock::Create(ctx_.context(), "sub_taylor", func);
+        llvm::BasicBlock* sub_after_taylor = llvm::BasicBlock::Create(ctx_.context(), "sub_after_taylor", func);
+        ctx_.builder().CreateCondBr(emitIsTaylorCheck(left, right), sub_taylor_path, sub_after_taylor);
+        ctx_.builder().SetInsertPoint(sub_taylor_path);
+        llvm::Value* sub_twr = emitTaylorBinaryCall(left, right, 1);
+        ctx_.builder().CreateBr(merge);
+        llvm::BasicBlock* sub_twr_exit = ctx_.builder().GetInsertBlock();
+        ctx_.builder().SetInsertPoint(sub_after_taylor);
+
         llvm::Value* any_bignum = emitIsBignumCheck(left, right);
         llvm::BasicBlock* check_rational = llvm::BasicBlock::Create(ctx_.context(), "sub_check_rational", func);
         ctx_.builder().CreateCondBr(any_bignum, bignum_path, check_rational);
@@ -973,7 +1088,8 @@ llvm::Value* ArithmeticCodegen::sub(llvm::Value* left, llvm::Value* right) {
 
         // Merge all non-AD paths
         ctx_.builder().SetInsertPoint(merge);
-        llvm::PHINode* phi = ctx_.builder().CreatePHI(ctx_.taggedValueType(), 8, "sub_result");
+        llvm::PHINode* phi = ctx_.builder().CreatePHI(ctx_.taggedValueType(), 9, "sub_result");
+        phi->addIncoming(sub_twr, sub_twr_exit);
         phi->addIncoming(bn_sub_tagged, bignum_exit);
         phi->addIncoming(rat_sub_tagged, rational_exit);
         phi->addIncoming(vec_result, vector_exit);
@@ -1029,6 +1145,16 @@ llvm::Value* ArithmeticCodegen::mul(llvm::Value* left, llvm::Value* right) {
         llvm::BasicBlock* merge = llvm::BasicBlock::Create(ctx_.context(), "mul_merge", func);
 
         // Check bignum first via safe runtime call
+        // ESH-0186: intercept Taylor towers before the heap/tensor path.
+        llvm::BasicBlock* mul_taylor_path = llvm::BasicBlock::Create(ctx_.context(), "mul_taylor", func);
+        llvm::BasicBlock* mul_after_taylor = llvm::BasicBlock::Create(ctx_.context(), "mul_after_taylor", func);
+        ctx_.builder().CreateCondBr(emitIsTaylorCheck(left, right), mul_taylor_path, mul_after_taylor);
+        ctx_.builder().SetInsertPoint(mul_taylor_path);
+        llvm::Value* mul_twr = emitTaylorBinaryCall(left, right, 2);
+        ctx_.builder().CreateBr(merge);
+        llvm::BasicBlock* mul_twr_exit = ctx_.builder().GetInsertBlock();
+        ctx_.builder().SetInsertPoint(mul_after_taylor);
+
         llvm::Value* any_bignum = emitIsBignumCheck(left, right);
         llvm::BasicBlock* check_rational = llvm::BasicBlock::Create(ctx_.context(), "mul_check_rational", func);
         ctx_.builder().CreateCondBr(any_bignum, bignum_path, check_rational);
@@ -1149,7 +1275,8 @@ llvm::Value* ArithmeticCodegen::mul(llvm::Value* left, llvm::Value* right) {
 
         // Merge all non-AD paths
         ctx_.builder().SetInsertPoint(merge);
-        llvm::PHINode* phi = ctx_.builder().CreatePHI(ctx_.taggedValueType(), 8, "mul_result");
+        llvm::PHINode* phi = ctx_.builder().CreatePHI(ctx_.taggedValueType(), 9, "mul_result");
+        phi->addIncoming(mul_twr, mul_twr_exit);
         phi->addIncoming(bn_mul_tagged, bignum_exit);
         phi->addIncoming(rat_mul_tagged, rational_exit);
         phi->addIncoming(vec_result, vector_exit);
@@ -1205,6 +1332,16 @@ llvm::Value* ArithmeticCodegen::div(llvm::Value* left, llvm::Value* right) {
         llvm::BasicBlock* merge = llvm::BasicBlock::Create(ctx_.context(), "div_merge", func);
 
         // Check bignum first via safe runtime call
+        // ESH-0186: intercept Taylor towers before the heap/tensor path.
+        llvm::BasicBlock* div_taylor_path = llvm::BasicBlock::Create(ctx_.context(), "div_taylor", func);
+        llvm::BasicBlock* div_after_taylor = llvm::BasicBlock::Create(ctx_.context(), "div_after_taylor", func);
+        ctx_.builder().CreateCondBr(emitIsTaylorCheck(left, right), div_taylor_path, div_after_taylor);
+        ctx_.builder().SetInsertPoint(div_taylor_path);
+        llvm::Value* div_twr = emitTaylorBinaryCall(left, right, 3);
+        ctx_.builder().CreateBr(merge);
+        llvm::BasicBlock* div_twr_exit = ctx_.builder().GetInsertBlock();
+        ctx_.builder().SetInsertPoint(div_after_taylor);
+
         llvm::Value* any_bignum = emitIsBignumCheck(left, right);
         llvm::BasicBlock* check_rational = llvm::BasicBlock::Create(ctx_.context(), "div_check_rational", func);
         ctx_.builder().CreateCondBr(any_bignum, bignum_path, check_rational);
@@ -1370,7 +1507,8 @@ llvm::Value* ArithmeticCodegen::div(llvm::Value* left, llvm::Value* right) {
 
         // Merge all non-AD paths
         ctx_.builder().SetInsertPoint(merge);
-        llvm::PHINode* phi = ctx_.builder().CreatePHI(ctx_.taggedValueType(), 8, "div_result");
+        llvm::PHINode* phi = ctx_.builder().CreatePHI(ctx_.taggedValueType(), 9, "div_result");
+        phi->addIncoming(div_twr, div_twr_exit);
         phi->addIncoming(bn_div_tagged, bignum_exit);
         phi->addIncoming(rat_div_tagged, rational_exit);
         phi->addIncoming(vec_result, vector_exit);
@@ -1751,9 +1889,27 @@ llvm::Value* ArithmeticCodegen::extractAsDouble(llvm::Value* tagged_val) {
     ctx_.builder().CreateBr(merge_bb);
     rational_bb = ctx_.builder().GetInsertBlock();
 
+    // ESH-0186: a Taylor tower coerces to its primal coefficient c[0].
+    ctx_.builder().SetInsertPoint(bignum_bb);
+    llvm::Value* ead_is_taylor = ctx_.builder().CreateICmpEQ(subtype,
+        llvm::ConstantInt::get(ctx_.int8Type(), HEAP_SUBTYPE_TAYLOR));
+    llvm::BasicBlock* ead_taylor_bb = llvm::BasicBlock::Create(ctx_.context(), "ead_taylor", func);
+    llvm::BasicBlock* ead_bignum2_bb = llvm::BasicBlock::Create(ctx_.context(), "ead_bignum2", func);
+    ctx_.builder().CreateCondBr(ead_is_taylor, ead_taylor_bb, ead_bignum2_bb);
+
+    ctx_.builder().SetInsertPoint(ead_taylor_bb);
+    llvm::Value* ead_twr_slot = ctx_.builder().CreateAlloca(ctx_.taggedValueType(), nullptr, "ead_twr");
+    ctx_.builder().CreateStore(tagged_val, ead_twr_slot);
+    llvm::FunctionType* twr_c0_type = llvm::FunctionType::get(
+        ctx_.doubleType(), {ctx_.ptrType()}, false);
+    llvm::FunctionCallee twr_c0 = ctx_.module().getOrInsertFunction("eshkol_taylor_c0", twr_c0_type);
+    llvm::Value* twr_c0_val = ctx_.builder().CreateCall(twr_c0, {ead_twr_slot}, "ead_twr_c0");
+    ctx_.builder().CreateBr(merge_bb);
+    ead_taylor_bb = ctx_.builder().GetInsertBlock();
+
     // Bignum/other heap path: verify subtype is bignum before calling eshkol_bignum_to_double.
     // Non-numeric heap types (strings, vectors, etc.) return 0.0 instead of crashing.
-    ctx_.builder().SetInsertPoint(bignum_bb);
+    ctx_.builder().SetInsertPoint(ead_bignum2_bb);
     llvm::Value* is_bignum = ctx_.builder().CreateICmpEQ(subtype,
         llvm::ConstantInt::get(ctx_.int8Type(), HEAP_SUBTYPE_BIGNUM));
     llvm::BasicBlock* actual_bignum_bb = llvm::BasicBlock::Create(ctx_.context(), "ead_actual_bn", func);
@@ -1784,12 +1940,13 @@ llvm::Value* ArithmeticCodegen::extractAsDouble(llvm::Value* tagged_val) {
 
     // Merge
     ctx_.builder().SetInsertPoint(merge_bb);
-    llvm::PHINode* phi = ctx_.builder().CreatePHI(ctx_.doubleType(), 7, "as_double");
+    llvm::PHINode* phi = ctx_.builder().CreatePHI(ctx_.doubleType(), 8, "as_double");
     phi->addIncoming(ad_val, ad_bb);
     phi->addIncoming(dual_val, dual_bb);
     phi->addIncoming(dbl_val, dbl_bb);
     phi->addIncoming(rat_dbl, rational_bb);
     phi->addIncoming(bn_dbl, actual_bignum_bb);
+    phi->addIncoming(twr_c0_val, ead_taylor_bb);
     phi->addIncoming(zero_fallback, non_numeric_bb);
     phi->addIncoming(int_as_dbl, int_bb);
     return phi;
@@ -2053,6 +2210,16 @@ llvm::Value* ArithmeticCodegen::pow(llvm::Value* base, llvm::Value* exponent) {
         llvm::BasicBlock* regular_path = llvm::BasicBlock::Create(ctx_.context(), "pow_regular", func);
         llvm::BasicBlock* merge = llvm::BasicBlock::Create(ctx_.context(), "pow_merge", func);
 
+        // ESH-0186: intercept Taylor towers before the exact/bignum-pow path.
+        llvm::BasicBlock* pow_taylor = llvm::BasicBlock::Create(ctx_.context(), "pow_taylor", func);
+        llvm::BasicBlock* pow_after_taylor = llvm::BasicBlock::Create(ctx_.context(), "pow_after_taylor", func);
+        ctx_.builder().CreateCondBr(emitIsTaylorCheck(base, exponent), pow_taylor, pow_after_taylor);
+        ctx_.builder().SetInsertPoint(pow_taylor);
+        llvm::Value* pow_twr = emitTaylorBinaryCall(base, exponent, 4);
+        ctx_.builder().CreateBr(merge);
+        llvm::BasicBlock* pow_twr_exit = ctx_.builder().GetInsertBlock();
+        ctx_.builder().SetInsertPoint(pow_after_taylor);
+
         // Check for dual numbers
         llvm::Value* base_is_dual = ctx_.builder().CreateICmpEQ(base_base,
             llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_DUAL_NUMBER));
@@ -2134,7 +2301,8 @@ llvm::Value* ArithmeticCodegen::pow(llvm::Value* base, llvm::Value* exponent) {
 
         // Merge paths
         ctx_.builder().SetInsertPoint(merge);
-        llvm::PHINode* phi = ctx_.builder().CreatePHI(ctx_.taggedValueType(), 3, "pow_result");
+        llvm::PHINode* phi = ctx_.builder().CreatePHI(ctx_.taggedValueType(), 4, "pow_result");
+        phi->addIncoming(pow_twr, pow_twr_exit);
         phi->addIncoming(dual_tagged, dual_exit);
         phi->addIncoming(exact_result, exact_exit);
         phi->addIncoming(regular_tagged, regular_exit);

--- a/lib/backend/autodiff_codegen.cpp
+++ b/lib/backend/autodiff_codegen.cpp
@@ -231,11 +231,53 @@ void AutodiffCodegen::adPertLevelStore(llvm::Value* level) {
     ctx_.builder().CreateStore(level, g);
 }
 
+// === ESH-0186: runtime Taylor-tower kernel declarations (lib/core/runtime_taylor.c) ===
+namespace {
+llvm::Function* getTaylorSeedFunc(CodegenContext& ctx) {
+    if (auto* f = ctx.module().getFunction("eshkol_taylor_seed_tagged")) return f;
+    // void eshkol_taylor_seed_tagged(arena*, const tagged* point, i32 order, tagged* out)
+    llvm::Type* p = ctx.ptrType();
+    auto* ft = llvm::FunctionType::get(ctx.voidType(),
+        {p, p, ctx.int32Type(), p}, false);
+    return llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
+                                  "eshkol_taylor_seed_tagged", &ctx.module());
+}
+llvm::Function* getTaylorExtractFunc(CodegenContext& ctx) {
+    if (auto* f = ctx.module().getFunction("eshkol_taylor_extract")) return f;
+    // double eshkol_taylor_extract(const tagged* tower, i32 n)
+    auto* ft = llvm::FunctionType::get(ctx.doubleType(),
+        {ctx.ptrType(), ctx.int32Type()}, false);
+    return llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
+                                  "eshkol_taylor_extract", &ctx.module());
+}
+llvm::Function* getTaylorCoeffsFunc(CodegenContext& ctx) {
+    if (auto* f = ctx.module().getFunction("eshkol_taylor_coeffs_list")) return f;
+    // void eshkol_taylor_coeffs_list(arena*, const tagged* tower, i32 k, tagged* out)
+    llvm::Type* p = ctx.ptrType();
+    auto* ft = llvm::FunctionType::get(ctx.voidType(),
+        {p /*arena*/, p /*tower*/, ctx.int32Type(), p /*out*/}, false);
+    return llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
+                                  "eshkol_taylor_coeffs_list", &ctx.module());
+}
+} // namespace
+
 llvm::Value* AutodiffCodegen::seedForwardAndPush(llvm::Value* point_tagged,
                                                  llvm::Value** out_level) {
     auto& b = ctx_.builder();
     llvm::Value* level = adPertLevelLoad();
     if (out_level) *out_level = level;
+
+    // ── Taylor-tower mode (ESH-0186): seed a heap tower {x0,1,0,...} of the
+    // requested order under a fresh perturbation epoch instead of a jet. The
+    // jet path below is untouched when adTowerMode_ == NONE (order <= 2). ──
+    if (adTowerMode_ != TowerMode::NONE && adTowerOrder_) {
+        llvm::Value* point_slot = ctx_.builder().CreateAlloca(ctx_.taggedValueType(), nullptr, "twr_point");
+        llvm::Value* out_slot   = ctx_.builder().CreateAlloca(ctx_.taggedValueType(), nullptr, "twr_seed_out");
+        ctx_.builder().CreateStore(point_tagged, point_slot);
+        ctx_.builder().CreateCall(getTaylorSeedFunc(ctx_),
+            {getArenaPtr(), point_slot, adTowerOrder_, out_slot});
+        return ctx_.builder().CreateLoad(ctx_.taggedValueType(), out_slot, "twr_seeded");
+    }
 
     // Push: the callee body runs one perturbation level deeper.
     adPertLevelStore(b.CreateAdd(level, llvm::ConstantInt::get(ctx_.int64Type(), 1)));
@@ -291,6 +333,23 @@ llvm::Value* AutodiffCodegen::popAndExtractForward(llvm::Value* result_tagged,
     auto& b = ctx_.builder();
     // Pop: restore the level the outer context expects.
     adPertLevelStore(level);
+
+    // ── Taylor-tower mode (ESH-0186): extract from the heap tower returned by
+    // the differentiated function. DERIV_N -> f^(k)=k!*c[k] (a double); COEFFS
+    // -> the K+1-element coefficient list. Short-circuits the jet R->Rⁿ logic. ──
+    if (adTowerMode_ == TowerMode::DERIV_N && adTowerOrder_) {
+        llvm::Value* res_slot = b.CreateAlloca(ctx_.taggedValueType(), nullptr, "twr_res");
+        b.CreateStore(result_tagged, res_slot);
+        llvm::Value* d = b.CreateCall(getTaylorExtractFunc(ctx_), {res_slot, adTowerOrder_});
+        return tagged_.packDouble(d);
+    }
+    if (adTowerMode_ == TowerMode::COEFFS && adTowerOrder_) {
+        llvm::Value* res_slot = b.CreateAlloca(ctx_.taggedValueType(), nullptr, "twr_res");
+        llvm::Value* out_slot = b.CreateAlloca(ctx_.taggedValueType(), nullptr, "twr_list_out");
+        b.CreateStore(result_tagged, res_slot);
+        b.CreateCall(getTaylorCoeffsFunc(ctx_), {getArenaPtr(), res_slot, adTowerOrder_, out_slot});
+        return b.CreateLoad(ctx_.taggedValueType(), out_slot, "twr_coeffs");
+    }
 
     llvm::Function* fn = b.GetInsertBlock()->getParent();
 
@@ -6103,6 +6162,22 @@ llvm::Value* AutodiffCodegen::derivative(const eshkol_operations_t* op) {
         return derivativeHigherOrder(op);
     }
 
+    // ESH-0186 / ESH-0118 closure: a nested `derivative` chain of depth >= 3 is
+    // pure repeated univariate differentiation, which the 2-level jet returns 0
+    // for. Detect the pure chain and route it through the arbitrary-order Taylor
+    // tower (derivative-n of the innermost base at the outermost point). Depth
+    // <= 2 falls through unchanged to the exact jet path below.
+    {
+        const eshkol_ast* inner_fn = nullptr;
+        const eshkol_ast* outer_pt = nullptr;
+        int depth = detectPureDerivChain(op, &inner_fn, &outer_pt);
+        if (depth >= 3 && inner_fn && outer_pt) {
+            eshkol_info("derivative: routing depth-%d nested chain through the Taylor tower (ESH-0118)", depth);
+            llvm::Value* order = llvm::ConstantInt::get(ctx_.int32Type(), depth);
+            return taylorApiCore(inner_fn, outer_pt, order, TowerMode::DERIV_N);
+        }
+    }
+
     if (!resolve_lambda_callback_ || !codegen_ast_callback_) {
         eshkol_error("derivative: Required callbacks not set");
         return tagged_.packNull();
@@ -6130,6 +6205,115 @@ llvm::Value* AutodiffCodegen::derivative(const eshkol_operations_t* op) {
     // Delegate to it.  v1.3 should re-extract this logic into a shared
     // helper rather than keeping two parallel implementations.
     return codegenDerivativeMonolith(op);
+}
+
+// === Arbitrary-order Taylor-tower AD entry points (ESH-0186, P1) ===
+//
+// (taylor f x k) and (derivative-n f x k) share codegenDerivativeMonolith's
+// resolve/capture/call machinery; the only difference from the jet path is that
+// seedForwardAndPush seeds a heap Taylor tower of order k (fresh perturbation
+// epoch) and popAndExtractForward extracts from the returned tower. That
+// re-pointing is gated on adTowerMode_, so the order-<=2 jet path is byte-for-
+// byte unchanged whenever these entry points are not on the stack.
+//
+// taylor_op {function, point, order} overlaps derivative_op {function, point}
+// field-for-field (same offsets), so the monolith reads function/point via the
+// derivative_op alias unchanged.
+// Shared implementation: build a synthetic derivative op referencing
+// function_ast/point_ast (which alias derivative_op.function/.point that the
+// monolith reads), set the tower mode + order, and run the monolith. The
+// monolith's seedForwardAndPush/popAndExtractForward are re-pointed at the
+// Taylor kernel while adTowerMode_ != NONE.
+llvm::Value* AutodiffCodegen::taylorApiCore(const eshkol_ast* function_ast,
+                                            const eshkol_ast* point_ast,
+                                            llvm::Value* order_i32, TowerMode mode) {
+    eshkol_operations_t tmp;
+    tmp.op = ESHKOL_DERIVATIVE_N_OP;
+    tmp.taylor_op.function = const_cast<eshkol_ast*>(function_ast);
+    tmp.taylor_op.point = const_cast<eshkol_ast*>(point_ast);
+    tmp.taylor_op.order = nullptr;  // order supplied as the LLVM value below
+
+    TowerMode saved_mode = adTowerMode_; llvm::Value* saved_order = adTowerOrder_;
+    adTowerMode_ = mode; adTowerOrder_ = order_i32;
+    llvm::Value* r = codegenDerivativeMonolith(&tmp);
+    adTowerMode_ = saved_mode; adTowerOrder_ = saved_order;
+    return r ? r : tagged_.packNull();
+}
+
+static llvm::Value* coerceOrderToI32(CodegenContext& ctx, TaggedValueCodegen& tagged,
+                                     llvm::Value* order) {
+    if (!order) return nullptr;
+    if (order->getType() == ctx.taggedValueType()) order = tagged.unpackInt64(order);
+    if (order->getType()->isDoubleTy()) order = ctx.builder().CreateFPToSI(order, ctx.int32Type());
+    else if (order->getType()->isIntegerTy()) order = ctx.builder().CreateIntCast(order, ctx.int32Type(), true);
+    return order;
+}
+
+llvm::Value* AutodiffCodegen::derivativeN(const eshkol_operations_t* op) {
+    if (!op->taylor_op.function || !op->taylor_op.point || !op->taylor_op.order) {
+        eshkol_error("derivative-n requires (derivative-n f x k)");
+        return tagged_.packNull();
+    }
+    llvm::Value* order = coerceOrderToI32(ctx_, tagged_,
+        codegen_ast_callback_(op->taylor_op.order, callback_context_));
+    if (!order) { eshkol_error("derivative-n: failed to evaluate order"); return tagged_.packNull(); }
+    return taylorApiCore(op->taylor_op.function, op->taylor_op.point, order, TowerMode::DERIV_N);
+}
+
+llvm::Value* AutodiffCodegen::taylorSeries(const eshkol_operations_t* op) {
+    if (!op->taylor_op.function || !op->taylor_op.point || !op->taylor_op.order) {
+        eshkol_error("taylor requires (taylor f x k)");
+        return tagged_.packNull();
+    }
+    llvm::Value* order = coerceOrderToI32(ctx_, tagged_,
+        codegen_ast_callback_(op->taylor_op.order, callback_context_));
+    if (!order) { eshkol_error("taylor: failed to evaluate order"); return tagged_.packNull(); }
+    return taylorApiCore(op->taylor_op.function, op->taylor_op.point, order, TowerMode::COEFFS);
+}
+
+// See header. Walks a nested `derivative` chain; returns total depth if it is
+// pure repeated univariate differentiation threading one variable, else 0.
+int AutodiffCodegen::detectPureDerivChain(const eshkol_operations_t* op,
+                                          const eshkol_ast** innermost_func,
+                                          const eshkol_ast** outer_point) {
+    if (!op || op->op != ESHKOL_DERIVATIVE_OP) return 0;
+    *outer_point = op->derivative_op.point;
+    const eshkol_operations_t* cur = op;
+    int depth = 0;
+    for (;;) {
+        const eshkol_ast* fn = cur->derivative_op.function;
+        if (!fn) return 0;
+        // Innermost differentiates a named function directly (`named` binding).
+        if (fn->type == ESHKOL_VAR) {
+            depth++;
+            *innermost_func = fn;
+            return depth;
+        }
+        // Otherwise it must be a single-parameter lambda.
+        if (fn->type != ESHKOL_OP || fn->operation.op != ESHKOL_LAMBDA_OP) return 0;
+        if (fn->operation.lambda_op.num_params != 1) return 0;
+        const eshkol_ast* params = fn->operation.lambda_op.parameters;
+        const eshkol_ast* body = fn->operation.lambda_op.body;
+        if (!params || !body) return 0;
+        const char* pname = params[0].variable.id;
+        if (!pname) return 0;
+        depth++;
+        // Is the lambda body itself a `derivative` threading THIS parameter?
+        if (body->type == ESHKOL_OP && body->operation.op == ESHKOL_DERIVATIVE_OP) {
+            const eshkol_ast* ipt = body->operation.derivative_op.point;
+            if (ipt && ipt->type == ESHKOL_VAR && ipt->variable.id &&
+                std::string(ipt->variable.id) == pname) {
+                cur = &body->operation;   // descend one level
+                continue;
+            }
+            // A nested derivative that does NOT thread this variable is not a
+            // pure chain — leave the whole thing on the jet path (safe).
+            return 0;
+        }
+        // Reached the base body: this lambda is the innermost function.
+        *innermost_func = fn;
+        return depth;
+    }
 }
 
 // === Static-only fast path retained for reference / future re-extraction ===

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -10301,6 +10301,10 @@ private:
                 
             case ESHKOL_DERIVATIVE_OP:
                 return autodiff_->derivative(op);
+            case ESHKOL_TAYLOR_OP:
+                return autodiff_->taylorSeries(op);
+            case ESHKOL_DERIVATIVE_N_OP:
+                return autodiff_->derivativeN(op);
             case ESHKOL_GRADIENT_OP:
                 return autodiff_->gradient(op);
             case ESHKOL_JACOBIAN_OP:
@@ -18939,6 +18943,36 @@ private:
         BasicBlock* regular_path = BasicBlock::Create(*context, (func_name + "_regular_path").c_str(), current_func);
         BasicBlock* merge = BasicBlock::Create(*context, (func_name + "_merge").c_str(), current_func);
 
+        // ESH-0186: Taylor-tower operand — route to the arbitrary-order kernel
+        // before any scalar/tensor handling. Wraps the rest of the function so a
+        // tower `sin`/`cos`/`exp`/`log`/... returns a tower, not a misread double.
+        int twr_uop = -1;
+        if      (func_name == "exp")  twr_uop = 1;
+        else if (func_name == "log")  twr_uop = 2;
+        else if (func_name == "sin")  twr_uop = 3;
+        else if (func_name == "cos")  twr_uop = 4;
+        else if (func_name == "tan")  twr_uop = 5;
+        else if (func_name == "sqrt") twr_uop = 6;
+        else if (func_name == "fabs") twr_uop = 7;
+        else if (func_name == "sinh") twr_uop = 8;
+        else if (func_name == "cosh") twr_uop = 9;
+        else if (func_name == "tanh") twr_uop = 10;
+        BasicBlock* mf_twr_done = nullptr;
+        Value* mf_twr_slot = nullptr;
+        if (twr_uop >= 0) {
+            mf_twr_done = BasicBlock::Create(*context, (func_name + "_twr_done").c_str(), current_func);
+            mf_twr_slot = builder->CreateAlloca(tagged_value_type, nullptr, (func_name + "_twr_slot").c_str());
+            BasicBlock* twr_path = BasicBlock::Create(*context, (func_name + "_twr_path").c_str(), current_func);
+            BasicBlock* twr_cont = BasicBlock::Create(*context, (func_name + "_twr_cont").c_str(), current_func);
+            Value* is_twr = isHeapSubtype(arg_tagged, HEAP_SUBTYPE_TAYLOR);
+            builder->CreateCondBr(is_twr, twr_path, twr_cont);
+            builder->SetInsertPoint(twr_path);
+            Value* twr_res = arith_->emitTaylorUnaryCall(arg_tagged, twr_uop);
+            builder->CreateStore(twr_res, mf_twr_slot);
+            builder->CreateBr(mf_twr_done);
+            builder->SetInsertPoint(twr_cont);
+        }
+
         // TENSOR OPERAND PATH: a scalar math builtin applied to a *tensor* must
         // map elementwise and return a tensor. The scalar machinery below would
         // otherwise reinterpret the tensor pointer's bits as a double and return
@@ -19301,13 +19335,23 @@ private:
 
         // If a tensor-operand fast path was emitted, merge the scalar result
         // with the elementwise-tensor result through math_done.
+        Value* mf_final;
         if (math_done) {
             builder->CreateStore(result_phi, math_result_slot);
             builder->CreateBr(math_done);
             builder->SetInsertPoint(math_done);
-            return builder->CreateLoad(tagged_value_type, math_result_slot);
+            mf_final = builder->CreateLoad(tagged_value_type, math_result_slot);
+        } else {
+            mf_final = result_phi;
         }
-        return result_phi;
+        // ESH-0186: merge the tower early-path (if emitted) with the scalar tail.
+        if (mf_twr_done) {
+            builder->CreateStore(mf_final, mf_twr_slot);
+            builder->CreateBr(mf_twr_done);
+            builder->SetInsertPoint(mf_twr_done);
+            return builder->CreateLoad(tagged_value_type, mf_twr_slot);
+        }
+        return mf_final;
     }
 
     // Polymorphic abs - handles AD/dual, then delegates to ArithmeticCodegen::abs
@@ -24750,6 +24794,19 @@ private:
                         }
                         if (op->derivative_op.point) {
                             findFreeVariablesImpl(op->derivative_op.point, current_scope, parameters, num_params, free_vars, bound_vars);
+                        }
+                        break;
+                    case ESHKOL_TAYLOR_OP:
+                    case ESHKOL_DERIVATIVE_N_OP:
+                        // ESH-0186: search function, point, and order expressions
+                        if (op->taylor_op.function) {
+                            findFreeVariablesImpl(op->taylor_op.function, current_scope, parameters, num_params, free_vars, bound_vars);
+                        }
+                        if (op->taylor_op.point) {
+                            findFreeVariablesImpl(op->taylor_op.point, current_scope, parameters, num_params, free_vars, bound_vars);
+                        }
+                        if (op->taylor_op.order) {
+                            findFreeVariablesImpl(op->taylor_op.order, current_scope, parameters, num_params, free_vars, bound_vars);
                         }
                         break;
                     case ESHKOL_DIRECTIONAL_DERIV_OP:

--- a/lib/core/runtime_taylor.c
+++ b/lib/core/runtime_taylor.c
@@ -1,0 +1,548 @@
+/*
+ * Copyright (C) tsotchke
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * runtime_taylor.c -- arbitrary-order forward-mode AD kernel (ESH-0186, P1).
+ *
+ * Univariate truncated-Taylor arithmetic ("Taylor tower"): a value is carried
+ * as its coefficient array c[0..K] of the truncated series
+ *
+ *     f(x0 + t) = sum_{k=0..K} c[k] * t^k        =>   f^(n)(x0) = n! * c[n].
+ *
+ * The differentiation variable is seeded {x0, 1, 0, ...}; a constant seeds
+ * {v, 0, ...}. All recurrences are the closed forms proven correct to d=8 in
+ * the Phase-0 POC (tests/ad_taylor_poc/taylor_poc.c) and documented in
+ * docs/design/AD_TAYLOR_TOWER.md section 5. They are the single computational
+ * kernel behind arbitrary-order `derivative`, `(derivative-n k)` and `taylor`.
+ *
+ * FP-contraction policy (design section 6a): every multiply-accumulate in the
+ * convolution recurrences uses an explicit fma() with the reduction order
+ * fixed to ascending j, so the runtime kernel and (future, P2) unrolled-IR
+ * tier are bit-exact-reconcilable rather than merely tight-ULP.
+ *
+ * Perturbation-confusion safety (design section 5a): each active
+ * differentiation context carries a 16-bit EPOCH tag in esh_taylor_t.flags.
+ * A binary op combines the full series of two towers only when their epochs
+ * match; a foreign-epoch tower (an outer/inner level) is lifted to a constant
+ * (its c[0]) with respect to the current (innermost = highest-epoch) level,
+ * exactly as JAX lifts a value from an outer trace.
+ */
+
+/* arena_memory.h declares thread-local storage with the C++/C23 spelling
+ * `thread_local`; provide it for the C11 build of this translation unit. */
+#if !defined(__cplusplus) && !defined(thread_local)
+#  if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#    define thread_local _Thread_local
+#  else
+#    define thread_local
+#  endif
+#endif
+
+#include "arena_memory.h"
+#include "../../inc/eshkol/logger.h"
+
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef __cplusplus
+#include <atomic>
+extern "C" {
+#endif
+
+/* Binary op codes (mirrored by the codegen dispatch in arithmetic_codegen). */
+#define ESH_TAYLOR_OP_ADD 0
+#define ESH_TAYLOR_OP_SUB 1
+#define ESH_TAYLOR_OP_MUL 2
+#define ESH_TAYLOR_OP_DIV 3
+#define ESH_TAYLOR_OP_POW 4
+
+/* Unary op codes. */
+#define ESH_TAYLOR_UOP_NEG  0
+#define ESH_TAYLOR_UOP_EXP  1
+#define ESH_TAYLOR_UOP_LOG  2
+#define ESH_TAYLOR_UOP_SIN  3
+#define ESH_TAYLOR_UOP_COS  4
+#define ESH_TAYLOR_UOP_TAN  5
+#define ESH_TAYLOR_UOP_SQRT 6
+#define ESH_TAYLOR_UOP_ABS  7
+#define ESH_TAYLOR_UOP_SINH 8
+#define ESH_TAYLOR_UOP_COSH 9
+#define ESH_TAYLOR_UOP_TANH 10
+
+/* ----------------------------------------------------------------------- */
+/* allocation                                                              */
+/* ----------------------------------------------------------------------- */
+
+/* Allocate a zeroed tower of order K (K+1 coefficients) with the given flags.
+ * Returns the DATA pointer (after the 8-byte object header), so it can be
+ * stored in a tagged HEAP_PTR exactly like a tensor. */
+esh_taylor_t* eshkol_taylor_alloc(arena_t* arena, uint32_t order_k, uint32_t flags) {
+    if (!arena) arena = get_global_arena();
+    if (!arena) return NULL;
+
+    size_t ncoeff = (size_t)order_k + 1;
+    size_t data_size = sizeof(esh_taylor_t) + ncoeff * sizeof(double);
+    size_t total = sizeof(eshkol_object_header_t) + data_size;
+    total = (total + 15) & ~((size_t)15);
+
+    uint8_t* mem = (uint8_t*)arena_allocate_aligned(arena, total, 16);
+    if (!mem) {
+        eshkol_error("Failed to allocate Taylor tower (order %u)", order_k);
+        return NULL;
+    }
+
+    eshkol_object_header_t* hdr = (eshkol_object_header_t*)mem;
+    hdr->subtype = HEAP_SUBTYPE_TAYLOR;
+    hdr->flags = 0;
+    hdr->ref_count = 0;
+    hdr->size = (uint32_t)data_size;
+
+    esh_taylor_t* t = (esh_taylor_t*)(mem + sizeof(eshkol_object_header_t));
+    t->order_k = order_k;
+    t->flags = flags;
+    memset(t->c, 0, ncoeff * sizeof(double));
+    return t;
+}
+
+static inline eshkol_tagged_value_t taylor_to_tagged(const esh_taylor_t* t) {
+    eshkol_tagged_value_t v;
+    memset(&v, 0, sizeof(v));
+    v.type = ESHKOL_VALUE_HEAP_PTR;
+    v.flags = ESHKOL_VALUE_INEXACT_FLAG;
+    v.data.ptr_val = (uint64_t)(uintptr_t)t;
+    return v;
+}
+
+/* If tv is a Taylor tower return its data pointer, else NULL. */
+static inline esh_taylor_t* tagged_as_taylor(const eshkol_tagged_value_t* tv) {
+    if (!tv) return NULL;
+    if ((tv->type & 0x0F) != ESHKOL_VALUE_HEAP_PTR) return NULL;
+    if (tv->data.ptr_val == 0) return NULL;
+    void* ptr = (void*)(uintptr_t)tv->data.ptr_val;
+    const eshkol_object_header_t* hdr = ESHKOL_GET_HEADER(ptr);
+    if (!hdr || hdr->subtype != HEAP_SUBTYPE_TAYLOR) return NULL;
+    return (esh_taylor_t*)ptr;
+}
+
+int eshkol_is_taylor_tagged(const eshkol_tagged_value_t* tv) {
+    return tagged_as_taylor(tv) != NULL;
+}
+
+/* Extract a plain scalar (the primal value c[0]) from any operand: a tower's
+ * c[0], a double, or an int. Used to lift constants and foreign-epoch towers. */
+static inline double tagged_scalar_value(const eshkol_tagged_value_t* tv) {
+    if (!tv) return 0.0;
+    esh_taylor_t* t = tagged_as_taylor(tv);
+    if (t) return t->c[0];
+    uint8_t bt = (uint8_t)(tv->type & 0x0F);
+    if (bt == ESHKOL_VALUE_DOUBLE) return tv->data.double_val;
+    if (bt == ESHKOL_VALUE_INT64)  return (double)tv->data.int_val;
+    return 0.0;
+}
+
+/* c[0] of a tower value (or the scalar value of a non-tower) — the coercion
+ * used when a tower flows into a plain-double numeric context. */
+double eshkol_taylor_c0(const eshkol_tagged_value_t* tv) {
+    return tagged_scalar_value(tv);
+}
+
+/* ----------------------------------------------------------------------- */
+/* recurrences (operate on raw coefficient arrays, n = K+1 entries)         */
+/* ----------------------------------------------------------------------- */
+
+static void tr_add(double* s, const double* u, const double* w, int n) {
+    for (int k = 0; k < n; k++) s[k] = u[k] + w[k];
+}
+static void tr_sub(double* s, const double* u, const double* w, int n) {
+    for (int k = 0; k < n; k++) s[k] = u[k] - w[k];
+}
+static void tr_neg(double* s, const double* u, int n) {
+    for (int k = 0; k < n; k++) s[k] = -u[k];
+}
+
+/* s = u * w : s_k = sum_{j=0..k} u_j * w_{k-j}   (Cauchy convolution, fma). */
+static void tr_mul(double* s, const double* u, const double* w, int n) {
+    for (int k = 0; k < n; k++) {
+        double acc = 0.0;
+        for (int j = 0; j <= k; j++) acc = fma(u[j], w[k - j], acc);
+        s[k] = acc;
+    }
+}
+
+/* s = u / w : s_k = ( u_k - sum_{j=1..k} w_j * s_{k-j} ) / w_0. */
+static void tr_div(double* s, const double* u, const double* w, int n) {
+    for (int k = 0; k < n; k++) {
+        double acc = u[k];
+        for (int j = 1; j <= k; j++) acc = fma(-w[j], s[k - j], acc);
+        s[k] = acc / w[0];
+    }
+}
+
+/* s = exp(u) : s_0 = exp(u_0); s_k = (1/k) sum_{j=1..k} j*u_j*s_{k-j}. */
+static void tr_exp(double* s, const double* u, int n) {
+    s[0] = exp(u[0]);
+    for (int k = 1; k < n; k++) {
+        double acc = 0.0;
+        for (int j = 1; j <= k; j++) acc = fma((double)j * u[j], s[k - j], acc);
+        s[k] = acc / (double)k;
+    }
+}
+
+/* s = log(u) : s_0 = log(u_0);
+ * s_k = ( u_k - (1/k) sum_{j=1..k-1} j*s_j*u_{k-j} ) / u_0. */
+static void tr_log(double* s, const double* u, int n) {
+    s[0] = log(u[0]);
+    for (int k = 1; k < n; k++) {
+        double acc = 0.0;
+        for (int j = 1; j <= k - 1; j++) acc = fma((double)j * s[j], u[k - j], acc);
+        s[k] = (u[k] - acc / (double)k) / u[0];
+    }
+}
+
+/* coupled: so = sin(u), co = cos(u).
+ * so_k =  (1/k) sum_{j=1..k} j*u_j*co_{k-j}
+ * co_k = -(1/k) sum_{j=1..k} j*u_j*so_{k-j}. */
+static void tr_sincos(double* so, double* co, const double* u, int n) {
+    so[0] = sin(u[0]);
+    co[0] = cos(u[0]);
+    for (int k = 1; k < n; k++) {
+        double as = 0.0, ac = 0.0;
+        for (int j = 1; j <= k; j++) {
+            double ju = (double)j * u[j];
+            as = fma(ju, co[k - j], as);
+            ac = fma(ju, so[k - j], ac);
+        }
+        so[k] =  as / (double)k;
+        co[k] = -ac / (double)k;
+    }
+}
+
+/* s = u^r (constant real exponent r):
+ * s_0 = u_0^r; s_k = (1/(k*u_0)) sum_{j=1..k} (j*r - (k-j))*u_j*s_{k-j}. */
+static void tr_pow_const(double* s, const double* u, double r, int n) {
+    s[0] = pow(u[0], r);
+    for (int k = 1; k < n; k++) {
+        double acc = 0.0;
+        for (int j = 1; j <= k; j++)
+            acc = fma(((double)j * r - (double)(k - j)) * u[j], s[k - j], acc);
+        s[k] = acc / ((double)k * u[0]);
+    }
+}
+
+/* ----------------------------------------------------------------------- */
+/* operand normalisation + epoch (perturbation-confusion) handling          */
+/* ----------------------------------------------------------------------- */
+
+/* Materialise operand `tv` as a length-`n` coefficient array into `buf`,
+ * relative to the current active epoch `active_epoch`:
+ *   - a same-epoch tower  -> its coefficients (zero-extended to n)
+ *   - a foreign tower / scalar / int -> a constant series {value, 0, ...}
+ * This is the section-5a lift: order->=1 coefficients of a foreign-epoch tower
+ * do not participate in the current level's differentiation. */
+static void normalise_operand(const eshkol_tagged_value_t* tv, uint32_t active_epoch,
+                              double* buf, int n) {
+    memset(buf, 0, (size_t)n * sizeof(double));
+    esh_taylor_t* t = tagged_as_taylor(tv);
+    if (t && ESH_TAYLOR_GET_EPOCH(t->flags) == active_epoch) {
+        int m = (int)t->order_k + 1;
+        if (m > n) m = n;
+        memcpy(buf, t->c, (size_t)m * sizeof(double));
+    } else {
+        buf[0] = tagged_scalar_value(tv);
+    }
+}
+
+/* The order and active epoch a result should carry: the max order and max
+ * epoch across the tower operands (scalars contribute nothing). */
+static void result_shape(const eshkol_tagged_value_t* l, const eshkol_tagged_value_t* r,
+                         uint32_t* order_k, uint32_t* epoch) {
+    esh_taylor_t* lt = tagged_as_taylor(l);
+    esh_taylor_t* rt = tagged_as_taylor(r);
+    uint32_t k = 0, e = 0;
+    if (lt) { if (lt->order_k > k) k = lt->order_k; }
+    if (rt) { if (rt->order_k > k) k = rt->order_k; }
+    if (lt) { uint32_t le = ESH_TAYLOR_GET_EPOCH(lt->flags); if (le > e) e = le; }
+    if (rt) { uint32_t re = ESH_TAYLOR_GET_EPOCH(rt->flags); if (re > e) e = re; }
+    *order_k = k;
+    *epoch = e;
+}
+
+/* ----------------------------------------------------------------------- */
+/* tagged binary / unary dispatch (called from codegen)                     */
+/* ----------------------------------------------------------------------- */
+
+/* Small stack buffer avoids a heap alloc for the common orders; falls back
+ * to the arena for very high K. */
+#define ESH_TAYLOR_STACKN 64
+
+void eshkol_taylor_binary_tagged(arena_t* arena,
+    const eshkol_tagged_value_t* left, const eshkol_tagged_value_t* right,
+    int op, eshkol_tagged_value_t* result) {
+    if (!arena) arena = get_global_arena();
+
+    uint32_t order_k, epoch;
+    result_shape(left, right, &order_k, &epoch);
+    int n = (int)order_k + 1;
+
+    double sbuf_u[ESH_TAYLOR_STACKN], sbuf_w[ESH_TAYLOR_STACKN];
+    double *u = sbuf_u, *w = sbuf_w;
+    double *hu = NULL, *hw = NULL;
+    if (n > ESH_TAYLOR_STACKN) {
+        hu = (double*)arena_allocate(arena, (size_t)n * sizeof(double));
+        hw = (double*)arena_allocate(arena, (size_t)n * sizeof(double));
+        u = hu; w = hw;
+    }
+    normalise_operand(left, epoch, u, n);
+    normalise_operand(right, epoch, w, n);
+
+    esh_taylor_t* out = eshkol_taylor_alloc(arena, order_k,
+                                            ESH_TAYLOR_MK_FLAGS(ESH_TAYLOR_COEFF_F64, epoch));
+    if (!out) { *result = eshkol_make_double(0.0); return; }
+
+    switch (op) {
+        case ESH_TAYLOR_OP_ADD: tr_add(out->c, u, w, n); break;
+        case ESH_TAYLOR_OP_SUB: tr_sub(out->c, u, w, n); break;
+        case ESH_TAYLOR_OP_MUL: tr_mul(out->c, u, w, n); break;
+        case ESH_TAYLOR_OP_DIV: tr_div(out->c, u, w, n); break;
+        case ESH_TAYLOR_OP_POW: {
+            /* If the exponent is a plain constant (only c[0] set), use the exact
+             * power recurrence; otherwise u^w = exp(w * log(u)). */
+            int w_is_const = 1;
+            for (int k = 1; k < n; k++) if (w[k] != 0.0) { w_is_const = 0; break; }
+            if (w_is_const) {
+                tr_pow_const(out->c, u, w[0], n);
+            } else {
+                double lb[ESH_TAYLOR_STACKN], pb[ESH_TAYLOR_STACKN];
+                double *lg = lb, *pr = pb, *hlg = NULL, *hpr = NULL;
+                if (n > ESH_TAYLOR_STACKN) {
+                    hlg = (double*)arena_allocate(arena, (size_t)n * sizeof(double));
+                    hpr = (double*)arena_allocate(arena, (size_t)n * sizeof(double));
+                    lg = hlg; pr = hpr;
+                }
+                tr_log(lg, u, n);
+                tr_mul(pr, w, lg, n);
+                tr_exp(out->c, pr, n);
+            }
+            break;
+        }
+        default: tr_add(out->c, u, w, n); break;
+    }
+    *result = taylor_to_tagged(out);
+}
+
+void eshkol_taylor_unary_tagged(arena_t* arena,
+    const eshkol_tagged_value_t* in, int op, eshkol_tagged_value_t* result) {
+    if (!arena) arena = get_global_arena();
+
+    esh_taylor_t* t = tagged_as_taylor(in);
+    uint32_t order_k = t ? t->order_k : 0;
+    uint32_t epoch = t ? ESH_TAYLOR_GET_EPOCH(t->flags) : 0;
+    int n = (int)order_k + 1;
+
+    double sbuf_u[ESH_TAYLOR_STACKN];
+    double* u = sbuf_u;
+    double* hu = NULL;
+    if (n > ESH_TAYLOR_STACKN) {
+        hu = (double*)arena_allocate(arena, (size_t)n * sizeof(double));
+        u = hu;
+    }
+    normalise_operand(in, epoch, u, n);
+
+    esh_taylor_t* out = eshkol_taylor_alloc(arena, order_k,
+                                            ESH_TAYLOR_MK_FLAGS(ESH_TAYLOR_COEFF_F64, epoch));
+    if (!out) { *result = eshkol_make_double(0.0); return; }
+
+    switch (op) {
+        case ESH_TAYLOR_UOP_NEG: tr_neg(out->c, u, n); break;
+        case ESH_TAYLOR_UOP_EXP: tr_exp(out->c, u, n); break;
+        case ESH_TAYLOR_UOP_LOG: tr_log(out->c, u, n); break;
+        case ESH_TAYLOR_UOP_SIN: {
+            double cbuf[ESH_TAYLOR_STACKN]; double* co = cbuf;
+            double* hco = NULL;
+            if (n > ESH_TAYLOR_STACKN) { hco = (double*)arena_allocate(arena, (size_t)n*sizeof(double)); co = hco; }
+            tr_sincos(out->c, co, u, n);
+            break;
+        }
+        case ESH_TAYLOR_UOP_COS: {
+            double sbuf[ESH_TAYLOR_STACKN]; double* so = sbuf;
+            double* hso = NULL;
+            if (n > ESH_TAYLOR_STACKN) { hso = (double*)arena_allocate(arena, (size_t)n*sizeof(double)); so = hso; }
+            tr_sincos(so, out->c, u, n);
+            break;
+        }
+        case ESH_TAYLOR_UOP_TAN: {
+            double sb[ESH_TAYLOR_STACKN], cb[ESH_TAYLOR_STACKN];
+            double *so = sb, *co = cb, *hso = NULL, *hco = NULL;
+            if (n > ESH_TAYLOR_STACKN) {
+                hso = (double*)arena_allocate(arena, (size_t)n*sizeof(double));
+                hco = (double*)arena_allocate(arena, (size_t)n*sizeof(double));
+                so = hso; co = hco;
+            }
+            tr_sincos(so, co, u, n);
+            tr_div(out->c, so, co, n);
+            break;
+        }
+        case ESH_TAYLOR_UOP_SQRT: tr_pow_const(out->c, u, 0.5, n); break;
+        case ESH_TAYLOR_UOP_ABS: {
+            double sgn = (u[0] < 0.0) ? -1.0 : 1.0;
+            out->c[0] = fabs(u[0]);
+            for (int k = 1; k < n; k++) out->c[k] = sgn * u[k];
+            break;
+        }
+        case ESH_TAYLOR_UOP_SINH: {
+            /* sinh(u) = (exp(u) - exp(-u))/2 */
+            double eb[ESH_TAYLOR_STACKN], nb[ESH_TAYLOR_STACKN], mb[ESH_TAYLOR_STACKN];
+            double *ep = eb, *nu = nb, *em = mb;
+            double *hep=NULL,*hnu=NULL,*hem=NULL;
+            if (n > ESH_TAYLOR_STACKN) { hep=(double*)arena_allocate(arena,(size_t)n*sizeof(double));hnu=(double*)arena_allocate(arena,(size_t)n*sizeof(double));hem=(double*)arena_allocate(arena,(size_t)n*sizeof(double));ep=hep;nu=hnu;em=hem;}
+            tr_exp(ep, u, n);
+            tr_neg(nu, u, n);
+            tr_exp(em, nu, n);
+            for (int k = 0; k < n; k++) out->c[k] = 0.5 * (ep[k] - em[k]);
+            break;
+        }
+        case ESH_TAYLOR_UOP_COSH: {
+            double eb[ESH_TAYLOR_STACKN], nb[ESH_TAYLOR_STACKN], mb[ESH_TAYLOR_STACKN];
+            double *ep = eb, *nu = nb, *em = mb;
+            double *hep=NULL,*hnu=NULL,*hem=NULL;
+            if (n > ESH_TAYLOR_STACKN) { hep=(double*)arena_allocate(arena,(size_t)n*sizeof(double));hnu=(double*)arena_allocate(arena,(size_t)n*sizeof(double));hem=(double*)arena_allocate(arena,(size_t)n*sizeof(double));ep=hep;nu=hnu;em=hem;}
+            tr_exp(ep, u, n);
+            tr_neg(nu, u, n);
+            tr_exp(em, nu, n);
+            for (int k = 0; k < n; k++) out->c[k] = 0.5 * (ep[k] + em[k]);
+            break;
+        }
+        case ESH_TAYLOR_UOP_TANH: {
+            /* tanh via sinh/cosh */
+            double sb[ESH_TAYLOR_STACKN], cbb[ESH_TAYLOR_STACKN], eb[ESH_TAYLOR_STACKN], nb[ESH_TAYLOR_STACKN], mb[ESH_TAYLOR_STACKN];
+            double *sh=sb,*ch=cbb,*ep=eb,*nu=nb,*em=mb;
+            double *hsh=NULL,*hch=NULL,*hep=NULL,*hnu=NULL,*hem=NULL;
+            if (n > ESH_TAYLOR_STACKN) { hsh=(double*)arena_allocate(arena,(size_t)n*sizeof(double));hch=(double*)arena_allocate(arena,(size_t)n*sizeof(double));hep=(double*)arena_allocate(arena,(size_t)n*sizeof(double));hnu=(double*)arena_allocate(arena,(size_t)n*sizeof(double));hem=(double*)arena_allocate(arena,(size_t)n*sizeof(double));sh=hsh;ch=hch;ep=hep;nu=hnu;em=hem;}
+            tr_exp(ep, u, n);
+            tr_neg(nu, u, n);
+            tr_exp(em, nu, n);
+            for (int k = 0; k < n; k++) { sh[k] = 0.5*(ep[k]-em[k]); ch[k] = 0.5*(ep[k]+em[k]); }
+            tr_div(out->c, sh, ch, n);
+            break;
+        }
+        default: memcpy(out->c, u, (size_t)n * sizeof(double)); break;
+    }
+    *result = taylor_to_tagged(out);
+}
+
+/* ----------------------------------------------------------------------- */
+/* seeding, extraction, differentiation (called from codegen for the API)   */
+/* ----------------------------------------------------------------------- */
+
+/* Monotonic epoch counter. 0 is reserved for "no active perturbation"
+ * (scalars / constants); every fresh differentiation context gets >= 1. */
+#ifdef __cplusplus
+static std::atomic<uint32_t> g_taylor_epoch{0};
+uint32_t eshkol_taylor_next_epoch(void) {
+    uint32_t e = g_taylor_epoch.fetch_add(1) + 1;
+    /* 16-bit tag: wrap back to 1 (never 0). */
+    return ((e - 1) & 0xFFFFu) + 1;
+}
+#else
+static uint32_t g_taylor_epoch = 0;
+uint32_t eshkol_taylor_next_epoch(void) {
+    uint32_t e = ++g_taylor_epoch;
+    return ((e - 1) & 0xFFFFu) + 1;
+}
+#endif
+
+/* Seed a tower: {x0, is_var ? 1 : 0, 0, ...} of order K under `epoch`. */
+void eshkol_taylor_seed(arena_t* arena, double x0, int is_var,
+                        uint32_t order_k, uint32_t epoch,
+                        eshkol_tagged_value_t* out) {
+    if (!arena) arena = get_global_arena();
+    esh_taylor_t* t = eshkol_taylor_alloc(arena, order_k,
+                                          ESH_TAYLOR_MK_FLAGS(ESH_TAYLOR_COEFF_F64, epoch));
+    if (!t) { *out = eshkol_make_double(x0); return; }
+    t->c[0] = x0;
+    if (is_var && order_k >= 1) t->c[1] = 1.0;
+    *out = taylor_to_tagged(t);
+}
+
+/* Seed the differentiation variable from a tagged point at a FRESH epoch.
+ * Reads x0 as the point's scalar value (a plain double/int, or c[0] of an
+ * outer tower) and produces {x0, 1, 0, ...} of order K. Called by codegen for
+ * (taylor f x k) / (derivative-n f x k). */
+void eshkol_taylor_seed_tagged(arena_t* arena, const eshkol_tagged_value_t* point,
+                               int32_t order_k, eshkol_tagged_value_t* out) {
+    if (!arena) arena = get_global_arena();
+    if (order_k < 0) order_k = 0;
+    double x0 = tagged_scalar_value(point);
+    uint32_t epoch = eshkol_taylor_next_epoch();
+    eshkol_taylor_seed(arena, x0, 1, (uint32_t)order_k, epoch, out);
+}
+
+static double factorial_d(uint32_t n) {
+    double f = 1.0;
+    for (uint32_t i = 2; i <= n; i++) f *= (double)i;
+    return f;
+}
+
+/* f^(n)(x0) = n! * c[n]. Non-towers: value at n==0, else 0. */
+double eshkol_taylor_extract(const eshkol_tagged_value_t* tv, uint32_t n) {
+    esh_taylor_t* t = tagged_as_taylor(tv);
+    if (!t) return (n == 0) ? tagged_scalar_value(tv) : 0.0;
+    if (n > t->order_k) return 0.0;
+    return factorial_d(n) * t->c[n];
+}
+
+/* Differentiate a tower: (f')_k = (k+1) * c_{k+1}. Preserves order/epoch;
+ * the top coefficient becomes 0. Non-towers differentiate to 0. */
+void eshkol_taylor_shift(arena_t* arena, const eshkol_tagged_value_t* tv,
+                         eshkol_tagged_value_t* out) {
+    if (!arena) arena = get_global_arena();
+    esh_taylor_t* t = tagged_as_taylor(tv);
+    if (!t) { *out = eshkol_make_double(0.0); return; }
+    esh_taylor_t* r = eshkol_taylor_alloc(arena, t->order_k, t->flags);
+    if (!r) { *out = eshkol_make_double(0.0); return; }
+    for (uint32_t k = 0; k < t->order_k; k++)
+        r->c[k] = (double)(k + 1) * t->c[k + 1];
+    r->c[t->order_k] = 0.0;
+    *out = taylor_to_tagged(r);
+}
+
+/* Build a Scheme list of the K+1 coefficients (c[0] first) for `(taylor f x k)`.
+ * Written through `out` (out-param convention, matching the codegen call). */
+void eshkol_taylor_coeffs_list(arena_t* arena, const eshkol_tagged_value_t* tv,
+                               int32_t order_k_in, eshkol_tagged_value_t* out) {
+    if (!arena) arena = get_global_arena();
+    if (order_k_in < 0) order_k_in = 0;
+    uint32_t order_k = (uint32_t)order_k_in;
+    eshkol_tagged_value_t nil;
+    memset(&nil, 0, sizeof(nil));
+    nil.type = ESHKOL_VALUE_NULL;
+
+    esh_taylor_t* t = tagged_as_taylor(tv);
+    eshkol_tagged_value_t acc = nil;
+    /* cons from the tail so element order is c[0], c[1], ..., c[K]. */
+    for (int k = (int)order_k; k >= 0; k--) {
+        double cv = 0.0;
+        if (t) {
+            cv = ((uint32_t)k <= t->order_k) ? t->c[k] : 0.0;
+        } else {
+            cv = (k == 0) ? tagged_scalar_value(tv) : 0.0;
+        }
+        arena_tagged_cons_cell_t* cell = arena_allocate_cons_with_header(arena);
+        if (!cell) { *out = nil; return; }
+        cell->car = eshkol_make_double(cv);
+        cell->cdr = acc;
+        eshkol_tagged_value_t v;
+        memset(&v, 0, sizeof(v));
+        v.type = ESHKOL_VALUE_HEAP_PTR;
+        v.data.ptr_val = (uint64_t)(uintptr_t)cell;
+        acc = v;
+    }
+    *out = acc;
+}
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif

--- a/lib/core/taylor_recurrences.def
+++ b/lib/core/taylor_recurrences.def
@@ -1,0 +1,49 @@
+/*
+ * taylor_recurrences.def -- single source of truth for the Taylor-tower
+ * primitives (ESH-0186, docs/design/AD_TAYLOR_TOWER.md section 5b).
+ *
+ * X-macro table. Each row names a primitive, its arity, the runtime op-code
+ * (as consumed by eshkol_taylor_binary_tagged / eshkol_taylor_unary_tagged),
+ * and a d=8 analytic self-test spec (a C-library reference function + a test
+ * point) so that a per-primitive correctness gate can be generated from the
+ * same table that defines the kernel.
+ *
+ * P1 consumes this table for the runtime kernel (lib/core/runtime_taylor.c) and
+ * the analytic self-test (tests/ad/taylor_recurrences_test.c). The IR-emitter
+ * column (unrolled straight-line SSA) is reserved for P2 monomorphization
+ * (ESH-0187) and is intentionally not expanded here yet.
+ *
+ * Columns:
+ *   TAYLOR_BIN(name, OPCODE)              -- binary recurrence
+ *   TAYLOR_UN (name, OPCODE, TESTFN, X0)  -- unary recurrence + d=8 test spec
+ */
+
+#ifndef TAYLOR_BIN
+#define TAYLOR_BIN(name, opcode)
+#endif
+#ifndef TAYLOR_UN
+#define TAYLOR_UN(name, opcode, testfn, x0)
+#endif
+
+/* --- binary recurrences (section 5) --- */
+TAYLOR_BIN(add, 0)   /* s_k = u_k + w_k                                       */
+TAYLOR_BIN(sub, 1)   /* s_k = u_k - w_k                                       */
+TAYLOR_BIN(mul, 2)   /* s_k = sum_{j=0..k} u_j w_{k-j}   (Cauchy, fma)        */
+TAYLOR_BIN(div, 3)   /* s_k = (u_k - sum_{j>=1} w_j s_{k-j}) / w_0            */
+TAYLOR_BIN(pow, 4)   /* u^r exact for constant r; else exp(w*log u)          */
+
+/* --- unary recurrences (section 5) + analytic d=8 self-test points --- */
+TAYLOR_UN(neg,  0, /*none*/, 0.0)
+TAYLOR_UN(exp,  1, exp,      0.5)   /* s_k = (1/k) sum j u_j s_{k-j}          */
+TAYLOR_UN(log,  2, log,      1.3)   /* s_k = (u_k - (1/k) sum j s_j u_{k-j})/u_0 */
+TAYLOR_UN(sin,  3, sin,      0.7)   /* coupled sin/cos                        */
+TAYLOR_UN(cos,  4, cos,      0.7)   /* coupled companion                      */
+TAYLOR_UN(tan,  5, tan,      0.4)   /* sin/cos                                */
+TAYLOR_UN(sqrt, 6, sqrt,     2.0)   /* u^(1/2) via the power recurrence       */
+TAYLOR_UN(abs,  7, fabs,     1.5)   /* |u_0|, sign(u_0)*u_k                    */
+TAYLOR_UN(sinh, 8, sinh,     0.6)   /* (exp(u) - exp(-u))/2                    */
+TAYLOR_UN(cosh, 9, cosh,     0.6)   /* (exp(u) + exp(-u))/2                    */
+TAYLOR_UN(tanh, 10, tanh,    0.6)   /* sinh/cosh                              */
+
+#undef TAYLOR_BIN
+#undef TAYLOR_UN

--- a/lib/frontend/parser.cpp
+++ b/lib/frontend/parser.cpp
@@ -1345,6 +1345,8 @@ static eshkol_op_t get_operator_type(const std::string& op) {
     // Automatic differentiation operators
     if (op == "derivative") return ESHKOL_DERIVATIVE_OP;
     if (op == "D") return ESHKOL_DERIVATIVE_OP;
+    if (op == "taylor") return ESHKOL_TAYLOR_OP;
+    if (op == "derivative-n") return ESHKOL_DERIVATIVE_N_OP;
     if (op == "gradient") return ESHKOL_GRADIENT_OP;
     if (op == "jacobian") return ESHKOL_JACOBIAN_OP;
     if (op == "hessian") return ESHKOL_HESSIAN_OP;
@@ -2455,6 +2457,19 @@ static void collectVariableReferences(const eshkol_ast_t* ast, std::set<std::str
                     }
                     if (ast->operation.gradient_op.point) {
                         collectVariableReferences(ast->operation.gradient_op.point, refs);
+                    }
+                    break;
+
+                case ESHKOL_TAYLOR_OP:
+                case ESHKOL_DERIVATIVE_N_OP:
+                    if (ast->operation.taylor_op.function) {
+                        collectVariableReferences(ast->operation.taylor_op.function, refs);
+                    }
+                    if (ast->operation.taylor_op.point) {
+                        collectVariableReferences(ast->operation.taylor_op.point, refs);
+                    }
+                    if (ast->operation.taylor_op.order) {
+                        collectVariableReferences(ast->operation.taylor_op.order, refs);
                     }
                     break;
                     
@@ -7934,7 +7949,62 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
 
             return ast;
         }
-        
+
+        // Arbitrary-order Taylor-tower AD (ESH-0186):
+        //   (taylor       f x k)  -> list of the K+1 Taylor coefficients c[0..k]
+        //   (derivative-n f x k)  -> the k-th derivative f^(k)(x) = k! * c[k]
+        // Both share taylor_op {function, point, order}.
+        if (ast.operation.op == ESHKOL_TAYLOR_OP ||
+            ast.operation.op == ESHKOL_DERIVATIVE_N_OP) {
+            const char* opname = (ast.operation.op == ESHKOL_TAYLOR_OP)
+                                 ? "taylor" : "derivative-n";
+
+            // function
+            token = tokenizer.nextToken();
+            if (token.type == TOKEN_EOF) {
+                PARSE_ERROR_AT(token, "taylor/derivative-n requires a function argument");
+                ast.type = ESHKOL_INVALID; return ast;
+            }
+            tokenizer.pushBack(token);
+            eshkol_ast_t t_function = parse_expression(tokenizer);
+            if (t_function.type == ESHKOL_INVALID) { ast.type = ESHKOL_INVALID; return ast; }
+
+            // point
+            token = tokenizer.nextToken();
+            if (token.type == TOKEN_EOF || token.type == TOKEN_RPAREN) {
+                PARSE_ERROR_AT(token, "taylor/derivative-n requires an evaluation point");
+                ast.type = ESHKOL_INVALID; return ast;
+            }
+            tokenizer.pushBack(token);
+            eshkol_ast_t t_point = parse_expression(tokenizer);
+            if (t_point.type == ESHKOL_INVALID) { ast.type = ESHKOL_INVALID; return ast; }
+
+            // order k
+            token = tokenizer.nextToken();
+            if (token.type == TOKEN_EOF || token.type == TOKEN_RPAREN) {
+                PARSE_ERROR_AT(token, "taylor/derivative-n requires an order k");
+                ast.type = ESHKOL_INVALID; return ast;
+            }
+            tokenizer.pushBack(token);
+            eshkol_ast_t t_order = parse_expression(tokenizer);
+            if (t_order.type == ESHKOL_INVALID) { ast.type = ESHKOL_INVALID; return ast; }
+
+            Token t_close = tokenizer.nextToken();
+            if (t_close.type != TOKEN_RPAREN) {
+                PARSE_ERROR_AT(t_close, "expected closing parenthesis after");
+                (void)opname;
+                ast.type = ESHKOL_INVALID; return ast;
+            }
+
+            ast.operation.taylor_op.function = new eshkol_ast_t;
+            *ast.operation.taylor_op.function = t_function;
+            ast.operation.taylor_op.point = new eshkol_ast_t;
+            *ast.operation.taylor_op.point = t_point;
+            ast.operation.taylor_op.order = new eshkol_ast_t;
+            *ast.operation.taylor_op.order = t_order;
+            return ast;
+        }
+
         // Special handling for gradient - reverse-mode automatic differentiation
         if (ast.operation.op == ESHKOL_GRADIENT_OP) {
             // Syntax: (gradient function vector)

--- a/scripts/ad_depth_report.py
+++ b/scripts/ad_depth_report.py
@@ -37,10 +37,14 @@ REPORT = os.path.join(ROOT, "AD_DEPTH_REPORT.md")
 # expected (green); below baseline is a regression (red). Fixes that raise a
 # boundary stay green and are flagged as improvements in the report.
 BASELINE = {
-    ("deriv", "capnone"): 2,
-    ("deriv", "glob"): 2,
-    ("deriv", "localparam"): 1,   # d2 returns garbage (ESH-0122)
-    ("deriv", "vecref"): 1,       # d2 returns garbage (ESH-0122)
+    # ESH-0186 (P1 Taylor tower): nested `derivative` chains of depth>=3 route
+    # through the arbitrary-order tower, so derivative^d is now exact to d=8 for
+    # every capture form (this also closes the ESH-0122 localparam/vecref cases,
+    # whose captures flow through the tower call unchanged). Was 2/2/1/1.
+    ("deriv", "capnone"): 8,
+    ("deriv", "glob"): 8,
+    ("deriv", "localparam"): 8,
+    ("deriv", "vecref"): 8,
     ("gradn", "capnone"): 2,
     ("gradn", "vecref"): 1,       # d2 returns garbage (ESH-0122 capture bug)
     ("gofd", "vecref"): 1,        # d>=2 returns 0 (ESH-0117 family)

--- a/site/static/eshkol-runtime.js
+++ b/site/static/eshkol-runtime.js
@@ -569,6 +569,19 @@ class EshkolRuntime {
                 eshkol_rational_floor:            () => 0,
                 eshkol_list_reverse_tagged:       (value) => value,
 
+                // Taylor-tower runtime (ESH-0186 / AD P1) — same degradation
+                // pattern as bignum/rational above: eshkol_is_taylor_tagged
+                // always reports "not a tower" so the generic double/AD path
+                // handles everything, leaving the binary/unary/seed/extract
+                // kernels below unreachable.
+                eshkol_is_taylor_tagged:        () => 0,
+                eshkol_taylor_c0:               () => 0.0,
+                eshkol_taylor_binary_tagged:    () => 0,
+                eshkol_taylor_unary_tagged:     () => 0,
+                eshkol_taylor_seed_tagged:      () => 0,
+                eshkol_taylor_extract:          () => 0.0,
+                eshkol_taylor_coeffs_list:      () => 0,
+
                 // Lazy futures — no browser worker backing for this WASM glue.
                 eshkol_lazy_future_is_ready: () => 1,
                 eshkol_lazy_future_is_async: () => 0,

--- a/tests/ad/taylor_tower_test.esk
+++ b/tests/ad/taylor_tower_test.esk
@@ -1,0 +1,89 @@
+;; tests/ad/taylor_tower_test.esk
+;; ESH-0186 (P1): arbitrary-order forward-mode AD via the runtime Taylor tower.
+;;
+;; Verifies (derivative-n f x k) = f^(k)(x) and (taylor f x k) = the K+1
+;; coefficients c[n] = f^(n)/n!, to arbitrary order k (here 0..8), against
+;; closed-form analytic derivatives, for x^5, sin, exp, log(1+x) and 1/(1-x).
+;; Runs identically under -r (JIT) and AOT. Also checks nested composition and
+;; perturbation-epoch safety (a nested inner differentiation does not leak into
+;; the outer level).
+;;
+;; This closes the ESH-0118 ceiling (derivative^n = 0 for n >= 3).
+
+(define npass 0)
+(define nfail 0)
+
+;; relative + absolute tolerance (coefficients span 0 .. ~2e7 here)
+(define (close? got expect)
+  (<= (abs (- got expect)) (+ 1e-7 (* 1e-9 (abs expect)))))
+
+(define (check name n got expect)
+  (if (close? got expect)
+      (begin (set! npass (+ npass 1))
+             (display "PASS ") (display name) (display " n=") (display n)
+             (display " = ") (display got) (newline))
+      (begin (set! nfail (+ nfail 1))
+             (display "FAIL ") (display name) (display " n=") (display n)
+             (display " got=") (display got) (display " expect=") (display expect)
+             (newline))))
+
+;; check (derivative-n f x0 n) for n = 0..(length expected)-1 against expected
+(define (check-series name f x0 expected)
+  (let loop ((n 0) (es expected))
+    (if (null? es)
+        #t
+        (begin
+          (check name n (derivative-n f x0 n) (car es))
+          (loop (+ n 1) (cdr es))))))
+
+;; ---- f(x) = x^5  at x0 = 2.0 ----
+;; f^(n) = 5!/(5-n)! * 2^(5-n)  (0 for n > 5)
+(check-series "x^5" (lambda (x) (* x x x x x)) 2.0
+              (list 32.0 80.0 160.0 240.0 240.0 120.0 0.0 0.0 0.0))
+
+;; ---- f(x) = sin(x)  at x0 = 0.0 ----
+;; derivatives cycle 0, 1, 0, -1, ...
+(check-series "sin" (lambda (x) (sin x)) 0.0
+              (list 0.0 1.0 0.0 -1.0 0.0 1.0 0.0 -1.0 0.0))
+
+;; ---- f(x) = exp(x)  at x0 = 0.5 ----  (all derivatives = exp(0.5))
+(define e05 (exp 0.5))
+(check-series "exp" (lambda (x) (exp x)) 0.5
+              (list e05 e05 e05 e05 e05 e05 e05 e05 e05))
+
+;; ---- f(x) = log(1+x)  at x0 = 0.0 ----
+;; f^(n) = (-1)^(n-1) (n-1)!  for n >= 1
+(check-series "log1p" (lambda (x) (log (+ 1.0 x))) 0.0
+              (list 0.0 1.0 -1.0 2.0 -6.0 24.0 -120.0 720.0 -5040.0))
+
+;; ---- f(x) = 1/(1-x)  at x0 = 0.5 ----
+;; f^(n) = n! / (1-x0)^(n+1) = n! * 2^(n+1)
+(check-series "geom" (lambda (x) (/ 1.0 (- 1.0 x))) 0.5
+              (list 2.0 4.0 16.0 96.0 768.0 7680.0 92160.0 1290240.0 20643840.0))
+
+;; ---- (taylor f x k): coefficients c[n] = f^(n)/n!  ----
+;; taylor(exp, 0.5, 4) = (e05  e05  e05/2  e05/6  e05/24)
+(define tcoeffs (taylor (lambda (x) (exp x)) 0.5 4))
+(check "taylor-exp c0" 0 (list-ref tcoeffs 0) e05)
+(check "taylor-exp c1" 1 (list-ref tcoeffs 1) e05)
+(check "taylor-exp c2" 2 (list-ref tcoeffs 2) (/ e05 2.0))
+(check "taylor-exp c3" 3 (list-ref tcoeffs 3) (/ e05 6.0))
+(check "taylor-exp c4" 4 (list-ref tcoeffs 4) (/ e05 24.0))
+
+;; ---- nested composition + perturbation-epoch safety ----
+;; The inner (derivative-n ... 3.0 1) computes d/dy y^3 |_{y=3} = 27, a value
+;; wholly independent of the outer variable x. Its perturbation epoch must NOT
+;; contaminate the outer differentiation: d/dx (x^2 + 27) |_{x=4} = 2*4 = 8.
+(check "nested-safe" 1
+       (derivative-n
+         (lambda (x) (+ (* x x)
+                        (derivative-n (lambda (y) (* y y y)) 3.0 1)))
+         4.0 1)
+       8.0)
+
+;; Pure same-variable high-order composition: d^3/dx^3 x^4 |_{x=2} = 24*2 = 48.
+(check "highorder" 3 (derivative-n (lambda (x) (* x x x x)) 2.0 3) 48.0)
+
+(display "----") (newline)
+(display "taylor-tower tests: ") (display npass) (display " passed, ")
+(display nfail) (display " failed") (newline)

--- a/tests/ad_taylor_poc/run.sh
+++ b/tests/ad_taylor_poc/run.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Compile and run the Eshkol Taylor-tower Phase-0 POC.
+# Self-contained: no repo dependencies. Exits 0 iff every check passes.
+set -eu
+
+here="$(cd "$(dirname "$0")" && pwd)"
+CC="${CC:-cc}"
+out="$here/taylor_poc"
+
+"$CC" -O2 -std=c11 -Wall -Wextra "$here/taylor_poc.c" -lm -o "$out"
+"$out"
+status=$?
+rm -f "$out"
+exit "$status"

--- a/tests/ad_taylor_poc/taylor_poc.c
+++ b/tests/ad_taylor_poc/taylor_poc.c
@@ -1,0 +1,273 @@
+/*
+ * taylor_poc.c  --  Phase-0 proof-of-concept for Eshkol arbitrary-order AD.
+ *
+ * Self-contained C (no repo dependencies). Implements univariate truncated-
+ * Taylor arithmetic (a "Taylor tower") via the closed recurrences documented
+ * in docs/design/AD_TAYLOR_TOWER.md section 5, and verifies that the k-th
+ * derivative recovered as f^(k)(x0) = k! * c[k] matches the closed-form
+ * analytic derivative for k = 0..8, to relative error < 1e-12.
+ *
+ * A Taylor tower is the coefficient array c[0..K] of the truncated series
+ *
+ *     f(x0 + t) = sum_{k=0..K} c[k] * t^k      =>   f^(k)(x0) = k! * c[k].
+ *
+ * The differentiation variable x is seeded as the series {x0, 1, 0, ..., 0}
+ * (value x0, unit first-order perturbation, nothing higher); constants seed
+ * {value, 0, 0, ...}.
+ *
+ * Build & run:  cc -O2 -std=c11 -Wall -Wextra taylor_poc.c -lm -o taylor_poc && ./taylor_poc
+ * or:           ./run.sh
+ *
+ * Exit status 0  iff  every check passes.
+ */
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Truncation order K: series carries K+1 coefficients (indices 0..K). */
+#define K 8
+#define N (K + 1)
+
+typedef double tower[N];   /* c[0..K] */
+
+/* ---- seeding ----------------------------------------------------------- */
+
+static void t_const(tower s, double v) {
+    memset(s, 0, sizeof(tower));
+    s[0] = v;
+}
+
+/* the differentiation variable: value x0, unit first-order slope */
+static void t_var(tower s, double x0) {
+    memset(s, 0, sizeof(tower));
+    s[0] = x0;
+    s[1] = 1.0;
+}
+
+/* ---- elementwise linear ops -------------------------------------------- */
+
+static void t_add(tower s, const tower u, const tower w) {
+    for (int k = 0; k < N; k++) s[k] = u[k] + w[k];
+}
+
+static void t_sub(tower s, const tower u, const tower w) {
+    for (int k = 0; k < N; k++) s[k] = u[k] - w[k];
+}
+
+/* ---- multiplicative / transcendental recurrences ----------------------- */
+
+/* s = u * w :  s_k = sum_{j=0..k} u_j * w_{k-j}   (Cauchy convolution) */
+static void t_mul(tower s, const tower u, const tower w) {
+    tower out;
+    for (int k = 0; k < N; k++) {
+        double acc = 0.0;
+        for (int j = 0; j <= k; j++) acc += u[j] * w[k - j];
+        out[k] = acc;
+    }
+    memcpy(s, out, sizeof(tower));
+}
+
+/* s = u / w :  s_k = ( u_k - sum_{j=1..k} w_j * s_{k-j} ) / w_0 */
+static void t_div(tower s, const tower u, const tower w) {
+    tower out;
+    for (int k = 0; k < N; k++) {
+        double acc = u[k];
+        for (int j = 1; j <= k; j++) acc -= w[j] * out[k - j];
+        out[k] = acc / w[0];
+    }
+    memcpy(s, out, sizeof(tower));
+}
+
+/* s = exp(u) :  s_0 = exp(u_0);  s_k = (1/k) sum_{j=1..k} j * u_j * s_{k-j} */
+static void t_exp(tower s, const tower u) {
+    tower out;
+    out[0] = exp(u[0]);
+    for (int k = 1; k < N; k++) {
+        double acc = 0.0;
+        for (int j = 1; j <= k; j++) acc += (double)j * u[j] * out[k - j];
+        out[k] = acc / (double)k;
+    }
+    memcpy(s, out, sizeof(tower));
+}
+
+/* s = log(u) :  s_0 = log(u_0);
+ * s_k = ( u_k - (1/k) sum_{j=1..k-1} j * s_j * u_{k-j} ) / u_0 */
+static void t_log(tower s, const tower u) {
+    tower out;
+    out[0] = log(u[0]);
+    for (int k = 1; k < N; k++) {
+        double acc = 0.0;
+        for (int j = 1; j <= k - 1; j++) acc += (double)j * out[j] * u[k - j];
+        out[k] = (u[k] - acc / (double)k) / u[0];
+    }
+    memcpy(s, out, sizeof(tower));
+}
+
+/* coupled:  s = sin(u), c = cos(u)
+ * s_0 = sin(u_0), c_0 = cos(u_0);
+ * s_k =  (1/k) sum_{j=1..k} j * u_j * c_{k-j}
+ * c_k = -(1/k) sum_{j=1..k} j * u_j * s_{k-j} */
+static void t_sincos(tower s, tower c, const tower u) {
+    tower so, co;
+    so[0] = sin(u[0]);
+    co[0] = cos(u[0]);
+    for (int k = 1; k < N; k++) {
+        double as = 0.0, ac = 0.0;
+        for (int j = 1; j <= k; j++) {
+            double ju = (double)j * u[j];
+            as += ju * co[k - j];
+            ac += ju * so[k - j];
+        }
+        so[k] =  as / (double)k;
+        co[k] = -ac / (double)k;
+    }
+    memcpy(s, so, sizeof(tower));
+    memcpy(c, co, sizeof(tower));
+}
+
+/* s = u^r :  s_0 = u_0^r;
+ * s_k = (1/(k*u_0)) sum_{j=1..k} (j*r - (k-j)) * u_j * s_{k-j} */
+static void t_pow(tower s, const tower u, double r) {
+    tower out;
+    out[0] = pow(u[0], r);
+    for (int k = 1; k < N; k++) {
+        double acc = 0.0;
+        for (int j = 1; j <= k; j++)
+            acc += ((double)j * r - (double)(k - j)) * u[j] * out[k - j];
+        out[k] = acc / ((double)k * u[0]);
+    }
+    memcpy(s, out, sizeof(tower));
+}
+
+/* ---- verification harness ---------------------------------------------- */
+
+static long g_fail = 0;
+static long g_pass = 0;
+
+/* factorial 0..8 */
+static double fct(int k) {
+    double f = 1.0;
+    for (int i = 2; i <= k; i++) f *= (double)i;
+    return f;
+}
+
+/* Compare recovered derivatives f^(k) = k!*c[k] against analytic[]. */
+static void check(const char *name, const tower c, const double *analytic) {
+    printf("\n  %s\n", name);
+    printf("    %2s  %-22s  %-22s  %-12s  %s\n",
+           "k", "c[k]", "f^(k)=k!*c[k]", "analytic", "rel-err");
+    for (int k = 0; k < N; k++) {
+        double got = fct(k) * c[k];
+        double ref = analytic[k];
+        double denom = fabs(ref);
+        double err = (denom > 1e-30) ? fabs(got - ref) / denom : fabs(got - ref);
+        /* pass if rel-err < 1e-12, or (for ref ~ 0) abs-err < 1e-9 */
+        int ok = (denom > 1e-30) ? (err < 1e-12) : (fabs(got - ref) < 1e-9);
+        if (ok) g_pass++; else g_fail++;
+        printf("    %2d  % -22.15g  % -22.15g  % -12.6g  %-10.3g %s\n",
+               k, c[k], got, ref, err, ok ? "ok" : "FAIL");
+    }
+}
+
+int main(void) {
+    printf("Eshkol Taylor-tower Phase-0 POC  (K=%d, orders k=0..%d)\n", K, K);
+    printf("f^(k)(x0) = k! * c[k];  pass threshold rel-err < 1e-12\n");
+
+    /* --- f(x) = x^5 at x0 = 2.0 ------------------------------------------ */
+    {
+        const double x0 = 2.0, r = 5.0;
+        tower x, f, f_mul;
+        t_var(x, x0);
+        t_pow(f, x, r);
+
+        /* cross-check: x^5 via repeated Cauchy convolution */
+        t_const(f_mul, 1.0);
+        for (int i = 0; i < 5; i++) t_mul(f_mul, f_mul, x);
+
+        double an[N];
+        for (int k = 0; k < N; k++) {
+            if (k > 5) { an[k] = 0.0; continue; }
+            /* d^k/dx^k x^5 = 5!/(5-k)! * x0^(5-k) */
+            double coef = 1.0;
+            for (int i = 0; i < k; i++) coef *= (double)(5 - i);
+            an[k] = coef * pow(x0, (double)(5 - k));
+        }
+        check("f(x) = x^5   at x0 = 2.0   (via t_pow)", f, an);
+        check("f(x) = x^5   at x0 = 2.0   (via repeated t_mul, cross-check)", f_mul, an);
+    }
+
+    /* --- f(x) = sin(x) at x0 = 0.0 -------------------------------------- */
+    {
+        const double x0 = 0.0;
+        tower x, s, c;
+        t_var(x, x0);
+        t_sincos(s, c, x);
+
+        double an_sin[N], an_cos[N];
+        /* At x0 = 0 the derivatives cycle exactly with period 4; use the exact
+         * integer cycle (not sin(k*pi/2), which floats to ~1e-16 for pi). */
+        static const double sin0[4] = { 0.0,  1.0,  0.0, -1.0 };
+        static const double cos0[4] = { 1.0,  0.0, -1.0,  0.0 };
+        for (int k = 0; k < N; k++) {
+            an_sin[k] = sin0[k % 4];
+            an_cos[k] = cos0[k % 4];
+        }
+        check("f(x) = sin(x) at x0 = 0.0", s, an_sin);
+        check("f(x) = cos(x) at x0 = 0.0   (coupled companion)", c, an_cos);
+    }
+
+    /* --- f(x) = exp(x) at x0 = 0.5 -------------------------------------- */
+    {
+        const double x0 = 0.5;
+        tower x, f;
+        t_var(x, x0);
+        t_exp(f, x);
+        double an[N];
+        for (int k = 0; k < N; k++) an[k] = exp(x0);  /* exp^(k) = exp */
+        check("f(x) = exp(x) at x0 = 0.5", f, an);
+    }
+
+    /* --- f(x) = 1/(1-x) at x0 = 0.5 ------------------------------------- */
+    {
+        const double x0 = 0.5;
+        tower x, one, w, f;
+        t_var(x, x0);
+        t_const(one, 1.0);
+        t_sub(w, one, x);          /* w = 1 - x */
+        t_div(f, one, w);          /* f = 1 / (1 - x) */
+        double an[N];
+        /* d^k/dx^k 1/(1-x) = k! / (1-x)^(k+1) */
+        for (int k = 0; k < N; k++)
+            an[k] = fct(k) / pow(1.0 - x0, (double)(k + 1));
+        check("f(x) = 1/(1-x) at x0 = 0.5", f, an);
+    }
+
+    /* --- f(x) = log(1+x) at x0 = 0.0 ------------------------------------ */
+    {
+        const double x0 = 0.0;
+        tower x, one, u, f;
+        t_var(x, x0);
+        t_const(one, 1.0);
+        t_add(u, one, x);          /* u = 1 + x */
+        t_log(f, u);               /* f = log(1 + x) */
+        double an[N];
+        an[0] = log(1.0 + x0);
+        for (int k = 1; k < N; k++) {
+            /* d^k/dx^k log(1+x) = (-1)^(k-1) (k-1)! / (1+x)^k */
+            double sgn = (k % 2 == 1) ? 1.0 : -1.0;
+            an[k] = sgn * fct(k - 1) / pow(1.0 + x0, (double)k);
+        }
+        check("f(x) = log(1+x) at x0 = 0.0", f, an);
+    }
+
+    printf("\n================================================================\n");
+    printf("checks passed: %ld   failed: %ld\n", g_pass, g_fail);
+    if (g_fail == 0) {
+        printf("RESULT: PASS  (all derivatives k=0..%d exact to rel-err < 1e-12)\n", K);
+        return 0;
+    }
+    printf("RESULT: FAIL\n");
+    return 1;
+}

--- a/web/eshkol-repl.js
+++ b/web/eshkol-repl.js
@@ -550,6 +550,20 @@ class EshkolRepl {
                 eshkol_is_rational_tagged_ptr:  () => 0,
                 eshkol_list_reverse_tagged:      (value) => value,
 
+                // Taylor-tower runtime (ESH-0186 / AD P1) — mirrors the
+                // bignum dispatch pattern: eshkol_is_taylor_tagged always
+                // reports "not a tower" so the generic double/AD path
+                // handles every value in the browser build; the
+                // binary/unary/seed/extract kernels below are therefore
+                // unreachable stubs.
+                eshkol_is_taylor_tagged:        () => 0,
+                eshkol_taylor_c0:               () => 0.0,
+                eshkol_taylor_binary_tagged:    () => 0,
+                eshkol_taylor_unary_tagged:     () => 0,
+                eshkol_taylor_seed_tagged:      () => 0,
+                eshkol_taylor_extract:          () => 0.0,
+                eshkol_taylor_coeffs_list:      () => 0,
+
                 // Lazy futures — no async worker runtime in browser WASM yet.
                 eshkol_lazy_future_is_ready: () => 1,
                 eshkol_lazy_future_is_async: () => 0,


### PR DESCRIPTION
## Summary

Phase 1 of the arbitrary-order Taylor-tower AD design (`docs/design/AD_TAYLOR_TOWER.md`, ESH-0186). Adopts univariate truncated-Taylor arithmetic — a coefficient array `c[0..K]` computed by closed recurrences — as the single kernel for high-order forward-mode AD, lifting the fixed 2-perturbation jet ceiling under which `derivative^n` returned an exact `0` for `n >= 3` (**ESH-0118**).

`f(x0+t) = Σ c_k t^k` ⇒ `f^(n)(x0) = n!·c_n`.

## What landed

**Representation** — `HEAP_SUBTYPE_TAYLOR` (=23) + `esh_taylor_t { order_k, flags, c[] }`, arena-allocated, mirroring `HEAP_SUBTYPE_TENSOR`. `flags` carry a coefficient-type field (F64 now; RATIONAL/TENSOR reserved for P6/P7) and a 16-bit perturbation **epoch** tag.

**Runtime kernel** (`lib/core/runtime_taylor.c` + `taylor_recurrences.def`) — `add/sub/mul/div/pow` and `neg/exp/log/sin/cos/tan/sqrt/abs/sinh/cosh/tanh` ported from the validated POC, with an explicit `fma()` FP-contraction policy (§6a) and ascending-`j` reduction. Perturbation-confusion safety (§5a): binary ops combine full series only for same-epoch towers; a foreign-epoch tower is lifted to its `c[0]` constant.

**Codegen dispatch** — Taylor operands intercepted before the heap/tensor path in `+ - * / pow` and the unary math builtins; `extractAsDouble` coerces a tower to `c[0]`; free-variable analysis handles the new ops. **The order-≤2 4-component jet path is untouched.**

**API + nested derivative** — `(taylor f x k)` returns the K+1 coefficients; `(derivative-n f x k)` returns `f^(k)(x)` (k may be a runtime value). Nested `derivative` chains of depth ≥ 3 (pure repeated univariate differentiation) are detected and routed through the tower; depth ≤ 2 stays on the jet.

## Gates (all green)

| Gate | Result |
|---|---|
| `tests/ad/taylor_tower_test.esk` (-r **and** AOT) | **52/52** — `x^5, sin, exp, log(1+x), 1/(1-x)` exact to `n=8`; taylor coeffs; nested-epoch safety; high-order |
| `scripts/run_ad_depth.sh` `ad_depth_gate` | **PASS**, 0 regressions — every `deriv` cell now max-depth **8** (was 2/1). **Closes ESH-0118** (and the ESH-0122 localparam/vecref capture cases) |
| AD oracle | **56/56** |
| SICP smoke | **88/88** |

Nested example: `derivative^3(x^8)@1 = 336`, `derivative^5(exp)@0 = 1`, `derivative^2(sin)@0 = 0` (still jet).

## Scoped out of P1 (tracked)

- `((derivative-n k) f)` curried / `(derivative f #:order k)` keyword sugar — shipped the direct `(derivative-n f x k)` form.
- Full cross-variable perturbation confusion at order ≥ 3 (foreign-epoch towers lift to `c[0]`; order ≤ 2 cross terms stay exact on the jet). Unified confusion model is **P3** (ESH-0188).
- P2 compile-time-K monomorphization / unrolled-IR emitter (ESH-0187) — the `.def` IR-emit column is reserved for it.
- `COEFF_RATIONAL`/`COEFF_TENSOR` are laid out in `flags` but are P6/P7.

Author: tsotchke