### PR TITLE
feat(build): --emit-depfile + canonical eshkol_compile_executable with real dependency tracking (ESH-0215)

### DIFF
--- a/.swarm/tasks/ESH-0215.json
+++ b/.swarm/tasks/ESH-0215.json
@@ -1,0 +1,34 @@
+{
+  "id": "ESH-0215",
+  "title": "Build-system dependency tracking: editing a .esk source does not reliably trigger recompile of the AOT object",
+  "status": "done",
+  "priority": "high",
+  "workstream": "build-integration",
+  "goal": "Noesis BUGS-2026-07-04 #3/#5 and Selene PRIORITY 2: a downstream CMake+ninja build that compiles main.esk to main.o via eshkol-run --emit-object only tracked main.esk itself as a build-graph prerequisite. Editing a (load \"...\")ed / (import ...)ed / (require ...)d dependency left the object's only tracked input unchanged, so ninja treated it as up to date and the project silently linked a stale binary — the workaround was to rm the object and re-run ninja 2-3 times. Fix by teaching eshkol-run to emit a Makefile-format depfile of the full transitive source graph, and by shipping a canonical cmake/EshkolCompile.cmake that wires that depfile into ninja's DEPFILE build-edge attribute.",
+  "file_globs": [
+    "exe/eshkol-run.cpp",
+    "cmake/EshkolCompile.cmake",
+    "CMakeLists.txt",
+    "tests/build_integration/CMakeLists.txt",
+    "tests/build_integration/main.esk",
+    "tests/build_integration/dep.esk",
+    "docs/BUILD_INTEGRATION.md"
+  ],
+  "acceptance": [
+    "eshkol-run --emit-object -o out.o --emit-depfile out.o.d main.esk writes out.o.d as a Makefile depfile listing main.esk plus every transitively (load ...)/(import ...)/(require ...)-reached source file, with Make-safe escaping for spaces/#/$.",
+    "cmake/EshkolCompile.cmake's eshkol_compile_executable/eshkol_compile_library attach DEPFILE to the compiling add_custom_command on generators that support it (Ninja; Makefiles on CMake >= 3.20), falling back to entry-file-only DEPENDS elsewhere.",
+    "tests/build_integration/ (main.esk + loaded dep.esk) built via the helper under ninja: editing dep.esk and re-running a single `ninja` invocation recompiles the object and relinks the executable, reflecting the edit; re-running ninja with no changes is a no-op.",
+    "`ninja -t deps` reports the depfile-derived prerequisites as VALID for the compiled object."
+  ],
+  "blocked_by": [],
+  "campaign_payoff": "Removes a silent-stale-binary trap for every downstream Eshkol build integration (Noesis's ~230-file faculty tree via (load ...) chains being the motivating case); the depfile walker is the build-system-facing counterpart to ESH-0183's transitiveSourceDigest fix for the -r persistent run-cache.",
+  "repro": "tests/build_integration/ — cmake -S . -B build -G Ninja && ninja -C build build_integration_demo, edit tests/build_integration/dep.esk, ninja -C build build_integration_demo (single invocation recompiles+relinks)",
+  "verifications": [
+    {
+      "date": "2026-07-06",
+      "branch": "fix/esk-build-deps",
+      "verdict": "pass",
+      "evidence": "Manual end-to-end run: built build_integration_demo (prints 42 = 41+1 from helper in dep.esk), `ninja` re-run with no changes reported 'no work to do', edited dep.esk to +1000, single `ninja` invocation recompiled main.esk.o and relinked the executable, new run printed 1041, `ninja -t deps` reported the depfile prerequisites (main.esk, dep.esk) as VALID. Also verified space/# escaping in depfile paths and clean configure under both Ninja and Unix Makefiles generators."
+    }
+  ]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3423,6 +3423,14 @@ if(ESHKOL_ENABLE_FUZZ AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/fuzz/CMakeLi
     add_subdirectory(tests/fuzz)
 endif()
 
+# ESH-0215: build-integration fixture exercising cmake/EshkolCompile.cmake's
+# --emit-depfile-backed dependency tracking (a (load …)ed dependency must
+# retrigger a recompile+relink on a single `ninja` invocation).
+if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run AND TARGET eshkol-runtime AND
+   EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/build_integration/CMakeLists.txt")
+    add_subdirectory(tests/build_integration)
+endif()
+
 # where to find our CMake modules
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(Packing)

--- a/cmake/EshkolCompile.cmake
+++ b/cmake/EshkolCompile.cmake
@@ -1,0 +1,309 @@
+# ─────────────────────────────────────────────────────────────────────
+# EshkolCompile.cmake  (ESH-0215)
+#
+# Canonical CMake integration for compiling .esk sources into a CMake
+# library/executable target with REAL incremental-build dependency
+# tracking: editing a (load …)ed / (import …)ed / (require …)d Eshkol
+# source now reliably triggers a recompile of the object that transitively
+# reaches it, in a single ninja invocation — no more "rm the object and
+# run ninja 2-3 times" (Noesis BUGS-2026-07-04 #3/#5, Selene PRIORITY 2).
+#
+# Provides:
+#   eshkol_compile_library(NAME
+#     SOURCES        <.esk files…>
+#     [INCLUDE_DIRS   <dirs…>]
+#     [LINK_LIBRARIES <targets…>]
+#     [DEFINES        <name=value…>]
+#     [DEPENDS        <extra files / targets…>])
+#
+#   eshkol_compile_executable(NAME
+#     SOURCES        <.esk files…>
+#     [INCLUDE_DIRS   <dirs…>]
+#     [LINK_LIBRARIES <targets…>]
+#     [DEFINES        <name=value…>]
+#     [DEPENDS        <extra files / targets…>])
+#
+# Each .esk source is compiled to a .o by invoking eshkol-run with
+# `--emit-object -o <obj>`, then linked into a SHARED (library) or
+# EXECUTABLE target via the C++ compiler.  The older
+# `--compile-only --output <stem>` compatibility path remains available
+# through ESHKOL_OBJECT_MODE=COMPILE_ONLY for older Eshkol binaries that
+# predate --emit-object.
+#
+# --- Dependency tracking (ESH-0215) ---------------------------------
+# eshkol-run supports `--emit-depfile <path>`, which walks the SAME
+# (load …)/(import …)/(require …) graph the compiler itself follows and
+# writes a Makefile-format depfile:
+#
+#   out.o: main.esk dep1.esk dep2.esk ...
+#
+# This module always passes `--emit-depfile <obj>.d` and attaches it to
+# the custom command via CMake's DEPFILE argument to add_custom_command,
+# so Ninja (and, on CMake >= 3.20, the Makefiles generator) re-stats every
+# transitively-loaded source on each build and reruns the compile the
+# moment any one of them changes — not just the entry file. Generators
+# without DEPFILE support (Xcode, Visual Studio) fall back to depending on
+# the entry file alone, matching the previous behavior; multi-config /
+# IDE generators are out of scope for this ticket.
+#
+# Eshkol_COMPILER must be defined (by find_package(Eshkol), a vendored
+# build directory that exports an `eshkol-run` target, or by the caller).
+# ─────────────────────────────────────────────────────────────────────
+
+if(POLICY CMP0116)
+  # Ninja DEPFILE paths are resolved relative to CMAKE_CURRENT_BINARY_DIR
+  # under the NEW behavior; this module always writes absolute depfile
+  # paths, so NEW vs. OLD is a no-op here except for silencing the CMake
+  # developer warning that fires whenever DEPFILE is used with policy
+  # CMP0116 unset (introduced 3.20; harmless when the active generator
+  # predates DEPFILE support entirely).
+  cmake_policy(SET CMP0116 NEW)
+endif()
+
+if(NOT Eshkol_COMPILER)
+  if(TARGET eshkol::eshkol-run)
+    get_target_property(Eshkol_COMPILER eshkol::eshkol-run LOCATION)
+  elseif(TARGET eshkol-run)
+    set(Eshkol_COMPILER "$<TARGET_FILE:eshkol-run>")
+  endif()
+endif()
+
+if(NOT Eshkol_COMPILER)
+  message(FATAL_ERROR
+    "EshkolCompile: Eshkol_COMPILER not set. "
+    "Either find_package(Eshkol) must succeed, or the vendored Eshkol "
+    "build must export an `eshkol-run` target, or set Eshkol_COMPILER "
+    "to the eshkol-run binary explicitly.")
+endif()
+
+if(NOT DEFINED ESHKOL_OBJECT_MODE)
+  set(ESHKOL_OBJECT_MODE "AUTO" CACHE STRING
+    "Eshkol object emission mode: AUTO, EMIT_OBJECT, or COMPILE_ONLY")
+endif()
+
+string(TOUPPER "${ESHKOL_OBJECT_MODE}" _eshkol_object_mode)
+if(NOT _eshkol_object_mode MATCHES "^(AUTO|EMIT_OBJECT|COMPILE_ONLY)$")
+  message(FATAL_ERROR
+    "ESHKOL_OBJECT_MODE must be AUTO, EMIT_OBJECT, or COMPILE_ONLY "
+    "(got: ${ESHKOL_OBJECT_MODE})")
+endif()
+
+set(ESHKOL_EFFECTIVE_OBJECT_MODE "${_eshkol_object_mode}")
+if(_eshkol_object_mode STREQUAL "AUTO")
+  if(Eshkol_COMPILER MATCHES "^\\$<")
+    # Vendored compiler targets are not executable at configure time — the
+    # pinned Eshkol contract is the direct object path, so use it by default.
+    set(ESHKOL_EFFECTIVE_OBJECT_MODE "EMIT_OBJECT")
+  else()
+    set(_eshkol_probe_dir "${CMAKE_BINARY_DIR}/CMakeFiles/eshkol-object-mode")
+    set(_eshkol_probe_src "${_eshkol_probe_dir}/probe.esk")
+    set(_eshkol_probe_obj "${_eshkol_probe_dir}/probe.o")
+    file(MAKE_DIRECTORY "${_eshkol_probe_dir}")
+    file(WRITE "${_eshkol_probe_src}" "(define (main) 0)\n")
+    execute_process(
+      COMMAND "${Eshkol_COMPILER}"
+              --emit-object -o "${_eshkol_probe_obj}"
+              --shared-lib -fPIC
+              "${_eshkol_probe_src}"
+      RESULT_VARIABLE _eshkol_probe_result
+      OUTPUT_VARIABLE _eshkol_probe_stdout
+      ERROR_VARIABLE  _eshkol_probe_stderr
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_STRIP_TRAILING_WHITESPACE
+      TIMEOUT 15)
+    if(_eshkol_probe_result EQUAL 0 AND EXISTS "${_eshkol_probe_obj}")
+      set(ESHKOL_EFFECTIVE_OBJECT_MODE "EMIT_OBJECT")
+    else()
+      set(ESHKOL_EFFECTIVE_OBJECT_MODE "COMPILE_ONLY")
+      message(WARNING
+        "Eshkol --emit-object probe failed; falling back to "
+        "ESHKOL_OBJECT_MODE=COMPILE_ONLY. Probe output: "
+        "${_eshkol_probe_stdout} ${_eshkol_probe_stderr}")
+    endif()
+  endif()
+endif()
+
+message(STATUS
+  "Eshkol object mode: ${ESHKOL_EFFECTIVE_OBJECT_MODE} "
+  "(requested ${ESHKOL_OBJECT_MODE})")
+
+# Does the active generator honor add_custom_command(... DEPFILE ...)?
+# Ninja has supported it since CMake 3.7; the Makefiles family gained
+# support in CMake 3.20. Multi-config/IDE generators (Xcode, Visual
+# Studio) do not support it at all as of CMake 4.x.
+set(_eshkol_depfile_supported FALSE)
+if(CMAKE_GENERATOR MATCHES "Ninja")
+  set(_eshkol_depfile_supported TRUE)
+elseif(CMAKE_GENERATOR MATCHES "Makefiles" AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.20")
+  set(_eshkol_depfile_supported TRUE)
+endif()
+
+# ── Internal helper — compile a single .esk → .o ──────────────────
+function(_eshkol_compile_one ESK_FILE OBJ_FILE OUT_DEPS_VAR
+                             INCLUDE_DIRS DEFINES DEPENDS_LIST SHARED)
+  get_filename_component(_abs "${ESK_FILE}" ABSOLUTE)
+  get_filename_component(_dir "${OBJ_FILE}" DIRECTORY)
+
+  set(_eshkol_path_entries
+    "${CMAKE_SOURCE_DIR}"
+    "${CMAKE_SOURCE_DIR}/src"
+    ${INCLUDE_DIRS})
+
+  if(NOT Eshkol_COMPILER MATCHES "^\\$<")
+    get_filename_component(_eshkol_compiler_dir "${Eshkol_COMPILER}" DIRECTORY)
+    get_filename_component(_eshkol_root "${_eshkol_compiler_dir}/.." ABSOLUTE)
+    list(APPEND _eshkol_path_entries
+      "${_eshkol_root}"
+      "${_eshkol_root}/lib")
+  endif()
+
+  set(_include_flag_entries)
+  list(APPEND _include_flag_entries "${CMAKE_SOURCE_DIR}" "${CMAKE_SOURCE_DIR}/src")
+  foreach(_inc IN LISTS INCLUDE_DIRS)
+    if(NOT IS_ABSOLUTE "${_inc}")
+      get_filename_component(_inc_abs "${_inc}" ABSOLUTE)
+      list(APPEND _eshkol_path_entries "${_inc_abs}")
+      list(APPEND _include_flag_entries "${_inc_abs}")
+    else()
+      list(APPEND _include_flag_entries "${_inc}")
+    endif()
+  endforeach()
+  if(DEFINED ENV{ESHKOL_PATH} AND NOT "$ENV{ESHKOL_PATH}" STREQUAL "")
+    list(APPEND _eshkol_path_entries "$ENV{ESHKOL_PATH}")
+  endif()
+
+  list(REMOVE_DUPLICATES _eshkol_path_entries)
+  if(WIN32)
+    string(JOIN "\;" _eshkol_path ${_eshkol_path_entries})
+  else()
+    string(JOIN ":" _eshkol_path ${_eshkol_path_entries})
+  endif()
+
+  set(_flags)
+  set(_byproducts)
+  if(ESHKOL_EFFECTIVE_OBJECT_MODE STREQUAL "EMIT_OBJECT")
+    set(_flags --emit-object -o "${OBJ_FILE}")
+    if(SHARED)
+      list(APPEND _flags --shared-lib -fPIC)
+    endif()
+    list(REMOVE_DUPLICATES _include_flag_entries)
+    foreach(_inc IN LISTS _include_flag_entries)
+      list(APPEND _flags -I "${_inc}")
+    endforeach()
+    foreach(_define IN LISTS DEFINES)
+      list(APPEND _flags -D "${_define}")
+    endforeach()
+    list(APPEND _byproducts "${OBJ_FILE}.bc")
+  else()
+    if(DEFINES)
+      message(FATAL_ERROR
+        "EshkolCompile: DEFINES were requested for ${ESK_FILE}, but "
+        "ESHKOL_OBJECT_MODE=COMPILE_ONLY uses the older compatibility "
+        "path that does not pass -D/--define.")
+    endif()
+    set(_obj_stem "${OBJ_FILE}")
+    if(_obj_stem MATCHES "\\.o$")
+      string(REGEX REPLACE "\\.o$" "" _obj_stem "${_obj_stem}")
+    endif()
+    set(_flags --compile-only --output "${_obj_stem}")
+    if(SHARED)
+      list(APPEND _flags --shared-lib)
+    endif()
+    list(APPEND _byproducts "${_obj_stem}.bc")
+  endif()
+
+  # ESH-0215: always ask eshkol-run for a depfile — it walks the same
+  # load/import/require graph the compile itself follows, so it is exactly
+  # the prerequisite list this build edge needs.  --emit-depfile is
+  # supported regardless of EMIT_OBJECT vs. COMPILE_ONLY (both paths route
+  # through eshkol-run's shared object-emission code).
+  set(_depfile "${OBJ_FILE}.d")
+  list(APPEND _flags --emit-depfile "${_depfile}")
+  list(APPEND _byproducts "${_depfile}")
+
+  set(_depfile_args)
+  if(_eshkol_depfile_supported)
+    set(_depfile_args DEPFILE "${_depfile}")
+  endif()
+
+  add_custom_command(
+    OUTPUT  "${OBJ_FILE}"
+    BYPRODUCTS ${_byproducts}
+    COMMAND "${CMAKE_COMMAND}" -E make_directory "${_dir}"
+    COMMAND "${CMAKE_COMMAND}" -E env "ESHKOL_PATH=${_eshkol_path}"
+            "${Eshkol_COMPILER}" ${_flags} "${_abs}"
+    DEPENDS "${_abs}" ${DEPENDS_LIST}
+    ${_depfile_args}
+    COMMENT "Eshkol → ${OBJ_FILE}"
+    VERBATIM)
+
+  set(${OUT_DEPS_VAR} "${OBJ_FILE}" PARENT_SCOPE)
+endfunction()
+
+# ── Internal — common machinery for both libraries + executables ──
+function(_eshkol_compile_target NAME KIND)
+  cmake_parse_arguments(ARG
+    ""
+    ""
+    "SOURCES;INCLUDE_DIRS;LINK_LIBRARIES;DEFINES;DEPENDS"
+    ${ARGN})
+
+  if(NOT ARG_SOURCES)
+    message(FATAL_ERROR "${NAME}: SOURCES is required")
+  endif()
+
+  set(_objects)
+  set(_obj_dir "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${NAME}.esk.dir")
+  set(_shared FALSE)
+  if(KIND STREQUAL "LIBRARY")
+    set(_shared TRUE)
+  endif()
+
+  foreach(_src IN LISTS ARG_SOURCES)
+    get_filename_component(_abs "${_src}" ABSOLUTE)
+    file(RELATIVE_PATH _rel "${CMAKE_CURRENT_SOURCE_DIR}" "${_abs}")
+    string(REPLACE ".." "_up" _rel "${_rel}")
+    string(REPLACE "/"  "__" _rel "${_rel}")
+    set(_obj "${_obj_dir}/${_rel}.o")
+
+    _eshkol_compile_one("${_abs}" "${_obj}" _obj_out
+      "${ARG_INCLUDE_DIRS}" "${ARG_DEFINES}" "${ARG_DEPENDS}" ${_shared})
+    list(APPEND _objects "${_obj_out}")
+  endforeach()
+
+  if(KIND STREQUAL "LIBRARY")
+    add_library(${NAME} SHARED ${_objects})
+  else()
+    add_executable(${NAME} ${_objects})
+  endif()
+
+  # Tell CMake the .o files come from an external producer
+  set_source_files_properties(${_objects} PROPERTIES
+    EXTERNAL_OBJECT TRUE
+    GENERATED       TRUE)
+
+  # The runtime is C++ (and Objective-C++ on Apple platforms), so link
+  # even a target whose direct inputs are externally generated .o files
+  # with the C++ driver.
+  set_target_properties(${NAME} PROPERTIES LINKER_LANGUAGE CXX)
+
+  if(ARG_LINK_LIBRARIES)
+    target_link_libraries(${NAME} PRIVATE ${ARG_LINK_LIBRARIES})
+  endif()
+
+  # Always link against the Eshkol runtime, if a target for it exists.
+  if(TARGET Eshkol::eshkol)
+    target_link_libraries(${NAME} PRIVATE Eshkol::eshkol)
+  elseif(TARGET eshkol::eshkol)
+    target_link_libraries(${NAME} PRIVATE eshkol::eshkol)
+  endif()
+endfunction()
+
+# ── Public API ─────────────────────────────────────────────────────
+function(eshkol_compile_library NAME)
+  _eshkol_compile_target(${NAME} LIBRARY ${ARGN})
+endfunction()
+
+function(eshkol_compile_executable NAME)
+  _eshkol_compile_target(${NAME} EXECUTABLE ${ARGN})
+endfunction()

--- a/docs/BUILD_INTEGRATION.md
+++ b/docs/BUILD_INTEGRATION.md
@@ -1,0 +1,143 @@
+# Build-system integration (ESH-0215)
+
+This document covers compiling `.esk` sources from a CMake project — the
+supported path for embedding Eshkol as an AOT-compiled dependency of a
+larger C/C++ project (e.g. Noesis) — and, specifically, how incremental
+rebuilds stay correct when a source changes.
+
+## The bug this fixes
+
+Prior to ESH-0215, a build-system integration that compiled `main.esk` to
+`main.o` via `eshkol-run --emit-object -o main.o main.esk` could only tell
+its build graph that `main.o` depends on `main.esk`. If `main.esk` did
+`(load "dep.esk")`, editing `dep.esk` left `main.o`'s only tracked
+prerequisite unchanged — Ninja/Make saw no reason to rebuild, and the
+downstream project silently linked a stale object. The workaround was to
+`rm` the object and re-run the build 2-3 times, hoping a stale link
+surfaced the mismatch. That is architecturally the same class of bug as
+ESH-0183 (the `-r` persistent run-cache also used to hash only the entry
+file — see `exe/eshkol-run.cpp`'s `transitiveSourceDigest`).
+
+## `--emit-depfile PATH`
+
+`eshkol-run`, when compiling to an object (`-c`/`--compile-only` or
+`--emit-object`, with `-o`/`--output`), accepts `--emit-depfile PATH`. It
+writes a Makefile-format depfile:
+
+```
+out.o: \
+  main.esk \
+  dep.esk \
+  dep/of/dep.esk
+```
+
+The prerequisite list is exactly the entry file plus every file
+transitively reachable from it via `(load "…")`, `(import "…")`, and
+`(require module)`, resolved through the same search order the compiler
+itself uses (the referring file's directory, `-I` include paths, the
+current directory, the Eshkol `lib/` directory, then `$ESHKOL_PATH`).
+Paths with spaces, `#`, or `$` are escaped per Make depfile conventions.
+The scan is deliberately generous — a dependency that turns out to be
+unreachable at compile time only costs a redundant rebuild, whereas a
+missed dependency reintroduces the stale-object bug.
+
+Ninja's `DEPFILE` build-edge attribute (or `make`'s `-include *.d`) reads
+this file and adds each listed path as an *implicit* dependency of the
+edge's `OUTPUT`, so the build system reruns the compile whenever any of
+them changes — without the project having to know the dependency graph
+in advance at configure time.
+
+## `cmake/EshkolCompile.cmake`
+
+This repository ships the canonical CMake integration at
+`cmake/EshkolCompile.cmake`. It provides:
+
+```cmake
+eshkol_compile_library(NAME
+  SOURCES        <.esk files…>
+  [INCLUDE_DIRS   <dirs…>]
+  [LINK_LIBRARIES <targets…>]
+  [DEFINES        <name=value…>]
+  [DEPENDS        <extra files / targets…>])
+
+eshkol_compile_executable(NAME
+  SOURCES        <.esk files…>
+  [INCLUDE_DIRS   <dirs…>]
+  [LINK_LIBRARIES <targets…>]
+  [DEFINES        <name=value…>]
+  [DEPENDS        <extra files / targets…>])
+```
+
+Each `.esk` source becomes one `add_custom_command` that invokes
+`eshkol-run --emit-object -o <obj> --emit-depfile <obj>.d ...`, attaches
+`DEPFILE <obj>.d` to the command (Ninja, and Make on CMake >= 3.20 — see
+below), and `DEPENDS`s on the source file itself as a floor guarantee even
+where DEPFILE isn't supported. The resulting `.o` files are wired into a
+normal `add_library(... SHARED ...)` / `add_executable(...)` target with
+`LINKER_LANGUAGE CXX`, so the rest of a downstream project's CMake (linking
+against the Eshkol runtime, packaging, install rules) is unaffected.
+
+`Eshkol_COMPILER` must resolve to an `eshkol-run` binary — either set
+explicitly, discovered via `find_package(Eshkol)`, or picked up
+automatically from an in-tree `eshkol-run`/`eshkol::eshkol-run` CMake
+target (as happens when this module is used from within the Eshkol build
+itself — see `tests/build_integration/`).
+
+### Generator support for DEPFILE
+
+`add_custom_command(... DEPFILE ...)` is a Ninja-only feature prior to
+CMake 3.20; CMake 3.20+ also supports it for the Makefiles generator
+family. Multi-config/IDE generators (Xcode, Visual Studio) do not support
+it. `EshkolCompile.cmake` detects this at configure time
+(`CMAKE_GENERATOR` + `CMAKE_VERSION`) and only passes `DEPFILE` when the
+active generator honors it; on unsupported generators the custom command
+still `DEPENDS`s on the entry `.esk` file (the pre-ESH-0215 behavior), so
+nothing regresses — dependency tracking on `(load …)`ed files simply isn't
+available there.
+
+### `ESHKOL_OBJECT_MODE`
+
+- `AUTO` (default): probes `eshkol-run --emit-object` at configure time
+  and falls back to the legacy `--compile-only --output <stem>` path if
+  the probe fails (e.g. a pre-`--emit-object` binary). When
+  `Eshkol_COMPILER` is a generator expression (an in-tree, not-yet-built
+  target), the probe can't run at configure time, so `AUTO` assumes
+  `EMIT_OBJECT`.
+- `EMIT_OBJECT` / `COMPILE_ONLY`: force one or the other.
+
+`--emit-depfile` is emitted in both modes — both route through the same
+object-emission code in `eshkol-run.cpp`.
+
+## Verification fixture: `tests/build_integration/`
+
+`tests/build_integration/` is a minimal end-to-end fixture built when
+`ESHKOL_BUILD_TESTS` is on and the in-tree `eshkol-run`/`eshkol-runtime`
+targets exist: `main.esk` `(load "dep.esk")`s a one-line helper and calls
+it. It is wired into the top-level `CMakeLists.txt` via `add_subdirectory`
+and links `eshkol-runtime` directly (the same target real generated
+programs link against), so it exercises the production dependency graph
+rather than a hand-rolled stand-in.
+
+To reproduce the fix manually:
+
+```sh
+cmake -S . -B build -G Ninja
+ninja -C build build_integration_demo
+./build/tests/build_integration/build_integration_demo   # -> 42
+
+# Edit the LOADED dependency, not the entry file:
+$EDITOR tests/build_integration/dep.esk
+
+ninja -C build build_integration_demo   # single invocation: recompiles + relinks
+./build/tests/build_integration/build_integration_demo   # -> reflects the edit
+
+ninja -C build build_integration_demo   # touch nothing again: no-op
+```
+
+The depfile itself can be inspected directly, or through Ninja's own deps
+log:
+
+```sh
+cat build/tests/build_integration/CMakeFiles/build_integration_demo.esk.dir/main.esk.o.d
+ninja -C build -t deps tests/build_integration/CMakeFiles/build_integration_demo.esk.dir/main.esk.o
+```

--- a/exe/eshkol-run.cpp
+++ b/exe/eshkol-run.cpp
@@ -950,6 +950,7 @@ static struct option long_options[] = {
     {"output", required_argument, nullptr, 'o'},
     {"compile-only", no_argument, nullptr, 'c'},
     {"emit-object", no_argument, nullptr, 259},
+    {"emit-depfile", required_argument, nullptr, 265},
     {"shared-lib", no_argument, nullptr, 's'},
     {"wasm", no_argument, nullptr, 'w'},
     {"lib", required_argument, nullptr, 'l'},
@@ -2085,6 +2086,10 @@ static void print_help(int x = 0)
         "\t--output:[-o] = Outputs into a binary file.\n"
         "\t--compile-only:[-c] = Compiles into an intermediate object file.\n"
         "\t--emit-object = Alias for --compile-only.\n"
+        "\t--emit-depfile PATH = With -o/--emit-object, write a Makefile-format\n"
+        "\t    depfile listing the entry source plus every file transitively\n"
+        "\t    reached via (load …)/(import …)/(require …), so a build system\n"
+        "\t    (e.g. ninja DEPFILE) recompiles the object when any of them change.\n"
         "\t--shared-lib:[-s] = Compiles it into a shared library.\n"
         "\t-fPIC = Accepted for build-system compatibility.\n"
         "\t-I DIR = Add a source/module search path.\n"
@@ -2697,6 +2702,141 @@ static std::string transitiveSourceDigest(
         hashUpdate(hash, "dep-bytes", entry.second);
     }
     return sha256Hex(hash);
+}
+
+// ESH-0215: collect the canonical path of the entry file plus every source
+// file reachable from it via (load "…") / (import "…") / (require module),
+// for --emit-depfile. This walks the SAME graph — through the same
+// resolve_module_path search order (referring dir, -I include paths, cwd,
+// lib dir, $ESHKOL_PATH) — as transitiveSourceDigest() (fix/aot-stale-output,
+// ESH-0183) uses to invalidate the `-r` run-cache; the two exist for
+// different consumers (a build-system depfile vs. a persistent-cache key) so
+// only the path is retained here, not the file bytes. The scan is
+// deliberately generous: over-collection only adds a harmless extra
+// prerequisite, whereas under-collection would resurrect the stale-object
+// bug (Noesis BUGS-2026-07-04 #3/#5).
+static void collectTransitiveSourcePaths(
+    const std::filesystem::path& path,
+    const std::vector<char*>& include_paths,
+    std::vector<std::string>& order,
+    std::set<std::string>& seen)
+{
+    std::error_code ec;
+    std::string canon = std::filesystem::weakly_canonical(path, ec).string();
+    if (canon.empty()) canon = path.string();
+    if (!seen.insert(canon).second) {
+        return;  // already visited
+    }
+    order.push_back(canon);
+
+    std::string text = readFileBytes(path);
+    if (text.empty()) return;
+
+    if (g_lib_dir.empty()) g_lib_dir = find_lib_dir();
+    std::string base_dir = path.parent_path().string();
+    if (base_dir.empty()) base_dir = ".";
+
+    auto resolve_ref = [&](const std::string& ref) -> std::string {
+        std::string mp = resolve_module_path(ref, base_dir, g_lib_dir);
+        if (!mp.empty()) return mp;
+        for (char* inc : include_paths) {
+            if (!inc || !*inc) continue;
+            mp = resolve_module_path(ref, inc, g_lib_dir);
+            if (!mp.empty()) return mp;
+        }
+        return "";
+    };
+
+    static const char* kForms[] = {"(load", "(import", "(require"};
+    for (const char* form : kForms) {
+        const size_t flen = std::strlen(form);
+        size_t pos = 0;
+        while ((pos = text.find(form, pos)) != std::string::npos) {
+            pos += flen;
+            const size_t close = text.find(')', pos);
+            if (close == std::string::npos) break;
+            std::string clause = text.substr(pos, close - pos);
+            pos = close;
+            // Tokenise; strip stray quote/paren/quasiquote chars (mirrors the
+            // require scan used by file_requires_agent_ffi / transitiveSourceDigest).
+            std::stringstream ts(clause);
+            std::string tok;
+            while (ts >> tok) {
+                while (!tok.empty() && (tok.front() == '(' || tok.front() == '\'' ||
+                                        tok.front() == '"'))
+                    tok.erase(tok.begin());
+                while (!tok.empty() && (tok.back() == ')' || tok.back() == '"'))
+                    tok.pop_back();
+                if (tok.empty()) continue;
+                std::string mp = resolve_ref(tok);
+                if (!mp.empty())
+                    collectTransitiveSourcePaths(mp, include_paths, order, seen);
+            }
+        }
+    }
+}
+
+// Escape a path for a Makefile-format depfile: Make treats a bare space as a
+// prerequisite separator and '#' as a comment start, so both must be
+// backslash-escaped; '$' begins a variable reference, so it is doubled.
+static std::string escapeDepfilePath(const std::string& path) {
+    std::string out;
+    out.reserve(path.size());
+    for (char c : path) {
+        switch (c) {
+        case ' ':
+        case '#':
+            out.push_back('\\');
+            out.push_back(c);
+            break;
+        case '$':
+            out.push_back('$');
+            out.push_back('$');
+            break;
+        default:
+            out.push_back(c);
+        }
+    }
+    return out;
+}
+
+// ESH-0215: write a Makefile-format depfile (`target: prereq1 prereq2 …`,
+// consumable via ninja's `DEPFILE` build-edge attribute or `make`'s
+// `-include foo.d`) so a build system recompiles the emitted object when the
+// entry source OR any file it transitively (load …)s / (import …)s /
+// (require …)s changes. Without this, editing a (load …)ed dependency left
+// the object's only tracked prerequisite (the entry file) unchanged, so
+// ninja treated the object as up to date — the exact staleness Noesis
+// BUGS-2026-07-04 items #3/#5 reported ("must rm the object and run ninja
+// 2-3x, or silently ship a stale binary").
+static bool writeDepfile(const std::string& depfile_path,
+                         const std::string& target_path,
+                         const std::string& entry_source,
+                         const std::vector<char*>& include_paths) {
+    std::vector<std::string> order;
+    std::set<std::string> seen;
+    collectTransitiveSourcePaths(entry_source, include_paths, order, seen);
+
+    std::ofstream out(depfile_path, std::ios::binary | std::ios::trunc);
+    if (!out.is_open()) {
+        eshkol_error("Failed to write depfile: %s", depfile_path.c_str());
+        return false;
+    }
+
+    // The left-hand target spelling is conventional (ninja documents that it
+    // ignores the depfile's own target field and attaches the listed
+    // prerequisites to the OUTPUT of the owning build edge instead), so the
+    // caller-provided path is used verbatim rather than canonicalized.
+    out << escapeDepfilePath(target_path) << ":";
+    for (const auto& dep : order) {
+        out << " \\\n  " << escapeDepfilePath(dep);
+    }
+    out << "\n";
+    if (!out.good()) {
+        eshkol_error("Failed to write depfile: %s", depfile_path.c_str());
+        return false;
+    }
+    return true;
 }
 
 // Recursively discover all modules that a library requires.
@@ -3584,6 +3724,7 @@ int main(int argc, char **argv)
     bool embedded_vm_profile = false;
     std::vector<std::string> required_vm_entries;
     std::vector<std::string> required_zero_arg_vm_entries;
+    const char* depfile_path = nullptr;  // --emit-depfile PATH (ESH-0215)
 
     if (argc == 1) print_help(1);
 
@@ -3732,6 +3873,13 @@ int main(int argc, char **argv)
                 return 1;
             }
             required_zero_arg_vm_entries.emplace_back(optarg);
+            break;
+        case 265:
+            if (!optarg || !*optarg) {
+                fprintf(stderr, "--emit-depfile requires a non-empty path\n");
+                return 1;
+            }
+            depfile_path = optarg;
             break;
         default:
             print_help(1);
@@ -4503,6 +4651,23 @@ int main(int argc, char **argv)
                 bc_filename = module_name + ".bc";
             }
             eshkol_compile_llvm_ir_to_bitcode(llvm_module, bc_filename.c_str());
