### PR TITLE
fix(tco): tail calls through guard — flat long-running loops with per-iteration error boundaries (ESH-0222)

### DIFF
--- a/.swarm/tasks/ESH-0222.json
+++ b/.swarm/tasks/ESH-0222.json
@@ -1,0 +1,41 @@
+{
+  "id": "ESH-0222",
+  "title": "Tail calls through `guard` grow the stack — resident/daemon tick loops with a per-iteration error boundary stack-overflow",
+  "status": "done",
+  "priority": "high",
+  "workstream": "language/tco-guard",
+  "goal": "Selene's compiled long-running resident (a tail-recursive tick loop whose body is wrapped in a per-tick `guard` error boundary) SIGSEGV'd with 'stack overflow' every ~45-75min of live idle cadence (seconds under fast foreground cadence). Determine whether Eshkol's `guard` preserves tail position for self-calls in its protected body / handler clauses, fix the root cause, and document a canonical flat long-running-loop-with-guard pattern.",
+  "root_cause": [
+    "TWO independent, compounding bugs, both stemming from `guard` being invisible to the tail-call analyses used by BOTH TCO entry points:",
+    "(1) Top-level `(define (loop ...) ...)` self-tail-recursion (isSelfTailRecursive -> countAllRecursiveCalls/findTailCalls/isInTailPosition, lib/backend/llvm_codegen.cpp): these three helpers had NO case for ESHKOL_GUARD_OP and fell to `default: break`/`default: return false`. A self-call textually inside a guard's body or handler clause was therefore COMPLETELY INVISIBLE to the recursion counter. For a loop whose ONLY recursive calls live inside a guard (Selene's exact shape), total_recursive_calls came out as 0, isSelfTailRecursive() returned false, and TCO was silently DISABLED — the loop compiled to real, unbounded recursive calls, one native stack frame per tick, forever.",
+    "(2) Named-let TCO (areAllSelfCallsInTailPosition -> allSelfCallsInTailPosition, lib/backend/tail_call_codegen.cpp): the OPPOSITE lie — GUARD_OP fell to `default: return true`, claiming any self-call buried in a guard was tail-safe WITHOUT looking. When (accidentally) correct, TCO got enabled, but the codegen mechanism itself was unsound for that case: (a) codegenGuard's jmp_buf is allocated via a dynamically-sized `alloca` (allocaJmpBuf, size from a runtime call, not a compile-time constant) inside the loop's basic-block body; LLVM cannot hoist/reuse a dynamic alloca across iterations of a hand-rolled branch-based loop, so every iteration through `guard` permanently lowers the stack pointer a little more (never reclaimed) until the native stack overflows. (b) codegenTailCallFromContext's tail-call shortcut (an unconditional `br` back to the loop header) bypassed codegenGuard's own post-body eshkol_pop_exception_handler() call (only emitted when the body's block is NOT already terminated), leaving the runtime handler chain (g_exception_handler_stack) growing by one unbalanced node per iteration and retaining a stale jmp_buf pointer into stack memory that would otherwise be reclaimed."
+  ],
+  "fix": [
+    "lib/backend/tail_call_codegen.cpp: add an honest ESHKOL_GUARD_OP case to allSelfCallsInTailPosition — guard's protected body (parser-normalized to a single node, body[0]) inherits the guard form's own tail position; each handler clause's LAST body expression is tail, its test and earlier expressions are not (mirrors the existing ESHKOL_COND_OP case). No more silent 'assume safe'.",
+    "lib/backend/llvm_codegen.cpp: same honesty fix for the top-level-define path across three mutually-consistent helpers — countAllRecursiveCalls, findTailCalls, and isInTailPosition each gained an ESHKOL_GUARD_OP case that recurses into guard's body[0] and handler-clause bodies instead of silently treating guard as opaque/absent.",
+    "inc/eshkol/backend/binding_codegen.h: TailCallContext gained two fields — `unsigned open_guard_handlers` and `llvm::Value* loop_stack_save` — with a long comment explaining both leaks.",
+    "lib/backend/llvm_codegen.cpp codegenGuard: snapshot `open_guard_handlers` on entry (`guard_open_before`), increment right after eshkol_push_exception_handler(), and unconditionally restore to the baseline right after the (always-emitted) handler_block's own eshkol_pop_exception_handler() call — the single normalization point that covers every exit from a guard (normal completion, caught exception, uncaught re-raise, and a TCO tail-call branch out of the body).",
+    "lib/backend/llvm_codegen.cpp codegenTailCallFromContext: before emitting the back-edge branch, drain `open_guard_handlers` (emit that many eshkol_pop_exception_handler() calls, reset to 0) so the runtime handler chain never grows across iterations; then, if `loop_stack_save` is set, call `llvm.stackrestore` on it to reclaim any dynamic-alloca stack space (guard's jmp_buf, or any future dynamic-alloca construct) consumed during that iteration.",
+    "All three TCO loop-header setup sites (top-level define ~line 10761, lambda-binding ~line 25987, named-let ~line 27285) now capture `llvm.stacksave()` into `loop_stack_save` and reset `open_guard_handlers = 0` right after entering the loop header block — the reset is deliberately scoped to THIS loop so an enclosing guard opened OUTSIDE the loop (once, for its whole lifetime) is untouched by per-iteration draining. Named-let's existing nested-TCO save/restore block was extended to save/restore the two new fields alongside the pre-existing ones.",
+    "Left `apply` as a known, documented, SEPARATE gap: call_apply_codegen.cpp never consults TailCallContext/isTCOActive, so `(apply loop lst)` is always a genuine non-tail call. Not fixed here (real feature work, not this bug); the canonical pattern doc steers users away from `apply` for the loop back-edge instead."
+  ],
+  "acceptance": [
+    "tests/tco/guard_loop_tail_test.esk: shape (a) top-level define with self-calls in BOTH guard-body-tail and handler-clause-tail position at N=1,000,000 — PASS, correctness verified against a guard-free reference loop, RSS ~45MB / peak footprint ~22MB, 0.5s (was: unbounded real recursion, would have overflowed the 64MB native stack cap well before 1e6 ticks pre-fix).",
+    "Shape (b) guard wraps only the fallible section and returns a value, loop call genuinely outside guard's dynamic extent, N=1,000,000 — PASS (this shape was already safe pre-fix; included as the canonical always-safe baseline).",
+    "Shape (a') named-let variant of shape (a), capped at N=50,000 (see ESH-0223 — a SEPARATE, pre-existing, guard-unrelated named-let TCO stack bug blocks proving flatness at 1e6 for named-let specifically) — PASS.",
+    "Shape (c) `(apply loop lst)`, capped at N=20,000, correctness-only (apply is not TCO'd — documented, not fixed) — PASS.",
+    "Full build clean (cmake --build build --target eshkol-run stdlib -j8, zero new warnings from the changed files).",
+    "TCO suite / SICP 88/88 / exception+guard suites / AD oracle 56/56 re-verified after the change (see verifications)."
+  ],
+  "blocked_by": [],
+  "campaign_payoff": "guard-wrapped per-iteration error boundaries around a tail-recursive loop are the natural, idiomatic way to write a resilient long-running daemon/resident/agent tick loop in Eshkol. Before this fix that pattern was a silent stack-overflow trap (either via disabled TCO for plain define loops, or via a leaking dynamic alloca + unbalanced handler stack for named-let loops) with no diagnostic beyond a generic SIGSEGV. Selene's noesis resident is the first production consumer; the fix + docs/LONG_RUNNING_LOOPS.md make the pattern a documented, tested, supported part of the language rather than an accidental crash-every-hour behavior.",
+  "repro": "tests/tco/guard_loop_tail_test.esk",
+  "verifications": [
+    {
+      "date": "2026-07-06",
+      "branch": "fix/guard-tail-position",
+      "verdict": "fixed",
+      "evidence": "tests/tco/guard_loop_tail_test.esk 4/4 shapes PASS (correctness verified against guard-free reference loops). Shape (a) (Selene's exact top-level-define pattern) flat at N=1e6: RSS ~45MB, peak footprint ~22MB, 0.5s wall — no stack growth, no crash. Pre-fix, the identical pattern hit isSelfTailRecursive()'s total_recursive_calls==0 short-circuit and fell back to unbounded real recursion. See ESH-0223 for the separate pre-existing named-let-without-guard stack bug discovered during this investigation (does not affect define-based loops; Selene's actual code is define-based)."
+    }
+  ]
+}

