### PR TITLE
chore: harden final v1.3.3 release audit

### DIFF
--- a/.icc/modularity-justifications.json
+++ b/.icc/modularity-justifications.json
@@ -59,6 +59,24 @@
    "task_id": "post-v1.3.1-hardening",
    "reason": "system_codegen.cpp is the cohesive registry of system/OS/FFI builtin codegen (file/process/terminal/HTTP/websocket/tree-sitter/etc.), kept as one facade so the builtin-dispatch table stays co-located. It crossed the 2000-line threshold by 6 lines solely due to the v1.3.1 Doxygen documentation pass (comment-only growth), not new logic.",
    "mitigation": "Any real code growth would be split by extracting per-domain builtin groups (fs/process/net/terminal) behind the existing dispatch facade into focused modules; tracked with the v1.8 modular-boundaries plan. Comment-driven growth needs no split."
-  }
- ]
+   },
+   {
+    "path_patterns": [
+     "lib/agent/c/agent_subprocess.c"
+    ],
+    "status": "accepted",
+    "task_id": "v1.3.3-agent-subprocess-contract",
+    "reason": "agent_subprocess.c owns one cohesive cross-platform subprocess lifecycle state machine: argument validation and quoting, spawn, pipe I/O, timeout-aware wait, termination, and destruction. Keeping that state and its Windows/POSIX parity logic together makes ownership and cleanup invariants auditable; splitting solely at the line threshold would scatter the lifecycle across translation units without creating a stable public boundary.",
+    "mitigation": "Keep the lifecycle behind the existing qllm_process_* API, require the sanitizer/build-directory and hosted Windows/POSIX lanes for changes, and extract a platform backend only when it can share a typed internal process-state contract rather than duplicate cleanup logic."
+   },
+   {
+    "path_patterns": [
+     "lib/agent/c/agent_platform.c"
+    ],
+    "status": "temporary_legacy_boundary",
+    "task_id": "eshkol-v1.4-agent-platform-modularization",
+    "reason": "agent_platform.c is the existing portability facade for filesystem, time, path, text-width, encoding, hashing, and security helpers. Its public surface is stable and fully cross-platform tested, but its domains are broader than one ideal module; a release-time textual split would add linkage and platform risk without changing behavior.",
+    "mitigation": "Do not add new domains to this file. During the v1.4 agent-platform boundary pass, extract filesystem/path, time/identity, terminal-text, and encoding/crypto helpers behind focused internal headers while preserving the current exported ABI and validating every extraction on macOS, Linux, and old-donkey Windows."
+   }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.3-evolve] - 2026-07-13 (release candidate; untagged)
+## [1.3.3-evolve] - 2026-07-15 (release candidate; untagged)
 
 An evolve release over v1.3.2-evolve that completes the Moonlab quantum
 trajectory, closes native/VM semantic gaps, makes every declared language
