### PR TITLE
fix: correct R7RS modulo (bignum) and remainder (VM) sign semantics

### DIFF
--- a/lib/backend/arithmetic_codegen.cpp
+++ b/lib/backend/arithmetic_codegen.cpp
@@ -1851,7 +1851,12 @@ llvm::Value* ArithmeticCodegen::div(llvm::Value* left, llvm::Value* right) {
  *
  * Dispatches to the bignum runtime (op code 4) when either operand is a
  * bignum; otherwise unpacks int64 operands, raises a divide-by-zero
- * exception on a zero divisor, and computes the result via LLVM's `srem`.
+ * exception on a zero divisor, and computes the result via LLVM's `srem`
+ * followed by a floor-mod sign correction (R7RS `modulo`: the result has the
+ * same sign as the divisor, unlike C's truncating `srem`).
+ *
+ * NOTE: the live `modulo` builtin is lowered by codegenModulo() in
+ * llvm_codegen.cpp; this method mirrors that semantics for any future caller.
  *
  * @param left Tagged dividend.
  * @param right Tagged divisor.
@@ -1891,9 +1896,17 @@ llvm::Value* ArithmeticCodegen::mod(llvm::Value* left, llvm::Value* right) {
     raiseDivideByZeroException();
     ctx_.builder().CreateUnreachable();
 
-    // Safe path - perform modulo
+    // Safe path - perform modulo (floor semantics: sign of divisor).
     ctx_.builder().SetInsertPoint(safe_bb);
-    llvm::Value* int_result = ctx_.builder().CreateSRem(left_int, right_int, "mod_result");
+    llvm::Value* srem = ctx_.builder().CreateSRem(left_int, right_int, "mod_srem");
+    llvm::Value* zero_v = llvm::ConstantInt::get(ctx_.int64Type(), 0);
+    llvm::Value* rem_neg = ctx_.builder().CreateICmpSLT(srem, zero_v, "mod_rem_neg");
+    llvm::Value* div_neg = ctx_.builder().CreateICmpSLT(right_int, zero_v, "mod_div_neg");
+    llvm::Value* signs_differ = ctx_.builder().CreateXor(rem_neg, div_neg, "mod_signs_differ");
+    llvm::Value* rem_nonzero = ctx_.builder().CreateICmpNE(srem, zero_v, "mod_rem_nonzero");
+    llvm::Value* need_adjust = ctx_.builder().CreateAnd(signs_differ, rem_nonzero, "mod_need_adjust");
+    llvm::Value* adjusted = ctx_.builder().CreateAdd(srem, right_int, "mod_adjusted");
+    llvm::Value* int_result = ctx_.builder().CreateSelect(need_adjust, adjusted, srem, "mod_result");
     llvm::Value* int_tagged = tagged_.packInt64(int_result, true);
     ctx_.builder().CreateBr(merge);
     llvm::BasicBlock* int_exit = ctx_.builder().GetInsertBlock();

--- a/lib/backend/vm_compiler.c
+++ b/lib/backend/vm_compiler.c
@@ -1893,10 +1893,13 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
     /* Type predicates that need VM opcodes (not closures — these check types at opcode level) */
     if (is_sym(head, "integer?") && node->n_children == 2) { compile_expr(c, node->children[1], 0); chunk_emit(c, OP_NUM_P, 0); return; }
 
-    /* abs and modulo are opcodes, not native calls — keep as special cases */
+    /* abs and modulo are opcodes, not native calls — keep as special cases.
+     * NOTE: remainder must NOT map to OP_MOD. OP_MOD implements R7RS `modulo`
+     * (floor semantics, sign of divisor); `remainder` needs truncating
+     * semantics (sign of dividend). It resolves through the native table
+     * (id 37) like `quotient` (id 38), which computes ia%ib correctly. */
     if (is_sym(head, "abs") && node->n_children == 2) { compile_expr(c, node->children[1], 0); chunk_emit(c, OP_ABS, 0); return; }
     if (is_sym(head, "modulo") && node->n_children == 3) { compile_expr(c, node->children[1], 0); compile_expr(c, node->children[2], 0); chunk_emit(c, OP_MOD, 0); return; }
-    if (is_sym(head, "remainder") && node->n_children == 3) { compile_expr(c, node->children[1], 0); compile_expr(c, node->children[2], 0); chunk_emit(c, OP_MOD, 0); return; }
 
     /* All other builtins (sin, cos, sqrt, even?, odd?, floor, ceiling, round, expt, min, max,
      * positive?, negative?, number->string, string-append, string=?, newline, length, etc.)

--- a/lib/core/bignum.cpp
+++ b/lib/core/bignum.cpp
@@ -982,9 +982,21 @@ void eshkol_bignum_binary_tagged(arena_t* arena,
             }
             break;
         }
-        case 4: r = eshkol_bignum_mod(arena, a, b); break;
+        case 4: {
+            /* modulo: R7RS floor-mod — result has the SAME SIGN AS THE DIVISOR.
+             * eshkol_bignum_mod yields the truncating remainder (sign of the
+             * dividend), so when that remainder is nonzero and its sign differs
+             * from the divisor's, add the divisor to fold it into the divisor's
+             * sign — matching the int64 fast path in codegenModulo(). */
+            eshkol_bignum_t* m = eshkol_bignum_mod(arena, a, b);
+            if (m && !eshkol_bignum_is_zero(m) && m->sign != b->sign) {
+                m = eshkol_bignum_add(arena, m, b);
+            }
+            r = m;
+            break;
+        }
         case 5: r = eshkol_bignum_div(arena, a, b); break;  /* quotient = truncated div */
-        case 6: r = eshkol_bignum_mod(arena, a, b); break;  /* remainder = mod */
+        case 6: r = eshkol_bignum_mod(arena, a, b); break;  /* remainder = trunc rem (sign of dividend) */
         default: { *result = eshkol_make_int64(0, true); return; }
     }
 

--- a/tests/features/modulo_semantics_test.esk
+++ b/tests/features/modulo_semantics_test.esk
@@ -1,0 +1,62 @@
+;; R7RS modulo / remainder / quotient semantics regression test.
+;;
+;; Locks the sign conventions of the integer numeric tower:
+;;   modulo    -> floor division; result has the SIGN OF THE DIVISOR
+;;   remainder -> truncating division; result has the SIGN OF THE DIVIDEND
+;;   quotient  -> truncating division (toward zero)
+;;
+;; Covers the int64 fast path, the bignum runtime path (op 4 in
+;; eshkol_bignum_binary_tagged), and a hot loop so the optimized int64
+;; path is exercised rather than a runtime fallback. On any mismatch the
+;; test prints a line containing "error:" so the features harness flags it.
+
+(define fail-count 0)
+
+(define (check name got expected)
+  (if (= got expected)
+      (begin (display "ok   ") (display name) (newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "error: ") (display name)
+             (display " expected ") (display expected)
+             (display " got ") (display got) (newline))))
+
+;; --- modulo: sign of divisor (int64 fast path) ---
+(check "modulo -7 3"   (modulo -7 3)   2)
+(check "modulo 7 -3"   (modulo 7 -3)  -2)
+(check "modulo -7 -3"  (modulo -7 -3) -1)
+(check "modulo 7 3"    (modulo 7 3)    1)
+(check "modulo 0 5"    (modulo 0 5)    0)
+(check "modulo -6 3"   (modulo -6 3)   0)
+
+;; --- remainder: sign of dividend (int64 fast path) ---
+(check "remainder -7 3"  (remainder -7 3)  -1)
+(check "remainder 7 -3"  (remainder 7 -3)   1)
+(check "remainder -7 -3" (remainder -7 -3) -1)
+(check "remainder 7 3"   (remainder 7 3)    1)
+
+;; --- quotient: truncating toward zero ---
+(check "quotient -7 3"  (quotient -7 3)  -2)
+(check "quotient 7 -3"  (quotient 7 -3)  -2)
+(check "quotient 7 3"   (quotient 7 3)    2)
+(check "quotient -7 -3" (quotient -7 -3)  2)
+
+;; --- bignum path: modulo must still follow the divisor's sign ---
+;;  2^100 = 1 (mod 3), so -(2^100) mod 3 = 2, and 2^100 mod -3 = -2.
+(check "modulo -(2^100) 3"  (modulo (- (expt 2 100)) 3)   2)
+(check "modulo 2^100 -3"    (modulo (expt 2 100) -3)     -2)
+(check "modulo -7 2^70"     (modulo -7 (expt 2 70))      (- (expt 2 70) 7))
+;; bignum remainder keeps the dividend's sign
+(check "remainder -(2^100) 3" (remainder (- (expt 2 100)) 3) -1)
+
+;; --- hot loop: forces the optimized int64 modulo path ---
+(define (sum-mod i limit acc)
+  (if (>= i limit)
+      acc
+      (sum-mod (+ i 1) limit (+ acc (modulo (- 0 i) 7)))))
+;; Each (modulo (- 0 i) 7) is in [0,7); sum over i in [0,1000000).
+(check "hot-loop sum" (sum-mod 0 1000000 0) 2999997)
+
+(if (= fail-count 0)
+    (begin (display "ALL MODULO/REMAINDER/QUOTIENT SEMANTICS OK") (newline))
+    (begin (display "error: ") (display fail-count)
+           (display " modulo/remainder semantics FAILURES") (newline)))

--- a/tests/vm_parity/corpus/26_int_division.esk
+++ b/tests/vm_parity/corpus/26_int_division.esk
@@ -1,0 +1,12 @@
+; R7RS integer division sign conventions — VM must match native codegen.
+;   modulo    -> sign of divisor
+;   remainder -> sign of dividend
+;   quotient  -> truncate toward zero
+(display (modulo -7 3)) (newline)
+(display (modulo 7 -3)) (newline)
+(display (modulo -7 -3)) (newline)
+(display (remainder -7 3)) (newline)
+(display (remainder 7 -3)) (newline)
+(display (remainder -7 -3)) (newline)
+(display (quotient -7 3)) (newline)
+(display (quotient 7 -3)) (newline)


### PR DESCRIPTION
## Verdict: BUG CONFIRMED (two real defects) — but not where the report pointed

The documentation review flagged `ArithmeticCodegen::mod` emitting plain `srem` with no sign correction. That function is **dead code** — it is defined but never called. The live `modulo` builtin is lowered by `codegenModulo()` in `llvm_codegen.cpp`, whose int64 fast path already applies the correct floor-mod sign correction. So the reported int64 case is **not** broken.

Investigation of the full numeric tower surfaced two genuine bugs plus one latent trap:

### Bug 1 — bignum `modulo` (compiled JIT + AOT)
`eshkol_bignum_binary_tagged` op 4 called `eshkol_bignum_mod`, which returns the **truncating remainder** (sign of dividend). R7RS `modulo` must carry the **sign of the divisor**. So for operands large enough to hit the bignum path with mismatched signs, `modulo` returned a remainder-signed value.

Fixed in `lib/core/bignum.cpp`: op 4 now folds the remainder into the divisor's sign (add the divisor when the nonzero remainder's sign differs). op 6 (`remainder`) is unchanged — its truncating semantics are correct.

