### PR TITLE
fix(tco): named-let tail-call optimization in all tail positions (ESH-0211)

### DIFF
--- a/.swarm/tasks/ESH-0211.json
+++ b/.swarm/tasks/ESH-0211.json
@@ -1,0 +1,33 @@
+{
+  "id": "ESH-0211",
+  "title": "named-let (`let loop`) not tail-call-optimized in most tail positions",
+  "status": "done",
+  "priority": "high",
+  "workstream": "tco/named-let",
+  "goal": "Named-let self-calls sitting inside an `if` branch — the single most common `let loop` shape — were not tail-call-optimized: the parser lowers every `(if test then else)` to ESHKOL_CALL_OP with synthetic func name \"if\", but TailCallCodegen::allSelfCallsInTailPosition (the whole-loop gate codegenNamedLet uses to decide whether to enable TCO) treated `if`'s then/else operands as ordinary call arguments (never tail), so it misclassified any self-call in an if-branch as non-tail and disabled TCO for the entire loop (all-or-nothing gate). Found while fixing `length` (PR #153): the named-let form overflowed at 10^6 iterations where the equivalent nested-`define` self-tail-call form looped fine at the same depth, because isSelfTailRecursive's findTailCalls/countAllRecursiveCalls (the define path) already special-cased `if` as CALL_OP — only the named-let path lacked it.",
+  "file_globs": [
+    "lib/backend/tail_call_codegen.cpp",
+    "lib/backend/control_flow_codegen.cpp",
+    "lib/backend/llvm_codegen.cpp",
+    "tests/tco/named_let_tail_positions_test.esk"
+  ],
+  "acceptance": [
+    "allSelfCallsInTailPosition special-cases CALL_OP(\"if\", test, then, else) the same way collectMutualTailCallSites/findTailCalls/countAllRecursiveCalls already do: test is non-tail, both branches inherit the surrounding tail-position status.",
+    "allSelfCallsInTailPosition adds correct tail-position propagation for WHEN_OP/UNLESS_OP (body tail, test non-tail) and CASE_OP (key non-tail, each clause's implicit-begin body tail on the last expression), replacing the previous unsound catch-all `default: return true` for those op types.",
+    "codegenCase (control_flow_codegen.cpp) checks for an existing block terminator before emitting CreateBr(done_block)/adding a phi input after a clause body, mirroring the guard codegenBegin/codegenNamedLet already have — fixes an LLVM verifier crash (\"Terminator found in the middle of a basic block!\") once case clauses are correctly recognized as tail positions.",
+    "named-let self-calls loop in O(1) stack (verified to 10^7 iterations, and under a 512 KB ulimit -s) at: top level, function body, inside begin, last expr of a let, inside if branches, inside cond branches, called from another function, inside when/unless, inside case, and as an and/or operand — under both -r (JIT) and AOT.",
+    "A genuinely non-tail self-call (used as a call argument, e.g. `(+ i (loop (- i 1)))`) correctly remains un-TCO'd (documented, not a bug) and still produces the correct result at bounded depth.",
+    "No regression: SICP smoke 88/88 (JIT+AOT), tests/tco/ suite 7/7 (nested_tco_test.esk), closures suites (closure_edge_test.esk 40/40, shared_mutable_capture_test.esk 24/24), AD oracle quick gate 9/9 passed."
+  ],
+  "blocked_by": [],
+  "campaign_payoff": "Named-let (`let loop`) is the idiomatic Scheme iteration construct and R7RS requires proper tail calls; silently falling back to stack-growing recursion for the common if-branch shape made large/unbounded named-let loops crash unpredictably at depths well within what users reasonably expect O(1)-stack iteration to handle (surfaced via `length` in PR #153, but affects any named-let user code with the same shape).",
+  "repro": "tests/tco/named_let_tail_positions_test.esk",
+  "verifications": [
+    {
+      "date": "2026-07-06",
+      "branch": "fix/named-let-tco",
+      "verdict": "fixed",
+      "evidence": "tests/tco/named_let_tail_positions_test.esk 11/11 PASS under -r and AOT (10^7 iterations per case, and under ulimit -s 512 confirming O(1) stack); tests/tco/nested_tco_test.esk 7/7 PASS (no regression); scripts/run_sicp_smoke.sh 88/88 PASS (JIT+AOT); tests/closures/closure_edge_test.esk 40/40, shared_mutable_capture_test.esk 24/24; scripts/run_ad_oracle.sh --quick --no-aot 9/9 passed, 0 xknown/failed/crashed."
+    }
+  ]
+}

