### PR TITLE
fix(memory): deep-walk bignum rationals in region evacuation (heap-use-after-free)

### DIFF
--- a/lib/core/runtime_regions.cpp
+++ b/lib/core/runtime_regions.cpp
@@ -15,6 +15,7 @@
 #include "../../inc/eshkol/core/logic.h"       // eshkol_substitution_t / _fact_t / _knowledge_base_t
 #include "../../inc/eshkol/core/inference.h"   // eshkol_factor_graph_t / _factor_t
 #include "../../inc/eshkol/core/workspace.h"   // eshkol_workspace_t / _workspace_module_t
+#include "../../inc/eshkol/core/rational.h"    // eshkol_rational_t (bignum-backed exact rationals)
 
 #include <cstring>
 #include <cstdlib>
@@ -902,6 +903,7 @@ enum EvacKind : uint8_t {
     EVAC_FACTOR_GRAPH,   // eshkol_factor_graph_t: nested raw numeric buffers
     EVAC_WORKSPACE,      // eshkol_workspace_t: content buffer + per-module name/process_fn
     EVAC_PROMISE,        // [forced:i64][thunk:tagged @8][cached:tagged @24] (delay/force)
+    EVAC_RATIONAL,       // eshkol_rational_t: big_num/big_den raw bignum pointers (is_big==1 only)
 };
 
 using EvacFwdMap = std::unordered_map<const void*, void*>;
