### PR TITLE
fix(vm): 7 silent-miscompiles vs the native backend (chars/bignum/rational/list->vector/equal?/round/sibling-let)

### DIFF
--- a/lib/backend/eshkol_vm.c
+++ b/lib/backend/eshkol_vm.c
@@ -254,7 +254,7 @@ static const BuiltinDef BUILTINS[] = {
     /* List operations — IDs 135-141 */
     {"append", 135, 2}, {"reverse", 136, 1},
     {"member", 137, 2}, {"assoc", 138, 2}, {"memq", 139, 2},
-    {"list->vector", 139, 1}, {"vector->list", 140, 1}, {"iota", 141, 1},
+    {"list->vector", 227, 1}, {"vector->list", 140, 1}, {"iota", 141, 1},
     /* Arithmetic as first-class (2-arg) — IDs 142-145 */
     {"add2", 142, 2}, {"sub2", 143, 2}, {"mul2", 144, 2}, {"div2", 145, 2},
     /* Comparison operators as first-class — IDs 146-150 */

--- a/lib/backend/vm_compiler.c
+++ b/lib/backend/vm_compiler.c
@@ -1,6 +1,30 @@
 static void compile_expr_impl(FuncChunk* c, Node* node, int tail);
 static void compile_expr(FuncChunk* c, Node* node, int tail);
 
+/**
+ * @brief Compile node->children[first..last] as a sequence of operands left
+ *        on the stack, registering each pushed result as an anonymous local
+ *        so that c->n_locals keeps tracking the true compile-time stack depth
+ *        above fp.
+ *
+ * Binding forms (let, let-star, letrec) allocate their local stack slots
+ * from c->n_locals. Inline opcode forms (arithmetic, comparisons, vector-ref)
+ * push operand values onto the stack without registering them; if a later
+ * operand is itself a binding form it would then allocate slots that alias an
+ * earlier operand still sitting on the stack, silently corrupting the result
+ * (the "sibling-let corruption" defect: (+ (let ...) (let ...)) -> wrong sum).
+ * The generic function-call path already tracks operands this way via
+ * __call_arg__ locals; this helper applies the same invariant to the inline
+ * opcode forms. The caller emits the combining opcode (which consumes the
+ * operands) and then restores c->n_locals to its saved entry value.
+ */
+static void compile_operands_tracked(FuncChunk* c, Node* node, int first, int last) {
+    for (int i = first; i <= last; i++) {
+        compile_expr(c, node->children[i], 0);
+        add_local(c, "__operand__");
+    }
+}
+
 /** @brief Emit bytecode that constructs a quoted-symbol value: packs
  *         @p symbol's bytes into 8-byte constant chunks and passes them to
  *         native call 100 (symbol construction). Shared by compile_quote()
@@ -1610,7 +1634,14 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
 
     if (node->type == N_NUMBER) {
         double v = node->numval;
-        if (v == (int64_t)v && fabs(v) < 1e15)
+        if (node->is_char) {
+            /* Character literal (#\x): push the codepoint, then tag it as a
+             * VAL_CHAR at runtime so display/char? distinguish it from an int
+             * (native 228). Using an int constant + native call keeps the ESKB
+             * constant pool format unchanged. */
+            chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL((int64_t)v)));
+            chunk_emit(c, OP_NATIVE_CALL, 228);
+        } else if (!node->is_inexact && v == (int64_t)v && fabs(v) < 1e15)
             chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL((int64_t)v)));
         else
             chunk_emit(c, OP_CONST, chunk_add_const(c, FLOAT_VAL(v)));
@@ -1827,10 +1858,13 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
                     result = 1;
                     for (int i = 1; i < node->n_children; i++) result *= node->children[i]->numval;
                     folded = 1;
-                } else if (strcmp(head->symbol, "/") == 0 && node->n_children == 3 && node->children[2]->numval != 0) {
-                    result = node->children[1]->numval / node->children[2]->numval;
-                    folded = 1;
                 }
+                /* NOTE: `/` is deliberately NOT folded here. Folding it at
+                 * compile time collapsed exact/exact division to an inexact
+                 * float ((/ 1 3) -> 0.333…), and there is no exactness flag on
+                 * N_NUMBER to tell 6 from 6.0. Leaving division to the runtime
+                 * lets it produce an exact rational (or int), or a float, based
+                 * on the actual operand types. */
                 if (folded) {
                     int ci = chunk_add_const(c, result == (int64_t)result && fabs(result) < 1e15
                         ? INT_VAL((int64_t)result) : FLOAT_VAL(result));
@@ -1841,35 +1875,64 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
         }
     }
 
-    /* (+ a b ...), (- a b), (* a b ...), (/ a b) */
+    /* (+ a b ...), (- a b), (* a b ...), (/ a b)
+     *
+     * The reduce loops keep exactly one accumulator value on the stack while
+     * the next operand is compiled. That accumulator must be tracked as an
+     * anonymous local so a binding form in a later operand doesn't alias its
+     * slot (sibling-let corruption); see compile_operands_tracked(). */
     if (is_sym(head, "+")) {
+        int saved = c->n_locals;
         compile_expr(c, node->children[1], 0);
-        for (int i = 2; i < node->n_children; i++) { compile_expr(c, node->children[i], 0); chunk_emit(c, OP_ADD, 0); }
+        for (int i = 2; i < node->n_children; i++) {
+            add_local(c, "__operand__");                    /* accumulator on stack */
+            compile_expr(c, node->children[i], 0);
+            chunk_emit(c, OP_ADD, 0);
+            c->n_locals = saved;                            /* ADD collapsed acc+operand → 1 */
+        }
         return;
     }
     if (is_sym(head, "-")) {
         if (node->n_children == 2) { compile_expr(c, node->children[1], 0); chunk_emit(c, OP_NEG, 0); return; }
+        int saved = c->n_locals;
         compile_expr(c, node->children[1], 0);
-        for (int i = 2; i < node->n_children; i++) { compile_expr(c, node->children[i], 0); chunk_emit(c, OP_SUB, 0); }
+        for (int i = 2; i < node->n_children; i++) {
+            add_local(c, "__operand__");
+            compile_expr(c, node->children[i], 0);
+            chunk_emit(c, OP_SUB, 0);
+            c->n_locals = saved;
+        }
         return;
     }
     if (is_sym(head, "*")) {
+        int saved = c->n_locals;
         compile_expr(c, node->children[1], 0);
-        for (int i = 2; i < node->n_children; i++) { compile_expr(c, node->children[i], 0); chunk_emit(c, OP_MUL, 0); }
+        for (int i = 2; i < node->n_children; i++) {
+            add_local(c, "__operand__");
+            compile_expr(c, node->children[i], 0);
+            chunk_emit(c, OP_MUL, 0);
+            c->n_locals = saved;
+        }
         return;
     }
     if (is_sym(head, "/")) {
+        int saved = c->n_locals;
         compile_expr(c, node->children[1], 0);
-        for (int i = 2; i < node->n_children; i++) { compile_expr(c, node->children[i], 0); chunk_emit(c, OP_DIV, 0); }
+        for (int i = 2; i < node->n_children; i++) {
+            add_local(c, "__operand__");
+            compile_expr(c, node->children[i], 0);
+            chunk_emit(c, OP_DIV, 0);
+            c->n_locals = saved;
+        }
         return;
     }
 
     /* Comparisons — push proper booleans */
