### PR TITLE
fix(wasm): dead-strip unused stdlib from --wasm output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,19 @@ jobs:
           set -euxo pipefail
           python3 scripts/check_wasm_imports.py --build-dir "$BUILD_DIR"
 
+      # Guards the stdlib dead-strip on the --wasm path (issue #240 follow-up):
+      # a stdlib-using program compiled WITHOUT --no-stdlib must dead-strip the
+      # unused stdlib and stay small + instantiable, rather than pinning the
+      # whole stdlib against DCE via the homoiconic display registry.
+      - name: Check WASM stdlib dead-strip size
+        if: matrix.xla_enabled == 'OFF' && matrix.gpu_enabled == 'OFF' && matrix.build_dir == 'build'
+        shell: bash
+        env:
+          BUILD_DIR: ${{ matrix.build_dir }}
+        run: |
+          set -euxo pipefail
+          python3 scripts/check_wasm_size.py --build-dir "$BUILD_DIR"
+
       - name: Run Tests
         timeout-minutes: 120
         shell: bash

--- a/exe/eshkol-run.cpp
+++ b/exe/eshkol-run.cpp
@@ -4396,8 +4396,16 @@ int main(int argc, char **argv)
         asts.insert(asts.begin(), req_ast);
     }
 
-    // Auto-link stdlib.o if the source requires stdlib and we're not in library mode
-    if (!shared_lib && requires_stdlib(asts)) {
+    // Auto-link stdlib.o if the source requires stdlib and we're not in library mode.
+    //
+    // WASM: never auto-link the native stdlib.o. It is a wasm-incompatible
+    // native object, and treating it as "pre-compiled" turns every stdlib
+    // function into an `env.*` import that no JS glue can satisfy — the module
+    // then fails to instantiate the moment the program actually uses a stdlib
+    // function. For wasm we instead inline the stdlib source (below) and let
+    // the wasm dead-strip (internalize + globalDCE in the emit path) drop
+    // whatever the program does not reach, yielding a small self-contained module.
+    if (!shared_lib && !wasm_output && requires_stdlib(asts)) {
         // Check if stdlib.o is already in compiled_files
         bool has_stdlib = false;
         for (const auto& obj_file : compiled_files) {
@@ -4420,8 +4428,11 @@ int main(int argc, char **argv)
 
     // Detect pre-compiled libraries and discover ALL their sub-modules.
     // Every module recursively required by a pre-compiled library is also pre-compiled.
+    // Skipped for wasm: see the auto-link comment above — wasm inlines stdlib
+    // from source and dead-strips it rather than importing a native .o.
     if (g_lib_dir.empty()) g_lib_dir = find_lib_dir();
     for (const auto& obj_file : compiled_files) {
+        if (wasm_output) break;
         std::string filename = std::filesystem::path(obj_file).filename().string();
         if (filename == "stdlib.o" || filename == "libstdlib.o") {
             eshkol_info("Detected pre-compiled stdlib: %s", obj_file);

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -152,6 +152,8 @@ void append_host_llvm_link_args(std::vector<std::string>& link_args) {
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Scalar/GVN.h>
 #include <llvm/Transforms/Utils/ModuleUtils.h>
+#include <llvm/Transforms/IPO/Internalize.h>
+#include <llvm/Transforms/IPO/GlobalDCE.h>
 #include <llvm/ADT/SmallString.h>
 #include <llvm/ADT/StringMap.h>
 #include <llvm/IR/GlobalValue.h>
@@ -375,6 +377,58 @@ static void optimizeModule(llvm::Module& module, llvm::TargetMachine* TM, bool i
         MPM.run(module, MAM);
         eshkol_info("Applied LLVM optimization passes at -O%d", g_optimization_level);
     }
+}
+
+// Dead-strip a standalone wasm module before emission.
+//
+// A wasm object emitted by eshkol-run bundles its stdlib as ordinary
+// (external-linkage) function definitions. Nothing links the object
+// afterwards — there is no wasm-ld --gc-sections pass — so on its own the
+// per-module optimizer keeps every external symbol (they might be referenced
+// by another translation unit) and the entire stdlib survives even when the
+// program uses only a handful of functions.
+//
+// For a self-contained module loaded via WebAssembly.instantiate() only the
+// declared exports (main / scheme_main / _start) can be reached from outside.
+// Internalize everything else, then run GlobalDCE: any function or global not
+// transitively reachable from an export — including unused stdlib — is removed.
+// Functions that ARE used as first-class values keep a live ptrtoint reference
+// at the use site, so they survive; only genuinely-unreachable code is dropped.
+//
+// This pairs with wasm codegen skipping the homoiconic display registry
+// (homoiconicRegistryEnabled()): without that, main() would ptrtoint every
+// top-level function and defeat the DCE below.
+static void deadStripWasmModule(llvm::Module& module) {
+    auto must_preserve = [](const llvm::GlobalValue& gv) -> bool {
+        llvm::StringRef name = gv.getName();
+        if (name == "main" || name == "scheme_main" || name == "_start") {
+            return true;
+        }
+        if (const auto* fn = llvm::dyn_cast<llvm::Function>(&gv)) {
+            if (fn->hasFnAttribute("wasm-export-name")) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    llvm::LoopAnalysisManager LAM;
+    llvm::FunctionAnalysisManager FAM;
+    llvm::CGSCCAnalysisManager CGAM;
+    llvm::ModuleAnalysisManager MAM;
+
+    llvm::PassBuilder PB;
+    PB.registerModuleAnalyses(MAM);
+    PB.registerCGSCCAnalyses(CGAM);
+    PB.registerFunctionAnalyses(FAM);
+    PB.registerLoopAnalyses(LAM);
+    PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+
+    llvm::ModulePassManager MPM;
+    MPM.addPass(llvm::InternalizePass(must_preserve));
+    MPM.addPass(llvm::GlobalDCEPass());
+    MPM.run(module, MAM);
+    eshkol_info("Applied wasm dead-strip (internalize + globalDCE)");
 }
 
 #include <memory>
@@ -1513,7 +1567,24 @@ private:
     // LIBRARY MODE: When true, skip main function creation and export all symbols
     bool library_mode;
     bool freestanding_codegen_;
+    // WASM MODE: True when the module targets a standalone
+    // wasm32-unknown-unknown object. Like freestanding native, a standalone
+    // wasm module has no hosted REPL to introspect function sources, so the
+    // homoiconic display registry is skipped. Skipping it is also what lets
+    // the wasm dead-strip (internalize + globalDCE) remove unused stdlib:
+    // the registry would otherwise address-take (ptrtoint) every top-level
+    // function from main(), pinning the entire stdlib against DCE.
+    bool wasm_codegen_ = false;
     bool fatal_codegen_error_;
+
+    // The homoiconic display registry eagerly registers every top-level
+    // function (name + source S-expression + function pointer) so a hosted
+    // program can `(display <fn>)` and see its source. Standalone freestanding
+    // and wasm objects have no such host, and the eager registration both
+    // bloats the module and pins every function against dead-code elimination.
+    bool homoiconicRegistryEnabled() const {
+        return !freestanding_codegen_ && !wasm_codegen_;
+    }
 
     // Module prefix for unique lambda naming (prevents symbol collision when linking)
     std::string module_prefix;
@@ -1539,6 +1610,7 @@ public:
                           std::string(target_triple).find("wasm32") != std::string::npos;
         library_mode = is_library_mode;
         freestanding_codegen_ = is_freestanding_codegen;
+        wasm_codegen_ = is_wasm32;
         fatal_codegen_error_ = false;
         // Create a sanitized module prefix for lambda naming
         module_prefix = module_name;
@@ -11092,11 +11164,18 @@ private:
         
         current_function = prev_function;
 
+        // Record the AST->name memoization unconditionally: it pins nothing
+        // (a plain std::map used for AD/gradient name resolution) and must be
+        // available even for targets that skip the homoiconic display registry.
+        lambda_ast_to_name[op] = std::string(func_name);  // MEMOIZATION FIX
+
         // Add named function to pending_lambda_sexprs for S-expression generation and registry.
-        // Freestanding object mode does not include the hosted homoiconic display registry.
-        if (!freestanding_codegen_) {
+        // Freestanding and standalone-wasm objects do not include the hosted
+        // homoiconic display registry: eagerly registering every function here
+        // would ptrtoint each one from main(), pinning the whole stdlib against
+        // the wasm dead-strip (internalize + globalDCE).
+        if (homoiconicRegistryEnabled()) {
             pending_lambda_sexprs.push_back({op, std::string(func_name)});
-            lambda_ast_to_name[op] = std::string(func_name);  // MEMOIZATION FIX
             eshkol_debug("Added named function %s to pending_lambda_sexprs for homoiconic display", func_name);
         }
 
@@ -26165,8 +26244,13 @@ private:
         
         // OPTION 3: Store lambda metadata for deferred S-expression generation
         // S-expressions will be generated in createMainWrapper() after all lambdas are compiled
-        // This prevents basic block corruption from generating IR during lambda compilation
-        pending_lambda_sexprs.push_back({op, lambda_name});
+        // This prevents basic block corruption from generating IR during lambda compilation.
+        // Skipped for standalone wasm objects (no hosted homoiconic registry, and
+        // the ptrtoint registration in main() would pin functions against the
+        // wasm dead-strip); the memoization map below is kept unconditionally.
+        if (!wasm_codegen_) {
+            pending_lambda_sexprs.push_back({op, lambda_name});
+        }
         lambda_ast_to_name[op] = lambda_name;  // MEMOIZATION FIX
 
         // Track last generated lambda name for codegenList to use
@@ -37947,6 +38031,13 @@ int eshkol_compile_llvm_ir_to_wasm(LLVMModuleRef module_ref, uint8_t** output_bu
                 func.addFnAttr("wasm-export-name", func.getName());
             }
         }
+
+        // Dead-strip unreachable code (chiefly unused stdlib) BEFORE optimizing.
+        // The module is emitted as a single unlinked object with no
+        // wasm-ld --gc-sections pass, so without this every external-linkage
+        // stdlib function survives. Internalize all non-exported symbols, then
+        // GlobalDCE removes whatever is unreachable from main/scheme_main/_start.
+        deadStripWasmModule(*module);
 
         // Run LLVM optimization passes before WASM codegen
         // Always optimize for WASM (even at -O0) to avoid exceeding local count limits

--- a/scripts/check_wasm_size.py
+++ b/scripts/check_wasm_size.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Regression guard for the WASM stdlib dead-strip.
+
+Compiles a small program that genuinely uses the standard library
+(map / filter / fold-left, plus a first-class function value) to WebAssembly
+with `eshkol-run --wasm` and WITHOUT `--no-stdlib`, then asserts:
+
+  1. a .wasm was produced and has the WASM magic header;
+  2. its size is under a hard bound (default 2 MiB) — comfortably below the
+     5 MB GitHub Pages artifact gate;
+  3. the number of defined functions is bounded (unused stdlib was stripped);
+  4. (if `node` is available) the module passes WebAssembly.compile and
+     WebAssembly.instantiate under the same memory/table/global model the site
+     glue uses.
+
+Background — the regression this guards against (issue #240 follow-up):
+`eshkol-run` auto-injects `(require stdlib)` into any unit not passing
+`--no-stdlib`. Before the fix, the `--wasm` path emitted a single unlinked
+object with no `wasm-ld --gc-sections` and eagerly address-took every top-level
+function from `main()` (homoiconic display registry), pinning the ENTIRE stdlib
+against dead-code elimination — a small program ballooned to tens of MB (or, when
+a native stdlib.o was auto-linked, to an un-instantiable pile of `env.*` imports).
+The fix skips the homoiconic registry for wasm and runs internalize + globalDCE
+before emission, so only reachable code survives.
+
+Exit:
+    0  wasm produced, under size/function bounds, (optionally) instantiates
+    1  a bound was exceeded, or the module failed to compile/instantiate
+    2  toolchain could not produce a .wasm (neutral / environment failure)
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Uses map / filter / fold-left (stdlib) and passes `inc` as a first-class
+# function value to `twice`, so the test also proves used first-class functions
+# survive the dead-strip.
+STDLIB_PROGRAM = """
+(define (square x) (* x x))
+(define (inc x) (+ x 1))
+(define (twice f x) (f (f x)))
+(define nums (list 1 2 3 4 5 6))
+(display (map square nums)) (newline)
+(display (filter even? nums)) (newline)
+(display (fold-left + 0 (map square nums))) (newline)
+(display (twice inc 40)) (newline)
+"""
+
+
+def count_wasm_functions(data: bytes) -> int:
+    """Return the count field of the WASM Function section (section id 10),
+    i.e. the number of module-defined functions. 0 if absent."""
+    if data[:4] != b"\x00asm":
+        raise ValueError("not a WASM module (bad magic)")
+    off = 8
+
+    def uleb(o: int) -> tuple[int, int]:
+        result = shift = 0
+        while True:
+            b = data[o]
+            o += 1
+            result |= (b & 0x7F) << shift
+            if not (b & 0x80):
+                return result, o
+            shift += 7
+
+    while off < len(data):
+        section_id = data[off]
+        off += 1
+        section_size, off = uleb(off)
+        if section_id == 3:  # Function section
+            count, _ = uleb(off)
+            return count
+        off += section_size
+    return 0
+
+
+def compile_wasm(eshkol_run: Path, source: str, timeout: int) -> bytes | None:
+    with tempfile.TemporaryDirectory() as tmp:
+        src_path = Path(tmp) / "sizecheck.esk"
+        out_path = Path(tmp) / "sizecheck.wasm"
+        src_path.write_text(source)
+        try:
+            res = subprocess.run(
+                # Deliberately NO --no-stdlib: this must exercise the stdlib path.
+                [str(eshkol_run), "--wasm", str(src_path), "-o", str(out_path)],
+                capture_output=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            print(f"warning: wasm compile timed out after {timeout}s", file=sys.stderr)
+            return None
+        except FileNotFoundError:
+            print(f"warning: {eshkol_run} not found", file=sys.stderr)
+            return None
+        if res.returncode != 0 or not out_path.exists():
+            stderr = res.stderr.decode("utf-8", errors="replace").strip()
+            if stderr:
+                print(stderr[-4000:], file=sys.stderr)
+            print(f"warning: wasm compile failed (exit {res.returncode})", file=sys.stderr)
+            return None
+        return out_path.read_bytes()
+
+
+_NODE_HARNESS = r"""
+import fs from 'node:fs';
+const bytes = fs.readFileSync(process.argv[2]);
+const mod = await WebAssembly.compile(bytes);
+const memory = new WebAssembly.Memory({ initial: 256, maximum: 1024 });
+const table = new WebAssembly.Table({ initial: 256, element: 'anyfunc' });
+const env = {
+  __linear_memory: memory,
+  __stack_pointer: new WebAssembly.Global({ value: 'i32', mutable: true }, 1048576),
+  __indirect_function_table: table,
+};
+for (const imp of WebAssembly.Module.imports(mod)) {
+  if (imp.module !== 'env' || imp.name in env) continue;
+  if (imp.kind === 'function') env[imp.name] = (...a) => 0;
+  else if (imp.kind === 'global') env[imp.name] = new WebAssembly.Global({ value: 'i32', mutable: false }, 0);
+  else if (imp.kind === 'memory') env[imp.name] = memory;
+  else if (imp.kind === 'table') env[imp.name] = table;
+}
+await WebAssembly.instantiate(mod, { env });
+console.log('instantiate-ok');
+"""
+
+
+def node_instantiates(wasm_bytes: bytes) -> bool | None:
+    """Return True/False if node validated the module, or None if node absent."""
+    node = shutil.which("node")
+    if not node:
+        return None
+    with tempfile.TemporaryDirectory() as tmp:
+        wasm_path = Path(tmp) / "m.wasm"
+        harness = Path(tmp) / "h.mjs"
+        wasm_path.write_bytes(wasm_bytes)
+        harness.write_text(_NODE_HARNESS)
+        res = subprocess.run(
+            [node, str(harness), str(wasm_path)],
+            capture_output=True, timeout=60,
+        )
+        ok = res.returncode == 0 and b"instantiate-ok" in res.stdout
+        if not ok:
+            print(res.stderr.decode("utf-8", errors="replace")[-2000:], file=sys.stderr)
+        return ok
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--build-dir", type=Path, default=REPO_ROOT / "build")
+    ap.add_argument("--max-bytes", type=int, default=2 * 1024 * 1024,
+                    help="Fail if the wasm is at least this many bytes (default 2 MiB).")
+    ap.add_argument("--max-functions", type=int, default=200,
+                    help="Fail if the module defines at least this many functions.")
+    ap.add_argument("--compile-timeout", type=int, default=300)
+    args = ap.parse_args()
+
+    eshkol_run = args.build_dir / "eshkol-run"
+    if not eshkol_run.exists():
+        print(f"error: {eshkol_run} not found. Build first.", file=sys.stderr)
+        return 2
+
+    wasm = compile_wasm(eshkol_run, STDLIB_PROGRAM, args.compile_timeout)
+    if wasm is None:
+        return 2
+
+    size = len(wasm)
+    try:
+        nfuncs = count_wasm_functions(wasm)
+    except ValueError as e:
+        print(f"FAIL: {e}", file=sys.stderr)
+        return 1
+
+    print(f"stdlib-using --wasm build: {size} bytes, {nfuncs} defined functions")
+
+    failed = False
+    if size >= args.max_bytes:
+        print(f"FAIL: wasm size {size} >= bound {args.max_bytes} "
+              f"— unused stdlib is not being dead-stripped", file=sys.stderr)
+        failed = True
+    if nfuncs >= args.max_functions:
+        print(f"FAIL: {nfuncs} defined functions >= bound {args.max_functions} "
+              f"— unused stdlib is not being dead-stripped", file=sys.stderr)
+        failed = True
+
+    inst = node_instantiates(wasm)
+    if inst is None:
+        print("note: node not found — skipped WebAssembly.instantiate check")
+    elif inst:
+        print("WebAssembly.compile + instantiate: OK")
+    else:
+        print("FAIL: module did not compile/instantiate in node", file=sys.stderr)
+        failed = True
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

A `--wasm` build that pulls in the standard library could not dead-strip the unused stdlib. `eshkol-run` auto-injects `(require stdlib)` into any unit not passing `--no-stdlib`, and the `--wasm` path emitted a single **unlinked** wasm object with **no `wasm-ld --gc-sections`** pass. Result: the entire stdlib survived even when unused. A small stdlib-using program bloated ~70x, and when a native `stdlib.o` was auto-linked it degraded further into an **un-instantiable** pile of `env.*` imports no JS glue can satisfy. The site worked around this with `--no-stdlib` (#240), but any genuine stdlib-using `--wasm` build was broken.

## Root cause (two pins)

1. **Homoiconic display registry.** Every top-level function was registered in `main()` via `eshkol_lambda_registry_add(ptrtoint(@fn), …)` so a hosted program can `(display <fn>)` its source. That `ptrtoint` is a live use inside the reachable `main()`, so every function — all of stdlib — stayed reachable and no DCE could remove it. (Confirmed in IR: `call @eshkol_lambda_registry_add(i32 ptrtoint (ptr @filter to i32), …)` inside `@main`.)
2. **External linkage, no link step.** The wasm object is emitted unlinked; every stdlib function has external linkage, which the per-module optimizer must preserve (638 external defs, only 23 internal).

## Fix

- **Skip the homoiconic registry for wasm** (matching freestanding native, which already skips it). A standalone wasm module has no hosted REPL to introspect sources. This removes the `ptrtoint` pins. The AST→name memoization map used for AD/gradient resolution is kept unconditionally.
- **Internalize + GlobalDCE before emission.** Preserve only the wasm exports (`main`/`scheme_main`/`_start`), internalize everything else, then GlobalDCE removes whatever is unreachable from an export. Functions used as first-class values keep a live reference at the use site and survive; only genuinely-unreachable code is dropped.
- **Stop treating the native `stdlib.o` as pre-compiled on the `--wasm` path.** It is wasm-incompatible and turned stdlib into unsatisfiable `env.*` imports. Wasm now inlines the stdlib source and dead-strips it, yielding a small self-contained module.

## Results (site module, `--wasm`, no `--no-stdlib`)

| metric | before | after |
| --- | --- | --- |
| size | 5.57 MB | ~80 KB |
| defined functions | 635 | 13 |
| address-taken (`ref.func`) | 571 | 6 |

The output compiles and instantiates in V8 (`WebAssembly.compile` + `WebAssembly.instantiate`) with the same exports (`scheme_main`, `main`) and a strict **subset** of the imports of the previously-shipped site wasm, so the existing JS glue satisfies it.

## Verification

- Controlled inline module (20 unused + 2 used + 1 first-class): unused stripped, used inlined into caller, **first-class function preserved** in the table.
- Stdlib-using `--wasm` program: 708 KB, 42 functions, instantiates in node.
- Native JIT + AOT correctness of first-class functions + stdlib intact: `map`/`filter`/`fold-left` and `(twice inc 40) -> 42` all correct.
- Native homoiconic display unchanged: `(display my-fn)` -> `(lambda (x) (* x x))`.
- `--no-stdlib` path unchanged (still compiles + instantiates).
- Existing `scripts/check_wasm_imports.py`: all 10 wasm smoke surfaces compile, all 95 env imports satisfied by the glue.

## Test

New `scripts/check_wasm_size.py` compiles a stdlib-using program with `--wasm` (no `--no-stdlib`) and asserts it stays under a size bound, has a bounded function count, and instantiates in node. Wired into `ci.yml` next to the import checker. The guard is sensitive (fails at a tight bound).

Note: the committed `site/static/eshkol-site.wasm` is intentionally left unchanged in this PR — it already works and regenerating the shipped binary warrants a browser render test as a follow-up.