--- a/.swarm/tasks/ESH-0223.json
+++ b/.swarm/tasks/ESH-0223.json
@@ -1,0 +1,17 @@
+{
+  "id": "ESH-0223",
+  "title": "named-let TCO loop overflows the native stack around n~300-500k even with NO guard/call-cc/dynamic-alloca construct in the body",
+  "status": "open",
+  "priority": "high",
+  "workstream": "language/tco",
+  "goal": "Discovered while reproducing ESH-0222 (tail calls through guard). A completely plain named-let tail loop — `(define (f) (let loop ((n 0)) (if (>= n N) n (loop (+ n 1)))))` — SIGSEGVs/SIGBUSes with the 'stack overflow' diagnostic somewhere between N=300,000 and N=500,000 on unmodified master (verified both before and independent of the ESH-0222 guard fix; a top-level `(define (f n) (if (>= n N) n (f (+ n 1))))` with the identical arithmetic does NOT crash at N=1,000,000+). This means named-let TCO is NOT actually flat today for any sufficiently long-running loop, regardless of guard usage.",
+  "root_cause": "NOT YET DIAGNOSED — out of scope for ESH-0222's time budget, filed here as a clean follow-up. Candidate hypotheses to check first: (1) does `all_tail` (areAllSelfCallsInTailPosition) actually evaluate true for this trivial shape, i.e. is codegenTailCallFromContext's `br` back-edge actually being taken at runtime, or is the self-call falling through to a genuine recursive `CreateCall` for some named-let-specific reason (e.g. a function-table/symbol-table lookup race between the loop's own name and the enclosing define, or the loop_func not being found as 'the active TCO function' by isTCOActive() for some param-count-independent reason)? (2) if TCO IS engaging, is there some OTHER per-iteration dynamic/growing allocation in the named-let loop-header/body path unrelated to guard (e.g. capture-pointer handling, arena-moved-captures bookkeeping, or something in the parameter alloca setup) that isn't a `guard`-specific dynamic alloca but still grows unboundedly per textual loop-header re-entry? Bisect with a debug build (ESHKOL_DEBUG output around 'TCO: named let ... all-tail=' in llvm_codegen.cpp) to settle (1) first — that's the fast, cheap check.",
+  "fix": [],
+  "acceptance": [
+    "A plain named-let tail loop with zero guard/call-cc/dynamic-alloca constructs runs flat (O(1) stack, bounded RSS) to at least N=10,000,000, matching the existing top-level-define TCO guarantee (tests/stress/rec_tco_1e8.esk already proves this for define-based loops).",
+    "tests/tco/guard_loop_tail_test.esk's shape (a') NL_N cap can be raised back to 1,000,000 once this is fixed (currently capped at 50,000 to avoid tripping this unrelated bug — see that test's comment and ESH-0222's ledger entry)."
+  ],
+  "blocked_by": [],
+  "campaign_payoff": "named-let is one of the two syntactic forms Eshkol offers for writing a tail-recursive loop (the other being top-level define); if it silently can't sustain more than a few hundred thousand iterations regardless of body content, that's a hard ceiling on a common, idiomatic Scheme looping construct with no diagnostic pointing at the real cause (it reports as a generic stack-overflow, indistinguishable from genuine unbounded recursion).",
+  "repro": "(define N 500000) (define (f) (let loop ((n 0)) (if (>= n N) n (loop (+ n 1))))) (display (f))  -- crashes with 'fatal signal: SIGBUS ... this is most likely a stack overflow' on unmodified master (verified 2026-07-06, both before and after the ESH-0222 guard-tail-position fix landed; the guard fix neither causes nor cures this)."
+}

