### PR TITLE
docs(capi): document backend codegen headers (A)

### DIFF
--- a/inc/eshkol/backend/arithmetic_codegen.h
+++ b/inc/eshkol/backend/arithmetic_codegen.h
@@ -234,20 +234,109 @@ public:
 
     // === Bignum dispatch helpers (public for use by llvm_codegen eqv?/equal?) ===
 
+    /**
+     * Emit a call into the bignum runtime's binary-op kernel (add/sub/mul/
+     * div/mod/quotient/remainder/negate), used once emitIsBignumCheck has
+     * confirmed at least one operand is an arbitrary-precision integer.
+     * @param left Left operand (tagged_value)
+     * @param right Right operand (tagged_value)
+     * @param op_code Bignum binary operation code (e.g. 0=add, 1=sub, 2=mul, 3=div)
+     * @return Result as tagged_value
+     */
     llvm::Value* emitBignumBinaryCall(llvm::Value* left, llvm::Value* right, int op_code);
+
+    /**
+     * Emit a call into the bignum runtime's comparison kernel, used once
+     * emitIsBignumCheck has confirmed at least one operand is an
+     * arbitrary-precision integer.
+     * @param left Left operand (tagged_value)
+     * @param right Right operand (tagged_value)
+     * @param op_code Bignum comparison operation code (e.g. 0=lt, 1=gt)
+     * @return Boolean result as tagged_value
+     */
     llvm::Value* emitBignumCompareCall(llvm::Value* left, llvm::Value* right, int op_code);
+
+    /**
+     * Check whether either operand is a bignum (arbitrary-precision integer)
+     * tagged value, so arithmetic/comparison ops can be routed to the bignum
+     * dispatch helpers instead of the fixed-width int/double fast path.
+     * @param left Left operand (tagged_value)
+     * @param right Right operand (tagged_value)
+     * @return Boolean i1 value: true if either operand is a bignum
+     */
     llvm::Value* emitIsBignumCheck(llvm::Value* left, llvm::Value* right);
 
     // === Taylor-tower dispatch helpers (ESH-0186) ===
+
+    /**
+     * Check whether either operand is a Taylor tower (HEAP_PTR with
+     * HEAP_SUBTYPE_TAYLOR), so it can be intercepted before the generic
+     * vector/tensor heap path, which would otherwise misread its storage.
+     * @param left Left operand (tagged_value)
+     * @param right Right operand (tagged_value)
+     * @return i1 boolean: true if either operand is a Taylor tower
+     */
     llvm::Value* emitIsTaylorCheck(llvm::Value* left, llvm::Value* right);
+
+    /**
+     * Check whether a single operand is a Taylor tower.
+     * @param v Operand (tagged_value)
+     * @return i1 boolean: true if the operand is a Taylor tower
+     */
     llvm::Value* emitIsTaylorSingle(llvm::Value* v);
+
+    /**
+     * Emit a call into the Taylor-tower runtime's binary-op kernel
+     * (eshkol_taylor_binary_tagged), used once a Taylor tower operand has
+     * been detected.
+     * @param left Left operand (tagged_value)
+     * @param right Right operand (tagged_value)
+     * @param op_code Taylor binary operation code (e.g. 0=add, 1=sub, 2=mul, 3=div)
+     * @return Result as tagged_value
+     */
     llvm::Value* emitTaylorBinaryCall(llvm::Value* left, llvm::Value* right, int op_code);
+
+    /**
+     * Emit a call into the Taylor-tower runtime's unary-op kernel
+     * (eshkol_taylor_unary_tagged).
+     * @param in Operand (tagged_value)
+     * @param op_code Taylor unary operation code
+     * @return Result as tagged_value
+     */
     llvm::Value* emitTaylorUnaryCall(llvm::Value* in, int op_code);
 
     // === Rational dispatch helpers ===
 
+    /**
+     * Check whether either operand is an exact rational number, so
+     * arithmetic/comparison ops can be routed to the rational dispatch
+     * helpers instead of the fixed-width int/double fast path.
+     * @param left Left operand (tagged_value)
+     * @param right Right operand (tagged_value)
+     * @return Boolean i1 value: true if either operand is a rational
+     */
     llvm::Value* emitIsRationalCheck(llvm::Value* left, llvm::Value* right);
