### PR TITLE
feat(ad): P5 reverse-over-Taylor — high-order gradients through the tape (ESH-0190)

### DIFF
--- a/.swarm/tasks/ESH-0190.json
+++ b/.swarm/tasks/ESH-0190.json
@@ -1,0 +1,54 @@
+{
+  "id": "ESH-0190",
+  "title": "AD Taylor-tower P5: reverse-over-Taylor -- high-order gradients through the reverse tape via a seed-tangent dual tower",
+  "status": "done",
+  "priority": "high",
+  "workstream": "ad-taylor-tower/P5-reverse-over-taylor",
+  "goal": "Make `gradient` correct when the differentiated function computes a high-order forward derivative internally via the Taylor tower, i.e. grad_v of g(v)=derivative-n(lambda(t) f(t,v), t0, k) for k>=2 (docs/design/AD_TAYLOR_TOWER.md sec 8). Before P5 this returned 0: the reverse-tape dispatch swallowed the tower (converting the tower operand of `t` to a scalar AD node) and the tower extraction handed back a bare double disconnected from the tape. Fix at the root by carrying a first-order seed tangent alongside the tower value series (the tower analogue of the 8-jet ep-derivative half) and recording it back on the reverse tape through the SAME eshkol_ad_mixed_record hook the order-<=2 jet path uses. Order-<=2 hot path and the P1/P2 forward tower stay byte-for-byte unchanged.",
+  "file_globs": [
+    "inc/eshkol/eshkol.h",
+    "lib/core/runtime_taylor.c",
+    "lib/core/runtime_autodiff.cpp",
+    "lib/backend/autodiff_codegen.cpp",
+    "lib/backend/llvm_codegen.cpp",
+    "inc/eshkol/backend/autodiff_codegen.h",
+    "inc/eshkol/backend/codegen_context.h",
+    "tests/ad/reverse_over_taylor_test.esk",
+    "docs/design/AD_TAYLOR_TOWER.md",
+    "CMakeLists.txt"
+  ],
+  "acceptance": [
+    "gradient over derivative-n matches ANALYTIC references for k=2..4 scalar (d^k/dt^k[sin(v t)]|1, exp variant) to abs err < 1e-5, cross-checked against central finite differences",
+    "vector params work in multiple shapes: 2-vector (sin(v0 t)+v1 t^3, k=2) and 3-vector (v0 t^2 + v1 sin t + v2 exp t, k=3) match analytic ground truth and FD; both #(...) tensor points (reverse-tape path) and (vector ...) points",
+    "epoch safety: sibling derivative-n in one gradient, derivative-n nested inside derivative-n, and an inner tower over an independent variable that must drop out -- each level's gradient depends only on its own perturbation",
+    "order <= 2 jet hot path and the P1/P2 forward tower untouched; regressions hold: reverse_nested_forward_test 11/11, taylor_tower_test 52/52, taylor_tower_mono_test 441/441, guw_multivariate_test 35/35, run_ad_depth.sh gate PASS (0 regressions), run_ad_oracle.sh 56/56, run_sicp_smoke.sh 88/88",
+    "new test tests/ad/reverse_over_taylor_test.esk PASS under BOTH -r and AOT (byte-identical) and wired into CTest (reverse_over_taylor_runtime_smoke)"
+  ],
+  "blocked_by": ["ESH-0189"],
+  "campaign_payoff": "High-order gradients of tower-computed quantities (grad of a Laplacian, grad of an arbitrary-order derivative) become available: the reverse tape can now differentiate through the arbitrary-order Taylor tower, not just the order-<=2 jet. Delivers the 'tower-valued reverse-tape primals/adjoints' that P3 (ESH-0188) named as the prerequisite for retiring JET8, and is the foundation for P10 checkpointed high-order reverse.",
+  "delivered": {
+    "mechanism": "A tower may carry, alongside its value series c[0..K], a parallel first-order SEED-TANGENT series c'[k]=d(c[k])/d(reverse-seed) -- one sensitivity of every coefficient to the outer gradient's active seed. Marked by a reserved flag bit ESH_TAYLOR_TANGENT_FLAG (flags byte 8, the RESERVED0 region of sec 4); a dual tower's coefficient storage doubles to 2*(K+1) doubles (values then tangents). The seed dimension is orthogonal to the value EPOCH_TAG (there is exactly one active reverse seed per gradient pass), so it always combines while the value series keeps its sec 5a epoch discipline unchanged.",
+    "root_cause_fixed": "In tower mode the tower seed does not bump __ad_pert_level, so maybeJetLiftTapeOperand did not freeze a reverse-tape AD node before withADBinaryDispatch, which then converted the tower operand of `t` to a scalar constant AD node -- the reverse tape swallowed the tower, collapsing the whole derivative-n onto the tape with `t` frozen, and popAndExtractForward returned a bare double disconnected from the tape (gradient=0, the ESH-0117 failure class).",
+    "runtime": "lib/core/runtime_taylor.c: dual (value+tangent) recurrences (tr_conv, trd_mul, trd_div, ddual_mul/div/exp/log/sincos/pow_const) mirroring the tr_* value recurrences with the same fma/ascending-j reduction order (sec 6a); normalise_operand_dual materialising value (epoch-gated) + tangent (epoch-independent) from a tower-with-tangent, a forward jet (primal + e1), a reverse-tape AD node (node->value + eshkol_ad_seed_flag), or a scalar; dual branches in eshkol_taylor_binary_tagged / eshkol_taylor_unary_tagged that fire only when an operand carries a tangent (so the plain forward tower is byte-for-byte unchanged); eshkol_taylor_lift_ad_node (freeze an AD node to a dual-tower constant), eshkol_taylor_has_tangent, eshkol_taylor_extract_tangent (n! * tangent[n]). lib/core/runtime_autodiff.cpp: __ad_tower_active / __ad_tower_order context globals.",
+    "codegen": "lib/backend/autodiff_codegen.cpp: towerCtxPush/Pop (maintain the tower-active depth + order globals, pushed in seedForwardAndPush's tower branch, popped in popAndExtractForward); towerLiftOperand (runtime-gated on __ad_tower_active>0, freezes a reverse-tape AD node to a dual-tower via eshkol_taylor_lift_ad_node so the reverse tape can no longer swallow the tower), invoked as a preprocessing step from maybeJetLiftTapeOperand so it applies at every arithmetic site including lambda bodies compiled standalone; tangent-aware DERIV_N extraction that reads value=k!*c[K] and dseed=k!*c'[K] and threads dseed back to the outer pass -- via the SAME eshkol_ad_mixed_record hook when a reverse tape is live, or as a forward jet {value, dseed*e1} otherwise. lib/backend/llvm_codegen.cpp + inc/eshkol/backend/codegen_context.h: the two context globals (REPL-external / compiler-internal, mirroring __ad_pert_level). inc/eshkol/eshkol.h: ESH_TAYLOR_TANGENT_FLAG + ESH_TAYLOR_HAS_TANGENT.",
+    "hook_reuse": "dseed is a single scalar per derivative-n call (extraction is scalar-per-call), so eshkol_ad_mixed_record is reused UNCHANGED -- the design-doc's 'generalize dseed per-order' was unnecessary. The recorded node is an exact local linearization result = value + dseed*(seed-seed0) built from CONSTANT/MUL/ADD nodes, so backprop needs no new rule.",
+    "tests": "tests/ad/reverse_over_taylor_test.esk: 18 analytic + FD + epoch-safety + JET8-parity checks. Prints 'PASS: reverse-over-Taylor 18/18 ...' on success, FAIL: on failure. Registered in CMakeLists.txt as reverse_over_taylor_runtime_smoke (JIT -r, PASS/FAIL regex).",
+    "jet8_verdict": "NO -- JET8 retirement re-evaluated and deferred (design sec 12a). The capability blocker P3 (ESH-0188) cited ('tower-valued reverse-tape primals/adjoints') is now delivered and byte-identical to JET8 (measured bit-equal for polynomial, transcendental and compound-transcendental nested cases; depth oracle gofd.poly.v{2,3}.*.vecref jump baseline 1 -> 8). Retirement stays blocked ONLY by the order-<=2 hot-path invariant (JET8 is the order-<=2 reverse-over-forward adapter over the stack JET4 fast path; the test's single-forward depth-1 cases cannot route via detectPureDerivChain without sending every first-order derivative-in-gradient through the heap tower) and P5 scope isolation. Retirement is now unblocked for a focused order-thresholded dispatch-refactor phase. The P5 test carries a parity-witness check asserting tower==JET8 bit-equal."
+  },
+  "remainder": [
+    "JET8 retained (design sec 12a): retiring it needs an order-thresholded dispatch refactor (JET4 for order<=2, tower for order>=3) that preserves the order-<=2 hot path -- a dedicated follow-up phase, not P5's isolated scope.",
+    "The seed tangent is FIRST order (gradient is first-order reverse). Second-order-reverse / hessian-through-tower (grad^2 of a tower quantity) would need a second tangent dimension or the P10 checkpointed high-order reverse tape -- out of P5 scope.",
+    "Like the existing jet mixed-mode, the reverse seed is the pass's single published active variable; a captured value that is an INTERMEDIATE tape node depending on the seed (not the seed variable itself) is frozen to its value (seed_flag=0), matching the existing order-<=2 mixed-mode semantics -- gradient's per-component convention (vector-ref v i is the variable node) makes this correct for the standard gradient use.",
+    "Coefficients are on the F64 path; the exact-rational tower (P6/ESH-0191) tangent variant is not part of this phase.",
+    "Reverse-over-`taylor` (the coefficient-list API inside a gradient) sets the tower context and lifts correctly, but returns a list (mixed_record does not apply); only derivative-n's scalar return is wired to the tape/jet. Not a P5 gate."
+  ],
+  "verifications": [
+    {
+      "sweep": "P5",
+      "date": "2026-07-06",
+      "branch": "feat/ad-taylor-p5-reverse-over-taylor",
+      "verdict": "closed",
+      "evidence": "tests/ad/reverse_over_taylor_test.esk 18/18 PASS under BOTH -r (JIT) and AOT (byte-identical output, exit 0). Reverse-over-Taylor scalar: grad d2/dt2[sin(v t)]|1 @0.5 = -0.698821 (analytic -(2v sin v + v^2 cos v)); k=3 = -0.598259; k=4 = 0.294562; exp k=2 = 2.060901; all vs analytic AND central FD. Vector: 2-vec #(0.5 2.0) grad=(-0.698821, 6) vs analytic+FD; 3-vec #(1 1 1) grad=(0, -cos1=-0.540302, exp1=2.718282); tensor #(0.5) and (vector 0.5) both match scalar. Epoch safety: sibling derivative-n sum=0.743810, nested derivative-n=-0.698821, independent inner tower drops out=-0.698821. JET8 parity witness: tower==JET8 bit-equal for poly case (=#t). Regressions all green: reverse_nested_forward_test 11/11 (-r+AOT), taylor_tower_test 52/52, taylor_tower_mono_test 441/441 (mono==runtime bit-exact), guw_multivariate_test 35/35, full tests/ad/ 14/14; scripts/run_ad_depth.sh gate PASS regressions=0 improvements=7 (gofd.poly.v{2,3}.*.vecref 1->8, gradn.{expc,mono}.s.*.capnone 2->3); scripts/run_ad_oracle.sh total=56 passed=56 failed=0 crashed=0 hung=0; scripts/run_sicp_smoke.sh 88/88. Order-<=2 jet hot path and P1/P2 forward tower unchanged by construction (dual path fires only under ESH_TAYLOR_TANGENT_FLAG). New CTest reverse_over_taylor_runtime_smoke registered."
+    }
+  ]
+}

--- a/AD_DEPTH_REPORT.md
+++ b/AD_DEPTH_REPORT.md
@@ -15,7 +15,7 @@ Every AD value is swept at nesting depth **d = 1..8** and checked against a **cl
 | deriv | glob | 8 | ESH-0118 |
 | deriv | localparam | 8 | ESH-0122 |
 | deriv | vecref | 8 | ESH-0122 |
-| gofd | vecref | 2 | ESH-0117 |
+| gofd | vecref | 8 | ESH-0117 |
 | gradn | capnone | 3 | ESH-0118 |
 | gradn | vecref | 1 | ESH-0122 |
 | hessod | vecref | 0 | ESH-0121 |
@@ -23,14 +23,14 @@ Every AD value is swept at nesting depth **d = 1..8** and checked against a **cl
 
 ## ✅ Improvements over baseline (fix landed)
 
