### PR TITLE
docs: v1.3.0-evolve announcement + release blog post

### DIFF
--- a/ANNOUNCEMENT.md
+++ b/ANNOUNCEMENT.md
@@ -1,0 +1,120 @@
+# Eshkol v1.3.0-evolve — arbitrary-order automatic differentiation, and a compiler you can trust with long-running programs
+
+**Eshkol v1.3.0-evolve ships a Taylor-tower automatic-differentiation engine that computes exact derivatives of *any* order — including exact bignum/rational coefficients no double-based system can produce — alongside 100% conformance with a portable R7RS corpus verified against chibi-scheme, and a hardening pass across tail calls, memory, and shutdown that targets the kind of bug that only shows up in a program that runs for a long time.**
+
+Eshkol is Scheme (R7RS) compiled to native code via LLVM, with automatic differentiation as a compiler primitive rather than a library. v1.3.0-evolve is the "evolve" release: it takes AD from "correct at first and second order" to "correct, exact, and validated at *every* order," and closes out a long list of robustness gaps found by a new permanent adversarial-testing program shipped in the same release.
+
+Full engineering detail lives in [CHANGELOG.md](CHANGELOG.md); the user-facing summary is [RELEASE_NOTES.md](RELEASE_NOTES.md); the complete AD walkthrough is the [Automatic Differentiation guide](docs/guide/AUTOMATIC_DIFFERENTIATION.md) (PR #180). This document is the release announcement — quotable, and every claim below is grounded in shipped code and a real, run command.
+
+---
+
+## What's new
+
+### Arbitrary-order automatic differentiation (the headline)
+
+Eshkol's forward-mode, reverse-mode, and symbolic AD were already exact at first and second order. v1.3.0-evolve adds a second axis on top of that: **order**. A new Taylor-tower engine — designed in [`docs/design/AD_TAYLOR_TOWER.md`](docs/design/AD_TAYLOR_TOWER.md) and delivered across thirteen gated phases, P0 through P12 (PRs #147, #158, #160, #162, #163, #167–#169, #173, #174, #177, #178) — computes *every* derivative up to an arbitrary order `k` in one pass, using closed Taylor recurrences (`lib/core/taylor_recurrences.def`, `lib/core/runtime_taylor.c`) instead of nested dual numbers. Nested/hyper-dual AD doubles its representation with every additional order (2^k); Taylor-mode is `k+1` coefficients and O(k²) work — polynomial, not exponential, in the order.
+
+That matters because it is the same design JAX's `jax.experimental.jet` uses — and Eshkol's implementation goes further in three ways mainstream AD/ML frameworks (JAX, PyTorch) do not offer at the language level:
+
+- **Exact coefficients.** When the seed point is an exact number (an integer or rational, not a `double`) and the differentiated function only uses exact-preserving operators (`+ - * /` and integer `expt`), `derivative-n` and `taylor` return **exact arbitrary-precision** (bignum/rational) results — not floating-point approximations. The moment a transcendental primitive (`exp`, `sin`, ...) enters the computation, the tower gracefully demotes to the ordinary double tower, matching R7RS's own exactness-contagion discipline.
+- **Validated enclosures.** `taylor-model`, `tm-range`, and `tm-eval` pair the Taylor polynomial with a rigorous interval-remainder bound, giving a *provable* enclosure of a function's range — not just a point estimate.
+- **AD as a language property, not a library call.** Towers are tensor-valued (differentiate through `matmul`/`conv2d`/activations), compose through reverse-mode (checkpointed reverse-over-Taylor for memory-efficient high-order gradients), recover sparse high-order structure via graph coloring (`sparse-hessian`), and work correctly through `if`/`cond`/named-let/recursion — differentiable control flow, not just differentiable expressions.
+
+Perturbation confusion (the classic nested-derivative correctness trap) is handled structurally: every differentiation context gets its own epoch tag carried in the tower's header, so an inner and outer `derivative` can never silently cross-contaminate.
+
+Here it is, run for real — bignum-exact derivatives and a full Taylor series, straight from `eshkol-run -r`:
+
+```scheme
+;; f(x) = x^30 — arbitrary order, exact
+(define (f x) (expt x 30))
+
+(display "f^(12)(7), exact bignum: ")
+(display (derivative-n f 7 12))
+(newline)
+(display "  exact? ") (display (exact? (derivative-n f 7 12))) (newline)
+
+;; 1/(1-x) — exact rational-point derivative
+(define (geom x) (/ 1 (- 1 x)))
+(display "geom^(6)(1/2), exact: ")
+(display (derivative-n geom (/ 1 2) 6))
+(newline)
+
+;; Full Taylor series, order 5, exact rational coefficients
+(display "taylor(f, x0=2, order 5): ")
+(display (taylor f 2 5))
+(newline)
+```
+
+Real output, on this release:
+
+```
+f^(12)(7), exact bignum: 67465815595294257109436307840000
+  exact? #t
+geom^(6)(1/2), exact: 92160
+taylor(f, x0=2, order 5): (1073741824 16106127360 116769423360 544923975680 1839118417920 4781707886592)
+```
+
+Every value is exact — `(exact? ...)` returns `#t` — and the first Taylor coefficient, `1073741824`, is `2^30` on the nose, confirming the series is centered correctly. No floating-point error anywhere in the pipeline. See the [Automatic Differentiation guide](docs/guide/AUTOMATIC_DIFFERENTIATION.md) for the full operator-by-operator walkthrough with verified output for all thirteen phases, and [`docs/reference/ad/INDEX.md`](docs/reference/ad/INDEX.md) for the API reference.
+
+### 100% R7RS conformance on the portable corpus
+
+A new reference-Scheme differential oracle (P7a) runs the same portable R7RS-small program on Eshkol and on **chibi-scheme 0.12.0** — the strictest mainstream R7RS-small implementation — and diffs the output. It started the release cycle at 27/34 (79.4%) programs agreeing; every divergence found is now fixed: `apply` with leading arguments before the final list, multi-vector `vector-map`/`vector-for-each`, quasiquoted vector literals, `cond`/`case` `=>` arrow clauses, an allocating `vector-copy`, and more. Re-run live for this announcement:
+
+```
+Total         : 34
+AGREE         : 34
+ESHKOL-DIVERGES : 0
+Agreement rate: 100.0%
+Gate          : PASS  (PASS iff every program AGREES)
+```
+
+(`scripts/run_reference_differential.sh`, corpus in `tests/reference-diff/corpus/`.)
+
+### Robustness: tail calls, memory, and shutdown
+
+A cluster of fixes targets the class of bug that only shows up in a program that runs for a long time or recurses deeply, not in a quick test:
+
+- **Proper mutual tail calls** (ESH-0102): a call in tail position to another function is now emitted as an LLVM `musttail` call, so mutually tail-recursive functions (`even?`/`odd?`-style state machines) run in O(1) stack instead of overflowing after ~300k hops.
+- **Bounded-RSS long-running loops** (ESH-0214/ESH-0214b): named-let TCO loops get automatic, zero-annotation per-iteration arena-scope reclamation, closing a production-triggered class of unbounded memory growth.
+- **Safe teardown** (ESH-0216): `eshkol_runtime_shutdown()` now stops and joins the global parallel thread pool before running shutdown hooks, closing a use-after-free race that could `SIGSEGV` well after a graceful `SIGTERM` was already logged; AOT-compiled binaries now also emit the paired runtime shutdown call they were previously skipping entirely.
+
+Full root-cause detail for each: [CHANGELOG.md](CHANGELOG.md).
+
+### A hardened, permanent adversarial-testing program
+
+This release also ships the testing infrastructure that found and closed the gaps above, wired permanently into the ICC release oracle rather than run once and discarded: a multi-path differential harness with a seeded fuzzer, a feature-pair edge matrix, an AD finite-difference oracle, a stress harness with RSS/time budgets, a VM-parity ratchet, depth-parametric sweeps, and now the external reference-Scheme differential oracle described above. See [`docs/TESTING.md`](docs/TESTING.md).
+
+---
+
+## Why it matters
+
+Differentiable programming today mostly means "trace a Python function with a library and hope the trace is faithful." Eshkol takes the opposite bet: make the derivative operator part of the language the compiler already understands, so it composes with closures, recursion, control flow, and the numeric tower the same way `+` does — and, as of this release, at any order, exactly, with a provable error bound when you need one. That is a meaningfully larger AD surface than what JAX or PyTorch expose to user code today, delivered from an ahead-of-time native compiler rather than a runtime tracer.
+
+The robustness work matters for a different reason: a differentiable systems language is only useful if the programs built on it can run unattended. Proper tail calls, bounded memory in long-running loops, and a shutdown path that doesn't race are the difference between a research demo and something you can leave running.
+
+## Get started
+
+```bash
+brew tap tsotchke/eshkol && brew install eshkol
+```
+
+Or build from source (LLVM 21+, C++20, CMake 3.14+) — see [README.md](README.md#quick-start) and [`docs/tutorials/00_FIRST_5_MINUTES.md`](docs/tutorials/00_FIRST_5_MINUTES.md).
+
+Try the AD example above yourself:
+
+```bash
+eshkol-run -r your_file.esk
+```
+
+- **[Automatic Differentiation guide](docs/guide/AUTOMATIC_DIFFERENTIATION.md)** — the full P0–P12 walkthrough, every example verified against a real build (PR #180).
+- **[Eshkol Language Guide](ESHKOL_LANGUAGE_GUIDE.md)** — tutorial introduction to the language.
+- **[CHANGELOG.md](CHANGELOG.md)** — itemized engineering detail, phase by phase.
+- **[RELEASE_NOTES.md](RELEASE_NOTES.md)** — the user-facing release summary, with the full gate matrix.
+
+## Under the hood
+
+The Taylor tower represents a function's local behavior as a truncated power series, `f(x0 + t) = Σ c_k · t^k`, so `f⁽ⁿ⁾(x0) = n! · c_n`. Each primitive operator (`+ - * / exp log sin cos sqrt tan atan tanh pow ...`) has a closed recurrence for producing its output series' coefficients from its input series' coefficients — for example, Cauchy convolution for multiplication (`s_k = Σ_{j=0..k} u_j · w_{k-j}`) and a linear recurrence for `exp`/`log`/`sin`/`cos`. Composing these recurrences through a program the way the LLVM backend already composes arithmetic gives arbitrary-order differentiation at `O(k²)` cost, with **zero heap allocation** on the common path: when the order `k` is a literal at the call site — the overwhelmingly common case in a compiler — the entire tower is unrolled into stack-allocated, branch-free SSA IR at compile time. A runtime heap-allocated tower (`HEAP_SUBTYPE_TAYLOR`) is the correctness fallback for a dynamically chosen order. Every recurrence in the shared table (`taylor_recurrences.def`) auto-generates its own per-primitive analytic correctness gate, so adding a new differentiable primitive adds its own test.
+
+---
+
+*Eshkol v1.3.0-evolve. MIT License. [github.com/tsotchke/eshkol](https://github.com/tsotchke/eshkol)*

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Eshkol is a Scheme-based programming language that unifies functional programmin
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![Version](https://img.shields.io/badge/version-v1.3.0--evolve-green.svg)](RELEASE_NOTES.md) [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](CMakeLists.txt)
 
+📣 **v1.3.0-evolve released** — see [ANNOUNCEMENT.md](ANNOUNCEMENT.md) for the full release story.
+
 <br>
 
 <img alt="Eshkol" src="./site/static/img/eshkol-logo-light-transparent.png" width="320">

--- a/scripts/build-site-content.sh
+++ b/scripts/build-site-content.sh
@@ -11,7 +11,7 @@ mkdir -p "$CONTENT_DIR"
 echo "Building site content from markdown docs..."
 
 # Root docs
-for doc in ESHKOL_LANGUAGE_GUIDE ESHKOL_QUICK_REFERENCE ROADMAP CONTRIBUTING; do
+for doc in ESHKOL_LANGUAGE_GUIDE ESHKOL_QUICK_REFERENCE ROADMAP CONTRIBUTING ANNOUNCEMENT; do
     if [ -f "${doc}.md" ]; then
         out="$CONTENT_DIR/$(echo "$doc" | tr '[:upper:]' '[:lower:]').html"
         pandoc "${doc}.md" -f markdown -t html --no-highlight -o "$out"

--- a/site/src/main.esk
+++ b/site/src/main.esk
@@ -1146,6 +1146,10 @@
           (render-sidebar-item gs "Computable Transformer" "https://raw.githubusercontent.com/tsotchke/eshkol/master/docs/breakdown/COMPUTABLE_TRANSFORMER.md")
           (render-sidebar-item gs "VM as Weight Matrices" "https://raw.githubusercontent.com/tsotchke/eshkol/master/docs/breakdown/VM_MEMORY_OPS_AS_WEIGHT_MATRICES.md"))
 
+        ;; Announcements
+        (let ((ga (render-sidebar-group sidebar "ANNOUNCEMENTS")))
+          (render-sidebar-item ga "v1.3.0-evolve: Arbitrary-Order AD" "https://raw.githubusercontent.com/tsotchke/eshkol/master/ANNOUNCEMENT.md"))
+
         ;; Project
         (let ((g6 (render-sidebar-group sidebar "PROJECT")))
           (render-sidebar-item g6 "Roadmap" "https://raw.githubusercontent.com/tsotchke/eshkol/master/ROADMAP.md")

--- a/site/static/content/announcement.html
+++ b/site/static/content/announcement.html
@@ -1,0 +1,226 @@
+<h1
+id="eshkol-v1.3.0-evolve-arbitrary-order-automatic-differentiation-and-a-compiler-you-can-trust-with-long-running-programs">Eshkol
+v1.3.0-evolve — arbitrary-order automatic differentiation, and a
+compiler you can trust with long-running programs</h1>
+<p><strong>Eshkol v1.3.0-evolve ships a Taylor-tower
+automatic-differentiation engine that computes exact derivatives of
+<em>any</em> order — including exact bignum/rational coefficients no
+double-based system can produce — alongside 100% conformance with a
+portable R7RS corpus verified against chibi-scheme, and a hardening pass
+across tail calls, memory, and shutdown that targets the kind of bug
+that only shows up in a program that runs for a long time.</strong></p>
+<p>Eshkol is Scheme (R7RS) compiled to native code via LLVM, with
+automatic differentiation as a compiler primitive rather than a library.
+v1.3.0-evolve is the “evolve” release: it takes AD from “correct at
+first and second order” to “correct, exact, and validated at
+<em>every</em> order,” and closes out a long list of robustness gaps
+found by a new permanent adversarial-testing program shipped in the same
+release.</p>
+<p>Full engineering detail lives in <a
+href="CHANGELOG.md">CHANGELOG.md</a>; the user-facing summary is <a
+href="RELEASE_NOTES.md">RELEASE_NOTES.md</a>; the complete AD
+walkthrough is the <a
+href="docs/guide/AUTOMATIC_DIFFERENTIATION.md">Automatic Differentiation
+guide</a> (PR #180). This document is the release announcement —
+quotable, and every claim below is grounded in shipped code and a real,
+run command.</p>
+<hr />
+<h2 id="whats-new">What’s new</h2>
+<h3
+id="arbitrary-order-automatic-differentiation-the-headline">Arbitrary-order
+automatic differentiation (the headline)</h3>
+<p>Eshkol’s forward-mode, reverse-mode, and symbolic AD were already
+exact at first and second order. v1.3.0-evolve adds a second axis on top
+of that: <strong>order</strong>. A new Taylor-tower engine — designed in
+<a
+href="docs/design/AD_TAYLOR_TOWER.md"><code>docs/design/AD_TAYLOR_TOWER.md</code></a>
+and delivered across thirteen gated phases, P0 through P12 (PRs #147,
+#158, #160, #162, #163, #167–#169, #173, #174, #177, #178) — computes
+<em>every</em> derivative up to an arbitrary order <code>k</code> in one
+pass, using closed Taylor recurrences
+(<code>lib/core/taylor_recurrences.def</code>,
+<code>lib/core/runtime_taylor.c</code>) instead of nested dual numbers.
+Nested/hyper-dual AD doubles its representation with every additional
+order (2^k); Taylor-mode is <code>k+1</code> coefficients and O(k²) work
+— polynomial, not exponential, in the order.</p>
+<p>That matters because it is the same design JAX’s
+<code>jax.experimental.jet</code> uses — and Eshkol’s implementation
+goes further in three ways mainstream AD/ML frameworks (JAX, PyTorch) do
+not offer at the language level:</p>
+<ul>
+<li><strong>Exact coefficients.</strong> When the seed point is an exact
+number (an integer or rational, not a <code>double</code>) and the
+differentiated function only uses exact-preserving operators
+(<code>+ - * /</code> and integer <code>expt</code>),
+<code>derivative-n</code> and <code>taylor</code> return <strong>exact
+arbitrary-precision</strong> (bignum/rational) results — not
+floating-point approximations. The moment a transcendental primitive
+(<code>exp</code>, <code>sin</code>, …) enters the computation, the
+tower gracefully demotes to the ordinary double tower, matching R7RS’s
+own exactness-contagion discipline.</li>
+<li><strong>Validated enclosures.</strong> <code>taylor-model</code>,
+<code>tm-range</code>, and <code>tm-eval</code> pair the Taylor
+polynomial with a rigorous interval-remainder bound, giving a
+<em>provable</em> enclosure of a function’s range — not just a point
+estimate.</li>
+<li><strong>AD as a language property, not a library call.</strong>
+Towers are tensor-valued (differentiate through
+<code>matmul</code>/<code>conv2d</code>/activations), compose through
+reverse-mode (checkpointed reverse-over-Taylor for memory-efficient
+high-order gradients), recover sparse high-order structure via graph
+coloring (<code>sparse-hessian</code>), and work correctly through
+<code>if</code>/<code>cond</code>/named-let/recursion — differentiable
+control flow, not just differentiable expressions.</li>
+</ul>
+<p>Perturbation confusion (the classic nested-derivative correctness
+trap) is handled structurally: every differentiation context gets its
+own epoch tag carried in the tower’s header, so an inner and outer
+<code>derivative</code> can never silently cross-contaminate.</p>
+<p>Here it is, run for real — bignum-exact derivatives and a full Taylor
+series, straight from <code>eshkol-run -r</code>:</p>
+<pre class="scheme"><code>;; f(x) = x^30 — arbitrary order, exact
+(define (f x) (expt x 30))
+
+(display &quot;f^(12)(7), exact bignum: &quot;)
+(display (derivative-n f 7 12))
+(newline)
+(display &quot;  exact? &quot;) (display (exact? (derivative-n f 7 12))) (newline)
+
+;; 1/(1-x) — exact rational-point derivative
+(define (geom x) (/ 1 (- 1 x)))
+(display &quot;geom^(6)(1/2), exact: &quot;)
+(display (derivative-n geom (/ 1 2) 6))
+(newline)
+
+;; Full Taylor series, order 5, exact rational coefficients
+(display &quot;taylor(f, x0=2, order 5): &quot;)
+(display (taylor f 2 5))
+(newline)</code></pre>
+<p>Real output, on this release:</p>
+<pre><code>f^(12)(7), exact bignum: 67465815595294257109436307840000
+  exact? #t
+geom^(6)(1/2), exact: 92160
+taylor(f, x0=2, order 5): (1073741824 16106127360 116769423360 544923975680 1839118417920 4781707886592)</code></pre>
+<p>Every value is exact — <code>(exact? ...)</code> returns
+<code>#t</code> — and the first Taylor coefficient,
+<code>1073741824</code>, is <code>2^30</code> on the nose, confirming
+the series is centered correctly. No floating-point error anywhere in
+the pipeline. See the <a
+href="docs/guide/AUTOMATIC_DIFFERENTIATION.md">Automatic Differentiation
+guide</a> for the full operator-by-operator walkthrough with verified
+output for all thirteen phases, and <a
+href="docs/reference/ad/INDEX.md"><code>docs/reference/ad/INDEX.md</code></a>
+for the API reference.</p>
+<h3 id="r7rs-conformance-on-the-portable-corpus">100% R7RS conformance
+on the portable corpus</h3>
+<p>A new reference-Scheme differential oracle (P7a) runs the same
+portable R7RS-small program on Eshkol and on <strong>chibi-scheme
+0.12.0</strong> — the strictest mainstream R7RS-small implementation —
+and diffs the output. It started the release cycle at 27/34 (79.4%)
+programs agreeing; every divergence found is now fixed:
+<code>apply</code> with leading arguments before the final list,
+multi-vector <code>vector-map</code>/<code>vector-for-each</code>,
+quasiquoted vector literals, <code>cond</code>/<code>case</code>
+<code>=&gt;</code> arrow clauses, an allocating
+<code>vector-copy</code>, and more. Re-run live for this
+announcement:</p>
+<pre><code>Total         : 34
+AGREE         : 34
+ESHKOL-DIVERGES : 0
+Agreement rate: 100.0%
+Gate          : PASS  (PASS iff every program AGREES)</code></pre>
+<p>(<code>scripts/run_reference_differential.sh</code>, corpus in
+<code>tests/reference-diff/corpus/</code>.)</p>
+<h3 id="robustness-tail-calls-memory-and-shutdown">Robustness: tail
+calls, memory, and shutdown</h3>
+<p>A cluster of fixes targets the class of bug that only shows up in a
+program that runs for a long time or recurses deeply, not in a quick
+test:</p>
+<ul>
+<li><strong>Proper mutual tail calls</strong> (ESH-0102): a call in tail
+position to another function is now emitted as an LLVM
+<code>musttail</code> call, so mutually tail-recursive functions
+(<code>even?</code>/<code>odd?</code>-style state machines) run in O(1)
+stack instead of overflowing after ~300k hops.</li>
+<li><strong>Bounded-RSS long-running loops</strong>
+(ESH-0214/ESH-0214b): named-let TCO loops get automatic, zero-annotation
+per-iteration arena-scope reclamation, closing a production-triggered
+class of unbounded memory growth.</li>
+<li><strong>Safe teardown</strong> (ESH-0216):
+<code>eshkol_runtime_shutdown()</code> now stops and joins the global
+parallel thread pool before running shutdown hooks, closing a
+use-after-free race that could <code>SIGSEGV</code> well after a
+graceful <code>SIGTERM</code> was already logged; AOT-compiled binaries
+now also emit the paired runtime shutdown call they were previously
+skipping entirely.</li>
+</ul>
+<p>Full root-cause detail for each: <a
+href="CHANGELOG.md">CHANGELOG.md</a>.</p>
+<h3 id="a-hardened-permanent-adversarial-testing-program">A hardened,
+permanent adversarial-testing program</h3>
+<p>This release also ships the testing infrastructure that found and
+closed the gaps above, wired permanently into the ICC release oracle
+rather than run once and discarded: a multi-path differential harness
+with a seeded fuzzer, a feature-pair edge matrix, an AD
+finite-difference oracle, a stress harness with RSS/time budgets, a
+VM-parity ratchet, depth-parametric sweeps, and now the external
+reference-Scheme differential oracle described above. See <a
+href="docs/TESTING.md"><code>docs/TESTING.md</code></a>.</p>
+<hr />
+<h2 id="why-it-matters">Why it matters</h2>
+<p>Differentiable programming today mostly means “trace a Python
+function with a library and hope the trace is faithful.” Eshkol takes
+the opposite bet: make the derivative operator part of the language the
+compiler already understands, so it composes with closures, recursion,
+control flow, and the numeric tower the same way <code>+</code> does —
+and, as of this release, at any order, exactly, with a provable error
+bound when you need one. That is a meaningfully larger AD surface than
+what JAX or PyTorch expose to user code today, delivered from an
+ahead-of-time native compiler rather than a runtime tracer.</p>
+<p>The robustness work matters for a different reason: a differentiable
+systems language is only useful if the programs built on it can run
+unattended. Proper tail calls, bounded memory in long-running loops, and
+a shutdown path that doesn’t race are the difference between a research
+demo and something you can leave running.</p>
+<h2 id="get-started">Get started</h2>
+<pre class="bash"><code>brew tap tsotchke/eshkol &amp;&amp; brew install eshkol</code></pre>
+<p>Or build from source (LLVM 21+, C++20, CMake 3.14+) — see <a
+href="README.md#quick-start">README.md</a> and <a
+href="docs/tutorials/00_FIRST_5_MINUTES.md"><code>docs/tutorials/00_FIRST_5_MINUTES.md</code></a>.</p>
+<p>Try the AD example above yourself:</p>
+<pre class="bash"><code>eshkol-run -r your_file.esk</code></pre>
+<ul>
+<li><strong><a href="docs/guide/AUTOMATIC_DIFFERENTIATION.md">Automatic
+Differentiation guide</a></strong> — the full P0–P12 walkthrough, every
+example verified against a real build (PR #180).</li>
+<li><strong><a href="ESHKOL_LANGUAGE_GUIDE.md">Eshkol Language
+Guide</a></strong> — tutorial introduction to the language.</li>
+<li><strong><a href="CHANGELOG.md">CHANGELOG.md</a></strong> — itemized
+engineering detail, phase by phase.</li>
+<li><strong><a href="RELEASE_NOTES.md">RELEASE_NOTES.md</a></strong> —
+the user-facing release summary, with the full gate matrix.</li>
+</ul>
+<h2 id="under-the-hood">Under the hood</h2>
+<p>The Taylor tower represents a function’s local behavior as a
+truncated power series, <code>f(x0 + t) = Σ c_k · t^k</code>, so
+<code>f⁽ⁿ⁾(x0) = n! · c_n</code>. Each primitive operator
+(<code>+ - * / exp log sin cos sqrt tan atan tanh pow ...</code>) has a
+closed recurrence for producing its output series’ coefficients from its
+input series’ coefficients — for example, Cauchy convolution for
+multiplication (<code>s_k = Σ_{j=0..k} u_j · w_{k-j}</code>) and a
+linear recurrence for
+<code>exp</code>/<code>log</code>/<code>sin</code>/<code>cos</code>.
+Composing these recurrences through a program the way the LLVM backend
+already composes arithmetic gives arbitrary-order differentiation at
+<code>O(k²)</code> cost, with <strong>zero heap allocation</strong> on
+the common path: when the order <code>k</code> is a literal at the call
+site — the overwhelmingly common case in a compiler — the entire tower
+is unrolled into stack-allocated, branch-free SSA IR at compile time. A
+runtime heap-allocated tower (<code>HEAP_SUBTYPE_TAYLOR</code>) is the
+correctness fallback for a dynamically chosen order. Every recurrence in
+the shared table (<code>taylor_recurrences.def</code>) auto-generates
+its own per-primitive analytic correctness gate, so adding a new
+differentiable primitive adds its own test.</p>
+<hr />
+<p><em>Eshkol v1.3.0-evolve. MIT License. <a
+href="https://github.com/tsotchke/eshkol">github.com/tsotchke/eshkol</a></em></p>


### PR DESCRIPTION
## Summary

- Adds `ANNOUNCEMENT.md` — the press-style release announcement for
  v1.3.0-evolve. Leads with the headline story: arbitrary-order
  Taylor-tower automatic differentiation (P0-P12, PRs #147, #158, #160,
  #162, #163, #167-#169, #173, #174, #177, #178), including exact
  bignum/rational coefficients, validated Taylor-model enclosures,
  sparse high-order tensors, checkpointed reverse mode, and
  differentiable control flow. Secondary sections cover 100% R7RS
  conformance on the portable reference-diff corpus (re-verified live
  against chibi-scheme 0.12.0 for this PR: 34/34 AGREE) and the
  tail-call/memory/shutdown robustness pass (musttail mutual tail
  calls, bounded-RSS loop arena reclamation, safe shutdown teardown).
- The runnable AD example in the doc was executed against a real build
  (`build/eshkol-run -r`) and its output pasted verbatim — no invented
  numbers.
- Wires the announcement into the website: a new `ANNOUNCEMENTS`
  sidebar group in the Docs page (`site/src/main.esk`), following the
  exact convention of the existing sidebar groups (raw-GitHub-URL +
  `web-load-content`), plus the matching pre-rendered pandoc fragment
  (`site/static/content/announcement.html`) generated via
  `scripts/build-site-content.sh` (added `ANNOUNCEMENT` to its doc
  list). Verified `main.esk` still compiles cleanly with
  `eshkol-run --wasm`.
- `README.md` gets a one-line pointer to `ANNOUNCEMENT.md` only — the
  fuller badge/blurb refresh is left to the in-flight
  `docs/v1.3-release-docs` branch, which already owns
  CHANGELOG.md/RELEASE_NOTES.md/README.md for this release, to avoid
  duplicating or conflicting with that work.

## Coordination notes

- References (does not duplicate) the AD user guide, PR #180
  (`docs/guide/AUTOMATIC_DIFFERENTIATION.md`).
- References (does not duplicate) `CHANGELOG.md` / `RELEASE_NOTES.md`,
  owned by the in-flight `docs/v1.3-release-docs` branch.
- Does **not** touch `site/static/eshkol-site.wasm`: a local
  `eshkol-run --wasm` build of the changed `main.esk` produced a binary
  ~200KB larger than the committed one, indicating the committed wasm
  was built by a different toolchain/pipeline (the GitHub Pages CI
  build via `scripts/build-site.sh`). Shipping a locally-built binary
  risked a toolchain mismatch, so the source change is included and the
  binary rebuild is left to the canonical CI build on merge/deploy.

## Test plan

- [x] `build/eshkol-run -r` on the exact AD snippet in `ANNOUNCEMENT.md`
      — output matches what's pasted in the doc.
- [x] `scripts/run_reference_differential.sh` — 34/34 AGREE vs.
      chibi-scheme 0.12.0 (100.0%), re-run live for this PR.
- [x] `eshkol-run --wasm site/src/main.esk -o /tmp/x.wasm` — compiles
      cleanly with the new sidebar entry.
- [ ] Full site deploy (`scripts/build-site.sh` via the GitHub Pages
      workflow) to regenerate `site/static/eshkol-site.wasm` with the
      new nav entry live.