### PR TITLE
Fix sanitizer custom build directory contract

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3414,6 +3414,18 @@ if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/re
     )
 endif()
 
+if(ESHKOL_BUILD_TESTS AND UNIX AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/sanitizer_build_dir_contract_test.sh")
+    find_program(ESHKOL_BASH_EXECUTABLE bash)
+    if(ESHKOL_BASH_EXECUTABLE)
+        add_test(
+            NAME sanitizer_build_dir_contract_test
+            COMMAND "${ESHKOL_BASH_EXECUTABLE}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/sanitizer_build_dir_contract_test.sh"
+                    "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+    endif()
+endif()
+
 # ===== SDNC Paper Artifact: weight_matrices ===================================
 # The paper "The Self-Differentiating Neural Computer: Computable Transformers
 # via Analytical Weight Construction" (tsotchke 2026) reports a 2.8M-parameter

--- a/scripts/build-sanitizer.sh
+++ b/scripts/build-sanitizer.sh
@@ -9,11 +9,16 @@
 #   scripts/build-sanitizer.sh msan          # memory sanitizer (Linux only, needs
 #                                              instrumented libc++)
 #
-# Builds into build-<flavor>/ so the normal build/ stays intact.
+# Builds into build-<flavor>/ so the normal build/ stays intact.  Set
+# BUILD_DIR to select another repository-relative or absolute output path and
+# ESHKOL_BUILD_JOBS to select a positive parallel-build count.
 # After a successful build the script prints the env vars you should set
 # before running the binary (ASAN_OPTIONS etc.).
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 FLAVOR="${1:-}"
 if [[ -z "${FLAVOR}" ]]; then
@@ -33,8 +38,41 @@ case "${FLAVOR}" in
     *) echo "unknown flavor: ${FLAVOR}" >&2; exit 2 ;;
 esac
 
-BUILD_DIR="build-${FLAVOR//+/-}"
+detect_jobs() {
+    local detected=""
+    if command -v getconf >/dev/null 2>&1; then
+        detected="$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)"
+    fi
+    if ! [[ "$detected" =~ ^[1-9][0-9]*$ ]] && command -v sysctl >/dev/null 2>&1; then
+        detected="$(sysctl -n hw.ncpu 2>/dev/null || true)"
+    fi
+    if ! [[ "$detected" =~ ^[1-9][0-9]*$ ]] && command -v nproc >/dev/null 2>&1; then
+        detected="$(nproc 2>/dev/null || true)"
+    fi
+    if ! [[ "$detected" =~ ^[1-9][0-9]*$ ]]; then
+        detected=1
+    fi
+    printf '%s\n' "$detected"
+}
+
+JOBS="${ESHKOL_BUILD_JOBS:-$(detect_jobs)}"
+if ! [[ "$JOBS" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ESHKOL_BUILD_JOBS must be a positive integer: $JOBS" >&2
+    exit 2
+fi
+
+DEFAULT_BUILD_DIR="build-${FLAVOR//+/-}"
+BUILD_DIR="${BUILD_DIR:-$DEFAULT_BUILD_DIR}"
+case "$BUILD_DIR" in
+    /*) ;;
+    *) BUILD_DIR="$REPO_ROOT/$BUILD_DIR" ;;
+esac
 mkdir -p "${BUILD_DIR}"
+BUILD_DIR="$(cd "$BUILD_DIR" && pwd)"
+if [ "$BUILD_DIR" = "$REPO_ROOT" ]; then
+    echo "refusing in-source sanitizer build: $BUILD_DIR" >&2
+    exit 2
+fi
 
 # Sanitizer builds want Debug/RelWithDebInfo so stack traces have
 # symbols; -O0 makes the runs unbearable on real test suites, -O1
@@ -42,15 +80,14 @@ mkdir -p "${BUILD_DIR}"
 # yourself.
 : "${CMAKE_BUILD_TYPE:=RelWithDebInfo}"
 
-cd "${BUILD_DIR}"
-cmake .. \
+cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
     -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
     -DESHKOL_ENABLE_ASAN="${ASAN}" \
     -DESHKOL_ENABLE_UBSAN="${UBSAN}" \
     -DESHKOL_ENABLE_TSAN="${TSAN}" \
     -DESHKOL_ENABLE_MSAN="${MSAN}"
 
-make -j"$(sysctl -n hw.ncpu 2>/dev/null || nproc)" eshkol-run stdlib
+cmake --build "$BUILD_DIR" --target eshkol-run stdlib --parallel "$JOBS"
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
     ASAN_EXAMPLE_OPTIONS="detect_leaks=0:abort_on_error=0"
@@ -70,6 +107,6 @@ Run tests with:
                      ./eshkol-run ../tests/v1_2_edge_cases/hardening_path_test.esk)
 
 Or run the full regression suite:
-  BUILD_DIR=${BUILD_DIR} bash scripts/run_all_tests.sh
+  BUILD_DIR=${BUILD_DIR} bash ${SCRIPT_DIR}/run_all_tests.sh
 
 EOF

--- a/scripts/run_sanitizer_fuzz.sh
+++ b/scripts/run_sanitizer_fuzz.sh
@@ -1002,7 +1002,9 @@ if [ "$SELF_TEST_ONLY" -eq 1 ]; then
 fi
 
 if [ "$SKIP_BUILD" -eq 0 ]; then
-    CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-RelWithDebInfo}" scripts/build-sanitizer.sh asan+ubsan
+    BUILD_DIR="$BUILD_DIR_ABS" \
+        CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-RelWithDebInfo}" \
+        scripts/build-sanitizer.sh asan+ubsan
 fi
 
 if [ ! -x "$ESHKOL_RUN" ]; then

--- a/tests/toolchain/sanitizer_build_dir_contract_test.sh
+++ b/tests/toolchain/sanitizer_build_dir_contract_test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: sanitizer_build_dir_contract_test.sh <source-root>" >&2
+    exit 2
+fi
+
+SOURCE_ROOT="$(cd "$1" && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-sanitizer-build-dir.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+FAKE_BIN="$TMP_ROOT/bin"
+CUSTOM_BUILD="$TMP_ROOT/custom/nested/sanitizer-build"
+CMAKE_LOG="$TMP_ROOT/cmake.log"
+mkdir -p "$FAKE_BIN" "$TMP_ROOT/unrelated-cwd"
+
+cat > "$FAKE_BIN/cmake" <<'FAKE_CMAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$ESHKOL_TEST_CMAKE_LOG"
+FAKE_CMAKE
+chmod +x "$FAKE_BIN/cmake"
+
+(
+    cd "$TMP_ROOT/unrelated-cwd"
+    PATH="$FAKE_BIN:$PATH" \
+        ESHKOL_TEST_CMAKE_LOG="$CMAKE_LOG" \
+        ESHKOL_BUILD_JOBS=3 \
+        BUILD_DIR="$CUSTOM_BUILD" \
+        CMAKE_BUILD_TYPE=RelWithDebInfo \
+        "$SOURCE_ROOT/scripts/build-sanitizer.sh" asan+ubsan >/dev/null
+)
+
+call_count="$(wc -l < "$CMAKE_LOG" | tr -d ' ')"
+if [ "$call_count" -ne 2 ]; then
+    echo "expected exactly two cmake calls, got $call_count" >&2
+    cat "$CMAKE_LOG" >&2
+    exit 1
+fi
+
+configure="$(sed -n '1p' "$CMAKE_LOG")"
+build="$(sed -n '2p' "$CMAKE_LOG")"
+CANONICAL_BUILD="$(cd "$CUSTOM_BUILD" && pwd)"
+
+case "$configure" in
+    *"-S $SOURCE_ROOT -B $CANONICAL_BUILD"*) ;;
+    *) echo "configure did not preserve source/build roots: $configure" >&2; exit 1 ;;
+esac
+case "$configure" in
+    *"-DESHKOL_ENABLE_ASAN=ON"*"-DESHKOL_ENABLE_UBSAN=ON"*) ;;
+    *) echo "configure lost sanitizer selection: $configure" >&2; exit 1 ;;
+esac
+case "$build" in
+    *"--build $CANONICAL_BUILD --target eshkol-run stdlib --parallel 3"*) ;;
+    *) echo "build did not use the requested directory/targets: $build" >&2; exit 1 ;;
+esac
+
+test -d "$CUSTOM_BUILD"
+
+if PATH="$FAKE_BIN:$PATH" \
+    ESHKOL_TEST_CMAKE_LOG="$CMAKE_LOG" \
+    ESHKOL_BUILD_JOBS=0 \
+    BUILD_DIR="$TMP_ROOT/invalid-jobs" \
+    "$SOURCE_ROOT/scripts/build-sanitizer.sh" asan >/dev/null 2>"$TMP_ROOT/invalid.err"; then
+    echo "invalid ESHKOL_BUILD_JOBS unexpectedly succeeded" >&2
+    exit 1
+fi
+grep -F "ESHKOL_BUILD_JOBS must be a positive integer: 0" "$TMP_ROOT/invalid.err" >/dev/null
+test ! -e "$TMP_ROOT/invalid-jobs"
+
+if PATH="$FAKE_BIN:$PATH" \
+    ESHKOL_TEST_CMAKE_LOG="$CMAKE_LOG" \
+    ESHKOL_BUILD_JOBS=1 \
+    BUILD_DIR="$SOURCE_ROOT" \
+    "$SOURCE_ROOT/scripts/build-sanitizer.sh" asan >/dev/null 2>"$TMP_ROOT/in-source.err"; then
+    echo "in-source sanitizer build unexpectedly succeeded" >&2
+    exit 1
+fi
+grep -F "refusing in-source sanitizer build: $SOURCE_ROOT" "$TMP_ROOT/in-source.err" >/dev/null
+
+if [ "$(wc -l < "$CMAKE_LOG" | tr -d ' ')" -ne "$call_count" ]; then
+    echo "invalid contract inputs reached cmake" >&2
+    cat "$CMAKE_LOG" >&2
+    exit 1
+fi
+
+echo "sanitizer custom build-directory contract: PASS"


### PR DESCRIPTION
Summary:
- honor run_sanitizer_fuzz.sh --build-dir during configure/build instead of silently building build-asan-ubsan
- make build-sanitizer.sh independent of caller cwd, portable across macOS/Linux CPU detection, and refuse in-source or invalid parallel builds
- add a CTest contract test for custom output paths, sanitizer flags, targets, parallelism, and safety rejections

Verification:
- custom ASan+UBSan build completed at /private/tmp/eshkol-v133-final-asan-fixed
- bounded sanitizer gate: 150 corpus files across interpreter, AOT -O0, and AOT -O2; no ASan/UBSan findings; teeth check PASS; 73 MiB peak artifacts
- sanitizer_build_dir_contract_test: PASS directly and through CTest
- VM parity: 68/68 PASS
- ICC pre-commit: architecture 8/8, zero blockers

No release tag was created or moved.