### PR TITLE
release: v1.3.1

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -260,6 +260,14 @@ oracles:
 
       - runtime_event:
           event_kinds: [eshkol_smoke]
+          event_names: ["define_loop_flat_rss_aot"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'ESH-0214b v1.3.1: AOT guard-wrapped define loop stays under the 200MB flat-RSS ceiling'
+        action: ./scripts/run_icc_smoke.sh
+
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
           event_names: ["define_library_import_works"]
           event_values: ["PASS"]
         severity: high

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No changes yet since [1.3.0-evolve].
+No changes yet since [1.3.1-evolve].
+
+## [1.3.1-evolve] - 2026-07-09
+
+A resident-robustness point release over v1.3.0-evolve: two fixes that
+matter specifically for long-running/daemon and large-persisted-state
+workloads, plus a comprehensive documentation pass.
+
+### Fixed
+
+- **Iterative `read_list`** (#191): the reader's list-parsing path was
+  rewritten from per-element native recursion to an iterative loop, so
+  reading long flat lists — e.g. a 46K-entry persisted-state file — no
+  longer overflows the native stack. Verified: the pre-fix reader SIGBUS'd
+  at 20M elements; post-fix, the same input reads cleanly.
+- **ESH-0214b per-iteration arena scope for `define` loops + catch-all
+  guard** (#192): automatic per-iteration arena-scope reclamation, previously
+  named-let-only, now also applies to self-tail-recursive top-level `define`
+  loops, and the escape analysis that gates it no longer rejects a guard body
+  outright — it accepts a catch-all guard clause (`#t`/`else`) whose body is
+  itself escape-free. This enables flat-memory resident/daemon workloads
+  built on the `define`-loop-plus-guard idiom. Verified in AOT mode: a
+  1,000,000-iteration allocating guard-wrapped `define` loop holds peak RSS
+  at 27MB with the fix on, versus 2608MB with the fix off.
+
+### Documentation
+
+- Added Doxygen doc-comments across all 64 public headers (`inc/eshkol/**`)
+  and most implementation files (`lib/**`).
+- Added a navigable documentation index (`docs/README.md`); reduced orphaned
+  (unindexed) docs from 73 to 3.
+- Updated press materials and website content to reflect the shipped v1.3
+  state.
+- Aligned roadmap views with what has actually shipped.
 
 ## [1.3.0-evolve] - 2026-07-07
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if(POLICY CMP0091)
     cmake_policy(SET CMP0091 NEW)
 endif()
 
-set(ESHKOL_VERSION "1.3.0")
+set(ESHKOL_VERSION "1.3.1")
 
 project("Eshkol" VERSION ${ESHKOL_VERSION} LANGUAGES C CXX)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Eshkol is a Scheme-based programming language that unifies functional programming with native automatic differentiation, providing a mathematically rigorous foundation for gradient-based optimization, numerical simulation, and machine learning research. Built on Homotopy Type Theory foundations and compiled to native code via LLVM, Eshkol delivers mathematical correctness and deterministic performance without sacrificing the elegance of homoiconic Lisp syntax.
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![Version](https://img.shields.io/badge/version-v1.3.0--evolve-green.svg)](RELEASE_NOTES.md) [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](CMakeLists.txt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![Version](https://img.shields.io/badge/version-v1.3.1--evolve-green.svg)](RELEASE_NOTES.md) [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](CMakeLists.txt)
 
 📣 **v1.3.0-evolve released** — see [ANNOUNCEMENT.md](ANNOUNCEMENT.md) for the full release story.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,12 +1,66 @@
-# Eshkol v1.3.0-evolve — Release Notes
+# Eshkol v1.3.1-evolve — Release Notes
+
+**Release Date**: July 9, 2026
+
+Eshkol v1.3.1-evolve is a resident-robustness point release over
+v1.3.0-evolve: two fixes aimed squarely at long-running/daemon processes and
+large-persisted-state workloads, plus a comprehensive documentation pass.
+Full technical detail lives in [CHANGELOG.md](CHANGELOG.md); this page is the
+user-facing summary.
+
+**Release gates**: builds on the v1.3.0-evolve release gates (see below) with
+a new AOT flat-RSS regression gate
+(`tests/memory/define_loop_flat_rss_aot_test.sh`) that compiles the
+guard-wrapped self-tail-recursive `define`-loop shape ahead-of-time and fails
+if peak RSS exceeds a generous flat threshold, so the ESH-0214b fix cannot
+silently regress.
+
+## Highlights
+
+### Resident-robustness fixes
+
+- **Long persisted-state files now read safely.** The reader's list parser
+  (`read_list`) was rewritten from per-element native recursion to an
+  iterative loop, so reading a long flat list — e.g. a 46K-entry persisted
+  state file — no longer overflows the native stack. Verified: the pre-fix
+  reader crashed (SIGBUS) at 20M elements; post-fix, the same input reads
+  cleanly. (#191)
+- **`define`-loop daemons now hold flat memory.** Automatic per-iteration
+  arena-scope reclamation — previously limited to named-let loops — now also
+  covers self-tail-recursive top-level `define` loops, and the escape
+  analysis that gates it accepts a catch-all `guard` clause instead of
+  rejecting any guarded body outright. This is exactly the shape of a
+  production daemon/resident loop: a top-level `define` loop wrapped in an
+  error boundary. Verified in AOT mode: a 1,000,000-iteration allocating
+  guard-wrapped `define` loop holds peak RSS at 27MB with the fix on, versus
+  2608MB with the fix off. (#192)
+
+### Comprehensive documentation pass
+
+- Doxygen doc-comments added across all 64 public headers (`inc/eshkol/**`)
+  and most implementation files (`lib/**`).
+- A new navigable documentation index (`docs/README.md`); orphaned
+  (unindexed) docs reduced from 73 to 3.
+- Press materials and website content updated to reflect the shipped v1.3
+  state; roadmap views aligned with what has actually shipped.
+
+### Known issues
+
+See [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md) and the CHANGELOG's Known
+Issues section for the current, itemized list (none block ordinary use).
+
+---
+
+## Previous Releases
+
+### Eshkol v1.3.0-evolve — Arbitrary-Order Automatic Differentiation
 
 **Release Date**: July 7, 2026
 
 Eshkol v1.3.0-evolve is the "evolve" release: arbitrary-order automatic
 differentiation, full R7RS conformance on the portable differential
 corpus, and a hardening pass across closures, tail calls, and long-running
-processes. Full technical detail lives in [CHANGELOG.md](CHANGELOG.md); this
-page is the user-facing summary.
+processes.
 
 **Release gates** (all green on the release SHA): ICC readiness oracle
 `v1.3-evolve` ready (100/100, trace-verified); CI 14/14 lanes including
@@ -14,9 +68,9 @@ windows-arm64 lite/CUDA/XLA; SICP full-book gate 88/88 probes across all 5
 chapters under both `-r` and AOT; reference-Scheme differential oracle 34/34
 AGREE vs. chibi-scheme.
 
-## Highlights
+#### Highlights
 
-### Automatic differentiation, best-in-class and beyond
+##### Automatic differentiation, best-in-class and beyond
 
 Eshkol's AD system already did exact forward-mode, reverse-mode, and
 symbolic differentiation. v1.3.0-evolve adds a second axis on top: **order**.
@@ -57,7 +111,7 @@ arbitrary order `k` in a single pass:
 See the [Automatic Differentiation guide](docs/guide/AUTOMATIC_DIFFERENTIATION.md)
 for worked examples and the full API reference.
 
-### Full R7RS conformance on the portable corpus
+##### Full R7RS conformance on the portable corpus
 
 A new reference-Scheme differential oracle diffs Eshkol's behavior against
 chibi-scheme 0.12.0 across a 34-program portable R7RS corpus (numeric, list,
@@ -72,7 +126,7 @@ family, R7RS string-escaping in `write`, nested ellipsis (`x ... ...`) in
 `syntax-rules`, and the 2-argument form of `substring`. See the
 [CHANGELOG](CHANGELOG.md#fixed--r7rs-conformance) for the itemized list.
 
-### Robustness: closures, tail calls, and long-running processes
+##### Robustness: closures, tail calls, and long-running processes
 
 A cluster of fixes targets programs that run for a long time or recurse
 deeply — the kind of bug that only shows up in production, not in a quick
@@ -96,7 +150,7 @@ test:
 See [CHANGELOG.md](CHANGELOG.md#fixed--compiler--runtime-robustness) for the
 full list with root causes.
 
-### Also in this release
+##### Also in this release
 
 - A new build integration surface: `--emit-depfile` plus a canonical
   `cmake/EshkolCompile.cmake` for consumers embedding the Eshkol compiler in
@@ -109,14 +163,10 @@ full list with root causes.
   classes of bug keep getting caught going forward. See
   [docs/TESTING.md](docs/TESTING.md).
 
-### Known issues
+##### Known issues
 
 See [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md) and the CHANGELOG's Known
 Issues section for the current, itemized list (none block ordinary use).
-
----
-
-## Previous Releases
 
 ### Eshkol v1.2.3-scale — Platform Artifact Closeout
 

--- a/inc/eshkol/eshkol.h
+++ b/inc/eshkol/eshkol.h
@@ -15,9 +15,9 @@
  * embedded in binaries and reported by `--version`.
  */
 #define ESHKOL_VERSION_MAJOR 1
-#define ESHKOL_VERSION_MINOR 2
+#define ESHKOL_VERSION_MINOR 3
 #define ESHKOL_VERSION_PATCH 1
-#define ESHKOL_VERSION_STRING "1.2.1-scale"
+#define ESHKOL_VERSION_STRING "1.3.1-evolve"
 
 #include <stdint.h>
 #include <stdbool.h>

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -366,6 +366,14 @@ probe string_edge_ops_r7rs 'string-map returns a string; string->number honors r
      rm -f "$bin";
      exit 0'
 
+probe define_loop_flat_rss_aot 'ESH-0214b: AOT guard-wrapped define loop keeps RSS flat (v1.3.1 gate)' \
+    'cd "$REPO_ROOT";
+     ## v1.3.1 fix: per-iteration arena scope reclamation for self-tail
+     ## define loops with catch-all guard. Broken behavior is ~2.6GB peak
+     ## RSS at 1e6 allocating iterations; fixed is ~26MB. The gate fails
+     ## above a 200MB ceiling.
+     bash tests/memory/define_loop_flat_rss_aot_test.sh'
+
 echo
 echo "Trace written: $TRACE_FILE"
 echo "Run: python3 ~/Desktop/infinite_context_coder/scripts/codebase_tool.py \\"

--- a/tests/memory/define_loop_flat_rss_aot_test.esk
+++ b/tests/memory/define_loop_flat_rss_aot_test.esk
@@ -1,0 +1,35 @@
+;;; tests/memory/define_loop_flat_rss_aot_test.esk — ESH-0214b AOT flat-RSS
+;;; regression fixture, gated by define_loop_flat_rss_aot_test.sh.
+;;;
+;;; A TOP-LEVEL self-tail-recursive `define` loop whose body is wrapped in a
+;;; catch-all `guard` — the exact daemon-loop shape ESH-0214b targets. Each
+;;; iteration allocates a small fresh list via `(make-list 12 i)` (non-
+;;; foldable — the fill value changes every iteration, so it cannot be
+;;; hoisted or constant-folded away) that never escapes the iteration; the
+;;; only carried state is a plain numeric accumulator. Without automatic
+;;; per-iteration arena reclamation, this shape leaks ~one iteration's worth
+;;; of list cells forever; with it, peak RSS stays flat regardless of
+;;; iteration count. See tests/features/define_loop_iter_scope_test.esk for
+;;; the sibling correctness fixture and scripts/run_rss_bounded_test.sh for
+;;; the JIT (-r) bounded-RSS gate this AOT gate complements.
+
+(define total-passes 1000000)
+
+(define (loop i acc)
+  (guard (e (#t acc))                     ; catch-all: any raise yields acc
+    (if (>= i total-passes)
+        acc
+        (let ((scratch (make-list 12 i))) ; fresh, non-foldable, dead at back edge
+          (loop (+ i 1) (+ acc (length scratch)))))))
+
+(let ((result (loop 0 0)))
+  (display "[define_loop_flat_rss_aot_test] passes=")
+  (display total-passes)
+  (display " result=")
+  (display result)
+  (newline)
+  (if (= result (* total-passes 12))
+      (begin (display "PASS") (newline))
+      (begin (display "FAIL expected ")
+             (display (* total-passes 12))
+             (newline))))

--- a/tests/memory/define_loop_flat_rss_aot_test.sh
+++ b/tests/memory/define_loop_flat_rss_aot_test.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# tests/memory/define_loop_flat_rss_aot_test.sh — ESH-0214b AOT flat-RSS
+# regression gate.
+#
+# ESH-0214b extended automatic per-iteration arena-scope reclamation from
+# named-let loops to self-tail-recursive top-level `define` loops, and
+# taught the escape analysis to accept a catch-all `guard` body instead of
+# rejecting any guarded loop outright. This is the exact shape of a
+# production daemon/resident loop: a top-level `define` loop wrapped in an
+# error boundary. Without the fix, such a loop leaks roughly one iteration's
+# worth of garbage forever; with it, peak RSS stays flat regardless of
+# iteration count.
+#
+# Unlike scripts/run_rss_bounded_test.sh (which gates the JIT `-r` path),
+# this gate is AOT-only: it compiles tests/memory/define_loop_flat_rss_aot_test.esk
+# ahead-of-time to a native binary with `eshkol-run <src> -o <bin>`, runs the
+# binary directly under `/usr/bin/time` (macOS: `-l`, Linux: `-v`), and fails
+# if peak RSS exceeds a generous flat ceiling. The fixed behavior measures
+# ~27MB; the broken (pre-fix) behavior measures ~2.6GB for the same
+# 1,000,000-iteration program, so a 200MB ceiling cleanly separates the two
+# with wide margin in both directions.
+#
+# A second, advisory-only half recompiles the same source with
+# ESHKOL_NO_ITER_SCOPE=1 set at COMPILE time (disabling the fix globally)
+# and reports its peak RSS, to demonstrate the gate would actually catch a
+# regression. That half is informational (echo only) and never fails the
+# gate, to keep CI time bounded.
+#
+# Usage: tests/memory/define_loop_flat_rss_aot_test.sh [--ceiling-mb N] [--timeout S]
+#   BUILD_DIR env var selects the build directory (default: build).
+#   ESHKOL_RUN env var overrides the eshkol-run binary path directly.
+set -u
+cd "$(dirname "$0")/../.."
+REPO_ROOT="$(pwd)"
+
+BUILD_DIR="${BUILD_DIR:-build}"
+if [ -z "${ESHKOL_RUN:-}" ]; then
+    case "$BUILD_DIR" in
+        /*) ESHKOL_RUN="$BUILD_DIR/eshkol-run" ;;
+        *) ESHKOL_RUN="$REPO_ROOT/$BUILD_DIR/eshkol-run" ;;
+    esac
+fi
+if [ ! -x "$ESHKOL_RUN" ]; then
+    echo "define_loop_flat_rss_aot_test.sh: $ESHKOL_RUN not found — run \`cmake --build $BUILD_DIR --target eshkol-run stdlib\` first." >&2
+    exit 2
+fi
+
+SRC="$REPO_ROOT/tests/memory/define_loop_flat_rss_aot_test.esk"
+if [ ! -f "$SRC" ]; then
+    echo "define_loop_flat_rss_aot_test.sh: $SRC not found." >&2
+    exit 2
+fi
+
+CEILING_MB=200
+TIMEOUT_S=60
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --ceiling-mb) shift; CEILING_MB="${1:-$CEILING_MB}" ;;
+        --timeout) shift; TIMEOUT_S="${1:-$TIMEOUT_S}" ;;
+        *) echo "define_loop_flat_rss_aot_test.sh: unknown argument: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+# Detect which peak-RSS-reporting `time` flavor is available.
+# macOS (BSD time): `/usr/bin/time -l` reports "NNNN  maximum resident set size" in BYTES.
+# Linux (GNU time):  `/usr/bin/time -v` reports "Maximum resident set size (kbytes): NNNN" in KB.
+TIME_MODE=""
+if /usr/bin/time -l true >/dev/null 2>/tmp/.deflrat_probe.$$; then
+    if grep -q "maximum resident set size" /tmp/.deflrat_probe.$$ 2>/dev/null; then
+        TIME_MODE="bsd"
+    fi
+fi
+if [ -z "$TIME_MODE" ] && /usr/bin/time -v true >/tmp/.deflrat_probe.$$ 2>&1; then
+    if grep -qi "Maximum resident set size" /tmp/.deflrat_probe.$$ 2>/dev/null; then
+        TIME_MODE="gnu"
+    fi
+fi
+rm -f /tmp/.deflrat_probe.$$
+if [ -z "$TIME_MODE" ]; then
+    echo "define_loop_flat_rss_aot_test.sh: neither \`/usr/bin/time -l\` (macOS) nor \`/usr/bin/time -v\` (Linux) reports peak RSS on this host — cannot gate." >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-flat-rss-aot.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# run_aot <src> <bin> <compile_env...=> -> sets FR_COMPILE_RC FR_RUN_RC FR_RSS_MB FR_OUT
+run_aot() {
+    local src="$1" bin="$2"; shift 2
+    local compile_log="$WORK/compile_$(basename "$bin").log"
+    local run_out="$WORK/run_$(basename "$bin").out"
+    local time_log="$WORK/time_$(basename "$bin").log"
+
+    ( cd "$WORK" && env "$@" "$ESHKOL_RUN" "$src" -o "$bin" ) > "$compile_log" 2>&1
+    FR_COMPILE_RC=$?
+    if [ "$FR_COMPILE_RC" -ne 0 ]; then
+        FR_RUN_RC=127
+        FR_RSS_MB=0
+        FR_OUT="$compile_log"
+        return
+    fi
+    chmod +x "$bin"
+
+    if [ "$TIME_MODE" = "bsd" ]; then
+        ( cd "$WORK" && /usr/bin/time -l perl -e 'my $s=shift; alarm $s; exec @ARGV; die "exec failed: $!\n"' \
+            "$TIMEOUT_S" "$bin" ) > "$run_out" 2> "$time_log"
+        FR_RUN_RC=$?
+        FR_RSS_MB=$(awk '/maximum resident set size/{printf "%d", $1/1048576}' "$time_log")
+    else
+        ( cd "$WORK" && /usr/bin/time -v perl -e 'my $s=shift; alarm $s; exec @ARGV; die "exec failed: $!\n"' \
+            "$TIMEOUT_S" "$bin" ) > "$run_out" 2> "$time_log"
+        FR_RUN_RC=$?
+        FR_RSS_MB=$(awk -F: '/Maximum resident set size/{printf "%d", $2/1024}' "$time_log")
+    fi
+    [ -n "$FR_RSS_MB" ] || FR_RSS_MB=0
+    FR_OUT="$run_out"
+}
+
+echo "=========================================================="
+echo "  ESH-0214b AOT flat-RSS gate: define_loop_flat_rss_aot_test.esk"
+echo "  ceiling=${CEILING_MB}MB  time-mode=${TIME_MODE}"
+echo "=========================================================="
+echo
+
+echo "--- gate: AOT compile + run (fix ON, default build) ---"
+run_aot "$SRC" "$WORK/flat_rss_gate_bin"
+gate_compile_rc=$FR_COMPILE_RC
+gate_run_rc=$FR_RUN_RC
+gate_rss=$FR_RSS_MB
+gate_out="$FR_OUT"
+
+fail=0
+if [ "$gate_compile_rc" -ne 0 ]; then
+    echo "FAIL: AOT compile failed (exit=$gate_compile_rc). Output:"
+    cat "$gate_out"
+    fail=1
+elif [ "$gate_run_rc" -ne 0 ] || ! grep -q "^PASS$" "$gate_out"; then
+    echo "FAIL: AOT binary did not complete cleanly (exit=$gate_run_rc). Output:"
+    cat "$gate_out"
+    fail=1
+else
+    echo "  exit=$gate_run_rc  peak_rss=${gate_rss}MB"
+    if [ "$gate_rss" -gt "$CEILING_MB" ]; then
+        echo "FAIL: peak RSS ${gate_rss}MB exceeds ceiling ${CEILING_MB}MB"
+        echo "      -- looks like a reintroduced per-iteration leak in the"
+        echo "      define-loop + catch-all-guard arena-reclamation path (ESH-0214b)."
+        fail=1
+    else
+        echo "PASS: peak RSS ${gate_rss}MB is within the ${CEILING_MB}MB flat ceiling."
+    fi
+fi
+
+echo
+echo "--- advisory (informational only, not gated): AOT compile + run with"
+echo "    ESHKOL_NO_ITER_SCOPE=1 at COMPILE time (fix disabled) ---"
+run_aot "$SRC" "$WORK/flat_rss_noiter_bin" ESHKOL_NO_ITER_SCOPE=1
+if [ "$FR_COMPILE_RC" -ne 0 ]; then
+    echo "  (advisory) compile failed with ESHKOL_NO_ITER_SCOPE=1 (exit=$FR_COMPILE_RC) -- skipping comparison."
+elif [ "$FR_RUN_RC" -ne 0 ] || ! grep -q "^PASS$" "$FR_OUT"; then
+    echo "  (advisory) run failed with ESHKOL_NO_ITER_SCOPE=1 (exit=$FR_RUN_RC) -- skipping comparison."
+else
+    echo "  (advisory) peak_rss=${FR_RSS_MB}MB with fix disabled (fix-on gate measured ${gate_rss}MB)."
+    if [ "$FR_RSS_MB" -gt "$CEILING_MB" ]; then
+        echo "  (advisory) confirms the gate WOULD catch this regression: ${FR_RSS_MB}MB > ${CEILING_MB}MB ceiling."
+    else
+        echo "  (advisory) NOTE: disabling the fix did not exceed the ceiling on this host/build --"
+        echo "             the gate's discriminating power could not be confirmed this run."
+    fi
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+    echo "define_loop_flat_rss_aot_test.sh: PASS"
+else
+    echo "define_loop_flat_rss_aot_test.sh: FAIL"
+fi
+exit "$fail"


### PR DESCRIPTION
## Summary

v1.3.1 is a resident-robustness point release over v1.3.0-evolve:

- **Version bump**: `CMakeLists.txt` `ESHKOL_VERSION` 1.3.0 -> 1.3.1 (also drives `ESHKOL_VER` used by `eshkol-run --version`); `inc/eshkol/eshkol.h` `ESHKOL_VERSION_STRING`/`_MAJOR`/`_MINOR`/`_PATCH` (was stale at 1.2.1-scale, used by `eshkol-repl --version`) bumped to 1.3.1-evolve; README version badge updated. No changes to `site/`, `press/`, or historical `v1.3.0-evolve` mentions.
- **CHANGELOG.md** / **RELEASE_NOTES.md**: new v1.3.1-evolve entries (2026-07-09) covering:
  - fix(reader) #191 — iterative `read_list`: long flat lists (e.g. 46K-entry persisted state) no longer overflow the native stack on read. Pre-fix SIGBUS at 20M elements; post-fix clean.
  - fix(codegen) #192 — ESH-0214b per-iteration arena scope reclamation extended to self-tail-recursive `define` loops, escape analysis now accepts catch-all guard bodies. Verified in AOT mode: 1e6-iteration allocating guard-`define`-loop peak RSS 2608MB (fix off) -> 27MB (fix on).
  - Comprehensive documentation pass: Doxygen across all 64 public headers + most `lib/**`, new `docs/README.md` index (orphan docs 73 -> 3), press/website/roadmap updates (already merged to master).
- **New AOT flat-RSS regression gate**: `tests/memory/define_loop_flat_rss_aot_test.esk` + `tests/memory/define_loop_flat_rss_aot_test.sh`, modeled on `tests/features/define_loop_iter_scope_test.esk` and `scripts/run_rss_bounded_test.sh`. AOT-compiles a self-tail-recursive `define` loop wrapped in a catch-all `guard` that allocates a fresh non-foldable `(make-list 12 i)` each of 1,000,000 iterations, runs the binary under `/usr/bin/time -l`/`-v` (auto-detected), and fails if peak RSS exceeds a 200MB flat ceiling. A second, advisory-only half recompiles with `ESHKOL_NO_ITER_SCOPE=1` at compile time and reports (does not gate) the regression RSS, confirming the gate's discriminating power. Total runtime ~6s.

No git tag created (tagging is done separately by the maintainer).

## Test plan

Ran the new gate locally against a fresh Release build (`cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j`) on this branch:

```
==========================================================
  ESH-0214b AOT flat-RSS gate: define_loop_flat_rss_aot_test.esk
  ceiling=200MB  time-mode=bsd
==========================================================

--- gate: AOT compile + run (fix ON, default build) ---
  exit=0  peak_rss=26MB
PASS: peak RSS 26MB is within the 200MB flat ceiling.

--- advisory (informational only, not gated): AOT compile + run with
    ESHKOL_NO_ITER_SCOPE=1 at COMPILE time (fix disabled) ---
  (advisory) peak_rss=2608MB with fix disabled (fix-on gate measured 26MB).
  (advisory) confirms the gate WOULD catch this regression: 2608MB > 200MB ceiling.

define_loop_flat_rss_aot_test.sh: PASS
```

- [x] `eshkol-run --version` reports `Eshkol Compiler v1.3.1-evolve`
- [x] New AOT flat-RSS gate passes locally (26MB fix-on vs 2608MB fix-off, matching the documented verified numbers almost exactly)
- [x] Version strings consistent across `CMakeLists.txt`, `inc/eshkol/eshkol.h`, `README.md`