### PR TITLE
docs(impl): document quantum, ffi, bridge implementations

### DIFF
--- a/lib/bridge/tensor_backward.cpp
+++ b/lib/bridge/tensor_backward.cpp
@@ -26,6 +26,8 @@
  * Internal Helpers
  ******************************************************************************/
 
+/** @brief Computes the total element count of a tensor from its shape
+ *  (product of all dimension sizes). */
 static size_t tensor_size(const int64_t* shape, size_t ndim) {
     size_t size = 1;
     for (size_t i = 0; i < ndim; i++) {
@@ -41,7 +43,8 @@ extern "C" {
     void* arena_allocate_zeroed(arena_t* arena, size_t size);
 }
 
-/* Allocate zero-initialized gradient tensor (arena-scoped) */
+/** @brief Allocates a zero-initialized gradient buffer of n doubles from
+ *  the global arena. */
 static double* alloc_grad(size_t n) {
     return (double*)arena_allocate_zeroed(get_global_arena(), n * sizeof(double));
 }
@@ -55,6 +58,8 @@ static double* alloc_grad(size_t n) {
  *   dL/dB = A^T @ dL/dC   →  [k,m] @ [m,n] = [k,n]
  ******************************************************************************/
 
+/** @brief Backward pass for matrix multiply: propagates dL/dC into
+ *  dL/dA = dL/dC @ B^T and dL/dB = A^T @ dL/dC (2D case). */
 extern "C" void tensor_matmul_backward(ad_node_t* node) {
     if (!node || !node->tensor_gradient) return;
 
@@ -112,6 +117,8 @@ extern "C" void tensor_matmul_backward(ad_node_t* node) {
  *   dL/dx[i] = y[i] * (dL/dy[i] - sum_j(dL/dy[j] * y[j]))
  ******************************************************************************/
 
+/** @brief Backward pass for softmax: for each row along the last
+ *  dimension, computes dx[i] = y[i] * (dy[i] - sum_j(dy[j] * y[j])). */
 extern "C" void tensor_softmax_backward(ad_node_t* node) {
     if (!node || !node->tensor_gradient) return;
 
@@ -157,6 +164,10 @@ extern "C" void tensor_softmax_backward(ad_node_t* node) {
  * Backward: complex chain rule through mean and variance
  ******************************************************************************/
 
+/** @brief Backward pass for layer normalization: for each row along the
+ *  last dimension, chains gradients back through the mean/variance
+ *  normalization to dx, and accumulates dgamma when a gamma input is
+ *  present. */
 extern "C" void tensor_layernorm_backward(ad_node_t* node) {
     if (!node || !node->tensor_gradient) return;
 
@@ -238,6 +249,9 @@ extern "C" void tensor_layernorm_backward(ad_node_t* node) {
  * Backward: chain rule through RMS computation
  ******************************************************************************/
 
+/** @brief Backward pass for RMS normalization: for each row along the
+ *  last dimension, chains gradients back through the RMS computation to
+ *  dx, and accumulates dgamma when a gamma input is present. */
 extern "C" void tensor_rmsnorm_backward(ad_node_t* node) {
     if (!node || !node->tensor_gradient) return;
 
@@ -306,6 +320,9 @@ extern "C" void tensor_rmsnorm_backward(ad_node_t* node) {
  * where a = sqrt(2/pi), b = 0.044715
  ******************************************************************************/
 
+/** @brief Backward pass for the tanh-approximation GELU activation:
+ *  applies the derivative of gelu(x) = 0.5*x*(1+tanh(a*(x+b*x^3))) to
+ *  scale the incoming gradient. */
 extern "C" void tensor_gelu_backward(ad_node_t* node) {
     if (!node || !node->tensor_gradient) return;
 
@@ -341,6 +358,9 @@ extern "C" void tensor_gelu_backward(ad_node_t* node) {
  * silu'(x) = sigmoid(x) * (1 + x * (1 - sigmoid(x)))
  ******************************************************************************/
 
+/** @brief Backward pass for SiLU/Swish: applies the derivative
+ *  silu'(x) = sigmoid(x) * (1 + x * (1 - sigmoid(x))) to scale the
+ *  incoming gradient. */
 extern "C" void tensor_silu_backward(ad_node_t* node) {
     if (!node || !node->tensor_gradient) return;
 
@@ -369,6 +389,9 @@ extern "C" void tensor_silu_backward(ad_node_t* node) {
  * dL/dlogits = softmax(logits) - target  (numerically stable)
  ******************************************************************************/
 
+/** @brief Backward pass for softmax cross-entropy loss: computes the
+ *  numerically-stable gradient dL/dlogits = softmax(logits) - targets for
+ *  each row of the batch. */
 extern "C" void tensor_cross_entropy_backward(ad_node_t* node) {
     if (!node || !node->tensor_gradient) return;
 
@@ -426,9 +449,10 @@ extern "C" void tensor_cross_entropy_backward(ad_node_t* node) {
  * magnitude.
  ******************************************************************************/
 
-/* Transpose: dL/dX[i,j] = dL/dY[j,i]. Permutation is its own inverse
- * for 2D; higher-rank transposes require the permutation vector
- * which the forward codegen should set up on the node. */
+/** @brief Backward pass for transpose: dL/dX[i,j] = dL/dY[j,i]. Permutation
+ *  is its own inverse for 2D; higher-rank transposes require the
+ *  permutation vector which the forward codegen should set up on the
+ *  node. */
 extern "C" void tensor_transpose_backward(ad_node_t* node) {
     if (!node || !node->tensor_gradient) return;
     ad_node_t* in = node->input1;
@@ -449,8 +473,9 @@ extern "C" void tensor_transpose_backward(ad_node_t* node) {
     }
 }
 
-/* Sum over all elements: forward reduces to a scalar; backward
- * broadcasts dL/dy uniformly. */
+/** @brief Backward pass for a full sum reduction: the forward pass
+ *  reduces to a scalar, so backward broadcasts the scalar dL/dy uniformly
+ *  onto every element of the input. */
 extern "C" void tensor_sum_backward(ad_node_t* node) {
     if (!node || !node->tensor_gradient) return;
     ad_node_t* in = node->input1;
@@ -462,10 +487,11 @@ extern "C" void tensor_sum_backward(ad_node_t* node) {
     for (size_t i = 0; i < n; i++) dX[i] += dy;
 }
 
-/* Broadcast-add: forward is y[i] = a + b[i] (scalar a broadcast over
- * tensor b) or y[i,j] = a[i] + b[i,j]. The conservative backward
- * splits gradient along both inputs: dL/db = dL/dy (elementwise),
- * dL/da = sum(dL/dy) across the broadcast axis. */
+/** @brief Backward pass for broadcast-add: forward is y[i] = a + b[i]
+ *  (scalar a broadcast over tensor b) or y[i,j] = a[i] + b[i,j]. Splits
+ *  the gradient along both inputs: dL/db = dL/dy (elementwise, sum-reduced
+ *  if b is smaller than the output), dL/da = sum(dL/dy) across the
+ *  broadcast axis. */
 extern "C" void tensor_broadcast_add_backward(ad_node_t* node) {
     if (!node || !node->tensor_gradient) return;
     ad_node_t* a = node->input1;
@@ -505,9 +531,10 @@ extern "C" void tensor_broadcast_add_backward(ad_node_t* node) {
     }
 }
 
-/* Broadcast-multiply: y = a * b (one broadcast). Product rule:
- * dL/da = sum(dL/dy * b), dL/db = dL/dy * a (both may need
- * broadcast reduction). Same conservative shape handling as add. */
+/** @brief Backward pass for broadcast-multiply: y = a * b (one operand may
+ *  be broadcast). Applies the product rule dL/da = sum(dL/dy * b),
+ *  dL/db = sum(dL/dy * a), with the same broadcast-reduction handling as
+ *  tensor_broadcast_add_backward(). */
 extern "C" void tensor_broadcast_mul_backward(ad_node_t* node) {
     if (!node || !node->tensor_gradient) return;
     ad_node_t* a = node->input1;
@@ -549,14 +576,14 @@ extern "C" void tensor_broadcast_mul_backward(ad_node_t* node) {
     }
 }
 
-/* Embedding lookup backward: forward is y[i,:] = W[idx[i],:].
- * Backward scatters dL/dy rows into dL/dW at idx[i]. We don't have
- * the idx vector wired through the node structure yet — until that's
- * threaded, fall back to the conservative "sum grad into row 0" so
- * the gradient signal still reaches the weight tensor non-zero and
- * subsequent training steps don't silently stall. Tracked as ESH-0230
- * (.swarm/tasks/ESH-0230.json) — implement once the forward-pass wiring
- * delivers node->input2 as the index tensor. */
+/** @brief Backward pass for embedding lookup (forward is y[i,:] =
+ *  W[idx[i],:]); properly it should scatter dL/dy rows into dL/dW at
+ *  idx[i]. We don't have the idx vector wired through the node structure
+ *  yet — until that's threaded, fall back to the conservative "sum grad
+ *  into row 0" so the gradient signal still reaches the weight tensor
+ *  non-zero and subsequent training steps don't silently stall. Tracked
+ *  as ESH-0230 (.swarm/tasks/ESH-0230.json) — implement once the
+ *  forward-pass wiring delivers node->input2 as the index tensor. */
 extern "C" void tensor_embedding_backward(ad_node_t* node) {
     if (!node || !node->tensor_gradient) return;
     ad_node_t* W = node->input1;
@@ -592,11 +619,12 @@ extern "C" void tensor_embedding_backward(ad_node_t* node) {
     for (size_t i = 0; i < write && i < n_w; i++) dW[i] += dy[i];
 }
 
-/* Attention: conservative identity-like pass through for the value
- * input. Proper scaled-dot-product backward requires Q/K/V split in
- * the node — stubbed here to at least propagate a non-zero signal.
- * The exact formulation (5-step chain through softmax(QK^T/√d)V)
- * lands with the full attention codegen rewrite. */
+/** @brief Backward pass for attention: a conservative identity-like
+ *  pass-through for the value input only. Proper scaled-dot-product
+ *  backward requires the Q/K/V split in the node — stubbed here to at
+ *  least propagate a non-zero signal. The exact formulation (5-step chain
+ *  through softmax(QK^T/√d)V) lands with the full attention codegen
+ *  rewrite. */
 extern "C" void tensor_attention_backward(ad_node_t* node) {
     if (!node || !node->tensor_gradient) return;
     ad_node_t* v = node->input2 ? node->input2 : node->input1;
@@ -634,6 +662,11 @@ extern "C" void tensor_attention_backward(ad_node_t* node) {
 
 typedef void (*backward_fn_t)(ad_node_t*);
 
+/** @brief Looks up the backward-pass function for a given AD tensor node
+ *  type. Returns NULL (after a one-time stderr warning) for node types with
+ *  no registered backward, so the caller can skip gradient propagation for
+ *  genuinely non-AD node types (CONSTANT / VARIABLE) as well as any
+ *  op whose forward codegen has no matching backward implementation. */
 extern "C" backward_fn_t get_tensor_backward_fn(int node_type) {
     switch ((ad_node_type_t)node_type) {
         case AD_NODE_TENSOR_MATMUL:          return tensor_matmul_backward;

--- a/lib/ffi/eshkol_ffi.cpp
+++ b/lib/ffi/eshkol_ffi.cpp
@@ -39,6 +39,8 @@ extern "C" void eshkol_get_raised_value(eshkol_tagged_value_t* out);
 /* ── Thread-local error message ── */
 static thread_local char g_ffi_error[4096] = {0};
 
+/** @brief Formats a printf-style message into the thread-local FFI error
+ *  buffer (g_ffi_error), truncating to fit if necessary. */
 static void ffi_set_error(const char* fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
@@ -56,6 +58,8 @@ struct eshkol_ffi_context {
 
 /* ── Convert between FFI and runtime value types ── */
 /* These are layout-compatible (both 16 bytes, same field order). */
+/** @brief Reinterprets a runtime tagged value as the public FFI value type
+ *  (same 16-byte layout, byte-for-byte copy). */
 static inline eshkol_ffi_value_t to_ffi(eshkol_tagged_value_t v) {
     eshkol_ffi_value_t result;
     static_assert(sizeof(result) == sizeof(v), "FFI and tagged value must be same size");
@@ -63,6 +67,8 @@ static inline eshkol_ffi_value_t to_ffi(eshkol_tagged_value_t v) {
     return result;
 }
 
+/** @brief Reinterprets a public FFI value as the runtime tagged value type
+ *  (same 16-byte layout, byte-for-byte copy). */
 static inline eshkol_tagged_value_t from_ffi(eshkol_ffi_value_t v) {
     eshkol_tagged_value_t result;
     memcpy(&result, &v, sizeof(v));

--- a/lib/quantum/quantum_rng.c
+++ b/lib/quantum/quantum_rng.c
@@ -43,6 +43,8 @@ static uint64_t measure_state(qrng_ctx *ctx, double quantum_state, uint64_t last
 static void quantum_step(qrng_ctx *ctx);
 
 #ifdef _WIN32
+/** @brief Windows implementation of gettimeofday(): converts the current
+ *  FILETIME to a Unix-epoch struct timeval (seconds + microseconds). */
 static int qrng_gettimeofday(struct timeval *tv) {
     FILETIME file_time;
     ULARGE_INTEGER ticks;
@@ -59,6 +61,7 @@ static int qrng_gettimeofday(struct timeval *tv) {
 
 #define qrng_getpid _getpid
 #else
+/** @brief POSIX passthrough to the system gettimeofday(). */
 static int qrng_gettimeofday(struct timeval *tv) {
     return gettimeofday(tv, NULL);
 }
@@ -66,7 +69,9 @@ static int qrng_gettimeofday(struct timeval *tv) {
 #define qrng_getpid getpid
 #endif
 
-// Enhanced quantum noise function with multiple transformations
+/** @brief Chaotic noise transform: runs x through trigonometric mixing,
+ *  a Heisenberg-style combination, and a square-root "tunneling" step to
+ *  produce a pseudo-random value normalized to [0, 1). */
 static inline double quantum_noise(double x) {
     volatile double noise = x;
     
@@ -88,7 +93,8 @@ static inline double quantum_noise(double x) {
     return noise;
 }
 
-// Enhanced splitmix64 with better avalanche
+/** @brief SplitMix64-style 64-bit hash: xor-shift/multiply rounds (with an
+ *  extra constant folded in) that scramble x into a well-avalanched value. */
 static inline uint64_t splitmix64(uint64_t x) {
     x ^= x >> 30;
     x *= 0xbf58476d1ce4e5b9ULL;
@@ -100,7 +106,8 @@ static inline uint64_t splitmix64(uint64_t x) {
     return x;
 }
 
-// Enhanced Hadamard mixing function
+/** @brief Additional avalanche-mixing pass on top of splitmix64(), folding
+ *  in the Pauli/fine-structure constants for deeper bit diffusion. */
 static inline uint64_t hadamard_mix(uint64_t x) {
     x = splitmix64(x);
     x ^= QRNG_PAULI_X * (x >> 12);
@@ -113,7 +120,9 @@ static inline uint64_t hadamard_mix(uint64_t x) {
     return x;
 }
 
-// Enhanced system entropy collection
+/** @brief Gathers a one-time seed of system-level entropy (wall clock,
+ *  process id, CPU clock ticks, a stack address, and — on x86 — the RDTSC
+ *  cycle counter), XORed together into a single 64-bit value. */
 static uint64_t get_system_entropy(void) {
     struct timeval tv;
     qrng_gettimeofday(&tv);
@@ -134,7 +143,9 @@ static uint64_t get_system_entropy(void) {
     return entropy;
 }
 
-// Enhanced runtime entropy collection
+/** @brief Derives fresh per-call entropy from the current wall-clock time
+ *  mixed with the context's stored system entropy, unique id, and counter,
+ *  scrambled through hadamard_mix(). */
 static uint64_t get_runtime_entropy(qrng_ctx *ctx) {
     struct timeval tv;
     qrng_gettimeofday(&tv);
@@ -148,7 +159,9 @@ static uint64_t get_runtime_entropy(qrng_ctx *ctx) {
     return runtime;
 }
 
-// Enhanced Hadamard gate with improved quantum properties
+/** @brief Simulates a Hadamard-gate-like transform on x: converts it to a
+ *  normalized double, runs it through quantum_noise() to build a
+ *  superposition value, applies a phase rotation, and remixes the result. */
 static inline uint64_t hadamard_gate(uint64_t x) {
     volatile double state = (double)x / UINT64_MAX;
     state = quantum_noise(state);
@@ -167,7 +180,9 @@ static inline uint64_t hadamard_gate(uint64_t x) {
     return superposition;
 }
 
-// Enhanced phase gate with improved entropy
+/** @brief Simulates a phase-gate transform: derives a phase-dependent
+ *  mixing value from angle via quantum_noise() and several avalanche
+ *  rounds, then XORs it onto x. */
 static inline uint64_t phase_gate(uint64_t x, uint64_t angle) {
     volatile double phase = (double)angle / UINT64_MAX;
     phase = quantum_noise(phase);
@@ -184,7 +199,9 @@ static inline uint64_t phase_gate(uint64_t x, uint64_t angle) {
     return x ^ mixed;
 }
 
-// Enhanced measurement function with improved entropy collection
+/** @brief Simulates a quantum measurement: collapses quantum_state (combined
+ *  with fresh runtime entropy) into a 64-bit value, updating ctx's entropy
+ *  pool and pool mixer as a side effect, and returns the mixed result. */
 static uint64_t measure_state(qrng_ctx *ctx, double quantum_state, uint64_t last) {
     // Update runtime entropy
     ctx->runtime_entropy = get_runtime_entropy(ctx);
@@ -217,7 +234,11 @@ static uint64_t measure_state(qrng_ctx *ctx, double quantum_state, uint64_t last
     return result;
 }
 
-// Core state management and output generation
+/** @brief Advances the generator's internal quantum state by
+ *  QRNG_MIXING_ROUNDS rounds of qubit updates (Hadamard gate, noise
+ *  injection, measurement, and entanglement between adjacent qubits), then
+ *  refills ctx->buffer with fresh 64-bit words and resets buffer_pos.
+ *  Called by qrng_bytes() whenever the output buffer is exhausted. */
 static void quantum_step(qrng_ctx *ctx) {
     if (!ctx) return;
     

--- a/lib/quantum/quantum_rng_wrapper.c
+++ b/lib/quantum/quantum_rng_wrapper.c
@@ -21,7 +21,7 @@ int eshkol_qrng_init(void) {
     return 0;
 }
 
-// Ensure initialization before any operation
+/** @brief Lazily initializes the global quantum RNG context on first use. */
 static inline void ensure_init(void) {
     if (!g_qrng_initialized) {
         eshkol_qrng_init();


### PR DESCRIPTION
## Summary
- Add Doxygen `/** @brief ... */` doc-comments to previously-undocumented function definitions in `lib/quantum/quantum_rng.c` and `lib/quantum/quantum_rng_wrapper.c` (internal static helpers not covered by the existing header docs).
- Same for `lib/ffi/eshkol_ffi.cpp` (internal static helpers: error formatting, FFI/runtime value conversion).
- Same for `lib/bridge/tensor_backward.cpp` (AD tensor backward-pass functions and internal helpers).
- Documentation only — no code or behavior changes.

## Test plan
- [x] `clang++ -std=c++17 -fsyntax-only` on the two touched `.cpp` files
- [x] `gcc -c -fsyntax-only` on the two touched `.c` files
- [x] Verified balanced comment delimiters in all four files
- [x] `git diff` reviewed — comment-only insertions, no reformatting