### PR TITLE
Generative multi-oracle differential harness (P7c)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,9 @@ artifacts/nesting-depth/
 
 # P7a reference-differential runtime artifacts (binaries/logs, capped 1GB)
 artifacts/reference-diff/
+
+# P7c generative-differential runtime artifacts (per-oracle stdout on divergence)
+artifacts/generative-diff/
+# Generated (deterministic) corpus for the generative-differential harness —
+# regenerable via scripts/gen_generative_corpus.py; never checked in.
+tests/generative-diff/corpus/

--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -1820,6 +1820,46 @@ oracles:
         action: ./scripts/run_reference_differential.sh
 
   # ─────────────────────────────────────────────────────────────────
+  # Generative multi-oracle differential (adversarial testing pillar
+  # P7c). Where reference-diff (P7a) runs a fixed 34-program hand corpus,
+  # this GENERATES a large deterministic family of closed R7RS-small
+  # programs (scripts/gen_generative_corpus.py; pure function of
+  # seed+count) and runs each through every installed oracle —
+  # chibi-scheme (external truth), Eshkol JIT (-r), Eshkol AOT at -O0 AND
+  # -O2, and the bytecode VM — flagging any pairwise disagreement:
+  # R7RS gaps vs chibi, AOT-vs-JIT miscompiles, optimization-level
+  # divergence (-O0 vs -O2, guarding the O2-default change), silent VM
+  # miscompiles, and metamorphic property violations (the "meta" family
+  # self-checks apply-equivalence / map-ordering / commutativity /
+  # reverse-involution / length-append homomorphism / fold-equivalence,
+  # so a bug surfaces even with no reference installed). Writes
+  # kind:"generative_differential" events to
+  # scripts/icc_traces/generative_differential.jsonl.
+  #
+  # The gate event generative_differential_oracle is evaluated in
+  # regression mode against tests/generative-diff/baseline.txt: PASS iff
+  # no divergence appears that is NOT already a known/triaged entry in the
+  # baseline — i.e. it flips RED the moment a NEW miscompile is generated.
+  # The currently-exposed divergences are catalogued in
+  # docs/reports/GENERATIVE_DIFFERENTIAL_REPORT.md and enumerated in the
+  # baseline; each is an open bug for a separate fixing agent.
+  # ─────────────────────────────────────────────────────────────────
+  - name: generative-differential
+    aliases: [generative-diff, p7c-generative-diff, generative-differential-oracle]
+    requires:
+      - test_evidence: true
+        severity: high
+        label: Generative R7RS-small corpus is deterministic and regenerable
+        action: python3 scripts/gen_generative_corpus.py
+      - runtime_event:
+          event_kinds: [generative_differential]
+          event_names: ["generative_differential_oracle"]
+          event_values: ["PASS"]
+        severity: high
+        label: No NEW cross-oracle divergence beyond the triaged baseline (chibi/JIT/AOT-O0/AOT-O2/VM + metamorphic)
+        action: ./scripts/run_generative_differential.sh
+
+  # ─────────────────────────────────────────────────────────────────
   # GPU execution correctness (closes the CI gap where the *-cuda lanes
   # in .github/workflows/ci.yml compile CUDA on GPU-less hosted runners
   # but never run a kernel). tests/gpu/gpu_correctness_gate.sh builds