@@ -29,8 +29,8 @@ gate green.  This section describes an **untagged release candidate**; no
   200/200, H2 VQE agrees with the exact energy to `4.4e-16`, and the CHSH gate
   measures `S ~= 2.86`. (#261, #268-#270, #272-#273)
 - **Executable language-surface completion.** Deterministic native and VM
-  probes now execute every one of the 1,056 declared language-surface rows.
-  The coverage policy is ratcheted to **1056/1056 (100%)**, with no token-only,
+  probes now execute every one of the 1,057 declared language-surface rows.
+  The coverage policy is ratcheted to **1057/1057 (100%)**, with no token-only,
   unreachable, or dead-code credit and zero uncovered high-risk rows. (#258,
   #274 and this release candidate)
 - **Production architecture evidence.** The ICC architecture model now checks
@@ -76,11 +76,11 @@ gate green.  This section describes an **untagged release candidate**; no
 ### Verification
 
 - Aggregate suite: **44/44 suites, 716/716 tests**.
-- CTest: **71/71**; SICP full-book gate: **88/88** JIT+AOT probes.
+- CTest: **77/77**; SICP full-book gate: **88/88** JIT+AOT probes.
 - Chibi Scheme reference differential: **34/34 AGREE**; generative five-oracle
   differential: **127 programs, zero divergences**.
 - VM parity: **68/68**; VM extended surface: **53/53**.
-- Executable language coverage: **1056/1056 (100%)**; WebAssembly import glue:
+- Executable language coverage: **1057/1057 (100%)**; WebAssembly import glue:
   **101/101 imports provided**.
 - Taylor monomorphization equivalence: **441/441 JIT + 441/441 AOT**, bit-exact
   through order eight.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Eshkol v1.3.3-evolve — Release Notes
 
-**Candidate Date**: July 14, 2026
+**Candidate Date**: July 15, 2026
 **Status**: untagged release candidate; no public `v1.3.3-evolve` tag exists.
 
 Eshkol v1.3.3-evolve combines the completed Moonlab quantum stack with a
@@ -11,10 +11,10 @@ full-book SICP, external-reference, generative, WebAssembly, CTest, and ICC
 architecture gates. Full technical detail lives in
 [CHANGELOG.md](CHANGELOG.md).
 
-**Release gates**: 44/44 suites and 716/716 tests; CTest 71/71; SICP 88/88
+**Release gates**: 44/44 suites and 716/716 tests; CTest 77/77; SICP 88/88
 JIT+AOT probes; Chibi Scheme 34/34 AGREE; five-oracle generative differential
 127 programs with zero divergences; VM parity 68/68; VM extended surface
-53/53; executable language coverage 1056/1056 (100%); WebAssembly imports
+53/53; executable language coverage 1057/1057 (100%); WebAssembly imports
 101/101 provided; Taylor monomorphization equivalence 441/441 under both JIT
 and AOT; ICC architecture model 8/8; ICC readiness 100/100.
 
@@ -46,7 +46,7 @@ upstream macOS weak-import linker fix and builds without a local override.
 
 ### Complete executable language coverage
 
-- The coverage manifest now has **1,056/1,056 executable rows**. Credit
+- The coverage manifest now has **1,057/1,057 executable rows**. Credit
   requires a deterministic reachable execution trace; tokens, declarations,
   and dead code do not count.
 - Native and bytecode backends agree on **68/68 parity probes**, including

--- a/docs/internal/RELEASE_READINESS_REPORT.md
+++ b/docs/internal/RELEASE_READINESS_REPORT.md
@@ -2,11 +2,11 @@
 
 **Candidate branch:** `master` plus the release-finalization change set
 **Release line:** `v1.3.x-evolve`
-**Verified hardening baseline:** `502b5a17c180a5e0281be2b339049a783b3e4066`
-**Baseline GitHub Actions:** run `29305913676`, **15/15 jobs green**
+**Verified hardening baseline:** `4055ff0314eb6d39fc72116d85a10ba2ac995ecd`
+**Baseline GitHub Actions:** run `29410550798`, **15/15 jobs green**
 **Candidate head:** the final merged master commit containing this report
 **Published base tag:** `v1.3.2-evolve` (`8443ddae`)
-**Candidate date:** 2026-07-14
+**Candidate date:** 2026-07-15
 **Tag status:** **untagged** — publishing any tag remains a maintainer action.
 
 This report is the release contract for the untagged v1.3.3-evolve candidate.
@@ -31,13 +31,13 @@ No release tag is authorized or created by this campaign.
 | Gate | Result |
 |---|---|
 | Aggregate test harness | **44/44 suites, 716/716 tests**, zero failed/skipped suites |
-| CTest | **71/71** |
+| CTest | **77/77** |
 | SICP full-book | **88/88** JIT+AOT probes, zero xfail/XPASS |
 | Chibi R7RS reference differential | **34/34 AGREE**, zero divergence/error |
 | Generative multi-oracle differential | **127 programs**, Chibi/JIT/AOT-O0/AOT-O2/VM, zero divergence |
 | Native/VM parity | **68/68** source+ESKB probes; unsupported paths fail explicitly |
 | VM extended hosted surface | **53/53** |
-| Executable language surface | **1056/1056 (100%)**, zero uncovered/high-risk rows |
+| Executable language surface | **1057/1057 (100%)**, zero uncovered/high-risk rows |
 | Taylor monomorphization equivalence | **441/441 JIT + 441/441 AOT**, bit-exact through order 8 |
 | Poincare manifold invariant | **17/17** analytic checks |
 | Automatic differentiation | **54/54** aggregate AD suite plus adversarial finite-difference gates |
@@ -62,7 +62,7 @@ default build remains dependency-light.
 The language manifest is no longer aspirational. Every declared row must be
 executed by a deterministic test and runtime trace. Token sightings, parser
 recognition, unreachable branches, and dead code earn no credit. The resulting
-ratchet is 1056/1056 and cannot silently regress below 100%.
+ratchet is 1057/1057 and cannot silently regress below 100%.
 
 ### Honest backend parity
 

--- a/tests/toolchain/sanitizer_build_dir_contract_test.sh
+++ b/tests/toolchain/sanitizer_build_dir_contract_test.sh
@@ -18,6 +18,24 @@ mkdir -p "$FAKE_BIN" "$TMP_ROOT/unrelated-cwd"
 cat > "$FAKE_BIN/cmake" <<'FAKE_CMAKE'
 #!/usr/bin/env bash
 set -euo pipefail
+
+require_output_file_path() {
+    local output_path="${1:?output path is required}"
+    case "$output_path" in
+        /*) ;;
+        *)
+            echo "output path must be absolute: $output_path" >&2
+            return 2
+            ;;
+    esac
+    if [ -L "$output_path" ]; then
+        echo "refusing symlinked output path: $output_path" >&2
+        return 2
+    fi
+}
+
+: "${ESHKOL_TEST_CMAKE_LOG:?ESHKOL_TEST_CMAKE_LOG is required}"
+require_output_file_path "$ESHKOL_TEST_CMAKE_LOG"
 printf '%s\n' "$*" >> "$ESHKOL_TEST_CMAKE_LOG"
 FAKE_CMAKE
 chmod +x "$FAKE_BIN/cmake"


### PR DESCRIPTION
## Summary
- validate the sanitizer contract harness log path before redirecting output
- document the cohesive subprocess lifecycle boundary and the tracked v1.4 platform-facade extraction plan
- refresh v1.3.3 candidate evidence to the exact 77/77 CTest and 1057/1057 executable-surface results
- clear the strict ICC v1.3 release production audit without suppressions

## Verification
- sanitizer custom build-directory contract: PASS
- memory suite: 16/16 PASS
- ICC pre-commit check: PASS, 0 blockers
- ICC architecture verification: 8/8 PASS
- ICC v1.3-evolve readiness: 100/100
- ICC v1.3 production audit: PASS, 0 risks, 0 suppressions
- exact pre-PR master CI run 29410550798: 15/15 PASS

This is release-audit and evidence hardening only; it does not reduce coverage or alter product behavior.