### PR TITLE
fix(r7rs): cond/case =>, vector-copy, error-object accessors, write escaping (ESH-0152/0153/0155/0156)

### DIFF
--- a/.swarm/tasks/ESH-0152.json
+++ b/.swarm/tasks/ESH-0152.json
@@ -1,0 +1,31 @@
+{
+  "id": "ESH-0152",
+  "title": "cond/case `=>` receiver form unsupported",
+  "status": "done",
+  "priority": "high",
+  "workstream": "r7rs-conformance",
+  "owner": "tsotchke",
+  "preferred_backend": "claude",
+  "goal": "R7RS §5.5 `=>` clause: (cond ((assv 1 (list (cons 1 10))) => cdr) (else 0)) must return 10. The test is evaluated once; if truthy the receiver is applied to the test value and the cond/case returns that result.",
+  "file_globs": [
+    "lib/backend/control_flow_codegen.cpp",
+    "inc/eshkol/backend/control_flow_codegen.h",
+    "lib/backend/llvm_codegen.cpp",
+    "tests/r7rs/conformance_batch_test.esk"
+  ],
+  "root_cause": "The parser lowers `(test => receiver)` to a clause whose body is [`=>`, receiver]. codegenCond/codegenCase simply evaluated every body expression in order, so it hit the bare identifier `=>` and failed with `Undefined variable: =>`. There was no special handling for the arrow form and no way to apply a computed procedure value to the test result inside ControlFlowCodegen.",
+  "fix": "Added a ClosureCallFunc callback to ControlFlowCodegen (wired to the main codegen's codegenClosureCall via ControlFlowCallbacks::closureCallWrapper). codegenCond now detects a two-element body whose first element is the identifier `=>`, evaluates the test once, and in the then-block applies the receiver (evaluated to a tagged procedure value) to the tagged test value. codegenCase applies the receiver to the matched key value the same way.",
+  "acceptance": [
+    "(cond ((assv 1 (list (cons 1 10))) => cdr) (else 0)) => 10",
+    "cond => clause not taken falls through to else",
+    "(case 5 ((4 5 6) => (lambda (x) (* x 10))) (else 0)) => 50",
+    "works under -r and AOT"
+  ],
+  "verification": [
+    "./build/eshkol-run tests/r7rs/conformance_batch_test.esk -r",
+    "./build/eshkol-run tests/r7rs/conformance_batch_test.esk -o /tmp/conf && /tmp/conf",
+    "bash scripts/run_sicp_smoke.sh (88/88)",
+    "tests/control_flow/cond_test.esk 31/31, if_then_else_test.esk 47/47"
+  ],
+  "blocked_by": []
+}

--- a/.swarm/tasks/ESH-0153.json
+++ b/.swarm/tasks/ESH-0153.json
@@ -1,0 +1,34 @@
+{
+  "id": "ESH-0153",
+  "title": "vector-copy (fresh slice) unimplemented",
+  "status": "done",
+  "priority": "high",
+  "workstream": "r7rs-conformance",
+  "owner": "tsotchke",
+  "preferred_backend": "claude",
+  "goal": "R7RS vector-copy: (vector-copy v), (vector-copy v start), (vector-copy v start end) return a FRESH vector holding the [start,end) slice, with bounds checking. vector-copy! (in-place) already existed; vector-copy did not and errored with `Unknown function: vector-copy`.",
+  "file_globs": [
+    "lib/backend/collection_codegen.cpp",
+    "inc/eshkol/backend/collection_codegen.h",
+    "lib/backend/llvm_codegen.cpp",
+    "tests/r7rs/conformance_batch_test.esk"
+  ],
+  "root_cause": "Only vector-copy! (CollectionCodegen::vectorCopy) was implemented/registered. There was no allocating vector-copy, so it was rejected as an unknown function at codegen time.",
+  "fix": "Added CollectionCodegen::vectorCopyNew implementing the allocating form on HEAP_SUBTYPE_VECTOR (length at offset 0, 16-byte tagged elements at offset 8): it rejects tensors with a clear raised error, bounds-checks 0<=start<=end<=len (raising via eshkol_make_exception_with_header/eshkol_raise like vector-ref), allocates a fresh vector via getArenaAllocateVectorWithHeader, and memcpys the slice. Registered vector-copy in the dispatch table, the known-builtins list, and function_return_types (Vector).",
+  "acceptance": [
+    "(vector-copy (vector 1 2 3)) => #(1 2 3)",
+    "(vector-copy (vector 10 20 30 40) 2) => #(30 40)",
+    "(vector-copy (vector 1 2 3 4) 1 3) => #(2 3)",
+    "empty slice (start=end) => #()",
+    "returned vector is fresh (mutating it does not touch the source)",
+    "out-of-range start/end or start>end raises an error",
+    "works under -r and AOT"
+  ],
+  "verification": [
+    "./build/eshkol-run tests/r7rs/conformance_batch_test.esk -r",
+    "./build/eshkol-run tests/r7rs/conformance_batch_test.esk -o /tmp/conf && /tmp/conf",
+    "tests/collections/empty_collection_test.esk all PASS",
+    "scripts/run_differential.sh 246/246 axis pairs agree"
+  ],
+  "blocked_by": []
+}

