### PR TITLE
release: make packages self-contained for cached runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,9 +214,13 @@ jobs:
           cp "${{ matrix.build_dir }}/stdlib.bc" "$pkg_dir/lib/"
           cp "${{ matrix.build_dir }}/stdlib.bc" "$pkg_dir/lib/eshkol/"
           runtime_archive="${{ matrix.build_dir }}/libeshkol-runtime.a"
+          agent_ffi_archive="${{ matrix.build_dir }}/libeshkol-agent-ffi.a"
           test -s "$runtime_archive"
+          test -s "$agent_ffi_archive"
           cp "$runtime_archive" "$pkg_dir/lib/"
           cp "$runtime_archive" "$pkg_dir/lib/eshkol/"
+          cp "$agent_ffi_archive" "$pkg_dir/lib/"
+          cp "$agent_ffi_archive" "$pkg_dir/lib/eshkol/"
 
           cp "lib/stdlib.esk" "$pkg_dir/share/eshkol/"
           if [[ -f "lib/math.esk" ]]; then
@@ -239,6 +243,7 @@ jobs:
           python3 scripts/verify_release_package.py \
             --package-dir "$pkg_dir" \
             --smoke-source "tests/toolchain/windows-smoke.esk" \
+            --agent-smoke-source "tests/toolchain/release-agent-smoke.esk" \
             --expected-version "$RELEASE_TAG"
 
           tar -czf "$RUNNER_TEMP/$archive_root.tar.gz" -C "$RUNNER_TEMP" "$archive_root"
@@ -427,7 +432,7 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $targets = @('eshkol-run', 'eshkol-repl', 'eshkol-runtime', 'stdlib')
+          $targets = @('eshkol-run', 'eshkol-repl', 'eshkol-runtime', 'eshkol-agent-ffi', 'stdlib')
           if ('${{ matrix.test_mode }}' -eq 'xla') {
             $targets += 'xla_codegen_test'
           }
@@ -458,6 +463,7 @@ jobs:
           $stdlibObject = Join-Path '${{ matrix.build_dir }}' 'stdlib.o'
           $stdlibBitcode = Join-Path '${{ matrix.build_dir }}' 'stdlib.bc'
           $runtimeLibrary = Join-Path $binaryDir 'eshkol-runtime.lib'
+          $agentFfiLibrary = Join-Path $binaryDir 'eshkol-agent-ffi.lib'
           if (-not (Test-Path $stdlibObject)) {
             $stdlibCandidate = Join-Path $binaryDir 'stdlib.o'
             if (Test-Path $stdlibCandidate) {
@@ -482,6 +488,14 @@ jobs:
               throw "eshkol-runtime.lib was not found in '${{ matrix.build_dir }}' or '$binaryDir'"
             }
           }
+          if (-not (Test-Path $agentFfiLibrary -PathType Leaf)) {
+            $agentFfiLibraryCandidate = Join-Path '${{ matrix.build_dir }}' 'eshkol-agent-ffi.lib'
+            if (Test-Path $agentFfiLibraryCandidate -PathType Leaf) {
+              $agentFfiLibrary = $agentFfiLibraryCandidate
+            } else {
+              throw "eshkol-agent-ffi.lib was not found in '${{ matrix.build_dir }}' or '$binaryDir'"
+            }
+          }
 
           New-Item -ItemType Directory -Force -Path $binDir, $libDir, $libEshkolDir, $shareDir, $shareLibDir | Out-Null
 
@@ -498,6 +512,8 @@ jobs:
           Copy-Item -LiteralPath $stdlibBitcode -Destination $libEshkolDir
           Copy-Item -LiteralPath $runtimeLibrary -Destination $libDir
           Copy-Item -LiteralPath $runtimeLibrary -Destination $libEshkolDir
