### PR TITLE
build: add git and lld to Dockerfile.test for a clean Linux build

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,12 +1,12 @@
 FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
-    wget gnupg cmake ninja-build g++ \
+    wget gnupg git cmake ninja-build g++ \
     libreadline-dev pkg-config libssl-dev libncurses-dev libopenblas-dev \
     libpng-dev libjpeg-dev libwebp-dev \
     && wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
     && echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-21 main" >> /etc/apt/sources.list.d/llvm.list \
-    && apt-get update && apt-get install -y llvm-21 llvm-21-dev \
+    && apt-get update && apt-get install -y llvm-21 llvm-21-dev lld-21 \
     && ln -sf /usr/bin/llvm-config-21 /usr/bin/llvm-config \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /eshkol


### PR DESCRIPTION
<!--
  Title:  build: add git and lld to Dockerfile.test for a clean Linux build
  Base:   tsotchke/eshkol : master
  Head:   RichardHoekstra:build/dockerfile-arm64-deps
  Create: gh pr create --repo tsotchke/eshkol --base master \
            --head RichardHoekstra:build/dockerfile-arm64-deps \
            --title "build: add git and lld to Dockerfile.test for a clean Linux build" \
            --body-file PR_BODY_eshkol_dockerfile.md
-->

## Summary

`Dockerfile.test` cannot build eshkol from a clean image: `git` and `lld` are
missing from the package set. This adds both (2-line diff). With #295 already
guarding the cmake ≥ 3.24 requirement, these two packages are all that stand
between a fresh container and a green build.

## Motivation

Building the image from scratch fails in two places:

1. **`git` missing** — `FetchContent` clones dependencies (pcre2) at configure
   time; without git the fetch fails.
2. **`lld` missing** — eshkol links with `-fuse-ld=lld` (see `exe/eshkol-run.cpp`
   and `lib/backend/llvm_codegen.cpp`), so the LLVM linker must be installed, else
   `collect2: fatal error: cannot find 'ld'`.

The third historical failure — jammy's cmake 3.22 vs the
`DOWNLOAD_EXTRACT_TIMESTAMP` that needs 3.24 — is already handled upstream by
**#295**, so no cmake change is needed here.

## What changed

`Dockerfile.test`, two additions to the existing apt install:

- `git` in the base package list;
- `lld-21` alongside `llvm-21 llvm-21-dev` — it rides the apt.llvm.org repo the
  Dockerfile already configures, so no new apt source is introduced.

```diff
-    wget gnupg cmake ninja-build g++ \
+    wget gnupg git cmake ninja-build g++ \
     ...
-    && apt-get update && apt-get install -y llvm-21 llvm-21-dev \
+    && apt-get update && apt-get install -y llvm-21 llvm-21-dev lld-21 \
```

## Validation

From-scratch `docker build -f Dockerfile.test` on the current master: the image
builds `eshkol-run` 554/554 and runs the test suite.
```
[542/559] Linking CXX executable eshkol-run
BUILD SUCCESS
...
TESTS DONE
```
(stock jammy cmake 3.22 + #295's DOWNLOAD_EXTRACT_TIMESTAMP guard + git + lld-21.)