-    if (is_sym(head, "=") && node->n_children == 3) { compile_expr(c, node->children[1], 0); compile_expr(c, node->children[2], 0); chunk_emit(c, OP_EQ, 0); return; }
-    if (is_sym(head, "<") && node->n_children == 3) { compile_expr(c, node->children[1], 0); compile_expr(c, node->children[2], 0); chunk_emit(c, OP_LT, 0); return; }
-    if (is_sym(head, ">") && node->n_children == 3) { compile_expr(c, node->children[1], 0); compile_expr(c, node->children[2], 0); chunk_emit(c, OP_GT, 0); return; }
-    if (is_sym(head, "<=") && node->n_children == 3) { compile_expr(c, node->children[1], 0); compile_expr(c, node->children[2], 0); chunk_emit(c, OP_LE, 0); return; }
-    if (is_sym(head, ">=") && node->n_children == 3) { compile_expr(c, node->children[1], 0); compile_expr(c, node->children[2], 0); chunk_emit(c, OP_GE, 0); return; }
+    if (is_sym(head, "=") && node->n_children == 3) { int s = c->n_locals; compile_operands_tracked(c, node, 1, 2); c->n_locals = s; chunk_emit(c, OP_EQ, 0); return; }
+    if (is_sym(head, "<") && node->n_children == 3) { int s = c->n_locals; compile_operands_tracked(c, node, 1, 2); c->n_locals = s; chunk_emit(c, OP_LT, 0); return; }
+    if (is_sym(head, ">") && node->n_children == 3) { int s = c->n_locals; compile_operands_tracked(c, node, 1, 2); c->n_locals = s; chunk_emit(c, OP_GT, 0); return; }
+    if (is_sym(head, "<=") && node->n_children == 3) { int s = c->n_locals; compile_operands_tracked(c, node, 1, 2); c->n_locals = s; chunk_emit(c, OP_LE, 0); return; }
+    if (is_sym(head, ">=") && node->n_children == 3) { int s = c->n_locals; compile_operands_tracked(c, node, 1, 2); c->n_locals = s; chunk_emit(c, OP_GE, 0); return; }
     if (is_sym(head, "not") && node->n_children == 2) { compile_expr(c, node->children[1], 0); chunk_emit(c, OP_NOT, 0); return; }
     if (is_sym(head, "zero?") && node->n_children == 2) { compile_expr(c, node->children[1], 0); chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL(0))); chunk_emit(c, OP_EQ, 0); return; }
     /* Core type predicates — always available as opcodes (not closures) */
@@ -1899,7 +1962,7 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
      * semantics (sign of dividend). It resolves through the native table
      * (id 37) like `quotient` (id 38), which computes ia%ib correctly. */
     if (is_sym(head, "abs") && node->n_children == 2) { compile_expr(c, node->children[1], 0); chunk_emit(c, OP_ABS, 0); return; }
-    if (is_sym(head, "modulo") && node->n_children == 3) { compile_expr(c, node->children[1], 0); compile_expr(c, node->children[2], 0); chunk_emit(c, OP_MOD, 0); return; }
+    if (is_sym(head, "modulo") && node->n_children == 3) { int s = c->n_locals; compile_operands_tracked(c, node, 1, 2); c->n_locals = s; chunk_emit(c, OP_MOD, 0); return; }
 
     /* All other builtins (sin, cos, sqrt, even?, odd?, floor, ceiling, round, expt, min, max,
      * positive?, negative?, number->string, string-append, string=?, newline, length, etc.)
@@ -1936,20 +1999,21 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
     }
     if (is_sym(head, "make-vector") && node->n_children >= 2) {
         /* (make-vector n) or (make-vector n fill) — emit via NATIVE or direct */
+        int s = c->n_locals;
         compile_expr(c, node->children[1], 0);
-        if (node->n_children >= 3) compile_expr(c, node->children[2], 0);
+        if (node->n_children >= 3) { add_local(c, "__operand__"); compile_expr(c, node->children[2], 0); c->n_locals = s; }
         else chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL(0)));
         /* make-vector: n and fill are on stack, dispatch to runtime native */
         chunk_emit(c, OP_NATIVE_CALL, 218);
         return;
     }
-    if (is_sym(head, "vector-ref") && node->n_children == 3) { compile_expr(c, node->children[1], 0); compile_expr(c, node->children[2], 0); chunk_emit(c, OP_VEC_REF, 0); return; }
-    if (is_sym(head, "vector-set!") && node->n_children == 4) { compile_expr(c, node->children[1], 0); compile_expr(c, node->children[2], 0); compile_expr(c, node->children[3], 0); chunk_emit(c, OP_VEC_SET, 0); return; }
+    if (is_sym(head, "vector-ref") && node->n_children == 3) { int s = c->n_locals; compile_operands_tracked(c, node, 1, 2); c->n_locals = s; chunk_emit(c, OP_VEC_REF, 0); return; }
+    if (is_sym(head, "vector-set!") && node->n_children == 4) { int s = c->n_locals; compile_operands_tracked(c, node, 1, 3); c->n_locals = s; chunk_emit(c, OP_VEC_SET, 0); return; }
     if (is_sym(head, "vector-length") && node->n_children == 2) { compile_expr(c, node->children[1], 0); chunk_emit(c, OP_VEC_LEN, 0); return; }
 
     /* Mutation */
