### PR TITLE
ci: add real GPU execution correctness gate (Metal/CUDA)

### DIFF
--- a/.github/workflows/gpu-execution-gate.yml
+++ b/.github/workflows/gpu-execution-gate.yml
@@ -1,0 +1,86 @@
+name: GPU Execution Gate
+
+# WHY THIS WORKFLOW EXISTS (read before touching runs-on below)
+#
+# The `linux-x64-cuda` / `linux-arm64-cuda` / `windows-arm64-cuda` jobs in
+# ci.yml build Eshkol with -DESHKOL_GPU_ENABLED=ON and run
+# scripts/run_gpu_tests.sh against that build. Those jobs run on
+# GitHub-hosted runners (ubuntu-22.04, ubuntu-22.04-arm, windows-11-arm),
+# and hosted runners have NO GPU. nvcc/the CUDA toolkit compiles the
+# .cu kernels fine, and vm_gpu_dispatch.h's `eshkol_gpu_init()` returns 0
+# devices, so every "GPU" tensor op in that lane silently falls through to
+# the CPU path. Those lanes are a COMPILATION gate, not an EXECUTION gate
+# — they will not catch a real bug in gpu_cuda_kernels.cu, gpu_memory_cuda.cpp,
+# or gpu_memory.mm (Metal). Ad hoc GPU execution otherwise only happened
+# on a Jetson AGX Xavier (nix/jetson/), run by hand.
+#
+# This workflow is the missing execution gate: tests/gpu/gpu_correctness_gate.sh
+# builds Eshkol with GPU acceleration ON *and* OFF, runs the same
+# differentiable workload (tests/gpu/gpu_correctness_gate.esk) through
+# both, and diffs GPU-vs-CPU numeric output within tolerance. It only
+# produces a verdict on a host with a real GPU device; everywhere else it
+# exits 0 with a SKIP message (see the script's step-1/step-4 checks), so
+# it is always safe to invoke.
+#
+# IT WILL NOT RUN ON A GITHUB-HOSTED RUNNER, BY DESIGN. `runs-on` below
+# targets a self-hosted runner carrying the `[self-hosted, gpu]` labels.
+# Until such a runner is registered against this repository, the job
+# queues and does nothing harmful — it does not fail CI, and it is not a
+# required check on any branch protection rule. Candidates for that
+# runner label: this repo's own Apple Silicon / Metal development
+# machines, or the Jetson AGX Xavier described in nix/jetson/README.md
+# (attach via `nix-shell nix/jetson/shell.nix` + the standard GitHub
+# Actions self-hosted runner agent). Do NOT repoint this at a
+# GitHub-hosted runner — that silently turns it back into a
+# compile-only gate, defeating the point of this file.
+on:
+  workflow_dispatch: {}
+  schedule:
+    # Nightly, well off the hour to avoid the herd of on-the-hour jobs.
+    - cron: '17 9 * * *'
+  push:
+    branches: [master]
+    paths:
+      - 'lib/backend/gpu/**'
+      - 'lib/backend/vm_gpu_dispatch.h'
+      - 'tests/gpu/gpu_correctness_gate.*'
+      - '.github/workflows/gpu-execution-gate.yml'
+
+concurrency:
+  group: gpu-execution-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gpu-execution:
+    name: GPU execution correctness (real GPU, not compile-only)
+    # Requires a self-hosted runner registered with BOTH labels below.
+    # See the file-level comment for why this deliberately does not
+    # target a GitHub-hosted runner.
+    runs-on: [self-hosted, gpu]
+    # A missing self-hosted runner leaves this job queued rather than
+    # failed; cap the wait so a permanently-absent runner doesn't hang
+    # the workflow run indefinitely.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run GPU execution correctness gate
+        shell: bash
+        env:
+          # Fresh build every run — correctness is the point, not build
+          # caching. Self-hosted runners can set REUSE_BUILDS=1 in their
+          # own environment if they persist build-gpu-gate*/ between runs.
+          GPU_GATE_TOL: '1e-4'
+        run: ./tests/gpu/gpu_correctness_gate.sh
+
+      - name: Upload gate logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: gpu-execution-gate-logs
+          path: |
+            build-gpu-gate.configure.log
+            build-gpu-gate.build.log
+            build-gpu-gate-cpuref.configure.log
+            build-gpu-gate-cpuref.build.log
+          if-no-files-found: ignore

--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -1818,3 +1818,31 @@ oracles:
         severity: high
         label: Every portable program agrees with the reference R7RS Scheme on -r and AOT
         action: ./scripts/run_reference_differential.sh
