### PR TITLE
Exact tensor gradients for first-class losses and vector gamma

### DIFF
--- a/lib/backend/autodiff_codegen.cpp
+++ b/lib/backend/autodiff_codegen.cpp
@@ -4097,6 +4097,173 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
                     ctx_.context(), "grad_rt_collection", current_func);
                 BasicBlock* grad_rt_done = BasicBlock::Create(
                     ctx_.context(), "grad_rt_done", current_func);
+
+                // ESH-0212 (defect 1): first-class tensor gradient. A runtime
+                // function value — one bound to a variable, passed as a
+                // parameter, or reached through a wrapper — arrives here with no
+                // compile-time Function*, so the code below differentiates it
+                // with forward-mode dual numbers. That is correct for scalar and
+                // scalar-vector points, but tensor ops do NOT carry dual numbers
+                // through their elements, so a TENSOR point silently collapsed to
+                // a zero gradient (#(0 0 0 0)). Reverse mode does carry the
+                // signal: seed each input element as an AD variable, call the
+                // closure once in AD mode, backpropagate, and read each
+                // variable's gradient — exactly what the literal-lambda path does
+                // for a statically known function, but dispatched through the
+                // runtime closure so it works for any first-class loss.
+                {
+                    auto& b = ctx_.builder();
+                    Value* rvt_base = tagged_.getBaseType(tagged_.getType(point_val));
+                    Value* rvt_is_heap = b.CreateICmpEQ(rvt_base,
+                        ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_HEAP_PTR));
+                    BasicBlock* rvt_check = BasicBlock::Create(ctx_.context(), "grad_rt_rev_check", current_func);
+                    BasicBlock* rvt_reverse = BasicBlock::Create(ctx_.context(), "grad_rt_rev", current_func);
+                    BasicBlock* rvt_not_tensor = BasicBlock::Create(ctx_.context(), "grad_rt_rev_skip", current_func);
+                    b.CreateCondBr(rvt_is_heap, rvt_check, rvt_not_tensor);
+
+                    b.SetInsertPoint(rvt_check);
+                    Value* rvt_hp = tagged_.unpackPtr(point_val);
+                    Value* rvt_hdr = b.CreateGEP(ctx_.int8Type(), rvt_hp, ConstantInt::get(ctx_.int64Type(), -8));
+                    Value* rvt_sub = b.CreateLoad(ctx_.int8Type(), rvt_hdr);
+                    Value* rvt_is_tensor = b.CreateICmpEQ(rvt_sub,
+                        ConstantInt::get(ctx_.int8Type(), HEAP_SUBTYPE_TENSOR));
+                    b.CreateCondBr(rvt_is_tensor, rvt_reverse, rvt_not_tensor);
+
+                    // ---- reverse-mode tensor gradient ----
+                    b.SetInsertPoint(rvt_reverse);
+                    llvm::StructType* rvt_tt = ctx_.tensorType();
+                    Value* rvt_ptr = b.CreateIntToPtr(tagged_.unpackInt64(point_val), ctx_.ptrType());
+                    Value* rvt_dims = b.CreateLoad(ctx_.ptrType(), b.CreateStructGEP(rvt_tt, rvt_ptr, 0));
+                    Value* rvt_ndim = b.CreateLoad(ctx_.int64Type(), b.CreateStructGEP(rvt_tt, rvt_ptr, 1));
+                    Value* rvt_elems = b.CreateLoad(ctx_.ptrType(), b.CreateStructGEP(rvt_tt, rvt_ptr, 2));
+                    Value* rvt_n = b.CreateLoad(ctx_.int64Type(), b.CreateStructGEP(rvt_tt, rvt_ptr, 3));
+
+                    // Fresh tape for this gradient; publish as current so
+                    // createADVariable / tensor-op recording target it.
+                    Value* rvt_tape = b.CreateCall(mem_.getArenaAllocateTape(),
+                        {arena_ptr, ConstantInt::get(ctx_.int64Type(), 1024)});
+                    Value* rvt_saved_tape = current_tape_ptr_;
+                    current_tape_ptr_ = rvt_tape;
+                    pushTapeContext(rvt_tape);
+
+                    // Per-element AD variable node pointer array.
+                    Value* rvt_nodes = b.CreateCall(arena_allocate_func,
+                        {arena_ptr, b.CreateMul(rvt_n, ConstantInt::get(ctx_.int64Type(), sizeof(void*)))});
+                    Value* rvt_nodes_t = b.CreatePointerCast(rvt_nodes, ctx_.ptrType());
+
+                    // AD-node tensor (same shape) passed to the closure.
+                    Value* rvt_ad = b.CreateCall(mem_.getArenaAllocateTensorFull(),
+                        {arena_ptr, rvt_ndim, rvt_n});
+                    Value* rvt_ad_dims = b.CreateLoad(ctx_.ptrType(), b.CreateStructGEP(rvt_tt, rvt_ad, 0));
+                    Value* rvt_ad_elems = b.CreateLoad(ctx_.ptrType(), b.CreateStructGEP(rvt_tt, rvt_ad, 2));
+
+                    // Result tensor (same shape) that receives the gradient.
+                    Value* rvt_res = b.CreateCall(mem_.getArenaAllocateTensorFull(),
+                        {arena_ptr, rvt_ndim, rvt_n});
+                    Value* rvt_res_dims = b.CreateLoad(ctx_.ptrType(), b.CreateStructGEP(rvt_tt, rvt_res, 0));
+                    Value* rvt_res_elems = b.CreateLoad(ctx_.ptrType(), b.CreateStructGEP(rvt_tt, rvt_res, 2));
+
+                    // Copy the shape into both the AD-node tensor and the result.
+                    Value* rvt_di = b.CreateAlloca(ctx_.int64Type(), nullptr, "rvt_di");
+                    b.CreateStore(ConstantInt::get(ctx_.int64Type(), 0), rvt_di);
+                    BasicBlock* rvt_dc = BasicBlock::Create(ctx_.context(), "rvt_dcopy_cond", current_func);
+                    BasicBlock* rvt_db = BasicBlock::Create(ctx_.context(), "rvt_dcopy_body", current_func);
+                    BasicBlock* rvt_de = BasicBlock::Create(ctx_.context(), "rvt_dcopy_end", current_func);
+                    b.CreateBr(rvt_dc);
+                    b.SetInsertPoint(rvt_dc);
+                    Value* rvt_div = b.CreateLoad(ctx_.int64Type(), rvt_di);
+                    b.CreateCondBr(b.CreateICmpULT(rvt_div, rvt_ndim), rvt_db, rvt_de);
+                    b.SetInsertPoint(rvt_db);
+                    Value* rvt_dv = b.CreateLoad(ctx_.int64Type(), b.CreateGEP(ctx_.int64Type(), rvt_dims, rvt_div));
+                    b.CreateStore(rvt_dv, b.CreateGEP(ctx_.int64Type(), rvt_ad_dims, rvt_div));
+                    b.CreateStore(rvt_dv, b.CreateGEP(ctx_.int64Type(), rvt_res_dims, rvt_div));
+                    b.CreateStore(b.CreateAdd(rvt_div, ConstantInt::get(ctx_.int64Type(), 1)), rvt_di);
+                    b.CreateBr(rvt_dc);
+                    b.SetInsertPoint(rvt_de);
+
+                    // Seed each element as an AD variable node.
+                    Value* rvt_ji = b.CreateAlloca(ctx_.int64Type(), nullptr, "rvt_ji");
+                    b.CreateStore(ConstantInt::get(ctx_.int64Type(), 0), rvt_ji);
+                    BasicBlock* rvt_sc = BasicBlock::Create(ctx_.context(), "rvt_seed_cond", current_func);
+                    BasicBlock* rvt_sb = BasicBlock::Create(ctx_.context(), "rvt_seed_body", current_func);
+                    BasicBlock* rvt_se = BasicBlock::Create(ctx_.context(), "rvt_seed_end", current_func);
+                    b.CreateBr(rvt_sc);
+                    b.SetInsertPoint(rvt_sc);
+                    Value* rvt_jv = b.CreateLoad(ctx_.int64Type(), rvt_ji);
+                    b.CreateCondBr(b.CreateICmpULT(rvt_jv, rvt_n), rvt_sb, rvt_se);
+                    b.SetInsertPoint(rvt_sb);
+                    Value* rvt_ebits = b.CreateLoad(ctx_.int64Type(), b.CreateGEP(ctx_.int64Type(), rvt_elems, rvt_jv));
+                    Value* rvt_edbl = b.CreateBitCast(rvt_ebits, ctx_.doubleType());
+                    Value* rvt_node = createADVariable(rvt_edbl, 0);
+                    b.CreateStore(rvt_node, b.CreateGEP(ctx_.ptrType(), rvt_nodes_t, rvt_jv));
+                    b.CreateStore(b.CreatePtrToInt(rvt_node, ctx_.int64Type()),
+                        b.CreateGEP(ctx_.int64Type(), rvt_ad_elems, rvt_jv));
+                    b.CreateStore(b.CreateAdd(rvt_jv, ConstantInt::get(ctx_.int64Type(), 1)), rvt_ji);
+                    b.CreateBr(rvt_sc);
+                    b.SetInsertPoint(rvt_se);
+
+                    // Call the closure in AD mode with the AD-node tensor.
+                    b.CreateStore(ConstantInt::get(ctx_.int1Type(), 1), ctx_.adModeActive());
+                    Value* rvt_ad_tagged = tagged_.packPtr(
+                        b.CreatePtrToInt(rvt_ad, ctx_.int64Type()), ESHKOL_VALUE_HEAP_PTR);
+                    Value* rvt_out = closure_call_callback_(closure_val,
+                        std::vector<Value*>{rvt_ad_tagged}, "autodiff", callback_context_);
+                    b.CreateStore(ConstantInt::get(ctx_.int1Type(), 0), ctx_.adModeActive());
+                    popTapeContext();
+
+                    if (!rvt_out) {
+                        eshkol_error("gradient: failed to call runtime tensor function");
+                        return nullptr;
+                    }
+
+                    // Backpropagate only when the closure returned an AD node. A
+                    // constant return means the loss ignores its input, so a zero
+                    // gradient is the correct answer (not a dropped signal).
+                    Value* rvt_ob = tagged_.getBaseType(tagged_.getType(rvt_out));
+                    Value* rvt_is_ad = b.CreateICmpEQ(rvt_ob,
+                        ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_CALLABLE));
+                    BasicBlock* rvt_bwd = BasicBlock::Create(ctx_.context(), "rvt_bwd", current_func);
+                    BasicBlock* rvt_nobwd = BasicBlock::Create(ctx_.context(), "rvt_nobwd", current_func);
+                    BasicBlock* rvt_after = BasicBlock::Create(ctx_.context(), "rvt_after_bwd", current_func);
+                    b.CreateCondBr(rvt_is_ad, rvt_bwd, rvt_nobwd);
+
+                    b.SetInsertPoint(rvt_bwd);
+                    Value* rvt_out_node = b.CreateIntToPtr(tagged_.unpackInt64(rvt_out), ctx_.ptrType());
+                    backpropagate(rvt_tape, rvt_out_node);
+                    ctx_.builder().CreateBr(rvt_after);
+
+                    ctx_.builder().SetInsertPoint(rvt_nobwd);
+                    ctx_.builder().CreateBr(rvt_after);
+
+                    ctx_.builder().SetInsertPoint(rvt_after);
+                    // Extract per-element gradients (0.0 where no backward ran).
+                    Value* rvt_gi = ctx_.builder().CreateAlloca(ctx_.int64Type(), nullptr, "rvt_gi");
+                    ctx_.builder().CreateStore(ConstantInt::get(ctx_.int64Type(), 0), rvt_gi);
+                    BasicBlock* rvt_gc = BasicBlock::Create(ctx_.context(), "rvt_grad_cond", current_func);
+                    BasicBlock* rvt_gb = BasicBlock::Create(ctx_.context(), "rvt_grad_body", current_func);
+                    BasicBlock* rvt_ge = BasicBlock::Create(ctx_.context(), "rvt_grad_end", current_func);
+                    ctx_.builder().CreateBr(rvt_gc);
+                    ctx_.builder().SetInsertPoint(rvt_gc);
+                    Value* rvt_gv = ctx_.builder().CreateLoad(ctx_.int64Type(), rvt_gi);
+                    ctx_.builder().CreateCondBr(ctx_.builder().CreateICmpULT(rvt_gv, rvt_n), rvt_gb, rvt_ge);
+                    ctx_.builder().SetInsertPoint(rvt_gb);
+                    Value* rvt_gnode = ctx_.builder().CreateLoad(ctx_.ptrType(),
+                        ctx_.builder().CreateGEP(ctx_.ptrType(), rvt_nodes_t, rvt_gv));
+                    Value* rvt_g = loadNodeGradient(rvt_gnode);
+                    ctx_.builder().CreateStore(ctx_.builder().CreateBitCast(rvt_g, ctx_.int64Type()),
+                        ctx_.builder().CreateGEP(ctx_.int64Type(), rvt_res_elems, rvt_gv));
+                    ctx_.builder().CreateStore(
+                        ctx_.builder().CreateAdd(rvt_gv, ConstantInt::get(ctx_.int64Type(), 1)), rvt_gi);
+                    ctx_.builder().CreateBr(rvt_gc);
+                    ctx_.builder().SetInsertPoint(rvt_ge);
+
+                    current_tape_ptr_ = rvt_saved_tape;
+                    ctx_.builder().CreateStore(tagged_.packHeapPtr(rvt_res), rt_result_slot);
+                    ctx_.builder().CreateBr(grad_rt_done);
+
+                    ctx_.builder().SetInsertPoint(rvt_not_tensor);
+                }
+
                 ctx_.builder().CreateCondBr(rt_point_is_scalar, grad_rt_scalar_fwd, grad_rt_collection);
 
                 ctx_.builder().SetInsertPoint(grad_rt_scalar_fwd);

