### PR TITLE
docs: bring public-facing site and press content current to v1.3.3-evolve

### DIFF
--- a/ANNOUNCEMENT.md
+++ b/ANNOUNCEMENT.md
@@ -1,37 +1,39 @@
-# Eshkol v1.3.1 — flat memory for long-running programs, and a fully documented public API
+# Eshkol v1.3.3-evolve — exact AD gradients for first-class losses, and the region-evacuator closeout
 
-**Eshkol v1.3.1 builds on v1.3.0-evolve's arbitrary-order Taylor-tower automatic differentiation and 100% R7RS conformance with what a differentiable systems language needs to run unattended: flat memory in long-running resident/daemon workloads, and a comprehensive documentation pass across every public header and implementation module.**
+**Eshkol v1.3.3-evolve corrects an overstated automatic-differentiation claim from v1.3.2-evolve with the real fix — exact gradients through the `input2` path for first-class losses and vector/learnable gamma — and completes the region-escape evacuator series (ESH-0214) by covering the last heap subtype, `PROMISE`.**
 
-Eshkol is Scheme (R7RS) compiled to native code via LLVM, with automatic differentiation as a compiler primitive rather than a library. Where v1.3.0-evolve took AD from "correct at first and second order" to "correct, exact, and validated at *every* order" and closed out a long list of robustness gaps found by a new permanent adversarial-testing program, v1.3.1 closes the remaining gap between "runs correctly" and "runs unattended for days": a memory-growth class that survived the v1.3.0-evolve TCO-loop hardening, and a native-stack overflow on very large persisted data.
+Eshkol is Scheme (R7RS) compiled to native code via LLVM, with automatic differentiation as a compiler primitive rather than a library. v1.3.2-evolve's CHANGELOG entry for issue #212 claimed the `input2` gradient path — the second operand of `conv2d`/`batchnorm`/`layernorm`/`attention` (kernel / gamma / K / V) — was complete. An adversarial audit run during this cycle found that claim was wrong: the v1.3.2 change landed a test and a roadmap update, but no gradient code. v1.3.3-evolve ships the actual fix, corrects the record in CHANGELOG.md, and — separately — finishes the region-evacuator hardening that v1.3.1-evolve and v1.3.2-evolve had been closing out one heap subtype at a time.
 
 Full engineering detail lives in [CHANGELOG.md](CHANGELOG.md); the user-facing summary is [RELEASE_NOTES.md](RELEASE_NOTES.md); the complete AD walkthrough is the [Automatic Differentiation guide](docs/guide/AUTOMATIC_DIFFERENTIATION.md). This document is the release announcement — quotable, and every claim below is grounded in shipped code and a real, run command.
 
 ---
 
-## What's new in v1.3.1
+## What's new since v1.3.1-evolve
 
-### Flat memory for resident and daemon workloads
+### v1.3.3-evolve: exact AD gradients, and the region-evacuator series closes out
 
