### PR TITLE
fix(ad): reverse-seed a (vector ...) gradient point through tensor ops (ESH-0235)

### DIFF
--- a/lib/backend/autodiff_codegen.cpp
+++ b/lib/backend/autodiff_codegen.cpp
@@ -3378,11 +3378,23 @@ static bool adIsTensorValuedBuiltin(const char* cname) {
  * @param ast the AST node (or cons-cell) to scan.
  * @return true iff the subtree reaches a tensor operation.
  */
-static bool adAstUsesTensorOps(const eshkol_ast_t* ast) {
+// ESH-0235: when `bodies` is non-null, a call to a user-defined function is
+// followed into that function's registered body AST (guarded by `visited` to
+// stop recursion and a depth cap). This lets the tensor-flow test see through a
+// layer of indirection — a differentiated wrapper `(lambda (z) (loss z))` whose
+// tensor op lives inside the named `loss` — so its (vector …) point is
+// reverse-seeded like the equivalent #(…)/(tensor …) point instead of silently
+// zeroing on the forward-mode dual path. With `bodies` null (every pre-existing
+// caller) the behaviour is exactly as before: no calls are followed.
+static bool adAstUsesTensorOps(
+        const eshkol_ast_t* ast,
+        const std::unordered_map<std::string, const eshkol_ast_t*>* bodies = nullptr,
+        std::unordered_set<std::string>* visited = nullptr,
+        int depth = 0) {
     if (!ast) return false;
     if (ast->type == ESHKOL_CONS) {
-        return adAstUsesTensorOps(ast->cons_cell.car) ||
-               adAstUsesTensorOps(ast->cons_cell.cdr);
+        return adAstUsesTensorOps(ast->cons_cell.car, bodies, visited, depth) ||
+               adAstUsesTensorOps(ast->cons_cell.cdr, bodies, visited, depth);
     }
     if (ast->type != ESHKOL_OP) return false;
     const eshkol_operations_t* op = &ast->operation;
@@ -3393,29 +3405,38 @@ static bool adAstUsesTensorOps(const eshkol_ast_t* ast) {
         case ESHKOL_COND_OP: {
             const eshkol_ast_t* f = op->call_op.func;
             if (f && f->type == ESHKOL_VAR && adIsTensorValuedBuiltin(f->variable.id)) return true;
-            if (f && adAstUsesTensorOps(f)) return true;
+            // Follow a call into a user-defined function's body (ESH-0235).
+            if (bodies && visited && depth < 8 && f && f->type == ESHKOL_VAR &&
+                !visited->count(f->variable.id)) {
+                auto it = bodies->find(f->variable.id);
+                if (it != bodies->end()) {
+                    visited->insert(f->variable.id);
+                    if (adAstUsesTensorOps(it->second, bodies, visited, depth + 1)) return true;
+                }
+            }
+            if (f && adAstUsesTensorOps(f, bodies, visited, depth)) return true;
             for (uint64_t i = 0; i < op->call_op.num_vars; i++)
-                if (adAstUsesTensorOps(&op->call_op.variables[i])) return true;
+                if (adAstUsesTensorOps(&op->call_op.variables[i], bodies, visited, depth)) return true;
             return false;
         }
         case ESHKOL_SEQUENCE_OP:
         case ESHKOL_AND_OP:
         case ESHKOL_OR_OP:
             for (uint64_t i = 0; i < op->sequence_op.num_expressions; i++)
-                if (adAstUsesTensorOps(&op->sequence_op.expressions[i])) return true;
+                if (adAstUsesTensorOps(&op->sequence_op.expressions[i], bodies, visited, depth)) return true;
             return false;
         case ESHKOL_LET_OP:
         case ESHKOL_LET_STAR_OP:
         case ESHKOL_LETREC_OP:
         case ESHKOL_LETREC_STAR_OP: {
             for (uint64_t i = 0; i < op->let_op.num_bindings; i++)
-                if (adAstUsesTensorOps(&op->let_op.bindings[i])) return true;
-            return adAstUsesTensorOps(op->let_op.body);
+                if (adAstUsesTensorOps(&op->let_op.bindings[i], bodies, visited, depth)) return true;
+            return adAstUsesTensorOps(op->let_op.body, bodies, visited, depth);
         }
         case ESHKOL_LAMBDA_OP:
-            return adAstUsesTensorOps(op->lambda_op.body);
+            return adAstUsesTensorOps(op->lambda_op.body, bodies, visited, depth);
         case ESHKOL_DEFINE_OP:
-            return adAstUsesTensorOps(op->define_op.value);
+            return adAstUsesTensorOps(op->define_op.value, bodies, visited, depth);
         default:
             return false;
     }
@@ -4132,12 +4153,72 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
                     Value* rvt_sub = b.CreateLoad(ctx_.int8Type(), rvt_hdr);
                     Value* rvt_is_tensor = b.CreateICmpEQ(rvt_sub,
                         ConstantInt::get(ctx_.int8Type(), HEAP_SUBTYPE_TENSOR));
-                    b.CreateCondBr(rvt_is_tensor, rvt_reverse, rvt_not_tensor);
+                    // ESH-0235: a (vector …)-constructed point must be reverse-
+                    // seeded exactly like a #(…)/(tensor …) point. Accept the
+                    // HEAP_SUBTYPE_VECTOR subtype too and convert it to a 1-D
+                    // plain-double tensor below, so the identical tape machinery
+                    // seeds each element as an AD variable. Without this a
+                    // first-class / wrapper loss at a (vector …) point falls to
+                    // the forward-mode dual path, which drops the tangent through
+                    // a tensor op and returns a silent all-zero gradient.
+                    Value* rvt_is_vec = b.CreateICmpEQ(rvt_sub,
+                        ConstantInt::get(ctx_.int8Type(), HEAP_SUBTYPE_VECTOR));
+                    Value* rvt_seedable = b.CreateOr(rvt_is_tensor, rvt_is_vec);
+                    llvm::StructType* rvt_tt = ctx_.tensorType();
+                    BasicBlock* rvt_norm_vec = BasicBlock::Create(ctx_.context(), "grad_rt_rev_norm_vec", current_func);
+                    BasicBlock* rvt_norm_ten = BasicBlock::Create(ctx_.context(), "grad_rt_rev_norm_ten", current_func);
+                    b.CreateCondBr(rvt_seedable, rvt_norm_ten, rvt_not_tensor);
+
+                    // Tensor point: use the tensor struct pointer directly.
+                    b.SetInsertPoint(rvt_norm_ten);
+                    Value* rvt_ten_ptr = b.CreateIntToPtr(tagged_.unpackInt64(point_val), ctx_.ptrType());
+                    b.CreateCondBr(rvt_is_vec, rvt_norm_vec, rvt_reverse);
+                    BasicBlock* rvt_norm_ten_exit = b.GetInsertBlock();
+
+                    // (vector …) point: build a 1-D plain-double tensor from the
+                    // Scheme vector [len(8)][tagged elems] layout.
+                    b.SetInsertPoint(rvt_norm_vec);
+                    Value* rvt_vsvec = tagged_.unpackPtr(point_val);
+                    Value* rvt_vn = b.CreateLoad(ctx_.int64Type(), rvt_vsvec);
+                    Value* rvt_vsrc_base = b.CreateGEP(ctx_.int8Type(), rvt_vsvec, ConstantInt::get(ctx_.int64Type(), 8));
+                    Value* rvt_vsrc = b.CreatePointerCast(rvt_vsrc_base, ctx_.ptrType());
+                    Value* rvt_vten = b.CreateCall(mem_.getArenaAllocateTensorWithHeader(), {arena_ptr});
+                    Value* rvt_vdims = b.CreateCall(mem_.getArenaAllocate(), {arena_ptr, ConstantInt::get(ctx_.int64Type(), sizeof(uint64_t))});
+                    Value* rvt_vdims_t = b.CreatePointerCast(rvt_vdims, ctx_.builder().getPtrTy());
+                    b.CreateStore(rvt_vn, rvt_vdims_t);
+                    b.CreateStore(rvt_vdims_t, b.CreateStructGEP(rvt_tt, rvt_vten, 0));
+                    b.CreateStore(ConstantInt::get(ctx_.int64Type(), 1), b.CreateStructGEP(rvt_tt, rvt_vten, 1));
+                    b.CreateStore(rvt_vn, b.CreateStructGEP(rvt_tt, rvt_vten, 3));
+                    Value* rvt_vdst_raw = b.CreateCall(mem_.getArenaAllocate(),
+                        {arena_ptr, b.CreateMul(rvt_vn, ConstantInt::get(ctx_.int64Type(), sizeof(double)))});
+                    Value* rvt_vdst = b.CreatePointerCast(rvt_vdst_raw, ctx_.builder().getPtrTy());
+                    b.CreateStore(rvt_vdst, b.CreateStructGEP(rvt_tt, rvt_vten, 2));
+                    Value* rvt_vi = b.CreateAlloca(ctx_.int64Type(), nullptr, "rvt_vi");
+                    b.CreateStore(ConstantInt::get(ctx_.int64Type(), 0), rvt_vi);
+                    BasicBlock* rvt_vcc = BasicBlock::Create(ctx_.context(), "rvt_vconv_cond", current_func);
+                    BasicBlock* rvt_vcb = BasicBlock::Create(ctx_.context(), "rvt_vconv_body", current_func);
+                    BasicBlock* rvt_vce = BasicBlock::Create(ctx_.context(), "rvt_vconv_end", current_func);
+                    b.CreateBr(rvt_vcc);
+                    b.SetInsertPoint(rvt_vcc);
+                    Value* rvt_vidx = b.CreateLoad(ctx_.int64Type(), rvt_vi);
+                    b.CreateCondBr(b.CreateICmpULT(rvt_vidx, rvt_vn), rvt_vcb, rvt_vce);
+                    b.SetInsertPoint(rvt_vcb);
+                    Value* rvt_vsrc_ptr = b.CreateGEP(ctx_.taggedValueType(), rvt_vsrc, rvt_vidx);
+                    Value* rvt_vsrc_val = b.CreateLoad(ctx_.taggedValueType(), rvt_vsrc_ptr);
+                    Value* rvt_vdbl = tagged_.unpackDouble(rvt_vsrc_val);
+                    b.CreateStore(b.CreateBitCast(rvt_vdbl, ctx_.int64Type()),
+                        b.CreateGEP(ctx_.int64Type(), rvt_vdst, rvt_vidx));
+                    b.CreateStore(b.CreateAdd(rvt_vidx, ConstantInt::get(ctx_.int64Type(), 1)), rvt_vi);
+                    b.CreateBr(rvt_vcc);
+                    b.SetInsertPoint(rvt_vce);
+                    b.CreateBr(rvt_reverse);
+                    BasicBlock* rvt_norm_vec_exit = b.GetInsertBlock();
 
                     // ---- reverse-mode tensor gradient ----
                     b.SetInsertPoint(rvt_reverse);
-                    llvm::StructType* rvt_tt = ctx_.tensorType();
-                    Value* rvt_ptr = b.CreateIntToPtr(tagged_.unpackInt64(point_val), ctx_.ptrType());
+                    PHINode* rvt_ptr = b.CreatePHI(ctx_.ptrType(), 2, "rvt_ptr");
+                    rvt_ptr->addIncoming(rvt_ten_ptr, rvt_norm_ten_exit);
+                    rvt_ptr->addIncoming(rvt_vten, rvt_norm_vec_exit);
                     Value* rvt_dims = b.CreateLoad(ctx_.ptrType(), b.CreateStructGEP(rvt_tt, rvt_ptr, 0));
                     Value* rvt_ndim = b.CreateLoad(ctx_.int64Type(), b.CreateStructGEP(rvt_tt, rvt_ptr, 1));
                     Value* rvt_elems = b.CreateLoad(ctx_.ptrType(), b.CreateStructGEP(rvt_tt, rvt_ptr, 2));
@@ -4768,6 +4849,62 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
     // Get arena for OALR-compliant tensor allocation (used throughout gradient computation)
     Value* arena_ptr = ctx_.builder().CreateLoad(PointerType::getUnqual(ctx_.context()), ctx_.globalArena());
 
+    // ESH-0235: decide, at compile time, whether a HEAP_SUBTYPE_VECTOR
+    // ((vector …)-constructed) point must be seeded on the REVERSE-mode tensor
+    // tape rather than the forward-mode dual scheme-vector path. A #(…) reader
+    // literal and a (tensor …) value both lower to a TENSOR subtype and, for a
+    // single-argument tensor-op function, take the reverse-mode `vector_input`
+    // path (which seeds every element as an AD variable). A (vector …) point is
+    // a genuine Scheme vector and would instead fall to the forward-mode dual
+    // path, where a tensor op (tensor-dot/-mul/-sum/-matmul/…) reads ONLY the
+    // primal double out of each dual-tagged element and silently drops the
+    // tangent — a WRONG all-zero gradient. So when the differentiated function
+    // flows the input through a tensor op, convert the Scheme vector to a 1-D
+    // tensor and route it through the SAME reverse-mode seeding as the
+    // #(…)/(tensor …) point. The forward-mode scheme-vector path is retained for
+    // scalar / vector-ref bodies because it (and only it) carries the outer
+    // perturbation of a NESTED gradient-of-gradient over a vector point
+    // (ESH-0096); reverse-seeding those would drop the second-order term. Tensor
+    // use is detected THROUGH one layer of named-function indirection so a
+    // wrapper (lambda (z) (loss z)) over a named tensor loss is caught too.
+    // Multi-argument (arity>1) vector points keep the forward / scheme-vector
+    // path below (the inverse tensor→svec conversion handles the multi-param
+    // case). Mirrors the arity>1 tensor→svec conversion.
+    uint64_t grad_arity_early = 0;
+    {
+        std::string key = func_ptr->getName().str();
+        auto rv = key.rfind("__rv");
+        if (rv != std::string::npos && rv + 4 < key.size() &&
+            key.find_first_not_of("0123456789", rv + 4) == std::string::npos) {
+            key.erase(rv);
+        }
+        auto ait = function_arity_table_->find(key);
+        if (ait != function_arity_table_->end()) grad_arity_early = ait->second;
+    }
+    std::unordered_set<std::string> grad_tensor_visited;
+    bool grad_fn_uses_tensors =
+        adAstUsesTensorOps(op->gradient_op.function, function_body_ast_, &grad_tensor_visited);
+    if (!grad_fn_uses_tensors && op->gradient_op.function->type == ESHKOL_VAR) {
+        const eshkol_ast_t* gbody = nullptr;
+        std::string gkey = func_ptr->getName().str();
+        auto grv = gkey.rfind("__rv");
+        if (grv != std::string::npos && grv + 4 < gkey.size() &&
+            gkey.find_first_not_of("0123456789", grv + 4) == std::string::npos) {
+            gkey.erase(grv);
+        }
+        if (function_body_ast_) {
+            auto bit = function_body_ast_->find(gkey);
+            if (bit == function_body_ast_->end())
+                bit = function_body_ast_->find(op->gradient_op.function->variable.id);
+            if (bit != function_body_ast_->end()) gbody = bit->second;
+        }
+        grad_tensor_visited.clear();
+        grad_fn_uses_tensors = gbody
+            ? adAstUsesTensorOps(gbody, function_body_ast_, &grad_tensor_visited)
+            : adFunctionUsesTensors(func_ptr);
+    }
+    bool grad_vec_point_reverse = (grad_arity_early <= 1) && grad_fn_uses_tensors;
+
     // Extract type from input (may be DOUBLE, INT64, TENSOR_PTR, or AD_NODE_PTR for nested gradients)
     Value* input_type = tagged_.getType(vector_val);
     Value* input_base_type = tagged_.getBaseType(input_type);
@@ -4797,6 +4934,8 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
     BasicBlock* scalar_input = BasicBlock::Create(ctx_.context(), "grad_scalar_input", current_func);
     BasicBlock* scheme_vector_input = BasicBlock::Create(ctx_.context(), "grad_scheme_vector_input", current_func);
     BasicBlock* vector_input = BasicBlock::Create(ctx_.context(), "grad_vector_input", current_func);
+    // ESH-0235: svec→tensor bridge for a (vector …) point into the reverse path.
+    BasicBlock* grad_vec_to_tensor = BasicBlock::Create(ctx_.context(), "grad_vec_to_tensor", current_func);
     BasicBlock* grad_merge_input = BasicBlock::Create(ctx_.context(), "grad_merge_input", current_func);
     // Create grad_done early so scheme_vector_input path can branch to it
     BasicBlock* grad_done = BasicBlock::Create(ctx_.context(), "grad_done", current_func);
@@ -4877,7 +5016,13 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
     BasicBlock* grad_check_cons = BasicBlock::Create(ctx_.context(), "grad_check_cons", current_func);
     BasicBlock* grad_list_to_svec = BasicBlock::Create(ctx_.context(), "grad_list_to_svec", current_func);
     BasicBlock* grad_check_tensor = BasicBlock::Create(ctx_.context(), "grad_check_tensor", current_func);
-    ctx_.builder().CreateCondBr(is_vec_subtype_grad, scheme_vector_input, grad_check_cons);
+    // ESH-0235: a single-arg tensor-op function must seed a (vector …) point on
+    // the reverse-mode tape (via svec→tensor), identical to a #(…)/(tensor …)
+    // point; otherwise the forward-mode dual path drops the tangent through the
+    // tensor op and returns a silent all-zero gradient.
+    BasicBlock* grad_vec_subtype_target =
+        grad_vec_point_reverse ? grad_vec_to_tensor : scheme_vector_input;
+    ctx_.builder().CreateCondBr(is_vec_subtype_grad, grad_vec_subtype_target, grad_check_cons);
 
     // A (list …) input is a cons cell (HEAP_SUBTYPE_CONS): convert it to a
     // Scheme vector so it goes through the same path as a (vector …) input.
@@ -5310,6 +5455,55 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
     ctx_.builder().CreateBr(grad_done);  // Skip reverse-mode AD, go directly to done
     BasicBlock* scheme_vector_exit = ctx_.builder().GetInsertBlock();
 
+    // ESH-0235 VEC→TENSOR BRIDGE: a (vector …)-constructed point feeding a
+    // single-arg tensor-op function is converted to a 1-D tensor here and fed
+    // into the reverse-mode `vector_input` seeding via the merge PHI, so it is
+    // taped identically to a #(…)/(tensor …) point (each element becomes an AD
+    // variable). Reads the Scheme vector layout [len(8)][tagged elems] and
+    // writes a plain-double tensor [dims|ndim=1|elems|total].
+    ctx_.builder().SetInsertPoint(grad_vec_to_tensor);
+    Value* v2t_svec_ptr = tagged_.unpackPtr(vector_val);
+    Value* v2t_n = ctx_.builder().CreateLoad(ctx_.int64Type(), v2t_svec_ptr);
+    Value* v2t_elems_base = ctx_.builder().CreateGEP(ctx_.int8Type(), v2t_svec_ptr, ConstantInt::get(ctx_.int64Type(), 8));
+    Value* v2t_elems = ctx_.builder().CreatePointerCast(v2t_elems_base, ctx_.ptrType());
+
+    Value* v2t_tensor = ctx_.builder().CreateCall(mem_.getArenaAllocateTensorWithHeader(), {arena_ptr});
+    Value* v2t_dims_ptr = ctx_.builder().CreateCall(mem_.getArenaAllocate(), {arena_ptr, ConstantInt::get(ctx_.int64Type(), sizeof(uint64_t))});
+    Value* v2t_typed_dims = ctx_.builder().CreatePointerCast(v2t_dims_ptr, ctx_.builder().getPtrTy());
+    ctx_.builder().CreateStore(v2t_n, v2t_typed_dims);
+    ctx_.builder().CreateStore(v2t_typed_dims, ctx_.builder().CreateStructGEP(ctx_.tensorType(), v2t_tensor, 0));
+    ctx_.builder().CreateStore(ConstantInt::get(ctx_.int64Type(), 1), ctx_.builder().CreateStructGEP(ctx_.tensorType(), v2t_tensor, 1));
+    ctx_.builder().CreateStore(v2t_n, ctx_.builder().CreateStructGEP(ctx_.tensorType(), v2t_tensor, 3));
+
+    Value* v2t_elems_size = ctx_.builder().CreateMul(v2t_n, ConstantInt::get(ctx_.int64Type(), sizeof(double)));
+    Value* v2t_dst_ptr = ctx_.builder().CreateCall(mem_.getArenaAllocate(), {arena_ptr, v2t_elems_size});
+    Value* v2t_dst = ctx_.builder().CreatePointerCast(v2t_dst_ptr, ctx_.builder().getPtrTy());
+    ctx_.builder().CreateStore(v2t_dst, ctx_.builder().CreateStructGEP(ctx_.tensorType(), v2t_tensor, 2));
+
+    Value* v2t_i = ctx_.builder().CreateAlloca(ctx_.int64Type(), nullptr, "v2t_i");
+    ctx_.builder().CreateStore(ConstantInt::get(ctx_.int64Type(), 0), v2t_i);
+    BasicBlock* v2t_cond = BasicBlock::Create(ctx_.context(), "v2t_cond", current_func);
+    BasicBlock* v2t_body = BasicBlock::Create(ctx_.context(), "v2t_body", current_func);
+    BasicBlock* v2t_end = BasicBlock::Create(ctx_.context(), "v2t_end", current_func);
+    ctx_.builder().CreateBr(v2t_cond);
+    ctx_.builder().SetInsertPoint(v2t_cond);
+    Value* v2t_idx = ctx_.builder().CreateLoad(ctx_.int64Type(), v2t_i);
+    ctx_.builder().CreateCondBr(ctx_.builder().CreateICmpULT(v2t_idx, v2t_n), v2t_body, v2t_end);
+    ctx_.builder().SetInsertPoint(v2t_body);
+    Value* v2t_src_ptr = ctx_.builder().CreateGEP(ctx_.taggedValueType(), v2t_elems, v2t_idx);
+    Value* v2t_src_val = ctx_.builder().CreateLoad(ctx_.taggedValueType(), v2t_src_ptr);
+    Value* v2t_dbl = tagged_.unpackDouble(v2t_src_val);
+    Value* v2t_bits = ctx_.builder().CreateBitCast(v2t_dbl, ctx_.int64Type());
+    Value* v2t_dst_slot = ctx_.builder().CreateGEP(ctx_.int64Type(), v2t_dst, v2t_idx);
+    ctx_.builder().CreateStore(v2t_bits, v2t_dst_slot);
+    ctx_.builder().CreateStore(ctx_.builder().CreateAdd(v2t_idx, ConstantInt::get(ctx_.int64Type(), 1)), v2t_i);
+    ctx_.builder().CreateBr(v2t_cond);
+    ctx_.builder().SetInsertPoint(v2t_end);
+    Value* v2t_tensor_int = ctx_.builder().CreatePtrToInt(v2t_tensor, ctx_.int64Type());
+    Value* v2t_tensor_tagged = tagged_.packPtr(v2t_tensor_int, ESHKOL_VALUE_HEAP_PTR);
+    ctx_.builder().CreateBr(grad_merge_input);
+    BasicBlock* grad_vec_to_tensor_exit = ctx_.builder().GetInsertBlock();
+
     // VECTOR INPUT: Use original vector as-is (existing behavior - tensor format)
     ctx_.builder().SetInsertPoint(vector_input);
     ctx_.builder().CreateBr(grad_merge_input);
@@ -5318,15 +5512,17 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
     // MERGE: PHI node selects AD node promoted, scalar promoted, or original tensor
     // NOTE: Scheme vector path now uses forward-mode AD and branches directly to grad_done
     ctx_.builder().SetInsertPoint(grad_merge_input);
-    PHINode* actual_input = ctx_.builder().CreatePHI(ctx_.taggedValueType(), 3, "gradient_input");
+    PHINode* actual_input = ctx_.builder().CreatePHI(ctx_.taggedValueType(), 4, "gradient_input");
     actual_input->addIncoming(ad_promoted_tagged, ad_node_exit);  // Nested gradient path
     actual_input->addIncoming(promoted_vector_tagged, scalar_input_exit);
     actual_input->addIncoming(vector_val, vector_input_exit);
+    actual_input->addIncoming(v2t_tensor_tagged, grad_vec_to_tensor_exit);  // ESH-0235: (vector …) point
 
-    PHINode* input_was_scalar_promoted = ctx_.builder().CreatePHI(ctx_.int1Type(), 3, "gradient_input_was_scalar");
+    PHINode* input_was_scalar_promoted = ctx_.builder().CreatePHI(ctx_.int1Type(), 4, "gradient_input_was_scalar");
     input_was_scalar_promoted->addIncoming(ConstantInt::get(ctx_.int1Type(), 1), ad_node_exit);
     input_was_scalar_promoted->addIncoming(ConstantInt::get(ctx_.int1Type(), 1), scalar_input_exit);
     input_was_scalar_promoted->addIncoming(ConstantInt::get(ctx_.int1Type(), 0), vector_input_exit);
+    input_was_scalar_promoted->addIncoming(ConstantInt::get(ctx_.int1Type(), 0), grad_vec_to_tensor_exit);
     
     // Continue with gradient computation using merged input (guaranteed to be tensor!)
     Value* vector_ptr_int = tagged_.unpackInt64(actual_input);

--- a/tests/ad/tensor_grad_vector_point_test.esk
+++ b/tests/ad/tensor_grad_vector_point_test.esk
@@ -1,0 +1,200 @@
+;; tensor_grad_vector_point_test.esk -- ESH-0235: reverse-mode AD through a
+;; tensor op at a (vector …)-constructed differentiation point.
+;;
+;; Before ESH-0235, a gradient of a tensor-op loss (tensor-dot / tensor-mul+sum
+;; / tensor-matmul) evaluated at a point built with the (vector …) constructor
+;; silently returned an all-zero gradient, while the IDENTICAL point written as
+;; a #(…) reader literal or a (tensor …) value returned the correct gradient.
+;; Root cause: a (vector …) point is a genuine HEAP_SUBTYPE_VECTOR and was
+;; routed to the forward-mode dual scheme-vector path, where a tensor op reads
+;; only the primal double out of each dual-tagged element and drops the tangent.
+;; The fix routes a single-arg tensor-op function's (vector …) point through the
+;; SAME reverse-mode tensor tape as a #(…)/(tensor …) point, in every calling
+;; form: a direct lambda, a first-class named loss, a lambda that indirects
+;; through the named loss, and a higher-order wrapper.
+;;
+;; Each loss is evaluated at a (vector …) point and its AD gradient asserted to
+;; (a) be non-zero, (b) match a central finite difference to ~1e-4, and (c) be
+;; elementwise identical to the gradient at the same point written as a #(…)
+;; literal. The finite-difference oracle is the TEST ORACLE only; the compiler's
+;; gradient path is exact reverse-mode AD.
+
+(require stdlib)
+
+(define passed 0)
+(define failed 0)
+
+(define (approx= a b tol) (< (abs (- a b)) tol))
+
+(define (check name cond)
+  (if cond
+      (begin (display "PASS: ") (display name) (newline)
+             (set! passed (+ passed 1)))
+      (begin (display "FAIL: ") (display name) (newline)
+             (set! failed (+ failed 1)))))
+
+(define (perturb-vector v idx delta)
+  (let ((n (vector-length v))
+        (out (make-vector (vector-length v) 0.0)))
+    (letrec ((loop (lambda (i)
+                     (if (< i n)
+                         (begin
+                           (vector-set! out i
+                             (if (= i idx)
+                                 (+ (vector-ref v i) delta)
+                                 (vector-ref v i)))
+                           (loop (+ i 1)))
+                         out))))
+      (loop 0))))
+
+;; The losses flow their argument straight into a tensor op, which reads a
+;; genuine tensor (not a raw Scheme vector) — so the FD oracle reshapes each
+;; perturbed point to a 1-D tensor before evaluating, exactly as the AD path
+;; feeds the loss a tensor-seeded input.
+(define (finite-diff f x idx eps)
+  (let ((n (vector-length x)))
+    (/ (- (f (reshape (perturb-vector x idx eps) n))
+          (f (reshape (perturb-vector x idx (- eps)) n)))
+       (* 2.0 eps))))
+
+(define (grad-matches-fd? g f x eps tol)
+  (let ((n (vector-length g)))
+    (letrec ((loop (lambda (i)
+                     (if (< i n)
+                         (let* ((fd (finite-diff f x i eps))
+                                (gi (vector-ref g i))
+                                (scale (+ 1.0 (abs fd))))
+                           (if (approx= gi fd (* tol scale))
+                               (loop (+ i 1))
+                               (begin
+                                 (display "   mismatch @") (display i)
+                                 (display " ad=") (display gi)
+                                 (display " fd=") (display fd) (newline)
+                                 #f)))
+                         #t))))
+      (loop 0))))
+
+(define (vec-any-nonzero? g)
+  (let ((n (vector-length g)))
+    (letrec ((loop (lambda (i)
+                     (if (< i n)
+                         (if (> (abs (vector-ref g i)) 1e-9) #t (loop (+ i 1)))
+                         #f))))
+      (loop 0))))
+
+(define (vecs-agree? a b tol)
+  (and (= (vector-length a) (vector-length b))
+       (let ((n (vector-length a)))
+         (letrec ((loop (lambda (i)
+                          (if (< i n)
+                              (if (approx= (vector-ref a i) (vector-ref b i) tol)
+                                  (loop (+ i 1)) #f)
+                              #t))))
+           (loop 0)))))
+
+;; Higher-order wrapper: forces the loss to arrive as a runtime function value.
+(define (wg f x) (gradient f x))
+
+;; Assert the (vector …) gradient in every calling form:
+;;   gd  -- direct lambda with the tensor op inline
+;;   gv  -- first-class named loss
+;;   gi  -- lambda that indirects through the named loss
+;;   gw  -- higher-order wrapper
+;; against a central finite difference AND against gl, the gradient at the same
+;; point written as a #(…) literal (which was already correct pre-fix).
+(define (assert-forms name loss gd gv gi gw gl vpt)
+  (check (string-append name "_direct_nonzero")   (vec-any-nonzero? gd))
+  (check (string-append name "_firstclass_nonzero") (vec-any-nonzero? gv))
+  (check (string-append name "_indirect_nonzero") (vec-any-nonzero? gi))
+  (check (string-append name "_wrapper_nonzero")  (vec-any-nonzero? gw))
+  (check (string-append name "_direct_matches_fd")     (grad-matches-fd? gd loss vpt 1e-4 1e-3))
+  (check (string-append name "_firstclass_matches_fd") (grad-matches-fd? gv loss vpt 1e-4 1e-3))
+  (check (string-append name "_indirect_matches_fd")   (grad-matches-fd? gi loss vpt 1e-4 1e-3))
+  (check (string-append name "_wrapper_matches_fd")    (grad-matches-fd? gw loss vpt 1e-4 1e-3))
+  ;; The defining ESH-0235 assertion: a (vector …) point gives the SAME gradient
+  ;; as the identical #(…) point in every form, not a silent zero.
+  (check (string-append name "_all_forms_equal_literal_point")
+         (and (vec-any-nonzero? gl)
+              (vecs-agree? gd gl 1e-6)
+              (vecs-agree? gv gl 1e-6)
+              (vecs-agree? gi gl 1e-6)
+              (vecs-agree? gw gl 1e-6))))
+
+;; ---- tensor-dot, several shapes -------------------------------------------
+(define c3 #(2.0 -1.0 0.5))
+(define (dot3 z) (tensor-dot z c3))
+(assert-forms "dot3" dot3
+  (gradient (lambda (z) (tensor-dot z c3)) (vector 1.0 2.0 4.0))
+  (gradient dot3 (vector 1.0 2.0 4.0))
+  (gradient (lambda (z) (dot3 z)) (vector 1.0 2.0 4.0))
+  (wg dot3 (vector 1.0 2.0 4.0))
+  (gradient dot3 #(1.0 2.0 4.0))
+  (vector 1.0 2.0 4.0))
+
+(define c4 #(2.0 -1.0 0.5 -0.75))
+(define (dot4 z) (tensor-dot z c4))
+(assert-forms "dot4" dot4
+  (gradient (lambda (z) (tensor-dot z c4)) (vector 1.2335 0.5795 1.6262 0.6787))
+  (gradient dot4 (vector 1.2335 0.5795 1.6262 0.6787))
+  (gradient (lambda (z) (dot4 z)) (vector 1.2335 0.5795 1.6262 0.6787))
+  (wg dot4 (vector 1.2335 0.5795 1.6262 0.6787))
+  (gradient dot4 #(1.2335 0.5795 1.6262 0.6787))
+  (vector 1.2335 0.5795 1.6262 0.6787))
+
+(define c5 #(0.3 -0.7 1.1 -0.2 0.9))
+(define (dot5 z) (tensor-dot z c5))
+(assert-forms "dot5" dot5
+  (gradient (lambda (z) (tensor-dot z c5)) (vector 0.5 1.5 -2.0 3.0 -1.0))
+  (gradient dot5 (vector 0.5 1.5 -2.0 3.0 -1.0))
+  (gradient (lambda (z) (dot5 z)) (vector 0.5 1.5 -2.0 3.0 -1.0))
+  (wg dot5 (vector 0.5 1.5 -2.0 3.0 -1.0))
+  (gradient dot5 #(0.5 1.5 -2.0 3.0 -1.0))
+  (vector 0.5 1.5 -2.0 3.0 -1.0))
+
+;; ---- tensor-sum(tensor-mul z c) (elementwise product then reduce) ----------
+(define m3 #(0.5 -1.5 0.25))
+(define (summul3 z) (tensor-sum (tensor-mul z m3)))
+(assert-forms "summul3" summul3
+  (gradient (lambda (z) (tensor-sum (tensor-mul z m3))) (vector 1.0 2.0 4.0))
+  (gradient summul3 (vector 1.0 2.0 4.0))
+  (gradient (lambda (z) (summul3 z)) (vector 1.0 2.0 4.0))
+  (wg summul3 (vector 1.0 2.0 4.0))
+  (gradient summul3 #(1.0 2.0 4.0))
+  (vector 1.0 2.0 4.0))
+
+(define m4 #(1.0 -2.0 0.5 3.0))
+(define (summul4 z) (tensor-sum (tensor-mul z m4)))
+(assert-forms "summul4" summul4
+  (gradient (lambda (z) (tensor-sum (tensor-mul z m4))) (vector 0.25 1.75 -0.5 2.25))
+  (gradient summul4 (vector 0.25 1.75 -0.5 2.25))
+  (gradient (lambda (z) (summul4 z)) (vector 0.25 1.75 -0.5 2.25))
+  (wg summul4 (vector 0.25 1.75 -0.5 2.25))
+  (gradient summul4 #(0.25 1.75 -0.5 2.25))
+  (vector 0.25 1.75 -0.5 2.25))
+
+;; ---- tensor-matmul then reduce, 2x2 ---------------------------------------
+(define K22 (reshape #(1.0 0.0 0.0 1.0) 2 2))
+(define (matmul22 z) (tensor-sum (tensor-matmul (reshape z 2 2) K22)))
+(assert-forms "matmul22" matmul22
+  (gradient (lambda (z) (tensor-sum (tensor-matmul (reshape z 2 2) K22))) (vector 1.0 2.0 3.0 4.0))
+  (gradient matmul22 (vector 1.0 2.0 3.0 4.0))
+  (gradient (lambda (z) (matmul22 z)) (vector 1.0 2.0 3.0 4.0))
+  (wg matmul22 (vector 1.0 2.0 3.0 4.0))
+  (gradient matmul22 #(1.0 2.0 3.0 4.0))
+  (vector 1.0 2.0 3.0 4.0))
+
+(define K22b (reshape #(0.5 -1.0 2.0 0.25) 2 2))
+(define (matmul22b z) (tensor-sum (tensor-matmul (reshape z 2 2) K22b)))
+(assert-forms "matmul22b" matmul22b
+  (gradient (lambda (z) (tensor-sum (tensor-matmul (reshape z 2 2) K22b))) (vector 0.7 -0.3 1.2 0.9))
+  (gradient matmul22b (vector 0.7 -0.3 1.2 0.9))
+  (gradient (lambda (z) (matmul22b z)) (vector 0.7 -0.3 1.2 0.9))
+  (wg matmul22b (vector 0.7 -0.3 1.2 0.9))
+  (gradient matmul22b #(0.7 -0.3 1.2 0.9))
+  (vector 0.7 -0.3 1.2 0.9))
+
+(display "Results: ") (display passed) (display " passed, ")
+(display failed) (display " failed") (newline)
+(if (= failed 0)
+    (begin (display "PASS: tensor_grad_vector_point_test") (newline) (exit 0))
+    (begin (display "FAIL: tensor_grad_vector_point_test") (newline) (exit 1)))

--- a/tests/ad_adversarial/gen_ad_adversarial.py
+++ b/tests/ad_adversarial/gen_ad_adversarial.py
@@ -64,13 +64,16 @@ H2 = "1e-4"
 # generator surfaces a real defect, add its id here with an ESH task so the gate
 # stays green-able while a fix agent works, and it FAILs loudly if it regresses
 # in a NEW way.
-# ESH-0235 (found by this harness): reverse-mode AD through a tensor op returns
-# a silently-WRONG all-zero gradient when the differentiation point is built
-# with the (vector ...) constructor (the identical #(...) literal / (tensor ...)
-# point is correct). The `vecpoint` family reproduces this deterministically and
-# is marked XKNOWN so the gate stays green-able while the fix is tracked; it
-# flips to PASS (and this entry should be deleted) once ESH-0235 lands.
-XKNOWN = {"vecpoint": "ESH-0235"}   # id-prefix -> "ESH-NNNN"
+# ESH-0235 (found by this harness): reverse-mode AD through a tensor op used to
+# return a silently-WRONG all-zero gradient when the differentiation point was
+# built with the (vector ...) constructor (the identical #(...) literal /
+# (tensor ...) point was correct). FIXED — a single-arg tensor-op function's
+# (vector ...) point is now converted to a 1-D tensor and reverse-seeded exactly
+# like the #(...)/(tensor ...) point, in every calling form (direct lambda,
+# first-class named loss, named indirection, higher-order wrapper). The
+# `vecpoint` family therefore drops out of XKNOWN and is a hard PASS/FAIL gate:
+# any recurrence FAILs loudly.
+XKNOWN = {}                          # id-prefix -> "ESH-NNNN"
 KNOWN_CRASHERS = {}                  # id-prefix -> "ESH-NNNN"
 
 SEEDS_SCALAR = list(range(0, 48))

--- a/tests/ad_adversarial/generated/ad_adv_vecpoint_01.esk
+++ b/tests/ad_adversarial/generated/ad_adv_vecpoint_01.esk
@@ -141,9 +141,9 @@
 (define lit145 (gradient (lambda (z) (loss145 z)) (vector 1.2335 0.5795 1.6262 0.6787)))
 (define var145 (gradient loss145 (vector 1.2335 0.5795 1.6262 0.6787)))
 (define wrp145 (wg loss145 (vector 1.2335 0.5795 1.6262 0.6787)))
-(chk-grad "vecpoint.dot.literal" lit145 loss145 (vector 1.2335 0.5795 1.6262 0.6787) 1e-4 1e-4 "ESH-0235")
-(chk-grad "vecpoint.dot.firstclass" var145 loss145 (vector 1.2335 0.5795 1.6262 0.6787) 1e-4 1e-4 "ESH-0235")
-(chk-grad "vecpoint.dot.wrapper" wrp145 loss145 (vector 1.2335 0.5795 1.6262 0.6787) 1e-4 1e-4 "ESH-0235")
+(chk-grad "vecpoint.dot.literal" lit145 loss145 (vector 1.2335 0.5795 1.6262 0.6787) 1e-4 1e-4 #f)
+(chk-grad "vecpoint.dot.firstclass" var145 loss145 (vector 1.2335 0.5795 1.6262 0.6787) 1e-4 1e-4 #f)
+(chk-grad "vecpoint.dot.wrapper" wrp145 loss145 (vector 1.2335 0.5795 1.6262 0.6787) 1e-4 1e-4 #f)
 
 ;; probe vecpoint.summul
 (define Cvp2 (vector 0.5 -1.5 0.25))
@@ -151,9 +151,9 @@
 (define lit146 (gradient (lambda (z) (loss146 z)) (vector 1.0 2.0 4.0)))
 (define var146 (gradient loss146 (vector 1.0 2.0 4.0)))
 (define wrp146 (wg loss146 (vector 1.0 2.0 4.0)))
-(chk-grad "vecpoint.summul.literal" lit146 loss146 (vector 1.0 2.0 4.0) 1e-4 1e-4 "ESH-0235")
-(chk-grad "vecpoint.summul.firstclass" var146 loss146 (vector 1.0 2.0 4.0) 1e-4 1e-4 "ESH-0235")
-(chk-grad "vecpoint.summul.wrapper" wrp146 loss146 (vector 1.0 2.0 4.0) 1e-4 1e-4 "ESH-0235")
+(chk-grad "vecpoint.summul.literal" lit146 loss146 (vector 1.0 2.0 4.0) 1e-4 1e-4 #f)
+(chk-grad "vecpoint.summul.firstclass" var146 loss146 (vector 1.0 2.0 4.0) 1e-4 1e-4 #f)
+(chk-grad "vecpoint.summul.wrapper" wrp146 loss146 (vector 1.0 2.0 4.0) 1e-4 1e-4 #f)
 
 ;; probe vecpoint.matmul
 (define Kvp (reshape (vector 1.0 0.0 0.0 1.0) 2 2))
@@ -161,9 +161,9 @@
 (define lit147 (gradient (lambda (z) (loss147 z)) (vector 1.0 2.0 3.0 4.0)))
 (define var147 (gradient loss147 (vector 1.0 2.0 3.0 4.0)))
 (define wrp147 (wg loss147 (vector 1.0 2.0 3.0 4.0)))
-(chk-grad "vecpoint.matmul.literal" lit147 loss147 (vector 1.0 2.0 3.0 4.0) 1e-4 1e-4 "ESH-0235")
-(chk-grad "vecpoint.matmul.firstclass" var147 loss147 (vector 1.0 2.0 3.0 4.0) 1e-4 1e-4 "ESH-0235")
-(chk-grad "vecpoint.matmul.wrapper" wrp147 loss147 (vector 1.0 2.0 3.0 4.0) 1e-4 1e-4 "ESH-0235")
+(chk-grad "vecpoint.matmul.literal" lit147 loss147 (vector 1.0 2.0 3.0 4.0) 1e-4 1e-4 #f)
+(chk-grad "vecpoint.matmul.firstclass" var147 loss147 (vector 1.0 2.0 3.0 4.0) 1e-4 1e-4 #f)
+(chk-grad "vecpoint.matmul.wrapper" wrp147 loss147 (vector 1.0 2.0 3.0 4.0) 1e-4 1e-4 #f)
 
 (display "Passed: ") (display op-pass) (newline)
 (display "Failed: ") (display op-fail) (newline)


### PR DESCRIPTION
## Summary

Reverse-mode AD through a tensor op returned a silently-**wrong all-zero gradient** when the differentiation point was built with the `(vector ...)` constructor, while the identical point written as a `#(...)` reader literal or a `(tensor ...)` value returned the correct gradient. Silent zeros are the worst AD failure class, so this violated the exact-AD-or-explicit-error contract.

```
(gradient (lambda (z) (tensor-dot z #(2.0 -1.0 0.5))) (vector 1.0 2.0 4.0))  => #(0 0 0)     ; WRONG (before)
(gradient (lambda (z) (tensor-dot z #(2.0 -1.0 0.5))) #(1.0 2.0 4.0))        => #(2 -1 0.5)  ; correct
(gradient (lambda (z) (tensor-dot z #(2.0 -1.0 0.5))) (tensor 3 1.0 2.0 4.0)) => #(2 -1 0.5)  ; correct
```

## Root cause

A `#(...)` literal and a `(tensor ...)` value both lower to a **TENSOR** heap subtype and, for a single-argument function, take the reverse-mode tensor-tape path in `AutodiffCodegen::gradient` (`lib/backend/autodiff_codegen.cpp`), which seeds every element as an AD variable. A `(vector ...)` point is a genuine **HEAP_SUBTYPE_VECTOR** and fell instead to the forward-mode dual scheme-vector path, where a tensor op (`tensor-dot` / `tensor-mul`+`tensor-sum` / `tensor-matmul` / …) reads **only the primal double** out of each dual-tagged element and drops the tangent — so the reverse sweep never registered the inputs and read zero. The exact divergence is the subtype dispatch that sent `HEAP_SUBTYPE_VECTOR` to the forward path (`is_vec_subtype_grad → scheme_vector_input`) and, in the runtime-closure path, the ESH-0212 reverse branch that fired only for `HEAP_SUBTYPE_TENSOR`.

## Fix

When the differentiated single-arg function flows its input through a tensor op, convert the `(vector ...)` point to a 1-D tensor and route it through the **same reverse-mode seeding** as the `#(...)`/`(tensor ...)` point, in every calling form:

- **compile-time path** — a new svec→tensor bridge feeds the reverse `vector_input` merge PHI; tensor use is detected through one layer of named indirection so `(lambda (z) (loss z))` over a named tensor loss is caught too;
- **runtime path** (first-class / higher-order wrapper closures) — the ESH-0212 reverse branch now also accepts a `HEAP_SUBTYPE_VECTOR` point and normalizes it to a tensor before taping.

The forward-mode scheme-vector path is **retained** for scalar / vector-ref bodies because it (and only it) carries the outer perturbation of a nested gradient-of-gradient over a vector point (ESH-0096); multi-argument vector points keep the forward path as before.

## AD vs central finite differences at `(vector ...)` points (after)

| loss | point | AD gradient | FD gradient |
|------|-------|-------------|-------------|
| `(tensor-dot z #(2 -1 0.5))` | `(vector 1 2 4)` | `#(2 -1 0.5)` | `#(2 -1 0.5)` |
| `(tensor-sum (tensor-mul z #(0.5 -1.5 0.25)))` | `(vector 1 2 4)` | `#(0.5 -1.5 0.25)` | `#(0.5 -1.5 0.25)` |
| `(tensor-sum (tensor-matmul (reshape z 2 2) K))` | `(vector 0.7 -0.3 1.2 0.9)` | `#(-0.5 2.25 -0.5 2.25)` | `#(-0.5 2.25 -0.5 2.25)` |

Before the fix, the AD column was `#(0 0 0…)` for every `(vector ...)` row.

## Testing

- New `tests/ad/tensor_grad_vector_point_test.esk` — 63 checks across `tensor-dot`/`tensor-mul+sum`/`tensor-matmul` and several shapes, in the direct-lambda, first-class, named-indirect and wrapper forms; each `(vector ...)` gradient is asserted non-zero, FD-matched (~1e-4), and elementwise identical to the `#(...)`-point gradient. **63/63 under both JIT (`-r`) and AOT.**
- AD adversarial oracle `scripts/run_ad_adversarial.sh`: the `vecpoint` family moves from XKNOWN to a hard **PASS** gate (9/9), the ESH-0235 XKNOWN entry is removed from the generator and the corpus regenerated. `gofg` family still passes (forward-path preserved).
- Full AD suite `scripts/run_autodiff_tests.sh`: **54/54.**
- `scripts/run_tensor_input2_grad_gate.sh`: **24/24** (JIT + AOT).

### Pre-existing, out of scope

The adversarial oracle's `htensor` family (`hessian` at a tensor/vector point through a tensor op) returns an all-zero Hessian and FAILs — **including the `(tensor ...)`-point subcase**, which this vector-only `gradient()` change cannot affect. It reproduces identically on a clean baseline build; the defect predates this branch (the `hessian` path is untouched here). Tracked separately.