### PR TITLE
docs(impl): document agent-FFI, types, parser, REPL implementations

### DIFF
--- a/lib/agent/c/agent_compression.c
+++ b/lib/agent/c/agent_compression.c
@@ -15,6 +15,15 @@
 
 #include <zlib.h>
 
+/**
+ * @brief Compresses @p data into zlib (RFC 1950) format using the default compression level.
+ *
+ * Wraps zlib's compress2(). The compressed output is written to @p buf,
+ * whose capacity is given by @p buf_size.
+ *
+ * @return Number of compressed bytes written to @p buf, or -1 on invalid
+ *         arguments or if @p buf is too small to hold the compressed data.
+ */
 int32_t eshkol_deflate(const char* data, int32_t data_len,
                         char* buf, int32_t buf_size) {
     if (!data || !buf || data_len <= 0 || buf_size <= 0) return -1;
@@ -24,6 +33,15 @@ int32_t eshkol_deflate(const char* data, int32_t data_len,
     return r == Z_OK ? (int32_t)dest_len : -1;
 }
 
+/**
+ * @brief Decompresses a zlib (RFC 1950) buffer produced by eshkol_deflate() back into @p buf.
+ *
+ * Wraps zlib's uncompress(). @p buf_size gives the caller-supplied capacity
+ * of @p buf and is used as the initial estimate of the decompressed size.
+ *
+ * @return Number of decompressed bytes written to @p buf, or -1 on invalid
+ *         arguments or decompression failure.
+ */
 int32_t eshkol_inflate_data(const char* data, int32_t data_len,
                              char* buf, int32_t buf_size) {
     if (!data || !buf || data_len <= 0 || buf_size <= 0) return -1;
@@ -33,6 +51,17 @@ int32_t eshkol_inflate_data(const char* data, int32_t data_len,
     return r == Z_OK ? (int32_t)dest_len : -1;
 }
 
+/**
+ * @brief Compresses @p data into gzip (RFC 1952) format.
+ *
+ * Configures a zlib deflate stream with windowBits = 15+16 so the output
+ * includes a gzip header/trailer, then compresses the entire input in one
+ * Z_FINISH call.
+ *
+ * @return Number of compressed bytes written to @p buf, or -1 if
+ *         initialization fails, arguments are invalid, or @p buf is too
+ *         small to hold the full compressed stream.
+ */
 int32_t eshkol_gzip(const char* data, int32_t data_len,
                       char* buf, int32_t buf_size) {
     if (!data || !buf || data_len <= 0 || buf_size <= 0) return -1;
@@ -51,6 +80,17 @@ int32_t eshkol_gzip(const char* data, int32_t data_len,
     return result;
 }
 
+/**
+ * @brief Decompresses a gzip (RFC 1952) buffer produced by eshkol_gzip() (or any gzip stream).
+ *
+ * Configures a zlib inflate stream with windowBits = 15+16 to accept the
+ * gzip header/trailer, then decompresses the entire input in one Z_FINISH
+ * call.
+ *
+ * @return Number of decompressed bytes written to @p buf, or -1 if
+ *         initialization fails, arguments are invalid, or decompression
+ *         does not complete in a single pass.
+ */
 int32_t eshkol_gunzip(const char* data, int32_t data_len,
                         char* buf, int32_t buf_size) {
     if (!data || !buf || data_len <= 0 || buf_size <= 0) return -1;
@@ -68,18 +108,24 @@ int32_t eshkol_gunzip(const char* data, int32_t data_len,
     return result;
 }
 
+/** @brief Reports that zlib-backed compression support is compiled in. @return Always 1. */
 int32_t eshkol_compression_available(void) { return 1; }
 
 #else /* !HAS_ZLIB */
 
+/** @brief Stub used when built without HAS_ZLIB; deflate compression is unavailable. @return Always -1. */
 int32_t eshkol_deflate(const char* d, int32_t dl, char* b, int32_t bs)
     { (void)d;(void)dl;(void)b;(void)bs; return -1; }
+/** @brief Stub used when built without HAS_ZLIB; inflate decompression is unavailable. @return Always -1. */
 int32_t eshkol_inflate_data(const char* d, int32_t dl, char* b, int32_t bs)
     { (void)d;(void)dl;(void)b;(void)bs; return -1; }
+/** @brief Stub used when built without HAS_ZLIB; gzip compression is unavailable. @return Always -1. */
 int32_t eshkol_gzip(const char* d, int32_t dl, char* b, int32_t bs)
     { (void)d;(void)dl;(void)b;(void)bs; return -1; }
+/** @brief Stub used when built without HAS_ZLIB; gunzip decompression is unavailable. @return Always -1. */
 int32_t eshkol_gunzip(const char* d, int32_t dl, char* b, int32_t bs)
     { (void)d;(void)dl;(void)b;(void)bs; return -1; }
+/** @brief Reports that zlib-backed compression support is not compiled in. @return Always 0. */
 int32_t eshkol_compression_available(void) { return 0; }
 
 #endif

--- a/lib/agent/c/agent_concurrency.c
+++ b/lib/agent/c/agent_concurrency.c
@@ -41,6 +41,11 @@
 
 static pthread_mutex_t* g_mutexes[MAX_MUTEXES] = {0};
 
+/**
+ * @brief Finds the first free (NULL) slot in the mutex handle table, skipping index 0 so 0 is never a valid handle.
+ *
+ * @return Index of a free slot (>= 1), or -1 if all MAX_MUTEXES slots are in use.
+ */
 static int alloc_mutex_slot(void) {
     for (int i = 1; i < MAX_MUTEXES; i++) {
         if (!g_mutexes[i]) return i;
@@ -52,6 +57,11 @@ static int alloc_mutex_slot(void) {
  * Create a new mutex.
  * Returns: handle (>= 1), -1 if slots full
  */
+/**
+ * @brief Allocates and initializes a new pthread mutex and stores it in the mutex handle table.
+ *
+ * @return Mutex handle (>= 1) on success, -1 if the slot table is full, allocation fails, or pthread_mutex_init() fails.
+ */
 int64_t eshkol_make_mutex(void) {
     int slot = alloc_mutex_slot();
     if (slot < 0) return -1;
@@ -62,16 +72,34 @@ int64_t eshkol_make_mutex(void) {
     return (int64_t)slot;
 }
 
+/**
+ * @brief Locks the mutex at @p handle, blocking until it is acquired.
+ *
+ * @param handle Mutex handle from eshkol_make_mutex().
+ * @return 0 on success, -1 on invalid handle or pthread_mutex_lock() failure.
+ */
 int32_t eshkol_mutex_lock(int64_t handle) {
     if (handle < 1 || handle >= MAX_MUTEXES || !g_mutexes[handle]) return -1;
     return pthread_mutex_lock(g_mutexes[handle]) == 0 ? 0 : -1;
 }
 
+/**
+ * @brief Unlocks the mutex at @p handle.
+ *
+ * @param handle Mutex handle from eshkol_make_mutex().
+ * @return 0 on success, -1 on invalid handle or pthread_mutex_unlock() failure.
+ */
 int32_t eshkol_mutex_unlock(int64_t handle) {
     if (handle < 1 || handle >= MAX_MUTEXES || !g_mutexes[handle]) return -1;
     return pthread_mutex_unlock(g_mutexes[handle]) == 0 ? 0 : -1;
 }
 
+/**
+ * @brief Attempts to lock the mutex at @p handle without blocking.
+ *
+ * @param handle Mutex handle from eshkol_make_mutex().
+ * @return 1 if the lock was acquired, 0 if it is already held by someone else, -1 on invalid handle or other error.
+ */
 int32_t eshkol_mutex_trylock(int64_t handle) {
     if (handle < 1 || handle >= MAX_MUTEXES || !g_mutexes[handle]) return -1;
     int r = pthread_mutex_trylock(g_mutexes[handle]);
@@ -80,6 +108,11 @@ int32_t eshkol_mutex_trylock(int64_t handle) {
     return -1;                       /* Error */
 }
 
+/**
+ * @brief Destroys the pthread mutex at @p handle, frees it, and clears its slot.
+ *
+ * @param handle Mutex handle from eshkol_make_mutex(). No-op if out of range or already destroyed.
+ */
 void eshkol_mutex_destroy(int64_t handle) {
     if (handle < 1 || handle >= MAX_MUTEXES || !g_mutexes[handle]) return;
     pthread_mutex_destroy(g_mutexes[handle]);
@@ -95,6 +128,11 @@ void eshkol_mutex_destroy(int64_t handle) {
 
 static pthread_cond_t* g_condvars[MAX_CONDVARS] = {0};
 
+/**
+ * @brief Allocates and initializes a new pthread condition variable and stores it in the condition-variable handle table.
+ *
+ * @return Condition-variable handle (>= 1) on success, -1 if the slot table is full, allocation fails, or pthread_cond_init() fails.
+ */
 int64_t eshkol_make_condition_variable(void) {
     for (int i = 1; i < MAX_CONDVARS; i++) {
         if (!g_condvars[i]) {
@@ -108,22 +146,50 @@ int64_t eshkol_make_condition_variable(void) {
     return -1;
 }
 
+/**
+ * @brief Atomically unlocks @p mutex_handle and waits on @p cv_handle, relocking the mutex before returning.
+ *
+ * Mirrors pthread_cond_wait() semantics: the caller must already hold the
+ * mutex, and must be prepared to re-check its wait condition on return
+ * since condition variables can wake spuriously.
+ *
+ * @param cv_handle Condition-variable handle from eshkol_make_condition_variable().
+ * @param mutex_handle Mutex handle from eshkol_make_mutex(), currently held by the caller.
+ * @return 0 on success, -1 on invalid handles or pthread_cond_wait() failure.
+ */
 int32_t eshkol_condition_wait(int64_t cv_handle, int64_t mutex_handle) {
     if (cv_handle < 1 || cv_handle >= MAX_CONDVARS || !g_condvars[cv_handle]) return -1;
     if (mutex_handle < 1 || mutex_handle >= MAX_MUTEXES || !g_mutexes[mutex_handle]) return -1;
     return pthread_cond_wait(g_condvars[cv_handle], g_mutexes[mutex_handle]) == 0 ? 0 : -1;
 }
 
+/**
+ * @brief Wakes at least one thread waiting on the condition variable at @p handle.
+ *
+ * @param handle Condition-variable handle from eshkol_make_condition_variable().
+ * @return 0 on success, -1 on invalid handle or pthread_cond_signal() failure.
+ */
 int32_t eshkol_condition_signal(int64_t handle) {
     if (handle < 1 || handle >= MAX_CONDVARS || !g_condvars[handle]) return -1;
     return pthread_cond_signal(g_condvars[handle]) == 0 ? 0 : -1;
 }
 
+/**
+ * @brief Wakes all threads waiting on the condition variable at @p handle.
+ *
+ * @param handle Condition-variable handle from eshkol_make_condition_variable().
+ * @return 0 on success, -1 on invalid handle or pthread_cond_broadcast() failure.
+ */
 int32_t eshkol_condition_broadcast(int64_t handle) {
     if (handle < 1 || handle >= MAX_CONDVARS || !g_condvars[handle]) return -1;
     return pthread_cond_broadcast(g_condvars[handle]) == 0 ? 0 : -1;
 }
 
+/**
+ * @brief Destroys the pthread condition variable at @p handle, frees it, and clears its slot.
+ *
+ * @param handle Condition-variable handle from eshkol_make_condition_variable(). No-op if out of range or already destroyed.
+ */
 void eshkol_condition_destroy(int64_t handle) {
     if (handle < 1 || handle >= MAX_CONDVARS || !g_condvars[handle]) return;
     pthread_cond_destroy(g_condvars[handle]);
@@ -163,6 +229,17 @@ static Channel* g_channels[MAX_CHANNELS] = {0};
  * capacity: max buffered values. 0 = synchronous (rendezvous).
  * Returns: handle (>= 1), -1 error
  */
+/**
+ * @brief Allocates a bounded, thread-safe FIFO channel with room for @p capacity buffered values.
+ *
+ * A @p capacity of 0 is stored internally with one buffer slot but behaves
+ * as a synchronous rendezvous, since eshkol_channel_send() and
+ * eshkol_channel_receive() coordinate via the same not_full/not_empty
+ * condition variables regardless of buffer size.
+ *
+ * @param capacity Maximum number of buffered values (0 for synchronous rendezvous); must be between 0 and MAX_CHANNEL_BUF.
+ * @return Channel handle (>= 1) on success, -1 if @p capacity is out of range, the slot table is full, or allocation fails.
+ */
 int64_t eshkol_make_channel(int32_t capacity) {
     if (capacity < 0 || capacity > MAX_CHANNEL_BUF) return -1;
     int effective_cap = capacity > 0 ? capacity : 1;  /* Need at least 1 slot for rendezvous */
@@ -189,6 +266,13 @@ int64_t eshkol_make_channel(int32_t capacity) {
  * Send a value to the channel. Blocks if buffer is full.
  * Returns: 0 success, -1 error (channel closed)
  */
+/**
+ * @brief Pushes @p value onto the channel at @p handle, blocking while the buffer is full.
+ *
+ * @param handle Channel handle from eshkol_make_channel().
+ * @param value Opaque tagged Eshkol value to enqueue.
+ * @return 0 on success, -1 on invalid handle or if the channel is (or becomes) closed while waiting.
+ */
 int32_t eshkol_channel_send(int64_t handle, int64_t value) {
     if (handle < 1 || handle >= MAX_CHANNELS || !g_channels[handle]) return -1;
     Channel* ch = g_channels[handle];
@@ -214,6 +298,14 @@ int32_t eshkol_channel_send(int64_t handle, int64_t value) {
  * timeout_ms: -1 = infinite, 0 = immediate, >0 = milliseconds
  * value_out: receives the value
  * Returns: 1 = value received, 0 = timeout, -1 = closed/error
+ */
+/**
+ * @brief Pops the next value from the channel at @p handle, waiting according to @p timeout_ms if it is empty.
+ *
+ * @param handle Channel handle from eshkol_make_channel().
+ * @param timeout_ms -1 to wait indefinitely, 0 to try without blocking, or a positive number of milliseconds to wait.
+ * @param value_out Output: receives the dequeued value when the return value is 1.
+ * @return 1 if a value was received, 0 on timeout (or empty with timeout_ms 0), -1 on invalid handle/arguments or if the channel is closed and empty.
  */
 int32_t eshkol_channel_receive(int64_t handle, int32_t timeout_ms, int64_t* value_out) {
     if (handle < 1 || handle >= MAX_CHANNELS || !g_channels[handle] || !value_out) return -1;
@@ -265,6 +357,11 @@ int32_t eshkol_channel_receive(int64_t handle, int32_t timeout_ms, int64_t* valu
 /*
  * Close a channel. Wakes all waiting senders/receivers.
  */
+/**
+ * @brief Marks the channel at @p handle closed and wakes all threads blocked in eshkol_channel_send() or eshkol_channel_receive().
+ *
+ * @param handle Channel handle from eshkol_make_channel(). No-op if out of range or unallocated.
+ */
 void eshkol_channel_close(int64_t handle) {
     if (handle < 1 || handle >= MAX_CHANNELS || !g_channels[handle]) return;
     Channel* ch = g_channels[handle];
@@ -277,6 +374,11 @@ void eshkol_channel_close(int64_t handle) {
 
 /*
  * Destroy a channel and free resources.
+ */
+/**
+ * @brief Closes the channel at @p handle, destroys its mutex/condition variables, frees its buffer, and clears its slot.
+ *
+ * @param handle Channel handle from eshkol_make_channel(). No-op if out of range or unallocated.
  */
 void eshkol_channel_destroy(int64_t handle) {
     if (handle < 1 || handle >= MAX_CHANNELS || !g_channels[handle]) return;
@@ -313,6 +415,19 @@ typedef struct {
 
 static Timer* g_timers[MAX_TIMERS] = {0};
 
+/**
+ * @brief Background thread body for both one-shot timers and repeating intervals; sleeps for the configured delay and sets the "fired" flag.
+ *
+ * For a repeating timer (@c interval_ms > 0), loops sleeping and setting
+ * @c fired until cancelled. For a one-shot timer, sleeps once for
+ * @c delay_ms and sets @c fired, then exits. Never invokes an Eshkol
+ * closure directly from this thread — the Eshkol runtime is not
+ * thread-safe for closure invocation, so callers must poll
+ * eshkol_timer_check() from the main event loop instead.
+ *
+ * @param arg Pointer to the owning Timer.
+ * @return Always NULL.
+ */
 static void* timer_thread_func(void* arg) {
     Timer* t = (Timer*)arg;
 
@@ -343,6 +458,12 @@ static void* timer_thread_func(void* arg) {
  * delay_ms: milliseconds until timer fires
  * Returns: handle (>= 1), -1 error
  */
+/**
+ * @brief Creates and starts a detached background thread that sets a "fired" flag once after @p delay_ms.
+ *
+ * @param delay_ms Milliseconds to wait before firing; must be >= 0.
+ * @return Timer handle (>= 1) on success, -1 if @p delay_ms is negative, the slot table is full, allocation fails, or the thread cannot be created.
+ */
 int64_t eshkol_make_timer(int64_t delay_ms) {
     if (delay_ms < 0) return -1;
     for (int i = 1; i < MAX_TIMERS; i++) {
@@ -372,6 +493,12 @@ int64_t eshkol_make_timer(int64_t delay_ms) {
  * interval_ms: milliseconds between firings
  * Returns: handle (>= 1), -1 error
  */
+/**
+ * @brief Creates and starts a detached background thread that sets a "fired" flag repeatedly every @p interval_ms until cancelled.
+ *
+ * @param interval_ms Milliseconds between firings; must be > 0.
+ * @return Timer handle (>= 1) on success, -1 if @p interval_ms is not positive, the slot table is full, allocation fails, or the thread cannot be created.
+ */
 int64_t eshkol_make_interval(int64_t interval_ms) {
     if (interval_ms <= 0) return -1;
     for (int i = 1; i < MAX_TIMERS; i++) {
@@ -400,6 +527,12 @@ int64_t eshkol_make_interval(int64_t interval_ms) {
  * Check if timer has fired (and clear the flag).
  * Returns: 1 if fired since last check, 0 if not yet, -1 if handle invalid
  */
+/**
+ * @brief Checks whether the timer at @p handle has fired since the last check, clearing the flag if so.
+ *
+ * @param handle Timer handle from eshkol_make_timer() or eshkol_make_interval().
+ * @return 1 if the timer fired since the last check, 0 if not yet fired, -1 if @p handle is invalid.
+ */
 int32_t eshkol_timer_check(int64_t handle) {
     if (handle < 1 || handle >= MAX_TIMERS || !g_timers[handle]) return -1;
     Timer* t = g_timers[handle];
@@ -412,6 +545,15 @@ int32_t eshkol_timer_check(int64_t handle) {
 
 /*
  * Cancel a timer or interval.
+ */
+/**
+ * @brief Cancels the timer at @p handle, waits briefly for its background thread to notice, then frees it and clears its slot.
+ *
+ * Waits up to ~100ms (100 x 1ms sleeps) for the timer thread to observe
+ * the cancellation flag and exit before freeing the Timer struct out from
+ * under it; this is a best-effort wait, not a hard join.
+ *
+ * @param handle Timer handle from eshkol_make_timer() or eshkol_make_interval(). No-op if out of range or unallocated.
  */
 void eshkol_timer_cancel(int64_t handle) {
     if (handle < 1 || handle >= MAX_TIMERS || !g_timers[handle]) return;

--- a/lib/agent/c/agent_eagle_training.c
+++ b/lib/agent/c/agent_eagle_training.c
@@ -22,6 +22,14 @@ typedef struct {
 
 void qllm_ffi_linear_destroy(void* handle);
 
+/**
+ * @brief Validates that a linear layer's input/output dimensions are positive,
+ * bounded, and won't overflow when multiplied.
+ *
+ * @param in_dim Proposed input dimension.
+ * @param out_dim Proposed output dimension.
+ * @return 1 if the dimensions are usable, 0 otherwise.
+ */
 static int qllm_ffi_linear_valid_dims(int64_t in_dim, int64_t out_dim) {
     const int64_t max_dim = 1 << 20;
     if (in_dim <= 0 || out_dim <= 0) return 0;
@@ -30,6 +38,15 @@ static int qllm_ffi_linear_valid_dims(int64_t in_dim, int64_t out_dim) {
     return 1;
 }
 
+/**
+ * @brief Checks that @p layer is non-NULL and (@p out, @p in) is a valid
+ * weight-matrix coordinate for it.
+ *
+ * @param layer Layer to validate against (may be NULL).
+ * @param out Output-dimension index to check.
+ * @param in Input-dimension index to check.
+ * @return 1 if @p layer is non-NULL and both indices are in range, 0 otherwise.
+ */
 static int qllm_ffi_linear_bounds(qllm_ffi_linear_t* layer, int64_t out, int64_t in) {
     if (!layer) return 0;
     if (out < 0 || out >= layer->out_dim) return 0;
@@ -37,6 +54,18 @@ static int qllm_ffi_linear_bounds(qllm_ffi_linear_t* layer, int64_t out, int64_t
     return 1;
 }
 
+/**
+ * @brief Allocates a linear layer with zero-initialized weights, gradients,
+ * input, target, and prediction buffers.
+ *
+ * On any allocation failure, all partially-allocated buffers are released
+ * via qllm_ffi_linear_destroy() before returning NULL.
+ *
+ * @param in_dim Input dimension (must be positive and bounded; see
+ *        qllm_ffi_linear_valid_dims()).
+ * @param out_dim Output dimension (same constraints as @p in_dim).
+ * @return Opaque layer handle on success, or NULL on invalid dimensions or OOM.
+ */
 void* qllm_ffi_linear_create(int64_t in_dim, int64_t out_dim) {
     if (!qllm_ffi_linear_valid_dims(in_dim, out_dim)) return NULL;
 
@@ -61,6 +90,11 @@ void* qllm_ffi_linear_create(int64_t in_dim, int64_t out_dim) {
     return layer;
 }
 
+/**
+ * @brief Frees a linear layer and all of its internal buffers.
+ *
+ * @param handle Layer handle from qllm_ffi_linear_create(). No-op if NULL.
+ */
 void qllm_ffi_linear_destroy(void* handle) {
     qllm_ffi_linear_t* layer = (qllm_ffi_linear_t*)handle;
     if (!layer) return;
@@ -72,6 +106,15 @@ void qllm_ffi_linear_destroy(void* handle) {
     free(layer);
 }
 
+/**
+ * @brief Sets a single entry of the layer's row-major weight matrix.
+ *
+ * @param handle Layer handle from qllm_ffi_linear_create().
+ * @param out Output-dimension (row) index.
+ * @param in Input-dimension (column) index.
+ * @param value New weight value.
+ * @return 0 on success, -1 if @p handle is invalid or the indices are out of range.
+ */
 int32_t qllm_ffi_linear_set_weight(void* handle, int64_t out, int64_t in, double value) {
     qllm_ffi_linear_t* layer = (qllm_ffi_linear_t*)handle;
     if (!qllm_ffi_linear_bounds(layer, out, in)) return -1;
@@ -79,12 +122,29 @@ int32_t qllm_ffi_linear_set_weight(void* handle, int64_t out, int64_t in, double
     return 0;
 }
 
+/**
+ * @brief Reads a single entry of the layer's row-major weight matrix.
+ *
+ * @param handle Layer handle from qllm_ffi_linear_create().
+ * @param out Output-dimension (row) index.
+ * @param in Input-dimension (column) index.
+ * @return The weight value, or 0.0 if @p handle is invalid or the indices
+ *         are out of range.
+ */
 double qllm_ffi_linear_get_weight(void* handle, int64_t out, int64_t in) {
     qllm_ffi_linear_t* layer = (qllm_ffi_linear_t*)handle;
     if (!qllm_ffi_linear_bounds(layer, out, in)) return 0.0;
     return layer->weights[(size_t)(out * layer->in_dim + in)];
 }
 
+/**
+ * @brief Sets one component of the layer's input vector x.
+ *
+ * @param handle Layer handle from qllm_ffi_linear_create().
+ * @param in Input-dimension index.
+ * @param value New input value.
+ * @return 0 on success, -1 if @p handle is invalid or @p in is out of range.
+ */
 int32_t qllm_ffi_linear_set_input(void* handle, int64_t in, double value) {
     qllm_ffi_linear_t* layer = (qllm_ffi_linear_t*)handle;
     if (!layer || in < 0 || in >= layer->in_dim) return -1;
@@ -92,6 +152,14 @@ int32_t qllm_ffi_linear_set_input(void* handle, int64_t in, double value) {
     return 0;
 }
 
+/**
+ * @brief Sets one component of the layer's training target vector.
+ *
+ * @param handle Layer handle from qllm_ffi_linear_create().
+ * @param out Output-dimension index.
+ * @param value New target value.
+ * @return 0 on success, -1 if @p handle is invalid or @p out is out of range.
+ */
 int32_t qllm_ffi_linear_set_target(void* handle, int64_t out, double value) {
     qllm_ffi_linear_t* layer = (qllm_ffi_linear_t*)handle;
     if (!layer || out < 0 || out >= layer->out_dim) return -1;
@@ -99,6 +167,13 @@ int32_t qllm_ffi_linear_set_target(void* handle, int64_t out, double value) {
     return 0;
 }
 
+/**
+ * @brief Computes the forward pass y = W.x, storing the result in the layer's
+ * prediction buffer.
+ *
+ * @param handle Layer handle from qllm_ffi_linear_create().
+ * @return 0 on success, -1 if @p handle is NULL.
+ */
 int32_t qllm_ffi_linear_forward(void* handle) {
     qllm_ffi_linear_t* layer = (qllm_ffi_linear_t*)handle;
     if (!layer) return -1;
@@ -114,12 +189,29 @@ int32_t qllm_ffi_linear_forward(void* handle) {
     return 0;
 }
 
+/**
+ * @brief Reads one component of the layer's most recent prediction (from
+ * qllm_ffi_linear_forward()).
+ *
+ * @param handle Layer handle from qllm_ffi_linear_create().
+ * @param out Output-dimension index.
+ * @return The predicted value, or 0.0 if @p handle is invalid or @p out is
+ *         out of range.
+ */
 double qllm_ffi_linear_pred(void* handle, int64_t out) {
     qllm_ffi_linear_t* layer = (qllm_ffi_linear_t*)handle;
     if (!layer || out < 0 || out >= layer->out_dim) return 0.0;
     return layer->pred[out];
 }
 
+/**
+ * @brief Computes the mean squared error between the layer's prediction and
+ * target vectors.
+ *
+ * @param handle Layer handle from qllm_ffi_linear_create().
+ * @return Mean squared error over all output dimensions, or 0.0 if @p handle
+ *         is NULL.
+ */
 double qllm_ffi_linear_loss(void* handle) {
     qllm_ffi_linear_t* layer = (qllm_ffi_linear_t*)handle;
     if (!layer) return 0.0;
@@ -131,6 +223,16 @@ double qllm_ffi_linear_loss(void* handle) {
     return loss / (double)layer->out_dim;
 }
 
+/**
+ * @brief Computes the MSE-loss gradient dW = dL/dy outer x and stores it in
+ * the layer's gradient buffer.
+ *
+ * Requires qllm_ffi_linear_forward() to have already populated the
+ * prediction buffer for the current input/target.
+ *
+ * @param handle Layer handle from qllm_ffi_linear_create().
+ * @return 0 on success, -1 if @p handle is NULL.
+ */
 int32_t qllm_ffi_linear_backward(void* handle) {
     qllm_ffi_linear_t* layer = (qllm_ffi_linear_t*)handle;
     if (!layer) return -1;
@@ -150,12 +252,29 @@ int32_t qllm_ffi_linear_backward(void* handle) {
     return 0;
 }
 
+/**
+ * @brief Reads a single entry of the layer's gradient matrix (from
+ * qllm_ffi_linear_backward()).
+ *
+ * @param handle Layer handle from qllm_ffi_linear_create().
+ * @param out Output-dimension (row) index.
+ * @param in Input-dimension (column) index.
+ * @return The gradient value, or 0.0 if @p handle is invalid or the indices
+ *         are out of range.
+ */
 double qllm_ffi_linear_grad(void* handle, int64_t out, int64_t in) {
     qllm_ffi_linear_t* layer = (qllm_ffi_linear_t*)handle;
     if (!qllm_ffi_linear_bounds(layer, out, in)) return 0.0;
     return layer->grads[(size_t)(out * layer->in_dim + in)];
 }
 
+/**
+ * @brief Applies one vanilla SGD update: weights -= lr * grads, elementwise.
+ *
+ * @param handle Layer handle from qllm_ffi_linear_create().
+ * @param lr Learning rate.
+ * @return 0 on success, -1 if @p handle is NULL.
+ */
 int32_t qllm_ffi_linear_sgd_step(void* handle, double lr) {
     qllm_ffi_linear_t* layer = (qllm_ffi_linear_t*)handle;
     if (!layer) return -1;
@@ -167,6 +286,14 @@ int32_t qllm_ffi_linear_sgd_step(void* handle, double lr) {
     return 0;
 }
 
+/**
+ * @brief Runs one full training step: forward pass, backward pass, then an
+ * SGD weight update.
+ *
+ * @param handle Layer handle from qllm_ffi_linear_create().
+ * @param lr Learning rate passed through to qllm_ffi_linear_sgd_step().
+ * @return 0 on success, -1 if any sub-step fails (invalid @p handle).
+ */
 int32_t qllm_ffi_linear_train_step(void* handle, double lr) {
     if (qllm_ffi_linear_forward(handle) != 0) return -1;
     if (qllm_ffi_linear_backward(handle) != 0) return -1;

--- a/lib/agent/c/agent_http_client.c
+++ b/lib/agent/c/agent_http_client.c
@@ -54,6 +54,15 @@ typedef struct qllm_http_response {
 static pthread_mutex_t g_init_mutex = PTHREAD_MUTEX_INITIALIZER;
 static int g_init_refs = 0;
 
+/**
+ * @brief malloc() wrapper that aborts the process on allocation failure.
+ *
+ * Used throughout this file so out-of-memory is treated as fatal
+ * rather than requiring every call site to check for NULL.
+ *
+ * @param n Number of bytes to allocate.
+ * @return Newly allocated, uninitialized buffer of @p n bytes; never NULL (aborts instead of returning NULL).
+ */
 static void* xmalloc(size_t n) {
     void* p = malloc(n);
     if (!p) {
@@ -63,6 +72,13 @@ static void* xmalloc(size_t n) {
     return p;
 }
 
+/**
+ * @brief Allocates a NUL-terminated copy of @p n bytes from @p src.
+ *
+ * @param src Source bytes to copy; may be NULL if @p n is 0.
+ * @param n Number of bytes to copy from @p src.
+ * @return Newly allocated, NUL-terminated buffer of @p n + 1 bytes.
+ */
 static char* xstrdup_n(const char* src, size_t n) {
     char* out = (char*)xmalloc(n + 1);
     if (n > 0 && src) memcpy(out, src, n);
@@ -78,6 +94,19 @@ typedef struct {
     size_t cap;
 } body_buf_t;
 
+/**
+ * @brief libcurl write callback that appends received bytes into a body_buf_t.
+ *
+ * Grows @p userdata's buffer geometrically (doubling) so repeated
+ * chunked writes stay amortized O(n), and keeps the buffer
+ * NUL-terminated after each append.
+ *
+ * @param ptr Chunk of received data from libcurl.
+ * @param size Element size, per libcurl's CURLOPT_WRITEFUNCTION contract.
+ * @param nmemb Element count; total bytes received is @p size * @p nmemb.
+ * @param userdata The body_buf_t* accumulator passed via CURLOPT_WRITEDATA.
+ * @return Number of bytes consumed; returning 0 (on a realloc failure) signals libcurl to abort the transfer.
+ */
 static size_t write_cb(void* ptr, size_t size, size_t nmemb, void* userdata) {
     body_buf_t* buf = (body_buf_t*)userdata;
     size_t add = size * nmemb;
@@ -98,6 +127,18 @@ static size_t write_cb(void* ptr, size_t size, size_t nmemb, void* userdata) {
 /* Configure shared curl options for all requests. Centralizing this
  * means TLS cert verification and redirect policy are consistent
  * across get/post/post_json. */
+/**
+ * @brief Applies the curl options shared by all HTTP requests (GET/POST/POST-JSON).
+ *
+ * Wires up the write callback/buffer, enables following redirects (up
+ * to 10), disables libcurl's SIGPIPE handling for thread-safety, sets
+ * the connect and total timeouts, sets a fixed User-Agent, and enables
+ * TLS peer and host verification.
+ *
+ * @param curl The easy handle to configure.
+ * @param buf Body accumulator to receive the response via write_cb().
+ * @param timeout_ms Total request timeout in milliseconds; values <= 0 default to 30000ms.
+ */
 static void apply_common_opts(CURL* curl, body_buf_t* buf, int32_t timeout_ms) {
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, buf);
@@ -114,6 +155,21 @@ static void apply_common_opts(CURL* curl, body_buf_t* buf, int32_t timeout_ms) {
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
 }
 
+/**
+ * @brief Builds a qllm_http_response_t from a completed curl transfer.
+ *
+ * On a transfer-level failure (@p rc != CURLE_OK), returns a response
+ * with status 0 and an error string from curl_easy_strerror(), and
+ * frees the partially-accumulated body. On success, reads the HTTP
+ * status code from @p curl and transfers ownership of @p buf's data
+ * into the response body, allocating an empty string instead if no
+ * body bytes were ever written so callers never see a NULL body.
+ *
+ * @param curl The completed easy handle (read only for the status code on success).
+ * @param buf Body accumulator populated by write_cb(); its buffer ownership transfers to the returned response on success.
+ * @param rc The CURLcode result of curl_easy_perform().
+ * @return Newly allocated response; never NULL.
+ */
 static qllm_http_response_t* finalize_response(CURL* curl, body_buf_t* buf, CURLcode rc) {
     qllm_http_response_t* resp = (qllm_http_response_t*)xmalloc(sizeof(*resp));
     memset(resp, 0, sizeof(*resp));
@@ -142,6 +198,14 @@ static qllm_http_response_t* finalize_response(CURL* curl, body_buf_t* buf, CURL
  * Public ABI — qllm_http_*
  * ============================================================================ */
 
+/**
+ * @brief Initializes libcurl's global state, ref-counted so concurrent/nested init calls are safe.
+ *
+ * Only the first call (when the ref count is 0) actually invokes
+ * curl_global_init(); subsequent calls just increment the ref count.
+ *
+ * @return 1 on success, 0 if curl_global_init() failed.
+ */
 int32_t qllm_http_init(void) {
     pthread_mutex_lock(&g_init_mutex);
     if (g_init_refs == 0) {
@@ -156,6 +220,11 @@ int32_t qllm_http_init(void) {
     return 1;
 }
 
+/**
+ * @brief Decrements the libcurl init ref count, tearing down global state only when it reaches zero.
+ *
+ * Pairs with qllm_http_init(); safe to call even if the ref count is already 0.
+ */
 void qllm_http_shutdown(void) {
     pthread_mutex_lock(&g_init_mutex);
     if (g_init_refs > 0) {
@@ -167,6 +236,11 @@ void qllm_http_shutdown(void) {
     pthread_mutex_unlock(&g_init_mutex);
 }
 
+/**
+ * @brief Reports whether the linked libcurl build has TLS/SSL support.
+ *
+ * @return 1 if the CURL_VERSION_SSL feature bit is set, 0 otherwise or if version info is unavailable.
+ */
 int32_t qllm_http_has_ssl(void) {
     /* libcurl built without TLS would still link; check the feature
      * bitmap to give an accurate answer. */
@@ -175,6 +249,17 @@ int32_t qllm_http_has_ssl(void) {
     return (info->features & CURL_VERSION_SSL) ? 1 : 0;
 }
 
+/**
+ * @brief Performs a blocking HTTP GET and returns the response.
+ *
+ * Lazily calls qllm_http_init() if the agent never initialized libcurl
+ * explicitly. Each call creates and destroys its own CURL easy handle,
+ * so this is safe to call concurrently from multiple threads.
+ *
+ * @param url Target URL; NULL returns NULL immediately.
+ * @param timeout_ms Total request timeout in milliseconds (see apply_common_opts()).
+ * @return Newly allocated response (caller must call qllm_http_response_free()), or NULL if @p url is NULL or the easy handle could not be created.
+ */
 qllm_http_response_t* qllm_http_get(const char* url, int32_t timeout_ms) {
     if (!url) return NULL;
     /* Lazy-init: the agent may forget to call http-init before its first
@@ -199,6 +284,17 @@ qllm_http_response_t* qllm_http_get(const char* url, int32_t timeout_ms) {
  * style array — that's the layout the qLLM C client uses. Eshkol's
  * http.esk currently doesn't pass headers through this path (it goes
  * via http-post-json-raw), but provide the full ABI for forward compat. */
+/**
+ * @brief Performs a blocking HTTP POST with an optional body and header list.
+ *
+ * @param url Target URL; NULL returns NULL immediately.
+ * @param headers Array of @p header_count "Name: value" header strings; may be NULL.
+ * @param header_count Number of entries in @p headers.
+ * @param body Request body bytes; ignored if @p body_len <= 0.
+ * @param body_len Length of @p body in bytes.
+ * @param timeout_ms Total request timeout in milliseconds.
+ * @return Newly allocated response (caller must call qllm_http_response_free()), or NULL if @p url is NULL or the easy handle could not be created.
+ */
 qllm_http_response_t* qllm_http_post(const char* url,
                                      const char** headers,
                                      int64_t header_count,
@@ -239,6 +335,15 @@ qllm_http_response_t* qllm_http_post(const char* url,
  * body with Content-Type application/json plus an optional auth header.
  * The auth_header string is taken verbatim — caller is responsible
  * for choosing "Authorization: Bearer ..." vs "x-api-key: ..." etc. */
+/**
+ * @brief Performs a blocking HTTP POST of a JSON body with Content-Type/Accept headers, plus an optional auth header.
+ *
+ * @param url Target URL; NULL returns NULL immediately.
+ * @param body JSON request body; its strlen() determines the length sent, empty/NULL sends no body.
+ * @param auth_header Full "Header-Name: value" line to add verbatim, or NULL/empty to omit.
+ * @param timeout_ms Total request timeout in milliseconds.
+ * @return Newly allocated response (caller must call qllm_http_response_free()), or NULL if @p url is NULL or the easy handle could not be created.
+ */
 qllm_http_response_t* qllm_http_post_json(const char* url,
                                           const char* body,
                                           const char* auth_header,
@@ -280,18 +385,41 @@ qllm_http_response_t* qllm_http_post_json(const char* url,
     return resp;
 }
 
+/**
+ * @brief Returns the HTTP status code of a response.
+ *
+ * @param resp Response to inspect; NULL is safe.
+ * @return The HTTP status code, or 0 if @p resp is NULL or the transfer failed before a response was received.
+ */
 int32_t qllm_http_response_status(qllm_http_response_t* resp) {
     return resp ? resp->status : 0;
 }
 
+/**
+ * @brief Returns the response body as a NUL-terminated string.
+ *
+ * @param resp Response to inspect; NULL is safe.
+ * @return Pointer to the NUL-terminated body (owned by @p resp), or NULL if @p resp is NULL.
+ */
 const char* qllm_http_response_body(qllm_http_response_t* resp) {
     return resp ? resp->body : NULL;
 }
 
+/**
+ * @brief Returns the response body length in bytes (binary-safe, excludes the NUL terminator).
+ *
+ * @param resp Response to inspect; NULL is safe.
+ * @return Body length in bytes, or 0 if @p resp is NULL.
+ */
 int64_t qllm_http_response_body_len(qllm_http_response_t* resp) {
     return resp ? resp->body_len : 0;
 }
 
+/**
+ * @brief Frees a response and its owned body/error strings.
+ *
+ * @param resp Response to free; NULL is a no-op.
+ */
 void qllm_http_response_free(qllm_http_response_t* resp) {
     if (!resp) return;
     free(resp->body);
@@ -299,6 +427,12 @@ void qllm_http_response_free(qllm_http_response_t* resp) {
     free(resp);
 }
 
+/**
+ * @brief Maps a curl error code to a human-readable string.
+ *
+ * @param code A CURLcode value; codes <= 0 are treated as "no error".
+ * @return A static, non-owned string describing the error.
+ */
 const char* qllm_http_error_string(int32_t code) {
     /* Map curl error codes to human strings. Negative or zero → no error. */
     if (code <= 0) return "no error";
@@ -309,6 +443,12 @@ const char* qllm_http_error_string(int32_t code) {
  * Eshkol's http.esk doesn't currently call this directly (it uses
  * the get/post/post_json convenience entries). Provide a NULL-returning
  * stub so the symbol resolves at link time without crashing. */
+/**
+ * @brief Stub for the qLLM packed-request ABI entry point; not implemented.
+ *
+ * @param req Unused.
+ * @return Always NULL.
+ */
 void* qllm_http_request(void* req) {
     (void)req;
     return NULL;
@@ -317,6 +457,13 @@ void* qllm_http_request(void* req) {
 /* SSE streaming entry points: deliberately return NULL/error so the
  * Eshkol fallback path runs. Real implementation needs CURL multi
  * interface or chunked-transfer line parsing; deferred to a follow-up. */
+/**
+ * @brief Stub for opening an SSE stream; not implemented, always fails.
+ *
+ * Deliberately returns NULL so callers fall back to Eshkol's existing non-streaming path.
+ *
+ * @return Always NULL.
+ */
 void* qllm_http_stream_open(const char* url, const char** headers, int64_t hdr_count,
                             const char* body, int64_t body_len, int32_t timeout_ms,
                             void* callback) {
@@ -325,20 +472,32 @@ void* qllm_http_stream_open(const char* url, const char** headers, int64_t hdr_c
     return NULL;
 }
 
+/**
+ * @brief Stub for reading the next SSE event; not implemented.
+ *
+ * @return Always -1 (error/no event).
+ */
 int32_t qllm_http_stream_next(void* stream, void* event_out, int32_t timeout_ms) {
     (void)stream; (void)event_out; (void)timeout_ms;
     return -1;
 }
 
+/**
+ * @brief Stub for checking whether an SSE stream is finished.
+ *
+ * @return Always 1 (done), since streaming is not implemented.
+ */
 int32_t qllm_http_stream_done(void* stream) {
     (void)stream;
     return 1;
 }
 
+/** @brief Stub for closing an SSE stream; not implemented (no-op). */
 void qllm_http_stream_close(void* stream) {
     (void)stream;
 }
 
+/** @brief Stub for freeing an SSE event; not implemented (no-op). */
 void qllm_sse_event_free(void* event) {
     (void)event;
 }

--- a/lib/agent/c/agent_http_server.c
+++ b/lib/agent/c/agent_http_server.c
@@ -51,6 +51,18 @@
 #  define ESHKOL_WS_HAS_ARC4RANDOM 0
 #endif
 
+/**
+ * @brief Fills a 4-byte WebSocket frame masking key with unpredictable bytes.
+ *
+ * RFC 6455 section 5.3 requires every client-to-server frame to be masked
+ * with a key that is not predictable to an attacker. Prefers
+ * arc4random_buf() where available, falls back to reading from
+ * /dev/urandom, and as a last resort (both unavailable) uses a
+ * time-seeded linear congruential generator that is not
+ * cryptographically strong but avoids the RFC-violating all-zero mask.
+ *
+ * @param out Buffer of 4 bytes to receive the mask.
+ */
 static void eshkol_ws_random_mask(unsigned char out[4]) {
 #if ESHKOL_WS_HAS_ARC4RANDOM
     arc4random_buf(out, 4);
@@ -90,6 +102,18 @@ static HttpServer* g_servers[MAX_HTTP_SERVERS] = {0};
  * Create HTTP server and bind to port.
  * port: TCP port (0 = random available port)
  * Returns: handle (>= 1), -1 error
+ */
+/**
+ * @brief Allocates a server slot, creates a loopback-only TCP listening socket, and binds/listens on @p port.
+ *
+ * Binds to 127.0.0.1 (INADDR_LOOPBACK) only, never all interfaces, since
+ * this server exists for local OAuth PKCE callbacks and similar short-lived
+ * local IPC, not for serving remote clients. If @p port is 0, the OS
+ * assigns an ephemeral port, which can be retrieved with
+ * eshkol_http_server_port().
+ *
+ * @param port TCP port to bind, or 0 to let the OS choose one.
+ * @return Server handle (>= 1) on success, -1 on socket/bind/listen failure or if all server slots are in use.
  */
 int64_t eshkol_http_server_create(int32_t port) {
     int slot = -1;
@@ -136,6 +160,15 @@ int64_t eshkol_http_server_create(int32_t port) {
 /*
  * Get actual port number.
  */
+/**
+ * @brief Returns the TCP port a server handle is actually bound to.
+ *
+ * Useful when eshkol_http_server_create() was called with port 0 and the
+ * OS assigned an ephemeral port.
+ *
+ * @param handle Server handle from eshkol_http_server_create().
+ * @return The bound port number, or -1 if @p handle is invalid.
+ */
 int32_t eshkol_http_server_port(int64_t handle) {
     if (handle < 1 || handle >= MAX_HTTP_SERVERS || !g_servers[handle]) return -1;
     return (int32_t)g_servers[handle]->port;
@@ -148,6 +181,22 @@ int32_t eshkol_http_server_port(int64_t handle) {
  * then "\n" then body.
  *
  * Returns: strlen written to buf, 0 on timeout, -1 error
+ */
+/**
+ * @brief Blocks up to @p timeout_ms waiting for one client connection, then reads its HTTP request into @p buf.
+ *
+ * Accepts a single connection on the listening socket, sets a 5-second
+ * receive timeout on the accepted client socket, and reads until either
+ * @p buf fills or the "\r\n\r\n" end-of-headers marker is seen (the request
+ * body, if any, is not read separately here). The accepted client fd is
+ * stashed on the server so a subsequent eshkol_http_server_respond() can
+ * reply on the same connection.
+ *
+ * @param handle Server handle from eshkol_http_server_create().
+ * @param buf Destination buffer for the raw request text (method/path, headers, and any body read so far).
+ * @param buf_size Size of @p buf, including space for the terminating NUL.
+ * @param timeout_ms How long to wait for an incoming connection before giving up.
+ * @return Number of bytes written to @p buf on success, 0 on timeout, -1 on error.
  */
 int32_t eshkol_http_server_accept(int64_t handle, char* buf, int32_t buf_size,
                                     int32_t timeout_ms) {
@@ -187,6 +236,19 @@ int32_t eshkol_http_server_accept(int64_t handle, char* buf, int32_t buf_size,
 /*
  * Send HTTP response on the current connection.
  */
+/**
+ * @brief Writes a complete HTTP/1.1 response (status line, Content-Type/Length headers, body) to the currently connected client and closes the connection.
+ *
+ * Maps a handful of common status codes (301, 400, 404, 500) to their
+ * reason phrases, defaulting to "OK" otherwise. Always sends
+ * "Connection: close" since this server is single-shot per client. Does
+ * nothing if there is no client currently connected on @p handle.
+ *
+ * @param handle Server handle from eshkol_http_server_create().
+ * @param status HTTP status code to send.
+ * @param content_type Value for the Content-Type header, or "text/html" if NULL.
+ * @param body Response body, or NULL/empty for no body.
+ */
 void eshkol_http_server_respond(int64_t handle, int32_t status,
                                   const char* content_type, const char* body) {
     if (handle < 1 || handle >= MAX_HTTP_SERVERS || !g_servers[handle]) return;
@@ -222,6 +284,11 @@ void eshkol_http_server_respond(int64_t handle, int32_t status,
 /*
  * Close and free HTTP server.
  */
+/**
+ * @brief Closes any open client/listening sockets for @p handle, frees the server, and clears its slot.
+ *
+ * @param handle Server handle from eshkol_http_server_create().
+ */
 void eshkol_http_server_close(int64_t handle) {
     if (handle < 1 || handle >= MAX_HTTP_SERVERS || !g_servers[handle]) return;
     HttpServer* srv = g_servers[handle];
@@ -235,6 +302,16 @@ void eshkol_http_server_close(int64_t handle) {
  * Unix Domain Socket Connect (for IDE IPC: VS Code VSCODE_IPC_HOOK)
  ******************************************************************************/
 
+/**
+ * @brief Opens a Unix domain socket and connects it to @p path.
+ *
+ * Used for local IDE IPC (e.g. VS Code's VSCODE_IPC_HOOK socket). The
+ * connected fd is returned directly rather than through a handle table,
+ * since callers manage it like any other raw socket fd.
+ *
+ * @param path Filesystem path of the Unix domain socket to connect to.
+ * @return Connected file descriptor (>= 0) on success, -1 on error or if @p path is NULL.
+ */
 int64_t eshkol_unix_socket_connect(const char* path) {
     if (!path) return -1;
     int fd = socket(AF_UNIX, SOCK_STREAM, 0);
@@ -278,6 +355,16 @@ static WsConnection* g_ws[MAX_WS_HANDLES] = {0};
  * operations and let the Eshkol wrapper handle the upgrade via
  * the existing HTTP client. */
 
+/**
+ * @brief Wraps an already-connected, already-upgraded TCP socket fd in a WebSocket handle for use with the eshkol_ws_* frame functions.
+ *
+ * Does not perform the HTTP Upgrade handshake itself — the caller is
+ * expected to complete the WebSocket upgrade (e.g. via the Eshkol HTTP
+ * client) before calling this, and pass in the resulting fd.
+ *
+ * @param fd Already-connected, already-upgraded socket file descriptor.
+ * @return WebSocket handle (>= 1) on success, -1 if all handle slots are in use.
+ */
 int64_t eshkol_ws_wrap_fd(int32_t fd) {
     for (int i = 1; i < MAX_WS_HANDLES; i++) {
         if (!g_ws[i]) {
@@ -293,6 +380,21 @@ int64_t eshkol_ws_wrap_fd(int32_t fd) {
 }
 
 /* Send WebSocket text frame (opcode 0x81, masked) */
+/**
+ * @brief Encodes and sends @p data as a single masked WebSocket text frame (opcode 0x1).
+ *
+ * Builds an RFC 6455 frame header with the appropriate extended-length
+ * encoding for @p len (7-bit, 16-bit, or 64-bit length), generates a fresh
+ * random mask per eshkol_ws_random_mask(), and masks the payload in
+ * place — using a 4096-byte stack buffer directly when the payload fits,
+ * otherwise masking and sending it in 4096-byte chunks to avoid a heap
+ * allocation.
+ *
+ * @param handle WebSocket handle from eshkol_ws_wrap_fd().
+ * @param data Text payload bytes to send.
+ * @param len Length of @p data in bytes.
+ * @return 0 on success, -1 on error, invalid handle, closed connection, or a short send().
+ */
 int32_t eshkol_ws_send_text(int64_t handle, const char* data, int32_t len) {
     if (handle < 1 || handle >= MAX_WS_HANDLES || !g_ws[handle]) return -1;
     WsConnection* ws = g_ws[handle];
@@ -350,6 +452,17 @@ int32_t eshkol_ws_send_text(int64_t handle, const char* data, int32_t len) {
 }
 
 /* Send WebSocket binary frame (opcode 0x82) */
+/**
+ * @brief Encodes and sends @p data as a single masked WebSocket binary frame (opcode 0x2).
+ *
+ * Identical framing/masking logic to eshkol_ws_send_text(), differing
+ * only in the opcode byte.
+ *
+ * @param handle WebSocket handle from eshkol_ws_wrap_fd().
+ * @param data Binary payload bytes to send.
+ * @param len Length of @p data in bytes.
+ * @return 0 on success, -1 on error, invalid handle, closed connection, or a short send().
+ */
 int32_t eshkol_ws_send_binary(int64_t handle, const char* data, int32_t len) {
     if (handle < 1 || handle >= MAX_WS_HANDLES || !g_ws[handle]) return -1;
     WsConnection* ws = g_ws[handle];
@@ -401,6 +514,23 @@ int32_t eshkol_ws_send_binary(int64_t handle, const char* data, int32_t len) {
 }
 
 /* Receive WebSocket frame */
+/**
+ * @brief Waits up to @p timeout_ms for a WebSocket frame, decodes and unmasks it into @p buf, and reports its opcode via @p frame_type.
+ *
+ * Reads the 2-byte base header plus any RFC 6455 extended length field
+ * (16-bit or 64-bit) and mask key, then reads and (if masked) unmasks the
+ * payload, truncating to @p buf_size if the frame is larger than the
+ * buffer. Close frames (opcode 0x8) mark the connection closed; ping
+ * frames (opcode 0x9) are answered automatically with an empty pong
+ * before returning.
+ *
+ * @param handle WebSocket handle from eshkol_ws_wrap_fd().
+ * @param buf Destination buffer for the (unmasked) payload.
+ * @param buf_size Size of @p buf, including space for the terminating NUL.
+ * @param frame_type Output: 1 text, 2 binary, 8 close, 9 ping, 10 pong, 0 unknown opcode.
+ * @param timeout_ms How long to wait for a frame before returning 0.
+ * @return Number of payload bytes written to @p buf, 0 on timeout, -1 on error.
+ */
 int32_t eshkol_ws_receive(int64_t handle, char* buf, int32_t buf_size,
                             int32_t* frame_type, int32_t timeout_ms) {
     if (handle < 1 || handle >= MAX_WS_HANDLES || !g_ws[handle]) return -1;
@@ -474,6 +604,11 @@ int32_t eshkol_ws_receive(int64_t handle, char* buf, int32_t buf_size,
 }
 
 /* Close WebSocket connection */
+/**
+ * @brief Sends a WebSocket close frame (if not already closed), closes the underlying socket, and frees @p handle.
+ *
+ * @param handle WebSocket handle from eshkol_ws_wrap_fd().
+ */
 void eshkol_ws_close(int64_t handle) {
     if (handle < 1 || handle >= MAX_WS_HANDLES || !g_ws[handle]) return;
     WsConnection* ws = g_ws[handle];

--- a/lib/agent/c/agent_kb_io.c
+++ b/lib/agent/c/agent_kb_io.c
@@ -40,6 +40,16 @@ typedef struct {
     size_t cap;
 } JsonBuf;
 
+/**
+ * @brief Initializes a JsonBuf with a freshly malloc'd buffer.
+ *
+ * Allocates @p initial bytes for the buffer and resets the length to
+ * zero. If the allocation fails, @p jb's buf is left NULL and
+ * subsequent jb_append()/jb_puts() calls become no-ops.
+ *
+ * @param jb Buffer to initialize.
+ * @param initial Initial capacity in bytes to allocate.
+ */
 static void jb_init(JsonBuf* jb, size_t initial) {
     jb->buf = (char*)malloc(initial);
     jb->len = 0;
@@ -47,6 +57,19 @@ static void jb_init(JsonBuf* jb, size_t initial) {
     if (jb->buf) jb->buf[0] = '\0';
 }
 
+/**
+ * @brief Appends a raw byte span to a JsonBuf, growing the buffer as needed.
+ *
+ * Doubles the buffer capacity until the new content plus a NUL
+ * terminator fits, then copies the bytes in. If @p jb's buffer is
+ * already NULL (a prior allocation failed) or a realloc() fails here,
+ * the buffer is left/marked NULL so further writes are silently
+ * skipped.
+ *
+ * @param jb Buffer to append to.
+ * @param str Bytes to append (need not be NUL-terminated).
+ * @param slen Number of bytes to copy from @p str.
+ */
 static void jb_append(JsonBuf* jb, const char* str, size_t slen) {
     if (!jb->buf) return;
     while (jb->len + slen + 1 > jb->cap) {
@@ -60,11 +83,25 @@ static void jb_append(JsonBuf* jb, const char* str, size_t slen) {
     jb->buf[jb->len] = '\0';
 }
 
+/**
+ * @brief Appends a NUL-terminated C string to a JsonBuf.
+ *
+ * Convenience wrapper around jb_append() that computes the length via
+ * strlen().
+ */
 static void jb_puts(JsonBuf* jb, const char* str) {
     jb_append(jb, str, strlen(str));
 }
 
 /* Write a JSON-escaped string (with surrounding quotes) */
+/**
+ * @brief Writes a JSON string literal (quoted and escaped) into the buffer.
+ *
+ * Wraps @p str in double quotes and escapes control characters per the
+ * JSON spec: `"`, `\`, newline, carriage return, and tab get their
+ * short escapes; other bytes below 0x20 become `\u00XX`. A NULL
+ * @p str is written as an empty string `""`.
+ */
 static void jb_string(JsonBuf* jb, const char* str) {
     jb_puts(jb, "\"");
     if (str) {
@@ -89,6 +126,9 @@ static void jb_string(JsonBuf* jb, const char* str) {
     jb_puts(jb, "\"");
 }
 
+/**
+ * @brief Frees a JsonBuf's backing buffer and resets it to an empty state.
+ */
 static void jb_free(JsonBuf* jb) {
     free(jb->buf);
     jb->buf = NULL;
@@ -121,6 +161,21 @@ static int32_t g_fact_count = 0;
  * Add a fact to the in-memory store.
  * Returns: fact index (>= 0), -1 if full
  */
+/**
+ * @brief Appends a new fact to the flat in-memory fact store.
+ *
+ * Copies @p subject, @p predicate, and @p object into the next free
+ * slot (truncating each to MAX_FIELD_LEN - 1 characters), along with
+ * @p value and the @p has_value flag. NULL string arguments are
+ * stored as empty strings.
+ *
+ * @param subject Fact subject field, or NULL for empty.
+ * @param predicate Fact predicate field, or NULL for empty.
+ * @param object Fact object field, or NULL for empty.
+ * @param value Numeric value associated with the fact (meaningful only if @p has_value is nonzero).
+ * @param has_value Non-zero if @p value should be considered set.
+ * @return The new fact's index (>= 0) on success, or -1 if the store is full (MAX_FACTS reached).
+ */
 int32_t eshkol_kb_fact_add(const char* subject, const char* predicate,
                              const char* object, double value, int32_t has_value) {
     if (g_fact_count >= MAX_FACTS) return -1;
@@ -140,12 +195,21 @@ int32_t eshkol_kb_fact_add(const char* subject, const char* predicate,
 /*
  * Clear all facts.
  */
+/**
+ * @brief Discards all stored facts by resetting the fact count to zero.
+ *
+ * Does not zero or free the underlying g_facts array; existing slots
+ * are simply overwritten as new facts are added.
+ */
 void eshkol_kb_fact_clear(void) {
     g_fact_count = 0;
 }
 
 /*
  * Get fact count.
+ */
+/**
+ * @brief Returns the number of facts currently stored.
  */
 int32_t eshkol_kb_fact_count(void) {
     return g_fact_count;
@@ -155,6 +219,18 @@ int32_t eshkol_kb_fact_count(void) {
  * Get fact field by index.
  * field: 0=subject, 1=predicate, 2=object
  * Returns: strlen written to buf, -1 error
+ */
+/**
+ * @brief Copies one string field of a stored fact into a caller-supplied buffer.
+ *
+ * Truncates to fit if the field is longer than @p buf_size - 1 and
+ * always NUL-terminates @p buf.
+ *
+ * @param idx Fact index, must be in [0, eshkol_kb_fact_count()).
+ * @param field Which field to fetch: 0=subject, 1=predicate, 2=object.
+ * @param buf Destination buffer.
+ * @param buf_size Size of @p buf in bytes.
+ * @return Number of characters written (excluding the NUL terminator), or -1 on an invalid index, field, or NULL/zero-size buffer.
  */
 int32_t eshkol_kb_fact_get_field(int32_t idx, int32_t field,
                                    char* buf, int32_t buf_size) {
@@ -178,11 +254,23 @@ int32_t eshkol_kb_fact_get_field(int32_t idx, int32_t field,
  * Get fact value by index.
  * Returns: the numeric value, 0.0 if not applicable
  */
+/**
+ * @brief Returns the numeric value stored with a fact.
+ *
+ * @param idx Fact index.
+ * @return The fact's value field, or 0.0 if @p idx is out of range.
+ */
 double eshkol_kb_fact_get_value(int32_t idx) {
     if (idx < 0 || idx >= g_fact_count) return 0.0;
     return g_facts[idx].value;
 }
 
+/**
+ * @brief Reports whether a fact's numeric value field is meaningful.
+ *
+ * @param idx Fact index.
+ * @return 1 if the fact has a valid numeric value, 0 if it does not or @p idx is out of range.
+ */
 int32_t eshkol_kb_fact_has_value(int32_t idx) {
     if (idx < 0 || idx >= g_fact_count) return 0;
     return g_facts[idx].has_value;
@@ -195,6 +283,21 @@ int32_t eshkol_kb_fact_has_value(int32_t idx) {
 /*
  * Save all facts to a JSON file.
  * Returns: 0 success, -1 error
+ */
+/**
+ * @brief Serializes all stored facts to a JSON array file at @p path.
+ *
+ * Builds the JSON text in memory (see the JsonBuf/jb_* helpers above),
+ * writing each fact as an object with subject/predicate/object string
+ * fields and, when the fact has a value (see eshkol_kb_fact_has_value()),
+ * a numeric "value" field formatted with up to 15 significant digits.
+ * The buffer is then written to @p path in one fwrite() call,
+ * overwriting any existing file.
+ *
+ * @param path Filesystem path to write; NULL is rejected.
+ * @return 0 on success, -1 if @p path is NULL, the in-memory buffer
+ *   failed to allocate, the file could not be opened, or not all
+ *   bytes were written.
  */
 int32_t eshkol_kb_save_json(const char* path) {
     if (!path) return -1;
@@ -238,6 +341,23 @@ int32_t eshkol_kb_save_json(const char* path) {
  * produced by eshkol_kb_save_json.
  *
  * Returns: number of facts loaded, -1 error
+ */
+/**
+ * @brief Loads facts from a JSON file produced by eshkol_kb_save_json(), appending them to the in-memory store.
+ *
+ * Reads the whole file into memory (rejecting files that are empty,
+ * unreadable, or larger than 10 MiB), then runs a minimal hand-written
+ * parser that only understands the specific
+ * `[ {"subject":..,"predicate":..,"object":..,"value":..}, ... ]` shape
+ * this module itself writes — it is not a general JSON parser.
+ * Recognized string fields are unescaped for `\"`, `\\`, `\n`, `\r`,
+ * `\t`; unrecognized keys/value types are skipped. Objects whose
+ * subject/predicate/object all come out empty are not added.
+ *
+ * @param path Filesystem path to read; NULL is rejected.
+ * @return Number of facts successfully appended, or -1 if @p path is
+ *   NULL, the file cannot be opened, or the file size is invalid
+ *   (empty or over 10 MiB).
  */
 int32_t eshkol_kb_load_json(const char* path) {
     if (!path) return -1;

--- a/lib/agent/c/agent_platform.c
+++ b/lib/agent/c/agent_platform.c
@@ -43,6 +43,12 @@
  * D.1 / B.7: OS Information (compile-time constants)
  ******************************************************************************/
 
+/**
+ * @brief Returns a short lowercase identifier for the host operating system.
+ *
+ * @return A static string literal: "darwin", "linux", "windows", or
+ *         "unknown", selected at compile time from platform macros.
+ */
 const char* eshkol_os_type(void) {
 #ifdef __APPLE__
     return "darwin";
@@ -55,6 +61,12 @@ const char* eshkol_os_type(void) {
 #endif
 }
 
+/**
+ * @brief Returns a short lowercase identifier for the host CPU architecture.
+ *
+ * @return A static string literal: "aarch64", "x86_64", "x86", "arm", or
+ *         "unknown", selected at compile time from platform macros.
+ */
 const char* eshkol_os_arch(void) {
 #if defined(__aarch64__) || defined(_M_ARM64)
     return "aarch64";
@@ -73,6 +85,17 @@ const char* eshkol_os_arch(void) {
  * B.7: Home Directory
  ******************************************************************************/
 
+/**
+ * @brief Writes the current user's home directory path into @p buf.
+ *
+ * Looks up the home directory via getpwuid() first, falling back to the
+ * $HOME environment variable if the passwd entry is unavailable or empty.
+ *
+ * @param buf Destination buffer for the null-terminated path.
+ * @param buf_size Capacity of @p buf.
+ * @return Length of the path written (excluding the null terminator), or -1
+ *         if no home directory could be determined or @p buf is too small.
+ */
 int32_t eshkol_home_directory(char* buf, int32_t buf_size) {
     /* Try getpwuid first (most reliable) */
     struct passwd* pw = getpwuid(getuid());
@@ -97,12 +120,28 @@ int32_t eshkol_home_directory(char* buf, int32_t buf_size) {
  * B.7: Hostname, Username
  ******************************************************************************/
 
+/**
+ * @brief Writes the local machine's hostname into @p buf.
+ *
+ * @param buf Destination buffer; if the result would not fit, the last byte
+ *        of @p buf is forced to '\0' to guarantee termination.
+ * @param buf_size Capacity of @p buf.
+ * @return Length of the hostname string, or -1 if gethostname() fails.
+ */
 int32_t eshkol_hostname(char* buf, int32_t buf_size) {
     if (gethostname(buf, (size_t)buf_size) != 0) return -1;
     buf[buf_size - 1] = '\0';
     return (int32_t)strlen(buf);
 }
 
+/**
+ * @brief Writes the current user's login name into @p buf.
+ *
+ * @param buf Destination buffer for the null-terminated username.
+ * @param buf_size Capacity of @p buf.
+ * @return Length of the username, or -1 if the passwd entry is unavailable
+ *         or @p buf is too small.
+ */
 int32_t eshkol_username(char* buf, int32_t buf_size) {
     struct passwd* pw = getpwuid(getuid());
     if (!pw || !pw->pw_name) return -1;
@@ -116,6 +155,15 @@ int32_t eshkol_username(char* buf, int32_t buf_size) {
  * B.7: Executable Search (PATH lookup)
  ******************************************************************************/
 
+/**
+ * @brief Checks whether an executable named @p name can be found and run.
+ *
+ * If @p name is an absolute path, checks it directly with access(X_OK).
+ * Otherwise searches each colon-separated directory in the $PATH
+ * environment variable for an executable file with that name.
+ *
+ * @return 1 if a matching executable is found, 0 otherwise.
+ */
 int32_t eshkol_executable_exists(const char* name) {
     if (!name || name[0] == '\0') return 0;
     /* If absolute path, check directly */
@@ -141,6 +189,18 @@ int32_t eshkol_executable_exists(const char* name) {
     return 0;
 }
 
+/**
+ * @brief Resolves @p name to a full executable path, searching $PATH if needed.
+ *
+ * If @p name is an absolute path, verifies it is executable and copies it
+ * to @p buf as-is. Otherwise searches each colon-separated directory in
+ * $PATH for an executable file named @p name.
+ *
+ * @param buf Destination buffer for the resolved path.
+ * @param buf_size Capacity of @p buf.
+ * @return Length of the resolved path written to @p buf, or -1 if no
+ *         matching executable is found or @p buf is too small.
+ */
 int32_t eshkol_executable_path(const char* name, char* buf, int32_t buf_size) {
     if (!name || !buf || buf_size < 2) return -1;
     if (name[0] == '/') {
@@ -181,18 +241,32 @@ int32_t eshkol_executable_path(const char* name, char* buf, int32_t buf_size) {
  * B.7: Time (millisecond precision)
  ******************************************************************************/
 
+/**
+ * @brief Returns the current wall-clock time as milliseconds since the Unix epoch.
+ */
 int64_t eshkol_current_time_ms(void) {
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);
     return (int64_t)ts.tv_sec * 1000 + (int64_t)ts.tv_nsec / 1000000;
 }
 
+/**
+ * @brief Returns a monotonic clock reading in milliseconds, suitable for measuring elapsed time.
+ *
+ * Unlike eshkol_current_time_ms(), this is unaffected by system clock
+ * adjustments and has no defined relation to wall-clock time.
+ */
 int64_t eshkol_monotonic_time_ms(void) {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return (int64_t)ts.tv_sec * 1000 + (int64_t)ts.tv_nsec / 1000000;
 }
 
+/**
+ * @brief Returns the directory to use for temporary files.
+ *
+ * @return The value of $TMPDIR if set and non-empty, otherwise "/tmp".
+ */
 const char* eshkol_temp_directory(void) {
     const char* tmp = getenv("TMPDIR");
     if (tmp && tmp[0] != '\0') return tmp;
@@ -203,6 +277,9 @@ const char* eshkol_temp_directory(void) {
  * E.6: getpid
  ******************************************************************************/
 
+/**
+ * @brief Returns the current process ID.
+ */
 int64_t eshkol_getpid_val(void) {
     return (int64_t)getpid();
 }
@@ -211,6 +288,11 @@ int64_t eshkol_getpid_val(void) {
  * E.5: stderr output
  ******************************************************************************/
 
+/**
+ * @brief Writes @p str to stderr and flushes immediately.
+ *
+ * No-op if @p str is NULL.
+ */
 void eshkol_eprint(const char* str) {
     if (str) {
         fputs(str, stderr);
@@ -222,6 +304,12 @@ void eshkol_eprint(const char* str) {
  * E.7: Precise millisecond sleep
  ******************************************************************************/
 
+/**
+ * @brief Sleeps the calling thread for approximately @p ms milliseconds.
+ *
+ * Uses nanosleep() internally; values of @p ms <= 0 return immediately
+ * without sleeping.
+ */
 void eshkol_sleep_ms(int64_t ms) {
     if (ms <= 0) return;
     struct timespec ts;
@@ -234,6 +322,19 @@ void eshkol_sleep_ms(int64_t ms) {
  * B.22: Shell Quoting (POSIX single-quote escaping)
  ******************************************************************************/
 
+/**
+ * @brief Quotes @p str for safe inclusion as a single argument in a POSIX shell command line.
+ *
+ * If none of the shell-special characters (whitespace, quotes, `$`, `` ` ``,
+ * globbing/redirection characters, etc.) are present, @p str is copied to
+ * @p buf unchanged. Otherwise the result is wrapped in single quotes, with
+ * any embedded single quote escaped as `'\''`.
+ *
+ * @param buf Destination buffer for the quoted string.
+ * @param buf_size Capacity of @p buf; must be at least 3.
+ * @return Length of the quoted string written to @p buf, or -1 if
+ *         arguments are invalid or @p buf is too small.
+ */
 int32_t eshkol_shell_quote(const char* str, char* buf, int32_t buf_size) {
     if (!str || !buf || buf_size < 3) return -1;
 
@@ -283,6 +384,23 @@ int32_t eshkol_shell_quote(const char* str, char* buf, int32_t buf_size) {
  * E.8: Temp File/Dir Creation (race-free)
  ******************************************************************************/
 
+/**
+ * @brief Creates a uniquely-named temporary file (race-free) and returns its path.
+ *
+ * Builds a template "<dir-or-tmpdir>/<prefix>XXXXXX", creates it via
+ * mkstemp(), closes the resulting file descriptor, and — if @p suffix is
+ * non-empty — renames the file to append @p suffix.
+ *
+ * @param prefix Filename prefix; must be non-NULL.
+ * @param suffix Optional suffix appended after the random characters (may
+ *        be NULL/empty for none).
+ * @param dir Optional directory to create the file in; falls back to
+ *        eshkol_temp_directory() if NULL/empty.
+ * @param path_buf Destination buffer for the created file's path.
+ * @param buf_size Capacity of @p path_buf; must be at least 32.
+ * @return Length of the path written to @p path_buf, or -1 on failure (the
+ *         partially-created file is unlinked before returning).
+ */
 int32_t eshkol_mkstemp_path(const char* prefix, const char* suffix,
                              const char* dir, char* path_buf, int32_t buf_size) {
     if (!prefix || !path_buf || buf_size < 32) return -1;
@@ -312,6 +430,19 @@ int32_t eshkol_mkstemp_path(const char* prefix, const char* suffix,
     return len;
 }
 
+/**
+ * @brief Creates a uniquely-named temporary directory (race-free) and returns its path.
+ *
+ * Builds a template "<dir-or-tmpdir>/<prefix>XXXXXX" and creates it via
+ * mkdtemp().
+ *
+ * @param prefix Directory name prefix; must be non-NULL.
+ * @param dir Optional parent directory; falls back to
+ *        eshkol_temp_directory() if NULL/empty.
+ * @param path_buf Destination buffer for the created directory's path.
+ * @param buf_size Capacity of @p path_buf; must be at least 32.
+ * @return Length of the path written to @p path_buf, or -1 on failure.
+ */
 int32_t eshkol_mkdtemp_path(const char* prefix, const char* dir,
                               char* path_buf, int32_t buf_size) {
     if (!prefix || !path_buf || buf_size < 32) return -1;
@@ -332,6 +463,16 @@ int32_t eshkol_mkdtemp_path(const char* prefix, const char* dir,
  * B.1: Recursive mkdir (create all parents)
  ******************************************************************************/
 
+/**
+ * @brief Creates @p path and all missing parent directories, like `mkdir -p`.
+ *
+ * Walks each '/'-separated path component, creating it with mode @p mode if
+ * it does not already exist. Pre-existing components (EEXIST) are not
+ * treated as errors.
+ *
+ * @return 0 on success, -1 if @p path is invalid, too long, or a component
+ *         could not be created.
+ */
 int32_t eshkol_mkdir_recursive(const char* path, int32_t mode) {
     if (!path || path[0] == '\0') return -1;
     char tmp[PATH_MAX];
@@ -361,6 +502,15 @@ static const char* g_dangerous_paths[] = {
     NULL
 };
 
+/**
+ * @brief nftw() visitor callback that deletes each visited file or directory.
+ *
+ * Used by eshkol_rmdir_recursive() with FTW_DEPTH so directories are
+ * removed only after their contents; directories (FTW_D/FTW_DP) are
+ * rmdir()'d, everything else is unlink()'d.
+ *
+ * @return The result of the underlying rmdir()/unlink() call.
+ */
 static int rmdir_recursive_cb(const char* fpath, const struct stat* sb,
                                int typeflag, struct FTW* ftwbuf) {
     (void)sb; (void)ftwbuf;
@@ -370,6 +520,18 @@ static int rmdir_recursive_cb(const char* fpath, const struct stat* sb,
     return unlink(fpath);
 }
 
+/**
+ * @brief Recursively deletes the directory tree at @p path.
+ *
+ * Resolves @p path with realpath() and refuses to proceed if it matches one
+ * of a hardcoded list of dangerous system directories (@ref
+ * g_dangerous_paths), such as "/", "/usr", or "/Users". Deletion itself is
+ * performed via nftw() with rmdir_recursive_cb().
+ *
+ * @return 0 on success or if @p path does not exist; -1 if @p path is
+ *         invalid, resolves to a protected directory (errno set to EPERM),
+ *         or deletion fails.
+ */
 int32_t eshkol_rmdir_recursive(const char* path) {
     if (!path || path[0] == '\0') return -1;
 
@@ -393,6 +555,20 @@ int32_t eshkol_rmdir_recursive(const char* path) {
  * B.1: File Stat (structured)
  ******************************************************************************/
 
+/**
+ * @brief Retrieves lstat() metadata for @p path into individually-typed output parameters.
+ *
+ * Uses lstat() (not stat()), so symlinks are reported as themselves rather
+ * than being followed.
+ *
+ * @param out_size Set to the file size in bytes, if non-NULL.
+ * @param out_mtime Set to the modification time (epoch seconds), if non-NULL.
+ * @param out_ctime Set to the status-change time (epoch seconds), if non-NULL.
+ * @param out_mode Set to the raw st_mode bits, if non-NULL.
+ * @param out_type Set to a simplified file-type code, if non-NULL:
+ *        0 = regular file, 1 = directory, 2 = symlink, 3 = other.
+ * @return 0 on success, -1 if @p path is NULL or lstat() fails.
+ */
 int32_t eshkol_file_stat_fields(const char* path,
                                   int64_t* out_size, int64_t* out_mtime,
                                   int64_t* out_ctime, int32_t* out_mode,
@@ -419,6 +595,16 @@ int32_t eshkol_file_stat_fields(const char* path,
  * B.1: File Copy
  ******************************************************************************/
 
+/**
+ * @brief Copies the file at @p src to @p dst.
+ *
+ * On macOS, first attempts a copy-on-write clone via copyfile()
+ * (COPYFILE_ALL | COPYFILE_CLONE) for an instant, no-I/O copy. If that is
+ * unavailable or fails (or on non-Apple platforms), falls back to a
+ * chunked read/write loop, creating/truncating @p dst with mode 0644.
+ *
+ * @return 0 on success, -1 if either file cannot be opened or an I/O error occurs.
+ */
 int32_t eshkol_file_copy(const char* src, const char* dst) {
     if (!src || !dst) return -1;
 
@@ -457,14 +643,32 @@ done:
  * B.1: File chmod, symlink, realpath, glob-match, file-lock
  ******************************************************************************/
 
+/**
+ * @brief Changes the permission bits of @p path to @p mode.
+ *
+ * @return 0 on success, -1 on failure.
+ */
 int32_t eshkol_file_chmod(const char* path, int32_t mode) {
     return chmod(path, (mode_t)mode) == 0 ? 0 : -1;
 }
 
+/**
+ * @brief Creates a symbolic link at @p link_path pointing to @p target.
+ *
+ * @return 0 on success, -1 on failure.
+ */
 int32_t eshkol_symlink_create(const char* target, const char* link_path) {
     return symlink(target, link_path) == 0 ? 0 : -1;
 }
 
+/**
+ * @brief Reads the target of the symbolic link at @p path into @p buf.
+ *
+ * @param buf Destination buffer for the target path; this function
+ *        null-terminates it (readlink() itself does not).
+ * @param buf_size Capacity of @p buf.
+ * @return Length of the link target written to @p buf, or -1 on failure.
+ */
 int32_t eshkol_symlink_read(const char* path, char* buf, int32_t buf_size) {
     ssize_t n = readlink(path, buf, (size_t)(buf_size - 1));
     if (n < 0) return -1;
@@ -472,6 +676,14 @@ int32_t eshkol_symlink_read(const char* path, char* buf, int32_t buf_size) {
     return (int32_t)n;
 }
 
+/**
+ * @brief Resolves @p path to an absolute, symlink-free canonical path via realpath().
+ *
+ * @param buf Destination buffer for the resolved path.
+ * @param buf_size Capacity of @p buf.
+ * @return Length of the resolved path, or -1 if realpath() fails or @p buf
+ *         is too small.
+ */
 int32_t eshkol_realpath_resolve(const char* path, char* buf, int32_t buf_size) {
     char resolved[PATH_MAX];
     if (!realpath(path, resolved)) return -1;
@@ -481,10 +693,24 @@ int32_t eshkol_realpath_resolve(const char* path, char* buf, int32_t buf_size) {
     return len;
 }
 
+/**
+ * @brief Tests whether @p path matches the shell glob @p pattern.
+ *
+ * Wraps fnmatch() with FNM_PATHNAME, so wildcards do not match '/'.
+ *
+ * @return 1 if @p path matches, 0 otherwise.
+ */
 int32_t eshkol_glob_match(const char* pattern, const char* path) {
     return fnmatch(pattern, path, FNM_PATHNAME) == 0 ? 1 : 0;
 }
 
+/**
+ * @brief Opens (creating if needed) and acquires an exclusive, non-blocking advisory lock on @p path.
+ *
+ * @return A file descriptor handle to be passed to eshkol_file_unlock(), or
+ *         -1 if the file could not be opened or is already locked by
+ *         another holder.
+ */
 int64_t eshkol_file_lock(const char* path) {
     int fd = open(path, O_RDWR | O_CREAT, 0644);
     if (fd < 0) return -1;
@@ -495,6 +721,12 @@ int64_t eshkol_file_lock(const char* path) {
     return (int64_t)fd;
 }
 
+/**
+ * @brief Releases a lock previously acquired by eshkol_file_lock() and closes its file descriptor.
+ *
+ * @param fd The handle returned by eshkol_file_lock().
+ * @return 0 on success, -1 if @p fd is negative.
+ */
 int32_t eshkol_file_unlock(int64_t fd) {
     if (fd < 0) return -1;
     flock((int)fd, LOCK_UN);
@@ -506,6 +738,17 @@ int32_t eshkol_file_unlock(int64_t fd) {
  * B.6: UUID v4
  ******************************************************************************/
 
+/**
+ * @brief Generates a random RFC 4122 version-4 UUID and writes its canonical string form to @p buf.
+ *
+ * Sources 16 random bytes from /dev/urandom, falling back to a
+ * time/pid-seeded rand() if /dev/urandom cannot be opened (not
+ * cryptographically secure in that case). Sets the version and variant
+ * bits per RFC 4122 before formatting.
+ *
+ * @param buf Destination buffer; must be at least 37 bytes
+ *        ("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" plus null terminator).
+ */
 void eshkol_uuid_v4(char* buf) {
     unsigned char bytes[16];
     /* Read from /dev/urandom */
@@ -533,6 +776,14 @@ void eshkol_uuid_v4(char* buf) {
  * B.11: Date/Time Formatting
  ******************************************************************************/
 
+/**
+ * @brief Formats @p epoch (Unix seconds, UTC) as an ISO 8601 string ("YYYY-MM-DDTHH:MM:SSZ").
+ *
+ * @param buf Destination buffer.
+ * @param buf_size Capacity of @p buf; must be at least 21.
+ * @return Number of characters written (excluding null terminator), or -1
+ *         on failure.
+ */
 int32_t eshkol_format_iso8601(int64_t epoch, char* buf, int32_t buf_size) {
     if (!buf || buf_size < 21) return -1;
     time_t t = (time_t)epoch;
@@ -542,6 +793,12 @@ int32_t eshkol_format_iso8601(int64_t epoch, char* buf, int32_t buf_size) {
     return n > 0 ? n : -1;
 }
 
+/**
+ * @brief Parses an ISO 8601 timestamp ("YYYY-MM-DDTHH:MM:SS") into Unix epoch seconds (UTC).
+ *
+ * @return Epoch seconds, or -1 if @p str is NULL or does not match the
+ *         expected format.
+ */
 int64_t eshkol_parse_iso8601(const char* str) {
     if (!str) return -1;
     struct tm tm;
@@ -550,6 +807,17 @@ int64_t eshkol_parse_iso8601(const char* str) {
     return (int64_t)timegm(&tm);
 }
 
+/**
+ * @brief Formats @p seconds_ago as a short human-readable relative-time string.
+ *
+ * Chooses the coarsest unit that keeps the value under 3 digits: seconds
+ * ("Ns ago") below 60s, minutes ("Nm ago") below an hour, hours ("Nh ago")
+ * below a day, and days ("Nd ago") otherwise.
+ *
+ * @param buf Destination buffer.
+ * @param buf_size Capacity of @p buf; must be at least 16.
+ * @return Number of characters written, or -1 on failure.
+ */
 int32_t eshkol_format_relative(int64_t seconds_ago, char* buf, int32_t buf_size) {
     if (!buf || buf_size < 16) return -1;
     int n;
@@ -564,6 +832,13 @@ int32_t eshkol_format_relative(int64_t seconds_ago, char* buf, int32_t buf_size)
     return n > 0 ? n : -1;
 }
 
+/**
+ * @brief Returns the local timezone's current UTC offset, in seconds.
+ *
+ * Computed as the difference between the local and UTC broken-down
+ * representations of the current time, so it reflects DST if currently
+ * in effect.
+ */
 int64_t eshkol_local_timezone_offset(void) {
     time_t t = time(NULL);
     struct tm local, utc;
@@ -582,6 +857,19 @@ int64_t eshkol_local_timezone_offset(void) {
 #define MAX_MMAPS 16
 static struct { void* ptr; size_t len; } g_mmaps[MAX_MMAPS] = {{0}};
 
+/**
+ * @brief Memory-maps a read-only region of the file at @p path and registers it in the internal mmap table.
+ *
+ * If @p length <= 0, maps from @p offset to the end of the file. The
+ * mapping is tracked in a small fixed-size table (@ref g_mmaps) so it can
+ * be read via eshkol_mmap_read() and released via eshkol_file_munmap()
+ * using an integer handle instead of a raw pointer.
+ *
+ * @return A handle (index into @ref g_mmaps) for use with
+ *         eshkol_mmap_read()/eshkol_mmap_length()/eshkol_file_munmap(), or
+ *         -1 on failure (including if the mmap table is full, in which case
+ *         the mapping is unmapped before returning).
+ */
 int64_t eshkol_file_mmap(const char* path, int64_t offset, int64_t length) {
     if (!path) return -1;
     int fd = open(path, O_RDONLY);
@@ -610,6 +898,11 @@ int64_t eshkol_file_mmap(const char* path, int64_t offset, int64_t length) {
     return -1;
 }
 
+/**
+ * @brief Unmaps and releases the mmap handle previously returned by eshkol_file_mmap().
+ *
+ * @return 0 on success, -1 if @p handle is out of range or not currently mapped.
+ */
 int32_t eshkol_file_munmap(int64_t handle) {
     if (handle < 0 || handle >= MAX_MMAPS || !g_mmaps[handle].ptr) return -1;
     munmap(g_mmaps[handle].ptr, g_mmaps[handle].len);
@@ -618,6 +911,17 @@ int32_t eshkol_file_munmap(int64_t handle) {
     return 0;
 }
 
+/**
+ * @brief Copies up to @p buf_size bytes starting at @p offset from a memory-mapped region into @p buf.
+ *
+ * @param handle A handle returned by eshkol_file_mmap().
+ * @param offset Byte offset into the mapped region to start reading from.
+ * @param buf Destination buffer (not null-terminated).
+ * @param buf_size Capacity of @p buf.
+ * @return Number of bytes copied (may be less than @p buf_size if fewer
+ *         bytes remain in the mapping), or -1 if @p handle is invalid or
+ *         @p offset is out of range.
+ */
 /* Read bytes from mmap'd region */
 int32_t eshkol_mmap_read(int64_t handle, int64_t offset, char* buf, int32_t buf_size) {
     if (handle < 0 || handle >= MAX_MMAPS || !g_mmaps[handle].ptr) return -1;
@@ -629,6 +933,11 @@ int32_t eshkol_mmap_read(int64_t handle, int64_t offset, char* buf, int32_t buf_
     return to_read;
 }
 
+/**
+ * @brief Returns the length in bytes of the memory-mapped region for @p handle.
+ *
+ * @return The mapping length, or -1 if @p handle is invalid or not currently mapped.
+ */
 int64_t eshkol_mmap_length(int64_t handle) {
     if (handle < 0 || handle >= MAX_MMAPS || !g_mmaps[handle].ptr) return -1;
     return (int64_t)g_mmaps[handle].len;
@@ -638,6 +947,19 @@ int64_t eshkol_mmap_length(int64_t handle) {
  * B.1: directory-walk — recursive directory traversal
  ******************************************************************************/
 
+/**
+ * @brief Recursive worker for eshkol_directory_walk() that lists @p base and its subdirectories.
+ *
+ * Emits one "type:path" NUL-terminated entry per directory item into @p buf
+ * (type is 'f' file / 'd' directory / 'l' symlink), incrementing *@p count
+ * for each, and recurses into subdirectories while @p depth stays within
+ * @p max_depth (unlimited if @p max_depth < 0).
+ *
+ * @param written In/out cursor tracking bytes written so far into @p buf.
+ * @param count In/out running count of entries written.
+ * @return 0 on success (including when @p base cannot be opened, which is
+ *         silently skipped), or -1 if @p buf runs out of space.
+ */
 static int32_t directory_walk_impl(const char* base, int depth, int max_depth,
                                      char* buf, int32_t buf_size,
                                      int32_t* written, int32_t* count) {
@@ -682,6 +1004,19 @@ static int32_t directory_walk_impl(const char* base, int depth, int max_depth,
     return 0;
 }
 
+/**
+ * @brief Recursively lists the contents of @p path up to @p max_depth levels deep.
+ *
+ * Writes NUL-separated "type:path" entries (see directory_walk_impl()) into
+ * @p buf and reports the number of entries in @p count.
+ *
+ * @param max_depth Maximum recursion depth, or a negative value for
+ *        unlimited depth.
+ * @param buf Destination buffer for the NUL-separated entry list.
+ * @param buf_size Capacity of @p buf.
+ * @param count Set to the number of entries written.
+ * @return Number of bytes written to @p buf, or -1 on invalid arguments.
+ */
 int32_t eshkol_directory_walk(const char* path, int32_t max_depth,
                                 char* buf, int32_t buf_size, int32_t* count) {
     if (!path || !buf || buf_size <= 0 || !count) return -1;
@@ -696,6 +1031,17 @@ int32_t eshkol_directory_walk(const char* path, int32_t max_depth,
  * B.1: glob-expand — walk + fnmatch
  ******************************************************************************/
 
+/**
+ * @brief Recursive worker for eshkol_glob_expand() that matches @p pattern against entries under @p dir_path.
+ *
+ * Compares each directory entry's name (not full path) against @p pattern
+ * with fnmatch(), appending full matching paths as NUL-separated entries
+ * into @p buf, and recurses into every subdirectory regardless of whether
+ * it matched.
+ *
+ * @param written In/out cursor tracking bytes written so far into @p buf.
+ * @param count In/out running count of matches written.
+ */
 static void glob_expand_impl(const char* dir_path, const char* pattern,
                                char* buf, int32_t buf_size,
                                int32_t* written, int32_t* count) {
@@ -733,6 +1079,17 @@ static void glob_expand_impl(const char* dir_path, const char* pattern,
     closedir(dir);
 }
 
+/**
+ * @brief Recursively searches under @p root for entries whose name matches @p pattern.
+ *
+ * Writes NUL-separated matching full paths (see glob_expand_impl()) into
+ * @p buf and reports the number of matches in @p count.
+ *
+ * @param buf Destination buffer for the NUL-separated match list.
+ * @param buf_size Capacity of @p buf.
+ * @param count Set to the number of matches written.
+ * @return Number of bytes written to @p buf, or -1 on invalid arguments.
+ */
 int32_t eshkol_glob_expand(const char* pattern, const char* root,
                              char* buf, int32_t buf_size, int32_t* count) {
     if (!pattern || !root || !buf || buf_size <= 0 || !count) return -1;
@@ -747,6 +1104,20 @@ int32_t eshkol_glob_expand(const char* pattern, const char* root,
  * B.22: shell-split — parse shell command into argv
  ******************************************************************************/
 
+/**
+ * @brief Splits @p cmd into shell-style arguments, honoring single/double quoting and backslash escapes.
+ *
+ * Writes each argument as a NUL-terminated string, one after another, into
+ * @p buf, and reports the number of arguments in @p argc. Within double
+ * quotes, backslash escapes the next character; outside quotes, backslash
+ * escapes the next character and single/double quote characters start a
+ * quoted region. Unquoted whitespace (space/tab) separates arguments.
+ *
+ * @param buf Destination buffer for the concatenated NUL-separated arguments.
+ * @param buf_size Capacity of @p buf.
+ * @param argc Set to the number of arguments parsed.
+ * @return Number of bytes written to @p buf, or -1 on invalid arguments.
+ */
 int32_t eshkol_shell_split(const char* cmd, char* buf, int32_t buf_size, int32_t* argc) {
     if (!cmd || !buf || buf_size <= 0 || !argc) return -1;
     *argc = 0;
@@ -808,6 +1179,15 @@ int32_t eshkol_shell_split(const char* cmd, char* buf, int32_t buf_size, int32_t
  * - Everything else: 1 column
  ******************************************************************************/
 
+/**
+ * @brief Determines whether Unicode codepoint @p cp occupies two terminal columns.
+ *
+ * Classifies @p cp as double-width per East Asian Width conventions: CJK
+ * ideographs, Hangul syllables, fullwidth forms, Hiragana/Katakana, and
+ * emoji ranges.
+ *
+ * @return 1 if @p cp is double-width, 0 otherwise.
+ */
 static int is_wide_char(uint32_t cp) {
     /* CJK Unified Ideographs */
     if (cp >= 0x4E00 && cp <= 0x9FFF) return 1;
@@ -833,6 +1213,14 @@ static int is_wide_char(uint32_t cp) {
     return 0;
 }
 
+/**
+ * @brief Determines whether Unicode codepoint @p cp occupies zero terminal columns.
+ *
+ * Classifies @p cp as zero-width if it is a combining mark, zero-width
+ * space/joiner/non-joiner, BOM, or variation selector.
+ *
+ * @return 1 if @p cp is zero-width, 0 otherwise.
+ */
 static int is_zero_width(uint32_t cp) {
     /* Combining marks */
     if (cp >= 0x0300 && cp <= 0x036F) return 1;
@@ -849,6 +1237,18 @@ static int is_zero_width(uint32_t cp) {
     return 0;
 }
 
+/**
+ * @brief Decodes one UTF-8 codepoint from @p str starting at *@p pos, advancing *@p pos past it.
+ *
+ * Determines the sequence length from the leading byte and folds in
+ * continuation bytes; invalid leading bytes (0x80-0xBF) decode to the
+ * replacement character U+FFFD as a single byte.
+ *
+ * @param len Total length of @p str, used to avoid reading continuation
+ *        bytes past the end of the string.
+ * @param pos In/out byte offset; advanced by the number of bytes consumed.
+ * @return The decoded codepoint.
+ */
 /* Decode one UTF-8 codepoint, advance *pos */
 static uint32_t decode_utf8(const char* str, int len, int* pos) {
     unsigned char c = (unsigned char)str[*pos];
@@ -866,6 +1266,16 @@ static uint32_t decode_utf8(const char* str, int len, int* pos) {
     return cp;
 }
 
+/**
+ * @brief Computes the terminal column width of @p str, accounting for wide/zero-width Unicode and ANSI escapes.
+ *
+ * Skips over ANSI CSI ("ESC[...") and OSC ("ESC]...BEL"/"ESC]...ST")
+ * escape sequences (contributing 0 columns), decodes the remaining text as
+ * UTF-8, and sums 0/1/2 columns per codepoint via is_zero_width() /
+ * is_wide_char().
+ *
+ * @return The total display width in columns, or 0 if @p str is NULL.
+ */
 int32_t eshkol_string_display_width(const char* str) {
     if (!str) return 0;
     int len = (int)strlen(str);
@@ -911,6 +1321,22 @@ int32_t eshkol_string_display_width(const char* str) {
     return width;
 }
 
+/**
+ * @brief Truncates @p str to at most @p max_width display columns, appending @p suffix if truncation occurs.
+ *
+ * Walks @p str codepoint-by-codepoint (skipping ANSI escapes, as in
+ * eshkol_string_display_width()) accumulating display width until adding
+ * the next codepoint would exceed the truncation target (@p max_width minus
+ * the display width of @p suffix). If the full string already fits within
+ * @p max_width, it is copied unchanged; otherwise the safely-truncated
+ * prefix is copied followed by @p suffix.
+ *
+ * @param suffix Optional string appended when truncation occurs (may be
+ *        NULL for none).
+ * @param buf Destination buffer.
+ * @param buf_size Capacity of @p buf.
+ * @return Number of bytes written to @p buf, or -1 on invalid arguments.
+ */
 int32_t eshkol_string_truncate_display(const char* str, int32_t max_width,
                                          const char* suffix,
                                          char* buf, int32_t buf_size) {
@@ -983,6 +1409,18 @@ int32_t eshkol_string_truncate_display(const char* str, int32_t max_width,
 
 static const char b64url_table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
+/**
+ * @brief Encodes @p data as URL-safe base64 (RFC 4648 §5), with no padding.
+ *
+ * @param data Input bytes (need not be null-terminated).
+ * @param data_len Number of input bytes.
+ * @param buf Destination buffer for the encoded, null-terminated string.
+ * @param buf_size Capacity of @p buf.
+ * @return Number of characters written to @p buf (excluding null
+ *         terminator), or -1 on invalid arguments. Encoding stops early
+ *         (producing a truncated result) if @p buf_size is insufficient
+ *         for the full output.
+ */
 int32_t eshkol_base64url_encode(const char* data, int32_t data_len,
                                   char* buf, int32_t buf_size) {
     if (!data || !buf || data_len < 0 || buf_size <= 0) return -1;
@@ -1009,6 +1447,12 @@ int32_t eshkol_base64url_encode(const char* data, int32_t data_len,
     return j;
 }
 
+/**
+ * @brief Maps a single URL-safe base64 character to its 6-bit value.
+ *
+ * @return The 6-bit value (0-63) for a valid base64url character, or -1 if
+ *         @p c is not part of the alphabet.
+ */
 static int b64url_val(char c) {
     if (c >= 'A' && c <= 'Z') return c - 'A';
     if (c >= 'a' && c <= 'z') return c - 'a' + 26;
@@ -1018,6 +1462,19 @@ static int b64url_val(char c) {
     return -1;
 }
 
+/**
+ * @brief Decodes a URL-safe base64 (RFC 4648 §5) string back into raw bytes.
+ *
+ * Characters outside the base64url alphabet (as determined by
+ * b64url_val()) are silently skipped rather than treated as errors.
+ *
+ * @param data Input base64url characters (need not be null-terminated).
+ * @param data_len Number of input characters to consider.
+ * @param buf Destination buffer for the decoded bytes (null-terminated for
+ *        convenience, though the data may contain embedded NULs).
+ * @param buf_size Capacity of @p buf.
+ * @return Number of bytes written to @p buf, or -1 on invalid arguments.
+ */
 int32_t eshkol_base64url_decode(const char* data, int32_t data_len,
                                   char* buf, int32_t buf_size) {
     if (!data || !buf || data_len < 0 || buf_size <= 0) return -1;
@@ -1040,6 +1497,16 @@ int32_t eshkol_base64url_decode(const char* data, int32_t data_len,
  * B.6: constant-time-equal
  ******************************************************************************/
 
+/**
+ * @brief Compares two byte buffers for equality in constant time, to avoid timing side-channels.
+ *
+ * Intended for comparing secrets (e.g. tokens, MACs) where early-exit
+ * comparison could leak information via timing. Always scans the full
+ * length when sizes match; a length mismatch is detected (and returns
+ * false) before any byte comparison.
+ *
+ * @return 1 if @p a and @p b are equal in length and content, 0 otherwise.
+ */
 int32_t eshkol_constant_time_equal(const char* a, int32_t a_len,
                                      const char* b, int32_t b_len) {
     if (a_len != b_len) return 0;
@@ -1058,6 +1525,18 @@ int32_t eshkol_constant_time_equal(const char* a, int32_t a_len,
 #ifdef __APPLE__
 #include <CommonCrypto/CommonDigest.h>
 
+/**
+ * @brief Computes the SHA-256 digest of the file at @p path, streaming its contents in chunks.
+ *
+ * Uses CommonCrypto (CC_SHA256_*) on Apple platforms. Reads the file in
+ * 64KB chunks rather than loading it fully into memory, then writes the
+ * digest as a 64-character lowercase hex string to @p hex_buf.
+ *
+ * @param hex_buf Destination buffer for the null-terminated hex digest.
+ * @param buf_size Capacity of @p hex_buf; must be at least 65.
+ * @return 0 on success, -1 if the file cannot be opened, cannot be fully
+ *         read, or @p buf_size is too small.
+ */
 int32_t eshkol_sha256_file(const char* path, char* hex_buf, int32_t buf_size) {
     if (!path || !hex_buf || buf_size < 65) return -1;
     int fd = open(path, O_RDONLY);
@@ -1088,6 +1567,18 @@ int32_t eshkol_sha256_file(const char* path, char* hex_buf, int32_t buf_size) {
 /* Linux: use OpenSSL */
 #include <openssl/sha.h>
 
+/**
+ * @brief Computes the SHA-256 digest of the file at @p path, streaming its contents in chunks.
+ *
+ * Uses OpenSSL (SHA256_*) on non-Apple platforms. Reads the file in 64KB
+ * chunks rather than loading it fully into memory, then writes the digest
+ * as a 64-character lowercase hex string to @p hex_buf.
+ *
+ * @param hex_buf Destination buffer for the null-terminated hex digest.
+ * @param buf_size Capacity of @p hex_buf; must be at least 65.
+ * @return 0 on success, -1 if the file cannot be opened, cannot be fully
+ *         read, or @p buf_size is too small.
+ */
 int32_t eshkol_sha256_file(const char* path, char* hex_buf, int32_t buf_size) {
     if (!path || !hex_buf || buf_size < 65) return -1;
     int fd = open(path, O_RDONLY);

--- a/lib/agent/c/agent_poll.c
+++ b/lib/agent/c/agent_poll.c
@@ -41,6 +41,16 @@
  * Returns: number of ready fds (0=timeout, -1=error)
  ******************************************************************************/
 
+/**
+ * @brief Waits for any of several file descriptors to become ready for I/O, batching a poll(2) call.
+ *
+ * @param fds Array of @p nfds file descriptors to watch.
+ * @param directions Array of @p nfds direction flags per fd: bit 0 (1) = watch for readable (POLLIN), bit 1 (2) = watch for writable (POLLOUT); either or both may be set.
+ * @param nfds Number of entries in @p fds / @p directions (must be in (0, 256]).
+ * @param timeout_ms Milliseconds to wait; -1 blocks indefinitely, 0 polls without blocking.
+ * @param ready_out Array of @p nfds ints filled with a status bitmask per fd: 1=readable, 2=writable, 4=error/hangup/invalid (bits may combine).
+ * @return Number of ready fds, 0 on timeout (including an interrupting signal), or -1 on invalid arguments or a poll() error.
+ */
 int32_t eshkol_poll(const int32_t* fds, const int32_t* directions,
                      int32_t nfds, int32_t timeout_ms, int32_t* ready_out) {
     if (!fds || !directions || !ready_out || nfds <= 0 || nfds > 256) return -1;
@@ -77,6 +87,15 @@ int32_t eshkol_poll(const int32_t* fds, const int32_t* directions,
  * Returns: 1=readable, 0=timeout, -1=error/hangup
  ******************************************************************************/
 
+/**
+ * @brief Checks whether a single file descriptor becomes readable within a timeout.
+ *
+ * Convenience wrapper around poll() for the common single-fd case.
+ *
+ * @param fd File descriptor to watch for POLLIN.
+ * @param timeout_ms Milliseconds to wait; -1 blocks indefinitely, 0 polls without blocking.
+ * @return 1 if readable, 0 on timeout (including an interrupting signal), -1 on error, hangup, or invalid fd.
+ */
 int32_t eshkol_poll_read(int32_t fd, int32_t timeout_ms) {
     struct pollfd pfd = { .fd = fd, .events = POLLIN, .revents = 0 };
     int ret = poll(&pfd, 1, timeout_ms);
@@ -90,12 +109,24 @@ int32_t eshkol_poll_read(int32_t fd, int32_t timeout_ms) {
  * Non-blocking fd operations
  ******************************************************************************/
 
+/**
+ * @brief Sets O_NONBLOCK on a file descriptor.
+ *
+ * @param fd File descriptor to modify.
+ * @return 0 on success, -1 if the current flags could not be read or fcntl(F_SETFL) failed.
+ */
 int32_t eshkol_fd_set_nonblocking(int32_t fd) {
     int flags = fcntl(fd, F_GETFL, 0);
     if (flags < 0) return -1;
     return fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0 ? 0 : -1;
 }
 
+/**
+ * @brief Clears O_NONBLOCK on a file descriptor, restoring blocking I/O.
+ *
+ * @param fd File descriptor to modify.
+ * @return 0 on success, -1 if the current flags could not be read or fcntl(F_SETFL) failed.
+ */
 int32_t eshkol_fd_set_blocking(int32_t fd) {
     int flags = fcntl(fd, F_GETFL, 0);
     if (flags < 0) return -1;
@@ -109,6 +140,14 @@ int32_t eshkol_fd_set_blocking(int32_t fd) {
  * Returns: bytes read (>0), 0=nothing available, -1=EOF/error
  ******************************************************************************/
 
+/**
+ * @brief Reads whatever data is immediately available from a (typically non-blocking) fd.
+ *
+ * @param fd File descriptor to read from.
+ * @param buf Destination buffer.
+ * @param buf_size Size of @p buf in bytes.
+ * @return Number of bytes read (> 0), 0 if no data is currently available (EAGAIN/EWOULDBLOCK), or -1 on EOF, error, or invalid arguments.
+ */
 int32_t eshkol_fd_read_available(int32_t fd, char* buf, int32_t buf_size) {
     if (!buf || buf_size <= 0) return -1;
     ssize_t n = read(fd, buf, (size_t)buf_size);
@@ -125,6 +164,14 @@ int32_t eshkol_fd_read_available(int32_t fd, char* buf, int32_t buf_size) {
  * Returns: bytes written (>0), 0=would block, -1=error
  ******************************************************************************/
 
+/**
+ * @brief Writes data to a (typically non-blocking) fd without blocking if the write would stall.
+ *
+ * @param fd File descriptor to write to.
+ * @param data Bytes to write.
+ * @param len Number of bytes in @p data.
+ * @return Number of bytes written (> 0, possibly less than @p len for a partial write), 0 if the write would block (EAGAIN/EWOULDBLOCK), or -1 on error or invalid arguments.
+ */
 int32_t eshkol_fd_write_available(int32_t fd, const char* data, int32_t len) {
     if (!data || len <= 0) return -1;
     ssize_t n = write(fd, data, (size_t)len);
@@ -140,6 +187,13 @@ int32_t eshkol_fd_write_available(int32_t fd, const char* data, int32_t len) {
  * Returns: 0 success (read_fd and write_fd filled), -1 error
  ******************************************************************************/
 
+/**
+ * @brief Creates a unidirectional OS pipe.
+ *
+ * @param read_fd Out-parameter set to the pipe's read-end fd.
+ * @param write_fd Out-parameter set to the pipe's write-end fd.
+ * @return 0 on success, -1 if either out-parameter is NULL or pipe() failed.
+ */
 int32_t eshkol_make_pipe(int32_t* read_fd, int32_t* write_fd) {
     if (!read_fd || !write_fd) return -1;
     int pipefd[2];
@@ -173,6 +227,15 @@ typedef struct {
 static LineReader* g_line_readers[MAX_LINE_READERS] = {0};
 static int g_next_reader = 1;
 
+/**
+ * @brief Finds a free slot in the global line-reader table.
+ *
+ * Scans forward from the last allocated index (wrapping around) so
+ * slot reuse spreads across the table rather than always restarting
+ * at index 1.
+ *
+ * @return A free slot index in [1, MAX_LINE_READERS), or -1 if the table is full.
+ */
 static int alloc_reader(void) {
     for (int i = g_next_reader; i < MAX_LINE_READERS; i++) {
         if (!g_line_readers[i]) { g_next_reader = i + 1; return i; }
@@ -183,6 +246,12 @@ static int alloc_reader(void) {
     return -1;
 }
 
+/**
+ * @brief Looks up a LineReader by its handle, validating the handle range.
+ *
+ * @param handle Handle previously returned by eshkol_line_reader_create().
+ * @return The LineReader, or NULL if @p handle is out of range or the slot is unallocated.
+ */
 static LineReader* get_reader(int64_t handle) {
     if (handle < 1 || handle >= MAX_LINE_READERS) return NULL;
     return g_line_readers[handle];
@@ -192,6 +261,15 @@ static LineReader* get_reader(int64_t handle) {
  * Create a line reader for the given file descriptor.
  * The fd should already be open and preferably non-blocking.
  * Returns: handle (>= 1), -1 on error
+ */
+/**
+ * @brief Allocates and registers a buffered line reader for a file descriptor.
+ *
+ * @p fd should already be open, and preferably set to non-blocking mode
+ * (see eshkol_fd_set_nonblocking()) so eshkol_line_reader_next() never stalls.
+ *
+ * @param fd File descriptor to read lines from; ownership stays with the caller (not closed by this module).
+ * @return A handle (>= 1) usable with the other eshkol_line_reader_* functions, or -1 if the reader table is full or allocation failed.
  */
 int64_t eshkol_line_reader_create(int32_t fd) {
     int slot = alloc_reader();
@@ -218,6 +296,23 @@ int64_t eshkol_line_reader_create(int32_t fd) {
  *   0:   no complete line available yet (not an error, call again later)
  *   -1:  EOF or error (no more lines will come)
  *   -2:  handle invalid
+ */
+/**
+ * @brief Reads the next complete, newline-terminated line from a line reader, without blocking.
+ *
+ * Reads whatever is currently available on the underlying fd into an
+ * internal 64KB buffer, then returns the first complete line found
+ * (the trailing '\n' is stripped and not included in the output). If
+ * EOF is reached with a trailing partial line (no '\n'), that
+ * remaining data is delivered as a final line.
+ *
+ * @param handle Handle from eshkol_line_reader_create().
+ * @param out_buf Destination buffer for the line text (NUL-terminated); truncated if longer than @p out_size - 1.
+ * @param out_size Size of @p out_buf in bytes.
+ * @return Line length in bytes if a complete line was delivered, 0 if
+ *   no complete line is available yet (not an error, call again
+ *   later), -1 on EOF/error with nothing left to deliver, or -2 if
+ *   @p handle or the buffer arguments are invalid.
  */
 int32_t eshkol_line_reader_next(int64_t handle, char* out_buf, int32_t out_size) {
     LineReader* lr = get_reader(handle);
@@ -275,6 +370,12 @@ int32_t eshkol_line_reader_next(int64_t handle, char* out_buf, int32_t out_size)
  * Check if the reader has reached EOF.
  * Returns: 1 if EOF reached, 0 if more data may come
  */
+/**
+ * @brief Reports whether a line reader has hit EOF with no buffered data left.
+ *
+ * @param handle Handle from eshkol_line_reader_create().
+ * @return 1 if the underlying fd reached EOF and all buffered bytes have been consumed (or @p handle is invalid), 0 if more data may still arrive.
+ */
 int32_t eshkol_line_reader_eof(int64_t handle) {
     LineReader* lr = get_reader(handle);
     if (!lr) return 1;
@@ -285,6 +386,12 @@ int32_t eshkol_line_reader_eof(int64_t handle) {
  * Peek at buffered data without consuming it.
  * Returns: number of bytes currently buffered
  */
+/**
+ * @brief Returns the number of bytes currently buffered but not yet delivered as a line.
+ *
+ * @param handle Handle from eshkol_line_reader_create().
+ * @return Buffered byte count, or 0 if @p handle is invalid.
+ */
 int32_t eshkol_line_reader_buffered(int64_t handle) {
     LineReader* lr = get_reader(handle);
     if (!lr) return 0;
@@ -293,6 +400,13 @@ int32_t eshkol_line_reader_buffered(int64_t handle) {
 
 /*
  * Close and free a line reader. Does NOT close the underlying fd.
+ */
+/**
+ * @brief Frees a line reader and removes it from the reader table.
+ *
+ * Does not close the underlying file descriptor; the caller retains ownership of it.
+ *
+ * @param handle Handle from eshkol_line_reader_create(); invalid handles are a no-op.
  */
 void eshkol_line_reader_close(int64_t handle) {
     LineReader* lr = get_reader(handle);
@@ -320,18 +434,46 @@ void eshkol_line_reader_close(int64_t handle) {
 /*   stdout_fd: offset 8 (4 bytes)                                        */
 /*   stderr_fd: offset 12 (4 bytes)                                       */
 
+/**
+ * @brief Extracts the stdout pipe fd from an opaque qllm_process_t handle.
+ *
+ * Reinterprets @p proc as a flat array of ints per the qllm_process_t
+ * layout `{ pid_t pid; int stdin_fd; int stdout_fd; int stderr_fd; ... }`
+ * (pid_t is 4 bytes on both macOS and Linux), so stdout_fd is the 3rd
+ * int field. This creates a coupling to that struct's layout: if it
+ * changes, this offset must be updated too.
+ *
+ * @param proc Pointer to a qllm_process_t; NULL is rejected.
+ * @return The stdout file descriptor, or -1 if @p proc is NULL.
+ */
 int32_t eshkol_process_stdout_fd(void* proc) {
     if (!proc) return -1;
     const int* fields = (const int*)proc;
     return fields[2];  /* stdout_fd is the 3rd int field */
 }
 
+/**
+ * @brief Extracts the stderr pipe fd from an opaque qllm_process_t handle.
+ *
+ * See eshkol_process_stdout_fd() for the assumed struct layout and its caveats.
+ *
+ * @param proc Pointer to a qllm_process_t; NULL is rejected.
+ * @return The stderr file descriptor, or -1 if @p proc is NULL.
+ */
 int32_t eshkol_process_stderr_fd(void* proc) {
     if (!proc) return -1;
     const int* fields = (const int*)proc;
     return fields[3];  /* stderr_fd is the 4th int field */
 }
 
+/**
+ * @brief Extracts the process ID from an opaque qllm_process_t handle.
+ *
+ * See eshkol_process_stdout_fd() for the assumed struct layout and its caveats.
+ *
+ * @param proc Pointer to a qllm_process_t; NULL is rejected.
+ * @return The process ID, or -1 if @p proc is NULL.
+ */
 int32_t eshkol_process_pid(void* proc) {
     if (!proc) return -1;
     const int* fields = (const int*)proc;

--- a/lib/agent/c/agent_regex.c
+++ b/lib/agent/c/agent_regex.c
@@ -23,6 +23,16 @@
 static pcre2_code* g_regex_handles[MAX_REGEX_HANDLES] = {0};
 static int g_next_handle = 1;
 
+/**
+ * @brief Allocates a slot in the global regex handle table for a compiled @p code.
+ *
+ * Scans forward from the last-used index (wrapping around once) for a free
+ * slot, so repeated compile/free cycles reuse released handles instead of
+ * exhausting the table.
+ *
+ * @param code Compiled PCRE2 pattern to store.
+ * @return The new handle (>= 1), or -1 if the table is full.
+ */
 static int alloc_handle(pcre2_code* code) {
     for (int i = g_next_handle; i < MAX_REGEX_HANDLES; i++) {
         if (!g_regex_handles[i]) {
@@ -42,6 +52,12 @@ static int alloc_handle(pcre2_code* code) {
     return -1;  /* Table full */
 }
 
+/**
+ * @brief Looks up the compiled PCRE2 pattern for a given handle.
+ *
+ * @param h Handle previously returned by alloc_handle() / eshkol_regex_compile().
+ * @return The stored pcre2_code pointer, or NULL if @p h is out of range or unused.
+ */
 static pcre2_code* get_handle(int64_t h) {
     if (h < 1 || h >= MAX_REGEX_HANDLES) return NULL;
     return g_regex_handles[h];
@@ -51,6 +67,18 @@ static pcre2_code* get_handle(int64_t h) {
  * Public API
  ******************************************************************************/
 
+/**
+ * @brief Compiles a PCRE2 pattern and returns an opaque handle for later matching.
+ *
+ * Translates the low three bits of @p flags into PCRE2_CASELESS,
+ * PCRE2_MULTILINE, and PCRE2_DOTALL respectively (always with PCRE2_UTF set),
+ * compiles @p pattern, and stores the result in the handle table.
+ *
+ * @param pattern NUL-terminated UTF-8 pattern string.
+ * @param flags Bit 0 = case-insensitive, bit 1 = multiline, bit 2 = dotall.
+ * @return Handle (>= 1) on success, -1 on a NULL pattern, compile error, or
+ *         full handle table.
+ */
 int64_t eshkol_regex_compile(const char* pattern, int flags) {
     if (!pattern) return -1;
 
@@ -75,6 +103,12 @@ int64_t eshkol_regex_compile(const char* pattern, int flags) {
     return handle;
 }
 
+/**
+ * @brief Returns a lazily-initialized, process-global PCRE2 match context with
+ * ReDoS-mitigating backtrack and depth limits.
+ *
+ * @return The shared match_context (may be NULL if PCRE2 allocation fails).
+ */
 /* #195 MEDIUM: ReDoS protection. A pattern like "(a+)+$" on a long
  * subject of a's + one unmatched trailing char triggers exponential
  * backtracking and freezes the thread. Without a match_limit, the
@@ -103,6 +137,18 @@ static pcre2_match_context* get_match_context(void) {
     return s_ctx;
 }
 
+/**
+ * @brief Runs a single match of a compiled pattern against @p subject.
+ *
+ * On a match, copies the matched substring (group 0) into @p match_buf,
+ * truncating to fit @p buf_size and NUL-terminating.
+ *
+ * @param handle Compiled pattern handle from eshkol_regex_compile().
+ * @param subject NUL-terminated subject string to search.
+ * @param match_buf Optional output buffer to receive the matched text.
+ * @param buf_size Size of @p match_buf in bytes.
+ * @return 1 if a match was found, 0 otherwise (including invalid handle/subject).
+ */
 int eshkol_regex_match(int64_t handle, const char* subject,
                        char* match_buf, size_t buf_size) {
     pcre2_code* code = get_handle(handle);
@@ -132,6 +178,21 @@ int eshkol_regex_match(int64_t handle, const char* subject,
     return 1;
 }
 
+/**
+ * @brief Finds successive non-overlapping matches of a pattern in @p subject.
+ *
+ * Repeatedly matches starting after the previous match's end (advancing by
+ * one byte on zero-length matches to guarantee progress), writing each
+ * matched substring into @p matches_buf separated by NUL bytes, until
+ * @p max_matches is reached, the subject is exhausted, or the buffer is full.
+ *
+ * @param handle Compiled pattern handle.
+ * @param subject NUL-terminated subject string to search.
+ * @param matches_buf Output buffer receiving NUL-separated matched substrings.
+ * @param buf_size Size of @p matches_buf in bytes.
+ * @param max_matches Maximum number of matches to collect.
+ * @return The number of matches written, or 0 on invalid arguments.
+ */
 int eshkol_regex_match_all(int64_t handle, const char* subject,
                             char* matches_buf, size_t buf_size,
                             int max_matches) {
@@ -171,6 +232,20 @@ int eshkol_regex_match_all(int64_t handle, const char* subject,
     return count;
 }
 
+/**
+ * @brief Performs a global regex substitution of a pattern in @p subject.
+ *
+ * Delegates to pcre2_substitute() with PCRE2_SUBSTITUTE_GLOBAL. If the
+ * substitution fails, falls back to copying @p subject unchanged (truncated
+ * to fit @p output) rather than returning an empty result.
+ *
+ * @param handle Compiled pattern handle.
+ * @param subject NUL-terminated subject string.
+ * @param replacement Replacement text (may contain PCRE2 substitution syntax).
+ * @param output Output buffer receiving the result.
+ * @param output_size Size of @p output in bytes.
+ * @return Length of the resulting string on success, or -1 on invalid arguments.
+ */
 int eshkol_regex_replace(int64_t handle, const char* subject,
                           const char* replacement,
                           char* output, size_t output_size) {
@@ -197,6 +272,12 @@ int eshkol_regex_replace(int64_t handle, const char* subject,
     return (int)out_len;
 }
 
+/**
+ * @brief Frees a compiled pattern and releases its handle slot.
+ *
+ * @param handle Handle previously returned by eshkol_regex_compile(). No-op if
+ *        the handle is invalid or already freed.
+ */
 void eshkol_regex_free(int64_t handle) {
     pcre2_code* code = get_handle(handle);
     if (code) {
@@ -222,6 +303,17 @@ void eshkol_regex_free(int64_t handle) {
  * if that group didn't participate in the match).
  ******************************************************************************/
 
+/**
+ * @brief Reports how many capture groups (including group 0) a single match
+ * of @p subject against the compiled pattern would produce.
+ *
+ * Useful for callers that want to size a buffer before calling
+ * eshkol_regex_match_groups().
+ *
+ * @param handle Compiled pattern handle.
+ * @param subject NUL-terminated subject string.
+ * @return Number of groups on a match, -1 if no match, 0 on invalid input.
+ */
 /* Return the number of capture groups (including group 0) on success;
  * -1 on no match; 0 on invalid input. */
 int eshkol_regex_match_groups_count(int64_t handle, const char* subject) {
@@ -237,6 +329,21 @@ int eshkol_regex_match_groups_count(int64_t handle, const char* subject) {
     return rc;
 }
 
+/**
+ * @brief Matches @p subject and writes every capture group's substring into
+ * @p out_buf as a NUL-separated list.
+ *
+ * Layout of @p out_buf is "group0\0group1\0...\0groupN\0" where group 0 is
+ * the whole match; a group that didn't participate in the match is emitted
+ * as an empty string.
+ *
+ * @param handle Compiled pattern handle.
+ * @param subject NUL-terminated subject string.
+ * @param out_buf Output buffer receiving the NUL-separated group substrings.
+ * @param buf_size Size of @p out_buf in bytes.
+ * @return Number of groups written (including group 0) on success, -1 if no
+ *         match, 0 on invalid input or if @p out_buf is too small.
+ */
 /* Fill out_buf with NUL-separated group substrings for the first match.
  * Returns the number of groups written on success (including group 0),
  * -1 if no match, 0 on invalid input or buffer overflow. */
@@ -282,6 +389,13 @@ int eshkol_regex_match_groups(int64_t handle, const char* subject,
     return rc;
 }
 
+/**
+ * @brief Resolves a named capture group to its 1-based group number.
+ *
+ * @param handle Compiled pattern handle.
+ * @param name Capture group name to look up.
+ * @return The 1-based group number, or -1 if @p name doesn't exist in the pattern.
+ */
 /* Count capture groups for a named group lookup. Returns the 1-based
  * group number, or -1 if not found. */
 int eshkol_regex_named_group_number(int64_t handle, const char* name) {

--- a/lib/agent/c/agent_signal.c
+++ b/lib/agent/c/agent_signal.c
@@ -42,11 +42,29 @@
 static volatile sig_atomic_t g_last_signal = 0;
 static volatile sig_atomic_t g_signal_count = 0;
 
+/**
+ * @brief Async-signal-safe handler that records the last-received signal.
+ *
+ * Only touches sig_atomic_t flags, deferring all real work to
+ * eshkol_signal_check() polled from normal (non-signal) context.
+ *
+ * @param sig Signal number delivered by the OS.
+ */
 static void signal_handler(int sig) {
     g_last_signal = sig;
     g_signal_count++;
 }
 
+/**
+ * @brief Installs signal_handler() for @p signum via sigaction().
+ *
+ * Uses SA_RESTART so interrupted syscalls are automatically restarted.
+ * Common signal numbers: 2 = SIGINT (Ctrl-C), 15 = SIGTERM (kill),
+ * 28 = SIGWINCH (terminal resize).
+ *
+ * @param signum Signal number to install the handler for.
+ * @return 0 on success, -1 on error.
+ */
 /*
  * Install signal handler for the given signal number.
  *
@@ -66,6 +84,16 @@ int32_t eshkol_signal_handler_install(int32_t signum) {
     return sigaction(signum, &sa, NULL) == 0 ? 0 : -1;
 }
 
+/**
+ * @brief Checks and consumes the most recently received signal.
+ *
+ * Intended to be polled at safe points in the Eshkol event loop between
+ * tool calls, avoiding the need to run Eshkol closures from async-signal
+ * context. Calling this clears the flag (consume-once semantics), so a
+ * signal is only reported to one caller.
+ *
+ * @return The signal number if one was pending, or 0 if none was pending.
+ */
 /*
  * Check if a signal has been received since last check.
  *
@@ -81,6 +109,14 @@ int32_t eshkol_signal_check(void) {
     return sig;
 }
 
+/**
+ * @brief Returns the cumulative count of signals received since process start.
+ *
+ * Unlike eshkol_signal_check(), this does not reset the counter; it's meant
+ * for debugging/metrics rather than consume-once dispatch.
+ *
+ * @return Total number of signals delivered so far.
+ */
 /*
  * Get total signal count (for debugging/metrics).
  * Does not reset.
@@ -89,6 +125,12 @@ int32_t eshkol_signal_total_count(void) {
     return (int32_t)g_signal_count;
 }
 
+/**
+ * @brief Restores the default disposition (SIG_DFL) for the given signal.
+ *
+ * @param signum Signal number to reset.
+ * @return 0 on success, -1 on error.
+ */
 /*
  * Reset signal handler to default for the given signal.
  * Returns: 0 success, -1 error
@@ -101,6 +143,12 @@ int32_t eshkol_signal_handler_reset(int32_t signum) {
     return sigaction(signum, &sa, NULL) == 0 ? 0 : -1;
 }
 
+/**
+ * @brief Sets the given signal's disposition to SIG_IGN so it is ignored.
+ *
+ * @param signum Signal number to ignore.
+ * @return 0 on success, -1 on error.
+ */
 /*
  * Ignore the given signal.
  * Returns: 0 success, -1 error
@@ -129,11 +177,26 @@ int32_t eshkol_signal_ignore(int32_t signum) {
 
 static int g_atexit_registered = 0;
 
+/**
+ * @brief atexit() callback that flushes stderr and stdout on process exit.
+ *
+ * Ensures buffered error/output text isn't lost if the process terminates
+ * abruptly; Eshkol-level cleanup should instead be registered via
+ * (at-exit ...) / dynamic-wind at the top level.
+ */
 static void eshkol_atexit_handler(void) {
     fflush(stderr);
     fflush(stdout);
 }
 
+/**
+ * @brief Registers eshkol_atexit_handler() with atexit(), exactly once.
+ *
+ * Idempotent: safe to call multiple times, the handler is only registered
+ * on the first call.
+ *
+ * @return Always 0.
+ */
 /*
  * Ensure atexit flush is registered. Idempotent.
  * Returns: 0
@@ -172,6 +235,17 @@ typedef void (*eshkol_kt_visitor)(pid_t child, void* ctx);
 static void kill_tree_recursive(pid_t pid, int sig);
 
 #if defined(__linux__)
+/**
+ * @brief Invokes @p cb for every direct child process of @p pid (Linux).
+ *
+ * Reads /proc/<pid>/task/<tid>/children for each task (thread) belonging to
+ * the process, avoiding any shell or PATH lookup. This closes the popen-pgrep
+ * command-injection vector the previous shell-based implementation exposed.
+ *
+ * @param pid Parent process ID whose children are enumerated.
+ * @param cb Callback invoked once per direct child PID found.
+ * @param ctx Opaque context pointer forwarded to @p cb.
+ */
 static void kt_visit_children(pid_t pid, eshkol_kt_visitor cb, void* ctx) {
     char task_dir[64];
     snprintf(task_dir, sizeof(task_dir), "/proc/%d/task", (int)pid);
@@ -202,6 +276,17 @@ static void kt_visit_children(pid_t pid, eshkol_kt_visitor cb, void* ctx) {
     closedir(td);
 }
 #else
+/**
+ * @brief Invokes @p cb for every direct child process of @p pid (macOS/BSD).
+ *
+ * Forks and execv()s "/usr/bin/pgrep -P <pid>" directly (no shell, no PATH
+ * lookup), captures its stdout via a pipe, waits for it to exit, and parses
+ * the resulting whitespace-separated PID list.
+ *
+ * @param pid Parent process ID whose children are enumerated.
+ * @param cb Callback invoked once per direct child PID found.
+ * @param ctx Opaque context pointer forwarded to @p cb.
+ */
 static void kt_visit_children(pid_t pid, eshkol_kt_visitor cb, void* ctx) {
     int pipefd[2];
     if (pipe(pipefd) != 0) return;
@@ -255,17 +340,40 @@ static void kt_visit_children(pid_t pid, eshkol_kt_visitor cb, void* ctx) {
 }
 #endif
 
+/**
+ * @brief kt_visit_children() callback that recurses kill_tree_recursive() into a child.
+ *
+ * @param child Child PID reported by kt_visit_children().
+ * @param ctx Pointer to the `int` signal number to deliver.
+ */
 static void kt_recurse_cb(pid_t child, void* ctx) {
     int sig = *(const int*)ctx;
     kill_tree_recursive(child, sig);
 }
 
+/**
+ * @brief Recursively delivers @p sig to @p pid's entire descendant tree, then to @p pid itself.
+ *
+ * Visits children depth-first via kt_visit_children()/kt_recurse_cb() before
+ * signaling the current process, so descendants are signaled before their
+ * parent to avoid leaving orphans behind.
+ *
+ * @param pid Root process ID of the tree to signal.
+ * @param sig Signal number to deliver to every process in the tree.
+ */
 static void kill_tree_recursive(pid_t pid, int sig) {
     /* Find children first, then kill this process. */
     kt_visit_children(pid, kt_recurse_cb, &sig);
     kill(pid, sig);
 }
 
+/**
+ * @brief Signals a process and its entire descendant tree.
+ *
+ * @param pid Root process ID to kill (must be positive).
+ * @param sig Signal number to deliver (e.g. 15 = SIGTERM, 9 = SIGKILL).
+ * @return 0 on success, -1 if @p pid is not positive.
+ */
 /*
  * Kill process and all descendants.
  *

--- a/lib/agent/c/agent_sqlite.c
+++ b/lib/agent/c/agent_sqlite.c
@@ -25,6 +25,15 @@ static sqlite3_stmt* g_stmt_handles[MAX_STMT_HANDLES]  = {0};
 static int g_next_db   = 1;
 static int g_next_stmt = 1;
 
+/**
+ * @brief Allocates a slot in the global DB handle table for an open @p db.
+ *
+ * Scans forward from the last-used index (wrapping around once) so released
+ * handles are reused rather than exhausting the table.
+ *
+ * @param db Open sqlite3 connection to store.
+ * @return The new handle (>= 1), or -1 if the table is full.
+ */
 static int alloc_db(sqlite3* db) {
     for (int i = g_next_db; i < MAX_DB_HANDLES; i++) {
         if (!g_db_handles[i]) { g_db_handles[i] = db; g_next_db = i+1; return i; }
@@ -35,6 +44,15 @@ static int alloc_db(sqlite3* db) {
     return -1;
 }
 
+/**
+ * @brief Allocates a slot in the global statement handle table for a prepared @p stmt.
+ *
+ * Scans forward from the last-used index (wrapping around once) so released
+ * handles are reused rather than exhausting the table.
+ *
+ * @param stmt Prepared statement to store.
+ * @return The new handle (>= 1), or -1 if the table is full.
+ */
 static int alloc_stmt(sqlite3_stmt* stmt) {
     for (int i = g_next_stmt; i < MAX_STMT_HANDLES; i++) {
         if (!g_stmt_handles[i]) { g_stmt_handles[i] = stmt; g_next_stmt = i+1; return i; }
@@ -45,11 +63,23 @@ static int alloc_stmt(sqlite3_stmt* stmt) {
     return -1;
 }
 
+/**
+ * @brief Looks up the open sqlite3 connection for a given handle.
+ *
+ * @param h Handle previously returned by eshkol_sqlite_open().
+ * @return The stored sqlite3 pointer, or NULL if @p h is out of range or unused.
+ */
 static sqlite3* get_db(int64_t h) {
     if (h < 1 || h >= MAX_DB_HANDLES) return NULL;
     return g_db_handles[h];
 }
 
+/**
+ * @brief Looks up the prepared statement for a given handle.
+ *
+ * @param h Handle previously returned by eshkol_sqlite_prepare().
+ * @return The stored sqlite3_stmt pointer, or NULL if @p h is out of range or unused.
+ */
 static sqlite3_stmt* get_stmt(int64_t h) {
     if (h < 1 || h >= MAX_STMT_HANDLES) return NULL;
     return g_stmt_handles[h];
@@ -59,6 +89,17 @@ static sqlite3_stmt* get_stmt(int64_t h) {
  * Database Operations
  ******************************************************************************/
 
+/**
+ * @brief Opens (or creates) a SQLite database file and returns an opaque handle.
+ *
+ * Opens with SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX,
+ * then enables WAL journal mode for concurrent readers and sets a 5-second
+ * busy timeout before storing the connection in the handle table.
+ *
+ * @param path Filesystem path to the database file.
+ * @return Handle (>= 1) on success, -1 on a NULL path, open failure, or full
+ *         handle table.
+ */
 int64_t eshkol_sqlite_open(const char* path) {
     if (!path) return -1;
 
@@ -84,6 +125,12 @@ int64_t eshkol_sqlite_open(const char* path) {
     return handle;
 }
 
+/**
+ * @brief Closes a database connection and releases its handle slot.
+ *
+ * @param handle Handle previously returned by eshkol_sqlite_open(). No-op if
+ *        the handle is invalid or already closed.
+ */
 void eshkol_sqlite_close(int64_t handle) {
     sqlite3* db = get_db(handle);
     if (db) {
@@ -92,6 +139,17 @@ void eshkol_sqlite_close(int64_t handle) {
     }
 }
 
+/**
+ * @brief Executes one or more SQL statements with no result-row callback.
+ *
+ * Intended for DDL/DML (CREATE, INSERT, UPDATE, ...) where no rows are
+ * expected back. Any error message produced by SQLite is freed internally.
+ *
+ * @param handle Database handle from eshkol_sqlite_open().
+ * @param sql SQL text to execute.
+ * @return 0 on success, the SQLite error code on failure, or -1 on invalid
+ *         handle/sql.
+ */
 int eshkol_sqlite_exec(int64_t handle, const char* sql) {
     sqlite3* db = get_db(handle);
     if (!db || !sql) return -1;
@@ -106,6 +164,14 @@ int eshkol_sqlite_exec(int64_t handle, const char* sql) {
  * Prepared Statements
  ******************************************************************************/
 
+/**
+ * @brief Compiles a SQL statement into a reusable prepared-statement handle.
+ *
+ * @param db_handle Database handle from eshkol_sqlite_open().
+ * @param sql SQL text to prepare.
+ * @return Statement handle (>= 1) on success, -1 on invalid database handle,
+ *         NULL sql, a prepare error, or a full statement handle table.
+ */
 int64_t eshkol_sqlite_prepare(int64_t db_handle, const char* sql) {
     sqlite3* db = get_db(db_handle);
     if (!db || !sql) return -1;
@@ -122,18 +188,37 @@ int64_t eshkol_sqlite_prepare(int64_t db_handle, const char* sql) {
     return handle;
 }
 
+/**
+ * @brief Advances a prepared statement to its next result.
+ *
+ * @param stmt_handle Statement handle from eshkol_sqlite_prepare().
+ * @return The raw sqlite3_step() result code (e.g. SQLITE_ROW = 100,
+ *         SQLITE_DONE = 101), or -1 if @p stmt_handle is invalid.
+ */
 int eshkol_sqlite_step(int64_t stmt_handle) {
     sqlite3_stmt* stmt = get_stmt(stmt_handle);
     if (!stmt) return -1;
     return sqlite3_step(stmt);  /* Returns SQLITE_ROW (100) or SQLITE_DONE (101) */
 }
 
+/**
+ * @brief Resets a prepared statement so it can be re-executed (bindings are kept).
+ *
+ * @param stmt_handle Statement handle from eshkol_sqlite_prepare().
+ * @return The sqlite3_reset() result code, or -1 if @p stmt_handle is invalid.
+ */
 int eshkol_sqlite_reset(int64_t stmt_handle) {
     sqlite3_stmt* stmt = get_stmt(stmt_handle);
     if (!stmt) return -1;
     return sqlite3_reset(stmt);
 }
 
+/**
+ * @brief Finalizes a prepared statement and releases its handle slot.
+ *
+ * @param stmt_handle Statement handle from eshkol_sqlite_prepare(). No-op if
+ *        the handle is invalid or already finalized.
+ */
 void eshkol_sqlite_finalize(int64_t stmt_handle) {
     sqlite3_stmt* stmt = get_stmt(stmt_handle);
     if (stmt) {
@@ -146,24 +231,58 @@ void eshkol_sqlite_finalize(int64_t stmt_handle) {
  * Parameter Binding
  ******************************************************************************/
 
+/**
+ * @brief Binds a text value to a 1-based parameter index of a prepared statement.
+ *
+ * Uses SQLITE_TRANSIENT, so SQLite copies @p text internally and the caller's
+ * buffer may be freed or reused immediately after this call.
+ *
+ * @param stmt_handle Statement handle from eshkol_sqlite_prepare().
+ * @param index 1-based bind parameter index.
+ * @param text NUL-terminated text to bind.
+ * @return The sqlite3_bind_text() result code, or -1 on invalid statement/text.
+ */
 int eshkol_sqlite_bind_text(int64_t stmt_handle, int index, const char* text) {
     sqlite3_stmt* stmt = get_stmt(stmt_handle);
     if (!stmt || !text) return -1;
     return sqlite3_bind_text(stmt, index, text, -1, SQLITE_TRANSIENT);
 }
 
+/**
+ * @brief Binds a 64-bit integer value to a 1-based parameter index.
+ *
+ * @param stmt_handle Statement handle from eshkol_sqlite_prepare().
+ * @param index 1-based bind parameter index.
+ * @param value Integer value to bind.
+ * @return The sqlite3_bind_int64() result code, or -1 on invalid statement.
+ */
 int eshkol_sqlite_bind_int(int64_t stmt_handle, int index, int64_t value) {
     sqlite3_stmt* stmt = get_stmt(stmt_handle);
     if (!stmt) return -1;
     return sqlite3_bind_int64(stmt, index, value);
 }
 
+/**
+ * @brief Binds a floating-point value to a 1-based parameter index.
+ *
+ * @param stmt_handle Statement handle from eshkol_sqlite_prepare().
+ * @param index 1-based bind parameter index.
+ * @param value Value to bind.
+ * @return The sqlite3_bind_double() result code, or -1 on invalid statement.
+ */
 int eshkol_sqlite_bind_double(int64_t stmt_handle, int index, double value) {
     sqlite3_stmt* stmt = get_stmt(stmt_handle);
     if (!stmt) return -1;
     return sqlite3_bind_double(stmt, index, value);
 }
 
+/**
+ * @brief Binds SQL NULL to a 1-based parameter index.
+ *
+ * @param stmt_handle Statement handle from eshkol_sqlite_prepare().
+ * @param index 1-based bind parameter index.
+ * @return The sqlite3_bind_null() result code, or -1 on invalid statement.
+ */
 int eshkol_sqlite_bind_null(int64_t stmt_handle, int index) {
     sqlite3_stmt* stmt = get_stmt(stmt_handle);
     if (!stmt) return -1;
@@ -174,6 +293,19 @@ int eshkol_sqlite_bind_null(int64_t stmt_handle, int index) {
  * Column Access
  ******************************************************************************/
 
+/**
+ * @brief Returns the exact byte length of a TEXT/BLOB column without copying it.
+ *
+ * Lets the Eshkol wrapper size its receiving buffer correctly before calling
+ * eshkol_sqlite_column_text(), avoiding silent truncation on large payloads.
+ * Calls sqlite3_column_text() first per SQLite's docs, since column_bytes()
+ * may require the value to have been converted to TEXT.
+ *
+ * @param stmt_handle Statement handle positioned on a row (after a
+ *        SQLITE_ROW step).
+ * @param index 0-based column index.
+ * @return Byte length of the column value, or -1 if @p stmt_handle is invalid.
+ */
 /* Get the byte length of a TEXT/BLOB column without copying the data.
  * Required so the Eshkol wrapper can size its receiving buffer
  * correctly for large payloads (session JSON, embedded blobs, etc.)
@@ -191,6 +323,23 @@ int64_t eshkol_sqlite_column_bytes(int64_t stmt_handle, int index) {
     return (int64_t)sqlite3_column_bytes(stmt, index);
 }
 
+/**
+ * @brief Copies a TEXT column's value into a caller-provided buffer.
+ *
+ * Uses sqlite3_column_bytes() (binary-safe) rather than strlen() to determine
+ * the source length, since the previous fixed-size scheme silently truncated
+ * large payloads. If @p buf is too small, the copy is truncated but the
+ * return value is encoded as -(len+1) so the caller can detect truncation
+ * and retry with a larger buffer.
+ *
+ * @param stmt_handle Statement handle positioned on a row.
+ * @param index 0-based column index.
+ * @param buf Output buffer receiving the NUL-terminated text.
+ * @param buf_size Size of @p buf in bytes.
+ * @return Number of bytes copied (excluding the NUL) on success, 0 if the
+ *         column is NULL, -(len+1) if @p buf was too small to hold the full
+ *         value, or -1 on invalid arguments.
+ */
 int eshkol_sqlite_column_text(int64_t stmt_handle, int index,
                                 char* buf, size_t buf_size) {
     sqlite3_stmt* stmt = get_stmt(stmt_handle);
@@ -224,24 +373,54 @@ int eshkol_sqlite_column_text(int64_t stmt_handle, int index,
     return (int)copy;
 }
 
+/**
+ * @brief Reads the current row's column value as a 64-bit integer.
+ *
+ * @param stmt_handle Statement handle positioned on a row.
+ * @param index 0-based column index.
+ * @return The column value converted to int64_t, or 0 if @p stmt_handle is invalid.
+ */
 int64_t eshkol_sqlite_column_int(int64_t stmt_handle, int index) {
     sqlite3_stmt* stmt = get_stmt(stmt_handle);
     if (!stmt) return 0;
     return sqlite3_column_int64(stmt, index);
 }
 
+/**
+ * @brief Reads the current row's column value as a double.
+ *
+ * @param stmt_handle Statement handle positioned on a row.
+ * @param index 0-based column index.
+ * @return The column value converted to double, or 0.0 if @p stmt_handle is invalid.
+ */
 double eshkol_sqlite_column_double(int64_t stmt_handle, int index) {
     sqlite3_stmt* stmt = get_stmt(stmt_handle);
     if (!stmt) return 0.0;
     return sqlite3_column_double(stmt, index);
 }
 
+/**
+ * @brief Returns the number of columns in a prepared statement's result set.
+ *
+ * @param stmt_handle Statement handle from eshkol_sqlite_prepare().
+ * @return Column count, or 0 if @p stmt_handle is invalid.
+ */
 int eshkol_sqlite_column_count(int64_t stmt_handle) {
     sqlite3_stmt* stmt = get_stmt(stmt_handle);
     if (!stmt) return 0;
     return sqlite3_column_count(stmt);
 }
 
+/**
+ * @brief Copies a result column's declared name into a caller-provided buffer.
+ *
+ * @param stmt_handle Statement handle from eshkol_sqlite_prepare().
+ * @param index 0-based column index.
+ * @param buf Output buffer receiving the NUL-terminated column name.
+ * @param buf_size Size of @p buf in bytes.
+ * @return Number of bytes copied (excluding the NUL), 0 if the name is
+ *         unavailable, or -1 on invalid arguments.
+ */
 int eshkol_sqlite_column_name(int64_t stmt_handle, int index,
                                 char* buf, size_t buf_size) {
     sqlite3_stmt* stmt = get_stmt(stmt_handle);
@@ -256,6 +435,14 @@ int eshkol_sqlite_column_name(int64_t stmt_handle, int index,
     return (int)copy;
 }
 
+/**
+ * @brief Returns the SQLite storage class (type) of the current row's column value.
+ *
+ * @param stmt_handle Statement handle positioned on a row.
+ * @param index 0-based column index.
+ * @return One of the SQLITE_{INTEGER,FLOAT,TEXT,BLOB,NULL} constants, or -1
+ *         if @p stmt_handle is invalid.
+ */
 int eshkol_sqlite_column_type(int64_t stmt_handle, int index) {
     sqlite3_stmt* stmt = get_stmt(stmt_handle);
     if (!stmt) return -1;
@@ -266,6 +453,14 @@ int eshkol_sqlite_column_type(int64_t stmt_handle, int index) {
  * Error Handling
  ******************************************************************************/
 
+/**
+ * @brief Copies the database connection's last error message into a buffer.
+ *
+ * @param db_handle Database handle from eshkol_sqlite_open().
+ * @param buf Output buffer receiving the NUL-terminated error message.
+ * @param buf_size Size of @p buf in bytes.
+ * @return Number of bytes copied (excluding the NUL), or -1 on invalid arguments.
+ */
 int eshkol_sqlite_last_error(int64_t db_handle, char* buf, size_t buf_size) {
     sqlite3* db = get_db(db_handle);
     if (!db || !buf || buf_size == 0) return -1;
@@ -278,12 +473,24 @@ int eshkol_sqlite_last_error(int64_t db_handle, char* buf, size_t buf_size) {
     return (int)copy;
 }
 
+/**
+ * @brief Returns the rowid of the most recent successful INSERT on this connection.
+ *
+ * @param db_handle Database handle from eshkol_sqlite_open().
+ * @return The last inserted rowid, or -1 if @p db_handle is invalid.
+ */
 int64_t eshkol_sqlite_last_insert_rowid(int64_t db_handle) {
     sqlite3* db = get_db(db_handle);
     if (!db) return -1;
     return sqlite3_last_insert_rowid(db);
 }
 
+/**
+ * @brief Returns the number of rows changed by the most recent INSERT/UPDATE/DELETE.
+ *
+ * @param db_handle Database handle from eshkol_sqlite_open().
+ * @return The row-change count, or 0 if @p db_handle is invalid.
+ */
 int eshkol_sqlite_changes(int64_t db_handle) {
     sqlite3* db = get_db(db_handle);
     if (!db) return 0;

--- a/lib/agent/c/agent_subprocess.c
+++ b/lib/agent/c/agent_subprocess.c
@@ -103,6 +103,15 @@ static void set_pipes_nonblocking(eshkol_subprocess_t* proc);
  * Also bail if we see a \n or \r — newlines are rare in command
  * strings and reserved for scripts.
  */
+/**
+ * @brief Check whether @p cmd is free of shell metacharacters and can be
+ *        exec'd directly instead of via `/bin/sh -c`.
+ *
+ * @param cmd NUL-terminated command string; NULL is treated as unsafe.
+ * @return 1 if @p cmd contains only whitespace-separated tokens with no
+ *         shell metacharacters or control bytes (see the block comment
+ *         above for the exact character set), 0 otherwise.
+ */
 static int command_is_shell_safe(const char* cmd) {
     if (!cmd) return 0;
     for (const char* p = cmd; *p; p++) {
@@ -133,6 +142,20 @@ static int command_is_shell_safe(const char* cmd) {
 /* Split a metacharacter-free command string on whitespace into an
  * argv array. Returns NULL on OOM or empty input. Caller frees with
  * `free(argv[0]); free(argv);`. */
+/**
+ * @brief Tokenize a metacharacter-free command string into an argv array.
+ *
+ * Splits @p cmd on runs of spaces/tabs into a NULL-terminated argv vector
+ * suitable for execvp/posix_spawnp. Only safe to call after
+ * command_is_shell_safe() has confirmed @p cmd contains no shell
+ * metacharacters.
+ *
+ * @param cmd      Whitespace-separated command string (must be
+ *                 shell-metacharacter-free).
+ * @param out_argc Optional out-parameter receiving the token count.
+ * @return Newly allocated argv array, or NULL on OOM or empty input.
+ *         Caller frees with `free(argv[0]); free(argv);`.
+ */
 static char** split_shell_safe_command(const char* cmd, int* out_argc) {
     if (!cmd) return NULL;
     /* Work on a mutable copy. The returned argv[i] all point into it,
@@ -201,6 +224,16 @@ static char** split_shell_safe_command(const char* cmd, int* out_argc) {
  *
  * Setting a limit > the hard limit is silently ignored so we don't
  * block legitimate tools on a host that already has lower caps. */
+/**
+ * @brief Apply default resource limits (RLIMIT_AS/CPU/NOFILE/NPROC) to the
+ *        calling process, meant to be invoked in the child after fork().
+ *
+ * Limits are read from the ESHKOL_SUBPROC_MEM_MB / ESHKOL_SUBPROC_CPU_SEC /
+ * ESHKOL_SUBPROC_NOFILE / ESHKOL_SUBPROC_NPROC environment variables (with
+ * generous defaults) and only lowered, never raised, past the existing hard
+ * limit. No-op on Windows. See the comment above this function for the
+ * posix_spawn coverage gap.
+ */
 static void eshkol_apply_subproc_rlimits(void) {
 #ifndef _WIN32
     struct rlimit r;
@@ -261,6 +294,14 @@ static void eshkol_apply_subproc_rlimits(void) {
  * exec (audit C6). Used on fork+exec paths where we don't have the
  * posix_spawn attr machinery to pass a filtered env — call this in
  * the child process right before execvp/execlp. */
+/**
+ * @brief Unset dynamic-linker injection environment variables (LD_PRELOAD,
+ *        DYLD_INSERT_LIBRARIES, etc.) in the calling process.
+ *
+ * Meant to be called in the child right before execvp/execlp on the
+ * fork+exec path, where the posix_spawn attr machinery to pass a
+ * pre-filtered environment isn't available. No-op on Windows.
+ */
 static void eshkol_unset_env_injection_vars(void) {
 #ifndef _WIN32
     static const char* const kVars[] = {
@@ -315,6 +356,21 @@ static pthread_mutex_t g_env_cache_mu = PTHREAD_MUTEX_INITIALIZER;
 static char** g_env_cache = NULL;
 static char** g_env_cache_source = NULL;  /* the environ ptr we scrubbed */
 
+/**
+ * @brief Return a copy of `environ` with dynamic-linker injection variables
+ *        (LD_PRELOAD, DYLD_INSERT_LIBRARIES, LD_LIBRARY_PATH, etc.) removed,
+ *        for use as the envp passed to posix_spawn.
+ *
+ * The result is cached in g_env_cache and rebuilt only if `environ` itself
+ * changes identity; callers must NOT free the returned pointer. Entries in
+ * the returned array alias the original `environ` strings. Returns NULL on
+ * Windows (a different env API is used there) or if `environ` is NULL; on
+ * allocation failure inside the rebuild, falls back to returning the raw
+ * `environ` pointer so a scrub failure never blocks a spawn outright.
+ *
+ * @return Malloc'd, NUL-terminated envp array (do not free), the raw
+ *         `environ` pointer as a fallback, or NULL.
+ */
 static char** eshkol_scrub_environ(void) {
 #ifdef _WIN32
     return NULL;  /* Windows uses a different env API */
@@ -382,6 +438,31 @@ static char** eshkol_scrub_environ(void) {
 #endif
 }
 
+/**
+ * @brief Shared implementation behind qllm_process_spawn() and
+ *        qllm_process_spawn_shell(): spawns @p command with stdin/stdout/
+ *        stderr wired to pipes (or stdin to /dev/null when
+ *        ESHKOL_SPAWN_STDIN_NULL is set in @p flags).
+ *
+ * On POSIX, uses posix_spawn on the hot path when @p cwd_arg is empty or
+ * "." (no chdir needed), bypassing /bin/sh entirely when @p force_shell is
+ * false and command_is_shell_safe(@p command) holds; otherwise falls back
+ * to `/bin/sh -c command`. When a chdir is required, falls back to
+ * fork+exec so the child can chdir before exec. The child's environment is
+ * scrubbed via eshkol_scrub_environ() and, on the fork+exec path, resource
+ * limits are applied via eshkol_apply_subproc_rlimits(). On Windows, uses
+ * CreateProcessA with `cmd /c command`.
+ *
+ * @param command    Command string to run (shell form).
+ * @param cwd_arg    Working directory for the child, or NULL/""/"." for
+ *                   the parent's current directory.
+ * @param flags      ESHKOL_SPAWN_STDIN_NULL or 0.
+ * @param force_shell If nonzero, always go through /bin/sh -c even when
+ *                    @p command has no shell metacharacters.
+ * @return Newly allocated eshkol_subprocess_t handle, or NULL on failure
+ *         (OOM, pipe/spawn/fork error); errno is set to the spawn error on
+ *         posix_spawn failure paths.
+ */
 static eshkol_subprocess_t* qllm_process_spawn_command_impl(const char* command,
                                                             const char* cwd_arg,
                                                             int64_t flags,
@@ -646,18 +727,40 @@ static eshkol_subprocess_t* qllm_process_spawn_command_impl(const char* command,
 #endif
 }
 
+/**
+ * @brief Public qllm_process_spawn entry point: spawn @p command via the
+ *        legacy shell-compatible path (may bypass /bin/sh when safe).
+ *
+ * Delegates to qllm_process_spawn_command_impl() with force_shell=0.
+ * @p unused_arg is accepted for ABI compatibility with callers but ignored.
+ *
+ * @return New process handle, or NULL on failure.
+ */
 eshkol_subprocess_t* qllm_process_spawn(const char* command, const char* cwd_arg,
                                          const char* unused_arg, int64_t flags) {
     (void)unused_arg;
     return qllm_process_spawn_command_impl(command, cwd_arg, flags, 0);
 }
 
+/**
+ * @brief Spawn @p command, always via the platform shell
+ *        (/bin/sh -c on POSIX, cmd /c on Windows).
+ *
+ * Delegates to qllm_process_spawn_command_impl() with force_shell=1, so
+ * shell grammar (pipes, redirection, globbing) is always honored.
+ *
+ * @return New process handle, or NULL on failure.
+ */
 eshkol_subprocess_t* qllm_process_spawn_shell(const char* command,
                                                const char* cwd_arg,
                                                int64_t flags) {
     return qllm_process_spawn_command_impl(command, cwd_arg, flags, 1);
 }
 
+/**
+ * @brief Free a buffer previously returned by qllm_process_read_all_stdout()
+ *        or qllm_process_read_all_stderr().
+ */
 void qllm_process_free_buffer(char* buf) {
     free(buf);
 }
@@ -681,6 +784,21 @@ void qllm_process_free_buffer(char* buf) {
  * ═══════════════════════════════════════════════════════════════════ */
 
 #ifndef _WIN32
+/**
+ * @brief Split a tab-separated packed argv string into a NULL-terminated
+ *        argv array for execvp.
+ *
+ * @p packed is a single C string of the form "program\targ1\targ2\t…";
+ * tab is used as the separator because the FFI layer only exposes `ptr` as
+ * a plain C string.
+ *
+ * @param packed    Tab-separated argv string.
+ * @param argc_out  Out-parameter receiving the number of tokens (0 on
+ *                  failure).
+ * @return Newly allocated argv array, or NULL on NULL/empty input or OOM.
+ *         Caller must free both the array and its underlying buffer via
+ *         `free(argv[0]); free(argv);`.
+ */
 static char** parse_tab_argv(const char* packed, int* argc_out) {
     if (!packed) { *argc_out = 0; return NULL; }
     /* Count tabs + 1. */
@@ -710,6 +828,25 @@ static char** parse_tab_argv(const char* packed, int* argc_out) {
 }
 #endif
 
+/**
+ * @brief Spawn a program directly via execvp semantics (no shell), from a
+ *        tab-packed argv string, with stdin/stdout/stderr wired to pipes
+ *        (or stdin to /dev/null when ESHKOL_SPAWN_STDIN_NULL is set).
+ *
+ * Parses @p tab_packed_argv with parse_tab_argv() and execs argv[0]
+ * directly — there is no shell expansion, so this is the safe entry point
+ * for callers that interpolate untrusted values into arguments. Uses
+ * posix_spawn on the hot path when @p cwd_arg is empty or ".", falling
+ * back to fork+exec when a chdir is required (posix_spawn has no portable
+ * chdir action here). Not implemented on Windows (returns NULL).
+ *
+ * @param tab_packed_argv Tab-separated "program\targ1\targ2\t…" string;
+ *                        must be non-NULL and non-empty.
+ * @param cwd_arg         Working directory for the child, or NULL/""/"."
+ *                        for the parent's current directory.
+ * @param flags           ESHKOL_SPAWN_STDIN_NULL or 0.
+ * @return Newly allocated eshkol_subprocess_t handle, or NULL on failure.
+ */
 eshkol_subprocess_t* qllm_process_spawn_argv_flags(const char* tab_packed_argv,
                                                     const char* cwd_arg,
                                                     int64_t flags) {
@@ -894,6 +1031,15 @@ eshkol_subprocess_t* qllm_process_spawn_argv_flags(const char* tab_packed_argv,
 /* Back-compat shim: original 2-arg signature, still referenced by the
  * extern decl in subprocess.esk and the legacy callers. Delegates to
  * the _flags variant with flags=0 (wires a stdin pipe). */
+/**
+ * @brief Back-compat 2-argument entry point for argv-based spawn.
+ *
+ * Delegates to qllm_process_spawn_argv_flags() with flags=0 (stdin wired
+ * to a pipe). Kept for the extern declaration in subprocess.esk and other
+ * legacy callers.
+ *
+ * @return Newly allocated eshkol_subprocess_t handle, or NULL on failure.
+ */
 eshkol_subprocess_t* qllm_process_spawn_argv(const char* tab_packed_argv,
                                               const char* cwd_arg) {
     return qllm_process_spawn_argv_flags(tab_packed_argv, cwd_arg, 0);
@@ -903,6 +1049,16 @@ eshkol_subprocess_t* qllm_process_spawn_argv(const char* tab_packed_argv,
  * Stdin Write / Close
  * ═══════════════════════════════════════════════════════════════════ */
 
+/**
+ * @brief Write @p len bytes from @p data to the child's stdin pipe.
+ *
+ * If the process was spawned with ESHKOL_SPAWN_STDIN_NULL (stdin wired to
+ * /dev/null), the write is ignored and a one-time warning is printed to
+ * stderr rather than silently losing data (audit H9).
+ *
+ * @return Number of bytes actually written, or -1 on a NULL/invalid
+ *         argument or a write error (including the /dev/null-stdin case).
+ */
 int64_t qllm_process_write_stdin(eshkol_subprocess_t* proc, const char* data, int64_t len) {
     if (!proc || !data || len <= 0) return -1;
 #ifndef _WIN32
@@ -927,6 +1083,9 @@ int64_t qllm_process_write_stdin(eshkol_subprocess_t* proc, const char* data, in
 #endif
 }
 
+/**
+ * @brief Close the child's stdin pipe/handle, signalling EOF to the child.
+ */
 void qllm_process_close_stdin(eshkol_subprocess_t* proc) {
     if (!proc) return;
 #ifndef _WIN32
@@ -940,6 +1099,13 @@ void qllm_process_close_stdin(eshkol_subprocess_t* proc) {
  * Stdout / Stderr Read
  * ═══════════════════════════════════════════════════════════════════ */
 
+/**
+ * @brief Non-blocking read of up to @p buf_size bytes from the child's
+ *        stdout pipe into @p buf.
+ *
+ * @return Number of bytes read, 0 if no data is currently available
+ *         (EAGAIN), or -1 on a NULL/invalid argument, closed fd, or error.
+ */
 int64_t qllm_process_read_stdout(eshkol_subprocess_t* proc, char* buf, int64_t buf_size) {
     if (!proc || !buf || buf_size <= 0) return -1;
 #ifndef _WIN32
@@ -954,6 +1120,13 @@ int64_t qllm_process_read_stdout(eshkol_subprocess_t* proc, char* buf, int64_t b
 #endif
 }
 
+/**
+ * @brief Non-blocking read of up to @p buf_size bytes from the child's
+ *        stderr pipe into @p buf.
+ *
+ * @return Number of bytes read, 0 if no data is currently available
+ *         (EAGAIN), or -1 on a NULL/invalid argument, closed fd, or error.
+ */
 int64_t qllm_process_read_stderr(eshkol_subprocess_t* proc, char* buf, int64_t buf_size) {
     if (!proc || !buf || buf_size <= 0) return -1;
 #ifndef _WIN32
@@ -972,6 +1145,27 @@ int64_t qllm_process_read_stderr(eshkol_subprocess_t* proc, char* buf, int64_t b
  * qllm_process_wait plus any remainder still in the pipe. The buffer
  * is malloc'd for the caller to free; internal proc buffer is
  * zero'd after transfer so a second call returns empty string. */
+/**
+ * @brief Shared POSIX implementation behind qllm_process_read_all_stdout()
+ *        and qllm_process_read_all_stderr(): return everything captured
+ *        from @p fd so far, plus whatever remains in the pipe.
+ *
+ * First hands over the bytes already accumulated in `*inline_buf` (drained
+ * by qllm_process_wait's drain loop), then, if the fd isn't at EOF, keeps
+ * reading (briefly polling across EAGAIN) until EOF or @p max_size bytes
+ * have been collected. The inline buffer is freed and reset afterward so a
+ * second call on the same stream returns an empty string.
+ *
+ * @param fd          Pipe fd to read from (POSIX only; may be closed/-1).
+ * @param inline_buf  In/out pointer to the proc's accumulated buffer.
+ * @param inline_len  In/out length of `*inline_buf`.
+ * @param inline_cap  In/out capacity of `*inline_buf`.
+ * @param eof_flag    In/out EOF flag for this stream.
+ * @param max_size    Maximum number of bytes to return.
+ * @param out_len     Optional out-parameter receiving the returned length.
+ * @return Newly malloc'd, NUL-terminated buffer (caller frees), or NULL on
+ *         OOM or non-positive @p max_size. Always NULL on Windows.
+ */
 static char* read_all_stream_posix(int fd,
                                    char** inline_buf, size_t* inline_len, size_t* inline_cap,
                                    int* eof_flag,
@@ -1035,6 +1229,16 @@ static char* read_all_stream_posix(int fd,
 #endif
 }
 
+/**
+ * @brief Return all stdout output captured for @p proc so far (accumulated
+ *        during qllm_process_wait plus any pipe remainder), up to
+ *        @p max_size bytes.
+ *
+ * @param out_len Optional out-parameter receiving the returned length.
+ * @return Newly malloc'd, NUL-terminated buffer (caller frees via
+ *         qllm_process_free_buffer), or NULL on NULL @p proc, OOM, or
+ *         non-positive @p max_size. Always NULL on Windows.
+ */
 char* qllm_process_read_all_stdout(eshkol_subprocess_t* proc, int64_t max_size, int64_t* out_len) {
     if (!proc) return NULL;
 #ifndef _WIN32
@@ -1047,6 +1251,16 @@ char* qllm_process_read_all_stdout(eshkol_subprocess_t* proc, int64_t max_size, 
 #endif
 }
 
+/**
+ * @brief Return all stderr output captured for @p proc so far (accumulated
+ *        during qllm_process_wait plus any pipe remainder), up to
+ *        @p max_size bytes.
+ *
+ * @param out_len Optional out-parameter receiving the returned length.
+ * @return Newly malloc'd, NUL-terminated buffer (caller frees via
+ *         qllm_process_free_buffer), or NULL on NULL @p proc, OOM, or
+ *         non-positive @p max_size. Always NULL on Windows.
+ */
 char* qllm_process_read_all_stderr(eshkol_subprocess_t* proc, int64_t max_size, int64_t* out_len) {
     if (!proc) return NULL;
 #ifndef _WIN32
@@ -1074,8 +1288,33 @@ char* qllm_process_read_all_stderr(eshkol_subprocess_t* proc, int64_t max_size, 
  * interrupt a blocking syscall with EINTR rather than killing us (the
  * SIGALRM default). Defined at file scope so its address is usable
  * inside nested functions. */
+/**
+ * @brief No-op SIGALRM handler; installed only so signal delivery
+ *        interrupts a blocking syscall with EINTR instead of terminating
+ *        the process (SIGALRM's default disposition).
+ *
+ * @param sig Unused; present to match the sa_handler signature.
+ */
 static void eshkol_subprocess_alrm_noop(int sig) { (void)sig; }
 
+/**
+ * @brief Drain all currently-available bytes from non-blocking fd @p fd
+ *        into the growable buffer described by @p buf/@p len/@p cap,
+ *        stopping at EAGAIN, EOF, or a hard read error.
+ *
+ * Once @p len reaches @p max_bytes, continues reading (and discarding) so
+ * the child is never blocked on a full pipe, without growing the buffer
+ * further. Sets `*eof_flag` on EOF or a hard error.
+ *
+ * @param fd        Non-blocking pipe fd to read from.
+ * @param buf       In/out pointer to the (possibly reallocated) buffer.
+ * @param len       In/out number of valid bytes in `*buf`.
+ * @param cap       In/out allocated capacity of `*buf`.
+ * @param max_bytes Cap on retained bytes (0 means unlimited).
+ * @param eof_flag  In/out EOF flag for this fd.
+ * @return Nonzero if any bytes were read (retained or discarded) this
+ *         call, 0 otherwise.
+ */
 static int drain_fd_nonblocking(int fd,
                                 char** buf, size_t* len, size_t* cap,
                                 size_t max_bytes,
@@ -1124,6 +1363,14 @@ static int drain_fd_nonblocking(int fd,
  * `nonblock_set`); drain_proc_pipes therefore runs in the hot path without
  * any per-iteration fcntl() cost. The earlier version re-tested every
  * iteration which turned out to dominate the 20-call loop benchmark. */
+/**
+ * @brief Opportunistically drain both @p proc's stdout and stderr pipes
+ *        (up to @p max_per_stream bytes each) into their accumulation
+ *        buffers.
+ *
+ * Called repeatedly from qllm_process_wait's event loop so a chatty child
+ * never blocks on a full pipe while the parent waits for it to exit.
+ */
 static void drain_proc_pipes(eshkol_subprocess_t* proc, size_t max_per_stream) {
     if (!proc) return;
     drain_fd_nonblocking(proc->stdout_fd,
@@ -1135,6 +1382,12 @@ static void drain_proc_pipes(eshkol_subprocess_t* proc, size_t max_per_stream) {
 }
 
 /* Set both stdout/stderr pipe fds to O_NONBLOCK. Call once at spawn. */
+/**
+ * @brief Put @p proc's stdout and stderr pipe fds into O_NONBLOCK mode.
+ *
+ * Called once at spawn time so later drain/read paths never pay a
+ * per-iteration fcntl() cost.
+ */
 static void set_pipes_nonblocking(eshkol_subprocess_t* proc) {
     if (!proc) return;
     for (int which = 0; which < 2; which++) {
@@ -1152,6 +1405,13 @@ static void set_pipes_nonblocking(eshkol_subprocess_t* proc) {
  * EAGAIN. The fd goes back to non-blocking after the drain thread
  * exits, so callers observing pipes post-wait still see the
  * non-blocking behaviour the older drain-in-wait path relied on. */
+/**
+ * @brief Re-enable blocking mode on @p fd.
+ *
+ * Used by the pthread drain path so a helper thread's read() can sleep
+ * waiting for bytes instead of spinning on EAGAIN; the fd is expected to
+ * go back to non-blocking afterward via set_pipes_nonblocking-style logic.
+ */
 static void set_fd_blocking(int fd) {
     if (fd < 0) return;
     int f = fcntl(fd, F_GETFL);
@@ -1178,6 +1438,18 @@ typedef struct {
     int* eof_flag;
 } drain_thread_arg_t;
 
+/**
+ * @brief Pthread entry point that blockingly reads from one pipe fd into
+ *        a growable buffer until EOF, for the Linux/non-kqueue fallback
+ *        drain path of qllm_process_wait.
+ *
+ * @p vp is a drain_thread_arg_t*. Sets the fd to blocking mode first, then
+ * loops on read(), growing `*buf` as needed (dropping bytes past
+ * `max_bytes` once reached) until read() returns 0 (EOF) or a non-EINTR
+ * error, setting `*eof_flag` accordingly.
+ *
+ * @return Always NULL.
+ */
 static void* drain_thread_fn(void* vp) {
     drain_thread_arg_t* a = (drain_thread_arg_t*)vp;
     if (!a || a->fd < 0) return NULL;
@@ -1225,6 +1497,13 @@ static void* drain_thread_fn(void* vp) {
  * Process Status
  * ═══════════════════════════════════════════════════════════════════ */
 
+/**
+ * @brief Non-blocking check of whether @p proc's child has exited, updating
+ *        `proc->exited` / `proc->exit_code` if so.
+ *
+ * Uses waitpid(..., WNOHANG) on POSIX and GetExitCodeProcess on Windows.
+ * No-op if @p proc is NULL or already marked exited.
+ */
 static void check_exit_status(eshkol_subprocess_t* proc) {
     if (!proc || proc->exited) return;
 #ifndef _WIN32
@@ -1260,6 +1539,23 @@ static void check_exit_status(eshkol_subprocess_t* proc) {
  *
  * This implementation ALSO drains stdout/stderr pipes while waiting so a
  * chatty child (> ~64 KB output) doesn't deadlock blocking on write.
+ */
+/**
+ * @brief Wait for @p proc's child to exit, up to @p timeout_ms
+ *        milliseconds, while draining its stdout/stderr pipes so a chatty
+ *        child never deadlocks on a full pipe.
+ *
+ * On macOS/FreeBSD, uses a single kqueue with EVFILT_PROC (NOTE_EXIT) and
+ * EVFILT_READ on both pipes so one syscall wakes on exit or new output. On
+ * other POSIX platforms, falls back to one blocking-read pthread per pipe
+ * (drain_thread_fn) alongside a SIGALRM-based waitpid timeout. On Windows,
+ * uses WaitForSingleObject.
+ *
+ * @param timeout_ms Milliseconds to wait, or a negative value to block
+ *                   indefinitely.
+ * @return 0 if the child exited (read the code via
+ *         qllm_process_exit_code), 1 if @p timeout_ms elapsed first, or -1
+ *         on error (NULL @p proc, waitpid failure, kqueue setup failure).
  */
 int32_t qllm_process_wait(eshkol_subprocess_t* proc, int32_t timeout_ms) {
     if (!proc) return -1;
@@ -1459,12 +1755,26 @@ int32_t qllm_process_wait(eshkol_subprocess_t* proc, int32_t timeout_ms) {
 #endif
 }
 
+/**
+ * @brief Report whether @p proc's child is still running.
+ *
+ * Refreshes exit status via check_exit_status() first.
+ * @return 1 if still running (or @p proc has no recorded exit yet), 0 if
+ *         it has exited or @p proc is NULL.
+ */
 int32_t qllm_process_running(eshkol_subprocess_t* proc) {
     if (!proc) return 0;
     check_exit_status(proc);
     return !proc->exited;
 }
 
+/**
+ * @brief Return @p proc's child exit code, refreshing exit status first.
+ *
+ * @return The child's exit code (128+signal if it was signaled), -1 if
+ *         @p proc is NULL, or the still-pending sentinel if it hasn't
+ *         exited yet.
+ */
 int32_t qllm_process_exit_code(eshkol_subprocess_t* proc) {
     if (!proc) return -1;
     check_exit_status(proc);
@@ -1475,6 +1785,13 @@ int32_t qllm_process_exit_code(eshkol_subprocess_t* proc) {
  * Process Kill / Destroy
  * ═══════════════════════════════════════════════════════════════════ */
 
+/**
+ * @brief Send @p signal to @p proc's child process.
+ *
+ * On POSIX this is kill((pid_t)proc->pid, signal); on Windows @p signal is
+ * ignored and TerminateProcess is used unconditionally. No-op if @p proc
+ * is NULL.
+ */
 void qllm_process_kill(eshkol_subprocess_t* proc, int32_t signal) {
     if (!proc) return;
 #ifndef _WIN32
@@ -1494,11 +1811,34 @@ void qllm_process_kill(eshkol_subprocess_t* proc, int32_t signal) {
  * across log streams, and (d) emitting WARN if a stale handle outlives
  * its OS process. Without an accessor, callers were either parsing
  * the proc handle pointer (meaningless) or rolling a synthetic ID. */
+/**
+ * @brief Return the OS process identity (PID / dwProcessId) of @p proc's
+ *        child.
+ *
+ * Exists so callers can build child-aware trace IDs, support external
+ * observability (pgrep, top), correlate log streams, and detect a stale
+ * handle whose OS process has already gone away.
+ *
+ * @return The child's PID (always > 0 for a live OS process), or 0 if
+ *         @p proc is NULL.
+ */
 int64_t qllm_process_pid(eshkol_subprocess_t* proc) {
     if (!proc) return 0;
     return proc->pid;
 }
 
+/**
+ * @brief Tear down @p proc: terminate the child if still running, close
+ *        all pipe fds/handles, free accumulated drain buffers, and free
+ *        the handle itself.
+ *
+ * On POSIX, a still-running child is first sent SIGTERM and given up to
+ * ~500ms (50 * 10ms polls) to exit gracefully before SIGKILL is used to
+ * force it. On Windows, a still-active process is terminated via
+ * TerminateProcess with a 5-second wait. process-destroy is a hard cleanup
+ * boundary; callers wanting a graceful shutdown should signal/wait
+ * explicitly beforehand. No-op if @p proc is NULL.
+ */
 void qllm_process_destroy(eshkol_subprocess_t* proc) {
     if (!proc) return;
 #ifndef _WIN32

--- a/lib/agent/c/agent_tensor_io.c
+++ b/lib/agent/c/agent_tensor_io.c
@@ -36,6 +36,20 @@ typedef struct {
     uint32_t reserved;
 } EshtHeader;
 
+/**
+ * @brief Writes tensor data and shape to a binary file in the ESHT v1 format.
+ *
+ * Validates that @p total matches the product of @p shape before writing the
+ * fixed EshtHeader, the shape array, and the raw float64 data in sequence.
+ *
+ * @param data Contiguous row-major float64 array of @p total elements.
+ * @param shape Array of @p ndim dimension sizes.
+ * @param ndim Number of dimensions (1-32).
+ * @param total Total element count; must equal the product of @p shape.
+ * @param path Output file path (overwritten if it exists).
+ * @return 0 on success, -1 on invalid arguments, a shape/total mismatch, or
+ *         a file I/O error.
+ */
 /*
  * Save tensor data to a binary file.
  *
@@ -82,6 +96,23 @@ fail:
     return -1;
 }
 
+/**
+ * @brief Reads a tensor previously written by eshkol_tensor_save() from a
+ * binary ESHT v1 file.
+ *
+ * Validates the file's magic/version header and each shape dimension
+ * (rejecting non-positive dimensions), then mallocs a buffer for the data
+ * and reads it in.
+ *
+ * @param path Input file path.
+ * @param data_out Receives a malloc'd float64 array; caller must free it via
+ *        eshkol_tensor_free_loaded(). Set to NULL on failure.
+ * @param shape_out Caller-allocated array of at least 32 int64_t; receives
+ *        the tensor's per-dimension sizes.
+ * @param ndim_out Receives the number of dimensions.
+ * @param total_out Receives the total element count (product of shape).
+ * @return 0 on success, -1 on invalid arguments, missing/corrupt file, or OOM.
+ */
 /*
  * Load tensor data from a binary file.
  *
@@ -141,6 +172,11 @@ fail:
     return -1;
 }
 
+/**
+ * @brief Frees a float64 buffer previously returned by eshkol_tensor_load().
+ *
+ * @param data Buffer to free (NULL is safely ignored, as with free()).
+ */
 /*
  * Free tensor data allocated by eshkol_tensor_load.
  */
@@ -148,6 +184,22 @@ void eshkol_tensor_free_loaded(double* data) {
     free(data);
 }
 
+/**
+ * @brief Reads an ESHT file's header and shape without loading its tensor data.
+ *
+ * Validates the magic/version header, then optionally reads the shape array
+ * and computes the total element count, without ever reading the (much
+ * larger) data payload.
+ *
+ * @param path Input file path.
+ * @param ndim_out Receives the number of dimensions.
+ * @param shape_out Optional caller-allocated array receiving per-dimension
+ *        sizes; pass NULL to skip reading the shape.
+ * @param total_out Optional pointer receiving the total element count
+ *        (only computed if @p shape_out is also non-NULL).
+ * @return 0 on success, -1 on invalid arguments, missing file, or a bad/
+ *         mismatched header.
+ */
 /*
  * Get tensor file metadata without loading data.
  *

--- a/lib/agent/c/agent_terminal.c
+++ b/lib/agent/c/agent_terminal.c
@@ -56,6 +56,14 @@ static int g_cursor_cache_row = 0;
 static int g_cursor_cache_col = 0;
 
 /* SIGWINCH handler */
+/**
+ * @brief SIGWINCH signal handler: flags a pending resize and refreshes the cached terminal dimensions.
+ *
+ * Queries TIOCGWINSZ directly and updates g_term_width/g_term_height
+ * from within the handler.
+ *
+ * @param sig Unused (the signal number).
+ */
 static void sigwinch_handler(int sig) {
     (void)sig;
     g_resized = 1;
@@ -67,6 +75,12 @@ static void sigwinch_handler(int sig) {
 }
 
 /* Restore terminal on exit */
+/**
+ * @brief Restores the terminal's original termios settings and shows the cursor, if raw mode is active.
+ *
+ * Registered via atexit() in eshkol_term_init() so the terminal is
+ * always left in a sane state when the process exits.
+ */
 static void restore_terminal(void) {
     if (g_raw_mode) {
         tcsetattr(STDIN_FILENO, TCSAFLUSH, &g_orig_termios);
@@ -80,6 +94,16 @@ static void restore_terminal(void) {
  * Public API
  ******************************************************************************/
 
+/**
+ * @brief Initializes terminal state for the agent TUI.
+ *
+ * Captures the current termios settings (so they can be restored
+ * later), registers restore_terminal() via atexit(), queries the
+ * initial terminal dimensions, and installs a SIGWINCH handler to
+ * track resizes.
+ *
+ * @return 1 on success, 0 if the current termios could not be read (e.g. stdin is not a TTY).
+ */
 int eshkol_term_init(void) {
     /* Save original termios */
     if (tcgetattr(STDIN_FILENO, &g_orig_termios) != 0) return 0;
@@ -101,10 +125,24 @@ int eshkol_term_init(void) {
     return 1;
 }
 
+/**
+ * @brief Restores the terminal to its original (cooked) mode.
+ *
+ * Thin wrapper around restore_terminal(); safe to call even if raw
+ * mode was never entered.
+ */
 void eshkol_term_shutdown(void) {
     restore_terminal();
 }
 
+/**
+ * @brief Switches the terminal into raw mode for direct key-by-key input.
+ *
+ * Disables canonical processing, echo, signal generation, and various
+ * input/output translations, and configures a 100ms read timeout
+ * (VMIN=0, VTIME=1) instead of blocking indefinitely. No-op if raw
+ * mode is already active.
+ */
 void eshkol_term_raw_mode(void) {
     if (g_raw_mode) return;
     struct termios raw = g_orig_termios;
@@ -118,25 +156,59 @@ void eshkol_term_raw_mode(void) {
     g_raw_mode = 1;
 }
 
+/**
+ * @brief Restores the terminal's original termios settings, leaving raw mode.
+ *
+ * No-op if the terminal is not currently in raw mode.
+ */
 void eshkol_term_cooked_mode(void) {
     if (!g_raw_mode) return;
     tcsetattr(STDIN_FILENO, TCSAFLUSH, &g_orig_termios);
     g_raw_mode = 0;
 }
 
+/** @brief Returns the last known terminal width in columns. */
 int eshkol_term_width(void)  { return g_term_width;  }
+/** @brief Returns the last known terminal height in rows. */
 int eshkol_term_height(void) { return g_term_height; }
 
+/**
+ * @brief Checks and clears the pending-resize flag set by the SIGWINCH handler.
+ *
+ * @return 1 if a resize occurred since the last call, 0 otherwise.
+ */
 int eshkol_term_resized(void) {
     int r = g_resized;
     g_resized = 0;
     return r;
 }
 
+/**
+ * @brief Reads a single key from stdin, blocking indefinitely until one is available.
+ *
+ * Thin wrapper around eshkol_term_read_key_timeout() with an infinite timeout.
+ */
 int eshkol_term_read_key(void) {
     return eshkol_term_read_key_timeout(-1);
 }
 
+/**
+ * @brief Reads and decodes a single key press from stdin, with an optional timeout.
+ *
+ * Recognizes control characters (Ctrl+A..Ctrl+Z), Tab, Enter,
+ * Backspace, and multi-byte ANSI escape sequences (arrow keys,
+ * Home/End, Delete, Page Up/Down, and F1-F4 in both `ESC [` and
+ * `ESC O` forms), decoding them into the KEY_* constants defined
+ * above. Continuation bytes of an escape sequence are read with a
+ * short 50ms poll so a bare Escape key press (no follow-up bytes) is
+ * still reported promptly as KEY_ESCAPE. Any other byte is returned
+ * as its raw character code.
+ *
+ * @param timeout_ms Milliseconds to wait for the first byte; negative
+ *   blocks indefinitely. Escape-sequence continuation bytes use their
+ *   own fixed short timeouts regardless of this value.
+ * @return The key code (a raw byte value or a KEY_* constant), or -1 on timeout or read error.
+ */
 int eshkol_term_read_key_timeout(int timeout_ms) {
     unsigned char c;
 
@@ -225,16 +297,38 @@ int eshkol_term_read_key_timeout(int timeout_ms) {
     return (int)c;
 }
 
+/**
+ * @brief Clears the terminal screen and moves the cursor to the home position.
+ */
 void eshkol_term_clear(void) {
     write(STDOUT_FILENO, "\033[2J\033[H", 7);
 }
 
+/**
+ * @brief Moves the terminal cursor to the given 1-based row and column.
+ *
+ * @param row Target row (1-based).
+ * @param col Target column (1-based).
+ */
 void eshkol_term_move_to(int row, int col) {
     char buf[32];
     int len = snprintf(buf, sizeof(buf), "\033[%d;%dH", row, col);
     write(STDOUT_FILENO, buf, len);
 }
 
+/**
+ * @brief Queries the terminal for the cursor's current row and column via a DSR escape sequence.
+ *
+ * Temporarily switches stdin to non-canonical, non-echoing mode (if
+ * possible), sends the Device Status Report request (`ESC [6n`), and
+ * parses the terminal's `ESC [row;colR` reply, polling up to 100ms
+ * per byte read. Requires both stdin and stdout to be TTYs. On any
+ * failure, @p row and @p col are set to 0.
+ *
+ * @param row Out-parameter for the 1-based cursor row.
+ * @param col Out-parameter for the 1-based cursor column.
+ * @return 1 on success, 0 if not a TTY, the write failed, or the reply could not be parsed.
+ */
 int eshkol_term_cursor_pos(int* row, int* col) {
     if (row) *row = 0;
     if (col) *col = 0;
@@ -277,6 +371,11 @@ int eshkol_term_cursor_pos(int* row, int* col) {
     return ok;
 }
 
+/**
+ * @brief Refreshes the cached cursor position by querying the terminal.
+ *
+ * Updates g_cursor_cache_row/col/ok via eshkol_term_cursor_pos() and marks the cache as ready.
+ */
 static void eshkol_term_refresh_cursor_cache(void) {
     g_cursor_cache_row = 0;
     g_cursor_cache_col = 0;
@@ -284,11 +383,29 @@ static void eshkol_term_refresh_cursor_cache(void) {
     g_cursor_cache_ready = 1;
 }
 
+/**
+ * @brief Returns the terminal's current cursor row, always re-querying the terminal.
+ *
+ * Also refreshes the cursor cache so an immediately following call to
+ * eshkol_term_cursor_col() can reuse the result instead of issuing a
+ * second DSR round-trip.
+ *
+ * @return The 1-based cursor row, or 0 if the query failed.
+ */
 int eshkol_term_cursor_row(void) {
     eshkol_term_refresh_cursor_cache();
     return g_cursor_cache_ok ? g_cursor_cache_row : 0;
 }
 
+/**
+ * @brief Returns the terminal's current cursor column.
+ *
+ * Reuses a cached cursor query if one was just populated by
+ * eshkol_term_cursor_row(); otherwise queries the terminal directly.
+ * The cache is marked stale after this call either way.
+ *
+ * @return The 1-based cursor column, or 0 if the query failed.
+ */
 int eshkol_term_cursor_col(void) {
     if (!g_cursor_cache_ready) eshkol_term_refresh_cursor_cache();
     int col = g_cursor_cache_ok ? g_cursor_cache_col : 0;
@@ -296,23 +413,37 @@ int eshkol_term_cursor_col(void) {
     return col;
 }
 
+/** @brief Makes the terminal cursor visible. */
 void eshkol_term_show_cursor(void) {
     write(STDOUT_FILENO, "\033[?25h", 6);
 }
 
+/** @brief Hides the terminal cursor. */
 void eshkol_term_hide_cursor(void) {
     write(STDOUT_FILENO, "\033[?25l", 6);
 }
 
+/**
+ * @brief Writes a raw string directly to stdout via write(2), bypassing stdio buffering.
+ *
+ * @param str NUL-terminated string to write; NULL is a no-op.
+ */
 void eshkol_term_write(const char* str) {
     if (str) write(STDOUT_FILENO, str, strlen(str));
 }
 
+/** @brief Flushes stdio's output buffer for stdout. */
 void eshkol_term_flush(void) {
     /* stdout is line-buffered or fully-buffered; fsync the fd */
     fflush(stdout);
 }
 
+/**
+ * @brief Sets the terminal window/tab title via an OSC 0 escape sequence.
+ *
+ * @param title NUL-terminated title string; NULL is a no-op. Silently
+ *   truncated if it would overflow the internal 256-byte buffer.
+ */
 void eshkol_term_set_title(const char* title) {
     if (!title) return;
     char buf[256];
@@ -328,28 +459,53 @@ void eshkol_term_set_title(const char* title) {
  * agent FFI library still compiles. Calls succeed silently or return
  * default values; (eshkol_term_init) returns -1 to signal "not available". */
 
+/** @brief Windows stub: terminal control is not yet implemented; always reports unavailable. */
 int eshkol_term_init(void)            { return -1; }
+/** @brief Windows stub: no-op (nothing to restore). */
 void eshkol_term_shutdown(void)       { }
+/** @brief Windows stub: no-op (raw mode not implemented). */
 void eshkol_term_raw_mode(void)       { }
+/** @brief Windows stub: no-op. */
 void eshkol_term_cooked_mode(void)    { }
+/** @brief Windows stub: always returns a fixed width of 80 columns. */
 int eshkol_term_width(void)           { return 80; }
+/** @brief Windows stub: always returns a fixed height of 24 rows. */
 int eshkol_term_height(void)          { return 24; }
+/** @brief Windows stub: always reports no resize occurred. */
 int eshkol_term_resized(void)         { return 0; }
+/** @brief Windows stub: always reports no key available. */
 int eshkol_term_read_key(void)        { return -1; }
+/** @brief Windows stub: ignores @p timeout_ms and always reports no key available. */
 int eshkol_term_read_key_timeout(int timeout_ms) { (void)timeout_ms; return -1; }
+/** @brief Windows stub: no-op. */
 void eshkol_term_clear(void)          { }
+/** @brief Windows stub: no-op; ignores @p row and @p col. */
 void eshkol_term_move_to(int row, int col) { (void)row; (void)col; }
+/**
+ * @brief Windows stub: cursor position query is not implemented.
+ *
+ * @param row Out-parameter set to 0 if non-NULL.
+ * @param col Out-parameter set to 0 if non-NULL.
+ * @return -1 (unavailable).
+ */
 int eshkol_term_cursor_pos(int* row, int* col) {
     if (row) *row = 0;
     if (col) *col = 0;
     return -1;
 }
+/** @brief Windows stub: always returns row 0. */
 int eshkol_term_cursor_row(void)      { return 0; }
+/** @brief Windows stub: always returns column 0. */
 int eshkol_term_cursor_col(void)      { return 0; }
+/** @brief Windows stub: no-op. */
 void eshkol_term_show_cursor(void)    { }
+/** @brief Windows stub: no-op. */
 void eshkol_term_hide_cursor(void)    { }
+/** @brief Windows stub: writes @p s to stdout via fputs(), unlike the POSIX raw write(2) version. */
 void eshkol_term_write(const char* s) { if (s) fputs(s, stdout); }
+/** @brief Flushes stdio's output buffer for stdout. */
 void eshkol_term_flush(void)          { fflush(stdout); }
+/** @brief Windows stub: no-op; ignores @p title (window title not implemented). */
 void eshkol_term_set_title(const char* title) { (void)title; }
 
 #endif /* _WIN32 */

--- a/lib/agent/c/agent_treesitter.c
+++ b/lib/agent/c/agent_treesitter.c
@@ -77,6 +77,12 @@ static const LangEntry g_languages[] = {
     { NULL, NULL }
 };
 
+/**
+ * @brief Looks up the tree-sitter grammar factory registered under @p name in g_languages.
+ *
+ * @param name Language name or short alias (e.g. "javascript"/"js", "python"/"py").
+ * @return The matching TSLanguage, or NULL if @p name is not registered.
+ */
 static const TSLanguage* find_language(const char* name) {
     for (const LangEntry* e = g_languages; e->name; e++) {
         if (strcmp(e->name, name) == 0) return e->factory();
@@ -99,6 +105,13 @@ static uint32_t g_tree_source_lens[MAX_TREES] = {0};
 static TSQuery*  g_queries[MAX_QUERIES] = {0};
 static const TSLanguage* g_query_langs[MAX_QUERIES] = {0};
 
+/**
+ * @brief Finds the first NULL (free) entry in a fixed-size handle table, skipping index 0 so handle 0 is never valid.
+ *
+ * @param table Array of @p max opaque pointers, one per handle slot.
+ * @param max Number of entries in @p table.
+ * @return Index of a free slot (>= 1), or -1 if the table is full.
+ */
 static int alloc_slot(void** table, int max) {
     for (int i = 1; i < max; i++) {
         if (!table[i]) return i;
@@ -117,6 +130,12 @@ static int alloc_slot(void** table, int max) {
  *           "ruby", "bash", "typescript" (and short aliases "js", "py", etc.)
  *
  * Returns: parser handle (>= 1), -1 if language unknown or slots full
+ */
+/**
+ * @brief Creates a tree-sitter parser configured for @p language and stores it in the parser handle table.
+ *
+ * @param language Language name or short alias, as accepted by find_language() (e.g. "javascript", "js", "python", "rust", "go", "c", "cpp", "java", "ruby", "bash").
+ * @return Parser handle (>= 1) on success, -1 if @p language is unknown, the parser slot table is full, or allocation fails.
  */
 int64_t eshkol_ts_parser_new(const char* language) {
     if (!language) return -1;
@@ -138,6 +157,11 @@ int64_t eshkol_ts_parser_new(const char* language) {
 
 /*
  * Free a parser and its slot.
+ */
+/**
+ * @brief Deletes the parser at @p handle and clears its slot.
+ *
+ * @param handle Parser handle from eshkol_ts_parser_new(). No-op if out of range or already freed.
  */
 void eshkol_ts_parser_free(int64_t handle) {
     if (handle < 1 || handle >= MAX_PARSERS) return;
@@ -163,6 +187,14 @@ void eshkol_ts_parser_free(int64_t handle) {
  * The source string is NOT copied — caller must keep it alive while the
  * tree is in use. The handle stores a reference to it.
  */
+/**
+ * @brief Parses @p source with the parser at @p parser_handle and stores the resulting syntax tree in the tree handle table.
+ *
+ * @param parser_handle Parser handle from eshkol_ts_parser_new().
+ * @param source Source code bytes; need not be NUL-terminated. Not copied — must remain valid for the lifetime of the returned tree handle, since node-text extraction reads directly from it.
+ * @param source_len Length of @p source in bytes.
+ * @return Tree handle (>= 1) on success, -1 on invalid handle/arguments, parse failure, or if the tree slot table is full.
+ */
 int64_t eshkol_ts_parse(int64_t parser_handle, const char* source, int32_t source_len) {
     if (parser_handle < 1 || parser_handle >= MAX_PARSERS) return -1;
     TSParser* parser = g_parsers[parser_handle];
@@ -182,6 +214,11 @@ int64_t eshkol_ts_parse(int64_t parser_handle, const char* source, int32_t sourc
 /*
  * Free a tree and its slot.
  */
+/**
+ * @brief Deletes the tree at @p handle and clears its slot, including the stored source-text reference.
+ *
+ * @param handle Tree handle from eshkol_ts_parse(). No-op if out of range or already freed.
+ */
 void eshkol_ts_tree_free(int64_t handle) {
     if (handle < 1 || handle >= MAX_TREES) return;
     if (g_trees[handle]) {
@@ -199,6 +236,16 @@ void eshkol_ts_tree_free(int64_t handle) {
  *   "type\tstart_row\tstart_col\tend_row\tend_col\tstart_byte\tend_byte\tchild_count\tnamed"
  ******************************************************************************/
 
+/**
+ * @brief Serializes a single TSNode's type, position, byte range, and child count into a tab-separated line.
+ *
+ * Output format: "type\tstart_row\tstart_col\tend_row\tend_col\tstart_byte\tend_byte\tchild_count\tnamed".
+ *
+ * @param node Node to serialize.
+ * @param buf Destination buffer.
+ * @param buf_size Size of @p buf.
+ * @return Value from snprintf(): the number of characters that would have been written (excluding the NUL), which may exceed @p buf_size if truncated.
+ */
 static int serialize_node(TSNode node, char* buf, int buf_size) {
     const char* type = ts_node_type(node);
     TSPoint start = ts_node_start_point(node);
@@ -226,6 +273,14 @@ static int serialize_node(TSNode node, char* buf, int buf_size) {
  *
  * Returns: strlen written to buf, -1 error
  */
+/**
+ * @brief Serializes the root node of tree @p tree_handle into @p buf via serialize_node().
+ *
+ * @param tree_handle Tree handle from eshkol_ts_parse().
+ * @param buf Destination buffer for the serialized node.
+ * @param buf_size Size of @p buf.
+ * @return Number of bytes written to @p buf, or -1 on invalid handle/arguments or if the serialized node would not fit.
+ */
 int32_t eshkol_ts_tree_root(int64_t tree_handle, char* buf, int32_t buf_size) {
     if (tree_handle < 1 || tree_handle >= MAX_TREES) return -1;
     TSTree* tree = g_trees[tree_handle];
@@ -247,6 +302,23 @@ int32_t eshkol_ts_tree_root(int64_t tree_handle, char* buf, int32_t buf_size) {
  * count_out receives the number of children.
  *
  * Returns: total bytes written to buf, -1 error
+ */
+/**
+ * @brief Serializes the named children of the root node, or of the smallest named node containing [@p start_byte, @p end_byte), as NUL-separated records in @p buf.
+ *
+ * When @p start_byte and @p end_byte are both 0, the children of the tree
+ * root are returned. Otherwise the smallest named descendant covering that
+ * byte range is located first (via
+ * ts_node_named_descendant_for_byte_range()) and its named children are
+ * returned instead.
+ *
+ * @param tree_handle Tree handle from eshkol_ts_parse().
+ * @param start_byte Start of the byte range identifying the target node, or 0 with @p end_byte 0 for the root.
+ * @param end_byte End of the byte range identifying the target node, or 0 with @p start_byte 0 for the root.
+ * @param buf Destination buffer for NUL-separated serialized child nodes.
+ * @param buf_size Size of @p buf.
+ * @param count_out Output: number of children written.
+ * @return Total bytes written to @p buf, or -1 on invalid handle/arguments.
  */
 int32_t eshkol_ts_node_children(int64_t tree_handle,
                                   uint32_t start_byte, uint32_t end_byte,
@@ -293,6 +365,16 @@ int32_t eshkol_ts_node_children(int64_t tree_handle,
  *
  * Returns: strlen of extracted text, -1 error
  */
+/**
+ * @brief Copies the source text spanning [@p start_byte, @p end_byte) of tree @p tree_handle's original source into @p buf.
+ *
+ * @param tree_handle Tree handle from eshkol_ts_parse(); its stored source pointer/length are used.
+ * @param start_byte Start byte offset (inclusive).
+ * @param end_byte End byte offset (exclusive); must be > @p start_byte and within the source length.
+ * @param buf Destination buffer, truncated to @p buf_size - 1 bytes if the range is longer.
+ * @param buf_size Size of @p buf.
+ * @return Number of bytes written to @p buf, or -1 on invalid handle/arguments or an out-of-range/empty byte range.
+ */
 int32_t eshkol_ts_node_text(int64_t tree_handle, uint32_t start_byte,
                               uint32_t end_byte, char* buf, int32_t buf_size) {
     if (tree_handle < 1 || tree_handle >= MAX_TREES) return -1;
@@ -323,6 +405,13 @@ int32_t eshkol_ts_node_text(int64_t tree_handle, uint32_t start_byte,
  *
  * Returns: query handle (>= 1), -1 on error
  */
+/**
+ * @brief Compiles a tree-sitter S-expression @p pattern for @p language and stores it in the query handle table.
+ *
+ * @param language Language name or alias the pattern is written against; must match the language used to parse any tree the query is later run on.
+ * @param pattern Tree-sitter query pattern, e.g. "(function_declaration name: (identifier) @name)".
+ * @return Query handle (>= 1) on success, -1 if @p language is unknown, @p pattern fails to compile, or the query slot table is full.
+ */
 int64_t eshkol_ts_query_new(const char* language, const char* pattern) {
     if (!language || !pattern) return -1;
     const TSLanguage* lang = find_language(language);
@@ -344,6 +433,11 @@ int64_t eshkol_ts_query_new(const char* language, const char* pattern) {
 /*
  * Free a query.
  */
+/**
+ * @brief Deletes the query at @p handle and clears its slot.
+ *
+ * @param handle Query handle from eshkol_ts_query_new(). No-op if out of range or already freed.
+ */
 void eshkol_ts_query_free(int64_t handle) {
     if (handle < 1 || handle >= MAX_QUERIES) return;
     if (g_queries[handle]) {
@@ -364,6 +458,22 @@ void eshkol_ts_query_free(int64_t handle) {
  * count_out: receives number of captures written
  *
  * Returns: total bytes written to buf, -1 error
+ */
+/**
+ * @brief Runs query @p query_handle against tree @p tree_handle and serializes each capture as a NUL-separated record in @p buf.
+ *
+ * Each capture is written as
+ * "capture_name\tstart_byte\tend_byte\tstart_row\tstart_col\tend_row\tend_col".
+ * Iterates matches via a fresh TSQueryCursor until either @p max_matches
+ * matches have been processed or @p buf is full.
+ *
+ * @param query_handle Query handle from eshkol_ts_query_new().
+ * @param tree_handle Tree handle from eshkol_ts_parse(); must have been parsed with the same language as the query.
+ * @param max_matches Maximum number of matches to process, or 0 for effectively unlimited (bounded only by @p buf capacity).
+ * @param buf Destination buffer for NUL-separated capture records.
+ * @param buf_size Size of @p buf.
+ * @param count_out Output: number of captures written.
+ * @return Total bytes written to @p buf, or -1 on invalid handle/arguments.
  */
 int32_t eshkol_ts_query_matches(int64_t query_handle, int64_t tree_handle,
                                   int32_t max_matches,
@@ -424,6 +534,14 @@ done:
  *
  * Returns: strlen, -1 error
  */
+/**
+ * @brief Renders the S-expression form of tree @p tree_handle's root node (via ts_node_string()) into @p buf, for debugging.
+ *
+ * @param tree_handle Tree handle from eshkol_ts_parse().
+ * @param buf Destination buffer, truncated to @p buf_size - 1 bytes if the S-expression is longer.
+ * @param buf_size Size of @p buf.
+ * @return Number of bytes written to @p buf, or -1 on invalid handle/arguments or allocation failure.
+ */
 int32_t eshkol_ts_tree_sexp(int64_t tree_handle, char* buf, int32_t buf_size) {
     if (tree_handle < 1 || tree_handle >= MAX_TREES) return -1;
     TSTree* tree = g_trees[tree_handle];
@@ -445,6 +563,11 @@ int32_t eshkol_ts_tree_sexp(int64_t tree_handle, char* buf, int32_t buf_size) {
  * Check if tree-sitter is available.
  * Returns: 1 (compiled with tree-sitter support)
  */
+/**
+ * @brief Reports whether this build was compiled with tree-sitter support.
+ *
+ * @return 1 when compiled with HAS_TREE_SITTER (this definition).
+ */
 int32_t eshkol_ts_available(void) { return 1; }
 
 #else /* !HAS_TREE_SITTER */
@@ -453,23 +576,38 @@ int32_t eshkol_ts_available(void) { return 1; }
  * Graceful stubs when tree-sitter is not available
  ******************************************************************************/
 
+/** @brief Stub: tree-sitter support was not compiled in, so parser creation always fails. */
 int64_t eshkol_ts_parser_new(const char* language) { (void)language; return -1; }
+/** @brief Stub: no-op since no parsers exist without tree-sitter support. */
 void    eshkol_ts_parser_free(int64_t h) { (void)h; }
+/** @brief Stub: tree-sitter support was not compiled in, so parsing always fails. */
 int64_t eshkol_ts_parse(int64_t p, const char* s, int32_t l) { (void)p;(void)s;(void)l; return -1; }
+/** @brief Stub: no-op since no trees exist without tree-sitter support. */
 void    eshkol_ts_tree_free(int64_t h) { (void)h; }
+/** @brief Stub: always fails since no trees exist without tree-sitter support. */
 int32_t eshkol_ts_tree_root(int64_t h, char* b, int32_t s) { (void)h;(void)b;(void)s; return -1; }
+/** @brief Stub: always fails since no trees exist without tree-sitter support. */
 int32_t eshkol_ts_node_children(int64_t h, uint32_t sb, uint32_t eb, char* b, int32_t bs, int32_t* c) {
     (void)h;(void)sb;(void)eb;(void)b;(void)bs;(void)c; return -1;
 }
+/** @brief Stub: always fails since no trees exist without tree-sitter support. */
 int32_t eshkol_ts_node_text(int64_t h, uint32_t sb, uint32_t eb, char* b, int32_t bs) {
     (void)h;(void)sb;(void)eb;(void)b;(void)bs; return -1;
 }
+/** @brief Stub: tree-sitter support was not compiled in, so query compilation always fails. */
 int64_t eshkol_ts_query_new(const char* l, const char* p) { (void)l;(void)p; return -1; }
+/** @brief Stub: no-op since no queries exist without tree-sitter support. */
 void    eshkol_ts_query_free(int64_t h) { (void)h; }
+/** @brief Stub: always fails since no queries or trees exist without tree-sitter support. */
 int32_t eshkol_ts_query_matches(int64_t q, int64_t t, int32_t m, char* b, int32_t bs, int32_t* c) {
     (void)q;(void)t;(void)m;(void)b;(void)bs;(void)c; return -1;
 }
+/** @brief Stub: always fails since no trees exist without tree-sitter support. */
 int32_t eshkol_ts_tree_sexp(int64_t h, char* b, int32_t s) { (void)h;(void)b;(void)s; return -1; }
+/**
+ * @brief Reports whether this build was compiled with tree-sitter support.
+ * @return 0 (this build lacks HAS_TREE_SITTER).
+ */
 int32_t eshkol_ts_available(void) { return 0; }
 
 #endif /* HAS_TREE_SITTER */

--- a/lib/agent/c/agent_watch.c
+++ b/lib/agent/c/agent_watch.c
@@ -63,6 +63,17 @@ typedef struct {
 
 static Watcher* g_watchers[MAX_WATCHERS] = {0};
 
+/**
+ * @brief Appends an event to a watcher's ring buffer of pending events.
+ *
+ * Formats @p type and @p path as "type\tpath" for later retrieval by
+ * eshkol_watch_poll(). If the buffer is full, the new event is silently
+ * dropped (oldest events are kept, not overwritten).
+ *
+ * @param w Watcher whose event ring buffer is appended to.
+ * @param type Event type string (e.g. "change", "create", "delete", "rename").
+ * @param path Path the event pertains to.
+ */
 static void push_event(Watcher* w, const char* type, const char* path) {
     if (w->event_count >= MAX_EVENTS) return;  /* Drop oldest */
     snprintf(w->events[w->event_head], sizeof(w->events[0]),
@@ -73,6 +84,16 @@ static void push_event(Watcher* w, const char* type, const char* path) {
 
 #ifdef USE_KQUEUE
 
+/**
+ * @brief Opens @p path and registers a kqueue EVFILT_VNODE watch on it.
+ *
+ * Watches for write, delete, rename, and attribute-change events with
+ * EV_CLEAR (edge-triggered) semantics, and records the opened fd/path in the
+ * watcher's entry table for later lookup and cleanup.
+ *
+ * @param w Watcher to add the entry to.
+ * @param path Filesystem path to watch.
+ */
 static void add_kqueue_watch(Watcher* w, const char* path) {
     if (w->n_entries >= MAX_WATCH_FDS) return;
     int fd = open(path, O_RDONLY | O_EVTONLY);
@@ -91,6 +112,15 @@ static void add_kqueue_watch(Watcher* w, const char* path) {
     e->wd = fd;
 }
 
+/**
+ * @brief Recursively registers kqueue watches on @p path and every subdirectory beneath it.
+ *
+ * Skips dotfiles/dot-directories. Each subdirectory found via readdir() is
+ * watched via add_kqueue_watch() and then recursed into.
+ *
+ * @param w Watcher to add entries to.
+ * @param path Root directory path to watch recursively.
+ */
 static void add_recursive(Watcher* w, const char* path) {
     add_kqueue_watch(w, path);
     DIR* dir = opendir(path);
@@ -110,6 +140,15 @@ static void add_recursive(Watcher* w, const char* path) {
 
 #elif defined(USE_INOTIFY)
 
+/**
+ * @brief Registers an inotify watch on @p path for create/delete/modify/rename events.
+ *
+ * Records the returned watch descriptor and path in the watcher's entry
+ * table for later lookup and cleanup.
+ *
+ * @param w Watcher to add the entry to.
+ * @param path Filesystem path to watch.
+ */
 static void add_inotify_watch(Watcher* w, const char* path) {
     if (w->n_entries >= MAX_WATCH_FDS) return;
     int wd = inotify_add_watch(w->inotify_fd, path,
@@ -121,6 +160,15 @@ static void add_inotify_watch(Watcher* w, const char* path) {
     e->wd = wd;
 }
 
+/**
+ * @brief Recursively registers inotify watches on @p path and every subdirectory beneath it.
+ *
+ * Skips dotfiles/dot-directories. Each subdirectory found via readdir() is
+ * watched via add_inotify_watch() and then recursed into.
+ *
+ * @param w Watcher to add entries to.
+ * @param path Root directory path to watch recursively.
+ */
 static void add_recursive(Watcher* w, const char* path) {
     add_inotify_watch(w, path);
     DIR* dir = opendir(path);
@@ -140,6 +188,18 @@ static void add_recursive(Watcher* w, const char* path) {
 
 #endif
 
+/**
+ * @brief Starts watching a filesystem path for change events, returning a handle.
+ *
+ * Allocates a Watcher slot and backing OS resource (a kqueue on macOS, an
+ * inotify instance on Linux), then registers a watch on @p path — and, if
+ * @p recursive is set, on every subdirectory beneath it.
+ *
+ * @param path Filesystem path to watch.
+ * @param recursive Nonzero to also watch all subdirectories.
+ * @return Watcher handle (>= 1) on success, -1 on error or on platforms with
+ *         no supported file-watching backend.
+ */
 /*
  * Start watching a path for filesystem events.
  * recursive: 1 to watch all subdirectories
@@ -177,6 +237,20 @@ int64_t eshkol_watch_start(const char* path, int32_t recursive) {
     return (int64_t)slot;
 }
 
+/**
+ * @brief Retrieves the next pending filesystem event for a watcher, if any.
+ *
+ * Drains the watcher's internal event buffer first; if empty, does a
+ * non-blocking poll of the underlying OS mechanism (kqueue or inotify),
+ * translates any new events into "type\tpath" strings via push_event(), and
+ * returns the oldest buffered event.
+ *
+ * @param handle Watcher handle from eshkol_watch_start().
+ * @param buf Output buffer receiving "event_type\tpath", NUL-terminated.
+ * @param buf_size Size of @p buf in bytes.
+ * @return Length of the event string written to @p buf, 0 if no events are
+ *         pending, or -1 on an invalid handle/buffer.
+ */
 /*
  * Poll for filesystem events.
  *
@@ -261,6 +335,14 @@ int32_t eshkol_watch_poll(int64_t handle, char* buf, int32_t buf_size) {
     return 0;  /* No events */
 }
 
+/**
+ * @brief Stops a watcher and releases all of its OS and memory resources.
+ *
+ * Closes every per-entry fd/removes every inotify watch descriptor, closes
+ * the kqueue/inotify fd, frees the Watcher struct, and clears its handle slot.
+ *
+ * @param handle Watcher handle from eshkol_watch_start(). No-op if invalid.
+ */
 /*
  * Stop watching and free resources.
  */

--- a/lib/agent/c/agent_yoga.c
+++ b/lib/agent/c/agent_yoga.c
@@ -19,6 +19,14 @@
 
 static YGNodeRef g_nodes[MAX_YOGA_NODES] = {0};
 
+/**
+ * @brief Finds the first free slot in the @ref g_nodes handle table.
+ *
+ * Slot 0 is skipped (reserved so 0 is never a valid handle); the search
+ * starts at index 1.
+ *
+ * @return The free slot index, or -1 if the table is full.
+ */
 static int alloc_node(void) {
     for (int i = 1; i < MAX_YOGA_NODES; i++) {
         if (!g_nodes[i]) return i;
@@ -26,6 +34,13 @@ static int alloc_node(void) {
     return -1;
 }
 
+/**
+ * @brief Allocates a new Yoga layout node and returns a handle for it.
+ *
+ * @return A handle (index into @ref g_nodes) for use with the other
+ *         eshkol_yoga_node_* functions, or -1 if the node table is full or
+ *         YGNodeNew() fails.
+ */
 int64_t eshkol_yoga_node_create(void) {
     int slot = alloc_node();
     if (slot < 0) return -1;
@@ -33,12 +48,30 @@ int64_t eshkol_yoga_node_create(void) {
     return g_nodes[slot] ? (int64_t)slot : -1;
 }
 
+/**
+ * @brief Frees the Yoga node for @p handle along with its entire child subtree.
+ *
+ * No-op if @p handle is out of range or already freed.
+ */
 void eshkol_yoga_node_free(int64_t handle) {
     if (handle < 1 || handle >= MAX_YOGA_NODES || !g_nodes[handle]) return;
     YGNodeFreeRecursive(g_nodes[handle]);
     g_nodes[handle] = NULL;
 }
 
+/**
+ * @brief Sets a float-valued Yoga style property on the node for @p handle.
+ *
+ * @param prop Property selector: 0=width, 1=height, 2=min-width,
+ *        3=min-height, 4=max-width, 5=max-height, 6=flex-grow,
+ *        7=flex-shrink, 8=flex-basis, 9=gap, 10-13=padding
+ *        (left/right/top/bottom), 14-17=margin (left/right/top/bottom),
+ *        18-21=border (left/right/top/bottom). Unrecognized values are
+ *        ignored.
+ * @param value The property value, cast to float.
+ *
+ * No-op if @p handle is out of range or not currently allocated.
+ */
 /* Float properties: width, height, min/max, flex, padding, margin, border, gap */
 void eshkol_yoga_node_set_float(int64_t handle, int32_t prop, double value) {
     if (handle < 1 || handle >= MAX_YOGA_NODES || !g_nodes[handle]) return;
@@ -70,6 +103,16 @@ void eshkol_yoga_node_set_float(int64_t handle, int32_t prop, double value) {
     }
 }
 
+/**
+ * @brief Sets an enum-valued Yoga style property on the node for @p handle.
+ *
+ * @param prop Property selector: 0=flex-direction, 1=justify-content,
+ *        2=align-items, 3=align-self, 4=align-content, 5=position-type,
+ *        6=overflow, 7=display. Unrecognized values are ignored.
+ * @param value The enum value, cast to the corresponding Yoga enum type.
+ *
+ * No-op if @p handle is out of range or not currently allocated.
+ */
 /* Integer properties: flex-direction, justify, align, position, overflow, display */
 void eshkol_yoga_node_set_int(int64_t handle, int32_t prop, int32_t value) {
     if (handle < 1 || handle >= MAX_YOGA_NODES || !g_nodes[handle]) return;
@@ -86,17 +129,43 @@ void eshkol_yoga_node_set_int(int64_t handle, int32_t prop, int32_t value) {
     }
 }
 
+/**
+ * @brief Inserts the node for @p child into the node for @p parent's children at @p index.
+ *
+ * No-op if either @p parent or @p child is out of range or not currently
+ * allocated.
+ */
 void eshkol_yoga_node_add_child(int64_t parent, int64_t child, int32_t index) {
     if (parent < 1 || parent >= MAX_YOGA_NODES || !g_nodes[parent]) return;
     if (child < 1 || child >= MAX_YOGA_NODES || !g_nodes[child]) return;
     YGNodeInsertChild(g_nodes[parent], g_nodes[child], (uint32_t)index);
 }
 
+/**
+ * @brief Computes flexbox layout for the tree rooted at @p root, in left-to-right direction.
+ *
+ * After this call, computed values for @p root and its descendants can be
+ * read via eshkol_yoga_node_get_computed().
+ *
+ * @param width Available width for the root node.
+ * @param height Available height for the root node.
+ *
+ * No-op if @p root is out of range or not currently allocated.
+ */
 void eshkol_yoga_node_calculate(int64_t root, double width, double height) {
     if (root < 1 || root >= MAX_YOGA_NODES || !g_nodes[root]) return;
     YGNodeCalculateLayout(g_nodes[root], (float)width, (float)height, YGDirectionLTR);
 }
 
+/**
+ * @brief Reads a computed layout value from the node for @p handle after eshkol_yoga_node_calculate() has run.
+ *
+ * @param prop Property selector: 0=left, 1=top, 2=width, 3=height,
+ *        4-7=padding (left/top/right/bottom), 8-11=margin
+ *        (left/top/right/bottom), 12-15=border (left/top/right/bottom).
+ * @return The computed value, or 0.0 if @p handle is out of range, not
+ *         currently allocated, or @p prop is unrecognized.
+ */
 double eshkol_yoga_node_get_computed(int64_t handle, int32_t prop) {
     if (handle < 1 || handle >= MAX_YOGA_NODES || !g_nodes[handle]) return 0.0;
     YGNodeRef node = g_nodes[handle];
@@ -121,17 +190,26 @@ double eshkol_yoga_node_get_computed(int64_t handle, int32_t prop) {
     }
 }
 
+/** @brief Reports that Yoga layout support is compiled in. @return Always 1. */
 int32_t eshkol_yoga_available(void) { return 1; }
 
 #else /* !HAS_YOGA */
 
+/** @brief Stub used when built without HAS_YOGA; no node is created. @return Always -1. */
 int64_t eshkol_yoga_node_create(void) { return -1; }
+/** @brief Stub used when built without HAS_YOGA; no-op. */
 void    eshkol_yoga_node_free(int64_t h) { (void)h; }
+/** @brief Stub used when built without HAS_YOGA; no-op. */
 void    eshkol_yoga_node_set_float(int64_t h, int32_t p, double v) { (void)h;(void)p;(void)v; }
+/** @brief Stub used when built without HAS_YOGA; no-op. */
 void    eshkol_yoga_node_set_int(int64_t h, int32_t p, int32_t v) { (void)h;(void)p;(void)v; }
+/** @brief Stub used when built without HAS_YOGA; no-op. */
 void    eshkol_yoga_node_add_child(int64_t p, int64_t c, int32_t i) { (void)p;(void)c;(void)i; }
+/** @brief Stub used when built without HAS_YOGA; no-op. */
 void    eshkol_yoga_node_calculate(int64_t r, double w, double h) { (void)r;(void)w;(void)h; }
+/** @brief Stub used when built without HAS_YOGA; layout is unavailable. @return Always 0.0. */
 double  eshkol_yoga_node_get_computed(int64_t h, int32_t p) { (void)h;(void)p; return 0.0; }
+/** @brief Reports that Yoga layout support is not compiled in. @return Always 0. */
 int32_t eshkol_yoga_available(void) { return 0; }
 
 #endif

--- a/lib/frontend/macro_expander.cpp
+++ b/lib/frontend/macro_expander.cpp
@@ -13,31 +13,62 @@
 
 namespace eshkol {
 
+/**
+ * @brief Constructs a macro expander with a single, empty global scope.
+ */
 MacroExpander::MacroExpander() {
     // Initialize with a global scope
     scope_stack_.emplace_back();
 }
 
+/**
+ * @brief Destroys the expander. Registered macro definitions are owned by the
+ * AST they came from, so nothing is freed here.
+ */
 MacroExpander::~MacroExpander() {
     // Macro definitions are owned by the AST, not by us
 }
 
+/**
+ * @brief Pushes a new, empty macro scope onto the scope stack (used when
+ * entering a `let-syntax`/`letrec-syntax` body).
+ */
 void MacroExpander::pushScope() {
     scope_stack_.emplace_back();
 }
 
+/**
+ * @brief Pops the innermost macro scope, restoring the enclosing one.
+ *
+ * The global (outermost) scope is never popped, so this is a no-op once only
+ * one scope remains on the stack.
+ */
 void MacroExpander::popScope() {
     if (scope_stack_.size() > 1) {
         scope_stack_.pop_back();
     }
 }
 
+/**
+ * @brief Registers a `define-syntax` (or `let-syntax`/`letrec-syntax`) macro
+ * definition under its name in the innermost scope.
+ *
+ * Silently does nothing if @p macro is null, has no name, or the scope stack
+ * is empty.
+ */
 void MacroExpander::registerMacro(const eshkol_macro_def_t* macro) {
     if (macro && macro->name && !scope_stack_.empty()) {
         scope_stack_.back()[macro->name] = const_cast<eshkol_macro_def_t*>(macro);
     }
 }
 
+/**
+ * @brief Looks up a macro by name, searching scopes from innermost to
+ * outermost so that locally shadowing definitions win.
+ *
+ * @return The matching macro definition, or nullptr if @p name is not bound
+ * to a macro in any active scope.
+ */
 eshkol_macro_def_t* MacroExpander::lookupMacro(const std::string& name) const {
     // Search from innermost scope to outermost
     for (auto it = scope_stack_.rbegin(); it != scope_stack_.rend(); ++it) {
@@ -49,10 +80,25 @@ eshkol_macro_def_t* MacroExpander::lookupMacro(const std::string& name) const {
     return nullptr;
 }
 
+/**
+ * @brief Reports whether @p name currently resolves to a registered macro.
+ */
 bool MacroExpander::isMacro(const std::string& name) const {
     return lookupMacro(name) != nullptr;
 }
 
+/**
+ * @brief Expands a top-level sequence of forms, applying two passes so
+ * macros can be used before their textually-later `define-syntax` sibling
+ * definitions are all visible (mirrors R7RS top-level macro scoping).
+ *
+ * The first pass registers every top-level `define-syntax` definition. The
+ * second pass expands every non-`define-syntax` form (define-syntax forms
+ * themselves produce no runtime code and are dropped from the result).
+ *
+ * @return The expanded forms, in original order, with all `define-syntax`
+ * forms removed.
+ */
 std::vector<eshkol_ast_t> MacroExpander::expandAll(const std::vector<eshkol_ast_t>& asts) {
     std::vector<eshkol_ast_t> result;
 
@@ -77,10 +123,41 @@ std::vector<eshkol_ast_t> MacroExpander::expandAll(const std::vector<eshkol_ast_
     return result;
 }
 
+/**
+ * @brief Public entry point for expanding a single top-level or nested form.
+ *
+ * Thin forwarding wrapper around expandNode().
+ */
 eshkol_ast_t MacroExpander::expand(const eshkol_ast_t& ast) {
     return expandNode(ast);
 }
 
+/**
+ * @brief Core recursive macro-expansion driver: repeatedly expands macro
+ * calls at the current node, then descends into sub-expressions.
+ *
+ * A macro call is expanded iteratively (via a `for (;;)` loop) rather than by
+ * recursive self-call, so a macro that expands into another macro call does
+ * not grow the C++ call stack; a per-expansion-chain @c expansion_chain set
+ * detects a macro expanding back into itself and reports a circular-expansion
+ * error instead of looping forever. A thread-local @c expansion_depth guard
+ * also caps total nested expandNode() recursion (from descending into child
+ * forms) at 1000 to bound runaway expansion.
+ *
+ * Along the way this handles the three macro-introducing forms directly:
+ * `define-syntax` is registered and erased (replaced with a null AST, since
+ * it produces no runtime code); `let-syntax`/`letrec-syntax` push a scope,
+ * register their local macros, expand the body, and pop the scope. Once no
+ * more macro calls apply at this node, sub-expressions of every recognized
+ * operation kind (calls, sequences, define/lambda/let-family bindings and
+ * bodies, cond/case/when/unless/do, set!, guard, raise, values, call/cc,
+ * dynamic-wind, and quasiquote/unquote/unquote-splicing operands) are
+ * recursively expanded so nested macro uses anywhere in the tree are also
+ * expanded. Quoted (`quote`) data is deliberately left un-expanded since it
+ * is literal data, not code.
+ *
+ * @return The fully macro-expanded AST for this node and its subtree.
+ */
 eshkol_ast_t MacroExpander::expandNode(const eshkol_ast_t& ast) {
     // Use iterative re-expansion for macro calls to prevent unbounded recursion.
     // A macro expanding to another macro call is handled by looping, not recursing.
@@ -342,6 +419,19 @@ eshkol_ast_t MacroExpander::expandNode(const eshkol_ast_t& ast) {
     return result;
 }
 
+/**
+ * @brief Attempts to expand one macro call by trying each `syntax-rules` rule
+ * of the called macro in order until one matches.
+ *
+ * Looks up the macro named by @p call's callee, builds its literals list, and
+ * for each rule tries matchPatternSeq() against the call's arguments
+ * (skipping the macro-name pattern element itself). The first rule whose
+ * pattern matches has its template instantiated via instantiateTemplate().
+ *
+ * @return The instantiated template AST on a matching rule; if the macro
+ * name is not actually registered, or no rule's pattern matches (a syntax
+ * error, reported via eshkol_error()), returns @p call unchanged.
+ */
 eshkol_ast_t MacroExpander::tryExpandMacroCall(const eshkol_ast_t& call) {
     const auto* call_op = &call.operation.call_op;
     std::string macro_name = call_op->func->variable.id;
@@ -391,6 +481,20 @@ eshkol_ast_t MacroExpander::tryExpandMacroCall(const eshkol_ast_t& call) {
     return call;
 }
 
+/**
+ * @brief Instantiates a matched macro rule's template into a concrete AST
+ * node, dispatching on the template's shape.
+ *
+ * A @c MACRO_TPL_LITERAL template is literal AST data with pattern variables
+ * substituted via substituteBindings(); a @c MACRO_TPL_VARIABLE template
+ * looks up its name in @p bindings and copies the bound value (falling back
+ * to a bare symbol reference if unbound); a @c MACRO_TPL_LIST template
+ * recursively instantiates each element and rebuilds them as a call
+ * expression (first element is the callee, the rest are arguments).
+ *
+ * @return The instantiated AST. Returns a null AST for a null @p tmpl, an
+ * unbound/absent variable template, or an empty list template.
+ */
 eshkol_ast_t MacroExpander::instantiateTemplate(const eshkol_macro_template_t* tmpl,
                                                   const Bindings& bindings) {
     if (!tmpl) {
@@ -472,21 +576,53 @@ eshkol_ast_t MacroExpander::instantiateTemplate(const eshkol_macro_template_t* t
     return null_ast;
 }
 
+/**
+ * @brief Reports whether @p ast is the literal ellipsis symbol `...` used to
+ * mark repeated pattern/template elements in `syntax-rules`.
+ */
 bool MacroExpander::isEllipsisSymbol(const eshkol_ast_t& ast) const {
     return ast.type == ESHKOL_VAR && ast.variable.id &&
            std::string(ast.variable.id) == "...";
 }
 
+/**
+ * @brief Reports whether a MatchTree holds at least one concrete matched
+ * value.
+ *
+ * A depth-0 (scalar) tree always has a value; a repeated (depth >= 1) tree
+ * has a value only if it matched at least one repetition.
+ */
 bool MacroExpander::matchTreeHasValue(const MatchTree& tree) {
     if (tree.depth == 0) return true;
     return !tree.elements.empty();
 }
 
+/**
+ * @brief Descends into a MatchTree's first repetition at each level until
+ * reaching a scalar (depth-0) leaf, and returns that matched AST.
+ *
+ * Used to obtain a representative concrete value for a pattern variable
+ * without needing to know its full repetition structure.
+ */
 const eshkol_ast_t& MacroExpander::matchTreeFirstScalar(const MatchTree& tree) {
     if (tree.depth == 0) return tree.scalar;
     return matchTreeFirstScalar(tree.elements.front());
 }
 
+/**
+ * @brief Produces the bindings map for one repetition of an ellipsis
+ * expansion by "peeling" every repeated binding down one MatchTree level.
+ *
+ * For each entry in @p bindings: a non-repeated (depth-0) binding is shared
+ * unchanged across every repetition; a repeated binding with at least one
+ * matched element selects the sub-tree at @p index (clamped to the last
+ * available element, matching how R7RS treats unequal-length repeated
+ * bindings under one ellipsis); a repeated binding that matched zero
+ * repetitions peels to an empty tree one level shallower.
+ *
+ * @return A new Bindings map holding the binding values applicable to
+ * repetition @p index.
+ */
 MacroExpander::Bindings MacroExpander::peelBindingsAtIndex(const Bindings& bindings, size_t index) const {
     Bindings result;
     for (const auto& kv : bindings) {
@@ -508,6 +644,22 @@ MacroExpander::Bindings MacroExpander::peelBindingsAtIndex(const Bindings& bindi
     return result;
 }
 
+/**
+ * @brief Searches a template subtree for a pattern variable bound at
+ * ellipsis depth >= 1, to use as the "driver" that determines how many
+ * repetitions an adjacent `...` should expand to.
+ *
+ * Recurses through variable references, cons cells, and every recognized
+ * operation kind's sub-expressions (mirroring the same traversal shape used
+ * by expandNode()/substituteBindings()), stopping as soon as any qualifying
+ * variable is found.
+ *
+ * @param binding_name Out-parameter set to the name of the first
+ * depth->=1 pattern variable found; left unmodified if none is found.
+ * @return true if a driver variable was found (and @p binding_name set),
+ * false otherwise (e.g. the template element has no repeated pattern
+ * variable at all — a misplaced-ellipsis error case handled by the caller).
+ */
 bool MacroExpander::findEllipsisDriver(const eshkol_ast_t& ast,
                                         const Bindings& bindings,
                                         std::string& binding_name) const {
@@ -648,6 +800,26 @@ bool MacroExpander::findEllipsisDriver(const eshkol_ast_t& ast,
     }
 }
 
+/**
+ * @brief Expands a single template element followed by one or more
+ * consecutive `...` markers into the list of AST nodes it produces.
+ *
+ * Finds the repetition count via findEllipsisDriver() (the number of matched
+ * repetitions of the driving pattern variable), then for each repetition
+ * index peels @p bindings down to that repetition's values
+ * (peelBindingsAtIndex()) and substitutes @p ast against them. When
+ * @p ellipsis_count is greater than 1 (R7RS nested-ellipsis flattening, e.g.
+ * `row ... ...`), each repetition's result is itself recursively expanded one
+ * ellipsis shallower and the results are concatenated (spliced) rather than
+ * nested.
+ *
+ * @param ellipsis_count Number of consecutive `...` markers following
+ * @p ast in the template.
+ * @return The flattened list of expanded AST nodes, one per repetition (or
+ * more, if further nested ellipsis splice additional elements in). If no
+ * driver variable can be found, reports a misplaced-ellipsis error and
+ * returns a single-element vector holding @p ast substituted as-is.
+ */
 std::vector<eshkol_ast_t> MacroExpander::expandEllipsisElementN(const eshkol_ast_t& ast,
                                                                   const Bindings& bindings,
                                                                   int ellipsis_count) {
@@ -680,6 +852,21 @@ std::vector<eshkol_ast_t> MacroExpander::expandEllipsisElementN(const eshkol_ast
     return expanded;
 }
 
+/**
+ * @brief Substitutes template bindings across a flat array of template
+ * elements, expanding and flattening any element followed by one or more
+ * `...` markers.
+ *
+ * Walks @p items left to right; for each element it counts how many
+ * consecutive ellipsis-symbol items follow it (R7RS nested ellipsis, e.g.
+ * `row ... ...`, flattens one extra level per additional consecutive `...`),
+ * and if at least one follows, delegates to expandEllipsisElementN() and
+ * inlines its results. A bare `...` with no preceding element to repeat is a
+ * misplaced-ellipsis error and is skipped. Elements with no following
+ * ellipsis are substituted individually via substituteBindings().
+ *
+ * @return The fully substituted and ellipsis-flattened list of AST nodes.
+ */
 std::vector<eshkol_ast_t> MacroExpander::substituteBindingsInList(const eshkol_ast_t* items,
                                                                    uint64_t count,
                                                                    const Bindings& bindings) {
@@ -717,6 +904,26 @@ std::vector<eshkol_ast_t> MacroExpander::substituteBindingsInList(const eshkol_a
     return result;
 }
 
+/**
+ * @brief Recursively substitutes matched pattern-variable bindings into a
+ * macro template subtree, producing the (non-ellipsis-flattened) expanded
+ * AST for @p ast.
+ *
+ * A variable reference bound in @p bindings is replaced by a copy of its
+ * matched value (via matchTreeFirstScalar()); an unbound variable is copied
+ * as-is. Cons cells recurse into car/cdr. Operation nodes recurse into their
+ * relevant sub-expressions per operation kind (calls, sequences,
+ * define/lambda/let-family bindings and bodies, cond/case/when/unless/do,
+ * set!, guard, raise, values, call/cc, dynamic-wind, and
+ * quote/quasiquote/unquote/unquote-splicing operands — quoted data is
+ * recursed into here, unlike expandNode(), because pattern variables inside
+ * quoted template data must still be substituted per R7RS 4.3.2). List-typed
+ * sub-expression arrays are substituted via substituteBindingsInList() so
+ * ellipsis elements within them are expanded/flattened. Any other AST type is
+ * simply deep-copied via copyAst().
+ *
+ * @return The substituted AST subtree.
+ */
 eshkol_ast_t MacroExpander::substituteBindings(const eshkol_ast_t& ast,
                                                  const Bindings& bindings) {
     // Check if this is a variable that should be substituted
@@ -981,6 +1188,19 @@ eshkol_ast_t MacroExpander::substituteBindings(const eshkol_ast_t& ast,
     return copyAst(ast);
 }
 
+/**
+ * @brief Shallow-copies an AST node, deep-copying any owned string data so
+ * the copy does not alias the original's heap allocations.
+ *
+ * For @c ESHKOL_STRING and @c ESHKOL_VAR nodes, the string/identifier
+ * pointer is duplicated via strdup(). @c ESHKOL_OP nodes are copied
+ * shallowly here; deep-copying their nested operand pointers is the
+ * responsibility of the caller (expandNode()/substituteBindings()), which
+ * know which sub-pointers are relevant for each operation kind. All other
+ * node types are plain (primitive) data and are copied as-is.
+ *
+ * @return The copied AST node.
+ */
 eshkol_ast_t MacroExpander::copyAst(const eshkol_ast_t& ast) {
     eshkol_ast_t result = ast;
 
@@ -1012,6 +1232,10 @@ eshkol_ast_t MacroExpander::copyAst(const eshkol_ast_t& ast) {
     return result;
 }
 
+/**
+ * @brief Reports whether @p ast is a variable reference whose identifier
+ * equals @p name.
+ */
 bool MacroExpander::isSymbol(const eshkol_ast_t& ast, const std::string& name) const {
     if (ast.type == ESHKOL_VAR && ast.variable.id) {
         return std::string(ast.variable.id) == name;
@@ -1019,6 +1243,12 @@ bool MacroExpander::isSymbol(const eshkol_ast_t& ast, const std::string& name) c
     return false;
 }
 
+/**
+ * @brief Returns the identifier of a variable-reference AST node.
+ *
+ * @return The variable's name, or an empty string if @p ast is not a
+ * variable reference (or has a null identifier).
+ */
 std::string MacroExpander::getSymbolName(const eshkol_ast_t& ast) const {
     if (ast.type == ESHKOL_VAR && ast.variable.id) {
         return std::string(ast.variable.id);
@@ -1026,11 +1256,34 @@ std::string MacroExpander::getSymbolName(const eshkol_ast_t& ast) const {
     return "";
 }
 
+/**
+ * @brief Reports whether @p name is one of a macro's declared
+ * `syntax-rules` literal identifiers (which must match exactly rather than
+ * bind as a pattern variable).
+ */
 bool MacroExpander::isLiteral(const std::string& name,
                                const std::vector<std::string>& literals) const {
     return std::find(literals.begin(), literals.end(), name) != literals.end();
 }
 
+/**
+ * @brief Matches a single `syntax-rules` pattern node against an input AST,
+ * recording any pattern-variable bindings on success.
+ *
+ * Dispatches on pattern kind: @c MACRO_PAT_VARIABLE binds the matched AST
+ * under the pattern's identifier (the wildcard `_` matches anything without
+ * binding); @c MACRO_PAT_LITERAL requires @p ast to be a symbol reference
+ * exactly equal to the pattern's literal identifier; @c MACRO_PAT_LIST
+ * requires @p ast to be a call-shaped form and delegates element-by-element
+ * matching (including ellipsis handling) to matchPatternSeq().
+ *
+ * @param bindings Accumulates matched pattern-variable bindings; only
+ * modified on a successful match (partial matches from a failed sub-pattern
+ * may still leave entries in @p bindings, since callers discard the whole
+ * attempt on failure).
+ * @return true if @p pattern matches @p ast, false otherwise (including a
+ * null @p pattern).
+ */
 bool MacroExpander::matchPattern(const eshkol_macro_pattern_t* pattern,
                                   const eshkol_ast_t& ast,
                                   const std::vector<std::string>& literals,
@@ -1084,6 +1337,27 @@ bool MacroExpander::matchPattern(const eshkol_macro_pattern_t* pattern,
     }
 }
 
+/**
+ * @brief Matches a sequence of `syntax-rules` pattern elements (starting at
+ * @p pat_start) against a sequence of input argument ASTs, handling ellipsis
+ * repetition.
+ *
+ * Shared by both top-level macro-call matching (tryExpandMacroCall(), which
+ * skips the macro-name element) and nested list sub-pattern matching
+ * (matchPattern()'s @c MACRO_PAT_LIST case), so nested ellipsis (e.g.
+ * `((r ...) ...)`) is handled uniformly wherever it occurs. A pattern element
+ * marked @c followed_by_ellipsis greedily consumes every remaining argument
+ * as one repetition each of that element's sub-pattern; the per-repetition
+ * bindings are then merged into a single depth+1 MatchTree per pattern
+ * variable the element can bind (computed via collectPatternVarDepths()), so
+ * even a zero-repetition match binds those variables to an empty sequence
+ * rather than leaving them unbound. An element with no ellipsis consumes
+ * exactly one argument.
+ *
+ * @return true only if every pattern element matched and the entire argument
+ * sequence was consumed exactly (no leftover arguments or unmatched
+ * patterns); false otherwise.
+ */
 bool MacroExpander::matchPatternSeq(eshkol_macro_pattern_t* const* elements,
                                      uint64_t pat_start, uint64_t pat_count,
                                      const eshkol_ast_t* args, uint64_t arg_count,
@@ -1148,6 +1422,21 @@ bool MacroExpander::matchPatternSeq(eshkol_macro_pattern_t* const* elements,
     return arg_idx == arg_count;
 }
 
+/**
+ * @brief Recursively walks a `syntax-rules` sub-pattern, recording each
+ * pattern variable's ellipsis-nesting depth (number of enclosing `...`
+ * repetitions) into @p out.
+ *
+ * @p depth is the nesting depth accumulated so far by the caller; each
+ * @c MACRO_PAT_LIST child adds one more level if that child itself is
+ * marked @c followed_by_ellipsis. Used by matchPatternSeq() to know, for
+ * every variable bindable within an ellipsis-repeated element, what depth of
+ * MatchTree to build even when a given repetition doesn't happen to bind it.
+ *
+ * @param out Out-parameter map of pattern-variable name to depth; entries
+ * are added, never cleared, so callers should pass a fresh map per
+ * ellipsis element.
+ */
 void MacroExpander::collectPatternVarDepths(const eshkol_macro_pattern_t* pattern,
                                              const std::vector<std::string>& literals,
                                              int depth,

--- a/lib/frontend/parser.cpp
+++ b/lib/frontend/parser.cpp
@@ -55,6 +55,20 @@ static thread_local uint32_t g_stream_column = 1;
 // Stack space check: detect remaining stack and bail before overflow.
 // Uses platform APIs to measure actual stack consumption rather than
 // imposing an arbitrary depth limit.
+/**
+ * @brief Checks whether the current thread has enough remaining stack space
+ * to safely continue recursive parsing.
+ *
+ * Uses platform-specific APIs (pthread stack introspection on macOS/Linux)
+ * to measure how much of the thread's stack has actually been consumed,
+ * rather than imposing an arbitrary recursion-depth limit. Reserves a fixed
+ * @c STACK_SAFETY_MARGIN (64 KB) below the top of the stack.
+ *
+ * @return true if there is still more than the safety margin of stack space
+ *         free (or the check is unsupported/unavailable on this platform,
+ *         in which case it conservatively returns true); false if the
+ *         thread is at risk of stack overflow and parsing should bail out.
+ */
 static bool check_stack_space() {
     static const size_t STACK_SAFETY_MARGIN = 65536; // 64 KB reserved
 #ifdef _WIN32
@@ -864,6 +878,13 @@ private:
 
 static eshkol_ast_t parse_expression(SchemeTokenizer& tokenizer);
 
+/**
+ * @brief Builds an eshkol_ast_t string-literal node from a C++ string.
+ *
+ * Heap-allocates a NUL-terminated copy of @p value and wires it into the
+ * AST via eshkol_ast_make_string(), stamping the node with the given
+ * source @p line and @p column for diagnostics.
+ */
 static eshkol_ast_t make_parser_string_ast(const std::string& value,
                                            uint32_t line,
                                            uint32_t column) {
@@ -877,6 +898,12 @@ static eshkol_ast_t make_parser_string_ast(const std::string& value,
     return ast;
 }
 
+/**
+ * @brief Builds an ESHKOL_VAR AST node referencing the symbol @p name.
+ *
+ * Heap-allocates a NUL-terminated copy of @p name for ast.variable.id and
+ * stamps the node with @p line / @p column.
+ */
 static eshkol_ast_t make_parser_var_ast(const char* name,
                                         uint32_t line,
                                         uint32_t column) {
@@ -891,6 +918,16 @@ static eshkol_ast_t make_parser_var_ast(const char* name,
     return ast;
 }
 
+/**
+ * @brief Builds an ESHKOL_CALL_OP AST node calling the function named @p name
+ * with the given @p args.
+ *
+ * Synthesizes a variable-reference AST node for @p name as the callee and
+ * copies @p args into a heap-allocated array, producing the same shape a
+ * parsed `(name arg...)` form would produce. Used by the parser to inject
+ * synthetic calls (e.g. to helper procedures such as "list", "format",
+ * "string-append") that don't come directly from source text.
+ */
 static eshkol_ast_t make_parser_call_ast(const char* name,
                                          const std::vector<eshkol_ast_t>& args,
                                          uint32_t line,
@@ -921,17 +958,37 @@ struct KeywordFormal {
     uint32_t column;
 };
 
+/**
+ * @brief Heap-allocates a NUL-terminated copy of @p value.
+ *
+ * @return Newly allocated buffer owned by the caller, or nullptr on
+ *         allocation failure.
+ */
 static char* copy_parser_string(const std::string& value) {
     char* out = new char[value.size() + 1];
     if (out) memcpy(out, value.c_str(), value.size() + 1);
     return out;
 }
 
+/**
+ * @brief Generates a unique synthetic parameter name for the "rest" argument
+ * that collects keyword arguments not bound to an explicit formal.
+ *
+ * The name is derived from @p line and @p column so it cannot collide with
+ * any other synthetic or user-written identifier at a different source
+ * location.
+ */
 static std::string make_keyword_rest_name(uint32_t line, uint32_t column) {
     return "__eshkol_kw_rest_" + std::to_string(line) + "_" +
            std::to_string(column);
 }
 
+/**
+ * @brief Checks whether @p keyword already appears among @p formals.
+ *
+ * Used to detect duplicate `#:keyword` formal parameters in a lambda/define
+ * argument list.
+ */
 static bool has_keyword_formal(const std::vector<KeywordFormal>& formals,
                                const std::string& keyword) {
     for (const KeywordFormal& formal : formals) {
@@ -940,6 +997,15 @@ static bool has_keyword_formal(const std::vector<KeywordFormal>& formals,
     return false;
 }
 
+/**
+ * @brief Builds an AST node equivalent to `(quote name)` for the symbol
+ * @p name.
+ *
+ * Wraps a synthesized ESHKOL_VAR node for @p name in an ESHKOL_QUOTE_OP,
+ * so the symbol evaluates to itself rather than being looked up as a
+ * variable. Used e.g. to embed keyword-formal names as quoted symbol
+ * literals in synthesized validation calls.
+ */
 static eshkol_ast_t make_parser_quoted_symbol_ast(const std::string& name,
                                                   uint32_t line,
                                                   uint32_t column) {
@@ -957,6 +1023,14 @@ static eshkol_ast_t make_parser_quoted_symbol_ast(const std::string& name,
     return ast;
 }
 
+/**
+ * @brief Builds a `(list 'kw1 'kw2 ...)` AST node enumerating the allowed
+ * keywords from @p formals.
+ *
+ * Used to synthesize the second argument of a `(__keyword-args-validate
+ * rest allowed-list)` call so unrecognized `#:keyword` arguments can be
+ * rejected at run time.
+ */
 static eshkol_ast_t make_keyword_allowed_list_ast(
     const std::vector<KeywordFormal>& formals,
     uint32_t line,
@@ -971,6 +1045,13 @@ static eshkol_ast_t make_keyword_allowed_list_ast(
     return make_parser_call_ast("list", args, line, column);
 }
 
+/**
+ * @brief Builds a single `(name . value)` cons-cell AST node representing
+ * one let-binding.
+ *
+ * @p name becomes an ESHKOL_VAR node stored in the car; @p value (already
+ * a parsed/synthesized AST) is stored in the cdr.
+ */
 static eshkol_ast_t make_parser_binding_ast(const char* name,
                                             eshkol_ast_t value,
                                             uint32_t line,
@@ -986,6 +1067,30 @@ static eshkol_ast_t make_parser_binding_ast(const char* name,
     return binding;
 }
 
+/**
+ * @brief Wraps @p body in a synthesized `let` that destructures keyword
+ * arguments (`#:key val ...`) collected in @p rest_param into their
+ * matching @p formals.
+ *
+ * For each keyword formal, generates a binding that calls the
+ * `__keyword-arg` helper against @p rest_param to fetch that keyword's
+ * value. When @p validate_rest is true, prepends a call to
+ * `__keyword-args-validate` (via an ESHKOL_SEQUENCE_OP) that raises an
+ * error if @p rest_param contains any keyword not present in @p formals.
+ * If @p formals is empty, returns @p body unchanged.
+ *
+ * @param formals        Keyword formal parameters to bind (keyword name,
+ *                        local parameter name, and source location).
+ * @param rest_param      Name of the synthetic rest-argument variable
+ *                        (see make_keyword_rest_name()) holding the raw
+ *                        keyword-argument list at run time.
+ * @param body            Original lambda/define body to wrap.
+ * @param validate_rest   Whether to emit a run-time check rejecting
+ *                        unknown keywords.
+ * @param line, column    Source location used for the synthesized nodes.
+ * @return The original @p body when there are no keyword formals,
+ *         otherwise a synthesized ESHKOL_LET_OP node.
+ */
 static eshkol_ast_t wrap_keyword_formal_body(
     const std::vector<KeywordFormal>& formals,
     const char* rest_param,
@@ -1043,6 +1148,10 @@ static eshkol_ast_t wrap_keyword_formal_body(
     return ast;
 }
 
+/**
+ * @brief Returns true if @p value is empty or contains only whitespace
+ * characters.
+ */
 static bool is_blank_string(const std::string& value) {
     for (char c : value) {
         if (!std::isspace(static_cast<unsigned char>(c))) return false;
@@ -1050,6 +1159,18 @@ static bool is_blank_string(const std::string& value) {
     return true;
 }
 
+/**
+ * @brief Parses the Scheme expression embedded in a `~{...}`-style string
+ * interpolation placeholder and wraps it in a `(format "~a" expr)` call.
+ *
+ * @p source is the raw text between the interpolation delimiters. Rejects
+ * blank/empty expressions and expressions that don't parse to exactly one
+ * complete form (any trailing tokens after the first expression are an
+ * error). @p token is used only for diagnostic source-location reporting.
+ *
+ * @return The synthesized `(format "~a" expr)` call AST, or an
+ *         ESHKOL_INVALID node (with an error already reported) on failure.
+ */
 static eshkol_ast_t parse_string_interpolation_expr(const Token& token,
                                                     const std::string& source) {
     if (is_blank_string(source)) {
@@ -1076,6 +1197,23 @@ static eshkol_ast_t parse_string_interpolation_expr(const Token& token,
     return make_parser_call_ast("format", args, token.line, token.column);
 }
 
+/**
+ * @brief Converts a (possibly interpolated) string token into its AST
+ * representation.
+ *
+ * String tokens containing embedded expressions are delimited internally
+ * by the sentinel bytes kStringInterpolationStart/kStringInterpolationEnd
+ * (inserted by the tokenizer). Splits @p token's value on those markers
+ * into literal text segments and interpolated-expression segments (each
+ * parsed via parse_string_interpolation_expr()), then joins them with a
+ * synthesized `(string-append ...)` call. Tokens with no interpolation
+ * markers are returned as a plain string-literal AST unchanged. Returns a
+ * single string-literal node if only one segment results, or an empty
+ * string literal if the token is empty.
+ *
+ * @return AST node for the (possibly concatenated) string, or
+ *         ESHKOL_INVALID on an unterminated or malformed interpolation.
+ */
 static eshkol_ast_t parse_interpolated_string_token(const Token& token) {
     if (token.value.find(kStringInterpolationStart) == std::string::npos) {
         return make_parser_string_ast(token.value, token.line, token.column);
@@ -1127,6 +1265,33 @@ static eshkol_ast_t parse_interpolated_string_token(const Token& token) {
     return make_parser_call_ast("string-append", parts, token.line, token.column);
 }
 
+/**
+ * @brief Parses a single atomic (non-list) token into its eshkol_ast_t
+ * representation.
+ *
+ * Dispatches on token.type:
+ *  - TOKEN_STRING: delegates to parse_interpolated_string_token().
+ *  - TOKEN_NUMBER: recognizes R7RS special float literals (+inf.0,
+ *    -inf.0, +nan.0/-nan.0); rational literals of the form `num/den`
+ *    (synthesized as a `(make-rational num den)` call); floating-point
+ *    literals (containing '.', 'e', or 'E', parsed with strtod); and
+ *    plain integers (parsed with std::stoll, falling back to an
+ *    ESHKOL_BIGNUM_LITERAL string payload for values that overflow
+ *    int64_t, to be reconstructed as a bignum at codegen time).
+ *  - TOKEN_BOOLEAN: `#t`/`#f` literal.
+ *  - TOKEN_KEYWORD: a Racket-style self-evaluating `#:name` keyword,
+ *    wrapped in ESHKOL_QUOTE_OP so it evaluates to itself.
+ *  - TOKEN_CHAR: decodes the token's UTF-8 byte sequence into a single
+ *    Unicode codepoint for eshkol_ast_make_char().
+ *  - TOKEN_SYMBOL: logic-variable syntax (`?x`, `?name`, ...) becomes an
+ *    ESHKOL_LOGIC_VAR_OP node; all other symbols become a plain
+ *    ESHKOL_VAR reference.
+ *  - Any other token type: returns an ESHKOL_INVALID node.
+ *
+ * Malformed numeric literals report a parse error via PARSE_ERROR_AT and
+ * leave the node's type as whatever was set before the error (typically
+ * ESHKOL_INVALID or a partially-built node).
+ */
 static eshkol_ast_t parse_atom(const Token& token) {
     eshkol_ast_t ast = {};  // Zero-initialize all fields
     ast.type = ESHKOL_INVALID;
@@ -1294,6 +1459,24 @@ static eshkol_ast_t parse_atom(const Token& token) {
     return ast;
 }
 
+/**
+ * @brief Maps a special-form keyword (e.g. "if", "lambda", "let", "quote")
+ * to its eshkol_op_t enum value.
+ *
+ * Covers R7RS core special forms, Eshkol's ownership-aware memory
+ * operators (with-region, owned, move, borrow, shared, weak-ref),
+ * automatic-differentiation operators (diff, derivative, gradient,
+ * jacobian, hessian, ...), exception handling (guard, raise), multiple
+ * values, the neuro-symbolic consciousness engine (unify, make-kb,
+ * kb-query, ...), differentiable external memory (dnc-*, sdnc-*), active
+ * inference (make-factor-graph, fg-infer!, ...), the global workspace
+ * (make-workspace, ws-step!, ...), and R7RS "Wave 3" forms
+ * (case-lambda, define-record-type, parameterize, cond-expand, ...).
+ *
+ * @return The matching eshkol_op_t, or ESHKOL_CALL_OP if @p op is not a
+ *         recognized special form (i.e. it should be treated as an
+ *         ordinary function call).
+ */
 static eshkol_op_t get_operator_type(const std::string& op) {
     if (op == "if") return ESHKOL_IF_OP;
     if (op == "lambda") return ESHKOL_LAMBDA_OP;
@@ -1427,6 +1610,12 @@ static eshkol_ast_t parse_quoted_data_with_token(SchemeTokenizer& tokenizer, Tok
 static eshkol_ast_t parse_quoted_list_internal(SchemeTokenizer& tokenizer);
 static hott_type_expr_t* parseTypeExpression(SchemeTokenizer& tokenizer);
 
+/**
+ * @brief Heap-allocates a NUL-terminated copy of @p value.
+ *
+ * Equivalent helper to copy_parser_string(), used for token text elsewhere
+ * in the parser.
+ */
 static char* copy_token_text(const std::string& value) {
     char* ptr = new char[value.length() + 1];
     if (ptr) {
@@ -1435,6 +1624,18 @@ static char* copy_token_text(const std::string& value) {
     return ptr;
 }
 
+/**
+ * @brief Parses @p token as an unsigned 64-bit decimal integer literal.
+ *
+ * Rejects negative signs, decimal points, fractions ('/'), and exponent
+ * markers ('e'/'E'), so it only accepts plain non-negative integer tokens
+ * (used by declaration modifiers such as `:align`). On success stores the
+ * parsed value in @p out.
+ *
+ * @param token Tokenizer token to parse; must be a TOKEN_NUMBER.
+ * @param out   Receives the parsed value on success; must not be null.
+ * @return true if @p token is a valid unsigned 64-bit decimal integer.
+ */
 static bool parse_uint64_token(const Token& token, uint64_t* out) {
     if (!out || token.type != TOKEN_NUMBER || token.value.empty()) {
         return false;
@@ -1460,17 +1661,35 @@ static bool parse_uint64_token(const Token& token, uint64_t* out) {
     }
 }
 
+/**
+ * @brief Returns true if @p value is a nonzero power of two.
+ */
 static bool is_power_of_two_u64(uint64_t value) {
     return value != 0 && (value & (value - 1)) == 0;
 }
 
 static constexpr uint64_t kMaxLlvmGlobalAlignment = uint64_t{1} << 32;
 
+/**
+ * @brief Checks whether @p token begins a `:modifier` declaration tail (e.g. on `define`/`extern` forms).
+ *
+ * True for a bare TOKEN_COLON, or a TOKEN_SYMBOL that begins with ':'
+ * (such as `:align`).
+ */
 static bool is_declaration_modifier_start(const Token& token) {
     return token.type == TOKEN_COLON ||
            (token.type == TOKEN_SYMBOL && token.value.size() > 1 && token.value[0] == ':');
 }
 
+/**
+ * @brief Extracts the modifier name following a leading ':' from @p token.
+ *
+ * If @p token is a symbol like `:align`, returns "align" directly. If
+ * @p token is a bare TOKEN_COLON, reads the next token from @p tokenizer
+ * and returns its text (stripping a redundant leading ':' if present).
+ *
+ * @return The modifier name, or an empty string if no valid name follows.
+ */
 static std::string declaration_modifier_name(const Token& token, SchemeTokenizer& tokenizer) {
     if (token.type == TOKEN_SYMBOL && token.value.size() > 1 && token.value[0] == ':') {
         return token.value.substr(1);
@@ -1484,6 +1703,21 @@ static std::string declaration_modifier_name(const Token& token, SchemeTokenizer
     return "";
 }
 
+/**
+ * @brief Parses the trailing `:modifier` clauses of a `(define ...)` form.
+ *
+ * Starting from @p modifier_start (the first modifier token already read),
+ * repeatedly parses declaration modifiers and applies them to @p ast, which
+ * must be an ESHKOL_DEFINE_OP node. Supports `:link-section <name>`,
+ * `:align <power-of-two>`, `:used`, `:weak`, `:export-symbol [<name>]`
+ * (which may itself be followed by further modifiers), and `:no-return`
+ * (only valid on function definitions). Each modifier may appear at most
+ * once. Consumes tokens up to and including the closing `)`.
+ *
+ * @param modifier_start The first modifier-start token (':' or `:name`).
+ * @return true on success; false and reports a parse error on malformed
+ *         or duplicate modifiers.
+ */
 static bool parse_define_modifier_tail(SchemeTokenizer& tokenizer,
                                        eshkol_ast_t* ast,
                                        Token modifier_start) {
@@ -1589,6 +1823,18 @@ static bool parse_define_modifier_tail(SchemeTokenizer& tokenizer,
     }
 }
 
+/**
+ * @brief Parses the trailing `:modifier` clauses of an `(extern ...)` form.
+ *
+ * Mirrors parse_define_modifier_tail() for ESHKOL_EXTERN_OP nodes.
+ * Supports `:extern-symbol <name>` / `:real <name>` (the external linkage
+ * name), `:weak`, and `:no-return`, each at most once, terminated by the
+ * form's closing `)`.
+ *
+ * @param modifier_start The first modifier-start token (':' or `:name`).
+ * @return true on success; false and reports a parse error on malformed
+ *         or duplicate modifiers.
+ */
 static bool parse_extern_modifier_tail(SchemeTokenizer& tokenizer,
                                        eshkol_ast_t* ast,
                                        Token modifier_start) {
@@ -1646,6 +1892,18 @@ static bool parse_extern_modifier_tail(SchemeTokenizer& tokenizer,
     }
 }
 
+/**
+ * @brief Parses the trailing `:modifier` clauses of an `(extern-var ...)` form.
+ *
+ * Mirrors parse_extern_modifier_tail() for ESHKOL_EXTERN_VAR_OP nodes.
+ * Currently only supports `:extern-symbol <name>` / `:real <name>` to
+ * override the external variable's linkage name, at most once, terminated
+ * by the form's closing `)`.
+ *
+ * @param modifier_start The first modifier-start token (':' or `:name`).
+ * @return true on success; false and reports a parse error on malformed
+ *         or duplicate modifiers.
+ */
 static bool parse_extern_var_modifier_tail(SchemeTokenizer& tokenizer,
                                            eshkol_ast_t* ast,
                                            Token modifier_start) {
@@ -1969,6 +2227,13 @@ static hott_type_expr_t* parseTypeExpression(SchemeTokenizer& tokenizer) {
 // Parse quoted data - allows any expression including data lists like (1 2 3)
 // Helper: build a (cons car cdr) CALL_OP node used by both quoted and
 // quasiquoted list parsers when they encounter a dotted-pair tail.
+/**
+ * @brief Builds a `(cons @p car_ast @p cdr_ast)` CALL_OP AST node.
+ *
+ * Shared helper used by the quoted- and quasiquoted-list parsers to
+ * represent a dotted-pair tail, e.g. `'(a b . c)` lowers to
+ * `(cons a (cons b c))`.
+ */
 static eshkol_ast_t make_cons_call(eshkol_ast_t car_ast, eshkol_ast_t cdr_ast) {
     eshkol_ast_t ast;
     ast.type = ESHKOL_OP;
@@ -1986,12 +2251,27 @@ static eshkol_ast_t make_cons_call(eshkol_ast_t car_ast, eshkol_ast_t cdr_ast) {
 }
 
 // This is called AFTER consuming the opening token (QUOTE or first element of quote form)
+/**
+ * @brief Reads the next token and parses it as a quoted datum, e.g. the body of `'expr` or `(quote expr)`.
+ *
+ * Thin wrapper around parse_quoted_data_with_token() for callers that have
+ * not yet consumed the datum's first token.
+ */
 static eshkol_ast_t parse_quoted_data(SchemeTokenizer& tokenizer) {
     Token token = tokenizer.nextToken();
     return parse_quoted_data_with_token(tokenizer, token);
 }
 
 // Parse quoted data when we already have the first token
+/**
+ * @brief Parses a quoted datum whose first token, @p token, has already been consumed.
+ *
+ * Dispatches on @p token: `(` begins a (possibly dotted) quoted list via
+ * parse_quoted_list_internal(); a nested quote token recurses and wraps
+ * the result in an ESHKOL_QUOTE_OP node; anything else is parsed as a
+ * literal atom via parse_atom(). Unlike expression parsing, quoted data is
+ * treated as literal — symbols and lists are not evaluated as calls.
+ */
 static eshkol_ast_t parse_quoted_data_with_token(SchemeTokenizer& tokenizer, Token token) {
     if (token.type == TOKEN_LPAREN) {
         // Parse a list without requiring a symbol as first element
@@ -2015,6 +2295,18 @@ static eshkol_ast_t parse_quoted_data_with_token(SchemeTokenizer& tokenizer, Tok
 
 // Parse a quoted list - called after consuming '('
 // Handles both proper lists '(a b c) and dotted/improper lists '(a b . c).
+/**
+ * @brief Parses the elements of a quoted list after the opening `(` has been consumed.
+ *
+ * Handles both proper lists `'(a b c)`, which are built as a `(list a b c)`
+ * CALL_OP node, and dotted/improper lists `'(a b . c)` (R7RS 7.1.2), which
+ * are built as a right-nested chain of make_cons_call() nodes:
+ * `(cons a (cons b c))`. Each element is parsed recursively so quoted data
+ * can nest arbitrarily.
+ *
+ * @return The resulting list AST, or an ESHKOL_INVALID node on a malformed
+ *         dotted pair or unexpected end of input.
+ */
 static eshkol_ast_t parse_quoted_list_internal(SchemeTokenizer& tokenizer) {
     std::vector<eshkol_ast_t> elements;
     bool has_dot_tail = false;
@@ -2090,12 +2382,31 @@ static eshkol_ast_t parse_quasiquoted_list_internal(SchemeTokenizer& tokenizer);
 static eshkol_ast_t parse_expression(SchemeTokenizer& tokenizer);
 
 // Parse quasiquoted data - similar to quoted data but handles unquote/unquote-splicing
+/**
+ * @brief Reads the next token and parses it as a quasiquoted datum, e.g. the body of `` `expr `` or `(quasiquote expr)`.
+ *
+ * Thin wrapper around parse_quasiquoted_data_with_token() for callers that
+ * have not yet consumed the datum's first token.
+ */
 static eshkol_ast_t parse_quasiquoted_data(SchemeTokenizer& tokenizer) {
     Token token = tokenizer.nextToken();
     return parse_quasiquoted_data_with_token(tokenizer, token);
 }
 
 // Parse quasiquoted data when we already have the first token
+/**
+ * @brief Parses a quasiquoted datum whose first token, @p token, has already been consumed.
+ *
+ * Extends parse_quoted_data_with_token() with R7RS §4.2.8 quasiquote
+ * escapes: `(` recurses into parse_quasiquoted_list_internal(); `#(` parses
+ * a quasiquoted vector literal into a 1-D ESHKOL_TENSOR_OP whose elements
+ * may themselves contain unquotes; `,expr` / `,@expr` (TOKEN_COMMA /
+ * TOKEN_COMMA_AT) escape back to full expression-mode parsing via
+ * parse_expression() and become ESHKOL_UNQUOTE_OP / ESHKOL_UNQUOTE_SPLICING_OP
+ * nodes (their bodies are evaluated, not treated as literal data); a nested
+ * backquote recurses as a nested ESHKOL_QUASIQUOTE_OP; anything else is a
+ * literal atom.
+ */
 static eshkol_ast_t parse_quasiquoted_data_with_token(SchemeTokenizer& tokenizer, Token token) {
     if (token.type == TOKEN_LPAREN) {
         // Parse a list without requiring a symbol as first element
@@ -2187,6 +2498,21 @@ static eshkol_ast_t parse_quasiquoted_data_with_token(SchemeTokenizer& tokenizer
 }
 
 // Parse a quasiquoted list - called after consuming '('
+/**
+ * @brief Parses the elements of a quasiquoted list after the opening `(` has been consumed.
+ *
+ * First checks for the long-form spellings `(unquote e)`,
+ * `(unquote-splicing e)`, `(quasiquote e)`, and `(quote e)`, which R7RS
+ * §4.2.8 requires to behave identically to the `,e` / `,@e` / `` `e `` / `'e`
+ * reader sugar; if none match, the head token is pushed back and the list
+ * is parsed as an ordinary (possibly dotted) quasiquoted list via
+ * parse_quasiquoted_data_with_token(), mirroring parse_quoted_list_internal()
+ * but preserving unquote/unquote-splicing escapes and building dotted
+ * tails with make_cons_call().
+ *
+ * @return The resulting list (or long-form escape) AST, or an
+ *         ESHKOL_INVALID node on malformed input.
+ */
 static eshkol_ast_t parse_quasiquoted_list_internal(SchemeTokenizer& tokenizer) {
     std::vector<eshkol_ast_t> elements;
     bool has_dot_tail = false;
@@ -2340,6 +2666,14 @@ static ScopeTracker g_scope_tracker;
 // Static AST analysis for closure capture detection
 
 // Helper: Collect all defined variables at a given AST level (not recursing into nested functions)
+/**
+ * @brief Records the name bound by @p ast if it is a top-level `(define ...)` node.
+ *
+ * Does not recurse into nested subexpressions; used to gather the set of
+ * names a single body-level form introduces, for closure-capture analysis.
+ *
+ * @param defined_vars Set of variable names to insert into.
+ */
 static void collectDefinedVariables(const eshkol_ast_t* ast, std::set<std::string>& defined_vars) {
     if (!ast) return;
     
@@ -2352,6 +2686,15 @@ static void collectDefinedVariables(const eshkol_ast_t* ast, std::set<std::strin
 }
 
 // Helper: Collect defined variables from function body (for function's local scope)
+/**
+ * @brief Collects all top-level defined variable names from a function/lambda body.
+ *
+ * If @p body is an ESHKOL_SEQUENCE_OP, applies collectDefinedVariables() to
+ * each expression in the sequence; otherwise treats @p body itself as the
+ * single expression to inspect.
+ *
+ * @param defined_vars Set of variable names to insert into.
+ */
 static void collectBodyDefinedVariables(const eshkol_ast_t* body, std::set<std::string>& defined_vars) {
     if (!body) return;
     
@@ -2366,6 +2709,18 @@ static void collectBodyDefinedVariables(const eshkol_ast_t* body, std::set<std::
 }
 
 // Recursively collect all variable references in an AST subtree
+/**
+ * @brief Recursively collects every variable name referenced within @p ast into @p refs.
+ *
+ * Walks ESHKOL_VAR leaves, call arguments/function position, lambda bodies
+ * (lambda parameters are not collected, since they shadow), define values,
+ * let / let* / letrec bindings and bodies, sequences, and the AD-operator
+ * function/point/order subexpressions (derivative, gradient, taylor,
+ * derivative-n). Used by analyzeLambdaCaptures() to determine which outer
+ * variables a lambda body references.
+ *
+ * @param refs Set of variable names to insert into.
+ */
 static void collectVariableReferences(const eshkol_ast_t* ast, std::set<std::string>& refs) {
     if (!ast) return;
     
@@ -2488,6 +2843,27 @@ static void collectVariableReferences(const eshkol_ast_t* ast, std::set<std::str
 // Becomes:
 //   (letrec ((a 1) (helper (lambda (x) (+ x 1))))
 //     (begin (display "before") (+ a (helper 2))))
+/**
+ * @brief Hoists all internal `define`s in a body into a single `letrec*`, per R7RS §5.3.3 (Racket-compatible interspersed-define semantics).
+ *
+ * Splits @p body_expressions into defines and non-define expressions,
+ * regardless of where the defines appear in the body (interspersed defines
+ * are accepted, matching Racket/MIT/Guile/Chez rather than requiring all
+ * defines to precede all expressions). Each define becomes a `letrec*`
+ * binding — function defines are wrapped in an ESHKOL_LAMBDA_OP capturing
+ * the original parameters/rest-param/type annotations, and simple variable
+ * defines use their value expression directly — bound left-to-right so
+ * each definition's initializer can see earlier ones. All non-define
+ * expressions are preserved in their original relative order and become
+ * the resulting letrec*'s body (wrapped in an ESHKOL_SEQUENCE_OP if there
+ * is more than one), so side effects still execute in source order even
+ * though the defines' initializers all evaluate up front.
+ *
+ * @param body_expressions The body's expressions in source order.
+ * @return An ESHKOL_LETREC_STAR_OP AST node; if there are no defines,
+ *         returns @p body_expressions unchanged (a single expression, or a
+ *         plain ESHKOL_SEQUENCE_OP of them).
+ */
 static eshkol_ast_t transformInternalDefinesToLetrec(const std::vector<eshkol_ast_t>& body_expressions) {
     eshkol_ast_t result;
 
@@ -2697,6 +3073,19 @@ static eshkol_ast_t transformInternalDefinesToLetrec(const std::vector<eshkol_as
 // Analyze lambda for captured variables using STATIC AST ANALYSIS
 // Returns a list of variable names that are captured from parent scope
 // parent_defined_vars: variables available in the enclosing scope
+/**
+ * @brief Determines which outer-scope variables a lambda body captures, via static AST analysis.
+ *
+ * A referenced variable in @p lambda_body counts as a capture when it is
+ * not one of @p params, not locally defined within @p lambda_body (per
+ * collectBodyDefinedVariables()), and is present in @p parent_defined_vars
+ * (the enclosing scope's defined names).
+ *
+ * @param lambda_body          The lambda's body AST.
+ * @param params               The lambda's parameter list (these shadow outer bindings).
+ * @param parent_defined_vars  Variable names defined in the enclosing scope.
+ * @return The captured variable names.
+ */
 static std::vector<std::string> analyzeLambdaCaptures(
     const eshkol_ast_t* lambda_body,
     const std::vector<eshkol_ast_t>& params,
@@ -2739,6 +3128,24 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer);
 static eshkol_ast_t parse_vector_body(SchemeTokenizer& tokenizer);
 static eshkol_pattern_t* parse_pattern(SchemeTokenizer& tokenizer);
 
+/**
+ * @brief Parses a `define`-style function signature `(name param...)` into an ESHKOL_FUNC AST node.
+ *
+ * Consumes tokens for the function name followed by its parameter list,
+ * supporting plain symbol parameters, inline-typed parameters
+ * `(param : type)`, a dotted rest parameter `(name a b . rest)`, and (when
+ * @p keyword_formals is non-null) `#:keyword` formals collected into
+ * @p keyword_formals. If keyword formals were parsed and no explicit rest
+ * parameter was given, a synthetic rest parameter is generated to collect
+ * them and @p generated_keyword_rest is set to true.
+ *
+ * @param keyword_formals Out-param collecting any `#:keyword name` formals;
+ *   if null, encountering a keyword formal is a parse error.
+ * @param generated_keyword_rest Out-param set to true if a rest parameter
+ *   was synthesized to hold keyword formals.
+ * @return An ESHKOL_FUNC AST populated with name, parameters, and (if any)
+ *   rest-parameter/variadic info, or an ESHKOL_INVALID AST on parse error.
+ */
 static eshkol_ast_t parse_function_signature(
     SchemeTokenizer& tokenizer,
     std::vector<KeywordFormal>* keyword_formals,
@@ -2928,6 +3335,21 @@ static eshkol_ast_t parse_function_signature(
 // ===== PATTERN MATCHING HELPER =====
 
 // Recursive pattern parser - handles nested patterns
+/**
+ * @brief Recursively parses a single `match`/`let-match` pattern datum into an eshkol_pattern_t tree.
+ *
+ * Handles wildcard (`_`) and variable-binding symbols, literal atoms
+ * (numbers/strings/booleans/chars), quoted literals (wrapped in an
+ * ESHKOL_QUOTE_OP AST so codegen compares against the datum rather than
+ * evaluating it as a variable reference), and parenthesized forms:
+ * `(cons car-pat cdr-pat)`, `(list p1 p2 ...)`, `(? pred [name])` predicate
+ * patterns with an optional binding name, `(or p1 p2 ...)`, the empty-list
+ * pattern `()`, and unrecognized/other forms which are skipped and treated
+ * as an invalid or literal placeholder pattern.
+ *
+ * @return A newly-allocated eshkol_pattern_t; callers own the result. Its
+ *   `type` is PATTERN_INVALID if the input did not form a recognized pattern.
+ */
 static eshkol_pattern_t* parse_pattern(SchemeTokenizer& tokenizer) {
     Token token = tokenizer.nextToken();
 
@@ -3100,12 +3522,28 @@ struct LetMatchBinding {
     eshkol_ast_t expr;
 };
 
+/**
+ * @brief Creates a fresh PATTERN_WILDCARD pattern node (matches anything, binds nothing).
+ *
+ * Used, e.g., as the catch-all clause in `let-match`'s generated failure branch.
+ * @return A newly-allocated eshkol_pattern_t; caller owns the result.
+ */
 static eshkol_pattern_t* make_wildcard_pattern() {
     eshkol_pattern_t* pattern = new eshkol_pattern_t;
     pattern->type = PATTERN_WILDCARD;
     return pattern;
 }
 
+/**
+ * @brief Wraps zero or more expressions into a single AST node for use as a body/sequence.
+ *
+ * Empty @p exprs yields a null-datum AST; a single expression is returned
+ * unwrapped; two or more are combined into an ESHKOL_SEQUENCE_OP node
+ * evaluated in order. Used to lower `define-library`/`import`/`let-match`
+ * bodies (which may lower to any number of forms) into one AST value.
+ *
+ * @return The resulting AST node, tagged with @p line / @p column.
+ */
 static eshkol_ast_t make_sequence_or_null_ast(const std::vector<eshkol_ast_t>& exprs,
                                               uint32_t line,
                                               uint32_t column) {
@@ -3133,12 +3571,23 @@ static eshkol_ast_t make_sequence_or_null_ast(const std::vector<eshkol_ast_t>& e
     return ast;
 }
 
+/**
+ * @brief Heap-allocates a NUL-terminated copy of @p value for storage in a C-style AST field.
+ * @return A newly `new[]`-allocated `char*` owned by the caller, or null on allocation failure.
+ */
 static char* parser_copy_cstr(const std::string& value) {
     char* out = new char[value.size() + 1];
     if (out) memcpy(out, value.c_str(), value.size() + 1);
     return out;
 }
 
+/**
+ * @brief Joins an R7RS library-name's symbol @p parts (e.g. `(foo bar baz)`) into an internal module-name string.
+ *
+ * Special-cases the standard `(scheme base)` library name, mapping it to
+ * Eshkol's built-in "stdlib" module; otherwise joins the parts with `.`
+ * (e.g. `(foo bar baz)` becomes `"foo.bar.baz"`).
+ */
 static std::string join_r7rs_library_name(const std::vector<std::string>& parts) {
     if (parts.size() == 2 && parts[0] == "scheme" && parts[1] == "base") {
         return "stdlib";
@@ -3165,6 +3614,14 @@ struct R7rsImportSpec {
     std::string prefix;
 };
 
+/**
+ * @brief Builds an ESHKOL_REQUIRE_OP AST node requiring @p modules, with empty per-module prefix/except metadata.
+ *
+ * Allocates parallel arrays (module names, import prefixes, except-name
+ * lists) sized to @p modules.size(), initializing the prefix/except entries
+ * to empty/null; callers such as make_r7rs_require_ast() may subsequently
+ * fill in per-module prefix and except-name data.
+ */
 static eshkol_ast_t make_require_ast(const std::vector<std::string>& modules,
                                      uint32_t line,
                                      uint32_t column) {
@@ -3187,6 +3644,15 @@ static eshkol_ast_t make_require_ast(const std::vector<std::string>& modules,
     return ast;
 }
 
+/**
+ * @brief Builds an ESHKOL_REQUIRE_OP AST for a set of parsed R7RS import specs, wiring up per-module prefix/except data.
+ *
+ * Delegates module-name collection to make_require_ast(), then for each
+ * spec whose prefix should apply to the *whole* module (i.e. it has a
+ * @c prefix but no @c only list and no @c renames — those cases instead
+ * generate individual alias defines via append_r7rs_import_forms()),
+ * fills in that module's import prefix and except-name list.
+ */
 static eshkol_ast_t make_r7rs_require_ast(const std::vector<R7rsImportSpec>& specs,
                                           uint32_t line,
                                           uint32_t column) {
@@ -3216,6 +3682,13 @@ static eshkol_ast_t make_r7rs_require_ast(const std::vector<R7rsImportSpec>& spe
     return ast;
 }
 
+/**
+ * @brief Builds an ESHKOL_DEFINE_OP AST that defines @p alias as a plain variable bound to the value of @p source.
+ *
+ * Used to lower R7RS `rename` and prefixed `only` import-set entries into
+ * `(define alias source)` forms so the renamed/prefixed name resolves to
+ * the underlying imported binding.
+ */
 static eshkol_ast_t make_define_alias_ast(const std::string& alias,
                                           const std::string& source,
                                           uint32_t line,
@@ -3247,6 +3720,12 @@ static eshkol_ast_t make_define_alias_ast(const std::string& alias,
     return ast;
 }
 
+/**
+ * @brief Builds an ESHKOL_PROVIDE_OP AST node exporting the given symbol names.
+ *
+ * Used to lower an R7RS `define-library` `(export ...)` clause into
+ * Eshkol's native provide/export form.
+ */
 static eshkol_ast_t make_provide_ast(const std::vector<std::string>& exports,
                                      uint32_t line,
                                      uint32_t column) {
@@ -3263,6 +3742,21 @@ static eshkol_ast_t make_provide_ast(const std::vector<std::string>& exports,
     return ast;
 }
 
+/**
+ * @brief Parses a parenthesized R7RS library-name datum, e.g. `(foo bar baz)`, into a joined module name.
+ *
+ * Expects an opening `(` followed by one or more symbol tokens up to the
+ * matching `)`; each part must be a bare symbol (nested sub-forms like
+ * `(bar 1)` version specifiers are not supported here). On success, the
+ * joined name (via join_r7rs_library_name()) is written to @p out_name.
+ *
+ * @param form_token Token of the enclosing form, used for error location on
+ *   unexpected end-of-input.
+ * @param out_name Out-param receiving the joined library/module name; may be null.
+ * @param context Short description of the calling form (e.g. "define-library"),
+ *   used in error messages.
+ * @return true on success; false (with a parse error emitted) on malformed input.
+ */
 static bool parse_r7rs_library_name(SchemeTokenizer& tokenizer,
                                     const Token& form_token,
                                     std::string* out_name,
@@ -3297,11 +3791,27 @@ static bool parse_r7rs_library_name(SchemeTokenizer& tokenizer,
     return true;
 }
 
+/**
+ * @brief Checks whether @p value names one of the R7RS import-set modifiers: `only`, `except`, `prefix`, or `rename`.
+ */
 static bool is_r7rs_import_modifier(const std::string& value) {
     return value == "only" || value == "except" ||
            value == "prefix" || value == "rename";
 }
 
+/**
+ * @brief Reads a non-empty list of bare symbol tokens up to a closing `)` and appends them to @p out.
+ *
+ * Used for the symbol lists inside `only`/`except` import-set modifiers.
+ *
+ * @param form_token Token of the enclosing form, used for error location on
+ *   unexpected end-of-input.
+ * @param context Short description of the calling construct, used in error messages.
+ * @param out Vector that parsed symbol names are appended to.
+ * @return true on success; false (with a parse error emitted) if a
+ *   non-symbol token is encountered, input ends unexpectedly, or the list
+ *   turns out to be empty.
+ */
 static bool parse_r7rs_symbol_list_until_rparen(SchemeTokenizer& tokenizer,
                                                 const Token& form_token,
                                                 const char* context,
@@ -3326,6 +3836,22 @@ static bool parse_r7rs_symbol_list_until_rparen(SchemeTokenizer& tokenizer,
     return true;
 }
 
+/**
+ * @brief Recursively parses the body of one R7RS import-set datum (already past its opening `(`) into an R7rsImportSpec.
+ *
+ * A plain import set is a library name, e.g. `(foo bar)`, which sets
+ * @p out_spec's `module`. Otherwise the set may be wrapped in one of the
+ * four R7RS modifiers, each of which recursively parses a nested import
+ * set and then augments it: `(only <set> name...)` sets the allowed name
+ * list, `(except <set> name...)` extends the excluded-name list,
+ * `(prefix <set> prefix)` prepends @p prefix to any existing prefix, and
+ * `(rename <set> (old new)...)` accumulates old/new rename pairs. The
+ * (possibly nested-and-augmented) resulting spec is written to @p out_spec.
+ *
+ * @param open_token The already-consumed opening `(` token of this import
+ *   set, used for error location on unexpected end-of-input.
+ * @return true on success; false (with a parse error emitted) on malformed input.
+ */
 static bool parse_r7rs_import_set_body(SchemeTokenizer& tokenizer,
                                        const Token& open_token,
                                        R7rsImportSpec* out_spec) {
@@ -3443,6 +3969,18 @@ static bool parse_r7rs_import_set_body(SchemeTokenizer& tokenizer,
     return true;
 }
 
+/**
+ * @brief Parses a sequence of parenthesized R7RS import sets up to a closing `)`, appending each to @p specs.
+ *
+ * Used for the body of an `import` form (or a `define-library` `import`
+ * clause): each element must itself be a parenthesized import set, parsed
+ * via parse_r7rs_import_set_body().
+ *
+ * @param form_token Token of the enclosing form, used for error location.
+ * @return true on success; false (with a parse error emitted) if a
+ *   non-list element is found, input ends unexpectedly, or no import sets
+ *   were present.
+ */
 static bool parse_r7rs_import_sets(SchemeTokenizer& tokenizer,
                                    const Token& form_token,
                                    std::vector<R7rsImportSpec>* specs) {
@@ -3472,11 +4010,26 @@ static bool parse_r7rs_import_sets(SchemeTokenizer& tokenizer,
     return true;
 }
 
+/**
+ * @brief Checks whether @p name is listed in @p spec's `except` names (from an R7RS `(except <set> name...)` import set).
+ */
 static bool r7rs_name_is_excepted(const R7rsImportSpec& spec,
                                   const std::string& name) {
     return std::find(spec.except.begin(), spec.except.end(), name) != spec.except.end();
 }
 
+/**
+ * @brief Lowers parsed R7RS import specs into a sequence of AST forms, appending them to @p forms.
+ *
+ * First appends a single require-all form (via make_r7rs_require_ast()).
+ * Then, for each spec's rename pairs not excluded via `except`, appends a
+ * `(define new old)` alias (make_define_alias_ast()) so the renamed binding
+ * is visible under its new name. If a spec has a non-empty `prefix`, also
+ * appends a `(define prefix+name name)` alias for each of its `only` names
+ * that wasn't already covered by a rename, so prefixed names resolve
+ * correctly (per-module prefix-of-everything is instead handled directly by
+ * make_r7rs_require_ast() when there is no `only`/`renames` narrowing).
+ */
 static void append_r7rs_import_forms(const std::vector<R7rsImportSpec>& specs,
                                      std::vector<eshkol_ast_t>* forms,
                                      uint32_t line,
@@ -3508,6 +4061,13 @@ static void append_r7rs_import_forms(const std::vector<R7rsImportSpec>& specs,
     }
 }
 
+/**
+ * @brief Builds the AST for a top-level R7RS `import` form from its parsed import specs.
+ *
+ * Lowers @p specs into a require form plus any alias defines (via
+ * append_r7rs_import_forms()) and wraps them into a single AST node with
+ * make_sequence_or_null_ast().
+ */
 static eshkol_ast_t make_r7rs_import_ast(const std::vector<R7rsImportSpec>& specs,
                                          uint32_t line,
                                          uint32_t column) {
@@ -3516,6 +4076,26 @@ static eshkol_ast_t make_r7rs_import_ast(const std::vector<R7rsImportSpec>& spec
     return make_sequence_or_null_ast(forms, line, column);
 }
 
+/**
+ * @brief Parses an R7RS `(define-library (name ...) <library-declaration>*)` top-level form into a lowered AST.
+ *
+ * First parses the parenthesized library name (its joined form is
+ * currently unused beyond validation), then iterates the library's
+ * declaration clauses:
+ *  - `(export name...)` becomes a provide/export AST (make_provide_ast());
+ *    renamed exports (`(export (old new))`) are not yet supported.
+ *  - `(import <import-set>...)` is parsed via parse_r7rs_import_sets() and
+ *    lowered to require/alias forms via append_r7rs_import_forms().
+ *  - `(begin expr...)` has each contained expression parsed in place via
+ *    parse_expression() and appended as-is.
+ *  - any other clause name is a parse error (unsupported clause).
+ *
+ * All lowered forms across the library's clauses are combined into a
+ * single AST via make_sequence_or_null_ast().
+ *
+ * @return The combined AST for the whole library body, or an
+ *   ESHKOL_INVALID AST on any parse error.
+ */
 static eshkol_ast_t parse_define_library_form(SchemeTokenizer& tokenizer,
                                              const Token& form_token) {
     std::string library_name;
@@ -3601,12 +4181,29 @@ static eshkol_ast_t parse_define_library_form(SchemeTokenizer& tokenizer,
     return make_sequence_or_null_ast(lowered_forms, form_token.line, form_token.column);
 }
 
+/**
+ * @brief Builds the AST for the fallback `(error "let-match pattern failed")` call raised when a `let-match` binding pattern fails to match.
+ */
 static eshkol_ast_t make_let_match_failure_ast(uint32_t line, uint32_t column) {
     std::vector<eshkol_ast_t> args;
     args.push_back(make_parser_string_ast("let-match pattern failed", line, column));
     return make_parser_call_ast("error", args, line, column);
 }
 
+/**
+ * @brief Recursively lowers `let-match` bindings starting at @p index into nested ESHKOL_MATCH_OP AST nodes wrapping @p body.
+ *
+ * For binding @p index, builds a two-clause match on that binding's
+ * expression: the first clause uses the binding's pattern with the
+ * recursively-built continuation (bindings after @p index, terminating in
+ * @p body) as its success branch, and the second is a wildcard clause
+ * whose body raises the let-match failure error
+ * (make_let_match_failure_ast()). Once @p index reaches the end of
+ * @p bindings, simply returns @p body unchanged — the base case of the
+ * recursion.
+ *
+ * @return The (possibly nested) AST implementing all remaining pattern-matched bindings.
+ */
 static eshkol_ast_t build_let_match_ast(const std::vector<LetMatchBinding>& bindings,
                                         size_t index,
                                         eshkol_ast_t body,
@@ -3642,6 +4239,21 @@ static eshkol_ast_t build_let_match_ast(const std::vector<LetMatchBinding>& bind
     return ast;
 }
 
+/**
+ * @brief Parses the `let-match` special form `(let-match ((pattern expr) ...) body ...)` into a lowered AST.
+ *
+ * Parses a required parenthesized list of `(pattern expr)` bindings — each
+ * pattern via parse_pattern() and each expression via parse_expression() —
+ * followed by one or more body expressions. The body expressions are
+ * combined with make_sequence_or_null_ast(), then each binding is lowered,
+ * outermost-first, into a chain of pattern-match tests via
+ * build_let_match_ast(): if a binding's expression fails to match its
+ * pattern, evaluation raises a runtime error instead of proceeding to the
+ * next binding or the body.
+ *
+ * @return The lowered AST for the whole `let-match` form, or an
+ *   ESHKOL_INVALID AST if the bindings, patterns, or body fail to parse.
+ */
 static eshkol_ast_t parse_let_match_form(SchemeTokenizer& tokenizer,
                                          const Token& form_token) {
     std::vector<LetMatchBinding> bindings;
@@ -3718,6 +4330,42 @@ static eshkol_ast_t parse_let_match_form(SchemeTokenizer& tokenizer,
     return build_let_match_ast(bindings, 0, body, form_token.line, form_token.column);
 }
 
+/**
+ * @brief Parses a parenthesized form after the opening `(` has been consumed,
+ * dispatching over the entire set of Scheme/Eshkol special forms.
+ *
+ * Called with @p tokenizer positioned to read the head of the list. Reads
+ * the first token and, when it is a symbol, classifies it via
+ * get_operator_type() and then branches through a long if/else-if chain keyed
+ * on the resulting operator (with a handful of forms — e.g. `let-match` and
+ * `define-library` — dispatched by name to dedicated helper parsers before
+ * that). Recognized categories include: binding forms (`let`/`let*`/`letrec`/
+ * `letrec*`/`let-values`/`let*-values`/`let-match`/`let-syntax`/
+ * `letrec-syntax`); definition forms (`define`, `define-type`,
+ * `define-record-type`, `define-syntax`, `define-library`); `lambda` and
+ * `case-lambda`; quoting forms (`quote`, `quasiquote`, and their unquote/
+ * unquote-splicing counterparts); ordinary control forms (`if`, `cond`,
+ * `case`, `when`, `unless`, `do`, `and`, `or`, `begin`, `set!`); R7RS
+ * library/module forms (`import`, `require`, `provide`, `include`,
+ * `cond-expand`, `extern`, `extern-var`); multiple-values forms (`values`,
+ * `call-with-values`); exception handling (`guard`, `raise`) and
+ * continuations (`call/cc`, `dynamic-wind`); pattern matching (`match`,
+ * `let-match`); ownership/borrow-checking forms (`with-region`, `owned`,
+ * `move`, `borrow`, `shared`, `weak-ref`); automatic-differentiation forms
+ * (`diff`, `derivative`, `taylor`, `derivative-n`, `gradient`, `jacobian`,
+ * `hessian`, `divergence`, `curl`, `laplacian`, `directional-derivative`);
+ * tensor literals (`tensor`); parameter objects (`make-parameter`,
+ * `parameterize`); promises (`delay`, `delay-force`); a `(: name type)` type
+ * annotation; and the neuro-symbolic consciousness-engine operation family
+ * (unify/kb-query/workspace/DNC ops).
+ *
+ * When the head symbol matches none of the recognized special forms (i.e.
+ * get_operator_type() reports an ordinary call), or when the head itself is
+ * not a bare symbol (e.g. `((lambda ...) ...)` or `(#t 'yes)` appearing as a
+ * list head), the function falls through to the default case: the head is
+ * treated as the callee expression and the remaining elements are parsed as
+ * argument expressions, producing an ESHKOL_CALL_OP AST node.
+ */
 static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
     eshkol_ast_t ast = {};  // Zero-initialize all fields
     ast.type = ESHKOL_OP;
@@ -9500,6 +10148,29 @@ static eshkol_ast_t parse_vector_body(SchemeTokenizer& tokenizer) {
     return ast;
 }
 
+/**
+ * @brief Top-level recursive-descent dispatcher: reads one token and parses the
+ * single datum/expression it begins, delegating to the appropriate specialized
+ * parser for its syntactic form.
+ *
+ * Consumes exactly one token from @p tokenizer via nextToken() and switches on
+ * its type: `(` recurses into parse_list() for lists and special forms; `#(`
+ * delegates to parse_vector_body() for vector literals (including nested
+ * vectors flattened into tensors); `'`, `` ` ``, `,`, and `,@` build
+ * ESHKOL_QUOTE_OP / ESHKOL_QUASIQUOTE_OP / ESHKOL_UNQUOTE_OP /
+ * ESHKOL_UNQUOTE_SPLICING_OP wrapper nodes around the recursively parsed
+ * sub-expression (quote uses parse_quoted_data(), quasiquote uses
+ * parse_quasiquoted_data() so list *shape* is preserved for unquote splicing);
+ * symbols, strings, numbers, booleans, characters, and keywords are handed to
+ * parse_atom(). Before consuming any token it calls check_stack_space() to
+ * detect near-exhausted native stack (guards against segfaults from
+ * pathologically deep nesting) and, on a stray `)` or EOF, reports an error
+ * and returns an invalid node instead of recursing further.
+ *
+ * @return The parsed eshkol_ast_t for the single datum read; an ESHKOL_INVALID
+ * node on a stack-space guard trip, unexpected `)`, EOF, or a parse error
+ * propagated from a delegate parser.
+ */
 static eshkol_ast_t parse_expression(SchemeTokenizer& tokenizer) {
     // Stack space guard: detect actual remaining stack space using platform APIs.
     // This prevents segfaults from deeply nested input without imposing arbitrary limits.
@@ -9620,7 +10291,34 @@ static eshkol_ast_t parse_expression(SchemeTokenizer& tokenizer) {
     }
 }
 
-// Generic stream-based parser (works with any std::istream)
+/**
+ * @brief Public entry point: reads and parses the next complete top-level
+ * S-expression from an arbitrary std::istream.
+ *
+ * Scans @p in_stream character-by-character (not via SchemeTokenizer) to find
+ * the boundary of one complete top-level form, tracking string-quote state
+ * (`"`, honoring backslash-escaping) and parenthesis nesting depth so commas,
+ * quotes, and nested parens inside strings or character literals (`#\(`,
+ * `#\)`, `#\"`, `#\;`) are not mistaken for structural tokens. Line comments
+ * (`;`) are stripped from the accumulated text but their terminating newline
+ * is preserved so downstream line-number tracking (@c g_stream_line /
+ * @c g_stream_column) stays accurate. A bare top-level atom (not inside
+ * parens) is read up to the next whitespace/paren/comment; reader-prefix
+ * characters (`'`, `` ` ``, `,`, `#`) are treated as part of the following
+ * expression rather than standalone atoms. Once a complete form's text is
+ * isolated, leading/trailing whitespace is trimmed (advancing the line/column
+ * counters for any skipped newlines), a fresh SchemeTokenizer is constructed
+ * over just that form, and parse_expression() is invoked to produce the AST.
+ * The cumulative @c g_stream_line / @c g_stream_column counters are advanced
+ * by the exact text consumed on every call, whether or not a form was found,
+ * so repeated calls over the same stream keep accurate source positions for
+ * error reporting.
+ *
+ * @param in_stream Input stream positioned at (or before) the next form; may
+ * have leading whitespace/comments.
+ * @return The parsed eshkol_ast_t for the next top-level form, or an
+ * ESHKOL_INVALID node at end of stream or on a parse error.
+ */
 eshkol_ast_t eshkol_parse_next_ast_from_stream(std::istream &in_stream)
 {
     std::string input;
@@ -9777,13 +10475,34 @@ eshkol_ast_t eshkol_parse_next_ast_from_stream(std::istream &in_stream)
     return {.type = ESHKOL_INVALID};
 }
 
-// Reset the cumulative line/column counter — call before parsing a new file.
+/**
+ * @brief Resets the cumulative stream line/column counters (@c g_stream_line,
+ * @c g_stream_column) used by eshkol_parse_next_ast_from_stream() for error
+ * reporting.
+ *
+ * Must be called before parsing a new file/stream from its start; otherwise
+ * line numbers reported for the new stream would continue accumulating from
+ * wherever a previous stream left off.
+ */
 extern "C" void eshkol_reset_parse_line_counter(void) {
     g_stream_line = 1;
     g_stream_column = 1;
 }
 
-// File-based parser (wrapper for backwards compatibility)
+/**
+ * @brief Public entry point: reads and parses the next top-level S-expression
+ * from a file stream.
+ *
+ * Thin wrapper that forwards @p in_file to
+ * eshkol_parse_next_ast_from_stream() (an std::ifstream is-a std::istream),
+ * kept for source/binary backwards compatibility with callers that pass an
+ * ifstream specifically.
+ *
+ * @param in_file Open input file stream positioned at (or before) the next
+ * form.
+ * @return The parsed eshkol_ast_t for the next top-level form, or an
+ * ESHKOL_INVALID node at end of file or on a parse error.
+ */
 eshkol_ast_t eshkol_parse_next_ast(std::ifstream &in_file)
 {
     return eshkol_parse_next_ast_from_stream(in_file);

--- a/lib/repl/eval_bridge_impl.cpp
+++ b/lib/repl/eval_bridge_impl.cpp
@@ -22,6 +22,17 @@ namespace {
 std::mutex g_jit_mutex;
 std::unique_ptr<eshkol::ReplJITContext> g_jit_context;
 
+/**
+ * @brief Lazily creates and returns the process-wide REPL JIT context.
+ *
+ * Thread-safe via @c g_jit_mutex: the first caller constructs the singleton
+ * eshkol::ReplJITContext and logs success; construction failures are caught,
+ * logged, and reported as a null return rather than propagated as an
+ * exception. Subsequent calls return the already-constructed instance.
+ *
+ * @return Pointer to the singleton JIT context, or nullptr if construction
+ *         failed.
+ */
 eshkol::ReplJITContext* acquire_repl_jit(void) {
     std::lock_guard<std::mutex> lock(g_jit_mutex);
     if (!g_jit_context) {
@@ -36,10 +47,32 @@ eshkol::ReplJITContext* acquire_repl_jit(void) {
     return g_jit_context.get();
 }
 
+/**
+ * @brief Bridge-function-pointer adapter that acquires the REPL JIT context.
+ *
+ * Matches the `void* (*)(void)` signature expected by
+ * eshkol_eval_jit_register(); wraps acquire_repl_jit() so it can be
+ * registered as the eval bridge's "acquire" callback.
+ *
+ * @return Opaque pointer to the eshkol::ReplJITContext singleton (nullptr on
+ *         failure).
+ */
 void* bridge_acquire(void) {
     return static_cast<void*>(acquire_repl_jit());
 }
 
+/**
+ * @brief Bridge-function-pointer adapter that executes an AST via the REPL JIT.
+ *
+ * Matches the eval bridge's "execute" callback signature. If @p jit is null
+ * (acquisition failed earlier), returns a zeroed ESHKOL_VALUE_NULL tagged
+ * value instead of dereferencing it; otherwise forwards to
+ * eshkol::ReplJITContext::executeTagged().
+ *
+ * @param jit Opaque pointer previously returned by bridge_acquire(), or null.
+ * @param ast The AST node to compile and execute.
+ * @return The tagged result value, or a null tagged value if @p jit is null.
+ */
 eshkol_tagged_value_t bridge_execute(void* jit, eshkol_ast_t* ast) {
     if (!jit) {
         eshkol_tagged_value_t out;
@@ -52,6 +85,17 @@ eshkol_tagged_value_t bridge_execute(void* jit, eshkol_ast_t* ast) {
     return static_cast<eshkol::ReplJITContext*>(jit)->executeTagged(ast);
 }
 
+/**
+ * @brief Bridge-function-pointer adapter that looks up a symbol's JIT address.
+ *
+ * Matches the eval bridge's "lookup" callback signature. Returns 0 if either
+ * @p jit or @p name is null, otherwise forwards to
+ * eshkol::ReplJITContext::lookupSymbol().
+ *
+ * @param jit Opaque pointer previously returned by bridge_acquire(), or null.
+ * @param name Symbol name to resolve.
+ * @return JIT address of the symbol, or 0 if not found or on null input.
+ */
 uint64_t bridge_lookup(void* jit, const char* name) {
     if (!jit || !name) return 0;
     return static_cast<eshkol::ReplJITContext*>(jit)->lookupSymbol(name);
@@ -62,6 +106,14 @@ uint64_t bridge_lookup(void* jit, const char* name) {
  * Wrapped in a struct-with-constructor so the registration is
  * guaranteed to happen exactly once and survives -force_load linking. */
 struct BridgeRegistrar {
+    /**
+     * @brief Registers the bridge_acquire/bridge_execute/bridge_lookup
+     * callbacks as the process-wide eval bridge implementation.
+     *
+     * Runs as a static-initialization side effect (see the enclosing
+     * comment) so the bridge pointers are installed before main() when this
+     * translation unit is linked in.
+     */
     BridgeRegistrar() {
         eshkol_eval_jit_register(bridge_acquire,
                                  bridge_execute,

--- a/lib/repl/jitlink_branch26_range_extension.h
+++ b/lib/repl/jitlink_branch26_range_extension.h
@@ -85,6 +85,20 @@ namespace eshkol {
 class Branch26RangeExtensionPlugin
     : public llvm::orc::LinkGraphLinkingLayer::Plugin {
 public:
+  /**
+   * @brief Installs the Branch26 range-extension pass on eligible LinkGraphs.
+   *
+   * No-op unless the graph's target triple is AArch64 (or AArch64_be) with
+   * an ELF or COFF object format (the formats where AArch64's large code
+   * model is incomplete; Mach-O already emits correct far calls and is
+   * skipped). Also honors the `ESHKOL_JIT_NO_BRANCH26_VENEER=1` environment
+   * variable as a debugging escape hatch. When active, appends
+   * extendBranches() to @p Config's PostPrunePasses.
+   *
+   * @param G The LinkGraph being processed; its target triple determines
+   *          whether the pass is installed.
+   * @param Config Pass configuration to append the PostPrune pass to.
+   */
   void modifyPassConfig(llvm::orc::MaterializationResponsibility &,
                         llvm::jitlink::LinkGraph &G,
                         llvm::jitlink::PassConfiguration &Config) override {
@@ -119,13 +133,31 @@ public:
   }
 
   // Required overrides; this plugin tracks no per-resource state.
+  /**
+   * @brief Required Plugin override for materialization-failure notification.
+   *
+   * This plugin holds no per-resource state, so there is nothing to clean
+   * up; always succeeds.
+   */
   llvm::Error notifyFailed(llvm::orc::MaterializationResponsibility &) override {
     return llvm::Error::success();
   }
+  /**
+   * @brief Required Plugin override for resource-removal notification.
+   *
+   * This plugin holds no per-resource state, so there is nothing to clean
+   * up; always succeeds.
+   */
   llvm::Error notifyRemovingResources(llvm::orc::JITDylib &,
                                       llvm::orc::ResourceKey) override {
     return llvm::Error::success();
   }
+  /**
+   * @brief Required Plugin override for resource-transfer notification.
+   *
+   * This plugin holds no per-resource state, so there is nothing to
+   * transfer; intentionally empty.
+   */
   void notifyTransferringResources(llvm::orc::JITDylib &,
                                    llvm::orc::ResourceKey,
                                    llvm::orc::ResourceKey) override {}
@@ -135,6 +167,22 @@ private:
   // movk x16,#0,lsl#48 ; br x16   (little-endian, imm fields zeroed)
   static constexpr std::size_t kStubSize = 20;
 
+  /**
+   * @brief Rewrites every AArch64 Branch26PCRel edge in @p G to jump through
+   * a range-extension stub instead of directly to its target.
+   *
+   * For each `Branch26PCRel` edge found, emits (or reuses) a stub block in
+   * the same Section as the calling block, containing an absolute
+   * movz/movk/movk/movk/br x16 sequence that can reach any 64-bit address;
+   * the original edge is then re-pointed at the stub with its addend
+   * cleared (the addend is folded into the stub's target instead). Stubs
+   * are deduplicated per (section ordinal, target symbol) so callers in the
+   * same section sharing a callee share one stub. See the file-level
+   * comment for the full rationale.
+   *
+   * @param G The LinkGraph to modify in place.
+   * @return Always llvm::Error::success(); failure is not currently possible.
+   */
   static llvm::Error extendBranches(llvm::jitlink::LinkGraph &G) {
     using namespace llvm::jitlink;
 

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -75,10 +75,18 @@ using namespace llvm;
 // Extracts the module's original LLVMContext and releases module ownership from g_llvm_modules.
 std::unique_ptr<LLVMContext> eshkol_extract_module_context_for_jit(LLVMModuleRef module_ref);
 
+/**
+ * @brief Reinterprets an opaque C-ABI @p module_ref back into the LLVM Module it wraps.
+ */
 static llvm::Module* module_from_ref(LLVMModuleRef module_ref) {
     return reinterpret_cast<llvm::Module*>(module_ref);
 }
 
+/**
+ * @brief Heap-allocates a NUL-terminated copy of @p value for embedding into a synthesized eshkol_ast_t.
+ *
+ * The caller (and ultimately the AST it is attached to) owns the returned buffer.
+ */
 static char* repl_copy_ast_cstr(const std::string& value) {
     char* out = new char[value.size() + 1];
     if (out) {
@@ -87,6 +95,11 @@ static char* repl_copy_ast_cstr(const std::string& value) {
     return out;
 }
 
+/**
+ * @brief Synthesizes an ESHKOL_VAR AST node referencing variable @p name, for use in generated aliasing code.
+ * @param line Source line to attribute to the synthesized node (for diagnostics).
+ * @param column Source column to attribute to the synthesized node (for diagnostics).
+ */
 static eshkol_ast_t repl_make_var_ast(const std::string& name,
                                       uint32_t line,
                                       uint32_t column) {
@@ -99,6 +112,13 @@ static eshkol_ast_t repl_make_var_ast(const std::string& name,
     return ast;
 }
 
+/**
+ * @brief Synthesizes a `(define alias source)` AST node used to materialize an R7RS import prefix alias.
+ *
+ * Builds an ESHKOL_OP/ESHKOL_DEFINE_OP node whose value is an ESHKOL_VAR
+ * referencing @p source, so evaluating it binds @p alias to the same value
+ * as the already-imported @p source name.
+ */
 static eshkol_ast_t repl_make_define_alias_ast(const std::string& alias,
                                                const std::string& source,
                                                uint32_t line,
@@ -114,6 +134,15 @@ static eshkol_ast_t repl_make_define_alias_ast(const std::string& alias,
     return ast;
 }
 
+/**
+ * @brief Appends synthesized `(define prefixed-name original-name)` AST nodes for an R7RS `(prefix ...)` import clause.
+ *
+ * For the module at @p module_index within @p require_ast, if an import
+ * prefix was specified, generates one alias definition per name in
+ * @p exports (skipping any listed in that module's `except` clause) and
+ * pushes them onto @p out in sorted order. No-op if @p require_ast has no
+ * prefix configured for @p module_index.
+ */
 static void append_repl_r7rs_prefix_aliases(const eshkol_ast_t& require_ast,
                                             uint64_t module_index,
                                             const std::unordered_set<std::string>& exports,
@@ -525,6 +554,14 @@ namespace eshkol {
 static std::vector<eshkol_ast_t> parseAllAstsFromString(const std::string& content);
 static std::string resolveModulePath(const std::string& module_name, const std::string& base_dir = ".");
 
+/**
+ * @brief Constructs an empty REPL JIT context and enables REPL-mode codegen immediately.
+ *
+ * The LLJIT instance itself is not created here; call initializeJIT() before
+ * compiling or executing any forms. Enabling REPL mode up front ensures
+ * modules compiled prior to LLJIT startup still emit shared runtime globals
+ * as extern declarations instead of local definitions.
+ */
 ReplJITContext::ReplJITContext()
     : jit_(nullptr)
     , eval_counter_(0)
@@ -535,6 +572,12 @@ ReplJITContext::ReplJITContext()
     eshkol_repl_enable();
 }
 
+/**
+ * @brief Destroys the REPL JIT context, freeing forward-reference pointer slots allocated during evaluation.
+ *
+ * The underlying LLJIT instance's own destructor handles teardown of
+ * compiled modules and JIT dylibs.
+ */
 ReplJITContext::~ReplJITContext() {
     // Free all forward-reference pointer slots allocated with 'new void*'
     for (auto& [name, ptr_slot] : forward_ref_slots_) {
@@ -545,6 +588,23 @@ ReplJITContext::~ReplJITContext() {
     // LLJIT destructor handles remaining cleanup
 }
 
+/**
+ * @brief Creates and configures the LLJIT instance used to compile and run REPL forms.
+ *
+ * Initializes all LLVM targets, loads the current process's symbols into the
+ * dynamic-library search path, and builds a JITTargetMachineBuilder from the
+ * detected host CPU/features so the JIT's code generation matches the
+ * precompiled stdlib.o exactly: PIC relocation, the Large code model (needed
+ * so AArch64 Branch26 PC-relative calls can reach across the >128 MB stdlib
+ * IR without JITLink range errors), and -O0 codegen (matching stdlib.o's ABI
+ * for tagged-value struct arguments). Also installs the AArch64 Branch26
+ * range-extension JITLink plugin when applicable, installs an error reporter
+ * that filters out benign "became defunct" teardown errors, registers the
+ * runtime's manually-exported symbols (registerRuntimeSymbols()), and binds
+ * shared_arena_ to the process-global arena. Must be called once before any
+ * form is compiled or executed. Exits the process on unrecoverable LLJIT
+ * creation failures.
+ */
 void ReplJITContext::initializeJIT() {
     // Match the batch compiler's target initialization so the Windows LLVM SDK
     // exposes registered targets to LLJIT before host detection runs.
@@ -688,6 +748,21 @@ void ReplJITContext::initializeJIT() {
 // REMOVED: Failed IR manipulation approach - now using AST-level wrapping instead
 // void ReplJITContext::modifyToDisplayResult(Module* module, Function* func) { ... }
 
+/**
+ * @brief Manually registers every eshkol-static runtime function/global the JIT needs, since dlsym-based discovery is unreliable on some platforms.
+ *
+ * Builds an orc::SymbolMap of process-local addresses (arena allocation,
+ * exception handling, platform runtime exports, optional agent-FFI hooks,
+ * type-error reporting, automatic differentiation, closure/tensor/hash-table/
+ * region/ref-counted memory management, BLAS acceleration, bignum/rational
+ * numerics, global data symbols, and the parallel-execution runtime) using
+ * the ADD_SYMBOL / ADD_DATA_SYMBOL / ADD_TLS_SYMBOL helper macros, then
+ * defines them all in the JIT's main JITDylib via orc::absoluteSymbols().
+ * This is required because macOS does not export symbols from statically
+ * linked libraries through the normal dynamic-library search path, so
+ * DynamicLibrarySearchGenerator alone cannot resolve them. Exits the process
+ * if defining the symbols in the dylib fails.
+ */
 void ReplJITContext::registerRuntimeSymbols() {
     // Build a symbol map with addresses of runtime functions
     // These are all from eshkol-static which is statically linked
@@ -1335,6 +1410,14 @@ void ReplJITContext::registerRuntimeSymbols() {
 }
 
 // Stub function called when a forward-referenced function hasn't been defined yet
+/**
+ * @brief Placeholder callee for a forward-referenced function that was never actually defined; raises a catchable exception when invoked.
+ *
+ * This is the legacy fallback path: most call sites are now guarded by
+ * eshkol_check_forward_ref, which reports a named error before reaching this
+ * stub. It still runs if a pointer to an unresolved forward reference
+ * escapes through another route (apply, function-as-value, REPL eval).
+ */
 static eshkol_tagged_value __repl_forward_ref_stub() {
     // Raise an exception so that (guard ...) can catch it in user code.
     // This is the LEGACY path — the call-site guard added for Bug W (see
@@ -1358,10 +1441,17 @@ static eshkol_tagged_value __repl_forward_ref_stub() {
 // `eshkol_repl_forward_ref_stub_addr` and passes it to
 // eshkol_check_forward_ref so the helper can compare without needing
 // link-time access to the C++ static.
+/**
+ * @brief Returns the address of __repl_forward_ref_stub() so generated code can compare a callee pointer against it.
+ * @return Opaque function pointer identifying the unresolved-forward-reference stub.
+ */
 extern "C" void* eshkol_repl_forward_ref_stub_addr(void) {
     return reinterpret_cast<void*>(&__repl_forward_ref_stub);
 }
 
+/**
+ * @brief Tests whether @p global_var is one of the host-provided REPL runtime globals (argc/argv/shared-arena pointer).
+ */
 static bool is_repl_runtime_global(const llvm::GlobalVariable& global_var) {
     auto name = global_var.getName();
     return name == "__eshkol_argc" ||
@@ -1376,6 +1466,10 @@ static bool is_repl_runtime_global(const llvm::GlobalVariable& global_var) {
 // registries (versioned for direct JIT lookup, unversioned for code that uses
 // the function as a value, e.g. (map sq lst)). Returns "" if `vname` is not
 // in versioned form.
+/**
+ * @brief Recovers the original user-visible function name from a hot-reload versioned symbol like "name__rv3".
+ * @return The unversioned name, or "" if @p vname is not in `<name>__rv<digits>` form.
+ */
 static std::string strip_repl_version_suffix(const std::string& vname) {
     auto pos = vname.rfind("__rv");
     if (pos == std::string::npos || pos == 0) return "";
@@ -1386,6 +1480,13 @@ static std::string strip_repl_version_suffix(const std::string& vname) {
     return vname.substr(0, pos);
 }
 
+/**
+ * @brief Derives a stable JIT symbol name for a top-level variable's persistent storage slot from its Scheme @p name.
+ *
+ * Prefixes with "__repl_storage_" and percent-escapes (as "_XX" hex) any
+ * byte that is not alphanumeric, so identifiers containing characters like
+ * `-`, `!`, or `?` still produce a valid, collision-resistant symbol name.
+ */
 static std::string repl_var_storage_symbol_name(const std::string& name) {
     std::string out = "__repl_storage_";
     char encoded[4];
@@ -1400,6 +1501,35 @@ static std::string repl_var_storage_symbol_name(const std::string& name) {
     return out;
 }
 
+/**
+ * @brief Compiles-in and hot-reload-links one freshly generated LLVM @p module into the running JIT session.
+ *
+ * This is the central per-eval linking routine and performs, in order:
+ * (1) rewrites REPL host-provided globals (argc/argv/shared-arena) to
+ * external declarations so they resolve against the single host-registered
+ * definition instead of duplicating it per module; (2) processes
+ * `__repl_fwd_<X>` forward-reference markers, remapping any privatized
+ * variable-storage globals and recording which markers should later be
+ * pointed at real function addresses; (3) processes `__repl_var_<X>`
+ * top-level-variable markers, lazily allocating a persistent 16-byte tagged
+ * value storage slot per variable name (reused across redefinitions) and
+ * registering it as an absolute JIT symbol under a private, collision-free
+ * storage name; (4) creates forward-reference pointer-slot stubs for any
+ * externally referenced `__repl_fwd_<X>` symbol not yet resolvable; (5)
+ * evicts any previously JIT-linked module that defined a symbol this module
+ * is about to redefine, via ResourceTracker::remove(), enabling hot-reload
+ * without duplicate-symbol errors; (6) verifies the module and optionally
+ * dumps its IR/DataLayout for debugging; (7) wraps @p module with
+ * @p module_context in a ThreadSafeModule and adds it to the JIT under a
+ * fresh ResourceTracker; (8) if the module defines
+ * `__eshkol_init_parallel_workers`, invokes it immediately since ORC does
+ * not reliably run it as an initializer for REPL snippets; and (9) resolves
+ * every collected forward-reference update to the real function address now
+ * materialized in the JIT, allocating the pointer slot if this is the
+ * symbol's first definition. Lazily calls initializeJIT() if the JIT has not
+ * been created yet. Throws std::runtime_error on module verification failure
+ * or if addIRModule fails.
+ */
 void ReplJITContext::addModule(std::unique_ptr<Module> module, std::unique_ptr<LLVMContext> module_context) {
     if (!jit_) {
         initializeJIT();
@@ -1758,6 +1888,10 @@ void ReplJITContext::addModule(std::unique_ptr<Module> module, std::unique_ptr<L
     }
 }
 
+/**
+ * @brief Resolves @p name to its runtime address, checking the local symbol-table cache before falling back to a JIT lookup.
+ * @return The symbol's address, or 0 if @p name could not be resolved (not an error — callers handle this case).
+ */
 uint64_t ReplJITContext::lookupSymbol(const std::string& name) {
     if (!jit_) {
         initializeJIT();
@@ -1785,6 +1919,9 @@ uint64_t ReplJITContext::lookupSymbol(const std::string& name) {
     return address;
 }
 
+/**
+ * @brief Checks whether @p name is already known to the REPL, searching the local symbol table, pending-lambda/global registries, and finally the live JIT.
+ */
 bool ReplJITContext::isSymbolDefined(const std::string& name) {
     if (!jit_) {
         initializeJIT();
@@ -1816,6 +1953,12 @@ bool ReplJITContext::isSymbolDefined(const std::string& name) {
     return false;
 }
 
+/**
+ * @brief Registers @p name -> @p address in both the local symbol-table cache and the JIT's main dylib, so later modules can link against it.
+ *
+ * Applies the target's global symbol-name mangling (e.g. a leading `_` on
+ * Darwin) before defining the absolute symbol in the JIT.
+ */
 void ReplJITContext::registerSymbol(const std::string& name, uint64_t address) {
     if (!jit_) {
         initializeJIT();
@@ -1851,6 +1994,13 @@ void ReplJITContext::registerSymbol(const std::string& name, uint64_t address) {
     }
 }
 
+/**
+ * @brief Marks @p var_name as pending a lambda binding, before the lambda's compiled name/arity are known.
+ *
+ * Records a placeholder entry ("" name, 0 arity) in defined_lambdas_; the
+ * real function name and arity are filled in once the corresponding module
+ * has been compiled and inspected.
+ */
 void ReplJITContext::registerLambdaVar(const std::string& var_name) {
     // Mark that this variable will hold a lambda
     // The actual lambda function name and arity will be discovered after compilation
@@ -1858,6 +2008,10 @@ void ReplJITContext::registerLambdaVar(const std::string& var_name) {
     defined_lambdas_[var_name] = {"", 0};  // Empty name and 0 arity means "pending"
 }
 
+/**
+ * @brief Searches a set of platform-specific candidate paths for a precompiled stdlib.o object file.
+ * @return The first existing candidate path, or an empty string if none is found.
+ */
 // Find the pre-compiled stdlib.o file
 static std::string findStdlibObject() {
     auto cwd = platform::current_directory();
@@ -1891,6 +2045,10 @@ static std::string findStdlibObject() {
     return platform::find_first_existing(candidates);
 }
 
+/**
+ * @brief Searches a set of platform-specific candidate paths for a precompiled stdlib.bc bitcode file.
+ * @return The first existing candidate path, or an empty string if none is found.
+ */
 // Find the pre-compiled stdlib.bc bitcode file
 static std::string findStdlibBitcode() {
     auto cwd = platform::current_directory();
@@ -1927,6 +2085,24 @@ static std::string findStdlibBitcode() {
 // Discover and register stdlib symbols dynamically from .bc metadata.
 // No hardcoded function lists — iterates the bitcode module's IR to find
 // all exported functions (names + arities) and _sexpr globals.
+/**
+ * @brief Discovers all stdlib functions and data globals by parsing stdlib.bc's IR, and registers them with the REPL's compiler-visible symbol tables.
+ *
+ * Marks the built-in stdlib module names as already-loaded (to prevent
+ * circular re-import), then, if stdlib.bc can be located and parsed,
+ * iterates every non-declaration, non-internal-linkage function to register
+ * its name/arity (via eshkol_repl_register_function() and
+ * defined_lambdas_/registered_lambdas_), reading back the `eshkol-variadic`
+ * function attribute where present so REPL callers know how many trailing
+ * arguments to cons into a rest list. It also registers `_sexpr` metadata
+ * globals and externally linked `eshkol_tagged_value`-typed data globals
+ * (top-level `(define name expr)` bindings) so codegen does not attempt to
+ * redefine them and so closures capturing those names can resolve them. Uses
+ * bitcode (not the precompiled object) specifically because it preserves
+ * original (unscalarized) IR types, giving accurate arities. Falls back to a
+ * warning if stdlib.bc is unavailable, in which case stdlib symbol discovery
+ * is disabled.
+ */
 void ReplJITContext::registerStdlibSymbols() {
     // Mark stdlib modules as loaded to prevent re-loading
     loaded_modules.insert("stdlib");
@@ -2066,6 +2242,27 @@ void ReplJITContext::registerStdlibSymbols() {
     std::cerr << "Warning: stdlib.bc not found — stdlib symbol discovery unavailable" << std::endl;
 }
 
+/**
+ * @brief Loads the Eshkol standard library into the JIT session, trying progressively slower fallback paths until one succeeds.
+ *
+ * Idempotent (returns true immediately if already loaded). Tries, in order:
+ * (1) a cached, JIT-ABI-matched stdlib object file keyed on a content hash of
+ * stdlib.bc plus the target triple — emitted once with the exact
+ * TargetMachine configuration (host CPU, PIC, CodeModel::Large,
+ * CodeGenOptLevel::None, per-function/data sections for Branch26 range
+ * extension) the JIT itself uses, then added via addObjectFile() on every
+ * subsequent run to skip SelectionDAG entirely; (2) parsing stdlib.bc
+ * directly and adding it as an ORC IR module, keeping stdlib in the same
+ * compilation pipeline as REPL-compiled code so aggregate tagged-value
+ * arguments use a consistent ABI; (3) the legacy precompiled stdlib.o via
+ * addObjectFile() for installations that have not shipped stdlib.bc; and
+ * (4) JIT-compiling the stdlib from source via loadModule(), the slowest but
+ * always-correct path. On success, registers stdlib symbols
+ * (registerStdlibSymbols()) and explicitly invokes
+ * `__eshkol_lib_init__`/`__eshkol_init_parallel_workers` since ORC does not
+ * reliably run Eshkol's library/global-ctor initializers for REPL preloads.
+ * @return true if the stdlib was loaded (or already had been) by any path.
+ */
 bool ReplJITContext::loadStdlib() {
     if (stdlib_loaded_) {
         return true;  // Already loaded — idempotent.
@@ -2304,10 +2501,35 @@ bool ReplJITContext::loadStdlib() {
     return loaded;
 }
 
+/**
+ * @brief Loads @p module_name (a stdlib module or a user `(require ...)`-resolved file), preferring precompiled stdlib when available.
+ *
+ * Convenience overload equivalent to loadModule(module_name, true).
+ */
 bool ReplJITContext::loadModule(const std::string& module_name) {
     return loadModule(module_name, true);
 }
 
+/**
+ * @brief Loads @p module_name into the REPL, parsing and batch-compiling its source unless it can be satisfied from the precompiled stdlib.
+ *
+ * If @p allow_precompiled_stdlib is set and @p module_name is "stdlib" or a
+ * `core.*` module, first tries loadStdlib(); if the precompiled stdlib
+ * genuinely provides that module name, returns immediately. Otherwise
+ * resolves the module's source path (resolveModulePath()), reads and parses
+ * it into ASTs, and processes it in two passes: `(provide ...)` and
+ * `(define ...)` forms determine each module's exported vs. private symbol
+ * surface (recorded into module_exports_ and, for private symbols,
+ * private_symbols_ / eshkol_repl_register_private_symbol() after compilation
+ * so intra-module forward references still work during loading); then
+ * `(require/import ...)` dependency forms are executed immediately
+ * (continuing past a failed dependency with a warning rather than aborting
+ * the whole module), while all remaining top-level forms are collected and
+ * compiled together in one executeBatch() call so later definitions can
+ * forward-reference earlier ones. Idempotent per module name and per
+ * resolved path via the loaded_modules set.
+ * @return true on success; false if the module cannot be found/opened.
+ */
 bool ReplJITContext::loadModule(const std::string& module_name, bool allow_precompiled_stdlib) {
     // Check if already loaded by NAME first (for stdlib.o preloaded modules)
     if (loaded_modules.count(module_name)) {
@@ -2461,6 +2683,17 @@ bool ReplJITContext::loadModule(const std::string& module_name, bool allow_preco
     return true;
 }
 
+/**
+ * @brief Adds external declarations to @p module for every previously REPL-defined lambda and global variable it does not already contain.
+ *
+ * For each entry in defined_lambdas_ with a resolved (non-pending) name,
+ * declares an external function of the standard all-tagged-value signature
+ * matching its recorded arity if @p module does not already define/declare
+ * it. For each name in defined_globals_, declares an external i64 global if
+ * not already present. This lets newly compiled REPL code call/reference
+ * symbols that were defined in earlier evaluations without needing to
+ * recompile them.
+ */
 void ReplJITContext::injectPreviousSymbols(Module* module) {
     // Inject external function declarations for all previously defined lambdas
     // This allows new code to reference functions defined in previous REPL evaluations
@@ -2522,6 +2755,14 @@ void ReplJITContext::injectPreviousSymbols(Module* module) {
     }
 }
 
+/**
+ * @brief Records every `(define-syntax ...)` form in @p asts into persistent_macro_asts_ so later MacroExpander instances can still see them, replacing any prior definition of the same macro name.
+ *
+ * Non-macro ASTs in @p asts are ignored. Only a shallow copy of each macro
+ * AST is stored, which is safe because the parser allocates macro
+ * definitions for the process lifetime and eshkol_ast_clean() does not free
+ * them.
+ */
 void ReplJITContext::rememberPersistentMacros(const std::vector<eshkol_ast_t>& asts) {
     for (const auto& ast_item : asts) {
         if (ast_item.type != ESHKOL_OP ||
@@ -2550,6 +2791,13 @@ void ReplJITContext::rememberPersistentMacros(const std::vector<eshkol_ast_t>& a
     }
 }
 
+/**
+ * @brief Parses every top-level form in @p content into a vector of ASTs, skipping blank lines and `;`-comments.
+ *
+ * Resets the parser's cumulative line counter first so the first form in
+ * @p content is reported as starting at line 1. Stops at end of stream or on
+ * the first ESHKOL_INVALID parse result.
+ */
 // Helper to parse all ASTs from a string content
 // Returns a vector of parsed ASTs
 // Note: Uses ::eshkol_parse_next_ast_from_stream from global namespace (declared in eshkol.h)
@@ -2588,6 +2836,10 @@ static std::vector<eshkol_ast_t> parseAllAstsFromString(const std::string& conte
     return results;
 }
 
+/**
+ * @brief Searches a set of platform-specific candidate paths for the Eshkol `lib` directory (module source root).
+ * @return The first existing candidate directory path, or an empty string if none is found.
+ */
 // Find the lib directory (matches eshkol-run.cpp logic)
 static std::string findLibDir() {
     auto cwd = platform::current_directory();
@@ -2615,6 +2867,21 @@ static std::string g_lib_dir;
 
 // Helper to resolve module path (e.g., "core.functional.compose" -> "lib/core/functional/compose.esk")
 // Matches eshkol-run.cpp module resolution logic
+/**
+ * @brief Resolves a `(require ...)` module name (or literal `(load ...)` path) to a canonical, existing `.esk` file path.
+ *
+ * If @p module_name already looks like a path literal (absolute, `./`,
+ * `../`, contains a `/`, or ends in `.esk`), it is used as-is (appending
+ * `.esk` only if missing and the bare path does not already exist);
+ * otherwise dots are converted to path separators and `.esk` appended (e.g.
+ * "core.functional.compose" -> "core/functional/compose.esk"). The resulting
+ * relative path is then searched for, in order: @p base_dir, the cached
+ * library directory (found via findLibDir(), memoized in g_lib_dir),
+ * each colon/semicolon-separated directory in `$ESHKOL_PATH`, and finally a
+ * short list of legacy fallback paths.
+ * @return The canonicalized absolute path of the first match found, or "" if
+ * the module could not be located anywhere.
+ */
 static std::string resolveModulePath(const std::string& module_name, const std::string& base_dir) {
     // PATH-LITERAL DETECTION:
     //
@@ -2709,6 +2976,32 @@ static std::string resolveModulePath(const std::string& module_name, const std::
     return "";
 }
 
+/**
+ * @brief Compiles and runs a batch of top-level forms as a single LLVM module, allowing forward references between them.
+ *
+ * Pre-registers every top-level lambda `(define ...)` in @p asts via
+ * registerLambdaVar() (clearing any stale hot-reload registration first),
+ * then generates one LLVM module for the whole batch (prepending any
+ * persistent macro definitions collected via rememberPersistentMacros()) by
+ * calling eshkol_generate_llvm_ir(). Injects declarations for previously
+ * defined REPL symbols (injectPreviousSymbols()), scans the generated
+ * functions to update defined_lambdas_ arities, locates the batch's entry
+ * function (exactly named "main" or "__top_level" — matched by whole name,
+ * not substring, per historical Bug U — falling back to the first
+ * non-internal, non-locally-linked function), and renames it to a unique
+ * `__repl_batch_eval_<N>` symbol before handing the module to addModule()
+ * for JIT linking. After linking, resolves and registers every exported
+ * function's address and arity with the REPL's function registry (including
+ * the unversioned user-visible name for hot-reloaded `__rv<N>` symbols) and
+ * every top-level global variable's address, then invokes the entry
+ * function (if one was found) with empty argv.
+ * @param asts Top-level forms to compile together; if empty, this is a no-op.
+ * @param silent If true, suppresses diagnostic stderr output on internal
+ * codegen anomalies (used for module loading).
+ * @return A heap-allocated int64_t holding the entry function's return value
+ * (caller-owned), or nullptr if there was no entry function (define-only
+ * batch).
+ */
 void* ReplJITContext::executeBatch(std::vector<eshkol_ast_t>& asts, bool silent) {
     if (asts.empty()) {
         return nullptr;
@@ -2990,6 +3283,36 @@ void* ReplJITContext::executeBatch(std::vector<eshkol_ast_t>& asts, bool silent)
     return result;
 }
 
+/**
+ * @brief Compiles and JIT-executes a single top-level form as its own LLVM module, the primary single-form REPL evaluation entry point.
+ *
+ * Handles several AST shapes specially before falling into the general
+ * single-module compile path: an ESHKOL_SEQUENCE_OP (as emitted by macro
+ * expansions like define-record-type) is flattened by recursively calling
+ * execute() on each inner expression so each `define` becomes its own
+ * top-level binding rather than a local one, returning the last
+ * sub-expression's result; `(import "path")` reads, parses, and
+ * batch-compiles the target file (rejecting `..`-traversal paths, skipping
+ * already-loaded files); `(require module ...)` delegates to loadModule()
+ * per module and executes any generated R7RS import-prefix aliases; and
+ * `(provide ...)` is a no-op (exports are implicit in the REPL). For an
+ * ordinary top-level form, pre-registers any lambda `(define ...)` for
+ * hot-reload tracking, generates a single-form LLVM module via
+ * eshkol_generate_llvm_ir(), injects previously defined REPL symbols
+ * (injectPreviousSymbols()), locates the entry function (matching
+ * "__top_level"/"main" as a substring, or falling back to the first
+ * non-internal function), renames it to a unique `__repl_eval_<N>` symbol,
+ * hands the module to addModule() for JIT linking, registers the resulting
+ * exported functions/globals with the REPL's symbol registry (mirroring
+ * executeBatch()), invokes the entry function, and — for any `_sexpr`
+ * globals the entry function just initialized — captures their values via
+ * eshkol_repl_register_sexpr() after execution completes.
+ * @return A heap-allocated int64_t holding the raw (untyped) result value
+ * promoted from the entry function's i32 return (caller-owned); use
+ * executeTagged() instead when a properly typed tagged value is needed.
+ * Throws std::runtime_error on codegen, module-unwrap, or entry-function
+ * lookup failure.
+ */
 void* ReplJITContext::execute(eshkol_ast_t* ast) {
     if (!ast) {
         throw std::runtime_error("Cannot execute null AST");
@@ -3454,6 +3777,26 @@ void* ReplJITContext::execute(eshkol_ast_t* ast) {
     return result_ptr;
 }
 
+/**
+ * @brief Evaluates @p ast via execute() and returns a properly typed eshkol_tagged_value_t rather than a raw promoted-i32 result.
+ *
+ * Clears the thread-local "last value" capture slot first so a parse/codegen
+ * failure cannot surface a stale tagged value from a previous evaluation.
+ * After calling execute(), prefers whatever typed value the JIT-compiled
+ * code itself captured via eshkol_repl_get_last_value() (the fix for
+ * evaluations that previously always read back as `{type=INT64, val=0}`
+ * because `main` unconditionally returns `ret i32 0`); the raw legacy
+ * pointer result is freed and discarded in that case. If no captured value
+ * is available, falls back to reinterpreting the raw int64 result according
+ * to @p ast's inferred HoTT type (`ast->inferred_hott_type`, unpacked into a
+ * TypeId and exactness/flag bits), mapping each numeric/text/collection/
+ * function/resource/autodiff BuiltinTypes case to its corresponding
+ * ESHKOL_VALUE_* tag; if no type was inferred (packed_type == 0), falls back
+ * further to a coarser classification based on the raw AST node's own type
+ * (ESHKOL_INT64, ESHKOL_DOUBLE, ESHKOL_STRING, etc.).
+ * @return A fully tagged eshkol_tagged_value_t; ESHKOL_VALUE_NULL if @p ast
+ * is null or execution produced no result.
+ */
 eshkol_tagged_value_t ReplJITContext::executeTagged(eshkol_ast_t* ast) {
     eshkol_tagged_value_t result;
     result.type = ESHKOL_VALUE_NULL;

--- a/lib/repl/repl_utils.h
+++ b/lib/repl/repl_utils.h
@@ -24,6 +24,17 @@ namespace repl {
 // ============================================================================
 
 // Check if terminal supports colors
+/**
+ * @brief Detects whether the current stdout stream supports ANSI color escape codes.
+ *
+ * Checks (in order) the `NO_COLOR` env var (disables colors if set), whether
+ * stdout is a TTY, the `COLORTERM` env var, Windows terminal env vars
+ * (`WT_SESSION`/`ANSICON`), and finally heuristics on the `TERM` env var
+ * (looking for "color", "256", "xterm", "screen", "tmux", or "vt100").
+ * The result is cached in a static variable after the first call.
+ *
+ * @return true if ANSI colors should be emitted, false otherwise.
+ */
 inline bool supports_color() {
     static int cached = -1;
     if (cached == -1) {
@@ -59,51 +70,89 @@ inline bool supports_color() {
 // ANSI Color Codes
 namespace color {
     // Reset
+    /** @brief Returns the ANSI escape code that resets all text formatting, or "" if color output is disabled/unsupported. */
     inline const char* reset()    { return supports_color() ? "\033[0m" : ""; }
 
     // Regular colors
+    /** @brief Returns the ANSI escape code for black text, or "" if color output is disabled/unsupported. */
     inline const char* black()    { return supports_color() ? "\033[30m" : ""; }
+    /** @brief Returns the ANSI escape code for red text, or "" if color output is disabled/unsupported. */
     inline const char* red()      { return supports_color() ? "\033[31m" : ""; }
+    /** @brief Returns the ANSI escape code for green text, or "" if color output is disabled/unsupported. */
     inline const char* green()    { return supports_color() ? "\033[32m" : ""; }
+    /** @brief Returns the ANSI escape code for yellow text, or "" if color output is disabled/unsupported. */
     inline const char* yellow()   { return supports_color() ? "\033[33m" : ""; }
+    /** @brief Returns the ANSI escape code for blue text, or "" if color output is disabled/unsupported. */
     inline const char* blue()     { return supports_color() ? "\033[34m" : ""; }
+    /** @brief Returns the ANSI escape code for magenta text, or "" if color output is disabled/unsupported. */
     inline const char* magenta()  { return supports_color() ? "\033[35m" : ""; }
+    /** @brief Returns the ANSI escape code for cyan text, or "" if color output is disabled/unsupported. */
     inline const char* cyan()     { return supports_color() ? "\033[36m" : ""; }
+    /** @brief Returns the ANSI escape code for white text, or "" if color output is disabled/unsupported. */
     inline const char* white()    { return supports_color() ? "\033[37m" : ""; }
 
     // Bright colors
+    /** @brief Returns the ANSI escape code for bright black (gray) text, or "" if color output is disabled/unsupported. */
     inline const char* bright_black()   { return supports_color() ? "\033[90m" : ""; }
+    /** @brief Returns the ANSI escape code for bright red text, or "" if color output is disabled/unsupported. */
     inline const char* bright_red()     { return supports_color() ? "\033[91m" : ""; }
+    /** @brief Returns the ANSI escape code for bright green text, or "" if color output is disabled/unsupported. */
     inline const char* bright_green()   { return supports_color() ? "\033[92m" : ""; }
+    /** @brief Returns the ANSI escape code for bright yellow text, or "" if color output is disabled/unsupported. */
     inline const char* bright_yellow()  { return supports_color() ? "\033[93m" : ""; }
+    /** @brief Returns the ANSI escape code for bright blue text, or "" if color output is disabled/unsupported. */
     inline const char* bright_blue()    { return supports_color() ? "\033[94m" : ""; }
+    /** @brief Returns the ANSI escape code for bright magenta text, or "" if color output is disabled/unsupported. */
     inline const char* bright_magenta() { return supports_color() ? "\033[95m" : ""; }
+    /** @brief Returns the ANSI escape code for bright cyan text, or "" if color output is disabled/unsupported. */
     inline const char* bright_cyan()    { return supports_color() ? "\033[96m" : ""; }
+    /** @brief Returns the ANSI escape code for bright white text, or "" if color output is disabled/unsupported. */
     inline const char* bright_white()   { return supports_color() ? "\033[97m" : ""; }
 
     // Styles
+    /** @brief Returns the ANSI escape code for bold text, or "" if color output is disabled/unsupported. */
     inline const char* bold()      { return supports_color() ? "\033[1m" : ""; }
+    /** @brief Returns the ANSI escape code for dim/faint text, or "" if color output is disabled/unsupported. */
     inline const char* dim()       { return supports_color() ? "\033[2m" : ""; }
+    /** @brief Returns the ANSI escape code for italic text, or "" if color output is disabled/unsupported. */
     inline const char* italic()    { return supports_color() ? "\033[3m" : ""; }
+    /** @brief Returns the ANSI escape code for underlined text, or "" if color output is disabled/unsupported. */
     inline const char* underline() { return supports_color() ? "\033[4m" : ""; }
 
     // Semantic colors for Eshkol REPL
+    /** @brief Semantic color for numeric literals in REPL output (bright cyan). */
     inline const char* number()    { return bright_cyan(); }      // Numbers
+    /** @brief Semantic color for string literals in REPL output (bright green). */
     inline const char* string()    { return bright_green(); }     // Strings
+    /** @brief Semantic color for symbols/variable names in REPL output (bright yellow). */
     inline const char* symbol()    { return bright_yellow(); }    // Symbols/variables
+    /** @brief Semantic color for language keywords such as define/lambda in REPL output (bright magenta). */
     inline const char* keyword()   { return bright_magenta(); }   // Keywords (define, lambda, etc.)
+    /** @brief Semantic color for function names in REPL output (bright blue). */
     inline const char* function()  { return bright_blue(); }      // Function names
+    /** @brief Semantic color for arithmetic operators such as +, -, *, / in REPL output (yellow). */
     inline const char* operator_() { return yellow(); }           // Operators (+, -, *, /)
+    /** @brief Semantic color for comments in REPL output (bright black). */
     inline const char* comment()   { return bright_black(); }     // Comments
+    /** @brief Semantic color for error messages in REPL output (bright red). */
     inline const char* error()     { return bright_red(); }       // Errors
+    /** @brief Semantic color for success messages in REPL output (bright green). */
     inline const char* success()   { return bright_green(); }     // Success messages
+    /** @brief Semantic color for informational messages in REPL output (bright cyan). */
     inline const char* info()      { return bright_cyan(); }      // Info messages
+    /** @brief Semantic color for the REPL prompt (bright blue). */
     inline const char* prompt()    { return bright_blue(); }      // Prompt
+    /** @brief Semantic color for evaluated result values in REPL output (cyan). */
     inline const char* result()    { return cyan(); }             // Result values
+    /** @brief Semantic color for type annotations in REPL output (dim). */
     inline const char* type()      { return dim(); }              // Type annotations
+    /** @brief Semantic color for boolean literals in REPL output (bright magenta). */
     inline const char* boolean()   { return bright_magenta(); }   // Booleans
+    /** @brief Semantic color for the null/empty-list value in REPL output (bright black). */
     inline const char* null()      { return bright_black(); }     // Null/empty list
+    /** @brief Semantic color for list delimiters in REPL output (white). */
     inline const char* list()      { return white(); }            // List delimiters
+    /** @brief Semantic color for the lambda indicator in REPL output (bright yellow). */
     inline const char* lambda()    { return bright_yellow(); }    // Lambda indicator
 }
 
@@ -112,6 +161,17 @@ namespace color {
 // ============================================================================
 
 // All built-in functions and special forms
+/**
+ * @brief Returns the static list of all built-in function and special-form names used for REPL tab completion.
+ *
+ * Covers special forms, the module system, arithmetic/comparison/math
+ * functions, list/vector/string/hash-table operations, type predicates and
+ * conversions, I/O, control-flow constructs, exception handling,
+ * OALR memory-management forms, automatic-differentiation operators, tensor
+ * operations, functional-programming helpers, and the REPL's `exit` form.
+ *
+ * @return A const reference to the static vector of symbol names.
+ */
 inline const std::vector<std::string>& get_builtin_symbols() {
     static const std::vector<std::string> builtins = {
         // Special forms
@@ -229,6 +289,11 @@ struct ReplCommand {
     std::string usage;
 };
 
+/**
+ * @brief Returns the static table of REPL colon-commands (e.g. `:help`, `:quit`, `:doc`) with their aliases, descriptions, and usage strings.
+ *
+ * @return A const reference to the static vector of ReplCommand entries.
+ */
 inline const std::vector<ReplCommand>& get_repl_commands() {
     static const std::vector<ReplCommand> commands = {
         {":help",    ":h",  "Show this help message", ":help"},
@@ -255,6 +320,14 @@ inline const std::vector<ReplCommand>& get_repl_commands() {
 // History File Path
 // ============================================================================
 
+/**
+ * @brief Builds the path to the REPL's persistent command-history file.
+ *
+ * Uses `$HOME/.eshkol_history` when the `HOME` environment variable is set,
+ * falling back to the relative path `.eshkol_history` otherwise.
+ *
+ * @return The history file path.
+ */
 inline std::string get_history_file_path() {
     const char* home = std::getenv("HOME");
     if (home) {
@@ -268,6 +341,16 @@ inline std::string get_history_file_path() {
 // ============================================================================
 
 // Format a number with appropriate precision
+/**
+ * @brief Formats a double for REPL display, printing it without a decimal point when it represents an exact integer.
+ *
+ * Values that equal their int64_t truncation and fall within
+ * [-1e15, 1e15] are printed as plain integers; all other values are
+ * formatted with `%.15g` precision.
+ *
+ * @param value The number to format.
+ * @return The formatted string representation of @p value.
+ */
 inline std::string format_number(double value) {
     // Check if it's effectively an integer
     if (value == static_cast<int64_t>(value) &&
@@ -282,6 +365,13 @@ inline std::string format_number(double value) {
 }
 
 // Truncate long strings with ellipsis
+/**
+ * @brief Truncates a string to at most @p max_len characters, appending "..." if it was shortened.
+ *
+ * @param str The input string.
+ * @param max_len Maximum length of the returned string, including the ellipsis (default 80).
+ * @return @p str unchanged if it fits within @p max_len, otherwise the first (max_len - 3) characters followed by "...".
+ */
 inline std::string truncate_string(const std::string& str, size_t max_len = 80) {
     if (str.length() <= max_len) {
         return str;
@@ -293,6 +383,13 @@ inline std::string truncate_string(const std::string& str, size_t max_len = 80) 
 // Welcome Banner
 // ============================================================================
 
+/**
+ * @brief Prints the Eshkol REPL's ASCII-art welcome banner, version string, and quick-start hints to stdout.
+ *
+ * Displays the boxed "ESHKOL" logo, the tagline, the compiled
+ * ESHKOL_VERSION_STRING, and reminders for the `:help`/`:examples` commands
+ * and how to quit the REPL.
+ */
 inline void print_welcome_banner() {
     using namespace color;
 
@@ -323,6 +420,9 @@ inline void print_welcome_banner() {
 // Example Expressions
 // ============================================================================
 
+/**
+ * @brief Prints a categorized set of example Eshkol expressions (arithmetic, functions, closures, lists, control flow, modules, hash tables, functional programming, automatic differentiation, and vector calculus) to stdout.
+ */
 inline void print_examples() {
     using namespace color;
 
@@ -393,6 +493,19 @@ inline void print_examples() {
 // Colored Prompt
 // ============================================================================
 
+/**
+ * @brief Builds the colored REPL prompt string for a new top-level input or a multi-line continuation.
+ *
+ * For a fresh input, returns the "eshkol> " prompt. For a continuation
+ * line (when more input is needed to complete an expression), returns a
+ * "  [line_num,depth]> " prompt showing the current line number and
+ * nesting depth.
+ *
+ * @param continuation Whether this is a continuation of a multi-line input.
+ * @param line_num Current input line number, shown only when @p continuation is true.
+ * @param depth Current nesting depth (e.g. open-paren count), shown only when @p continuation is true.
+ * @return The formatted, color-escaped prompt string.
+ */
 inline std::string make_prompt(bool continuation = false, int line_num = 0, int depth = 0) {
     using namespace color;
     std::string p;
@@ -424,6 +537,12 @@ inline std::string make_prompt(bool continuation = false, int line_num = 0, int 
 // AST Type Names
 // ============================================================================
 
+/**
+ * @brief Maps an eshkol_type_t enum value to its human-readable REPL type name (e.g. ESHKOL_INT64 -> "integer", ESHKOL_DOUBLE -> "number").
+ *
+ * @param type The AST/value type tag to name.
+ * @return A static string naming @p type, or "unknown" if it is not recognized.
+ */
 inline const char* get_type_name(eshkol_type_t type) {
     switch (type) {
         case ESHKOL_INVALID: return "invalid";
@@ -449,6 +568,12 @@ inline const char* get_type_name(eshkol_type_t type) {
     }
 }
 
+/**
+ * @brief Maps an eshkol_op_t enum value to its Scheme-syntax operator/form name (e.g. ESHKOL_IF_OP -> "if", ESHKOL_ADD_OP -> "+").
+ *
+ * @param op The AST operation tag to name.
+ * @return A static string naming @p op, or "unknown-op" if it is not recognized.
+ */
 inline const char* get_op_name(eshkol_op_t op) {
     switch (op) {
         case ESHKOL_INVALID_OP:      return "invalid-op";
@@ -491,6 +616,17 @@ inline const char* get_op_name(eshkol_op_t op) {
 }
 
 // Get detailed type string for an AST node
+/**
+ * @brief Produces a detailed, human-readable description of an AST node's type for the REPL's `:type`/`:ast` commands.
+ *
+ * Beyond the plain type name, includes the symbol's name for ESHKOL_VAR
+ * nodes, distinguishes lambdas from named procedures for ESHKOL_FUNC nodes,
+ * and includes the operator name (via get_op_name()) for ESHKOL_OP nodes.
+ * Falls back to get_type_name() for any other type.
+ *
+ * @param ast The AST node to describe; may be nullptr.
+ * @return "nil" if @p ast is nullptr, otherwise a descriptive type string.
+ */
 inline std::string get_ast_type_string(const eshkol_ast_t* ast) {
     if (!ast) return "nil";
 
@@ -538,6 +674,11 @@ struct FunctionDoc {
     std::string example;
 };
 
+/**
+ * @brief Returns the static table of built-in function documentation entries (name, signature, description, and example) used by the REPL's `:doc` command.
+ *
+ * @return A const reference to the static vector of FunctionDoc entries.
+ */
 inline const std::vector<FunctionDoc>& get_function_docs() {
     static const std::vector<FunctionDoc> docs = {
         // Arithmetic
@@ -688,6 +829,12 @@ inline const std::vector<FunctionDoc>& get_function_docs() {
 }
 
 // Look up documentation for a function
+/**
+ * @brief Finds the FunctionDoc entry matching a given function name.
+ *
+ * @param name The built-in function name to look up.
+ * @return A pointer to the matching entry in get_function_docs(), or nullptr if no entry has that name.
+ */
 inline const FunctionDoc* lookup_doc(const std::string& name) {
     const auto& docs = get_function_docs();
     for (const auto& doc : docs) {
@@ -699,6 +846,11 @@ inline const FunctionDoc* lookup_doc(const std::string& name) {
 }
 
 // Print documentation for a function
+/**
+ * @brief Prints the documentation (signature, description, and example) for a named built-in function to stdout, or an error message if no documentation is found.
+ *
+ * @param name The function name to look up via lookup_doc().
+ */
 inline void print_doc(const std::string& name) {
     using namespace color;
 
@@ -720,6 +872,9 @@ inline void print_doc(const std::string& name) {
 }
 
 // Print list of documented topics
+/**
+ * @brief Prints a categorized index of all documented built-in function names (arithmetic, math, comparison, lists, control, binding, modules, hash tables, functional, I/O, types, equality, memory/OALR, autodiff, and tensors) for the REPL's `:doc` command with no arguments.
+ */
 inline void print_doc_topics() {
     using namespace color;
 
@@ -783,6 +938,12 @@ inline void print_doc_topics() {
 // Error Formatting
 // ============================================================================
 
+/**
+ * @brief Prints a formatted error message to stderr, with an optional dimmed detail line.
+ *
+ * @param message The main error message.
+ * @param detail Optional additional detail printed on a second, dimmed line; omitted if empty.
+ */
 inline void print_error(const std::string& message, const std::string& detail = "") {
     using namespace color;
     std::cerr << bold() << error() << "Error: " << reset();
@@ -793,17 +954,32 @@ inline void print_error(const std::string& message, const std::string& detail = 
     std::cerr << "\n";
 }
 
+/**
+ * @brief Prints a formatted warning message to stderr.
+ *
+ * @param message The warning text.
+ */
 inline void print_warning(const std::string& message) {
     using namespace color;
     std::cerr << bold() << yellow() << "Warning: " << reset();
     std::cerr << message << "\n";
 }
 
+/**
+ * @brief Prints an informational message to stdout in the REPL's info color.
+ *
+ * @param message The message to print.
+ */
 inline void print_info(const std::string& message) {
     using namespace color;
     std::cout << info() << message << reset() << "\n";
 }
 
+/**
+ * @brief Prints a success message to stdout in the REPL's success color.
+ *
+ * @param message The message to print.
+ */
 inline void print_success(const std::string& message) {
     using namespace color;
     std::cout << success() << message << reset() << "\n";

--- a/lib/types/dependent.cpp
+++ b/lib/types/dependent.cpp
@@ -24,6 +24,7 @@ struct ConstValue {
     int64_t int_val = 0;
     double float_val = 0.0;
 
+    /** @brief Create an integer-kind ConstValue holding @p v (also caching the double-converted value). */
     static ConstValue makeInt(int64_t v) {
         ConstValue cv;
         cv.kind = Kind::Integer;
@@ -32,6 +33,7 @@ struct ConstValue {
         return cv;
     }
 
+    /** @brief Create a float-kind ConstValue holding @p v (also caching the truncated integer value). */
     static ConstValue makeFloat(double v) {
         ConstValue cv;
         cv.kind = Kind::Float;
@@ -40,21 +42,31 @@ struct ConstValue {
         return cv;
     }
 
+    /** @brief Create an invalid/empty ConstValue representing "could not evaluate". */
     static ConstValue none() {
         return ConstValue();
     }
 
+    /** @brief True if this ConstValue holds an actual evaluated result (kind != None). */
     bool isValid() const { return kind != Kind::None; }
+    /** @brief True if this ConstValue holds an integer result. */
     bool isInt() const { return kind == Kind::Integer; }
+    /** @brief True if this ConstValue holds a floating-point result. */
     bool isFloat() const { return kind == Kind::Float; }
 
     // Get as double (works for both int and float)
+    /** @brief Get the value as a double, regardless of whether it was stored as int or float. */
     double asDouble() const { return float_val; }
 
     // Get as int64 (truncates floats)
+    /** @brief Get the value as an int64_t, truncating toward zero if it was stored as a float. */
     int64_t asInt() const { return int_val; }
 
     // Promote to float if either operand is float
+    /**
+     * @brief Add two constant values, promoting to float if either operand is a float.
+     * @return The sum, or an invalid ConstValue if either operand is invalid.
+     */
     static ConstValue add(const ConstValue& a, const ConstValue& b) {
         if (!a.isValid() || !b.isValid()) return none();
         if (a.isFloat() || b.isFloat()) {
@@ -63,6 +75,10 @@ struct ConstValue {
         return makeInt(a.asInt() + b.asInt());
     }
 
+    /**
+     * @brief Subtract two constant values, promoting to float if either operand is a float.
+     * @return The difference (a - b), or an invalid ConstValue if either operand is invalid.
+     */
     static ConstValue sub(const ConstValue& a, const ConstValue& b) {
         if (!a.isValid() || !b.isValid()) return none();
         if (a.isFloat() || b.isFloat()) {
@@ -71,6 +87,10 @@ struct ConstValue {
         return makeInt(a.asInt() - b.asInt());
     }
 
+    /**
+     * @brief Multiply two constant values, promoting to float if either operand is a float.
+     * @return The product, or an invalid ConstValue if either operand is invalid.
+     */
     static ConstValue mul(const ConstValue& a, const ConstValue& b) {
         if (!a.isValid() || !b.isValid()) return none();
         if (a.isFloat() || b.isFloat()) {
@@ -79,6 +99,11 @@ struct ConstValue {
         return makeInt(a.asInt() * b.asInt());
     }
 
+    /**
+     * @brief Divide two constant values, promoting to float if either operand is a float.
+     * @return The quotient (a / b), or an invalid ConstValue if either operand is invalid or if
+     * division by zero is detected.
+     */
     static ConstValue div(const ConstValue& a, const ConstValue& b) {
         if (!a.isValid() || !b.isValid()) return none();
         // Check for division by zero
@@ -201,6 +226,15 @@ ConstValue evaluateConstExpr(const eshkol_ast_t* expr) {
 
 } // anonymous namespace
 
+/**
+ * @brief Try to evaluate this CTValue as a concrete natural number (uint64_t).
+ *
+ * For Kind::Nat returns the stored value directly. For Kind::Expr, folds the referenced AST
+ * expression via evaluateConstExpr(), accepting non-negative integer literals and integer-valued
+ * float literals (and arithmetic combinations thereof).
+ *
+ * @return The evaluated value, or std::nullopt if it depends on a runtime value or is negative/non-integral.
+ */
 std::optional<uint64_t> CTValue::tryEvalNat() const {
     switch (kind_) {
         case Kind::Nat:
@@ -232,6 +266,14 @@ std::optional<uint64_t> CTValue::tryEvalNat() const {
     }
 }
 
+/**
+ * @brief Try to evaluate this CTValue as a concrete double.
+ *
+ * For Kind::Nat, converts the stored natural number to double. For Kind::Expr, folds the
+ * referenced AST expression via evaluateConstExpr().
+ *
+ * @return The evaluated value, or std::nullopt if it depends on a runtime value.
+ */
 std::optional<double> CTValue::tryEvalFloat() const {
     switch (kind_) {
         case Kind::Nat:
@@ -255,6 +297,12 @@ std::optional<double> CTValue::tryEvalFloat() const {
 
 // ===== DependentType Implementation =====
 
+/**
+ * @brief Render this dependent type as a string such as "Type#104<Type#16, 3, 4>".
+ *
+ * Note: base and parameter type names are printed as "Type#<id>" since no TypeEnvironment is
+ * available here to resolve human-readable names; value indices use CTValue::toString().
+ */
 std::string DependentType::toString() const {
     std::ostringstream ss;
 
@@ -285,6 +333,12 @@ std::string DependentType::toString() const {
     return ss.str();
 }
 
+/**
+ * @brief Structural equality check for dependent types.
+ *
+ * Requires the same base type, the same type indices (in order), and the same value indices
+ * (compared via CTValue::equals(), each of which must yield CompareResult::True).
+ */
 bool DependentType::equals(const DependentType& other) const {
     // Check base type
     if (base != other.base) return false;
@@ -305,6 +359,15 @@ bool DependentType::equals(const DependentType& other) const {
     return true;
 }
 
+/**
+ * @brief Subtype check for dependent types.
+ *
+ * Requires the base types to be subtypes per @p env, requires type indices to be pairwise equal
+ * or subtypes (covariant), and requires all value indices to be provably equal
+ * (CompareResult::True) — dimensions cannot differ between subtype and supertype.
+ *
+ * @return True if this type is a subtype of @p other under @p env.
+ */
 bool DependentType::isSubtypeOf(const DependentType& other, const TypeEnvironment& env) const {
     // First check if base types are subtypes
     if (!env.isSubtype(base, other.base)) {
@@ -336,6 +399,17 @@ bool DependentType::isSubtypeOf(const DependentType& other, const TypeEnvironmen
 
 // ===== DimensionChecker Implementation =====
 
+/**
+ * @brief Check that a compile-time index is within `[0, bound)`.
+ *
+ * If both @p idx and @p bound evaluate to concrete naturals, checks the bound directly. If only
+ * @p idx is known, or if @p idx cannot be evaluated at all, the check conservatively fails since
+ * it cannot be statically proven.
+ *
+ * @return Result::success() only when both values are known and the index is in bounds;
+ * otherwise a Result::failure() carrying a diagnostic message that includes @p context when
+ * non-empty.
+ */
 DimensionChecker::Result DimensionChecker::checkBounds(
     const CTValue& idx, const CTValue& bound, const std::string& context) {
 
@@ -375,6 +449,12 @@ DimensionChecker::Result DimensionChecker::checkBounds(
     return Result::failure(ss.str());
 }
 
+/**
+ * @brief Check that two compile-time dimensions are equal.
+ *
+ * @return Result::success() if CTValue::equals() proves equality; a Result::failure() with a
+ * mismatch or "proof required" message otherwise, including @p context when non-empty.
+ */
 DimensionChecker::Result DimensionChecker::checkDimensionsEqual(
     const CTValue& dim1, const CTValue& dim2, const std::string& context) {
 
@@ -404,6 +484,13 @@ DimensionChecker::Result DimensionChecker::checkDimensionsEqual(
     return Result::failure(ss.str());
 }
 
+/**
+ * @brief Check matrix-multiplication dimension compatibility: (m x n) * (n x p) requires the
+ * left matrix's column count to equal the right matrix's row count.
+ *
+ * @return Result::failure() if either side has fewer than 2 dimension indices; otherwise the
+ * result of checkDimensionsEqual() on the shared "n" dimension.
+ */
 DimensionChecker::Result DimensionChecker::checkMatMulDimensions(
     const DependentType& left, const DependentType& right, const std::string& context) {
 
@@ -421,6 +508,13 @@ DimensionChecker::Result DimensionChecker::checkMatMulDimensions(
         context.empty() ? "matrix multiplication" : context);
 }
 
+/**
+ * @brief Check vector dot-product dimension compatibility: both vectors must have the same
+ * (first) dimension.
+ *
+ * @return Result::failure() if either side has no dimension indices; otherwise the result of
+ * checkDimensionsEqual() on the first dimension of each.
+ */
 DimensionChecker::Result DimensionChecker::checkDotProductDimensions(
     const DependentType& left, const DependentType& right, const std::string& context) {
 

--- a/lib/types/hott_types.cpp
+++ b/lib/types/hott_types.cpp
@@ -17,6 +17,11 @@ namespace eshkol::hott {
 // UTILITY FUNCTIONS
 // ============================================================================
 
+/**
+ * @brief Convert a Universe level to a human-readable label.
+ * @param u Universe level to describe.
+ * @return A static UTF-8 string such as "Type₀"/"Type₁"/"Type₂"/"Typeω", or "Type?" for an unrecognized value.
+ */
 const char* universeToString(Universe u) {
     switch (u) {
         case Universe::U0: return "Type\342\202\200";  // Type₀ (UTF-8 subscript 0)
@@ -27,6 +32,11 @@ const char* universeToString(Universe u) {
     }
 }
 
+/**
+ * @brief Convert a RuntimeRep to its short lowercase name (e.g. "int64", "ptr").
+ * @param rep Runtime representation to describe.
+ * @return A static string naming the representation, or "unknown" if unrecognized.
+ */
 const char* runtimeRepToString(RuntimeRep rep) {
     switch (rep) {
         case RuntimeRep::Int8: return "int8";
@@ -47,10 +57,22 @@ const char* runtimeRepToString(RuntimeRep rep) {
     }
 }
 
+/**
+ * @brief Check whether a type is numeric, i.e. Number or one of its subtypes.
+ * @param env Type environment used to resolve the subtype relationship.
+ * @param id Type to test.
+ * @return True if @p id is Number or a subtype of Number.
+ */
 bool isNumericType(const TypeEnvironment& env, TypeId id) {
     return env.isSubtype(id, BuiltinTypes::Number);
 }
 
+/**
+ * @brief Check whether a type is a collection type (List, Vector, or Tensor, or a subtype thereof).
+ * @param env Type environment used to resolve the subtype relationships.
+ * @param id Type to test.
+ * @return True if @p id is a subtype of List, Vector, or Tensor.
+ */
 bool isCollectionType(const TypeEnvironment& env, TypeId id) {
     return env.isSubtype(id, BuiltinTypes::List) ||
            env.isSubtype(id, BuiltinTypes::Vector) ||
@@ -61,10 +83,19 @@ bool isCollectionType(const TypeEnvironment& env, TypeId id) {
 // TYPE ENVIRONMENT IMPLEMENTATION
 // ============================================================================
 
+/**
+ * @brief Construct a TypeEnvironment and populate it with all builtin types via initializeBuiltinTypes().
+ */
 TypeEnvironment::TypeEnvironment() {
     initializeBuiltinTypes();
 }
 
+/**
+ * @brief Register every builtin type (universes, the numeric tower, text types,
+ * collection/type-constructor families, autodiff and hash types, resource types, and proposition
+ * types) and populate the common name aliases (e.g. "int", "i32", "float64") used for parsing
+ * type annotations.
+ */
 void TypeEnvironment::initializeBuiltinTypes() {
     using namespace BuiltinTypes;
 
@@ -241,6 +272,15 @@ void TypeEnvironment::initializeBuiltinTypes() {
     name_to_id_["adnode"] = ADNode;
 }
 
+/**
+ * @brief Register a non-parameterized builtin type in the type graph.
+ *
+ * Creates a TypeNode for @p id with the given @p name, @p level, @p flags, and runtime
+ * representation @p rep, records it under both its numeric id and its @p name, and (if
+ * @p supertype is given) links it into the supertype's subtype list via addSubtype().
+ *
+ * @return The TypeId assigned to the newly registered type.
+ */
 TypeId TypeEnvironment::registerBuiltinType(uint16_t id, const std::string& name,
                                              Universe level, uint8_t flags,
                                              RuntimeRep rep,
@@ -266,6 +306,14 @@ TypeId TypeEnvironment::registerBuiltinType(uint16_t id, const std::string& name
     return type_id;
 }
 
+/**
+ * @brief Register a parameterized type family (e.g. List<A>, Pair<A,B>).
+ *
+ * Creates a TypeNode marked as a type family (is_type_family = true) with the given
+ * @p param_names, and records it under both its numeric id and its @p name.
+ *
+ * @return The TypeId assigned to the newly registered type family.
+ */
 TypeId TypeEnvironment::registerTypeFamily(uint16_t id, const std::string& name,
                                             Universe level,
                                             const std::vector<std::string>& param_names,
@@ -286,6 +334,15 @@ TypeId TypeEnvironment::registerTypeFamily(uint16_t id, const std::string& name,
     return type_id;
 }
 
+/**
+ * @brief Register a user-defined type (from a `define-type` form), assigning it a fresh id
+ * starting at 1000.
+ *
+ * Creates a TypeNode marked with Origin::UserDefined, records it by name, and (if @p supertype
+ * is given) links it into the supertype's subtype list via addSubtype().
+ *
+ * @return The newly assigned TypeId.
+ */
 TypeId TypeEnvironment::registerUserType(const std::string& name, Universe level,
                                           uint8_t flags,
                                           std::optional<TypeId> supertype) {
@@ -310,6 +367,11 @@ TypeId TypeEnvironment::registerUserType(const std::string& name, Universe level
     return type_id;
 }
 
+/**
+ * @brief Record @p subtype as a child of @p supertype in the type graph.
+ *
+ * No-op if @p supertype is not a registered type.
+ */
 void TypeEnvironment::addSubtype(TypeId supertype, TypeId subtype) {
     auto it = types_.find(supertype.id);
     if (it != types_.end()) {
@@ -317,6 +379,10 @@ void TypeEnvironment::addSubtype(TypeId supertype, TypeId subtype) {
     }
 }
 
+/**
+ * @brief Look up a type by name, trying an exact match first and then a lowercase fallback.
+ * @return The TypeId if found, or std::nullopt otherwise.
+ */
 std::optional<TypeId> TypeEnvironment::lookupType(const std::string& name) const {
     // Try exact match first
     auto it = name_to_id_.find(name);
@@ -335,11 +401,21 @@ std::optional<TypeId> TypeEnvironment::lookupType(const std::string& name) const
     return std::nullopt;
 }
 
+/**
+ * @brief Look up the TypeNode for a given TypeId.
+ * @return Pointer to the stored TypeNode, or nullptr if @p id is not registered.
+ */
 const TypeNode* TypeEnvironment::getTypeNode(TypeId id) const {
     auto it = types_.find(id.id);
     return (it != types_.end()) ? &it->second : nullptr;
 }
 
+/**
+ * @brief Get a human-readable name for a type.
+ *
+ * If @p id is a tracked pair type, returns "Pair<car, cdr>" built recursively from the element
+ * types; otherwise returns the registered name, or "unknown" if @p id is not registered.
+ */
 std::string TypeEnvironment::getTypeName(TypeId id) const {
     // Check if this is a tracked pair type
     auto pair_elems = getPairElementTypes(id);
@@ -351,6 +427,12 @@ std::string TypeEnvironment::getTypeName(TypeId id) const {
     return node ? node->name : "unknown";
 }
 
+/**
+ * @brief Check whether @p sub is a subtype of @p super, using a cache to avoid re-walking the
+ * type graph.
+ *
+ * On a cache miss, delegates to isSubtypeUncached() and stores the result.
+ */
 bool TypeEnvironment::isSubtype(TypeId sub, TypeId super) const {
     // Check cache
     auto key = std::make_pair(sub.id, super.id);
@@ -364,6 +446,13 @@ bool TypeEnvironment::isSubtype(TypeId sub, TypeId super) const {
     return result;
 }
 
+/**
+ * @brief Compute (without using the cache) whether @p sub is a subtype of @p super.
+ *
+ * Handles reflexivity (a type is a subtype of itself), tracked pair types (which are treated as
+ * subtypes of the generic Pair type), and otherwise walks the supertype chain from @p sub looking
+ * for @p super.
+ */
 bool TypeEnvironment::isSubtypeUncached(TypeId sub, TypeId super) const {
     // Reflexivity
     if (sub == super) return true;
@@ -387,6 +476,14 @@ bool TypeEnvironment::isSubtypeUncached(TypeId sub, TypeId super) const {
     return false;
 }
 
+/**
+ * @brief Find the least (most specific) common supertype of two types.
+ *
+ * Walks both types' supertype chains (via getSupertypeChain()) from most specific to most
+ * general and returns the first type that appears in both.
+ *
+ * @return The common supertype, or std::nullopt if none exists.
+ */
 std::optional<TypeId> TypeEnvironment::leastCommonSupertype(TypeId a, TypeId b) const {
     // Same type
     if (a == b) return a;
@@ -405,6 +502,11 @@ std::optional<TypeId> TypeEnvironment::leastCommonSupertype(TypeId a, TypeId b) 
     return std::nullopt;
 }
 
+/**
+ * @brief Compute the chain of supertypes from @p type up to the root, inclusive of @p type itself.
+ *
+ * Tracked pair types delegate to the generic Pair type's chain (prefixed by the pair type itself).
+ */
 std::vector<TypeId> TypeEnvironment::getSupertypeChain(TypeId type) const {
     std::vector<TypeId> chain;
     chain.push_back(type);
@@ -425,6 +527,13 @@ std::vector<TypeId> TypeEnvironment::getSupertypeChain(TypeId type) const {
     return chain;
 }
 
+/**
+ * @brief Determine the result type of an arithmetic operation between two types, implementing
+ * the Scheme numeric tower promotion rules (exact/inexact contagion, Complex/BigInt/Real handling).
+ *
+ * @return The promoted TypeId, falling back to the least common supertype (or Number) if no
+ * specific promotion rule applies.
+ */
 TypeId TypeEnvironment::promoteForArithmetic(TypeId a, TypeId b) const {
     using namespace BuiltinTypes;
 
@@ -482,16 +591,32 @@ TypeId TypeEnvironment::promoteForArithmetic(TypeId a, TypeId b) const {
     return lcs.value_or(Number);
 }
 
+/**
+ * @brief Check whether two types are equivalent. Currently this is identity only; type aliasing
+ * is not yet implemented.
+ */
 bool TypeEnvironment::areEquivalent(TypeId a, TypeId b) const {
     // For now, just identity. Will support type aliases later.
     return a == b;
 }
 
+/**
+ * @brief Get the runtime representation (LLVM/C-level layout) for a type.
+ * @return The registered RuntimeRep, or RuntimeRep::TaggedValue if @p id is not registered.
+ */
 RuntimeRep TypeEnvironment::getRuntimeRep(TypeId id) const {
     const TypeNode* node = getTypeNode(id);
     return node ? node->runtime_rep : RuntimeRep::TaggedValue;
 }
 
+/**
+ * @brief Map a runtime `eshkol_value_type_t` tag to the corresponding HoTT TypeId.
+ *
+ * Strips exactness flags for immediate types (tag < 8) but passes legacy pointer tags (>= 8,
+ * e.g. CONS_PTR, STRING_PTR) through unmasked.
+ *
+ * @return The corresponding TypeId, or BuiltinTypes::Value if the tag is not recognized.
+ */
 TypeId TypeEnvironment::fromRuntimeType(uint8_t runtime_type) const {
     using namespace BuiltinTypes;
 
@@ -538,6 +663,10 @@ TypeId TypeEnvironment::fromRuntimeType(uint8_t runtime_type) const {
     }
 }
 
+/**
+ * @brief Map a HoTT TypeId back to a runtime `eshkol_value_type_t` tag.
+ * @return The corresponding runtime tag, or ESHKOL_VALUE_NULL as a fallback for supertypes/unknown types.
+ */
 uint8_t TypeEnvironment::toRuntimeType(TypeId id) const {
     using namespace BuiltinTypes;
 
@@ -570,6 +699,11 @@ uint8_t TypeEnvironment::toRuntimeType(TypeId id) const {
 // PARAMETERIZED TYPES IMPLEMENTATION
 // ============================================================================
 
+/**
+ * @brief Create (and cache) a ParameterizedType instance for @p base_type applied to @p type_args.
+ *
+ * For example, instantiateType(List, {Int64}) represents List<Int64>.
+ */
 ParameterizedType TypeEnvironment::instantiateType(TypeId base_type,
                                                     const std::vector<TypeId>& type_args) const {
     ParameterizedType ptype;
@@ -582,31 +716,49 @@ ParameterizedType TypeEnvironment::instantiateType(TypeId base_type,
     return ptype;
 }
 
+/** @brief Create a List<element_type> parameterized type. Convenience wrapper over instantiateType(). */
 ParameterizedType TypeEnvironment::makeListType(TypeId element_type) const {
     return instantiateType(BuiltinTypes::List, {element_type});
 }
 
+/** @brief Create a Vector<element_type> parameterized type. Convenience wrapper over instantiateType(). */
 ParameterizedType TypeEnvironment::makeVectorType(TypeId element_type) const {
     return instantiateType(BuiltinTypes::Vector, {element_type});
 }
 
+/** @brief Create a Ptr<element_type> parameterized type. Convenience wrapper over instantiateType(). */
 ParameterizedType TypeEnvironment::makePointerType(TypeId element_type) const {
     return instantiateType(BuiltinTypes::Pointer, {element_type});
 }
 
+/** @brief Create a HashTable<key_type, value_type> parameterized type. */
 ParameterizedType TypeEnvironment::makeHashTableType(TypeId key_type, TypeId value_type) const {
     return instantiateType(BuiltinTypes::HashTable, {key_type, value_type});
 }
 
+/** @brief Check whether a type is a type family (parameterized type constructor like List or Vector). */
 bool TypeEnvironment::isTypeFamily(TypeId id) const {
     const TypeNode* node = getTypeNode(id);
     return node && node->is_type_family;
 }
 
+/**
+ * @brief Get the element type of a parameterized collection type.
+ * @return @p ptype's first type argument, or BuiltinTypes::Value if it has none.
+ */
 TypeId TypeEnvironment::getElementType(const ParameterizedType& ptype) const {
     return ptype.elementType();
 }
 
+/**
+ * @brief Infer the common element type of a homogeneous list from its elements' types.
+ *
+ * Starts from the first element's type and, for each subsequent differing type, attempts to
+ * widen to their least common supertype.
+ *
+ * @return The inferred common type, or BuiltinTypes::Value if the list is empty or no common
+ * supertype exists among the element types.
+ */
 TypeId TypeEnvironment::inferListElementType(const std::vector<TypeId>& element_types) const {
     if (element_types.empty()) {
         return BuiltinTypes::Value;  // Empty list has unknown element type
@@ -635,6 +787,10 @@ TypeId TypeEnvironment::inferListElementType(const std::vector<TypeId>& element_
 // Dependent Type Dimension Tracking
 // ============================================================================
 
+/**
+ * @brief Create a Vector<element_type, dimension> parameterized type carrying a known
+ * compile-time dimension, and cache the instantiation.
+ */
 ParameterizedType TypeEnvironment::makeVectorTypeWithDim(TypeId element_type, uint64_t dimension) const {
     ParameterizedType ptype;
     ptype.base_type = BuiltinTypes::Vector;
@@ -647,6 +803,10 @@ ParameterizedType TypeEnvironment::makeVectorTypeWithDim(TypeId element_type, ui
     return ptype;
 }
 
+/**
+ * @brief Create a Tensor<element_type, dims...> parameterized type carrying known compile-time
+ * dimensions, and cache the instantiation.
+ */
 ParameterizedType TypeEnvironment::makeTensorTypeWithDims(TypeId element_type,
                                                            const std::vector<uint64_t>& dimensions) const {
     ParameterizedType ptype;
@@ -663,10 +823,15 @@ ParameterizedType TypeEnvironment::makeTensorTypeWithDims(TypeId element_type,
     return ptype;
 }
 
+/** @brief Store dimension info for @p type_id so it can later be retrieved via getDimensionInfo(). */
 void TypeEnvironment::storeDimensionInfo(TypeId type_id, const std::vector<CTValueSimple>& dimensions) {
     dimension_cache_[type_id.id] = dimensions;
 }
 
+/**
+ * @brief Retrieve previously stored dimension info for a TypeId.
+ * @return The stored dimensions, or std::nullopt if none were stored via storeDimensionInfo().
+ */
 std::optional<std::vector<CTValueSimple>> TypeEnvironment::getDimensionInfo(TypeId type_id) const {
     auto it = dimension_cache_.find(type_id.id);
     if (it != dimension_cache_.end()) {
@@ -679,10 +844,24 @@ std::optional<std::vector<CTValueSimple>> TypeEnvironment::getDimensionInfo(Type
 // FUNCTION TYPES (Π-TYPES)
 // ============================================================================
 
+/**
+ * @brief Create a non-variadic function type. Convenience overload forwarding to the
+ * 3-argument makeFunctionType() with is_variadic = false.
+ */
 TypeId TypeEnvironment::makeFunctionType(const std::vector<TypeId>& param_types, TypeId return_type) const {
     return makeFunctionType(param_types, return_type, /*is_variadic=*/false);
 }
 
+/**
+ * @brief Create or retrieve a cached function type for the given parameter types, return type,
+ * and variadic flag.
+ *
+ * Searches function_type_cache_ for an existing PiType with matching return type, parameter
+ * count, variadic flag, and parameter types; if found, its TypeId is reused. Otherwise a new
+ * PiType is built and assigned a fresh id from next_function_type_id_.
+ *
+ * @return The TypeId identifying this function type.
+ */
 TypeId TypeEnvironment::makeFunctionType(const std::vector<TypeId>& param_types, TypeId return_type,
                                           bool is_variadic) const {
     // Check if we already have this exact function type cached
@@ -717,10 +896,15 @@ TypeId TypeEnvironment::makeFunctionType(const std::vector<TypeId>& param_types,
     return TypeId{type_id, Universe::U0, 0};
 }
 
+/** @brief Create a simple unary function type `input -> output`. */
 TypeId TypeEnvironment::makeSimpleFunctionType(TypeId input, TypeId output) const {
     return makeFunctionType({input}, output);
 }
 
+/**
+ * @brief Look up the PiType describing a function TypeId.
+ * @return Pointer to the cached PiType, or nullptr if @p id is not a function type.
+ */
 const PiType* TypeEnvironment::getFunctionType(TypeId id) const {
     // Check if it's in the function type cache
     auto it = function_type_cache_.find(id.id);
@@ -732,6 +916,10 @@ const PiType* TypeEnvironment::getFunctionType(TypeId id) const {
     return nullptr;
 }
 
+/**
+ * @brief Check whether a TypeId represents a function type (the generic Function type or a
+ * specific cached function signature).
+ */
 bool TypeEnvironment::isFunctionType(TypeId id) const {
     // Check if it's the base Function type or a specific function type
     if (id == BuiltinTypes::Function) {
@@ -740,6 +928,10 @@ bool TypeEnvironment::isFunctionType(TypeId id) const {
     return function_type_cache_.find(id.id) != function_type_cache_.end();
 }
 
+/**
+ * @brief Get the return type of a function TypeId.
+ * @return The function's return type, or BuiltinTypes::Value if @p id is not a function type.
+ */
 TypeId TypeEnvironment::getFunctionReturnType(TypeId id) const {
     const PiType* pi = getFunctionType(id);
     if (pi) {
@@ -748,6 +940,11 @@ TypeId TypeEnvironment::getFunctionReturnType(TypeId id) const {
     return BuiltinTypes::Value;
 }
 
+/**
+ * @brief Get the parameter types of a function TypeId.
+ * @return The function's parameter types in order, or an empty vector if @p id is not a
+ * function type.
+ */
 std::vector<TypeId> TypeEnvironment::getFunctionParamTypes(TypeId id) const {
     const PiType* pi = getFunctionType(id);
     if (pi) {
@@ -761,6 +958,10 @@ std::vector<TypeId> TypeEnvironment::getFunctionParamTypes(TypeId id) const {
     return {};
 }
 
+/**
+ * @brief Build a human-readable name for a function type, e.g. "(Int64, Float64) -> Boolean".
+ * @return "Function" if @p id is not a registered function type.
+ */
 std::string TypeEnvironment::getFunctionTypeName(TypeId id) const {
     const PiType* pi = getFunctionType(id);
     if (!pi) {
@@ -789,6 +990,13 @@ std::string TypeEnvironment::getFunctionTypeName(TypeId id) const {
 // PAIR TYPE TRACKING
 // ============================================================================
 
+/**
+ * @brief Create or retrieve a cached Pair<car_type, cdr_type> TypeId, used by cons to propagate
+ * element types through car/cdr.
+ *
+ * Searches pair_element_cache_ for a matching (car_type, cdr_type) pair; if found, its TypeId is
+ * reused, otherwise a new id is allocated from next_pair_type_id_.
+ */
 TypeId TypeEnvironment::makePairType(TypeId car_type, TypeId cdr_type) const {
     // Check if we already have this exact pair type cached
     for (const auto& entry : pair_element_cache_) {
@@ -804,6 +1012,10 @@ TypeId TypeEnvironment::makePairType(TypeId car_type, TypeId cdr_type) const {
     return TypeId{type_id, Universe::U1, 0};
 }
 
+/**
+ * @brief Retrieve the (car_type, cdr_type) element types for a tracked pair TypeId.
+ * @return The element type pair, or std::nullopt if @p id is not a tracked pair type.
+ */
 std::optional<std::pair<TypeId, TypeId>> TypeEnvironment::getPairElementTypes(TypeId id) const {
     auto it = pair_element_cache_.find(id.id);
     if (it != pair_element_cache_.end()) {
@@ -812,6 +1024,10 @@ std::optional<std::pair<TypeId, TypeId>> TypeEnvironment::getPairElementTypes(Ty
     return std::nullopt;
 }
 
+/**
+ * @brief Check whether a TypeId represents a tracked pair type (one with known element types
+ * created via makePairType()).
+ */
 bool TypeEnvironment::isTrackedPairType(TypeId id) const {
     return pair_element_cache_.find(id.id) != pair_element_cache_.end();
 }

--- a/lib/types/type_checker.cpp
+++ b/lib/types/type_checker.cpp
@@ -16,27 +16,51 @@ namespace eshkol::hott {
 // Context Implementation
 // ============================================================================
 
+/**
+ * @brief Construct a type-checking context, seeding it with a single global scope.
+ */
 Context::Context() {
     // Start with global scope
     scopes_.push_back({});
 }
 
+/**
+ * @brief Push a new, empty variable-binding scope onto the scope stack.
+ */
 void Context::pushScope() {
     scopes_.push_back({});
 }
 
+/**
+ * @brief Pop the innermost variable-binding scope, discarding its bindings.
+ *
+ * The outermost (global) scope is never popped, so the scope stack always
+ * has at least one entry.
+ */
 void Context::popScope() {
     if (scopes_.size() > 1) {
         scopes_.pop_back();
     }
 }
 
+/**
+ * @brief Bind @p name to @p type in the innermost (current) scope.
+ *
+ * If @p name is already bound in the innermost scope, the previous binding
+ * is shadowed/overwritten.
+ */
 void Context::bind(const std::string& name, TypeId type) {
     if (!scopes_.empty()) {
         scopes_.back()[name] = type;
     }
 }
 
+/**
+ * @brief Look up the type bound to @p name, searching from the innermost
+ * scope outward to the global scope.
+ * @return The bound TypeId, or std::nullopt if @p name is not bound in any
+ * scope.
+ */
 std::optional<TypeId> Context::lookup(const std::string& name) const {
     // Search from innermost to outermost scope
     for (auto it = scopes_.rbegin(); it != scopes_.rend(); ++it) {
@@ -48,6 +72,13 @@ std::optional<TypeId> Context::lookup(const std::string& name) const {
     return std::nullopt;
 }
 
+/**
+ * @brief Register a type alias introduced by a `define-type` form.
+ *
+ * Records @p type_expr under @p name so later references to @p name resolve
+ * to it. If @p params is non-empty, @p name is also recorded as a
+ * parameterized (generic) alias, e.g. `(define-type (MyList a) (list a))`.
+ */
 void Context::defineTypeAlias(const std::string& name, hott_type_expr_t* type_expr,
                               const std::vector<std::string>& params) {
     type_aliases_[name] = type_expr;
@@ -57,10 +88,18 @@ void Context::defineTypeAlias(const std::string& name, hott_type_expr_t* type_ex
     }
 }
 
+/**
+ * @brief True if the type alias @p name was declared with formal type parameters.
+ */
 bool Context::hasTypeAliasParams(const std::string& name) const {
     return type_alias_params_.find(name) != type_alias_params_.end();
 }
 
+/**
+ * @brief Get the formal type parameter names for the parameterized type alias @p name.
+ * @return The declared parameter names, or a reference to an empty vector if
+ * @p name has no parameters (or is not a known alias).
+ */
 const std::vector<std::string>& Context::getTypeAliasParams(const std::string& name) const {
     auto it = type_alias_params_.find(name);
     if (it != type_alias_params_.end()) {
@@ -69,6 +108,11 @@ const std::vector<std::string>& Context::getTypeAliasParams(const std::string& n
     return empty_params_;
 }
 
+/**
+ * @brief Look up the type expression registered for the type alias @p name.
+ * @return The alias's type expression, or std::nullopt if @p name is not a
+ * known alias.
+ */
 std::optional<hott_type_expr_t*> Context::lookupTypeAlias(const std::string& name) const {
     auto found = type_aliases_.find(name);
     if (found != type_aliases_.end()) {
@@ -77,7 +121,11 @@ std::optional<hott_type_expr_t*> Context::lookupTypeAlias(const std::string& nam
     return std::nullopt;
 }
 
-// Helper function to allocate a type expression
+/**
+ * @brief Allocate a zero-initialized hott_type_expr_t of the given @p kind from the global arena.
+ * @return The new type expression with `kind` set (and all other fields
+ * zeroed), or nullptr if arena allocation fails.
+ */
 static hott_type_expr_t* allocTypeExpr(hott_type_kind_t kind) {
     void* mem = arena_allocate_zeroed(get_global_arena(), sizeof(hott_type_expr_t));
     hott_type_expr_t* type = (hott_type_expr_t*)mem;
@@ -85,7 +133,19 @@ static hott_type_expr_t* allocTypeExpr(hott_type_kind_t kind) {
     return type;
 }
 
-// Helper function to substitute type variables in a type expression
+/**
+ * @brief Recursively substitute type variables in @p type_expr per @p substitutions.
+ *
+ * Deep-copies @p type_expr, replacing any HOTT_TYPE_VAR node whose name is a
+ * key of @p substitutions with a copy of the corresponding replacement type
+ * (falling back to copying the variable itself if unmapped). For
+ * HOTT_TYPE_FORALL, the variables bound by the forall are removed from the
+ * substitution map before recursing into its body so bound variables are not
+ * accidentally captured/replaced. Used to instantiate parameterized type
+ * aliases (see Context::instantiateTypeAlias).
+ * @return A freshly allocated type expression with substitutions applied, or
+ * nullptr if @p type_expr is nullptr.
+ */
 static hott_type_expr_t* substituteTypeVars(
     const hott_type_expr_t* type_expr,
     const std::map<std::string, hott_type_expr_t*>& substitutions) {
@@ -176,6 +236,18 @@ static hott_type_expr_t* substituteTypeVars(
     return result;
 }
 
+/**
+ * @brief Instantiate the parameterized type alias @p name with concrete type arguments.
+ *
+ * Looks up @p name's registered type expression and formal parameters, binds
+ * each formal parameter to the corresponding entry of @p type_args (pairing
+ * up to `min(params.size(), type_args.size())`), and returns the result of
+ * substituting those bindings into the alias body via substituteTypeVars().
+ * If @p name has no declared parameters, a plain copy of the alias's type
+ * expression is returned.
+ * @return The instantiated type expression, or nullptr if @p name is not a
+ * known type alias.
+ */
 hott_type_expr_t* Context::instantiateTypeAlias(
     const std::string& name,
     const std::vector<hott_type_expr_t*>& type_args) const {
@@ -210,11 +282,22 @@ hott_type_expr_t* Context::instantiateTypeAlias(
 // LinearContext Implementation
 // ============================================================================
 
+/**
+ * @brief Declare @p name as a tracked linear variable, starting in the Unused state.
+ */
 void LinearContext::declareLinear(const std::string& name) {
     linear_vars_.insert(name);
     usage_[name] = Usage::Unused;
 }
 
+/**
+ * @brief Record a use of @p name, advancing its usage state.
+ *
+ * No-op if @p name is not a declared linear variable. Otherwise transitions
+ * Unused -> UsedOnce on the first use, and UsedOnce/UsedMultiple ->
+ * UsedMultiple on any subsequent use, so a linearity violation (used more
+ * than once) is detectable later via getOverused()/checkAllUsedOnce().
+ */
 void LinearContext::use(const std::string& name) {
     if (linear_vars_.count(name) == 0) return;
 
@@ -226,6 +309,11 @@ void LinearContext::use(const std::string& name) {
     }
 }
 
+/**
+ * @brief Check that every declared linear variable was used exactly once.
+ * @return True if all tracked variables are in the UsedOnce state; false if
+ * any is Unused or UsedMultiple.
+ */
 bool LinearContext::checkAllUsedOnce() const {
     for (const auto& name : linear_vars_) {
         auto it = usage_.find(name);
@@ -236,6 +324,10 @@ bool LinearContext::checkAllUsedOnce() const {
     return true;
 }
 
+/**
+ * @brief Get the names of declared linear variables that were never used.
+ * @return Names currently in the Unused usage state.
+ */
 std::vector<std::string> LinearContext::getUnused() const {
     std::vector<std::string> result;
     for (const auto& name : linear_vars_) {
@@ -247,6 +339,10 @@ std::vector<std::string> LinearContext::getUnused() const {
     return result;
 }
 
+/**
+ * @brief Get the names of declared linear variables that were used more than once.
+ * @return Names currently in the UsedMultiple usage state.
+ */
 std::vector<std::string> LinearContext::getOverused() const {
     std::vector<std::string> result;
     for (const auto& name : linear_vars_) {
@@ -258,11 +354,22 @@ std::vector<std::string> LinearContext::getOverused() const {
     return result;
 }
 
+/**
+ * @brief Mark @p name as fully consumed (must be used exactly once).
+ *
+ * Semantically delegates to use(); provided as a clearer-named API entry
+ * point for call sites that consume a linear variable outright.
+ */
 void LinearContext::consume(const std::string& name) {
     // Mark as used exactly once (same as use() semantically, but clearer for API)
     use(name);
 }
 
+/**
+ * @brief Get the current usage state of @p name.
+ * @return The tracked Usage value, or Usage::Unused if @p name has no
+ * recorded usage (including if it is not a declared linear variable).
+ */
 LinearContext::Usage LinearContext::getUsage(const std::string& name) const {
     auto it = usage_.find(name);
     if (it == usage_.end()) {
@@ -271,6 +378,9 @@ LinearContext::Usage LinearContext::getUsage(const std::string& name) const {
     return it->second;
 }
 
+/**
+ * @brief True if @p name was declared via declareLinear().
+ */
 bool LinearContext::isLinear(const std::string& name) const {
     return linear_vars_.count(name) > 0;
 }
@@ -279,10 +389,21 @@ bool LinearContext::isLinear(const std::string& name) const {
 // BorrowChecker Implementation (Phase 6.3)
 // ============================================================================
 
+/**
+ * @brief Enter a new nested scope, incrementing the current scope depth.
+ */
 void BorrowChecker::pushScope() {
     current_scope_++;
 }
 
+/**
+ * @brief Exit the current scope, checking that no borrows outlive it.
+ *
+ * For every tracked value whose BorrowInfo::scope_depth equals the scope
+ * being popped and which still has an active shared or mutable borrow,
+ * records a BorrowError::Kind::BorrowOutlivesValue error before decrementing
+ * the scope depth. No-op if already at the outermost scope (depth 0).
+ */
 void BorrowChecker::popScope() {
     if (current_scope_ > 0) {
         // Check for borrows that outlive their scope
@@ -297,6 +418,12 @@ void BorrowChecker::popScope() {
     }
 }
 
+/**
+ * @brief Declare @p name as a newly owned value in the current scope.
+ *
+ * Initializes (or resets) its BorrowInfo to BorrowState::Owned, no active
+ * borrows, and BorrowInfo::scope_depth set to the current scope.
+ */
 void BorrowChecker::declareOwned(const std::string& name) {
     BorrowInfo info;
     info.state = BorrowState::Owned;
@@ -304,6 +431,15 @@ void BorrowChecker::declareOwned(const std::string& name) {
     values_[name] = info;
 }
 
+/**
+ * @brief Attempt to move the value bound to @p name.
+ *
+ * Fails (recording the corresponding BorrowError) if @p name is unknown,
+ * already moved (UseAfterMove), already dropped (UseAfterDrop), or has any
+ * active shared/mutable borrow (MoveWhileBorrowed). On success, transitions
+ * @p name's state to BorrowState::Moved.
+ * @return True if the move succeeded; false otherwise.
+ */
 bool BorrowChecker::move(const std::string& name) {
     auto it = values_.find(name);
     if (it == values_.end()) {
@@ -335,6 +471,15 @@ bool BorrowChecker::move(const std::string& name) {
     return true;
 }
 
+/**
+ * @brief Explicitly drop the value bound to @p name.
+ *
+ * Fails silently (returns false, no error recorded) if @p name is unknown or
+ * already moved/dropped. Fails with a MoveWhileBorrowed error if @p name has
+ * any active shared/mutable borrow. On success, transitions @p name's state
+ * to BorrowState::Dropped.
+ * @return True if the drop succeeded; false otherwise.
+ */
 bool BorrowChecker::drop(const std::string& name) {
     auto it = values_.find(name);
     if (it == values_.end()) {
@@ -357,6 +502,15 @@ bool BorrowChecker::drop(const std::string& name) {
     return true;
 }
 
+/**
+ * @brief Attempt to take an immutable (shared) borrow of @p name.
+ *
+ * Fails if @p name is unknown, already moved (UseAfterMove), already dropped
+ * (UseAfterDrop), or currently has an active mutable borrow
+ * (MutableBorrowWhileShared). On success, increments the shared borrow
+ * count and, if the value was Owned, transitions it to BorrowedShared.
+ * @return True if the borrow succeeded; false otherwise.
+ */
 bool BorrowChecker::borrowShared(const std::string& name) {
     auto it = values_.find(name);
     if (it == values_.end()) {
@@ -390,6 +544,16 @@ bool BorrowChecker::borrowShared(const std::string& name) {
     return true;
 }
 
+/**
+ * @brief Attempt to take an exclusive (mutable) borrow of @p name.
+ *
+ * Fails if @p name is unknown, already moved (UseAfterMove), already dropped
+ * (UseAfterDrop), has any active shared borrows (MutableBorrowWhileShared),
+ * or already has an active mutable borrow (DoubleMutableBorrow). On success,
+ * sets BorrowInfo::has_mutable_borrow and transitions the state to
+ * BorrowState::BorrowedMut.
+ * @return True if the borrow succeeded; false otherwise.
+ */
 bool BorrowChecker::borrowMut(const std::string& name) {
     auto it = values_.find(name);
     if (it == values_.end()) {
@@ -426,6 +590,14 @@ bool BorrowChecker::borrowMut(const std::string& name) {
     return true;
 }
 
+/**
+ * @brief End one active borrow of @p name (mutable borrow takes priority over shared).
+ *
+ * No-op if @p name is unknown. Releases the mutable borrow if one is active,
+ * otherwise decrements the shared borrow count if positive. If no borrows
+ * remain afterward, restores the state from BorrowedShared/BorrowedMut back
+ * to BorrowState::Owned.
+ */
 void BorrowChecker::returnBorrow(const std::string& name) {
     auto it = values_.find(name);
     if (it == values_.end()) {
@@ -449,6 +621,11 @@ void BorrowChecker::returnBorrow(const std::string& name) {
     }
 }
 
+/**
+ * @brief Get the current BorrowState of @p name.
+ * @return The tracked state, or BorrowState::Owned if @p name is not tracked
+ * (treated as an untracked value that is assumed owned).
+ */
 BorrowState BorrowChecker::getState(const std::string& name) const {
     auto it = values_.find(name);
     if (it == values_.end()) {
@@ -457,6 +634,11 @@ BorrowState BorrowChecker::getState(const std::string& name) const {
     return it->second.state;
 }
 
+/**
+ * @brief True if @p name can currently be used, i.e. it has not been moved-from or dropped.
+ *
+ * Untracked names are assumed usable.
+ */
 bool BorrowChecker::canUse(const std::string& name) const {
     auto it = values_.find(name);
     if (it == values_.end()) {
@@ -466,6 +648,11 @@ bool BorrowChecker::canUse(const std::string& name) const {
            it->second.state != BorrowState::Dropped;
 }
 
+/**
+ * @brief True if @p name can currently be moved: owned, with no active shared or mutable borrows.
+ *
+ * Untracked names are assumed movable.
+ */
 bool BorrowChecker::canMove(const std::string& name) const {
     auto it = values_.find(name);
     if (it == values_.end()) {
@@ -477,6 +664,12 @@ bool BorrowChecker::canMove(const std::string& name) const {
            !info.has_mutable_borrow;
 }
 
+/**
+ * @brief True if @p name can currently be borrowed immutably: owned or already
+ * shared-borrowed, and not mutably borrowed.
+ *
+ * Untracked names are assumed borrowable.
+ */
 bool BorrowChecker::canBorrowShared(const std::string& name) const {
     auto it = values_.find(name);
     if (it == values_.end()) {
@@ -488,6 +681,12 @@ bool BorrowChecker::canBorrowShared(const std::string& name) const {
            !info.has_mutable_borrow;
 }
 
+/**
+ * @brief True if @p name can currently be borrowed mutably: owned, with no
+ * active shared or mutable borrows.
+ *
+ * Untracked names are assumed borrowable.
+ */
 bool BorrowChecker::canBorrowMut(const std::string& name) const {
     auto it = values_.find(name);
     if (it == values_.end()) {
@@ -499,6 +698,9 @@ bool BorrowChecker::canBorrowMut(const std::string& name) const {
            !info.has_mutable_borrow;
 }
 
+/**
+ * @brief Record a borrow-checking violation of the given @p kind for variable @p var.
+ */
 void BorrowChecker::addError(BorrowError::Kind kind, const std::string& var,
                               const std::string& msg) {
     errors_.push_back({kind, var, msg});
@@ -508,6 +710,13 @@ void BorrowChecker::addError(BorrowError::Kind kind, const std::string& var,
 // Context Linear Methods (Phase 6)
 // ============================================================================
 
+/**
+ * @brief Bind @p name to @p type in the innermost scope and mark it as a
+ * linear variable (must be used exactly once).
+ *
+ * Combines an ordinary Context::bind() with registering @p name in the
+ * linear-variable tracking set with a fresh usage count of 0.
+ */
 void Context::bindLinear(const std::string& name, TypeId type) {
     // Bind the variable normally
     bind(name, type);
@@ -516,26 +725,49 @@ void Context::bindLinear(const std::string& name, TypeId type) {
     linear_usage_count_[name] = 0;  // Unused initially
 }
 
+/**
+ * @brief Record a use of the linear variable @p name, incrementing its usage count.
+ *
+ * No-op if @p name was not bound via bindLinear(). A count greater than 1
+ * indicates a linearity violation, surfaced via getOverusedLinear().
+ */
 void Context::useLinear(const std::string& name) {
     if (linear_vars_.count(name) > 0) {
         linear_usage_count_[name]++;
     }
 }
 
+/**
+ * @brief Mark the linear variable @p name as consumed.
+ *
+ * Currently identical to useLinear(); kept as a distinctly named entry point
+ * for call sites that consume a linear binding outright (e.g. at let scope
+ * exit).
+ */
 void Context::consumeLinear(const std::string& name) {
     // Same as useLinear for tracking
     useLinear(name);
 }
 
+/**
+ * @brief True if @p name was bound via bindLinear().
+ */
 bool Context::isLinear(const std::string& name) const {
     return linear_vars_.count(name) > 0;
 }
 
+/**
+ * @brief True if the linear variable @p name has been used at least once.
+ */
 bool Context::isLinearUsed(const std::string& name) const {
     auto it = linear_usage_count_.find(name);
     return it != linear_usage_count_.end() && it->second > 0;
 }
 
+/**
+ * @brief Get the names of linear variables in scope that were never used.
+ * @return Names whose usage count is zero (or has no recorded entry).
+ */
 std::vector<std::string> Context::getUnusedLinear() const {
     std::vector<std::string> result;
     for (const auto& name : linear_vars_) {
@@ -547,6 +779,10 @@ std::vector<std::string> Context::getUnusedLinear() const {
     return result;
 }
 
+/**
+ * @brief Get the names of linear variables in scope that were used more than once.
+ * @return Names whose usage count exceeds 1.
+ */
 std::vector<std::string> Context::getOverusedLinear() const {
     std::vector<std::string> result;
     for (const auto& name : linear_vars_) {
@@ -558,6 +794,9 @@ std::vector<std::string> Context::getOverusedLinear() const {
     return result;
 }
 
+/**
+ * @brief True if every linear variable currently in scope was used exactly once.
+ */
 bool Context::checkLinearConstraints() const {
     for (const auto& name : linear_vars_) {
         auto it = linear_usage_count_.find(name);
@@ -572,10 +811,25 @@ bool Context::checkLinearConstraints() const {
 // TypeChecker Implementation
 // ============================================================================
 
+/**
+ * @brief Construct a type checker over @p env with the given strictness/safety mode.
+ * @param env Type environment providing type registration/lookup/subtyping.
+ * @param strict_types If true, reported type issues call eshkol_error() and
+ * abort compilation; if false, they call eshkol_warn() and compilation
+ * continues (gradual typing).
+ * @param unsafe_mode If true, the checker starts with type/linear/borrow
+ * issues silently ignored.
+ */
 TypeChecker::TypeChecker(TypeEnvironment& env, bool strict_types, bool unsafe_mode)
     : strict_types_(strict_types), unsafe_mode_(unsafe_mode), env_(env) {}
 
-// Helper to store inferred type in AST and return result
+/**
+ * @brief Store a successful result's inferred type into @p expr->inferred_hott_type, then return the result unchanged.
+ *
+ * Common tail call used by the synthesize()/check() helpers so every
+ * synthesis/checking rule records its result type on the AST node it typed.
+ * Failed results pass through without touching @p expr.
+ */
 static TypeCheckResult storeAndReturn(eshkol_ast_t* expr, TypeCheckResult result) {
     if (result.success && expr) {
         expr->inferred_hott_type = result.inferred_type.pack();
@@ -583,7 +837,11 @@ static TypeCheckResult storeAndReturn(eshkol_ast_t* expr, TypeCheckResult result
     return result;
 }
 
-// Helper to create error with source location from AST node
+/**
+ * @brief Build a TypeCheckResult::error() using @p expr's source line/column, if available.
+ *
+ * Falls back to an error with no location (line/column 0) if @p expr is null.
+ */
 static TypeCheckResult errorAt(const eshkol_ast_t* expr, const std::string& msg) {
     if (expr) {
         return TypeCheckResult::error(msg, expr->line, expr->column);
@@ -591,6 +849,14 @@ static TypeCheckResult errorAt(const eshkol_ast_t* expr, const std::string& msg)
     return TypeCheckResult::error(msg);
 }
 
+/**
+ * @brief Bind @p name in @p ctx to a synthetic function type of the given @p arity.
+ *
+ * Used to seed the context with the signatures of well-known stdlib
+ * procedures (see bindKnownRequireExports()) whose parameter/return types
+ * are approximated as BuiltinTypes::Value, so calls to them type-check
+ * without requiring full stdlib type declarations.
+ */
 static void bindKnownProcedure(Context& ctx,
                                TypeEnvironment& env,
                                const char* name,
@@ -600,6 +866,9 @@ static void bindKnownProcedure(Context& ctx,
     ctx.bind(name, env.makeFunctionType(params, BuiltinTypes::Value, is_variadic));
 }
 
+/**
+ * @brief True if a `require` operation @p op lists @p module_name among its imported modules.
+ */
 static bool requireNamesModule(const eshkol_operation& op, const char* module_name) {
     for (uint64_t i = 0; i < op.require_op.num_modules; ++i) {
         const char* candidate = op.require_op.module_names[i];
@@ -610,6 +879,16 @@ static bool requireNamesModule(const eshkol_operation& op, const char* module_na
     return false;
 }
 
+/**
+ * @brief Bind the known exported procedures of a `require`d module into @p ctx.
+ *
+ * Given a `require` operation @p op, checks whether it imports the "stdlib"
+ * or "core.list.higher_order" module and, if so, binds the well-known
+ * higher-order list procedures (map1/map2/map3, fold variants, for-each,
+ * any, every) via bindKnownProcedure() so subsequent calls to them
+ * type-check even though the stdlib's own type declarations are not loaded
+ * during isolated type checking.
+ */
 static void bindKnownRequireExports(Context& ctx,
                                     TypeEnvironment& env,
                                     const eshkol_operation& op) {
@@ -632,6 +911,19 @@ static void bindKnownRequireExports(Context& ctx,
     }
 }
 
+/**
+ * @brief Synthesis-mode entry point: infer the type of @p expr bottom-up (Γ ⊢ e ⇒ τ).
+ *
+ * Dispatches on @p expr's AST node kind to the appropriate synthesize*
+ * helper (literals/symbols to synthesizeLiteral(), variable references to
+ * synthesizeVariable(), operation forms to synthesizeOperation(), lambdas to
+ * synthesizeLambda(), and cons cells trivially to BuiltinTypes::List). On
+ * success, stores the inferred type into @p expr->inferred_hott_type via
+ * storeAndReturn().
+ * @return A successful TypeCheckResult carrying the inferred type, or a
+ * failing result (e.g. null expression, or an AST node kind with no
+ * synthesis rule).
+ */
 TypeCheckResult TypeChecker::synthesize(eshkol_ast_t* expr) {
     if (!expr) {
         return TypeCheckResult::error("Null expression");
@@ -674,6 +966,20 @@ TypeCheckResult TypeChecker::synthesize(eshkol_ast_t* expr) {
     return storeAndReturn(expr, result);
 }
 
+/**
+ * @brief Checking-mode entry point: verify @p expr has the expected type, top-down (Γ ⊢ e ⇐ τ).
+ *
+ * Lambdas get a dedicated checking rule (checkLambda()) so their parameter
+ * types can be inferred from @p expected rather than requiring annotations.
+ * All other expression kinds fall back to synthesizing @p expr's type and
+ * verifying it is a subtype of @p expected via TypeEnvironment::isSubtype().
+ * @param expr The expression to check.
+ * @param expected The type @p expr is expected to have.
+ * @return TypeCheckResult::ok(expected) on success; a type-mismatch error
+ * (also recorded via addTypeMismatch()) if synthesis succeeds but the
+ * inferred type is not a subtype of @p expected; or the failing result from
+ * synthesis if that fails first.
+ */
 TypeCheckResult TypeChecker::check(eshkol_ast_t* expr, TypeId expected) {
     if (!expr) {
         return TypeCheckResult::error("Null expression");
@@ -701,6 +1007,16 @@ TypeCheckResult TypeChecker::check(eshkol_ast_t* expr, TypeId expected) {
         ", got " + env_.getTypeName(result.inferred_type));
 }
 
+/**
+ * @brief Synthesis rule for self-evaluating literals and bare symbols.
+ *
+ * Maps each literal AST node kind to its builtin type: ESHKOL_INT64 ->
+ * Int64, ESHKOL_BIGNUM_LITERAL -> BigInt, ESHKOL_DOUBLE -> Float64,
+ * ESHKOL_STRING -> String, ESHKOL_BOOL -> Boolean, ESHKOL_NULL -> Null,
+ * ESHKOL_CHAR -> Char, and ESHKOL_SYMBOL -> Symbol.
+ * @return TypeCheckResult::ok() with the corresponding builtin type, or an
+ * error if @p expr->type is not one of the recognized literal kinds.
+ */
 TypeCheckResult TypeChecker::synthesizeLiteral(eshkol_ast_t* expr) {
     switch (expr->type) {
         case ESHKOL_INT64:
@@ -731,6 +1047,21 @@ TypeCheckResult TypeChecker::synthesizeLiteral(eshkol_ast_t* expr) {
     }
 }
 
+/**
+ * @brief Synthesis rule for variable references (Γ ⊢ x ⇒ τ).
+ *
+ * Looks up the variable's name in the context. If unbound, special-cases a
+ * few builtins used as first-class values: the arithmetic operators
+ * (+, -, *, /) synthesize a variadic-looking (Int64, Int64) -> Int64
+ * function type, and the I/O procedures (display, write, newline)
+ * synthesize a (Value) -> Null function type, matching how codegen wraps
+ * them as unary closures. Any other unbound name is an error. If the
+ * variable is bound and tracked as linear (Context::isLinear()), records a
+ * use via Context::useLinear() and reports a type issue if it was already
+ * used (linearity violation).
+ * @return The variable's bound type (or the synthesized builtin function
+ * type), or an error if the name is unbound and not a recognized builtin.
+ */
 TypeCheckResult TypeChecker::synthesizeVariable(eshkol_ast_t* expr) {
     if (!expr->variable.id) {
         return errorAt(expr, "Variable has no name");
@@ -769,6 +1100,33 @@ TypeCheckResult TypeChecker::synthesizeVariable(eshkol_ast_t* expr) {
     return TypeCheckResult::ok(*type);
 }
 
+/**
+ * @brief Synthesis rule for ESHKOL_OP nodes: dispatches on the operation kind
+ * (expr->operation.op) to the appropriate typing rule.
+ *
+ * Delegates the structurally interesting forms to dedicated helpers:
+ * `define` to synthesizeDefine(), `let`/`let*`/`letrec`/`letrec*` to
+ * synthesizeLet(), `if` to synthesizeIf(), `lambda`/`case-lambda` to
+ * synthesizeLambda(), and function calls to synthesizeApplication().
+ * `define-type` is handled inline: it registers the named (possibly
+ * parameterized) type alias into the context via Context::defineTypeAlias()
+ * and synthesizes BuiltinTypes::Null. `require` binds the known exported
+ * procedures of imported stdlib modules via bindKnownRequireExports() and
+ * also synthesizes Null. Arithmetic (+, -, *, /) synthesizes its first two
+ * operands and returns their arithmetic-promoted type via
+ * TypeEnvironment::promoteForArithmetic(); `begin`/sequence returns the type
+ * of its last sub-expression (or Null if empty). All remaining operation
+ * kinds (tensors, booleans, predicates, control flow, continuations,
+ * multiple values, quoting, logic/consciousness/DNC constructors, memory
+ * management, extern declarations, macro/syntax forms, and the catch-all
+ * default) synthesize a fixed builtin type — mostly BuiltinTypes::Value for
+ * forms whose precise result type is branch- or runtime-dependent, Boolean
+ * for predicates and and/or, and Function for calculus operators
+ * (diff/gradient/jacobian/etc).
+ * @return A successful TypeCheckResult per the rule above; this function has
+ * no failure path of its own (unsuccessful results only propagate from
+ * delegated helpers or nested synthesize() calls).
+ */
 TypeCheckResult TypeChecker::synthesizeOperation(eshkol_ast_t* expr) {
     switch (expr->operation.op) {
         case ESHKOL_DEFINE_OP:
@@ -979,6 +1337,23 @@ TypeCheckResult TypeChecker::synthesizeOperation(eshkol_ast_t* expr) {
     }
 }
 
+/**
+ * @brief Synthesis rule for lambda/case-lambda expressions (Γ ⊢ (lambda ...) ⇒ τ).
+ *
+ * Pushes a fresh scope and binds each parameter: its type comes from an
+ * explicit annotation (resolveType()) if present, otherwise defaults to
+ * BuiltinTypes::Value; parameters whose type carries TYPE_FLAG_LINEAR are
+ * bound via Context::bindLinear() so single-use is enforced. The body is
+ * then synthesized in this scope. Before popping the scope, verifies linear
+ * parameter usage via Context::checkLinearConstraints(), reporting a type
+ * issue for every unused or overused linear parameter. If the lambda has a
+ * return type annotation, checks the synthesized body type is a subtype of
+ * it (failing otherwise) and uses the annotated type for the result;
+ * otherwise uses the body's inferred type directly.
+ * @return A function type (via TypeEnvironment::makeFunctionType()) from the
+ * parameter types to the return type, respecting lambda.is_variadic; or an
+ * error if the body fails to synthesize or violates the return annotation.
+ */
 TypeCheckResult TypeChecker::synthesizeLambda(eshkol_ast_t* expr) {
     const auto& lambda = expr->operation.lambda_op;
 
@@ -1051,6 +1426,61 @@ TypeCheckResult TypeChecker::synthesizeLambda(eshkol_ast_t* expr) {
                                                       lambda.is_variadic));
 }
 
+/**
+ * @brief Synthesis rule for function application, ESHKOL_CALL_OP (Γ ⊢ (f a...) ⇒ τ).
+ *
+ * This is the largest and most detail-heavy synthesis rule in the checker:
+ * it implements per-builtin typing for essentially all of Eshkol's
+ * primitive procedures, then falls back to generic function-type lookup for
+ * user-defined calls and inline lambdas.
+ *
+ * Structure:
+ * - If there is no callee expression, synthesizes BuiltinTypes::Value.
+ * - Determines whether the callee is a named builtin (a bare ESHKOL_VAR),
+ *   and computes should_skip_builtin_designator_arg(), a local predicate
+ *   identifying positional arguments that are compile-time designators
+ *   rather than ordinary values (e.g. the ordering/width argument of
+ *   atomic-, volatile-, target-intrinsic builtins) so those slots are not
+ *   mistakenly type-checked as values.
+ * - Pre-synthesizes every argument (skipping designator slots, which are
+ *   given BuiltinTypes::Value) so nested sub-expressions are always
+ *   type-checked even when the callee's own return type doesn't depend on
+ *   argument types (e.g. `(display (vector-ref v -1))` still checks the
+ *   vector-ref).
+ * - If the callee is a recognized builtin name, dispatches through a long
+ *   chain of name comparisons covering: arithmetic (+,-,*,/) with backward
+ *   inference that narrows Value-typed variable operands to Number;
+ *   comparison and numeric predicates (returns Boolean, also narrowing
+ *   operands to Number); polymorphic type predicates (equal?, pair?,
+ *   number?, ...); list operations with parametric Pair<A,B> tracking for
+ *   car/cdr/cons (including the R7RS proper-vs-improper list narrowing rule
+ *   for cons); string operations (with Value->String narrowing); numeric
+ *   library functions (abs, sqrt, trig, floor/ceiling/round, expt, modulo,
+ *   etc.); low-level FFI/memory intrinsics (volatile-load/store,
+ *   atomic-load/store/exchange/compare-exchange/fetch-*, target-intrinsic,
+ *   compiler-fence, memory-fence, addr-of, null-ptr, ptr->usize,
+ *   usize->ptr, ptr-add); vector operations (vector-ref/length/set!/copy/
+ *   append, list<->vector conversions); port and I/O predicates/procedures;
+ *   promises; bytevectors; tensor/model save-load; rational and complex
+ *   number constructors/accessors; DSP operations (fft, filters, window
+ *   functions, convolution); numerical optimization (gradient-descent,
+ *   adam, l-bfgs, conjugate-gradient, line-search, tensor-dot/norm/svd);
+ *   display/newline/write, set!, begin, textual/binary I/O; and the
+ *   not/and/or and `if`-as-procedure forms, with `if` computing the least
+ *   common supertype of its branches via TypeEnvironment::leastCommonSupertype().
+ * - If the callee is not (or is no longer, having fallen through) a
+ *   recognized builtin, resolves its function type by looking it up in the
+ *   context (named callee) or synthesizing it (inline lambda callee). If
+ *   that resolves to a function type, checks argument count against the
+ *   PiType (skipped for variadic callees) and checks each argument's
+ *   synthesized type against the parameter type (allowing Value on either
+ *   side, and using leastCommonSupertype() for compatibility), reporting a
+ *   type issue via reportTypeIssue() for any mismatch, then returns the
+ *   function's return type.
+ * @return A TypeCheckResult per the builtin/generic rule above.
+ * BuiltinTypes::Value is used as the fallback whenever the callee's
+ * signature or the call itself cannot be determined precisely.
+ */
 TypeCheckResult TypeChecker::synthesizeApplication(eshkol_ast_t* expr) {
     const auto& call = expr->operation.call_op;
 
@@ -2210,6 +2640,36 @@ TypeCheckResult TypeChecker::synthesizeApplication(eshkol_ast_t* expr) {
     return TypeCheckResult::ok(BuiltinTypes::Value);
 }
 
+/**
+ * @brief Synthesis rule for `define` forms, both variable and function shapes.
+ *
+ * External declarations (`def.is_external`, e.g. `extern` FFI bindings) are
+ * bound directly from their (optional) parameter/return type annotations
+ * without checking a body, since none exists.
+ *
+ * For a genuine function define `(define (name params...) body)`: computes
+ * parameter types from annotations (defaulting to BuiltinTypes::Value), then
+ * pre-binds `name` in the context to a function type built from those
+ * parameter types and the declared (or Value) return type *before*
+ * synthesizing the body — this makes recursive calls to `name` resolve
+ * during body checking. The body is then synthesized in a fresh scope with
+ * parameters bound. Because arithmetic/comparison rules in
+ * synthesizeApplication() can narrow a Value-typed parameter to a more
+ * precise type (e.g. Number) as a side effect of checking the body, the
+ * parameter types are re-read from the context immediately after body
+ * synthesis but before the scope is popped, and this narrowed parameter
+ * list is what the function's final type is built from. If a return type
+ * annotation exists, the body's inferred type must be a subtype of it
+ * (error otherwise); the final inferred function type (narrowed params +
+ * resolved return) replaces the pre-binding.
+ *
+ * For a variable define `(define name value)`: simply synthesizes @p value's
+ * type and binds `name` to it.
+ * @return TypeCheckResult::ok(BuiltinTypes::Null) on success (define itself
+ * has no value in this type system); an error if unnamed, if body synthesis
+ * fails for a variable define, or if a function's body type violates its
+ * return annotation.
+ */
 TypeCheckResult TypeChecker::synthesizeDefine(eshkol_ast_t* expr) {
     const auto& def = expr->operation.define_op;
 
@@ -2338,6 +2798,23 @@ TypeCheckResult TypeChecker::synthesizeDefine(eshkol_ast_t* expr) {
     return TypeCheckResult::ok(BuiltinTypes::Null);
 }
 
+/**
+ * @brief Synthesis rule for `let`/`let*`/`letrec`/`letrec*` forms (all share this rule).
+ *
+ * Pushes a fresh scope, then for each binding determines its type from an
+ * explicit annotation (resolveType()) or, failing that, by synthesizing the
+ * bound expression, and binds the name in the (already-pushed) scope — so
+ * later bindings and the body can see earlier ones, matching letrec-style
+ * visibility for all four let variants. For a named let (`(let loop
+ * ((i 0)) body)`), pre-binds `loop` as a recursive function from the
+ * binding types to BuiltinTypes::Value so recursive calls resolve during
+ * body synthesis, then re-binds it with the body's actual inferred return
+ * type afterward (best-effort, since this happens after the body was
+ * already checked against the placeholder type). The body is synthesized
+ * and its result becomes the let's type; the scope is popped before
+ * returning.
+ * @return The body's TypeCheckResult (success or failure).
+ */
 TypeCheckResult TypeChecker::synthesizeLet(eshkol_ast_t* expr) {
     const auto& let = expr->operation.let_op;
 
@@ -2399,6 +2876,24 @@ TypeCheckResult TypeChecker::synthesizeLet(eshkol_ast_t* expr) {
     return body_result;
 }
 
+/**
+ * @brief Synthesis rule for `if` expressions: type is the least common
+ * supertype (LCS) of the branch types.
+ *
+ * Requires at least a condition and a then-branch (error otherwise); the
+ * condition itself is not type-checked here. Synthesizes the then-branch
+ * type, and if an else-branch is present, synthesizes it too. As a
+ * special case for named-let recursive loops (where a recursive call
+ * branch often still carries the placeholder BuiltinTypes::Value while the
+ * base-case branch has a concrete type), if exactly one branch is Value,
+ * the other (concrete) branch's type is preferred outright rather than
+ * computing an LCS. Otherwise the result is
+ * TypeEnvironment::leastCommonSupertype() of the two branch types. With no
+ * else-branch, the then-branch's type is returned directly.
+ * @return The then-branch's TypeCheckResult if there is no else-branch or
+ * synthesis of a branch fails; otherwise the LCS (or preferred concrete
+ * branch type) of both branches.
+ */
 TypeCheckResult TypeChecker::synthesizeIf(eshkol_ast_t* expr) {
     // if has: condition, then-branch, else-branch
     // For now, just synthesize branches and take LCS
@@ -2435,23 +2930,73 @@ TypeCheckResult TypeChecker::synthesizeIf(eshkol_ast_t* expr) {
     return then_type;
 }
 
+/**
+ * @brief Checking rule for lambda expressions (Γ ⊢ (lambda ...) ⇐ τ).
+ *
+ * Currently a placeholder: rather than propagating @p expected's domain
+ * types down into unannotated parameters, it simply defers entirely to the
+ * synthesis rule synthesizeLambda(). The @p expected parameter is unused.
+ * @return Whatever synthesizeLambda() returns for @p expr.
+ */
 TypeCheckResult TypeChecker::checkLambda(eshkol_ast_t* expr, TypeId expected) {
     // If expected is a function type, use its domain for param types
     // For now, just synthesize
     return synthesizeLambda(expr);
 }
 
+/**
+ * @brief Check whether @p type is a function type, and if so extract its domain/codomain.
+ *
+ * Currently simplified: only recognizes the single builtin
+ * BuiltinTypes::Function marker and never populates @p domain/@p codomain
+ * (both output parameters are unused placeholders for a future
+ * parameterized function-type representation).
+ * @return True if @p type.id equals BuiltinTypes::Function.id.
+ */
 bool TypeChecker::isFunctionType(TypeId type, TypeId& domain, TypeId& codomain) const {
     // Check if type is Function or a parameterized function type
     // Simplified for now
     return type.id == BuiltinTypes::Function.id;
 }
 
+/**
+ * @brief Simple type unification: true if @p a and @p b are equal or either
+ * is a subtype of the other.
+ *
+ * This is not full bidirectional unification with substitution/metavariable
+ * solving — it is a compatibility check used where the checker needs a
+ * best-effort answer to "can these two types be reconciled."
+ */
 bool TypeChecker::unify(TypeId a, TypeId b) {
     // Simple unification - just check equality or subtyping
     return a == b || env_.isSubtype(a, b) || env_.isSubtype(b, a);
 }
 
+/**
+ * @brief Resolve a parsed HoTT type expression (as written in source, e.g.
+ * a type annotation) to a concrete TypeId in the type environment.
+ */
+/**
+ * @brief Resolve a parsed hott_type_expr_t (a type annotation as written in
+ * source) to a concrete runtime TypeId.
+ *
+ * Maps each HOTT_TYPE_* primitive kind to its corresponding BuiltinTypes
+ * entry (Integer->Int64, Real->Float64, String, Boolean, Char, Null, Symbol,
+ * Any->Value). HOTT_TYPE_VAR is resolved by first checking whether its name
+ * is a registered type alias (Context::lookupTypeAlias(), recursing into the
+ * alias's expansion) and otherwise a builtin type name
+ * (TypeEnvironment::lookupType()), falling back to Value if neither matches.
+ * HOTT_TYPE_ARROW recursively resolves its parameter and return types and
+ * builds a proper function type via TypeEnvironment::makeFunctionType().
+ * List/Vector/Tensor/Pointer/Pair map to their respective builtin container
+ * types; Product and Sum types are both represented at runtime as Pair
+ * (Sum specifically as a tagged `(tag . value)` cons cell, since HoTT
+ * polymorphism is erased and tagged values carry their own type tag).
+ * HOTT_TYPE_FORALL resolves to its body's type (the quantifier itself has no
+ * runtime representation — instantiation/substitution happens at compile
+ * time via substituteTypeVars()). Any other/unrecognized kind, or a null @p
+ * type_expr, resolves to BuiltinTypes::Value.
+ */
 TypeId TypeChecker::resolveType(const hott_type_expr_t* type_expr) {
     if (!type_expr) {
         return BuiltinTypes::Value;
@@ -2550,10 +3095,16 @@ TypeId TypeChecker::resolveType(const hott_type_expr_t* type_expr) {
     }
 }
 
+/**
+ * @brief Append a plain error TypeCheckResult (@p msg at @p line:@p col) to the recorded error list.
+ */
 void TypeChecker::addError(const std::string& msg, int line, int col) {
     errors_.push_back(TypeCheckResult::error(msg, line, col));
 }
 
+/**
+ * @brief Record a formatted "type mismatch: expected X, got Y" error at @p line:@p col.
+ */
 void TypeChecker::addTypeMismatch(TypeId expected, TypeId actual, int line, int col) {
     std::ostringstream ss;
     ss << "Type mismatch: expected " << env_.getTypeName(expected)
@@ -2561,6 +3112,16 @@ void TypeChecker::addTypeMismatch(TypeId expected, TypeId actual, int line, int 
     addError(ss.str(), line, col);
 }
 
+/**
+ * @brief Unified type-issue reporting entry point, respecting unsafe/strict mode.
+ *
+ * In unsafe mode, does nothing (issues are silently ignored). Otherwise
+ * appends @p node's line/column (when available) to @p msg and prints it to
+ * stderr — as `[ERROR] Type error: ...` if strict_types_ is set, or
+ * `[WARN] Type warning: ...` otherwise (gradual typing: warn and continue) —
+ * and always records the unformatted @p msg via addError() so it also
+ * appears in errors().
+ */
 void TypeChecker::reportTypeIssue(const std::string& msg, const eshkol_ast_t* node) {
     if (unsafe_mode_) return;
 
@@ -2585,6 +3146,15 @@ void TypeChecker::reportTypeIssue(const std::string& msg, const eshkol_ast_t* no
 // Dimension Checking (Phase 5.3)
 // ============================================================================
 
+/**
+ * @brief Check that a vector/tensor access @p index is within the compile-time bound @p bound.
+ *
+ * Delegates to DimensionChecker::checkBounds(); on failure, both records the
+ * error via addError() and returns it.
+ * @param context Description used in the diagnostic message on failure.
+ * @return TypeCheckResult::ok(BuiltinTypes::Boolean) if in bounds, otherwise
+ * a failing result carrying DimensionChecker's error message.
+ */
 TypeCheckResult TypeChecker::checkVectorBounds(const CTValue& index, const CTValue& bound,
                                                const std::string& context) {
     auto result = DimensionChecker::checkBounds(index, bound, context);
@@ -2595,6 +3165,15 @@ TypeCheckResult TypeChecker::checkVectorBounds(const CTValue& index, const CTVal
     return TypeCheckResult::error(result.error_message);
 }
 
+/**
+ * @brief Check that @p left and @p right have compatible dimensions for a dot product.
+ *
+ * Delegates to DimensionChecker::checkDotProductDimensions(); on failure,
+ * both records the error via addError() and returns it.
+ * @return TypeCheckResult::ok(BuiltinTypes::Float64) (a dot product is a
+ * scalar) if the dimensions are compatible, otherwise a failing result
+ * carrying DimensionChecker's error message.
+ */
 TypeCheckResult TypeChecker::checkDotProductDimensions(const DependentType& left,
                                                        const DependentType& right) {
     auto result = DimensionChecker::checkDotProductDimensions(left, right, "dot product");
@@ -2606,6 +3185,17 @@ TypeCheckResult TypeChecker::checkDotProductDimensions(const DependentType& left
     return TypeCheckResult::error(result.error_message);
 }
 
+/**
+ * @brief Check that @p left and @p right have compatible dimensions for matrix multiplication.
+ *
+ * Delegates to DimensionChecker::checkMatMulDimensions(); on failure, both
+ * records the error via addError() and returns it. The result dimensions
+ * for a valid (m x n) * (n x p) -> (m x p) multiply are not yet tracked
+ * precisely — only the generic Tensor type is returned.
+ * @return TypeCheckResult::ok(BuiltinTypes::Tensor) if the dimensions are
+ * compatible, otherwise a failing result carrying DimensionChecker's error
+ * message.
+ */
 TypeCheckResult TypeChecker::checkMatrixMultiplyDimensions(const DependentType& left,
                                                            const DependentType& right) {
     auto result = DimensionChecker::checkMatMulDimensions(left, right, "matrix multiply");
@@ -2618,6 +3208,17 @@ TypeCheckResult TypeChecker::checkMatrixMultiplyDimensions(const DependentType& 
     return TypeCheckResult::error(result.error_message);
 }
 
+/**
+ * @brief Extract the compile-time size of dimension @p dim_index of a vector/tensor @p type.
+ *
+ * First checks the type environment's per-@p type dimension cache
+ * (TypeEnvironment::getDimensionInfo()); if that misses and @p type is
+ * exactly BuiltinTypes::Tensor or BuiltinTypes::Vector, falls back to
+ * checking the cache keyed by that base builtin type (dimensions recorded
+ * generically rather than per concrete instantiation).
+ * @return The dimension's CTValue if it is known and statically a natural
+ * number (CTValue::isNat()); std::nullopt if unknown or symbolic.
+ */
 std::optional<CTValue> TypeChecker::extractDimension(TypeId type, size_t dim_index) const {
     // Look up dimension info from the type environment's cache
     auto dim_info = env_.getDimensionInfo(type);
@@ -2661,6 +3262,14 @@ std::optional<CTValue> TypeChecker::extractDimension(TypeId type, size_t dim_ind
 // Linear Type Checking (Phase 6.2)
 // ============================================================================
 
+/**
+ * @brief True if @p type is linear (must be used exactly once): the no-cloning constraint.
+ *
+ * Checks both @p type's own TYPE_FLAG_LINEAR bit and, as a fallback, the
+ * flags on the type's registered TypeNode in the environment
+ * (TypeEnvironment::getTypeNode()), in case the flag was set at
+ * registration time rather than on this particular TypeId instance.
+ */
 bool TypeChecker::isLinearType(TypeId type) const {
     // Check if the type has the LINEAR flag set
     if (type.flags & TYPE_FLAG_LINEAR) {
@@ -2676,6 +3285,15 @@ bool TypeChecker::isLinearType(TypeId type) const {
     return false;
 }
 
+/**
+ * @brief Check linear variable usage across the current context, recording
+ * an error for every violation found.
+ *
+ * Reports (via addError()) one error per linear variable in
+ * Context::getUnusedLinear() (never used) and one per variable in
+ * Context::getOverusedLinear() (used more than once). Does not itself
+ * return a result — callers inspect errors() afterward.
+ */
 void TypeChecker::checkLinearUsage() {
     // Check for unused linear variables
     auto unused = ctx_.getUnusedLinear();
@@ -2690,6 +3308,18 @@ void TypeChecker::checkLinearUsage() {
     }
 }
 
+/**
+ * @brief Verify a single use-site of variable @p name, enforcing linear no-cloning.
+ *
+ * If @p name is not tracked as linear, this is just a normal variable
+ * lookup. If it is linear, checks whether it was already used
+ * (Context::isLinearUsed()): in isUnsafe() mode, a repeat use is tolerated
+ * (still recorded via Context::useLinear() for tracking) and its type
+ * returned; otherwise a repeat use is an error. On a fresh (first) use,
+ * marks it used and returns its type.
+ * @return The variable's type on success; an error if @p name is unbound,
+ * or if it is linear and already used outside unsafe mode.
+ */
 TypeCheckResult TypeChecker::checkLinearVariable(const std::string& name) {
     // Check if this is a linear variable
     if (!ctx_.isLinear(name)) {
@@ -2726,6 +3356,20 @@ TypeCheckResult TypeChecker::checkLinearVariable(const std::string& name) {
     return TypeCheckResult::error("Undefined linear variable: " + name);
 }
 
+/**
+ * @brief Check that all linear @p bindings introduced by a let scope were consumed exactly once.
+ *
+ * Intended to be called at the end of a let scope's lifetime. In isUnsafe()
+ * mode, all checks are skipped and success is returned unconditionally.
+ * Otherwise, filters @p bindings down to those tracked as linear
+ * (Context::isLinear()) and collects any that were never used
+ * (Context::isLinearUsed() false); overuse is not re-checked here since
+ * checkLinearVariable() already reports it at the use site. If any bindings
+ * are unused, records and returns a single combined error listing all of
+ * their names.
+ * @return TypeCheckResult::ok(BuiltinTypes::Null) if unsafe or all linear
+ * bindings were used; otherwise an error naming the unconsumed bindings.
+ */
 TypeCheckResult TypeChecker::checkLinearLet(const std::vector<std::string>& bindings) {
     // Check that all linear bindings were consumed exactly once
     // This is called at the end of a let scope
@@ -2771,14 +3415,27 @@ TypeCheckResult TypeChecker::checkLinearLet(const std::vector<std::string>& bind
 // Unsafe Context (Phase 6.4)
 // ============================================================================
 
+/**
+ * @brief Enter an unsafe block: relax linear/borrow restrictions for its duration.
+ *
+ * Delegates to UnsafeContext::enterUnsafe(), incrementing the nesting depth.
+ */
 void TypeChecker::enterUnsafe() {
     unsafe_.enterUnsafe();
 }
 
+/**
+ * @brief Exit the innermost unsafe block, restoring the previous safety level.
+ *
+ * Delegates to UnsafeContext::exitUnsafe(), decrementing the nesting depth.
+ */
 void TypeChecker::exitUnsafe() {
     unsafe_.exitUnsafe();
 }
 
+/**
+ * @brief True if the checker is currently inside one or more nested unsafe blocks.
+ */
 bool TypeChecker::isUnsafe() const {
     return unsafe_.isUnsafe();
 }
@@ -2787,6 +3444,24 @@ bool TypeChecker::isUnsafe() const {
 // Program-Level Type Checking
 // ============================================================================
 
+/**
+ * @brief Type check a complete program: synthesize the type of every
+ * top-level AST in @p asts.
+ *
+ * Constructs a fresh TypeChecker over @p env (using default strict/unsafe
+ * settings) and calls synthesize() on each of the @p num_asts top-level
+ * definitions in order. If @p strict is true, returns immediately with the
+ * accumulated errors as soon as any top-level synthesis fails; if false,
+ * continues checking all remaining top-level forms regardless of earlier
+ * failures so all errors can be reported together.
+ * @param env The type environment.
+ * @param asts Array of top-level ASTs.
+ * @param num_asts Number of ASTs.
+ * @param strict If true, stop and return on the first error; if false,
+ * collect all errors across the whole program.
+ * @return The type checker's accumulated errors (empty if the program is
+ * well-typed).
+ */
 std::vector<TypeCheckResult> typeCheckProgram(
     TypeEnvironment& env,
     eshkol_ast_t* asts,


### PR DESCRIPTION
## Summary
Doxygen doc-comments for undocumented function definitions in lib/agent/c, lib/types, lib/frontend, lib/repl. Documentation only.

- lib/agent/c/*.c (17 files): agent FFI/runtime — HTTP client/server, SQLite, regex, compression, subprocess, terminal, concurrency primitives, tree-sitter, Yoga layout, signal handling, filesystem watch, poll/event-loop I/O, eagle training, tensor I/O, kb I/O, platform helpers.
- lib/types/*.cpp (3 files): bidirectional HoTT type checker, dependent-type support, HoTT core types.
- lib/frontend/*.cpp (2 files): Scheme parser/reader and macro expander.
- lib/repl/* (4 files with changes): REPL/JIT (repl_jit.cpp), eval bridge, Branch26 range-extension JIT-link plugin, REPL utility helpers.

No code, formatting, or behavior changed — pure comment insertions, verified via diff review and clang/gcc syntax checks on every touched translation unit.

## Test plan
- [x] `git diff --numstat` reviewed: only added `/** @brief ... */` blocks (5256 insertions, 7 deletions where a pre-existing one-line comment was folded into the new Doxygen block directly above the same function).
- [x] `gcc -fsyntax-only` on all touched `.c` files: clean.
- [x] `clang++ -std=c++20 -fsyntax-only` (matching the project's `CMAKE_CXX_STANDARD`) on all touched `.cpp` files, including `repl_jit.cpp` against the real LLVM headers: clean.
- [x] Touched-header files (`repl_utils.h`, `jitlink_branch26_range_extension.h`) verified via their real includers (`exe/eshkol-repl.cpp`, `repl_jit.cpp`).