### PR TITLE
feat(gpu): INT8 tensor-core Ozaki f64 GEMM for CUDA (opt-in)

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -2011,3 +2011,30 @@ oracles:
         severity: high
         label: Ozaki-II CRT exact DGEMM (shipped fixed N=16) is bit-exact vs an independent CPU f64 reference across integer/fractional/pi-e/wide-magnitude regimes at K<=4096, with out-of-range moduli clamped loudly and opt-in adaptive free of gross CRT error
         action: ./tests/gpu/ozaki_correctness_gate.sh
+
+  # ─────────────────────────────────────────────────────────────────
+  # INT8 tensor-core Ozaki f64 GEMM (CUDA, opt-in). Recovers FP64-accurate
+  # C = A*B from the INT8 (IMMA) tensor cores via per-row/col-scaled 7-bit
+  # integer slicing + diagonal-fused int32 reconstruction — measured 4.74
+  # TFLOP/s-eq (8.8x native cublasDgemm) at full f64 on an RTX 3090, ~30 TF
+  # (20x native f64) on RTX PRO 6000 Blackwell. Opt-in via
+  # ESHKOL_CUDA_F64_KERNEL=ozaki-int8; the accuracy/throughput knob is
+  # ESHKOL_OZAKI_CUDA_T (default 6 = full f64, T=4 ~1e-11). Guarded K<133000
+  # for int32 exactness (loud fallback to cublasDgemm out of range).
+  # tests/gpu/cuda_ozaki_correctness_gate.sh drives the real CUDA kernel vs an
+  # independent in-process CPU f64 reference across integer / fractional / pi-e /
+  # wide-magnitude regimes at K up to 4096, asserting T=6 is machine-precision
+  # (normwise < 1e-9), T=4 correct, and the out-of-range knob clamps loudly and
+  # stays correct. CUDA-only + real-GPU-only, so it SKIPS (no trace) on Metal or
+  # GPU-less hosts.
+  # ─────────────────────────────────────────────────────────────────
+  - name: cuda-ozaki-int8-correctness
+    aliases: [cuda-ozaki-correctness, cuda-ozaki-int8, int8-ozaki, p-cuda-ozaki-correctness]
+    requires:
+      - runtime_event:
+          event_kinds: [cuda_ozaki_correctness]
+          event_names: ["cuda_ozaki_correctness_gate"]
+          event_values: ["PASS"]
+        severity: high
+        label: INT8 tensor-core Ozaki f64 GEMM (CUDA, opt-in ESHKOL_CUDA_F64_KERNEL=ozaki-int8) recovers full f64 (normwise < 1e-9 at T=6) vs an independent CPU f64 reference across integer/fractional/pi-e/wide-magnitude regimes at K<=4096, with the T=4 fast tier correct and the out-of-range accuracy knob clamped loudly
+        action: ./tests/gpu/cuda_ozaki_correctness_gate.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **INT8 tensor-core Ozaki f64 GEMM (CUDA, opt-in).** A new f64 GPU matmul path
+  recovers FP64-accurate `C = A*B` from the INT8 (IMMA) tensor cores, which run
+  ~500x faster than the deliberately crippled native FP64 pipeline on
+  consumer/prosumer NVIDIA GPUs (GeForce Ampere f64 = 1/64 FP32). Following the
+  Ootomo-Ozaki-Yokota scheme, each f64 operand is scaled per-row (A) / per-col
+  (B) into `[-1,1]`, sliced into `T+1` signed 7-bit integer slices, multiplied
+  as INT8->INT32 GEMMs via `cublasGemmEx` on the fast **TN/IMMA** layout
+  (transposed B-slices — mandatory on sm_86, a 3.7x cliff otherwise; Blackwell
+  is layout-indifferent so TN is safe everywhere), and reconstructed to f64 with
+  a **diagonal-fused** int32 reconstruction (same-weight slice-pairs on a
+  diagonal `d=p+q` accumulate via `beta=1` into int32-safe grouped buffers, then
+  a single fused kernel), provably int32-exact at any N. The int32 accumulation
+  is exact; the only error source is dropping slice-pairs with `p+q>T`. Measured
+  on an RTX 3090 (sm_86): **4.74 TFLOP/s-eq at full f64** (normwise error
+  2.7e-15) = **8.8x native cublasDgemm**, up to 16.6x at ~1e-11; on an RTX PRO
+  6000 Blackwell: **~30 TFLOP/s** (20x native f64). Opt-in and default OFF —
+  select via `ESHKOL_CUDA_F64_KERNEL=ozaki-int8` (the f64 GPU matmul otherwise
+  stays `cublasDgemm`). The accuracy/throughput knob is `ESHKOL_OZAKI_CUDA_T`
+  (default 6 = full f64 ~1e-15; T=4 ~1e-11 and ~2x faster), mirroring the Metal
+  Ozaki-II env conventions. `K` is guarded below 133,000 for int32 exactness;
+  out of range it falls back loudly to `cublasDgemm`. Wide-dynamic-range inputs
+  stay accurate via the per-row/col scaling (7.5e-15 on 1e-3..1e3 data). Adds
+  `tests/gpu/cuda_ozaki_correctness_gate.sh` / `cuda_ozaki_correctness_test.esk`
+  (INT8-Ozaki vs an independent CPU f64 reference across
+  integer/fractional/pi-e/wide-magnitude regimes at K up to 4096, a T=4/6 sweep,
+  and an out-of-range-knob loud-clamp check) and the
+  `cuda-ozaki-int8-correctness` ICC oracle.
+  (`lib/backend/gpu/gpu_memory_cuda.cpp`, `lib/backend/gpu/gpu_cuda_kernels.cu`)
+
 ### Fixed
 
 - **Ozaki-II exact DGEMM correctness (Metal).** The opt-in CRT matmul

--- a/docs/breakdown/GPU_ACCELERATION.md
+++ b/docs/breakdown/GPU_ACCELERATION.md
@@ -198,6 +198,57 @@ cublasDgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N,
 ```
 Both `cublasDgemm` (f64) and `cublasSgemm` (f32) are supported.
 
+### INT8 Tensor-Core Ozaki f64 GEMM (opt-in, `gpu_memory_cuda.cpp`)
+
+An opt-in f64 matmul path recovers FP64-accurate `C = A*B` from the INT8 (IMMA)
+tensor cores, which run ~500x faster than the deliberately crippled native FP64
+pipeline on consumer/prosumer NVIDIA GPUs (GeForce Ampere f64 = 1/64 FP32).
+Enable with `ESHKOL_CUDA_F64_KERNEL=ozaki-int8`; the default f64 GPU matmul
+stays `cublasDgemm`.
+
+Scheme (Ootomo-Ozaki-Yokota, per-row/col scaled 7-bit integer slicing), for
+row-major `A` (MxK), `B` (KxN):
+
+1. Scale into `[-1,1]`: `r_i = max_k|A[i,k]|`, `c_j = max_k|B[k,j]|`.
+2. Slice `A/r` and `B/c` into `s = T+1` signed 7-bit int8 slices, base 128
+   (`|slice| <= 127`). A-slices are stored in natural layout, B-slices are
+   stored **transposed** so each pair GEMM issues as
+   `cublasGemmEx(OP_T, OP_N, CUDA_R_8I -> CUDA_R_32I, COMPUTE_32I)` on the fast
+   IMMA **TN** layout — mandatory on sm_86 (a 3.7x throughput cliff vs NN);
+   Blackwell (sm_120) is layout-indifferent, so TN is safe everywhere.
+3. `C[i,j] = r_i c_j * sum_{p+q<=T} 128^{-(p+q+2)} (A_p x B_q)[i,j]`. Each
+   `A_p x B_q` is one INT8->INT32 GEMM; the int32 accumulation is **exact** (no
+   rounding) — the only error source is dropping slice-pairs with `p+q > T`.
+4. **Diagonal-fused reconstruction**: all slice-pairs on a diagonal `d = p+q`
+   carry the same weight `128^-(d+2)`, so they accumulate into one int32 buffer
+   via `cublasGemmEx` `beta=1` (staying on the tensor path), then a single fused
+   FP64 kernel streams the diagonal buffers, applies the weight, and scales by
+   `r_i c_j`. Buffers are capped at `floor((2^31-1)/(K*127^2))` pairs so the
+   accumulation stays int32-exact at any N; the split/reconstruct kernels are in
+   `gpu_cuda_kernels.cu`.
+
+The accuracy/throughput knob is `ESHKOL_OZAKI_CUDA_T` (default 6 = full f64
+~1e-15, 28 GEMMs; T=4 ~1e-11, 15 GEMMs, ~2x faster). `#GEMMs = (T+1)(T+2)/2`;
+relative error `~2^{-7(T+1)}`. `K` is guarded below 133,000 (`K*127^2 < 2^31`);
+out of range it falls back **loudly** to `cublasDgemm` (K-panel splitting is not
+implemented). Best throughput needs M, K, N multiples of 4; any `cublasGemmEx`
+`NOT_SUPPORTED` (e.g. unaligned dims) falls back quietly to `cublasDgemm`.
+
+Measured (normwise Frobenius error is the accuracy metric — a single near-zero
+output entry inflates per-element error meaninglessly):
+
+| GPU | f64-accurate INT8-Ozaki | native `cublasDgemm` | speedup |
+|-----|-------------------------|----------------------|---------|
+| RTX 3090 (sm_86), N=4096 | 4.74 TFLOP/s-eq @ err 2.7e-15 | 0.54 TFLOP/s | **8.8x** |
+| RTX PRO 6000 Blackwell (sm_120), N=16384 | ~30 TFLOP/s @ err <8.4e-15 (fused) | 1.50 TFLOP/s | **20x** |
+
+Per-row/col scaling keeps wide-dynamic-range data accurate (7.5e-15 on 1e-3..1e3
+inputs on the 3090). FP8-Ozaki was measured but is 2x slower than INT8 on
+Blackwell (identical tensor throughput, fewer exact bits/slice), so INT8 is the
+f64-accurate path. Correctness is gated by
+`tests/gpu/cuda_ozaki_correctness_gate.sh` (ICC oracle
+`cuda-ozaki-int8-correctness`).
+
 ### Custom Kernels (`gpu_cuda_kernels.cu`)
 
 All kernels use 256 threads/block with grid-stride loops, grid capped at 65535.
