### PR TITLE
feat(numeric): bignum-capable exact rational type (ESH-0105, ESH-0123)

### DIFF
--- a/inc/eshkol/core/rational.h
+++ b/inc/eshkol/core/rational.h
@@ -13,20 +13,77 @@
 #define ESHKOL_CORE_RATIONAL_H
 
 #include <eshkol/eshkol.h>
+#include <eshkol/core/bignum.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* Rational struct: 16 bytes, always GCD-reduced, denominator > 0 */
+/*
+ * Bignum-capable exact rational.
+ *
+ * Two representations, chosen canonically so equal values share one form:
+ *   - is_big == 0 (fast path): numerator/denominator hold the reduced int64
+ *     pair, denominator > 0. Used whenever both fit in int64.
+ *   - is_big == 1 (bignum path): big_num/big_den hold the reduced bignum
+ *     pair (big_den > 0). Used ONLY when the reduced numerator or denominator
+ *     does not fit in int64. In this case numerator/denominator are unused
+ *     (set to 0/1).
+ *
+ * Invariant (both paths): the fraction is fully GCD-reduced with a positive
+ * denominator, and the int64 fast path is preferred whenever representable —
+ * so value equality reduces to comparing (is_big, and the active fields).
+ *
+ * The numerator/denominator int64 fields remain the first two members so the
+ * common small-rational read paths keep working unchanged.
+ */
 typedef struct {
-    int64_t numerator;
-    int64_t denominator;
+    int64_t numerator;    /* fast-path numerator   (valid iff is_big == 0) */
+    int64_t denominator;  /* fast-path denominator (valid iff is_big == 0; > 0) */
+    int32_t is_big;       /* 0 = int64 fast path, 1 = bignum path */
+    int32_t reserved;
+    eshkol_bignum_t* big_num;  /* bignum numerator   (valid iff is_big == 1) */
+    eshkol_bignum_t* big_den;  /* bignum denominator (valid iff is_big == 1; > 0) */
 } eshkol_rational_t;
 
-/* Create a rational from numerator/denominator, auto-reduces via GCD */
+/* Create a rational from int64 numerator/denominator, auto-reduces via GCD.
+ * Promotes to the bignum path only for the INT64_MIN sign-flip corner. */
 void* eshkol_rational_create(void* arena, int64_t num, int64_t denom);
+
+/* Create a rational from two bignum numerator/denominator pointers.
+ * Sign-canonicalizes (positive denominator), GCD-reduces via bignum gcd,
+ * and demotes to the int64 fast path when the reduced pair fits.
+ * Never degrades to double — this is the exact bignum-rational constructor. */
+void* eshkol_rational_create_bn(void* arena, eshkol_bignum_t* num, eshkol_bignum_t* denom);
+
+/* Build an EXACT tagged number from bignum numerator/denominator: an INT64 or
+ * bare bignum when the reduced denominator is 1, otherwise a rational HEAP_PTR.
+ * Used by the bignum division dispatch to preserve exactness (ESH-0105). */
+void eshkol_rational_from_bignums_tagged(
+    void* arena, eshkol_bignum_t* num, eshkol_bignum_t* denom,
+    eshkol_tagged_value_t* result);
+
+/* (make-rational num den) with tagged operands: each of num/den may be an
+ * INT64 or a bignum HEAP_PTR (bignum-magnitude literal). Produces an exact
+ * INT64/bignum (when the reduced denominator is 1) or a rational HEAP_PTR. */
+void eshkol_rational_make_tagged(
+    void* arena, const eshkol_tagged_value_t* num, const eshkol_tagged_value_t* den,
+    eshkol_tagged_value_t* result);
+
+/* Value equality on reduced rationals (handles both int64 and bignum paths).
+ * Used by eqv?/equal? via the deep-equality runtime (ESH-0114). */
+int eshkol_rational_equal(void* a, void* b);
+
+/* Write a rational's "n/d" (or bare "n" when integer) form to a FILE*. */
+void eshkol_rational_display(void* r, void* file);
+
+/* Tagged numerator/denominator: return an exact INT64 or bignum HEAP_PTR so
+ * bignum-magnitude rationals report their true numerator/denominator. */
+void eshkol_rational_numerator_tagged(
+    void* arena, const eshkol_tagged_value_t* v, eshkol_tagged_value_t* result);
+void eshkol_rational_denominator_tagged(
+    void* arena, const eshkol_tagged_value_t* v, eshkol_tagged_value_t* result);
 
 /* Arithmetic: returns arena-allocated rational pointer */
 void* eshkol_rational_add(void* arena, void* a, void* b);

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -2072,8 +2072,10 @@ public:
         function_return_types["%make-lazy-promise"] = BuiltinTypes::Value;
         function_return_types["%make-lazy-promise-force"] = BuiltinTypes::Value;
         function_return_types["rational?"] = BuiltinTypes::Boolean;
-        function_return_types["numerator"] = BuiltinTypes::Int64;
-        function_return_types["denominator"] = BuiltinTypes::Int64;
+        // numerator/denominator may return a bignum for bignum-magnitude
+        // rationals, so they are tagged Values, not raw int64.
+        function_return_types["numerator"] = BuiltinTypes::Value;
+        function_return_types["denominator"] = BuiltinTypes::Value;
         function_return_types["make-rational"] = BuiltinTypes::Value;
         function_return_types["rationalize"] = BuiltinTypes::Value;
         function_return_types["read-string"] = BuiltinTypes::String;
@@ -14765,96 +14767,64 @@ private:
             return packBoolToTaggedValue(phi);
         }
 
