### PR TITLE
perf(codegen): optimize generated artifacts by default (O2)

### DIFF
--- a/bench/pgo_corpus/arithmetic.esk
+++ b/bench/pgo_corpus/arithmetic.esk
@@ -1,0 +1,39 @@
+;; PGO training corpus — arithmetic / numeric hot paths.
+;;
+;; Exercises the integer + floating-point arithmetic codegen, recursion,
+;; tail calls, and the bignum dispatch path. Deterministic and offline:
+;; the program prints checksums so the workload driver can confirm the
+;; instrumented binary actually executed (not just linked).
+
+;; Tight integer loop — TCO + add/mul/compare dispatch.
+(define (sum-to n acc)
+  (if (= n 0) acc (sum-to (- n 1) (+ acc n))))
+
+;; Floating-point accumulation — packDouble / unpackDouble round-trips.
+(define (fsum i n acc)
+  (if (>= i n) acc (fsum (+ i 1) n (+ acc (* (exact->inexact i) 1.5)))))
+
+;; Recursive factorial — drives the bignum promotion path past 2^63.
+(define (fact n)
+  (if (<= n 1) 1 (* n (fact (- n 1)))))
+
+;; Newton's method square root — mixes div / compare on doubles.
+(define (newton-sqrt x guess iters)
+  (if (= iters 0)
+      guess
+      (newton-sqrt x (/ (+ guess (/ x guess)) 2.0) (- iters 1))))
+
+(define (run)
+  (let loop ((k 0) (checksum 0))
+    (if (= k 200)
+        checksum
+        (loop (+ k 1)
+              (+ checksum
+                 (sum-to 500 0)
+                 (modulo (* k 7) 13))))))
+
+(display "arith.sum-to=")   (display (sum-to 1000 0))            (newline)
+(display "arith.fsum=")     (display (fsum 0 2000 0.0))          (newline)
+(display "arith.fact25=")   (display (fact 25))                  (newline)
+(display "arith.sqrt2=")    (display (newton-sqrt 2.0 1.0 20))   (newline)
+(display "arith.checksum=") (display (run))                      (newline)

