### PR TITLE
fix(numeric): exact gcd, bignum divmod identity, eqv/equal on rationals

### DIFF
--- a/inc/eshkol/backend/arithmetic_codegen.h
+++ b/inc/eshkol/backend/arithmetic_codegen.h
@@ -257,6 +257,16 @@ public:
     llvm::Value* emitBignumCompareCall(llvm::Value* left, llvm::Value* right, int op_code);
 
     /**
+     * Emit a call into the exact GCD runtime kernel (eshkol_gcd_tagged),
+     * which handles int64/bignum/mixed operands exactly and demotes the
+     * result to int64 when it fits (ESH-0124).
+     * @param left Left operand (tagged_value)
+     * @param right Right operand (tagged_value)
+     * @return gcd(|left|, |right|) as a tagged_value
+     */
+    llvm::Value* emitGcdTaggedCall(llvm::Value* left, llvm::Value* right);
+
+    /**
      * Check whether either operand is a bignum (arbitrary-precision integer)
      * tagged value, so arithmetic/comparison ops can be routed to the bignum
      * dispatch helpers instead of the fixed-width int/double fast path.

--- a/inc/eshkol/core/bignum.h
+++ b/inc/eshkol/core/bignum.h
@@ -281,6 +281,21 @@ void eshkol_bignum_compare_tagged(
     int op, eshkol_tagged_value_t* result);
 
 /**
+ * @brief Exact GCD of two exact integers using bignum arithmetic (ESH-0124).
+ *
+ * Promotes both operands to bignum, runs the Euclidean algorithm exactly, and
+ * demotes the (non-negative) result to INT64 when it fits. Matches R7RS gcd.
+ *
+ * @param arena Arena for intermediate/result bignums.
+ * @param left  Left operand (tagged INT64 or bignum HEAP_PTR).
+ * @param right Right operand (tagged INT64 or bignum HEAP_PTR).
+ * @param[out] result Tagged result (INT64 if it fits, else bignum HEAP_PTR).
+ */
+void eshkol_gcd_tagged(arena_t* arena,
+    const eshkol_tagged_value_t* left, const eshkol_tagged_value_t* right,
+    eshkol_tagged_value_t* result);
+
+/**
  * @brief Test whether a tagged value currently holds a bignum.
  *
  * Checks the HEAP_PTR type tag together with the HEAP_SUBTYPE_BIGNUM object

--- a/lib/backend/arithmetic_codegen.cpp
+++ b/lib/backend/arithmetic_codegen.cpp
@@ -603,6 +603,25 @@ static llvm::Function* getBignumBinaryTaggedFunc(CodegenContext& ctx) {
     return func;
 }
 
+// Declare eshkol_gcd_tagged(arena, left*, right*, result*)
+/**
+ * @brief Gets or declares `eshkol_gcd_tagged(arena, left*, right*, result*)`.
+ *
+ * @param ctx Codegen context.
+ * @return The declared/found LLVM function (void return, writes through `result*`).
+ */
+static llvm::Function* getGcdTaggedFunc(CodegenContext& ctx) {
+    llvm::Function* func = ctx.module().getFunction("eshkol_gcd_tagged");
+    if (!func) {
+        llvm::FunctionType* fn_type = llvm::FunctionType::get(
+            llvm::Type::getVoidTy(ctx.context()),
+            {ctx.ptrType(), ctx.ptrType(), ctx.ptrType(), ctx.ptrType()}, false);
+        func = llvm::Function::Create(fn_type,
+            llvm::Function::ExternalLinkage, "eshkol_gcd_tagged", &ctx.module());
+    }
+    return func;
+}
+
 // Declare eshkol_bignum_compare_tagged(left*, right*, op, result*)
 /**
  * @brief Gets or declares `eshkol_bignum_compare_tagged(left*, right*, op, result*)`.
@@ -677,6 +696,31 @@ llvm::Value* ArithmeticCodegen::emitBignumBinaryCall(llvm::Value* left, llvm::Va
         result_alloca
     });
     return ctx_.builder().CreateLoad(ctx_.taggedValueType(), result_alloca, "bn_result");
+}
+
+/**
+ * @brief Emits a call to the exact GCD runtime dispatcher and loads its result.
+ *
+ * Handles int64 and bignum (and mixed) operands exactly; result is demoted to
+ * int64 when it fits, else returned as a bignum HEAP_PTR (ESH-0124).
+ *
+ * @param left Left tagged operand.
+ * @param right Right tagged operand.
+ * @return Tagged value holding gcd(|left|, |right|).
+ */
+llvm::Value* ArithmeticCodegen::emitGcdTaggedCall(llvm::Value* left, llvm::Value* right) {
+    llvm::Function* fn = ctx_.builder().GetInsertBlock()->getParent();
+    llvm::IRBuilder<> entry_builder(&fn->getEntryBlock(), fn->getEntryBlock().begin());
+    llvm::Value* left_alloca = entry_builder.CreateAlloca(ctx_.taggedValueType(), nullptr, "gcd_l");
+    llvm::Value* right_alloca = entry_builder.CreateAlloca(ctx_.taggedValueType(), nullptr, "gcd_r");
+    llvm::Value* result_alloca = entry_builder.CreateAlloca(ctx_.taggedValueType(), nullptr, "gcd_res");
+    ctx_.builder().CreateStore(left, left_alloca);
+    ctx_.builder().CreateStore(right, right_alloca);
+    llvm::Value* arena_ptr = getArenaPtr(ctx_);
+    ctx_.builder().CreateCall(getGcdTaggedFunc(ctx_), {
+        arena_ptr, left_alloca, right_alloca, result_alloca
+    });
+    return ctx_.builder().CreateLoad(ctx_.taggedValueType(), result_alloca, "gcd_result");
 }
 
 /**

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -19380,15 +19380,21 @@ private:
             BasicBlock* dual_gcd_exit = builder->GetInsertBlock();
             builder->CreateBr(gcd_outer_merge);
 
-            // Normal path: existing int fold.
+            // Normal path: exact fold via the GCD runtime kernel so bignum
+            // operands stay exact (ESH-0124). Operands that are plain int64
+            // are handled by the same kernel without bignum overhead.
             builder->SetInsertPoint(normal_gcd_bb);
-            Value* result = toAbsInt64(args[0].llvm_value);
-            for (uint64_t i = 1; i < args.size(); i++) {
-                Value* arg = toAbsInt64(args[i].llvm_value);
-                result = emitGCDPair(result, arg);
+            Value* normal_tagged = tagged_args[0];
+            for (uint64_t i = 1; i < tagged_args.size(); i++) {
+                normal_tagged = arith_->emitGcdTaggedCall(normal_tagged, tagged_args[i]);
             }
-            // Pack as int64 tagged value so the outer merge PHI has matching types.
-            Value* normal_tagged = packInt64ToTaggedValue(result, true);
+            // A single-operand gcd must return |n|; fold above leaves it as-is,
+            // so normalise the lone-operand case through the kernel with 0.
+            if (tagged_args.size() == 1) {
+                Value* zero_tagged = packInt64ToTaggedValue(
+                    ConstantInt::get(int64_type, 0), true);
+                normal_tagged = arith_->emitGcdTaggedCall(normal_tagged, zero_tagged);
+            }
             BasicBlock* normal_gcd_exit = builder->GetInsertBlock();
             builder->CreateBr(gcd_outer_merge);
 
@@ -22530,10 +22536,39 @@ private:
         Value* is_bignum1 = isHeapSubtype(arg1, HEAP_SUBTYPE_BIGNUM);
         Value* is_bignum2 = isHeapSubtype(arg2, HEAP_SUBTYPE_BIGNUM);
 
+        // Exact rationals and complex numbers (ESH-0114): eqv? must compare by
+        // value, not by heap-pointer identity. Route these operands through the
+        // deep-equality runtime, which compares reduced numerator/denominator
+        // (rationals) or real/imag components (complex).
+        Value* is_rat1 = isHeapSubtype(arg1, HEAP_SUBTYPE_RATIONAL);
+        Value* is_rat2 = isHeapSubtype(arg2, HEAP_SUBTYPE_RATIONAL);
+        Value* is_cplx1 = builder->CreateICmpEQ(base_type1, ConstantInt::get(int8_type, ESHKOL_VALUE_COMPLEX));
+        Value* is_cplx2 = builder->CreateICmpEQ(base_type2, ConstantInt::get(int8_type, ESHKOL_VALUE_COMPLEX));
+        Value* use_deep = builder->CreateOr(
+            builder->CreateOr(is_rat1, is_rat2),
+            builder->CreateOr(is_cplx1, is_cplx2));
+
+        Function* func = builder->GetInsertBlock()->getParent();
+        BasicBlock* deep_bb = BasicBlock::Create(*context, "eqv_deep", func);
+        BasicBlock* scalar_bb = BasicBlock::Create(*context, "eqv_scalar", func);
+        BasicBlock* outer_merge_bb = BasicBlock::Create(*context, "eqv_outer_merge", func);
+        builder->CreateCondBr(use_deep, deep_bb, scalar_bb);
+
+        // Deep path: value equality for rationals/complex via runtime helper.
+        builder->SetInsertPoint(deep_bb);
+        Value* deep_arg1 = builder->CreateAlloca(tagged_value_type, nullptr, "eqv_deep_a1");
+        Value* deep_arg2 = builder->CreateAlloca(tagged_value_type, nullptr, "eqv_deep_a2");
+        builder->CreateStore(arg1, deep_arg1);
+        builder->CreateStore(arg2, deep_arg2);
+        Value* deep_result = builder->CreateCall(eshkol_deep_equal_func, {deep_arg1, deep_arg2});
+        BasicBlock* deep_exit = builder->GetInsertBlock();
+        builder->CreateBr(outer_merge_bb);
+
+        builder->SetInsertPoint(scalar_bb);
+
         // If either operand is bignum, use bignum compare (handles bignum-bignum and bignum-int64)
         Value* either_bignum = builder->CreateOr(is_bignum1, is_bignum2);
 
-        Function* func = builder->GetInsertBlock()->getParent();
         BasicBlock* bignum_bb = BasicBlock::Create(*context, "eqv_bignum", func);
         BasicBlock* normal_bb = BasicBlock::Create(*context, "eqv_normal", func);
         BasicBlock* merge_bb = BasicBlock::Create(*context, "eqv_merge", func);
@@ -22593,13 +22628,21 @@ private:
         builder->CreateBr(merge_bb);
         BasicBlock* normal_exit = builder->GetInsertBlock();
 
-        // Merge
+        // Merge (scalar path: bignum vs normal)
         builder->SetInsertPoint(merge_bb);
         PHINode* result = builder->CreatePHI(int1_type, 2);
         result->addIncoming(bn_eq, bignum_exit);
         result->addIncoming(normal_result, normal_exit);
+        BasicBlock* scalar_exit = builder->GetInsertBlock();
+        builder->CreateBr(outer_merge_bb);
 
-        return packBoolToTaggedValue(result);
+        // Outer merge: deep (rational/complex) path vs scalar path.
+        builder->SetInsertPoint(outer_merge_bb);
+        PHINode* outer_result = builder->CreatePHI(int1_type, 2);
+        outer_result->addIncoming(deep_result, deep_exit);
+        outer_result->addIncoming(result, scalar_exit);
+
+        return packBoolToTaggedValue(outer_result);
     }
 
     // equal? - Deep structural equality using runtime helper

--- a/lib/core/bignum.cpp
+++ b/lib/core/bignum.cpp
@@ -274,15 +274,27 @@ static void bignum_divmod_abs(arena_t* arena,
             if (rhat >= ((__uint128_t)1 << 64)) break;
         }
 
-        /* Multiply and subtract: un[j..j+n] -= qhat * vn_shifted */
+        /* Multiply and subtract: un[j..j+n] -= qhat * vn_shifted.
+         *
+         * The product limbs (plo, phi) must be treated as UNSIGNED 64-bit
+         * magnitudes. A previous implementation cast them via
+         * `(int64_t)(uint64_t)...`, which reinterprets any word whose bit 63
+         * is set as a negative number and corrupts the subtraction by 2^64
+         * (ESH-0125: this silently broke the Euclidean identity
+         * a = q*b + r for large operands). We keep the running borrow in a
+         * signed __int128 (always <= 0) so both the low subtraction and the
+         * high-word carry propagate with their true unsigned magnitudes. */
         __int128_t borrow_s = 0;
         for (uint32_t i = 0; i < n; i++) {
             __uint128_t prod = (__uint128_t)(uint64_t)qhat * vn_shifted[i];
-            __int128_t diff = (__int128_t)un[j + i] - (int64_t)(uint64_t)prod - borrow_s;
+            uint64_t plo = (uint64_t)prod;
+            uint64_t phi = (uint64_t)(prod >> 64);
+            __int128_t diff = (__int128_t)un[j + i] - (__int128_t)plo + borrow_s;
             un[j + i] = (uint64_t)diff;
-            borrow_s = (int64_t)(uint64_t)(prod >> 64) - (int64_t)(diff >> 64);
+            /* diff >> 64 is the (signed, <= 0) borrow out of this limb. */
+            borrow_s = (diff >> 64) - (__int128_t)phi;
         }
