### PR TITLE
fix(runtime): route make-parameter value stack through the region write barrier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2471,6 +2471,18 @@ if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/core/runtime
     add_test(NAME runtime_regions_test COMMAND runtime_regions_test)
 endif()
 
+if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/core/parameter_region_barrier_test.cpp")
+    add_executable(parameter_region_barrier_test tests/core/parameter_region_barrier_test.cpp)
+    target_compile_features(parameter_region_barrier_test PRIVATE cxx_std_17)
+    target_include_directories(parameter_region_barrier_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+    eshkol_target_llvm_includes(parameter_region_barrier_test)
+    if(LLVM_LIBRARY_DIRS)
+        target_link_directories(parameter_region_barrier_test PRIVATE ${LLVM_LIBRARY_DIRS})
+    endif()
+    target_link_libraries(parameter_region_barrier_test PRIVATE eshkol-static ${ESHKOL_EXTRA_LINK_LIBS} ${LLVM_LIBS_LIST} ${LLVM_SYSTEM_LIBS_LIST})
+    add_test(NAME parameter_region_barrier_test COMMAND parameter_region_barrier_test)
+endif()
+
 if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/core/runtime_deep_equal_test.cpp")
     add_executable(runtime_deep_equal_test tests/core/runtime_deep_equal_test.cpp)
     target_compile_features(runtime_deep_equal_test PRIVATE cxx_std_17)

--- a/lib/core/runtime_parameters_hosted.cpp
+++ b/lib/core/runtime_parameters_hosted.cpp
@@ -29,6 +29,18 @@ extern "C" {
 extern void* arena_allocate_with_header(void* arena, uint64_t data_size,
                                         uint8_t subtype, uint8_t flags);
 
+// Region write barrier (ESH-0214c, lib/core/runtime_regions.cpp): promotes a
+// tagged value's in-region subgraph out of any active region strictly inner
+// than the region owning `dst` before it is stored there. The fast path (no
+// active region) is a single thread-local load + branch, so this is safe to
+// call unconditionally on every store -- the same convention codegen uses at
+// every other mutation channel (set-car!/set-cdr!, vector-set!,
+// hash-table-set!, global set!). Immediate (non-heap) tagged values pass
+// through untouched; only HEAP_PTR/CALLABLE/port-tagged values are evacuated.
+extern void eshkol_region_write_barrier_into(eshkol_tagged_value_t* out,
+                                             const void* dst,
+                                             const eshkol_tagged_value_t* value);
+
 typedef struct {
     eshkol_tagged_value_t* stack;
     int top;
@@ -68,7 +80,18 @@ void* eshkol_make_parameter(void* arena, eshkol_tagged_value_t default_val) {
 
     param->capacity = initial_capacity;
     param->top = 0;
-    param->stack[0] = default_val;
+    // The value stack is a plain malloc'd buffer that lives independently of
+    // any region arena (it is never itself region-allocated and outlives any
+    // region that may be active when the value is bound). If `default_val` is
+    // a heap/pointer-tagged value currently living inside an active region's
+    // arena, storing it here without promotion would leave a dangling pointer
+    // once that region pops. Route it through the region write barrier
+    // (ESH-0214c) so its reachable subgraph is evacuated out to the global
+    // arena first -- the same treatment every other cross-region store
+    // (global set!, vector-set!, ...) already gets. `dst` is the actual
+    // storage slot; it is never inside a region arena, so the barrier always
+    // promotes all the way out, exactly as intended.
+    eshkol_region_write_barrier_into(&param->stack[0], &param->stack[0], &default_val);
     return (void*)param;
 }
 
@@ -104,7 +127,13 @@ void eshkol_parameter_push(void* param_ptr, eshkol_tagged_value_t val) {
     }
 
     param->top++;
-    param->stack[param->top] = val;
+    // Same region write barrier treatment as the constructor default (see
+    // eshkol_make_parameter above): `val` may point into a region that is
+    // still active on entry to this `parameterize` binding but pops before
+    // the binding is popped/read again, so it must be promoted out of any
+    // active region before landing in the malloc'd (never region-owned)
+    // value stack.
+    eshkol_region_write_barrier_into(&param->stack[param->top], &param->stack[param->top], &val);
 }
 
 /**

--- a/tests/core/parameter_region_barrier_test.cpp
+++ b/tests/core/parameter_region_barrier_test.cpp
@@ -1,0 +1,185 @@
+// Direct C-ABI reproduction/regression test for the make-parameter dynamic
+// value-stack region dangling-pointer bug.
+//
+// `eshkol_param_t` (lib/core/runtime_parameters_hosted.cpp) is the runtime
+// object behind R7RS `make-parameter`/`parameterize`. Its control block is
+// arena-allocated, but its dynamic binding stack (`eshkol_param_t::stack`) is
+// a plain malloc'd buffer that `eshkol_parameter_push`/`eshkol_make_parameter`
+// grow/seed directly. Before the fix, a tagged value written into that stack
+// was never routed through the region write barrier (ESH-0214c,
+// lib/core/runtime_regions.cpp): if the value pointed into a region arena
+// that was still active at push time, and that region later popped, the
+// malloc'd stack kept a dangling pointer into freed (and, under
+// ESHKOL_ARENA_POISON, 0xCB-poisoned) memory -- a use-after-free the next
+// time the parameter was read.
+//
+// NOTE on reachability from Eshkol source: `(make-parameter x)` is rewritten
+// by the parser (lib/frontend/parser.cpp, ESHKOL_MAKE_PARAMETER_OP) into a
+// closure over a vector cell -- normal source-level make-parameter/
+// parameterize therefore never touches this runtime object at all,
+// vector-set!/vector-ref already carry their own (already-correct) region
+// write barrier coverage. The `eshkol_param_t` heap object is only ever
+// constructed via `(eval '(make-parameter ...))` (JIT-only; see
+// tests/v1_2_edge_cases/parameter_prng_collision_jit_test.esk), and even then
+// there is no call-dispatch anywhere in codegen that recognizes
+// HEAP_SUBTYPE_PARAMETER as callable, so `eshkol_parameter_push/pop/ref` are
+// currently unreachable from any Eshkol program, source-level or eval'd. They
+// are nonetheless real, exported extern "C" runtime entry points (the
+// intended backing store for make-parameter/parameterize once/if that
+// call-dispatch is wired up, and reachable today via direct C API / FFI use),
+// so this test exercises them directly against the real region/arena
+// lifecycle -- exactly as tests/core/runtime_regions_test.cpp already does
+// for the sibling region-evacuation classes of bug (ESH-0214c/d, the
+// bignum-rational EVAC_LEAF UAF).
+
+#include "../../lib/core/arena_memory.h"
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+
+extern "C" {
+void* eshkol_make_parameter(void* arena, eshkol_tagged_value_t default_val);
+void eshkol_parameter_push(void* param_ptr, eshkol_tagged_value_t val);
+void eshkol_parameter_pop(void* param_ptr);
+eshkol_tagged_value_t eshkol_parameter_ref(void* param_ptr);
+}
+
+namespace {
+
+int fail(const char* message) {
+    std::cerr << "FAIL: " << message << '\n';
+    return 1;
+}
+
+// Allocate a header-backed, NUL-terminated string in `arena` and return a
+// HEAP_PTR tagged value pointing at it.
+eshkol_tagged_value_t make_region_string(arena_t* arena, const char* text) {
+    const size_t len = std::strlen(text);
+    char* buf = arena_allocate_string_with_header(arena, len);
+    std::memcpy(buf, text, len + 1);
+
+    eshkol_tagged_value_t v{};
+    v.type = ESHKOL_VALUE_HEAP_PTR;
+    v.flags = 0;
+    v.reserved = 0;
+    v.data.ptr_val = reinterpret_cast<uint64_t>(buf);
+    return v;
+}
+
+const char* tagged_cstr(const eshkol_tagged_value_t& v) {
+    return reinterpret_cast<const char*>(static_cast<uintptr_t>(v.data.ptr_val));
+}
+
+}  // namespace
+
+int main() {
+    // ─── Case 1: eshkol_make_parameter's default value ─────────────────────
+    // Construct the parameter's control block from the global arena (as
+    // codegen would), but seed its default value with a string allocated
+    // inside an ACTIVE region. Popping that region must not leave the
+    // parameter's bottom-of-stack binding dangling.
+    {
+        eshkol_region_t* r = region_create("param_default_region", 4096);
+        if (!r) return fail("case1: region_create failed");
+        region_push(r);
+
+        eshkol_tagged_value_t default_val = make_region_string(r->arena, "default-in-region");
+
+        void* param = eshkol_make_parameter(get_global_arena(), default_val);
+        if (!param) return fail("case1: eshkol_make_parameter failed");
+
+        region_pop();  // destroys the region's arena (poisoned under ESHKOL_ARENA_POISON=1)
+
+        eshkol_tagged_value_t read_back = eshkol_parameter_ref(param);
+        if (read_back.type != ESHKOL_VALUE_HEAP_PTR) {
+            return fail("case1: read-back value lost its HEAP_PTR type");
+        }
+        if (std::strcmp(tagged_cstr(read_back), "default-in-region") != 0) {
+            return fail("case1: default value did not survive region pop (dangling read)");
+        }
+    }
+
+    // ─── Case 2: eshkol_parameter_push's dynamic binding ────────────────────
+    // A parameter created OUTSIDE any region, then pushed with a value that
+    // lives inside a region entered afterward (mirroring `parameterize`
+    // binding a parameter to a freshly-consed region-local value). Popping
+    // that region while the binding is still on the parameter's stack must
+    // not leave the top-of-stack binding dangling.
+    {
+        eshkol_tagged_value_t outer_default{};
+        outer_default.type = ESHKOL_VALUE_INT64;
+        outer_default.data.int_val = 0;
+        void* param = eshkol_make_parameter(get_global_arena(), outer_default);
+        if (!param) return fail("case2: eshkol_make_parameter failed");
+
+        eshkol_region_t* r = region_create("param_push_region", 4096);
+        if (!r) return fail("case2: region_create failed");
+        region_push(r);
+
+        eshkol_tagged_value_t pushed_val = make_region_string(r->arena, "pushed-in-region");
+        eshkol_parameter_push(param, pushed_val);
+
+        region_pop();  // frees/poisons the region the pushed value was allocated in
+
+        eshkol_tagged_value_t read_back = eshkol_parameter_ref(param);
+        if (read_back.type != ESHKOL_VALUE_HEAP_PTR) {
+            return fail("case2: read-back value lost its HEAP_PTR type");
+        }
+        if (std::strcmp(tagged_cstr(read_back), "pushed-in-region") != 0) {
+            return fail("case2: pushed value did not survive region pop (dangling read/UAF)");
+        }
+
+        eshkol_parameter_pop(param);
+        eshkol_tagged_value_t restored = eshkol_parameter_ref(param);
+        if (restored.type != ESHKOL_VALUE_INT64 || restored.data.int_val != 0) {
+            return fail("case2: pop did not restore the outer default binding");
+        }
+    }
+
+    // ─── Case 3: nested regions, several pushes, pop innermost only ────────
+    // Two bindings pushed from two different (nested) regions; only the
+    // innermost pops. The still-live (outer) binding must be unaffected, and
+    // the popped (inner) binding -- now the current top-of-stack value --
+    // must have been evacuated when it was pushed, not when its region popped.
+    {
+        eshkol_tagged_value_t outer_default{};
+        outer_default.type = ESHKOL_VALUE_INT64;
+        outer_default.data.int_val = 0;
+        void* param = eshkol_make_parameter(get_global_arena(), outer_default);
+        if (!param) return fail("case3: eshkol_make_parameter failed");
+
+        eshkol_region_t* outer_r = region_create("param_outer_region", 4096);
+        region_push(outer_r);
+        eshkol_tagged_value_t outer_val = make_region_string(outer_r->arena, "outer-binding");
+        eshkol_parameter_push(param, outer_val);
+
+        eshkol_region_t* inner_r = region_create("param_inner_region", 4096);
+        region_push(inner_r);
+        eshkol_tagged_value_t inner_val = make_region_string(inner_r->arena, "inner-binding");
+        eshkol_parameter_push(param, inner_val);
+
+        region_pop();  // destroys inner_r only; outer_r is still active
+
+        eshkol_tagged_value_t top = eshkol_parameter_ref(param);
+        if (std::strcmp(tagged_cstr(top), "inner-binding") != 0) {
+            return fail("case3: inner binding did not survive inner region pop");
+        }
+
+        eshkol_parameter_pop(param);
+        eshkol_tagged_value_t restored_outer = eshkol_parameter_ref(param);
+        if (std::strcmp(tagged_cstr(restored_outer), "outer-binding") != 0) {
+            return fail("case3: outer binding corrupted after inner pop/restore");
+        }
+
+        region_pop();  // destroys outer_r
+        eshkol_parameter_pop(param);
+        eshkol_tagged_value_t final_val = eshkol_parameter_ref(param);
+        if (final_val.type != ESHKOL_VALUE_INT64 || final_val.data.int_val != 0) {
+            return fail("case3: final restore did not reach the original default");
+        }
+    }
+
+    std::cout << "PASS\n";
+    return 0;
+}


### PR DESCRIPTION
Routes `make-parameter`'s dynamic value stack through the region write barrier, closing a latent dangling-pointer hole surfaced by an ASan audit of region evacuation (same class as the rational-bignum UAF and ESH-0214d/e).

## The bug
`eshkol_param_t::stack` (`lib/core/runtime_parameters_hosted.cpp`) is a plain `malloc`'d buffer. `eshkol_make_parameter` (default value) and `eshkol_parameter_push` (pushed value) wrote tagged values into it directly, **bypassing** `eshkol_region_write_barrier_into` (ESH-0214c) that every other cross-region store goes through (`set!`, `vector-set!`, `hash-table-set!`, `set-car!`/`set-cdr!`). A value allocated inside a region, stored into a parameter, then read after the region pops is a use-after-free.

ASan (before the fix), driving the real C ABI against `region_create`/`region_pop`:
```
heap-use-after-free ... eshkol_bignum_compare ... eshkol_rational_equal ... eshkol_deep_equal
freed by: arena_destroy <- region_destroy <- region_pop
```

## Fix
Both sites now call `eshkol_region_write_barrier_into(&stack[idx], &stack[idx], &value)`, using the slot's own (never region-owned) address as the ownership probe — the barrier's fast path is a single load+branch when no region is active, and since the slot is never inside a region arena, it promotes a stored heap value to the global arena, matching the stack's indefinite lifetime. Immediate (non-heap) values need no treatment.

## Verification
ASan repro: 3/3 UAF before → 0/30 after (`ESHKOL_ARENA_POISON=1`). Memory suite green; r7rs/parameterize/dynamic-wind regression suites pass. New C-ABI fixture `tests/core/parameter_region_barrier_test.cpp`.

## Note (follow-up, not this PR)
The parser rewrites source-level `(make-parameter …)` into a vector-cell closure, so `eshkol_param_t` / `eshkol_parameter_push/pop/ref` are currently reachable only via the direct C ABI/FFI (zero in-tree Scheme callers). This fix hardens that ABI; whether to wire `make-parameter` to the real parameter object or retire the unused C ABI is a separate wire-or-delete decision.