--- a/lib/backend/tensor_backward.cpp
+++ b/lib/backend/tensor_backward.cpp
@@ -16,6 +16,7 @@
 
 #include <eshkol/backend/tensor_backward.h>
 #include <eshkol/eshkol.h>
+#include <eshkol/logger.h>
 #include <cstring>
 #include <cmath>
 #include <cstdlib>
@@ -1337,31 +1338,44 @@ extern "C" void eshkol_tensor_backward_dispatch(void* ad_node_ptr) {
     case AD_NODE_TENSOR_RMSNORM:
     case AD_NODE_TENSOR_GELU:
     case AD_NODE_TENSOR_SILU:
-    case AD_NODE_TENSOR_CROSS_ENTROPY: {
-        /* Use the bridge dispatch table to find the right backward fn */
-        bridge_backward_fn_t fn = get_tensor_backward_fn((int)node->type);
-        if (fn) fn(node);
-        break;
-    }
-
-    /* Tensor bridge ops without dedicated backward (gradient passthrough) */
+    case AD_NODE_TENSOR_CROSS_ENTROPY:
+    /* Previously these fell into a "gradient passthrough" case that silently
+     * dropped the gradient even though get_tensor_backward_fn HAS a registered
+     * backward for each. Route them through the dispatch table like the ops
+     * above. attention/embedding backends now raise an explicit unsupported-op
+     * error instead of returning a plausible-but-wrong gradient (hard
+     * constraint: exact AD or an explicit error, never a silent zero). */
     case AD_NODE_TENSOR_ATTENTION:
     case AD_NODE_TENSOR_TRANSPOSE:
     case AD_NODE_TENSOR_SUM:
     case AD_NODE_TENSOR_BROADCAST_ADD:
     case AD_NODE_TENSOR_BROADCAST_MUL:
-    case AD_NODE_TENSOR_EMBEDDING:
+    case AD_NODE_TENSOR_EMBEDDING: {
+        /* Use the bridge dispatch table to find the right backward fn */
+        bridge_backward_fn_t fn = get_tensor_backward_fn((int)node->type);
+        if (!fn) {
+            eshkol_fatal("unsupported AD op: no backward registered for tensor "
+                         "bridge node type %d; refusing to drop the gradient "
+                         "silently", (int)node->type);
+        }
+        fn(node);
+        break;
+    }
+
     case AD_NODE_FRECHET_MEAN:
-        /* These node types don't yet have bridge backward implementations.
-         * get_tensor_backward_fn returns NULL for them, so rather than
-         * calling into a no-op, we explicitly skip. When backward functions
-         * are added to lib/bridge/tensor_backward.cpp, move these cases
-         * into the dispatch group above. */
+        /* No exact backward for the Riemannian center-of-mass node yet. Refuse
+         * rather than leave the gradient at a silent zero. */
+        eshkol_fatal("unsupported AD op: exact backward for the Frechet-mean "
+                     "tensor node is not implemented; refusing to drop the "
+                     "gradient silently.");
         break;
 
     default:
-        /* Unhandled tensor op — gradient silently dropped.
-         * Geometric/hyperbolic ops (33-40) use scalar backward in codegen. */
+        /* Scalar activation / geometric / hyperbolic ops (12-18, 33-66) are
+         * differentiated by their scalar backward emitted in codegen and
+         * legitimately reach here with nothing to do. Every TENSOR op
+         * (19-32 and the qLLM bridge ops 67-80) has an explicit case above, so
+         * a tensor-op gradient can never silently fall through this default. */
         break;
     }
 

