### PR TITLE
fix(vm): make bytecode-VM arithmetic bignum-aware

### DIFF
--- a/lib/backend/vm_compiler.c
+++ b/lib/backend/vm_compiler.c
@@ -63,7 +63,8 @@ static void compile_quasiquote(FuncChunk* c, Node* node) {
 
     /* Atom: number */
     if (node->type == N_NUMBER) {
-        int ci = chunk_add_const(c, node->numval == (int64_t)node->numval ? INT_VAL((int64_t)node->numval) : FLOAT_VAL(node->numval));
+        int ci = chunk_add_const(c, node->is_int ? INT_VAL(node->ival)
+            : (node->numval == (int64_t)node->numval ? INT_VAL((int64_t)node->numval) : FLOAT_VAL(node->numval)));
         if (ci >= 0) chunk_emit(c, OP_CONST, ci);
         return;
     }
@@ -1641,7 +1642,9 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
              * constant pool format unchanged. */
             chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL((int64_t)v)));
             chunk_emit(c, OP_NATIVE_CALL, 228);
-        } else if (!node->is_inexact && v == (int64_t)v && fabs(v) < 1e15)
+        } else if (node->is_int)
+            chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL(node->ival)));
+        else if (!node->is_inexact && v == (int64_t)v && fabs(v) < 1e15)
             chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL((int64_t)v)));
         else
             chunk_emit(c, OP_CONST, chunk_add_const(c, FLOAT_VAL(v)));