-- `gofd.mono.v2.inline.vecref`: max-depth **2** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
-- `gofd.mono.v2.named.vecref`: max-depth **2** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
-- `gofd.mono.v3.inline.vecref`: max-depth **2** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
-- `gofd.mono.v3.named.vecref`: max-depth **2** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
-- `gofd.poly.v2.inline.vecref`: max-depth **2** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
-- `gofd.poly.v2.named.vecref`: max-depth **2** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
-- `gofd.poly.v3.inline.vecref`: max-depth **2** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
-- `gofd.poly.v3.named.vecref`: max-depth **2** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
+- `gofd.mono.v2.inline.vecref`: max-depth **8** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
+- `gofd.mono.v2.named.vecref`: max-depth **8** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
+- `gofd.mono.v3.inline.vecref`: max-depth **8** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
+- `gofd.mono.v3.named.vecref`: max-depth **8** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
+- `gofd.poly.v2.inline.vecref`: max-depth **8** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
+- `gofd.poly.v2.named.vecref`: max-depth **8** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
+- `gofd.poly.v3.inline.vecref`: max-depth **8** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
+- `gofd.poly.v3.named.vecref`: max-depth **8** > baseline **1** (update BASELINE in ad_depth_report.py once confirmed)
 - `gradn.expc.s.inline.capnone`: max-depth **3** > baseline **2** (update BASELINE in ad_depth_report.py once confirmed)
 - `gradn.expc.s.named.capnone`: max-depth **3** > baseline **2** (update BASELINE in ad_depth_report.py once confirmed)
 - `gradn.mono.s.inline.capnone`: max-depth **3** > baseline **2** (update BASELINE in ad_depth_report.py once confirmed)
@@ -84,22 +84,22 @@ Every AD value is swept at nesting depth **d = 1..8** and checked against a **cl
 
 | cell | lane | d1 | d2 | d3 | d4 | d5 | d6 | d7 | d8 | MCD |
 |---|---|---|---|---|---|---|---|---|---|---|
