### PR TITLE
docs(roadmap): align derived roadmap views with v1.3.0-evolve shipped state; remove emoji

### DIFF
--- a/docs/COMPILER_ROADMAP.md
+++ b/docs/COMPILER_ROADMAP.md
@@ -76,7 +76,7 @@ Verification snapshot:
 | Version | Codename | Target date | Theme |
 |---|---|---|---|
 | v1.2.x | scale | May 2026 | Model I/O + Noesis M0 closeout |
-| v1.3 | evolve | Jun 2026 | R7RS polish + dev-experience + stdlib surface |
+| v1.3.0-evolve | evolve | Jul 2026 — **SHIPPED** | R7RS polish + dev-experience + stdlib surface — **plus the full arbitrary-order Taylor-tower AD matrix (P0–P12), 34/34 R7RS conformance, and permanent adversarial-testing infrastructure, all delivered ahead of the original plan** |
 | v1.4 | connection | Jul 2026 | Networking + concurrency + linear types |
 | v1.5 | intelligence | Aug 2026 | Neuro-symbolic bridge |
 | v1.6 | reasoning | Sep 2026 | Production logic engine |
@@ -90,31 +90,31 @@ Verification snapshot:
 ## v1.2.x — "scale" (closeout)
 
 Already-shipped items as of current branch:
-- #136 quasiquote codegen ✅
-- #137 hash-table SRFI-125 aliases ✅
-- #139 match `(? pred)` scoping ✅
-- Per-thread AD tape + arena init (#130) ✅
-- Image I/O arena safety (#107, #132) ✅
-- Symbol tagged-value consistency (#129) ✅
-- Python FFI structured returns + error recovery (#110) ✅
-- Car/cdr type guards on non-pair input (#135) ✅
-- v1.2 regression suite plus current 87-test edge/security suite ✅
+- #136 quasiquote codegen
+- #137 hash-table SRFI-125 aliases
+- #139 match `(? pred)` scoping
+- Per-thread AD tape + arena init (#130)
+- Image I/O arena safety (#107, #132)
+- Symbol tagged-value consistency (#129)
+- Python FFI structured returns + error recovery (#110)
+- Car/cdr type guards on non-pair input (#135)
+- v1.2 regression suite plus current 87-test edge/security suite
 
 **Noesis M0 closeout status (verified 2026-05-19)**
 
 | # | Item | Effort | Noesis tier |
 |---|---|---|---|
-| #138 | `define-record-type` codegen | ✅ done | M0 |
-| #140 | keyword-symbol parsing used by Noesis `':keyword` paths | ✅ done | M0 |
-| #142 | Testing framework (`define-test`, `check-equal?`) | ✅ done | M0 |
-| #143 | timing helpers / `(time …)` surface | ✅ done | M0 |
-| #144 | Binary ports + bytevector I/O | ✅ done | M0 |
-| #166 | `call-with-values` consumer-lambda stdlib | ✅ done | M0 |
-| #167 | Regex capture groups | ✅ done | M0 |
-| #168 | Time API (ISO8601 parse/format, duration) | ✅ done | M0 |
-| #169 | CLI argument parser stdlib | ✅ done | M0 |
-| #134 | Compile-to-binary `eval` linker | ✅ done | — |
-| #141 | match apostrophe-quote subject hang | ✅ done | — |
+| #138 | `define-record-type` codegen | done | M0 |
+| #140 | keyword-symbol parsing used by Noesis `':keyword` paths | done | M0 |
+| #142 | Testing framework (`define-test`, `check-equal?`) | done | M0 |
+| #143 | timing helpers / `(time …)` surface | done | M0 |
+| #144 | Binary ports + bytevector I/O | done | M0 |
+| #166 | `call-with-values` consumer-lambda stdlib | done | M0 |
+| #167 | Regex capture groups | done | M0 |
+| #168 | Time API (ISO8601 parse/format, duration) | done | M0 |
+| #169 | CLI argument parser stdlib | done | M0 |
+| #134 | Compile-to-binary `eval` linker | done | — |
+| #141 | match apostrophe-quote subject hang | done | — |
 
 **Exit criterion for v1.2**: Noesis M0 is fully unblocked. All 11 closeout
 items shipped. The current v1.2 edge/security suite passes 87/87,
@@ -145,7 +145,18 @@ Eshkol. The remaining work is v1.3+ productization.
 
 ---
 
-## v1.3 — "evolve" (June 2026)
+## v1.3 — "evolve" (SHIPPED as v1.3.0-evolve, July 2026)
+
+> **SHIPPED.** v1.3.0-evolve is released (tag `v1.3.0-evolve`; ICC
+> `v1.3-evolve` readiness oracle: `ready`, score 100). It delivered the
+> planned R7RS/dev-experience/stdlib work below **and much more**: the full
+> arbitrary-order Taylor-tower AD matrix (all 13 phases P0–P12), full R7RS
+> conformance (34/34 vs. chibi-scheme 0.12.0), TCO/closure/memory robustness
+> hardening, and permanent adversarial-testing infrastructure. The AD phases
+> P4–P12 — originally staged across v1.4 through v2.0 — all landed here ahead
+> of schedule. The task tiers below are retained as the as-planned engineering
+> record; see the canonical [`../ROADMAP.md`](../ROADMAP.md) and
+> [`../CHANGELOG.md`](../CHANGELOG.md) for as-shipped contents.
 
 R7RS polish, language ergonomics, stdlib expansion, developer experience.
 
@@ -265,15 +276,15 @@ Acceptance:
 ### Noesis M1 (Hiereia production stack)
 | # | Item | Effort |
 |---|---|---|
-| #154 | Extra AD ops (atan2, asin, acos, softmax, gelu, silu, sinh, cosh) | ✅ finite-difference coverage landed in v1.2.x |
-| #155 | Priority queues + sets + deques stdlib | ✅ landed in v1.2.x |
+| #154 | Extra AD ops (atan2, asin, acos, softmax, gelu, silu, sinh, cosh) | finite-difference coverage landed in v1.2.x |
+| #155 | Priority queues + sets + deques stdlib | landed in v1.2.x |
 | #147 | Structured logging (JSON-L + trace IDs) | core contracts tested; needs Noesis integration |
 | #149 | Capability / permission hooks | hosted allow-list hooks landed for agent surfaces and core file I/O |
 | #150 | Resource limits (CPU / memory / wall-time) | hosted env initialization, accounting, and watchdog primitives tested |
-| #170 | Reflection primitives (`procedure-arity`, `record-fields`, `describe`) | ✅ landed in v1.2.x |
-| #171 | Memoization / LRU cache stdlib | ✅ landed in v1.2.x |
-| #172 | JSON Schema validation | ✅ landed in v1.2.x |
-| #173 | PRNG seeding + deterministic replay | ✅ landed in v1.2.x |
+| #170 | Reflection primitives (`procedure-arity`, `record-fields`, `describe`) | landed in v1.2.x |
+| #171 | Memoization / LRU cache stdlib | landed in v1.2.x |
+| #172 | JSON Schema validation | landed in v1.2.x |
+| #173 | PRNG seeding + deterministic replay | landed in v1.2.x |
 
 Phase 2 productionizes this surface:
 - Keep focused tests for `core.logging`, including JSON escaping, trace-id
@@ -322,7 +333,7 @@ Acceptance:
 ### Stdlib — Noesis M2 items that are pure stdlib (no new substrate)
 | # | Item | Effort |
 |---|---|---|
-| #174 | SRFI-41 lazy streams | ✅ landed in v1.2.x |
+| #174 | SRFI-41 lazy streams | landed in v1.2.x |
 | #176 | Unicode `string-normalize`, TOML, YAML, URL parse/encode | 5-7 days |
 | #177 | SQLite migrations stdlib | 2 days |
 
@@ -720,15 +731,15 @@ target release version. Use this as the handoff cheatsheet.
 
 | # | Item | Noesis tier | Release |
 |---|---|---|---|
-| #136 | Quasiquote interpolation | M0 | v1.2.x ✅ |
-| #137 | Hash tables | M0 | v1.2.x ✅ |
-| #138 | `define-record-type` | M0 | v1.2.x ✅ |
-| #139 | match `(? pred)` | M0 | v1.2.x ✅ |
-| #140 | keyword-symbol parsing used by Noesis `':keyword` paths | M0 | v1.2.x ✅ |
-| #141 | match apostrophe-quote subject | — | v1.2.x ✅ |
-| #142 | Testing framework | M0 | v1.2.x ✅ |
-| #143 | `(time …)` macro | M0 | v1.2.x ✅ |
-| #144 | Binary ports + bytevector I/O | M0 | v1.2.x ✅ |
+| #136 | Quasiquote interpolation | M0 | v1.2.x |
+| #137 | Hash tables | M0 | v1.2.x |
+| #138 | `define-record-type` | M0 | v1.2.x |
+| #139 | match `(? pred)` | M0 | v1.2.x |
+| #140 | keyword-symbol parsing used by Noesis `':keyword` paths | M0 | v1.2.x |
+| #141 | match apostrophe-quote subject | — | v1.2.x |
+| #142 | Testing framework | M0 | v1.2.x |
+| #143 | `(time …)` macro | M0 | v1.2.x |
+| #144 | Binary ports + bytevector I/O | M0 | v1.2.x |
 | #145 | HTTP server | M1 | v1.4 |
 | #146 | WebSocket server | M1 | v1.4 |
 | #147 | Structured logging | M1 | v1.3 |
@@ -739,7 +750,7 @@ target release version. Use this as the handoff cheatsheet.
 | #152 | Tokenizer | M2 | v1.5 |
 | #153 | Sparse tensors | M2 | v1.5 |
 | #154 | Extra AD ops | M1 | v1.3 |
-| #155 | Priority queues / sets / deques | M1 | v1.2.x ✅ |
+| #155 | Priority queues / sets / deques | M1 | v1.2.x |
 | #156 | Threads + mutex + condvars | M3 | v1.4 |
 | #157 | Channels | M3 | v1.4 |
 | #158 | Async I/O event loop | M3 | v1.4 |
@@ -750,19 +761,19 @@ target release version. Use this as the handoff cheatsheet.
 | #163 | Protocol Buffers | M4 | v1.4 |
 | #164 | CRDT library | M4 | v1.8 |
 | #165 | Byzantine consensus | M4 | v2.0 |
-| #166 | call-with-values consumer | M0 | v1.2.x ✅ |
-| #167 | Regex capture groups | M0 | v1.2.x ✅ |
-| #168 | Time API (ISO8601 + duration) | M0 | v1.2.x ✅ |
-| #169 | CLI argparse | M0 | v1.2.x ✅ |
-| #170 | Reflection (`procedure-arity`, `type-name`, `describe`) | M1 | v1.2.x ✅ |
-| #171 | LRU cache | M1 | v1.2.x ✅ |
-| #172 | JSON Schema validation | M1 | v1.2.x ✅ |
-| #173 | PRNG seeding + deterministic replay | M1 | v1.2.x ✅ |
-| #174 | SRFI-41 streams | M2 stdlib | v1.2.x ✅ |
+| #166 | call-with-values consumer | M0 | v1.2.x |
+| #167 | Regex capture groups | M0 | v1.2.x |
+| #168 | Time API (ISO8601 + duration) | M0 | v1.2.x |
+| #169 | CLI argparse | M0 | v1.2.x |
+| #170 | Reflection (`procedure-arity`, `type-name`, `describe`) | M1 | v1.2.x |
+| #171 | LRU cache | M1 | v1.2.x |
+| #172 | JSON Schema validation | M1 | v1.2.x |
+| #173 | PRNG seeding + deterministic replay | M1 | v1.2.x |
+| #174 | SRFI-41 streams | M2 stdlib | v1.2.x |
 | #175 | CAS + Merkle trees | M2 | v1.4 |
 | #176 | Unicode NFC/NFD + TOML + YAML + URL | M2 stdlib | v1.3 |
 | #177 | SQLite migrations | M2 | v1.3 |
-| #134 | Compile-to-binary eval linker | — | v1.2.x ✅ |
+| #134 | Compile-to-binary eval linker | — | v1.2.x |
 
 ---
 

--- a/docs/vision/FUTURE_ROADMAP.md
+++ b/docs/vision/FUTURE_ROADMAP.md
@@ -12,66 +12,66 @@ This document outlines Eshkol's evolution from the **completed v1.0-foundation**
 
 ## v1.0-foundation: COMPLETED (2025)
 
-**Status:** ✅ **Production Release**
+**Status:** **Production Release**
 
 Eshkol v1.0-foundation delivers a production-ready compiler that tightly integrates automatic differentiation, deterministic arena memory management, and homoiconic native-code execution.
 
 ### Completed Achievements
 
 **Core Compiler:**
-- ✅ LLVM-based modular backend (21 specialized codegen modules)
-- ✅ Recursive descent parser with HoTT type expressions
-- ✅ Bidirectional type checker with gradual typing
-- ✅ Ownership and escape analysis
-- ✅ Module system with dependency resolution and cycle detection
-- ✅ Macro expansion (syntax-rules with hygienic macros)
-- ✅ Exception handling (guard/raise with R7RS semantics)
+- LLVM-based modular backend (21 specialized codegen modules)
+- Recursive descent parser with HoTT type expressions
+- Bidirectional type checker with gradual typing
+- Ownership and escape analysis
+- Module system with dependency resolution and cycle detection
+- Macro expansion (syntax-rules with hygienic macros)
+- Exception handling (guard/raise with R7RS semantics)
 
 **Automatic Differentiation:**
-- ✅ Forward-mode AD with dual numbers
-- ✅ Reverse-mode AD with computational graphs
-- ✅ Nested gradients up to 32 levels deep
-- ✅ Vector calculus operators: derivative, gradient, jacobian, hessian, divergence, curl, laplacian
-- ✅ Polymorphic arithmetic supporting int64/double/dual/tensor/AD-node
+- Forward-mode AD with dual numbers
+- Reverse-mode AD with computational graphs
+- Nested gradients up to 32 levels deep
+- Vector calculus operators: derivative, gradient, jacobian, hessian, divergence, curl, laplacian
+- Polymorphic arithmetic supporting int64/double/dual/tensor/AD-node
 
 **Memory Management:**
-- ✅ Arena allocation with OALR (Ownership-Aware Lexical Regions)
-- ✅ Escape analysis determining stack/region/shared allocation
-- ✅ with-region syntax for lexical memory scopes
-- ✅ Ownership tracking (owned, moved, borrowed states)
-- ✅ Deterministic deallocation (no garbage collection)
+- Arena allocation with OALR (Ownership-Aware Lexical Regions)
+- Escape analysis determining stack/region/shared allocation
+- with-region syntax for lexical memory scopes
+- Ownership tracking (owned, moved, borrowed states)
+- Deterministic deallocation (no garbage collection)
 
 **Data Structures:**
-- ✅ 16-byte tagged values with consolidated type system
-- ✅ 32-byte cons cells supporting mixed-type lists
-- ✅ N-dimensional tensors with element-wise operations
-- ✅ Hash tables with FNV-1a hashing
-- ✅ Heterogeneous vectors
-- ✅ UTF-8 strings with escape sequences
+- 16-byte tagged values with consolidated type system
+- 32-byte cons cells supporting mixed-type lists
+- N-dimensional tensors with element-wise operations
+- Hash tables with FNV-1a hashing
+- Heterogeneous vectors
+- UTF-8 strings with escape sequences
 
 **Standard Library:**
-- ✅ 60+ list operations (map, filter, fold, etc.)
-- ✅ 30+ string utilities
-- ✅ Functional programming (compose, curry, flip)
-- ✅ JSON parsing and serialization
-- ✅ CSV processing
-- ✅ Base64 encoding/decoding
-- ✅ Math library (linear algebra: det, inv, solve; numerical integration; root finding; statistics)
+- 60+ list operations (map, filter, fold, etc.)
+- 30+ string utilities
+- Functional programming (compose, curry, flip)
+- JSON parsing and serialization
+- CSV processing
+- Base64 encoding/decoding
+- Math library (linear algebra: det, inv, solve; numerical integration; root finding; statistics)
 
 **Development Tools:**
-- ✅ Interactive REPL with LLVM ORC JIT
-- ✅ Standalone compiler (eshkol-run)
-- ✅ Library compilation mode
-- ✅ Comprehensive test suite (170+ test files)
-- ✅ CMake build system
-- ✅ Docker containers
+- Interactive REPL with LLVM ORC JIT
+- Standalone compiler (eshkol-run)
+- Library compilation mode
+- Comprehensive test suite (170+ test files)
+- CMake build system
+- Docker containers
 
 **Documentation:**
-- ✅ Complete language specification (300+ features)
-- ✅ Language reference with examples
-- ✅ Architecture documentation
-- ✅ API reference
-- ✅ Quickstart guide
+- Complete language specification (300+ features)
+- Language reference with examples
+- Architecture documentation
+- API reference
+- Quickstart guide
 
 **What v1.0-foundation Proves:**
 - Compiler-integrated AD is achievable and practical
@@ -83,17 +83,26 @@ Eshkol v1.0-foundation delivers a production-ready compiler that tightly integra
 
 | Release | Timeframe | Status | Focus |
 |---------|-----------|--------|-------|
-| **v1.0-foundation** | **2025** | **✅ COMPLETE** | **Core compiler, AD system, arena memory, REPL** |
-| **v1.1-accelerate** | **Q1 2026** | **✅ COMPLETE** | **XLA backend, GPU acceleration, parallelism, consciousness engine** |
-| **v1.2-scale** | **Q2 2026** | **✅ COMPLETE** | **Full numeric tower (bignum / rational / complex), Metal + CUDA, XLA dual-mode, FFI hardening (HTTP / SQLite / subprocess / fs-watch), 22-builtin consciousness engine** |
-| **v1.2.1-scale** | **2026-05-20** | **✅ COMPLETE** | **Edge-case hardening: stdlib `LinkOnceODR`, parser line-tracking, closure capture in `dynamic-wind` / `call-cc` / `guard`, TCO context preservation, agent-FFI link wiring** |
-| **v1.3-evolve** | **Target Q3 2026** | 📋 Planned | **Effect/refinement type system, PGO + whole-program opt, distributed training, automatic C-header bindings** |
-| **v1.5-intelligence** | **Q4 2026** | 📋 Planned | **Neuro-symbolic integration, advanced optimizers, VM-as-transformer Stage 3 (lift remaining delegated opcodes into weight matrices)** |
-| **v2.0-quantum** | **2027+** | 🔬 Research | **Quantum computing, formal verification, fully verified compilation chain** |
+| **v1.0-foundation** | **2025** | **COMPLETE** | **Core compiler, AD system, arena memory, REPL** |
+| **v1.1-accelerate** | **Q1 2026** | **COMPLETE** | **XLA backend, GPU acceleration, parallelism, consciousness engine** |
+| **v1.2-scale** | **Q2 2026** | **COMPLETE** | **Full numeric tower (bignum / rational / complex), Metal + CUDA, XLA dual-mode, FFI hardening (HTTP / SQLite / subprocess / fs-watch), 22-builtin consciousness engine** |
+| **v1.2.1-scale** | **2026-05-20** | **COMPLETE** | **Edge-case hardening: stdlib `LinkOnceODR`, parser line-tracking, closure capture in `dynamic-wind` / `call-cc` / `guard`, TCO context preservation, agent-FFI link wiring** |
+| **v1.3.0-evolve** | **Jul 2026** | **SHIPPED** | **Arbitrary-order Taylor-tower AD matrix (all 13 phases P0–P12: exact bignum/rational coefficients, GUW multivariate mixed partials, reverse-over-Taylor, tensor towers, validated Taylor models, sparse high-order tensors, differentiable control flow, checkpointed reverse, tower numerics); full R7RS conformance (34/34 vs. chibi-scheme); TCO/closure/memory robustness hardening; permanent adversarial-testing infrastructure. See [`../../ROADMAP.md`](../../ROADMAP.md) (canonical) and [`../../CHANGELOG.md`](../../CHANGELOG.md).** |
+| **v1.4-connection** | **Target Q3 2026** | **Planned** | **Networking, TLS, event loop, linear resource types** |
+| **v1.5-intelligence** | **Q4 2026** | **Planned** | **Symbol embeddings, differentiable logic, LSTM/GRU, neuro-symbolic integration, VM-as-transformer Stage 3 (lift remaining delegated opcodes into weight matrices)** |
+| **v1.9-types** | **Dec 2026** | **Planned** | **Effect / refinement type system, dependent types, algebraic effects, session types** |
+| **v2.0-quantum** | **2027+** | **Research** | **Quantum computing, formal verification (Lean-certified validated-AD Taylor models), fully verified compilation chain** |
+
+> **Note:** items previously slotted under "v1.3" in this vision view — effect/refinement
+> types, PGO + whole-program optimization, distributed training, automatic C-header
+> bindings — were never part of what v1.3.0-evolve actually shipped. Effect/refinement
+> types now track to **v1.9-types**; PGO and whole-program opt are ongoing backend work;
+> C-header binding generation is a stdlib/tooling item. The canonical
+> [`ROADMAP.md`](../../ROADMAP.md) is authoritative for release contents.
 
 ## v1.1-accelerate: Performance and Parallelism (Q1 2026)
 
-**Status:** ✅ **COMPLETE (Production Release)**
+**Status:** **COMPLETE (Production Release)**
 
 Building on the v1.0 foundation, this release focuses on **computational acceleration** through XLA integration, automatic vectorization, and multi-core parallelism.
 
@@ -164,7 +173,7 @@ Building on the v1.0 foundation, this release focuses on **computational acceler
 
 ## v1.2-scale: Numeric Tower, GPU, Agent FFI, Production Deployment (Q2 2026)
 
-**Status:** ✅ **COMPLETE (Production Release).** Closed out as v1.2.1-scale on 2026-05-20.
+**Status:** **COMPLETE (Production Release).** Closed out as v1.2.1-scale on 2026-05-20.
 
 The release combined a production-grade numeric tower with the GPU dispatch infrastructure (Metal + CUDA + XLA) and the native agent FFI surface, plus the hardening pass that brought sanitiser-clean status across the regression suite.
 
@@ -213,7 +222,7 @@ The release combined a production-grade numeric tower with the GPU dispatch infr
 
 ## v1.5-intelligence: Neuro-Symbolic Integration (Q4 2026)
 
-**Status:** 📋 **Planned**
+**Status:** **Planned**
 
 Advanced AI capabilities building on v1.0's homoiconic foundation.
 
@@ -245,7 +254,7 @@ Advanced AI capabilities building on v1.0's homoiconic foundation.
 
 ## v2.0-quantum: Advanced Research Features (Q4 2026)
 
-**Status:** 🔬 **Research Phase**
+**Status:** **Research Phase**
 
 Long-term research directions extending Eshkol's capabilities into emerging computational paradigms.
 


### PR DESCRIPTION
## What

Brings the two derived roadmap views into agreement with the canonical `ROADMAP.md` (which the v1.3 release-docs PR #182 updates to mark **v1.3.0-evolve SHIPPED**), and removes emoji status markers from both in favor of a consistent plain-text convention.

## Why

The canonical roadmap now records v1.3.0-evolve as shipped — full Taylor-tower AD matrix (P0–P12), 34/34 R7RS conformance vs chibi-scheme, TCO/closure/memory hardening, permanent adversarial-testing infra (ICC `v1.3-evolve` readiness oracle: ready/100). Two derived views still contradicted it.

## Changes

- **docs/vision/FUTURE_ROADMAP.md** — v1.3 row said *Planned* with a scope that never shipped (effect types, PGO, distributed training, C-header bindings) and skipped v1.4. Now marked **SHIPPED** with true contents; unshipped items re-slotted (effect/refinement types → v1.9-types; PGO/whole-program → ongoing backend; C-header bindings → stdlib/tooling). Added v1.4 row.
- **docs/COMPILER_ROADMAP.md** — added an authoritative SHIPPED banner to the v1.3 section + status-table update; retained task tiers as the as-planned engineering record.
- **Both** — removed all emoji status markers; normalized to COMPLETE / SHIPPED / Planned / Research.

Docs-only. No code paths touched.