@@ -221,7 +272,7 @@ All kernels use 256 threads/block with grid-stride loops, grid capped at 65535.
 | Matmul (df64) | `matmul_df64`, `matmul_df64_pure` | -- | O(MKN) |
 | Matmul (f32) | `matmul_f32_simd`, `matmul_f32_simd_128` | `cublasSgemm` | O(MKN) |
 | Matmul (fp24/fp53) | `matmul_fp24`, `matmul_fp53` | -- | O(MKN) |
-| Matmul (Ozaki-II) | `matmul_ozaki_gemm` | -- | O(N_mod*MKN) |
+| Matmul (Ozaki-II) | `matmul_ozaki_gemm` | INT8-Ozaki `cublasGemmEx` (opt-in) | O(T^2*MKN) |
 | Elementwise | `elementwise_sf64` | `elementwise_f64_kernel` | O(N) |
 | Reduce (full/axis) | `reduce_sf64`, `reduce_axis_sf64` | `reduce_f64_kernel` | O(N) |
 | Softmax | `softmax_sf64` | `softmax_f64_kernel` | O(N) |
@@ -292,6 +343,13 @@ bit 0 prevents deallocation of externally-owned memory.
 |----------|---------|--------|
 | `ESHKOL_BLAS_PEAK_GFLOPS` | 1100 | `blas_backend.cpp` |
 | `ESHKOL_GPU_PEAK_GFLOPS` | 200 | `blas_backend.cpp` |
+
+**CUDA INT8-Ozaki f64 GEMM (opt-in):**
+
+| Variable | Values | Meaning |
+|----------|--------|---------|
+| `ESHKOL_CUDA_F64_KERNEL` | `ozaki-int8` | Select the INT8 tensor-core Ozaki f64 matmul (default: `cublasDgemm`) |
+| `ESHKOL_OZAKI_CUDA_T` | 1..8 (default 6) | Accuracy/throughput knob: T=6 full f64 (~1e-15), T=4 ~1e-11 (~2x faster) |
 
 **Metal kernel tuning:**
 

--- a/lib/backend/gpu/gpu_cuda_kernels.cu
+++ b/lib/backend/gpu/gpu_cuda_kernels.cu
@@ -635,3 +635,166 @@ extern "C" int cuda_layernorm_backward_f64(
 }
 
 } // extern "C"
