### PR TITLE
Harden ICC completion oracle: assert full input2 gradient + region-evac coverage

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -69,6 +69,33 @@ oracles:
         label: eshkol-repl + eshkol-run -r return cleanly on a smoke input
         action: ./scripts/run_icc_smoke.sh
 
+      # -- Full-claim adversarial gates (2026-07-10 oracle hardening). --
+      # These assert the COMPLETE feature claims that an audit found the
+      # oracle was silently over-promising. The narrow ad_input2_* probes
+      # in v1.3-evolve only ever exercised the one working calling pattern
+      # (literal-lambda loss + scalar gamma); this criterion is the one
+      # that certifies input2 gradients actually work end-to-end.
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["tensor_input2_grad_exact_firstclass_and_vector"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'ESH-0212/#229: input2 tensor gradients (matmul B, conv2d kernel, attention K/V, per-feature batch/layer-norm gamma) match central finite-difference EXACTLY across literal, first-class AND higher-order loss forms and vector gamma (JIT+AOT, 24/24) — not just the literal-scalar path'
+        action: ./scripts/run_icc_smoke.sh
+
+      # Region escape-evacuator subtype coverage, run under
+      # ESHKOL_ARENA_POISON=1 so a missed interior pointer crashes at a
+      # 0xCB.. address rather than reading stale data. Closes the blind
+      # spot where the PROMISE-corruption evacuation gap was invisible to
+      # readiness=100 because no oracle criterion referenced this gate.
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["region_evac_subtype_coverage"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'ESH-0214d/e: region escape-evacuator keeps promoted logic/workspace/PROMISE subtype interiors intact under ESHKOL_ARENA_POISON=1 (AOT, flat RSS)'
+        action: ./scripts/run_icc_smoke.sh
+
   # ─────────────────────────────────────────────────────────────────
   # Agent-FFI readiness — the contract the eshkol-agent depends on.
   # When this oracle goes green, the agent's three blockers (HTTP,
@@ -295,7 +322,7 @@ oracles:
           event_names: ["ad_input2_conv2d_grad_works"]
           event_values: ["PASS"]
         severity: high
-        label: 'gradient flows through conv2d to the kernel operand'
+        label: 'gradient flows through conv2d to the kernel operand (literal-form scalar path only; full first-class + vector coverage is tensor_input2_grad_exact_firstclass_and_vector)'
         action: ./scripts/run_icc_smoke.sh
 
       - runtime_event:
@@ -303,7 +330,7 @@ oracles:
           event_names: ["ad_input2_batchnorm_grad_works"]
           event_values: ["PASS"]
         severity: high
-        label: 'gradient flows through batch-norm to the gamma operand'
+        label: 'gradient flows through batch-norm to the gamma operand (literal-form scalar path only; full first-class + vector coverage is tensor_input2_grad_exact_firstclass_and_vector)'
         action: ./scripts/run_icc_smoke.sh
 
       - runtime_event:
@@ -311,7 +338,7 @@ oracles:
           event_names: ["ad_input2_layernorm_grad_works"]
           event_values: ["PASS"]
         severity: high
-        label: 'gradient flows through layer-norm to the gamma operand'
+        label: 'gradient flows through layer-norm to the gamma operand (literal-form scalar path only; full first-class + vector coverage is tensor_input2_grad_exact_firstclass_and_vector)'
         action: ./scripts/run_icc_smoke.sh
 
       - runtime_event:
@@ -319,7 +346,7 @@ oracles:
           event_names: ["ad_input2_attention_grad_works"]
           event_values: ["PASS"]
         severity: high
-        label: 'gradient flows through scaled-dot-attention to K/V operands'
+        label: 'gradient flows through scaled-dot-attention to K/V operands (literal-form scalar path only; full first-class + vector coverage is tensor_input2_grad_exact_firstclass_and_vector)'
         action: ./scripts/run_icc_smoke.sh
 
       # -- arbitrary-order AD Taylor-tower v1.3 track --

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -327,6 +327,40 @@ probe ad_input2_attention_grad_works 'gradient flows through scaled-dot-attentio
     '"$ESHKOL_RUN" -r "$REPO_ROOT/tests/v1_3_edge_cases/ad_input2_test.esk" -L"$REPO_ROOT/build" 2>&1 |
      grep -q "PASS: ad_input2_attention_grad_works"'
 
+# ───────────────────────────────────────────────────────────────────
+# Full-claim adversarial gates (2026-07-10 oracle hardening).
+#
+# The narrow ad_input2_* probes above only exercise the ONE working
+# calling pattern (literal-lambda loss + scalar gamma). The two probes
+# below assert the FULL claims that an adversarial audit found the oracle
+# was silently over-promising:
+#
+#   * tensor_input2_grad_exact_firstclass_and_vector — the #229/ESH-0212
+#     gate: every second-operand gradient (matmul B, conv2d kernel,
+#     attention K/V, per-feature batch/layer-norm gamma) matches a central
+#     finite-difference oracle EXACTLY across literal, first-class, and
+#     higher-order loss forms AND for a vector/learnable gamma, under both
+#     the JIT and AOT (24/24). Guards the silent-zero regressions the
+#     narrow probes could not see (first-class loss → #(0 0 …), vector
+#     gamma → 0).
+#   * region_evac_subtype_coverage — the ESH-0214d/e evacuator gate, run
+#     under ESHKOL_ARENA_POISON=1 so a missed interior pointer crashes at a
+#     0xCB.. address instead of reading stale-but-valid data. Covers the
+#     logic/workspace/PROMISE subtypes whose evacuation gap was invisible
+#     to readiness=100 before this probe existed.
+# ───────────────────────────────────────────────────────────────────
+probe tensor_input2_grad_exact_firstclass_and_vector \
+    'input2 tensor gradients (matmul B / conv2d kernel / attention K,V / per-feature batch+layer-norm gamma) match central FD EXACTLY across literal, first-class AND higher-order loss forms and vector gamma (JIT+AOT, 24/24)' \
+    'cd "$REPO_ROOT";
+     out=$(BUILD_DIR=build bash scripts/run_tensor_input2_grad_gate.sh 2>&1) || exit 1;
+     printf "%s" "$out" | grep -q "ESH-0212 tensor-AD second-operand gate: PASS"'
+
+probe region_evac_subtype_coverage \
+    'ESH-0214d/e region escape-evacuator keeps promoted logic/workspace/PROMISE subtype interiors intact under ESHKOL_ARENA_POISON=1 (AOT, flat RSS)' \
+    'cd "$REPO_ROOT";
+     out=$(ESHKOL_ARENA_POISON=1 BUILD_DIR=build bash tests/memory/region_evac_subtype_coverage_test.sh 2>&1) || exit 1;
+     printf "%s" "$out" | grep -q "region_evac_subtype_coverage_test.sh: PASS"'
+
 probe jit_cache_hit_invalidates 'eshkol-run -r persistent cache hits and source edits invalidate' \
     'bash "$REPO_ROOT/tests/v1_3_edge_cases/jit_cache_test.sh" "$ESHKOL_RUN"'
 


### PR DESCRIPTION
## Summary

Closes two blind spots where the ICC readiness oracle could report green while a feature was broken (both underlying code fixes already landed; this makes the oracle assert the real claims):

1. The region escape-evacuator subtype-coverage gate was not referenced by any oracle criterion, so the PROMISE interior-pointer corruption hole was invisible to readiness=100.
2. The narrow `ad_input2_*` smoke events only exercise the one working calling pattern (literal-lambda loss + scalar gamma), so the oracle certified "input2 gradients work" while first-class losses and vector gamma silently returned zeros.

## Changes

- `scripts/run_icc_smoke.sh`: add two probes.
  - `tensor_input2_grad_exact_firstclass_and_vector` runs `scripts/run_tensor_input2_grad_gate.sh` (24/24: matmul B, conv2d kernel, attention K/V, per-feature batch/layer-norm gamma; finite-difference-exact across literal, first-class and higher-order loss forms; JIT+AOT).
  - `region_evac_subtype_coverage` runs `tests/memory/region_evac_subtype_coverage_test.sh` under `ESHKOL_ARENA_POISON=1`.
- `.icc/completion-oracles.yaml`: add high-severity `runtime_event` criteria for both new events to `eshkol-compiler-readiness`; relabel the four narrow `ad_input2_*` criteria as "literal-form scalar path only" so they no longer over-promise, deferring the full claim to the new criterion.

The oracle now fails if either gate regresses.

## Verification

- `BUILD_DIR=build bash scripts/run_icc_smoke.sh` emits both new events as PASS.
- `icc readiness --target eshkol-compiler-readiness`: Status `ready`, Score `100`, Oracle `complete`; both new criteria PASS.
- Falsification: forcing the `region_evac_subtype_coverage` probe to fail drops readiness to `blocked` (score 92, Oracle `blocked`) with the criterion showing FAIL; restoring returns it to ready/100/complete.

Touches `.icc/` + `scripts/` only.