### PR TITLE
fix(codegen): ESH-0214b per-iteration arena scope for define loops + catch-all guard

### DIFF
--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -10796,6 +10796,16 @@ private:
         BasicBlock* tco_loop_bb = nullptr;
 
         bool is_tail_rec = op->define_op.value && isSelfTailRecursive(op, func_name);
+        // ESH-0214b (Bug 1): enable automatic per-iteration arena reclamation
+        // for a self-tail-recursive define exactly as codegenNamedLet does for
+        // named lets. Requires the branch-based TCO transform (is_tail_rec ==
+        // all recursive calls in tail position) AND that the escape analysis
+        // proves the body cannot leak an iteration-allocated value except
+        // through the loop-carried args / return value. The define's own name
+        // is the loop name, so its self-tail-calls are recognized as back
+        // edges by the analysis (local_fns) and by codegenTailCallFromContext.
+        bool define_iter_scope_safe = is_tail_rec &&
+            loopBodyIterScopeSafe(op->define_op.value, func_name);
         if (is_tail_rec) {
             use_tco = true;
             eshkol_debug("TCO: Enabling tail call optimization for define %s", func_name);
@@ -10804,11 +10814,11 @@ private:
             auto& tco_ctx = binding_->getTCOContext();
             tco_ctx.func_name = func_name;
             tco_ctx.enabled = true;
-            // ESH-0214b: automatic per-iteration scoping is named-let-only for
-            // now (its exit path is a single, known return point). Explicitly
-            // clear the flag so a define's back edges never inherit a stale
-            // iter_scope from an enclosing context.
-            tco_ctx.iter_scope = false;
+            // ESH-0214b (Bug 1): per-iteration arena scoping now applies to the
+            // define TCO path too, gated on the escape analysis above. When
+            // unsafe this is false, so a define's back edges never inherit a
+            // stale iter_scope from an enclosing context.
+            tco_ctx.iter_scope = define_iter_scope_safe;
             tco_ctx.param_allocas.clear();
             tco_ctx.param_names.clear();
 
@@ -10841,6 +10851,20 @@ private:
             // Branch to loop header
             builder->CreateBr(tco_loop_bb);
             builder->SetInsertPoint(tco_loop_bb);
+
+            // ESH-0214b (Bug 1): open the per-iteration arena scope at the top
+            // of the loop header, exactly like codegenNamedLet. Every path out
+            // of the iteration -- each TCO back edge (codegenTailCallFromContext,
+            // which ends the scope when tco_ctx.iter_scope is set) and the
+            // define's base-case return below -- ends it with
+            // eshkol_arena_iter_scope_end, so pushes and releases stay strictly
+            // balanced (LIFO).
+            if (define_iter_scope_safe) {
+                Value* iter_arena_ptr = getArenaPtr();
+                if (iter_arena_ptr) {
+                    builder->CreateCall(getArenaPushScopeFunc(), {iter_arena_ptr});
+                }
+            }
 
             // ESH-0222: see TailCallContext::loop_stack_save /
             // open_guard_handlers (binding_codegen.h) for the full
@@ -10908,6 +10932,9 @@ private:
             binding_->getTCOContext().enabled = false;
             binding_->getTCOContext().func_name = "";
             binding_->getTCOContext().loop_header = nullptr;
+            // ESH-0214b (Bug 1): clear iter_scope too so a later, non-tail
+            // define's back edges never inherit this loop's stale flag.
+            binding_->getTCOContext().iter_scope = false;
         }
         eshkol_debug("Function %s body_result: %p", func_name, body_result);
 
@@ -10938,6 +10965,14 @@ private:
                     eshkol_debug("Function %s returns closure/lambda %s (tagged value)",
                                 func_name, last_generated_lambda_name.c_str());
                 }