-v1.3.0-evolve already gave named-let TCO loops automatic, zero-annotation per-iteration arena-scope reclamation (ESH-0214). v1.3.1 closes the remaining case in that same bug class and fixes a second, unrelated way a long-running process's native stack could blow out:
+- **Exact tensor AD gradients for first-class losses and vector/learnable gamma; silent-zero backward paths now error instead of returning zero** (#229). The real `input2` fix, in three parts: (1) a loss with no compile-time `Function*` — a first-class/higher-order loss — fell to the forward-mode-dual closure path, which loses the tangent for tensor ops and silently returned a zero gradient; a reverse-mode tensor path was added to the closure branch of `AutodiffCodegen::gradient` to close that. (2) Batch-norm/layer-norm now wire per-feature gamma/beta as individual AD nodes instead of a single scalar, so vector/learnable gamma differentiates correctly rather than only a scalar approximation. (3) Any remaining unsupported tensor-op backward path now raises an explicit unsupported-op error instead of silently returning zero, honoring exact-AD-or-error rather than exact-AD-or-silently-wrong. Finite-difference-verified exact in both literal and first-class forms across matmul/conv2d/attention-K-V/vector-gamma; autodiff suite 54/54, the `input2` gradient gate 24/24 under both JIT and AOT.
+- **Region escape evacuator now covers the `PROMISE` heap subtype** (ESH-0214e, #230). Adversarial-audit follow-up to ESH-0214d: `PROMISE` was left a shallow-copied leaf despite carrying interior pointers (a thunk and a cached value). A `delay`/`make-promise` created inside `with-region` that escaped outward dangled after `region_pop`, observable as a segfault or `car: not a pair` under `ESHKOL_ARENA_POISON=1` when the promise was later forced. Fixed by adding an evacuation case that walks both interior slots; verified flat at ~116 MB under poison over escape-then-force for both `delay` and `make-promise`. This closes out the ESH-0214 region-evacuator series (ESH-0214a through e) that started with named-let/`define`-loop arena reclamation in v1.3.1-evolve.
+- **ICC release-oracle hardening** (#232): the completion oracle now checks region-evacuator poison coverage and the corrected `input2` gradient gate, so both fixes above are load-bearing release gates going forward, not one-off verifications.
+- **Subprocess `process-wait` kqueue lost-wakeup race — documented.** The fix itself shipped in v1.3.2-evolve (commit `8443ddae`) but was never recorded in the CHANGELOG until now: on macOS, a child that exited before its `kevent` `EVFILT_PROC` filter was registered could make `process-wait` block for the full timeout and misreport a dead process as still running. The fix probes once with `waitpid(WNOHANG)` right after registering the filter (and again on the timeout branch) so an already-dead child is reaped immediately instead of falling through to a spurious timeout.
 
-- **Self-tail-recursive `define` loops, including a catch-all guard body** (ESH-0214b): the escape analysis that makes per-iteration arena reclamation safe now also recognizes self-tail-recursive functions written with plain `define` rather than named-let, and accepts a catch-all guard body in that analysis rather than declining to optimize it. Verified on a 1,000,000-iteration loop: RSS goes from 1,369 MB (unbounded growth) to 224 MB (flat).
-- **Iterative S-expression reader** (ESH-0191): `read_list`, the core parser routine for reading persisted S-expression data back in, was rewritten from one native stack frame per list element to an iterative loop. A program that reads back a very large persisted data structure — a long checkpoint, a big literal table, a large logged fact base — no longer risks a native-stack overflow on load. Verified: the pre-fix reader crashed with SIGBUS at 20 million elements; the post-fix reader completes cleanly at the same size.
+### v1.3.2-evolve: thread-safe regions, deeper evacuation, and new tooling
 
-Together, these are the difference between a program that degrades over a long run and one that doesn't: an Eshkol process built as a resident worker or daemon — a long-lived agent loop, a persistent server, a checkpoint/restore pipeline — can now run with flat memory instead of monitoring RSS and scheduling restarts.
-
-### Comprehensive C-API and implementation documentation
-
-Every public embedding header and every previously-undocumented implementation file gets Doxygen-format documentation in this release: 50 of the 64 public headers under `inc/eshkol/` (backend codegen, runtime core, type system, XLA backend, subprocess/macro-expander/qLLM-bridge surfaces, thread pool and work-stealing deque, logger, model I/O, platform runtime, runtime exports) across six commits, plus 56 previously-undocumented implementation files under `lib/` (agent FFI, the type checker, the parser, the REPL, core non-runtime modules, the quantum RNG, FFI bridges) across three commits. Combined, that is 116 files and roughly 12,600 lines of new documentation — comments only, no behavior changes. Anyone embedding `libeshkol` or reading the compiler's own source now has a documented contract to read instead of guessing from call sites.
-
-### A navigable documentation reference index
-
-A per-subsystem reference index now organizes the language surface for lookup rather than linear reading: [`docs/reference/language/`](docs/reference/language/INDEX.md), [`ad/`](docs/reference/ad/INDEX.md), [`runtime/`](docs/reference/runtime/INDEX.md), [`tensors/`](docs/reference/tensors/INDEX.md), [`stdlib/`](docs/reference/stdlib/INDEX.md), and [`agent/`](docs/reference/agent/INDEX.md), each an example-verified index into the corresponding function and syntax reference. It is linked from [README.md](README.md#documentation).
+- **Region escape evacuator now covers logic and workspace subtypes** (ESH-0214d, #226): `SUBSTITUTION`, `FACT`, `KNOWLEDGE_BASE`, `FACTOR_GRAPH`, and `WORKSPACE` — the state a resident tick loop mutates via the neuro-symbolic stack — are now deep-walked on region escape instead of shallow-copied, so a `with-region`-wrapped tick loop can reclaim transient garbage per iteration while its escaping knowledge-base/workspace state is promoted intact. `arena_destroy` is now poisoned under `ESHKOL_ARENA_POISON` so a region use-after-free crashes loudly instead of passing by luck.
+- **Thread-safe region scope stack** (#217): `parallel-map`/future callbacks that opened a `with-region` raced on the shared current-arena slot under concurrency; the region hijack moved into the runtime with a parallel-scope guard.
+- **`eshkol-doc` — API reference generator** (#213): harvests Doxygen `/** @brief */` comments from `inc/` and `lib/` and generates `docs/api/`.
+- **`core.blc` — Binary Lambda Calculus, plus a universal machine** (#218): a pure-Eshkol implementation of John Tromp's Binary Lambda Calculus — De Bruijn-indexed terms, `blc-encode`/`blc-decode`, normal-order `blc-eval` — deepened with `(blc-U)`, Tromp's 232-bit self-interpreter, BLC8 byte I/O, and ASCII lambda diagrams.
+- **Three deferred latent bugs triaged**: ESH-0223 (named-let stack overflow at high iteration counts), ESH-0227 (apply-loop SIGBUS), ESH-0228 (`sleep-ms` argument type check) (#215).
 
 ---
 
-## The foundation this release runs on: v1.3.0-evolve
+## The foundation this release runs on: v1.3.1-evolve and v1.3.0-evolve
 
-### Arbitrary-order automatic differentiation
+### Flat memory for resident and daemon workloads (v1.3.1-evolve)
+
+The per-iteration arena-reclamation work that the region-evacuator series above builds on started here: self-tail-recursive `define` loops, including a catch-all guard body, gained the same automatic per-iteration arena-scope reclamation that named-let loops already had (ESH-0214b) — verified on a 1,000,000-iteration loop, RSS goes from 1,369 MB (unbounded growth) to 224 MB (flat) — and the S-expression reader (`read_list`) was rewritten from one native stack frame per list element to an iterative loop, so reading back a very large persisted data structure no longer risks a native-stack overflow (ESH-0191). v1.3.1-evolve also shipped a comprehensive Doxygen documentation pass across every public embedding header and most implementation files, plus a navigable per-subsystem documentation index.
+
+### Arbitrary-order automatic differentiation (v1.3.0-evolve)
 
 Eshkol's forward-mode, reverse-mode, and symbolic AD were already exact at first and second order. v1.3.0-evolve added a second axis on top of that: **order**. A Taylor-tower engine — designed in [`docs/design/AD_TAYLOR_TOWER.md`](docs/design/AD_TAYLOR_TOWER.md) and delivered across thirteen gated phases, P0 through P12 — computes *every* derivative up to an arbitrary order `k` in one pass, using closed Taylor recurrences (`lib/core/taylor_recurrences.def`, `lib/core/runtime_taylor.c`) instead of nested dual numbers. Nested/hyper-dual AD doubles its representation with every additional order (2^k); Taylor-mode is `k+1` coefficients and O(k²) work — polynomial, not exponential, in the order.
 
@@ -93,7 +95,7 @@ Gate          : PASS  (PASS iff every program AGREES)
 
 ### Robustness: tail calls and shutdown
 
-A cluster of fixes from v1.3.0-evolve targets the class of bug that only shows up in a program that runs for a long time or recurses deeply, not in a quick test — the same class this release's arena-reclamation and reader fixes continue to close:
+A cluster of fixes from v1.3.0-evolve targets the class of bug that only shows up in a program that runs for a long time or recurses deeply, not in a quick test — the same class the arena-reclamation, reader, and region-evacuator fixes since have continued to close:
 
 - **Proper mutual tail calls** (ESH-0102): a call in tail position to another function is emitted as an LLVM `musttail` call, so mutually tail-recursive functions (`even?`/`odd?`-style state machines) run in O(1) stack instead of overflowing after ~300k hops.
 - **Safe teardown** (ESH-0216): `eshkol_runtime_shutdown()` stops and joins the global parallel thread pool before running shutdown hooks, closing a use-after-free race that could `SIGSEGV` well after a graceful `SIGTERM` was already logged; AOT-compiled binaries now also emit the paired runtime shutdown call they were previously skipping entirely.
@@ -102,15 +104,15 @@ Full root-cause detail for each: [CHANGELOG.md](CHANGELOG.md).
 
 ### A hardened, permanent adversarial-testing program
 
-v1.3.0-evolve shipped the testing infrastructure that found and closed the gaps above, wired permanently into the ICC release oracle rather than run once and discarded: a multi-path differential harness with a seeded fuzzer, a feature-pair edge matrix, an AD finite-difference oracle, a stress harness with RSS/time budgets, a VM-parity ratchet, depth-parametric sweeps, and the external reference-Scheme differential oracle described above. See [`docs/TESTING.md`](docs/TESTING.md).
+v1.3.0-evolve shipped the testing infrastructure that found and closed the gaps above — and that this release's adversarial audit used to catch the v1.3.2-evolve `input2` overstatement — wired permanently into the ICC release oracle rather than run once and discarded: a multi-path differential harness with a seeded fuzzer, a feature-pair edge matrix, an AD finite-difference oracle, a stress harness with RSS/time budgets, a VM-parity ratchet, depth-parametric sweeps, and the external reference-Scheme differential oracle described above. See [`docs/TESTING.md`](docs/TESTING.md).
 
 ---
 
 ## Why it matters
 
-Differentiable programming today mostly means "trace a Python function with a library and hope the trace is faithful." Eshkol takes the opposite bet: make the derivative operator part of the language the compiler already understands, so it composes with closures, recursion, control flow, and the numeric tower the same way `+` does — and, since v1.3.0-evolve, at any order, exactly, with a provable error bound when you need one. That is a meaningfully larger AD surface than what JAX or PyTorch expose to user code today, delivered from an ahead-of-time native compiler rather than a runtime tracer.
+Differentiable programming today mostly means "trace a Python function with a library and hope the trace is faithful." Eshkol takes the opposite bet: make the derivative operator part of the language the compiler already understands, so it composes with closures, recursion, control flow, and the numeric tower the same way `+` does — and, since v1.3.0-evolve, at any order, exactly, with a provable error bound when you need one. v1.3.3-evolve's correction matters for the same reason: "exact AD" is a claim that has to hold for every path through the compiler, including the first-class-loss path that v1.3.2-evolve missed, or it isn't exact AD at all. That is a meaningfully larger AD surface than what JAX or PyTorch expose to user code today, delivered from an ahead-of-time native compiler rather than a runtime tracer.
 
-The robustness work in this release matters for a different reason: a differentiable systems language is only useful if the programs built on it can run unattended. Proper tail calls, flat memory in long-running loops, a reader that doesn't overflow the stack on large persisted state, and a shutdown path that doesn't race are the difference between a research demo and something you can leave running as a daemon.
+The region-evacuator work matters for a different, complementary reason: a differentiable systems language is only useful if the programs built on it can run unattended. Proper tail calls, flat memory in long-running loops, a reader that doesn't overflow the stack on large persisted state, a shutdown path that doesn't race, and — as of this release — a region evacuator that correctly promotes every heap subtype a program can allocate (including a `delay`d promise) across a `with-region` boundary are the difference between a research demo and something you can leave running as a daemon.
 
 ## Get started
 
@@ -129,15 +131,15 @@ eshkol-run -r your_file.esk
 - **[Automatic Differentiation guide](docs/guide/AUTOMATIC_DIFFERENTIATION.md)** — the full P0–P12 walkthrough, every example verified against a real build.
 - **[Documentation reference index](docs/reference/language/INDEX.md)** — navigable, example-verified language/AD/runtime/tensor/stdlib/agent reference.
 - **[Eshkol Language Guide](docs/ESHKOL_LANGUAGE_GUIDE.md)** — tutorial introduction to the language.
-- **[CHANGELOG.md](CHANGELOG.md)** — itemized engineering detail, phase by phase.
+- **[CHANGELOG.md](CHANGELOG.md)** — itemized engineering detail, release by release.
 - **[RELEASE_NOTES.md](RELEASE_NOTES.md)** — the user-facing release summary, with the full gate matrix.
 
 ## Under the hood
 
 The Taylor tower represents a function's local behavior as a truncated power series, `f(x0 + t) = Σ c_k · t^k`, so `f⁽ⁿ⁾(x0) = n! · c_n`. Each primitive operator (`+ - * / exp log sin cos sqrt tan atan tanh pow ...`) has a closed recurrence for producing its output series' coefficients from its input series' coefficients — for example, Cauchy convolution for multiplication (`s_k = Σ_{j=0..k} u_j · w_{k-j}`) and a linear recurrence for `exp`/`log`/`sin`/`cos`. Composing these recurrences through a program the way the LLVM backend already composes arithmetic gives arbitrary-order differentiation at `O(k²)` cost, with **zero heap allocation** on the common path: when the order `k` is a literal at the call site — the overwhelmingly common case in a compiler — the entire tower is unrolled into stack-allocated, branch-free SSA IR at compile time. A runtime heap-allocated tower (`HEAP_SUBTYPE_TAYLOR`) is the correctness fallback for a dynamically chosen order.
 
-The per-iteration arena-reclamation fix in this release uses the same style of static escape analysis: a self-tail-recursive loop body (named-let or plain `define`) is proven safe to reclaim per iteration by conservatively checking that nothing escapes the loop's arena scope across the back-edge — a catch-all guard clause is now accepted into that analysis rather than causing the optimization to bail out. The iterative reader fix replaces per-element native recursion in `read_list` with an explicit loop and heap-allocated work list, so the reader's stack usage no longer scales with the length of the list being read.
+The region-evacuator series (ESH-0214a through e) uses a complementary style of static-plus-runtime safety: a self-tail-recursive loop body (named-let or plain `define`) is proven safe to reclaim per iteration by conservatively checking that nothing escapes the loop's arena scope across the back-edge; when something *does* escape a `with-region` boundary — a cons cell, a knowledge base, a factor graph, a workspace, or, as of v1.3.3-evolve, a promise — the evacuator deep-walks its interior pointers and promotes them into the surviving arena rather than leaving them dangling. `ESHKOL_ARENA_POISON=1` turns any remaining gap in that coverage into an immediate, loud crash instead of a silent corruption.
 
 ---
 
-*Eshkol v1.3.1. MIT License. [github.com/tsotchke/eshkol](https://github.com/tsotchke/eshkol)*
+*Eshkol v1.3.3-evolve. MIT License. [github.com/tsotchke/eshkol](https://github.com/tsotchke/eshkol)*

--- a/press/ESHKOL_DESCRIPTION_COPY.md
+++ b/press/ESHKOL_DESCRIPTION_COPY.md
@@ -3,10 +3,12 @@
 ## A compiled Scheme with a constructive proof that a transformer is an interpreter
 
 Eshkol is a compiled programming language for mathematical and cognitive computing.
-The repository ships v1.3.1 (July 2026) of the compiler — an arbitrary-order
-automatic-differentiation system, 100% conformance on a portable R7RS
-differential corpus, and hardening that makes long-running/resident programs
-safe to leave running — together with the reproducibility artefact for
+The repository ships v1.3.3-evolve (July 2026) of the compiler — an arbitrary-order
+automatic-differentiation system with exact gradients now verified through the
+tensor-op `input2` path, 100% conformance on a portable R7RS differential corpus,
+and a region-escape evacuator that makes long-running/resident programs safe to
+leave running across every heap subtype the language can allocate — together
+with the reproducibility artefact for
 *The Self-Differentiating Neural Computer: Computable Transformers via
 Analytical Weight Construction* (tsotchke, 2026), in which a six-layer
 transformer with 12.22 million analytically-constructed parameters executes
@@ -25,7 +27,10 @@ The language treats automatic differentiation, arena memory, and a neuro-symboli
 computation layer as compiler primitives rather than library add-ons. Differentiation
 is available in symbolic, forward, and reverse modes alongside eight vector-calculus
 operators — and, as of v1.3.0-evolve, at arbitrary order via a Taylor-tower engine that
-returns exact bignum/rational derivatives when the math supports it; memory is
+returns exact bignum/rational derivatives when the math supports it, with the
+reverse-mode tensor-op gradient path (`conv2d`/`batchnorm`/`layernorm`/`attention`)
+now verified exact for first-class losses and vector/learnable gamma as of
+v1.3.3-evolve; memory is
 allocated through Ownership-Aware Lexical Regions with deterministic, per-scope
 deallocation and no garbage collector; the consciousness engine exposes twenty-two
 builtins covering unification, factor-graph belief propagation, free-energy
@@ -63,6 +68,17 @@ Each item below cites the file or measurement that grounds the claim.
   recursion. See *lib/core/taylor_recurrences.def*, *lib/core/runtime_taylor.c*, and the
   [Automatic Differentiation guide](../docs/guide/AUTOMATIC_DIFFERENTIATION.md).
 
+- **Exact reverse-mode tensor-op gradients for first-class losses (v1.3.3-evolve).**
+  `gradient` on `conv2d`/`batchnorm`/`layernorm`/`attention` now propagates an exact
+  gradient to the second operand (kernel/gamma-beta/K-V) whether the loss is a
+  compile-time-known function or a first-class value with no compile-time `Function*` —
+  the latter previously fell to a forward-mode-dual closure path that silently returned
+  a zero gradient. Batch-norm/layer-norm gamma/beta are now differentiated per-feature
+  rather than as one scalar, and any remaining unsupported tensor-op backward path
+  raises an explicit error instead of a silent zero. This corrects a prior CHANGELOG
+  entry (#212) that an adversarial finite-difference audit found to be a no-op; the real
+  fix is #229, finite-difference-verified in both literal and first-class forms.
+
 - **Compiler-integrated automatic differentiation (order ≤ 2).** Three modes: symbolic AST
   rewriting at compile time using twelve differentiation rules; forward mode through
   16-byte dual numbers `{value, derivative}`; reverse mode through a computational
@@ -95,6 +111,17 @@ Each item below cites the file or measurement that grounds the claim.
   native-stack overflow (verified clean at 20 million elements, where the prior
   implementation crashed with SIGBUS). See *lib/backend/llvm_codegen.cpp* and
   *lib/core/runtime_reader_hosted.cpp*.
+
+- **Region-escape evacuator closes out across every heap subtype (ESH-0214a-e,
+  complete as of v1.3.3-evolve).** A value allocated inside `with-region` that escapes
+  the region — is returned, stored outward, or captured by a closure — is deep-walked
+  and promoted into the surviving arena instead of being left dangling after the region
+  pops. Coverage was built out subtype by subtype: cons/vector/hash/tensor/exception/
+  closure first, then the logic and global-workspace subtypes (substitution, fact,
+  knowledge base, factor graph, workspace) in v1.3.2-evolve, and `PROMISE` — a
+  `delay`/`make-promise` thunk plus its cached value — in v1.3.3-evolve, completing
+  the series. `ESHKOL_ARENA_POISON=1` poisons freed arena memory so any remaining gap
+  crashes loudly instead of corrupting silently.
 
 - **Neuro-symbolic stack as compiler primitives.** Twenty-two builtins:
   `unify`, `walk`, `make-substitution`, `make-fact`, `make-kb`, `kb-assert!`,
@@ -129,11 +156,12 @@ Each item below cites the file or measurement that grounds the claim.
   removed in v1.2 to eliminate shell-metacharacter exposure), kqueue/inotify
   filesystem watching (*lib/agent/c/agent_watch.c*).
 
-- **Comprehensively documented public API and implementation.** v1.3.1 adds
+- **Comprehensively documented public API and implementation.** v1.3.1-evolve added
   Doxygen-format documentation across 50 of the 64 public headers under
   `inc/eshkol/` (~4,650 lines) and 56 previously-undocumented implementation files
   under `lib/` (~7,478 lines) — 116 files and roughly 12,600 lines total, comments
-  only. A navigable per-subsystem reference index
+  only; v1.3.2-evolve added `eshkol-doc`, which harvests those comments automatically
+  into a generated `docs/api/` reference. A navigable per-subsystem reference index
   (*docs/reference/{language,ad,runtime,tensors,stdlib,agent}/INDEX.md*) organizes
   the language surface for lookup.
 
@@ -141,11 +169,21 @@ Each item below cites the file or measurement that grounds the claim.
   harness — differential, feature-pair edge matrix, AD finite-difference oracle,
   stress (RSS/time budgets), VM-parity ratchet, depth-parametric sweeps, and the
   external reference-Scheme differential oracle — is wired permanently into the ICC
-  release oracle rather than run once and discarded. Release gates green on the
+  release oracle rather than run once and discarded; this is the same infrastructure
+  whose adversarial audit caught the v1.3.2-evolve `input2` overstatement corrected
+  above, and the ICC oracle itself was hardened in v1.3.3-evolve to gate on that
+  correction and on region-evacuator poison coverage. Release gates green on the
   v1.3.0-evolve SHA: ICC readiness oracle 100/100 (trace-verified); CI 14/14 lanes
   including windows-arm64; SICP full-book gate 88/88 probes across all five chapters
   under both `-r` and AOT; reference-Scheme differential oracle 34/34 AGREE. See
   *docs/TESTING.md*.
+
+- **Binary Lambda Calculus (`core.blc`, v1.3.2-evolve).** A pure-Eshkol
+  implementation of John Tromp's BLC: De Bruijn-indexed terms as homoiconic
+  s-expressions, self-delimiting bit encode/decode, normal-order evaluation, a
+  decoded 232-bit universal machine, BLC8 byte I/O, and ASCII lambda diagrams.
+  Loaded on demand via `(require core.blc)`. See
+  *docs/guide/BINARY_LAMBDA_CALCULUS.md*.
 
 ---
 
@@ -244,8 +282,8 @@ release builds produce byte-identical `build/stdlib.bc` and `build/eshkol-run`
 | | |
 |:---|:---|
 | Project | Eshkol |
-| Version | v1.3.1 |
-| Release date | 8 July 2026 (builds on v1.3.0-evolve, 7 July 2026) |
+| Version | v1.3.3-evolve |
+| Release date | 10 July 2026 (builds on v1.3.2-evolve, 9 July 2026; v1.3.1-evolve and v1.3.0-evolve, 7 July 2026) |
 | Implementation | C17 runtime, C++20 compiler |
 | Backend | LLVM 21 (version-enforced) |
 | Platforms | macOS Intel and Apple Silicon, Linux x86-64 and ARM64, Windows x86-64 and ARM64 via Visual Studio 2022 + ClangCL |

--- a/press/ESHKOL_PRESS_INFORMATION_SHEET.md
+++ b/press/ESHKOL_PRESS_INFORMATION_SHEET.md
@@ -1,4 +1,4 @@
-# Eshkol v1.3.1 — Press Information Sheet
+# Eshkol v1.3.3-evolve — Press Information Sheet
 
 For trade-press and academic readers preparing coverage of the v1.3 release
 line — arbitrary-order automatic differentiation, full R7RS conformance,
@@ -12,9 +12,9 @@ carries.
 | | |
 |:---|:---|
 | Project | Eshkol |
-| Version | v1.3.1 |
-| Builds on | v1.3.0-evolve (7 July 2026) |
-| Release date | 8 July 2026 |
+| Version | v1.3.3-evolve |
+| Builds on | v1.3.2-evolve (9 July 2026), v1.3.1-evolve, v1.3.0-evolve (7 July 2026) |
+| Release date | 10 July 2026 |
 | Licence | MIT |
 | Source | https://github.com/tsotchke/eshkol |
 | Website | https://eshkol.ai |
@@ -37,10 +37,16 @@ regenerates in one command on a developer laptop.
 The host language has moved in this release line too: v1.3.0-evolve gave
 Eshkol's automatic differentiation a second axis, arbitrary order, with
 exact bignum/rational derivatives and full R7RS conformance on a portable
-differential corpus; v1.3.1 adds the robustness — flat memory in long-running
-loops, a reader that doesn't overflow the stack on large persisted state —
-that makes an Eshkol program safe to run unattended as a daemon, plus a
-comprehensive documentation pass across the public embedding API.
+differential corpus; v1.3.1-evolve added the robustness — flat memory in
+long-running loops, a reader that doesn't overflow the stack on large
+persisted state — that makes an Eshkol program safe to run unattended as a
+daemon, plus a comprehensive documentation pass across the public embedding
+API. v1.3.2-evolve extended that memory-safety work to the logic/workspace
+heap subtypes and made region scoping thread-safe under `parallel-map`.
+v1.3.3-evolve closes out that series with the last heap subtype, `PROMISE`,
+and — separately — replaces an overstated v1.3.2-evolve automatic-differentiation
+claim with the real fix: exact gradients through the `input2` path for
+first-class losses and vector/learnable gamma.
 
 ---
 
@@ -89,7 +95,7 @@ against chibi-scheme 0.12.0 on a 34-program portable corpus — reports
 The parser handles ninety-four operation types over an S-expression syntax
 with line/column tracking and an R7RS-compliant internal-defines transform
 to `letrec*`. The macro expander supports ellipsis patterns, nested
-patterns, and hygienic renaming. As of v1.3.1, the S-expression reader
+patterns, and hygienic renaming. As of v1.3.1-evolve, the S-expression reader
 (`read_list`) is iterative rather than per-element recursive, so reading
 back a very large persisted list no longer risks a native-stack overflow.
 See *lib/frontend/parser.cpp*, *lib/frontend/macro_expander.cpp*, and
@@ -113,7 +119,7 @@ See *lib/frontend/parser.cpp*, *lib/frontend/macro_expander.cpp*, and
 | Macro expander | 861 | *lib/frontend/macro_expander.cpp* |
 | Type checker | 1,999 | *lib/types/type_checker.cpp* |
 | Arena memory | 6,186 | *lib/core/arena_memory.cpp* |
-| S-expression reader (iterative as of v1.3.1) | 555 | *lib/core/runtime_reader_hosted.cpp* |
+| S-expression reader (iterative as of v1.3.1-evolve) | 555 | *lib/core/runtime_reader_hosted.cpp* |
 | Logic engine | 805 | *lib/core/logic.cpp* |
 | Active-inference engine | 912 | *lib/core/inference.cpp* |
 | Global workspace | 308 | *lib/core/workspace.cpp* |
@@ -121,11 +127,13 @@ See *lib/frontend/parser.cpp*, *lib/frontend/macro_expander.cpp*, and
 | Bytecode VM + runtime libs | ≈41,000 | *lib/backend/eshkol_vm.c* and runtime |
 
 Total compiler infrastructure is approximately 232,000 lines of C17 and C++20
-across more than 130 files (*docs/DESIGN.md §Implementation Scale*). v1.3.1
-adds roughly 12,600 lines of Doxygen-format documentation across 116 files —
+across more than 130 files (*docs/DESIGN.md §Implementation Scale*). v1.3.1-evolve
+added roughly 12,600 lines of Doxygen-format documentation across 116 files —
 50 of the 64 public headers under `inc/eshkol/` (≈4,650 lines) and 56
 previously-undocumented implementation files under `lib/` (≈7,478 lines) —
-comments only, no behaviour change.
+comments only, no behaviour change; v1.3.2-evolve added a further
+`eshkol-doc` reference generator (`docs/api/`) that harvests those comments
+automatically.
 
 ### Target backend
 
@@ -158,12 +166,17 @@ The language occupies a region not covered by the established alternatives.
   obtained through tracing, source-to-source rewriting, or operator
   overloading, and — since v1.3.0-evolve — computes exact derivatives at any
   order via Taylor towers, which JAX's `jax.experimental.jet` approaches only
-  numerically. The host runtime has no garbage collector; allocation is
-  bounded by the arena reset boundary, and as of v1.3.1 self-tail-recursive
-  loops reclaim their arena scope automatically per iteration, which makes
-  Eshkol viable in contexts (real-time control loops, embedded inference,
-  long-running daemons) where Python or Julia's GC pauses, or unbounded
-  process RSS growth, are disqualifying.
+  numerically; as of v1.3.3-evolve those exact gradients also flow correctly
+  through the `input2` path (kernel/gamma/K/V) for first-class losses, not
+  just literal-loss compile-time-known functions. The host runtime has no
+  garbage collector; allocation is bounded by the arena reset boundary, and
+  as of v1.3.1-evolve self-tail-recursive loops reclaim their arena scope
+  automatically per iteration — a region-escape evacuator, completed in
+  v1.3.3-evolve, promotes any heap object that escapes that scope (including
+  logic/workspace state and, as of this release, a `delay`d promise) rather
+  than leaving it dangling — which makes Eshkol viable in contexts (real-time
+  control loops, embedded inference, long-running daemons) where Python or
+  Julia's GC pauses, or unbounded process RSS growth, are disqualifying.
 
 Each comparison is grounded in *docs/breakdown/OVERVIEW.md §Comparison with
 other languages*; the document explicitly enumerates where Eshkol gives less
@@ -182,11 +195,14 @@ consists of:
 - An 8-byte object header prepended to every heap object
   `{subtype:u8, flags:u8, ref_count:u16, size:u32}`. The header is at
   offset −8 from the data pointer returned by allocators.
-- Twenty-four heap-subtype slots assigned through v1.3.1 (slot 14 remains
-  reserved for a future `RULE` backward-chaining type; slot 23 is
+- Twenty-four heap-subtype slots assigned through v1.3.1-evolve (slot 14
+  remains reserved for a future `RULE` backward-chaining type; slot 23 is
   `HEAP_SUBTYPE_TAYLOR`, added in v1.3.0-evolve for the arbitrary-order
   Taylor-tower AD engine) and five callable subtypes, consolidating eight
   historical pointer types into two supertypes (`HEAP_PTR`, `CALLABLE`).
+  As of v1.3.3-evolve every subtype that carries interior pointers —
+  including `PROMISE`, the last one — is deep-walked by the region-escape
+  evacuator rather than shallow-copied on escape from a `with-region` scope.
   See *inc/eshkol/eshkol.h §heap subtypes*.
 - 16-byte tagged values laid out `{type:u8, flags:u8, reserved:u16,
   padding:u32, data:u64}`. When the compiler can prove the type at
@@ -200,14 +216,27 @@ consists of:
   parallel workers; the global arena is used only to construct result
   lists after parallel tasks have completed (*docs/breakdown/PARALLEL_COMPUTING.md §2.1*).
 - **Per-iteration arena-scope reclamation for self-tail-recursive loops**
-  (new coverage in v1.3.1). A conservative static escape analysis
+  (extended in v1.3.1-evolve). A conservative static escape analysis
   (`namedLetIterScopeSafe`) proves a loop body's arena allocations don't
   escape across the tail-call back-edge; when it does, the loop's arena
   scope is reclaimed every iteration with zero source annotation. v1.3.0-evolve
-  covered named-let loops; v1.3.1 extends the same analysis to self-tail-recursive
-  `define` loops and accepts a catch-all guard clause in the loop body. Verified
-  on a 1,000,000-iteration loop: RSS goes from 1,369 MB (unbounded growth) to
-  224 MB (flat). See *lib/backend/llvm_codegen.cpp*.
+  covered named-let loops; v1.3.1-evolve extended the same analysis to
+  self-tail-recursive `define` loops and accepts a catch-all guard clause in
+  the loop body. Verified on a 1,000,000-iteration loop: RSS goes from
+  1,369 MB (unbounded growth) to 224 MB (flat). See
+  *lib/backend/llvm_codegen.cpp*.
+- **Region-escape evacuator** (ESH-0214a through e, completed v1.3.3-evolve).
+  When a value allocated inside a `with-region` block escapes that block
+  (is returned, stored into an outer binding, or captured by a closure), a
+  companion evacuator deep-walks it and promotes its interior pointers into
+  the surviving arena before the region is popped, rather than leaving them
+  dangling. Coverage was built out subtype by subtype: `CONS`/`VECTOR`/
+  `HASH`/`TENSOR`/`EXCEPTION`/`CLOSURE` first, then the logic/workspace
+  subtypes (`SUBSTITUTION`/`FACT`/`KNOWLEDGE_BASE`/`FACTOR_GRAPH`/
+  `WORKSPACE`) in v1.3.2-evolve, and `PROMISE` in v1.3.3-evolve, which closes
+  the series. `ESHKOL_ARENA_POISON=1` poisons `arena_destroy`'d memory so any
+  remaining gap in that coverage crashes loudly instead of corrupting
+  silently. See *lib/core/arena_memory.cpp* and *lib/backend/llvm_codegen.cpp*.
 - Optional linear types via `(owned ...)`, `(borrow value body)`, and
   `(shared ...)`; the third activates reference counting against the
   header's 16-bit `ref_count` field (*README.md §Memory architecture*).
@@ -323,6 +352,22 @@ slowdown, reverse mode 3–5× with O(n) memory, symbolic mode zero runtime
 overhead because the rewrite is at compile time (*README.md §Autodiff
 overhead*). The Taylor-tower engine is O(k²) in the requested order `k` and
 zero-heap when `k` is a compile-time literal.
+
+**Reverse-mode tensor-op gradients (`input2`), corrected in v1.3.3-evolve.**
+`gradient` on `conv2d`, `batchnorm`, `layernorm`, and `attention` propagates
+an exact gradient to the second operand (kernel / gamma-beta / K-V) in both
+the literal-loss form (a compile-time-known `Function*`) and the first-class
+form (a loss value with no compile-time `Function*`, e.g. one selected or
+constructed at runtime); a v1.3.2-evolve CHANGELOG entry had claimed this
+path was already complete, but an adversarial finite-difference audit found
+the change shipped a test and a roadmap update with no gradient code behind
+it — the first-class path still silently returned a zero gradient. The
+v1.3.3-evolve fix adds a reverse-mode tensor path to the closure branch of
+`gradient`'s codegen, wires batch-norm/layer-norm gamma/beta as per-feature
+AD nodes instead of one scalar, and turns any remaining unsupported
+tensor-op backward path into an explicit compile error instead of a silent
+zero. Finite-difference-verified across matmul/conv2d/attention-K-V/
+vector-gamma in both forms.
 
 See the [Automatic Differentiation guide](../docs/guide/AUTOMATIC_DIFFERENTIATION.md)
 for a worked, example-verified walkthrough of all thirteen phases, and
@@ -443,7 +488,7 @@ The scheduler is a per-worker Chase-Lev work-stealing deque
 epoch-based reclamation, three-stage idle backoff (spin / yield / sleep),
 and hardware-aware sizing (`std::thread::hardware_concurrency()`,
 override via `ESHKOL_NUM_THREADS`). See
-*inc/eshkol/backend/work_stealing_deque.h* (documented in v1.3.1) and
+*inc/eshkol/backend/work_stealing_deque.h* (documented in v1.3.1-evolve) and
 *lib/backend/thread_pool.cpp*.
 
 Primitives: `parallel-map`, `parallel-fold`, `parallel-filter`,
@@ -552,8 +597,8 @@ C and exposed to Eshkol through tagged-value calling conventions.
 AOT linking is automatic: `ESHKOL_HOST_AGENT_FFI_LINK_ARGS` in the build
 config is consulted, and the AST is scanned pre-process for require
 declarations so AOT binaries link the HTTP, SQLite, and subprocess
-backends without the user having to specify library flags. v1.3.1 adds
-Doxygen documentation across every agent-FFI implementation file in
+backends without the user having to specify library flags. v1.3.1-evolve
+added Doxygen documentation across every agent-FFI implementation file in
 *lib/agent/c/*.
 
 ---
@@ -564,10 +609,13 @@ Doxygen documentation across every agent-FFI implementation file in
   (`-c -o`), shared library (`--shared-lib`), and WebAssembly (`--wasm`)
   output modes; supports JIT execution (`-r`).
 - **eshkol-repl** — interactive REPL via LLVM OrcJIT, documented as part of
-  the v1.3.1 implementation doc-comment pass. Preloads stdlib functions and
-  globals from precompiled `.o` and `.bc` metadata. The `--machine` mode
+  the v1.3.1-evolve implementation doc-comment pass. Preloads stdlib functions
+  and globals from precompiled `.o` and `.bc` metadata. The `--machine` mode
   emits `EREPL READY` / `DONE` / `FAIL` framing on stderr for warm-worker
   IPC.
+- **eshkol-doc** — API reference generator, added in v1.3.2-evolve. Harvests
+  Doxygen `/** @brief */` comments from `inc/` and `lib/` and generates
+  `docs/api/` (Markdown pages plus an HTML index).
 - **eshkol-pkg** — package manager. TOML manifests, git-based
   registry, recursive submodule discovery. Commands: `init`, `build`,
   `run`, `add`, `clean`.
@@ -579,15 +627,17 @@ Doxygen documentation across every agent-FFI implementation file in
   pytest-format smoke harness under `.icc/`; native Eshkol-aware (accepts
   Eshkol VM step / halt records as `eshkol_vm_step` / `eshkol_vm_halt`
   events; recognises `runtime_event` compact dict form and explicit
-  `kind` JSON records). ICC readiness oracle reports 100/100, trace-verified,
-  on the v1.3.0-evolve release SHA.
+  `kind` JSON records). Hardened in v1.3.3-evolve (#232) to also check
+  region-evacuator poison coverage and the corrected `input2` gradient
+  gate. ICC readiness oracle reports 100/100, trace-verified.
 
 ---
 
 ## Documentation
 
-v1.3.1's principal addition, alongside the memory/reader robustness fixes,
-is documentation coverage:
+v1.3.1-evolve's principal addition, alongside its memory/reader robustness
+fixes, was documentation coverage; v1.3.2-evolve turned that coverage into a
+generated, navigable artefact:
 
 - **Public C-API headers.** Doxygen-format documentation across 50 of the
   64 public headers under `inc/eshkol/` — backend codegen, runtime core,
@@ -608,16 +658,48 @@ is documentation coverage:
   [`agent/`](../docs/reference/agent/INDEX.md), each an example-verified
   index into the corresponding function and syntax reference, linked from
   *README.md §Documentation*.
+- **Generated API reference (`eshkol-doc`, v1.3.2-evolve).** The Doxygen
+  comments above are now harvested automatically into `docs/api/` rather
+  than requiring a hand-maintained index.
 
-Combined, this is 116 files and roughly 12,600 lines of new documentation —
-comments and reference pages only, no behaviour change.
+Combined, the v1.3.1-evolve pass alone is 116 files and roughly 12,600 lines
+of new documentation — comments and reference pages only, no behaviour
+change.
 
 ---
 
 ## Hardening and robustness posture
 
-**v1.3.1 (this release).** Two fixes close the remaining gap between
-"correct" and "safe to run unattended":
+**v1.3.3-evolve (current release).** Corrects an overstated AD claim and
+finishes the region-evacuator series:
+
+- **Exact `input2` gradients for first-class losses and vector/learnable
+  gamma** (#229): the real fix for a v1.3.2-evolve CHANGELOG claim that an
+  adversarial audit found to be a no-op. See *Automatic differentiation*
+  above for the full description.
+- **Region-escape evacuator covers `PROMISE`** (ESH-0214e, #230): closes
+  the ESH-0214 series (a through e). Verified flat at ~116 MB under
+  `ESHKOL_ARENA_POISON=1` over escape-then-force for both `delay` and
+  `make-promise`.
+- **ICC oracle hardening** (#232): the two fixes above are now load-bearing
+  release gates, not one-off verifications.
+
+**v1.3.2-evolve.** Deepened the memory-safety and concurrency work:
+
+- **Region-escape evacuator covers logic/workspace subtypes** (ESH-0214d,
+  #226): `SUBSTITUTION`/`FACT`/`KNOWLEDGE_BASE`/`FACTOR_GRAPH`/`WORKSPACE`
+  are deep-walked on escape instead of shallow-copied; `arena_destroy` is
+  poisoned under `ESHKOL_ARENA_POISON` so region use-after-free crashes
+  loudly.
+- **Thread-safe region scope stack** (#217): `parallel-map`/future
+  callbacks that opened a `with-region` no longer race on the shared
+  current-arena slot.
+- **Three deferred latent bugs triaged** (#215): ESH-0223 (named-let stack
+  overflow at high iteration counts), ESH-0227 (apply-loop SIGBUS),
+  ESH-0228 (`sleep-ms` argument type check).
+
+**v1.3.1-evolve.** Two fixes closed the gap between "correct" and "safe to
+run unattended" that the region-evacuator series above continues:
 
 - **Flat memory in long-running loops** (ESH-0214b): per-iteration
   arena-scope reclamation, previously limited to named-let TCO loops,
@@ -630,7 +712,7 @@ comments and reference pages only, no behaviour change.
   the rewritten reader completes cleanly at the same size.
 
 **v1.3.0-evolve release gates** (green on the release SHA, and the base
-this release builds on): ICC readiness oracle 100/100, trace-verified;
+this release line builds on): ICC readiness oracle 100/100, trace-verified;
 CI 14/14 lanes including windows-arm64 lite/CUDA/XLA; SICP full-book gate
 88/88 probes across all five chapters under both `-r` and AOT
 (`scripts/run_sicp_smoke.sh`); reference-Scheme differential oracle 34/34
@@ -642,7 +724,9 @@ and wired into the ICC release oracle rather than run once and discarded:
 a multi-path differential harness with a seeded fuzzer, a feature-pair
 edge matrix, an AD finite-difference oracle, a stress harness with
 RSS/time budgets, a VM-parity ratchet, depth-parametric sweeps, and the
-external reference-Scheme differential oracle. See *docs/TESTING.md*.
+external reference-Scheme differential oracle. This is the same
+infrastructure whose adversarial audit found the v1.3.2-evolve `input2`
+overstatement above. See *docs/TESTING.md*.
 
 **v1.2-line hardening** (carried forward, unchanged in this release):
 fourteen audit blockers and seven critical/high security fixes closed
@@ -721,6 +805,13 @@ Namespaces:
   isolation, quantum-inspired RNG
 - `web.*` — WASM / DOM API, HTTP fetch
 - `tensor.*` — shape manipulation, stacking, broadcasting helpers
+- `core.blc` — Binary Lambda Calculus, added in v1.3.2-evolve. A pure-Eshkol
+  implementation of John Tromp's BLC: De Bruijn-indexed terms as
+  homoiconic s-expressions, `blc-encode`/`blc-decode` for Tromp's
+  self-delimiting bit encoding, normal-order `blc-eval`, a decoded
+  232-bit universal machine (`blc-U`), BLC8 byte I/O, and ASCII lambda
+  diagrams. Loaded on demand via `(require core.blc)`. See
+  *docs/guide/BINARY_LAMBDA_CALCULUS.md*.
 
 The stdlib uses `LinkOnceODR` linkage so user redefinitions cleanly
 shadow stdlib functions without the historical "duplicate symbol"
@@ -748,7 +839,7 @@ link errors.
 @software{eshkol2026,
   title    = {Eshkol: A Programming Language for Mathematical Computing},
   author   = {tsotchke},
-  version  = {1.3.1},
+  version  = {1.3.3-evolve},
   year     = {2026},
   url      = {https://github.com/tsotchke/eshkol}
 }

--- a/site/static/content/announcement.html
+++ b/site/static/content/announcement.html
@@ -1,22 +1,24 @@
 <h1
-id="eshkol-v1.3.1-flat-memory-for-long-running-programs-and-a-fully-documented-public-api">Eshkol
-v1.3.1 — flat memory for long-running programs, and a fully documented
-public API</h1>
-<p><strong>Eshkol v1.3.1 builds on v1.3.0-evolve’s arbitrary-order
-Taylor-tower automatic differentiation and 100% R7RS conformance with
-what a differentiable systems language needs to run unattended: flat
-memory in long-running resident/daemon workloads, and a comprehensive
-documentation pass across every public header and implementation
-module.</strong></p>
+id="eshkol-v1.3.3-evolve-exact-ad-gradients-for-first-class-losses-and-the-region-evacuator-closeout">Eshkol
+v1.3.3-evolve — exact AD gradients for first-class losses, and the
+region-evacuator closeout</h1>
+<p><strong>Eshkol v1.3.3-evolve corrects an overstated
+automatic-differentiation claim from v1.3.2-evolve with the real fix —
+exact gradients through the <code>input2</code> path for first-class
+losses and vector/learnable gamma — and completes the region-escape
+evacuator series (ESH-0214) by covering the last heap subtype,
+<code>PROMISE</code>.</strong></p>
 <p>Eshkol is Scheme (R7RS) compiled to native code via LLVM, with
 automatic differentiation as a compiler primitive rather than a library.
-Where v1.3.0-evolve took AD from “correct at first and second order” to
-“correct, exact, and validated at <em>every</em> order” and closed out a
-long list of robustness gaps found by a new permanent
-adversarial-testing program, v1.3.1 closes the remaining gap between
-“runs correctly” and “runs unattended for days”: a memory-growth class
-that survived the v1.3.0-evolve TCO-loop hardening, and a native-stack
-overflow on very large persisted data.</p>
+v1.3.2-evolve’s CHANGELOG entry for issue #212 claimed the
+<code>input2</code> gradient path — the second operand of
+<code>conv2d</code>/<code>batchnorm</code>/<code>layernorm</code>/<code>attention</code>
+(kernel / gamma / K / V) — was complete. An adversarial audit run during
+this cycle found that claim was wrong: the v1.3.2 change landed a test
+and a roadmap update, but no gradient code. v1.3.3-evolve ships the
+actual fix, corrects the record in CHANGELOG.md, and — separately —
+finishes the region-evacuator hardening that v1.3.1-evolve and
+v1.3.2-evolve had been closing out one heap subtype at a time.</p>
 <p>Full engineering detail lives in <a
 href="CHANGELOG.md">CHANGELOG.md</a>; the user-facing summary is <a
 href="RELEASE_NOTES.md">RELEASE_NOTES.md</a>; the complete AD
@@ -26,71 +28,117 @@ guide</a>. This document is the release announcement — quotable, and
 every claim below is grounded in shipped code and a real, run
 command.</p>
 <hr />
-<h2 id="whats-new-in-v1.3.1">What’s new in v1.3.1</h2>
-<h3 id="flat-memory-for-resident-and-daemon-workloads">Flat memory for
-resident and daemon workloads</h3>
-<p>v1.3.0-evolve already gave named-let TCO loops automatic,
-zero-annotation per-iteration arena-scope reclamation (ESH-0214). v1.3.1
-closes the remaining case in that same bug class and fixes a second,
-unrelated way a long-running process’s native stack could blow out:</p>
-<ul>
-<li><strong>Self-tail-recursive <code>define</code> loops, including a
-catch-all guard body</strong> (ESH-0214b): the escape analysis that
-makes per-iteration arena reclamation safe now also recognizes
-self-tail-recursive functions written with plain <code>define</code>
-rather than named-let, and accepts a catch-all guard body in that
-analysis rather than declining to optimize it. Verified on a
-1,000,000-iteration loop: RSS goes from 1,369 MB (unbounded growth) to
-224 MB (flat).</li>
-<li><strong>Iterative S-expression reader</strong> (ESH-0191):
-<code>read_list</code>, the core parser routine for reading persisted
-S-expression data back in, was rewritten from one native stack frame per
-list element to an iterative loop. A program that reads back a very
-large persisted data structure — a long checkpoint, a big literal table,
-a large logged fact base — no longer risks a native-stack overflow on
-load. Verified: the pre-fix reader crashed with SIGBUS at 20 million
-elements; the post-fix reader completes cleanly at the same size.</li>
-</ul>
-<p>Together, these are the difference between a program that degrades
-over a long run and one that doesn’t: an Eshkol process built as a
-resident worker or daemon — a long-lived agent loop, a persistent
-server, a checkpoint/restore pipeline — can now run with flat memory
-instead of monitoring RSS and scheduling restarts.</p>
+<h2 id="whats-new-since-v1.3.1-evolve">What’s new since
+v1.3.1-evolve</h2>
 <h3
-id="comprehensive-c-api-and-implementation-documentation">Comprehensive
-C-API and implementation documentation</h3>
-<p>Every public embedding header and every previously-undocumented
-implementation file gets Doxygen-format documentation in this release:
-50 of the 64 public headers under <code>inc/eshkol/</code> (backend
-codegen, runtime core, type system, XLA backend,
-subprocess/macro-expander/qLLM-bridge surfaces, thread pool and
-work-stealing deque, logger, model I/O, platform runtime, runtime
-exports) across six commits, plus 56 previously-undocumented
-implementation files under <code>lib/</code> (agent FFI, the type
-checker, the parser, the REPL, core non-runtime modules, the quantum
-RNG, FFI bridges) across three commits. Combined, that is 116 files and
-roughly 12,600 lines of new documentation — comments only, no behavior
-changes. Anyone embedding <code>libeshkol</code> or reading the
-compiler’s own source now has a documented contract to read instead of
-guessing from call sites.</p>
-<h3 id="a-navigable-documentation-reference-index">A navigable
-documentation reference index</h3>
-<p>A per-subsystem reference index now organizes the language surface
-for lookup rather than linear reading: <a
-href="docs/reference/language/INDEX.md"><code>docs/reference/language/</code></a>,
-<a href="docs/reference/ad/INDEX.md"><code>ad/</code></a>, <a
-href="docs/reference/runtime/INDEX.md"><code>runtime/</code></a>, <a
-href="docs/reference/tensors/INDEX.md"><code>tensors/</code></a>, <a
-href="docs/reference/stdlib/INDEX.md"><code>stdlib/</code></a>, and <a
-href="docs/reference/agent/INDEX.md"><code>agent/</code></a>, each an
-example-verified index into the corresponding function and syntax
-reference. It is linked from <a
-href="README.md#documentation">README.md</a>.</p>
+id="v1.3.3-evolve-exact-ad-gradients-and-the-region-evacuator-series-closes-out">v1.3.3-evolve:
+exact AD gradients, and the region-evacuator series closes out</h3>
+<ul>
+<li><strong>Exact tensor AD gradients for first-class losses and
+vector/learnable gamma; silent-zero backward paths now error instead of
+returning zero</strong> (#229). The real <code>input2</code> fix, in
+three parts: (1) a loss with no compile-time <code>Function*</code> — a
+first-class/higher-order loss — fell to the forward-mode-dual closure
+path, which loses the tangent for tensor ops and silently returned a
+zero gradient; a reverse-mode tensor path was added to the closure
+branch of <code>AutodiffCodegen::gradient</code> to close that. (2)
+Batch-norm/layer-norm now wire per-feature gamma/beta as individual AD
+nodes instead of a single scalar, so vector/learnable gamma
+differentiates correctly rather than only a scalar approximation. (3)
+Any remaining unsupported tensor-op backward path now raises an explicit
+unsupported-op error instead of silently returning zero, honoring
+exact-AD-or-error rather than exact-AD-or-silently-wrong.
+Finite-difference-verified exact in both literal and first-class forms
+across matmul/conv2d/attention-K-V/vector-gamma; autodiff suite 54/54,
+the <code>input2</code> gradient gate 24/24 under both JIT and AOT.</li>
+<li><strong>Region escape evacuator now covers the <code>PROMISE</code>
+heap subtype</strong> (ESH-0214e, #230). Adversarial-audit follow-up to
+ESH-0214d: <code>PROMISE</code> was left a shallow-copied leaf despite
+carrying interior pointers (a thunk and a cached value). A
+<code>delay</code>/<code>make-promise</code> created inside
+<code>with-region</code> that escaped outward dangled after
+<code>region_pop</code>, observable as a segfault or
+<code>car: not a pair</code> under <code>ESHKOL_ARENA_POISON=1</code>
+when the promise was later forced. Fixed by adding an evacuation case
+that walks both interior slots; verified flat at ~116 MB under poison
+over escape-then-force for both <code>delay</code> and
+<code>make-promise</code>. This closes out the ESH-0214 region-evacuator
+series (ESH-0214a through e) that started with
+named-let/<code>define</code>-loop arena reclamation in
+v1.3.1-evolve.</li>
+<li><strong>ICC release-oracle hardening</strong> (#232): the completion
+oracle now checks region-evacuator poison coverage and the corrected
+<code>input2</code> gradient gate, so both fixes above are load-bearing
+release gates going forward, not one-off verifications.</li>
+<li><strong>Subprocess <code>process-wait</code> kqueue lost-wakeup race
+— documented.</strong> The fix itself shipped in v1.3.2-evolve (commit
+<code>8443ddae</code>) but was never recorded in the CHANGELOG until
+now: on macOS, a child that exited before its <code>kevent</code>
+<code>EVFILT_PROC</code> filter was registered could make
+<code>process-wait</code> block for the full timeout and misreport a
+dead process as still running. The fix probes once with
+<code>waitpid(WNOHANG)</code> right after registering the filter (and
+again on the timeout branch) so an already-dead child is reaped
+immediately instead of falling through to a spurious timeout.</li>
+</ul>
+<h3
+id="v1.3.2-evolve-thread-safe-regions-deeper-evacuation-and-new-tooling">v1.3.2-evolve:
+thread-safe regions, deeper evacuation, and new tooling</h3>
+<ul>
+<li><strong>Region escape evacuator now covers logic and workspace
+subtypes</strong> (ESH-0214d, #226): <code>SUBSTITUTION</code>,
+<code>FACT</code>, <code>KNOWLEDGE_BASE</code>,
+<code>FACTOR_GRAPH</code>, and <code>WORKSPACE</code> — the state a
+resident tick loop mutates via the neuro-symbolic stack — are now
+deep-walked on region escape instead of shallow-copied, so a
+<code>with-region</code>-wrapped tick loop can reclaim transient garbage
+per iteration while its escaping knowledge-base/workspace state is
+promoted intact. <code>arena_destroy</code> is now poisoned under
+<code>ESHKOL_ARENA_POISON</code> so a region use-after-free crashes
+loudly instead of passing by luck.</li>
+<li><strong>Thread-safe region scope stack</strong> (#217):
+<code>parallel-map</code>/future callbacks that opened a
+<code>with-region</code> raced on the shared current-arena slot under
+concurrency; the region hijack moved into the runtime with a
+parallel-scope guard.</li>
+<li><strong><code>eshkol-doc</code> — API reference generator</strong>
+(#213): harvests Doxygen <code>/** @brief */</code> comments from
+<code>inc/</code> and <code>lib/</code> and generates
+<code>docs/api/</code>.</li>
+<li><strong><code>core.blc</code> — Binary Lambda Calculus, plus a
+universal machine</strong> (#218): a pure-Eshkol implementation of John
+Tromp’s Binary Lambda Calculus — De Bruijn-indexed terms,
+<code>blc-encode</code>/<code>blc-decode</code>, normal-order
+<code>blc-eval</code> — deepened with <code>(blc-U)</code>, Tromp’s
+232-bit self-interpreter, BLC8 byte I/O, and ASCII lambda diagrams.</li>
+<li><strong>Three deferred latent bugs triaged</strong>: ESH-0223
+(named-let stack overflow at high iteration counts), ESH-0227
+(apply-loop SIGBUS), ESH-0228 (<code>sleep-ms</code> argument type
+check) (#215).</li>
+</ul>
 <hr />
-<h2 id="the-foundation-this-release-runs-on-v1.3.0-evolve">The
-foundation this release runs on: v1.3.0-evolve</h2>
-<h3 id="arbitrary-order-automatic-differentiation">Arbitrary-order
-automatic differentiation</h3>
+<h2
+id="the-foundation-this-release-runs-on-v1.3.1-evolve-and-v1.3.0-evolve">The
+foundation this release runs on: v1.3.1-evolve and v1.3.0-evolve</h2>
+<h3
+id="flat-memory-for-resident-and-daemon-workloads-v1.3.1-evolve">Flat
+memory for resident and daemon workloads (v1.3.1-evolve)</h3>
+<p>The per-iteration arena-reclamation work that the region-evacuator
+series above builds on started here: self-tail-recursive
+<code>define</code> loops, including a catch-all guard body, gained the
+same automatic per-iteration arena-scope reclamation that named-let
+loops already had (ESH-0214b) — verified on a 1,000,000-iteration loop,
+RSS goes from 1,369 MB (unbounded growth) to 224 MB (flat) — and the
+S-expression reader (<code>read_list</code>) was rewritten from one
+native stack frame per list element to an iterative loop, so reading
+back a very large persisted data structure no longer risks a
+native-stack overflow (ESH-0191). v1.3.1-evolve also shipped a
+comprehensive Doxygen documentation pass across every public embedding
+header and most implementation files, plus a navigable per-subsystem
+documentation index.</p>
+<h3
+id="arbitrary-order-automatic-differentiation-v1.3.0-evolve">Arbitrary-order
+automatic differentiation (v1.3.0-evolve)</h3>
 <p>Eshkol’s forward-mode, reverse-mode, and symbolic AD were already
 exact at first and second order. v1.3.0-evolve added a second axis on
 top of that: <strong>order</strong>. A Taylor-tower engine — designed in
@@ -198,8 +246,8 @@ hygienic macros.</p>
 shutdown</h3>
 <p>A cluster of fixes from v1.3.0-evolve targets the class of bug that
 only shows up in a program that runs for a long time or recurses deeply,
-not in a quick test — the same class this release’s arena-reclamation
-and reader fixes continue to close:</p>
+not in a quick test — the same class the arena-reclamation, reader, and
+region-evacuator fixes since have continued to close:</p>
 <ul>
 <li><strong>Proper mutual tail calls</strong> (ESH-0102): a call in tail
 position to another function is emitted as an LLVM <code>musttail</code>
@@ -219,12 +267,14 @@ href="CHANGELOG.md">CHANGELOG.md</a>.</p>
 <h3 id="a-hardened-permanent-adversarial-testing-program">A hardened,
 permanent adversarial-testing program</h3>
 <p>v1.3.0-evolve shipped the testing infrastructure that found and
-closed the gaps above, wired permanently into the ICC release oracle
-rather than run once and discarded: a multi-path differential harness
-with a seeded fuzzer, a feature-pair edge matrix, an AD
-finite-difference oracle, a stress harness with RSS/time budgets, a
-VM-parity ratchet, depth-parametric sweeps, and the external
-reference-Scheme differential oracle described above. See <a
+closed the gaps above — and that this release’s adversarial audit used
+to catch the v1.3.2-evolve <code>input2</code> overstatement — wired
+permanently into the ICC release oracle rather than run once and
+discarded: a multi-path differential harness with a seeded fuzzer, a
+feature-pair edge matrix, an AD finite-difference oracle, a stress
+harness with RSS/time budgets, a VM-parity ratchet, depth-parametric
+sweeps, and the external reference-Scheme differential oracle described
+above. See <a
 href="docs/TESTING.md"><code>docs/TESTING.md</code></a>.</p>
 <hr />
 <h2 id="why-it-matters">Why it matters</h2>
@@ -234,15 +284,21 @@ the opposite bet: make the derivative operator part of the language the
 compiler already understands, so it composes with closures, recursion,
 control flow, and the numeric tower the same way <code>+</code> does —
 and, since v1.3.0-evolve, at any order, exactly, with a provable error
-bound when you need one. That is a meaningfully larger AD surface than
-what JAX or PyTorch expose to user code today, delivered from an
-ahead-of-time native compiler rather than a runtime tracer.</p>
-<p>The robustness work in this release matters for a different reason: a
-differentiable systems language is only useful if the programs built on
-it can run unattended. Proper tail calls, flat memory in long-running
-loops, a reader that doesn’t overflow the stack on large persisted
-state, and a shutdown path that doesn’t race are the difference between
-a research demo and something you can leave running as a daemon.</p>
+bound when you need one. v1.3.3-evolve’s correction matters for the same
+reason: “exact AD” is a claim that has to hold for every path through
+the compiler, including the first-class-loss path that v1.3.2-evolve
+missed, or it isn’t exact AD at all. That is a meaningfully larger AD
+surface than what JAX or PyTorch expose to user code today, delivered
+from an ahead-of-time native compiler rather than a runtime tracer.</p>
+<p>The region-evacuator work matters for a different, complementary
+reason: a differentiable systems language is only useful if the programs
+built on it can run unattended. Proper tail calls, flat memory in
+long-running loops, a reader that doesn’t overflow the stack on large
+persisted state, a shutdown path that doesn’t race, and — as of this
+release — a region evacuator that correctly promotes every heap subtype
+a program can allocate (including a <code>delay</code>d promise) across
+a <code>with-region</code> boundary are the difference between a
+research demo and something you can leave running as a daemon.</p>
 <h2 id="get-started">Get started</h2>
 <pre class="bash"><code>brew tap tsotchke/eshkol &amp;&amp; brew install eshkol</code></pre>
 <p>Or build from source (LLVM 21+, C++20, CMake 3.14+) — see <a
@@ -260,7 +316,7 @@ language/AD/runtime/tensor/stdlib/agent reference.</li>
 <li><strong><a href="docs/ESHKOL_LANGUAGE_GUIDE.md">Eshkol Language
 Guide</a></strong> — tutorial introduction to the language.</li>
 <li><strong><a href="CHANGELOG.md">CHANGELOG.md</a></strong> — itemized
-engineering detail, phase by phase.</li>
+engineering detail, release by release.</li>
 <li><strong><a href="RELEASE_NOTES.md">RELEASE_NOTES.md</a></strong> —
 the user-facing release summary, with the full gate matrix.</li>
 </ul>
@@ -282,16 +338,18 @@ site — the overwhelmingly common case in a compiler — the entire tower
 is unrolled into stack-allocated, branch-free SSA IR at compile time. A
 runtime heap-allocated tower (<code>HEAP_SUBTYPE_TAYLOR</code>) is the
 correctness fallback for a dynamically chosen order.</p>
-<p>The per-iteration arena-reclamation fix in this release uses the same
-style of static escape analysis: a self-tail-recursive loop body
-(named-let or plain <code>define</code>) is proven safe to reclaim per
-iteration by conservatively checking that nothing escapes the loop’s
-arena scope across the back-edge — a catch-all guard clause is now
-accepted into that analysis rather than causing the optimization to bail
-out. The iterative reader fix replaces per-element native recursion in
-<code>read_list</code> with an explicit loop and heap-allocated work
-list, so the reader’s stack usage no longer scales with the length of
-the list being read.</p>
+<p>The region-evacuator series (ESH-0214a through e) uses a
+complementary style of static-plus-runtime safety: a self-tail-recursive
+loop body (named-let or plain <code>define</code>) is proven safe to
+reclaim per iteration by conservatively checking that nothing escapes
+the loop’s arena scope across the back-edge; when something
+<em>does</em> escape a <code>with-region</code> boundary — a cons cell,
+a knowledge base, a factor graph, a workspace, or, as of v1.3.3-evolve,
+a promise — the evacuator deep-walks its interior pointers and promotes
+them into the surviving arena rather than leaving them dangling.
+<code>ESHKOL_ARENA_POISON=1</code> turns any remaining gap in that
+coverage into an immediate, loud crash instead of a silent
+corruption.</p>
 <hr />
-<p><em>Eshkol v1.3.1. MIT License. <a
+<p><em>Eshkol v1.3.3-evolve. MIT License. <a
 href="https://github.com/tsotchke/eshkol">github.com/tsotchke/eshkol</a></em></p>

--- a/site/static/content/api_reference.html
+++ b/site/static/content/api_reference.html
@@ -1,5 +1,5 @@
-<h1 id="eshkol-v1.3.1-api-reference">Eshkol v1.3.1 API Reference</h1>
-<p><strong>Version</strong>: 1.3.1 <strong>Last Updated</strong>:
+<h1 id="eshkol-v1.3.3-api-reference">Eshkol v1.3.3 API Reference</h1>
+<p><strong>Version</strong>: 1.3.3 <strong>Last Updated</strong>:
 2026-07-08 <strong>Audience</strong>: Scientific Computing &amp; AI
 Systems Programming</p>
 <p>This comprehensive reference documents all special forms, functions,

--- a/site/static/content/complete_language_specification.html
+++ b/site/static/content/complete_language_specification.html
@@ -1,6 +1,6 @@
 <h1 id="eshkol-language---complete-technical-specification">Eshkol
 Language - Complete Technical Specification</h1>
-<p><strong>Version:</strong> v1.3.1 <strong>Generated:</strong>
+<p><strong>Version:</strong> v1.3.3 <strong>Generated:</strong>
 2026-07-08 <strong>Status:</strong> Comprehensive implementation
 documentation from source code</p>
 <hr />
@@ -3820,7 +3820,7 @@ Automatic handler cleanup</p>
 <code>provide</code>)</p>
 <hr />
 <h2 id="version-information">26. Version Information</h2>
-<p><strong>Current Version:</strong> v1.3.1</p>
+<p><strong>Current Version:</strong> v1.3.3</p>
 <p><strong>Version History:</strong> - v1.3.1 - Robustness for
 long-running, resident programs: per-iteration arena reclamation for
 define-loops guarded by a catch-all handler, an iterative reader so
@@ -3940,7 +3940,7 @@ exit.</p>
 <hr />
 <h2 id="conclusion">Conclusion</h2>
 <p>This document provides a <strong>complete</strong> specification of
-the Eshkol programming language version v1.3.1, documenting
+the Eshkol programming language version v1.3.3, documenting
 <strong>every</strong> feature, function, operator, and capability found
 in the implementation.</p>
 <p><strong>Total Coverage:</strong> - All 101 special forms and parser

--- a/site/static/content/contributing.html
+++ b/site/static/content/contributing.html
@@ -223,6 +223,21 @@ return values.</li>
 <li>Keep the README and other high-level documentation up to date.</li>
 <li>Use Markdown for all documentation files.</li>
 </ul>
+<h4 id="api-reference-docsapi">API Reference (docs/api/)</h4>
+<p><code>docs/api/</code> is a generated browsable reference for the
+public C/C++ headers under <code>inc/eshkol/**/*.h</code>, harvested
+from their Doxygen <code>/** @brief ... */</code> comment blocks by
+<code>scripts/gen_api_docs.py</code>. It is not hand-edited.</p>
+<p>When you add or change a Doxygen comment on a public header symbol,
+regenerate the reference and commit the result alongside your
+change:</p>
+<pre class="sh"><code>make api-docs          # regenerate docs/api/
+make api-docs-check    # verify docs/api/ has no drift (used before a PR)</code></pre>
+<p>The generator is documentation-only — it never modifies files under
+<code>inc/</code> — and its output is deterministic (sorted, stable
+across re-runs), so a regeneration with no underlying comment changes
+produces an empty diff. It is not run automatically in CI; regenerate
+locally when you touch a header comment.</p>
 <h3 id="testing">Testing</h3>
 <p>We strive for good test coverage:</p>
 <ul>
@@ -296,7 +311,7 @@ reviews.</li>
 Contribution (v1.4+)</h2>
 <p>v1.0-foundation, v1.1-accelerate, v1.2-scale, and v1.3.0-evolve
 (arbitrary-order AD, full R7RS conformance, closure/TCO/memory
-hardening) are <strong>complete</strong>, and v1.3.1 has landed further
+hardening) are <strong>complete</strong>, and v1.3.3 has landed further
 robustness for long-running, resident programs plus comprehensive C-API
 documentation. We welcome contributions for upcoming releases:</p>
 <h3 id="immediate-priorities-v1.4-connection---july-2026">Immediate

--- a/site/static/content/eshkol_language_guide.html
+++ b/site/static/content/eshkol_language_guide.html
@@ -1146,7 +1146,7 @@ detection</li>
 :history   Show command history</code></pre>
 <h3 id="example-session">Example Session</h3>
 <pre><code>$ ./eshkol-repl
-Eshkol REPL v1.3.1
+Eshkol REPL v1.3.3
 Type :help for assistance, :quit to exit
 
 eshkol&gt; (define (square x) (* x x))
@@ -1696,6 +1696,6 @@ integration</label></li>
 <p>MIT License - Copyright (C) tsotchke</p>
 <hr />
 <p align="center">
-<strong>Eshkol v1.3.1</strong>: Where functional programming meets
+<strong>Eshkol v1.3.3</strong>: Where functional programming meets
 scientific computing, GPU acceleration, and machine consciousness.
 </p>

--- a/site/static/content/eshkol_quick_reference.html
+++ b/site/static/content/eshkol_quick_reference.html
@@ -1,5 +1,5 @@
 <h1 id="eshkol-quick-reference-card">Eshkol Quick Reference Card</h1>
-<p><strong>v1.3.1</strong> – 555+ built-in functions</p>
+<p><strong>v1.3.3</strong> – 555+ built-in functions</p>
 <h2 id="basics">Basics</h2>
 <pre class="scheme"><code>;; Variables
 (define x 42)

--- a/site/static/content/feature_matrix.html
+++ b/site/static/content/feature_matrix.html
@@ -1,4 +1,4 @@
-<h1 id="eshkol-v1.3.1-feature-matrix">Eshkol v1.3.1 Feature Matrix</h1>
+<h1 id="eshkol-v1.3.3-feature-matrix">Eshkol v1.3.3 Feature Matrix</h1>
 <p><strong>Status Key</strong>: ✅ Production | 🚧 In Progress | 📋
 Planned | ❌ Not Planned</p>
 <p>This matrix documents all implemented and planned features for the
@@ -3994,6 +3994,6 @@ JAX/PyTorch (AD implementation insights) - Julia (technical computing
 design patterns)</p>
 <hr />
 <p><strong>Last Updated</strong>: 2026-07-08 <strong>Document
-Version</strong>: 1.3.1</p>
+Version</strong>: 1.3.3</p>
 <p>For detailed API documentation, see <a
 href="API_REFERENCE.md">API_REFERENCE.md</a></p>

--- a/site/static/content/roadmap.html
+++ b/site/static/content/roadmap.html
@@ -502,12 +502,23 @@ handling, no vendoring</strong>: image I/O uses native platform/system
 codec APIs (ImageIO/CoreGraphics on macOS, system libpng/libjpeg/libwebp
 on Linux, GDI+ on Windows). Going forward the project does not vendor
 third-party media decoders.</label></li>
-<li><label><input type="checkbox" checked="" />AD <code>input2</code>
-plumbing for <code>tensor-matmul</code> — verified by
-<code>gradient</code> smoke probe: gradient flows to the kernel side
-(input2). Conv2d / batchnorm / layernorm / attention forward sites still
-leave <code>input2</code> null in their tape nodes and are tracked
-separately.</label></li>
+<li><label><input type="checkbox" checked="" />AD second-operand
+(<code>input2</code>) gradient plumbing for every tensor op —
+<code>tensor-matmul</code>, <code>conv2d</code>,
+<code>batch-norm</code>, <code>layer-norm</code>, and
+<code>scaled-dot-attention</code>. Each op’s AD forward path unrolls
+into the scalar reverse-mode graph (<code>recordADNodeBinary</code>), so
+gradients flow to the second differentiable operand (matmul kernel,
+conv2d kernel, norm gamma, attention K/V) with no monolithic tape node
+left with a null <code>input2</code>. Verified end-to-end by the
+finite-difference AD oracle
+<code>tests/v1_3_edge_cases/ad_input2_test.esk</code> and smoke probes
+<code>ad_input2_conv2d_grad_works</code> /
+<code>ad_input2_batchnorm_grad_works</code> /
+<code>ad_input2_layernorm_grad_works</code> /
+<code>ad_input2_attention_grad_works</code> (JIT <code>-r</code> and
+AOT), which compare the AD gradient to central finite differences at
+tight tolerance.</label></li>
 <li><label><input type="checkbox" checked="" /><strong>Arbitrary-order
 AD Taylor-tower campaign — fully delivered, all 13 phases (P0-P12), well
 ahead of the original P1-only-in-v1.3 plan below</strong>: runtime tower

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Eshkol — R7RS Scheme on LLVM 21 with AD as a compiler primitive</title>
-  <meta name="description" content="Eshkol is R7RS Scheme compiled to native code via LLVM 21, with automatic differentiation as a compiler primitive and a 22-builtin neuro-symbolic stack. v1.3.1 carries the Self-Differentiating Neural Computer constructive proof forward with hardening for long-running, resident programs.">
+  <meta name="description" content="Eshkol is R7RS Scheme compiled to native code via LLVM 21, with automatic differentiation as a compiler primitive and a 22-builtin neuro-symbolic stack. v1.3.3-evolve carries the Self-Differentiating Neural Computer constructive proof forward with exact tensor-gradient and region-memory correctness fixes for long-running, resident programs.">
   <meta property="og:title" content="Eshkol — R7RS Scheme with AD as a compiler primitive">
-  <meta property="og:description" content="Compiler-native automatic differentiation, zero garbage collection, heterogeneous GPU dispatch, and the SDNC constructive proof. v1.3.1.">
+  <meta property="og:description" content="Compiler-native automatic differentiation, zero garbage collection, heterogeneous GPU dispatch, and the SDNC constructive proof. v1.3.3-evolve.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://eshkol.ai">
   <meta property="og:image" content="https://eshkol.ai/img/og-image.png">
@@ -15,7 +15,7 @@
   <meta property="og:image:alt" content="Eshkol logo — a stylized grape cluster">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Eshkol — R7RS Scheme with AD as a compiler primitive">
-  <meta name="twitter:description" content="Compiler-native automatic differentiation, zero garbage collection, heterogeneous GPU dispatch, and the SDNC constructive proof. v1.3.1.">
+  <meta name="twitter:description" content="Compiler-native automatic differentiation, zero garbage collection, heterogeneous GPU dispatch, and the SDNC constructive proof. v1.3.3-evolve.">
   <meta name="twitter:image" content="https://eshkol.ai/img/og-image.png">
   <meta name="theme-color" content="#7c3aed">
   <link rel="icon" href="img/favicon.ico" sizes="any">


### PR DESCRIPTION
## Summary

The website (`site/`) and press materials (`press/`, `ANNOUNCEMENT.md`) still described v1.3.1, predating the v1.3.2-evolve and v1.3.3-evolve release cycles. This brings them current, using `CHANGELOG.md` ([1.3.2-evolve] / [1.3.3-evolve]) and `RELEASE_NOTES.md` as the source of truth.

- `ANNOUNCEMENT.md` rewritten as the v1.3.3-evolve release announcement: the corrected `input2` AD-gradient fix (#229, which replaces an overstated v1.3.2-evolve claim about #212), the `PROMISE` region-escape evacuator that closes out the ESH-0214 series (#230), ICC oracle hardening (#232), plus a summary of what v1.3.2-evolve shipped (thread-safe region scoping #217, logic/workspace evacuator coverage #226, `eshkol-doc` #213, the BLC universal machine #218).
- `press/ESHKOL_PRESS_INFORMATION_SHEET.md` and `press/ESHKOL_DESCRIPTION_COPY.md` updated to match: version/identity tables, the region-evacuator narrative, and a corrected description of the `input2` AD fix (explicitly noting the v1.3.2-evolve claim was found to be a no-op by an adversarial audit).
- `site/static/content/*.html` regenerated via `scripts/build-site-content.sh` from the `docs/*.md` / `ROADMAP.md` / `CONTRIBUTING.md` sources, which had already been bumped to v1.3.3 in the release commit but never re-rendered into the site's HTML fragments.
- `site/static/index.html` meta description/OG tags bumped from v1.3.1 to v1.3.3-evolve (hand-maintained HTML, not generated).

## Known limitation — WASM rebuild blocked by a pre-existing compiler regression

`site/src/main.esk` (the hero copy, "What's new" panel, and REPL banner) still says v1.3.1, and `site/static/eshkol-site.wasm` is unchanged. I attempted the update per the standard rule (main.esk changes require `scripts/build-site.sh` + a regenerated, committed `.wasm`), but discovered the current compiler produces a ~21.6MB WASM module for `main.esk`, versus the ~834KB checked-in artifact — a 26x regression that blows through the Pages workflow's hard 5MB gate (`.github/workflows/pages.yml`) and would fail `Validate committed site bundle`.

I confirmed this is **not** caused by this change: rebuilding the unmodified, currently-checked-in `main.esk` (from the commit that produced the 834KB artifact) with today's compiler binary reproduces the same ~21.6MB output. This is a pre-existing `--wasm` codegen regression on `master`, unrelated to site copy, and needs its own investigation — out of scope for a docs/press update. I left `main.esk` and the `.wasm` untouched rather than ship either a stale-paired regeneration or an oversized artifact that fails CI.

## Test plan

- [x] Reviewed regenerated `site/static/content/*.html` diffs — version-string and previously-unrendered content only (e.g. the `eshkol-doc` section in `contributing.html`), no formatting noise.
- [x] Reproduced the WASM bloat against an unmodified historical `main.esk` to confirm it predates this branch.
- [ ] CI (site pairing/size gate, doc-only paths-ignore build matrix).