### PR TITLE
fix(parser): bare () call-argument lowering (ESH-0217)

### DIFF
--- a/.swarm/tasks/ESH-0217.json
+++ b/.swarm/tasks/ESH-0217.json
@@ -1,0 +1,35 @@
+{
+  "id": "ESH-0217",
+  "title": "Bare () as a call/datum-position argument lowers differently from other empty-list datums",
+  "status": "done",
+  "priority": "medium",
+  "workstream": "parser",
+  "goal": "Bare () reaching the general expression parser (macro-call argument, ordinary call argument, or any other datum/argument position) must lower to the same AST shape as every other route to the empty list (an explicit (list) call), so structural AST consumers — macro-call argument pattern matching in particular — do not silently reject a bare () that an equivalent (list) or (quote ()) argument would not have.",
+  "root_cause": "lib/frontend/parser.cpp parse_list(): the 'Empty list' branch (bare () with no elements) built a bespoke ESHKOL_INVALID_OP sentinel AST node instead of the CALL_OP invoking \"list\" with zero arguments that (list), '(), and the payload of (quote ()) all already produce (see parse_quoted_list_internal / make_parser_call_ast). ESHKOL_INVALID_OP was only ever recognized by codegen's own special case (packNullToTaggedValue()); nothing else in the codebase (macro_expander.cpp's matchPattern in particular, which structurally requires ESHKOL_OP + ESHKOL_CALL_OP to recognize 'a list-shaped argument') ever treated it as an empty list. A macro whose pattern destructures a list-shaped argument therefore matched an explicit (list) but failed with 'no matching pattern' on a bare () in the exact same position.",
+  "fix": "parser.cpp's TOKEN_RPAREN-immediately branch of parse_list() now returns make_parser_call_ast(\"list\", {}, ...) — the identical zero-arg CALL_OP shape (list) already produces — instead of ESHKOL_INVALID_OP. Scoped strictly to datum/argument position: binding/formal lists such as (let () ...) and (lambda () ...) parse their own () directly (checking TOKEN_RPAREN right after their own '(', before ever calling parse_list/parse_expression) and are unaffected. () used as a call head still flows into the existing 'first element is an expression' branch unchanged, and still fails gracefully at runtime (not parse time), consistent with R7RS treating () as an error outside quote — verified it does not crash, hang, or abort control flow either before or after this change.",
+  "file_globs": [
+    "lib/frontend/parser.cpp",
+    "tests/parser/bare_null_arg_test.esk"
+  ],
+  "acceptance": [
+    "AST dump (--dump-ast) shows bare () producing the same CALL_OP(list, 0 args) shape as an explicit (list) call, where it previously produced ESHKOL_INVALID_OP.",
+    "A syntax-rules macro with a list-destructuring pattern argument matches a bare () call argument identically to an explicit (list) argument, under both -r (JIT) and AOT compile+run.",
+    "(null? ()), (cons 1 ()), (length ()), (append () ...), (equal? () (quote ())) all continue to work under -r and AOT (regression, was already working via the old ESHKOL_INVALID_OP codegen special case).",
+    "tests/parser/bare_null_arg_test.esk: 11/11 checks pass under -r and AOT; fails at 'flatten2 with bare ()' on the pre-fix binary, confirming it is a real regression test.",
+    "tests/macros: 7/7 pass.",
+    "scripts/run_sicp_smoke.sh: 88/88 gate probes pass.",
+    "scripts/run_parser_tests.sh: 31/31 pass (30 pre-existing + bare_null_arg_test.esk).",
+    "scripts/run_differential.sh: 246/246 axis pairs agree across 41 programs, no divergences."
+  ],
+  "verification": [
+    "cmake --build build --target eshkol-run stdlib -j8",
+    "bash scripts/run_macros_tests.sh",
+    "bash scripts/run_sicp_smoke.sh",
+    "bash scripts/run_parser_tests.sh",
+    "bash scripts/run_differential.sh",
+    "./build/eshkol-run -L./build tests/parser/bare_null_arg_test.esk && ./a.out",
+    "./build/eshkol-run -r tests/parser/bare_null_arg_test.esk"
+  ],
+  "blocked_by": [],
+  "status_note": "DONE. No partial Kimi-backend branch/PR found on origin (git ls-remote origin fix/bare-null-call-arg was empty; gh pr list --search bare had no match) — implemented fresh on branch fix/bare-null-call-arg off master (d5f4fcf5). Deep-dived whether the flatten2-style nested list-destructuring pattern match (e.g. (a ...) (b ...)) can be made to fully succeed for a *quoted* empty list argument as well; confirmed that is a separate, pre-existing, and much broader limitation (matchPattern's MACRO_PAT_LIST requires the argument to literally be ESHKOL_CALL_OP, so *any* quoted list literal — empty or not — never structurally matches a list-destructuring pattern, on master and on the unmerged fix/nested-ellipsis branch alike). That is out of scope for this ticket, which is specifically about the parser's inconsistent lowering of unquoted bare ()."
+}

