### PR TITLE
fix(ad): custom-VJP gradient silently zeroed on transitive captures (#296)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
                 grep -q 'VQE H2: PASS' <<<"$output"
                 ;;
               vqe_ad_test.esk)
-                grep -q 'vqe_ad_test: PASS (3/3)' <<<"$output"
+                grep -q 'vqe_ad_test: PASS (5/5)' <<<"$output"
                 ;;
               pqc_mlkem_test.esk)
                 grep -q 'pqc_mlkem_test: PASS (9/9)' <<<"$output"

--- a/lib/agent/c/agent_quantum.c
+++ b/lib/agent/c/agent_quantum.c
@@ -803,9 +803,20 @@ void* eshkol_vqe_ad_prepare(int64_t handle, const eshkol_tagged_value_t* params)
 
     ctx->hamiltonian_handle = handle;
     ctx->parameter_count = n;
+    if (!get_hamiltonian(handle)) {
+        fprintf(stderr,
+                "eshkol: vqe-energy AD error: invalid Hamiltonian handle %lld "
+                "inside gradient — the gradient would silently be zero\n",
+                (long long)handle);
+        set_last_error("vqe-energy AD: invalid Hamiltonian handle");
+        return NULL;
+    }
     for (int i = 0; i < n; ++i) {
         ad_node_t* input = (ad_node_t*)(uintptr_t)tensor->elements[i];
         if (!input) {
+            fprintf(stderr,
+                    "eshkol: vqe-energy AD error: parameter tensor contains a "
+                    "non-AD value — the gradient would silently be zero\n");
             set_last_error("vqe-energy AD: parameter tensor contains a non-AD value");
             return NULL;
         }

--- a/lib/backend/autodiff_codegen.cpp
+++ b/lib/backend/autodiff_codegen.cpp
@@ -6215,7 +6215,15 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
                 // temp slot; only a genuine pointer storage is packed via ptrtoint.
                 if (auto* arg = llvm::dyn_cast<llvm::Argument>(storage)) {
                     if (arg->getType()->isPointerTy() &&
-                        arg->getName() == (var_name + "_cap")) {
+                        (arg->getName() == (var_name + "_cap") ||
+                         arg->getName() == ("captured_" + var_name))) {
+                        // #296: transitive capture — the free variable is the
+                        // enclosing function's own `captured_<var>` slot,
+                        // already in the callee's single-load convention.
+                        // Packing its ADDRESS below handed the differentiated
+                        // lambda the slot address as its value; a custom-VJP
+                        // callee (vqe-energy) unpacked it as the Hamiltonian
+                        // handle and the gradient silently zeroed.
                         grad_call_args.push_back(storage);
                         continue;
                     }
@@ -9941,7 +9949,13 @@ std::vector<llvm::Value*> AutodiffCodegen::loadCapturesForAutodiff(
             // resolveGradientCaptures.
             if (auto* arg = llvm::dyn_cast<llvm::Argument>(storage)) {
                 if (arg->getType()->isPointerTy() &&
-                    arg->getName() == (var_name + "_cap")) {
+                    (arg->getName() == (var_name + "_cap") ||
+                     arg->getName() == ("captured_" + var_name))) {
+                    // #296: when the free variable is itself a capture of the
+                    // ENCLOSING function (a transitive capture), `storage` is
+                    // that function's own `captured_<var>` slot. Forward it
+                    // as-is — re-wrapping it in the pointer-marker below hands
+                    // the callee the slot's ADDRESS as its value.
                     capture_args.push_back(storage);
                     continue;
                 }
@@ -10107,7 +10121,18 @@ void AutodiffCodegen::resolveGradientCaptures(
             // When storage IS that carry pointer, forward it as-is.
             if (auto* arg = llvm::dyn_cast<llvm::Argument>(storage)) {
                 if (arg->getType()->isPointerTy() &&
-                    arg->getName() == (var_name + "_cap")) {
+                    (arg->getName() == (var_name + "_cap") ||
+                     arg->getName() == ("captured_" + var_name))) {
+                    // #296: a TRANSITIVE capture — the free variable is itself
+                    // a capture of the enclosing function, so `storage` is that
+                    // function's own pointer-typed `captured_<var>` slot,
+                    // already in the callee's expected single-load convention.
+                    // Forward it as-is. The default pointer-marker packing
+                    // below would hand the differentiated lambda the slot's
+                    // ADDRESS as its value: a custom-VJP callee (vqe-energy)
+                    // then unpacked that address as its Hamiltonian handle,
+                    // its AD-prepare failed, and the gradient silently zeroed
+                    // (issue #296).
                     call_args.push_back(storage);
                     continue;
                 }

--- a/tests/quantum/vqe_ad_test.esk
+++ b/tests/quantum/vqe_ad_test.esk
@@ -88,9 +88,28 @@
      (check "custom VJP matches central finite difference (< 1e-4)"
             (< fd-error 1e-4))
      (check "VQE energy composes through Eshkol chain rule (< 1e-6)"
-            (< compose-error 1e-6)))))
+            (< compose-error 1e-6))
+
+     ;; Issue #296 regression: the custom-VJP gradient must not depend on the
+     ;; lexical nesting of the call site. A helper whose differentiated lambda
+     ;; reaches `ham` as a TRANSITIVE capture (through the helper's own
+     ;; closure) silently returned an all-zero gradient: the reverse-mode
+     ;; capture resolver re-wrapped the enclosing function's `captured_ham`
+     ;; slot as a pointer-marker, so vqe-energy unpacked the slot's ADDRESS as
+     ;; its Hamiltonian handle.
+     (define (nested-vqe-grad v)
+       (gradient (lambda (q) (vqe-energy ham q)) v))
+     (let ((helper (lambda (v) (gradient (lambda (q) (vqe-energy ham q)) v))))
+       (let ((g-nested (nested-vqe-grad params0))
+             (g-let-helper (helper params0)))
+         (display "g_nested_define: ") (display g-nested) (newline)
+         (display "g_let_helper: ") (display g-let-helper) (newline)
+         (check "custom VJP gradient inside nested define matches enclosing scope (#296)"
+                (< (max-abs-diff g-nested g-eshkol) 1e-12))
+         (check "custom VJP gradient inside let-bound helper matches enclosing scope (#296)"
+                (< (max-abs-diff g-let-helper g-eshkol) 1e-12)))))))
 
 (display "vqe_ad_test: ")
 (if (= fail 0)
-    (begin (display "PASS (") (display pass) (display "/3)") (newline) (exit 0))
+    (begin (display "PASS (") (display pass) (display "/5)") (newline) (exit 0))
     (begin (display "FAIL (") (display fail) (display " failed)") (newline) (exit 1)))