-| `gofd.mono.v2.inline.vecref` | jit | P | P | F | F | F | F | F | F | **2** |
-| `gofd.mono.v2.inline.vecref` | aot | P | P | F | F | F | F | F | F | **2** |
-| `gofd.mono.v2.named.vecref` | jit | P | P | F | F | F | F | F | F | **2** |
-| `gofd.mono.v2.named.vecref` | aot | P | P | F | F | F | F | F | F | **2** |
-| `gofd.mono.v3.inline.vecref` | jit | P | P | F | F | F | F | F | F | **2** |
-| `gofd.mono.v3.inline.vecref` | aot | P | P | F | F | F | F | F | F | **2** |
-| `gofd.mono.v3.named.vecref` | jit | P | P | F | F | F | F | F | F | **2** |
-| `gofd.mono.v3.named.vecref` | aot | P | P | F | F | F | F | F | F | **2** |
-| `gofd.poly.v2.inline.vecref` | jit | P | P | F | F | F | F | F | F | **2** |
-| `gofd.poly.v2.inline.vecref` | aot | P | P | F | F | F | F | F | F | **2** |
-| `gofd.poly.v2.named.vecref` | jit | P | P | F | F | F | F | F | F | **2** |
-| `gofd.poly.v2.named.vecref` | aot | P | P | F | F | F | F | F | F | **2** |
-| `gofd.poly.v3.inline.vecref` | jit | P | P | F | F | F | F | F | F | **2** |
-| `gofd.poly.v3.inline.vecref` | aot | P | P | F | F | F | F | F | F | **2** |
-| `gofd.poly.v3.named.vecref` | jit | P | P | F | F | F | F | F | F | **2** |
-| `gofd.poly.v3.named.vecref` | aot | P | P | F | F | F | F | F | F | **2** |
+| `gofd.mono.v2.inline.vecref` | jit | P | P | P | P | P | P | P | P | **8** |
+| `gofd.mono.v2.inline.vecref` | aot | P | P | P | P | P | P | P | P | **8** |
+| `gofd.mono.v2.named.vecref` | jit | P | P | P | P | P | P | P | P | **8** |
+| `gofd.mono.v2.named.vecref` | aot | P | P | P | P | P | P | P | P | **8** |
+| `gofd.mono.v3.inline.vecref` | jit | P | P | P | P | P | P | P | P | **8** |
+| `gofd.mono.v3.inline.vecref` | aot | P | P | P | P | P | P | P | P | **8** |
+| `gofd.mono.v3.named.vecref` | jit | P | P | P | P | P | P | P | P | **8** |
+| `gofd.mono.v3.named.vecref` | aot | P | P | P | P | P | P | P | P | **8** |
+| `gofd.poly.v2.inline.vecref` | jit | P | P | P | P | P | P | P | P | **8** |
+| `gofd.poly.v2.inline.vecref` | aot | P | P | P | P | P | P | P | P | **8** |
+| `gofd.poly.v2.named.vecref` | jit | P | P | P | P | P | P | P | P | **8** |
+| `gofd.poly.v2.named.vecref` | aot | P | P | P | P | P | P | P | P | **8** |
+| `gofd.poly.v3.inline.vecref` | jit | P | P | P | P | P | P | P | P | **8** |
+| `gofd.poly.v3.inline.vecref` | aot | P | P | P | P | P | P | P | P | **8** |
+| `gofd.poly.v3.named.vecref` | jit | P | P | P | P | P | P | P | P | **8** |
+| `gofd.poly.v3.named.vecref` | aot | P | P | P | P | P | P | P | P | **8** |
 
 ### gradn
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2188,6 +2188,17 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
             PASS_REGULAR_EXPRESSION "PASS: GUW multivariate"
             FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
     add_test(
+        NAME reverse_over_taylor_runtime_smoke
+        COMMAND $<TARGET_FILE:eshkol-run>
+                -r "${CMAKE_CURRENT_SOURCE_DIR}/tests/ad/reverse_over_taylor_test.esk"
+                -L"${CMAKE_CURRENT_BINARY_DIR}"
+    )
+    set_tests_properties(reverse_over_taylor_runtime_smoke
+        PROPERTIES
+            TIMEOUT 300
+            PASS_REGULAR_EXPRESSION "PASS: reverse-over-Taylor"
+            FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
+    add_test(
         NAME empty_collection_runtime_smoke
         COMMAND $<TARGET_FILE:eshkol-run>
                 -r "${CMAKE_CURRENT_SOURCE_DIR}/tests/collections/empty_collection_test.esk"

--- a/docs/design/AD_TAYLOR_TOWER.md
+++ b/docs/design/AD_TAYLOR_TOWER.md
@@ -5,7 +5,7 @@
 **Builds on / subsumes:** PR #138 (8-component jet for reverse-over-nested-forward, ESH-0117)
 **Author:** tsotchke
 **Target:** post-v1.3.0-evolve (not a tag blocker — #138 already handles the reported order-≤2 nested case)
-**Ledger:** ESH-0185 (P0, done) · ESH-0186..0197 (P1..P12, open)
+**Ledger:** ESH-0185 (P0, done) · ESH-0186 (P1) · ESH-0187 (P2) · ESH-0188 (P3) · ESH-0189 (P4, done) · ESH-0190 (P5, done) · ESH-0191..0197 (P6..P12, open)
 
 ---
 
@@ -219,11 +219,109 @@ as the public primitive. Given it, the GUW interpolation layer (P4) drops in wit
 
 ---
 
-## 8. Reverse-over-Taylor (high-order gradients, Phase P5)
+## 8. Reverse-over-Taylor (high-order gradients, Phase P5 — ESH-0190, done)
 
-`gradient` of a high-order scalar quantity (e.g. `∇` of a Laplacian) = the existing reverse tape with **tower-valued primals and adjoints**. The tape's forward pass records tower primals; the backward pass propagates tower adjoints. Perturbation tags (§5a) keep the reverse level distinct from the forward tower levels.
+**Goal.** Make `gradient` correct when the differentiated function computes a
+high-order forward derivative internally via the Taylor tower:
 
-This is the **highest-risk** piece (reverse mode has crash history — [[project_ad_multivar_operators]] — and the pure-Scheme tape `lib/core/ad/tape.esk` has AOT constraints: no `for-each`/`map` in core modules — [[project_stateful_ad_tape]]). It lands behind its own oracle, AOT-verified.
+```scheme
+(gradient (lambda (v) (derivative-n (lambda (t) (f t v)) t0 k)) v0)
+```
+
+i.e. `∇_v g(v)` where `g(v) = f^(k)_t(t0; v)` is an arbitrary-order (k ≥ 2)
+derivative in `t` that also depends on the outer variable `v`.
+
+### 8a. What was already working, and the precise break
+
+The tower's tagged arithmetic is fully polymorphic, so the *forward* quantity
+`(derivative-n (lambda (t) (f t v)) t0 k)` already computed the correct value
+for a fixed `v`. But wrapping it in `gradient` returned an exact **0** (the same
+failure class as ESH-0117). Root cause, found by probing the P4 build:
+
+- The reverse `gradient` pass runs the closure with `v` bound to a reverse-tape
+  **AD node** (`ESHKOL_VALUE_CALLABLE`, subtype `AD_NODE`). Inside, `derivative-n`
+  seeds `t` as a heap Taylor tower.
+- When `v` (an AD node) meets `t` (a tower) in `(* v t)`, the reverse-tape
+  dispatch (`withADBinaryDispatch`) fires *first* and **converts the tower
+  operand to a scalar constant AD node** — the reverse tape "swallows" the
+  tower, freezing `t` to `t0`. The whole `derivative-n` collapses onto the tape.
+- `popAndExtractForward` for the tower path then reads a bare double
+  (`k!·c[k]`) with **no** link back to the tape, so the outer backward pass sees
+  a constant → gradient 0.
+
+The order-≤2 jet path avoids this via `maybeJetLiftTapeOperand`, which freezes an
+AD node to a jet *before* the reverse dispatch — but it is gated on
+`__ad_pert_level > 0`, and the tower seed deliberately does **not** bump that
+level. So nothing lifted the node on the tower path.
+
+### 8b. Mechanism: a first-order seed tangent riding the tower
+
+P5 generalises the 8-jet's `ep`-derivative half (§5a "Interaction with
+JET4/JET8") from a single hyper-dual slot to the whole tower. A tower may now
+carry, alongside its value series `c[0..K]`, a parallel **seed-tangent** series
+`c′[k] = d(c[k])/d(reverse-seed)` — one first-order sensitivity of every
+coefficient to the outer gradient's active seed. This is the tower embodiment of
+the design's "tower-valued primals and adjoints".
+
+- **Representation.** A reserved flag bit `ESH_TAYLOR_TANGENT_FLAG`
+  (`flags` byte 8, the RESERVED0 region of §4) marks a *dual tower*; its
+  coefficient storage doubles to `2·(K+1)` doubles (values then tangents). The
+  seed dimension is orthogonal to the value **EPOCH_TAG**: there is exactly one
+  active reverse seed per gradient pass, so the tangent is a single global
+  first-order direction that always combines (it is not epoch-gated), while the
+  value series keeps its §5a epoch discipline unchanged.
+- **Seeding the tangent.** When a carrier of the outer seed enters tower
+  arithmetic it is lifted to a dual-tower *constant*:
+  - a reverse-tape **AD node** → value `{node->value, 0, …}`, tangent
+    `{seed_flag(node), 0, …}` (`seed_flag` = 1 iff it is the pass's active seed).
+    Done in codegen by `towerLiftOperand`, invoked from `maybeJetLiftTapeOperand`
+    and gated on a new runtime counter `__ad_tower_active > 0` (set while a
+    `derivative-n`/`taylor` pass runs), so the reverse tape can no longer swallow
+    the tower.
+  - a forward-mode **jet** (the scalar/vector gradient's own seed) → value
+    `{primal, 0, …}`, tangent `{e1, 0, …}`. Handled purely at runtime in
+    `normalise_operand_dual`.
+- **Propagation.** Each recurrence gains a linearised tangent rule computed in
+  lock-step with the value series, using the same `fma` / ascending-`j`
+  reduction order as §6a: `(u·w)′ = u′·w + u·w′`; `(u/w)′` from the divided
+  recurrence; and `g(u)′ = g′(u)·u′` realised as a series convolution for
+  `exp/log/sin/cos/tan/pow/sqrt/sinh/cosh/tanh`. A tower without the flag never
+  enters this path, so the P1/P2 forward tower is **byte-for-byte unchanged**.
+- **Extraction.** `popAndExtractForward` for `DERIV_N` reads
+  `value = k!·c[K]` and `dseed = k!·c′[K]`. If a reverse tape is live it records
+  the pair through the **same** `eshkol_ad_mixed_record` hook the order-≤2 jet
+  path uses (an exact local linearization `result = value + dseed·(seed−seed0)`,
+  built from CONSTANT/MUL/ADD nodes, so backprop needs no new rule). With no live
+  tape (scalar/vector forward-protocol gradient) it returns a jet
+  `{value, dseed·e1}` the outer forward extraction reads. `dseed` is a single
+  scalar per call, so the hook is reused **unchanged** — the design's
+  "generalize `dseed` per-order" turned out to be unnecessary because
+  `derivative-n` extraction is already scalar-per-call.
+
+### 8c. Perturbation / epoch safety
+
+Nested tower contexts get distinct value **epochs** (§5a) exactly as before; the
+single seed-tangent dimension is shared but only ever seeded from the *one*
+published active reverse seed, so an inner tower's perturbation cannot enter the
+outer adjoint and vice-versa. Verified by three nested cases (sibling
+`derivative-n`, `derivative-n`-inside-`derivative-n`, and an inner tower over an
+independent variable that must drop out) in
+`tests/ad/reverse_over_taylor_test.esk`.
+
+### 8d. Files & risk
+
+Runtime `lib/core/runtime_taylor.c` (dual recurrences, dual operand
+normalisation, `eshkol_taylor_lift_ad_node` / `_has_tangent` /
+`_extract_tangent`); `lib/core/runtime_autodiff.cpp` (the `__ad_tower_active` /
+`__ad_tower_order` context globals); codegen `lib/backend/autodiff_codegen.cpp`
+(`towerCtxPush/Pop`, `towerLiftOperand`, the tangent-aware `DERIV_N`
+extraction), `lib/backend/llvm_codegen.cpp` + `codegen_context.h` (context
+globals), `inc/eshkol/eshkol.h` (`ESH_TAYLOR_TANGENT_FLAG`). No new AD primitive
+and no change to the order-≤2 hot path. This is the design's **highest-risk**
+piece (reverse mode has crash history — [[project_ad_multivar_operators]]); it
+lands behind its own oracle `tests/ad/reverse_over_taylor_test.esk`,
+**AOT-verified** (byte-identical to `-r`), with the P3/P4/depth/oracle/SICP
+suites held green.
 
 ---
 
@@ -267,6 +365,56 @@ A **Taylor model** is a Taylor polynomial plus a rigorous **interval remainder**
 - **New-numeric-type checklist** (per [[reference-bugs-fixed]]): add the `HEAP_SUBTYPE_TAYLOR` case to `arith_->{add,sub,mul,div,pow, exp,log,sin,cos,…}`, `compare`/`abs`, `convertTo*`, `findFreeVariablesImpl`, `number->string`, and the type checker. Missing any one silently corrupts.
 - **JET4 unchanged; JET8 subsumed in P3:** keep #138's 8-jet behind its tests until reverse-over-nested-forward parity holds on the tower, then remove the special case. No churn on freshly-merged code.
 - **Arena/tape interop:** the stateful tape must accept tower values; verified **AOT**, not just `-r`.
+
+### 12a. P5 JET8 re-evaluation verdict (2026-07-06, ESH-0190)
+
+**Context.** P3 (ESH-0188) *evaluated* JET8 subsumption and explicitly deferred
+it, finding: *"full subsumption of JET8 into that tower is not achievable here …
+Expressing it exactly needs either GUW multivariate directional propagation
+(P4) or tower-valued reverse-tape primals/adjoints (P5)."* P5 delivers the
+latter, so the re-evaluation was re-run here.
+
+**Verdict: NO — do not retire JET8 in P5 (retirement now *unblocked* but
+deferred to a focused dispatch-refactor phase).**
+
+*The capability blocker P3 cited is resolved.* Reverse-over-nested-forward is
+`d/dv[d²/dt² f(t,v)]` — a 2nd-order tower in `t` plus a 1st-order sensitivity in
+`v`. P5's dual tower represents exactly that, and the results are **byte-for-byte
+identical** to the JET8 path, not merely close: measured `= ` (bit-equal) for the
+polynomial cases in `reverse_nested_forward_test.esk`, and also for
+transcendental (`p·sin(xx)`) and compound-transcendental (`p·sin(xx²)·exp(xx)`)
+nested cases (`abs diff = 0` in all probes). The AD depth oracle confirms it: the
+`gofd.poly.v{2,3}.*.vecref` reverse-over-forward cells jump from baseline
+max-depth 1 to 8 under P5.
+
+*Why JET8 nevertheless stays, for now:*
+
+1. **Order-≤2 hot-path invariant (the real blocker).** JET8 is the thin adapter
+   that serves reverse-over-forward at **order ≤ 2** over the stack-allocated
+   JET4 fast path. Retiring it routes that case onto the **heap** Taylor tower,
+   directly violating §1 ("Order ≤ 2 semantics and performance strictly
+   unchanged") and §12's dispatch order ("a tower only appears when order ≥ 3 is
+   requested, so the hot path is never burdened"). A correct retirement must keep
+   JET4 for order ≤ 2 and route *only* order ≥ 3 reverse-over-forward through the
+   tower — a dispatch decision, not a representation change.
+2. **The test's single-forward cases cannot be rerouted structurally.** The
+   `g-single`/`gt-single` cells are a *single* `derivative` inside `gradient`
+   (depth 1). The tower's entry for nested `derivative` is `detectPureDerivChain`,
+   which only recognises a *chain* (depth ≥ 2 today; ≥ 3 for the pure path).
+   Routing a plain depth-1 `derivative` through the tower would mean sending
+   **every** first-order `derivative`-in-`gradient` through the heap tower —
+   precisely the hot-path regression of point 1.
+3. **Scope isolation (§16).** Retirement touches the shared JET4/JET8 dispatch,
+   outside P5's "isolated to P5, extra review" risk boundary; P5 adds no churn to
+   the freshly-merged reverse-tape path.
+
+**Consequence.** JET8 is retained unchanged; `reverse_nested_forward_test.esk`
+stays 11/11 on its existing path. The tower-valued reverse-tape capability that
+was P3's stated prerequisite now exists and is byte-identical, so a later phase
+can retire JET8 behind an order-thresholded dispatch (JET4 for order ≤ 2, tower
+for order ≥ 3) without a hot-path regression. The P5 test carries a "parity
+witness" check asserting `tower == JET8` bit-equal for the polynomial case so the
+equivalence is guarded going forward.
 
 ---
 
@@ -388,7 +536,7 @@ Each phase gated by `scripts/run_ad_depth.sh` (derivative^d / gradient^d to d=8)
 | **P2** | Compile-time-K monomorphization (unrolled stack towers) + one FP-contraction policy (§6a) | correctness PASS + no heap in AD loop + metamorphic `mono(K) ≡ runtime(K)` **bit-exact** | **ESH-0187** |
 | **P3** | Subsume `AD_JET8`: route reverse-over-nested-forward through the tower; re-express levels as explicit tags; remove 8-comp special case | #138's tests still PASS; JET4 retained; confusion model unified | **ESH-0188** |
 | **P4** | GUW multivariate layer: `gradient^n` / mixed partials to arbitrary order via `taylor_propagate` + interpolation | `gradient^d` PASS to d=8 | **ESH-0189** |
-| **P5** | Reverse-over-Taylor + tower-aware tape (high-order gradients) | reverse high-order oracle PASS, AOT-verified | **ESH-0190** |
+| **P5** *(done)* | Reverse-over-Taylor: seed-tangent dual tower → high-order gradients through the reverse tape (§8) | `reverse_over_taylor_test.esk` 18/18 (-r + AOT); depth oracle 0 regressions | **ESH-0190** |
 | **P6** | Exact-coefficient towers (`COEFF_RATIONAL`, §9) | rational/bignum derivatives **bit-exact** vs symbolic oracle; exactness-contagion suite PASS | **ESH-0191** |
 | **P7** | Tensor-valued towers (`COEFF_TENSOR`, §10): conv2d/attention/batchnorm/layernorm high-order AD | ML AD smoke PASS; order-1 agrees with existing tensor-AD; FD-checked | **ESH-0192** |
 | **P8** | Taylor models (§11): validated AD with rigorous interval remainder | enclosure soundness (contains true range) + tightness (width ↓ in k) | **ESH-0193** |

--- a/inc/eshkol/backend/autodiff_codegen.h
+++ b/inc/eshkol/backend/autodiff_codegen.h
@@ -130,6 +130,20 @@ public:
     // (which dropped the forward tangent — the mixed-mode composition bug).
     llvm::Value* maybeJetLiftTapeOperand(llvm::Value* operand_tagged);
 
+    // ESH-0190 (P5): Taylor-tower differentiation context (reverse-over-Taylor).
+    // Codegen-maintained counter/order globals (mirroring __ad_pert_level) that
+    // tell maybeJetLiftTapeOperand a `derivative-n`/`taylor` tower pass is live
+    // so a reverse-tape AD node is frozen into a dual-tower carrying its seed
+    // tangent (instead of the reverse tape swallowing the tower). Pushed in
+    // seedForwardAndPush and popped in popAndExtractForward when in tower mode.
+    void towerCtxPush(llvm::Value* order_i32);
+    void towerCtxPop();
+    // If a tower differentiation is active and `operand_tagged` is a reverse-tape
+    // AD node, freeze it to a dual-tower constant (value + seed tangent) so the
+    // tower arithmetic — not the reverse tape — consumes it. Otherwise a no-op.
+    // Applied as a preprocessing step inside maybeJetLiftTapeOperand.
+    llvm::Value* towerLiftOperand(llvm::Value* operand_tagged);
+
     /**
      * Add two dual numbers: (a + b, a' + b')
      * @param left Left dual number

--- a/inc/eshkol/backend/codegen_context.h
+++ b/inc/eshkol/backend/codegen_context.h
@@ -240,6 +240,11 @@ public:
     // runtime around each forward-mode call, so it is invariant under TCO.
     llvm::GlobalVariable* adPertLevel() { return ad_pert_level_; }
     void setAdPertLevel(llvm::GlobalVariable* var) { ad_pert_level_ = var; }
+    // ESH-0190 P5: Taylor-tower differentiation context globals.
+    llvm::GlobalVariable* adTowerActive() { return ad_tower_active_; }
+    void setAdTowerActive(llvm::GlobalVariable* var) { ad_tower_active_ = var; }
+    llvm::GlobalVariable* adTowerOrder() { return ad_tower_order_; }
+    void setAdTowerOrder(llvm::GlobalVariable* var) { ad_tower_order_ = var; }
 
     // Double backward support
     llvm::GlobalVariable* outerAdNodeStorage() { return outer_ad_node_storage_; }
@@ -368,6 +373,8 @@ private:
     llvm::GlobalVariable* ad_tape_stack_ = nullptr;
     llvm::GlobalVariable* ad_tape_depth_ = nullptr;
     llvm::GlobalVariable* ad_pert_level_ = nullptr;  // ESH-0070 forward-mode perturbation level
+    llvm::GlobalVariable* ad_tower_active_ = nullptr; // ESH-0190 P5: Taylor-tower diff depth
+    llvm::GlobalVariable* ad_tower_order_ = nullptr;  // ESH-0190 P5: current tower order
     llvm::GlobalVariable* outer_ad_node_storage_ = nullptr;
     llvm::GlobalVariable* outer_ad_node_to_inner_ = nullptr;
     llvm::GlobalVariable* outer_grad_accumulator_ = nullptr;

--- a/inc/eshkol/eshkol.h
+++ b/inc/eshkol/eshkol.h
@@ -183,6 +183,14 @@ typedef struct esh_taylor {
 // esh_taylor_t.flags bitfield accessors (§4 of the design).
 #define ESH_TAYLOR_COEFF_MASK    0x000000FFu  // coefficient type: 0=F64 (P6 adds RATIONAL/TENSOR)
 #define ESH_TAYLOR_COEFF_F64     0u
+// P5 (ESH-0190) reverse-over-Taylor: a tower may carry a parallel first-order
+// "seed tangent" series alongside its value series. When ESH_TAYLOR_TANGENT_FLAG
+// is set the coefficient storage holds 2*(K+1) doubles: c[0..K] values followed
+// by c[K+1..2K+1] = d(value_k)/d(reverse-seed). This is the tower analogue of
+// the 8-jet's ep-derivative half (docs/design/AD_TAYLOR_TOWER.md §8). Lives in
+// the RESERVED0 byte (bit 8); orthogonal to COEFF_MASK and EPOCH_TAG.
+#define ESH_TAYLOR_TANGENT_FLAG  0x00000100u
+#define ESH_TAYLOR_HAS_TANGENT(fl) (((fl) & ESH_TAYLOR_TANGENT_FLAG) != 0u)
 #define ESH_TAYLOR_EPOCH_SHIFT   16u
 #define ESH_TAYLOR_EPOCH_MASK    0xFFFF0000u  // perturbation-confusion tag (bits 16..31)
 #define ESH_TAYLOR_GET_EPOCH(fl) (((fl) & ESH_TAYLOR_EPOCH_MASK) >> ESH_TAYLOR_EPOCH_SHIFT)

--- a/lib/backend/autodiff_codegen.cpp
+++ b/lib/backend/autodiff_codegen.cpp
@@ -234,6 +234,39 @@ void AutodiffCodegen::adPertLevelStore(llvm::Value* level) {
     ctx_.builder().CreateStore(level, g);
 }
 
+// ESH-0190 (P5): enter a Taylor-tower differentiation context. Increments the
+// active-depth counter and records the current tower order, so that reverse-tape
+// AD nodes reaching arithmetic inside the tower body (the lambda, compiled
+// separately) are frozen to dual-towers rather than swallowed by the tape.
+void AutodiffCodegen::towerCtxPush(llvm::Value* order_i32) {
+    auto& b = ctx_.builder();
+    llvm::GlobalVariable* ga = ctx_.adTowerActive();
+    llvm::GlobalVariable* go = ctx_.adTowerOrder();
+    if (ga) {
+        llvm::Value* d = b.CreateLoad(ctx_.int64Type(), ga, "twr_depth");
+        b.CreateStore(b.CreateAdd(d, llvm::ConstantInt::get(ctx_.int64Type(), 1)), ga);
+    }
+    if (go && order_i32) {
+        llvm::Value* o64 = b.CreateIntCast(order_i32, ctx_.int64Type(), true);
+        b.CreateStore(o64, go);
+    }
+}
+
+// ESH-0190 (P5): leave a Taylor-tower differentiation context (decrement depth).
+// The order global is left as-is: a foreign-tag constant tower zero-extends, so
+// a stale innermost order is harmless while depth > 0, and unread at depth 0.
+void AutodiffCodegen::towerCtxPop() {
+    auto& b = ctx_.builder();
+    llvm::GlobalVariable* ga = ctx_.adTowerActive();
+    if (!ga) return;
+    llvm::Value* d = b.CreateLoad(ctx_.int64Type(), ga, "twr_depth");
+    llvm::Value* dm = b.CreateSub(d, llvm::ConstantInt::get(ctx_.int64Type(), 1));
+    // clamp at 0 (defensive; balanced push/pop keeps it >= 0)
+    llvm::Value* neg = b.CreateICmpSLT(dm, llvm::ConstantInt::get(ctx_.int64Type(), 0));
+    dm = b.CreateSelect(neg, llvm::ConstantInt::get(ctx_.int64Type(), 0), dm);
+    b.CreateStore(dm, ga);
+}
+
 // === ESH-0186: runtime Taylor-tower kernel declarations (lib/core/runtime_taylor.c) ===
 namespace {
 llvm::Function* getTaylorSeedFunc(CodegenContext& ctx) {
@@ -252,6 +285,31 @@ llvm::Function* getTaylorExtractFunc(CodegenContext& ctx) {
         {ctx.ptrType(), ctx.int32Type()}, false);
     return llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
                                   "eshkol_taylor_extract", &ctx.module());
+}
+// ESH-0190 (P5): reverse-over-Taylor extraction / lift helpers.
+llvm::Function* getTaylorHasTangentFunc(CodegenContext& ctx) {
+    if (auto* f = ctx.module().getFunction("eshkol_taylor_has_tangent")) return f;
+    // i32 eshkol_taylor_has_tangent(const tagged* tower)
+    auto* ft = llvm::FunctionType::get(ctx.int32Type(), {ctx.ptrType()}, false);
+    return llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
+                                  "eshkol_taylor_has_tangent", &ctx.module());
+}
+llvm::Function* getTaylorExtractTangentFunc(CodegenContext& ctx) {
+    if (auto* f = ctx.module().getFunction("eshkol_taylor_extract_tangent")) return f;
+    // double eshkol_taylor_extract_tangent(const tagged* tower, i32 n)
+    auto* ft = llvm::FunctionType::get(ctx.doubleType(),
+        {ctx.ptrType(), ctx.int32Type()}, false);
+    return llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
+                                  "eshkol_taylor_extract_tangent", &ctx.module());
+}
+llvm::Function* getTaylorLiftAdNodeFunc(CodegenContext& ctx) {
+    if (auto* f = ctx.module().getFunction("eshkol_taylor_lift_ad_node")) return f;
+    // void eshkol_taylor_lift_ad_node(arena*, void* node, i32 order, tagged* out)
+    llvm::Type* p = ctx.ptrType();
+    auto* ft = llvm::FunctionType::get(ctx.voidType(),
+        {p, p, ctx.int32Type(), p}, false);
+    return llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
+                                  "eshkol_taylor_lift_ad_node", &ctx.module());
 }
 llvm::Function* getTaylorCoeffsFunc(CodegenContext& ctx) {
     if (auto* f = ctx.module().getFunction("eshkol_taylor_coeffs_list")) return f;
@@ -279,6 +337,10 @@ llvm::Value* AutodiffCodegen::seedForwardAndPush(llvm::Value* point_tagged,
         ctx_.builder().CreateStore(point_tagged, point_slot);
         ctx_.builder().CreateCall(getTaylorSeedFunc(ctx_),
             {getArenaPtr(), point_slot, adTowerOrder_, out_slot});
+        // ESH-0190 (P5): mark the tower context active so a reverse-tape AD node
+        // captured by the differentiated lambda is frozen to a dual-tower rather
+        // than swallowed by the reverse tape. Popped in popAndExtractForward.
+        towerCtxPush(adTowerOrder_);
         return ctx_.builder().CreateLoad(ctx_.taggedValueType(), out_slot, "twr_seeded");
     }
 
@@ -341,12 +403,78 @@ llvm::Value* AutodiffCodegen::popAndExtractForward(llvm::Value* result_tagged,
     // the differentiated function. DERIV_N -> f^(k)=k!*c[k] (a double); COEFFS
     // -> the K+1-element coefficient list. Short-circuits the jet R->Rⁿ logic. ──
     if (adTowerMode_ == TowerMode::DERIV_N && adTowerOrder_) {
+        towerCtxPop();     // leave the tower differentiation context
         llvm::Value* res_slot = b.CreateAlloca(ctx_.taggedValueType(), nullptr, "twr_res");
         b.CreateStore(result_tagged, res_slot);
         llvm::Value* d = b.CreateCall(getTaylorExtractFunc(ctx_), {res_slot, adTowerOrder_});
-        return tagged_.packDouble(d);
+        // ── ESH-0190 (P5) reverse-over-Taylor: if the returned tower carries a
+        // seed tangent (an outer gradient's seed flowed into f^(k)), extract
+        // dseed = d(f^(k))/d(seed) and thread it back to the outer pass:
+        //   • reverse tape live  → record an exact local linearization via the
+        //     SAME eshkol_ad_mixed_record hook used by the order-≤2 jet path;
+        //   • forward (no tape)  → return a jet {value, dseed·e1} the outer
+        //     forward extraction reads. ──
+        llvm::Value* has_tan = b.CreateCall(getTaylorHasTangentFunc(ctx_), {res_slot});
+        llvm::Value* has_tan_b = b.CreateICmpNE(has_tan, llvm::ConstantInt::get(ctx_.int32Type(), 0));
+        llvm::Function* fn = b.GetInsertBlock()->getParent();
+        llvm::BasicBlock* tan_bb   = llvm::BasicBlock::Create(ctx_.context(), "twr_tan", fn);
+        llvm::BasicBlock* plain_bb = llvm::BasicBlock::Create(ctx_.context(), "twr_plain", fn);
+        llvm::BasicBlock* done_bb  = llvm::BasicBlock::Create(ctx_.context(), "twr_done", fn);
+        b.CreateCondBr(has_tan_b, tan_bb, plain_bb);
+
+        // plain: no seed dependence → the bare k-th derivative as a double.
+        b.SetInsertPoint(plain_bb);
+        llvm::Value* plain_res = tagged_.packDouble(d);
+        b.CreateBr(done_bb);
+        llvm::BasicBlock* plain_exit = b.GetInsertBlock();
+
+        // tangent: dseed = k! * tangent[k].
+        b.SetInsertPoint(tan_bb);
+        llvm::Value* dseed = b.CreateCall(getTaylorExtractTangentFunc(ctx_), {res_slot, adTowerOrder_});
+        llvm::Value* tan_res = nullptr;
+        if (ctx_.currentAdTape()) {
+            llvm::FunctionCallee mixed_rec = ctx_.module().getOrInsertFunction(
+                "eshkol_ad_mixed_record",
+                llvm::FunctionType::get(ctx_.ptrType(),
+                    {ctx_.ptrType(), ctx_.ptrType(), ctx_.doubleType(), ctx_.doubleType()}, false));
+            llvm::Value* arena_ptr = getArenaPtr();
+            llvm::Value* tape_ptr = b.CreateLoad(ctx_.ptrType(), ctx_.currentAdTape());
+            llvm::Value* node = b.CreateCall(mixed_rec, {arena_ptr, tape_ptr, d, dseed});
+            llvm::Value* node_ok = b.CreateICmpNE(node,
+                llvm::ConstantPointerNull::get(llvm::PointerType::getUnqual(ctx_.context())));
+            llvm::BasicBlock* rec_bb = llvm::BasicBlock::Create(ctx_.context(), "twr_rec", fn);
+            llvm::BasicBlock* jet_bb = llvm::BasicBlock::Create(ctx_.context(), "twr_jet", fn);
+            llvm::BasicBlock* tmrg   = llvm::BasicBlock::Create(ctx_.context(), "twr_tmrg", fn);
+            b.CreateCondBr(node_ok, rec_bb, jet_bb);
+            b.SetInsertPoint(rec_bb);
+            llvm::Value* rec_v = tagged_.packPtr(node, ESHKOL_VALUE_CALLABLE);
+            b.CreateBr(tmrg);
+            llvm::BasicBlock* rec_exit = b.GetInsertBlock();
+            b.SetInsertPoint(jet_bb);
+            llvm::Value* zero = llvm::ConstantFP::get(ctx_.doubleType(), 0.0);
+            llvm::Value* jet_v = packDualToTagged(makeDual8(ctx_, d, dseed, zero, zero, zero, zero, zero, zero));
+            b.CreateBr(tmrg);
+            llvm::BasicBlock* jet_exit = b.GetInsertBlock();
+            b.SetInsertPoint(tmrg);
+            llvm::PHINode* tsel = b.CreatePHI(ctx_.taggedValueType(), 2, "twr_tan_sel");
+            tsel->addIncoming(rec_v, rec_exit);
+            tsel->addIncoming(jet_v, jet_exit);
+            tan_res = tsel;
+        } else {
+            llvm::Value* zero = llvm::ConstantFP::get(ctx_.doubleType(), 0.0);
+            tan_res = packDualToTagged(makeDual8(ctx_, d, dseed, zero, zero, zero, zero, zero, zero));
+        }
+        b.CreateBr(done_bb);
+        llvm::BasicBlock* tan_exit = b.GetInsertBlock();
+
+        b.SetInsertPoint(done_bb);
+        llvm::PHINode* dres = b.CreatePHI(ctx_.taggedValueType(), 2, "twr_deriv_res");
+        dres->addIncoming(plain_res, plain_exit);
+        dres->addIncoming(tan_res, tan_exit);
+        return dres;
     }
     if (adTowerMode_ == TowerMode::COEFFS && adTowerOrder_) {
+        towerCtxPop();     // leave the tower differentiation context
         llvm::Value* res_slot = b.CreateAlloca(ctx_.taggedValueType(), nullptr, "twr_res");
         llvm::Value* out_slot = b.CreateAlloca(ctx_.taggedValueType(), nullptr, "twr_list_out");
         b.CreateStore(result_tagged, res_slot);
@@ -577,9 +705,71 @@ llvm::Value* AutodiffCodegen::popAndExtractForward(llvm::Value* result_tagged,
 // The 8-jet now carries d(result 4-jet)/d(seed) through any depth; the outer
 // derivative's popAndExtractForward reads the surviving e1·ep coefficient and
 // records the dependency back onto the tape (eshkol_ad_mixed_record).
+// ESH-0190 (P5): freeze a reverse-tape AD node into a dual-tower constant while
+// a Taylor-tower differentiation is active, so the tower kernel (not the reverse
+// tape) consumes it. The lifted constant carries value {node->value,0,…} and
+// seed tangent {seed_flag,0,…}; its first-order dependence on the active
+// gradient seed then propagates through the tower recurrences and is read back
+// at popAndExtractForward via eshkol_ad_mixed_record. No-op unless a tower pass
+// is live AND the operand is a reverse-tape AD node.
+llvm::Value* AutodiffCodegen::towerLiftOperand(llvm::Value* operand_tagged) {
+    if (!operand_tagged || operand_tagged->getType() != ctx_.taggedValueType())
+        return operand_tagged;
+    llvm::GlobalVariable* active_g = ctx_.adTowerActive();
+    llvm::GlobalVariable* order_g  = ctx_.adTowerOrder();
+    if (!active_g || !order_g) return operand_tagged;
+    auto& b = ctx_.builder();
+    llvm::Function* fn = b.GetInsertBlock()->getParent();
+
+    // result slot (defaults to the unchanged operand).
+    llvm::AllocaInst* slot;
+    llvm::AllocaInst* out_slot;
+    {
+        llvm::IRBuilder<> eb(&fn->getEntryBlock(), fn->getEntryBlock().begin());
+        slot = eb.CreateAlloca(ctx_.taggedValueType(), nullptr, "twrlift_slot");
+        out_slot = eb.CreateAlloca(ctx_.taggedValueType(), nullptr, "twrlift_out");
+    }
+    b.CreateStore(operand_tagged, slot);
+
+    llvm::Value* depth = b.CreateLoad(ctx_.int64Type(), active_g, "twr_active");
+    llvm::Value* twr_on = b.CreateICmpSGT(depth, llvm::ConstantInt::get(ctx_.int64Type(), 0));
+    llvm::Value* base = tagged_.getBaseType(tagged_.getType(operand_tagged));
+    llvm::Value* is_callable = b.CreateICmpEQ(base,
+        llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_CALLABLE));
+    llvm::Value* cand = b.CreateAnd(twr_on, is_callable);
+
+    llvm::BasicBlock* sub_bb  = llvm::BasicBlock::Create(ctx_.context(), "twrlift_sub", fn);
+    llvm::BasicBlock* lift_bb = llvm::BasicBlock::Create(ctx_.context(), "twrlift_lift", fn);
+    llvm::BasicBlock* done_bb = llvm::BasicBlock::Create(ctx_.context(), "twrlift_done", fn);
+    b.CreateCondBr(cand, sub_bb, done_bb);
+
+    // CALLABLE: confirm it is an AD node (subtype check dereferences the header).
+    b.SetInsertPoint(sub_bb);
+    llvm::Value* is_ad = tagged_.checkCallableSubtype(operand_tagged, CALLABLE_SUBTYPE_AD_NODE);
+    b.CreateCondBr(is_ad, lift_bb, done_bb);
+
+    // Lift via the runtime helper (reads node->value + seed_flag).
+    b.SetInsertPoint(lift_bb);
+    llvm::Value* node_ptr = tagged_.unpackPtr(operand_tagged);
+    llvm::Value* order32 = b.CreateIntCast(
+        b.CreateLoad(ctx_.int64Type(), order_g, "twr_order"), ctx_.int32Type(), true);
+    b.CreateCall(getTaylorLiftAdNodeFunc(ctx_), {getArenaPtr(), node_ptr, order32, out_slot});
+    b.CreateStore(b.CreateLoad(ctx_.taggedValueType(), out_slot), slot);
+    b.CreateBr(done_bb);
+
+    b.SetInsertPoint(done_bb);
+    return b.CreateLoad(ctx_.taggedValueType(), slot, "twrlift_result");
+}
+
 llvm::Value* AutodiffCodegen::maybeJetLiftTapeOperand(llvm::Value* operand_tagged) {
     if (!operand_tagged || operand_tagged->getType() != ctx_.taggedValueType())
         return operand_tagged;
+    // ESH-0190 (P5): reverse-over-Taylor. When a tower differentiation is live,
+    // freeze a reverse-tape AD node into a dual-tower FIRST, so the tower
+    // arithmetic consumes it instead of the reverse tape swallowing the tower.
+    // If it lifts, the operand is now a HEAP_PTR tower and the jet gate below is
+    // a no-op; if not, the operand is unchanged and the jet path runs as before.
+    operand_tagged = towerLiftOperand(operand_tagged);
     auto& b = ctx_.builder();
 
     // Cheap gate first: no live forward perturbation → no lifting (this is the

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -1338,6 +1338,8 @@ private:
     GlobalVariable* ad_tape_stack;  // Array of tape pointers [MAX_TAPE_DEPTH]
     GlobalVariable* ad_tape_depth;  // Current stack depth (0 = no active gradient)
     GlobalVariable* ad_pert_level;  // ESH-0070 forward-mode perturbation level (runtime)
+    GlobalVariable* ad_tower_active; // ESH-0190 P5: Taylor-tower diff depth (>0 while active)
+    GlobalVariable* ad_tower_order;  // ESH-0190 P5: current innermost tower order
 
     // DOUBLE BACKWARD: Storage for outer AD node when in nested gradient
     // Used to connect inner gradient's result to outer's computation graph
@@ -2353,6 +2355,13 @@ public:
                     nullptr, // External - defined in runtime_autodiff.cpp
                     "__ad_pert_level"
                 );
+                // ESH-0190 P5: Taylor-tower differentiation context (external for REPL)
+                ad_tower_active = new GlobalVariable(
+                    *module, int64_type, false, GlobalValue::ExternalLinkage,
+                    nullptr, "__ad_tower_active");
+                ad_tower_order = new GlobalVariable(
+                    *module, int64_type, false, GlobalValue::ExternalLinkage,
+                    nullptr, "__ad_tower_order");
 
                 // DOUBLE BACKWARD: Create outer AD node storage globals (external for REPL)
                 outer_ad_node_storage = new GlobalVariable(
@@ -2443,6 +2452,13 @@ public:
                     ConstantInt::get(int64_type, 0),
                     "__ad_pert_level"
                 );
+                // ESH-0190 P5: Taylor-tower differentiation context (internal, zero init)
+                ad_tower_active = new GlobalVariable(
+                    *module, int64_type, false, GlobalValue::InternalLinkage,
+                    ConstantInt::get(int64_type, 0), "__ad_tower_active");
+                ad_tower_order = new GlobalVariable(
+                    *module, int64_type, false, GlobalValue::InternalLinkage,
+                    ConstantInt::get(int64_type, 0), "__ad_tower_order");
 
                 // DOUBLE BACKWARD: Create outer AD node storage globals (internal with null init)
                 outer_ad_node_storage = new GlobalVariable(
@@ -3807,6 +3823,8 @@ private:
         ctx_->setAdTapeStack(ad_tape_stack);
         ctx_->setAdTapeDepth(ad_tape_depth);
         ctx_->setAdPertLevel(ad_pert_level);
+        ctx_->setAdTowerActive(ad_tower_active);
+        ctx_->setAdTowerOrder(ad_tower_order);
         ctx_->setOuterAdNodeStorage(outer_ad_node_storage);
         ctx_->setOuterAdNodeToInner(outer_ad_node_to_inner);
         ctx_->setOuterGradAccumulator(outer_grad_accumulator);

--- a/lib/core/runtime_autodiff.cpp
+++ b/lib/core/runtime_autodiff.cpp
@@ -42,6 +42,20 @@ thread_local uint64_t __ad_tape_depth = 0;
 // ESH-0070: runtime forward-mode perturbation level (see codegen_context.h).
 thread_local uint64_t __ad_pert_level = 0;
 
+// ESH-0190 (P5): Taylor-tower differentiation context. __ad_tower_active is a
+// depth counter (> 0 while a `derivative-n`/`taylor` tower pass is running); it
+// is the fast gate that tells maybeJetLiftTapeOperand to freeze a reverse-tape
+// AD node into a dual-tower (carrying its seed tangent) instead of letting the
+// reverse tape swallow the tower. __ad_tower_order is the current innermost
+// tower order, passed to eshkol_taylor_lift_ad_node as the lifted constant's
+// order (a constant tower zero-extends, so best-effort order is sufficient).
+// Codegen-only state (mirrors __ad_pert_level): written at the derivative-n
+// call site, read in the lambda body — same module, so internal-linkage AOT
+// globals stay consistent. Not thread-local: AD runs on the main thread and
+// LLVM external globals link more portably as plain symbols (see note above).
+uint64_t __ad_tower_active = 0;
+uint64_t __ad_tower_order = 0;
+
 thread_local void* __outer_ad_node_storage = nullptr;
 thread_local void* __outer_ad_node_to_inner = nullptr;
 thread_local void* __outer_grad_accumulator = nullptr;

--- a/lib/core/runtime_taylor.c
+++ b/lib/core/runtime_taylor.c
@@ -72,13 +72,17 @@ enum {
 
 /* Allocate a zeroed tower of order K (K+1 coefficients) with the given flags.
  * Returns the DATA pointer (after the 8-byte object header), so it can be
- * stored in a tagged HEAP_PTR exactly like a tensor. */
+ * stored in a tagged HEAP_PTR exactly like a tensor. When `flags` has
+ * ESH_TAYLOR_TANGENT_FLAG set the storage is doubled to 2*(K+1) doubles so a
+ * parallel first-order seed-tangent series (P5) rides alongside the value
+ * series; both halves are zero-initialised. */
 esh_taylor_t* eshkol_taylor_alloc(arena_t* arena, uint32_t order_k, uint32_t flags) {
     if (!arena) arena = get_global_arena();
     if (!arena) return NULL;
 
     size_t ncoeff = (size_t)order_k + 1;
-    size_t data_size = sizeof(esh_taylor_t) + ncoeff * sizeof(double);
+    size_t nstore = ESH_TAYLOR_HAS_TANGENT(flags) ? (2u * ncoeff) : ncoeff;
+    size_t data_size = sizeof(esh_taylor_t) + nstore * sizeof(double);
     size_t total = sizeof(eshkol_object_header_t) + data_size;
     total = (total + 15) & ~((size_t)15);
 
@@ -97,8 +101,15 @@ esh_taylor_t* eshkol_taylor_alloc(arena_t* arena, uint32_t order_k, uint32_t fla
     esh_taylor_t* t = (esh_taylor_t*)(mem + sizeof(eshkol_object_header_t));
     t->order_k = order_k;
     t->flags = flags;
-    memset(t->c, 0, ncoeff * sizeof(double));
+    memset(t->c, 0, nstore * sizeof(double));
     return t;
+}
+
+/* Pointer to a tower's tangent (seed-derivative) coefficient array, or NULL if
+ * the tower does not carry one. The tangent half follows the value half. */
+static inline double* taylor_tan(esh_taylor_t* t) {
+    if (!t || !ESH_TAYLOR_HAS_TANGENT(t->flags)) return NULL;
+    return t->c + ((size_t)t->order_k + 1);
 }
 
 static inline eshkol_tagged_value_t taylor_to_tagged(const esh_taylor_t* t) {
@@ -227,6 +238,99 @@ static void tr_pow_const(double* s, const double* u, double r, int n) {
 }
 
 /* ----------------------------------------------------------------------- */
+/* dual recurrences: value + first-order seed tangent (P5, ESH-0190)        */
+/* ----------------------------------------------------------------------- */
+/* A "dual tower" carries, alongside its value series u, a tangent series
+ * u' = d(u)/d(reverse-seed). Reverse-over-Taylor (docs/design §8) needs one
+ * first-order sensitivity of every high-order coefficient to the outer
+ * gradient's seed; this is exactly the tower analogue of the 8-jet's
+ * ep-derivative half. Each rule below computes the value with the existing
+ * tr_* recurrence and the tangent with the linearised (product/chain) rule,
+ * using the same fma / ascending-j reduction order (design §6a). */
+
+/* Small stack buffer avoids a heap alloc for the common orders; falls back
+ * to the arena for very high K. */
+#define ESH_TAYLOR_STACKN 64
+
+/* s = convolution(a, b): s_k = sum_{j=0..k} a_j * b_{k-j}. */
+static void tr_conv(double* s, const double* a, const double* b, int n) {
+    for (int k = 0; k < n; k++) {
+        double acc = 0.0;
+        for (int j = 0; j <= k; j++) acc = fma(a[j], b[k - j], acc);
+        s[k] = acc;
+    }
+}
+
+/* Tangent of u*w: (u*w)' = u'*w + u*w'. */
+static void trd_mul(double* st, const double* uv, const double* ut,
+                    const double* wv, const double* wt, int n) {
+    for (int k = 0; k < n; k++) {
+        double acc = 0.0;
+        for (int j = 0; j <= k; j++) {
+            acc = fma(ut[j], wv[k - j], acc);
+            acc = fma(uv[j], wt[k - j], acc);
+        }
+        st[k] = acc;
+    }
+}
+
+/* Tangent of s = u/w, given the already-computed value quotient sv:
+ *   s'_k = ( u'_k - sum_{j=1..k}(w'_j s_{k-j} + w_j s'_{k-j}) - s_k w'_0 ) / w_0. */
+static void trd_div(double* st, const double* sv,
+                    const double* ut, const double* wv, const double* wt, int n) {
+    for (int k = 0; k < n; k++) {
+        double acc = ut[k];
+        for (int j = 1; j <= k; j++) {
+            acc = fma(-wt[j], sv[k - j], acc);
+            acc = fma(-wv[j], st[k - j], acc);
+        }
+        acc = fma(-sv[k], wt[0], acc);
+        st[k] = acc / wv[0];
+    }
+}
+
+/* Composable dual ops: each fills value sv and tangent st from operand
+ * value/tangent series. Value uses the proven tr_* recurrence; tangent uses
+ * the chain rule s' = g'(u)·u' realised as a series convolution/division. */
+static void ddual_mul(double* sv, double* st, const double* uv, const double* ut,
+                      const double* wv, const double* wt, int n) {
+    tr_mul(sv, uv, wv, n);
+    trd_mul(st, uv, ut, wv, wt, n);
+}
+static void ddual_div(double* sv, double* st, const double* uv, const double* ut,
+                      const double* wv, const double* wt, int n) {
+    tr_div(sv, uv, wv, n);
+    trd_div(st, sv, ut, wv, wt, n);
+}
+static void ddual_exp(double* sv, double* st, const double* uv, const double* ut, int n) {
+    tr_exp(sv, uv, n);
+    tr_conv(st, sv, ut, n);                 /* (exp u)' = exp(u)·u' */
+}
+static void ddual_log(double* sv, double* st, const double* uv, const double* ut, int n) {
+    tr_log(sv, uv, n);
+    tr_div(st, ut, uv, n);                  /* (log u)' = u'/u */
+}
+/* sin/cos share the coupled recurrence; fills both values + both tangents. */
+static void ddual_sincos(double* so, double* sot, double* co, double* cot,
+                         const double* uv, const double* ut, int n) {
+    tr_sincos(so, co, uv, n);
+    tr_conv(sot, co, ut, n);                /* (sin u)' =  cos(u)·u' */
+    tr_conv(cot, so, ut, n);
+    for (int k = 0; k < n; k++) cot[k] = -cot[k];   /* (cos u)' = -sin(u)·u' */
+}
+/* u^r, constant real exponent r. (u^r)' = r·u^{r-1}·u' = r·(u^r/u)·u'. */
+static void ddual_pow_const(double* sv, double* st, const double* uv, const double* ut,
+                            double r, int n, arena_t* arena) {
+    tr_pow_const(sv, uv, r, n);
+    double qb[ESH_TAYLOR_STACKN];
+    double* q = qb; double* hq = NULL;
+    if (n > ESH_TAYLOR_STACKN) { hq = (double*)arena_allocate(arena, (size_t)n*sizeof(double)); q = hq; }
+    tr_div(q, sv, uv, n);                   /* q = u^r / u = u^{r-1} */
+    tr_conv(st, q, ut, n);
+    for (int k = 0; k < n; k++) st[k] = r * st[k];
+}
+
+/* ----------------------------------------------------------------------- */
 /* operand normalisation + epoch (perturbation-confusion) handling          */
 /* ----------------------------------------------------------------------- */
 
@@ -265,12 +369,80 @@ static void result_shape(const eshkol_tagged_value_t* l, const eshkol_tagged_val
 }
 
 /* ----------------------------------------------------------------------- */
+/* P5 seed-tangent operand extraction (ESH-0190)                            */
+/* ----------------------------------------------------------------------- */
+/* Reverse-mode hook (defined in runtime_autodiff.cpp): 1.0 iff `node` is the
+ * gradient pass's active seed variable. Read here so an AD-node operand flowing
+ * into tower arithmetic contributes d(value)/d(seed) = seed_flag into c[0] of
+ * its tangent series. */
+extern double eshkol_ad_seed_flag(void* node);
+
+/* Does this operand carry (or induce) a first-order seed tangent?
+ *   - a tower with ESH_TAYLOR_TANGENT_FLAG            -> yes
+ *   - a forward-mode DUAL number (outer gradient seed) -> yes (its e1 tangent)
+ *   - a reverse-tape CALLABLE AD node                  -> yes (its seed_flag)
+ * Plain scalars / towers-without-tangent do not. */
+static int operand_has_tangent(const eshkol_tagged_value_t* tv) {
+    if (!tv) return 0;
+    esh_taylor_t* t = tagged_as_taylor(tv);
+    if (t) return ESH_TAYLOR_HAS_TANGENT(t->flags);
+    uint8_t bt = (uint8_t)(tv->type & 0x0F);
+    if (bt == ESHKOL_VALUE_DUAL_NUMBER) return 1;
+    if (bt == ESHKOL_VALUE_CALLABLE) return 1;  /* AD node (subtype not re-checked) */
+    return 0;
+}
+
+/* Materialise BOTH the value series (epoch-gated, exactly like normalise_operand)
+ * and the tangent series (a single global first-order seed dimension, epoch-
+ * independent) of an operand into vbuf/tbuf (length n). */
+static void normalise_operand_dual(const eshkol_tagged_value_t* tv, uint32_t active_epoch,
+                                   double* vbuf, double* tbuf, int n) {
+    memset(vbuf, 0, (size_t)n * sizeof(double));
+    memset(tbuf, 0, (size_t)n * sizeof(double));
+    esh_taylor_t* t = tagged_as_taylor(tv);
+    if (t) {
+        /* value: same-epoch tower contributes its full series; foreign-epoch
+         * (outer/inner level) is lifted to its constant c[0] (§5a). */
+        if (ESH_TAYLOR_GET_EPOCH(t->flags) == active_epoch) {
+            int m = (int)t->order_k + 1;
+            if (m > n) m = n;
+            memcpy(vbuf, t->c, (size_t)m * sizeof(double));
+        } else {
+            vbuf[0] = t->c[0];
+        }
+        /* tangent: the seed dimension is orthogonal to the value epoch, so it
+         * always combines. */
+        double* tt = taylor_tan(t);
+        if (tt) {
+            int m = (int)t->order_k + 1;
+            if (m > n) m = n;
+            memcpy(tbuf, tt, (size_t)m * sizeof(double));
+        }
+        return;
+    }
+    uint8_t bt = (uint8_t)(tv->type & 0x0F);
+    if (bt == ESHKOL_VALUE_DUAL_NUMBER && tv->data.ptr_val) {
+        /* forward-mode jet {primal, e1, ...}: primal is the value, e1 is the
+         * outer gradient's first-order perturbation = the seed tangent. */
+        const double* d = (const double*)(uintptr_t)tv->data.ptr_val;
+        vbuf[0] = d[0];
+        tbuf[0] = d[1];
+        return;
+    }
+    if (bt == ESHKOL_VALUE_CALLABLE && tv->data.ptr_val) {
+        /* reverse-tape AD node: value is node->value, tangent c[0] is 1.0 iff
+         * this IS the active seed (frozen local linearisation, §8). */
+        void* node = (void*)(uintptr_t)tv->data.ptr_val;
+        vbuf[0] = ((const ad_node_t*)node)->value;
+        tbuf[0] = eshkol_ad_seed_flag(node);
+        return;
+    }
+    vbuf[0] = tagged_scalar_value(tv);
+}
+
+/* ----------------------------------------------------------------------- */
 /* tagged binary / unary dispatch (called from codegen)                     */
 /* ----------------------------------------------------------------------- */
-
-/* Small stack buffer avoids a heap alloc for the common orders; falls back
- * to the arena for very high K. */
-#define ESH_TAYLOR_STACKN 64
 
 void eshkol_taylor_binary_tagged(arena_t* arena,
     const eshkol_tagged_value_t* left, const eshkol_tagged_value_t* right,
@@ -280,6 +452,62 @@ void eshkol_taylor_binary_tagged(arena_t* arena,
     uint32_t order_k, epoch;
     result_shape(left, right, &order_k, &epoch);
     int n = (int)order_k + 1;
+
+    /* P5 (ESH-0190): reverse-over-Taylor. If either operand carries a first-
+     * order seed tangent (a tangent-tower, a forward jet, or a reverse-tape AD
+     * node), propagate the seed derivative alongside the value series so the
+     * outer gradient can read d(f^(k))/d(seed) at extraction. */
+    if (operand_has_tangent(left) || operand_has_tangent(right)) {
+        double uvb[ESH_TAYLOR_STACKN], utb[ESH_TAYLOR_STACKN];
+        double wvb[ESH_TAYLOR_STACKN], wtb[ESH_TAYLOR_STACKN];
+        double *uv=uvb,*ut=utb,*wv=wvb,*wt=wtb, *h1=NULL,*h2=NULL,*h3=NULL,*h4=NULL;
+        if (n > ESH_TAYLOR_STACKN) {
+            h1=(double*)arena_allocate(arena,(size_t)n*sizeof(double));
+            h2=(double*)arena_allocate(arena,(size_t)n*sizeof(double));
+            h3=(double*)arena_allocate(arena,(size_t)n*sizeof(double));
+            h4=(double*)arena_allocate(arena,(size_t)n*sizeof(double));
+            uv=h1;ut=h2;wv=h3;wt=h4;
+        }
+        normalise_operand_dual(left,  epoch, uv, ut, n);
+        normalise_operand_dual(right, epoch, wv, wt, n);
+        esh_taylor_t* out = eshkol_taylor_alloc(arena, order_k,
+            ESH_TAYLOR_MK_FLAGS(ESH_TAYLOR_COEFF_F64, epoch) | ESH_TAYLOR_TANGENT_FLAG);
+        if (!out) { *result = eshkol_make_double(0.0); return; }
+        double* ov = out->c;
+        double* ot = taylor_tan(out);
+        switch (op) {
+            case ESH_TAYLOR_OP_add: tr_add(ov, uv, wv, n); tr_add(ot, ut, wt, n); break;
+            case ESH_TAYLOR_OP_sub: tr_sub(ov, uv, wv, n); tr_sub(ot, ut, wt, n); break;
+            case ESH_TAYLOR_OP_mul: ddual_mul(ov, ot, uv, ut, wv, wt, n); break;
+            case ESH_TAYLOR_OP_div: ddual_div(ov, ot, uv, ut, wv, wt, n); break;
+            case ESH_TAYLOR_OP_pow: {
+                int w_is_const = 1;
+                for (int k = 1; k < n; k++) if (wv[k] != 0.0 || wt[k] != 0.0) { w_is_const = 0; break; }
+                if (w_is_const && wt[0] == 0.0) {
+                    ddual_pow_const(ov, ot, uv, ut, wv[0], n, arena);
+                } else {
+                    /* u^w = exp(w·log u); compose the dual log/mul/exp. */
+                    double lb[ESH_TAYLOR_STACKN], lbt[ESH_TAYLOR_STACKN];
+                    double pb[ESH_TAYLOR_STACKN], pbt[ESH_TAYLOR_STACKN];
+                    double *lg=lb,*lgt=lbt,*pr=pb,*prt=pbt,*g1=NULL,*g2=NULL,*g3=NULL,*g4=NULL;
+                    if (n > ESH_TAYLOR_STACKN) {
+                        g1=(double*)arena_allocate(arena,(size_t)n*sizeof(double));
+                        g2=(double*)arena_allocate(arena,(size_t)n*sizeof(double));
+                        g3=(double*)arena_allocate(arena,(size_t)n*sizeof(double));
+                        g4=(double*)arena_allocate(arena,(size_t)n*sizeof(double));
+                        lg=g1;lgt=g2;pr=g3;prt=g4;
+                    }
+                    ddual_log(lg, lgt, uv, ut, n);
+                    ddual_mul(pr, prt, wv, wt, lg, lgt, n);
+                    ddual_exp(ov, ot, pr, prt, n);
+                }
+                break;
+            }
+            default: tr_add(ov, uv, wv, n); tr_add(ot, ut, wt, n); break;
+        }
+        *result = taylor_to_tagged(out);
+        return;
+    }
 
     double sbuf_u[ESH_TAYLOR_STACKN], sbuf_w[ESH_TAYLOR_STACKN];
     double *u = sbuf_u, *w = sbuf_w;
@@ -335,6 +563,88 @@ void eshkol_taylor_unary_tagged(arena_t* arena,
     uint32_t order_k = t ? t->order_k : 0;
     uint32_t epoch = t ? ESH_TAYLOR_GET_EPOCH(t->flags) : 0;
     int n = (int)order_k + 1;
+
+    /* P5 (ESH-0190): dual (value + seed-tangent) unary path — see the binary
+     * dispatch for the rationale. Fires only when the operand carries a seed
+     * tangent, so the plain forward-tower path below is byte-for-byte unchanged. */
+    if (operand_has_tangent(in)) {
+        double uvb[ESH_TAYLOR_STACKN], utb[ESH_TAYLOR_STACKN];
+        double *uv=uvb, *ut=utb, *h1=NULL,*h2=NULL;
+        if (n > ESH_TAYLOR_STACKN) {
+            h1=(double*)arena_allocate(arena,(size_t)n*sizeof(double));
+            h2=(double*)arena_allocate(arena,(size_t)n*sizeof(double));
+            uv=h1;ut=h2;
+        }
+        normalise_operand_dual(in, epoch, uv, ut, n);
+        esh_taylor_t* out = eshkol_taylor_alloc(arena, order_k,
+            ESH_TAYLOR_MK_FLAGS(ESH_TAYLOR_COEFF_F64, epoch) | ESH_TAYLOR_TANGENT_FLAG);
+        if (!out) { *result = eshkol_make_double(0.0); return; }
+        double* ov = out->c;
+        double* ot = taylor_tan(out);
+        switch (op) {
+            case ESH_TAYLOR_UOP_neg: tr_neg(ov, uv, n); tr_neg(ot, ut, n); break;
+            case ESH_TAYLOR_UOP_exp: ddual_exp(ov, ot, uv, ut, n); break;
+            case ESH_TAYLOR_UOP_log: ddual_log(ov, ot, uv, ut, n); break;
+            case ESH_TAYLOR_UOP_sin: {
+                double cb[ESH_TAYLOR_STACKN], cbt[ESH_TAYLOR_STACKN];
+                double *co=cb,*cot=cbt,*g1=NULL,*g2=NULL;
+                if (n>ESH_TAYLOR_STACKN){g1=(double*)arena_allocate(arena,(size_t)n*sizeof(double));g2=(double*)arena_allocate(arena,(size_t)n*sizeof(double));co=g1;cot=g2;}
+                ddual_sincos(ov, ot, co, cot, uv, ut, n);
+                break;
+            }
+            case ESH_TAYLOR_UOP_cos: {
+                double sb[ESH_TAYLOR_STACKN], sbt[ESH_TAYLOR_STACKN];
+                double *so=sb,*sot=sbt,*g1=NULL,*g2=NULL;
+                if (n>ESH_TAYLOR_STACKN){g1=(double*)arena_allocate(arena,(size_t)n*sizeof(double));g2=(double*)arena_allocate(arena,(size_t)n*sizeof(double));so=g1;sot=g2;}
+                ddual_sincos(so, sot, ov, ot, uv, ut, n);
+                break;
+            }
+            case ESH_TAYLOR_UOP_tan: {
+                double sb[ESH_TAYLOR_STACKN],sbt[ESH_TAYLOR_STACKN],cb[ESH_TAYLOR_STACKN],cbt[ESH_TAYLOR_STACKN];
+                double *so=sb,*sot=sbt,*co=cb,*cot=cbt,*g1=NULL,*g2=NULL,*g3=NULL,*g4=NULL;
+                if (n>ESH_TAYLOR_STACKN){g1=(double*)arena_allocate(arena,(size_t)n*sizeof(double));g2=(double*)arena_allocate(arena,(size_t)n*sizeof(double));g3=(double*)arena_allocate(arena,(size_t)n*sizeof(double));g4=(double*)arena_allocate(arena,(size_t)n*sizeof(double));so=g1;sot=g2;co=g3;cot=g4;}
+                ddual_sincos(so, sot, co, cot, uv, ut, n);
+                ddual_div(ov, ot, so, sot, co, cot, n);
+                break;
+            }
+            case ESH_TAYLOR_UOP_sqrt: ddual_pow_const(ov, ot, uv, ut, 0.5, n, arena); break;
+            case ESH_TAYLOR_UOP_abs: {
+                double sgn = (uv[0] < 0.0) ? -1.0 : 1.0;
+                ov[0] = fabs(uv[0]); ot[0] = sgn * ut[0];
+                for (int k = 1; k < n; k++) { ov[k] = sgn * uv[k]; ot[k] = sgn * ut[k]; }
+                break;
+            }
+            case ESH_TAYLOR_UOP_sinh:
+            case ESH_TAYLOR_UOP_cosh:
+            case ESH_TAYLOR_UOP_tanh: {
+                /* sinh/cosh/tanh via dual exp(±u). */
+                double epb[ESH_TAYLOR_STACKN],eptb[ESH_TAYLOR_STACKN];
+                double emb[ESH_TAYLOR_STACKN],emtb[ESH_TAYLOR_STACKN];
+                double nub[ESH_TAYLOR_STACKN],nutb[ESH_TAYLOR_STACKN];
+                double *ep=epb,*ept=eptb,*em=emb,*emt=emtb,*nu=nub,*nut=nutb;
+                double *g1=NULL,*g2=NULL,*g3=NULL,*g4=NULL,*g5=NULL,*g6=NULL;
+                if (n>ESH_TAYLOR_STACKN){g1=(double*)arena_allocate(arena,(size_t)n*sizeof(double));g2=(double*)arena_allocate(arena,(size_t)n*sizeof(double));g3=(double*)arena_allocate(arena,(size_t)n*sizeof(double));g4=(double*)arena_allocate(arena,(size_t)n*sizeof(double));g5=(double*)arena_allocate(arena,(size_t)n*sizeof(double));g6=(double*)arena_allocate(arena,(size_t)n*sizeof(double));ep=g1;ept=g2;em=g3;emt=g4;nu=g5;nut=g6;}
+                ddual_exp(ep, ept, uv, ut, n);
+                tr_neg(nu, uv, n); tr_neg(nut, ut, n);
+                ddual_exp(em, emt, nu, nut, n);
+                if (op == ESH_TAYLOR_UOP_sinh) {
+                    for (int k=0;k<n;k++){ ov[k]=0.5*(ep[k]-em[k]); ot[k]=0.5*(ept[k]-emt[k]); }
+                } else if (op == ESH_TAYLOR_UOP_cosh) {
+                    for (int k=0;k<n;k++){ ov[k]=0.5*(ep[k]+em[k]); ot[k]=0.5*(ept[k]+emt[k]); }
+                } else { /* tanh = sinh/cosh */
+                    double shb[ESH_TAYLOR_STACKN],shtb[ESH_TAYLOR_STACKN],chb[ESH_TAYLOR_STACKN],chtb[ESH_TAYLOR_STACKN];
+                    double *sh=shb,*sht=shtb,*ch=chb,*cht=chtb,*g7=NULL,*g8=NULL,*g9=NULL,*g10=NULL;
+                    if (n>ESH_TAYLOR_STACKN){g7=(double*)arena_allocate(arena,(size_t)n*sizeof(double));g8=(double*)arena_allocate(arena,(size_t)n*sizeof(double));g9=(double*)arena_allocate(arena,(size_t)n*sizeof(double));g10=(double*)arena_allocate(arena,(size_t)n*sizeof(double));sh=g7;sht=g8;ch=g9;cht=g10;}
+                    for (int k=0;k<n;k++){ sh[k]=0.5*(ep[k]-em[k]); sht[k]=0.5*(ept[k]-emt[k]); ch[k]=0.5*(ep[k]+em[k]); cht[k]=0.5*(ept[k]+emt[k]); }
+                    ddual_div(ov, ot, sh, sht, ch, cht, n);
+                }
+                break;
+            }
+            default: memcpy(ov, uv, (size_t)n*sizeof(double)); memcpy(ot, ut, (size_t)n*sizeof(double)); break;
+        }
+        *result = taylor_to_tagged(out);
+        return;
+    }
 
     double sbuf_u[ESH_TAYLOR_STACKN];
     double* u = sbuf_u;
@@ -486,6 +796,51 @@ double eshkol_taylor_extract(const eshkol_tagged_value_t* tv, uint32_t n) {
     if (!t) return (n == 0) ? tagged_scalar_value(tv) : 0.0;
     if (n > t->order_k) return 0.0;
     return factorial_d(n) * t->c[n];
+}
+
+/* ----------------------------------------------------------------------- */
+/* P5 seed-tangent extraction & AD-node lift (ESH-0190)                     */
+/* ----------------------------------------------------------------------- */
+
+/* 1 iff the tower value carries a first-order seed tangent series. */
+int eshkol_taylor_has_tangent(const eshkol_tagged_value_t* tv) {
+    esh_taylor_t* t = tagged_as_taylor(tv);
+    return (t && ESH_TAYLOR_HAS_TANGENT(t->flags)) ? 1 : 0;
+}
+
+/* d(f^(n)(x0))/d(reverse-seed) = n! * tangent[n]. 0 when the tower has no
+ * tangent series or n exceeds the order. This is the dseed the outer gradient's
+ * mixed-mode record (or forward jet) reads at the derivative-n return site. */
+double eshkol_taylor_extract_tangent(const eshkol_tagged_value_t* tv, uint32_t n) {
+    esh_taylor_t* t = tagged_as_taylor(tv);
+    if (!t || !ESH_TAYLOR_HAS_TANGENT(t->flags)) return 0.0;
+    if (n > t->order_k) return 0.0;
+    double* tan = taylor_tan(t);
+    return factorial_d(n) * tan[n];
+}
+
+/* Freeze a reverse-tape AD node into a dual-tower CONSTANT of order K:
+ *   value   = {node->value, 0, ..., 0}
+ *   tangent = {seed_flag(node), 0, ..., 0}
+ * so that when it flows into tower arithmetic the reverse tape does not swallow
+ * the tower (withADBinaryDispatch would otherwise convert the tower operand to a
+ * scalar AD node) and its first-order dependence on the active gradient seed is
+ * propagated as the tower's seed tangent (docs/design/AD_TAYLOR_TOWER.md §8).
+ * A constant tower zero-extends, so `order_k` need only be a best-effort upper
+ * bound (the current innermost tower order). Called from codegen's
+ * maybeJetLiftTapeOperand while a tower differentiation is active. */
+void eshkol_taylor_lift_ad_node(arena_t* arena, void* node, int32_t order_k,
+                                eshkol_tagged_value_t* out) {
+    if (!arena) arena = get_global_arena();
+    if (order_k < 0) order_k = 0;
+    double val = node ? ((const ad_node_t*)node)->value : 0.0;
+    double flag = node ? eshkol_ad_seed_flag(node) : 0.0;
+    esh_taylor_t* t = eshkol_taylor_alloc(arena, (uint32_t)order_k,
+        ESH_TAYLOR_MK_FLAGS(ESH_TAYLOR_COEFF_F64, 0u) | ESH_TAYLOR_TANGENT_FLAG);
+    if (!t) { *out = eshkol_make_double(val); return; }
+    t->c[0] = val;
+    taylor_tan(t)[0] = flag;
+    *out = taylor_to_tagged(t);
 }
 
 /* Differentiate a tower: (f')_k = (k+1) * c_{k+1}. Preserves order/epoch;

--- a/tests/ad/reverse_over_taylor_test.esk
+++ b/tests/ad/reverse_over_taylor_test.esk
@@ -1,0 +1,129 @@
+;;; tests/ad/reverse_over_taylor_test.esk
+;;; ESH-0190 (P5): reverse-over-Taylor — high-order GRADIENTS taken through the
+;;; reverse tape when the differentiated quantity is itself a high-order forward
+;;; derivative computed via the arbitrary-order Taylor tower (`derivative-n`).
+;;;
+;;;   g(v) = d^k/dt^k [ f(t, v) ] |_{t=t0}          (inner: Taylor tower, order k)
+;;;   (gradient (lambda (v) (g v)) v0)              (outer: reverse mode)
+;;;
+;;; Before P5 this returned 0: the tower extraction handed back a bare double
+;;; disconnected from the reverse tape, so the outer gradient saw a constant.
+;;; P5 threads a first-order "seed tangent" alongside the tower value series
+;;; (the tower analogue of the 8-jet's ep-derivative half) and records it on the
+;;; reverse tape through the SAME eshkol_ad_mixed_record hook the order-<=2 jet
+;;; path uses. Correct for k = 2..4, scalar / vector params, and nested tower
+;;; contexts (epoch safety). Runs identically under -r (JIT) and AOT.
+
+(define pass 0)(define fail 0)
+(define (approx= a b) (< (abs (- a b)) 1e-5))
+(define (chk label v)
+  (display "  [")(display (if v "PASS" "FAIL"))(display "] ")(display label)(newline)
+  (if v (set! pass (+ pass 1)) (set! fail (+ fail 1))))
+
+(define v0 0.5)
+(define s   (sin v0))
+(define c   (cos v0))
+
+;; ── Scalar param, k = 2,3,4 : g(v) = d^k/dt^k[sin(v t)]|_{t=1} ───────────
+;; d^k/dt^k sin(v t) = v^k sin(v + k*pi/2); at t=1:
+;;   k=2 -> -v^2 sin v          d/dv = -(2v sin v + v^2 cos v)
+;;   k=3 -> -v^3 cos v          d/dv = -3v^2 cos v + v^3 sin v
+;;   k=4 ->  v^4 sin v          d/dv =  4v^3 sin v + v^4 cos v
+(define (g2 v) (derivative-n (lambda (t) (sin (* v t))) 1.0 2))
+(define (g3 v) (derivative-n (lambda (t) (sin (* v t))) 1.0 3))
+(define (g4 v) (derivative-n (lambda (t) (sin (* v t))) 1.0 4))
+(chk "k=2 scalar grad d2/dt2[sin(v t)]"
+     (approx= (gradient g2 v0) (- (+ (* 2 v0 s) (* v0 v0 c)))))
+(chk "k=3 scalar grad d3/dt3[sin(v t)]"
+     (approx= (gradient g3 v0) (+ (* -3 v0 v0 c) (* v0 v0 v0 s))))
+(chk "k=4 scalar grad d4/dt4[sin(v t)]"
+     (approx= (gradient g4 v0) (+ (* 4 v0 v0 v0 s) (* v0 v0 v0 v0 c))))
+
+;; exp variant, k=2 : g(v) = d2/dt2[exp(v t)]|1 = v^2 exp v ; d/dv = exp(v)(2v+v^2)
+(define (ge v) (derivative-n (lambda (t) (exp (* v t))) 1.0 2))
+(chk "k=2 scalar grad d2/dt2[exp(v t)]"
+     (approx= (gradient ge v0) (* (exp v0) (+ (* 2 v0) (* v0 v0)))))
+
+;; finite-difference cross-check on the k=2 scalar case
+(define h 1e-5)
+(define fd (/ (- (g2 (+ v0 h)) (g2 (- v0 h))) (* 2.0 h)))
+(chk "k=2 scalar grad vs finite-difference" (approx= (gradient g2 v0) fd))
+
+;; ── Tensor param #(...) (reverse-tape path) mirrors the scalar answer ────
+(define (g2t v) (derivative-n (lambda (t) (sin (* (vector-ref v 0) t))) 1.0 2))
+(define rt (gradient g2t #(0.5)))
+(chk "k=2 tensor #(0.5) grad" (approx= (vector-ref rt 0) (- (+ (* 2 v0 s) (* v0 v0 c)))))
+(define rv (gradient g2t (vector 0.5)))
+(chk "k=2 vector (vector 0.5) grad" (approx= (vector-ref rv 0) (- (+ (* 2 v0 s) (* v0 v0 c)))))
+
+;; ── 2-vector : f(t,v) = sin(v0 t) + v1 t^3 ; k=2 ────────────────────────
+;; d2/dt2|1 = -v0^2 sin v0 + 6 v1 ; grad = ( -(2 v0 sin v0 + v0^2 cos v0), 6 )
+(define (gv2 v) (derivative-n (lambda (t)
+   (+ (sin (* (vector-ref v 0) t)) (* (vector-ref v 1) (* t t t)))) 1.0 2))
+(define r2 (gradient gv2 #(0.5 2.0)))
+(chk "2-vec grad[0]" (approx= (vector-ref r2 0) (- (+ (* 2 v0 s) (* v0 v0 c)))))
+(chk "2-vec grad[1] = 6" (approx= (vector-ref r2 1) 6.0))
+;; finite-difference cross-check on each component
+(define (gv2-0 x) (gv2 (vector x 2.0)))
+(define (gv2-1 y) (gv2 (vector 0.5 y)))
+(chk "2-vec grad[0] vs FD" (approx= (vector-ref r2 0)
+     (/ (- (gv2-0 (+ 0.5 h)) (gv2-0 (- 0.5 h))) (* 2.0 h))))
+(chk "2-vec grad[1] vs FD" (approx= (vector-ref r2 1)
+     (/ (- (gv2-1 (+ 2.0 h)) (gv2-1 (- 2.0 h))) (* 2.0 h))))
+
+;; ── 3-vector : f(t,v) = v0 t^2 + v1 sin t + v2 exp t ; k=3 ───────────────
+;; d3/dt3|1 = 0 + v1(-cos 1) + v2 exp 1 ; grad = (0, -cos 1, exp 1)
+(define (gv3 v) (derivative-n (lambda (t)
+   (+ (* (vector-ref v 0) (* t t))
+      (* (vector-ref v 1) (sin t))
+      (* (vector-ref v 2) (exp t)))) 1.0 3))
+(define r3 (gradient gv3 #(1.0 1.0 1.0)))
+(chk "3-vec grad[0] = 0"      (approx= (vector-ref r3 0) 0.0))
+(chk "3-vec grad[1] = -cos 1" (approx= (vector-ref r3 1) (- (cos 1.0))))
+(chk "3-vec grad[2] = exp 1"  (approx= (vector-ref r3 2) (exp 1.0)))
+
+;; ── Epoch safety 1: two sibling derivative-n in one gradient closure ─────
+;; each level has its own tower epoch; the reverse seed must reach BOTH.
+;; g = d2/dt2[sin(v t)]|1 + d3/ds3[exp(v s)]|1 = -v^2 sin v + v^3 exp v
+(define (gsib v) (+ (derivative-n (lambda (t) (sin (* v t))) 1.0 2)
+                    (derivative-n (lambda (s) (exp (* v s))) 1.0 3)))
+(chk "epoch: sibling derivative-n sum"
+     (approx= (gradient gsib v0)
+              (+ (- (+ (* 2 v0 s) (* v0 v0 c)))
+                 (* (exp v0) (+ (* 3 v0 v0) (* v0 v0 v0))))))
+
+;; ── Epoch safety 2: derivative-n nested inside derivative-n ──────────────
+;; inner d2/ds2[sin(v s)]|1 = -v^2 sin v (constant in t); outer d1/dt1[t*inner]|1
+;; = inner. The inner tower's epoch must NOT leak into the outer t-perturbation.
+(define (gnest v) (derivative-n (lambda (t)
+    (* t (derivative-n (lambda (s) (sin (* v s))) 1.0 2))) 1.0 1))
+(chk "epoch: nested derivative-n (no leak)"
+     (approx= (gradient gnest v0) (- (+ (* 2 v0 s) (* v0 v0 c)))))
+
+;; ── Epoch safety 3: an inner tower over an INDEPENDENT variable vanishes ─
+;; g = d2/dt2[ sin(v t) + d1/ds1[cos(w s)]|1 ]|1 ; the inner term is constant in
+;; t and independent of v, so it drops out: g = -v^2 sin v.
+(define w 2.0)
+(define (gindep v) (derivative-n (lambda (t)
+    (+ (sin (* v t)) (derivative-n (lambda (s) (cos (* w s))) 1.0 1))) 1.0 2))
+(chk "epoch: independent inner tower drops out"
+     (approx= (gradient gindep v0) (- (+ (* 2 v0 s) (* v0 v0 c)))))
+
+;; ── Parity witness (scope item 3): reverse-over-nested-forward via the tower
+;; equals the JET8 path for the reverse_nested_forward_test's polynomial style.
+;; f = p0*xx^2 ; d2 = 2 p0 ; grad = 2 — byte-identical to nested `derivative`.
+(define jet8 (gradient (lambda (p) (derivative (lambda (x)
+   (derivative (lambda (xx) (* (vector-ref p 0) (* xx xx))) x)) 2.0)) (vector 3.0)))
+(define twr  (gradient (lambda (p)
+   (derivative-n (lambda (xx) (* (vector-ref p 0) (* xx xx))) 2.0 2)) (vector 3.0)))
+(chk "parity: tower == JET8 (poly, byte-identical)"
+     (= (vector-ref jet8 0) (vector-ref twr 0)))
+
+(newline)
+(display "Passed: ")(display pass)(newline)
+(display "Failed: ")(display fail)(newline)
+(if (= fail 0)
+    (begin (display "PASS: reverse-over-Taylor ")(display pass)
+           (display "/")(display pass)
+           (display " checks (k=2..4, scalar/2-vec/3-vec, epoch safety, JET8 parity)")(newline))
+    (begin (display "FAIL: reverse-over-Taylor ")(display fail)(display " checks failed")(newline)))


### PR DESCRIPTION
## Phase P5 — Reverse-over-Taylor (ESH-0190)

Stacked on **PR #162 (P4 GUW multivariate)**; base branch `feat/ad-taylor-p4-guw-multivariate`.

Makes `gradient` correct when the differentiated function computes a high-order forward derivative internally via the arbitrary-order Taylor tower:

```scheme
(gradient (lambda (v) (derivative-n (lambda (t) (f t v)) t0 k)) v0)   ; k >= 2
```

### Already working vs. what was broken
- **Already working:** the *forward* quantity `(derivative-n (lambda (t) (f t v)) t0 k)` computed the correct value for a fixed `v` (the tower's tagged arithmetic is polymorphic).
- **Broken (returned exactly 0):** wrapping it in `gradient`. The reverse-tape dispatch (`withADBinaryDispatch`) fires before the tower path and converts the tower operand of `t` to a scalar constant AD node — the reverse tape **swallows the tower**, freezing `t`, and the tower extraction returns a bare double disconnected from the tape (the ESH-0117 failure class). The order-≤2 jet path avoids this via `maybeJetLiftTapeOperand`, gated on `__ad_pert_level`, which the tower seed deliberately does not bump.

### Fix (root cause, mirrors the 8-jet ep-derivative half)
A tower may now carry, alongside its value series `c[0..K]`, a first-order **seed-tangent** series `c'[k] = d(c[k])/d(reverse-seed)`, flagged by `ESH_TAYLOR_TANGENT_FLAG` (storage doubles). The seed dimension is orthogonal to the value `EPOCH_TAG` (one active reverse seed per gradient pass), so it always combines while the value series keeps its §5a epoch discipline.
- A reverse-tape AD node is frozen to a dual-tower constant by `towerLiftOperand` (runtime-gated on a new `__ad_tower_active` counter) so the reverse tape can no longer swallow the tower; a forward jet contributes its `e1` as the tangent.
- Each recurrence gains a linearised tangent rule (product/chain) in the same `fma`/ascending-`j` order as the value series (§6a).
- At extraction, `dseed = k!·c'[K]` is recorded through the **same `eshkol_ad_mixed_record` hook** the order-≤2 jet path uses (reused unchanged — `dseed` is scalar-per-call), or returned as a forward jet `{value, dseed·e1}` when no tape is live.
- The order-≤2 jet hot path and the P1/P2 forward tower are **byte-for-byte unchanged** (the dual path fires only under the tangent flag).

### JET8 verdict (scope item 3, design §12a): **NO — deferred, now unblocked**
The capability blocker P3 (ESH-0188) cited ("tower-valued reverse-tape primals/adjoints") is now delivered and **byte-identical** to JET8 (measured bit-equal for polynomial, transcendental, and compound-transcendental nested cases; depth oracle `gofd.poly.v{2,3}.*.vecref` jump baseline 1 → 8). Retirement stays blocked only by the order-≤2 hot-path invariant (JET8 is the order-≤2 reverse-over-forward adapter over the stack JET4 fast path; the test's single-forward depth-1 cases cannot route via `detectPureDerivChain` without sending every first-order `derivative`-in-`gradient` through the heap tower) and P5 scope isolation. Unblocked for a focused order-thresholded dispatch refactor. `reverse_nested_forward_test.esk` stays 11/11 on its existing path; the P5 test carries a parity-witness check.

### Verification (all under `-r` and AOT where applicable)
| Gate | Before | After |
|---|---|---|
| `reverse_over_taylor_test.esk` (new) | — | **18/18** (-r + AOT byte-identical) |
| `reverse_nested_forward_test.esk` | 11/11 | **11/11** |
| `taylor_tower_test.esk` | 52/52 | **52/52** |
| `taylor_tower_mono_test.esk` | 441/441 | **441/441** |
| `guw_multivariate_test.esk` | 35/35 | **35/35** |
| full `tests/ad/` | — | **14/14** |
| `run_ad_depth.sh` | gate PASS | **gate PASS, 0 regressions, 7 improvements** |
| `run_ad_oracle.sh` | 56/56 | **56/56** |
| `run_sicp_smoke.sh` | 88/88 | **88/88** |

New CTest `reverse_over_taylor_runtime_smoke` registered (mirrors `guw_multivariate_runtime_smoke`).