-    if (is_sym(head, "set-car!") && node->n_children == 3) { compile_expr(c, node->children[1], 0); compile_expr(c, node->children[2], 0); chunk_emit(c, OP_SET_CAR, 0); return; }
-    if (is_sym(head, "set-cdr!") && node->n_children == 3) { compile_expr(c, node->children[1], 0); compile_expr(c, node->children[2], 0); chunk_emit(c, OP_SET_CDR, 0); return; }
+    if (is_sym(head, "set-car!") && node->n_children == 3) { int s = c->n_locals; compile_operands_tracked(c, node, 1, 2); c->n_locals = s; chunk_emit(c, OP_SET_CAR, 0); return; }
+    if (is_sym(head, "set-cdr!") && node->n_children == 3) { int s = c->n_locals; compile_operands_tracked(c, node, 1, 2); c->n_locals = s; chunk_emit(c, OP_SET_CDR, 0); return; }
 
     /* String operations via opcodes (these ARE opcodes, not native calls) */
     if (is_sym(head, "string-length") && node->n_children == 2) {
@@ -1958,8 +2022,9 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
         return;
     }
     if (is_sym(head, "string-ref") && node->n_children == 3) {
-        compile_expr(c, node->children[1], 0);
-        compile_expr(c, node->children[2], 0);
+        int s = c->n_locals;
+        compile_operands_tracked(c, node, 1, 2);
+        c->n_locals = s;
         chunk_emit(c, OP_STR_REF, 0);
         return;
     }
@@ -2229,8 +2294,11 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
 
     /* Pair operations */
     if (is_sym(head, "cons") && node->n_children == 3) {
+        int s = c->n_locals;
         compile_expr(c, node->children[2], 0); /* cdr first (SOS) */
+        add_local(c, "__operand__");
         compile_expr(c, node->children[1], 0); /* car second (TOS) */
+        c->n_locals = s;
         chunk_emit(c, OP_CONS, 0); return;
     }
     if (is_sym(head, "car") && node->n_children == 2) { compile_expr(c, node->children[1], 0); chunk_emit(c, OP_CAR, 0); return; }
@@ -2600,7 +2668,9 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
 
 
     if (is_sym(head, "vref") && node->n_children == 3) {
-        compile_expr(c, node->children[1], 0); compile_expr(c, node->children[2], 0);
+        int s = c->n_locals;
+        compile_operands_tracked(c, node, 1, 2);
+        c->n_locals = s;
         chunk_emit(c, OP_VEC_REF, 0); return;
     }
 

