### PR TITLE
feat(stdlib): core.blc — binary lambda calculus (encode/decode/normal-order eval)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No changes yet since [1.3.1-evolve].
+### Added
+
+- **`core.blc` — Binary Lambda Calculus**: a pure-Eshkol module implementing
+  John Tromp's Binary Lambda Calculus, showcasing the language's
+  lambda-calculus foundations. De Bruijn-indexed terms are represented
+  homoiconically as s-expressions (`(var i)`, `(lam B)`, `(app M N)`);
+  `blc-encode`/`blc-decode` convert to and from Tromp's self-delimiting bit
+  encoding, and `blc-eval` reduces to beta normal form using **normal-order
+  (leftmost-outermost)** reduction with correct De Bruijn shift/substitution
+  and a divergence step-cap. Loaded on demand via `(require core.blc)`. The
+  reference encodings are reproduced exactly (`I` = `0010`, `K` = `0000110`,
+  pairing `λλλ.132` = `0000000101101110110`). See
+  `docs/guide/BINARY_LAMBDA_CALCULUS.md`.
 
 ## [1.3.1-evolve] - 2026-07-09
 

--- a/docs/guide/BINARY_LAMBDA_CALCULUS.md
+++ b/docs/guide/BINARY_LAMBDA_CALCULUS.md
@@ -1,0 +1,128 @@
+# Binary Lambda Calculus in Eshkol
+
+*The `core.blc` module — a pure-Eshkol implementation of John Tromp's
+Binary Lambda Calculus (BLC).*
+
+Eshkol is a compiled R7RS Scheme, and Scheme is lambda calculus with a
+concrete syntax. The `core.blc` module makes that lineage explicit: it
+encodes De Bruijn-indexed lambda terms as bit strings, decodes them back,
+and reduces them to normal form — all in ordinary Eshkol, with terms
+represented as plain s-expressions.
+
+Load it on demand:
+
+```scheme
+(require core.blc)
+```
+
+## Term representation
+
+Terms are homoiconic s-expressions. De Bruijn indices are **1-based**:
+index `1` refers to the innermost enclosing binder.
+
+| Form        | Meaning                          | Constructor         |
+| ----------- | -------------------------------- | ------------------- |
+| `(var i)`   | variable, `i >= 1` (De Bruijn)   | `(blc-var i)`       |
+| `(lam B)`   | abstraction over body `B`        | `(blc-lam B)`       |
+| `(app M N)` | application of `M` to `N`        | `(blc-app M N)`     |
+
+Predicates `blc-var?`, `blc-lam?`, `blc-app?`, `blc-term?` and accessors
+`blc-var-index`, `blc-lam-body`, `blc-app-fun`, `blc-app-arg` are provided.
+Because terms are just lists, a quoted literal such as `'(lam (var 1))` is
+structurally equal to `(blc-lam (blc-var 1))`.
+
+## The bit encoding
+
+BLC encodes a term as bits (Tromp):
+
+| Term          | Encoding                                  |
+| ------------- | ----------------------------------------- |
+| `(lam M)`     | `00` · `blc(M)`                           |
+| `(app M N)`   | `01` · `blc(M)` · `blc(N)`                |
+| `(var i)`     | (`1` repeated `i` times) · `0`  (1-based) |
+
+The encoding is **self-delimiting**: a term's bit string carries its own
+end, so terms can be concatenated unambiguously. `blc-decode` therefore
+parses exactly one term from the front of the string and ignores any
+trailing bits.
+
+Verified reference encodings (reproduced exactly by this module):
+
+| Term                                    | Bits                        |
+| --------------------------------------- | --------------------------- |
+| `I = λx.x` = `(lam (var 1))`            | `0010`                      |
+| `K = λx.λy.x` = `(lam (lam (var 2)))`   | `0000110`                   |
+| pairing `λλλ.((1 3) 2)`                 | `0000000101101110110`       |
+| `S = λx.λy.λz.((x z)(y z))`             | `00000001011110100111010`   |
+
+## API
+
+| Procedure                     | Description                                                        |
+| ----------------------------- | ----------------------------------------------------------------- |
+| `(blc-encode term)`           | Encode a term to a bit string of `#\0`/`#\1` characters.          |
+| `(blc-decode bits)`           | Decode one term; trailing bits ignored. Errors on truncated/invalid input. |
+| `(blc-eval term)`             | Reduce to beta normal form via **normal-order** reduction.        |
+| `(blc-apply program arg)`     | `(blc-eval (blc-app program arg))`.                               |
+| `(blc-shift d cutoff term)`   | De Bruijn shift (raise free indices by `d`).                      |
+| `(blc-subst term j s)`        | De Bruijn substitution of `s` for `(var j)`.                     |
+| `(blc-step term)`             | One leftmost-outermost step; returns `(reduced? . term')`.        |
+| `(blc->debruijn-string term)` | Pretty-printer, e.g. `"λλλ.132"`.                                 |
+
+Predefined terms: `blc-I`, `blc-K`, `blc-S`, the Church booleans
+`blc-true` / `blc-false`, and the divergent `blc-omega`. Their known bit
+strings are `blc-I-bits`, `blc-K-bits`, `blc-S-bits`. The reduction bound
+is `blc-max-steps`.
+
+### Normal-order reduction
+
+`blc-eval` uses **normal-order** (leftmost-outermost) reduction, which is
+required for BLC faithfulness: it reaches a normal form whenever one
+exists, even when a subterm that would diverge is ultimately discarded.
+Eager/applicative order is *wrong* for BLC — it can loop on terms that
+have a perfectly good normal form. Divergent terms are capped at
+`blc-max-steps` reductions, after which `blc-eval` signals
+`"no normal form within step bound"` rather than hanging.
+
+The reducer implements De Bruijn `shift`/`subst` directly; a single beta
+contraction of `(app (lam B) N)` is
+`shift(-1, 1, subst(B, 1, shift(1, 1, N)))`.
+
+## Examples
+
+Exact encoding and round-trip:
+
+```scheme
+(require core.blc)
+
+(blc-encode blc-I)              ; => "0010"
+(blc-encode blc-K)              ; => "0000110"
+(blc-decode "0010")            ; => (lam (var 1))   [= blc-I]
+(equal? blc-K (blc-decode (blc-encode blc-K)))   ; => #t
+```
+
+Evaluation — combinators reduce as expected:
+
+```scheme
+;; K I S = I
+(blc-eval (blc-app (blc-app blc-K blc-I) blc-S))   ; => (lam (var 1))
+
+;; S K K I = I
+(blc-eval (blc-app (blc-app (blc-app blc-S blc-K) blc-K) blc-I))
+                                                   ; => (lam (var 1))
+```
+
+Normal-order in action — a divergent argument is discarded, not evaluated,
+so evaluation terminates (applicative order would loop forever):
+
+```scheme
+;; K I Omega = I   (Omega = (λx.x x)(λx.x x) never gets reduced)
+(blc-eval (blc-app (blc-app blc-K blc-I) blc-omega))   ; => (lam (var 1))
+```
+
+## Reference
+
+John Tromp, *Binary Lambda Calculus*,
+<https://tromp.github.io/cl/Binary_lambda_calculus.html>.
+
+The self-interpreter / universal machine `U` (232 bits) and BLC8 byte-list
+I/O are natural next steps built on this module; they are not included here.

