### PR TITLE
fix(stdlib): bound list sort memory with a stable vector merge sort (fixes linux-lite OOM)

### DIFF
--- a/lib/core/list/sort.esk
+++ b/lib/core/list/sort.esk
@@ -1,75 +1,86 @@
 ;;; core/list/sort.esk
 ;;; Sorting algorithms
 
+(require core.list.convert)
+
 (provide sort)
 
-;;; sort: Sort a list using merge sort
+;;; sort: Stably sort a list using bottom-up merge sort.
 ;;; (sort '(3 1 4 1 5 9 2 6) <) => (1 1 2 3 4 5 6 9)
 ;;;
-;;; ESH-0098: the original merge/len/take-n helpers built their result via
-;;; non-tail `(cons x (helper ...))` / `(+ 1 (helper ...))` recursion, so
-;;; their native call-stack depth grew with the *length of the list being
-;;; processed* rather than with the O(log n) depth of the merge-sort
-;;; recursion tree. `len` alone recursed as deep as the whole list on the
-;;; very first call, guaranteeing a blown stack well under a million
-;;; elements ("maximum recursion depth (100000) exceeded" at 500k+). Every
-;;; helper below is now an accumulator-based tail loop (the same
-;;; nested-define self-tail-call pattern used by `length`/`filter`), so
-;;; each lowers to a real loop with O(1) added native stack regardless of
-;;; list length. Only the `sort` recursion itself grows with input size,
-;;; and it halves the list at every level, so its depth is O(log n) --
-;;; about 21 frames for 2,000,000 elements. As a side effect this also
-;;; makes the sort stable: ties now keep the left half's element first
-;;; (the original was not stable -- on ties it emitted the right half's
-;;; element first).
+;;; OALR regions retain every allocation until their owner pops.  A
+;;; recursive list merge sort therefore retains all intermediate cons cells
+;;; from every level of the recursion tree.  Keep the sort workspace in two
+;;; contiguous vectors instead: the input vector and one scratch vector.
+;;; Each pass merges runs of width 1, 2, 4, ... and swaps their roles.  This
+;;; is O(n) retained workspace and O(log n) tail-call depth.  The final
+;;; vector->list allocation is the only output list allocation.
 (define (sort lst less?)
-  ;; rappend: (append (reverse rev) tail), as a single tail loop.
-  ;; Used to "un-reverse" an accumulator built up in reverse order.
-  (define (rappend rev tail)
-    (if (null? rev)
-        tail
-        (rappend (cdr rev) (cons (car rev) tail))))
+  (if (null? lst)
+      '()
+      (if (null? (cdr lst))
+          lst
+          (let* ((values (list->vector lst))
+                 (n (vector-length values))
+                 (scratch (make-vector n #f)))
+            ;; Bound start + width at the end of the vector.
+            (define (run-end start width)
+              (let ((end (+ start width)))
+                (if (> end n) n end)))
 
-  ;; Count list length: iterative accumulator (mirrors `length`).
-  (define (len rest n)
-    (if (null? rest)
-        n
-        (len (cdr rest) (+ n 1))))
+            ;; Copy source[from, end) to dest starting at to.  The loop is
+            ;; tail-recursive so a partially filled final run is safe at any
+            ;; input size.
+            (define (copy-run source from end dest to)
+              (if (>= from end)
+                  dest
+                  (begin
+                    (vector-set! dest to (vector-ref source from))
+                    (copy-run source (+ from 1) end dest (+ to 1)))))
 
-  ;; Take first n elements, preserving order: accumulate then un-reverse.
-  (define (take-n n rest acc)
-    (if (or (<= n 0) (null? rest))
-        (rappend acc '())
-        (take-n (- n 1) (cdr rest) (cons (car rest) acc))))
+            ;; Merge two adjacent sorted runs from source into dest.  Take
+            ;; the left element unless the right is strictly less, which
+            ;; preserves the input order of equal elements.
+            ;; Keep this loop at sort scope rather than defining it inside
+            ;; each merged run.  Local closures allocate in the arena too,
+            ;; so a per-run nested definition would reintroduce O(n) small
+            ;; allocations per pass.
+            (define (merge-run source dest middle right i j out)
+              (if (>= i middle)
+                  (copy-run source j right dest out)
+                  (if (>= j right)
+                      (copy-run source i middle dest out)
+                      (if (less? (vector-ref source j) (vector-ref source i))
+                          (begin
+                            (vector-set! dest out (vector-ref source j))
+                            (merge-run source dest middle right
+                                       i (+ j 1) (+ out 1)))
+                          (begin
+                            (vector-set! dest out (vector-ref source i))
+                            (merge-run source dest middle right
+                                       (+ i 1) j (+ out 1)))))))
 
-  ;; Drop first n elements (already tail-recursive).
-  (define (drop-n n rest)
-    (if (or (<= n 0) (null? rest))
-        rest
-        (drop-n (- n 1) (cdr rest))))
+            ;; Merge every adjacent pair of runs of this width.  Runs are
+            ;; disjoint, so it is safe to fill the destination sequentially.
+            (define (merge-pass source dest width)
+              (define (loop start)
+                (if (>= start n)
+                    dest
+                    (let ((middle (run-end start width))
+                          (right (run-end start (* width 2))))
+                      (begin
+                        (merge-run source dest middle right start middle start)
+                        (loop right)))))
+              (loop 0))
 
-  ;; Merge two already-sorted lists: accumulate then un-reverse onto
-  ;; whichever input still has elements left. Stable: on ties (neither
-  ;; strictly less than the other), the left list's element is taken.
-  ;; Written with nested `if` rather than `cond`: the backend's tail-call
-  ;; optimizer only recognizes `if` in tail position, so a `cond`-based
-  ;; accumulator loop here still blows the recursion-depth guard even
-  ;; though every branch is logically a tail call.
-  (define (merge l1 l2 acc)
-    (if (null? l1)
-        (rappend acc l2)
-        (if (null? l2)
-            (rappend acc l1)
-            (if (less? (car l2) (car l1))
-                (merge l1 (cdr l2) (cons (car l2) acc))
-                (merge (cdr l1) l2 (cons (car l1) acc))))))
+            ;; Alternating the source and scratch vectors avoids allocating
+            ;; one vector per pass.  This tail call advances the run width
+            ;; only O(log n) times.
+            (define (merge-passes source dest width)
+              (if (>= width n)
+                  source
+                  (merge-passes (merge-pass source dest width)
+                                source
+                                (* width 2))))
 
-  ;; Main merge sort - split by counting, not mutating.
-  (cond ((null? lst) '())
-        ((null? (cdr lst)) lst)
-        (else
-         (let ((n (len lst 0)))
-           (let ((mid (quotient n 2)))
-             (merge (sort (take-n mid lst '()) less?)
-                    (sort (drop-n mid lst) less?)
-                    '()))))))
+            (vector->list (merge-passes values scratch 1))))))


### PR DESCRIPTION
Fixes the last red lanes on master (`linux-x64-lite`, `linux-arm64-lite`), which were **not** an infra flake — they OOM the 7GB GitHub linux runner.

## Root cause
`sort_filter_scale_test.esk` sorts 2,000,000 elements, and `lib/core/list/sort.esk`'s top-down list merge sort used **~32 GB peak RSS** to do it (~1.8 GB for just 100k). In the OALR arena (no GC), it retained O(n·log n) intermediate cons cells: `take-n` and `merge` built their accumulator in reverse then `rappend`-ed to un-reverse (2× allocation per element), and every recursion level's intermediates were never freed. At ~256 bytes/cons that is ~4·n·log n·256 bytes. On macOS (big RAM) the test passed; on the 7GB linux runners it OOM-killed the runner mid-suite, which surfaced as "runner received a shutdown signal / exit code 143" — the reason only the linux `lite` lanes failed while every other lane (incl. same-image linux `xla`/`cuda`/`asan` with a reduced test command, and macOS lite) passed. #265 unmasked this by fixing the stdlib link so the test finally ran.

## Fix
Replace the top-down list merge sort with a **stable bottom-up merge sort over a vector**: convert the list to a vector once, merge in place using a single scratch vector, alternating buffers per pass, then convert back. Memory is O(n) contiguous (~2 vectors) instead of O(n·log n) retained cons. Stability is preserved by taking the left element on ties.

## Verification (local, on the branch)
- `sort_filter_scale_test.esk`: **19/19 pass**, including the explicit `sort: stability (ties keep left-input order)` assertion.
- **Peak RSS for the 2,000,000-element test: ~362 MiB** (was ~32 GB — an ~88× reduction), comfortably under a 7GB runner.
- Memory suite 15/15; correctness/stability checked on empty/singleton/sorted/reverse/duplicates + independent-reference random inputs.

This should turn the linux-lite CI lanes green.
