### PR TITLE
fix(r7rs): vector-copy accepts tensor-backed vector literals (ESH-0225)

### DIFF
--- a/.swarm/tasks/ESH-0225.json
+++ b/.swarm/tasks/ESH-0225.json
@@ -1,0 +1,37 @@
+{
+  "id": "ESH-0225",
+  "title": "vector-copy rejects tensor-backed #(...) vector literals",
+  "status": "done",
+  "priority": "high",
+  "workstream": "r7rs-conformance",
+  "owner": "tsotchke",
+  "preferred_backend": "claude",
+  "goal": "R7RS: #(...) IS a vector literal, so (vector-copy #(1 2 3 4 5) 1 4) must succeed exactly like (vector-copy (vector 1 2 3 4 5) 1 4). Eshkol lowers #(...) literals to HEAP_SUBTYPE_TENSOR (homogeneous doubles, separate dims/elements arrays) while (vector ...) / (make-vector ...) build HEAP_SUBTYPE_VECTOR (inline tagged slots); vector-copy (added by ESH-0153) only handled the latter and raised \"vector-copy: argument is a tensor, not a vector\" on the former. This was the last remaining divergence in the reference-Scheme differential oracle (P7a): 33/34 AGREE with 0013_vector_basic as the sole ESHKOL-DIVERGES case.",
+  "file_globs": [
+    "lib/backend/collection_codegen.cpp",
+    "tests/r7rs/conformance_batch_test.esk"
+  ],
+  "root_cause": "CollectionCodegen::vectorCopyNew (ESH-0153) unconditionally raised on HEAP_SUBTYPE_TENSOR instead of dispatching on it the way vector-ref/vector-length/vector-map already do. Vector literals #(...) always lower to HEAP_SUBTYPE_TENSOR at parse/codegen time (lib/frontend/parser.cpp parse_vector_body -> ESHKOL_TENSOR_OP), so every literal hit the reject path while vectors built via (vector ...) (HEAP_SUBTYPE_VECTOR) did not.",
+  "fix": "Restructured CollectionCodegen::vectorCopyNew (lib/backend/collection_codegen.cpp) to dispatch on the header subtype at ptr-8, same as vector-ref/vector-length/vector-map: (1) length read branches to the tensor struct's total_elements field (offset 3) for HEAP_SUBTYPE_TENSOR vs the inline length field for HEAP_SUBTYPE_VECTOR, merged via a PHI; (2) start/end/bounds-check logic is now shared and unchanged; (3) the allocation+copy branches on the same subtype check: the tensor path allocates a fresh rank-1 tensor (arena_allocate_tensor_with_header + a 1-entry dims array + a fresh count*sizeof(double) elements buffer, memcpy'd from the [start,end) slice of the source elements array), mirroring the existing tensor `cdr` pattern; the vector path is the original ESH-0153 code, unchanged, just moved into its own basic block. Both paths merge into one PHI'd tagged result via packHeapPtr. No change to vector-copy! (CollectionCodegen::vectorCopy) since it has no tensor-rejecting guard (out of scope for this bug: it doesn't error on tensors, it just assumes vector layout unconditionally, a separate latent issue).",
+  "acceptance": [
+    "(vector-copy #(1 2 3 4 5) 1 4) => #(2 3 4)",
+    "(vector-copy #(1 2 3)) => #(1 2 3)",
+    "(vector-copy #(10 20 30 40) 2) => #(30 40)",
+    "(vector-copy #(1 2 3) 1 1) => #()",
+    "copy of a #(...) literal is fresh (vector-set! on the copy does not mutate the literal)",
+    "out-of-range start/end on a #(...) literal still raises 'vector-copy: index out of range'",
+    "constructed-vector vector-copy path (ESH-0153) unchanged / byte-identical behavior",
+    "works under -r and AOT"
+  ],
+  "verification": [
+    "cmake --build build --target eshkol-run stdlib -j8",
+    "./build/eshkol-run -r <literal-and-constructed vector-copy repro> matches expected output",
+    "./build/eshkol-run -O2 <same repro> -o /tmp/bin && /tmp/bin matches -r output",
+    "./build/eshkol-run -r tests/r7rs/conformance_batch_test.esk : 24/24 PASS, 0 FAIL",
+    "./build/eshkol-run -O2 tests/r7rs/conformance_batch_test.esk -o /tmp/conf && /tmp/conf : 24/24 PASS, 0 FAIL",
+    "scripts/run_sicp_smoke.sh : 88/88 gate probes PASS",
+    "scripts/run_tensor_collection_depth.sh : no regressions",
+    "scripts/run_reference_differential.sh (PR #140 corpus, borrowed locally to verify): 34/34 AGREE, 0013_vector_basic AGREES (was the sole ESHKOL-DIVERGES case)"
+  ],
+  "blocked_by": []
+}

