### PR TITLE
feat(quantum): S5 capstone — CHSH gate, gated CI lane, coverage/arch-model/oracle wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,97 @@ env:
   WINDOWS_LLVM_SDK_VERSION: '21.1.8'
 
 jobs:
+  # Moonlab is deliberately opt-in, so keep its networked macOS coverage in a
+  # separate advisory job. `continue-on-error` makes the lane informative
+  # without turning the default required CI set into a Moonlab availability
+  # gate; branch-protection configuration must not add this check as required.
+  quantum-macos:
+    name: quantum-macos (advisory)
+    runs-on: macos-14
+    continue-on-error: true
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          brew install llvm@${LLVM_MAJOR} cmake ninja readline pcre2 sqlite
+
+      - name: Configure quantum build
+        shell: bash
+        run: |
+          set -euxo pipefail
+          LLVM_PREFIX="$(brew --prefix llvm@${LLVM_MAJOR})"
+          export PATH="$LLVM_PREFIX/bin:$PATH"
+          cmake -S . -B build-quantum -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DESHKOL_REQUIRED_LLVM_MAJOR="${LLVM_MAJOR}" \
+            -DLLVM_CONFIG_EXECUTABLE="$LLVM_PREFIX/bin/llvm-config" \
+            -DESHKOL_QUANTUM_ENABLED=ON \
+            -DESHKOL_BUILD_TESTS=ON \
+            -DESHKOL_BUILD_AGENT_FFI=ON
+
+      - name: Build quantum runner and stdlib
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cmake --build build-quantum --target eshkol-run stdlib --parallel
+
+      - name: Run quantum integration gates
+        shell: bash
+        run: |
+          set -euo pipefail
+          runner="$PWD/build-quantum/eshkol-run"
+          libflag="-L$PWD/build-quantum"
+          for test in tests/quantum/*.esk; do
+            echo "== $test =="
+            output="$($runner -r "$test" "$libflag" 2>&1)"
+            printf '%s\n' "$output"
+            case "$(basename "$test")" in
+              quantum_smoke_test.esk)
+                grep -q 'Bell-pair correlation over 200 shots: 200/200  PASS' <<<"$output"
+                grep -q 'quantum_smoke_test: PASS' <<<"$output"
+                ;;
+              vqe_test.esk)
+                grep -q 'VQE H2: PASS' <<<"$output"
+                ;;
+              vqe_ad_test.esk)
+                grep -q 'vqe_ad_test: PASS (3/3)' <<<"$output"
+                ;;
+              pqc_mlkem_test.esk)
+                grep -q 'pqc_mlkem_test: PASS (9/9)' <<<"$output"
+                ;;
+              bell_chsh_test.esk)
+                grep -q 'bell_chsh_test: PASS' <<<"$output"
+                ;;
+              quantum_surface_coverage_test.esk)
+                grep -q 'quantum_surface_coverage_test: PASS (3/3)' <<<"$output"
+                ;;
+              vqe_ad_adversarial.esk)
+                grep -q 'vqe_ad_adversarial: PASS' <<<"$output"
+                ;;
+              *)
+                echo "Unhandled quantum test: $test" >&2
+                exit 1
+                ;;
+            esac
+          done
+
+      # The default AD oracle remains Moonlab-free. This opt-in invocation
+      # enables its VQE-energy AD-vs-finite-difference probe on the same
+      # quantum build that compiled the agent.quantum bridge.
+      - name: Run quantum AD adversarial probe
+        shell: bash
+        env:
+          BUILD_DIR: build-quantum
+          ESHKOL_QUANTUM_ENABLED: 'ON'
+        run: |
+          set -euxo pipefail
+          ./scripts/run_ad_adversarial.sh --quick
+
   unix-matrix:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}

--- a/.icc/architecture-model.yaml
+++ b/.icc/architecture-model.yaml
@@ -5,7 +5,7 @@ description: >
   Machine-checked architecture model of the Eshkol compiler — a compiled
   R7RS Scheme frontend, an LLVM AOT/JIT backend, a bytecode VM, an OALR region
   memory manager, an automatic-differentiation tower, an exact numeric tower,
-  and a WASM emission path with browser glue.  Components, dataflows,
+  an opt-in Moonlab quantum backend, and a WASM emission path with browser glue.  Components, dataflows,
   capabilities, and first-class INVARIANTS that encode the incident classes the
   adversarial campaign surfaced (VM-parity gaps, FFI/link-registration drift,
   language-surface under-exercise, WASM import/glue drift, OALR interior-pointer
@@ -13,8 +13,8 @@ description: >
   Verified by `icc architecture-verify --repo eshkol --model
   .icc/architecture-model.yaml`.
 
-  Ground truth: tests/coverage/language_surface.json (958 builtins with
-  per-backend membership, 116 special forms, 112 AST ops) and
+  Ground truth: tests/coverage/language_surface.json (985 builtins including
+  22 opt-in Agent FFI quantum APIs, 116 special forms, 112 AST ops) and
   scripts/language_coverage.py (dynamic exposure-engine coverage tracker).
 
   FIDELITY HONESTY: ICC's C symbol index does not AST-resolve C/C++ the way it
@@ -103,6 +103,25 @@ components:
       - lib/backend/arithmetic_codegen.cpp
     entry_points:
       - {path: lib/backend/arithmetic_codegen.cpp}
+
+  - id: quantum-backend
+    role: backend
+    description: >
+      Opt-in Moonlab quantum integration: Agent FFI state-vector and CHSH
+      shims, VQE/custom-VJP surface, FIPS 203 ML-KEM bindings, and the core
+      QRNG wrapper. Native builds with ESHKOL_QUANTUM_ENABLED route quantum
+      entropy to Moonlab; default and browser builds retain an explicitly
+      labelled classical fallback.
+    modules:
+      - lib/agent/quantum.esk
+      - lib/agent/c/agent_quantum.c
+      - lib/agent/pqc.esk
+      - lib/agent/c/agent_pqc.c
+      - lib/quantum/quantum_rng_wrapper.c
+      - lib/quantum/quantum_rng_wrapper.h
+      - lib/repl/repl_jit.cpp
+    entry_points:
+      - {path: lib/agent/c/agent_quantum.c, symbol: eshkol_quantum_bell_chsh}
 
   - id: exposure-engines
     role: analysis
@@ -223,7 +242,20 @@ capabilities:
     arming:
       kind: runtime_event
       path: scripts/language_coverage.py
-      pattern: language_surface_coverage
+    pattern: language_surface_coverage
+
+  - id: quantum_qrng_route
+    feature: Moonlab Bell-verified QRNG route for quantum-random on opt-in native builds
+    entry_points:
+      - {path: lib/quantum/quantum_rng_wrapper.c, symbol: eshkol_qrng_uint64}
+      - {path: lib/quantum/quantum_rng_wrapper.c, symbol: eshkol_qrng_source_label}
+    arming:
+      kind: compile_definition
+      path: lib/quantum/quantum_rng_wrapper.c
+      pattern: ESHKOL_MOONLAB_QRNG_ENABLED
+    dependencies: [quantum-backend]
+    dependency_constructor: "moonlab_qrng_bytes|moonlab-qrng"
+    dependency_paths: [lib/quantum/quantum_rng_wrapper.c]
 
 # --------------------------------------------------------------------------
 # INVARIANTS — one per incident class from the adversarial campaign
@@ -268,7 +300,24 @@ invariants:
       (#250) and the WASM glue.
     capability: base64_ffi_builtin
 
-  # 3. language-surface-exercise, encoded as exercise (runtime-bound).  Binds to
+  # 3. quantum-random-routing: the opt-in source label and byte path must
+  #    agree that quantum-random reaches Moonlab's Bell-verified QRNG. The
+  #    default/WASM classical fallback is intentional and explicitly labelled;
+  #    this invariant is specifically armed by ESHKOL_MOONLAB_QRNG_ENABLED.
+  - id: INV-quantum-random-routes-to-moonlab-qrng
+    kind: dependency-presence
+    incident: quantum-entropy-placeholder
+    severity: critical
+    fidelity: grep
+    description: >
+      When the Moonlab QRNG compile definition is enabled, the core
+      quantum-random wrapper must call moonlab_qrng_bytes and report the
+      machine-readable source label moonlab-qrng. This prevents a regression
+      to an unlabeled bare PRNG while preserving the explicit
+      classical-fallback contract for default and WASM builds.
+    capability: quantum_qrng_route
+
+  # 4. language-surface-exercise, encoded as exercise (runtime-bound).  Binds to
   #    the language_surface_coverage runtime_event scripts/language_coverage.py
   #    emits.  The generic exercise kind is PRESENCE+RECENCY based: it FAILs when
   #    other traces exist but no coverage trace is fresh (engines not run), and
@@ -292,7 +341,7 @@ invariants:
       trace_event_kind: runtime_event
       trace_name_pattern: language_surface_coverage
 
-  # 4. wasm-import-glue-equality, encoded as key-space-equality.  The env-import
+  # 5. wasm-import-glue-equality, encoded as key-space-equality.  The env-import
   #    stub key space must be IDENTICAL across both JS glue files — any import a
   #    WASM needs must be provided by both.  Expected to FAIL right now: a live
   #    drift (eshkol_qrng_* present in web/ glue but not site/ glue, and
@@ -316,7 +365,7 @@ invariants:
         path: web/eshkol-repl.js
         key_pattern: '(eshkol_[A-Za-z0-9_]+|region_[A-Za-z0-9_]+)\s*:'
 
-  # 5. OALR interior-pointer deep-walk (ESH-0214d), encoded as key-space-equality.
+  # 6. OALR interior-pointer deep-walk (ESH-0214d), encoded as key-space-equality.
   #    Every interior-pointer heap subtype declared in the enum must have a case
   #    in the region evacuator; the pattern enumerates exactly the deep-walk set
   #    (leaf subtypes like STRING/SYMBOL/BIGNUM are intentionally excluded).
@@ -340,7 +389,7 @@ invariants:
         path: lib/core/runtime_regions.cpp
         key_pattern: '(HEAP_SUBTYPE_(?:CONS|VECTOR|RECORD|MULTI_VALUE|HASH|TENSOR|EXCEPTION|SUBSTITUTION|FACT|KNOWLEDGE_BASE|FACTOR_GRAPH|WORKSPACE|PROMISE|DNC|SDNC|TAYLOR))'
 
-  # 6. AD-exactness, encoded as dependency-presence.  The default derivative path
+  # 7. AD-exactness, encoded as dependency-presence.  The default derivative path
   #    must construct the exact dual/jet tangent, never a finite-difference
   #    approximation.  Armed by the derivative-op dispatch; dependency is the
   #    dual/jet constructor set.  Expected PASS.
@@ -356,7 +405,7 @@ invariants:
       difference fallback would silently degrade every default gradient.
     capability: exact_ad_default_gradient
 
-  # 7. TCO tail-position coverage, encoded as key-space-equality.  The core
+  # 8. TCO tail-position coverage, encoded as key-space-equality.  The core
   #    tail-transparent forms (if / let* family / sequence) must each be handled
   #    by isTailPosition; cond/case/when reach it desugared to these forms.
   #    Expected PASS; removing a case (a TCO regression) FAILs it.

--- a/lib/agent/c/agent_quantum.c
+++ b/lib/agent/c/agent_quantum.c
@@ -28,6 +28,7 @@
  *                                   quantum_entropy_ctx_create_hw/_destroy
  *   - src/algorithms/vqe.h         : molecular Hamiltonians, VQE solver,
  *                                   optimizer, and vqe_solve
+ *   - src/applications/bell_test.h : bell_test_run_chsh CHSH experiment
  *   - src/applications/moonlab_export.h
  *                                 : moonlab_vqe_gradient stable ABI wrapper
  *
@@ -88,6 +89,7 @@ typedef struct {
 #include "quantum/measurement.h"
 #include "utils/quantum_entropy.h"
 #include "algorithms/vqe.h"
+#include "applications/bell_test.h"
 #include "applications/moonlab_export.h"
 
 /*******************************************************************************
@@ -238,6 +240,42 @@ static double error_double(void) {
 static double unavailable_double(const char* message) {
     set_last_error(message);
     return error_double();
+}
+
+/*******************************************************************************
+ * Stage S5: Bell/CHSH acceptance experiment
+ ******************************************************************************/
+
+/**
+ * Run Moonlab's public CHSH experiment with the canonical settings that
+ * maximise the |Phi+> violation: Alice (0, pi/2), Bob (pi/4, -pi/4).
+ *
+ * bell_test_default_config() uses a historical set of angles that does not
+ * match bell_test_run_chsh()'s difference-angle correlator, so the default
+ * configuration reports about 1.3 rather than the physical 2*sqrt(2).  Keep
+ * the public experiment, but explicitly select the canonical settings here;
+ * this makes the Scheme gate a test of entanglement rather than a test of that
+ * stale application default.  The returned S is positive for this ordering.
+ *
+ * @return CHSH S on success, or NaN with eshkol_quantum_last_error() set.
+ */
+double eshkol_quantum_bell_chsh(int32_t num_trials) {
+    if (num_trials < 4) {
+        return unavailable_double("bell-chsh: num-trials must be at least four");
+    }
+
+    bell_test_config_t config = bell_test_default_config();
+    config.num_trials = num_trials;
+    config.alice_angle_1 = 0.0;
+    config.alice_angle_2 = 1.57079632679489661923;  /* pi / 2 */
+    config.bob_angle_1 = 0.78539816339744830962;    /* pi / 4 */
+    config.bob_angle_2 = -0.78539816339744830962;   /* -pi / 4 */
+
+    bell_test_results_t results;
+    if (bell_test_run_chsh(&config, &results) != 0 || results.S != results.S) {
+        return unavailable_double("bell-chsh: Moonlab CHSH experiment failed");
+    }
+    return results.S;
 }
 
 /*******************************************************************************
@@ -1012,6 +1050,12 @@ int32_t eshkol_quantum_measure(int64_t handle, int32_t qubit) { (void)handle; (v
 /** @brief Stub: always fails (NaN sentinel) since no states exist without Moonlab support. */
 double eshkol_quantum_expectation_z(int64_t handle, int32_t qubit) {
     (void)handle; (void)qubit;
+    volatile double zero = 0.0;
+    return zero / zero;
+}
+/** @brief Stub: Moonlab support was not compiled in, so CHSH is unavailable. */
+double eshkol_quantum_bell_chsh(int32_t num_trials) {
+    (void)num_trials;
     volatile double zero = 0.0;
     return zero / zero;
 }

