### PR TITLE
fix(aot): preserve ELF dependency runpaths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -685,6 +685,93 @@ function(eshkol_resolve_host_link_arg item out_var)
     set(${out_var} "${_eshkol_host_link_arg}" PARENT_SCOPE)
 endfunction()
 
+# AOT-generated ELF executables must be runnable without inheriting the build
+# shell's LD_LIBRARY_PATH. CMake/llvm-config can express shared dependencies
+# either as `-L<dir> -l<name>` pairs or as absolute `.so[.N]` paths. The
+# compiler driver records only the dependency SONAME in DT_NEEDED, so preserve
+# every corresponding directory as a DT_RUNPATH entry. This is especially
+# important for immutable Nix-store paths, but is equally correct for ordinary
+# non-system dependency prefixes. Mach-O libraries carry install names and
+# Windows resolves DLLs through PATH, so this is deliberately ELF-only.
+function(eshkol_append_elf_runtime_search_paths list_var)
+    if(APPLE OR WIN32 OR ESHKOL_USING_MSVC)
+        set(${list_var} "${${list_var}}" PARENT_SCOPE)
+        return()
+    endif()
+
+    set(_eshkol_link_args ${${list_var}})
+    set(_eshkol_runtime_dirs "")
+    foreach(_eshkol_link_arg IN LISTS _eshkol_link_args)
+        set(_eshkol_runtime_dir "")
+        if(_eshkol_link_arg MATCHES "^-L(.+)$")
+            set(_eshkol_runtime_dir "${CMAKE_MATCH_1}")
+        elseif(IS_ABSOLUTE "${_eshkol_link_arg}")
+            if(_eshkol_link_arg MATCHES "\\.so(\\.[0-9]+)*$")
+                get_filename_component(_eshkol_runtime_dir
+                    "${_eshkol_link_arg}" DIRECTORY)
+            endif()
+        endif()
+
+        if(NOT "${_eshkol_runtime_dir}" STREQUAL "")
+            file(TO_CMAKE_PATH "${_eshkol_runtime_dir}" _eshkol_runtime_dir)
+            list(APPEND _eshkol_runtime_dirs "${_eshkol_runtime_dir}")
+        endif()
+    endforeach()
+
+    list(REMOVE_DUPLICATES _eshkol_runtime_dirs)
+    foreach(_eshkol_runtime_dir IN LISTS _eshkol_runtime_dirs)
+        set(_eshkol_rpath_arg "-Wl,-rpath,${_eshkol_runtime_dir}")
+        list(FIND _eshkol_link_args "${_eshkol_rpath_arg}" _eshkol_rpath_index)
+        if(_eshkol_rpath_index EQUAL -1)
+            list(APPEND _eshkol_link_args "${_eshkol_rpath_arg}")
+        endif()
+    endforeach()
+
+    set(${list_var} "${_eshkol_link_args}" PARENT_SCOPE)
+endfunction()
+
+# The compiler driver also injects its C++ ABI/runtime libraries implicitly;
+# those paths never appear in llvm-config or target_link_libraries. Raw Nix
+# clang installations rely on their development shell's LD_LIBRARY_PATH for
+# libstdc++, which makes an otherwise valid generated binary non-relocatable.
+# Ask the exact host driver used for AOT links where its shared runtimes live
+# and preserve those directories beside the explicit dependency RUNPATHs.
+function(eshkol_append_host_cxx_runtime_search_paths list_var)
+    if(APPLE OR WIN32 OR ESHKOL_USING_MSVC)
+        set(${list_var} "${${list_var}}" PARENT_SCOPE)
+        return()
+    endif()
+
+    set(_eshkol_link_args ${${list_var}})
+    foreach(_eshkol_runtime_name IN ITEMS
+            libstdc++.so.6
+            libc++.so.1
+            libgcc_s.so.1)
+        execute_process(
+            COMMAND "${ESHKOL_HOST_CXX_COMPILER}"
+                    "-print-file-name=${_eshkol_runtime_name}"
+            RESULT_VARIABLE _eshkol_runtime_probe_rc
+            OUTPUT_VARIABLE _eshkol_runtime_file
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET)
+        if(_eshkol_runtime_probe_rc EQUAL 0 AND
+           IS_ABSOLUTE "${_eshkol_runtime_file}" AND
+           EXISTS "${_eshkol_runtime_file}")
+            get_filename_component(_eshkol_runtime_dir
+                "${_eshkol_runtime_file}" DIRECTORY)
+            file(TO_CMAKE_PATH "${_eshkol_runtime_dir}" _eshkol_runtime_dir)
+            set(_eshkol_rpath_arg "-Wl,-rpath,${_eshkol_runtime_dir}")
+            list(FIND _eshkol_link_args
+                "${_eshkol_rpath_arg}" _eshkol_rpath_index)
+            if(_eshkol_rpath_index EQUAL -1)
+                list(APPEND _eshkol_link_args "${_eshkol_rpath_arg}")
+            endif()
+        endif()
+    endforeach()
+
+    set(${list_var} "${_eshkol_link_args}" PARENT_SCOPE)
+endfunction()
+
 set(ESHKOL_HOST_LLVM_LINK_ARGS "")
 foreach(_llvm_lib_dir IN LISTS LLVM_LIBRARY_DIRS)
     list(APPEND ESHKOL_HOST_LLVM_LINK_ARGS "-L${_llvm_lib_dir}")