-        __int128_t diff_top = (__int128_t)un[j + n] - borrow_s;
+        __int128_t diff_top = (__int128_t)un[j + n] + borrow_s;
         un[j + n] = (uint64_t)diff_top;
 
         ql[j] = (uint64_t)qhat;
@@ -1008,6 +1020,57 @@ void eshkol_bignum_binary_tagged(arena_t* arena,
         *result = eshkol_make_int64(fits, true);
     } else {
         *result = eshkol_make_ptr((uint64_t)(void*)r, ESHKOL_VALUE_HEAP_PTR);
+        result->flags = ESHKOL_VALUE_EXACT_FLAG;
+    }
+}
+
+/**
+ * @brief Exact GCD of two exact integers, using bignum arithmetic (ESH-0124).
+ *
+ * The native/LLVM `gcd` builtin previously extracted every operand to a
+ * lossy double and truncated to int64, so `(gcd (* 3 (expt 2 61))
+ * (* 5 (expt 2 61)))` collapsed to 1 and two full bignums saturated to
+ * INT64_MAX. This helper promotes both operands to bignum and runs the
+ * Euclidean algorithm exactly, then demotes back to int64 when the result
+ * fits. Both operands are treated by magnitude; the result is non-negative,
+ * matching R7RS gcd. `(gcd 0 0)` is 0.
+ *
+ * @param arena Arena for intermediate/result bignums.
+ * @param left  Left operand (tagged INT64 or bignum HEAP_PTR).
+ * @param right Right operand (tagged INT64 or bignum HEAP_PTR).
+ * @param[out] result Tagged result (INT64 if it fits, else bignum HEAP_PTR).
+ */
+void eshkol_gcd_tagged(arena_t* arena,
+    const eshkol_tagged_value_t* left, const eshkol_tagged_value_t* right,
+    eshkol_tagged_value_t* result) {
+
+    eshkol_bignum_t* a = tagged_to_bignum(arena, left);
+    eshkol_bignum_t* b = tagged_to_bignum(arena, right);
+    if (!a || !b) { *result = eshkol_make_int64(0, true); return; }
+
+    /* Work on non-negative magnitudes (eshkol_bignum_neg yields a fresh copy
+     * for negative inputs; positive inputs are already non-negative). */
+    eshkol_bignum_t* g_a = a->sign ? eshkol_bignum_neg(arena, a) : a;
+    eshkol_bignum_t* g_b = b->sign ? eshkol_bignum_neg(arena, b) : b;
+    if (!g_a || !g_b) { *result = eshkol_make_int64(0, true); return; }
+
+    /* Euclid: gcd(g_a, g_b) = gcd(g_b, g_a mod g_b). */
+    while (!eshkol_bignum_is_zero(g_b)) {
+        eshkol_bignum_t* rem = eshkol_bignum_mod(arena, g_a, g_b);
+        if (!rem) { g_a = g_b; break; }
+        if (rem->sign) rem->sign = 0; /* mod can be negative; take magnitude */
+        g_a = g_b;
+        g_b = rem;
+    }
+    if (g_a && g_a->sign) g_a->sign = 0;
+
+    if (!g_a) { *result = eshkol_make_int64(0, true); return; }
+
+    int64_t fits;
+    if (eshkol_bignum_fits_int64(g_a, &fits)) {
+        *result = eshkol_make_int64(fits, true);
+    } else {
+        *result = eshkol_make_ptr((uint64_t)(void*)g_a, ESHKOL_VALUE_HEAP_PTR);
         result->flags = ESHKOL_VALUE_EXACT_FLAG;
     }
 }