--- a/lib/agent/quantum.esk
+++ b/lib/agent/quantum.esk
@@ -1,5 +1,5 @@
 ;;
-;; quantum.esk - Moonlab state-vector and VQE FFI wrapper (Stages S1/S2)
+;; quantum.esk - Moonlab state-vector, CHSH, and VQE FFI wrapper (S1-S5)
 ;; Bindings to agent_quantum.c, which links Moonlab's libquantumsim.
 ;;
 ;; Only usable when Eshkol is built with -DESHKOL_QUANTUM_ENABLED=ON (see
@@ -9,9 +9,9 @@
 ;; agent.http uses for its libcurl-optional symbols.
 ;;
 ;; HONESTY NOTE: this module gives you the real thing -- Moonlab's actual
-;; state-vector simulator, gates, and measurement, Bell-verifiable via
-;; Moonlab's own bell_test_run_chsh (not bound here yet; see Stage S5 in the
-;; design doc). It is unrelated to the classical `quantum-random` builtin
+;; state-vector simulator, gates, and measurement, Bell-verifiable through the
+;; public bell-chsh wrapper around Moonlab's bell_test_run_chsh. It is unrelated
+;; to the classical `quantum-random` builtin
 ;; family (lib/quantum/quantum_rng.c) -- see Part D for wiring that builtin to
 ;; Moonlab's QRNG.
 ;;
