### PR TITLE
fix(codegen): TCO self-tail-calls through cond/case/when/unless/and/or

### DIFF
--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -23509,6 +23509,76 @@ private:
                     }
                     return false;
 
+                case ESHKOL_COND_OP:
+                    // COND_OP uses call_op: each variables[i] is a clause,
+                    // itself a CALL_OP whose func is the test (NOT tail) and
+                    // whose variables are the clause body (implicit begin).
+                    // Only the LAST body expression of each clause inherits
+                    // cond's own tail position; an `else` clause has the same
+                    // shape (func names "else"). Mirrors the tail rules in
+                    // TailCallCodegen::allSelfCallsInTailPosition (COND_OP).
+                    for (uint64_t i = 0; i < op->call_op.num_vars; i++) {
+                        const eshkol_ast_t* clause = &op->call_op.variables[i];
+                        if (clause->type != ESHKOL_OP ||
+                            clause->operation.op != ESHKOL_CALL_OP ||
+                            clause->operation.call_op.num_vars == 0) {
+                            continue;
+                        }
+                        uint64_t last = clause->operation.call_op.num_vars - 1;
+                        if (isInTailPosition(expr,
+                                &clause->operation.call_op.variables[last])) {
+                            return true;
+                        }
+                    }
+                    return false;
+
+                case ESHKOL_CASE_OP:
+                    // CASE_OP uses call_op: func = key (NOT tail),
+                    // variables[i] = clause CONS(car=datums, cdr=body). The
+                    // body is a CALL_OP(func unused, variables=body exprs);
+                    // only its LAST expression inherits case's tail position.
+                    for (uint64_t i = 0; i < op->call_op.num_vars; i++) {
+                        const eshkol_ast_t* clause = &op->call_op.variables[i];
+                        if (clause->type != ESHKOL_CONS || !clause->cons_cell.cdr) {
+                            continue;
+                        }
+                        const eshkol_ast_t* body = clause->cons_cell.cdr;
+                        if (body->type != ESHKOL_OP ||
+                            body->operation.op != ESHKOL_CALL_OP ||
+                            body->operation.call_op.num_vars == 0) {
+                            continue;
+                        }
+                        uint64_t last = body->operation.call_op.num_vars - 1;
+                        if (isInTailPosition(expr,
+                                &body->operation.call_op.variables[last])) {
+                            return true;
+                        }
+                    }
+                    return false;
+
+                case ESHKOL_WHEN_OP:
+                case ESHKOL_UNLESS_OP:
+                    // when/unless use call_op: variables[0] = test (NOT tail),
+                    // variables[1..] = body (implicit begin). Only the LAST
+                    // body expression is in tail position.
+                    if (op->call_op.num_vars > 1) {
+                        return isInTailPosition(expr,
+                            &op->call_op.variables[op->call_op.num_vars - 1]);
+                    }
+                    return false;
+
+                case ESHKOL_AND_OP:
+                case ESHKOL_OR_OP:
+                    // and/or use sequence_op: every operand but the last is a
+                    // (non-tail) short-circuit test; only the LAST operand
+                    // supplies the result and inherits the form's tail position.
+                    if (op->sequence_op.num_expressions > 0) {
+                        return isInTailPosition(expr,
+                            &op->sequence_op.expressions[
+                                op->sequence_op.num_expressions - 1]);
+                    }
+                    return false;
+
                 default:
                     return false;
             }
@@ -23584,6 +23654,59 @@ private:
                     break;
 
                 case ESHKOL_SEQUENCE_OP:
+                    for (uint64_t i = 0; i < op->sequence_op.num_expressions; i++) {
+                        count += countAllRecursiveCalls(&op->sequence_op.expressions[i], func_name);
+                    }
+                    break;
+
+                case ESHKOL_COND_OP:
+                    // Each clause (CALL_OP) has func = test and variables =
+                    // body. Count self-calls in BOTH (tail and non-tail) so the
+                    // total matches findTailCalls' tail-only count only when
+                    // every self-call is genuinely in tail position.
+                    for (uint64_t i = 0; i < op->call_op.num_vars; i++) {
+                        const eshkol_ast_t* clause = &op->call_op.variables[i];
+                        if (clause->type != ESHKOL_OP ||
+                            clause->operation.op != ESHKOL_CALL_OP) {
+                            continue;
+                        }
+                        count += countAllRecursiveCalls(clause->operation.call_op.func, func_name);
+                        for (uint64_t j = 0; j < clause->operation.call_op.num_vars; j++) {
+                            count += countAllRecursiveCalls(
+                                &clause->operation.call_op.variables[j], func_name);
+                        }
+                    }
+                    break;
+
+                case ESHKOL_CASE_OP:
+                    // func = key expression; each clause is CONS(car=datums,
+                    // cdr=body CALL_OP). Datums are quoted literals (no calls);
+                    // count the key and every clause body expression.
+                    count += countAllRecursiveCalls(op->call_op.func, func_name);
+                    for (uint64_t i = 0; i < op->call_op.num_vars; i++) {
+                        const eshkol_ast_t* clause = &op->call_op.variables[i];
+                        if (clause->type != ESHKOL_CONS || !clause->cons_cell.cdr) continue;
+                        const eshkol_ast_t* body = clause->cons_cell.cdr;
+                        if (body->type != ESHKOL_OP ||
+                            body->operation.op != ESHKOL_CALL_OP) continue;
+                        for (uint64_t j = 0; j < body->operation.call_op.num_vars; j++) {
+                            count += countAllRecursiveCalls(
+                                &body->operation.call_op.variables[j], func_name);
+                        }
+                    }
+                    break;
+
+                case ESHKOL_WHEN_OP:
+                case ESHKOL_UNLESS_OP:
+                    // variables[0] = test, variables[1..] = body; count all.
+                    for (uint64_t i = 0; i < op->call_op.num_vars; i++) {
+                        count += countAllRecursiveCalls(&op->call_op.variables[i], func_name);
+                    }
+                    break;
+
+                case ESHKOL_AND_OP:
+                case ESHKOL_OR_OP:
+                    // sequence_op operands; count self-calls in all of them.
                     for (uint64_t i = 0; i < op->sequence_op.num_expressions; i++) {
                         count += countAllRecursiveCalls(&op->sequence_op.expressions[i], func_name);
                     }
@@ -23717,6 +23840,59 @@ private:
                     break;
 
                 case ESHKOL_SEQUENCE_OP:
+                    for (uint64_t i = 0; i < op->sequence_op.num_expressions; i++) {
+                        findTailCalls(&op->sequence_op.expressions[i], body, func_name, tail_calls);
+                    }
+                    break;
+
+                case ESHKOL_COND_OP:
+                    // Walk into every clause's test (func) and body exprs.
+                    // isInTailPosition (now COND-aware) decides which reached
+                    // self-calls actually qualify as tail. Without this case
+                    // the switch fell to `default: break` and no self-call in a
+                    // cond was ever recorded — so isSelfTailRecursive saw
+                    // tail_calls=0 != total>0 and disabled TCO (the exact
+                    // reason the earlier cond/case attempt was a no-op: it
+                    // updated isInTailPosition + countAllRecursiveCalls but
+                    // left THIS function untouched).
+                    for (uint64_t i = 0; i < op->call_op.num_vars; i++) {
+                        const eshkol_ast_t* clause = &op->call_op.variables[i];
+                        if (clause->type != ESHKOL_OP ||
+                            clause->operation.op != ESHKOL_CALL_OP) {
+                            continue;
+                        }
+                        findTailCalls(clause->operation.call_op.func, body, func_name, tail_calls);
+                        for (uint64_t j = 0; j < clause->operation.call_op.num_vars; j++) {
+                            findTailCalls(&clause->operation.call_op.variables[j],
+                                          body, func_name, tail_calls);
+                        }
+                    }
+                    break;
+
+                case ESHKOL_CASE_OP:
+                    findTailCalls(op->call_op.func, body, func_name, tail_calls);
+                    for (uint64_t i = 0; i < op->call_op.num_vars; i++) {
+                        const eshkol_ast_t* clause = &op->call_op.variables[i];
+                        if (clause->type != ESHKOL_CONS || !clause->cons_cell.cdr) continue;
+                        const eshkol_ast_t* body_ast = clause->cons_cell.cdr;
+                        if (body_ast->type != ESHKOL_OP ||
+                            body_ast->operation.op != ESHKOL_CALL_OP) continue;
+                        for (uint64_t j = 0; j < body_ast->operation.call_op.num_vars; j++) {
+                            findTailCalls(&body_ast->operation.call_op.variables[j],
+                                          body, func_name, tail_calls);
+                        }
+                    }
+                    break;
+
+                case ESHKOL_WHEN_OP:
+                case ESHKOL_UNLESS_OP:
+                    for (uint64_t i = 0; i < op->call_op.num_vars; i++) {
+                        findTailCalls(&op->call_op.variables[i], body, func_name, tail_calls);
+                    }
+                    break;
+
+                case ESHKOL_AND_OP:
+                case ESHKOL_OR_OP:
                     for (uint64_t i = 0; i < op->sequence_op.num_expressions; i++) {
                         findTailCalls(&op->sequence_op.expressions[i], body, func_name, tail_calls);
                     }