--- a/lib/core/runtime_deep_equal.cpp
+++ b/lib/core/runtime_deep_equal.cpp
@@ -8,6 +8,7 @@
 
 #include "arena_memory.h"
 #include "../../inc/eshkol/core/bignum.h"
+#include "../../inc/eshkol/core/rational.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -177,6 +178,37 @@ bool eshkol_deep_equal(const eshkol_tagged_value_t* val1,
             if (!eshkol_deep_equal(&elems1[i], &elems2[i])) return false;
         }
         return true;
+    }
+
+    // Exact rationals (ESH-0114): rationals are always stored in reduced form
+    // with a positive denominator, so value equality reduces to comparing the
+    // numerator/denominator fields. (equal? (/ 1 3) (/ 2 6)) must be #t.
+    auto is_rational = [](uint8_t type, const eshkol_tagged_value_t* val) -> bool {
+        if (type == ESHKOL_VALUE_HEAP_PTR && val->data.ptr_val) {
+            eshkol_object_header_t* hdr = ESHKOL_GET_HEADER((void*)val->data.ptr_val);
+            return hdr->subtype == HEAP_SUBTYPE_RATIONAL;
+        }
+        return false;
+    };
+    bool is_rat1 = is_rational(type1, val1);
+    bool is_rat2 = is_rational(type2, val2);
+    if (is_rat1 && is_rat2) {
+        const eshkol_rational_t* r1 = (const eshkol_rational_t*)val1->data.ptr_val;
+        const eshkol_rational_t* r2 = (const eshkol_rational_t*)val2->data.ptr_val;
+        return r1->numerator == r2->numerator &&
+               r1->denominator == r2->denominator;
+    }
+
+    // Complex numbers (ESH-0114): compare real and imaginary components by
+    // value. Complex tagged values are inexact (double components).
+    if (type1 == ESHKOL_VALUE_COMPLEX && type2 == ESHKOL_VALUE_COMPLEX) {
+        if (val1->data.ptr_val == val2->data.ptr_val) return true;
+        const eshkol_complex_number_t* c1 =
+            (const eshkol_complex_number_t*)val1->data.ptr_val;
+        const eshkol_complex_number_t* c2 =
+            (const eshkol_complex_number_t*)val2->data.ptr_val;
+        if (!c1 || !c2) return c1 == c2;
+        return c1->real == c2->real && c1->imag == c2->imag;
     }
 
     if (type1 != type2) return false;

