### PR TITLE
feat(ad): custom-VJP AD nodes — differentiate through Moonlab VQE circuits (S3)

### DIFF
--- a/inc/eshkol/backend/autodiff_codegen.h
+++ b/inc/eshkol/backend/autodiff_codegen.h
@@ -212,6 +212,17 @@ public:
         llvm::Value* shape, llvm::Value* ndim);
 
     /**
+     * Record an opaque scalar primitive with an externally supplied VJP.
+     * `inputs` is an arena-owned ad_node_t* array of `input_count` entries and
+     * `custom_vjp` is an arena-owned eshkol_custom_vjp_t whose inputs field
+     * refers to that array. The descriptor is saved in saved_tensors[0].
+     */
+    llvm::Value* recordADNodeCustom(llvm::Value* value,
+                                    llvm::Value* inputs,
+                                    llvm::Value* input_count,
+                                    llvm::Value* custom_vjp);
+
+    /**
      * Accumulate a tensor gradient onto an AD node's tensor_gradient field.
      * If tensor_gradient is NULL, allocates and zero-fills it first.
      * @param node_ptr Pointer to AD node

--- a/inc/eshkol/eshkol.h
+++ b/inc/eshkol/eshkol.h
@@ -951,9 +951,39 @@ typedef enum {
     AD_NODE_FRECHET_MEAN,              // Riemannian center of mass backward
     AD_NODE_ATAN2,                     // Binary atan2(y, x) backward
 
+    // Custom vector-Jacobian-product node (external adjoint). The reverse pass
+    // invokes a user-supplied backward callback stored in saved_tensors[0] as an
+    // eshkol_custom_vjp_t; it accumulates the callback's per-input gradients into
+    // this node's input variable nodes. Used to differentiate through opaque
+    // primitives that supply their own exact adjoint (e.g. a Moonlab VQE circuit),
+    // composed inside Eshkol's reverse-mode AD tape.
+    AD_NODE_CUSTOM,
+
     // Sentinel for bounds checking
     AD_NODE_TYPE_COUNT
 } ad_node_type_t;
+
+/**
+ * Custom vector-Jacobian-product descriptor for AD_NODE_CUSTOM.
+ *
+ * An AD_NODE_CUSTOM node models an opaque scalar-valued primitive y = f(x_0..x_{n-1})
+ * whose reverse-mode adjoint is supplied externally rather than by a hardcoded
+ * formula. During the backward pass the node's accumulated upstream gradient
+ * (dL/dy) is passed to `backward`, which fills `out_grads[i] = dy/dx_i` as an
+ * unscaled local partial; the runtime then accumulates
+ * `upstream * out_grads[i]` into `inputs[i]`.
+ *
+ * A pointer to this struct is stored in ad_node_t::saved_tensors[0]; the node's
+ * num_saved is 1. The struct, its `inputs` array, and its `ctx` are arena-owned
+ * with the same lifetime as the tape.
+ */
+typedef struct eshkol_custom_vjp {
+    /* Receives upstream for context, but fills unscaled dy/dx_i local partials. */
+    void (*backward)(void* ctx, double upstream, double* out_grads, int n);
+    void* ctx;              /* Opaque context (e.g. Hamiltonian handle + params). */
+    struct ad_node** inputs;/* n input variable nodes to accumulate into. */
+    int n;                  /* Number of inputs / gradient components. */
+} eshkol_custom_vjp_t;
 
 /**
  * @brief One node of the reverse-mode AD computational graph.

--- a/lib/agent/c/agent_quantum.c
+++ b/lib/agent/c/agent_quantum.c
@@ -54,6 +54,28 @@
 #include <stdlib.h>
 #include <string.h>
 #include <float.h>
+#include <limits.h>
+
+/* The VQE AD bridge needs Eshkol's arena-owned tape nodes. Do not include
+ * arena_memory.h here: it exposes C++ thread_local declarations and this shim
+ * is intentionally compiled as C. Keep the tiny runtime boundary explicit. */
+#include "../../../inc/eshkol/eshkol.h"
+
+typedef struct arena arena_t;
+extern arena_t* eshkol_current_arena(void);
+extern void* arena_allocate_aligned(arena_t* arena, size_t size, size_t alignment);
+extern void* arena_allocate_zeroed(arena_t* arena, size_t size);
+
+/* Must stay in lockstep with eshkol_tensor_t's first five fields in
+ * lib/core/arena_memory.h. The AD parameter tensor uses this homogeneous
+ * int64-bit-pattern element layout. */
+typedef struct {
+    uint64_t* dimensions;
+    uint64_t num_dimensions;
+    int64_t* elements;
+    uint64_t total_elements;
+    uint64_t dtype;
+} vqe_tensor_layout_t;
 
 /*******************************************************************************
  * CONDITIONAL COMPILATION: full Moonlab-backed implementation vs graceful stubs
@@ -517,6 +539,286 @@ static vqe_solver_t* create_default_vqe_solver(pauli_hamiltonian_t* hamiltonian,
 }
 
 /**
+ * Evaluate the fixed-parameter Stage S2 default ansatz.  This is deliberately
+ * separate from vqe_solve(): the bridge needs E(theta), not an optimizer run.
+ */
+static double vqe_energy_at_parameters(int64_t handle, const double* parameters,
+                                       size_t parameter_count) {
+    pauli_hamiltonian_t* hamiltonian = get_hamiltonian(handle);
+    if (!hamiltonian || !parameters) {
+        return unavailable_double("vqe-energy: invalid Hamiltonian handle or parameter buffer");
+    }
+
+    vqe_ansatz_t* ansatz = NULL;
+    vqe_optimizer_t* optimizer = NULL;
+    vqe_solver_t* solver = create_default_vqe_solver(hamiltonian, 1,
+                                                      &ansatz, &optimizer);
+    if (!solver) return error_double();
+
+    if (parameter_count != ansatz->num_parameters) {
+        vqe_solver_free(solver);
+        vqe_optimizer_free(optimizer);
+        vqe_ansatz_free(ansatz);
+        return unavailable_double("vqe-energy: parameter vector has the wrong length");
+    }
+
+    double energy = vqe_compute_energy(solver, parameters);
+    vqe_solver_free(solver);
+    vqe_optimizer_free(optimizer);
+    vqe_ansatz_free(ansatz);
+
+    if (energy != energy || energy >= DBL_MAX) {
+        return unavailable_double("vqe-energy: Moonlab energy evaluation failed");
+    }
+    return energy;
+}
+
+/** Run exactly the same native adjoint path exposed by Stage S2's vqe-gradient. */
+static int vqe_gradient_at_parameters(int64_t handle, const double* parameters,
+                                      double* gradient, size_t parameter_count) {
+    pauli_hamiltonian_t* hamiltonian = get_hamiltonian(handle);
+    if (!hamiltonian || !parameters || !gradient) {
+        set_last_error("vqe-energy AD: invalid Hamiltonian handle or gradient buffer");
+        return -1;
+    }
+
+    vqe_ansatz_t* ansatz = NULL;
+    vqe_optimizer_t* optimizer = NULL;
+    vqe_solver_t* solver = create_default_vqe_solver(hamiltonian, 1,
+                                                      &ansatz, &optimizer);
+    if (!solver) return -1;
+
+    if (parameter_count != ansatz->num_parameters) {
+        vqe_solver_free(solver);
+        vqe_optimizer_free(optimizer);
+        vqe_ansatz_free(ansatz);
+        set_last_error("vqe-energy AD: parameter vector has the wrong length");
+        return -1;
+    }
+
+    /* moonlab_vqe_gradient is the frozen ABI around Moonlab's exact native
+     * adjoint (with its analytic parameter-shift fallback), matching
+     * eshkol_vqe_gradient_compute exactly. */
+    int rc = moonlab_vqe_gradient(solver, parameters, gradient, parameter_count);
+    vqe_solver_free(solver);
+    vqe_optimizer_free(optimizer);
+    vqe_ansatz_free(ansatz);
+    if (rc != 0) {
+        set_last_error("vqe-energy AD: Moonlab exact gradient failed");
+        return -1;
+    }
+    return 0;
+}
+
+/* Converts an ordinary Scheme numeric vector/tensor to a contiguous arena
+ * buffer. The compiler intrinsic calls this only outside AD mode. */
+static double* vqe_copy_plain_parameters(const eshkol_tagged_value_t* params,
+                                         size_t* count_out) {
+    if (!params || !count_out) {
+        set_last_error("vqe-energy: params must be a vector");
+        return NULL;
+    }
+
+    size_t count = 0;
+    double* values = NULL;
+    arena_t* arena = eshkol_current_arena();
+    if (!arena) {
+        set_last_error("vqe-energy: no active Eshkol arena");
+        return NULL;
+    }
+
+    if (ESHKOL_IS_VECTOR_COMPAT(*params)) {
+        const uint8_t* raw = (const uint8_t*)(uintptr_t)params->data.ptr_val;
+        if (!raw) {
+            set_last_error("vqe-energy: params must be a vector");
+            return NULL;
+        }
+        int64_t signed_count = 0;
+        memcpy(&signed_count, raw, sizeof(signed_count));
+        if (signed_count <= 0 || (uint64_t)signed_count > SIZE_MAX / sizeof(double)) {
+            set_last_error("vqe-energy: parameter vector must be non-empty");
+            return NULL;
+        }
+        count = (size_t)signed_count;
+        values = (double*)arena_allocate_aligned(arena, count * sizeof(double), sizeof(double));
+        if (!values) {
+            set_last_error("vqe-energy: allocation failed");
+            return NULL;
+        }
+        const eshkol_tagged_value_t* elements =
+            (const eshkol_tagged_value_t*)(raw + sizeof(int64_t));
+        for (size_t i = 0; i < count; ++i) {
+            if (elements[i].type == ESHKOL_VALUE_DOUBLE) {
+                values[i] = elements[i].data.double_val;
+            } else if (elements[i].type == ESHKOL_VALUE_INT64) {
+                values[i] = (double)elements[i].data.int_val;
+            } else {
+                set_last_error("vqe-energy: parameters must be real numbers");
+                return NULL;
+            }
+            if (values[i] != values[i]) {
+                set_last_error("vqe-energy: parameters must be finite numbers");
+                return NULL;
+            }
+        }
+    } else if (ESHKOL_IS_TENSOR_COMPAT(*params)) {
+        const vqe_tensor_layout_t* tensor =
+            (const vqe_tensor_layout_t*)(uintptr_t)params->data.ptr_val;
+        if (!tensor || !tensor->elements || tensor->total_elements == 0 ||
+            tensor->total_elements > SIZE_MAX / sizeof(double)) {
+            set_last_error("vqe-energy: parameter tensor must be non-empty");
+            return NULL;
+        }
+        count = (size_t)tensor->total_elements;
+        values = (double*)arena_allocate_aligned(arena, count * sizeof(double), sizeof(double));
+        if (!values) {
+            set_last_error("vqe-energy: allocation failed");
+            return NULL;
+        }
+        for (size_t i = 0; i < count; ++i) {
+            memcpy(&values[i], &tensor->elements[i], sizeof(double));
+            if (values[i] != values[i]) {
+                set_last_error("vqe-energy: parameters must be finite numbers");
+                return NULL;
+            }
+        }
+    } else {
+        set_last_error("vqe-energy: params must be a vector");
+        return NULL;
+    }
+
+    *count_out = count;
+    return values;
+}
+
+/** C entry used by the non-AD half of the compiler intrinsic. */
+double eshkol_vqe_energy_from_tagged(int64_t handle,
+                                     const eshkol_tagged_value_t* params) {
+    size_t count = 0;
+    double* values = vqe_copy_plain_parameters(params, &count);
+    if (!values) return error_double();
+    return vqe_energy_at_parameters(handle, values, count);
+}
+
+typedef struct {
+    int64_t hamiltonian_handle;
+    int parameter_count;
+    double parameters[];
+} vqe_custom_vjp_context_t;
+
+typedef struct {
+    double energy;
+    eshkol_custom_vjp_t* vjp;
+    ad_node_t** inputs;
+    int64_t input_count;
+} vqe_ad_prepared_t;
+
+/* The custom-VJP convention is local partials only. `upstream` is supplied by
+ * the general runtime callback ABI but is intentionally not applied here;
+ * eshkol_ad_node_custom_backward multiplies it exactly once. */
+static void vqe_custom_vjp_backward(void* raw_ctx, double upstream,
+                                    double* out_grads, int n) {
+    (void)upstream;
+    if (!out_grads || n <= 0) return;
+    for (int i = 0; i < n; ++i) out_grads[i] = 0.0;
+
+    vqe_custom_vjp_context_t* ctx = (vqe_custom_vjp_context_t*)raw_ctx;
+    if (!ctx || ctx->parameter_count != n) return;
+    (void)vqe_gradient_at_parameters(ctx->hamiltonian_handle, ctx->parameters,
+                                     out_grads, (size_t)n);
+}
+
+/**
+ * Prepare an arena-owned descriptor for an AD-node tensor of VQE parameters.
+ * The generated intrinsic invokes this only while Eshkol reverse mode is live:
+ * tensor elements are therefore ad_node_t* bit patterns, not f64 bit patterns.
+ */
+void* eshkol_vqe_ad_prepare(int64_t handle, const eshkol_tagged_value_t* params) {
+    if (!params || !ESHKOL_IS_TENSOR_COMPAT(*params)) {
+        set_last_error("vqe-energy AD: params must be an AD tensor");
+        return NULL;
+    }
+    const vqe_tensor_layout_t* tensor =
+        (const vqe_tensor_layout_t*)(uintptr_t)params->data.ptr_val;
+    if (!tensor || !tensor->elements || tensor->total_elements == 0 ||
+        tensor->total_elements > (uint64_t)INT_MAX) {
+        set_last_error("vqe-energy AD: invalid parameter tensor");
+        return NULL;
+    }
+
+    const int n = (int)tensor->total_elements;
+    arena_t* arena = eshkol_current_arena();
+    if (!arena || (size_t)n > SIZE_MAX / sizeof(ad_node_t*) ||
+        (size_t)n > (SIZE_MAX - sizeof(vqe_custom_vjp_context_t)) / sizeof(double)) {
+        set_last_error("vqe-energy AD: allocation size overflow");
+        return NULL;
+    }
+
+    ad_node_t** inputs = (ad_node_t**)arena_allocate_aligned(
+        arena, (size_t)n * sizeof(*inputs), sizeof(void*));
+    vqe_custom_vjp_context_t* ctx = (vqe_custom_vjp_context_t*)arena_allocate_aligned(
+        arena, sizeof(*ctx) + (size_t)n * sizeof(double), sizeof(double));
+    if (!inputs || !ctx) {
+        set_last_error("vqe-energy AD: arena allocation failed");
+        return NULL;
+    }
+
+    ctx->hamiltonian_handle = handle;
+    ctx->parameter_count = n;
+    for (int i = 0; i < n; ++i) {
+        ad_node_t* input = (ad_node_t*)(uintptr_t)tensor->elements[i];
+        if (!input) {
+            set_last_error("vqe-energy AD: parameter tensor contains a non-AD value");
+            return NULL;
+        }
+        inputs[i] = input;
+        ctx->parameters[i] = input->value;
+    }
+
+    double energy = vqe_energy_at_parameters(handle, ctx->parameters, (size_t)n);
+    if (energy != energy) return NULL;
+
+    eshkol_custom_vjp_t* vjp = (eshkol_custom_vjp_t*)arena_allocate_zeroed(
+        arena, sizeof(*vjp));
+    vqe_ad_prepared_t* prepared = (vqe_ad_prepared_t*)arena_allocate_zeroed(
+        arena, sizeof(*prepared));
+    if (!vjp || !prepared) {
+        set_last_error("vqe-energy AD: arena allocation failed");
+        return NULL;
+    }
+
+    vjp->backward = vqe_custom_vjp_backward;
+    vjp->ctx = ctx;
+    vjp->inputs = inputs;
+    vjp->n = n;
+    prepared->energy = energy;
+    prepared->vjp = vjp;
+    prepared->inputs = inputs;
+    prepared->input_count = n;
+    return prepared;
+}
+
+double eshkol_vqe_ad_prepared_energy(const void* raw_prepared) {
+    const vqe_ad_prepared_t* prepared = (const vqe_ad_prepared_t*)raw_prepared;
+    return prepared ? prepared->energy : error_double();
+}
+
+void* eshkol_vqe_ad_prepared_inputs(void* raw_prepared) {
+    vqe_ad_prepared_t* prepared = (vqe_ad_prepared_t*)raw_prepared;
+    return prepared ? prepared->inputs : NULL;
+}
+
+int64_t eshkol_vqe_ad_prepared_input_count(const void* raw_prepared) {
+    const vqe_ad_prepared_t* prepared = (const vqe_ad_prepared_t*)raw_prepared;
+    return prepared ? prepared->input_count : 0;
+}
+
+void* eshkol_vqe_ad_prepared_vjp(void* raw_prepared) {
+    vqe_ad_prepared_t* prepared = (vqe_ad_prepared_t*)raw_prepared;
+    return prepared ? prepared->vjp : NULL;
+}
+
+/**
  * Run Moonlab VQE using the default one-layer hardware-efficient ansatz.
  * @return Optimized variational energy, or NaN on a genuine Moonlab failure.
  */