--- a/lib/backend/vm_core.c
+++ b/lib/backend/vm_core.c
@@ -146,6 +146,7 @@ static int is_truthy(Value v) {
 static double as_number(Value v) {
     if (v.type == VAL_INT) return (double)v.as.i;
     if (v.type == VAL_FLOAT) return v.as.f;
+    if (v.type == VAL_CHAR) return (double)v.as.i; /* codepoint (char->integer, char comparisons) */
     return 0.0;
 }
 
@@ -515,6 +516,7 @@ static inline int is_valid_heap_ptr(VM* vm, int32_t ptr) {
 static double as_number_vm(VM* vm, Value v) {
     if (v.type == VAL_INT) return (double)v.as.i;
     if (v.type == VAL_FLOAT) return v.as.f;
+    if (v.type == VAL_CHAR) return (double)v.as.i; /* codepoint */
     if (v.type == VAL_RATIONAL && vm) {
         VmRational* r = (VmRational*)vm->heap.objects[v.as.ptr]->opaque.ptr;
         if (r && r->denom != 0) return (double)r->num / (double)r->denom;
@@ -614,6 +616,15 @@ static void print_value(VM* vm, Value v) {
         case VAL_NIL:   printf("()"); break;
         case VAL_INT:   printf("%lld", (long long)v.as.i); break;
         case VAL_FLOAT: printf("%.6g", v.as.f); break;
+        case VAL_CHAR: {
+            /* `display` renders a character as its glyph (UTF-8). `write`
+             * would use #\ syntax, but this VM shares one printer for both
+             * (the write/display distinction is filed separately). */
+            char buf[4];
+            int n = vm_utf8_encode((int)v.as.i, buf);
+            if (n > 0) printf("%.*s", n, buf);
+            break;
+        }
         case VAL_BOOL:  printf("%s", v.as.b ? "#t" : "#f"); break;
         case VAL_PAIR: {
             printf("(");
@@ -670,7 +681,16 @@ static void print_value(VM* vm, Value v) {
             } else printf("<rational>");
             break;
         }
-        case VAL_BIGNUM: printf("<bignum>"); break;
+        case VAL_BIGNUM: {
+            HeapObject* obj = vm->heap.objects[v.as.ptr];
+            if (obj && obj->opaque.ptr) {
+                VmBignum* b = (VmBignum*)obj->opaque.ptr;
+                char* s = bignum_to_string(&vm->heap.regions, b);
+                if (s) printf("%s", s);
+                else printf("<bignum>");
+            } else printf("<bignum>");
+            break;
+        }
         case VAL_DUAL: printf("<dual>"); break;
         case VAL_TENSOR: {
             HeapObject* obj = vm->heap.objects[v.as.ptr];

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -4550,6 +4550,106 @@ static int vm_closure_native_id(VM* vm, Value fn) {
  *        timers on every call via vm_timers_poll_due(). Errors are reported
  *        via `vm->error = 1` rather than by return value.
  */
+/**
+ * @brief Round @p x to the nearest integer using round-half-to-even (banker's
+ *        rounding), as required by R7RS `round`. The C library `round()`
+ *        rounds halves away from zero (2.5 → 3), which silently disagreed with
+ *        the native/reference path (2.5 → 2, 3.5 → 4).
+ */
+static double vm_round_half_even(double x) {
+    double f = floor(x);
+    double diff = x - f;
+    double r;
+    if (diff < 0.5) r = f;
+    else if (diff > 0.5) r = f + 1.0;
+    else r = (fmod(f, 2.0) == 0.0) ? f : f + 1.0; /* exactly halfway: round to even */
+    /* Preserve the sign of zero so (round -0.5) yields -0.0, matching the
+     * reference path, rather than +0.0. */
+    if (r == 0.0) return copysign(0.0, x);
+    return r;
+}
+
+/**
+ * @brief Deep structural equality (`equal?` per R7RS): recurses through pairs
+ *        and vectors, compares strings by content and numbers by value.
+ *        Numbers keep exactness distinctions (an exact int is not `equal?` to
+ *        an inexact float), matching the native/reference path. The prior
+ *        implementation compared pairs and vectors by heap identity, so
+ *        freshly-built equal structures reported `#f`.
+ */
+static int vm_deep_equal(VM* vm, Value a, Value b) {
+    if (a.type != b.type) return 0;
+    switch ((int)a.type) {
+        case VAL_NIL:   return 1;
+        case VAL_BOOL:  return a.as.b == b.as.b;
+        case VAL_INT:   return a.as.i == b.as.i;
+        case VAL_CHAR:  return a.as.i == b.as.i;
+        case VAL_FLOAT: return a.as.f == b.as.f;
+        case VAL_STRING: {
+            VmString* as = vm_value_as_string(vm, a);
+            VmString* bs = vm_value_as_string(vm, b);
+            return as && bs && as->byte_len == bs->byte_len &&
+                   memcmp(as->data, bs->data, (size_t)as->byte_len) == 0;
+        }
+        case VAL_PAIR: {
+            /* Iterate the spine to avoid deep C recursion on long lists;
+             * recurse only into each car. */
+            while (a.type == VAL_PAIR && b.type == VAL_PAIR) {
+                HeapObject* ao = vm->heap.objects[a.as.ptr];
+                HeapObject* bo = vm->heap.objects[b.as.ptr];
+                if (!ao || !bo) return 0;
+                if (!vm_deep_equal(vm, ao->cons.car, bo->cons.car)) return 0;
+                a = ao->cons.cdr;
+                b = bo->cons.cdr;
+            }
+            return vm_deep_equal(vm, a, b); /* compare tails (incl. proper-list NIL) */
+        }
+        case VAL_VECTOR: {
+            HeapObject* ao = vm->heap.objects[a.as.ptr];
+            HeapObject* bo = vm->heap.objects[b.as.ptr];
+            VmVector* av = (ao && ao->opaque.ptr) ? (VmVector*)ao->opaque.ptr : NULL;
+            VmVector* bv = (bo && bo->opaque.ptr) ? (VmVector*)bo->opaque.ptr : NULL;
+            if (!av || !bv) return av == bv;
+            if (av->len != bv->len) return 0;
+            for (int i = 0; i < av->len; i++)
+                if (!vm_deep_equal(vm, av->items[i], bv->items[i])) return 0;
+            return 1;
+        }
+        case VAL_BIGNUM: {
+            HeapObject* ao = vm->heap.objects[a.as.ptr];
+            HeapObject* bo = vm->heap.objects[b.as.ptr];
+            VmBignum* ab = (ao && ao->opaque.ptr) ? (VmBignum*)ao->opaque.ptr : NULL;
+            VmBignum* bb = (bo && bo->opaque.ptr) ? (VmBignum*)bo->opaque.ptr : NULL;
+            return ab && bb && bignum_compare(ab, bb) == 0;
+        }
+        case VAL_RATIONAL: {
+            HeapObject* ao = vm->heap.objects[a.as.ptr];
+            HeapObject* bo = vm->heap.objects[b.as.ptr];
+            VmRational* ar = (ao && ao->opaque.ptr) ? (VmRational*)ao->opaque.ptr : NULL;
+            VmRational* br = (bo && bo->opaque.ptr) ? (VmRational*)bo->opaque.ptr : NULL;
+            return ar && br && ar->num == br->num && ar->denom == br->denom;
+        }
+        case VAL_TENSOR: {
+            /* Numeric vector literals compile to tensors in this VM, so
+             * structural tensor equality is needed for equal? on such
+             * "vectors" to match the native path. */
+            HeapObject* ao = vm->heap.objects[a.as.ptr];
+            HeapObject* bo = vm->heap.objects[b.as.ptr];
+            VmTensor* at = (ao && ao->opaque.ptr) ? (VmTensor*)ao->opaque.ptr : NULL;
+            VmTensor* bt = (bo && bo->opaque.ptr) ? (VmTensor*)bo->opaque.ptr : NULL;
+            if (!at || !bt) return at == bt;
+            if (at->n_dims != bt->n_dims || at->total != bt->total) return 0;
+            for (int i = 0; i < at->n_dims; i++)
+                if (at->shape[i] != bt->shape[i]) return 0;
+            for (int64_t i = 0; i < at->total; i++)
+                if (at->data[i] != bt->data[i]) return 0;
+            return 1;
+        }
+        default:
+            return a.as.ptr == b.as.ptr; /* eq? fallback for opaque types */
+    }
+}
+
 static void vm_dispatch_native(VM* vm, int fid) {
     vm_timers_poll_due(vm);
     if (fid >= ESHKOL_VM_HOST_NATIVE_BASE) {
@@ -4578,13 +4678,30 @@ static void vm_dispatch_native(VM* vm, int fid) {
     case 25: { Value a = vm_pop(vm); if (a.type==VAL_DUAL) { vm_push(vm,a); vm_dispatch_native(vm,381); } else vm_push(vm, FLOAT_VAL(sqrt(as_number(a)))); break; }
     case 26: { Value a = vm_pop(vm); vm_push(vm, number_val(floor(as_number_vm(vm,a)))); break; }
     case 27: { Value a = vm_pop(vm); vm_push(vm, number_val(ceil(as_number_vm(vm,a)))); break; }
-    case 28: { Value a = vm_pop(vm); vm_push(vm, number_val(round(as_number_vm(vm,a)))); break; }
+    case 28: { Value a = vm_pop(vm); vm_push(vm, number_val(vm_round_half_even(as_number_vm(vm,a)))); break; }
     case 29: { Value a = vm_pop(vm); vm_push(vm, FLOAT_VAL(asin(as_number_vm(vm,a)))); break; }
     case 30: { Value a = vm_pop(vm); vm_push(vm, FLOAT_VAL(acos(as_number_vm(vm,a)))); break; }
     case 31: { Value a = vm_pop(vm); vm_push(vm, FLOAT_VAL(atan(as_number_vm(vm,a)))); break; }
     case 32: { Value b = vm_pop(vm); Value a = vm_pop(vm);
-        if (a.type==VAL_DUAL||b.type==VAL_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,385); }
-        else vm_push(vm, FLOAT_VAL(pow(as_number(a), as_number(b)))); break; }
+        if (a.type==VAL_DUAL||b.type==VAL_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,385); break; }
+        /* Exact integer base with a non-negative integer exponent → exact
+         * result: an int64 while it fits, promoting to a bignum on overflow
+         * (matching the native path). Previously always used pow() and
+         * returned an inexact float, so (expt 2 40) printed 1.09951e+12. */
+        if ((a.type==VAL_INT || a.type==VAL_BIGNUM) && b.type==VAL_INT && b.as.i >= 0) {
+            VmRegionStack* bn_rs = &vm->heap.regions;
+            VmBignum* base_bn = (a.type==VAL_BIGNUM)
+                ? (VmBignum*)vm->heap.objects[a.as.ptr]->opaque.ptr
+                : bignum_from_int64(bn_rs, a.as.i);
+            VmBignum* result = base_bn ? bignum_pow(bn_rs, base_bn, (uint64_t)b.as.i) : NULL;
+            if (result) {
+                int ov = 0; int64_t iv = bignum_to_int64(result, &ov);
+                if (!ov) vm_push(vm, INT_VAL(iv));
+                else VM_PUSH_HEAP_OPAQUE(vm, HEAP_BIGNUM, VAL_BIGNUM, result);
+                break;
+            }
+        }
+        vm_push(vm, FLOAT_VAL(pow(as_number(a), as_number(b)))); break; }
     case 33: { Value b = vm_pop(vm); Value a = vm_pop(vm); double da=as_number_vm(vm,a),db=as_number_vm(vm,b); vm_push(vm, number_val(da<db?da:db)); break; }
     case 34: { Value b = vm_pop(vm); Value a = vm_pop(vm); double da=as_number_vm(vm,a),db=as_number_vm(vm,b); vm_push(vm, number_val(da>db?da:db)); break; }
     case 35: { Value a = vm_pop(vm); if (a.type==VAL_DUAL) { vm_push(vm,a); vm_dispatch_native(vm,383); } else vm_push(vm, number_val(fabs(as_number(a)))); break; }
@@ -4805,6 +4922,35 @@ static void vm_dispatch_native(VM* vm, int fid) {
         break;
     }
 
+    case 227: { /* list->vector: (list->vector lst) → #(elts...)
+                 * Native id 227: previously the name table aliased
+                 * list->vector to id 139 (memq), so it silently returned #f. */
+        Value lst = vm_pop(vm);
+        int n = 0;
+        for (Value cur = lst; cur.type == VAL_PAIR; cur = vm->heap.objects[cur.as.ptr]->cons.cdr) n++;
+        int32_t p = heap_alloc(&vm->heap); if (p < 0) { vm->error = 1; break; }
+        vm->heap.objects[p]->type = HEAP_VECTOR;
+        VmVector* v = (VmVector*)vm_alloc(&vm->heap.regions, sizeof(VmVector));
+        if (!v) { vm->error = 1; break; }
+        v->len = n; v->cap = n;
+        v->items = n ? (Value*)vm_alloc(&vm->heap.regions, (size_t)n * sizeof(Value)) : NULL;
+        if (n && !v->items) { vm->error = 1; break; }
+        int i = 0;
+        for (Value cur = lst; cur.type == VAL_PAIR; cur = vm->heap.objects[cur.as.ptr]->cons.cdr)
+            v->items[i++] = vm->heap.objects[cur.as.ptr]->cons.car;
+        vm->heap.objects[p]->opaque.ptr = v;
+        vm_push(vm, (Value){VAL_VECTOR, {.ptr = p}});
+        break;
+    }
+
+    case 228: { /* char-from-int: tag an integer codepoint as a VAL_CHAR.
+                 * Emitted by the compiler for #\x literals so display/char?
+                 * distinguish a character from its integer code point. */
+        Value a = vm_pop(vm);
+        vm_push(vm, (Value){.type = VAL_CHAR, .as.i = (int64_t)as_number(a)});
+        break;
+    }
+
     /* ══════════════════════════════════════════════════════════════════════
      * Make-vector (260)
      * ══════════════════════════════════════════════════════════════════════ */
@@ -4999,7 +5145,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
             else vm_push(vm, INT_VAL((int64_t)as_number(v))); break; }
         case 345: { Value v = vm_pop(vm);
             if (v.type == VAL_RATIONAL) { VmRational* r = (VmRational*)vm->heap.objects[v.as.ptr]->opaque.ptr; vm_push(vm, INT_VAL(vm_rational_round(r))); }
-            else vm_push(vm, INT_VAL((int64_t)round(as_number(v)))); break; }
+            else vm_push(vm, INT_VAL((int64_t)vm_round_half_even(as_number(v)))); break; }
         case 346: { Value v = vm_pop(vm);
             if (v.type == VAL_RATIONAL) { VmRational* r = (VmRational*)vm->heap.objects[v.as.ptr]->opaque.ptr; vm_push(vm, INT_VAL(vm_rational_numerator(r))); }
             else vm_push(vm, INT_VAL((int64_t)as_number(v))); break; }
@@ -6466,7 +6612,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
                 int32_t p = heap_alloc(&vm->heap);
                 if (p < 0) break;
                 vm->heap.objects[p]->type = HEAP_CONS;
-                vm->heap.objects[p]->cons.car = INT_VAL(cp >= 0 ? cp : 0);
+                vm->heap.objects[p]->cons.car = (Value){.type = VAL_CHAR, .as.i = cp >= 0 ? cp : 0};
                 vm->heap.objects[p]->cons.cdr = result;
                 result = PAIR_VAL(p);
             }
@@ -9913,32 +10059,16 @@ static void vm_dispatch_native(VM* vm, int fid) {
         else if (a.type == VAL_NIL) result = 1;
         else if (a.type == VAL_BOOL) result = (a.as.b == b.as.b);
         else if (a.type == VAL_INT) result = (a.as.i == b.as.i);
+        else if (a.type == VAL_CHAR) result = (a.as.i == b.as.i);
         else if (a.type == VAL_FLOAT) result = (a.as.f == b.as.f);
         else result = (a.as.ptr == b.as.ptr);
         vm_push(vm, BOOL_VAL(result));
         break;
     }
 
-    case 134: { /* equal?: deep structural equality */
+    case 134: { /* equal?: deep structural equality (pairs, vectors, strings, numbers) */
         Value b = vm_pop(vm), a = vm_pop(vm);
-        int result = 0;
-        if (a.type != b.type) result = 0;
-        else if (a.type == VAL_NIL) result = 1;
-        else if (a.type == VAL_BOOL) result = (a.as.b == b.as.b);
-        else if (a.type == VAL_INT) result = (a.as.i == b.as.i);
-        else if (a.type == VAL_FLOAT) result = (a.as.f == b.as.f);
-        else if (a.type == VAL_STRING) {
-            VmString* as = vm_value_as_string(vm, a);
-            VmString* bs = vm_value_as_string(vm, b);
-            result = (as && bs && as->byte_len == bs->byte_len &&
-                      memcmp(as->data, bs->data, (size_t)as->byte_len) == 0);
-        }
-        else if (a.type == VAL_PAIR) {
-            /* Simple shallow equality for pairs */
-            result = (a.as.ptr == b.as.ptr);
-        }
-        else result = (a.as.ptr == b.as.ptr);
-        vm_push(vm, BOOL_VAL(result));
+        vm_push(vm, BOOL_VAL(vm_deep_equal(vm, a, b)));
         break;
     }
 
@@ -9981,7 +10111,11 @@ static void vm_dispatch_native(VM* vm, int fid) {
             vm_push(vm, (Value){.type = VAL_COMPLEX, .as.ptr = p});
         } else { vm_push(vm, number_val(as_number(a_val) * as_number(b_val))); }
         break; }
-    case 145: { /* div2 — complex-aware */
+    case 145: { /* div2 — complex- and rational-aware.
+                 * The prelude's variadic `/` folds with div2, so this is the
+                 * real path for (/ 1 3). Exact/exact division yields an exact
+                 * rational (or an integer when it divides), matching the native
+                 * path; previously it always produced an inexact float. */
         Value b_val = vm_pop(vm), a_val = vm_pop(vm);
         if (a_val.type == VAL_COMPLEX || b_val.type == VAL_COMPLEX) {
             VmComplex a_z = {as_number(a_val), 0}, b_z = {as_number(b_val), 0};
@@ -9992,6 +10126,10 @@ static void vm_dispatch_native(VM* vm, int fid) {
             int32_t p = heap_alloc(&vm->heap); if (p < 0) { vm->error = 1; break; }
             vm->heap.objects[p]->type = HEAP_COMPLEX; vm->heap.objects[p]->opaque.ptr = r;
             vm_push(vm, (Value){.type = VAL_COMPLEX, .as.ptr = p});
+        } else if (a_val.type == VAL_RATIONAL || b_val.type == VAL_RATIONAL ||
+                   (a_val.type == VAL_INT && b_val.type == VAL_INT)) {
+            if ((a_val.type == VAL_INT && b_val.type == VAL_INT && b_val.as.i == 0)) { vm->error = 1; break; }
+            vm_push(vm, a_val); vm_push(vm, b_val); vm_dispatch_native(vm, 334); /* rational div: reduces, collapses denom==1 to int */
         } else { vm_push(vm, number_val(as_number(a_val) / as_number(b_val))); }
         break; }
     /* Comparison operators as first-class functions (for sort, map, fold, etc.) */
@@ -10055,7 +10193,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
         }
         break; }
     case 216: { Value a = vm_pop(vm); vm_push(vm, INT_VAL((int64_t)as_number(a))); break; } /* char->integer */
-    case 217: { Value a = vm_pop(vm); vm_push(vm, INT_VAL((int64_t)as_number(a))); break; } /* integer->char */
+    case 217: { Value a = vm_pop(vm); vm_push(vm, (Value){.type = VAL_CHAR, .as.i = (int64_t)as_number(a)}); break; } /* integer->char */
     case 218: { /* make-vector */
         Value fill = vm_pop(vm), size_v = vm_pop(vm);
         int sz = (int)as_number(size_v);
@@ -10097,7 +10235,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
                 int cp = vm_string_ref(s, i);
                 int32_t p = heap_alloc(&vm->heap); if (p < 0) break;
                 vm->heap.objects[p]->type = HEAP_CONS;
-                vm->heap.objects[p]->cons.car = INT_VAL(cp);
+                vm->heap.objects[p]->cons.car = (Value){.type = VAL_CHAR, .as.i = cp};
                 vm->heap.objects[p]->cons.cdr = result;
                 result = PAIR_VAL(p);
             }
@@ -10346,8 +10484,8 @@ static void vm_dispatch_native(VM* vm, int fid) {
     case 1682: { Value a = vm_pop(vm); int c = (int)as_number(a); vm_push(vm, BOOL_VAL(isspace(c))); break; }
     case 1683: { Value a = vm_pop(vm); int c = (int)as_number(a); vm_push(vm, BOOL_VAL(isupper(c))); break; }
     case 1684: { Value a = vm_pop(vm); int c = (int)as_number(a); vm_push(vm, BOOL_VAL(islower(c))); break; }
-    case 1685: { Value a = vm_pop(vm); int c = (int)as_number(a); vm_push(vm, INT_VAL(toupper(c))); break; }
-    case 1686: { Value a = vm_pop(vm); int c = (int)as_number(a); vm_push(vm, INT_VAL(tolower(c))); break; }
+    case 1685: { Value a = vm_pop(vm); int c = (int)as_number(a); vm_push(vm, (Value){.type = VAL_CHAR, .as.i = toupper(c)}); break; }
+    case 1686: { Value a = vm_pop(vm); int c = (int)as_number(a); vm_push(vm, (Value){.type = VAL_CHAR, .as.i = tolower(c)}); break; }
     case 1687: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL((int)as_number(a) == (int)as_number(b))); break; }
     case 1688: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL((int)as_number(a) < (int)as_number(b))); break; }
     case 1689: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL((int)as_number(a) > (int)as_number(b))); break; }