--- a/tests/numeric/bignum_rational_exactness_test.esk
+++ b/tests/numeric/bignum_rational_exactness_test.esk
@@ -1,0 +1,85 @@
+(require stdlib)
+
+; Regression tests for numeric-tower exactness bugs.
+; Emits "PASS: ..." / "FAIL: ..." lines; the numeric harness fails the
+; suite if any line begins with FAIL.
+
+(display "TEST: bignum / rational exactness") (newline)
+
+; ---------------------------------------------------------------------------
+; ESH-0124: gcd must have an exact bignum path (no lossy double/int64 collapse)
+; ---------------------------------------------------------------------------
+(display (if (= (gcd (* 3 (expt 2 61)) (* 5 (expt 2 61))) (expt 2 61))
+             "PASS" "FAIL"))
+(display ": gcd(3*2^61, 5*2^61) = 2^61") (newline)
+
+(display (if (= (gcd (expt 2 64) (expt 2 65)) (expt 2 64)) "PASS" "FAIL"))
+(display ": gcd(2^64, 2^65) = 2^64") (newline)
+
+(display (if (= (gcd (* 7 (expt 10 30)) (* 11 (expt 10 30))) (expt 10 30))
+             "PASS" "FAIL"))
+(display ": gcd(7*10^30, 11*10^30) = 10^30") (newline)
+
+; gcd is symmetric and non-negative over signs and int64 operands
+(display (if (= (gcd 48 36) 12) "PASS" "FAIL")) (display ": gcd(48, 36) = 12") (newline)
+(display (if (= (gcd -48 36) 12) "PASS" "FAIL")) (display ": gcd(-48, 36) = 12") (newline)
+(display (if (= (gcd (- (expt 2 70)) (expt 2 66)) (expt 2 66)) "PASS" "FAIL"))
+(display ": gcd(-2^70, 2^66) = 2^66") (newline)
+(display (if (= (gcd 0 (expt 10 25)) (expt 10 25)) "PASS" "FAIL"))
+(display ": gcd(0, 10^25) = 10^25") (newline)
+
+; ---------------------------------------------------------------------------
+; ESH-0125: bignum quotient/remainder must satisfy a = q*b + r exactly
+; ---------------------------------------------------------------------------
+(define a1 (expt 10 25))
+(define b1 (expt 7 25))
+(display (if (= a1 (+ (* (quotient a1 b1) b1) (remainder a1 b1))) "PASS" "FAIL"))
+(display ": 10^25 = q*7^25 + r") (newline)
+
+(define a2 (* (expt 3 40) (expt 5 7)))
+(define b2 (expt 6 20))
+(display (if (= a2 (+ (* (quotient a2 b2) b2) (remainder a2 b2))) "PASS" "FAIL"))
+(display ": 3^40*5^7 = q*6^20 + r") (newline)
+
+(define a3 (- (expt 2 130)))
+(define b3 (expt 3 50))
+(display (if (= a3 (+ (* (quotient a3 b3) b3) (remainder a3 b3))) "PASS" "FAIL"))
+(display ": -2^130 = q*3^50 + r (signed)") (newline)
+
+; remainder magnitude is strictly less than |b|
+(display (if (< (remainder a1 b1) b1) "PASS" "FAIL"))
+(display ": |remainder| < |divisor|") (newline)
+
+; exact quotient of a multiple has zero remainder
+(define k (expt 13 22))
+(display (if (and (= (quotient (* k b1) b1) k) (= (remainder (* k b1) b1) 0))
+             "PASS" "FAIL"))
+(display ": (k*b) / b = k, rem 0") (newline)
+
+; ---------------------------------------------------------------------------
+; ESH-0114: eqv?/equal? must be value-correct + reflexive on rationals/complex
+; ---------------------------------------------------------------------------
+(display (if (eqv? (/ 1 3) (/ 1 3)) "PASS" "FAIL"))
+(display ": (eqv? 1/3 1/3)") (newline)
+(display (if (equal? (/ 1 3) (/ 2 6)) "PASS" "FAIL"))
+(display ": (equal? 1/3 2/6)") (newline)
+(display (if (eqv? (/ 2 6) (/ 3 9)) "PASS" "FAIL"))
+(display ": (eqv? 2/6 3/9) both reduce to 1/3") (newline)
+(display (if (not (equal? (/ 1 3) (/ 1 4))) "PASS" "FAIL"))
+(display ": (equal? 1/3 1/4) is #f") (newline)
+(display (if (not (eqv? (/ 1 3) (/ 1 4))) "PASS" "FAIL"))
+(display ": (eqv? 1/3 1/4) is #f") (newline)
+
+; complex value equality (separately-constructed instances, distinct pointers)
+(display (if (equal? (make-rectangular 3 4) (make-rectangular 3 4)) "PASS" "FAIL"))
+(display ": (equal? 3+4i 3+4i)") (newline)
+(display (if (not (equal? (make-rectangular 3 4) (make-rectangular 3 5))) "PASS" "FAIL"))
+(display ": (equal? 3+4i 3+5i) is #f") (newline)
+
+; ---------------------------------------------------------------------------
+; Sanity: existing int64-range rationals and integers keep working
+; ---------------------------------------------------------------------------
+(display (if (= (gcd 1071 462) 21) "PASS" "FAIL")) (display ": gcd(1071, 462) = 21") (newline)
+(display (if (= (quotient 17 5) 3) "PASS" "FAIL")) (display ": quotient(17, 5) = 3") (newline)
+(display (if (= (remainder 17 5) 2) "PASS" "FAIL")) (display ": remainder(17, 5) = 2") (newline)
+(display (if (eqv? 42 42) "PASS" "FAIL")) (display ": (eqv? 42 42)") (newline)