-        if (func_name == "numerator") {
+        // (numerator x) / (denominator x): route through the runtime so
+        // bignum-magnitude rationals report their true (possibly bignum)
+        // numerator/denominator (ESH-0105), not a truncated int64 field read.
+        if (func_name == "numerator" || func_name == "denominator") {
             TypedValue tv = codegenTypedAST(&op->call_op.variables[0]);
             if (!tv.llvm_value) return nullptr;
             Value* arg = typedValueToTaggedValue(tv);
 
-            // If INT64, numerator is the value itself
-            // If HEAP_PTR+RATIONAL, extract numerator field
-            Value* type_tag = builder->CreateExtractValue(arg, {0});
-            Value* is_int = builder->CreateICmpEQ(type_tag,
-                ConstantInt::get(int8_type, ESHKOL_VALUE_INT64));
+            auto* tvTy = tagged_value_type;
+            auto* ptrTy = PointerType::getUnqual(*context);
+            Value* arg_alloca = builder->CreateAlloca(tvTy, nullptr, "nd_arg");
+            Value* res_alloca = builder->CreateAlloca(tvTy, nullptr, "nd_res");
+            builder->CreateStore(arg, arg_alloca);
 
-            Function* current_func = builder->GetInsertBlock()->getParent();
-            BasicBlock* int_bb = BasicBlock::Create(*context, "num_int", current_func);
-            BasicBlock* rat_bb = BasicBlock::Create(*context, "num_rat", current_func);
-            BasicBlock* merge_bb = BasicBlock::Create(*context, "num_merge", current_func);
-
-            builder->CreateCondBr(is_int, int_bb, rat_bb);
-
-            builder->SetInsertPoint(int_bb);
-            Value* int_val = builder->CreateExtractValue(arg, {4});
-            builder->CreateBr(merge_bb);
-
-            builder->SetInsertPoint(rat_bb);
-            Value* ptr = builder->CreateIntToPtr(
-                builder->CreateExtractValue(arg, {4}), PointerType::getUnqual(*context));
-            Value* num = builder->CreateLoad(int64_type, ptr, "numerator");
-            builder->CreateBr(merge_bb);
-
-            builder->SetInsertPoint(merge_bb);
-            PHINode* phi = builder->CreatePHI(int64_type, 2);
-            phi->addIncoming(int_val, int_bb);
-            phi->addIncoming(num, rat_bb);
-            return packInt64ToTaggedValue(phi);
+            const char* rt_name = (func_name == "numerator")
+                ? "eshkol_rational_numerator_tagged"
+                : "eshkol_rational_denominator_tagged";
+            Function* nd_fn = module->getFunction(rt_name);
+            if (!nd_fn) {
+                FunctionType* ft = FunctionType::get(Type::getVoidTy(*context),
+                    {ptrTy, ptrTy, ptrTy}, false);
+                nd_fn = Function::Create(ft, Function::ExternalLinkage,
+                    rt_name, module.get());
+            }
+            Value* arena_ptr = builder->CreateLoad(ptrTy, global_arena);
+            builder->CreateCall(nd_fn, {arena_ptr, arg_alloca, res_alloca});
+            return builder->CreateLoad(tvTy, res_alloca,
+                func_name == "numerator" ? "numerator_result" : "denominator_result");
         }
 
-        if (func_name == "denominator") {
-            TypedValue tv = codegenTypedAST(&op->call_op.variables[0]);
-            if (!tv.llvm_value) return nullptr;
-            Value* arg = typedValueToTaggedValue(tv);
-
-            // If INT64, denominator is 1
-            // If HEAP_PTR+RATIONAL, extract denominator field
-            Value* type_tag = builder->CreateExtractValue(arg, {0});
-            Value* is_int = builder->CreateICmpEQ(type_tag,
-                ConstantInt::get(int8_type, ESHKOL_VALUE_INT64));
-
-            Function* current_func = builder->GetInsertBlock()->getParent();
-            BasicBlock* int_bb = BasicBlock::Create(*context, "den_int", current_func);
-            BasicBlock* rat_bb = BasicBlock::Create(*context, "den_rat", current_func);
-            BasicBlock* merge_bb = BasicBlock::Create(*context, "den_merge", current_func);
-
-            builder->CreateCondBr(is_int, int_bb, rat_bb);
-
-            builder->SetInsertPoint(int_bb);
-            builder->CreateBr(merge_bb);
-
-            builder->SetInsertPoint(rat_bb);
-            Value* ptr = builder->CreateIntToPtr(
-                builder->CreateExtractValue(arg, {4}), PointerType::getUnqual(*context));
-            Value* denom_ptr = builder->CreateGEP(int8_type, ptr,
-                ConstantInt::get(int64_type, 8));
-            Value* denom = builder->CreateLoad(int64_type, denom_ptr, "denominator");
-            builder->CreateBr(merge_bb);
-
-            builder->SetInsertPoint(merge_bb);
-            PHINode* phi = builder->CreatePHI(int64_type, 2);
-            phi->addIncoming(ConstantInt::get(int64_type, 1), int_bb);
-            phi->addIncoming(denom, rat_bb);
-            return packInt64ToTaggedValue(phi);
-        }
-
-        // (make-rational num denom) — explicit rational constructor
+        // (make-rational num denom) — explicit rational constructor.
+        // Operands are passed as tagged values (INT64 or bignum HEAP_PTR) so
+        // bignum-magnitude numerator/denominator stay exact (ESH-0123).
         if (func_name == "make-rational" || func_name == "/rational") {
             TypedValue num_tv = codegenTypedAST(&op->call_op.variables[0]);
             TypedValue den_tv = codegenTypedAST(&op->call_op.variables[1]);
             if (!num_tv.llvm_value || !den_tv.llvm_value) return nullptr;
-            Value* num = unpackInt64FromTaggedValue(typedValueToTaggedValue(num_tv));
-            Value* den = unpackInt64FromTaggedValue(typedValueToTaggedValue(den_tv));
+            Value* num_tagged = typedValueToTaggedValue(num_tv);
+            Value* den_tagged = typedValueToTaggedValue(den_tv);
 
-            // Call runtime: eshkol_rational_create(arena, num, denom)
-            Function* create_fn = module->getFunction("eshkol_rational_create");
-            if (!create_fn) {
-                FunctionType* ft = FunctionType::get(PointerType::getUnqual(*context),
-                    {PointerType::getUnqual(*context), int64_type, int64_type}, false);
-                create_fn = Function::Create(ft, Function::ExternalLinkage,
-                    "eshkol_rational_create", module.get());
+            auto* tvTy = tagged_value_type;
+            auto* ptrTy = PointerType::getUnqual(*context);
+            Value* num_alloca = builder->CreateAlloca(tvTy, nullptr, "mkrat_num");
+            Value* den_alloca = builder->CreateAlloca(tvTy, nullptr, "mkrat_den");
+            Value* result_alloca = builder->CreateAlloca(tvTy, nullptr, "mkrat_res");
+            builder->CreateStore(num_tagged, num_alloca);
+            builder->CreateStore(den_tagged, den_alloca);
+
+            Function* mk_fn = module->getFunction("eshkol_rational_make_tagged");
+            if (!mk_fn) {
+                FunctionType* ft = FunctionType::get(Type::getVoidTy(*context),
+                    {ptrTy, ptrTy, ptrTy, ptrTy}, false);
+                mk_fn = Function::Create(ft, Function::ExternalLinkage,
+                    "eshkol_rational_make_tagged", module.get());
             }
-            Value* arena_ptr = builder->CreateLoad(PointerType::getUnqual(*context), global_arena);
-            Value* rat_ptr = builder->CreateCall(create_fn, {arena_ptr, num, den});
-            return packPtrToTaggedValue(rat_ptr, ESHKOL_VALUE_HEAP_PTR);
+            Value* arena_ptr = builder->CreateLoad(ptrTy, global_arena);
+            builder->CreateCall(mk_fn, {arena_ptr, num_alloca, den_alloca, result_alloca});
+            return builder->CreateLoad(tvTy, result_alloca, "make_rational_result");
         }
 
         // (rationalize x epsilon) — R7RS: simplest rational within epsilon of x

--- a/lib/core/bignum.cpp
+++ b/lib/core/bignum.cpp
@@ -941,6 +941,27 @@ void eshkol_bignum_binary_tagged(arena_t* arena,
     const eshkol_tagged_value_t* left, const eshkol_tagged_value_t* right,
     int op, eshkol_tagged_value_t* result) {
 
+    /* Exact rational operands (either side) route to the bignum-capable
+     * rational dispatch so mixed rational/bignum arithmetic stays exact
+     * (ESH-0105). A rational operand reaching the bignum add/sub/mul/div path
+     * would otherwise be misread as a bignum by tagged_to_bignum(). */
+    bool left_rat = eshkol_is_rational_tagged(*left);
+    bool right_rat = eshkol_is_rational_tagged(*right);
+    if (left_rat || right_rat) {
+        if (op >= 0 && op <= 3) {
+            *result = eshkol_rational_binary_tagged(arena, *left, *right, op);
+            return;
+        }
+        if (op == 7) { /* unary neg: 0 - operand, via exact rational sub */
+            eshkol_tagged_value_t zero = eshkol_make_int64(0, true);
+            *result = eshkol_rational_binary_tagged(arena, zero, *left, 1);
+            return;
+        }
+        /* mod/quotient/remainder on a non-integer rational is undefined. */
+        *result = eshkol_make_int64(0, true);
+        return;
+    }
+
     /* op 7 = unary neg (right is ignored) */
     if (op == 7) {
         eshkol_bignum_t* a = tagged_to_bignum(arena, left);
@@ -982,17 +1003,17 @@ void eshkol_bignum_binary_tagged(arena_t* arena,
         case 0: r = eshkol_bignum_add(arena, a, b); break;
         case 1: r = eshkol_bignum_sub(arena, a, b); break;
         case 2: r = eshkol_bignum_mul(arena, a, b); break;
-        case 3: { /* div: exact if mod==0, else inexact double */
-            eshkol_bignum_t* m = eshkol_bignum_mod(arena, a, b);
-            if (m && eshkol_bignum_is_zero(m)) {
-                r = eshkol_bignum_div(arena, a, b);
-            } else {
-                double ad = eshkol_bignum_to_double(a);
-                double bd = eshkol_bignum_to_double(b);
-                *result = eshkol_make_double(ad / bd);
+        case 3: { /* div: exact — quotient when evenly divisible, else an
+                   * EXACT rational a/b (ESH-0105: never degrade to double). */
+            if (eshkol_bignum_is_zero(b)) {
+                eshkol_exception_t* exc = eshkol_make_exception(
+                    ESHKOL_EXCEPTION_DIVIDE_BY_ZERO, "bignum division by zero");
+                eshkol_raise(exc);
+                *result = eshkol_make_int64(0, true);
                 return;
             }
-            break;
+            eshkol_rational_from_bignums_tagged(arena, a, b, result);
+            return;
         }
         case 4: {
             /* modulo: R7RS floor-mod — result has the SAME SIGN AS THE DIVISOR.
@@ -1089,6 +1110,15 @@ void eshkol_gcd_tagged(arena_t* arena,
 void eshkol_bignum_compare_tagged(
     const eshkol_tagged_value_t* left, const eshkol_tagged_value_t* right,
     int op, eshkol_tagged_value_t* result) {
+
+    /* Exact rational operand on either side: route to the rational comparison,
+     * which handles rational/int/bignum mixes exactly. Reuse the runtime
+     * thread-local arena for any bignum cross-product scratch. */
+    if (eshkol_is_rational_tagged(*left) || eshkol_is_rational_tagged(*right)) {
+        extern arena_t* arena_get_thread_local(void);
+        eshkol_rational_compare_tagged_ptr(arena_get_thread_local(), left, right, op, result);
+        return;
+    }
 
     bool left_is_heap = (left->type == ESHKOL_VALUE_HEAP_PTR);
     bool right_is_heap = (right->type == ESHKOL_VALUE_HEAP_PTR);

--- a/lib/core/rational.cpp
+++ b/lib/core/rational.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <eshkol/core/rational.h>
+#include <eshkol/core/bignum.h>
 #include <eshkol/eshkol.h>
 #include <eshkol/logger.h>
 #include <cmath>
@@ -20,6 +21,63 @@ extern "C" void* arena_allocate_with_header(void* arena, uint64_t data_size,
                                              uint8_t subtype, uint8_t flags);
 extern "C" void* arena_allocate(void* arena, uint64_t size);
 extern "C" void* arena_allocate_string_with_header(void* arena, uint64_t size);
+/* Runtime thread-local (or global) arena — used by the arena-less rational
+ * comparison API for bignum cross-product scratch space. */
+extern "C" arena_t* arena_get_thread_local(void);
+
+/* ===== Bignum-path helpers =====
+ * The exact rational substrate promotes to arbitrary precision whenever the
+ * reduced numerator or denominator leaves int64 range. All bignum work goes
+ * through the public bignum API (lib/core/bignum.cpp); this file never
+ * degrades an exact rational to double. */
+
+/** True if bignum @p a equals the int64 constant @p k. */
+static inline bool bn_equals_i64(const eshkol_bignum_t* a, int64_t k) {
+    int64_t v;
+    return eshkol_bignum_fits_int64(a, &v) && v == k;
+}
+
+/** Non-negative bignum GCD of |a| and |b| (Euclid over magnitudes). */
+static eshkol_bignum_t* bn_gcd(arena_t* arena,
+                               const eshkol_bignum_t* a,
+                               const eshkol_bignum_t* b) {
+    eshkol_bignum_t* x = a->sign ? eshkol_bignum_neg(arena, a) : (eshkol_bignum_t*)a;
+    eshkol_bignum_t* y = b->sign ? eshkol_bignum_neg(arena, b) : (eshkol_bignum_t*)b;
+    while (!eshkol_bignum_is_zero(y)) {
+        eshkol_bignum_t* r = eshkol_bignum_mod(arena, x, y);
+        if (!r) break;
+        if (r->sign) r->sign = 0; /* magnitude */
+        x = y;
+        y = r;
+    }
+    if (x && x->sign) x->sign = 0;
+    return x;
+}
+
+/* Allocate a small (int64 fast-path) rational, assuming num/denom already
+ * reduced with denom > 0. */
+static void* rational_alloc_small(void* arena, int64_t num, int64_t denom) {
+    eshkol_rational_t* r = (eshkol_rational_t*)arena_allocate_with_header(
+        arena, sizeof(eshkol_rational_t), HEAP_SUBTYPE_RATIONAL, 0);
+    r->numerator = num;
+    r->denominator = denom;
+    r->is_big = 0;
+    r->reserved = 0;
+    r->big_num = nullptr;
+    r->big_den = nullptr;
+    return r;
+}
+
+/* Extract a rational operand's numerator as a bignum (promoting the small
+ * fast path). */
+static eshkol_bignum_t* rat_num_bn(arena_t* arena, const eshkol_rational_t* r) {
+    return r->is_big ? r->big_num : eshkol_bignum_from_int64(arena, r->numerator);
+}
+
+/* Extract a rational operand's denominator as a bignum. */
+static eshkol_bignum_t* rat_den_bn(arena_t* arena, const eshkol_rational_t* r) {
+    return r->is_big ? r->big_den : eshkol_bignum_from_int64(arena, r->denominator);
+}
 
 /** Euclidean greatest common divisor of two 64-bit integers (operates on absolute values). */
 static int64_t gcd(int64_t a, int64_t b) {
@@ -52,8 +110,10 @@ static inline int fits_int64(__int128_t v) {
     return v >= (__int128_t)INT64_MIN && v <= (__int128_t)INT64_MAX;
 }
 
-/* Create a rational from 128-bit intermediates.
- * Returns NULL if result doesn't fit in int64 after GCD reduction. */
+/* Create a rational from 128-bit intermediates (both operands were small).
+ * Returns a reduced int64 fast-path rational, or NULL if the reduced result
+ * exceeds int64 range — in which case the caller recomputes exactly with the
+ * bignum path (it never degrades to double). */
 static void* rational_create_safe(void* arena, __int128_t num, __int128_t denom) {
     if (denom == 0) {
         denom = 1;
@@ -69,9 +129,51 @@ static void* rational_create_safe(void* arena, __int128_t num, __int128_t denom)
         denom /= g;
     }
     if (!fits_int64(num) || !fits_int64(denom)) {
-        return NULL; /* Signal overflow — caller falls back to double */
+        return NULL; /* Signal: caller falls back to the exact bignum path */
     }
-    return eshkol_rational_create(arena, (int64_t)num, (int64_t)denom);
+    return rational_alloc_small(arena, (int64_t)num, (int64_t)denom);
+}
+
+/** @brief Exact rational from bignum numerator/denominator (ESH-0105/ESH-0123).
+ *  Sign-canonicalizes to a positive denominator, reduces by the bignum GCD, and
+ *  demotes to the int64 fast path when the reduced pair fits. Never lossy. */
+extern "C" void* eshkol_rational_create_bn(void* arena_v,
+                                           eshkol_bignum_t* num,
+                                           eshkol_bignum_t* denom) {
+    arena_t* arena = (arena_t*)arena_v;
+    if (!num || !denom || eshkol_bignum_is_zero(denom)) {
+        eshkol_error("rational: division by zero (denominator is 0)");
+        return rational_alloc_small(arena_v, 0, 1);
+    }
+
+    /* Normalize sign so the denominator is positive. */
+    if (denom->sign) {
+        num = eshkol_bignum_neg(arena, num);
+        denom = eshkol_bignum_neg(arena, denom);
+    }
+
+    /* Reduce by GCD (skip the divide only when gcd == 1). */
+    eshkol_bignum_t* g = bn_gcd(arena, num, denom);
+    if (g && !bn_equals_i64(g, 1) && !eshkol_bignum_is_zero(g)) {
+        num = eshkol_bignum_div(arena, num, g);
+        denom = eshkol_bignum_div(arena, denom, g);
+    }
+
+    /* Prefer the int64 fast path whenever the reduced pair fits. */
+    int64_t ni, di;
+    if (eshkol_bignum_fits_int64(num, &ni) && eshkol_bignum_fits_int64(denom, &di)) {
+        return rational_alloc_small(arena_v, ni, di);
+    }
+
+    eshkol_rational_t* r = (eshkol_rational_t*)arena_allocate_with_header(
+        arena_v, sizeof(eshkol_rational_t), HEAP_SUBTYPE_RATIONAL, 0);
+    r->numerator = 0;
+    r->denominator = 1;
+    r->is_big = 1;
+    r->reserved = 0;
+    r->big_num = num;
+    r->big_den = denom;
+    return r;
 }
 
 /** @brief Create a normalized rational number in @p arena from a numerator/denominator pair.
@@ -86,20 +188,14 @@ extern "C" void* eshkol_rational_create(void* arena, int64_t num, int64_t denom)
         num = 0;
     }
 
-    /* Audit C7: normalize denominator to positive without INT64_MIN overflow.
-     * Previously `if (denom < 0) { num = -num; denom = -denom; }` silently
-     * produced a NON-NORMALISED rational when either side was INT64_MIN
-     * because -INT64_MIN == INT64_MIN in two's complement. Downstream
-     * arithmetic (gcd / mul / add) then treated INT64_MIN as positive
-     * in 128-bit promotion and returned silent wrong answers. Detect
-     * the two unsafe cases and raise; legitimate rationals at INT64_MIN
-     * magnitude are rare and can be re-expressed once bignum rationals
-     * land. */
+    /* Audit C7: the INT64_MIN sign-flip (-INT64_MIN == INT64_MIN) cannot be
+     * normalised in int64. Now that the rational substrate is bignum-capable,
+     * route these rare cases through the exact bignum constructor instead of
+     * erroring. */
     if (denom == INT64_MIN || num == INT64_MIN) {
-        eshkol_error("rational: INT64_MIN numerator/denominator cannot be "
-                     "sign-normalised without overflow");
-        denom = 1;
-        num = 0;
+        eshkol_bignum_t* bn = eshkol_bignum_from_int64((arena_t*)arena, num);
+        eshkol_bignum_t* bd = eshkol_bignum_from_int64((arena_t*)arena, denom);
+        return eshkol_rational_create_bn(arena, bn, bd);
     }
     if (denom < 0) {
         num = -num;
@@ -113,57 +209,108 @@ extern "C" void* eshkol_rational_create(void* arena, int64_t num, int64_t denom)
         denom /= g;
     }
 
-    /* Allocate with header: 16 bytes for {numerator, denominator} */
-    eshkol_rational_t* r = (eshkol_rational_t*)arena_allocate_with_header(
-        arena, sizeof(eshkol_rational_t), HEAP_SUBTYPE_RATIONAL, 0);
-    r->numerator = num;
-    r->denominator = denom;
-    return r;
+    return rational_alloc_small(arena, num, denom);
 }
 
-/** @brief Add two rationals, returning a reduced result (NULL on int64 overflow). */
+/* Is a rational operand a big (bignum-path) rational? */
+static inline bool rat_is_big(const void* r) {
+    return ((const eshkol_rational_t*)r)->is_big != 0;
+}
+
+/* Bignum-path add/sub/mul: exact, never lossy. sub == 0, add == 1 selector via
+ * caller. */
+static void* rat_add_sub_big(void* arena_v, const eshkol_rational_t* ra,
+                             const eshkol_rational_t* rb, bool subtract) {
+    arena_t* arena = (arena_t*)arena_v;
+    eshkol_bignum_t* an = rat_num_bn(arena, ra);
+    eshkol_bignum_t* ad = rat_den_bn(arena, ra);
+    eshkol_bignum_t* bn = rat_num_bn(arena, rb);
+    eshkol_bignum_t* bd = rat_den_bn(arena, rb);
+    eshkol_bignum_t* left = eshkol_bignum_mul(arena, an, bd);
+    eshkol_bignum_t* right = eshkol_bignum_mul(arena, bn, ad);
+    eshkol_bignum_t* num = subtract ? eshkol_bignum_sub(arena, left, right)
+                                    : eshkol_bignum_add(arena, left, right);
+    eshkol_bignum_t* den = eshkol_bignum_mul(arena, ad, bd);
+    return eshkol_rational_create_bn(arena_v, num, den);
+}
+
+static void* rat_mul_big(void* arena_v, const eshkol_rational_t* ra,
+                         const eshkol_rational_t* rb) {
+    arena_t* arena = (arena_t*)arena_v;
+    eshkol_bignum_t* num = eshkol_bignum_mul(arena, rat_num_bn(arena, ra), rat_num_bn(arena, rb));
+    eshkol_bignum_t* den = eshkol_bignum_mul(arena, rat_den_bn(arena, ra), rat_den_bn(arena, rb));
+    return eshkol_rational_create_bn(arena_v, num, den);
+}
+
+static void* rat_div_big(void* arena_v, const eshkol_rational_t* ra,
+                         const eshkol_rational_t* rb) {
+    arena_t* arena = (arena_t*)arena_v;
+    eshkol_bignum_t* num = eshkol_bignum_mul(arena, rat_num_bn(arena, ra), rat_den_bn(arena, rb));
+    eshkol_bignum_t* den = eshkol_bignum_mul(arena, rat_den_bn(arena, ra), rat_num_bn(arena, rb));
+    return eshkol_rational_create_bn(arena_v, num, den);
+}
+
+/** @brief Add two rationals, returning an exact reduced result. */
 extern "C" void* eshkol_rational_add(void* arena, void* a, void* b) {
     eshkol_rational_t* ra = (eshkol_rational_t*)a;
     eshkol_rational_t* rb = (eshkol_rational_t*)b;
-    /* a/b + c/d = (a*d + c*b) / (b*d) — uses __int128_t to prevent overflow */
-    __int128_t num = (__int128_t)ra->numerator * rb->denominator
-                   + (__int128_t)rb->numerator * ra->denominator;
-    __int128_t denom = (__int128_t)ra->denominator * rb->denominator;
-    return rational_create_safe(arena, num, denom);
+    if (!ra->is_big && !rb->is_big) {
+        /* a/b + c/d = (a*d + c*b) / (b*d) — __int128_t guards int64 overflow */
+        __int128_t num = (__int128_t)ra->numerator * rb->denominator
+                       + (__int128_t)rb->numerator * ra->denominator;
+        __int128_t denom = (__int128_t)ra->denominator * rb->denominator;
+        void* r = rational_create_safe(arena, num, denom);
+        if (r) return r;
+    }
+    return rat_add_sub_big(arena, ra, rb, /*subtract=*/false);
 }
 
-/** @brief Subtract rational @p b from @p a, returning a reduced result (NULL on int64 overflow). */
+/** @brief Subtract rational @p b from @p a, returning an exact reduced result. */
 extern "C" void* eshkol_rational_sub(void* arena, void* a, void* b) {
     eshkol_rational_t* ra = (eshkol_rational_t*)a;
     eshkol_rational_t* rb = (eshkol_rational_t*)b;
-    __int128_t num = (__int128_t)ra->numerator * rb->denominator
-                   - (__int128_t)rb->numerator * ra->denominator;
-    __int128_t denom = (__int128_t)ra->denominator * rb->denominator;
-    return rational_create_safe(arena, num, denom);
+    if (!ra->is_big && !rb->is_big) {
+        __int128_t num = (__int128_t)ra->numerator * rb->denominator
+                       - (__int128_t)rb->numerator * ra->denominator;
+        __int128_t denom = (__int128_t)ra->denominator * rb->denominator;
+        void* r = rational_create_safe(arena, num, denom);
+        if (r) return r;
+    }
+    return rat_add_sub_big(arena, ra, rb, /*subtract=*/true);
 }
 
-/** @brief Multiply two rationals, returning a reduced result (NULL on int64 overflow). */
+/** @brief Multiply two rationals, returning an exact reduced result. */
 extern "C" void* eshkol_rational_mul(void* arena, void* a, void* b) {
     eshkol_rational_t* ra = (eshkol_rational_t*)a;
     eshkol_rational_t* rb = (eshkol_rational_t*)b;
-    __int128_t num = (__int128_t)ra->numerator * rb->numerator;
-    __int128_t denom = (__int128_t)ra->denominator * rb->denominator;
-    return rational_create_safe(arena, num, denom);
+    if (!ra->is_big && !rb->is_big) {
+        __int128_t num = (__int128_t)ra->numerator * rb->numerator;
+        __int128_t denom = (__int128_t)ra->denominator * rb->denominator;
+        void* r = rational_create_safe(arena, num, denom);
+        if (r) return r;
+    }
+    return rat_mul_big(arena, ra, rb);
 }
 
-/** @brief Divide rational @p a by @p b, returning a reduced result.
- *  Raises a divide-by-zero exception if @p b is zero; returns NULL on int64 overflow. */
+/** @brief Divide rational @p a by @p b, returning an exact reduced result.
+ *  Raises a divide-by-zero exception if @p b is zero. */
 extern "C" void* eshkol_rational_div(void* arena, void* a, void* b) {
     eshkol_rational_t* ra = (eshkol_rational_t*)a;
     eshkol_rational_t* rb = (eshkol_rational_t*)b;
-    if (rb->numerator == 0) {
+    bool b_zero = rb->is_big ? eshkol_bignum_is_zero(rb->big_num)
+                             : (rb->numerator == 0);
+    if (b_zero) {
         eshkol_exception_t* exc = eshkol_make_exception(ESHKOL_EXCEPTION_DIVIDE_BY_ZERO, "rational division by zero");
         eshkol_raise(exc);
         return nullptr;  // unreachable, but satisfies compiler
     }
-    __int128_t num = (__int128_t)ra->numerator * rb->denominator;
-    __int128_t denom = (__int128_t)ra->denominator * rb->numerator;
-    return rational_create_safe(arena, num, denom);
+    if (!ra->is_big && !rb->is_big) {
+        __int128_t num = (__int128_t)ra->numerator * rb->denominator;
+        __int128_t denom = (__int128_t)ra->denominator * rb->numerator;
+        void* r = rational_create_safe(arena, num, denom);
+        if (r) return r;
+    }
+    return rat_div_big(arena, ra, rb);
 }
 
 /** @brief Compare two rationals via cross-multiplication.
@@ -171,12 +318,22 @@ extern "C" void* eshkol_rational_div(void* arena, void* a, void* b) {
 extern "C" int eshkol_rational_compare(void* a, void* b) {
     eshkol_rational_t* ra = (eshkol_rational_t*)a;
     eshkol_rational_t* rb = (eshkol_rational_t*)b;
-    /* Compare a/b vs c/d → a*d vs c*b — uses __int128_t to prevent overflow */
-    __int128_t lhs = (__int128_t)ra->numerator * rb->denominator;
-    __int128_t rhs = (__int128_t)rb->numerator * ra->denominator;
-    if (lhs < rhs) return -1;
-    if (lhs > rhs) return 1;
-    return 0;
+    if (!ra->is_big && !rb->is_big) {
+        /* Compare a/b vs c/d → a*d vs c*b — __int128_t guards int64 overflow */
+        __int128_t lhs = (__int128_t)ra->numerator * rb->denominator;
+        __int128_t rhs = (__int128_t)rb->numerator * ra->denominator;
+        if (lhs < rhs) return -1;
+        if (lhs > rhs) return 1;
+        return 0;
+    }
+    /* Denominators are positive, so compare a_num*b_den vs b_num*a_den. The
+     * cross-products need bignum scratch space; use the runtime thread-local
+     * arena (this API has no arena parameter, and the temporaries are dead
+     * after the comparison). */
+    arena_t* arena = arena_get_thread_local();
+    eshkol_bignum_t* lhs = eshkol_bignum_mul(arena, rat_num_bn(arena, ra), rat_den_bn(arena, rb));
+    eshkol_bignum_t* rhs = eshkol_bignum_mul(arena, rat_num_bn(arena, rb), rat_den_bn(arena, ra));
+    return eshkol_bignum_compare(lhs, rhs);
 }
 
 /** Return the numerator of a rational. */
@@ -192,12 +349,18 @@ extern "C" int64_t eshkol_rational_denominator(void* r) {
 /** Convert a rational to its nearest double-precision floating-point value. */
 extern "C" double eshkol_rational_to_double(void* r) {
     eshkol_rational_t* rat = (eshkol_rational_t*)r;
+    if (rat->is_big) {
+        return eshkol_bignum_to_double(rat->big_num) /
+               eshkol_bignum_to_double(rat->big_den);
+    }
     return (double)rat->numerator / (double)rat->denominator;
 }
 
 /** Return non-zero if the rational represents an integer (denominator == 1). */
 extern "C" int eshkol_rational_is_integer(void* r) {
-    return ((eshkol_rational_t*)r)->denominator == 1;
+    eshkol_rational_t* rat = (eshkol_rational_t*)r;
+    if (rat->is_big) return bn_equals_i64(rat->big_den, 1);
+    return rat->denominator == 1;
 }
 
 /* Convert IEEE 754 double to exact rational (R7RS inexact->exact) */
@@ -221,6 +384,23 @@ extern "C" void* eshkol_double_to_rational(void* arena, double d) {
  * string-length sees len+1 chars after the header-aware fix. */
 extern "C" char* eshkol_rational_to_string(void* arena, void* r) {
     eshkol_rational_t* rat = (eshkol_rational_t*)r;
+    if (rat->is_big) {
+        /* Format bignum numerator/denominator into a fresh buffer. */
+        char* num_s = eshkol_bignum_to_string((arena_t*)arena, rat->big_num);
+        if (bn_equals_i64(rat->big_den, 1)) return num_s;
+        char* den_s = eshkol_bignum_to_string((arena_t*)arena, rat->big_den);
+        size_t nlen = num_s ? strlen(num_s) : 0;
+        size_t dlen = den_s ? strlen(den_s) : 0;
+        size_t total = nlen + 1 + dlen;
+        char* buf = (char*)arena_allocate_string_with_header(arena, total);
+        if (buf) {
+            memcpy(buf, num_s, nlen);
+            buf[nlen] = '/';
+            memcpy(buf + nlen + 1, den_s, dlen);
+            buf[total] = '\0';
+        }
+        return buf;
+    }
     if (rat->denominator == 1) {
         char tmp[32];
         int len = snprintf(tmp, sizeof(tmp), "%lld", (long long)rat->numerator);
@@ -234,6 +414,104 @@ extern "C" char* eshkol_rational_to_string(void* arena, void* r) {
     char* buf = (char*)arena_allocate_string_with_header(arena, len);
     if (buf) memcpy(buf, tmp, len + 1);  /* copy including NUL */
     return buf;
+}
+
+/** @brief Write a rational's "n/d" (or bare "n" when integer) form to a FILE*.
+ *  Handles both int64 and bignum paths. Used by the display runtime. */
+extern "C" void eshkol_rational_display(void* r, void* file) {
+    eshkol_rational_t* rat = (eshkol_rational_t*)r;
+    FILE* f = (FILE*)file;
+    if (!rat || !f) return;
+    if (rat->is_big) {
+        eshkol_bignum_display(rat->big_num, f);
+        if (!bn_equals_i64(rat->big_den, 1)) {
+            fputc('/', f);
+            eshkol_bignum_display(rat->big_den, f);
+        }
+        return;
+    }
+    if (rat->denominator == 1) {
+        fprintf(f, "%lld", (long long)rat->numerator);
+    } else {
+        fprintf(f, "%lld/%lld", (long long)rat->numerator,
+                (long long)rat->denominator);
+    }
+}
+
+/** @brief Value equality on reduced rationals (int64 and bignum paths).
+ *  Both operands are in canonical reduced form, so equality is: same path and
+ *  matching fields (int64 pair, or bignum numerator+denominator). */
+extern "C" int eshkol_rational_equal(void* a, void* b) {
+    eshkol_rational_t* ra = (eshkol_rational_t*)a;
+    eshkol_rational_t* rb = (eshkol_rational_t*)b;
+    if (!ra->is_big && !rb->is_big) {
+        return ra->numerator == rb->numerator &&
+               ra->denominator == rb->denominator;
+    }
+    if (ra->is_big != rb->is_big) {
+        /* Canonical form guarantees a big rational never equals a small one
+         * (a big one does not fit int64), so the paths differing => unequal. */
+        return 0;
+    }
+    return eshkol_bignum_compare(ra->big_num, rb->big_num) == 0 &&
+           eshkol_bignum_compare(ra->big_den, rb->big_den) == 0;
+}
+
+/* Build a tagged exact integer from a bignum, demoting to INT64 when it fits. */
+static eshkol_tagged_value_t bignum_to_tagged_int(eshkol_bignum_t* b) {
+    eshkol_tagged_value_t t;
+    memset(&t, 0, sizeof(t));
+    int64_t v;
+    if (eshkol_bignum_fits_int64(b, &v)) {
+        t.type = ESHKOL_VALUE_INT64;
+        t.data.int_val = v;
+    } else {
+        t.type = ESHKOL_VALUE_HEAP_PTR;
+        t.flags = ESHKOL_VALUE_EXACT_FLAG;
+        t.data.int_val = (int64_t)(uintptr_t)b;
+    }
+    return t;
+}
+
+/** @brief R7RS numerator as a tagged value (INT64 or bignum HEAP_PTR). */
+extern "C" void eshkol_rational_numerator_tagged(
+    void* arena, const eshkol_tagged_value_t* v, eshkol_tagged_value_t* result)
+{
+    (void)arena;
+    if (v->type == ESHKOL_VALUE_HEAP_PTR && v->data.int_val) {
+        uint8_t subtype = *((uint8_t*)(uintptr_t)v->data.int_val - 8);
+        if (subtype == HEAP_SUBTYPE_RATIONAL) {
+            eshkol_rational_t* r = (eshkol_rational_t*)(uintptr_t)v->data.int_val;
+            if (r->is_big) { *result = bignum_to_tagged_int(r->big_num); return; }
+            memset(result, 0, sizeof(*result));
+            result->type = ESHKOL_VALUE_INT64;
+            result->data.int_val = r->numerator;
+            return;
+        }
+    }
+    /* int64, bignum integer, double, or non-number: numerator is the value. */
+    *result = *v;
+}
+
+/** @brief R7RS denominator as a tagged value (INT64 or bignum HEAP_PTR). */
+extern "C" void eshkol_rational_denominator_tagged(
+    void* arena, const eshkol_tagged_value_t* v, eshkol_tagged_value_t* result)
+{
+    (void)arena;
+    memset(result, 0, sizeof(*result));
+    if (v->type == ESHKOL_VALUE_HEAP_PTR && v->data.int_val) {
+        uint8_t subtype = *((uint8_t*)(uintptr_t)v->data.int_val - 8);
+        if (subtype == HEAP_SUBTYPE_RATIONAL) {
+            eshkol_rational_t* r = (eshkol_rational_t*)(uintptr_t)v->data.int_val;
+            if (r->is_big) { *result = bignum_to_tagged_int(r->big_den); return; }
+            result->type = ESHKOL_VALUE_INT64;
+            result->data.int_val = r->denominator;
+            return;
+        }
+    }
+    /* int64, bignum integer, or other: denominator is 1. */
+    result->type = ESHKOL_VALUE_INT64;
+    result->data.int_val = 1;
 }
 
 /* Helper: check if tagged value is a rational (HEAP_PTR with RATIONAL subtype) */
@@ -257,40 +535,84 @@ extern "C" void eshkol_rational_binary_tagged_ptr(
     *result = eshkol_rational_binary_tagged(arena, *a, *b, op);
 }
 
-/* Tagged value binary dispatch for rationals */
+/* Heap subtype of a HEAP_PTR tagged value (0 if not a heap pointer). */
+static inline uint8_t tagged_heap_subtype(const eshkol_tagged_value_t* v) {
+    if (v->type != ESHKOL_VALUE_HEAP_PTR || !v->data.int_val) return 0xFF;
+    return *((uint8_t*)(uintptr_t)v->data.int_val - 8);
+}
+
+/* Coerce an exact tagged operand (INT64, bignum HEAP_PTR, or rational HEAP_PTR)
+ * to a rational object pointer. Returns NULL if not an exact number. */
+static void* tagged_exact_to_rational(void* arena, const eshkol_tagged_value_t* v) {
+    if (v->type == ESHKOL_VALUE_INT64) {
+        return eshkol_rational_create(arena, v->data.int_val, 1);
+    }
+    if (v->type == ESHKOL_VALUE_HEAP_PTR && v->data.int_val) {
+        void* p = (void*)(uintptr_t)v->data.int_val;
+        uint8_t subtype = tagged_heap_subtype(v);
+        if (subtype == HEAP_SUBTYPE_RATIONAL) return p;
+        if (subtype == HEAP_SUBTYPE_BIGNUM) {
+            eshkol_bignum_t* one = eshkol_bignum_from_int64((arena_t*)arena, 1);
+            return eshkol_rational_create_bn(arena, (eshkol_bignum_t*)p, one);
+        }
+    }
+    return NULL;
+}
+
+/* Demote an exact rational-object result to a canonical tagged value:
+ *   - integer that fits int64 -> INT64
+ *   - integer too large       -> bare bignum HEAP_PTR (EXACT)
+ *   - non-integer             -> rational HEAP_PTR (EXACT) */
+static eshkol_tagged_value_t rational_result_to_tagged(void* rr) {
+    eshkol_tagged_value_t result;
+    memset(&result, 0, sizeof(result));
+    eshkol_rational_t* rat = (eshkol_rational_t*)rr;
+    if (rat->is_big) {
+        result.type = ESHKOL_VALUE_HEAP_PTR;
+        result.flags = ESHKOL_VALUE_EXACT_FLAG;
+        result.data.int_val = bn_equals_i64(rat->big_den, 1)
+            ? (int64_t)(uintptr_t)rat->big_num   /* huge integer -> bare bignum */
+            : (int64_t)(uintptr_t)rr;             /* proper bignum rational */
+        return result;
+    }
+    if (rat->denominator == 1) {
+        result.type = ESHKOL_VALUE_INT64;
+        result.data.int_val = rat->numerator;
+    } else {
+        result.type = ESHKOL_VALUE_HEAP_PTR;
+        result.data.int_val = (int64_t)(uintptr_t)rr;
+    }
+    return result;
+}
+
+/* Extract a double from an exact-or-inexact tagged operand (int64, double,
+ * bignum, or rational). */
+static double tagged_any_to_double(const eshkol_tagged_value_t* v) {
+    if (v->type == ESHKOL_VALUE_INT64) return (double)v->data.int_val;
+    if (v->type == ESHKOL_VALUE_DOUBLE) {
+        union { int64_t i; double d; } conv; conv.i = v->data.int_val; return conv.d;
+    }
+    uint8_t subtype = tagged_heap_subtype(v);
+    if (subtype == HEAP_SUBTYPE_RATIONAL)
+        return eshkol_rational_to_double((void*)(uintptr_t)v->data.int_val);
+    if (subtype == HEAP_SUBTYPE_BIGNUM)
+        return eshkol_bignum_to_double((eshkol_bignum_t*)(uintptr_t)v->data.int_val);
+    return 0.0;
+}
+
+/* Tagged value binary dispatch for rationals. Accepts INT64, DOUBLE, bignum,
+ * and rational operands. Exact operands stay exact — bignum-capable, never
+ * lossy (ESH-0105). Only a genuine DOUBLE operand yields an inexact result. */
 extern "C" eshkol_tagged_value_t eshkol_rational_binary_tagged(
     void* arena, eshkol_tagged_value_t a, eshkol_tagged_value_t b, int op)
 {
-    int a_is_rational = eshkol_is_rational_tagged(a);
-    int b_is_rational = eshkol_is_rational_tagged(b);
-    int a_is_int = (a.type == ESHKOL_VALUE_INT64);
-    int b_is_int = (b.type == ESHKOL_VALUE_INT64);
-
     eshkol_tagged_value_t result;
     memset(&result, 0, sizeof(result));
 
-    /* If either is a double, convert to double arithmetic */
+    /* If either is inexact (double), R7RS forces an inexact result. */
     if (a.type == ESHKOL_VALUE_DOUBLE || b.type == ESHKOL_VALUE_DOUBLE) {
-        double da, db;
-        if (a_is_rational) {
-            da = eshkol_rational_to_double((void*)(uintptr_t)a.data.int_val);
-        } else if (a_is_int) {
-            da = (double)a.data.int_val;
-        } else {
-            union { int64_t i; double d; } conv;
-            conv.i = a.data.int_val;
-            da = conv.d;
-        }
-        if (b_is_rational) {
-            db = eshkol_rational_to_double((void*)(uintptr_t)b.data.int_val);
-        } else if (b_is_int) {
-            db = (double)b.data.int_val;
-        } else {
-            union { int64_t i; double d; } conv;
-            conv.i = b.data.int_val;
-            db = conv.d;
-        }
-
+        double da = tagged_any_to_double(&a);
+        double db = tagged_any_to_double(&b);
         double dr;
         switch (op) {
             case 0: dr = da + db; break;
@@ -299,7 +621,6 @@ extern "C" eshkol_tagged_value_t eshkol_rational_binary_tagged(
             case 3: dr = da / db; break;
             default: dr = 0; break;
         }
-
         result.type = ESHKOL_VALUE_DOUBLE;
         union { double d; int64_t i; } pack;
         pack.d = dr;
@@ -307,21 +628,13 @@ extern "C" eshkol_tagged_value_t eshkol_rational_binary_tagged(
         return result;
     }
 
-    /* Both are exact (int or rational) */
-    void* ra;
-    void* rb;
-
-    /* Convert int64 to rational 1-element if needed */
-    if (a_is_rational) {
-        ra = (void*)(uintptr_t)a.data.int_val;
-    } else {
-        ra = eshkol_rational_create(arena, a.data.int_val, 1);
-    }
-
-    if (b_is_rational) {
-        rb = (void*)(uintptr_t)b.data.int_val;
-    } else {
-        rb = eshkol_rational_create(arena, b.data.int_val, 1);
+    /* Both exact: promote each to a rational object (int64/bignum -> n/1). */
+    void* ra = tagged_exact_to_rational(arena, &a);
+    void* rb = tagged_exact_to_rational(arena, &b);
+    if (!ra || !rb) {
+        result.type = ESHKOL_VALUE_INT64;
+        result.data.int_val = 0;
+        return result;
     }
 
     void* rr;
@@ -332,35 +645,40 @@ extern "C" eshkol_tagged_value_t eshkol_rational_binary_tagged(
         case 3: rr = eshkol_rational_div(arena, ra, rb); break;
         default: rr = eshkol_rational_create(arena, 0, 1); break;
     }
+    return rational_result_to_tagged(rr);
+}
 
-    /* NULL means overflow — fall back to double arithmetic */
-    if (!rr) {
-        double da = eshkol_rational_to_double(ra);
-        double db = eshkol_rational_to_double(rb);
-        double dr;
-        switch (op) {
-            case 0: dr = da + db; break;
-            case 1: dr = da - db; break;
-            case 2: dr = da * db; break;
-            case 3: dr = db != 0.0 ? da / db : 0.0; break;
-            default: dr = 0; break;
-        }
-        result.type = ESHKOL_VALUE_DOUBLE;
-        union { double d; int64_t i; } pack;
-        pack.d = dr;
-        result.data.int_val = pack.i;
-        return result;
-    }
+/** @brief Build an EXACT tagged number from bignum numerator/denominator.
+ *  Reduces and demotes (bare int64/bignum when integer; rational otherwise).
+ *  Used by the bignum division dispatch so `(/ 1 (expt 10 19))` stays exact. */
+extern "C" void eshkol_rational_from_bignums_tagged(
+    void* arena, eshkol_bignum_t* num, eshkol_bignum_t* denom,
+    eshkol_tagged_value_t* result)
+{
+    void* rr = eshkol_rational_create_bn(arena, num, denom);
+    *result = rational_result_to_tagged(rr);
+}
 
-    /* If result is an integer (denom=1), return as INT64 */
-    if (eshkol_rational_is_integer(rr)) {
-        result.type = ESHKOL_VALUE_INT64;
-        result.data.int_val = eshkol_rational_numerator(rr);
-    } else {
-        result.type = ESHKOL_VALUE_HEAP_PTR;
-        result.data.int_val = (int64_t)(uintptr_t)rr;
+/* Coerce an INT64 or bignum HEAP_PTR tagged operand to a bignum. */
+static eshkol_bignum_t* make_operand_bignum(void* arena, const eshkol_tagged_value_t* v) {
+    if (v->type == ESHKOL_VALUE_INT64) {
+        return eshkol_bignum_from_int64((arena_t*)arena, v->data.int_val);
     }
-    return result;
+    if (tagged_heap_subtype(v) == HEAP_SUBTYPE_BIGNUM) {
+        return (eshkol_bignum_t*)(uintptr_t)v->data.int_val;
+    }
+    /* Fallback: coerce via double->int (should not happen for integer args). */
+    return eshkol_bignum_from_int64((arena_t*)arena, 0);
+}
+
+/** @brief (make-rational num den) on tagged operands (INT64 or bignum). */
+extern "C" void eshkol_rational_make_tagged(
+    void* arena, const eshkol_tagged_value_t* num, const eshkol_tagged_value_t* den,
+    eshkol_tagged_value_t* result)
+{
+    eshkol_bignum_t* bn = make_operand_bignum(arena, num);
+    eshkol_bignum_t* bd = make_operand_bignum(arena, den);
+    eshkol_rational_from_bignums_tagged(arena, bn, bd, result);
 }
 
 /* Pointer-based comparison dispatch for LLVM codegen.
@@ -371,33 +689,13 @@ extern "C" void eshkol_rational_compare_tagged_ptr(
     void* arena, const eshkol_tagged_value_t* a, const eshkol_tagged_value_t* b,
     int op, eshkol_tagged_value_t* result)
 {
-    int a_is_rational = eshkol_is_rational_tagged(*a);
-    int b_is_rational = eshkol_is_rational_tagged(*b);
-
     memset(result, 0, sizeof(*result));
     result->type = ESHKOL_VALUE_BOOL;
 
     /* If either is a double, convert to double comparison */
     if (a->type == ESHKOL_VALUE_DOUBLE || b->type == ESHKOL_VALUE_DOUBLE) {
-        double da, db;
-        if (a_is_rational) {
-            da = eshkol_rational_to_double((void*)(uintptr_t)a->data.int_val);
-        } else if (a->type == ESHKOL_VALUE_INT64) {
-            da = (double)a->data.int_val;
-        } else {
-            union { int64_t i; double d; } conv;
-            conv.i = a->data.int_val;
-            da = conv.d;
-        }
-        if (b_is_rational) {
-            db = eshkol_rational_to_double((void*)(uintptr_t)b->data.int_val);
-        } else if (b->type == ESHKOL_VALUE_INT64) {
-            db = (double)b->data.int_val;
-        } else {
-            union { int64_t i; double d; } conv;
-            conv.i = b->data.int_val;
-            db = conv.d;
-        }
+        double da = tagged_any_to_double(a);
+        double db = tagged_any_to_double(b);
         int cmp_result = 0;
         switch (op) {
             case 0: cmp_result = (da < db); break;
@@ -410,21 +708,10 @@ extern "C" void eshkol_rational_compare_tagged_ptr(
         return;
     }
 
-    /* Both are exact (int or rational) - promote int to rational n/1 */
-    void* ra;
-    void* rb;
-
-    if (a_is_rational) {
-        ra = (void*)(uintptr_t)a->data.int_val;
-    } else {
-        ra = eshkol_rational_create(arena, a->data.int_val, 1);
-    }
-
-    if (b_is_rational) {
-        rb = (void*)(uintptr_t)b->data.int_val;
-    } else {
-        rb = eshkol_rational_create(arena, b->data.int_val, 1);
-    }
+    /* Both exact: promote each (int64/bignum/rational) to a rational object. */
+    void* ra = tagged_exact_to_rational(arena, a);
+    void* rb = tagged_exact_to_rational(arena, b);
+    if (!ra || !rb) { result->data.int_val = 0; return; }
 
     int cmp = eshkol_rational_compare(ra, rb);
     int cmp_result = 0;

--- a/lib/core/runtime_deep_equal.cpp
+++ b/lib/core/runtime_deep_equal.cpp
@@ -193,10 +193,10 @@ bool eshkol_deep_equal(const eshkol_tagged_value_t* val1,
     bool is_rat1 = is_rational(type1, val1);
     bool is_rat2 = is_rational(type2, val2);
     if (is_rat1 && is_rat2) {
-        const eshkol_rational_t* r1 = (const eshkol_rational_t*)val1->data.ptr_val;
-        const eshkol_rational_t* r2 = (const eshkol_rational_t*)val2->data.ptr_val;
-        return r1->numerator == r2->numerator &&
-               r1->denominator == r2->denominator;
+        // Canonical value equality across both the int64 and bignum
+        // representations (ESH-0105/ESH-0114).
+        return eshkol_rational_equal((void*)val1->data.ptr_val,
+                                     (void*)val2->data.ptr_val) != 0;
     }
 
     // Complex numbers (ESH-0114): compare real and imaginary components by

--- a/lib/core/runtime_display_hosted.cpp
+++ b/lib/core/runtime_display_hosted.cpp
@@ -344,9 +344,8 @@ void eshkol_display_value_opts(const eshkol_tagged_value_t* value, eshkol_displa
                     fprintf(get_output(opts), "#<promise>");
                     break;
                 case HEAP_SUBTYPE_RATIONAL: {
-                    eshkol_rational_t* rat = (eshkol_rational_t*)data_ptr;
-                    fprintf(get_output(opts), "%lld/%lld",
-                        (long long)rat->numerator, (long long)rat->denominator);
+                    // Handles both int64 and bignum-magnitude rationals.
+                    eshkol_rational_display(data_ptr, get_output(opts));
                     break;
                 }
                 case HEAP_SUBTYPE_PRNG:

--- a/lib/frontend/parser.cpp
+++ b/lib/frontend/parser.cpp
@@ -1319,20 +1319,60 @@ static eshkol_ast_t parse_atom(const Token& token) {
                 break;
             }
 
-            // Check if it's a rational literal (e.g., 1/3, 22/7)
+            // Check if it's a rational literal (e.g., 1/3, 22/7, and
+            // bignum-magnitude forms like 100000000000000000000/3). Each side
+            // is emitted as an int64 literal when it fits, or an
+            // ESHKOL_BIGNUM_LITERAL (string payload, constructed at codegen)
+            // when it exceeds int64 range — ESH-0123.
             if (token.value.find('/') != std::string::npos) {
                 size_t slash_pos = token.value.find('/');
                 std::string num_str = token.value.substr(0, slash_pos);
                 std::string den_str = token.value.substr(slash_pos + 1);
-                int64_t num, den;
-                try {
-                    num = std::stoll(num_str);
-                    den = std::stoll(den_str);
-                } catch (...) {
+
+                // Emit one operand node from a signed decimal-integer string.
+                // Returns false if the string is not a valid integer literal;
+                // sets *is_zero when the value is exactly 0 (int64 range only).
+                auto build_int_operand = [&](const std::string& s,
+                                             eshkol_ast_t* node,
+                                             bool* is_zero) -> bool {
+                    size_t i = 0;
+                    if (i < s.size() && (s[i] == '+' || s[i] == '-')) i++;
+                    if (i >= s.size()) return false;
+                    for (size_t j = i; j < s.size(); j++) {
+                        if (s[j] < '0' || s[j] > '9') return false;
+                    }
+                    memset(node, 0, sizeof(*node));
+                    node->line = token.line;
+                    node->column = token.column;
+                    *is_zero = false;
+                    try {
+                        int64_t v = std::stoll(s);
+                        eshkol_ast_make_int64(node, v);
+                        if (v == 0) *is_zero = true;
+                    } catch (const std::out_of_range&) {
+                        // Too large for int64 — defer to bignum construction.
+                        node->type = ESHKOL_BIGNUM_LITERAL;
+                        size_t len = s.size();
+                        char* ptr = new char[len + 1];
+                        memcpy(ptr, s.c_str(), len + 1);
+                        node->str_val.ptr = ptr;
+                        node->str_val.size = len + 1;
+                    } catch (...) {
+                        return false;
+                    }
+                    return true;
+                };
+
+                eshkol_ast_t* variables = new eshkol_ast_t[2];
+                bool num_zero = false, den_zero = false;
+                if (!build_int_operand(num_str, &variables[0], &num_zero) ||
+                    !build_int_operand(den_str, &variables[1], &den_zero)) {
+                    delete[] variables;
                     PARSE_ERROR_AT(token, "invalid rational literal: %s", token.value.c_str());
                     break;
                 }
-                if (den == 0) {
+                if (den_zero) {
+                    delete[] variables;
                     PARSE_ERROR_AT(token, "division by zero in rational literal");
                     break;
                 }
@@ -1345,9 +1385,7 @@ static eshkol_ast_t parse_atom(const Token& token) {
                 memcpy(ast.operation.call_op.func->variable.id, "make-rational", sizeof("make-rational"));
                 ast.operation.call_op.func->variable.data = nullptr;
                 ast.operation.call_op.num_vars = 2;
-                ast.operation.call_op.variables = new eshkol_ast_t[2];
-                eshkol_ast_make_int64(&ast.operation.call_op.variables[0], num);
-                eshkol_ast_make_int64(&ast.operation.call_op.variables[1], den);
+                ast.operation.call_op.variables = variables;
                 break;
             }
             // Check if it's a floating-point number (has '.' or scientific notation 'e'/'E')

--- a/tests/numeric/bignum_rational_type_test.esk
+++ b/tests/numeric/bignum_rational_type_test.esk
@@ -1,0 +1,105 @@
+(require stdlib)
+
+; Regression test for the bignum-capable exact rational type (ESH-0105 /
+; ESH-0123). Every expected value is an exact analytic oracle cross-checked
+; against Python's fractions.Fraction. Emits "PASS: ..." / "FAIL: ..." lines;
+; the numeric harness fails the suite if any line begins with FAIL.
+;
+; The HARD invariant under test: exact rational arithmetic NEVER degrades to a
+; double once a bignum magnitude appears. If a result were inexact, the exact
+; `=` / `equal?` comparisons below would fail.
+
+(display "TEST: bignum-capable exact rational type") (newline)
+
+; ---------------------------------------------------------------------------
+; ESH-0105: exact rational must survive a bignum magnitude (no double degrade)
+; ---------------------------------------------------------------------------
+
+; (/ 1 (expt 10 19)) is the exact 1/10000000000000000000 (denominator > int64).
+(define r1 (/ 1 (expt 10 19)))
+(display (if (exact? r1) "PASS" "FAIL")) (display ": (/ 1 10^19) is exact") (newline)
+(display (if (= r1 1/10000000000000000000) "PASS" "FAIL"))
+(display ": (/ 1 10^19) = literal 1/10^19") (newline)
+(display (if (= (numerator r1) 1) "PASS" "FAIL")) (display ": numerator = 1") (newline)
+(display (if (= (denominator r1) 10000000000000000000) "PASS" "FAIL"))
+(display ": denominator = 10^19") (newline)
+; Round-trip: reconstruct from its own numerator/denominator.
+(display (if (= r1 (/ (numerator r1) (denominator r1))) "PASS" "FAIL"))
+(display ": (/ 1 10^19) round-trips through numerator/denominator") (newline)
+
+; (+ (/ 1 3) (/ 1 (expt 2 62))) = 4611686018427387907/13835058055282163712
+; (denominator exceeds int64; numerator fits — a mixed small/big rational).
+(define s (+ (/ 1 3) (/ 1 (expt 2 62))))
+(display (if (exact? s) "PASS" "FAIL")) (display ": (+ 1/3 1/2^62) is exact") (newline)
+(display (if (= (numerator s) 4611686018427387907) "PASS" "FAIL"))
+(display ": numerator = 4611686018427387907 (vs Python Fraction)") (newline)
+(display (if (= (denominator s) 13835058055282163712) "PASS" "FAIL"))
+(display ": denominator = 13835058055282163712 (vs Python Fraction)") (newline)
+(display (if (= s (make-rational 4611686018427387907 13835058055282163712)) "PASS" "FAIL"))
+(display ": (+ 1/3 1/2^62) = exact reconstructed fraction") (newline)
+
+; ---------------------------------------------------------------------------
+; ESH-0123: bignum-magnitude rational literal parses, reduces, round-trips
+; ---------------------------------------------------------------------------
+(define lit 100000000000000000000/3)
+(display (if (rational? lit) "PASS" "FAIL")) (display ": literal 10^20/3 is rational") (newline)
+(display (if (= lit (/ (expt 10 20) 3)) "PASS" "FAIL"))
+(display ": literal 10^20/3 = (/ 10^20 3)") (newline)
+(display (if (= (numerator lit) 100000000000000000000) "PASS" "FAIL"))
+(display ": literal numerator = 10^20") (newline)
+(display (if (= (denominator lit) 3) "PASS" "FAIL")) (display ": literal denominator = 3") (newline)
+
+; Literal that must REDUCE: 2*10^20 / (4*10^20) = 1/2.
+(display (if (= 200000000000000000000/400000000000000000000 1/2) "PASS" "FAIL"))
+(display ": literal 2e20/4e20 reduces to 1/2") (newline)
+
+; ---------------------------------------------------------------------------
+; Mixed int64/bignum rational arithmetic stays exact
+; ---------------------------------------------------------------------------
+(display (if (= (* (/ 1 3) (expt 10 30))
+                (/ (expt 10 30) 3)) "PASS" "FAIL"))
+(display ": (* 1/3 10^30) = 10^30/3") (newline)
+(display (if (= (- (/ 1 3) (/ 1 (* 3 (expt 10 20))))
+                33333333333333333333/100000000000000000000) "PASS" "FAIL"))
+(display ": (- 1/3 1/(3*10^20)) exact (vs Python Fraction)") (newline)
+; Exact integer result demotes cleanly.
+(display (if (= (* (/ 3 (expt 10 20)) (expt 10 20)) 3) "PASS" "FAIL"))
+(display ": (* 3/10^20 10^20) = 3 (integer demotion)") (newline)
+; Big integer result (denominator 1) becomes an exact integer, not a rational.
+(display (if (= (* (/ 1 3) (* 3 (expt 10 30))) (expt 10 30)) "PASS" "FAIL"))
+(display ": (* 1/3 3*10^30) = 10^30 (big-integer demotion)") (newline)
+; Sum to a whole number.
+(display (if (= (+ (/ 1 3) (/ 2 3)) 1) "PASS" "FAIL")) (display ": 1/3 + 2/3 = 1") (newline)
+
+; ---------------------------------------------------------------------------
+; Sign canonicalization and ordering on bignum rationals
+; ---------------------------------------------------------------------------
+(display (if (= (/ 1 (- (expt 10 19))) (/ -1 (expt 10 19))) "PASS" "FAIL"))
+(display ": 1/(-10^19) canonicalizes to -1/10^19") (newline)
+(display (if (< (/ 1 (- (expt 10 19))) 0) "PASS" "FAIL"))
+(display ": -1/10^19 < 0") (newline)
+(display (if (< (/ 1 (expt 10 20)) (/ 1 (expt 10 19))) "PASS" "FAIL"))
+(display ": 1/10^20 < 1/10^19") (newline)
+(display (if (> (/ 2 (expt 10 19)) (/ 1 (expt 10 19))) "PASS" "FAIL"))
+(display ": 2/10^19 > 1/10^19") (newline)
+
+; ---------------------------------------------------------------------------
+; eqv?/equal? correct on reduced bignum rationals (value, not identity)
+; ---------------------------------------------------------------------------
+(display (if (eqv? (/ 1 (expt 10 19)) (/ 1 (expt 10 19))) "PASS" "FAIL"))
+(display ": (eqv? 1/10^19 1/10^19)") (newline)
+(display (if (equal? (/ 2 (* 2 (expt 10 19))) (/ 1 (expt 10 19))) "PASS" "FAIL"))
+(display ": (equal? 2/(2*10^19) 1/10^19) both reduce") (newline)
+(display (if (not (eqv? (/ 1 (expt 10 19)) (/ 1 (expt 10 20)))) "PASS" "FAIL"))
+(display ": (eqv? 1/10^19 1/10^20) is #f") (newline)
+; A bignum rational is never eqv? to a small one of a different value.
+(display (if (not (eqv? (/ 1 (expt 10 19)) 1/3)) "PASS" "FAIL"))
+(display ": (eqv? 1/10^19 1/3) is #f") (newline)
+
+; ---------------------------------------------------------------------------
+; exact->inexact still available (opt-in), and int64-range rationals unaffected
+; ---------------------------------------------------------------------------
+(display (if (< (abs (- (exact->inexact (/ 1 (expt 10 19))) 1e-19)) 1e-30) "PASS" "FAIL"))
+(display ": exact->inexact of 1/10^19 ~ 1e-19") (newline)
+(display (if (= (/ 1 3) (/ 2 6)) "PASS" "FAIL")) (display ": int64 rational 1/3 = 2/6") (newline)
+(display (if (= (+ (/ 1 4) (/ 1 4)) 1/2) "PASS" "FAIL")) (display ": 1/4 + 1/4 = 1/2") (newline)


### PR DESCRIPTION
## Summary

Makes Eshkol's exact rationals arbitrary-precision so they **never silently degrade to double** once a bignum magnitude appears, and lets the parser accept bignum-magnitude rational literals. This is the deep numeric-tower workstream deferred from #241 (a partial fix would have been silently wrong).

Two bugs, one root — `eshkol_rational_t` was `{int64 numerator; int64 denominator}` with an int64-only creator, so int64-range rationals were exact but bignum-magnitude ones fell off a cliff:

- **ESH-0105 (silent-wrong):** `(/ 1 (expt 10 19))` returned `1e-19` and `(+ (/ 1 3) (/ 1 (expt 2 62)))` returned `0.333333` — both degraded to double.
- **ESH-0123 (conformance):** the literal `100000000000000000000/3` was rejected at compile time (`std::stoll` overflow).

## Representation

`eshkol_rational_t` gains a **canonical discriminated representation**:

- **int64 fast path** (`numerator`/`denominator`, denominator > 0) — preferred whenever the fully-reduced pair fits in int64; no allocation, the existing `__int128` overflow-guarded path is retained.
- **bignum path** (`big_num`/`big_den`) — used **only** when the reduced numerator or denominator leaves int64 range.

Because a value has exactly one form (small preferred), `eqv?`/`equal?` reduce to comparing the active fields. Every create/add/sub/mul/div/compare path sign-canonicalizes (positive denominator) and reduces via the bignum GCD; the int64 fast path falls through to exact bignum arithmetic on overflow instead of returning NULL / degrading to double. **No path is lossy — if a result is exact it stays exact.**

## Op coverage

create/normalize (bignum GCD reduce + sign-canonicalize), add, sub, mul, div, compare & `=`, `numerator`/`denominator` (tagged — return a bignum when needed), print (`n/d`), `eqv?`/`equal?` (value equality on reduced form, via the deep-equality runtime shared with #241), mixed int64/bignum-rational/bignum arithmetic, integer/huge-integer demotion.

## Wiring

- Bignum division dispatch yields an exact rational (`eshkol_rational_from_bignums_tagged`) instead of a double when the quotient is not integral; bignum binary/compare dispatch delegates rational operands to the rational path (fixes mixed rational×bignum).
- Parser emits each side of a rational literal as an int64 or `ESHKOL_BIGNUM_LITERAL` node; `make-rational` codegen passes tagged operands to `eshkol_rational_make_tagged`.
- `numerator`/`denominator` codegen routes through tagged runtime helpers so a bignum-magnitude denominator is reported exactly, not a truncated int64 field read.
- `display` and the deep-equality runtime handle both representations.

## Exactness verification (vs Python `fractions.Fraction`)

| expression | result |
|---|---|
| `(/ 1 (expt 10 19))` | `1/10000000000000000000` |
| `(+ (/ 1 3) (/ 1 (expt 2 62)))` | `4611686018427387907/13835058055282163712` |
| `(numerator …)` / `(denominator …)` of that sum | `4611686018427387907` / `13835058055282163712` |
| literal `100000000000000000000/3` | parses, `numerator` `10^20`, `denominator` `3`, round-trips |
| `(- (/ 1 3) (/ 1 (* 3 (expt 10 20))))` | `33333333333333333333/100000000000000000000` |

All match the analytic oracles.

## Tests

- New `tests/numeric/bignum_rational_type_test.esk` — 30 assertions (exactness, mixed arithmetic, reduction, sign, demotion, ordering, `eqv?`/`equal?`), all PASS on both `-r` and AOT paths.
- `scripts/run_numeric_tests.sh` (10/10), `scripts/run_bignum_tests.sh` (2/2), and the #241 `bignum_rational_exactness_test.esk` (23/23) remain green. SICP `ch2_rational` and the differential rational corpus pass.
- The `.icc/completion-oracles.yaml` / `run_icc_smoke.sh` gates were **not** edited (coordinator wires gates centrally); the numeric_exactness probe stays green.

## Scope notes

- The bytecode VM's separate `VmRational` implementation (`lib/backend/vm_rational.c`) is untouched — VM parity unaffected.
- `negative?`/`positive?`/`zero?` on rationals is a **pre-existing** bug (returns `#f` for `-1/3` on master too — the shared numeric-predicate codegen has no rational branch, unrelated to bignum/exactness). Left out of scope to keep this PR focused; `(< x 0)` works correctly. Flagged as a follow-up.