### PR TITLE
fix(stdlib): implement and link base64-encode-string / base64-decode-string

### DIFF
--- a/inc/eshkol/backend/system_codegen.h
+++ b/inc/eshkol/backend/system_codegen.h
@@ -406,6 +406,10 @@ public:
     llvm::Value* urlDecode(const eshkol_operations_t* op);
     /** @brief (url-parse str) — parse a URL into its components (scheme, host, path, query, ...). */
     llvm::Value* urlParse(const eshkol_operations_t* op);
+    /** @brief (base64-encode-string bytes) — RFC 4648 standard base64 with padding. */
+    llvm::Value* base64EncodeString(const eshkol_operations_t* op);
+    /** @brief (base64-decode-string str) — decode RFC 4648 standard base64. */
+    llvm::Value* base64DecodeString(const eshkol_operations_t* op);
     /** @brief (base64url-encode bytes) — base64url-encode a byte string. */
     llvm::Value* base64urlEncode(const eshkol_operations_t* op);
     /** @brief (base64url-decode str) — decode a base64url-encoded string. */

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -1889,6 +1889,8 @@ public:
         function_return_types["url-encode"] = BuiltinTypes::String;
         function_return_types["url-decode"] = BuiltinTypes::String;
         function_return_types["url-parse"] = BuiltinTypes::Value;
+        function_return_types["base64-encode-string"] = BuiltinTypes::String;
+        function_return_types["base64-decode-string"] = BuiltinTypes::String;
         function_return_types["base64url-encode"] = BuiltinTypes::String;
         function_return_types["base64url-decode"] = BuiltinTypes::String;
         function_return_types["uuid-v4"] = BuiltinTypes::String;
@@ -14041,6 +14043,8 @@ private:
         if (func_name == "url-encode") return system_->urlEncode(op);
         if (func_name == "url-decode") return system_->urlDecode(op);
         if (func_name == "url-parse") return system_->urlParse(op);
+        if (func_name == "base64-encode-string") return system_->base64EncodeString(op);
+        if (func_name == "base64-decode-string") return system_->base64DecodeString(op);
         if (func_name == "base64url-encode") return system_->base64urlEncode(op);
         if (func_name == "base64url-decode") return system_->base64urlDecode(op);
         if (func_name == "uuid-v4") return system_->uuidV4(op);
@@ -23185,6 +23189,7 @@ private:
             "fs-watch-native", "fs-watch-recursive", "fs-watch-poll", "fs-unwatch",
             "ansi-strip", "string-display-width", "string-truncate-display",
             "url-encode", "url-decode", "url-parse",
+            "base64-encode-string", "base64-decode-string",
             "base64url-encode", "base64url-decode", "uuid-v4",
             "constant-time-equal?", "sha256-file",
             "regex-compile", "regex-free", "regex-match", "regex-match?",

