### PR TITLE
fix: green CI — stdlib tail-call export DCE (root fix) + windows compile-timeout + rational-bignum evac UAF

### DIFF
--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -11040,17 +11040,14 @@ private:
             return nullptr;
         }
 
-        // If block is already terminated (TCO tail call), skip return generation
+        // A tail call may have emitted its own terminator.  It still needs the
+        // common post-body bookkeeping below: library mode registers every
+        // public function for S-expression lookup, which keeps an otherwise
+        // unreferenced linkonce_odr definition in the precompiled stdlib.
         if (current_bb->getTerminator()) {
-            // Block was terminated by a tail call jump - this is expected for TCO
-            eshkol_debug("Function %s: block already terminated (TCO path)", func_name);
-            symbol_table = prev_symbols;
-            current_function = prev_function;
-            return function;
-        }
-
-        // Return the result - pack to tagged_value since functions now return tagged_value
-        if (body_result) {
+            eshkol_debug("Function %s: block already terminated by tail call", func_name);
+        } else if (body_result) {
+            // Return the result - pack to tagged_value since functions now return tagged_value
             // If body_result is already a tagged_value, return it directly
             if (body_result->getType() == tagged_value_type) {
                 // CLOSURE FIX: Check if this is a closure/lambda and register it

--- a/lib/core/runtime_regions.cpp
+++ b/lib/core/runtime_regions.cpp
@@ -15,6 +15,7 @@
 #include "../../inc/eshkol/core/logic.h"       // eshkol_substitution_t / _fact_t / _knowledge_base_t
 #include "../../inc/eshkol/core/inference.h"   // eshkol_factor_graph_t / _factor_t
 #include "../../inc/eshkol/core/workspace.h"   // eshkol_workspace_t / _workspace_module_t
+#include "../../inc/eshkol/core/rational.h"    // eshkol_rational_t (bignum-backed exact rationals)
 
 #include <cstring>
 #include <cstdlib>
@@ -902,6 +903,7 @@ enum EvacKind : uint8_t {
     EVAC_FACTOR_GRAPH,   // eshkol_factor_graph_t: nested raw numeric buffers
     EVAC_WORKSPACE,      // eshkol_workspace_t: content buffer + per-module name/process_fn
     EVAC_PROMISE,        // [forced:i64][thunk:tagged @8][cached:tagged @24] (delay/force)
+    EVAC_RATIONAL,       // eshkol_rational_t: big_num/big_den raw bignum pointers (is_big==1 only)
 };
 
 using EvacFwdMap = std::unordered_map<const void*, void*>;
@@ -968,8 +970,17 @@ static EvacKind evac_kind_for(const eshkol_tagged_value_t& v, const void* old_da
         case HEAP_SUBTYPE_FACTOR_GRAPH:   return EVAC_FACTOR_GRAPH;
         case HEAP_SUBTYPE_WORKSPACE:      return EVAC_WORKSPACE;
         case HEAP_SUBTYPE_PROMISE:        return EVAC_PROMISE;
-        // STRING / SYMBOL / BIGNUM / RATIONAL / BYTEVECTOR: self-contained
-        // payloads -> a contiguous leaf copy fully preserves them.
+        // RATIONAL: the int64 fast path (is_big == 0) is fully self-contained
+        // (numerator/denominator are inline scalars), but the bignum path
+        // (is_big == 1) carries two RAW eshkol_bignum_t* pointers (big_num /
+        // big_den) that can themselves be region-resident. A shallow leaf copy
+        // of a big rational left those two pointers aimed into the popped
+        // region arena -- the same class of gap ESH-0214d closed for the
+        // logic/workspace subtypes. Always dispatched through EVAC_RATIONAL;
+        // the is_big==0 case is a cheap no-op there (nothing to walk).
+        case HEAP_SUBTYPE_RATIONAL:       return EVAC_RATIONAL;
+        // STRING / SYMBOL / BIGNUM / BYTEVECTOR: self-contained payloads ->
+        // a contiguous leaf copy fully preserves them.
         //
         // Deliberately kept EVAC_LEAF (no interior region pointers, or their
         // interior graph is not confidently/safely traversable here, AND they
@@ -1330,6 +1341,28 @@ static eshkol_tagged_value_t region_evacuate_value(eshkol_tagged_value_t val,
                 auto* cached = (eshkol_tagged_value_t*)((uint8_t*)nd + 24);
                 *thunk  = evac_value(st, *thunk);
                 *cached = evac_value(st, *cached);
+                break;
+            }
+            case EVAC_RATIONAL: {
+                // is_big == 0 (fast path): numerator/denominator are inline
+                // int64 scalars -- already copied verbatim by the contiguous
+                // header+payload copy, nothing further to walk.
+                //
+                // is_big == 1 (bignum path): big_num/big_den are RAW
+                // eshkol_bignum_t* pointers (not tagged values -- same shape
+                // as a knowledge base's facts[] array), each an independently
+                // header-prefixed HEAP_SUBTYPE_BIGNUM object that can itself
+                // be region-resident (e.g. the result of exact arithmetic
+                // performed inside a `with-region` body). Left un-walked, a
+                // rational whose reduced numerator/denominator overflow
+                // int64 -- promoted out of its region via vector-set!/
+                // set-car!/etc. -- would carry two pointers straight into the
+                // arena region_pop is about to free.
+                auto* r = (eshkol_rational_t*)nd;
+                if (r->is_big) {
+                    if (r->big_num) r->big_num = (eshkol_bignum_t*)evac_object_ptr(st, r->big_num);
+                    if (r->big_den) r->big_den = (eshkol_bignum_t*)evac_object_ptr(st, r->big_den);
+                }
                 break;
             }
             case EVAC_FACTOR_GRAPH: {

--- a/scripts/run_all_tests.ps1
+++ b/scripts/run_all_tests.ps1
@@ -8,6 +8,10 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 3.0
 
+# AOT compilation is bounded separately from test execution.  Windows ARM64
+# linking can legitimately take longer than the Unix-hosted default.
+$script:CompileTimeoutSec = 120
+
 function Write-Section {
     param([string]$Text)
     Write-Host ""
@@ -334,6 +338,24 @@ function Show-ProcessFailureDetails {
         return
     }
 
+    $hasExitCode = $Result.PSObject.Properties.Match("ExitCode").Count -gt 0
+    $timedOut = ($Result.PSObject.Properties.Match("TimedOut").Count -gt 0) -and $Result.TimedOut
+    $showedDetailsHeader = $false
+    if ($hasExitCode -or $timedOut) {
+        Write-Host ("  {0} {1} details:" -f $TestName, $Phase) -ForegroundColor DarkGray
+        $showedDetailsHeader = $true
+        if ($timedOut) {
+            $timeoutText = ""
+            if ($Result.PSObject.Properties.Match("TimeoutSec").Count -gt 0) {
+                $timeoutText = (" after {0}s" -f $Result.TimeoutSec)
+            }
+            Write-Host ("    process timed out{0}" -f $timeoutText) -ForegroundColor Yellow
+        }
+        if ($hasExitCode) {
+            Write-Host ("    exit code: {0}" -f (Format-ExitCodeLabel $Result.ExitCode)) -ForegroundColor DarkGray
+        }
+    }
+
     $sections = @()
     if ($Result.StdErr) {
         $sections += [pscustomobject]@{
@@ -358,7 +380,9 @@ function Show-ProcessFailureDetails {
         return
     }
 
-    Write-Host ("  {0} {1} details:" -f $TestName, $Phase) -ForegroundColor DarkGray
+    if (-not $showedDetailsHeader) {
+        Write-Host ("  {0} {1} details:" -f $TestName, $Phase) -ForegroundColor DarkGray
+    }
     foreach ($section in $sections) {
         $allLines = @($section.Text -split "`r?`n")
         $lines = @($allLines | Where-Object { $_ -ne $null })
@@ -543,7 +567,8 @@ function Invoke-EshkolCompile {
         [string]$BuildDir,
         [string]$TestFile,
         [string]$OutputBase,
-        [string[]]$ExtraArgs = @()
+        [string[]]$ExtraArgs = @(),
+        [int]$TimeoutSec = $script:CompileTimeoutSec
     )
 
     $exePath = $OutputBase + ".exe"
@@ -555,11 +580,12 @@ function Invoke-EshkolCompile {
     }
     $args += @($TestFile)
 
-    $captured = Invoke-ProcessCapture -FilePath $EshkolRun -Arguments $args -WorkingDirectory $BuildDir
+    $captured = Invoke-ProcessCapture -FilePath $EshkolRun -Arguments $args -WorkingDirectory $BuildDir -TimeoutSec $TimeoutSec
 
     [pscustomobject]@{
         ExitCode = $captured.ExitCode
         TimedOut = $captured.TimedOut
+        TimeoutSec = $TimeoutSec
         Success  = ($captured.ExitCode -eq 0 -and (Test-RegularFile -Path $exePath))
         StdOut   = $captured.StdOut
         StdErr   = $captured.StdErr
@@ -632,6 +658,12 @@ function Invoke-SimpleCompileRunSuite {
         $testName = Split-Path -Leaf $testFile
         $outputBase = New-OutputBase -TempRoot $script:TempRoot -SuiteName $SuiteName -TestName $testName
         $compile = Invoke-EshkolCompile -EshkolRun $script:EshkolRun -ProjectRoot $script:ProjectRoot -BuildDir $script:BuildDir -TestFile $testFile -OutputBase $outputBase
+        if ($compile.TimedOut) {
+            Format-TestStatus $testName ("COMPILE TIMEOUT ({0}s)" -f $compile.TimeoutSec) Yellow
+            Show-ProcessFailureDetails -TestName $testName -Phase "compile" -Result $compile
+            Add-Fail $suite "$testName (compile timeout)"
+            continue
+        }
         if (-not $compile.Success) {
             Format-TestStatus $testName "COMPILE FAIL" Red
             Show-ProcessFailureDetails -TestName $testName -Phase "compile" -Result $compile
@@ -1508,6 +1540,10 @@ switch ($Mode) {
         # Full feature/category coverage remains on the Unix matrix and local
         # Windows verifier; hosted ARM64 validates representative portable
         # surfaces so platform regressions are caught without 2-hour jobs.
+        # The ARM64 COFF link of exception-heavy AOT programs can exceed the
+        # normal 120-second compile limit.  Keep the bound, but give each
+        # Windows smoke-test compile five minutes before declaring a timeout.
+        $script:CompileTimeoutSec = 300
         $suiteResults += Invoke-SimpleCompileRunSuite -SuiteName "features" -Title "Eshkol Windows Feature Smoke Suite" -Patterns @("tests/features/*.esk") -RuntimeErrorRegex "error:" -IncludeNames @(
             "bitwise_ops_test.esk",
             "bytevector_test.esk",

--- a/tests/memory/region_evac_rational_bignum_test.esk
+++ b/tests/memory/region_evac_rational_bignum_test.esk
@@ -1,0 +1,61 @@
+;;; tests/memory/region_evac_rational_bignum_test.esk — region evacuator
+;;; RATIONAL (bignum-path) subtype-coverage correctness fixture.
+;;;
+;;; evac_kind_for (lib/core/runtime_regions.cpp) classified HEAP_SUBTYPE_RATIONAL
+;;; as EVAC_LEAF (a shallow header+payload copy) for both representations an
+;;; eshkol_rational_t can take:
+;;;   - is_big == 0 (fast path): numerator/denominator are inline int64
+;;;     scalars -- a shallow copy is correct.
+;;;   - is_big == 1 (bignum path): big_num/big_den are RAW eshkol_bignum_t*
+;;;     pointers (used whenever the GCD-reduced numerator or denominator
+;;;     overflows int64) that are themselves independently arena-allocated,
+;;;     header-prefixed HEAP_SUBTYPE_BIGNUM objects.
+;;;
+;;; A big rational built inside a `(with-region ...)` body and promoted to an
+;;; outer container via the region write barrier (vector-set!/set-car!/etc.)
+;;; kept those two raw bignum pointers aimed into the region's arena. Once
+;;; region_pop freed that arena, any later read of the rational (arithmetic,
+;;; equal?, display, ...) dereferenced freed memory: a confirmed
+;;; AddressSanitizer heap-use-after-free in eshkol_bignum_compare (reached via
+;;; eshkol_rational_equal / eshkol_deep_equal), and — under
+;;; ESHKOL_ARENA_POISON=1 — a deterministic wrong-answer/crash reading
+;;; 0xCB-poisoned memory instead.
+;;;
+;;; This fixture builds several big (bignum-path) rationals inside per-
+;;; iteration regions, promotes each into an outer vector slot, and verifies
+;;; every promoted rational reads back exactly equal to the same value
+;;; computed directly (outside any region) after all regions have been popped.
+
+(define slots (make-vector 4 0))
+
+(define (mk-big i)
+  ;; 2^100 is far outside int64 range; dividing by 7 (coprime to 2^100) forces
+  ;; the GCD-reduced (numerator, denominator) pair onto the bignum path
+  ;; (is_big == 1), carrying two raw eshkol_bignum_t* interior pointers.
+  (/ (+ (expt 2 100) i) 7))
+
+(define (fill i)
+  (if (< i 4)
+      (begin
+        (with-region 'r
+          (vector-set! slots i (mk-big i)))
+        (fill (+ i 1)))))
+
+(fill 0)
+
+(define (check i ok)
+  (if (>= i 4)
+      ok
+      (let* ((r (vector-ref slots i))
+             (expected (mk-big i)))
+        (check (+ i 1) (and ok (equal? r expected))))))
+
+(define result (check 0 #t))
+
+(display "[region_evac_rational_bignum_test] result=")
+(display result)
+(newline)
+
+(if result
+    (begin (display "PASS") (newline))
+    (begin (display "FAIL") (newline) (exit 1)))


### PR DESCRIPTION
Makes master CI green by fixing the three independent things that had it red, bundled because they must land together (every separate PR inherits the others' red).

## 1. stdlib export DCE — the real root cause (supersedes #264)
`codegenFunctionDefinition` early-returned for any function whose body ends in a **tail call** (block already terminated), skipping the common post-body bookkeeping that, in library mode, registers every public function for S-expression lookup — the registration that also keeps an otherwise-unreferenced `linkonce_odr` definition alive. So tail-call-terminated stdlib exports (`atomic-write-file`, `fold-left`, `csv-parse-line`, `string-trim`, …) were dropped from `stdlib.o` by `-O2` GlobalDCE, and any AOT program calling one failed to link. Fix: only skip *return emission* when the block is already terminated; always run the shared registration. Verified: `nm stdlib.o` now exports all four; stdlib AOT suite 18/18. This is the surgical root fix that #264 (a blanket `@llvm.compiler.used` pin) only worked around — **#264 is superseded and will be closed.**

## 2. windows-arm64-lite "COMPILE FAIL" was a masked timeout (bug B)
`exception_test.esk` and `atomic_file_test.esk` were hitting the harness's 120s AOT-compile limit exactly (slow ARM64 COFF link of exception-heavy programs); `run_all_tests.ps1` converted the synthetic exit-124 into a misleading `COMPILE FAIL` while capturing only benign vectorization remarks. Fix: label timeouts as `COMPILE TIMEOUT` with real exit-code/output detail, and bound the windows-lite AOT compile at 300s.

## 3. rational-bignum region-evac heap-use-after-free (was #263, included here)
Fixing (1) enlarges `stdlib.o`, which shifts heap layout and can expose a pre-existing latent UAF: `HEAP_SUBTYPE_RATIONAL` on the bignum path had `big_num`/`big_den` as `EVAC_LEAF`, dangling into a freed arena. Included here (deep-walk via `EVAC_RATIONAL`) so the layout change cannot flake memory red. ASan-proven; regression test `region_evac_rational_bignum_test.esk`.

## Verification (local, integration branch)
- stdlib AOT suite **18/18**; `nm` confirms the four exports restored.
- `exception_test.esk` + `atomic_file_test.esk` compile and run on macOS (`passed=8 failed=0`).
- memory suite **10/10 runs clean** (rational fix holds it green under the layout shift).
- Windows lane validated by CI on this PR.
