### PR TITLE
docs(roadmap): integrate arbitrary-order AD Taylor-tower campaign + ICC gates

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -306,6 +306,31 @@ oracles:
         label: 'gradient flows through scaled-dot-attention to K/V operands'
         action: ./scripts/run_icc_smoke.sh
 
+      # -- arbitrary-order AD Taylor-tower v1.3 track --
+      - runtime_event:
+          event_kinds: [ad_depth]
+          event_names: ["ad_taylor_p1_runtime_tower"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'P1 runtime Taylor tower: derivative^d passes to d=8 and closes ESH-0118'
+        action: ./scripts/run_ad_depth.sh
+
+      - runtime_event:
+          event_kinds: [mono_equiv]
+          event_names: ["ad_taylor_p2_monomorphization"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'P2 compile-time-K monomorphized towers match runtime towers bit-exactly'
+        action: run_mono_equiv_ad_taylor_gate
+
+      - runtime_event:
+          event_kinds: [mono_equiv]
+          event_names: ["ad_taylor_p3_jet8_subsumed"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'P3 JET8 route is subsumed by tagged Taylor towers without regression'
+        action: run_mono_equiv_ad_taylor_gate
+
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["jit_cache_hit_invalidates"]
@@ -405,6 +430,205 @@ oracles:
         severity: high
         label: 'No silent fallbacks in v1.3 production paths'
         action: classify_or_replace_each_stub
+
+  # -----------------------------------------------------------------
+  # Arbitrary-order AD Taylor-tower campaign -- cross-release gate.
+  # The release gates below select the phase rows assigned to their
+  # ROADMAP.md themes; this target keeps the whole P0..P12 campaign in
+  # one place for ICC planning.
+  # -----------------------------------------------------------------
+  - name: ad-taylor-campaign
+    aliases: [ad-taylor, arbitrary-order-ad, taylor-tower]
+    requires:
+      - runtime_event:
+          event_kinds: [ad_depth]
+          event_names: ["ad_taylor_p0_poc"]
+          event_values: ["PASS"]
+        severity: medium
+        label: P0 recurrence POC matches analytic derivatives to d=8
+        action: tests/ad_taylor_poc/run.sh
+
+      - runtime_event:
+          event_kinds: [ad_depth]
+          event_names: ["ad_taylor_p1_runtime_tower"]
+          event_values: ["PASS"]
+        severity: high
+        label: P1 runtime Taylor tower supports derivative^n and closes ESH-0118
+        action: ./scripts/run_ad_depth.sh
+
+      - runtime_event:
+          event_kinds: [mono_equiv]
+          event_names: ["ad_taylor_p2_monomorphization"]
+          event_values: ["PASS"]
+        severity: high
+        label: P2 compile-time-K monomorphization equals runtime tower execution
+        action: run_mono_equiv_ad_taylor_gate
+
+      - runtime_event:
+          event_kinds: [mono_equiv]
+          event_names: ["ad_taylor_p3_jet8_subsumed"]
+          event_values: ["PASS"]
+        severity: high
+        label: P3 JET8 behavior is preserved through the tagged tower route
+        action: run_mono_equiv_ad_taylor_gate
+
+      - runtime_event:
+          event_kinds: [ad_exact]
+          event_names: ["ad_taylor_p4_guw_multivariate"]
+          event_values: ["PASS"]
+        severity: high
+        label: P4 GUW multivariate mixed partials match analytic references to d=8
+        action: run_ad_exact_taylor_gate
+
+      - runtime_event:
+          event_kinds: [ad_reverse_highorder]
+          event_names: ["ad_taylor_p5_reverse_over_taylor"]
+          event_values: ["PASS"]
+        severity: high
+        label: P5 reverse-over-Taylor high-order gradient oracle passes under AOT
+        action: run_ad_reverse_highorder_gate
+
+      - runtime_event:
+          event_kinds: [ad_exact]
+          event_names: ["ad_taylor_p6_exact_coefficients"]
+          event_values: ["PASS"]
+        severity: high
+        label: P6 rational/bignum Taylor coefficients are bit-exact vs symbolic oracle
+        action: run_ad_exact_taylor_gate
+
+      - runtime_event:
+          event_kinds: [ad_tensor_highorder]
+          event_names: ["ad_taylor_p7_tensor_towers"]
+          event_values: ["PASS"]
+        severity: high
+        label: P7 tensor-valued towers pass high-order ML AD smoke tests
+        action: run_ad_tensor_highorder_gate
+
+      - runtime_event:
+          event_kinds: [ad_validated_bounds]
+          event_names: ["ad_taylor_p8_taylor_models"]
+          event_values: ["PASS"]
+        severity: high
+        label: P8 Taylor-model bounds contain the true range and tighten with order
+        action: run_ad_validated_bounds_gate
+
+      - runtime_event:
+          event_kinds: [ad_control_flow]
+          event_names: ["ad_taylor_p9_control_flow"]
+          event_values: ["PASS"]
+        severity: high
+        label: P9 towers pass through loops, branches, recursion, closures, named-let, map, and fold
+        action: run_ad_control_flow_gate
+
+      - runtime_event:
+          event_kinds: [ad_reverse_highorder]
+          event_names: ["ad_taylor_p10_checkpointed_reverse"]
+          event_values: ["PASS"]
+        severity: high
+        label: P10 checkpointed high-order reverse matches dense tape within memory budget
+        action: run_ad_reverse_highorder_gate
+
+      - runtime_event:
+          event_kinds: [ad_numerics]
+          event_names: ["ad_taylor_p11_user_numerics"]
+          event_values: ["PASS"]
+        severity: medium
+        label: P11 Taylor-series ODE, root, inversion, and continuation APIs converge
+        action: run_ad_numerics_gate
+
+      - runtime_event:
+          event_kinds: [ad_sparse]
+          event_names: ["ad_taylor_p12_sparse_highorder_tensors"]
+          event_values: ["PASS"]
+        severity: medium
+        label: P12 sparse high-order tensors match dense recovery on tractable cases
+        action: run_ad_sparse_gate
+
+  # -----------------------------------------------------------------
+  # v1.4-connection readiness -- adds the AD infrastructure track
+  # assigned to v1.4 without replacing the networking/resource theme.
+  # -----------------------------------------------------------------
+  - name: v1.4-release
+    aliases: [v1.4, release-1.4, connection]
+    requires:
+      - runtime_event:
+          event_kinds: [ad_exact]
+          event_names: ["ad_taylor_p4_guw_multivariate"]
+          event_values: ["PASS"]
+        severity: high
+        label: P4 GUW multivariate mixed partials pass analytic oracle to d=8
+        action: run_ad_exact_taylor_gate
+
+      - runtime_event:
+          event_kinds: [ad_exact]
+          event_names: ["ad_taylor_p6_exact_coefficients"]
+          event_values: ["PASS"]
+        severity: high
+        label: P6 exact-coefficient towers pass rational/bignum symbolic oracle
+        action: run_ad_exact_taylor_gate
+
+      - runtime_event:
+          event_kinds: [ad_numerics]
+          event_names: ["ad_taylor_p11_user_numerics"]
+          event_values: ["PASS"]
+        severity: medium
+        label: P11 tower-based user numerics converge on ODE/root/inversion examples
+        action: run_ad_numerics_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["connection_theme_deliverables"]
+          event_values: ["PASS"]
+        severity: high
+        label: Placeholder for v1.4 networking, TLS, event loop, and linear resource deliverables
+        action: replace_with_v1_4_connection_oracle
+
+  # -----------------------------------------------------------------
+  # v1.5-intelligence readiness -- high-order AD gates for the
+  # differentiable-logic and neuro-symbolic ML theme.
+  # -----------------------------------------------------------------
+  - name: v1.5-release
+    aliases: [v1.5, release-1.5, intelligence]
+    requires:
+      - runtime_event:
+          event_kinds: [ad_reverse_highorder]
+          event_names: ["ad_taylor_p5_reverse_over_taylor"]
+          event_values: ["PASS"]
+        severity: high
+        label: P5 reverse-over-Taylor high-order gradient oracle passes under AOT
+        action: run_ad_reverse_highorder_gate
+
+      - runtime_event:
+          event_kinds: [ad_tensor_highorder]
+          event_names: ["ad_taylor_p7_tensor_towers"]
+          event_values: ["PASS"]
+        severity: high
+        label: P7 tensor-valued towers cover high-order conv2d, attention, batchnorm, and layernorm AD
+        action: run_ad_tensor_highorder_gate
+
+      - runtime_event:
+          event_kinds: [ad_control_flow]
+          event_names: ["ad_taylor_p9_control_flow"]
+          event_values: ["PASS"]
+        severity: high
+        label: P9 differentiable control-flow oracle passes through loops, branches, recursion, and closures
+        action: run_ad_control_flow_gate
+
+      - runtime_event:
+          event_kinds: [ad_reverse_highorder]
+          event_names: ["ad_taylor_p10_checkpointed_reverse"]
+          event_values: ["PASS"]
+        severity: medium
+        label: P10 checkpointed high-order reverse begins the v1.5 to v1.7 memory-scaling bridge
+        action: run_ad_reverse_highorder_gate
+
+      - runtime_event:
+          event_kinds: [v1_5_intelligence]
+          event_names: ["intelligence_theme_deliverables"]
+          event_values: ["PASS"]
+        severity: high
+        label: Placeholder for v1.5 symbol embeddings, soft unification, LSTM/GRU, differentiable logic, KB attention, and gradient estimators
+        action: replace_with_v1_5_intelligence_oracle
 
   # ─────────────────────────────────────────────────────────────────
   # SDNC paper reproducibility — the headline claim from

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -235,6 +235,14 @@ v2.0 ─────────────────────────
                                                        └ Formal verification (requires dep types)
 ```
 
+**Arbitrary-order AD (Taylor-tower) track:** The Taylor-tower campaign is
+threaded through the existing version themes as enabling substrate, not
+as a separate release ladder. P1 lands in v1.3.1, P2/P3 in v1.3.2,
+P4/P6/P11 in the v1.4 infrastructure track alongside networking,
+P5/P7/P9 in v1.5 intelligence, P10 bridges v1.5 to v1.7, P12 supports
+v1.6 reasoning, and P8 feeds v2.0 formal verification of AD. See
+[`docs/AD_CAMPAIGN.md`](docs/AD_CAMPAIGN.md).
+
 ---
 
 ## v1.2-scale (May 2026) - SHIPPED
@@ -327,6 +335,10 @@ v2.0 ─────────────────────────
       (input2). Conv2d / batchnorm / layernorm / attention forward
       sites still leave `input2` null in their tape nodes and are
       tracked separately.
+- [ ] Arbitrary-order AD Taylor-tower v1.3 track: P1 runtime
+      `derivative^n` in v1.3.1 closes ESH-0118; P2 compile-time-K
+      monomorphization and P3 JET8 subsumption land in v1.3.2, gated by
+      `ad-depth` and `mono-equiv`.
 
 ---
 
@@ -341,6 +353,9 @@ v2.0 ─────────────────────────
 - [ ] HTTP client (built on sockets + TLS)
 - [ ] Linear types for all handles: `open → borrowed → closed` with compile-time tracking
 - [ ] Borrow pattern for temporary resource access
+- [ ] AD infrastructure track alongside networking: P4 GUW
+      multivariate towers, P6 exact-coefficient towers, and P11
+      tower-based user numerics, gated by `ad-exact` and `ad-numerics`.
 
 ---
 
@@ -356,6 +371,13 @@ Informed by the [Neuro-Symbolic Architecture](docs/future/NEURO_SYMBOLIC_COMPLET
 - [ ] Differentiable logic programs (gradients flow through rule application)
 - [ ] Attention over knowledge base (neural query mechanism over symbolic facts)
 - [ ] Gradient estimators for discrete operations (Gumbel-Softmax, straight-through)
+- [ ] High-order AD for neuro-symbolic ML: P5 reverse-over-Taylor, P7
+      tensor-valued towers, and P9 differentiable control flow provide
+      the substrate for differentiable logic and recurrent/neural
+      workloads, gated by `ad-reverse-highorder`, `ad-tensor-highorder`,
+      and `ad-control-flow`.
+- [ ] Checkpointed high-order reverse begins here as P10, with the
+      memory-scaling work continuing into v1.7 synthesis.
 
 ---
 
@@ -368,6 +390,9 @@ Informed by the [Neuro-Symbolic Architecture](docs/future/NEURO_SYMBOLIC_COMPLET
 - [ ] Constraint solving (finite domain constraints, SAT solver integration)
 - [ ] Knowledge graphs (RDF-style triple store with SPO/POS/OSP indexing)
 - [ ] Knowledge graph embeddings (entity-relation-entity triples as learnable vectors)
+- [ ] Sparse high-order AD tensors (P12) for knowledge-graph and
+      relational workloads, gated by `ad-sparse` against dense recovery
+      on tractable cases.
 
 ---
 
@@ -439,6 +464,9 @@ Leverages OALR linear types (no-cloning theorem) and AD (variational circuits).
 ### Formal Verification
 - [ ] Integration with proof assistants (Lean) for certified compilation
 - [ ] Quantitative type theory for unified linear/quantum resource tracking
+- [ ] Formal verification of automatic differentiation via Taylor
+      models (P8), gated by `ad-validated-bounds` for sound enclosures
+      and tightening with order.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -476,14 +476,19 @@ Leverages OALR linear types (no-cloning theorem) and AD (variational circuits).
 |---------|------|-------|-----------------|
 | **v1.1.13** | Apr 2026 | Accelerate | Windows ARM64, 16-lane release matrix, VM closure fixes, mobile site |
 | **v1.2** | May 2026 | Scale | Model serialization, Python bindings, image I/O |
-| **v1.3** | Jun 2026 | Evolve | R7RS libraries, string interpolation, PGO |
-| **v1.4** | Jul 2026 | Connection | Networking, TLS, event loop, linear resource types |
-| **v1.5** | Aug 2026 | Intelligence | Symbol embeddings, differentiable logic, LSTM/GRU |
-| **v1.6** | Sep 2026 | Reasoning | Backward chaining, constraint solving, knowledge graphs |
+| **v1.3** | Jun 2026 | Evolve | R7RS libraries, string interpolation, PGO; arbitrary-order AD P1–P3 (closes ESH-0118) |
+| **v1.4** | Jul 2026 | Connection | Networking, TLS, event loop, linear resource types; AD substrate P4/P6/P11 (GUW multivariate, exact-coefficient, user numerics) |
+| **v1.5** | Aug 2026 | Intelligence | Symbol embeddings, differentiable logic, LSTM/GRU; high-order AD P5/P7/P9/P10 (reverse-over-Taylor, tensor towers, differentiable control flow) |
+| **v1.6** | Sep 2026 | Reasoning | Backward chaining, constraint solving, knowledge graphs; sparse high-order AD tensors (P12) |
 | **v1.7** | Oct 2026 | Synthesis | Neural-guided search, program synthesis, GNN |
 | **v1.8** | Nov 2026 | Platform | Windowing, audio, Vulkan, embedded targets |
 | **v1.9** | Dec 2026 | Types | Dependent types, effects, algebraic effects, session types |
-| **v2.0** | Q1 2027 | Starlight | Quantum types, VQE/QAOA, formal verification |
+| **v2.0** | Q1 2027 | Starlight | Quantum types, VQE/QAOA, formal verification; validated AD via Taylor models (P8) |
+
+> **Arbitrary-order AD (Taylor-tower) track** threads phases P0–P12 through the
+> version themes above as an enabling substrate — see
+> [`docs/AD_CAMPAIGN.md`](docs/AD_CAMPAIGN.md) for the full phase → version →
+> ICC-gate map. Each phase is gated by an `ad-*` ICC oracle criterion.
 
 ---
 
@@ -631,6 +636,14 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed contribution guidelines.
 
 ---
 
-*Last Updated: April 2026*
+*Last Updated: July 2026*
+
+*The arbitrary-order automatic-differentiation (Taylor-tower) campaign — phases
+P0–P12, spanning core high-order AD, exact-coefficient and tensor-valued towers,
+GUW multivariate recovery, differentiable control flow, and validated Taylor
+models — is threaded through the version themes above rather than run as a
+separate release ladder. It is the differentiable-programming substrate for the
+neuro-symbolic (v1.5–v1.7) and quantum/formal-verification (v2.0) arc. See
+[`docs/AD_CAMPAIGN.md`](docs/AD_CAMPAIGN.md).*
 
 *Eshkol v1.1-accelerate is complete with 47/47 roadmap items delivered plus the v1.1.12 and v1.1.13 additions (production VM, web platform, browser AD, Windows ARM64, mobile site). The roadmap progresses through data & deployment (v1.2-scale), language maturity (v1.3-evolve), networking & resources (v1.4-connection), neuro-symbolic intelligence (v1.5-intelligence), symbolic reasoning (v1.6-reasoning), program synthesis (v1.7-synthesis), platform & hardware (v1.8-platform), advanced type theory (v1.9-types), and quantum computing with formal verification (v2.0-starlight).*

--- a/docs/AD_CAMPAIGN.md
+++ b/docs/AD_CAMPAIGN.md
@@ -1,0 +1,64 @@
+# Arbitrary-order AD Taylor-tower Campaign
+
+This track integrates the arbitrary-order automatic differentiation
+Taylor-tower campaign into the canonical release roadmap. It is not a
+parallel version scheme: the Taylor tower is the enabling substrate that
+lets the existing roadmap move from neuro-symbolic intelligence through
+reasoning and into the v2.0 quantum/formal-verification arc.
+
+`ROADMAP.md` remains the source of truth for release themes. This file
+maps each AD phase to that roadmap, the ICC completion evidence expected
+for the phase, and the ledger tasks from the Taylor-tower design branch.
+`docs/design/AD_TAYLOR_TOWER.md` is not present on current `master`; it
+lands with PR #147 (`design/ad-taylor-tower`) along with ESH-0185..0197.
+Until that PR merges, the version and ICC gate mapping below is the
+canonical tag source for those ledger tasks.
+
+## Phase-to-roadmap Alignment
+
+| Phase / ESH | Capability | Target version | ICC oracle criterion | Dependencies | Roadmap theme it feeds |
+|---|---|---|---|---|---|
+| P0 / ESH-0185 | Standalone recurrence POC for univariate Taylor arithmetic to d=8 | v1.3.0 design input | `ad-depth` design evidence: recurrence POC exits cleanly and matches analytic derivatives | Existing forward AD and numeric tower | v1.3-evolve language maturity and AD hardening |
+| P1 / ESH-0186 | Runtime heap tower, `derivative^n`, epoch-tag scaffold; closes ESH-0118 | v1.3.1 | `ad-depth`: `derivative^d` PASS to d=8, nested-confusion suite PASS | P0, current AD runtime, arena heap subtype dispatch | v1.3-evolve AD correctness for day-to-day language use |
+| P2 / ESH-0187 | Compile-time-K monomorphization, unrolled stack towers, shared FP-contraction policy | v1.3.2 | `mono-equiv`: monomorphized tower equals runtime tower bit-exactly; no AD hot-loop heap allocation | P1 | v1.3-evolve optimization and compiler ergonomics |
+| P3 / ESH-0188 | Subsume JET8 into tagged Taylor towers while retaining JET4 hot path | v1.3.2 | `mono-equiv`: JET8 regression tests PASS through the tower route; perturbation model unified | P1, P2, PR #138 tests | v1.3-evolve AD surface consolidation |
+| P4 / ESH-0189 | GUW multivariate mixed partials through `taylor_propagate` and interpolation | v1.4.x | `ad-exact`: multivariate `gradient^d`/mixed partials PASS to d=8 against analytic references | P1, P2 | v1.4-connection infrastructure track alongside networking |
+| P5 / ESH-0190 | Reverse-over-Taylor and tower-aware high-order tape | v1.5 | `ad-reverse-highorder`: high-order reverse oracle PASS, AOT-verified | P1-P4, existing reverse tape | v1.5-intelligence differentiable logic and neuro-symbolic ML |
+| P6 / ESH-0191 | Exact-coefficient towers with rational/bignum coefficients | v1.4.x | `ad-exact`: rational/bignum derivatives bit-exact vs symbolic oracle; exactness contagion PASS | P1, numeric tower | v1.4-connection infrastructure track alongside networking |
+| P7 / ESH-0192 | Tensor-valued towers for conv2d/attention/batchnorm/layernorm high-order AD | v1.5 | `ad-tensor-highorder`: ML AD smoke PASS; order-1 agrees with current tensor AD | P1-P5, tensor AD path | v1.5-intelligence neural workloads and differentiable ML |
+| P8 / ESH-0193 | Taylor models with rigorous interval remainders and validated AD | v2.0 | `ad-validated-bounds`: true range contained and enclosure tightens as order increases | P1-P7, interval/remainder arithmetic | v2.0-starlight formal verification of AD |
+| P9 / ESH-0194 | Differentiable control flow through loops, branches, recursion, closures, named-let, map/fold | v1.5 | `ad-control-flow`: control-flow AD oracle PASS to d=8; kink policy enforced | P1-P5 | v1.5-intelligence differentiable programs, not just differentiable kernels |
+| P10 / ESH-0195 | Checkpointed high-order reverse with rematerialization for tower-valued tapes | v1.5->v1.7 | `ad-reverse-highorder`: deep high-order reverse PASS within memory budget | P5, P9 | v1.5-intelligence now; v1.7-synthesis scalability for learned search |
+| P11 / ESH-0196 | Tower-based user numerics: series ODEs, root finding, inversion, analytic continuation | v1.4.x | `ad-numerics`: ODE/root/inversion examples converge to analytic references | P1, P2, P6 | v1.4-connection infrastructure track as public numerical substrate |
+| P12 / ESH-0197 | Sparse high-order tensors via sparse GUW recovery and star-coloring seed directions | v1.6 | `ad-sparse`: sparse recovery matches dense recovery on tractable cases; savings recorded | P4, P9 | v1.6-reasoning knowledge graphs and sparse relational structure |
+
+## ICC Gate Names
+
+The campaign uses these ICC criterion/event families so release targets
+can compose AD evidence without duplicating implementation details:
+
+- `ad-depth`: arbitrary-order univariate derivatives and nested AD to d=8.
+- `ad-exact`: exact coefficients and multivariate analytic checks.
+- `ad-control-flow`: tower propagation through control-flow and higher-order calls.
+- `ad-tensor-highorder`: tensor-valued tower correctness for ML operators.
+- `ad-reverse-highorder`: reverse-over-Taylor and checkpointed reverse.
+- `ad-sparse`: sparse high-order mixed-partial recovery.
+- `ad-validated-bounds`: Taylor-model enclosure soundness and tightening.
+- `ad-numerics`: public Taylor-series numerical APIs.
+- `mono-equiv`: compile-time monomorphized tower/runtime tower equivalence.
+
+## Ledger Tagging
+
+The current `master` branch has ledger tasks only through ESH-0184, so
+there are no `.swarm/tasks/ESH-0185..0197.json` files to edit in this
+branch. When PR #147 merges those tasks, tag each JSON file with:
+
+```json
+"version": "<target version from the table>",
+"icc_gate": "<ICC oracle criterion from the table>"
+```
+
+For P10, use `version: "v1.5->v1.7"` and
+`icc_gate: "ad-reverse-highorder"` to reflect the current release
+bridge: it starts as v1.5 intelligence infrastructure and carries the
+scaling work forward into synthesis.


### PR DESCRIPTION
Threads the AD Taylor-tower campaign (P0–P12) through the **existing** canonical version themes as enabling substrate — not a parallel release ladder.

**ROADMAP.md** (all existing themes/items preserved; 11/11 version sections intact):
- v1.3-evolve: P1–P3 (P1 closes ESH-0118)
- v1.4-connection: P4/P6/P11 AD-infra track alongside networking
- v1.5-intelligence: P5/P7/P9/P10 (reverse-over-Taylor, tensor towers, differentiable control flow)
- v1.6-reasoning: P12 sparse high-order tensors
- v2.0-starlight: P8 validated AD (Taylor models)
- dependency-chain note + Release Timeline + footer updated

**docs/AD_CAMPAIGN.md** — phase → version → ICC-gate map with dependencies + roadmap theme each feeds.

**.icc/completion-oracles.yaml** — adds `ad-taylor-campaign`, `v1.4-release`, `v1.5-release` oracle targets so readiness objectively includes AD gates (additive; YAML validated, 23 targets).

Companion: design PR #147, P1 PR #148 (ESH-0118 closed).