--- a/lib/backend/system_codegen.cpp
+++ b/lib/backend/system_codegen.cpp
@@ -1962,6 +1962,8 @@ THREE_ARG_BUILTIN(stringTruncateDisplay, "eshkol_builtin_string_truncate_display
 ONE_ARG_BUILTIN(urlEncode, "eshkol_builtin_url_encode")
 ONE_ARG_BUILTIN(urlDecode, "eshkol_builtin_url_decode")
 ONE_ARG_BUILTIN(urlParse, "eshkol_builtin_url_parse")
+ONE_ARG_BUILTIN(base64EncodeString, "eshkol_builtin_base64_encode_string")
+ONE_ARG_BUILTIN(base64DecodeString, "eshkol_builtin_base64_decode_string")
 ONE_ARG_BUILTIN(base64urlEncode, "eshkol_builtin_base64url_encode")
 ONE_ARG_BUILTIN(base64urlDecode, "eshkol_builtin_base64url_decode")
 ZERO_ARG_BUILTIN(uuidV4, "eshkol_builtin_uuid_v4")

--- a/lib/core/system_builtins.c
+++ b/lib/core/system_builtins.c
@@ -107,6 +107,8 @@ extern void* get_global_arena(void);
 extern void* arena_allocate(void* arena, size_t size);
 extern char* arena_allocate_string_with_header(void* arena, size_t length);
 extern void* arena_allocate_cons_with_header(void* arena);
+/* Reads an Eshkol string's header size, preserving embedded NUL bytes. */
+extern int64_t eshkol_string_byte_length(const char* s);
 extern int eshkol_capability_runtime_allows(const char* capability);
 extern void eshkol_capability_runtime_deny(const char* capability);
 /* ESH-0228: raise a proper R7RS type error (formats "Type error in <proc>:
@@ -2861,17 +2863,27 @@ static eshkol_sysbuiltin_value_t eshkol_builtin_url_parse_v(eshkol_sysbuiltin_va
     return result;
 }
 
-/** Implements `(base64url-encode data)`: encodes @p data_val using the
- *  URL-safe base64 alphabet (- and _), without padding. */
-static eshkol_sysbuiltin_value_t eshkol_builtin_base64url_encode_v(eshkol_sysbuiltin_value_t data_val) {
-    static const char table[] =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+static const char sys_base64_standard_table[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+static const char sys_base64url_table[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+/** Encode an Eshkol string with the supplied RFC 4648 alphabet.  String
+ * headers retain the true byte count, including embedded NUL bytes. */
+static eshkol_sysbuiltin_value_t sys_base64_encode_v(
+    eshkol_sysbuiltin_value_t data_val, const char table[65], int padded) {
     const char* data = sys_extract_string(data_val);
     if (!data) return sys_make_bool(0);
-    size_t len = strlen(data);
-    size_t out_len = (len / 3) * 4;
-    if (len % 3 == 1) out_len += 2;
-    else if (len % 3 == 2) out_len += 3;
+    int64_t signed_len = eshkol_string_byte_length(data);
+    if (signed_len < 0) return sys_make_bool(0);
+    size_t len = (size_t)signed_len;
+    size_t groups = len / 3;
+    size_t rem = len % 3;
+    size_t tail = rem ? (padded ? 4 : rem + 1) : 0;
+    if (groups > (SIZE_MAX - tail) / 4) return sys_make_bool(0);
+    size_t out_len = groups * 4 + tail;
+    if (out_len == SIZE_MAX) return sys_make_bool(0);
+
     char* out = (char*)malloc(out_len + 1);
     if (!out) return sys_make_bool(0);
     size_t pos = 0;
@@ -2887,10 +2899,15 @@ static eshkol_sysbuiltin_value_t eshkol_builtin_base64url_encode_v(eshkol_sysbui
     }
     if (i < len) {
         unsigned int n = (unsigned int)(unsigned char)data[i] << 16;
-        if (i + 1 < len) n |= (unsigned int)(unsigned char)data[i + 1] << 8;
+        int has_second_byte = i + 1 < len;
+        if (has_second_byte) n |= (unsigned int)(unsigned char)data[i + 1] << 8;
         out[pos++] = table[(n >> 18) & 63];
         out[pos++] = table[(n >> 12) & 63];
-        if (i + 1 < len) out[pos++] = table[(n >> 6) & 63];
+        if (has_second_byte) out[pos++] = table[(n >> 6) & 63];
+        if (padded) {
+            if (!has_second_byte) out[pos++] = '=';
+            out[pos++] = '=';
+        }
     }
     out[pos] = '\0';
     eshkol_sysbuiltin_value_t result = sys_make_string_len(out, pos);
@@ -2898,34 +2915,43 @@ static eshkol_sysbuiltin_value_t eshkol_builtin_base64url_encode_v(eshkol_sysbui
     return result;
 }
 
-/** Return the 6-bit value 0-63 of a URL-safe base64 character @p c, or -1 if
- *  it is not part of the alphabet. */
-static int sys_base64url_value(unsigned char c) {
+/** Return the 6-bit value 0-63 of a base64 character @p c, or -1 if it is
+ * not in the selected RFC 4648 alphabet. */
+static int sys_base64_value(unsigned char c, int url_safe) {
     if (c >= 'A' && c <= 'Z') return c - 'A';
     if (c >= 'a' && c <= 'z') return c - 'a' + 26;
     if (c >= '0' && c <= '9') return c - '0' + 52;
-    if (c == '-') return 62;
-    if (c == '_') return 63;
+    if (url_safe && c == '-') return 62;
+    if (url_safe && c == '_') return 63;
+    if (!url_safe && c == '+') return 62;
+    if (!url_safe && c == '/') return 63;
     return -1;
 }
 
-/** Implements `(base64url-decode data)`: decodes a URL-safe base64 string
- *  @p data_val (optional trailing '=' padding tolerated) back to its raw
- *  bytes, returning #f on invalid input. */
-static eshkol_sysbuiltin_value_t eshkol_builtin_base64url_decode_v(eshkol_sysbuiltin_value_t data_val) {
+/** Decode an RFC 4648 string using the selected alphabet.  Trailing padding
+ * is optional for compatibility with the existing Scheme helpers; padding in
+ * the middle of the input is rejected. */
+static eshkol_sysbuiltin_value_t sys_base64_decode_v(
+    eshkol_sysbuiltin_value_t data_val, int url_safe) {
     const char* data = sys_extract_string(data_val);
     if (!data) return sys_make_bool(0);
-    size_t len = strlen(data);
+    int64_t signed_len = eshkol_string_byte_length(data);
+    if (signed_len < 0) return sys_make_bool(0);
+    size_t len = (size_t)signed_len;
     while (len > 0 && data[len - 1] == '=') len--;
     if ((len % 4) == 1) return sys_make_bool(0);
-    size_t out_cap = (len * 6) / 8 + 1;
+
+    size_t full_groups = len / 4;
+    size_t tail_bytes = ((len % 4) * 6) / 8;
+    if (full_groups > (SIZE_MAX - tail_bytes - 1) / 3) return sys_make_bool(0);
+    size_t out_cap = full_groups * 3 + tail_bytes + 1;
     char* out = (char*)malloc(out_cap);
     if (!out) return sys_make_bool(0);
     uint32_t acc = 0;
     int bits = 0;
     size_t pos = 0;
     for (size_t i = 0; i < len; i++) {
-        int v = sys_base64url_value((unsigned char)data[i]);
+        int v = sys_base64_value((unsigned char)data[i], url_safe);
         if (v < 0) {
             free(out);
             return sys_make_bool(0);
@@ -2941,6 +2967,29 @@ static eshkol_sysbuiltin_value_t eshkol_builtin_base64url_decode_v(eshkol_sysbui
     eshkol_sysbuiltin_value_t result = sys_make_string_len(out, pos);
     free(out);
     return result;
+}
+
+/** Implements `(base64-encode-string data)` using RFC 4648's standard
+ * `A-Za-z0-9+/` alphabet and required `=` padding. */
+static eshkol_sysbuiltin_value_t eshkol_builtin_base64_encode_string_v(eshkol_sysbuiltin_value_t data_val) {
+    return sys_base64_encode_v(data_val, sys_base64_standard_table, 1);
+}
+
+/** Implements `(base64-decode-string data)` for standard RFC 4648 base64. */
+static eshkol_sysbuiltin_value_t eshkol_builtin_base64_decode_string_v(eshkol_sysbuiltin_value_t data_val) {
+    return sys_base64_decode_v(data_val, 0);
+}
+
+/** Implements `(base64url-encode data)`: RFC 4648 section 5, without
+ * padding. */
+static eshkol_sysbuiltin_value_t eshkol_builtin_base64url_encode_v(eshkol_sysbuiltin_value_t data_val) {
+    return sys_base64_encode_v(data_val, sys_base64url_table, 0);
+}
+
+/** Implements `(base64url-decode data)`, accepting optional trailing `=`
+ * padding for compatibility. */
+static eshkol_sysbuiltin_value_t eshkol_builtin_base64url_decode_v(eshkol_sysbuiltin_value_t data_val) {
+    return sys_base64_decode_v(data_val, 1);
 }
 
 /** Fill @p out with @p len cryptographically-random bytes from /dev/urandom,
@@ -5423,6 +5472,8 @@ void eshkol_builtin_string_truncate_display(sv_t* out, const sv_t* a, const sv_t
 void eshkol_builtin_url_encode(sv_t* out, const sv_t* a) { *out = eshkol_builtin_url_encode_v(*a); }
 void eshkol_builtin_url_decode(sv_t* out, const sv_t* a) { *out = eshkol_builtin_url_decode_v(*a); }
 void eshkol_builtin_url_parse(sv_t* out, const sv_t* a) { *out = eshkol_builtin_url_parse_v(*a); }
+void eshkol_builtin_base64_encode_string(sv_t* out, const sv_t* a) { *out = eshkol_builtin_base64_encode_string_v(*a); }
+void eshkol_builtin_base64_decode_string(sv_t* out, const sv_t* a) { *out = eshkol_builtin_base64_decode_string_v(*a); }
 void eshkol_builtin_base64url_encode(sv_t* out, const sv_t* a) { *out = eshkol_builtin_base64url_encode_v(*a); }
 void eshkol_builtin_base64url_decode(sv_t* out, const sv_t* a) { *out = eshkol_builtin_base64url_decode_v(*a); }
 void eshkol_builtin_uuid_v4(sv_t* out) { *out = eshkol_builtin_uuid_v4_v(); }


### PR DESCRIPTION
tests/memory/memory_test.esk failed to compile because base64-encode-string/base64-decode-string were undefined at link (only the base64url variants existed). Implement + register the standard RFC 4648 base64 string builtins. RFC 4648 test vectors verified: ""->"", "f"->Zg==, "fo"->Zm8=, "foo"->Zm9v, "hello"->aGVsbG8=, and decode round-trips. Memory suite goes 13/14 -> 14/14 (memory_test now compiles). Pre-existing bug (not a regression).