### PR TITLE
chore(quantum): bump Moonlab pin to the macOS-linkable SHA (d2503460)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,7 @@ if(ESHKOL_QUANTUM_ENABLED)
 
     FetchContent_Declare(moonlab
         GIT_REPOSITORY "${ESHKOL_MOONLAB_REPO}"
-        GIT_TAG c613234cd8498804428f3838aa46dd730b1de810
+        GIT_TAG d2503460246da893c28b59845bb32689aa9602fc
         GIT_SHALLOW FALSE
     )
     FetchContent_MakeAvailable(moonlab)


### PR DESCRIPTION
Bumps the opt-in Moonlab pin from `c613234c` (v1.1.0-rc, which does not link CPU-only on macOS/arm64) to `d2503460` — Moonlab master including the `weak_import` linker fix (tsotchke/moonlab#11, merged). This lets the quantum ON-path (`-DESHKOL_QUANTUM_ENABLED=ON`) build and link **out of the box** without a `FETCHCONTENT_SOURCE_DIR_MOONLAB` override.

Verified out-of-box (FetchContent pulls d2503460 from GitHub): `Quantum: ENABLED`, links, Bell-pair smoke **200/200**, VQE H₂ matches the exact ground energy to **4.4e-16**. Default build is unaffected (quantum OFF by default; the pin is only used when enabled).