### PR TITLE
examples: differentiable quantum chemistry (Eshkol AD × Moonlab VQE)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -47,6 +47,18 @@ Work-stealing thread pool, Chase-Lev deques, per-worker arenas, no GC pauses.
 | **[monte_carlo_pi.esk](monte_carlo_pi.esk)** | Estimate π by parallel Monte Carlo: 1.6M samples across 8 independent PRNG streams in ~45 ms (≈35M samples/sec on M2 Ultra) | 63 |
 | **[streaming_stats.esk](streaming_stats.esk)** | Welford's online algorithm for running mean, variance, min, max. 200,000 samples processed without ever storing the stream | 90 |
 
+
+## Quantum chemistry
+
+Eshkol's automatic differentiation driving [Moonlab](https://github.com/tsotchke/moonlab)'s VQE — built only when `-DESHKOL_QUANTUM_ENABLED=ON`.
+
+| Example | What it shows | LOC |
+|---------|--------------|----:|
+| **[vqe_h2.esk](vqe_h2.esk)** | Gradient-descend *through* `vqe-energy` to the H₂ ground state, −1.14217 Ha; the gradient is Eshkol's, flowing through the Moonlab energy call | 60 |
+| **[h2_vibrational_quantum.esk](h2_vibrational_quantum.esk)** | Vibrational frequency from Moonlab's exact ground energy, finite-differenced over bond length: ω ≈ 4936 cm⁻¹ | 70 |
+| **[h2_vibrational_full.esk](h2_vibrational_full.esk)** | The deep weld: Eshkol Taylor-towers the Pauli coefficients while Moonlab supplies ⟨Pᵢ⟩, the parameter Hessian, and the response gradient via auxiliary Hamiltonians — the Born-Oppenheimer response formula gives ω = 5003 cm⁻¹, matching the pure-AD answer exactly | 175 |
+| **[qng_vqe.esk](qng_vqe.esk)** | Quantum Natural Gradient in Scheme: θ ← θ − lr·(g+εI)⁻¹∇E with the Fubini-Study metric g = `vqe-qgt`; reaches the ground state in ~⅓ the steps of vanilla GD | 96 |
+
 ## Cognitive computing
 
 The consciousness engine: logic programming, active inference, global workspace.