+
+  # ─────────────────────────────────────────────────────────────────
+  # GPU execution correctness (closes the CI gap where the *-cuda lanes
+  # in .github/workflows/ci.yml compile CUDA on GPU-less hosted runners
+  # but never run a kernel). tests/gpu/gpu_correctness_gate.sh builds
+  # Eshkol twice — once with ESHKOL_GPU_ENABLED=ON (Metal on macOS, CUDA
+  # on Linux/Windows), once OFF — runs the identical differentiable
+  # workload (tests/gpu/gpu_correctness_gate.esk: matmul, tensor-add,
+  # tensor-mul, transpose round-trip, tensor-sum/tensor-max) through
+  # both, and diffs GPU vs CPU output within a relative tolerance. It
+  # exits 0 with a SKIP message (no trace emitted, no false PASS) on any
+  # host with no real GPU device — nearly every dev machine and every
+  # GitHub-hosted runner — so this oracle is EXPECTED to show no
+  # evidence outside a machine with a real GPU (self-hosted CI runner,
+  # a workstation/laptop with a dGPU or Apple Silicon Metal, the Jetson
+  # AGX Xavier under nix/jetson/). See docs on wiring a self-hosted
+  # GPU runner in .github/workflows/gpu-execution-gate.yml.
+  # ─────────────────────────────────────────────────────────────────
+  - name: gpu-execution
+    aliases: [gpu-execution-gate, gpu-correctness, p-gpu-execution]
+    requires:
+      - runtime_event:
+          event_kinds: [gpu_execution]
+          event_names: ["gpu_execution_gate"]
+          event_values: ["PASS"]
+        severity: medium
+        label: GPU-accelerated tensor ops (matmul, elementwise, transpose, reduce) match the CPU reference within tolerance on a real GPU device
+        action: ./tests/gpu/gpu_correctness_gate.sh

--- a/docs/breakdown/GPU_ACCELERATION.md
+++ b/docs/breakdown/GPU_ACCELERATION.md
@@ -883,3 +883,31 @@ Metal and CUDA coexist via compile-time guards and runtime detection:
   `eshkol_gpu_supports_f64()` returns true for CUDA (native) and false
   for "no GPU" (`gpu_memory_cuda.cpp`). The Metal backend reports
   f64 support via SF64 emulation.
+
+## 9. CI Testing: Compilation vs. Execution
+
+Two separate things are gated, and it matters which one you're looking at:
+
+- **Compilation** (`.github/workflows/ci.yml`, the `linux-x64-cuda`,
+  `linux-arm64-cuda`, and `windows-arm64-cuda` jobs): builds with
+  `-DESHKOL_GPU_ENABLED=ON` and runs `scripts/run_gpu_tests.sh` against
+  the result. These jobs run on GitHub-hosted runners, which have no
+  GPU. `nvcc` compiles `gpu_cuda_kernels.cu` and `gpu_memory_cuda.cpp`
+  fine, but at runtime `eshkol_gpu_init()` finds zero CUDA devices, so
+  `tests/gpu/*.esk` all execute their CPU fallback path. These lanes
+  prove the GPU backend *builds*; they do not exercise a single GPU
+  kernel.
+
+- **Execution** (`.github/workflows/gpu-execution-gate.yml`,
+  `tests/gpu/gpu_correctness_gate.sh`): builds Eshkol twice — once with
+  GPU acceleration on, once off — and diffs GPU-vs-CPU output on the
+  same differentiable workload within a numeric tolerance. This is the
+  gate that actually proves a Metal or CUDA kernel ran and produced a
+  correct answer. It exits 0 with a SKIP message on any host without a
+  real GPU device (which includes essentially all GitHub-hosted
+  runners), so it only ever produces a verdict where one is possible.
+  It needs a self-hosted runner carrying `[self-hosted, gpu]` labels to
+  run in CI; until one is registered it stays queued rather than
+  failing anything. It can also be run by hand on any workstation with
+  a real GPU (Metal on any Mac, CUDA with an NVIDIA driver present —
+  including the Jetson AGX Xavier setup in `nix/jetson/`).

--- a/nix/jetson/README.md
+++ b/nix/jetson/README.md
@@ -57,3 +57,19 @@ Measured on this Xavier (1024x1024x1024 f64, end-to-end through `(matmul ...)`):
 numerically identical to the CPU reference. The full `tests/gpu/*` suite
 (matmul / scale-correctness up to 4096x4096, transpose, reduce, elementwise)
 passes on the GPU.
