### PR TITLE
fix(memory): evacuate PROMISE interior slots on region escape (ESH-0214e)

### DIFF
--- a/lib/core/runtime_regions.cpp
+++ b/lib/core/runtime_regions.cpp
@@ -823,6 +823,7 @@ enum EvacKind : uint8_t {
     EVAC_KNOWLEDGE_BASE, // eshkol_knowledge_base_t: facts[] raw array of fact ptrs
     EVAC_FACTOR_GRAPH,   // eshkol_factor_graph_t: nested raw numeric buffers
     EVAC_WORKSPACE,      // eshkol_workspace_t: content buffer + per-module name/process_fn
+    EVAC_PROMISE,        // [forced:i64][thunk:tagged @8][cached:tagged @24] (delay/force)
 };
 
 using EvacFwdMap = std::unordered_map<const void*, void*>;
@@ -888,6 +889,7 @@ static EvacKind evac_kind_for(const eshkol_tagged_value_t& v, const void* old_da
         case HEAP_SUBTYPE_KNOWLEDGE_BASE: return EVAC_KNOWLEDGE_BASE;
         case HEAP_SUBTYPE_FACTOR_GRAPH:   return EVAC_FACTOR_GRAPH;
         case HEAP_SUBTYPE_WORKSPACE:      return EVAC_WORKSPACE;
+        case HEAP_SUBTYPE_PROMISE:        return EVAC_PROMISE;
         // STRING / SYMBOL / BIGNUM / RATIONAL / BYTEVECTOR: self-contained
         // payloads -> a contiguous leaf copy fully preserves them.
         //
@@ -896,9 +898,6 @@ static EvacKind evac_kind_for(const eshkol_tagged_value_t& v, const void* old_da
         // are not observed to escape a region by mutation):
         //   PORT      - wraps an OS fd/FILE*; handle intentionally shared, not copied.
         //   PRNG      - self-contained state words, no interior pointers.
-        //   PROMISE   - thunk/closure + memoized value; the closure/value escape
-        //               through their own tagged slots via the normal barrier when
-        //               forced, and a delayed promise almost never escapes a region.
         //   DNC/SDNC  - large differentiable weight/program buffers; escaping a
         //               region by mutation is not a supported pattern.
         //   TAYLOR    - truncated-Taylor tower; rational-coeff interior not traversed.
@@ -967,7 +966,6 @@ static void* evac_object(EvacState& st, void* old_data, const eshkol_tagged_valu
         const auto* dh = (const eshkol_object_header_t*)
             ((const uint8_t*)new_data - sizeof(eshkol_object_header_t));
         switch (dh->subtype) {
-            case HEAP_SUBTYPE_PROMISE:
             case HEAP_SUBTYPE_DNC:
             case HEAP_SUBTYPE_SDNC:
             case HEAP_SUBTYPE_TAYLOR:
@@ -1240,6 +1238,20 @@ static eshkol_tagged_value_t region_evacuate_value(eshkol_tagged_value_t val,
                             st, mods[i].name, std::strlen(mods[i].name) + 1);
                     mods[i].process_fn = evac_value(st, mods[i].process_fn);
                 }
+                break;
+            }
+            case EVAC_PROMISE: {
+                // [forced:i64 @0][thunk:tagged @8][cached:tagged @24] (40 bytes,
+                // llvm_codegen.cpp %make-lazy-promise / make-promise). Both the
+                // thunk closure (unforced) and the memoized cached value (forced)
+                // can be region-allocated; a promise that escapes its region via
+                // delay/force/make-promise must have both slots evacuated or they
+                // dangle into the freed arena after region_pop (ESH-0214d gap:
+                // subtype 18 was previously leaf-copied). ESH-0214e.
+                auto* thunk  = (eshkol_tagged_value_t*)((uint8_t*)nd + 8);
+                auto* cached = (eshkol_tagged_value_t*)((uint8_t*)nd + 24);
+                *thunk  = evac_value(st, *thunk);
+                *cached = evac_value(st, *cached);
                 break;
             }
             case EVAC_FACTOR_GRAPH: {

--- a/tests/memory/region_evac_subtype_coverage_test.esk
+++ b/tests/memory/region_evac_subtype_coverage_test.esk
@@ -75,7 +75,7 @@
 
 ;; ───────────────────── PHASE 2: bounded heavy-subtype variant ───────────────
 (define heavy-passes 5000)
-(define heavy (make-vector 5 0))
+(define heavy (make-vector 7 0))
 
 (define (heavy-tick i)
   (guard (e (#t (begin (display "GUARD-CAUGHT-P2 at ") (display i) (newline) i)))
@@ -98,7 +98,14 @@
                 (vector-set! heavy 2 fg))
               ;; RECORD (allocates as VECTOR) + CONS list control.
               (vector-set! heavy 3 (make-point i (* i 2)))
-              (vector-set! heavy 4 (list i (car scratch) (length scratch)))))
+              (vector-set! heavy 4 (list i (car scratch) (length scratch)))
+              ;; PROMISE (ESH-0214e): a delayed promise whose thunk closure
+              ;; captures the region-allocated scratch (slot 5), and an
+              ;; already-forced promise memoizing a region list (slot 6). Both
+              ;; the thunk and the cached tagged slots live in the region and
+              ;; must be evacuated, or force after region_pop dangles.
+              (vector-set! heavy 5 (delay (length scratch)))
+              (vector-set! heavy 6 (make-promise (list i (car scratch))))))
           (heavy-tick (+ i 1))))))
 
 (define heavy-result (heavy-tick 0))