@@ -1839,22 +1842,50 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
     /* If all operands are compile-time constants, evaluate at compile time */
     if (node->type == N_LIST && node->n_children >= 3) {
         if (head->type == N_SYMBOL) {
-            int all_const = 1;
+            int all_const = 1, all_int = 1;
             for (int i = 1; i < node->n_children; i++) {
                 if (node->children[i]->type != N_NUMBER) { all_const = 0; break; }
+                if (!node->children[i]->is_int) all_int = 0;
             }
-            if (all_const) {
+            int is_add = strcmp(head->symbol, "+") == 0;
+            int is_sub = strcmp(head->symbol, "-") == 0;
+            int is_mul = strcmp(head->symbol, "*") == 0;
+            /* Exact-integer fold with overflow detection. On overflow, DON'T
+             * fold — fall through to the runtime reduce loops, whose ops now
+             * promote to bignum (folding to a double here would silently make
+             * e.g. (* 9223372036854775807 2) inexact). */
+            if (all_const && all_int && (is_add || is_sub || is_mul)) {
+                int64_t acc = is_mul ? 1 : 0;
+                int overflow = 0;
+                if (is_add) {
+                    for (int i = 1; i < node->n_children; i++)
+                        if (__builtin_add_overflow(acc, node->children[i]->ival, &acc)) { overflow = 1; break; }
+                } else if (is_sub) {
+                    acc = node->children[1]->ival;
+                    for (int i = 2; i < node->n_children; i++)
+                        if (__builtin_sub_overflow(acc, node->children[i]->ival, &acc)) { overflow = 1; break; }
+                } else { /* is_mul */
+                    for (int i = 1; i < node->n_children; i++)
+                        if (__builtin_mul_overflow(acc, node->children[i]->ival, &acc)) { overflow = 1; break; }
+                }
+                if (!overflow) {
+                    int ci = chunk_add_const(c, INT_VAL(acc));
+                    if (ci >= 0) chunk_emit(c, OP_CONST, ci);
+                    return;
+                }
+                /* overflow → leave to runtime */
+            } else if (all_const) {
                 double result = 0;
                 int folded = 0;
-                if (strcmp(head->symbol, "+") == 0) {
+                if (is_add) {
                     result = 0;
                     for (int i = 1; i < node->n_children; i++) result += node->children[i]->numval;
                     folded = 1;
-                } else if (strcmp(head->symbol, "-") == 0 && node->n_children >= 2) {
+                } else if (is_sub && node->n_children >= 2) {
                     result = node->children[1]->numval;
                     for (int i = 2; i < node->n_children; i++) result -= node->children[i]->numval;
                     folded = 1;
-                } else if (strcmp(head->symbol, "*") == 0) {
+                } else if (is_mul) {
                     result = 1;
                     for (int i = 1; i < node->n_children; i++) result *= node->children[i]->numval;
                     folded = 1;

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -4813,7 +4813,9 @@ static void vm_dispatch_native(VM* vm, int fid) {
     case 34: { Value b = vm_pop(vm); Value a = vm_pop(vm);
         if (vm_either_bignum(a,b)) { vm_push(vm, vm_bignum_compare_vals(vm,a,b) >= 0 ? a : b); break; }
         double da=as_number_vm(vm,a),db=as_number_vm(vm,b); vm_push(vm, number_val(da>db?da:db)); break; }
-    case 35: { Value a = vm_pop(vm); if (a.type==VAL_DUAL) { vm_push(vm,a); vm_dispatch_native(vm,383); } else vm_push(vm, number_val(fabs(as_number(a)))); break; }
+    case 35: { Value a = vm_pop(vm); if (a.type==VAL_DUAL) { vm_push(vm,a); vm_dispatch_native(vm,383); }
+        else if (a.type==VAL_BIGNUM) { vm_push_bignum_norm(vm, bignum_abs_val(&vm->heap.regions, (VmBignum*)vm->heap.objects[a.as.ptr]->opaque.ptr)); }
+        else vm_push(vm, number_val(fabs(as_number(a)))); break; }
     /* modulo, remainder, quotient — first-class closure versions */
     case 36: { Value b = vm_pop(vm); Value a = vm_pop(vm);
         if (vm_either_bignum(a,b)) { vm_bignum_arith(vm,a,b,'m'); break; }

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -4650,6 +4650,111 @@ static int vm_deep_equal(VM* vm, Value a, Value b) {
     }
 }
 
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Bignum-aware arithmetic helpers
+ *
+ * The base VM's arithmetic/comparison opcodes and native builtins coerced
+ * operands through as_number(), which returns 0.0 for a VAL_BIGNUM. Any
+ * expression whose exact result overflows int64 (e.g. (+ (expt 7 41) 13),
+ * (modulo (expt 10 26) 3)) therefore silently produced a wrong small value on
+ * the VM path while the native/JIT/AOT paths stayed correct. These helpers let
+ * the ops promote to the arena bignum runtime (vm_bignum.c) whenever a bignum
+ * operand appears or an int64 op overflows.
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+/** @brief True when either operand is a heap-boxed bignum. */
+static inline int vm_either_bignum(Value a, Value b) {
+    return a.type == VAL_BIGNUM || b.type == VAL_BIGNUM;
+}
+
+/** @brief Coerce an integer-ish Value to a VmBignum*. VAL_BIGNUM returns its
+ *         heap payload directly; VAL_INT/VAL_CHAR (and anything else, best
+ *         effort) is materialised as a fresh bignum. NULL only on alloc
+ *         failure. */
+static VmBignum* vm_coerce_bignum(VM* vm, Value v) {
+    if (v.type == VAL_BIGNUM)
+        return (VmBignum*)vm->heap.objects[v.as.ptr]->opaque.ptr;
+    int64_t iv = (v.type == VAL_INT || v.type == VAL_CHAR)
+        ? v.as.i : (int64_t)as_number(v);
+    return bignum_from_int64(&vm->heap.regions, iv);
+}
+
+/** @brief Push a bignum result, demoting it back to a fixnum (VAL_INT) when it
+ *         fits in int64 so downstream ops and eqv?/= keep matching the native
+ *         fixnum path. Sets vm->error if @p b is NULL. */
+static void vm_push_bignum_norm(VM* vm, VmBignum* b) {
+    if (!b) { vm->error = 1; return; }
+    int ov = 0;
+    int64_t iv = bignum_to_int64(b, &ov);
+    if (!ov) vm_push(vm, INT_VAL(iv));
+    else VM_PUSH_HEAP_OPAQUE(vm, HEAP_BIGNUM, VAL_BIGNUM, b);
+}
+
+/** @brief Compute (a op b) exactly in the bignum domain and push the
+ *         normalized result. @p op is one of '+','-','*','q' (quotient),
+ *         'r' (remainder), 'm' (R7RS modulo). A float operand on +,-,* falls
+ *         back to inexact float (R7RS contagion). Division by zero sets
+ *         vm->error. */
+static void vm_bignum_arith(VM* vm, Value a, Value b, char op) {
+    /* Bignum mixed with an inexact float → inexact float. */
+    if ((op == '+' || op == '-' || op == '*') &&
+        (a.type == VAL_FLOAT || b.type == VAL_FLOAT)) {
+        double x = (a.type == VAL_BIGNUM)
+            ? bignum_to_double((VmBignum*)vm->heap.objects[a.as.ptr]->opaque.ptr)
+            : as_number(a);
+        double y = (b.type == VAL_BIGNUM)
+            ? bignum_to_double((VmBignum*)vm->heap.objects[b.as.ptr]->opaque.ptr)
+            : as_number(b);
+        double r = (op == '+') ? x + y : (op == '-') ? x - y : x * y;
+        vm_push(vm, FLOAT_VAL(r));
+        return;
+    }
+    VmRegionStack* rs = &vm->heap.regions;
+    VmBignum* ab = vm_coerce_bignum(vm, a);
+    VmBignum* bb = vm_coerce_bignum(vm, b);
+    if (!ab || !bb) { vm->error = 1; return; }
+    VmBignum* r = NULL;
+    switch (op) {
+    case '+': r = bignum_add(rs, ab, bb); break;
+    case '-': r = bignum_sub(rs, ab, bb); break;
+    case '*': r = bignum_mul(rs, ab, bb); break;
+    case 'q': if (bignum_is_zero(bb)) { vm->error = 1; return; }
+              r = bignum_div(rs, ab, bb); break;
+    case 'r': if (bignum_is_zero(bb)) { vm->error = 1; return; }
+              r = bignum_mod(rs, ab, bb); break;
+    case 'm': {
+        /* R7RS modulo: result carries the sign of the divisor. bignum_mod
+         * returns the truncated remainder (sign of the dividend), so adjust
+         * by adding the divisor when the signs disagree. */
+        if (bignum_is_zero(bb)) { vm->error = 1; return; }
+        r = bignum_mod(rs, ab, bb);
+        if (r && !bignum_is_zero(r) && bignum_sign(r) != bignum_sign(bb))
+            r = bignum_add(rs, r, bb);
+        break;
+    }
+    default: vm->error = 1; return;
+    }
+    vm_push_bignum_norm(vm, r);
+}
+
+/** @brief Three-way compare of two integer-ish values through the bignum
+ *         domain (-1/0/1). A float operand compares via double. */
+static int vm_bignum_compare_vals(VM* vm, Value a, Value b) {
+    if (a.type == VAL_FLOAT || b.type == VAL_FLOAT) {
+        double x = (a.type == VAL_BIGNUM)
+            ? bignum_to_double((VmBignum*)vm->heap.objects[a.as.ptr]->opaque.ptr)
+            : as_number(a);
+        double y = (b.type == VAL_BIGNUM)
+            ? bignum_to_double((VmBignum*)vm->heap.objects[b.as.ptr]->opaque.ptr)
+            : as_number(b);
+        return (x < y) ? -1 : (x > y) ? 1 : 0;
+    }
+    VmBignum* ab = vm_coerce_bignum(vm, a);
+    VmBignum* bb = vm_coerce_bignum(vm, b);
+    if (!ab || !bb) return 0;
+    return bignum_compare(ab, bb);
+}
+
 static void vm_dispatch_native(VM* vm, int fid) {
     vm_timers_poll_due(vm);
     if (fid >= ESHKOL_VM_HOST_NATIVE_BASE) {
@@ -4702,20 +4807,27 @@ static void vm_dispatch_native(VM* vm, int fid) {
             }
         }
         vm_push(vm, FLOAT_VAL(pow(as_number(a), as_number(b)))); break; }
-    case 33: { Value b = vm_pop(vm); Value a = vm_pop(vm); double da=as_number_vm(vm,a),db=as_number_vm(vm,b); vm_push(vm, number_val(da<db?da:db)); break; }
-    case 34: { Value b = vm_pop(vm); Value a = vm_pop(vm); double da=as_number_vm(vm,a),db=as_number_vm(vm,b); vm_push(vm, number_val(da>db?da:db)); break; }
+    case 33: { Value b = vm_pop(vm); Value a = vm_pop(vm);
+        if (vm_either_bignum(a,b)) { vm_push(vm, vm_bignum_compare_vals(vm,a,b) <= 0 ? a : b); break; }
+        double da=as_number_vm(vm,a),db=as_number_vm(vm,b); vm_push(vm, number_val(da<db?da:db)); break; }
+    case 34: { Value b = vm_pop(vm); Value a = vm_pop(vm);
+        if (vm_either_bignum(a,b)) { vm_push(vm, vm_bignum_compare_vals(vm,a,b) >= 0 ? a : b); break; }
+        double da=as_number_vm(vm,a),db=as_number_vm(vm,b); vm_push(vm, number_val(da>db?da:db)); break; }
     case 35: { Value a = vm_pop(vm); if (a.type==VAL_DUAL) { vm_push(vm,a); vm_dispatch_native(vm,383); } else vm_push(vm, number_val(fabs(as_number(a)))); break; }
     /* modulo, remainder, quotient — first-class closure versions */
     case 36: { Value b = vm_pop(vm); Value a = vm_pop(vm);
+        if (vm_either_bignum(a,b)) { vm_bignum_arith(vm,a,b,'m'); break; }
         int64_t ia=(int64_t)as_number(a), ib=(int64_t)as_number(b);
         if (ib==0){vm->error=1;break;}
         int64_t r=ia%ib; if(r!=0&&((r^ib)<0)) r+=ib;
         vm_push(vm, INT_VAL(r)); break; }
     case 37: { Value b = vm_pop(vm); Value a = vm_pop(vm);
+        if (vm_either_bignum(a,b)) { vm_bignum_arith(vm,a,b,'r'); break; }
         int64_t ia=(int64_t)as_number(a), ib=(int64_t)as_number(b);
         if (ib==0){vm->error=1;break;}
         vm_push(vm, INT_VAL(ia%ib)); break; }
     case 38: { Value b = vm_pop(vm); Value a = vm_pop(vm);
+        if (vm_either_bignum(a,b)) { vm_bignum_arith(vm,a,b,'q'); break; }
         int64_t ia=(int64_t)as_number(a), ib=(int64_t)as_number(b);
         if (ib==0){vm->error=1;break;}
         vm_push(vm, INT_VAL(ia/ib)); break; }
@@ -10083,6 +10195,9 @@ static void vm_dispatch_native(VM* vm, int fid) {
             int32_t p = heap_alloc(&vm->heap); if (p < 0) { vm->error = 1; break; }
             vm->heap.objects[p]->type = HEAP_COMPLEX; vm->heap.objects[p]->opaque.ptr = r;
             vm_push(vm, (Value){.type = VAL_COMPLEX, .as.ptr = p});
+        } else if (vm_either_bignum(a_val,b_val)) { vm_bignum_arith(vm,a_val,b_val,'+'); }
+        else if (a_val.type==VAL_INT && b_val.type==VAL_INT) {
+            int64_t r; if (__builtin_add_overflow(a_val.as.i,b_val.as.i,&r)) vm_bignum_arith(vm,a_val,b_val,'+'); else vm_push(vm, INT_VAL(r));
         } else { vm_push(vm, number_val(as_number(a_val) + as_number(b_val))); }
         break; }
     case 143: { /* sub2 — complex-aware */
@@ -10096,6 +10211,9 @@ static void vm_dispatch_native(VM* vm, int fid) {
             int32_t p = heap_alloc(&vm->heap); if (p < 0) { vm->error = 1; break; }
             vm->heap.objects[p]->type = HEAP_COMPLEX; vm->heap.objects[p]->opaque.ptr = r;
             vm_push(vm, (Value){.type = VAL_COMPLEX, .as.ptr = p});
+        } else if (vm_either_bignum(a_val,b_val)) { vm_bignum_arith(vm,a_val,b_val,'-'); }
+        else if (a_val.type==VAL_INT && b_val.type==VAL_INT) {
+            int64_t r; if (__builtin_sub_overflow(a_val.as.i,b_val.as.i,&r)) vm_bignum_arith(vm,a_val,b_val,'-'); else vm_push(vm, INT_VAL(r));
         } else { vm_push(vm, number_val(as_number(a_val) - as_number(b_val))); }
         break; }
     case 144: { /* mul2 — complex-aware */
@@ -10109,6 +10227,9 @@ static void vm_dispatch_native(VM* vm, int fid) {
             int32_t p = heap_alloc(&vm->heap); if (p < 0) { vm->error = 1; break; }
             vm->heap.objects[p]->type = HEAP_COMPLEX; vm->heap.objects[p]->opaque.ptr = r;
             vm_push(vm, (Value){.type = VAL_COMPLEX, .as.ptr = p});
+        } else if (vm_either_bignum(a_val,b_val)) { vm_bignum_arith(vm,a_val,b_val,'*'); }
+        else if (a_val.type==VAL_INT && b_val.type==VAL_INT) {
+            int64_t r; if (__builtin_mul_overflow(a_val.as.i,b_val.as.i,&r)) vm_bignum_arith(vm,a_val,b_val,'*'); else vm_push(vm, INT_VAL(r));
         } else { vm_push(vm, number_val(as_number(a_val) * as_number(b_val))); }
         break; }
     case 145: { /* div2 — complex- and rational-aware.
@@ -10133,11 +10254,11 @@ static void vm_dispatch_native(VM* vm, int fid) {
         } else { vm_push(vm, number_val(as_number(a_val) / as_number(b_val))); }
         break; }
     /* Comparison operators as first-class functions (for sort, map, fold, etc.) */
-    case 146: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL(as_number(a) < as_number(b))); break; }  /* < */
-    case 147: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL(as_number(a) > as_number(b))); break; }  /* > */
-    case 148: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL(as_number(a) <= as_number(b))); break; } /* <= */
-    case 149: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL(as_number(a) >= as_number(b))); break; } /* >= */
-    case 150: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL(as_number(a) == as_number(b))); break; } /* = */
+    case 146: { Value b = vm_pop(vm), a = vm_pop(vm); if (vm_either_bignum(a,b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm,a,b) <  0)); break; } vm_push(vm, BOOL_VAL(as_number(a) < as_number(b))); break; }  /* < */
+    case 147: { Value b = vm_pop(vm), a = vm_pop(vm); if (vm_either_bignum(a,b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm,a,b) >  0)); break; } vm_push(vm, BOOL_VAL(as_number(a) > as_number(b))); break; }  /* > */
+    case 148: { Value b = vm_pop(vm), a = vm_pop(vm); if (vm_either_bignum(a,b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm,a,b) <= 0)); break; } vm_push(vm, BOOL_VAL(as_number(a) <= as_number(b))); break; } /* <= */
+    case 149: { Value b = vm_pop(vm), a = vm_pop(vm); if (vm_either_bignum(a,b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm,a,b) >= 0)); break; } vm_push(vm, BOOL_VAL(as_number(a) >= as_number(b))); break; } /* >= */
+    case 150: { Value b = vm_pop(vm), a = vm_pop(vm); if (vm_either_bignum(a,b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm,a,b) == 0)); break; } vm_push(vm, BOOL_VAL(as_number(a) == as_number(b))); break; } /* = */
 
     /* Core operations as first-class native functions (IDs 200-226) */
     case 200: { Value a = vm_pop(vm); /* car */

--- a/lib/backend/vm_parser.c
+++ b/lib/backend/vm_parser.c
@@ -18,6 +18,10 @@ typedef struct Node {
     int n_children;
     int is_char;      /* N_NUMBER node that originated from a #\ character literal */
     int is_inexact;   /* N_NUMBER literal written in inexact (float) syntax: 2.0, 1e3 */
+    int is_int;       /* N_NUMBER exact integer literal that fits int64 (ival holds it) */
+    int64_t ival;     /* exact int64 value when is_int; avoids the precision loss of
+                       * routing large integer literals (up to INT64_MAX) through the
+                       * double numval field. */
 } Node;
 
 /* Hygienic macro expansion (syntax-rules).
@@ -510,12 +514,26 @@ static Node* parse_sexp(void) {
             return div_node;
         }
         buf[i] = 0;
-        Node* n = make_node(N_NUMBER); if (!n) return NULL; n->numval = atof(buf);
+        Node* n = make_node(N_NUMBER); if (!n) return NULL;
         /* Inexact syntax (a decimal point or exponent) must stay inexact even
          * when the value is integral (2.0, 1e3), so downstream codegen emits a
          * float rather than an exact int. Without this the VM collapsed 2.0 to
          * exact 2, and (/ 7 2.0) then produced the rational 7/2 instead of 3.5. */
-        for (int k = 0; buf[k]; k++) if (buf[k] == '.' || buf[k] == 'e' || buf[k] == 'E') { n->is_inexact = 1; break; }
+        int inexact_syntax = 0;
+        for (int k = 0; buf[k]; k++) if (buf[k] == '.' || buf[k] == 'e' || buf[k] == 'E') { inexact_syntax = 1; break; }
+        if (!inexact_syntax) {
+            /* Pure integer token: preserve the exact int64 value (up to
+             * INT64_MAX) rather than round-tripping through a double, which
+             * loses precision above 2^53 and made e.g. 9223372036854775807
+             * come out inexact on the VM path. On int64 overflow fall back to
+             * the inexact double (matching the pre-existing behaviour). */
+            errno = 0;
+            char* endp = NULL;
+            long long iv = strtoll(buf, &endp, 10);
+            if (errno == 0 && endp && *endp == '\0') { n->is_int = 1; n->ival = (int64_t)iv; n->numval = (double)iv; return n; }
+        }
+        n->numval = atof(buf);
+        n->is_inexact = inexact_syntax;
         return n;
     }
     /* Symbol */