@@ -731,6 +1033,27 @@ double eshkol_vqe_optimize(int64_t handle, int32_t iterations) {
     volatile double zero = 0.0;
     return zero / zero;
 }
+double eshkol_vqe_energy_from_tagged(int64_t handle,
+                                     const eshkol_tagged_value_t* params) {
+    (void)handle; (void)params;
+    volatile double zero = 0.0;
+    return zero / zero;
+}
+void* eshkol_vqe_ad_prepare(int64_t handle, const eshkol_tagged_value_t* params) {
+    (void)handle; (void)params;
+    return NULL;
+}
+double eshkol_vqe_ad_prepared_energy(const void* prepared) {
+    (void)prepared;
+    volatile double zero = 0.0;
+    return zero / zero;
+}
+void* eshkol_vqe_ad_prepared_inputs(void* prepared) { (void)prepared; return NULL; }
+int64_t eshkol_vqe_ad_prepared_input_count(const void* prepared) {
+    (void)prepared;
+    return 0;
+}
+void* eshkol_vqe_ad_prepared_vjp(void* prepared) { (void)prepared; return NULL; }
 int64_t eshkol_vqe_gradient_context_create(int64_t handle) { (void)handle; return -1; }
 void eshkol_vqe_gradient_context_destroy(int64_t handle) { (void)handle; }
 int64_t eshkol_vqe_gradient_parameter_count(int64_t handle) { (void)handle; return -1; }