@@ -734,6 +821,8 @@ foreach(_llvm_link_arg IN LISTS LLVM_LDFLAGS_LIST LLVM_LIBS_LIST LLVM_SYSTEM_LIB
         endif()
     endif()
 endforeach()
+eshkol_append_elf_runtime_search_paths(ESHKOL_HOST_LLVM_LINK_ARGS)
+eshkol_append_host_cxx_runtime_search_paths(ESHKOL_HOST_LLVM_LINK_ARGS)
 
 # Keep LLVM's defines and unwind flags, but let the project control language mode
 # and exception support.
@@ -1402,6 +1491,8 @@ endif()
 if(ESHKOL_ENABLE_MSAN)
     eshkol_append_host_runtime_link_arg("-fsanitize=memory")
 endif()
+
+eshkol_append_elf_runtime_search_paths(ESHKOL_HOST_RUNTIME_LINK_ARGS)
 
 if(DEFINED ESHKOL_GENERATED_INCLUDE_DIR)
     configure_file(
@@ -2494,6 +2585,20 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
                 PASS_REGULAR_EXPRESSION "PASS: static_link_getenv_capability_test"
                 FAIL_REGULAR_EXPRESSION "FAIL:")
     endif()
+    if(NOT APPLE AND NOT WIN32 AND
+       EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/aot_elf_rpath_config_test.sh")
+        add_test(
+            NAME aot_elf_rpath_config_test
+            COMMAND bash
+                    "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/aot_elf_rpath_config_test.sh"
+                    "${CMAKE_CURRENT_BINARY_DIR}"
+        )
+        set_tests_properties(aot_elf_rpath_config_test
+            PROPERTIES
+                TIMEOUT 30
+                PASS_REGULAR_EXPRESSION "PASS: aot_elf_rpath_config_test"
+                FAIL_REGULAR_EXPRESSION "FAIL:")
+    endif()
 endif()
 
 if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/core/runtime_shutdown_hooks_test.cpp")
@@ -3543,6 +3648,8 @@ if(ESHKOL_BUILD_AGENT_FFI)
                 list(APPEND ESHKOL_HOST_AGENT_FFI_LINK_ARGS "-lssl" "-lcrypto")
             endif()
         endif()
+
+        eshkol_append_elf_runtime_search_paths(ESHKOL_HOST_AGENT_FFI_LINK_ARGS)
 
         # The CMake variable carries semicolons as list separators; for
         # build_config.h.in's @VAR@ substitution we want the args

--- a/tests/toolchain/aot_elf_rpath_config_test.sh
+++ b/tests/toolchain/aot_elf_rpath_config_test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Verify that every ELF library search directory emitted for an AOT-generated
+# program is also preserved in that program's DT_RUNPATH.
+set -euo pipefail
+
+BUILD_DIR="${1:-}"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+[ -n "$BUILD_DIR" ] || fail "usage: $0 <build-dir>"
+CONFIG_HEADER="$BUILD_DIR/generated/eshkol/build_config.h"
+[ -f "$CONFIG_HEADER" ] || fail "generated build config not found: $CONFIG_HEADER"
+
+config_value() {
+    local name="$1"
+    sed -n "s/^#define ${name} \"\\(.*\\)\"$/\\1/p" "$CONFIG_HEADER" | head -1
+}
+
+assert_runtime_paths() {
+    local label="$1"
+    local raw_args="$2"
+    local normalized="${raw_args//;/ }"
+    local -a args=()
+    local -a expected_dirs=()
+    local arg dir expected found
+
+    read -r -a args <<< "$normalized"
+    for arg in "${args[@]}"; do
+        dir=""
+        case "$arg" in
+            -L?*) dir="${arg#-L}" ;;
+            /*.so|/*.so.[0-9]*) dir="${arg%/*}" ;;
+        esac
+        [ -n "$dir" ] && expected_dirs+=("$dir")
+    done
+
+    for expected in "${expected_dirs[@]}"; do
+        found=0
+        for arg in "${args[@]}"; do
+            if [ "$arg" = "-Wl,-rpath,$expected" ]; then
+                found=1
+                break
+            fi
+        done
+        [ "$found" -eq 1 ] ||
+            fail "$label omits -Wl,-rpath,$expected for an AOT shared-library search directory"
+    done
+}
+
+assert_runtime_paths "LLVM link args" "$(config_value ESHKOL_HOST_LLVM_LINK_ARGS)"
+assert_runtime_paths "runtime link args" "$(config_value ESHKOL_HOST_RUNTIME_LINK_ARGS)"
+assert_runtime_paths "agent FFI link args" "$(config_value ESHKOL_HOST_AGENT_FFI_LINK_ARGS)"
+
+HOST_CXX="$(config_value ESHKOL_HOST_CXX_COMPILER)"
+LLVM_ARGS="$(config_value ESHKOL_HOST_LLVM_LINK_ARGS)"
+if [ -n "$HOST_CXX" ] && [ -x "$HOST_CXX" ]; then
+    for runtime_name in libstdc++.so.6 libc++.so.1 libgcc_s.so.1; do
+        runtime_file="$($HOST_CXX "-print-file-name=$runtime_name" 2>/dev/null || true)"
+        case "$runtime_file" in
+            /*)
+                [ -f "$runtime_file" ] || continue
+                runtime_dir="${runtime_file%/*}"
+                case ";${LLVM_ARGS// /;};" in
+                    *";-Wl,-rpath,$runtime_dir;"*) ;;
+                    *) fail "LLVM link args omit host C++ runtime path $runtime_dir" ;;
+                esac
+                ;;
+        esac
+    done
+fi
+
+echo "PASS: aot_elf_rpath_config_test"


### PR DESCRIPTION
## Summary

- preserve ELF runtime search directories for every AOT dependency expressed as either `-L<dir>` or an absolute `.so[.N]` path
- query the exact configured host C++ driver for implicit `libstdc++` / `libc++` / `libgcc_s` locations and preserve those paths too
- add a Linux regression test that rejects generated link metadata with a missing dependency or compiler-runtime RPATH
- leave Mach-O and Windows link behavior unchanged

## Root cause

The exact-head Jetson validation for #278 exposed an AOT portability defect. The generated CPU reference compiled successfully, but exited 127 before entering Eshkol because its ELF loader could not locate Nix-store `libcurl`, `libncursesw`, and `libLLVM`. After preserving those explicit dependency paths, a second no-environment launch correctly exposed the implicit `libstdc++.so.6` path injected by raw Nix clang. The existing LLVM RPATH loop ran before `llvm-config`'s `-L` flags were appended, and absolute agent/runtime `.so` dependencies had no equivalent RUNPATH step.

This patch makes the generated executable carry the complete loader closure instead of depending on the build shell's `LD_LIBRARY_PATH`.

## Verification

- ICC exact index: 2,654 files / 48,229 symbols, zero blind spots
- ICC pre-commit: PASS
- ICC architecture model: 8/8 invariants PASS
- ICC strict production audit: PASS, release readiness 100, zero risks
- dedicated Ubuntu x64 node: full build and CTest 71/71 PASS (including the new configuration test)
- exact-patch VM parity on Ubuntu: 68/68 PASS
- Jetson AGX Xavier / Nix / arm64:
  - generated CPU payload reaches `GATE-DONE` with `LD_LIBRARY_PATH` explicitly removed
  - `readelf` confirms RUNPATH entries for curl, SQLite, ncurses, LLVM, GCC C++ runtime, and OpenSSL
  - real CUDA/cuBLAS GPU gate remains 10/10 PASS with maximum relative difference 0
- local macOS configuration and shell-test positive/negative fixtures PASS

No feature, test, or backend is reduced or disabled.
