### PR TITLE
docs(impl): document backend codegen implementations (B, part 1)

### DIFF
--- a/lib/backend/parallel_codegen.cpp
+++ b/lib/backend/parallel_codegen.cpp
@@ -251,6 +251,24 @@ struct eshkol_lazy_future_layout {
 };
 } // anonymous namespace
 
+/**
+ * @brief Kick off asynchronous evaluation of a `lazy_future` thunk on the
+ *        global thread pool.
+ *
+ * Allocates a heap result slot and an `eshkol_parallel_execute_task`, submits
+ * them to `g_parallel_execute_worker`, and stashes the resulting
+ * `eshkol_future_t*` plus the slot/task pointers into the lazy_future's async
+ * fields (see the layout comment above `eshkol_lazy_future_layout`) so that
+ * `eshkol_lazy_future_join_async` can later block on it and copy out the
+ * result.
+ *
+ * @param lf_void       Pointer to the `lazy_future` struct (as `void*`).
+ * @param closure_ptr   Raw pointer field of the thunk closure to invoke.
+ * @param closure_type  Tagged-value type byte of the thunk closure.
+ * @param closure_flags Tagged-value flags byte of the thunk closure.
+ * @return 1 on success (async submission started), 0 if `lf_void` is null,
+ *         the execute worker isn't registered, or no thread pool is available.
+ */
 extern "C" uint8_t eshkol_lazy_future_submit_async(
     void* lf_void, uint64_t closure_ptr, uint8_t closure_type, uint8_t closure_flags) {
     if (!lf_void) return 0;
@@ -280,6 +298,16 @@ extern "C" uint8_t eshkol_lazy_future_submit_async(
     return 1;
 }
 
+/**
+ * @brief Block until a `lazy_future` previously started with
+ *        `eshkol_lazy_future_submit_async` has finished, then copy the
+ *        worker's result into the lazy_future's result fields and release
+ *        the async bookkeeping (pool future, result slot, task).
+ *
+ * No-op if the future was already forced or was never submitted async.
+ *
+ * @param lf_void Pointer to the `lazy_future` struct (as `void*`).
+ */
 extern "C" void eshkol_lazy_future_join_async(void* lf_void) {
     if (!lf_void) return;
     auto* lf = reinterpret_cast<eshkol_lazy_future_layout*>(lf_void);

--- a/lib/backend/string_io_codegen.cpp
+++ b/lib/backend/string_io_codegen.cpp
@@ -22,6 +22,10 @@
 
 namespace eshkol {
 
+/**
+ * @brief Construct the string/IO codegen helper bound to a shared codegen
+ *        context and tagged-value helper.
+ */
 StringIOCodegen::StringIOCodegen(CodegenContext& ctx, TaggedValueCodegen& tagged)
     : ctx_(ctx)
     , tagged_(tagged)
@@ -29,6 +33,19 @@ StringIOCodegen::StringIOCodegen(CodegenContext& ctx, TaggedValueCodegen& tagged
     eshkol_debug("StringIOCodegen initialized");
 }
 
+/**
+ * @brief Coerce an LLVM value to a raw (untagged) i64.
+ *
+ * Handles three cases: values already of type i64 are returned unchanged;
+ * narrower integer types are sign-extended; and Eshkol tagged-value structs
+ * are unpacked at runtime by branching on the type tag so that a DOUBLE
+ * tagged value (as produced by, e.g., FFI calls returning i32, see #145) is
+ * converted via FPToSI instead of having its bit pattern read verbatim.
+ *
+ * @param val  Value to coerce (raw integer or tagged_value struct).
+ * @param name Name prefix used for generated basic blocks/values.
+ * @return An i64 SSA value, or nullptr if val is null.
+ */
 llvm::Value* StringIOCodegen::ensureRawInt64(llvm::Value* val, const std::string& name) {
     if (!val) return nullptr;
 
@@ -108,6 +125,11 @@ llvm::Value* StringIOCodegen::ensureRawInt64(llvm::Value* val, const std::string
     return tagged_.unpackInt64(val);
 }
 
+/**
+ * @brief Intern a C string as a global constant and return an opaque pointer
+ *        to it (no Eshkol heap header), suitable for passing to printf-style
+ *        runtime calls.
+ */
 llvm::Value* StringIOCodegen::createString(const char* str) {
     if (!str) return nullptr;
 
@@ -121,6 +143,13 @@ llvm::Value* StringIOCodegen::createString(const char* str) {
     );
 }
 
+/**
+ * @brief Intern a C string as a global with an Eshkol heap header
+ *        ([header][data] layout) so it can be treated as a HEAP_PTR value.
+ * @param str     Null-terminated string contents.
+ * @param subtype Heap subtype tag to store in the header (e.g. HEAP_SUBTYPE_STRING).
+ * @return Pointer to the string data (header lives at ptr - 8).
+ */
 llvm::Value* StringIOCodegen::createStringWithHeader(const char* str, uint8_t subtype) {
     if (!str) return nullptr;
 
@@ -130,6 +159,10 @@ llvm::Value* StringIOCodegen::createStringWithHeader(const char* str, uint8_t su
     return ctx_.internStringWithHeader(str, subtype);
 }
 
+/**
+ * @brief Intern a C string with a heap header and pack it into a tagged
+ *        HEAP_PTR value ready to be used as an Eshkol runtime value.
+ */
 llvm::Value* StringIOCodegen::packString(const char* str) {
     // Use createStringWithHeader to ensure proper header for HEAP_PTR
     llvm::Value* str_ptr = createStringWithHeader(str, HEAP_SUBTYPE_STRING);
@@ -138,6 +171,10 @@ llvm::Value* StringIOCodegen::packString(const char* str) {
     return tagged_.packPtr(str_ptr, ESHKOL_VALUE_HEAP_PTR);
 }
 
+/**
+ * @brief Get (declaring and caching if needed) the C library `printf`
+ *        function used to implement display/write output.
+ */
 llvm::Function* StringIOCodegen::getPrintf() {
     if (printf_func_) return printf_func_;
 
@@ -169,6 +206,13 @@ static llvm::Function* getOrDeclareDisplayToPort(CodegenContext& ctx);
 static llvm::Function* getOrDeclareStdoutStream(CodegenContext& ctx);
 static llvm::Function* getOrDeclareStdinStream(CodegenContext& ctx);
 
+/**
+ * @brief Codegen for R7RS `(newline)` / `(newline port)`.
+ *
+ * Writes a single newline character to the given port (or stdout if no port
+ * argument is supplied) via `fputc`.
+ * @return Packed null tagged value (the R7RS unspecified result).
+ */
 llvm::Value* StringIOCodegen::newline(const eshkol_operations_t* op) {
     // (newline) or (newline port) — R7RS: optional port argument
     llvm::Value* file_ptr;
@@ -205,6 +249,12 @@ llvm::Value* StringIOCodegen::newline(const eshkol_operations_t* op) {
 // These implementations remain in llvm_codegen.cpp until those modules are extracted.
 // The functions below provide stubs that warn when called.
 
+/**
+ * @brief Codegen for R7RS `(string-length s)`.
+ *
+ * Calls the `eshkol_utf8_strlen` runtime helper to count Unicode codepoints
+ * (not bytes) and packs the result as an exact integer.
+ */
 llvm::Value* StringIOCodegen::stringLength(const eshkol_operations_t* op) {
     if (!codegen_ast_callback_) {
         eshkol_warn("StringIOCodegen::stringLength - callbacks not set");
@@ -238,6 +288,13 @@ llvm::Value* StringIOCodegen::stringLength(const eshkol_operations_t* op) {
     return tagged_.packInt64(len, true);
 }
 
+/**
+ * @brief Codegen for `(string-byte-length s)`.
+ *
+ * Reads the byte count directly from the string's heap header via
+ * `eshkol_string_byte_length` (no UTF-8 decoding), unlike `string-length`
+ * which counts codepoints.
+ */
 llvm::Value* StringIOCodegen::stringByteLength(const eshkol_operations_t* op) {
     if (!codegen_ast_callback_) {
         eshkol_warn("StringIOCodegen::stringByteLength - callbacks not set");
@@ -273,6 +330,13 @@ llvm::Value* StringIOCodegen::stringByteLength(const eshkol_operations_t* op) {
     return tagged_.packInt64(len, true);
 }
 
+/**
+ * @brief Codegen for R7RS `(string-ref s k)`.
+ *
+ * Emits a runtime bounds check against the UTF-8 codepoint count (raising an
+ * `eshkol_raise` exception on out-of-range index), then fetches the
+ * codepoint at index `k` via `eshkol_utf8_ref` and packs it as a CHAR value.
+ */
 llvm::Value* StringIOCodegen::stringRef(const eshkol_operations_t* op) {
     if (!codegen_ast_callback_ || !codegen_typed_ast_callback_) {
         eshkol_warn("StringIOCodegen::stringRef - callbacks not set");
@@ -369,6 +433,14 @@ llvm::Value* StringIOCodegen::stringRef(const eshkol_operations_t* op) {
     return tagged_.packChar(codepoint);
 }
 
+/**
+ * @brief Codegen for R7RS `(string-append s1 s2 ...)`.
+ *
+ * Computes each argument's header-based byte length (not a NUL-terminated
+ * strlen, so embedded NUL bytes are preserved), allocates a single new
+ * string with the summed length, memcpy's each argument into place, and
+ * appends an explicit NUL terminator for C-string interop.
+ */
 llvm::Value* StringIOCodegen::stringAppend(const eshkol_operations_t* op) {
     if (!codegen_ast_callback_) {
         eshkol_warn("StringIOCodegen::stringAppend - callbacks not set");
@@ -450,6 +522,13 @@ llvm::Value* StringIOCodegen::stringAppend(const eshkol_operations_t* op) {
     return tagged_.packHeapPtr(new_str);
 }
 
+/**
+ * @brief Codegen for R7RS `(substring string start [end])`.
+ *
+ * Accepts both the 2-argument form (end defaults to the string length) and
+ * the 3-argument form; validates argument count and delegates the actual
+ * slicing to substringImpl().
+ */
 llvm::Value* StringIOCodegen::substring(const eshkol_operations_t* op) {
     if (!codegen_ast_callback_ || !codegen_typed_ast_callback_) {
         eshkol_warn("StringIOCodegen::substring - callbacks not set");
@@ -637,6 +716,13 @@ llvm::Value* StringIOCodegen::stringCopy(const eshkol_operations_t* op) {
     return substringImpl(str_ptr, start, end);
 }
 
+/**
+ * @brief Codegen for R7RS string comparison predicates
+ *        (`string=?`/`string<?`/`string>?`/`string<=?`/`string>=?`).
+ *
+ * Calls libc `strcmp` and maps the sign of the result to the requested
+ * comparison via @p cmp_type (one of "eq"/"lt"/"gt"/"le"/"ge").
+ */
 llvm::Value* StringIOCodegen::stringCompare(const eshkol_operations_t* op, const std::string& cmp_type) {
     if (!codegen_ast_callback_) {
         eshkol_warn("StringIOCodegen::stringCompare - callbacks not set");
@@ -684,6 +770,11 @@ llvm::Value* StringIOCodegen::stringCompare(const eshkol_operations_t* op, const
     return tagged_.packBool(result);
 }
 
+/**
+ * @brief Codegen for R7RS case-insensitive string comparison predicates
+ *        (`string-ci=?` etc.), analogous to stringCompare() but using
+ *        `strcasecmp`.
+ */
 llvm::Value* StringIOCodegen::stringCiCompare(const eshkol_operations_t* op, const std::string& cmp_type) {
     if (!codegen_ast_callback_) {
         eshkol_warn("StringIOCodegen::stringCiCompare - callbacks not set");
@@ -729,6 +820,14 @@ llvm::Value* StringIOCodegen::stringCiCompare(const eshkol_operations_t* op, con
     return tagged_.packBool(result);
 }
 
+/**
+ * @brief Codegen for R7RS `(string->number string [radix])`.
+ *
+ * Delegates to the `eshkol_string_to_number_tagged` (1-arg) or
+ * `eshkol_string_to_number_radix_tagged` (2-arg) runtime helpers, which parse
+ * int64/bignum/double/rational forms and `#`-radix prefixes and write the
+ * result into a stack-allocated tagged value that is then loaded and returned.
+ */
 llvm::Value* StringIOCodegen::stringToNumber(const eshkol_operations_t* op) {
     if (!codegen_ast_callback_) {
         eshkol_warn("StringIOCodegen::stringToNumber - callbacks not set");
@@ -789,6 +888,15 @@ namespace {
     };
 }
 
+/**
+ * @brief Codegen for R7RS `(number->string num [radix])`.
+ *
+ * The 2-arg form calls `eshkol_number_to_string_radix_raw` directly on the
+ * unpacked int64 value. The 1-arg form formats the number in-line via
+ * snprintf into a header-allocated buffer, then rewrites the header's size
+ * field to the actual formatted length (the buffer is over-allocated so it
+ * fits any number).
+ */
 llvm::Value* StringIOCodegen::numberToString(const eshkol_operations_t* op) {
     if (!codegen_typed_ast_callback_) {
         eshkol_warn("StringIOCodegen::numberToString - callbacks not set");
@@ -999,6 +1107,12 @@ llvm::Value* StringIOCodegen::numberToString(const eshkol_operations_t* op) {
     return tagged_.packHeapPtr(buf);
 }
 
+/**
+ * @brief Codegen for R7RS `(make-string k [char])`.
+ *
+ * Allocates a header-tagged string buffer of length k, fills it with
+ * `char` (default space) via memset, and NUL-terminates it.
+ */
 llvm::Value* StringIOCodegen::makeString(const eshkol_operations_t* op) {
     if (!codegen_typed_ast_callback_ || !codegen_ast_callback_) {
         eshkol_warn("StringIOCodegen::makeString - callbacks not set");
@@ -1057,6 +1171,12 @@ llvm::Value* StringIOCodegen::makeString(const eshkol_operations_t* op) {
     return tagged_.packHeapPtr(buf);
 }
 
+/**
+ * @brief Codegen for R7RS `(string-set! s k char)`.
+ *
+ * Stores the character byte directly at offset k in the mutable string
+ * buffer (no bounds check here) and returns the (unspecified) string.
+ */
 llvm::Value* StringIOCodegen::stringSet(const eshkol_operations_t* op) {
     if (!codegen_ast_callback_ || !codegen_typed_ast_callback_) {
         eshkol_warn("StringIOCodegen::stringSet - callbacks not set");
@@ -1103,6 +1223,12 @@ llvm::Value* StringIOCodegen::stringSet(const eshkol_operations_t* op) {
     return str_arg;
 }
 
+/**
+ * @brief Codegen for R7RS `(string-fill! s char)`.
+ *
+ * Fills the entire mutable string buffer (length from strlen) with the
+ * given character via memset.
+ */
 llvm::Value* StringIOCodegen::stringFill(const eshkol_operations_t* op) {
     if (!codegen_ast_callback_) {
         eshkol_warn("StringIOCodegen::stringFill - callbacks not set");
@@ -1143,6 +1269,16 @@ llvm::Value* StringIOCodegen::stringFill(const eshkol_operations_t* op) {
     return str_arg;
 }
 
+/**
+ * @brief Codegen for `(string-split string delimiter)`, where delimiter may
+ *        be either a char or a string.
+ *
+ * Emits a hand-built LLVM IR loop that scans for occurrences of the
+ * delimiter (via strncmp at each candidate position), conses each segment
+ * found onto a result list, and finally reverses that list (via
+ * `eshkol_list_reverse_tagged`) so segments come out in left-to-right order.
+ * A char delimiter is first materialized as a temporary 2-byte C string.
+ */
 llvm::Value* StringIOCodegen::stringSplit(const eshkol_operations_t* op) {
     if (!codegen_ast_callback_ || !cons_create_callback_) {
         eshkol_warn("StringIOCodegen::stringSplit - callbacks not set");
@@ -1369,6 +1505,10 @@ llvm::Value* StringIOCodegen::stringSplit(const eshkol_operations_t* op) {
     return ctx_.builder().CreateLoad(ctx_.taggedValueType(), rev_out_ptr);
 }
 
+/**
+ * @brief Codegen for `(string-contains? s substr)`: calls libc `strstr` and
+ *        packs whether a non-null match pointer was returned.
+ */
 llvm::Value* StringIOCodegen::stringContains(const eshkol_operations_t* op) {
     if (!codegen_ast_callback_) {
         eshkol_warn("StringIOCodegen::stringContains - callbacks not set");
@@ -1402,6 +1542,11 @@ llvm::Value* StringIOCodegen::stringContains(const eshkol_operations_t* op) {
     return tagged_.packBool(found);
 }
 
+/**
+ * @brief Codegen for `(string-index s substr)`: like stringContains() but
+ *        returns the byte offset of the match (via pointer subtraction), or
+ *        -1 if not found.
+ */
 llvm::Value* StringIOCodegen::stringIndex(const eshkol_operations_t* op) {
     if (!codegen_ast_callback_) {
         eshkol_warn("StringIOCodegen::stringIndex - callbacks not set");
@@ -1442,6 +1587,12 @@ llvm::Value* StringIOCodegen::stringIndex(const eshkol_operations_t* op) {
     return tagged_.packInt64(final_index, true);
 }
 
+/**
+ * @brief Codegen for R7RS `(string-upcase s)`.
+ *
+ * Allocates a new header-tagged string of the same byte length and copies
+ * each byte through `toupper` (emitted as an inline byte loop).
+ */
 llvm::Value* StringIOCodegen::stringUpcase(const eshkol_operations_t* op) {
     if (!codegen_ast_callback_) {
         eshkol_warn("StringIOCodegen::stringUpcase - callbacks not set");
@@ -1539,6 +1690,10 @@ llvm::Value* StringIOCodegen::stringUpcase(const eshkol_operations_t* op) {
     return tagged_.packHeapPtr(new_str);
 }
 
+/**
+ * @brief Codegen for R7RS `(string-downcase s)`, mirroring stringUpcase()
+ *        but converting 'A'-'Z' bytes to lowercase via an inline byte loop.
+ */
 llvm::Value* StringIOCodegen::stringDowncase(const eshkol_operations_t* op) {
     if (!codegen_ast_callback_) {
         eshkol_warn("StringIOCodegen::stringDowncase - callbacks not set");
@@ -1633,6 +1788,13 @@ llvm::Value* StringIOCodegen::stringDowncase(const eshkol_operations_t* op) {
     return tagged_.packHeapPtr(new_str);
 }
 
+/**
+ * @brief Codegen for R7RS `(string->list s)`.
+ *
+ * Emits an LLVM IR loop walking the string backwards from its last byte,
+ * consing each byte (packed as a CHAR) onto the result so the final list
+ * comes out in forward order without a separate reverse pass.
+ */
 llvm::Value* StringIOCodegen::stringToList(const eshkol_operations_t* op) {
     if (!codegen_ast_callback_ || !cons_create_callback_) {
         eshkol_warn("StringIOCodegen::stringToList - callbacks not set");
@@ -1714,6 +1876,14 @@ llvm::Value* StringIOCodegen::stringToList(const eshkol_operations_t* op) {
     return ctx_.builder().CreateLoad(ctx_.taggedValueType(), list_ptr);
 }
 
+/**
+ * @brief Codegen for R7RS `(list->string chars)`.
+ *
+ * Emits an LLVM IR loop that first walks the list to count its length (by
+ * following cons cell cdrs at offset 16), allocates a header-tagged string
+ * buffer of that length, then walks the list a second time storing each
+ * char byte into the buffer.
+ */
 llvm::Value* StringIOCodegen::listToString(const eshkol_operations_t* op) {
     if (!codegen_ast_callback_) {
         eshkol_warn("StringIOCodegen::listToString - callbacks not set");
@@ -1845,6 +2015,17 @@ llvm::Value* StringIOCodegen::listToString(const eshkol_operations_t* op) {
     return tagged_.packHeapPtr(str_buf);
 }
 
+/**
+ * @brief Codegen for R7RS `(display obj [port])`.
+ *
+ * When the argument is a variable bound to a preserved homoiconic
+ * S-expression (looked up via a `<name>_sexpr` global, scoped to the
+ * enclosing function first), displays that S-expression instead of the
+ * evaluated value so lambdas/procedures print their source form; otherwise
+ * falls back to evaluating the typed AST and calling the unified C
+ * `display_value_func_` (or `eshkol_display_value_to_port` when a port
+ * argument is given).
+ */
 llvm::Value* StringIOCodegen::display(const eshkol_operations_t* op) {
     if (!codegen_typed_ast_callback_ || !typed_to_tagged_callback_) {
         eshkol_warn("StringIOCodegen::display - callbacks not set");
@@ -1981,7 +2162,7 @@ llvm::Value* StringIOCodegen::display(const eshkol_operations_t* op) {
 
 // === File I/O Operations ===
 
-// Helper to get or declare fopen
+/** @brief Get (declaring if needed) `void eshkol_display_value_to_port(tagged_value*, FILE*)`. */
 static llvm::Function* getOrDeclareDisplayToPort(CodegenContext& ctx) {
     if (auto* existing = ctx.module().getFunction("eshkol_display_value_to_port")) return existing;
     auto* ft = llvm::FunctionType::get(ctx.builder().getVoidTy(),
@@ -1989,6 +2170,7 @@ static llvm::Function* getOrDeclareDisplayToPort(CodegenContext& ctx) {
     return llvm::Function::Create(ft, llvm::Function::ExternalLinkage, "eshkol_display_value_to_port", ctx.module());
 }
 
+/** @brief Get (declaring if needed) the C library `FILE* fopen(const char*, const char*)`. */
 static llvm::Function* getOrDeclareFopen(CodegenContext& ctx) {
     if (auto* existing = ctx.module().getFunction(runtime::fopen_symbol)) return existing;
     auto* ft = llvm::FunctionType::get(ctx.ptrType(),
@@ -2091,6 +2273,7 @@ static llvm::Value* getStdout(CodegenContext& ctx) {
     return ctx.builder().CreateCall(callee, {});
 }
 
+/** @brief Get (declaring if needed) the runtime accessor returning the stdout `FILE*` stream. */
 static llvm::Function* getOrDeclareStdoutStream(CodegenContext& ctx) {
     if (auto* existing = ctx.module().getFunction(runtime::stdout_stream_symbol)) {
         return existing;
@@ -2104,6 +2287,7 @@ static llvm::Function* getOrDeclareStdoutStream(CodegenContext& ctx) {
     );
 }
 
+/** @brief Get (declaring if needed) the runtime accessor returning the stdin `FILE*` stream. */
 static llvm::Function* getOrDeclareStdinStream(CodegenContext& ctx) {
     if (auto* existing = ctx.module().getFunction(runtime::stdin_stream_symbol)) {
         return existing;
@@ -2117,6 +2301,14 @@ static llvm::Function* getOrDeclareStdinStream(CodegenContext& ctx) {
     );
 }
 
+/**
+ * @brief Build a tagged port value from a `FILE*`, or `#f` if the pointer is
+ *        null (i.e. the underlying `fopen` call failed).
+ * @param file_ptr  Result of an `fopen`-family call.
+ * @param port_type Tagged-value type byte to stamp on success (encodes
+ *                   input/output/binary port kind).
+ * @param name      Prefix used for generated basic block/value names.
+ */
 static llvm::Value* packFilePortOrFalse(CodegenContext& ctx,
                                          TaggedValueCodegen& tagged,
                                          llvm::Value* file_ptr,
@@ -2163,6 +2355,10 @@ static llvm::Value* packFilePortOrFalse(CodegenContext& ctx,
     return result;
 }
 
+/**
+ * @brief Codegen for R7RS `(open-input-file filename)`: calls `fopen` in
+ *        "r" mode and packs the result as an input file port (or #f on failure).
+ */
 llvm::Value* StringIOCodegen::openInputFile(const eshkol_operations_t* op) {
     if (!codegen_typed_ast_callback_ || !typed_to_tagged_callback_) {
         eshkol_warn("StringIOCodegen::openInputFile - callbacks not set");
@@ -2204,10 +2400,16 @@ llvm::Value* StringIOCodegen::openOutputFile(const eshkol_operations_t* op) {
     return openOutputFileImpl(op, "w", "open-output-file");
 }
 
+/** @brief Codegen for `(open-output-file-append filename)`: opens in "a" (append) mode. */
 llvm::Value* StringIOCodegen::openOutputFileAppend(const eshkol_operations_t* op) {
     return openOutputFileImpl(op, "a", "open-output-file-append");
 }
 
+/**
+ * @brief Shared implementation for open-output-file and
+ *        open-output-file-append: validates arity, calls `fopen` with the
+ *        given @p mode_str, and packs the result as an output file port.
+ */
 llvm::Value* StringIOCodegen::openOutputFileImpl(const eshkol_operations_t* op,
                                                   const char* mode_str,
                                                   const char* scheme_name) {
@@ -2243,6 +2445,14 @@ llvm::Value* StringIOCodegen::openOutputFileImpl(const eshkol_operations_t* op,
         ESHKOL_VALUE_HEAP_PTR | 0x40, "open_output_file");
 }
 
+/**
+ * @brief Codegen for R7RS `(read-line [port])`.
+ *
+ * Reads a line via `fgets` into a function-entry-hoisted scratch buffer,
+ * strips a trailing newline if present, and copies the result into a
+ * freshly right-sized header-tagged string. Returns the eof-object
+ * (type byte 0xFF) if `fgets` hits EOF immediately.
+ */
 llvm::Value* StringIOCodegen::readLine(const eshkol_operations_t* op) {
     if (!codegen_typed_ast_callback_ || !typed_to_tagged_callback_) {
         eshkol_warn("StringIOCodegen::readLine - callbacks not set");
@@ -2399,6 +2609,13 @@ llvm::Value* StringIOCodegen::readLine(const eshkol_operations_t* op) {
     return phi;
 }
 
+/**
+ * @brief Codegen for R7RS `(read-string k [port])`.
+ *
+ * Allocates a k+1 byte header-tagged buffer, reads up to k bytes via
+ * `fread`, NUL-terminates and truncates the header's recorded size to the
+ * actual bytes read, and returns the eof-object if zero bytes were read.
+ */
 llvm::Value* StringIOCodegen::readString(const eshkol_operations_t* op) {
     if (!codegen_typed_ast_callback_ || !typed_to_tagged_callback_) {
         eshkol_warn("StringIOCodegen::readString - callbacks not set");
@@ -2519,6 +2736,7 @@ llvm::Value* StringIOCodegen::readString(const eshkol_operations_t* op) {
     return phi;
 }
 
+/** @brief Codegen for R7RS `(close-port port)`: calls libc `fclose` on the port's `FILE*`. */
 llvm::Value* StringIOCodegen::closePort(const eshkol_operations_t* op) {
     if (!codegen_typed_ast_callback_ || !typed_to_tagged_callback_) {
         eshkol_warn("StringIOCodegen::closePort - callbacks not set");
@@ -2550,6 +2768,7 @@ llvm::Value* StringIOCodegen::closePort(const eshkol_operations_t* op) {
     return tagged_.packInt64(llvm::ConstantInt::get(ctx_.int64Type(), 0), true);
 }
 
+/** @brief Codegen for R7RS `(eof-object? obj)`: tests whether the tagged value's type byte is 0xFF. */
 llvm::Value* StringIOCodegen::eofObject(const eshkol_operations_t* op) {
     if (!codegen_typed_ast_callback_ || !typed_to_tagged_callback_) {
         eshkol_warn("StringIOCodegen::eofObject - callbacks not set");
@@ -2577,6 +2796,7 @@ llvm::Value* StringIOCodegen::eofObject(const eshkol_operations_t* op) {
     return tagged_.packBool(is_eof);
 }
 
+/** @brief Codegen for R7RS `(write-string s [port])`: calls `eshkol_fputs` on the string pointer. */
 llvm::Value* StringIOCodegen::writeString(const eshkol_operations_t* op) {
     if (!codegen_typed_ast_callback_ || !typed_to_tagged_callback_) {
         eshkol_warn("StringIOCodegen::writeString - callbacks not set");
@@ -2623,9 +2843,11 @@ llvm::Value* StringIOCodegen::writeString(const eshkol_operations_t* op) {
     return tagged_.packInt64(llvm::ConstantInt::get(ctx_.int64Type(), 0), true);
 }
 
+/**
+ * @brief Codegen for `(write-line str [port])`: writes the string followed
+ *        by a newline (unspecified return value).
+ */
 llvm::Value* StringIOCodegen::writeLine(const eshkol_operations_t* op) {
-    // (write-line str [port]) -> unspecified
-    // Writes string followed by newline
     if (!codegen_typed_ast_callback_ || !typed_to_tagged_callback_) {
         eshkol_warn("StringIOCodegen::writeLine - callbacks not set");
         return tagged_.packNull();
@@ -2679,8 +2901,8 @@ llvm::Value* StringIOCodegen::writeLine(const eshkol_operations_t* op) {
     return tagged_.packInt64(llvm::ConstantInt::get(ctx_.int64Type(), 0), true);
 }
 
+/** @brief Codegen for `(write-char char [port])`: writes one char via `fputc` (unspecified return value). */
 llvm::Value* StringIOCodegen::writeChar(const eshkol_operations_t* op) {
-    // (write-char char [port]) -> unspecified
     if (!codegen_typed_ast_callback_ || !typed_to_tagged_callback_) {
         eshkol_warn("StringIOCodegen::writeChar - callbacks not set");
         return tagged_.packNull();
@@ -2739,8 +2961,8 @@ llvm::Value* StringIOCodegen::writeChar(const eshkol_operations_t* op) {
     return tagged_.packInt64(llvm::ConstantInt::get(ctx_.int64Type(), 0), true);
 }
 
+/** @brief Codegen for `(flush-output-port port)`: calls libc `fflush` on the port's `FILE*` (unspecified return value). */
 llvm::Value* StringIOCodegen::flushOutputPort(const eshkol_operations_t* op) {
-    // (flush-output-port port) -> unspecified
     if (!codegen_typed_ast_callback_ || !typed_to_tagged_callback_) {
         eshkol_warn("StringIOCodegen::flushOutputPort - callbacks not set");
         return tagged_.packNull();
@@ -2774,6 +2996,7 @@ llvm::Value* StringIOCodegen::flushOutputPort(const eshkol_operations_t* op) {
 
 // === Character Operations ===
 
+/** @brief Codegen for R7RS `(char->integer c)`: unpacks the char's codepoint and repacks it as an exact integer. */
 llvm::Value* StringIOCodegen::charToInteger(const eshkol_operations_t* op) {
     if (!codegen_ast_callback_) {
         eshkol_warn("StringIOCodegen::charToInteger - callbacks not set");
@@ -2793,6 +3016,7 @@ llvm::Value* StringIOCodegen::charToInteger(const eshkol_operations_t* op) {
     return tagged_.packInt64(char_val, true);
 }
 
+/** @brief Codegen for R7RS `(integer->char n)`: packs the raw integer as a CHAR tagged value. */
 llvm::Value* StringIOCodegen::integerToChar(const eshkol_operations_t* op) {
     if (!codegen_typed_ast_callback_) {
         eshkol_warn("StringIOCodegen::integerToChar - callbacks not set");
@@ -2816,6 +3040,11 @@ llvm::Value* StringIOCodegen::integerToChar(const eshkol_operations_t* op) {
     return tagged_.packChar(int_val);
 }
 
+/**
+ * @brief Codegen for R7RS character comparison predicates
+ *        (`char=?`/`char<?`/`char>?`/`char<=?`/`char>=?`), comparing raw
+ *        codepoint values per @p cmp_type ("eq"/"lt"/"gt"/"le"/"ge").
+ */
 llvm::Value* StringIOCodegen::charCompare(const eshkol_operations_t* op, const std::string& cmp_type) {
     if (!codegen_ast_callback_) {
         eshkol_warn("StringIOCodegen::charCompare - callbacks not set");
@@ -2971,6 +3200,13 @@ static llvm::Value* buildReadCharCommon(CodegenContext& ctx, TaggedValueCodegen&
     return phi;
 }
 
+/**
+ * @brief Codegen for R7RS `(read-char [port])`.
+ *
+ * Validates that an explicit port argument actually carries the input or
+ * output port flag (falling back to stdin otherwise), then delegates to
+ * buildReadCharCommon() with `peek=false`.
+ */
 llvm::Value* StringIOCodegen::readChar(const eshkol_operations_t* op) {
     // (read-char) or (read-char port)
     if (op->call_op.num_vars > 1) {
@@ -3004,6 +3240,11 @@ llvm::Value* StringIOCodegen::readChar(const eshkol_operations_t* op) {
     return buildReadCharCommon(ctx_, tagged_, file_ptr, false);
 }
 
+/**
+ * @brief Codegen for R7RS `(peek-char [port])`: like readChar() but
+ *        delegates to buildReadCharCommon() with `peek=true` so the read
+ *        byte is pushed back via `ungetc`.
+ */
 llvm::Value* StringIOCodegen::peekChar(const eshkol_operations_t* op) {
     // (peek-char) or (peek-char port)
     if (op->call_op.num_vars > 1) {
@@ -3037,6 +3278,11 @@ llvm::Value* StringIOCodegen::peekChar(const eshkol_operations_t* op) {
     return buildReadCharCommon(ctx_, tagged_, file_ptr, true);
 }
 
+/**
+ * @brief Codegen for R7RS `(char-ready? [port])`. Simplified stub that
+ *        always returns #t; a proper non-blocking check would use
+ *        select()/poll().
+ */
 llvm::Value* StringIOCodegen::charReady(const eshkol_operations_t* op) {
     // (char-ready?) or (char-ready? port)
     // For simplicity, always return #t (character I/O is always ready on file ports)
@@ -3049,6 +3295,10 @@ llvm::Value* StringIOCodegen::charReady(const eshkol_operations_t* op) {
 // Binary I/O Operations (R7RS §6.13.3)
 // ═══════════════════════════════════════════════════════════════════════════
 
+/**
+ * @brief Codegen for R7RS `(open-binary-input-file filename)`: opens via
+ *        `fopen` in "rb" mode and packs as a binary input port.
+ */
 llvm::Value* StringIOCodegen::openBinaryInputFile(const eshkol_operations_t* op) {
     if (!codegen_typed_ast_callback_ || !typed_to_tagged_callback_) {
         eshkol_warn("StringIOCodegen::openBinaryInputFile - callbacks not set");
@@ -3080,6 +3330,10 @@ llvm::Value* StringIOCodegen::openBinaryInputFile(const eshkol_operations_t* op)
         "open_binary_input_file");
 }
 
+/**
+ * @brief Codegen for R7RS `(open-binary-output-file filename)`: opens via
+ *        `fopen` in "wb" mode and packs as a binary output port.
+ */
 llvm::Value* StringIOCodegen::openBinaryOutputFile(const eshkol_operations_t* op) {
     if (!codegen_typed_ast_callback_ || !typed_to_tagged_callback_) {
         eshkol_warn("StringIOCodegen::openBinaryOutputFile - callbacks not set");
@@ -3111,6 +3365,10 @@ llvm::Value* StringIOCodegen::openBinaryOutputFile(const eshkol_operations_t* op
         "open_binary_output_file");
 }
 
+/**
+ * @brief Codegen for R7RS `(read-u8 [port])`: reads one byte via `fgetc` and
+ *        returns it as an exact integer, or the eof-object at EOF.
+ */
 llvm::Value* StringIOCodegen::readU8(const eshkol_operations_t* op) {
     // (read-u8) or (read-u8 port)
     if (op->call_op.num_vars > 1) {
@@ -3180,6 +3438,10 @@ llvm::Value* StringIOCodegen::readU8(const eshkol_operations_t* op) {
     return phi;
 }
 
+/**
+ * @brief Codegen for R7RS `(peek-u8 [port])`: like readU8() but pushes the
+ *        byte back with `ungetc` so it is not consumed.
+ */
 llvm::Value* StringIOCodegen::peekU8(const eshkol_operations_t* op) {
     // (peek-u8) or (peek-u8 port) — R7RS: read byte without consuming
     if (op->call_op.num_vars > 1) {
@@ -3251,6 +3513,9 @@ llvm::Value* StringIOCodegen::peekU8(const eshkol_operations_t* op) {
     return phi;
 }
 
+/**
+ * @brief Codegen for R7RS `(write-u8 byte [port])`: writes one byte via `fputc`.
+ */
 llvm::Value* StringIOCodegen::writeU8(const eshkol_operations_t* op) {
     // (write-u8 byte) or (write-u8 byte port)
     if (op->call_op.num_vars < 1 || op->call_op.num_vars > 2) {
@@ -3291,6 +3556,11 @@ llvm::Value* StringIOCodegen::writeU8(const eshkol_operations_t* op) {
     return tagged_.packNull();
 }
 
+/**
+ * @brief Codegen for R7RS `(read-bytevector k [port])`: reads up to k bytes
+ *        via `fread` into a freshly allocated bytevector, or returns the
+ *        eof-object if nothing was read.
+ */
 llvm::Value* StringIOCodegen::readBytevector(const eshkol_operations_t* op) {
     // (read-bytevector k) or (read-bytevector k port)
     if (op->call_op.num_vars < 1 || op->call_op.num_vars > 2) {
@@ -3397,6 +3667,10 @@ llvm::Value* StringIOCodegen::readBytevector(const eshkol_operations_t* op) {
     return phi;
 }
 
+/**
+ * @brief Codegen for R7RS `(write-bytevector bv [port [start [end]]])`:
+ *        writes the (optionally sliced) bytevector contents via `fwrite`.
+ */
 llvm::Value* StringIOCodegen::writeBytevector(const eshkol_operations_t* op) {
     // (write-bytevector bv) or (write-bytevector bv port) or (write-bytevector bv port start end)
     if (op->call_op.num_vars < 1 || op->call_op.num_vars > 4) {

--- a/lib/backend/system_codegen.cpp
+++ b/lib/backend/system_codegen.cpp
@@ -30,6 +30,11 @@ llvm::Function* getOrDeclareRuntimeFuncAllPtr(CodegenContext& ctx, llvm::Module*
 static llvm::Value* callPtrRuntime(CodegenContext& ctx, llvm::Function* f,
                                    llvm::ArrayRef<llvm::Value*> args);
 
+/**
+ * @brief Emit a runtime call checking whether @p capability is permitted
+ *        under the current capability/sandboxing policy.
+ * @return i1 SSA value: true if the runtime capability check allows it.
+ */
 static llvm::Value* runtimeCapabilityAllowed(CodegenContext& ctx, const char* capability) {
     llvm::FunctionType* fn_type = llvm::FunctionType::get(
         ctx.int32Type(), {ctx.ptrType()}, false);
@@ -41,6 +46,11 @@ static llvm::Value* runtimeCapabilityAllowed(CodegenContext& ctx, const char* ca
         allowed, llvm::ConstantInt::get(ctx.int32Type(), 0));
 }
 
+/**
+ * @brief Emit a runtime call that raises a capability-denied error for
+ *        @p capability (used when a sandboxed program attempts a disallowed
+ *        system operation).
+ */
 static void runtimeCapabilityDeny(CodegenContext& ctx, const char* capability) {
     llvm::FunctionType* fn_type = llvm::FunctionType::get(
         ctx.voidType(), {ctx.ptrType()}, false);
@@ -50,6 +60,7 @@ static void runtimeCapabilityDeny(CodegenContext& ctx, const char* capability) {
     ctx.builder().CreateCall(callee, {capability_name});
 }
 
+/** @brief Construct the system-operations codegen helper bound to the shared codegen context, tagged-value helper, memory codegen, and function table. */
 SystemCodegen::SystemCodegen(CodegenContext& ctx, TaggedValueCodegen& tagged, MemoryCodegen& mem,
                              std::unordered_map<std::string, llvm::Function*>& function_table)
     : ctx_(ctx)
@@ -59,6 +70,7 @@ SystemCodegen::SystemCodegen(CodegenContext& ctx, TaggedValueCodegen& tagged, Me
     eshkol_debug("SystemCodegen initialized");
 }
 
+/** @brief Unpack a tagged string/pointer value's raw data field into an LLVM pointer. */
 llvm::Value* SystemCodegen::extractStringPtr(llvm::Value* tagged_val) {
     llvm::Value* ptr_int = tagged_.unpackInt64(tagged_val);
     return ctx_.builder().CreateIntToPtr(ptr_int, ctx_.ptrType());
@@ -184,6 +196,11 @@ llvm::Value* SystemCodegen::getenv(const eshkol_operations_t* op) {
     return final_phi;
 }
 
+/**
+ * @brief Codegen for `(setenv name value)`: gates on the "env-write"
+ *        capability, then calls libc `setenv(name, value, 1)` and packs
+ *        whether it succeeded.
+ */
 llvm::Value* SystemCodegen::setenv(const eshkol_operations_t* op) {
     if (op->call_op.num_vars != 2) {
         eshkol_warn("setenv requires exactly 2 arguments (name value)");
@@ -245,6 +262,10 @@ llvm::Value* SystemCodegen::setenv(const eshkol_operations_t* op) {
     return phi;
 }
 
+/**
+ * @brief Codegen for `(unsetenv name)`: gates on the "env-write" capability,
+ *        then calls libc `unsetenv(name)` and packs whether it succeeded.
+ */
 llvm::Value* SystemCodegen::unsetenv(const eshkol_operations_t* op) {
     if (op->call_op.num_vars != 1) {
         eshkol_warn("unsetenv requires exactly 1 argument");
@@ -335,6 +356,11 @@ llvm::Value* SystemCodegen::systemCall(const eshkol_operations_t* op) {
     return tagged_.packInt64(result_i64, true);
 }
 
+/**
+ * @brief Codegen for `(sleep seconds)`: converts the (possibly fractional)
+ *        second count to microseconds, clamps to the valid int32 range, and
+ *        calls libc `usleep`.
+ */
 llvm::Value* SystemCodegen::sleep(const eshkol_operations_t* op) {
     if (op->call_op.num_vars != 1) {
         eshkol_warn("sleep requires exactly 1 argument");
@@ -391,6 +417,7 @@ llvm::Value* SystemCodegen::sleep(const eshkol_operations_t* op) {
     return tagged_.packNull();
 }
 
+/** @brief Codegen for `(current-seconds)`: calls libc `time(NULL)` and packs the result as an exact integer. */
 llvm::Value* SystemCodegen::currentSeconds(const eshkol_operations_t* op) {
     llvm::Function* time_func = function_table_["time"];
     if (!time_func) return tagged_.packInt64(llvm::ConstantInt::get(ctx_.int64Type(), 0), true);
@@ -402,6 +429,11 @@ llvm::Value* SystemCodegen::currentSeconds(const eshkol_operations_t* op) {
     return tagged_.packInt64(result, true);
 }
 
+/**
+ * @brief Codegen for `(current-time)`: returns Unix time as a fractional
+ *        double, computed via `gettimeofday` (tv_sec + tv_usec/1e6), or
+ *        falling back to whole-second `time(NULL)` if unavailable.
+ */
 llvm::Value* SystemCodegen::currentTime(const eshkol_operations_t* op) {
     (void)op;
 
@@ -442,6 +474,11 @@ llvm::Value* SystemCodegen::currentTime(const eshkol_operations_t* op) {
     return tagged_.packDouble(result);
 }
 
+/**
+ * @brief Codegen for `(current-time-ms)`: milliseconds since epoch, computed
+ *        via `gettimeofday` (tv_sec*1000 + tv_usec/1000), falling back to
+ *        `time(NULL)*1000` if `gettimeofday` is unavailable.
+ */
 llvm::Value* SystemCodegen::currentTimeMs(const eshkol_operations_t* op) {
     (void)op;  // No arguments needed
 
@@ -492,6 +529,10 @@ llvm::Value* SystemCodegen::currentTimeMs(const eshkol_operations_t* op) {
     return tagged_.packDouble(result);
 }
 
+/**
+ * @brief Codegen for `(current-time-ns)`: nanoseconds since epoch via
+ *        `clock_gettime(CLOCK_REALTIME, ...)` (tv_sec*1e9 + tv_nsec).
+ */
 llvm::Value* SystemCodegen::currentTimeNs(const eshkol_operations_t* op) {
     (void)op;  // No arguments needed
 
@@ -533,6 +574,11 @@ llvm::Value* SystemCodegen::currentTimeNs(const eshkol_operations_t* op) {
     return tagged_.packDouble(result);
 }
 
+/**
+ * @brief Codegen for `(exit code)`: coerces the exit code to a clamped i32
+ *        in [0, 255] (from a double, if that's the argument's type) and
+ *        calls libc `exit`.
+ */
 llvm::Value* SystemCodegen::exitProgram(const eshkol_operations_t* op) {
     if (op->call_op.num_vars != 1) {
         eshkol_warn("exit requires exactly 1 argument (exit code)");
@@ -589,6 +635,15 @@ llvm::Value* SystemCodegen::exitProgram(const eshkol_operations_t* op) {
     return nullptr;
 }
 
+/**
+ * @brief Codegen for `(command-line)`.
+ *
+ * Declares (or reuses) the `__eshkol_argc`/`__eshkol_argv` externs backed by
+ * the host process/JIT (see ADD_DATA_SYMBOL in repl_jit.cpp), then emits an
+ * IR loop that walks argv in reverse, copies each arg into an arena-header
+ * string, and conses it onto the result so the final list is in original
+ * argv order.
+ */
 llvm::Value* SystemCodegen::commandLine(const eshkol_operations_t* op) {
     // The argc/argv globals are owned by the host process and exposed to
     // JIT via ADD_DATA_SYMBOL (lib/repl/repl_jit.cpp:558-559). The
@@ -743,6 +798,7 @@ llvm::Value* SystemCodegen::fileExists(const eshkol_operations_t* op) {
     return tagged_.packBool(exists);
 }
 
+/** @brief Codegen for `(file-readable? path)`: calls libc `access(path, R_OK)`. */
 llvm::Value* SystemCodegen::fileReadable(const eshkol_operations_t* op) {
     if (op->call_op.num_vars != 1) {
         eshkol_warn("file-readable? requires exactly 1 argument");
@@ -768,6 +824,7 @@ llvm::Value* SystemCodegen::fileReadable(const eshkol_operations_t* op) {
     return tagged_.packBool(readable);
 }
 
+/** @brief Codegen for `(file-writable? path)`: calls libc `access(path, W_OK)`. */
 llvm::Value* SystemCodegen::fileWritable(const eshkol_operations_t* op) {
     if (op->call_op.num_vars != 1) {
         eshkol_warn("file-writable? requires exactly 1 argument");
@@ -793,6 +850,7 @@ llvm::Value* SystemCodegen::fileWritable(const eshkol_operations_t* op) {
     return tagged_.packBool(writable);
 }
 
+/** @brief Codegen for `(file-delete path)`: calls libc `remove(path)`. */
 llvm::Value* SystemCodegen::fileDelete(const eshkol_operations_t* op) {
     if (op->call_op.num_vars != 1) {
         eshkol_warn("file-delete requires exactly 1 argument");
@@ -816,6 +874,7 @@ llvm::Value* SystemCodegen::fileDelete(const eshkol_operations_t* op) {
     return tagged_.packBool(success);
 }
 
+/** @brief Codegen for `(file-rename old new)`: delegates to the `eshkol_builtin_file_rename` C runtime helper via callPtrRuntime(). */
 llvm::Value* SystemCodegen::fileRename(const eshkol_operations_t* op) {
     if (op->call_op.num_vars != 2) {
         eshkol_warn("file-rename requires exactly 2 arguments");
@@ -833,6 +892,11 @@ llvm::Value* SystemCodegen::fileRename(const eshkol_operations_t* op) {
     return callPtrRuntime(ctx_, rename_func, {old_arg, new_arg});
 }
 
+/**
+ * @brief Codegen for `(file-size path)`: opens the file with `fopen`,
+ *        seeks to the end via `fseek`/`ftell` to get the byte size, then
+ *        closes it. Returns #f if the file could not be opened.
+ */
 llvm::Value* SystemCodegen::fileSize(const eshkol_operations_t* op) {
     if (op->call_op.num_vars != 1) {
         eshkol_warn("file-size requires exactly 1 argument");
@@ -895,6 +959,12 @@ llvm::Value* SystemCodegen::fileSize(const eshkol_operations_t* op) {
     return phi;
 }
 
+/**
+ * @brief Codegen for `(read-file path)`: opens the file in "rb" mode, seeks
+ *        to determine its size, allocates a header-tagged string buffer of
+ *        that size, reads the whole file into it via `fread`, and
+ *        NUL-terminates it. Returns #f if the file could not be opened.
+ */
 llvm::Value* SystemCodegen::readFile(const eshkol_operations_t* op) {
     if (op->call_op.num_vars != 1) {
         eshkol_warn("read-file requires exactly 1 argument");
@@ -987,6 +1057,10 @@ llvm::Value* SystemCodegen::readFile(const eshkol_operations_t* op) {
     return phi;
 }
 
+/**
+ * @brief Codegen for `(write-file path content)`: opens the file in "wb"
+ *        (truncating) mode and writes the whole content string via `fwrite`.
+ */
 llvm::Value* SystemCodegen::writeFile(const eshkol_operations_t* op) {
     if (op->call_op.num_vars != 2) {
         eshkol_warn("write-file requires exactly 2 arguments");
@@ -1050,6 +1124,10 @@ llvm::Value* SystemCodegen::writeFile(const eshkol_operations_t* op) {
     return phi;
 }
 
+/**
+ * @brief Codegen for `(append-file path content)`: like writeFile() but
+ *        opens in "ab" (append) mode.
+ */
 llvm::Value* SystemCodegen::appendFile(const eshkol_operations_t* op) {
     if (op->call_op.num_vars != 2) {
         eshkol_warn("append-file requires exactly 2 arguments");
@@ -1170,6 +1248,7 @@ llvm::Value* SystemCodegen::directoryExists(const eshkol_operations_t* op) {
     return phi;
 }
 
+/** @brief Codegen for `(make-directory path)`: calls libc `mkdir(path, 0755)`. */
 llvm::Value* SystemCodegen::makeDirectory(const eshkol_operations_t* op) {
     if (op->call_op.num_vars != 1) {
         eshkol_warn("make-directory requires exactly 1 argument");
@@ -1195,6 +1274,7 @@ llvm::Value* SystemCodegen::makeDirectory(const eshkol_operations_t* op) {
     return tagged_.packBool(success);
 }
 
+/** @brief Codegen for `(delete-directory path)`: calls libc `rmdir(path)`. */
 llvm::Value* SystemCodegen::deleteDirectory(const eshkol_operations_t* op) {
     if (op->call_op.num_vars != 1) {
         eshkol_warn("delete-directory requires exactly 1 argument");
@@ -1218,6 +1298,13 @@ llvm::Value* SystemCodegen::deleteDirectory(const eshkol_operations_t* op) {
     return tagged_.packBool(success);
 }
 
+/**
+ * @brief Codegen for `(directory-list path)`: opens the directory with
+ *        `opendir`, loops over `readdir` entries (reading the platform's
+ *        `d_name` field at a fixed offset), copies each entry name into an
+ *        arena-allocated string, conses it onto a result list, and closes
+ *        the directory on EOF.
+ */
 llvm::Value* SystemCodegen::directoryList(const eshkol_operations_t* op) {
     if (op->call_op.num_vars != 1) {
         eshkol_warn("directory-list requires exactly 1 argument");
@@ -1327,6 +1414,7 @@ llvm::Value* SystemCodegen::directoryList(const eshkol_operations_t* op) {
     return ctx_.builder().CreateLoad(ctx_.taggedValueType(), result_ptr);
 }
 
+/** @brief Codegen for `(current-directory)`: calls libc `getcwd` into a 4096-byte arena buffer. */
 llvm::Value* SystemCodegen::currentDirectory(const eshkol_operations_t* op) {
     llvm::Function* getcwd_func = function_table_["getcwd"];
     if (!getcwd_func) return tagged_.packBool(llvm::ConstantInt::getFalse(ctx_.context()));
@@ -1369,6 +1457,7 @@ llvm::Value* SystemCodegen::currentDirectory(const eshkol_operations_t* op) {
     return phi;
 }
 
+/** @brief Codegen for `(set-current-directory! path)`: calls libc `chdir(path)`. */
 llvm::Value* SystemCodegen::setCurrentDirectory(const eshkol_operations_t* op) {
     if (op->call_op.num_vars != 1) {
         eshkol_warn("set-current-directory! requires exactly 1 argument");
@@ -1568,6 +1657,7 @@ llvm::Value* SystemCodegen::method_name(const eshkol_operations_t* op) { \
     return callPtrRuntime(ctx_, f, {a, b, c}); \
 }
 
+/** @brief Defines a 4-argument SystemCodegen method delegating to the all-pointer C runtime builtin @p c_func_name. */
 #define FOUR_ARG_BUILTIN(method_name, c_func_name) \
 llvm::Value* SystemCodegen::method_name(const eshkol_operations_t* op) { \
     if (op->call_op.num_vars != 4) return tagged_.packNull(); \
@@ -1582,6 +1672,7 @@ llvm::Value* SystemCodegen::method_name(const eshkol_operations_t* op) { \
     return callPtrRuntime(ctx_, f, {a, b, c, d}); \
 }
 
+/** @brief Defines a 5-argument SystemCodegen method delegating to the all-pointer C runtime builtin @p c_func_name. */
 #define FIVE_ARG_BUILTIN(method_name, c_func_name) \
 llvm::Value* SystemCodegen::method_name(const eshkol_operations_t* op) { \
     if (op->call_op.num_vars != 5) return tagged_.packNull(); \
@@ -1672,12 +1763,14 @@ static llvm::Value* callArenaTaggedFunc(CodegenContext& ctx, TaggedValueCodegen&
     return builder.CreateLoad(ctx.taggedValueType(), result_ptr);
 }
 
+/** @brief Defines a 0-argument SystemCodegen method delegating to the arena-first tagged consciousness-engine builtin @p c_func_name (via callArenaTaggedFunc()). */
 #define CE_ZERO_ARG(method_name, c_func_name) \
 llvm::Value* SystemCodegen::method_name(const eshkol_operations_t* op) { \
     (void)op; \
     return callArenaTaggedFunc(ctx_, tagged_, c_func_name, 0, {}); \
 }
 
+/** @brief Defines a 2-argument SystemCodegen method delegating to an arena-first tagged consciousness-engine builtin @p c_func_name. */
 #define CE_TWO_ARG(method_name, c_func_name) \
 llvm::Value* SystemCodegen::method_name(const eshkol_operations_t* op) { \
     if (op->call_op.num_vars != 2) return tagged_.packNull(); \
@@ -1688,6 +1781,7 @@ llvm::Value* SystemCodegen::method_name(const eshkol_operations_t* op) { \
     return callArenaTaggedFunc(ctx_, tagged_, c_func_name, 2, {a, b}); \
 }
 
+/** @brief Defines a 3-argument SystemCodegen method delegating to an arena-first tagged consciousness-engine builtin @p c_func_name. */
 #define CE_THREE_ARG(method_name, c_func_name) \
 llvm::Value* SystemCodegen::method_name(const eshkol_operations_t* op) { \
     if (op->call_op.num_vars != 3) return tagged_.packNull(); \
@@ -1699,6 +1793,7 @@ llvm::Value* SystemCodegen::method_name(const eshkol_operations_t* op) { \
     return callArenaTaggedFunc(ctx_, tagged_, c_func_name, 3, {a, b, c}); \
 }
 
+/** @brief Defines a 1-argument SystemCodegen method delegating to an arena-first tagged consciousness-engine builtin @p c_func_name. */
 #define CE_ONE_ARG(method_name, c_func_name) \
 llvm::Value* SystemCodegen::method_name(const eshkol_operations_t* op) { \
     if (op->call_op.num_vars != 1) return tagged_.packNull(); \
@@ -1708,6 +1803,7 @@ llvm::Value* SystemCodegen::method_name(const eshkol_operations_t* op) { \
     return callArenaTaggedFunc(ctx_, tagged_, c_func_name, 1, {a}); \
 }
 
+/** @brief Defines a 4-argument SystemCodegen method delegating to an arena-first tagged consciousness-engine builtin @p c_func_name. */
 #define CE_FOUR_ARG(method_name, c_func_name) \
 llvm::Value* SystemCodegen::method_name(const eshkol_operations_t* op) { \
     if (op->call_op.num_vars != 4) return tagged_.packNull(); \
@@ -1774,6 +1870,11 @@ ONE_ARG_BUILTIN(adTapeRelease, "eshkol_ad_tape_release_sret")
 TWO_ARG_BUILTIN(adConst, "eshkol_ad_const_sret")
 TWO_ARG_BUILTIN(adVar, "eshkol_ad_var_sret")
 
+/**
+ * @brief Shared codegen for reverse-mode AD tape binary node builders
+ *        (`(tape left right)` shape). Delegates to the all-pointer C runtime
+ *        function named @p func_name via callPtrRuntime().
+ */
 llvm::Value* SystemCodegen::adBinaryOp(const eshkol_operations_t* op, const char* func_name) {
     if (op->call_op.num_vars != 3) return tagged_.packNull();
     if (!codegen_ast_callback_) return tagged_.packNull();
@@ -1786,6 +1887,11 @@ llvm::Value* SystemCodegen::adBinaryOp(const eshkol_operations_t* op, const char
     return callPtrRuntime(ctx_, f, {tape, left, right});
 }
 
+/**
+ * @brief Shared codegen for reverse-mode AD tape unary node builders
+ *        (`(tape node)` shape). Delegates to the all-pointer C runtime
+ *        function named @p func_name via callPtrRuntime().
+ */
 llvm::Value* SystemCodegen::adUnaryOp(const eshkol_operations_t* op, const char* func_name) {
     if (op->call_op.num_vars != 2) return tagged_.packNull();
     if (!codegen_ast_callback_) return tagged_.packNull();

--- a/lib/backend/tagged_value_codegen.cpp
+++ b/lib/backend/tagged_value_codegen.cpp
@@ -14,6 +14,7 @@
 
 namespace eshkol {
 
+/** @brief Construct the tagged-value pack/unpack codegen helper bound to the shared codegen context. */
 TaggedValueCodegen::TaggedValueCodegen(CodegenContext& ctx)
     : ctx_(ctx) {
 }
@@ -51,6 +52,10 @@ llvm::Value* TaggedValueCodegen::buildTaggedValue(uint8_t type, uint8_t flags, l
     return v;
 }
 
+/**
+ * @brief Like buildTaggedValue(), but with runtime (non-constant) type and
+ *        flags values — used when the type/flags byte is itself computed in IR.
+ */
 llvm::Value* TaggedValueCodegen::buildTaggedValueDyn(llvm::Value* type_val, llvm::Value* flags_val, llvm::Value* data_i64) {
     auto& B = ctx_.builder();
     llvm::Value* v = llvm::UndefValue::get(ctx_.taggedValueType());
@@ -69,6 +74,10 @@ llvm::Value* TaggedValueCodegen::packInt64(llvm::Value* int64_val, bool is_exact
     return buildTaggedValue(ESHKOL_VALUE_INT64, flags, int64_val);
 }
 
+/**
+ * @brief Pack a value (i64, pointer, or narrower integer) as a tagged value
+ *        with an explicit @p type and @p flags rather than the default INT64.
+ */
 llvm::Value* TaggedValueCodegen::packInt64WithType(
     llvm::Value* int64_val,
     eshkol_value_type_t type,
@@ -89,11 +98,13 @@ llvm::Value* TaggedValueCodegen::packInt64WithType(
     return buildTaggedValue(type, flags, val_as_i64);
 }
 
+/** @brief Pack an i1 boolean as a BOOL tagged value. */
 llvm::Value* TaggedValueCodegen::packBool(llvm::Value* bool_val) {
     llvm::Value* int64_val = ctx_.builder().CreateZExt(bool_val, ctx_.int64Type());
     return buildTaggedValue(ESHKOL_VALUE_BOOL, 0, int64_val);
 }
 
+/** @brief Like packInt64WithType(), but with both type and flags as runtime (non-constant) values. */
 llvm::Value* TaggedValueCodegen::packInt64WithTypeAndFlags(
     llvm::Value* int64_val,
     llvm::Value* type_val,
@@ -101,11 +112,20 @@ llvm::Value* TaggedValueCodegen::packInt64WithTypeAndFlags(
     return buildTaggedValueDyn(type_val, flags_val, int64_val);
 }
 
+/** @brief Pack a double as a DOUBLE tagged value (bitcast into the i64 data slot, INEXACT flag set). */
 llvm::Value* TaggedValueCodegen::packDouble(llvm::Value* double_val) {
     llvm::Value* double_as_int64 = ctx_.builder().CreateBitCast(double_val, ctx_.int64Type());
     return buildTaggedValue(ESHKOL_VALUE_DOUBLE, ESHKOL_VALUE_INEXACT_FLAG, double_as_int64);
 }
 
+/**
+ * @brief Normalize any LLVM value (already-tagged struct, double, i64, i1,
+ *        or pointer) into a full tagged_value struct.
+ *
+ * Used before storing an argument into a tagged-value ABI slot: storing a
+ * raw scalar directly would leave the type/flags bytes uninitialized.
+ * Returns a null tagged value for unrecognized raw types or a null input.
+ */
 llvm::Value* TaggedValueCodegen::ensureTagged(llvm::Value* val) {
     if (!val) {
         return buildTaggedValue(ESHKOL_VALUE_NULL, 0,
@@ -128,6 +148,7 @@ llvm::Value* TaggedValueCodegen::ensureTagged(llvm::Value* val) {
         llvm::ConstantInt::get(ctx_.int64Type(), 0));
 }
 
+/** @brief Pack a pointer (or i64 already holding a pointer bit-pattern) as a tagged value of the given @p type/@p flags. */
 llvm::Value* TaggedValueCodegen::packPtr(
     llvm::Value* ptr_val,
     eshkol_value_type_t type,
@@ -146,6 +167,7 @@ llvm::Value* TaggedValueCodegen::packPtr(
     return buildTaggedValue(type, flags, ptr_as_int64);
 }
 
+/** @brief Like packPtr(), but with both type and flags as runtime (non-constant) values. */
 llvm::Value* TaggedValueCodegen::packPtrWithFlags(
     llvm::Value* ptr_val,
     llvm::Value* type_val,
@@ -177,6 +199,7 @@ llvm::Value* TaggedValueCodegen::packHeapPtr(llvm::Value* ptr_val, uint8_t flags
     return packPtr(ptr_val, ESHKOL_VALUE_HEAP_PTR, flags);
 }
 
+/** @brief Pack a pointer using the consolidated CALLABLE type (subtype—closure, lambda-sexpr, ad-node—lives in the object header). */
 llvm::Value* TaggedValueCodegen::packCallable(llvm::Value* ptr_val, uint8_t flags) {
     // Pack pointer using consolidated CALLABLE type.
     // The subtype (closure, lambda-sexpr, ad-node) is in the object header.
@@ -184,6 +207,7 @@ llvm::Value* TaggedValueCodegen::packCallable(llvm::Value* ptr_val, uint8_t flag
     return packPtr(ptr_val, ESHKOL_VALUE_CALLABLE, flags);
 }
 
+/** @brief Build the NULL tagged value (via an entry alloca + field stores, then a load). */
 llvm::Value* TaggedValueCodegen::packNull() {
     llvm::Value* tagged_val_ptr = createEntryAlloca("tagged_null");
 
@@ -210,6 +234,13 @@ llvm::Value* TaggedValueCodegen::packNull() {
     return ctx_.builder().CreateLoad(ctx_.taggedValueType(), tagged_val_ptr);
 }
 
+/**
+ * @brief Pack a codepoint value as a CHAR tagged value.
+ *
+ * Accepts the codepoint as i64, a narrower integer, or an already-tagged
+ * value (unpacked first); falls back to a pointer-to-int cast with a
+ * warning for any other type.
+ */
 llvm::Value* TaggedValueCodegen::packChar(llvm::Value* char_val) {
     llvm::Value* tagged_val_ptr = createEntryAlloca("char_tagged");
 
@@ -272,10 +303,15 @@ llvm::Value* TaggedValueCodegen::getType(llvm::Value* tagged_val) {
     return ctx_.builder().CreateExtractValue(tagged_val, {0});
 }
 
+/** @brief Extract the flags byte (field 1) from a tagged value struct. */
 llvm::Value* TaggedValueCodegen::getFlags(llvm::Value* tagged_val) {
     return ctx_.builder().CreateExtractValue(tagged_val, {1});
 }
 
+/**
+ * @brief Extract the raw i64 data field from a tagged value, or coerce a
+ *        raw (untagged) LLVM value of any supported type to i64.
+ */
 llvm::Value* TaggedValueCodegen::unpackInt64(llvm::Value* tagged_val) {
     if (tagged_val->getType() != ctx_.taggedValueType()) {
         // Raw value — convert to i64 directly
@@ -291,6 +327,10 @@ llvm::Value* TaggedValueCodegen::unpackInt64(llvm::Value* tagged_val) {
     return ctx_.builder().CreateExtractValue(tagged_val, {4});
 }
 
+/**
+ * @brief Extract a double from a tagged value (bitcasting the i64 data
+ *        field) or coerce a raw double/integer/null value to double.
+ */
 llvm::Value* TaggedValueCodegen::unpackDouble(llvm::Value* tagged_val) {
     if (!tagged_val) {
         return llvm::ConstantFP::get(ctx_.doubleType(), 0.0);
@@ -312,11 +352,13 @@ llvm::Value* TaggedValueCodegen::unpackDouble(llvm::Value* tagged_val) {
     return ctx_.builder().CreateBitCast(data_i64, ctx_.doubleType());
 }
 
+/** @brief Extract the data field of a tagged value as an LLVM pointer. */
 llvm::Value* TaggedValueCodegen::unpackPtr(llvm::Value* tagged_val) {
     llvm::Value* data_i64 = ctx_.builder().CreateExtractValue(tagged_val, {4});
     return ctx_.builder().CreateIntToPtr(data_i64, ctx_.ptrType());
 }
 
+/** @brief Extract the data field of a tagged value and truncate it to i1. */
 llvm::Value* TaggedValueCodegen::unpackBool(llvm::Value* tagged_val) {
     llvm::Value* data_i64 = ctx_.builder().CreateExtractValue(tagged_val, {4});
     return ctx_.builder().CreateTrunc(data_i64, ctx_.builder().getInt1Ty(), "bool_val");
@@ -360,6 +402,7 @@ llvm::Value* TaggedValueCodegen::safeExtractInt64(llvm::Value* val) {
     return llvm::ConstantInt::get(ctx_.int64Type(), 0);
 }
 
+/** @brief Compile-time (non-IR) check: does @p val have the tagged_value LLVM struct type? */
 bool TaggedValueCodegen::isTaggedValue(llvm::Value* val) const {
     return val && val->getType() == ctx_.taggedValueType();
 }
@@ -394,6 +437,12 @@ llvm::Value* TaggedValueCodegen::isNull(llvm::Value* tagged_val) {
         base_type, llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_NULL));
 }
 
+/**
+ * @brief Emit an i1 IR check for whether @p tagged_val is a cons cell:
+ *        HEAP_PTR type whose object header subtype equals HEAP_SUBTYPE_CONS.
+ *        Uses branching control flow so the header is only read when the
+ *        value is actually a HEAP_PTR.
+ */
 llvm::Value* TaggedValueCodegen::isCons(llvm::Value* tagged_val) {
     // M1 CONSOLIDATION FIX: Check HEAP_PTR type and HEAP_SUBTYPE_CONS subtype
     // Cons cells are HEAP_PTR with header subtype == HEAP_SUBTYPE_CONS (0)
@@ -428,6 +477,7 @@ llvm::Value* TaggedValueCodegen::isCons(llvm::Value* tagged_val) {
     return result;
 }
 
+/** @brief Emit an i1 IR check for whether @p tagged_val is a string: HEAP_PTR with header subtype HEAP_SUBTYPE_STRING (see isCons()). */
 llvm::Value* TaggedValueCodegen::isString(llvm::Value* tagged_val) {
     // M1 CONSOLIDATION FIX: Check HEAP_PTR type and HEAP_SUBTYPE_STRING subtype
     // Strings are HEAP_PTR with header subtype == HEAP_SUBTYPE_STRING (1)
@@ -462,6 +512,7 @@ llvm::Value* TaggedValueCodegen::isString(llvm::Value* tagged_val) {
     return result;
 }
 
+/** @brief Emit an i1 IR check for whether @p tagged_val is a vector: HEAP_PTR with header subtype HEAP_SUBTYPE_VECTOR (see isCons()). */
 llvm::Value* TaggedValueCodegen::isVector(llvm::Value* tagged_val) {
     // M1 CONSOLIDATION: Check HEAP_PTR type and HEAP_SUBTYPE_VECTOR subtype
     // Vectors are HEAP_PTR with header subtype == HEAP_SUBTYPE_VECTOR (2)
@@ -495,6 +546,7 @@ llvm::Value* TaggedValueCodegen::isVector(llvm::Value* tagged_val) {
     return result;
 }
 
+/** @brief Emit an i1 IR check for whether @p tagged_val is a tensor: HEAP_PTR with header subtype HEAP_SUBTYPE_TENSOR (see isCons()). */
 llvm::Value* TaggedValueCodegen::isTensor(llvm::Value* tagged_val) {
     // M1 CONSOLIDATION: Check HEAP_PTR type and HEAP_SUBTYPE_TENSOR subtype
     // Tensors are HEAP_PTR with header subtype == HEAP_SUBTYPE_TENSOR (3)
@@ -528,6 +580,12 @@ llvm::Value* TaggedValueCodegen::isTensor(llvm::Value* tagged_val) {
     return result;
 }
 
+/**
+ * @brief Emit an i1 IR check for whether @p tagged_val is a closure:
+ *        CALLABLE type whose object header subtype equals
+ *        CALLABLE_SUBTYPE_CLOSURE. Uses branching control flow so the
+ *        header is only read when the value is actually CALLABLE.
+ */
 llvm::Value* TaggedValueCodegen::isClosure(llvm::Value* tagged_val) {
     // M1 CONSOLIDATION FIX: Check CALLABLE type and CALLABLE_SUBTYPE_CLOSURE subtype
     // Closures are CALLABLE with header subtype == CALLABLE_SUBTYPE_CLOSURE (0)
@@ -562,6 +620,7 @@ llvm::Value* TaggedValueCodegen::isClosure(llvm::Value* tagged_val) {
     return result;
 }
 
+/** @brief Emit an i1 IR check for whether @p tagged_val is a preserved lambda S-expression: CALLABLE with header subtype CALLABLE_SUBTYPE_LAMBDA_SEXPR (see isClosure()). */
 llvm::Value* TaggedValueCodegen::isLambdaSexpr(llvm::Value* tagged_val) {
     // M1 CONSOLIDATION FIX: Check CALLABLE type and CALLABLE_SUBTYPE_LAMBDA_SEXPR subtype
     // Lambda s-exprs are CALLABLE with header subtype == CALLABLE_SUBTYPE_LAMBDA_SEXPR (1)
@@ -596,6 +655,7 @@ llvm::Value* TaggedValueCodegen::isLambdaSexpr(llvm::Value* tagged_val) {
     return result;
 }
 
+/** @brief Emit an i1 IR check for whether @p tagged_val's type tag is the consolidated HEAP_PTR type (any heap data object). */
 llvm::Value* TaggedValueCodegen::isHeapPtr(llvm::Value* tagged_val) {
     // M1 CONSOLIDATION FIX: All heap data objects use HEAP_PTR type (8)
     // Subtypes (cons, string, vector, tensor, hash, exception) are in the object header
@@ -604,6 +664,7 @@ llvm::Value* TaggedValueCodegen::isHeapPtr(llvm::Value* tagged_val) {
         type_tag, llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_HEAP_PTR));
 }
 
+/** @brief Emit an i1 IR check for whether @p tagged_val's type tag is the consolidated CALLABLE type (any callable object). */
 llvm::Value* TaggedValueCodegen::isCallable(llvm::Value* tagged_val) {
     // M1 CONSOLIDATION FIX: All callable objects use CALLABLE type (9)
     // Subtypes (closure, lambda_sexpr, ad_node) are in the object header
@@ -612,6 +673,7 @@ llvm::Value* TaggedValueCodegen::isCallable(llvm::Value* tagged_val) {
         type_tag, llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_CALLABLE));
 }
 
+/** @brief Emit an i1 IR check for `(exact? and integer-typed)`: base type (via getBaseType()) equals INT64. */
 llvm::Value* TaggedValueCodegen::isInt64(llvm::Value* tagged_val) {
     llvm::Value* type_tag = getType(tagged_val);
     // Use getBaseType() to properly handle legacy types (>=32) and exactness flags
@@ -621,6 +683,7 @@ llvm::Value* TaggedValueCodegen::isInt64(llvm::Value* tagged_val) {
         base_type, llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_INT64));
 }
 
+/** @brief Emit an i1 IR check: base type (via getBaseType()) equals DOUBLE. */
 llvm::Value* TaggedValueCodegen::isDouble(llvm::Value* tagged_val) {
     llvm::Value* type_tag = getType(tagged_val);
     // Use getBaseType() to properly handle legacy types (>=32) and exactness flags
@@ -630,6 +693,7 @@ llvm::Value* TaggedValueCodegen::isDouble(llvm::Value* tagged_val) {
         base_type, llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_DOUBLE));
 }
 
+/** @brief Emit an i1 IR check: base type is INT64 or DOUBLE. */
 llvm::Value* TaggedValueCodegen::isNumeric(llvm::Value* tagged_val) {
     llvm::Value* type_tag = getType(tagged_val);
     // Use getBaseType() to properly handle legacy types (>=32) and exactness flags
@@ -643,6 +707,7 @@ llvm::Value* TaggedValueCodegen::isNumeric(llvm::Value* tagged_val) {
     return ctx_.builder().CreateOr(is_int, is_double);
 }
 
+/** @brief Emit an i1 IR check: base type (via getBaseType()) equals BOOL. */
 llvm::Value* TaggedValueCodegen::isBool(llvm::Value* tagged_val) {
     llvm::Value* type_tag = getType(tagged_val);
     // Use getBaseType() to properly handle legacy types (>=32) and exactness flags
@@ -652,6 +717,13 @@ llvm::Value* TaggedValueCodegen::isBool(llvm::Value* tagged_val) {
         base_type, llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_BOOL));
 }
 
+/**
+ * @brief Normalize a raw type tag to its base type for comparison,
+ *        masking off exactness flag bits for immediate types (0-7) but
+ *        leaving consolidated (8-9), multimedia (16-19), and legacy (32+)
+ *        type tags unmasked (masking those would corrupt them — e.g.
+ *        legacy CONS_PTR=32 masked with 0x0F becomes 0/NULL).
+ */
 llvm::Value* TaggedValueCodegen::getBaseType(llvm::Value* type_tag) {
     // Get base type from type tag, handling legacy types correctly:
     // - Immediate types (0-7): may have exactness flags in high bits, mask with 0x0F
@@ -705,6 +777,7 @@ llvm::Value* TaggedValueCodegen::getSubtypeFromHeader(llvm::Value* ptr_val) {
     return subtype;
 }
 
+/** @brief Unpack @p tagged_val's pointer and compare its object-header subtype byte against @p expected_subtype. */
 llvm::Value* TaggedValueCodegen::checkHeapSubtype(llvm::Value* tagged_val, uint8_t expected_subtype) {
     // Extract pointer from tagged value and check subtype in header
     llvm::Value* ptr_val = unpackInt64(tagged_val);
@@ -716,6 +789,7 @@ llvm::Value* TaggedValueCodegen::checkHeapSubtype(llvm::Value* tagged_val, uint8
         "subtype_match");
 }
 
+/** @brief Same as checkHeapSubtype(), for CALLABLE-typed values (both read the header at ptr-8). */
 llvm::Value* TaggedValueCodegen::checkCallableSubtype(llvm::Value* tagged_val, uint8_t expected_subtype) {
     // Extract pointer from tagged value and check subtype in header
     // Same implementation as checkHeapSubtype - both use object header at ptr-8

--- a/lib/backend/type_system.cpp
+++ b/lib/backend/type_system.cpp
@@ -16,6 +16,13 @@
 
 namespace eshkol {
 
+/**
+ * @brief Construct the type system, caching primitive/SIMD LLVM types and
+ *        building the shared struct types used across codegen.
+ * @param ctx LLVM context that owns all created types.
+ * @param is_wasm32 If true, size/pointer-sized types are created as i32
+ *                   instead of i64 to match the wasm32 target.
+ */
 TypeSystem::TypeSystem(llvm::LLVMContext& ctx, bool is_wasm32)
     : context(ctx), is_wasm32_(is_wasm32) {
     // Cache primitive types (avoid repeated lookups)
@@ -42,6 +49,11 @@ TypeSystem::TypeSystem(llvm::LLVMContext& ctx, bool is_wasm32)
     createStructTypes();
 }
 
+/**
+ * @brief Create the shared LLVM struct types (tagged value, dual number,
+ *        complex number, AD node, tensor) that mirror the corresponding C
+ *        runtime struct layouts field-for-field.
+ */
 void TypeSystem::createStructTypes() {
     // Tagged value struct type (matches C struct exactly):
     // struct eshkol_tagged_value {


### PR DESCRIPTION
Doxygen doc-comments for undocumented function definitions in lib/backend/ group B (part 1: parallel_codegen, string_io_codegen, system_codegen, tagged_value_codegen, type_system). Documentation only — verified comment-only (0 non-comment additions). Remaining group-B files (tail_call/tensor_*/vm_*/xla/gpu/weight_matrices/eshkol_compiler/thread_pool/work_stealing) to follow in part 2.