+          Copy-Item -LiteralPath $agentFfiLibrary -Destination $libDir
+          Copy-Item -LiteralPath $agentFfiLibrary -Destination $libEshkolDir
 
           Copy-Item -LiteralPath 'lib\stdlib.esk' -Destination $shareDir
           if (Test-Path 'lib\math.esk') {
@@ -524,6 +540,7 @@ jobs:
           python scripts/verify_release_package.py `
             --package-dir "$pkgDir" `
             --smoke-source "tests/toolchain/windows-smoke.esk" `
+            --agent-smoke-source "tests/toolchain/release-agent-smoke.esk" `
             --expected-version "$env:RELEASE_TAG"
           if ($LASTEXITCODE -ne 0) {
             throw "release package smoke failed with exit code $LASTEXITCODE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,6 +213,10 @@ jobs:
           cp "${{ matrix.build_dir }}/stdlib.o" "$pkg_dir/lib/eshkol/"
           cp "${{ matrix.build_dir }}/stdlib.bc" "$pkg_dir/lib/"
           cp "${{ matrix.build_dir }}/stdlib.bc" "$pkg_dir/lib/eshkol/"
+          runtime_archive="${{ matrix.build_dir }}/libeshkol-runtime.a"
+          test -s "$runtime_archive"
+          cp "$runtime_archive" "$pkg_dir/lib/"
+          cp "$runtime_archive" "$pkg_dir/lib/eshkol/"
 
           cp "lib/stdlib.esk" "$pkg_dir/share/eshkol/"
           if [[ -f "lib/math.esk" ]]; then
@@ -231,6 +235,11 @@ jobs:
               cp "$doc" "$pkg_dir/"
             fi
           done
+
+          python3 scripts/verify_release_package.py \
+            --package-dir "$pkg_dir" \
+            --smoke-source "tests/toolchain/windows-smoke.esk" \
+            --expected-version "$RELEASE_TAG"
 
           tar -czf "$RUNNER_TEMP/$archive_root.tar.gz" -C "$RUNNER_TEMP" "$archive_root"
 
@@ -418,7 +427,7 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $targets = @('eshkol-run', 'eshkol-repl', 'stdlib')
+          $targets = @('eshkol-run', 'eshkol-repl', 'eshkol-runtime', 'stdlib')
           if ('${{ matrix.test_mode }}' -eq 'xla') {
             $targets += 'xla_codegen_test'
           }
@@ -448,6 +457,7 @@ jobs:
           $binaryDir = Join-Path '${{ matrix.build_dir }}' 'Release'
           $stdlibObject = Join-Path '${{ matrix.build_dir }}' 'stdlib.o'
           $stdlibBitcode = Join-Path '${{ matrix.build_dir }}' 'stdlib.bc'
+          $runtimeLibrary = Join-Path $binaryDir 'eshkol-runtime.lib'
           if (-not (Test-Path $stdlibObject)) {
             $stdlibCandidate = Join-Path $binaryDir 'stdlib.o'
             if (Test-Path $stdlibCandidate) {
@@ -464,6 +474,14 @@ jobs:
               throw "stdlib.bc was not found in '${{ matrix.build_dir }}' or '$binaryDir'"
             }
           }
+          if (-not (Test-Path $runtimeLibrary -PathType Leaf)) {
+            $runtimeLibraryCandidate = Join-Path '${{ matrix.build_dir }}' 'eshkol-runtime.lib'
+            if (Test-Path $runtimeLibraryCandidate -PathType Leaf) {
+              $runtimeLibrary = $runtimeLibraryCandidate
+            } else {
+              throw "eshkol-runtime.lib was not found in '${{ matrix.build_dir }}' or '$binaryDir'"
+            }
+          }
 
           New-Item -ItemType Directory -Force -Path $binDir, $libDir, $libEshkolDir, $shareDir, $shareLibDir | Out-Null
 
@@ -478,6 +496,8 @@ jobs:
           Copy-Item -LiteralPath $stdlibObject -Destination $libEshkolDir
           Copy-Item -LiteralPath $stdlibBitcode -Destination $libDir
           Copy-Item -LiteralPath $stdlibBitcode -Destination $libEshkolDir
+          Copy-Item -LiteralPath $runtimeLibrary -Destination $libDir
+          Copy-Item -LiteralPath $runtimeLibrary -Destination $libEshkolDir
 
           Copy-Item -LiteralPath 'lib\stdlib.esk' -Destination $shareDir
           if (Test-Path 'lib\math.esk') {
@@ -499,6 +519,14 @@ jobs:
             if (Test-Path $doc) {
               Copy-Item -LiteralPath $doc -Destination $pkgDir
             }
+          }
+
+          python scripts/verify_release_package.py `
+            --package-dir "$pkgDir" `
+            --smoke-source "tests/toolchain/windows-smoke.esk" `
+            --expected-version "$env:RELEASE_TAG"
+          if ($LASTEXITCODE -ne 0) {
+            throw "release package smoke failed with exit code $LASTEXITCODE"
           }
 
           $archivePath = Join-Path $env:RUNNER_TEMP "$archiveRoot.zip"

--- a/exe/eshkol-run.cpp
+++ b/exe/eshkol-run.cpp
@@ -116,6 +116,25 @@ static void append_space_separated_link_args(const char* raw_args,
     }
 }
 
+static void append_host_agent_ffi_dependency_link_args(
+    std::vector<std::string>& link_args) {
+    std::vector<std::string> configured_args;
+    append_space_separated_link_args(
+        ESHKOL_HOST_AGENT_FFI_LINK_ARGS, configured_args);
+
+    for (const auto& item : configured_args) {
+        // The packaged/build-tree archive is resolved relative to the runtime
+        // archive below. Do not replay CMake's build-machine archive path or
+        // its force/whole-archive wrapper; retain only its dependency closure.
+        if (item == "-Wl,--whole-archive" ||
+            item == "-Wl,--no-whole-archive" ||
+            item.find("eshkol-agent-ffi") != std::string::npos) {
+            continue;
+        }
+        link_args.emplace_back(item);
+    }
+}
+
 // Noesis bug report #2 (2026-07-04), part (b): a standalone `eshkol-run -r`
 // AOT link that races a *concurrent* rebuild of one of the static runtime
 // archives (libeshkol-runtime.a / libeshkol-agent-ffi.a — e.g. a `cmake
@@ -4910,6 +4929,20 @@ int main(int argc, char **argv)
             return 1;
         }
 
+        if (needs_agent_ffi) {
+            const auto agent_ffi_path =
+                std::filesystem::path(runtime_lib).parent_path() /
+                eshkol::platform::static_library_name("eshkol-agent-ffi");
+            if (!std::filesystem::is_regular_file(agent_ffi_path)) {
+                eshkol_error("Agent module requires %s, but the archive is missing",
+                             agent_ffi_path.string().c_str());
+                eshkol_error("Reinstall Eshkol with its complete lib directory");
+                return 1;
+            }
+            link_args.emplace_back(agent_ffi_path.generic_string());
+            append_host_agent_ffi_dependency_link_args(link_args);
+        }
+
         // Add linked libraries
         for (const auto &linked_lib : linked_libs) {
             link_args.emplace_back("-l" + std::string(linked_lib));
@@ -4969,31 +5002,6 @@ int main(int argc, char **argv)
 
         append_host_runtime_link_args(link_args);
         append_host_llvm_link_args(link_args);
-
-        // #248: Splice agent-FFI link args when the user's source has
-        // any (require agent.…). Empty when the build wasn't
-        // configured with libcurl / sqlite3 / pcre2 — in that case
-        // calls to qllm_http_get / etc. would still hit the existing
-        // "explicit unavailable" stubs at runtime, same as before.
-        // Splitting on whitespace is safe because we constructed
-        // ESHKOL_HOST_AGENT_FFI_LINK_ARGS from pkg-config and CMake
-        // path lookups; user paths with spaces would be a problem,
-        // but pkg-config produces system-style absolute paths which
-        // are never spaced in practice.
-        if (needs_agent_ffi) {
-            std::string raw = ESHKOL_HOST_AGENT_FFI_LINK_ARGS;
-            if (!raw.empty()) {
-                size_t pos = 0;
-                while (pos < raw.size()) {
-                    size_t end = raw.find(' ', pos);
-                    if (end == std::string::npos) end = raw.size();
-                    if (end > pos) {
-                        link_args.emplace_back(raw.substr(pos, end - pos));
-                    }
-                    pos = end + 1;
-                }
-            }
-        }
 
 // Set 512 MB main-thread stack so deeply recursive Scheme code
 // (e.g. nested letrec / non-tail-recursive helpers in

--- a/scripts/verify_release_package.py
+++ b/scripts/verify_release_package.py
@@ -21,6 +21,7 @@ from typing import NoReturn
 
 DEFAULT_TIMEOUT_SECONDS = 900
 EXPECTED_SMOKE_OUTPUT = "hello from windows smoke"
+EXPECTED_AGENT_SMOKE_OUTPUT = "release agent smoke"
 
 
 def fail(message: str, *, stdout: str = "", stderr: str = "") -> NoReturn:
@@ -82,6 +83,7 @@ def verify_cache_run(
     env: dict[str, str],
     timeout: int,
     expected_trace: str,
+    expected_output: str,
 ) -> None:
     result = run_checked(
         [str(runner), "-r", str(smoke_source)],
@@ -90,9 +92,9 @@ def verify_cache_run(
         timeout=timeout,
         description=f"package smoke ({expected_trace.strip()})",
     )
-    if EXPECTED_SMOKE_OUTPUT not in result.stdout:
+    if expected_output not in result.stdout:
         fail(
-            f"package smoke did not print {EXPECTED_SMOKE_OUTPUT!r}",
+            f"package smoke did not print {expected_output!r}",
             stdout=result.stdout,
             stderr=result.stderr,
         )
@@ -119,6 +121,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--package-dir", required=True, type=Path)
     parser.add_argument("--smoke-source", required=True, type=Path)
+    parser.add_argument("--agent-smoke-source", required=True, type=Path)
     parser.add_argument("--expected-version", required=True)
     parser.add_argument(
         "--timeout-seconds",
@@ -129,28 +132,36 @@ def main() -> int:
 
     package_dir = args.package_dir.resolve()
     smoke_source = args.smoke_source.resolve()
+    agent_smoke_source = args.agent_smoke_source.resolve()
     if not package_dir.is_dir():
         fail(f"package directory does not exist: {package_dir}")
     if not smoke_source.is_file():
         fail(f"smoke source does not exist: {smoke_source}")
+    if not agent_smoke_source.is_file():
+        fail(f"agent smoke source does not exist: {agent_smoke_source}")
     if args.timeout_seconds <= 0:
         fail("--timeout-seconds must be positive")
 
     windows = os.name == "nt"
     runner = package_dir / "bin" / ("eshkol-run.exe" if windows else "eshkol-run")
-    runtime_name = "eshkol-runtime.lib" if windows else "libeshkol-runtime.a"
-    runtime_paths = (
-        package_dir / "lib" / runtime_name,
-        package_dir / "lib" / "eshkol" / runtime_name,
+    archive_names = (
+        ("eshkol-runtime.lib", "eshkol-agent-ffi.lib")
+        if windows
+        else ("libeshkol-runtime.a", "libeshkol-agent-ffi.a")
     )
 
     if not runner.is_file():
         fail(f"packaged runner is missing: {runner}")
-    for runtime_path in runtime_paths:
-        if not runtime_path.is_file() or runtime_path.stat().st_size == 0:
-            fail(f"packaged runtime archive is missing or empty: {runtime_path}")
-    if sha256(runtime_paths[0]) != sha256(runtime_paths[1]):
-        fail("packaged runtime archive copies differ")
+    for archive_name in archive_names:
+        archive_paths = (
+            package_dir / "lib" / archive_name,
+            package_dir / "lib" / "eshkol" / archive_name,
+        )
+        for archive_path in archive_paths:
+            if not archive_path.is_file() or archive_path.stat().st_size == 0:
+                fail(f"packaged archive is missing or empty: {archive_path}")
+        if sha256(archive_paths[0]) != sha256(archive_paths[1]):
+            fail(f"packaged archive copies differ: {archive_name}")
 
     base_env = os.environ.copy()
     version = run_checked(
@@ -188,6 +199,7 @@ def main() -> int:
             env,
             args.timeout_seconds,
             "[jit-cache] store ",
+            EXPECTED_SMOKE_OUTPUT,
         )
         verify_cache_run(
             runner,
@@ -196,10 +208,29 @@ def main() -> int:
             env,
             args.timeout_seconds,
             "[jit-cache] hit ",
+            EXPECTED_SMOKE_OUTPUT,
+        )
+        verify_cache_run(
+            runner,
+            agent_smoke_source,
+            package_dir,
+            env,
+            args.timeout_seconds,
+            "[jit-cache] store ",
+            EXPECTED_AGENT_SMOKE_OUTPUT,
+        )
+        verify_cache_run(
+            runner,
+            agent_smoke_source,
+            package_dir,
+            env,
+            args.timeout_seconds,
+            "[jit-cache] hit ",
+            EXPECTED_AGENT_SMOKE_OUTPUT,
         )
 
     print(
-        "PASS: release package is self-contained; cold run-cache store and warm hit succeeded"
+        "PASS: release package is self-contained; core and agent cold stores and warm hits succeeded"
     )
     return 0
 

--- a/scripts/verify_release_package.py
+++ b/scripts/verify_release_package.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Verify that a staged Eshkol release package is self-contained and runnable.
+
+The release archives must support the default ``eshkol-run -r`` persistent
+run-cache path without consulting an older system-wide Eshkol installation.
+This verifier deliberately performs both a cold cache build and a warm cache
+execution, and rejects the otherwise-successful in-process JIT fallback.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+from typing import NoReturn
+
+
+DEFAULT_TIMEOUT_SECONDS = 900
+EXPECTED_SMOKE_OUTPUT = "hello from windows smoke"
+
+
+def fail(message: str, *, stdout: str = "", stderr: str = "") -> NoReturn:
+    print(f"FAIL: {message}", file=sys.stderr)
+    if stdout:
+        print("--- stdout ---", file=sys.stderr)
+        print(stdout, file=sys.stderr, end="" if stdout.endswith("\n") else "\n")
+    if stderr:
+        print("--- stderr ---", file=sys.stderr)
+        print(stderr, file=sys.stderr, end="" if stderr.endswith("\n") else "\n")
+    raise SystemExit(1)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def run_checked(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    timeout: int,
+    description: str,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        fail(
+            f"{description} timed out after {timeout}s",
+            stdout=exc.stdout or "",
+            stderr=exc.stderr or "",
+        )
+    if result.returncode != 0:
+        fail(
+            f"{description} exited with status {result.returncode}",
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+    return result
+
+
+def verify_cache_run(
+    runner: Path,
+    smoke_source: Path,
+    package_dir: Path,
+    env: dict[str, str],
+    timeout: int,
+    expected_trace: str,
+) -> None:
+    result = run_checked(
+        [str(runner), "-r", str(smoke_source)],
+        cwd=package_dir,
+        env=env,
+        timeout=timeout,
+        description=f"package smoke ({expected_trace.strip()})",
+    )
+    if EXPECTED_SMOKE_OUTPUT not in result.stdout:
+        fail(
+            f"package smoke did not print {EXPECTED_SMOKE_OUTPUT!r}",
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+    forbidden = (
+        "[jit-cache] compile-failed",
+        "[jit-cache] compile-timeout",
+        "[jit-cache] store-failed",
+    )
+    if any(marker in result.stderr for marker in forbidden):
+        fail(
+            "persistent run-cache failed and silently fell back to in-process JIT",
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+    if expected_trace not in result.stderr:
+        fail(
+            f"package smoke did not report required trace {expected_trace!r}",
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--package-dir", required=True, type=Path)
+    parser.add_argument("--smoke-source", required=True, type=Path)
+    parser.add_argument("--expected-version", required=True)
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=DEFAULT_TIMEOUT_SECONDS,
+    )
+    args = parser.parse_args()
+
+    package_dir = args.package_dir.resolve()
+    smoke_source = args.smoke_source.resolve()
+    if not package_dir.is_dir():
+        fail(f"package directory does not exist: {package_dir}")
+    if not smoke_source.is_file():
+        fail(f"smoke source does not exist: {smoke_source}")
+    if args.timeout_seconds <= 0:
+        fail("--timeout-seconds must be positive")
+
+    windows = os.name == "nt"
+    runner = package_dir / "bin" / ("eshkol-run.exe" if windows else "eshkol-run")
+    runtime_name = "eshkol-runtime.lib" if windows else "libeshkol-runtime.a"
+    runtime_paths = (
+        package_dir / "lib" / runtime_name,
+        package_dir / "lib" / "eshkol" / runtime_name,
+    )
+
+    if not runner.is_file():
+        fail(f"packaged runner is missing: {runner}")
+    for runtime_path in runtime_paths:
+        if not runtime_path.is_file() or runtime_path.stat().st_size == 0:
+            fail(f"packaged runtime archive is missing or empty: {runtime_path}")
+    if sha256(runtime_paths[0]) != sha256(runtime_paths[1]):
+        fail("packaged runtime archive copies differ")
+
+    base_env = os.environ.copy()
+    version = run_checked(
+        [str(runner), "--version"],
+        cwd=package_dir,
+        env=base_env,
+        timeout=60,
+        description="packaged eshkol-run --version",
+    )
+    version_text = version.stdout + version.stderr
+    if args.expected_version not in version_text:
+        fail(
+            f"packaged version does not contain {args.expected_version!r}",
+            stdout=version.stdout,
+            stderr=version.stderr,
+        )
+
+    with tempfile.TemporaryDirectory(prefix="eshkol-release-package-smoke-") as tmp:
+        state_dir = Path(tmp)
+        home_dir = state_dir / "home"
+        cache_dir = state_dir / "jit-cache"
+        home_dir.mkdir()
+
+        env = base_env.copy()
+        env["HOME"] = str(home_dir)
+        env["XDG_CACHE_HOME"] = str(state_dir / "xdg-cache")
+        env["LOCALAPPDATA"] = str(state_dir / "local-app-data")
+        env["ESHKOL_JIT_CACHE_DIR"] = str(cache_dir)
+        env["ESHKOL_JIT_CACHE_TRACE"] = "1"
+
+        verify_cache_run(
+            runner,
+            smoke_source,
+            package_dir,
+            env,
+            args.timeout_seconds,
+            "[jit-cache] store ",
+        )
+        verify_cache_run(
+            runner,
+            smoke_source,
+            package_dir,
+            env,
+            args.timeout_seconds,
+            "[jit-cache] hit ",
+        )
+
+    print(
+        "PASS: release package is self-contained; cold run-cache store and warm hit succeeded"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/toolchain/release-agent-smoke.esk
+++ b/tests/toolchain/release-agent-smoke.esk
@@ -1,0 +1,21 @@
+;; Release-package smoke for the separately shipped agent FFI archive.
+;; A cold `eshkol-run -r` must link this from the package, never from a
+;; build-machine path baked into build_config.h.
+(require stdlib)
+(require agent.regex)
+
+(define pattern (regex-compile "^release-[0-9]+$"))
+(define ok (and (not (= pattern -1))
+                (regex-match? pattern "release-133")
+                (not (regex-match? pattern "release-broken"))))
+(when (not (= pattern -1))
+  (regex-free pattern))
+
+(if ok
+    (begin
+      (display "release agent smoke")
+      (newline))
+    (begin
+      (display "release agent smoke failed")
+      (newline)
+      (exit 1)))


### PR DESCRIPTION
Fixes the v1.3.3 release blockers found by smoke-testing the nonpublishing asset bundle.

The archives shipped stdlib.o and stdlib.bc but omitted the split Eshkol runtime archives. A packaged eshkol-run -r therefore searched system install locations, linked against a stale core runtime when one existed, emitted unresolved promise/port symbols, and silently fell back to in-process ORC. Agent AOT links also retained the build-machine eshkol-agent-ffi archive path.

This change:
- bundles matching core and agent FFI runtime archives in every Unix/macOS and Windows package
- resolves agent FFI archives beside the packaged core runtime instead of replaying a build-machine path
- preserves the exact optional dependency closure discovered by CMake
- adds a cross-platform staged-package verifier
- requires version correctness, duplicate archive integrity, core and agent cold persistent-cache stores, and warm cache hits
- rejects compile-failed, compile-timeout, and store-failed fallback traces

Local verification:
- exact source build: cold store + warm hit
- original macOS ARM64 archive: correctly rejected for missing runtime archive
- corrected macOS ARM64 staging: core and agent cold stores + warm hits PASS
- existing jit_cache_test PASS
- full agent FFI regression: 13/13 PASS
- Python syntax, workflow YAML parse, and git diff checks PASS

No release tag or GitHub release is created.