### PR TITLE
fix(memory): deep transitive escape promotion for with-region + mutation write barrier

### DIFF
--- a/inc/eshkol/backend/codegen_context.h
+++ b/inc/eshkol/backend/codegen_context.h
@@ -193,6 +193,28 @@ public:
     /** Get the lambda name a function returns (or empty string) */
     std::string getFunctionReturnsLambda(const std::string& funcName) const;
 
+    // === Region Write Barrier (ESH-0214c) ===
+
+    /**
+     * Emit a region write barrier for a value about to be stored into a
+     * longer-lived destination (vector-set!/set-car!/set-cdr!/hash-table-set!/
+     * global set!). Returns the (possibly deep-promoted) tagged value to store.
+     *
+     * The value is spilled to an entry-block alloca and routed through the
+     * runtime helper eshkol_region_write_barrier_into, whose fast path (no
+     * active region) is a single thread-local load + branch. If a region is
+     * active and @p tagged_value points into a region strictly inner than the
+     * one owning @p dst_ptr, its reachable in-region subgraph is evacuated into
+     * the surviving arena so it does not dangle after region_pop.
+     *
+     * @param dst_ptr      Address of the container/slot being written (used only
+     *                     to locate the destination's owning region).
+     * @param tagged_value The value being stored (must be taggedValueType()).
+     * @return             The value to store (barriered when necessary).
+     */
+    llvm::Value* emitRegionWriteBarrier(llvm::Value* dst_ptr,
+                                        llvm::Value* tagged_value);
+
     // === Global Variables (Arena, AD State) ===
 
     /** Get/set the global arena variable */

--- a/lib/backend/codegen_context.cpp
+++ b/lib/backend/codegen_context.cpp
@@ -12,8 +12,56 @@
 #ifdef ESHKOL_LLVM_BACKEND_ENABLED
 
 #include <llvm/IR/Constants.h>
+#include <llvm/IR/Function.h>
 
 namespace eshkol {
+
+// ESH-0214c: emit the region write barrier around a store of a tagged value
+// into a longer-lived destination. Spills value + result to entry-block allocas
+// (so the pattern is safe inside loop bodies) and calls the runtime helper.
+llvm::Value* CodegenContext::emitRegionWriteBarrier(llvm::Value* dst_ptr,
+                                                    llvm::Value* tagged_value) {
+    if (!tagged_value || tagged_value->getType() != taggedValueType()) {
+        // Only tagged values can carry a heap pointer that might dangle.
+        return tagged_value;
+    }
+
+    llvm::Type* tv_ty = taggedValueType();
+    llvm::PointerType* ptr_ty = ptrType();
+
+    // Hoist the spill/result slots to the function entry block: an alloca in a
+    // loop body re-adjusts the stack pointer every iteration and is only
+    // reclaimed at function return.
+    llvm::Function* fn = builder_.GetInsertBlock()->getParent();
+    llvm::IRBuilderBase::InsertPoint saved_ip = builder_.saveIP();
+    if (fn && !fn->empty()) {
+        llvm::BasicBlock& entry = fn->getEntryBlock();
+        builder_.SetInsertPoint(&entry, entry.begin());
+    }
+    llvm::AllocaInst* val_slot = builder_.CreateAlloca(tv_ty, nullptr, "wb_val_slot");
+    llvm::AllocaInst* out_slot = builder_.CreateAlloca(tv_ty, nullptr, "wb_out_slot");
+    builder_.restoreIP(saved_ip);
+
+    builder_.CreateStore(tagged_value, val_slot);
+
+    llvm::Function* wb = module_.getFunction("eshkol_region_write_barrier_into");
+    if (!wb) {
+        llvm::FunctionType* wb_ty = llvm::FunctionType::get(
+            voidType(), {ptr_ty, ptr_ty, ptr_ty}, false);
+        wb = llvm::Function::Create(wb_ty, llvm::GlobalValue::ExternalLinkage,
+                                    "eshkol_region_write_barrier_into", &module_);
+    }
+
+    llvm::Value* dst_cast = dst_ptr;
+    if (dst_ptr && dst_ptr->getType() != ptr_ty) {
+        dst_cast = builder_.CreateBitCast(dst_ptr, ptr_ty);
+    } else if (!dst_ptr) {
+        dst_cast = llvm::ConstantPointerNull::get(ptr_ty);
+    }
+
+    builder_.CreateCall(wb, {out_slot, dst_cast, val_slot});
+    return builder_.CreateLoad(tv_ty, out_slot, "wb_result");
+}
 
 CodegenContext::CodegenContext(llvm::LLVMContext& llvm_ctx,
                                llvm::Module& llvm_mod,

--- a/lib/backend/collection_codegen.cpp
+++ b/lib/backend/collection_codegen.cpp
@@ -2149,7 +2149,12 @@ llvm::Value* CollectionCodegen::vectorSet(const eshkol_operations_t* op) {
             llvm::ConstantInt::get(ctx_.int64Type(), 8));
         llvm::Value* elem_base_typed = ctx_.builder().CreatePointerCast(elem_base, ctx_.ptrType());
         llvm::Value* elem_ptr = ctx_.builder().CreateGEP(ctx_.taggedValueType(), elem_base_typed, idx);
-        ctx_.builder().CreateStore(tagged_val, elem_ptr);
+        // ESH-0214c region write barrier: if a region is active and `tagged_val`
+        // points into it while this vector lives outside it, deep-promote the
+        // value's subgraph so it survives region_pop. Fast path (no region) is a
+        // single load+branch inside the runtime helper.
+        llvm::Value* barriered = ctx_.emitRegionWriteBarrier(vec_ptr, tagged_val);
+        ctx_.builder().CreateStore(barriered, elem_ptr);
         ctx_.builder().CreateBr(vset_merge);
     }
 
@@ -2253,6 +2258,23 @@ llvm::Value* CollectionCodegen::vectorCopy(const eshkol_operations_t* op) {
         dest_ptr, llvm::MaybeAlign(8),
         src_ptr, llvm::MaybeAlign(8),
         byte_count);
+
+    // ESH-0214c region write barrier (range form): the copied slots may hold
+    // region-allocated values while `to` lives outside the region; promote each
+    // in place. Fast path (no active region) is one load+branch in the runtime.
+    {
+        llvm::Function* wb_range =
+            ctx_.module().getFunction("eshkol_region_write_barrier_range");
+        if (!wb_range) {
+            llvm::FunctionType* wb_ty = llvm::FunctionType::get(
+                ctx_.builder().getVoidTy(),
+                {ctx_.ptrType(), ctx_.ptrType(), ctx_.int64Type()}, false);
+            wb_range = llvm::Function::Create(
+                wb_ty, llvm::GlobalValue::ExternalLinkage,
+                "eshkol_region_write_barrier_range", &ctx_.module());
+        }
+        ctx_.builder().CreateCall(wb_range, {to_ptr, dest_ptr, count});
+    }
 
     return tagged_.packNull();
 }