@@ -30,6 +30,7 @@
          apply-rz
          measure
          expectation-z
+         bell-chsh
          with-quantum-state
          make-h2-hamiltonian
          make-lih-hamiltonian
@@ -56,6 +57,7 @@
 (extern i32    quantum-measure-raw          i64 i32       :real eshkol_quantum_measure)
 (extern double quantum-expectation-z-raw    i64 i32       :real eshkol_quantum_expectation_z)
 (extern i32    quantum-last-error-raw       ptr i64       :real eshkol_quantum_last_error)
+(extern double bell-chsh-raw                i32           :real eshkol_quantum_bell_chsh)
 
 ;; Stage S2 VQE declarations.  Hamiltonians remain opaque i64 handles; the
 ;; gradient context is private to vqe-gradient and exists only because Scheme
@@ -183,6 +185,13 @@
 (define (expectation-z st qubit)
   "Expectation value <psi|Z_qubit|psi> in [-1, 1], without collapsing the state."
   (quantum-expectation-z-raw st qubit))
+
+(define (bell-chsh num-trials)
+  "Run Moonlab's CHSH Bell experiment and return its signed S value.
+   Uses the canonical maximum-violation settings: Alice (0, pi/2), Bob
+   (pi/4, -pi/4). `num-trials` must be at least four."
+  (capability-require! 'ffi 'bell-chsh)
+  (check-quantum-real! "bell-chsh" (bell-chsh-raw num-trials)))
 
 ;; ---------------------------------------------------------------------------
 ;; Convenience: auto-destroy on exit (mirrors sqlite.esk's with-db)

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -368,6 +368,7 @@ extern "C" {
         ESHKOL_OPTIONAL_AGENT_FFI;
     double eshkol_quantum_expectation_z(int64_t handle, int32_t qubit)
         ESHKOL_OPTIONAL_AGENT_FFI;
+    double eshkol_quantum_bell_chsh(int32_t num_trials) ESHKOL_OPTIONAL_AGENT_FFI;
     int32_t eshkol_quantum_last_error(char* buf, int64_t buf_size)
         ESHKOL_OPTIONAL_AGENT_FFI;
 
@@ -1107,6 +1108,7 @@ void ReplJITContext::registerRuntimeSymbols() {
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_gate_rz);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_measure);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_expectation_z);
+    ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_bell_chsh);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_quantum_last_error);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_vqe_make_h2_hamiltonian);
     ADD_OPTIONAL_AGENT_FFI_SYMBOL(eshkol_vqe_make_lih_hamiltonian);

--- a/scripts/gen_language_surface.py
+++ b/scripts/gen_language_surface.py
@@ -38,6 +38,39 @@ VM_C = os.path.join(REPO, "lib", "backend", "eshkol_vm.c")
 LLVM_CPP = os.path.join(REPO, "lib", "backend", "llvm_codegen.cpp")
 PARSER = os.path.join(REPO, "lib", "frontend", "parser.cpp")
 ESHKOL_H = os.path.join(REPO, "inc", "eshkol", "eshkol.h")
