### PR TITLE
fix(memory): thread-safe region scope stack — parallel-map + with-region no longer crashes

### DIFF
--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -29926,6 +29926,21 @@ private:
             false);
         FunctionCallee region_pop_fn = module->getOrInsertFunction("region_pop", region_pop_type);
 
+        // Thread-safe region allocation-scope routing (see runtime_regions.cpp).
+        // eshkol_region_enter(region) -> arena_t* saved; eshkol_region_leave(saved).
+        FunctionType* region_enter_type = FunctionType::get(
+            PointerType::get(*context, 0),      // returns arena_t* (displaced or sentinel)
+            {PointerType::get(*context, 0)},    // eshkol_region_t*
+            false);
+        FunctionCallee region_enter_fn =
+            module->getOrInsertFunction("eshkol_region_enter", region_enter_type);
+        FunctionType* region_leave_type = FunctionType::get(
+            void_type,
+            {PointerType::get(*context, 0)},    // arena_t* saved
+            false);
+        FunctionCallee region_leave_fn =
+            module->getOrInsertFunction("eshkol_region_leave", region_leave_type);
+
         // Create the region name string (or null)
         Value* name_ptr;
         if (op->with_region_op.name) {
@@ -29953,16 +29968,18 @@ private:
         // global arena and region_pop freed an empty region -> unbounded RSS
         // growth (Noesis OOM, exit 137).
         //
-        // Fix: temporarily overwrite the current-arena slot with region->arena
-        // for the duration of the body, then restore the previous value after
-        // region_pop. region->arena is the FIRST field of eshkol_region_t, so it
-        // lives at offset 0 of the region pointer returned by region_create.
-        GlobalVariable* arena_slot = ctx_ ? ctx_->currentArenaPtr() : global_arena;
-        Value* saved_arena = builder->CreateLoad(
-            PointerType::getUnqual(*context), arena_slot, "saved_arena_before_region");
-        Value* region_arena = builder->CreateLoad(
-            PointerType::getUnqual(*context), region, "region_arena");
-        builder->CreateStore(region_arena, arena_slot);
+        // Fix: temporarily redirect the current-arena slot to region->arena for
+        // the duration of the body, then restore afterwards. This redirect is NOT
+        // done inline here (that raced across worker threads sharing the single
+        // __global_arena pointer — parallel-map + with-region SIGSEGV); it is
+        // delegated to eshkol_region_enter/eshkol_region_leave, which perform it
+        // only when thread-safe (single-threaded, non-parallel context) and skip
+        // it on worker threads / inside a work-stealing construct. Body
+        // allocations there stay in the thread-safe shared arena and escape
+        // promotion still copies out anything region-resident. See
+        // runtime_regions.cpp.
+        Value* saved_arena =
+            builder->CreateCall(region_enter_fn, {region}, "region_saved_arena");
 
         // Evaluate body expressions - last one is the result
         Value* result = nullptr;
@@ -30017,7 +30034,9 @@ private:
         // Allocations after the region must NOT target the (now-freed) region
         // arena. region_escape above already copied the result into the parent /
         // global arena (region_escape is slot-independent), so it survives.
-        builder->CreateStore(saved_arena, arena_slot);
+        // eshkol_region_leave is the counterpart to eshkol_region_enter and is a
+        // no-op when enter declined to hijack (parallel/worker context).
+        builder->CreateCall(region_leave_fn, {saved_arena});
 
         if (!result) {
             result = packNullToTaggedValue();

--- a/lib/backend/parallel_codegen.cpp
+++ b/lib/backend/parallel_codegen.cpp
@@ -59,6 +59,22 @@
 // Worker function type
 typedef void* (*parallel_worker_fn)(void*);
 
+// RAII guard opening a parallel scope for the duration of a work-stealing
+// construct (see eshkol_parallel_scope_begin/end in runtime_regions.cpp). While
+// open, with-region on any thread stops hijacking the process-shared
+// current-arena slot and that slot is pinned to the thread-safe process arena,
+// so concurrent workers running with-region bodies can never race on it or
+// allocate into a region arena that another thread is about to free. Exception-
+// and early-return-safe.
+namespace {
+struct ParallelArenaScope {
+    ParallelArenaScope()  { eshkol_parallel_scope_begin(); }
+    ~ParallelArenaScope() { eshkol_parallel_scope_end(); }
+    ParallelArenaScope(const ParallelArenaScope&) = delete;
+    ParallelArenaScope& operator=(const ParallelArenaScope&) = delete;
+};
+} // namespace
+
 // Function pointers for LLVM-generated workers (set by __eshkol_register_parallel_workers)
 static parallel_worker_fn g_parallel_map_worker = nullptr;
 static parallel_worker_fn g_parallel_fold_worker = nullptr;
@@ -289,8 +305,14 @@ extern "C" uint8_t eshkol_lazy_future_submit_async(
         static_cast<uint64_t>(closure_flags),
         reinterpret_cast<uint64_t>(slot),
     };
+    // Open a parallel scope for the lifetime of this async future (closed in
+    // eshkol_lazy_future_join_async). While it is outstanding the shared arena
+    // is pinned to the thread-safe root so the async worker — and any with-region
+    // in its thunk — never races the spawning thread on the current-arena slot.
+    eshkol_parallel_scope_begin();
+
     eshkol_future_t* fut = thread_pool_submit(pool, g_parallel_execute_worker, task);
-    if (!fut) { delete slot; delete task; return 0; }
+    if (!fut) { eshkol_parallel_scope_end(); delete slot; delete task; return 0; }
 
     lf->pool_future = fut;
     lf->async_result_slot = slot;
@@ -330,6 +352,9 @@ extern "C" void eshkol_lazy_future_join_async(void* lf_void) {
     lf->pool_future = nullptr;
     lf->async_task = nullptr;
     lf->async_result_slot = nullptr;
+
+    // Close the parallel scope opened at submit (balances scope_begin above).
+    eshkol_parallel_scope_end();
 }
 
 // ============================================================================
@@ -448,6 +473,10 @@ void eshkol_parallel_map(
     eshkol_tagged_value_t* out_result)
 {
     eshkol_debug("parallel-map: fn.type=%d, list.type=%d", fn.type, list.type);
+
+    // Suppress region-arena hijack + pin the shared arena to the thread-safe root
+    // for the whole construct, so worker bodies using with-region are race-free.
+    ParallelArenaScope _parallel_scope;
 
     // Handle empty list
     if (list.type == ESHKOL_VALUE_NULL) {
@@ -717,6 +746,9 @@ void eshkol_parallel_filter(
 {
     eshkol_debug("parallel-filter: pred.type=%d, list.type=%d", pred.type, list.type);
 
+    // See eshkol_parallel_map: race-free with-region for worker predicate bodies.
+    ParallelArenaScope _parallel_scope;
+
     if (list.type == ESHKOL_VALUE_NULL) {
         *out_result = list; return;
     }
@@ -850,6 +882,9 @@ void eshkol_parallel_execute(
     eshkol_tagged_value_t* out_result)
 {
     eshkol_debug("parallel-execute: num_thunks=%lld", (long long)num_thunks);
+
+    // See eshkol_parallel_map: race-free with-region for worker thunk bodies.
+    ParallelArenaScope _parallel_scope;
 
     eshkol_tagged_value_t null_val = {};
     null_val.type = ESHKOL_VALUE_NULL;

--- a/lib/core/arena_memory.h
+++ b/lib/core/arena_memory.h
@@ -364,6 +364,19 @@ void region_push(eshkol_region_t* region);
 void region_pop(void);
 eshkol_region_t* region_current(void);
 
+// Thread-safe region allocation-scope routing (with-region codegen calls these
+// around the body). eshkol_region_enter redirects the shared current-arena slot
+// to the region's arena ONLY in single-threaded, non-parallel context (returns
+// the displaced arena, or an opaque sentinel when it declines); eshkol_region_leave
+// restores it. The parallel-scope guards suppress that hijack and pin the shared
+// slot to the thread-safe process arena while a work-stealing construct
+// (parallel-map/fold/execute/filter/for-each, async futures) may run on worker
+// threads. See runtime_regions.cpp for the full rationale.
+arena_t* eshkol_region_enter(eshkol_region_t* region);
+void eshkol_region_leave(arena_t* saved);
+void eshkol_parallel_scope_begin(void);
+void eshkol_parallel_scope_end(void);
+
 // Region allocation - allocates in the current region
 void* region_allocate(size_t size);
 void* region_allocate_aligned(size_t size, size_t alignment);

--- a/lib/core/runtime_regions.cpp
+++ b/lib/core/runtime_regions.cpp
@@ -18,6 +18,8 @@
 #include <unordered_map>
 #include <vector>
 #include <utility>
+#include <atomic>
+#include <mutex>
 
 void eshkol_arena_global_once(void (*init)(void));
 
@@ -32,18 +34,59 @@ ESHKOL_RUNTIME_WEAK arena_t* __global_arena = nullptr;
 
 static thread_local arena_t* __thread_local_arena = nullptr;
 
+// ─────────────────────────────────────────────────────────────────────────────
+// THREAD-SAFE REGION ARENA ROUTING (parallel-map/fold/execute/future × with-region)
+//
+// Generated code funnels *every* allocation through the single process-global
+// __global_arena pointer (the "current allocation arena" slot). `with-region`
+// makes body allocations land in the region's arena by temporarily overwriting
+// that slot with the region arena and restoring it on exit. That save/hijack/
+// restore is correct for a single thread, but __global_arena is ONE shared
+// location: when work-stealing workers run a body that uses with-region, several
+// threads hijack/restore the same pointer concurrently — a worker allocates into
+// another worker's region arena, whose region_pop then frees it out from under
+// the first — SIGSEGV / heap corruption.
+//
+// Making __global_arena itself thread-local is not viable: generated code reads
+// it as a plain (non-TLS) global across the LLVM↔C / JIT boundary, and this
+// codebase deliberately avoids TLS symbols there (see the __current_ad_tape note
+// in arena_memory.h). Instead the hijack is moved out of codegen into this
+// runtime, where it is performed ONLY when it is genuinely safe — a
+// single-threaded, non-parallel context — and a parallel-scope guard keeps the
+// shared slot pointed at the true thread-safe process arena for the duration of
+// any work-stealing construct, so concurrent workers never observe a hijacked
+// (non-thread-safe) region arena. In a parallel/worker context body allocations
+// stay in the thread-safe shared arena; escape promotion (region_escape*/write
+// barrier) still copies any region-arena-resident value out, so results are
+// correct. The only tradeoff is weaker region reclamation while parallel work is
+// in flight (transient region allocations land in the shared arena instead of
+// being freed at region_pop) — a bounded, documented cost, never a correctness
+// hazard. Single-threaded programs are entirely unaffected (identical hijack).
+static arena_t* s_shared_root_arena = nullptr;         // true process-wide thread-safe arena
+static std::atomic<int> s_parallel_depth{0};           // >0 while a work-stealing construct may run
+static std::mutex s_parallel_arena_mtx;                // guards the 0<->1 transition swap
+static arena_t* s_saved_arena_at_parallel = nullptr;   // __global_arena captured at the 0->1 edge
+
+// Sentinel returned by eshkol_region_enter when it did NOT hijack the shared
+// slot (parallel/worker context). No real arena lives at address 0x1.
+static arena_t* const REGION_NO_HIJACK = reinterpret_cast<arena_t*>(0x1);
+
 /**
  * @brief One-time initializer that creates the process-wide global arena.
  *
  * Invoked exactly once (via eshkol_arena_global_once) to create a
  * thread-safe arena and store it in __global_arena; logs an error if
- * creation fails.
+ * creation fails. Also records it as the immutable thread-safe "root" arena
+ * (s_shared_root_arena) that the parallel-scope guard points workers at while a
+ * work-stealing construct is active — captured here, before any with-region can
+ * hijack the __global_arena slot.
  */
 static void init_global_arena_internal() {
     __global_arena = arena_create_threadsafe(65536);
     if (!__global_arena) {
         eshkol_error("Failed to create global arena");
     }
+    s_shared_root_arena = __global_arena;
 }
 
 /**
@@ -411,6 +454,95 @@ void region_pop(void) {
 eshkol_region_t* region_current(void) {
     if (__region_stack_depth == 0) return nullptr;
     return __region_stack[__region_stack_depth - 1];
+}
+
+/**
+ * @brief Enter a region's allocation scope: redirect the shared current-arena
+ *        slot to @p region's arena, but ONLY when that is thread-safe.
+ *
+ * Called by with-region codegen immediately after region_push. Replaces the
+ * old inline codegen hijack of the __global_arena GlobalVariable so the decision
+ * of whether it is safe to mutate that process-shared pointer is made here, at
+ * runtime, with thread context in view:
+ *
+ *   • Single-threaded, non-parallel context — the common case, and every
+ *     sequential program — hijacks exactly as before: body allocations land in
+ *     the region arena and are freed at region_pop (full reclamation).
+ *   • Worker thread, or any thread while a work-stealing parallel construct is
+ *     active — does NOT touch the shared slot (returns REGION_NO_HIJACK). Body
+ *     allocations stay in the thread-safe shared arena; escape promotion still
+ *     copies any value that DID land in a region arena out at region_pop, so
+ *     results are correct. This is what makes parallel-map + with-region safe.
+ *
+ * @param region Region being entered (its arena is the hijack target).
+ * @return The arena that was displaced (to be restored by eshkol_region_leave),
+ *         or the REGION_NO_HIJACK sentinel if the slot was left untouched.
+ */
+extern "C" arena_t* eshkol_region_enter(eshkol_region_t* region) {
+    if (!region || !region->arena) return REGION_NO_HIJACK;
+
+    // Unsafe to mutate the process-shared __global_arena when other threads may
+    // be reading it concurrently: on a pool worker, or while any work-stealing
+    // construct is in flight (which also covers the main thread running the
+    // parallel-map JIT-warmup item while workers spin up).
+    if (s_parallel_depth.load(std::memory_order_acquire) != 0 ||
+        arena_is_worker_thread()) {
+        return REGION_NO_HIJACK;
+    }
+
+    arena_t* saved = __global_arena;
+    __global_arena = region->arena;
+    return saved;
+}
+
+/**
+ * @brief Leave a region's allocation scope: undo the redirect performed by
+ *        eshkol_region_enter (no-op if it declined to hijack).
+ *
+ * Called by with-region codegen after region_pop.
+ *
+ * @param saved The value returned by the matching eshkol_region_enter.
+ */
+extern "C" void eshkol_region_leave(arena_t* saved) {
+    if (saved == REGION_NO_HIJACK) return;
+    __global_arena = saved;
+}
+
+/**
+ * @brief Open a parallel scope around a work-stealing construct
+ *        (parallel-map/fold/execute/filter/for-each and async futures).
+ *
+ * While the scope is open, region hijacks are suppressed (eshkol_region_enter
+ * returns without touching the shared slot) and the shared current-arena slot is
+ * forced to the true thread-safe process arena (s_shared_root_arena) so every
+ * worker that reads __global_arena allocates into a lockable arena rather than
+ * into whatever region arena a with-region on the spawning thread may have
+ * hijacked it to. The displaced value (e.g. an enclosing region's arena) is
+ * captured on the 0->1 edge and restored on the 1->0 edge; nested/overlapping
+ * scopes just bump the depth. Idempotent w.r.t. the arena value because every
+ * scope forces the same root.
+ */
+extern "C" void eshkol_parallel_scope_begin(void) {
+    std::lock_guard<std::mutex> lk(s_parallel_arena_mtx);
+    if (s_parallel_depth.fetch_add(1, std::memory_order_acq_rel) == 0) {
+        arena_t* root = s_shared_root_arena;
+        if (!root) root = get_global_arena_shared();  // ensures init + captures root
+        s_saved_arena_at_parallel = __global_arena;
+        if (root) __global_arena = root;
+    }
+}
+
+/**
+ * @brief Close a parallel scope opened by eshkol_parallel_scope_begin(),
+ *        restoring the current-arena slot displaced on the 0->1 edge once the
+ *        last overlapping scope closes.
+ */
+extern "C" void eshkol_parallel_scope_end(void) {
+    std::lock_guard<std::mutex> lk(s_parallel_arena_mtx);
+    if (s_parallel_depth.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+        __global_arena = s_saved_arena_at_parallel;
+        s_saved_arena_at_parallel = nullptr;
+    }
 }
 
 /**

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -1290,6 +1290,8 @@ void ReplJITContext::registerRuntimeSymbols() {
     ADD_SYMBOL(region_push);
     ADD_SYMBOL(region_pop);
     ADD_SYMBOL(region_current);
+    ADD_SYMBOL(eshkol_region_enter);   // thread-safe with-region arena routing
+    ADD_SYMBOL(eshkol_region_leave);
     ADD_SYMBOL(region_allocate);
     ADD_SYMBOL(region_allocate_aligned);
     ADD_SYMBOL(region_allocate_zeroed);

--- a/site/static/eshkol-runtime.js
+++ b/site/static/eshkol-runtime.js
@@ -649,6 +649,11 @@ class EshkolRuntime {
                 region_create: (_name, _size_hint) => 1,
                 region_push:   () => {},
                 region_pop:    () => {},
+                // with-region hijack (thread-safe region scope): JS has no region
+                // system, so decline the hijack. enter returns 0 (no displaced arena to
+                // restore); leave is a no-op for a declined enter.
+                eshkol_region_enter: (_region) => 0,
+                eshkol_region_leave: (_saved) => {},
                 region_escape_tagged_value_into: (out, val) => {
                     const buf = rt._importedMemory?.buffer || rt.instance?.exports?.memory?.buffer;
                     if (!buf || !out || !val) return;

--- a/tests/parallel/parallel_region_race_test.esk
+++ b/tests/parallel/parallel_region_race_test.esk
@@ -1,0 +1,101 @@
+;;; tests/parallel/parallel_region_race_test.esk
+;;;
+;;; Concurrency × memory-region regression fixture.
+;;;
+;;; parallel-map runs its mapped function on work-stealing pool threads. When
+;;; that function body uses (with-region ...), each worker enters/exits a region
+;;; concurrently. Region entry temporarily redirects the "current allocation
+;;; arena" so body allocations land in the region's arena, then restores it and
+;;; frees the arena at exit.
+;;;
+;;; If that current-arena routing slot is a single process-global shared across
+;;; every OS thread (rather than thread-local), concurrent with-region on
+;;; workers clobber each other's routing: worker A allocates into worker B's
+;;; region arena, and B's region_pop frees it out from under A — SIGSEGV /
+;;; heap corruption / "argument is not a pair".
+;;;
+;;; This fixture stresses that path: each mapped item builds a non-trivial list
+;;; inside a per-call region and escapes it. With a thread-safe (thread-local)
+;;; region routing slot the results are deterministic and correct; the pre-fix
+;;; build crashes or returns garbage under the concurrency.
+
+(define passed 0)
+(define failed 0)
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (set! passed (+ passed 1))
+      (begin (display "FAIL: ") (display name)
+             (display " expected=") (display expected)
+             (display " actual=") (display actual) (newline)
+             (set! failed (+ failed 1)))))
+
+;; Build (list 0 1 2 ... n-1)
+(define (range n)
+  (let loop ((i (- n 1)) (acc '()))
+    (if (< i 0) acc (loop (- i 1) (cons i acc)))))
+
+;; sum 0..k-1
+(define (sum-to k)
+  (let loop ((i 0) (s 0)) (if (< i k) (loop (+ i 1) (+ s i)) s)))
+
+;; Mapped function: inside a region, build a K-element list whose elements are
+;; (x + i), then reduce it (sum) and escape the scalar. Allocation + escape both
+;; happen inside the region, on a worker thread.
+(define K 64)
+(define (work x)
+  (with-region 'r
+    (let build ((i 0) (acc '()))
+      (if (< i K)
+          (build (+ i 1) (cons (+ x i) acc))
+          ;; reduce the region-allocated list to a scalar and escape it
+          (let red ((lst acc) (s 0))
+            (if (pair? lst) (red (cdr lst) (+ s (car lst))) s))))))
+
+;; work(x) == sum_{i=0}^{K-1} (x+i) == K*x + sum(0..K-1)
+(define base (sum-to K))
+(define (expected-work x) (+ (* K x) base))
+
+(define N 4000)
+(define input (range N))
+
+;; A second, structure-escaping variant: escape an actual list out of the region
+;; on a worker, then read it back — this exercises the deep-escape promotion on
+;; worker threads too.
+(define (work-list x)
+  (with-region 'r2
+    (list x (* x 2) (* x 3))))
+
+;; ── Run it several times: races are flaky, so repeat to make a latent crash
+;;    or corruption overwhelmingly likely to surface at least once. ──
+(define (run-once trial)
+  (let ((res (parallel-map work input)))
+    ;; verify a stride through the results
+    (let vloop ((lst res) (i 0) (ok #t))
+      (if (pair? lst)
+          (vloop (cdr lst) (+ i 1)
+                 (and ok (= (car lst) (expected-work i))))
+          (check (string-append "parallel work-scalar trial "
+                                (number->string trial))
+                 #t (and ok (= i N))))))
+  (let ((res2 (parallel-map work-list (range 512))))
+    (let vloop ((lst res2) (i 0) (ok #t))
+      (if (pair? lst)
+          (vloop (cdr lst) (+ i 1)
+                 (and ok (equal? (car lst) (list i (* i 2) (* i 3)))))
+          (check (string-append "parallel work-list trial "
+                                (number->string trial))
+                 #t (and ok (= i 512)))))))
+
+(define (trials n)
+  (let loop ((t 0)) (if (< t n) (begin (run-once t) (loop (+ t 1))))))
+
+(trials 12)
+
+(display "[parallel_region_race_test] passed=")
+(display passed)
+(display " failed=")
+(display failed)
+(newline)
+(if (= failed 0)
+    (begin (display "PASS") (newline))
+    (begin (display "FAIL") (newline)))

--- a/web/eshkol-repl.js
+++ b/web/eshkol-repl.js
@@ -631,6 +631,11 @@ class EshkolRepl {
                 region_create: (_name, _size_hint) => 1,
                 region_push:   () => {},
                 region_pop:    () => {},
+                // with-region hijack (thread-safe region scope): JS has no region
+                // system, so decline the hijack. enter returns 0 (no displaced arena to
+                // restore); leave is a no-op for a declined enter.
+                eshkol_region_enter: (_region) => 0,
+                eshkol_region_leave: (_saved) => {},
                 // region_escape / write-barrier: the CALLER passes an
                 // uninitialized `out` slot and reads it back after the call —
                 // the runtime fn is the SOLE writer of `out`. A no-op would


### PR DESCRIPTION
## The bug

Combining a work-stealing parallel construct (`parallel-map` / `parallel-fold` / `parallel-execute` / `parallel-filter` / `parallel-for-each` / async `future`) with `(with-region ...)` SIGSEGV'd or corrupted the heap.

## Root cause — exact unsynchronized shared state

The region *stack* (`__region_stack` / `__region_stack_depth`) is already thread-local. The state that races is the **"current allocation arena" slot**: every generated allocation reads the single process-global `__global_arena` pointer. `with-region` routed its body's allocations into the region arena by **temporarily overwriting that one shared pointer** and restoring it on exit (the ESH-0039 inline codegen hijack).

On worker threads this races two ways:

- **Region inside the mapped body:** several workers hijack/restore the *same* shared `__global_arena` concurrently. Worker A sets it to A's (non-thread-safe) region arena; worker B allocates into A's arena; A's `region_pop` frees it out from under B → use-after-free / "argument is not a pair" / SIGSEGV.
- **Region *enclosing* the parallel call** (`(with-region (parallel-map ...))`): the outer region has already hijacked `__global_arena` to a non-thread-safe region arena, and all workers then allocate into it concurrently.

## The fix

Making `__global_arena` itself thread-local is **not viable**: generated code reads it as a plain (non-TLS) global across the LLVM↔C / JIT boundary, which this codebase deliberately avoids (see the `__current_ad_tape` "cross-platform LLVM↔C TLS ABI constraints" note in `arena_memory.h`). So the hijack is moved **out of codegen into the runtime**, where thread context is visible:

- **`eshkol_region_enter` / `eshkol_region_leave`** replace `with-region`'s inline save/hijack/restore of the `__global_arena` GlobalVariable. The runtime hijacks the shared slot **only in single-threaded, non-parallel context**; on a worker thread, or while any work-stealing construct is active, it leaves the slot untouched. Body allocations then stay in the thread-safe shared arena, and escape promotion (`region_escape*` / the ESH-0214c write barrier) still copies any region-arena-resident value out — so results are correct.
- **A parallel-scope guard** (`eshkol_parallel_scope_begin/end`, applied via an RAII object around `parallel-map/-filter/-execute` and balanced across async future submit/join) suppresses region hijacks for the duration and **pins `__global_arena` to the true thread-safe process arena**, so workers never observe a hijacked (non-thread-safe) region arena even when the spawning thread is inside a `with-region`.

`parallel-fold` is sequential (runs closures on the calling thread), so it needs no guard; `parallel-for-each` delegates to the guarded `parallel-map`.

## Semantics preserved / tradeoff

Single-threaded programs are **entirely unaffected** — `eshkol_region_enter` performs the identical hijack, so per-region reclamation is unchanged (the AOT flat-RSS gate still measures ~90MB flat; the ESH-0214c deep-escape suite passes 16/16). The one tradeoff: while parallel work is in flight, transient region allocations land in the thread-safe shared arena instead of being freed at `region_pop` — **weaker reclamation during the parallel section**, a bounded and documented cost, never a correctness hazard.

## Before / after

Repro added: `tests/parallel/parallel_region_race_test.esk` (parallel-map over a `with-region` body, allocating + escaping), plus an ad-hoc enclosing-region variant.

| Scenario | Before | After |
|---|---|---|
| Region inside body (AOT, ×40) | 30/30 **SIGSEGV** (exit 139) | **40/40 clean** |
| Region inside body (JIT `-r`, ×5) | — | **5/5 clean** |
| Enclosing region ×parallel-map (AOT, ×25) | 24 crash / 1 fail | **25/25 clean** |
| ThreadSanitizer | — | **0 data races** |

## Suites

- Parallel: **8/8** (`scripts/run_parallel_tests.sh`)
- Memory: **13/13** (`scripts/run_memory_tests.sh`), incl. `region_deep_escape_test` (16/16) and the AOT flat-RSS reclamation gate
- Full build green (Release); TSan build (RelWithDebInfo) green, repro + outer-region + `parallel_map_test` all 0 races
