### PR TITLE
feat(quantum): Moonlab integration Stage 1 — gated FetchContent, agent.quantum FFI, honest quantum-random

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3253,6 +3253,23 @@ if(ESHKOL_BUILD_AGENT_FFI)
             list(APPEND AGENT_FFI_SOURCES ${AGENT_FFI_DIR}/agent_http_client.c)
         endif()
 
+        # Moonlab quantum state-vector core (Stage S1,
+        # docs/design/MOONLAB_INTEGRATION.md). Unlike the pkg-config-optional
+        # modules above, this file is ALWAYS compiled (like agent_treesitter.c
+        # / agent_yoga.c) so the JIT weak-symbol table in lib/repl/repl_jit.cpp
+        # always has a real definition to bind against -- there is no shared
+        # system library that could plausibly provide these `eshkol_quantum_*`
+        # symbols if we skipped compiling the file, so omitting it entirely
+        # would leave `(require agent.quantum)` a dangling reference (and
+        # break the AOT/JIT link) rather than a graceful "not enabled" error.
+        # ESHKOL_HAVE_MOONLAB (set below only when ESHKOL_QUANTUM_ENABLED=ON
+        # and Moonlab's FetchContent produced the `quantumsim` target) picks
+        # the real Moonlab-backed implementation vs. honest stubs inside the
+        # file's own #ifdef.
+        if(EXISTS "${AGENT_FFI_DIR}/agent_quantum.c")
+            list(APPEND AGENT_FFI_SOURCES ${AGENT_FFI_DIR}/agent_quantum.c)
+        endif()
+
         add_library(eshkol-agent-ffi STATIC ${AGENT_FFI_SOURCES})
 
         target_include_directories(eshkol-agent-ffi PRIVATE
@@ -3313,6 +3330,18 @@ if(ESHKOL_BUILD_AGENT_FFI)
             endif()
         endif()
 
+        # Moonlab quantum state-vector core (agent_quantum.c above). quantumsim's
+        # own PUBLIC target_include_directories already exposes Moonlab's src/
+        # headers (quantum/state.h, quantum/gates.h, ...) to anything that
+        # links this target, so no extra include-dir wiring is needed here.
+        # ESHKOL_HAVE_MOONLAB selects agent_quantum.c's real-implementation
+        # branch instead of its graceful stubs (see the comment above its
+        # add_library entry).
+        if(ESHKOL_QUANTUM_ENABLED AND TARGET quantumsim)
+            target_compile_definitions(eshkol-agent-ffi PRIVATE ESHKOL_HAVE_MOONLAB=1)
+            target_link_libraries(eshkol-agent-ffi PUBLIC quantumsim)
+        endif()
+
         # Crypto: CommonCrypto on macOS, OpenSSL on Linux
         if(APPLE)
             target_link_libraries(eshkol-agent-ffi PUBLIC
@@ -3333,6 +3362,11 @@ if(ESHKOL_BUILD_AGENT_FFI)
         message(STATUS "  Regex:     ${PCRE2_AGENT_FOUND}")
         message(STATUS "  SQLite:    ${SQLITE3_AGENT_FOUND}")
         message(STATUS "  HTTP/curl: ${LIBCURL_AGENT_FOUND}")
+        if(ESHKOL_QUANTUM_ENABLED AND TARGET quantumsim)
+            message(STATUS "  Quantum:   ENABLED (agent.quantum -> Moonlab quantumsim)")
+        else()
+            message(STATUS "  Quantum:   DISABLED (agent.quantum unavailable; -DESHKOL_QUANTUM_ENABLED=ON to enable)")
+        endif()
 
         # ─────────────────────────────────────────────────────────────
         # Build the link-arg string AOT-compiled user binaries need so
@@ -3405,6 +3439,18 @@ if(ESHKOL_BUILD_AGENT_FFI)
         endif()
         if(NCURSES_AGENT)
             list(APPEND ESHKOL_HOST_AGENT_FFI_LINK_ARGS "${NCURSES_AGENT}")
+        endif()
+        if(ESHKOL_QUANTUM_ENABLED AND TARGET quantumsim AND ESHKOL_MOONLAB_LIBRARY_FILE)
+            # Concrete path (not a generator expression - see the "Avoids
+            # generator expressions" note above), plus an rpath so the AOT
+            # binary finds Moonlab's shared library at run time without
+            # requiring the user to set LD_LIBRARY_PATH/DYLD_LIBRARY_PATH.
+            list(APPEND ESHKOL_HOST_AGENT_FFI_LINK_ARGS "${ESHKOL_MOONLAB_LIBRARY_FILE}")
+            if(APPLE)
+                list(APPEND ESHKOL_HOST_AGENT_FFI_LINK_ARGS "-Wl,-rpath,${ESHKOL_MOONLAB_LIBRARY_DIR}")
+            else()
+                list(APPEND ESHKOL_HOST_AGENT_FFI_LINK_ARGS "-Wl,-rpath,${ESHKOL_MOONLAB_LIBRARY_DIR}")
+            endif()
         endif()
         if(APPLE)
             list(APPEND ESHKOL_HOST_AGENT_FFI_LINK_ARGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,55 @@ option(ESHKOL_ENABLE_LSAN "Enable Leak Sanitizer (standalone)"   OFF)
 option(ESHKOL_ENABLE_FUZZ "Build fuzz harnesses (reader_fuzz: any compiler; libFuzzer targets: clang only)" OFF)
 option(ESHKOL_FUZZ_ASAN "Build reader_fuzz (and the runtime it exercises) with ASan+UBSan" OFF)
 
+# Moonlab is deliberately opt-in: normal Eshkol builds neither fetch nor link
+# the simulator.  c613234cd8498804428f3838aa46dd730b1de810 is pinned by object
+# SHA (rather than the mutable v1.1.0-rc name) for reproducible builds.  At the
+# upstream repository this annotated object peels to commit 572c3940faf8e275a0e3730f2947411eefb1fa19.
+option(ESHKOL_QUANTUM_ENABLED "Enable the opt-in Moonlab quantum simulator integration" OFF)
+set(ESHKOL_MOONLAB_REPO "https://github.com/tsotchke/moonlab.git" CACHE STRING
+    "Moonlab git repository used when ESHKOL_QUANTUM_ENABLED is ON")
+set(ESHKOL_MOONLAB_LIBRARY_DIR "")
+set(ESHKOL_MOONLAB_LIBRARY_FILE "")
+
+if(ESHKOL_QUANTUM_ENABLED)
+    include(FetchContent)
+
+    # Stage 1 needs only libquantumsim.  Disable Moonlab's standalone products
+    # and optional accelerators so this opt-in dependency remains focused on
+    # the CPU state-vector/QRNG surface bound below.
+    set(QSIM_BUILD_SHARED ON CACHE BOOL "Build Moonlab as a shared library for Eshkol" FORCE)
+    set(QSIM_BUILD_STATIC OFF CACHE BOOL "Build Moonlab static library for Eshkol" FORCE)
+    set(QSIM_BUILD_TESTS OFF CACHE BOOL "Build Moonlab tests as an Eshkol dependency" FORCE)
+    set(QSIM_BUILD_EXAMPLES OFF CACHE BOOL "Build Moonlab examples as an Eshkol dependency" FORCE)
+    set(QSIM_BUILD_VISUALIZATION OFF CACHE BOOL "Build Moonlab visualization as an Eshkol dependency" FORCE)
+    set(QSIM_BUILD_BENCHMARKS OFF CACHE BOOL "Build Moonlab benchmarks as an Eshkol dependency" FORCE)
+    set(QSIM_ENABLE_OPENMP OFF CACHE BOOL "Enable Moonlab OpenMP as an Eshkol dependency" FORCE)
+    set(QSIM_ENABLE_METAL OFF CACHE BOOL "Enable Moonlab Metal as an Eshkol dependency" FORCE)
+    set(QSIM_ENABLE_TLS OFF CACHE BOOL "Enable Moonlab TLS as an Eshkol dependency" FORCE)
+    set(QSIM_ENABLE_LTO OFF CACHE BOOL "Enable Moonlab LTO as an Eshkol dependency" FORCE)
+    set(QSIM_WERROR OFF CACHE BOOL "Treat Moonlab warnings as errors as an Eshkol dependency" FORCE)
+
+    FetchContent_Declare(moonlab
+        GIT_REPOSITORY "${ESHKOL_MOONLAB_REPO}"
+        GIT_TAG c613234cd8498804428f3838aa46dd730b1de810
+        GIT_SHALLOW FALSE
+    )
+    FetchContent_MakeAvailable(moonlab)
+
+    # Verified against Moonlab's CMakeLists.txt at the pinned revision:
+    # add_library(quantumsim ...), producing libquantumsim.
+    if(NOT TARGET quantumsim)
+        message(FATAL_ERROR "Moonlab dependency did not define the expected quantumsim target")
+    endif()
+
+    # Moonlab's shared target uses CMake's standard output location.  The AOT
+    # linker receives this concrete path plus an rpath in the agent-FFI block.
+    set(ESHKOL_MOONLAB_LIBRARY_DIR "${moonlab_BINARY_DIR}")
+    set(ESHKOL_MOONLAB_LIBRARY_FILE
+        "${ESHKOL_MOONLAB_LIBRARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}quantumsim${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    message(STATUS "Moonlab quantum integration: ENABLED (target=quantumsim)")
+endif()
+
 if(ESHKOL_BUILD_TESTS)
     enable_testing()
 endif()
@@ -1737,6 +1786,18 @@ target_include_directories(
     ${ESHKOL_BUILD_INTERFACE_INCLUDE_DIRS}
 )
 eshkol_apply_common_compile_settings(eshkol-static)
+
+if(ESHKOL_QUANTUM_ENABLED)
+    # The runtime wrapper is the one place that includes Moonlab's stable QRNG
+    # header; target usage requirements provide the verified src/ include path.
+    target_compile_definitions(eshkol-runtime-support-obj PRIVATE ESHKOL_MOONLAB_QRNG_ENABLED=1)
+    target_link_libraries(eshkol-runtime-support-obj PRIVATE quantumsim)
+
+    # Both archives carry the wrapper object.  Keep quantumsim PUBLIC so
+    # CMake consumers and the Eshkol host executables link the same target.
+    target_link_libraries(eshkol-runtime PUBLIC quantumsim)
+    target_link_libraries(eshkol-static PUBLIC quantumsim)
+endif()
 
 # Extract library directories from LDFLAGS for proper linking
 if(NOT LLVM_LIBRARY_DIRS)

--- a/docs/FEATURE_MATRIX.md
+++ b/docs/FEATURE_MATRIX.md
@@ -329,8 +329,8 @@ This matrix documents all implemented and planned features for the Eshkol langua
 | File operations | ✅ | `file-delete`, `file-rename` | POSIX |
 | **Random Numbers** |
 | Pseudo-random | ✅ | `random` | drand48 |
-| Quantum random | ✅ | `quantum-random` | ANU QRNG API |
-| Integer ranges | ✅ | `quantum-random-range` | Uniform distribution |
+| Quantum random | ✅ | `quantum-random` | Classical software PRNG fallback (NOT the ANU QRNG API, NOT real quantum hardware, NOT Bell-verified). Real quantum entropy (Moonlab, Bell-verified) is opt-in via `-DESHKOL_QUANTUM_ENABLED=ON`; see `docs/design/MOONLAB_INTEGRATION.md`. Check the active source at runtime via `eshkol_qrng_source_label()`. |
+| Integer ranges | ✅ | `quantum-random-range` | Uniform distribution (same classical-fallback-by-default caveat as above) |
 
 ---
 

--- a/docs/breakdown/QUANTUM_RNG.md
+++ b/docs/breakdown/QUANTUM_RNG.md
@@ -5,18 +5,40 @@
 
 ---
 
+## Honesty notice (read this first)
+
+**By default, and always on WASM/browser builds, this is a classical software
+PRNG - not real quantum hardware, not a hardware entropy source, and not
+Bell-verified.** The "quantum circuit simulation" described below is a
+software bit-mixing routine that borrows quantum vocabulary ("Hadamard",
+"entanglement", "measurement") as naming/metaphor for its internal stages; no
+qubits, quantum circuits, or physical randomness are involved. Its seed
+material is wall-clock time, process id, `clock()`, a stack address, and (on
+x86) the `rdtsc` cycle counter - not an OS entropy pool such as
+`/dev/urandom` or `getrandom()`, despite the "system entropy pool" phrasing
+used loosely below. Given known seed material, its output is reproducible.
+
+A real, Bell-verified quantum entropy source (Moonlab's `moonlab_qrng_bytes`,
+combining hardware entropy with a verified quantum-simulation layer) is an
+opt-in build configuration; see `docs/design/MOONLAB_INTEGRATION.md`. Call
+`eshkol_qrng_source_label()` at runtime to find out which source is actually
+active in the build you are running - do not infer it from the `quantum-*`
+function names.
+
+---
+
 ## Overview
 
 Eshkol provides a dual-layer random number generation system: a standard pseudorandom number generator (PRNG) based on `drand48`, and a quantum-inspired RNG (QRNG) that simulates quantum circuit behavior on classical hardware. Both layers are exposed through a unified Eshkol API in `lib/random/random.esk`.
 
 The quantum-inspired RNG differs from standard PRNGs in several important ways:
 
-- **Quantum circuit simulation.** The QRNG maintains an 8-qubit state vector and applies Hadamard gates, phase gates, and entanglement operations to evolve the state. Each random number is produced by "measuring" the quantum state.
-- **Hardware entropy seeding.** The QRNG collects entropy from system sources (timing jitter, process ID, system entropy pool) to initialize its state, rather than relying solely on a numeric seed.
-- **Multiple mixing stages.** Output passes through Hadamard mixing, Pauli gate rotations, and splitmix64 avalanche functions. Physical constants (fine structure, Planck, Rydberg) serve as mixing constants.
-- **Non-deterministic output.** Because the QRNG incorporates runtime entropy (timing, floating-point uncertainty), identical seeds do not guarantee identical output sequences.
+- **Quantum circuit simulation (software metaphor, not real qubits).** The QRNG maintains an 8-element state array and applies XOR-mixing steps named after Hadamard gates, phase gates, and entanglement operations to evolve the state. Each random number is produced by "measuring" (collapsing) that classical state - no quantum circuit is actually simulated.
+- **Classical timing/process seeding (not a hardware entropy pool).** The QRNG seeds its state from wall-clock time, process id, `clock()`, a stack address, and (on x86) `rdtsc` - not from `/dev/urandom`, `getrandom()`, or any OS-level entropy pool.
+- **Multiple mixing stages.** Output passes through Hadamard-style mixing, Pauli-style rotations, and splitmix64 avalanche functions. Physical constants (fine structure, Planck, Rydberg) serve only as mixing multipliers, not as physics inputs.
+- **Best-effort non-repeating output.** Because the QRNG incorporates timing-based seed material, running the program twice will usually produce different sequences - but this is ordinary timing-jitter entropy, the same class of non-determinism a `srand(time(NULL))` PRNG has, not a cryptographic or physical randomness guarantee.
 
-For most applications, the standard PRNG functions are sufficient. Use the quantum functions when you need higher-quality randomness or want non-reproducible sequences.
+For most applications, the standard PRNG functions are sufficient. Use the quantum-named functions when you want a differently-seeded stream; do not rely on them for cryptographic security or for any claim of real quantum randomness unless the build is configured with Moonlab (`-DESHKOL_QUANTUM_ENABLED=ON`) and `eshkol_qrng_source_label()` confirms `"moonlab-qrng"`.
 
 ---
 

--- a/lib/agent/c/agent_quantum.c
+++ b/lib/agent/c/agent_quantum.c
@@ -1,0 +1,362 @@
+/*******************************************************************************
+ * Moonlab Quantum State-Vector Bindings for Eshkol (Stage S1)
+ *
+ * Thin C shim over Moonlab's dense state-vector core (quantum_state_t,
+ * gate_*, quantum_measure, measurement_expectation_z).
+ *
+ * Compile with -DESHKOL_HAVE_MOONLAB and link against libquantumsim (set by
+ * CMakeLists.txt's Agent FFI block only when configured with
+ * -DESHKOL_QUANTUM_ENABLED=ON and Moonlab's FetchContent succeeded).
+ * Without -DESHKOL_HAVE_MOONLAB, every function below returns a graceful,
+ * honestly-labeled "unavailable" error (-1 / NaN) instead of crashing or
+ * silently returning a bogus value -- mirroring the existing
+ * agent_treesitter.c / agent_yoga.c degrade-gracefully convention, and
+ * keeping this file safe to compile unconditionally (so JIT weak-symbol
+ * resolution in lib/repl/repl_jit.cpp always has a real definition to bind,
+ * instead of leaving `(require agent.quantum)` a dangling reference on the
+ * default ESHKOL_QUANTUM_ENABLED=OFF build).
+ *
+ * Symbol names below are verified against Moonlab's actual headers at the
+ * pinned revision c613234cd8498804428f3838aa46dd730b1de810 (tag v1.1.0-rc):
+ *   - src/quantum/state.h        : quantum_state_create, quantum_state_destroy
+ *   - src/quantum/gates.h        : gate_hadamard, gate_pauli_x/_y/_z,
+ *                                   gate_cnot, gate_rx/_ry/_rz, quantum_measure,
+ *                                   measurement_basis_t, measurement_result_t
+ *   - src/quantum/measurement.h  : measurement_expectation_z
+ *   - src/utils/quantum_entropy.h: quantum_entropy_ctx_t,
+ *                                   quantum_entropy_ctx_create_hw/_destroy
+ *
+ * quantum_state_t is a public struct in Moonlab (state.h) but this shim
+ * follows the same discipline as the Rust binding (the model called out in
+ * docs/design/MOONLAB_INTEGRATION.md Section 1.5): treat it as opaque, never
+ * mirror its layout in Scheme. Eshkol callers only ever see a small integer
+ * handle; the actual quantum_state_t* lives in a process-local handle table
+ * here, matching the existing agent_sqlite.c / agent_regex.c pattern.
+ *
+ * Measurement entropy: quantum_measure() requires a caller-supplied
+ * quantum_entropy_ctx_t*. We use Moonlab's own hardware-backed helper
+ * (quantum_entropy_ctx_create_hw) so simulated measurement collapse is not
+ * seeded by anything Eshkol controls -- lazily created once per process and
+ * released at exit, mirroring moonlab_qrng_bytes's own "process-lifetime
+ * context freed at atexit" pattern (documented at moonlab_export.h:33-75
+ * in the pinned Moonlab revision).
+ *
+ * Copyright (c) 2026 Eshkol Project
+ ******************************************************************************/
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*******************************************************************************
+ * CONDITIONAL COMPILATION: full Moonlab-backed implementation vs graceful stubs
+ ******************************************************************************/
+
+#ifdef ESHKOL_HAVE_MOONLAB
+
+#include "quantum/state.h"
+#include "quantum/gates.h"
+#include "quantum/measurement.h"
+#include "utils/quantum_entropy.h"
+
+/*******************************************************************************
+ * Handle Table
+ ******************************************************************************/
+
+#define MAX_QSTATE_HANDLES 256
+
+static quantum_state_t* g_qstate_handles[MAX_QSTATE_HANDLES] = {0};
+static int g_next_qstate_handle = 1;
+
+/** @brief Human-readable last-error message, mirrored via eshkol_quantum_last_error(). */
+static char g_quantum_last_error[256] = {0};
+
+static void set_last_error(const char* msg) {
+    if (!msg) { g_quantum_last_error[0] = '\0'; return; }
+    size_t len = strlen(msg);
+    size_t copy = len < sizeof(g_quantum_last_error) - 1 ? len : sizeof(g_quantum_last_error) - 1;
+    memcpy(g_quantum_last_error, msg, copy);
+    g_quantum_last_error[copy] = '\0';
+}
+
+/**
+ * @brief Allocates a slot in the global quantum-state handle table.
+ *
+ * Scans forward from the last-used index (wrapping around once) so released
+ * handles are reused rather than exhausting the table.
+ */
+static int alloc_qstate(quantum_state_t* state) {
+    for (int i = g_next_qstate_handle; i < MAX_QSTATE_HANDLES; i++) {
+        if (!g_qstate_handles[i]) { g_qstate_handles[i] = state; g_next_qstate_handle = i + 1; return i; }
+    }
+    for (int i = 1; i < g_next_qstate_handle; i++) {
+        if (!g_qstate_handles[i]) { g_qstate_handles[i] = state; g_next_qstate_handle = i + 1; return i; }
+    }
+    return -1;
+}
+
+static quantum_state_t* get_qstate(int64_t h) {
+    if (h < 1 || h >= MAX_QSTATE_HANDLES) return NULL;
+    return g_qstate_handles[h];
+}
+
+/*******************************************************************************
+ * Lazily-initialized hardware entropy context for quantum_measure()
+ ******************************************************************************/
+
+static quantum_entropy_ctx_t* g_measure_entropy = NULL;
+
+static void teardown_measure_entropy(void) {
+    if (g_measure_entropy) {
+        quantum_entropy_ctx_destroy(g_measure_entropy);
+        g_measure_entropy = NULL;
+    }
+}
+
+/** @return Non-NULL on success. Sets the shim's last-error on failure. */
+static quantum_entropy_ctx_t* ensure_measure_entropy(void) {
+    if (!g_measure_entropy) {
+        g_measure_entropy = quantum_entropy_ctx_create_hw();
+        if (g_measure_entropy) {
+            atexit(teardown_measure_entropy);
+        } else {
+            set_last_error("failed to initialize Moonlab hardware entropy context for measurement");
+        }
+    }
+    return g_measure_entropy;
+}
+
+/*******************************************************************************
+ * Lifecycle
+ ******************************************************************************/
+
+/**
+ * @brief Allocates an n-qubit state vector initialized to |0...0>.
+ * @return Handle (>= 1) on success, -1 on invalid n / OOM / handle-table full.
+ */
+int64_t eshkol_quantum_state_create(int32_t num_qubits) {
+    if (num_qubits <= 0) {
+        set_last_error("make-quantum-state: num_qubits must be positive");
+        return -1;
+    }
+    quantum_state_t* state = quantum_state_create(num_qubits);
+    if (!state) {
+        set_last_error("quantum_state_create failed (Moonlab returned NULL -- invalid qubit count or OOM)");
+        return -1;
+    }
+    int handle = alloc_qstate(state);
+    if (handle < 0) {
+        quantum_state_destroy(state);
+        set_last_error("quantum-state handle table exhausted");
+        return -1;
+    }
+    return (int64_t)handle;
+}
+
+/** @brief Destroys a state vector and frees its handle slot. Safe on an already-freed handle. */
+void eshkol_quantum_state_destroy(int64_t handle) {
+    if (handle < 1 || handle >= MAX_QSTATE_HANDLES) return;
+    quantum_state_t* state = g_qstate_handles[handle];
+    if (state) {
+        quantum_state_destroy(state);
+        g_qstate_handles[handle] = NULL;
+    }
+}
+
+/*******************************************************************************
+ * Gates -- each returns 0 on success, or the qs_error_t (always < 0) Moonlab
+ * reported, so Scheme callers can raise a specific, catchable error.
+ ******************************************************************************/
+
+int32_t eshkol_quantum_gate_hadamard(int64_t handle, int32_t qubit) {
+    quantum_state_t* state = get_qstate(handle);
+    if (!state) { set_last_error("apply-hadamard: invalid quantum-state handle"); return -1; }
+    qs_error_t err = gate_hadamard(state, qubit);
+    if (err != QS_SUCCESS) set_last_error("gate_hadamard failed");
+    return (int32_t)err;
+}
+
+int32_t eshkol_quantum_gate_pauli_x(int64_t handle, int32_t qubit) {
+    quantum_state_t* state = get_qstate(handle);
+    if (!state) { set_last_error("apply-pauli-x: invalid quantum-state handle"); return -1; }
+    qs_error_t err = gate_pauli_x(state, qubit);
+    if (err != QS_SUCCESS) set_last_error("gate_pauli_x failed");
+    return (int32_t)err;
+}
+
+int32_t eshkol_quantum_gate_pauli_y(int64_t handle, int32_t qubit) {
+    quantum_state_t* state = get_qstate(handle);
+    if (!state) { set_last_error("apply-pauli-y: invalid quantum-state handle"); return -1; }
+    qs_error_t err = gate_pauli_y(state, qubit);
+    if (err != QS_SUCCESS) set_last_error("gate_pauli_y failed");
+    return (int32_t)err;
+}
+
+int32_t eshkol_quantum_gate_pauli_z(int64_t handle, int32_t qubit) {
+    quantum_state_t* state = get_qstate(handle);
+    if (!state) { set_last_error("apply-pauli-z: invalid quantum-state handle"); return -1; }
+    qs_error_t err = gate_pauli_z(state, qubit);
+    if (err != QS_SUCCESS) set_last_error("gate_pauli_z failed");
+    return (int32_t)err;
+}
+
+int32_t eshkol_quantum_gate_cnot(int64_t handle, int32_t control, int32_t target) {
+    quantum_state_t* state = get_qstate(handle);
+    if (!state) { set_last_error("apply-cnot: invalid quantum-state handle"); return -1; }
+    qs_error_t err = gate_cnot(state, control, target);
+    if (err != QS_SUCCESS) set_last_error("gate_cnot failed");
+    return (int32_t)err;
+}
+
+int32_t eshkol_quantum_gate_rx(int64_t handle, int32_t qubit, double theta) {
+    quantum_state_t* state = get_qstate(handle);
+    if (!state) { set_last_error("apply-rx: invalid quantum-state handle"); return -1; }
+    qs_error_t err = gate_rx(state, qubit, theta);
+    if (err != QS_SUCCESS) set_last_error("gate_rx failed");
+    return (int32_t)err;
+}
+
+int32_t eshkol_quantum_gate_ry(int64_t handle, int32_t qubit, double theta) {
+    quantum_state_t* state = get_qstate(handle);
+    if (!state) { set_last_error("apply-ry: invalid quantum-state handle"); return -1; }
+    qs_error_t err = gate_ry(state, qubit, theta);
+    if (err != QS_SUCCESS) set_last_error("gate_ry failed");
+    return (int32_t)err;
+}
+
+int32_t eshkol_quantum_gate_rz(int64_t handle, int32_t qubit, double theta) {
+    quantum_state_t* state = get_qstate(handle);
+    if (!state) { set_last_error("apply-rz: invalid quantum-state handle"); return -1; }
+    qs_error_t err = gate_rz(state, qubit, theta);
+    if (err != QS_SUCCESS) set_last_error("gate_rz failed");
+    return (int32_t)err;
+}
+
+/*******************************************************************************
+ * Measurement
+ ******************************************************************************/
+
+/**
+ * @brief Projectively measures one qubit in the computational (Z) basis,
+ *        collapsing the state vector.
+ * @return 0 or 1 (the measurement outcome), or -1 on error (invalid handle,
+ *         invalid qubit, or entropy-context failure -- check
+ *         eshkol_quantum_last_error()).
+ */
+int32_t eshkol_quantum_measure(int64_t handle, int32_t qubit) {
+    quantum_state_t* state = get_qstate(handle);
+    if (!state) { set_last_error("measure: invalid quantum-state handle"); return -1; }
+    quantum_entropy_ctx_t* entropy = ensure_measure_entropy();
+    if (!entropy) return -1; /* set_last_error already called */
+    measurement_result_t result = quantum_measure(state, qubit, MEASURE_COMPUTATIONAL, entropy);
+    return (int32_t)result.outcome;
+}
+
+/**
+ * @brief Expectation value of the Pauli-Z observable on one qubit, <psi|Z_q|psi>.
+ * @return Value in [-1, 1], or a NaN sentinel on invalid handle (check
+ *         eshkol_quantum_last_error()).
+ */
+double eshkol_quantum_expectation_z(int64_t handle, int32_t qubit) {
+    quantum_state_t* state = get_qstate(handle);
+    if (!state) {
+        set_last_error("expectation-z: invalid quantum-state handle");
+        /* Portable NaN sentinel without a literal 0.0/0.0 constant-fold warning. */
+        volatile double zero = 0.0;
+        return zero / zero;
+    }
+    return measurement_expectation_z(state, qubit);
+}
+
+/*******************************************************************************
+ * Diagnostics
+ ******************************************************************************/
+
+/** @return Number of qubits the handle was created with, or -1 on invalid handle. */
+int32_t eshkol_quantum_num_qubits(int64_t handle) {
+    quantum_state_t* state = get_qstate(handle);
+    if (!state) return -1;
+    return (int32_t)state->num_qubits;
+}
+
+/**
+ * @brief Copies the last shim-level error message into @p buf.
+ * @return Number of bytes written (excluding NUL), or -1 if @p buf is NULL/too small.
+ */
+int32_t eshkol_quantum_last_error(char* buf, int64_t buf_size) {
+    if (!buf || buf_size <= 0) return -1;
+    size_t len = strlen(g_quantum_last_error);
+    size_t copy = (size_t)buf_size - 1 < len ? (size_t)buf_size - 1 : len;
+    memcpy(buf, g_quantum_last_error, copy);
+    buf[copy] = '\0';
+    return (int32_t)copy;
+}
+
+#else /* !ESHKOL_HAVE_MOONLAB */
+
+/*******************************************************************************
+ * Graceful stubs when Moonlab is not compiled in (ESHKOL_QUANTUM_ENABLED=OFF,
+ * the default). Every entry point fails honestly and explicitly -- never a
+ * silently-wrong value -- so lib/agent/quantum.esk's Scheme wrappers raise a
+ * clear "Moonlab quantum support not enabled in this build" error instead of
+ * segfaulting on a dangling weak symbol or fabricating quantum data.
+ ******************************************************************************/
+
+static const char* const kUnavailableMsg =
+    "Moonlab quantum support not enabled in this build "
+    "(reconfigure with -DESHKOL_QUANTUM_ENABLED=ON)";
+
+/** @brief Stub: Moonlab support was not compiled in, so state creation always fails. */
+int64_t eshkol_quantum_state_create(int32_t num_qubits) { (void)num_qubits; return -1; }
+/** @brief Stub: no-op since no states exist without Moonlab support. */
+void eshkol_quantum_state_destroy(int64_t handle) { (void)handle; }
+/** @brief Stub: always fails since no states exist without Moonlab support. */
+int32_t eshkol_quantum_num_qubits(int64_t handle) { (void)handle; return -1; }
+/** @brief Stub: always fails since no states exist without Moonlab support. */
+int32_t eshkol_quantum_gate_hadamard(int64_t handle, int32_t qubit) { (void)handle; (void)qubit; return -1; }
+/** @brief Stub: always fails since no states exist without Moonlab support. */
+int32_t eshkol_quantum_gate_pauli_x(int64_t handle, int32_t qubit) { (void)handle; (void)qubit; return -1; }
+/** @brief Stub: always fails since no states exist without Moonlab support. */
+int32_t eshkol_quantum_gate_pauli_y(int64_t handle, int32_t qubit) { (void)handle; (void)qubit; return -1; }
+/** @brief Stub: always fails since no states exist without Moonlab support. */
+int32_t eshkol_quantum_gate_pauli_z(int64_t handle, int32_t qubit) { (void)handle; (void)qubit; return -1; }
+/** @brief Stub: always fails since no states exist without Moonlab support. */
+int32_t eshkol_quantum_gate_cnot(int64_t handle, int32_t control, int32_t target) {
+    (void)handle; (void)control; (void)target; return -1;
+}
+/** @brief Stub: always fails since no states exist without Moonlab support. */
+int32_t eshkol_quantum_gate_rx(int64_t handle, int32_t qubit, double theta) {
+    (void)handle; (void)qubit; (void)theta; return -1;
+}
+/** @brief Stub: always fails since no states exist without Moonlab support. */
+int32_t eshkol_quantum_gate_ry(int64_t handle, int32_t qubit, double theta) {
+    (void)handle; (void)qubit; (void)theta; return -1;
+}
+/** @brief Stub: always fails since no states exist without Moonlab support. */
+int32_t eshkol_quantum_gate_rz(int64_t handle, int32_t qubit, double theta) {
+    (void)handle; (void)qubit; (void)theta; return -1;
+}
+/** @brief Stub: always fails since no states exist without Moonlab support. */
+int32_t eshkol_quantum_measure(int64_t handle, int32_t qubit) { (void)handle; (void)qubit; return -1; }
+/** @brief Stub: always fails (NaN sentinel) since no states exist without Moonlab support. */
+double eshkol_quantum_expectation_z(int64_t handle, int32_t qubit) {
+    (void)handle; (void)qubit;
+    volatile double zero = 0.0;
+    return zero / zero;
+}
+/**
+ * @brief Stub: copies the fixed "not enabled" message into @p buf, so callers
+ *        that always check eshkol_quantum_last_error() after a -1 get an
+ *        honest, actionable reason instead of an empty string.
+ */
+int32_t eshkol_quantum_last_error(char* buf, int64_t buf_size) {
+    if (!buf || buf_size <= 0) return -1;
+    size_t len = strlen(kUnavailableMsg);
+    size_t copy = (size_t)buf_size - 1 < len ? (size_t)buf_size - 1 : len;
+    memcpy(buf, kUnavailableMsg, copy);
+    buf[copy] = '\0';
+    return (int32_t)copy;
+}
+
+#endif /* ESHKOL_HAVE_MOONLAB */

--- a/lib/agent/quantum.esk
+++ b/lib/agent/quantum.esk
@@ -1,0 +1,165 @@
+;;
+;; quantum.esk - Moonlab quantum state-vector FFI wrapper (Stage S1)
+;; Bindings to agent_quantum.c, which links Moonlab's libquantumsim.
+;;
+;; Only usable when Eshkol is built with -DESHKOL_QUANTUM_ENABLED=ON (see
+;; docs/design/MOONLAB_INTEGRATION.md). Without that flag, agent_quantum.c is
+;; not compiled and these externs resolve to nothing -- (require agent.quantum)
+;; on such a build fails to link, the same graceful-unavailability contract
+;; agent.http uses for its libcurl-optional symbols.
+;;
+;; HONESTY NOTE: this module gives you the real thing -- Moonlab's actual
+;; state-vector simulator, gates, and measurement, Bell-verifiable via
+;; Moonlab's own bell_test_run_chsh (not bound here yet; see Stage S5 in the
+;; design doc). It is unrelated to the classical `quantum-random` builtin
+;; family (lib/quantum/quantum_rng.c) -- see Part D for wiring that builtin to
+;; Moonlab's QRNG.
+;;
+(require core.capabilities)
+
+(provide make-quantum-state
+         quantum-state-destroy!
+         quantum-state-num-qubits
+         apply-hadamard
+         apply-pauli-x
+         apply-pauli-y
+         apply-pauli-z
+         apply-cnot
+         apply-rx
+         apply-ry
+         apply-rz
+         measure
+         expectation-z
+         with-quantum-state)
+
+;; FFI declarations
+(extern i64    quantum-state-create-raw     i32           :real eshkol_quantum_state_create)
+(extern void   quantum-state-destroy-raw    i64           :real eshkol_quantum_state_destroy)
+(extern i32    quantum-num-qubits-raw       i64           :real eshkol_quantum_num_qubits)
+(extern i32    quantum-gate-hadamard-raw    i64 i32       :real eshkol_quantum_gate_hadamard)
+(extern i32    quantum-gate-pauli-x-raw     i64 i32       :real eshkol_quantum_gate_pauli_x)
+(extern i32    quantum-gate-pauli-y-raw     i64 i32       :real eshkol_quantum_gate_pauli_y)
+(extern i32    quantum-gate-pauli-z-raw     i64 i32       :real eshkol_quantum_gate_pauli_z)
+(extern i32    quantum-gate-cnot-raw        i64 i32 i32   :real eshkol_quantum_gate_cnot)
+(extern i32    quantum-gate-rx-raw          i64 i32 double :real eshkol_quantum_gate_rx)
+(extern i32    quantum-gate-ry-raw          i64 i32 double :real eshkol_quantum_gate_ry)
+(extern i32    quantum-gate-rz-raw          i64 i32 double :real eshkol_quantum_gate_rz)
+(extern i32    quantum-measure-raw          i64 i32       :real eshkol_quantum_measure)
+(extern double quantum-expectation-z-raw    i64 i32       :real eshkol_quantum_expectation_z)
+(extern i32    quantum-last-error-raw       ptr i64       :real eshkol_quantum_last_error)
+
+;; ---------------------------------------------------------------------------
+;; Internal: honest error surface. Moonlab/the shim signal failure with a
+;; negative return code; this turns that into a catchable Eshkol error
+;; carrying Moonlab's own message, rather than returning a bogus value.
+;; ---------------------------------------------------------------------------
+
+(define (quantum-last-error)
+  (let ((buf (make-string 256 #\nul)))
+    (let ((n (quantum-last-error-raw buf 256)))
+      (if (> n 0) (substring buf 0 n) "unknown Moonlab quantum error"))))
+
+(define (check-gate-result! op-name rc)
+  (if (< rc 0)
+      (error (string-append "agent.quantum: " op-name " failed: " (quantum-last-error)))
+      rc))
+
+;; ---------------------------------------------------------------------------
+;; Lifecycle
+;; ---------------------------------------------------------------------------
+
+(define (make-quantum-state n)
+  "Allocate an n-qubit state vector initialized to |0...0>.
+   Returns an opaque handle. Raises on invalid n or Moonlab allocation failure."
+  (capability-require! 'ffi 'make-quantum-state)
+  (let ((h (quantum-state-create-raw n)))
+    (if (< h 0)
+        (error (string-append "agent.quantum: make-quantum-state failed: " (quantum-last-error)))
+        h)))
+
+(define (quantum-state-destroy! st)
+  "Release a quantum state's Moonlab-side resources. Safe to call once;
+   calling twice or with an invalid handle is a documented no-op on the
+   C side, never a crash."
+  (quantum-state-destroy-raw st))
+
+(define (quantum-state-num-qubits st)
+  "Number of qubits `st` was created with."
+  (let ((n (quantum-num-qubits-raw st)))
+    (if (< n 0)
+        (error "agent.quantum: quantum-state-num-qubits: invalid quantum-state handle")
+        n)))
+
+;; ---------------------------------------------------------------------------
+;; Gates
+;; ---------------------------------------------------------------------------
+
+(define (apply-hadamard st qubit)
+  "Apply a Hadamard gate to `qubit`. Returns `st` for chaining."
+  (check-gate-result! "apply-hadamard" (quantum-gate-hadamard-raw st qubit))
+  st)
+
+(define (apply-pauli-x st qubit)
+  "Apply a Pauli-X (NOT) gate to `qubit`. Returns `st` for chaining."
+  (check-gate-result! "apply-pauli-x" (quantum-gate-pauli-x-raw st qubit))
+  st)
+
+(define (apply-pauli-y st qubit)
+  "Apply a Pauli-Y gate to `qubit`. Returns `st` for chaining."
+  (check-gate-result! "apply-pauli-y" (quantum-gate-pauli-y-raw st qubit))
+  st)
+
+(define (apply-pauli-z st qubit)
+  "Apply a Pauli-Z gate to `qubit`. Returns `st` for chaining."
+  (check-gate-result! "apply-pauli-z" (quantum-gate-pauli-z-raw st qubit))
+  st)
+
+(define (apply-cnot st control target)
+  "Apply a CNOT gate: flip `target` iff `control` is |1>. Returns `st` for chaining."
+  (check-gate-result! "apply-cnot" (quantum-gate-cnot-raw st control target))
+  st)
+
+(define (apply-rx st qubit theta)
+  "Apply an RX(theta) rotation to `qubit`. Returns `st` for chaining."
+  (check-gate-result! "apply-rx" (quantum-gate-rx-raw st qubit theta))
+  st)
+
+(define (apply-ry st qubit theta)
+  "Apply an RY(theta) rotation to `qubit`. Returns `st` for chaining."
+  (check-gate-result! "apply-ry" (quantum-gate-ry-raw st qubit theta))
+  st)
+
+(define (apply-rz st qubit theta)
+  "Apply an RZ(theta) rotation to `qubit`. Returns `st` for chaining."
+  (check-gate-result! "apply-rz" (quantum-gate-rz-raw st qubit theta))
+  st)
+
+;; ---------------------------------------------------------------------------
+;; Measurement
+;; ---------------------------------------------------------------------------
+
+(define (measure st qubit)
+  "Projectively measure `qubit` in the computational (Z) basis, collapsing
+   the state vector. Returns 0 or 1. Sampled using Moonlab's own
+   hardware-backed entropy context (quantum_entropy_ctx_create_hw), not any
+   Eshkol-controlled seed."
+  (let ((outcome (quantum-measure-raw st qubit)))
+    (if (< outcome 0)
+        (error (string-append "agent.quantum: measure failed: " (quantum-last-error)))
+        outcome)))
+
+(define (expectation-z st qubit)
+  "Expectation value <psi|Z_qubit|psi> in [-1, 1], without collapsing the state."
+  (quantum-expectation-z-raw st qubit))
+
+;; ---------------------------------------------------------------------------
+;; Convenience: auto-destroy on exit (mirrors sqlite.esk's with-db)
+;; ---------------------------------------------------------------------------
+
+(define (with-quantum-state n fn)
+  "Allocate an n-qubit state, call (fn state), destroy the state on exit
+   (including on error/non-local exit via dynamic-wind)."
+  (let ((st (make-quantum-state n)))
+    (dynamic-wind (lambda () #f)
+                  (lambda () (fn st))
+                  (lambda () (quantum-state-destroy! st)))))

--- a/lib/backend/eshkol_vm.c
+++ b/lib/backend/eshkol_vm.c
@@ -82,6 +82,14 @@
 #include "eshkol/backend/vm_limits.h"
 #include "eshkol/backend/vm.h"
 
+/* quantum-random / -int / -range (vm_native.c dispatch cases 1860-1862) route
+ * through the SAME eshkol_qrng_* entry points the LLVM AOT/JIT backend uses
+ * (lib/quantum/quantum_rng_wrapper.c), rather than the VM's own separate
+ * generator, so the two backends agree on both the numbers and the entropy
+ * source. See that file's honesty notice for what source is actually active
+ * in a given build. */
+#include "../quantum/quantum_rng_wrapper.h"
+
 #ifdef ESHKOL_VM_WASM
 /* The VM networking natives reference POSIX socket and fd declarations.
  * Emscripten provides these headers in its sysroot; include them for the

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -4296,54 +4296,17 @@ static VmTensor* vm_tensor_operand(VM* vm, Value v, const char* op_name) {
     return NULL;
 }
 
-/* HONESTY NOTICE: despite the "quantum" name of the VM dispatch cases below
- * (1860-1862, "quantum-random"/"-int"/"-range"), vm_qrng_next_u64() is a
- * plain classical xorshift64* PRNG - no quantum hardware or simulation is
- * involved, and it is not Bell-verified. This is also the VM interpreter's
- * OWN separate implementation, distinct from (and today numerically
- * divergent from) the eshkol_qrng_* generator the LLVM AOT/JIT backend uses
- * (lib/quantum/quantum_rng_wrapper.c) for the same builtins - see
- * docs/design/MOONLAB_INTEGRATION.md Section 3.2 for the divergence and the
- * planned fix (re-point both backends at the same, honestly-labeled source).
- * Do not present this generator's output as "real quantum" randomness. */
-static uint64_t vm_qrng_state = 0;
-
-/** @brief xorshift64* PRNG step, lazily self-seeding on first call from a
- *         mix of a stack address and platform-specific entropy (tick count/
- *         QueryPerformanceCounter on Windows, gettimeofday+pid elsewhere).
- *         Classical PRNG only - see the honesty notice above. */
-static uint64_t vm_qrng_next_u64(void) {
-    if (vm_qrng_state == 0) {
-        uint64_t seed = 0x9e3779b97f4a7c15ULL ^ (uint64_t)(uintptr_t)&vm_qrng_state;
-#if !defined(ESHKOL_VM_WASM)
-#if defined(_WIN32)
-        seed ^= (uint64_t)GetTickCount64();
-        LARGE_INTEGER counter;
-        if (QueryPerformanceCounter(&counter)) {
-            seed ^= (uint64_t)counter.QuadPart;
-        }
-#else
-        struct timeval tv;
-        if (gettimeofday(&tv, NULL) == 0) {
-            seed ^= ((uint64_t)tv.tv_sec << 32) ^ (uint64_t)tv.tv_usec;
-        }
-        seed ^= ((uint64_t)(uint32_t)getpid() << 17);
-#endif
-#endif
-        vm_qrng_state = seed ? seed : 0x2545f4914f6cdd1dULL;
-    }
-    uint64_t x = vm_qrng_state;
-    x ^= x >> 12;
-    x ^= x << 25;
-    x ^= x >> 27;
-    vm_qrng_state = x;
-    return x * 0x2545f4914f6cdd1dULL;
-}
-
-/** @brief Convert one xorshift64* draw into a double uniformly distributed in [0,1). */
-static double vm_qrng_double(void) {
-    return (double)(vm_qrng_next_u64() >> 11) * (1.0 / 9007199254740992.0);
-}
+/* quantum-random / -int / -range (dispatch cases 1860-1862 below) used to be
+ * backed by a VM-only xorshift64* PRNG that was numerically divergent from
+ * the eshkol_qrng_* generator the LLVM AOT/JIT backend used for the same
+ * builtins (docs/design/MOONLAB_INTEGRATION.md Section 3.2 flagged this as a
+ * cross-backend honesty problem: same builtin name, different numbers,
+ * neither one real quantum entropy). Fixed by routing the VM dispatch
+ * through the SAME eshkol_qrng_uint64() / eshkol_qrng_double() entry points
+ * (lib/quantum/quantum_rng_wrapper.c, included via eshkol_vm.c) that the
+ * LLVM backend calls - see that file's honesty notice for what source is
+ * actually active (classical fallback by default and on WASM; Moonlab's
+ * Bell-verified QRNG when built with -DESHKOL_QUANTUM_ENABLED=ON). */
 
 /* Runtime host-native registry. Compile-time fids stay in the static switch
  * below; fids >= ESHKOL_VM_HOST_NATIVE_BASE are looked up here by slot index
@@ -12398,11 +12361,13 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
 
     /* ══════════════════════════════════════════════════════════════════════
-     * "Quantum-inspired" RNG (1860-1862) - classical PRNG, not real quantum
-     * entropy. See the honesty notice above vm_qrng_state/vm_qrng_next_u64.
+     * `quantum-random` family (1860-1862). Routed through eshkol_qrng_* (see
+     * the honesty notice above this dispatch block's case labels) so the VM
+     * and LLVM AOT/JIT backends agree on both the numbers and the entropy
+     * source instead of each running its own generator.
      * ══════════════════════════════════════════════════════════════════════ */
     case 1860: { /* quantum-random() -> double in [0, 1) */
-        vm_push(vm, FLOAT_VAL(vm_qrng_double()));
+        vm_push(vm, FLOAT_VAL(eshkol_qrng_double()));
         break;
     }
     case 1861: { /* quantum-random-int(bound) -> integer in [0, bound) */
@@ -12411,7 +12376,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
         if (bound <= 1) {
             vm_push(vm, INT_VAL(0));
         } else {
-            vm_push(vm, INT_VAL((int64_t)(vm_qrng_next_u64() % (uint64_t)bound)));
+            vm_push(vm, INT_VAL((int64_t)(eshkol_qrng_uint64() % (uint64_t)bound)));
         }
         break;
     }
@@ -12427,9 +12392,9 @@ static void vm_dispatch_native(VM* vm, int fid) {
             int64_t ilo = min_val.as.i;
             int64_t ihi = max_val.as.i;
             uint64_t span = (uint64_t)(ihi - ilo + 1);
-            vm_push(vm, INT_VAL(ilo + (int64_t)(vm_qrng_next_u64() % span)));
+            vm_push(vm, INT_VAL(ilo + (int64_t)(eshkol_qrng_uint64() % span)));
         } else {
-            vm_push(vm, FLOAT_VAL(lo + vm_qrng_double() * (hi - lo)));
+            vm_push(vm, FLOAT_VAL(lo + eshkol_qrng_double() * (hi - lo)));
         }
         break;
     }

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -4296,11 +4296,22 @@ static VmTensor* vm_tensor_operand(VM* vm, Value v, const char* op_name) {
     return NULL;
 }
 
+/* HONESTY NOTICE: despite the "quantum" name of the VM dispatch cases below
+ * (1860-1862, "quantum-random"/"-int"/"-range"), vm_qrng_next_u64() is a
+ * plain classical xorshift64* PRNG - no quantum hardware or simulation is
+ * involved, and it is not Bell-verified. This is also the VM interpreter's
+ * OWN separate implementation, distinct from (and today numerically
+ * divergent from) the eshkol_qrng_* generator the LLVM AOT/JIT backend uses
+ * (lib/quantum/quantum_rng_wrapper.c) for the same builtins - see
+ * docs/design/MOONLAB_INTEGRATION.md Section 3.2 for the divergence and the
+ * planned fix (re-point both backends at the same, honestly-labeled source).
+ * Do not present this generator's output as "real quantum" randomness. */
 static uint64_t vm_qrng_state = 0;
 
 /** @brief xorshift64* PRNG step, lazily self-seeding on first call from a
  *         mix of a stack address and platform-specific entropy (tick count/
- *         QueryPerformanceCounter on Windows, gettimeofday+pid elsewhere). */
+ *         QueryPerformanceCounter on Windows, gettimeofday+pid elsewhere).
+ *         Classical PRNG only - see the honesty notice above. */
 static uint64_t vm_qrng_next_u64(void) {
     if (vm_qrng_state == 0) {
         uint64_t seed = 0x9e3779b97f4a7c15ULL ^ (uint64_t)(uintptr_t)&vm_qrng_state;
@@ -12387,7 +12398,8 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
 
     /* ══════════════════════════════════════════════════════════════════════
-     * Quantum-inspired RNG (1860-1862)
+     * "Quantum-inspired" RNG (1860-1862) - classical PRNG, not real quantum
+     * entropy. See the honesty notice above vm_qrng_state/vm_qrng_next_u64.
      * ══════════════════════════════════════════════════════════════════════ */
     case 1860: { /* quantum-random() -> double in [0, 1) */
         vm_push(vm, FLOAT_VAL(vm_qrng_double()));

--- a/lib/quantum/quantum_rng.h
+++ b/lib/quantum/quantum_rng.h
@@ -18,12 +18,32 @@ typedef int pid_t;
 
 /**
  * @file quantum_rng.h
- * @brief Quantum-inspired random number generator
+ * @brief Classical "quantum-inspired" pseudorandom number generator (NOT real quantum entropy)
  *
- * This library implements a high-performance random number generator that leverages
- * quantum computing principles on classical hardware. It uses quantum circuit simulation,
- * floating-point uncertainty, and quantum entanglement to achieve high-quality
- * non-deterministic random numbers.
+ * HONESTY NOTICE: despite the "quantum" vocabulary in this file's function and
+ * type names (qrng_entangle_states, qrng_measure_state, quantum_state[], ...),
+ * this is an entirely classical, deterministic software PRNG. It borrows terms
+ * like "entanglement" and "measurement" only as metaphors for its internal
+ * bit-mixing stages (splitmix64, Hadamard-style XOR mixing, physical-constant
+ * multipliers); no quantum hardware, no quantum circuit simulator, and no
+ * physical randomness are involved anywhere in this file. Its only source of
+ * non-determinism is classical: wall-clock time, process id, and a stack
+ * address, folded together in get_system_entropy() (quantum_rng.c). Given a
+ * fixed seed and fixed entropy inputs, the output stream is fully
+ * reproducible - this is an ordinary keyed pseudorandom generator, not a
+ * hardware entropy source, and it is not Bell-verified.
+ *
+ * This is the always-available, dependency-free fallback that backs Eshkol's
+ * `quantum-random` / `quantum-random-int` / `quantum-random-range` builtins
+ * when the build does not link a real quantum entropy source. When Eshkol is
+ * configured with -DESHKOL_QUANTUM_ENABLED=ON, those builtins are re-pointed
+ * at Moonlab's Bell-verified `moonlab_qrng_bytes()` (see
+ * lib/quantum/quantum_rng_wrapper.c and docs/design/MOONLAB_INTEGRATION.md);
+ * on WASM/browser builds and any build with quantum support disabled, this
+ * classical generator remains the fallback and must not be presented to users
+ * as "real quantum" randomness. See eshkol_qrng_source_label() in
+ * quantum_rng_wrapper.h for a machine-readable capability that reports which
+ * source is actually active.
  */
 
 /**

--- a/lib/quantum/quantum_rng_wrapper.c
+++ b/lib/quantum/quantum_rng_wrapper.c
@@ -1,9 +1,20 @@
+/*
+ * quantum_rng_wrapper.c - Eshkol runtime entry points behind `quantum-random`.
+ *
+ * HONESTY NOTICE: this file wires the classical software PRNG in
+ * quantum_rng.c to Eshkol's `quantum-random` / `-int` / `-range` builtins.
+ * It is NOT connected to real quantum hardware and is NOT Bell-verified; see
+ * quantum_rng.h's file comment and eshkol_qrng_source_label() below. A real
+ * (Bell-verified, hardware-entropy) source is only wired up when Eshkol is
+ * built with -DESHKOL_QUANTUM_ENABLED=ON, re-pointing these entry points at
+ * Moonlab's moonlab_qrng_bytes() - see docs/design/MOONLAB_INTEGRATION.md.
+ */
 #include "quantum_rng_wrapper.h"
 #include "quantum_rng.h"
 #include <stdlib.h>
 #include <string.h>
 
-// Global quantum RNG context
+// Global classical-PRNG context (see file-level honesty notice above).
 static qrng_ctx* g_qrng_ctx = NULL;
 static int g_qrng_initialized = 0;
 
@@ -59,4 +70,18 @@ int eshkol_qrng_bytes(uint8_t* buffer, size_t len) {
 
 const char* eshkol_qrng_version(void) {
     return qrng_version();
+}
+
+const char* eshkol_qrng_source_label(void) {
+    /* Stage S1: this build compiles only the classical fallback path.
+     * ESHKOL_MOONLAB_QRNG_ENABLED (set by CMake when -DESHKOL_QUANTUM_ENABLED=ON
+     * and Moonlab links successfully) re-points this label at "moonlab-qrng"
+     * once the real routing lands - see Part D of
+     * docs/design/MOONLAB_INTEGRATION.md. Until then, tell the truth: this is
+     * the deterministic-seed classical PRNG, not real quantum entropy. */
+#if defined(ESHKOL_MOONLAB_QRNG_ENABLED)
+    return "moonlab-qrng";
+#else
+    return "classical-fallback";
+#endif
 }

--- a/lib/quantum/quantum_rng_wrapper.c
+++ b/lib/quantum/quantum_rng_wrapper.c
@@ -1,20 +1,45 @@
 /*
- * quantum_rng_wrapper.c - Eshkol runtime entry points behind `quantum-random`.
+ * quantum_rng_wrapper.c - Eshkol runtime entry points behind `quantum-random`,
+ * shared by BOTH native backends (the LLVM AOT/JIT codegen calls these
+ * eshkol_qrng_* symbols directly; the VM interpreter's vm_native.c dispatch
+ * for the same builtins also calls these, not its own generator - see
+ * lib/backend/vm_native.c's honesty notice above vm_qrng_next_u64 for that
+ * history). Routing both backends through this single file is what makes
+ * "the VM and AOT/JIT backends agree on the source" true.
  *
- * HONESTY NOTICE: this file wires the classical software PRNG in
- * quantum_rng.c to Eshkol's `quantum-random` / `-int` / `-range` builtins.
- * It is NOT connected to real quantum hardware and is NOT Bell-verified; see
- * quantum_rng.h's file comment and eshkol_qrng_source_label() below. A real
- * (Bell-verified, hardware-entropy) source is only wired up when Eshkol is
- * built with -DESHKOL_QUANTUM_ENABLED=ON, re-pointing these entry points at
- * Moonlab's moonlab_qrng_bytes() - see docs/design/MOONLAB_INTEGRATION.md.
+ * HONESTY NOTICE / two build configurations:
+ *
+ *  - ESHKOL_MOONLAB_QRNG_ENABLED not defined (default, and always on
+ *    WASM/browser builds): every function below is backed by the classical
+ *    software PRNG in quantum_rng.c - NOT real quantum hardware, NOT
+ *    Bell-verified. See quantum_rng.h's file comment.
+ *  - ESHKOL_MOONLAB_QRNG_ENABLED defined (set by CMake only when built with
+ *    -DESHKOL_QUANTUM_ENABLED=ON and Moonlab's `quantumsim` target linked):
+ *    every function below draws its raw bytes from Moonlab's
+ *    moonlab_qrng_bytes() (applications/moonlab_export.h), which "combines a
+ *    hardware entropy pool (RDSEED / /dev/urandom / SecRandomCopyBytes) with
+ *    a Bell-verified quantum simulation layer" (Moonlab's own documentation
+ *    of that function). On the rare documented failure of that call, this
+ *    file falls back to the classical generator for just that one draw and
+ *    prints a one-time diagnostic to stderr - never silently gives a
+ *    same-looking-but-different-source result without saying so.
+ *
+ * eshkol_qrng_source_label() reports which configuration is active.
  */
 #include "quantum_rng_wrapper.h"
 #include "quantum_rng.h"
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-// Global classical-PRNG context (see file-level honesty notice above).
+#ifdef ESHKOL_MOONLAB_QRNG_ENABLED
+#include "applications/moonlab_export.h"
+#endif
+
+// Global classical-PRNG context (see file-level honesty notice above). Used
+// unconditionally as the entropy source when ESHKOL_MOONLAB_QRNG_ENABLED is
+// not defined, and as a same-call fallback in the Moonlab-enabled path if
+// moonlab_qrng_bytes() itself fails.
 static qrng_ctx* g_qrng_ctx = NULL;
 static int g_qrng_initialized = 0;
 
@@ -32,40 +57,103 @@ int eshkol_qrng_init(void) {
     return 0;
 }
 
-/** @brief Lazily initializes the global quantum RNG context on first use. */
+/** @brief Lazily initializes the global classical-PRNG context on first use. */
 static inline void ensure_init(void) {
     if (!g_qrng_initialized) {
         eshkol_qrng_init();
     }
 }
 
-double eshkol_qrng_double(void) {
-    ensure_init();
-    return qrng_double(g_qrng_ctx);
+#ifdef ESHKOL_MOONLAB_QRNG_ENABLED
+/**
+ * @brief Draws sizeof(uint64_t) raw bytes from Moonlab's Bell-verified v3
+ *        QRNG. On the rare documented failure (moonlab_qrng_bytes returning
+ *        nonzero: NULL buffer, engine-init failure, or a rejected
+ *        Bell-verification epoch), falls back to the classical generator for
+ *        just this one draw and prints a one-time stderr diagnostic so a
+ *        persistent failure is discoverable rather than silently masked.
+ */
+static uint64_t moonlab_next_u64(void) {
+    uint64_t result = 0;
+    int rc = moonlab_qrng_bytes((uint8_t*)&result, sizeof(result));
+    if (rc != 0) {
+        static int warned = 0;
+        if (!warned) {
+            fprintf(stderr,
+                    "eshkol: moonlab_qrng_bytes failed (rc=%d); falling back to the "
+                    "classical PRNG for this draw only. quantum-random-source still "
+                    "reports moonlab-qrng because that is this build's configured "
+                    "source -- a persistent failure will keep printing this warning.\n",
+                    rc);
+            warned = 1;
+        }
+        ensure_init();
+        qrng_bytes(g_qrng_ctx, (uint8_t*)&result, sizeof(result));
+    }
+    return result;
 }
+#endif /* ESHKOL_MOONLAB_QRNG_ENABLED */
 
 uint64_t eshkol_qrng_uint64(void) {
+#ifdef ESHKOL_MOONLAB_QRNG_ENABLED
+    return moonlab_next_u64();
+#else
     ensure_init();
     return qrng_uint64(g_qrng_ctx);
+#endif
+}
+
+double eshkol_qrng_double(void) {
+    /* Standard "top 53 bits -> [0,1)" conversion (same formula
+     * quantum_rng.c's own qrng_double uses), applied uniformly to whichever
+     * source eshkol_qrng_uint64() drew from this build. */
+    return (double)(eshkol_qrng_uint64() >> 11) * (1.0 / 9007199254740992.0);
 }
 
 int64_t eshkol_qrng_range(int64_t min, int64_t max) {
-    ensure_init();
     if (min > max) {
         int64_t tmp = min;
         min = max;
         max = tmp;
     }
-    // Use 64-bit range function
     uint64_t umin = (uint64_t)min;
     uint64_t umax = (uint64_t)max;
-    uint64_t result = qrng_range64(g_qrng_ctx, umin, umax);
-    return (int64_t)result;
+    if (umin == umax) {
+        return (int64_t)umin;
+    }
+    uint64_t range = umax - umin + 1; /* 0 only if [min,max] spans the full uint64 range */
+    if (range == 0) {
+        return (int64_t)eshkol_qrng_uint64();
+    }
+    /* Rejection sampling for an unbiased draw in [0, range) -- the same
+     * technique quantum_rng.c's own qrng_range64 uses -- built on top of
+     * eshkol_qrng_uint64() so this logic (and its bias-freedom) is identical
+     * regardless of which source backs this build. */
+    uint64_t threshold = (uint64_t)(-range) % range;
+    uint64_t r;
+    do {
+        r = eshkol_qrng_uint64();
+    } while (r < threshold);
+    return (int64_t)(umin + (r % range));
 }
 
 int eshkol_qrng_bytes(uint8_t* buffer, size_t len) {
+#ifdef ESHKOL_MOONLAB_QRNG_ENABLED
+    int rc = moonlab_qrng_bytes(buffer, len);
+    if (rc == 0) return 0;
+    static int warned = 0;
+    if (!warned) {
+        fprintf(stderr,
+                "eshkol: moonlab_qrng_bytes failed (rc=%d) for eshkol_qrng_bytes; "
+                "falling back to the classical PRNG for this call only.\n", rc);
+        warned = 1;
+    }
     ensure_init();
     return (int)qrng_bytes(g_qrng_ctx, buffer, len);
+#else
+    ensure_init();
+    return (int)qrng_bytes(g_qrng_ctx, buffer, len);
+#endif
 }
 
 const char* eshkol_qrng_version(void) {
@@ -73,12 +161,6 @@ const char* eshkol_qrng_version(void) {
 }
 
 const char* eshkol_qrng_source_label(void) {
-    /* Stage S1: this build compiles only the classical fallback path.
-     * ESHKOL_MOONLAB_QRNG_ENABLED (set by CMake when -DESHKOL_QUANTUM_ENABLED=ON
-     * and Moonlab links successfully) re-points this label at "moonlab-qrng"
-     * once the real routing lands - see Part D of
-     * docs/design/MOONLAB_INTEGRATION.md. Until then, tell the truth: this is
-     * the deterministic-seed classical PRNG, not real quantum entropy. */
 #if defined(ESHKOL_MOONLAB_QRNG_ENABLED)
     return "moonlab-qrng";
 #else

--- a/lib/quantum/quantum_rng_wrapper.h
+++ b/lib/quantum/quantum_rng_wrapper.h
@@ -4,6 +4,19 @@
 #include <stdint.h>
 #include <stddef.h>
 
+/**
+ * @file quantum_rng_wrapper.h
+ * @brief Eshkol runtime entry points behind the `quantum-random` family of builtins.
+ *
+ * HONESTY NOTICE: as configured by default (ESHKOL_QUANTUM_ENABLED=OFF, and
+ * always on WASM/browser builds), every function in this header is backed by
+ * the classical software PRNG in quantum_rng.c/.h - NOT real hardware quantum
+ * entropy, and NOT Bell-verified. See quantum_rng.h's file comment for the
+ * full disclosure. Call eshkol_qrng_source_label() to find out, at runtime,
+ * which source is actually wired up in the build you are running - do not
+ * assume "quantum" from the function/builtin names alone.
+ */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,6 +60,28 @@ int eshkol_qrng_bytes(uint8_t* buffer, size_t len);
  * @return Version string
  */
 const char* eshkol_qrng_version(void);
+
+/**
+ * @brief Report which entropy source actually backs the eshkol_qrng_* /
+ *        `quantum-random` family in this build, honestly.
+ *
+ * This is the machine-readable half of the honesty fix: rather than trusting
+ * the "quantum" name of the builtins, callers (and test/CI gates) can check
+ * this label at runtime.
+ *
+ * @return A static, NUL-terminated string, one of:
+ *   - "classical-fallback" - the vendored quantum_rng.c software PRNG
+ *     (wall-clock/pid/stack-address seeded, deterministic given a fixed
+ *     seed). This is the value in every build with ESHKOL_QUANTUM_ENABLED=OFF
+ *     (the default) and on every WASM/browser build. NOT real quantum
+ *     entropy, NOT Bell-verified.
+ *   - "moonlab-qrng" - Moonlab's Bell-verified `moonlab_qrng_bytes()` v3 QRNG
+ *     engine, combining hardware entropy (RDSEED / /dev/urandom /
+ *     SecRandomCopyBytes) with a verified quantum-simulation layer. Only
+ *     possible when built with -DESHKOL_QUANTUM_ENABLED=ON and the runtime
+ *     successfully routed to it (see Part D of docs/design/MOONLAB_INTEGRATION.md).
+ */
+const char* eshkol_qrng_source_label(void);
 
 #ifdef __cplusplus
 }

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -339,6 +339,38 @@ extern "C" {
         ESHKOL_OPTIONAL_AGENT_FFI;
     int eshkol_sqlite_changes(int64_t db_handle) ESHKOL_OPTIONAL_AGENT_FFI;
 
+    // Moonlab quantum state-vector core (agent.quantum, Stage S1). Weak like
+    // the rest of this table: only defined when the build was configured
+    // with -DESHKOL_QUANTUM_ENABLED=ON and Moonlab linked successfully
+    // (see CMakeLists.txt's Agent FFI block and
+    // docs/design/MOONLAB_INTEGRATION.md). Symbol names verified against
+    // lib/agent/c/agent_quantum.c.
+    int64_t eshkol_quantum_state_create(int32_t num_qubits) ESHKOL_OPTIONAL_AGENT_FFI;
+    void eshkol_quantum_state_destroy(int64_t handle) ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t eshkol_quantum_num_qubits(int64_t handle) ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t eshkol_quantum_gate_hadamard(int64_t handle, int32_t qubit)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t eshkol_quantum_gate_pauli_x(int64_t handle, int32_t qubit)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t eshkol_quantum_gate_pauli_y(int64_t handle, int32_t qubit)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t eshkol_quantum_gate_pauli_z(int64_t handle, int32_t qubit)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t eshkol_quantum_gate_cnot(int64_t handle, int32_t control, int32_t target)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t eshkol_quantum_gate_rx(int64_t handle, int32_t qubit, double theta)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t eshkol_quantum_gate_ry(int64_t handle, int32_t qubit, double theta)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t eshkol_quantum_gate_rz(int64_t handle, int32_t qubit, double theta)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t eshkol_quantum_measure(int64_t handle, int32_t qubit)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    double eshkol_quantum_expectation_z(int64_t handle, int32_t qubit)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t eshkol_quantum_last_error(char* buf, int64_t buf_size)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+
     void* qllm_process_spawn(const char* command, const char* cwd_arg,
                              const char* env_arg, int64_t flags)
         ESHKOL_OPTIONAL_AGENT_FFI;
@@ -1010,6 +1042,21 @@ void ReplJITContext::registerRuntimeSymbols() {
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_sqlite_last_error);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_sqlite_last_insert_rowid);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_sqlite_changes);
+
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_state_create);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_state_destroy);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_num_qubits);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_gate_hadamard);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_gate_pauli_x);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_gate_pauli_y);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_gate_pauli_z);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_gate_cnot);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_gate_rx);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_gate_ry);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_gate_rz);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_measure);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_expectation_z);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_last_error);
 
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_process_spawn);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_process_spawn_shell);


