### PR TITLE
feat(pqc): ML-KEM (FIPS 203) post-quantum KEM builtins over Moonlab, QRNG-seeded (S4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3282,6 +3282,15 @@ if(ESHKOL_BUILD_AGENT_FFI)
             list(APPEND AGENT_FFI_SOURCES ${AGENT_FFI_DIR}/agent_quantum.c)
         endif()
 
+        # Moonlab ML-KEM (Stage S4) follows the same opt-in contract as the
+        # state-vector/VQE bridge above.  Compile the shim unconditionally so
+        # its honest "not enabled" stubs remain available in default builds;
+        # ESHKOL_HAVE_MOONLAB selects the real FIPS 203 implementation only
+        # when ESHKOL_QUANTUM_ENABLED fetched and linked quantumsim.
+        if(EXISTS "${AGENT_FFI_DIR}/agent_pqc.c")
+            list(APPEND AGENT_FFI_SOURCES ${AGENT_FFI_DIR}/agent_pqc.c)
+        endif()
+
         add_library(eshkol-agent-ffi STATIC ${AGENT_FFI_SOURCES})
 
         target_include_directories(eshkol-agent-ffi PRIVATE

--- a/lib/agent/c/agent_pqc.c
+++ b/lib/agent/c/agent_pqc.c
@@ -1,0 +1,379 @@
+/*******************************************************************************
+ * Moonlab ML-KEM Bindings for Eshkol (Stage S4)
+ *
+ * A narrow FIPS 203 bridge over Moonlab's ML-KEM-512, ML-KEM-768, and
+ * ML-KEM-1024 APIs.  Scheme owns every key, ciphertext, and shared-secret as
+ * an Eshkol bytevector; this shim only receives the bytevector payloads after
+ * validating their heap subtype and exact parameter-set length.
+ *
+ * The real implementation is compiled only with ESHKOL_HAVE_MOONLAB, which
+ * CMake defines when -DESHKOL_QUANTUM_ENABLED=ON successfully provides
+ * Moonlab's quantumsim target.  The unconditional stub branch deliberately
+ * keeps default builds linkable and reports an honest unavailable error.
+ ******************************************************************************/
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "../../../inc/eshkol/eshkol.h"
+
+static char g_mlkem_last_error[256] = {0};
+
+static void mlkem_set_last_error(const char* message) {
+    if (!message) {
+        g_mlkem_last_error[0] = '\0';
+        return;
+    }
+    size_t length = strlen(message);
+    if (length >= sizeof(g_mlkem_last_error)) {
+        length = sizeof(g_mlkem_last_error) - 1;
+    }
+    memcpy(g_mlkem_last_error, message, length);
+    g_mlkem_last_error[length] = '\0';
+}
+
+int32_t eshkol_mlkem_last_error(char* buffer, int64_t buffer_size) {
+    if (!buffer || buffer_size <= 0) return 0;
+    size_t capacity = (size_t)buffer_size;
+    size_t length = strlen(g_mlkem_last_error);
+    if (length >= capacity) length = capacity - 1;
+    memcpy(buffer, g_mlkem_last_error, length);
+    buffer[length] = '\0';
+    return (int32_t)length;
+}
+
+#ifdef ESHKOL_HAVE_MOONLAB
+
+#include "crypto/mlkem/mlkem.h"
+#include "crypto/sha3/sha3.h"
+#include "crypto/drbg/ctr_drbg.h"
+
+#define ESHKOL_MLKEM_SHARED_SECRET_BYTES 32u
+
+typedef struct {
+    size_t public_key_bytes;
+    size_t secret_key_bytes;
+    size_t ciphertext_bytes;
+} eshkol_mlkem_sizes_t;
+
+static int mlkem_sizes_for_level(int32_t level, eshkol_mlkem_sizes_t* sizes) {
+    if (!sizes) {
+        mlkem_set_last_error("ML-KEM internal error: missing size output");
+        return -1;
+    }
+    switch (level) {
+        case 512:
+            sizes->public_key_bytes = MLKEM512_PUBLICKEYBYTES;
+            sizes->secret_key_bytes = MLKEM512_SECRETKEYBYTES;
+            sizes->ciphertext_bytes = MLKEM512_CIPHERTEXTBYTES;
+            return 0;
+        case 768:
+            sizes->public_key_bytes = MLKEM768_PUBLICKEYBYTES;
+            sizes->secret_key_bytes = MLKEM768_SECRETKEYBYTES;
+            sizes->ciphertext_bytes = MLKEM768_CIPHERTEXTBYTES;
+            return 0;
+        case 1024:
+            sizes->public_key_bytes = MLKEM1024_PUBLICKEYBYTES;
+            sizes->secret_key_bytes = MLKEM1024_SECRETKEYBYTES;
+            sizes->ciphertext_bytes = MLKEM1024_CIPHERTEXTBYTES;
+            return 0;
+        default:
+            mlkem_set_last_error("ML-KEM level must be 512, 768, or 1024");
+            return -1;
+    }
+}
+
+/* An extern `ptr` receives the Eshkol heap payload, whose first eight bytes
+ * are the bytevector length and whose bytes begin at +8.  High-level Scheme
+ * wrappers check bytevector? before the FFI call; repeat the exact subtype and
+ * length checks here so accidental ABI misuse cannot reach Moonlab. */
+static int checked_bytevector(void* raw, size_t expected_length,
+                              const char* role, uint8_t** bytes_out) {
+    if (!raw || ESHKOL_GET_SUBTYPE(raw) != HEAP_SUBTYPE_BYTEVECTOR) {
+        char message[160];
+        snprintf(message, sizeof(message),
+                 "ML-KEM %s must be an Eshkol bytevector", role);
+        mlkem_set_last_error(message);
+        return -1;
+    }
+
+    int64_t actual_length = -1;
+    memcpy(&actual_length, raw, sizeof(actual_length));
+    if (actual_length < 0 || (uint64_t)actual_length != (uint64_t)expected_length) {
+        char message[192];
+        snprintf(message, sizeof(message),
+                 "ML-KEM %s must be exactly %zu bytes", role, expected_length);
+        mlkem_set_last_error(message);
+        return -1;
+    }
+
+    *bytes_out = (uint8_t*)raw + sizeof(int64_t);
+    return 0;
+}
+
+static int checked_const_bytevector(const void* raw, size_t expected_length,
+                                    const char* role, const uint8_t** bytes_out) {
+    uint8_t* bytes = NULL;
+    if (checked_bytevector((void*)raw, expected_length, role, &bytes) != 0) {
+        return -1;
+    }
+    *bytes_out = bytes;
+    return 0;
+}
+
+int32_t eshkol_mlkem_keygen(int32_t level, void* public_key, void* secret_key) {
+    eshkol_mlkem_sizes_t sizes;
+    uint8_t* ek = NULL;
+    uint8_t* dk = NULL;
+    if (mlkem_sizes_for_level(level, &sizes) != 0 ||
+        checked_bytevector(public_key, sizes.public_key_bytes, "public key", &ek) != 0 ||
+        checked_bytevector(secret_key, sizes.secret_key_bytes, "secret key", &dk) != 0) {
+        return -1;
+    }
+
+    int rc = -1;
+    switch (level) {
+        case 512:  rc = moonlab_mlkem512_keygen_qrng(ek, dk); break;
+        case 768:  rc = moonlab_mlkem768_keygen_qrng(ek, dk); break;
+        case 1024: rc = moonlab_mlkem1024_keygen_qrng(ek, dk); break;
+        default: return -1; /* Already rejected by mlkem_sizes_for_level. */
+    }
+    if (rc != 0) {
+        mlkem_set_last_error("Moonlab ML-KEM key generation failed: quantum RNG unavailable");
+        return -1;
+    }
+    mlkem_set_last_error(NULL);
+    return 0;
+}
+
+int32_t eshkol_mlkem_encaps(int32_t level, void* ciphertext,
+                            void* shared_secret, const void* public_key) {
+    eshkol_mlkem_sizes_t sizes;
+    uint8_t* c = NULL;
+    uint8_t* K = NULL;
+    const uint8_t* ek = NULL;
+    if (mlkem_sizes_for_level(level, &sizes) != 0 ||
+        checked_bytevector(ciphertext, sizes.ciphertext_bytes, "ciphertext", &c) != 0 ||
+        checked_bytevector(shared_secret, ESHKOL_MLKEM_SHARED_SECRET_BYTES,
+                           "shared secret", &K) != 0 ||
+        checked_const_bytevector(public_key, sizes.public_key_bytes, "public key", &ek) != 0) {
+        return -1;
+    }
+
+    int rc = -1;
+    switch (level) {
+        case 512:  rc = moonlab_mlkem512_encaps_qrng(c, K, ek); break;
+        case 768:  rc = moonlab_mlkem768_encaps_qrng(c, K, ek); break;
+        case 1024: rc = moonlab_mlkem1024_encaps_qrng(c, K, ek); break;
+        default: return -1;
+    }
+    if (rc != 0) {
+        mlkem_set_last_error("Moonlab ML-KEM encapsulation failed: quantum RNG unavailable");
+        return -1;
+    }
+    mlkem_set_last_error(NULL);
+    return 0;
+}
+
+int32_t eshkol_mlkem_decaps(int32_t level, void* shared_secret,
+                            const void* ciphertext, const void* secret_key) {
+    eshkol_mlkem_sizes_t sizes;
+    uint8_t* K = NULL;
+    const uint8_t* c = NULL;
+    const uint8_t* dk = NULL;
+    if (mlkem_sizes_for_level(level, &sizes) != 0 ||
+        checked_bytevector(shared_secret, ESHKOL_MLKEM_SHARED_SECRET_BYTES,
+                           "shared secret", &K) != 0 ||
+        checked_const_bytevector(ciphertext, sizes.ciphertext_bytes, "ciphertext", &c) != 0 ||
+        checked_const_bytevector(secret_key, sizes.secret_key_bytes, "secret key", &dk) != 0) {
+        return -1;
+    }
+
+    /* FIPS 203 decapsulation has implicit rejection: malformed but correctly
+     * sized ciphertexts produce a pseudorandom 32-byte secret, not an error. */
+    switch (level) {
+        case 512:  moonlab_mlkem512_decaps(K, c, dk); break;
+        case 768:  moonlab_mlkem768_decaps(K, c, dk); break;
+        case 1024: moonlab_mlkem1024_decaps(K, c, dk); break;
+        default: return -1;
+    }
+    mlkem_set_last_error(NULL);
+    return 0;
+}
+
+/* Moonlab ships a NIST-seeded deterministic KAT harness, but not the raw .rsp
+ * artifacts.  Reproduce its count=0 SP 800-90A seed flow here so the Eshkol
+ * integration tests verify the bridge against the same fixed FIPS 203 output
+ * fingerprints while production APIs remain QRNG-only. */
+typedef struct {
+    const char* public_key_hash;
+    const char* secret_key_hash;
+    const char* ciphertext_hash;
+    const char* shared_secret_hash;
+} mlkem_kat_hashes_t;
+
+static int hex_nibble(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+static int sha3_256_matches_hex(const uint8_t* bytes, size_t length,
+                                 const char* expected_hex) {
+    uint8_t digest[32];
+    sha3_256(bytes, length, digest);
+    for (size_t i = 0; i < sizeof(digest); ++i) {
+        int high = hex_nibble(expected_hex[2 * i]);
+        int low = hex_nibble(expected_hex[2 * i + 1]);
+        if (high < 0 || low < 0 || digest[i] != (uint8_t)((high << 4) | low)) {
+            return 0;
+        }
+    }
+    return expected_hex[64] == '\0';
+}
+
+static void secure_clear(void* ptr, size_t length) {
+    volatile uint8_t* bytes = (volatile uint8_t*)ptr;
+    while (length-- > 0) *bytes++ = 0;
+}
+
+int32_t eshkol_mlkem_nist_kat(int32_t level) {
+    static const char seed_hex[] =
+        "061550234D158C5EC95595FE04EF7A25767F2E24CC2BC479D09D86DC9ABCFDE7"
+        "056A8C266F9EF97ED08541DBD2E1FFA1";
+    static const mlkem_kat_hashes_t kat512 = {
+        "50c8dd152a4531aab560d2fc7ca9a40ad8af25ad1dd08c6d79afe4dd4d1eee5a",
+        "2e08d2c82a07f5f67878b54e06848c924ee7a0929cb6440d06fffd9622687b48",
+        "ed14369380d501d2bb28861a26ad092b1bbd6764c083244551c436ccf98dd9f8",
+        "ea6dfd89a819935fa7b9072a0cd4b495e751e5620d2cb173fc62843255a959d8"
+    };
+    static const mlkem_kat_hashes_t kat768 = {
+        "f57262661358cde8d3ebf990e5fd1d5b896c992ccfaadb5256b68bbf5943b132",
+        "7deef44965b03d76de543ad6ef9e74a2772fa5a9fa0e761120dac767cf0152ef",
+        "6e777e2cf8054659136a971d9e70252f301226930c19c470ee0688163a63c15b",
+        "732325d1305c70fd98df41716b42041eee95feba84bbc59a68175aee00f03b1e"
+    };
+    static const mlkem_kat_hashes_t kat1024 = {
+        "ebbe41cd4dea489dedd00e76ae0bcf54aa8550202920eb64d5892ad02b13f2e5",
+        "ecfa369ec7e834204291fccb4d59c3fd1557b0ec3ab2ed7d50c98c01f292612e",
+        "507dcdae0432f558189a09c5e79fd69896e2f830e37ae4d598b00566e55f20f5",
+        "2184138ce3b4d73ccc2f1c8b6c14b2c52df6ffc8d34dce162af386c6fad2d941"
+    };
+
+    eshkol_mlkem_sizes_t sizes;
+    const mlkem_kat_hashes_t* expected = NULL;
+    if (mlkem_sizes_for_level(level, &sizes) != 0) return -1;
+    switch (level) {
+        case 512: expected = &kat512; break;
+        case 768: expected = &kat768; break;
+        case 1024: expected = &kat1024; break;
+        default: return -1;
+    }
+
+    uint8_t seed[48];
+    uint8_t d[32], z[32], m[32], K[ESHKOL_MLKEM_SHARED_SECRET_BYTES];
+    uint8_t public_key[MLKEM1024_PUBLICKEYBYTES];
+    uint8_t secret_key[MLKEM1024_SECRETKEYBYTES];
+    uint8_t ciphertext[MLKEM1024_CIPHERTEXTBYTES];
+    for (size_t i = 0; i < sizeof(seed); ++i) {
+        int high = hex_nibble(seed_hex[2 * i]);
+        int low = hex_nibble(seed_hex[2 * i + 1]);
+        if (high < 0 || low < 0) {
+            mlkem_set_last_error("ML-KEM KAT has an invalid NIST seed constant");
+            return -1;
+        }
+        seed[i] = (uint8_t)((high << 4) | low);
+    }
+
+    ctr_drbg_ctx_t drbg;
+    ctr_drbg_init(&drbg, seed);
+    ctr_drbg_generate(&drbg, d, sizeof(d));
+    ctr_drbg_generate(&drbg, z, sizeof(z));
+    ctr_drbg_generate(&drbg, m, sizeof(m));
+
+    switch (level) {
+        case 512:
+            moonlab_mlkem512_keygen(public_key, secret_key, d, z);
+            moonlab_mlkem512_encaps(ciphertext, K, public_key, m);
+            break;
+        case 768:
+            moonlab_mlkem768_keygen(public_key, secret_key, d, z);
+            moonlab_mlkem768_encaps(ciphertext, K, public_key, m);
+            break;
+        case 1024:
+            moonlab_mlkem1024_keygen(public_key, secret_key, d, z);
+            moonlab_mlkem1024_encaps(ciphertext, K, public_key, m);
+            break;
+        default:
+            return -1;
+    }
+
+    int valid = sha3_256_matches_hex(public_key, sizes.public_key_bytes,
+                                     expected->public_key_hash) &&
+                sha3_256_matches_hex(secret_key, sizes.secret_key_bytes,
+                                     expected->secret_key_hash) &&
+                sha3_256_matches_hex(ciphertext, sizes.ciphertext_bytes,
+                                     expected->ciphertext_hash) &&
+                sha3_256_matches_hex(K, sizeof(K), expected->shared_secret_hash);
+
+    secure_clear(&drbg, sizeof(drbg));
+    secure_clear(seed, sizeof(seed));
+    secure_clear(d, sizeof(d));
+    secure_clear(z, sizeof(z));
+    secure_clear(m, sizeof(m));
+    secure_clear(K, sizeof(K));
+    secure_clear(secret_key, sizeof(secret_key));
+
+    if (!valid) {
+        mlkem_set_last_error("Moonlab ML-KEM NIST deterministic KAT fingerprint mismatch");
+        return -1;
+    }
+    mlkem_set_last_error(NULL);
+    return 0;
+}
+
+#else
+
+static int32_t mlkem_unavailable(const char* operation) {
+    char message[256];
+    snprintf(message, sizeof(message),
+             "ML-KEM %s unavailable: rebuild with -DESHKOL_QUANTUM_ENABLED=ON",
+             operation);
+    mlkem_set_last_error(message);
+    return -1;
+}
+
+int32_t eshkol_mlkem_keygen(int32_t level, void* public_key, void* secret_key) {
+    (void)level;
+    (void)public_key;
+    (void)secret_key;
+    return mlkem_unavailable("key generation");
+}
+
+int32_t eshkol_mlkem_encaps(int32_t level, void* ciphertext,
+                            void* shared_secret, const void* public_key) {
+    (void)level;
+    (void)ciphertext;
+    (void)shared_secret;
+    (void)public_key;
+    return mlkem_unavailable("encapsulation");
+}
+
+int32_t eshkol_mlkem_decaps(int32_t level, void* shared_secret,
+                            const void* ciphertext, const void* secret_key) {
+    (void)level;
+    (void)shared_secret;
+    (void)ciphertext;
+    (void)secret_key;
+    return mlkem_unavailable("decapsulation");
+}
+
+int32_t eshkol_mlkem_nist_kat(int32_t level) {
+    (void)level;
+    return mlkem_unavailable("NIST KAT");
+}
+
+#endif

--- a/lib/agent/pqc.esk
+++ b/lib/agent/pqc.esk
@@ -1,0 +1,141 @@
+;;
+;; pqc.esk - FIPS 203 ML-KEM bytevector bindings (Stage S4)
+;;
+;; This stays separate from agent.quantum: it shares Moonlab's opt-in link
+;; target, but it has a distinct cryptographic lifecycle and only exposes
+;; serializable R7RS bytevectors rather than quantum-state/VQE handles.
+;;
+;; Production key generation and encapsulation always use Moonlab's
+;; Bell-verified QRNG wrappers.  The deterministic Moonlab entry points are
+;; intentionally not part of this Scheme surface; agent_pqc.c uses them only
+;; in its fixed-seed NIST KAT helper exercised by the test suite.
+;;
+
+(require core.capabilities)
+
+(provide mlkem-keygen
+         mlkem-encaps
+         mlkem-decaps
+         mlkem-public-key-bytes
+         mlkem-secret-key-bytes
+         mlkem-ciphertext-bytes
+         mlkem-shared-secret-bytes)
+
+;; Eshkol bytevector pointers point to [length:i64 | bytes...].  The C shim
+;; validates the bytevector subtype and exact FIPS 203 length on every call.
+(extern i32 mlkem-keygen-raw i32 ptr ptr :real eshkol_mlkem_keygen)
+(extern i32 mlkem-encaps-raw i32 ptr ptr ptr :real eshkol_mlkem_encaps)
+(extern i32 mlkem-decaps-raw i32 ptr ptr ptr :real eshkol_mlkem_decaps)
+(extern i32 mlkem-last-error-raw ptr i64 :real eshkol_mlkem_last_error)
+
+(define mlkem-shared-secret-bytes 32)
+
+(define (mlkem-level-valid? level)
+  (or (= level 512) (= level 768) (= level 1024)))
+
+(define (mlkem-require-level! who level)
+  (if (mlkem-level-valid? level)
+      level
+      (error (string-append "agent.pqc: " who
+                            " level must be 512, 768, or 1024"))))
+
+(define (mlkem-public-key-bytes level)
+  (mlkem-require-level! "mlkem-public-key-bytes" level)
+  (cond ((= level 512) 800)
+        ((= level 768) 1184)
+        (else 1568)))
+
+(define (mlkem-secret-key-bytes level)
+  (mlkem-require-level! "mlkem-secret-key-bytes" level)
+  (cond ((= level 512) 1632)
+        ((= level 768) 2400)
+        (else 3168)))
+
+(define (mlkem-ciphertext-bytes level)
+  (mlkem-require-level! "mlkem-ciphertext-bytes" level)
+  (cond ((= level 512) 768)
+        ((= level 768) 1088)
+        (else 1568)))
+
+(define (mlkem-last-error)
+  (let ((buffer (make-string 256 #\nul)))
+    (let ((length (mlkem-last-error-raw buffer 256)))
+      (if (> length 0)
+          (substring buffer 0 length)
+          "unknown Moonlab ML-KEM error"))))
+
+(define (mlkem-check-result! operation result)
+  (if (= result 0)
+      #t
+      (error (string-append "agent.pqc: " operation " failed: "
+                            (mlkem-last-error)))))
+
+(define (mlkem-require-bytevector! operation value expected-length)
+  (if (not (bytevector? value))
+      (error (string-append "agent.pqc: " operation " requires a bytevector"))
+      (if (= (bytevector-length value) expected-length)
+          value
+          (error (string-append "agent.pqc: " operation " requires a "
+                                (number->string expected-length)
+                                "-byte bytevector")))))
+
+(define (mlkem-level-from-public-key public-key)
+  (if (not (bytevector? public-key))
+      (error "agent.pqc: mlkem-encaps requires a public-key bytevector")
+      (let ((length (bytevector-length public-key)))
+        (cond ((= length 800) 512)
+              ((= length 1184) 768)
+              ((= length 1568) 1024)
+              (else (error "agent.pqc: public key has no ML-KEM parameter-set length"))))))
+
+(define (mlkem-level-from-secret-key secret-key)
+  (if (not (bytevector? secret-key))
+      (error "agent.pqc: mlkem-decaps requires a secret-key bytevector")
+      (let ((length (bytevector-length secret-key)))
+        (cond ((= length 1632) 512)
+              ((= length 2400) 768)
+              ((= length 3168) 1024)
+              (else (error "agent.pqc: secret key has no ML-KEM parameter-set length"))))))
+
+(define (mlkem-keygen level)
+  "Generate an ML-KEM keypair with Moonlab's Bell-verified QRNG.
+   `level` is 512, 768, or 1024.  Returns #(public-key secret-key), where
+   both fields are R7RS bytevectors sized by the FIPS 203 parameter set."
+  (capability-require! 'ffi 'mlkem-keygen)
+  (mlkem-require-level! "mlkem-keygen" level)
+  (let ((public-key (make-bytevector (mlkem-public-key-bytes level) 0))
+        (secret-key (make-bytevector (mlkem-secret-key-bytes level) 0)))
+    (mlkem-check-result! "mlkem-keygen"
+                         (mlkem-keygen-raw level public-key secret-key))
+    (vector public-key secret-key)))
+
+(define (mlkem-encaps public-key)
+  "Encapsulate to `public-key` with Moonlab's Bell-verified QRNG.
+   Returns #(ciphertext shared-secret), both R7RS bytevectors.  The key's
+   parameter set is inferred from its exact FIPS 203 public-key length."
+  (capability-require! 'ffi 'mlkem-encaps)
+  (let* ((level (mlkem-level-from-public-key public-key))
+         (public-key-size (mlkem-public-key-bytes level))
+         (ciphertext (make-bytevector (mlkem-ciphertext-bytes level) 0))
+         (shared-secret (make-bytevector mlkem-shared-secret-bytes 0)))
+    (mlkem-require-bytevector! "mlkem-encaps public key" public-key public-key-size)
+    (mlkem-check-result! "mlkem-encaps"
+                         (mlkem-encaps-raw level ciphertext shared-secret public-key))
+    (vector ciphertext shared-secret)))
+
+(define (mlkem-decaps secret-key ciphertext)
+  "Recover the 32-byte shared secret for `ciphertext` using `secret-key`.
+   The parameter set is inferred from the secret-key length.  A wrong-size or
+   wrong-type input raises a catchable Eshkol error.  As required by FIPS 203,
+   a correctly sized tampered ciphertext returns an implicit-rejection secret
+   rather than exposing a validity oracle."
+  (capability-require! 'ffi 'mlkem-decaps)
+  (let* ((level (mlkem-level-from-secret-key secret-key))
+         (secret-key-size (mlkem-secret-key-bytes level))
+         (ciphertext-size (mlkem-ciphertext-bytes level))
+         (shared-secret (make-bytevector mlkem-shared-secret-bytes 0)))
+    (mlkem-require-bytevector! "mlkem-decaps secret key" secret-key secret-key-size)
+    (mlkem-require-bytevector! "mlkem-decaps ciphertext" ciphertext ciphertext-size)
+    (mlkem-check-result! "mlkem-decaps"
+                         (mlkem-decaps-raw level shared-secret ciphertext secret-key))
+    shared-secret))

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -407,6 +407,21 @@ extern "C" {
     double eshkol_vqe_gradient_get(int64_t handle, int32_t index)
         ESHKOL_OPTIONAL_AGENT_FFI;
 
+    // Moonlab ML-KEM (agent.pqc, Stage S4).  Bytevectors are passed as their
+    // arena payload pointers; agent_pqc.c validates their subtype and exact
+    // FIPS 203 length before calling Moonlab.
+    int32_t eshkol_mlkem_keygen(int32_t level, void* public_key,
+                                void* secret_key) ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t eshkol_mlkem_encaps(int32_t level, void* ciphertext,
+                                void* shared_secret,
+                                const void* public_key) ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t eshkol_mlkem_decaps(int32_t level, void* shared_secret,
+                                const void* ciphertext,
+                                const void* secret_key) ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t eshkol_mlkem_last_error(char* buf, int64_t buf_size)
+        ESHKOL_OPTIONAL_AGENT_FFI;
+    int32_t eshkol_mlkem_nist_kat(int32_t level) ESHKOL_OPTIONAL_AGENT_FFI;
+
     void* qllm_process_spawn(const char* command, const char* cwd_arg,
                              const char* env_arg, int64_t flags)
         ESHKOL_OPTIONAL_AGENT_FFI;
@@ -1111,6 +1126,11 @@ void ReplJITContext::registerRuntimeSymbols() {
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_vqe_gradient_set_parameter);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_vqe_gradient_compute);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_vqe_gradient_get);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_mlkem_keygen);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_mlkem_encaps);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_mlkem_decaps);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_mlkem_last_error);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_mlkem_nist_kat);
 
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_process_spawn);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(qllm_process_spawn_shell);

