### PR TITLE
test: validate generated release evidence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2870,15 +2870,23 @@ if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/ma
     add_test(NAME machine_integer_types_test COMMAND machine_integer_types_test)
 endif()
 
-if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/test_runtime_language_coverage.py")
+if(ESHKOL_BUILD_TESTS)
     find_program(ESHKOL_PYTHON3_EXECUTABLE NAMES python3 python)
+    if(ESHKOL_PYTHON3_EXECUTABLE AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_generated_artifact_validator.py")
+        add_test(
+            NAME generated_artifact_validator_test
+            COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_generated_artifact_validator.py"
+        )
+        set_tests_properties(generated_artifact_validator_test PROPERTIES TIMEOUT 120)
+    endif()
     # Native Windows builds intentionally omit the bytecode VM.  Do not
     # register a test whose generator expression names that absent target;
     # CMake evaluates TARGET_FILE expressions during generation and would
     # otherwise reject the entire Windows build before any test can run.
     # The VM target is declared later in this file, so TARGET cannot be used
     # as the configure-time guard here.
-    if(ESHKOL_PYTHON3_EXECUTABLE AND NOT WIN32)
+    if(ESHKOL_PYTHON3_EXECUTABLE AND NOT WIN32 AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/test_runtime_language_coverage.py")
         add_test(
             NAME runtime_language_coverage_test
             COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"

--- a/scripts/check_depth_coverage.py
+++ b/scripts/check_depth_coverage.py
@@ -99,6 +99,34 @@ def check_entry(name, entry, errors):
     return (True, False)
 
 
+def write_depth_coverage_trace(
+    trace_dir, *, passed, swept, composables, pct, gap_count, error_count
+):
+    """Write the bounded depth-coverage runtime contract and return its path."""
+    os.makedirs(trace_dir, exist_ok=True)
+    trace_path = os.path.join(trace_dir, "depth_coverage.jsonl")
+    rec = {
+        "kind": "depth_coverage",
+        "name": "depth_coverage_gate",
+        "value": "PASS" if passed else "FAIL",
+        "snippet": (
+            f"{swept}/{composables} composables swept ({pct:.1f}%), "
+            f"{gap_count} tracked gaps, {error_count} errors"
+        ),
+        "confidence": 0.95,
+    }
+    with open(trace_path, "w", encoding="utf-8") as f:
+        f.write(json.dumps(rec) + "\n")
+        f.write(json.dumps({
+            "kind": "depth_coverage",
+            "name": "depth_coverage_pct",
+            "value": f"{pct:.1f}",
+            "snippet": f"{swept}/{composables} composables have a pillar sweep",
+            "confidence": 0.95,
+        }) + "\n")
+    return trace_path
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--repo-root", default=repo_root_default())
@@ -189,26 +217,15 @@ def main():
 
     if not args.no_trace:
         trace_dir = os.path.join(root, "scripts", "icc_traces")
-        os.makedirs(trace_dir, exist_ok=True)
-        rec = {
-            "kind": "depth_coverage",
-            "name": "depth_coverage_gate",
-            "value": "PASS" if passed else "FAIL",
-            "snippet": (f"{swept}/{composables} composables swept ({pct:.1f}%), "
-                        f"{len(gaps)} tracked gaps, {len(errors)} errors"),
-            "confidence": 0.95,
-        }
-        with open(os.path.join(trace_dir, "depth_coverage.jsonl"), "w",
-                  encoding="utf-8") as f:
-            f.write(json.dumps(rec) + "\n")
-            # Also emit the coverage percentage as a numeric-carrying event.
-            f.write(json.dumps({
-                "kind": "depth_coverage",
-                "name": "depth_coverage_pct",
-                "value": f"{pct:.1f}",
-                "snippet": f"{swept}/{composables} composables have a pillar sweep",
-                "confidence": 0.95,
-            }) + "\n")
+        write_depth_coverage_trace(
+            trace_dir,
+            passed=passed,
+            swept=swept,
+            composables=composables,
+            pct=pct,
+            gap_count=len(gaps),
+            error_count=len(errors),
+        )
 
     return 0 if passed else 1
 

--- a/tests/test_generated_artifact_validator.py
+++ b/tests/test_generated_artifact_validator.py
@@ -1,0 +1,108 @@
+"""CPU-only validators for generated Eshkol manifests and trace artifacts."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+import tempfile
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from scripts import check_depth_coverage
+from scripts import gen_ad_depth
+from scripts import gen_nesting_depth
+from scripts import gen_numeric_depth
+from scripts import gen_recursion_depth
+from scripts import run_generative_differential
+
+
+class GeneratedArtifactValidatorTest(unittest.TestCase):
+    def test_depth_coverage_trace_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(check_depth_coverage.write_depth_coverage_trace(
+                tmp,
+                passed=True,
+                swept=7,
+                composables=8,
+                pct=87.5,
+                gap_count=1,
+                error_count=0,
+            ))
+            self.assertEqual(path.name, "depth_coverage.jsonl")
+            rows = [json.loads(line) for line in path.read_text().splitlines()]
+            self.assertEqual(
+                [row["name"] for row in rows],
+                ["depth_coverage_gate", "depth_coverage_pct"],
+            )
+            self.assertEqual(rows[0]["value"], "PASS")
+
+    def test_ad_depth_manifest_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            generator = gen_ad_depth.Gen(tmp, max_depth=1)
+            generator.generate()
+            manifest = Path(tmp) / "MANIFEST.txt"
+            self.assertTrue(manifest.is_file())
+            self.assertTrue(
+                manifest.read_text().startswith("# depth-parametric AD oracle")
+            )
+            self.assertTrue(generator.files)
+
+    def test_nesting_depth_manifest_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            argv = ["gen_nesting_depth.py", "--outdir", tmp, "--depths", "1"]
+            with mock.patch.object(sys, "argv", argv):
+                gen_nesting_depth.main()
+            manifest = Path(tmp) / "MANIFEST.txt"
+            rows = [
+                line for line in manifest.read_text().splitlines()
+                if not line.startswith("#")
+            ]
+            self.assertEqual(len(rows), len(gen_nesting_depth.CONSTRUCT_ORDER))
+
+    def test_numeric_depth_manifest_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            argv = ["gen_numeric_depth.py", "--out-dir", tmp, "--scale", "0.1"]
+            with mock.patch.object(sys, "argv", argv):
+                gen_numeric_depth.main()
+            manifest = json.loads((Path(tmp) / "manifest.json").read_text())
+            self.assertEqual(manifest["scale"], 0.1)
+            self.assertEqual(len(manifest["families"]), len(gen_numeric_depth.GENERATORS))
+
+    def test_recursion_depth_manifest_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            argv = ["gen_recursion_depth.py", "--outdir", tmp]
+            with mock.patch.object(sys, "argv", argv):
+                gen_recursion_depth.main()
+            manifest = Path(tmp) / "MANIFEST.txt"
+            self.assertTrue(manifest.is_file())
+            text = manifest.read_text()
+            self.assertTrue(all(kind in text for kind in gen_recursion_depth.KIND_ORDER))
+
+    def test_divergence_artifact_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_generative_differential.OracleResult("jit")
+            result.rc = 1
+            result.out = "stdout\n"
+            result.err = "stderr\n"
+            harness = SimpleNamespace(diverg_dir=tmp)
+            divergences = [{
+                "kind": "VALUE_MISMATCH",
+                "program": "case-1",
+                "detail": "expected fixture mismatch",
+            }]
+            run_generative_differential.write_divergence_artifacts(
+                harness, "numeric", "case-1", {"jit": result}, divergences,
+            )
+            record = Path(tmp) / "case-1" / "DIVERGENCES.txt"
+            self.assertEqual(
+                record.read_text(),
+                "VALUE_MISMATCH :: case-1 :: expected fixture mismatch\n",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary: extracts the depth-coverage trace writer into a directly testable contract; validates all six generated artifacts previously reported by ICC as untested; registers the validator in CTest on every supported platform. Verification: Python validator 6/6; focused CTest pass; ICC find-contract-gaps 0 (down from 6); ICC pre-commit-check 0 blockers; git diff check clean. This changes release-readiness evidence only, not language or runtime behavior.