### PR TITLE
feat(parameters): wire make-parameter/parameterize to real dynamic parameter objects (native + VM)

### DIFF
--- a/inc/eshkol/eshkol.h
+++ b/inc/eshkol/eshkol.h
@@ -1269,6 +1269,10 @@ typedef struct eshkol_exception {
  */
 typedef struct eshkol_exception_handler {
     void* jmp_buf_ptr;                  // Pointer to setjmp buffer
+    // Dynamic-wind stack present when this handler was installed.  A raise
+    // must run after-thunks for every extent entered after this point before
+    // it transfers control with longjmp.
+    void* wind_mark;
     struct eshkol_exception_handler* prev;  // Previous handler in stack
 } eshkol_exception_handler_t;
 
@@ -1455,6 +1459,29 @@ void eshkol_pop_dynamic_wind(void);
 void eshkol_unwind_dynamic_wind(void* saved_wind_mark);
 
 // ===== END FIRST-CLASS CONTINUATIONS =====
+
+// ===== R7RS DYNAMIC PARAMETERS =====
+// The by-value entry points are the stable hosted C ABI.  The pointer forms
+// are provided for generated LLVM code, whose ABI passes tagged aggregates by
+// address on every supported target.
+void* eshkol_make_parameter(void* arena, eshkol_tagged_value_t default_val);
+void eshkol_parameter_push(void* param, eshkol_tagged_value_t value);
+void eshkol_parameter_pop(void* param);
+eshkol_tagged_value_t eshkol_parameter_ref(void* param);
+void eshkol_parameter_set(void* param, eshkol_tagged_value_t value);
+void eshkol_parameter_set_converter(void* param, eshkol_tagged_value_t converter);
+eshkol_tagged_value_t eshkol_parameter_converter_ref(void* param);
+
+void* eshkol_make_parameter_ptr(void* arena, const eshkol_tagged_value_t* default_val);
+void eshkol_parameter_push_ptr(void* param, const eshkol_tagged_value_t* value);
+void eshkol_parameter_set_ptr(void* param, const eshkol_tagged_value_t* value);
+void eshkol_parameter_set_converter_ptr(void* param,
+                                        const eshkol_tagged_value_t* converter);
+void eshkol_parameter_ref_ptr(void* param, eshkol_tagged_value_t* result);
+void eshkol_parameter_converter_ref_ptr(void* param,
+                                        eshkol_tagged_value_t* result);
+
+// ===== END R7RS DYNAMIC PARAMETERS =====
 
 /**
  * @brief Initialize process/thread stack sizing for deep recursion support.

--- a/lib/backend/eshkol_vm.c
+++ b/lib/backend/eshkol_vm.c
@@ -421,6 +421,10 @@ static const BuiltinDef BUILTINS[] = {
     {"ws-register!", 542, 3}, {"ws-step!", 543, 1},
     {"ws-get-content", 544, 1}, {"ws-set-content!", 545, 2},
     {"ws-get-dim", 546, 1}, {"ws-get-step-count", 547, 1},
+    /* R7RS dynamic parameters — make-parameter has optional arity and is
+     * lowered directly by vm_compiler.c; these fixed-arity operations remain
+     * first-class preamble closures. */
+    {"parameter-ref", 701, 1}, {"parameter?", 704, 1},
     /* ═══════════════════════════════════════════════════════════════
      * I/O — IDs 580-602
      * ═══════════════════════════════════════════════════════════════ */

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -7018,10 +7018,189 @@ private:
         return val;
     }
 
+    // Apply an optional Scheme converter exactly once.  Converter execution is
+    // generated here (rather than in the C parameter runtime) because a
+    // converter is an arbitrary Eshkol closure.
+    Value* codegenOptionalParameterConverter(Value* converter, Value* value,
+                                             const char* context_name) {
+        Value* converter_tagged = ensureTaggedValue(converter);
+        Value* candidate = ensureTaggedValue(value);
+        Value* converter_type = getBaseType(getTaggedValueType(converter_tagged));
+        Value* has_converter = builder->CreateICmpNE(
+            converter_type, ConstantInt::get(int8_type, ESHKOL_VALUE_NULL));
+
+        Function* current_func = builder->GetInsertBlock()->getParent();
+        BasicBlock* call_converter_bb = BasicBlock::Create(*context,
+            "parameter_converter_call", current_func);
+        BasicBlock* identity_bb = BasicBlock::Create(*context,
+            "parameter_converter_identity", current_func);
+        BasicBlock* merge_bb = BasicBlock::Create(*context,
+            "parameter_converter_merge", current_func);
+        builder->CreateCondBr(has_converter, call_converter_bb, identity_bb);
+
+        builder->SetInsertPoint(identity_bb);
+        builder->CreateBr(merge_bb);
+        BasicBlock* identity_exit = builder->GetInsertBlock();
+
+        builder->SetInsertPoint(call_converter_bb);
+        // Do not recursively emit the parameter-object dispatch while
+        // compiling the converter invocation itself.  A converter is required
+        // to be a procedure, and re-entering that dispatch here would make
+        // every ordinary closure call instantiate an unbounded tree of
+        // hypothetical parameter-set converter calls at compile time.
+        Value* converted = codegenClosureCall(converter_tagged, {candidate},
+                                              context_name, false);
+        builder->CreateBr(merge_bb);
+        BasicBlock* converter_exit = builder->GetInsertBlock();
+
+        builder->SetInsertPoint(merge_bb);
+        PHINode* result = builder->CreatePHI(tagged_value_type, 2,
+                                              "parameter_converted");
+        result->addIncoming(candidate, identity_exit);
+        result->addIncoming(ensureTaggedValue(converted), converter_exit);
+        return result;
+    }
+
+    Value* codegenParameterConverterFor(Value* param_ptr, Value* value,
+                                        const char* context_name) {
+        Value* converter_slot = builder->CreateAlloca(tagged_value_type, nullptr,
+                                                      "parameter_converter");
+        FunctionCallee converter_ref = module->getOrInsertFunction(
+            "eshkol_parameter_converter_ref_ptr",
+            FunctionType::get(builder->getVoidTy(), {ptr_type, ptr_type}, false));
+        builder->CreateCall(converter_ref, {param_ptr, converter_slot});
+        Value* converter = builder->CreateLoad(tagged_value_type, converter_slot);
+        return codegenOptionalParameterConverter(converter, value, context_name);
+    }
+
+    Value* codegenParameterRef(Value* param_ptr) {
+        Value* result_slot = builder->CreateAlloca(tagged_value_type, nullptr,
+                                                   "parameter_ref");
+        FunctionCallee ref = module->getOrInsertFunction(
+            "eshkol_parameter_ref_ptr",
+            FunctionType::get(builder->getVoidTy(), {ptr_type, ptr_type}, false));
+        builder->CreateCall(ref, {param_ptr, result_slot});
+        return builder->CreateLoad(tagged_value_type, result_slot);
+    }
+
+    Value* codegenParameterSet(Value* param_ptr, Value* value) {
+        Value* value_slot = builder->CreateAlloca(tagged_value_type, nullptr,
+                                                  "parameter_set_value");
+        Value* tagged_value = ensureTaggedValue(value);
+        builder->CreateStore(tagged_value, value_slot);
+        FunctionCallee set = module->getOrInsertFunction(
+            "eshkol_parameter_set_ptr",
+            FunctionType::get(builder->getVoidTy(), {ptr_type, ptr_type}, false));
+        builder->CreateCall(set, {param_ptr, value_slot});
+        return tagged_value;
+    }
+
+    Value* codegenParameterPush(Value* parameter, Value* value) {
+        Value* parameter_tagged = ensureTaggedValue(parameter);
+        Value* param_bits = unpackInt64FromTaggedValue(parameter_tagged);
+        Value* param_ptr = builder->CreateIntToPtr(param_bits, ptr_type,
+                                                   "parameter_push_handle");
+        Value* value_slot = builder->CreateAlloca(tagged_value_type, nullptr,
+                                                  "parameter_push_value");
+        Value* tagged_value = ensureTaggedValue(value);
+        builder->CreateStore(tagged_value, value_slot);
+        FunctionCallee push = module->getOrInsertFunction(
+            "eshkol_parameter_push_ptr",
+            FunctionType::get(builder->getVoidTy(), {ptr_type, ptr_type}, false));
+        builder->CreateCall(push, {param_ptr, value_slot});
+        return tagged_value;
+    }
+
+    Value* codegenParameterPop(Value* parameter) {
+        Value* parameter_tagged = ensureTaggedValue(parameter);
+        Value* param_bits = unpackInt64FromTaggedValue(parameter_tagged);
+        Value* param_ptr = builder->CreateIntToPtr(param_bits, ptr_type,
+                                                   "parameter_pop_handle");
+        FunctionCallee pop = module->getOrInsertFunction(
+            "eshkol_parameter_pop",
+            FunctionType::get(builder->getVoidTy(), {ptr_type}, false));
+        builder->CreateCall(pop, {param_ptr});
+        return packNullToTaggedValue();
+    }
+
+    Value* codegenMakeParameter(const eshkol_operations_t* op) {
+        if (op->call_op.num_vars < 1 || op->call_op.num_vars > 2) {
+            eshkol_error("make-parameter requires an initial value and an optional converter");
+            return packNullToTaggedValue();
+        }
+
+        Value* initial = ensureTaggedValue(codegenAST(&op->call_op.variables[0]));
+        if (builder->GetInsertBlock()->getTerminator()) {
+            return UndefValue::get(tagged_value_type);
+        }
+        Value* converter = packNullToTaggedValue();
+        if (op->call_op.num_vars == 2) {
+            converter = ensureTaggedValue(codegenAST(&op->call_op.variables[1]));
+            if (builder->GetInsertBlock()->getTerminator()) {
+                return UndefValue::get(tagged_value_type);
+            }
+            initial = codegenOptionalParameterConverter(converter, initial,
+                                                        "make-parameter-converter");
+        }
+
+        Value* initial_slot = builder->CreateAlloca(tagged_value_type, nullptr,
+                                                    "parameter_default");
+        builder->CreateStore(initial, initial_slot);
+        Value* arena_ptr = getArenaPtr();
+        FunctionCallee make = module->getOrInsertFunction(
+            "eshkol_make_parameter_ptr",
+            FunctionType::get(ptr_type, {ptr_type, ptr_type}, false));
+        Value* param_ptr = builder->CreateCall(make, {arena_ptr, initial_slot},
+                                               "parameter_handle");
+
+        Value* converter_slot = builder->CreateAlloca(tagged_value_type, nullptr,
+                                                      "parameter_converter_value");
+        builder->CreateStore(converter, converter_slot);
+        FunctionCallee set_converter = module->getOrInsertFunction(
+            "eshkol_parameter_set_converter_ptr",
+            FunctionType::get(builder->getVoidTy(), {ptr_type, ptr_type}, false));
+        builder->CreateCall(set_converter, {param_ptr, converter_slot});
+        return packPtrToTaggedValue(param_ptr, ESHKOL_VALUE_HEAP_PTR);
+    }
+
     // Runtime closure call dispatcher - supports variadic closures with up to 16 captures
     // This is essential for N-dimensional lambda calculus and AD operations
-    Value* codegenClosureCall(Value* func_result, const std::vector<Value*>& call_args, const char* caller_info = "unknown") {
-        (void)caller_info;  // Used for debugging
+    Value* codegenClosureCall(Value* func_result, const std::vector<Value*>& call_args,
+                              const char* caller_info = "unknown",
+                              bool parameter_dispatch = true) {
+        func_result = ensureTaggedValue(func_result);
+        Function* current_func = builder->GetInsertBlock()->getParent();
+        BasicBlock* merge_bb = BasicBlock::Create(*context, "call_merge", current_func);
+
+        // A parameter object is both a heap object and a procedure.  Dispatch
+        // it before the ordinary closure path so it never gets interpreted as
+        // an eshkol_closure_t.  Zero arguments read the real dynamic stack;
+        // one or more preserve the historical setter behaviour using the first
+        // argument, after its parameter-specific converter has run.
+        Value* parameter_result = nullptr;
+        BasicBlock* parameter_exit_bb = nullptr;
+        if (parameter_dispatch) {
+            Value* is_parameter = isHeapSubtype(func_result, HEAP_SUBTYPE_PARAMETER);
+            BasicBlock* parameter_bb = BasicBlock::Create(*context, "call_parameter", current_func);
+            BasicBlock* dispatch_bb = BasicBlock::Create(*context, "call_non_parameter", current_func);
+            builder->CreateCondBr(is_parameter, parameter_bb, dispatch_bb);
+
+            builder->SetInsertPoint(parameter_bb);
+            Value* parameter_bits = unpackInt64FromTaggedValue(func_result);
+            Value* parameter_ptr = builder->CreateIntToPtr(parameter_bits, ptr_type,
+                                                           "call_parameter_handle");
+            if (call_args.empty()) {
+                parameter_result = codegenParameterRef(parameter_ptr);
+            } else {
+                Value* converted = codegenParameterConverterFor(
+                    parameter_ptr, call_args[0], "parameter-procedure-converter");
+                parameter_result = codegenParameterSet(parameter_ptr, converted);
+            }
+            builder->CreateBr(merge_bb);
+            parameter_exit_bb = builder->GetInsertBlock();
+
+            builder->SetInsertPoint(dispatch_bb);
+        }
         // Check if the result is a CLOSURE_PTR (legacy) or CALLABLE (consolidated) or a direct function pointer
         // M1 Migration: Check both legacy and consolidated formats for backward compatibility
         Value* type_tag = getTaggedValueType(func_result);
@@ -7032,10 +7211,8 @@ private:
             ConstantInt::get(int8_type, ESHKOL_VALUE_CALLABLE));
         Value* is_closure = builder->CreateOr(is_legacy_closure, is_callable_type);
 
-        Function* current_func = builder->GetInsertBlock()->getParent();
         BasicBlock* closure_bb = BasicBlock::Create(*context, "call_closure", current_func);
         BasicBlock* direct_bb = BasicBlock::Create(*context, "call_direct", current_func);
-        BasicBlock* merge_bb = BasicBlock::Create(*context, "call_merge", current_func);
 
         builder->CreateCondBr(is_closure, closure_bb, direct_bb);
 
@@ -7643,12 +7820,17 @@ private:
 
         // MERGE: PHI node to select result from all paths
         builder->SetInsertPoint(merge_bb);
-        PHINode* phi = builder->CreatePHI(tagged_value_type, results.size() + 2, "call_result");
+        PHINode* phi = builder->CreatePHI(tagged_value_type,
+                                          results.size() + (parameter_dispatch ? 3 : 2),
+                                          "call_result");
         for (auto& [bb, val] : results) {
             phi->addIncoming(val, bb);
         }
         phi->addIncoming(direct_result, direct_exit_bb);
         phi->addIncoming(as_is_result, as_is_exit_bb);
+        if (parameter_dispatch) {
+            phi->addIncoming(ensureTaggedValue(parameter_result), parameter_exit_bb);
+        }
 
         return phi;
     }