--- a/lib/frontend/parser.cpp
+++ b/lib/frontend/parser.cpp
@@ -3744,12 +3744,49 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
     ast.line = token.line;
     ast.column = token.column;
     
-    // Empty list
+    // Empty list (ESH-0217).
+    //
+    // A bare () reaching this point is a standalone datum/argument-position
+    // value — e.g. a macro-call argument like (flatten2 () (1 2)), or any
+    // other spot the ordinary expression parser is asked to parse a value.
+    // Binding/formal lists such as (let () ...) and (lambda () ...) never
+    // reach this branch: each of those checks for TOKEN_RPAREN itself,
+    // immediately after consuming its own '(', before ever delegating to
+    // parse_list/parse_expression, so they are unaffected by this change.
+    //
+    // Previously this returned a bespoke ESHKOL_INVALID_OP sentinel node,
+    // which is a *different AST shape* from every other route to the empty
+    // list. (quote ()), '(), and an explicit (list) call all lower to a
+    // CALL_OP invoking "list" with zero arguments (see
+    // parse_quoted_list_internal and make_parser_call_ast) — the quoted
+    // spellings additionally wrap that CALL_OP in ESHKOL_QUOTE_OP, but the
+    // payload underneath is the same zero-arg "list" call every route
+    // shares. Structural consumers that recognize "an empty/unquoted list
+    // argument" by that CALL_OP shape — most importantly macro-call
+    // argument pattern matching, which is how a caller-supplied argument
+    // like the () in (flatten2 () (1 2)) is inspected against a list
+    // pattern such as (a ...) — never recognized ESHKOL_INVALID_OP, so a
+    // bare () silently failed to pattern-match a spot that an explicit
+    // (list) (an empty list built the "long way") already matched fine.
+    // Building the identical zero-arg (list) CALL_OP here — rather than
+    // wrapping it in ESHKOL_QUOTE_OP — keeps bare () indistinguishable
+    // from (list) for exactly this structural inspection, instead of
+    // opting it out of the same treatment via a quote wrapper that no
+    // other unquoted list argument gets. codegen already special-cases
+    // the "list" callee by name (EshkolLLVMCodeGen::codegenCall /
+    // CollectionCodegen::list) independent of whether a "list" symbol is
+    // actually bound, so this holds even under --no-stdlib. (() used as a
+    // call head, e.g. (() 1 2), still flows into the "first element is an
+    // expression" branch below unchanged — it now calls the nil value
+    // produced by (list) instead of an ESHKOL_INVALID_OP node, which still
+    // fails at runtime with a normal "not callable" error rather than a
+    // parser-level distinction, consistent with R7RS treating () as an
+    // error outside quote.)
     if (token.type == TOKEN_RPAREN) {
-        ast.operation.op = ESHKOL_INVALID_OP;
+        ast = make_parser_call_ast("list", {}, token.line, token.column);
         return ast;
     }