@@ -860,7 +878,9 @@ static void compile_quote(FuncChunk* c, Node* datum) {
     if (!datum) { chunk_emit(c, OP_NIL, 0); return; }
     if (datum->type == N_NUMBER) {
         double v = datum->numval;
-        if (v == (int64_t)v && fabs(v) < 1e15)
+        if (datum->is_int)
+            chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL(datum->ival)));
+        else if (v == (int64_t)v && fabs(v) < 1e15)
             chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL((int64_t)v)));
         else
             chunk_emit(c, OP_CONST, chunk_add_const(c, FLOAT_VAL(v)));

--- a/lib/backend/vm_run.c
+++ b/lib/backend/vm_run.c
@@ -155,6 +155,9 @@ void vm_run(VM* vm) {
         else if (a.type == VAL_DUAL || b.type == VAL_DUAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 373); }
         else if (a.type == VAL_RATIONAL || b.type == VAL_RATIONAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 331); }
         else if (a.type == VAL_COMPLEX || b.type == VAL_COMPLEX) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 307); }
+        else if (vm_either_bignum(a, b)) { vm->ad_node_map[vm->sp] = -1; vm_bignum_arith(vm, a, b, '+'); }
+        else if (a.type == VAL_INT && b.type == VAL_INT) { int64_t r; VM_AD_BINARY(vm, a_sp, b_sp, ad_add, 0);
+            if (__builtin_add_overflow(a.as.i, b.as.i, &r)) vm_bignum_arith(vm, a, b, '+'); else vm_push(vm, INT_VAL(r)); }
         else { VM_AD_BINARY(vm, a_sp, b_sp, ad_add, 0); vm_push(vm, number_val(as_number(a) + as_number(b))); } DISPATCH(); }
     lbl_SUB: { int b_sp = vm->sp - 1, a_sp = vm->sp - 2;
         Value b = vm_pop(vm), a = vm_pop(vm);
@@ -162,6 +165,9 @@ void vm_run(VM* vm) {
         else if (a.type == VAL_DUAL || b.type == VAL_DUAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 374); }
         else if (a.type == VAL_RATIONAL || b.type == VAL_RATIONAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 332); }
         else if (a.type == VAL_COMPLEX || b.type == VAL_COMPLEX) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 308); }