+
+    /**
+     * Emit a call into the rational runtime's binary-op kernel
+     * (eshkol_rational_binary_tagged_ptr), used once emitIsRationalCheck has
+     * confirmed at least one operand is an exact rational.
+     * @param left Left operand (tagged_value)
+     * @param right Right operand (tagged_value)
+     * @param op_code Rational binary operation code (e.g. 0=add, 1=sub, 2=mul, 3=div)
+     * @return Result as tagged_value
+     */
     llvm::Value* emitRationalBinaryCall(llvm::Value* left, llvm::Value* right, int op_code);
+
+    /**
+     * Emit a call into the rational runtime's comparison kernel
+     * (eshkol_rational_compare_tagged_ptr), used once emitIsRationalCheck has
+     * confirmed at least one operand is an exact rational.
+     * @param left Left operand (tagged_value)
+     * @param right Right operand (tagged_value)
+     * @param op_code Rational comparison operation code (e.g. 0=lt, 1=gt)
+     * @return Boolean result as tagged_value
+     */
     llvm::Value* emitRationalCompareCall(llvm::Value* left, llvm::Value* right, int op_code);
 
     /**

--- a/inc/eshkol/backend/autodiff_codegen.h
+++ b/inc/eshkol/backend/autodiff_codegen.h
@@ -135,6 +135,10 @@ public:
     // tangent (instead of the reverse tape swallowing the tower). Pushed in
     // seedForwardAndPush and popped in popAndExtractForward when in tower mode.
     void towerCtxPush(llvm::Value* order_i32);
+    /**
+     * Leave a Taylor-tower differentiation context (decrement the runtime
+     * tower depth counter pushed by towerCtxPush, clamped at 0).
+     */
     void towerCtxPop();
     // If a tower differentiation is active and `operand_tagged` is a reverse-tape
     // AD node, freeze it to a dual-tower constant (value + seed tangent) so the
@@ -345,9 +349,20 @@ public:
     // mode below re-points seedForwardAndPush / popAndExtractForward at the
     // heap-tower runtime kernel (lib/core/runtime_taylor.c) instead of the jet.
     llvm::Value* taylorSeries(const eshkol_operations_t* op);  // ESHKOL_TAYLOR_OP
+    /**
+     * Compute (derivative-n f x k): the k-th derivative of f at x via the
+     * arbitrary-order Taylor tower. Attempts P2 compile-time-K
+     * monomorphization (tryMonomorphizedTaylor) when k is a literal integer,
+     * else falls back to the P1 runtime heap-tower path (taylorApiCore).
+     * @param op The ESHKOL_DERIVATIVE_N_OP AST node (function, point, order)
+     * @return Scalar derivative value (k! * c[k])
+     */
     llvm::Value* derivativeN(const eshkol_operations_t* op);   // ESHKOL_DERIVATIVE_N_OP
+    /** Selects which tower-API extraction mode a taylorApiCore call performs. */
     enum class TowerMode { NONE, DERIV_N, COEFFS };
+    /** Current tower-API mode; only meaningful while a tower-API call (taylor/derivative-n) is in progress. */
     TowerMode adTowerMode_ = TowerMode::NONE;   // set only during a tower-API call
+    /** Requested Taylor-tower order k (as an i32 runtime value) for the in-progress tower-API call. */
     llvm::Value* adTowerOrder_ = nullptr;       // i32 requested order k (runtime value)
     // Shared seed+call+extract core for the tower API and the nested-derivative
     // rewrite. `order_i32` is the requested order; `mode` selects extraction.
@@ -796,6 +811,7 @@ public:
 
     /** Closure call callback — dispatches runtime closure calls */
     using ClosureCallCallback = llvm::Value* (*)(llvm::Value*, const std::vector<llvm::Value*>&, const char*, void*);
+    /** Set the closure call callback used to dispatch runtime closure calls. */
     void setClosureCallCallback(ClosureCallCallback callback) {
         closure_call_callback_ = callback;
     }
@@ -830,6 +846,7 @@ public:
 
     /** Get arena-allocate-closure-with-header function declaration */
     using GetClosureAllocFunc = llvm::Function* (*)(void*);
+    /** Set the callback used to obtain the arena-allocate-closure-with-header function declaration. */
     void setGetClosureAllocFunc(GetClosureAllocFunc func) {
         get_closure_alloc_func_ = func;
     }