+
+            // ESH-0215: --emit-depfile PATH — write a Makefile-format depfile
+            // so a build system (ninja DEPFILE, make -include) recompiles this
+            // object when the entry file or any transitively load/import/
+            // require-reached dependency changes (Noesis BUGS-2026-07-04 #3/#5).
+            if (depfile_path) {
+                if (source_files.empty()) {
+                    eshkol_error("--emit-depfile requires a source file");
+                    eshkol_dispose_llvm_module(llvm_module);
+                    return 1;
+                }
+                if (!writeDepfile(depfile_path, obj_filename, source_files[0], include_paths)) {
+                    eshkol_dispose_llvm_module(llvm_module);
+                    return 1;
+                }
+                eshkol_info("Wrote depfile: %s", depfile_path);
+            }
         } else if (wasm_output) {
             // Compile to WebAssembly
             std::string wasm_filename;

--- a/tests/build_integration/CMakeLists.txt
+++ b/tests/build_integration/CMakeLists.txt
@@ -1,0 +1,22 @@
+# ESH-0215: end-to-end verification of cmake/EshkolCompile.cmake's real
+# dependency tracking.  build_integration_demo compiles main.esk, which
+# (load)s dep.esk.  The bug this fixture exercises: previously the custom
+# command that compiles main.esk -> main.esk.o only DEPENDS'd on main.esk
+# itself, so editing dep.esk left the object (and the linked executable)
+# stale until a downstream user ran `rm` + `ninja` two or three times
+# (Noesis BUGS-2026-07-04 #3/#5). eshkol-run's new --emit-depfile now lets
+# the custom command's DEPFILE track dep.esk too, so a single `ninja`
+# invocation after editing dep.esk recompiles and relinks.
+#
+# This directory is only added when the in-tree eshkol-run/eshkol-runtime
+# targets exist (see the ESHKOL_BUILD_TESTS guard in the top-level
+# CMakeLists.txt) — it links directly against the vendored eshkol-runtime
+# target so it inherits the exact runtime/BLAS/GPU link flags the real
+# build already computed, rather than re-deriving them.
+
+include(${CMAKE_SOURCE_DIR}/cmake/EshkolCompile.cmake)
+
+eshkol_compile_executable(build_integration_demo
+  SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/main.esk
+  LINK_LIBRARIES eshkol-runtime
+)

--- a/tests/build_integration/dep.esk
+++ b/tests/build_integration/dep.esk
@@ -1,0 +1,5 @@
+; ESH-0215 build-integration fixture: a (load)ed dependency of main.esk.
+; The whole point of this fixture is that editing THIS file — not
+; main.esk — must still trigger a rebuild of the linked object/executable
+; on the next `ninja` invocation.
+(define (helper x) (+ x 1))

--- a/tests/build_integration/main.esk
+++ b/tests/build_integration/main.esk
@@ -1,0 +1,7 @@
+; ESH-0215 build-integration fixture: entry point, (load)s dep.esk.
+(load "dep.esk")
+
+(define (main)
+  (display (helper 41))
+  (newline)
+  0)


### PR DESCRIPTION
## Summary
- Noesis BUGS-2026-07-04 #3/#5, Selene PRIORITY 2: a downstream CMake+ninja build compiling `main.esk` to `main.o` via `eshkol-run --emit-object` only tracked `main.esk` itself as a build-graph prerequisite. Editing a `(load "...")`ed / `(import ...)`ed / `(require ...)`d dependency left the object's only tracked input unchanged, so ninja treated it as up to date and silently linked a stale binary — the workaround was `rm` + re-run ninja 2-3 times.
- `exe/eshkol-run.cpp` gains `--emit-depfile PATH`: when compiling to an object (`-c`/`--compile-only` or `--emit-object`, with `-o`), it walks the entry file's `(load ...)`/`(import ...)`/`(require ...)` graph — the same `resolve_module_path` search order and traversal shape as ESH-0183's `transitiveSourceDigest` (used for the `-r` persistent run-cache, on the still-unmerged `fix/aot-stale-output` branch) — and writes a Makefile-format depfile listing every reachable source, with Make-safe escaping for spaces/`#`/`$`.
- `cmake/EshkolCompile.cmake` is now the canonical `eshkol_compile_library`/`eshkol_compile_executable` implementation (previously only vendored downstream in Noesis): each `.esk` source's custom command passes `--emit-depfile` and attaches `DEPFILE` on generators that support it (Ninja; Makefiles on CMake >= 3.20), falling back to entry-file-only `DEPENDS` elsewhere.
- `tests/build_integration/` (`main.esk` `(load)`ing `dep.esk`, wired into the top-level build via `add_subdirectory`) verifies the fix end-to-end.
- Documented in `docs/BUILD_INTEGRATION.md`.

## Verification transcript

```
$ ninja -C build build_integration_demo
[7/9] Eshkol → .../build_integration_demo.esk.dir/main.esk.o
[8/9] Linking CXX executable tests/build_integration/build_integration_demo
$ ./build/tests/build_integration/build_integration_demo
42

$ ninja -C build build_integration_demo      # nothing touched
ninja: no work to do.

$ $EDITOR tests/build_integration/dep.esk    # (+ x 1) -> (+ x 1000)
$ ninja -C build build_integration_demo      # ONE invocation
[1/3] Eshkol → .../main.esk.o
[2/3] Linking CXX executable tests/build_integration/build_integration_demo
$ ./build/tests/build_integration/build_integration_demo
1041

$ ninja -C build -t deps tests/build_integration/CMakeFiles/build_integration_demo.esk.dir/main.esk.o
...main.esk.o: #deps 2, deps mtime ... (VALID)
    .../dep.esk
    .../main.esk
```

Depfile sample (`--emit-depfile out.o.d`):
```
out.o: \
  /abs/path/main.esk \
  /abs/path/dep.esk
```

## Test plan
- [x] Full `ninja` build of the repo succeeds with the new code (`exe/eshkol-run.cpp`, `cmake/EshkolCompile.cmake`, `tests/build_integration/`).
- [x] `--emit-object -o out.o --emit-depfile out.o.d main.esk` produces a correct 2-level transitive depfile; verified space/`#` path escaping.
- [x] `tests/build_integration/build_integration_demo`: edit `dep.esk` → single `ninja` invocation recompiles + relinks + reflects the edit; unchanged re-run is a no-op.
- [x] `ninja -t deps` reports the depfile prerequisites as `VALID`.
- [x] Configured cleanly under both `Ninja` and `Unix Makefiles` generators (no `CMP0116` dev warning).
- [x] `ctest -R "eshkol_run_profile_cli_test|freestanding_object_smoke_test"` passes.