+AGENT_QUANTUM = os.path.join(REPO, "lib", "agent", "quantum.esk")
+AGENT_PQC = os.path.join(REPO, "lib", "agent", "pqc.esk")
+
+# Agent modules are part of the user-callable language surface even though they
+# are not registered in the core VM/native builtin tables. Keep this list small
+# and intentional: it is the Moonlab-backed contract exercised only on the
+# ESHKOL_QUANTUM_ENABLED=ON lane. The source check in
+# extract_agent_module_provides() below prevents a manifest entry from drifting
+# away from its exported Scheme API.
+QUANTUM_AGENT_BUILTINS = {
+    "make-quantum-state": (AGENT_QUANTUM, 1, "ffi_system"),
+    "apply-hadamard": (AGENT_QUANTUM, 2, "ffi_system"),
+    "apply-pauli-x": (AGENT_QUANTUM, 2, "ffi_system"),
+    "apply-pauli-y": (AGENT_QUANTUM, 2, "ffi_system"),
+    "apply-pauli-z": (AGENT_QUANTUM, 2, "ffi_system"),
+    "apply-cnot": (AGENT_QUANTUM, 3, "ffi_system"),
+    "apply-rx": (AGENT_QUANTUM, 3, "ffi_system"),
+    "apply-ry": (AGENT_QUANTUM, 3, "ffi_system"),
+    "apply-rz": (AGENT_QUANTUM, 3, "ffi_system"),
+    "measure": (AGENT_QUANTUM, 2, "ffi_system"),
+    "expectation-z": (AGENT_QUANTUM, 2, "ffi_system"),
+    "bell-chsh": (AGENT_QUANTUM, 1, "ffi_system"),
+    "make-h2-hamiltonian": (AGENT_QUANTUM, 1, "ffi_system"),
+    "make-lih-hamiltonian": (AGENT_QUANTUM, 1, "ffi_system"),
+    "make-h2o-hamiltonian": (AGENT_QUANTUM, 0, "ffi_system"),
+    "hamiltonian-exact-ground-energy": (AGENT_QUANTUM, 1, "tensor_ad"),
+    "vqe-optimize": (AGENT_QUANTUM, 2, "tensor_ad"),
+    "vqe-gradient": (AGENT_QUANTUM, 2, "tensor_ad"),
+    "vqe-energy": (AGENT_QUANTUM, 2, "tensor_ad"),
+    "mlkem-keygen": (AGENT_PQC, 1, "ffi_system"),
+    "mlkem-encaps": (AGENT_PQC, 1, "ffi_system"),
+    "mlkem-decaps": (AGENT_PQC, 2, "ffi_system"),
+}
 
 TRIPLE = re.compile(r'\{\s*"([^"]+)"\s*,\s*(-?\d+)\s*,\s*(-?\d+)\s*\}')
 
@@ -133,6 +166,22 @@ def extract_prelude_defs():
     names.update({"map", "filter", "fold-left", "fold-right", "for-each",
                   "reduce", "compose", "any", "every", "find", "take", "drop"})
     return sorted(names)
+
+
+def extract_agent_module_provides(path):
+    """Extract the flat public API from an agent module's `(provide ...)` form.
+
+    Agent modules are compiled into programs that require them, rather than
+    registered in the core BUILTINS[] tables. This is deliberately a narrow
+    parser for the flat provide lists used by lib/agent/*.esk, not a general
+    Scheme parser.
+    """
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        text = fh.read()
+    match = re.search(r"\(provide\s+([^)]*)\)", text, re.S)
+    if not match:
+        raise ValueError("no flat (provide ...) form in %s" % path)
+    return set(re.findall(r"[A-Za-z][A-Za-z0-9!?*/<>=._+-]*", match.group(1)))
 
 
 # ---------------------------------------------------------------------------
@@ -412,6 +461,29 @@ def build_manifest():
             "category": categorize(name),
         })
 
+    # The Moonlab agent APIs are opt-in, but are still user-callable Scheme
+    # names and therefore need to participate in total-language coverage. They
+    # have no core builtin id by design; `agent_ffi` honestly records their
+    # dispatch vehicle without pretending the VM implements them.
+    agent_provides = {}
+    for _, (path, _, _) in QUANTUM_AGENT_BUILTINS.items():
+        agent_provides.setdefault(path, extract_agent_module_provides(path))
+    for name, (path, arity, category) in sorted(QUANTUM_AGENT_BUILTINS.items()):
+        if name not in agent_provides[path]:
+            raise ValueError("tracked quantum API %s is not provided by %s"
+                             % (name, os.path.relpath(path, REPO)))
+        if name in names:
+            raise ValueError("quantum agent API %s unexpectedly collides with a core builtin"
+                             % name)
+        builtins.append({
+            "name": name,
+            "ids": [],
+            "arity": arity,
+            "backends": ["agent_ffi"],
+            "category": category,
+            "source": os.path.relpath(path, REPO),
+        })
+
     special = []
     for kw in sorted(forms):
         special.append({
@@ -440,6 +512,10 @@ def build_manifest():
                 "special_forms": "lib/frontend/parser.cpp get_operator_type + "
                                  "direct dispatch",
                 "prelude": "lib/backend/eshkol_compiler.c scheme_prelude",
+                "quantum_agent_ffi": [
+                    "lib/agent/quantum.esk provide",
+                    "lib/agent/pqc.esk provide",
+                ],
             },
         },
         "counts": {
@@ -452,6 +528,7 @@ def build_manifest():
                                                  if "native_llvm" in b["backends"]),
             "builtins_aot_only": sum(1 for b in builtins
                                      if b["backends"] == ["native_llvm"]),
+            "quantum_agent_ffi_builtins": len(QUANTUM_AGENT_BUILTINS),
             "special_forms": len(special),
             "ast_ops": len(ops),
             "prelude": len(prelude_entries),

--- a/scripts/language_coverage.py
+++ b/scripts/language_coverage.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """language_coverage.py — dynamic language-surface coverage for the exposure engines.
 
-Runs the two generative exposure engines, collects the set of BUILTINS and
+Runs the generative exposure engines plus the opt-in quantum test corpus,
+collects the set of BUILTINS and
 SPECIAL FORMS their generated (and executed) programs actually contain, diffs
 that against the ground-truth manifest (tests/coverage/language_surface.json),
 and reports covered% plus the categorised list of UNCOVERED constructs — the
@@ -15,12 +16,14 @@ completion-oracle runtime_event (see tests/coverage/README.md).
 Engines measured:
   * scripts/gen_generative_corpus.py        (run_generative_differential.py)
   * tests/ad_adversarial/gen_ad_adversarial.py (run_ad_adversarial.sh)
+  * tests/quantum/*.esk                     (quantum-macos CI lane)
 
 Usage:
   python3 scripts/language_coverage.py [--json OUT] [--emit-runtime-event]
 """
 
 import argparse
+import glob
 import json
 import os
 import re
@@ -109,6 +112,24 @@ def gen_ad_adversarial_text():
     return "\n".join(parts)
 
 
+def quantum_test_text():
+    """Return the exact quantum-enabled test corpus exercised by CI.
+
+    These tests require Moonlab and therefore run only in the separate opt-in
+    macOS lane. Their source still participates in this manifest calculation:
+    every file is self-checking and is executed by that lane, matching the
+    source-scan contract used for the deterministic generative engines.
+    """
+    paths = sorted(glob.glob(os.path.join(REPO, "tests", "quantum", "*.esk")))
+    if not paths:
+        raise RuntimeError("no quantum coverage tests found")
+    parts = []
+    for path in paths:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            parts.append(fh.read())
+    return "\n".join(parts), [os.path.relpath(path, REPO) for path in paths]
+
+
 def load_manifest():
     with open(MANIFEST) as fh:
         return json.load(fh)
