### PR TITLE
docs: flip v1.3.3-evolve release-status wording from candidate to released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.3-evolve] - 2026-07-15 (release candidate; untagged)
+## [1.3.3-evolve] - 2026-07-16
 
 An evolve release over v1.3.2-evolve that completes the Moonlab quantum
 trajectory, closes native/VM semantic gaps, makes every declared language
 surface executable under deterministic coverage, and incorporates the
 correctness and memory-safety defects exposed while driving every release
-gate green.  This section describes an **untagged release candidate**; no
-`v1.3.3-evolve` tag has been published.
+gate green.
 
 ### Added
 
@@ -32,7 +31,7 @@ gate green.  This section describes an **untagged release candidate**; no
   probes now execute every one of the 1,057 declared language-surface rows.
   The coverage policy is ratcheted to **1057/1057 (100%)**, with no token-only,
   unreachable, or dead-code credit and zero uncovered high-risk rows. (#258,
-  #274 and this release candidate)
+  #274 and this release)
 - **Production architecture evidence.** The ICC architecture model now checks
   eight static/runtime invariants, including honest VM dispatch, quantum QRNG
   provenance, WebAssembly import glue, executable coverage, and the corrected

--- a/README.md
+++ b/README.md
@@ -8,16 +8,14 @@
 
 Eshkol is a Scheme-based programming language that unifies functional programming with native automatic differentiation, providing a mathematically rigorous foundation for gradient-based optimization, numerical simulation, and machine learning research. Built on Homotopy Type Theory foundations and compiled to native code via LLVM, Eshkol delivers mathematical correctness and deterministic performance without sacrificing the elegance of homoiconic Lisp syntax.
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![Version](https://img.shields.io/badge/version-v1.3.3--evolve--rc-orange.svg)](RELEASE_NOTES.md) [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](CMakeLists.txt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![Version](https://img.shields.io/badge/version-v1.3.3--evolve-blue.svg)](RELEASE_NOTES.md) [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](CMakeLists.txt)
 
-🧪 **v1.3.3-evolve release candidate prepared (untagged)** — complete quantum
+📣 **v1.3.3-evolve released** — complete quantum
 S1-S5, 100% executable language-surface coverage, and a clean-host-verified
 payload of **15 platform packages plus `SHA256SUMS.txt`** (16 published files).
 The [release workflow](.github/workflows/release.yml) enforces that contract;
 the full release-gate record and exact platform matrix are in
-[RELEASE_NOTES.md](RELEASE_NOTES.md).
-
-📣 **v1.3.3-evolve announcement prepared** — see
+[RELEASE_NOTES.md](RELEASE_NOTES.md); see
 [ANNOUNCEMENT.md](ANNOUNCEMENT.md) for the full release story.
 
 **[Full documentation index](docs/README.md)** — every guide, reference, and design doc in one place.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,13 +42,12 @@ host compiler cache entry uses CMake's forward-slash path form so nvcc receives
 an intact `-ccbin` value even when Visual Studio is installed below a path with
 spaces.
 
-**Candidate Date**: July 15, 2026
-**Status**: untagged release candidate; no public `v1.3.3-evolve` tag exists.
+**Release Date**: July 16, 2026
 
 Eshkol v1.3.3-evolve combines the completed Moonlab quantum stack with a
 language-wide correctness and evidence campaign. Every declared language
 surface now has deterministic executable evidence, native and VM behavior is
-cross-checked, and the release candidate is green across the aggregate,
+cross-checked, and the release is green across the aggregate,
 full-book SICP, external-reference, generative, WebAssembly, CTest, and ICC
 architecture gates. Full technical detail lives in
 [CHANGELOG.md](CHANGELOG.md).


### PR DESCRIPTION
Final pre-tag documentation fix. The current tree describes itself as an "untagged release candidate" in three public documents — README banner + version badge (README ships inside every release package), the CHANGELOG heading, and the RELEASE_NOTES status block — wording that would be frozen into the tag and contradict the published release. The v1.3.2 tagged tree read "released" with a clean dated heading; this matches that precedent.

Docs-only (3 files, +6/-9). Gates on the exact edited tree: site release validator PASS; ICC architecture 8/8; ICC pre-commit PASS 0 blockers (with vm_parity/coverage trace routes); no residual candidate/untagged wording in any public doc (the internal readiness report intentionally keeps its pre-tag audit record).

After merge, the new master SHA is the tag target for v1.3.3-evolve.