@@ -968,8 +970,17 @@ static EvacKind evac_kind_for(const eshkol_tagged_value_t& v, const void* old_da
         case HEAP_SUBTYPE_FACTOR_GRAPH:   return EVAC_FACTOR_GRAPH;
         case HEAP_SUBTYPE_WORKSPACE:      return EVAC_WORKSPACE;
         case HEAP_SUBTYPE_PROMISE:        return EVAC_PROMISE;
-        // STRING / SYMBOL / BIGNUM / RATIONAL / BYTEVECTOR: self-contained
-        // payloads -> a contiguous leaf copy fully preserves them.
+        // RATIONAL: the int64 fast path (is_big == 0) is fully self-contained
+        // (numerator/denominator are inline scalars), but the bignum path
+        // (is_big == 1) carries two RAW eshkol_bignum_t* pointers (big_num /
+        // big_den) that can themselves be region-resident. A shallow leaf copy
+        // of a big rational left those two pointers aimed into the popped
+        // region arena -- the same class of gap ESH-0214d closed for the
+        // logic/workspace subtypes. Always dispatched through EVAC_RATIONAL;
+        // the is_big==0 case is a cheap no-op there (nothing to walk).
+        case HEAP_SUBTYPE_RATIONAL:       return EVAC_RATIONAL;
+        // STRING / SYMBOL / BIGNUM / BYTEVECTOR: self-contained payloads ->
+        // a contiguous leaf copy fully preserves them.
         //
         // Deliberately kept EVAC_LEAF (no interior region pointers, or their
         // interior graph is not confidently/safely traversable here, AND they
@@ -1330,6 +1341,28 @@ static eshkol_tagged_value_t region_evacuate_value(eshkol_tagged_value_t val,
                 auto* cached = (eshkol_tagged_value_t*)((uint8_t*)nd + 24);
                 *thunk  = evac_value(st, *thunk);
                 *cached = evac_value(st, *cached);
+                break;
+            }
+            case EVAC_RATIONAL: {
+                // is_big == 0 (fast path): numerator/denominator are inline
+                // int64 scalars -- already copied verbatim by the contiguous
+                // header+payload copy, nothing further to walk.
+                //
+                // is_big == 1 (bignum path): big_num/big_den are RAW
+                // eshkol_bignum_t* pointers (not tagged values -- same shape
+                // as a knowledge base's facts[] array), each an independently
+                // header-prefixed HEAP_SUBTYPE_BIGNUM object that can itself
+                // be region-resident (e.g. the result of exact arithmetic
+                // performed inside a `with-region` body). Left un-walked, a
+                // rational whose reduced numerator/denominator overflow
+                // int64 -- promoted out of its region via vector-set!/
+                // set-car!/etc. -- would carry two pointers straight into the
+                // arena region_pop is about to free.
+                auto* r = (eshkol_rational_t*)nd;
+                if (r->is_big) {
+                    if (r->big_num) r->big_num = (eshkol_bignum_t*)evac_object_ptr(st, r->big_num);
+                    if (r->big_den) r->big_den = (eshkol_bignum_t*)evac_object_ptr(st, r->big_den);
+                }
                 break;
             }
             case EVAC_FACTOR_GRAPH: {

--- a/tests/memory/region_evac_rational_bignum_test.esk
+++ b/tests/memory/region_evac_rational_bignum_test.esk
@@ -1,0 +1,61 @@
+;;; tests/memory/region_evac_rational_bignum_test.esk — region evacuator
+;;; RATIONAL (bignum-path) subtype-coverage correctness fixture.
+;;;
+;;; evac_kind_for (lib/core/runtime_regions.cpp) classified HEAP_SUBTYPE_RATIONAL
+;;; as EVAC_LEAF (a shallow header+payload copy) for both representations an
+;;; eshkol_rational_t can take:
+;;;   - is_big == 0 (fast path): numerator/denominator are inline int64
+;;;     scalars -- a shallow copy is correct.
+;;;   - is_big == 1 (bignum path): big_num/big_den are RAW eshkol_bignum_t*
+;;;     pointers (used whenever the GCD-reduced numerator or denominator
+;;;     overflows int64) that are themselves independently arena-allocated,
+;;;     header-prefixed HEAP_SUBTYPE_BIGNUM objects.
+;;;
+;;; A big rational built inside a `(with-region ...)` body and promoted to an
+;;; outer container via the region write barrier (vector-set!/set-car!/etc.)
+;;; kept those two raw bignum pointers aimed into the region's arena. Once
+;;; region_pop freed that arena, any later read of the rational (arithmetic,
+;;; equal?, display, ...) dereferenced freed memory: a confirmed
+;;; AddressSanitizer heap-use-after-free in eshkol_bignum_compare (reached via
+;;; eshkol_rational_equal / eshkol_deep_equal), and — under
+;;; ESHKOL_ARENA_POISON=1 — a deterministic wrong-answer/crash reading
+;;; 0xCB-poisoned memory instead.
+;;;
+;;; This fixture builds several big (bignum-path) rationals inside per-
+;;; iteration regions, promotes each into an outer vector slot, and verifies
+;;; every promoted rational reads back exactly equal to the same value
+;;; computed directly (outside any region) after all regions have been popped.
+
+(define slots (make-vector 4 0))
+
+(define (mk-big i)
+  ;; 2^100 is far outside int64 range; dividing by 7 (coprime to 2^100) forces
+  ;; the GCD-reduced (numerator, denominator) pair onto the bignum path
+  ;; (is_big == 1), carrying two raw eshkol_bignum_t* interior pointers.
+  (/ (+ (expt 2 100) i) 7))
+
+(define (fill i)
+  (if (< i 4)
+      (begin
+        (with-region 'r
+          (vector-set! slots i (mk-big i)))
+        (fill (+ i 1)))))
+
+(fill 0)
+
+(define (check i ok)
+  (if (>= i 4)
+      ok
+      (let* ((r (vector-ref slots i))
+             (expected (mk-big i)))
+        (check (+ i 1) (and ok (equal? r expected))))))
+
+(define result (check 0 #t))
+
+(display "[region_evac_rational_bignum_test] result=")
+(display result)
+(newline)
+
+(if result
+    (begin (display "PASS") (newline))
+    (begin (display "FAIL") (newline) (exit 1)))


### PR DESCRIPTION
A latent heap-use-after-free in region evacuation, found by an ASan audit of every `HEAP_SUBTYPE_*` against `evac_kind_for`'s coverage.

## The bug
`HEAP_SUBTYPE_RATIONAL` was classified `EVAC_LEAF`. That is correct for the int64 fast path, but wrong for the bignum path (`is_big == 1`, used when a GCD-reduced exact rational's numerator/denominator overflows int64): `big_num` / `big_den` are raw `eshkol_bignum_t*` pointers to independently arena-allocated objects. As a leaf, they were left unwalked, so after the owning region popped, a rational that survived the region carried dangling pointers into the freed arena. This is the same residual-subtype class as ESH-0214d/e (#226/#230), in a subtype neither existing memory test constructed.

## Evidence (ASan, before the fix)
```
ERROR: AddressSanitizer: heap-use-after-free ... READ of size 4
  #0 eshkol_bignum_compare bignum.cpp:690
  #1 eshkol_rational_equal rational.cpp:456
  #2 eshkol_deep_equal runtime_deep_equal.cpp:198
freed by:  arena_destroy runtime_arena_core.cpp:186  <- region_destroy runtime_regions.cpp:435
allocated: arena_create  runtime_arena_core.cpp:94   <- region_create  runtime_regions.cpp:370
```

## Fix
`lib/core/runtime_regions.cpp`: add `EVAC_RATIONAL` to `evac_kind_for` and a worklist case that deep-copies `big_num` / `big_den` via the existing `evac_object_ptr` raw-pointer path (the same mechanism used for a knowledge base's `facts[]`) whenever `is_big` is set.

## Verification
- New fixture `tests/memory/region_evac_rational_bignum_test.esk`: before fix, 3/3 deterministic ASan crash and 5/5 poison-build failures; after fix, clean.
- Full memory suite stable at 15/15 across 3 runs (14 prior + the new fixture) on a normal build; ASan+poison runs of the fixture clean.

Found during a broader region-evacuation audit; an additional gap in `make-parameter`'s dynamic value stack (`HEAP_SUBTYPE_PARAMETER`) was identified and is tracked separately (it needs write-barrier call-site changes, not an `evac_kind_for` entry).