@@ -137,8 +158,15 @@ def main():
     # internal-only helpers (leading underscore) are not user-facing surface.
     surface = {k: v for k, v in surface.items() if not k.startswith("_")}
 
-    text = gen_generative_corpus_text() + "\n" + gen_ad_adversarial_text()
-    heads = collect_heads(text)
+    quantum_text, quantum_paths = quantum_test_text()
+    engine_text = {
+        "gen_generative_corpus.py": gen_generative_corpus_text(),
+        "gen_ad_adversarial.py": gen_ad_adversarial_text(),
+        "tests/quantum/*.esk (quantum-enabled CI)": quantum_text,
+    }
+    heads_by_engine = {name: collect_heads(text)
+                       for name, text in engine_text.items()}
+    heads = set().union(*heads_by_engine.values())
 
     covered = {k: v for k, v in surface.items() if k in heads}
     uncovered = {k: v for k, v in surface.items() if k not in heads}
@@ -172,7 +200,14 @@ def main():
         "covered_by_category": {k: len(v) for k, v in sorted(cov_by_cat.items())},
         "uncovered_by_category": {k: sorted(v) for k, v in ranked},
         "covered_names": sorted(covered),
-        "engines": ["gen_generative_corpus.py", "gen_ad_adversarial.py"],
+        "engines": list(engine_text),
+        "covered_by_engine": {
+            name: len(set(surface) & engine_heads)
+            for name, engine_heads in heads_by_engine.items()
+        },
+        "quantum_test_paths": quantum_paths,
+        "exercised_by_quantum_tests": sorted(set(surface) &
+                                              heads_by_engine["tests/quantum/*.esk (quantum-enabled CI)"]),
     }
     os.makedirs(os.path.dirname(args.json), exist_ok=True)
     with open(args.json, "w") as fh:

--- a/scripts/run_ad_adversarial.sh
+++ b/scripts/run_ad_adversarial.sh
@@ -29,6 +29,11 @@
 #   --quick   one file per family (fast CI subset); JIT lane only
 #   --no-aot  skip the AOT lane
 #   --regen   re-run the (deterministic) generator before running
+#
+# When ESHKOL_QUANTUM_ENABLED=ON, the harness also runs the fixed
+# tests/quantum/vqe_ad_adversarial.esk probe. It compares Eshkol's custom-VJP
+# gradient of vqe-energy with central finite differences through vqe-energy;
+# ordinary default builds remain Moonlab-free and skip this opt-in probe.
 set -u
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
@@ -157,8 +162,8 @@ count_verdict() { # verdict file mode
         CRASH)  crashed+=1; pyv="FAILED"; BAD="$BAD $f:$mode=$v" ;;
         HANG)   hung+=1;    pyv="FAILED"; BAD="$BAD $f:$mode=$v" ;;
     esac
-    printf '  %-6s tests/ad_adversarial/generated/%s::%s\n' "$v" "$f" "$mode"
-    echo "$pyv tests/ad_adversarial/generated/$f::$mode"
+    printf '  %-6s %s::%s\n' "$v" "$f" "$mode"
+    echo "$pyv $f::$mode"
 }
 
 echo "Generative adversarial AD/FD oracle -> $TRACE_FILE"
@@ -179,7 +184,7 @@ for path in "$GEN_DIR"/ad_adv_*.esk; do
 
     rout=$(run_guarded "$JIT_TIMEOUT" "$ESHKOL_RUN" -r "$path" "$LIBFLAG" 2>&1); rrc=$?
     rv=$(verdict "$rrc" "$rout" "$xc")
-    count_verdict "$rv" "$f" "r"
+    count_verdict "$rv" "tests/ad_adversarial/generated/$f" "r"
     if [ "$rv" = "FAIL" ]; then
         printf '%s\n' "$rout" | grep -E '^FAIL:' | head -6 | sed 's/^/         /'
     fi
@@ -198,9 +203,46 @@ for path in "$GEN_DIR"/ad_adv_*.esk; do
             fi
         fi
         rm -f "$bin"
-        count_verdict "$av" "$f" "aot"
+        count_verdict "$av" "tests/ad_adversarial/generated/$f" "aot"
     fi
 done
+
+# The Moonlab VQE bridge is opt-in. Keep the default adversarial sweep exactly
+# dependency-free, but make a quantum-enabled build expose the same custom-VJP
+# path to the oracle's JIT and AOT verdict machinery.
+if [ "${ESHKOL_QUANTUM_ENABLED:-OFF}" = "ON" ]; then
+    quantum_path="$REPO_ROOT/tests/quantum/vqe_ad_adversarial.esk"
+    quantum_label="tests/quantum/$(basename "$quantum_path")"
+    quantum_base="${quantum_label##*/}"
+    quantum_base="${quantum_base%.esk}"
+    echo "Running opt-in quantum VQE AD/FD probe"
+
+    qout=$(run_guarded "$JIT_TIMEOUT" "$ESHKOL_RUN" -r "$quantum_path" "$LIBFLAG" 2>&1); qrc=$?
+    qv=$(verdict "$qrc" "$qout" 0)
+    count_verdict "$qv" "$quantum_label" "r"
+    if [ "$qv" = "FAIL" ]; then
+        printf '%s\n' "$qout" | grep -E '^FAIL:' | head -6 | sed 's/^/         /'
+    fi
+
+    if [ "$DO_AOT" -eq 1 ]; then
+        qbin="${TMPDIR:-/tmp}/ad_adv_${quantum_base}.bin"; rm -f "$qbin"
+        qcout=$(run_guarded "$AOT_COMPILE_TIMEOUT" "$ESHKOL_RUN" "$quantum_path" "$LIBFLAG" -o "$qbin" 2>&1); qcrc=$?
+        if [ "$qcrc" -ne 0 ] || [ ! -x "$qbin" ] || printf '%s' "$qcout" | grep -qE \
+            "Failed to generate LLVM IR|LLVM module verification failed"; then
+            if [ "$qcrc" -eq 142 ]; then qav=HANG; else qav=CRASH; fi
+        else
+            qaout=$(run_guarded "$AOT_RUN_TIMEOUT" "$qbin" 2>&1); qarc=$?
+            qav=$(verdict "$qarc" "$qaout" 0)
+            if [ "$qav" = "FAIL" ]; then
+                printf '%s\n' "$qaout" | grep -E '^FAIL:' | head -6 | sed 's/^/         /'
+            fi
+        fi
+        rm -f "$qbin"
+        count_verdict "$qav" "$quantum_label" "aot"
+    fi
+else
+    echo "Skipping quantum VQE AD/FD probe (ESHKOL_QUANTUM_ENABLED is not ON)"
+fi
 
 echo
 echo "ad_adversarial summary: total=$total passed=$passed xknown=$xknown failed=$failed crashed=$crashed hung=$hung"

