### PR TITLE
fix(codegen): keep loop-body closures aliased to set!-mutated global captures (ESH-0094)

### DIFF
--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -26669,19 +26669,35 @@ private:
                 continue;
             }
 
+            // ESH-0094: a capture whose outer storage is ALREADY a shared cell
+            // pointer (GlobalVariable, an enclosing loop's `_cap` Argument, a
+            // closure-env IntToPtr, or a generic tagged_value*) is pointer-passed
+            // as-is below. But if the loop body set!-mutates it — including from a
+            // closure created in the body — the loop-body closure would otherwise
+            // by-value-load the pointer-typed `_cap` Argument (codegenLambda's
+            // Argument branch) and snapshot the value, silently dropping the
+            // mutation. Record it in mutable_loop_captures_ so codegenLambda
+            // pointer-passes the `_cap` Argument instead, keeping the closure
+            // aliased to the real cell. (The AllocaInst+set! case above already
+            // arena-moves and records; these branches cover the non-alloca cells.)
+            const bool body_mutates_capture = astSetsVar(op->let_op.body, fv);
+
             // Already a pointer we can pass directly.
             if (isa<AllocaInst>(outer_val) || isa<GlobalVariable>(outer_val) ||
                 isa<IntToPtrInst>(outer_val)) {
+                if (body_mutates_capture) mutable_loop_captures_.insert(fv);
                 capture_outer_ptrs.push_back(outer_val);
                 continue;
             }
             if (isa<Argument>(outer_val) && outer_val->getType()->isPointerTy()) {
+                if (body_mutates_capture) mutable_loop_captures_.insert(fv);
                 capture_outer_ptrs.push_back(outer_val);
                 continue;
             }
             if (outer_val->getType()->isPointerTy()) {
                 // Generic pointer instruction (e.g., GEP, BitCast yielding a
                 // tagged_value*). Pass directly.
+                if (body_mutates_capture) mutable_loop_captures_.insert(fv);
                 capture_outer_ptrs.push_back(outer_val);
                 continue;
             }

