### PR TITLE
fix(codegen): out-line numeric-tower dispatch to linearize nested-expr compile (ESH-0103)

### DIFF
--- a/exe/eshkol-run.cpp
+++ b/exe/eshkol-run.cpp
@@ -4517,6 +4517,18 @@ int main(int argc, char **argv)
         }
     }
 
+    // ESH-0103 phase timing (gated on ESHKOL_PHASE_TIME)
+    const bool esh0103_phase_time = (std::getenv("ESHKOL_PHASE_TIME") != nullptr);
+    auto esh0103_now = []() { return std::chrono::steady_clock::now(); };
+    auto esh0103_report = [&](const char* name, std::chrono::steady_clock::time_point a,
+                              std::chrono::steady_clock::time_point b) {
+        if (esh0103_phase_time) {
+            double ms = std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(b - a).count();
+            fprintf(stderr, "[PHASE] %-22s %10.2f ms\n", name, ms);
+        }
+    };
+    auto esh0103_t_own0 = esh0103_now();
+
     // Run ownership analysis before code generation
     if (!asts.empty()) {
         eshkol_info("Running ownership analysis...");
@@ -4530,6 +4542,9 @@ int main(int argc, char **argv)
         }
     }
 
+    auto esh0103_t_own1 = esh0103_now();
+    esh0103_report("ownership", esh0103_t_own0, esh0103_t_own1);
+
     // Run escape analysis for allocation decisions
     if (!asts.empty()) {
         eshkol_info("Running escape analysis...");
@@ -4538,6 +4553,8 @@ int main(int argc, char **argv)
             g_escape_analyzer.printAnalysis();
         }
     }
+    auto esh0103_t_escape1 = esh0103_now();
+    esh0103_report("escape", esh0103_t_own1, esh0103_t_escape1);
 
     // Generate LLVM IR if we have ASTs and need compilation or IR output
     // Default behavior is to compile to executable unless only AST dump is requested
@@ -4596,6 +4613,7 @@ int main(int argc, char **argv)
         }
 
         // Generate LLVM IR (use library mode if --shared-lib flag is set)
+        auto esh0103_t_irgen0 = esh0103_now();
         LLVMModuleRef llvm_module;
         const bool library_codegen = shared_lib || freestanding_native_profile;
         if (library_codegen) {
@@ -4613,6 +4631,9 @@ int main(int argc, char **argv)
             );
         }
         
+        auto esh0103_t_irgen1 = esh0103_now();
+        esh0103_report("irgen", esh0103_t_irgen0, esh0103_t_irgen1);
+
         if (!llvm_module) {
             eshkol_error("Failed to generate LLVM IR");
             return 1;
@@ -4685,11 +4706,13 @@ int main(int argc, char **argv)
             }
 
             eshkol_info("Compiling to object file: %s", obj_filename.c_str());
+            auto esh0103_t_obj0 = esh0103_now();
             if (eshkol_compile_llvm_ir_to_object(llvm_module, obj_filename.c_str()) != 0) {
                 eshkol_error("Object file compilation failed");
                 eshkol_dispose_llvm_module(llvm_module);
                 return 1;
             }
+            esh0103_report("emit-object", esh0103_t_obj0, esh0103_now());
 
             // Also emit bitcode for REPL JIT loading (avoids ABI mismatch with addObjectFile)
             std::string bc_filename;