--- a/tests/tco/cond_case_tail_test.esk
+++ b/tests/tco/cond_case_tail_test.esk
@@ -1,0 +1,60 @@
+;;; Self-tail-recursion through cond/case/when/unless/and/or.
+;;;
+;;; Bug: the backend's tail-position analysis (llvm_codegen.cpp
+;;; isInTailPosition / countAllRecursiveCalls / findTailCalls, which together
+;;; drive isSelfTailRecursive and hence whether a self-recursive define is
+;;; rewritten into a flat loop back-edge) only understood `if`, `begin`, let*,
+;;; sequence and guard. A self-tail-call written with `cond`, `case`, `when`,
+;;; `unless`, or as the last operand of `and`/`or` fell through to the switch
+;;; default, so isSelfTailRecursive reported "no tail recursion" and TCO was
+;;; never enabled. Those loops compiled to genuine per-iteration recursion and
+;;; overflowed the native C stack (SIGBUS) a couple of million iterations in,
+;;; while the identical loop written with `if` looped flat. That `if` worked
+;;; and `cond` did not was the whole bug.
+;;;
+;;; An earlier attempt updated isInTailPosition and countAllRecursiveCalls but
+;;; NOT findTailCalls, so tail_calls.size() (0) still differed from the total
+;;; recursive-call count and TCO stayed disabled -- a complete no-op. This test
+;;; guards against that regression by exercising every affected form.
+;;;
+;;; Each loop runs to 2,000,000 iterations: large enough that a real
+;;; per-iteration stack frame reliably crashes long before the end. Printing
+;;; the expected value (2000000) instead of crashing proves O(1)-stack TCO.
+
+(define N 2000000)
+
+;; cond: self-call in the else clause body
+(define (f-cond i a) (cond ((>= i N) a) (else (f-cond (+ i 1) (+ a 1)))))
+(display "cond:    ")
+(let ((r (f-cond 0 0))) (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; case: self-call in the else clause body
+(define (f-case i a) (case (>= i N) ((#t) a) (else (f-case (+ i 1) (+ a 1)))))
+(display "case:    ")
+(let ((r (f-case 0 0))) (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; when: self-call as the when body (in the else branch of an if)
+(define (f-when i a) (if (>= i N) a (when #t (f-when (+ i 1) (+ a 1)))))
+(display "when:    ")
+(let ((r (f-when 0 0))) (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; unless: self-call as the unless body (in the else branch of an if)
+(define (f-unless i a) (if (>= i N) a (unless #f (f-unless (+ i 1) (+ a 1)))))
+(display "unless:  ")
+(let ((r (f-unless 0 0))) (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; or: self-call as the last operand of or
+(define (f-or i a) (or (and (>= i N) a) (f-or (+ i 1) (+ a 1))))
+(display "or:      ")
+(let ((r (f-or 0 0))) (if (= r N) (display "PASS") (display "FAIL")))
+(newline)
+
+;; and: self-call as the last operand of and (guarded so the loop terminates)
+(define (f-and i a) (if (>= i N) a (and #t (f-and (+ i 1) (+ a 1)))))
+(display "and:     ")
+(let ((r (f-and 0 0))) (if (= r N) (display "PASS") (display "FAIL")))
+(newline)


### PR DESCRIPTION
## Summary

Self-tail-recursion written with `cond`, `case`, `when`, `unless`, or as the last operand of `and`/`or` was **not** tail-call-optimized: those loops grew the native C stack and crashed with SIGBUS/overflow at high iteration counts, while the identical loop written with `if` looped flat. That `if` worked and `cond` did not was the whole bug.

## Root cause

The self-tail-call analysis that decides whether a self-recursive `define` is rewritten into a flat loop back-edge (rather than real per-iteration recursion) lives in three mutually-consistent functions in `lib/backend/llvm_codegen.cpp`:

- `isInTailPosition` — classifies a node as tail within the function body
- `countAllRecursiveCalls` — counts every self-call (tail + non-tail)
- `findTailCalls` — collects only the self-calls in tail position

`isSelfTailRecursive` enables TCO iff `findTailCalls().size() == countAllRecursiveCalls()`. All three only understood `if`/`begin`/`let*`/`sequence`/`guard`. `ESHKOL_COND_OP`, `ESHKOL_CASE_OP`, `ESHKOL_WHEN_OP`, `ESHKOL_UNLESS_OP`, `ESHKOL_AND_OP`, `ESHKOL_OR_OP` fell through the `switch` default, so `countAllRecursiveCalls` returned 0 for a cond body → `isSelfTailRecursive` short-circuited to false → TCO disabled → stack overflow.

The control-flow codegen (`control_flow_codegen.cpp`) was already TCO-ready (it checks `getTerminator()` and erases dead merge blocks when a clause terminates via the back-edge), so **no codegen change was required** once the analysis enables the transform.

### Why the prior attempt was a no-op

An earlier attempt taught `isInTailPosition` and `countAllRecursiveCalls` the new forms but **left `findTailCalls` untouched**. Result: for a cond loop `countAllRecursiveCalls` now returned 1 but `findTailCalls` still hit `default: break` and returned 0, so `0 != 1` kept `all_in_tail` false and TCO stayed disabled — every form still overflowed. This PR fixes all three, `findTailCalls` included.

## IR evidence

Compiling the cond loop and the if loop to LLVM IR, the `f` function is now identical in shape: both branch to a `tco_loop` header with a loop back-edge and emit **zero** recursive `call @f`:

```
cond.ll  f(): recursive 'call @f' = 0   back-edges 'br label %tco_loop' = 2
if.ll    f(): recursive 'call @f' = 0   back-edges 'br label %tco_loop' = 2
```

## Behavioral results (2,000,000 iterations)

| form | before | after (JIT `-r`) | after (AOT `-o`) |
|------|--------|------------------|------------------|
| if      | 2000000 | 2000000 | 2000000 |
| cond    | SIGBUS (exit 138) | 2000000 | 2000000 |
| case    | SIGBUS (exit 138) | 2000000 | 2000000 |
| when    | SIGBUS (exit 138) | 2000000 | 2000000 |
| unless  | SIGBUS | 2000000 | 2000000 |
| and     | SIGBUS | 2000000 | 2000000 |
| or      | SIGBUS (exit 138) | 2000000 | 2000000 |

## Tests

Adds `tests/tco/cond_case_tail_test.esk` asserting all six forms run to 2,000,000 iterations returning the correct value (crash or wrong value = FAIL). All PASS under JIT and AOT.

## Regression gates

- `scripts/run_memory_tests.sh` — 14/14
- `scripts/run_tco_tests.sh` — 5/5
- `scripts/run_autodiff_tests.sh` — 54/54
- `tests/closures/` — all pass (incl. `tco_loop_capture_test`, `closure_set_in_tco_loop_test`)