--- a/tests/coverage/README.md
+++ b/tests/coverage/README.md
@@ -9,7 +9,7 @@ generative exposure engines actually exercise, names the gap, and turns
 
 | File | Producer | What it is |
 |---|---|---|
-| `language_surface.json` | `scripts/gen_language_surface.py` | Ground-truth manifest: every builtin, special form, AST op, and prelude fn, each categorised by risk. Extracted from source — never hand-maintained. |
+| `language_surface.json` | `scripts/gen_language_surface.py` | Ground-truth manifest: every core builtin, tracked Agent FFI API, special form, AST op, and prelude fn, each categorised by risk. Extracted from source — never hand-maintained. |
 | `coverage_run.json` | `scripts/language_coverage.py` | Per-run sidecar: covered / total, covered fraction, covered + uncovered names by category. |
 | `coverage_gap.md` | analysis | Human-readable gap report ranked by silent-wrong risk. |
 
@@ -39,6 +39,9 @@ silently drift from the compiler:
    (keyword → `eshkol_op_t`) plus the directly-dispatched forms
    (`begin`, `define-library`, `delay`, `named-let`, ...), and the
    `eshkol_op_t` enum from `inc/eshkol/eshkol.h`.
+5. **Tracked Agent FFI APIs** — the Moonlab `provide` surfaces in
+   `lib/agent/quantum.esk` and `lib/agent/pqc.esk`. These entries are marked
+   `agent_ffi`, not falsely attributed to the core VM/native builtin tables.
 
 Each builtin records which backend(s) register it (`native`, `vm`,
 `native_llvm`) so a construct that exists in only one backend is visible.
