### PR TITLE
site: update website content for v1.3.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,9 @@ Thank you for your interest in contributing to Eshkol! This document provides gu
     - [Testing](#testing)
   - [Project Structure](#project-structure)
   - [Communication](#communication)
-  - [Priority Areas for Contribution (v1.3+)](#priority-areas-for-contribution-v13)
-    - [Immediate Priorities (v1.3-evolve - June 2026)](#immediate-priorities-v13-evolve---june-2026)
-    - [Near-Term (v1.5-intelligence - Q3 2026)](#near-term-v15-intelligence---q3-2026)
+  - [Priority Areas for Contribution (v1.4+)](#priority-areas-for-contribution-v14)
+    - [Immediate Priorities (v1.4-connection - July 2026)](#immediate-priorities-v14-connection---july-2026)
+    - [Near-Term (v1.5-intelligence - August 2026)](#near-term-v15-intelligence---august-2026)
     - [Ongoing](#ongoing)
   - [Recognition](#recognition)
 
@@ -280,24 +280,27 @@ eshkol/
 - **GitHub Discussions**: For general questions, ideas, and community discussions.
 - **Pull Requests**: For code contributions and code reviews.
 
-## Priority Areas for Contribution (v1.3+)
+## Priority Areas for Contribution (v1.4+)
 
-v1.0-foundation, v1.1-accelerate, and v1.2.0-scale are **complete**. We welcome contributions for upcoming releases:
+v1.0-foundation, v1.1-accelerate, v1.2-scale, and v1.3.0-evolve (arbitrary-order
+AD, full R7RS conformance, closure/TCO/memory hardening) are **complete**, and
+v1.3.1 has landed further robustness for long-running, resident programs plus
+comprehensive C-API documentation. We welcome contributions for upcoming releases:
 
-### Immediate Priorities (v1.3-evolve - June 2026)
-1. **R7RS Library System**: `define-library` / `import` with renaming, prefixing, `only`, `except`
-2. **String Interpolation**: `~{expr}` syntax in strings
-3. **Named Keyword Arguments**: `(f #:key value)` call syntax
-4. **Destructuring Let**: `(let-match ((cons a b) lst) ...)`
-5. **Profile-Guided & Whole-Program Optimization**: PGO + LTO wired through the build
+### Immediate Priorities (v1.4-connection - July 2026)
+1. **TCP/UDP Sockets**: Linear resource types with guaranteed close
+2. **TLS/SSL**: Via system libraries
+3. **Non-Blocking I/O**: Event loop (epoll/kqueue)
+4. **HTTP Client**: Built on sockets + TLS
+5. **Linear Types for Handles**: `open -> borrowed -> closed` with compile-time tracking
 6. **Debugger**: REPL step-through with breakpoints + variable inspection
 7. **Documentation Generator**: `eshkol-doc` from docstrings
 
-### Near-Term (v1.5-intelligence - Q3 2026)
+### Near-Term (v1.5-intelligence - August 2026)
 1. **Neural-Symbolic Search**: Differentiable logic programs (building on v1.1 consciousness engine)
-2. **Multi-GPU Support**: Distribute work across multiple GPUs
-3. **Profile-Guided Optimization**: Runtime profile-based optimization
-4. **Full R7RS Library System**: `define-library` / `import` with renaming
+2. **Symbol Embeddings & Soft Unification**: Differentiable similarity over the knowledge base
+3. **LSTM/GRU Cells**: Standard recurrent neural architectures
+4. **Multi-GPU Support**: Distribute work across multiple GPUs
 
 ### Ongoing
 1. **Documentation**: Tutorials, examples, case studies

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,7 +1,7 @@
-# Eshkol v1.3.0-evolve API Reference
+# Eshkol v1.3.1 API Reference
 
-**Version**: 1.3.0-evolve
-**Last Updated**: 2026-05-20
+**Version**: 1.3.1
+**Last Updated**: 2026-07-08
 **Audience**: Scientific Computing & AI Systems Programming
 
 This comprehensive reference documents all special forms, functions, and operations in the Eshkol language. All documentation is code-verified against the production compiler implementation (~232,000 lines of LLVM-based C++ code, 555+ builtins).

--- a/docs/COMPLETE_LANGUAGE_SPECIFICATION.md
+++ b/docs/COMPLETE_LANGUAGE_SPECIFICATION.md
@@ -1,7 +1,7 @@
 # Eshkol Language - Complete Technical Specification
 
-**Version:** v1.3.0-evolve
-**Generated:** 2026-05-20
+**Version:** v1.3.1
+**Generated:** 2026-07-08
 **Status:** Comprehensive implementation documentation from source code
 
 ---
@@ -4043,9 +4043,14 @@ Keep original name (exported via `provide`)
 
 ## 26. Version Information
 
-**Current Version:** v1.3.0-evolve
+**Current Version:** v1.3.1
 
 **Version History:**
+- v1.3.1 - Robustness for long-running, resident programs: per-iteration
+  arena reclamation for define-loops guarded by a catch-all handler, an
+  iterative reader so large persisted structures load without native stack
+  overflow, and comprehensive C-API documentation. See
+  [CHANGELOG.md](../CHANGELOG.md).
 - v1.3.0-evolve - Arbitrary-order automatic differentiation (Taylor towers,
   phases P0-P12: exact bignum/rational coefficients, no-heap
   monomorphization, GUW multivariate mixed partials, reverse-over-Taylor,
@@ -4163,7 +4168,7 @@ Dynamic binding of parameter objects. Parameters created with `make-parameter` a
 
 ## Conclusion
 
-This document provides a **complete** specification of the Eshkol programming language version v1.3.0-evolve, documenting **every** feature, function, operator, and capability found in the implementation.
+This document provides a **complete** specification of the Eshkol programming language version v1.3.1, documenting **every** feature, function, operator, and capability found in the implementation.
 
 **Total Coverage:**
 - All 101 special forms and parser operations

--- a/docs/ESHKOL_LANGUAGE_GUIDE.md
+++ b/docs/ESHKOL_LANGUAGE_GUIDE.md
@@ -1135,7 +1135,7 @@ Map Eshkol names to C names:
 
 ```
 $ ./eshkol-repl
-Eshkol REPL v1.3.0-evolve
+Eshkol REPL v1.3.1
 Type :help for assistance, :quit to exit
 
 eshkol> (define (square x) (* x x))
@@ -1492,5 +1492,5 @@ MIT License - Copyright (C) tsotchke
 ---
 
 <p align="center">
-<strong>Eshkol v1.3.0-evolve</strong>: Where functional programming meets scientific computing, GPU acceleration, and machine consciousness.
+<strong>Eshkol v1.3.1</strong>: Where functional programming meets scientific computing, GPU acceleration, and machine consciousness.
 </p>

--- a/docs/ESHKOL_QUICK_REFERENCE.md
+++ b/docs/ESHKOL_QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Eshkol Quick Reference Card
 
-**v1.3.0-evolve** -- 555+ built-in functions
+**v1.3.1** -- 555+ built-in functions
 
 ## Basics
 

--- a/docs/FEATURE_MATRIX.md
+++ b/docs/FEATURE_MATRIX.md
@@ -1,4 +1,4 @@
-# Eshkol v1.3.0-evolve Feature Matrix
+# Eshkol v1.3.1 Feature Matrix
 
 **Status Key**: ✅ Production | 🚧 In Progress | 📋 Planned | ❌ Not Planned
 
@@ -690,6 +690,10 @@ This matrix documents all implemented and planned features for the Eshkol langua
 
 ## Roadmap
 
+> This section is a historical snapshot and may lag; see the canonical,
+> continuously-updated [ROADMAP.md](../ROADMAP.md) for current status. As of
+> v1.3.1, v1.1-accelerate, v1.2-scale, and v1.3.0-evolve have all shipped.
+
 ### v1.1-accelerate (Q1 2026) — COMPLETED
 
 - ✅ **GPU Support**: Metal (Apple Silicon) + CUDA (NVIDIA)
@@ -701,7 +705,7 @@ This matrix documents all implemented and planned features for the Eshkol langua
 - ✅ **Optimizers**: Adam, L-BFGS, conjugate gradient in stdlib
 - ✅ **R7RS Extensions**: call/cc, dynamic-wind, bytevectors, let-syntax
 
-### v1.2-scale (Q2 2026)
+### v1.2-scale (Q2 2026) — SHIPPED
 
 - **Data I/O**: Image/audio I/O, typed buffers, streams, DataFrame, plotting
 - **Vulkan Compute**: Cross-platform GPU backend, multi-GPU
@@ -709,7 +713,7 @@ This matrix documents all implemented and planned features for the Eshkol langua
 - **Python Bindings**: Call Eshkol from Python and vice versa
 - **Distributed Training**: AllReduce, MPI, gRPC
 
-### v1.3-evolve (Q3 2026)
+### v1.3-evolve (Q3 2026) — SHIPPED as v1.3.0-evolve
 
 - **Language Extensions**: Full R7RS library system, string interpolation, keyword arguments
 - **Advanced Types**: Refinement types, effect types, higher-rank types, row polymorphism
@@ -905,7 +909,7 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for development guidelines.
 
 ---
 
-**Last Updated**: 2026-05-20
-**Document Version**: 1.3.0-evolve
+**Last Updated**: 2026-07-08
+**Document Version**: 1.3.1
 
 For detailed API documentation, see [API_REFERENCE.md](API_REFERENCE.md)

--- a/site/src/main.esk
+++ b/site/src/main.esk
@@ -374,7 +374,7 @@
         (let ((title (create-text "h1" "Build systems that think." left)))
           (web-add-class title "hero-title"))
 
-        (let ((sub (create-text "p" "Eshkol is R7RS Scheme on LLVM 21 with automatic differentiation as a compiler primitive and a 22-builtin neuro-symbolic stack. v1.3.0-evolve ships the constructive proof that a six-layer transformer can be an interpreter — the Self-Differentiating Neural Computer." left)))
+        (let ((sub (create-text "p" "Eshkol is R7RS Scheme on LLVM 21 with automatic differentiation as a compiler primitive and a 22-builtin neuro-symbolic stack. v1.3.1 carries forward the constructive proof that a six-layer transformer can be an interpreter — the Self-Differentiating Neural Computer — with hardening for long-running, resident programs." left)))
           (web-add-class sub "hero-sub"))
 
         ;; Install command
@@ -548,8 +548,8 @@
 
 (define (render-v12-features parent)
   (let ((section (create-section parent)))
-    (section-heading section "What's new in v1.3.0-evolve")
-    (body-html section "<strong style='color:#a78bfa'>Evolve.</strong> v1.3.0-evolve brings full SICP coverage (an 88/88 full-book gate under both JIT and AOT), exact nested/mixed-mode automatic differentiation, closure-semantics completion, and a green CI across all 14 platform lanes including windows-arm64 &mdash; backed by a new permanent adversarial-testing infrastructure (differential, edge-matrix, AD finite-difference oracle, stress, and VM-parity harnesses).")
+    (section-heading section "What's new in v1.3.1")
+    (body-html section "<strong style='color:#a78bfa'>Evolve, hardened.</strong> v1.3.1 builds on the v1.3.0-evolve AD matrix &mdash; full SICP coverage (an 88/88 full-book gate under both JIT and AOT), exact nested/mixed-mode automatic differentiation, and a green CI across all 14 platform lanes including windows-arm64 &mdash; with robustness for long-running, resident programs: per-iteration arena reclamation for define-loops wrapped in a catch-all guard, and an iterative reader so large persisted structures load without a native stack overflow. The public C API is now comprehensively documented, and the permanent adversarial-testing infrastructure (differential, edge-matrix, AD finite-difference oracle, stress, and VM-parity harnesses) continues to gate every release.")
 
     (let ((grid (create-grid-3 section)))
       (render-feature-card grid
@@ -1328,7 +1328,7 @@
 
         ;; Welcome message
         (web-set-inner-html output
-          "<span style='color:#7c3aed;font-weight:bold'>Eshkol Bytecode VM</span> <span style='color:#71717a'>v1.3.0-evolve</span>\n<span style='color:#71717a'>83-opcode ISA | Arena memory (OALR) | R7RS Scheme</span>\n<span style='color:#71717a'>Type an expression and press Enter.</span>\n\n"))
+          "<span style='color:#7c3aed;font-weight:bold'>Eshkol Bytecode VM</span> <span style='color:#71717a'>v1.3.1</span>\n<span style='color:#71717a'>83-opcode ISA | Arena memory (OALR) | R7RS Scheme</span>\n<span style='color:#71717a'>Type an expression and press Enter.</span>\n\n"))
 
       ;; Terminal input area
       (let ((input-row (create-div terminal)))

--- a/site/static/content/api_reference.html
+++ b/site/static/content/api_reference.html
@@ -1,7 +1,6 @@
-<h1 id="eshkol-v1.3.0-evolve-api-reference">Eshkol v1.3.0-evolve API
-Reference</h1>
-<p><strong>Version</strong>: 1.3.0-evolve <strong>Last Updated</strong>:
-2026-05-20 <strong>Audience</strong>: Scientific Computing &amp; AI
+<h1 id="eshkol-v1.3.1-api-reference">Eshkol v1.3.1 API Reference</h1>
+<p><strong>Version</strong>: 1.3.1 <strong>Last Updated</strong>:
+2026-07-08 <strong>Audience</strong>: Scientific Computing &amp; AI
 Systems Programming</p>
 <p>This comprehensive reference documents all special forms, functions,
 and operations in the Eshkol language. All documentation is

--- a/site/static/content/complete_language_specification.html
+++ b/site/static/content/complete_language_specification.html
@@ -1,7 +1,7 @@
 <h1 id="eshkol-language---complete-technical-specification">Eshkol
 Language - Complete Technical Specification</h1>
-<p><strong>Version:</strong> v1.3.0-evolve <strong>Generated:</strong>
-2026-05-20 <strong>Status:</strong> Comprehensive implementation
+<p><strong>Version:</strong> v1.3.1 <strong>Generated:</strong>
+2026-07-08 <strong>Status:</strong> Comprehensive implementation
 documentation from source code</p>
 <hr />
 <h2 id="table-of-contents">Table of Contents</h2>
@@ -657,6 +657,14 @@ Multi-way Conditional</h4>
 <pre class="scheme"><code>(cond ((&lt; x 0) &quot;negative&quot;)
       ((= x 0) &quot;zero&quot;)
       ((&gt; x 0) &quot;positive&quot;))</code></pre>
+<p><strong>R7RS <code>=&gt;</code> arrow clause</strong>
+(<code>(test =&gt; receiver)</code>): if <code>test</code> evaluates to
+a true value, that value (evaluated exactly once) is passed to the unary
+procedure <code>receiver</code>, whose result becomes the value of the
+<code>cond</code>:</p>
+<pre class="scheme"><code>(cond ((assv 1 (list (cons 1 10))) =&gt; cdr)
+      (else 0))
+; =&gt; 10  (assv returns (1 . 10); cdr of that is 10)</code></pre>
 <h4 id="case---switch-on-value">3.4.3 <code>case</code> - Switch on
 Value</h4>
 <p><strong>Syntax:</strong></p>
@@ -670,6 +678,14 @@ Value</h4>
   ((1) &quot;one&quot;)
   ((2) &quot;two&quot;)
   (else &quot;other&quot;))  ; =&gt; &quot;two&quot;</code></pre>
+<p><strong>R7RS <code>=&gt;</code> arrow clause</strong>, same semantics
+as <code>cond</code>’s: the matched key is passed to a unary receiver
+procedure:</p>
+<pre class="scheme"><code>(case 5
+  ((1 2 3) =&gt; (lambda (x) (* x 100)))
+  ((4 5 6) =&gt; (lambda (x) (* x 10)))
+  (else 0))
+; =&gt; 50</code></pre>
 <h4 id="match---pattern-matching">3.4.4 <code>match</code> - Pattern
 Matching</h4>
 <p><strong>Syntax:</strong></p>
@@ -750,6 +766,11 @@ and substitute - <code>,@expr</code> - Evaluate and splice into list</p>
 <pre class="scheme"><code>(define x 5)
 `(1 2 ,x 4)    ; =&gt; (1 2 5 4)
 `(1 ,@(list 2 3) 4)  ; =&gt; (1 2 3 4)</code></pre>
+<p><strong>Quasiquoted vector literals</strong> (v1.3.0-evolve):
+<code>unquote</code>/<code>unquote-splicing</code> also work inside a
+<code>#(...)</code> vector literal under quasiquote:</p>
+<pre class="scheme"><code>`#(1 ,(+ 1 1) 3)        ; =&gt; #(1 2 3)
+`#(1 ,@(list 2 3) 4)    ; =&gt; #(1 2 3 4)</code></pre>
 <h3 id="type-annotations">3.6 Type Annotations</h3>
 <h4 id="type-annotation-syntax">3.6.1 Type Annotation Syntax</h4>
 <pre class="scheme"><code>(: name type)  ; Standalone type declaration</code></pre>
@@ -845,6 +866,19 @@ Exception</h4>
 <pre class="scheme"><code>(raise exception-object)</code></pre>
 <p><strong>Example:</strong></p>
 <pre class="scheme"><code>(raise (error &quot;Something went wrong&quot;))</code></pre>
+<h4 id="error-and-the-r7rs-condition-object-family">3.8.3
+<code>error</code> and the R7RS Condition-Object Family</h4>
+<p><strong>Syntax:</strong></p>
+<pre class="scheme"><code>(error message irritant ...)     ; raise an R7RS error object
+(error-object? obj)               ; #t iff obj was raised via (error ...)
+(error-object-message e)          ; the message string
+(error-object-irritants e)        ; the irritants, as a list</code></pre>
+<p><strong>Example:</strong></p>
+<pre class="scheme"><code>(guard (e (#t (list (error-object-message e) (error-object-irritants e))))
+  (error &quot;boom&quot; 1 2))
+; =&gt; (&quot;boom&quot; (1 2))
+
+(guard (e (#t (error-object? e))) (raise &quot;plain-string&quot;))  ; =&gt; #f</code></pre>
 <h3 id="multiple-return-values">3.9 Multiple Return Values</h3>
 <h4 id="values---return-multiple-values">3.9.1 <code>values</code> -
 Return Multiple Values</h4>
@@ -892,6 +926,16 @@ repetition - Nested lists</p>
   (syntax-rules ()
     ((when test expr ...)
      (if test (begin expr ...)))))</code></pre>
+<p><strong>Nested ellipsis</strong> (v1.3.0-evolve): a pattern variable
+bound at ellipsis depth N is followed by N ellipses in the template to
+flatten one level per extra ellipsis. Pattern matching tracks ellipsis
+depth explicitly, so <code>(x ... ...)</code>-style templates over a
+list-of-lists now expand correctly:</p>
+<pre class="scheme"><code>(define-syntax my-flatten
+  (syntax-rules ()
+    ((_ (a ...) ...) (list a ... ...))))
+
+(my-flatten (1 2) (3 4 5))  ; =&gt; (1 2 3 4 5)</code></pre>
 <h3 id="external-ffi">3.11 External FFI</h3>
 <h4 id="extern---declare-external-function">3.11.1 <code>extern</code> -
 Declare External Function</h4>
@@ -1163,11 +1207,18 @@ Function to List</h4>
 </ul>
 <h4 id="string-access">4.7.2 String Access</h4>
 <ul>
-<li><code>(string-length str)</code> - Character count</li>
+<li><code>(string-length str)</code> - Codepoint (character) count</li>
+<li><code>(string-byte-length str)</code> - UTF-8 byte count
+(v1.3.0-evolve; differs from <code>string-length</code> for any
+multibyte-UTF-8 string)</li>
 <li><code>(string-ref str k)</code> - Get character at index k</li>
 <li><code>(string-set! str k char)</code> - Set character at index
 k</li>
-<li><code>(substring str start end)</code> - Extract substring</li>
+<li><code>(substring str start end)</code> - Extract substring
+<code>[start, end)</code></li>
+<li><code>(substring str start)</code> - Extract from <code>start</code>
+to the end of the string (2-argument form, equivalent to
+<code>(substring str start (string-length str))</code>)</li>
 </ul>
 <h4 id="string-predicates">4.7.3 String Predicates</h4>
 <ul>
@@ -1228,11 +1279,28 @@ fill value</li>
 <li><code>(vector-length vec)</code> - Element count</li>
 <li><code>(vector-ref vec k)</code> - Get element at index k</li>
 <li><code>(vector-set! vec k val)</code> - Set element at index k</li>
+<li><code>(vector-copy vec)</code> /
+<code>(vector-copy vec start)</code> /
+<code>(vector-copy vec start end)</code> - Fresh (shallow) copy of
+<code>vec</code>, or of the <code>[start,end)</code> slice. Also accepts
+a tensor-backed <code>#(...)</code> vector literal, not just
+<code>(vector ...)</code>-allocated vectors (v1.3.0-evolve).</li>
+<li><code>(vector-copy! to at from)</code> /
+<code>(vector-copy! to at from start end)</code> - In-place copy into
+<code>to</code> starting at index <code>at</code></li>
 </ul>
 <h4 id="vector-conversions">4.9.3 Vector Conversions</h4>
 <ul>
 <li><code>(vector-&gt;list vec)</code> - Convert to list</li>
 <li><code>(list-&gt;vector lst)</code> - Convert from list</li>
+</ul>
+<h4 id="vector-iteration">4.9.4 Vector Iteration</h4>
+<ul>
+<li><code>(vector-map proc vec1 vec2 ...)</code> - Apply
+<code>proc</code> element-wise across one or more vectors in lockstep
+(R7RS 6.9), stopping at the shortest vector</li>
+<li><code>(vector-for-each proc vec1 vec2 ...)</code> - Same iteration,
+for side effects</li>
 </ul>
 <h3 id="tensor-operations">4.10 Tensor Operations</h3>
 <h4 id="tensor-creation">4.10.1 Tensor Creation</h4>
@@ -2128,6 +2196,102 @@ recording</li>
       (vector 1.0)))
   (vector 2.0))
 ; Computes ∂/∂x[∂/∂y(xy²)]</code></pre>
+<h3 id="arbitrary-order-ad-taylor-towers-v1.3.0-evolve">8.5
+Arbitrary-Order AD: Taylor Towers (v1.3.0-evolve)</h3>
+<p>A second, orthogonal AD engine computes every derivative up to an
+arbitrary order <code>k</code> in a single pass. Full detail: the <a
+href="guide/AUTOMATIC_DIFFERENTIATION.md">Automatic Differentiation
+guide</a> and <code>docs/design/AD_TAYLOR_TOWER.md</code>.</p>
+<h4 id="taylor-derivative-n-core-tower-builtins">8.5.1
+<code>taylor</code> / <code>derivative-n</code> — Core Tower
+Builtins</h4>
+<p><strong>Syntax:</strong></p>
+<pre class="scheme"><code>(taylor function point k)          ; List of k+1 Taylor coefficients c[0..k]
+(derivative-n function point k)    ; Scalar: the k-th derivative f^(k)(point)</code></pre>
+<p>Coefficient <code>c[n] = f^(n)(point)/n!</code>. Stored on a new heap
+subtype (<code>HEAP_SUBTYPE_TAYLOR</code>). When <code>point</code> is
+exact (integer/rational) and <code>function</code> uses only
+exact-preserving arithmetic (<code>+ - * /</code>, non-negative integer
+<code>expt</code>), the coefficients are returned as exact
+bignum/rational values instead of <code>double</code> (automatic
+demotion to <code>double</code> on overflow or on the first
+transcendental call). When <code>k</code> is a compile-time literal, the
+tower may be compiled with zero heap allocation (compile-time-K
+monomorphization).</p>
+<p><strong>Example:</strong></p>
+<pre class="scheme"><code>(taylor (lambda (x) (exp x)) 0.5 4)
+; =&gt; (1.64872 1.64872 0.824361 0.274787 0.0686967)
+
+(derivative-n (lambda (y) (* y y y)) 3.0 1)  ; =&gt; 27  (f&#39;(x) = 3x^2 at x=3)</code></pre>
+<h4 id="core.ad.guw-arbitrary-order-multivariate-mixed-partials">8.5.2
+<code>core.ad.guw</code> — Arbitrary-Order Multivariate Mixed
+Partials</h4>
+<p><strong>Syntax:</strong></p>
+<pre class="scheme"><code>(require core.ad.guw)
+(taylor-propagate function point direction k)  ; Taylor coeffs of g(t) = f(point + t*direction)
+(mixed-partial function point multi-index)     ; scalar D^beta f(point)
+(gradient-n function point order)              ; order&gt;=3 symmetric derivative tensor</code></pre>
+<p><code>multi-index</code> is a list of variable indices with
+repetition, e.g. <code>(0 0 1)</code> denotes
+<code>d^3f/dx0^2 dx1</code>. Implemented via Griewank-Utke-Walther (GUW)
+directional propagation of univariate towers along principal-lattice
+direction vectors. <code>order</code> &lt;= 2 continues to use the
+existing <code>gradient</code>/<code>hessian</code> jet path.</p>
+<h4 id="core.ad.taylor_models-validated-ad">8.5.3
+<code>core.ad.taylor_models</code> — Validated AD</h4>
+<p><strong>Syntax:</strong></p>
+<pre class="scheme"><code>(require core.ad.taylor_models)
+(taylor-model function center radius k)  ; polynomial + interval remainder
+(tm-range tm)                            ; guaranteed range enclosure (lo . hi)
+(tm-eval tm x)                           ; guaranteed point enclosure (lo . hi)
+(tm-add tm1 tm2) (tm-mul tm1 tm2)        ; Makino-Berz Taylor-model arithmetic
+(tm-order tm) (tm-coeffs tm) (tm-center tm) (tm-radius tm) (tm-remainder tm) (tm-domain tm)</code></pre>
+<p>Pairs a Taylor polynomial with a rigorous interval-remainder bound so
+<code>tm-range</code>/<code>tm-eval</code> are provable enclosures, not
+point estimates.</p>
+<h4 id="core.ad.sparse_guw-sparse-high-order-tensors">8.5.4
+<code>core.ad.sparse_guw</code> — Sparse High-Order Tensors</h4>
+<p><strong>Syntax:</strong></p>
+<pre class="scheme"><code>(require core.ad.sparse_guw)
+(sparse-hessian function point)                        ; auto-probed sparsity structure
+(sparse-hessian-pat function point pattern)            ; explicit hyperedge pattern
+(sparse-hessian-ref sp i j) (sparse-hessian-nonzeros sp)
+(sparse-hessian-row-ptr sp) (sparse-hessian-col-idx sp) (sparse-hessian-values sp)
+(sparse-hessian-colors sp) (sparse-hessian-directions sp) (sparse-hessian-dense? sp)
+(sparse-mixed-partials function point order pattern)   ; order&gt;=3 sparse recovery
+(sparse-mixed-partials-ref sp multi-index) (sparse-mixed-partials-entries sp)</code></pre>
+<p>Recovers a sparse Hessian/mixed-partial tensor via greedy distance-2
+(star) graph coloring plus one reverse-over-Taylor Hessian-vector
+product per color, so cost scales with variable-interaction bandwidth
+rather than dimension. <code>sparse-mixed-partials</code> is
+order-&gt;=3 only.</p>
+<h4 id="core.ad.taylor_numerics-tower-based-user-numerics">8.5.5
+<code>core.ad.taylor_numerics</code> — Tower-Based User Numerics</h4>
+<p><strong>Syntax:</strong></p>
+<pre class="scheme"><code>(require core.ad.taylor_numerics)
+(taylor-eval coefficients dt)                    ; Horner-evaluate a taylor coefficient list at offset dt
+(taylor-ode-solve function y0 t0 t1 k n)         ; order-k, n-step fixed-step scalar IVP solver
+(taylor-root function x0 k)                      ; Householder root refinement (k=1 Newton, k=2 Halley)
+(taylor-inverse-series function x0 k)            ; Taylor series of f^-1 via Lagrange inversion</code></pre>
+<p>All arguments are positional (no keyword-arg formals).</p>
+<h4 id="core.ad.tensor_tower-and-core.ad.checkpoint">8.5.6
+<code>core.ad.tensor_tower</code> and
+<code>core.ad.checkpoint</code></h4>
+<p><code>core.ad.tensor_tower</code> generalizes a tower to a “tower of
+tensors” (one Cauchy-convolution series per tensor element, sharing a
+single shape), so high-order AD composes with
+<code>matmul</code>/<code>conv2d</code>/<code>sigmoid</code>/<code>tanh</code>
+unchanged. <code>core.ad.checkpoint</code> demonstrates checkpointed
+(Griewank/binomial sqrt(N)-schedule) high-order reverse-mode
+differentiation, holding at most one block’s tape live at a time instead
+of the whole chain.</p>
+<p>Differentiable control flow
+(<code>if</code>/<code>cond</code>/<code>case</code>/named-let/recursion/
+<code>map</code>/<code>fold</code> over Taylor-tower values) and
+reverse-over-Taylor (a <code>gradient</code> that differentiates through
+an inner <code>derivative-n</code>/<code>taylor</code> call) require no
+separate API — they are properties of the core tower engine and the
+reverse-mode tape described in 8.2.</p>
 <hr />
 <h2 id="module-system-1">9. Module System</h2>
 <h3 id="module-resolution">9.1 Module Resolution</h3>
@@ -3437,8 +3601,10 @@ through <code>tenth</code></p>
 <h3 id="all-string-functions-30">22.4 All String Functions (30+)</h3>
 <p><strong>Construction:</strong> <code>string</code>,
 <code>make-string</code>, <code>string-append</code>,
-<code>substring</code></p>
+<code>substring</code> (2-arg <code>(substring s start)</code> or 3-arg
+<code>(substring s start end)</code>)</p>
 <p><strong>Access:</strong> <code>string-length</code>,
+<code>string-byte-length</code> (UTF-8 byte count),
 <code>string-ref</code>, <code>string-set!</code></p>
 <p><strong>Comparison:</strong> <code>string=?</code>,
 <code>string&lt;?</code>, <code>string&gt;?</code>,
@@ -3462,7 +3628,10 @@ through <code>tenth</code></p>
 <code>linspace</code></p>
 <p><strong>Access:</strong> <code>vref</code>, <code>tensor-get</code>,
 <code>tensor-set</code>, <code>vector-ref</code>,
-<code>vector-set!</code>, <code>vector-length</code></p>
+<code>vector-set!</code>, <code>vector-length</code>,
+<code>vector-copy</code>, <code>vector-copy!</code>,
+<code>vector-map</code> (multi-vector), <code>vector-for-each</code>
+(multi-vector)</p>
 <p><strong>Arithmetic:</strong> <code>tensor-add</code>,
 <code>tensor-sub</code>, <code>tensor-mul</code>,
 <code>tensor-div</code>, <code>tensor-dot</code>,
@@ -3487,13 +3656,25 @@ through <code>tenth</code></p>
 <code>hash-table-exists?</code>, <code>hash-table-delete!</code>,
 <code>hash-table-keys</code>, <code>hash-table-values</code>,
 <code>hash-table-size</code>, <code>hash-table-clear!</code>.</p>
-<h3 id="all-autodiff-operators-8">22.7 All Autodiff Operators (8)</h3>
+<h3 id="all-autodiff-operators">22.7 All Autodiff Operators</h3>
 <p><strong>Univariate:</strong> <code>derivative</code></p>
 <p><strong>Multivariate:</strong> <code>gradient</code>,
 <code>jacobian</code>, <code>hessian</code></p>
 <p><strong>Vector Calculus:</strong> <code>divergence</code>,
 <code>curl</code>, <code>laplacian</code>,
 <code>directional-derivative</code></p>
+<p><strong>Arbitrary-Order Taylor Towers (v1.3.0-evolve, see
+8.5):</strong> <code>taylor</code>, <code>derivative-n</code> (core, no
+<code>require</code> needed); <code>taylor-propagate</code>,
+<code>mixed-partial</code>, <code>gradient-n</code>
+(<code>core.ad.guw</code>); <code>taylor-model</code>,
+<code>tm-range</code>, <code>tm-eval</code>, <code>tm-add</code>,
+<code>tm-mul</code> and accessors (<code>core.ad.taylor_models</code>);
+<code>sparse-hessian</code>, <code>sparse-hessian-pat</code>,
+<code>sparse-mixed-partials</code> and accessors
+(<code>core.ad.sparse_guw</code>); <code>taylor-ode-solve</code>,
+<code>taylor-root</code>, <code>taylor-inverse-series</code>
+(<code>core.ad.taylor_numerics</code>)</p>
 <h3 id="all-type-predicates-20">22.8 All Type Predicates (20+)</h3>
 <p><code>null?</code>, <code>boolean?</code>, <code>char?</code>,
 <code>string?</code>, <code>symbol?</code>, <code>number?</code>,
@@ -3501,7 +3682,8 @@ through <code>tenth</code></p>
 <code>pair?</code>, <code>list?</code>, <code>vector?</code>,
 <code>procedure?</code>, <code>hash-table?</code>, <code>tensor?</code>,
 <code>input-port?</code>, <code>output-port?</code>, <code>port?</code>,
-<code>eof-object?</code></p>
+<code>eof-object?</code>, <code>error-object?</code> (R7RS
+condition-object predicate, see 3.8.3)</p>
 <h3 id="all-equalitycomparison-3">22.9 All Equality/Comparison (3)</h3>
 <p><code>eq?</code>, <code>eqv?</code>, <code>equal?</code></p>
 <h3 id="all-io-functions-20">22.10 All I/O Functions (20+)</h3>
@@ -3638,8 +3820,24 @@ Automatic handler cleanup</p>
 <code>provide</code>)</p>
 <hr />
 <h2 id="version-information">26. Version Information</h2>
-<p><strong>Current Version:</strong> v1.3.0-evolve</p>
-<p><strong>Version History:</strong> - v1.2.0-scale - Production
+<p><strong>Current Version:</strong> v1.3.1</p>
+<p><strong>Version History:</strong> - v1.3.1 - Robustness for
+long-running, resident programs: per-iteration arena reclamation for
+define-loops guarded by a catch-all handler, an iterative reader so
+large persisted structures load without native stack overflow, and
+comprehensive C-API documentation. See <a
+href="../CHANGELOG.md">CHANGELOG.md</a>. - v1.3.0-evolve -
+Arbitrary-order automatic differentiation (Taylor towers, phases P0-P12:
+exact bignum/rational coefficients, no-heap monomorphization, GUW
+multivariate mixed partials, reverse-over-Taylor, tensor towers,
+validated Taylor models, sparse high-order tensors, differentiable
+control flow, checkpointed reverse-mode, tower-based numerics), full
+R7RS conformance on the portable differential corpus (34/34
+vs. chibi-scheme), closure/TCO/memory robustness hardening (mutual tail
+calls, named-let TCO in every position, 16-&gt;64 capture ceiling,
+bounded-RSS long-running loops), and a permanent multi-pillar
+adversarial-testing infrastructure. See <a
+href="../CHANGELOG.md">CHANGELOG.md</a>. - v1.2.0-scale - Production
 readiness: model serialization, stable C ABI + Python bindings,
 per-thread arenas, 512 MB main-thread stack on Darwin, image I/O,
 plotting stdlib, actionable error messages with file:line:col + caret,
@@ -3742,7 +3940,7 @@ exit.</p>
 <hr />
 <h2 id="conclusion">Conclusion</h2>
 <p>This document provides a <strong>complete</strong> specification of
-the Eshkol programming language version v1.3.0-evolve, documenting
+the Eshkol programming language version v1.3.1, documenting
 <strong>every</strong> feature, function, operator, and capability found
 in the implementation.</p>
 <p><strong>Total Coverage:</strong> - All 101 special forms and parser

--- a/site/static/content/contributing.html
+++ b/site/static/content/contributing.html
@@ -34,13 +34,13 @@ Tools)</a></li>
 </ul></li>
 <li><a href="#project-structure">Project Structure</a></li>
 <li><a href="#communication">Communication</a></li>
-<li><a href="#priority-areas-for-contribution-v13">Priority Areas for
-Contribution (v1.3+)</a>
+<li><a href="#priority-areas-for-contribution-v14">Priority Areas for
+Contribution (v1.4+)</a>
 <ul>
-<li><a href="#immediate-priorities-v13-evolve---june-2026">Immediate
-Priorities (v1.3-evolve - June 2026)</a></li>
-<li><a href="#near-term-v15-intelligence---q3-2026">Near-Term
-(v1.5-intelligence - Q3 2026)</a></li>
+<li><a href="#immediate-priorities-v14-connection---july-2026">Immediate
+Priorities (v1.4-connection - July 2026)</a></li>
+<li><a href="#near-term-v15-intelligence---august-2026">Near-Term
+(v1.5-intelligence - August 2026)</a></li>
 <li><a href="#ongoing">Ongoing</a></li>
 </ul></li>
 <li><a href="#recognition">Recognition</a></li>
@@ -292,41 +292,40 @@ and community discussions.</li>
 <li><strong>Pull Requests</strong>: For code contributions and code
 reviews.</li>
 </ul>
-<h2 id="priority-areas-for-contribution-v1.3">Priority Areas for
-Contribution (v1.3+)</h2>
-<p>v1.0-foundation, v1.1-accelerate, and v1.2.0-scale are
-<strong>complete</strong>. We welcome contributions for upcoming
-releases:</p>
-<h3 id="immediate-priorities-v1.3-evolve---june-2026">Immediate
-Priorities (v1.3-evolve - June 2026)</h3>
+<h2 id="priority-areas-for-contribution-v1.4">Priority Areas for
+Contribution (v1.4+)</h2>
+<p>v1.0-foundation, v1.1-accelerate, v1.2-scale, and v1.3.0-evolve
+(arbitrary-order AD, full R7RS conformance, closure/TCO/memory
+hardening) are <strong>complete</strong>, and v1.3.1 has landed further
+robustness for long-running, resident programs plus comprehensive C-API
+documentation. We welcome contributions for upcoming releases:</p>
+<h3 id="immediate-priorities-v1.4-connection---july-2026">Immediate
+Priorities (v1.4-connection - July 2026)</h3>
 <ol type="1">
-<li><strong>R7RS Library System</strong>: <code>define-library</code> /
-<code>import</code> with renaming, prefixing, <code>only</code>,
-<code>except</code></li>
-<li><strong>String Interpolation</strong>: <code>~{expr}</code> syntax
-in strings</li>
-<li><strong>Named Keyword Arguments</strong>:
-<code>(f #:key value)</code> call syntax</li>
-<li><strong>Destructuring Let</strong>:
-<code>(let-match ((cons a b) lst) ...)</code></li>
-<li><strong>Profile-Guided &amp; Whole-Program Optimization</strong>:
-PGO + LTO wired through the build</li>
+<li><strong>TCP/UDP Sockets</strong>: Linear resource types with
+guaranteed close</li>
+<li><strong>TLS/SSL</strong>: Via system libraries</li>
+<li><strong>Non-Blocking I/O</strong>: Event loop (epoll/kqueue)</li>
+<li><strong>HTTP Client</strong>: Built on sockets + TLS</li>
+<li><strong>Linear Types for Handles</strong>:
+<code>open -&gt; borrowed -&gt; closed</code> with compile-time
+tracking</li>
 <li><strong>Debugger</strong>: REPL step-through with breakpoints +
 variable inspection</li>
 <li><strong>Documentation Generator</strong>: <code>eshkol-doc</code>
 from docstrings</li>
 </ol>
-<h3 id="near-term-v1.5-intelligence---q3-2026">Near-Term
-(v1.5-intelligence - Q3 2026)</h3>
+<h3 id="near-term-v1.5-intelligence---august-2026">Near-Term
+(v1.5-intelligence - August 2026)</h3>
 <ol type="1">
 <li><strong>Neural-Symbolic Search</strong>: Differentiable logic
 programs (building on v1.1 consciousness engine)</li>
+<li><strong>Symbol Embeddings &amp; Soft Unification</strong>:
+Differentiable similarity over the knowledge base</li>
+<li><strong>LSTM/GRU Cells</strong>: Standard recurrent neural
+architectures</li>
 <li><strong>Multi-GPU Support</strong>: Distribute work across multiple
 GPUs</li>
-<li><strong>Profile-Guided Optimization</strong>: Runtime profile-based
-optimization</li>
-<li><strong>Full R7RS Library System</strong>:
-<code>define-library</code> / <code>import</code> with renaming</li>
 </ol>
 <h3 id="ongoing">Ongoing</h3>
 <ol type="1">

--- a/site/static/content/eshkol_language_guide.html
+++ b/site/static/content/eshkol_language_guide.html
@@ -356,14 +356,21 @@ logic programming, active inference, and web platform APIs.</p>
 <code>assoc</code>, + 30 compound accessors (<code>caar</code>,
 <code>cadr</code>, <code>caddr</code>, …)</p>
 <p><strong>Strings:</strong> <code>string-append</code>,
-<code>substring</code>, <code>string-length</code>,
+<code>substring</code> (2-arg <code>(substring s start)</code> or 3-arg
+<code>(substring s start end)</code>), <code>string-length</code>,
+<code>string-byte-length</code> (UTF-8 byte count,
+vs. <code>string-length</code>’s codepoint count),
 <code>string-&gt;list</code>, <code>number-&gt;string</code>,
 <code>string-&gt;number</code>, <code>string-for-each</code>,
 <code>string-map</code>, <code>string-fill!</code></p>
 <p><strong>Vectors:</strong> <code>vector</code>,
 <code>make-vector</code>, <code>vector-ref</code>,
 <code>vector-set!</code>, <code>vector-length</code>,
-<code>vector-for-each</code>, <code>vector-map</code></p>
+<code>vector-for-each</code>, <code>vector-map</code> (multi-vector:
+<code>(vector-map f v1 v2 ...)</code>), <code>vector-copy</code>
+(<code>(vector-copy v)</code>/<code>(vector-copy v start)</code>/<code>(vector-copy v start end)</code>,
+also accepts <code>#(...)</code> tensor literals),
+<code>vector-copy!</code></p>
 <p><strong>I/O:</strong> <code>display</code>, <code>newline</code>,
 <code>printf</code>, <code>open-input-file</code>,
 <code>open-output-file</code>, <code>read-line</code>,
@@ -464,6 +471,49 @@ functions:</p>
 
 ;; Directional derivative: D_u f
 (directional-derivative f (vector 3.0 4.0) (vector 1.0 0.0))  ;; -&gt; 6.0</code></pre>
+<h3 id="arbitrary-order-ad-taylor-towers-v1.3.0-evolve">Arbitrary-Order
+AD: Taylor Towers (v1.3.0-evolve)</h3>
+<p>Everything above differentiates once (or, with nesting, a small fixed
+number of times). The Taylor-tower engine computes
+<strong>every</strong> derivative up to an arbitrary order
+<code>k</code> in a single pass, exactly where the arithmetic allows it.
+See the <a href="guide/AUTOMATIC_DIFFERENTIATION.md">Automatic
+Differentiation guide</a> for the full walkthrough of all 13 phases
+(P0-P12: no-heap monomorphization, multivariate mixed partials,
+reverse-over-Taylor, exact bignum/rational coefficients, tensor towers,
+validated Taylor models, sparse tensors, differentiable control flow,
+checkpointed reverse-mode, and tower-based numerics).</p>
+<pre class="scheme"><code>;; The k-th derivative of f at x, for any order k -- no require needed
+(derivative-n (lambda (y) (* y y y)) 3.0 1)   ;; -&gt; 27 (f&#39;(x) = 3x^2 at x=3)
+
+;; All K+1 Taylor coefficients c[0..K] where c[n] = f^(n)(x)/n!
+(taylor (lambda (x) (exp x)) 0.5 4)
+;; -&gt; (1.64872 1.64872 0.824361 0.274787 0.0686967)</code></pre>
+<p>Coefficients come back <strong>exact</strong> (arbitrary-precision
+integer/rational, not <code>double</code>) when <code>x</code> is exact
+and <code>f</code> only uses exact-preserving arithmetic
+(<code>+ - * /</code>, non-negative-integer <code>expt</code>) – most
+autodiff systems only ever produce floating-point derivatives.</p>
+<p>Beyond order and exactness, <code>core.ad.guw</code> recovers
+arbitrary-order mixed partial derivatives of a multivariate
+function:</p>
+<pre class="scheme"><code>(require core.ad.guw)
+(define (f xs) (* (vref xs 0) (* (vref xs 1) (vref xs 1))))  ;; f(x,y) = x*y^2
+
+;; d^3f/dx dy^2 at (2.0, 3.0) -- idxs is a multi-index with repetition
+(mixed-partial f (vector 2.0 3.0) (list 0 1 1))  ;; -&gt; 2.0
+
+;; The full order-&gt;=3 symmetric derivative tensor, as (multi-index . value) pairs
+(gradient-n f (vector 2.0 3.0) 3)</code></pre>
+<p>And <code>core.ad.taylor_models</code> gives
+<strong>validated</strong> AD – a Taylor polynomial paired with a
+rigorous interval-remainder bound, so
+<code>tm-range</code>/<code>tm-eval</code> return a provable enclosure
+rather than a point estimate:</p>
+<pre class="scheme"><code>(require core.ad.taylor_models)
+(define tm (taylor-model (lambda (x) (sin x)) 0.0 0.1 4))
+(tm-range tm)      ;; -&gt; a (lo . hi) pair guaranteed to contain sin over [-0.1, 0.1]
+(tm-eval tm 0.05)  ;; -&gt; a (lo . hi) pair guaranteed to contain sin(0.05)</code></pre>
 <hr />
 <h2 id="tensor-matrix-operations">Tensor &amp; Matrix Operations</h2>
 <h3 id="creation">Creation</h3>
@@ -654,7 +704,16 @@ Handling</h3>
 
 ;; Raise errors
 (raise &quot;division by zero&quot;)
-(raise (list &#39;error &#39;file-not-found &quot;/tmp/missing.txt&quot;))</code></pre>
+(raise (list &#39;error &#39;file-not-found &quot;/tmp/missing.txt&quot;))
+
+;; R7RS error objects: (error message irritant ...) plus the condition
+;; accessors error-object?/error-object-message/error-object-irritants
+(guard (e (#t (list (error-object-message e) (error-object-irritants e))))
+  (error &quot;boom&quot; 1 2))
+;; -&gt; (&quot;boom&quot; (1 2))
+
+(guard (e (#t (error-object? e))) (error &quot;x&quot;))    ;; -&gt; #t
+(guard (e (#t (error-object? e))) (raise &quot;plain&quot;)) ;; -&gt; #f: a raised non-error value</code></pre>
 <hr />
 <h2 id="parallel-primitives">Parallel Primitives</h2>
 <p>Eshkol v1.1 provides built-in parallel execution primitives that
@@ -925,7 +984,11 @@ eshkol-run program.esk --wasm -o program.wasm
 
 ;; Fold: reduce to single value
 (fold + 0 (list 1 2 3 4 5))    ;; -&gt; 15
-(fold * 1 (list 1 2 3 4 5))    ;; -&gt; 120</code></pre>
+(fold * 1 (list 1 2 3 4 5))    ;; -&gt; 120
+
+;; Apply: call a function on an argument list, with optional leading args
+(apply + &#39;(1 2 3))             ;; -&gt; 6
+(apply + 1 2 &#39;(3 4 5))         ;; -&gt; 15 (leading args are consed onto the list)</code></pre>
 <h3 id="closures">Closures</h3>
 <pre class="scheme"><code>;; Factory pattern
 (define (make-adder n)
@@ -972,6 +1035,34 @@ eshkol-run program.esk --wasm -o program.wasm
 ;; Partial application
 (define add5 (partial2 + 5))
 (add5 10)              ;; -&gt; 15</code></pre>
+<hr />
+<h2 id="macros-and-quoting">Macros and Quoting</h2>
+<h3 id="quote-and-quasiquote">Quote and Quasiquote</h3>
+<pre class="scheme"><code>&#39;(1 2 3)                   ;; quote: data, not evaluated -&gt; (1 2 3)
+(quote (1 2 3))             ;; long form, same thing
+
+`(1 ,(+ 1 1) 3)              ;; quasiquote + unquote -&gt; (1 2 3)
+`(1 ,@(list 2 3) 4)          ;; unquote-splicing -&gt; (1 2 3 4)
+
+;; Quasiquoted vector literals work the same way
+`#(1 ,(+ 1 1) 3)              ;; -&gt; #(1 2 3)
+`#(1 ,@(list 2 3) 4)          ;; -&gt; #(1 2 3 4)</code></pre>
+<h3 id="hygienic-macros-syntax-rules">Hygienic Macros
+(<code>syntax-rules</code>)</h3>
+<pre class="scheme"><code>;; A simple macro
+(define-syntax my-when
+  (syntax-rules ()
+    ((_ test body ...) (if test (begin body ...) #f))))
+
+(my-when (&gt; 3 2) (display &quot;yes&quot;) (newline))  ;; -&gt; prints &quot;yes&quot;
+
+;; Ellipsis patterns can nest: a pattern variable bound at ellipsis depth N
+;; is followed by N ellipses in the template to flatten one level per ellipsis
+(define-syntax my-flatten
+  (syntax-rules ()
+    ((_ (a ...) ...) (list a ... ...))))
+
+(my-flatten (1 2) (3 4 5))    ;; -&gt; (1 2 3 4 5)</code></pre>
 <hr />
 <h2 id="memory-model">Memory Model</h2>
 <h3 id="arena-allocation-no-garbage-collection">Arena Allocation (No
@@ -1055,7 +1146,7 @@ detection</li>
 :history   Show command history</code></pre>
 <h3 id="example-session">Example Session</h3>
 <pre><code>$ ./eshkol-repl
-Eshkol REPL v1.3.0-evolve
+Eshkol REPL v1.3.1
 Type :help for assistance, :quit to exit
 
 eshkol&gt; (define (square x) (* x x))
@@ -1605,6 +1696,6 @@ integration</label></li>
 <p>MIT License - Copyright (C) tsotchke</p>
 <hr />
 <p align="center">
-<strong>Eshkol v1.3.0-evolve</strong>: Where functional programming
-meets scientific computing, GPU acceleration, and machine consciousness.
+<strong>Eshkol v1.3.1</strong>: Where functional programming meets
+scientific computing, GPU acceleration, and machine consciousness.
 </p>

--- a/site/static/content/eshkol_quick_reference.html
+++ b/site/static/content/eshkol_quick_reference.html
@@ -1,5 +1,5 @@
 <h1 id="eshkol-quick-reference-card">Eshkol Quick Reference Card</h1>
-<p><strong>v1.3.0-evolve</strong> – 555+ built-in functions</p>
+<p><strong>v1.3.1</strong> – 555+ built-in functions</p>
 <h2 id="basics">Basics</h2>
 <pre class="scheme"><code>;; Variables
 (define x 42)
@@ -48,6 +48,17 @@
   ((1 2 3) =&gt; (lambda (x) (* x 100)))
   ((4 5 6) =&gt; (lambda (x) (* x 10)))          ;; -&gt; 50
   (else 0))</code></pre>
+<h2 id="quoting-macros">Quoting &amp; Macros</h2>
+<pre class="scheme"><code>&#39;(1 2 3)                          ;; quote -&gt; (1 2 3)
+`(1 ,(+ 1 1) 3)                   ;; quasiquote + unquote -&gt; (1 2 3)
+`(1 ,@(list 2 3) 4)               ;; unquote-splicing -&gt; (1 2 3 4)
+`#(1 ,@(list 2 3) 4)              ;; quasiquoted vector literal -&gt; #(1 2 3 4)
+
+;; Hygienic macros via syntax-rules, including nested ellipsis
+(define-syntax my-flatten
+  (syntax-rules ()
+    ((_ (a ...) ...) (list a ... ...))))
+(my-flatten (1 2) (3 4 5))        ;; -&gt; (1 2 3 4 5)</code></pre>
 <h2 id="lists">Lists</h2>
 <pre class="scheme"><code>(list 1 2 3)              ;; create list
 (cons 1 (list 2 3))       ;; prepend
@@ -147,6 +158,34 @@
 (curl F v)                ;; curl(F) at v (3D)
 (laplacian f v)           ;; laplacian(f) at v
 (directional-derivative f v dir)</code></pre>
+<h3 id="arbitrary-order-ad-taylor-towers-v1.3.0-evolve">Arbitrary-Order
+AD (Taylor Towers, v1.3.0-evolve)</h3>
+<p>See the <a href="guide/AUTOMATIC_DIFFERENTIATION.md">Automatic
+Differentiation guide</a> for the full walkthrough.</p>
+<pre class="scheme"><code>;; Core tower builtins (no require needed)
+(taylor f x k)                    ;; k+1 Taylor coefficients c[0..k] of f at x
+(derivative-n f x k)              ;; the k-th derivative f^(k)(x), any order
+                                   ;; exact (bignum/rational) when x is exact
+                                   ;; and f uses only +,-,*,/,non-negative expt
+
+(require core.ad.guw)
+(mixed-partial f xs idxs)         ;; e.g. (mixed-partial f xs &#39;(0 1 1)) = d^3f/dx0dx1^2
+(gradient-n f xs order)           ;; full order-&gt;=3 symmetric derivative tensor
+(taylor-propagate f xs v k)       ;; Taylor coefficients of g(t) = f(xs + t*v)
+
+(require core.ad.taylor_models)
+(taylor-model f x0 r k)           ;; validated AD: polynomial + interval remainder
+(tm-range tm)                     ;; guaranteed range enclosure, a (lo . hi) pair
+(tm-eval tm x)                    ;; guaranteed point enclosure at x
+
+(require core.ad.sparse_guw)
+(sparse-hessian f xs)             ;; sparse Hessian via colored reverse-over-Taylor
+(sparse-hessian-nonzeros sp)      ;; nonzero (i j) index pairs
+
+(require core.ad.taylor_numerics)
+(taylor-ode-solve f y0 t0 t1 k n) ;; order-k fixed-step scalar IVP solver
+(taylor-root f x0 k)              ;; Householder root refinement (k=1 Newton, k=2 Halley)
+(taylor-inverse-series f x0 k)    ;; Taylor series of f^-1 via Lagrange inversion</code></pre>
 <h2 id="exact-arithmetic">Exact Arithmetic</h2>
 <pre class="scheme"><code>;; Bignums (automatic promotion beyond 64-bit)
 (expt 2 256)              ;; arbitrary precision integer
@@ -220,6 +259,12 @@ Handling</h2>
 
 ;; Raise exceptions
 (raise value)               ;; raise any value as exception
+(error &quot;boom&quot; 1 2)          ;; raise an R7RS error-object with irritants 1 2
+
+;; R7RS condition-object accessors (bound inside guard)
+(guard (e (#t (list (error-object-message e) (error-object-irritants e))))
+  (error &quot;boom&quot; 1 2))       ;; -&gt; (&quot;boom&quot; (1 2))
+(error-object? e)           ;; -&gt; #t for an (error ...)-raised condition
 
 ;; Multiple values
 (values 1 2 3)              ;; return multiple values

--- a/site/static/content/feature_matrix.html
+++ b/site/static/content/feature_matrix.html
@@ -1,5 +1,4 @@
-<h1 id="eshkol-v1.3.0-evolve-feature-matrix">Eshkol v1.3.0-evolve
-Feature Matrix</h1>
+<h1 id="eshkol-v1.3.1-feature-matrix">Eshkol v1.3.1 Feature Matrix</h1>
 <p><strong>Status Key</strong>: ✅ Production | 🚧 In Progress | 📋
 Planned | ❌ Not Planned</p>
 <p>This matrix documents all implemented and planned features for the
@@ -3589,6 +3588,12 @@ Languages</h2>
 </table>
 <hr />
 <h2 id="roadmap">Roadmap</h2>
+<blockquote>
+<p>This section is a historical snapshot and may lag; see the canonical,
+continuously-updated <a href="../ROADMAP.md">ROADMAP.md</a> for current
+status. As of v1.3.1, v1.1-accelerate, v1.2-scale, and v1.3.0-evolve
+have all shipped.</p>
+</blockquote>
 <h3 id="v1.1-accelerate-q1-2026-completed">v1.1-accelerate (Q1 2026) —
 COMPLETED</h3>
 <ul>
@@ -3608,7 +3613,7 @@ stdlib</li>
 <li>✅ <strong>R7RS Extensions</strong>: call/cc, dynamic-wind,
 bytevectors, let-syntax</li>
 </ul>
-<h3 id="v1.2-scale-q2-2026">v1.2-scale (Q2 2026)</h3>
+<h3 id="v1.2-scale-q2-2026-shipped">v1.2-scale (Q2 2026) — SHIPPED</h3>
 <ul>
 <li><strong>Data I/O</strong>: Image/audio I/O, typed buffers, streams,
 DataFrame, plotting</li>
@@ -3620,7 +3625,8 @@ quantization</li>
 versa</li>
 <li><strong>Distributed Training</strong>: AllReduce, MPI, gRPC</li>
 </ul>
-<h3 id="v1.3-evolve-q3-2026">v1.3-evolve (Q3 2026)</h3>
+<h3 id="v1.3-evolve-q3-2026-shipped-as-v1.3.0-evolve">v1.3-evolve (Q3
+2026) — SHIPPED as v1.3.0-evolve</h3>
 <ul>
 <li><strong>Language Extensions</strong>: Full R7RS library system,
 string interpolation, keyword arguments</li>
@@ -3987,7 +3993,7 @@ infrastructure) - Scheme community (language design inspiration) -
 JAX/PyTorch (AD implementation insights) - Julia (technical computing
 design patterns)</p>
 <hr />
-<p><strong>Last Updated</strong>: 2026-05-20 <strong>Document
-Version</strong>: 1.3.0-evolve</p>
+<p><strong>Last Updated</strong>: 2026-07-08 <strong>Document
+Version</strong>: 1.3.1</p>
 <p>For detailed API documentation, see <a
 href="API_REFERENCE.md">API_REFERENCE.md</a></p>

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Eshkol — R7RS Scheme on LLVM 21 with AD as a compiler primitive</title>
-  <meta name="description" content="Eshkol is R7RS Scheme compiled to native code via LLVM 21, with automatic differentiation as a compiler primitive and a 22-builtin neuro-symbolic stack. v1.3.0-evolve ships the Self-Differentiating Neural Computer constructive proof: a six-layer transformer that is bit-identical to a bounded 83-instruction bytecode VM.">
+  <meta name="description" content="Eshkol is R7RS Scheme compiled to native code via LLVM 21, with automatic differentiation as a compiler primitive and a 22-builtin neuro-symbolic stack. v1.3.1 carries the Self-Differentiating Neural Computer constructive proof forward with hardening for long-running, resident programs.">
   <meta property="og:title" content="Eshkol — R7RS Scheme with AD as a compiler primitive">
-  <meta property="og:description" content="Compiler-native automatic differentiation, zero garbage collection, heterogeneous GPU dispatch, and the SDNC constructive proof. v1.3.0-evolve.">
+  <meta property="og:description" content="Compiler-native automatic differentiation, zero garbage collection, heterogeneous GPU dispatch, and the SDNC constructive proof. v1.3.1.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://eshkol.ai">
   <meta property="og:image" content="https://eshkol.ai/img/og-image.png">
@@ -15,7 +15,7 @@
   <meta property="og:image:alt" content="Eshkol logo — a stylized grape cluster">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Eshkol — R7RS Scheme with AD as a compiler primitive">
-  <meta name="twitter:description" content="Compiler-native automatic differentiation, zero garbage collection, heterogeneous GPU dispatch, and the SDNC constructive proof. v1.3.0-evolve.">
+  <meta name="twitter:description" content="Compiler-native automatic differentiation, zero garbage collection, heterogeneous GPU dispatch, and the SDNC constructive proof. v1.3.1.">
   <meta name="twitter:image" content="https://eshkol.ai/img/og-image.png">
   <meta name="theme-color" content="#7c3aed">
   <link rel="icon" href="img/favicon.ico" sizes="any">


### PR DESCRIPTION
## Summary
- Bumped version references from v1.3.0-evolve to v1.3.1 across the site: hero subtitle, "What's new" section, Playground REPL welcome banner, and `<meta>` description/og/twitter tags in `site/static/index.html`.
- Rewrote the "What's new" narrative (`site/src/main.esk`) to describe v1.3.1's actual additions on top of the v1.3.0-evolve AD matrix: per-iteration arena reclamation for guarded define-loops, an iterative reader so large persisted structures load without native stack overflow, and comprehensive C-API documentation.
- Updated the version metadata (title/`Version:`/`Last Updated`) in the doc sources that feed the generated content fragments: `docs/API_REFERENCE.md`, `docs/FEATURE_MATRIX.md`, `docs/COMPLETE_LANGUAGE_SPECIFICATION.md` (also added a v1.3.1 entry to its Version History), `docs/ESHKOL_QUICK_REFERENCE.md`, `docs/ESHKOL_LANGUAGE_GUIDE.md`. Historical "introduced in v1.3.0-evolve" feature annotations were left untouched since they're accurate.
- Fixed two stale-status contradictions with the canonical ROADMAP.md that were being served on the site's docs pages: `docs/FEATURE_MATRIX.md`'s embedded roadmap subsection still listed v1.2-scale and v1.3-evolve as future/unshipped (they're both SHIPPED per ROADMAP.md); `CONTRIBUTING.md`'s "Priority Areas" still asked for contributions on R7RS libraries/string interpolation/keyword args, all of which shipped in v1.3.0-evolve — both now point at the current v1.4-connection priorities.
- Regenerated `site/static/content/*.html` via `bash scripts/build-site-content.sh` (pandoc was available in-environment), so the served fragments match their markdown sources. This also picked up several doc sections that had drifted out of sync with the previously-committed HTML before this change (R7RS `cond`/`case` `=>` arrow clauses, error-object accessors, nested-ellipsis macros, `vector-copy`/`vector-map`) — those come from prior doc commits, not new content added here.
- No changes to the WASM REPL glue (`eshkol-runtime.js`, `eshkol-vm.js`, `eshkol-site.wasm`, `eshkol-vm.wasm`).

## Test plan
- [x] `bash scripts/build-site-content.sh` ran clean (pandoc found), regenerated fragments committed alongside their markdown sources.
- [x] `git diff` reviewed — no emoji introduced, no touches to `eshkol-runtime.js`/`eshkol-vm.js`/WASM binaries.
- [ ] CI (pages workflow / any site build/deploy lane) to confirm the site still builds and deploys from this branch.