--- a/lib/core/blc.esk
+++ b/lib/core/blc.esk
@@ -1,0 +1,319 @@
+;;; lib/core/blc.esk — Binary Lambda Calculus (BLC) for Eshkol.
+;;;
+;;; A pure-Eshkol implementation of John Tromp's Binary Lambda Calculus:
+;;; a bit-level encoding of De Bruijn-indexed lambda terms, together with
+;;; a faithful normal-order (leftmost-outermost) beta-reducer.
+;;;
+;;; This module showcases Eshkol's lambda-calculus foundations. Terms are
+;;; represented homoiconically as ordinary s-expressions:
+;;;
+;;;   (var i)     ; variable, i a POSITIVE (1-based) De Bruijn index.
+;;;               ; index 1 refers to the innermost enclosing binder.
+;;;   (lam B)     ; abstraction over body B.
+;;;   (app M N)   ; application of M to N.
+;;;
+;;; Encoding (Tromp, https://tromp.github.io/cl/Binary_lambda_calculus.html):
+;;;
+;;;   blc(lam M)  = 00 . blc(M)
+;;;   blc(app M N)= 01 . blc(M) . blc(N)
+;;;   blc(var i)  = (1 repeated i times) . 0        ; i is 1-based
+;;;
+;;; Verified reference encodings (reproduced exactly by this module):
+;;;
+;;;   I = (lam (var 1))                 => "0010"
+;;;   K = (lam (lam (var 2)))           => "0000110"
+;;;   pairing (lam(lam(lam ((1 3) 2)))) => "0000000101101110110"
+;;;
+;;; API:
+;;;   (blc-var i) (blc-lam b) (blc-app m n)   — constructors
+;;;   (blc-var? t) (blc-lam? t) (blc-app? t)  — predicates
+;;;   (blc-term? t)                           — recognises any BLC term
+;;;   (blc-encode term)   -> bit string of #\0 / #\1 characters
+;;;   (blc-decode bits)   -> term (trailing bits ignored; see note below)
+;;;   (blc-eval term)     -> beta normal form (normal-order reduction)
+;;;   (blc-apply p a)     -> (blc-eval (blc-app p a))
+;;;   (blc->debruijn-string term) -> pretty printer, e.g. "λλλ.132"
+;;;   Predefined: blc-I blc-K blc-S  (De Bruijn terms)
+;;;               blc-I-bits blc-K-bits blc-S-bits (their bit strings)
+;;;               blc-true blc-false (Church booleans)
+;;;               blc-omega (divergent term, for testing the step cap)
+;;;
+;;; Decoding note: BLC terms are self-delimiting. (blc-decode) parses one
+;;; complete term starting at the front of the string and silently ignores
+;;; any trailing bits. Truncated / invalid input signals a clear error
+;;; (never crashes or loops).
+;;;
+;;; Reduction note: (blc-eval) uses NORMAL-ORDER (leftmost-outermost)
+;;; reduction to normal form, which is required for BLC faithfulness.
+;;; A step bound (blc-max-steps) guards against divergent terms: exceeding
+;;; it signals "no normal form within step bound".
+
+(provide blc-var blc-lam blc-app
+         blc-var? blc-lam? blc-app? blc-term?
+         blc-var-index blc-lam-body blc-app-fun blc-app-arg
+         blc-encode blc-decode
+         blc-shift blc-subst blc-step blc-eval blc-apply
+         blc->debruijn-string
+         blc-I blc-K blc-S
+         blc-I-bits blc-K-bits blc-S-bits
+         blc-true blc-false blc-omega
+         blc-max-steps)
+
+;; ============================================================================
+;; Term constructors, predicates, accessors
+;; ============================================================================
+
+(define (blc-var i) (list 'var i))
+(define (blc-lam b) (list 'lam b))
+(define (blc-app m n) (list 'app m n))
+
+(define (blc-tagged? t tag)
+  (and (pair? t) (eq? (car t) tag)))
+
+(define (blc-var? t) (blc-tagged? t 'var))
+(define (blc-lam? t) (blc-tagged? t 'lam))
+(define (blc-app? t) (blc-tagged? t 'app))
+
+(define (blc-var-index t) (cadr t))
+(define (blc-lam-body t) (cadr t))
+(define (blc-app-fun t) (cadr t))
+(define (blc-app-arg t) (caddr t))
+
+;; Recognise a structurally well-formed BLC term.
+(define (blc-term? t)
+  (cond
+    ((blc-var? t) (let ((i (blc-var-index t)))
+                    (and (integer? i) (>= i 1))))
+    ((blc-lam? t) (blc-term? (blc-lam-body t)))
+    ((blc-app? t) (and (blc-term? (blc-app-fun t))
+                       (blc-term? (blc-app-arg t))))
+    (else #f)))
+
+;; ============================================================================
+;; Encoding:  term -> bit string
+;; ============================================================================
+
+;; A run of n #\1 characters.
+(define (blc-ones n) (make-string n #\1))
+
+(define (blc-encode term)
+  (cond
+    ((blc-var? term)
+     (let ((i (blc-var-index term)))
+       (if (and (integer? i) (>= i 1))
+           (string-append (blc-ones i) "0")
+           (error "blc-encode: variable index must be a positive integer" i))))
+    ((blc-lam? term)
+     (string-append "00" (blc-encode (blc-lam-body term))))
+    ((blc-app? term)
+     (string-append "01"
+                    (blc-encode (blc-app-fun term))
+                    (blc-encode (blc-app-arg term))))
+    (else
+     (error "blc-encode: not a valid BLC term" term))))
+
+;; ============================================================================
+;; Decoding:  bit string -> term
+;; ============================================================================
+;;
+;; blc-decode-at returns a pair (term . next-position). Errors on any
+;; truncated or malformed input rather than crashing or looping.
+
+(define (blc-decode bits)
+  (if (or (not (string? bits)) (= (string-length bits) 0))
+      (error "blc-decode: empty input, no term to decode")
+      (car (blc-decode-at bits 0 (string-length bits)))))
+
+(define (blc-decode-at bits pos len)
+  (if (>= pos len)
+      (error "blc-decode: unexpected end of input (truncated term)" pos)
+      (let ((c (string-ref bits pos)))
+        (cond
+          ((char=? c #\0) (blc-decode-compound bits pos len))
+          ((char=? c #\1) (blc-decode-var bits pos len 0))
+          (else (error "blc-decode: invalid bit character (expected 0 or 1)" c))))))
+
+;; At a leading #\0: the next bit selects abstraction (0) or application (1).
+(define (blc-decode-compound bits pos len)
+  (if (>= (+ pos 1) len)
+      (error "blc-decode: unexpected end of input after '0'" pos)
+      (let ((c2 (string-ref bits (+ pos 1))))
+        (cond
+          ((char=? c2 #\0)
+           ;; abstraction: "00" . body
+           (let ((body (blc-decode-at bits (+ pos 2) len)))
+             (cons (blc-lam (car body)) (cdr body))))
+          ((char=? c2 #\1)
+           ;; application: "01" . fun . arg
+           (let* ((m (blc-decode-at bits (+ pos 2) len))
+                  (n (blc-decode-at bits (cdr m) len)))
+             (cons (blc-app (car m) (car n)) (cdr n))))
+          (else (error "blc-decode: invalid bit character (expected 0 or 1)" c2))))))
+
+;; At a leading #\1: count the run of 1s, which must be terminated by a 0.
+;; A run of i ones followed by a 0 denotes (var i).
+(define (blc-decode-var bits pos len count)
+  (if (>= pos len)
+      (error "blc-decode: unexpected end of input in variable (missing terminating 0)" pos)
+      (let ((c (string-ref bits pos)))
+        (cond
+          ((char=? c #\1) (blc-decode-var bits (+ pos 1) len (+ count 1)))
+          ((char=? c #\0)
+           (if (= count 0)
+               (error "blc-decode: zero-length variable" pos)
+               (cons (blc-var count) (+ pos 1))))
+          (else (error "blc-decode: invalid bit character (expected 0 or 1)" c))))))
+
+;; ============================================================================
+;; De Bruijn substitution (the subtle part)
+;; ============================================================================
+;;
+;; Indices are 1-based: (var 1) is the innermost binder. We use the
+;; standard shift / substitute pair, adapted to 1-based indexing.
+;;
+;;   blc-shift d c t   adds d to every FREE variable of t, where a variable
+;;                     is free when its index is >= the cutoff c. Going under
+;;                     a binder raises the cutoff by 1.
+;;
+;;   blc-subst t j s   replaces (var j) by s inside t, raising j and shifting
+;;                     s as it descends under binders.
+;;
+;;   Beta:  (app (lam B) N)  ->  shift(-1, 1, subst(B, 1, shift(1, 1, N)))
+
+(define (blc-shift d cutoff term)
+  (cond
+    ((blc-var? term)
+     (let ((k (blc-var-index term)))
+       (if (>= k cutoff) (blc-var (+ k d)) (blc-var k))))
+    ((blc-lam? term)
+     (blc-lam (blc-shift d (+ cutoff 1) (blc-lam-body term))))
+    ((blc-app? term)
+     (blc-app (blc-shift d cutoff (blc-app-fun term))
+              (blc-shift d cutoff (blc-app-arg term))))
+    (else (error "blc-shift: invalid term" term))))
+
+(define (blc-subst term j s)
+  (cond
+    ((blc-var? term)
+     (if (= (blc-var-index term) j) s term))
+    ((blc-lam? term)
+     (blc-lam (blc-subst (blc-lam-body term) (+ j 1) (blc-shift 1 1 s))))
+    ((blc-app? term)
+     (blc-app (blc-subst (blc-app-fun term) j s)
+              (blc-subst (blc-app-arg term) j s)))
+    (else (error "blc-subst: invalid term" term))))
+
+;; Contract a single beta redex (app (lam B) N).
+(define (blc-beta redex)
+  (let ((b (blc-lam-body (blc-app-fun redex)))
+        (n (blc-app-arg redex)))
+    (blc-shift -1 1 (blc-subst b 1 (blc-shift 1 1 n)))))
+
+;; ============================================================================
+;; Normal-order (leftmost-outermost) reduction
+;; ============================================================================
+;;
+;; blc-step performs ONE leftmost-outermost reduction and returns a pair
+;; (reduced? . term). At an application whose head is an abstraction we
+;; contract that (outermost) redex; otherwise we descend into the function
+;; (leftmost) before the argument. We also reduce under abstractions so as
+;; to reach full beta normal form.
+
+(define (blc-step term)
+  (cond
+    ((blc-var? term) (cons #f term))
+    ((blc-lam? term)
+     (let ((r (blc-step (blc-lam-body term))))
+       (if (car r)
+           (cons #t (blc-lam (cdr r)))
+           (cons #f term))))
+    ((blc-app? term)
+     (let ((m (blc-app-fun term))
+           (n (blc-app-arg term)))
+       (if (blc-lam? m)
+           ;; leftmost-outermost redex: contract it now
+           (cons #t (blc-beta term))
+           ;; otherwise reduce the function first, then the argument
+           (let ((rm (blc-step m)))
+             (if (car rm)
+                 (cons #t (blc-app (cdr rm) n))
+                 (let ((rn (blc-step n)))
+                   (if (car rn)
+                       (cons #t (blc-app m (cdr rn)))
+                       (cons #f term))))))))
+    (else (error "blc-step: invalid term" term))))
+
+;; Upper bound on reduction steps before declaring divergence.
+(define blc-max-steps 1000000)
+
+(define (blc-eval term)
+  (blc-eval-loop term 0))
+
+(define (blc-eval-loop term steps)
+  (if (> steps blc-max-steps)
+      (error "blc-eval: no normal form within step bound" blc-max-steps)
+      (let ((r (blc-step term)))
+        (if (car r)
+            (blc-eval-loop (cdr r) (+ steps 1))
+            term))))
+
+(define (blc-apply program arg)
+  (blc-eval (blc-app program arg)))
+
+;; ============================================================================
+;; Pretty printer  ("λλλ.132" De Bruijn style)
+;; ============================================================================
+
+(define (blc->debruijn-string term)
+  (cond
+    ((blc-var? term) (number->string (blc-var-index term)))
+    ((blc-lam? term)
+     (let ((body (blc-lam-body term)))
+       (if (blc-lam? body)
+           (string-append "λ" (blc->debruijn-string body))
+           (string-append "λ." (blc->debruijn-string body)))))
+    ((blc-app? term)
+     (string-append (blc-render-fun (blc-app-fun term))
+                    (blc-render-arg (blc-app-arg term))))
+    (else (error "blc->debruijn-string: invalid term" term))))
+
+;; Left operand of an application: parenthesise only abstractions
+;; (application is left-associative, variables need no parens).
+(define (blc-render-fun t)
+  (if (blc-lam? t)
+      (string-append "(" (blc->debruijn-string t) ")")
+      (blc->debruijn-string t)))
+
+;; Right operand: parenthesise anything compound (abstraction or application).
+(define (blc-render-arg t)
+  (if (blc-var? t)
+      (blc->debruijn-string t)
+      (string-append "(" (blc->debruijn-string t) ")")))
+
+;; ============================================================================
+;; Predefined terms
+;; ============================================================================
+
+;; I = λx.x
+(define blc-I (blc-lam (blc-var 1)))
+;; K = λx.λy.x
+(define blc-K (blc-lam (blc-lam (blc-var 2))))
+;; S = λx.λy.λz. (x z)(y z)   (x=3, y=2, z=1 under all three binders)
+(define blc-S
+  (blc-lam (blc-lam (blc-lam
+    (blc-app (blc-app (blc-var 3) (blc-var 1))
+             (blc-app (blc-var 2) (blc-var 1)))))))
+
+;; Church booleans: true = λx.λy.x (= K), false = λx.λy.y.
+(define blc-true (blc-lam (blc-lam (blc-var 2))))
+(define blc-false (blc-lam (blc-lam (blc-var 1))))
+
+;; Omega = (λx.x x)(λx.x x) — has no normal form; used to exercise the cap.
+(define blc-omega
+  (blc-app (blc-lam (blc-app (blc-var 1) (blc-var 1)))
+           (blc-lam (blc-app (blc-var 1) (blc-var 1)))))
+
+;; Known bit strings (verified against Tromp's grammar).
+(define blc-I-bits "0010")
+(define blc-K-bits "0000110")
+(define blc-S-bits "00000001011110100111010")

--- a/tests/features/blc_test.esk
+++ b/tests/features/blc_test.esk
@@ -1,0 +1,160 @@
+;; Binary Lambda Calculus (core.blc) test suite.
+;;
+;; Verifies, against John Tromp's primary source
+;;   (https://tromp.github.io/cl/Binary_lambda_calculus.html):
+;;   1. Exact bit encodings of I, K and the pairing term.
+;;   2. encode/decode round-trips.
+;;   3. Normal-order (leftmost-outermost) evaluation, including that a
+;;      divergent-but-discarded argument does NOT cause non-termination
+;;      (which it would under applicative/eager order).
+;;   4. Robustness: truncated/invalid bit strings signal errors, never
+;;      crash or hang.
+;;
+;; Self-asserting: prints PASS/FAIL per case and a summary, exits 1 on any
+;; failure.
+
+(require core.blc)
+
+(define tests-passed 0)
+(define tests-failed 0)
+
+(define (check name ok)
+  (if ok
+      (begin
+        (set! tests-passed (+ tests-passed 1))
+        (display "PASS: ") (display name) (newline))
+      (begin
+        (set! tests-failed (+ tests-failed 1))
+        (display "FAIL: ") (display name) (newline))))
+
+(define (check-equal name expected actual)
+  (if (equal? expected actual)
+      (begin
+        (set! tests-passed (+ tests-passed 1))
+        (display "PASS: ") (display name) (newline))
+      (begin
+        (set! tests-failed (+ tests-failed 1))
+        (display "FAIL: ") (display name)
+        (display " (expected ") (display expected)
+        (display ", got ") (display actual) (display ")") (newline))))
+
+;; Did (thunk) raise an error?  Returns #t if it did.
+(define (raised? thunk)
+  (guard (exn (#t #t))
+    (thunk)
+    #f))
+
+;; The pairing term  λλλ.((1 3) 2).
+(define blc-pair
+  (blc-lam (blc-lam (blc-lam
+    (blc-app (blc-app (blc-var 1) (blc-var 3)) (blc-var 2))))))
+
+;; ============================================================================
+;; 1. Exact encodings (ground truth from Tromp)
+;; ============================================================================
+(display "=== 1. Exact encodings ===") (newline)
+
+(check-equal "encode I = 0010"                (blc-encode blc-I)   "0010")
+(check-equal "encode K = 0000110"             (blc-encode blc-K)   "0000110")
+(check-equal "encode pairing = 0000000101101110110"
+             (blc-encode blc-pair) "0000000101101110110")
+(check-equal "encode S = 00000001011110100111010"
+             (blc-encode blc-S)   "00000001011110100111010")
+;; The predefined bit strings agree with the encoder.
+(check-equal "blc-I-bits matches encoder" blc-I-bits (blc-encode blc-I))
+(check-equal "blc-K-bits matches encoder" blc-K-bits (blc-encode blc-K))
+(check-equal "blc-S-bits matches encoder" blc-S-bits (blc-encode blc-S))
+
+;; ============================================================================
+;; 2. Round-trips:  decode . encode = identity (structurally)
+;; ============================================================================
+(display "=== 2. Round-trips ===") (newline)
+
+(define (roundtrip name t)
+  (check-equal (string-append "roundtrip " name) t (blc-decode (blc-encode t))))
+
+(roundtrip "I" blc-I)
+(roundtrip "K" blc-K)
+(roundtrip "S" blc-S)
+(roundtrip "pairing" blc-pair)
+(roundtrip "var 5" (blc-var 5))
+(roundtrip "app I K" (blc-app blc-I blc-K))
+(roundtrip "lam(app (var 1)(var 2))"
+           (blc-lam (blc-app (blc-var 1) (blc-var 2))))
+(roundtrip "nested app ((K I) S)"
+           (blc-app (blc-app blc-K blc-I) blc-S))
+;; Trailing bits are ignored (terms are self-delimiting): "0010" is I,
+;; and "0010" + junk still decodes to I.
+(check-equal "decode ignores trailing bits"
+             blc-I (blc-decode (string-append blc-I-bits "1101")))
+
+;; ============================================================================
+;; 3. Evaluation (normal-order, structural normal-form comparison)
+;; ============================================================================
+(display "=== 3. Evaluation ===") (newline)
+
+;; I X = X
+(check-equal "I K = K" blc-K (blc-eval (blc-app blc-I blc-K)))
+;; K X Y = X
+(check-equal "K I S = I"
+             blc-I (blc-eval (blc-app (blc-app blc-K blc-I) blc-S)))
+;; S K K = I  (as normal forms): S K K applied to anything acts as identity.
+(check-equal "S K K I = I"
+             (blc-eval blc-I)
+             (blc-eval (blc-app (blc-app (blc-app blc-S blc-K) blc-K) blc-I)))
+(check-equal "S K K K = K"
+             (blc-eval blc-K)
+             (blc-eval (blc-app (blc-app (blc-app blc-S blc-K) blc-K) blc-K)))
+;; blc-apply agrees with (blc-eval (app ...))
+(check-equal "blc-apply I K = K" blc-K (blc-apply blc-I blc-K))
+
+;; Normal-order proof: K I Omega = I. The divergent Omega is DISCARDED by K
+;; and never reduced. Eager/applicative order would loop forever here; a
+;; normal-order reducer reaches I.
+(check-equal "K I Omega = I  (divergent arg discarded, normal-order)"
+             blc-I
+             (blc-eval (blc-app (blc-app blc-K blc-I) blc-omega)))
+
+;; Church booleans select correctly: true X Y = X, false X Y = Y.
+(check-equal "true K I = K"
+             blc-K (blc-eval (blc-app (blc-app blc-true blc-K) blc-I)))
+(check-equal "false K I = I"
+             blc-I (blc-eval (blc-app (blc-app blc-false blc-K) blc-I)))
+
+;; Omega alone has no normal form: blc-eval must signal the step-cap error,
+;; not hang. (raised? drives it and confirms an error was signalled.)
+(check "Omega has no normal form -> step-cap error signalled"
+       (raised? (lambda () (blc-eval blc-omega))))
+
+;; ============================================================================
+;; 4. Robustness: truncated / invalid input signals errors (no crash/hang)
+;; ============================================================================
+(display "=== 4. Robustness ===") (newline)
+
+(check "decode \"\"  signals error"   (raised? (lambda () (blc-decode ""))))
+(check "decode \"1\" signals error"   (raised? (lambda () (blc-decode "1"))))
+(check "decode \"0\" signals error"   (raised? (lambda () (blc-decode "0"))))
+(check "decode \"00\" (missing body) signals error"
+       (raised? (lambda () (blc-decode "00"))))
+(check "decode \"01\" (missing operands) signals error"
+       (raised? (lambda () (blc-decode "01"))))
+(check "decode \"0101\" (missing 2nd operand) signals error"
+       (raised? (lambda () (blc-decode "0101"))))
+(check "decode \"0x\" (invalid char) signals error"
+       (raised? (lambda () (blc-decode "0x"))))
+;; And a valid truncation boundary: "0010" is fine (I), "001" is truncated.
+(check "decode \"001\" (truncated var body) signals error"
+       (raised? (lambda () (blc-decode "001"))))
+(check-equal "decode \"0010\" = I  (valid, for contrast)"
+             blc-I (blc-decode "0010"))
+
+;; ============================================================================
+;; Summary
+;; ============================================================================
+(newline)
+(display "==== SUMMARY ====") (newline)
+(display "Passed: ") (display tests-passed) (newline)
+(display "Failed: ") (display tests-failed) (newline)
+(if (> tests-failed 0)
+    (begin (display "RESULT: FAIL") (newline) (exit 1))
+    (begin (display "RESULT: PASS") (newline)))


### PR DESCRIPTION
## Summary

Adds `lib/core/blc.esk`, a pure-Eshkol implementation of John Tromp's
**Binary Lambda Calculus** — a v1.3.x showcase of the language's
lambda-calculus foundations. De Bruijn-indexed terms are represented
homoiconically as s-expressions; the module encodes/decodes them to and
from Tromp's self-delimiting bit encoding and reduces them to beta normal
form using **normal-order (leftmost-outermost)** reduction.

Loaded on demand via `(require core.blc)`. Path-based module resolution
(`core.blc` -> `lib/core/blc.esk`) means no manifest edit is needed — this
mirrors `core.msgpack` (a specialized, require-only module not auto-loaded
into the default stdlib).

## Design

Terms (1-based De Bruijn indices; index 1 = innermost binder):

- `(var i)` / `(lam B)` / `(app M N)`, with constructors `blc-var`/`blc-lam`/
  `blc-app`, predicates, and accessors. Terms are plain lists, so quoted
  literals like `'(lam (var 1))` are `equal?` to constructed terms.

Encoding (Tromp):

- `blc(lam M)  = 00 · blc(M)`
- `blc(app M N)= 01 · blc(M) · blc(N)`
- `blc(var i)  = (1 × i) · 0`

De Bruijn substitution — the subtle part — is implemented directly:
`blc-shift d cutoff t` raises free indices, `blc-subst t j s` substitutes,
and a single beta contraction of `(app (lam B) N)` is
`shift(-1, 1, subst(B, 1, shift(1, 1, N)))`. `blc-eval` repeatedly applies
the leftmost-outermost `blc-step` until no redex remains, capped at
`blc-max-steps` (1,000,000) reductions — divergent terms signal
`"no normal form within step bound"` rather than hanging.

## API

`blc-var`/`blc-lam`/`blc-app` (+ predicates/accessors), `blc-term?`,
`blc-encode`, `blc-decode`, `blc-shift`, `blc-subst`, `blc-step`,
`blc-eval`, `blc-apply`, `blc->debruijn-string`. Predefined: `blc-I`,
`blc-K`, `blc-S`, `blc-true`, `blc-false`, `blc-omega`, `blc-I-bits`,
`blc-K-bits`, `blc-S-bits`, `blc-max-steps`.

## Exact-encoding verification (ground truth from Tromp)

| Term | Bits |
| --- | --- |
| `I = (lam (var 1))` | `0010` |
| `K = (lam (lam (var 2)))` | `0000110` |
| pairing `λλλ.((1 3) 2)` | `0000000101101110110` |
| `S = λλλ.((3 1)(2 1))` | `00000001011110100111010` |

All four reproduced exactly by `blc-encode`. Pretty-printer confirms
`(blc->debruijn-string pairing)` = `λλλ.132`.

## Decode note

BLC terms are self-delimiting; `blc-decode` parses one term from the front
and ignores trailing bits (verified: `"0010"` + junk still decodes to `I`).
Truncated/invalid input (`""`, `"0"`, `"1"`, `"00"`, `"01"`, `"0101"`,
`"001"`, `"0x"`) signals a clear error — never crashes or loops.

## Test results — `tests/features/blc_test.esk` (34 assertions)

Run in **both** JIT (`eshkol-run -r`) and AOT (compiled binary): **34/34
PASS, exit 0** in both modes. Coverage:

1. Exact encodings (I/K/pairing/S + `*-bits` agree with the encoder).
2. Round-trips: `decode(encode(t)) = t` for I/K/S/pairing and several
   hand-built terms; trailing-bit tolerance.
3. Evaluation (normal-order, structural NF comparison): `I K = K`;
   `K I S = I`; `S K K I = I`; `S K K K = K`; Church-boolean selection;
   and the key normal-order proof `K I Omega = I` — the divergent `Omega`
   argument is **discarded, not reduced** (applicative order would loop).
   `blc-eval` on `Omega` alone hits the step-cap and signals an error.
4. Robustness: all truncated/invalid inputs signal errors.

The module also compiles cleanly via the `--shared-lib` precompile path,
and the `tests/modules` suite (module/stdlib/import/visibility/cycle/
define-library) still passes.

## Docs

- `docs/guide/BINARY_LAMBDA_CALCULUS.md` — encoding table, API, runnable
  examples, and citation to Tromp's page.
- CHANGELOG `[Unreleased]` note.

## Limitation

The self-interpreter / universal machine `U` (232 bits) and BLC8 byte-list
I/O are left as a documented stretch, built naturally on this module.

## Reference

John Tromp, *Binary Lambda Calculus*,
https://tromp.github.io/cl/Binary_lambda_calculus.html