### PR DESCRIPTION
Fixes #296.

## Root cause

The reverse-mode AD capture resolvers special-case named-let carry pointers (`<var>_cap`) and value-typed storage, but not **transitive captures**. When the differentiated lambda's free variable is itself a capture of the enclosing helper (the natural shape of any `gradient-step`/`train` helper), all three resolver sites fell through to the mutable-variable default and packed the enclosing function's `captured_<var>` slot **address** as a pointer-marker. The compiled lambda single-loads its capture slot expecting a value, so `vqe-energy` unpacked that address as its Hamiltonian handle, AD-prepare failed, and the gradient silently zeroed. Pure-Eshkol gradients were unaffected because arithmetic extraction dereferences the marker; the FFI handle unpack does not — which is exactly the isolation the reporter observed.

Diagnosed by discriminating repro (ham-as-parameter works, ham-as-capture fails identically for nested `define` and `let`-bound helpers), runtime tracing of the intrinsic (handle arrived as a heap address), and IR inspection of the `grad_vector_call` capture packing.

## Fix

- Forward the enclosing function's `captured_<var>` slot as-is in all three resolver sites (`resolveGradientCaptures`, the shared jacobian/hessian resolver, and the inline vector-reverse-path copy), mirroring the existing `<var>_cap` precedent.
- **Loud failure**: `eshkol_vqe_ad_prepare` now validates the handle and prints a hard diagnostic on every failure path naming the consequence — a custom-VJP node that cannot participate in a gradient can never again silently zero.
- Regression tests: nested-define and let-bound-helper gradients must match the enclosing-scope gradient to 1e-12 (`vqe_ad_test` now 5/5).

## Verification

- Reporter's A/B/C repro plus both discriminators: all five shapes bit-identical to the enclosing-scope gradient, which itself matches Moonlab's native adjoint.
- Quantum suite 7/7 (Bell, CHSH, ML-KEM, surface coverage, VQE, AD, adversarial AD oracle).
- Full battery: 44/44 suites, 716/716 tests, 0 failures.
- ICC pre-commit: PASS, 0 blockers.