### PR DESCRIPTION
Stage 1 of the Moonlab quantum-simulator integration (ROADMAP v2.0 quantum trajectory; design in `docs/design/MOONLAB_INTEGRATION.md`). Delivers runtime quantum-sim scaffolding **gated OFF by default**, plus a standalone correctness fix to `quantum-random` honesty that lands regardless of the gate.

## What this does

- **Part A — gated dependency pinning.** New CMake option `ESHKOL_QUANTUM_ENABLED` (default OFF). When ON, `FetchContent` pulls Moonlab from `ESHKOL_MOONLAB_REPO` (default `github.com/tsotchke/moonlab`) pinned to the exact `v1.1.0-rc` SHA `c613234c` (SHA, not tag, for reproducibility) and links the `quantumsim` target. Default builds are completely unaffected — quantum code is excluded.
- **Part B — honest `quantum-random` (the correctness fix; lands even with the gate OFF).** The shipped `docs/FEATURE_MATRIX.md` falsely claimed the source was the **"ANU QRNG API"**; it is a local classical PRNG (wall-clock/pid/rdtsc seed). Corrected the matrix, added in-source honesty notices (`quantum_rng.h`, `quantum_rng_wrapper.*`, `vm_native.c`), fixed `docs/breakdown/QUANTUM_RNG.md`'s overstated "system entropy pool" wording, and added `eshkol_qrng_source_label()` returning `"classical-fallback"` / `"moonlab-qrng"` so callers can check the active source at runtime. No numeric behavior change to the classical path.
- **Part C — `agent.quantum` FFI binding (compiled real only when enabled).** New `lib/agent/quantum.esk` + `lib/agent/c/agent_quantum.c` mirroring the `agent.sqlite` pattern: opaque handle + finalizer, `(make-quantum-state n)`, `(apply-hadamard st q)`, `(apply-cnot st a b)`, `(apply-pauli-{x,y,z})`, `(apply-r{x,y,z})`, `(measure st q)`, `(expectation-z st q)`. Compiled unconditionally with an internal `#ifdef ESHKOL_HAVE_MOONLAB` switch (real impl vs. honest "not enabled" stubs) — the same portability pattern as `agent_treesitter.c`/`agent_yoga.c`, required because Mach-O static links reject a totally-undefined weak symbol.
- **Part D — route honest QRNG to Moonlab when enabled.** `quantum-random` draws route through Moonlab's Bell-verified `moonlab_qrng_bytes` when `ESHKOL_MOONLAB_QRNG_ENABLED`. Also removes the VM interpreter's separate xorshift and routes VM cases 1860-1862 through the same `eshkol_qrng_*` the LLVM backend uses, closing a VM/LLVM divergence.

