### PR TITLE
harden(runtime): bounds/overflow fixes in string/vector/tensor/bignum surfaces

### DIFF
--- a/lib/backend/collection_codegen.cpp
+++ b/lib/backend/collection_codegen.cpp
@@ -1465,6 +1465,46 @@ llvm::Value* CollectionCodegen::makeVector(const eshkol_operations_t* op) {
     // Extract length as i64
     llvm::Value* length = tagged_.unpackInt64(len_tagged);
 
+    // Guard against a negative length. The fill loop below compares with an
+    // unsigned predicate, so a negative length wraps to ~2^63 iterations of
+    // out-of-bounds stores (hang / OOM / heap corruption). make-vector
+    // requires a non-negative k in R7RS — raise a catchable error instead.
+    {
+        llvm::Value* neg_len = ctx_.builder().CreateICmpSLT(length,
+            llvm::ConstantInt::get(ctx_.int64Type(), 0));
+        llvm::Function* mv_func = ctx_.builder().GetInsertBlock()->getParent();
+        llvm::BasicBlock* mv_ok = llvm::BasicBlock::Create(ctx_.context(), "mkvec_len_ok", mv_func);
+        llvm::BasicBlock* mv_fail = llvm::BasicBlock::Create(ctx_.context(), "mkvec_len_fail", mv_func);
+        ctx_.builder().CreateCondBr(neg_len, mv_fail, mv_ok);
+
+        ctx_.builder().SetInsertPoint(mv_fail);
+        {
+            llvm::Function* raise_func = ctx_.module().getFunction("eshkol_raise");
+            if (!raise_func) {
+                llvm::FunctionType* raise_type = llvm::FunctionType::get(
+                    ctx_.builder().getVoidTy(), {ctx_.ptrType()}, false);
+                raise_func = llvm::Function::Create(raise_type, llvm::Function::ExternalLinkage,
+                    "eshkol_raise", &ctx_.module());
+                raise_func->setDoesNotReturn();
+            }
+            llvm::Function* make_exc_func = ctx_.module().getFunction("eshkol_make_exception_with_header");
+            if (!make_exc_func) {
+                llvm::FunctionType* make_type = llvm::FunctionType::get(ctx_.ptrType(),
+                    {ctx_.builder().getInt32Ty(), ctx_.ptrType()}, false);
+                make_exc_func = llvm::Function::Create(make_type, llvm::Function::ExternalLinkage,
+                    "eshkol_make_exception_with_header", &ctx_.module());
+            }
+            llvm::Value* msg = ctx_.builder().CreateGlobalString(
+                "make-vector: length must be non-negative");
+            llvm::Value* exc_type = llvm::ConstantInt::get(ctx_.builder().getInt32Ty(), ESHKOL_EXCEPTION_ERROR);
+            llvm::Value* exc = ctx_.builder().CreateCall(make_exc_func, {exc_type, msg});
+            ctx_.builder().CreateCall(raise_func, {exc});
+            ctx_.builder().CreateUnreachable();
+        }
+
+        ctx_.builder().SetInsertPoint(mv_ok);
+    }
+
     // Allocate from arena with header (for consolidated HEAP_PTR type)
     llvm::Value* arena_ptr = ctx_.builder().CreateLoad(ctx_.ptrType(), ctx_.globalArena());
     llvm::Value* vec_ptr = ctx_.builder().CreateCall(mem_.getArenaAllocateVectorWithHeader(),

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -26992,6 +26992,34 @@ private:
         return builder->CreatePtrToInt(typed_tensor_ptr, int64_type);
     }
     
+    // Emit an out-of-bounds raise for the vref/tensor-ref access paths and
+    // terminate the current block with `unreachable`. The caller is expected to
+    // have positioned the builder in a dedicated failure block. Mirrors the
+    // eshkol_raise / eshkol_make_exception_with_header idiom used by the
+    // collection and string bounds-check paths.
+    void emitVrefBoundsRaise(const char* message) {
+        Function* raise_func = module->getFunction("eshkol_raise");
+        if (!raise_func) {
+            FunctionType* raise_type = FunctionType::get(
+                builder->getVoidTy(), {builder->getPtrTy()}, false);
+            raise_func = Function::Create(raise_type, Function::ExternalLinkage,
+                "eshkol_raise", module.get());
+            raise_func->setDoesNotReturn();
+        }
+        Function* make_exc_func = module->getFunction("eshkol_make_exception_with_header");
+        if (!make_exc_func) {
+            FunctionType* make_type = FunctionType::get(builder->getPtrTy(),
+                {builder->getInt32Ty(), builder->getPtrTy()}, false);
+            make_exc_func = Function::Create(make_type, Function::ExternalLinkage,
+                "eshkol_make_exception_with_header", module.get());
+        }
+        Value* msg = builder->CreateGlobalString(message);
+        Value* exc_type = ConstantInt::get(builder->getInt32Ty(), ESHKOL_EXCEPTION_ERROR);
+        Value* exc = builder->CreateCall(make_exc_func, {exc_type, msg});
+        builder->CreateCall(raise_func, {exc});
+        builder->CreateUnreachable();
+    }
+
     Value* codegenTensorVectorRef(const eshkol_operations_t* op) {
         // vref: (vref tensor index) - shorthand for (tensor-get tensor index)
         // Simplified 1D tensor access for numerical arrays
@@ -27141,6 +27169,23 @@ private:
         // Get index as int64
         Value* scheme_index_int = safeExtractInt64(index);
 
+        // Bounds check: 0 <= idx < length.  The Scheme-vector length word lives
+        // at offset 0; without this guard (tensor-ref (vector ...) idx) with an
+        // out-of-range idx was an out-of-bounds heap READ (ASAN: SEGV).
+        {
+            Value* svec_len = builder->CreateLoad(int64_type, scheme_vec_ptr);
+            Value* svec_neg = builder->CreateICmpSLT(scheme_index_int,
+                ConstantInt::get(int64_type, 0));
+            Value* svec_big = builder->CreateICmpSGE(scheme_index_int, svec_len);
+            Value* svec_bad = builder->CreateOr(svec_neg, svec_big);
+            BasicBlock* svec_ok = BasicBlock::Create(*context, "vref_svec_bounds_ok", current_func);
+            BasicBlock* svec_fail = BasicBlock::Create(*context, "vref_svec_bounds_fail", current_func);
+            builder->CreateCondBr(svec_bad, svec_fail, svec_ok);
+            builder->SetInsertPoint(svec_fail);
+            emitVrefBoundsRaise("tensor-ref: index out of bounds");
+            builder->SetInsertPoint(svec_ok);
+        }
+
         // Get pointer to elements (after length field - 8 bytes offset)
         Value* scheme_elem_base = builder->CreateGEP(int8_type, scheme_vec_ptr,
             ConstantInt::get(int64_type, 8));
@@ -27162,12 +27207,33 @@ private:
         // Use class member tensor_type (shared by all tensor operations)
         
         Value* vector_ptr = builder->CreateIntToPtr(vector_ptr_int, builder->getPtrTy());
-        
+
         // Get elements array
         Value* elements_field = builder->CreateStructGEP(tensor_type, vector_ptr, 2);
         Value* elements_ptr = builder->CreateLoad(PointerType::getUnqual(*context), elements_field);
         Value* typed_elements_ptr = builder->CreatePointerCast(elements_ptr, builder->getPtrTy());
-        
+
+        // Bounds check: 0 <= idx < total_elements.  This 2-arg tensor-ref/vref
+        // path indexed the flat element buffer with no guard, so a negative or
+        // out-of-range index (e.g. (tensor-ref t 900000000000)) was an
+        // out-of-bounds heap READ (ASAN: SEGV on READ). Field 3 is
+        // total_elements. Mirrors the guard the collection vector-ref path and
+        // tensor-set! already enforce.
+        {
+            Value* total_field = builder->CreateStructGEP(tensor_type, vector_ptr, 3);
+            Value* total_elems = builder->CreateLoad(int64_type, total_field);
+            Value* tref_neg = builder->CreateICmpSLT(index_int,
+                ConstantInt::get(int64_type, 0));
+            Value* tref_big = builder->CreateICmpSGE(index_int, total_elems);
+            Value* tref_bad = builder->CreateOr(tref_neg, tref_big);
+            BasicBlock* tref_ok = BasicBlock::Create(*context, "vref_tensor_bounds_ok", current_func);
+            BasicBlock* tref_fail = BasicBlock::Create(*context, "vref_tensor_bounds_fail", current_func);
+            builder->CreateCondBr(tref_bad, tref_fail, tref_ok);
+            builder->SetInsertPoint(tref_fail);
+            emitVrefBoundsRaise("tensor-ref: index out of bounds");
+            builder->SetInsertPoint(tref_ok);
+        }
+
         // Load element as int64 (could be double bitcasted OR AD node pointer)
         Value* elem_ptr = builder->CreateGEP(int64_type, typed_elements_ptr, index_int);
         Value* elem_as_int64 = builder->CreateLoad(int64_type, elem_ptr);

--- a/lib/backend/string_io_codegen.cpp
+++ b/lib/backend/string_io_codegen.cpp
@@ -1139,6 +1139,45 @@ llvm::Value* StringIOCodegen::makeString(const eshkol_operations_t* op) {
         len = ctx_.builder().CreateZExt(len, ctx_.int64Type());
     }
 
+    // Guard against a negative length. `len` flows into memset as a size_t;
+    // a negative value wraps to an enormous unsigned count, hanging/OOMing the
+    // process (make-string requires a non-negative k in R7RS). Raise instead.
+    {
+        llvm::Value* neg_len = ctx_.builder().CreateICmpSLT(len,
+            llvm::ConstantInt::get(ctx_.int64Type(), 0));
+        llvm::Function* ms_func = ctx_.builder().GetInsertBlock()->getParent();
+        llvm::BasicBlock* ms_ok = llvm::BasicBlock::Create(ctx_.context(), "mkstr_len_ok", ms_func);
+        llvm::BasicBlock* ms_fail = llvm::BasicBlock::Create(ctx_.context(), "mkstr_len_fail", ms_func);
+        ctx_.builder().CreateCondBr(neg_len, ms_fail, ms_ok);
+
+        ctx_.builder().SetInsertPoint(ms_fail);
+        {
+            llvm::Function* raise_func = ctx_.module().getFunction("eshkol_raise");
+            if (!raise_func) {
+                llvm::FunctionType* raise_type = llvm::FunctionType::get(
+                    ctx_.builder().getVoidTy(), {ctx_.ptrType()}, false);
+                raise_func = llvm::Function::Create(raise_type, llvm::Function::ExternalLinkage,
+                    "eshkol_raise", &ctx_.module());
+                raise_func->setDoesNotReturn();
+            }
+            llvm::Function* make_exc_func = ctx_.module().getFunction("eshkol_make_exception_with_header");
+            if (!make_exc_func) {
+                llvm::FunctionType* make_type = llvm::FunctionType::get(ctx_.ptrType(),
+                    {ctx_.builder().getInt32Ty(), ctx_.ptrType()}, false);
+                make_exc_func = llvm::Function::Create(make_type, llvm::Function::ExternalLinkage,
+                    "eshkol_make_exception_with_header", &ctx_.module());
+            }
+            llvm::Value* err_msg = ctx_.builder().CreateGlobalString(
+                "make-string: length must be non-negative");
+            llvm::Value* exc_type = llvm::ConstantInt::get(ctx_.builder().getInt32Ty(), ESHKOL_EXCEPTION_ERROR);
+            llvm::Value* exception = ctx_.builder().CreateCall(make_exc_func, {exc_type, err_msg});
+            ctx_.builder().CreateCall(raise_func, {exception});
+            ctx_.builder().CreateUnreachable();
+        }
+
+        ctx_.builder().SetInsertPoint(ms_ok);
+    }
+
     // Get the fill character (default to space, ASCII 32)
     llvm::Value* fill_char;
     if (op->call_op.num_vars == 2) {
@@ -1214,6 +1253,58 @@ llvm::Value* StringIOCodegen::stringSet(const eshkol_operations_t* op) {
     // Get character value
     llvm::Value* char_val = tagged_.unpackInt64(char_arg);
     char_val = ctx_.builder().CreateTrunc(char_val, ctx_.int8Type());
+
+    // Bounds check: 0 <= idx < byte-length.  string-set! writes a raw byte
+    // straight at offset idx, so without this guard a negative or out-of-range
+    // index (e.g. (string-set! (make-string 4) 900000000000 #\z)) is an
+    // out-of-bounds heap WRITE (ASAN: BUS/SEGV on WRITE). Use the header byte
+    // length (payload size excluding the trailing NUL) as the exclusive upper
+    // bound so writing never clobbers the NUL terminator or beyond.
+    llvm::Function* byte_len_func = ctx_.module().getFunction("eshkol_string_byte_length");
+    if (!byte_len_func) {
+        llvm::FunctionType* byte_len_ty = llvm::FunctionType::get(
+            ctx_.int64Type(), {ctx_.ptrType()}, false);
+        byte_len_func = llvm::Function::Create(byte_len_ty,
+            llvm::Function::ExternalLinkage,
+            "eshkol_string_byte_length", &ctx_.module());
+    }
+    llvm::Value* sset_len = ctx_.builder().CreateCall(byte_len_func, {str_ptr});
+    llvm::Value* sset_neg = ctx_.builder().CreateICmpSLT(idx,
+        llvm::ConstantInt::get(ctx_.int64Type(), 0));
+    llvm::Value* sset_big = ctx_.builder().CreateICmpSGE(idx, sset_len);
+    llvm::Value* sset_bad = ctx_.builder().CreateOr(sset_neg, sset_big);
+
+    llvm::Function* sset_func = ctx_.builder().GetInsertBlock()->getParent();
+    llvm::BasicBlock* sset_ok = llvm::BasicBlock::Create(ctx_.context(), "sset_ok", sset_func);
+    llvm::BasicBlock* sset_fail = llvm::BasicBlock::Create(ctx_.context(), "sset_fail", sset_func);
+    ctx_.builder().CreateCondBr(sset_bad, sset_fail, sset_ok);
+
+    ctx_.builder().SetInsertPoint(sset_fail);
+    {
+        llvm::Function* raise_func = ctx_.module().getFunction("eshkol_raise");
+        if (!raise_func) {
+            llvm::FunctionType* raise_type = llvm::FunctionType::get(
+                ctx_.builder().getVoidTy(), {ctx_.ptrType()}, false);
+            raise_func = llvm::Function::Create(raise_type, llvm::Function::ExternalLinkage,
+                "eshkol_raise", &ctx_.module());
+            raise_func->setDoesNotReturn();
+        }
+        llvm::Function* make_exc_func = ctx_.module().getFunction("eshkol_make_exception_with_header");
+        if (!make_exc_func) {
+            llvm::FunctionType* make_type = llvm::FunctionType::get(ctx_.ptrType(),
+                {ctx_.builder().getInt32Ty(), ctx_.ptrType()}, false);
+            make_exc_func = llvm::Function::Create(make_type, llvm::Function::ExternalLinkage,
+                "eshkol_make_exception_with_header", &ctx_.module());
+        }
+        llvm::Value* err_msg = ctx_.builder().CreateGlobalString(
+            "string-set!: index out of bounds");
+        llvm::Value* exc_type = llvm::ConstantInt::get(ctx_.builder().getInt32Ty(), ESHKOL_EXCEPTION_ERROR);
+        llvm::Value* exception = ctx_.builder().CreateCall(make_exc_func, {exc_type, err_msg});
+        ctx_.builder().CreateCall(raise_func, {exception});
+        ctx_.builder().CreateUnreachable();
+    }
+
+    ctx_.builder().SetInsertPoint(sset_ok);
 
     // Store character at index
     llvm::Value* char_ptr = ctx_.builder().CreateGEP(ctx_.int8Type(), str_ptr, idx);

--- a/lib/backend/tensor_codegen.cpp
+++ b/lib/backend/tensor_codegen.cpp
@@ -654,6 +654,51 @@ llvm::Value* TensorCodegen::tensorGet(const eshkol_operations_t* op) {
         num_indices_val = llvm::ConstantInt::get(ctx_.int64Type(), num_indices);
     }
 
+    // ===== BOUNDS CHECK: linear_offset in [0, total_elements) =====
+    // The single-index (num_indices == 1) path routes through
+    // eshkol_tensor_linear_from_index_arg, which trusts the caller and does
+    // NOT bounds-check the resulting offset. Without this guard a negative or
+    // out-of-range scalar/list index (e.g. (tensor-get t 900000000000)) walked
+    // straight into an out-of-bounds load below (ASAN: SEGV on READ). An
+    // unsigned compare catches both negatives (wrap to huge) and overshoot,
+    // and — since any valid slice start is < total_elements — it is safe for
+    // the partial-index slice path too. Mirrors the guard tensor-set! already
+    // performs on its own linear index.
+    {
+        llvm::Value* oob = ctx_.builder().CreateICmpUGE(linear_offset, total_elements);
+        llvm::Function* cur_fn = ctx_.builder().GetInsertBlock()->getParent();
+        llvm::BasicBlock* tget_bounds_ok = llvm::BasicBlock::Create(ctx_.context(), "tget_bounds_ok", cur_fn);
+        llvm::BasicBlock* tget_bounds_err = llvm::BasicBlock::Create(ctx_.context(), "tget_bounds_err", cur_fn);
+        ctx_.builder().CreateCondBr(oob, tget_bounds_err, tget_bounds_ok);
+
+        ctx_.builder().SetInsertPoint(tget_bounds_err);
+        {
+            llvm::Function* raise_func = ctx_.module().getFunction("eshkol_raise");
+            if (!raise_func) {
+                llvm::FunctionType* raise_type = llvm::FunctionType::get(
+                    ctx_.builder().getVoidTy(), {ctx_.ptrType()}, false);
+                raise_func = llvm::Function::Create(raise_type, llvm::Function::ExternalLinkage,
+                    "eshkol_raise", &ctx_.module());
+                raise_func->setDoesNotReturn();
+            }
+            llvm::Function* make_exc_func = ctx_.module().getFunction("eshkol_make_exception_with_header");
+            if (!make_exc_func) {
+                llvm::FunctionType* make_type = llvm::FunctionType::get(ctx_.ptrType(),
+                    {ctx_.builder().getInt32Ty(), ctx_.ptrType()}, false);
+                make_exc_func = llvm::Function::Create(make_type, llvm::Function::ExternalLinkage,
+                    "eshkol_make_exception_with_header", &ctx_.module());
+            }
+            llvm::Value* msg = ctx_.builder().CreateGlobalString(
+                "tensor-get: index out of bounds");
+            llvm::Value* exc_type = llvm::ConstantInt::get(ctx_.builder().getInt32Ty(), ESHKOL_EXCEPTION_ERROR);
+            llvm::Value* exc = ctx_.builder().CreateCall(make_exc_func, {exc_type, msg});
+            ctx_.builder().CreateCall(raise_func, {exc});
+            ctx_.builder().CreateUnreachable();
+        }
+
+        ctx_.builder().SetInsertPoint(tget_bounds_ok);
+    }
+
     // ===== PHASE 2: Decide scalar vs slice =====
     llvm::Value* is_full_index = ctx_.builder().CreateICmpEQ(num_indices_val, ndim);
 

--- a/tests/features/runtime_bounds_hardening_test.esk
+++ b/tests/features/runtime_bounds_hardening_test.esk
@@ -1,0 +1,66 @@
+;;; runtime_bounds_hardening_test.esk
+;;;
+;;; Regression tests for the runtime bounds/overflow hardening audit.
+;;;
+;;; Each of the following operations previously performed an unchecked memory
+;;; access reachable straight from Scheme, confirmed under AddressSanitizer:
+;;;
+;;;   - (string-set! s k c)   raw byte WRITE at offset k, no bounds check
+;;;                           -> ASAN BUS/SEGV on WRITE (out-of-bounds heap write)
+;;;   - (tensor-ref t k)      flat element READ at index k, no bounds check
+;;;                           -> ASAN SEGV on READ
+;;;   - (tensor-get t k)      single-index READ, linear offset unchecked
+;;;                           -> ASAN SEGV on READ
+;;;   - (make-string -1 c)    negative length -> memset with ~2^64 size (hang/OOM)
+;;;   - (make-vector -1 x)    negative length -> ~2^63 out-of-bounds stores (hang/OOM)
+;;;
+;;; They now raise a catchable condition instead of corrupting memory. This
+;;; test asserts the error IS raised for out-of-range arguments and that valid
+;;; in-range arguments still behave exactly as before. It requires no
+;;; sanitizer to run.
+
+(require stdlib)
+
+;; Assert that evaluating `thunk` raises a condition (rather than crashing or
+;; silently succeeding).
+(define (expect-raise name thunk)
+  (let ((r (guard (e (#t 'raised)) (thunk) 'no-raise)))
+    (if (eq? r 'raised)
+        (begin (display "PASS: ") (display name) (newline))
+        (begin (display "FAIL: ") (display name) (display " (expected raise)") (newline)))))
+
+;; Assert an ordinary (non-erroring) result is unchanged.
+(define (expect-equal name actual expected)
+  (if (equal? actual expected)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (display "FAIL: ") (display name)
+             (display " expected=") (write expected)
+             (display " actual=") (write actual) (newline))))
+
+;; ---- out-of-bounds / out-of-range arguments must raise, not crash ----
+(expect-raise "string-set! huge index raises"
+  (lambda () (string-set! (make-string 4 #\a) 900000000000 #\z)))
+(expect-raise "string-set! negative index raises"
+  (lambda () (string-set! (make-string 4 #\a) -5 #\z)))
+(expect-raise "tensor-ref huge index raises"
+  (lambda () (tensor-ref (arange 3) 900000000000)))
+(expect-raise "tensor-ref negative index raises"
+  (lambda () (tensor-ref (arange 3) -1)))
+(expect-raise "tensor-get huge index raises"
+  (lambda () (tensor-get (arange 3) 900000000000)))
+(expect-raise "make-string negative length raises"
+  (lambda () (make-string -1 #\a)))
+(expect-raise "make-vector negative length raises"
+  (lambda () (make-vector -1 0)))
+
+;; ---- valid in-range arguments must still work unchanged ----
+(let ((s (make-string 4 #\a)))
+  (string-set! s 2 #\z)
+  (expect-equal "string-set! valid index unchanged" (string-ref s 2) #\z))
+(expect-equal "tensor-ref valid index unchanged" (tensor-ref (arange 3) 2) 2.0)
+(expect-equal "tensor-get valid index unchanged" (tensor-get (arange 3) 1) 1.0)
+(expect-equal "make-vector valid length unchanged" (vector-length (make-vector 3 0)) 3)
+(expect-equal "make-string valid length unchanged" (string-length (make-string 5 #\x)) 5)
+
+(display "runtime bounds hardening test complete")
+(newline)


### PR DESCRIPTION
## Summary

Adversarial bounds/overflow hardening audit of the runtime value-family
surfaces reachable from Scheme (strings/UTF-8, vectors/bytevectors,
tensors, bignum/rational). Found and fixed several unchecked memory
accesses. **Every fixed OOB bug was confirmed under AddressSanitizer**
(ASAN build driving the in-process `-r` JIT); each now raises a catchable
condition instead of corrupting memory. Behaviour on valid in-range inputs
is unchanged (regression test passes in both JIT and AOT).

## Bugs fixed

| Surface | Bug | ASAN before | Fix | Regression test |
|---|---|---|---|---|
| `string-set!` | raw byte WRITE at offset `k`, no bounds check (old comment even said "no bounds check here") | `(string-set! (make-string 4) 900000000000 #\z)` -> `AddressSanitizer: BUS on WRITE` (OOB heap write) | bounds-check `k` in `[0, byte-length)`, raise otherwise | `string-set! huge/negative index raises` |
| `tensor-ref` / `vref` (2-arg) | flat element READ, no bounds check — tensor path **and** Scheme-vector path | `(tensor-ref (arange 3) 900000000000)` -> `AddressSanitizer: SEGV on READ` | bounds-check index vs `total_elements` / vector length, raise otherwise | `tensor-ref huge/negative index raises` |
| `tensor-get` (single index) | 1-arg path routes through `eshkol_tensor_linear_from_index_arg` (trusts caller); linear offset never checked before scalar load | `(tensor-get (arange 3) 900000000000)` -> `AddressSanitizer: SEGV on READ` | add the `linear_offset < total_elements` check the multi-arg / `tensor-set!` paths already have | `tensor-get huge index raises` |
| `make-string` | negative length flows into `memset` as `size_t` (~2^64 fill) | hang / OOM | raise "length must be non-negative" | `make-string negative length raises` |
| `make-vector` | negative length: fill loop's unsigned compare -> ~2^63 OOB stores | hang / OOM | raise "length must be non-negative" | `make-vector negative length raises` |

After the fixes, every repro prints a clean catchable error (e.g.
`Unhandled exception: tensor-ref: index out of bounds`) with **no ASAN
report**. All error paths use the existing
`eshkol_raise` / `eshkol_make_exception_with_header` idiom, matching the
already-guarded `vector-ref` / `string-ref` paths, so they are catchable
with `guard`.

## Surfaces audited and found already clean (no changes)

- **Bytevectors** — `make-bytevector`, `bytevector-u8-ref/set!`,
  `bytevector-copy`: all bounds- and range-checked.
- **Strings** — `string-ref`, `substring`, `string-copy`, `string-append`,
  and the UTF-8 runtime helpers (`eshkol_utf8_ref/substring/strlen`):
  negative/`start>end`/overshoot all guarded.
- **Vectors** — collection `vector-ref` / `vector-set!` (incl. their
  tensor branches): bounds-checked.
- **Tensors** — `tensor-set!` (already bounds-checked), tensor allocation
  (`arena_allocate_tensor_full` overflow-checked), rect/disk fills
  (clamped to extents).
- **Bignum / rational** — 64-bit arena allocation sizes, fixed-size
  `snprintf` formatting, shift counts guarded (`shift > 0`).

## Verification

- ASAN+UBSAN build (AppleClang) reproduced every OOB as BUS/SEGV before
  the fix and a clean catchable raise after.
- Clean Release build green.
- New `tests/features/runtime_bounds_hardening_test.esk` (12 checks: 7
  out-of-range must-raise + 5 valid-input unchanged) passes **12/12 in
  both JIT (`-r`) and AOT**, no sanitizer required.
- Surface-relevant existing tests re-run AOT with no regression:
  `tests/xla/shape_ops_test.esk` (heavy `tensor-get`) all PASS,
  `r7rs_wave2_test`, `closure_mutation_test`, `bytevector_test` clean.