+        else if (vm_either_bignum(a, b)) { vm->ad_node_map[vm->sp] = -1; vm_bignum_arith(vm, a, b, '-'); }
+        else if (a.type == VAL_INT && b.type == VAL_INT) { int64_t r; VM_AD_BINARY(vm, a_sp, b_sp, ad_sub, 0);
+            if (__builtin_sub_overflow(a.as.i, b.as.i, &r)) vm_bignum_arith(vm, a, b, '-'); else vm_push(vm, INT_VAL(r)); }
         else { VM_AD_BINARY(vm, a_sp, b_sp, ad_sub, 0); vm_push(vm, number_val(as_number(a) - as_number(b))); } DISPATCH(); }
     lbl_MUL: { int b_sp = vm->sp - 1, a_sp = vm->sp - 2;
         Value b = vm_pop(vm), a = vm_pop(vm);
@@ -169,6 +175,9 @@ void vm_run(VM* vm) {
         else if (a.type == VAL_DUAL || b.type == VAL_DUAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 375); }
         else if (a.type == VAL_RATIONAL || b.type == VAL_RATIONAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 333); }
         else if (a.type == VAL_COMPLEX || b.type == VAL_COMPLEX) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 309); }
+        else if (vm_either_bignum(a, b)) { vm->ad_node_map[vm->sp] = -1; vm_bignum_arith(vm, a, b, '*'); }
+        else if (a.type == VAL_INT && b.type == VAL_INT) { int64_t r; VM_AD_BINARY(vm, a_sp, b_sp, ad_mul, 0);
+            if (__builtin_mul_overflow(a.as.i, b.as.i, &r)) vm_bignum_arith(vm, a, b, '*'); else vm_push(vm, INT_VAL(r)); }
         else { VM_AD_BINARY(vm, a_sp, b_sp, ad_mul, 0); vm_push(vm, number_val(as_number(a) * as_number(b))); } DISPATCH(); }
     lbl_DIV: { int b_sp = vm->sp - 1, a_sp = vm->sp - 2;
         Value b = vm_pop(vm), a = vm_pop(vm);
@@ -190,6 +199,12 @@ void vm_run(VM* vm) {
         VM_AD_BINARY(vm, a_sp, b_sp, ad_div, 0); vm_push(vm, number_val(as_number(a) / bd)); } DISPATCH(); }
     lbl_MOD: {
         Value b = vm_pop(vm), a = vm_pop(vm);
+        if (vm_either_bignum(a, b)) { vm->ad_node_map[vm->sp] = -1; vm_bignum_arith(vm, a, b, 'm'); DISPATCH(); }
+        if (a.type == VAL_INT && b.type == VAL_INT) {
+            if (b.as.i == 0) { fprintf(stderr, "MODULO BY ZERO\n"); vm->error = 1; goto vm_exit; }
+            int64_t r = a.as.i % b.as.i; if (r != 0 && ((r ^ b.as.i) < 0)) r += b.as.i;
+            vm_push(vm, INT_VAL(r)); DISPATCH();
+        }
         double bd = as_number(b);
         if (bd == 0) { fprintf(stderr, "MODULO BY ZERO\n"); vm->error = 1; goto vm_exit; }
         double r = fmod(as_number(a), bd);
@@ -208,11 +223,26 @@ void vm_run(VM* vm) {
 
     /* --- Comparison --- */
 
-    lbl_EQ: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL(as_number_vm(vm, a) == as_number_vm(vm, b))); DISPATCH(); }
-    lbl_LT: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL(as_number_vm(vm, a) <  as_number_vm(vm, b))); DISPATCH(); }
-    lbl_GT: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL(as_number_vm(vm, a) >  as_number_vm(vm, b))); DISPATCH(); }
-    lbl_LE: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL(as_number_vm(vm, a) <= as_number_vm(vm, b))); DISPATCH(); }
-    lbl_GE: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL(as_number_vm(vm, a) >= as_number_vm(vm, b))); DISPATCH(); }
+    lbl_EQ: { Value b = vm_pop(vm), a = vm_pop(vm);
+        if (vm_either_bignum(a, b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm, a, b) == 0)); DISPATCH(); }
+        if (a.type == VAL_INT && b.type == VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i == b.as.i)); DISPATCH(); }
+        vm_push(vm, BOOL_VAL(as_number_vm(vm, a) == as_number_vm(vm, b))); DISPATCH(); }
+    lbl_LT: { Value b = vm_pop(vm), a = vm_pop(vm);
+        if (vm_either_bignum(a, b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm, a, b) <  0)); DISPATCH(); }
+        if (a.type == VAL_INT && b.type == VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i <  b.as.i)); DISPATCH(); }
+        vm_push(vm, BOOL_VAL(as_number_vm(vm, a) <  as_number_vm(vm, b))); DISPATCH(); }
+    lbl_GT: { Value b = vm_pop(vm), a = vm_pop(vm);
+        if (vm_either_bignum(a, b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm, a, b) >  0)); DISPATCH(); }
+        if (a.type == VAL_INT && b.type == VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i >  b.as.i)); DISPATCH(); }
+        vm_push(vm, BOOL_VAL(as_number_vm(vm, a) >  as_number_vm(vm, b))); DISPATCH(); }
+    lbl_LE: { Value b = vm_pop(vm), a = vm_pop(vm);
+        if (vm_either_bignum(a, b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm, a, b) <= 0)); DISPATCH(); }
+        if (a.type == VAL_INT && b.type == VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i <= b.as.i)); DISPATCH(); }
+        vm_push(vm, BOOL_VAL(as_number_vm(vm, a) <= as_number_vm(vm, b))); DISPATCH(); }
+    lbl_GE: { Value b = vm_pop(vm), a = vm_pop(vm);
+        if (vm_either_bignum(a, b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm, a, b) >= 0)); DISPATCH(); }
+        if (a.type == VAL_INT && b.type == VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i >= b.as.i)); DISPATCH(); }
+        vm_push(vm, BOOL_VAL(as_number_vm(vm, a) >= as_number_vm(vm, b))); DISPATCH(); }
     lbl_NOT: { Value a = vm_pop(vm); vm_push(vm, BOOL_VAL(!is_truthy(a))); DISPATCH(); }
 
     /* --- Variables --- */