@@ -841,7 +858,25 @@ public:
 
     // Private helpers for vector calculus
     llvm::Value* createNullVectorTensor(llvm::Value* dimension);
+    /**
+     * Extract element `indices` from an N-dimensional tensor's element
+     * array, computing the linear offset via row-major strides over the
+     * tensor's dims field. Elements are stored as int64 bit patterns and
+     * bitcast back to double on load.
+     * @param tensor_ptr Pointer to the tensor struct
+     * @param indices Per-dimension indices (e.g. [row, col] for a Jacobian)
+     * @return The element value as a double
+     */
     llvm::Value* extractTensorElement(llvm::Value* tensor_ptr, std::vector<llvm::Value*> indices);
+    /**
+     * Convenience wrapper over extractTensorElement for 2D tensors
+     * (Jacobian/Hessian matrices): extracts J[row_idx, col_idx].
+     * @param jacobian_ptr Pointer to the 2D tensor
+     * @param row_idx Row index
+     * @param col_idx Column index
+     * @param n Matrix dimension (unused by the current implementation, kept for callers)
+     * @return The element value as a double
+     */
     llvm::Value* extractJacobianElement(llvm::Value* jacobian_ptr, llvm::Value* row_idx, llvm::Value* col_idx, llvm::Value* n);
 
 private:

--- a/inc/eshkol/backend/binding_codegen.h
+++ b/inc/eshkol/backend/binding_codegen.h
@@ -138,6 +138,8 @@ public:
     llvm::Value* loadVariable(const std::string& name);
 
 private:
+    // Shared codegen state and tagged-value helper (not owned; refs injected
+    // via the constructor)
     CodegenContext& ctx_;
     TaggedValueCodegen& tagged_;
 
@@ -150,6 +152,8 @@ private:
     // Register function binding (for apply/call resolution)
     using RegisterFuncBindingFunc = void (*)(const char* var_name, void* typed_value, void* context);
 
+    // Stored callback instances set via setCodegenCallbacks() (see the
+    // typedefs above for each callback's signature/purpose)
     CodegenASTFunc codegen_ast_callback_ = nullptr;
     CodegenTypedASTFunc codegen_typed_ast_callback_ = nullptr;
     TypedToTaggedFunc typed_to_tagged_callback_ = nullptr;
@@ -350,6 +354,8 @@ public:
     }
 
 private:
+    // Backing storage for the active TCO context and the self-tail-recursion
+    // detection callback (see getTCOContext()/setTCOCallbacks() above)
     TailCallContext tco_context_ = {};
     IsTailRecursiveFunc is_tail_recursive_callback_ = nullptr;
 };

--- a/inc/eshkol/backend/blas_backend.h
+++ b/inc/eshkol/backend/blas_backend.h
@@ -224,8 +224,22 @@ void daxpy(int n, double alpha, const double* x, int incx, double* y, int incy);
 namespace eshkol {
 namespace blas {
 
+/**
+ * Stub: BLAS is not compiled in, so it is never available.
+ * @return Always false
+ */
 inline bool isAvailable() { return false; }
+
+/**
+ * Stub: no BLAS backend is compiled in.
+ * @return Always "none"
+ */
 inline const char* getBackendName() { return "none"; }
+
+/**
+ * Stub: without a BLAS backend, BLAS dispatch is never selected.
+ * @return Always false
+ */
 inline bool shouldUseBLAS(size_t) { return false; }
 
 } // namespace blas

--- a/inc/eshkol/backend/call_apply_codegen.h
+++ b/inc/eshkol/backend/call_apply_codegen.h
@@ -272,6 +272,8 @@ public:
     }
 
 private:
+    // Shared codegen state and helper modules (not owned; refs injected via
+    // the constructor)
     CodegenContext& ctx_;
     TaggedValueCodegen& tagged_;
     ArithmeticCodegen& arith_;

--- a/inc/eshkol/backend/codegen_context.h
+++ b/inc/eshkol/backend/codegen_context.h
@@ -220,15 +220,23 @@ public:
 
     // === AD (Automatic Differentiation) State ===
 
+    /** Get/set the global i1 flag that is true while forward- or reverse-mode
+     *  AD instrumentation is active, so numeric ops know to record onto the tape. */
     llvm::GlobalVariable* adModeActive() { return ad_mode_active_; }
     void setAdModeActive(llvm::GlobalVariable* var) { ad_mode_active_ = var; }
 
