### PR TITLE
fix(ad): exact tensor-op Hessian — restore tensor-sum/mul/dot second derivatives (ESH-0121)

### DIFF
--- a/inc/eshkol/backend/tensor_codegen.h
+++ b/inc/eshkol/backend/tensor_codegen.h
@@ -1270,6 +1270,27 @@ private:
     llvm::Value* schemeVectorArithmetic(llvm::Value* vec1, llvm::Value* vec2, const std::string& operation);
 
     /**
+     * Forward-mode-dual-aware elementwise binary op on two tagged scalars.
+     *
+     * ESH-0121 (tensor-op Hessian): the vector/tensor Hessian feeds a Scheme
+     * vector whose components are forward-mode DUAL_NUMBER jets to the loss.
+     * The scalar-arithmetic path already dispatches on the dual tag, but the
+     * Scheme-vector tensor kernels (tensor-mul/tensor-sum/tensor-dot) read each
+     * element with extractAsDouble, which drops the e1/e2/e1e2 perturbation
+     * components and silently zeros every second derivative. This helper emits
+     * a runtime branch: if EITHER operand carries the DUAL_NUMBER tag it lifts
+     * both to duals and applies the exact dual rule (autodiff_->dualMul/…),
+     * repacking a DUAL_NUMBER; otherwise it takes the plain-double fast path.
+     * Requires autodiff_ to be wired; callers must guard on it.
+     *
+     * @param a_tagged First operand (tagged value).
+     * @param b_tagged Second operand (tagged value).
+     * @param operation One of "add", "sub", "mul", "div".
+     * @return The tagged result (DUAL_NUMBER if any operand was a dual, else DOUBLE).
+     */
+    llvm::Value* dualAwareScalarBinOp(llvm::Value* a_tagged, llvm::Value* b_tagged, const std::string& operation);
+
+    /**
      * Tensor arithmetic for TENSOR_PTR type.
      * Tensors use double elements in a contiguous array.
      * @param tensor1 First tensor (tagged)

--- a/lib/backend/tensor_arith_codegen.cpp
+++ b/lib/backend/tensor_arith_codegen.cpp
@@ -43,6 +43,82 @@ namespace eshkol {
 // ===== INTERNAL TENSOR ARITHMETIC IMPLEMENTATIONS =====
 
 // Scheme vector arithmetic: vectors with [length:i64][elem0:tagged][elem1:tagged]...
+// ESH-0121: forward-mode-dual-aware elementwise binary op. See header.
+llvm::Value* TensorCodegen::dualAwareScalarBinOp(llvm::Value* a_tagged, llvm::Value* b_tagged,
+                                                 const std::string& operation) {
+    // Ensure tagged form so the dual tag is inspectable.
+    if (a_tagged->getType() != ctx_.taggedValueType()) a_tagged = tagged_.packDouble(extractAsDouble(a_tagged));
+    if (b_tagged->getType() != ctx_.taggedValueType()) b_tagged = tagged_.packDouble(extractAsDouble(b_tagged));
+
+    auto numericResult = [&](llvm::Value* av, llvm::Value* bv) -> llvm::Value* {
+        if (operation == "add") return ctx_.builder().CreateFAdd(av, bv);
+        if (operation == "sub") return ctx_.builder().CreateFSub(av, bv);
+        if (operation == "mul") return ctx_.builder().CreateFMul(av, bv);
+        if (operation == "div") return ctx_.builder().CreateFDiv(av, bv);
+        if (operation == "pow") {
+            llvm::Function* pow_fn = ESHKOL_GET_INTRINSIC(&ctx_.module(), llvm::Intrinsic::pow, {ctx_.doubleType()});
+            return ctx_.builder().CreateCall(pow_fn, {av, bv});
+        }
+        if (operation == "max") {
+            llvm::Function* max_fn = ESHKOL_GET_INTRINSIC(&ctx_.module(), llvm::Intrinsic::maxnum, {ctx_.doubleType()});
+            return ctx_.builder().CreateCall(max_fn, {av, bv});
+        }
+        if (operation == "min") {
+            llvm::Function* min_fn = ESHKOL_GET_INTRINSIC(&ctx_.module(), llvm::Intrinsic::minnum, {ctx_.doubleType()});
+            return ctx_.builder().CreateCall(min_fn, {av, bv});
+        }
+        return llvm::ConstantFP::get(ctx_.doubleType(), 0.0);
+    };
+
+    // Without autodiff wired there are never duals in flight: plain path.
+    if (!autodiff_) {
+        return tagged_.packDouble(numericResult(extractAsDouble(a_tagged), extractAsDouble(b_tagged)));
+    }
+
+    llvm::Value* a_is_dual = ctx_.builder().CreateICmpEQ(
+        tagged_.getBaseType(tagged_.getType(a_tagged)),
+        llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_DUAL_NUMBER));
+    llvm::Value* b_is_dual = ctx_.builder().CreateICmpEQ(
+        tagged_.getBaseType(tagged_.getType(b_tagged)),
+        llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_DUAL_NUMBER));
+    llvm::Value* any_dual = ctx_.builder().CreateOr(a_is_dual, b_is_dual);
+
+    llvm::Function* fn = ctx_.builder().GetInsertBlock()->getParent();
+    llvm::BasicBlock* dual_bb = llvm::BasicBlock::Create(ctx_.context(), "vbin_dual", fn);
+    llvm::BasicBlock* num_bb = llvm::BasicBlock::Create(ctx_.context(), "vbin_num", fn);
+    llvm::BasicBlock* merge_bb = llvm::BasicBlock::Create(ctx_.context(), "vbin_merge", fn);
+    ctx_.builder().CreateCondBr(any_dual, dual_bb, num_bb);
+
+    // Dual path: lift both operands and apply the exact dual rule.
+    ctx_.builder().SetInsertPoint(dual_bb);
+    llvm::Value* da = autodiff_->safeUnpackDualFromTagged(a_tagged);
+    llvm::Value* db = autodiff_->safeUnpackDualFromTagged(b_tagged);
+    llvm::Value* dr = nullptr;
+    if (operation == "add") dr = autodiff_->dualAdd(da, db);
+    else if (operation == "sub") dr = autodiff_->dualSub(da, db);
+    else if (operation == "mul") dr = autodiff_->dualMul(da, db);
+    else if (operation == "div") dr = autodiff_->dualDiv(da, db);
+    else if (operation == "pow") dr = autodiff_->dualPow(da, db);
+    else if (operation == "max") dr = autodiff_->dualMax(da, db);
+    else if (operation == "min") dr = autodiff_->dualMin(da, db);
+    else dr = autodiff_->dualMul(da, db);
+    llvm::Value* dual_tagged = autodiff_->packDualToTagged(dr);
+    llvm::BasicBlock* dual_exit = ctx_.builder().GetInsertBlock();
+    ctx_.builder().CreateBr(merge_bb);
+
+    // Numeric path: plain doubles.
+    ctx_.builder().SetInsertPoint(num_bb);
+    llvm::Value* num_tagged = tagged_.packDouble(numericResult(extractAsDouble(a_tagged), extractAsDouble(b_tagged)));
+    llvm::BasicBlock* num_exit = ctx_.builder().GetInsertBlock();
+    ctx_.builder().CreateBr(merge_bb);
+
+    ctx_.builder().SetInsertPoint(merge_bb);
+    llvm::PHINode* phi = ctx_.builder().CreatePHI(ctx_.taggedValueType(), 2, "vbin_result");
+    phi->addIncoming(dual_tagged, dual_exit);
+    phi->addIncoming(num_tagged, num_exit);
+    return phi;
+}
+
 llvm::Value* TensorCodegen::schemeVectorArithmetic(llvm::Value* vec1_tagged, llvm::Value* vec2_tagged, const std::string& operation) {
     // Extract pointers from tagged values
     llvm::Value* ptr1_int = vec1_tagged;
@@ -113,36 +189,11 @@ llvm::Value* TensorCodegen::schemeVectorArithmetic(llvm::Value* vec1_tagged, llv
     llvm::Value* elem1_tagged = ctx_.builder().CreateLoad(ctx_.taggedValueType(), elem1_ptr);
     llvm::Value* elem2_tagged = ctx_.builder().CreateLoad(ctx_.taggedValueType(), elem2_ptr);
 
-    // Extract doubles from tagged values
-    llvm::Value* elem1_double = tagged_.unpackDouble(elem1_tagged);
-    llvm::Value* elem2_double = tagged_.unpackDouble(elem2_tagged);
-
-    // Perform operation
-    llvm::Value* result_double = nullptr;
-    if (operation == "add") {
-        result_double = ctx_.builder().CreateFAdd(elem1_double, elem2_double);
-    } else if (operation == "sub") {
-        result_double = ctx_.builder().CreateFSub(elem1_double, elem2_double);
-    } else if (operation == "mul") {
-        result_double = ctx_.builder().CreateFMul(elem1_double, elem2_double);
-    } else if (operation == "div") {
-        result_double = ctx_.builder().CreateFDiv(elem1_double, elem2_double);
-    } else if (operation == "pow") {
-        llvm::Function* pow_fn = ESHKOL_GET_INTRINSIC(&ctx_.module(), llvm::Intrinsic::pow, {ctx_.doubleType()});
-        result_double = ctx_.builder().CreateCall(pow_fn, {elem1_double, elem2_double});
-    } else if (operation == "max") {
-        llvm::Function* max_fn = ESHKOL_GET_INTRINSIC(&ctx_.module(), llvm::Intrinsic::maxnum, {ctx_.doubleType()});
-        result_double = ctx_.builder().CreateCall(max_fn, {elem1_double, elem2_double});
-    } else if (operation == "min") {
-        llvm::Function* min_fn = ESHKOL_GET_INTRINSIC(&ctx_.module(), llvm::Intrinsic::minnum, {ctx_.doubleType()});
-        result_double = ctx_.builder().CreateCall(min_fn, {elem1_double, elem2_double});
-    } else {
-        // Unsupported operation — use zero as fallback (prevents nullptr crash)
-        result_double = llvm::ConstantFP::get(ctx_.doubleType(), 0.0);
-    }
-
-    // Pack result and store
-    llvm::Value* result_tagged = tagged_.packDouble(result_double);
+    // ESH-0121: dual-aware elementwise op. When the Hessian's forward-over-forward
+    // sweep feeds a Scheme vector of DUAL_NUMBER jets, this propagates the exact
+    // dual (including the mixed e1e2 second-order term) instead of dropping it to
+    // a plain double and silently zeroing the second derivative.
+    llvm::Value* result_tagged = dualAwareScalarBinOp(elem1_tagged, elem2_tagged, operation);
     ctx_.builder().CreateStore(result_tagged, result_elem_ptr);
 
     // Increment counter

--- a/lib/backend/tensor_reduce_codegen.cpp
+++ b/lib/backend/tensor_reduce_codegen.cpp
@@ -559,9 +559,12 @@ llvm::Value* TensorCodegen::tensorDot(const eshkol_operations_t* op) {
     llvm::BasicBlock* svec_loop_body = llvm::BasicBlock::Create(ctx_.context(), "svec_dot_body", current_func);
     llvm::BasicBlock* svec_loop_exit = llvm::BasicBlock::Create(ctx_.context(), "svec_dot_exit", current_func);
 
-    llvm::Value* svec_sum = ctx_.builder().CreateAlloca(ctx_.doubleType(), nullptr, "svec_dot_acc");
+    // ESH-0121: tagged accumulator so a Scheme vector of DUAL_NUMBER jets dots
+    // to a dual (preserving the mixed e1e2 second-order term) instead of being
+    // flattened to a plain double, which silently zeros the Hessian.
+    llvm::Value* svec_sum = ctx_.builder().CreateAlloca(ctx_.taggedValueType(), nullptr, "svec_dot_acc");
     llvm::Value* svec_counter = ctx_.builder().CreateAlloca(ctx_.int64Type(), nullptr, "svec_dot_i");
-    ctx_.builder().CreateStore(llvm::ConstantFP::get(ctx_.doubleType(), 0.0), svec_sum);
+    ctx_.builder().CreateStore(tagged_.packDouble(llvm::ConstantFP::get(ctx_.doubleType(), 0.0)), svec_sum);
     ctx_.builder().CreateStore(llvm::ConstantInt::get(ctx_.int64Type(), 0), svec_counter);
     ctx_.builder().CreateBr(svec_loop_cond);
 
@@ -577,26 +580,24 @@ llvm::Value* TensorCodegen::tensorDot(const eshkol_operations_t* op) {
     llvm::Value* svec_a_elems_typed = ctx_.builder().CreatePointerCast(svec_a_elems_base, ctx_.ptrType());
     llvm::Value* svec_a_elem_ptr = ctx_.builder().CreateGEP(ctx_.taggedValueType(), svec_a_elems_typed, svec_i);
     llvm::Value* svec_a_elem_tagged = ctx_.builder().CreateLoad(ctx_.taggedValueType(), svec_a_elem_ptr);
-    llvm::Value* svec_a_val = extractAsDouble(svec_a_elem_tagged);
 
     llvm::Value* svec_b_elems_base = ctx_.builder().CreateGEP(ctx_.int8Type(), svec_b_ptr,
         llvm::ConstantInt::get(ctx_.int64Type(), 8));
     llvm::Value* svec_b_elems_typed = ctx_.builder().CreatePointerCast(svec_b_elems_base, ctx_.ptrType());
     llvm::Value* svec_b_elem_ptr = ctx_.builder().CreateGEP(ctx_.taggedValueType(), svec_b_elems_typed, svec_i);
     llvm::Value* svec_b_elem_tagged = ctx_.builder().CreateLoad(ctx_.taggedValueType(), svec_b_elem_ptr);
-    llvm::Value* svec_b_val = extractAsDouble(svec_b_elem_tagged);
 
-    // Multiply and accumulate
-    llvm::Value* svec_product = ctx_.builder().CreateFMul(svec_a_val, svec_b_val);
-    llvm::Value* svec_current_sum = ctx_.builder().CreateLoad(ctx_.doubleType(), svec_sum);
-    llvm::Value* svec_new_sum = ctx_.builder().CreateFAdd(svec_current_sum, svec_product);
+    // Multiply and accumulate (dual-aware).
+    llvm::Value* svec_product = dualAwareScalarBinOp(svec_a_elem_tagged, svec_b_elem_tagged, "mul");
+    llvm::Value* svec_current_sum = ctx_.builder().CreateLoad(ctx_.taggedValueType(), svec_sum);
+    llvm::Value* svec_new_sum = dualAwareScalarBinOp(svec_current_sum, svec_product, "add");
     ctx_.builder().CreateStore(svec_new_sum, svec_sum);
     llvm::Value* svec_next_i = ctx_.builder().CreateAdd(svec_i, llvm::ConstantInt::get(ctx_.int64Type(), 1));
     ctx_.builder().CreateStore(svec_next_i, svec_counter);
     ctx_.builder().CreateBr(svec_loop_cond);
 
     ctx_.builder().SetInsertPoint(svec_loop_exit);
-    llvm::Value* svec_result = ctx_.builder().CreateLoad(ctx_.doubleType(), svec_sum);
+    llvm::Value* svec_result = ctx_.builder().CreateLoad(ctx_.taggedValueType(), svec_sum);
     // Don't branch yet - we'll branch to scalar_merge once it's created
     llvm::BasicBlock* svec_exit_block = ctx_.builder().GetInsertBlock();
 
@@ -1139,9 +1140,11 @@ llvm::Value* TensorCodegen::tensorDot(const eshkol_operations_t* op) {
     // Create scalar_merge block for 1D scalar results (from both Scheme vec and 1D tensor)
     llvm::BasicBlock* scalar_merge = llvm::BasicBlock::Create(ctx_.context(), "scalar_merge", current_func);
 
-    // Now add the deferred branch from svec_exit_block to scalar_merge
+    // Now add the deferred branch from svec_exit_block to scalar_merge.
+    // svec_result is already a tagged value (DUAL_NUMBER when the dot was over a
+    // Scheme vector of forward-mode duals, DOUBLE otherwise), so no repack.
     ctx_.builder().SetInsertPoint(svec_exit_block);
-    llvm::Value* svec_packed = tagged_.packDouble(svec_result);
+    llvm::Value* svec_packed = svec_result;
     ctx_.builder().CreateBr(scalar_merge);
 
     // Tensor merge for 1D scalar path - pack and branch to scalar_merge
@@ -1858,9 +1861,12 @@ llvm::Value* TensorCodegen::tensorSum(const eshkol_operations_t* op) {
     llvm::BasicBlock* svec_loop_body = llvm::BasicBlock::Create(ctx_.context(), "svec_sum_body", current_func);
     llvm::BasicBlock* svec_loop_exit = llvm::BasicBlock::Create(ctx_.context(), "svec_sum_exit", current_func);
 
-    llvm::Value* svec_sum = ctx_.builder().CreateAlloca(ctx_.doubleType(), nullptr, "svec_sum_acc");
+    // ESH-0121: tagged accumulator so a Scheme vector of DUAL_NUMBER jets sums
+    // to a dual (preserving the mixed e1e2 second-order term) instead of being
+    // flattened to a plain double, which silently zeros the Hessian.
+    llvm::Value* svec_sum = ctx_.builder().CreateAlloca(ctx_.taggedValueType(), nullptr, "svec_sum_acc");
     llvm::Value* svec_counter = ctx_.builder().CreateAlloca(ctx_.int64Type(), nullptr, "svec_sum_i");
-    ctx_.builder().CreateStore(llvm::ConstantFP::get(ctx_.doubleType(), 0.0), svec_sum);
+    ctx_.builder().CreateStore(tagged_.packDouble(llvm::ConstantFP::get(ctx_.doubleType(), 0.0)), svec_sum);
     ctx_.builder().CreateStore(llvm::ConstantInt::get(ctx_.int64Type(), 0), svec_counter);
     ctx_.builder().CreateBr(svec_loop_cond);
 
@@ -1875,17 +1881,17 @@ llvm::Value* TensorCodegen::tensorSum(const eshkol_operations_t* op) {
     llvm::Value* svec_elems_typed = ctx_.builder().CreatePointerCast(svec_elems_base, ctx_.ptrType());
     llvm::Value* svec_elem_ptr = ctx_.builder().CreateGEP(ctx_.taggedValueType(), svec_elems_typed, svec_i);
     llvm::Value* svec_elem_tagged = ctx_.builder().CreateLoad(ctx_.taggedValueType(), svec_elem_ptr);
-    llvm::Value* svec_elem_val = extractAsDouble(svec_elem_tagged);
-    llvm::Value* svec_current_sum = ctx_.builder().CreateLoad(ctx_.doubleType(), svec_sum);
-    llvm::Value* svec_new_sum = ctx_.builder().CreateFAdd(svec_current_sum, svec_elem_val);
+    llvm::Value* svec_current_sum = ctx_.builder().CreateLoad(ctx_.taggedValueType(), svec_sum);
+    llvm::Value* svec_new_sum = dualAwareScalarBinOp(svec_current_sum, svec_elem_tagged, "add");
     ctx_.builder().CreateStore(svec_new_sum, svec_sum);
+    // dualAwareScalarBinOp leaves the builder at its own merge block; the
+    // back-edge and increment below are correctly emitted there.
     llvm::Value* svec_next_i = ctx_.builder().CreateAdd(svec_i, llvm::ConstantInt::get(ctx_.int64Type(), 1));
     ctx_.builder().CreateStore(svec_next_i, svec_counter);
     ctx_.builder().CreateBr(svec_loop_cond);
 
     ctx_.builder().SetInsertPoint(svec_loop_exit);
-    llvm::Value* svec_result = ctx_.builder().CreateLoad(ctx_.doubleType(), svec_sum);
-    llvm::Value* svec_tagged_result = tagged_.packDouble(svec_result);
+    llvm::Value* svec_tagged_result = ctx_.builder().CreateLoad(ctx_.taggedValueType(), svec_sum);
     ctx_.builder().CreateBr(sum_merge);
     llvm::BasicBlock* svec_exit_block = ctx_.builder().GetInsertBlock();
 

--- a/tests/ad/hessian_tensor_op_test.esk
+++ b/tests/ad/hessian_tensor_op_test.esk
@@ -1,0 +1,74 @@
+;;; tests/ad/hessian_tensor_op_test.esk
+;;; ESH-0121 regression: exact Hessian of a scalar loss that flows its VECTOR
+;;; argument through a TENSOR OP (tensor-sum / tensor-mul / tensor-dot).
+;;;
+;;; PR #246 rewrote the vector/tensor Hessian to exact forward-over-forward AD
+;;; (a Scheme vector of forward-mode DUAL_NUMBER jets is fed to the loss, and
+;;; the mixed e1*e2 jet coefficient IS the second derivative). That fixed the
+;;; ESH-0120/0121 inner-derivative case, but the Scheme-vector tensor kernels
+;;; (tensor-mul -> schemeVectorArithmetic, tensor-sum / tensor-dot reductions)
+;;; read every element with extractAsDouble, dropping the perturbation slots and
+;;; SILENTLY returning an all-zero Hessian for tensor-op losses:
+;;;   (hessian (lambda (v) (tensor-sum (tensor-mul v v))) #(1.0 2.0))
+;;;     -> #((0 0)(0 0))   [WRONG]   analytic [[2,0],[0,2]]
+;;;
+;;; Fix: those kernels are now forward-mode-dual-aware — a DUAL_NUMBER element
+;;; propagates the exact dual (dualMul/dualAdd/...) instead of flattening to a
+;;; double. Off-diagonals of separable losses stay EXACTLY zero (no finite
+;;; differences). The scalar/vector-ref Hessian path and the ESH-0120/0121
+;;; forward-over-forward machinery are unchanged.
+(define pass 0)(define fail 0)
+(define (approx= a b) (< (abs (- a b)) 1e-4))
+(define (exact= a b) (= a b))
+(define (chk label v)
+  (display "  [")(display (if v "PASS" "FAIL"))(display "] ")(display label)(newline)
+  (if v (set! pass (+ pass 1)) (set! fail (+ fail 1))))
+
+;; ── tensor-sum(tensor-mul v v) = sum v_i^2  ->  H = 2 I ────────────────────
+;; at a VECTOR point.
+(define hqv (hessian (lambda (v) (tensor-sum (tensor-mul v v))) (vector 1.3 -0.7 0.6)))
+(chk "quad/vec H[0][0] = 2"          (approx= (tensor-ref hqv 0 0) 2.0))
+(chk "quad/vec H[1][1] = 2"          (approx= (tensor-ref hqv 1 1) 2.0))
+(chk "quad/vec H[2][2] = 2"          (approx= (tensor-ref hqv 2 2) 2.0))
+(chk "quad/vec H[0][1] = 0 (exact)"  (exact=  (tensor-ref hqv 0 1) 0.0))
+(chk "quad/vec H[1][2] = 0 (exact)"  (exact=  (tensor-ref hqv 1 2) 0.0))
+(chk "quad/vec H[2][0] = 0 (exact)"  (exact=  (tensor-ref hqv 2 0) 0.0))
+
+;; same loss at a literal TENSOR point (#(...)) and a (tensor ...) point.
+(define hql (hessian (lambda (v) (tensor-sum (tensor-mul v v))) #(1.0 2.0)))
+(chk "quad/lit H[0][0] = 2"          (approx= (tensor-ref hql 0 0) 2.0))
+(chk "quad/lit H[1][1] = 2"          (approx= (tensor-ref hql 1 1) 2.0))
+(chk "quad/lit H[0][1] = 0 (exact)"  (exact=  (tensor-ref hql 0 1) 0.0))
+
+(define hqt (hessian (lambda (v) (tensor-sum (tensor-mul v v))) (tensor 3 1.3 -0.7 0.6)))
+(chk "quad/tensor H[0][0] = 2"         (approx= (tensor-ref hqt 0 0) 2.0))
+(chk "quad/tensor H[2][2] = 2"         (approx= (tensor-ref hqt 2 2) 2.0))
+(chk "quad/tensor H[0][2] = 0 (exact)" (exact=  (tensor-ref hqt 0 2) 0.0))
+
+;; ── cubic via tensor-mul + tensor-dot: sum v_i^3  ->  H = diag(6 v_i) ──────
+;; exercises tensor-mul feeding tensor-dot; off-diagonals must be exactly 0.
+(define hcu (hessian (lambda (v) (tensor-dot (tensor-mul v v) v)) (vector 1.0 2.0 3.0)))
+(chk "cubic H[0][0] = 6"          (approx= (tensor-ref hcu 0 0) 6.0))
+(chk "cubic H[1][1] = 12"         (approx= (tensor-ref hcu 1 1) 12.0))
+(chk "cubic H[2][2] = 18"         (approx= (tensor-ref hcu 2 2) 18.0))
+(chk "cubic H[0][1] = 0 (exact)"  (exact=  (tensor-ref hcu 0 1) 0.0))
+(chk "cubic H[1][2] = 0 (exact)"  (exact=  (tensor-ref hcu 1 2) 0.0))
+
+;; ── rational over tensor-dot: f(v) = 1/(1 + v.v)  (nonseparable) ───────────
+;; H[i][j] = (8 v_i v_j)/(1+s)^3 - 2 delta_ij/(1+s)^2,  s = v.v.
+;; at v=(0.8,1.1): s = 0.64+1.21 = 1.85, 1+s = 2.85; analytic values below.
+(define hr (hessian (lambda (v) (/ 1.0 (+ 1.0 (tensor-dot v v)))) (vector 0.8 1.1)))
+(define s3 (* 2.85 2.85 2.85))
+(define s2 (* 2.85 2.85))
+(chk "rat H[0][0]" (approx= (tensor-ref hr 0 0) (- (/ (* 8.0 0.8 0.8) s3) (/ 2.0 s2))))
+(chk "rat H[1][1]" (approx= (tensor-ref hr 1 1) (- (/ (* 8.0 1.1 1.1) s3) (/ 2.0 s2))))
+(chk "rat H[0][1]" (approx= (tensor-ref hr 0 1) (/ (* 8.0 0.8 1.1) s3)))
+(chk "rat H[1][0] symmetric" (approx= (tensor-ref hr 1 0) (tensor-ref hr 0 1)))
+
+;; ── do-no-harm: the scalar/vector-ref Hessian path is unchanged ────────────
+;; f(v) = v0^3  ->  f'' = 6 v0 = 12 at v0=2.
+(define hs (hessian (lambda (v) (let ((x (vector-ref v 0))) (* x x x))) (vector 2.0)))
+(chk "scalar/vref H[0][0] = 12" (approx= (tensor-ref hs 0 0) 12.0))
+
+(display "Passed: ")(display pass)(newline)(display "Failed: ")(display fail)(newline)
+(if (> fail 0) (error "hessian_tensor_op_test FAILED"))


### PR DESCRIPTION
## Summary

Fixes a silent-wrong AD regression introduced by #246 (ESH-0120/0121, 318fad68): the Hessian of a scalar loss that flows its vector argument through a **tensor op** returned an all-zero Hessian.

```
(hessian (lambda (v) (tensor-sum (tensor-mul v v))) #(1.0 2.0))
  before: #((0 0)(0 0))   WRONG (silent zero)
  after:  #((2 0)(0 2))   exact   (analytic [[2,0],[0,2]])
```

## Regression mechanism

#246 replaced the vector/tensor Hessian with exact **forward-over-forward AD**: the loss is evaluated on a Scheme vector whose components are forward-mode `DUAL_NUMBER` jets, and the mixed `e1*e2` jet coefficient is read as the second derivative. This correctly fixed the inner-derivative case (ESH-0120/0121), but the **Scheme-vector tensor kernels are not forward-dual-aware**:

- `tensor-mul` → `schemeVectorArithmetic` read each element with `unpackDouble`
- `tensor-sum` / `tensor-dot` (Scheme-vector reductions) read each element with `extractAsDouble` into a plain-`double` accumulator

A `DUAL_NUMBER` is a tagged pointer; reading it as a `double` discards the `e1/e2/e1e2` perturbation slots. So `tensor-mul` produced a plain-double vector and `tensor-sum`/`tensor-dot` a plain double — the loss returned a non-dual, and every mixed second-order term collapsed to `0`. The scalar/`vector-ref` path was unaffected (scalar arithmetic already dispatches on the dual tag), which is why `(hessian (lambda (v) (* x x x)) …)` stayed correct.

## Fix

New helper `TensorCodegen::dualAwareScalarBinOp` emits a runtime branch: if either operand carries the `DUAL_NUMBER` tag it lifts both to duals and applies the exact dual rule (`dualMul`/`dualAdd`/…), repacking a `DUAL_NUMBER`; otherwise it takes the unchanged plain-double fast path. Wired into `schemeVectorArithmetic` and the `tensor-sum`/`tensor-dot` Scheme-vector reductions (accumulators are now tagged). Off-diagonals of separable losses stay **exactly** zero — no finite differences.

The scalar/`vector-ref` Hessian path and the ESH-0120/0121 forward-over-forward machinery are untouched; the non-AD tensor path (plain doubles, SIMD/XLA, and the reverse-mode AD-node branch) is unchanged.

## FD-vs-AD Hessian (before → after)

| loss | point | analytic H | before | after (exact, matches FD) |
|---|---|---|---|---|
| `tensor-sum(tensor-mul v v)` | `(1.3 -0.7 0.6)` | `diag(2,2,2)` | all-zero | `diag(2,2,2)`, off-diag exact 0 |
| `tensor-dot(tensor-mul v v, v)` | `(1 2 3)` | `diag(6,12,18)` | all-zero | `diag(6,12,18)`, off-diag exact 0 |
| `1/(1 + tensor-dot v v)` | `(0.8 1.1)` | non-separable | all-zero | matches analytic + FD |

Verified JIT (`-r`) and AOT at vector, literal-tensor (`#(...)`) and `(tensor …)` points.

## Gates

- `tests/ad/forward_over_reverse_test.esk` — **17/17** (ESH-0120/0121 not regressed)
- `scripts/run_autodiff_tests.sh` — **54/54**
- `scripts/run_ad_adversarial.sh` (full sweep) — **htensor family FAIL → PASS** (JIT + AOT); `vecpoint` and `gofg` stay green (0 FAIL)
- `scripts/run_tensor_input2_grad_gate.sh` — **24/24** (JIT + AOT)
- New regression test `tests/ad/hessian_tensor_op_test.esk` — 22/22 (JIT + AOT)

## Known limitation (out of scope, pre-existing)

Hessian of a `tensor-matmul`-based loss that first `reshape`s the vector into a 2-D tensor still returns zero (`reshape` flattens the forward dual into a raw double tensor, and the 2-D matmul path is reverse-mode-only). This is **unchanged by this PR** — it is all-zero on master too — and is not covered by the AD adversarial oracle (the htensor family is `tensor-sum`/`tensor-mul`/`tensor-dot`). The `tensor-input2` gate exercises matmul with `gradient` (reverse-mode), which is unaffected. Restoring exact matmul Hessian needs a tensors-of-duals representation and is tracked separately.
