### PR TITLE
fix(ci): validate variable paths at point of use

### DIFF
--- a/scripts/run_ad_adversarial.sh
+++ b/scripts/run_ad_adversarial.sh
@@ -116,7 +116,7 @@ emit_event() {
     en=$(json_escape "$name"); ev=$(json_escape "$value")
     es=$(json_escape "$snippet")
     printf '{"kind":"ad_adversarial","name":"%s","value":"%s","snippet":"%s","confidence":0.95}\n' \
-        "$en" "$ev" "$es" >> "$TRACE_FILE"
+        "$en" "$ev" "$es" >> "${TRACE_FILE:?}"
 }
 
 # classify a completed run: args rc out xc -> PASS|FAIL|XKNOWN|CRASH|HANG

--- a/scripts/run_ad_oracle.sh
+++ b/scripts/run_ad_oracle.sh
@@ -90,7 +90,7 @@ emit_event() {
     esc_value=$(json_escape "$value")
     esc_snippet=$(json_escape "$snippet")
     printf '{"kind":"ad_oracle","name":"%s","value":"%s","snippet":"%s","confidence":0.95}\n' \
-        "$esc_name" "$esc_value" "$esc_snippet" >> "$TRACE_FILE"
+        "$esc_name" "$esc_value" "$esc_snippet" >> "${TRACE_FILE:?}"
 }
 
 # classify a completed (non-timeout) run of one probe file

--- a/scripts/run_dbsp_gate.sh
+++ b/scripts/run_dbsp_gate.sh
@@ -59,7 +59,7 @@ else
     echo "AOT: FAIL (compile)"
     FAILURES=$((FAILURES + 1))
 fi
-rm -f "$AOT_BIN"
+rm -f -- "${AOT_BIN:?}"
 
 echo ""
 echo "========================================="