### Bug 2 — VM `remainder`
`lib/backend/vm_compiler.c` special-cased `remainder` to `OP_MOD` (floor semantics), so the VM computed `modulo` for `remainder`. Removed the special case; `remainder` now resolves through native id 37 (`ia%ib`, truncating), exactly as `quotient` already resolves through id 38. The VM natives (36 floor-mod, 37 truncating rem, 38 truncating quot) were already correct.

### Bug 3 — dead code hardening
`ArithmeticCodegen::mod` got the same floor-mod correction and a corrected docstring, so it cannot become a latent bug if ever wired up.

## Evidence — observed outputs

The 5 required probes (int64) were already correct before and after, in both JIT and AOT:

| probe | expected | before | after |
|-------|----------|--------|-------|
| `(modulo -7 3)`  |  2 |  2 |  2 |
| `(modulo 7 -3)`  | -2 | -2 | -2 |
| `(modulo -7 -3)` | -1 | -1 | -1 |
| `(remainder -7 3)` | -1 | -1 | -1 |
| `(remainder 7 -3)` |  1 |  1 |  1 |

Bignum `modulo` (JIT and AOT), before → after (chibi-scheme reference in parens):

| probe | before | after (ref) |
|-------|--------|-------------|
| `(modulo (- (expt 2 100)) 3)` | -1 | **2** (2) |
| `(modulo (expt 2 100) -3)`    |  1 | **-2** (-2) |
| `(modulo -7 (expt 2 70))`     | -7 | **1180591620717411303417** (…303417) |
| `(remainder (- (expt 2 100)) 3)` | -1 | -1 (-1) |

VM `remainder`, before → after:

| probe | before | after (correct) |
|-------|--------|-----------------|
| `(remainder -7 3)` | 2 | **-1** |
| `(remainder 7 -3)` | -2 | **1** |
| `(modulo -7 3)` | 2 | 2 |
| `(quotient -7 3)` | -2 | -2 |

## Tests
- New self-asserting `tests/features/modulo_semantics_test.esk` (int64 fast path, bignum path, hot loop). Passes in both JIT (`-r`) and AOT.
- New VM-vs-native parity corpus `tests/vm_parity/corpus/26_int_division.esk`.
- `tests/features`: 29/29 pass. `tests/autodiff`: 54/54 pass. VM parity: 58/58 pass.
- Differential-checked against `chibi-scheme`.