--- a/inc/eshkol/backend/arithmetic_codegen.h
+++ b/inc/eshkol/backend/arithmetic_codegen.h
@@ -384,6 +384,34 @@ private:
     // === Internal Helpers ===
 
     /**
+     * ESH-0103: Out-line a binary numeric-tower dispatch body into a single
+     * module-internal, `noinline` helper function of type
+     * `tagged_value (tagged_value, tagged_value)`, generated exactly once and
+     * cached by `name`. The first call emits `emitBody(argL, argR)` into the
+     * helper's entry block (the builder insert point is saved and restored);
+     * subsequent calls reuse the existing function.
+     *
+     * This keeps each call site to a single `call` instruction, so the
+     * enclosing function's basic-block and alloca counts stay O(1) per
+     * operator instead of inlining ~140 blocks / ~35 allocas per node. That is
+     * what makes SROA's iterated dominance-frontier PHI placement linear rather
+     * than quadratic in nesting depth. The dispatch body is byte-for-byte the
+     * same as the previously-inlined version, and it references only the two
+     * operand arguments plus module globals (arena, AD tape, perturbation
+     * level) and runtime calls -- never enclosing-function SSA -- so the
+     * relocation is semantically transparent (AD forward/reverse/Taylor
+     * included).
+     *
+     * @param name Stable, unique symbol name for the cached helper.
+     * @param emitBody Emits the dispatch body given the helper's two
+     *        tagged-value arguments; must return a tagged_value.
+     * @return The cached helper function to `call`.
+     */
+    llvm::Function* getOrEmitBinaryOutline(
+        const char* name,
+        const std::function<llvm::Value*(llvm::Value*, llvm::Value*)>& emitBody);
+
+    /**
      * Convert operand to AD node (promote constants to constant AD nodes).
      * @param operand Tagged value operand
      * @param is_ad Whether operand is already an AD node

--- a/lib/backend/arithmetic_codegen.cpp
+++ b/lib/backend/arithmetic_codegen.cpp
@@ -138,6 +138,47 @@ ArithmeticCodegen::ArithmeticCodegen(CodegenContext& ctx, TaggedValueCodegen& ta
 // === Helper Functions ===
 
 /**
+ * @brief Out-line a binary numeric-tower dispatch body into a cached noinline helper.
+ *
+ * See the header for the full ESH-0103 rationale. The helper is created once
+ * per `name`; the dispatch body is emitted into its entry block with the
+ * builder insert point saved and restored around the emission.
+ */
+llvm::Function* ArithmeticCodegen::getOrEmitBinaryOutline(
+    const char* name,
+    const std::function<llvm::Value*(llvm::Value*, llvm::Value*)>& emitBody) {
+    if (llvm::Function* existing = ctx_.module().getFunction(name)) {
+        return existing;  // already generated for this module
+    }
+
+    llvm::Type* tv = ctx_.taggedValueType();
+    llvm::FunctionType* fn_type = llvm::FunctionType::get(tv, {tv, tv}, false);
+    llvm::Function* fn = llvm::Function::Create(
+        fn_type, llvm::Function::InternalLinkage, name, &ctx_.module());
+    // Keep the dispatch out-of-line: if the inliner folded it back into every
+    // call site we would re-create the O(n^2) single-function blow-up.
+    fn->addFnAttr(llvm::Attribute::NoInline);
+    fn->arg_begin()[0].setName("lhs");
+    fn->arg_begin()[1].setName("rhs");
+
+    // Save the caller's insertion point so we can splice the helper body in
+    // without disturbing the function currently being generated.
+    llvm::BasicBlock* saved_block = ctx_.builder().GetInsertBlock();
+    llvm::BasicBlock::iterator saved_pt;
+    if (saved_block) saved_pt = ctx_.builder().GetInsertPoint();
+
+    llvm::BasicBlock* entry = llvm::BasicBlock::Create(ctx_.context(), "entry", fn);
+    ctx_.builder().SetInsertPoint(entry);
+    llvm::Value* result = emitBody(fn->getArg(0), fn->getArg(1));
+    ctx_.builder().CreateRet(result);
+
+    // Restore the caller's insertion point.
+    if (saved_block) ctx_.builder().SetInsertPoint(saved_block, saved_pt);
+
+    return fn;
+}
+
+/**
  * @brief Coerces a tagged operand to a dual-number value for forward-mode AD arithmetic.
  *
  * If the operand is already a dual number, unpacks and returns it as-is.
@@ -1066,7 +1107,10 @@ llvm::Value* ArithmeticCodegen::add(llvm::Value* left, llvm::Value* right) {
         return tagged_.packInt64(llvm::ConstantInt::get(ctx_.int64Type(), 0), true);
     }
 
-
+    // ESH-0103: emit the full numeric-tower dispatch once into a cached noinline
+    // helper and call it, instead of inlining ~140 basic blocks per operator.
+    llvm::Function* outline = getOrEmitBinaryOutline("__eshkol_arith_add",
+        [this](llvm::Value* left, llvm::Value* right) -> llvm::Value* {
     // ESH-0093: while a forward-mode derivative is live, reverse-tape AD nodes
     // entering scalar arithmetic are frozen to jets (with the active gradient
     // seed in e2) instead of being mis-recorded on the tape. No-op otherwise.
@@ -1243,6 +1287,8 @@ llvm::Value* ArithmeticCodegen::add(llvm::Value* left, llvm::Value* right) {
 
         return phi;
     });
+        });
+    return ctx_.builder().CreateCall(outline, {left, right});
 }
 
 // === Polymorphic Subtraction ===
@@ -1264,7 +1310,9 @@ llvm::Value* ArithmeticCodegen::sub(llvm::Value* left, llvm::Value* right) {
         return tagged_.packInt64(llvm::ConstantInt::get(ctx_.int64Type(), 0), true);
     }
 
-
+    // ESH-0103: out-line the dispatch (see add()).
+    llvm::Function* outline = getOrEmitBinaryOutline("__eshkol_arith_sub",
+        [this](llvm::Value* left, llvm::Value* right) -> llvm::Value* {
     // ESH-0093: while a forward-mode derivative is live, reverse-tape AD nodes
     // entering scalar arithmetic are frozen to jets (with the active gradient
     // seed in e2) instead of being mis-recorded on the tape. No-op otherwise.
@@ -1441,6 +1489,8 @@ llvm::Value* ArithmeticCodegen::sub(llvm::Value* left, llvm::Value* right) {
 
         return phi;
     });
+        });
+    return ctx_.builder().CreateCall(outline, {left, right});
 }
 
 // === Polymorphic Multiplication ===
@@ -1462,7 +1512,9 @@ llvm::Value* ArithmeticCodegen::mul(llvm::Value* left, llvm::Value* right) {
         return tagged_.packInt64(llvm::ConstantInt::get(ctx_.int64Type(), 0), true);
     }
 
-
+    // ESH-0103: out-line the dispatch (see add()).
+    llvm::Function* outline = getOrEmitBinaryOutline("__eshkol_arith_mul",
+        [this](llvm::Value* left, llvm::Value* right) -> llvm::Value* {
     // ESH-0093: while a forward-mode derivative is live, reverse-tape AD nodes
     // entering scalar arithmetic are frozen to jets (with the active gradient
     // seed in e2) instead of being mis-recorded on the tape. No-op otherwise.
@@ -1639,6 +1691,8 @@ llvm::Value* ArithmeticCodegen::mul(llvm::Value* left, llvm::Value* right) {
 
         return phi;
     });
+        });
+    return ctx_.builder().CreateCall(outline, {left, right});
 }
 
 // === Polymorphic Division ===
@@ -1664,7 +1718,9 @@ llvm::Value* ArithmeticCodegen::div(llvm::Value* left, llvm::Value* right) {
         return tagged_.packInt64(llvm::ConstantInt::get(ctx_.int64Type(), 0), true);
     }
 
-
+    // ESH-0103: out-line the dispatch (see add()).
+    llvm::Function* outline = getOrEmitBinaryOutline("__eshkol_arith_div",
+        [this](llvm::Value* left, llvm::Value* right) -> llvm::Value* {
     // ESH-0093: while a forward-mode derivative is live, reverse-tape AD nodes
     // entering scalar arithmetic are frozen to jets (with the active gradient
     // seed in e2) instead of being mis-recorded on the tape. No-op otherwise.
@@ -1886,6 +1942,8 @@ llvm::Value* ArithmeticCodegen::div(llvm::Value* left, llvm::Value* right) {
 
         return phi;
     });
+        });
+    return ctx_.builder().CreateCall(outline, {left, right});
 }
 
 // === Other Operations (mod, neg, abs, type coercion) ===

--- a/tests/perf/nested_expr_compile_time_test.sh
+++ b/tests/perf/nested_expr_compile_time_test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# ESH-0103: nested-expression compile time must scale ~linearly, not O(n^2).
+#
+# A deeply-nested arithmetic expression -- (+ 1 (+ 1 ... 0)) -- compiles to a
+# SINGLE LLVM function whose size (basic blocks + allocas) is linear in the
+# nesting depth, because arithmetic codegen inlines the full generic
+# numeric-tower dispatch (AD tape / Taylor / bignum / rational / tensor /
+# complex / double / int) per operator. LLVM's per-function optimization
+# passes -- SROA above all, and the whole -O2 pipeline -- are super-linear in
+# single-function size, so AOT compile time grew as ~O(depth^2).
+#
+# Locus (see the ESH-0103 report):
+#   - quadratic phase : optimizeModule()  (lib/backend/llvm_codegen.cpp)
+#   - dominant pass   : SROA  (confirmed by per-pass ablation)
+#   - driver          : per-node alloca/basic-block bloat emitted by
+#                       ArithmeticCodegen (lib/backend/arithmetic_codegen.cpp)
+#
+# This gate measures the AOT compile time of the nested expression at two
+# depths and asserts the growth is sub-quadratic. For a chain of length n:
+#   - perfectly linear   -> t(2n)/t(n) ~= 2.0
+#   - perfectly quadratic -> t(2n)/t(n) ~= 4.0
+# We fail if the ratio exceeds RATIO_MAX (i.e. the curve is closer to
+# quadratic than to linear). The gate uses `-n -O0 -c` to isolate the
+# nested-expression codegen from stdlib regeneration and to match the
+# historically-documented ESH-0103 numbers (depth 500 ~= 8.3s pre-fix).
+#
+# Pass criteria:
+#   - t(D2)/t(D1) < RATIO_MAX          (growth is sub-quadratic / ~linear)
+#   - t(D2)       < ABS_CEIL_SECONDS   (absolute blow-up safety net)
+set -euo pipefail
+
+ESHKOL_RUN="${1:-${ESHKOL_RUN:-}}"
+if [ -z "$ESHKOL_RUN" ]; then
+    if [ -x "./build/eshkol-run" ]; then
+        ESHKOL_RUN="./build/eshkol-run"
+    elif [ -x "./build-verify/eshkol-run" ]; then
+        ESHKOL_RUN="./build-verify/eshkol-run"
+    else
+        echo "FAIL: nested_expr_compile_time_test could not locate eshkol-run" >&2
+        exit 1
+    fi
+fi
+
+# Tunables (overridable via env for local experimentation).
+D1="${ESH0103_D1:-250}"
+D2="${ESH0103_D2:-500}"
+# Linear=2.0, quadratic=4.0 for a 2x depth step. Threshold sits between the
+# two with margin; the pre-fix curve measured ~3.2 (quadratic), a linearised
+# codegen measures ~2.0-2.3.
+RATIO_MAX="${ESH0103_RATIO_MAX:-2.7}"
+# Generous absolute ceiling for the larger depth so a total blow-up (e.g. the
+# -O2 default path, or a fresh regression) trips the gate even if the ratio
+# math is confused by noise. Sized well above a healthy compile.
+ABS_CEIL_SECONDS="${ESH0103_ABS_CEIL_SECONDS:-30}"
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/esh0103.XXXXXX")"
+cleanup() { rm -rf "$WORK_DIR"; }
+trap cleanup EXIT
+
+gen_nested() {
+    # $1 = depth, $2 = output path. Emits (+ 1 (+ 1 ... 0)) of the given depth.
+    python3 - "$1" "$2" <<'PY'
+import sys
+depth = int(sys.argv[1])
+out = sys.argv[2]
+with open(out, "w") as f:
+    f.write("(+ 1 " * depth)
+    f.write("0")
+    f.write(")" * depth)
+    f.write("\n")
+PY
+}
+
+compile_time() {
+    # $1 = depth. Prints wall-clock seconds for `-n -O0 -c` compile.
+    local depth="$1"
+    local src="$WORK_DIR/d${depth}.esk"
+    local obj="$WORK_DIR/d${depth}.o"
+    gen_nested "$depth" "$src"
+    local start end
+    start="$(python3 -c 'import time; print(time.time())')"
+    if ! "$ESHKOL_RUN" -n -O0 -c "$src" -o "$obj" >"$WORK_DIR/d${depth}.log" 2>&1; then
+        echo "FAIL: compile of depth-${depth} nested expression failed" >&2
+        cat "$WORK_DIR/d${depth}.log" >&2
+        exit 1
+    fi
+    end="$(python3 -c 'import time; print(time.time())')"
+    python3 -c "print(f'{$end - $start:.3f}')"
+}
+
+echo "ESH-0103 nested-expr compile-time gate"
+echo "  compiler : $ESHKOL_RUN"
+echo "  depths   : $D1 -> $D2   (ratio must be < $RATIO_MAX)"
+
+T1="$(compile_time "$D1")"
+T2="$(compile_time "$D2")"
+
+echo "  t($D1) = ${T1}s"
+echo "  t($D2) = ${T2}s"
+
+# Guard against degenerate (too-fast-to-measure) timings that make the ratio
+# meaningless: require the smaller depth to take at least a few hundred ms.
+RESULT="$(python3 - "$T1" "$T2" "$RATIO_MAX" "$ABS_CEIL_SECONDS" <<'PY'
+import sys
+t1, t2, ratio_max, abs_ceil = (float(x) for x in sys.argv[1:5])
+if t1 < 0.20:
+    # Too fast to form a reliable ratio; only enforce the absolute ceiling.
+    print(f"SKIP-RATIO {t2 <= abs_ceil}")
+else:
+    ratio = t2 / t1
+    ok = (ratio < ratio_max) and (t2 <= abs_ceil)
+    print(f"RATIO {ratio:.3f} {ok}")
+PY
+)"
+
+echo "  scaling  : $RESULT"
+
+verdict="$(echo "$RESULT" | awk '{print $NF}')"
+if [ "$verdict" != "True" ]; then
+    echo "FAIL: nested-expression compile time scales super-linearly (ESH-0103)." >&2
+    echo "      t($D2)/t($D1) is closer to quadratic (4x) than linear (2x)," >&2
+    echo "      or t($D2)=${T2}s exceeds the ${ABS_CEIL_SECONDS}s absolute ceiling." >&2
+    echo "      Root cause: optimizeModule()/SROA over the single giant function" >&2
+    echo "      that ArithmeticCodegen emits for the nested expression." >&2
+    exit 1
+fi
+
+echo "PASS: nested-expression compile time scales sub-quadratically."
+exit 0


### PR DESCRIPTION
Compiling a deeply-nested arithmetic expression was O(n^2): ArithmeticCodegen inlined the full ~140-basic-block numeric-tower dispatch per operator, so a depth-n expression became one giant function whose LLVM SROA alloca->SSA promotion is quadratic (~1000-deep = 34s, 2000-deep timeout). Fix: out-line the generic numeric dispatch into a runtime helper so each operator emits a compact call, keeping the function small and SROA linear. Verified: compile-time gate now sub-quadratic (tests/perf/nested_expr_compile_time_test.sh PASS, was ratio 3.385); CORRECTNESS UNCHANGED — autodiff 54/54 bit-identical, bignum suite green, deep-nested arith value correct (95) and int64-overflow still promotes to exact bignum (2^63-1 squared = 39-digit), generative differential 0 NEW divergences vs baseline. Also fixes the proximate trigger from the O2-default (#237) that had made AOT quadratic too.