@@ -10376,7 +10514,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
      * ══════════════════════════════════════════════════════════════════════ */
     case 160: { Value a = vm_pop(vm); /* symbol? — in the VM, symbols are interned strings */
         vm_push(vm, BOOL_VAL(a.type == VAL_STRING)); break; }
-    case 161: { Value a = vm_pop(vm); vm_push(vm, BOOL_VAL(a.type == VAL_INT && as_number(a) >= 0 && as_number(a) <= 0x10FFFF)); break; } /* char? */
+    case 161: { Value a = vm_pop(vm); vm_push(vm, BOOL_VAL(a.type == VAL_CHAR)); break; } /* char? */
     case 162: { Value a = vm_pop(vm); vm_push(vm, BOOL_VAL(a.type == VAL_INT || a.type == VAL_RATIONAL)); break; } /* exact? */
     case 163: { Value a = vm_pop(vm); vm_push(vm, BOOL_VAL(a.type == VAL_FLOAT)); break; } /* inexact? */
     case 164: { Value a = vm_pop(vm); vm_push(vm, BOOL_VAL(a.type == VAL_FLOAT && isnan(a.as.f))); break; } /* nan? */

--- a/lib/backend/vm_numeric.h
+++ b/lib/backend/vm_numeric.h
@@ -45,6 +45,7 @@
 #define VAL_HYPER_DUAL  26   /* heap-allocated VmHyperDual (opaque)          */
 #define VAL_RIEMANNIAN_ADAM_STATE 27 /* heap-allocated optimizer state       */
 #define VAL_FUTURE      28   /* heap-allocated standalone VM future handle   */
