### PR TITLE
fix/docs: triage deferred latents (ESH-0223/0227/0228)

### DIFF
--- a/.swarm/tasks/ESH-0223.json
+++ b/.swarm/tasks/ESH-0223.json
@@ -1,7 +1,7 @@
 {
   "id": "ESH-0223",
   "title": "named-let TCO loop overflows the native stack around n~300-500k even with NO guard/call-cc/dynamic-alloca construct in the body",
-  "status": "open",
+  "status": "fixed",
   "priority": "high",
   "workstream": "language/tco",
   "goal": "Discovered while reproducing ESH-0222 (tail calls through guard). A completely plain named-let tail loop — `(define (f) (let loop ((n 0)) (if (>= n N) n (loop (+ n 1)))))` — SIGSEGVs/SIGBUSes with the 'stack overflow' diagnostic somewhere between N=300,000 and N=500,000 on unmodified master (verified both before and independent of the ESH-0222 guard fix; a top-level `(define (f n) (if (>= n N) n (f (+ n 1))))` with the identical arithmetic does NOT crash at N=1,000,000+). This means named-let TCO is NOT actually flat today for any sufficiently long-running loop, regardless of guard usage.",

--- a/.swarm/tasks/ESH-0227.json
+++ b/.swarm/tasks/ESH-0227.json
@@ -1,7 +1,7 @@
 {
   "id": "ESH-0227",
   "title": "`(apply loop lst)` is never tail-call-optimized — call_apply_codegen never consults TailCallContext",
-  "status": "open",
+  "status": "fixed",
   "priority": "medium",
   "workstream": "language/tco",
   "owner": null,

--- a/.swarm/tasks/ESH-0228.json
+++ b/.swarm/tasks/ESH-0228.json
@@ -1,7 +1,7 @@
 {
   "id": "ESH-0228",
   "title": "sleep-ms does not type-check its argument — non-numeric input reinterprets tagged-value bits as an integer",
-  "status": "open",
+  "status": "fixed",
   "priority": "medium",
   "workstream": "runtime/robustness",
   "owner": null,

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -94,17 +94,17 @@ Edge-case findings surfaced by the adversarial-testing harnesses (see
   tail calls (emitted as LLVM `musttail`) and run in O(1) stack — ESH-0102
   resolved (2026-07-04). The remaining exception is a higher-order tail call that
   forwards a stack-allocated closure argument, which falls back to a bounded call.
-- **Plain named-let TCO loops overflow the native stack around n≈300k-500k**
-  even with zero `guard`/`call/cc`/dynamic-alloca in the loop body — e.g.
-  `(let loop ((n 0)) (if (>= n N) n (loop (+ n 1))))` SIGSEGVs/SIGBUSes
-  between N=300,000 and N=500,000, while the equivalent top-level
-  `(define (f n) (if (>= n N) n (f (+ n 1))))` runs flat past N=1,000,000.
-  **Status: open, root cause not yet diagnosed** (ESH-0223). This is
-  *distinct* from, and not fixed by, PR #157/ESH-0211 (named-let TCO in
-  `if`/`case`/`when`/`unless` tail positions, merged 2026-07-06) or
-  ESH-0222 (tail calls through `guard`) — both were re-verified against this
-  bug and neither causes nor cures it; it reproduces on unmodified master
-  independent of either fix.
+- Plain named-let TCO loops used to overflow the native stack around
+  n≈300k-500k even with zero `guard`/`call/cc`/dynamic-alloca in the loop body
+  (e.g. `(let loop ((n 0)) (if (>= n N) n (loop (+ n 1))))`). **Status: fixed**
+  (ESH-0223) — no longer reproduces on current master. Re-tested after the
+  define-loop TCO + per-iteration arena reclamation (ESH-0214b/#192), the
+  iterative reader (#191), and deep region-escape (#210) landed: the bare
+  named-let loop now runs flat with O(1) stack (~28 MB RSS, <1 s at N=1e7 under
+  a 512 KB stack ulimit), matching the top-level-define TCO guarantee.
+  Regression test `tests/tco/named_let_long_loop_test.esk` (and Test 1 of
+  `tests/tco/named_let_tail_positions_test.esk`, which runs the identical shape
+  to 1e7).
 
 **Language edges**
 - A closure created inside a named-let loop that `set!`s a global loses the
@@ -122,20 +122,29 @@ Edge-case findings surfaced by the adversarial-testing harnesses (see
   root cause, **one** ticket. **Status: fixed** 2026-07-06 in
   `lib/backend/autodiff_codegen.cpp` (ESH-0221); regression test
   `tests/closures/tco_loop_capture_test.esk`.
-- `(apply loop lst)` is **not** a proper tail call — `call_apply_codegen.cpp`
-  never consults the TCO context, so using `apply` for a loop's back-edge
-  grows the native call stack by one frame per iteration regardless of the
-  target function's body. Documented in
-  [LONG_RUNNING_LOOPS.md](LONG_RUNNING_LOOPS.md) (Q3); call the loop function
-  directly with its arguments spelled out instead. **Status: open, tracked**
-  (ESH-0227).
-- `sleep-ms` does not type-check its argument — the AOT/JIT builtin
-  (`eshkol_builtin_sleep_ms_v`) casts the tagged value's raw `.data` field
-  straight to `int64_t` with no tag check, so a non-numeric argument
-  reinterprets whatever bits happen to be there (a pointer, for heap-tagged
-  values) as a millisecond count instead of raising a type error. Flagged
-  during the v1.3 campaign (Selene slow-tick lead). **Status: open, tracked**
-  (ESH-0228).
+- `(apply f (list ...))` used as a loop's back-edge used to grow the native
+  call stack by one frame per iteration (and, for a named-let, could not even
+  resolve the local loop name — it warned "apply: Unknown function" and
+  returned `'()`). **Status: fixed** (ESH-0227). A statically spelled
+  `(apply f leading... (list ...))` whose target `f` names the enclosing
+  function's active TCO loop and whose total argument count matches the loop's
+  arity now lowers to the same O(1)-stack loop back-edge a direct
+  `(f arg ...)` self-call gets. The whole-function tail analysis recognizes
+  apply-self-calls, so a *non-tail* apply-self-call still correctly disables the
+  transform (the apply stays a normal call), and a dynamically-shaped final
+  list is left as an ordinary (non-tail) apply. Fixed in
+  `lib/backend/tail_call_codegen.cpp` and `lib/backend/llvm_codegen.cpp`;
+  regression test `tests/tco/apply_loop_tail_test.esk`.
+- `sleep-ms` used not to type-check its argument — the AOT/JIT builtin cast the
+  tagged value's raw `.data` field straight to `int64_t` with no tag check, so a
+  non-numeric argument reinterpreted whatever bits were there (a pointer, for
+  heap-tagged values) as a millisecond count instead of raising a type error;
+  the bytecode VM path silently no-op'd non-numbers. **Status: fixed**
+  (ESH-0228). Both paths now accept only fixnums/flonums (valid values keep
+  their behavior: sleep n ms, or a no-op for `<= 0`) and raise a clean,
+  catchable "Type error in sleep-ms: expected number" on any non-number. Fixed
+  in `lib/core/system_builtins.c` and `lib/backend/vm_native.c`; regression
+  test `tests/system/sleep_ms_test.esk`.
 - Exact rational arithmetic degrades to double once a bignum is involved
   (ESH-0105).
 - Long-form `(quasiquote x)`/`(unquote x)` and nested quasiquote (level >= 2)

--- a/docs/LONG_RUNNING_LOOPS.md
+++ b/docs/LONG_RUNNING_LOOPS.md
@@ -97,15 +97,15 @@ Verified flat at 1,000,000 ticks (top-level `define` form): ~45MB RSS,
 ~22MB peak footprint, well under half a second. See
 `tests/tco/guard_loop_tail_test.esk`.
 
-**Caveat — named-let specifically:** a separate, pre-existing bug
-(ESH-0223, discovered while verifying this fix) means named-let tail loops
-overflow the stack somewhere around 300-500k iterations **regardless of
-whether `guard` is involved at all** — even `(let loop ((n 0)) (if (>= n N)
-n (loop (+ n 1))))` with zero `guard` usage hits it. If you need a loop
-that runs well past that count, prefer a **top-level `define`** (as in the
-canonical pattern above) until ESH-0223 is resolved; `define`-based
-tail-recursive loops are independently verified flat past 10^8 iterations
-(`tests/stress/rec_tco_1e8.esk`).
+**Named-let (ESH-0223, fixed):** a plain named-let tail loop —
+`(let loop ((n 0)) (if (>= n N) n (loop (+ n 1))))` — used to overflow the
+stack around 300-500k iterations regardless of `guard`. That no longer
+reproduces on current master: named-let now runs flat with O(1) stack (~28MB
+RSS, <1s at N=1e7 under a 512KB stack ulimit), matching the top-level-define
+guarantee. Both forms are fine for long-running loops; `define`-based loops
+remain independently verified flat past 10^8 iterations
+(`tests/stress/rec_tco_1e8.esk`) and named-let is locked by
+`tests/tco/named_let_long_loop_test.esk`.
 
 Either way, **the flat-outside-guard pattern at the top of this document
 remains the recommended default** regardless of which bug is or isn't
@@ -126,8 +126,7 @@ In order of preference:
    (the pattern ESH-0222 fixes) — use this when the error boundary
    genuinely needs to wrap the recursive step itself (e.g. different
    recovery logic depending on *where* in the tick the error occurred).
-   Prefer a top-level `define` over a named-let per the ESH-0223 caveat
-   above.
+   Named-let and top-level `define` are both flat here (ESH-0223 fixed).
 
 **Threading state without consing:** prefer a single accumulator value, or
 a small `define-record-type` instance passed by reference, over
@@ -146,27 +145,33 @@ the most robust choice even after that feature lands.
 
 ## Q3: Is `(apply loop lst)` a proper tail call?
 
-**No.** `call_apply_codegen.cpp` never consults the tail-call-optimization
-context (`isTCOActive`/`TailCallContext`) — every `apply` call, self-recursive
-or not, compiles to a genuine (non-tail) LLVM `call`. Using `apply` for a
-loop's back-edge will grow the native call stack by one frame per
-iteration no matter what the target function's body looks like. This is a
-distinct, currently-unfixed gap (tracked separately; not part of
-ESH-0222), not a special case of the guard bug — it reproduces identically
-with or without `guard` in the loop body.
+**Yes, when the argument list is statically spelled** (ESH-0227, fixed).
+`(apply loop leading... (list a b ...))`, where `loop` names the enclosing
+function's active TCO loop and the total spelled-out argument count matches the
+loop's arity, now lowers to the very same O(1)-stack loop back-edge a direct
+`(loop a b ...)` self-call gets — `codegenApply` consults the TCO context and
+emits the branch, and the whole-function tail analysis recognizes
+apply-self-calls (so a *non-tail* apply-self-call still correctly disables the
+transform). This holds identically with or without `guard` in the loop body.
 
-**Do not use `(apply loop next-args)` as a long-running loop's back-edge.**
-Call the loop function directly with its arguments spelled out
-(`(loop (+ tick 1) new-state)`), which does participate in TCO. If the
-argument list's arity is only known at runtime, thread a single record or
-vector instead of relying on `apply` to spread a list.
+**Two cases are still ordinary (non-tail) `apply` calls, by design:**
 
-(A prior attempt to work around ESH-0222 by moving the recursive call
-outside `guard` via `(apply loop (list ...))` ballooned RSS from 0.6GB to
-3GB in about a minute and crashed — consistent with this: every iteration
-made a real, non-tail `apply` call, and the per-iteration `(list ...)`
-allocation was never reclaimed because the surrounding recursion was never
-flat to begin with.)
+1. A **dynamically-shaped final list** — `(apply loop some-list-variable)`
+   where the argument list is not a literal `(list ...)`. Its length (and hence
+   whether it matches the loop arity) is not known at compile time, so it is
+   left as a normal call. Prefer spelling the arguments — `(apply loop (list
+   (+ tick 1) new-state))` or, better, a direct `(loop (+ tick 1) new-state)`.
+2. A **non-tail** apply-self-call (e.g. `(+ 1 (apply loop ...))`) — never a
+   tail call in any language, and it correctly disables the loop transform for
+   the whole function.
+
+For a runtime-arity call, thread a single record or vector rather than relying
+on `apply` to spread a list.
+
+(A prior attempt to work around ESH-0222 by moving the recursive call outside
+`guard` via `(apply loop (list ...))` ballooned RSS from 0.6GB to 3GB in about
+a minute and crashed. With ESH-0227 that exact statically-spelled shape is now
+a flat back-edge; the pathology it described applied to the pre-fix compiler.)
 
 ## Q4: Is there a stack-size stopgap?
 
@@ -186,8 +191,11 @@ indefinitely; use the canonical pattern above instead.
 - `tests/tco/guard_loop_tail_test.esk` — the regression test for this
   document's shapes.
 - `.swarm/tasks/ESH-0222.json` — the guard-tail-position fix.
-- `.swarm/tasks/ESH-0223.json` — the separate, still-open named-let stack
-  bug referenced in the caveat above.
+- `tests/tco/named_let_long_loop_test.esk` — ESH-0223 (named-let long-loop)
+  regression; `tests/tco/apply_loop_tail_test.esk` — ESH-0227 (apply
+  back-edge) regression.
+- `.swarm/tasks/ESH-0223.json`, `.swarm/tasks/ESH-0227.json` — the named-let
+  stack and apply-back-edge tickets referenced above (both fixed).
 - `docs/KNOWN_ISSUES.md` — "Arena memory (OALR) instead of garbage
   collection": Eshkol has no tracing/stop-the-world collector, so a
   long-running loop's memory behavior is governed entirely by arena

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -23418,6 +23418,19 @@ private:
                     if (call_name == func_name) {
                         count++;
                     }
+                    // ESH-0227: (apply f ...) with f == func_name is also a
+                    // self-recursive call (routed through apply). Count it so a
+                    // define whose ONLY recursion is apply-based is not
+                    // mis-classified as non-recursive (total==0 short-circuit),
+                    // which would leave TCO disabled and the apply loop
+                    // overflowing the stack.
+                    if (call_name == "apply" && op->call_op.num_vars >= 1) {
+                        const eshkol_ast_t* applied = &op->call_op.variables[0];
+                        if (applied->type == ESHKOL_VAR && applied->variable.id &&
+                            func_name == applied->variable.id) {
+                            count++;
+                        }
+                    }
                     // Recurse into arguments
                     for (uint64_t i = 0; i < op->call_op.num_vars; i++) {
                         count += countAllRecursiveCalls(&op->call_op.variables[i], func_name);
@@ -23524,6 +23537,21 @@ private:
                         // Check if this call is in tail position
                         bool in_tail = isInTailPosition(ast, body);
                         if (in_tail) {
+                            tail_calls.push_back(op);
+                        }
+                    }
+                    // ESH-0227: (apply f ...) with f == func_name in tail
+                    // position is a tail self-call routed through apply. Record
+                    // it so isSelfTailRecursive's all-in-tail equality holds for
+                    // apply-based loops (this vector is used only for its size;
+                    // codegenApply performs the actual back-edge rewrite). A
+                    // non-tail apply-self-call is deliberately NOT recorded, so
+                    // it makes the counts differ and correctly disables TCO.
+                    if (call_name == "apply" && op->call_op.num_vars >= 1) {
+                        const eshkol_ast_t* applied = &op->call_op.variables[0];
+                        if (applied->type == ESHKOL_VAR && applied->variable.id &&
+                            func_name == std::string(applied->variable.id) &&
+                            isInTailPosition(ast, body)) {
                             tail_calls.push_back(op);
                         }
                     }
@@ -24366,15 +24394,41 @@ private:
             return nullptr;  // TCO not active, caller should use normal call
         }
 
+        // Gather the argument AST nodes from the direct self-call operands and
+        // emit the shared loop back-edge. Extracted into emitTCOBackEdge so the
+        // apply-in-tail-position path (ESH-0227) can reuse the identical
+        // arg-eval/store/branch sequence with argument nodes it recovered from
+        // a statically-spelled `(apply f ... (list ...))`.
+        std::vector<const eshkol_ast_t*> arg_nodes;
+        arg_nodes.reserve(call_op->call_op.num_vars);
+        for (uint64_t i = 0; i < call_op->call_op.num_vars; i++) {
+            arg_nodes.push_back(&call_op->call_op.variables[i]);
+        }
+        return emitTCOBackEdge(arg_nodes, tco_ctx);
+    }
+
+    // Shared core of a TCO loop back-edge: evaluate `arg_nodes` (with TCO
+    // suppressed during the evaluation, since arguments are never in tail
+    // position), store the resulting values into the loop's parameter allocas,
+    // and branch to the loop header. Returns a null sentinel (the block is
+    // terminated by the branch and the caller never observes a real value), or
+    // nullptr if TCO is inactive or the argument count does not match the
+    // loop's arity, in which case the caller must fall back to a normal call.
+    Value* emitTCOBackEdge(const std::vector<const eshkol_ast_t*>& arg_nodes,
+                           eshkol::BindingCodegen::TailCallContext& tco_ctx) {
+        if (!tco_ctx.enabled || !tco_ctx.loop_header) {
+            return nullptr;
+        }
+
         // Check arity matches
-        if (call_op->call_op.num_vars != tco_ctx.param_allocas.size()) {
+        if (arg_nodes.size() != tco_ctx.param_allocas.size()) {
             eshkol_warn_at(
                 g_source_filepath.empty() ? nullptr : g_source_filepath.c_str(),
                 current_source_line, current_source_column,
                 g_source_text.empty() ? nullptr : g_source_text.c_str(),
-                "TCO: arity mismatch in tail call to %s (expected %zu, got %llu)",
+                "TCO: arity mismatch in tail call to %s (expected %zu, got %zu)",
                 tco_ctx.func_name.c_str(), tco_ctx.param_allocas.size(),
-                (unsigned long long)call_op->call_op.num_vars);
+                arg_nodes.size());
             return nullptr;
         }
 
@@ -24404,10 +24458,10 @@ private:
 
         // Evaluate all arguments first (to temporaries)
         std::vector<Value*> new_values;
-        for (uint64_t i = 0; i < call_op->call_op.num_vars; i++) {
-            Value* arg = codegenAST(&call_op->call_op.variables[i]);
+        for (size_t i = 0; i < arg_nodes.size(); i++) {
+            Value* arg = codegenAST(arg_nodes[i]);
             if (!arg) {
-                eshkol_error("TCO: Failed to evaluate argument %llu", (unsigned long long)i);
+                eshkol_error("TCO: Failed to evaluate argument %zu", i);
                 tco_ctx.enabled = saved_enabled;
                 tco_ctx.loop_header = saved_header;
                 return nullptr;
@@ -34181,7 +34235,74 @@ private:
     // (apply fn args-list) - calls fn with arguments from args-list
     // REFACTORED: Delegates to CallApplyCodegen module
     Value* codegenApply(const eshkol_operations_t* op) {
+        // ESH-0227: proper tail call through `apply`. `(apply f a1 ... aM
+        // (list b1 ... bK))`, where `f` names the enclosing function's active
+        // TCO loop and the total spelled-out argument count (M + K) matches the
+        // loop's arity, is a legitimate R7RS tail call. Lower it to the very
+        // same loop back-edge a direct `(f a1 ... aM b1 ... bK)` self-call
+        // gets, instead of a genuine (stack-growing) call — otherwise using
+        // `apply` as a loop's back-edge overflows the native stack (one frame
+        // per iteration) regardless of the target's body.
+        //
+        // Only fires when every argument is statically spelled: any leading
+        // apply operands plus a final `(list ...)` literal tail. A
+        // dynamically-shaped final list (or a non-list last operand) falls
+        // through to the normal, correctly non-tail apply path below. The
+        // whole-function tail analysis (allSelfCallsInTailPosition, ESH-0227)
+        // guarantees TCO is only enabled here when this apply-self-call is
+        // genuinely in tail position, so emitting the branch is sound.
+        if (Value* tco_result = tryApplyTailCall(op)) {
+            return tco_result;
+        }
         return call_apply_->apply(op);
+    }
+
+    // Recognize and lower a statically-spelled apply-self-call in tail position
+    // to a TCO loop back-edge (ESH-0227). Returns nullptr (no interception) for
+    // anything that is not provably `(apply <this-loop> leading... (list ...))`
+    // with a total argument count equal to the loop's arity, so the caller
+    // falls back to the ordinary apply lowering.
+    Value* tryApplyTailCall(const eshkol_operations_t* op) {
+        if (!binding_) return nullptr;
+        // (apply proc last) needs at least the procedure + one final list.
+        if (op->call_op.num_vars < 2) return nullptr;
+
+        // First operand must be a bare variable naming the active TCO loop.
+        const eshkol_ast_t* proc = &op->call_op.variables[0];
+        if (proc->type != ESHKOL_VAR || !proc->variable.id) return nullptr;
+        if (!binding_->isTCOActive(proc->variable.id)) return nullptr;
+
+        // Final operand must be a `(list ...)` literal so every element is a
+        // compile-time-known argument node (no runtime list walking).
+        const eshkol_ast_t* last = &op->call_op.variables[op->call_op.num_vars - 1];
+        if (last->type != ESHKOL_OP || last->operation.op != ESHKOL_CALL_OP) {
+            return nullptr;
+        }
+        const eshkol_operations_t& list_call = last->operation;
+        if (!list_call.call_op.func ||
+            list_call.call_op.func->type != ESHKOL_VAR ||
+            !list_call.call_op.func->variable.id ||
+            std::string(list_call.call_op.func->variable.id) != "list") {
+            return nullptr;
+        }
+
+        // Assemble the full argument list: leading apply operands (between the
+        // procedure and the final list), then the list literal's elements.
+        std::vector<const eshkol_ast_t*> arg_nodes;
+        for (uint64_t i = 1; i + 1 < op->call_op.num_vars; i++) {
+            arg_nodes.push_back(&op->call_op.variables[i]);
+        }
+        for (uint64_t i = 0; i < list_call.call_op.num_vars; i++) {
+            arg_nodes.push_back(&list_call.call_op.variables[i]);
+        }
+
+        auto& tco_ctx = binding_->getTCOContext();
+        if (arg_nodes.size() != tco_ctx.param_allocas.size()) {
+            // Arity does not match the loop — not a valid loop back-edge; let
+            // the normal apply path handle it (and report any real error).
+            return nullptr;
+        }
+        return emitTCOBackEdge(arg_nodes, tco_ctx);
     }
 
     /* Bug P (2026-04-23): apply on a cross-file user-defined function

--- a/lib/backend/tail_call_codegen.cpp
+++ b/lib/backend/tail_call_codegen.cpp
@@ -328,6 +328,26 @@ static bool allSelfCallsInTailPosition(const eshkol_ast_t* expr,
                 // Self-call found — must be in tail position
                 if (!in_tail_pos) return false;
             }
+
+            // ESH-0227: `(apply f ...)` where `f` names this very function is a
+            // self-recursive call routed through `apply`. Exactly like a direct
+            // self-call it is only sound to TCO-transform when it sits in tail
+            // position. A non-tail apply-self-call (e.g.
+            // `(+ 1 (apply loop (list ...)))`) must disable TCO for the whole
+            // function so codegenApply lowers it to a normal (correctly
+            // non-tail) call rather than an unconditional loop back-edge — the
+            // same reason a non-tail direct self-call disables TCO above.
+            // Only the statically provable case (first apply operand is a bare
+            // variable naming this function) is treated as a self-call; a
+            // dynamically-computed target is left alone (it stays a normal
+            // call and never triggers the codegenApply back-edge either).
+            if (call_name == "apply" && op->call_op.num_vars >= 1) {
+                const eshkol_ast_t* applied = &op->call_op.variables[0];
+                if (applied->type == ESHKOL_VAR && applied->variable.id &&
+                    func_name == applied->variable.id && !in_tail_pos) {
+                    return false;
+                }
+            }
             // Check arguments (they are NOT in tail position)
             for (uint64_t i = 0; i < op->call_op.num_vars; i++) {
                 if (!allSelfCallsInTailPosition(&op->call_op.variables[i], func_name, false)) {

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -10812,6 +10812,15 @@ static void vm_dispatch_native(VM* vm, int fid) {
 
     case 1711: { /* sleep-ms(milliseconds) → void */
         Value ms_val = vm_pop(vm);
+        /* ESH-0228: type-check the argument. as_number() silently returns 0.0
+         * for non-numeric values, so a bad argument used to no-op instead of
+         * signalling an error; match the AOT/JIT path and reject non-numbers
+         * cleanly (the VM's runtime-error idiom: message + vm->error = 1). */
+        if (ms_val.type != VAL_INT && ms_val.type != VAL_FLOAT) {
+            fprintf(stderr, "ERROR: sleep-ms: expected a number\n");
+            vm->error = 1;
+            break;
+        }
 #ifndef ESHKOL_VM_WASM
         int64_t ms = (int64_t)as_number(ms_val);
         if (ms > 0) {

--- a/lib/core/system_builtins.c
+++ b/lib/core/system_builtins.c
@@ -109,6 +109,11 @@ extern char* arena_allocate_string_with_header(void* arena, size_t length);
 extern void* arena_allocate_cons_with_header(void* arena);
 extern int eshkol_capability_runtime_allows(const char* capability);
 extern void eshkol_capability_runtime_deny(const char* capability);
+/* ESH-0228: raise a proper R7RS type error (formats "Type error in <proc>:
+ * expected <type>" and terminates via ESHKOL_EXCEPTION_TYPE_ERROR). Declared
+ * here rather than via runtime.h, which pulls in the C++/C23 tagged-value
+ * typedefs this C11 TU does not use. Does not return. */
+extern void eshkol_type_error(const char* proc_name, const char* expected_type);
 
 /* Tagged value layout MUST match LLVM IR: {i8, i8, i16, i32, i64} = 16 bytes.
  * The i32 is explicit padding — this matches the LLVM struct exactly so that
@@ -358,7 +363,19 @@ static eshkol_sysbuiltin_value_t eshkol_builtin_home_directory_v(void) {
 /** Implements `(sleep-ms n)`: blocks the calling thread for @p ms_val
  *  milliseconds (no-op for non-positive values). Returns null. */
 static eshkol_sysbuiltin_value_t eshkol_builtin_sleep_ms_v(eshkol_sysbuiltin_value_t ms_val) {
-    int64_t ms = (int64_t)ms_val.data;
+    /* ESH-0228: type-check the argument. Previously this cast ms_val.data
+     * (a raw uint64) straight to int64 with no tag check, so a non-numeric
+     * argument (string, boolean, pair, …) reinterpreted whatever bits happened
+     * to be in .data — a heap pointer, in the heap-tagged cases — as a
+     * millisecond count, sleeping for a garbage duration or effectively
+     * hanging. Accept only fixnums and flonums; raise a clean type error
+     * otherwise. sys_extract_int64 handles the double case correctly (bit-cast,
+     * then truncate) rather than reinterpreting the raw payload as an integer. */
+    if (ms_val.type != SYS_TYPE_INT64 && ms_val.type != SYS_TYPE_DOUBLE) {
+        eshkol_type_error("sleep-ms", "number");
+        return sys_make_null();  /* not reached: eshkol_type_error does not return */
+    }
+    int64_t ms = sys_extract_int64(ms_val);
     if (ms <= 0) return sys_make_null();
 #ifndef _WIN32
     struct timespec ts;

--- a/tests/system/sleep_ms_test.esk
+++ b/tests/system/sleep_ms_test.esk
@@ -1,0 +1,45 @@
+;;; sleep-ms argument type-checking (ESH-0228 regression)
+;;;
+;;; Bug: eshkol_builtin_sleep_ms_v (lib/core/system_builtins.c) cast the tagged
+;;; value's raw .data field straight to int64 with NO tag check, so a
+;;; non-numeric argument reinterpreted whatever bits were in .data (a heap
+;;; pointer, in the heap-tagged cases) as a millisecond count — sleeping for a
+;;; garbage duration or effectively hanging. The bytecode VM's case 1711
+;;; (lib/backend/vm_native.c) silently no-op'd non-numbers via as_number()==0.0.
+;;;
+;;; Fix (ESH-0228): both paths now type-check the argument. Valid fixnums and
+;;; flonums keep their behavior (sleep n ms / no-op for <= 0); any non-number
+;;; raises a clean, catchable type error ("Type error in sleep-ms: expected
+;;; number") instead of reinterpreting bits.
+;;;
+;;; The runner scores this test by exit code (0 = PASS). It exits non-zero if
+;;; any assertion fails, so a regression to the silent-reinterpret behavior
+;;; (bad input NOT raising) is caught.
+
+;; --- Good path: valid numeric args must NOT raise and must return promptly. ---
+(sleep-ms 0)      ; no-op
+(sleep-ms -5)     ; negative -> no-op
+(sleep-ms 3)      ; small positive -> ~3ms real sleep
+(display "good-args-ok") (newline)
+
+;; --- Bad path: a non-numeric arg must raise a (catchable) type error. ---
+;; If the guard body's (sleep-ms ...) does NOT raise, `guard` falls through to
+;; 'no-error and the assertion below fails the whole test.
+(define str-result
+  (guard (e (#t 'raised))
+    (sleep-ms "100")
+    'no-error))
+
+(define bool-result
+  (guard (e (#t 'raised))
+    (sleep-ms #t)
+    'no-error))
+
+(if (and (eq? str-result 'raised)
+         (eq? bool-result 'raised))
+    (begin (display "bad-args-rejected") (newline))
+    (begin
+      (display "FAIL: sleep-ms did not type-check its argument") (newline)
+      (exit 1)))
+
+(display "PASS") (newline)

--- a/tests/tco/apply_loop_tail_test.esk
+++ b/tests/tco/apply_loop_tail_test.esk
@@ -1,0 +1,87 @@
+;;; Proper tail calls through `apply` (ESH-0227)
+;;;
+;;; Bug: `(apply f (list ...))` used as a loop's back-edge was compiled to a
+;;; genuine (non-tail) LLVM call regardless of whether `f` named the enclosing
+;;; function's active TCO loop. `call_apply_codegen` never consulted the TCO
+;;; context, so an apply-based loop grew the native call stack by one frame per
+;;; iteration and overflowed (SIGBUS/"stack overflow") a few hundred thousand
+;;; iterations in — while the equivalent direct `(f arg ...)` self-call looped
+;;; flat. For the named-let form it was worse than slow: apply could not even
+;;; resolve the local `loop` binding, warned "apply: Unknown function: loop",
+;;; and returned '() (a silent wrong result).
+;;;
+;;; Fix (ESH-0227):
+;;;   - lib/backend/tail_call_codegen.cpp allSelfCallsInTailPosition and
+;;;     lib/backend/llvm_codegen.cpp countAllRecursiveCalls/findTailCalls now
+;;;     recognize `(apply f ...)` (f a bare variable naming this function) as a
+;;;     self-recursive call, so TCO is enabled iff every apply-self-call is in
+;;;     tail position (a non-tail one correctly disables the transform).
+;;;   - lib/backend/llvm_codegen.cpp codegenApply intercepts a statically
+;;;     spelled `(apply f leading... (list ...))` whose total argument count
+;;;     matches the loop arity and emits the same loop back-edge a direct
+;;;     self-call gets (shared emitTCOBackEdge helper).
+;;;
+;;; Each loop below runs to 10,000,000 iterations — large enough that a real
+;;; per-iteration stack frame reliably SIGSEGVs/SIGBUSes well before the end.
+;;; Printing the expected value instead of crashing proves O(1)-stack TCO for
+;;; the apply back-edge.
+
+(define N 10000000)
+
+;; ================================================================
+;; Test 1: named-let loop whose back-edge is `(apply loop (list ...))`
+;; (was: "apply: Unknown function: loop" + wrong result '())
+;; ================================================================
+(display "Test 1 (named-let apply back-edge): ")
+(let ((r (let loop ((n 0))
+           (if (>= n N) n (apply loop (list (+ n 1)))))))
+  (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; ================================================================
+;; Test 2: top-level define whose only recursion is via `apply`
+;; (was: SIGBUS stack overflow around n~300k-1M)
+;; ================================================================
+(define (count-via-apply n)
+  (if (>= n N) n (apply count-via-apply (list (+ n 1)))))
+
+(display "Test 2 (define apply-only recursion): ")
+(let ((r (count-via-apply 0)))
+  (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; ================================================================
+;; Test 3: arity-2 apply loop — list literal supplies both arguments
+;; ================================================================
+(define (count2 a b)
+  (if (>= a N) b (apply count2 (list (+ a 1) (+ b 1)))))
+
+(display "Test 3 (arity-2 apply loop): ")
+(let ((r (count2 0 0)))
+  (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; ================================================================
+;; Test 4: leading spelled arg + a `(list ...)` tail — (apply f x (list y))
+;; exercises the leading-operand path of the apply back-edge.
+;; ================================================================
+(define (count-lead a b)
+  (if (>= a N) b (apply count-lead (+ a 1) (list (+ b 1)))))
+
+(display "Test 4 (leading arg + list-literal apply): ")
+(let ((r (count-lead 0 0)))
+  (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; ================================================================
+;; Test 5: SOUNDNESS — a NON-tail apply-self-call must NOT be turned into a
+;; loop back-edge. This is genuine recursion (bounded n=200) and must return
+;; the correct sum; a miscompiled branch here would produce a wrong result or
+;; a verifier failure at compile time.
+;; ================================================================
+(define (sum-nontail n)
+  (if (<= n 0) 0 (+ n (apply sum-nontail (list (- n 1))))))
+
+(display "Test 5 (non-tail apply stays a real call): ")
+(if (= (sum-nontail 200) 20100) (display "PASS") (display "FAIL"))
+(newline)

--- a/tests/tco/named_let_long_loop_test.esk
+++ b/tests/tco/named_let_long_loop_test.esk
@@ -1,0 +1,44 @@
+;;; Plain named-let TCO loop sustains a very long run (ESH-0223 regression)
+;;;
+;;; ESH-0223 reported that a completely plain named-let tail loop —
+;;;   (let loop ((n 0)) (if (>= n N) n (loop (+ n 1))))
+;;; with zero guard/call-cc/dynamic-alloca in the body — SIGSEGVed/SIGBUSed
+;;; with the "stack overflow" diagnostic somewhere between N=300,000 and
+;;; N=500,000, while the equivalent top-level define looped flat past 1e6.
+;;; That meant named-let (one of the two idiomatic Scheme tail-loop forms) had
+;;; a hard few-hundred-thousand-iteration ceiling with no diagnostic pointing
+;;; at the real cause.
+;;;
+;;; Re-tested on current master (post the define-loop TCO + per-iteration arena
+;;; reclamation ESH-0214b/#192, the iterative reader #191, and deep
+;;; region-escape #210): the named-let form now runs flat with O(1) stack and
+;;; bounded RSS well past the reported failure window — verified here to
+;;; 10,000,000 iterations, and manually to 1e7 under a 512 KB stack ulimit
+;;; (~28 MB RSS, <1 s). ESH-0223 no longer reproduces; this test locks that in.
+;;;
+;;; 10^7 iterations is far beyond where a real per-iteration stack frame would
+;;; overflow, so a plain PASS here is proof of tail-call elimination for the
+;;; bare named-let loop shape ESH-0223 named.
+
+(define N 10000000)
+
+;; ================================================================
+;; The exact ESH-0223 repro shape, wrapped as a function.
+;; ================================================================
+(define (count-to n)
+  (let loop ((i 0))
+    (if (>= i n) i (loop (+ i 1)))))
+
+(display "Test 1 (plain named-let, 1e7 iters): ")
+(if (= (count-to N) N) (display "PASS") (display "FAIL"))
+(newline)
+
+;; ================================================================
+;; Two-accumulator variant — carries a second loop-var across the same
+;; iteration count so an accumulated result (not just a counter) is checked.
+;; ================================================================
+(display "Test 2 (named-let with accumulator, 1e7 iters): ")
+(let ((r (let loop ((i 0) (acc 0))
+           (if (>= i N) acc (loop (+ i 1) (+ acc 1))))))
+  (if (= r N) (display "PASS") (display "FAIL")))
+(newline)


### PR DESCRIPTION
Triage + fixes for three deferred latent bugs. Based off current master (fe61261d). All fixes reproduced BEFORE, verified AFTER, with regression tests.

## Verdict

| ID | Still reproduces on master? | Action | Regression test |
|----|-----------------------------|--------|-----------------|
| ESH-0223 named-let long-loop overflow | **No** (fixed by prior merged work) | Locked with regression test + docs | `tests/tco/named_let_long_loop_test.esk` |
| ESH-0227 apply back-edge non-tail | **Yes** | **Fixed at root** | `tests/tco/apply_loop_tail_test.esk` |
| ESH-0228 sleep-ms missing type check | **Yes** | **Fixed at root** (AOT/JIT + VM) | `tests/system/sleep_ms_test.esk` |

## ESH-0223 — named-let ~300k overflow: no longer reproduces
Re-tested on current master (post define-loop TCO + per-iteration arena reclamation ESH-0214b/#192, iterative reader #191, deep region-escape #210). A plain `(let loop ((n 0)) (if (>= n N) n (loop (+ n 1))))` now runs flat: **N=1e7 in 0.77s, ~28MB RSS, under a 512KB stack ulimit** — matching the top-level-define TCO guarantee. The earlier 300-500k stack overflow is gone. Locked with a dedicated regression test (and Test 1 of the existing `named_let_tail_positions_test.esk` runs the identical shape to 1e7). KNOWN_ISSUES / LONG_RUNNING_LOOPS updated to mark fixed.

## ESH-0227 — apply-loop non-tail: fixed
**Before:** `(apply f (list ...))` used as a loop back-edge compiled to a genuine (non-tail) call → SIGBUS/stack overflow at N~1M. For the named-let form it was worse — apply couldn't resolve the local `loop` binding, warned `apply: Unknown function: loop`, and returned `'()` (silent wrong result).

**Fix (root):**
- `tail_call_codegen.cpp` `allSelfCallsInTailPosition` and `llvm_codegen.cpp` `countAllRecursiveCalls`/`findTailCalls` now recognize `(apply f ...)` (f a bare variable naming this function) as a self-recursive call, so TCO is enabled iff **every** apply-self-call is in tail position — a non-tail one correctly disables the transform.
- `llvm_codegen.cpp` `codegenApply` intercepts a statically-spelled `(apply f leading... (list ...))` whose total arg count matches the loop arity and emits the same loop back-edge a direct self-call gets (shared `emitTCOBackEdge` helper, extracted from `codegenTailCallFromContext`).
- A dynamically-shaped final list (non-literal) stays an ordinary non-tail apply — no change to general apply semantics.

**After:** named-let and top-level-define apply loops both flat and RSS-bounded (~27MB) to **N=1e7 under a 512KB stack**. Soundness verified: non-tail `(+ n (apply f (list (- n 1))))` still returns the correct sum (TCO disabled, no miscompile); dynamic-list apply to a non-self function still correct.

## ESH-0228 — sleep-ms type check: fixed (AOT/JIT + VM)
**Before:** `eshkol_builtin_sleep_ms_v` cast the tagged value's raw `.data` straight to int64 with no tag check — a non-numeric arg reinterpreted a heap pointer as a millisecond count (garbage sleep / effective hang). The VM path silently no-op'd non-numbers.

**Fix (root):** `lib/core/system_builtins.c` and `lib/backend/vm_native.c` case 1711 now accept only fixnums/flonums (valid values unchanged: sleep n ms, no-op for `<= 0`) and raise a clean, catchable `Type error in sleep-ms: expected number` on any non-number.

**After (verified JIT, AOT, VM):** `(sleep-ms 0/-5/3)` behave; `(sleep-ms "100")` / `(sleep-ms #t)` raise the type error and do not proceed.

## Test results (build-h1c, Release)
- TCO suite: **5/5** (incl. 2 new tests)
- System suite: **14/14** (incl. new sleep-ms test)
- Features suite: **32/32**
- VM standalone: **53/53**