--- a/lib/backend/control_flow_codegen.cpp
+++ b/lib/backend/control_flow_codegen.cpp
@@ -735,14 +735,28 @@ llvm::Value* ControlFlowCodegen::codegenCase(const eshkol_operations_t* op) {
             if (body_ast && body_ast->type == ESHKOL_OP &&
                 body_ast->operation.op == ESHKOL_CALL_OP) {
                 for (uint64_t j = 0; j < body_ast->operation.call_op.num_vars; j++) {
+                    // TCO / noreturn SAFETY (ESH-0211): a body expression in
+                    // tail position (e.g. a named-let self-call) may compile
+                    // to an unconditional branch back to a loop header,
+                    // terminating this block mid-clause. Stop emitting
+                    // further sibling expressions once that happens — they
+                    // would land after the terminator and trip "Terminator
+                    // found in the middle of a basic block!" (mirrors the
+                    // same guard in codegenBegin).
+                    if (ctx_.builder().GetInsertBlock()->getTerminator()) break;
                     void* tv_ptr = codegen_typed_ast_callback_(&body_ast->operation.call_op.variables[j], callback_context_);
                     if (tv_ptr) result = typed_to_tagged_callback_(tv_ptr, callback_context_);
                 }
             }
-            if (result) {
-                phi_inputs.push_back({result, ctx_.builder().GetInsertBlock()});
+            // If the clause body already terminated the block (TCO tail
+            // jump / noreturn), there is no fallthrough edge into
+            // done_block — do not add a phi input or branch for it.
+            if (!ctx_.builder().GetInsertBlock()->getTerminator()) {
+                if (result) {
+                    phi_inputs.push_back({result, ctx_.builder().GetInsertBlock()});
+                }
+                ctx_.builder().CreateBr(done_block);
             }
-            ctx_.builder().CreateBr(done_block);
             break;
         } else {
             // Regular clause - datums_ast is a CALL_OP with variables containing datums
@@ -771,14 +785,22 @@ llvm::Value* ControlFlowCodegen::codegenCase(const eshkol_operations_t* op) {
             if (body_ast && body_ast->type == ESHKOL_OP &&
                 body_ast->operation.op == ESHKOL_CALL_OP) {
                 for (uint64_t j = 0; j < body_ast->operation.call_op.num_vars; j++) {
+                    // TCO / noreturn SAFETY (ESH-0211): see matching comment
+                    // in the else-clause branch above.
+                    if (ctx_.builder().GetInsertBlock()->getTerminator()) break;
                     void* tv_ptr = codegen_typed_ast_callback_(&body_ast->operation.call_op.variables[j], callback_context_);
                     if (tv_ptr) result = typed_to_tagged_callback_(tv_ptr, callback_context_);
                 }
             }
-            if (result) {
-                phi_inputs.push_back({result, ctx_.builder().GetInsertBlock()});
+            // See matching comment in the else-clause branch above: skip the
+            // phi input and branch entirely if the clause body already
+            // terminated the block.
+            if (!ctx_.builder().GetInsertBlock()->getTerminator()) {
+                if (result) {
+                    phi_inputs.push_back({result, ctx_.builder().GetInsertBlock()});
+                }
+                ctx_.builder().CreateBr(done_block);
             }
-            ctx_.builder().CreateBr(done_block);
 
             ctx_.builder().SetInsertPoint(next_block);
         }

--- a/lib/backend/tail_call_codegen.cpp
+++ b/lib/backend/tail_call_codegen.cpp
@@ -225,10 +225,60 @@ static bool allSelfCallsInTailPosition(const eshkol_ast_t* expr,
 
     switch (op->op) {
         case ESHKOL_CALL_OP: {
+            // PARSER QUIRK (see llvm_codegen.cpp countAllRecursiveCalls /
+            // findTailCalls / collectMutualTailCallSites for the same
+            // convention): `if` is not represented as ESHKOL_IF_OP — the
+            // parser lowers every parsed `(if test then else)` straight to
+            // ESHKOL_CALL_OP with a synthetic func name "if" and 3 operands
+            // (test, then, else). Falling through to the generic self-call
+            // handling below treated `then`/`else` as ordinary call
+            // *arguments* — which are never in tail position — so any
+            // self-call sitting in an `if` branch (the single most common
+            // named-let loop shape) was misclassified as non-tail and
+            // disabled TCO for the entire named let (ESH-0211). Special-case
+            // "if" the same way every other tail-position analysis in this
+            // codebase already does: the test is NOT in tail position, but
+            // both branches inherit the surrounding tail-position status.
+            std::string call_name = (op->call_op.func && op->call_op.func->type == ESHKOL_VAR &&
+                                      op->call_op.func->variable.id)
+                                         ? op->call_op.func->variable.id
+                                         : "";
+
+            if (call_name == "if") {
+                if (op->call_op.num_vars >= 1 &&
+                    !allSelfCallsInTailPosition(&op->call_op.variables[0], func_name, false)) {
+                    return false;
+                }
+                if (op->call_op.num_vars >= 2 &&
+                    !allSelfCallsInTailPosition(&op->call_op.variables[1], func_name, in_tail_pos)) {
+                    return false;
+                }
+                if (op->call_op.num_vars >= 3 &&
+                    !allSelfCallsInTailPosition(&op->call_op.variables[2], func_name, in_tail_pos)) {
+                    return false;
+                }
+                return true;
+            }
+
+            // Defensive: some AST construction paths represent `begin` as a
+            // CALL_OP("begin", ...) rather than ESHKOL_SEQUENCE_OP (mirrors
+            // the same guard in collectMutualTailCallSites). Only the last
+            // expression is in tail position.
+            if (call_name == "begin") {
+                if (op->call_op.num_vars > 0) {
+                    uint64_t last = op->call_op.num_vars - 1;
+                    for (uint64_t i = 0; i < last; i++) {
+                        if (!allSelfCallsInTailPosition(&op->call_op.variables[i], func_name, false)) {
+                            return false;
+                        }
+                    }
+                    return allSelfCallsInTailPosition(&op->call_op.variables[last], func_name, in_tail_pos);
+                }
+                return true;
+            }
+
             // Check if this is a self-call
-            if (op->call_op.func && op->call_op.func->type == ESHKOL_VAR &&
-                op->call_op.func->variable.id &&
-                std::string(op->call_op.func->variable.id) == func_name) {
+            if (!call_name.empty() && call_name == func_name) {
                 // Self-call found — must be in tail position
                 if (!in_tail_pos) return false;
             }
@@ -330,6 +380,60 @@ static bool allSelfCallsInTailPosition(const eshkol_ast_t* expr,
                 if (!allSelfCallsInTailPosition(
                         &op->sequence_op.expressions[i], func_name,
                         is_last ? in_tail_pos : false)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        case ESHKOL_WHEN_OP:
+        case ESHKOL_UNLESS_OP: {
+            // when/unless use call_op structure: variables[0] = test,
+            // variables[1..] = body expressions (implicit begin — only the
+            // LAST body expression is in tail position; the test and any
+            // earlier body expressions are not).
+            if (op->call_op.num_vars == 0) return true;
+            if (!allSelfCallsInTailPosition(&op->call_op.variables[0], func_name, false)) {
+                return false;
+            }
+            uint64_t last = op->call_op.num_vars - 1;
+            for (uint64_t i = 1; i < last; i++) {
+                if (!allSelfCallsInTailPosition(&op->call_op.variables[i], func_name, false)) {
+                    return false;
+                }
+            }
+            if (last >= 1 &&
+                !allSelfCallsInTailPosition(&op->call_op.variables[last], func_name, in_tail_pos)) {
+                return false;
+            }
+            return true;
+        }
+
+        case ESHKOL_CASE_OP: {
+            // CASE_OP uses call_op structure: call_op.func = key expression
+            // (NOT in tail position), call_op.variables[i] = clauses. Each
+            // clause is an ESHKOL_CONS: car = datums (literal data — quoted,
+            // never executed, safe to skip), cdr = body, itself a
+            // CALL_OP(func=nullptr, variables=body exprs) — an implicit
+            // begin per clause, so only the LAST body expression of each
+            // clause is in tail position.
+            if (!allSelfCallsInTailPosition(op->call_op.func, func_name, false)) {
+                return false;
+            }
+            for (uint64_t i = 0; i < op->call_op.num_vars; i++) {
+                const eshkol_ast_t* clause = &op->call_op.variables[i];
+                if (clause->type != ESHKOL_CONS || !clause->cons_cell.cdr) continue;
+                const eshkol_ast_t* body = clause->cons_cell.cdr;
+                if (body->type != ESHKOL_OP || body->operation.op != ESHKOL_CALL_OP) continue;
+                const eshkol_operations_t* body_op = &body->operation;
+                if (body_op->call_op.num_vars == 0) continue;
+                uint64_t last = body_op->call_op.num_vars - 1;
+                for (uint64_t j = 0; j < last; j++) {
+                    if (!allSelfCallsInTailPosition(&body_op->call_op.variables[j], func_name, false)) {
+                        return false;
+                    }
+                }
+                if (!allSelfCallsInTailPosition(&body_op->call_op.variables[last], func_name, in_tail_pos)) {
                     return false;
                 }
             }

--- a/tests/tco/named_let_tail_positions_test.esk
+++ b/tests/tco/named_let_tail_positions_test.esk
@@ -1,0 +1,204 @@
+;;; Named-let (`let loop`) TCO tail-position matrix (ESH-0211)
+;;;
+;;; Root cause: the parser lowers every `(if test then else)` to
+;;; ESHKOL_CALL_OP with a synthetic function name "if" and 3 operands
+;;; (test, then, else) — there is no ESHKOL_IF_OP node in real parsed
+;;; programs. `TailCallCodegen::allSelfCallsInTailPosition` (the gate
+;;; `codegenNamedLet` in llvm_codegen.cpp uses to decide whether a named
+;;; let's self-calls may compile to a loop) did not know this convention:
+;;; its generic ESHKOL_CALL_OP case treated `if`'s then/else operands as
+;;; ordinary call *arguments*, which are never in tail position. So any
+;;; named-let whose self-call sat in an `if` branch — the single most
+;;; common loop shape — was misclassified as non-tail, TCO was disabled
+;;; for the WHOLE loop (the gate is all-or-nothing), and the loop
+;;; recursed with a real stack frame per iteration until it overflowed
+;;; (observed at 10^6 iterations while fixing `length`, PR #153).
+;;;
+;;; Every other tail-position analysis in llvm_codegen.cpp
+;;; (isSelfTailRecursive's findTailCalls/countAllRecursiveCalls,
+;;; collectMutualTailCallSites for PR #143's musttail mutual TCO) already
+;;; special-cases call_name == "if" — only the named-let path lacked it,
+;;; which is why the nested-`define` self-tail-call form looped fine at
+;;; the same depth while named-let did not.
+;;;
+;;; Fix: lib/backend/tail_call_codegen.cpp's allSelfCallsInTailPosition
+;;; now special-cases "if" (and, defensively, "begin") the same way, and
+;;; adds real tail-position propagation for `when`/`unless`/`case`
+;;; (previously silently assumed safe via the catch-all `default: return
+;;; true`, which is unsound in general and, for `case`, papered over a
+;;; separate pre-existing codegen bug — see Test 9). `cond` already had
+;;; its own dedicated, correct case and was never affected.
+;;;
+;;; Each test below counts a named-let loop to 10,000,000 — large enough
+;;; that a real per-iteration stack frame reliably SIGSEGVs/SIGBUSes
+;;; well before completion. A test that prints its expected sum instead
+;;; of crashing demonstrates O(1)-stack tail-call elimination for that
+;;; position.
+
+(define N 10000000)
+
+;; ================================================================
+;; Test 1: named-let directly at top level (self-call in `if`-else)
+;; ================================================================
+(display "Test 1 (top-level, if-branch): ")
+(let ((r (let loop ((i 0))
+           (if (>= i N) i (loop (+ i 1))))))
+  (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; ================================================================
+;; Test 2: named-let as the entire body of a defined function
+;; ================================================================
+(define (count-to-n n)
+  (let loop ((i 0))
+    (if (>= i n) i (loop (+ i 1)))))
+
+(display "Test 2 (function body): ")
+(let ((r (count-to-n N)))
+  (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; ================================================================
+;; Test 3: named-let is the last form inside a `begin`
+;; ================================================================
+(define (count-via-begin n)
+  (begin
+    (if #f #f)  ; side-effecting no-op, forces a real begin sequence
+    (let loop ((i 0))
+      (if (>= i n) i (loop (+ i 1))))))
+
+(display "Test 3 (inside begin): ")
+(let ((r (count-via-begin N)))
+  (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; ================================================================
+;; Test 4: named-let is the last expression of an enclosing (plain) let
+;; ================================================================
+(define (count-via-let n)
+  (let ((dummy 1))
+    (let loop ((i 0))
+      (if (>= i n) i (loop (+ i 1))))))
+
+(display "Test 4 (last expr of let): ")
+(let ((r (count-via-let N)))
+  (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; ================================================================
+;; Test 5: self-call nested one level deeper inside `if` branches
+;; ================================================================
+(define (count-via-nested-if n)
+  (let loop ((i 0) (flag #t))
+    (if flag
+        (if (>= i n) i (loop (+ i 1) #t))
+        (loop i #f))))
+
+(display "Test 5 (nested if branches): ")
+(let ((r (count-via-nested-if N)))
+  (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; ================================================================
+;; Test 6: self-call inside `cond` branches (already worked pre-fix —
+;; COND_OP has always had its own dedicated, correct analysis case;
+;; kept here as a same-shape control alongside Test 5's `if`).
+;; ================================================================
+(define (count-via-cond n)
+  (let loop ((i 0))
+    (cond
+      ((>= i n) i)
+      (else (loop (+ i 1))))))
+
+(display "Test 6 (cond branches): ")
+(let ((r (count-via-cond N)))
+  (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; ================================================================
+;; Test 7: the named-let-containing function is invoked via a tail call
+;; from ANOTHER function — confirms cross-function calls into a TCO'd
+;; named let don't disturb the loop's own tail-call elimination.
+;; ================================================================
+(define (run-loop n)
+  (let loop ((i 0))
+    (if (>= i n) i (loop (+ i 1)))))
+
+(define (entry-point n)
+  (run-loop n))
+
+(display "Test 7 (called from another function): ")
+(let ((r (entry-point N)))
+  (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; ================================================================
+;; Test 8 (bonus): self-call inside `when`/`unless` bodies
+;; ================================================================
+(define (count-via-when n)
+  (let loop ((i 0))
+    (if (>= i n) i (when #t (loop (+ i 1))))))
+
+(define (count-via-unless n)
+  (let loop ((i 0))
+    (if (>= i n) i (unless #f (loop (+ i 1))))))
+
+(display "Test 8 (when/unless bodies): ")
+(let ((r1 (count-via-when N)) (r2 (count-via-unless N)))
+  (if (and (= r1 N) (= r2 N)) (display "PASS") (display "FAIL")))
+(newline)
+
+;; ================================================================
+;; Test 9 (bonus): self-call inside `case` branches. Pre-fix, this did
+;; not merely fail to loop in O(1) stack — the LLVM verifier rejected
+;; the module ("Terminator found in the middle of a basic block!")
+;; because codegenCase (control_flow_codegen.cpp) unconditionally
+;; emitted `CreateBr(done_block)` after a clause body, without checking
+;; whether the body already terminated the block via a TCO tail jump
+;; (the same class of bug `codegenBegin`/`codegenNamedLet` already guard
+;; against). Both the analysis gate and codegenCase's clause-emission
+;; are fixed.
+;; ================================================================
+(define (count-via-case n)
+  (let loop ((i 0))
+    (case (if (>= i n) 'done 'more)
+      ((done) i)
+      (else (loop (+ i 1))))))
+
+(display "Test 9 (case branches): ")
+(let ((r (count-via-case N)))
+  (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; ================================================================
+;; Test 10: self-call as an `and`/`or` operand (already correct
+;; pre-fix — AND_OP/OR_OP already had dedicated, correct analysis
+;; cases). Kept as a control alongside the fixed positions above.
+;; ================================================================
+(define (count-via-or n)
+  (let loop ((i 0))
+    (or (and (>= i n) i)
+        (loop (+ i 1)))))
+
+(display "Test 10 (and/or operand): ")
+(let ((r (count-via-or N)))
+  (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; ================================================================
+;; Test 11: documented non-TCO'able position — a self-call used as a
+;; call ARGUMENT is genuinely NOT in tail position per R7RS §3.5 (the
+;; `+` still has work to do with the result), so it correctly does NOT
+;; get the loop transform and consumes a real stack frame per call.
+;; This is by definition, not a bug — verified at a bounded depth only
+;; (10^7 here would legitimately stack-overflow, which is the point).
+;; ================================================================
+(define (sum-non-tail n)
+  (let loop ((i n))
+    (if (= i 0) 0 (+ i (loop (- i 1))))))
+
+(display "Test 11 (non-tail argument position, bounded depth, must still be correct): ")
+(let ((r (sum-non-tail 1000)))
+  ;; sum 1..1000 = 500500
+  (if (= r 500500) (display "PASS") (display "FAIL")))
+(newline)


### PR DESCRIPTION
## Summary

- Named-let (`let loop`) self-calls sitting inside an `if` branch — the single most common loop shape — were not tail-call-optimized, because the parser lowers every `(if test then else)` to `ESHKOL_CALL_OP` with a synthetic func name `"if"`, and `TailCallCodegen::allSelfCallsInTailPosition` (the whole-loop gate `codegenNamedLet` uses to decide whether TCO is safe) fell through to the generic `CALL_OP` case, which treats `if`'s then/else operands as ordinary call arguments — never tail. Any self-call in an if-branch was misclassified as non-tail, and since the gate is all-or-nothing, TCO was disabled for the *entire* loop.
- Found while fixing `length` (PR #153): the named-let form overflowed at 10^6 iterations where the equivalent nested-`define` self-tail-call form looped fine at the same depth — because `isSelfTailRecursive`'s `findTailCalls`/`countAllRecursiveCalls` (the `define` path) and `collectMutualTailCallSites` (PR #143's mutual TCO) already special-case `"if"` as `CALL_OP`; only the named-let path lacked it.
- Fixes `allSelfCallsInTailPosition` to special-case `"if"` (and, defensively, `"begin"`) the same way, and adds real tail-position propagation for `when`/`unless` and `case` — previously silently assumed safe via the catch-all `default: return true`, which is unsound in general and, for `case`, was masking a separate codegen bug (see below).
- Fixes `codegenCase` (control_flow_codegen.cpp): it unconditionally branched to its `done` block after each clause body without checking whether the body already terminated the block via a TCO tail jump. Once `case` clauses are correctly recognized as tail positions this surfaced an LLVM verifier crash ("Terminator found in the middle of a basic block!"); guarded the same way `codegenBegin`/`codegenNamedLet` already guard theirs.
- `cond`, `and`, `or` already had dedicated, correct analysis cases and were never affected.

## Root cause / fixed matrix

| Position | Before | After |
|---|---|---|
| top level | overflow | O(1) stack |
| function body | overflow | O(1) stack |
| inside `begin` | overflow | O(1) stack |
| last expr of a `let` | overflow | O(1) stack |
| inside `if` branches | overflow | O(1) stack |
| inside `cond` branches | already OK | O(1) stack |
| called from another function | overflow | O(1) stack |
| inside `when`/`unless` | OK by coincidence (unverified) | O(1) stack, verified |
| inside `case` | LLVM verifier crash | O(1) stack |
| `and`/`or` operand | already OK | O(1) stack |
| self-call as a call **argument** (genuinely non-tail) | correct, non-TCO | unchanged — correct by R7RS §3.5, documented, not a bug |

`match`, `guard`, `do`, `let-values`/`let*-values` bodies are left on the pre-existing `default: return true` path (unverified, not required by this fix's scope, no discovered failure) — flagged as a follow-up if a concrete repro turns up.

## Test plan

- [x] New `tests/tco/named_let_tail_positions_test.esk` — 11 cases (10^7 iterations each) covering every required position plus `when`/`unless`/`case`/`and`-`or` bonus coverage and a documented non-tail control case; passes under both `-r` (JIT) and AOT, and under `ulimit -s 512` (confirms O(1) stack).
- [x] `tests/tco/nested_tco_test.esk` 7/7 (no regression).
- [x] `scripts/run_sicp_smoke.sh` 88/88 (JIT+AOT).
- [x] `tests/closures/closure_edge_test.esk` 40/40, `shared_mutable_capture_test.esk` 24/24.
- [x] `scripts/run_ad_oracle.sh --quick --no-aot` 9/9 passed, 0 xknown/failed/crashed.
- [x] `tests/stress/rec_mutual.esk` (mutual TCO smoke) unaffected.