### PR TITLE
feat(numerics): mixed-precision iterative-refinement linear solver

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -172,6 +172,13 @@ oracles:
         severity: high
         label: 'AD nesting: jacobian/hessian differentiating through an inner forward-mode derivative is exact, not silent-zero (ESH-0120/0121)'
         action: ./scripts/run_icc_smoke.sh
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["linear_solve_full_f64_oracle"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'linear-solve: mixed-precision iterative-refinement dense solver reaches full-f64 backward residual (<=1e-12, computed independently) on well-conditioned/identity systems and raises catchably on singular/dimension-mismatch — verified on JIT, AOT, and the VM'
+        action: ./scripts/run_icc_smoke.sh
 
   # ─────────────────────────────────────────────────────────────────
   # TOTAL-LANGUAGE completion — unlike the compiler-readiness ratchet above,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   boxed) so both compute bit-identical results. Docs:
   `docs/reference/language/i128.md`; tests: `tests/types/i128_test.esk`
   (native + VM parity) and `tests/types/i128_error_test.esk`.
+- **`linear-solve` — full-f64 dense linear solver with a mixed-precision fast
+  path.** `(linear-solve A b)` solves `A x = b` for a square `N×N` tensor `A`
+  and length-`N` `b` with a full-f64 accuracy guarantee. On Apple/Accelerate it
+  factorizes `A` in fp32 (the `O(n³)` cost, ~2–3× faster than f64 on the AMX
+  units) and polishes the result back to full f64 by iterative refinement
+  (Langou/Baboulin/Dongarra): the residual is recomputed in f64 and a fp32
+  back-solve corrects `x` until the relative backward residual is certified at
+  ~`1e-13`. When refinement cannot certify a full-f64 result (ill-conditioned
+  systems) it silently falls back to a plain-f64 LAPACK `dgesv`, so the caller
+  always gets a correct f64 answer — the speedup is opportunistic, the
+  correctness is not. Non-Apple builds use a direct f64 LU. Singular,
+  non-square, and dimension-mismatch inputs raise catchable conditions.
+  Measured on an M2 Ultra: ~1.15–1.4× faster than the forced-`dgesv` path at
+  `N = 2048–4096` at `~1e-15` residual. Implemented in `lib/core/linear_solve.cpp`
+  with native-codegen and bytecode-VM surfaces (native call id 472) and an
+  `linear-solve-full-f64` ICC oracle; see
+  `tests/features/linear_solve_test.esk` and
+  [docs/reference/tensors/operations.md](docs/reference/tensors/operations.md#linear-solve--full-f64-solve-with-a-mixed-precision-fast-path).
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2036,6 +2036,7 @@ set(ESHKOL_RUNTIME_CORE_SRC
   lib/core/runtime_deep_equal.cpp
   lib/core/runtime_hash_table.cpp
   lib/core/runtime_list_helpers.cpp
+  lib/core/linear_solve.cpp
   lib/core/runtime_object_alloc.cpp
   lib/core/runtime_regions.cpp
   lib/core/runtime_shared_memory.cpp

--- a/docs/reference/tensors/INDEX.md
+++ b/docs/reference/tensors/INDEX.md
@@ -26,7 +26,9 @@ against their behavior, not hidden.
 ## What works, what to avoid
 
 **Solid:** all shape ops, elementwise/unary math, linear algebra incl.
-LU/QR/SVD/Cholesky/solve/inverse/det, reductions, `conv1d`/`conv2d`/`conv3d`,
+LU/QR/SVD/Cholesky/solve/inverse/det plus `linear-solve` (full-f64
+mixed-precision iterative refinement — see [operations.md](operations.md#linear-solve--full-f64-solve-with-a-mixed-precision-fast-path)),
+reductions, `conv1d`/`conv2d`/`conv3d`,
 `max-pool2d`/`avg-pool2d`, `multi-head-attention` (forward), `embedding`,
 `positional-encoding`, `dropout`, `softmax`, tensor-only activations, dtype
 casts, rect/disk pixel fills, and all three library modules.

--- a/docs/reference/tensors/operations.md
+++ b/docs/reference/tensors/operations.md
@@ -78,6 +78,7 @@ Scalar-broadcast and unary:
 | `tensor-inverse` | `(tensor-inverse A)` | 2×2 inverse |
 | `tensor-det` | `(tensor-det A)` | → `10` |
 | `tensor-solve` | `(tensor-solve A b)` | solves `Ax=b` → `#(2 3)` |
+| `linear-solve` | `(linear-solve A b)` | full-f64 `Ax=b`, mixed-precision IR (see below) |
 | `tensor-cholesky` | `(tensor-cholesky A)` | lower-triangular `L` |
 | `tensor-lu` | `(tensor-lu A)` | **list** `(LU pivot sign)` |
 | `tensor-qr` | `(tensor-qr A)` | **list** `(Q R)` |
@@ -88,6 +89,49 @@ The three decompositions return **lists of tensors**, e.g.
 `(tensor-svd A)` → `(U S V)`. `matmul` (and `gpu-matmul`) route through the
 cost-model dispatch and may run on the GPU (see [gpu.md](gpu.md));
 `batch-matmul` is a separate CPU path.
+
+### `linear-solve` — full-f64 solve with a mixed-precision fast path
+
+`(linear-solve A b)` solves the dense system `A x = b` for a square `N×N`
+tensor `A` and a length-`N` tensor `b`, returning `x` as a length-`N` tensor.
+Unlike `tensor-solve` (a plain f64 LU), `linear-solve` carries a **full-f64
+accuracy guarantee with an opportunistic speedup**:
+
+- On Apple/Accelerate it factorizes `A` in **fp32** (the `O(n³)` cost) and then
+  polishes the solution back to full f64 by **iterative refinement** — the
+  residual `r = b − A x` is recomputed in f64 (an `O(n²)` GEMV) and a fp32
+  back-solve corrects `x`, looping until the relative backward residual
+  `‖b − A x‖ / ‖b‖` is certified at or below ~`1e-13`. Because the fp32
+  factorization runs ~2–3× faster than an f64 one on the AMX units while the
+  refinement tail is asymptotically free, a well-conditioned solve reaches the
+  same f64 residual as `dgesv` at a fraction of the cost.
+- When refinement cannot certify a full-f64 result within its iteration cap —
+  an **ill-conditioned** system where `κ·ε_fp32 ≳ 1` — it **silently falls
+  back to a plain-f64 LAPACK `dgesv`**. Either way the caller always receives a
+  genuine full-precision f64 solution; the speedup is opportunistic, the
+  correctness is not.
+- Non-Apple builds use a direct f64 LU with partial pivoting (correct
+  everywhere; the fp32 IR speedup is Apple-first for now).
+
+Measured on an M2 Ultra, the mixed-precision path is ~1.1–1.4× faster than the
+forced-`dgesv` fallback at `N = 2048–4096` (well-conditioned), at a residual of
+`~1e-15` — the win grows with `N`.
+
+Errors are catchable with `guard`: a **singular** `A`, a **non-square** `A`, or
+a **length mismatch** between `A` and `b` raise a condition rather than
+returning a wrong answer.
+
+```scheme
+;; A = [[4 1 0] [1 4 1] [0 1 4]], b = [6 12 14]  =>  x = [1 2 3]
+(define A (reshape (make-vec (list 4.0 1.0 0.0
+                                   1.0 4.0 1.0
+                                   0.0 1.0 4.0) 9) (list 3 3)))
+(linear-solve A (make-vec (list 6.0 12.0 14.0) 3))   ;; => #(1 2 3)
+
+(guard (e (#t 'singular))
+  (linear-solve (reshape (make-vec (list 1.0 2.0 2.0 4.0) 4) (list 2 2))
+                (make-vec (list 1.0 1.0) 2)))         ;; => singular  (raises)
+```
 
 ```scheme
 (tensor-matmul (reshape (tensor 1.0 2.0 3.0 4.0) (list 2 2))

--- a/inc/eshkol/backend/tensor_codegen.h
+++ b/inc/eshkol/backend/tensor_codegen.h
@@ -406,6 +406,9 @@ public:
     llvm::Value* tensorInverse(const eshkol_operations_t* op);
     /** Solve linear system Ax=b via LU decomposition */
     llvm::Value* tensorSolve(const eshkol_operations_t* op);
+    /** Solve Ax=b with a full-f64 guarantee via mixed-precision iterative
+     *  refinement (Apple/Accelerate) with a plain-f64 LAPACK fallback. */
+    llvm::Value* tensorLinearSolve(const eshkol_operations_t* op);
     /** Cholesky decomposition for SPD matrices: A = L @ L^T */
     llvm::Value* tensorCholesky(const eshkol_operations_t* op);
     /** QR decomposition via Householder reflections: A = Q @ R */

--- a/lib/backend/eshkol_vm.c
+++ b/lib/backend/eshkol_vm.c
@@ -390,6 +390,7 @@ static const BuiltinDef BUILTINS[] = {
     {"_tensor-reduce-sum", 457, 2}, {"_tensor-reduce-mean", 458, 2},
     {"_tensor-reduce-max", 459, 2}, {"_tensor-reduce-min", 460, 2},
     {"gpu-elementwise", 470, 3}, {"gpu-reduce", 471, 2},
+    {"linear-solve", 472, 2},
     {"gpu-transpose", 416, 1},
     {"relu", 462, 1}, {"softmax", 463, 1}, {"gpu-softmax", 463, 1}, {"sigmoid", 464, 1},
     {"eye", 745, 1}, {"linspace", 746, 3},

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -16413,6 +16413,7 @@ private:
         if (func_name == "tensor-det") return tensor_->tensorDet(op);
         if (func_name == "tensor-inverse") return tensor_->tensorInverse(op);
         if (func_name == "tensor-solve") return tensor_->tensorSolve(op);
+        if (func_name == "linear-solve") return tensor_->tensorLinearSolve(op);
         if (func_name == "tensor-cholesky") return tensor_->tensorCholesky(op);
         if (func_name == "tensor-qr") return tensor_->tensorQR(op);
         if (func_name == "tensor-svd") return tensor_->tensorSVD(op);

--- a/lib/backend/tensor_linalg_codegen.cpp
+++ b/lib/backend/tensor_linalg_codegen.cpp
@@ -656,7 +656,6 @@ llvm::Value* TensorCodegen::tensorLinearSolve(const eshkol_operations_t* op) {
                    a_elems, b_elems, res_elems});
 
     // Nonzero status => raise the corresponding catchable error and stop.
-    llvm::Function* cur_fn = builder.GetInsertBlock()->getParent();
     llvm::Value* is_err = builder.CreateICmpNE(
         status, llvm::ConstantInt::get(ctx_.int64Type(), 0));
     llvm::BasicBlock* err_bb = llvm::BasicBlock::Create(ctx_.context(), "linsolve_err", cur_fn);

--- a/lib/backend/tensor_linalg_codegen.cpp
+++ b/lib/backend/tensor_linalg_codegen.cpp
@@ -571,30 +571,72 @@ llvm::Value* TensorCodegen::tensorLinearSolve(const eshkol_operations_t* op) {
     if (!a_tagged || !b_tagged) return nullptr;
 
     llvm::StructType* tensor_type = ctx_.tensorType();
-    llvm::Value* a_ptr = tagged_.unpackPtr(a_tagged);
-    llvm::Value* b_ptr = tagged_.unpackPtr(b_tagged);
+    // Native typed validation first: reject wrong-typed operands via
+    // eshkol_tensor_operand_checked before dereferencing internal tensor fields.
+    llvm::Value* a_ptr = unpackTensorOperandChecked(a_tagged, "linear-solve");
+    llvm::Value* b_ptr = unpackTensorOperandChecked(b_tagged, "linear-solve");
 
-    // A: dims pointer (idx 0), rank (idx 1), elements (idx 2).
-    llvm::Value* a_dims_ptr = builder.CreateLoad(
-        ctx_.ptrType(), builder.CreateStructGEP(tensor_type, a_ptr, 0));
     llvm::Value* a_ndim = builder.CreateLoad(
         ctx_.int64Type(), builder.CreateStructGEP(tensor_type, a_ptr, 1));
-    llvm::Value* a_elems = builder.CreateLoad(
-        ctx_.ptrType(), builder.CreateStructGEP(tensor_type, a_ptr, 2));
-    // N = A's first dimension (the solution length). Valid for any rank>=1;
-    // the runtime rejects non-square / rank!=2 shapes before touching it.
-    llvm::Value* n = builder.CreateLoad(ctx_.int64Type(), a_dims_ptr);
-
-    // b: dims pointer (idx 0), rank (idx 1), elements (idx 2).
-    llvm::Value* b_dims_ptr = builder.CreateLoad(
-        ctx_.ptrType(), builder.CreateStructGEP(tensor_type, b_ptr, 0));
     llvm::Value* b_ndim = builder.CreateLoad(
         ctx_.int64Type(), builder.CreateStructGEP(tensor_type, b_ptr, 1));
+
+    llvm::FunctionType* raise_ft = llvm::FunctionType::get(
+        ctx_.voidType(), {ctx_.int64Type()}, false);
+    llvm::Function* raise_fn = getOrDeclareRuntimeFunc(
+        ctx_.module(), ctx_.context(), "eshkol_linear_solve_raise", raise_ft);
+
+    // shape checks that must happen before result allocation.
+    llvm::Function* cur_fn = builder.GetInsertBlock()->getParent();
+    llvm::BasicBlock* rank_ok_bb = llvm::BasicBlock::Create(ctx_.context(), "linsolve_rank_ok", cur_fn);
+    llvm::BasicBlock* rank_err_bb = llvm::BasicBlock::Create(ctx_.context(), "linsolve_rank_err", cur_fn);
+    llvm::BasicBlock* shape_ok_bb = llvm::BasicBlock::Create(ctx_.context(), "linsolve_shape_ok", cur_fn);
+    llvm::BasicBlock* shape_err_bb = llvm::BasicBlock::Create(ctx_.context(), "linsolve_shape_err", cur_fn);
+
+    llvm::Value* rank_ok = builder.CreateAnd(
+        builder.CreateICmpEQ(a_ndim, llvm::ConstantInt::get(ctx_.int64Type(), 2)),
+        builder.CreateICmpEQ(b_ndim, llvm::ConstantInt::get(ctx_.int64Type(), 1)));
+    builder.CreateCondBr(rank_ok, rank_ok_bb, rank_err_bb);
+
+    // non-2-D A (or non-1-D b) is a rank-level shape error.
+    builder.SetInsertPoint(rank_err_bb);
+    builder.CreateCall(
+        raise_fn,
+        {builder.CreateSelect(builder.CreateICmpEQ(a_ndim, llvm::ConstantInt::get(ctx_.int64Type(), 2)),
+                             llvm::ConstantInt::get(ctx_.int64Type(), 3),
+                             llvm::ConstantInt::get(ctx_.int64Type(), 2))});
+    builder.CreateUnreachable();
+
+    builder.SetInsertPoint(rank_ok_bb);
+    llvm::Value* a_dims_ptr = builder.CreateLoad(
+        ctx_.ptrType(), builder.CreateStructGEP(tensor_type, a_ptr, 0));
+    llvm::Value* a_cols_ptr = builder.CreateGEP(ctx_.int64Type(), a_dims_ptr, llvm::ConstantInt::get(ctx_.int64Type(), 1));
+    llvm::Value* n = builder.CreateLoad(ctx_.int64Type(), a_dims_ptr);
+    llvm::Value* a_cols = builder.CreateLoad(ctx_.int64Type(), a_cols_ptr);
+    llvm::Value* b_dims_ptr = builder.CreateLoad(
+        ctx_.ptrType(), builder.CreateStructGEP(tensor_type, b_ptr, 0));
+    llvm::Value* a_elems = builder.CreateLoad(
+        ctx_.ptrType(), builder.CreateStructGEP(tensor_type, a_ptr, 2));
     llvm::Value* b_elems = builder.CreateLoad(
         ctx_.ptrType(), builder.CreateStructGEP(tensor_type, b_ptr, 2));
+    llvm::Value* b_n = builder.CreateLoad(ctx_.int64Type(), b_dims_ptr);
+
+    llvm::Value* is_square = builder.CreateICmpEQ(n, a_cols);
+    llvm::Value* rhs_matches = builder.CreateICmpEQ(n, b_n);
+    llvm::Value* shape_ok = builder.CreateAnd(is_square, rhs_matches);
+    builder.CreateCondBr(shape_ok, shape_ok_bb, shape_err_bb);
+
+    builder.SetInsertPoint(shape_err_bb);
+    builder.CreateCall(
+        raise_fn,
+        {builder.CreateSelect(is_square,
+                              llvm::ConstantInt::get(ctx_.int64Type(), 3),
+                              llvm::ConstantInt::get(ctx_.int64Type(), 2))});
+    builder.CreateUnreachable();
 
     // Result: a 1-D tensor of length N. Its elements buffer is the solver's
-    // output x (f64 bit patterns == doubles).
+    // output x (f64 bit patterns == doubles). Construct only after shape checks.
+    builder.SetInsertPoint(shape_ok_bb);
     std::vector<llvm::Value*> dims = {n};
     llvm::Value* result_ptr = createTensorWithDims(dims);
     if (!result_ptr) return nullptr;
@@ -622,10 +664,6 @@ llvm::Value* TensorCodegen::tensorLinearSolve(const eshkol_operations_t* op) {
     builder.CreateCondBr(is_err, err_bb, ok_bb);
 
     builder.SetInsertPoint(err_bb);
-    llvm::FunctionType* raise_ft = llvm::FunctionType::get(
-        ctx_.voidType(), {ctx_.int64Type()}, false);
-    llvm::Function* raise_fn = getOrDeclareRuntimeFunc(
-        ctx_.module(), ctx_.context(), "eshkol_linear_solve_raise", raise_ft);
     builder.CreateCall(raise_fn, {status});
     builder.CreateUnreachable();
 

--- a/lib/backend/tensor_linalg_codegen.cpp
+++ b/lib/backend/tensor_linalg_codegen.cpp
@@ -553,6 +553,86 @@ llvm::Value* TensorCodegen::tensorSolve(const eshkol_operations_t* op) {
     return tagged_.packHeapPtr(result_ptr);
 }
 
+llvm::Value* TensorCodegen::tensorLinearSolve(const eshkol_operations_t* op) {
+    // linear-solve: (linear-solve A b) -> x where A x = b, with a full-f64
+    // guarantee. The heavy lifting (mixed-precision iterative refinement plus
+    // the plain-f64 fallback) lives in the runtime; codegen just marshals the
+    // tensor buffers, calls eshkol_linear_solve(), and raises on a nonzero
+    // status. A's elements are f64 bit patterns (never modified by the
+    // solver), so they alias a double* directly — no working copy needed.
+    if (op->call_op.num_vars != 2) {
+        eshkol_error("linear-solve requires 2 arguments: matrix A, vector b");
+        return nullptr;
+    }
+
+    llvm::IRBuilder<>& builder = ctx_.builder();
+    llvm::Value* a_tagged = codegenAST(&op->call_op.variables[0]);
+    llvm::Value* b_tagged = codegenAST(&op->call_op.variables[1]);
+    if (!a_tagged || !b_tagged) return nullptr;
+
+    llvm::StructType* tensor_type = ctx_.tensorType();
+    llvm::Value* a_ptr = tagged_.unpackPtr(a_tagged);
+    llvm::Value* b_ptr = tagged_.unpackPtr(b_tagged);
+
+    // A: dims pointer (idx 0), rank (idx 1), elements (idx 2).
+    llvm::Value* a_dims_ptr = builder.CreateLoad(
+        ctx_.ptrType(), builder.CreateStructGEP(tensor_type, a_ptr, 0));
+    llvm::Value* a_ndim = builder.CreateLoad(
+        ctx_.int64Type(), builder.CreateStructGEP(tensor_type, a_ptr, 1));
+    llvm::Value* a_elems = builder.CreateLoad(
+        ctx_.ptrType(), builder.CreateStructGEP(tensor_type, a_ptr, 2));
+    // N = A's first dimension (the solution length). Valid for any rank>=1;
+    // the runtime rejects non-square / rank!=2 shapes before touching it.
+    llvm::Value* n = builder.CreateLoad(ctx_.int64Type(), a_dims_ptr);
+
+    // b: dims pointer (idx 0), rank (idx 1), elements (idx 2).
+    llvm::Value* b_dims_ptr = builder.CreateLoad(
+        ctx_.ptrType(), builder.CreateStructGEP(tensor_type, b_ptr, 0));
+    llvm::Value* b_ndim = builder.CreateLoad(
+        ctx_.int64Type(), builder.CreateStructGEP(tensor_type, b_ptr, 1));
+    llvm::Value* b_elems = builder.CreateLoad(
+        ctx_.ptrType(), builder.CreateStructGEP(tensor_type, b_ptr, 2));
+
+    // Result: a 1-D tensor of length N. Its elements buffer is the solver's
+    // output x (f64 bit patterns == doubles).
+    std::vector<llvm::Value*> dims = {n};
+    llvm::Value* result_ptr = createTensorWithDims(dims);
+    if (!result_ptr) return nullptr;
+    llvm::Value* res_elems = builder.CreateLoad(
+        ctx_.ptrType(), builder.CreateStructGEP(tensor_type, result_ptr, 2));
+
+    // status = eshkol_linear_solve(a_ndim, a_dims, b_ndim, b_dims, A, b, x)
+    llvm::FunctionType* solve_ft = llvm::FunctionType::get(
+        ctx_.int64Type(),
+        {ctx_.int64Type(), ctx_.ptrType(), ctx_.int64Type(), ctx_.ptrType(),
+         ctx_.ptrType(), ctx_.ptrType(), ctx_.ptrType()},
+        false);
+    llvm::Function* solve_fn = getOrDeclareRuntimeFunc(
+        ctx_.module(), ctx_.context(), "eshkol_linear_solve", solve_ft);
+    llvm::Value* status = builder.CreateCall(
+        solve_fn, {a_ndim, a_dims_ptr, b_ndim, b_dims_ptr,
+                   a_elems, b_elems, res_elems});
+
+    // Nonzero status => raise the corresponding catchable error and stop.
+    llvm::Function* cur_fn = builder.GetInsertBlock()->getParent();
+    llvm::Value* is_err = builder.CreateICmpNE(
+        status, llvm::ConstantInt::get(ctx_.int64Type(), 0));
+    llvm::BasicBlock* err_bb = llvm::BasicBlock::Create(ctx_.context(), "linsolve_err", cur_fn);
+    llvm::BasicBlock* ok_bb = llvm::BasicBlock::Create(ctx_.context(), "linsolve_ok", cur_fn);
+    builder.CreateCondBr(is_err, err_bb, ok_bb);
+
+    builder.SetInsertPoint(err_bb);
+    llvm::FunctionType* raise_ft = llvm::FunctionType::get(
+        ctx_.voidType(), {ctx_.int64Type()}, false);
+    llvm::Function* raise_fn = getOrDeclareRuntimeFunc(
+        ctx_.module(), ctx_.context(), "eshkol_linear_solve_raise", raise_ft);
+    builder.CreateCall(raise_fn, {status});
+    builder.CreateUnreachable();
+
+    builder.SetInsertPoint(ok_bb);
+    return tagged_.packHeapPtr(result_ptr);
+}
+
 llvm::Value* TensorCodegen::tensorCholesky(const eshkol_operations_t* op) {
     // tensor-cholesky: (tensor-cholesky A) -> L where A = L @ L^T
     if (op->call_op.num_vars != 1) {

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -1,3 +1,10 @@
+/* Dense linear solver (lib/core/linear_solve.cpp): full-f64 Ax=b, row-major
+ * f64 buffers, returns 0 on success or a nonzero catchable status code. */
+extern int64_t eshkol_linear_solve(
+    int64_t a_ndim, const int64_t* a_dims,
+    int64_t b_ndim, const int64_t* b_dims,
+    const double* A, const double* b, double* x);
+
 /* Heap pointer validation — prevent OOB heap access from untrusted values.
  * Used before any vm->heap.objects[val.as.ptr] dereference. */
 #define VM_VALIDATE_HEAP(vm, val) \
@@ -5501,6 +5508,39 @@ static void vm_escape_native_control(VM* vm) {
     }
 }
 
+/* Raise `exn` as the current exception and transfer control to the innermost
+ * installed handler (unwinding dynamic-wind after-thunks, parameter bindings
+ * and pending promises on the way), exactly like the `raise` native (fid 130).
+ * With no handler on the stack this reports an unhandled exception and flags
+ * vm->error. Shared by `raise` and by native builtins (e.g. linear-solve) that
+ * need to signal a catchable condition. */
+static void vm_dispatch_exception(VM* vm, Value exn) {
+    vm->current_exception = exn;
+    if (vm->n_handlers > 0) {
+        vm->n_handlers--;
+        int target_winds = vm->handler_stack[vm->n_handlers].n_winds;
+        while (vm->n_winds > target_winds) {
+            vm->n_winds--;
+            Value after = vm->wind_stack[vm->n_winds].after;
+            vm_run_wind_after(vm, after);
+        }
+        vm_unwind_parameter_bindings(
+            vm, vm->handler_stack[vm->n_handlers].n_parameter_bindings);
+        vm_promise_eval_unwind_to(
+            vm, vm->handler_stack[vm->n_handlers].promise_mark);
+        vm->sp = vm->handler_stack[vm->n_handlers].sp;
+        vm->fp = vm->handler_stack[vm->n_handlers].fp;
+        vm->frame_count = vm->handler_stack[vm->n_handlers].frame_count;
+        vm->pc = vm->handler_stack[vm->n_handlers].pc;
+        vm_escape_native_control(vm);
+    } else {
+        fprintf(stderr, "ERROR: unhandled exception: ");
+        print_value(vm, exn);
+        fprintf(stderr, "\n");
+        vm->error = 1;
+    }
+}
+
 /* R7RS delay-force trampoline.  Both ordinary and delay-force evaluations
  * join the VM-wide intrusive chain so exceptions and continuations can roll
  * them back in O(1) auxiliary memory.  Successful delay-force chains are
@@ -7026,6 +7066,53 @@ static void vm_dispatch_native(VM* vm, int fid) {
         vm_push(vm, t);
         vm_push(vm, INT_VAL(-1));
         vm_dispatch_native(vm, target);
+        break;
+    }
+
+    case 472: { /* linear-solve(A, b) -> x, full-f64 Ax=b (mixed-precision IR) */
+        Value b_val = vm_pop(vm), a_val = vm_pop(vm);
+        VmTensor* A = vm_tensor_operand(vm, a_val, "linear-solve");
+        VmTensor* b = vm_tensor_operand(vm, b_val, "linear-solve");
+        if (!A || !b) { vm_push(vm, NIL_VAL); break; }
+
+        int64_t a_dims[VM_TENSOR_MAX_DIMS], b_dims[VM_TENSOR_MAX_DIMS];
+        for (int i = 0; i < A->n_dims && i < VM_TENSOR_MAX_DIMS; i++) a_dims[i] = A->shape[i];
+        for (int i = 0; i < b->n_dims && i < VM_TENSOR_MAX_DIMS; i++) b_dims[i] = b->shape[i];
+
+        /* Solution length is A's leading dimension; the runtime validates that
+         * A is a square 2-D matrix and that b's length matches before use. */
+        int64_t n = (A->n_dims >= 1 && A->shape[0] > 0) ? A->shape[0] : 0;
+        double* x = (n > 0)
+            ? (double*)vm_alloc(&vm->heap.regions, (size_t)n * sizeof(double))
+            : NULL;
+        if (n > 0 && !x) { vm_push(vm, NIL_VAL); break; }
+
+        int64_t status = eshkol_linear_solve(
+            A->n_dims, a_dims, b->n_dims, b_dims, A->data, b->data, x);
+
+        if (status != 0) {
+            const char* msg =
+                (status == 1) ? "linear-solve: matrix is singular" :
+                (status == 2) ? "linear-solve: A must be a square 2-D matrix" :
+                                "linear-solve: dimension mismatch (b length must equal N)";
+            VmError* e = vm_error_make(&vm->heap.regions, "error", msg, NULL, 0);
+            Value exn = NIL_VAL;
+            if (e) {
+                int32_t ep = heap_alloc(&vm->heap);
+                if (ep >= 0) {
+                    vm->heap.objects[ep]->type = HEAP_ERROR;
+                    vm->heap.objects[ep]->opaque.ptr = e;
+                    exn = (Value){.type = VAL_ERROR_OBJ, .as.ptr = ep};
+                }
+            }
+            vm_dispatch_exception(vm, exn);
+            break;
+        }
+
+        int64_t shape[1] = { n };
+        VmTensor* out = vm_tensor_from_data(&vm->heap.regions, x, shape, 1);
+        if (!out) { vm_push(vm, NIL_VAL); break; }
+        VM_PUSH_TENSOR(vm, out);
         break;
     }
 
@@ -11624,31 +11711,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
 
     case 130: { /* raise: dispatch to handler or error */
         Value exn = vm_pop(vm);
-        vm->current_exception = exn;
-        if (vm->n_handlers > 0) {
-            vm->n_handlers--;
-            /* Unwind dynamic-wind after-thunks */
-            int target_winds = vm->handler_stack[vm->n_handlers].n_winds;
-            while (vm->n_winds > target_winds) {
-                vm->n_winds--;
-                Value after = vm->wind_stack[vm->n_winds].after;
-                vm_run_wind_after(vm, after);
-            }
-            vm_unwind_parameter_bindings(
-                vm, vm->handler_stack[vm->n_handlers].n_parameter_bindings);
-            vm_promise_eval_unwind_to(
-                vm, vm->handler_stack[vm->n_handlers].promise_mark);
-            vm->sp = vm->handler_stack[vm->n_handlers].sp;
-            vm->fp = vm->handler_stack[vm->n_handlers].fp;
-            vm->frame_count = vm->handler_stack[vm->n_handlers].frame_count;
-            vm->pc = vm->handler_stack[vm->n_handlers].pc;
-            vm_escape_native_control(vm);
-        } else {
-            fprintf(stderr, "ERROR: unhandled exception: ");
-            print_value(vm, exn);
-            fprintf(stderr, "\n");
-            vm->error = 1;
-        }
+        vm_dispatch_exception(vm, exn);
         break;
     }
 

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -7073,7 +7073,23 @@ static void vm_dispatch_native(VM* vm, int fid) {
         Value b_val = vm_pop(vm), a_val = vm_pop(vm);
         VmTensor* A = vm_tensor_operand(vm, a_val, "linear-solve");
         VmTensor* b = vm_tensor_operand(vm, b_val, "linear-solve");
-        if (!A || !b) { vm_push(vm, NIL_VAL); break; }
+        if (!A || !b) {
+            vm->error = 0;
+            VmError* e = vm_error_make(
+                &vm->heap.regions, "error",
+                "linear-solve: expected tensor operands for A and b", NULL, 0);
+            Value exn = NIL_VAL;
+            if (e) {
+                int32_t ep = heap_alloc(&vm->heap);
+                if (ep >= 0) {
+                    vm->heap.objects[ep]->type = HEAP_ERROR;
+                    vm->heap.objects[ep]->opaque.ptr = e;
+                    exn = (Value){.type = VAL_ERROR_OBJ, .as.ptr = ep};
+                }
+            }
+            vm_dispatch_exception(vm, exn);
+            break;
+        }
 
         int64_t a_dims[VM_TENSOR_MAX_DIMS], b_dims[VM_TENSOR_MAX_DIMS];
         for (int i = 0; i < A->n_dims && i < VM_TENSOR_MAX_DIMS; i++) a_dims[i] = A->shape[i];

--- a/lib/core/linear_solve.cpp
+++ b/lib/core/linear_solve.cpp
@@ -1,0 +1,293 @@
+/*
+ * Copyright (C) tsotchke
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Dense linear solver Ax = b with a full-f64 accuracy guarantee.
+ *
+ * On Apple (Accelerate) the O(n^3) factorization is done in fp32 and the
+ * solution is polished back to full f64 by mixed-precision iterative
+ * refinement (Langou/Baboulin/Dongarra): the residual r = b - A*x is
+ * recomputed in f64 (an O(n^2) GEMV), a fp32 back-solve corrects x, and the
+ * loop repeats until the relative backward residual is certified below
+ * ACCEPT_TOL. Because the fp32 factorization runs ~2-3x faster than an f64
+ * one on the AMX units while the refinement tail is asymptotically free, a
+ * well-conditioned solve reaches the *same* f64 residual as a plain LAPACK
+ * dgesv at a fraction of the cost.
+ *
+ * The speedup is opportunistic; correctness is not. When refinement cannot
+ * certify a full-f64 result within the iteration cap (an ill-conditioned
+ * system, where kappa * eps_fp32 >~ 1), the solver silently falls back to a
+ * plain-f64 LAPACK dgesv and returns that answer. Either way the caller gets
+ * a genuine full-precision f64 solution.
+ *
+ * Non-Apple builds have no guaranteed fast fp32 LAPACK path, so they use a
+ * self-contained f64 LU with partial pivoting directly: correct everywhere,
+ * with the IR speedup Apple-first for now.
+ *
+ * Called from LLVM-generated native code and from the bytecode VM through the
+ * extern "C" name below. Inputs are raw row-major double buffers (the native
+ * tensor stores f64 bit patterns in an int64 array; the VM stores doubles —
+ * both alias a `const double*` here).
+ */
+
+#include <eshkol/eshkol.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+// eshkol_runtime_fatal is defined in runtime_errors_hosted.cpp; it builds a
+// catchable exception and raises it (or exits if unhandled). No public header
+// declares it, so forward-declare it here for the native raise helper.
+extern "C" void eshkol_runtime_fatal(eshkol_exception_type_t type,
+                                     const char* fmt, ...);
+
+// Status codes returned by eshkol_linear_solve(). 0 = a full-f64 solution was
+// produced (via IR or the dgesv fallback); the rest are catchable errors.
+enum {
+    ESHKOL_LINSOLVE_OK          = 0,
+    ESHKOL_LINSOLVE_SINGULAR    = 1,  // A is singular / no unique solution
+    ESHKOL_LINSOLVE_NOT_SQUARE  = 2,  // A is not a square 2-D matrix
+    ESHKOL_LINSOLVE_DIM_MISMATCH = 3  // b length != N
+};
+
+// Refinement acceptance: certify the IR solution only once its relative
+// backward residual ||b - Ax|| / ||b|| is at or below this. Well-conditioned
+// systems reach ~1e-15; anything that cannot get here falls back to dgesv.
+static const double ESHKOL_LINSOLVE_ACCEPT_TOL = 1e-13;
+static const int    ESHKOL_LINSOLVE_MAX_ITERS  = 30;
+
+#if defined(ESHKOL_BLAS_ACCELERATE)
+
+// Fortran LAPACK symbols exported by Accelerate (column-major, LP64 => the
+// LAPACK integer is a 32-bit int). Declared locally so this translation unit
+// does not depend on the exact shape of Accelerate's (legacy vs new) LAPACK
+// headers; the linker resolves them against the Accelerate framework.
+extern "C" {
+void sgetrf_(const int* m, const int* n, float* a, const int* lda,
+             int* ipiv, int* info);
+void sgetrs_(const char* trans, const int* n, const int* nrhs,
+             const float* a, const int* lda, const int* ipiv,
+             float* b, const int* ldb, int* info);
+void dgesv_(const int* n, const int* nrhs, double* a, const int* lda,
+            int* ipiv, double* b, const int* ldb, int* info);
+
+// CBLAS entry points (enums are int-sized, so plain int is ABI-compatible).
+double cblas_dnrm2(int n, const double* x, int incx);
+void cblas_dgemv(int order, int trans, int m, int n, double alpha,
+                 const double* a, int lda, const double* x, int incx,
+                 double beta, double* y, int incy);
+}
+
+// CBLAS constants (avoid pulling the header for two enum values).
+#define ESHKOL_CBLAS_ROW_MAJOR 101
+#define ESHKOL_CBLAS_NO_TRANS  111
+
+// Plain-f64 fallback: solve A x = b via LAPACK dgesv on a column-major copy.
+// Returns ESHKOL_LINSOLVE_OK or ESHKOL_LINSOLVE_SINGULAR.
+static int64_t linsolve_dgesv_fallback(const double* A, const double* b,
+                                       double* x, int n) {
+    double* Ac = (double*)std::malloc((size_t)n * (size_t)n * sizeof(double));
+    double* xb = (double*)std::malloc((size_t)n * sizeof(double));
+    int*    ip = (int*)std::malloc((size_t)n * sizeof(int));
+    if (!Ac || !xb || !ip) {
+        std::free(Ac); std::free(xb); std::free(ip);
+        return ESHKOL_LINSOLVE_SINGULAR;  // treat OOM as unsolvable here
+    }
+    // Row-major A -> column-major Ac (transpose of the buffer layout).
+    for (int j = 0; j < n; j++)
+        for (int i = 0; i < n; i++)
+            Ac[i + (size_t)j * n] = A[(size_t)i * n + j];
+    std::memcpy(xb, b, (size_t)n * sizeof(double));
+
+    int nn = n, nrhs = 1, info = 0;
+    dgesv_(&nn, &nrhs, Ac, &nn, ip, xb, &nn, &info);
+
+    int64_t status = (info == 0) ? ESHKOL_LINSOLVE_OK : ESHKOL_LINSOLVE_SINGULAR;
+    if (status == ESHKOL_LINSOLVE_OK)
+        std::memcpy(x, xb, (size_t)n * sizeof(double));
+    std::free(Ac); std::free(xb); std::free(ip);
+    return status;
+}
+
+// Mixed-precision iterative refinement, Apple/Accelerate path.
+static int64_t linsolve_ir_accelerate(const double* A, const double* b,
+                                      double* x, int n) {
+    if (n == 0) return ESHKOL_LINSOLVE_OK;
+
+    // Benchmark hook: force the plain-f64 path so the IR speedup can be
+    // measured against the same-machine dgesv baseline in-tree.
+    if (const char* force = std::getenv("ESHKOL_LINSOLVE_FORCE_DGESV")) {
+        if (force[0] && force[0] != '0')
+            return linsolve_dgesv_fallback(A, b, x, n);
+    }
+
+    double bnorm = cblas_dnrm2(n, b, 1);
+    double denom = (bnorm > 0.0) ? bnorm : 1.0;
+
+    float* As = (float*)std::malloc((size_t)n * (size_t)n * sizeof(float));
+    float* xf = (float*)std::malloc((size_t)n * sizeof(float));
+    double* r = (double*)std::malloc((size_t)n * sizeof(double));
+    int*   ip = (int*)std::malloc((size_t)n * sizeof(int));
+    if (!As || !xf || !r || !ip) {
+        std::free(As); std::free(xf); std::free(r); std::free(ip);
+        return linsolve_dgesv_fallback(A, b, x, n);
+    }
+
+    // Row-major f64 A -> column-major fp32 As (so LAPACK factors A, not A^T).
+    for (int j = 0; j < n; j++)
+        for (int i = 0; i < n; i++)
+            As[i + (size_t)j * n] = (float)A[(size_t)i * n + j];
+
+    int nn = n, nrhs = 1, info = 0;
+    sgetrf_(&nn, &nn, As, &nn, ip, &info);
+    if (info != 0) {
+        // fp32 factorization hit a zero pivot; let dgesv decide singularity.
+        std::free(As); std::free(xf); std::free(r); std::free(ip);
+        return linsolve_dgesv_fallback(A, b, x, n);
+    }
+
+    // Initial fp32 solve: x0 = A^{-1} b.
+    for (int i = 0; i < n; i++) xf[i] = (float)b[i];
+    sgetrs_("N", &nn, &nrhs, As, &nn, ip, xf, &nn, &info);
+    for (int i = 0; i < n; i++) x[i] = (double)xf[i];
+
+    double prev = 1e300;
+    for (int it = 0; it < ESHKOL_LINSOLVE_MAX_ITERS; it++) {
+        // r = b - A*x in full f64 (O(n^2)); A is row-major.
+        std::memcpy(r, b, (size_t)n * sizeof(double));
+        cblas_dgemv(ESHKOL_CBLAS_ROW_MAJOR, ESHKOL_CBLAS_NO_TRANS, n, n,
+                    -1.0, A, n, x, 1, 1.0, r, 1);
+        double relres = cblas_dnrm2(n, r, 1) / denom;
+
+        if (relres <= ESHKOL_LINSOLVE_ACCEPT_TOL) {
+            std::free(As); std::free(xf); std::free(r); std::free(ip);
+            return ESHKOL_LINSOLVE_OK;  // certified full-f64 IR solution
+        }
+        // Not improving by at least 10% => stalled/diverging; stop refining
+        // and hand off to the guaranteed f64 path.
+        if (it > 0 && relres > 0.9 * prev) break;
+        prev = relres;
+
+        // fp32 correction d = A^{-1} r; x += d.
+        for (int i = 0; i < n; i++) xf[i] = (float)r[i];
+        sgetrs_("N", &nn, &nrhs, As, &nn, ip, xf, &nn, &info);
+        for (int i = 0; i < n; i++) x[i] += (double)xf[i];
+    }
+
+    std::free(As); std::free(xf); std::free(r); std::free(ip);
+    // IR did not certify full f64 within the cap -> plain-f64 LAPACK solve.
+    return linsolve_dgesv_fallback(A, b, x, n);
+}
+
+#else  // !ESHKOL_BLAS_ACCELERATE
+
+// Self-contained f64 LU with partial pivoting (row-major, in place on a copy).
+// Correct on every platform; used where no fast fp32 LAPACK path is present.
+static int64_t linsolve_lu_f64(const double* A, const double* b,
+                               double* x, int n) {
+    if (n == 0) return ESHKOL_LINSOLVE_OK;
+    double* M = (double*)std::malloc((size_t)n * (size_t)n * sizeof(double));
+    int*    piv = (int*)std::malloc((size_t)n * sizeof(int));
+    if (!M || !piv) { std::free(M); std::free(piv); return ESHKOL_LINSOLVE_SINGULAR; }
+    std::memcpy(M, A, (size_t)n * (size_t)n * sizeof(double));
+    for (int i = 0; i < n; i++) { piv[i] = i; x[i] = b[i]; }
+
+    for (int k = 0; k < n; k++) {
+        double maxv = 0.0; int maxr = k;
+        for (int i = k; i < n; i++) {
+            double v = std::fabs(M[(size_t)i * n + k]);
+            if (v > maxv) { maxv = v; maxr = i; }
+        }
+        if (maxv == 0.0) { std::free(M); std::free(piv); return ESHKOL_LINSOLVE_SINGULAR; }
+        if (maxr != k) {
+            for (int j = 0; j < n; j++) {
+                double t = M[(size_t)k * n + j];
+                M[(size_t)k * n + j] = M[(size_t)maxr * n + j];
+                M[(size_t)maxr * n + j] = t;
+            }
+            double tb = x[k]; x[k] = x[maxr]; x[maxr] = tb;
+        }
+        double pivot = M[(size_t)k * n + k];
+        for (int i = k + 1; i < n; i++) {
+            double f = M[(size_t)i * n + k] / pivot;
+            M[(size_t)i * n + k] = f;
+            for (int j = k + 1; j < n; j++)
+                M[(size_t)i * n + j] -= f * M[(size_t)k * n + j];
+            x[i] -= f * x[k];
+        }
+    }
+    for (int i = n - 1; i >= 0; i--) {
+        double s = x[i];
+        for (int j = i + 1; j < n; j++) s -= M[(size_t)i * n + j] * x[j];
+        x[i] = s / M[(size_t)i * n + i];
+    }
+    std::free(M); std::free(piv);
+    return ESHKOL_LINSOLVE_OK;
+}
+
+#endif  // ESHKOL_BLAS_ACCELERATE
+
+/**
+ * @brief Solve the dense linear system A x = b with a full-f64 guarantee.
+ *
+ * Validates shapes, then solves. On Apple this uses mixed-precision iterative
+ * refinement with a plain-f64 dgesv fallback; elsewhere a direct f64 LU. The
+ * returned solution is always full-precision f64 when the status is OK.
+ *
+ * @param a_ndim Rank of A (must be 2).
+ * @param a_dims Shape of A (row-major); a_dims[0] x a_dims[1].
+ * @param b_ndim Rank of b.
+ * @param b_dims Shape of b (its element product must equal N).
+ * @param A      Row-major N*N f64 coefficient buffer (not modified).
+ * @param b      Length-N f64 right-hand side (not modified).
+ * @param x      Length-N f64 output solution (caller-allocated).
+ * @return       ESHKOL_LINSOLVE_OK, or a nonzero catchable error code.
+ */
+extern "C" int64_t eshkol_linear_solve(
+    int64_t a_ndim, const int64_t* a_dims,
+    int64_t b_ndim, const int64_t* b_dims,
+    const double* A, const double* b, double* x) {
+
+    if (a_ndim != 2 || !a_dims || a_dims[0] != a_dims[1] || a_dims[0] < 0)
+        return ESHKOL_LINSOLVE_NOT_SQUARE;
+    int64_t n = a_dims[0];
+
+    int64_t b_total = 1;
+    if (b_ndim <= 0 || !b_dims) {
+        b_total = 0;
+    } else {
+        for (int64_t d = 0; d < b_ndim; d++) b_total *= b_dims[d];
+    }
+    if (b_total != n) return ESHKOL_LINSOLVE_DIM_MISMATCH;
+
+    if (n == 0) return ESHKOL_LINSOLVE_OK;
+
+#if defined(ESHKOL_BLAS_ACCELERATE)
+    return linsolve_ir_accelerate(A, b, x, (int)n);
+#else
+    return linsolve_lu_f64(A, b, x, (int)n);
+#endif
+}
+
+/**
+ * @brief Raise the catchable exception for a nonzero eshkol_linear_solve()
+ *        status. Called only from LLVM-generated native code (the VM raises
+ *        through its own condition machinery). Never returns.
+ */
+extern "C" void eshkol_linear_solve_raise(int64_t status) {
+    const char* msg;
+    switch (status) {
+        case ESHKOL_LINSOLVE_SINGULAR:
+            msg = "linear-solve: matrix is singular"; break;
+        case ESHKOL_LINSOLVE_NOT_SQUARE:
+            msg = "linear-solve: A must be a square 2-D matrix"; break;
+        case ESHKOL_LINSOLVE_DIM_MISMATCH:
+            msg = "linear-solve: dimension mismatch (b length must equal N)"; break;
+        default:
+            msg = "linear-solve: error"; break;
+    }
+    eshkol_runtime_fatal(ESHKOL_EXCEPTION_ERROR, "%s", msg);
+}

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -497,6 +497,23 @@ probe stdlib_sort_filter_scale_oracle 'stdlib sort (2M) and filter (1M) are tail
     'cd "$REPO_ROOT"; out=$(ESHKOL_PATH="$REPO_ROOT/lib" "$ESHKOL_RUN" -r tests/stdlib/sort_filter_scale_test.esk 2>&1) || exit 1; echo "$out" | grep -qE "Failed:[[:space:]]+0" || exit 1'
 probe ad_forward_over_reverse_oracle 'jacobian/hessian differentiating through an inner forward-mode derivative is exact, not silent-zero (ESH-0120/0121)' \
     'cd "$REPO_ROOT"; out=$(ESHKOL_PATH="$REPO_ROOT/lib" "$ESHKOL_RUN" -r tests/ad/forward_over_reverse_test.esk 2>&1) || exit 1; echo "$out" | grep -qE "Failed:[[:space:]]+0" || exit 1'
+probe linear_solve_full_f64_oracle 'linear-solve: mixed-precision IR dense solver reaches full-f64 residual (<=1e-12, computed in-test) on well-conditioned/identity systems and raises catchably on singular/dimension-mismatch — verified on JIT, AOT, and the VM' \
+    'cd "$REPO_ROOT"; t=tests/features/linear_solve_test.esk;
+     out=$(ESHKOL_PATH="$REPO_ROOT/lib" "$ESHKOL_RUN" -r "$t" 2>/dev/null) || exit 1;
+     [ "$(printf "%s" "$out" | grep -c "PASS:")" -eq 6 ] || exit 1;
+     printf "%s" "$out" | grep -q "FAIL:" && exit 1;
+     bin=$(mktemp) || exit 1;
+     ESHKOL_PATH="$REPO_ROOT/lib" "$ESHKOL_RUN" "$t" -o "$bin" >/dev/null 2>&1 || { rm -f "$bin"; exit 1; };
+     out=$("$bin" 2>/dev/null); rc=$?; rm -f "$bin"; [ "$rc" -eq 0 ] || exit 1;
+     [ "$(printf "%s" "$out" | grep -c "PASS:")" -eq 6 ] || exit 1;
+     printf "%s" "$out" | grep -q "FAIL:" && exit 1;
+     vm="$BUILD_DIR_PATH/eshkol-vm-standalone-test";
+     if [ -x "$vm" ]; then
+       out=$(ESHKOL_VM_NO_DISASM=1 ESHKOL_PATH="$REPO_ROOT/lib" "$vm" "$t" 2>/dev/null) || exit 1;
+       [ "$(printf "%s" "$out" | grep -c "PASS:")" -eq 6 ] || exit 1;
+       printf "%s" "$out" | grep -q "FAIL:" && exit 1;
+     fi;
+     exit 0'
 
 echo
 echo "Trace written: $TRACE_FILE"

--- a/tests/features/linear_solve_test.esk
+++ b/tests/features/linear_solve_test.esk
@@ -1,0 +1,120 @@
+;; linear_solve_test.esk
+;;
+;; Mixed-precision iterative-refinement dense linear solver: (linear-solve A b).
+;;
+;; Verifies the full-f64 accuracy guarantee across the native JIT/AOT backends
+;; and the bytecode VM. Every well-conditioned case computes the relative
+;; backward residual ||A x - b|| / ||b|| *in this test* (never trusting the
+;; solver's own certificate) and requires it below 1e-12. Also checks an
+;; identity solve, a singular system (must raise, caught by guard), and a
+;; dimension mismatch (must raise).
+
+(define pass-count 0)
+(define fail-count 0)
+
+(define (report name ok)
+  (if ok
+      (begin (set! pass-count (+ pass-count 1))
+             (display "PASS: ") (display name) (newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "FAIL: ") (display name) (newline))))
+
+;; Build a 1-D tensor of length n from a list of numbers.
+(define (make-vec lst n)
+  (let ((t (make-tensor (list n) 0.0)))
+    (let loop ((i 0) (l lst))
+      (if (null? l) t
+          (begin (tensor-set! t i (car l)) (loop (+ i 1) (cdr l)))))))
+
+;; Euclidean norm of a length-n 1-D tensor.
+(define (vec-norm v n)
+  (let loop ((i 0) (acc 0.0))
+    (if (= i n) (sqrt acc)
+        (let ((e (tensor-ref v i)))
+          (loop (+ i 1) (+ acc (* e e)))))))
+
+;; ||A x - b|| with A a flat 1-D tensor (row-major n*n), x and b length-n.
+(define (residual-norm aflat x b n)
+  (let loop ((i 0) (acc 0.0))
+    (if (= i n) (sqrt acc)
+        (let inner ((j 0) (s 0.0))
+          (if (= j n)
+              (let ((d (- s (tensor-ref b i))))
+                (loop (+ i 1) (+ acc (* d d))))
+              (inner (+ j 1)
+                     (+ s (* (tensor-ref aflat (+ (* i n) j))
+                             (tensor-ref x j)))))))))
+
+;; Well-conditioned solve: build A/b, solve, verify the residual computed here.
+(define (well-conditioned-case name flat bl n tol)
+  (let* ((aflat (make-vec flat (* n n)))
+         (A (reshape aflat (list n n)))
+         (b (make-vec bl n))
+         (x (linear-solve A b))
+         (rr (/ (residual-norm aflat x b n) (vec-norm b n))))
+    (display "  ") (display name) (display " rel-residual = ") (display rr) (newline)
+    (report name (< rr tol))))
+
+;; --- Well-conditioned solves at several N (residual verified in-test). ---
+
+;; n=3, SPD tridiagonal [1,4,1]; xtrue = [1,2,3] => b = [6,12,14].
+(well-conditioned-case "solve-n3"
+  (list 4.0 1.0 0.0
+        1.0 4.0 1.0
+        0.0 1.0 4.0)
+  (list 6.0 12.0 14.0) 3 1e-12)
+
+;; n=4, diagonally dominant tridiagonal [1,10,1]; xtrue = [1,-1,1,-1].
+(well-conditioned-case "solve-n4"
+  (list 10.0  1.0  0.0  0.0
+         1.0 10.0  1.0  0.0
+         0.0  1.0 10.0  1.0
+         0.0  0.0  1.0 10.0)
+  (list 9.0 -8.0 8.0 -9.0) 4 1e-12)
+
+;; n=8, SPD tridiagonal [1,4,1]; xtrue = all ones => b = [5,6,6,6,6,6,6,5].
+(well-conditioned-case "solve-n8"
+  (list 4.0 1.0 0.0 0.0 0.0 0.0 0.0 0.0
+        1.0 4.0 1.0 0.0 0.0 0.0 0.0 0.0
+        0.0 1.0 4.0 1.0 0.0 0.0 0.0 0.0
+        0.0 0.0 1.0 4.0 1.0 0.0 0.0 0.0
+        0.0 0.0 0.0 1.0 4.0 1.0 0.0 0.0
+        0.0 0.0 0.0 0.0 1.0 4.0 1.0 0.0
+        0.0 0.0 0.0 0.0 0.0 1.0 4.0 1.0
+        0.0 0.0 0.0 0.0 0.0 0.0 1.0 4.0)
+  (list 5.0 6.0 6.0 6.0 6.0 6.0 6.0 5.0) 8 1e-12)
+
+;; --- Identity solve: A = I(3), b = [7,-3,5] => x = b exactly. ---
+(let* ((aflat (make-vec (list 1.0 0.0 0.0
+                              0.0 1.0 0.0
+                              0.0 0.0 1.0) 9))
+       (A (reshape aflat (list 3 3)))
+       (b (make-vec (list 7.0 -3.0 5.0) 3))
+       (x (linear-solve A b))
+       (err (max (abs (- (tensor-ref x 0) 7.0))
+                 (max (abs (- (tensor-ref x 1) -3.0))
+                      (abs (- (tensor-ref x 2) 5.0))))))
+  (display "  identity-exact max|x-b| = ") (display err) (newline)
+  (report "identity-exact" (< err 1e-13)))
+
+;; --- Singular system A = [[1,2],[2,4]] (rank 1) must raise a catchable error. ---
+(let* ((A (reshape (make-vec (list 1.0 2.0 2.0 4.0) 4) (list 2 2)))
+       (b (make-vec (list 1.0 1.0) 2))
+       (result (guard (e (#t 'raised))
+                 (begin (linear-solve A b) 'no-raise))))
+  (report "singular-raises" (eq? result 'raised)))
+
+;; --- Dimension mismatch: A is 3x3, b length 2 must raise. ---
+(let* ((A (reshape (make-vec (list 1.0 0.0 0.0
+                                   0.0 1.0 0.0
+                                   0.0 0.0 1.0) 9) (list 3 3)))
+       (b (make-vec (list 1.0 2.0) 2))
+       (result (guard (e (#t 'raised))
+                 (begin (linear-solve A b) 'no-raise))))
+  (report "dim-mismatch-raises" (eq? result 'raised)))
+
+;; --- Summary ---
+(display "=== linear-solve: ")
+(display pass-count) (display " passed, ")
+(display fail-count) (display " failed ===")
+(newline)

--- a/tests/features/linear_solve_test.esk
+++ b/tests/features/linear_solve_test.esk
@@ -113,6 +113,19 @@
                  (begin (linear-solve A b) 'no-raise))))
   (report "dim-mismatch-raises" (eq? result 'raised)))
 
+;; --- Operand validation regressions ---
+;; Wrong-type operand must raise and be catchable.
+(let* ((result (guard (e (#t 'raised))
+               (begin (linear-solve 1 (make-vec (list 1.0) 1)) 'no-raise))))
+  (report "wrong-type-raises" (eq? result 'raised)))
+
+;; Non-2D A must raise and be catchable.
+(let* ((A (make-vec (list 1.0 2.0 3.0) 3))
+       (b (make-vec (list 1.0 2.0 3.0) 3))
+       (result (guard (e (#t 'raised))
+                 (begin (linear-solve A b) 'no-raise))))
+  (report "non-2d-raises" (eq? result 'raised)))
+
 ;; --- Summary ---
 (display "=== linear-solve: ")
 (display pass-count) (display " passed, ")

--- a/tests/features/linear_solve_test.esk
+++ b/tests/features/linear_solve_test.esk
@@ -127,7 +127,7 @@
   (report "non-2d-raises" (eq? result 'raised)))
 
 ;; --- Summary ---
-(display "=== linear-solve: ")
-(display pass-count) (display " passed, ")
-(display fail-count) (display " failed ===")
+(display (string-append
+  "=== linear-solve: " (number->string pass-count) " passed, "
+  (number->string fail-count) " failed ==="))
 (newline)

--- a/tests/vm_parity/PARITY.tsv
+++ b/tests/vm_parity/PARITY.tsv
@@ -411,6 +411,7 @@ length	vm-supported
 line-reader-close	vm-supported	
 line-reader-poll	vm-supported	
 line-search	gap	ml faculty has no VM fid coverage
+linear-solve	vm-supported
 linear-warmup-lr	gap	ml faculty has no VM fid coverage
 linspace	vm-supported	
 list	vm-supported	


### PR DESCRIPTION
## Summary

Adds `(linear-solve A b)`, a dense `Ax=b` solver with a full-f64 accuracy guarantee and an opportunistic mixed-precision fast path.

- Apple/Accelerate factorizes in fp32 and uses f64 iterative refinement; if it cannot certify the residual, it falls back to f64 `dgesv`.
- Non-Apple builds use direct f64 LU with partial pivoting.
- Singular, dimension-mismatch, wrong-type, and non-2D inputs raise catchable conditions instead of crashing.
- The builtin is wired through native JIT/AOT codegen and the bytecode VM, with docs, parity metadata, an ICC completion oracle, and a smoke probe.

## Verified test evidence

Verified on the exact rebased head against current `master` on an M2 Ultra. JIT, AOT, and VM each exit 0 with:

```
solve-n3 rel-residual = 0
PASS: solve-n3
solve-n4 rel-residual = 0
PASS: solve-n4
solve-n8 rel-residual = 2.24535e-16
PASS: solve-n8
identity-exact max|x-b| = 0
PASS: identity-exact
PASS: singular-raises
PASS: dim-mismatch-raises
PASS: wrong-type-raises
PASS: non-2d-raises
=== linear-solve: 8 passed, 0 failed ===
```

The regression suite computes the relative backward residual independently and requires `<= 1e-12`. The two added invalid-input cases specifically verify that a native integer operand and a non-2D tensor produce catchable errors on JIT, AOT, and VM.

ICC is indexed at the exact PR head, source drift is zero, and the ICC pre-commit gate reports zero blockers.

## Measured Apple speedup

Same-function comparison against `ESHKOL_LINSOLVE_FORCE_DGESV=1`, best of three interleaved runs:

| N | dgesv | iterative refinement | residual | speedup |
|---:|---:|---:|---:|---:|
| 2048 | 0.03393 s | 0.02821 s | 1.47e-15 | 1.20x |
| 4096 | 0.18093 s | 0.13437 s | 2.22e-15 | 1.35x |

Both paths include the row-to-column-major transpose, so the comparison is like-for-like.

## Implementation map

- Runtime core: `lib/core/linear_solve.cpp`
- Native codegen: `inc/eshkol/backend/tensor_codegen.h`, `lib/backend/tensor_linalg_codegen.cpp`, `lib/backend/llvm_codegen.cpp`
- VM: `lib/backend/eshkol_vm.c`, `lib/backend/vm_native.c`
- Regression: `tests/features/linear_solve_test.esk`
- Docs/oracle/smoke: tensor references, `.icc/completion-oracles.yaml`, and `scripts/run_icc_smoke.sh`