+    /** Get/set the global pointer to the AD tape currently being recorded to
+     *  (reverse-mode). Saved/restored around nested gradient/derivative calls. */
     llvm::GlobalVariable* currentAdTape() { return current_ad_tape_; }
     void setCurrentAdTape(llvm::GlobalVariable* var) { current_ad_tape_ = var; }
 
+    /** Get/set the global stack of saved AD tapes used to restore
+     *  currentAdTape() when a nested differentiation call returns. */
     llvm::GlobalVariable* adTapeStack() { return ad_tape_stack_; }
     void setAdTapeStack(llvm::GlobalVariable* var) { ad_tape_stack_ = var; }
 
+    /** Get/set the global counter tracking how many tapes are pushed on
+     *  adTapeStack(), i.e. the current AD nesting depth. */
     llvm::GlobalVariable* adTapeDepth() { return ad_tape_depth_; }
     void setAdTapeDepth(llvm::GlobalVariable* var) { ad_tape_depth_ = var; }
 
@@ -285,30 +293,48 @@ public:
 
     // === Mode Flags ===
 
+    /** Get/set whether the module is being compiled as a library (no
+     *  standalone entry point; exported symbols keep external linkage). */
     bool isLibraryMode() const { return library_mode_; }
     void setLibraryMode(bool mode) { library_mode_ = mode; }
 
+    /** Get/set whether code is being generated for incremental REPL
+     *  evaluation, which affects global storage naming/linkage decisions. */
     bool isReplMode() const { return repl_mode_; }
     void setReplMode(bool mode) { repl_mode_ = mode; }
 
+    /** Get/set the name-mangling prefix applied to this module's globals,
+     *  used to disambiguate symbols across separately loaded modules. */
     const std::string& modulePrefix() const { return module_prefix_; }
     void setModulePrefix(const std::string& prefix) { module_prefix_ = prefix; }
 
     // === Builtin Function Declarations ===
     // These are set during initialization and used throughout codegen
 
+    /** Get/set the declaration for `eshkol_deep_equal`, the runtime helper
+     *  implementing structural (deep) equality over tagged values. */
     llvm::Function* deepEqualFunc() { return deep_equal_func_; }
     void setDeepEqualFunc(llvm::Function* func) { deep_equal_func_ = func; }
 
+    /** Get/set the declaration for `eshkol_display_value`, the runtime
+     *  helper that prints a tagged value (used by display/write). */
     llvm::Function* displayValueFunc() { return display_value_func_; }
     void setDisplayValueFunc(llvm::Function* func) { display_value_func_ = func; }
 
+    /** Get/set the declaration for `eshkol_lambda_registry_init`, which
+     *  initializes the runtime registry mapping lambda function pointers to
+     *  their originating s-expression (used for eq?/display on closures). */
     llvm::Function* lambdaRegistryInitFunc() { return lambda_registry_init_func_; }
     void setLambdaRegistryInitFunc(llvm::Function* func) { lambda_registry_init_func_ = func; }
 
+    /** Get/set the declaration for `eshkol_lambda_registry_add`, which
+     *  registers a (function pointer, s-expression pointer, name) entry. */
     llvm::Function* lambdaRegistryAddFunc() { return lambda_registry_add_func_; }
     void setLambdaRegistryAddFunc(llvm::Function* func) { lambda_registry_add_func_ = func; }
 
+    /** Get/set the declaration for `eshkol_lambda_registry_lookup`, which
+     *  resolves a function pointer back to its registered s-expression
+     *  pointer (or 0 if not found). */
     llvm::Function* lambdaRegistryLookupFunc() { return lambda_registry_lookup_func_; }
     void setLambdaRegistryLookupFunc(llvm::Function* func) { lambda_registry_lookup_func_ = func; }
 

