### PR TITLE
release: v1.3.3-evolve documentation and version cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.3-evolve] - 2026-07-10
+
+An evolve point release over v1.3.2-evolve: an exact-gradient correction to
+the automatic-differentiation `input2` path that v1.3.2 had claimed complete,
+a region-escape evacuator fix that closes out the ESH-0214 series for the
+`PROMISE` heap subtype, and documentation of a subprocess race fix that
+shipped in v1.3.2 but was never written up.
+
+### Fixed
+
+- **Exact tensor AD gradients for first-class losses and vector/learnable
+  gamma; silent-zero backward paths now error instead of returning zero.**
+  This corrects the v1.3.2-evolve CHANGELOG entry for #212, which claimed
+  `input2` gradient plumbing was "complete" for `conv2d`/`batchnorm`/
+  `layernorm`/`attention`. An adversarial audit found #212 was in fact a
+  no-op — its test and roadmap updates landed, but no gradient code changed.
+  The real fix is #229: (1) a loss with no compile-time `Function*` fell to
+  the forward-mode-dual closure path, which loses the tangent for tensor ops
+  and silently returns a zero gradient — added a reverse-mode tensor path in
+  the closure branch of `AutodiffCodegen::gradient`; (2) batch-norm/layer-norm
+  now wire per-feature gamma/beta as individual AD nodes instead of a single
+  scalar, so vector/learnable gamma differentiates correctly; (3) remaining
+  silent-zero backward paths for unsupported tensor ops now raise explicit
+  unsupported-op errors rather than returning zero, honoring
+  exact-AD-or-error. Finite-difference-verified exact in both literal and
+  first-class forms across matmul/conv2d/attention-K-V/vector-gamma; autodiff
+  suite 54/54, new input2 gate 24/24 under both JIT and AOT. (#229)
+- **Region escape evacuator now covers the `PROMISE` heap subtype
+  (ESH-0214e).** Adversarial-audit follow-up to ESH-0214d: `PROMISE` was left
+  `EVAC_LEAF` despite carrying interior pointers (thunk at `+8`, cached value
+  at `+24`). A `delay`/`make-promise` created inside `with-region` that
+  escaped outward dangled after `region_pop`, observed as a segfault or
+  `car: not a pair` under `ESHKOL_ARENA_POISON=1` when the promise was later
+  forced. Adds an `EVAC_PROMISE` case that evacuates both slots; extends
+  `region_evac_subtype_coverage` to exercise escape-then-force for both
+  `delay` and `make-promise`. Flat ~116MB under poison; memory suite 100%.
+  This completes the ESH-0214 region-evacuator series (ESH-0214a-e). (#230)
+- **Subprocess `process-wait` kqueue lost-wakeup race** (documentation-only
+  entry — the fix itself shipped in v1.3.2-evolve as commit `8443ddae` but was
+  never recorded here). On macOS, `qllm_process_wait` registered
+  `EVFILT_PROC`/`NOTE_EXIT` and then blocked in `kevent()`. If the child had
+  already exited before the filter was registered — routine right after
+  `process-kill`, and common under load for any short-lived child — the
+  exit notification was never delivered, so `kevent()` blocked for the full
+  timeout and reported "timed out" for a process that was already dead. This
+  was the source of intermittent failures in
+  `subprocess_shell_argv_test`'s "process-wait after process-kill exits"
+  check on the macos-arm64-lite CI lane. Fix: after registering the filter,
+  probe once with `waitpid(WNOHANG)`; if the child is already a zombie,
+  drain, reap, and report exited — any exit strictly after the probe is still
+  caught by the already-registered filter, closing the gap. The same
+  `WNOHANG` recheck was added on the timeout branch as defense in depth.
+  Verified on macOS arm64 (M2): 0/200 failures under 20-way parallel load,
+  versus a reliable reproduction (roughly 1/48) beforehand.
+
 ## [1.3.2-evolve] - 2026-07-09
 
 An evolve point release over v1.3.1-evolve: a resident-memory correctness fix

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if(POLICY CMP0091)
     cmake_policy(SET CMP0091 NEW)
 endif()
 
-set(ESHKOL_VERSION "1.3.2")
+set(ESHKOL_VERSION "1.3.3")
 
 project("Eshkol" VERSION ${ESHKOL_VERSION} LANGUAGES C CXX)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,7 +304,7 @@ eshkol/
 
 v1.0-foundation, v1.1-accelerate, v1.2-scale, and v1.3.0-evolve (arbitrary-order
 AD, full R7RS conformance, closure/TCO/memory hardening) are **complete**, and
-v1.3.1 has landed further robustness for long-running, resident programs plus
+v1.3.3 has landed further robustness for long-running, resident programs plus
 comprehensive C-API documentation. We welcome contributions for upcoming releases:
 
 ### Immediate Priorities (v1.4-connection - July 2026)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,53 @@
+# Eshkol v1.3.3-evolve — Release Notes
+
+**Release Date**: July 10, 2026
+
+Eshkol v1.3.3-evolve is an evolve point release over v1.3.2-evolve. It
+corrects an overstated automatic-differentiation claim from the v1.3.2
+CHANGELOG, closes out the region-escape evacuator series for the last
+remaining heap subtype, and documents a subprocess race fix that had already
+shipped. Full technical detail lives in [CHANGELOG.md](CHANGELOG.md); this
+page is the user-facing summary.
+
+**Release gates**: builds on the v1.3.2-evolve gates; the
+`region_evac_subtype_coverage` gate now also exercises `PROMISE`
+escape-then-force, and the `input2` gradient gate (24/24, JIT+AOT) now
+verifies exact gradients rather than passing on unchanged zero-gradient
+behavior.
+
+## Highlights
+
+### Automatic differentiation — correction
+
+- **Exact tensor AD gradients for first-class losses and vector/learnable
+  gamma.** v1.3.2's CHANGELOG entry for #212 claimed the `input2` gradient
+  path was complete for `conv2d`/`batchnorm`/`layernorm`/`attention`; an
+  adversarial audit found that change was a no-op (test and roadmap updates
+  only, no gradient code). This release ships the real fix: first-class
+  losses (no compile-time `Function*`) no longer silently lose the tangent
+  through the forward-mode-dual closure path; batch-norm/layer-norm gamma/beta
+  are now differentiated per-feature rather than as one scalar; and any
+  remaining unsupported tensor-op backward path raises an explicit error
+  instead of returning a silent zero gradient. (#229)
+
+### Resident-memory correctness
+
+- **Region escape evacuator now covers `PROMISE`.** A `delay`/`make-promise`
+  created inside `with-region` that escaped the region no longer dangles
+  after the region is popped. This completes the ESH-0214 region-evacuator
+  series. (#230, ESH-0214e)
+
+### Documentation
+
+- **Subprocess `process-wait` kqueue race — documented.** The fix for a
+  lost-wakeup race in `process-wait` on macOS (a child exiting before its
+  `kevent` exit filter was registered could make `process-wait` block for the
+  full timeout and misreport a dead process as still running) shipped in
+  v1.3.2-evolve but was omitted from that release's notes. It is recorded
+  here for completeness; no v1.3.3 code change was required.
+
+---
+
 # Eshkol v1.3.2-evolve — Release Notes
 
 **Release Date**: July 9, 2026

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,6 +1,6 @@
-# Eshkol v1.3.1 API Reference
+# Eshkol v1.3.3 API Reference
 
-**Version**: 1.3.1
+**Version**: 1.3.3
 **Last Updated**: 2026-07-08
 **Audience**: Scientific Computing & AI Systems Programming
 

--- a/docs/COMPLETE_LANGUAGE_SPECIFICATION.md
+++ b/docs/COMPLETE_LANGUAGE_SPECIFICATION.md
@@ -1,6 +1,6 @@
 # Eshkol Language - Complete Technical Specification
 
-**Version:** v1.3.1
+**Version:** v1.3.3
 **Generated:** 2026-07-08
 **Status:** Comprehensive implementation documentation from source code
 
@@ -4043,7 +4043,7 @@ Keep original name (exported via `provide`)
 
 ## 26. Version Information
 
-**Current Version:** v1.3.1
+**Current Version:** v1.3.3
 
 **Version History:**
 - v1.3.1 - Robustness for long-running, resident programs: per-iteration
@@ -4168,7 +4168,7 @@ Dynamic binding of parameter objects. Parameters created with `make-parameter` a
 
 ## Conclusion
 
-This document provides a **complete** specification of the Eshkol programming language version v1.3.1, documenting **every** feature, function, operator, and capability found in the implementation.
+This document provides a **complete** specification of the Eshkol programming language version v1.3.3, documenting **every** feature, function, operator, and capability found in the implementation.
 
 **Total Coverage:**
 - All 101 special forms and parser operations

--- a/docs/ESHKOL_LANGUAGE_GUIDE.md
+++ b/docs/ESHKOL_LANGUAGE_GUIDE.md
@@ -1135,7 +1135,7 @@ Map Eshkol names to C names:
 
 ```
 $ ./eshkol-repl
-Eshkol REPL v1.3.1
+Eshkol REPL v1.3.3
 Type :help for assistance, :quit to exit
 
 eshkol> (define (square x) (* x x))
@@ -1492,5 +1492,5 @@ MIT License - Copyright (C) tsotchke
 ---
 
 <p align="center">
-<strong>Eshkol v1.3.1</strong>: Where functional programming meets scientific computing, GPU acceleration, and machine consciousness.
+<strong>Eshkol v1.3.3</strong>: Where functional programming meets scientific computing, GPU acceleration, and machine consciousness.
 </p>

--- a/docs/ESHKOL_QUICK_REFERENCE.md
+++ b/docs/ESHKOL_QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Eshkol Quick Reference Card
 
-**v1.3.1** -- 555+ built-in functions
+**v1.3.3** -- 555+ built-in functions
 
 ## Basics
 

--- a/docs/FEATURE_MATRIX.md
+++ b/docs/FEATURE_MATRIX.md
@@ -1,4 +1,4 @@
-# Eshkol v1.3.1 Feature Matrix
+# Eshkol v1.3.3 Feature Matrix
 
 **Status Key**: ✅ Production | 🚧 In Progress | 📋 Planned | ❌ Not Planned
 
@@ -910,6 +910,6 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for development guidelines.
 ---
 
 **Last Updated**: 2026-07-08
-**Document Version**: 1.3.1
+**Document Version**: 1.3.3
 
 For detailed API documentation, see [API_REFERENCE.md](API_REFERENCE.md)

--- a/inc/eshkol/eshkol.h
+++ b/inc/eshkol/eshkol.h
@@ -16,8 +16,8 @@
  */
 #define ESHKOL_VERSION_MAJOR 1
 #define ESHKOL_VERSION_MINOR 3
-#define ESHKOL_VERSION_PATCH 2
-#define ESHKOL_VERSION_STRING "1.3.2-evolve"
+#define ESHKOL_VERSION_PATCH 3
+#define ESHKOL_VERSION_STRING "1.3.3-evolve"
 
 #include <stdint.h>
 #include <stdbool.h>


### PR DESCRIPTION
## Summary

- Bumps version to 1.3.3-evolve (`CMakeLists.txt` `ESHKOL_VERSION`, `inc/eshkol/eshkol.h` `ESHKOL_VERSION_PATCH`/`ESHKOL_VERSION_STRING`). Verified: `eshkol-run --version` prints `Eshkol Compiler v1.3.3-evolve`.
- Adds a `[1.3.3-evolve] - 2026-07-10` CHANGELOG section and a matching RELEASE_NOTES.md section documenting the three fixes on master since v1.3.2-evolve:
  - Subprocess `process-wait` kqueue lost-wakeup race — this shipped in v1.3.2-evolve as commit `8443ddae` but was never recorded in the CHANGELOG/RELEASE_NOTES; documented now for completeness.
  - ESH-0214e: `PROMISE` region-escape evacuation (#230) — completes the ESH-0214 series; `delay`/`make-promise` created inside `with-region` that escapes no longer dangles.
  - #229: exact tensor AD gradients for first-class losses and vector/learnable gamma; silent-zero backward paths now raise explicit unsupported-op errors. This corrects v1.3.2's CHANGELOG entry for #212, which claimed the `input2` gradient path was complete — an adversarial audit found #212 was actually a no-op (test/roadmap only, no gradient code changed).
- Fixes stale "1.3.1" current-version banners/fields found by a release audit in `docs/FEATURE_MATRIX.md`, `docs/API_REFERENCE.md`, `docs/COMPLETE_LANGUAGE_SPECIFICATION.md`, `docs/ESHKOL_QUICK_REFERENCE.md`, `docs/ESHKOL_LANGUAGE_GUIDE.md`, and `CONTRIBUTING.md`. Historical changelog/roadmap-history references to 1.3.1 (e.g. FEATURE_MATRIX.md's shipped-versions list, the language spec's Version History bullet) are intentionally left untouched.

Out of scope (noted, not touched): `press/`, `ANNOUNCEMENT.md`, and `site/src` also reference 1.3.1 but need a separate site rebuild pass.

No git tag is created by this PR — tagging is a separate, human-authorized step.

## Test plan

- [x] `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && cmake --build build --target eshkol-run -j`
- [x] `./build/eshkol-run --version` prints `Eshkol Compiler v1.3.3-evolve`
- [x] Verified 8443ddae is included in the `v1.3.2-evolve` tag before writing it up as an already-shipped fix
- [x] Grepped each stale-version-string file to confirm only current-version fields were changed, not historical references