@@ -726,18 +756,24 @@ vm_exit:
             else if (a.type==VAL_DUAL||b.type==VAL_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,373); }
             else if (a.type==VAL_RATIONAL||b.type==VAL_RATIONAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,331); }
             else if (a.type==VAL_COMPLEX||b.type==VAL_COMPLEX) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,307); }
+            else if (vm_either_bignum(a,b)) vm_bignum_arith(vm,a,b,'+');
+            else if (a.type==VAL_INT && b.type==VAL_INT) { int64_t r; if (__builtin_add_overflow(a.as.i,b.as.i,&r)) vm_bignum_arith(vm,a,b,'+'); else vm_push(vm, INT_VAL(r)); }
             else vm_push(vm, number_val(as_number(a) + as_number(b))); break; }
         case OP_SUB: { Value b = vm_pop(vm), a = vm_pop(vm);
             if (a.type==VAL_HYPER_DUAL||b.type==VAL_HYPER_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,1906); }
             else if (a.type==VAL_DUAL||b.type==VAL_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,374); }
             else if (a.type==VAL_RATIONAL||b.type==VAL_RATIONAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,332); }
             else if (a.type==VAL_COMPLEX||b.type==VAL_COMPLEX) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,308); }
+            else if (vm_either_bignum(a,b)) vm_bignum_arith(vm,a,b,'-');
+            else if (a.type==VAL_INT && b.type==VAL_INT) { int64_t r; if (__builtin_sub_overflow(a.as.i,b.as.i,&r)) vm_bignum_arith(vm,a,b,'-'); else vm_push(vm, INT_VAL(r)); }
             else vm_push(vm, number_val(as_number(a) - as_number(b))); break; }
         case OP_MUL: { Value b = vm_pop(vm), a = vm_pop(vm);
             if (a.type==VAL_HYPER_DUAL||b.type==VAL_HYPER_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,1907); }
             else if (a.type==VAL_DUAL||b.type==VAL_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,375); }
             else if (a.type==VAL_RATIONAL||b.type==VAL_RATIONAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,333); }
             else if (a.type==VAL_COMPLEX||b.type==VAL_COMPLEX) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,309); }