--- a/inc/eshkol/backend/complex_codegen.h
+++ b/inc/eshkol/backend/complex_codegen.h
@@ -44,6 +44,12 @@ class MemoryCodegen;
  */
 class ComplexCodegen {
 public:
+    /**
+     * Construct ComplexCodegen with context and helpers.
+     * @param ctx The shared codegen context
+     * @param tagged Tagged value operations helper
+     * @param mem Memory/arena allocation helper
+     */
     ComplexCodegen(CodegenContext& ctx, TaggedValueCodegen& tagged, MemoryCodegen& mem);
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/inc/eshkol/backend/cpu_features.h
+++ b/inc/eshkol/backend/cpu_features.h
@@ -111,10 +111,18 @@ public:
 
 private:
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+    /**
+     * Detect x86/x86-64 SIMD and FMA capabilities via CPUID and populate
+     * the corresponding flags on @p features.
+     */
     static void detectX86Features(CPUFeatures& features);
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)
+    /**
+     * Detect ARM64 NEON and related feature extensions (FP16, dot product,
+     * FHM, BF16, I8MM) and populate the corresponding flags on @p features.
+     */
     static void detectARMFeatures(CPUFeatures& features);
 #endif
 };
@@ -125,31 +133,48 @@ private:
  */
 class CPUCapabilities {
 public:
+    /**
+     * Get the process-wide singleton instance, detecting CPU features on
+     * first access.
+     */
     static CPUCapabilities& instance();
 
+    /** Get the cached detected CPU features. */
     const CPUFeatures& getFeatures() const { return features_; }
+    /** Get the cached best available SIMD level. */
     SIMDLevel getSIMDLevel() const { return features_.getBestSIMDLevel(); }
+    /** Get the cached optimal vector width in doubles. */
     unsigned getVectorWidth() const { return features_.getOptimalVectorWidth(); }
 
     // Convenience accessors - x86
     bool hasAVX() const { return features_.has_avx; }
+    /** True if the host CPU supports AVX2. */
     bool hasAVX2() const { return features_.has_avx2; }
+    /** True if the host CPU supports AVX-512 Foundation. */
     bool hasAVX512() const { return features_.has_avx512f; }
+    /** True if the host CPU supports FMA (fused multiply-add). */
     bool hasFMA() const { return features_.has_fma; }
 
     // Convenience accessors - ARM
     bool hasNEON() const { return features_.has_neon; }
+    /** True if the host CPU supports NEON FP16 arithmetic (FEAT_FP16). */
     bool hasNEON_FP16() const { return features_.has_neon_fp16; }
+    /** True if the host CPU supports NEON SDOT/UDOT dot product (FEAT_DotProd). */
     bool hasNEON_DotProd() const { return features_.has_neon_dotprod; }
+    /** True if the host CPU supports NEON FP16 fused multiply-accumulate (FEAT_FHM). */
     bool hasNEON_FHM() const { return features_.has_neon_fhm; }
+    /** True if the host CPU supports NEON BFloat16 (FEAT_BF16). */
     bool hasNEON_BF16() const { return features_.has_neon_bf16; }
+    /** True if the host CPU supports NEON Int8 matrix multiply (FEAT_I8MM). */
     bool hasNEON_I8MM() const { return features_.has_neon_i8mm; }
 
     // Architecture detection
     bool isARM64() const { return features_.is_arm64; }
+    /** True if the host architecture is x86/x86-64. */
     bool isX86() const { return features_.is_x86; }
 
 private:
+    /** Detects and caches CPU features for the current host. */
     CPUCapabilities();
     CPUFeatures features_;
 };

--- a/inc/eshkol/backend/function_cache.h
+++ b/inc/eshkol/backend/function_cache.h
@@ -41,20 +41,29 @@ public:
 
     // String functions
     llvm::Function* getStrlen();   // size_t strlen(const char*)
+    /** @brief Get (declaring if needed) `int strcmp(const char*, const char*)`. */
     llvm::Function* getStrcmp();   // int strcmp(const char*, const char*)
+    /** @brief Get (declaring if needed) `int strncmp(const char*, const char*, size_t)`. */
     llvm::Function* getStrncmp();  // int strncmp(const char*, const char*, size_t)
+    /** @brief Get (declaring if needed) `char* strcpy(char*, const char*)`. */
     llvm::Function* getStrcpy();   // char* strcpy(char*, const char*)
+    /** @brief Get (declaring if needed) `char* strcat(char*, const char*)`. */
     llvm::Function* getStrcat();   // char* strcat(char*, const char*)
+    /** @brief Get (declaring if needed) `char* strstr(const char*, const char*)`. */
     llvm::Function* getStrstr();      // char* strstr(const char*, const char*)
+    /** @brief Get (declaring if needed) `int strcasecmp(const char*, const char*)`. */
     llvm::Function* getStrcasecmp();  // int strcasecmp(const char*, const char*)
 
     // Memory functions
     llvm::Function* getMalloc();   // void* malloc(size_t)