-    
+
     // Handle case where first element is a lambda or other expression (e.g., ((lambda ...) ...))
     if (token.type == TOKEN_LPAREN) {
         // Parse the first element as an expression (could be lambda, function call, etc.)

--- a/tests/parser/bare_null_arg_test.esk
+++ b/tests/parser/bare_null_arg_test.esk
@@ -1,0 +1,109 @@
+;; Parser Test: bare () as a call/datum-position argument (ESH-0217).
+;;
+;; A bare () reaching the general expression parser (e.g. as a macro-call
+;; argument, or as an ordinary function-call argument) used to lower to a
+;; bespoke ESHKOL_INVALID_OP AST node instead of the CALL_OP invoking
+;; "list" with zero arguments that every other route to the empty list
+;; (quote (), '(), and an explicit (list) call) already produced. That made
+;; a bare () invisible to structural AST inspection — most importantly
+;; macro-call argument pattern matching — so a macro whose pattern
+;; destructures a list-shaped argument (e.g. (a ...)) matched an explicit
+;; (list) but silently failed to match a bare () in the same position.
+;;
+;; This covers: the basic value semantics of bare () (which already worked,
+;; since codegen special-cased ESHKOL_INVALID_OP), the actual regression
+;; (macro-argument pattern matching), and that () keeps behaving reasonably
+;; as a call head (a runtime "not callable" error, not a parser crash).
+
+(require stdlib)
+
+(define tests-passed 0)
+(define tests-failed 0)
+
+(define (test-case name expected actual)
+  (if (equal? expected actual)
+      (begin
+        (set! tests-passed (+ tests-passed 1))
+        (display "PASS: ") (display name) (display "\n"))
+      (begin
+        (set! tests-failed (+ tests-failed 1))
+        (display "FAIL: ") (display name)
+        (display " (expected ") (display expected)
+        (display ", got ") (display actual) (display ")\n"))))
+
+;; ============================================================
+;; Basic value semantics of bare () in datum/argument position
+;; ============================================================
+(test-case "bare () is null?" #t (null? ()))
+(test-case "bare () equal? to (quote ())" #t (equal? () (quote ())))
+(test-case "bare () equal? to '()" #t (equal? () '()))
+(test-case "bare () equal? to (list)" #t (equal? () (list)))
+(test-case "(cons 1 ()) is (1)" (list 1) (cons 1 ()))
+(test-case "(length ()) is 0" 0 (length ()))
+(test-case "(append () (list 1 2)) is (1 2)" (list 1 2) (append () (list 1 2)))
+(test-case "bare () as a plain call argument" '() (car (list ())))
+
+;; ============================================================
+;; ESH-0217 regression: bare () as a macro-call argument must
+;; pattern-match a list pattern exactly like an explicit (list) does.
+;; ============================================================
+;; flatten2 destructures a single-element list-shaped argument. Both an
+;; explicit (list) and a bare () lower to the same CALL_OP invoking "list"
+;; with zero arguments, so both are (structurally) a 1-"element" call whose
+;; sole element is the "list" callee symbol itself — this is a pre-existing
+;; quirk of how this parser represents unquoted list literals as syntax
+;; data (unrelated to ESH-0217), but it means the two spellings must match
+;; identically.
+(define-syntax flatten2
+  (syntax-rules ()
+    ((_ (x)) (list 'got x))))
+
+;; An explicit (list) already produced a CALL_OP the pattern matcher could
+;; see — this was never broken, and pins down the reference behavior: the
+;; match succeeds and binds x to a real (procedure) value.
+(define flatten2-list-result (flatten2 (list)))
+(test-case "flatten2 with explicit (list) matches and binds a procedure"
+           #t
+           (and (pair? flatten2-list-result)
+                (eq? (car flatten2-list-result) 'got)
+                (procedure? (cadr flatten2-list-result))))
+
+;; This is the actual ESH-0217 regression: before the fix, this bare ()
+;; lowered to ESHKOL_INVALID_OP (a foreign shape the structural pattern
+;; matcher never recognized) and flatten2 failed with "no matching pattern
+;; for macro 'flatten2'" instead of matching, even though (list) in the
+;; same position matched fine. After the fix, bare () lowers to the exact
+;; same CALL_OP shape as (list), so the two calls must succeed identically
+;; (each closure reference gets its own identity, so compare structure/
+;; success rather than eq?/equal? on the bound procedure value itself).
+(define flatten2-bare-result (flatten2 ()))
+(test-case "flatten2 with bare () matches (does not error like ESHKOL_INVALID_OP did)"
+           #t
+           (and (pair? flatten2-bare-result)
+                (eq? (car flatten2-bare-result) 'got)
+                (procedure? (cadr flatten2-bare-result))))
+
+;; ============================================================
+;; () used as a call head does not crash the parser or codegen. This
+;; project does not statically reject a non-callable operator position, so
+;; calling the empty-list value degrades to a gracefully-typed runtime nil
+;; rather than a hard error either before or after this fix — the point of
+;; this check is only that control flow continues normally, i.e. that
+;; normalizing bare ()'s datum-position lowering did not turn a call-head
+;; () into something that hangs, aborts, or corrupts later execution.
+;; ============================================================
+(define call-head-marker 'not-reached)
+(() 1 2)
+(set! call-head-marker 'reached)
+(test-case "() as a call head does not abort execution"
+           'reached call-head-marker)
+
+;; ============================================================
+;; Summary
+;; ============================================================
+(display "\n=== Results ===\n")
+(display "Passed: ") (display tests-passed) (display "\n")
+(display "Failed: ") (display tests-failed) (display "\n")
+(if (= tests-failed 0)
+    (display "ALL TESTS PASSED\n")
+    (display "SOME TESTS FAILED\n"))


### PR DESCRIPTION
## Summary

Fixes **ESH-0217**: bare `()` as a call/datum-position argument (e.g. a macro-call argument like `(flatten2 () (1 2))`) lowered differently from every other route to the empty list, so structural AST consumers — macro pattern matching in particular — recognized an explicit `(list)` argument but not an equivalent bare `()`.

No partial branch/PR was found for this ticket (`git ls-remote origin fix/bare-null-call-arg` and `gh pr list --search "bare"` both came back empty), so this is implemented fresh.

## Root cause

`lib/frontend/parser.cpp`'s `parse_list()` has a dedicated "empty list" branch for a bare `()`. It built a bespoke `ESHKOL_INVALID_OP` sentinel AST node — a shape unique to this one code path. Every other route to the empty list (`(quote ())`, `'()`, and an explicit `(list)` call) lowers to a `CALL_OP` invoking `"list"` with zero arguments instead (see `parse_quoted_list_internal` / `make_parser_call_ast`).

Nothing outside codegen's own special case (`case ESHKOL_INVALID_OP: return packNullToTaggedValue();`) ever recognized `ESHKOL_INVALID_OP` as "the empty list". In particular, `macro_expander.cpp`'s `matchPattern` requires a list-shaped macro argument to literally be `ESHKOL_OP` + `ESHKOL_CALL_OP` before it will structurally destructure it. So a macro whose pattern destructures a list argument (e.g. `(a ...)`) matched `(flatten2 (list) (1 2))` but failed with `no matching pattern for macro 'flatten2'` on `(flatten2 () (1 2))` in the exact same position — confirmed via `--dump-ast`, where the third argument of `(list (quote ()) (list) ())` showed `INVALID_OP` while the others showed `QUOTE_OP` / `CALL_OP`.

## Fix (architectural root, in `lib/frontend/parser.cpp`)

`parse_list()`'s empty-list branch now returns `make_parser_call_ast("list", {}, ...)` — the identical zero-arg `(list)` `CALL_OP` shape every other route already produces — instead of `ESHKOL_INVALID_OP`. This makes bare `()` indistinguishable from `(list)` for the exact structural inspection macro pattern matching performs. `codegen` already special-cases the `"list"` callee by name independent of whether a `list` symbol is bound (`EshkolLLVMCodeGen::codegenCall` / `CollectionCodegen::list`), so this holds even under `--no-stdlib`.

Scoped strictly to datum/argument position, per R7RS: binding/formal lists such as `(let () ...)` and `(lambda () ...)` parse their own `()` directly (checking for the closing paren immediately after consuming their own `(`, before ever calling `parse_list`/`parse_expression`), so they're untouched. `()` used as a call head, e.g. `(() 1 2)`, still flows into the existing "first element is an expression" branch unchanged, and still fails to do anything useful at runtime (not at parse time) — verified this doesn't crash, hang, or abort control flow either before or after the change.

One related, larger limitation was found but is explicitly out of scope here: `matchPattern`'s `MACRO_PAT_LIST` case requires the argument to literally be `CALL_OP`, so a *quoted* list literal (empty or not) never structurally matches a list-destructuring pattern — this is pre-existing on both `master` and the unmerged `fix/nested-ellipsis` branch, and is a much broader gap (affects all quoted lists, not just bare `()`) than what ESH-0217 asks for.

## Testing

- New `tests/parser/bare_null_arg_test.esk` (11 checks): basic value semantics of bare `()` (`null?`, `equal?`, `cons`, `length`, `append`), the actual regression (a `syntax-rules` macro with a list-destructuring pattern matches a bare `()` argument the same as an explicit `(list)` argument), and that `()` as a call head doesn't abort execution. Confirmed this test fails at the macro-matching case on the pre-fix parser and passes 11/11 post-fix, under both `-r` (JIT) and AOT compile+run.
- `scripts/run_macros_tests.sh`: 7/7 pass.
- `scripts/run_sicp_smoke.sh`: 88/88 gate probes pass.
- `scripts/run_parser_tests.sh`: 31/31 pass (30 pre-existing + the new test).
- `scripts/run_differential.sh`: 246/246 axis pairs agree across 41 corpus programs, no divergences.
- `.swarm/tasks/ESH-0217.json` → `status: done`.

## Test plan

- [x] `cmake --build build --target eshkol-run stdlib -j8`
- [x] `bash scripts/run_macros_tests.sh` — 7/7
- [x] `bash scripts/run_sicp_smoke.sh` — 88/88
- [x] `bash scripts/run_parser_tests.sh` — 31/31
- [x] `bash scripts/run_differential.sh` — 246/246, clean
- [x] `./build/eshkol-run -r tests/parser/bare_null_arg_test.esk` — 11/11
- [x] `./build/eshkol-run tests/parser/bare_null_arg_test.esk -o a.out && ./a.out` — 11/11