--- a/lib/agent/quantum.esk
+++ b/lib/agent/quantum.esk
@@ -37,6 +37,7 @@
          hamiltonian-destroy!
          hamiltonian-exact-ground-energy
          vqe-optimize
+         vqe-energy
          vqe-gradient
          with-hamiltonian)
 
@@ -255,6 +256,19 @@
             (error "agent.quantum: vqe-optimize iterations must be positive")
             (check-quantum-real! "vqe-optimize"
                                  (vqe-optimize-raw ham iterations))))))
+
+(define (vqe-energy ham params)
+  "Return the exact ideal-state energy E(params) of the default one-layer
+   hardware-efficient VQE ansatz for `ham`.
+
+   This delegates to Eshkol's vqe-energy-primitive compiler builtin rather
+   than an ordinary FFI extern. In normal execution it calls Moonlab's fixed-
+   parameter energy evaluator. During reverse-mode AD the primitive receives
+   Eshkol's AD-node parameter tensor, records an AD_NODE_CUSTOM with Moonlab's
+   exact adjoint VJP, and returns an Eshkol AD scalar. Consequently it composes
+   with surrounding differentiable Scheme arithmetic without exposing Moonlab
+   internals to Scheme."
+  (vqe-energy-primitive ham params))
 
 (define (vqe-gradient ham params)
   "Return Moonlab's exact dE/dtheta vector for the default one-layer

--- a/lib/backend/autodiff_codegen.cpp
+++ b/lib/backend/autodiff_codegen.cpp
@@ -25,6 +25,7 @@
 #include <unordered_map>
 #include <vector>
 #include <string>
+#include <cstring>
 
 // LLVM VERSION COMPATIBILITY
 #if LLVM_VERSION_MAJOR >= 21
@@ -2442,6 +2443,92 @@ llvm::Value* AutodiffCodegen::recordADNodeTensor(
         }
         ctx_.builder().CreateBr(skip_block);
 
+        ctx_.builder().SetInsertPoint(skip_block);
+    }
+
+    return node_ptr;
+}
+
+// === Custom scalar VJP AD Node Recording ===
+
+/**
+ * @brief Allocate and append an AD_NODE_CUSTOM scalar node.
+ *
+ * The external descriptor owns the complete multi-input edge list because a
+ * scalar ad_node_t has only input1/input2 fields.  We deliberately keep those
+ * legacy binary fields null and save the descriptor as the sole saved tensor;
+ * the runtime custom-backward helper reads it and accumulates into every input.
+ */
+llvm::Value* AutodiffCodegen::recordADNodeCustom(
+    llvm::Value* value,
+    llvm::Value* inputs,
+    llvm::Value* input_count,
+    llvm::Value* custom_vjp)
+{
+    if (!value || !inputs || !input_count || !custom_vjp) return nullptr;
+
+    llvm::Value* arena_ptr = getArenaPtr();
+    llvm::Function* node_alloc = mem_.getArenaAllocateAdNodeWithHeader();
+    llvm::Function* raw_alloc = mem_.getArenaAllocate();
+    if (!arena_ptr || !node_alloc || !raw_alloc) return nullptr;
+
+    llvm::StructType* ad_type = ctx_.adNodeType();
+    auto null_ptr = llvm::ConstantPointerNull::get(ctx_.ptrType());
+    auto zero_f64 = llvm::ConstantFP::get(ctx_.doubleType(), 0.0);
+
+    llvm::Value* node_ptr = ctx_.builder().CreateCall(node_alloc, {arena_ptr});
+    ctx_.builder().CreateStore(
+        llvm::ConstantInt::get(ctx_.int32Type(), static_cast<int>(AD_NODE_CUSTOM)),
+        ctx_.builder().CreateStructGEP(ad_type, node_ptr, 0));
+    ctx_.builder().CreateStore(value,
+        ctx_.builder().CreateStructGEP(ad_type, node_ptr, 1));
+    ctx_.builder().CreateStore(zero_f64,
+        ctx_.builder().CreateStructGEP(ad_type, node_ptr, 2));
+    ctx_.builder().CreateStore(null_ptr,
+        ctx_.builder().CreateStructGEP(ad_type, node_ptr, 3));
+    ctx_.builder().CreateStore(null_ptr,
+        ctx_.builder().CreateStructGEP(ad_type, node_ptr, 4));
+    ctx_.builder().CreateStore(
+        llvm::ConstantInt::get(ctx_.int64Type(), next_node_id_++),
+        ctx_.builder().CreateStructGEP(ad_type, node_ptr, 5));
+
+    // saved_tensors is always a one-slot arena allocation for custom nodes.
+    llvm::Value* saved_slots = ctx_.builder().CreateCall(raw_alloc, {
+        arena_ptr,
+        llvm::ConstantInt::get(ctx_.int64Type(), sizeof(void*))
+    });
+    llvm::Value* saved_slots_typed = ctx_.builder().CreatePointerCast(
+        saved_slots, ctx_.ptrType());
+    ctx_.builder().CreateStore(custom_vjp, saved_slots_typed);
+    ctx_.builder().CreateStore(saved_slots_typed,
+        ctx_.builder().CreateStructGEP(ad_type, node_ptr, 10));
+    ctx_.builder().CreateStore(
+        llvm::ConstantInt::get(ctx_.int64Type(), 1),
+        ctx_.builder().CreateStructGEP(ad_type, node_ptr, 11));
+
+    // `inputs` and `input_count` are carried by custom_vjp->inputs/n. Keeping
+    // the explicit parameters in this builder makes the tape-lifetime contract
+    // visible at the compiler call site and prevents accidental stack storage.
+    (void)inputs;
+    (void)input_count;
+
+    llvm::GlobalVariable* tape_global = ctx_.currentAdTape();
+    if (tape_global) {
+        llvm::Value* tape_ptr = ctx_.builder().CreateLoad(ctx_.ptrType(), tape_global);
+        llvm::Value* tape_not_null = ctx_.builder().CreateICmpNE(
+            tape_ptr, llvm::ConstantPointerNull::get(ctx_.ptrType()));
+        llvm::Function* current_func = ctx_.builder().GetInsertBlock()->getParent();
+        llvm::BasicBlock* add_block = llvm::BasicBlock::Create(
+            ctx_.context(), "add_custom_to_tape", current_func);
+        llvm::BasicBlock* skip_block = llvm::BasicBlock::Create(
+            ctx_.context(), "skip_custom_tape", current_func);
+        ctx_.builder().CreateCondBr(tape_not_null, add_block, skip_block);
+
+        ctx_.builder().SetInsertPoint(add_block);
+        if (llvm::Function* add_node = mem_.getArenaTapeAddNode()) {
+            ctx_.builder().CreateCall(add_node, {tape_ptr, node_ptr});
+        }
+        ctx_.builder().CreateBr(skip_block);
         ctx_.builder().SetInsertPoint(skip_block);
     }
 
@@ -11375,6 +11462,7 @@ void AutodiffCodegen::propagateGradient(llvm::Value* node_ptr) {
     llvm::BasicBlock* mobius_add_block = llvm::BasicBlock::Create(ctx_.context(), "grad_mobius_add", current_func);
     llvm::BasicBlock* mobius_matmul_block = llvm::BasicBlock::Create(ctx_.context(), "grad_mobius_matmul", current_func);
     llvm::BasicBlock* gyrovector_block = llvm::BasicBlock::Create(ctx_.context(), "grad_gyrovector", current_func);
+    llvm::BasicBlock* custom_block = llvm::BasicBlock::Create(ctx_.context(), "grad_custom", current_func);
 
     // --- CONV2D (type=19): dL/d_input ≈ grad (scalar approx) ---
     ctx_.builder().SetInsertPoint(check_conv2d);
@@ -11714,8 +11802,18 @@ void AutodiffCodegen::propagateGradient(llvm::Value* node_ptr) {
     // --- GYROVECTOR_SPACE (type=40) ---
     ctx_.builder().SetInsertPoint(check_gyrovector);
     llvm::Value* is_gyrovector = ctx_.builder().CreateICmpEQ(node_type, llvm::ConstantInt::get(ctx_.int32Type(), 40));
+    llvm::BasicBlock* check_custom = llvm::BasicBlock::Create(ctx_.context(), "check_custom", current_func);
+    ctx_.builder().CreateCondBr(is_gyrovector, gyrovector_block, check_custom);
+
+    // --- CUSTOM (external vector-Jacobian product) ---
+    // AD_NODE_CUSTOM is intentionally compared through the C enum, never a
+    // stale literal: it is appended after AD_NODE_ATAN2 and may move again.
+    ctx_.builder().SetInsertPoint(check_custom);
+    llvm::Value* is_custom = ctx_.builder().CreateICmpEQ(
+        node_type,
+        llvm::ConstantInt::get(ctx_.int32Type(), static_cast<int>(AD_NODE_CUSTOM)));
     llvm::BasicBlock* unknown_type_block = llvm::BasicBlock::Create(ctx_.context(), "grad_unknown_type", current_func);
-    ctx_.builder().CreateCondBr(is_gyrovector, gyrovector_block, unknown_type_block);
+    ctx_.builder().CreateCondBr(is_custom, custom_block, unknown_type_block);
 
     ctx_.builder().SetInsertPoint(gyrovector_block);
     {
@@ -11741,6 +11839,16 @@ void AutodiffCodegen::propagateGradient(llvm::Value* node_ptr) {
             accumulateGradient(input1, ctx_.builder().CreateFMul(node_grad, lambda_x));
             accumulateGradient(input2, ctx_.builder().CreateFMul(node_grad, lambda_y));
         }
+    }
+    ctx_.builder().CreateBr(done_block);
+
+    ctx_.builder().SetInsertPoint(custom_block);
+    {
+        llvm::FunctionType* custom_backward_type = llvm::FunctionType::get(
+            ctx_.voidType(), {ctx_.ptrType()}, false);
+        llvm::FunctionCallee custom_backward = ctx_.module().getOrInsertFunction(
+            "eshkol_ad_node_custom_backward", custom_backward_type);
+        ctx_.builder().CreateCall(custom_backward, {node_ptr});
     }
     ctx_.builder().CreateBr(done_block);
 

--- a/lib/backend/autodiff_codegen.cpp
+++ b/lib/backend/autodiff_codegen.cpp
@@ -3491,6 +3491,13 @@ static bool adAstUsesTensorOps(
         case ESHKOL_IF_OP:
         case ESHKOL_COND_OP: {
             const eshkol_ast_t* f = op->call_op.func;
+            // Moonlab's VQE primitive consumes the reverse-mode AD-node tensor
+            // produced for vector inputs. Mark it as tensor-flowing so
+            // (gradient (lambda (p) (vqe-energy ham p)) (vector ...)) takes
+            // the reverse path rather than the forward dual-vector path.
+            if (f && f->type == ESHKOL_VAR && f->variable.id &&
+                (std::strcmp(f->variable.id, "vqe-energy") == 0 ||
+                 std::strcmp(f->variable.id, "vqe-energy-primitive") == 0)) return true;
             if (f && f->type == ESHKOL_VAR && adIsTensorValuedBuiltin(f->variable.id)) return true;
             // Follow a call into a user-defined function's body (ESH-0235).
             if (bodies && visited && depth < 8 && f && f->type == ESHKOL_VAR &&

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -14403,6 +14403,13 @@ private:
         if (func_name == "quantum-random-int") return codegenQuantumRandomInt(op);
         if (func_name == "quantum-random-range") return codegenQuantumRandomRange(op);
 
+        // Moonlab VQE bridge. This is intentionally a compiler primitive:
+        // ordinary FFI values cannot preserve the AD-node pointers stored in a
+        // reverse-mode parameter tensor. The primitive dispatches to the plain
+        // Moonlab energy evaluator outside AD and records AD_NODE_CUSTOM inside
+        // a live tape, so its scalar result composes with following Eshkol ops.
+        if (func_name == "vqe-energy-primitive") return codegenVqeEnergyPrimitive(op);
+
         // Handle parallel execution primitives - DELEGATED to ParallelCodegen
         if (func_name == "parallel-map") return parallel_ ? parallel_->parallelMap(op) : unavailableParallelBuiltin(func_name);
         if (func_name == "parallel-fold") return parallel_ ? parallel_->parallelFold(op) : unavailableParallelBuiltin(func_name);
@@ -32448,6 +32455,98 @@ private:
         }
         Value* random_val = builder->CreateCall(qrng_double_func, {});
         return packDoubleToTaggedValue(random_val);
+    }
+
+    /**
+     * Lower (vqe-energy-primitive ham params) to the Moonlab energy bridge.
+     *
+     * The AD branch receives the parameter tensor produced by gradient(): its
+     * element slots hold ad_node_t* bit patterns. The C preparation helper
+     * snapshots those primal values, creates an arena-owned exact Moonlab VJP,
+     * and returns its descriptor plus the input-node array. recordADNodeCustom
+     * then appends the opaque scalar to the active Eshkol tape.
+     */
+    Value* codegenVqeEnergyPrimitive(const eshkol_operations_t* op) {
+        if (!op || op->call_op.num_vars != 2) {
+            eshkol_error("vqe-energy requires exactly a Hamiltonian and parameter vector");
+            return nullptr;
+        }
+
+        Value* ham = ensureTaggedValue(codegenAST(&op->call_op.variables[0]));
+        Value* params = ensureTaggedValue(codegenAST(&op->call_op.variables[1]));
+        if (!ham || !params) return nullptr;
+
+        Value* handle = unpackInt64FromTaggedValue(ham);
+        Value* params_slot = builder->CreateAlloca(tagged_value_type, nullptr,
+                                                   "vqe_energy_params");
+        builder->CreateStore(params, params_slot);
+
+        FunctionCallee plain_energy = module->getOrInsertFunction(
+            "eshkol_vqe_energy_from_tagged",
+            FunctionType::get(double_type, {int64_type, builder->getPtrTy()}, false));
+        FunctionCallee ad_prepare = module->getOrInsertFunction(
+            "eshkol_vqe_ad_prepare",
+            FunctionType::get(builder->getPtrTy(), {int64_type, builder->getPtrTy()}, false));
+        FunctionCallee prepared_energy = module->getOrInsertFunction(
+            "eshkol_vqe_ad_prepared_energy",
+            FunctionType::get(double_type, {builder->getPtrTy()}, false));
+        FunctionCallee prepared_inputs = module->getOrInsertFunction(
+            "eshkol_vqe_ad_prepared_inputs",
+            FunctionType::get(builder->getPtrTy(), {builder->getPtrTy()}, false));
+        FunctionCallee prepared_count = module->getOrInsertFunction(
+            "eshkol_vqe_ad_prepared_input_count",
+            FunctionType::get(int64_type, {builder->getPtrTy()}, false));
+        FunctionCallee prepared_vjp = module->getOrInsertFunction(
+            "eshkol_vqe_ad_prepared_vjp",
+            FunctionType::get(builder->getPtrTy(), {builder->getPtrTy()}, false));
+
+        Function* current_func = builder->GetInsertBlock()->getParent();
+        BasicBlock* non_ad_block = BasicBlock::Create(*context, "vqe_energy_plain", current_func);
+        BasicBlock* ad_block = BasicBlock::Create(*context, "vqe_energy_ad", current_func);
+        BasicBlock* ad_ready_block = BasicBlock::Create(*context, "vqe_energy_ad_ready", current_func);
+        BasicBlock* ad_fail_block = BasicBlock::Create(*context, "vqe_energy_ad_fail", current_func);
+        BasicBlock* done_block = BasicBlock::Create(*context, "vqe_energy_done", current_func);
+
+        Value* in_ad_mode = builder->CreateLoad(int1_type, ctx_->adModeActive());
+        builder->CreateCondBr(in_ad_mode, ad_block, non_ad_block);
+
+        builder->SetInsertPoint(non_ad_block);
+        Value* plain = builder->CreateCall(plain_energy, {handle, params_slot});
+        Value* plain_tagged = packDoubleToTaggedValue(plain);
+        builder->CreateBr(done_block);
+        BasicBlock* non_ad_exit = builder->GetInsertBlock();
+
+        builder->SetInsertPoint(ad_block);
+        Value* prepared = builder->CreateCall(ad_prepare, {handle, params_slot});
+        Value* prep_ok = builder->CreateICmpNE(
+            prepared, ConstantPointerNull::get(builder->getPtrTy()));
+        builder->CreateCondBr(prep_ok, ad_ready_block, ad_fail_block);
+
+        builder->SetInsertPoint(ad_ready_block);
+        Value* energy = builder->CreateCall(prepared_energy, {prepared});
+        Value* inputs = builder->CreateCall(prepared_inputs, {prepared});
+        Value* count = builder->CreateCall(prepared_count, {prepared});
+        Value* vjp = builder->CreateCall(prepared_vjp, {prepared});
+        Value* custom_node = autodiff_->recordADNodeCustom(energy, inputs, count, vjp);
+        if (!custom_node) {
+            eshkol_error("vqe-energy: could not record custom AD node");
+            return nullptr;
+        }
+        Value* ad_tagged = packPtrToTaggedValue(custom_node, ESHKOL_VALUE_CALLABLE);
+        builder->CreateBr(done_block);
+        BasicBlock* ad_ready_exit = builder->GetInsertBlock();
+
+        builder->SetInsertPoint(ad_fail_block);
+        Value* failed_tagged = packDoubleToTaggedValue(ConstantFP::getNaN(double_type));
+        builder->CreateBr(done_block);
+        BasicBlock* ad_fail_exit = builder->GetInsertBlock();
+
+        builder->SetInsertPoint(done_block);
+        PHINode* result = builder->CreatePHI(tagged_value_type, 3, "vqe_energy_result");
+        result->addIncoming(plain_tagged, non_ad_exit);
+        result->addIncoming(ad_tagged, ad_ready_exit);
+        result->addIncoming(failed_tagged, ad_fail_exit);
+        return result;
     }
 
     // Quantum random integer: (quantum-random-int bound) -> integer in [0, bound).

--- a/lib/core/arena_memory.h
+++ b/lib/core/arena_memory.h
@@ -256,6 +256,11 @@ ad_node_t* arena_allocate_ad_node(arena_t* arena);
 ad_node_t* arena_allocate_ad_node_with_header(arena_t* arena);  // For consolidated CALLABLE type
 ad_node_t* arena_allocate_ad_batch(arena_t* arena, size_t count);
 
+// Runtime reverse-dispatch hook for AD_NODE_CUSTOM. The node's saved_tensors[0]
+// is an eshkol_custom_vjp_t whose callback writes unscaled local partials; this
+// helper applies the node upstream adjoint and accumulates into every input.
+void eshkol_ad_node_custom_backward(void* node_ptr);
+
 // Global tape pointer for AD operations (shared across JIT modules in REPL).
 // Not thread_local due to cross-platform LLVM↔C TLS ABI constraints.
 // Thread safety: AD tape stack (__ad_tape_stack) is thread_local.

--- a/lib/core/runtime_autodiff.cpp
+++ b/lib/core/runtime_autodiff.cpp
@@ -11,6 +11,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <limits>
 
 extern "C" {
 
@@ -191,6 +192,45 @@ void* eshkol_ad_mixed_record(void* arena_v, void* tape_v, double value, double d
     arena_tape_add_node(tape, scaled);
     arena_tape_add_node(tape, result);
     return result;
+}
+
+/**
+ * @brief Run an externally supplied vector-Jacobian product for AD_NODE_CUSTOM.
+ *
+ * The callback contract intentionally returns unscaled local partials
+ * `dy/dx_i`; this helper owns the universal reverse-mode rule and performs
+ * `input_i->gradient += node->gradient * dy/dx_i`.  Keeping the upstream
+ * multiplication here makes one custom primitive compose exactly like every
+ * built-in scalar node, including when several downstream paths meet at it.
+ */
+void eshkol_ad_node_custom_backward(void* node_ptr) {
+    ad_node_t* node = static_cast<ad_node_t*>(node_ptr);
+    if (!node || !node->saved_tensors || node->num_saved == 0) return;
+
+    eshkol_custom_vjp_t* vjp =
+        static_cast<eshkol_custom_vjp_t*>(node->saved_tensors[0]);
+    if (!vjp || !vjp->backward || !vjp->inputs || vjp->n <= 0) return;
+
+    const int n = vjp->n;
+    double stack_grads[64];
+    double* local_grads = stack_grads;
+    if (n > static_cast<int>(sizeof(stack_grads) / sizeof(stack_grads[0]))) {
+        const size_t count = static_cast<size_t>(n);
+        if (count > std::numeric_limits<size_t>::max() / sizeof(double)) return;
+        arena_t* arena = eshkol_current_arena();
+        local_grads = static_cast<double*>(
+            arena_allocate_aligned(arena, count * sizeof(double), alignof(double)));
+        if (!local_grads) return;
+    }
+
+    const double upstream = node->gradient;
+    vjp->backward(vjp->ctx, upstream, local_grads, n);
+    for (int i = 0; i < n; ++i) {
+        ad_node_t* input = vjp->inputs[i];
+        if (input) {
+            input->gradient += upstream * local_grads[i];
+        }
+    }
 }
 
 /**

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -383,6 +383,18 @@ extern "C" {
         ESHKOL_OPTIONAL_AGENT_FFI;
     double eshkol_vqe_optimize(int64_t handle, int32_t iterations)
         ESHKOL_OPTIONAL_AGENT_FFI;
+    double eshkol_vqe_energy_from_tagged(int64_t handle, const void* params)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    void* eshkol_vqe_ad_prepare(int64_t handle, const void* params)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    double eshkol_vqe_ad_prepared_energy(const void* prepared)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    void* eshkol_vqe_ad_prepared_inputs(void* prepared)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    int64_t eshkol_vqe_ad_prepared_input_count(const void* prepared)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    void* eshkol_vqe_ad_prepared_vjp(void* prepared)
+        ESHKOL_OPTIONAL_AGENT_FFI;
     int64_t eshkol_vqe_gradient_context_create(int64_t handle)
         ESHKOL_OPTIONAL_AGENT_FFI;
     void eshkol_vqe_gradient_context_destroy(int64_t handle)
@@ -1087,6 +1099,12 @@ void ReplJITContext::registerRuntimeSymbols() {
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_vqe_hamiltonian_destroy);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_vqe_hamiltonian_exact_ground_energy);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_vqe_optimize);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_vqe_energy_from_tagged);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_vqe_ad_prepare);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_vqe_ad_prepared_energy);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_vqe_ad_prepared_inputs);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_vqe_ad_prepared_input_count);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_vqe_ad_prepared_vjp);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_vqe_gradient_context_create);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_vqe_gradient_context_destroy);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_vqe_gradient_parameter_count);

--- a/tests/quantum/vqe_ad_test.esk
+++ b/tests/quantum/vqe_ad_test.esk
@@ -1,0 +1,96 @@
+;; Stage S3: Eshkol reverse-mode AD through Moonlab's fixed-parameter VQE
+;; energy. Requires -DESHKOL_QUANTUM_ENABLED=ON.
+;;
+;; This proves three independent properties of the AD bridge:
+;;   1. Its custom VJP is Moonlab's exact native adjoint.
+;;   2. That adjoint agrees with a central finite-difference oracle.
+;;   3. The opaque VQE node remains composable in Eshkol's surrounding tape.
+
+(require agent.quantum)
+
+(define pass 0)
+(define fail 0)
+
+(define (check label ok)
+  (if ok
+      (begin (set! pass (+ pass 1))
+             (display "PASS: ") (display label) (newline))
+      (begin (set! fail (+ fail 1))
+             (display "FAIL: ") (display label) (newline))))
+
+(define (perturb p index delta)
+  (let ((out (make-vector (vector-length p) 0.0)))
+    (let loop ((i 0))
+      (if (< i (vector-length p))
+          (begin
+            (vector-set! out i (if (= i index)
+                                    (+ (vector-ref p i) delta)
+                                    (vector-ref p i)))
+            (loop (+ i 1)))
+          out))))
+
+(define (max-abs-diff a b)
+  (if (not (= (vector-length a) (vector-length b)))
+      1e300
+      (let loop ((i 0) (m 0.0))
+        (if (< i (vector-length a))
+            (loop (+ i 1) (max m (abs (- (vector-ref a i) (vector-ref b i)))))
+            m))))
+
+(define (finite-difference-gradient ham p eps)
+  (let ((out (make-vector (vector-length p) 0.0)))
+    (let loop ((i 0))
+      (if (< i (vector-length p))
+          (begin
+            (vector-set! out i
+              (/ (- (vqe-energy ham (perturb p i eps))
+                    (vqe-energy ham (perturb p i (- eps))))
+                 (* 2.0 eps)))
+            (loop (+ i 1)))
+          out))))
+
+(define (scaled-gradient scalar g)
+  (let ((out (make-vector (vector-length g) 0.0)))
+    (let loop ((i 0))
+      (if (< i (vector-length g))
+          (begin (vector-set! out i (* scalar (vector-ref g i)))
+                 (loop (+ i 1)))
+          out))))
+
+(with-hamiltonian
+ (make-h2-hamiltonian 0.735)
+ (lambda (ham)
+   (let* ((params0 (vector 0.1 0.2 0.3 0.4))
+          (energy (vqe-energy ham params0))
+          (g-eshkol (gradient (lambda (p) (vqe-energy ham p)) params0))
+          (g-moonlab (vqe-gradient ham params0))
+          (g-fd (finite-difference-gradient ham params0 1e-5))
+          (g-square (gradient
+                     (lambda (p)
+                       (let ((e (vqe-energy ham p)))
+                         (* e e)))
+                     params0))
+          (g-square-expected (scaled-gradient (* 2.0 energy) g-moonlab))
+          (adjoint-error (max-abs-diff g-eshkol g-moonlab))
+          (fd-error (max-abs-diff g-eshkol g-fd))
+          (compose-error (max-abs-diff g-square g-square-expected)))
+     (display "E(params0): ") (display energy) (newline)
+     (display "g_eshkol: ") (display g-eshkol) (newline)
+     (display "g_moonlab: ") (display g-moonlab) (newline)
+     (display "g_fd: ") (display g-fd) (newline)
+     (display "2E*g_moonlab: ") (display g-square-expected) (newline)
+     (display "g_(E^2): ") (display g-square) (newline)
+     (display "max |g_eshkol - g_moonlab|: ") (display adjoint-error) (newline)
+     (display "max |g_eshkol - g_fd|: ") (display fd-error) (newline)
+     (display "max |g_(E^2) - 2E*g_moonlab|: ") (display compose-error) (newline)
+     (check "custom VJP matches Moonlab native adjoint (< 1e-8)"
+            (< adjoint-error 1e-8))
+     (check "custom VJP matches central finite difference (< 1e-4)"
+            (< fd-error 1e-4))
+     (check "VQE energy composes through Eshkol chain rule (< 1e-6)"
+            (< compose-error 1e-6)))))
+
+(display "vqe_ad_test: ")
+(if (= fail 0)
+    (begin (display "PASS (") (display pass) (display "/3)") (newline) (exit 0))
+    (begin (display "FAIL (") (display fail) (display " failed)") (newline) (exit 1)))


### PR DESCRIPTION
Stage 3 of the Moonlab quantum integration — the flagship: **differentiate through a quantum circuit with Eshkol's own reverse-mode AD.** `(gradient (lambda (p) (vqe-energy ham p)) p0)` returns dE/dp via Moonlab's exact native adjoint, fully composable inside Eshkol AD.

## What this adds

**`AD_NODE_CUSTOM` — a custom vector-Jacobian-product hook in the AD tower** (genuinely new; every existing backward rule was a hardcoded formula keyed by enum):
- `eshkol_custom_vjp_t { backward(ctx, upstream, out_grads, n), ctx, inputs, n }` stored in the node's `saved_tensors[0]` — an opaque scalar primitive can supply its own exact reverse-mode adjoint.
- Runtime backward helper applies the universal rule exactly once: `input->gradient += upstream * local_partial`.
- A new dispatch case in the codegen'd scalar backward chain (`propagateGradient`), inserted before the unknown-type trap; the type constant comes from the C++ enum, never a literal.
- `recordADNodeCustom` tape builder (arena-owned descriptor, tape lifetime).

**`(vqe-energy ham params)`** in `agent.quantum`: evaluates ⟨ψ(θ)|H|ψ(θ)⟩; under AD it snapshots the primal parameters, wires Moonlab's `vqe_compute_gradient` (exact adjoint) as the custom VJP over the parameter variable nodes, and records the custom tape node — so the energy is a first-class differentiable value.

## Verification (independent, fresh out-of-box build, `-DESHKOL_QUANTUM_ENABLED=ON`)

```
E(params0): -1.083
max |g_eshkol - g_moonlab|      = 0          (exact adjoint match)
max |g_eshkol - g_finite_diff|  = 4.75e-11   (central differences, eps=1e-5)
max |g(E^2) - 2E*g_moonlab|     = 0          (composability: chain rule through Eshkol AD)
vqe_ad_test: PASS (3/3)
```

The composability check is the point of the design: the quantum energy composes with arbitrary differentiable Eshkol code and the chain rule flows exactly.

Bell smoke still 200/200; S2 VQE test still PASS. Default (quantum OFF) build unaffected: memory suite **15/15**, autodiff suite **54/54** (the new enum value + backward case regress nothing). Includes the master merge picking up the #269 Moonlab pin bump so the ON-path builds out of the box.

New test: `tests/quantum/vqe_ad_test.esk` (runs under `ESHKOL_QUANTUM_ENABLED`).
