### PR TITLE
feat(ad): complete input2 gradient plumbing for conv2d/batchnorm/layernorm/attention

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -333,11 +333,18 @@ much more: a full arbitrary-order automatic-differentiation system.
       system libpng/libjpeg/libwebp on Linux, GDI+ on Windows).
       Going forward the project does not vendor third-party media
       decoders.
-- [x] AD `input2` plumbing for `tensor-matmul` — verified by
-      `gradient` smoke probe: gradient flows to the kernel side
-      (input2). Conv2d / batchnorm / layernorm / attention forward
-      sites still leave `input2` null in their tape nodes and are
-      tracked separately.
+- [x] AD second-operand (`input2`) gradient plumbing for every tensor
+      op — `tensor-matmul`, `conv2d`, `batch-norm`, `layer-norm`, and
+      `scaled-dot-attention`. Each op's AD forward path unrolls into the
+      scalar reverse-mode graph (`recordADNodeBinary`), so gradients flow
+      to the second differentiable operand (matmul kernel, conv2d kernel,
+      norm gamma, attention K/V) with no monolithic tape node left with a
+      null `input2`. Verified end-to-end by the finite-difference AD oracle
+      `tests/v1_3_edge_cases/ad_input2_test.esk` and smoke probes
+      `ad_input2_conv2d_grad_works` / `ad_input2_batchnorm_grad_works` /
+      `ad_input2_layernorm_grad_works` / `ad_input2_attention_grad_works`
+      (JIT `-r` and AOT), which compare the AD gradient to central finite
+      differences at tight tolerance.
 - [x] **Arbitrary-order AD Taylor-tower campaign — fully delivered, all 13
       phases (P0-P12), well ahead of the original P1-only-in-v1.3 plan
       below**: runtime tower + `taylor`/`derivative-n` (P1); no-heap

--- a/tests/v1_3_edge_cases/ad_input2_test.esk
+++ b/tests/v1_3_edge_cases/ad_input2_test.esk
@@ -54,6 +54,18 @@
 (define (finite-diff-scalar f x eps)
   (/ (- (f (+ x eps)) (f (- x eps))) (* 2.0 eps)))
 
+;; True iff at least one component of the gradient vector is non-trivial.
+;; Used to guarantee second-operand gradients are genuinely flowing, not
+;; a null-input2 zero that would spuriously "match" a zero finite diff.
+(define (vec-any-nonzero? g)
+  (let ((n (vector-length g)))
+    (letrec ((loop
+              (lambda (i)
+                (if (< i n)
+                    (if (> (abs (vector-ref g i)) 1e-9) #t (loop (+ i 1)))
+                    #f))))
+      (loop 0))))
+
 ;; conv2d: f(k) = sum(conv2d(image, reshape(k, 2, 2), stride=1)).
 ;; NON-SCALAR operand (a 2x2 kernel over a 3x3 image), checked at TIGHT
 ;; tolerance against BOTH the analytic gradient AND central finite differences.
@@ -143,7 +155,30 @@
          (and (= (vector-length g-k) 4)
               (= (vector-length g-v) 4)
               (gradient-matches-finite-diff? g-k k-loss k0 1e-4 1e-3)
-              (gradient-matches-finite-diff? g-v v-loss v0 1e-4 1e-3))))
+              (gradient-matches-finite-diff? g-v v-loss v0 1e-4 1e-3)))
+  ;; Second-operand gradients must be genuinely present — guard against a
+  ;; false "match" where a null input2 collapses BOTH the AD gradient and
+  ;; the finite difference to zero. K and V are the second/third operands
+  ;; of scaled-dot-attention; both gradients are non-trivial here.
+  (check "ad_input2_attention_k_grad_nonzero" (vec-any-nonzero? g-k))
+  (check "ad_input2_attention_v_grad_nonzero" (vec-any-nonzero? g-v)))
+
+;; Non-zero guards for the remaining second operands (conv2d kernel and
+;; normalization gamma), so a regression that silently zeroes input2 cannot
+;; slip through a finite-difference comparison that also reads zero.
+(let* ((image (tensor 3 3 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0))
+       (k0 (tensor 4 1.0 1.0 1.0 1.0))
+       (conv-loss (lambda (k) (tensor-sum (conv2d image (reshape k 2 2) 1))))
+       (g-conv (gradient conv-loss k0))
+       (x (tensor 3 1.0 2.0 4.0))
+       (weights (tensor 3 1.0 2.0 3.0))
+       (bn-loss (lambda (gamma) (tensor-sum (tensor-mul (batch-norm x gamma 0.0 0.00001) weights))))
+       (ln-loss (lambda (gamma) (tensor-sum (tensor-mul (layer-norm x gamma 0.0 0.00001) weights))))
+       (g-bn (gradient bn-loss 1.0))
+       (g-ln (gradient ln-loss 1.0)))
+  (check "ad_input2_conv2d_kernel_grad_nonzero" (vec-any-nonzero? g-conv))
+  (check "ad_input2_batchnorm_gamma_grad_nonzero" (not (approx= g-bn 0.0 1e-9)))
+  (check "ad_input2_layernorm_gamma_grad_nonzero" (not (approx= g-ln 0.0 1e-9))))
 
 (display "Results: ") (display passed) (display " passed, ")
 (display failed) (display " failed") (newline)


