### PR TITLE
fix(site): make section anchor links work (heading ids + fragment scroll)

### DIFF
--- a/site/static/eshkol-runtime.js
+++ b/site/static/eshkol-runtime.js
@@ -225,19 +225,43 @@ class EshkolRuntime {
         });
         // Inline code
         html = html.replace(/`([^`]+)`/g, '<code style="background:#0d0d15;padding:2px 6px;border-radius:4px;font-size:0.85em;color:#a78bfa">$1</code>');
-        // Headers
-        html = html.replace(/^######\s+(.+)$/gm, '<h6 style="margin-top:1.5em;margin-bottom:0.3em;font-size:0.85rem;color:#a0a0b8">$1</h6>');
-        html = html.replace(/^#####\s+(.+)$/gm, '<h5 style="margin-top:1.5em;margin-bottom:0.3em;font-size:0.9rem;color:#a0a0b8">$1</h5>');
-        html = html.replace(/^####\s+(.+)$/gm, '<h4 style="margin-top:1.8em;margin-bottom:0.4em;font-size:1rem;color:#a0a0b8">$1</h4>');
-        html = html.replace(/^###\s+(.+)$/gm, '<h3 style="margin-top:2em;margin-bottom:0.5em;font-size:1.2rem;color:#e8e8f0">$1</h3>');
-        html = html.replace(/^##\s+(.+)$/gm, '<h2 style="margin-top:2.5em;margin-bottom:0.5em;font-size:1.5rem;color:#e8e8f0;border-bottom:1px solid #2a2a3a;padding-bottom:0.3em">$1</h2>');
-        html = html.replace(/^#\s+(.+)$/gm, '<h1 style="margin-top:2em;margin-bottom:0.5em;font-size:2rem;color:#e8e8f0;border-bottom:1px solid #2a2a3a;padding-bottom:0.3em">$1</h1>');
+        // Headers — each carries a GitHub-style slug id so in-document TOC
+        // links and /docs#section deep links have anchors to land on.
+        const usedSlugs = new Map();
+        const headingId = (text) => {
+            let slug = text
+                .replace(/<[^>]+>/g, '')
+                .toLowerCase()
+                .replace(/[^a-z0-9\s_-]/g, '')
+                .trim()
+                .replace(/[\s_]+/g, '-');
+            const seen = usedSlugs.get(slug);
+            usedSlugs.set(slug, (seen || 0) + 1);
+            if (seen) slug = `${slug}-${seen}`;
+            return slug;
+        };
+        const HEADING_STYLES = {
+            1: 'margin-top:2em;margin-bottom:0.5em;font-size:2rem;color:#e8e8f0;border-bottom:1px solid #2a2a3a;padding-bottom:0.3em',
+            2: 'margin-top:2.5em;margin-bottom:0.5em;font-size:1.5rem;color:#e8e8f0;border-bottom:1px solid #2a2a3a;padding-bottom:0.3em',
+            3: 'margin-top:2em;margin-bottom:0.5em;font-size:1.2rem;color:#e8e8f0',
+            4: 'margin-top:1.8em;margin-bottom:0.4em;font-size:1rem;color:#a0a0b8',
+            5: 'margin-top:1.5em;margin-bottom:0.3em;font-size:0.9rem;color:#a0a0b8',
+            6: 'margin-top:1.5em;margin-bottom:0.3em;font-size:0.85rem;color:#a0a0b8',
+        };
+        for (let level = 6; level >= 1; level--) {
+            const re = new RegExp(`^#{${level}}\\s+(.+)$`, 'gm');
+            html = html.replace(re, (_, text) =>
+                `<h${level} id="${headingId(text)}" style="${HEADING_STYLES[level]}">${text}</h${level}>`);
+        }
         // Bold and italic
         html = html.replace(/\*\*\*(.+?)\*\*\*/g, '<strong><em>$1</em></strong>');
         html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
         html = html.replace(/\*(.+?)\*/g, '<em>$1</em>');
         // Links
