### PR TITLE
fix(memory): complete region evacuator subtype coverage for logic/workspace subtypes (ESH-0214d)

### DIFF
--- a/lib/core/runtime_arena_core.cpp
+++ b/lib/core/runtime_arena_core.cpp
@@ -167,10 +167,22 @@ void arena_destroy(arena_t* arena) {
         eshkol_arena_mutex_destroy(arena->mutex);
     }
 
-    // Free all blocks
+    // Free all blocks. When arena poisoning is enabled (ESHKOL_ARENA_POISON),
+    // fill each block's live bytes with the 0xCB sentinel BEFORE releasing it.
+    // arena_destroy() is the teardown path for region arenas (region_pop ->
+    // region_destroy -> arena_destroy), which — unlike scope pops — otherwise
+    // hand memory back to the allocator untouched, so a stale interior pointer
+    // into a popped region would silently read valid-looking data. Poisoning
+    // here turns any such region use-after-free into an immediate crash at an
+    // obvious 0xCB.. address, which is what the region-escape evacuator gates
+    // rely on to distinguish a real fix from working by luck.
+    const bool poison = eshkol_arena_poison_enabled() != 0;
     arena_block_t* block = arena->current_block;
     while (block) {
         arena_block_t* next = block->next;
+        if (poison && block->memory && block->used > 0) {
+            std::memset(block->memory, 0xCB, block->used);
+        }
         free_arena_block(block);
         block = next;
     }

--- a/lib/core/runtime_regions.cpp
+++ b/lib/core/runtime_regions.cpp
@@ -12,6 +12,9 @@
 
 #include "arena_memory.h"
 #include "../../inc/eshkol/logger.h"
+#include "../../inc/eshkol/core/logic.h"       // eshkol_substitution_t / _fact_t / _knowledge_base_t
+#include "../../inc/eshkol/core/inference.h"   // eshkol_factor_graph_t / _factor_t
+#include "../../inc/eshkol/core/workspace.h"   // eshkol_workspace_t / _workspace_module_t
 
 #include <cstring>
 #include <cstdlib>
@@ -680,6 +683,14 @@ enum EvacKind : uint8_t {
     EVAC_TENSOR,      // eshkol_tensor_t: dimensions + elements raw buffers
     EVAC_EXCEPTION,   // eshkol_exception_t: message/filename/irritants
     EVAC_CLOSURE,     // eshkol_closure_t: captured environment
+    // ESH-0214d: neuro-symbolic / workspace subtypes that carry interior
+    // tagged values and/or raw arena buffers (previously dropped to EVAC_LEAF,
+    // which silently left those interior pointers aimed into the dying region).
+    EVAC_SUBSTITUTION,   // eshkol_substitution_t: inline terms[] tagged values
+    EVAC_FACT,           // eshkol_fact_t: inline args[] tagged values (+ predicate str)
+    EVAC_KNOWLEDGE_BASE, // eshkol_knowledge_base_t: facts[] raw array of fact ptrs
+    EVAC_FACTOR_GRAPH,   // eshkol_factor_graph_t: nested raw numeric buffers
+    EVAC_WORKSPACE,      // eshkol_workspace_t: content buffer + per-module name/process_fn
 };
 
 using EvacFwdMap = std::unordered_map<const void*, void*>;