--- a/docs/LONG_RUNNING_LOOPS.md
+++ b/docs/LONG_RUNNING_LOOPS.md
@@ -1,0 +1,194 @@
+# Long-running loops with a per-iteration error boundary
+
+This document is the canonical reference for writing a tail-recursive loop
+that runs indefinitely (a resident process, a daemon, an agent's tick loop)
+and wants to catch and recover from per-iteration errors without crashing
+the whole process or leaking stack/heap over time. It grew out of ESH-0222
+("tail calls through `guard` grow the stack"), filed after a compiled
+long-running resident stack-overflowed every 45-75 minutes.
+
+## TL;DR — the canonical pattern
+
+```scheme
+(define (resident-loop tick state)
+  (if (>= tick max-ticks)
+      state
+      (let ((next-state
+              (guard (e (#t (log-stumble! e) state))   ; guard wraps ONLY the
+                (run-one-tick! state))))                ; fallible section
+        (resident-loop (+ tick 1) next-state))))         ; loop call OUTSIDE guard
+```
+
+- `guard` wraps **only** the fallible computation and evaluates to a value.
+- The recursive loop call is **outside** `guard`'s dynamic extent, in the
+  tail position of the enclosing `let`.
+- State is threaded as a single value (or a small record — see below), not
+  reconstructed by consing a fresh list every iteration.
+
+This shape was already safe before ESH-0222 and remains the recommended
+default. The rest of this document explains why, what else is now *also*
+safe after the ESH-0222 fix, and what to avoid.
+
+## Q1: Does `guard` preserve tail position for its body?
+
+R7RS does not require it to — a `guard` form's protected body is not
+inherently a tail context, because conceptually the exception handler must
+stay installed while the body runs. Eshkol special-cases self-recursive
+tail calls textually inside a `guard`'s protected body or handler clauses
+so they *can* compile to a genuine loop back-edge instead of a real call —
+but two related bugs meant this either didn't happen (TCO silently
+disabled) or happened unsoundly (TCO enabled but leaking) before ESH-0222:
+
+1. **Top-level `(define (f ...) ...)` self-tail-recursion** used a family
+   of helpers (`isSelfTailRecursive` → `countAllRecursiveCalls` /
+   `findTailCalls` / `isInTailPosition`, in `lib/backend/llvm_codegen.cpp`)
+   that had **no case for `guard`** and silently skipped over it. A
+   function whose *only* recursive calls live inside a `guard` (exactly
+   the shape below) had those calls become invisible to the recursion
+   counter — `total_recursive_calls` came out as 0, so the compiler
+   concluded "no recursion at all" and never even attempted TCO. The loop
+   then ran as real, unbounded recursion — one native stack frame per
+   iteration, forever:
+
+   ```scheme
+   (define (loop tick state)
+     (if (>= tick max-ticks)
+         state
+         (guard (e (#t (loop (+ tick 1) (on-error state e))))  ; handler tail-recurses
+           (run-one-tick! state)
+           (loop (+ tick 1) (updated state)))))                 ; body tail-recurses
+   ```
+
+2. **Named-let TCO** used a separate analysis
+   (`allSelfCallsInTailPosition` in `lib/backend/tail_call_codegen.cpp`)
+   that had the *opposite* bug: it silently assumed any self-call inside a
+   `guard` was tail-safe without checking. When that assumption happened
+   to be true, TCO got enabled — but the code generator itself wasn't
+   sound for it: `guard`'s `setjmp` buffer is a **dynamically-sized**
+   `alloca` (its size comes from a runtime call, not a compile-time
+   constant), so LLVM cannot hoist or reuse it across iterations of a
+   hand-rolled branch-based loop. Every iteration through `guard`
+   permanently consumed a little more native stack — never reclaimed,
+   because the loop never returns — until the process overflowed. On top
+   of that, the compiler's tail-call shortcut (an unconditional branch
+   back to the loop header) bypassed the exception handler's own cleanup
+   code, so the runtime's handler chain also grew by one unpopped entry
+   per iteration.
+
+**Both are fixed as of ESH-0222.** The tail-position analyses are now
+honest about `guard` (they actually look inside it, in both directions),
+and the code generator reclaims the per-iteration stack space
+(`llvm.stacksave`/`stackrestore` bracket the loop's back-edge) and rebalances
+the exception-handler push/pop across the shortcut branch. Concretely, this
+means the pattern from bug (1) above — recursion in **both** the guard
+body's tail position and a handler clause's tail position — now compiles
+to a flat loop:
+
+```scheme
+(define (loop tick state)
+  (if (>= tick max-ticks)
+      state
+      (guard (e (#t (loop (+ tick 1) (on-error state e))))
+        (run-one-tick! state)
+        (loop (+ tick 1) (updated state)))))
+```
+
+Verified flat at 1,000,000 ticks (top-level `define` form): ~45MB RSS,
+~22MB peak footprint, well under half a second. See
+`tests/tco/guard_loop_tail_test.esk`.
+
+**Caveat — named-let specifically:** a separate, pre-existing bug
+(ESH-0223, discovered while verifying this fix) means named-let tail loops
+overflow the stack somewhere around 300-500k iterations **regardless of
+whether `guard` is involved at all** — even `(let loop ((n 0)) (if (>= n N)
+n (loop (+ n 1))))` with zero `guard` usage hits it. If you need a loop
+that runs well past that count, prefer a **top-level `define`** (as in the
+canonical pattern above) until ESH-0223 is resolved; `define`-based
+tail-recursive loops are independently verified flat past 10^8 iterations
+(`tests/stress/rec_tco_1e8.esk`).
+
+Either way, **the flat-outside-guard pattern at the top of this document
+remains the recommended default** regardless of which bug is or isn't
+fixed on a given build — it never depended on either.
+
+## Q2: What per-iteration-error-handling loop structure is provably tail-optimized?
+
+In order of preference:
+
+1. **`guard` wraps only the fallible section; the loop call is outside it**
+   (the canonical pattern above). Never relies on the guard-tail-call
+   mechanism at all — `guard` here is just an ordinary expression that
+   produces a value, no different from any other subexpression the loop's
+   tail call depends on. This is unaffected by ESH-0222 or ESH-0223 and is
+   the pattern to reach for first.
+
+2. **Self-calls in guard-body-tail and/or handler-clause-tail position**
+   (the pattern ESH-0222 fixes) — use this when the error boundary
+   genuinely needs to wrap the recursive step itself (e.g. different
+   recovery logic depending on *where* in the tick the error occurred).
+   Prefer a top-level `define` over a named-let per the ESH-0223 caveat
+   above.
+
+**Threading state without consing:** prefer a single accumulator value, or
+a small `define-record-type` instance passed by reference, over
+reconstructing a fresh list every iteration. Consing a new list per
+iteration is extra per-tick allocation for no benefit — the arena reclaims
+it at the same rate either way, but a record/scalar avoids the allocation
+and the cons-traversal entirely. This project's automatic per-iteration
+arena-scope reclamation work (ESH-0214/ESH-0214b, `fix/loop-arena-reclamation`,
+not yet merged as of this writing) is complementary: once merged, it
+further bounds RSS for named-let loops whose static shape qualifies for
+automatic per-iteration scoping, independent of whether guard is used.
+`guard`/`call/cc` bodies are expected to be on that feature's rejection
+list for automatic scoping (their handler/continuation state must survive
+past a naive iteration boundary), so the flat-outside-guard pattern remains
+the most robust choice even after that feature lands.
+
+## Q3: Is `(apply loop lst)` a proper tail call?
+
+**No.** `call_apply_codegen.cpp` never consults the tail-call-optimization
+context (`isTCOActive`/`TailCallContext`) — every `apply` call, self-recursive
+or not, compiles to a genuine (non-tail) LLVM `call`. Using `apply` for a
+loop's back-edge will grow the native call stack by one frame per
+iteration no matter what the target function's body looks like. This is a
+distinct, currently-unfixed gap (tracked separately; not part of
+ESH-0222), not a special case of the guard bug — it reproduces identically
+with or without `guard` in the loop body.
+
+**Do not use `(apply loop next-args)` as a long-running loop's back-edge.**
+Call the loop function directly with its arguments spelled out
+(`(loop (+ tick 1) new-state)`), which does participate in TCO. If the
+argument list's arity is only known at runtime, thread a single record or
+vector instead of relying on `apply` to spread a list.
+
+(A prior attempt to work around ESH-0222 by moving the recursive call
+outside `guard` via `(apply loop (list ...))` ballooned RSS from 0.6GB to
+3GB in about a minute and crashed — consistent with this: every iteration
+made a real, non-tail `apply` call, and the per-iteration `(list ...)`
+allocation was never reclaimed because the surrounding recursion was never
+flat to begin with.)
+
+## Q4: Is there a stack-size stopgap?
+
+Yes — `ESHKOL_STACK_SIZE` (bytes, minimum 1MB) raises the process's
+`RLIMIT_STACK` soft limit at startup (`eshkol_init_stack_size()`,
+`lib/core/runtime_stack_hosted.cpp`). The default is 512MB. This is a
+**stopgap, not a fix**: it linearly extends how long an unbounded-growth
+loop survives before overflowing, it does not make the loop flat. Note
+also that the OS hard limit (`ulimit -Hs`) caps how far this can actually
+go — e.g. 64MB is a common macOS default hard limit, well under Eshkol's
+512MB *request*, so `setrlimit` silently clamps to whatever the hard limit
+allows. Don't rely on this for a process that's supposed to run
+indefinitely; use the canonical pattern above instead.
+
+## See also
+
+- `tests/tco/guard_loop_tail_test.esk` — the regression test for this
+  document's shapes.
+- `.swarm/tasks/ESH-0222.json` — the guard-tail-position fix.
+- `.swarm/tasks/ESH-0223.json` — the separate, still-open named-let stack
+  bug referenced in the caveat above.
+- `docs/KNOWN_ISSUES.md` — "Arena memory (OALR) instead of garbage
+  collection": Eshkol has no tracing/stop-the-world collector, so a
+  long-running loop's memory behavior is governed entirely by arena
+  growth (page pressure), not GC pauses.

--- a/inc/eshkol/backend/binding_codegen.h
+++ b/inc/eshkol/backend/binding_codegen.h
@@ -290,6 +290,42 @@ public:
                                               // per-iteration arena scope; the TCO
                                               // back edge must end it (pop/commit)
                                               // before jumping to the loop header
+
+        // --- ESH-0222: tail calls through `guard` inside a TCO loop ---
+        //
+        // A self-call that textually appears inside a `guard`'s protected body
+        // (in tail position) or one of its handler clauses (also tail position)
+        // gets rewritten by codegenTailCallFromContext into an unconditional
+        // branch back to `loop_header`, bypassing whatever cleanup code
+        // codegenGuard would otherwise have emitted after a *normal* return
+        // from the body. Two kinds of per-iteration state must be reclaimed
+        // before that branch, or they leak once per loop iteration:
+        //
+        //  1. `open_guard_handlers` — the number of
+        //     eshkol_push_exception_handler() calls, made within the CURRENT
+        //     loop body since `loop_header` was entered, that have not yet
+        //     been balanced by a compile-time-emitted
+        //     eshkol_pop_exception_handler() along this control-flow path.
+        //     codegenGuard saves/restores this around its own body exactly
+        //     like a stack; codegenTailCallFromContext drains it (emitting
+        //     that many pops) immediately before branching back, so the
+        //     runtime handler chain (g_exception_handler_stack) never grows
+        //     across iterations and never retains a stale jmp_buf pointer.
+        //
+        //  2. `loop_stack_save` — the result of `llvm.stacksave()` captured
+        //     right after entering `loop_header`. guard's jmp_buf is a
+        //     dynamically-sized `alloca` (its size comes from a runtime call,
+        //     not a compile-time constant), so LLVM cannot hoist or reuse it
+        //     across iterations of a hand-rolled branch-based loop the way it
+        //     would for a real recursive call's stack frame. Without an
+        //     explicit `llvm.stackrestore(loop_stack_save)` before the
+        //     back-edge, every iteration that passes through `guard` (or any
+        //     other dynamic-alloca construct) permanently consumes more of
+        //     the native stack until it overflows — this is the direct cause
+        //     of the "stack overflow" SIGSEGV in long-running tick loops that
+        //     wrap each iteration in a per-iteration `guard` error boundary.
+        unsigned open_guard_handlers = 0;
+        llvm::Value* loop_stack_save = nullptr;
     };
 
     /**

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -10841,6 +10841,17 @@ private:
             // Branch to loop header
             builder->CreateBr(tco_loop_bb);
             builder->SetInsertPoint(tco_loop_bb);
+
+            // ESH-0222: see TailCallContext::loop_stack_save /
+            // open_guard_handlers (binding_codegen.h) for the full
+            // rationale — this reclaims per-iteration dynamic stack
+            // allocations (e.g. guard's jmp_buf) and resets the
+            // per-iteration handler-push counter for this fresh loop.
+            {
+                Function* stacksave_fn = ESHKOL_GET_INTRINSIC(module.get(), Intrinsic::stacksave, {builder->getPtrTy()});
+                tco_ctx.loop_stack_save = builder->CreateCall(stacksave_fn, {}, "tco_loop_sp");
+            }
+            tco_ctx.open_guard_handlers = 0;
         }
 
         // ASSIGNMENT CONVERSION (ESH-0074): box set!-mutated parameters.
@@ -20527,6 +20538,17 @@ private:
         }
         Function* current_func = builder->GetInsertBlock()->getParent();
 
+        // ESH-0222: snapshot how many exception handlers are currently
+        // "open" (pushed, not yet matched by a compile-time-emitted pop)
+        // within the innermost active TCO loop, BEFORE this guard pushes its
+        // own. codegenTailCallFromContext drains exactly this many pops
+        // before branching back to a loop header from inside our body/handler
+        // (see below); restoring to this exact baseline once our own push is
+        // resolved — however it resolves — keeps sibling/enclosing guards'
+        // bookkeeping correct regardless of nesting. A no-op when we're not
+        // inside a TCO loop (binding_ still tracks it, just never consulted).
+        unsigned guard_open_before = binding_ ? binding_->getTCOContext().open_guard_handlers : 0;
+
         // Create basic blocks - IMPORTANT: setup_block is separate to avoid
         // corrupting the caller's block when we're nested inside another expression
         BasicBlock* setup_block = BasicBlock::Create(*context, "guard_setup", current_func);
@@ -20545,6 +20567,11 @@ private:
 
         // Push exception handler
         builder->CreateCall(push_handler_func, {jmp_buf_alloc});
+        if (binding_) {
+            // ESH-0222: record that this push is now open, relative to
+            // whatever was already open when we entered.
+            binding_->getTCOContext().open_guard_handlers = guard_open_before + 1;
+        }
 
         // Call setjmp - returns 0 on first call, non-zero when longjmp is called
         Value* setjmp_result = builder->CreateCall(setjmp_func, makeSetjmpArgs(jmp_buf_alloc), "setjmp_result");
@@ -20587,6 +20614,19 @@ private:
 
         // Pop handler first
         builder->CreateCall(pop_handler_func, {});
+        if (binding_) {
+            // ESH-0222: this basic block is always constructed (whether or
+            // not it's reached at runtime), so this is the single point,
+            // covering every exit from this guard (normal completion, a
+            // caught exception, an uncaught re-raise, AND a TCO tail-call
+            // branch out of the protected body — which drained down to 0 and
+            // skipped its own pop), where this guard's own push is
+            // definitively resolved. Restore to the pre-push baseline so
+            // handler-clause bodies (evaluated below, possibly containing
+            // their own tail self-call back to an enclosing loop) see the
+            // correct count of genuinely-still-open ancestor handlers.
+            binding_->getTCOContext().open_guard_handlers = guard_open_before;
+        }
 
         // R7RS: Get the original raised value (not the exception struct)
         Function* get_raised_func = module->getFunction("eshkol_get_raised_value");
@@ -24274,6 +24314,38 @@ private:
                     }
                     return false;
 
+                case ESHKOL_GUARD_OP:
+                    // ESH-0222: guard used to fall through to `default: return
+                    // false`, so isSelfTailRecursive() could never see a
+                    // self-call buried in a guard as tail — even when it
+                    // genuinely was (Selene's resident tick loop: the guard's
+                    // protected body's last expression, and each handler
+                    // clause's last expression, both recurse). That silently
+                    // disabled TCO and fell back to unbounded real recursion.
+                    //
+                    // guard's body is parser-normalized to a single node
+                    // (body[0]); whatever tail position guard itself has, that
+                    // node inherits.
+                    if (op->guard_op.body && op->guard_op.num_body_exprs > 0 &&
+                        isInTailPosition(expr, &op->guard_op.body[0])) {
+                        return true;
+                    }
+                    // A handler clause's LAST body expression is also in tail
+                    // position — it's what the whole `guard` evaluates to when
+                    // that clause fires.
+                    for (uint64_t i = 0; i < op->guard_op.num_clauses; i++) {
+                        const eshkol_ast_t* clause = &op->guard_op.clauses[i];
+                        if (clause->type == ESHKOL_OP &&
+                            clause->operation.op == ESHKOL_CALL_OP &&
+                            clause->operation.call_op.num_vars > 0) {
+                            uint64_t last = clause->operation.call_op.num_vars - 1;
+                            if (isInTailPosition(expr, &clause->operation.call_op.variables[last])) {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+
                 default:
                     return false;
             }
@@ -24338,6 +24410,29 @@ private:
                 case ESHKOL_SEQUENCE_OP:
                     for (uint64_t i = 0; i < op->sequence_op.num_expressions; i++) {
                         count += countAllRecursiveCalls(&op->sequence_op.expressions[i], func_name);
+                    }
+                    break;
+
+                case ESHKOL_GUARD_OP:
+                    // ESH-0222: previously fell to `default: break`, so a
+                    // self-call hidden inside a guard body/handler was
+                    // completely invisible to this counter — total_recursive_calls
+                    // silently came out as 0 for functions whose only
+                    // recursion lives inside a `guard`, which made
+                    // isSelfTailRecursive() report "no recursion at all" and
+                    // disable TCO outright (the exact shape of Selene's
+                    // resident tick loop: `(define (loop ...) (if ... (guard
+                    // ...)))`).
+                    if (op->guard_op.body && op->guard_op.num_body_exprs > 0) {
+                        count += countAllRecursiveCalls(&op->guard_op.body[0], func_name);
+                    }
+                    for (uint64_t i = 0; i < op->guard_op.num_clauses; i++) {
+                        const eshkol_ast_t* clause = &op->guard_op.clauses[i];
+                        if (clause->type == ESHKOL_OP && clause->operation.op == ESHKOL_CALL_OP) {
+                            for (uint64_t j = 0; j < clause->operation.call_op.num_vars; j++) {
+                                count += countAllRecursiveCalls(&clause->operation.call_op.variables[j], func_name);
+                            }
+                        }
                     }
                     break;
 
@@ -24433,6 +24528,23 @@ private:
                 case ESHKOL_SEQUENCE_OP:
                     for (uint64_t i = 0; i < op->sequence_op.num_expressions; i++) {
                         findTailCalls(&op->sequence_op.expressions[i], body, func_name, tail_calls);
+                    }
+                    break;
+
+                case ESHKOL_GUARD_OP:
+                    // ESH-0222: search guard's protected body and every
+                    // handler clause for self-calls; isInTailPosition() (now
+                    // guard-aware) decides which ones actually qualify.
+                    if (op->guard_op.body && op->guard_op.num_body_exprs > 0) {
+                        findTailCalls(&op->guard_op.body[0], body, func_name, tail_calls);
+                    }
+                    for (uint64_t i = 0; i < op->guard_op.num_clauses; i++) {
+                        const eshkol_ast_t* clause = &op->guard_op.clauses[i];
+                        if (clause->type == ESHKOL_OP && clause->operation.op == ESHKOL_CALL_OP) {
+                            for (uint64_t j = 0; j < clause->operation.call_op.num_vars; j++) {
+                                findTailCalls(&clause->operation.call_op.variables[j], body, func_name, tail_calls);
+                            }
+                        }
                     }
                     break;
 
@@ -25239,6 +25351,43 @@ private:
         // Store all new values to parameter allocas
         for (size_t i = 0; i < new_values.size(); i++) {
             builder->CreateStore(new_values[i], tco_ctx.param_allocas[i]);
+        }
+
+        // ESH-0222: this branch is about to skip past any `guard` cleanup
+        // code that a normal (non-tail-call) return through this control
+        // path would have run — specifically codegenGuard's post-body
+        // eshkol_pop_exception_handler() call, which only fires when the
+        // body's block is NOT already terminated. Drain every handler push
+        // still open within this loop iteration so the runtime handler
+        // chain (g_exception_handler_stack) stays balanced across
+        // iterations instead of growing forever and retaining stale
+        // jmp_buf pointers into stack memory we're about to reclaim below.
+        if (tco_ctx.open_guard_handlers > 0) {
+            Function* pop_handler_fn = module->getFunction("eshkol_pop_exception_handler");
+            if (!pop_handler_fn) {
+                FunctionType* pop_type = FunctionType::get(builder->getVoidTy(), {}, false);
+                pop_handler_fn = Function::Create(pop_type, Function::ExternalLinkage,
+                                                   "eshkol_pop_exception_handler", module.get());
+            }
+            for (unsigned i = 0; i < tco_ctx.open_guard_handlers; i++) {
+                builder->CreateCall(pop_handler_fn, {});
+            }
+            tco_ctx.open_guard_handlers = 0;
+        }
+
+        // ESH-0222: reclaim any dynamically-sized stack allocations made
+        // during this iteration (e.g. guard's setjmp jmp_buf — allocaJmpBuf()
+        // sizes it from a runtime call, so LLVM cannot statically hoist or
+        // reuse it across iterations of this branch-based loop). Without
+        // this, every iteration that passes through `guard` (or any other
+        // dynamic alloca) permanently lowers the stack pointer a little more
+        // until the native stack overflows — this is the direct mechanism
+        // behind "stack overflow" crashes in long-running tick loops with a
+        // per-iteration error boundary.
+        if (tco_ctx.loop_stack_save) {
+            Function* stackrestore_fn = ESHKOL_GET_INTRINSIC(module.get(), Intrinsic::stackrestore,
+                                                               {builder->getPtrTy()});
+            builder->CreateCall(stackrestore_fn, {tco_ctx.loop_stack_save});
         }
 
         // Create unreachable sentinel BEFORE the branch (can't add instructions
@@ -26625,6 +26774,17 @@ private:
             // Branch from entry to loop body
             builder->CreateBr(tco_loop_bb);
             builder->SetInsertPoint(tco_loop_bb);
+
+            // ESH-0222: see TailCallContext::loop_stack_save /
+            // open_guard_handlers (binding_codegen.h). This lambda's own
+            // whole-struct save/restore of TailCallContext (above/below)
+            // already keeps these fields correctly scoped across nested
+            // TCO'd closures.
+            {
+                Function* stacksave_fn = ESHKOL_GET_INTRINSIC(module.get(), Intrinsic::stacksave, {builder->getPtrTy()});
+                tco_ctx.loop_stack_save = builder->CreateCall(stacksave_fn, {}, "tco_loop_sp");
+            }
+            tco_ctx.open_guard_handlers = 0;
         }
 
         // ASSIGNMENT CONVERSION (ESH-0074): box set!-mutated lambda parameters.
@@ -27881,6 +28041,8 @@ private:
         std::vector<AllocaInst*> saved_tco_param_allocas = tco_ctx.param_allocas;
         std::vector<std::string> saved_tco_param_names = tco_ctx.param_names;
         bool saved_tco_iter_scope = tco_ctx.iter_scope;
+        unsigned saved_tco_open_guard_handlers = tco_ctx.open_guard_handlers;  // ESH-0222
+        llvm::Value* saved_tco_loop_stack_save = tco_ctx.loop_stack_save;      // ESH-0222
 
         // Set up TCO context for this named let only when sound.
         tco_ctx.func_name = loop_name;
@@ -27922,6 +28084,18 @@ private:
                 builder->CreateCall(getArenaPushScopeFunc(), {iter_arena_ptr});
             }
         }
+
+        // ESH-0222: see TailCallContext::loop_stack_save / open_guard_handlers
+        // (binding_codegen.h) for the full rationale. Reset relative to THIS
+        // named let's own loop — an enclosing guard opened OUTSIDE the loop
+        // (once, for the loop's whole lifetime) is deliberately hidden from
+        // this per-iteration bookkeeping; it is saved/restored below
+        // alongside the other nested-named-let TCO context fields.
+        {
+            Function* stacksave_fn = ESHKOL_GET_INTRINSIC(module.get(), Intrinsic::stacksave, {builder->getPtrTy()});
+            tco_ctx.loop_stack_save = builder->CreateCall(stacksave_fn, {}, "tco_loop_sp");
+        }
+        tco_ctx.open_guard_handlers = 0;
 
         // Generate body
         Value* body_result = codegenAST(op->let_op.body);
@@ -27983,6 +28157,8 @@ private:
         tco_ctx.param_allocas = saved_tco_param_allocas;
         tco_ctx.param_names = saved_tco_param_names;
         tco_ctx.iter_scope = saved_tco_iter_scope;
+        tco_ctx.open_guard_handlers = saved_tco_open_guard_handlers;  // ESH-0222
+        tco_ctx.loop_stack_save = saved_tco_loop_stack_save;          // ESH-0222
 
         // Call the loop function with initial values + capture pointers (#224)
         std::vector<Value*> call_args;

--- a/lib/backend/tail_call_codegen.cpp
+++ b/lib/backend/tail_call_codegen.cpp
@@ -447,6 +447,51 @@ static bool allSelfCallsInTailPosition(const eshkol_ast_t* expr,
             return true;
         }
 
+        case ESHKOL_GUARD_OP: {
+            // (guard (var clause ...) body ...) — ESH-0222.
+            //
+            // This used to fall through to `default: return true`, silently
+            // claiming ANY self-call buried inside a guard's protected body or
+            // handler clauses was tail-safe without ever looking inside. That
+            // let the named-let TCO transform rewrite a genuinely non-tail
+            // self-call (e.g. `(guard (e #t) (+ 1 (loop ...)))`) into an
+            // unconditional branch back to the loop header — a silent
+            // miscompile, not just a missed optimization.
+            //
+            // The parser always normalizes guard's body to a single AST node
+            // (body[0], already a begin/letrec if the source had multiple
+            // forms — see parser.cpp), and codegenGuard evaluates exactly
+            // that node as guard's own continuation. So body[0] honestly
+            // inherits the guard form's own tail position.
+            if (op->guard_op.body && op->guard_op.num_body_exprs > 0) {
+                if (!allSelfCallsInTailPosition(&op->guard_op.body[0], func_name, in_tail_pos)) {
+                    return false;
+                }
+            }
+            // Each handler clause is (test expr ...), mirroring ESHKOL_COND_OP
+            // above: the test is NOT in tail position; only the clause's last
+            // body expression is — it's what the whole `guard` evaluates to
+            // when that clause fires.
+            for (uint64_t i = 0; i < op->guard_op.num_clauses; i++) {
+                const eshkol_ast_t* clause = &op->guard_op.clauses[i];
+                if (clause->type != ESHKOL_OP || clause->operation.op != ESHKOL_CALL_OP) {
+                    continue;
+                }
+                if (!allSelfCallsInTailPosition(clause->operation.call_op.func, func_name, false)) {
+                    return false;
+                }
+                for (uint64_t j = 0; j < clause->operation.call_op.num_vars; j++) {
+                    bool is_last_body = (j == clause->operation.call_op.num_vars - 1);
+                    if (!allSelfCallsInTailPosition(
+                            &clause->operation.call_op.variables[j], func_name,
+                            is_last_body ? in_tail_pos : false)) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
         default:
             // For other ops (arithmetic, etc.), sub-expressions are not in tail position
             return true;

--- a/tests/tco/guard_loop_tail_test.esk
+++ b/tests/tco/guard_loop_tail_test.esk
@@ -1,0 +1,141 @@
+;;; ESH-0222: tail calls through `guard` inside a long-running loop.
+;;;
+;;; Regression coverage for the resident/daemon tick-loop pattern:
+;;;   (define (loop tick ...)
+;;;     (if (>= tick max-ticks)
+;;;         <terminate>
+;;;         (guard (e (#t ... (loop (+ tick 1) ...)))   ; handler-tail self-call
+;;;           <fallible tick body>
+;;;           (loop <updated args>))))                   ; body-tail self-call
+;;;
+;;; Before this fix:
+;;;  - top-level `(define (loop ...) ...)` self-calls hidden inside a guard
+;;;    were INVISIBLE to isSelfTailRecursive()'s recursive-call counter, so
+;;;    TCO was silently disabled and the loop recursed via real (growing)
+;;;    call frames forever.
+;;;  - a named-let loop whose analysis DID (accidentally) enable TCO leaked
+;;;    real native stack every iteration: guard's jmp_buf is a
+;;;    dynamically-sized `alloca` with no llvm.stacksave/stackrestore
+;;;    bracketing the loop's back-edge, and the TCO shortcut branch skipped
+;;;    codegenGuard's own eshkol_pop_exception_handler() call, leaving the
+;;;    runtime handler chain (and the alloca'd jmp_buf storage it points
+;;;    into) growing forever too.
+;;;
+;;; Each shape below is checked against a plain (guard-free) reference loop
+;;; computing the identical value, so this is a CORRECTNESS test, not just a
+;;; "didn't crash" smoke test. Run with a reduced `ulimit -s` (see
+;;; docs/LONG_RUNNING_LOOPS.md) to prove the stack stays flat rather than
+;;; merely fitting under the 512MB ESHKOL_STACK_SIZE default.
+
+(define N 1000000)
+
+;; Ground truth: no guard at all. +1 on a normal tick, -1 every 97th tick.
+(define (ref-loop n acc)
+  (if (>= n N)
+      acc
+      (if (= (modulo n 97) 0)
+          (ref-loop (+ n 1) (- acc 1))
+          (ref-loop (+ n 1) (+ acc 1)))))
+
+(define expected (ref-loop 0 0))
+
+;; --- Shape (a): top-level define, self-call in BOTH guard-body tail
+;;     position and handler-clause tail position (Selene's exact pattern).
+(define (tick-loop-define n acc)
+  (if (>= n N)
+      acc
+      (guard (e (#t (tick-loop-define (+ n 1) (- acc 1))))
+        (if (= (modulo n 97) 0) (raise 'stumble) #t)
+        (tick-loop-define (+ n 1) (+ acc 1)))))
+
+(display "Shape (a) top-level define, guard body+handler tail: ")
+(let ((r (tick-loop-define 0 0)))
+  (if (= r expected) (display "PASS") (begin (display "FAIL got=") (display r) (display " want=") (display expected))))
+(newline)
+
+;; --- Shape (a'): the same pattern, but as a named-let loop instead of a
+;;     top-level define. The tail-position analysis fix (ESH-0222) applies
+;;     here too (allSelfCallsInTailPosition's GUARD_OP case), but named-let
+;;     TCO has a SEPARATE, PRE-EXISTING stack-overflow bug independent of
+;;     guard — a plain guard-free named-let loop
+;;     `(let loop ((n 0)) (if (>= n N) n (loop (+ n 1))))` already
+;;     overflows the native stack around n≈3-500k on unmodified master.
+;;     Filed as ESH-0223 (tracked separately; not caused by and not fixed
+;;     by this change). Capped well below that threshold here so this
+;;     still regression-checks the guard-tail-position analysis itself
+;;     without tripping the unrelated bug.
+(define NL_N 50000)
+
+(define (ref-loop-nl n acc)
+  (if (>= n NL_N)
+      acc
+      (if (= (modulo n 97) 0)
+          (ref-loop-nl (+ n 1) (- acc 1))
+          (ref-loop-nl (+ n 1) (+ acc 1)))))
+
+(define expected-nl (ref-loop-nl 0 0))
+
+(define (tick-loop-named-let)
+  (let loop ((n 0) (acc 0))
+    (if (>= n NL_N)
+        acc
+        (guard (e (#t (loop (+ n 1) (- acc 1))))
+          (if (= (modulo n 97) 0) (raise 'stumble) #t)
+          (loop (+ n 1) (+ acc 1))))))
+
+(display "Shape (a') named-let, guard body+handler tail (capped, see ESH-0223): ")
+(let ((r (tick-loop-named-let)))
+  (if (= r expected-nl) (display "PASS") (begin (display "FAIL got=") (display r) (display " want=") (display expected-nl))))
+(newline)
+
+;; --- Shape (b): guard wraps ONLY the fallible section and returns a
+;;     value; the recursive loop call is genuinely OUTSIDE guard's dynamic
+;;     extent, in the tail position of the enclosing `let`. This shape
+;;     never needed the fix below (guard never wraps the self-call) — it
+;;     is the canonical, always-safe pattern documented in
+;;     docs/LONG_RUNNING_LOOPS.md.
+(define (tick-loop-outside n acc)
+  (if (>= n N)
+      acc
+      (let ((delta (guard (e (#t -1))
+                     (if (= (modulo n 97) 0) (raise 'stumble) 1))))
+        (tick-loop-outside (+ n 1) (+ acc delta)))))
+
+(display "Shape (b) loop call outside guard, on guard's return value: ")
+(let ((r (tick-loop-outside 0 0)))
+  (if (= r expected) (display "PASS") (begin (display "FAIL got=") (display r) (display " want=") (display expected))))
+(newline)
+
+;; --- Shape (c): `(apply loop lst)` variant. `apply` does NOT participate
+;;     in TCO in Eshkol today (call_apply_codegen.cpp never consults
+;;     binding_->isTCOActive()/TailCallContext — every apply call is a
+;;     genuine, non-tail LLVM `call`), so this is capped at a small depth:
+;;     it is a CORRECTNESS check only, not a flatness claim. See
+;;     docs/LONG_RUNNING_LOOPS.md for why the canonical pattern avoids
+;;     `apply` for the loop back-edge.
+(define APPLY_N 20000)
+
+(define (ref-loop-small n acc)
+  (if (>= n APPLY_N)
+      acc
+      (if (= (modulo n 97) 0)
+          (ref-loop-small (+ n 1) (- acc 1))
+          (ref-loop-small (+ n 1) (+ acc 1)))))
+
+(define expected-small (ref-loop-small 0 0))
+
+(define (tick-loop-apply state)
+  (let ((n (car state)) (acc (cadr state)))
+    (if (>= n APPLY_N)
+        acc
+        (apply tick-loop-apply
+               (list (list (+ n 1)
+                           (+ acc (guard (e (#t -1))
+                                    (if (= (modulo n 97) 0) (raise 'stumble) 1)))))))))
+
+(display "Shape (c) (apply loop lst), bounded depth, correctness only: ")
+(let ((r (tick-loop-apply (list 0 0))))
+  (if (= r expected-small) (display "PASS") (begin (display "FAIL got=") (display r) (display " want=") (display expected-small))))
+(newline)
+
+(display "guard_loop_tail_test complete") (newline)


### PR DESCRIPTION
## Summary

Selene's compiled resident tick loop (a tail-recursive loop whose body is
wrapped in a per-tick `guard` error boundary) SIGSEGV'd with "stack
overflow" every 45-75 minutes. Root cause: `guard` was invisible to both
of Eshkol's tail-call analyses, in opposite and equally unsound ways.

- **Top-level `(define (f ...) ...)` self-tail-recursion** — the helpers
  `countAllRecursiveCalls`/`findTailCalls`/`isInTailPosition`
  (`lib/backend/llvm_codegen.cpp`) had no `ESHKOL_GUARD_OP` case, so a
  self-call buried inside a `guard` was completely invisible. A loop whose
  *only* recursion lives inside guard (Selene's exact shape) silently got
  `total_recursive_calls == 0`, TCO was never attempted, and the loop
  recursed via real, unbounded native stack frames forever.
- **Named-let TCO** — `allSelfCallsInTailPosition`
  (`lib/backend/tail_call_codegen.cpp`) had the opposite lie: it assumed
  any self-call inside `guard` was tail-safe without checking. When that
  happened to enable TCO, the code generator itself was unsound for it:
  `guard`'s setjmp `jmp_buf` is a dynamically-sized `alloca` that LLVM
  cannot hoist across a branch-based loop's iterations (permanent stack
  growth per iteration), and the TCO shortcut branch skipped `guard`'s own
  `eshkol_pop_exception_handler()` call, unbalancing the runtime handler
  chain.

## Fix

- Both tail-position analyses now honestly recurse into guard's protected
  body and handler clauses instead of silently assuming an answer.
- `TailCallContext` (`inc/eshkol/backend/binding_codegen.h`) gains two
  fields: `open_guard_handlers` (drained via `eshkol_pop_exception_handler`
  before every TCO back-edge branch) and `loop_stack_save`
  (`llvm.stacksave`/`stackrestore` bracketing each loop iteration), so
  per-iteration handler pushes and dynamic stack allocations never
  accumulate across iterations. Wired into `codegenGuard`,
  `codegenTailCallFromContext`, and all three TCO loop-header setup sites
  (top-level define, lambda-binding, named-let).
- `apply` is left as a known, separate, documented gap (never TCO'd) —
  not this bug, not fixed here.

Verified flat at 1,000,000 ticks for the top-level-define shape (Selene's
exact pattern): ~45MB RSS, ~22MB peak footprint, no growth, <1s.

Discovered a **separate, pre-existing** bug along the way: plain
guard-free named-let TCO already overflows the stack around 300-500k
iterations on unmodified master. Filed as ESH-0223 (not fixed in this PR;
documented as a caveat in the new doc, and the new test's named-let shape
is capped below that threshold accordingly).

## Test plan

- [x] `tests/tco/guard_loop_tail_test.esk` (new) — 4 shapes, correctness
      checked against guard-free reference loops: top-level define with
      self-calls in guard-body-tail AND handler-clause-tail position
      (N=1e6, flat), loop-call-outside-guard (N=1e6, flat, canonical
      pattern), named-let variant (N=50k, capped per ESH-0223), `apply`
      variant (N=20k, correctness-only, apply is not TCO'd).
- [x] `scripts/run_tco_tests.sh` — 3/3 (includes pre-existing + new)
- [x] `scripts/run_sicp_smoke.sh` — 88/88
- [x] `scripts/run_error_handling_tests.sh` — 7/7 (guard suites included)
- [x] `scripts/run_ad_oracle.sh` — 56/56
- [x] Clean rebuild (`cmake --build build --target eshkol-run stdlib -j8`), no new warnings from changed files
- [x] `docs/LONG_RUNNING_LOOPS.md` (new) — canonical pattern + Q&A on
      guard tail position, `apply`'s non-tail status, `ESHKOL_STACK_SIZE`
      stopgap, and the arena/no-GC memory model.