+#define VAL_CHAR        29   /* immediate Unicode character (codepoint in .as.i) */
 
 /* ── Heap Subtypes ── */
 #define VM_SUBTYPE_COMPLEX   5

--- a/lib/backend/vm_parser.c
+++ b/lib/backend/vm_parser.c
@@ -16,6 +16,8 @@ typedef struct Node {
     char symbol[128];
     struct Node** children;
     int n_children;
+    int is_char;      /* N_NUMBER node that originated from a #\ character literal */
+    int is_inexact;   /* N_NUMBER literal written in inexact (float) syntax: 2.0, 1e3 */
 } Node;
 
 /* Hygienic macro expansion (syntax-rules).
@@ -442,6 +444,7 @@ static Node* parse_sexp(void) {
             }
             Node* n = make_node(N_NUMBER); if (!n) return NULL;
             n->numval = ch;
+            n->is_char = 1;   /* preserve char-ness through to codegen */
             return n;
         }
         /* Vector literal: #(elements...) */
@@ -466,6 +469,7 @@ static Node* parse_sexp(void) {
         src_ptr += 6; /* skip +nan.0 / +inf.0 / -inf.0 */
         Node* n = make_node(N_NUMBER); if (!n) return NULL;
         n->numval = val;
+        n->is_inexact = 1;
         return n;
     }
     /* Number (including rational literals like 1/3) */