@@ -2601,6 +2623,12 @@ llvm::Value* CollectionCodegen::vectorFill(const eshkol_operations_t* op) {
     // Extract vector pointer and length
     llvm::Value* vec_ptr = ctx_.builder().CreateIntToPtr(tagged_.unpackInt64(vec_arg), ctx_.ptrType());
     llvm::Value* length = ctx_.builder().CreateLoad(ctx_.int64Type(), vec_ptr, "vfill_len");
+
+    // ESH-0214c region write barrier: like vector-set!, vector-fill! can store a
+    // region value into an outer vector. One barrier call suffices — every slot
+    // receives the same (possibly promoted) value.
+    if (fill_val->getType() == ctx_.taggedValueType())
+        fill_val = ctx_.emitRegionWriteBarrier(vec_ptr, fill_val);
 
     // Get element base
     llvm::Value* elem_base = ctx_.builder().CreateGEP(ctx_.int8Type(), vec_ptr,

--- a/lib/backend/hash_codegen.cpp
+++ b/lib/backend/hash_codegen.cpp
@@ -356,6 +356,15 @@ llvm::Value* HashCodegen::hashSet(const eshkol_operations_t* op) {
     // Extract table pointer
     llvm::Value* table_ptr = tagged_.unpackPtr(table_arg);
 
+    // ESH-0214c region write barrier: the table's backing arrays live in the
+    // table's home_arena (which may be an OUTER arena while a region is active).
+    // Deep-promote any region-allocated key/value subgraph into that home arena
+    // so it survives region_pop. Fast path (no region) is a single load+branch.
+    if (key_arg->getType() == ctx_.taggedValueType())
+        key_arg = ctx_.emitRegionWriteBarrier(table_ptr, key_arg);
+    if (value_arg->getType() == ctx_.taggedValueType())
+        value_arg = ctx_.emitRegionWriteBarrier(table_ptr, value_arg);
+
     // Get arena pointer
     llvm::Value* arena_ptr = builder.CreateLoad(
         llvm::PointerType::get(context, 0), ctx_.globalArena());

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -12530,6 +12530,21 @@ private:
                 }
             }
 
+            // ESH-0214c region write barrier: a set! that stores a region-
+            // allocated value into a GLOBAL variable (which outlives every
+            // region) would leave the global holding a dangling pointer after
+            // region_pop. Deep-promote such a value into the global arena.
+            // Restricted to GlobalVariable destinations: plain local allocas and
+            // closure-capture pointers are conservatively NOT barriered here to
+            // avoid over-promoting values that never actually cross a region
+            // boundary (see runtime_regions.cpp / PR notes). Fast path (no active
+            // region) is a single load+branch in the runtime helper.
+            if (ctx_ && store_type == tagged_value_type &&
+                isa<GlobalVariable>(var_ptr) &&
+                store_value->getType() == tagged_value_type) {
+                store_value = ctx_->emitRegionWriteBarrier(var_ptr, store_value);
+            }
+
             builder->CreateStore(store_value, var_ptr);
             eshkol_debug("set! updated variable: %s", var_name);
 
@@ -35132,6 +35147,12 @@ private:
         // it to an entry-block alloca and pass the pointer to the
         // tagged-value cons setter (same call used by allocConsCell).
         if (new_value->getType() == tagged_value_type) {
+            // ESH-0214c region write barrier: set-car!/set-cdr! can splice a
+            // region-allocated value into a pair that lives outside the region;
+            // deep-promote it so it survives region_pop. Fast path (no active
+            // region) is a single load+branch in the runtime helper.
+            Value* barriered = ctx_ ? ctx_->emitRegionWriteBarrier(cons_ptr, new_value)
+                                    : new_value;
             IRBuilderBase::InsertPoint saved_ip = builder->saveIP();
             Function* func = builder->GetInsertBlock()->getParent();
             if (func && !func->empty()) {
@@ -35140,7 +35161,7 @@ private:
             }
             Value* tv_slot = builder->CreateAlloca(tagged_value_type, nullptr, "set_pair_tv");
             builder->restoreIP(saved_ip);
-            builder->CreateStore(new_value, tv_slot);
+            builder->CreateStore(barriered, tv_slot);
             builder->CreateCall(getTaggedConsSetTaggedValueFunc(),
                                 {cons_ptr, slot_flag, tv_slot});
             return new_value;

--- a/lib/core/arena_memory.h
+++ b/lib/core/arena_memory.h
@@ -317,6 +317,23 @@ struct eshkol_region {
     size_t size_hint;                // Size hint provided at creation
     size_t escape_count;             // Track escaping allocations
     uint8_t is_active;               // Whether this region is currently active
+    // ESH-0214c: the arena that outlives this region — where escaping values are
+    // promoted to. Captured at region_push (BEFORE with-region codegen hijacks
+    // the __global_arena slot to point at this region's arena), so it is the
+    // TRUE enclosing arena: the parent region's arena when nested, or the real
+    // process/global arena at top level. Must NOT be recomputed from
+    // get_global_arena() at escape time, which by then returns this very region.
+    arena_t* escape_base;
+    // ESH-0214c: persistent forwarding map (old data ptr -> promoted copy) for
+    // deep escape promotion, living for exactly this region's lifetime. Keys
+    // reference memory in this region (or an enclosing one), values reference
+    // fwd_target -- both strictly outlive the map, which region_destroy frees.
+    // Persisting it across separate escapes preserves shared structure (two
+    // stores of lists sharing a tail keep sharing it) and makes re-storing an
+    // already-escaped object free. Opaque (std::unordered_map) -- only
+    // runtime_regions.cpp touches it.
+    void* fwd_map;
+    arena_t* fwd_target;   // target arena the fwd_map entries were promoted into
 };
 
 // Thread-local region stack (safe for parallel-map + with-region)
@@ -362,6 +379,19 @@ void* region_escape_string(const char* str);
 arena_tagged_cons_cell_t* region_escape_tagged_cons_cell(const arena_tagged_cons_cell_t* cell);
 eshkol_tagged_value_t region_escape_tagged_value(eshkol_tagged_value_t val);
 void region_escape_tagged_value_into(eshkol_tagged_value_t* out, const eshkol_tagged_value_t* val);
+
+// Region write barrier (ESH-0214c): promote a value's in-region subgraph when it
+// is stored (by set-car!/set-cdr!/vector-set!/hash-table-set!/global set!) into a
+// destination that outlives the value's region. Fast path (no active region) is a
+// single thread-local load + branch. See runtime_regions.cpp for full semantics.
+void eshkol_region_write_barrier_into(eshkol_tagged_value_t* out,
+                                      const void* dst,
+                                      const eshkol_tagged_value_t* value);
+// Range form for bulk copies (vector-copy!): promotes each copied slot in
+// place. Fast path (no region) is a single thread-local load + branch.
+void eshkol_region_write_barrier_range(const void* dst,
+                                       eshkol_tagged_value_t* slots,
+                                       uint64_t n);
 
 // Region statistics
 size_t region_get_used_memory(const eshkol_region_t* region);

--- a/lib/core/runtime_regions.cpp
+++ b/lib/core/runtime_regions.cpp
@@ -15,6 +15,9 @@
 
 #include <cstring>
 #include <cstdlib>
+#include <unordered_map>
+#include <vector>
+#include <utility>
 
 void eshkol_arena_global_once(void (*init)(void));
 
@@ -275,6 +278,9 @@ eshkol_region_t* region_create(const char* name, size_t size_hint) {
     region->size_hint = size_hint;
     region->escape_count = 0;
     region->is_active = 0;
+    region->escape_base = nullptr;  // captured at region_push (see ESH-0214c)
+    region->fwd_map = nullptr;      // lazily created at first deep escape
+    region->fwd_target = nullptr;
 
     eshkol_debug("Created region '%s' with size hint %zu",
                  name ? name : "(anonymous)", size_hint);
@@ -295,6 +301,9 @@ eshkol_region_t* region_create(const char* name, size_t size_hint) {
  *
  * @param region Region to destroy (no-op if NULL).
  */
+// Defined below (after the evacuator's map type) -- frees region->fwd_map.
+static void region_free_fwd_map(eshkol_region_t* region);
+
 void region_destroy(eshkol_region_t* region) {
     if (!region) return;
 
@@ -313,6 +322,10 @@ void region_destroy(eshkol_region_t* region) {
         arena_destroy(region->arena);
         region->arena = nullptr;
     }
+
+    // ESH-0214c: the deep-escape forwarding map's keys reference this region's
+    // (now freed) arena; drop it with the region.
+    region_free_fwd_map(region);
 
     // ESH-0214: region->name and the region struct itself are malloc'd (see
     // region_create) precisely so this call is a complete, bounded release --
@@ -346,6 +359,20 @@ void region_push(eshkol_region_t* region) {
 
     region->parent = (__region_stack_depth > 0) ?
         __region_stack[__region_stack_depth - 1] : nullptr;
+
+    // ESH-0214c: capture the arena that outlives this region NOW, before the
+    // with-region codegen overwrites the __global_arena allocation slot with
+    // this region's arena. At this instant that slot still holds the true
+    // enclosing arena (the parent region's arena when nested, or the real
+    // process/global arena at top level), which is exactly where escaping values
+    // must be promoted. Prefer the parent region's own arena when nested (robust
+    // even if callers push without going through with-region codegen).
+    if (region->parent && region->parent->arena) {
+        region->escape_base = region->parent->arena;
+    } else {
+        region->escape_base = get_global_arena();
+    }
+
     region->is_active = 1;
     __region_stack[__region_stack_depth++] = region;
 
@@ -483,6 +510,14 @@ uint64_t region_get_depth(void) {
  * @return        Arena the escaped copy should be allocated in.
  */
 static arena_t* region_escape_target(eshkol_region_t* current) {
+    // ESH-0214c: escape_base is captured at region_push and is the arena that
+    // genuinely outlives this region. It must be used instead of
+    // get_global_arena(), which during a with-region body has been hijacked by
+    // codegen to point at THIS region's arena (so escaping through it would copy
+    // the value straight back into the arena about to be freed).
+    if (current->escape_base) {
+        return current->escape_base;
+    }
     if (current->parent && current->parent->arena) {
         return current->parent->arena;
     }
@@ -584,16 +619,388 @@ arena_tagged_cons_cell_t* region_escape_tagged_cons_cell(const arena_tagged_cons
     return copy;
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// DEEP TRANSITIVE ESCAPE PROMOTION (evacuation) — ESH-0214c
+//
+// A region's arena is torn down at region_pop. A value that escapes the region
+// (returned as the with-region body result, or stored by mutation into an outer
+// container) must have its ENTIRE reachable subgraph that lives in the dying
+// region copied out first, otherwise the escaped object keeps interior pointers
+// (car/cdr, vector slots, captured env, hash key/value arrays, tensor buffers)
+// aimed into freed memory -> "car/cdr: argument is not a pair" corruption.
+//
+// The evacuator is a Cheney-style copying collector restricted to the escaping
+// subgraph: a forwarding map (old data-ptr -> new data-ptr) preserves shared
+// structure and terminates on cycles, and a worklist drives a breadth-first
+// walk so arbitrarily deep lists do not overflow the native stack.
+//
+// A node is COPIED iff it lives in an active region strictly INNER than the
+// destination's owning region (`boundary_idx`); anything at-or-outside the
+// boundary (an ancestor region, the global arena, static/stack storage) already
+// outlives the destination and is left in place (forwarding identity). This is
+// correct for nested regions: escaping to the global arena copies everything in
+// any active region; escaping to region D copies only what lives in D's
+// descendants.
+// ───────────────────────────────────────────────────────────────────────────
+
+// Walk an arena's block chain and test raw containment. Region arenas are
+// non-thread-safe single-owner arenas (region_create uses arena_create), so no
+// locking is required here.
+static bool arena_contains_ptr(const arena_t* a, const void* p) {
+    if (!a || !p) return false;
+    const uint8_t* q = (const uint8_t*)p;
+    for (const arena_block_t* b = a->current_block; b; b = b->next) {
+        if (q >= b->memory && q < b->memory + b->used) return true;
+    }
+    return false;
+}
+
+// Index (into __region_stack) of the innermost active region whose arena
+// contains @p p, or -1 if @p p is not inside any active region arena (i.e. it
+// lives in the global/thread arena or in static/stack storage).
+static int region_index_owning(const void* p) {
+    for (int i = (int)__region_stack_depth - 1; i >= 0; --i) {
+        eshkol_region_t* r = __region_stack[i];
+        if (r && r->arena && arena_contains_ptr(r->arena, p)) return i;
+    }
+    return -1;
+}
+
+namespace {
+
+// How to traverse a copied object's interior after the contiguous header+payload
+// copy. EVAC_LEAF objects are self-contained (no interior region pointers) and
+// need no further work.
+enum EvacKind : uint8_t {
+    EVAC_LEAF = 0,
+    EVAC_CONS,        // arena_tagged_cons_cell_t: car + cdr tagged values
+    EVAC_VECTOR,      // [i64 length][length tagged values]  (also records)
+    EVAC_MULTIVALUE,  // [size_t count][count tagged values]
+    EVAC_HASH,        // eshkol_hash_table_t: keys/values/status arrays + home_arena
+    EVAC_TENSOR,      // eshkol_tensor_t: dimensions + elements raw buffers
+    EVAC_EXCEPTION,   // eshkol_exception_t: message/filename/irritants
+    EVAC_CLOSURE,     // eshkol_closure_t: captured environment
+};
+
+using EvacFwdMap = std::unordered_map<const void*, void*>;
+
+struct EvacState {
+    arena_t* target;
+    int boundary_idx;
+    EvacFwdMap* fwd;   // persistent per-region map (see eshkol_region_t::fwd_map)
+    std::vector<std::pair<void*, EvacKind>> worklist;
+    size_t copies = 0;
+};
+
+} // namespace
+
+// Free a region's persistent deep-escape forwarding map (declared above
+// region_destroy; the map type is only visible from here down).
+static void region_free_fwd_map(eshkol_region_t* region) {
+    if (region && region->fwd_map) {
+        delete (EvacFwdMap*)region->fwd_map;
+        region->fwd_map = nullptr;
+        region->fwd_target = nullptr;
+    }
+}
+
+// Classify an object (given its live original data pointer and the tagged value
+// referencing it) into an EvacKind. Ports are never deep-traversed (they wrap OS
+// resources / fds); they are leaf-copied with care so the escaped port struct is
+// stable, but the underlying handle is intentionally shared, not duplicated.
+static EvacKind evac_kind_for(const eshkol_tagged_value_t& v, const void* old_data) {
+    const uint8_t type = v.type;
+    const bool is_port = ((type & ESHKOL_PORT_ANY_FLAG) != 0) &&
+                         ((type & ESHKOL_VALUE_HEAP_PTR) == ESHKOL_VALUE_HEAP_PTR);
+    if (is_port) return EVAC_LEAF;
+
+    const auto* h = (const eshkol_object_header_t*)
+        ((const uint8_t*)old_data - sizeof(eshkol_object_header_t));
+    const uint8_t sub = h->subtype;
+
+    if (ESHKOL_IS_ANY_CALLABLE_TYPE(type)) {
+        if (sub == CALLABLE_SUBTYPE_CLOSURE) return EVAC_CLOSURE;
+        // LAMBDA_SEXPR / AD_NODE / PRIMITIVE / CONTINUATION: their interior
+        // reference graph is not confidently traversable here and they almost
+        // never escape a region via mutation. Kept shallow (documented).
+        return EVAC_LEAF;
+    }
+
+    switch (sub) {
+        case HEAP_SUBTYPE_CONS:        return EVAC_CONS;
+        case HEAP_SUBTYPE_VECTOR:      return EVAC_VECTOR;   // records are vectors too
+        case HEAP_SUBTYPE_MULTI_VALUE: return EVAC_MULTIVALUE;
+        case HEAP_SUBTYPE_HASH:        return EVAC_HASH;
+        case HEAP_SUBTYPE_TENSOR:      return EVAC_TENSOR;
+        case HEAP_SUBTYPE_EXCEPTION:   return EVAC_EXCEPTION;
+        // STRING / SYMBOL / BIGNUM / RATIONAL / BYTEVECTOR: self-contained
+        // payloads -> a contiguous leaf copy fully preserves them.
+        //
+        // SUBSTITUTION / FACT / KNOWLEDGE_BASE / FACTOR_GRAPH / WORKSPACE /
+        // PROMISE / DNC / SDNC / TAYLOR(rational-coeff): may carry interior
+        // tagged values, but (a) they are exceedingly rare to escape a region by
+        // mutation and (b) their internal layouts are not traversed here. They
+        // fall through to a shallow leaf copy — a documented limitation, not a
+        // regression (this matches the pre-ESH-0214c behavior for every subtype).
+        default:                       return EVAC_LEAF;
+    }
+}
+
+// Copy a headerless raw buffer (closure env, hash arrays, tensor buffers,
+// C strings) into the target arena, with forwarding so shared/aliased buffers
+// are copied once.
+static void* evac_raw(EvacState& st, const void* old, size_t size) {
+    if (!old || size == 0) return (void*)old;
+    auto it = st.fwd->find(old);
+    if (it != st.fwd->end()) return it->second;
+    void* raw = arena_allocate_aligned(st.target, size, 16);
+    if (!raw) return (void*)old;
+    std::memcpy(raw, old, size);
+    (*st.fwd)[old] = raw;
+    st.copies++;
+    return raw;
+}
+
+// Copy a header-prefixed object into the target arena (contiguous header+payload),
+// register forwarding, and enqueue it for interior traversal if non-leaf.
+static void* evac_object(EvacState& st, void* old_data, const eshkol_tagged_value_t& v) {
+    auto it = st.fwd->find(old_data);
+    if (it != st.fwd->end()) return it->second;
+
+    auto* h = (eshkol_object_header_t*)((uint8_t*)old_data - sizeof(eshkol_object_header_t));
+    const size_t total = sizeof(eshkol_object_header_t) + h->size;
+    if (h->size == 0) return old_data;  // nothing to copy; leave in place
+    // Plausibility guard: every live producer of tagged heap values allocates
+    // through the *_with_header paths, but a handful of legacy helpers
+    // (arena_allocate_tagged_cons_cell, arena_create_*_cons) emit HEADERLESS
+    // cells; if one ever leaked into a traversed graph, the 8 bytes before it
+    // are arbitrary. A garbage size would make the memcpy below read/allocate
+    // wildly; cap it at the region's own footprint upper bound. Skipping the
+    // copy degrades to the pre-ESH-0214c shallow behavior for that node only.
+    if (h->size > (uint32_t)0x10000000u) {  // 256MB: far above any real object
+        eshkol_warn("region evacuate: implausible object size %u at %p; "
+                    "leaving in place (headerless allocation?)",
+                    (unsigned)h->size, old_data);
+        return old_data;
+    }
+
+    void* raw = arena_allocate_aligned(st.target, total, 16);
+    if (!raw) {
+        eshkol_error("region evacuate: failed to allocate %zu bytes", total);
+        return old_data;
+    }
+    std::memcpy(raw, h, total);
+    void* new_data = (uint8_t*)raw + sizeof(eshkol_object_header_t);
+    (*st.fwd)[old_data] = new_data;
+    st.copies++;
+
+    EvacKind k = evac_kind_for(v, old_data);
+    if (k != EVAC_LEAF) st.worklist.push_back({new_data, k});
+    return new_data;
+}
+
+// Rewrite one tagged value: if it points into a dying region (strictly inner
+// than the boundary), evacuate the pointed-to object and repoint; otherwise
+// leave it untouched.
+static eshkol_tagged_value_t evac_value(EvacState& st, eshkol_tagged_value_t v) {
+    const uint8_t type = v.type;
+    const bool is_port = ((type & ESHKOL_PORT_ANY_FLAG) != 0) &&
+                         ((type & ESHKOL_VALUE_HEAP_PTR) == ESHKOL_VALUE_HEAP_PTR);
+    const bool is_heap = ESHKOL_IS_ANY_PTR_TYPE(type) || is_port;
+    if (!is_heap) return v;
+
+    void* p = (void*)(uintptr_t)v.data.ptr_val;
+    if (!p) return v;
+    if (region_index_owning(p) <= st.boundary_idx) return v;  // stable relative to dst
+
+    void* np = evac_object(st, p, v);
+    v.data.ptr_val = (uint64_t)(uintptr_t)np;
+    return v;
+}
+
+// Drive the deep evacuation of @p val into @p target, copying everything
+// reachable that lives in an active region strictly inner than @p boundary_idx.
+static eshkol_tagged_value_t region_evacuate_value(eshkol_tagged_value_t val,
+                                                   arena_t* target,
+                                                   int boundary_idx) {
+    if (!target) return val;
+    EvacState st;
+    st.target = target;
+    st.boundary_idx = boundary_idx;
+
+    // Use the innermost active region's PERSISTENT forwarding map so shared
+    // structure is preserved across SEPARATE escapes within one region body
+    // (two vector-set! calls storing lists that share a tail must keep sharing
+    // it after promotion). The map's keys reference memory in this region or an
+    // enclosing one -- the innermost region is the first of those to die, and
+    // region_destroy frees the map with it, so no entry can ever go stale. The
+    // map is only valid for one promotion target; if a nested escape targets a
+    // different arena (rare: barrier into an intermediate region), reset it.
+    EvacFwdMap local_fwd;
+    eshkol_region_t* owner = region_current();
+    if (owner) {
+        if (!owner->fwd_map) {
+            owner->fwd_map = new (std::nothrow) EvacFwdMap();
+            owner->fwd_target = target;
+        } else if (owner->fwd_target != target) {
+            ((EvacFwdMap*)owner->fwd_map)->clear();
+            owner->fwd_target = target;
+        }
+        st.fwd = owner->fwd_map ? (EvacFwdMap*)owner->fwd_map : &local_fwd;
+    } else {
+        st.fwd = &local_fwd;
+    }
+
+    eshkol_tagged_value_t root = evac_value(st, val);
+
+    while (!st.worklist.empty()) {
+        std::pair<void*, EvacKind> item = st.worklist.back();
+        st.worklist.pop_back();
+        void* nd = item.first;
+        switch (item.second) {
+            case EVAC_CONS: {
+                auto* c = (arena_tagged_cons_cell_t*)nd;
+                c->car = evac_value(st, c->car);
+                c->cdr = evac_value(st, c->cdr);
+                break;
+            }
+            case EVAC_VECTOR: {
+                int64_t len = *(int64_t*)nd;
+                if (len < 0) len = 0;
+                auto* elems = (eshkol_tagged_value_t*)((uint8_t*)nd + sizeof(int64_t));
+                for (int64_t i = 0; i < len; ++i) elems[i] = evac_value(st, elems[i]);
+                break;
+            }
+            case EVAC_MULTIVALUE: {
+                size_t count = *(size_t*)nd;
+                auto* elems = (eshkol_tagged_value_t*)((uint8_t*)nd + sizeof(size_t));
+                for (size_t i = 0; i < count; ++i) elems[i] = evac_value(st, elems[i]);
+                break;
+            }
+            case EVAC_EXCEPTION: {
+                auto* ex = (eshkol_exception_t*)nd;
+                if (ex->message && region_index_owning(ex->message) > st.boundary_idx)
+                    ex->message = (char*)evac_raw(st, ex->message, std::strlen(ex->message) + 1);
+                if (ex->filename && region_index_owning(ex->filename) > st.boundary_idx)
+                    ex->filename = (char*)evac_raw(st, ex->filename, std::strlen(ex->filename) + 1);
+                if (ex->irritants && ex->num_irritants &&
+                    region_index_owning(ex->irritants) > st.boundary_idx) {
+                    ex->irritants = (eshkol_tagged_value_t*)evac_raw(
+                        st, ex->irritants, (size_t)ex->num_irritants * sizeof(eshkol_tagged_value_t));
+                }
+                if (ex->irritants) {
+                    for (uint32_t i = 0; i < ex->num_irritants; ++i)
+                        ex->irritants[i] = evac_value(st, ex->irritants[i]);
+                }
+                break;
+            }
+            case EVAC_TENSOR: {
+                auto* t = (eshkol_tensor_t*)nd;
+                if (t->dimensions && region_index_owning(t->dimensions) > st.boundary_idx)
+                    t->dimensions = (uint64_t*)evac_raw(
+                        st, t->dimensions, (size_t)t->num_dimensions * sizeof(uint64_t));
+                if (t->elements && region_index_owning(t->elements) > st.boundary_idx)
+                    t->elements = (int64_t*)evac_raw(
+                        st, t->elements, (size_t)t->total_elements * sizeof(int64_t));
+                break;
+            }
+            case EVAC_HASH: {
+                auto* tbl = (eshkol_hash_table_t*)nd;
+                const size_t cap = tbl->capacity;
+                if (tbl->keys && region_index_owning(tbl->keys) > st.boundary_idx)
+                    tbl->keys = (eshkol_tagged_value_t*)evac_raw(
+                        st, tbl->keys, cap * sizeof(eshkol_tagged_value_t));
+                if (tbl->values && region_index_owning(tbl->values) > st.boundary_idx)
+                    tbl->values = (eshkol_tagged_value_t*)evac_raw(
+                        st, tbl->values, cap * sizeof(eshkol_tagged_value_t));
+                if (tbl->status && region_index_owning(tbl->status) > st.boundary_idx)
+                    tbl->status = (uint8_t*)evac_raw(st, tbl->status, cap * sizeof(uint8_t));
+                if (tbl->keys && tbl->values && tbl->status) {
+                    for (size_t i = 0; i < cap; ++i) {
+                        if (tbl->status[i] == HASH_ENTRY_OCCUPIED) {
+                            tbl->keys[i]   = evac_value(st, tbl->keys[i]);
+                            tbl->values[i] = evac_value(st, tbl->values[i]);
+                        }
+                    }
+                }
+                // Future resizes must grow the arrays in the surviving arena,
+                // never the dying region.
+                tbl->home_arena = st.target;
+                break;
+            }
+            case EVAC_CLOSURE: {
+                auto* c = (eshkol_closure_t*)nd;
+                if (c->env && region_index_owning(c->env) > st.boundary_idx) {
+                    const size_t ncap = CLOSURE_ENV_GET_NUM_CAPTURES(c->env->num_captures);
+                    const size_t env_size =
+                        sizeof(eshkol_closure_env_t) + ncap * sizeof(eshkol_tagged_value_t);
+                    auto* ne = (eshkol_closure_env_t*)evac_raw(st, c->env, env_size);
+                    c->env = ne;
+                    for (size_t i = 0; i < ncap; ++i) {
+                        eshkol_tagged_value_t& cap = ne->captures[i];
+                        // MUTABLE-CAPTURE CELLS: lambda codegen moves a set!-able
+                        // captured local into a 16-byte headerless arena cell
+                        // (one eshkol_tagged_value_t) and stores the CELL ADDRESS
+                        // in the capture slot packed as an exact INT64
+                        // (packInt64ToTaggedValue(PtrToInt(cell))) — see
+                        // "CLOSURE ESCAPE FIX" / "MUTABLE CAPTURE FIX" in
+                        // llvm_codegen.cpp. During a with-region body that cell
+                        // lives in the region arena and would dangle after
+                        // region_pop. There is no type tag distinguishing this
+                        // packed pointer from a genuine integer, so we test
+                        // conservatively: an INT64 capture whose value, read as
+                        // a pointer, falls INSIDE a dying region arena is treated
+                        // as a capture cell — copied (forwarded, so cells shared
+                        // between closures stay shared), its contained tagged
+                        // value evacuated, and the slot repointed. A genuine
+                        // captured integer can only misfire if it exactly equals
+                        // a live interior address of the few-KB region arena
+                        // active at escape time (Boehm-style conservatism;
+                        // astronomically unlikely, documented in the PR). The
+                        // other producers of INT64-packed pointers in capture
+                        // slots are GlobalVariable addresses and JIT/AOT code
+                        // addresses, neither of which is ever inside a region
+                        // arena, so they always take the identity path here.
+                        if (cap.type == ESHKOL_VALUE_INT64 && cap.data.int_val != 0) {
+                            void* cell = (void*)(uintptr_t)cap.data.int_val;
+                            if (region_index_owning(cell) > st.boundary_idx) {
+                                auto* nc =
+                                    (eshkol_tagged_value_t*)evac_raw(st, cell, 16);
+                                if (nc != cell) {
+                                    *nc = evac_value(st, *nc);
+                                    cap.data.int_val = (int64_t)(intptr_t)nc;
+                                }
+                                continue;
+                            }
+                        }
+                        cap = evac_value(st, cap);
+                    }
+                }
+                if (c->name && region_index_owning(c->name) > st.boundary_idx)
+                    c->name = (const char*)evac_raw(st, c->name, std::strlen(c->name) + 1);
+                break;
+            }
+            case EVAC_LEAF:
+            default:
+                break;
+        }
+    }
+
+    eshkol_region_t* cur = region_current();
+    if (cur) cur->escape_count += st.copies;
+    return root;
+}
+
 /**
- * @brief Copy a tagged value's heap payload (if any) out of the current region.
+ * @brief Copy a tagged value's heap payload (and its whole in-region subgraph)
+ *        out of the current region.
  *
- * Non-heap values (ints, doubles, etc.) and non-pointer/port heap flags are
- * returned unchanged, as are heap values that are NULL pointers or whose
- * object header reports zero size. Otherwise reads the object header
- * immediately preceding the value's payload, copies the header plus payload
- * as one contiguous block into region_escape_target()'s arena, rewrites the
- * returned value's pointer to the copy's payload (past the copied header),
- * and increments the current region's escape_count. If no region is
+ * Non-heap values (ints, doubles, etc.) are returned unchanged, as are heap
+ * values that are NULL. Otherwise the value's reachable subgraph that lives in
+ * the current (about-to-be-destroyed) region's arena is deep-copied into
+ * region_escape_target()'s arena via region_evacuate_value(): shared structure
+ * and cycles are preserved by a forwarding map, and objects already living in an
+ * enclosing region or the global arena are left in place. If no region is
  * currently active, the value is returned unchanged. Shared implementation
  * behind the two `region_escape_tagged_value*` extern "C" entry points.
  *
@@ -615,21 +1022,13 @@ static eshkol_tagged_value_t region_escape_tagged_value_impl(eshkol_tagged_value
     void* ptr = (void*)(uintptr_t)val.data.ptr_val;
     if (!ptr) return val;
 
-    auto* header = (eshkol_object_header_t*)((uint8_t*)ptr - sizeof(eshkol_object_header_t));
-    const size_t obj_size = header->size;
-    if (obj_size == 0) return val;
-
-    const size_t total = sizeof(eshkol_object_header_t) + obj_size;
-    void* raw = arena_allocate_aligned(region_escape_target(current), total, 8);
-    if (!raw) {
-        eshkol_error("region_escape_tagged_value: failed to allocate %zu bytes", total);
-        return val;
-    }
-
-    std::memcpy(raw, header, total);
-    val.data.ptr_val = (uint64_t)(uintptr_t)((uint8_t*)raw + sizeof(eshkol_object_header_t));
-    current->escape_count++;
-    return val;
+    // Escaping FROM `current` (stack index depth-1) into its parent (or the
+    // global arena). Everything living in `current`'s arena must be copied;
+    // anything already in an ancestor region or the global arena is stable.
+    // boundary = index of current's parent = depth-2.
+    arena_t* target = region_escape_target(current);
+    const int boundary = (int)__region_stack_depth - 2;
+    return region_evacuate_value(val, target, boundary);
 }
 
 /**
@@ -660,4 +1059,90 @@ extern "C" void region_escape_tagged_value_into(eshkol_tagged_value_t* out,
         return;
     }
     *out = region_escape_tagged_value_impl(*val);
+}
+
+/**
+ * @brief Region write barrier: promote @p value's in-region subgraph when it is
+ *        stored into a longer-lived destination (ESH-0214c).
+ *
+ * Called by codegen at every mutation channel that can store a value into a
+ * location that outlives the value's region (set-car!/set-cdr!, vector-set!,
+ * hash-table-set!, set! of a global). The FAST PATH — no active region — is a
+ * single thread-local load and branch, so the barrier is essentially free
+ * outside `(with-region ...)`.
+ *
+ * When a region is active, the barrier evacuates @p value's reachable subgraph
+ * out of any region strictly inner than @p dst's owning region iff @p value
+ * actually points into such a region. If @p value already lives at least as long
+ * as @p dst (same or an enclosing region, or the global arena), it is stored
+ * unchanged. The evacuation preserves shared structure and cycles via a
+ * forwarding map, so this is safe to apply on every store.
+ *
+ * @param out   Destination for the (possibly promoted) value to actually store.
+ * @param dst   Address of the container/slot being written (used only to locate
+ *              which region owns the destination); NULL is treated as
+ *              global/outer.
+ * @param value The value about to be stored.
+ */
+extern "C" void eshkol_region_write_barrier_into(eshkol_tagged_value_t* out,
+                                                 const void* dst,
+                                                 const eshkol_tagged_value_t* value) {
+    if (!out) return;
+    if (!value) {
+        std::memset(out, 0, sizeof(*out));
+        return;
+    }
+    eshkol_tagged_value_t v = *value;
+
+    // FAST PATH: no active region -> nothing can dangle.
+    if (__region_stack_depth == 0) { *out = v; return; }
+
+    const uint8_t type = v.type;
+    const bool is_port = ((type & ESHKOL_PORT_ANY_FLAG) != 0) &&
+                         ((type & ESHKOL_VALUE_HEAP_PTR) == ESHKOL_VALUE_HEAP_PTR);
+    const bool is_heap = ESHKOL_IS_ANY_PTR_TYPE(type) || is_port;
+    if (!is_heap) { *out = v; return; }
+
+    void* vptr = (void*)(uintptr_t)v.data.ptr_val;
+    if (!vptr) { *out = v; return; }
+
+    const int val_idx = region_index_owning(vptr);
+    if (val_idx < 0) { *out = v; return; }          // value already outer/global
+
+    const int dst_idx = region_index_owning(dst);   // -1 when dst is outer/global
+    if (val_idx <= dst_idx) { *out = v; return; }    // value outlives-or-coeval with dst
+
+    // Where the promoted subgraph lands: the destination's own region arena
+    // when dst lives in an active region, otherwise the TRUE global arena. The
+    // outermost region's escape_base is that true global (captured before the
+    // __global_arena slot was hijacked by with-region codegen), so use it rather
+    // than get_global_arena(), which is hijacked during a region body.
+    arena_t* target = (dst_idx >= 0) ? __region_stack[dst_idx]->arena
+                                     : __region_stack[0]->escape_base;
+    if (!target) target = get_global_arena();
+    *out = region_evacuate_value(v, target, dst_idx);
+}
+
+/**
+ * @brief Range form of the region write barrier: fix up @p n tagged slots at
+ *        @p slots after a bulk copy (vector-copy!) into destination @p dst.
+ *
+ * Called by codegen after the memmove of `(vector-copy! to at from ...)`. The
+ * fast path (no active region) is a single thread-local load + branch. When a
+ * region is active, each copied slot that points into a region strictly inner
+ * than @p dst's owning region is deep-promoted in place (same semantics as
+ * eshkol_region_write_barrier_into, applied slot-by-slot; the per-region
+ * forwarding map keeps shared structure shared across the whole range).
+ *
+ * @param dst   Address of the destination container (region-ownership probe).
+ * @param slots First copied slot (already holding the copied values).
+ * @param n     Number of copied slots.
+ */
+extern "C" void eshkol_region_write_barrier_range(const void* dst,
+                                                  eshkol_tagged_value_t* slots,
+                                                  uint64_t n) {
+    if (__region_stack_depth == 0 || !slots) return;
+    for (uint64_t i = 0; i < n; ++i) {
+        eshkol_region_write_barrier_into(&slots[i], dst, &slots[i]);
+    }
 }

--- a/site/static/eshkol-runtime.js
+++ b/site/static/eshkol-runtime.js
@@ -640,12 +640,32 @@ class EshkolRuntime {
                 eshkol_lazy_future_set_result_ptr: () => {},
 
                 // OALR regions — JIT path uses these.  In WASM we don't
-                // have a region system; degrade to no-op (region_create
-                // returns a fake handle, push/pop/escape are no-ops).
+                // have a region system; degrade (region_create returns a fake
+                // handle, push/pop are no-ops). But escape / write-barrier
+                // receive an UNINITIALIZED `out` slot that the caller reads back
+                // — the runtime fn is the SOLE writer of `out`, so a no-op would
+                // drop the value. With nothing ever freed, the correct
+                // degradation is a shallow 16-byte tagged-value copy src -> out.
                 region_create: (_name, _size_hint) => 1,
                 region_push:   () => {},
                 region_pop:    () => {},
-                region_escape_tagged_value_into: (_dst, _src) => {},
+                region_escape_tagged_value_into: (out, val) => {
+                    const buf = rt._importedMemory?.buffer || rt.instance?.exports?.memory?.buffer;
+                    if (!buf || !out || !val) return;
+                    const o = Number(out), v = Number(val);
+                    new Uint8Array(buf).copyWithin(o, v, v + 16);
+                },
+                // eshkol_region_write_barrier_into(out, dst, value): shallow-copy
+                // value -> out (dst is only a region-ownership probe).
+                eshkol_region_write_barrier_into: (out, _dst, value) => {
+                    const buf = rt._importedMemory?.buffer || rt.instance?.exports?.memory?.buffer;
+                    if (!buf || !out || !value) return;
+                    const o = Number(out), v = Number(value);
+                    new Uint8Array(buf).copyWithin(o, v, v + 16);
+                },
+                // Range form (vector-copy!): slots already populated by the
+                // preceding memmove; nothing to promote -> genuine no-op.
+                eshkol_region_write_barrier_range: () => {},
 
                 // Tensor runtime helpers
                 eshkol_broadcast_elementwise_f64: () => 0,

--- a/tests/memory/region_deep_escape_test.esk
+++ b/tests/memory/region_deep_escape_test.esk
@@ -1,0 +1,141 @@
+;;; tests/memory/region_deep_escape_test.esk — ESH-0214c deep transitive
+;;; escape-promotion correctness fixture.
+;;;
+;;; Before ESH-0214c, (with-region ...) promoted an escaping value with a
+;;; SHALLOW single-object copy: for a graph-bearing value (cons list, vector of
+;;; tagged values, closure, hash table) the copied object's interior pointers
+;;; (car/cdr, vector slots, captured env) still pointed INTO the region arena,
+;;; which region_pop then freed — leaving dangling interior pointers. Reading
+;;; the escaped structure back after the region exit produced garbage or a
+;;; "car/cdr: argument is not a pair" crash.
+;;;
+;;; The fix rewrites the escape path as a deep evacuator (forwarding map +
+;;; worklist) and adds a mutation write barrier so a region value stored into an
+;;; OUTER container (vector-set!/set-car!/hash-table-set!/global set!) is
+;;; deep-promoted before region_pop. This fixture verifies:
+;;;   1. large-N cons-list / vector / closure mutation into an outer vector,
+;;;   2. shared-tail preservation (no duplication of a shared list tail),
+;;;   3. a small cyclic structure surviving escape,
+;;; all read back correct AFTER the region has exited.
+
+(define passed 0)
+(define failed 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (set! passed (+ passed 1)))
+      (begin (display "FAIL: ") (display name)
+             (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline)
+             (set! failed (+ failed 1)))))
+
+;; ─── 1. Large-N: cons a fresh 3-element list into an OUTER vector each
+;;        iteration, inside a per-iteration region. After the loop, every stored
+;;        list must read back intact. Pre-fix: dangling car/cdr → crash/garbage.
+(define N 100000)
+(define store (make-vector N 0))
+
+(define (fill-loop i)
+  (if (< i N)
+      (begin
+        (with-region 'r
+          ;; Fresh region-allocated list; vector-set! stores it into the OUTER
+          ;; `store` vector — the write barrier must deep-promote it.
+          (vector-set! store i (list i (* i 2) (* i 3))))
+        (fill-loop (+ i 1)))))
+(fill-loop 0)
+
+;; Verify a representative sample (checking all 100k with `equal?` is slow but
+;; we spot-check the boundaries and a stride through the middle).
+(define (verify-loop i step ok)
+  (if (>= i N)
+      ok
+      (let ((lst (vector-ref store i)))
+        (verify-loop
+         (+ i step) step
+         (and ok
+              (= (car lst) i)
+              (= (cadr lst) (* i 2))
+              (= (caddr lst) (* i 3)))))))
+(check "deep list escape via vector-set! (100k, sampled)" #t
+       (verify-loop 0 97 #t))
+(check "deep list escape: first element intact" 0 (car (vector-ref store 0)))
+(check "deep list escape: last element intact"
+       (* (- N 1) 3) (caddr (vector-ref store (- N 1))))
+
+;; ─── 1b. A vector-of-tagged-values (nested vector) escaping into an outer slot.
+(define vstore (make-vector 4 0))
+(define (vfill i)
+  (if (< i 4)
+      (begin
+        (with-region 'rv
+          (let ((v (make-vector 3 0)))
+            (vector-set! v 0 (* i 10))
+            (vector-set! v 1 (list i i))     ; nested list inside the vector
+            (vector-set! v 2 (+ i 100))
+            (vector-set! vstore i v)))
+        (vfill (+ i 1)))))
+(vfill 0)
+(check "deep vector escape: elem 0" 20 (vector-ref (vector-ref vstore 2) 0))
+(check "deep vector escape: nested list" (list 3 3)
+       (vector-ref (vector-ref vstore 3) 1))
+(check "deep vector escape: elem 2" 101 (vector-ref (vector-ref vstore 1) 2))
+
+;; ─── 1c. A closure capturing a region-allocated value, escaping into an outer
+;;        slot. The captured environment must be deep-promoted with the closure.
+(define cstore (make-vector 3 0))
+(define (cfill i)
+  (if (< i 3)
+      (begin
+        (with-region 'rc
+          (let* ((captured (list i (* i i)))          ; region-allocated capture
+                 (f (lambda () captured)))
+            (vector-set! cstore i f)))
+        (cfill (+ i 1)))))
+(cfill 0)
+(check "deep closure escape: env capture 0" (list 0 0) ((vector-ref cstore 0)))
+(check "deep closure escape: env capture 2" (list 2 4) ((vector-ref cstore 2)))
+
+;; ─── 2. Shared-tail preservation. Two lists built inside the region share a
+;;        common tail; after escape the shared structure must remain shared (or
+;;        at minimum be structurally correct — we assert structural equality of
+;;        both the tail and the full lists).
+(define pair-store (make-vector 2 0))
+(with-region 'rshare
+  (let* ((tail (list 100 200 300))
+         (a (cons 1 tail))
+         (b (cons 2 tail)))
+    (vector-set! pair-store 0 a)
+    (vector-set! pair-store 1 b)))
+(let ((a (vector-ref pair-store 0))
+      (b (vector-ref pair-store 1)))
+  (check "shared-tail: list a intact" (list 1 100 200 300) a)
+  (check "shared-tail: list b intact" (list 2 100 200 300) b)
+  (check "shared-tail: tails structurally equal" (cdr a) (cdr b))
+  ;; Sharing preserved: mutating the tail through a is visible through b.
+  (set-car! (cdr a) 999)
+  (check "shared-tail: mutation through a visible through b" 999 (cadr b)))
+
+;; ─── 3. Small cyclic structure surviving escape. Build a 2-node cycle inside a
+;;        region, store it outside, and confirm we can walk it a bounded number
+;;        of steps without corruption after region exit.
+(define cyc-store (make-vector 1 0))
+(with-region 'rcyc
+  (let ((node (list 'a 'b)))
+    (set-cdr! (cdr node) node)   ; (a b a b a b ...) cyclic
+    (vector-set! cyc-store 0 node)))
+(let ((c (vector-ref cyc-store 0)))
+  (check "cycle: node 0" 'a (car c))
+  (check "cycle: node 1" 'b (cadr c))
+  ;; After two cdrs we are back at the head (cycle preserved, not duplicated).
+  (check "cycle: caddr wraps to head car" 'a (caddr c))
+  (check "cycle: cadddr wraps to head cadr" 'b (car (cdddr c))))
+
+;; ─── Report ─────────────────────────────────────────────────────────────────
+(display "[region_deep_escape_test] passed=")
+(display passed)
+(display " failed=")
+(display failed)
+(newline)
+(if (= failed 0)
+    (begin (display "PASS") (newline))
+    (begin (display "FAIL") (newline) (exit 1)))

--- a/tests/memory/region_mutating_loop_flat_rss_test.esk
+++ b/tests/memory/region_mutating_loop_flat_rss_test.esk
@@ -1,0 +1,61 @@
+;;; tests/memory/region_mutating_loop_flat_rss_test.esk — ESH-0214c flat-RSS
+;;; regression fixture, gated by region_mutating_loop_flat_rss_test.sh.
+;;;
+;;; The resident-AI tick-loop shape from the field report: a guard-wrapped
+;;; top-level define loop where each iteration
+;;;   (a) allocates transient garbage that dies with the iteration, and
+;;;   (b) MUTATES one slot of a persistent OUTER vector with a freshly consed
+;;;       small list,
+;;; with the whole body wrapped in a PER-ITERATION (with-region ...). The
+;;; per-iteration placement (region inside the loop body, not around the loop)
+;;; is what reclaims each iteration's garbage: region_pop frees the region
+;;; arena every pass, and ONLY the freshly stored list escapes — deep-promoted
+;;; into the global arena by the ESH-0214c mutation write barrier.
+;;;
+;;; Without the region, this shape leaks ~17.5KB/iteration (~7GB at 400k
+;;; iterations). With the region but WITHOUT the deep-escape fix, RSS stays
+;;; flat but the outer vector's slots dangle into freed region arenas
+;;; (car/cdr corruption). With both, RSS stays flat AND every stored value
+;;; reads back correct at the end — which is what this fixture asserts.
+
+(define total-passes 400000)
+(define slots 64)
+(define state (make-vector slots 0))
+
+(define (tick i acc)
+  (guard (e (#t acc))                       ; catch-all error boundary (daemon shape)
+    (if (>= i total-passes)
+        acc
+        (begin
+          (with-region 'tick
+            ;; (a) transient garbage: dead at region exit, reclaimed by region_pop
+            (let ((scratch (make-list 100 i)))
+              ;; (b) persistent mutation: fresh small list into the OUTER vector.
+              ;; The write barrier must deep-promote it out of the region.
+              (vector-set! state (modulo i slots) (list i (* i 2) (length scratch)))))
+          (tick (+ i 1) (+ acc 1))))))
+
+(define result (tick 0 0))
+
+;; ─── Correctness read-back: every slot must hold the intact list from the
+;;     last iteration that touched it (no car/cdr errors, correct values).
+(define (verify s ok)
+  (if (>= s slots)
+      ok
+      (let* ((lst (vector-ref state s))
+             ;; last i that wrote slot s: largest i < total-passes with (modulo i slots) = s
+             (last-i (+ s (* (quotient (- total-passes 1 s) slots) slots))))
+        (verify (+ s 1)
+                (and ok
+                     (= (car lst) last-i)
+                     (= (cadr lst) (* last-i 2))
+                     (= (caddr lst) 100))))))
+
+(display "[region_mutating_loop_flat_rss_test] passes=")
+(display result)
+(display "/")
+(display total-passes)
+(newline)
+(if (and (= result total-passes) (verify 0 #t))
+    (begin (display "PASS") (newline))
+    (begin (display "FAIL") (newline) (exit 1)))

--- a/tests/memory/region_mutating_loop_flat_rss_test.sh
+++ b/tests/memory/region_mutating_loop_flat_rss_test.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# tests/memory/region_mutating_loop_flat_rss_test.sh — ESH-0214c AOT flat-RSS
+# + correctness gate for the with-region mutating tick loop.
+#
+# ESH-0214c made with-region escape promotion DEEP (transitive evacuation with
+# a forwarding map) and added a mutation write barrier, so a resident tick loop
+# can allocate transient garbage inside a per-iteration region while mutating
+# persistent outer state with freshly consed values. Before the fix the choice
+# was: leak ~17.5KB/iteration without the region (~7GB at 400k iterations), or
+# corrupt the outer state with dangling interior pointers with it.
+#
+# This gate compiles tests/memory/region_mutating_loop_flat_rss_test.esk AOT
+# (same harness pattern as define_loop_flat_rss_aot_test.sh), runs it under
+# /usr/bin/time (macOS: -l, Linux: -v), and fails if
+#   (1) the program does not print PASS (correctness: every outer-vector slot
+#       reads back intact after 400k region-wrapped mutations), or
+#   (2) peak RSS exceeds a flat ceiling. The fixed behavior measures tens of
+#       MB; the leak this guards against is ~7GB, so a 300MB ceiling separates
+#       the two with wide margin in both directions.
+#
+# Usage: tests/memory/region_mutating_loop_flat_rss_test.sh [--ceiling-mb N] [--timeout S]
+#   BUILD_DIR env var selects the build directory (default: build).
+#   ESHKOL_RUN env var overrides the eshkol-run binary path directly.
+set -u
+cd "$(dirname "$0")/../.."
+REPO_ROOT="$(pwd)"
+
+BUILD_DIR="${BUILD_DIR:-build}"
+if [ -z "${ESHKOL_RUN:-}" ]; then
+    case "$BUILD_DIR" in
+        /*) ESHKOL_RUN="$BUILD_DIR/eshkol-run" ;;
+        *) ESHKOL_RUN="$REPO_ROOT/$BUILD_DIR/eshkol-run" ;;
+    esac
+fi
+if [ ! -x "$ESHKOL_RUN" ]; then
+    echo "region_mutating_loop_flat_rss_test.sh: $ESHKOL_RUN not found — run \`cmake --build $BUILD_DIR --target eshkol-run stdlib\` first." >&2
+    exit 2
+fi
+
+SRC="$REPO_ROOT/tests/memory/region_mutating_loop_flat_rss_test.esk"
+if [ ! -f "$SRC" ]; then
+    echo "region_mutating_loop_flat_rss_test.sh: $SRC not found." >&2
+    exit 2
+fi
+
+CEILING_MB=300
+TIMEOUT_S=120
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --ceiling-mb) shift; CEILING_MB="${1:-$CEILING_MB}" ;;
+        --timeout) shift; TIMEOUT_S="${1:-$TIMEOUT_S}" ;;
+        *) echo "region_mutating_loop_flat_rss_test.sh: unknown argument: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+# Detect which peak-RSS-reporting `time` flavor is available.
+TIME_MODE=""
+if /usr/bin/time -l true >/dev/null 2>/tmp/.regmut_probe.$$; then
+    if grep -q "maximum resident set size" /tmp/.regmut_probe.$$ 2>/dev/null; then
+        TIME_MODE="bsd"
+    fi
+fi
+if [ -z "$TIME_MODE" ] && /usr/bin/time -v true >/tmp/.regmut_probe.$$ 2>&1; then
+    if grep -qi "Maximum resident set size" /tmp/.regmut_probe.$$ 2>/dev/null; then
+        TIME_MODE="gnu"
+    fi
+fi
+rm -f /tmp/.regmut_probe.$$
+if [ -z "$TIME_MODE" ]; then
+    echo "region_mutating_loop_flat_rss_test.sh: neither \`/usr/bin/time -l\` (macOS) nor \`/usr/bin/time -v\` (Linux) reports peak RSS on this host — cannot gate." >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-region-mut-rss.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "=========================================================="
+echo "  ESH-0214c AOT flat-RSS + correctness gate:"
+echo "  region_mutating_loop_flat_rss_test.esk"
+echo "  ceiling=${CEILING_MB}MB  time-mode=${TIME_MODE}"
+echo "=========================================================="
+echo
+
+BIN="$WORK/region_mut_rss_bin"
+COMPILE_LOG="$WORK/compile.log"
+RUN_OUT="$WORK/run.out"
+TIME_LOG="$WORK/time.log"
+
+( cd "$WORK" && "$ESHKOL_RUN" "$SRC" -o "$BIN" ) > "$COMPILE_LOG" 2>&1
+COMPILE_RC=$?
+if [ "$COMPILE_RC" -ne 0 ]; then
+    echo "FAIL: AOT compile failed (exit=$COMPILE_RC). Output:"
+    cat "$COMPILE_LOG"
+    echo "region_mutating_loop_flat_rss_test.sh: FAIL"
+    exit 1
+fi
+chmod +x "$BIN"
+
+if [ "$TIME_MODE" = "bsd" ]; then
+    ( cd "$WORK" && /usr/bin/time -l perl -e 'my $s=shift; alarm $s; exec @ARGV; die "exec failed: $!\n"' \
+        "$TIMEOUT_S" "$BIN" ) > "$RUN_OUT" 2> "$TIME_LOG"
+    RUN_RC=$?
+    RSS_MB=$(awk '/maximum resident set size/{printf "%d", $1/1048576}' "$TIME_LOG")
+else
+    ( cd "$WORK" && /usr/bin/time -v perl -e 'my $s=shift; alarm $s; exec @ARGV; die "exec failed: $!\n"' \
+        "$TIMEOUT_S" "$BIN" ) > "$RUN_OUT" 2> "$TIME_LOG"
+    RUN_RC=$?
+    RSS_MB=$(awk -F: '/Maximum resident set size/{printf "%d", $2/1024}' "$TIME_LOG")
+fi
+[ -n "$RSS_MB" ] || RSS_MB=0
+
+fail=0
+if [ "$RUN_RC" -ne 0 ] || ! grep -q "^PASS$" "$RUN_OUT"; then
+    echo "FAIL: AOT binary did not complete cleanly (exit=$RUN_RC). Output:"
+    cat "$RUN_OUT"
+    echo "      -- a correctness failure here means the outer vector's slots"
+    echo "      dangle into freed region arenas: the deep escape promotion /"
+    echo "      mutation write barrier (ESH-0214c) has regressed."
+    fail=1
+else
+    echo "  exit=$RUN_RC  peak_rss=${RSS_MB}MB  (correctness: PASS)"
+    if [ "$RSS_MB" -gt "$CEILING_MB" ]; then
+        echo "FAIL: peak RSS ${RSS_MB}MB exceeds ceiling ${CEILING_MB}MB"
+        echo "      -- looks like per-iteration region reclamation regressed, or"
+        echo "      the write barrier is over-promoting (copying the transient"
+        echo "      garbage instead of only the escaping subgraph)."
+        fail=1
+    else
+        echo "PASS: peak RSS ${RSS_MB}MB is within the ${CEILING_MB}MB flat ceiling."
+    fi
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+    echo "region_mutating_loop_flat_rss_test.sh: PASS"
+else
+    echo "region_mutating_loop_flat_rss_test.sh: FAIL"
+fi
+exit "$fail"

--- a/web/eshkol-repl.js
+++ b/web/eshkol-repl.js
@@ -626,11 +626,37 @@ class EshkolRepl {
                 eshkol_lazy_future_set_result_ptr: () => {},
 
                 // OALR regions — degrade to no-op (WASM has no region
-                // system; the heap allocator handles everything).
+                // system; the heap allocator handles everything so nothing is
+                // ever freed out from under an escaping value).
                 region_create: (_name, _size_hint) => 1,
                 region_push:   () => {},
                 region_pop:    () => {},
-                region_escape_tagged_value_into: (_dst, _src) => {},
+                // region_escape / write-barrier: the CALLER passes an
+                // uninitialized `out` slot and reads it back after the call —
+                // the runtime fn is the SOLE writer of `out`. A no-op would
+                // leave `out` as garbage and drop the value in the browser. With
+                // no region system to escape from, the correct degradation is a
+                // shallow byte copy of the 16-byte tagged value from the source
+                // slot into `out` (no deep promotion needed — nothing is freed).
+                region_escape_tagged_value_into: (out, val) => {
+                    if (!this.memory || !out || !val) return;
+                    const o = Number(out), v = Number(val);
+                    new Uint8Array(this.memory.buffer).copyWithin(o, v, v + 16);
+                },
+                // eshkol_region_write_barrier_into(out, dst, value): promote
+                // `value` when stored into a longer-lived `dst` (vector-set! /
+                // set-car! / hash-table-set! / global set!). Same out-slot ABI
+                // as above — shallow-copy value -> out (dst is only a
+                // region-ownership probe, irrelevant with no regions).
+                eshkol_region_write_barrier_into: (out, _dst, value) => {
+                    if (!this.memory || !out || !value) return;
+                    const o = Number(out), v = Number(value);
+                    new Uint8Array(this.memory.buffer).copyWithin(o, v, v + 16);
+                },
+                // Range form (vector-copy!): the copied slots are already
+                // populated by the preceding memmove, and there is no region to
+                // promote out of, so this is a genuine no-op.
+                eshkol_region_write_barrier_range: () => {},
 
                 // Tensor runtime helpers
                 eshkol_broadcast_elementwise_f64: () => 0,


### PR DESCRIPTION
## Root cause

`(with-region ...)` promotes escaping values via `region_escape_tagged_value_impl` (lib/core/runtime_regions.cpp), which performed a SHALLOW single-object memcpy (header+payload). For graph-bearing values — cons lists, vectors of tagged values, closures, hash tables — the copied object's interior pointers (car/cdr, vector slots, captured env, key/value arrays) still pointed INTO the region arena, which `region_pop` then freed. Reading the escaped structure back produced dangling-pointer corruption ("car/cdr: argument is not a pair"). Only self-contained payloads (strings, bignum limbs, immediates) survived.

Two additional latent bugs surfaced while fixing this:

1. **Escape target was the dying region itself.** `region_escape_target` fell back to `get_global_arena()`, but with-region codegen hijacks the `__global_arena` slot to point at the region's own arena for the duration of the body — so escapes "to the parent" were actually copied straight back into the arena about to be freed. Single-object escapes appeared to work only because freed malloc blocks usually retain their contents briefly; in a loop, every iteration's region reuses the same block address and all previously escaped values alias the last iteration's data.
2. **No write barrier on mutation channels.** A region value stored into an OUTER structure (`vector-set!`, `set-car!`/`set-cdr!`, `hash-table-set!`, `set!` of a global, `vector-fill!`, `vector-copy!`) was never promoted at all.

## Design

**Evacuator (runtime_regions.cpp).** The escape path is now a Cheney-style copying evacuator restricted to the escaping subgraph: a worklist drives a breadth-first walk (no native-stack recursion on deep lists), and a forwarding map (old data ptr -> promoted copy) preserves shared structure and terminates on cycles. A node is copied iff it lives in an active region strictly inner than the destination's owning region; anything at-or-outside that boundary (ancestor region, global arena, static storage) is left in place. Ownership is decided by walking the region stack's arena block chains (`arena_contains_ptr` / `region_index_owning`).

The forwarding map is PERSISTENT per region (`eshkol_region_t::fwd_map`, freed in `region_destroy`): separate escapes within one region body share one map, so two stores of lists sharing a tail keep sharing it after promotion (true aliasing, verified by mutation visibility through the other reference), and re-storing an already-escaped object is free.

**Escape target correctness.** `eshkol_region_t::escape_base` captures the true enclosing arena at `region_push` time — before codegen hijacks the `__global_arena` slot — and `region_escape_target` now uses it. Nested regions escape to the parent region's arena; the outermost escapes to the real global (or thread-local worker) arena.

**Write barrier.** One shared runtime helper, `eshkol_region_write_barrier_into(out, dst_slot, value)` (+ a range form `eshkol_region_write_barrier_range` for bulk copies), does the containment checks and calls the evacuator only when the value lives strictly inner to the destination. Fast path with no active region: a single thread-local load + branch. Codegen (`CodegenContext::emitRegionWriteBarrier`) routes the mutation channels through it.

**Mutable-capture cells.** Lambda codegen moves set!-able captured locals into 16-byte headerless arena cells and stores the CELL ADDRESS in the closure env packed as an exact INT64 (no type tag distinguishes it from a real integer). The evacuator handles this inside closure-env traversal only, conservatively: an INT64 capture slot whose value, read as a pointer, falls inside a dying region arena is treated as a capture cell — copied (forwarded), its contained tagged value evacuated, slot repointed. The other producers of INT64-packed pointers in capture slots (GlobalVariable addresses, JIT/AOT code addresses) are never inside a region arena and always take the identity path. A genuine captured integer can only misfire if it exactly equals a live interior address of the region arena active at escape time (Boehm-style conservatism).

## Per-subtype coverage

| Subtype | Handling | Notes |
|---|---|---|
| CONS | deep | car+cdr tagged values, worklist |
| VECTOR | deep | [i64 len][tagged slots]; records share this layout |
| MULTI_VALUE | deep | [size_t n][tagged slots] |
| HASH | deep | keys/values/status arrays copied + occupied entries evacuated; `home_arena` retargeted so future resizes land in the surviving arena |
| TENSOR | deep | dimensions/elements raw buffers copied (numeric payload, no tagged interior) |
| EXCEPTION | deep | message/filename C strings, irritants array + each irritant |
| CLOSURE (CALLABLE) | deep | env header+captures; mutable-capture cells chased conservatively (see above); `name` string copied |
| STRING / SYMBOL / BIGNUM / RATIONAL / BYTEVECTOR | leaf copy | self-contained payloads; a contiguous copy fully preserves them |
| PORT | shallow, never deep-copied | wraps OS resources/fds; struct copied so the tagged value stays valid, underlying handle intentionally shared |
| LAMBDA_SEXPR / AD_NODE / PRIMITIVE / CONTINUATION | shallow (leaf) | interior graphs (S-expression arenas, AD tape linkage) not confidently traversable here; AD tape has its own lifetime machinery and mixing it with with-region escape is out of scope |
| SUBSTITUTION / FACT / KNOWLEDGE_BASE / FACTOR_GRAPH / WORKSPACE / PROMISE / PRNG / DNC / SDNC / TAYLOR | shallow (leaf) | internal layouts not traversed; matches pre-fix behavior for these subtypes, documented in code |

A plausibility guard (`header->size > 256MB` -> leave in place + warn) protects traversal if a legacy headerless cons cell ever leaks into a reachable graph.

## Barrier channels covered

- `vector-set!` (Scheme-vector path; tensor path stores raw doubles — no pointers)
- `set-car!` / `set-cdr!` (tagged-value path)
- `hash-table-set!` / `hash-set!` (key and value)
- `set!` on a **GlobalVariable** destination (incl. REPL globals)
- `vector-fill!` (one barrier call; same promoted value fills all slots)
- `vector-copy!` (range barrier after the memmove)

NOT barriered (documented limitations):
- `set!` on plain local allocas / closure-capture pointers — conservatively skipped to avoid over-promoting values that never cross a region boundary. A region value stored via `set!` into a captured variable belonging to a scope that outlives the region is still unsafe (pre-existing).
- `string-set!` / `bytevector-u8-set!` / tensor stores — raw bytes/doubles, no pointers, nothing to promote.
- `list-set!` has no live codegen dispatch (not a channel).

## Semantics notes

- Escape is a *snapshot at store time*: mutations applied to the in-region original AFTER it escaped (through the original reference, not the escaped one) are not replayed onto the promoted copy. Within one region body, repeated stores of the same object reuse the same promoted copy via the forwarding map.
- Promoted data lands in an arena (no GC): overwriting an outer slot in a loop retains each promoted generation until the owning arena is reclaimed. RSS growth is proportional to genuinely escaping data only.

## Acceptance results (macOS arm64, Release)

1. **tests/memory/region_deep_escape_test.esk** — 16/16 PASS in both JIT (`-r`) and AOT: 100k cons-lists via `vector-set!` into an outer vector (spot-verified), nested vector + nested list, closures capturing region values, shared tail preserved with TRUE aliasing (`set-car!` through one list visible through the other), 2-node cyclic structure survives escape.
2. **tests/memory/region_mutating_loop_flat_rss_test.sh** (AOT) — guard-wrapped define loop, 400k iterations, each allocating ~100-cell transient garbage in a **per-iteration** `with-region` (that placement reclaims per iteration) and mutating one slot of an outer 64-slot vector with a fresh 3-element list: peak RSS **90MB** (ceiling 300MB; the unfixed no-region leak is ~17.5KB/iter = ~7GB) AND all 64 slots read back intact at the end. Companion ESH-0214b gate: 27MB with reclamation on vs 2608MB advisory with it disabled.
3. **Suite**: scripts/run_all_tests.sh green on the branch build (see PR checks / local log); existing with-region tests unregressed — tests/v1_3_edge_cases/with_region_reclaims_test.esk 11/11. ICC smoke 30/31 (the 1 miss, `example_agent_compiles`, is an untracked local `examples/agent.esk` absent from any commit — environmental, fails identically on a clean master checkout).
   - Pre-existing, unrelated: `with_region_reclaims_test.sh`'s ratio criterion (region < baseline/2) fails on master too (27MB vs 26MB) because ESH-0214b iter-scope reclamation flattened the no-region baseline; its RSS-bounded criterion passes.

## Performance

- No-region fast path: one thread-local load + branch behind one call. 20M-iteration pure `vector-set!` microloop: 1.06s -> 1.12s user (~3ns/op); real workloads see far less.
- Deep promotion cost is proportional to the escaping subgraph only; the rest of the region is reclaimed for free by `region_pop`.
