### PR TITLE
fix(codegen): pin library-mode stdlib exports against O2 GlobalDCE (fixes red lite/asan lanes)

### DIFF
--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -3357,6 +3357,8 @@ public:
 
             pruneUnusedFreestandingDeclarations();
 
+            preserveLibraryModeDefinitions();
+
             // Coerce mismatched integer types before verification so wasm32
             // does not trip on i32 size_t / i64 byte-count mismatches in
             // generated calls or binary operators.  On native this is usually
@@ -5098,6 +5100,72 @@ private:
         if (removed_functions || removed_globals) {
             eshkol_debug("Freestanding cleanup removed %u unused functions and %u unused globals",
                          removed_functions, removed_globals);
+        }
+    }
+
+    // Library mode (--shared-lib, e.g. the precompiled stdlib.o build) gives
+    // every top-level definition LinkOnceODR linkage (publicDefinitionLinkage /
+    // sexprGlobalLinkage) so that when the SAME core.* module is compiled into
+    // more than one linked object — e.g. a user program that both transitively
+    // pulls in stdlib.o AND requires a core.* module directly — the native
+    // linker merges the duplicate weak definitions instead of erroring
+    // "duplicate symbol". Per the library-mode contract ("skip main function
+    // creation and export all symbols"), every one of those definitions is
+    // meant to be part of the compiled unit's public surface, regardless of
+    // whether anything ELSE inside this translation unit happens to call it.
+    //
+    // LinkOnceODR linkage tells LLVM's OWN module optimizer something
+    // different: "some other translation unit may already provide this
+    // definition," which licenses GlobalOpt/GlobalDCE (part of the standard
+    // -O2 pipeline run later in optimizeModule()) to delete any LinkOnceODR
+    // definition that has no in-module callers, on the theory that the
+    // program will still link against whatever other TU supplies it. For a
+    // precompiled library object there IS no other TU — stdlib.o is the one
+    // and only definition every downstream AOT program links against — so a
+    // "thin wrapper" export nothing else in stdlib.esk happens to call
+    // in-module (fold-left, foldl, foldr, atomic-write-file, csv-parse-line,
+    // string-trim, ...) was being silently optimized away before it ever
+    // reached the object file, and any external program calling it failed to
+    // link with "undefined reference to 'fold-left'" etc.
+    //
+    // Fix: add every LinkOnceODR/WeakAny-linkage *definition* to
+    // @llvm.compiler.used. That is LLVM's documented mechanism for telling
+    // the in-module optimizer "treat this as reachable" without changing the
+    // symbol's actual linkage — duplicate weak definitions across separately
+    // linked objects still merge exactly as before. Native (non-library)
+    // codegen and the --wasm path (which never sets library_mode — see
+    // eshkol_generate_llvm_ir_library() vs eshkol_generate_llvm_ir(), and
+    // deadStripWasmModule()'s Internalize+GlobalDCE) are unaffected.
+    void preserveLibraryModeDefinitions() {
+        if (!library_mode) return;
+
+        SmallVector<GlobalValue*, 64> keep_alive;
+        for (Function& fn : *module) {
+            if (fn.isDeclaration()) continue;
+            auto linkage = fn.getLinkage();
+            if (linkage == GlobalValue::LinkOnceODRLinkage ||
+                linkage == GlobalValue::LinkOnceAnyLinkage ||
+                linkage == GlobalValue::WeakAnyLinkage ||
+                linkage == GlobalValue::WeakODRLinkage) {
+                keep_alive.push_back(&fn);
+            }
+        }
+        // Only pin FUNCTIONS, not globals. The pre-#256 homoiconic display
+        // registry pinned stdlib against DCE by ptrtoint-ing every top-level
+        // FUNCTION from main() — it never address-took data globals. Force-
+        // keeping weak/linkonce GlobalVariables here (e.g. the *_sexpr display
+        // metadata) materializes data that the freestanding object is not set
+        // up to own, which corrupts memory at runtime (region-evac SIGBUS) and
+        // bloats RSS. Restoring the functions-only pin matches the old
+        // behavior and is sufficient to keep exported stdlib symbols linkable.
+
+        if (!keep_alive.empty()) {
+            appendToCompilerUsed(*module, keep_alive);
+            eshkol_debug(
+                "Library mode: marked %zu weak/linkonce definitions "
+                "compiler-used so O2 GlobalDCE cannot strip unreferenced "
+                "exports from the compiled object",
+                keep_alive.size());
         }
     }
 


### PR DESCRIPTION
Fixes the RED `lite` and `asan-ubsan` CI lanes (all platforms). Since PR #256 they have failed to link AOT stdlib test binaries with undefined references to stdlib functions (`atomic-write-file`, `csv-parse-line`, `fold-left`, `string-trim`, ...).

## Root cause
PR #256 gated the homoiconic display registry behind `homoiconicRegistryEnabled() = !freestanding && !wasm` so that standalone wasm objects could dead-strip unused stdlib. But the native precompiled `stdlib.o` is *also* a freestanding object, so it lost the registry's `ptrtoint` pinning as well. Its `LinkOnceODR` exports that nothing else in the translation unit calls were then deleted by the standard -O2 GlobalDCE before the object was written, so any downstream AOT program using one failed to link. The `xla`/`cuda` lanes stayed green only because they don't run the stdlib AOT test suite.

## Fix
Restore the pre-#256 contract for a precompiled library object — every public definition is part of its exported surface regardless of in-module callers — by marking library-mode weak/linkonce **function** definitions `@llvm.compiler.used`. That is LLVM's documented mechanism for "treat as reachable" without changing linkage, so duplicate weak definitions across separately linked objects still merge. Only functions are pinned, never data globals (the old registry only address-took functions; force-keeping weak globals corrupts the freestanding object's memory — an ASan-confirmed dead-end during development). Native non-library codegen and the `--wasm` path are unaffected: wasm never sets `library_mode`, so its Internalize+GlobalDCE dead-strip (the #256 win, guarded by `scripts/check_wasm_size.py`) is preserved.

## Verification (lite config, Release, XLA/GPU off)
- stdlib AOT suite: **18/18** (was failing to link). `nm build/stdlib.o` confirms `fold-left` / `atomic-write-file` / `csv-parse-line` / `string-trim` are now defined (`T`).
- memory suite: **14/14 stable across 20 consecutive runs** (no crashes, deterministic).
- The `--wasm` dead-strip path is untouched (guarded separately by `library_mode`).

Note: this audit also surfaced two pre-existing region-evacuation memory bugs (a bignum-rational heap-use-after-free, fixed in a separate PR; and a `make-parameter` write-barrier gap, tracked as follow-up) — found because enlarging `stdlib.o` perturbed memory layout. They are independent of this linkage fix.