--- a/.swarm/tasks/ESH-0155.json
+++ b/.swarm/tasks/ESH-0155.json
@@ -1,0 +1,34 @@
+{
+  "id": "ESH-0155",
+  "title": "error-object? / error-object-message / error-object-irritants missing",
+  "status": "done",
+  "priority": "high",
+  "workstream": "r7rs-conformance",
+  "owner": "tsotchke",
+  "preferred_backend": "claude",
+  "goal": "R7RS §6.11: (guard (e (#t (display (error-object? e)) (display (error-object-message e)) (write (error-object-irritants e)))) (error \"boom\" 1 2)) must show #t, boom, (1 2). error-object? must be #f for a non-error raised value (e.g. a bare string).",
+  "file_globs": [
+    "lib/core/runtime_exceptions_hosted.cpp",
+    "inc/eshkol/eshkol.h",
+    "lib/backend/llvm_codegen.cpp",
+    "tests/r7rs/conformance_batch_test.esk"
+  ],
+  "root_cause": "The exception object (eshkol_exception_t, HEAP_SUBTYPE_EXCEPTION) already carried a message + irritants array and guard binds the raised HEAP_PTR to `e`, but codegenError dropped every argument after the message (never called add_irritant), and the three error-object accessors were not implemented, so they errored as unknown functions.",
+  "fix": "codegenError now attaches arguments 2..N as irritants via a new ABI-safe eshkol_exception_add_irritant_ptr (pointer arg, no by-value 16-byte struct across the C ABI). Added runtime accessors eshkol_error_object_p (checks HEAP_PTR + HEAP_SUBTYPE_EXCEPTION, so returns #f for a raised string), eshkol_error_object_message (arena-copies the message into an Eshkol string), and eshkol_error_object_irritants (rebuilds the irritant array into a cons list). Codegen calls them through out-param helpers (codegenErrorObjectPredicate / codegenErrorObjectAccessor); registered the three names in the dispatch, known-builtins list, and function_return_types.",
+  "acceptance": [
+    "(error-object? e) => #t inside guard over (error ...)",
+    "(error-object-message e) => \"boom\"",
+    "(error-object-irritants e) => (1 2); () when no irritants",
+    "(error-object? e) => #f for (raise \"string\")",
+    "raised string still binds guard var e",
+    "existing guard/with-exception-handler behaviour unchanged",
+    "works under -r and AOT"
+  ],
+  "verification": [
+    "./build/eshkol-run tests/r7rs/conformance_batch_test.esk -r",
+    "./build/eshkol-run tests/r7rs/conformance_batch_test.esk -o /tmp/conf && /tmp/conf",
+    "tests/error_handling/{exception_test,exception_nesting_test,guard_advanced_test,guard_edge_test}.esk all PASS",
+    "bash scripts/run_sicp_smoke.sh (88/88)"
+  ],
+  "blocked_by": []
+}

--- a/.swarm/tasks/ESH-0156.json
+++ b/.swarm/tasks/ESH-0156.json
@@ -1,0 +1,31 @@
+{
+  "id": "ESH-0156",
+  "title": "write does not escape strings",
+  "status": "done",
+  "priority": "high",
+  "workstream": "r7rs-conformance",
+  "owner": "tsotchke",
+  "preferred_backend": "claude",
+  "goal": "R7RS: (write \"a\\nb\\tc\") must print the literal characters \"a\\nb\\tc\" (quoted, with \\n and \\t escaped); display of the same string stays raw. Characters under write must print as #\\a, #\\newline, #\\tab, #\\space, etc.",
+  "file_globs": [
+    "lib/core/runtime_display_hosted.cpp",
+    "tests/r7rs/conformance_batch_test.esk"
+  ],
+  "root_cause": "write already routed to eshkol_write_value (quote_strings=1) and chars already printed with #\\ names under write, but the string path only wrapped the bytes in double quotes without escaping. So (write \"a\\nb\") emitted a literal newline instead of \\n, producing output the reader cannot round-trip.",
+  "fix": "Added write_escaped_string() in the shared display runtime: wraps in double quotes and escapes \\\" and \\\\ (mandatory), the mnemonic escapes \\a \\b \\t \\n \\r, and any other control byte as inline hex \\xNN; while passing UTF-8 bytes (>=0x80) through untouched. Both string display paths (HEAP_SUBTYPE_STRING and ESHKOL_VALUE_STRING_PTR) call it only when quote_strings is set, so display is unchanged and the write path (including recursion into lists/vectors and cycle handling) keeps its existing machinery.",
+  "acceptance": [
+    "(write \"a\\nb\\tc\") => \"a\\nb\\tc\" (12 literal chars)",
+    "(write \"x\\\\y\\\"z\") escapes backslash and doublequote",
+    "(display \"a\\nb\\tc\") stays raw/unquoted",
+    "(write #\\newline) => #\\newline, #\\space, #\\tab, #\\a",
+    "write recurses into lists escaping nested strings",
+    "works under -r and AOT"
+  ],
+  "verification": [
+    "./build/eshkol-run tests/r7rs/conformance_batch_test.esk -r",
+    "./build/eshkol-run tests/r7rs/conformance_batch_test.esk -o /tmp/conf && /tmp/conf",
+    "bash scripts/run_sicp_smoke.sh (88/88)",
+    "scripts/run_differential.sh 246/246 axis pairs agree (no display regression)"
+  ],
+  "blocked_by": []
+}

--- a/inc/eshkol/backend/collection_codegen.h
+++ b/inc/eshkol/backend/collection_codegen.h
@@ -131,6 +131,16 @@ public:
     llvm::Value* vectorCopy(const eshkol_operations_t* op);
 
     /**
+     * Copy a vector slice into a fresh vector:
+     *   (vector-copy v)             — whole vector
+     *   (vector-copy v start)       — from start to end
+     *   (vector-copy v start end)   — the [start,end) slice
+     * @param op The operation AST node
+     * @return New vector as tagged value
+     */
+    llvm::Value* vectorCopyNew(const eshkol_operations_t* op);
+
+    /**
      * Concatenate vectors: (vector-append vec1 vec2 ...)
      * @param op The operation AST node
      * @return New vector as tagged value

--- a/inc/eshkol/backend/control_flow_codegen.h
+++ b/inc/eshkol/backend/control_flow_codegen.h
@@ -20,6 +20,7 @@
 #include <eshkol/backend/tagged_value_codegen.h>
 #include <eshkol/eshkol.h>
 #include <llvm/IR/Value.h>
+#include <vector>
 
 namespace eshkol {
 
@@ -149,6 +150,14 @@ private:
     DetectAndPackFunc detect_and_pack_callback_ = nullptr;
     void* callback_context_ = nullptr;
 
+    // Apply a computed procedure value to argument values. Used by the R7RS
+    // `=>` receiver form in cond/case: (test => receiver) applies receiver to
+    // the value of test. Reuses the main codegen's closure-call dispatcher.
+    using ClosureCallFunc = llvm::Value* (*)(llvm::Value* closure,
+                                             const std::vector<llvm::Value*>& args,
+                                             void* context);
+    ClosureCallFunc closure_call_callback_ = nullptr;
+
 public:
     /**
      * Set callbacks for AST code generation.
@@ -172,6 +181,15 @@ public:
         eqv_compare_callback_ = eqv_compare;
         detect_and_pack_callback_ = detect_and_pack;
         callback_context_ = context;
+    }
+
+    /**
+     * Set the closure-call callback used for the `=>` receiver form in
+     * cond/case. Injected separately to avoid disturbing the existing
+     * setCodegenCallbacks signature and its other callers.
+     */
+    void setClosureCallCallback(ClosureCallFunc closure_call) {
+        closure_call_callback_ = closure_call;
     }
 };
 

