### PR TITLE
docs: reconcile final v1.3.3 release evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Eshkol brings **mathematical computing to Lisp** and delivers what other languag
 - **Learn** — interactive textbook with runnable code examples, plus 27 in-depth tutorials
 - **Examples** — 11 complete programs you can run instantly (AD, neural networks, ODE solving, logic programming)
 
-The website itself is written in Eshkol (1,500+ lines) compiled to a 502KB WASM binary. Automatic differentiation works in the browser:
+The website itself is written in Eshkol (1,500+ lines) and compiles to a 220,306-byte (about 215 KiB) WASM binary. Automatic differentiation works in the browser:
 
 ```scheme
 (derivative (lambda (x) (* x x x)) 2.0)  ;; => 12.0 (3x² at x=2)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -130,7 +130,7 @@ This is transparent to user code — the same expression compiles to different b
 
 - macOS (Apple Silicon ARM64, Intel x86_64)
 - Linux (x86_64, ARM64)
-- Windows (native x86_64 via Visual Studio 2022 + LLVM 21)
+- Windows (native x86_64 and ARM64 via Visual Studio 2022 + LLVM 21; CUDA packages are x86_64-only)
 - WebAssembly (browser)
 
 ### Can I deploy Eshkol programs as standalone binaries?
@@ -143,4 +143,4 @@ eshkol-run program.esk -o program
 
 ### Can Eshkol run in the browser?
 
-Yes. Eshkol compiles to WebAssembly. The project website ([eshkol.ai](https://eshkol.ai)) is itself written in Eshkol — 1,500+ lines compiled to a 502KB WASM binary. A bytecode VM REPL also runs in the browser for interactive evaluation.
+Yes. Eshkol compiles to WebAssembly. The project website ([eshkol.ai](https://eshkol.ai)) is itself written in Eshkol — 1,500+ lines compiled to a 220,306-byte (about 215 KiB) WASM binary. A bytecode VM REPL also runs in the browser for interactive evaluation.

--- a/docs/VM_PARITY.md
+++ b/docs/VM_PARITY.md
@@ -14,10 +14,10 @@ but not the VM, and nothing recorded which shared behaviors silently diverged.
 The **VM parity ratchet** makes the subset explicit and makes drift impossible
 to miss.
 
-> Status: the ratchet, manifest, and gate ship with the v1.3.0-evolve release
-> (PR #118 — `scripts/run_vm_parity.sh`, `scripts/vm_parity_audit.py`,
-> `tests/vm_parity/`). The numbers below are from the seeded manifest on the
-> release SHA.
+> Status: the ratchet, manifest, and gate shipped with the v1.3.0-evolve
+> release (PR #118 — `scripts/run_vm_parity.sh`,
+> `scripts/vm_parity_audit.py`, `tests/vm_parity/`). The counts below are from
+> the current v1.3.3-evolve candidate audit.
 
 ## The manifest
 
@@ -30,10 +30,11 @@ statuses:
 | `native-only-justified` | conscious, permanent waiver (FFI, OALR regions, static type syntax, OS/process, parallel runtime, front-end module machinery) — justification mandatory |
 | `gap` | acknowledged hole **or a verified behavioral divergence** (rows referencing `found/*.esk` name symbols present on both surfaces that compute different answers) — justification mandatory |
 
-Seeded 2026-07-03 from the live extraction and hand-verified with probe runs on
-`eshkol-vm-standalone-test` vs native `-r`: **912 rows — 520 `vm-supported`,
-41 `native-only-justified`, 351 `gap`** (the gaps include 27 documented
-bytecode-VM behavioral divergences).
+Seeded 2026-07-03 from the live extraction and continuously re-audited with
+probe runs on `eshkol-vm-standalone-test` vs native `-r`: **916 rows — 540
+`vm-supported`, 44 `native-only-justified`, 332 `gap`**. Verified behavioral
+divergences remain explicit `gap` rows with reproducible programs under
+`tests/vm_parity/found/`.
 
 ## The ratchet workflow
 

--- a/docs/internal/RELEASE_READINESS_REPORT.md
+++ b/docs/internal/RELEASE_READINESS_REPORT.md
@@ -1,12 +1,15 @@
 # Eshkol v1.3.3-evolve Release-Candidate Readiness Report
 
-**Candidate branch:** `master` plus the release-finalization change set
+**Candidate branch:** `master`
 **Release line:** `v1.3.x-evolve`
-**Verified hardening baseline:** `4055ff0314eb6d39fc72116d85a10ba2ac995ecd`
-**Baseline GitHub Actions:** run `29410550798`, **15/15 jobs green**
-**Candidate head:** the final merged master commit containing this report
+**Candidate head:** `bb22e9704db8831c951ea787af87f7fc14b8c960`
+**Exact-head GitHub Actions:** run `29506084897`, **15/15 jobs green**
+**Exact-head Pages deployment:** run `29506084923`, **2/2 jobs green**
+**Code-exact nonpublishing release dry run:** run `29486554508` at
+`af71aaf99b1b36da9a2b358c82d19fd27a9e4232`, **15/15 package jobs plus
+checksum aggregation green**
 **Published base tag:** `v1.3.2-evolve` (`8443ddae`)
-**Candidate date:** 2026-07-15
+**Candidate date:** 2026-07-16
 **Tag status:** **untagged** — publishing any tag remains a maintainer action.
 
 This report is the release contract for the untagged v1.3.3-evolve candidate.
@@ -14,24 +17,28 @@ It supersedes the July 8 readiness snapshot and records gates executed from an
 isolated Release build (`build-hardening`, tests enabled, XLA/GPU disabled with
 their CPU fallbacks still exercised), the final hosted matrix, and dedicated
 mesh evidence. A public tag must not be created until this finalization change
-is merged, the exact master matrix is green, and the non-publishing release
-workflow dry run succeeds.
+is merged, the exact master matrix is green, and a final nonpublishing release
+workflow dry run succeeds on the exact pre-tag head. The successful code-exact
+dry run predates only the documentation/site merge and this readiness-report
+correction; it did not create or move a tag.
 
 ## Verdict
 
-The candidate is release-ready. All deterministic code, differential,
+The candidate code and deployed site are release-ready. All deterministic code, differential,
 coverage, architecture, freestanding, WebAssembly, full-book, hosted-matrix,
-and cross-platform mesh gates are green. The verified hardening baseline's
-required GitHub Actions matrix passed 15/15; the finalization commit must repeat
-that exact-master check and complete the manual non-publishing release matrix.
-No release tag is authorized or created by this campaign.
+and cross-platform mesh gates are green. Exact-master GitHub Actions passed
+15/15 and the Pages deployment passed 2/2. The code-exact nonpublishing release
+run built and validated all 15 supported packages and the checksum aggregation.
+The remaining pre-tag gate is a final nonpublishing packaging replay on the
+exact head after this documentation correction merges. No release tag is
+authorized or created by this campaign.
 
 ## Release Gates
 
 | Gate | Result |
 |---|---|
 | Aggregate test harness | **44/44 suites, 716/716 tests**, zero failed/skipped suites |
-| CTest | **77/77** |
+| CTest | **76/76** |
 | SICP full-book | **88/88** JIT+AOT probes, zero xfail/XPASS |
 | Chibi R7RS reference differential | **34/34 AGREE**, zero divergence/error |
 | Generative multi-oracle differential | **127 programs**, Chibi/JIT/AOT-O0/AOT-O2/VM, zero divergence |
@@ -45,7 +52,7 @@ No release tag is authorized or created by this campaign.
 | WebAssembly import contract | **101/101 unique imports** provided in both JS runtimes |
 | ICC architecture model | **8/8 PASS**, zero FAIL/UNCHECKABLE |
 | ICC release readiness | **100/100**, oracle complete, zero contract/fallback gaps |
-| Working-tree hygiene | Only generated, gitignored ICC runtime evidence is untracked |
+| Working-tree hygiene | Clean exact-source audit; ICC runtime evidence generated outside the audited worktree |
 
 ## What This Candidate Delivers
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -89,4 +89,4 @@ Exact arithmetic, the numeric tower, category-theoretic models.
 
 ## Try it in the browser
 
-Visit **[eshkol.ai](https://eshkol.ai)** to run Eshkol without installing anything. The website itself is a 1,500-line Eshkol program compiled to a 502 KB WebAssembly binary.
+Visit **[eshkol.ai](https://eshkol.ai)** to run Eshkol without installing anything. The website itself is a 1,500-line Eshkol program compiled to a 220,306-byte (about 215 KiB) WebAssembly binary.


### PR DESCRIPTION
## Summary

- update the release-readiness report to exact master CI, Pages, and code-exact dry-run evidence
- correct the CTest gate from 77/77 to the exact 76/76 result
- refresh the VM parity manifest counts to 916 total: 540 supported, 44 native-only justified, 332 gaps
- replace stale current-facing 502 KB WASM claims with the deployed 220,306-byte artifact size
- document native Windows ARM64 support while keeping CUDA scoped to x86_64

## ICC verification

- exact commit: d69a4362faf988d9572ccf92e44fd5039fb8b523
- index: 2,689 files, 48,501 symbols, zero oversized-file blind spots
- memory: 42,876 chunks, zero contract-graph gaps
- runtime evidence: 15 sources, 1,063 events, failure-free PASS
- architecture: 8/8 PASS, zero drift/unchecked
- completion oracle: 28/28 PASS
- readiness: 100/100, zero gaps/stubs
- guard diff and pre-commit: PASS, zero blockers
- production audit: PASS, zero risks
- site release validator: PASS (15 packages + SHA256SUMS = 16 files; VM subset wording scoped)

No tag or release is created by this PR. After merge, the final exact-master nonpublishing release matrix remains the last pre-tag packaging gate.