### PR TITLE
fix: resolve HEAP_SUBTYPE_PARAMETER/PRNG type-tag collision

### DIFF
--- a/inc/eshkol/eshkol.h
+++ b/inc/eshkol/eshkol.h
@@ -516,7 +516,8 @@ typedef enum {
     HEAP_SUBTYPE_DNC             = 21,  // Differentiable external memory (NTM/DNC head)
     HEAP_SUBTYPE_SDNC            = 22,  // SDNC weight-program handle (bytecode-VM-as-transformer θ)
     HEAP_SUBTYPE_TAYLOR          = 23,  // Truncated-Taylor tower for arbitrary-order AD (ESH-0186)
-    // Reserved: 24-255 for future heap types
+    HEAP_SUBTYPE_PARAMETER       = 24,  // R7RS dynamic parameter object (make-parameter/parameterize)
+    // Reserved: 25-255 for future heap types
 } heap_subtype_t;
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -15763,6 +15763,19 @@ private:
             return packPtrToTaggedValue(param_ptr, ESHKOL_VALUE_HEAP_PTR);
         }
 
+        if (func_name == "parameter?") {
+            // (parameter? obj) — heap-subtype check for HEAP_SUBTYPE_PARAMETER.
+            if (op->call_op.num_vars != 1) {
+                eshkol_warn("parameter? requires exactly 1 argument");
+                return packBoolToTaggedValue(ConstantInt::getFalse(*context));
+            }
+            TypedValue tv = codegenTypedAST(&op->call_op.variables[0]);
+            if (!tv.llvm_value) return nullptr;
+            Value* tagged = ensureTaggedValue(tv.llvm_value);
+            Value* matches = isHeapSubtype(tagged, HEAP_SUBTYPE_PARAMETER);
+            return packBoolToTaggedValue(matches);
+        }
+
         // =========================================================================
         // R7RS Bytevector Operations
         // Layout: [header(-8) | length(i64,+0) | data(uint8[],+8)]

--- a/lib/core/introspection.cpp
+++ b/lib/core/introspection.cpp
@@ -1409,6 +1409,12 @@ eshkol_tagged_value_t eshkol_type_of(eshkol_tagged_value_t value) {
                         case HEAP_SUBTYPE_WORKSPACE:
                             type_name = "workspace";
                             break;
+                        case HEAP_SUBTYPE_PRNG:
+                            type_name = "prng";
+                            break;
+                        case HEAP_SUBTYPE_PARAMETER:
+                            type_name = "parameter";
+                            break;
                         default:
                             eshkol_warn("unknown heap subtype: %d", header->subtype);
                             type_name = "heap-object";

--- a/lib/core/runtime_display_hosted.cpp
+++ b/lib/core/runtime_display_hosted.cpp
@@ -349,6 +349,12 @@ void eshkol_display_value_opts(const eshkol_tagged_value_t* value, eshkol_displa
                         (long long)rat->numerator, (long long)rat->denominator);
                     break;
                 }
+                case HEAP_SUBTYPE_PRNG:
+                    fprintf(get_output(opts), "#<prng>");
+                    break;
+                case HEAP_SUBTYPE_PARAMETER:
+                    fprintf(get_output(opts), "#<parameter>");
+                    break;
                 default:
                     fprintf(get_output(opts), "#<heap:%d>", header->subtype);
                     break;

--- a/lib/core/runtime_errors_hosted.cpp
+++ b/lib/core/runtime_errors_hosted.cpp
@@ -241,6 +241,7 @@ const char* eshkol_format_value_type_tag(eshkol_tagged_value_t v) {
                 case HEAP_SUBTYPE_PROMISE:        return "promise";
                 case HEAP_SUBTYPE_RATIONAL:       return "rational";
                 case HEAP_SUBTYPE_PRNG:           return "prng";
+                case HEAP_SUBTYPE_PARAMETER:      return "parameter";
                 default:                          return "heap-object";
             }
         }

--- a/lib/core/runtime_parameters_hosted.cpp
+++ b/lib/core/runtime_parameters_hosted.cpp
@@ -16,7 +16,13 @@
 #include <cstdint>
 #include <cstdlib>
 