+
+## Relationship to the CI GPU execution gate
+
+This directory was the only place Eshkol's GPU backend was ever actually
+*run* — CI's `*-cuda` lanes only compile it (GitHub-hosted runners have no
+GPU). `tests/gpu/gpu_correctness_gate.sh` generalizes the differential
+check this benchmark did by hand (GPU matmul vs. CPU reference, same
+input, numeric diff) into a self-contained script that builds Eshkol with
+and without GPU acceleration, runs a shared workload through both, and
+skips cleanly on any host without a real GPU. It is wired into
+`.github/workflows/gpu-execution-gate.yml` for a self-hosted GPU
+runner (this Jetson is one candidate) or a scheduled job; see that
+workflow file and `docs/breakdown/GPU_ACCELERATION.md` section 9 for the
+compilation-vs-execution distinction. `jetson_gemm_bench.esk` stays as-is
+for hand-run GFLOPS benchmarking — the gate script is the correctness
+signal, this file is the performance one.

--- a/tests/gpu/gpu_correctness_gate.esk
+++ b/tests/gpu/gpu_correctness_gate.esk
@@ -1,0 +1,75 @@
+;; GPU correctness gate payload.
+;;
+;; Runs the same fixed, non-trivial workload through whichever binary
+;; executes this file. tests/gpu/gpu_correctness_gate.sh runs it twice —
+;; once through a GPU-enabled build with GPU dispatch forced
+;; (ESHKOL_GPU_THRESHOLD=1) and once through a GPU-disabled (CPU-only)
+;; build — and diffs the two "RESULT " lines within a numeric tolerance.
+;; That is the actual differential correctness check; this file only
+;; needs to print deterministic, GPU-dispatch-sized numeric summaries.
+;;
+;; Inputs use sin()/index-derived fractional values rather than all-ones
+;; matrices so that the matmul/reduce accumulation order actually matters
+;; numerically — an all-ones input would trivially agree between a GPU
+;; and CPU reduction even if the two accumulated in a different order.
+;;
+;; Sizes are chosen so total element products clear the VM's GPU-dispatch
+;; threshold (100,000, see lib/backend/vm_gpu_dispatch.h) without an env
+;; override, and so a 512x512 f64 matmul finishes in well under a second
+;; on both CPU and GPU paths — this is a correctness gate, not a
+;; benchmark.
+
+(define N 512)
+(define K 512)
+(define elems (* N K))
+
+;; Deterministic non-uniform fill: A[i] = sin(i * 0.001) + 1.0001,
+;; B[i] = cos(i * 0.0013) + 1.0002. Offsets keep values away from zero
+;; (avoids near-cancellation making the tolerance check noisy) while
+;; remaining irrational/non-repeating across the whole matrix.
+(define (fill-vec n scale offset fn)
+  (let loop ((i 0) (acc '()))
+    (if (= i n)
+        (list->vector (reverse acc))
+        (loop (+ i 1) (cons (+ offset (fn (* i scale))) acc)))))
+
+(define A-data (fill-vec elems 0.001 1.0001 sin))
+(define B-data (fill-vec elems 0.0013 1.0002 cos))
+
+(define A (reshape A-data N K))
+(define B (reshape B-data K N))
+
+;; `display` on a float prints with ~6 significant digits (not full
+;; round-trip precision) — that's a separate stdlib formatting
+;; characteristic, not something this gate changes. It's still enough
+;; precision to catch a real GPU-kernel bug (wrong dimensions, transposed
+;; data, NaN/garbage, wrong accumulation) while the harness's tolerance
+;; comparison (tests/gpu/gpu_correctness_gate.sh) absorbs any last-digit
+;; GPU-vs-CPU floating-point summation-order drift.
+(define (result label val)
+  (display "RESULT ") (display label) (display " ") (display val) (newline))
+
+;; --- matmul ---
+(define C (matmul A B))
+(result "matmul-checksum" (tensor-sum C))
+(result "matmul-c00" (tensor-get C 0 0))
+(result "matmul-cmid" (tensor-get C 256 256))
+(result "matmul-clast" (tensor-get C 511 511))
+
+;; --- elementwise add/mul (same shape, GPU-dispatch sized) ---
+(define S (tensor-add A B))
+(result "add-checksum" (tensor-sum S))
+
+(define P (tensor-mul A B))
+(result "mul-checksum" (tensor-sum P))
+
+;; --- transpose round-trip on the matmul output ---
+(define Ct (transpose (transpose C)))
+(result "transpose-roundtrip-c00" (tensor-get Ct 0 0))
+(result "transpose-roundtrip-clast" (tensor-get Ct 511 511))
+
+;; --- full reduce ---
+(result "reduce-sum-A" (tensor-sum A))
+(result "reduce-max-A" (tensor-max A))
+
+(display "GATE-DONE") (newline)

--- a/tests/gpu/gpu_correctness_gate.sh
+++ b/tests/gpu/gpu_correctness_gate.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# tests/gpu/gpu_correctness_gate.sh — GPU EXECUTION correctness gate.
+#
+# What this closes: the *-cuda lanes in .github/workflows/ci.yml run on
+# GitHub-hosted GPU-less runners, so ESHKOL_GPU_ENABLED=ON only proves
+# `nvcc`/Metal frameworks *compile* — no GPU kernel ever actually runs in
+# CI. This script is the missing EXECUTION gate: on a machine with a real
+# GPU (Metal on macOS, CUDA on Linux/Windows), it builds Eshkol twice —
+# once with GPU acceleration on, once with it off — runs the identical
+# differentiable workload (tests/gpu/gpu_correctness_gate.esk) through
+# both, and diffs the numeric output within a tolerance. A mismatch means
+# the GPU kernel path is producing wrong answers: a real bug, not a CI
+# infra gap.
+#
+# On a machine with no GPU (the common case — every GitHub-hosted runner,
+# a laptop with no discrete/integrated GPU framework support), this
+# SKIPS cleanly: exit 0 with a "SKIP:" message. It never fails a run for
+# lacking hardware it was never meant to require.
+#
+# Usage:
+#   tests/gpu/gpu_correctness_gate.sh
+#
+# Env overrides:
+#   BUILD_DIR_GPU   build dir for the GPU-enabled binary (default: build-gpu-gate)
+#   BUILD_DIR_CPU   build dir for the GPU-disabled reference binary (default: build-gpu-gate-cpuref)
+#   REUSE_BUILDS=1  skip (re)configuring/building if eshkol-run already exists
+#                   in both dirs — for CI jobs that cache the build step
+#   GPU_GATE_TOL    relative tolerance for the numeric diff (default: 1e-4;
+#                   loose because eshkol's `display` prints floats with
+#                   ~6 significant digits, not full round-trip precision —
+#                   see the comment in gpu_correctness_gate.esk)
+#   LLVM_CONFIG     path to llvm-config (auto-detected via `brew --prefix
+#                   llvm@21` on macOS, or llvm-config-21 on Linux, if unset)
+set -u
+cd "$(dirname "$0")/../.."
+REPO_ROOT="$(pwd)"
+
+BUILD_DIR_GPU="${BUILD_DIR_GPU:-build-gpu-gate}"
+BUILD_DIR_CPU="${BUILD_DIR_CPU:-build-gpu-gate-cpuref}"
+REUSE_BUILDS="${REUSE_BUILDS:-0}"
+GPU_GATE_TOL="${GPU_GATE_TOL:-1e-4}"
+GATE_ESK="$REPO_ROOT/tests/gpu/gpu_correctness_gate.esk"
+
+# ICC evidence trace (.icc/completion-oracles.yaml::gpu-execution). Only
+# written on an actual PASS/FAIL verdict — a SKIP (no GPU on this host)
+# leaves no trace line, so the oracle correctly reports "no evidence yet"
+# rather than a false PASS, on every GPU-less dev machine and hosted
+# runner. See scripts/run_reference_differential.sh for the same
+# kind/name/value/snippet JSON-L convention this reuses.
+TRACE_DIR="$REPO_ROOT/scripts/icc_traces"
+TRACE_FILE="$TRACE_DIR/gpu_execution.jsonl"
+emit_trace() {  # emit_trace <value> <snippet>
+    local value="$1" snippet="$2"
+    mkdir -p "$TRACE_DIR"
+    local esnip
+    if command -v python3 >/dev/null 2>&1; then
+        esnip="$(printf '%s' "$snippet" | python3 -c 'import json,sys; sys.stdout.write(json.dumps(sys.stdin.read()))')"
+    else
+        esnip="$(printf '%s' "$snippet" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')"
+        esnip="\"$esnip\""
+    fi
+    printf '{"kind":"gpu_execution","name":"gpu_execution_gate","value":"%s","snippet":%s,"confidence":0.95}\n' \
+        "$value" "$esnip" >> "$TRACE_FILE"
+}
+
+log()  { printf '%s\n' "$*"; }
+skip() { log "SKIP: $*"; exit 0; }
+fail() { log "FAIL: $*"; emit_trace FAIL "$*"; exit 1; }
+
+# ─────────────────────────────────────────────────────────────────
+# Step 1: build-time GPU framework detection. No point configuring a
+# full build if neither Metal nor a CUDA toolchain is present at all.
+# ─────────────────────────────────────────────────────────────────
+UNAME_S="$(uname -s)"
+HAVE_GPU_FRAMEWORK=0
+case "$UNAME_S" in
+    Darwin)
+        # Every Mac Eshkol supports has a Metal-capable GPU (integrated
+        # or discrete); the runtime check in step 4 is what actually
+        # proves a device answers, which is what matters on virtualized
+        # hosted runners that may not pass a GPU through to Metal.
+        if xcrun -sdk macosx --show-sdk-path >/dev/null 2>&1; then
+            HAVE_GPU_FRAMEWORK=1
+        fi
+        ;;
+    Linux)
+        if command -v nvidia-smi >/dev/null 2>&1 || command -v nvcc >/dev/null 2>&1; then
+            HAVE_GPU_FRAMEWORK=1
+        fi
+        ;;
+    *)
+        HAVE_GPU_FRAMEWORK=0
+        ;;
+esac
+
+if [ "$HAVE_GPU_FRAMEWORK" -ne 1 ]; then
+    skip "no GPU build framework detected on $UNAME_S (no Metal SDK / no nvidia-smi or nvcc) — nothing to execute"
+fi
+
+if [ "$UNAME_S" = "Linux" ] && ! command -v nvidia-smi >/dev/null 2>&1; then
+    skip "nvcc present but nvidia-smi is not — CUDA toolchain without a driver/GPU (e.g. a hosted CI compile-only runner)"
+fi
+if [ "$UNAME_S" = "Linux" ] && command -v nvidia-smi >/dev/null 2>&1; then
+    if ! nvidia-smi -L >/dev/null 2>&1 || [ -z "$(nvidia-smi -L 2>/dev/null)" ]; then
+        skip "nvidia-smi present but reports no GPU device"
+    fi
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Step 2: resolve LLVM (mirrors CMakeLists.txt / nix/jetson/build.sh's
+# lite-build LLVM discovery).
+# ─────────────────────────────────────────────────────────────────
+if [ -z "${LLVM_CONFIG:-}" ]; then
+    if [ "$UNAME_S" = "Darwin" ] && command -v brew >/dev/null 2>&1 && brew --prefix llvm@21 >/dev/null 2>&1; then
+        LLVM_CONFIG="$(brew --prefix llvm@21)/bin/llvm-config"
+    elif command -v llvm-config-21 >/dev/null 2>&1; then
+        LLVM_CONFIG="$(command -v llvm-config-21)"
+    elif command -v llvm-config >/dev/null 2>&1; then
+        LLVM_CONFIG="$(command -v llvm-config)"
+    else
+        fail "could not locate llvm-config (LLVM 21) — set LLVM_CONFIG explicitly"
+    fi
+fi
+[ -x "$LLVM_CONFIG" ] || fail "LLVM_CONFIG=$LLVM_CONFIG is not executable"
+
+configure_and_build() {
+    local build_dir="$1" gpu_flag="$2"
+    if [ "$REUSE_BUILDS" = "1" ] && [ -x "$build_dir/eshkol-run" ]; then
+        log "  reusing $build_dir/eshkol-run (REUSE_BUILDS=1)"
+        return 0
+    fi
+    log "  configuring $build_dir (ESHKOL_GPU_ENABLED=$gpu_flag)..."
+    cmake -S "$REPO_ROOT" -B "$build_dir" -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DESHKOL_REQUIRED_LLVM_MAJOR=21 \
+        -DLLVM_CONFIG_EXECUTABLE="$LLVM_CONFIG" \
+        -DESHKOL_XLA_ENABLED=OFF \
+        -DESHKOL_GPU_ENABLED="$gpu_flag" \
+        -DESHKOL_BUILD_TESTS=OFF \
+        > "$build_dir.configure.log" 2>&1 || { tail -n 60 "$build_dir.configure.log"; return 1; }
+
+    if [ "$gpu_flag" = "ON" ] && ! grep -q "GPU acceleration: ENABLED" "$build_dir.configure.log"; then
+        # Framework check in step 1 said yes, but CMake's own probe (which
+        # actually tries to find_package(Metal)/find_package(CUDAToolkit))
+        # disagrees — trust CMake and skip rather than fail the gate.
+        return 2
+    fi
+
+    log "  building $build_dir..."
+    ninja -C "$build_dir" eshkol-run > "$build_dir.build.log" 2>&1 || { tail -n 80 "$build_dir.build.log"; return 1; }
+}
+
+log "=== Eshkol GPU execution correctness gate ==="
+log "Platform: $UNAME_S"
+log ""
+log "Building GPU-enabled reference ($BUILD_DIR_GPU)..."
+configure_and_build "$BUILD_DIR_GPU" ON
+rc=$?
+if [ "$rc" -eq 2 ]; then
+    skip "CMake could not find a usable GPU framework (Metal/CUDA) despite the coarse OS-level probe — nothing to execute"
+fi
+[ "$rc" -eq 0 ] || fail "GPU-enabled build failed — see $BUILD_DIR_GPU.build.log"
+
+log "Building CPU-only reference ($BUILD_DIR_CPU)..."
+configure_and_build "$BUILD_DIR_CPU" OFF || fail "CPU-only reference build failed — see $BUILD_DIR_CPU.build.log"
+
+GPU_RUN="$REPO_ROOT/$BUILD_DIR_GPU/eshkol-run"
+CPU_RUN="$REPO_ROOT/$BUILD_DIR_CPU/eshkol-run"
+[ -x "$GPU_RUN" ] || fail "$GPU_RUN missing after build"
+[ -x "$CPU_RUN" ] || fail "$CPU_RUN missing after build"
+
+# ─────────────────────────────────────────────────────────────────
+# Step 3: compile the shared payload with each binary.
+# ─────────────────────────────────────────────────────────────────
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-gpu-gate.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+log ""
+log "Compiling gate payload with both binaries..."
+"$GPU_RUN" "$GATE_ESK" -o "$WORK_DIR/gate_gpu.bin" > "$WORK_DIR/gpu_compile.log" 2>&1 \
+    || fail "GPU binary failed to compile $GATE_ESK — $(tail -n 20 "$WORK_DIR/gpu_compile.log")"
+"$CPU_RUN" "$GATE_ESK" -o "$WORK_DIR/gate_cpu.bin" > "$WORK_DIR/cpu_compile.log" 2>&1 \
+    || fail "CPU-reference binary failed to compile $GATE_ESK — $(tail -n 20 "$WORK_DIR/cpu_compile.log")"
+
+# ─────────────────────────────────────────────────────────────────
+# Step 4: runtime GPU-presence check + forced-dispatch run. Verbose GPU
+# logging is opt-in (ESHKOL_VERBOSE on Metal, ESHKOL_GPU_VERBOSE on
+# CUDA) and prints an init banner ("[GPU] Metal: ..." / a CUDA device
+# line) the moment eshkol_gpu_init() finds a real device, plus (on the
+# forced sf64 dispatch kernel) an explicit per-call
+# "[GPU] sf64 dispatch: ... completed: ...ms ...GFLOPS" line and (on
+# CUDA) "-> CUDA cuBLAS" per matmul call. ESHKOL_GPU_THRESHOLD=1 forces
+# every tensor op in the payload through the GPU path regardless of the
+# VM's default dispatch-size heuristic.
+# ─────────────────────────────────────────────────────────────────
+log ""
+log "Running GPU-enabled binary with dispatch forced..."
+GPU_STDOUT="$WORK_DIR/gpu_stdout.txt"
+GPU_STDERR="$WORK_DIR/gpu_stderr.txt"
+ESHKOL_VERBOSE=1 ESHKOL_GPU_VERBOSE=1 ESHKOL_GPU_THRESHOLD=1 ESHKOL_SF64_KERNEL=legacy \
+    "$WORK_DIR/gate_gpu.bin" > "$GPU_STDOUT" 2> "$GPU_STDERR"
+gpu_run_rc=$?
+[ "$gpu_run_rc" -eq 0 ] || fail "GPU binary crashed/exited $gpu_run_rc — stderr: $(tail -n 40 "$GPU_STDERR")"
+grep -q "^GATE-DONE$" "$GPU_STDOUT" || fail "GPU run did not reach GATE-DONE — output: $(cat "$GPU_STDOUT")"
+
+if grep -qE '\[GPU\] Metal: |\[GPU\] .*-> CUDA cuBLAS|\[GPU\] sf64 (dispatch|completed):' "$GPU_STDERR"; then
+    log "  GPU device confirmed live (init banner / per-call dispatch log present):"
+    grep -E '\[GPU\] Metal: |\[GPU\] .*-> CUDA cuBLAS|\[GPU\] sf64 (dispatch|completed):' "$GPU_STDERR" | sed 's/^/    /'
+else
+    skip "GPU-enabled binary built and ran, but no GPU device announced itself at runtime (no [GPU] init/dispatch log) — likely a GPU-less/virtualized host despite compile-time framework detection"
+fi
+
+log ""
+log "Running CPU-only reference binary..."
+CPU_STDOUT="$WORK_DIR/cpu_stdout.txt"
+"$WORK_DIR/gate_cpu.bin" > "$CPU_STDOUT" 2>"$WORK_DIR/cpu_stderr.txt"
+cpu_run_rc=$?
+[ "$cpu_run_rc" -eq 0 ] || fail "CPU-reference binary crashed/exited $cpu_run_rc"
+grep -q "^GATE-DONE$" "$CPU_STDOUT" || fail "CPU run did not reach GATE-DONE"
+
+# ─────────────────────────────────────────────────────────────────
+# Step 5: differential comparison, tolerance-based.
+# ─────────────────────────────────────────────────────────────────
+log ""
+log "Diffing GPU vs CPU RESULT lines (relative tolerance $GPU_GATE_TOL)..."
+
+grep '^RESULT ' "$GPU_STDOUT" > "$WORK_DIR/gpu_results.txt"
+grep '^RESULT ' "$CPU_STDOUT" > "$WORK_DIR/cpu_results.txt"
+
+gpu_labels="$(awk '{print $2}' "$WORK_DIR/gpu_results.txt")"
+cpu_labels="$(awk '{print $2}' "$WORK_DIR/cpu_results.txt")"
+[ "$gpu_labels" = "$cpu_labels" ] || fail "RESULT label sets differ between GPU and CPU runs — payload divergence, not a numeric issue"
+
+mismatch=0
+max_rel_diff=0
+while read -r _ label gval; do
+    cval="$(awk -v l="$label" '$2==l {print $3}' "$WORK_DIR/cpu_results.txt")"
+    rel_diff="$(awk -v g="$gval" -v c="$cval" -v tol="$GPU_GATE_TOL" '
+        BEGIN {
+            diff = g - c; if (diff < 0) diff = -diff;
+            denom = c; if (denom < 0) denom = -denom;
+            if (denom < 1e-12) denom = 1e-12;
+            rel = diff / denom;
+            printf "%.10g %d", rel, (rel > tol) ? 1 : 0;
+        }')"
+    rel="$(echo "$rel_diff" | awk '{print $1}')"
+    bad="$(echo "$rel_diff" | awk '{print $2}')"
+    is_greater="$(awk -v a="$rel" -v b="$max_rel_diff" 'BEGIN{print (a>b)?1:0}')"
+    [ "$is_greater" = "1" ] && max_rel_diff="$rel"
+    if [ "$bad" = "1" ]; then
+        mismatch=1
+        log "  MISMATCH $label: GPU=$gval CPU=$cval rel_diff=$rel (> $GPU_GATE_TOL)"
+    else
+        log "  ok       $label: GPU=$gval CPU=$cval rel_diff=$rel"
+    fi
+done < "$WORK_DIR/gpu_results.txt"
+
+log ""
+log "Max relative diff across all probes: $max_rel_diff (tolerance $GPU_GATE_TOL)"
+
+if [ "$mismatch" -eq 1 ]; then
+    fail "GPU-vs-CPU differential mismatch exceeded tolerance — this is a GPU kernel correctness bug, not an infra flake"
+fi
+
+log ""
+log "PASS: GPU execution matches CPU reference within tolerance ($GPU_GATE_TOL) on $UNAME_S"
+emit_trace PASS "platform=$UNAME_S max_rel_diff=$max_rel_diff tol=$GPU_GATE_TOL probes=$(wc -l < "$WORK_DIR/gpu_results.txt" | tr -d ' ')"
+exit 0


### PR DESCRIPTION
## Summary

The `linux-x64-cuda` / `linux-arm64-cuda` / `windows-arm64-cuda` lanes in `ci.yml` build the GPU backend with `-DESHKOL_GPU_ENABLED=ON` but run on GitHub-hosted runners, which have no GPU. `nvcc`/Metal frameworks compile fine, but at runtime `eshkol_gpu_init()` finds zero devices and every "GPU" tensor op silently falls through to the CPU path. Those lanes are a **compilation** gate, not an **execution** gate. Real GPU kernel execution has only ever happened ad hoc, by hand, on a Jetson AGX Xavier under `nix/jetson/`.

This PR adds the missing execution gate:

- `tests/gpu/gpu_correctness_gate.sh` + `tests/gpu/gpu_correctness_gate.esk`: a self-contained differential correctness gate. It builds Eshkol twice (GPU acceleration on, then off), runs the identical workload (matmul, tensor-add, tensor-mul, transpose round-trip, tensor-sum/tensor-max on a 512x512 non-trivial `sin`/`cos`-derived matrix) through both binaries, and diffs GPU-vs-CPU numeric output within a relative tolerance. It also greps GPU-run stderr for the Metal/CUDA device-init banner and per-call dispatch log lines, so a silent CPU fallback inside the "GPU-enabled" binary can't produce a false pass. On any host without a real GPU device (virtually every dev machine and every GitHub-hosted runner) it exits 0 with a `SKIP:` message — never blocks a run for missing hardware it doesn't require.
- `.github/workflows/gpu-execution-gate.yml`: a new, separate workflow that runs the gate on `runs-on: [self-hosted, gpu]` (manual dispatch + nightly cron + pushes touching `lib/backend/gpu/**`). It does not touch the existing `*-cuda` lanes and will not run on hosted runners by design — until a self-hosted GPU runner is registered it just queues harmlessly.
- `.icc/completion-oracles.yaml`: a new `gpu-execution` oracle. The gate script emits a `gpu_execution_gate` PASS/FAIL trace only when it produces a real verdict (never on SKIP), so the oracle correctly shows "no evidence" rather than a false PASS on GPU-less hosts.
- `docs/breakdown/GPU_ACCELERATION.md` (new section 9) and `nix/jetson/README.md`: document the compilation-vs-execution distinction and point at the new gate.

## Verification on this machine (Apple M2 Ultra, Metal)

Ran the gate end-to-end from a clean checkout (fresh `cmake`+`ninja` build in both directions, no build reuse):

```
[GPU] Metal: Apple M2 Ultra, M2 (Apple8), maxBuffer=110592MB, unified=yes
[GPU] sf64 dispatch: M=512 K=512 N=512 chunk=512 groups=(8,8)
[GPU] sf64 completed: 8.9ms 30 GFLOPS (M=512 K=512 N=512)

  ok       matmul-checksum: GPU=1.35256e+08 CPU=1.35256e+08 rel_diff=0
  ok       matmul-c00: GPU=642.759 CPU=642.759 rel_diff=0
  ok       matmul-cmid: GPU=219.077 CPU=219.077 rel_diff=0
  ok       matmul-clast: GPU=52.8141 CPU=52.8141 rel_diff=0
  ok       add-checksum: GPU=526313 CPU=526313 rel_diff=0
  ok       mul-checksum: GPU=260852 CPU=260852 rel_diff=0
  ok       transpose-roundtrip-c00: GPU=642.759 CPU=642.759 rel_diff=0
  ok       transpose-roundtrip-clast: GPU=52.8141 CPU=52.8141 rel_diff=0
  ok       reduce-sum-A: GPU=263349 CPU=263349 rel_diff=0
  ok       reduce-max-A: GPU=2.0001 CPU=2.0001 rel_diff=0

Max relative diff across all probes: 0 (tolerance 1e-4)
PASS: GPU execution matches CPU reference within tolerance (1e-4) on Darwin
```

Also independently verified both SKIP paths (no GPU framework on the platform; `nvcc` present but no `nvidia-smi`/driver) exit 0 with a clear `SKIP:` message, and reran the gate a second time to confirm the ICC trace (`scripts/icc_traces/gpu_execution.jsonl`) and the `gpu-execution` oracle (`codebase_tool.py completion-oracle --target gpu-execution`) both pick it up correctly.

## Test plan

- [x] `tests/gpu/gpu_correctness_gate.sh` run fresh (clean build, both GPU-on and GPU-off) on Apple M2 Ultra — PASS, 0 relative diff on all 10 probes
- [x] Same script rerun with `REUSE_BUILDS=1` against the same build dirs — PASS, consistent result
- [x] SKIP path exercised for a simulated no-GPU-framework Linux host — exits 0
- [x] SKIP path exercised for a simulated `nvcc`-present/no-driver host — exits 0
- [x] Existing `*-cuda` CI lanes in `ci.yml` untouched
- [ ] `gpu-execution-gate.yml` job itself needs a `[self-hosted, gpu]`-labeled runner registered against this repo before it can execute in GitHub Actions (documented in the workflow file)