--- a/scripts/run_differential.sh
+++ b/scripts/run_differential.sh
@@ -103,7 +103,7 @@ json_escape() {
 
 emit_event() { # name value snippet
     printf '{"kind":"differential_smoke","name":"%s","value":"%s","snippet":"%s","confidence":0.95}\n' \
-        "$(json_escape "$1")" "$(json_escape "$2")" "$(json_escape "$3")" >> "$TRACE_FILE"
+        "$(json_escape "$1")" "$(json_escape "$2")" "$(json_escape "$3")" >> "${TRACE_FILE:?}"
 }
 
 # Normalize captured stdout: strip harness/compiler noise lines, then drop

--- a/scripts/run_edge_matrix.sh
+++ b/scripts/run_edge_matrix.sh
@@ -144,7 +144,7 @@ WORK_LIST="$WORK_DIR/worklist"
 shopt -s nullglob
 for f in "$GEN_DIR"/$FILTER; do
     for mode in $MODES; do
-        printf '%s\n%s\n' "$f" "$mode" >> "$WORK_LIST"
+        printf '%s\n%s\n' "$f" "$mode" >> "${WORK_LIST:?}"
     done
 done
 shopt -u nullglob
@@ -161,12 +161,12 @@ xargs -n2 -P "$JOBS" env EDGE_MATRIX_WORKER=1 bash "$0" < "$WORK_LIST"
 # ---------------------------------------------------------------------------
 # Aggregate, emit traces + summary
 # ---------------------------------------------------------------------------
-: > "$TRACE_FILE"
+: > "${TRACE_FILE:?}"
 emit_event() {   # name value snippet
     local esc
     esc=$(printf '%s' "$3" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
     printf '{"kind":"edge_matrix","name":"%s","value":"%s","snippet":"%s","confidence":0.95}\n' \
-        "$1" "$2" "$esc" >> "$TRACE_FILE"
+        "$1" "$2" "$esc" >> "${TRACE_FILE:?}"
 }
 
 is_known_failure() {  # base mode

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -84,7 +84,7 @@ import json, sys
 print(json.dumps({"kind": "eshkol_smoke", "name": sys.argv[1],
                   "value": sys.argv[2], "snippet": sys.argv[3],
                   "confidence": 0.95}, ensure_ascii=False))
-' "$probe_id" "$status" "$snippet" >> "$TRACE_FILE"
+' "$probe_id" "$status" "$snippet" >> "${TRACE_FILE:?}"
 }
 
 PROBE_TOTAL=0

--- a/scripts/run_reference_differential.sh
+++ b/scripts/run_reference_differential.sh
@@ -150,7 +150,7 @@ emit_trace() {  # emit_trace <name> <value> <snippet>
     local name="$1" value="$2" snippet="$3"
     local esnip; esnip="$(printf '%s' "$snippet" | json_escape)"
     printf '{"kind":"reference_diff","name":"%s","value":"%s","snippet":%s,"confidence":0.95}\n' \
-        "$name" "$value" "$esnip" >> "$TRACE_FILE"
+        "$name" "$value" "$esnip" >> "${TRACE_FILE:?}"
 }
 
 # ---- run all programs -----------------------------------------------------
@@ -172,7 +172,7 @@ for scm in "$CORPUS_DIR"/*.scm; do
     # Program body (strip our leading ';;' header comment lines? keep them —
     # both engines ignore comments). Build the two engine sources.
     cp "$scm" "$ESK_SRC"
-    { printf '%s\n' "$REF_PROLOGUE"; cat "$scm"; } > "$SCM_SRC"
+    { printf '%s\n' "$REF_PROLOGUE"; cat "$scm"; } > "${SCM_SRC:?}"
 
     # --- reference ---
     ref_out="$(run_guarded "$TIMEOUT_SECS" "$REF_BIN" "$SCM_SRC" 2>/dev/null)"; ref_ec=$?
@@ -183,7 +183,7 @@ for scm in "$CORPUS_DIR"/*.scm; do
     jit_norm="$(printf '%s' "$jit_out" | $NORMALIZE)"
 
     # --- eshkol AOT (single reused binary, deleted after) ---
-    rm -f "$AOT_BIN"
+    rm -f -- "${AOT_BIN:?}"
     aot_comp_err="$(run_guarded "$TIMEOUT_SECS" "$ESHKOL_RUN" -O0 "$ESK_SRC" -o "$AOT_BIN" 2>&1)"; aot_comp_ec=$?
     if [ "$aot_comp_ec" -eq 0 ] && [ -x "$AOT_BIN" ]; then
         aot_out="$(run_guarded "$TIMEOUT_SECS" "$AOT_BIN" 2>/dev/null)"; aot_ec=$?
@@ -191,7 +191,7 @@ for scm in "$CORPUS_DIR"/*.scm; do
         aot_out=""; aot_ec=$aot_comp_ec
     fi
     aot_norm="$(printf '%s' "$aot_out" | $NORMALIZE)"
-    rm -f "$AOT_BIN"
+    rm -f -- "${AOT_BIN:?}"
 
     ref_ok=0; [ "$ref_ec" -eq 0 ] && ref_ok=1
     jit_ok=0; [ "$jit_ec" -eq 0 ] && jit_ok=1

--- a/scripts/run_repl_tests.sh
+++ b/scripts/run_repl_tests.sh
@@ -21,7 +21,7 @@ else
 fi
 
 OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/eshkol-repl-test.XXXXXX")"
-trap 'rm -f "$OUTPUT_FILE"' EXIT
+trap 'rm -f -- "${OUTPUT_FILE:?}"' EXIT
 
 
 # Colors for output
@@ -76,11 +76,11 @@ for test_file in tests/repl/*.esk; do
     set +e
     if command -v timeout > /dev/null 2>&1; then
         # Linux has timeout
-        { cat "$test_file"; echo ""; echo ":quit"; } | timeout "$REPL_TEST_TIMEOUT" "$REPL_BIN" > "$OUTPUT_FILE" 2>&1
+        { cat "$test_file"; echo ""; echo ":quit"; } | timeout "$REPL_TEST_TIMEOUT" "$REPL_BIN" > "${OUTPUT_FILE:?}" 2>&1
         EXIT_CODE=$?
     else
         # macOS - run directly (no timeout needed, tests are fast)
-        { cat "$test_file"; echo ""; echo ":quit"; } | "$REPL_BIN" > "$OUTPUT_FILE" 2>&1
+        { cat "$test_file"; echo ""; echo ":quit"; } | "$REPL_BIN" > "${OUTPUT_FILE:?}" 2>&1
         EXIT_CODE=$?
     fi
     set -e

--- a/scripts/run_stress.sh
+++ b/scripts/run_stress.sh
@@ -90,7 +90,7 @@ json_escape() {
 
 emit_event() { # name value snippet
     printf '{"kind":"stress_smoke","name":"%s","value":"%s","snippet":"%s","confidence":0.95}\n' \
-        "$(json_escape "$1")" "$(json_escape "$2")" "$(json_escape "$3")" >> "$TRACE_FILE"
+        "$(json_escape "$1")" "$(json_escape "$2")" "$(json_escape "$3")" >> "${TRACE_FILE:?}"
 }
 
 # run_budgeted <timeout_s> <cmd...>
@@ -108,7 +108,7 @@ run_budgeted() {
     # the program output for diagnosis.
     # </dev/null: keep the budgets.tsv read-loop's stdin away from programs.
     /usr/bin/time -l perl -e 'my $s=shift; alarm $s; exec @ARGV; die "exec failed: $!\n"' \
-        "$tmo" "$@" > "$RB_OUT_FILE" 2> "$RB_TIME_FILE" < /dev/null
+        "$tmo" "$@" > "${RB_OUT_FILE:?}" 2> "${RB_TIME_FILE:?}" < /dev/null
     RB_RC=$?
     t1=$(perl -MTime::HiRes=time -e 'printf "%.3f", time')
     RB_WALL_S=$(perl -e 'printf "%.2f", $ARGV[1]-$ARGV[0]' "$t0" "$t1")
@@ -117,7 +117,7 @@ run_budgeted() {
     # program stderr (compile errors etc.) is interleaved into time file; keep
     # the non-rusage part with the output for the failure snippet.
     grep -vE 'real .*user .*sys|maximum resident set size|average .* size|page reclaims|page faults|swaps|block .* operations|messages (sent|received)|signals received|context switches|instructions retired|cycles elapsed|peak memory footprint' \
-        "$RB_TIME_FILE" >> "$RB_OUT_FILE" 2>/dev/null || true
+        "$RB_TIME_FILE" >> "${RB_OUT_FILE:?}" 2>/dev/null || true
 }
 
 # classify <rc> <wall_s> <rss_mb> <timeout_s> <rss_ceiling_mb> <expect> <out_file>

--- a/scripts/run_tensor_collection_depth.sh
+++ b/scripts/run_tensor_collection_depth.sh
@@ -88,7 +88,7 @@ WORK_BIN="$ARTIFACT_DIR/aot_work_bin"
 RESULTS="$(mktemp "${TMPDIR:-/tmp}/tcd_results.XXXXXX")"
 : "${WORK_BIN:?WORK_BIN must be set}"
 : "${RESULTS:?RESULTS must be set}"
-cleanup() { rm -f "$WORK_BIN" "$RESULTS"; }
+cleanup() { rm -f -- "${WORK_BIN:?}" "${RESULTS:?}"; }
 trap cleanup EXIT
 
 check_disk_cap() {
@@ -97,7 +97,7 @@ check_disk_cap() {
     [ -z "$used_mb" ] && used_mb=0
     if [ "$used_mb" -gt "$ARTIFACT_CAP_MB" ]; then
         echo "run_tensor_collection_depth.sh: artifact dir ${used_mb}MB > cap ${ARTIFACT_CAP_MB}MB — aborting." >&2
-        rm -f "$WORK_BIN"; rm -rf "$LOG_DIR"; exit 4
+        rm -f -- "${WORK_BIN:?}"; rm -rf -- "${LOG_DIR:?}"; exit 4
     fi
 }
 
@@ -112,7 +112,7 @@ json_escape() {
 }
 emit_event() { # name value family depth axis detail
     printf '{"kind":"tensor_collection_depth","name":"%s","value":"%s","family":"%s","depth":%s,"axis":"%s","detail":"%s"}\n' \
-        "$1" "$2" "$3" "$4" "$5" "$(json_escape "$6")" >> "$TRACE_FILE"
+        "$1" "$2" "$3" "$4" "$5" "$(json_escape "$6")" >> "${TRACE_FILE:?}"
 }
 
 # run one axis; echoes "STATUS|value" where STATUS in RAN|LIMIT and value is the
@@ -127,13 +127,13 @@ run_axis() {
             ;;
         aot-O0|aot-O2)
             local olvl="${axis#aot-O}"
-            rm -f "$WORK_BIN"
+            rm -f -- "${WORK_BIN:?}"
             if ! run_to "$TIMEOUT" "$ESHKOL_RUN" -O "$olvl" "$main" -o "$WORK_BIN" >"$errlog" 2>&1; then
                 echo "LIMIT|"; return
             fi
             [ -x "$WORK_BIN" ] || { echo "LIMIT|"; return; }
             out="$(run_to "$TIMEOUT" "$WORK_BIN" 2>"$errlog")"; ec=$?
-            rm -f "$WORK_BIN"
+            rm -f -- "${WORK_BIN:?}"
             ;;
     esac
     if [ "$ec" -eq 124 ]; then echo "LIMIT|"; return; fi
@@ -175,7 +175,7 @@ while IFS= read -r line; do
         if [ "$st" = "RAN" ] && [ "$val" = "$expected" ]; then axcls="PASS"
         elif [ "$st" = "RAN" ]; then axcls="WRONG"
         else axcls="LIMIT"; fi
-        printf 'AX\t%s\t%s\t%s\t%s\t%s\n' "$family" "$axis" "$depth" "$axcls" "$val" >> "$RESULTS"
+        printf 'AX\t%s\t%s\t%s\t%s\t%s\n' "$family" "$axis" "$depth" "$axcls" "$val" >> "${RESULTS:?}"
     done
 
     # combined classification across axes
@@ -194,7 +194,7 @@ while IFS= read -r line; do
     fi
 
     n_total=$((n_total+1))
-    printf 'CB\t%s\t%s\t%s\t%s\n' "$family" "$depth" "$cls" "$detail" >> "$RESULTS"
+    printf 'CB\t%s\t%s\t%s\t%s\n' "$family" "$depth" "$cls" "$detail" >> "${RESULTS:?}"
     printf '%s' "$AXLINES" | while IFS='|' read -r axis st val; do
         [ -z "$axis" ] && continue
         emit_event "tcd_case" "$cls" "$family" "$depth" "$axis" "axis=$st:$val exp=$expected"

--- a/scripts/run_v1_3_readiness.sh
+++ b/scripts/run_v1_3_readiness.sh
@@ -15,7 +15,7 @@ ARCH_MODEL="${ARCH_MODEL:-.icc/architecture-model.yaml}"
 ARCH_TRACE_GLOB="${ARCH_TRACE_GLOB:-.icc/runtime-traces-oracle-view/*architecture-model-verify-*.jsonl}"
 READINESS_JSON="$(mktemp "${TMPDIR:-/tmp}/eshkol-v13-readiness.XXXXXX.json")"
 : "${READINESS_JSON:?READINESS_JSON must be set}"
-trap 'rm -f "$READINESS_JSON"' EXIT
+trap 'rm -f -- "${READINESS_JSON:?}"' EXIT
 
 BUILD_DIR="${BUILD_DIR:-build}" TRACE_DIR="$TRACE_DIR" \
   scripts/run_mono_equiv_ad_taylor_gate.sh
@@ -36,7 +36,7 @@ scripts/run_icc_smoke.sh
   --target v1.3-evolve \
   --trace-dir "$TRACE_DIR" \
   --trace-latest "$ARCH_TRACE_GLOB" \
-  --format json > "$READINESS_JSON"
+  --format json > "${READINESS_JSON:?}"
 
 "$ICC_BIN" readiness \
   --repo "$ICC_REPO" \

--- a/scripts/run_vm_parity.sh
+++ b/scripts/run_vm_parity.sh
@@ -98,7 +98,7 @@ emit_test_result() { # name PASS|FAIL snippet
     local passed=false
     [ "$2" = "PASS" ] && passed=true
     printf '{"kind":"test_result","name":"%s","value":{"passed":%s,"summary":"%s"},"timestamp":%s}\n' \
-        "$(json_escape "$1")" "$passed" "$(json_escape "$3")" "$(date +%s)" >> "$TRACE_FILE"
+        "$(json_escape "$1")" "$passed" "$(json_escape "$3")" "$(date +%s)" >> "${TRACE_FILE:?}"
 }
 
 pass=0; fail=0

--- a/scripts/run_xla_tests.sh
+++ b/scripts/run_xla_tests.sh
@@ -14,7 +14,7 @@ cd "$REPO_ROOT"
 TRACE_DIR=${ICC_TRACE_DIR:-"$REPO_ROOT/scripts/icc_traces"}
 XLA_TARGET_TRACE="$TRACE_DIR/xla_target_queries.jsonl"
 mkdir -p "$TRACE_DIR"
-: > "$XLA_TARGET_TRACE"
+: > "${XLA_TARGET_TRACE:?}"
 
 emit_xla_target_query_trace() {
     python3 -c '
@@ -29,7 +29,7 @@ print(json.dumps({
     ),
     "confidence": 0.95,
 }))
-' >> "$XLA_TARGET_TRACE"
+' >> "${XLA_TARGET_TRACE:?}"
 }
 
 # Colors for output

--- a/scripts/test_run_sicp_smoke_gate.sh
+++ b/scripts/test_run_sicp_smoke_gate.sh
@@ -105,7 +105,7 @@ run_smoke() {
         BUILD_DIR="$RUN_BUILD_DIR" \
             ESHKOL_JIT_CACHE_DIR="$WORK/jit-cache-$label" \
             LC_ALL=C LC_CTYPE=C LANG=C \
-            "$FAKE/scripts/run_sicp_smoke.sh" "$@" >"$LAST_OUT" 2>&1
+            "$FAKE/scripts/run_sicp_smoke.sh" "$@" >"${LAST_OUT:?}" 2>&1
     else
         # Isolate the fake repository from a BUILD_DIR exported by the outer
         # aggregate harness.  This branch is specifically the default-build
@@ -113,7 +113,7 @@ run_smoke() {
         BUILD_DIR=build \
             ESHKOL_JIT_CACHE_DIR="$WORK/jit-cache-$label" \
             LC_ALL=C LC_CTYPE=C LANG=C \
-            "$FAKE/scripts/run_sicp_smoke.sh" "$@" >"$LAST_OUT" 2>&1
+            "$FAKE/scripts/run_sicp_smoke.sh" "$@" >"${LAST_OUT:?}" 2>&1
     fi
     LAST_RC=$?
 }

--- a/tests/gpu/gpu_correctness_gate.sh
+++ b/tests/gpu/gpu_correctness_gate.sh
@@ -74,7 +74,7 @@ emit_trace() {  # emit_trace <value> <snippet>
         esnip="\"$esnip\""
     fi
     printf '{"kind":"gpu_execution","name":"gpu_execution_gate","value":"%s","snippet":%s,"confidence":0.95}\n' \
-        "$value" "$esnip" >> "$TRACE_FILE"
+        "$value" "$esnip" >> "${TRACE_FILE:?}"
 }
 
 log()  { printf '%s\n' "$*"; }
@@ -340,7 +340,7 @@ log "Running GPU-enabled binary with dispatch forced..."
 GPU_STDOUT="$WORK_DIR/gpu_stdout.txt"
 GPU_STDERR="$WORK_DIR/gpu_stderr.txt"
 ESHKOL_VERBOSE=1 ESHKOL_GPU_VERBOSE=1 ESHKOL_GPU_THRESHOLD=1 ESHKOL_SF64_KERNEL=legacy \
-    "$GPU_PAYLOAD" > "$GPU_STDOUT" 2> "$GPU_STDERR"
+    "$GPU_PAYLOAD" > "${GPU_STDOUT:?}" 2> "${GPU_STDERR:?}"
 gpu_run_rc=$?
 [ "$gpu_run_rc" -eq 0 ] || fail "GPU binary crashed/exited $gpu_run_rc — stderr: $(tail -n 40 "$GPU_STDERR")"
 grep -q "^GATE-DONE$" "$GPU_STDOUT" || fail "GPU run did not reach GATE-DONE — output: $(cat "$GPU_STDOUT")"
@@ -355,7 +355,7 @@ fi
 log ""
 log "Running CPU-only reference binary..."
 CPU_STDOUT="$WORK_DIR/cpu_stdout.txt"
-"$CPU_PAYLOAD" > "$CPU_STDOUT" 2>"$WORK_DIR/cpu_stderr.txt"
+"$CPU_PAYLOAD" > "${CPU_STDOUT:?}" 2>"${WORK_DIR:?}/cpu_stderr.txt"
 cpu_run_rc=$?
 [ "$cpu_run_rc" -eq 0 ] || fail "CPU-reference binary crashed/exited $cpu_run_rc"
 grep -q "^GATE-DONE$" "$CPU_STDOUT" || fail "CPU run did not reach GATE-DONE"

--- a/tests/memory/region_evac_subtype_coverage_test.sh
+++ b/tests/memory/region_evac_subtype_coverage_test.sh
@@ -117,12 +117,12 @@ chmod +x "$BIN"
 # interior pointer crashes at a 0xCB.. address rather than passing by luck.
 if [ "$TIME_MODE" = "bsd" ]; then
     ( cd "$WORK" && ESHKOL_ARENA_POISON=1 /usr/bin/time -l perl -e 'my $s=shift; alarm $s; exec @ARGV; die "exec failed: $!\n"' \
-        "$TIMEOUT_S" "$BIN" ) > "$RUN_OUT" 2> "$TIME_LOG"
+        "$TIMEOUT_S" "$BIN" ) > "${RUN_OUT:?}" 2> "${TIME_LOG:?}"
     RUN_RC=$?
     RSS_MB=$(awk '/maximum resident set size/{printf "%d", $1/1048576}' "$TIME_LOG")
 else
     ( cd "$WORK" && ESHKOL_ARENA_POISON=1 /usr/bin/time -v perl -e 'my $s=shift; alarm $s; exec @ARGV; die "exec failed: $!\n"' \
-        "$TIMEOUT_S" "$BIN" ) > "$RUN_OUT" 2> "$TIME_LOG"
+        "$TIMEOUT_S" "$BIN" ) > "${RUN_OUT:?}" 2> "${TIME_LOG:?}"
     RUN_RC=$?
     RSS_MB=$(awk -F: '/Maximum resident set size/{printf "%d", $2/1024}' "$TIME_LOG")
 fi

--- a/tests/memory/region_mutating_loop_flat_rss_test.sh
+++ b/tests/memory/region_mutating_loop_flat_rss_test.sh
@@ -102,12 +102,12 @@ chmod +x "$BIN"
 
 if [ "$TIME_MODE" = "bsd" ]; then
     ( cd "$WORK" && /usr/bin/time -l perl -e 'my $s=shift; alarm $s; exec @ARGV; die "exec failed: $!\n"' \
-        "$TIMEOUT_S" "$BIN" ) > "$RUN_OUT" 2> "$TIME_LOG"
+        "$TIMEOUT_S" "$BIN" ) > "${RUN_OUT:?}" 2> "${TIME_LOG:?}"
     RUN_RC=$?
     RSS_MB=$(awk '/maximum resident set size/{printf "%d", $1/1048576}' "$TIME_LOG")
 else
     ( cd "$WORK" && /usr/bin/time -v perl -e 'my $s=shift; alarm $s; exec @ARGV; die "exec failed: $!\n"' \
-        "$TIMEOUT_S" "$BIN" ) > "$RUN_OUT" 2> "$TIME_LOG"
+        "$TIMEOUT_S" "$BIN" ) > "${RUN_OUT:?}" 2> "${TIME_LOG:?}"
     RUN_RC=$?
     RSS_MB=$(awk -F: '/Maximum resident set size/{printf "%d", $2/1024}' "$TIME_LOG")
 fi


### PR DESCRIPTION
## Summary

- validate every audit-identified variable redirect target before use
- add `--` and non-empty expansion guards to variable-path removals
- preserve all existing test and runtime behavior while preventing empty-path and option-confusion hazards

## Verification

- ICC shell-hardening audit: 0 findings
- ICC pre-commit: PASS, 0 blockers
- ICC strict v1.3-release production audit: PASS, 0 risks
- index quality: 0 blind spots (canonical references/r7rs.pdf excluded only from code-symbol indexing)
- bash syntax: all changed scripts PASS
- SICP smoke gate self-test: PASS
- CTest: 70/70 PASS

This is a focused follow-up to the release hardening in #277. No features or tests are removed or weakened.