### PR TITLE
Fix Windows persistent JIT cache publication

### DIFF
--- a/exe/eshkol-run.cpp
+++ b/exe/eshkol-run.cpp
@@ -44,8 +44,14 @@
 #include <cstdlib>
 #include <cctype>
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <optional>
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
 
 static constexpr char eshkol_path_separator =
 #ifdef _WIN32
@@ -736,9 +742,35 @@ std::optional<int> tryRunFromPersistentJitCache(const char* argv0,
     jitCacheTrace("miss", key);
     pruneJitCache(cache_dir);
 
+    static std::atomic<uint64_t> temp_sequence{0};
     const auto stamp = std::to_string(
         std::chrono::steady_clock::now().time_since_epoch().count());
-    const auto temp_binary = cache_dir / (cached_binary.filename().string() + ".tmp-" + stamp);
+#ifdef _WIN32
+    const auto process_id = static_cast<uint64_t>(_getpid());
+#else
+    const auto process_id = static_cast<uint64_t>(getpid());
+#endif
+    const auto sequence = temp_sequence.fetch_add(1, std::memory_order_relaxed);
+    // Keep the native executable suffix at the very end of the temporary
+    // filename.  The AOT output normalizer appends the host suffix whenever
+    // the requested output does not already end in it.  On Windows, placing
+    // `.tmp-<stamp>` after `.exe` therefore caused the compiler to create
+    // `run-<key>.exe.tmp-<stamp>.exe` while the cache publisher still tried
+    // to rename `run-<key>.exe.tmp-<stamp>`, forcing every cold packaged run
+    // through the in-process fallback.  POSIX has an empty executable suffix,
+    // so this preserves its established suffix-free temporary convention.
+    const auto temp_binary = cache_dir /
+        (cached_binary.stem().string() + ".tmp-" +
+         std::to_string(process_id) + "-" + stamp + "-" +
+         std::to_string(sequence) +
+         cached_binary.extension().string());
+    auto temp_object = eshkol::platform::with_executable_suffix(temp_binary);
+    temp_object += ".tmp.o";
+
+    const auto remove_temp_object = [&temp_object]() {
+        std::error_code cleanup_ec;
+        std::filesystem::remove(temp_object, cleanup_ec);
+    };
 
     std::vector<std::string> compile_args;
     compile_args.push_back(self_path.string());
@@ -777,6 +809,11 @@ std::optional<int> tryRunFromPersistentJitCache(const char* argv0,
     // asked for: a JIT-link problem must never hang, only fall back.
     int compile_status = eshkol::pkg::run_subprocess(
         compile_args, nullptr, link_subprocess_timeout_seconds());
+    // The child compiler normally removes this linker input itself, but a
+    // concurrent cold-cache stress exposed persistent `.tmp.o` sidecars.
+    // The parent owns the cache transaction and therefore performs a final,
+    // idempotent cleanup after the child has exited on every outcome.
+    remove_temp_object();
     if (compile_status == eshkol::pkg::SUBPROCESS_TIMEOUT) {
         std::filesystem::remove(temp_binary, ec);
         jitCacheTrace("compile-timeout", std::to_string(link_subprocess_timeout_seconds()));
@@ -788,11 +825,26 @@ std::optional<int> tryRunFromPersistentJitCache(const char* argv0,
         return std::nullopt;
     }
 
+    std::error_code temp_ec;
+    if (!std::filesystem::is_regular_file(temp_binary, temp_ec) || temp_ec) {
+        std::filesystem::remove(temp_binary, ec);
+        jitCacheTrace("store-failed", key);
+        return std::nullopt;
+    }
+
     std::filesystem::rename(temp_binary, cached_binary, ec);
     if (ec) {
-        std::filesystem::remove(cached_binary, ec);
-        ec.clear();
-        std::filesystem::rename(temp_binary, cached_binary, ec);
+        // Windows rename does not replace an existing target.  If another
+        // process published the immutable content-addressed entry while this
+        // process compiled, keep the winner and discard only our temporary;
+        // deleting the winner here creates a destructive publication race.
+        std::error_code winner_ec;
+        if (std::filesystem::is_regular_file(cached_binary, winner_ec) &&
+            !winner_ec) {
+            std::filesystem::remove(temp_binary, temp_ec);
+            jitCacheTrace("hit", key);
+            return eshkol::pkg::run_subprocess({cached_binary.string()});
+        }
     }
     if (ec) {
         std::filesystem::remove(temp_binary, ec);

--- a/scripts/run_all_tests.ps1
+++ b/scripts/run_all_tests.ps1
@@ -560,6 +560,91 @@ function Invoke-ProcessCapture {
     }
 }
 
+function Invoke-JitCacheSuite {
+    Write-Section "Eshkol Persistent JIT Cache Test"
+    $suite = New-SuiteState "jit_cache"
+    $testRoot = Join-Path $script:TempRoot ("jit-cache-" + [Guid]::NewGuid().ToString("N"))
+    $cacheDir = Join-Path $testRoot "cache"
+    $sourcePath = Join-Path $testRoot "cache-smoke.esk"
+
+    New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
+    '(display "jit-cache-windows") (newline)' |
+        Set-Content -LiteralPath $sourcePath -Encoding ASCII
+
+    $savedCacheDir = [Environment]::GetEnvironmentVariable("ESHKOL_JIT_CACHE_DIR", "Process")
+    $savedCacheTrace = [Environment]::GetEnvironmentVariable("ESHKOL_JIT_CACHE_TRACE", "Process")
+    try {
+        [Environment]::SetEnvironmentVariable("ESHKOL_JIT_CACHE_DIR", $cacheDir, "Process")
+        [Environment]::SetEnvironmentVariable("ESHKOL_JIT_CACHE_TRACE", "1", "Process")
+
+        $cold = Invoke-ProcessCapture `
+            -FilePath $script:EshkolRun `
+            -Arguments @("-r", $sourcePath) `
+            -WorkingDirectory $script:BuildDir `
+            -TimeoutSec $script:CompileTimeoutSec
+        $coldFailed = $cold.Output -match '\[jit-cache\] (compile-failed|compile-timeout|store-failed)'
+        if ($cold.ExitCode -eq 0 -and
+            $cold.StdOut.Trim() -eq "jit-cache-windows" -and
+            $cold.StdErr -match '\[jit-cache\] miss ' -and
+            $cold.StdErr -match '\[jit-cache\] store ' -and
+            -not $coldFailed) {
+            Format-TestStatus "cold cache store" "PASS" Green
+            Add-Pass $suite
+        } else {
+            Format-TestStatus "cold cache store" "FAIL" Red
+            Show-ProcessFailureDetails -TestName "cold cache store" -Phase "runtime" -Result $cold
+            Add-Fail $suite "cold cache store"
+        }
+
+        $warm = Invoke-ProcessCapture `
+            -FilePath $script:EshkolRun `
+            -Arguments @("-r", $sourcePath) `
+            -WorkingDirectory $script:BuildDir `
+            -TimeoutSec $script:CompileTimeoutSec
+        $warmFailed = $warm.Output -match '\[jit-cache\] (compile-failed|compile-timeout|store-failed)'
+        if ($warm.ExitCode -eq 0 -and
+            $warm.StdOut.Trim() -eq "jit-cache-windows" -and
+            $warm.StdErr -match '\[jit-cache\] hit ' -and
+            -not $warmFailed) {
+            Format-TestStatus "warm cache hit" "PASS" Green
+            Add-Pass $suite
+        } else {
+            Format-TestStatus "warm cache hit" "FAIL" Red
+            Show-ProcessFailureDetails -TestName "warm cache hit" -Phase "runtime" -Result $warm
+            Add-Fail $suite "warm cache hit"
+        }
+
+        $cacheExecutables = @(
+            Get-ChildItem -LiteralPath $cacheDir -File -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -match '^run-[0-9a-f]+\.exe$' }
+        )
+        $orphanTemps = @(
+            Get-ChildItem -LiteralPath $cacheDir -File -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -match '\.tmp-' }
+        )
+        if ($cacheExecutables.Count -eq 1 -and $orphanTemps.Count -eq 0) {
+            Format-TestStatus "cache artifact publication" "PASS" Green
+            Add-Pass $suite
+        } else {
+            Format-TestStatus "cache artifact publication" "FAIL" Red
+            $entryNames = @(
+                Get-ChildItem -LiteralPath $cacheDir -File -ErrorAction SilentlyContinue |
+                    ForEach-Object { $_.Name }
+            )
+            Add-Fail $suite ("expected one final .exe and no temporary artifacts; final={0}, temp={1}, entries={2}" -f $cacheExecutables.Count, $orphanTemps.Count, ($entryNames -join ','))
+        }
+    } finally {
+        [Environment]::SetEnvironmentVariable("ESHKOL_JIT_CACHE_DIR", $savedCacheDir, "Process")
+        [Environment]::SetEnvironmentVariable("ESHKOL_JIT_CACHE_TRACE", $savedCacheTrace, "Process")
+        if ([System.IO.Directory]::Exists($testRoot)) {
+            Remove-Item -LiteralPath $testRoot -Recurse -Force
+        }
+    }
+
+    Show-SuiteSummary $suite
+    return $suite
+}
+
 function Invoke-EshkolCompile {
     param(
         [string]$EshkolRun,
@@ -1493,6 +1578,7 @@ Write-Host ""
 $suiteResults = @()
 switch ($Mode) {
     "all" {
+        $suiteResults += Invoke-JitCacheSuite
         $suiteResults += Invoke-SimpleCompileRunSuite -SuiteName "features" -Title "Eshkol Features Test Suite" -Patterns @("tests/features/*.esk") -RuntimeErrorRegex "error:"
         $suiteResults += Invoke-SimpleCompileRunSuite -SuiteName "stdlib" -Title "Eshkol Stdlib Test Suite" -Patterns @("tests/stdlib/*.esk") -RuntimeErrorRegex "error:"
         $suiteResults += Invoke-SimpleCompileRunSuite -SuiteName "list" -Title "Eshkol List Test Suite" -Patterns @("tests/list/*.esk") -RuntimeErrorRegex "error:"
@@ -1544,6 +1630,7 @@ switch ($Mode) {
         # normal 120-second compile limit.  Keep the bound, but give each
         # Windows smoke-test compile five minutes before declaring a timeout.
         $script:CompileTimeoutSec = 300
+        $suiteResults += Invoke-JitCacheSuite
         $suiteResults += Invoke-SimpleCompileRunSuite -SuiteName "features" -Title "Eshkol Windows Feature Smoke Suite" -Patterns @("tests/features/*.esk") -RuntimeErrorRegex "error:" -IncludeNames @(
             "bitwise_ops_test.esk",
             "bytevector_test.esk",

--- a/tests/toolchain/windows_suite_surface_test.cpp
+++ b/tests/toolchain/windows_suite_surface_test.cpp
@@ -81,6 +81,16 @@ int main(int argc, char** argv) {
     bool ok = true;
 
     ok = ok &&
+         expect_contains(script, "function Invoke-JitCacheSuite",
+                         "Windows suite declares persistent JIT-cache runtime coverage") &&
+         expect_contains(script, "$cold.StdErr -match '\\[jit-cache\\] store '",
+                         "Windows suite requires a real cold cache store") &&
+         expect_contains(script, "$warm.StdErr -match '\\[jit-cache\\] hit '",
+                         "Windows suite requires a real warm cache hit") &&
+         expect_contains(script, "$orphanTemps.Count -eq 0",
+                         "Windows suite rejects orphaned JIT-cache temporaries") &&
+         expect_contains(script, "$suiteResults += Invoke-JitCacheSuite",
+                         "Windows modes execute persistent JIT-cache coverage") &&
          expect_contains(script, "function Get-RegularFileItem",
                          "Windows suite declares regular-file resolver") &&
          expect_contains(script, "Get-Item -LiteralPath $Path -Force -ErrorAction Stop",


### PR DESCRIPTION
The v1.3.3-evolve nonpublishing release matrix exposed a package-wide Windows failure: all six completed Windows assets built and tested successfully, then the release verifier observed a cold cache miss followed by store-failed. The temporary output placed .tmp after .exe, so Windows AOT normalization produced a different suffixed filename than the cache publisher renamed.

This change keeps the native executable suffix final, gives each publisher a process/clock/sequence-unique temporary, validates the child output before publication, preserves an immutable winner in concurrent Windows rename races, and removes linker-object sidecars in the parent transaction. The Windows suite now requires cold miss+store, warm hit, exact output, one final executable, and no temporary artifacts.

Verified:
- macOS Release build and persistent cache suite
- POSIX eight-publisher cold-cache stress: all successful, one final entry, no temp artifacts
- old-donkey Windows 11 x64 MSVC build
- Windows windows-lite: 11/11 suites, 47/47 tests
- Windows two-publisher race: one store, one hit, subsequent warm hit, one final .exe, no temp artifacts
- ICC pre-commit: 8/8 architecture invariants, no drift or blockers

The package verifier remains strict; no fallback, skip, or reduced coverage is introduced.