--- a/inc/eshkol/eshkol.h
+++ b/inc/eshkol/eshkol.h
@@ -980,8 +980,13 @@ extern eshkol_exception_handler_t* g_exception_handler_stack;
 eshkol_exception_t* eshkol_make_exception(eshkol_exception_type_t type, const char* message);
 eshkol_exception_t* eshkol_make_exception_with_header(eshkol_exception_type_t type, const char* message);
 void eshkol_exception_add_irritant(eshkol_exception_t* exc, eshkol_tagged_value_t irritant);
+void eshkol_exception_add_irritant_ptr(eshkol_exception_t* exc, const eshkol_tagged_value_t* irritant);
 void eshkol_exception_set_location(eshkol_exception_t* exc, uint32_t line, uint32_t column, const char* filename);
 void eshkol_raise(eshkol_exception_t* exception);
+// R7RS error-object accessors (implemented in runtime_exceptions_hosted.cpp)
+int  eshkol_error_object_p(const eshkol_tagged_value_t* obj);
+void eshkol_error_object_message(const eshkol_tagged_value_t* obj, eshkol_tagged_value_t* out);
+void eshkol_error_object_irritants(const eshkol_tagged_value_t* obj, eshkol_tagged_value_t* out);
 void eshkol_push_exception_handler(void* jmp_buf_ptr);
 void eshkol_pop_exception_handler(void);
 int eshkol_exception_type_matches(eshkol_exception_t* exc, eshkol_exception_type_t type);

--- a/lib/backend/collection_codegen.cpp
+++ b/lib/backend/collection_codegen.cpp
@@ -2041,6 +2041,135 @@ llvm::Value* CollectionCodegen::vectorCopy(const eshkol_operations_t* op) {
     return tagged_.packNull();
 }
 