@@ -10539,6 +10721,9 @@ private:
                 eshkol_error("parameterize should have been transformed at parse time");
                 return nullptr;
 
+            case ESHKOL_MAKE_PARAMETER_OP:
+                return codegenMakeParameter(op);
+
             case ESHKOL_QUOTE_OP:
                 // Quote returns the AST as literal data
                 if (op->call_op.num_vars > 0) {
@@ -11969,6 +12154,47 @@ private:
         }
         
         std::string func_name = op->call_op.func->variable.id;
+
+        // Parser-private parameter helpers.  They are intentionally lowered
+        // here instead of exposed as Scheme-library procedures: this keeps the
+        // opaque eshkol_param_t handle inside the native object path while the
+        // parser can still build ordinary dynamic-wind closures for unwind
+        // safety.
+        if (func_name == "__eshkol_parameter_convert") {
+            if (op->call_op.num_vars != 2) {
+                eshkol_error("internal parameter conversion requires a parameter and a value");
+                return packNullToTaggedValue();
+            }
+            Value* parameter = ensureTaggedValue(codegenAST(&op->call_op.variables[0]));
+            if (builder->GetInsertBlock()->getTerminator()) return UndefValue::get(tagged_value_type);
+            Value* value = ensureTaggedValue(codegenAST(&op->call_op.variables[1]));
+            if (builder->GetInsertBlock()->getTerminator()) return UndefValue::get(tagged_value_type);
+            Value* parameter_bits = unpackInt64FromTaggedValue(parameter);
+            Value* parameter_ptr = builder->CreateIntToPtr(parameter_bits, ptr_type,
+                                                           "parameter_convert_handle");
+            return codegenParameterConverterFor(parameter_ptr, value,
+                                                "parameterize-converter");
+        }
+        if (func_name == "__eshkol_parameter_push") {
+            if (op->call_op.num_vars != 2) {
+                eshkol_error("internal parameter push requires a parameter and a converted value");
+                return packNullToTaggedValue();
+            }
+            Value* parameter = ensureTaggedValue(codegenAST(&op->call_op.variables[0]));
+            if (builder->GetInsertBlock()->getTerminator()) return UndefValue::get(tagged_value_type);
+            Value* value = ensureTaggedValue(codegenAST(&op->call_op.variables[1]));
+            if (builder->GetInsertBlock()->getTerminator()) return UndefValue::get(tagged_value_type);
+            return codegenParameterPush(parameter, value);
+        }
+        if (func_name == "__eshkol_parameter_pop") {
+            if (op->call_op.num_vars != 1) {
+                eshkol_error("internal parameter pop requires a parameter");
+                return packNullToTaggedValue();
+            }
+            Value* parameter = ensureTaggedValue(codegenAST(&op->call_op.variables[0]));
+            if (builder->GetInsertBlock()->getTerminator()) return UndefValue::get(tagged_value_type);
+            return codegenParameterPop(parameter);
+        }
 
         // TCO CHECK: If TCO is active and this is a self-recursive call, use tail call jump
         // Check the binding module's TCO context (set by letrec during lambda generation)