--- a/lib/backend/collection_codegen.cpp
+++ b/lib/backend/collection_codegen.cpp
@@ -2059,7 +2059,7 @@ llvm::Value* CollectionCodegen::vectorCopyNew(const eshkol_operations_t* op) {
 
     llvm::Function* current_func = ctx_.builder().GetInsertBlock()->getParent();
 
-    // Reusable raise helper for the out-of-range / wrong-type conditions.
+    // Reusable raise helper for the out-of-range condition.
     auto raise_error = [&](const char* message) {
         llvm::Function* raise_func = ctx_.module().getFunction("eshkol_raise");
         if (!raise_func) {
@@ -2083,23 +2083,41 @@ llvm::Value* CollectionCodegen::vectorCopyNew(const eshkol_operations_t* op) {
         ctx_.builder().CreateUnreachable();
     };
 
-    // Reject tensors (`#(...)` literals) — their layout differs from a
-    // Scheme vector, so silently copying would corrupt memory.
-    {
-        llvm::Value* header_ptr = ctx_.builder().CreateGEP(ctx_.int8Type(), vec_ptr,
-            llvm::ConstantInt::get(ctx_.int64Type(), -8));
-        llvm::Value* subtype = ctx_.builder().CreateLoad(ctx_.int8Type(), header_ptr, "vcopy_subtype");
-        llvm::Value* is_tensor = ctx_.builder().CreateICmpEQ(subtype,
-            llvm::ConstantInt::get(ctx_.int8Type(), HEAP_SUBTYPE_TENSOR));
-        llvm::BasicBlock* tensor_fail = llvm::BasicBlock::Create(ctx_.context(), "vcopy_tensor_fail", current_func);
-        llvm::BasicBlock* not_tensor = llvm::BasicBlock::Create(ctx_.context(), "vcopy_not_tensor", current_func);
-        ctx_.builder().CreateCondBr(is_tensor, tensor_fail, not_tensor);
-        ctx_.builder().SetInsertPoint(tensor_fail);
-        raise_error("vector-copy: argument is a tensor, not a vector");
-        ctx_.builder().SetInsertPoint(not_tensor);
-    }
+    // R7RS: `#(...)` vector literals ARE vectors, so vector-copy must accept
+    // them. They lower to HEAP_SUBTYPE_TENSOR (homogeneous doubles, separate
+    // dims/elements arrays) instead of HEAP_SUBTYPE_VECTOR (inline tagged
+    // slots), so the two representations need different length reads and
+    // different copy/allocation code below. Dispatch on the header subtype at
+    // ptr-8, exactly like vector-ref/vector-length/vector-map do.
+    llvm::Value* header_ptr = ctx_.builder().CreateGEP(ctx_.int8Type(), vec_ptr,
+        llvm::ConstantInt::get(ctx_.int64Type(), -8));
+    llvm::Value* subtype = ctx_.builder().CreateLoad(ctx_.int8Type(), header_ptr, "vcopy_subtype");
+    llvm::Value* is_tensor = ctx_.builder().CreateICmpEQ(subtype,
+        llvm::ConstantInt::get(ctx_.int8Type(), HEAP_SUBTYPE_TENSOR));
 
-    llvm::Value* len = ctx_.builder().CreateLoad(ctx_.int64Type(), vec_ptr, "vcopy_len");
+    llvm::BasicBlock* tensor_len_block = llvm::BasicBlock::Create(ctx_.context(), "vcopy_tensor_len", current_func);
+    llvm::BasicBlock* vector_len_block = llvm::BasicBlock::Create(ctx_.context(), "vcopy_vector_len", current_func);
+    llvm::BasicBlock* len_merge_block = llvm::BasicBlock::Create(ctx_.context(), "vcopy_len_merge", current_func);
+    ctx_.builder().CreateCondBr(is_tensor, tensor_len_block, vector_len_block);
+
+    // Tensor length: field 3 of the tensor struct (total_elements). Treated
+    // as a flat rank-1 sequence for copy purposes regardless of the source
+    // tensor's actual rank (mirrors the R7RS-visible "vector of N elements").
+    ctx_.builder().SetInsertPoint(tensor_len_block);
+    llvm::Value* tensor_total_ptr = ctx_.builder().CreateStructGEP(ctx_.tensorType(), vec_ptr, 3);
+    llvm::Value* tensor_len = ctx_.builder().CreateLoad(ctx_.int64Type(), tensor_total_ptr, "vcopy_tensor_len");
+    ctx_.builder().CreateBr(len_merge_block);
+
+    // Vector length: first 8 bytes of the vector object.
+    ctx_.builder().SetInsertPoint(vector_len_block);
+    llvm::Value* vector_len = ctx_.builder().CreateLoad(ctx_.int64Type(), vec_ptr, "vcopy_vec_len");
+    ctx_.builder().CreateBr(len_merge_block);
+
+    ctx_.builder().SetInsertPoint(len_merge_block);
+    llvm::PHINode* len_phi = ctx_.builder().CreatePHI(ctx_.int64Type(), 2, "vcopy_len");
+    len_phi->addIncoming(tensor_len, tensor_len_block);
+    len_phi->addIncoming(vector_len, vector_len_block);
+    llvm::Value* len = len_phi;
 
     // start (default 0)
     llvm::Value* start;
@@ -2143,14 +2161,63 @@ llvm::Value* CollectionCodegen::vectorCopyNew(const eshkol_operations_t* op) {
 
     llvm::Value* count = ctx_.builder().CreateSub(end, start, "vcopy_count");
 
-    // Allocate the fresh vector and store its length.
+    // Dispatch the actual allocation + copy on the same subtype check used
+    // for the length read above. Each path allocates a *fresh* object of the
+    // *same* representation as the source (tensor in -> fresh rank-1 tensor,
+    // constructed vector in -> fresh vector), so downstream consumers keep
+    // seeing whichever representation they already handle.
+    llvm::BasicBlock* tensor_copy_block = llvm::BasicBlock::Create(ctx_.context(), "vcopy_tensor_copy", current_func);
+    llvm::BasicBlock* vector_copy_block = llvm::BasicBlock::Create(ctx_.context(), "vcopy_vector_copy", current_func);
+    llvm::BasicBlock* copy_merge_block = llvm::BasicBlock::Create(ctx_.context(), "vcopy_copy_merge", current_func);
+    ctx_.builder().CreateCondBr(is_tensor, tensor_copy_block, vector_copy_block);
+
+    // TENSOR PATH: allocate a fresh rank-1 tensor of `count` elements and
+    // memcpy the [start,end) slice of raw 8-byte elements (double bit
+    // patterns / AD-node pointers, per the tensor element encoding used
+    // elsewhere in this file, e.g. vectorRef's tensor_1d_path).
+    ctx_.builder().SetInsertPoint(tensor_copy_block);
+    llvm::Value* tensor_arena_ptr = ctx_.builder().CreateLoad(ctx_.ptrType(), ctx_.globalArena());
+    llvm::Value* new_tensor = ctx_.builder().CreateCall(mem_.getArenaAllocateTensorWithHeader(), {tensor_arena_ptr});
+
+    // dims = [count] (rank 1)
+    llvm::Value* new_dims = ctx_.builder().CreateCall(mem_.getArenaAllocate(),
+        {tensor_arena_ptr, llvm::ConstantInt::get(ctx_.sizeType(), sizeof(uint64_t))});
+    ctx_.builder().CreateStore(count, new_dims);
+    ctx_.builder().CreateStore(new_dims, ctx_.builder().CreateStructGEP(ctx_.tensorType(), new_tensor, 0));
+    ctx_.builder().CreateStore(llvm::ConstantInt::get(ctx_.int64Type(), 1),
+        ctx_.builder().CreateStructGEP(ctx_.tensorType(), new_tensor, 1));
+    ctx_.builder().CreateStore(count, ctx_.builder().CreateStructGEP(ctx_.tensorType(), new_tensor, 3));
+
+    // elements: fresh arena buffer of `count` doubles, sliced from [start,end).
+    llvm::Value* src_elems_field_ptr = ctx_.builder().CreateStructGEP(ctx_.tensorType(), vec_ptr, 2);
+    llvm::Value* src_elems_ptr = ctx_.builder().CreateLoad(ctx_.ptrType(), src_elems_field_ptr);
+    llvm::Value* new_elems_size = ctx_.builder().CreateMul(count,
+        llvm::ConstantInt::get(ctx_.sizeType(), sizeof(double)));
+    llvm::Value* new_elems = ctx_.builder().CreateCall(mem_.getArenaAllocate(),
+        {tensor_arena_ptr, new_elems_size});
+    ctx_.builder().CreateStore(new_elems, ctx_.builder().CreateStructGEP(ctx_.tensorType(), new_tensor, 2));
+
+    llvm::Value* tensor_src_ptr = ctx_.builder().CreateGEP(ctx_.int64Type(), src_elems_ptr, start);
+    llvm::Value* tensor_byte_count = ctx_.builder().CreateMul(count,
+        llvm::ConstantInt::get(ctx_.int64Type(), sizeof(double)), "vcopy_tensor_bytes");
+    ctx_.builder().CreateMemCpy(
+        new_elems, llvm::MaybeAlign(8),
+        tensor_src_ptr, llvm::MaybeAlign(8),
+        tensor_byte_count);
+
+    llvm::Value* tensor_result = tagged_.packHeapPtr(new_tensor);
+    ctx_.builder().CreateBr(copy_merge_block);
+    llvm::BasicBlock* tensor_copy_exit = ctx_.builder().GetInsertBlock();
+
+    // VECTOR PATH (#156, unchanged): allocate the fresh vector and store its
+    // length, then copy the [start,end) slice (16 bytes per tagged element).
+    ctx_.builder().SetInsertPoint(vector_copy_block);
     llvm::Value* arena_ptr = ctx_.builder().CreateLoad(ctx_.ptrType(), ctx_.globalArena());
     llvm::Value* new_vec = ctx_.builder().CreateCall(mem_.getArenaAllocateVectorWithHeader(),
         {arena_ptr, count});
     llvm::Value* new_len_ptr = ctx_.builder().CreatePointerCast(new_vec, ctx_.ptrType());
     ctx_.builder().CreateStore(count, new_len_ptr);
 
-    // Copy the [start,end) slice (16 bytes per tagged element).
     llvm::Value* src_elem_base = ctx_.builder().CreateGEP(ctx_.int8Type(), vec_ptr,
         llvm::ConstantInt::get(ctx_.int64Type(), 8));
     llvm::Value* src_elem_typed = ctx_.builder().CreatePointerCast(src_elem_base, ctx_.ptrType());
@@ -2167,7 +2234,15 @@ llvm::Value* CollectionCodegen::vectorCopyNew(const eshkol_operations_t* op) {
         src_ptr, llvm::MaybeAlign(8),
         byte_count);
 
-    return tagged_.packHeapPtr(new_vec);
+    llvm::Value* vector_result = tagged_.packHeapPtr(new_vec);
+    ctx_.builder().CreateBr(copy_merge_block);
+    llvm::BasicBlock* vector_copy_exit = ctx_.builder().GetInsertBlock();
+
+    ctx_.builder().SetInsertPoint(copy_merge_block);
+    llvm::PHINode* final_result = ctx_.builder().CreatePHI(ctx_.taggedValueType(), 2, "vcopy_result");
+    final_result->addIncoming(tensor_result, tensor_copy_exit);
+    final_result->addIncoming(vector_result, vector_copy_exit);
+    return final_result;
 }
 
 llvm::Value* CollectionCodegen::vectorAppend(const eshkol_operations_t* op) {

--- a/tests/r7rs/conformance_batch_test.esk
+++ b/tests/r7rs/conformance_batch_test.esk
@@ -1,8 +1,9 @@
-; R7RS-small conformance batch (ESH-0152/0153/0155/0156)
+; R7RS-small conformance batch (ESH-0152/0153/0155/0156/0225)
 ;   ESH-0152  cond/case `=>` receiver form
 ;   ESH-0153  vector-copy (fresh slice)
 ;   ESH-0155  error-object? / error-object-message / error-object-irritants
 ;   ESH-0156  write escaping (strings and chars)
+;   ESH-0225  vector-copy on tensor-backed `#(...)` vector literals
 ; Runs identically under `-r` (JIT) and AOT.
 
 (define (check name ok)
@@ -41,6 +42,28 @@
     (let ((dst (vector-copy src)))
       (vector-set! dst 0 99)
       (= 1 (vector-ref src 0)))))
+
+; ── ESH-0225: vector-copy on tensor-backed `#(...)` literals ────────────
+; #(...) vector literals lower to a homogeneous-double tensor representation
+; internally, but R7RS says #(...) IS a vector, so vector-copy must accept it
+; and return a fresh copy of that same representation.
+(check "vector-copy on vector literal start..end slice"
+  (equal? '(2 3 4) (vector->list (vector-copy #(1 2 3 4 5) 1 4))))
+
+(check "vector-copy on vector literal whole vector"
+  (equal? '(1 2 3) (vector->list (vector-copy #(1 2 3)))))
+
+(check "vector-copy on vector literal from start"
+  (equal? '(30 40) (vector->list (vector-copy #(10 20 30 40) 2))))
+
+(check "vector-copy on vector literal empty slice"
+  (equal? '() (vector->list (vector-copy #(1 2 3) 1 1))))
+
+(define esh-0225-lit-vec #(1 2 3))
+(check "vector-copy on vector literal makes a fresh copy (source unmutated)"
+  (let ((dst (vector-copy esh-0225-lit-vec)))
+    (vector-set! dst 0 99)
+    (= 1 (vector-ref esh-0225-lit-vec 0))))
 
 ; ── ESH-0155: error-object family ──────────────────────────────────────
 (check "error-object? true for (error ...)"


### PR DESCRIPTION
## Summary

R7RS says `#(...)` **is** a vector literal, so `vector-copy` must accept it
exactly like a vector built with `(vector ...)`. Eshkol lowers `#(...)`
literals to `HEAP_SUBTYPE_TENSOR` (homogeneous doubles, separate
dims/elements arrays) while `(vector ...)`/`(make-vector ...)` build
`HEAP_SUBTYPE_VECTOR` (inline tagged slots). `CollectionCodegen::vectorCopyNew`
(ESH-0153) only handled the latter and raised
`vector-copy: argument is a tensor, not a vector` on the former:

```scheme
(vector-copy #(1 2 3 4 5) 1 4)      ; => error (BUG)
(vector-copy (vector 1 2 3 4 5) 1 4) ; => #(2 3 4) (already worked)
```

This was the **last remaining divergence** in the reference-Scheme
differential oracle (PR #140, adversarial pillar P7a): 33/34 AGREE with
`0013_vector_basic` as the sole `ESHKOL-DIVERGES` case (its final line is
`(display (vector-copy #(1 2 3 4 5) 1 4))`).

## Fix

`lib/backend/collection_codegen.cpp::CollectionCodegen::vectorCopyNew` now
dispatches on the header subtype at `ptr-8`, the same way
`vector-ref`/`vector-length`/`vector-map` already do, instead of
unconditionally rejecting `HEAP_SUBTYPE_TENSOR`:

- **Length read** branches to the tensor struct's `total_elements` field
  (offset 3) for `HEAP_SUBTYPE_TENSOR` vs. the inline length field for
  `HEAP_SUBTYPE_VECTOR`, merged via a PHI. `start`/`end`/bounds-check logic
  is shared and unchanged.
- **Allocation + copy** branches on the same subtype check:
  - tensor path: allocates a fresh **rank-1** tensor (new dims array
    `[count]`, fresh `count * sizeof(double)` elements buffer) and memcpys
    the `[start,end)` slice of raw elements — mirrors the existing tensor
    `cdr` pattern elsewhere in this file.
  - vector path: the original ESH-0153 code, unchanged, just moved into its
    own basic block.
  - Both merge into one PHI'd tagged result via `packHeapPtr`.

`vector-copy!` (`CollectionCodegen::vectorCopy`) is untouched — it has no
tensor-rejecting guard to begin with (it just assumes vector layout
unconditionally on both `to` and `from`), which is a separate, out-of-scope
latent issue, not this bug.

## Test plan

- [x] `(vector-copy #(1 2 3 4 5) 1 4)` => `#(2 3 4)` under `-r` and AOT
- [x] `(vector-copy #(1 2 3))` => `#(1 2 3)` under `-r` and AOT
- [x] `tests/r7rs/conformance_batch_test.esk` extended with literal-vector
      cases (slice, whole, from-start, empty, freshness) — 24/24 PASS under
      both `-r` and AOT
- [x] Constructed-vector `vector-copy` path (ESH-0153) regression-free
- [x] `scripts/run_sicp_smoke.sh` — 88/88 gate probes PASS
- [x] `scripts/run_tensor_collection_depth.sh` — no regressions
- [x] Vector/tensor edge-matrix pairs and stress corpora (100k vector,
      1024×1024 tensor matmul) — all pass
- [x] Reference-Scheme differential oracle corpus (from PR #140, run
      locally against this fix): **34/34 AGREE** (was 33/34), including
      `0013_vector_basic`