### PR DESCRIPTION
## Summary

Completes the AD second-operand (`input2`) gradient matrix begun with `tensor-matmul`. The second-operand gradient path is now verified end-to-end for **conv2d**, **batch-norm**, **layer-norm** and **scaled-dot-attention**, closing the stale ROADMAP gap (~line 336) that claimed these ops left `input2` null.

### Mechanism

In the compiled AD path, each tensor op's forward pass unrolls into the scalar reverse-mode graph via `recordADNodeBinary` (mul/add/div nodes each carry `input1`/`input2`), rather than emitting a single monolithic tensor tape node. Because the second operand is bound as `input2` of those scalar product nodes, its gradient flows automatically — the same way it already did for matmul. Confirmed on `master`:

- `lib/backend/tensor_conv_codegen.cpp` — conv2d wires `recordADNodeBinary(4, ad_in_node, ad_kernel_node)`; normalize dispatch wires `scaled = recordADNodeBinary(4, normalized, gamma_node)`.
- `lib/backend/tensor_transformer_codegen.cpp` — attention wires Q/K into the score product and V into the weighted sum.

### Per-op finite-difference verification (AD vs central differences)

| op | second operand | AD gradient | finite-diff | max error |
|----|----------------|-------------|-------------|-----------|
| conv2d | 2x2 kernel over 3x3 image | `[12, 16, 24, 28]` | `[12, 16, 24, 28]` | < 1e-4 |
| conv2d (asymmetric kernel) | 2x2 kernel `[1,2,3,4]` | `[12, 16, 24, 28]` | matches | < 1e-4 |
| batch-norm | gamma (scalar) | `2.40534` | `2.40534` | < 1e-3 |
| layer-norm | gamma (scalar) | `2.40534` | `2.40534` | < 1e-3 |
| attention | K (2x2) | `[-0.6256, -0.6256, 0.6256, 0.6256]` | matches | < 1e-3 |
| attention | V (2x2) | `[1, 1, 1, 1]` | matches | < 1e-3 |

conv2d additionally checks against the hand-computed analytic gradient `dL/dK[r,c] = sum over window positions of image[r+oh, c+ow]` at tight (1e-6) tolerance.

### Oracle hardening

`tests/v1_3_edge_cases/ad_input2_test.esk` gains explicit non-zero guards on every second-operand gradient (conv2d kernel, batch/layer-norm gamma, attention K and V). This blocks a false pass where a regression that zeroes `input2` also zeroes the finite difference it is compared against. The oracle now runs **11/11**, under both **JIT (`-r`)** and **AOT**.

### Test results

- `tests/v1_3_edge_cases/ad_input2_test.esk`: 11/11 passed (JIT and AOT).
- Smoke probes `ad_input2_conv2d_grad_works` / `ad_input2_batchnorm_grad_works` / `ad_input2_layernorm_grad_works` / `ad_input2_attention_grad_works` — all show the checkmark (plus `matmul_kernel_grad_nonzero`).
- ctest `v1_3_ad_input2_runtime_smoke` and `autodiff_tensor_reductions_runtime_smoke`: pass.

No compiler/runtime source changed — the plumbing was already correct; this PR verifies it adversarially and corrects the stale roadmap entry.