--- a/lib/backend/tensor_conv_codegen.cpp
+++ b/lib/backend/tensor_conv_codegen.cpp
@@ -1205,6 +1205,65 @@ bool TensorCodegen::emitTensorADNormalizeDispatch(llvm::Value* src_elems,
     llvm::Value* beta_node = scalarToADNode(beta_source, beta, name + "_beta");
     llvm::Value* epsilon_node = scalarToADNode(epsilon_source, epsilon, name + "_epsilon");
 
+    // ESH-0212: per-feature (vector/learnable) gamma & beta support. When gamma
+    // or beta is a tensor rather than a scalar, each normalized element k must
+    // be scaled/shifted by gamma[k]/beta[k] as its OWN AD node, so reverse mode
+    // yields d loss / d gamma[k] instead of an unconditional zero. The scalar
+    // path (scalarToADNode above) covers the broadcast-scalar and scalar-AD-
+    // variable forms; this covers the tensor form, indexed along the
+    // normalization axis to match the numeric kernel's norm_param_at(gamma, k).
+    auto paramIsTensor = [&](llvm::Value* source) -> llvm::Value* {
+        if (!source || source->getType() != ctx_.taggedValueType())
+            return builder.getInt1(false);
+        llvm::Value* base_type = tagged_.getBaseType(tagged_.getType(source));
+        return builder.CreateICmpEQ(base_type,
+            llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_HEAP_PTR));
+    };
+    llvm::Value* gamma_is_tensor = paramIsTensor(gamma_source);
+    llvm::Value* beta_is_tensor = paramIsTensor(beta_source);
+
+    // Return the effective per-element AD node for a scale/shift parameter:
+    // gamma[idx]/beta[idx] when the parameter is a tensor, else the shared
+    // scalar node. Reuses adNodeFromTensorElementBits so an element that is
+    // itself an outer AD variable (a gradient input) is wired in directly.
+    auto effectiveParamNode = [&](llvm::Value* scalar_node, llvm::Value* source,
+                                  llvm::Value* is_tensor, llvm::Value* idx,
+                                  const std::string& pname) -> llvm::Value* {
+        if (!source || source->getType() != ctx_.taggedValueType())
+            return scalar_node;
+        llvm::BasicBlock* t_bb = llvm::BasicBlock::Create(ctx_.context(), pname + "_tensor", current_func);
+        llvm::BasicBlock* s_bb = llvm::BasicBlock::Create(ctx_.context(), pname + "_scalar", current_func);
+        llvm::BasicBlock* m_bb = llvm::BasicBlock::Create(ctx_.context(), pname + "_merge", current_func);
+        builder.CreateCondBr(is_tensor, t_bb, s_bb);
+
+        builder.SetInsertPoint(t_bb);
+        llvm::Value* tptr = tagged_.unpackPtr(source);
+        llvm::Value* pelems = builder.CreateLoad(ctx_.ptrType(),
+            builder.CreateStructGEP(ctx_.tensorType(), tptr, 2));
+        llvm::Value* ptotal = builder.CreateLoad(ctx_.int64Type(),
+            builder.CreateStructGEP(ctx_.tensorType(), tptr, 3));
+        // Broadcast-safe index: a length-1 tensor behaves like a scalar, a
+        // per-feature tensor (length == axis_len) reads gamma[k] exactly.
+        llvm::Value* safe_total = builder.CreateSelect(
+            builder.CreateICmpSGT(ptotal, zero_i64), ptotal, one_i64);
+        llvm::Value* pidx = builder.CreateURem(idx, safe_total);
+        llvm::Value* pbits = builder.CreateLoad(ctx_.int64Type(),
+            builder.CreateGEP(ctx_.int64Type(), pelems, pidx));
+        llvm::Value* tnode = adNodeFromTensorElementBits(pbits, pname + "_elem");
+        llvm::BasicBlock* t_exit = builder.GetInsertBlock();
+        builder.CreateBr(m_bb);
+
+        builder.SetInsertPoint(s_bb);
+        llvm::BasicBlock* s_exit = builder.GetInsertBlock();
+        builder.CreateBr(m_bb);
+
+        builder.SetInsertPoint(m_bb);
+        llvm::PHINode* phi = builder.CreatePHI(ctx_.ptrType(), 2, pname + "_node");
+        phi->addIncoming(tnode, t_exit);
+        phi->addIncoming(scalar_node, s_exit);
+        return phi;
+    };
+
     llvm::Value* group_i_alloca = builder.CreateAlloca(ctx_.int64Type(), nullptr, (name + "_group_i").c_str());
     builder.CreateStore(zero_i64, group_i_alloca);
     llvm::BasicBlock* group_cond = llvm::BasicBlock::Create(ctx_.context(), name + "_group_cond", current_func);