-        html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" style="color:#a78bfa">$1</a>');
+        html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, href) =>
+            href.startsWith('#')
+                ? `<a href="${href}" style="color:#a78bfa">${text}</a>`
+                : `<a href="${href}" target="_blank" style="color:#a78bfa">${text}</a>`);
         // Images (just show as links)
         html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<em>[$1]</em>');
         // Blockquotes
@@ -991,6 +1015,13 @@ class EshkolRuntime {
                         }).then(text => {
                             // Render markdown to HTML with syntax highlighting
                             target.innerHTML = rt.renderMarkdown(text);
+                            // Deep links (/docs#section): the anchor only
+                            // exists after this async load, so scroll now.
+                            const fragment = decodeURIComponent(window.location.hash.slice(1));
+                            if (fragment) {
+                                const anchor = document.getElementById(fragment);
+                                if (anchor) anchor.scrollIntoView();
+                            }
                         }).catch(e => {
                             target.innerHTML = '<p style="color:#ff4444">Failed to load: ' + e.message + '</p>';
                         });

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -81,10 +81,21 @@
 
         // ─── Navigation helper ─────────────────────────────────────────
         // Calls scheme_main which re-reads pathname and renders the page.
+        // Scroll to the URL fragment if its anchor is in the DOM. Content
+        // rendered synchronously by scheme_main anchors immediately; content
+        // fetched asynchronously scrolls from its own load callback.
+        const scrollToFragment = () => {
+          const fragment = decodeURIComponent(window.location.hash.slice(1));
+          if (!fragment) return;
+          const anchor = document.getElementById(fragment);
+          if (anchor) anchor.scrollIntoView();
+        };
+
         const navigate = () => {
           if (instance.exports.scheme_main) {
             instance.exports.scheme_main(0);
           }
+          scrollToFragment();
           if (window.location.pathname === '/downloads' ||
               window.location.pathname === '/download') {
             setTimeout(loadReleases, 100);
@@ -95,6 +106,7 @@
         if (instance.exports.main) {
           instance.exports.main(0, 0);
         }
+        scrollToFragment();
 
         // Back / forward
         window.addEventListener('popstate', navigate);
@@ -166,6 +178,11 @@
               }).then(md => {
                 area.innerHTML = runtime.renderMarkdown(md);
                 area.scrollTop = 0;
+                const fragment = decodeURIComponent(window.location.hash.slice(1));
+                if (fragment) {
+                  const anchor = document.getElementById(fragment);
+                  if (anchor) anchor.scrollIntoView();
+                }
               }).catch(err => {
                 area.innerHTML = '<p style="color:#ff4444">Failed to load: ' + err.message + '</p>';
               });


### PR DESCRIPTION
## Problem

Deep links to documentation sections, e.g. https://eshkol.ai/docs#consciousness-engine, land at the top of the page instead of the section. In-document table-of-contents links also opened new tabs instead of scrolling.

## Root causes (site shell only, no wasm change)

1. `renderMarkdown` in `eshkol-runtime.js` emitted headings with **no id attributes** — URL fragments had no anchors to land on.
2. Nothing scrolled to `location.hash` after SPA boot, in-page navigation, or the async sidebar content fetch — the anchor only exists after the fetch resolves.
3. The markdown link renderer forced `target="_blank"` on every link, including pure-fragment `#section` links.

## Fix

- Every rendered heading now carries a GitHub-style slug id (lowercased, punctuation stripped, spaces to dashes, deduplicated within a document, inline HTML stripped first).
- All four content injection points (initial boot, `navigate()`, the sidebar `data-url` loader, and `web_load_content`) scroll the fragment's anchor into view once it exists.
- Pure-fragment links no longer get `target="_blank"`.

## Verification

Headless-Chrome harness replaying the exact deep-link flow: boot at `/docs#consciousness-engine` → async Language Guide fetch → `ANCHOR-FOUND tag=H2 viewportTop=0 scrolled=true`. `scripts/verify_site_release.py` PASS.