+
+// ============================================================================
+// INT8 Tensor-Core Ozaki f64 GEMM kernels (opt-in high-throughput DGEMM)
+// ============================================================================
+// Recover FP64-accurate C = A*B from the INT8 (IMMA) tensor cores, which run
+// ~500x faster than the crippled native FP64 pipeline on consumer/prosumer
+// NVIDIA GPUs (GeForce Ampere f64 = 1/64 FP32). Ootomo-Ozaki-Yokota per-row/col
+// scaled 7-bit integer slicing. The cuBLAS orchestration (INT8 GEMMs +
+// diagonal-fused reconstruction) lives in gpu_memory_cuda.cpp; these are the
+// scale/slice/reconstruct device kernels. See docs/breakdown/GPU_ACCELERATION.md.
+//
+// Row-major (Eshkol) convention: A is MxK, B is KxN, C is MxN.
+//   r_i = max_k|A[i,k]| (per row of A),  c_j = max_k|B[k,j]| (per col of B)
+//   Abar = A/r in [-1,1] sliced into s int8 slices A_p (base 128, |A_p|<=127)
+//   Bbar = B/c in [-1,1] sliced into s int8 slices B_q (base 128, |B_q|<=127)
+//   G_{p,q}[i,j] = sum_k A_p[i,k]*B_q[k,j]   (one INT8->INT32 tensor-core GEMM)
+//   C[i,j] = r_i c_j * sum_{p+q<=T} 128^{-(p+q+2)} G_{p,q}[i,j]
+//
+// A_p slices are stored in natural row-major order (which is exactly col-major
+// KxM A_p^T); B_q slices are stored TRANSPOSED to col-major KxN. With those
+// stores the per-pair GEMM issued as cublasGemmEx(OP_T, OP_N, m=N,n=M,k=K,
+// B_q, A_p) computes col-major NxM G^T (== row-major MxN G) and lands on the
+// fast IMMA "TN" path — mandatory on sm_86 (3.7x cliff otherwise; Blackwell is
+// layout-indifferent so TN is safe everywhere).
+
+// per-row max of |A|, A row-major MxK -> rmax[M]
+__global__ void ozaki_rowmax_f64_kernel(const double* A, uint64_t M, uint64_t K,
+                                        double* rmax) {
+    for (uint64_t i = (uint64_t)blockIdx.x * blockDim.x + threadIdx.x;
+         i < M; i += (uint64_t)blockDim.x * gridDim.x) {
+        double m = 0.0;
+        const double* row = A + i * K;
+        for (uint64_t k = 0; k < K; k++) { double v = fabs(row[k]); if (v > m) m = v; }
+        rmax[i] = (m > 0.0) ? m : 1.0;
+    }
+}
+
+// per-col max of |B|, B row-major KxN -> cmax[N]
+__global__ void ozaki_colmax_f64_kernel(const double* B, uint64_t K, uint64_t N,
+                                        double* cmax) {
+    for (uint64_t j = (uint64_t)blockIdx.x * blockDim.x + threadIdx.x;
+         j < N; j += (uint64_t)blockDim.x * gridDim.x) {
+        double m = 0.0;
+        for (uint64_t k = 0; k < K; k++) { double v = fabs(B[k * N + j]); if (v > m) m = v; }
+        cmax[j] = (m > 0.0) ? m : 1.0;
+    }
+}
+
+// Split A (row-major MxK) into s int8 slices, scaled per-row by rmax.
+// Slice p stored at slices[p*M*K + (i*K+k)] (natural == col-major KxM A_p^T).
+__global__ void ozaki_split_a_f64_kernel(const double* A, uint64_t M, uint64_t K,
+                                         const double* rmax, int s, int8_t* slices) {
+    uint64_t tot = M * K;
+    for (uint64_t idx = (uint64_t)blockIdx.x * blockDim.x + threadIdx.x;
+         idx < tot; idx += (uint64_t)blockDim.x * gridDim.x) {
+        uint64_t i = idx / K;
+        double res = A[idx] / rmax[i];        // in [-1,1]
+        for (int p = 0; p < s; p++) {
+            res *= 128.0;
+            double a = rint(res);
+            if (a > 127.0) a = 127.0; else if (a < -127.0) a = -127.0;
+            slices[(uint64_t)p * tot + idx] = (int8_t)a;
+            res -= a;
+        }
+    }
+}
+
+// Split B (row-major KxN) into s int8 slices, scaled per-col by cmax.
+// Slice q stored TRANSPOSED at slices[q*K*N + (k + j*K)] (col-major KxN).
+__global__ void ozaki_split_b_f64_kernel(const double* B, uint64_t K, uint64_t N,
+                                         const double* cmax, int s, int8_t* slices) {
+    uint64_t tot = K * N;
+    for (uint64_t idx = (uint64_t)blockIdx.x * blockDim.x + threadIdx.x;
+         idx < tot; idx += (uint64_t)blockDim.x * gridDim.x) {
+        uint64_t k = idx / N, j = idx % N;
+        uint64_t tidx = k + j * K;            // transposed store -> col-major KxN
+        double res = B[idx] / cmax[j];
+        for (int q = 0; q < s; q++) {
+            res *= 128.0;
+            double b = rint(res);
+            if (b > 127.0) b = 127.0; else if (b < -127.0) b = -127.0;
+            slices[(uint64_t)q * tot + tidx] = (int8_t)b;
+            res -= b;
+        }
+    }
+}
+
+// Reconstruct C (row-major MxN) from nbuf int32 diagonal buffers (each MxN, in
+// col-major NxM G^T layout == row-major MxN), applying the per-buffer weight,
+// summing in FP64, and scaling by r_i*c_j.
+__global__ void ozaki_reconstruct_f64_kernel(double* C, const int32_t* Gall,
+                                             const double* weights, int nbuf,
+                                             const double* rmax, const double* cmax,
+                                             uint64_t M, uint64_t N) {
+    uint64_t tot = M * N;
+    for (uint64_t idx = (uint64_t)blockIdx.x * blockDim.x + threadIdx.x;
+         idx < tot; idx += (uint64_t)blockDim.x * gridDim.x) {
+        uint64_t i = idx / N, j = idx % N;
+        double acc = 0.0;
+        for (int b = 0; b < nbuf; b++)
+            acc += weights[b] * (double)Gall[(uint64_t)b * tot + idx];
+        C[idx] = acc * rmax[i] * cmax[j];
+    }
+}
+
+extern "C" {
+
+// Compute per-row max of A then split A into `s` int8 slices (natural layout).
+int cuda_ozaki_split_a_f64(const double* A, uint64_t M, uint64_t K, int s,
+                           double* rmax, int8_t* slices, void* stream) {
+    cudaStream_t st = static_cast<cudaStream_t>(stream);
+    int bs = 256;
+    int g1 = (int)((M + bs - 1) / bs); if (g1 > 65535) g1 = 65535; if (g1 < 1) g1 = 1;
+    ozaki_rowmax_f64_kernel<<<g1, bs, 0, st>>>(A, M, K, rmax);
+    if (cudaGetLastError() != cudaSuccess) return -1;
+    uint64_t tot = M * K;
+    int g2 = (int)((tot + bs - 1) / bs); if (g2 > 65535) g2 = 65535; if (g2 < 1) g2 = 1;
+    ozaki_split_a_f64_kernel<<<g2, bs, 0, st>>>(A, M, K, rmax, s, slices);
+    if (cudaGetLastError() != cudaSuccess) return -1;
+    cudaStreamSynchronize(st);
+    return 0;
+}
+
+// Compute per-col max of B then split B into `s` int8 slices (transposed layout).
+int cuda_ozaki_split_b_f64(const double* B, uint64_t K, uint64_t N, int s,
+                           double* cmax, int8_t* slices, void* stream) {
+    cudaStream_t st = static_cast<cudaStream_t>(stream);
+    int bs = 256;
+    int g1 = (int)((N + bs - 1) / bs); if (g1 > 65535) g1 = 65535; if (g1 < 1) g1 = 1;
+    ozaki_colmax_f64_kernel<<<g1, bs, 0, st>>>(B, K, N, cmax);
+    if (cudaGetLastError() != cudaSuccess) return -1;
+    uint64_t tot = K * N;
+    int g2 = (int)((tot + bs - 1) / bs); if (g2 > 65535) g2 = 65535; if (g2 < 1) g2 = 1;
+    ozaki_split_b_f64_kernel<<<g2, bs, 0, st>>>(B, K, N, cmax, s, slices);
+    if (cudaGetLastError() != cudaSuccess) return -1;
+    cudaStreamSynchronize(st);
+    return 0;
+}
+
+// Reconstruct C from the diagonal-fused int32 buffers. `h_weights` is a host
+// array of nbuf per-buffer weights; it is staged to the device internally.
+int cuda_ozaki_reconstruct_f64(double* C, const int32_t* Gall,
+                               const double* h_weights, int nbuf,
+                               const double* rmax, const double* cmax,
+                               uint64_t M, uint64_t N, void* stream) {
+    cudaStream_t st = static_cast<cudaStream_t>(stream);
+    double* d_w = nullptr;
+    if (cudaMalloc(&d_w, (size_t)nbuf * sizeof(double)) != cudaSuccess) return -1;
+    if (cudaMemcpyAsync(d_w, h_weights, (size_t)nbuf * sizeof(double),
+                        cudaMemcpyHostToDevice, st) != cudaSuccess) {
+        cudaFree(d_w); return -1;
+    }
+    uint64_t tot = M * N;
+    int bs = 256;
+    int g = (int)((tot + bs - 1) / bs); if (g > 65535) g = 65535; if (g < 1) g = 1;
+    ozaki_reconstruct_f64_kernel<<<g, bs, 0, st>>>(C, Gall, d_w, nbuf, rmax, cmax, M, N);
+    cudaError_t err = cudaGetLastError();
+    cudaStreamSynchronize(st);
+    cudaFree(d_w);
+    return (err == cudaSuccess) ? 0 : -1;
+}
+
+} // extern "C"

--- a/lib/backend/gpu/gpu_memory_cuda.cpp
+++ b/lib/backend/gpu/gpu_memory_cuda.cpp
@@ -28,6 +28,8 @@
 #include <cublas_v2.h>
 #include <cuda_fp16.h>
 #include <vector>
+#include <cstdint>
+#include <utility>
 
 // Forward declarations for real CUDA kernel launchers (in gpu_cuda_kernels.cu)
 /** Launch the elementwise unary/binary op kernel (add/sub/mul/.../sigmoid,
@@ -58,6 +60,25 @@ extern "C" int cuda_launch_normalize_f64(const double* in, double* out,
                                           uint64_t num_slices, uint64_t slice_len,
                                           double gamma, double beta, double epsilon,
                                           void* stream);
+
+// INT8-Ozaki f64 GEMM device kernels (gpu_cuda_kernels.cu). Split the f64
+// operands into per-row/col-scaled int8 slices, then reconstruct the f64 result
+// from the diagonal-fused int32 tensor-core GEMM outputs. See
+// cuda_matmul_ozaki_int8_f64 below for the cuBLAS orchestration.
+/** Per-row max of A (row-major MxK), then split A into `s` int8 slices (natural
+ *  layout == col-major KxM A^T). Writes rmax[M] and slices[s*M*K]. */
+extern "C" int cuda_ozaki_split_a_f64(const double* A, uint64_t M, uint64_t K, int s,
+                                      double* rmax, int8_t* slices, void* stream);
+/** Per-col max of B (row-major KxN), then split B into `s` int8 slices stored
+ *  transposed to col-major KxN. Writes cmax[N] and slices[s*K*N]. */
+extern "C" int cuda_ozaki_split_b_f64(const double* B, uint64_t K, uint64_t N, int s,
+                                      double* cmax, int8_t* slices, void* stream);
+/** Reconstruct C (row-major MxN) from `nbuf` int32 diagonal buffers with
+ *  host-supplied per-buffer weights, scaling each entry by rmax[i]*cmax[j]. */
+extern "C" int cuda_ozaki_reconstruct_f64(double* C, const int32_t* Gall,
+                                          const double* h_weights, int nbuf,
+                                          const double* rmax, const double* cmax,
+                                          uint64_t M, uint64_t N, void* stream);
 #endif
 
 // ============================================================================