--- a/docs/reports/GENERATIVE_DIFFERENTIAL_REPORT.md
+++ b/docs/reports/GENERATIVE_DIFFERENTIAL_REPORT.md
@@ -1,0 +1,195 @@
+# Generative Multi-Oracle Differential Report (P7c)
+
+> "If our system does not constantly expose every single hidden bug then it has
+> no coverage." — the maintainer.
+
+The hand-written reference-differential corpus (P7a, `scripts/gen_reference_
+corpus.py`) is 34 fixed programs and, on current master, **34/34 AGREE** against
+chibi — it no longer exposes anything. This pillar makes differential testing
+**generative and multi-oracle**: it generates a large, deterministic family of
+closed R7RS-small programs and cross-checks each across every installed
+execution oracle. Any pairwise disagreement is an exposed bug.
+
+See `tests/generative-diff/README.md` for the design; this document is the
+**exposed-bug catalogue** with a minimal repro for each distinct defect. The
+underlying defects are NOT fixed here — each is an open task for a separate
+fixing agent. The harness itself ships green (regression mode against the
+triaged baseline); it flips RED the moment a NEW divergence is generated.
+
+## Resolved: the "34 vs 27" conflict
+
+`docs/reports/REFERENCE_DIFFERENTIAL_REPORT.md` records **27/34 AGREE** (RED);
+`CHANGELOG.md` claims **34/34 AGREE (100%)**. Re-running the actual harness on
+this branch (master + this branch's non-functional additions):
+
+```
+$ scripts/run_reference_differential.sh
+Reference : chibi-scheme 0.12.0 "magnesium"
+Total     : 34    AGREE : 34    ESHKOL-DIVERGES : 0
+Agreement rate: 100.0%    Gate : PASS
+```
+
+**The CHANGELOG is correct: 34/34 today.** The `REFERENCE_DIFFERENTIAL_REPORT.md`
+"27/34" table is a **stale pre-fix snapshot** — the 7 divergences it lists
+(ESH-0150..0156: apply-leading-args crash, multi-arg `vector-map`, `cond`/`case`
+`=>`, `vector-copy`, vector quasiquote, `error-object?` family, `write` escaping)
+plus ESH-0225 were all fixed and are documented as fixed in the CHANGELOG. The
+report even carries a note that it is "superseded by this changelog entry." The
+27/34 figure should be read only as history. This is precisely why a fixed corpus
+is insufficient and a generative one is needed.
+
+## Oracles
+
+| Oracle | Command |
+|---|---|
+| `chibi`  | `chibi-scheme <prologue+body>` (external R7RS ground truth) |
+| `jit`    | `build/eshkol-run -r prog.esk` |
+| `aot-O0` | `build/eshkol-run -O0 prog.esk -o BIN && BIN` |
+| `aot-O2` | `build/eshkol-run -O2 prog.esk -o BIN && BIN` |
+| `vm`     | `eshkol-run --profile hosted-vm --emit-eskb X.eskb prog.esk` then `eshkol-vm-standalone-test X.eskb` |
+
+## Generator
+
+`scripts/gen_generative_corpus.py` — a deterministic (pure function of
+`seed`,`count`) typed recursive generator over a meaningful R7RS-small subset:
+exact integer arithmetic (incl. `quotient`/`remainder`/`modulo`, `gcd`/`lcm`,
+bignum via bounded `expt`), exact rationals, inexact reals (`sqrt`/`floor`/
+`round`/…), booleans and predicates, lists (`cons`/`append`/`reverse`/`map`/
+`list-ref`/`list-tail`), higher-order `map`/`apply`/inline `filter`/`fold`,
+`let`/`let*`/`letrec`/named-let, `cond`/`case`/`if`/`and`/`or`, closures, chars,
+strings (`string-append`/`substring`/`string-upcase`/…), vectors
+(`vector-map`/`list->vector`/`vector-copy`), and quasiquote. Every generated
+program is **closed, printable, TOTAL** (structurally free of division by zero,
+out-of-range indexing and `car` of `'()`) and **deterministic**. Two families:
+
+* **diff** — typed value-printing probes, cross-checked across all oracles.
+* **meta** — self-checking metamorphic properties (each must display `#t`):
+  `(f x)==(apply f (list x))`, `(map f xs)` vs a hand-rolled left-to-right map,
+  `+`/`*` commutativity, `reverse` involution, `length`/`append` homomorphism,
+  `let`/`let*` re-association, fold-vs-`apply +`. A `#f` on any oracle — or a
+  cross-oracle disagreement — is a bug even with **no reference installed**.
+
+Ground-truth validation: all generated programs run cleanly on chibi (generator
+is total) and every `meta` property evaluates to `#t` on chibi.
+
+## Results summary
+
+* **Native paths are clean.** Across every generated program checked, the four
+  native/reference oracles — `chibi`, `jit`, `aot-O0`, `aot-O2` — **agree**.
+  No `*_VS_CHIBI_MISMATCH`, no `AOT_O0_VS_O2_MISMATCH`, no `JIT_VS_AOT_MISMATCH`
+  reproduced under re-verification. (Transient `AOT_O0_VS_O2_STATUS` events seen
+  under heavy concurrent CPU load were **timeout artifacts**; they did not
+  reproduce on a second run and are rejected by the harness's re-verify pass —
+  see "False-positive control" below.) This is a strong positive result: the
+  LLVM codegen, JIT/AOT paths and the new `-O2` default are mutually consistent
+  and R7RS-conformant on the generated subset.
+
+* **The bytecode VM silently diverges** on a broad, common slice of the
+  language. Every divergence below is a **silent wrong answer**: the VM exits 0
+  with **no** `ERROR`/`OVERFLOW`/diagnostic marker (the VM exits 0 even on fatal
+  errors — `tests/vm_parity/found/error_exit_code_zero.esk`), so a wrong value
+  with no warning is the dangerous case this pillar targets. These generalise
+  the "27 VM-vs-native divergences" the maintainer flagged, now reproduced at
+  generated scale and minimised to **7 distinct root-cause defect classes**.
+
+## Exposed VM defects (the treasure) — minimal repros
+
+Each was reduced to a one-line closed program. `chibi` and `jit` (and AOT) all
+produce the correct value; the VM silently produces the wrong one.
+
+### V1. Characters render as their integer code point under `display`
+```scheme
+(display #\I)          ; chibi/jit: I     vm: 73
+(display (char-upcase #\a))  ; chibi/jit: A  vm: 65
+```
+The char type collapses to its code point when displayed.
+(cf. `tests/vm_parity/found/char_type_collapsed.esk`.)
+
+### V2. `list->vector` returns `#f`
+```scheme
+(display (list->vector (list 1 2 3)))   ; chibi/jit: #(1 2 3)   vm: #f
+```
+`(vector 1 2 3)` renders correctly, so it is `list->vector` specifically.
+
+### V3. Large integers / bignums render as inexact floats
+```scheme
+(display (expt 2 40))   ; chibi/jit: 1099511627776   vm: 1.09951e+12
+```
+Exactness and full precision are lost in the VM's numeric printing/representation
+for large integers.
+
+### V4. Exact rationals collapse to inexact floats
+```scheme
+(display (/ 1 3))              ; chibi/jit: 1/3   vm: 0.333333
+(display (+ (/ 1 3) (/ 1 6)))  ; chibi/jit: 1/2   vm: 0.5
+```
+The VM has no exact-rational representation; `/` produces a float.
+
+### V5. `round` is not round-half-to-even
+```scheme
+(display (round 2.5))   ; chibi/jit: 2   vm: 3
+```
+R7RS `round` uses banker's rounding (2.5 → 2, 3.5 → 4); the VM rounds half up.
+
+### V6. `equal?` on compound data returns `#f` (structural equality broken)
+```scheme
+(display (equal? (list 1 2 3) (list 1 2 3)))    ; chibi/jit: #t   vm: #f
+(display (equal? (vector 1 2) (vector 1 2)))     ; chibi/jit: #t   vm: #f
+```
+`equal?` behaves like `eq?` (identity) on pairs and vectors; strings and numbers
+compare correctly. This is the root cause of most `META_PROPERTY_FALSE` VM hits
+(the `reverse`-involution and `map`-ordering properties compare freshly-built
+lists with `equal?`). (cf. `tests/vm_parity/found/equal_eq_structural_false.esk`.)
+
+### V7. Sibling binding-forms as operands corrupt each other
+```scheme
+(display (+ (let ((a 1) (b 2)) (+ a b))
+            (let ((a 10) (b 20)) (+ a b))))   ; chibi/jit: 33   vm: 16
+```
+Two `let`/`let*` blocks used as sibling arguments to the same call clobber each
+other's stack slots in the VM — each block evaluated **alone** is correct
+(`(let ((a 1)(b 2)) (+ a b))` → 3), but as adjacent operands the result is
+wrong. Independent of whether the two blocks share variable names. A frame /
+slot-allocation defect in the VM compiler for nested binding forms in argument
+position. (Related family: `consecutive_do_state_leak.esk`,
+`define_after_do_corrupted.esk`.)
+
+## False-positive control (why the native "clean" result is trustworthy)
+
+A generative differential harness is only credible if it does not cry wolf.
+Every divergence is **re-verified**: on the first sign of a disagreement the
+harness re-runs the same program and keeps only the divergence **kinds** that
+reproduce. Under the heavy concurrent build load on the development host
+(load average ~13, several other agents compiling simultaneously) individual
+`-O2` AOT compiles occasionally exceeded the timeout, which without re-verify
+would surface as a spurious `AOT_O0_VS_O2_STATUS`. Re-verify rejects these; the
+7 VM defects above are perfectly deterministic and survive every re-run.
+
+## Reproduce
+
+```sh
+brew install chibi-scheme
+cmake --build build --target eshkol-run stdlib eshkol-vm-standalone-test -j
+
+# full discovery run (RED while any divergence remains — the philosophy)
+scripts/run_generative_differential.py --seed 1234 --count 60
+
+# regression tripwire against the triaged baseline (green now; RED on a NEW bug)
+scripts/run_generative_differential.sh          # == --smoke --baseline <baseline>
+
+# minimise a single VM defect by hand
+printf '(display (equal? (list 1 2 3) (list 1 2 3)))(newline)\n' > /tmp/r.esk
+build/eshkol-run -r /tmp/r.esk                                   # #t
+build/eshkol-run --profile hosted-vm --emit-eskb /tmp/r.eskb /tmp/r.esk
+build/eshkol-vm-standalone-test /tmp/r.eskb                      # #f
+```
+
+## ICC wiring
+
+The harness writes `kind:"generative_differential"` JSON-L to
+`scripts/icc_traces/generative_differential.jsonl`. The gate event
+`generative_differential_oracle` is consumed by the new
+`.icc/completion-oracles.yaml::generative-differential` oracle (severity high)
+and by the `generative_differential_oracle` probe in `scripts/run_icc_smoke.sh`.
+In regression mode both are PASS while every divergence is a known baseline
+entry; a NEW cross-oracle divergence flips them RED.

--- a/docs/reports/REFERENCE_DIFFERENTIAL_REPORT.md
+++ b/docs/reports/REFERENCE_DIFFERENTIAL_REPORT.md
@@ -1,5 +1,13 @@
 # Reference-Implementation Differential Report (P7a)
 
+> STALE SNAPSHOT — the "27/34 AGREE" results table below is a pre-fix
+> historical snapshot. On current master the harness reports **34/34 AGREE
+> (100%)**; the 7 divergences listed here (ESH-0150..0156) and ESH-0225 are all
+> fixed (see `CHANGELOG.md`). Re-run `scripts/run_reference_differential.sh` to
+> confirm. The fixed 34-program corpus no longer exposes anything, which is why
+> the differential is now *generative* — see
+> `docs/reports/GENERATIVE_DIFFERENTIAL_REPORT.md` (pillar P7c).
+
 External R7RS ground-truth conformance oracle for Eshkol. Unlike every other
 differential harness in this repo (which diffs Eshkol against *itself* across
 its JIT/AOT axes — self-consistency only), this pillar runs the **same portable

--- a/scripts/gen_generative_corpus.py
+++ b/scripts/gen_generative_corpus.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+r"""gen_generative_corpus.py — GENERATIVE R7RS-small program generator for the
+multi-oracle differential harness (adversarial testing pillar P7c).
+
+Motivation (from the maintainer): "if our system does not constantly expose
+every single hidden bug then it has no coverage." The hand-written
+reference-differential corpus (scripts/gen_reference_corpus.py, ~34 programs)
+is far too small to keep exposing miscompiles. This module GENERATES a large,
+deterministic family of closed, printable R7RS-small programs so the harness
+in scripts/run_generative_differential.py can cross-check every one across as
+many execution oracles as are installed (chibi-scheme, Eshkol JIT, Eshkol AOT
+at -O0 and -O2, and the Eshkol bytecode VM). Any pairwise disagreement is an
+exposed bug.
+
+Two program families are produced:
+
+  * DIFFERENTIAL programs (family "diff"): a sequence of typed probe
+    expressions, each wrapped in `(display EXPR)(newline)`. Every probe is
+    TOTAL (well-defined on a conformant R7RS-small implementation — no
+    division by zero, no out-of-range index, no car of '()) and DETERMINISTIC
+    (no time / randomness / addresses). chibi-scheme is ground truth: if chibi
+    errors on a generated program that is a generator bug, not a finding.
+
+  * METAMORPHIC programs (family "meta"): self-checking property assertions
+    that need NO external reference. Each line evaluates a property that must
+    hold under R7RS semantics and displays `#t`. Any oracle that prints `#f`
+    (or errors, or disagrees with another oracle) has exposed a bug. Encoded
+    properties:
+      - (f x)            == (apply f (list x))            [apply equivalence]
+      - (map f xs)       == hand-rolled left-to-right map [map ordering]
+      - (+ a b)          == (+ b a) ; (* a b) == (* b a)  [commutativity]
+      - (reverse (reverse xs)) == xs                       [involution]
+      - (length (append a b)) == (+ (length a)(length b)) [homomorphism]
+      - let/let* re-association where independent
+      - fold-based sum   == (apply + xs)                   [fold equivalence]
+
+Determinism: the corpus is a pure function of (seed, count). Same inputs ->
+byte-identical programs, so CI is reproducible. The generator NEVER embeds a
+timestamp or absolute path.
+
+Portability: every program body uses ONLY R7RS-small identifiers that BOTH
+chibi and Eshkol accept. Higher-order helpers that are NOT in (scheme base)
+(filter, fold) are DEFINED inline under `gd-`/`gm-` prefixes in a shared
+prelude, so no `(import (scheme list))` is needed and the program body is
+byte-identical across engines. The reference runner prepends chibi's import
+prologue; Eshkol needs no imports.
+
+Usage:
+  python3 scripts/gen_generative_corpus.py --out DIR [--seed N] [--count K]
+      Writes K programs per family to DIR (default tests/generative-diff/corpus).
+
+  The harness (run_generative_differential.py) imports generate_programs()
+  directly and does not need the on-disk corpus; the CLI exists for
+  inspection, reproducibility and manual minimisation of a divergence.
+"""
+
+import argparse
+import os
+import random
+import sys
+
+# ---------------------------------------------------------------------------
+# Shared portable prelude. R7RS-base only. Prefixed helpers so they can never
+# shadow (or be shadowed by) an Eshkol or chibi builtin. Included verbatim and
+# identically in EVERY generated program body (both engines see the same text).
+# ---------------------------------------------------------------------------
+PRELUDE = r"""
+(define (gd-filter p xs)
+  (if (null? xs) '()
+      (if (p (car xs))
+          (cons (car xs) (gd-filter p (cdr xs)))
+          (gd-filter p (cdr xs)))))
+(define (gd-foldl f acc xs)
+  (if (null? xs) acc (gd-foldl f (f acc (car xs)) (cdr xs))))
+(define (gd-map1 f xs)
+  (if (null? xs) '() (cons (f (car xs)) (gd-map1 f (cdr xs)))))
+(define (gd-sum xs) (gd-foldl + 0 xs))
+(define (gd-iota n) (let loop ((i 0) (acc '()))
+  (if (= i n) (reverse acc) (loop (+ i 1) (cons i acc)))))
+""".strip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Typed expression generator. Each gen_<type> returns a string that evaluates,
+# on any conformant R7RS-small implementation, to a value of that type WITHOUT
+# raising an error. Totality is enforced structurally: divisors/moduli are
+# always nonzero literals, indices are always in range for a list/string/vector
+# whose length is known at generation time, expt exponents are non-negative.
+# ---------------------------------------------------------------------------
+
+NONZERO = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, -2, -3, -4, -7]
+
+
+class Gen:
+    def __init__(self, rng):
+        self.rng = rng
+        self._vc = 0
+
+    def fresh(self, tag="v"):
+        self._vc += 1
+        return "g%s%d" % (tag, self._vc)
+
+    # ---- integers (exact) -------------------------------------------------
+    def gen_int(self, depth):
+        r = self.rng
+        if depth <= 0:
+            return str(r.randint(-50, 50))
+        pick = r.randrange(14)
+        if pick == 0:
+            return str(r.randint(-50, 50))
+        if pick == 1:
+            op = r.choice(["+", "-", "*"])
+            return "(%s %s %s)" % (op, self.gen_int(depth - 1), self.gen_int(depth - 1))
+        if pick == 2:
+            op = r.choice(["quotient", "remainder", "modulo"])
+            return "(%s %s %s)" % (op, self.gen_int(depth - 1), str(r.choice(NONZERO)))
+        if pick == 3:
+            op = r.choice(["abs", "-"])
+            return "(%s %s)" % (op, self.gen_int(depth - 1))
+        if pick == 4:
+            op = r.choice(["min", "max"])
+            return "(%s %s %s)" % (op, self.gen_int(depth - 1), self.gen_int(depth - 1))
+        if pick == 5:  # bignum via bounded expt
+            return "(expt %d %d)" % (r.choice([2, 3, 5, 7, 10]), r.randint(1, 45))
+        if pick == 6:
+            op = r.choice(["gcd", "lcm"])
+            a = r.randint(1, 48)
+            b = r.randint(1, 48)
+            return "(%s %d %d)" % (op, a, b)
+        if pick == 7:  # if
+            return "(if %s %s %s)" % (self.gen_bool(depth - 1),
+                                      self.gen_int(depth - 1), self.gen_int(depth - 1))
+        if pick == 8:  # let binding + use
+            v = self.fresh()
+            val = self.gen_int(depth - 1)
+            body = "(%s %s %s)" % (r.choice(["+", "-", "*"]), v, self.gen_int(depth - 1))
+            return "(let ((%s %s)) %s)" % (v, val, body)
+        if pick == 9:  # fold / apply over a list literal
+            lst = self.int_list_literal()
+            return r.choice([
+                "(apply + (list %s))" % lst,
+                "(apply * (list %s))" % (self.small_int_list_literal()),
+                "(gd-sum (list %s))" % lst,
+                "(gd-foldl - 0 (list %s))" % lst,
+            ])
+        if pick == 10:  # car/cadr/caddr of known-length list
+            n = r.randint(3, 5)
+            elems = " ".join(self.gen_int(0) for _ in range(n))
+            acc = r.choice(["car", "cadr", "caddr"])
+            return "(%s (list %s))" % (acc, elems)
+        if pick == 11:  # length / list-ref within range
+            n = r.randint(1, 5)
+            elems = " ".join(self.gen_int(0) for _ in range(n))
+            if r.random() < 0.5:
+                return "(length (list %s))" % elems
+            return "(list-ref (list %s) %d)" % (elems, r.randrange(n))
+        if pick == 12:  # cond
+            return ("(cond (%s %s) (%s %s) (else %s))"
+                    % (self.gen_bool(depth - 1), self.gen_int(depth - 1),
+                       self.gen_bool(depth - 1), self.gen_int(depth - 1),
+                       self.gen_int(depth - 1)))
+        # pick == 13: named-let accumulator loop (tail recursion)
+        n = r.randint(0, 12)
+        return ("(let gloop ((gi 0) (gacc 0)) "
+                "(if (= gi %d) gacc (gloop (+ gi 1) (+ gacc gi))))" % n)
+
+    def int_list_literal(self):
+        n = self.rng.randint(2, 6)
+        return " ".join(str(self.rng.randint(-30, 30)) for _ in range(n))
+
+    def small_int_list_literal(self):
+        n = self.rng.randint(2, 4)
+        return " ".join(str(self.rng.randint(-4, 4)) for _ in range(n))
+
+    # ---- exact rationals --------------------------------------------------
+    def gen_ratio(self, depth):
+        r = self.rng
+        if depth <= 0 or r.random() < 0.4:
+            return "(/ %d %d)" % (r.randint(-20, 20), r.choice(NONZERO))
+        op = r.choice(["+", "-", "*"])
+        return "(%s %s %s)" % (op, self.gen_ratio(depth - 1), self.gen_ratio(depth - 1))
+
+    # ---- reals (inexact) --------------------------------------------------
+    def gen_real(self, depth):
+        r = self.rng
+        if depth <= 0:
+            return "%.3f" % r.uniform(-20, 20)
+        pick = r.randrange(7)
+        if pick == 0:
+            return "%.3f" % r.uniform(-20, 20)
+        if pick == 1:
+            op = r.choice(["+", "-", "*"])
+            return "(%s %s %s)" % (op, self.gen_real(depth - 1), self.gen_real(depth - 1))
+        if pick == 2:
+            op = r.choice(["floor", "ceiling", "truncate", "round"])
+            return "(%s %s)" % (op, self.gen_real(depth - 1))
+        if pick == 3:
+            return "(sqrt %s)" % ("%.3f" % r.uniform(0.1, 40.0))
+        if pick == 4:
+            return "(abs %s)" % self.gen_real(depth - 1)
+        if pick == 5:
+            return "(* 1.0 %s)" % self.gen_int(depth - 1)   # exact->inexact via *1.0
+        return "(min %s %s)" % (self.gen_real(depth - 1), self.gen_real(depth - 1))
+
+    # ---- booleans ---------------------------------------------------------
+    def gen_bool(self, depth):
+        r = self.rng
+        if depth <= 0:
+            return r.choice(["#t", "#f"])
+        pick = r.randrange(9)
+        if pick == 0:
+            return r.choice(["#t", "#f"])
+        if pick in (1, 2):
+            op = r.choice(["<", "<=", ">", ">=", "=", "eqv?"])
+            return "(%s %s %s)" % (op, self.gen_int(depth - 1), self.gen_int(depth - 1))
+        if pick == 3:
+            op = r.choice(["and", "or"])
+            return "(%s %s %s)" % (op, self.gen_bool(depth - 1), self.gen_bool(depth - 1))
+        if pick == 4:
+            return "(not %s)" % self.gen_bool(depth - 1)
+        if pick == 5:
+            op = r.choice(["even?", "odd?", "zero?", "positive?", "negative?"])
+            return "(%s %s)" % (op, self.gen_int(depth - 1))
+        if pick == 6:
+            op = r.choice(["null?", "pair?", "list?"])
+            n = r.randint(0, 4)
+            elems = " ".join(self.gen_int(0) for _ in range(n))
+            return "(%s (list %s))" % (op, elems)
+        if pick == 7:
+            return "(equal? %s %s)" % (self.gen_listint(depth - 1), self.gen_listint(depth - 1))
+        return "(if %s %s %s)" % (self.gen_bool(depth - 1),
+                                  self.gen_bool(depth - 1), self.gen_bool(depth - 1))
+
+    # ---- lists of integers ------------------------------------------------
+    def gen_listint(self, depth):
+        r = self.rng
+        if depth <= 0:
+            n = r.randint(0, 4)
+            return "(list %s)" % " ".join(str(r.randint(-9, 9)) for _ in range(n))
+        pick = r.randrange(10)
+        if pick == 0:
+            n = r.randint(0, 5)
+            return "(list %s)" % " ".join(str(r.randint(-9, 9)) for _ in range(n))
+        if pick == 1:
+            return "(cons %s %s)" % (self.gen_int(depth - 1), self.gen_listint(depth - 1))
+        if pick == 2:
+            return "(append %s %s)" % (self.gen_listint(depth - 1), self.gen_listint(depth - 1))
+        if pick == 3:
+            return "(reverse %s)" % self.gen_listint(depth - 1)
+        if pick == 4:
+            return "(cdr (cons 0 %s))" % self.gen_listint(depth - 1)
+        if pick == 5:
+            v = self.fresh("x")
+            return "(map (lambda (%s) (* %s %s)) %s)" % (v, v, v, self.gen_listint(depth - 1))
+        if pick == 6:
+            v = self.fresh("x")
+            return "(map (lambda (%s) (+ %s %d)) %s)" % (v, v, r.randint(-5, 5),
+                                                         self.gen_listint(depth - 1))
+        if pick == 7:
+            v = self.fresh("x")
+            pred = r.choice(["even?", "odd?", "positive?", "negative?"])
+            return "(gd-filter %s %s)" % (pred, self.gen_listint(depth - 1))
+        if pick == 8:
+            return "(gd-iota %d)" % r.randint(0, 8)
+        # cons two ints then existing
+        return "(list-copy %s)" % self.gen_listint(depth - 1)
+
+    # ---- characters -------------------------------------------------------
+    def gen_char(self, depth):
+        r = self.rng
+        c = r.choice(list("abcdefghijklmnopqrstuvwxyzABCDEFGHIJ0123456789"))
+        pick = r.randrange(4)
+        if pick == 0:
+            return "#\\%s" % c
+        if pick == 1:
+            return "(char-upcase #\\%s)" % c
+        if pick == 2:
+            return "(char-downcase #\\%s)" % c
+        return "(integer->char %d)" % r.randint(33, 126)
+
+    # ---- strings ----------------------------------------------------------
+    ALPHA = "abcdefghijklmnopqrstuvwxyz"
+
+    def gen_string(self, depth):
+        r = self.rng
+        base = "".join(r.choice(self.ALPHA) for _ in range(r.randint(3, 9)))
+        if depth <= 0:
+            return '"%s"' % base
+        pick = r.randrange(7)
+        if pick == 0:
+            return '"%s"' % base
+        if pick == 1:
+            return "(string-append %s %s)" % (self.gen_string(depth - 1), self.gen_string(depth - 1))
+        if pick == 2:
+            n = len(base)
+            a = r.randint(0, n)
+            b = r.randint(a, n)
+            return '(substring "%s" %d %d)' % (base, a, b)
+        if pick == 3:
+            return "(string-upcase %s)" % self.gen_string(depth - 1)
+        if pick == 4:
+            return "(string-downcase %s)" % self.gen_string(depth - 1)
+        if pick == 5:
+            return "(list->string (list %s))" % " ".join(
+                "#\\%s" % r.choice(self.ALPHA) for _ in range(r.randint(1, 5)))
+        return "(make-string %d #\\%s)" % (r.randint(0, 5), r.choice(self.ALPHA))
+
+    # ---- vectors ----------------------------------------------------------
+    def gen_vector(self, depth):
+        r = self.rng
+        n = r.randint(0, 5)
+        elems = " ".join(str(r.randint(-9, 9)) for _ in range(n))
+        pick = r.randrange(4)
+        if pick == 0 or n == 0:
+            return "(vector %s)" % elems
+        if pick == 1:
+            v = self.fresh("x")
+            return "(vector-map (lambda (%s) (* %s %s)) (vector %s))" % (v, v, v, elems)
+        if pick == 2:
+            return "(list->vector (list %s))" % elems
+        return "(vector-copy (vector %s) %d)" % (elems, r.randrange(n))
+
+    # ---- dispatch a printable probe of a random type ----------------------
+    PRINTABLE = ["int", "ratio", "real", "bool", "listint", "char", "string", "vector"]
+
+    def gen_printable(self, depth):
+        t = self.rng.choice(self.PRINTABLE)
+        return {
+            "int": self.gen_int,
+            "ratio": self.gen_ratio,
+            "real": self.gen_real,
+            "bool": self.gen_bool,
+            "listint": self.gen_listint,
+            "char": self.gen_char,
+            "string": self.gen_string,
+            "vector": self.gen_vector,
+        }[t](depth)
+
+
+# ---------------------------------------------------------------------------
+# Program builders.
+# ---------------------------------------------------------------------------
+
+def build_diff_program(seed, n_probes=8, depth=4):
+    rng = random.Random(seed)
+    g = Gen(rng)
+    lines = [PRELUDE]
+    for _ in range(n_probes):
+        lines.append("(display %s)(newline)" % g.gen_printable(depth))
+    return "".join(l if l.endswith("\n") else l + "\n" for l in lines)
+
+
+def build_meta_program(seed, n_props=8, depth=3):
+    """Every displayed value MUST be #t on a correct implementation. A #f (or an
+    error, or cross-oracle disagreement) exposes a bug — no reference needed."""
+    rng = random.Random(seed)
+    g = Gen(rng)
+    lines = [PRELUDE]
+
+    def prop(expr_bool):
+        return "(display %s)(newline)" % expr_bool
+
+    for _ in range(n_props):
+        kind = rng.randrange(7)
+        if kind == 0:  # apply equivalence: (f x) == (apply f (list x))
+            v = g.fresh("x")
+            body = g.gen_int(depth)
+            arg = g.gen_int(1)
+            f = "(lambda (%s) %s)" % (v, body)
+            lines.append(prop("(let ((gf %s) (ga %s)) (equal? (gf ga) (apply gf (list ga))))"
+                              % (f, arg)))
+        elif kind == 1:  # map ordering: (map f xs) == gd-map1 f xs
+            v = g.fresh("x")
+            f = "(lambda (%s) (* %s %s))" % (v, v, v)
+            xs = g.gen_listint(depth)
+            lines.append(prop("(let ((gf %s) (gl %s)) (equal? (map gf gl) (gd-map1 gf gl)))"
+                              % (f, xs)))
+        elif kind == 2:  # commutativity of + and *
+            a = g.gen_int(depth)
+            b = g.gen_int(depth)
+            lines.append(prop("(let ((ga %s) (gb %s)) "
+                              "(and (= (+ ga gb) (+ gb ga)) (= (* ga gb) (* gb ga))))"
+                              % (a, b)))
+        elif kind == 3:  # reverse involution
+            xs = g.gen_listint(depth)
+            lines.append(prop("(let ((gl %s)) (equal? (reverse (reverse gl)) gl))" % xs))
+        elif kind == 4:  # length homomorphism over append
+            a = g.gen_listint(depth)
+            b = g.gen_listint(depth)
+            lines.append(prop("(let ((ga %s) (gb %s)) "
+                              "(= (length (append ga gb)) (+ (length ga) (length gb))))"
+                              % (a, b)))
+        elif kind == 5:  # fold equivalence: gd-sum == apply +
+            xs = g.gen_listint(depth)
+            lines.append(prop("(let ((gl %s)) (= (gd-sum gl) (apply + gl)))" % xs))
+        else:  # let re-association where independent
+            a = g.gen_int(depth)
+            b = g.gen_int(depth)
+            lines.append(prop("(= (let ((ga %s) (gb %s)) (- ga gb)) "
+                              "(let* ((gb %s) (ga %s)) (- ga gb)))"
+                              % (a, b, b, a)))
+    return "".join(l if l.endswith("\n") else l + "\n" for l in lines)
+
+
+def generate_programs(seed=1234, count=60, diff_probes=8, meta_props=8):
+    """Return a deterministic list of (family, name, body). Pure function of
+    the arguments — the harness and the CLI both call this."""
+    progs = []
+    for i in range(count):
+        s = seed * 1_000_003 + i
+        progs.append(("diff", "diff_%05d" % i, build_diff_program(s, diff_probes)))
+    for i in range(count):
+        s = seed * 2_000_003 + i
+        progs.append(("meta", "meta_%05d" % i, build_meta_program(s, meta_props)))
+    return progs
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", default=None, help="output corpus directory")
+    ap.add_argument("--seed", type=int, default=1234)
+    ap.add_argument("--count", type=int, default=60,
+                    help="programs PER family (diff + meta) — total is 2*count")
+    args = ap.parse_args()
+
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    out_dir = args.out or os.path.join(repo_root, "tests", "generative-diff", "corpus")
+    os.makedirs(out_dir, exist_ok=True)
+    for f in os.listdir(out_dir):
+        if f.endswith(".scm"):
+            os.remove(os.path.join(out_dir, f))
+
+    progs = generate_programs(seed=args.seed, count=args.count)
+    idx = 0
+    for family, name, body in progs:
+        idx += 1
+        fname = "%04d_%s.scm" % (idx, name)
+        header = ";; %s  (generated; seed=%d; R7RS-small portable)\n" % (name, args.seed)
+        with open(os.path.join(out_dir, fname), "w") as fh:
+            fh.write(header)
+            fh.write(body)
+    print("Wrote %d programs (seed=%d, %d per family) to %s"
+          % (idx, args.seed, args.count, out_dir))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_generative_differential.py
+++ b/scripts/run_generative_differential.py
@@ -1,0 +1,564 @@
+#!/usr/bin/env python3
+r"""run_generative_differential.py — GENERATIVE multi-oracle differential harness
+(adversarial testing pillar P7c).
+
+Principle (from the maintainer): "if our system does not constantly expose every
+single hidden bug then it has no coverage." This harness generates a large,
+deterministic family of closed R7RS-small programs (scripts/gen_generative_
+corpus.py) and runs each one through EVERY execution oracle available, then
+cross-checks the outputs. Any pairwise disagreement is an exposed bug.
+
+Oracles (auto-discovered; a program is checked across all that are present):
+
+  chibi   : chibi-scheme <prologue+body>            (external R7RS ground truth)
+  jit     : build/eshkol-run -r <body.esk>          (LLVM JIT)
+  aot-O0  : build/eshkol-run -O0 <body.esk> -o BIN && BIN
+  aot-O2  : build/eshkol-run -O2 <body.esk> -o BIN && BIN
+  vm      : build/eshkol-run --profile hosted-vm --emit-eskb X.eskb <body.esk>
+            && build/eshkol-vm-standalone-test X.eskb   (bytecode VM)
+
+What this catches that the 34-program hand corpus cannot:
+  * R7RS conformance gaps vs chibi, at generated scale.
+  * AOT-vs-JIT miscompiles (same source, different Eshkol backends disagree).
+  * OPTIMIZATION-LEVEL divergence: aot-O0 vs aot-O2 (metamorphic invariant that
+    guards the recent O2-default change; needs no reference).
+  * SILENT VM miscompiles: the VM exits 0 even on fatal errors, so a wrong
+    value with no error marker is the dangerous case — flagged here.
+  * Metamorphic property violations: the "meta" program family self-checks
+    (f x)==(apply f (list x)), map ordering, commutativity, reverse involution,
+    length/append homomorphism, fold equivalence — any oracle printing #f is a
+    bug even with NO reference installed.
+
+Normalization: chibi/jit/aot outputs are compared through
+scripts/lib/normalize_scheme_output.py (documented cosmetic canonicalisation;
+can only ever hide an implementation-defined rendering difference, never
+manufacture a false agreement). The VM appends a newline per `display` call
+(a filed quirk, tests/vm_parity/found/display_newline_per_call.esk), so any
+comparison INVOLVING the VM additionally strips ALL newlines from both sides —
+the strongest comparison the quirk permits; value divergences still surface.
+
+Determinism / reproducibility: the corpus is a pure function of (seed, count),
+so a divergence found in CI reproduces locally byte-for-byte. On any divergence
+the exact program and every oracle's raw + normalized output are written under
+artifacts/generative-diff/divergences/<program>/.
+
+Known-crasher gating: a program that wedges an oracle process (defeats the
+per-oracle timeout) can be listed in KNOWN_CRASHERS below (documented, with the
+reason) so the harness stays runnable; every oracle otherwise runs under a hard
+timeout and a segfault/timeout is captured as a normal result, not an abort.
+
+Baseline / regression mode: `--baseline FILE` treats the divergences recorded
+in FILE as KNOWN (the currently-exposed bug list) and exits non-zero only when a
+divergence appears that is NOT in the baseline — i.e. a NEW miscompile. Without
+`--baseline` the gate is PASS iff ZERO divergences (the "constantly red while
+bugs remain" philosophy, matching the reference-diff oracle).
+
+ICC: emits kind:"generative_differential" JSON-L to
+scripts/icc_traces/generative_differential.jsonl. The gate event
+generative_differential_oracle is PASS/FAIL; per-divergence events carry the
+program name and divergence kind. Consumed by
+.icc/completion-oracles.yaml::generative-differential and by the
+generative_differential_oracle probe in scripts/run_icc_smoke.sh.
+
+Usage:
+  scripts/run_generative_differential.py [--seed N] [--count K] [--depth D]
+      [--baseline FILE] [--smoke] [--no-vm] [--timeout SECS] [--jobs N]
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(HERE)
+sys.path.insert(0, os.path.join(HERE, "lib"))
+sys.path.insert(0, HERE)
+
+import normalize_scheme_output as _norm          # noqa: E402
+from gen_generative_corpus import generate_programs  # noqa: E402
+
+CHIBI_PROLOGUE = ("(import (scheme base) (scheme write) (scheme char) "
+                  "(scheme inexact) (scheme cxr))\n")
+
+# Programs that reliably wedge an oracle process badly enough to threaten the
+# runner even under the per-oracle timeout. Format: {program_name: "reason"}.
+# Empty by default — every oracle already runs under a hard timeout and a
+# crash/timeout is captured as a normal result. Populate only if a specific
+# generated program is observed to defeat the timeout.
+KNOWN_CRASHERS = {}
+
+
+# VM banner / loader / compiler-noise lines to drop before comparison. Mirrors
+# the perl filter in scripts/run_vm_parity.sh::normalize so only VALUES remain.
+_VM_NOISE_PREFIXES = ("WARN", "INFO:", "DEBUG", "[ESKB]", "[GPU]",
+                      "=== Eshkol VM", "=== Execution complete ===",
+                      "remark:", "warning: <unknown>")
+
+
+def _strip_vm_banner(text):
+    keep = []
+    for ln in text.split("\n"):
+        s = ln.lstrip()
+        if any(s.startswith(p) for p in _VM_NOISE_PREFIXES) or s.startswith("[compiled:"):
+            continue
+        keep.append(ln)
+    return "\n".join(keep)
+
+
+def _oracle_text(r):
+    """Raw stdout to feed the normaliser: strip VM banner/log lines for the VM."""
+    return _strip_vm_banner(r.out) if r.name == "vm" else r.out
+
+
+def _norm_full(text):
+    return _norm.normalize(text)
+
+
+def _norm_nl_free(text):
+    # For any comparison involving the VM (whose display appends a per-call
+    # newline). Preserve spaces; drop newlines. Mirrors run_vm_parity.sh.
+    return _norm_full(text).replace("\n", "")
+
+
+def _nf(r):
+    """Full normalised text of an oracle result (VM banner stripped first)."""
+    return _norm_full(_oracle_text(r))
+
+
+def _nlf(r):
+    """Newline-free normalised text (for comparisons involving the VM)."""
+    return _norm_nl_free(_oracle_text(r))
+
+
+class OracleResult:
+    __slots__ = ("name", "rc", "out", "err", "timed_out", "compile_failed",
+                 "vm_error", "available")
+
+    def __init__(self, name):
+        self.name = name
+        self.rc = None
+        self.out = ""
+        self.err = ""
+        self.timed_out = False
+        self.compile_failed = False
+        self.vm_error = False
+        self.available = True
+
+    def ran_clean(self):
+        """The oracle produced a value we can trust for comparison."""
+        if not self.available:
+            return False
+        if self.timed_out or self.compile_failed or self.vm_error:
+            return False
+        return self.rc == 0
+
+
+def _run(cmd, timeout, env=None, cwd=None):
+    try:
+        p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                           timeout=timeout, env=env, cwd=cwd)
+        return p.returncode, p.stdout.decode("utf-8", "replace"), \
+            p.stderr.decode("utf-8", "replace"), False
+    except subprocess.TimeoutExpired as e:
+        out = (e.stdout or b"").decode("utf-8", "replace")
+        err = (e.stderr or b"").decode("utf-8", "replace")
+        return None, out, err, True
+
+
+class Harness:
+    def __init__(self, args):
+        self.args = args
+        self.build = os.path.join(REPO_ROOT, args.build)
+        self.eshkol = os.path.join(self.build, "eshkol-run")
+        vm = os.path.join(self.build, "eshkol-vm-standalone-test")
+        if not os.path.exists(vm):
+            vm = os.path.join(self.build, "eshkol-vm-standalone")
+        self.vm_bin = vm
+        self.chibi = shutil.which("chibi-scheme")
+        self.timeout = args.timeout
+        self.work = tempfile.mkdtemp(prefix="eshkol-gendiff.")
+        self.esk = os.path.join(self.work, "prog.esk")
+        self.scm = os.path.join(self.work, "prog.scm")
+        self.bin = os.path.join(self.work, "prog.bin")
+        self.eskb = os.path.join(self.work, "prog.eskb")
+        self.jit_cache = os.path.join(self.work, "jit-cache")
+        os.makedirs(self.jit_cache, exist_ok=True)
+        # Which oracles participate.
+        self.use_vm = (not args.no_vm) and os.path.exists(self.vm_bin)
+        self.use_chibi = (not args.no_chibi) and self.chibi is not None
+        self.art = os.path.join(REPO_ROOT, "artifacts", "generative-diff")
+        self.diverg_dir = os.path.join(self.art, "divergences")
+
+    def cleanup(self):
+        shutil.rmtree(self.work, ignore_errors=True)
+
+    # ---- individual oracle runners ---------------------------------------
+    def run_chibi(self, body):
+        r = OracleResult("chibi")
+        if not self.use_chibi:
+            r.available = False
+            return r
+        with open(self.scm, "w") as fh:
+            fh.write(CHIBI_PROLOGUE)
+            fh.write(body)
+        r.rc, r.out, r.err, r.timed_out = _run([self.chibi, self.scm], self.timeout)
+        return r
+
+    def run_jit(self, body):
+        r = OracleResult("jit")
+        with open(self.esk, "w") as fh:
+            fh.write(body)
+        env = dict(os.environ, ESHKOL_JIT_CACHE_DIR=self.jit_cache)
+        r.rc, r.out, r.err, r.timed_out = _run(
+            [self.eshkol, "-r", self.esk], self.timeout, env=env)
+        return r
+
+    def run_aot(self, body, opt):
+        r = OracleResult("aot-%s" % opt)
+        with open(self.esk, "w") as fh:
+            fh.write(body)
+        if os.path.exists(self.bin):
+            os.remove(self.bin)
+        crc, cout, cerr, cto = _run(
+            [self.eshkol, "-%s" % opt, self.esk, "-o", self.bin], self.timeout)
+        if cto:
+            r.timed_out = True
+            r.err = cerr
+            return r
+        if crc != 0 or not os.path.exists(self.bin):
+            r.compile_failed = True
+            r.rc = crc
+            r.err = cerr + cout
+            return r
+        r.rc, r.out, r.err, r.timed_out = _run([self.bin], self.timeout)
+        if os.path.exists(self.bin):
+            os.remove(self.bin)
+        return r
+
+    def run_vm(self, body):
+        r = OracleResult("vm")
+        if not self.use_vm:
+            r.available = False
+            return r
+        with open(self.esk, "w") as fh:
+            fh.write(body)
+        if os.path.exists(self.eskb):
+            os.remove(self.eskb)
+        crc, cout, cerr, cto = _run(
+            [self.eshkol, "--profile", "hosted-vm", "--emit-eskb", self.eskb, self.esk],
+            self.timeout)
+        if cto or crc != 0 or not os.path.exists(self.eskb):
+            r.compile_failed = True
+            r.rc = crc
+            r.err = cerr
+            return r
+        env = dict(os.environ, ESHKOL_VM_NO_DISASM="1")
+        r.rc, r.out, r.err, r.timed_out = _run([self.vm_bin, self.eskb], self.timeout, env=env)
+        # The VM exits 0 even on fatal errors; stderr markers are the signal.
+        markers = ("ERROR", "OVERFLOW", "unhandled native call", "Assertion",
+                   "Segmentation", "abort")
+        if any(m in r.err for m in markers):
+            r.vm_error = True
+        return r
+
+    # ---- one program across all oracles ----------------------------------
+    def check_program(self, family, name, body):
+        """Return a list of divergence dicts (empty if all oracles agree)."""
+        crasher = name in KNOWN_CRASHERS
+        results = {}
+        results["chibi"] = self.run_chibi(body)
+        results["jit"] = self.run_jit(body)
+        results["aot-O0"] = self.run_aot(body, "O0")
+        results["aot-O2"] = self.run_aot(body, "O2")
+        results["vm"] = self.run_vm(body)
+
+        divs = []
+
+        def add(kind, detail, involved):
+            divs.append({
+                "program": name, "family": family, "kind": kind,
+                "detail": detail, "oracles": involved,
+            })
+
+        chibi = results["chibi"]
+        jit = results["jit"]
+        aot0 = results["aot-O0"]
+        aot2 = results["aot-O2"]
+        vm = results["vm"]
+
+        # --- reference truth: prefer chibi, else jit ----------------------
+        ref = chibi if chibi.ran_clean() else (jit if jit.ran_clean() else None)
+
+        # Timeouts are ENVIRONMENTAL (CPU contention on the host), never counted
+        # as a differential bug — an oracle that timed out simply does not
+        # participate in any comparison for this program.
+        def participates(o):
+            return o.available and not o.timed_out
+
+        # (1) Each Eshkol native path vs the reference (chibi first).
+        if chibi.ran_clean():
+            ref_norm = _nf(chibi)
+            for o in (jit, aot0, aot2):
+                if not participates(o):
+                    continue
+                if not o.ran_clean():
+                    add("%s_VS_CHIBI_ERROR" % o.name.upper().replace("-", "_"),
+                        "chibi exit 0 but %s errored (rc=%s comp_fail=%s)"
+                        % (o.name, o.rc, o.compile_failed),
+                        {"chibi": chibi, o.name: o})
+                elif _nf(o) != ref_norm:
+                    add("%s_VS_CHIBI_MISMATCH" % o.name.upper().replace("-", "_"),
+                        "output differs from chibi ground truth", {"chibi": chibi, o.name: o})
+
+        # (2) Optimization-level metamorphic invariant: aot-O0 == aot-O2.
+        if aot0.ran_clean() and aot2.ran_clean():
+            if _nf(aot0) != _nf(aot2):
+                add("AOT_O0_VS_O2_MISMATCH",
+                    "AOT output changes with optimization level (miscompile)",
+                    {"aot-O0": aot0, "aot-O2": aot2})
+        elif (participates(aot0) and participates(aot2)
+              and aot0.ran_clean() != aot2.ran_clean()):
+            # One opt level errored (a real codegen error, not a timeout) while
+            # the other produced a value.
+            add("AOT_O0_VS_O2_STATUS",
+                "one AOT opt level errored and the other produced a value",
+                {"aot-O0": aot0, "aot-O2": aot2})
+
+        # (3) JIT vs AOT-O0 metamorphic invariant (same backend surface).
+        if jit.ran_clean() and aot0.ran_clean():
+            if _nf(jit) != _nf(aot0):
+                add("JIT_VS_AOT_MISMATCH",
+                    "JIT and AOT disagree on the same source",
+                    {"jit": jit, "aot-O0": aot0})
+
+        # (4) Silent VM miscompile: VM ran clean (no error marker) but its value
+        #     disagrees with the reference. Newline-free comparison (VM quirk).
+        if self.use_vm and ref is not None:
+            if vm.ran_clean():
+                if _nlf(vm) != _nlf(ref):
+                    add("VM_SILENT_WRONG",
+                        "VM exited clean but value differs from %s" % ref.name,
+                        {ref.name: ref, "vm": vm})
+            # A VM error marker means the feature is outside the VM subset — that
+            # is expected drift, not a differential bug, so it is NOT flagged.
+
+        # (5) Metamorphic self-check: a "meta" program printing #f is a property
+        #     violation on whichever oracle printed it (reference-free).
+        if family == "meta":
+            for o in (chibi, jit, aot0, aot2, vm):
+                if not o.available or not o.ran_clean():
+                    continue
+                if "#f" in _nf(o):
+                    add("META_PROPERTY_FALSE",
+                        "%s printed #f for a property that must hold" % o.name,
+                        {o.name: o})
+
+        if crasher and divs:
+            # Documented known-crasher: record but tag so the gate can ignore.
+            for d in divs:
+                d["known_crasher"] = True
+
+        return divs, results
+
+
+def _sig(d):
+    return "%s::%s" % (d["program"], d["kind"])
+
+
+def load_baseline(path):
+    if not path or not os.path.exists(path):
+        return set()
+    sigs = set()
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                sigs.add(line)
+    return sigs
+
+
+def write_divergence_artifacts(h, family, name, results, divs):
+    d = os.path.join(h.diverg_dir, name)
+    os.makedirs(d, exist_ok=True)
+    for oname, r in results.items():
+        if not r.available:
+            continue
+        with open(os.path.join(d, "%s.stdout" % oname), "w") as fh:
+            fh.write(r.out)
+        if r.err:
+            with open(os.path.join(d, "%s.stderr" % oname), "w") as fh:
+                fh.write(r.err)
+    with open(os.path.join(d, "DIVERGENCES.txt"), "w") as fh:
+        for x in divs:
+            fh.write("%s :: %s :: %s\n" % (x["kind"], x["program"], x["detail"]))
+
+
+def emit_trace(trace_file, name, value, snippet):
+    with open(trace_file, "a") as fh:
+        fh.write(json.dumps({
+            "kind": "generative_differential", "name": name, "value": value,
+            "snippet": snippet, "confidence": 0.95,
+        }) + "\n")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--seed", type=int, default=1234)
+    ap.add_argument("--count", type=int, default=60, help="programs per family")
+    ap.add_argument("--depth", type=int, default=4)
+    ap.add_argument("--timeout", type=int, default=30)
+    ap.add_argument("--build", default="build")
+    ap.add_argument("--baseline", default=None,
+                    help="known-divergence file; exit non-zero only on NEW divergences")
+    ap.add_argument("--write-baseline", default=None,
+                    help="write the found divergence signatures to this file and exit 0")
+    ap.add_argument("--no-vm", action="store_true")
+    ap.add_argument("--no-chibi", action="store_true")
+    ap.add_argument("--no-reverify", action="store_true",
+                    help="skip the reproduce-once confirmation of each divergence")
+    ap.add_argument("--smoke", action="store_true",
+                    help="fast reduced run (seed=1234 count=12) for CI probes")
+    ap.add_argument("--trace-dir", default=os.path.join(REPO_ROOT, "scripts", "icc_traces"))
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args()
+
+    if args.smoke:
+        args.count = min(args.count, 12)
+
+    if not os.path.exists(os.path.join(REPO_ROOT, args.build, "eshkol-run")):
+        print("FATAL: build/eshkol-run not found — build it: "
+              "cmake --build build --target eshkol-run stdlib -j", file=sys.stderr)
+        return 2
+
+    os.makedirs(args.trace_dir, exist_ok=True)
+    trace_file = os.path.join(args.trace_dir, "generative_differential.jsonl")
+    open(trace_file, "w").close()
+
+    h = Harness(args)
+    shutil.rmtree(h.diverg_dir, ignore_errors=True)
+    os.makedirs(h.diverg_dir, exist_ok=True)
+
+    oracles = ["jit", "aot-O0", "aot-O2"]
+    if h.use_chibi:
+        oracles = ["chibi"] + oracles
+    if h.use_vm:
+        oracles = oracles + ["vm"]
+
+    print("Generative differential harness (P7c)")
+    print("  seed=%d  count/family=%d  depth=%d  timeout=%ds" %
+          (args.seed, args.count, args.depth, args.timeout))
+    print("  oracles: %s" % ", ".join(oracles))
+    print("  chibi:  %s" % (h.chibi or "(not installed — reference-free mode)"))
+    print("  vm:     %s" % (h.vm_bin if h.use_vm else "(disabled)"))
+    print("-" * 72)
+
+    programs = generate_programs(seed=args.seed, count=args.count)
+    all_divs = []
+    n_checked = 0
+    per_program_div = 0
+    try:
+        for family, name, body in programs:
+            divs, results = h.check_program(family, name, body)
+            n_checked += 1
+            if divs and not args.no_reverify:
+                # Re-verify: re-run the program and keep only divergence KINDS
+                # that reproduce. This rejects environmental flakiness (a
+                # compile/run that timed out under transient CPU contention
+                # would otherwise masquerade as an AOT-O0-vs-O2 status
+                # divergence). A genuine miscompile is deterministic and
+                # survives; a timeout under load usually does not.
+                divs2, results2 = h.check_program(family, name, body)
+                kinds2 = set(d["kind"] for d in divs2)
+                confirmed = [d for d in divs if d["kind"] in kinds2]
+                dropped = [d for d in divs if d["kind"] not in kinds2]
+                if dropped and not args.quiet:
+                    for d in dropped:
+                        print("  (flaky, not reproduced) %-22s %s" % (d["kind"], name))
+                divs = confirmed
+                # Prefer the artifacts from whichever run still shows the divergence.
+                if divs and any(d["kind"] in kinds2 for d in divs):
+                    results = results2
+            if divs:
+                per_program_div += 1
+                all_divs.extend(divs)
+                write_divergence_artifacts(h, family, name, results, divs)
+                if not args.quiet:
+                    for d in divs:
+                        print("  DIVERGENCE %-26s %s  (%s)"
+                              % (d["kind"], name, d["detail"]))
+    finally:
+        h.cleanup()
+
+    # Group by kind for the summary.
+    by_kind = {}
+    for d in all_divs:
+        by_kind.setdefault(d["kind"], []).append(d["program"])
+
+    print("-" * 72)
+    print("programs checked : %d" % n_checked)
+    print("programs w/ divergence : %d" % per_program_div)
+    print("total divergences: %d" % len(all_divs))
+    for kind in sorted(by_kind):
+        progs = sorted(set(by_kind[kind]))
+        print("  %-28s %3d   e.g. %s" % (kind, len(progs), ", ".join(progs[:4])))
+
+    # Emit per-kind + gate events.
+    found_sigs = set(_sig(d) for d in all_divs if not d.get("known_crasher"))
+    for kind in sorted(by_kind):
+        emit_trace(trace_file, "kind:%s" % kind, "DIVERGES",
+                   "%d programs: %s" % (len(set(by_kind[kind])),
+                                        ", ".join(sorted(set(by_kind[kind]))[:8])))
+
+    if args.write_baseline:
+        with open(args.write_baseline, "w") as fh:
+            fh.write("# generative_differential baseline — known divergence "
+                     "signatures (program::kind).\n")
+            fh.write("# Regenerate: scripts/run_generative_differential.py "
+                     "--seed %d --count %d --write-baseline %s\n"
+                     % (args.seed, args.count, os.path.basename(args.write_baseline)))
+            for s in sorted(found_sigs):
+                fh.write(s + "\n")
+        print("Wrote baseline (%d signatures) to %s" % (len(found_sigs), args.write_baseline))
+        emit_trace(trace_file, "generative_differential_oracle", "PASS",
+                   "baseline written: %d known divergences" % len(found_sigs))
+        return 0
+
+    baseline = load_baseline(args.baseline)
+    new_divs = sorted(found_sigs - baseline) if args.baseline else sorted(found_sigs)
+    stale = sorted(baseline - found_sigs) if args.baseline else []
+
+    if args.baseline:
+        print("baseline signatures: %d   new (not in baseline): %d   stale: %d"
+              % (len(baseline), len(new_divs), len(stale)))
+        for s in new_divs:
+            print("  NEW DIVERGENCE  %s" % s)
+        for s in stale:
+            print("  (stale baseline entry no longer reproduces: %s)" % s)
+
+    gate_pass = (len(new_divs) == 0)
+    gate = "PASS" if gate_pass else "FAIL"
+    if args.baseline:
+        snippet = ("baseline mode: %d known, %d NEW divergences (%s)"
+                   % (len(baseline), len(new_divs), ", ".join(new_divs[:6]) or "none"))
+    else:
+        snippet = ("%d divergences across %d programs (%d checked); kinds: %s"
+                   % (len(all_divs), per_program_div, n_checked,
+                      ", ".join(sorted(by_kind)) or "none"))
+    emit_trace(trace_file, "generative_differential_oracle", gate, snippet)
+
+    print("-" * 72)
+    print("gate: %s   (%s)" % (gate, snippet))
+    print("trace: %s" % trace_file)
+    if all_divs:
+        print("divergence artifacts: %s" % h.diverg_dir)
+
+    return 0 if gate_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_generative_differential.sh
+++ b/scripts/run_generative_differential.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# run_generative_differential.sh — thin wrapper around the generative
+# multi-oracle differential harness (adversarial testing pillar P7c).
+#
+# Exists so the harness can be an ICC `action:` and a scripts/run_icc_smoke.sh
+# probe with a stable command line. All real logic lives in the Python harness
+# (scripts/run_generative_differential.py); see tests/generative-diff/README.md.
+#
+# Default invocation runs in regression mode against the committed baseline
+# (tests/generative-diff/baseline.txt): exit 0 iff no NEW divergence appears.
+# Pass any flags to override (e.g. --count 60 with no --baseline for a full
+# discovery run that is RED while any divergence remains).
+#
+# Usage:
+#   scripts/run_generative_differential.sh                 # smoke + baseline
+#   scripts/run_generative_differential.sh --count 60      # full discovery
+#   scripts/run_generative_differential.sh <any harness flags...>
+set -u
+
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+BASELINE="$REPO_ROOT/tests/generative-diff/baseline.txt"
+
+if [ "$#" -eq 0 ]; then
+    exec python3 "$REPO_ROOT/scripts/run_generative_differential.py" \
+        --smoke --baseline "$BASELINE"
+fi
+
+exec python3 "$REPO_ROOT/scripts/run_generative_differential.py" "$@"

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -411,6 +411,19 @@ probe define_loop_flat_rss_aot 'ESH-0214b: AOT guard-wrapped define loop keeps R
 probe reader_fuzz_smoke 'seeded adversarial reader harness: no crash/hang, depth guard graceful (fixed-seed smoke pass)' \
     'cd "$REPO_ROOT" && bash scripts/run_reader_fuzz.sh --smoke'
 
+# ───────────────────────────────────────────────────────────────────
+# Generative multi-oracle differential (P7c). Generates a deterministic
+# family of closed R7RS-small programs and cross-checks each across
+# chibi / Eshkol JIT / AOT-O0 / AOT-O2 / bytecode VM plus metamorphic
+# self-checks. Regression mode: passes iff no divergence appears outside
+# the triaged baseline (tests/generative-diff/baseline.txt) — a NEW
+# miscompile trips it. See docs/reports/GENERATIVE_DIFFERENTIAL_REPORT.md
+# and tests/generative-diff/README.md.
+# ───────────────────────────────────────────────────────────────────
+probe generative_differential_oracle 'generated R7RS programs agree across chibi/JIT/AOT-O0/AOT-O2/VM + metamorphic (no NEW divergence vs baseline)' \
+    'cd "$REPO_ROOT" && python3 scripts/run_generative_differential.py --smoke \
+        --baseline tests/generative-diff/baseline.txt --quiet'
+
 echo
 echo "Trace written: $TRACE_FILE"
 echo "Run: python3 ~/Desktop/infinite_context_coder/scripts/codebase_tool.py \\"

--- a/tests/generative-diff/README.md
+++ b/tests/generative-diff/README.md
@@ -1,0 +1,80 @@
+# Generative multi-oracle differential harness (adversarial testing pillar P7c)
+
+> "If our system does not constantly expose every single hidden bug then it has
+> no coverage." — the maintainer.
+
+The hand-written reference-differential corpus (`scripts/gen_reference_corpus.py`,
+34 programs) is now 34/34 AGREE against chibi on master — it no longer exposes
+anything. This pillar makes differential testing **generative and multi-oracle**:
+it generates a large, deterministic family of closed R7RS-small programs and runs
+each one through every execution oracle installed, flagging any pairwise
+disagreement.
+
+## Pieces
+
+| File | Role |
+|---|---|
+| `scripts/gen_generative_corpus.py` | Deterministic program generator (a pure function of `seed`, `count`). Two families: **diff** (typed value-printing probes) and **meta** (self-checking metamorphic properties). Every program is closed, printable, TOTAL (no div-by-zero / out-of-range / car-of-'()) and deterministic. |
+| `scripts/run_generative_differential.py` | The harness: generates programs, runs every oracle, normalises, cross-checks, writes divergence artifacts, emits the ICC trace. |
+| `scripts/run_generative_differential.sh` | Thin wrapper used as the ICC `action:` and by the smoke probe. |
+| `tests/generative-diff/baseline.txt` | Known-divergence signatures (`program::kind`). The smoke probe fails only on a divergence **not** in this baseline — i.e. a NEW miscompile. |
+
+## Oracles (auto-discovered)
+
+* `chibi`  — `chibi-scheme` (external R7RS ground truth; optional).
+* `jit`    — `build/eshkol-run -r prog.esk` (LLVM JIT).
+* `aot-O0` — `build/eshkol-run -O0 prog.esk -o BIN && BIN`.
+* `aot-O2` — `build/eshkol-run -O2 prog.esk -o BIN && BIN`.
+* `vm`     — `eshkol-run --profile hosted-vm --emit-eskb X.eskb prog.esk`
+             then `eshkol-vm-standalone-test X.eskb` (bytecode VM).
+
+## Divergence kinds
+
+| Kind | Meaning |
+|---|---|
+| `JIT_VS_CHIBI_MISMATCH` / `AOT_O0_VS_CHIBI_MISMATCH` / `AOT_O2_VS_CHIBI_MISMATCH` | An Eshkol native path disagrees with chibi ground truth (R7RS conformance bug). |
+| `*_VS_CHIBI_ERROR` | chibi ran clean (exit 0) but an Eshkol path errored/crashed/timed out. |
+| `AOT_O0_VS_O2_MISMATCH` | AOT output changes with optimisation level — a miscompile. Reference-free; guards the O2-default change. |
+| `JIT_VS_AOT_MISMATCH` | JIT and AOT disagree on the same source. Reference-free. |
+| `VM_SILENT_WRONG` | The VM exited **without an error marker** but its value differs from the reference — a silent VM miscompile (the treasure; the VM exits 0 even on fatal errors, so a wrong value with no diagnostic is the dangerous case). |
+| `META_PROPERTY_FALSE` | A `meta`-family program printed `#f` for a property that must hold — a reference-free bug on whichever oracle printed it. |
+
+The VM is only flagged when it runs *clean*: if the VM prints an
+`ERROR`/`OVERFLOW`/unhandled-native marker the feature is simply outside the VM
+subset (tracked by the P5 `vm-parity` ratchet) and is **not** counted here.
+
+## Normalisation
+
+`chibi`/`jit`/`aot` outputs pass through `scripts/lib/normalize_scheme_output.py`
+(documented cosmetic canonicalisation — boolean spelling, nested char/string
+rendering, float precision to 6 sig-figs; can only hide an implementation-defined
+rendering difference, never manufacture a false agreement). Any comparison
+involving the `vm` additionally strips the VM banner/loader lines and then all
+newlines (the VM appends a newline per `display`, a filed quirk) — the strongest
+comparison that quirk permits; value divergences still surface.
+
+## Running
+
+```sh
+# full discovery run (RED while divergences remain — the philosophy)
+scripts/run_generative_differential.py --seed 1234 --count 60
+
+# regression mode: fail only on a divergence NOT already in the baseline
+scripts/run_generative_differential.py --smoke --baseline tests/generative-diff/baseline.txt
+
+# regenerate the on-disk corpus for inspection / manual minimisation
+python3 scripts/gen_generative_corpus.py --out tests/generative-diff/corpus
+```
+
+Determinism: the corpus is a pure function of `(seed, count)`, so a divergence
+found in CI reproduces locally byte-for-byte. On any divergence the exact program
+and every oracle's raw stdout/stderr are written under
+`artifacts/generative-diff/divergences/<program>/` (gitignored).
+
+## ICC wiring
+
+The harness writes `kind:"generative_differential"` events to
+`scripts/icc_traces/generative_differential.jsonl`. The gate event
+`generative_differential_oracle` is consumed by
+`.icc/completion-oracles.yaml::generative-differential` and by the
+`generative_differential_oracle` probe in `scripts/run_icc_smoke.sh`.

--- a/tests/generative-diff/baseline.txt
+++ b/tests/generative-diff/baseline.txt
@@ -1,0 +1,15 @@
+# generative_differential baseline — known divergence signatures (program::kind).
+# Regenerate: scripts/run_generative_differential.py --seed 1234 --count 12 --write-baseline baseline.txt
+diff_00000::VM_SILENT_WRONG
+diff_00001::VM_SILENT_WRONG
+diff_00003::VM_SILENT_WRONG
+diff_00006::VM_SILENT_WRONG
+diff_00007::VM_SILENT_WRONG
+diff_00008::VM_SILENT_WRONG
+meta_00001::META_PROPERTY_FALSE
+meta_00001::VM_SILENT_WRONG
+meta_00003::VM_SILENT_WRONG
+meta_00007::META_PROPERTY_FALSE
+meta_00007::VM_SILENT_WRONG
+meta_00008::META_PROPERTY_FALSE
+meta_00008::VM_SILENT_WRONG


### PR DESCRIPTION
## Summary

The hand-written reference-differential corpus (P7a, `scripts/gen_reference_corpus.py`, 34 programs) is **34/34 AGREE** against chibi on master and no longer exposes anything. This PR makes differential testing **generative and multi-oracle** so it keeps surfacing miscompiles at scale, per the principle: "if our system does not constantly expose every single hidden bug then it has no coverage."

## What's here

- **Generator** (`scripts/gen_generative_corpus.py`): deterministic (pure function of seed+count) typed recursive generator over a meaningful R7RS-small subset — exact/rational/bignum arithmetic, lists, higher-order `map`/`apply`/`filter`/`fold`, `let`/`let*`/`letrec`/named-let, `cond`/`case`, closures + `set!`, tail recursion, vectors, strings, chars, quasiquote. Two families: **diff** (typed value probes) and **meta** (self-checking metamorphic properties). Every program is closed, printable, total and deterministic; all run cleanly on chibi and every meta property holds there.
- **Harness** (`scripts/run_generative_differential.py`): runs each program through every installed oracle — chibi (external R7RS truth), Eshkol JIT (`-r`), AOT at `-O0` **and** `-O2`, and the bytecode VM — and cross-checks. Catches R7RS gaps vs chibi, AOT-vs-JIT miscompiles, optimization-level divergence (`-O0` vs `-O2`, guarding the O2 default), silent VM miscompiles, and metamorphic property violations. Divergences are **re-verified** (reproduce-once) to reject load-induced timeout flakiness; timeouts are environmental and never counted. On divergence the exact program + every oracle's output are written under `artifacts/generative-diff/`. Baseline/regression mode fails only on a NEW divergence; a `KNOWN_CRASHERS` gate keeps it runnable.
- **ICC wiring**: emits `kind:"generative_differential"` to `scripts/icc_traces/generative_differential.jsonl`; a `generative_differential_oracle` probe in `scripts/run_icc_smoke.sh` and a high-severity `generative-differential` oracle in `.icc/completion-oracles.yaml`.
- **Report**: `docs/reports/GENERATIVE_DIFFERENTIAL_REPORT.md`.

## Resolved: the 34-vs-27 conflict

`REFERENCE_DIFFERENTIAL_REPORT.md` said 27/34 (RED); `CHANGELOG.md` said 34/34. Re-running `scripts/run_reference_differential.sh` on this branch: **34/34 AGREE, 100%, gate PASS**. The CHANGELOG is correct; the report's "27/34" table was a stale pre-fix snapshot (ESH-0150..0156 + ESH-0225 are fixed). A stale-snapshot banner was added to that report.

## Exposed bugs (not fixed here — for separate fixing agents)

Native paths (chibi/JIT/AOT-O0/AOT-O2) are **clean** — no native divergence reproduces. The bytecode VM **silently** diverges (exits 0, no diagnostic) in **7 distinct root-cause classes**, each with a one-line repro in the report:

1. Characters render as their integer code point under `display` (`(display #\I)` → `73`).
2. `list->vector` returns `#f`.
3. Large integers / bignums render as inexact floats (`(expt 2 40)` → `1.09951e+12`).
4. Exact rationals collapse to inexact floats (`(/ 1 3)` → `0.333333`).
5. `round` is not round-half-to-even (`(round 2.5)` → `3`).
6. `equal?` on lists/vectors returns `#f` (identity, not structural).
7. Sibling `let`/`let*` operands corrupt each other's frame slots (`(+ (let ((a 1)(b 2))(+ a b)) (let ((a 10)(b 20))(+ a b)))` → `16`, expected `33`).

## Reproduce

```sh
cmake --build build --target eshkol-run stdlib eshkol-vm-standalone-test -j
scripts/run_generative_differential.py --seed 1234 --count 60     # full discovery
scripts/run_generative_differential.sh                            # regression tripwire (green)
```

The harness ships **green** in regression mode against the triaged baseline (`tests/generative-diff/baseline.txt`); it flips RED the moment a NEW divergence is generated.