+    /** @brief Get (declaring if needed) `void* memcpy(void*, const void*, size_t)`. */
     llvm::Function* getMemcpy();   // void* memcpy(void*, const void*, size_t)
+    /** @brief Get (declaring if needed) `void* memset(void*, int, size_t)`. */
     llvm::Function* getMemset();   // void* memset(void*, int, size_t)
 
     // Formatting/conversion functions
     llvm::Function* getSnprintf(); // int snprintf(char*, size_t, const char*, ...)
+    /** @brief Get (declaring if needed) `double strtod(const char*, char**)`. */
     llvm::Function* getStrtod();   // double strtod(const char*, char**)
 
     /**

--- a/inc/eshkol/backend/hash_codegen.h
+++ b/inc/eshkol/backend/hash_codegen.h
@@ -67,14 +67,58 @@ public:
 
     // Hash table operations
     llvm::Value* hashSet(const eshkol_operations_t* op);
+
+    /**
+     * @brief Get a value by key: (hash-ref table key [default])
+     *
+     * Looks up key via the runtime hash_table_get. Returns the found value
+     * if present, otherwise the provided default argument if given, or #f
+     * if no default was given. Never errors on a missing key.
+     * @param op The HASH_REF operation AST node
+     * @return Tagged value found for key, the default, or #f
+     */
     llvm::Value* hashRef(const eshkol_operations_t* op);
+
+    /**
+     * @brief Check if a key exists: (hash-has-key? table key)
+     * @param op The operation AST node
+     * @return Tagged boolean, #t if the key is present, #f otherwise
+     */
     llvm::Value* hashHasKey(const eshkol_operations_t* op);
+
+    /**
+     * @brief Remove a key: (hash-remove! table key)
+     * @param op The operation AST node
+     * @return Tagged boolean, #t if the key was removed, #f if not found
+     */
     llvm::Value* hashRemove(const eshkol_operations_t* op);
 
     // Hash table queries
     llvm::Value* hashKeys(const eshkol_operations_t* op);
+
+    /**
+     * @brief Get all values as a list: (hash-values table)
+     * @param op The operation AST node
+     * @return Tagged null for an empty table, otherwise a tagged pointer
+     *         to a cons list of the table's values
+     */
     llvm::Value* hashValues(const eshkol_operations_t* op);
+
+    /**
+     * @brief Get number of entries: (hash-count table)
+     * @param op The operation AST node
+     * @return Tagged 64-bit integer entry count
+     */
     llvm::Value* hashCount(const eshkol_operations_t* op);
+
+    /**
+     * @brief Clear all entries: (hash-clear! table)
+     *
+     * Clears the table in place and returns it unchanged, following
+     * Scheme's `!` convention of returning the mutated object.
+     * @param op The operation AST node
+     * @return The original (now-empty) table argument
+     */
     llvm::Value* hashClear(const eshkol_operations_t* op);
 
 private:


### PR DESCRIPTION
Doxygen doc-comments for undocumented symbols in inc/eshkol/backend/ (group A: arithmetic..homoiconic). Documentation only.

## Scope
Added Doxygen `/** @brief ... */` doc-comments above previously-undocumented public symbols across the group A backend codegen headers. No code or behavior changes (all 256 added lines are comments/whitespace).

## Files documented (10 of 15 needed changes)
- arithmetic_codegen.h - bignum/Taylor/rational dispatch helpers
- autodiff_codegen.h - tower/tape accessors, TowerMode enum, tensor/jacobian element extractors
- binding_codegen.h - context/callback reference fields
- blas_backend.h - no-BLAS stub functions
- call_apply_codegen.h - private context reference fields
- codegen_context.h - AD-state / mode-flag / builtin-function accessor pairs
- complex_codegen.h - ComplexCodegen constructor
- cpu_features.h - CPUCapabilities accessors + feature-detection helpers
- function_cache.h - libc function accessors (strcmp, memcpy, ...)
- hash_codegen.h - hashRef/hashHasKey/hashRemove/hashValues/hashCount/hashClear

## Already fully documented (no changes)
builtin_declarations.h, collection_codegen.h, control_flow_codegen.h, function_codegen.h, homoiconic_codegen.h.

All comment blocks verified balanced; descriptions grounded in the matching lib/backend/*.cpp implementations.