--- a/bench/pgo_corpus/autodiff.esk
+++ b/bench/pgo_corpus/autodiff.esk
@@ -1,0 +1,40 @@
+;; PGO training corpus — automatic-differentiation hot paths.
+;;
+;; Exercises forward-mode derivative, reverse-mode gradient (scalar and
+;; vector), and a small gradient-descent loop — the dual-number /
+;; AD-node codegen that the v1.3 release leans on heavily.
+
+;; Scalar forward-mode derivative.
+(define f (lambda (x) (* x (* x x))))          ; x^3
+(define df (derivative f))
+
+;; Scalar reverse-mode gradient.
+(define g (lambda (x) (+ (* x (* x x)) (* 2.0 x))))  ; x^3 + 2x
+
+;; Vector gradient of a quadratic bowl: sum(x_i^2).
+(define (bowl v)
+  (+ (* (vector-ref v 0) (vector-ref v 0))
+     (* (vector-ref v 1) (vector-ref v 1))))
+
+;; Gradient-descent loop on the bowl — repeatedly calls `gradient`.
+(define (descend v0 lr iters)
+  (let loop ((v v0) (i 0))
+    (if (= i iters)
+        v
+        (let ((gr (gradient bowl v)))
+          (loop (vector (- (vector-ref v 0) (* lr (vector-ref gr 0)))
+                        (- (vector-ref v 1) (* lr (vector-ref gr 1))))
+                (+ i 1))))))
+
+(define (run)
+  (let loop ((k 0) (acc 0.0))
+    (if (= k 150)
+        acc
+        (loop (+ k 1) (+ acc (df (exact->inexact (+ k 1))))))))
+
+(define final (descend #(3.0 -4.0) 0.1 50))
+
+(display "ad.df5=")     (display (df 5.0))            (newline)
+(display "ad.grad3=")   (display (gradient g 3.0))    (newline)
+(display "ad.descent=") (display (vector-ref final 0)) (newline)
+(display "ad.run=")     (display (run))               (newline)

--- a/bench/pgo_corpus/lists.esk
+++ b/bench/pgo_corpus/lists.esk
@@ -1,0 +1,35 @@
+;; PGO training corpus — list / cons-cell hot paths.
+;;
+;; Exercises cons/car/cdr, map/filter/fold over the stdlib, and recursive
+;; list construction — the allocator + tagged-value cons path that almost
+;; every Eshkol program leans on.
+
+(require core.list.transform)
+(require core.list.fold)
+
+;; Build a list [1..n] without relying on iota (keep it self-contained).
+(define (range n)
+  (let loop ((i n) (acc '()))
+    (if (= i 0) acc (loop (- i 1) (cons i acc)))))
+
+;; Manual sum fold — recursion over cons cells.
+(define (list-sum xs)
+  (if (null? xs) 0 (+ (car xs) (list-sum (cdr xs)))))
+
+(define (run)
+  (let loop ((k 0) (total 0))
+    (if (= k 300)
+        total
+        (let* ((xs    (range 100))
+               (sq    (map (lambda (x) (* x x)) xs))
+               (evens (filter (lambda (x) (= (modulo x 2) 0)) sq))
+               (s     (fold-left + 0 evens)))
+          (loop (+ k 1) (+ total s))))))
+
+(define base (range 50))
+
+(display "list.len=")     (display (length base))               (newline)
+(display "list.sum=")     (display (list-sum base))             (newline)
+(display "list.reverse=") (display (car (reverse base)))        (newline)
+(display "list.map=")     (display (list-sum (map (lambda (x) (+ x 1)) base))) (newline)
+(display "list.run=")     (display (run))                       (newline)

--- a/bench/pgo_corpus/strings.esk
+++ b/bench/pgo_corpus/strings.esk
@@ -1,0 +1,30 @@
+;; PGO training corpus — string hot paths.
+;;
+;; Exercises string-append, substring, number->string, string->number,
+;; string-length and char iteration — the string-layer codegen with its
+;; header.size bookkeeping that several past bugs touched.
+
+(define (repeat s n)
+  (let loop ((i 0) (acc ""))
+    (if (>= i n) acc (loop (+ i 1) (string-append acc s)))))
+
+(define (digits-of n)
+  (number->string n))
+
+(define (run)
+  (let loop ((k 0) (total 0))
+    (if (= k 400)
+        total
+        (let* ((s   (string-append "row-" (number->string k) "-end"))
+               (len (string-length s))
+               (mid (substring s 0 (min 3 len)))
+               (rt  (string->number (number->string k))))
+          (loop (+ k 1) (+ total len (string-length mid) rt))))))
+
+(define banner (repeat "ab" 64))
+
+(display "str.banner-len=") (display (string-length banner))          (newline)
+(display "str.upcase=")     (display (string-upcase "eshkol"))        (newline)
+(display "str.sub=")        (display (substring banner 0 8))          (newline)
+(display "str.num=")        (display (digits-of 1234567890))          (newline)
+(display "str.run=")        (display (run))                           (newline)

--- a/bench/pgo_corpus/tensors.esk
+++ b/bench/pgo_corpus/tensors.esk
@@ -1,0 +1,22 @@
+;; PGO training corpus — tensor / linear-algebra hot paths.
+;;
+;; Exercises tensor construction, reshape, element-wise ops, matmul and
+;; reductions — the homogeneous-double tensor codegen + BLAS/SIMD dispatch.
+
+(define A (reshape #(1.0 2.0 3.0 4.0 5.0 6.0) 2 3))
+(define B (reshape #(7.0 8.0 9.0 10.0 11.0 12.0) 3 2))
+
+(define (run)
+  (let loop ((k 0) (acc 0.0))
+    (if (= k 250)
+        acc
+        (let* ((C (tensor-matmul A B))
+               (D (tensor-add C C))
+               (s (tensor-sum D)))
+          (loop (+ k 1) (+ acc s))))))
+
+(display "tensor.matmul-sum=") (display (tensor-sum (tensor-matmul A B))) (newline)
+(display "tensor.mean=")       (display (tensor-mean A))                  (newline)
+(display "tensor.max=")        (display (tensor-max A))                   (newline)
+(display "tensor.add-sum=")    (display (tensor-sum (tensor-add A A)))    (newline)
+(display "tensor.run=")        (display (run))                            (newline)

--- a/docs/design/adr/0007-performance-pgo-wpo.md
+++ b/docs/design/adr/0007-performance-pgo-wpo.md
@@ -795,6 +795,35 @@ may not be loosened without a reviewed result artifact and rationale.
 Exit criterion: one command produces a reproducible baseline report, and
 structural failures are distinguishable from timing regressions.
 
+#### Phase 0 implementation status
+
+Landed:
+
+- The generated-code default is no longer O0 for artifacts. Paths that produce
+  a persisted artifact (`-o` AOT binary, `-c` object, `--shared-lib`) now
+  default to O2, closing the sleeper gap where a Release compiler still emitted
+  unoptimized binaries ([`exe/eshkol-run.cpp`](../../../exe/eshkol-run.cpp), the
+  post-getopt default-resolution block). Ephemeral/interactive paths (plain
+  run, `-r`, `-e`, REPL) and `-g` debug builds stay at O0 for fast turnaround,
+  because whole-module optimization folds in referenced stdlib and costs far
+  more compile time than a single ephemeral run recovers. An explicit `-O<n>`
+  always wins; performance artifacts pass `-O3` explicitly as this phase
+  requires.
+- A structural assertion pins that contract:
+  [`scripts/run_codegen_optlevel_tests.sh`](../../../scripts/run_codegen_optlevel_tests.sh)
+  parses the backend's applied-level log and fails if `-o`/`-c` stop defaulting
+  to O2, if a plain run starts optimizing, or if an explicit `-O` is ignored. It
+  is wired into `run_all_tests.sh`.
+- A first PGO training corpus of hot-path programs is checked in at
+  [`bench/pgo_corpus/`](../../../bench/pgo_corpus) (arithmetic, autodiff, lists,
+  strings, tensors) for later native/IR PGO training.
+
+Deferred to a dedicated follow-up (kept out of this change to avoid displacing
+the O0->O2 fix, per "PGO is the last multiplier, not a substitute"): the
+versioned JSON result runner with machine metadata and paired A/B comparison,
+the separate training/holdout manifests, the Layer 0 staged counters, and the
+per-CPU-class non-PGO baselines.
+
 ### Phase 1: native PGO release workflow
 
 - Target-scope instrumentation/use flags and propagate the instrumentation

--- a/exe/eshkol-run.cpp
+++ b/exe/eshkol-run.cpp
@@ -3715,6 +3715,7 @@ int main(int argc, char **argv)
     uint8_t unsafe_mode = 0;
     uint8_t debug_info = 0;  // -g flag: emit DWARF debug info for lldb/gdb
     int opt_level = 0;       // -O flag: LLVM optimization level (0-3)
+    bool opt_level_explicit = false;  // true once the user passes an explicit -O
 
     std::vector<char*> source_files;
     std::vector<char*> compiled_files;
@@ -3798,6 +3799,7 @@ int main(int argc, char **argv)
                 fprintf(stderr, "Invalid optimization level: %s (must be 0-3)\n", optarg);
                 return 1;
             }
+            opt_level_explicit = true;
             break;
         case 256:
             strict_types = 1;
@@ -3894,6 +3896,32 @@ int main(int argc, char **argv)
         default:
             print_help(1);
         }
+    }
+
+    // Default optimization level for GENERATED code.
+    //
+    // A CMake Release build of the compiler does NOT imply optimized *emitted*
+    // Eshkol code: the backend optimization plane is independent of how the
+    // compiler itself was built (ADR 0007, "Generated code has an independent
+    // optimization plane"). Historically this defaulted to O0, so even
+    // `eshkol-run file.esk -o bin` produced unoptimized artifacts.
+    //
+    // Optimize the paths that PRODUCE a persisted artifact (-o AOT binary,
+    // -c object, --shared-lib), where the user is building something to keep
+    // and run repeatedly, so the "sleeper" O0 default no longer ships
+    // unoptimized binaries. Leave the ephemeral/interactive paths (plain run,
+    // -r JIT, -e eval, REPL) and debug builds (-g) at O0 for fast turnaround:
+    // for those, whole-module optimization (which folds in referenced stdlib)
+    // costs far more compile time than a single ephemeral execution saves.
+    // An explicit -O<n> always wins on every path, including -O0 to opt out
+    // and -O3 for a performance artifact.
+    //
+    // AD/gradient correctness is unaffected: the default pipeline enables no
+    // fast-math or reassociation; only inlining/DCE/vectorization change.
+    if (!opt_level_explicit) {
+        const bool builds_artifact =
+            (output != nullptr) || compile_only || shared_lib;
+        opt_level = (builds_artifact && !debug_info) ? 2 : 0;
     }
 
     {

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -138,6 +138,7 @@ TEST_SCRIPTS=(
     "run_benchmark_tests.sh"
     "run_migration_tests.sh"
     "run_codegen_tests.sh"
+    "run_codegen_optlevel_tests.sh"
     "run_numeric_tests.sh"
     "test_run_sicp_smoke_gate.sh"
     "run_v1_2_edge_cases_tests.sh"

--- a/scripts/run_codegen_optlevel_tests.sh
+++ b/scripts/run_codegen_optlevel_tests.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+# Eshkol Generated-Code Optimization-Level Test Suite
+#
+# Regression guard for the "sleeper" O0 default (ADR 0007, Phase 0:
+# "Make every performance build record and assert generated-code O3").
+#
+# A CMake Release build of the compiler does NOT imply optimized *emitted*
+# Eshkol code -- the backend optimization plane is independent of how the
+# compiler was built. Historically the default was O0, so even
+# `eshkol-run file.esk -o bin` shipped unoptimized binaries. These assertions
+# pin the intended behaviour so a regression is caught:
+#
+#   * artifact-producing paths (-o / -c / --shared-lib) default to O2;
+#   * ephemeral run paths (plain run, no -o) stay at O0 for fast turnaround;
+#   * -g (debug) stays unoptimized unless -O is explicit;
+#   * an explicit -O<n> always wins.
+#
+# The backend prints its applied level via the -d info log
+# ("Applied LLVM optimization passes at -O<n>" / "Applied LLVM O0 cleanup
+# passes"), which this suite parses as the observable.
+
+# NOTE: no `set -e` -- we tally failures and report a summary like the
+# other suites so run_all_tests.sh can aggregate our Passed/Failed counts.
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+declare -a FAILED_TESTS
+
+echo "========================================="
+echo "  Eshkol Generated-Code Opt-Level Tests"
+echo "========================================="
+echo ""
+
+BUILD_DIR="${BUILD_DIR:-build}"
+if [ ! -d "$BUILD_DIR" ] || [ ! -f "$BUILD_DIR/eshkol-run" ]; then
+    echo -e "${RED}Error: Build directory not found or eshkol-run missing.${NC}"
+    echo "Please build first: cd build && cmake .. && make -j8"
+    exit 1
+fi
+RUN="./$BUILD_DIR/eshkol-run"
+echo -e "${GREEN}Using build directory: $BUILD_DIR${NC}"
+echo ""
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PROBE="$WORK/optlevel_probe.esk"
+cat > "$PROBE" <<'EOF'
+(define (sq x) (* x x))
+(display (sq 21))
+(newline)
+EOF
+
+# Assert that the applied backend opt level matches an expected marker.
+#   $1 = human-readable case name
+#   $2 = expected marker (extended regex) in the -d log
+#   $3.. = eshkol-run arguments
+check_level() {
+    local name="$1"; shift
+    local expected="$1"; shift
+    printf "Testing %-52s " "$name"
+
+    local log="$WORK/log.txt"
+    "$RUN" -d -L"./$BUILD_DIR" "$@" > "$log" 2>&1
+
+    if grep -qE "$expected" "$log"; then
+        echo -e "${GREEN}PASS${NC}"
+        ((PASS++)) || true
+    else
+        echo -e "${RED}ASSERTION FAIL${NC}"
+        echo "    expected marker: $expected"
+        echo "    got:"
+        grep -iE "Applied LLVM|cleanup passes" "$log" | head -3 | sed 's/^/      /'
+        FAILED_TESTS+=("$name")
+        ((FAIL++)) || true
+    fi
+}
+
+# Assert that NO optimizing pipeline was applied (O0 / debug path). The O0
+# path prints "Applied LLVM O0 cleanup passes" (or nothing on targets that
+# skip cleanup), so the invariant is: never an "at -O2/-O3" line.
+check_not_optimized() {
+    local name="$1"; shift
+    printf "Testing %-52s " "$name"
+
+    local log="$WORK/log.txt"
+    "$RUN" -d -L"./$BUILD_DIR" "$@" > "$log" 2>&1
+
+    if grep -qE "optimization passes at -O[123]" "$log"; then
+        echo -e "${RED}ASSERTION FAIL${NC}"
+        echo "    expected O0 / unoptimized, but got:"
+        grep -iE "Applied LLVM" "$log" | head -3 | sed 's/^/      /'
+        FAILED_TESTS+=("$name")
+        ((FAIL++)) || true
+    else
+        echo -e "${GREEN}PASS${NC}"
+        ((PASS++)) || true
+    fi
+}
+
+OUT="$WORK/out.bin"
+OBJ="$WORK/out.o"
+
+# --- Default opt level: the sleeper-bug guard ------------------------------
+check_level  "AOT -o default is O2"          "optimization passes at -O2"  "$PROBE" -o "$OUT"
+check_level  "-c compile-only default is O2" "optimization passes at -O2"  -c "$PROBE" -o "$OBJ"
+check_not_optimized "plain run (no -o) stays O0"                            "$PROBE"
+
+# --- Explicit -O always wins ----------------------------------------------
+check_level  "-o -O3 is O3"                  "optimization passes at -O3"  -O3 "$PROBE" -o "$OUT"
+check_level  "-o -O1 is O1"                  "optimization passes at -O1"  -O1 "$PROBE" -o "$OUT"
+check_not_optimized "-o -O0 opts out"                                      -O0 "$PROBE" -o "$OUT"
+
+# --- Debug stays unoptimized ----------------------------------------------
+check_not_optimized "-o -g stays unoptimized"                              -g "$PROBE" -o "$OUT"
+
+echo ""
+echo "========================================="
+echo "  Opt-Level Test Results Summary"
+echo "========================================="
+TOTAL=$((PASS + FAIL))
+echo "Total Tests:    $TOTAL"
+echo -e "${GREEN}Passed:         $PASS${NC}"
+echo -e "${RED}Failed:         $FAIL${NC}"
+echo ""
+
+if [ $FAIL -gt 0 ]; then
+    echo "Failed Tests:"
+    for t in "${FAILED_TESTS[@]}"; do
+        echo "  - $t"
+    done
+    echo ""
+    echo -e "${RED}Some opt-level assertions failed.${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}All opt-level assertions passed!${NC}"
+exit 0


### PR DESCRIPTION
## Summary
The LLVM backend defaulted generated code to O0, so a CMake Release build of the compiler still emitted unoptimized Eshkol binaries -- `eshkol-run file.esk -o bin` produced O0 output regardless of how the compiler was built (ADR 0007, "Generated code has an independent optimization plane").

This defaults the artifact-producing paths (`-o` AOT binary, `-c` object, `--shared-lib`) to O2. Ephemeral/interactive paths (plain run, `-r`, `-e`, REPL) and `-g` debug builds stay at O0 for fast turnaround. An explicit `-O<n>` always wins (including `-O0` to opt out, `-O3` for a performance artifact).

## Measured speedup (AOT, best of 3, O0 vs new O2 default)
| program | O0 | O2 | speedup |
|---|---|---|---|
| scalar numeric loop | 2.12s | 0.94s | 2.26x |
| pure-Scheme matmul | 2.45s | 0.96s | 2.55x |

## Correctness
- AD gradients are bit-identical between O0 and O2 (the default pipeline enables no fast-math/reassociation).
- Autodiff suite: 54/54.
- Full `run_all_tests.sh`: green (one example, `eagle_train.esk`, flaked once under load and passes on isolated re-run; it uses the O0 plain-run path, unchanged by this PR).

## Tests / PGO Phase-0 groundwork
- Adds `scripts/run_codegen_optlevel_tests.sh` (wired into `run_all_tests.sh`): asserts the default opt level per path and that explicit `-O` wins -- a regression guard for the sleeper bug.
- Checks in a first PGO training corpus under `bench/pgo_corpus/`.
- ADR 0007 Phase-0 status note records what landed and what is deferred (JSON measurement runner + full PGO train/merge/use workflow).