@@ -244,11 +265,198 @@ static int cuda_sync(EshkolGPUBuffer* buffer, EshkolSyncDirection direction) {
     return 0;
 }
 
+// ============================================================================
+// INT8 tensor-core Ozaki f64 GEMM (opt-in) — ESHKOL_CUDA_F64_KERNEL=ozaki-int8
+// ============================================================================
+// Recover FP64-accurate C = A*B from the INT8 (IMMA) tensor cores, which run
+// ~500x faster than the crippled native FP64 pipeline on consumer/prosumer
+// NVIDIA GPUs. Measured on an RTX 3090 (sm_86): 4.74 TFLOP/s-eq at full f64
+// accuracy (normwise err 2.7e-15) = 8.8x native cublasDgemm; up to 16.6x at
+// ~1e-11. On an RTX PRO 6000 Blackwell: ~30 TFLOP/s (20x native f64).
+//
+// Default OFF: the f64 GPU matmul path stays cublasDgemm unless
+// ESHKOL_CUDA_F64_KERNEL=ozaki-int8 is set. The accuracy/throughput knob is
+// ESHKOL_OZAKI_CUDA_T (default 6 = full f64; T=4 ~1e-11 and ~2x faster). This
+// mirrors the Metal Ozaki-II env handling (ESHKOL_SF64_KERNEL / ESHKOL_OZAKI_*)
+// in gpu_memory.mm. See docs/breakdown/GPU_ACCELERATION.md and gpu_cuda_kernels.cu.
+
+static bool g_cuda_ozaki_enabled = false;
+static bool g_cuda_ozaki_checked = false;
+static int  g_cuda_ozaki_T = 6;
+
+/** @brief Parse (once, cached) the INT8-Ozaki env selection: enabled iff
+ *         ESHKOL_CUDA_F64_KERNEL=ozaki-int8; the accuracy knob T comes from
+ *         ESHKOL_OZAKI_CUDA_T (default 6, clamped to [1,8] with a loud note on
+ *         an out-of-range request, mirroring #307's loud-clamp philosophy). */
+static void cuda_ozaki_check_env(void) {
+    if (g_cuda_ozaki_checked) return;
+    const char* k = std::getenv("ESHKOL_CUDA_F64_KERNEL");
+    g_cuda_ozaki_enabled = (k && strcmp(k, "ozaki-int8") == 0);
+    int T = 6;
+    if (const char* t = std::getenv("ESHKOL_OZAKI_CUDA_T")) {
+        int v = atoi(t);
+        if (v >= 1 && v <= 8) T = v;
+        else fprintf(stderr,
+            "[GPU] ESHKOL_OZAKI_CUDA_T=%d out of range [1,8] (T=6 is full f64, "
+            "T=4 ~1e-11); using default 6\n", v);
+    }
+    g_cuda_ozaki_T = T;
+    g_cuda_ozaki_checked = true;
+    if (g_cuda_ozaki_enabled)
+        eshkol_info("CUDA: INT8-Ozaki f64 GEMM enabled (T=%d)", g_cuda_ozaki_T);
+}
+
+/** @brief INT8 tensor-core Ozaki f64 GEMM: C = A*B (row-major MxK, KxN, MxN) via
+ *         per-row/col-scaled 7-bit integer slicing, INT8->INT32 cublasGemmEx on
+ *         the fast TN/IMMA path, and diagonal-fused FP64 reconstruction. All
+ *         operands are device pointers (A,B read; C written). T is the accuracy
+ *         knob (kept slice-pair diagonal); s=T+1 slices/operand participate.
+ *
+ *         Returns 0 on success. Returns -1 (caller falls back to cublasDgemm) on
+ *         any allocation/cuBLAS failure, or when K exceeds the int32-exact bound
+ *         (~133,000) — the latter emits a one-time loud stderr note, since K-panel
+ *         splitting is not implemented. The INT32 accumulation is exact; the only
+ *         error source is dropping slice-pairs with p+q>T. */
+static int cuda_matmul_ozaki_int8_f64(const double* dA, const double* dB, double* dC,
+                                      uint64_t M, uint64_t K, uint64_t N, int T) {
+    if (!g_cublas_handle || !dA || !dB || !dC) return -1;
+    if (M == 0 || K == 0 || N == 0) return -1;
+    // cuBLAS int GEMM dims/leading dims are int; reject sizes that would truncate.
+    if (M > (uint64_t)0x7fffffff || K > (uint64_t)0x7fffffff || N > (uint64_t)0x7fffffff)
+        return -1;
+
+    // INT32-exactness guard: one INT8 GEMM accumulates |G| <= K*127^2 = K*16129,
+    // exact in int32 only while K*16129 < 2^31 -> K < 133,151. Beyond that a
+    // single pair already overflows and K-panel splitting is not implemented, so
+    // fall back LOUDLY to cublasDgemm (mirrors #307's loud-clamp philosophy).
+    static std::atomic<bool> warned_k{false};
+    const uint64_t K_MAX_INT32_EXACT = 133000;  // conservative; K*16129 < 2^31
+    if (K > K_MAX_INT32_EXACT) {
+        if (!warned_k.exchange(true))
+            fprintf(stderr,
+                "[GPU] INT8-Ozaki: K=%llu exceeds the int32-exact bound %llu; "
+                "falling back to cublasDgemm for this and future GEMMs at this K "
+                "(unset ESHKOL_CUDA_F64_KERNEL or reduce K)\n",
+                (unsigned long long)K, (unsigned long long)K_MAX_INT32_EXACT);
+        return -1;
+    }
+
+    const int s = T + 1;  // slice indices 0..T participate (pairs with p+q<=T)
+
+    // int32-exact cap: max same-weight pairs per diagonal buffer so that the
+    // beta=1 accumulation count*K*16129 stays < 2^31.
+    long long cap = (long long)(2147483647.0 / ((double)K * 16129.0));
+    if (cap < 1) return -1;  // defensive; already covered by the K guard above
+
+    // Plan the diagonal-fused buffers: pairs (p,q) with p+q=d share the weight
+    // 128^-(d+2). A diagonal with more than `cap` pairs is split across multiple
+    // same-weight int32 buffers (provably int32-exact at any N). Mirrors the
+    // measured Blackwell fused reconstruction (ozaki_fused2.cu).
+    struct Buf { double w; std::vector<std::pair<int,int>> pairs; };
+    std::vector<Buf> bufs;
+    try {
+        for (int d = 0; d <= T; d++) {
+            std::vector<std::pair<int,int>> ps;
+            for (int p = 0; p < s; p++) { int q = d - p; if (q >= 0 && q < s) ps.emplace_back(p, q); }
+            double w = pow(2.0, -7.0 * (d + 2));
+            for (size_t off = 0; off < ps.size(); off += (size_t)cap) {
+                Buf b; b.w = w;
+                for (size_t t2 = off; t2 < ps.size() && t2 < off + (size_t)cap; t2++)
+                    b.pairs.push_back(ps[t2]);
+                bufs.push_back(std::move(b));
+            }
+        }
+    } catch (...) { return -1; }
+    const int nbuf = (int)bufs.size();
+
+    const size_t totA = (size_t)M * K, totB = (size_t)K * N, totC = (size_t)M * N;
+
+    int8_t*  dAs   = nullptr;
+    int8_t*  dBs   = nullptr;
+    int32_t* dGall = nullptr;
+    double*  dr    = nullptr;
+    double*  dc    = nullptr;
+    int rc = -1;
+    do {
+        if (cudaMalloc(&dAs,   (size_t)s * totA * sizeof(int8_t))  != cudaSuccess) break;
+        if (cudaMalloc(&dBs,   (size_t)s * totB * sizeof(int8_t))  != cudaSuccess) break;
+        if (cudaMalloc(&dGall, (size_t)nbuf * totC * sizeof(int32_t)) != cudaSuccess) break;
+        if (cudaMalloc(&dr,    (size_t)M * sizeof(double))         != cudaSuccess) break;
+        if (cudaMalloc(&dc,    (size_t)N * sizeof(double))         != cudaSuccess) break;
+
+        if (cuda_ozaki_split_a_f64(dA, M, K, s, dr, dAs, g_cuda_stream) != 0) break;
+        if (cuda_ozaki_split_b_f64(dB, K, N, s, dc, dBs, g_cuda_stream) != 0) break;
+
+        // Per-pair INT8->INT32 GEMMs. TN layout (OP_T on the B-slice, OP_N on the
+        // A-slice) is MANDATORY for the fast IMMA path on sm_86. Diagonal fusion:
+        // all pairs of one buffer accumulate in int32 via beta=1 (stays on the
+        // tensor path, exact). alpha/beta are int32 for CUBLAS_COMPUTE_32I.
+        const int ialpha = 1;
+        bool gemm_ok = true;
+        for (int b = 0; b < nbuf && gemm_ok; b++) {
+            int32_t* Gd = dGall + (size_t)b * totC;
+            bool first = true;
+            for (const auto& pq : bufs[b].pairs) {
+                const int ibeta = first ? 0 : 1;
+                first = false;
+                const int8_t* Ap = dAs + (size_t)pq.first  * totA;  // col-major KxM (A_p^T bytes)
+                const int8_t* Bq = dBs + (size_t)pq.second * totB;  // col-major KxN (transposed)
+                cublasStatus_t st = cublasGemmEx(
+                    g_cublas_handle, CUBLAS_OP_T, CUBLAS_OP_N,
+                    (int)N, (int)M, (int)K,
+                    &ialpha,
+                    Bq, CUDA_R_8I, (int)K,
+                    Ap, CUDA_R_8I, (int)K,
+                    &ibeta,
+                    Gd, CUDA_R_32I, (int)N,
+                    CUBLAS_COMPUTE_32I, CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+                if (st != CUBLAS_STATUS_SUCCESS) { gemm_ok = false; break; }
+            }
+        }
+        if (!gemm_ok) break;
+
+        std::vector<double> hw;
+        try { hw.resize((size_t)nbuf); } catch (...) { break; }
+        for (int b = 0; b < nbuf; b++) hw[b] = bufs[b].w;
+        if (cuda_ozaki_reconstruct_f64(dC, dGall, hw.data(), nbuf, dr, dc, M, N,
+                                       g_cuda_stream) != 0) break;
+
+        rc = 0;
+    } while (0);
+
+    if (dAs)   cudaFree(dAs);
+    if (dBs)   cudaFree(dBs);
+    if (dGall) cudaFree(dGall);
+    if (dr)    cudaFree(dr);
+    if (dc)    cudaFree(dc);
+    return rc;
+}
+
 /** @brief Double-precision matmul via cuBLAS DGEMM, exploiting the
  *         column-major/row-major duality (computing C^T = B*A in cuBLAS
- *         terms yields row-major C = A*B without an explicit transpose). */
+ *         terms yields row-major C = A*B without an explicit transpose).
+ *         When ESHKOL_CUDA_F64_KERNEL=ozaki-int8 is set, the INT8 tensor-core
+ *         Ozaki path is tried first and cublasDgemm is the fallback. */
 static int cuda_matmul_f64(EshkolGPUBuffer* A, EshkolGPUBuffer* B, EshkolGPUBuffer* C,
                             uint64_t M, uint64_t K, uint64_t N) {
+    cuda_ozaki_check_env();
+    if (g_cuda_ozaki_enabled) {
+        GPU_LOG("matmul %llux%llu @ %llux%llu -> CUDA INT8-Ozaki (T=%d)",
+                (unsigned long long)M, (unsigned long long)K,
+                (unsigned long long)K, (unsigned long long)N, g_cuda_ozaki_T);
+        int rc = cuda_matmul_ozaki_int8_f64(
+            (const double*)A->device_ptr, (const double*)B->device_ptr,
+            (double*)C->device_ptr, M, K, N, g_cuda_ozaki_T);
+        if (rc == 0) {
+            cudaStreamSynchronize(g_cuda_stream);
+            return 0;
+        }
+        // Any failure / K-guard -> fall through to cublasDgemm below.
+        GPU_LOG("matmul %llux%llu @ %llux%llu -> INT8-Ozaki fell back to cublasDgemm",
+                (unsigned long long)M, (unsigned long long)K,
+                (unsigned long long)K, (unsigned long long)N);
+    }
+
     const double alpha = 1.0;
     const double beta = 0.0;
 

--- a/lib/backend/gpu/gpu_memory_cuda.cpp
+++ b/lib/backend/gpu/gpu_memory_cuda.cpp
@@ -18,6 +18,24 @@
 #include <atomic>
 #include <mutex>
 
+// ----------------------------------------------------------------------------
+// Verbose diagnostics (defined before all GPU_LOG uses in this TU)
+// ----------------------------------------------------------------------------
+static bool g_gpu_verbose = false;
+static bool g_gpu_verbose_checked = false;
+
+/** @brief True if `ESHKOL_GPU_VERBOSE` is set in the environment (checked
+ *         once and cached), enabling GPU_LOG diagnostic output. */
+static bool gpu_verbose(void) {
+    if (!g_gpu_verbose_checked) {
+        g_gpu_verbose = (getenv("ESHKOL_GPU_VERBOSE") != nullptr);
+        g_gpu_verbose_checked = true;
+    }
+    return g_gpu_verbose;
+}
+
+#define GPU_LOG(fmt, ...) do { if (gpu_verbose()) fprintf(stderr, "[GPU] " fmt "\n", ##__VA_ARGS__); } while(0)
+
 // ============================================================================
 // Platform Detection
 // ============================================================================
@@ -651,21 +669,6 @@ static int cuda_wrap_host(void* host_ptr, size_t size_bytes, EshkolGPUBuffer* ou
 // ============================================================================
 // GPU Dispatch Logging
 // ============================================================================
-
-static bool g_gpu_verbose = false;
-static bool g_gpu_verbose_checked = false;
-
-/** @brief True if `ESHKOL_GPU_VERBOSE` is set in the environment (checked
- *         once and cached), enabling GPU_LOG diagnostic output. */
-static bool gpu_verbose(void) {
-    if (!g_gpu_verbose_checked) {
-        g_gpu_verbose = (getenv("ESHKOL_GPU_VERBOSE") != nullptr);
-        g_gpu_verbose_checked = true;
-    }
-    return g_gpu_verbose;
-}
-
-#define GPU_LOG(fmt, ...) do { if (gpu_verbose()) fprintf(stderr, "[GPU] " fmt "\n", ##__VA_ARGS__); } while(0)
 
 // ============================================================================
 // Public API Implementation

--- a/tests/gpu/cuda_ozaki_correctness_gate.sh
+++ b/tests/gpu/cuda_ozaki_correctness_gate.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# tests/gpu/cuda_ozaki_correctness_gate.sh — INT8 tensor-core Ozaki f64 GEMM gate.
+#
+# Drives the opt-in CUDA INT8-Ozaki matmul (ESHKOL_CUDA_F64_KERNEL=ozaki-int8)
+# and asserts it is numerically correct vs an independent in-process CPU f64
+# reference across integer / fractional / pi-e / wide-magnitude regimes at K up
+# to 4096, plus:
+#   * default T=6 (full f64): normwise Frobenius error is machine-precision
+#     (< 1e-9) on every regime — proving the INT8 tensor-core path recovers f64,
+#   * fast T=4 (~1e-11): still passes the correctness gate (normwise < 1e-6),
+#   * an out-of-range accuracy knob (ESHKOL_OZAKI_CUDA_T=99) FAILS LOUDLY (a
+#     clamp warning on stderr) and still returns correct results (clamped to the
+#     default T=6) instead of garbage — mirrors #307's loud-clamp philosophy.
+#
+# The K<133000 int32-exactness guard (loud fallback to cublasDgemm) is verified
+# behaviorally at unit level on real 3090 hardware by the standalone harness
+# (scratchpad ozaki_cuda_proto / cuda_ozaki_unit_harness.cu — a K>133000 skinny
+# GEMM is infeasible to build as an in-language tensor here). The guard itself is
+# a single K-bound check by inspection.
+#
+# INT8-Ozaki is a CUDA (IMMA tensor-core) kernel. On a Metal-only or GPU-less
+# host it SKIPS cleanly (exit 0) and leaves no ICC trace, so the oracle reports
+# "no evidence yet" rather than a false PASS.
+#
+# Usage:
+#   ESHKOL_RUN=/path/to/eshkol-run tests/gpu/cuda_ozaki_correctness_gate.sh
+# If ESHKOL_RUN is unset it searches build*/eshkol-run under the repo root.
+set -u
+cd "$(dirname "$0")/../.."
+REPO_ROOT="$(pwd)"
+TEST_ESK="$REPO_ROOT/tests/gpu/cuda_ozaki_correctness_test.esk"
+
+# ICC evidence trace (.icc/completion-oracles.yaml::cuda-ozaki-int8-correctness).
+# Written only on an actual PASS/FAIL verdict; a SKIP leaves no trace.
+TRACE_DIR="$REPO_ROOT/scripts/icc_traces"
+TRACE_FILE="$TRACE_DIR/cuda_ozaki_correctness.jsonl"
+emit_trace() {  # emit_trace <value> <snippet>
+    local value="$1" snippet="$2"
+    mkdir -p "$TRACE_DIR"
+    local esnip
+    if command -v python3 >/dev/null 2>&1; then
+        esnip="$(printf '%s' "$snippet" | python3 -c 'import json,sys; sys.stdout.write(json.dumps(sys.stdin.read()))')"
+    else
+        esnip="$(printf '%s' "$snippet" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')"
+        esnip="\"$esnip\""
+    fi
+    printf '{"kind":"cuda_ozaki_correctness","name":"cuda_ozaki_correctness_gate","value":"%s","snippet":%s,"confidence":0.95}\n' \
+        "$value" "$esnip" >> "${TRACE_FILE:?}"
+}
+
+log()  { printf '%s\n' "$*"; }
+skip() { log "SKIP: $*"; exit 0; }
+fail() { log "FAIL: $*"; emit_trace FAIL "$*"; exit 1; }
+pass() { log "PASS: $*"; emit_trace PASS "$*"; exit 0; }
+
+# ── GPU presence (CUDA / IMMA only) ─────────────────────────────────────────
+UNAME_S="$(uname -s)"
+if [ "$UNAME_S" = "Darwin" ]; then
+    skip "INT8-Ozaki is a CUDA (IMMA tensor-core) kernel; no CUDA GPU on macOS"
+elif command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then
+    log "note: CUDA host detected — driving INT8-Ozaki f64 GEMM"
+    nvidia-smi -L 2>/dev/null | head -1
+else
+    skip "no CUDA GPU detected (nvidia-smi absent or no device)"
+fi
+
+# ── locate eshkol-run ───────────────────────────────────────────────────────
+BIN="${ESHKOL_RUN:-}"
+if [ -z "$BIN" ]; then
+    for d in build-ozaki build build-gpu-gate build-*; do
+        if [ -x "$REPO_ROOT/$d/eshkol-run" ]; then BIN="$REPO_ROOT/$d/eshkol-run"; break; fi
+    done
+fi
+[ -n "$BIN" ] && [ -x "$BIN" ] || skip "no eshkol-run binary found (set ESHKOL_RUN)"
+log "using eshkol-run: $BIN"
+
+# Force the GPU INT8-Ozaki path for every matmul regardless of size.
+FORCE_GPU=(
+  ESHKOL_GPU_THRESHOLD=1
+  ESHKOL_GPU_MATMUL_THRESHOLD=1
+  ESHKOL_GPU_WAIT_TIMEOUT=300
+  ESHKOL_CUDA_F64_KERNEL=ozaki-int8
+)
+
+OUT_F="$(mktemp)"
+ERR_F="$(mktemp)"
+run_case() {  # run_case <extra-env...>; stdout -> $OUT_F, stderr -> $ERR_F
+    env "${FORCE_GPU[@]}" "$@" "$BIN" -r "$TEST_ESK" >"$OUT_F" 2>"$ERR_F"
+}
+
+# max NORMWISE value printed across all REGIME lines (awk float compare)
+max_normwise() { awk '
+    { for (i=1;i<=NF;i++) if ($i ~ /^NORMWISE=/) { v=substr($i,10)+0; if (v>m) m=v } }
+    END { printf "%.3e", m }' ; }
+
+ALL_OUT=""
+overall=0
+
+# ── Case 1: DEFAULT T=6 (full f64). HARD: normwise machine-precision everywhere ─
+log "=== Case 1: default INT8-Ozaki T=6 (full f64) across all regimes, K<=4096 [HARD] ==="
+run_case; OUT1="$(cat "$OUT_F")"; ALL_OUT="$OUT1"
+printf '%s\n' "$OUT1"
+printf '%s\n' "$OUT1" | grep -q "SUMMARY total_fail=0" || { overall=1; log "  -> T=6 produced failures (normwise >= 1e-6)"; }
+printf '%s\n' "$OUT1" | grep -q "VERDICT=FAIL" && { overall=1; log "  -> T=6 has a FAIL verdict"; }
+MAXNW1="$(printf '%s\n' "$OUT1" | max_normwise)"
+if awk "BEGIN{exit !($MAXNW1 < 1e-9)}"; then
+    log "  -> T=6 full-f64 confirmed: max normwise error $MAXNW1 < 1e-9"
+else
+    overall=1; log "  -> T=6 NOT full-f64: max normwise error $MAXNW1 >= 1e-9 (INT8 tensor-core path did not recover f64)"
+fi
+
+# ── Case 2: FAST T=4 (~1e-11). Correctness gate must still pass (normwise<1e-6). ─
+log "=== Case 2: fast INT8-Ozaki T=4 (~1e-11, ~2x faster) — correctness gate [HARD] ==="
+run_case ESHKOL_OZAKI_CUDA_T=4; OUT2="$(cat "$OUT_F")"
+printf '%s\n' "$OUT2"
+printf '%s\n' "$OUT2" | grep -q "SUMMARY total_fail=0" || { overall=1; log "  -> T=4 produced failures (normwise >= 1e-6)"; }
+MAXNW2="$(printf '%s\n' "$OUT2" | max_normwise)"
+log "  -> T=4 max normwise error $MAXNW2 (expected ~1e-11, gate is 1e-6)"
+
+# ── Case 3: out-of-range knob must FAIL LOUDLY (warn) and stay correct [HARD] ──
+log "=== Case 3: out-of-range ESHKOL_OZAKI_CUDA_T=99 -> loud clamp to T=6, still correct [HARD] ==="
+run_case ESHKOL_OZAKI_CUDA_T=99; OUT3="$(cat "$OUT_F")"
+printf '%s\n' "$OUT3"
+grep -qi "out of range" "$ERR_F" || { overall=1; log "  -> expected a loud out-of-range warning on stderr, none seen"; }
+printf '%s\n' "$OUT3" | grep -q "SUMMARY total_fail=0" || { overall=1; log "  -> clamped run still incorrect"; }
+
+# ── verdict ─────────────────────────────────────────────────────────────────
+SNIP="$(printf '%s\n' "$ALL_OUT" | grep -E 'REGIME=|SUMMARY' | head -20)"
+rm -f "$OUT_F" "$ERR_F"
+if [ "$overall" -eq 0 ]; then
+    pass "INT8-Ozaki f64 GEMM: T=6 machine-precision (normwise $MAXNW1) and T=4 correct across integer/fractional/pi_e/wide regimes at K<=4096; out-of-range knob clamps loudly and stays correct"
+else
+    fail "INT8-Ozaki f64 GEMM correctness gate failed; output:\n$SNIP"
+fi

--- a/tests/gpu/cuda_ozaki_correctness_test.esk
+++ b/tests/gpu/cuda_ozaki_correctness_test.esk
@@ -1,0 +1,90 @@
+;; cuda_ozaki_correctness_test.esk — INT8 tensor-core Ozaki f64 GEMM probe (CUDA).
+;;
+;; Runs a GPU matmul (the gate forces the INT8-Ozaki path via
+;; ESHKOL_CUDA_F64_KERNEL=ozaki-int8 + a low GPU dispatch threshold) and checks
+;; each result against an INDEPENDENT in-process CPU f64 triple-loop reference at
+;; a 5x5 grid of probe positions, across four data regimes and K up to 4096.
+;;
+;; INT8-Ozaki recovers FP64-accurate C = A*B from the INT8 (IMMA) tensor cores by
+;; per-row/col-scaled 7-bit integer slicing. The int32 accumulation is exact; the
+;; only error source is dropping slice-pairs with p+q>T. The standard GEMM
+;; accuracy metric is the NORMWISE (Frobenius) relative error — a single
+;; near-zero output entry (cancellation) inflates the per-element relative error
+;; without meaning anything, so we gate on the normwise error over the probe grid
+;; and only report the per-element max for visibility (same convention the 3090
+;; and Blackwell prototypes use). At T=6 (default, full f64) the normwise error is
+;; ~1e-15; at T=4 (~1e-11). A layout/scaling bug is O(1e-2..1), so a single
+;; conservative normwise TOL cleanly separates correct from broken across T.
+;;
+;; NOTE (mirrors the Metal Ozaki-II test): the matmul and its `tensor-data` read
+;; are done at TOP-LEVEL scope and only PLAIN VECTORS are handed to the checker —
+;; reading a `matmul` tensor from inside a `define`d function currently reads
+;; zeros (a separate compiler-scope issue), so the probe must not touch the
+;; tensor object itself.
+
+(define TOL 1e-6)          ;; normwise Frobenius rel-err gate; correct Ozaki is 1e-11..1e-15
+(define total-fail 0)
+
+(define (fillA regime i)
+  (cond ((= regime 0) (exact->inexact (- (modulo i 7) 3)))                                  ;; integer (incl. negatives)
+        ((= regime 1) (+ 1.0 (* 0.5 (exact->inexact (modulo i 7)))))                        ;; fractional O(1)
+        ((= regime 2) (* 3.141592653589793 (+ 1.0 (exact->inexact (modulo i 11)))))         ;; pi multiples
+        (else (* (expt 2.0 (exact->inexact (- (modulo i 20) 10)))                           ;; wide magnitude 2^[-10,9]
+                 (+ 1.0 (* 0.1 (exact->inexact (modulo i 3))))))))
+(define (fillB regime i)
+  (cond ((= regime 0) (exact->inexact (- (modulo i 5) 2)))
+        ((= regime 1) (+ 0.5 (* 0.25 (exact->inexact (modulo i 5)))))
+        ((= regime 2) (* 2.718281828459045 (- (exact->inexact (modulo i 9)) 4.0)))          ;; e multiples (incl. negatives)
+        (else (* (expt 2.0 (exact->inexact (- (modulo i 18) 9)))
+                 (+ 1.0 (* 0.1 (exact->inexact (modulo i 4))))))))
+(define (rname regime)
+  (cond ((= regime 0) "integer") ((= regime 1) "fractional") ((= regime 2) "pi_e") (else "wide_range")))
+
+;; Probe a 5x5 grid of output positions against an independent CPU f64 reference.
+;; Gate metric = normwise Frobenius rel error over the grid; also report per-elem
+;; max rel error. Operates purely on plain vectors (Ad, Bd, Cd) — no tensor objects.
+(define (check regime N Ad Bd Cd)
+  (let ((maxrel 0.0) (sum-num 0.0) (sum-den 0.0))
+    (do ((pr 0 (+ pr 1))) ((>= pr 5))
+      (do ((pc 0 (+ pc 1))) ((>= pc 5))
+        (let ((ii (quotient (* pr (- N 1)) 4))
+              (jj (quotient (* pc (- N 1)) 4))
+              (ref 0.0))
+          (do ((k 0 (+ k 1))) ((>= k N))
+            (set! ref (+ ref (* (vector-ref Ad (+ (* ii N) k))
+                                (vector-ref Bd (+ (* k N) jj))))))
+          (let* ((cij (vector-ref Cd (+ (* ii N) jj)))
+                 (diff (- cij ref))
+                 (denom (if (> (abs ref) 1e-9) (abs ref) 1.0))
+                 (rel (/ (abs diff) denom)))
+            (set! sum-num (+ sum-num (* diff diff)))
+            (set! sum-den (+ sum-den (* ref ref)))
+            (when (> rel maxrel) (set! maxrel rel))))))
+    (let* ((normwise (/ (sqrt sum-num) (if (> sum-den 1e-24) (sqrt sum-den) 1.0)))
+           (pass (< normwise TOL)))
+      (when (not pass) (set! total-fail (+ total-fail 1)))
+      (display "REGIME=") (display (rname regime))
+      (display " N=") (display N)
+      (display " MAXREL=") (display maxrel)
+      (display " NORMWISE=") (display normwise)
+      (display " VERDICT=") (display (if pass "PASS" "FAIL"))
+      (newline))))
+
+(define sizes (vector 512 1024 2048 4096))
+(do ((r 0 (+ r 1))) ((>= r 4))
+  (do ((si 0 (+ si 1))) ((>= si 4))
+    (let* ((N (vector-ref sizes si))
+           (size (* N N))
+           (Ad (make-vector size 0.0))
+           (Bd (make-vector size 0.0)))
+      (do ((i 0 (+ i 1))) ((>= i size))
+        (vector-set! Ad i (fillA r i))
+        (vector-set! Bd i (fillB r i)))
+      ;; matmul + tensor-data at TOP-LEVEL scope; hand only plain vectors to check
+      (let* ((A (reshape Ad N N))
+             (B (reshape Bd N N))
+             (C (matmul A B))
+             (Cd (tensor-data C)))
+        (check r N Ad Bd Cd)))))
+
+(display "SUMMARY total_fail=") (display total-fail) (newline)


### PR DESCRIPTION
## Summary

Adds an **opt-in INT8 tensor-core Ozaki f64 GEMM** path to the CUDA backend. It recovers FP64-accurate `C = A·B` from the INT8 (IMMA) tensor cores, which run ~500× faster than the deliberately crippled native FP64 pipeline on consumer/prosumer NVIDIA GPUs (GeForce Ampere f64 = 1/64 FP32). The f64 GPU matmul path today has only `cublasDgemm` + f16 `GemmEx`; this adds an f64-accurate high-throughput alternative.

Default **OFF** — select with `ESHKOL_CUDA_F64_KERNEL=ozaki-int8`; otherwise the f64 GPU matmul stays `cublasDgemm`.

### Method (Ootomo–Ozaki–Yokota, per-row/col scaled 7-bit slicing)

1. Scale into `[-1,1]`: `r_i = max_k|A[i,k]|` (per row of A), `c_j = max_k|B[k,j]|` (per col of B).
2. Slice `A/r`, `B/c` into `s = T+1` signed int8 slices (base 128, `|slice| ≤ 127`). **A-slices stored natural, B-slices stored transposed** so each pair GEMM issues as `cublasGemmEx(OP_T, OP_N, CUDA_R_8I → CUDA_R_32I, COMPUTE_32I)` on the fast IMMA **TN** layout — mandatory on sm_86 (a **3.7× throughput cliff** vs NN); Blackwell sm_120 is layout-indifferent, so TN is safe everywhere.
3. `C[i,j] = r_i c_j · Σ_{p+q≤T} 128^{−(p+q+2)} (A_p × B_q)[i,j]`. Each `A_p × B_q` is one INT8→INT32 GEMM. The int32 accumulation is **exact** — the only error source is dropping slice-pairs with `p+q > T`.
4. **Diagonal-fused reconstruction** (the Blackwell win, `ozaki_fused2.cu`): all pairs on a diagonal `d = p+q` share the weight `128^{−(d+2)}`, so they accumulate into one int32 buffer via `cublasGemmEx` `beta=1` (staying on the tensor path), then a single fused kernel streams the diagonal buffers, applies the weight, and scales by `r_i c_j`. Buffers are capped at `⌊(2³¹−1)/(K·127²)⌋` pairs — **provably int32-exact at any N**.

`K` is guarded below **133,000** (`K·127² < 2³¹`); out of range it falls back **loudly** to `cublasDgemm` (mirrors #307's loud-clamp philosophy; K-panel splitting is not implemented).

### Accuracy / throughput knob — `ESHKOL_OZAKI_CUDA_T` (default 6)

| target accuracy | T | #INT8 GEMMs | note |
|---|---|---|---|
| ~1e-9 | 3 | 10 | |
| **~1e-11** | **4** | **15** | fast high-precision (~2× faster than T=6) |
| ~1e-13 | 5 | 21 | |
| **full f64 (~1e-15)** | **6** (default) | **28** | mantissa fully covered |

Relative error `≈ 2^{−7(T+1)}`; `#GEMMs = (T+1)(T+2)/2`.

## Measured correctness — real RTX 3090 (sm_86), live

Hardware run on **cosbox** (RTX 3090, sm_86, 82 SMs; CUDA 12.0 / nvcc, host `g++-12`). Accuracy metric is the **normwise Frobenius relative error** vs `cublasDgemm` (the standard GEMM metric — a single near-zero output entry inflates per-element error meaninglessly), cross-checked against an **independent CPU f64 reference** on a probe grid. Data regimes match the in-repo gate (`cuda_ozaki_correctness_test.esk`): integer, fractional, pi·e, wide-range (2^[-10,9]).

```
==== T=6 (full f64) ====
# REGIME       N     Dgemm_vs_CPU(probe)  Ozaki_vs_CPU(probe,maxrel)  Ozaki_vs_Dgemm(normwise)  VERDICT
  integer      512  0.000e+00            3.353e-14                  1.118e-14               PASS
  integer     4096  0.000e+00            1.406e-14                  1.019e-14               PASS
  fractional   512  0.000e+00            1.425e-15                  1.426e-15               PASS
  fractional  4096  0.000e+00            1.599e-15                  1.458e-15               PASS
  pi_e        2048  2.556e-13            1.527e-13                  8.495e-15               PASS
  pi_e        4096  1.184e-13            6.656e-14                  1.780e-14               PASS
  wide_range   512  1.503e-16            7.813e-15                  5.411e-15               PASS
  wide_range  4096  0.000e+00            7.651e-15                  4.997e-15               PASS

==== T=4 (fast ~1e-11) ====
  integer     4096  0.000e+00            1.735e-10                  1.267e-10               PASS
  fractional  4096  0.000e+00            2.038e-11                  2.038e-11               PASS
  pi_e        1024  6.781e-14            3.281e-08(*)               1.455e-10               PASS
  wide_range  4096  0.000e+00            1.020e-10                  6.947e-11               PASS

==== K-guard (int32 exactness) ====
  K=200000 (M=N=64): cuda_matmul_ozaki_int8_f64 returned -1 -> PASS (loud fallback to cublasDgemm)
  K=100000 (in-range): returned 0 -> PASS (INT8-Ozaki ran)

SUMMARY overall_fail=0
```
(Full 32-row sweep — all 4 regimes × N∈{512,1024,2048,4096} for both T — passed; representative rows shown.)

Highlights: **T=6 recovers full f64 everywhere** (normwise 5e-15…1.8e-14, incl. **wide-dynamic-range 1e-3…1e3 at 5.0e-15** — per-row/col scaling holds); **T=4 gives ~1e-10** as designed; the **K-guard fires loudly** at K>133000 and stays in-range below. `(*)` the T=4 pi_e per-element `maxrel` 3.3e-8 is a single near-zero-entry artifact (the normwise error is 1.5e-10) — same behavior the prototype documents.

This matches the proven prototype: RTX 3090 **4.74 TFLOP/s-eq at full f64 = 8.8× native `cublasDgemm`** (0.54 TF), up to 16.6× at ~1e-11.

## Expected upside — RTX PRO 6000 Blackwell (sm_120), quoted from prototype RESULTS.md

| metric | RTX 3090 | **Blackwell** |
|---|---|---|
| INT8 IMMA ceiling | 278 TOPS | **898 TOPS** |
| native `cublasDgemm` f64 | 0.54 TF | 1.50 TF |
| **INT8-Ozaki f64-accurate (fused, T=6)** | 4.74 TF | **~30 TFLOP/s** @ err ≤8.4e-15 |
| **× native f64** | 8.8× | **~20×** |

The diagonal-fused reconstruction shipped here is the Blackwell lever (1.26–1.85× over unfused), lifting efficiency to ~100% of the pure-INT8-GEMM ceiling. FP8-Ozaki was measured on Blackwell but is 2× slower than INT8 (identical tensor throughput, fewer exact bits/slice) — INT8 is the f64-accurate path.

## What was verified where

| item | where | status |
|---|---|---|
| INT8-Ozaki kernels + orchestration **compile** (nvcc 12.0, sm_86, cublas) | cosbox 3090 | built clean (verbatim-copy harness) |
| **Correctness** vs cublasDgemm + independent CPU f64, 4 regimes, K≤4096, T=4/6 | cosbox 3090 | all PASS (numbers above) |
| K<133000 **loud fallback** behavior | cosbox 3090 | PASS |
| **Full-app CUDA compile** of the exact repo files | CI cuda build-only lane | delegated (CI's job — the dev nodes have no CUDA; cosbox disk is 99% full, full LLVM build infeasible) |
| **Non-CUDA build stays green** | by construction | changed files are CUDA-only (`gpu_memory_cuda.cpp` / `gpu_cuda_kernels.cu` compile only on CUDA builds; non-CUDA uses `gpu_memory_stub.cpp`). New `.cpp` functions are all `static`; the extern-"C" launchers are CUDA-only. No public symbol added, no CMake/build-graph change. |

The correctness harness (`cuda_ozaki_unit_harness.cu`) is a **verbatim copy** of the added device kernels and host orchestration, so its 3090 run is a faithful proxy for the integrated path (a full Eshkol build on cosbox is infeasible: 7 GB disk free, 2.9 GB GPU free). The orchestration is host C++ compiled by `g++-12` (the same host-compiler path as a real Linux CUDA build); the kernels are the nvcc device path.

## Files

- `lib/backend/gpu/gpu_cuda_kernels.cu` — `ozaki_rowmax/colmax/split_a/split_b/reconstruct` kernels + launchers.
- `lib/backend/gpu/gpu_memory_cuda.cpp` — `cuda_matmul_ozaki_int8_f64` orchestration, env handling, hook in `cuda_matmul_f64`.
- `tests/gpu/cuda_ozaki_correctness_test.esk`, `tests/gpu/cuda_ozaki_correctness_gate.sh` — correctness gate (CUDA/real-GPU only; SKIPs cleanly elsewhere).
- `.icc/completion-oracles.yaml` — `cuda-ozaki-int8-correctness` oracle.
- `CHANGELOG.md`, `docs/breakdown/GPU_ACCELERATION.md`.

## Notes / deviations from brief

- **Hardware verification uses the standalone unit harness** (verbatim copy), not a full-app build on cosbox — the brief's explicit fallback, because cosbox disk is 99% full (7 GB free) and GPU is 21 GB occupied. Full-app CUDA compile is CI's build-only lane, as the brief states.
- `.github/` untouched (CI wired separately); `lib/math/fixed_point/` untouched; main working tree untouched.