@@ -47,10 +50,12 @@ Each builtin records which backend(s) register it (`native`, `vm`,
 
 `language_coverage.py` is the "ICC tracks the language dynamically" mechanism:
 
-1. Import and run both engines in-process:
+1. Import and run both generative engines in-process, and read the quantum
+   acceptance corpus that the opt-in `quantum-macos` CI lane compiles and runs:
    `gen_generative_corpus.generate_programs()` and
    `gen_ad_adversarial.Gen().generate()` (plus their in-language preludes,
-   which are compiled and executed as part of every program).
+   which are compiled and executed as part of every program), plus every
+   `tests/quantum/*.esk` file.
 2. Scan the concatenated generated source with a small s-expression head
    collector: the symbol immediately following each `(` is an
    application/operator head, and the reader macros `'` `` ` `` `,` `,@` and
@@ -65,7 +70,8 @@ The head-collector reads the generated *source*, which for these engines is
 exactly what gets compiled and run (the generators emit closed, total programs;
 nothing is dead). This needs no compiler changes and no execution, so it runs
 in CI in milliseconds and is engine-agnostic — any new generator is measured by
-adding one `gen_<engine>_text()` accessor.
+adding one source accessor. The sidecar records `exercised_by_quantum_tests`
+separately so Moonlab-only coverage remains auditable.
 
 ### Upgrade path: true execution-time instrumentation
 

--- a/tests/coverage/language_surface.json
+++ b/tests/coverage/language_surface.json
@@ -6,22 +6,27 @@
       "vm_builtins": "lib/backend/eshkol_vm.c BUILTINS[]",
       "ast_ops": "inc/eshkol/eshkol.h eshkol_op_t",
       "special_forms": "lib/frontend/parser.cpp get_operator_type + direct dispatch",
-      "prelude": "lib/backend/eshkol_compiler.c scheme_prelude"
+      "prelude": "lib/backend/eshkol_compiler.c scheme_prelude",
+      "quantum_agent_ffi": [
+        "lib/agent/quantum.esk provide",
+        "lib/agent/pqc.esk provide"
+      ]
     }
   },
   "counts": {
-    "builtins_total": 958,
+    "builtins_total": 985,
     "builtins_in_native_closure_table": 427,
-    "builtins_in_vm_table": 637,
-    "builtins_in_llvm_aot_dispatch": 733,
-    "builtins_aot_only": 299,
+    "builtins_in_vm_table": 639,
+    "builtins_in_llvm_aot_dispatch": 737,
+    "builtins_aot_only": 302,
+    "quantum_agent_ffi_builtins": 22,
     "special_forms": 116,
     "ast_ops": 112,
     "prelude": 16
   },
   "builtins_by_category": {
-    "ffi_system": 274,
-    "tensor_ad": 218,
+    "ffi_system": 292,
+    "tensor_ad": 222,
     "numeric": 86,
     "predicate": 70,
     "geometry": 61,
@@ -32,8 +37,8 @@
     "vector": 23,
     "hash": 22,
     "higher_order": 14,
+    "misc": 13,
     "misc_core": 13,
-    "misc": 8,
     "control_flow": 5
   },
   "special_forms_by_category": {
@@ -293,6 +298,33 @@
         "native_llvm"
       ],
       "category": "numeric"
+    },
+    {
+      "name": "__eshkol_parameter_convert",
+      "ids": [],
+      "arity": null,
+      "backends": [
+        "native_llvm"
+      ],
+      "category": "misc"
+    },
+    {
+      "name": "__eshkol_parameter_pop",
+      "ids": [],
+      "arity": null,
+      "backends": [
+        "native_llvm"
+      ],
+      "category": "misc"
+    },
+    {
+      "name": "__eshkol_parameter_push",
+      "ids": [],
+      "arity": null,
+      "backends": [
+        "native_llvm"
+      ],
+      "category": "misc"
     },
     {
       "name": "_atan1",
@@ -6873,10 +6905,24 @@
       "category": "geometry"
     },
     {
-      "name": "parameter?",
-      "ids": [],
-      "arity": null,
+      "name": "parameter-ref",
+      "ids": [
+        701
+      ],
+      "arity": 1,
       "backends": [
+        "vm"
+      ],
+      "category": "misc"
+    },
+    {
+      "name": "parameter?",
+      "ids": [
+        704
+      ],
+      "arity": 1,
+      "backends": [
+        "vm",
         "native_llvm"
       ],
       "category": "predicate"
@@ -10572,6 +10618,15 @@
       "category": "ffi_system"
     },
     {
+      "name": "vqe-energy-primitive",
+      "ids": [],
+      "arity": null,
+      "backends": [
+        "native_llvm"
+      ],
+      "category": "misc"
+    },
+    {
       "name": "vref",
       "ids": [
         -1
@@ -11019,6 +11074,226 @@
         "native_llvm"
       ],
       "category": "tensor_ad"
+    },
+    {
+      "name": "apply-cnot",
+      "ids": [],
+      "arity": 3,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "apply-hadamard",
+      "ids": [],
+      "arity": 2,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "apply-pauli-x",
+      "ids": [],
+      "arity": 2,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "apply-pauli-y",
+      "ids": [],
+      "arity": 2,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "apply-pauli-z",
+      "ids": [],
+      "arity": 2,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "apply-rx",
+      "ids": [],
+      "arity": 3,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "apply-ry",
+      "ids": [],
+      "arity": 3,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "apply-rz",
+      "ids": [],
+      "arity": 3,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "bell-chsh",
+      "ids": [],
+      "arity": 1,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "expectation-z",
+      "ids": [],
+      "arity": 2,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "hamiltonian-exact-ground-energy",
+      "ids": [],
+      "arity": 1,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "tensor_ad",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "make-h2-hamiltonian",
+      "ids": [],
+      "arity": 1,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "make-h2o-hamiltonian",
+      "ids": [],
+      "arity": 0,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "make-lih-hamiltonian",
+      "ids": [],
+      "arity": 1,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "make-quantum-state",
+      "ids": [],
+      "arity": 1,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "measure",
+      "ids": [],
+      "arity": 2,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "mlkem-decaps",
+      "ids": [],
+      "arity": 2,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/pqc.esk"
+    },
+    {
+      "name": "mlkem-encaps",
+      "ids": [],
+      "arity": 1,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/pqc.esk"
+    },
+    {
+      "name": "mlkem-keygen",
+      "ids": [],
+      "arity": 1,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "ffi_system",
+      "source": "lib/agent/pqc.esk"
+    },
+    {
+      "name": "vqe-energy",
+      "ids": [],
+      "arity": 2,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "tensor_ad",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "vqe-gradient",
+      "ids": [],
+      "arity": 2,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "tensor_ad",
+      "source": "lib/agent/quantum.esk"
+    },
+    {
+      "name": "vqe-optimize",
+      "ids": [],
+      "arity": 2,
+      "backends": [
+        "agent_ffi"
+      ],
+      "category": "tensor_ad",
+      "source": "lib/agent/quantum.esk"
     }
   ],
   "special_forms": [

--- a/tests/quantum/bell_chsh_test.esk
+++ b/tests/quantum/bell_chsh_test.esk
@@ -1,0 +1,20 @@
+;; Stage S5 ON-path Bell/CHSH acceptance gate. Requires
+;; -DESHKOL_QUANTUM_ENABLED=ON.
+;;
+;; A local hidden-variable theory satisfies |S| <= 2.  Moonlab's ideal Bell
+;; state should approach 2*sqrt(2) ~= 2.828.  The lower bound proves a genuine
+;; quantum violation; the upper bound catches a malformed normalization.
+
+(require agent.quantum)
+
+(define shots 16000)
+(define s (bell-chsh shots))
+(define passed (and (> s 2.4) (<= s 2.95)))
+
+(display "CHSH S over ") (display shots) (display " shots: ")
+(display s) (newline)
+
+(display "bell_chsh_test: ")
+(if passed
+    (begin (display "PASS (2.4 < S <= 2.95)") (newline) (exit 0))
+    (begin (display "FAIL (expected 2.4 < S <= 2.95)") (newline) (exit 1)))

--- a/tests/quantum/quantum_smoke_test.esk
+++ b/tests/quantum/quantum_smoke_test.esk
@@ -18,8 +18,10 @@
         correlated
         (loop (+ i 1) (+ correlated (if (bell-correlated?) 1 0))))))
 
-(let* ((n 200)
-       (ok (run-bell n)))
+(define n 200)
+(define ok (run-bell n))
+
+(begin
   (display "Bell-pair correlation over ") (display n) (display " shots: ")
   (display ok) (display "/") (display n)
   (display (if (= ok n) "  PASS" "  FAIL")) (newline))
@@ -27,3 +29,9 @@
 ;; Honest quantum-random: should now be sourced from Moonlab's Bell-verified QRNG.
 (display "quantum-random sample: ") (display (quantum-random)) (newline)
 (display "quantum-random-int(100): ") (display (quantum-random-int 100)) (newline)
+(display "quantum-random-range(10,20): ") (display (quantum-random-range 10 20)) (newline)
+
+(display "quantum_smoke_test: ")
+(if (= ok n)
+    (begin (display "PASS (Bell 200/200)") (newline) (exit 0))
+    (begin (display "FAIL (Bell correlation was not 200/200)") (newline) (exit 1)))

--- a/tests/quantum/quantum_surface_coverage_test.esk
+++ b/tests/quantum/quantum_surface_coverage_test.esk
@@ -1,0 +1,51 @@
+;; Stage S5 ON-path exercise of the agent.quantum surface that is not covered
+;; by the Bell and VQE acceptance tests. Requires -DESHKOL_QUANTUM_ENABLED=ON.
+
+(require agent.quantum)
+
+(define passed 0)
+(define failed 0)
+
+(define (check label ok)
+  (if ok
+      (begin (set! passed (+ passed 1))
+             (display "PASS: ") (display label) (newline))
+      (begin (set! failed (+ failed 1))
+             (display "FAIL: ") (display label) (newline))))
+
+;; Exercise every state-vector gate in the public surface and ensure the
+;; non-destructive observable remains a physical expectation value.
+(with-quantum-state
+ 1
+ (lambda (st)
+   (apply-hadamard st 0)
+   (apply-pauli-x st 0)
+   (apply-pauli-y st 0)
+   (apply-pauli-z st 0)
+   (apply-rx st 0 0.125)
+   (apply-ry st 0 0.25)
+   (apply-rz st 0 0.5)
+   (let ((z (expectation-z st 0)))
+     (check "single-qubit gate surface and expectation-z"
+            (and (= (quantum-state-num-qubits st) 1)
+                 (<= -1.0 z)
+                 (<= z 1.0))))))
+
+;; Construction and deterministic destruction are the public lifecycle
+;; contract for the larger molecular Hamiltonians. Exact diagonalization of
+;; these systems belongs to dedicated Moonlab VQE workloads, not this fast
+;; language-surface exposure test.
+(with-hamiltonian
+ (make-lih-hamiltonian 1.6)
+ (lambda (ham)
+   (check "LiH Hamiltonian construction" (> ham 0))))
+
+(with-hamiltonian
+ (make-h2o-hamiltonian)
+ (lambda (ham)
+   (check "H2O Hamiltonian construction" (> ham 0))))
+
+(display "quantum_surface_coverage_test: ")
+(if (= failed 0)
+    (begin (display "PASS (") (display passed) (display "/3)") (newline) (exit 0))
+    (begin (display "FAIL (") (display failed) (display " failed)") (newline) (exit 1)))

--- a/tests/quantum/vqe_ad_adversarial.esk
+++ b/tests/quantum/vqe_ad_adversarial.esk
@@ -1,0 +1,80 @@
+;; Stage S5: adversarial AD oracle probe for the Moonlab VQE bridge.
+;; This file is invoked by scripts/run_ad_adversarial.sh only when
+;; ESHKOL_QUANTUM_ENABLED=ON; it is also self-checking when run directly.
+
+(require agent.quantum)
+
+(define passed 0)
+(define failed 0)
+
+(define (check label actual expected tolerance)
+  (let ((error (abs (- actual expected))))
+    (if (< error tolerance)
+        (begin
+          (set! passed (+ passed 1))
+          (display "PASS: ") (display label)
+          (display " error=") (display error) (newline))
+        (begin
+          (set! failed (+ failed 1))
+          (display "FAIL: ") (display label)
+          (display " ad=") (display actual)
+          (display " fd=") (display expected)
+          (display " error=") (display error) (newline)))))
+
+(define (perturb p index delta)
+  (let ((out (make-vector (vector-length p) 0.0)))
+    (let loop ((i 0))
+      (if (< i (vector-length p))
+          (begin
+            (vector-set! out i (if (= i index)
+                                    (+ (vector-ref p i) delta)
+                                    (vector-ref p i)))
+            (loop (+ i 1)))
+          out))))
+
+(define (finite-difference-gradient ham p eps)
+  (let ((out (make-vector (vector-length p) 0.0)))
+    (let loop ((i 0))
+      (if (< i (vector-length p))
+          (begin
+            (vector-set! out i
+              (/ (- (vqe-energy ham (perturb p i eps))
+                    (vqe-energy ham (perturb p i (- eps))))
+                 (* 2.0 eps)))
+            (loop (+ i 1)))
+          out))))
+
+(define (max-abs-diff left right)
+  (if (not (= (vector-length left) (vector-length right)))
+      1e300
+      (let loop ((i 0) (maximum 0.0))
+        (if (< i (vector-length left))
+            (loop (+ i 1)
+                  (max maximum
+                       (abs (- (vector-ref left i) (vector-ref right i)))))
+            maximum))))
+
+(define (probe ham label params)
+  (let* ((ad-gradient (gradient (lambda (p) (vqe-energy ham p)) params))
+         (fd-gradient (finite-difference-gradient ham params 1e-5))
+         (error (max-abs-diff ad-gradient fd-gradient)))
+    (check label error 0.0 1e-4)))
+
+;; Three separated points make a zero/custom-VJP regression visible without
+;; trusting Moonlab's native gradient as the oracle. The central difference is
+;; computed entirely through vqe-energy, the exact path under test.
+(with-hamiltonian
+ (make-h2-hamiltonian 0.735)
+ (lambda (ham)
+   (probe ham "quantum.vqe_ad_fd.theta-a" (vector 0.1 0.2 0.3 0.4))
+   (probe ham "quantum.vqe_ad_fd.theta-b" (vector -0.6 0.15 0.8 -0.25))
+   (probe ham "quantum.vqe_ad_fd.theta-c" (vector 1.1 -0.9 0.45 0.7))))
+
+(display "vqe_ad_adversarial: ")
+(if (= failed 0)
+    (begin (display "PASS (") (display passed) (display "/3)") (newline))
+    (begin (display "FAIL (") (display failed) (display " failed)") (newline)))
+(display "Passed: ") (display passed) (newline)
+(display "Failed: ") (display failed) (newline)
+(display "Xknown: 0") (newline)
+(if (= failed 0) (exit 0) (exit 1))


### PR DESCRIPTION
Stage 5 — the capstone. Puts the quantum surface under Eshkol's always-on bug-exposure regime: CI, a Bell-inequality acceptance gate, coverage tracking, an architecture invariant, and the adversarial AD oracle. Completes the S1–S5 Moonlab quantum trajectory.

## What this adds
1. **Bell-CHSH acceptance gate** — `(bell-chsh …)` binds Moonlab's CHSH experiment; `tests/quantum/bell_chsh_test.esk` asserts the measured S sits in the quantum regime (S > 2.4, ceiling 2.95; ideal 2√2 ≈ 2.828). Verified locally: **S = 2.858 over 16,000 shots**. This proves the integration yields genuine quantum correlations, not a classical (S ≤ 2) fake.
2. **Gated quantum CI lane** — an advisory `quantum-macos` job builds with `ESHKOL_QUANTUM_ENABLED=ON` (Moonlab links cleanly on macOS), runs every `tests/quantum/*.esk`, and runs the opt-in AD oracle. Advisory: it does not gate the default required CI (quantum is opt-in), but it *runs*.
3. **Coverage manifest** — the 22 `agent.quantum` / `agent.pqc` builtins (state/gates/measurement, `bell-chsh`, H2/LiH/H2O + VQE, ML-KEM) plus `quantum-random`/`-int`/`-range` are recorded as exercised. Coverage 137/1057 = **13.0%**.
4. **ICC architecture invariant** — a `quantum-backend` component + `INV-quantum-random-routes-to-moonlab-qrng` asserting `quantum-random` is sourced from Moonlab's Bell-verified QRNG (not a bare PRNG) when enabled.
5. **Adversarial AD oracle probe** — `tests/quantum/vqe_ad_adversarial.esk` cross-checks the AD-through-VQE gradient (`AD_NODE_CUSTOM`) against finite differences inside `run_ad_adversarial.sh` (gated). FD error 4.75e-11.

## Verification (independent build)
- ON-path: all 7 `tests/quantum/*.esk` PASS — bell_chsh (S=2.858), pqc_mlkem 9/9, quantum_smoke Bell 200/200, surface_coverage 3/3, vqe_ad 3/3, vqe_ad_adversarial 0-failed, vqe H2 PASS.
- OFF-default unchanged: memory 15/15, autodiff 54/54, `check_wasm_imports.py` OK (no new env imports).

Closes the quantum trajectory: **S1** gates/measurement/honest-QRNG → **S2** VQE → **S3** differentiate-through-circuits (`AD_NODE_CUSTOM`) → **S4** ML-KEM → **S5** the CI/coverage/arch/oracle harness.