@@ -729,19 +740,39 @@ static EvacKind evac_kind_for(const eshkol_tagged_value_t& v, const void* old_da
     switch (sub) {
         case HEAP_SUBTYPE_CONS:        return EVAC_CONS;
         case HEAP_SUBTYPE_VECTOR:      return EVAC_VECTOR;   // records are vectors too
+        case HEAP_SUBTYPE_RECORD:      return EVAC_VECTOR;   // records allocate as vectors;
+                                                             // belt-and-suspenders so a future
+                                                             // record allocator stamping subtype 7
+                                                             // cannot silently regress to leaf.
         case HEAP_SUBTYPE_MULTI_VALUE: return EVAC_MULTIVALUE;
         case HEAP_SUBTYPE_HASH:        return EVAC_HASH;
         case HEAP_SUBTYPE_TENSOR:      return EVAC_TENSOR;
         case HEAP_SUBTYPE_EXCEPTION:   return EVAC_EXCEPTION;
+        // ESH-0214d: neuro-symbolic / workspace subtypes now deep-walked. Each
+        // carries interior tagged values and/or raw arena buffers that a shallow
+        // leaf copy left dangling into the popped region arena.
+        case HEAP_SUBTYPE_SUBSTITUTION:   return EVAC_SUBSTITUTION;
+        case HEAP_SUBTYPE_FACT:           return EVAC_FACT;
+        case HEAP_SUBTYPE_KNOWLEDGE_BASE: return EVAC_KNOWLEDGE_BASE;
+        case HEAP_SUBTYPE_FACTOR_GRAPH:   return EVAC_FACTOR_GRAPH;
+        case HEAP_SUBTYPE_WORKSPACE:      return EVAC_WORKSPACE;
         // STRING / SYMBOL / BIGNUM / RATIONAL / BYTEVECTOR: self-contained
         // payloads -> a contiguous leaf copy fully preserves them.
         //
-        // SUBSTITUTION / FACT / KNOWLEDGE_BASE / FACTOR_GRAPH / WORKSPACE /
-        // PROMISE / DNC / SDNC / TAYLOR(rational-coeff): may carry interior
-        // tagged values, but (a) they are exceedingly rare to escape a region by
-        // mutation and (b) their internal layouts are not traversed here. They
-        // fall through to a shallow leaf copy — a documented limitation, not a
-        // regression (this matches the pre-ESH-0214c behavior for every subtype).
+        // Deliberately kept EVAC_LEAF (no interior region pointers, or their
+        // interior graph is not confidently/safely traversable here, AND they
+        // are not observed to escape a region by mutation):
+        //   PORT      - wraps an OS fd/FILE*; handle intentionally shared, not copied.
+        //   PRNG      - self-contained state words, no interior pointers.
+        //   PROMISE   - thunk/closure + memoized value; the closure/value escape
+        //               through their own tagged slots via the normal barrier when
+        //               forced, and a delayed promise almost never escapes a region.
+        //   DNC/SDNC  - large differentiable weight/program buffers; escaping a
+        //               region by mutation is not a supported pattern.
+        //   TAYLOR    - truncated-Taylor tower; rational-coeff interior not traversed.
+        // A guarded assert below (region_evacuate leaf handler) fires under a debug
+        // build if any such subtype is actually seen escaping, so a real escape is
+        // discovered instead of silently corrupting.
         default:                       return EVAC_LEAF;
     }
 }
@@ -795,6 +826,28 @@ static void* evac_object(EvacState& st, void* old_data, const eshkol_tagged_valu
     st.copies++;
 
     EvacKind k = evac_kind_for(v, old_data);
+#ifndef NDEBUG
+    // ESH-0214d: a subtype that carries interior region pointers must NOT be
+    // leaf-copied. These are the ones we deliberately left leaf but expect to
+    // never actually escape a region by mutation; warn loudly if one does, so a
+    // real escape is discovered instead of silently corrupting interior state.
+    if (k == EVAC_LEAF) {
+        const auto* dh = (const eshkol_object_header_t*)
+            ((const uint8_t*)new_data - sizeof(eshkol_object_header_t));
+        switch (dh->subtype) {
+            case HEAP_SUBTYPE_PROMISE:
+            case HEAP_SUBTYPE_DNC:
+            case HEAP_SUBTYPE_SDNC:
+            case HEAP_SUBTYPE_TAYLOR:
+                eshkol_warn("region evacuate: subtype %u escaped a region as a "
+                            "SHALLOW leaf copy (ESH-0214d watchlist); interior "
+                            "pointers may dangle -- deep coverage needed.",
+                            (unsigned)dh->subtype);
+                break;
+            default: break;
+        }
+    }
+#endif
     if (k != EVAC_LEAF) st.worklist.push_back({new_data, k});
     return new_data;
 }
@@ -816,6 +869,22 @@ static eshkol_tagged_value_t evac_value(EvacState& st, eshkol_tagged_value_t v) 
     void* np = evac_object(st, p, v);
     v.data.ptr_val = (uint64_t)(uintptr_t)np;
     return v;
+}
+
+// Evacuate a header-prefixed object referenced only by a RAW data pointer (no
+// enclosing tagged value), e.g. the fact pointers held in a knowledge base's
+// facts[] array. Synthesizes a plain HEAP_PTR tagged value so evac_object can
+// classify it by its object header and drive the normal deep walk (forwarding,
+// cycles, shared structure all preserved). Objects already at/outside the
+// boundary are returned unchanged.
+static void* evac_object_ptr(EvacState& st, void* data_ptr) {
+    if (!data_ptr) return data_ptr;
+    if (region_index_owning(data_ptr) <= st.boundary_idx) return data_ptr;
+    eshkol_tagged_value_t synth;
+    std::memset(&synth, 0, sizeof(synth));
+    synth.type = ESHKOL_VALUE_HEAP_PTR;
+    synth.data.ptr_val = (uint64_t)(uintptr_t)data_ptr;
+    return evac_object(st, data_ptr, synth);
 }
 
 // Drive the deep evacuation of @p val into @p target, copying everything
@@ -978,6 +1047,146 @@ static eshkol_tagged_value_t region_evacuate_value(eshkol_tagged_value_t val,
                 }
                 if (c->name && region_index_owning(c->name) > st.boundary_idx)
                     c->name = (const char*)evac_raw(st, c->name, std::strlen(c->name) + 1);