@@ -506,7 +510,13 @@ static Node* parse_sexp(void) {
             return div_node;
         }
         buf[i] = 0;
-        Node* n = make_node(N_NUMBER); if (!n) return NULL; n->numval = atof(buf); return n;
+        Node* n = make_node(N_NUMBER); if (!n) return NULL; n->numval = atof(buf);
+        /* Inexact syntax (a decimal point or exponent) must stay inexact even
+         * when the value is integral (2.0, 1e3), so downstream codegen emits a
+         * float rather than an exact int. Without this the VM collapsed 2.0 to
+         * exact 2, and (/ 7 2.0) then produced the rational 7/2 instead of 3.5. */
+        for (int k = 0; buf[k]; k++) if (buf[k] == '.' || buf[k] == 'e' || buf[k] == 'E') { n->is_inexact = 1; break; }
+        return n;
     }
     /* Symbol */
     char buf[128]; int i = 0;

--- a/lib/backend/vm_run.c
+++ b/lib/backend/vm_run.c
@@ -176,6 +176,14 @@ void vm_run(VM* vm) {
         else if (a.type == VAL_DUAL || b.type == VAL_DUAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 376); }
         else if (a.type == VAL_RATIONAL || b.type == VAL_RATIONAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 334); }
         else if (a.type == VAL_COMPLEX || b.type == VAL_COMPLEX) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 310); }
+        else if (a.type == VAL_INT && b.type == VAL_INT) {
+            /* exact/exact -> exact result (R7RS): native 334 (rational div)
+             * reduces the fraction and collapses denom==1 back to an integer,
+             * so (/ 1 3) yields 1/3 and (/ 6 3) yields 2 rather than the
+             * inexact float the double path produced. */
+            if (b.as.i == 0) { fprintf(stderr, "DIVIDE BY ZERO\n"); vm->error = 1; goto vm_exit; }
+            vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 334);
+        }
         else {
         double bd = as_number(b);
         if (bd == 0) { fprintf(stderr, "DIVIDE BY ZERO\n"); vm->error = 1; goto vm_exit; }
@@ -507,9 +515,10 @@ void vm_run(VM* vm) {
         if (str_val.type == VAL_STRING) {
             VmString* s = (VmString*)vm->heap.objects[str_val.as.ptr]->opaque.ptr;
             int i = (int)as_number(idx);
-            if (s && i >= 0 && i < s->byte_len) vm_push(vm, INT_VAL((unsigned char)s->data[i]));
-            else vm_push(vm, INT_VAL(0));
-        } else vm_push(vm, INT_VAL(0));
+            /* R7RS string-ref returns a character, not its integer code. */
+            if (s && i >= 0 && i < s->byte_len) vm_push(vm, (Value){.type = VAL_CHAR, .as.i = (unsigned char)s->data[i]});
+            else vm_push(vm, (Value){.type = VAL_CHAR, .as.i = 0});
+        } else vm_push(vm, (Value){.type = VAL_CHAR, .as.i = 0});
         DISPATCH();
     }
 
@@ -735,6 +744,14 @@ vm_exit:
             else if (a.type==VAL_DUAL||b.type==VAL_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,376); }
             else if (a.type==VAL_RATIONAL||b.type==VAL_RATIONAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,334); }
             else if (a.type==VAL_COMPLEX||b.type==VAL_COMPLEX) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,310); }
+            else if (a.type==VAL_INT && b.type==VAL_INT) {
+                /* exact/exact → exact result (R7RS): native 334 (rational div)
+                 * reduces the fraction and collapses denom==1 back to an
+                 * integer, so (/ 1 3) yields 1/3 and (/ 6 3) yields 2 rather
+                 * than the inexact float the double path produced. */
+                if (b.as.i == 0) { fprintf(stderr, "DIVIDE BY ZERO\n"); vm->error = 1; break; }
+                vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,334);
+            }
             else { double bd = as_number(b);
             if (bd == 0) { fprintf(stderr, "DIVIDE BY ZERO\n"); vm->error = 1; break; }
             vm_push(vm, number_val(as_number(a) / bd)); } break; }
@@ -1024,9 +1041,10 @@ vm_exit:
             if (str_val.type == VAL_STRING) {
                 VmString* s = (VmString*)vm->heap.objects[str_val.as.ptr]->opaque.ptr;
                 int i = (int)as_number(idx);
-                if (s && i >= 0 && i < s->byte_len) vm_push(vm, INT_VAL((unsigned char)s->data[i]));
-                else vm_push(vm, INT_VAL(0));
-            } else vm_push(vm, INT_VAL(0));
+                /* R7RS string-ref returns a character, not its integer code. */
+                if (s && i >= 0 && i < s->byte_len) vm_push(vm, (Value){.type = VAL_CHAR, .as.i = (unsigned char)s->data[i]});
+                else vm_push(vm, (Value){.type = VAL_CHAR, .as.i = 0});
+            } else vm_push(vm, (Value){.type = VAL_CHAR, .as.i = 0});
             break;
         }
 