+                // ESH-0214b (Bug 1): the self-tail define loop exits here on
+                // its base case -- release the final iteration's arena scope.
+                // The result is the only datum flowing out; the runtime helper
+                // pops (reclaims) unless it points into the iteration span, in
+                // which case it commits (keeps the memory, balanced stack).
+                if (use_tco && define_iter_scope_safe) {
+                    emitIterScopeEnd({body_result});
+                }
                 builder->CreateRet(body_result);
             }
             // If body_result is a function (lambda), pack as function pointer
@@ -10955,12 +10990,22 @@ private:
                 Value* func_tagged = packPtrToTaggedValue(
                     builder->CreateIntToPtr(func_addr, builder->getPtrTy()),
                     ESHKOL_VALUE_CALLABLE);  // CRITICAL: Mark as LAMBDA_SEXPR, not CONS_PTR
+                // ESH-0214b (Bug 1): balance the per-iteration scope on this
+                // exit path too (see the tagged-value case above).
+                if (use_tco && define_iter_scope_safe) {
+                    emitIterScopeEnd({func_tagged});
+                }
                 builder->CreateRet(func_tagged);
             }
             // Otherwise, detect type and pack to tagged_value
             else {
                 TypedValue typed = detectValueType(body_result);
                 Value* tagged = typedValueToTaggedValue(typed);
+                // ESH-0214b (Bug 1): balance the per-iteration scope on this
+                // exit path too (see the tagged-value case above).
+                if (use_tco && define_iter_scope_safe) {
+                    emitIterScopeEnd({tagged});
+                }
                 builder->CreateRet(tagged);
             }
         } else {
@@ -10968,6 +11013,11 @@ private:
             eshkol_debug("Function %s has no body result, returning null tagged value", func_name);
             Value* null_tagged = packInt64ToTaggedValue(
                 ConstantInt::get(int64_type, 0), true);
+            // ESH-0214b (Bug 1): balance the per-iteration scope on this exit
+            // path too (see the tagged-value case above).
+            if (use_tco && define_iter_scope_safe) {
+                emitIterScopeEnd({null_tagged});
+            }
             builder->CreateRet(null_tagged);
         }
 
@@ -25173,10 +25223,65 @@ private:
                 }
                 return true;
 
+            case ESHKOL_GUARD_OP: {
+                // ESH-0214b (Bug 1): a guard is iter-scope-safe iff it can
+                // never let an exception propagate PAST the loop body. That
+                // holds exactly when the guard has a CATCH-ALL clause (test is
+                // boolean #t or the symbol `else`): then every raise inside the
+                // iteration is caught, the handler yields a value, and control
+                // rejoins the normal flow -> the back edge's / exit's
+                // iter_scope_end is always reached and the shared scope stack
+                // stays balanced (LIFO). WITHOUT a catch-all an unmatched raise
+                // re-raises (longjmp) straight past the back edge, leaving an
+                // un-ended scope that corrupts the stack -- so those stay
+                // unsafe. On top of that, every body expression AND every
+                // clause (test + result exprs) must itself be escape-free.
+                //
+                // Clause layout mirrors codegenGuard: each clause is a CALL_OP
+                // whose `func` is the test (the symbol `else`, or a #t literal
+                // for a catch-all) and whose `variables[]` are the result
+                // exprs.
+                bool has_catch_all = false;
+                for (uint64_t i = 0; i < op->guard_op.num_clauses; i++) {
+                    const eshkol_ast_t* clause = &op->guard_op.clauses[i];
+                    if (!clause || clause->type != ESHKOL_OP ||
+                        clause->operation.op != ESHKOL_CALL_OP) {
+                        return false;  // malformed clause: cannot analyze
+                    }
+                    const eshkol_ast_t* test = clause->operation.call_op.func;
+                    // Detect catch-all: `else` symbol or a #t boolean literal.
+                    if (test) {
+                        if (test->type == ESHKOL_VAR && test->variable.id &&
+                            strcmp(test->variable.id, "else") == 0) {
+                            has_catch_all = true;
+                        } else if (test->type == ESHKOL_BOOL && test->int64_val != 0) {
+                            has_catch_all = true;
+                        }
+                    }
+                    // The test itself is evaluated every iteration a raise is
+                    // caught -- it must be escape-free too (`else`/#t are
+                    // trivially safe by the VAR/BOOL leaf cases).
+                    if (!iterScopeSafeExpr(test, local_fns, analyzing, depth + 1)) {
+                        return false;
+                    }
+                    for (uint64_t j = 0; j < clause->operation.call_op.num_vars; j++) {
+                        if (!iterScopeSafeExpr(&clause->operation.call_op.variables[j],
+                                               local_fns, analyzing, depth + 1)) return false;
+                    }
+                }
+                if (!has_catch_all) return false;
+                for (uint64_t i = 0; i < op->guard_op.num_body_exprs; i++) {
+                    if (!iterScopeSafeExpr(&op->guard_op.body[i],
+                                           local_fns, analyzing, depth + 1)) return false;
+                }
+                return true;
+            }
+
             default:
-                // set!/define/guard/raise/call-cc/dynamic-wind/case/match/
+                // set!/define/raise/call-cc/dynamic-wind/case/match/
                 // do/parallel/AD/consciousness/... : conservative no. The
-                // loop keeps its exact pre-feature behavior.
+                // loop keeps its exact pre-feature behavior. (guard is handled
+                // above, but only when it has a catch-all clause.)
                 return false;
         }
     }
@@ -25202,9 +25307,12 @@ private:
         return ok;
     }
 
-    // Gate for codegenNamedLet: is this loop body eligible for automatic
-    // per-iteration scope reclamation?
-    bool namedLetIterScopeSafe(const eshkol_ast_t* body, const std::string& loop_name) {
+    // Gate for codegenNamedLet AND the self-tail-recursive define TCO path
+    // (ESH-0214b Bug 1): is this loop body eligible for automatic
+    // per-iteration scope reclamation? `loop_name` is the name whose
+    // self-tail-calls are the loop's back edges (the named-let name, or the
+    // define's own function name).
+    bool loopBodyIterScopeSafe(const eshkol_ast_t* body, const std::string& loop_name) {
         static const bool disabled = (getenv("ESHKOL_NO_ITER_SCOPE") != nullptr);
         if (disabled || !body) return false;
         // ESH-0214c: reject outright if this loop's body is reachable (via
@@ -25215,14 +25323,14 @@ private:
         // thread shares without synchronization; concurrent scope ops from
         // multiple threads race and corrupt it (parallel_flags_byte_regression.esk).
         if (parallel_worker_ast_nodes.count((const void*)body)) {
-            eshkol_debug("ESH-0214c: named let '%s' iter-scope disabled "
+            eshkol_debug("ESH-0214c: loop '%s' iter-scope disabled "
                          "(reachable from a parallel/future callback)", loop_name.c_str());
             return false;
         }
         std::set<std::string> local_fns = {loop_name};
         std::set<std::string> analyzing;
         bool ok = iterScopeSafeExpr(body, local_fns, analyzing, 0);
-        eshkol_debug("ESH-0214b: named let '%s' iter-scope %s",
+        eshkol_debug("ESH-0214b: loop '%s' iter-scope %s",
                      loop_name.c_str(), ok ? "ENABLED" : "disabled (analysis)");
         return ok;
     }
@@ -28031,7 +28139,7 @@ private:
         // dynamic extent). See the analysis block above codegenTailCall-
         // FromContext for the safety argument.
         bool iter_scope_safe = all_tail &&
-            namedLetIterScopeSafe(op->let_op.body, loop_name);
+            loopBodyIterScopeSafe(op->let_op.body, loop_name);
 
         // NESTED NAMED LET FIX: Save TCO context to prevent corruption by nested named lets
         // Each named let saves the outer TCO state, does its work, then restores it

--- a/tests/features/define_loop_iter_scope_test.esk
+++ b/tests/features/define_loop_iter_scope_test.esk
@@ -1,0 +1,52 @@
+;;; tests/features/define_loop_iter_scope_test.esk — ESH-0214b Bug 1
+;;;
+;;; A TOP-LEVEL self-tail-recursive `define` loop whose body is wrapped in a
+;;; catch-all `guard` — the exact daemon-loop shape that used to accumulate
+;;; ~one iteration's arena garbage per pass FOREVER (unbounded RSS -> OOM /
+;;; SIGSEGV), because ESH-0214b's automatic per-iteration arena reclamation
+;;; was named-let-only (Gap A) AND the escape analysis rejected `guard`
+;;; outright (Gap B).
+;;;
+;;; With both gaps fixed:
+;;;   * codegenDefine's TCO path pushes a per-iteration arena scope at the
+;;;     loop header and ends it on every back edge + the base-case return;
+;;;   * iterScopeSafeExpr accepts a guard that has a CATCH-ALL clause (test
+;;;     #t or `else`) whose body/clauses are themselves escape-free — because
+;;;     such a guard can never let an exception propagate past the loop body,
+;;;     so the back edge's iter_scope_end is always reached (balanced LIFO).
+;;;
+;;; The loop's carried state is a plain counter (numeric every iteration), so
+;;; the dynamic escape check takes the POP (reclaim) path each pass; the
+;;; per-iteration `scratch` list + string is provably dead at the back edge
+;;; and gets reclaimed. Bounded-RSS is asserted by
+;;; scripts/run_rss_bounded_test.sh --test on this file (flat peak RSS across
+;;; a 10x pass-count scale). The value assertion below guards correctness.
+
+(define total-passes 300000)
+
+;; Self-tail-recursive define, body wrapped in a catch-all guard. Each
+;; iteration allocates a small list and a string that never escape the
+;; iteration; the carry is a plain integer count.
+(define (loop i acc)
+  (guard (e (#t acc))                     ; catch-all: any raise yields acc
+    (if (>= i total-passes)
+        acc
+        (let ((scratch (list i
+                             (* i 2)
+                             (number->string i)
+                             (string-append "iter-" (number->string i)))))
+          ;; length of scratch is always 4 -> deterministic checksum, and
+          ;; `scratch` itself is dead after this expression.
+          (loop (+ i 1) (+ acc (length scratch)))))))
+
+(let ((result (loop 0 0)))
+  (display "[define_loop_iter_scope_test] passes=")
+  (display total-passes)
+  (display " result=")
+  (display result)
+  (newline)
+  (if (= result (* total-passes 4))
+      (begin (display "PASS") (newline))
+      (begin (display "FAIL expected ")
+             (display (* total-passes 4))
+             (newline))))


### PR DESCRIPTION
## Root cause (two coordinated gaps)

ESH-0214b makes a TCO loop reclaim its own per-iteration arena garbage: push an arena scope at the loop header, and on every back edge + the loop exit call `eshkol_arena_iter_scope_end`. It existed **only** for named-let loops. A top-level self-tail `define` whose body is a catch-all `guard` (the resilient-daemon idiom `(define (loop i acc) (guard (e (#t <h>)) <body> (loop ...)))`) got no reclamation, for two independent reasons:

- **Gap A — the define TCO path hard-disabled iter_scope.** `codegenDefine` set `tco_ctx.iter_scope = false` unconditionally ("named-let-only"). Its back edges therefore never ended a scope, and no scope was pushed at the loop header.
- **Gap B — the escape analysis rejected `guard`.** `iterScopeSafeExpr` sent `ESHKOL_GUARD_OP` to `default: return false`, so even with Gap A fixed the guard-wrapped body would be classified unsafe.

Net effect: every iteration's allocations accumulated in the process-lifetime arena forever → unbounded RSS → OOM / SIGSEGV in long-running loops.

## The fix

**`lib/backend/llvm_codegen.cpp`**

- **Gap A (`codegenDefine` TCO setup + return paths):** compute `define_iter_scope_safe = isSelfTailRecursive(...) && loopBodyIterScopeSafe(define_op.value, func_name)` (the define's own name is registered as the loop name so its self-tail-calls are recognized as back edges). Set `tco_ctx.iter_scope = define_iter_scope_safe`. After branching to the loop header, push the per-iteration arena scope (`getArenaPushScopeFunc()` / `getArenaPtr()`) exactly like `codegenNamedLet`. The back edges already end the scope generically when `tco_ctx.iter_scope` is set (`codegenTailCallFromContext`); the base-case **return** paths now call `emitIterScopeEnd({retval})` before each `CreateRet`. Reset `iter_scope` to false in the TCO cleanup block so no later define inherits a stale flag. ESH-0222 machinery (`loop_stack_save`, `open_guard_handlers`) is untouched.
- **Gap B (`iterScopeSafeExpr`):** added `case ESHKOL_GUARD_OP` that returns safe **iff** (1) the guard has a catch-all clause — a clause whose test is boolean `#t` (`ESHKOL_BOOL`, nonzero) or the symbol `else`; AND (2) every guard body expr is iter-scope-safe; AND (3) every clause's test + result exprs are iter-scope-safe. Malformed (non-CALL_OP) clauses are conservatively rejected.
- Renamed `namedLetIterScopeSafe` → `loopBodyIterScopeSafe` (now shared by both the named-let and define paths); updated its one existing caller. No analysis logic duplicated.

**`tests/features/define_loop_iter_scope_test.esk`** — new repro: a top-level self-tail `define` loop wrapped in a catch-all `guard`, allocating a fresh list + strings per iteration, numeric carry, parametric on `(define total-passes ...)` so `scripts/run_rss_bounded_test.sh --test` drives it.

## Catch-all-guard correctness rationale

The per-iteration scope stack is a shared LIFO; correctness requires that **every** entered iteration reaches exactly one `iter_scope_end` (a back edge or the loop return). A `guard` with a catch-all clause (`#t` / `else`) can never let an exception propagate **past** the loop body: any raise inside the iteration (a syntactic `raise`, or a runtime error longjmp) is caught by the handler, the handler yields a value, and control rejoins the normal flow → the back edge's / return's `iter_scope_end` is still reached → the scope stack stays balanced. A **non**-catch-all guard can fall through all clauses and **re-raise** (longjmp) straight past the back edge, leaving an un-ended scope that corrupts the shared stack — so those remain unsafe (`return false`). This is preserved exactly.

## What I built and measured

- Built `eshkol-run` + `stdlib`: `cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build --target eshkol-run stdlib -j8` (clean, exit 0).
- **Flat-RSS proof** (`scripts/run_rss_bounded_test.sh --test tests/features/define_loop_iter_scope_test.esk`, macOS `/usr/bin/time -l`):
  - `#t`-clause define loop: **226 MB @ N=100k → 224 MB @ N=1,000,000** (10× iterations, peak-RSS ratio **0.99×**). exit 0, PASS, no SIGSEGV.
  - `else`-clause variant: **226 MB → 223 MB** over the same 10× range.
- **Mechanism-is-responsible control** (`ESHKOL_NO_ITER_SCOPE=1`, disabling reclamation): same program grows **225 MB @ 100k → 1369 MB @ 1M** — the linear leak the fix removes.
- **Semantics**: a catch-all guard that catches a `raise` on some iterations and continues the loop returns the exact expected checksum (406 for the designed case); non-catch-all guard loop still returns correctly (reclamation simply disabled).
- **Regressions**: `tests/memory/auto_iter_scope_test.esk` 11/11; named-let bounded-RSS gate flat (225→223 MB); `guard_advanced`/`guard_edge`/`exception`/`exception_nesting`/`tco/guard_loop_tail` all exit 0; sampled `tests/features` + full `tests/tco` clean.

Base RSS (~225 MB) is the `eshkol-run -r` JIT/LLVM baseline; the load-bearing property is flatness across iteration count, which holds.