### PR DESCRIPTION
## Summary

Fixes three silent-wrong-answer / conformance bugs in Eshkol's numeric tower, each at its architectural root, verified in both JIT (`-r`) and AOT against exact analytic oracles.

| Bug | Before | After (exact) |
|-----|--------|---------------|
| **ESH-0124** `(gcd (* 3 (expt 2 61)) (* 5 (expt 2 61)))` | `1` | `2305843009213693952` (2^61) |
| **ESH-0124** `(gcd (expt 2 64) (expt 2 65))` | `9223372036854775807` (INT64_MAX) | `18446744073709551616` (2^64) |
| **ESH-0125** `(= 10^25 (+ (* q 7^25) r))` | `#f` | `#t` (remainder was off by 2^shift) |
| **ESH-0114** `(eqv? (/ 1 3) (/ 1 3))` | `#f` | `#t` |
| **ESH-0114** `(equal? (/ 1 3) (/ 2 6))` | `#f` | `#t` |

## Fixes

- **ESH-0124 (gcd bignum path)** — `codegenGCD` extracted every operand to a lossy double then truncated to int64. Added `eshkol_gcd_tagged` (exact Euclid over bignum magnitudes, demoting to int64 when it fits) in `lib/core/bignum.cpp`; `codegenGCD`'s tagged, non-dual fold now routes through it via `ArithmeticCodegen::emitGcdTaggedCall`.
- **ESH-0125 (divmod identity)** — root cause in the multiply-and-subtract step of Knuth Algorithm D (`bignum_divmod_abs`): product limbs were cast `(int64_t)(uint64_t)...`, reinterpreting any word with bit 63 set as negative and corrupting the subtraction by 2^64. Rewrote the loop with unsigned product limbs (`plo`, `phi`) and a signed `__int128` borrow. Fixes quotient, remainder, modulo, and gcd-via-mod together.
- **ESH-0114 (eqv?/equal? on rationals/complex)** — both compared heap-pointer identity. `eshkol_deep_equal` now compares reduced numerator/denominator (rationals, always stored reduced with positive denominator) and real/imag (complex); `eqv?` codegen routes rational/complex operands through it while keeping the bit-pattern double compare so `(eqv? 0.0 -0.0)` stays `#f`.

## Verification

- New `tests/numeric/bignum_rational_exactness_test.esk` — 23 assertions, all PASS (JIT + AOT).
- Randomized stress: 60 large quotient/remainder identity checks + 40 gcd checks vs Python oracles → 0 failures.
- Suites green: bignum 2/2, numeric 9/9, rational 3/3, tensor-AD gate PASS, numeric-depth (JIT+AOT) magnitude 94/94, arith 39/39, **divmod 37/37**, **gcd 128/128**, roundtrip 86/86.

## Deferred (architecturally deep)

**ESH-0105** (exact rationals degrade to double once numerator/denominator exceed int64) and **ESH-0123** (bignum-magnitude rational literal `100000000000000000000/3` rejected by the parser) both require a **bignum-capable rational representation**. `eshkol_rational_t` is `{int64 numerator; int64 denominator}` and `eshkol_rational_create` takes `int64` args, so making these exact means a new heap subtype storing two bignum pointers plus create/normalize/add/sub/mul/div/compare/print/predicate/equality integration and parser + arithmetic-dispatch wiring. Deferred rather than shipped half-done (a partial fix here would be silently wrong). `(/ 1 (expt 10 18))` and all int64-range rationals remain exact.