--- a/lib/backend/vm_tests.c
+++ b/lib/backend/vm_tests.c
@@ -809,7 +809,9 @@ static int run_source_tests(void) {
     source_test("sort-descending","(display (sort > (list 1 5 3 2 4)))");
 
     /* String operations */
-    source_test_expect("string-ref",     "(display (string-ref \"hello\" 1))",    "101");
+    /* string-ref returns a character (R7RS); display renders its glyph, not
+     * the integer code point (previously mis-tested as "101"). */
+    source_test_expect("string-ref",     "(display (string-ref \"hello\" 1))",    "e");
     source_test_expect("substring",      "(display (substring \"hello\" 1 3))",   "el");
     source_test_expect("number->string", "(display (number->string 42))",          "42");
     source_test_expect("string->number", "(display (string->number \"99\"))",      "99");

--- a/tests/vm/vm_silent_miscompile_test.esk
+++ b/tests/vm/vm_silent_miscompile_test.esk
@@ -1,0 +1,60 @@
+; vm_silent_miscompile_test.esk
+;
+; Regression coverage for seven silent VM miscompiles exposed by the
+; generative multi-oracle differential harness (P7c). Each was a case where the
+; bytecode VM exited 0 with no diagnostic but produced a different value than
+; the native/JIT/AOT reference (which agrees with chibi-scheme). Every line
+; below prints the value the reference path produces; run under the VM it must
+; now print the SAME value.
+;
+; Expected output (one per line):
+;   I
+;   A
+;   #t
+;   #(1 2 3)
+;   1099511627776
+;   1267650600228229401496703205376
+;   1/3
+;   1/2
+;   2
+;   2
+;   4
+;   -2
+;   #t
+;   #t
+;   #t
+;   #t
+;   33
+;   33
+
+; V1 — characters display as their glyph, not their integer code point.
+(display #\I) (newline)
+(display (char-upcase #\a)) (newline)
+(display (char? #\a)) (newline)
+
+; V2 — list->vector builds a real vector (was aliased to memq → #f).
+(display (list->vector (list 1 2 3))) (newline)
+
+; V3 — exact integer expt stays exact (int, promoting to bignum), not float.
+(display (expt 2 40)) (newline)
+(display (expt 2 100)) (newline)
+
+; V4 — exact rational division stays exact.
+(display (/ 1 3)) (newline)
+(display (+ (/ 1 3) (/ 1 6))) (newline)
+(display (/ 6 3)) (newline)
+
+; V5 — round is round-half-to-even (banker's rounding).
+(display (round 2.5)) (newline)
+(display (round 3.5)) (newline)
+(display (round -2.5)) (newline)
+
+; V6 — equal? is structural on pairs and vectors, not identity.
+(display (equal? (list 1 2 3) (list 1 2 3))) (newline)
+(display (equal? (list 1 (list 2 3)) (list 1 (list 2 3)))) (newline)
+(display (equal? (list->vector (list 1 2)) (list->vector (list 1 2)))) (newline)
+(display (equal? (vector 1 2) (vector 1 2))) (newline)
+
+; V7 — sibling let/let* forms as operands must not clobber each other's slots.
+(display (+ (let ((a 1) (b 2)) (+ a b)) (let ((a 10) (b 20)) (+ a b)))) (newline)
+(display (+ (let* ((a 1) (b 2)) (+ a b)) (let* ((a 10) (b 20)) (+ a b)))) (newline)

--- a/tests/vm_parity/PARITY.tsv
+++ b/tests/vm_parity/PARITY.tsv
@@ -18,7 +18,7 @@ __arena-used	native-only-justified	native arena introspection probe; bytecode VM
 *	vm-supported	
 +	vm-supported	
 -	vm-supported	
-/	gap	exact rational division collapses to float (found/exact_division_lost.esk)
+/	vm-supported	exact/exact division now yields an exact rational (div2/OP_DIV dispatch to rational div; `/` no longer constant-folded to a float)
 /rational	gap	no VM name binding
 <	vm-supported	
 <=	vm-supported	
@@ -224,7 +224,7 @@ emergency-exit	gap	no VM name binding
 eof-object	gap	port/file IO surface missing in VM
 eof-object?	vm-supported	
 eq?	gap	symbol identity returns #f (found/equal_eq_structural_false.esk)
-equal?	gap	structural equality returns #f on equal lists (found/equal_eq_structural_false.esk)
+equal?	vm-supported	deep structural equality over pairs/vectors/tensors/strings/numbers (vm_deep_equal)
 eqv?	gap	aliased to broken eq?/equal? fids (found/equal_eq_structural_false.esk)
 error	vm-supported	
 eval	gap	eval/environment reflection has no VM binding
@@ -242,7 +242,7 @@ exp	vm-supported
 exp2	gap	no VM name binding
 expected-free-energy	vm-supported	
 exponential-decay-lr	gap	ml faculty has no VM fid coverage
-expt	gap	integer expt overflows to float not bignum (found/expt_bignum_to_float.esk)
+expt	vm-supported	exact integer^nonneg-integer stays exact (int, promoting to bignum on overflow)
 eye	vm-supported	
 fabs	gap	no VM name binding
 fact?	vm-supported	
@@ -363,7 +363,7 @@ inject-left	gap	no VM name binding
 inject-right	gap	no VM name binding
 input-port-open?	gap	port/file IO surface missing in VM
 input-port?	vm-supported	
-integer->char	gap	no char type — prints integer (found/char_type_collapsed.esk)
+integer->char	vm-supported	VAL_CHAR immediate type; #\ literals and char ops carry char-ness so display renders the glyph
 integer?	vm-supported	
 interaction-environment	gap	eval/environment reflection has no VM binding
 jacobian	gap	silently wrong values (found/ad_gradient_wrong.esk)
@@ -398,7 +398,7 @@ linspace	vm-supported
 list	vm-supported	
 list*	gap	no VM name binding
 list->string	vm-supported	
-list->vector	gap	BUILTINS maps it to fid 139 which collides with memq (found/vector_constructor_empty.esk)
+list->vector	vm-supported	dedicated native fid 227 (no longer aliased to memq/139)
 list-copy	gap	no VM name binding
 list-set!	gap	no VM name binding
 list?	vm-supported	


### PR DESCRIPTION
The bytecode VM silently diverged from the native compiler (exits 0, wrong answer) on 7 cases exposed by the generative differential engine (#243). Fixed at root in the VM sources: (1) chars now display as the char not the integer code, (3) bignums render as integers not floats, (4) exact rationals render as n/d not floats, (2) list->vector works, (6) equal? on lists/vectors is structural not identity, (5) round is banker's (round-half-to-even), (7) sibling let/let* operands no longer corrupt each other (slot-allocation aliasing). Verified on the actual VM path (--profile hosted-vm -> eshkol-vm-standalone-test): all 7 now match native/chibi; the differential engine drops from 13 divergences to 1. PARITY.tsv updated. The remaining 1 divergence is a DISTINCT pre-existing VM bignum-arithmetic bug (VM computes 13 where the reference gives a 35-digit bignum) — not touched by these display/equal/round/let fixes; tracked separately.