### PR TITLE
fix(stdlib): make sort and filter tail-recursive for large lists

### DIFF
--- a/lib/core/list/sort.esk
+++ b/lib/core/list/sort.esk
@@ -5,37 +5,71 @@
 
 ;;; sort: Sort a list using merge sort
 ;;; (sort '(3 1 4 1 5 9 2 6) <) => (1 1 2 3 4 5 6 9)
+;;;
+;;; ESH-0098: the original merge/len/take-n helpers built their result via
+;;; non-tail `(cons x (helper ...))` / `(+ 1 (helper ...))` recursion, so
+;;; their native call-stack depth grew with the *length of the list being
+;;; processed* rather than with the O(log n) depth of the merge-sort
+;;; recursion tree. `len` alone recursed as deep as the whole list on the
+;;; very first call, guaranteeing a blown stack well under a million
+;;; elements ("maximum recursion depth (100000) exceeded" at 500k+). Every
+;;; helper below is now an accumulator-based tail loop (the same
+;;; nested-define self-tail-call pattern used by `length`/`filter`), so
+;;; each lowers to a real loop with O(1) added native stack regardless of
+;;; list length. Only the `sort` recursion itself grows with input size,
+;;; and it halves the list at every level, so its depth is O(log n) --
+;;; about 21 frames for 2,000,000 elements. As a side effect this also
+;;; makes the sort stable: ties now keep the left half's element first
+;;; (the original was not stable -- on ties it emitted the right half's
+;;; element first).
 (define (sort lst less?)
-  ;; Merge two sorted lists
-  (define (merge l1 l2)
-    (cond ((null? l1) l2)
-          ((null? l2) l1)
-          ((less? (car l1) (car l2))
-           (cons (car l1) (merge (cdr l1) l2)))
-          (else
-           (cons (car l2) (merge l1 (cdr l2))))))
+  ;; rappend: (append (reverse rev) tail), as a single tail loop.
+  ;; Used to "un-reverse" an accumulator built up in reverse order.
+  (define (rappend rev tail)
+    (if (null? rev)
+        tail
+        (rappend (cdr rev) (cons (car rev) tail))))
 
-  ;; Get the length
-  (define (len lst)
-    (if (null? lst) 0 (+ 1 (len (cdr lst)))))
+  ;; Count list length: iterative accumulator (mirrors `length`).
+  (define (len rest n)
+    (if (null? rest)
+        n
+        (len (cdr rest) (+ n 1))))
 
-  ;; Take first n elements (local version)
-  (define (take-n n lst)
-    (if (or (<= n 0) (null? lst))
-        '()
-        (cons (car lst) (take-n (- n 1) (cdr lst)))))
+  ;; Take first n elements, preserving order: accumulate then un-reverse.
+  (define (take-n n rest acc)
+    (if (or (<= n 0) (null? rest))
+        (rappend acc '())
+        (take-n (- n 1) (cdr rest) (cons (car rest) acc))))
 
-  ;; Drop first n elements (local version)
-  (define (drop-n n lst)
-    (if (or (<= n 0) (null? lst))
-        lst
-        (drop-n (- n 1) (cdr lst))))
+  ;; Drop first n elements (already tail-recursive).
+  (define (drop-n n rest)
+    (if (or (<= n 0) (null? rest))
+        rest
+        (drop-n (- n 1) (cdr rest))))
 
-  ;; Main merge sort - split by counting, not mutating
+  ;; Merge two already-sorted lists: accumulate then un-reverse onto
+  ;; whichever input still has elements left. Stable: on ties (neither
+  ;; strictly less than the other), the left list's element is taken.
+  ;; Written with nested `if` rather than `cond`: the backend's tail-call
+  ;; optimizer only recognizes `if` in tail position, so a `cond`-based
+  ;; accumulator loop here still blows the recursion-depth guard even
+  ;; though every branch is logically a tail call.
+  (define (merge l1 l2 acc)
+    (if (null? l1)
+        (rappend acc l2)
+        (if (null? l2)
+            (rappend acc l1)
+            (if (less? (car l2) (car l1))
+                (merge l1 (cdr l2) (cons (car l2) acc))
+                (merge (cdr l1) l2 (cons (car l1) acc))))))
+
+  ;; Main merge sort - split by counting, not mutating.
   (cond ((null? lst) '())
         ((null? (cdr lst)) lst)
         (else
-         (let ((n (len lst)))
+         (let ((n (len lst 0)))
            (let ((mid (quotient n 2)))
-             (merge (sort (take-n mid lst) less?)
-                    (sort (drop-n mid lst) less?)))))))
+             (merge (sort (take-n mid lst '()) less?)
+                    (sort (drop-n mid lst) less?)
+                    '()))))))

--- a/lib/core/list/transform.esk
+++ b/lib/core/list/transform.esk
@@ -49,10 +49,21 @@
   (rev-helper lst '()))
 
 ;;; filter: Return elements satisfying predicate
+;;; Iterative (properly tail-recursive) accumulator traversal, same pattern
+;;; as `length`/`reverse`: O(n) time, O(1) stack. The previous non-tail
+;;; `(cons (car lst) (filter pred (cdr lst)))` overflowed the native stack
+;;; (SIGBUS) near 10^6 elements (ESH-0108). Written with nested `if` rather
+;;; than `cond`: the backend's tail-call optimizer only recognizes `if` in
+;;; tail position, so a `cond`-based accumulator loop here still blows the
+;;; recursion-depth guard even though every branch is logically a tail call.
 (define (filter pred lst)
-  (cond ((null? lst) '())
-        ((pred (car lst)) (cons (car lst) (filter pred (cdr lst))))
-        (else (filter pred (cdr lst)))))
+  (define (loop rest acc)
+    (if (null? rest)
+        (reverse acc)
+        (if (pred (car rest))
+            (loop (cdr rest) (cons (car rest) acc))
+            (loop (cdr rest) acc))))
+  (loop lst '()))
 
 ;;; unzip: Split a list of pairs into two lists
 ;;; (unzip '((a 1) (b 2) (c 3))) => ((a b c) (1 2 3))

--- a/tests/stdlib/sort_filter_scale_test.esk
+++ b/tests/stdlib/sort_filter_scale_test.esk
@@ -1,0 +1,150 @@
+;;; tests/stdlib/sort_filter_scale_test.esk
+;;;
+;;; Regression test for:
+;;;   ESH-0098 - stdlib `sort` (lib/core/list/sort.esk) had O(n) recursion
+;;;              depth (its `len`/`take-n`/`merge` helpers were non-tail
+;;;              recursive), crashing with "maximum recursion depth
+;;;              (100000) exceeded" on lists >= ~500k elements.
+;;;   ESH-0108 - stdlib `filter` (lib/core/list/transform.esk) was non-tail
+;;;              recursive, SIGBUS-crashing (native stack overflow) near
+;;;              10^6 elements.
+;;;
+;;; Both were rewritten as accumulator-based tail loops (the same pattern
+;;; already used by `length`/`reverse`), giving O(1) added native stack per
+;;; helper call regardless of list length; `sort`'s own recursion is now
+;;; the only part that grows with input size, and it halves the list at
+;;; every level, so its depth is O(log n) (~21 frames at 2,000,000
+;;; elements). This test pins both small-input correctness (including
+;;; stability, which the fix also restored) and large-input survival.
+
+(require stdlib)
+(require core.testing)
+
+(reset-tests!)
+
+;; ---------------------------------------------------------------------
+;; Small correctness checks
+;; ---------------------------------------------------------------------
+
+(register-test "sort: empty and singleton"
+  (lambda ()
+    (check-equal? (sort '() <) '())
+    (check-equal? (sort '(7) <) '(7))))
+
+(register-test "sort: already sorted / reverse sorted / duplicates"
+  (lambda ()
+    (check-equal? (sort '(1 2 3 4 5) <) '(1 2 3 4 5))
+    (check-equal? (sort '(5 4 3 2 1) <) '(1 2 3 4 5))
+    (check-equal? (sort '(3 1 4 1 5 9 2 6 5 3 5) <) '(1 1 2 3 3 4 5 5 5 6 9))
+    (check-equal? (sort '(2 2 2 2) <) '(2 2 2 2))))
+
+(register-test "sort: stability (ties keep left-input order)"
+  (lambda ()
+    ;; Tag each value with a marker for its original position; sort by
+    ;; value only and confirm tied values come out in original relative
+    ;; order (a stable sort must not reorder equal elements).
+    (let* ((data (list (cons 1 'a) (cons 2 'x) (cons 1 'b)
+                        (cons 2 'y) (cons 1 'c) (cons 0 'z)))
+           (sorted (sort data (lambda (p q) (< (car p) (car q)))))
+           (tags (map cdr sorted)))
+      (check-equal? tags '(z a b c x y)))))
+
+(register-test "filter: matches naive reference on small input"
+  (lambda ()
+    (define (naive-filter pred lst)
+      (if (null? lst)
+          '()
+          (if (pred (car lst))
+              (cons (car lst) (naive-filter pred (cdr lst)))
+              (naive-filter pred (cdr lst)))))
+    (let ((data (list 1 2 3 4 5 6 7 8 9 10 11 12 -1 -2 0)))
+      (check-equal? (filter even? data) (naive-filter even? data))
+      (check-equal? (filter (lambda (x) (> x 5)) data)
+                    (naive-filter (lambda (x) (> x 5)) data))
+      (check-equal? (filter (lambda (x) (< x -100)) data) '())
+      (check-equal? (filter (lambda (x) #t) data) data))))
+
+;; ---------------------------------------------------------------------
+;; Scale checks (ESH-0098 / ESH-0108 regression pins)
+;;
+;; Verification below is done with locally-defined, deliberately
+;; tail-recursive helpers rather than reusing stdlib procedures like
+;; `count-if` (still non-tail recursive) -- the point of this test is to
+;; confirm `sort`/`filter` survive at scale, so the verification path
+;; itself must not introduce a new depth-related crash.
+;; ---------------------------------------------------------------------
+
+;; (build-descending n) => (n-1 n-2 ... 1 0), built with a tail loop.
+(define (build-descending n)
+  (define (loop i acc)
+    (if (>= i n)
+        acc
+        (loop (+ i 1) (cons i acc))))
+  (loop 0 '()))
+
+(define (count-list lst)
+  (define (loop rest n)
+    (if (null? rest)
+        n
+        (loop (cdr rest) (+ n 1))))
+  (loop lst 0))
+
+(define (sum-list lst)
+  (define (loop rest acc)
+    (if (null? rest)
+        acc
+        (loop (cdr rest) (+ acc (car rest)))))
+  (loop lst 0))
+
+(define (monotonic-nondec? lst)
+  (define (loop rest)
+    (if (null? (cdr rest))
+        #t
+        (if (> (car rest) (car (cdr rest)))
+            #f
+            (loop (cdr rest)))))
+  (if (or (null? lst) (null? (cdr lst))) #t (loop lst)))
+
+(define (monotonic-nonincr? lst)
+  (define (loop rest)
+    (if (null? (cdr rest))
+        #t
+        (if (< (car rest) (car (cdr rest)))
+            #f
+            (loop (cdr rest)))))
+  (if (or (null? lst) (null? (cdr lst))) #t (loop lst)))
+
+(define (count-matching pred lst)
+  (define (loop rest n)
+    (if (null? rest)
+        n
+        (loop (cdr rest) (if (pred (car rest)) (+ n 1) n))))
+  (loop lst 0))
+
+(register-test "sort: 2,000,000 elements survive without crashing and sort correctly"
+  (lambda ()
+    (let* ((n 2000000)
+           (input (build-descending n))     ; (n-1 n-2 ... 1 0)
+           (expected-sum (sum-list input))
+           (sorted-lst (sort input <)))
+      (check-equal? (count-list sorted-lst) n)
+      (check-true (monotonic-nondec? sorted-lst))
+      ;; Same total => sorted output is (overwhelmingly likely to be) a
+      ;; genuine permutation of the input, not a truncated/corrupted list.
+      (check-equal? (sum-list sorted-lst) expected-sum)
+      (check-equal? (car sorted-lst) 0)
+      (check-equal? (car (drop sorted-lst (- n 1))) (- n 1)))))
+
+(register-test "filter: 1,000,000 elements survive without crashing and filter correctly"
+  (lambda ()
+    (let* ((n 1000000)
+           (input (build-descending n))     ; strictly descending
+           (expected-count (count-matching even? input))
+           (result (filter even? input)))
+      (check-equal? (count-list result) expected-count)
+      ;; filter preserves relative order, and a subsequence of a strictly
+      ;; descending list is itself non-increasing.
+      (check-true (monotonic-nonincr? result))
+      (check-equal? (count-matching odd? result) 0))))
+
+(run-tests)


### PR DESCRIPTION
## Summary

- ESH-0098: `sort` (`lib/core/list/sort.esk`) had O(n) native call-stack depth in its `len`/`take-n`/`merge` helpers (non-tail `cons`/`+` recursion), so sorting hit `maximum recursion depth (100000) exceeded` at 500k+ elements. `len` alone recursed as deep as the whole list on the very first call.
- ESH-0108: `filter` (`lib/core/list/transform.esk`) built its result via non-tail `(cons (car lst) (filter pred (cdr lst)))`, SIGBUS-crashing near 10^6 elements.
- Both helpers are rewritten as accumulator-based tail loops (the same pattern already used by `length`/`reverse`). Note: the backend's tail-call optimizer only recognizes `if` in tail position, not `cond` — a `cond`-based accumulator loop still blew the recursion-depth guard even though every branch was logically a tail call, so both fixes use nested `if`.
- `sort`'s own recursion is now the only part whose depth grows with input size, and it halves the list at every level (~21 frames at 2,000,000 elements).
- Side effect: merge is now stable on ties (the original was not — it emitted the right half's element first on ties instead of the left half's).

## Before / after

| Case | Before | After |
|---|---|---|
| `sort` 99,999 elements | OK | OK |
| `sort` 500,000 elements | `maximum recursion depth (100000) exceeded` | OK |
| `sort` 2,000,000 elements | crash | OK (~27s JIT / ~27s AOT) |
| `filter` 500,000 elements | OK | OK |
| `filter` 1,000,000 elements | SIGBUS (stack overflow) | OK |
| `filter` 2,000,000 elements | crash | OK |

## Correctness verification

- `sort` output checksums (index-weighted sum, mod 1e9+7) matched a Python reference `sorted()` exactly on: random (n=2000), already-sorted, reverse-sorted, low-cardinality duplicates, and all-equal inputs.
- `sort` is now stable; verified with tagged duplicate keys (previously it was not stable — ties came out in reversed relative order).
- `filter` output checksums matched a Python reference filter exactly across evens/mod-k predicates, always-true, and always-false (empty-result) cases.
- Edge cases: `(sort '() <)`, `(sort '(x) <)`, `(filter p '())`, `(filter p '(x))` all correct.

## Regression suite

- Added `tests/stdlib/sort_filter_scale_test.esk` (19 checks via `core.testing`): small-input correctness/stability/duplicates for `sort`, naive-filter comparison for `filter`, and scale pins — `sort` at 2,000,000 elements and `filter` at 1,000,000 elements — verified via locally-defined tail-recursive helpers (not stdlib `count-if`, which is itself still non-tail). Passes 19/19 under both `-r` (JIT) and AOT.
- Existing suites re-run green after the fix: `tests/lists/stdlib_test.esk`, `tests/lists/stdlib_display_test.esk`, `tests/modules/stdlib_test.esk`, `tests/differential/corpus/37_sort.esk`, `tests/metamorphic/generated/metamorphic_sorting.esk` (96/96 metamorphic sort-law trials), `tests/features/new_functions_test.esk`, `tests/memory/memory_test.esk`.
- `tests/stress/found/sort_100k.esk`, previously pinned `xknown ESH-0098`, now passes (XPASS) — the stress-harness manifest (`tests/stress/budgets.tsv`) still marks it `xknown`, so it will need to be promoted to a normal row; left untouched here per scope (gate wiring is handled centrally).

## Author identity check

- Commit authored as `tsotchke <tsotchkele@gmail.com>`.
- No `Co-Authored-By` or AI-attribution trailer in the commit message.

## Test plan

- [x] Reproduced both bugs at the stated failure thresholds before the fix
- [x] Verified fix resolves both, JIT and AOT
- [x] Correctness vs reference sort/filter (random, duplicates, sorted, reverse-sorted)
- [x] Scale: sort 2,000,000 / filter 1,000,000 (and 2,000,000) complete without crash
- [x] New regression test passes 19/19, JIT and AOT
- [x] Existing stdlib/list/metamorphic suites remain green