## Verification (on-branch, independent of the implementer's report)

- Default (OFF) build: `eshkol-run` + `stdlib` build clean, `Quantum: DISABLED`, no FetchContent activity.
- `run_memory_tests.sh`: **14/14**. `run_autodiff_tests.sh`: **54/54**.
- `quantum-random` / `quantum-random-range` smoke (AOT + JIT): in-range values from the shared generator.
- Moonlab symbols verified against the pinned-SHA headers (`state.h`/`gates.h`/`measurement.h`/`moonlab_export.h`); `quantumsim` target name confirmed.

## Known limitations (honest, not faked)

- **Part E (ON-path Bell smoke) is blocked by a Moonlab-side defect, not Eshkol.** With `-DESHKOL_QUANTUM_ENABLED=ON`, FetchContent + configure succeed but `libquantumsim` fails to link on macOS/arm64: Moonlab declares its GPU-routing hooks `__attribute__((weak))`, which resolves-to-NULL on Linux/ELF but is a hard `ld` error on Mach-O when the symbols are undefined everywhere (needs `weak_import`). No smoke test is committed rather than ship a green-that-lies. Tracked for the Moonlab maintainer; does not affect the default build.
- **Pre-existing (not introduced here):** the LLVM/AOT `codegenQuantumRandomInt` ignores its `bound` argument and returns a raw `uint64`, while the VM path honors `[0, bound)`. Confirmed identical on master. Filed as a separate follow-up.
