### PR TITLE
release: finalize v1.3.3 publication gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      candidate_tag:
+        description: Candidate tag label used only for dry-run asset names
+        required: true
+        default: v1.3.3-evolve
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,6 +22,9 @@ permissions:
 env:
   LLVM_MAJOR: '21'
   WINDOWS_LLVM_SDK_VERSION: '21.1.8'
+  # A manual dispatch is always non-publishing. Its explicit candidate label
+  # lets the dry-run archives use the exact names the later tag run will use.
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.candidate_tag || github.ref_name }}
 
 jobs:
   unix-release-matrix:
@@ -87,6 +97,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Validate release tag label
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9A-Za-z][0-9A-Za-z._-]*$ ]]; then
+            echo "Invalid release tag label: $RELEASE_TAG" >&2
+            exit 1
+          fi
 
       - name: Add LLVM Repository (Linux)
         if: runner.os == 'Linux'
@@ -184,7 +203,7 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          archive_root="eshkol-${{ github.ref_name }}-${{ matrix.name }}"
+          archive_root="eshkol-${RELEASE_TAG}-${{ matrix.name }}"
           pkg_dir="$RUNNER_TEMP/$archive_root"
           mkdir -p "$pkg_dir/bin" "$pkg_dir/lib/eshkol" "$pkg_dir/share/eshkol/lib"
 
@@ -207,7 +226,7 @@ jobs:
             cp "$source_file" "$dest_path"
           done < <(find lib -type f -name '*.esk' -print0)
 
-          for doc in README.md LICENSE CHANGELOG.md; do
+          for doc in README.md LICENSE CHANGELOG.md RELEASE_NOTES.md; do
             if [[ -f "$doc" ]]; then
               cp "$doc" "$pkg_dir/"
             fi
@@ -219,7 +238,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: release-asset-${{ matrix.name }}
-          path: ${{ runner.temp }}/eshkol-${{ github.ref_name }}-${{ matrix.name }}.tar.gz
+          path: ${{ runner.temp }}/eshkol-${{ env.RELEASE_TAG }}-${{ matrix.name }}.tar.gz
           if-no-files-found: error
 
   windows-release-matrix:
@@ -281,6 +300,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Validate release tag label
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ($env:RELEASE_TAG -notmatch '^v[0-9A-Za-z][0-9A-Za-z._-]*$') {
+            throw "Invalid release tag label: $env:RELEASE_TAG"
+          }
 
       - name: Restore LLVM SDK Cache
         id: llvm-cache
@@ -411,7 +438,7 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
 
-          $archiveRoot = "eshkol-${{ github.ref_name }}-${{ matrix.name }}"
+          $archiveRoot = "eshkol-$env:RELEASE_TAG-${{ matrix.name }}"
           $pkgDir = Join-Path $env:RUNNER_TEMP $archiveRoot
           $binDir = Join-Path $pkgDir 'bin'
           $libDir = Join-Path $pkgDir 'lib'
@@ -468,7 +495,7 @@ jobs:
             Copy-Item -LiteralPath $_.FullName -Destination $destinationPath
           }
 