+llvm::Value* CollectionCodegen::vectorCopyNew(const eshkol_operations_t* op) {
+    if (!codegen_ast_callback_ || !codegen_typed_ast_callback_ || !typed_to_tagged_callback_) {
+        eshkol_warn("CollectionCodegen::vectorCopyNew - callbacks not set");
+        return tagged_.packNull();
+    }
+
+    // (vector-copy v) | (vector-copy v start) | (vector-copy v start end)
+    if (op->call_op.num_vars < 1 || op->call_op.num_vars > 3) {
+        eshkol_warn("vector-copy requires 1-3 arguments");
+        return nullptr;
+    }
+
+    llvm::Value* vec_arg = codegen_ast_callback_(&op->call_op.variables[0], callback_context_);
+    if (!vec_arg) return nullptr;
+    llvm::Value* vec_ptr = ctx_.builder().CreateIntToPtr(tagged_.unpackInt64(vec_arg), ctx_.ptrType());
+
+    llvm::Function* current_func = ctx_.builder().GetInsertBlock()->getParent();
+
+    // Reusable raise helper for the out-of-range / wrong-type conditions.
+    auto raise_error = [&](const char* message) {
+        llvm::Function* raise_func = ctx_.module().getFunction("eshkol_raise");
+        if (!raise_func) {
+            llvm::FunctionType* raise_type = llvm::FunctionType::get(
+                ctx_.builder().getVoidTy(), {ctx_.ptrType()}, false);
+            raise_func = llvm::Function::Create(raise_type, llvm::Function::ExternalLinkage,
+                "eshkol_raise", &ctx_.module());
+            raise_func->setDoesNotReturn();
+        }
+        llvm::Function* make_exc_func = ctx_.module().getFunction("eshkol_make_exception_with_header");
+        if (!make_exc_func) {
+            llvm::FunctionType* make_type = llvm::FunctionType::get(ctx_.ptrType(),
+                {ctx_.builder().getInt32Ty(), ctx_.ptrType()}, false);
+            make_exc_func = llvm::Function::Create(make_type, llvm::Function::ExternalLinkage,
+                "eshkol_make_exception_with_header", &ctx_.module());
+        }
+        llvm::Value* msg = ctx_.builder().CreateGlobalString(message);
+        llvm::Value* exc_type = llvm::ConstantInt::get(ctx_.builder().getInt32Ty(), ESHKOL_EXCEPTION_ERROR);
+        llvm::Value* exc = ctx_.builder().CreateCall(make_exc_func, {exc_type, msg});
+        ctx_.builder().CreateCall(raise_func, {exc});
+        ctx_.builder().CreateUnreachable();
+    };
+
+    // Reject tensors (`#(...)` literals) — their layout differs from a
+    // Scheme vector, so silently copying would corrupt memory.
+    {
+        llvm::Value* header_ptr = ctx_.builder().CreateGEP(ctx_.int8Type(), vec_ptr,
+            llvm::ConstantInt::get(ctx_.int64Type(), -8));
+        llvm::Value* subtype = ctx_.builder().CreateLoad(ctx_.int8Type(), header_ptr, "vcopy_subtype");
+        llvm::Value* is_tensor = ctx_.builder().CreateICmpEQ(subtype,
+            llvm::ConstantInt::get(ctx_.int8Type(), HEAP_SUBTYPE_TENSOR));
+        llvm::BasicBlock* tensor_fail = llvm::BasicBlock::Create(ctx_.context(), "vcopy_tensor_fail", current_func);
+        llvm::BasicBlock* not_tensor = llvm::BasicBlock::Create(ctx_.context(), "vcopy_not_tensor", current_func);
+        ctx_.builder().CreateCondBr(is_tensor, tensor_fail, not_tensor);
+        ctx_.builder().SetInsertPoint(tensor_fail);
+        raise_error("vector-copy: argument is a tensor, not a vector");
+        ctx_.builder().SetInsertPoint(not_tensor);
+    }
+
+    llvm::Value* len = ctx_.builder().CreateLoad(ctx_.int64Type(), vec_ptr, "vcopy_len");
+
+    // start (default 0)
+    llvm::Value* start;
+    if (op->call_op.num_vars >= 2) {
+        void* start_typed = codegen_typed_ast_callback_(&op->call_op.variables[1], callback_context_);
+        if (!start_typed) return nullptr;
+        llvm::Value* start_tagged = typed_to_tagged_callback_(start_typed, callback_context_);
+        if (!start_tagged) return nullptr;
+        start = tagged_.unpackInt64(start_tagged);
+    } else {
+        start = llvm::ConstantInt::get(ctx_.int64Type(), 0);
+    }
+
+    // end (default len)
+    llvm::Value* end;
+    if (op->call_op.num_vars >= 3) {
+        void* end_typed = codegen_typed_ast_callback_(&op->call_op.variables[2], callback_context_);
+        if (!end_typed) return nullptr;
+        llvm::Value* end_tagged = typed_to_tagged_callback_(end_typed, callback_context_);
+        if (!end_tagged) return nullptr;
+        end = tagged_.unpackInt64(end_tagged);
+    } else {
+        end = len;
+    }
+
+    // Bounds check: 0 <= start <= end <= len
+    {
+        llvm::Value* start_neg = ctx_.builder().CreateICmpSLT(start,
+            llvm::ConstantInt::get(ctx_.int64Type(), 0));
+        llvm::Value* end_over = ctx_.builder().CreateICmpSGT(end, len);
+        llvm::Value* start_gt_end = ctx_.builder().CreateICmpSGT(start, end);
+        llvm::Value* bad = ctx_.builder().CreateOr(start_neg,
+            ctx_.builder().CreateOr(end_over, start_gt_end));
+        llvm::BasicBlock* bounds_fail = llvm::BasicBlock::Create(ctx_.context(), "vcopy_bounds_fail", current_func);
+        llvm::BasicBlock* bounds_ok = llvm::BasicBlock::Create(ctx_.context(), "vcopy_bounds_ok", current_func);
+        ctx_.builder().CreateCondBr(bad, bounds_fail, bounds_ok);
+        ctx_.builder().SetInsertPoint(bounds_fail);
+        raise_error("vector-copy: index out of range");
+        ctx_.builder().SetInsertPoint(bounds_ok);
+    }
+
+    llvm::Value* count = ctx_.builder().CreateSub(end, start, "vcopy_count");
+
+    // Allocate the fresh vector and store its length.
+    llvm::Value* arena_ptr = ctx_.builder().CreateLoad(ctx_.ptrType(), ctx_.globalArena());
+    llvm::Value* new_vec = ctx_.builder().CreateCall(mem_.getArenaAllocateVectorWithHeader(),
+        {arena_ptr, count});
+    llvm::Value* new_len_ptr = ctx_.builder().CreatePointerCast(new_vec, ctx_.ptrType());
+    ctx_.builder().CreateStore(count, new_len_ptr);
+
+    // Copy the [start,end) slice (16 bytes per tagged element).
+    llvm::Value* src_elem_base = ctx_.builder().CreateGEP(ctx_.int8Type(), vec_ptr,
+        llvm::ConstantInt::get(ctx_.int64Type(), 8));
+    llvm::Value* src_elem_typed = ctx_.builder().CreatePointerCast(src_elem_base, ctx_.ptrType());
+    llvm::Value* src_ptr = ctx_.builder().CreateGEP(ctx_.taggedValueType(), src_elem_typed, start);
+
+    llvm::Value* dst_elem_base = ctx_.builder().CreateGEP(ctx_.int8Type(), new_vec,
+        llvm::ConstantInt::get(ctx_.int64Type(), 8));
+    llvm::Value* dst_elem_typed = ctx_.builder().CreatePointerCast(dst_elem_base, ctx_.ptrType());
+
+    llvm::Value* byte_count = ctx_.builder().CreateMul(count,
+        llvm::ConstantInt::get(ctx_.int64Type(), 16), "vcopy_bytes");
+    ctx_.builder().CreateMemCpy(
+        dst_elem_typed, llvm::MaybeAlign(8),
+        src_ptr, llvm::MaybeAlign(8),
+        byte_count);
+
+    return tagged_.packHeapPtr(new_vec);
+}
+
 llvm::Value* CollectionCodegen::vectorAppend(const eshkol_operations_t* op) {
     if (!codegen_ast_callback_) {
         eshkol_warn("CollectionCodegen::vectorAppend - callbacks not set");

--- a/lib/backend/control_flow_codegen.cpp
+++ b/lib/backend/control_flow_codegen.cpp
@@ -331,6 +331,16 @@ llvm::Value* ControlFlowCodegen::codegenCond(const eshkol_operations_t* op) {
             }
             break;
         } else {
+            // R7RS §5.5 `=>` receiver form: (test => receiver). The test is
+            // evaluated once; if truthy, `receiver` (which must yield a
+            // procedure) is applied to the test's value and the cond returns
+            // that result. The parser lowers this to a clause whose body is
+            // [`=>`, receiver], so detect a leading `=>` identifier.
+            bool is_arrow = (clause->operation.call_op.num_vars == 2 &&
+                clause->operation.call_op.variables[0].type == ESHKOL_VAR &&
+                clause->operation.call_op.variables[0].variable.id &&
+                strcmp(clause->operation.call_op.variables[0].variable.id, "=>") == 0);
+
             // Regular clause — evaluate test using direct AST callback
             llvm::Value* test = codegen_ast_callback_(clause->operation.call_op.func, callback_context_);
             if (!test) continue;
@@ -344,6 +354,26 @@ llvm::Value* ControlFlowCodegen::codegenCond(const eshkol_operations_t* op) {
             // Then block — evaluate body expressions using direct AST callback
             ctx_.builder().SetInsertPoint(then_block);
             llvm::Value* result = nullptr;
+            if (is_arrow) {
+                // Evaluate the receiver to a procedure value, then apply it to
+                // the (tagged) test value via the closure-call dispatcher.
+                llvm::Value* receiver = codegen_ast_callback_(
+                    &clause->operation.call_op.variables[1], callback_context_);
+                llvm::Value* test_val = test;
+                if (test_val->getType() != ctx_.taggedValueType() && detect_and_pack_callback_) {
+                    test_val = detect_and_pack_callback_(test_val, callback_context_);
+                }
+                if (receiver && receiver->getType() != ctx_.taggedValueType() && detect_and_pack_callback_) {
+                    receiver = detect_and_pack_callback_(receiver, callback_context_);
+                }
+                if (receiver && closure_call_callback_) {
+                    std::vector<llvm::Value*> args{test_val};
+                    result = closure_call_callback_(receiver, args, callback_context_);
+                } else {
+                    eshkol_warn("cond `=>` requires a procedure receiver");
+                    result = test_val;
+                }
+            } else
             for (uint64_t j = 0; j < clause->operation.call_op.num_vars; j++) {
                 if (ctx_.builder().GetInsertBlock()->getTerminator()) break;
                 result = codegen_ast_callback_(&clause->operation.call_op.variables[j], callback_context_);
@@ -768,7 +798,24 @@ llvm::Value* ControlFlowCodegen::codegenCase(const eshkol_operations_t* op) {
             // Then block - evaluate body expressions
             ctx_.builder().SetInsertPoint(then_block);
             llvm::Value* result = nullptr;
-            if (body_ast && body_ast->type == ESHKOL_OP &&
+            // R7RS §5.5 `=>` receiver form in case: (datums => receiver).
+            bool is_arrow = (body_ast && body_ast->type == ESHKOL_OP &&
+                body_ast->operation.op == ESHKOL_CALL_OP &&
+                body_ast->operation.call_op.num_vars == 2 &&
+                body_ast->operation.call_op.variables[0].type == ESHKOL_VAR &&
+                body_ast->operation.call_op.variables[0].variable.id &&
+                strcmp(body_ast->operation.call_op.variables[0].variable.id, "=>") == 0);
+            if (is_arrow && codegen_ast_callback_ && closure_call_callback_) {
+                llvm::Value* receiver = codegen_ast_callback_(
+                    &body_ast->operation.call_op.variables[1], callback_context_);
+                if (receiver && receiver->getType() != ctx_.taggedValueType() && detect_and_pack_callback_) {
+                    receiver = detect_and_pack_callback_(receiver, callback_context_);
+                }
+                if (receiver) {
+                    std::vector<llvm::Value*> args{key};
+                    result = closure_call_callback_(receiver, args, callback_context_);
+                }
+            } else if (body_ast && body_ast->type == ESHKOL_OP &&
                 body_ast->operation.op == ESHKOL_CALL_OP) {
                 for (uint64_t j = 0; j < body_ast->operation.call_op.num_vars; j++) {
                     void* tv_ptr = codegen_typed_ast_callback_(&body_ast->operation.call_op.variables[j], callback_context_);

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -1706,7 +1706,13 @@ public:
         function_return_types["make-vector"] = BuiltinTypes::Vector;
         function_return_types["vector-length"] = BuiltinTypes::Int64;
         function_return_types["vector-ref"] = BuiltinTypes::Value;
+        function_return_types["vector-copy"] = BuiltinTypes::Vector;
         function_return_types["vector-append"] = BuiltinTypes::Vector;
+
+        // R7RS error-object accessors
+        function_return_types["error-object?"] = BuiltinTypes::Boolean;
+        function_return_types["error-object-message"] = BuiltinTypes::Value;
+        function_return_types["error-object-irritants"] = BuiltinTypes::List;
         function_return_types["vector->list"] = BuiltinTypes::List;
         function_return_types["list->vector"] = BuiltinTypes::Vector;
 
@@ -3930,6 +3936,7 @@ private:
             ControlFlowCallbacks::detectAndPackWrapper,
             this
         );
+        flow_->setClosureCallCallback(ControlFlowCallbacks::closureCallWrapper);
         eshkol_debug("Created ControlFlowCodegen with callbacks");
 
         // Initialize StringIOCodegen - string and I/O operations
@@ -14084,6 +14091,11 @@ private:
         }
 
         if (func_name == "error") return codegenError(op);
+        if (func_name == "error-object?") return codegenErrorObjectPredicate(op);
+        if (func_name == "error-object-message")
+            return codegenErrorObjectAccessor(op, "eshkol_error_object_message", "error-object-message");
+        if (func_name == "error-object-irritants")
+            return codegenErrorObjectAccessor(op, "eshkol_error_object_irritants", "error-object-irritants");
         if (func_name == "with-exception-handler") return codegenWithExceptionHandler(op);
 
         // Handle file I/O operations
@@ -15943,6 +15955,7 @@ private:
         if (func_name == "vector-set!") return coll_->vectorSet(op);
         if (func_name == "vector-length") return coll_->vectorLength(op);
         if (func_name == "vector-copy!") return coll_->vectorCopy(op);
+        if (func_name == "vector-copy") return coll_->vectorCopyNew(op);
         if (func_name == "vector-append") return coll_->vectorAppend(op);
         if (func_name == "vector-fill!") return coll_->vectorFill(op);
         if (func_name == "vector->list") return coll_->vectorToList(op);
@@ -23250,6 +23263,59 @@ private:
 
     // NOTE: codegenNewline has been migrated to StringIOCodegen (strio_->newline)
 
+    // (error-object? obj) — #t iff obj is an error object created by `error`.
+    Value* codegenErrorObjectPredicate(const eshkol_operations_t* op) {
+        if (op->call_op.num_vars != 1) {
+            eshkol_warn("error-object? requires exactly 1 argument");
+            return nullptr;
+        }
+        TypedValue arg = codegenTypedAST(&op->call_op.variables[0]);
+        Value* tagged = typedValueToTaggedValue(arg);
+        if (!tagged) return nullptr;
+
+        Function* cur = builder->GetInsertBlock()->getParent();
+        IRBuilder<> entry_builder(&cur->getEntryBlock(), cur->getEntryBlock().begin());
+        AllocaInst* slot = entry_builder.CreateAlloca(tagged_value_type, nullptr, "errobj_arg");
+        builder->CreateStore(tagged, slot);
+
+        Function* f = module->getFunction("eshkol_error_object_p");
+        if (!f) {
+            FunctionType* ft = FunctionType::get(builder->getInt32Ty(), {builder->getPtrTy()}, false);
+            f = Function::Create(ft, Function::ExternalLinkage, "eshkol_error_object_p", module.get());
+        }
+        Value* r = builder->CreateCall(f, {slot});
+        Value* b = builder->CreateICmpNE(r, ConstantInt::get(builder->getInt32Ty(), 0));
+        return packBoolToTaggedValue(b);
+    }
+
+    // (error-object-message obj) / (error-object-irritants obj) — extract the
+    // stored message string or irritant list via an out-param runtime call.
+    Value* codegenErrorObjectAccessor(const eshkol_operations_t* op,
+                                      const char* runtime_fn, const char* scheme_name) {
+        if (op->call_op.num_vars != 1) {
+            eshkol_warn("%s requires exactly 1 argument", scheme_name);
+            return nullptr;
+        }
+        TypedValue arg = codegenTypedAST(&op->call_op.variables[0]);
+        Value* tagged = typedValueToTaggedValue(arg);
+        if (!tagged) return nullptr;
+
+        Function* cur = builder->GetInsertBlock()->getParent();
+        IRBuilder<> entry_builder(&cur->getEntryBlock(), cur->getEntryBlock().begin());
+        AllocaInst* slot = entry_builder.CreateAlloca(tagged_value_type, nullptr, "errobj_arg");
+        AllocaInst* out = entry_builder.CreateAlloca(tagged_value_type, nullptr, "errobj_out");
+        builder->CreateStore(tagged, slot);
+
+        Function* f = module->getFunction(runtime_fn);
+        if (!f) {
+            FunctionType* ft = FunctionType::get(builder->getVoidTy(),
+                {builder->getPtrTy(), builder->getPtrTy()}, false);
+            f = Function::Create(ft, Function::ExternalLinkage, runtime_fn, module.get());
+        }
+        builder->CreateCall(f, {slot, out});
+        return builder->CreateLoad(tagged_value_type, out, "errobj_result");
+    }
+
     Value* codegenError(const eshkol_operations_t* op) {
         // Use exception system: create exception and raise it
         // This allows (error "msg" ...) to be caught by guard
@@ -23315,6 +23381,30 @@ private:
             ConstantInt::get(builder->getInt32Ty(), ESHKOL_EXCEPTION_ERROR),
             error_msg
         }, "error_exception");
+
+        // R7RS §6.11: attach the remaining arguments as irritants so
+        // error-object-irritants can recover them. Uses the pointer-based
+        // adder to stay ABI-safe.
+        if (op->call_op.num_vars > 1) {
+            Function* add_irritant_func = module->getFunction("eshkol_exception_add_irritant_ptr");
+            if (!add_irritant_func) {
+                FunctionType* add_type = FunctionType::get(builder->getVoidTy(),
+                    {builder->getPtrTy(), builder->getPtrTy()}, false);
+                add_irritant_func = Function::Create(add_type, Function::ExternalLinkage,
+                    "eshkol_exception_add_irritant_ptr", module.get());
+            }
+            Function* cur = builder->GetInsertBlock()->getParent();
+            IRBuilder<> entry_builder(&cur->getEntryBlock(), cur->getEntryBlock().begin());
+            AllocaInst* irritant_slot = entry_builder.CreateAlloca(tagged_value_type, nullptr, "error_irritant");
+            for (uint64_t i = 1; i < op->call_op.num_vars; i++) {
+                TypedValue irr = codegenTypedAST(&op->call_op.variables[i]);
+                if (!irr.llvm_value) continue;
+                Value* irr_tagged = typedValueToTaggedValue(irr);
+                if (!irr_tagged) continue;
+                builder->CreateStore(irr_tagged, irritant_slot);
+                builder->CreateCall(add_irritant_func, {exception, irritant_slot});
+            }
+        }
 
         // Raise exception
         builder->CreateCall(raise_func, {exception});
@@ -23614,7 +23704,7 @@ private:
             "string-foldcase", "string-for-each", "string-map",
             // Vectors
             "vector?", "make-vector", "vector", "vector-length",
-            "vector-ref", "vector-set!", "vector-copy!", "vector-append",
+            "vector-ref", "vector-set!", "vector-copy!", "vector-copy", "vector-append",
             "vector-fill!", "vector->list", "list->vector",
             "vector-for-each", "vector-map",
             // Control
@@ -23635,6 +23725,7 @@ private:
             "read-bytevector!", "u8-ready?",
             // Exceptions
             "error", "with-exception-handler", "raise", "guard",
+            "error-object?", "error-object-message", "error-object-irritants",
             // Continuations
             "call/cc", "call-with-current-continuation", "dynamic-wind",
             "call-with-port", "call-with-input-file", "call-with-output-file",

--- a/lib/core/runtime_display_hosted.cpp
+++ b/lib/core/runtime_display_hosted.cpp
@@ -53,6 +53,36 @@ static void display_tensor(uint64_t tensor_ptr, eshkol_display_opts_t* opts);
 static void display_vector(uint64_t vector_ptr, eshkol_display_opts_t* opts);
 static void display_char(uint32_t codepoint, eshkol_display_opts_t* opts);
 
+// R7RS `write` string external representation: wrap in double quotes and
+// escape the characters the reader would otherwise mis-parse. `\\` and `\"`
+// are mandatory; `\a \b \t \n \r` are the named mnemonic escapes; every
+// other control byte is emitted as an inline hex escape `\xNN;`. Bytes >=
+// 0x80 (UTF-8 continuation/lead bytes) pass through untouched so multi-byte
+// characters round-trip. `display` never calls this — only `write`.
+static void write_escaped_string(FILE* out, const char* data, size_t len) {
+    fputc('"', out);
+    for (size_t i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)data[i];
+        switch (c) {
+            case '"':  fputs("\\\"", out); break;
+            case '\\': fputs("\\\\", out); break;
+            case '\a': fputs("\\a", out); break;
+            case '\b': fputs("\\b", out); break;
+            case '\t': fputs("\\t", out); break;
+            case '\n': fputs("\\n", out); break;
+            case '\r': fputs("\\r", out); break;
+            default:
+                if (c < 0x20 || c == 0x7f) {
+                    fprintf(out, "\\x%x;", (unsigned)c);
+                } else {
+                    fputc((int)c, out);
+                }
+                break;
+        }
+    }
+    fputc('"', out);
+}
+
 // ─── R7RS current-output-port / current-input-port / current-error-port ───
 // The cells back the Scheme-level `current-output-port` / etc. parameter
 // objects. `parameterize` mutates them via the setter; runtime helpers
@@ -233,9 +263,7 @@ void eshkol_display_value_opts(const eshkol_tagged_value_t* value, eshkol_displa
                     size_t payload = (header->size > 0) ? (size_t)header->size - 1 : 0;
                     FILE* out = get_output(opts);
                     if (opts->quote_strings) {
-                        fputc('"', out);
-                        if (payload > 0) fwrite(data_ptr, 1, payload, out);
-                        fputc('"', out);
+                        write_escaped_string(out, (const char*)data_ptr, payload);
                     } else {
                         if (payload > 0) fwrite(data_ptr, 1, payload, out);
                     }
@@ -347,7 +375,8 @@ void eshkol_display_value_opts(const eshkol_tagged_value_t* value, eshkol_displa
 
         case ESHKOL_VALUE_STRING_PTR:
             if (opts->quote_strings) {
-                fprintf(get_output(opts), "\"%s\"", (const char*)value->data.ptr_val);
+                const char* s = (const char*)value->data.ptr_val;
+                write_escaped_string(get_output(opts), s, s ? strlen(s) : 0);
             } else {
                 fprintf(get_output(opts), "%s", (const char*)value->data.ptr_val);
             }

--- a/lib/core/runtime_exceptions_hosted.cpp
+++ b/lib/core/runtime_exceptions_hosted.cpp
@@ -158,6 +158,80 @@ extern "C" void eshkol_exception_add_irritant(eshkol_exception_t* exc, eshkol_ta
     exc->num_irritants = new_count;
 }
 
+// Pointer-based irritant adder — ABI-safe to call from generated code
+// (avoids passing a 16-byte tagged value by register/coercion).
+extern "C" void eshkol_exception_add_irritant_ptr(eshkol_exception_t* exc,
+                                                  const eshkol_tagged_value_t* irritant) {
+    if (!exc || !irritant) return;
+    eshkol_exception_add_irritant(exc, *irritant);
+}
+
+// ===== R7RS error-object accessors =====
+// `guard`/`with-exception-handler` bind the raised value. For
+// `(error msg irritant...)` that value is a HEAP_PTR to an
+// eshkol_exception_t (subtype HEAP_SUBTYPE_EXCEPTION). These helpers let
+// error-object?, error-object-message and error-object-irritants inspect it.
+// error-object? must return #f for any other raised value (e.g. a bare
+// string via `(raise "x")`), so it checks the heap subtype, not just the
+// pointer tag.
+
+extern "C" int eshkol_error_object_p(const eshkol_tagged_value_t* obj) {
+    if (!obj) return 0;
+    if (obj->type != ESHKOL_VALUE_HEAP_PTR) return 0;
+    void* ptr = (void*)obj->data.ptr_val;
+    if (!ptr) return 0;
+    return ESHKOL_GET_SUBTYPE(ptr) == HEAP_SUBTYPE_EXCEPTION ? 1 : 0;
+}
+
+extern "C" void eshkol_error_object_message(const eshkol_tagged_value_t* obj,
+                                            eshkol_tagged_value_t* out) {
+    out->type = ESHKOL_VALUE_NULL;
+    out->flags = 0;
+    out->reserved = 0;
+    out->data.ptr_val = 0;
+    if (!eshkol_error_object_p(obj)) return;
+    eshkol_exception_t* exc = (eshkol_exception_t*)obj->data.ptr_val;
+    const char* msg = exc->message ? exc->message : "";
+    arena_t* arena = __repl_shared_arena.load();
+    if (!arena) return;
+    size_t len = strlen(msg);
+    char* buf = arena_allocate_string_with_header(arena, len);
+    if (!buf) return;
+    if (len > 0) memcpy(buf, msg, len);
+    buf[len] = '\0';
+    out->type = ESHKOL_VALUE_HEAP_PTR;
+    out->data.ptr_val = (uint64_t)buf;
+}
+
+extern "C" void eshkol_error_object_irritants(const eshkol_tagged_value_t* obj,
+                                              eshkol_tagged_value_t* out) {
+    out->type = ESHKOL_VALUE_NULL;
+    out->flags = 0;
+    out->reserved = 0;
+    out->data.ptr_val = 0;
+    if (!eshkol_error_object_p(obj)) return;
+    eshkol_exception_t* exc = (eshkol_exception_t*)obj->data.ptr_val;
+    arena_t* arena = __repl_shared_arena.load();
+    if (!arena) return;
+    // Build the irritants list right-to-left so it preserves argument order.
+    eshkol_tagged_value_t list;
+    list.type = ESHKOL_VALUE_NULL;
+    list.flags = 0;
+    list.reserved = 0;
+    list.data.ptr_val = 0;
+    for (int i = (int)exc->num_irritants - 1; i >= 0; --i) {
+        arena_tagged_cons_cell_t* cell = arena_allocate_cons_with_header(arena);
+        if (!cell) return;
+        arena_tagged_cons_set_tagged_value(cell, false, &exc->irritants[i]);
+        arena_tagged_cons_set_tagged_value(cell, true, &list);
+        list.type = ESHKOL_VALUE_HEAP_PTR;
+        list.flags = 0;
+        list.reserved = 0;
+        list.data.ptr_val = (uint64_t)cell;
+    }
+    *out = list;
+}
+
 // Set source location on exception
 extern "C" void eshkol_exception_set_location(eshkol_exception_t* exc, uint32_t line, uint32_t column, const char* filename) {
     if (!exc) return;

--- a/tests/r7rs/conformance_batch_test.esk
+++ b/tests/r7rs/conformance_batch_test.esk
@@ -1,0 +1,91 @@
+; R7RS-small conformance batch (ESH-0152/0153/0155/0156)
+;   ESH-0152  cond/case `=>` receiver form
+;   ESH-0153  vector-copy (fresh slice)
+;   ESH-0155  error-object? / error-object-message / error-object-irritants
+;   ESH-0156  write escaping (strings and chars)
+; Runs identically under `-r` (JIT) and AOT.
+
+(define (check name ok)
+  (display (if ok "PASS: " "FAIL: "))
+  (display name)
+  (newline))
+
+; ── ESH-0152: cond `=>` ────────────────────────────────────────────────
+(check "cond => receiver returns applied result"
+  (= 10 (cond ((assv 1 (list (cons 1 10))) => cdr) (else 0))))
+
+(check "cond => not taken falls through to else"
+  (= 0 (cond ((assv 9 (list (cons 1 10))) => cdr) (else 0))))
+
+; ── ESH-0152: case `=>` ────────────────────────────────────────────────
+(check "case => applies receiver to key"
+  (= 50 (case 5 ((1 2 3) => (lambda (x) (* x 100)))
+                ((4 5 6) => (lambda (x) (* x 10)))
+                (else 0))))
+
+; ── ESH-0153: vector-copy ──────────────────────────────────────────────
+(check "vector-copy whole vector"
+  (equal? '(1 2 3) (vector->list (vector-copy (vector 1 2 3)))))
+
+(check "vector-copy from start"
+  (equal? '(30 40) (vector->list (vector-copy (vector 10 20 30 40) 2))))
+
+(check "vector-copy start..end slice"
+  (equal? '(2 3) (vector->list (vector-copy (vector 1 2 3 4) 1 3))))
+
+(check "vector-copy empty slice"
+  (equal? '() (vector->list (vector-copy (vector 1 2 3) 1 1))))
+
+(check "vector-copy makes a fresh vector (source unmutated)"
+  (let ((src (vector 1 2 3)))
+    (let ((dst (vector-copy src)))
+      (vector-set! dst 0 99)
+      (= 1 (vector-ref src 0)))))
+
+; ── ESH-0155: error-object family ──────────────────────────────────────
+(check "error-object? true for (error ...)"
+  (guard (e (#t (error-object? e))) (error "boom" 1 2)))
+
+(check "error-object-message extracts message"
+  (guard (e (#t (string=? "boom" (error-object-message e)))) (error "boom" 1 2)))
+
+(check "error-object-irritants extracts irritant list"
+  (guard (e (#t (equal? '(1 2) (error-object-irritants e)))) (error "boom" 1 2)))
+
+(check "error-object-irritants empty when none"
+  (guard (e (#t (equal? '() (error-object-irritants e)))) (error "msg")))
+
+(check "error-object? is #f for a raised string"
+  (guard (e (#t (not (error-object? e)))) (raise "plain-string")))
+
+(check "raised string still binds guard var"
+  (guard (e ((string? e) (string=? e "hi"))) (raise "hi")))
+
+; ── ESH-0156: write escaping ───────────────────────────────────────────
+(define (written x)
+  (let ((p (open-output-string)))
+    (write x p)
+    (get-output-string p)))
+
+(define (displayed x)
+  (let ((p (open-output-string)))
+    (display x p)
+    (get-output-string p)))
+
+(check "write escapes newline/tab and quotes string"
+  (string=? "\"a\\nb\\tc\"" (written "a\nb\tc")))
+
+(check "write escapes backslash and doublequote"
+  (string=? "\"x\\\\y\\\"z\"" (written "x\\y\"z")))
+
+(check "display leaves string raw and unquoted"
+  (string=? "a\nb\tc" (displayed "a\nb\tc")))
+
+(check "write names special chars"
+  (and (string=? "#\\newline" (written #\newline))
+       (string=? "#\\space"   (written #\space))
+       (string=? "#\\tab"     (written #\tab))
+       (string=? "#\\a"       (written #\a))))
+
+(check "write recurses into lists with escaped strings"
+  (string=? "(\"x\\ty\" 1 #\\z)" (written (list "x\ty" 1 #\z))))


### PR DESCRIPTION
Closes four R7RS-small conformance gaps surfaced by the reference-Scheme differential harness (P7a) and a downstream Noesis build. Each fix works identically under `-r` (JIT) and AOT.

## ESH-0152 — cond/case `=>` receiver form
- Before: `(cond ((assv 1 (list (cons 1 10))) => cdr) (else 0))` failed with `Undefined variable: =>` — the parser lowers `(test => receiver)` to a clause body starting with the bare identifier `=>`, which codegen evaluated as a variable.
- After: returns `10`. `codegenCond`/`codegenCase` detect the arrow form, evaluate the test/key once, and apply the receiver to that value via a new closure-call callback on `ControlFlowCodegen` (wired to the main codegen's `codegenClosureCall`). `case` supports `(datums => receiver)` too.

## ESH-0153 — vector-copy
- Before: `(vector-copy v ...)` errored with `Unknown function: vector-copy` (only the in-place `vector-copy!` existed).
- After: `(vector-copy v)`, `(vector-copy v start)`, `(vector-copy v start end)` return a fresh vector holding the `[start,end)` slice. Bounds-checked (`0<=start<=end<=len`, raises on violation), rejects tensors with a clear error, allocates a fresh arena vector and memcpys the slice. Registered in dispatch, known-builtins, and `function_return_types`.

## ESH-0155 — error-object family
- Before: `error-object?`, `error-object-message`, `error-object-irritants` were unknown functions, and `(error msg irritant...)` dropped all irritants.
- After: `codegenError` attaches arguments after the message as irritants (ABI-safe pointer-based adder). New runtime accessors `eshkol_error_object_p/_message/_irritants`. `error-object?` checks `HEAP_SUBTYPE_EXCEPTION`, so it correctly returns `#f` for a bare raised string (which `guard` still binds). The example now prints `#t`, `boom`, `(1 2)`.

## ESH-0156 — write escaping
- Before: `(write "a\nb\tc")` emitted a literal newline/tab instead of `\n`/`\t`.
- After: new `write_escaped_string` quotes strings and escapes `\"` `\\` `\a` `\b` `\t` `\n` `\r`, other control bytes as `\xNN;`, UTF-8 passed through. `display` is unchanged; chars already printed as `#\newline` etc. under `write`.

## Verification
- New `tests/r7rs/conformance_batch_test.esk`: 19/19 PASS under both `-r` and AOT.
- SICP smoke: **88/88** (unchanged).
- Differential harness (`scripts/run_differential.sh`): **246/246** axis pairs agree across 41 corpus programs, no divergences (jit / jit-nocache / aot-O0 / aot-O2).
- Existing suites clean: `control_flow/cond_test` 31/31, `control_flow/if_then_else_test` 47/47, `error_handling/{exception_test, exception_nesting_test 7/7, guard_advanced_test 8/8, guard_edge_test}`, `collections/empty_collection_test`.