+            else if (vm_either_bignum(a,b)) vm_bignum_arith(vm,a,b,'*');
+            else if (a.type==VAL_INT && b.type==VAL_INT) { int64_t r; if (__builtin_mul_overflow(a.as.i,b.as.i,&r)) vm_bignum_arith(vm,a,b,'*'); else vm_push(vm, INT_VAL(r)); }
             else vm_push(vm, number_val(as_number(a) * as_number(b))); break; }
         case OP_DIV: { Value b = vm_pop(vm), a = vm_pop(vm);
             if (a.type==VAL_HYPER_DUAL||b.type==VAL_HYPER_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,1908); }
@@ -757,6 +793,12 @@ vm_exit:
             vm_push(vm, number_val(as_number(a) / bd)); } break; }
         case OP_MOD: {
             Value b = vm_pop(vm), a = vm_pop(vm);
+            if (vm_either_bignum(a, b)) { vm_bignum_arith(vm, a, b, 'm'); break; }
+            if (a.type == VAL_INT && b.type == VAL_INT) {
+                if (b.as.i == 0) { fprintf(stderr, "MODULO BY ZERO\n"); vm->error = 1; break; }
+                int64_t r = a.as.i % b.as.i; if (r != 0 && ((r ^ b.as.i) < 0)) r += b.as.i;
+                vm_push(vm, INT_VAL(r)); break;
+            }
             double bd = as_number(b);
             if (bd == 0) { fprintf(stderr, "MODULO BY ZERO\n"); vm->error = 1; break; }
             double r = fmod(as_number(a), bd);
@@ -768,11 +810,26 @@ vm_exit:
         case OP_ABS: { Value a = vm_pop(vm); vm_push(vm, number_val(fabs(as_number(a)))); break; }
 
         /* Comparison — push proper booleans */
-        case OP_EQ: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL(as_number(a) == as_number(b))); break; }
-        case OP_LT: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL(as_number(a) < as_number(b))); break; }
-        case OP_GT: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL(as_number(a) > as_number(b))); break; }
-        case OP_LE: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL(as_number(a) <= as_number(b))); break; }
-        case OP_GE: { Value b = vm_pop(vm), a = vm_pop(vm); vm_push(vm, BOOL_VAL(as_number(a) >= as_number(b))); break; }
+        case OP_EQ: { Value b = vm_pop(vm), a = vm_pop(vm);
+            if (vm_either_bignum(a,b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm,a,b) == 0)); break; }
+            if (a.type==VAL_INT && b.type==VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i == b.as.i)); break; }
+            vm_push(vm, BOOL_VAL(as_number(a) == as_number(b))); break; }
+        case OP_LT: { Value b = vm_pop(vm), a = vm_pop(vm);
+            if (vm_either_bignum(a,b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm,a,b) <  0)); break; }
+            if (a.type==VAL_INT && b.type==VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i <  b.as.i)); break; }
+            vm_push(vm, BOOL_VAL(as_number(a) <  as_number(b))); break; }
+        case OP_GT: { Value b = vm_pop(vm), a = vm_pop(vm);
+            if (vm_either_bignum(a,b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm,a,b) >  0)); break; }
+            if (a.type==VAL_INT && b.type==VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i >  b.as.i)); break; }
+            vm_push(vm, BOOL_VAL(as_number(a) >  as_number(b))); break; }
+        case OP_LE: { Value b = vm_pop(vm), a = vm_pop(vm);
+            if (vm_either_bignum(a,b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm,a,b) <= 0)); break; }
+            if (a.type==VAL_INT && b.type==VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i <= b.as.i)); break; }
+            vm_push(vm, BOOL_VAL(as_number(a) <= as_number(b))); break; }
+        case OP_GE: { Value b = vm_pop(vm), a = vm_pop(vm);
+            if (vm_either_bignum(a,b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm,a,b) >= 0)); break; }
+            if (a.type==VAL_INT && b.type==VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i >= b.as.i)); break; }
+            vm_push(vm, BOOL_VAL(as_number(a) >= as_number(b))); break; }
         case OP_NOT: { Value a = vm_pop(vm); vm_push(vm, BOOL_VAL(!is_truthy(a))); break; }
 
         /* Variables */

