### PR TITLE
fix(reader): iterative read_list — long lists no longer overflow native stack

### DIFF
--- a/lib/core/runtime_reader_hosted.cpp
+++ b/lib/core/runtime_reader_hosted.cpp
@@ -197,37 +197,93 @@ static eshkol_tagged_value_t make_cons_tagged(arena_t* arena,
 }
 
 // Read a list: ( datum ... ) or ( datum ... . datum )
+//
+// Bug 2 (reader stack overflow on long lists): this used to recurse via
+// read_list() for the cdr of every element — one native stack frame per
+// list element. A flat list of ~46k elements overflowed the native stack
+// during `read`, independent of ESHKOL_STACK_SIZE. Rewritten to be
+// iterative: elements are collected into a growable heap buffer (realloc,
+// like read_vector's approach) with a plain loop, then the proper/
+// improper list is consed together right-to-left over the buffer — no
+// native recursion per element. Nested lists still legitimately recurse
+// through read_datum, bounded by g_reader_depth / ESHKOL_READ_MAX_DEPTH;
+// that path is untouched.
 static eshkol_tagged_value_t read_list(arena_t* arena, FILE* fp) {
-    int ch = read_skip_whitespace(fp);
-    if (ch == EOF) return make_eof_tagged();
-    if (ch == ')') return make_null_tagged(); // empty after elements
+    size_t capacity = 64;
+    size_t count = 0;
+    eshkol_tagged_value_t* elems =
+        (eshkol_tagged_value_t*)malloc(capacity * sizeof(eshkol_tagged_value_t));
+    if (!elems) return make_null_tagged(); // OOM: fail safe, mirrors make_cons_tagged's OOM path
 
-    // Read first element
-    eshkol_tagged_value_t car = read_datum(arena, fp, ch);
-    if (car.type == 0xFF) return car; // propagate EOF
+    eshkol_tagged_value_t tail = make_null_tagged();
 
-    // Check for dot notation
-    ch = read_skip_whitespace(fp);
-    if (ch == '.') {
-        // Improper list: (a . b)
-        int next = fgetc(fp);
-        if (next == ' ' || next == '\t' || next == '\n' || next == '\r') {
-            int ch2 = read_skip_whitespace(fp);
-            eshkol_tagged_value_t cdr = read_datum(arena, fp, ch2);
-            // Consume closing paren
-            read_skip_whitespace(fp); // should be ')'
-            return make_cons_tagged(arena, car, cdr);
+    for (;;) {
+        int ch = read_skip_whitespace(fp);
+        if (ch == EOF) {
+            // Matches original semantics: EOF before the closing ')'
+            // becomes the terminating tail rather than a hard error —
+            // e.g. an unterminated "(1 2 3" reads as (1 2 3 . #<eof>).
+            tail = make_eof_tagged();
+            break;
         }
-        // Not a dot pair, it's a symbol starting with .
-        ungetc(next, fp);
-        ungetc('.', fp);
-    } else {
-        ungetc(ch, fp);
+        if (ch == ')') {
+            tail = make_null_tagged(); // proper list end
+            break;
+        }
+
+        eshkol_tagged_value_t car = read_datum(arena, fp, ch);
+        if (car.type == 0xFF) {
+            // Propagate EOF / reader-depth error as the terminating tail
+            // (original code returned it bare from the recursive call,
+            // which became the enclosing cons's cdr — same shape here).
+            tail = car;
+            break;
+        }
+
+        if (count == capacity) {
+            capacity *= 2;
+            eshkol_tagged_value_t* grown = (eshkol_tagged_value_t*)realloc(
+                elems, capacity * sizeof(eshkol_tagged_value_t));
+            if (!grown) {
+                free(elems);
+                return make_null_tagged(); // OOM: fail safe
+            }
+            elems = grown;
+        }
+        elems[count++] = car;
+
+        // Check for dot notation
+        ch = read_skip_whitespace(fp);
+        if (ch == '.') {
+            // Improper list: (a . b)
+            int next = fgetc(fp);
+            if (next == ' ' || next == '\t' || next == '\n' || next == '\r') {
+                int ch2 = read_skip_whitespace(fp);
+                eshkol_tagged_value_t cdr = read_datum(arena, fp, ch2);
+                // Consume closing paren
+                read_skip_whitespace(fp); // should be ')'
+                tail = cdr;
+                break;
+            }
+            // Not a dot pair, it's a symbol starting with .
+            ungetc(next, fp);
+            ungetc('.', fp);
+            // Falls through to the next loop iteration, which re-reads
+            // '.' via read_skip_whitespace as the start of the next
+            // element — same as the original's recursive re-entry.
+        } else {
+            ungetc(ch, fp);
+        }
     }
 
-    // Read rest of list
-    eshkol_tagged_value_t cdr = read_list(arena, fp);
-    return make_cons_tagged(arena, car, cdr);
+    // Cons the collected elements onto the tail, right-to-left, so the
+    // whole list is built with a plain loop instead of native recursion.
+    eshkol_tagged_value_t result = tail;
+    for (size_t i = count; i > 0; i--) {
+        result = make_cons_tagged(arena, elems[i - 1], result);
+    }
+    free(elems);
+    return result;
 }
 
 // Read a vector: #( datum ... )

--- a/tests/stdlib/reader_long_list_test.esk
+++ b/tests/stdlib/reader_long_list_test.esk
@@ -1,0 +1,136 @@
+;;; reader_long_list_test.esk — Bug 2 regression: reader stack overflow on
+;;; long lists.
+;;;
+;;; lib/core/runtime_reader_hosted.cpp's read_list() used to recurse via
+;;; read_list() once per list element (one native C stack frame per
+;;; element) to read the cdr of a list. A flat persisted list of ~46,000+
+;;; elements overflowed the native stack during (read), independent of
+;;; ESHKOL_STACK_SIZE — this is what blocked booting a resident program
+;;; that reloads a large persisted data file.
+;;;
+;;; Fix: read_list() now collects elements iteratively into a growable
+;;; heap buffer (realloc-grown, mirroring read_vector's approach) with a
+;;; plain loop, then conses the proper/improper list together
+;;; right-to-left over that buffer. No native recursion occurs per list
+;;; element any more. Nested lists still legitimately recurse through
+;;; read_datum, bounded by the pre-existing g_reader_depth /
+;;; ESHKOL_READ_MAX_DEPTH (4096) guard — that path, and its guard, are
+;;; untouched by this fix and are exercised (well under the cap) below.
+;;;
+;;; This test writes a 100,000-element flat list and a 2,000-deep nested
+;;; list to files (as raw text — element-by-element — so the *writer*
+;;; side of this test doesn't depend on serializing a giant in-memory
+;;; list, which would risk conflating an unrelated display/write
+;;; recursion path with the reader bug this test targets), then reads
+;;; each back at the process's DEFAULT stack size (ESHKOL_STACK_SIZE is
+;;; deliberately left unset) and checks the resulting structure.
+
+(define FLAT-N 100000)
+(define NEST-DEPTH 2000) ; comfortably below the intentional 4096 nesting cap
+
+(define flat-file "/tmp/eshkol_reader_long_list_test_flat.txt")
+(define nested-file "/tmp/eshkol_reader_long_list_test_nested.txt")
+
+;; --- Writers -----------------------------------------------------------
+
+(define (write-flat-list!)
+  (let ((port (open-output-file flat-file)))
+    (display "(" port)
+    (let loop ((i 1))
+      (if (<= i FLAT-N)
+          (begin
+            (display i port)
+            (display " " port)
+            (loop (+ i 1)))))
+    (display ")" port)
+    (close-output-port port)))
+
+(define (write-nested-list!)
+  (let ((port (open-output-file nested-file)))
+    (let open-loop ((i 0))
+      (if (< i NEST-DEPTH)
+          (begin (display "(" port) (open-loop (+ i 1)))))
+    (display "99" port)
+    (let close-loop ((i 0))
+      (if (< i NEST-DEPTH)
+          (begin (display ")" port) (close-loop (+ i 1)))))
+    (close-output-port port)))
+
+(write-flat-list!)
+(write-nested-list!)
+
+;; --- Readers (the actual regression surface) ----------------------------
+
+(define in1 (open-input-file flat-file))
+(define flat-result (read in1))
+(close-input-port in1)
+
+(define in2 (open-input-file nested-file))
+(define nested-result (read in2))
+(close-input-port in2)
+
+;; --- Tail-recursive (TCO'd) structural checks — traversal itself must
+;; not add native recursion depth either, so these use accumulator-style
+;; named-let loops. ---------------------------------------------------
+
+(define (list-length-tco lst)
+  (let loop ((l lst) (n 0))
+    (if (pair? l)
+        (loop (cdr l) (+ n 1))
+        n)))
+
+(define (list-last-tco lst)
+  (let loop ((l lst))
+    (if (pair? (cdr l))
+        (loop (cdr l))
+        (car l))))
+
+(define (nesting-depth-tco v)
+  (let loop ((x v) (d 0))
+    (if (pair? x)
+        (loop (car x) (+ d 1))
+        d)))
+
+(define (innermost-atom-tco v)
+  (let loop ((x v))
+    (if (pair? x)
+        (loop (car x))
+        x)))
+
+(define flat-len (list-length-tco flat-result))
+(define flat-first (car flat-result))
+(define flat-last (list-last-tco flat-result))
+
+(define nest-depth (nesting-depth-tco nested-result))
+(define nest-atom (innermost-atom-tco nested-result))
+
+(display "flat-length: ") (display flat-len) (newline)
+(display "flat-first: ") (display flat-first) (newline)
+(display "flat-last: ") (display flat-last) (newline)
+(display "nest-depth: ") (display nest-depth) (newline)
+(display "nest-atom: ") (display nest-atom) (newline)
+
+;; --- Verdict -------------------------------------------------------------
+
+(define passed 0)
+(define failed 0)
+(define (check name cnd)
+  (if cnd
+      (begin (display "PASS: ") (display name) (newline)
+             (set! passed (+ passed 1)))
+      (begin (display "FAIL: ") (display name) (newline)
+             (set! failed (+ failed 1)))))
+
+(check "flat list did not crash and has correct length" (= flat-len FLAT-N))
+(check "flat list first element == 1" (= flat-first 1))
+(check "flat list last element == 100000" (= flat-last FLAT-N))
+(check "nested list did not crash and has correct depth" (= nest-depth NEST-DEPTH))
+(check "nested list innermost atom == 99" (= nest-atom 99))
+
+(newline)
+(display "=== Summary ===") (newline)
+(display "Passed: ") (display passed) (newline)
+(display "Failed: ") (display failed) (newline)
+(if (= failed 0)
+    (begin (display "RESULT: OK") (newline))
+    (begin (display "RESULT: FAIL") (newline) (exit 1)))


### PR DESCRIPTION
## Root cause

`lib/core/runtime_reader_hosted.cpp`'s `read_list()` recursed via `read_list()` itself to read the cdr of every list element — one native C stack frame per element, regardless of `ESHKOL_READ_MAX_DEPTH` (that guard only bounds *nested-structure* recursion through `read_datum`, since the per-element cdr recursion never goes through `read_datum`/the depth counter at all). A long flat persisted list therefore overflows the native stack during `(read)`, independent of `ESHKOL_STACK_SIZE` — this is what blocked a resident program from booting when it reloaded a large persisted data file (Bug 2).

## Fix

Rewrote `read_list()` to be iterative, following the same pattern `read_vector()` uses to avoid recursion:
- Elements are read one at a time in a plain loop (still calling `read_datum` per element) and collected into a `realloc`-grown heap buffer (starts at 64, doubles as needed — unlike `read_vector`'s fixed 1024-slot array, since a real payload can be far larger).
- Dotted-pair (`.`) detection, EOF-before-close, and the "symbol starting with `.`" fallback are preserved with **exactly** the original semantics/order of operations (including the original's lenient behavior of embedding the EOF/depth-error sentinel as the terminating tail rather than hard-erroring, and not validating that the token after a dotted cdr is actually `)`).
- After the loop, the list is consed together **right-to-left over the buffer, iteratively** (`make_cons_tagged` in a plain loop) — no native recursion per element.
- Nested lists still legitimately recurse through `read_datum`, bounded by the pre-existing `g_reader_depth` / `ESHKOL_READ_MAX_DEPTH` (4096) guard — that path and its cap are untouched.

No other function's behavior changed.

## Verification

**Build**: `cmake -S . -B build-fix -DCMAKE_BUILD_TYPE=Release && cmake --build build-fix -j24` — full lite build (system LLVM 21), succeeded, produced `eshkol-run`.

**New test**: `tests/stdlib/reader_long_list_test.esk` — writes a 100,000-element flat list and a 2,000-deep nested list to files (as raw text, element-by-element, so the writer side doesn't depend on serializing a giant in-memory list), reads both back via `(read)` on the freshly built `eshkol-run` at the **default** stack size (`ESHKOL_STACK_SIZE` deliberately left unset), and checks length/first/last/nesting-depth/innermost-atom with tail-recursive (TCO'd) traversal. Actually ran it:

```
flat-length: 100000
flat-first: 1
flat-last: 100000
nest-depth: 2000
nest-atom: 99
PASS: flat list did not crash and has correct length
PASS: flat list first element == 1
PASS: flat list last element == 100000
PASS: nested list did not crash and has correct depth
PASS: nested list innermost atom == 99
Passed: 5
Failed: 0
RESULT: OK
```

**Differential stress proof against the pre-fix code**: this repo links generated programs with a 512MB main-thread stack (`-Wl,-stack_size,0x20000000` / `-Wl,-z,stack-size=536870912`), so on this platform 100,000 elements doesn't actually overflow even the *old* recursive code (verified: built a control `eshkol-run` from the pre-fix source in a separate build dir, ran the same 100k list against it — no crash). To get an unambiguous differential result I bumped a throwaway probe script to a 20,000,000-element flat list:
- **Pre-fix control binary**: `SIGBUS` — `[Eshkol] fatal signal: SIGBUS (bus error) ... this is most likely a stack overflow (recursion too deep)`.
- **Post-fix binary**: completes cleanly, `flat-length: 20000000`, `DONE`, in ~8.8s.

This confirms the recursion-per-element issue is real on this exact build/platform and that the iterative rewrite eliminates it, while the smaller, CI-appropriate 100k/2k-deep committed test passes on the fix.

Not verified: behavior on Linux/Windows CI runners (only tested on this macOS dev box); the exact ~46,000-element crash threshold cited in the bug report, which likely reflects a build/thread context with a smaller effective stack (e.g. a 16MB thread-pool worker stack) than this box's 512MB main-thread link setting.