@@ -115,6 +122,12 @@
 (define rec-ok (and (point? pt) (= (point-x pt) heavy-last) (= (point-y pt) (* heavy-last 2))))
 (define lst (vector-ref heavy 4))
 (define lst-ok (and (= (car lst) heavy-last) (= (cadr lst) heavy-last) (= (caddr lst) 20)))
+;; force the escaped promises: thunk-path (length of captured region scratch)
+;; and cached-path (already-forced region list). Dangle -> crash/wrong here.
+(define prom-thunk-ok (= (force (vector-ref heavy 5)) 20))
+(define prom-cached (force (vector-ref heavy 6)))
+(define prom-ok (and prom-thunk-ok (pair? prom-cached)
+                     (= (car prom-cached) heavy-last) (= (cadr prom-cached) heavy-last)))
 
 (display "[region_evac_subtype_coverage_test] p1=")
 (display result) (display "/") (display total-passes)
@@ -126,9 +139,10 @@
 (display " fg=")   (display fg-ok)
 (display " rec=")  (display rec-ok)
 (display " lst=")  (display lst-ok)
+(display " prom=") (display prom-ok)
 (newline)
 
 (if (and (= result total-passes) (= heavy-result heavy-passes)
-         facts-ok ws-ok kb-ok fg-ok rec-ok lst-ok)
+         facts-ok ws-ok kb-ok fg-ok rec-ok lst-ok prom-ok)
     (begin (display "PASS") (newline))
     (begin (display "FAIL") (newline) (exit 1)))


### PR DESCRIPTION
Adversarial audit follow-up to ESH-0214d. HEAP_SUBTYPE_PROMISE was left as EVAC_LEAF but carries interior pointers (thunk @+8, cached @+24); a delay/make-promise created inside with-region that escapes outward dangled after region_pop (reproduced as SIGSEGV 0xcbcb and 'car: not a pair' under ESHKOL_ARENA_POISON=1, from stock R7RS). Adds EVAC_PROMISE (evacuate both slots) and extends the region_evac_subtype_coverage gate to escape+force a delay-promise and a make-promise; flat ~116MB under poison, crashes without the fix. Memory suite 100%.