--- a/lib/backend/vm_run.c
+++ b/lib/backend/vm_run.c
@@ -215,10 +215,18 @@ void vm_run(VM* vm) {
     lbl_NEG: { int a_sp = vm->sp - 1; Value a = vm_pop(vm);
         if (a.type == VAL_HYPER_DUAL) { vm_push(vm, a); vm_dispatch_native(vm, 1909); }
         else if (a.type == VAL_DUAL) { vm_push(vm, a); vm_dispatch_native(vm, 384); }
+        else if (a.type == VAL_BIGNUM) { vm->ad_node_map[vm->sp] = -1; vm_push_bignum_norm(vm, bignum_neg(&vm->heap.regions, (VmBignum*)vm->heap.objects[a.as.ptr]->opaque.ptr)); }
+        else if (a.type == VAL_INT) { VM_AD_UNARY(vm, a_sp, ad_neg);
+            if (a.as.i == INT64_MIN) vm_push_bignum_norm(vm, bignum_neg(&vm->heap.regions, bignum_from_int64(&vm->heap.regions, a.as.i)));
+            else vm_push(vm, INT_VAL(-a.as.i)); }
         else { VM_AD_UNARY(vm, a_sp, ad_neg); vm_push(vm, number_val(-as_number(a))); } DISPATCH(); }
     lbl_ABS: { int a_sp = vm->sp - 1; Value a = vm_pop(vm);
         if (a.type == VAL_HYPER_DUAL) { vm_push(vm, a); vm_dispatch_native(vm, 1916); }
         else if (a.type == VAL_DUAL) { vm_push(vm, a); vm_dispatch_native(vm, 383); }
+        else if (a.type == VAL_BIGNUM) { vm->ad_node_map[vm->sp] = -1; vm_push_bignum_norm(vm, bignum_abs_val(&vm->heap.regions, (VmBignum*)vm->heap.objects[a.as.ptr]->opaque.ptr)); }
+        else if (a.type == VAL_INT) { VM_AD_UNARY(vm, a_sp, ad_abs);
+            if (a.as.i == INT64_MIN) vm_push_bignum_norm(vm, bignum_abs_val(&vm->heap.regions, bignum_from_int64(&vm->heap.regions, a.as.i)));
+            else vm_push(vm, INT_VAL(a.as.i < 0 ? -a.as.i : a.as.i)); }
         else { VM_AD_UNARY(vm, a_sp, ad_abs); vm_push(vm, number_val(fabs(as_number(a)))); } DISPATCH(); }
 
     /* --- Comparison --- */
@@ -806,8 +814,16 @@ vm_exit:
             vm_push(vm, number_val(r));
             break;
         }