@@ -14947,21 +15173,10 @@ private:
         // R7RS Parameter Objects
         // =========================================================================
         if (func_name == "make-parameter") {
-            // (make-parameter default-value)
-            if (op->call_op.num_vars < 1) return nullptr;
-            TypedValue tv = codegenTypedAST(&op->call_op.variables[0]);
-            if (!tv.llvm_value) return nullptr;
-            Value* default_val = typedValueToTaggedValue(tv);
-            Value* arena_ptr = builder->CreateLoad(PointerType::getUnqual(*context), global_arena);
-            // Call eshkol_make_parameter(arena, default_val) — pass tagged value by pointer
-            FunctionType* mkp_type = FunctionType::get(PointerType::getUnqual(*context),
-                {PointerType::getUnqual(*context), PointerType::getUnqual(*context)}, false);
-            FunctionCallee mkp_fn = module->getOrInsertFunction("eshkol_make_parameter_ptr", mkp_type);
-            // Store default_val to stack slot
-            Value* val_alloca = builder->CreateAlloca(tagged_value_type, nullptr, "param_default");
-            builder->CreateStore(default_val, val_alloca);
-            Value* param_ptr = builder->CreateCall(mkp_fn, {arena_ptr, val_alloca});
-            return packPtrToTaggedValue(param_ptr, ESHKOL_VALUE_HEAP_PTR);
+            // Preserve the direct CALL_OP route used by eval/JIT and FFI ASTs:
+            // it must share the same converter-aware object construction as
+            // the parser-recognized special form.
+            return codegenMakeParameter(op);
         }
 
         if (func_name == "parameter?") {

--- a/lib/backend/vm_compiler.c
+++ b/lib/backend/vm_compiler.c
@@ -497,41 +497,70 @@ static void compile_form_define_record_type(FuncChunk* c, Node* node, int tail) 
 }
 
 /** @brief Compile a `(parameterize ((param value)...) body...)` special
- *         form: pushes each parameter binding (native call 702), compiles
- *         the body, then pops all bindings in reverse order (native call
- *         703) for correct unwinding. */
+ *         form.  Parameter and value expressions are first evaluated into
+ *         locals, then every converter is run exactly once before any
+ *         dynamic binding is installed.  This mirrors the native lowering:
+ *         a converter that raises cannot leave a partially-bound parameter
+ *         stack, and cleanup never re-evaluates a parameter expression. */
 static void compile_form_parameterize(FuncChunk* c, Node* node, int tail) {
     Node* head = node->children[0];
-    (void)head; (void)tail;
+    (void)head;
     Node* bindings = node->children[1];
-    int n_bindings = bindings->n_children;
+    int saved_locals = c->n_locals;
+    int parameter_slots[64];
+    int raw_value_slots[64];
+    int converted_value_slots[64];
+    int n_bindings = 0;
 
-    /* Push each parameter binding */
-    for (int i = 0; i < n_bindings; i++) {
-        if (bindings->children[i]->type == N_LIST &&
-            bindings->children[i]->n_children == 2) {
-            compile_expr(c, bindings->children[i]->children[0], 0); /* param */
-            compile_expr(c, bindings->children[i]->children[1], 0); /* new value */
-            chunk_emit(c, OP_NATIVE_CALL, 702); /* parameterize-push */
-            chunk_emit(c, OP_POP, 0); /* discard void result */
-        }
+    /* Preserve the normal left-to-right evaluation of binding expressions. */
+    for (int i = 0; i < bindings->n_children && n_bindings < 64; i++) {
+        Node* binding = bindings->children[i];
+        if (binding->type != N_LIST || binding->n_children != 2) continue;
+        compile_expr(c, binding->children[0], 0);
+        parameter_slots[n_bindings] = add_local(c, "__parameterize_parameter__");
+        compile_expr(c, binding->children[1], 0);
+        raw_value_slots[n_bindings] = add_local(c, "__parameterize_raw_value__");
+        n_bindings++;
     }
 
-    /* Compile body */
+    /* Converters run after all binding expressions but before the first push.
+     * Native 705 is deliberately separate from 702 so it is impossible for
+     * a binding to be converted twice. */
+    for (int i = 0; i < n_bindings; i++) {
+        chunk_emit(c, OP_GET_LOCAL, parameter_slots[i]);
+        chunk_emit(c, OP_GET_LOCAL, raw_value_slots[i]);
+        chunk_emit(c, OP_NATIVE_CALL, 705); /* parameter-convert */
+        converted_value_slots[i] = add_local(c, "__parameterize_value__");
+    }
+
+    /* Enter every binding.  Native 702 records a parameter cleanup entry in
+     * the VM wind stack, so exceptions and continuation escapes pop in LIFO
+     * order before enclosing dynamic-wind after thunks run. */
+    for (int i = 0; i < n_bindings; i++) {
+        chunk_emit(c, OP_GET_LOCAL, parameter_slots[i]);
+        chunk_emit(c, OP_GET_LOCAL, converted_value_slots[i]);
+        chunk_emit(c, OP_NATIVE_CALL, 702); /* parameterize-push */
+        chunk_emit(c, OP_POP, 0);
+    }
+
+    /* A tail call would bypass the mandatory pop sequence, so a bound body
+     * is never compiled in tail position. */
     for (int i = 2; i < node->n_children; i++) {
         if (i > 2) chunk_emit(c, OP_POP, 0);
-        compile_expr(c, node->children[i], tail && i == node->n_children - 1);
+        compile_expr(c, node->children[i],
+                     n_bindings == 0 && tail && i == node->n_children - 1);
     }
 
-    /* Pop each binding in reverse order for proper unwinding */
+    /* Pop each stored parameter in reverse order without re-evaluation. */
     for (int i = n_bindings - 1; i >= 0; i--) {
-        if (bindings->children[i]->type == N_LIST &&
-            bindings->children[i]->n_children >= 1) {
-            compile_expr(c, bindings->children[i]->children[0], 0); /* param */
-            chunk_emit(c, OP_NATIVE_CALL, 703); /* parameterize-pop */
-            chunk_emit(c, OP_POP, 0);
-        }
+        chunk_emit(c, OP_GET_LOCAL, parameter_slots[i]);
+        chunk_emit(c, OP_NATIVE_CALL, 703); /* parameterize-pop */
+        chunk_emit(c, OP_POP, 0);
     }
+
+    int n_locals = c->n_locals - saved_locals;
+    if (n_locals > 0) chunk_emit(c, OP_POPN, n_locals);
+    c->n_locals = saved_locals;
     return;
 }
 
@@ -2177,6 +2206,19 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
 
     /* (define-record-type name (constructor field...) pred (field accessor [mutator]) ...) */
     if (is_sym(head, "define-record-type") && node->n_children >= 4) { compile_form_define_record_type(c, node, tail); return; }
+
+    /* (make-parameter default [converter]) — this is a VM special lowering
+     * because the builtin preamble is fixed-arity while R7RS permits the
+     * optional converter.  Native 700 applies that converter to the default
+     * and keeps it for every later parameterize binding. */
+    if (is_sym(head, "make-parameter") &&
+        (node->n_children == 2 || node->n_children == 3)) {
+        compile_expr(c, node->children[1], 0);
+        if (node->n_children == 3) compile_expr(c, node->children[2], 0);
+        else chunk_emit(c, OP_NIL, 0);
+        chunk_emit(c, OP_NATIVE_CALL, 700);
+        return;
+    }
 
     /* (parameterize ((param1 val1) (param2 val2) ...) body ...) */
     if (is_sym(head, "parameterize") && node->n_children >= 3) { compile_form_parameterize(c, node, tail); return; }

--- a/lib/backend/vm_core.c
+++ b/lib/backend/vm_core.c
@@ -295,13 +295,26 @@ typedef struct VM {
     int n_outputs;
 
     /* Exception handling */
-    struct { int pc; int sp; int fp; int frame_count; int n_winds; } handler_stack[16];
+    struct {
+        int pc;
+        int sp;
+        int fp;
+        int frame_count;
+        int n_winds;
+        int n_parameter_bindings;
+    } handler_stack[16];
     int n_handlers;
     Value current_exception;
 
     /* Dynamic-wind stack */
     struct { Value before; Value after; } wind_stack[32];
     int n_winds;
+
+    /* Dynamic parameter bindings parallel dynamic-wind for VM exception
+     * unwinding.  Each entry names a VmParameter whose stack received an
+     * actual native 702 push; normal 703 and exceptional exits pop LIFO. */
+    Value parameter_bindings[64];
+    int n_parameter_bindings;
 
     /* Status */
     int halted;
@@ -830,9 +843,13 @@ static int vm_extract_shape(VM* vm, Value shape_val, int64_t* shape, int max_dim
 
 /* Continuation: saved VM state for call/cc */
 typedef struct {
-    int pc, fp, sp, frame_count, n_handlers, n_winds;
+    int pc, fp, sp, frame_count, n_handlers, n_winds, n_parameter_bindings;
     Value* saved_stack;
     CallFrame* saved_frames;
+    Value* saved_wind_befores;
+    Value* saved_wind_afters;
+    Value* saved_parameter_bindings;
+    Value* saved_parameter_values;
 } VmContinuation;
 
 /* Simple vector for VEC_CREATE/VEC_REF/VEC_SET/VEC_LEN opcodes */

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -4543,6 +4543,96 @@ static double vm_round_half_even(double x) {
     return r;
 }
 
+static VmParameter* vm_parameter_from_value(VM* vm, Value value) {
+    if (!vm || !is_heap_type(vm, value, HEAP_PARAMETER)) return NULL;
+    return (VmParameter*)vm->heap.objects[value.as.ptr]->opaque.ptr;
+}
+
+static Value vm_parameter_converter(VmParameter* parameter) {
+    Value converter = NIL_VAL;
+    vm_param_converter_ref(parameter, &converter);
+    return converter;
+}
+
+static Value vm_parameter_apply_converter(VM* vm, VmParameter* parameter,
+                                          Value value) {
+    Value converter = vm_parameter_converter(parameter);
+    if (converter.type == VAL_CLOSURE) {
+        return vm_call_closure_from_native(vm, converter, &value, 1);
+    }
+    return value;
+}
+
+static void vm_unwind_parameter_bindings(VM* vm, int target_depth) {
+    if (!vm) return;
+    if (target_depth < 0) target_depth = 0;
+    while (vm->n_parameter_bindings > target_depth) {
+        Value parameter_value = vm->parameter_bindings[--vm->n_parameter_bindings];
+        VmParameter* parameter = vm_parameter_from_value(vm, parameter_value);
+        if (parameter) vm_param_pop(parameter);
+    }
+}
+
+static int vm_record_parameter_binding(VM* vm, Value parameter_value) {
+    if (!vm) return 0;
+    if (vm->n_parameter_bindings >=
+        (int)(sizeof(vm->parameter_bindings) / sizeof(vm->parameter_bindings[0]))) {
+        fprintf(stderr, "ERROR: parameterize binding stack overflow\n");
+        vm->error = 1;
+        return 0;
+    }
+    vm->parameter_bindings[vm->n_parameter_bindings++] = parameter_value;
+    return 1;
+}
+
+static void vm_pop_recorded_parameter_binding(VM* vm, Value parameter_value) {
+    if (!vm || vm->n_parameter_bindings <= 0) return;
+    int top = vm->n_parameter_bindings - 1;
+    if (vm->parameter_bindings[top].type == parameter_value.type &&
+        vm->parameter_bindings[top].as.ptr == parameter_value.as.ptr) {
+        vm->n_parameter_bindings = top;
+    }
+}
+
+/* Parameters are entered in the VM's dynamic-wind stack as cleanup entries.
+ * That makes an outer dynamic-wind's after thunk observe the restored
+ * parameter value on exceptions and continuation escapes, just as the
+ * compiled native dynamic-wind lowering does. */
+static void vm_pop_parameter_binding(VM* vm, Value parameter_value) {
+    VmParameter* parameter = vm_parameter_from_value(vm, parameter_value);
+    if (parameter) vm_param_pop(parameter);
+    vm_pop_recorded_parameter_binding(vm, parameter_value);
+}
+
+static void vm_run_wind_after(VM* vm, Value after) {
+    if (after.type == VAL_CLOSURE) {
+        vm_call_closure_from_native(vm, after, NULL, 0);
+    } else if (after.type == VAL_PARAMETER_OBJ) {
+        vm_pop_parameter_binding(vm, after);
+    }
+}
+
+/* Procedure-call semantics for VAL_PARAMETER_OBJ.  The bytecode interpreter
+ * calls this from OP_CALL/OP_TAIL_CALL; a zero-arity call reads the dynamic
+ * stack and a one-or-more-arity call updates its current slot with the first
+ * converted argument, matching the hosted native path's legacy setter API. */
+static Value vm_parameter_invoke(VM* vm, Value parameter_value,
+                                 const Value* args, int argc) {
+    VmParameter* parameter = vm_parameter_from_value(vm, parameter_value);
+    if (!parameter) {
+        if (vm) vm->error = 1;
+        return NIL_VAL;
+    }
+    if (argc == 0) {
+        Value result;
+        vm_param_ref(parameter, &result);
+        return result;
+    }
+    Value converted = vm_parameter_apply_converter(vm, parameter, args[0]);
+    vm_param_set(parameter, &converted);
+    return converted;
+}
+
 /**
  * @brief Deep structural equality (`equal?` per R7RS): recurses through pairs
  *        and vectors, compares strings by content and numbers by value.
@@ -9389,39 +9479,63 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
 
     /* ══════════════════════════════════════════════════════════════════════
-     * Parameter Operations (700-704)
+     * Parameter Operations (700-705)
      * ══════════════════════════════════════════════════════════════════════ */
     case 700: { /* make-parameter(default, converter) */
         Value conv = vm_pop(vm), dflt = vm_pop(vm);
-        VmParameter* p = vm_param_make(&vm->heap.regions,
-            (void*)(uintptr_t)dflt.as.i, (void*)(uintptr_t)conv.as.i);
+        /* R7RS: the converter is applied to the default during creation. */
+        if (conv.type == VAL_CLOSURE) {
+            dflt = vm_call_closure_from_native(vm, conv, &dflt, 1);
+        }
+        VmParameter* p = vm_param_make(&vm->heap.regions, &dflt, &conv);
         if (!p) { vm_push(vm, NIL_VAL); break; }
         VM_PUSH_HEAP_OPAQUE(vm, HEAP_PARAMETER, VAL_PARAMETER_OBJ, p);
         break;
     }
     case 701: { /* parameter-ref */
         Value p_val = vm_pop(vm);
-        if (is_heap_type(vm, p_val, HEAP_PARAMETER)) {
-            VmParameter* p = (VmParameter*)vm->heap.objects[p_val.as.ptr]->opaque.ptr;
-            void* v = vm_param_ref(p);
-            vm_push(vm, INT_VAL((int64_t)(intptr_t)v));
+        VmParameter* p = vm_parameter_from_value(vm, p_val);
+        if (p) {
+            Value value;
+            vm_param_ref(p, &value);
+            vm_push(vm, value);
         } else vm_push(vm, NIL_VAL);
         break;
     }
-    case 702: { /* parameterize-push(param, value) */
+    case 702: { /* parameterize-push(param, converted-value) */
         Value val = vm_pop(vm), p_val = vm_pop(vm);
-        if (is_heap_type(vm, p_val, HEAP_PARAMETER)) {
-            VmParameter* p = (VmParameter*)vm->heap.objects[p_val.as.ptr]->opaque.ptr;
-            vm_param_push(&vm->heap.regions, p, (void*)(uintptr_t)val.as.i);
+        VmParameter* p = vm_parameter_from_value(vm, p_val);
+        if (!p) {
+            vm->error = 1;
+        } else if (vm->n_winds >=
+                   (int)(sizeof(vm->wind_stack) / sizeof(vm->wind_stack[0]))) {
+            fprintf(stderr, "ERROR: parameterize dynamic stack overflow\n");
+            vm->error = 1;
+        } else {
+            vm_param_push(&vm->heap.regions, p, &val);
+            if (vm_record_parameter_binding(vm, p_val)) {
+                vm->wind_stack[vm->n_winds].before = NIL_VAL;
+                vm->wind_stack[vm->n_winds].after = p_val;
+                vm->n_winds++;
+            } else {
+                vm_param_pop(p);
+            }
         }
         vm_push(vm, NIL_VAL);
         break;
     }
     case 703: { /* parameterize-pop(param) */
         Value p_val = vm_pop(vm);
-        if (is_heap_type(vm, p_val, HEAP_PARAMETER)) {
-            VmParameter* p = (VmParameter*)vm->heap.objects[p_val.as.ptr]->opaque.ptr;
-            vm_param_pop(p);
+        if (vm->n_winds > 0 &&
+            vm->wind_stack[vm->n_winds - 1].after.type == p_val.type &&
+            vm->wind_stack[vm->n_winds - 1].after.as.ptr == p_val.as.ptr) {
+            vm->n_winds--;
+            vm_pop_parameter_binding(vm, p_val);
+        } else {
+            /* A malformed bytecode stream must not silently leave a binding
+             * active; retain the old direct cleanup behavior and flag it. */
+            vm->error = 1;
+            vm_pop_parameter_binding(vm, p_val);
         }
         vm_push(vm, NIL_VAL);
         break;
@@ -9430,6 +9544,13 @@ static void vm_dispatch_native(VM* vm, int fid) {
         Value v = vm_pop(vm);
         int is_param = (is_heap_type(vm, v, HEAP_PARAMETER));
         vm_push(vm, BOOL_VAL(is_param));
+        break;
+    }
+    case 705: { /* parameter-convert(param, value) */
+        Value value = vm_pop(vm), p_val = vm_pop(vm);
+        VmParameter* p = vm_parameter_from_value(vm, p_val);
+        vm_push(vm, p ? vm_parameter_apply_converter(vm, p, value) : NIL_VAL);
+        if (!p) vm->error = 1;
         break;
     }
 
@@ -10403,9 +10524,10 @@ static void vm_dispatch_native(VM* vm, int fid) {
             while (vm->n_winds > target_winds) {
                 vm->n_winds--;
                 Value after = vm->wind_stack[vm->n_winds].after;
-                if (after.type == VAL_CLOSURE)
-                    vm_call_closure_from_native(vm, after, NULL, 0);
+                vm_run_wind_after(vm, after);
             }
+            vm_unwind_parameter_bindings(
+                vm, vm->handler_stack[vm->n_handlers].n_parameter_bindings);
             vm->sp = vm->handler_stack[vm->n_handlers].sp;
             vm->fp = vm->handler_stack[vm->n_handlers].fp;
             vm->frame_count = vm->handler_stack[vm->n_handlers].frame_count;

--- a/lib/backend/vm_parameter.c
+++ b/lib/backend/vm_parameter.c
@@ -6,7 +6,8 @@
  * parameterize-push/pop save and restore values on a per-parameter
  * stack, supporting arbitrary nesting.
  *
- * Native call IDs: 700-704
+ * Native call IDs: 700-704 (the interpreter-only converter invocation is
+ * native ID 705 and lives in vm_native.c because it must call closures).
  *
  * Copyright (C) Tsotchke Corporation. MIT License.
  */
@@ -17,10 +18,22 @@
 
 /* ── Parameter Object ── */
 
+/* This has the exact memory layout of vm_core.c's Value without depending on
+ * the unity include order.  The pointer APIs copy it to/from Value objects. */
 typedef struct {
-    void* current_value;
-    void* converter;      /* optional converter closure, NULL if none */
-    void** save_stack;    /* arena-allocated stack for parameterize nesting */
+    int type;
+    union {
+        int64_t i;
+        double f;
+        int b;
+        int32_t ptr;
+    } as;
+} VmParameterValue;
+
+typedef struct {
+    VmParameterValue current_value;
+    VmParameterValue converter;  /* VAL_NIL when absent */
+    VmParameterValue* save_stack;
     int stack_depth;
     int stack_cap;
 } VmParameter;
@@ -32,22 +45,35 @@ typedef struct {
 /** @brief Native call 700: `(make-parameter default [converter])` —
  *         allocate a dynamic parameter object with its save/restore stack
  *         pre-sized to PARAM_INITIAL_STACK. */
-VmParameter* vm_param_make(VmRegionStack* rs, void* default_val, void* converter) {
+VmParameter* vm_param_make(VmRegionStack* rs, const void* default_val,
+                           const void* converter) {
     VmParameter* p = (VmParameter*)vm_alloc_object(rs, VM_SUBTYPE_PARAMETER,
                                                     sizeof(VmParameter));
     if (!p) return NULL;
-    p->current_value = default_val;
-    p->converter = converter;
+    memset(&p->current_value, 0, sizeof(p->current_value));
+    memset(&p->converter, 0, sizeof(p->converter));
+    if (default_val) memcpy(&p->current_value, default_val, sizeof(p->current_value));
+    if (converter) memcpy(&p->converter, converter, sizeof(p->converter));
     p->stack_depth = 0;
     p->stack_cap = PARAM_INITIAL_STACK;
-    p->save_stack = (void**)vm_alloc(rs, (size_t)p->stack_cap * sizeof(void*));
+    p->save_stack = (VmParameterValue*)vm_alloc(
+        rs, (size_t)p->stack_cap * sizeof(VmParameterValue));
     if (!p->save_stack) return NULL;
     return p;
 }
 
-/** @brief Native call 701: current value of parameter @p p. */
-void* vm_param_ref(const VmParameter* p) {
-    return p ? p->current_value : NULL;
+/** @brief Native call 701: copy the current parameter value to @p out. */
+void vm_param_ref(const VmParameter* p, void* out) {
+    if (!out) return;
+    if (p) memcpy(out, &p->current_value, sizeof(p->current_value));
+    else memset(out, 0, sizeof(VmParameterValue));
+}
+
+/** Copy the optional converter to @p out. */
+void vm_param_converter_ref(const VmParameter* p, void* out) {
+    if (!out) return;
+    if (p) memcpy(out, &p->converter, sizeof(p->converter));
+    else memset(out, 0, sizeof(VmParameterValue));
 }
 
 /**
@@ -57,25 +83,27 @@ void* vm_param_ref(const VmParameter* p) {
  *        apply it to @p new_value before calling this (this module has no
  *        VM-level closure-call capability).
  */
-void vm_param_push(VmRegionStack* rs, VmParameter* p, void* new_value) {
+void vm_param_push(VmRegionStack* rs, VmParameter* p, const void* new_value) {
     if (!p) return;
 
     /* Grow stack if needed */
     if (p->stack_depth >= p->stack_cap) {
         int new_cap = p->stack_cap * 2;
-        void** new_stack = (void**)vm_alloc(rs, (size_t)new_cap * sizeof(void*));
+        VmParameterValue* new_stack = (VmParameterValue*)vm_alloc(
+            rs, (size_t)new_cap * sizeof(VmParameterValue));
         if (!new_stack) {
             fprintf(stderr, "ERROR: parameterize stack growth failed\n");
             return;
         }
-        memcpy(new_stack, p->save_stack, (size_t)p->stack_depth * sizeof(void*));
+        memcpy(new_stack, p->save_stack,
+               (size_t)p->stack_depth * sizeof(VmParameterValue));
         p->save_stack = new_stack;
         p->stack_cap = new_cap;
     }
 
     /* Save current value */
     p->save_stack[p->stack_depth++] = p->current_value;
-    p->current_value = new_value;
+    if (new_value) memcpy(&p->current_value, new_value, sizeof(p->current_value));
 }
 
 /** @brief Native call 703: `parameterize` exit — restore @p p's value from
@@ -86,6 +114,12 @@ void vm_param_pop(VmParameter* p) {
         return;
     }
     p->current_value = p->save_stack[--p->stack_depth];
+}
+
+/** Replace the current binding without changing dynamic nesting depth. */
+void vm_param_set(VmParameter* p, const void* new_value) {
+    if (!p || !new_value) return;
+    memcpy(&p->current_value, new_value, sizeof(p->current_value));
 }
 
 /** @brief Native call 704: `(parameter? obj)` — check the heap object
@@ -106,7 +140,13 @@ void* vm_param_dispatch(VmRegionStack* rs, int id, void** args, int nargs) {
     switch (id) {
     case 700: return vm_param_make(rs, nargs >= 1 ? args[0] : NULL,
                                         nargs >= 2 ? args[1] : NULL);
-    case 701: return vm_param_ref((VmParameter*)args[0]);
+    case 701: {
+        /* Kept useful for embedders that use this standalone dispatcher;
+         * the interpreter's native dispatcher copies Value objects directly. */
+        static VmParameterValue result;
+        vm_param_ref(nargs >= 1 ? (VmParameter*)args[0] : NULL, &result);
+        return &result;
+    }
     case 702: vm_param_push(rs, (VmParameter*)args[0], args[1]); return NULL;
     case 703: vm_param_pop((VmParameter*)args[0]); return NULL;
     case 704: { static int r; r = vm_param_is_parameter(args[0]); return &r; }
@@ -141,59 +181,69 @@ int main(void) {
 
     printf("=== vm_parameter self-test ===\n\n");
 
+    /* This source is also built independently of vm_core.c, so use the
+     * layout-compatible transport type instead of the VM's Value typedef. */
+    VmParameterValue value = {.type = 1, .as.i = 100}; /* VAL_INT */
+    VmParameterValue result;
+
     /* make-parameter with default */
-    VmParameter* p = vm_param_make(&rs, (void*)(uintptr_t)100, NULL);
+    VmParameter* p = vm_param_make(&rs, &value, NULL);
     CHECK("make returns non-null", p != NULL);
     CHECK("parameter? true", vm_param_is_parameter(p));
-    CHECK("initial value is 100", (uintptr_t)vm_param_ref(p) == 100);
+    vm_param_ref(p, &result);
+    CHECK("initial value is 100", result.type == 1 && result.as.i == 100);
 
     /* Single push/pop */
-    vm_param_push(&rs, p, (void*)(uintptr_t)200);
-    CHECK("after push value is 200", (uintptr_t)vm_param_ref(p) == 200);
+    value.as.i = 200; vm_param_push(&rs, p, &value);
+    vm_param_ref(p, &result);
+    CHECK("after push value is 200", result.as.i == 200);
     vm_param_pop(p);
-    CHECK("after pop value is 100", (uintptr_t)vm_param_ref(p) == 100);
+    vm_param_ref(p, &result);
+    CHECK("after pop value is 100", result.as.i == 100);
 
     /* Nested push/pop */
-    vm_param_push(&rs, p, (void*)(uintptr_t)10);
-    CHECK("nest1: value is 10", (uintptr_t)vm_param_ref(p) == 10);
-    vm_param_push(&rs, p, (void*)(uintptr_t)20);
-    CHECK("nest2: value is 20", (uintptr_t)vm_param_ref(p) == 20);
-    vm_param_push(&rs, p, (void*)(uintptr_t)30);
-    CHECK("nest3: value is 30", (uintptr_t)vm_param_ref(p) == 30);
+    value.as.i = 10; vm_param_push(&rs, p, &value); vm_param_ref(p, &result);
+    CHECK("nest1: value is 10", result.as.i == 10);
+    value.as.i = 20; vm_param_push(&rs, p, &value); vm_param_ref(p, &result);
+    CHECK("nest2: value is 20", result.as.i == 20);
+    value.as.i = 30; vm_param_push(&rs, p, &value); vm_param_ref(p, &result);
+    CHECK("nest3: value is 30", result.as.i == 30);
     vm_param_pop(p);
-    CHECK("pop nest3: value is 20", (uintptr_t)vm_param_ref(p) == 20);
+    vm_param_ref(p, &result); CHECK("pop nest3: value is 20", result.as.i == 20);
     vm_param_pop(p);
-    CHECK("pop nest2: value is 10", (uintptr_t)vm_param_ref(p) == 10);
+    vm_param_ref(p, &result); CHECK("pop nest2: value is 10", result.as.i == 10);
     vm_param_pop(p);
-    CHECK("pop nest1: value is 100", (uintptr_t)vm_param_ref(p) == 100);
+    vm_param_ref(p, &result); CHECK("pop nest1: value is 100", result.as.i == 100);
 
     /* Multiple parameters (independent) */
-    VmParameter* q = vm_param_make(&rs, (void*)(uintptr_t)999, NULL);
-    vm_param_push(&rs, p, (void*)(uintptr_t)1);
-    vm_param_push(&rs, q, (void*)(uintptr_t)2);
-    CHECK("p is 1", (uintptr_t)vm_param_ref(p) == 1);
-    CHECK("q is 2", (uintptr_t)vm_param_ref(q) == 2);
+    value.as.i = 999; VmParameter* q = vm_param_make(&rs, &value, NULL);
+    value.as.i = 1; vm_param_push(&rs, p, &value);
+    value.as.i = 2; vm_param_push(&rs, q, &value);
+    vm_param_ref(p, &result); CHECK("p is 1", result.as.i == 1);
+    vm_param_ref(q, &result); CHECK("q is 2", result.as.i == 2);
     vm_param_pop(q);
-    CHECK("q restored to 999", (uintptr_t)vm_param_ref(q) == 999);
-    CHECK("p still 1", (uintptr_t)vm_param_ref(p) == 1);
+    vm_param_ref(q, &result); CHECK("q restored to 999", result.as.i == 999);
+    vm_param_ref(p, &result); CHECK("p still 1", result.as.i == 1);
     vm_param_pop(p);
-    CHECK("p restored to 100", (uintptr_t)vm_param_ref(p) == 100);
+    vm_param_ref(p, &result); CHECK("p restored to 100", result.as.i == 100);
 
     /* Stack growth: push > initial capacity */
-    for (int i = 0; i < 20; i++)
-        vm_param_push(&rs, p, (void*)(uintptr_t)(1000 + i));
-    CHECK("after 20 pushes, value = 1019", (uintptr_t)vm_param_ref(p) == 1019);
+    for (int i = 0; i < 20; i++) { value.as.i = 1000 + i; vm_param_push(&rs, p, &value); }
+    vm_param_ref(p, &result);
+    CHECK("after 20 pushes, value = 1019", result.as.i == 1019);
     for (int i = 19; i >= 0; i--) {
         vm_param_pop(p);
         uintptr_t expected = (i > 0) ? (uintptr_t)(1000 + i - 1) : 100;
-        if ((uintptr_t)vm_param_ref(p) != expected) {
+        vm_param_ref(p, &result);
+        if ((uintptr_t)result.as.i != expected) {
             printf("  FAIL: pop %d expected %lu got %lu\n", i, (unsigned long)expected,
-                   (unsigned long)(uintptr_t)vm_param_ref(p));
+                   (unsigned long)result.as.i);
             fail++;
             break;
         }
     }
-    CHECK("all 20 pops restored correctly", (uintptr_t)vm_param_ref(p) == 100);
+    vm_param_ref(p, &result);
+    CHECK("all 20 pops restored correctly", result.as.i == 100);
 
     /* parameter? false for non-parameter (use a valid arena-allocated object) */
     void* not_param = vm_alloc_object(&rs, VM_SUBTYPE_STRING, 16);

--- a/lib/backend/vm_run.c
+++ b/lib/backend/vm_run.c
@@ -11,6 +11,68 @@
  *        vm_*_dispatch() runtime modules, exception handling, and
  *        continuations) directly inline in this function body.
  */
+static size_t vm_continuation_allocation_size(const VM* vm) {
+    return sizeof(VmContinuation) +
+        (size_t)vm->sp * sizeof(Value) +
+        (size_t)vm->frame_count * sizeof(CallFrame) +
+        (size_t)vm->n_winds * 2 * sizeof(Value) +
+        (size_t)vm->n_parameter_bindings * 2 * sizeof(Value);
+}
+
+static void vm_capture_continuation_dynamic_state(VM* vm,
+                                                  VmContinuation* cont) {
+    char* cursor = (char*)cont->saved_frames +
+        (size_t)vm->frame_count * sizeof(CallFrame);
+    cont->n_winds = vm->n_winds;
+    cont->n_parameter_bindings = vm->n_parameter_bindings;
+    cont->saved_wind_befores = (Value*)cursor;
+    cursor += (size_t)cont->n_winds * sizeof(Value);
+    cont->saved_wind_afters = (Value*)cursor;
+    cursor += (size_t)cont->n_winds * sizeof(Value);
+    cont->saved_parameter_bindings = (Value*)cursor;
+    cursor += (size_t)cont->n_parameter_bindings * sizeof(Value);
+    cont->saved_parameter_values = (Value*)cursor;
+
+    for (int i = 0; i < cont->n_winds; i++) {
+        cont->saved_wind_befores[i] = vm->wind_stack[i].before;
+        cont->saved_wind_afters[i] = vm->wind_stack[i].after;
+    }
+    for (int i = 0; i < cont->n_parameter_bindings; i++) {
+        Value parameter_value = vm->parameter_bindings[i];
+        VmParameter* parameter = vm_parameter_from_value(vm, parameter_value);
+        cont->saved_parameter_bindings[i] = parameter_value;
+        if (parameter) vm_param_ref(parameter, &cont->saved_parameter_values[i]);
+        else cont->saved_parameter_values[i] = NIL_VAL;
+    }
+}
+
+static void vm_restore_continuation_dynamic_state(VM* vm,
+                                                  const VmContinuation* cont) {
+    /* Parameter values live outside the VM execution stack.  Rebuild their
+     * dynamic stacks from the continuation snapshot before resuming code;
+     * merely restoring a binding depth would otherwise leave captured
+     * parameterize extents pointing at the values of the abandoned path. */
+    vm_unwind_parameter_bindings(vm, 0);
+
+    for (int i = 0; i < cont->n_winds; i++) {
+        vm->wind_stack[i].before = cont->saved_wind_befores[i];
+        vm->wind_stack[i].after = cont->saved_wind_afters[i];
+    }
+    vm->n_winds = cont->n_winds;
+
+    for (int i = 0; i < cont->n_parameter_bindings; i++) {
+        Value parameter_value = cont->saved_parameter_bindings[i];
+        VmParameter* parameter = vm_parameter_from_value(vm, parameter_value);
+        if (!parameter) {
+            vm->error = 1;
+            return;
+        }
+        vm_param_push(&vm->heap.regions, parameter,
+                      &cont->saved_parameter_values[i]);
+        if (!vm_record_parameter_binding(vm, parameter_value)) return;
+    }
+}
+
 void vm_run(VM* vm) {
 #if defined(__GNUC__) || defined(__clang__)
 /* =========================================================================
@@ -331,6 +393,13 @@ void vm_run(VM* vm) {
         int argc = instr.operand;
         Value func = vm->stack[vm->sp - 1 - argc];
 
+        if (func.type == VAL_PARAMETER_OBJ) {
+            Value result = vm_parameter_invoke(vm, func, &vm->stack[vm->sp - argc], argc);
+            vm->sp -= argc + 1;
+            vm_push(vm, result);
+            DISPATCH();
+        }
+
         /* Continuation invocation: (k value) */
         if (func.type == VAL_CONTINUATION && argc >= 1) {
             Value val = vm->stack[vm->sp - 1];
@@ -339,10 +408,11 @@ void vm_run(VM* vm) {
                 while (vm->n_winds > cont->n_winds) {
                     vm->n_winds--;
                     Value after = vm->wind_stack[vm->n_winds].after;
-                    if (after.type == VAL_CLOSURE)
-                        vm_call_closure_from_native(vm, after, NULL, 0);
+                    vm_run_wind_after(vm, after);
                 }
                 if (cont->sp > STACK_SIZE || cont->frame_count > MAX_FRAMES) { vm->error = 1; goto vm_exit; }
+                vm_restore_continuation_dynamic_state(vm, cont);
+                if (vm->error) goto vm_exit;
                 memcpy(vm->stack, cont->saved_stack, cont->sp * sizeof(Value));
                 memcpy(vm->frames, cont->saved_frames, cont->frame_count * sizeof(CallFrame));
                 vm->sp = cont->sp; vm->fp = cont->fp;
@@ -375,13 +445,36 @@ void vm_run(VM* vm) {
     lbl_TAIL_CALL: {
         int argc = instr.operand;
         Value func = vm->stack[vm->sp - 1 - argc];
+        if (func.type == VAL_PARAMETER_OBJ) {
+            Value result = vm_parameter_invoke(vm, func, &vm->stack[vm->sp - argc], argc);
+            if (vm->frame_count <= 0) {
+                vm->sp = 0;
+                vm_push(vm, result);
+                vm->halted = 1;
+                goto vm_exit;
+            }
+            vm->frame_count--;
+            if (vm->frames[vm->frame_count].return_pc == -1) {
+                vm->sp = 0;
+                vm_push(vm, result);
+                vm->halted = 1;
+                goto vm_exit;
+            }
+            vm->sp = vm->fp - 1;
+            vm->fp = vm->frames[vm->frame_count].return_fp;
+            vm->pc = vm->frames[vm->frame_count].return_pc;
+            vm_push(vm, result);
+            DISPATCH();
+        }
         /* Continuation invocation in tail position */
         if (func.type == VAL_CONTINUATION && argc >= 1) {
             Value val = vm->stack[vm->sp - 1];
             VmContinuation* cont = (VmContinuation*)vm->heap.objects[func.as.ptr]->opaque.ptr;
             if (cont) {
-                while (vm->n_winds > cont->n_winds) { vm->n_winds--; Value a = vm->wind_stack[vm->n_winds].after; if (a.type == VAL_CLOSURE) vm_call_closure_from_native(vm, a, NULL, 0); }
+                while (vm->n_winds > cont->n_winds) { vm->n_winds--; vm_run_wind_after(vm, vm->wind_stack[vm->n_winds].after); }
                 if (cont->sp > STACK_SIZE || cont->frame_count > MAX_FRAMES) { vm->error = 1; goto vm_exit; }
+                vm_restore_continuation_dynamic_state(vm, cont);
+                if (vm->error) goto vm_exit;
                 memcpy(vm->stack, cont->saved_stack, cont->sp * sizeof(Value)); memcpy(vm->frames, cont->saved_frames, cont->frame_count * sizeof(CallFrame));
                 vm->sp = cont->sp; vm->fp = cont->fp; vm->frame_count = cont->frame_count; vm->n_handlers = cont->n_handlers; vm->pc = cont->pc;
                 vm_push(vm, val); DISPATCH();
@@ -609,15 +702,16 @@ void vm_run(VM* vm) {
         vm->heap.objects[cont_ptr]->type = HEAP_CONTINUATION;
         /* Store: pc, fp, sp, frame_count, n_handlers, n_winds + copy of stack + frames */
         VmContinuation* cont = (VmContinuation*)vm_alloc(&vm->heap.regions,
-            sizeof(VmContinuation) + vm->sp * sizeof(Value) + vm->frame_count * sizeof(CallFrame));
+            vm_continuation_allocation_size(vm));
         if (!cont) { vm->error = 1; goto vm_exit; }
         cont->pc = vm->pc; cont->fp = vm->fp; cont->sp = vm->sp;
         cont->frame_count = vm->frame_count;
-        cont->n_handlers = vm->n_handlers; cont->n_winds = vm->n_winds;
+        cont->n_handlers = vm->n_handlers;
         cont->saved_stack = (Value*)((char*)cont + sizeof(VmContinuation));
         cont->saved_frames = (CallFrame*)((char*)cont->saved_stack + vm->sp * sizeof(Value));
         memcpy(cont->saved_stack, vm->stack, vm->sp * sizeof(Value));
         memcpy(cont->saved_frames, vm->frames, vm->frame_count * sizeof(CallFrame));
+        vm_capture_continuation_dynamic_state(vm, cont);
         vm->heap.objects[cont_ptr]->opaque.ptr = cont;
         /* Create continuation closure: a special closure that invokes OP_INVOKE_CC */
         Value cont_val = (Value){.type = VAL_CONTINUATION, .as.ptr = cont_ptr};
@@ -643,6 +737,7 @@ void vm_run(VM* vm) {
         vm->handler_stack[vm->n_handlers].fp = vm->fp;
         vm->handler_stack[vm->n_handlers].frame_count = vm->frame_count;
         vm->handler_stack[vm->n_handlers].n_winds = vm->n_winds;
+        vm->handler_stack[vm->n_handlers].n_parameter_bindings = vm->n_parameter_bindings;
         vm->n_handlers++;
         DISPATCH();
     }
@@ -668,11 +763,12 @@ void vm_run(VM* vm) {
                 while (vm->n_winds > cont->n_winds) {
                     vm->n_winds--;
                     Value after = vm->wind_stack[vm->n_winds].after;
-                    if (after.type == VAL_CLOSURE)
-                        vm_call_closure_from_native(vm, after, NULL, 0);
+                    vm_run_wind_after(vm, after);
                 }
                 /* Restore saved state (with bounds validation) */
                 if (cont->sp > STACK_SIZE || cont->frame_count > MAX_FRAMES) { vm->error = 1; goto vm_exit; }
+                vm_restore_continuation_dynamic_state(vm, cont);
+                if (vm->error) goto vm_exit;
                 memcpy(vm->stack, cont->saved_stack, cont->sp * sizeof(Value));
                 memcpy(vm->frames, cont->saved_frames, cont->frame_count * sizeof(CallFrame));
                 vm->sp = cont->sp; vm->fp = cont->fp;
@@ -705,21 +801,21 @@ void vm_run(VM* vm) {
 
     lbl_WIND_PUSH: {
         Value after = vm_pop(vm);
-        Value before = vm_pop(vm);
         if (vm->n_winds >= 32) { fprintf(stderr, "WIND STACK OVERFLOW\n"); vm->error = 1; goto vm_exit; }
-        vm->wind_stack[vm->n_winds].before = before;
+        /* The compiler has already called before and leaves only the after
+         * thunk on the operand stack.  Keep before as metadata for future
+         * continuation re-entry support; consuming a second stack value here
+         * previously corrupted the surrounding dynamic extent. */
+        vm->wind_stack[vm->n_winds].before = NIL_VAL;
         vm->wind_stack[vm->n_winds].after = after;
         vm->n_winds++;
         DISPATCH();
     }
 
     lbl_WIND_POP: {
-        if (vm->n_winds > 0) {
-            vm->n_winds--;
-            Value after = vm->wind_stack[vm->n_winds].after;
-            if (after.type == VAL_CLOSURE)
-                vm_call_closure_from_native(vm, after, NULL, 0);
-        }
+        /* Normal-path after invocation is emitted explicitly by the
+         * compiler.  This opcode only removes the exceptional-exit guard. */
+        if (vm->n_winds > 0) vm->n_winds--;
         DISPATCH();
     }
 
@@ -914,13 +1010,23 @@ vm_exit:
             int argc = instr.operand;
             Value func = vm->stack[vm->sp - 1 - argc]; /* function is below args */
 
+            if (func.type == VAL_PARAMETER_OBJ) {
+                Value result = vm_parameter_invoke(vm, func,
+                    &vm->stack[vm->sp - argc], argc);
+                vm->sp -= argc + 1;
+                vm_push(vm, result);
+                break;
+            }
+
             /* Continuation invocation: (k value) */
             if (func.type == VAL_CONTINUATION && argc >= 1) {
                 Value val = vm->stack[vm->sp - 1];
                 VmContinuation* cont = (VmContinuation*)vm->heap.objects[func.as.ptr]->opaque.ptr;
                 if (cont) {
-                    while (vm->n_winds > cont->n_winds) { vm->n_winds--; Value a = vm->wind_stack[vm->n_winds].after; if (a.type == VAL_CLOSURE) vm_call_closure_from_native(vm, a, NULL, 0); }
+                    while (vm->n_winds > cont->n_winds) { vm->n_winds--; vm_run_wind_after(vm, vm->wind_stack[vm->n_winds].after); }
                     if (cont->sp > STACK_SIZE || cont->frame_count > MAX_FRAMES) { vm->error = 1; break; }
+                    vm_restore_continuation_dynamic_state(vm, cont);
+                    if (vm->error) break;
                     memcpy(vm->stack, cont->saved_stack, cont->sp * sizeof(Value)); memcpy(vm->frames, cont->saved_frames, cont->frame_count * sizeof(CallFrame));
                     vm->sp = cont->sp; vm->fp = cont->fp; vm->frame_count = cont->frame_count; vm->n_handlers = cont->n_handlers; vm->pc = cont->pc;
                     vm_push(vm, val);
@@ -951,6 +1057,28 @@ vm_exit:
         case OP_TAIL_CALL: {
             int argc = instr.operand;
             Value func = vm->stack[vm->sp - 1 - argc];
+            if (func.type == VAL_PARAMETER_OBJ) {
+                Value result = vm_parameter_invoke(vm, func,
+                    &vm->stack[vm->sp - argc], argc);
+                if (vm->frame_count <= 0) {
+                    vm->sp = 0;
+                    vm_push(vm, result);
+                    vm->halted = 1;
+                    break;
+                }
+                vm->frame_count--;
+                if (vm->frames[vm->frame_count].return_pc == -1) {
+                    vm->sp = 0;
+                    vm_push(vm, result);
+                    vm->halted = 1;
+                    break;
+                }
+                vm->sp = vm->fp - 1;
+                vm->fp = vm->frames[vm->frame_count].return_fp;
+                vm->pc = vm->frames[vm->frame_count].return_pc;
+                vm_push(vm, result);
+                break;
+            }
             if (func.type != VAL_CLOSURE) { vm->error = 1; break; }
             HeapObject* cl = vm->heap.objects[func.as.ptr];
 
@@ -1166,15 +1294,16 @@ vm_exit:
             if (cont_ptr < 0) { vm->error = 1; break; }
             vm->heap.objects[cont_ptr]->type = HEAP_CONTINUATION;
             VmContinuation* cont = (VmContinuation*)vm_alloc(&vm->heap.regions,
-                sizeof(VmContinuation) + vm->sp * sizeof(Value) + vm->frame_count * sizeof(CallFrame));
+                vm_continuation_allocation_size(vm));
             if (!cont) { vm->error = 1; break; }
             cont->pc = vm->pc; cont->fp = vm->fp; cont->sp = vm->sp;
             cont->frame_count = vm->frame_count;
-            cont->n_handlers = vm->n_handlers; cont->n_winds = vm->n_winds;
+            cont->n_handlers = vm->n_handlers;
             cont->saved_stack = (Value*)((char*)cont + sizeof(VmContinuation));
             cont->saved_frames = (CallFrame*)((char*)cont->saved_stack + vm->sp * sizeof(Value));
             memcpy(cont->saved_stack, vm->stack, vm->sp * sizeof(Value));
             memcpy(cont->saved_frames, vm->frames, vm->frame_count * sizeof(CallFrame));
+            vm_capture_continuation_dynamic_state(vm, cont);
             vm->heap.objects[cont_ptr]->opaque.ptr = cont;
             Value cont_val = (Value){.type = VAL_CONTINUATION, .as.ptr = cont_ptr};
             vm_push(vm, proc); vm_push(vm, cont_val);
@@ -1192,8 +1321,10 @@ vm_exit:
             if (cont_val.type == VAL_CONTINUATION) {
                 VmContinuation* cont = (VmContinuation*)vm->heap.objects[cont_val.as.ptr]->opaque.ptr;
                 if (cont) {
-                    while (vm->n_winds > cont->n_winds) { vm->n_winds--; Value a = vm->wind_stack[vm->n_winds].after; if (a.type == VAL_CLOSURE) vm_call_closure_from_native(vm, a, NULL, 0); }
+                    while (vm->n_winds > cont->n_winds) { vm->n_winds--; vm_run_wind_after(vm, vm->wind_stack[vm->n_winds].after); }
                     if (cont->sp > STACK_SIZE || cont->frame_count > MAX_FRAMES) { vm->error = 1; break; }
+                    vm_restore_continuation_dynamic_state(vm, cont);
+                    if (vm->error) break;
                     memcpy(vm->stack, cont->saved_stack, cont->sp * sizeof(Value)); memcpy(vm->frames, cont->saved_frames, cont->frame_count * sizeof(CallFrame));
                     vm->sp = cont->sp; vm->fp = cont->fp; vm->frame_count = cont->frame_count; vm->n_handlers = cont->n_handlers; vm->pc = cont->pc;
                     vm_push(vm, val);
@@ -1209,6 +1340,7 @@ vm_exit:
             vm->handler_stack[vm->n_handlers].fp = vm->fp;
             vm->handler_stack[vm->n_handlers].frame_count = vm->frame_count;
             vm->handler_stack[vm->n_handlers].n_winds = vm->n_winds;
+            vm->handler_stack[vm->n_handlers].n_parameter_bindings = vm->n_parameter_bindings;
             vm->n_handlers++;
             break;
         }
@@ -1232,12 +1364,12 @@ vm_exit:
             break;
         }
         case OP_WIND_PUSH: {
-            Value after = vm_pop(vm), before = vm_pop(vm);
-            if (vm->n_winds < 32) { vm->wind_stack[vm->n_winds].before = before; vm->wind_stack[vm->n_winds].after = after; vm->n_winds++; }
+            Value after = vm_pop(vm);
+            if (vm->n_winds < 32) { vm->wind_stack[vm->n_winds].before = NIL_VAL; vm->wind_stack[vm->n_winds].after = after; vm->n_winds++; }
             break;
         }
         case OP_WIND_POP: {
-            if (vm->n_winds > 0) { vm->n_winds--; Value after = vm->wind_stack[vm->n_winds].after; if (after.type == VAL_CLOSURE) vm_call_closure_from_native(vm, after, NULL, 0); }
+            if (vm->n_winds > 0) vm->n_winds--;
             break;
         }
         /* OP_CLOSE_UPVALUE handled at line 720 — no duplicate */

--- a/lib/core/runtime_exceptions_hosted.cpp
+++ b/lib/core/runtime_exceptions_hosted.cpp
@@ -689,6 +689,10 @@ extern "C" void eshkol_raise(eshkol_exception_t* exception) {
     g_raised_value_set_by_user = false;  // Reset for next raise
 
     if (g_exception_handler_stack && g_exception_handler_stack->jmp_buf_ptr) {
+        // A longjmp skips generated normal-exit code.  Unwind dynamic-wind
+        // first so parameterize after-thunks pop their eshkol_param_t stack
+        // entries (and ordinary dynamic-wind cleanup retains R7RS ordering).
+        eshkol_unwind_dynamic_wind(g_exception_handler_stack->wind_mark);
         // Jump to the handler
         longjmp(*(jmp_buf*)g_exception_handler_stack->jmp_buf_ptr, 1);
     } else {
@@ -730,6 +734,7 @@ extern "C" void eshkol_push_exception_handler(void* jmp_buf_ptr) {
     }
 
     handler->jmp_buf_ptr = jmp_buf_ptr;
+    handler->wind_mark = g_dynamic_wind_stack;
     handler->prev = g_exception_handler_stack;
     g_exception_handler_stack = handler;
 }

--- a/lib/core/runtime_parameters_hosted.cpp
+++ b/lib/core/runtime_parameters_hosted.cpp
@@ -45,7 +45,18 @@ typedef struct {
     eshkol_tagged_value_t* stack;
     int top;
     int capacity;
+    // The converter is Scheme code and is therefore invoked by generated
+    // code, not by this C ABI.  Keeping it alongside the dynamic stack makes
+    // the parameter object self-contained: call dispatch and parameterize
+    // can retrieve the exact converter associated with this handle.
+    eshkol_tagged_value_t converter;
 } eshkol_param_t;
+
+static eshkol_tagged_value_t eshkol_parameter_null_value() {
+    eshkol_tagged_value_t null_val{};
+    null_val.type = ESHKOL_VALUE_NULL;
+    return null_val;
+}
 
 /**
  * @brief Create an R7RS parameter object seeded with `default_val` (`make-parameter` support).
@@ -68,6 +79,8 @@ void* eshkol_make_parameter(void* arena, eshkol_tagged_value_t default_val) {
     if (!param) {
         return nullptr;
     }
+
+    param->converter = eshkol_parameter_null_value();
 
     const int initial_capacity = 8;
     param->stack = (eshkol_tagged_value_t*)std::malloc(
@@ -153,6 +166,38 @@ void eshkol_parameter_pop(void* param_ptr) {
 }
 
 /**
+ * @brief Replace the current binding of a parameter object.
+ *
+ * This is the one-argument procedure-call path, distinct from
+ * `parameterize`'s push/pop dynamic extent.  It updates the top-most slot so
+ * a write inside a parameterize body remains local to that binding.  As with
+ * construction and push, route the value through the region barrier before it
+ * reaches the long-lived malloc stack.
+ */
+void eshkol_parameter_set(void* param_ptr, eshkol_tagged_value_t val) {
+    if (!param_ptr) return;
+    eshkol_param_t* param = (eshkol_param_t*)param_ptr;
+    if (param->top < 0 || !param->stack) return;
+    eshkol_region_write_barrier_into(&param->stack[param->top],
+                                     &param->stack[param->top], &val);
+}
+
+/** Store the optional Scheme converter associated with a parameter object. */
+void eshkol_parameter_set_converter(void* param_ptr,
+                                    eshkol_tagged_value_t converter) {
+    if (!param_ptr) return;
+    eshkol_param_t* param = (eshkol_param_t*)param_ptr;
+    eshkol_region_write_barrier_into(&param->converter, &param->converter,
+                                     &converter);
+}
+
+/** Return the optional Scheme converter, or #<null> when none was supplied. */
+eshkol_tagged_value_t eshkol_parameter_converter_ref(void* param_ptr) {
+    if (!param_ptr) return eshkol_parameter_null_value();
+    return ((eshkol_param_t*)param_ptr)->converter;
+}
+
+/**
  * @brief Read the current (top-of-stack) value bound to a parameter.
  *
  * Returns a zeroed ESHKOL_VALUE_NULL tagged value if the handle is null or the
@@ -164,22 +209,12 @@ void eshkol_parameter_pop(void* param_ptr) {
  */
 eshkol_tagged_value_t eshkol_parameter_ref(void* param_ptr) {
     if (!param_ptr) {
-        eshkol_tagged_value_t null_val;
-        null_val.type = ESHKOL_VALUE_NULL;
-        null_val.flags = 0;
-        null_val.reserved = 0;
-        null_val.data.int_val = 0;
-        return null_val;
+        return eshkol_parameter_null_value();
     }
     eshkol_param_t* param = (eshkol_param_t*)param_ptr;
 
     if (param->top < 0 || !param->stack) {
-        eshkol_tagged_value_t null_val;
-        null_val.type = ESHKOL_VALUE_NULL;
-        null_val.flags = 0;
-        null_val.reserved = 0;
-        null_val.data.int_val = 0;
-        return null_val;
+        return eshkol_parameter_null_value();
     }
 
     return param->stack[param->top];
@@ -197,10 +232,30 @@ void eshkol_parameter_push_ptr(void* param, const eshkol_tagged_value_t* val) {
     eshkol_parameter_push(param, *val);
 }
 
+/** Pointer-argument wrapper around eshkol_parameter_set. */
+void eshkol_parameter_set_ptr(void* param, const eshkol_tagged_value_t* val) {
+    if (!val) return;
+    eshkol_parameter_set(param, *val);
+}
+
+/** Pointer-argument wrapper around eshkol_parameter_set_converter. */
+void eshkol_parameter_set_converter_ptr(void* param,
+                                        const eshkol_tagged_value_t* converter) {
+    if (!converter) return;
+    eshkol_parameter_set_converter(param, *converter);
+}
+
 /** @brief Pointer-argument wrapper around eshkol_parameter_ref; writes the current value through `result` (no-op if `result` is null). */
 void eshkol_parameter_ref_ptr(void* param, eshkol_tagged_value_t* result) {
     if (!result) return;
     *result = eshkol_parameter_ref(param);
+}
+
+/** Pointer-result wrapper around eshkol_parameter_converter_ref. */
+void eshkol_parameter_converter_ref_ptr(void* param,
+                                        eshkol_tagged_value_t* result) {
+    if (!result) return;
+    *result = eshkol_parameter_converter_ref(param);
 }
 
 }  // extern "C"

--- a/lib/frontend/parser.cpp
+++ b/lib/frontend/parser.cpp
@@ -7601,139 +7601,42 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
         }
 
         // ===== R7RS WAVE 3: make-parameter =====
-        // (make-parameter init) → transforms to:
-        //   (let ((__p_cell (vector init)))
-        //     (lambda __p_args
-        //       (if (null? __p_args)
-        //         (vector-ref __p_cell 0)
-        //         (begin (vector-set! __p_cell 0 (car __p_args))
-        //                (vector-ref __p_cell 0)))))
+        // Keep this as a first-class operation until native codegen.  The old
+        // lowering made a closure over a one-cell vector, which looked
+        // callable but bypassed the real eshkol_param_t dynamic stack
+        // entirely.  codegenMakeParameter now allocates that runtime object.
         if (ast.operation.op == ESHKOL_MAKE_PARAMETER_OP) {
-            // Parse the init expression
-            token = tokenizer.nextToken();
-            if (token.type == TOKEN_EOF || token.type == TOKEN_RPAREN) {
-                PARSE_ERROR_AT(token, "make-parameter requires an initial value");
+            std::vector<eshkol_ast_t> args;
+            while (true) {
+                token = tokenizer.nextToken();
+                if (token.type == TOKEN_RPAREN) break;
+                if (token.type == TOKEN_EOF) {
+                    PARSE_ERROR_AT(token, "unexpected end of input in make-parameter");
+                    ast.type = ESHKOL_INVALID;
+                    return ast;
+                }
+                tokenizer.pushBack(token);
+                eshkol_ast_t arg = parse_expression(tokenizer);
+                if (arg.type == ESHKOL_INVALID) {
+                    ast.type = ESHKOL_INVALID;
+                    return ast;
+                }
+                args.push_back(arg);
+            }
+
+            if (args.empty() || args.size() > 2) {
+                PARSE_ERROR_AT(token,
+                               "make-parameter requires an initial value and an optional converter");
                 ast.type = ESHKOL_INVALID;
                 return ast;
             }
-            // ESH-0094: pushBack + parse_expression handles quote/quasiquote/
-            // #(...) tokens that the manual LPAREN/atom dispatch dropped.
-            tokenizer.pushBack(token);
-            eshkol_ast_t init_expr = parse_expression(tokenizer);
-            // Consume closing paren
-            token = tokenizer.nextToken();
 
-            // AST helpers (reusing pattern from case-lambda)
-            auto mpMakeVar = [](const char* name) -> eshkol_ast_t {
-                eshkol_ast_t v = {};
-                v.type = ESHKOL_VAR;
-                size_t _len = strlen(name);
-                v.variable.id = new char[_len + 1];
-                memcpy(v.variable.id, name, _len + 1);
-                v.variable.data = nullptr;
-                return v;
-            };
-            auto mpMakeInt = [](int64_t val) -> eshkol_ast_t {
-                eshkol_ast_t lit = {};
-                eshkol_ast_make_int64(&lit, val);
-                return lit;
-            };
-            auto mpMakeCall1 = [&mpMakeVar](const char* func, eshkol_ast_t arg) -> eshkol_ast_t {
-                eshkol_ast_t call = {};
-                call.type = ESHKOL_OP;
-                call.operation.op = ESHKOL_CALL_OP;
-                call.operation.call_op.func = new eshkol_ast_t;
-                *call.operation.call_op.func = mpMakeVar(func);
-                call.operation.call_op.num_vars = 1;
-                call.operation.call_op.variables = new eshkol_ast_t[1];
-                call.operation.call_op.variables[0] = arg;
-                return call;
-            };
-            auto mpMakeCall2 = [&mpMakeVar](const char* func, eshkol_ast_t a, eshkol_ast_t b) -> eshkol_ast_t {
-                eshkol_ast_t call = {};
-                call.type = ESHKOL_OP;
-                call.operation.op = ESHKOL_CALL_OP;
-                call.operation.call_op.func = new eshkol_ast_t;
-                *call.operation.call_op.func = mpMakeVar(func);
-                call.operation.call_op.num_vars = 2;
-                call.operation.call_op.variables = new eshkol_ast_t[2];
-                call.operation.call_op.variables[0] = a;
-                call.operation.call_op.variables[1] = b;
-                return call;
-            };
-            auto mpMakeCall3 = [&mpMakeVar](const char* func, eshkol_ast_t a, eshkol_ast_t b, eshkol_ast_t c) -> eshkol_ast_t {
-                eshkol_ast_t call = {};
-                call.type = ESHKOL_OP;
-                call.operation.op = ESHKOL_CALL_OP;
-                call.operation.call_op.func = new eshkol_ast_t;
-                *call.operation.call_op.func = mpMakeVar(func);
-                call.operation.call_op.num_vars = 3;
-                call.operation.call_op.variables = new eshkol_ast_t[3];
-                call.operation.call_op.variables[0] = a;
-                call.operation.call_op.variables[1] = b;
-                call.operation.call_op.variables[2] = c;
-                return call;
-            };
-
-            // Build: (vector-ref __p_cell 0)
-            eshkol_ast_t vref = mpMakeCall2("vector-ref", mpMakeVar("__p_cell"), mpMakeInt(0));
-
-            // Build: (vector-set! __p_cell 0 (car __p_args))
-            eshkol_ast_t vset = mpMakeCall3("vector-set!", mpMakeVar("__p_cell"), mpMakeInt(0),
-                                            mpMakeCall1("car", mpMakeVar("__p_args")));
-
-            // Build: (begin (vector-set! ...) (vector-ref ...))
-            eshkol_ast_t set_body = {};
-            set_body.type = ESHKOL_OP;
-            set_body.operation.op = ESHKOL_SEQUENCE_OP;
-            set_body.operation.sequence_op.num_expressions = 2;
-            set_body.operation.sequence_op.expressions = new eshkol_ast_t[2];
-            set_body.operation.sequence_op.expressions[0] = vset;
-            set_body.operation.sequence_op.expressions[1] = vref;
-
-            // Build: (if (null? __p_args) (vector-ref __p_cell 0) (begin ...))
-            eshkol_ast_t if_ast = {};
-            if_ast.type = ESHKOL_OP;
-            if_ast.operation.op = ESHKOL_IF_OP;
-            if_ast.operation.call_op.func = nullptr;
-            if_ast.operation.call_op.num_vars = 3;
-            if_ast.operation.call_op.variables = new eshkol_ast_t[3];
-            if_ast.operation.call_op.variables[0] = mpMakeCall1("null?", mpMakeVar("__p_args"));
-            if_ast.operation.call_op.variables[1] = vref;
-            if_ast.operation.call_op.variables[2] = set_body;
-
-            // Build: (lambda __p_args (if ...))
-            eshkol_ast_t lambda_ast = {};
-            lambda_ast.type = ESHKOL_OP;
-            lambda_ast.operation.op = ESHKOL_LAMBDA_OP;
-            lambda_ast.operation.lambda_op.is_variadic = 1;
-            lambda_ast.operation.lambda_op.rest_param = new char[sizeof("__p_args")];
-            memcpy(lambda_ast.operation.lambda_op.rest_param, "__p_args", sizeof("__p_args"));
-            lambda_ast.operation.lambda_op.num_params = 0;
-            lambda_ast.operation.lambda_op.parameters = nullptr;
-            lambda_ast.operation.lambda_op.param_types = nullptr;
-            lambda_ast.operation.lambda_op.return_type = nullptr;
-            lambda_ast.operation.lambda_op.captured_vars = nullptr;
-            lambda_ast.operation.lambda_op.num_captured = 0;
-            lambda_ast.operation.lambda_op.body = new eshkol_ast_t;
-            *lambda_ast.operation.lambda_op.body = if_ast;
-
-            // Build: (let ((__p_cell (vector init))) (lambda ...))
-            eshkol_ast_t vector_call = mpMakeCall1("vector", init_expr);
-
-            ast.type = ESHKOL_OP;
-            ast.operation.op = ESHKOL_LET_OP;
-            ast.operation.let_op.num_bindings = 1;
-            ast.operation.let_op.bindings = new eshkol_ast_t[1];
-            ast.operation.let_op.binding_types = nullptr;
-            ast.operation.let_op.name = nullptr;
-            ast.operation.let_op.bindings[0].type = ESHKOL_CONS;
-            ast.operation.let_op.bindings[0].cons_cell.car = new eshkol_ast_t;
-            *ast.operation.let_op.bindings[0].cons_cell.car = mpMakeVar("__p_cell");
-            ast.operation.let_op.bindings[0].cons_cell.cdr = new eshkol_ast_t;
-            *ast.operation.let_op.bindings[0].cons_cell.cdr = vector_call;
-            ast.operation.let_op.body = new eshkol_ast_t;
-            *ast.operation.let_op.body = lambda_ast;
+            ast.operation.call_op.func = nullptr;
+            ast.operation.call_op.num_vars = args.size();
+            ast.operation.call_op.variables = new eshkol_ast_t[args.size()];
+            for (size_t i = 0; i < args.size(); ++i) {
+                ast.operation.call_op.variables[i] = args[i];
+            }
             return ast;
         }
 
@@ -7786,6 +7689,15 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
                 eshkol_ast_t val_expr = parse_expression(tokenizer);
                 // Consume closing paren
                 token = tokenizer.nextToken();
+                if (token.type != TOKEN_RPAREN) {
+                    PARSE_ERROR_AT(token, "parameterize binding must contain exactly a parameter and a value");
+                    ast.type = ESHKOL_INVALID;
+                    return ast;
+                }
+                if (param_expr.type == ESHKOL_INVALID || val_expr.type == ESHKOL_INVALID) {
+                    ast.type = ESHKOL_INVALID;
+                    return ast;
+                }
                 params.push_back(param_expr);
                 values.push_back(val_expr);
             }
@@ -7804,9 +7716,20 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
                 body_exprs.push_back(expr);
             }
 
+            if (body_exprs.empty()) {
+                PARSE_ERROR_AT(token, "parameterize requires at least one body expression");
+                ast.type = ESHKOL_INVALID;
+                return ast;
+            }
+
             eshkol_ast_t body = transformInternalDefinesToLetrec(body_exprs);
 
-            // AST helper
+            // Lower to an explicit dynamic-wind.  The outer lets evaluate each
+            // parameter/value expression once, then apply every converter once
+            // before the wind frame is entered.  The before thunk contains only
+            // raw pushes; therefore a converter exception cannot leave a
+            // partially-installed dynamic binding.  The after thunk pops in
+            // reverse binding order on both normal and non-local exits.
             auto pmMakeVar = [](const char* name) -> eshkol_ast_t {
                 eshkol_ast_t v = {};
                 v.type = ESHKOL_VAR;
@@ -7816,111 +7739,144 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
                 v.variable.data = nullptr;
                 return v;
             };
-
-            // Build the transformation:
-            // Outer let: save current values by calling params with 0 args
             size_t n = params.size();
 
-            // Build sequence: set new values, evaluate body, restore old values, return result
-            // (begin (param0 val0) ... (paramN valN) (let ((__result body)) (param0 __saved0) ... __result))
-            std::vector<eshkol_ast_t> outer_body;
-
-            // Set new values: (param val) for each binding
-            for (size_t i = 0; i < n; i++) {
-                eshkol_ast_t set_call = {};
-                set_call.type = ESHKOL_OP;
-                set_call.operation.op = ESHKOL_CALL_OP;
-                set_call.operation.call_op.func = new eshkol_ast_t;
-                *set_call.operation.call_op.func = params[i];
-                set_call.operation.call_op.num_vars = 1;
-                set_call.operation.call_op.variables = new eshkol_ast_t[1];
-                set_call.operation.call_op.variables[0] = values[i];
-                outer_body.push_back(set_call);
+            if (n == 0) {
+                return body;
             }
 
-            // Inner let: capture body result
-            std::string result_name = "__pz_result";
-            eshkol_ast_t inner_let = {};
-            inner_let.type = ESHKOL_OP;
-            inner_let.operation.op = ESHKOL_LET_OP;
-            inner_let.operation.let_op.num_bindings = 1;
-            inner_let.operation.let_op.bindings = new eshkol_ast_t[1];
-            inner_let.operation.let_op.binding_types = nullptr;
-            inner_let.operation.let_op.name = nullptr;
-            inner_let.operation.let_op.bindings[0].type = ESHKOL_CONS;
-            inner_let.operation.let_op.bindings[0].cons_cell.car = new eshkol_ast_t;
-            *inner_let.operation.let_op.bindings[0].cons_cell.car = pmMakeVar("__pz_result");
-            inner_let.operation.let_op.bindings[0].cons_cell.cdr = new eshkol_ast_t;
-            *inner_let.operation.let_op.bindings[0].cons_cell.cdr = body;
+            auto pmMakeCall = [&pmMakeVar](const char* name,
+                                            const std::vector<eshkol_ast_t>& args) -> eshkol_ast_t {
+                eshkol_ast_t call = {};
+                call.type = ESHKOL_OP;
+                call.operation.op = ESHKOL_CALL_OP;
+                call.operation.call_op.func = new eshkol_ast_t;
+                *call.operation.call_op.func = pmMakeVar(name);
+                call.operation.call_op.num_vars = args.size();
+                call.operation.call_op.variables = args.empty() ? nullptr : new eshkol_ast_t[args.size()];
+                for (size_t i = 0; i < args.size(); ++i) call.operation.call_op.variables[i] = args[i];
+                return call;
+            };
+            auto pmMakeSequence = [](const std::vector<eshkol_ast_t>& expressions) -> eshkol_ast_t {
+                eshkol_ast_t seq = {};
+                seq.type = ESHKOL_OP;
+                seq.operation.op = ESHKOL_SEQUENCE_OP;
+                seq.operation.sequence_op.num_expressions = expressions.size();
+                seq.operation.sequence_op.expressions = expressions.empty() ? nullptr : new eshkol_ast_t[expressions.size()];
+                for (size_t i = 0; i < expressions.size(); ++i) seq.operation.sequence_op.expressions[i] = expressions[i];
+                return seq;
+            };
+            auto pmMakeLambda = [](eshkol_ast_t lambda_body) -> eshkol_ast_t {
+                eshkol_ast_t lambda = {};
+                lambda.type = ESHKOL_OP;
+                lambda.operation.op = ESHKOL_LAMBDA_OP;
+                lambda.operation.lambda_op.is_variadic = 0;
+                lambda.operation.lambda_op.rest_param = nullptr;
+                lambda.operation.lambda_op.num_params = 0;
+                lambda.operation.lambda_op.parameters = nullptr;
+                lambda.operation.lambda_op.param_types = nullptr;
+                lambda.operation.lambda_op.return_type = nullptr;
+                lambda.operation.lambda_op.captured_vars = nullptr;
+                lambda.operation.lambda_op.num_captured = 0;
+                lambda.operation.lambda_op.body = new eshkol_ast_t;
+                *lambda.operation.lambda_op.body = lambda_body;
+                return lambda;
+            };
+            auto pmMakeLet = [&pmMakeVar](const std::vector<std::pair<std::string, eshkol_ast_t>>& bindings,
+                                           eshkol_ast_t let_body) -> eshkol_ast_t {
+                eshkol_ast_t let = {};
+                let.type = ESHKOL_OP;
+                let.operation.op = ESHKOL_LET_OP;
+                let.operation.let_op.num_bindings = bindings.size();
+                let.operation.let_op.bindings = bindings.empty() ? nullptr : new eshkol_ast_t[bindings.size()];
+                let.operation.let_op.binding_types = nullptr;
+                let.operation.let_op.name = nullptr;
+                for (size_t i = 0; i < bindings.size(); ++i) {
+                    let.operation.let_op.bindings[i].type = ESHKOL_CONS;
+                    let.operation.let_op.bindings[i].cons_cell.car = new eshkol_ast_t;
+                    *let.operation.let_op.bindings[i].cons_cell.car = pmMakeVar(bindings[i].first.c_str());
+                    let.operation.let_op.bindings[i].cons_cell.cdr = new eshkol_ast_t;
+                    *let.operation.let_op.bindings[i].cons_cell.cdr = bindings[i].second;
+                }
+                let.operation.let_op.body = new eshkol_ast_t;
+                *let.operation.let_op.body = let_body;
+                return let;
+            };
 
-            // Inner let body: restore values, then return __pz_result
-            std::vector<eshkol_ast_t> restore_exprs;
-            for (size_t i = 0; i < n; i++) {
+            std::vector<std::pair<std::string, eshkol_ast_t>> evaluated_bindings;
+            std::vector<std::pair<std::string, eshkol_ast_t>> converted_bindings;
+            std::vector<eshkol_ast_t> push_expressions;
+            std::vector<eshkol_ast_t> pop_expressions;
+            std::vector<const char*> port_parameter_names(n, nullptr);
+
+            // current-{input,output,error}-port predate general parameter
+            // objects: their values are backed by dedicated hosted FILE*
+            // cells consulted directly by I/O codegen. Preserve that runtime
+            // contract as a compatibility binding while ordinary parameters
+            // below use the real eshkol_param_t stack.  This also keeps port
+            // rebinding unwind-safe through the same generated dynamic-wind.
+            auto pmRuntimePortParameterName = [](const eshkol_ast_t& parameter)
+                -> const char* {
+                if (parameter.type != ESHKOL_VAR || !parameter.variable.id) return nullptr;
+                const char* name = parameter.variable.id;
+                if (strcmp(name, "current-input-port") == 0 ||
+                    strcmp(name, "current-output-port") == 0 ||
+                    strcmp(name, "current-error-port") == 0) {
+                    return name;
+                }
+                return nullptr;
+            };
+
+            for (size_t i = 0; i < n; ++i) {
+                std::string param_name = "__pz_param_" + std::to_string(i);
+                std::string raw_name = "__pz_raw_" + std::to_string(i);
+                std::string value_name = "__pz_value_" + std::to_string(i);
                 std::string saved_name = "__pz_saved_" + std::to_string(i);
-                eshkol_ast_t restore_call = {};
-                restore_call.type = ESHKOL_OP;
-                restore_call.operation.op = ESHKOL_CALL_OP;
-                restore_call.operation.call_op.func = new eshkol_ast_t;
-                *restore_call.operation.call_op.func = params[i];
-                restore_call.operation.call_op.num_vars = 1;
-                restore_call.operation.call_op.variables = new eshkol_ast_t[1];
-                restore_call.operation.call_op.variables[0] = pmMakeVar(saved_name.c_str());
-                restore_exprs.push_back(restore_call);
+
+                port_parameter_names[i] = pmRuntimePortParameterName(params[i]);
+                if (port_parameter_names[i]) {
+                    // Preserve normal evaluation order: evaluate the new
+                    // value before snapshotting the cell that will be
+                    // restored after this dynamic extent.
+                    evaluated_bindings.push_back({raw_name, values[i]});
+                    evaluated_bindings.push_back({saved_name,
+                        pmMakeCall(port_parameter_names[i], {})});
+                    push_expressions.push_back(
+                        pmMakeCall(port_parameter_names[i], {pmMakeVar(raw_name.c_str())}));
+                    continue;
+                }
+
+                evaluated_bindings.push_back({param_name, params[i]});
+                evaluated_bindings.push_back({raw_name, values[i]});
+                converted_bindings.push_back({value_name,
+                    pmMakeCall("__eshkol_parameter_convert",
+                               {pmMakeVar(param_name.c_str()), pmMakeVar(raw_name.c_str())})});
+                push_expressions.push_back(
+                    pmMakeCall("__eshkol_parameter_push",
+                               {pmMakeVar(param_name.c_str()), pmMakeVar(value_name.c_str())}));
             }
-            restore_exprs.push_back(pmMakeVar("__pz_result"));
-
-            // Wrap restore sequence in a begin
-            eshkol_ast_t restore_seq = {};
-            restore_seq.type = ESHKOL_OP;
-            restore_seq.operation.op = ESHKOL_SEQUENCE_OP;
-            restore_seq.operation.sequence_op.num_expressions = restore_exprs.size();
-            restore_seq.operation.sequence_op.expressions = new eshkol_ast_t[restore_exprs.size()];
-            for (size_t i = 0; i < restore_exprs.size(); i++) {
-                restore_seq.operation.sequence_op.expressions[i] = restore_exprs[i];
-            }
-
-            inner_let.operation.let_op.body = new eshkol_ast_t;
-            *inner_let.operation.let_op.body = restore_seq;
-            outer_body.push_back(inner_let);
-
-            // Wrap set+inner_let in a begin for the outer let body
-            eshkol_ast_t outer_seq = {};
-            outer_seq.type = ESHKOL_OP;
-            outer_seq.operation.op = ESHKOL_SEQUENCE_OP;
-            outer_seq.operation.sequence_op.num_expressions = outer_body.size();
-            outer_seq.operation.sequence_op.expressions = new eshkol_ast_t[outer_body.size()];
-            for (size_t i = 0; i < outer_body.size(); i++) {
-                outer_seq.operation.sequence_op.expressions[i] = outer_body[i];
+            for (size_t i = n; i-- > 0;) {
+                if (port_parameter_names[i]) {
+                    pop_expressions.push_back(
+                        pmMakeCall(port_parameter_names[i],
+                                   {pmMakeVar(("__pz_saved_" + std::to_string(i)).c_str())}));
+                    continue;
+                }
+                pop_expressions.push_back(
+                    pmMakeCall("__eshkol_parameter_pop", {pmMakeVar(("__pz_param_" + std::to_string(i)).c_str())}));
             }
 
-            // Outer let: save current values
-            ast.type = ESHKOL_OP;
-            ast.operation.op = ESHKOL_LET_OP;
-            ast.operation.let_op.num_bindings = n;
-            ast.operation.let_op.bindings = new eshkol_ast_t[n];
-            ast.operation.let_op.binding_types = nullptr;
-            ast.operation.let_op.name = nullptr;
+            eshkol_ast_t wind = {};
+            wind.type = ESHKOL_OP;
+            wind.operation.op = ESHKOL_DYNAMIC_WIND_OP;
+            wind.operation.dynamic_wind_op.before = new eshkol_ast_t;
+            *wind.operation.dynamic_wind_op.before = pmMakeLambda(pmMakeSequence(push_expressions));
+            wind.operation.dynamic_wind_op.thunk = new eshkol_ast_t;
+            *wind.operation.dynamic_wind_op.thunk = pmMakeLambda(body);
+            wind.operation.dynamic_wind_op.after = new eshkol_ast_t;
+            *wind.operation.dynamic_wind_op.after = pmMakeLambda(pmMakeSequence(pop_expressions));
 
-            for (size_t i = 0; i < n; i++) {
-                std::string saved_name = "__pz_saved_" + std::to_string(i);
-                // Save: __pz_saved_i = (param_i)  ; call with 0 args
-                eshkol_ast_t save_call = {};
-                save_call.type = ESHKOL_OP;
-                save_call.operation.op = ESHKOL_CALL_OP;
-                save_call.operation.call_op.func = new eshkol_ast_t;
-                *save_call.operation.call_op.func = params[i];
-                save_call.operation.call_op.num_vars = 0;
-                save_call.operation.call_op.variables = nullptr;
-
-                ast.operation.let_op.bindings[i].type = ESHKOL_CONS;
-                ast.operation.let_op.bindings[i].cons_cell.car = new eshkol_ast_t;
-                *ast.operation.let_op.bindings[i].cons_cell.car = pmMakeVar(saved_name.c_str());
-                ast.operation.let_op.bindings[i].cons_cell.cdr = new eshkol_ast_t;
-                *ast.operation.let_op.bindings[i].cons_cell.cdr = save_call;
-            }
-
-            ast.operation.let_op.body = new eshkol_ast_t;
-            *ast.operation.let_op.body = outer_seq;
+            ast = pmMakeLet(evaluated_bindings, pmMakeLet(converted_bindings, wind));
             return ast;
         }
 

--- a/lib/types/type_checker.cpp
+++ b/lib/types/type_checker.cpp
@@ -3328,6 +3328,13 @@ TypeCheckResult TypeChecker::checkLinearVariable(const std::string& name) {
         if (type) {
             return TypeCheckResult::ok(*type);
         }
+        // The default-port parameters are runtime-provided procedures rather
+        // than lexical definitions.  Treat their bare references as values so
+        // parser lowering can preserve `parameterize` compatibility bindings.
+        if (name == "current-input-port" || name == "current-output-port" ||
+            name == "current-error-port") {
+            return TypeCheckResult::ok(BuiltinTypes::Value);
+        }
         return TypeCheckResult::error("Undefined variable: " + name);
     }
 

--- a/site/static/eshkol-runtime.js
+++ b/site/static/eshkol-runtime.js
@@ -338,6 +338,14 @@ class EshkolRuntime {
                 eshkol_qrng_uint64: () => BigInt(Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)),
                 eshkol_qrng_range: (min, max) => BigInt(Math.floor(Math.random() * Number(max - min)) + Number(min)),
                 eshkol_init_global_arena: () => {},
+                // R7RS parameter-object runtime (make-parameter / parameterize):
+                // opaque no-ops in the browser lite runtime (no arena), matching
+                // the other hosted-runtime imports. Full fidelity on native + VM.
+                eshkol_make_parameter_ptr: () => 0,
+                eshkol_parameter_set_ptr: () => {},
+                eshkol_parameter_set_converter_ptr: () => {},
+                eshkol_parameter_ref_ptr: () => {},
+                eshkol_parameter_converter_ref_ptr: () => {},
                 eshkol_init_stack_size: () => {},
                 eshkol_check_recursion_depth: () => 0,  // returns i32 (size_t)
                 eshkol_decrement_recursion_depth: () => {},

--- a/tests/core/parameter_region_barrier_test.cpp
+++ b/tests/core/parameter_region_barrier_test.cpp
@@ -13,24 +13,11 @@
 // ESHKOL_ARENA_POISON, 0xCB-poisoned) memory -- a use-after-free the next
 // time the parameter was read.
 //
-// NOTE on reachability from Eshkol source: `(make-parameter x)` is rewritten
-// by the parser (lib/frontend/parser.cpp, ESHKOL_MAKE_PARAMETER_OP) into a
-// closure over a vector cell -- normal source-level make-parameter/
-// parameterize therefore never touches this runtime object at all,
-// vector-set!/vector-ref already carry their own (already-correct) region
-// write barrier coverage. The `eshkol_param_t` heap object is only ever
-// constructed via `(eval '(make-parameter ...))` (JIT-only; see
-// tests/v1_2_edge_cases/parameter_prng_collision_jit_test.esk), and even then
-// there is no call-dispatch anywhere in codegen that recognizes
-// HEAP_SUBTYPE_PARAMETER as callable, so `eshkol_parameter_push/pop/ref` are
-// currently unreachable from any Eshkol program, source-level or eval'd. They
-// are nonetheless real, exported extern "C" runtime entry points (the
-// intended backing store for make-parameter/parameterize once/if that
-// call-dispatch is wired up, and reachable today via direct C API / FFI use),
-// so this test exercises them directly against the real region/arena
-// lifecycle -- exactly as tests/core/runtime_regions_test.cpp already does
-// for the sibling region-evacuation classes of bug (ESH-0214c/d, the
-// bignum-rational EVAC_LEAF UAF).
+// Source-level `(make-parameter x)` now constructs this object and
+// `parameterize` pushes/pops its dynamic stack through this same C ABI. This
+// direct test remains intentional: the regression is in the C storage layer,
+// where a value copied out of an active region must remain valid after that
+// region closes, independent of parser and closure-call lowering.
 
 #include "../../lib/core/arena_memory.h"
 

--- a/tests/features/parameter_prng_subtype_test.esk
+++ b/tests/features/parameter_prng_subtype_test.esk
@@ -8,13 +8,10 @@
 ;; eshkol_make_parameter was misidentified by (prng? ...) as a PRNG.
 ;; HEAP_SUBTYPE_PARAMETER now has its own canonical id (24).
 ;;
-;; Note on representations: source-level (make-parameter x) is rewritten by
-;; the parser into a closure over a vector cell, so in compiled programs the
-;; parameter value is CALLABLE, not a HEAP_SUBTYPE_PARAMETER object. The
-;; heap-object path (eshkol_make_parameter, reachable via eval/FFI) is
-;; covered by tests/v1_2_edge_cases/parameter_prng_collision_jit_test.esk,
-;; which is JIT-only because eval is unavailable in AOT binaries. This file
-;; checks the cross-discrimination that must hold in BOTH JIT and AOT.
+;; Source-level (make-parameter x) is a HEAP_SUBTYPE_PARAMETER object backed
+;; by the runtime dynamic stack. The JIT eval path is covered separately by
+;; tests/v1_2_edge_cases/parameter_prng_collision_jit_test.esk; this file
+;; checks the cross-discrimination that must hold in both AOT and JIT.
 
 (require stdlib)
 

--- a/tests/features/parameterize_dynamic_test.esk
+++ b/tests/features/parameterize_dynamic_test.esk
@@ -1,0 +1,91 @@
+;; R7RS parameter objects must use the hosted eshkol_param_t dynamic stack.
+;; Covers converter-once behavior, nesting, restoration after normal and
+;; exceptional exits, plus composition with dynamic-wind.
+
+(require stdlib)
+
+(define passed 0)
+(define failed 0)
+(define (check name value)
+  (if value
+      (begin (set! passed (+ passed 1))
+             (display "PASS: ") (display name) (newline))
+      (begin (set! failed (+ failed 1))
+             (display "FAIL: ") (display name) (newline))))
+
+(define converter-calls 0)
+(define (tens x)
+  (begin
+    (set! converter-calls (+ converter-calls 1))
+    (* x 10)))
+
+(define current-test-value (make-parameter 1 tens))
+
+(check "parameter? recognizes source-level parameter" (parameter? current-test-value))
+(check "converter applies once to initial value" (= converter-calls 1))
+(check "initial value is converted" (= (current-test-value) 10))
+
+(parameterize ((current-test-value 2))
+  (check "parameterize applies converter once" (= converter-calls 2))
+  (check "parameterize reads converted value" (= (current-test-value) 20)))
+(check "normal parameterize restores converted default" (= (current-test-value) 10))
+
+(parameterize ((current-test-value 3))
+  (check "outer dynamic binding" (= (current-test-value) 30))
+  (parameterize ((current-test-value 4))
+    (check "inner dynamic binding" (= (current-test-value) 40)))
+  (check "nested parameterize restores outer binding" (= (current-test-value) 30)))
+(check "nested parameterize restores default" (= (current-test-value) 10))
+(check "each nested binding converts once" (= converter-calls 4))
+
+(define value-seen-by-handler
+  (guard (e (#t (current-test-value)))
+    (parameterize ((current-test-value 5))
+      (raise 'parameterize-test-exception))))
+(check "handler sees restored parameter after exception unwind" (= value-seen-by-handler 10))
+(check "exceptional parameterize restores default" (= (current-test-value) 10))
+(check "exceptional binding converts once" (= converter-calls 5))
+
+(define wind-order "")
+(dynamic-wind
+  (lambda () (set! wind-order (string-append wind-order "B")))
+  (lambda ()
+    (parameterize ((current-test-value 6))
+      (set! wind-order
+            (string-append wind-order (if (= (current-test-value) 60) "I" "X"))))
+    (set! wind-order
+          (string-append wind-order (if (= (current-test-value) 10) "R" "X"))))
+  (lambda () (set! wind-order (string-append wind-order "A"))))
+(check "dynamic-wind observes parameter binding then restoration" (string=? wind-order "BIRA"))
+(check "dynamic-wind parameterize converts once" (= converter-calls 6))
+
+;; Preserve the existing one-argument parameter procedure behavior while
+;; ensuring it writes the current eshkol_param_t stack slot, not a vector cell.
+(current-test-value 7)
+(check "one-argument parameter call stores converted value" (= (current-test-value) 70))
+(check "one-argument parameter call converts once" (= converter-calls 7))
+
+;; Multiple bindings must convert each value once before either dynamic stack
+;; is pushed, then unwind in reverse order without disturbing the setter
+;; value above.
+(define secondary-calls 0)
+(define (plus-one-hundred x)
+  (begin
+    (set! secondary-calls (+ secondary-calls 1))
+    (+ x 100)))
+(define secondary-test-value (make-parameter 1 plus-one-hundred))
+(check "second parameter converter applies once to initial value" (= secondary-calls 1))
+(parameterize ((current-test-value 8) (secondary-test-value 4))
+  (check "multiple parameterize binds first parameter" (= (current-test-value) 80))
+  (check "multiple parameterize binds second parameter" (= (secondary-test-value) 104))
+  (check "multiple parameterize applies each converter once"
+         (and (= converter-calls 8) (= secondary-calls 2))))
+(check "multiple parameterize restores first parameter" (= (current-test-value) 70))
+(check "multiple parameterize restores second parameter" (= (secondary-test-value) 101))
+
+(display "---") (newline)
+(display "Total: ") (display (+ passed failed))
+(display ", PASS: ") (display passed)
+(display ", FAIL: ") (display failed)
+(newline)
+(if (> failed 0) (exit 1))

--- a/tests/v1_2_edge_cases/parameter_prng_collision_jit_test.esk
+++ b/tests/v1_2_edge_cases/parameter_prng_collision_jit_test.esk
@@ -5,9 +5,9 @@
 ;; allocated by eshkol_make_parameter therefore satisfied (prng? ...) and
 ;; displayed via the raw-subtype fallback. HEAP_SUBTYPE_PARAMETER is now 24.
 ;;
-;; The heap-object path is only reachable when a `make-parameter` CALL_OP
-;; bypasses the parser's closure rewrite — e.g. through (eval ...) — so this
-;; test is JIT-only (eval is unavailable in AOT binaries).
+;; eval constructs the same heap-backed parameter object as source-level
+;; make-parameter. This remains JIT-only because eval is unavailable in AOT
+;; binaries.
 
 (require stdlib)
 
@@ -22,8 +22,7 @@
       (begin (set! fail-count (+ fail-count 1))
              (display "FAIL: ") (display name) (newline))))
 
-;; Heap parameter object via the runtime allocator (eval bypasses the
-;; parser's make-parameter -> closure rewrite).
+;; Heap parameter object via the runtime allocator.
 (define heap-param (eval '(make-parameter 5)))
 (define my-prng (make-prng 42))
 

--- a/web/eshkol-repl.js
+++ b/web/eshkol-repl.js
@@ -285,6 +285,17 @@ class EshkolRepl {
                 eshkol_init_global_arena: () => {},
                 eshkol_tagged_cons_set_tagged_value: () => {},
 
+                // R7RS parameter-object runtime (make-parameter / parameterize).
+                // The hosted store operates on native arena memory; the browser
+                // lite runtime has no arena (eshkol_current_arena stubs to 0), so
+                // these are opaque no-ops like the other hosted-runtime imports.
+                // Full parameter fidelity is on the native and VM execution paths.
+                eshkol_make_parameter_ptr: () => 0,
+                eshkol_parameter_set_ptr: () => {},
+                eshkol_parameter_set_converter_ptr: () => {},
+                eshkol_parameter_ref_ptr: () => {},
+                eshkol_parameter_converter_ref_ptr: () => {},
+
                 // Named-let TCO loop per-iteration arena scope reclamation
                 // (ESH-0214b / fix/loop-arena-reclamation) -- the browser
                 // build never rewinds the arena (arena_allocate above is a


### PR DESCRIPTION
Wires `(make-parameter [converter])` and `(parameterize ...)` to the real R7RS parameter-object backing store — replacing the vector-cell closure shim with the proper dynamic-binding implementation, on both the native and VM paths.

## Before
The parser desugared `make-parameter` into a plain vector-cell closure; `parameterize` read/set/restored that cell. The real backing store (`eshkol_param_t` in `runtime_parameters_hosted.cpp`, arena-allocated, region-write-barrier-correct since #267) had zero Scheme callers, and the VM carried its own incomplete parameter implementation.

## After
- **Native**: parameter objects are real `eshkol_param_t` values holding default/current dynamic values and converters. Reading calls into the dynamic stack; `parameterize` applies the converter once per binding, pushes before the body, and pops LIFO via `dynamic-wind`.
- **Unwind safety**: `eshkol_raise` now unwinds dynamic-wind frames before `longjmp`, so parameter stacks (and any other wind frames) restore correctly on guarded exceptions — a general exception-correctness improvement.
- **VM**: wired independently for parity — native IDs 700–705, callable parameter dispatch, exception/dynamic-wind cleanup, and captured-continuation dynamic-state restoration.
- Current-port compatibility bindings preserved.

## Verification (independent, fresh build)
- New `tests/features/parameterize_dynamic_test.esk`: **24/24** (converter-once, nesting, normal/exception restoration, dynamic-wind ordering, setter behavior, multi-binding LIFO).
- R7RS wave3 comprehensive 27/27; parameter/PRNG subtype 17/17; JIT collision 6/6; first-class I/O parameterize 17/17; unicode capture 22/22; C-ABI `parameter_region_barrier_test` 1/1; VM standalone suite 53/53.
- memory suite **15/15**; features **33/33**; autodiff **54/54** (exception-path change regresses nothing).
- Generative differential engine (VM changed): **0 divergences, 0 new vs baseline** — VM/native parity holds.