--- a/examples/h2_vibrational_full.esk
+++ b/examples/h2_vibrational_full.esk
@@ -1,0 +1,187 @@
+;; ==================================================================
+;; H2 vibrational frequency: Eshkol geometry-AD + Moonlab quantum response
+;; ==================================================================
+;;
+;; The Born-Oppenheimer force constant is
+;;   k = d2E/dR2 = sum_i g_i''(R) <P_i>  -  E_thetaR^T (E_thetatheta)^-1 E_thetaR  +  1/R''
+;; where the geometry derivatives of the Pauli coefficients g_i(R) come from
+;; Eshkol's Taylor tower (exact AD), and every quantum quantity -- the ground
+;; state |psi(theta*)>, the per-configuration response, and the theta-Hessian --
+;; comes from Moonlab, assembled from vqe-energy / vqe-gradient over AUXILIARY
+;; Hamiltonians H = sum g_i P_i, H' = sum g_i' P_i, H'' = sum g_i'' P_i.
+;;
+;; The second (response) term is NOT a small correction: for H2 it is ~150% of
+;; the frozen term, so leaving it out gives a qualitatively wrong frequency.
+;;
+;; Run:  ./build/eshkol-run -r examples/h2_vibrational_full.esk
+
+(require agent.quantum)
+
+(define pi 3.141592653589793)
+(define exps  (list 3.42525091 0.62391373 0.16885540))
+(define coefs (list 0.15432897 0.53532814 0.44463454))
+(define (nprim a) (expt (/ (* 2.0 a) pi) 0.75))
+(define dn (map (lambda (a d) (* d (nprim a))) exps coefs))
+
+(define (my-erf x)   ;; Abramowitz-Stegun 7.1.26 (smooth, x>=0)
+  (let* ((t (/ 1.0 (+ 1.0 (* 0.3275911 x))))
+         (p (* t (+ 0.254829592 (* t (+ -0.284496736 (* t (+ 1.421413741
+              (* t (+ -1.453152027 (* t 1.061405429)))))))))))
+    (- 1.0 (* p (exp (- (* x x)))))))
+(define (boys0 u) (if (< u 1.0e-12) 1.0 (let ((su (sqrt u))) (* (/ (sqrt pi) 2.0) (/ (my-erf su) su)))))
+(define (zc c R) (if (= c 0) 0.0 R))
+(define (d2c ci cj R) (if (= ci cj) 0.0 (* R R)))
+(define (p-overlap a b ci cj R)
+  (let* ((p (+ a b)) (mu (/ (* a b) p))) (* (expt (/ pi p) 1.5) (exp (* (- mu) (d2c ci cj R))))))
+(define (p-kinetic a b ci cj R)
+  (let* ((p (+ a b)) (mu (/ (* a b) p)) (d2 (d2c ci cj R)))
+    (* (expt (/ pi p) 1.5) (exp (* (- mu) d2)) mu (- 3.0 (* 2.0 mu d2)))))
+(define (p-nuclear a b ci cj cc R)
+  (let* ((p (+ a b)) (mu (/ (* a b) p)) (pz (/ (+ (* a (zc ci R)) (* b (zc cj R))) p))
+         (dd (- pz (zc cc R))) (pc2 (* dd dd)))
+    (* (- (/ (* 2.0 pi) p)) (exp (* (- mu) (d2c ci cj R))) (boys0 (* p pc2)))))
+(define (p-eri a b c d ca cb cc cd R)
+  (let* ((p (+ a b)) (q (+ c d)) (muab (/ (* a b) p)) (mucd (/ (* c d) q))
+         (pz (/ (+ (* a (zc ca R)) (* b (zc cb R))) p)) (qz (/ (+ (* c (zc cc R)) (* d (zc cd R))) q))
+         (e (- pz qz)) (pq2 (* e e)))
+    (* (/ (* 2.0 (expt pi 2.5)) (* p q (sqrt (+ p q))))
+       (exp (* (- muab) (d2c ca cb R))) (exp (* (- mucd) (d2c cc cd R)))
+       (boys0 (* (/ (* p q) (+ p q)) pq2)))))
+(define (sum-range n f) (let loop ((i 0) (acc 0.0)) (if (>= i n) acc (loop (+ i 1) (+ acc (f i))))))
+(define (ao-1e fn ci cj R)
+  (sum-range 9 (lambda (idx)
+    (let ((i (modulo idx 3)) (j (quotient idx 3)))
+      (* (list-ref dn i) (list-ref dn j) (fn (list-ref exps i) (list-ref exps j) ci cj R))))))
+(define (ao-nuclear ci cj R)
+  (+ (ao-1e (lambda (a b ci cj R) (p-nuclear a b ci cj 0 R)) ci cj R)
+     (ao-1e (lambda (a b ci cj R) (p-nuclear a b ci cj 1 R)) ci cj R)))
+(define (ao-eri ca cb cc cd R)
+  (sum-range 81 (lambda (idx)
+    (let ((i (modulo idx 3)) (j (modulo (quotient idx 3) 3))
+          (k (modulo (quotient idx 9) 3)) (l (quotient idx 27)))
+      (* (list-ref dn i) (list-ref dn j) (list-ref dn k) (list-ref dn l)
+         (p-eri (list-ref exps i) (list-ref exps j) (list-ref exps k) (list-ref exps l) ca cb cc cd R))))))
+(define (mo-eri v1 v2 v3 v4 R)
+  (sum-range 16 (lambda (idx)
+    (let ((a (modulo idx 2)) (b (modulo (quotient idx 2) 2))
+          (c (modulo (quotient idx 4) 2)) (d (quotient idx 8)))
+      (* (list-ref v1 a) (list-ref v2 b) (list-ref v3 c) (list-ref v4 d) (ao-eri a b c d R))))))
+
+;; H11,H22,H12,eopen(R) -> the five Pauli coefficients g_i(R)
+(define (Hterms R)
+  (let* ((s (ao-1e p-overlap 0 1 R))
+         (hAA (+ (ao-1e p-kinetic 0 0 R) (ao-nuclear 0 0 R)))
+         (hAB (+ (ao-1e p-kinetic 0 1 R) (ao-nuclear 0 1 R)))
+         (hgg (/ (+ hAA hAB) (+ 1.0 s))) (huu (/ (- hAA hAB) (- 1.0 s)))
+         (cg (/ 1.0 (sqrt (* 2.0 (+ 1.0 s))))) (cu (/ 1.0 (sqrt (* 2.0 (- 1.0 s)))))
+         (gv (list cg cg)) (uv (list cu (- cu))))
+    (list (+ (* 2.0 hgg) (mo-eri gv gv gv gv R))     ; H11
+          (+ (* 2.0 huu) (mo-eri uv uv uv uv R))     ; H22
+          (mo-eri gv uv gv uv R)                     ; H12
+          (+ hgg huu (mo-eri gv gv uv uv R)))))      ; eopen
+(define (g0f R) (let ((h (Hterms R))) (* 0.5 (+ (list-ref h 3) (* 0.5 (+ (list-ref h 0) (list-ref h 1)))))))
+(define (g1f R) (let ((h (Hterms R))) (* 0.25 (- (list-ref h 1) (list-ref h 0)))))
+(define (g2f R) (let ((h (Hterms R))) (* 0.25 (- (list-ref h 0) (list-ref h 1)))))
+(define (g3f R) (let ((h (Hterms R))) (* 0.5 (- (list-ref h 3) (* 0.5 (+ (list-ref h 0) (list-ref h 1)))))))
+(define (g4f R) (list-ref (Hterms R) 2))
+
+;; full-CI energy (for locating the equilibrium)
+(define (energy R)
+  (let ((h (Hterms R)))
+    (let ((m (/ (+ (list-ref h 0) (list-ref h 1)) 2.0)) (dd (/ (- (list-ref h 0) (list-ref h 1)) 2.0)))
+      (+ (- m (sqrt (+ (* dd dd) (* (list-ref h 2) (list-ref h 2))))) (/ 1.0 R)))))
+
+;; ---- vector / linear-solve helpers (4-dim) ----
+(define (vsub u v) (vector (- (vector-ref u 0)(vector-ref v 0)) (- (vector-ref u 1)(vector-ref v 1))
+                           (- (vector-ref u 2)(vector-ref v 2)) (- (vector-ref u 3)(vector-ref v 3))))
+(define (vscale s v) (vector (* s (vector-ref v 0))(* s (vector-ref v 1))(* s (vector-ref v 2))(* s (vector-ref v 3))))
+(define (vdot u v) (+ (* (vector-ref u 0)(vector-ref v 0))(* (vector-ref u 1)(vector-ref v 1))
+                      (* (vector-ref u 2)(vector-ref v 2))(* (vector-ref u 3)(vector-ref v 3))))
+(define (perturb th b e) (let ((o (vector (vector-ref th 0)(vector-ref th 1)(vector-ref th 2)(vector-ref th 3))))
+                           (vector-set! o b (+ (vector-ref th b) e)) o))
+;; solve 4x4 A x = b ; A = vector of 4 row-vectors (mutated), b a 4-vector
+(define (solve4 A b)
+  (let ((x (make-vector 4 0.0)))
+    ;; forward elimination
+    (let cols ((c 0))
+      (if (< c 4)
+          (let ((diag (vector-ref (vector-ref A c) c)))
+            (let rows ((r (+ c 1)))
+              (if (< r 4)
+                  (let ((f (/ (vector-ref (vector-ref A r) c) diag)))
+                    (let cc ((k c))
+                      (if (< k 4)
+                          (begin
+                            (vector-set! (vector-ref A r) k
+                              (- (vector-ref (vector-ref A r) k) (* f (vector-ref (vector-ref A c) k))))
+                            (cc (+ k 1)))
+                          #f))
+                    (vector-set! b r (- (vector-ref b r) (* f (vector-ref b c))))
+                    (rows (+ r 1)))
+                  #f))
+            (cols (+ c 1)))
+          #f))
+    ;; back substitution
+    (let back ((i 3))
+      (if (>= i 0)
+          (let ((s (vector-ref b i)))
+            (let jj ((j (+ i 1)))
+              (if (< j 4)
+                  (begin
+                    (set! s (- s (* (vector-ref (vector-ref A i) j) (vector-ref x j))))
+                    (jj (+ j 1)))
+                  #f))
+            (vector-set! x i (/ s (vector-ref (vector-ref A i) i)))
+            (back (- i 1)))
+          #f))
+    x))
+
+;; ---- assemble the vibrational frequency ----
+(define R*
+  (let loop ((R 1.40) (i 0))
+    (if (>= i 8) R (loop (- R (/ (derivative-n energy R 1) (derivative-n energy R 2))) (+ i 1)))))
+
+(define g0 (g0f R*)) (define g1 (g1f R*)) (define g2 (g2f R*)) (define g3 (g3f R*)) (define g4 (g4f R*))
+(define g0p (derivative-n g0f R* 1)) (define g1p (derivative-n g1f R* 1)) (define g2p (derivative-n g2f R* 1))
+(define g3p (derivative-n g3f R* 1)) (define g4p (derivative-n g4f R* 1))
+(define g0pp (derivative-n g0f R* 2)) (define g1pp (derivative-n g1f R* 2)) (define g2pp (derivative-n g2f R* 2))
+(define g3pp (derivative-n g3f R* 2)) (define g4pp (derivative-n g4f R* 2))
+
+;; the 2-qubit H2 Pauli basis; make-pauli-hamiltonian generalises past this fixed
+;; 5-term form (any qubit count / any Pauli strings), 2 = the |01> HF reference.
+(define pauli-basis (vector "II" "IZ" "ZI" "ZZ" "XX"))
+(define H   (make-pauli-hamiltonian 2 pauli-basis (vector g0   g1   g2   g3   g4)   (/ 1.0 R*) 2))
+(define Hp  (make-pauli-hamiltonian 2 pauli-basis (vector g0p  g1p  g2p  g3p  g4p)  0.0        2))
+(define Hpp (make-pauli-hamiltonian 2 pauli-basis (vector g0pp g1pp g2pp g3pp g4pp) 0.0        2))
+
+;; optimize theta* on H via Moonlab's exact adjoint gradient (FFI call -> works in a loop)
+(define theta*
+  (let loop ((th (vector 0.1 0.2 0.3 0.4)) (i 0))
+    (if (>= i 400) th (loop (vsub th (vscale 0.2 (vqe-gradient H th))) (+ i 1)))))
+
+(define term1 (vqe-energy Hpp theta*))            ;; sum_i g_i'' <P_i>
+(define EtR   (vqe-gradient Hp theta*))           ;; E_thetaR (4-vector)
+(define eps 1.0e-4)
+(define Ett (vector (make-vector 4 0.0) (make-vector 4 0.0) (make-vector 4 0.0) (make-vector 4 0.0)))
+(let cols ((b 0))
+  (if (< b 4)
+      (let ((gp (vqe-gradient H (perturb theta* b eps))) (gm (vqe-gradient H (perturb theta* b (- eps)))))
+        (let rows ((a 0)) (if (< a 4)
+          (begin (vector-set! (vector-ref Ett a) b (/ (- (vector-ref gp a) (vector-ref gm a)) (* 2.0 eps)))
+                 (rows (+ a 1)))))
+        (cols (+ b 1)))))
+
+;; solve4 mutates its b argument, so pass a copy and dot with the original EtR
+(define EtRc (vector (vector-ref EtR 0)(vector-ref EtR 1)(vector-ref EtR 2)(vector-ref EtR 3)))
+(define response (- (vdot EtR (solve4 Ett EtRc))))  ;; - E_tR^T (E_tt)^-1 E_tR
+(define k (+ term1 (/ 2.0 (* R* R* R*)) response))
+(define mu (/ 1836.15267343 2.0))
+(define omega (* (sqrt (/ k mu)) 219474.6313702))
+
+(display "=== H2 vibrational frequency: Eshkol AD + Moonlab quantum response ===") (newline)
+(display "equilibrium R*        = ") (display R*) (display " bohr") (newline)
+(display "frozen term  sum g'' <P>  = ") (display (+ term1 (/ 2.0 (* R* R* R*)))) (display " Ha/bohr^2") (newline)
+(display "quantum response          = ") (display response) (display " Ha/bohr^2") (newline)
+(display "force constant k          = ") (display k) (display " Ha/bohr^2") (newline)
+(display "vibrational frequency     = ") (display omega) (display " cm^-1") (newline)
+(display "  (geometry derivs: Eshkol Taylor tower; <P>, response, Hessian: Moonlab)") (newline)

--- a/examples/h2_vibrational_quantum.esk
+++ b/examples/h2_vibrational_quantum.esk
@@ -1,0 +1,26 @@
+;; H2 vibrational frequency from Moonlab's smooth-PES Hamiltonian, finite-
+;; differenced over the bond length -- the quantum-backend route.  It gives a
+;; clean second derivative ONLY because the potential energy surface is smooth
+;; (the Morse/plateau stub would corrupt it), and it agrees with the exact
+;; Taylor-tower AD value in h2_vibrational.esk.
+(require agent.quantum)
+
+(define bohr 0.52917721067)   ;; Angstrom per bohr
+
+(define (E r-ang)             ;; Moonlab ground energy at bond length r (Angstrom)
+  (with-hamiltonian (make-h2-hamiltonian r-ang)
+    (lambda (ham) (hamiltonian-exact-ground-energy ham))))
+
+(define R0 0.740) (define d 0.02)
+(define Ep (E (+ R0 d))) (define E0 (E R0)) (define Em (E (- R0 d)))
+(define k-ang  (/ (+ Ep (* -2.0 E0) Em) (* d d)))   ;; Ha/Angstrom^2
+(define k-bohr (* k-ang bohr bohr))                  ;; Ha/bohr^2
+(define mu (/ 1836.15267343 2.0))
+(define omega (* (sqrt (/ k-bohr mu)) 219474.6313702))
+
+(display "Moonlab quantum-backend H2 vibrational frequency (FD over geometry):") (newline)
+(display "  E(0.72,0.74,0.76 A) = ") (display Em)(display " ")(display E0)(display " ")(display Ep) (newline)
+(display "  force constant = ") (display k-bohr) (display " Ha/bohr^2") (newline)
+(display "  omega          = ") (display omega)  (display " cm^-1") (newline)
+(display "  (exact Taylor-tower AD route gives 5003 cm^-1 -- two independent stacks agree;") (newline)
+(display "   the FD is clean only because the PES fix made E(R) smooth.)") (newline)

--- a/examples/qng_vqe.esk
+++ b/examples/qng_vqe.esk
@@ -1,0 +1,96 @@
+;; ==================================================================
+;; Quantum Natural Gradient VQE -- the whole loop in Eshkol
+;; ==================================================================
+;;
+;; Natural gradient preconditions the energy gradient by the Fubini-Study
+;; quantum geometric tensor (the natural metric on the ansatz state manifold):
+;;   theta <- theta - lr * (g + eps I)^-1 grad
+;; The gradient is Moonlab's exact adjoint (vqe-gradient); the metric g is
+;; Moonlab's quantum geometric tensor (vqe-qgt); the (g+eps I)^-1 grad solve is
+;; done here in Scheme.  Against plain gradient descent from identical initial
+;; parameters, QNG reaches the H2 ground state in far fewer iterations.
+;;
+;; Run:  ./build/eshkol-run -r examples/qng_vqe.esk
+
+(require agent.quantum)
+
+(define lr 0.3) (define reg 0.001) (define steps 40)
+
+;; --- 4-vector + 4x4 helpers ---
+(define (vsub u v) (vector (- (vector-ref u 0)(vector-ref v 0)) (- (vector-ref u 1)(vector-ref v 1))
+                           (- (vector-ref u 2)(vector-ref v 2)) (- (vector-ref u 3)(vector-ref v 3))))
+(define (vscale s v) (vector (* s (vector-ref v 0))(* s (vector-ref v 1))(* s (vector-ref v 2))(* s (vector-ref v 3))))
+(define (copy4 v) (vector (vector-ref v 0)(vector-ref v 1)(vector-ref v 2)(vector-ref v 3)))
+;; (g + reg I) as a fresh mutable 4x4
+(define (metric+reg M reg)
+  (let ((A (vector (make-vector 4 0.0)(make-vector 4 0.0)(make-vector 4 0.0)(make-vector 4 0.0))))
+    (let li ((i 0))
+      (if (< i 4)
+          (begin
+            (let lj ((j 0))
+              (if (< j 4)
+                  (begin (vector-set! (vector-ref A i) j
+                           (+ (vector-ref (vector-ref M i) j) (if (= i j) reg 0.0)))
+                         (lj (+ j 1)))
+                  #f))
+            (li (+ i 1)))
+          #f))
+    A))
+;; solve 4x4 A x = b (A, b mutated)
+(define (solve4 A b)
+  (let ((x (make-vector 4 0.0)))
+    (let cols ((c 0))
+      (if (< c 4)
+          (let ((diag (vector-ref (vector-ref A c) c)))
+            (let rows ((r (+ c 1)))
+              (if (< r 4)
+                  (let ((f (/ (vector-ref (vector-ref A r) c) diag)))
+                    (let cc ((k c))
+                      (if (< k 4)
+                          (begin (vector-set! (vector-ref A r) k
+                                   (- (vector-ref (vector-ref A r) k) (* f (vector-ref (vector-ref A c) k))))
+                                 (cc (+ k 1)))
+                          #f))
+                    (vector-set! b r (- (vector-ref b r) (* f (vector-ref b c))))
+                    (rows (+ r 1)))
+                  #f))
+            (cols (+ c 1)))
+          #f))
+    (let back ((i 3))
+      (if (>= i 0)
+          (let ((s (vector-ref b i)))
+            (let jj ((j (+ i 1)))
+              (if (< j 4)
+                  (begin (set! s (- s (* (vector-ref (vector-ref A i) j) (vector-ref x j)))) (jj (+ j 1)))
+                  #f))
+            (vector-set! x i (/ s (vector-ref (vector-ref A i) i)))
+            (back (- i 1)))
+          #f))
+    x))
+
+(with-hamiltonian (make-h2-hamiltonian 0.7414)
+  (lambda (ham)
+    (define exact (hamiltonian-exact-ground-energy ham))
+    (define init (vector 0.1 0.2 0.3 0.4))
+    (display "=== Quantum Natural Gradient VQE (H2) ===") (newline)
+    (display "exact ground state: ") (display exact) (display " Ha") (newline)
+    (newline)
+    (display "  step   E(QNG)        E(vanilla GD)") (newline)
+    (let loop ((tq init) (tv init) (i 0))
+      (if (> i steps)
+          (begin
+            (newline)
+            (display "final QNG:     ") (display (vqe-energy ham tq)) (display " Ha") (newline)
+            (display "final vanilla: ") (display (vqe-energy ham tv)) (display " Ha") (newline)
+            (display "exact:         ") (display exact) (display " Ha") (newline)
+            (newline)
+            (display "The QGT-preconditioned step (metric from Moonlab, solve in Scheme)") (newline)
+            (display "descends to the ground state far faster than the raw gradient.") (newline))
+          (begin
+            (if (= 0 (modulo i 5))
+                (begin (display "   ") (display i) (display "    ")
+                       (display (vqe-energy ham tq)) (display "   ") (display (vqe-energy ham tv)) (newline))
+                #f)
+            (let ((qdir (solve4 (metric+reg (vqe-qgt ham tq) reg) (copy4 (vqe-gradient ham tq))))
+                  (vgrad (vqe-gradient ham tv)))
+              (loop (vsub tq (vscale lr qdir)) (vsub tv (vscale lr vgrad)) (+ i 1))))))))

--- a/examples/vqe_h2.esk
+++ b/examples/vqe_h2.esk
@@ -1,0 +1,60 @@
+;; ============================================================
+;; Differentiable VQE — H2 ground state by reverse-mode gradient
+;; ============================================================
+;;
+;; A hybrid quantum-classical loop: the variational quantum
+;; eigensolver energy E(theta) = <psi(theta)|H|psi(theta)> is an
+;; ordinary differentiable Eshkol function, so the SAME `gradient`
+;; operator that trains a neural net descends the ansatz parameters
+;; to the molecular ground state of H2.
+;;
+;; Why this is interesting:
+;;   - `vqe-energy` runs a real quantum circuit (Moonlab), yet the
+;;     compiler differentiates THROUGH it: (gradient (lambda (p)
+;;     (vqe-energy ham p)) params) returns the exact dE/dtheta via
+;;     Moonlab's adjoint -- no finite differences, no framework.
+;;   - The optimisation loop is a dozen lines of Eshkol with a quantum
+;;     forward model in the middle.
+;;
+;; Build note: quantum support is opt-in. Configure Eshkol with
+;;   -DESHKOL_QUANTUM_ENABLED=ON
+;; then:  ./build/eshkol-run -r examples/vqe_h2.esk
+
+(require agent.quantum)
+
+(define bond 0.7414)   ;; H2 bond length in Angstrom (equilibrium)
+(define lr   0.2)      ;; gradient-descent step size
+(define steps 200)
+
+(with-hamiltonian (make-h2-hamiltonian bond)
+  (lambda (ham)
+    (define exact (hamiltonian-exact-ground-energy ham))
+
+    (display "=== Differentiable VQE: H2 ground state ===") (newline)
+    (display "Bond length:               ") (display bond)  (display " Angstrom") (newline)
+    (display "Exact ground-state energy: ") (display exact) (display " Ha") (newline)
+    (newline)
+
+    ;; Gradient descent, inlined here so the compiler can resolve
+    ;; vqe-energy's custom vector-Jacobian-product node in this scope.
+    (let loop ((p (vector 0.1 0.2 0.3 0.4)) (step 0))
+      (if (> step steps)
+          (begin
+            (newline)
+            (display "Final VQE energy:   ") (display (vqe-energy ham p)) (display " Ha") (newline)
+            (display "Exact ground state: ") (display exact) (display " Ha") (newline)
+            (newline)
+            (display "The compiler took the reverse-mode gradient of a quantum") (newline)
+            (display "expectation value and descended it to the molecule's ground") (newline)
+            (display "state -- no finite differences, no framework, no GC pauses.") (newline))
+          (begin
+            (if (= 0 (modulo step 20))
+                (begin (display "  step ") (display step)
+                       (display "   E = ") (display (vqe-energy ham p)) (display " Ha") (newline))
+                #f)
+            (let ((g (gradient (lambda (q) (vqe-energy ham q)) p)))
+              (loop (vector (- (vector-ref p 0) (* lr (vector-ref g 0)))
+                            (- (vector-ref p 1) (* lr (vector-ref g 1)))
+                            (- (vector-ref p 2) (* lr (vector-ref g 2)))
+                            (- (vector-ref p 3) (* lr (vector-ref g 3))))
+                    (+ step 1))))))))

--- a/lib/agent/c/agent_quantum.c
+++ b/lib/agent/c/agent_quantum.c
@@ -495,6 +495,65 @@ int64_t eshkol_vqe_make_h2o_hamiltonian(void) {
                              "make-h2o-hamiltonian: Moonlab allocation failed");
 }
 
+/** @return Handle for a 2-qubit Pauli Hamiltonian with the H2 term structure
+ * (II, IZ, ZI, ZZ, XX) assembled from the given coefficients and nuclear
+ * repulsion, or -1 on failure.  Lets Scheme build the auxiliary Hamiltonians
+ * sum_i g_i P_i (for a coefficient value / first / second derivative) needed to
+ * assemble a molecular Hessian from vqe-energy / vqe-gradient. */
+int64_t eshkol_vqe_pauli_create(int32_t num_qubits, int32_t num_terms,
+                                double nuc, int32_t hf_reference) {
+    pauli_hamiltonian_t* h = pauli_hamiltonian_create(num_qubits, num_terms);
+    if (h) {
+        h->nuclear_repulsion = nuc;
+        h->hf_reference = hf_reference;
+    }
+    return store_hamiltonian(h, "make-pauli-hamiltonian: Moonlab allocation failed");
+}
+
+int32_t eshkol_vqe_pauli_add_term(int64_t handle, int32_t index,
+                                  double coefficient, const char* pauli_string) {
+    pauli_hamiltonian_t* h = get_hamiltonian(handle);
+    if (!h) {
+        set_last_error("pauli-add-term: invalid Hamiltonian handle");
+        return -1;
+    }
+    if (!pauli_string) {
+        set_last_error("pauli-add-term: null Pauli string");
+        return -1;
+    }
+    return pauli_hamiltonian_add_term(h, coefficient, pauli_string, index);
+}
+
+/* Quantum geometric tensor (Fubini-Study metric) of the default ansatz at the
+ * given parameters, for quantum natural gradient.  Computed into a static
+ * row-major buffer; read back element-by-element so the FFI boundary stays
+ * scalar (the same strategy as the gradient context). */
+static vqe_solver_t* create_default_vqe_solver(pauli_hamiltonian_t* hamiltonian, int32_t iterations,
+                                               vqe_ansatz_t** ansatz_out, vqe_optimizer_t** optimizer_out);
+static double g_qgt_buffer[64];
+static int    g_qgt_dim = 0;
+int64_t eshkol_vqe_qgt_compute(int64_t handle, double p0, double p1, double p2, double p3) {
+    pauli_hamiltonian_t* ham = get_hamiltonian(handle);
+    if (!ham) { set_last_error("vqe-qgt: invalid Hamiltonian handle"); return -1; }
+    vqe_ansatz_t* ansatz = NULL; vqe_optimizer_t* optimizer = NULL;
+    vqe_solver_t* solver = create_default_vqe_solver(ham, 1, &ansatz, &optimizer);
+    if (!solver) return -1;
+    int64_t rc = -1;
+    if (ansatz->num_parameters == 4) {
+        double params[4] = { p0, p1, p2, p3 };
+        if (vqe_compute_qgt(solver, params, g_qgt_buffer) == 0) { g_qgt_dim = 4; rc = 4; }
+        else set_last_error("vqe-qgt: computation failed");
+    } else {
+        set_last_error("vqe-qgt: expected a 4-parameter ansatz");
+    }
+    vqe_solver_free(solver); vqe_optimizer_free(optimizer); vqe_ansatz_free(ansatz);
+    return rc;
+}
+double eshkol_vqe_qgt_get(int64_t i, int64_t j) {
+    if (g_qgt_dim <= 0 || i < 0 || j < 0 || i >= g_qgt_dim || j >= g_qgt_dim) return 0.0;
+    return g_qgt_buffer[i * g_qgt_dim + j];
+}
+
 /** Release a Hamiltonian handle. Safe on an already-released handle. */
 void eshkol_vqe_hamiltonian_destroy(int64_t handle) {
     if (handle < 1 || handle >= MAX_HAMILTONIAN_HANDLES) return;
@@ -1066,6 +1125,15 @@ double eshkol_quantum_bell_chsh(int32_t num_trials) {
 int64_t eshkol_vqe_make_h2_hamiltonian(double bond_distance) { (void)bond_distance; return -1; }
 int64_t eshkol_vqe_make_lih_hamiltonian(double bond_distance) { (void)bond_distance; return -1; }
 int64_t eshkol_vqe_make_h2o_hamiltonian(void) { return -1; }
+int64_t eshkol_vqe_pauli_create(int32_t num_qubits, int32_t num_terms,
+                                double nuc, int32_t hf_reference) {
+    (void)num_qubits; (void)num_terms; (void)nuc; (void)hf_reference; return 0; }
+int32_t eshkol_vqe_pauli_add_term(int64_t handle, int32_t index,
+                                  double coefficient, const char* pauli_string) {
+    (void)handle; (void)index; (void)coefficient; (void)pauli_string; return -1; }
+int64_t eshkol_vqe_qgt_compute(int64_t handle, double p0, double p1, double p2, double p3) {
+    (void)handle; (void)p0; (void)p1; (void)p2; (void)p3; return -1; }
+double eshkol_vqe_qgt_get(int64_t i, int64_t j) { (void)i; (void)j; return 0.0; }
 void eshkol_vqe_hamiltonian_destroy(int64_t handle) { (void)handle; }
 double eshkol_vqe_hamiltonian_exact_ground_energy(int64_t handle) {
     (void)handle;

--- a/lib/agent/quantum.esk
+++ b/lib/agent/quantum.esk
@@ -35,6 +35,8 @@
          make-h2-hamiltonian
          make-lih-hamiltonian
          make-h2o-hamiltonian
+         make-pauli-hamiltonian
+         vqe-qgt
          hamiltonian-destroy!
          hamiltonian-exact-ground-energy
          vqe-optimize
@@ -65,6 +67,10 @@
 (extern i64    vqe-make-h2-hamiltonian-raw  double        :real eshkol_vqe_make_h2_hamiltonian)
 (extern i64    vqe-make-lih-hamiltonian-raw double        :real eshkol_vqe_make_lih_hamiltonian)
 (extern i64    vqe-make-h2o-hamiltonian-raw              :real eshkol_vqe_make_h2o_hamiltonian)
+(extern i64    vqe-pauli-create-raw   i32 i32 double i32 :real eshkol_vqe_pauli_create)
+(extern i32    vqe-pauli-add-term-raw  i64 i32 double ptr :real eshkol_vqe_pauli_add_term)
+(extern i64    vqe-qgt-compute-raw i64 double double double double :real eshkol_vqe_qgt_compute)
+(extern double vqe-qgt-get-raw     i64 i64 :real eshkol_vqe_qgt_get)
 (extern void   hamiltonian-destroy-raw      i64           :real eshkol_vqe_hamiltonian_destroy)
 (extern double hamiltonian-exact-energy-raw i64           :real eshkol_vqe_hamiltonian_exact_ground_energy)
 (extern double vqe-optimize-raw             i64 i32       :real eshkol_vqe_optimize)
@@ -227,6 +233,42 @@
   (capability-require! 'ffi 'make-lih-hamiltonian)
   (check-hamiltonian-handle! "make-lih-hamiltonian"
                             (vqe-make-lih-hamiltonian-raw bond-distance)))
+
+(define (make-pauli-hamiltonian num-qubits pauli-strings coeffs nuc hf-reference)
+  "Create an N-qubit Pauli Hamiltonian from parallel vectors PAULI-STRINGS
+   (e.g. #(\"II\" \"IZ\" \"ZI\" \"ZZ\" \"XX\")) and COEFFS, with nuclear-repulsion
+   `nuc` and Hartree-Fock reference occupation bitmask `hf-reference` (e.g. #x2
+   for the H2 minimal basis).  Generalises past the fixed 5-term H2 form to any
+   qubit count and any Pauli strings -- it is Moonlab's pauli_hamiltonian_create
+   + pauli_hamiltonian_add_term surfaced to Scheme.  Returns an opaque
+   Hamiltonian handle; release it with hamiltonian-destroy!."
+  (capability-require! 'ffi 'make-pauli-hamiltonian)
+  (let* ((n (vector-length coeffs))
+         (h (check-hamiltonian-handle!
+             "make-pauli-hamiltonian"
+             (vqe-pauli-create-raw num-qubits n nuc hf-reference))))
+    (let loop ((i 0))
+      (if (< i n)
+          (begin
+            (vqe-pauli-add-term-raw h i (vector-ref coeffs i) (vector-ref pauli-strings i))
+            (loop (+ i 1)))
+          #f))
+    h))
+
+(define (vqe-qgt ham params)
+  "Quantum geometric (Fubini-Study) tensor of the default 4-parameter ansatz at
+   `params` (a length-4 vector).  Returns a 4x4 metric as a vector of 4 row
+   vectors, or raises on failure."
+  (capability-require! 'ffi 'vqe-qgt)
+  (let ((n (vqe-qgt-compute-raw ham (vector-ref params 0) (vector-ref params 1)
+                                    (vector-ref params 2) (vector-ref params 3))))
+    (if (< n 0)
+        (error (string-append "vqe-qgt failed: " (quantum-last-error)))
+        (vector
+          (vector (vqe-qgt-get-raw 0 0) (vqe-qgt-get-raw 0 1) (vqe-qgt-get-raw 0 2) (vqe-qgt-get-raw 0 3))
+          (vector (vqe-qgt-get-raw 1 0) (vqe-qgt-get-raw 1 1) (vqe-qgt-get-raw 1 2) (vqe-qgt-get-raw 1 3))
+          (vector (vqe-qgt-get-raw 2 0) (vqe-qgt-get-raw 2 1) (vqe-qgt-get-raw 2 2) (vqe-qgt-get-raw 2 3))
+          (vector (vqe-qgt-get-raw 3 0) (vqe-qgt-get-raw 3 1) (vqe-qgt-get-raw 3 2) (vqe-qgt-get-raw 3 3))))))
 
 (define (make-h2o-hamiltonian)
   "Create Moonlab's fixed-geometry H2O/STO-3G Pauli Hamiltonian."

--- a/scripts/run_examples_tests.sh
+++ b/scripts/run_examples_tests.sh
@@ -69,6 +69,17 @@ ensure_examples_build() {
 example_should_skip() {
     local test_name="$1"
 
+    # Quantum-chemistry examples require the Moonlab backend; skip them unless
+    # the quantum lane is enabled (mirrors the ESHKOL_QUANTUM_ENABLED gating used
+    # by the quantum test suite, e.g. run_ad_adversarial.sh).
+    case "$test_name" in
+        vqe_h2.esk|h2_vibrational_quantum.esk|h2_vibrational_full.esk|qng_vqe.esk)
+            if [ "${ESHKOL_QUANTUM_ENABLED:-OFF}" != "ON" ]; then
+                return 0
+            fi
+            ;;
+    esac
+
     case "$test_name" in
         selene_*|qllm_*|agent.esk|consciousness_*)
             return 0


### PR DESCRIPTION
## examples: differentiable quantum chemistry (Eshkol AD × Moonlab VQE)

The four Moonlab-backed examples from #297, gated behind `ESHKOL_QUANTUM_ENABLED` as suggested (the pure-AD one landed separately in #298). All verified in a containerized LLVM-21 quantum build.

### Examples (`examples/`, in a new "Quantum chemistry" README section)

| Example | Result |
|---|---|
| **vqe_h2** | gradient-descend *through* `vqe-energy` to the H₂ ground state, −1.14217 Ha |
| **h2_vibrational_quantum** | ω from Moonlab's exact energy + finite difference: **4936 cm⁻¹** |
| **h2_vibrational_full** | the Born–Oppenheimer response deep weld: Eshkol Taylor-towers the Pauli coefficients, Moonlab supplies ⟨Pᵢ⟩ / parameter Hessian / response gradient → **ω = 5003.19 cm⁻¹, matching the pure-AD answer exactly** |
| **qng_vqe** | Quantum Natural Gradient in Scheme via the Fubini–Study metric; reaches the ground state in ~⅓ the steps of vanilla GD |

### FFI surface (per your answers in #297)

Both additions follow the real-impl-under-`ESHKOL_HAVE_MOONLAB` / zero-stub-otherwise convention.

- **`make-pauli-hamiltonian num-qubits pauli-strings coeffs nuc hf-reference`** — the requested generalization of the arity-pinned `pauli5` form. It's Moonlab's `pauli_hamiltonian_create` + `pauli_hamiltonian_add_term` surfaced to Scheme as a builder loop, so it handles **any qubit count and any Pauli strings**. Only `i64/i32/double/ptr` cross the FFI boundary (Pauli strings as `ptr`, like `lib/web`), so no array-marshalling is needed.
  ```scheme
  (make-pauli-hamiltonian 2 (vector "II" "IZ" "ZI" "ZZ" "XX")
                            (vector g0 g1 g2 g3 g4) nuc 2)
  ```
- **`vqe-qgt ham params`** — kept as the thin expert-level accessor for the 4×4 quantum geometric tensor, with the regularized QNG solve living in Scheme (`qng_vqe.esk`), per your QGT↔QGTL note. The QNG *optimizer* is left for the Moonlab side (companion Moonlab PR); Eshkol just calls the metric.

### Gating

`scripts/run_examples_tests.sh` skips the four quantum examples unless `ESHKOL_QUANTUM_ENABLED=ON`, mirroring `run_ad_adversarial.sh`. A default build is unaffected.

### Dependencies

The `h2_vibrational_quantum` (smooth PES) and `qng_vqe` (QGT) paths depend on the companion **Moonlab PRs #12 / #13**; they'll build against upstream Moonlab once those land. The `vqe_h2` and `h2_vibrational_full` paths use only Moonlab's base VQE + the general `pauli_hamiltonian` API.

### Note on #296

The examples currently inline the `gradient` / descent loop rather than nesting it in a `define` (the silent-zero-gradient issue you've root-caused). Once your resolver fix merges I'll follow up to simplify them.

Ref: #297, #298