-        case OP_NEG: { Value a = vm_pop(vm); vm_push(vm, number_val(-as_number(a))); break; }
-        case OP_ABS: { Value a = vm_pop(vm); vm_push(vm, number_val(fabs(as_number(a)))); break; }
+        case OP_NEG: { Value a = vm_pop(vm);
+            if (a.type == VAL_BIGNUM) { vm_push_bignum_norm(vm, bignum_neg(&vm->heap.regions, (VmBignum*)vm->heap.objects[a.as.ptr]->opaque.ptr)); break; }
+            if (a.type == VAL_INT && a.as.i != INT64_MIN) { vm_push(vm, INT_VAL(-a.as.i)); break; }
+            if (a.type == VAL_INT) { vm_push_bignum_norm(vm, bignum_neg(&vm->heap.regions, bignum_from_int64(&vm->heap.regions, a.as.i))); break; }
+            vm_push(vm, number_val(-as_number(a))); break; }
+        case OP_ABS: { Value a = vm_pop(vm);
+            if (a.type == VAL_BIGNUM) { vm_push_bignum_norm(vm, bignum_abs_val(&vm->heap.regions, (VmBignum*)vm->heap.objects[a.as.ptr]->opaque.ptr)); break; }
+            if (a.type == VAL_INT && a.as.i != INT64_MIN) { vm_push(vm, INT_VAL(a.as.i < 0 ? -a.as.i : a.as.i)); break; }
+            if (a.type == VAL_INT) { vm_push_bignum_norm(vm, bignum_abs_val(&vm->heap.regions, bignum_from_int64(&vm->heap.regions, a.as.i))); break; }
+            vm_push(vm, number_val(fabs(as_number(a)))); break; }
 
         /* Comparison — push proper booleans */
         case OP_EQ: { Value b = vm_pop(vm), a = vm_pop(vm);

--- a/tests/vm/vm_bignum_arithmetic_test.esk
+++ b/tests/vm/vm_bignum_arithmetic_test.esk
@@ -1,0 +1,61 @@
+; vm_bignum_arithmetic_test.esk
+;
+; Regression coverage for a silent VM bignum-arithmetic miscompile exposed by
+; the generative multi-oracle differential harness (P7c). The bytecode VM's
+; core arithmetic/comparison opcodes and native builtins coerced operands
+; through as_number(), which returns 0.0 for a VAL_BIGNUM. Any expression whose
+; exact result overflowed int64 therefore silently produced a wrong small value
+; on the VM path (e.g. (+ (expt 7 41) 13) printed 13), while the
+; native/JIT/AOT/chibi paths stayed correct.
+;
+; Each line below prints the value the reference path produces; run under the
+; VM it must now print the SAME value.
+;
+; Expected output (one per line):
+;   44567640326363195900190045974568020
+;   999999999999999999999999999999
+;   340282366920938463463374607431768211456
+;   1
+;   -1
+;   1428571428571428571428571428571428571428
+;   1267650600228229401496703205376
+;   5
+;   #t
+;   #t
+;   #t
+;   18446744073709551614
+;   9223372036854775808
+;   2
+;   1267650600228229401496703205376
+
+; Addition/subtraction that overflow int64 -> exact bignum.
+(display (+ (expt 7 41) 13)) (newline)
+(display (- (expt 10 30) 1)) (newline)
+
+; Multiplication of two bignums.
+(display (* (expt 2 64) (expt 2 64))) (newline)
+
+; modulo/remainder/quotient over bignums, with R7RS signs (modulo carries the
+; sign of the divisor, remainder the sign of the dividend).
+(display (modulo (expt 10 26) 3)) (newline)
+(display (remainder (- (expt 10 26)) 3)) (newline)
+(display (quotient (expt 10 40) 7)) (newline)
+
+; min/max preserve the exact bignum operand.
+(display (max (expt 2 100) 5)) (newline)
+(display (min (expt 2 100) 5)) (newline)
+
+; Comparisons and equality across the bignum boundary.
+(display (< (expt 2 100) (expt 2 101))) (newline)
+(display (= (expt 2 64) (expt 2 64))) (newline)
+(display (eqv? (- (expt 7 41) (expt 7 41)) 0)) (newline)
+
+; int64-overflow literals promote to bignum instead of wrapping / going inexact.
+(display (* 9223372036854775807 2)) (newline)
+(display (+ 9223372036854775807 1)) (newline)
+
+; Negated-bignum modulo (exercises bignum-aware OP_NEG feeding OP_MOD).
+(display (modulo (- (expt 10 26)) 3)) (newline)
+
+; Bignum display round-trip.
+(display (expt 2 100)) (newline)


### PR DESCRIPTION
## Summary

Fixes a silent-wrong VM bignum-arithmetic bug exposed by the generative
differential engine (P7c). The bytecode VM's core arithmetic/comparison
opcodes and native builtins coerced operands through `as_number()`, which
returns `0.0` for a `VAL_BIGNUM`. Any expression whose exact result
overflowed int64 therefore silently produced a wrong small value on the VM
path, while the native/JIT/AOT/chibi paths stayed correct:

| expression | VM (before) | native / correct |
| --- | --- | --- |
| `(+ (expt 7 41) 13)` | `13` | `44567640326363195900190045974568020` |
| `(modulo (expt 10 26) 3)` | `0` | `1` |

## Root cause and fix

`as_number(bignum)` returns 0 in the VM, so bignum operands were treated as 0.
The bignum primitives already exist (`lib/backend/vm_bignum.c`); this PR wires
the arithmetic ops to be bignum-aware.

**Helpers** (`lib/backend/vm_native.c`): `vm_either_bignum`, `vm_coerce_bignum`,
`vm_push_bignum_norm` (demotes back to a fixnum when the result fits int64),
`vm_bignum_arith` (`+ - * quotient remainder modulo`, with R7RS-correct modulo
sign vs remainder for mixed signs) and `vm_bignum_compare_vals`.

**Ops wired** — bignum branches plus int64-overflow promotion
(`__builtin_{add,sub,mul}_overflow`) in:

- `vm_run.c` `OP_ADD/SUB/MUL/MOD`, `OP_NEG/OP_ABS` and `OP_EQ/LT/GT/LE/GE`,
  in **both** the computed-goto and the switch-fallback dispatch paths (the
  switch path is dead on GCC/Clang but kept correct for portability);
- native builtins `min/max` (33/34), `abs` (35),
  `modulo/remainder/quotient` (36/37/38), `add2/sub2/mul2` (142/143/144)
  and comparisons (146-150).

**Exactness of large results** — int64 results that exceed the old lossy
`number_val` `<1e15` demotion now stay exact via `INT_VAL`, and equality /
quotient / modulo demote a bignum result back to a fixnum when it fits int64.

**Exact large-integer literals** — the VM parser stored every literal in a
`double`, so an exact integer above 2^53 (e.g. `9223372036854775807`) became
inexact. Pure-integer tokens up to `INT64_MAX` now preserve their exact int64
(`Node.is_int/ival`), and compile-time constant folding of `+,-,*` over integer
literals folds in int64 with overflow detection — on overflow it leaves the
expression to the runtime ops (which promote to bignum) instead of collapsing
to a lossy double.

## Verification

- **14-program bignum sweep** matches the native/JIT answer exactly (including
  `(remainder (- (expt 10 26)) 3)` R7RS sign, `(* 9223372036854775807 2)` and
  `(+ 9223372036854775807 1)` int64-overflow promotion).
- **Generative differential** `--smoke` and `--seed 1234 --count 60`:
  **0 divergences** (120 programs checked) — previously flagged the bignum one.
- **`run_vm_parity.sh`**: green modulo the 3 known pre-existing fails (the
  7-row AD/`parameter?` audit ratchet, and `09_higher_order`'s native
  `_fold-left` link error).
- Ordinary numeric behaviour unchanged: `2.0` inexact, `(/ 1 3) => 1/3`,
  `(/ 6 3) => 2`, `(/ 7 2.0) => 3.5`, `(exact? 2.0) => #f`,
  `(exact? 9223372036854775807) => #t`.
- New regression test `tests/vm/vm_bignum_arithmetic_test.esk`.