-          foreach ($doc in @('README.md', 'LICENSE', 'CHANGELOG.md')) {
+          foreach ($doc in @('README.md', 'LICENSE', 'CHANGELOG.md', 'RELEASE_NOTES.md')) {
             if (Test-Path $doc) {
               Copy-Item -LiteralPath $doc -Destination $pkgDir
             }
@@ -484,7 +511,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: release-asset-${{ matrix.name }}
-          path: ${{ runner.temp }}\eshkol-${{ github.ref_name }}-${{ matrix.name }}.zip
+          path: ${{ runner.temp }}\eshkol-${{ env.RELEASE_TAG }}-${{ matrix.name }}.zip
           if-no-files-found: error
 
   publish-release:
@@ -495,6 +522,8 @@ jobs:
       - windows-release-matrix
 
     steps:
+      - uses: actions/checkout@v6
+
       - name: Download Packaged Assets
         uses: actions/download-artifact@v8
         with:
@@ -508,22 +537,22 @@ jobs:
           set -euo pipefail
 
           expected=(
-            "eshkol-${GITHUB_REF_NAME}-linux-x64-lite.tar.gz"
-            "eshkol-${GITHUB_REF_NAME}-linux-arm64-lite.tar.gz"
-            "eshkol-${GITHUB_REF_NAME}-linux-x64-xla.tar.gz"
-            "eshkol-${GITHUB_REF_NAME}-linux-arm64-xla.tar.gz"
-            "eshkol-${GITHUB_REF_NAME}-linux-x64-cuda.tar.gz"
-            "eshkol-${GITHUB_REF_NAME}-linux-arm64-cuda.tar.gz"
-            "eshkol-${GITHUB_REF_NAME}-macos-arm64-lite.tar.gz"
-            "eshkol-${GITHUB_REF_NAME}-macos-x64-lite.tar.gz"
-            "eshkol-${GITHUB_REF_NAME}-macos-arm64-xla.tar.gz"
-            "eshkol-${GITHUB_REF_NAME}-macos-x64-xla.tar.gz"
-            "eshkol-${GITHUB_REF_NAME}-windows-x64-lite.zip"
-            "eshkol-${GITHUB_REF_NAME}-windows-arm64-lite.zip"
-            "eshkol-${GITHUB_REF_NAME}-windows-x64-xla.zip"
-            "eshkol-${GITHUB_REF_NAME}-windows-arm64-xla.zip"
-            "eshkol-${GITHUB_REF_NAME}-windows-x64-cuda.zip"
-            "eshkol-${GITHUB_REF_NAME}-windows-arm64-cuda.zip"
+            "eshkol-${RELEASE_TAG}-linux-x64-lite.tar.gz"
+            "eshkol-${RELEASE_TAG}-linux-arm64-lite.tar.gz"
+            "eshkol-${RELEASE_TAG}-linux-x64-xla.tar.gz"
+            "eshkol-${RELEASE_TAG}-linux-arm64-xla.tar.gz"
+            "eshkol-${RELEASE_TAG}-linux-x64-cuda.tar.gz"
+            "eshkol-${RELEASE_TAG}-linux-arm64-cuda.tar.gz"
+            "eshkol-${RELEASE_TAG}-macos-arm64-lite.tar.gz"
+            "eshkol-${RELEASE_TAG}-macos-x64-lite.tar.gz"
+            "eshkol-${RELEASE_TAG}-macos-arm64-xla.tar.gz"
+            "eshkol-${RELEASE_TAG}-macos-x64-xla.tar.gz"
+            "eshkol-${RELEASE_TAG}-windows-x64-lite.zip"
+            "eshkol-${RELEASE_TAG}-windows-arm64-lite.zip"
+            "eshkol-${RELEASE_TAG}-windows-x64-xla.zip"
+            "eshkol-${RELEASE_TAG}-windows-arm64-xla.zip"
+            "eshkol-${RELEASE_TAG}-windows-x64-cuda.zip"
+            "eshkol-${RELEASE_TAG}-windows-arm64-cuda.zip"
           )
 
           cd dist
@@ -551,39 +580,65 @@ jobs:
           cd dist
           sha256sum * > SHA256SUMS.txt
 
+      - name: Prepare Curated Release Notes
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected_heading="# Eshkol ${RELEASE_TAG} — Release Notes"
+          actual_heading="$(head -n 1 RELEASE_NOTES.md)"
+          if [[ "$actual_heading" != "$expected_heading" ]]; then
+            echo "Release-notes heading mismatch" >&2
+            echo "expected: $expected_heading" >&2
+            echo "actual:   $actual_heading" >&2
+            exit 1
+          fi
+          awk 'NR == 1 { print; next } /^---$/ { exit } { print }' \
+            RELEASE_NOTES.md > "$RUNNER_TEMP/release-notes.md"
+          test -s "$RUNNER_TEMP/release-notes.md"
+
+      - name: Upload Validated Dry-Run Assets
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-dry-run-${{ github.sha }}
+          path: dist/
+          if-no-files-found: error
+
       - name: Publish GitHub Release
+        if: github.event_name == 'push'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euxo pipefail
 
-          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "::error::Release $GITHUB_REF_NAME already exists; refusing to overwrite or append assets."
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::Release $RELEASE_TAG already exists; refusing to overwrite or append assets."
             echo "Delete the failed draft/release manually before rerunning this tag workflow."
             exit 1
           fi
 
           prerelease_flags=()
-          if [[ "$GITHUB_REF_NAME" == *alpha* ||
-                "$GITHUB_REF_NAME" == *beta* ||
-                "$GITHUB_REF_NAME" == *rc* ]]; then
+          if [[ "$RELEASE_TAG" == *alpha* ||
+                "$RELEASE_TAG" == *beta* ||
+                "$RELEASE_TAG" == *rc* ]]; then
             prerelease_flags+=(--prerelease)
           fi
 
           # gh creates the release as a draft, uploads assets, then publishes it.
           # That avoids a public partial release if the upload is interrupted.
-          gh release create "$GITHUB_REF_NAME" \
+          gh release create "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --verify-tag \
-            --title "Eshkol $GITHUB_REF_NAME" \
-            --generate-notes \
+            --title "Eshkol $RELEASE_TAG" \
+            --notes-file "$RUNNER_TEMP/release-notes.md" \
             "${prerelease_flags[@]}" \
             dist/*
 
   bump-homebrew-tap:
     name: bump-homebrew-tap
     runs-on: ubuntu-22.04
+    if: github.event_name == 'push'
     needs:
       - publish-release
     steps:
@@ -600,13 +655,13 @@ jobs:
             exit 0
           fi
 
-          case "$GITHUB_REF_NAME" in
+          case "$RELEASE_TAG" in
             *alpha*|*beta*|*rc*)
-              echo "::notice::Prerelease tag $GITHUB_REF_NAME; not bumping the tap."
+              echo "::notice::Prerelease tag $RELEASE_TAG; not bumping the tap."
               exit 0;;
           esac
 
-          tag="$GITHUB_REF_NAME"
+          tag="$RELEASE_TAG"
           tarball_url="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${tag}.tar.gz"
 
           # GitHub source archives are generated on demand; fetch and hash.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,11 +63,20 @@ gate green.  This section describes an **untagged release candidate**; no
   accepts external build roots. A real RTX 3060 run dispatched through CUDA
   cuBLAS and matched the CPU reference across 10 probes with maximum relative
   difference `0`.
+- **Release shell entry points reject unsafe paths before cleanup.** Shared
+  guards enforce isolated build roots, reject symlink escapes and repository
+  roots, and keep Bash, Git Bash, and constrained ARM64 behavior aligned.
+  (#278)
+- **The tag workflow can execute as a non-publishing dry run.** Manual runs
+  build, test, package, validate, and checksum the complete 16-asset matrix,
+  but cannot publish a GitHub release or update Homebrew. Packaged archives
+  include the curated release notes, and the published release body is taken
+  from the current release section rather than generated commit summaries.
 
 ### Verification
 
 - Aggregate suite: **44/44 suites, 716/716 tests**.
-- CTest: **70/70**; SICP full-book gate: **88/88** JIT+AOT probes.
+- CTest: **71/71**; SICP full-book gate: **88/88** JIT+AOT probes.
 - Chibi Scheme reference differential: **34/34 AGREE**; generative five-oracle
   differential: **127 programs, zero divergences**.
 - VM parity: **68/68**; VM extended surface: **53/53**.
@@ -115,6 +124,12 @@ gate green.  This section describes an **untagged release candidate**; no
 - **Windows hosted-runtime portability.** The region-runtime fallback no longer
   declares ELF weak functions on PE/COFF. Windows uses the hosted runtime
   directly, while non-Windows builds retain the weak fallback contract.
+- **Generated ELF AOT binaries retain their dependency search paths.** Linux
+  AOT linking now derives RUNPATH entries from linked `-L` directories,
+  absolute shared-library inputs, and the selected host C++ compiler. Generated
+  programs therefore find LLVM, the C++ runtime, curl, SQLite, ncurses,
+  OpenSSL, and Nix-store dependencies without a custom `LD_LIBRARY_PATH`.
+  (#279)
 - **Exact tensor AD gradients for first-class losses and vector/learnable
   gamma; silent-zero backward paths now error instead of returning zero.**
   This corrects the v1.3.2-evolve CHANGELOG entry for #212, which claimed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Eshkol v1.3.3-evolve — Release Notes
 
-**Candidate Date**: July 13, 2026
+**Candidate Date**: July 14, 2026
 **Status**: untagged release candidate; no public `v1.3.3-evolve` tag exists.
 
 Eshkol v1.3.3-evolve combines the completed Moonlab quantum stack with a
@@ -11,7 +11,7 @@ full-book SICP, external-reference, generative, WebAssembly, CTest, and ICC
 architecture gates. Full technical detail lives in
 [CHANGELOG.md](CHANGELOG.md).
 
-**Release gates**: 44/44 suites and 716/716 tests; CTest 70/70; SICP 88/88
+**Release gates**: 44/44 suites and 716/716 tests; CTest 71/71; SICP 88/88
 JIT+AOT probes; Chibi Scheme 34/34 AGREE; five-oracle generative differential
 127 programs with zero divergences; VM parity 68/68; VM extended surface
 53/53; executable language coverage 1056/1056 (100%); WebAssembly imports
@@ -79,6 +79,15 @@ upstream macOS weak-import linker fix and builds without a local override.
   through CUDA cuBLAS and matched 10 CPU-reference probes with maximum relative
   difference `0`. PE/COFF hosted-runtime linkage no longer relies on ELF weak
   functions.
+- Release and verification shell entry points now reject unsafe build roots,
+  symlink escapes, and destructive cleanup targets before operating. The same
+  path contract is exercised across Bash, Git Bash, and constrained ARM64
+  shells. (#278)
+- Generated Linux AOT executables now preserve the runtime search paths of
+  every linked dependency, including indirect LLVM, C++ runtime, curl,
+  SQLite, ncurses, OpenSSL, and Nix-store libraries. The linker derives these
+  paths from actual `-L` and shared-library inputs and from the selected host
+  compiler instead of requiring a custom `LD_LIBRARY_PATH`. (#279)
 - Exact numeric and automatic-differentiation fixes cover bignums, rationals,
   tensors, forward-over-reverse composition, Hessians, and explicit
   unsupported-op errors instead of silent zero gradients.
@@ -87,8 +96,10 @@ upstream macOS weak-import linker fix and builds without a local override.
 
 The full suite uses an isolated requested build directory; reference and
 generative oracles execute portably on macOS; freestanding object checks allow
-only target intrinsics (never undeclared hosted ABI calls); and every required
-WebAssembly environment import is present in both JavaScript runtimes.
+only target intrinsics (never undeclared hosted ABI calls); every required
+WebAssembly environment import is present in both JavaScript runtimes; and the
+tag workflow supports a non-publishing manual dry run of the complete release
+matrix before any immutable release tag is created.
 
 ---
 

--- a/docs/internal/RELEASE_READINESS_REPORT.md
+++ b/docs/internal/RELEASE_READINESS_REPORT.md
@@ -1,33 +1,37 @@
 # Eshkol v1.3.3-evolve Release-Candidate Readiness Report
 
-**Candidate branch:** `feat/runtime-language-coverage`
+**Candidate branch:** `master` plus the release-finalization change set
 **Release line:** `v1.3.x-evolve`
-**Candidate head:** the commit containing this report
+**Verified hardening baseline:** `502b5a17c180a5e0281be2b339049a783b3e4066`
+**Baseline GitHub Actions:** run `29305913676`, **15/15 jobs green**
+**Candidate head:** the final merged master commit containing this report
 **Published base tag:** `v1.3.2-evolve` (`8443ddae`)
-**Candidate date:** 2026-07-13
+**Candidate date:** 2026-07-14
 **Tag status:** **untagged** — publishing any tag remains a maintainer action.
 
 This report is the release contract for the untagged v1.3.3-evolve candidate.
 It supersedes the July 8 readiness snapshot and records gates executed from an
 isolated Release build (`build-hardening`, tests enabled, XLA/GPU disabled with
-their CPU fallbacks still exercised). A public tag must not be created until
-this candidate is merged and the GitHub Actions matrix for the exact master
-head is green.
+their CPU fallbacks still exercised), the final hosted matrix, and dedicated
+mesh evidence. A public tag must not be created until this finalization change
+is merged, the exact master matrix is green, and the non-publishing release
+workflow dry run succeeds.
 
 ## Verdict
 
-The candidate is locally release-ready. All deterministic code, differential,
-coverage, architecture, freestanding, WebAssembly, and full-book gates are
-green. The remaining publication condition is the required GitHub Actions
-matrix on the final merged master head. No release tag is authorized or
-created by this campaign.
+The candidate is release-ready. All deterministic code, differential,
+coverage, architecture, freestanding, WebAssembly, full-book, hosted-matrix,
+and cross-platform mesh gates are green. The verified hardening baseline's
+required GitHub Actions matrix passed 15/15; the finalization commit must repeat
+that exact-master check and complete the manual non-publishing release matrix.
+No release tag is authorized or created by this campaign.
 
 ## Release Gates
 
 | Gate | Result |
 |---|---|
 | Aggregate test harness | **44/44 suites, 716/716 tests**, zero failed/skipped suites |
-| CTest | **70/70** |
+| CTest | **71/71** |
 | SICP full-book | **88/88** JIT+AOT probes, zero xfail/XPASS |
 | Chibi R7RS reference differential | **34/34 AGREE**, zero divergence/error |
 | Generative multi-oracle differential | **127 programs**, Chibi/JIT/AOT-O0/AOT-O2/VM, zero divergence |
@@ -135,6 +139,10 @@ coverage are release blockers.
 
 1. Merge the candidate only after every required pull-request check is green.
 2. Verify the GitHub Actions matrix for the exact merged master head is green.
-3. Re-run the release smoke against that head if packaging inputs change.
+3. Run the complete release workflow manually against that head; it must build,
+   test, package, validate, and checksum all 16 assets while publishing nothing.
 4. Only the maintainer may authorize and create `v1.3.3-evolve` (or another
    version) after reviewing these notes and artifacts.
+5. After the tag workflow succeeds, smoke representative downloaded assets on
+   macOS ARM64, Linux x64/ARM64, and Windows x64 and confirm the Homebrew tap
+   advanced to the exact tag and source-archive checksum.

--- a/tests/toolchain/release_workflow_surface_test.cpp
+++ b/tests/toolchain/release_workflow_surface_test.cpp
@@ -87,6 +87,13 @@ int main(int argc, char** argv) {
                          "release workflow is named") &&
          expect_contains(workflow, "tags:\n      - 'v*'",
                          "release workflow only runs for version tags") &&
+         expect_contains(workflow, "workflow_dispatch:",
+                         "release workflow supports a manual dry run") &&
+         expect_contains(workflow, "candidate_tag:",
+                         "manual dry run requires an explicit candidate tag label") &&
+         expect_contains(workflow,
+                         "RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.candidate_tag || github.ref_name }}",
+                         "tag and dry-run asset naming share one release label") &&
          expect_contains(workflow, "permissions:\n  contents: write",
                          "release workflow can publish GitHub releases") &&
          expect_contains(workflow, "cancel-in-progress: false",
@@ -112,37 +119,53 @@ int main(int argc, char** argv) {
                          "release workflow rejects missing or extra assets") &&
          expect_contains(workflow, "sha256sum * > SHA256SUMS.txt",
                          "release workflow writes checksums for all assets") &&
-         expect_contains(workflow, "gh release view \"$GITHUB_REF_NAME\"",
+         expect_contains(workflow, "gh release view \"$RELEASE_TAG\"",
                          "release workflow checks for existing release") &&
          expect_contains(workflow,
                          "refusing to overwrite or append assets",
                          "release workflow refuses to append to existing releases") &&
-         expect_contains(workflow, "gh release create \"$GITHUB_REF_NAME\"",
+         expect_contains(workflow, "gh release create \"$RELEASE_TAG\"",
                          "release workflow creates a tag-named GitHub release") &&
          expect_contains(workflow, "--verify-tag",
                          "release workflow verifies that the release tag exists") &&
+         expect_contains(workflow, "Prepare Curated Release Notes",
+                         "release workflow extracts the current curated notes") &&
+         expect_contains(workflow,
+                         "--notes-file \"$RUNNER_TEMP/release-notes.md\"",
+                         "GitHub release body uses curated release notes") &&
+         expect_contains(workflow, "Upload Validated Dry-Run Assets",
+                         "manual dry run preserves its validated asset set") &&
+         expect_contains(workflow,
+                         "if: github.event_name == 'workflow_dispatch'",
+                         "dry-run artifact upload is dispatch-only") &&
          expect_contains(workflow, "dist/*",
                          "release workflow uploads the complete dist directory");
 
     ok = ok &&
          expect_contains(workflow,
-                         "archive_root=\"eshkol-${{ github.ref_name }}-${{ matrix.name }}\"",
+                         "archive_root=\"eshkol-${RELEASE_TAG}-${{ matrix.name }}\"",
                          "Unix release archives include the tag and platform name") &&
          expect_contains(workflow,
                          "tar -czf \"$RUNNER_TEMP/$archive_root.tar.gz\"",
                          "Unix release matrix produces tar.gz assets") &&
          expect_contains(workflow,
-                         "path: ${{ runner.temp }}/eshkol-${{ github.ref_name }}-${{ matrix.name }}.tar.gz",
+                         "path: ${{ runner.temp }}/eshkol-${{ env.RELEASE_TAG }}-${{ matrix.name }}.tar.gz",
                          "Unix upload path includes the tag and platform name") &&
          expect_contains(workflow,
-                         "$archiveRoot = \"eshkol-${{ github.ref_name }}-${{ matrix.name }}\"",
+                         "$archiveRoot = \"eshkol-$env:RELEASE_TAG-${{ matrix.name }}\"",
                          "Windows release archives include the tag and platform name") &&
          expect_contains(workflow,
                          "$archivePath = Join-Path $env:RUNNER_TEMP \"$archiveRoot.zip\"",
                          "Windows release matrix produces zip assets") &&
          expect_contains(workflow,
-                         "path: ${{ runner.temp }}\\eshkol-${{ github.ref_name }}-${{ matrix.name }}.zip",
-                         "Windows upload path includes the tag and platform name");
+                         "path: ${{ runner.temp }}\\eshkol-${{ env.RELEASE_TAG }}-${{ matrix.name }}.zip",
+                         "Windows upload path includes the tag and platform name") &&
+         expect_contains(workflow,
+                         "for doc in README.md LICENSE CHANGELOG.md RELEASE_NOTES.md; do",
+                         "Unix archives include release notes") &&
+         expect_contains(workflow,
+                         "foreach ($doc in @('README.md', 'LICENSE', 'CHANGELOG.md', 'RELEASE_NOTES.md'))",
+                         "Windows archives include release notes");
 
     const std::vector<ReleaseAsset> expected_assets = {
         {"linux-x64-lite", "tar.gz"},
@@ -166,7 +189,7 @@ int main(int argc, char** argv) {
     for (const ReleaseAsset& asset : expected_assets) {
         const std::string matrix_name = std::string("- name: ") + asset.name;
         const std::string expected_filename =
-            std::string("\"eshkol-${GITHUB_REF_NAME}-") + asset.name + "." +
+            std::string("\"eshkol-${RELEASE_TAG}-") + asset.name + "." +
             asset.extension + "\"";
         ok = ok &&
              expect_contains(workflow, matrix_name,
@@ -175,8 +198,19 @@ int main(int argc, char** argv) {
                              std::string("validated asset list includes ") + asset.name);
     }
 
+    const std::size_t expected_block_begin = workflow.find("          expected=(\n");
+    const std::size_t expected_block_end =
+        expected_block_begin == std::string::npos
+            ? std::string::npos
+            : workflow.find("\n          )", expected_block_begin);
+    const std::string expected_block =
+        expected_block_begin == std::string::npos ||
+                expected_block_end == std::string::npos
+            ? std::string()
+            : workflow.substr(expected_block_begin,
+                              expected_block_end - expected_block_begin);
     const std::size_t validated_asset_count =
-        count_occurrences(workflow, "\"eshkol-${GITHUB_REF_NAME}-");
+        count_occurrences(expected_block, "\"eshkol-${RELEASE_TAG}-");
     if (validated_asset_count != expected_assets.size()) {
         std::cerr << "expected " << expected_assets.size()
                   << " validated release asset names, found "
@@ -187,10 +221,24 @@ int main(int argc, char** argv) {
     ok = ok &&
          expect_not_contains(workflow, "gh release upload",
                              "release workflow should not append assets to an existing release") &&
+         expect_not_contains(workflow, "--generate-notes",
+                             "release workflow should not replace curated notes with generated notes") &&
          expect_not_contains(workflow, "--clobber",
                              "release workflow should not overwrite release assets") &&
          expect_not_contains(workflow, "cancel-in-progress: true",
                              "release workflow should not cancel active tag builds");
+
+    if (count_occurrences(workflow, "if: github.event_name == 'push'") < 2) {
+        std::cerr << "publish and Homebrew jobs must both be disabled during manual dry runs"
+                  << std::endl;
+        ok = false;
+    }
+
+    if (count_occurrences(workflow, "uses: actions/checkout@v6") < 3) {
+        std::cerr << "all build matrices and the publish job must checkout the tagged source"
+                  << std::endl;
+        ok = false;
+    }
 
     if (!ok) {
         return 1;


### PR DESCRIPTION
## Summary

- add a manual, non-publishing dry run of the complete 16-platform release matrix
- validate one explicit release label and use it consistently for every archive
- include `RELEASE_NOTES.md` in Unix and Windows packages
- publish the curated current release-note section instead of generated commit summaries
- prevent manual dry runs from creating a GitHub release or updating Homebrew
- correct final release evidence to CTest 71/71 and record the exact green hardening baseline
- document the #278 shell-path hardening and #279 generated-ELF RUNPATH fix

No release tag is created or authorized by this PR. README and release documents remain explicitly marked as an untagged release candidate.

## Verification

- `release_workflow_surface_test`: PASS standalone and through CMake/CTest
- release workflow YAML parse: PASS
- Actionlint v1.7.12: PASS
- curated release-note extraction: PASS; historical releases excluded
- `git diff --check`: PASS
- ICC pre-commit: PASS, zero blockers
- ICC architecture verification: 8/8 PASS
- ICC trace-aware `v1.3-release` readiness: 100/100, oracle complete
- ICC strict production audit: PASS, zero risks

After this PR merges and master CI is green, the Release workflow should be manually dispatched with candidate label `v1.3.3-evolve`. That run must build, test, package, validate, checksum, and upload its dry-run artifacts without publishing anything.
