### PR TITLE
test(nesting): syntax/data nesting-depth-parametric sweep (P6c)

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -397,6 +397,13 @@ oracles:
         label: 'No metaprogramming/module family produces a WRONG value at any swept depth'
         action: ./scripts/run_metaprog_depth.sh
       - runtime_event:
+          event_kinds: [nesting_depth]
+          event_names: ["nesting_depth_gate"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'Syntax/data nesting-depth sweep: no silent wrong value, no -r/AOT-O0/AOT-O2 divergence at any nested depth'
+        action: ./scripts/run_nesting_depth.sh
+      - runtime_event:
           event_kinds: [metamorphic]
           event_names: ["metamorphic_gate"]
           event_values: ["PASS"]
@@ -1706,3 +1713,30 @@ oracles:
         severity: high
         label: No tensor/collection/string family is WRONG or axis-divergent at any swept depth/size
         action: ./scripts/run_tensor_collection_depth.sh
+
+  # ─────────────────────────────────────────────────────────────────
+  # Syntax/data NESTING-depth-parametric sweep (adversarial pillar P6c,
+  # .swarm/DEPTH_PARAMETRIC_TESTING.md). scripts/gen_nesting_depth.py
+  # nests every composable syntactic/data construct — quote/quasiquote/
+  # unquote/unquote-splicing, let/let*/letrec/letrec*, lambda + closure-
+  # capture chains, nested vectors/lists, guard/dynamic-wind, cond/if/case,
+  # begin, and deep application chains — parametrically at nesting depth
+  # d=1..N, each carrying a closed-form ground truth.
+  # scripts/run_nesting_depth.sh runs every probe under THREE axes (JIT -r,
+  # AOT -O0, AOT -O2), classifies each cell PASS / WRONG(silent) /
+  # AXIS-DIVERGENCE(-r vs AOT-O0 vs AOT-O2) / LIMIT(clean), and records the
+  # max-correct nesting depth per construct. A WRONG value, an axis
+  # divergence, or a silent crash at any depth flips the gate to FAIL; a
+  # clean LIMIT is a documented capability boundary. Writes
+  # kind:"nesting_depth" events to scripts/icc_traces/nesting_depth.jsonl.
+  # ─────────────────────────────────────────────────────────────────
+  - name: nesting-depth
+    aliases: [nesting_depth, nesting-depth-sweep, adversarial-p6c]
+    requires:
+      - runtime_event:
+          event_kinds: [nesting_depth]
+          event_names: ["nesting_depth_gate"]
+          event_values: ["PASS"]
+        severity: high
+        label: Syntax/data nesting-depth sweep gate (no silent wrong value, no -r/AOT-O0/AOT-O2 divergence, no silent crash at any tested depth)
+        action: ./scripts/run_nesting_depth.sh


### PR DESCRIPTION
## P6c — syntax/data NESTING-depth-parametric adversarial sweep

Adds pillar **P6c** of the depth-parametric adversarial campaign
(`.swarm/DEPTH_PARAMETRIC_TESTING.md`). Every composable syntactic/data
construct is nested **parametrically** at nesting depth
`d = 1,2,4,8,16,32,64,128,256` and each cell is verified two ways at once:

1. **Closed-form oracle** baked into each probe (`d(d+1)/2` or `d`).
2. **Differential across three axes** — JIT `-r`, AOT `-O0`, AOT `-O2`.

Each cell is classified **PASS / WRONG(silent) / AXIS-DIVERGENCE(-r vs O0 vs O2)
/ LIMIT(clean) / SILENT-CRASH**, and the runner records the max-correct nesting
depth per construct.

### Constructs swept (18)
quote / quasiquote / unquote / unquote-splicing nesting · let / let\* / letrec /
letrec\* nesting · curried lambda chains · closure-capture chains · nested
vectors / lists · if / cond / case nesting · begin · guard · dynamic-wind · deep
application chains.

### Result — gate PASS
```
total=162  pass=158  limit=4  wrong=0  diverge=0  silent_crash=0
```
**No silent wrong value, no `-r`/`-O0`/`-O2` divergence, no silent crash at any
depth.** 17/18 constructs correct on all axes to the tested ceiling (256).

### Finding (clean limit, not a silent bug) — ESH-0185
Curried lambda-application chains `((((lambda…)1)2)…)` are correct to depth 17,
then a **consistent, diagnosed SIGSEGV** from depth 18 on all three axes. It is a
clean capability boundary (not a silent miscompile): `closure_capture`,
`app_chain`, and the `let`/`letrec` families all reach 256. Likely `O(d^2)`
free-variable capture recursing during codegen. Tracked as `ESH-0185`.

### Deliverables
- `scripts/gen_nesting_depth.py` — deterministic generator (`--max`/`--depths`).
- `scripts/run_nesting_depth.sh` — 3-axis runner + gate; emits
  `kind:nesting_depth` ICC events (incl. `nesting_depth_gate`) to
  `scripts/icc_traces/nesting_depth.jsonl`.
- `.icc/completion-oracles.yaml` — additive `nesting-depth` oracle, also folded
  into the `v1.3-evolve` depth-campaign block (YAML validated).
- `NESTING_DEPTH_REPORT.md` — per-construct max-correct-depth table + findings.
- `.swarm/tasks/ESH-0185.json`.

### Disk budget (mandatory)
Single reused temp binary deleted after each run; git-ignored `artifacts/` +
generated corpus; 1 GB `du` abort; on-exit cleanup trap. Observed peak: **12 KB**
artifacts.

### Reproduce
```sh
cmake --build build --target eshkol-run stdlib -j8
scripts/run_nesting_depth.sh          # full sweep + gate
scripts/run_nesting_depth.sh --quick  # drops d=128,256
```