--- a/tests/quantum/pqc_mlkem_test.esk
+++ b/tests/quantum/pqc_mlkem_test.esk
@@ -1,0 +1,102 @@
+;; Stage S4 ON-path verification for agent.pqc over Moonlab ML-KEM.
+;; Run with -DESHKOL_QUANTUM_ENABLED=ON.
+
+(require agent.pqc)
+
+;; Test-only bridge to agent_pqc.c's NIST count=0 deterministic KAT.  The
+;; public Scheme API deliberately exposes only Bell-verified-QRNG keygen and
+;; encapsulation; deterministic operations are not production-safe defaults.
+(extern i32 mlkem-nist-kat-raw i32 :real eshkol_mlkem_nist_kat)
+
+(define passed 0)
+(define failed 0)
+
+(define (check label ok)
+  (if ok
+      (begin
+        (set! passed (+ passed 1))
+        (display "PASS: ") (display label) (newline))
+      (begin
+        (set! failed (+ failed 1))
+        (display "FAIL: ") (display label) (newline))))
+
+(define (bytevector=? left right)
+  (and (= (bytevector-length left) (bytevector-length right))
+       (let loop ((index 0))
+         (if (= index (bytevector-length left))
+             #t
+             (and (= (bytevector-u8-ref left index)
+                     (bytevector-u8-ref right index))
+                  (loop (+ index 1)))))))
+
+(define (raises? thunk)
+  (let ((raised #f))
+    (guard (exception (#t (set! raised #t)))
+      (thunk))
+    raised))
+
+(define (run-level label level public-key-bytes secret-key-bytes ciphertext-bytes)
+  (let* ((keypair-a (mlkem-keygen level))
+         (public-key-a (vector-ref keypair-a 0))
+         (secret-key-a (vector-ref keypair-a 1))
+         (keypair-b (mlkem-keygen level))
+         (public-key-b (vector-ref keypair-b 0))
+         (secret-key-b (vector-ref keypair-b 1))
+         (encapsulation-a (mlkem-encaps public-key-a))
+         (ciphertext-a (vector-ref encapsulation-a 0))
+         (shared-secret-a (vector-ref encapsulation-a 1))
+         (encapsulation-b (mlkem-encaps public-key-a))
+         (ciphertext-b (vector-ref encapsulation-b 0))
+         (shared-secret-b (vector-ref encapsulation-b 1))
+         (decapsulated-secret (mlkem-decaps secret-key-a ciphertext-a))
+         (sizes-correct
+          (and (= (bytevector-length public-key-a) public-key-bytes)
+               (= (bytevector-length secret-key-a) secret-key-bytes)
+               (= (bytevector-length ciphertext-a) ciphertext-bytes)
+               (= (bytevector-length shared-secret-a) 32)
+               (= (bytevector-length decapsulated-secret) 32)))
+         (round-trip-correct (bytevector=? shared-secret-a decapsulated-secret))
+         (distinct-keypairs
+          (and (not (bytevector=? public-key-a public-key-b))
+               (not (bytevector=? secret-key-a secret-key-b))))
+         (distinct-encapsulations
+          (and (not (bytevector=? ciphertext-a ciphertext-b))
+               (not (bytevector=? shared-secret-a shared-secret-b))))
+         (ok (and sizes-correct round-trip-correct distinct-keypairs
+                  distinct-encapsulations)))
+    (display label) (display " sizes: pk=") (display public-key-bytes)
+    (display " sk=") (display secret-key-bytes)
+    (display " ct=") (display ciphertext-bytes)
+    (display " ss=32") (newline)
+    (check label ok)))
+
+(run-level "ML-KEM-512" 512 800 1632 768)
+(run-level "ML-KEM-768" 768 1184 2400 1088)
+(run-level "ML-KEM-1024" 1024 1568 3168 1568)
+
+;; Moonlab's repository contains a NIST-seeded KAT harness with the published
+;; pq-crystals count=0 DRBG seed and SHA3-256 fingerprints for every artifact.
+;; The shim invokes deterministic (non-QRNG) keygen/encaps with the resulting
+;; fixed d, z, and m bytes and checks all pk/sk/ct/K fingerprints.
+(check "ML-KEM-512 deterministic NIST KAT" (= (mlkem-nist-kat-raw 512) 0))
+(check "ML-KEM-768 deterministic NIST KAT" (= (mlkem-nist-kat-raw 768) 0))
+(check "ML-KEM-1024 deterministic NIST KAT" (= (mlkem-nist-kat-raw 1024) 0))
+
+;; Boundary errors must be Scheme catchable, before unsafe bytevector data ever
+;; reaches the C ABI.  Exact-size checks are the public contract.
+(check "wrong-size public key raises"
+       (raises? (lambda () (mlkem-encaps (make-bytevector 7 0)))))
+(check "wrong-size secret key raises"
+       (raises? (lambda ()
+                  (mlkem-decaps (make-bytevector 7 0) (make-bytevector 7 0)))))
+(check "invalid ML-KEM level raises"
+       (raises? (lambda () (mlkem-keygen 42))))
+
+(display "pqc_mlkem_test: ")
+(if (= failed 0)
+    (begin
+      (display "PASS (") (display passed) (display "/9)") (newline)
+      (exit 0))
+    (begin
+      (display "FAIL (") (display failed) (display " failed)") (newline)
+      (exit 1)))


### PR DESCRIPTION
Stage 4 of the Moonlab quantum integration: **post-quantum cryptography (ML-KEM / FIPS 203)** as Scheme builtins, with keys and shared secrets seeded from Moonlab's Bell-verified QRNG. Gated behind `ESHKOL_QUANTUM_ENABLED` (default OFF), like S1–S3.

## New `agent.pqc` builtins
- `(mlkem-keygen level)` → `(public-key . secret-key)` — QRNG-seeded key generation.
- `(mlkem-encaps public-key)` → `(ciphertext . shared-secret)` — encapsulate a fresh 32-byte secret (QRNG-seeded).
- `(mlkem-decaps secret-key ciphertext)` → shared-secret — recover the 32-byte secret.
- `level` ∈ {512, 768, 1024}. Keys, ciphertext, and the shared secret are R7RS **bytevectors** sized to the FIPS 203 parameters. Wrong type/size/level raises a catchable error.

Bound to Moonlab's `moonlab_mlkem{512,768,1024}_{keygen,encaps}_qrng` (Bell-verified randomness) + `_decaps`; the deterministic `keygen(...d z)` / `encaps(...m)` symbols are used only by the KAT test. C shims in `lib/agent/c/agent_pqc.c` behind `#ifdef ESHKOL_HAVE_MOONLAB` with honest not-enabled stubs, mirroring `agent.quantum`.

## Verification (independent, on-path build)
`tests/quantum/pqc_mlkem_test.esk`:
- **Round-trip** (the KEM contract — both parties derive the same secret) PASS for all three levels, with correct sizes:
  - ML-KEM-512: pk 800, sk 1632, ct 768, ss 32
  - ML-KEM-768: pk 1184, sk 2400, ct 1088, ss 32
  - ML-KEM-1024: pk 1568, sk 3168, ct 1568, ss 32
- **Deterministic NIST KAT** fingerprint match (reproduces Moonlab's `count=0` DRBG seed, verifies pk/sk/ct/K SHA3-256 fingerprints) PASS for all three levels.
- Error handling: wrong-size public key / secret key / invalid level all raise. **PASS.**

OFF-default build unchanged (`Quantum: DISABLED`), memory suite 15/15; existing quantum tests still pass (Bell 200/200, VQE, VQE-AD 3/3). No new WASM env imports (all gated).