+                break;
+            }
+            case EVAC_SUBSTITUTION: {
+                // Layout [hdr][struct][var_ids u64[cap]][terms tagged[cap]] — all
+                // inline (already copied contiguously). var_ids are plain ints;
+                // only the bound terms carry heap pointers. Unused capacity slots
+                // beyond num_bindings are uninitialized and must not be walked.
+                auto* s = (eshkol_substitution_t*)nd;
+                eshkol_tagged_value_t* terms = SUBST_TERMS(s);
+                for (uint32_t i = 0; i < s->num_bindings; ++i)
+                    terms[i] = evac_value(st, terms[i]);
+                break;
+            }
+            case EVAC_FACT: {
+                // Layout [hdr][struct][args tagged[arity]] — args inline.
+                auto* f = (eshkol_fact_t*)nd;
+                eshkol_tagged_value_t* args = FACT_ARGS(f);
+                for (uint32_t i = 0; i < f->arity; ++i)
+                    args[i] = evac_value(st, args[i]);
+                // predicate is normally a pointer into the immortal interned
+                // predicate pool (static storage -> region_index_owning == -1 ->
+                // left in place, preserving pointer-equality matching). Only a
+                // non-interned predicate string allocated inside the dying region
+                // is copied (defensive; unify() has a string-compare fallback).
+                if (f->predicate) {
+                    void* pred = (void*)(uintptr_t)f->predicate;
+                    if (region_index_owning(pred) > st.boundary_idx)
+                        f->predicate = (uint64_t)(uintptr_t)evac_raw(
+                            st, pred, std::strlen((const char*)pred) + 1);
+                }
+                break;
+            }
+            case EVAC_KNOWLEDGE_BASE: {
+                // Layout [hdr][struct]; facts[] is a separate raw arena array of
+                // FACT data pointers (capacity slots, num_facts used).
+                auto* kb = (eshkol_knowledge_base_t*)nd;
+                if (kb->facts && region_index_owning(kb->facts) > st.boundary_idx)
+                    kb->facts = (eshkol_fact_t**)evac_raw(
+                        st, kb->facts, (size_t)kb->capacity * sizeof(eshkol_fact_t*));
+                if (kb->facts) {
+                    for (uint32_t i = 0; i < kb->num_facts; ++i)
+                        kb->facts[i] = (eshkol_fact_t*)evac_object_ptr(st, kb->facts[i]);
+                }
+                break;
+            }
+            case EVAC_WORKSPACE: {
+                // Layout [hdr][struct][modules module_t[max_modules]] — modules
+                // inline (already copied). content is a separate raw double buffer;
+                // each used module carries an arena name string + process_fn closure.
+                auto* ws = (eshkol_workspace_t*)nd;
+                if (ws->content && region_index_owning(ws->content) > st.boundary_idx)
+                    ws->content = (double*)evac_raw(
+                        st, ws->content, (size_t)ws->dim * sizeof(double));
+                eshkol_workspace_module_t* mods = WS_MODULES(ws);
+                for (uint32_t i = 0; i < ws->num_modules; ++i) {
+                    if (mods[i].name &&
+                        region_index_owning(mods[i].name) > st.boundary_idx)
+                        mods[i].name = (char*)evac_raw(
+                            st, mods[i].name, std::strlen(mods[i].name) + 1);
+                    mods[i].process_fn = evac_value(st, mods[i].process_fn);
+                }
+                break;
+            }
+            case EVAC_FACTOR_GRAPH: {
+                // A factor graph carries NO interior tagged values — only nested
+                // raw numeric buffers (arrays and arrays-of-arrays). Sizes are
+                // reconstructed from the graph's own counts, mirroring the
+                // allocation layout in inference.cpp.
+                auto* fg = (eshkol_factor_graph_t*)nd;
+                const uint32_t nvars = fg->num_vars;
+                if (fg->var_dims && region_index_owning(fg->var_dims) > st.boundary_idx)
+                    fg->var_dims = (uint32_t*)evac_raw(
+                        st, fg->var_dims, (size_t)nvars * sizeof(uint32_t));
+                if (fg->beliefs && region_index_owning(fg->beliefs) > st.boundary_idx)
+                    fg->beliefs = (double**)evac_raw(
+                        st, fg->beliefs, (size_t)nvars * sizeof(double*));
+                if (fg->beliefs && fg->var_dims) {
+                    for (uint32_t i = 0; i < nvars; ++i) {
+                        if (fg->beliefs[i] &&
+                            region_index_owning(fg->beliefs[i]) > st.boundary_idx)
+                            fg->beliefs[i] = (double*)evac_raw(
+                                st, fg->beliefs[i], (size_t)fg->var_dims[i] * sizeof(double));
+                    }
+                }
+                if (fg->observed && region_index_owning(fg->observed) > st.boundary_idx)
+                    fg->observed = (bool*)evac_raw(
+                        st, fg->observed, (size_t)nvars * sizeof(bool));
+                // factors[] holds max_factors ptrs (num_factors used). Each factor
+                // is a HEADERLESS raw buffer [eshkol_factor_t][var_indices...] with
+                // interior cpt/dims raw buffers.
+                if (fg->factors && region_index_owning(fg->factors) > st.boundary_idx)
+                    fg->factors = (eshkol_factor_t**)evac_raw(
+                        st, fg->factors, (size_t)fg->max_factors * sizeof(eshkol_factor_t*));
+                if (fg->factors) {
+                    for (uint32_t fi = 0; fi < fg->num_factors; ++fi) {
+                        eshkol_factor_t* f = fg->factors[fi];
+                        if (!f) continue;
+                        if (region_index_owning(f) > st.boundary_idx) {
+                            const size_t fsz = sizeof(eshkol_factor_t) +
+                                               (size_t)f->num_vars * sizeof(uint32_t);
+                            f = (eshkol_factor_t*)evac_raw(st, f, fsz);
+                            fg->factors[fi] = f;
+                        }
+                        if (f->cpt && region_index_owning(f->cpt) > st.boundary_idx)
+                            f->cpt = (double*)evac_raw(
+                                st, f->cpt, (size_t)f->cpt_size * sizeof(double));
+                        if (f->dims && region_index_owning(f->dims) > st.boundary_idx)
+                            f->dims = (uint32_t*)evac_raw(
+                                st, f->dims, (size_t)f->num_vars * sizeof(uint32_t));
+                    }
+                }
+                // msg_fv / msg_vf: parallel arrays of total_messages double* (NULL
+                // until eshkol_fg_infer allocates them). Edge k -> var_dims[var]
+                // doubles, where the (factor, var-slot) -> edge order mirrors
+                // ensure_messages() in inference.cpp (intentional coupling).
+                auto evac_msg_array = [&](double**& arr) {
+                    if (!arr) return;
+                    if (region_index_owning(arr) > st.boundary_idx)
+                        arr = (double**)evac_raw(
+                            st, arr, (size_t)fg->total_messages * sizeof(double*));
+                    uint32_t k = 0;
+                    for (uint32_t fi = 0;
+                         fi < fg->num_factors && k < fg->total_messages; ++fi) {
+                        eshkol_factor_t* f = fg->factors ? fg->factors[fi] : nullptr;
+                        if (!f) continue;
+                        const uint32_t* vidx = FACTOR_VAR_INDICES(f);
+                        for (uint32_t vi = 0;
+                             vi < f->num_vars && k < fg->total_messages; ++vi, ++k) {
+                            const uint32_t var_id = vidx[vi];
+                            const uint32_t dim =
+                                (fg->var_dims && var_id < nvars) ? fg->var_dims[var_id] : 0;
+                            if (arr[k] && dim &&
+                                region_index_owning(arr[k]) > st.boundary_idx)
+                                arr[k] = (double*)evac_raw(
+                                    st, arr[k], (size_t)dim * sizeof(double));
+                        }
+                    }
+                };
+                evac_msg_array(fg->msg_fv);
+                evac_msg_array(fg->msg_vf);
                 break;
             }
             case EVAC_LEAF:

--- a/tests/memory/region_evac_subtype_coverage_test.esk
+++ b/tests/memory/region_evac_subtype_coverage_test.esk
@@ -1,0 +1,134 @@
+;;; tests/memory/region_evac_subtype_coverage_test.esk — ESH-0214d region
+;;; evacuator subtype-coverage correctness fixture, gated by
+;;; region_evac_subtype_coverage_test.sh (runs this AOT under
+;;; ESHKOL_ARENA_POISON=1 with a flat-RSS ceiling).
+;;;
+;;; ESH-0214c (PR #210) made with-region escape promotion DEEP for CONS /
+;;; VECTOR / MULTI_VALUE / HASH / TENSOR / EXCEPTION / CLOSURE, but the
+;;; evacuator's type dispatch dropped the neuro-symbolic / workspace subtypes
+;;; (SUBSTITUTION / FACT / KNOWLEDGE_BASE / FACTOR_GRAPH / WORKSPACE) to a
+;;; SHALLOW leaf byte-copy. Those subtypes carry interior tagged values and/or
+;;; raw arena buffers (fact args, KB fact arrays, workspace content + per-module
+;;; process_fn closures, factor-graph numeric buffers). A shallow copy left
+;;; those interior pointers aimed into the per-iteration region arena; after
+;;; region_pop that memory is freed (and, under ESHKOL_ARENA_POISON, filled
+;;; with 0xCB), so the promoted object dangled.
+;;;
+;;; Two phases:
+;;;   PHASE 1 (flat-RSS, ~1,000,000 iterations): each iteration allocates heavy
+;;;   transient garbage inside a per-iteration (with-region ...) (dead at region
+;;;   exit -> reclaimed by region_pop -> flat RSS) and promotes ONE small fresh
+;;;   FACT (interior tagged-value args) into a rotating outer slot via the
+;;;   region write barrier. This exercises FACT interior-pointer evacuation a
+;;;   million times while keeping the promoted (never-freed global-arena)
+;;;   footprint tiny, so RSS stays flat.
+;;;
+;;;   PHASE 2 (bounded, heavy subtypes): a few thousand iterations that promote
+;;;   the LARGE subtypes — WORKSPACE (with a registered closure module),
+;;;   KNOWLEDGE_BASE (with a fact), FACTOR_GRAPH (with a factor), plus a RECORD
+;;;   and a CONS list — out of a per-iteration region, then reads/EXERCISES
+;;;   their interiors (ws-step! invokes the promoted module closure; kb-query
+;;;   and fg-infer! walk promoted interior buffers). Bounded count keeps the
+;;;   global-arena promotion footprint small.
+;;;
+;;; Under poison a missed interior pointer crashes at an obvious 0xCB.. address
+;;; instead of silently reading stale data. PASS is printed only if every read
+;;; is intact and the flat-RSS phase completed all iterations.
+
+(define-record-type point (make-point x y) point? (x point-x) (y point-y))
+
+;; ─────────────────────────── PHASE 1: flat-RSS FACT loop ───────────────────
+(define total-passes 1000000)
+(define slots 8)
+(define fact-slots (make-vector slots 0))
+
+(define (tick i)
+  (guard (e (#t (begin (display "GUARD-CAUGHT-P1 at ") (display i) (newline) i)))
+    (if (>= i total-passes)
+        i
+        (begin
+          (with-region 'tick
+            ;; heavy transient garbage: dead at region exit, reclaimed by region_pop
+            (let ((scratch (make-list 40 i)))
+              ;; small fresh FACT promoted into a rotating outer slot; its
+              ;; interior args must be evacuated out of the dying region.
+              (vector-set! fact-slots (modulo i slots)
+                           (make-fact 'p i (length scratch)))))
+          (tick (+ i 1))))))
+
+(define result (tick 0))
+
+;; read-back: every slot holds the fact from the last iteration that wrote it.
+;; last i writing slot s = largest i < total-passes with (modulo i slots) = s.
+(define (verify-facts s ok)
+  (if (>= s slots)
+      ok
+      (let* ((fct (vector-ref fact-slots s))
+             (last-i (+ s (* (quotient (- total-passes 1 s) slots) slots)))
+             ;; unify the promoted fact against its expected ground form; a
+             ;; success (substitution) proves predicate + both interior args
+             ;; survived promotion intact.
+             (u (unify fct (make-fact 'p last-i 40) (make-substitution))))
+        (verify-facts (+ s 1) (and ok (fact? fct) (substitution? u))))))
+
+(define facts-ok (verify-facts 0 #t))
+
+;; ───────────────────── PHASE 2: bounded heavy-subtype variant ───────────────
+(define heavy-passes 5000)
+(define heavy (make-vector 5 0))
+
+(define (heavy-tick i)
+  (guard (e (#t (begin (display "GUARD-CAUGHT-P2 at ") (display i) (newline) i)))
+    (if (>= i heavy-passes)
+        i
+        (begin
+          (with-region 'heavy
+            (let ((scratch (make-list 20 i)))
+              ;; WORKSPACE: content buffer + module name + process_fn closure.
+              (let ((ws (make-workspace 4 2)))
+                (ws-register! ws "m" (lambda (c) (cons 1.0 c)))
+                (vector-set! heavy 0 ws))
+              ;; KNOWLEDGE_BASE: facts[] raw array + FACT with interior args.
+              (let ((kb (make-kb)))
+                (kb-assert! kb (make-fact 'r i (+ i 1)))
+                (vector-set! heavy 1 kb))
+              ;; FACTOR_GRAPH: nested raw numeric buffers (var_dims/beliefs/factors).
+              (let ((fg (make-factor-graph 3 #(2 2 2))))
+                (fg-add-factor! fg #(0 1) #(0.1 0.2 0.3 0.4))
+                (vector-set! heavy 2 fg))
+              ;; RECORD (allocates as VECTOR) + CONS list control.
+              (vector-set! heavy 3 (make-point i (* i 2)))
+              (vector-set! heavy 4 (list i (car scratch) (length scratch)))))
+          (heavy-tick (+ i 1))))))
+
+(define heavy-result (heavy-tick 0))
+(define heavy-last (- heavy-passes 1))
+
+;; Exercise promoted interiors.
+(ws-step! (vector-ref heavy 0))                  ; invokes promoted module closure
+(define ws-ok (workspace? (vector-ref heavy 0)))
+(define kb-q (kb-query (vector-ref heavy 1) (make-fact 'r heavy-last (+ heavy-last 1))))
+(define kb-ok (pair? kb-q))                      ; walks promoted facts[] + args
+(fg-infer! (vector-ref heavy 2) 3)               ; walks promoted factor buffers
+(define fg-ok (factor-graph? (vector-ref heavy 2)))
+(define pt (vector-ref heavy 3))
+(define rec-ok (and (point? pt) (= (point-x pt) heavy-last) (= (point-y pt) (* heavy-last 2))))
+(define lst (vector-ref heavy 4))
+(define lst-ok (and (= (car lst) heavy-last) (= (cadr lst) heavy-last) (= (caddr lst) 20)))
+
+(display "[region_evac_subtype_coverage_test] p1=")
+(display result) (display "/") (display total-passes)
+(display " p2=") (display heavy-result) (display "/") (display heavy-passes)
+(newline)
+(display "  facts=") (display facts-ok)
+(display " ws=")   (display ws-ok)
+(display " kb=")   (display kb-ok)
+(display " fg=")   (display fg-ok)
+(display " rec=")  (display rec-ok)
+(display " lst=")  (display lst-ok)
+(newline)
+
+(if (and (= result total-passes) (= heavy-result heavy-passes)
+         facts-ok ws-ok kb-ok fg-ok rec-ok lst-ok)
+    (begin (display "PASS") (newline))
+    (begin (display "FAIL") (newline) (exit 1)))

--- a/tests/memory/region_evac_subtype_coverage_test.sh
+++ b/tests/memory/region_evac_subtype_coverage_test.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# tests/memory/region_evac_subtype_coverage_test.sh — ESH-0214d AOT flat-RSS +
+# correctness gate for the region escape-evacuator's neuro-symbolic / workspace
+# subtype coverage.
+#
+# ESH-0214c (PR #210) made with-region escape promotion DEEP for CONS / VECTOR /
+# MULTI_VALUE / HASH / TENSOR / EXCEPTION / CLOSURE, but its type dispatch
+# dropped SUBSTITUTION / FACT / KNOWLEDGE_BASE / FACTOR_GRAPH / WORKSPACE to a
+# SHALLOW leaf byte-copy that did not follow interior pointers (fact args, KB
+# fact arrays, workspace content + per-module process_fn closures, factor-graph
+# numeric buffers). ESH-0214d completes the transitive closure for those.
+#
+# This gate compiles tests/memory/region_evac_subtype_coverage_test.esk AOT
+# (same harness pattern as region_mutating_loop_flat_rss_test.sh), runs it under
+# /usr/bin/time (macOS: -l, Linux: -v) AND under ESHKOL_ARENA_POISON=1 — the
+# 0xCB poison allocator that fills freed region bytes on region_pop — and fails
+# if:
+#   (1) the program does not print PASS (correctness: after the region-wrapped
+#       loops every promoted subtype's interior — fact args, KB facts, workspace
+#       module closure, factor-graph buffers, record/list slots — reads back
+#       intact), or
+#   (2) peak RSS exceeds a flat ceiling.
+# Under poison a missed interior pointer dereferences 0xCB.. and crashes loudly
+# (SIGSEGV at 0xcbcbcbcb..) instead of silently reading stale-but-valid data, so
+# this gate fails hard on a real evacuation gap rather than passing by luck.
+#
+# The fixed behavior measures ~100MB (the 1M-iteration phase promotes ~56MB of
+# small FACTs into the global arena, which has no GC, plus base runtime). The
+# regression this guards against — per-iteration region reclamation failing so
+# the heavy transient (make-list 40) garbage is not freed — is 600MB+ / OOM, so
+# a 300MB ceiling separates the two with wide margin (matching the sibling
+# region_mutating_loop_flat_rss_test.sh gate).
+#
+# Usage: tests/memory/region_evac_subtype_coverage_test.sh [--ceiling-mb N] [--timeout S]
+#   BUILD_DIR env var selects the build directory (default: build).
+#   ESHKOL_RUN env var overrides the eshkol-run binary path directly.
+set -u
+cd "$(dirname "$0")/../.."
+REPO_ROOT="$(pwd)"
+
+BUILD_DIR="${BUILD_DIR:-build}"
+if [ -z "${ESHKOL_RUN:-}" ]; then
+    case "$BUILD_DIR" in
+        /*) ESHKOL_RUN="$BUILD_DIR/eshkol-run" ;;
+        *) ESHKOL_RUN="$REPO_ROOT/$BUILD_DIR/eshkol-run" ;;
+    esac
+fi
+if [ ! -x "$ESHKOL_RUN" ]; then
+    echo "region_evac_subtype_coverage_test.sh: $ESHKOL_RUN not found — run \`cmake --build $BUILD_DIR --target eshkol-run stdlib\` first." >&2
+    exit 2
+fi
+
+SRC="$REPO_ROOT/tests/memory/region_evac_subtype_coverage_test.esk"
+if [ ! -f "$SRC" ]; then
+    echo "region_evac_subtype_coverage_test.sh: $SRC not found." >&2
+    exit 2
+fi
+
+CEILING_MB=300
+TIMEOUT_S=180
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --ceiling-mb) shift; CEILING_MB="${1:-$CEILING_MB}" ;;
+        --timeout) shift; TIMEOUT_S="${1:-$TIMEOUT_S}" ;;
+        *) echo "region_evac_subtype_coverage_test.sh: unknown argument: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+# Detect which peak-RSS-reporting `time` flavor is available.
+TIME_MODE=""
+if /usr/bin/time -l true >/dev/null 2>/tmp/.regevac_probe.$$; then
+    if grep -q "maximum resident set size" /tmp/.regevac_probe.$$ 2>/dev/null; then
+        TIME_MODE="bsd"
+    fi
+fi
+if [ -z "$TIME_MODE" ] && /usr/bin/time -v true >/tmp/.regevac_probe.$$ 2>&1; then
+    if grep -qi "Maximum resident set size" /tmp/.regevac_probe.$$ 2>/dev/null; then
+        TIME_MODE="gnu"
+    fi
+fi
+rm -f /tmp/.regevac_probe.$$
+if [ -z "$TIME_MODE" ]; then
+    echo "region_evac_subtype_coverage_test.sh: neither \`/usr/bin/time -l\` (macOS) nor \`/usr/bin/time -v\` (Linux) reports peak RSS on this host — cannot gate." >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-region-evac.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "=========================================================="
+echo "  ESH-0214d AOT flat-RSS + correctness gate (poisoned):"
+echo "  region_evac_subtype_coverage_test.esk"
+echo "  ceiling=${CEILING_MB}MB  time-mode=${TIME_MODE}  ESHKOL_ARENA_POISON=1"
+echo "=========================================================="
+echo
+
+: "${WORK:?mktemp work dir must be set}"
+BIN="$WORK/region_evac_bin"
+COMPILE_LOG="$WORK/compile.log"
+RUN_OUT="$WORK/run.out"
+TIME_LOG="$WORK/time.log"
+: "${COMPILE_LOG:?}" "${RUN_OUT:?}" "${TIME_LOG:?}"
+
+( cd "$WORK" && "$ESHKOL_RUN" "$SRC" -o "$BIN" ) > "$COMPILE_LOG" 2>&1
+COMPILE_RC=$?
+if [ "$COMPILE_RC" -ne 0 ]; then
+    echo "FAIL: AOT compile failed (exit=$COMPILE_RC). Output:"
+    cat "$COMPILE_LOG"
+    echo "region_evac_subtype_coverage_test.sh: FAIL"
+    exit 1
+fi
+chmod +x "$BIN"
+
+# Run the AOT binary with the region-arena poison allocator enabled so a missed
+# interior pointer crashes at a 0xCB.. address rather than passing by luck.
+if [ "$TIME_MODE" = "bsd" ]; then
+    ( cd "$WORK" && ESHKOL_ARENA_POISON=1 /usr/bin/time -l perl -e 'my $s=shift; alarm $s; exec @ARGV; die "exec failed: $!\n"' \
+        "$TIMEOUT_S" "$BIN" ) > "$RUN_OUT" 2> "$TIME_LOG"
+    RUN_RC=$?
+    RSS_MB=$(awk '/maximum resident set size/{printf "%d", $1/1048576}' "$TIME_LOG")
+else
+    ( cd "$WORK" && ESHKOL_ARENA_POISON=1 /usr/bin/time -v perl -e 'my $s=shift; alarm $s; exec @ARGV; die "exec failed: $!\n"' \
+        "$TIMEOUT_S" "$BIN" ) > "$RUN_OUT" 2> "$TIME_LOG"
+    RUN_RC=$?
+    RSS_MB=$(awk -F: '/Maximum resident set size/{printf "%d", $2/1024}' "$TIME_LOG")
+fi
+[ -n "$RSS_MB" ] || RSS_MB=0
+
+fail=0
+if [ "$RUN_RC" -ne 0 ] || ! grep -q "^PASS$" "$RUN_OUT"; then
+    echo "FAIL: AOT binary did not complete cleanly under poison (exit=$RUN_RC). Output:"
+    cat "$RUN_OUT"
+    echo "      -- a crash at a 0xcbcbcbcb.. address (or a missing PASS) means a"
+    echo "      promoted logic/workspace subtype kept an interior pointer aimed"
+    echo "      into a freed region arena: the ESH-0214d evacuator subtype"
+    echo "      coverage has regressed (dropped back to a shallow leaf copy)."
+    fail=1
+else
+    echo "  exit=$RUN_RC  peak_rss=${RSS_MB}MB  (correctness: PASS)"
+    if [ "$RSS_MB" -gt "$CEILING_MB" ]; then
+        echo "FAIL: peak RSS ${RSS_MB}MB exceeds ceiling ${CEILING_MB}MB"
+        echo "      -- looks like per-iteration region reclamation regressed, or"
+        echo "      the write barrier is over-promoting (copying the transient"
+        echo "      garbage instead of only the escaping subgraph)."
+        fail=1
+    else
+        echo "PASS: peak RSS ${RSS_MB}MB is within the ${CEILING_MB}MB flat ceiling."
+    fi
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+    echo "region_evac_subtype_coverage_test.sh: PASS"
+else
+    echo "region_evac_subtype_coverage_test.sh: FAIL"
+fi
+exit "$fail"


### PR DESCRIPTION
## Summary

Completes the ESH-0214c (PR #210) region escape-evacuator so its transitive
closure covers the neuro-symbolic / workspace heap subtypes it previously
dropped to a shallow leaf copy. Runtime-only; no codegen changes.

PR #210 made `(with-region ...)` escape promotion a deep, Cheney-style
evacuation (forwarding map + write barriers) for CONS / VECTOR / MULTI_VALUE /
HASH / TENSOR / EXCEPTION / CLOSURE. But `evac_kind_for` dropped these subtypes
to a shallow `EVAC_LEAF` byte-copy that does not follow interior pointers:

| Subtype | Interior pointers left dangling by the leaf copy |
|---|---|
| `SUBSTITUTION` (12) | inline `terms[]` tagged values |
| `FACT` (13) | inline `args[]` tagged values (+ non-interned predicate string) |
| `KNOWLEDGE_BASE` (15) | raw `facts[]` array of FACT pointers, each with interior args |
| `FACTOR_GRAPH` (16) | nested raw numeric buffers: `var_dims`, `beliefs[][]`, `factors[]` (per-factor `cpt`/`dims`), `msg_fv`/`msg_vf` |
| `WORKSPACE` (17) | `content` double buffer + per-module `name` string and `process_fn` closure |

When one of these is mutated into outer/persistent state inside a with-region
body and the region is popped, the shallow copy left those interior pointers
aimed into freed region memory -> use-after-free ("car/cdr: argument is not a
pair" and friends).

## What changed

- `evac_kind_for` + the evacuator worklist now deep-walk all five subtypes,
  reusing the existing value-evacuation path (forwarding/cycles/shared structure
  preserved) for interior tagged values and `evac_raw` for raw buffers. A small
  `evac_object_ptr` helper evacuates header-prefixed objects referenced only by
  a raw pointer (the KB `facts[]` entries).
- Explicit `HEAP_SUBTYPE_RECORD -> EVAC_VECTOR` case (records allocate as
  vectors today; guards against a future record allocator stamping subtype 7 and
  silently regressing to a leaf copy).
- Subtypes deliberately kept `EVAC_LEAF` (PORT, PRNG, PROMISE, DNC, SDNC,
  TAYLOR) now trip a guarded (`#ifndef NDEBUG`) warning if one is ever seen
  escaping as a leaf copy, so a real escape is surfaced rather than silently
  corrupting.
- `arena_destroy()` fills each block's live bytes with the `0xCB` poison
  sentinel before releasing it when `ESHKOL_ARENA_POISON` is set. `arena_destroy`
  is the teardown path for region arenas (`region_pop -> region_destroy ->
  arena_destroy`), which previously returned memory to the allocator untouched —
  so a missed interior pointer read stale-but-valid data and passed by luck.
  With this, any region UAF crashes immediately at a `0xCB..` address.

## Test

`tests/memory/region_evac_subtype_coverage_test.esk` + gate
`region_evac_subtype_coverage_test.sh` (modeled on
`region_mutating_loop_flat_rss_test.sh`):

- **Phase 1 (flat RSS, 1,000,000 iterations):** heavy transient garbage inside a
  per-iteration region + a fresh FACT (interior args) promoted into a rotating
  outer slot; read back by unifying each promoted fact against its ground form.
- **Phase 2 (bounded):** promotes WORKSPACE (with a registered closure module),
  KNOWLEDGE_BASE (with a fact), FACTOR_GRAPH (with a factor), a record and a
  list; then `ws-step!` invokes the promoted module closure, `kb-query` walks the
  promoted facts, `fg-infer!` walks the promoted factor buffers.

Runs under `ESHKOL_ARENA_POISON=1` with a 300MB flat-RSS ceiling.

- With the fix: **PASS at ~110MB**.
- With the coverage reverted to leaf: **SIGSEGV at `0xcbcbcbcbcbcbcbcb`** (proven
  for both the logic subtypes and the factor-graph path).
- Existing `region_mutating_loop_flat_rss_test.sh` still PASSes; full
  `scripts/run_memory_tests.sh` suite 14/14.