@@ -1299,8 +1358,12 @@ bool TensorCodegen::emitTensorADNormalizeDispatch(llvm::Value* src_elems,
     llvm::Value* norm_elem_node = adNodeFromTensorElementBits(norm_bits, name + "_norm_elem");
     llvm::Value* norm_centered = autodiff_->recordADNodeBinary(3, norm_elem_node, mean_node);
     llvm::Value* normalized = autodiff_->recordADNodeBinary(5, norm_centered, std_node);
-    llvm::Value* scaled = autodiff_->recordADNodeBinary(4, normalized, gamma_node);
-    llvm::Value* shifted = autodiff_->recordADNodeBinary(2, scaled, beta_node);
+    llvm::Value* eff_gamma = effectiveParamNode(gamma_node, gamma_source,
+        gamma_is_tensor, norm_k, name + "_gamma_pe");
+    llvm::Value* eff_beta = effectiveParamNode(beta_node, beta_source,
+        beta_is_tensor, norm_k, name + "_beta_pe");
+    llvm::Value* scaled = autodiff_->recordADNodeBinary(4, normalized, eff_gamma);
+    llvm::Value* shifted = autodiff_->recordADNodeBinary(2, scaled, eff_beta);
     builder.CreateStore(builder.CreatePtrToInt(shifted, ctx_.int64Type()),
         builder.CreateGEP(ctx_.int64Type(), result_elems, norm_index));
     builder.CreateStore(builder.CreateAdd(norm_k, one_i64), k_alloca);

--- a/lib/bridge/tensor_backward.cpp
+++ b/lib/bridge/tensor_backward.cpp
@@ -21,6 +21,7 @@
 
 /* Include the Eshkol AD types — eshkol.h is a C++ header, no extern "C" needed */
 #include "eshkol/eshkol.h"
+#include "eshkol/logger.h"
 
 /*******************************************************************************
  * Internal Helpers
@@ -585,38 +586,18 @@ extern "C" void tensor_broadcast_mul_backward(ad_node_t* node) {
  *  as ESH-0230 (.swarm/tasks/ESH-0230.json) — implement once the
  *  forward-pass wiring delivers node->input2 as the index tensor. */
 extern "C" void tensor_embedding_backward(ad_node_t* node) {
-    if (!node || !node->tensor_gradient) return;
-    ad_node_t* W = node->input1;
-    if (!W) return;
-    size_t n_out = tensor_size(node->shape, node->ndim);
-    size_t n_w = tensor_size(W->shape, W->ndim);
-    if (W->tensor_gradient == NULL) W->tensor_gradient = alloc_grad(n_w);
-    double* dy = (double*)node->tensor_gradient;
-    double* dW = (double*)W->tensor_gradient;
-    /* Conservative fallback — accumulate into row 0. Replace with
-     * indexed scatter once node carries the lookup-index tensor.
-     *
-     * Loud one-shot warning so training that depends on multi-row
-     * embedding gradients can't hit this silently. */
-    {
-        static int warned = 0;
-        if (!warned) {
-            warned = 1;
-            fprintf(stderr,
-                "WARNING: tensor_embedding_backward is a row-0 stub — "
-                "gradients past row 0 are dropped. Tracked as ESH-0230; "
-                "full indexed scatter needs the lookup-index tensor "
-                "threaded through the AD node first. Training "
-                "with embeddings against rows other than 0 will not "
-                "converge correctly. See "
-                "lib/bridge/tensor_backward.cpp tensor_embedding_backward "
-                "and docs/breakdown/AUTODIFF.md for the tracking note.\n");
-        }
-    }
-    size_t feat_dim = (node->ndim >= 2) ? (size_t)node->shape[1]
-                                        : (n_out > 0 ? n_out : 0);
-    size_t write = feat_dim > 0 ? feat_dim : n_out;
-    for (size_t i = 0; i < write && i < n_w; i++) dW[i] += dy[i];
+    (void)node;
+    /* HARD CONSTRAINT (exact AD or an explicit error, never a silent/plausible
+     * zero): the correct backward scatters dL/dy[i,:] into dL/dW[idx[i],:], but
+     * the lookup-index tensor is not threaded through the AD node (ESH-0230). The
+     * former "accumulate into row 0" stub dropped every gradient past row 0 and
+     * mis-attributed the rest — a wrong gradient. Refuse instead of corrupting
+     * training. Wire node->input2 as the index tensor and implement the indexed
+     * scatter to restore support. */
+    eshkol_fatal("unsupported AD op: exact backward for the qLLM-bridge tensor "
+                 "embedding node is not implemented (the lookup-index tensor is "
+                 "not threaded through the AD node — ESH-0230); refusing to "
+                 "return an approximate (wrong) gradient.");
 }
 
 /** @brief Backward pass for attention: a conservative identity-like
@@ -626,34 +607,21 @@ extern "C" void tensor_embedding_backward(ad_node_t* node) {
  *  through softmax(QK^T/√d)V) lands with the full attention codegen
  *  rewrite. */
 extern "C" void tensor_attention_backward(ad_node_t* node) {
-    if (!node || !node->tensor_gradient) return;
-    ad_node_t* v = node->input2 ? node->input2 : node->input1;
-    if (!v) return;
-    size_t n = tensor_size(v->shape, v->ndim);
-    size_t n_out = tensor_size(node->shape, node->ndim);
-    if (v->tensor_gradient == NULL) v->tensor_gradient = alloc_grad(n);
-    double* dV = (double*)v->tensor_gradient;
-    double* dy = (double*)node->tensor_gradient;
-    /* Conservative fallback — passes dy through to V's gradient slot
-     * only. Q and K receive no gradient; the softmax chain is skipped.
-     * Proper backward ships with the full attention codegen rewrite. */
-    {
-        static int warned = 0;
-        if (!warned) {
-            warned = 1;
-            fprintf(stderr,
-                "WARNING: tensor_attention_backward is a value-passthrough "
-                "stub — gradients flow only into V, never into Q or K, and "
-                "the softmax chain through softmax(Q K^T / sqrt(d)) V is "
-                "skipped. This is a known v1.2 limitation; full backward "
-                "ships in v1.3. Training attention layers will not "
-                "converge correctly. See "
-                "lib/bridge/tensor_backward.cpp tensor_attention_backward "
-                "and docs/breakdown/AUTODIFF.md for the tracking note.\n");
-        }
-    }
-    size_t m = n < n_out ? n : n_out;
-    for (size_t i = 0; i < m; i++) dV[i] += dy[i];
+    (void)node;
+    /* HARD CONSTRAINT (exact AD or an explicit error, never a silent/plausible
+     * zero): the qLLM-bridge attention AD node has no exact backward. The former
+     * value-passthrough stub flowed dy into V only — skipping Q, K, and the
+     * softmax(Q K^T / sqrt(d)) chain — so it returned a plausible-but-WRONG
+     * gradient. Rather than corrupt a training run, refuse the operation.
+     *
+     * NOTE: the differentiable attention path used by `(gradient …
+     * (scaled-dot-attention …))` decomposes to scalar AD nodes in
+     * tensor_transformer_codegen.cpp and does NOT reach here; this stub only
+     * fires if the bridge AD_NODE_TENSOR_ATTENTION node is ever backpropagated. */
+    eshkol_fatal("unsupported AD op: exact backward for the qLLM-bridge tensor "
+                 "attention node is not implemented; refusing to return an "
+                 "approximate (wrong) gradient. Differentiate attention through "
+                 "scaled-dot-attention instead (that path is exact).");
 }
 
 /*******************************************************************************

--- a/scripts/run_tensor_input2_grad_gate.sh
+++ b/scripts/run_tensor_input2_grad_gate.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# run_tensor_input2_grad_gate.sh — ESH-0212 tensor-AD second-operand gate.
+#
+# Runs tests/ad/tensor_input2_grad_test.esk under BOTH the JIT (-r) and AOT and
+# checks that every second-operand gradient (matmul B, conv2d kernel,
+# scaled-dot-attention K and V, and VECTOR/per-feature batch-norm & layer-norm
+# gamma) matches a central finite-difference oracle in ALL THREE calling forms:
+# a literal lambda, a first-class variable, and a higher-order wrapper.
+#
+# Guards two regressions that ESH-0212 fixed:
+#   * first-class tensor loss silently returning #(0 0 0 ...) (defect 1), and
+#   * a vector learnable gamma silently returning zero gradient (defect 2).
+#
+# Usage: scripts/run_tensor_input2_grad_gate.sh [--no-aot]
+set -u
+
+export LC_ALL=C
+export LC_CTYPE=C
+export LANG=C
+
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+TEST_FILE="$REPO_ROOT/tests/ad/tensor_input2_grad_test.esk"
+
+: "${ESHKOL_JIT_CACHE_DIR:=${TMPDIR:-/tmp}/eshkol-tensor-input2-jit-cache}"
+export ESHKOL_JIT_CACHE_DIR
+mkdir -p "$ESHKOL_JIT_CACHE_DIR"
+
+BUILD_DIR="${BUILD_DIR:-build}"
+case "$BUILD_DIR" in
+    /*) ESHKOL_RUN="$BUILD_DIR/eshkol-run" ;;
+    *)  ESHKOL_RUN="$REPO_ROOT/$BUILD_DIR/eshkol-run" ;;
+esac
+if [ ! -x "$ESHKOL_RUN" ]; then
+    echo "run_tensor_input2_grad_gate.sh: $BUILD_DIR/eshkol-run not found — run" \
+         "\`cmake --build $BUILD_DIR --target eshkol-run stdlib -j\` first." >&2
+    exit 2
+fi
+
+DO_AOT=1
+for arg in "$@"; do
+    case "$arg" in
+        --no-aot) DO_AOT=0 ;;
+        *) echo "run_tensor_input2_grad_gate.sh: unknown argument: $arg" >&2; exit 2 ;;
+    esac
+done
+
+JIT_TIMEOUT="${JIT_TIMEOUT:-180}"
+AOT_COMPILE_TIMEOUT="${AOT_COMPILE_TIMEOUT:-300}"
+AOT_RUN_TIMEOUT="${AOT_RUN_TIMEOUT:-60}"
+
+# macOS has no `timeout(1)`; emulate with perl alarm (exit 142 on SIGALRM).
+run_guarded() {
+    perl -e 'my $s=shift; alarm $s; exec @ARGV; die "exec failed: $ARGV[0]: $!\n"' \
+        "$1" "${@:2}"
+}
+
+# ok (0) iff the final PASS line, a "N passed, 0 failed" summary, and no
+# FAIL:/crash markers are present.
+check_output() {
+    local out="$1"
+    printf '%s' "$out" | grep -q '^PASS: tensor_input2_grad_test' || return 1
+    printf '%s' "$out" | grep -qE 'Results: [0-9]+ passed, 0 failed' || return 1
+    printf '%s' "$out" | grep -qE '^FAIL:|fatal signal|LLVM module verification failed' && return 1
+    return 0
+}
+
+overall=PASS
+
+echo "== ESH-0212 tensor-AD second-operand gate =="
+
+# ---- JIT (-r) ----
+jout="$(run_guarded "$JIT_TIMEOUT" "$ESHKOL_RUN" -r "$TEST_FILE" -L"$REPO_ROOT/$BUILD_DIR" 2>&1)"
+if check_output "$jout"; then
+    jpass="$(printf '%s' "$jout" | grep -oE 'Results: [0-9]+ passed' | grep -oE '[0-9]+')"
+    echo "  JIT  PASS ($jpass checks)"
+else
+    echo "  JIT  FAIL"
+    printf '%s\n' "$jout" | grep -E '^FAIL:|fatal signal|failed$' | head
+    overall=FAIL
+fi
+
+# ---- AOT ----
+if [ "$DO_AOT" -eq 1 ]; then
+    bin="$(mktemp "${TMPDIR:-/tmp}/tensor_input2_gate_bin.XXXXXX")"
+    cout="$(run_guarded "$AOT_COMPILE_TIMEOUT" "$ESHKOL_RUN" "$TEST_FILE" -o "$bin" -L"$REPO_ROOT/$BUILD_DIR" 2>&1)"; crc=$?
+    if [ "$crc" -ne 0 ] || [ ! -x "$bin" ]; then
+        echo "  AOT  COMPILE-FAIL rc=$crc"
+        overall=FAIL
+    else
+        aout="$(run_guarded "$AOT_RUN_TIMEOUT" "$bin" 2>&1)"
+        if check_output "$aout"; then
+            apass="$(printf '%s' "$aout" | grep -oE 'Results: [0-9]+ passed' | grep -oE '[0-9]+')"
+            echo "  AOT  PASS ($apass checks)"
+        else
+            echo "  AOT  FAIL"
+            printf '%s\n' "$aout" | grep -E '^FAIL:|fatal signal|failed$' | head
+            overall=FAIL
+        fi
+    fi
+    rm -f "$bin"
+fi
+
+echo "ESH-0212 tensor-AD second-operand gate: $overall"
+[ "$overall" = "PASS" ] && exit 0 || exit 1

--- a/tests/ad/tensor_input2_grad_test.esk
+++ b/tests/ad/tensor_input2_grad_test.esk
@@ -1,0 +1,137 @@
+;; tensor_input2_grad_test.esk -- ESH-0212: tensor-AD second-operand gradients,
+;; verified against a central finite-difference oracle in BOTH calling forms.
+;;
+;; Every operand below is checked as:
+;;   (1) a LITERAL lambda at the gradient call site,
+;;   (2) a FIRST-CLASS value bound to a variable, and
+;;   (3) a FIRST-CLASS value threaded through a higher-order wrapper.
+;;
+;; Before ESH-0212, forms (2) and (3) silently returned #(0 0 0 ...) for any
+;; tensor loss, and a VECTOR (learnable per-feature) batch-norm/layer-norm gamma
+;; returned zero even in the literal form. The finite-difference oracle is the
+;; TEST ORACLE only; the compiler's gradient path is exact reverse-mode AD.
+
+(require stdlib)
+
+(define passed 0)
+(define failed 0)
+
+(define (approx= a b tol) (< (abs (- a b)) tol))
+
+(define (check name cond)
+  (if cond
+      (begin (display "PASS: ") (display name) (newline)
+             (set! passed (+ passed 1)))
+      (begin (display "FAIL: ") (display name) (newline)
+             (set! failed (+ failed 1)))))
+
+(define (perturb-vector v idx delta)
+  (let ((n (vector-length v))
+        (out (make-vector (vector-length v) 0.0)))
+    (letrec ((loop (lambda (i)
+                     (if (< i n)
+                         (begin
+                           (vector-set! out i
+                             (if (= i idx)
+                                 (+ (vector-ref v i) delta)
+                                 (vector-ref v i)))
+                           (loop (+ i 1)))
+                         out))))
+      (loop 0))))
+
+(define (finite-diff f x idx eps)
+  (/ (- (f (perturb-vector x idx eps))
+        (f (perturb-vector x idx (- eps))))
+     (* 2.0 eps)))
+
+;; Relative-or-absolute match to a central finite difference at each component.
+(define (grad-matches-fd? g f x eps tol)
+  (let ((n (vector-length g)))
+    (letrec ((loop (lambda (i)
+                     (if (< i n)
+                         (let* ((fd (finite-diff f x i eps))
+                                (gi (vector-ref g i))
+                                (scale (+ 1.0 (abs fd))))
+                           (if (approx= gi fd (* tol scale))
+                               (loop (+ i 1))
+                               (begin
+                                 (display "   mismatch @") (display i)
+                                 (display " ad=") (display gi)
+                                 (display " fd=") (display fd) (newline)
+                                 #f)))
+                         #t))))
+      (loop 0))))
+
+(define (vec-any-nonzero? g)
+  (let ((n (vector-length g)))
+    (letrec ((loop (lambda (i)
+                     (if (< i n)
+                         (if (> (abs (vector-ref g i)) 1e-9) #t (loop (+ i 1)))
+                         #f))))
+      (loop 0))))
+
+;; Higher-order wrapper: forces the loss to arrive as a runtime function value.
+(define (wg f x) (gradient f x))
+
+;; Runs one operand through all three calling forms and checks each against FD.
+(define (check-operand name loss-fn x0)
+  (let* ((lit (gradient (lambda (z) (loss-fn z)) x0))
+         (bound loss-fn)
+         (var (gradient bound x0))
+         (wrp (wg loss-fn x0)))
+    (check (string-append name "_literal_matches_fd")
+           (and (vec-any-nonzero? lit) (grad-matches-fd? lit loss-fn x0 1e-4 1e-3)))
+    (check (string-append name "_variable_matches_fd")
+           (and (vec-any-nonzero? var) (grad-matches-fd? var loss-fn x0 1e-4 1e-3)))
+    (check (string-append name "_wrapper_matches_fd")
+           (and (vec-any-nonzero? wrp) (grad-matches-fd? wrp loss-fn x0 1e-4 1e-3)))
+    ;; All three forms must agree with each other.
+    (check (string-append name "_forms_agree")
+           (and (grad-matches-fd? lit (lambda (z) (loss-fn z)) x0 1e-4 1e-3)
+                (= (vector-length lit) (vector-length var))
+                (= (vector-length lit) (vector-length wrp))
+                (let ((n (vector-length lit)))
+                  (letrec ((loop (lambda (i)
+                                   (if (< i n)
+                                       (if (and (approx= (vector-ref lit i) (vector-ref var i) 1e-6)
+                                                (approx= (vector-ref lit i) (vector-ref wrp i) 1e-6))
+                                           (loop (+ i 1)) #f)
+                                       #t))))
+                    (loop 0)))))))
+
+;; ---- matmul B (second operand) --------------------------------------------
+(define A (tensor 2 2 1.0 2.0 3.0 4.0))
+(define (matmul-B-loss B) (tensor-sum (tensor-matmul A (reshape B 2 2))))
+(check-operand "matmul_B" matmul-B-loss (tensor 4 0.5 -1.0 2.0 1.5))
+
+;; ---- conv2d kernel (second operand) ---------------------------------------
+(define image (tensor 3 3 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0))
+(define (conv-k-loss k) (tensor-sum (conv2d image (reshape k 2 2) 1)))
+(check-operand "conv2d_kernel" conv-k-loss (tensor 4 1.0 2.0 3.0 4.0))
+
+;; ---- scaled-dot-attention K and V -----------------------------------------
+(define Q (tensor 2 2 1.0 0.0 0.0 1.0))
+(define Kc (tensor 4 1.0 0.0 0.0 1.0))
+(define Vc (tensor 4 1.0 2.0 3.0 4.0))
+(define (attn-K-loss k) (tensor-sum (scaled-dot-attention Q (reshape k 2 2) (reshape Vc 2 2))))
+(define (attn-V-loss v) (tensor-sum (scaled-dot-attention Q (reshape Kc 2 2) (reshape v 2 2))))
+(check-operand "attention_K" attn-K-loss (tensor 4 1.0 0.0 0.0 1.0))
+(check-operand "attention_V" attn-V-loss (tensor 4 1.0 2.0 3.0 4.0))
+
+;; ---- batch-norm / layer-norm VECTOR (per-feature) gamma -------------------
+(define xin (tensor 3 1.0 2.0 4.0))
+(define wts (tensor 3 1.0 2.0 3.0))
+;; reshape coerces the operand to a 1-D tensor so BOTH the AD point (a tensor)
+;; and the finite-difference oracle's perturbed Scheme vector feed batch-norm a
+;; genuine per-feature tensor gamma (batch-norm decodes only tensor gammas
+;; per-feature; a raw Scheme vector would be read as a scalar).
+(define (bn-gamma-loss g) (tensor-sum (tensor-mul (batch-norm xin (reshape g 3) 0.0 0.00001) wts)))
+(define (ln-gamma-loss g) (tensor-sum (tensor-mul (layer-norm xin (reshape g 3) 0.0 0.00001) wts)))
+(check-operand "batchnorm_vector_gamma" bn-gamma-loss (tensor 3 1.0 2.0 3.0))
+(check-operand "layernorm_vector_gamma" ln-gamma-loss (tensor 3 1.0 2.0 3.0))
+
+(display "Results: ") (display passed) (display " passed, ")
+(display failed) (display " failed") (newline)
+(if (= failed 0)
+    (begin (display "PASS: tensor_input2_grad_test") (newline) (exit 0))
+    (begin (display "FAIL: tensor_input2_grad_test") (newline) (exit 1)))


### PR DESCRIPTION
## Summary

Tensor reverse-mode `gradient` previously returned a silent, plausible-looking
zero gradient (`#(0 0 0 ...)`) in two common situations, and several
tensor-backward paths dropped the gradient silently. This PR makes the
gradients exact and converts the remaining genuinely-unsupported paths into
explicit errors, upholding the invariant: exact AD, or a clear unsupported-op
error — never a silent zero.

### Defect 1 — first-class tensor loss collapse
A loss bound to a variable, passed as a parameter, or reached through a
higher-order wrapper had no compile-time function, so it used the runtime
forward-mode dual path — but tensor ops don't carry duals, so the gradient
came back zero. Added a reverse-mode path for a tensor point in the closure
branch of `AutodiffCodegen::gradient`: seed each element as an AD variable,
call the closure once in AD mode, backpropagate, and read each variable's
gradient. Scalar/scalar-vector first-class gradients are unchanged.

### Defect 2 — vector (per-feature) gamma silently zero
`emitTensorADNormalizeDispatch` scaled every element by a single scalar gamma
node. Now, when gamma/beta is a tensor, each output element uses
`gamma[k]`/`beta[k]` as its own AD node (indexed per feature to match the
numeric kernel). Scalar gamma/beta unchanged.

### Defect 3 — silent-zero backward paths become explicit errors
Routed the bridge tensor ops that have a registered backward (transpose, sum,
broadcast-add/mul) through the dispatch table instead of a passthrough that
dropped them. The attention/embedding bridge stubs (which warned then returned
a wrong partial/row-0 gradient) and the Frechet-mean node now raise an explicit
unsupported-op error. The scalar-op default case is unchanged and documented.

**Still unsupported-by-design, now erroring instead of zeroing:** exact
backward for the qLLM-bridge tensor attention and embedding AD nodes, and the
Frechet-mean node. The user-facing `scaled-dot-attention` path decomposes to
scalar AD nodes and is exact — it does not reach those stubs.

## Verification
- New `tests/ad/tensor_input2_grad_test.esk` + `scripts/run_tensor_input2_grad_gate.sh`:
  matmul B, conv2d kernel, attention K and V, and vector batch-norm/layer-norm
  gamma, each vs a central finite-difference oracle in all three calling forms
  (literal lambda, variable, wrapper), under JIT and AOT — 24/24 pass.
- Existing `tests/v1_3_edge_cases/ad_input2_test.esk`: 11/11.
- `tests/integration/autodiff_tensor_test.esk`, `tests/stdlib/v12_tensor_ops_test.esk`,
  `tests/ml/transformer_basic_test.esk`, `tests/ml/conv_correctness_test.esk`: green.
- Full `scripts/run_autodiff_tests.sh`: 54/54, 100%.