--- a/tests/closures/closure_set_in_tco_loop_test.esk
+++ b/tests/closures/closure_set_in_tco_loop_test.esk
@@ -1,0 +1,154 @@
+; ================================================================
+; ESH-0094: closure created in a named-let / TCO loop body that
+; set!s a captured GLOBAL (or outer) variable must mutate the REAL
+; cell, not a per-iteration by-value snapshot.
+; ================================================================
+;
+; Repro: a named-let loop whose body builds a closure that set!s a
+; global returned 0; the identical code WITHOUT the loop returned 3.
+; The loop context silently dropped the captured-variable mutation.
+;
+; Root cause (fix in lib/backend/llvm_codegen.cpp, codegenNamedLet):
+; codegenNamedLet pointer-passes each set!-mutated capture into the
+; loop function as a `<fv>_cap` pointer argument. For a captured
+; local ALLOCA it also recorded the var in `mutable_loop_captures_`,
+; which is what tells codegenLambda to pointer-pass (alias) the
+; `_cap` argument into a body closure's environment rather than
+; by-value-loading it. But when the outer storage was already a
+; shared cell POINTER — a GlobalVariable, an enclosing loop's `_cap`
+; argument, or a generic tagged_value* — that bookkeeping was
+; skipped. So the body closure by-value-loaded `_cap` (snapshotting
+; the value at closure-creation time) and its set! wrote to the
+; closure-env copy, never reaching the real cell: the mutation was
+; lost. The fix records EVERY pointer-passed set!-mutated capture in
+; `mutable_loop_captures_`, so the closure stays aliased to the real
+; cell in both the loop and non-loop paths.
+;
+; Must stay intact: named-let thread-safety (#224, per-call capture
+; pointers) and mutable-capture in named-let (#50). Section 5 guards
+; the outer-let alloca path (already correct pre-ESH-0094); Section 6
+; guards the non-loop baseline against an overly-broad fix.
+
+(require stdlib)
+
+(define pass-count 0)
+(define fail-count 0)
+
+(define (test name expected actual)
+  (if (equal? expected actual)
+      (begin (set! pass-count (+ pass-count 1))
+             (display (string-append "PASS: " name "\n")))
+      (begin (set! fail-count (+ fail-count 1))
+             (display (string-append "FAIL: " name "\n"))
+             (display "  Expected: ") (display expected) (newline)
+             (display "  Actual:   ") (display actual) (newline))))
+
+(define (call-it f) (f))
+
+; ----------------------------------------------------------------
+; Section 1: the ESH-0094 repro — closure in a named-let loop set!s
+; a global. Pre-fix this returned 0; must return 3.
+; ----------------------------------------------------------------
+
+(define c1 0)
+(test "closure in named-let loop set!s global"
+      3
+      (let loop ((i 0))
+        (if (< i 3)
+            (begin (call-it (lambda () (set! c1 (+ c1 1)))) (loop (+ i 1)))
+            c1)))
+
+; ----------------------------------------------------------------
+; Section 2: multiple closures created in the loop body sharing the
+; same global cell. Each iteration adds 1 then 10 => 3 * 11 = 33.
+; ----------------------------------------------------------------
+
+(define c2 0)
+(test "multiple loop-body closures share one global cell"
+      33
+      (let loop ((i 0))
+        (if (< i 3)
+            (begin
+              (call-it (lambda () (set! c2 (+ c2 1))))
+              (call-it (lambda () (set! c2 (+ c2 10))))
+              (loop (+ i 1)))
+            c2)))
+
+; ----------------------------------------------------------------
+; Section 3: nested named-let loops; the inner-loop closure set!s a
+; global. Outer runs 2x, inner runs 3x => 6. Exercises the
+; enclosing-loop `_cap` pointer-argument capture path.
+; ----------------------------------------------------------------
+
+(define c3 0)
+(test "nested named-let loops, inner closure set!s global"
+      6
+      (begin
+        (let outer ((i 0))
+          (if (< i 2)
+              (begin
+                (let inner ((j 0))
+                  (if (< j 3)
+                      (begin (call-it (lambda () (set! c3 (+ c3 1)))) (inner (+ j 1)))
+                      #t))
+                (outer (+ i 1)))
+              #t))
+        c3))
+
+; ----------------------------------------------------------------
+; Section 4: a closure built in the loop body ESCAPES the loop; its
+; set!s to the global must still land on the real cell when invoked
+; after the loop has returned.
+; ----------------------------------------------------------------
+
+(define c4 0)
+(define c4-saved #f)
+(test "escaped loop-body closure still mutates the global"
+      3
+      (begin
+        (let loop ((i 0))
+          (if (< i 1)
+              (begin (set! c4-saved (lambda () (set! c4 (+ c4 1)))) (loop (+ i 1)))
+              #t))
+        (c4-saved) (c4-saved) (c4-saved)
+        c4))
+
+; ----------------------------------------------------------------
+; Section 5: outer LET-bound (alloca) variable set! from a closure
+; made in a named-let loop. This path (arena-move of a set!-mutated
+; alloca capture) was already correct before ESH-0094; keep it green
+; so the fix does not regress #50 / #224.
+; ----------------------------------------------------------------
+
+(test "closure in named-let loop set!s outer let-bound var"
+      3
+      (let ((x 0))
+        (let loop ((i 0))
+          (if (< i 3)
+              (begin (call-it (lambda () (set! x (+ x 1)))) (loop (+ i 1)))
+              #t))
+        x))
+
+; ----------------------------------------------------------------
+; Section 6: non-loop baseline. The identical closure/set! pattern
+; WITHOUT a loop must remain correct (guards against an overly-broad
+; fix that would break the ordinary global-capture path).
+; ----------------------------------------------------------------
+
+(define c6 0)
+(test "non-loop closure set!s global baseline unaffected"
+      3
+      (begin
+        (call-it (lambda () (set! c6 (+ c6 1))))
+        (call-it (lambda () (set! c6 (+ c6 1))))
+        (call-it (lambda () (set! c6 (+ c6 1))))
+        c6))
+
+; Summary
+(display "\n=== Results ===\n")
+(display "Passed: ") (display pass-count) (newline)
+(display "Failed: ") (display fail-count) (newline)
+
+(if (= fail-count 0)
+    0
+    (error "closure set! in TCO loop tests failed"))


### PR DESCRIPTION
## Summary

Fixes ESH-0094, a silent-wrong-answer codegen bug: a closure created inside a named-let / TCO loop body that `set!`s a captured **global** (or other already-pointer outer cell) lost the mutation. The repro returned `0`; the identical code without the loop returned `3`.

```scheme
(define c 0)
(define (call-it f) (f))
(let loop ((i 0))
  (if (< i 3)
      (begin (call-it (lambda () (set! c (+ c 1)))) (loop (+ i 1)))
      c))
(display c)(newline)   ; was 0, now 3
```

## Root cause

`codegenNamedLet` pointer-passes each `set!`-mutated capture into the loop function as a `<fv>_cap` pointer argument, and records the variable in `mutable_loop_captures_` so `codegenLambda` pointer-passes (aliases) that `_cap` argument into a body closure's environment instead of by-value loading it.

That bookkeeping only ran for captured local **allocas**. When the outer storage was already a shared cell pointer — a `GlobalVariable`, an enclosing loop's `_cap` argument, or a generic `tagged_value*` — the `mutable_loop_captures_` insert was skipped. So the loop-body closure by-value-loaded `_cap`, snapshotting the value at closure-creation time; its `set!` wrote to the closure-env copy and never reached the real cell.

At the IR level, the buggy loop stored `load %c_cap` (the value) into the closure env, whereas the correct non-loop path stores `ptrtoint(@eshkol_g_c)` (the cell address).

## Fix

Record **every** pointer-passed, `set!`-mutated capture in `mutable_loop_captures_` (guarded by `astSetsVar`, which recurses into lambda bodies), covering the non-alloca cell cases (global / enclosing-loop `_cap` argument / generic pointer). The existing alloca+`set!` branch (which arena-moves and already records) is unchanged; the raw-value materialisation branch keeps its by-value semantics (Arguments are immutable in Eshkol). The closure now stays aliased to the real cell in both the loop and non-loop paths.

One localised change in `lib/backend/llvm_codegen.cpp` (`codegenNamedLet`).

## Tests

Adds `tests/closures/closure_set_in_tco_loop_test.esk` (6 cases): the repro, multiple closures sharing one global cell, nested named-let loops, an escaped loop-body closure, the outer let-bound (alloca) path, and the non-loop baseline. All pass under both `-r` (JIT) and AOT.

### Before / after (AOT and JIT identical)

| case | before | after |
|---|---|---|
| repro (named-let loop, global) | 0 | 3 |
| multiple closures share global | 0 | 33 |
| nested loops, global | 0 | 6 |
| escaped loop-body closure, global | 0 | 3 |
| outer let-bound var (alloca) | 3 | 3 (already correct) |
| non-loop baseline | 3 | 3 |

### Regression suites (green)

- `tests/closures/*`: `closure_edge_test` 40/40, `shared_mutable_capture_test` 24/24, `tco_loop_capture_test` 6/6, `curried_chain_depth_test` 10/10 — the named-let thread-safety (#224) and mutable-capture (#50) fixes stay intact.
- `scripts/run_autodiff_tests.sh`: 54/54.
- `scripts/run_memory_tests.sh`: 13/14; the one failure (`memory_test.esk`) is a pre-existing `base64-encode/decode-string` FFI link issue, identical on the unpatched base — unrelated to this change.