-#define HEAP_SUBTYPE_PARAMETER 20
+// HEAP_SUBTYPE_PARAMETER is defined canonically in inc/eshkol/eshkol.h
+// (heap_subtype_t). It used to be locally #define'd here as 20, which
+// numerically collided with HEAP_SUBTYPE_PRNG (also 20) — since both flow
+// through the same ESHKOL_VALUE_HEAP_PTR dispatch (isHeapSubtype checks,
+// eshkol_format_value_type_tag, display), a parameter object could be
+// misidentified as a PRNG object (e.g. `(prng? a-parameter)` => #t). Fixed
+// by giving HEAP_SUBTYPE_PARAMETER its own id (24) in the canonical table.
 
 extern "C" {
 

--- a/tests/features/parameter_prng_subtype_test.esk
+++ b/tests/features/parameter_prng_subtype_test.esk
@@ -1,0 +1,76 @@
+;; Regression test: HEAP_SUBTYPE_PARAMETER / HEAP_SUBTYPE_PRNG collision.
+;;
+;; lib/core/runtime_parameters_hosted.cpp used to locally #define
+;; HEAP_SUBTYPE_PARAMETER as 20, which numerically collided with the
+;; canonical HEAP_SUBTYPE_PRNG = 20 in inc/eshkol/eshkol.h. Both subtypes
+;; flow through the same ESHKOL_VALUE_HEAP_PTR dispatch (type predicates,
+;; display, type-error tags), so a parameter object allocated by
+;; eshkol_make_parameter was misidentified by (prng? ...) as a PRNG.
+;; HEAP_SUBTYPE_PARAMETER now has its own canonical id (24).
+;;
+;; Note on representations: source-level (make-parameter x) is rewritten by
+;; the parser into a closure over a vector cell, so in compiled programs the
+;; parameter value is CALLABLE, not a HEAP_SUBTYPE_PARAMETER object. The
+;; heap-object path (eshkol_make_parameter, reachable via eval/FFI) is
+;; covered by tests/v1_2_edge_cases/parameter_prng_collision_jit_test.esk,
+;; which is JIT-only because eval is unavailable in AOT binaries. This file
+;; checks the cross-discrimination that must hold in BOTH JIT and AOT.
+
+(require stdlib)
+
+(display "=== parameter/prng subtype discrimination (AOT-safe) ===") (newline)
+
+(define pass-count 0)
+(define fail-count 0)
+(define (check name cond)
+  (if cond
+      (begin (set! pass-count (+ pass-count 1))
+             (display "PASS: ") (display name) (newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "FAIL: ") (display name) (newline))))
+
+;; --- construct one of each --------------------------------------------
+(define my-param (make-parameter 42))
+(define my-prng (make-prng 7))
+
+;; --- type predicates must not cross-identify ---------------------------
+(check "prng? true for a prng object" (prng? my-prng))
+(check "prng? false for a parameter" (not (prng? my-param)))
+(check "parameter? false for a prng object" (not (parameter? my-prng)))
+(check "parameter? false for an integer" (not (parameter? 42)))
+(check "parameter? false for a string" (not (parameter? "hello")))
+(check "prng? false for a string" (not (prng? "hello")))
+(check "prng? false for an integer" (not (prng? 42)))
+
+;; --- parameter behaves as a dynamic binding -----------------------------
+(check "make-parameter default value reads back" (= (my-param) 42))
+(parameterize ((my-param 99))
+  (check "parameterize overrides value in dynamic extent" (= (my-param) 99)))
+(check "parameterize restores value on exit" (= (my-param) 42))
+
+;; --- prng still produces samples -----------------------------------------
+(define sample (prng-random my-prng))
+(check "prng-random stays in [0.0, 1.0)" (and (>= sample 0.0) (< sample 1.0)))
+
+;; --- display distinguishes them -------------------------------------------
+(define (render x)
+  (let ((p (open-output-string)))
+    (display x p)
+    (get-output-string p)))
+
+(define param-repr (render my-param))
+(define prng-repr (render my-prng))
+
+(check "parameter display is non-empty" (> (string-length param-repr) 0))
+(check "prng display is non-empty" (> (string-length prng-repr) 0))
+(check "parameter and prng render differently" (not (string=? param-repr prng-repr)))
+(check "prng display reads #<prng>" (string=? prng-repr "#<prng>"))
+(check "parameter display does not read #<prng>" (not (string=? param-repr "#<prng>")))
+(check "prng display is not the raw-subtype fallback" (not (string=? prng-repr "#<heap:20>")))
+
+(display "---") (newline)
+(display "Total: ") (display (+ pass-count fail-count))
+(display ", PASS: ") (display pass-count)
+(display ", FAIL: ") (display fail-count)
+(newline)
+(if (> fail-count 0) (exit 1))

--- a/tests/v1_2_edge_cases/parameter_prng_collision_jit_test.esk
+++ b/tests/v1_2_edge_cases/parameter_prng_collision_jit_test.esk
@@ -1,0 +1,53 @@
+;; mode: jit
+;; Regression: HEAP_SUBTYPE_PARAMETER used to be locally #define'd as 20 in
+;; lib/core/runtime_parameters_hosted.cpp, colliding with the canonical
+;; HEAP_SUBTYPE_PRNG = 20 (inc/eshkol/eshkol.h). A heap parameter object
+;; allocated by eshkol_make_parameter therefore satisfied (prng? ...) and
+;; displayed via the raw-subtype fallback. HEAP_SUBTYPE_PARAMETER is now 24.
+;;
+;; The heap-object path is only reachable when a `make-parameter` CALL_OP
+;; bypasses the parser's closure rewrite — e.g. through (eval ...) — so this
+;; test is JIT-only (eval is unavailable in AOT binaries).
+
+(require stdlib)
+
+(display "=== parameter/prng heap-subtype collision (JIT eval path) ===") (newline)
+
+(define pass-count 0)
+(define fail-count 0)
+(define (check name cond)
+  (if cond
+      (begin (set! pass-count (+ pass-count 1))
+             (display "PASS: ") (display name) (newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "FAIL: ") (display name) (newline))))
+
+;; Heap parameter object via the runtime allocator (eval bypasses the
+;; parser's make-parameter -> closure rewrite).
+(define heap-param (eval '(make-parameter 5)))
+(define my-prng (make-prng 42))
+
+;; --- the collision symptoms -----------------------------------------------
+(check "prng? is #f for a heap parameter object (was #t pre-fix)"
+       (not (prng? heap-param)))
+(check "parameter? is #t for a heap parameter object" (parameter? heap-param))
+(check "parameter? is #f for a prng object" (not (parameter? my-prng)))
+(check "prng? is #t for a prng object" (prng? my-prng))
+
+;; --- display discriminates --------------------------------------------------
+(define (render x)
+  (let ((p (open-output-string)))
+    (display x p)
+    (get-output-string p)))
+
+(check "heap parameter displays as #<parameter>"
+       (string=? (render heap-param) "#<parameter>"))
+(check "prng displays as #<prng>"
+       (string=? (render my-prng) "#<prng>"))
+
+(display "---") (newline)
+(display "Total: ") (display (+ pass-count fail-count))
+(display ", PASS: ") (display pass-count)
+(display ", FAIL: ") (display fail-count)
+(newline)
+(if (> fail-count 0) (exit 1))


### PR DESCRIPTION
## Verdict: REAL collision (narrow but demonstrable)

`lib/core/runtime_parameters_hosted.cpp` locally `#define`'d `HEAP_SUBTYPE_PARAMETER` as **20**, colliding with the canonical `HEAP_SUBTYPE_PRNG = 20` in `inc/eshkol/eshkol.h`. Both subtypes flow through the same `ESHKOL_VALUE_HEAP_PTR` dispatch (heap-subtype predicates, `display`, `eshkol_format_value_type_tag`, introspection `type-of`).

**Scope**: source-level `(make-parameter x)` is rewritten by the parser into a closure over a vector cell, so most compiled programs never allocate the heap parameter object. But the runtime allocator `eshkol_make_parameter` IS reachable — any `make-parameter` CALL_OP that bypasses the parser rewrite hits the `llvm_codegen.cpp` builtin branch, e.g. through `eval`/sexp_to_ast (and FFI callers).

**Demonstrated on master** (pre-fix):
```scheme
(prng? (eval '(make-parameter 5)))  ; => #t   — parameter misidentified as PRNG
(display (eval '(make-parameter 5))) ; => #<heap:20> fallback
```

## Fix (at the root)
- `HEAP_SUBTYPE_PARAMETER = 24` added to the canonical `heap_subtype_t` table (next free id; 14 stays reserved for RULE); local define deleted.
- Shared subtype readers updated: `eshkol_format_value_type_tag` gains `"parameter"`; `display` gains `#<prng>` / `#<parameter>` cases (both previously fell through to the raw `#<heap:N>` fallback); introspection `type-of` gains `"prng"` / `"parameter"`.
- New `(parameter? obj)` heap-subtype predicate in the LLVM codegen, mirroring `prng?`.

## Compat implications
- **None persisted**: kb-persistence and model_io only serialize STRING/SYMBOL heap subtypes and reject everything else, so no stored format contains the old 20-as-parameter byte; no cache-version bump needed.
- The VM has its own independent subtype namespace (`VM_SUBTYPE_PARAMETER = 23` in vm_numeric.h, `HEAP_PARAMETER = 23` in vm_core.c) — unaffected.
- Note: in compiled programs, source-level parameters remain closures (parser rewrite), so `(parameter? my-param)` is #t only for heap parameter objects (eval/FFI path). Documented in the tests.

## Tests
- `tests/features/parameter_prng_subtype_test.esk` — parameter + PRNG in one program; predicates and display must not cross-identify; parameterize semantics. **17/17 PASS in JIT (-r) and AOT.**
- `tests/v1_2_edge_cases/parameter_prng_collision_jit_test.esk` (`;; mode: jit`) — exercises the real heap-object path via eval; asserts the exact pre-fix symptoms are gone. **6/6 PASS.**

## Verification
Clean Release build (`cmake -B build-sub && cmake --build build-sub -j`), then:
- tests/types: **11/11 PASS**
- tests/features: **29/29 PASS** (includes new test)
- tests/memory: **11/11 PASS**
- new regression test run in both JIT (`-r`) and AOT (compile + run binary)