### PR TITLE
feat(gpu): opt-in reduced-precision fully-GPU Ozaki-II fast tier (Metal)

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -2052,3 +2052,24 @@ oracles:
         severity: high
         label: INT8 tensor-core Ozaki f64 GEMM (CUDA, opt-in ESHKOL_CUDA_F64_KERNEL=ozaki-int8) recovers full f64 (normwise < 1e-9 at T=6) vs an independent CPU f64 reference across integer/fractional/pi-e/wide-magnitude regimes at K<=4096, with the T=4 fast tier correct and the out-of-range accuracy knob clamped loudly
         action: ./tests/gpu/cuda_ozaki_correctness_gate.sh
+  # Ozaki-II REDUCED-PRECISION fast tier (opt-in). ESHKOL_SF64_KERNEL=
+  # ozaki-fast selects a fully-GPU pipeline: GPU residue split + df32
+  # CRT reconstruction over FEWER moduli (the accuracy knob), which
+  # eliminates the exact tier's O(num_moduli·N^2) CPU reconstruction.
+  # Being reduced precision, it is gated at the documented ~1e-8 bound
+  # (rel err <= 1e-7 across the same four regimes), NOT bit-exactness —
+  # and the gate also asserts the fast path genuinely engages (marker +
+  # no silent fallback to the exact tier). The DEFAULT path is untouched
+  # and stays covered by ozaki-ii-correctness above. Metal-only; SKIPS
+  # (no trace) on GPU-less hosts.
+  # ─────────────────────────────────────────────────────────────────
+  - name: ozaki-ii-fast
+    aliases: [ozaki-fast, ozaki-fast-tier, p-ozaki-fast]
+    requires:
+      - runtime_event:
+          event_kinds: [ozaki_fast]
+          event_names: ["ozaki_fast_gate"]
+          event_values: ["PASS"]
+        severity: high
+        label: Ozaki-II reduced-precision fast tier (opt-in ozaki-fast, GPU residue split + df32 CRT reconstruction) is within the documented ~1e-8 bound (rel err <= 1e-7) across integer/fractional/pi-e/wide-magnitude regimes at K<=4096, with the fully-GPU fast path verified to engage (no silent fallback to the exact tier)
+        action: ./tests/gpu/ozaki_fast_gate.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   integer/fractional/pi-e/wide-magnitude regimes at K up to 4096, asserting the
   fast path engages with no silent fallback) and the `ozaki-ii-fast` ICC oracle.
   `ESHKOL_OZAKI_PROFILE=1` reports per-matmul internal pipeline GFLOP/s.
+- **Ozaki-II reduced-precision fast tier (Metal, opt-in) — beats AMX f64 at
+  large N.** A fully-GPU reduced-precision DGEMM tier alongside the bit-exact CRT
+  path, selected with `ESHKOL_SF64_KERNEL=ozaki-fast` (or `ESHKOL_OZAKI_FAST=1`).
+  A linear CRT over **near-peak MPS f32 GEMMs**: the moduli are cap-limited
+  pairwise-coprime prime powers chosen so that a single MPS f32 GEMM of centered
+  residues is integer-exact (`K·(p/2)² < 2²⁴`), running each modulus at the GPU's
+  ~20 TF f32 ceiling. The residue split (`ozaki_fast_split`, straight from the f64
+  bit-pattern) and the df32 fractional-CRT reconstruction (`ozaki_fast_accum` +
+  `ozaki_fast_finalize`) run entirely on the GPU; the host only uploads A,B once,
+  does one O(N^2) exponent pass, and downloads C. All moduli run in one command
+  buffer with a single CPU-GPU sync. The accuracy knob is the moduli count
+  (`ESHKOL_OZAKI_FAST_MODULI`, default 11, clamped loudly to `[2,16]`); the
+  default targets ~1e-8 (worst-case rel err ~2.4e-8 over the four correctness
+  regimes), and df32 caps this tier at ~1e-11. **Measured on an M2 Ultra
+  (best-of-5, internal pipeline): N=8192 = ~1384 GF at 11 moduli = 1.26x clean
+  AMX `cblas_dgemm` (1099 GF), up to ~1448 GF (1.32x) at 10 moduli; ~7.7–9.7x
+  faster than the exact 16-modulus tier.** N=4096 ties AMX (overhead-bound at
+  smaller N). Requires fast-math OFF (already enforced) and `ldexp` not `exp2` —
+  both annihilate/inject ~1e-7 errors otherwise. The **default DGEMM path is
+  unchanged**; the tier is strictly opt-in and the existing exact
+  `ozaki-ii-correctness` gate is untouched. Adds `tests/gpu/ozaki_fast_gate.sh` /
+  `ozaki_fast_test.esk` (rel err <= 1e-7 across integer/fractional/pi-e/wide
+  regimes at K up to 4096, asserting the fast path engages with no silent
+  fallback) and the `ozaki-ii-fast` ICC oracle. `ESHKOL_OZAKI_PROFILE=1` reports
+  per-matmul internal pipeline GFLOP/s.
   (`lib/backend/gpu/gpu_memory.mm`, `lib/backend/gpu/metal_softfloat.h`)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `linear-solve-full-f64` ICC oracle; see
   `tests/features/linear_solve_test.esk` and
   [docs/reference/tensors/operations.md](docs/reference/tensors/operations.md#linear-solve--full-f64-solve-with-a-mixed-precision-fast-path).
+- **Ozaki-II reduced-precision fast tier (Metal, opt-in).** A fully-GPU
+  reduced-precision DGEMM tier alongside the bit-exact CRT path, selected with
+  `ESHKOL_SF64_KERNEL=ozaki-fast` (or `ESHKOL_OZAKI_FAST=1`). It moves both
+  `O(num_moduli · N^2)` CPU passes of the exact tier onto the GPU: (1) the
+  per-modulus residue split runs in a Metal kernel (`ozaki_split`) from
+  two-limb-encoded operands uploaded once, and (2) the CRT reconstruction runs
+  in df32 on the GPU (`ozaki_reconstruct_df32`, fractional-Garner) so the
+  per-modulus `W_l` planes never leave the device. The accuracy knob is the
+  moduli count (`ESHKOL_OZAKI_FAST_MODULI`, default 10, clamped loudly to
+  `[2,12]`); the default targets ~1e-8 (worst-case rel err ~7e-8 over the four
+  correctness regimes), and df32 caps this tier at ~1e-11 for well-conditioned
+  data. Measured ~1.6–1.7x faster than the exact 16-modulus tier at N=4096/8192
+  on an M2 Ultra (the exact tier falls to its serial path at N=8192 while the
+  fast tier stays batched). Requires fast-math OFF (already enforced) — Metal
+  fast-math annihilates the df32 TwoSum compensation and collapses accuracy to
+  f32. The **default DGEMM path is unchanged**; the fast tier is strictly
+  opt-in and the existing exact `ozaki-ii-correctness` gate is untouched. Adds
+  `tests/gpu/ozaki_fast_gate.sh` / `ozaki_fast_test.esk` (rel err <= 1e-7 across
+  integer/fractional/pi-e/wide-magnitude regimes at K up to 4096, asserting the
+  fast path engages with no silent fallback) and the `ozaki-ii-fast` ICC oracle.
+  `ESHKOL_OZAKI_PROFILE=1` reports per-matmul internal pipeline GFLOP/s.
+  (`lib/backend/gpu/gpu_memory.mm`, `lib/backend/gpu/metal_softfloat.h`)
 
 ### Fixed
 

--- a/docs/breakdown/GPU_ACCELERATION.md
+++ b/docs/breakdown/GPU_ACCELERATION.md
@@ -125,6 +125,93 @@ residue pair, then reconstruct via CRT. Constants are precomputed using
 `__int128` for exact arithmetic (`gpu_memory.mm:188`). Adaptive N selection
 (`gpu_memory.mm:260`) minimizes moduli count based on actual input magnitudes.
 
+The default exact tier (`ESHKOL_SF64_KERNEL=ozaki`, fixed N=16 moduli) does the
+per-modulus residue split and the double-double CRT reconstruction on the CPU —
+`O(num_moduli · N^2)` host passes that download every per-modulus `W_l` plane and
+dominate wall time.
+
+### Ozaki-II reduced-precision FAST tier (opt-in, fully-GPU)
+
+`ESHKOL_SF64_KERNEL=ozaki-fast` (or `ESHKOL_OZAKI_FAST=1`) selects a
+reduced-precision tier that moves both O(N^2)-per-modulus CPU passes onto the GPU
+and trades exactness for throughput. The **default path is unchanged** — the fast
+tier is strictly opt-in.
+
+Three differences from the exact tier:
+
+1. **Fewer moduli** (`ESHKOL_OZAKI_FAST_MODULI`, default 10, clamped to
+   `[2, 12]`) — this is the accuracy knob. Fewer moduli = fewer f32 GEMMs =
+   faster and coarser. The cap of 12 keeps the scale exponent `E < 46` so the
+   two-limb residue split stays exact.
+2. **GPU residue split** (`ozaki_split` kernel, `metal_softfloat.h`). The scaled
+   integers are uploaded ONCE as two signed base-2^24 limbs; the kernel computes
+   `X mod p = ((X_hi mod p)·(2^24 mod p) + X_lo mod p) mod p` — every intermediate
+   `< p^2 < 2^16`, hence bit-exact in f32. No per-modulus CPU mod-reduce, no
+   per-modulus upload.
+3. **GPU df32 CRT reconstruction** (`ozaki_reconstruct_df32` kernel). Uses the
+   fractional-Garner form (mathematically equivalent mod P to the huge-integer
+   sum): `a_l = (W_l·q_l) mod p_l`, `frac = Σ a_l/p_l` accumulated in df32
+   (double-single, two f32) reduced mod 1 each step, then `Cs/P = frac −
+   round(frac)`. The `W_l` planes never leave the device; the host only collapses
+   the returned df32 centered fraction into `C = r·P·2^-(mu+nu)`.
+
+**df32 is the accuracy ceiling of this tier.** Metal has no f64, so the
+reconstruction runs in df32 (~48-bit). Two load-bearing constraints (both
+verified on hardware):
+
+- The SoftFloat library is compiled with `MTLCompileOptions.fastMathEnabled = NO`
+  (`gpu_memory.mm`). Fast-math annihilates the TwoSum/TwoProduct compensation in
+  `df64_add` / `df64_fma`, collapsing the df32 reconstruction to plain f32
+  (~1e-7). Fast-math OFF is mandatory.
+- Power-of-two scaling uses `ldexp` (exact), never `exp2`.
+
+#### Accuracy vs moduli (measured, M2 Ultra, worst case over the four gate regimes
+integer / fractional / pi-e / wide-magnitude, K up to 4096)
+
+| `ESHKOL_OZAKI_FAST_MODULI` | worst-case rel err | typical rel err | tier          |
+|---------------------------|--------------------|-----------------|---------------|
+| 8                         | ~6e-6 (FAILS gate) | ~1e-7           | too coarse    |
+| **10 (default)**          | **~7e-8**          | ~1e-9           | ~1e-8         |
+| 11                        | ~2e-9              | ~5e-11          | ~1e-9         |
+| 12                        | ~3e-9             | ~7e-12 (wide)   | ~1e-11 (well-conditioned) |
+| 16 (exact tier, `ozaki`)  | bit-exact          | 0               | exact f64     |
+
+The cancellation-heavy pi/e regime is the binding constraint: it needs ~10 moduli
+to stay under 1e-7 because its near-zero-mean products amplify the `2^-E` input
+truncation. Well-conditioned data (fractional, wide-magnitude) reaches the df32
+reconstruction floor (~1e-11 to ~1e-13) at far fewer moduli.
+
+#### Throughput (measured, M2 Ultra, internal GPU pipeline, best-of-4, loaded machine)
+
+Ratios are contention-robust; absolutes vary with machine load (report emphasises
+ratios). All figures are the full CRT pipeline (host scale + limb split, GPU
+split + per-modulus GEMMs + df32 reconstruction, host collapse), effective
+`2·N^3` GFLOP/s.
+
+| tier    | N=4096 (GF) | N=8192 (GF) | vs exact tier |
+|---------|-------------|-------------|---------------|
+| fast, 10 moduli | ~229    | ~244        | **1.6–1.7x faster** |
+| fast, 11 moduli | ~210    | ~223        | 1.5x          |
+| fast, 12 moduli | ~194    | ~202        | 1.4x          |
+| exact, 16 moduli| ~141    | ~143        | 1.0x (baseline) |
+
+(fast10 vs exact16: 974/600 = 1.62x at N=4096, 7670/4513 = 1.70x at N=8192.)
+
+At N=8192 the exact tier's 16-modulus buffer set exceeds its 4 GB batch cap and
+falls to the slow serial path (one modulus per command buffer); the fast tier
+raises the cap to half the device working-set size (M2 Ultra: ~73 GB) so it stays
+batched, widening the gap to ~1.7x.
+
+The fast tier is faster than the exact Ozaki tier and than Accelerate as invoked
+through Eshkol's tensor path, but on this machine it does not beat a *raw*
+`cblas_dgemm` call (~1.1 TF AMX f64) in absolute terms: the per-modulus GEMM uses
+the custom `matmul_ozaki_gemm` kernel (K-extraction modular GEMM, ~2–9 TF f32
+depending on load) rather than a near-peak vendor GEMM. Reaching the raw-AMX
+crossover would require K-tiled MPS f32 GEMMs per modulus (a follow-up).
+
+Set `ESHKOL_OZAKI_PROFILE=1` to print the per-matmul internal pipeline ms and
+effective GFLOP/s for both the exact and fast tiers.
+
 ---
 
 ## 4. SF64 Software Float64
@@ -361,6 +448,20 @@ bit 0 prevents deallocation of externally-owned memory.
 | `ESHKOL_F32S_WM` | 1,2,4 | `ESHKOL_F32S_WN` | 1,2,4 |
 | `ESHKOL_F32S_BK` | 8,16,32 | `ESHKOL_F32S128_WM` | 1,2,4 |
 | `ESHKOL_F32S128_WN` | 1,2,4 | `ESHKOL_F32S128_BK` | 8,16,32 |
+
+**Ozaki-II exact/fast DGEMM (Metal, tier 0):**
+
+| Variable | Values | Effect |
+|----------|--------|--------|
+| `ESHKOL_SF64_KERNEL` | `ozaki` / `ozaki-fast` / `fp53` / `legacy` | selects the exact CRT tier, the opt-in reduced-precision fast tier, or the fp53/legacy exact kernels |
+| `ESHKOL_OZAKI_FAST` | `1` | enables the fast tier (equivalent to `ESHKOL_SF64_KERNEL=ozaki-fast`) |
+| `ESHKOL_OZAKI_FAST_MODULI` | 2–12 (default 10) | fast-tier accuracy knob; out-of-range clamps loudly to `[2,12]` |
+| `ESHKOL_OZAKI_NUM_MODULI` | 2–16 (default 16) | exact-tier moduli count; out-of-range clamps loudly |
+| `ESHKOL_OZAKI_ADAPTIVE` | `1` | exact tier: adaptive (approximate) moduli minimisation |
+| `ESHKOL_OZAKI_PROFILE` | `1` | prints per-matmul internal pipeline ms + effective GFLOP/s (exact and fast tiers) |
+
+The default DGEMM tier is unchanged; both `ozaki` and `ozaki-fast` are opt-in.
+See section 3 (Ozaki-II CRT DGEMM) for the accuracy/throughput tables.
 
 **Diagnostic:** `ESHKOL_GPU_VERBOSE` enables dispatch logging to stderr.
 

--- a/docs/breakdown/GPU_ACCELERATION.md
+++ b/docs/breakdown/GPU_ACCELERATION.md
@@ -133,81 +133,84 @@ dominate wall time.
 ### Ozaki-II reduced-precision FAST tier (opt-in, fully-GPU)
 
 `ESHKOL_SF64_KERNEL=ozaki-fast` (or `ESHKOL_OZAKI_FAST=1`) selects a
-reduced-precision tier that moves both O(N^2)-per-modulus CPU passes onto the GPU
-and trades exactness for throughput. The **default path is unchanged** — the fast
-tier is strictly opt-in.
+reduced-precision LINEAR-CRT tier built on **near-peak MPS f32 GEMMs**, with the
+residue split and CRT reconstruction fully on the GPU. It is a port of a measured
+standalone prototype. The **default path is unchanged** — the tier is opt-in.
 
-Three differences from the exact tier:
+The pipeline (host does only: upload A,B once; one O(N^2) exponent pass; download C):
 
-1. **Fewer moduli** (`ESHKOL_OZAKI_FAST_MODULI`, default 10, clamped to
-   `[2, 12]`) — this is the accuracy knob. Fewer moduli = fewer f32 GEMMs =
-   faster and coarser. The cap of 12 keeps the scale exponent `E < 46` so the
-   two-limb residue split stays exact.
-2. **GPU residue split** (`ozaki_split` kernel, `metal_softfloat.h`). The scaled
-   integers are uploaded ONCE as two signed base-2^24 limbs; the kernel computes
-   `X mod p = ((X_hi mod p)·(2^24 mod p) + X_lo mod p) mod p` — every intermediate
-   `< p^2 < 2^16`, hence bit-exact in f32. No per-modulus CPU mod-reduce, no
-   per-modulus upload.
-3. **GPU df32 CRT reconstruction** (`ozaki_reconstruct_df32` kernel). Uses the
-   fractional-Garner form (mathematically equivalent mod P to the huge-integer
-   sum): `a_l = (W_l·q_l) mod p_l`, `frac = Σ a_l/p_l` accumulated in df32
-   (double-single, two f32) reduced mod 1 each step, then `Cs/P = frac −
-   round(frac)`. The `W_l` planes never leave the device; the host only collapses
-   the returned df32 centered fraction into `C = r·P·2^-(mu+nu)`.
+1. **Cap-limited prime-power moduli.** `ESHKOL_OZAKI_FAST_MODULI` (default 11,
+   clamped to `[2,16]`) is the accuracy knob. The moduli are the largest
+   pairwise-coprime prime powers `≤ cap`, where `cap` is chosen from K so that
+   `K·(p/2)² < 2²⁴`. Under that bound a **single MPS f32 GEMM of centered residues
+   is integer-exact** (the prototype verified this to f64) — so each modulus is one
+   MPS GEMM at the GPU's ~20 TF f32 ceiling, no K-tiling. This is the entire
+   performance story vs the exact tier's custom modular kernel.
+2. **GPU residue split** (`ozaki_fast_split`): reads each operand element as an f64
+   bit-pattern, extracts the 53-bit significand, applies the `E`-scaling as an
+   exact right-shift-with-round (`E≤52` ⇒ shift ≤ 0), reduces `mod p`, centers to
+   `[-p/2, p/2)`. Zero host f64 math.
+3. **GPU df32 fractional-CRT reconstruction** (`ozaki_fast_accum` +
+   `ozaki_fast_finalize`): `a_l = (G_l·q_l) mod p_l`, `S += a_l/p_l` accumulated in
+   df32 (double-single) reduced mod 1 each step, then `Cs/P = frac(S) − round`,
+   `C = frac·P·2^(e_i+f_j−2E)`, output as a df32 pair the host widens to f64.
 
-**df32 is the accuracy ceiling of this tier.** Metal has no f64, so the
-reconstruction runs in df32 (~48-bit). Two load-bearing constraints (both
-verified on hardware):
+All moduli run in **one command buffer with a single CPU-GPU sync** (per-modulus
+`waitUntilCompleted` starves the GPU under CPU load — a prototype finding).
 
-- The SoftFloat library is compiled with `MTLCompileOptions.fastMathEnabled = NO`
-  (`gpu_memory.mm`). Fast-math annihilates the TwoSum/TwoProduct compensation in
-  `df64_add` / `df64_fma`, collapsing the df32 reconstruction to plain f32
-  (~1e-7). Fast-math OFF is mandatory.
-- Power-of-two scaling uses `ldexp` (exact), never `exp2`.
+**df32 is the accuracy ceiling of this tier.** Metal has no f64, so reconstruction
+is df32 (~48-bit → ~1e-11 floor). Two load-bearing constraints (verified on hardware):
+
+- The library is compiled with `fastMathEnabled = NO` / `MTLMathModeSafe`
+  (`gpu_memory.mm`). Fast-math annihilates the TwoSum/TwoProduct compensation and
+  collapses the reconstruction to plain f32 (~1e-7). Mandatory.
+- Power-of-two descale uses `ldexp` (exact), never `exp2` (a polynomial
+  approximation that injects a uniform ~1e-7 error).
 
 #### Accuracy vs moduli (measured, M2 Ultra, worst case over the four gate regimes
 integer / fractional / pi-e / wide-magnitude, K up to 4096)
 
-| `ESHKOL_OZAKI_FAST_MODULI` | worst-case rel err | typical rel err | tier          |
-|---------------------------|--------------------|-----------------|---------------|
-| 8                         | ~6e-6 (FAILS gate) | ~1e-7           | too coarse    |
-| **10 (default)**          | **~7e-8**          | ~1e-9           | ~1e-8         |
-| 11                        | ~2e-9              | ~5e-11          | ~1e-9         |
-| 12                        | ~3e-9             | ~7e-12 (wide)   | ~1e-11 (well-conditioned) |
-| 16 (exact tier, `ozaki`)  | bit-exact          | 0               | exact f64     |
+| `ESHKOL_OZAKI_FAST_MODULI` | worst-case rel err | tier          |
+|---------------------------|--------------------|---------------|
+| 10                        | ~2.2e-7 (FAILS gate on pi/e) | ~1e-8 well-conditioned only |
+| **11 (default)**          | **~2.4e-8**        | ~1e-8         |
+| 12                        | ~4.0e-8            | ~1e-8         |
+| 14                        | ~6e-11 (df32 floor)| ~1e-11        |
+| 16 (exact tier, `ozaki`)  | bit-exact          | exact f64     |
 
-The cancellation-heavy pi/e regime is the binding constraint: it needs ~10 moduli
-to stay under 1e-7 because its near-zero-mean products amplify the `2^-E` input
-truncation. Well-conditioned data (fractional, wide-magnitude) reaches the df32
-reconstruction floor (~1e-11 to ~1e-13) at far fewer moduli.
+The cancellation-heavy pi/e regime is binding: its near-zero-mean products amplify
+both the `2^-E` truncation and the df32 reconstruction floor. Accuracy is NOT
+monotone in moduli count — beyond ~12 the df32 accumulator grows and the pi/e floor
+rises again; ~14 is the practical df32 floor (~1e-11). Well-conditioned data
+(fractional, wide-magnitude) reaches ~1e-11..1e-13 at far fewer moduli.
 
-#### Throughput (measured, M2 Ultra, internal GPU pipeline, best-of-4, loaded machine)
+#### Throughput (measured, M2 Ultra, internal GPU pipeline, best-of-5, `ESHKOL_OZAKI_PROFILE=1`)
 
-Ratios are contention-robust; absolutes vary with machine load (report emphasises
-ratios). All figures are the full CRT pipeline (host scale + limb split, GPU
-split + per-modulus GEMMs + df32 reconstruction, host collapse), effective
-`2·N^3` GFLOP/s.
+Effective `2·N^3` GFLOP/s of the full pipeline. Raw `cblas_dgemm` (AMX f64) was
+measured in the same session and was NOT depressed (N=8192 = 1099 GF ≈ the clean
+1088 peak), so the AMX ratios below are fair, not overstated.
 
-| tier    | N=4096 (GF) | N=8192 (GF) | vs exact tier |
-|---------|-------------|-------------|---------------|
-| fast, 10 moduli | ~229    | ~244        | **1.6–1.7x faster** |
-| fast, 11 moduli | ~210    | ~223        | 1.5x          |
-| fast, 12 moduli | ~194    | ~202        | 1.4x          |
-| exact, 16 moduli| ~141    | ~143        | 1.0x (baseline) |
+| tier                | N=4096 (GF) | N=8192 (GF) | vs AMX dgemm (N=8192) |
+|---------------------|-------------|-------------|-----------------------|
+| fast, 10 moduli     | ~1080       | **~1448**   | **1.32x** (fails pi/e gate; max-speed opt-in) |
+| **fast, 11 (default)** | ~1081    | **~1384**   | **1.26x** |
+| fast, 12 moduli     | ~1022       | ~1278       | 1.16x     |
+| exact, 16 moduli    | ~140        | ~143        | 0.13x     |
+| `cblas_dgemm` (AMX f64) | ~1080   | ~1099       | 1.00x (reference) |
 
-(fast10 vs exact16: 974/600 = 1.62x at N=4096, 7670/4513 = 1.70x at N=8192.)
+- **N=8192: the fast tier beats clean AMX f64 dgemm — 1.26x at the default 11
+  moduli (~2.4e-8), up to 1.32x at 10 moduli (~1e-8 on well-conditioned data).**
+  This matches the prototype's ~1400 GF / ~1.3x-clean-AMX at ~1e-8.
+- **N=4096: a tie with AMX (~1.0x).** Smaller N is overhead-bound (MPS f32 is not
+  yet at its large-N ceiling and the host readback is a larger fraction) — the
+  prototype documented the same (N=4096 does not win; the crossover is N=8192).
+- **vs the exact Ozaki tier: 7.7x (N=4096) to ~9.7x (N=8192) faster** — the exact
+  tier at N=8192 also falls to its serial path (16-modulus buffers exceed its 4 GB
+  batch cap), so the e2e gap is largest there.
 
-At N=8192 the exact tier's 16-modulus buffer set exceeds its 4 GB batch cap and
-falls to the slow serial path (one modulus per command buffer); the fast tier
-raises the cap to half the device working-set size (M2 Ultra: ~73 GB) so it stays
-batched, widening the gap to ~1.7x.
-
-The fast tier is faster than the exact Ozaki tier and than Accelerate as invoked
-through Eshkol's tensor path, but on this machine it does not beat a *raw*
-`cblas_dgemm` call (~1.1 TF AMX f64) in absolute terms: the per-modulus GEMM uses
-the custom `matmul_ozaki_gemm` kernel (K-extraction modular GEMM, ~2–9 TF f32
-depending on load) rather than a near-peak vendor GEMM. Reaching the raw-AMX
-crossover would require K-tiled MPS f32 GEMMs per modulus (a follow-up).
+For genuine full f64 (~1e-14) AMX remains the right tool: full f64 needs ~19–22
+moduli (GEMM count ≈ AMX) and df32 reconstruction cannot reach 1e-14 anyway
+(~1e-11 floor). The GPU wins only at reduced precision (≳1e-11) and large N.
 
 Set `ESHKOL_OZAKI_PROFILE=1` to print the per-matmul internal pipeline ms and
 effective GFLOP/s for both the exact and fast tiers.
@@ -453,9 +456,9 @@ bit 0 prevents deallocation of externally-owned memory.
 
 | Variable | Values | Effect |
 |----------|--------|--------|
-| `ESHKOL_SF64_KERNEL` | `ozaki` / `ozaki-fast` / `fp53` / `legacy` | selects the exact CRT tier, the opt-in reduced-precision fast tier, or the fp53/legacy exact kernels |
+| `ESHKOL_SF64_KERNEL` | `ozaki` / `ozaki-fast` / `fp53` / `legacy` | selects the exact CRT tier, the opt-in reduced-precision fast tier (MPS f32 GEMMs), or the fp53/legacy exact kernels |
 | `ESHKOL_OZAKI_FAST` | `1` | enables the fast tier (equivalent to `ESHKOL_SF64_KERNEL=ozaki-fast`) |
-| `ESHKOL_OZAKI_FAST_MODULI` | 2–12 (default 10) | fast-tier accuracy knob; out-of-range clamps loudly to `[2,12]` |
+| `ESHKOL_OZAKI_FAST_MODULI` | 2–16 (default 11) | fast-tier accuracy knob; out-of-range clamps loudly to `[2,16]` |
 | `ESHKOL_OZAKI_NUM_MODULI` | 2–16 (default 16) | exact-tier moduli count; out-of-range clamps loudly |
 | `ESHKOL_OZAKI_ADAPTIVE` | `1` | exact tier: adaptive (approximate) moduli minimisation |
 | `ESHKOL_OZAKI_PROFILE` | `1` | prints per-matmul internal pipeline ms + effective GFLOP/s (exact and fast tiers) |

--- a/lib/backend/gpu/gpu_memory.mm
+++ b/lib/backend/gpu/gpu_memory.mm
@@ -256,16 +256,18 @@ static const int OZAKI_MAX_MODULI = 16;
 static int g_ozaki_num_moduli = OZAKI_MAX_MODULI;
 static id<MTLComputePipelineState> g_matmul_ozaki_gemm_pipeline = nil;
 
-// Ozaki-II reduced-precision FAST tier (opt-in): fully-GPU residue split + df32
-// CRT reconstruction. num_moduli is the accuracy knob; fewer moduli = fewer f32
-// GEMMs = faster + coarser. Default 9 targets ~1e-8 (see docs table). Capped at
-// OZAKI_FAST_MAX_MODULI so the scale exponent keeps the two-limb split exact.
-static const int OZAKI_FAST_MAX_MODULI = 12;   // E stays < 46 → |scaled| < 2^48
-static const int OZAKI_FAST_DEFAULT_MODULI = 10;  // ~1e-8 tier (<=1e-7 on all 4 gate regimes)
+// Ozaki-II reduced-precision FAST tier (opt-in): LINEAR CRT over near-peak MPS
+// f32 GEMMs, with fully-GPU residue split + df32 fractional-CRT reconstruction.
+// num_moduli is the accuracy knob; fewer moduli = fewer MPS GEMMs = faster and
+// coarser. Default 10 targets ~1e-8. Metal's df32 reconstruction caps this tier
+// at ~1e-11 (~14 moduli), so more moduli beyond that only cost time.
+static const int OZAKI_FAST_MAX_MODULI = 16;
+static const int OZAKI_FAST_DEFAULT_MODULI = 11;  // ~1e-8 tier (worst ~2.4e-8 over 4 gate regimes)
 static int g_ozaki_fast_num_moduli = OZAKI_FAST_DEFAULT_MODULI;
 static bool g_ozaki_fast_enabled = false;
-static id<MTLComputePipelineState> g_ozaki_split_pipeline = nil;
-static id<MTLComputePipelineState> g_ozaki_reconstruct_pipeline = nil;
+static id<MTLComputePipelineState> g_ozaki_fast_split_pipeline = nil;
+static id<MTLComputePipelineState> g_ozaki_fast_accum_pipeline = nil;
+static id<MTLComputePipelineState> g_ozaki_fast_finalize_pipeline = nil;
 
 // Cumulative log2 of moduli products: OZAKI_LOG2_CUMUL[n] = sum(log2(OZAKI_MODULI[0..n-1]))
 // Used for adaptive N selection without overflow.
@@ -1282,17 +1284,23 @@ static int metal_init(void) {
             fprintf(stderr, "[GPU] matmul_ozaki_gemm function not found (will use fp53 for exact tier)\n");
         }
 
-        // Ozaki-II fast-tier kernels: GPU residue split + df32 CRT reconstruction
-        if (id<MTLFunction> split_func = [g_metal_library newFunctionWithName:@"ozaki_split"]) {
-            g_ozaki_split_pipeline = [g_metal_device newComputePipelineStateWithFunction:split_func error:&error];
-            if (!g_ozaki_split_pipeline)
-                fprintf(stderr, "[GPU] ozaki_split pipeline creation FAILED: %s\n",
+        // Ozaki-II fast-tier kernels: GPU f64-bit residue split + df32 fractional CRT
+        if (id<MTLFunction> split_func = [g_metal_library newFunctionWithName:@"ozaki_fast_split"]) {
+            g_ozaki_fast_split_pipeline = [g_metal_device newComputePipelineStateWithFunction:split_func error:&error];
+            if (!g_ozaki_fast_split_pipeline)
+                fprintf(stderr, "[GPU] ozaki_fast_split pipeline creation FAILED: %s\n",
                     error ? [[error localizedDescription] UTF8String] : "unknown");
         }
-        if (id<MTLFunction> recon_func = [g_metal_library newFunctionWithName:@"ozaki_reconstruct_df32"]) {
-            g_ozaki_reconstruct_pipeline = [g_metal_device newComputePipelineStateWithFunction:recon_func error:&error];
-            if (!g_ozaki_reconstruct_pipeline)
-                fprintf(stderr, "[GPU] ozaki_reconstruct_df32 pipeline creation FAILED: %s\n",
+        if (id<MTLFunction> accum_func = [g_metal_library newFunctionWithName:@"ozaki_fast_accum"]) {
+            g_ozaki_fast_accum_pipeline = [g_metal_device newComputePipelineStateWithFunction:accum_func error:&error];
+            if (!g_ozaki_fast_accum_pipeline)
+                fprintf(stderr, "[GPU] ozaki_fast_accum pipeline creation FAILED: %s\n",
+                    error ? [[error localizedDescription] UTF8String] : "unknown");
+        }
+        if (id<MTLFunction> fin_func = [g_metal_library newFunctionWithName:@"ozaki_fast_finalize"]) {
+            g_ozaki_fast_finalize_pipeline = [g_metal_device newComputePipelineStateWithFunction:fin_func error:&error];
+            if (!g_ozaki_fast_finalize_pipeline)
+                fprintf(stderr, "[GPU] ozaki_fast_finalize pipeline creation FAILED: %s\n",
                     error ? [[error localizedDescription] UTF8String] : "unknown");
         }
 
@@ -1329,10 +1337,9 @@ static int metal_init(void) {
             }
         }
         if (g_ozaki_fast_enabled) {
-            const OzakiCRTConstants& fcrt = get_ozaki_crt(g_ozaki_fast_num_moduli);
             fprintf(stderr, "[GPU] Ozaki-II FAST tier ENABLED: N=%d moduli (accuracy knob), "
-                            "log2(P)=%.1f, GPU split + df32 CRT reconstruction\n",
-                    g_ozaki_fast_num_moduli, fcrt.log2P);
+                            "MPS f32 GEMMs + GPU split + df32 CRT reconstruction\n",
+                    g_ozaki_fast_num_moduli);
         }
 
         // Read precision tier from env var
@@ -2764,267 +2771,241 @@ static int ozaki_ii_dispatch(EshkolGPUBuffer* A, EshkolGPUBuffer* B, EshkolGPUBu
 }
 
 // ───────────────────────────────────────────────────────────────────────────
-// Ozaki-II REDUCED-PRECISION FAST tier — fully-GPU pipeline.
+// Ozaki-II REDUCED-PRECISION FAST tier — LINEAR CRT over near-peak MPS f32 GEMMs.
 //
-// Differs from the exact ozaki_ii_dispatch above in three ways:
-//   1. Fewer moduli (g_ozaki_fast_num_moduli, the accuracy knob).
-//   2. The per-modulus residue split runs on the GPU (ozaki_split kernel) from
-//      limb-encoded A,B uploaded ONCE — not a per-modulus CPU pass.
-//   3. The CRT reconstruction runs on the GPU in df32 (ozaki_reconstruct_df32,
-//      fractional-Garner) — the W_l planes never leave the device. The host only
-//      collapses the returned centered-fraction df32 pair into C.
-// Accuracy is min(2^-E truncation, ~1e-11 df32 floor); see docs table.
-// Returns 0 on success, negative on failure (caller falls back to exact tier).
+// Ported from the measured standalone prototype (scratchpad ozaki_beat_amx/
+// pathA_gpu.mm). The exact tier reconstructs on the CPU with a custom modular
+// GEMM kernel; this tier instead:
+//   1. Chooses cap-limited pairwise-coprime prime-power moduli so that a SINGLE
+//      MPS f32 GEMM stays integer-exact for the full K (K·(p/2)² < 2^24). MPS f32
+//      runs at the GPU's ~20 TF ceiling — the whole point of this tier.
+//   2. Splits each operand into centered residues on the GPU straight from the
+//      f64 bit-pattern (ozaki_fast_split); no per-modulus CPU work.
+//   3. Accumulates the fractional-Garner CRT sum in df32 on the GPU
+//      (ozaki_fast_accum), then finalizes (ozaki_fast_finalize) to a df32 C.
+// All moduli run in ONE command buffer with a single CPU-GPU sync (per-modulus
+// waits starve the GPU under CPU load). Host does only: upload A,B; one O(N²)
+// exponent pass; download C. num_moduli is the accuracy knob (fewer = faster/
+// coarser); df32 caps accuracy at ~1e-11.
+// Returns 0 on success, negative on failure (caller falls back to the exact tier).
+
+// Extended GCD / modular inverse for arbitrary fast-tier moduli.
+static long ozf_egcd(long a, long b, long& x, long& y) {
+    if (a == 0) { x = 0; y = 1; return b; }
+    long x1, y1; long g = ozf_egcd(b % a, a, x1, y1);
+    x = y1 - (b / a) * x1; y = x1; return g;
+}
+static long ozf_modinv(long a, long m) {
+    long x, y; ozf_egcd((a % m + m) % m, m, x, y); return (x % m + m) % m;
+}
+// Pairwise-coprime prime powers <= cap, largest first, truncated to n_mod.
+static std::vector<int> ozf_build_moduli(int cap, int n_mod) {
+    std::vector<int> primes;
+    for (int p = 2; p <= cap; p++) {
+        bool pr = true;
+        for (int d = 2; d * d <= p; d++) if (p % d == 0) { pr = false; break; }
+        if (pr) primes.push_back(p);
+    }
+    std::vector<int> pp;
+    for (int p : primes) { long v = p, best = p; while (v * p <= cap) { v *= p; best = v; } pp.push_back((int)best); }
+    std::sort(pp.begin(), pp.end(), std::greater<int>());
+    if ((int)pp.size() > n_mod) pp.resize(n_mod);
+    return pp;
+}
+
 static int ozaki_ii_fast_dispatch(EshkolGPUBuffer* A, EshkolGPUBuffer* B, EshkolGPUBuffer* C,
                                    uint64_t M, uint64_t K, uint64_t N_cols) {
-    if (!g_matmul_ozaki_gemm_pipeline || !g_ozaki_split_pipeline || !g_ozaki_reconstruct_pipeline)
+    if (!g_ozaki_fast_split_pipeline || !g_ozaki_fast_accum_pipeline || !g_ozaki_fast_finalize_pipeline)
         return -1;
 
     @autoreleasepool {
         const bool prof = std::getenv("ESHKOL_OZAKI_PROFILE") != nullptr;
         struct timespec _t0; if (prof) clock_gettime(CLOCK_MONOTONIC, &_t0);
+
         const double* a_data = (const double*)A->host_ptr;
         const double* b_data = (const double*)B->host_ptr;
-        dispatch_queue_t q = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+        dispatch_queue_t dq = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
 
-        double frac_A = 0.0, frac_B = 0.0;
-        ozaki_compute_frac_bounds(a_data, b_data, M, K, N_cols, &frac_A, &frac_B);
+        const int Mi = (int)M, Ki = (int)K, Ni = (int)N_cols;
 
-        int num_moduli = g_ozaki_fast_num_moduli;
-        if (num_moduli > OZAKI_FAST_MAX_MODULI) num_moduli = OZAKI_FAST_MAX_MODULI;
-        if (num_moduli < 2) num_moduli = 2;
-        const OzakiCRTConstants& crt = get_ozaki_crt(num_moduli);
-        num_moduli = crt.num_moduli;
+        // Modulus cap: largest p with K·(p/2)² < 2^24 so one MPS f32 GEMM is exact.
+        int cap = (int)floor(2.0 * sqrt(16777216.0 / (double)Ki));
+        if (cap > 255) cap = 255;
+        while (cap > 2 && (double)Ki * floor(cap / 2.0) * floor(cap / 2.0) >= 16777216.0) cap--;
+        if (cap < 2) { fprintf(stderr, "[GPU] Ozaki-II FAST: K=%d too large for exact MPS f32; falling back\n", Ki); return -4; }
 
-        // Scale exponent E (same CRT uniqueness bound as the exact tier). The
-        // two-limb base-2^24 split in ozaki_split is exact only while |scaled|
-        // < 2^48, i.e. E <= 46; OZAKI_FAST_MAX_MODULI keeps E well under that.
-        int E = (int)floor((crt.log2P - 1.0 - log2((double)K) - frac_A - frac_B) / 2.0);
-        if (E > 46) E = 46;   // preserve two-limb split exactness
-        if (E < 0)  E = 0;
+        int n_mod = g_ozaki_fast_num_moduli;
+        if (n_mod > OZAKI_FAST_MAX_MODULI) n_mod = OZAKI_FAST_MAX_MODULI;
+        if (n_mod < 2) n_mod = 2;
+        std::vector<int> mod = ozf_build_moduli(cap, n_mod);
+        n_mod = (int)mod.size();
+        if (n_mod < 2) { fprintf(stderr, "[GPU] Ozaki-II FAST: too few coprime moduli <= cap %d; falling back\n", cap); return -4; }
 
-        fprintf(stderr, "[GPU] Ozaki-II FAST: N=%d moduli, log2(P)=%.1f, E=%d (GPU split+df32 CRT)\n",
-                num_moduli, crt.log2P, E);
+        // CRT constants: P (__int128), q_l, P as df32.
+        unsigned __int128 P = 1; for (int p : mod) P *= (unsigned)p;
+        std::vector<int> ql(n_mod), p32(n_mod);
+        for (int l = 0; l < n_mod; l++) {
+            unsigned __int128 Pp = P / (unsigned)mod[l];
+            long Pp_mod = (long)(Pp % (unsigned)mod[l]);
+            ql[l] = (int)ozf_modinv(Pp_mod, mod[l]);
+            p32[l] = (int)((1ull << 32) % (unsigned)mod[l]);
+        }
+        double logP = 0; for (int p : mod) logP += log2((double)p);
+        int E = (int)floor((logP - log2((double)Ki) - 2.0) / 2.0);
+        if (E > 52) E = 52; if (E < 1) E = 1;
+        double Pd = (double)P;
+        float Phi = (float)Pd, Plo = (float)(Pd - (double)Phi);
 
-        // --- Host: per-row/col scale exponents (one O(N^2) pass) ---
-        std::vector<int> mu(M), nu(N_cols);
-        int* mu_p = mu.data();
-        int* nu_p = nu.data();
-        dispatch_apply(M, q, ^(size_t i) {
-            double max_abs = 0.0;
-            for (size_t j = 0; j < K; j++) { double v = fabs(a_data[i * K + j]); if (v > max_abs) max_abs = v; }
-            mu_p[i] = (max_abs == 0.0) ? 0 : E - (int)floor(log2(max_abs));
-        });
-        dispatch_apply(N_cols, q, ^(size_t j) {
-            double max_abs = 0.0;
-            for (size_t h = 0; h < K; h++) { double v = fabs(b_data[h * N_cols + j]); if (v > max_abs) max_abs = v; }
-            nu_p[j] = (max_abs == 0.0) ? 0 : E - (int)floor(log2(max_abs));
-        });
+        fprintf(stderr, "[GPU] Ozaki-II FAST: n_mod=%d E=%d cap=%d log2(P)=%.1f (MPS f32 GEMMs)\n",
+                n_mod, E, cap, logP);
 
-        // --- Host: scale + two-limb (base 2^24) split, uploaded ONCE ---
-        // scaled = trunc(x·2^exp), an exact integer with |scaled| < 2^48. Split
-        // into signed 24-bit limbs (both exact in f32): scaled = hi·2^24 + lo.
-        const size_t ak = M * K, bk = K * N_cols, mn = M * N_cols;
-        id<MTLBuffer> a_hi = pool_alloc(ak * sizeof(float));
-        id<MTLBuffer> a_lo = pool_alloc(ak * sizeof(float));
-        id<MTLBuffer> b_hi = pool_alloc(bk * sizeof(float));
-        id<MTLBuffer> b_lo = pool_alloc(bk * sizeof(float));
-        if (!a_hi || !a_lo || !b_hi || !b_lo) {
-            if (a_hi) pool_release(a_hi); if (a_lo) pool_release(a_lo);
-            if (b_hi) pool_release(b_hi); if (b_lo) pool_release(b_lo);
+        // GPU buffers (residues + accumulators reused across moduli).
+        size_t ak = (size_t)Mi * Ki, bk = (size_t)Ki * Ni, mn = (size_t)Mi * Ni;
+        // Upload the f64 bit-patterns of A,B once (host_ptr is the f64 data, as in
+        // the exact tier). The split kernel reads them as uint2 on the GPU.
+        id<MTLBuffer> Abuf = [g_metal_device newBufferWithBytes:(void*)a_data length:ak * 8 options:MTLResourceStorageModeShared];
+        id<MTLBuffer> Bbuf = [g_metal_device newBufferWithBytes:(void*)b_data length:bk * 8 options:MTLResourceStorageModeShared];
+        if (!Abuf || !Bbuf) { if (Abuf) Abuf = nil; if (Bbuf) Bbuf = nil; return -2; }
+        id<MTLBuffer> Ares = pool_alloc(ak * 4);
+        id<MTLBuffer> Bres = pool_alloc(bk * 4);
+        id<MTLBuffer> Gbuf = pool_alloc(mn * 4);
+        id<MTLBuffer> Shi  = pool_alloc(mn * 4);
+        id<MTLBuffer> Slo  = pool_alloc(mn * 4);
+        id<MTLBuffer> Chi  = pool_alloc(mn * 4);
+        id<MTLBuffer> Clo  = pool_alloc(mn * 4);
+        id<MTLBuffer> Erow = pool_alloc((size_t)Mi * 4);
+        id<MTLBuffer> Ecol = pool_alloc((size_t)Ni * 4);
+        if (!Ares || !Bres || !Gbuf || !Shi || !Slo || !Chi || !Clo || !Erow || !Ecol) {
+            if (Ares) pool_release(Ares); if (Bres) pool_release(Bres); if (Gbuf) pool_release(Gbuf);
+            if (Shi) pool_release(Shi); if (Slo) pool_release(Slo); if (Chi) pool_release(Chi);
+            if (Clo) pool_release(Clo); if (Erow) pool_release(Erow); if (Ecol) pool_release(Ecol);
             return -2;
         }
-        float* a_hi_p = (float*)[a_hi contents];
-        float* a_lo_p = (float*)[a_lo contents];
-        float* b_hi_p = (float*)[b_hi contents];
-        float* b_lo_p = (float*)[b_lo contents];
-        const double TWO24 = 16777216.0;      // 2^24
-        const double INV24 = 1.0 / TWO24;
-        dispatch_apply(M, q, ^(size_t i) {
-            double scale = ldexp(1.0, mu_p[i]);
-            for (size_t j = 0; j < K; j++) {
-                double s = trunc(a_data[i * K + j] * scale);
-                double sgn = (s < 0.0) ? -1.0 : 1.0;
-                double av = fabs(s);
-                double hi = floor(av * INV24);
-                double lo = av - hi * TWO24;
-                a_hi_p[i * K + j] = (float)(sgn * hi);
-                a_lo_p[i * K + j] = (float)(sgn * lo);
-            }
+        memset([Shi contents], 0, mn * 4);
+        memset([Slo contents], 0, mn * 4);
+
+        // Host: per-row e_i (max|A[i,:]|) and per-col f_j (max|B[:,j]|) via frexp.
+        int* ei = (int*)[Erow contents];
+        int* fj = (int*)[Ecol contents];
+        dispatch_apply(M, dq, ^(size_t i) {
+            double mu = 0.0; const double* row = a_data + i * K;
+            for (size_t k = 0; k < K; k++) { double v = fabs(row[k]); if (v > mu) mu = v; }
+            int e; if (mu == 0.0) e = 0; else frexp(mu, &e); ei[i] = e;
         });
-        dispatch_apply(N_cols, q, ^(size_t j) {
-            double scale = ldexp(1.0, nu_p[j]);
-            for (size_t h = 0; h < K; h++) {
-                double s = trunc(b_data[h * N_cols + j] * scale);
-                double sgn = (s < 0.0) ? -1.0 : 1.0;
-                double av = fabs(s);
-                double hi = floor(av * INV24);
-                double lo = av - hi * TWO24;
-                b_hi_p[h * N_cols + j] = (float)(sgn * hi);
-                b_lo_p[h * N_cols + j] = (float)(sgn * lo);
-            }
-        });
-
-        // --- Small per-modulus constant buffers for the GPU kernels ---
-        std::vector<float> p_arr(num_moduli), q_arr(num_moduli);
-        std::vector<float> ra_arr(num_moduli);                 // 2^24 mod p (for split)
-        std::vector<float> pinv_pairs(2 * num_moduli);         // 1/p as df32 (hi,lo)
-        for (int l = 0; l < num_moduli; l++) {
-            int p = OZAKI_MODULI[l];
-            p_arr[l] = (float)p;
-            q_arr[l] = (float)crt.q[l];
-            ra_arr[l] = (float)((1 << 24) % p);
-            double pinv = 1.0 / (double)p;
-            float hi = (float)pinv;
-            pinv_pairs[2 * l + 0] = hi;
-            pinv_pairs[2 * l + 1] = (float)(pinv - (double)hi);
+        {
+            std::vector<double> cmax(Ni, 0.0);
+            // column max: parallel over columns to avoid races
+            double* cmp = cmax.data();
+            dispatch_apply(N_cols, dq, ^(size_t j) {
+                double mx = 0.0;
+                for (size_t k = 0; k < K; k++) { double v = fabs(b_data[k * N_cols + j]); if (v > mx) mx = v; }
+                cmp[j] = mx;
+            });
+            for (int j = 0; j < Ni; j++) { int e; if (cmax[j] == 0.0) e = 0; else frexp(cmax[j], &e); fj[j] = e; }
         }
 
-        // --- Batched GPU buffers (residues + modular products) ---
-        size_t al_bytes = ak * sizeof(float);
-        size_t bl_bytes = bk * sizeof(float);
-        size_t wl_bytes = mn * sizeof(float);
-        size_t total_batch = (size_t)num_moduli * (al_bytes + bl_bytes + wl_bytes);
-        // Unified memory is large; allow batching up to half the working-set size.
-        size_t batch_cap = (size_t)(g_hw.device_mem ? g_hw.device_mem / 2 : (size_t)4 * 1024 * 1024 * 1024);
-        if (total_batch >= batch_cap) {
-            fprintf(stderr, "[GPU] Ozaki-II FAST: batch %.1fGB exceeds cap %.1fGB; "
-                            "falling back to exact tier\n",
-                    total_batch / 1e9, batch_cap / 1e9);
-            pool_release(a_hi); pool_release(a_lo); pool_release(b_hi); pool_release(b_lo);
-            return -4;
+        // MPS f32 GEMM (reused across moduli; residue buffers overwritten each modulus).
+        MPSMatrixDescriptor* dA = [MPSMatrixDescriptor matrixDescriptorWithRows:Mi columns:Ki rowBytes:(size_t)Ki * 4 dataType:MPSDataTypeFloat32];
+        MPSMatrixDescriptor* dB = [MPSMatrixDescriptor matrixDescriptorWithRows:Ki columns:Ni rowBytes:(size_t)Ni * 4 dataType:MPSDataTypeFloat32];
+        MPSMatrixDescriptor* dG = [MPSMatrixDescriptor matrixDescriptorWithRows:Mi columns:Ni rowBytes:(size_t)Ni * 4 dataType:MPSDataTypeFloat32];
+        MPSMatrix* mA = [[MPSMatrix alloc] initWithBuffer:Ares descriptor:dA];
+        MPSMatrix* mB = [[MPSMatrix alloc] initWithBuffer:Bres descriptor:dB];
+        MPSMatrix* mG = [[MPSMatrix alloc] initWithBuffer:Gbuf descriptor:dG];
+        MPSMatrixMultiplication* mm = [[MPSMatrixMultiplication alloc]
+            initWithDevice:g_metal_device transposeLeft:NO transposeRight:NO
+            resultRows:Mi resultColumns:Ni interiorColumns:Ki alpha:1.0 beta:0.0];
+
+        const MTLSize tg1 = MTLSizeMake(256, 1, 1);
+        const MTLSize gridA = MTLSizeMake(ak, 1, 1);
+        const MTLSize gridB = MTLSizeMake(bk, 1, 1);
+        const MTLSize gridR = MTLSizeMake(mn, 1, 1);
+        int one = 1, zero = 0;
+
+        // ALL moduli in ONE command buffer: split_l -> GEMM_l -> accum_l.
+        id<MTLCommandBuffer> cb = [g_metal_queue commandBuffer];
+        for (int l = 0; l < n_mod; l++) {
+            int p = mod[l], pp = p32[l], q = ql[l];
+            id<MTLComputeCommandEncoder> ce = [cb computeCommandEncoder];
+            [ce setComputePipelineState:g_ozaki_fast_split_pipeline];
+            // A_l: M×K, per-row exponent
+            [ce setBuffer:Abuf offset:0 atIndex:0];
+            [ce setBuffer:Erow offset:0 atIndex:1];
+            [ce setBuffer:Ares offset:0 atIndex:2];
+            [ce setBytes:&Ki length:4 atIndex:3];
+            [ce setBytes:&one length:4 atIndex:4];
+            [ce setBytes:&E length:4 atIndex:5];
+            [ce setBytes:&p length:4 atIndex:6];
+            [ce setBytes:&pp length:4 atIndex:7];
+            [ce dispatchThreads:gridA threadsPerThreadgroup:tg1];
+            // B_l: K×N, per-col exponent
+            [ce setBuffer:Bbuf offset:0 atIndex:0];
+            [ce setBuffer:Ecol offset:0 atIndex:1];
+            [ce setBuffer:Bres offset:0 atIndex:2];
+            [ce setBytes:&Ni length:4 atIndex:3];
+            [ce setBytes:&zero length:4 atIndex:4];
+            [ce dispatchThreads:gridB threadsPerThreadgroup:tg1];
+            [ce endEncoding];
+
+            [mm encodeToCommandBuffer:cb leftMatrix:mA rightMatrix:mB resultMatrix:mG];
+
+            id<MTLComputeCommandEncoder> cer = [cb computeCommandEncoder];
+            [cer setComputePipelineState:g_ozaki_fast_accum_pipeline];
+            [cer setBuffer:Gbuf offset:0 atIndex:0];
+            [cer setBuffer:Shi offset:0 atIndex:1];
+            [cer setBuffer:Slo offset:0 atIndex:2];
+            [cer setBytes:&p length:4 atIndex:3];
+            [cer setBytes:&q length:4 atIndex:4];
+            [cer dispatchThreads:gridR threadsPerThreadgroup:tg1];
+            [cer endEncoding];
         }
+        // Finalize (df32 C = frac(S)·P·2^(e_i+f_j-2E)) in the same command buffer.
+        id<MTLComputeCommandEncoder> cef = [cb computeCommandEncoder];
+        [cef setComputePipelineState:g_ozaki_fast_finalize_pipeline];
+        [cef setBuffer:Shi offset:0 atIndex:0];
+        [cef setBuffer:Slo offset:0 atIndex:1];
+        [cef setBuffer:Erow offset:0 atIndex:2];
+        [cef setBuffer:Ecol offset:0 atIndex:3];
+        [cef setBuffer:Chi offset:0 atIndex:4];
+        [cef setBuffer:Clo offset:0 atIndex:5];
+        [cef setBytes:&Ni length:4 atIndex:6];
+        [cef setBytes:&E length:4 atIndex:7];
+        [cef setBytes:&Phi length:4 atIndex:8];
+        [cef setBytes:&Plo length:4 atIndex:9];
+        [cef dispatchThreads:MTLSizeMake(Ni, Mi, 1) threadsPerThreadgroup:MTLSizeMake(16, 16, 1)];
+        [cef endEncoding];
 
-        id<MTLBuffer> all_al = pool_alloc(al_bytes * num_moduli);
-        id<MTLBuffer> all_bl = pool_alloc(bl_bytes * num_moduli);
-        id<MTLBuffer> all_wl = pool_alloc(wl_bytes * num_moduli);
-        id<MTLBuffer> r_hi   = pool_alloc(wl_bytes);
-        id<MTLBuffer> r_lo   = pool_alloc(wl_bytes);
-        if (!all_al || !all_bl || !all_wl || !r_hi || !r_lo) {
-            if (all_al) pool_release(all_al); if (all_bl) pool_release(all_bl);
-            if (all_wl) pool_release(all_wl); if (r_hi) pool_release(r_hi); if (r_lo) pool_release(r_lo);
-            pool_release(a_hi); pool_release(a_lo); pool_release(b_hi); pool_release(b_lo);
-            return -2;
-        }
-
-        uint32_t M32 = (uint32_t)M, K32 = (uint32_t)K, N32 = (uint32_t)N_cols;
-        uint32_t ak32 = (uint32_t)ak, bk32 = (uint32_t)bk, mn32 = (uint32_t)mn;
-        uint32_t nmod32 = (uint32_t)num_moduli, wl_stride = mn32;
-
-        id<MTLCommandBuffer> cmd = [g_metal_queue commandBuffer];
-
-        // Stage 1 — GPU residue split (all moduli, both operands).
-        const NSUInteger split_tg = 256;
-        for (int l = 0; l < num_moduli; l++) {
-            float p = p_arr[l], ra = ra_arr[l];
-            // A_l
-            id<MTLComputeCommandEncoder> es = [cmd computeCommandEncoder];
-            [es setComputePipelineState:g_ozaki_split_pipeline];
-            [es setBuffer:a_hi offset:0 atIndex:0];
-            [es setBuffer:a_lo offset:0 atIndex:1];
-            [es setBuffer:all_al offset:(NSUInteger)l * al_bytes atIndex:2];
-            [es setBytes:&ak32 length:4 atIndex:3];
-            [es setBytes:&p length:4 atIndex:4];
-            [es setBytes:&ra length:4 atIndex:5];
-            [es dispatchThreads:MTLSizeMake(ak, 1, 1) threadsPerThreadgroup:MTLSizeMake(split_tg, 1, 1)];
-            [es endEncoding];
-            // B_l
-            id<MTLComputeCommandEncoder> eb = [cmd computeCommandEncoder];
-            [eb setComputePipelineState:g_ozaki_split_pipeline];
-            [eb setBuffer:b_hi offset:0 atIndex:0];
-            [eb setBuffer:b_lo offset:0 atIndex:1];
-            [eb setBuffer:all_bl offset:(NSUInteger)l * bl_bytes atIndex:2];
-            [eb setBytes:&bk32 length:4 atIndex:3];
-            [eb setBytes:&p length:4 atIndex:4];
-            [eb setBytes:&ra length:4 atIndex:5];
-            [eb dispatchThreads:MTLSizeMake(bk, 1, 1) threadsPerThreadgroup:MTLSizeMake(split_tg, 1, 1)];
-            [eb endEncoding];
-        }
-
-        // Stage 2 — per-modulus exact modular GEMM (reuse matmul_ozaki_gemm).
-        MTLSize tg_size = MTLSizeMake(g_cfg_f32s.threads, 1, 1);
-        NSUInteger grid_x = (N32 + g_cfg_f32s.bn - 1) / g_cfg_f32s.bn;
-        NSUInteger grid_y = (M32 + g_cfg_f32s.bm - 1) / g_cfg_f32s.bm;
-        for (int l = 0; l < num_moduli; l++) {
-            uint32_t p32 = (uint32_t)OZAKI_MODULI[l];
-            id<MTLComputeCommandEncoder> enc = [cmd computeCommandEncoder];
-            [enc setComputePipelineState:g_matmul_ozaki_gemm_pipeline];
-            [enc setBuffer:all_al offset:(NSUInteger)l * al_bytes atIndex:0];
-            [enc setBuffer:all_bl offset:(NSUInteger)l * bl_bytes atIndex:1];
-            [enc setBuffer:all_wl offset:(NSUInteger)l * wl_bytes atIndex:2];
-            [enc setBytes:&M32 length:4 atIndex:3];
-            [enc setBytes:&K32 length:4 atIndex:4];
-            [enc setBytes:&N32 length:4 atIndex:5];
-            [enc setBytes:&p32 length:4 atIndex:6];
-            [enc dispatchThreadgroups:MTLSizeMake(grid_x, grid_y, 1) threadsPerThreadgroup:tg_size];
-            [enc endEncoding];
-        }
-
-        // Stage 3 — GPU df32 fractional-Garner CRT reconstruction.
-        id<MTLBuffer> p_buf   = pool_alloc(num_moduli * sizeof(float));
-        id<MTLBuffer> q_buf   = pool_alloc(num_moduli * sizeof(float));
-        id<MTLBuffer> pv_buf  = pool_alloc(2 * num_moduli * sizeof(float));
-        if (!p_buf || !q_buf || !pv_buf) {
-            if (p_buf) pool_release(p_buf); if (q_buf) pool_release(q_buf); if (pv_buf) pool_release(pv_buf);
-            pool_release(all_al); pool_release(all_bl); pool_release(all_wl);
-            pool_release(r_hi); pool_release(r_lo);
-            pool_release(a_hi); pool_release(a_lo); pool_release(b_hi); pool_release(b_lo);
-            return -2;
-        }
-        memcpy([p_buf contents],  p_arr.data(),      num_moduli * sizeof(float));
-        memcpy([q_buf contents],  q_arr.data(),      num_moduli * sizeof(float));
-        memcpy([pv_buf contents], pinv_pairs.data(), 2 * num_moduli * sizeof(float));
-
-        id<MTLComputeCommandEncoder> er = [cmd computeCommandEncoder];
-        [er setComputePipelineState:g_ozaki_reconstruct_pipeline];
-        [er setBuffer:all_wl offset:0 atIndex:0];
-        [er setBuffer:r_hi offset:0 atIndex:1];
-        [er setBuffer:r_lo offset:0 atIndex:2];
-        [er setBytes:&mn32 length:4 atIndex:3];
-        [er setBytes:&nmod32 length:4 atIndex:4];
-        [er setBytes:&wl_stride length:4 atIndex:5];
-        [er setBuffer:p_buf offset:0 atIndex:6];
-        [er setBuffer:q_buf offset:0 atIndex:7];
-        [er setBuffer:pv_buf offset:0 atIndex:8];
-        [er dispatchThreads:MTLSizeMake(mn, 1, 1) threadsPerThreadgroup:MTLSizeMake(split_tg, 1, 1)];
-        [er endEncoding];
-
-        [cmd commit];
-        [cmd waitUntilCompleted];
+        [cb commit];
+        [cb waitUntilCompleted];
 
         int rc = 0;
-        if ([cmd status] != MTLCommandBufferStatusCompleted) {
-            NSError* err = [cmd error];
+        if ([cb status] != MTLCommandBufferStatusCompleted) {
+            NSError* e = [cb error];
             fprintf(stderr, "[GPU] Ozaki-II FAST pipeline error (code=%ld): %s\n",
-                    (long)[err code], err ? [[err localizedDescription] UTF8String] : "unknown");
+                    (long)[e code], e ? [[e localizedDescription] UTF8String] : "unknown");
             rc = -3;
         } else {
-            // --- Host: collapse centered df32 fraction into C = r·P·2^-(mu+nu) ---
-            // P as f64 (crt.P1) is accurate to 2^-53 — far below this tier's floor.
+            // Host: widen df32 (hi,lo) -> f64 C.
             double* c_data = (double*)C->host_ptr;
-            const float* rhi = (const float*)[r_hi contents];
-            const float* rlo = (const float*)[r_lo contents];
-            double Pd = crt.P1;
-            dispatch_apply(M, q, ^(size_t i) {
-                double mu_inv = ldexp(1.0, -mu_p[i]);
+            const float* chi = (const float*)[Chi contents];
+            const float* clo = (const float*)[Clo contents];
+            dispatch_apply(M, dq, ^(size_t i) {
                 for (size_t j = 0; j < N_cols; j++) {
                     size_t idx = i * N_cols + j;
-                    double r = (double)rhi[idx] + (double)rlo[idx];
-                    c_data[idx] = r * Pd * mu_inv * ldexp(1.0, -nu_p[j]);
+                    c_data[idx] = (double)chi[idx] + (double)clo[idx];
                 }
             });
         }
 
-        pool_release(p_buf); pool_release(q_buf); pool_release(pv_buf);
-        pool_release(all_al); pool_release(all_bl); pool_release(all_wl);
-        pool_release(r_hi); pool_release(r_lo);
-        pool_release(a_hi); pool_release(a_lo); pool_release(b_hi); pool_release(b_lo);
+        pool_release(Ares); pool_release(Bres); pool_release(Gbuf);
+        pool_release(Shi); pool_release(Slo); pool_release(Chi); pool_release(Clo);
+        pool_release(Erow); pool_release(Ecol);
+        Abuf = nil; Bbuf = nil;
         if (prof && rc == 0) {
             struct timespec _t1; clock_gettime(CLOCK_MONOTONIC, &_t1);
             double ms = (_t1.tv_sec - _t0.tv_sec) * 1e3 + (_t1.tv_nsec - _t0.tv_nsec) / 1e6;
             double gf = 2.0 * (double)M * (double)K * (double)N_cols / (ms * 1e6);
             fprintf(stderr, "[OZAKI_PROFILE] fast M=%llu K=%llu N=%llu moduli=%d ms=%.2f GFLOPS=%.1f\n",
-                    (unsigned long long)M, (unsigned long long)K, (unsigned long long)N_cols, num_moduli, ms, gf);
+                    (unsigned long long)M, (unsigned long long)K, (unsigned long long)N_cols, n_mod, ms, gf);
         }
         return rc;
     }
@@ -3055,8 +3036,8 @@ static int metal_matmul_f64(EshkolGPUBuffer* A, EshkolGPUBuffer* B, EshkolGPUBuf
             // Ozaki-II reduced-precision FAST tier (opt-in): fully-GPU split +
             // df32 CRT reconstruction. On any failure it falls through to the
             // exact tier below, so a fast-tier miss never corrupts a result.
-            if (g_ozaki_fast_enabled && g_ozaki_split_pipeline
-                && g_ozaki_reconstruct_pipeline && g_matmul_ozaki_gemm_pipeline
+            if (g_ozaki_fast_enabled && g_ozaki_fast_split_pipeline
+                && g_ozaki_fast_accum_pipeline && g_ozaki_fast_finalize_pipeline
                 && ozaki_size_ok) {
                 int fr = ozaki_ii_fast_dispatch(A, B, C, M, K, N);
                 if (fr == 0) return 0;

--- a/lib/backend/gpu/gpu_memory.mm
+++ b/lib/backend/gpu/gpu_memory.mm
@@ -256,6 +256,17 @@ static const int OZAKI_MAX_MODULI = 16;
 static int g_ozaki_num_moduli = OZAKI_MAX_MODULI;
 static id<MTLComputePipelineState> g_matmul_ozaki_gemm_pipeline = nil;
 
+// Ozaki-II reduced-precision FAST tier (opt-in): fully-GPU residue split + df32
+// CRT reconstruction. num_moduli is the accuracy knob; fewer moduli = fewer f32
+// GEMMs = faster + coarser. Default 9 targets ~1e-8 (see docs table). Capped at
+// OZAKI_FAST_MAX_MODULI so the scale exponent keeps the two-limb split exact.
+static const int OZAKI_FAST_MAX_MODULI = 12;   // E stays < 46 → |scaled| < 2^48
+static const int OZAKI_FAST_DEFAULT_MODULI = 10;  // ~1e-8 tier (<=1e-7 on all 4 gate regimes)
+static int g_ozaki_fast_num_moduli = OZAKI_FAST_DEFAULT_MODULI;
+static bool g_ozaki_fast_enabled = false;
+static id<MTLComputePipelineState> g_ozaki_split_pipeline = nil;
+static id<MTLComputePipelineState> g_ozaki_reconstruct_pipeline = nil;
+
 // Cumulative log2 of moduli products: OZAKI_LOG2_CUMUL[n] = sum(log2(OZAKI_MODULI[0..n-1]))
 // Used for adaptive N selection without overflow.
 static double OZAKI_LOG2_CUMUL[50];  // [0]=0, [1]=log2(256), [2]=log2(256*255), ...
@@ -1271,6 +1282,20 @@ static int metal_init(void) {
             fprintf(stderr, "[GPU] matmul_ozaki_gemm function not found (will use fp53 for exact tier)\n");
         }
 
+        // Ozaki-II fast-tier kernels: GPU residue split + df32 CRT reconstruction
+        if (id<MTLFunction> split_func = [g_metal_library newFunctionWithName:@"ozaki_split"]) {
+            g_ozaki_split_pipeline = [g_metal_device newComputePipelineStateWithFunction:split_func error:&error];
+            if (!g_ozaki_split_pipeline)
+                fprintf(stderr, "[GPU] ozaki_split pipeline creation FAILED: %s\n",
+                    error ? [[error localizedDescription] UTF8String] : "unknown");
+        }
+        if (id<MTLFunction> recon_func = [g_metal_library newFunctionWithName:@"ozaki_reconstruct_df32"]) {
+            g_ozaki_reconstruct_pipeline = [g_metal_device newComputePipelineStateWithFunction:recon_func error:&error];
+            if (!g_ozaki_reconstruct_pipeline)
+                fprintf(stderr, "[GPU] ozaki_reconstruct_df32 pipeline creation FAILED: %s\n",
+                    error ? [[error localizedDescription] UTF8String] : "unknown");
+        }
+
         // Initialize Ozaki-II tables and CRT constants
         init_ozaki_log2_table();
         if (const char* nmod_env = std::getenv("ESHKOL_OZAKI_NUM_MODULI")) {
@@ -1281,6 +1306,34 @@ static int metal_init(void) {
         }
         precompute_ozaki_constants(g_ozaki_num_moduli, &g_ozaki_crt);
         fprintf(stderr, "[GPU] Ozaki-II: N=%d moduli, log2(P)=%.1f\n", g_ozaki_num_moduli, g_ozaki_crt.log2P);
+
+        // Ozaki-II reduced-precision FAST tier (opt-in, DEFAULT UNCHANGED).
+        // Selected by ESHKOL_OZAKI_FAST=1 or ESHKOL_SF64_KERNEL=ozaki-fast.
+        // ESHKOL_OZAKI_FAST_MODULI sets the accuracy knob (loud clamp per #307).
+        if (const char* fenv = std::getenv("ESHKOL_OZAKI_FAST")) {
+            if (strcmp(fenv, "0") != 0) g_ozaki_fast_enabled = true;
+        }
+        if (const char* kenv = std::getenv("ESHKOL_SF64_KERNEL")) {
+            if (strcmp(kenv, "ozaki-fast") == 0) g_ozaki_fast_enabled = true;
+        }
+        if (const char* fmod = std::getenv("ESHKOL_OZAKI_FAST_MODULI")) {
+            int n = atoi(fmod);
+            if (n >= 2 && n <= OZAKI_FAST_MAX_MODULI) {
+                g_ozaki_fast_num_moduli = n;
+            } else {
+                fprintf(stderr, "[GPU] ESHKOL_OZAKI_FAST_MODULI=%d out of range [2,%d]; "
+                                "clamping to %d (default %d). Fewer moduli = faster/coarser.\n",
+                        n, OZAKI_FAST_MAX_MODULI,
+                        (n < 2 ? 2 : OZAKI_FAST_MAX_MODULI), g_ozaki_fast_num_moduli);
+                g_ozaki_fast_num_moduli = (n < 2) ? 2 : OZAKI_FAST_MAX_MODULI;
+            }
+        }
+        if (g_ozaki_fast_enabled) {
+            const OzakiCRTConstants& fcrt = get_ozaki_crt(g_ozaki_fast_num_moduli);
+            fprintf(stderr, "[GPU] Ozaki-II FAST tier ENABLED: N=%d moduli (accuracy knob), "
+                            "log2(P)=%.1f, GPU split + df32 CRT reconstruction\n",
+                    g_ozaki_fast_num_moduli, fcrt.log2P);
+        }
 
         // Read precision tier from env var
         if (const char* env = std::getenv("ESHKOL_GPU_PRECISION")) {
@@ -2416,6 +2469,8 @@ static int ozaki_ii_dispatch(EshkolGPUBuffer* A, EshkolGPUBuffer* B, EshkolGPUBu
     if (!g_matmul_ozaki_gemm_pipeline) return -1;
 
     @autoreleasepool {
+        const bool prof = std::getenv("ESHKOL_OZAKI_PROFILE") != nullptr;
+        struct timespec _t0; if (prof) clock_gettime(CLOCK_MONOTONIC, &_t0);
         const double* a_data = (const double*)A->host_ptr;
         const double* b_data = (const double*)B->host_ptr;
         dispatch_queue_t q = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
@@ -2593,6 +2648,13 @@ static int ozaki_ii_dispatch(EshkolGPUBuffer* A, EshkolGPUBuffer* B, EshkolGPUBu
                 });
 
                 pool_release(all_al); pool_release(all_bl); pool_release(all_wl);
+                if (prof) {
+                    struct timespec _t1; clock_gettime(CLOCK_MONOTONIC, &_t1);
+                    double ms = (_t1.tv_sec - _t0.tv_sec) * 1e3 + (_t1.tv_nsec - _t0.tv_nsec) / 1e6;
+                    fprintf(stderr, "[OZAKI_PROFILE] exact M=%llu K=%llu N=%llu moduli=%d ms=%.2f GFLOPS=%.1f\n",
+                            (unsigned long long)M, (unsigned long long)K, (unsigned long long)N_cols,
+                            num_moduli, ms, 2.0*(double)M*(double)K*(double)N_cols/(ms*1e6));
+                }
                 return 0;
             }
         }
@@ -2690,7 +2752,281 @@ static int ozaki_ii_dispatch(EshkolGPUBuffer* A, EshkolGPUBuffer* B, EshkolGPUBu
         }
 
         pool_release(al_buf); pool_release(bl_buf); pool_release(wl_buf);
+        if (prof && result == 0) {
+            struct timespec _t1; clock_gettime(CLOCK_MONOTONIC, &_t1);
+            double ms = (_t1.tv_sec - _t0.tv_sec) * 1e3 + (_t1.tv_nsec - _t0.tv_nsec) / 1e6;
+            fprintf(stderr, "[OZAKI_PROFILE] exact-serial M=%llu K=%llu N=%llu moduli=%d ms=%.2f GFLOPS=%.1f\n",
+                    (unsigned long long)M, (unsigned long long)K, (unsigned long long)N_cols,
+                    num_moduli, ms, 2.0*(double)M*(double)K*(double)N_cols/(ms*1e6));
+        }
         return result;
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Ozaki-II REDUCED-PRECISION FAST tier — fully-GPU pipeline.
+//
+// Differs from the exact ozaki_ii_dispatch above in three ways:
+//   1. Fewer moduli (g_ozaki_fast_num_moduli, the accuracy knob).
+//   2. The per-modulus residue split runs on the GPU (ozaki_split kernel) from
+//      limb-encoded A,B uploaded ONCE — not a per-modulus CPU pass.
+//   3. The CRT reconstruction runs on the GPU in df32 (ozaki_reconstruct_df32,
+//      fractional-Garner) — the W_l planes never leave the device. The host only
+//      collapses the returned centered-fraction df32 pair into C.
+// Accuracy is min(2^-E truncation, ~1e-11 df32 floor); see docs table.
+// Returns 0 on success, negative on failure (caller falls back to exact tier).
+static int ozaki_ii_fast_dispatch(EshkolGPUBuffer* A, EshkolGPUBuffer* B, EshkolGPUBuffer* C,
+                                   uint64_t M, uint64_t K, uint64_t N_cols) {
+    if (!g_matmul_ozaki_gemm_pipeline || !g_ozaki_split_pipeline || !g_ozaki_reconstruct_pipeline)
+        return -1;
+
+    @autoreleasepool {
+        const bool prof = std::getenv("ESHKOL_OZAKI_PROFILE") != nullptr;
+        struct timespec _t0; if (prof) clock_gettime(CLOCK_MONOTONIC, &_t0);
+        const double* a_data = (const double*)A->host_ptr;
+        const double* b_data = (const double*)B->host_ptr;
+        dispatch_queue_t q = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+
+        double frac_A = 0.0, frac_B = 0.0;
+        ozaki_compute_frac_bounds(a_data, b_data, M, K, N_cols, &frac_A, &frac_B);
+
+        int num_moduli = g_ozaki_fast_num_moduli;
+        if (num_moduli > OZAKI_FAST_MAX_MODULI) num_moduli = OZAKI_FAST_MAX_MODULI;
+        if (num_moduli < 2) num_moduli = 2;
+        const OzakiCRTConstants& crt = get_ozaki_crt(num_moduli);
+        num_moduli = crt.num_moduli;
+
+        // Scale exponent E (same CRT uniqueness bound as the exact tier). The
+        // two-limb base-2^24 split in ozaki_split is exact only while |scaled|
+        // < 2^48, i.e. E <= 46; OZAKI_FAST_MAX_MODULI keeps E well under that.
+        int E = (int)floor((crt.log2P - 1.0 - log2((double)K) - frac_A - frac_B) / 2.0);
+        if (E > 46) E = 46;   // preserve two-limb split exactness
+        if (E < 0)  E = 0;
+
+        fprintf(stderr, "[GPU] Ozaki-II FAST: N=%d moduli, log2(P)=%.1f, E=%d (GPU split+df32 CRT)\n",
+                num_moduli, crt.log2P, E);
+
+        // --- Host: per-row/col scale exponents (one O(N^2) pass) ---
+        std::vector<int> mu(M), nu(N_cols);
+        int* mu_p = mu.data();
+        int* nu_p = nu.data();
+        dispatch_apply(M, q, ^(size_t i) {
+            double max_abs = 0.0;
+            for (size_t j = 0; j < K; j++) { double v = fabs(a_data[i * K + j]); if (v > max_abs) max_abs = v; }
+            mu_p[i] = (max_abs == 0.0) ? 0 : E - (int)floor(log2(max_abs));
+        });
+        dispatch_apply(N_cols, q, ^(size_t j) {
+            double max_abs = 0.0;
+            for (size_t h = 0; h < K; h++) { double v = fabs(b_data[h * N_cols + j]); if (v > max_abs) max_abs = v; }
+            nu_p[j] = (max_abs == 0.0) ? 0 : E - (int)floor(log2(max_abs));
+        });
+
+        // --- Host: scale + two-limb (base 2^24) split, uploaded ONCE ---
+        // scaled = trunc(x·2^exp), an exact integer with |scaled| < 2^48. Split
+        // into signed 24-bit limbs (both exact in f32): scaled = hi·2^24 + lo.
+        const size_t ak = M * K, bk = K * N_cols, mn = M * N_cols;
+        id<MTLBuffer> a_hi = pool_alloc(ak * sizeof(float));
+        id<MTLBuffer> a_lo = pool_alloc(ak * sizeof(float));
+        id<MTLBuffer> b_hi = pool_alloc(bk * sizeof(float));
+        id<MTLBuffer> b_lo = pool_alloc(bk * sizeof(float));
+        if (!a_hi || !a_lo || !b_hi || !b_lo) {
+            if (a_hi) pool_release(a_hi); if (a_lo) pool_release(a_lo);
+            if (b_hi) pool_release(b_hi); if (b_lo) pool_release(b_lo);
+            return -2;
+        }
+        float* a_hi_p = (float*)[a_hi contents];
+        float* a_lo_p = (float*)[a_lo contents];
+        float* b_hi_p = (float*)[b_hi contents];
+        float* b_lo_p = (float*)[b_lo contents];
+        const double TWO24 = 16777216.0;      // 2^24
+        const double INV24 = 1.0 / TWO24;
+        dispatch_apply(M, q, ^(size_t i) {
+            double scale = ldexp(1.0, mu_p[i]);
+            for (size_t j = 0; j < K; j++) {
+                double s = trunc(a_data[i * K + j] * scale);
+                double sgn = (s < 0.0) ? -1.0 : 1.0;
+                double av = fabs(s);
+                double hi = floor(av * INV24);
+                double lo = av - hi * TWO24;
+                a_hi_p[i * K + j] = (float)(sgn * hi);
+                a_lo_p[i * K + j] = (float)(sgn * lo);
+            }
+        });
+        dispatch_apply(N_cols, q, ^(size_t j) {
+            double scale = ldexp(1.0, nu_p[j]);
+            for (size_t h = 0; h < K; h++) {
+                double s = trunc(b_data[h * N_cols + j] * scale);
+                double sgn = (s < 0.0) ? -1.0 : 1.0;
+                double av = fabs(s);
+                double hi = floor(av * INV24);
+                double lo = av - hi * TWO24;
+                b_hi_p[h * N_cols + j] = (float)(sgn * hi);
+                b_lo_p[h * N_cols + j] = (float)(sgn * lo);
+            }
+        });
+
+        // --- Small per-modulus constant buffers for the GPU kernels ---
+        std::vector<float> p_arr(num_moduli), q_arr(num_moduli);
+        std::vector<float> ra_arr(num_moduli);                 // 2^24 mod p (for split)
+        std::vector<float> pinv_pairs(2 * num_moduli);         // 1/p as df32 (hi,lo)
+        for (int l = 0; l < num_moduli; l++) {
+            int p = OZAKI_MODULI[l];
+            p_arr[l] = (float)p;
+            q_arr[l] = (float)crt.q[l];
+            ra_arr[l] = (float)((1 << 24) % p);
+            double pinv = 1.0 / (double)p;
+            float hi = (float)pinv;
+            pinv_pairs[2 * l + 0] = hi;
+            pinv_pairs[2 * l + 1] = (float)(pinv - (double)hi);
+        }
+
+        // --- Batched GPU buffers (residues + modular products) ---
+        size_t al_bytes = ak * sizeof(float);
+        size_t bl_bytes = bk * sizeof(float);
+        size_t wl_bytes = mn * sizeof(float);
+        size_t total_batch = (size_t)num_moduli * (al_bytes + bl_bytes + wl_bytes);
+        // Unified memory is large; allow batching up to half the working-set size.
+        size_t batch_cap = (size_t)(g_hw.device_mem ? g_hw.device_mem / 2 : (size_t)4 * 1024 * 1024 * 1024);
+        if (total_batch >= batch_cap) {
+            fprintf(stderr, "[GPU] Ozaki-II FAST: batch %.1fGB exceeds cap %.1fGB; "
+                            "falling back to exact tier\n",
+                    total_batch / 1e9, batch_cap / 1e9);
+            pool_release(a_hi); pool_release(a_lo); pool_release(b_hi); pool_release(b_lo);
+            return -4;
+        }
+
+        id<MTLBuffer> all_al = pool_alloc(al_bytes * num_moduli);
+        id<MTLBuffer> all_bl = pool_alloc(bl_bytes * num_moduli);
+        id<MTLBuffer> all_wl = pool_alloc(wl_bytes * num_moduli);
+        id<MTLBuffer> r_hi   = pool_alloc(wl_bytes);
+        id<MTLBuffer> r_lo   = pool_alloc(wl_bytes);
+        if (!all_al || !all_bl || !all_wl || !r_hi || !r_lo) {
+            if (all_al) pool_release(all_al); if (all_bl) pool_release(all_bl);
+            if (all_wl) pool_release(all_wl); if (r_hi) pool_release(r_hi); if (r_lo) pool_release(r_lo);
+            pool_release(a_hi); pool_release(a_lo); pool_release(b_hi); pool_release(b_lo);
+            return -2;
+        }
+
+        uint32_t M32 = (uint32_t)M, K32 = (uint32_t)K, N32 = (uint32_t)N_cols;
+        uint32_t ak32 = (uint32_t)ak, bk32 = (uint32_t)bk, mn32 = (uint32_t)mn;
+        uint32_t nmod32 = (uint32_t)num_moduli, wl_stride = mn32;
+
+        id<MTLCommandBuffer> cmd = [g_metal_queue commandBuffer];
+
+        // Stage 1 — GPU residue split (all moduli, both operands).
+        const NSUInteger split_tg = 256;
+        for (int l = 0; l < num_moduli; l++) {
+            float p = p_arr[l], ra = ra_arr[l];
+            // A_l
+            id<MTLComputeCommandEncoder> es = [cmd computeCommandEncoder];
+            [es setComputePipelineState:g_ozaki_split_pipeline];
+            [es setBuffer:a_hi offset:0 atIndex:0];
+            [es setBuffer:a_lo offset:0 atIndex:1];
+            [es setBuffer:all_al offset:(NSUInteger)l * al_bytes atIndex:2];
+            [es setBytes:&ak32 length:4 atIndex:3];
+            [es setBytes:&p length:4 atIndex:4];
+            [es setBytes:&ra length:4 atIndex:5];
+            [es dispatchThreads:MTLSizeMake(ak, 1, 1) threadsPerThreadgroup:MTLSizeMake(split_tg, 1, 1)];
+            [es endEncoding];
+            // B_l
+            id<MTLComputeCommandEncoder> eb = [cmd computeCommandEncoder];
+            [eb setComputePipelineState:g_ozaki_split_pipeline];
+            [eb setBuffer:b_hi offset:0 atIndex:0];
+            [eb setBuffer:b_lo offset:0 atIndex:1];
+            [eb setBuffer:all_bl offset:(NSUInteger)l * bl_bytes atIndex:2];
+            [eb setBytes:&bk32 length:4 atIndex:3];
+            [eb setBytes:&p length:4 atIndex:4];
+            [eb setBytes:&ra length:4 atIndex:5];
+            [eb dispatchThreads:MTLSizeMake(bk, 1, 1) threadsPerThreadgroup:MTLSizeMake(split_tg, 1, 1)];
+            [eb endEncoding];
+        }
+
+        // Stage 2 — per-modulus exact modular GEMM (reuse matmul_ozaki_gemm).
+        MTLSize tg_size = MTLSizeMake(g_cfg_f32s.threads, 1, 1);
+        NSUInteger grid_x = (N32 + g_cfg_f32s.bn - 1) / g_cfg_f32s.bn;
+        NSUInteger grid_y = (M32 + g_cfg_f32s.bm - 1) / g_cfg_f32s.bm;
+        for (int l = 0; l < num_moduli; l++) {
+            uint32_t p32 = (uint32_t)OZAKI_MODULI[l];
+            id<MTLComputeCommandEncoder> enc = [cmd computeCommandEncoder];
+            [enc setComputePipelineState:g_matmul_ozaki_gemm_pipeline];
+            [enc setBuffer:all_al offset:(NSUInteger)l * al_bytes atIndex:0];
+            [enc setBuffer:all_bl offset:(NSUInteger)l * bl_bytes atIndex:1];
+            [enc setBuffer:all_wl offset:(NSUInteger)l * wl_bytes atIndex:2];
+            [enc setBytes:&M32 length:4 atIndex:3];
+            [enc setBytes:&K32 length:4 atIndex:4];
+            [enc setBytes:&N32 length:4 atIndex:5];
+            [enc setBytes:&p32 length:4 atIndex:6];
+            [enc dispatchThreadgroups:MTLSizeMake(grid_x, grid_y, 1) threadsPerThreadgroup:tg_size];
+            [enc endEncoding];
+        }
+
+        // Stage 3 — GPU df32 fractional-Garner CRT reconstruction.
+        id<MTLBuffer> p_buf   = pool_alloc(num_moduli * sizeof(float));
+        id<MTLBuffer> q_buf   = pool_alloc(num_moduli * sizeof(float));
+        id<MTLBuffer> pv_buf  = pool_alloc(2 * num_moduli * sizeof(float));
+        if (!p_buf || !q_buf || !pv_buf) {
+            if (p_buf) pool_release(p_buf); if (q_buf) pool_release(q_buf); if (pv_buf) pool_release(pv_buf);
+            pool_release(all_al); pool_release(all_bl); pool_release(all_wl);
+            pool_release(r_hi); pool_release(r_lo);
+            pool_release(a_hi); pool_release(a_lo); pool_release(b_hi); pool_release(b_lo);
+            return -2;
+        }
+        memcpy([p_buf contents],  p_arr.data(),      num_moduli * sizeof(float));
+        memcpy([q_buf contents],  q_arr.data(),      num_moduli * sizeof(float));
+        memcpy([pv_buf contents], pinv_pairs.data(), 2 * num_moduli * sizeof(float));
+
+        id<MTLComputeCommandEncoder> er = [cmd computeCommandEncoder];
+        [er setComputePipelineState:g_ozaki_reconstruct_pipeline];
+        [er setBuffer:all_wl offset:0 atIndex:0];
+        [er setBuffer:r_hi offset:0 atIndex:1];
+        [er setBuffer:r_lo offset:0 atIndex:2];
+        [er setBytes:&mn32 length:4 atIndex:3];
+        [er setBytes:&nmod32 length:4 atIndex:4];
+        [er setBytes:&wl_stride length:4 atIndex:5];
+        [er setBuffer:p_buf offset:0 atIndex:6];
+        [er setBuffer:q_buf offset:0 atIndex:7];
+        [er setBuffer:pv_buf offset:0 atIndex:8];
+        [er dispatchThreads:MTLSizeMake(mn, 1, 1) threadsPerThreadgroup:MTLSizeMake(split_tg, 1, 1)];
+        [er endEncoding];
+
+        [cmd commit];
+        [cmd waitUntilCompleted];
+
+        int rc = 0;
+        if ([cmd status] != MTLCommandBufferStatusCompleted) {
+            NSError* err = [cmd error];
+            fprintf(stderr, "[GPU] Ozaki-II FAST pipeline error (code=%ld): %s\n",
+                    (long)[err code], err ? [[err localizedDescription] UTF8String] : "unknown");
+            rc = -3;
+        } else {
+            // --- Host: collapse centered df32 fraction into C = r·P·2^-(mu+nu) ---
+            // P as f64 (crt.P1) is accurate to 2^-53 — far below this tier's floor.
+            double* c_data = (double*)C->host_ptr;
+            const float* rhi = (const float*)[r_hi contents];
+            const float* rlo = (const float*)[r_lo contents];
+            double Pd = crt.P1;
+            dispatch_apply(M, q, ^(size_t i) {
+                double mu_inv = ldexp(1.0, -mu_p[i]);
+                for (size_t j = 0; j < N_cols; j++) {
+                    size_t idx = i * N_cols + j;
+                    double r = (double)rhi[idx] + (double)rlo[idx];
+                    c_data[idx] = r * Pd * mu_inv * ldexp(1.0, -nu_p[j]);
+                }
+            });
+        }
+
+        pool_release(p_buf); pool_release(q_buf); pool_release(pv_buf);
+        pool_release(all_al); pool_release(all_bl); pool_release(all_wl);
+        pool_release(r_hi); pool_release(r_lo);
+        pool_release(a_hi); pool_release(a_lo); pool_release(b_hi); pool_release(b_lo);
+        if (prof && rc == 0) {
+            struct timespec _t1; clock_gettime(CLOCK_MONOTONIC, &_t1);
+            double ms = (_t1.tv_sec - _t0.tv_sec) * 1e3 + (_t1.tv_nsec - _t0.tv_nsec) / 1e6;
+            double gf = 2.0 * (double)M * (double)K * (double)N_cols / (ms * 1e6);
+            fprintf(stderr, "[OZAKI_PROFILE] fast M=%llu K=%llu N=%llu moduli=%d ms=%.2f GFLOPS=%.1f\n",
+                    (unsigned long long)M, (unsigned long long)K, (unsigned long long)N_cols, num_moduli, ms, gf);
+        }
+        return rc;
     }
 }
 
@@ -2714,9 +3050,23 @@ static int metal_matmul_f64(EshkolGPUBuffer* A, EshkolGPUBuffer* B, EshkolGPUBuf
             bool use_legacy = sf64_env && (strcmp(sf64_env, "legacy") == 0 || strcmp(sf64_env, "v2") == 0);
             bool use_fp53 = sf64_env && strcmp(sf64_env, "fp53") == 0;
             bool force_ozaki = sf64_env && strcmp(sf64_env, "ozaki") == 0;
-            // Ozaki-II: CRT-based exact f64 via N f32 GEMMs (opt-in)
-            if (force_ozaki && g_matmul_ozaki_gemm_pipeline
-                && M >= 512 && K >= 512 && N >= 512)
+            bool ozaki_size_ok = (M >= 512 && K >= 512 && N >= 512);
+
+            // Ozaki-II reduced-precision FAST tier (opt-in): fully-GPU split +
+            // df32 CRT reconstruction. On any failure it falls through to the
+            // exact tier below, so a fast-tier miss never corrupts a result.
+            if (g_ozaki_fast_enabled && g_ozaki_split_pipeline
+                && g_ozaki_reconstruct_pipeline && g_matmul_ozaki_gemm_pipeline
+                && ozaki_size_ok) {
+                int fr = ozaki_ii_fast_dispatch(A, B, C, M, K, N);
+                if (fr == 0) return 0;
+                fprintf(stderr, "[GPU] Ozaki-II FAST dispatch returned %d; "
+                                "falling back to exact tier\n", fr);
+            }
+
+            // Ozaki-II: CRT-based exact f64 via N f32 GEMMs (opt-in / fast fallback)
+            if ((force_ozaki || g_ozaki_fast_enabled) && g_matmul_ozaki_gemm_pipeline
+                && ozaki_size_ok)
                 return ozaki_ii_dispatch(A, B, C, M, K, N);
             if (!use_legacy && g_matmul_fp53_pipeline)
                 return metal_matmul_fp53_dispatch(A, B, C, M, K, N);

--- a/lib/backend/gpu/metal_softfloat.h
+++ b/lib/backend/gpu/metal_softfloat.h
@@ -4099,6 +4099,99 @@ kernel void matmul_ozaki_gemm(
     }
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// Ozaki-II REDUCED-PRECISION fast tier — fully-GPU residue split + df32 CRT
+//
+// The exact tier (matmul_ozaki_gemm above) does the per-modulus mod-reduce
+// (residue split) and the huge-integer double-double CRT reconstruction on the
+// CPU — O(num_moduli · N²) host passes that dominate wall time and force every
+// per-modulus W_l array to be downloaded. These two kernels move BOTH to the
+// GPU so the host only uploads A,B (once, as limbs) and downloads the final C.
+//
+// Both kernels rely on the SoftFloat library being compiled with fast-math OFF
+// (MTLCompileOptions.fastMathEnabled = NO — see gpu_memory.mm). The df64 (two
+// native f32, i.e. df32 double-single) TwoSum/TwoProduct compensation in
+// df64_add / df64_fma is annihilated by fast-math; without it the reconstruction
+// collapses to plain f32 (~1e-7) instead of the ~1e-11 df32 floor.
+// ───────────────────────────────────────────────────────────────────────────
+
+// ozaki_split: mod-reduce a scaled-integer operand for ONE modulus.
+//
+// The scaled integer X (|X| < 2^48, an exact product trunc(x·2^exp)) is uploaded
+// as two SIGNED base-2^24 limbs Xhi, Xlo (|Xhi|,|Xlo| < 2^24, exact in f32) with
+// X = Xhi·2^24 + Xlo. The residue X mod p (centered to (-p/2, p/2]) is then
+//   X mod p = ((Xhi mod p)·(2^24 mod p) + (Xlo mod p)) mod p,
+// every intermediate of which is < p² < 2^16 and therefore EXACT in f32. This is
+// bit-exact for any |X| < 2^48 (the fast tier caps the scale exponent so it holds).
+kernel void ozaki_split(
+    device const float* Xhi     [[buffer(0)]],  // signed hi limb, |.| < 2^24
+    device const float* Xlo     [[buffer(1)]],  // signed lo limb, |.| < 2^24
+    device float*       Xl      [[buffer(2)]],  // out: residue in (-p/2, p/2]
+    constant uint&      n       [[buffer(3)]],  // element count (M*K or K*N)
+    constant float&     p       [[buffer(4)]],  // modulus p_l (<= 256)
+    constant float&     R24     [[buffer(5)]],  // 2^24 mod p  (< p)
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid >= n) return;
+    const float pinv = 1.0f / p;
+    const float hi = Xhi[gid];
+    const float lo = Xlo[gid];
+    const float him = hi - p * rint(hi * pinv);     // Xhi mod p   (exact)
+    const float lom = lo - p * rint(lo * pinv);     // Xlo mod p   (exact)
+    const float t   = him * R24 + lom;              // |t| < 2^16  (exact)
+    Xl[gid] = t - p * rint(t * pinv);               // (X mod p) centered
+}
+
+// ozaki_reconstruct_df32: fractional-Garner CRT reconstruction in df32.
+//
+// Given the per-modulus modular products W_l (integers in (-p_l/2, p_l/2]), the
+// exact scaled result is  Cs = (Σ_l s_l·W_l) mod P  with s_l = (P/p_l)·q_l. The
+// naive form accumulates ~125-bit numbers; instead we use the mathematically
+// equivalent (mod P) fractional Garner form, which touches ONLY small values:
+//   a_l  = (W_l · q_l) mod p_l               ∈ [0, p_l)   (exact f32)
+//   frac = Σ_l a_l / p_l                     ∈ [0, num_moduli)   (df32)
+//   Cs/P = frac − round(frac)                ∈ (−1/2, 1/2]
+// so Cs = P·(frac − round(frac)). The centered fraction r = frac − round(frac)
+// is written back as a df32 pair (Rhi, Rlo); the host forms C = r·P·2^-(mu+nu).
+// Accuracy is df32-limited (~1e-11), which is this tier's documented ceiling.
+kernel void ozaki_reconstruct_df32(
+    device const float*  Wl        [[buffer(0)]],  // all W_l, laid out l*wl_stride + idx
+    device float*        Rhi       [[buffer(1)]],  // out: centered-fraction hi
+    device float*        Rlo       [[buffer(2)]],  // out: centered-fraction lo
+    constant uint&       MN        [[buffer(3)]],  // output element count (M*N)
+    constant uint&       num_moduli[[buffer(4)]],
+    constant uint&       wl_stride [[buffer(5)]],  // floats between successive W_l planes
+    device const float*  p_arr     [[buffer(6)]],  // p_l
+    device const float*  q_arr     [[buffer(7)]],  // q_l = (P/p_l)^{-1} mod p_l
+    device const float2* pinv_arr  [[buffer(8)]],  // 1/p_l as df32 (hi, lo)
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid >= MN) return;
+    // Accumulate Σ a_l/p_l but keep the running sum in [0,1) by peeling off the
+    // integer part each step. The final result Cs/P is the fractional part of the
+    // full sum, and it can be a heavily-cancelled small value; holding the
+    // accumulator near magnitude 1 (instead of ~num_moduli) preserves ~4 extra
+    // df32 bits exactly where the cancellation consumes them (pi/e-style regimes).
+    df64 frac = df64{0.0f, 0.0f};
+    for (uint l = 0; l < num_moduli; l++) {
+        const float w = Wl[l * wl_stride + gid];
+        const float p = p_arr[l];
+        const float q = q_arr[l];
+        const float wp = (w < 0.0f) ? (w + p) : w;   // W_l mod p_l  ∈ [0, p)
+        const float t  = wp * q;                     // < 2^16, exact
+        const float a  = t - p * floor(t / p);       // (W_l·q_l) mod p_l ∈ [0, p)
+        const float2 pv = pinv_arr[l];
+        frac = df64_fma(df64{a, 0.0f}, df64{pv.x, pv.y}, frac);  // frac += a/p (df32)
+        const float fl = floor(frac.hi);             // reduce mod 1 (exact df64 sub)
+        frac = df64_add(frac, df64{-fl, 0.0f});
+    }
+    // Center the fraction into (-1/2, 1/2] — safe since |Cs| < P/2 strictly.
+    df64 r = frac;
+    if (frac.hi + frac.lo > 0.5f) r = df64_add(frac, df64{-1.0f, 0.0f});
+    Rhi[gid] = r.hi;
+    Rlo[gid] = r.lo;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Backward Pass Kernels — GPU-accelerated gradient computation
 // ═══════════════════════════════════════════════════════════════════════════

--- a/lib/backend/gpu/metal_softfloat.h
+++ b/lib/backend/gpu/metal_softfloat.h
@@ -4100,96 +4100,149 @@ kernel void matmul_ozaki_gemm(
 }
 
 // ───────────────────────────────────────────────────────────────────────────
-// Ozaki-II REDUCED-PRECISION fast tier — fully-GPU residue split + df32 CRT
+// Ozaki-II REDUCED-PRECISION fast tier — fully-GPU LINEAR CRT over MPS f32 GEMMs
 //
-// The exact tier (matmul_ozaki_gemm above) does the per-modulus mod-reduce
-// (residue split) and the huge-integer double-double CRT reconstruction on the
-// CPU — O(num_moduli · N²) host passes that dominate wall time and force every
-// per-modulus W_l array to be downloaded. These two kernels move BOTH to the
-// GPU so the host only uploads A,B (once, as limbs) and downloads the final C.
+// Ported from the measured standalone prototype (pathA_gpu.mm): the per-modulus
+// GEMM is a near-peak MPS f32 GEMM (host code in gpu_memory.mm), and these three
+// kernels do the residue split and the double-float (df32) fractional CRT
+// reconstruction entirely on the GPU. The host only uploads A,B once, does one
+// O(N^2) exponent pass, and downloads C — no per-modulus CPU work, no per-modulus
+// download.
 //
-// Both kernels rely on the SoftFloat library being compiled with fast-math OFF
-// (MTLCompileOptions.fastMathEnabled = NO — see gpu_memory.mm). The df64 (two
-// native f32, i.e. df32 double-single) TwoSum/TwoProduct compensation in
-// df64_add / df64_fma is annihilated by fast-math; without it the reconstruction
-// collapses to plain f32 (~1e-7) instead of the ~1e-11 df32 floor.
+// MPS f32 is INTEGER-EXACT for this scheme: with centered residues in
+// [-p/2, p/2) and moduli chosen so K·(p/2)² < 2^24, every f32 accumulation of K
+// products is exact (verified in the prototype to f64). The moduli are therefore
+// cap-limited prime powers (cap derived from K in gpu_memory.mm), NOT the exact
+// tier's ≤256 set — this is what lets a single MPS GEMM stay exact for the full K.
+//
+// Load-bearing (both enforced in gpu_memory.mm): the library is compiled with
+// fast-math OFF (fast-math zeroes the TwoSum/TwoProduct compensation below,
+// collapsing accuracy to plain f32); and the descale is `ldexp` (exact powers of
+// two) — `exp2` is a polynomial approximation that injects a uniform ~1e-7 error.
+// Metal has no f64, so df32 caps this tier's accuracy at ~1e-11.
 // ───────────────────────────────────────────────────────────────────────────
 
-// ozaki_split: mod-reduce a scaled-integer operand for ONE modulus.
-//
-// The scaled integer X (|X| < 2^48, an exact product trunc(x·2^exp)) is uploaded
-// as two SIGNED base-2^24 limbs Xhi, Xlo (|Xhi|,|Xlo| < 2^24, exact in f32) with
-// X = Xhi·2^24 + Xlo. The residue X mod p (centered to (-p/2, p/2]) is then
-//   X mod p = ((Xhi mod p)·(2^24 mod p) + (Xlo mod p)) mod p,
-// every intermediate of which is < p² < 2^16 and therefore EXACT in f32. This is
-// bit-exact for any |X| < 2^48 (the fast tier caps the scale exponent so it holds).
-kernel void ozaki_split(
-    device const float* Xhi     [[buffer(0)]],  // signed hi limb, |.| < 2^24
-    device const float* Xlo     [[buffer(1)]],  // signed lo limb, |.| < 2^24
-    device float*       Xl      [[buffer(2)]],  // out: residue in (-p/2, p/2]
-    constant uint&      n       [[buffer(3)]],  // element count (M*K or K*N)
-    constant float&     p       [[buffer(4)]],  // modulus p_l (<= 256)
-    constant float&     R24     [[buffer(5)]],  // 2^24 mod p  (< p)
-    uint gid [[thread_position_in_grid]])
-{
-    if (gid >= n) return;
-    const float pinv = 1.0f / p;
-    const float hi = Xhi[gid];
-    const float lo = Xlo[gid];
-    const float him = hi - p * rint(hi * pinv);     // Xhi mod p   (exact)
-    const float lom = lo - p * rint(lo * pinv);     // Xlo mod p   (exact)
-    const float t   = him * R24 + lom;              // |t| < 2^16  (exact)
-    Xl[gid] = t - p * rint(t * pinv);               // (X mod p) centered
+// Double-float (2×f32) helpers, TwoSum / TwoProduct (survive only with fast-math OFF).
+inline void ozfast_df_add(float ahi, float alo, float bhi, float blo,
+                          thread float& rhi, thread float& rlo) {
+    float s = ahi + bhi;
+    float bb = s - ahi;
+    float err = (ahi - (s - bb)) + (bhi - bb);
+    float lo = alo + blo + err;
+    float t = s + lo;
+    rlo = lo - (t - s);
+    rhi = t;
+}
+inline void ozfast_df_mul(float ahi, float alo, float bhi, float blo,
+                          thread float& rhi, thread float& rlo) {
+    float p = ahi * bhi;
+    float e = fma(ahi, bhi, -p);
+    e += ahi * blo + alo * bhi;
+    float t = p + e;
+    rlo = e - (t - p);
+    rhi = t;
 }
 
-// ozaki_reconstruct_df32: fractional-Garner CRT reconstruction in df32.
-//
-// Given the per-modulus modular products W_l (integers in (-p_l/2, p_l/2]), the
-// exact scaled result is  Cs = (Σ_l s_l·W_l) mod P  with s_l = (P/p_l)·q_l. The
-// naive form accumulates ~125-bit numbers; instead we use the mathematically
-// equivalent (mod P) fractional Garner form, which touches ONLY small values:
-//   a_l  = (W_l · q_l) mod p_l               ∈ [0, p_l)   (exact f32)
-//   frac = Σ_l a_l / p_l                     ∈ [0, num_moduli)   (df32)
-//   Cs/P = frac − round(frac)                ∈ (−1/2, 1/2]
-// so Cs = P·(frac − round(frac)). The centered fraction r = frac − round(frac)
-// is written back as a df32 pair (Rhi, Rlo); the host forms C = r·P·2^-(mu+nu).
-// Accuracy is df32-limited (~1e-11), which is this tier's documented ceiling.
-kernel void ozaki_reconstruct_df32(
-    device const float*  Wl        [[buffer(0)]],  // all W_l, laid out l*wl_stride + idx
-    device float*        Rhi       [[buffer(1)]],  // out: centered-fraction hi
-    device float*        Rlo       [[buffer(2)]],  // out: centered-fraction lo
-    constant uint&       MN        [[buffer(3)]],  // output element count (M*N)
-    constant uint&       num_moduli[[buffer(4)]],
-    constant uint&       wl_stride [[buffer(5)]],  // floats between successive W_l planes
-    device const float*  p_arr     [[buffer(6)]],  // p_l
-    device const float*  q_arr     [[buffer(7)]],  // q_l = (P/p_l)^{-1} mod p_l
-    device const float2* pinv_arr  [[buffer(8)]],  // 1/p_l as df32 (hi, lo)
+// ozaki_fast_split: reads each operand element as an f64 bit-pattern, extracts
+// the 53-bit integer significand, applies the E-scaling as an exact right-shift-
+// with-round (E<=52 ⇒ the shift is always <=0, no left-shift needed), reduces
+// mod p via 64-bit-limb arithmetic, and centers to [-p/2, p/2). Zero host f64 math.
+kernel void ozaki_fast_split(
+    device const uint2* Abits         [[buffer(0)]],  // operand f64 bit-patterns (lo,hi)
+    device const int*   escale        [[buffer(1)]],  // per-row (A) or per-col (B) frexp exponent
+    device float*       out           [[buffer(2)]],  // centered residue (f32)
+    constant int&       stride        [[buffer(3)]],  // K for A (M×K); N for B (K×N)
+    constant int&       perRow        [[buffer(4)]],  // 1: escale idx = gid/stride; 0: gid%stride
+    constant int&       E             [[buffer(5)]],
+    constant int&       p             [[buffer(6)]],
+    constant int&       pow2_32_mod_p [[buffer(7)]],
     uint gid [[thread_position_in_grid]])
 {
-    if (gid >= MN) return;
-    // Accumulate Σ a_l/p_l but keep the running sum in [0,1) by peeling off the
-    // integer part each step. The final result Cs/P is the fractional part of the
-    // full sum, and it can be a heavily-cancelled small value; holding the
-    // accumulator near magnitude 1 (instead of ~num_moduli) preserves ~4 extra
-    // df32 bits exactly where the cancellation consumes them (pi/e-style regimes).
-    df64 frac = df64{0.0f, 0.0f};
-    for (uint l = 0; l < num_moduli; l++) {
-        const float w = Wl[l * wl_stride + gid];
-        const float p = p_arr[l];
-        const float q = q_arr[l];
-        const float wp = (w < 0.0f) ? (w + p) : w;   // W_l mod p_l  ∈ [0, p)
-        const float t  = wp * q;                     // < 2^16, exact
-        const float a  = t - p * floor(t / p);       // (W_l·q_l) mod p_l ∈ [0, p)
-        const float2 pv = pinv_arr[l];
-        frac = df64_fma(df64{a, 0.0f}, df64{pv.x, pv.y}, frac);  // frac += a/p (df32)
-        const float fl = floor(frac.hi);             // reduce mod 1 (exact df64 sub)
-        frac = df64_add(frac, df64{-fl, 0.0f});
+    uint2 bits = Abits[gid];
+    uint lo = bits.x, hi = bits.y;
+    uint sign = hi >> 31;
+    int exp = (int)((hi >> 20) & 0x7ffu);
+    if (exp == 0) { out[gid] = 0.0f; return; }         // zero / subnormal -> 0
+    uint Mhi = (hi & 0xfffffu) | 0x100000u;            // implicit leading 1 (normal)
+    uint Mlo = lo;
+    int es = perRow ? escale[gid / (uint)stride] : escale[gid % (uint)stride];
+    int sh = (exp - 1075) + E - es;                    // <= 0
+    int s = -sh;
+    if (s > 53) { out[gid] = 0.0f; return; }
+    if (s < 0) s = 0;
+    if (s >= 1) {                                      // round half up: M += 2^(s-1)
+        int rb = s - 1;
+        if (rb < 32) { uint old = Mlo; Mlo += (1u << rb); if (Mlo < old) Mhi++; }
+        else { Mhi += (1u << (rb - 32)); }
     }
-    // Center the fraction into (-1/2, 1/2] — safe since |Cs| < P/2 strictly.
-    df64 r = frac;
-    if (frac.hi + frac.lo > 0.5f) r = df64_add(frac, df64{-1.0f, 0.0f});
-    Rhi[gid] = r.hi;
-    Rlo[gid] = r.lo;
+    uint Arhi, Arlo;
+    if (s == 0) { Arhi = Mhi; Arlo = Mlo; }
+    else if (s < 32) { Arlo = (Mlo >> s) | (Mhi << (32 - s)); Arhi = Mhi >> s; }
+    else { Arlo = Mhi >> (s - 32); Arhi = 0; }
+    // Ar = Arhi·2^32 + Arlo, Ar < 2^53 so Arhi < 2^21
+    uint r = ((Arhi % (uint)p) * (uint)pow2_32_mod_p + (Arlo % (uint)p)) % (uint)p;
+    if (sign) r = ((uint)p - r) % (uint)p;
+    int ph = p >> 1;
+    int ri = (int)r;
+    out[gid] = (float)(ri > ph ? ri - p : ri);
+}
+
+// ozaki_fast_accum: incremental fractional-CRT accumulate, one modulus per call,
+// S += ((G mod p)·q mod p)/p in df32 (fractional Garner — touches only small values).
+kernel void ozaki_fast_accum(
+    device const float* G   [[buffer(0)]],  // MPS f32 GEMM output for this modulus
+    device float*       Shi [[buffer(1)]],
+    device float*       Slo [[buffer(2)]],
+    constant int&       p   [[buffer(3)]],
+    constant int&       q   [[buffer(4)]],  // (P/p)^{-1} mod p
+    uint gid [[thread_position_in_grid]])
+{
+    float g = G[gid];
+    int Gi = (int)rint(g);
+    int gg = ((Gi % p) + p) % p;
+    int u  = (gg * q) % p;
+    float pf = (float)p;
+    float thi = (float)u / pf;
+    float tlo = fma(-thi, pf, (float)u) / pf;          // exact u/p residual via fma
+    float rhi, rlo;
+    ozfast_df_add(Shi[gid], Slo[gid], thi, tlo, rhi, rlo);
+    // Reduce mod 1 each step so the accumulator stays in [0,1). Only frac(S)
+    // matters; holding S near magnitude 1 instead of ~n_mod keeps ~4 extra df32
+    // bits exactly where a heavily-cancelled (pi/e-style) result consumes them.
+    float fl = floor(rhi);
+    if (fl != 0.0f) ozfast_df_add(rhi, rlo, -fl, 0.0f, rhi, rlo);
+    Shi[gid] = rhi; Slo[gid] = rlo;
+}
+
+// ozaki_fast_finalize: frac(S) -> centered -> × (P·2^(e_i+f_j-2E)) -> C df32 (hi,lo).
+kernel void ozaki_fast_finalize(
+    device const float* Shi  [[buffer(0)]],
+    device const float* Slo  [[buffer(1)]],
+    device const int*   erow [[buffer(2)]],
+    device const int*   ecol [[buffer(3)]],
+    device float*       Chi  [[buffer(4)]],
+    device float*       Clo  [[buffer(5)]],
+    constant int&       Ncols[[buffer(6)]],  // output column count (row stride)
+    constant int&       E    [[buffer(7)]],
+    constant float&     Phi  [[buffer(8)]],  // P as df32 (hi,lo)
+    constant float&     Plo  [[buffer(9)]],
+    uint2 gid [[thread_position_in_grid]])
+{
+    int i = gid.y, j = gid.x;
+    uint idx = (uint)i * (uint)Ncols + (uint)j;
+    float shi = Shi[idx], slo = Slo[idx];
+    float fl = floor(shi);                             // integer part (S ∈ [0, n_mod))
+    float fhi, flo;
+    ozfast_df_add(shi, slo, -fl, 0.0f, fhi, flo);
+    float fl2 = floor(fhi);
+    if (fl2 != 0.0f) { ozfast_df_add(fhi, flo, -fl2, 0.0f, fhi, flo); }
+    if (fhi >= 0.5f) { ozfast_df_add(fhi, flo, -1.0f, 0.0f, fhi, flo); }  // center to [-0.5,0.5)
+    int scale = erow[i] + ecol[j] - 2 * E;
+    float w = ldexp(1.0f, scale);                      // EXACT 2^scale (never exp2)
+    float Whi = Phi * w, Wlo = Plo * w;
+    float chi, clo;
+    ozfast_df_mul(fhi, flo, Whi, Wlo, chi, clo);
+    Chi[idx] = chi; Clo[idx] = clo;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/tests/gpu/ozaki_correctness_gate.sh
+++ b/tests/gpu/ozaki_correctness_gate.sh
@@ -95,7 +95,7 @@ run_case() {  # run_case <extra-env...>; stdout -> $OUT_F, stderr -> $ERR_F (par
 ALL_OUT=""
 overall=0
 require_exact_ozaki_markers() {  # require_exact_ozaki_markers <stderr-file> <label> <count> <pattern>
-    local file="$1" label="$2" expected="$3" pattern="$4"
+    local file="$1" label="$2" expected="$3" pattern="$4" init_pattern="$5"
     local count sample poison
 
     count="$(grep -E "$pattern" "$file" | wc -l | tr -d ' ')"
@@ -113,12 +113,17 @@ require_exact_ozaki_markers() {  # require_exact_ozaki_markers <stderr-file> <la
     fi
 
     poison="$(grep -E '^\[GPU\] Ozaki-II:' "$file" | grep -Ev "$pattern" || true)"
+    if [ -n "$init_pattern" ]; then
+        poison="$(printf '%s' "$poison" | grep -Ev "$init_pattern" || true)"
+    fi
     if [ -n "$poison" ]; then
         overall=1
         log "  -> ${label}: non-dispatch Ozaki marker lines detected (poison guard)"
         while IFS= read -r line; do log "       $line"; done <<< "$(echo "$poison" | head -n 3)"
     fi
 }
+
+OZAKI_INIT_PATTERN='^\[GPU\] Ozaki-II: N=[0-9]+ moduli, log2\(P\)='
 
 # ── Case 1: DEFAULT / SHIPPED Ozaki config (fixed N=16). This is the exactness
 #    contract — HARD assertion: bit-exact vs the CPU reference on every regime. ──
@@ -127,7 +132,7 @@ run_case; OUT1="$(cat "$OUT_F")"; ALL_OUT="$OUT1"
 printf '%s\n' "$OUT1"
 printf '%s\n' "$OUT1" | grep -q "SUMMARY total_fail=0" || { overall=1; log "  -> default config produced failures"; }
 printf '%s\n' "$OUT1" | grep -q "VERDICT=FAIL" && { overall=1; log "  -> default config has a FAIL verdict"; }
-require_exact_ozaki_markers "$ERR_F" "case 1" 16 '^\[GPU\] Ozaki-II: N=[0-9]+( \(adaptive\))?, log2\(P\)='
+require_exact_ozaki_markers "$ERR_F" "case 1" 16 '^\[GPU\] Ozaki-II: N=[0-9]+( \(adaptive\))?, log2\(P\)=' "$OZAKI_INIT_PATTERN"
 
 # ── Case 2: adaptive moduli (ESHKOL_OZAKI_ADAPTIVE=1) — OPT-IN / INFORMATIONAL.
 #    Adaptive can reduce the moduli count below the tuned N=16 point; the
@@ -138,7 +143,7 @@ require_exact_ozaki_markers "$ERR_F" "case 1" 16 '^\[GPU\] Ozaki-II: N=[0-9]+( \
 log "=== Case 2: adaptive moduli (opt-in, approximate) — informational ==="
 run_case ESHKOL_OZAKI_ADAPTIVE=1; OUT2="$(cat "$OUT_F")"
 printf '%s\n' "$OUT2"
-require_exact_ozaki_markers "$ERR_F" "case 2" 16 '^\[GPU\] Ozaki-II: N=[0-9]+( \(adaptive\))?, log2\(P\)='
+require_exact_ozaki_markers "$ERR_F" "case 2" 16 '^\[GPU\] Ozaki-II: N=[0-9]+( \(adaptive\))?, log2\(P\)=' "$OZAKI_INIT_PATTERN"
 if printf '%s\n' "$OUT2" | grep -q "SUMMARY total_fail=0"; then
     log "  -> adaptive is bit-exact on this run"
 else
@@ -156,7 +161,7 @@ log "=== Case 3: out-of-range ESHKOL_OZAKI_NUM_MODULI=32 -> loud clamp, still co
 run_case ESHKOL_OZAKI_NUM_MODULI=32; OUT3="$(cat "$OUT_F")"
 printf '%s\n' "$OUT3"
 grep -qi "out of range" "$ERR_F" || { overall=1; log "  -> expected a loud out-of-range warning on stderr, none seen"; }
-require_exact_ozaki_markers "$ERR_F" "case 3" 16 '^\[GPU\] Ozaki-II: N=[0-9]+( \(adaptive\))?, log2\(P\)='
+require_exact_ozaki_markers "$ERR_F" "case 3" 16 '^\[GPU\] Ozaki-II: N=[0-9]+( \(adaptive\))?, log2\(P\)=' "$OZAKI_INIT_PATTERN"
 printf '%s\n' "$OUT3" | grep -q "SUMMARY total_fail=0" || { overall=1; log "  -> clamped run still incorrect"; }
 
 # ── verdict ─────────────────────────────────────────────────────────────────

--- a/tests/gpu/ozaki_correctness_gate.sh
+++ b/tests/gpu/ozaki_correctness_gate.sh
@@ -78,6 +78,8 @@ log "using eshkol-run: $BIN"
 # Force the GPU Ozaki-II path for every matmul regardless of size.
 FORCE_GPU=(
   ESHKOL_GPU_MATMUL_THRESHOLD=0
+  ESHKOL_GPU_THRESHOLD=1
+  ESHKOL_GPU_VERBOSE=1
   ESHKOL_BLAS_PEAK_GFLOPS=0.001
   ESHKOL_GPU_PEAK_GFLOPS=1000000
   ESHKOL_GPU_WAIT_TIMEOUT=300
@@ -92,6 +94,13 @@ run_case() {  # run_case <extra-env...>; stdout -> $OUT_F, stderr -> $ERR_F (par
 
 ALL_OUT=""
 overall=0
+require_ozaki_marker() {  # require_ozaki_marker <stderr-file> <label>
+    local file="$1" label="$2"
+    if ! grep -q "\\[GPU\\] Ozaki-II:" "$file"; then
+        overall=1
+        log "  -> ${label}: expected Ozaki-GPU marker '[GPU] Ozaki-II:' is missing from stderr"
+    fi
+}
 
 # ── Case 1: DEFAULT / SHIPPED Ozaki config (fixed N=16). This is the exactness
 #    contract — HARD assertion: bit-exact vs the CPU reference on every regime. ──
@@ -100,6 +109,7 @@ run_case; OUT1="$(cat "$OUT_F")"; ALL_OUT="$OUT1"
 printf '%s\n' "$OUT1"
 printf '%s\n' "$OUT1" | grep -q "SUMMARY total_fail=0" || { overall=1; log "  -> default config produced failures"; }
 printf '%s\n' "$OUT1" | grep -q "VERDICT=FAIL" && { overall=1; log "  -> default config has a FAIL verdict"; }
+require_ozaki_marker "$ERR_F" "case 1"
 
 # ── Case 2: adaptive moduli (ESHKOL_OZAKI_ADAPTIVE=1) — OPT-IN / INFORMATIONAL.
 #    Adaptive can reduce the moduli count below the tuned N=16 point; the
@@ -110,6 +120,7 @@ printf '%s\n' "$OUT1" | grep -q "VERDICT=FAIL" && { overall=1; log "  -> default
 log "=== Case 2: adaptive moduli (opt-in, approximate) — informational ==="
 run_case ESHKOL_OZAKI_ADAPTIVE=1; OUT2="$(cat "$OUT_F")"
 printf '%s\n' "$OUT2"
+require_ozaki_marker "$ERR_F" "case 2"
 if printf '%s\n' "$OUT2" | grep -q "SUMMARY total_fail=0"; then
     log "  -> adaptive is bit-exact on this run"
 else
@@ -127,6 +138,7 @@ log "=== Case 3: out-of-range ESHKOL_OZAKI_NUM_MODULI=32 -> loud clamp, still co
 run_case ESHKOL_OZAKI_NUM_MODULI=32; OUT3="$(cat "$OUT_F")"
 printf '%s\n' "$OUT3"
 grep -qi "out of range" "$ERR_F" || { overall=1; log "  -> expected a loud out-of-range warning on stderr, none seen"; }
+require_ozaki_marker "$ERR_F" "case 3"
 printf '%s\n' "$OUT3" | grep -q "SUMMARY total_fail=0" || { overall=1; log "  -> clamped run still incorrect"; }
 
 # ── verdict ─────────────────────────────────────────────────────────────────

--- a/tests/gpu/ozaki_correctness_gate.sh
+++ b/tests/gpu/ozaki_correctness_gate.sh
@@ -94,11 +94,29 @@ run_case() {  # run_case <extra-env...>; stdout -> $OUT_F, stderr -> $ERR_F (par
 
 ALL_OUT=""
 overall=0
-require_ozaki_marker() {  # require_ozaki_marker <stderr-file> <label>
-    local file="$1" label="$2"
-    if ! grep -q "\\[GPU\\] Ozaki-II:" "$file"; then
+require_exact_ozaki_markers() {  # require_exact_ozaki_markers <stderr-file> <label> <count> <pattern>
+    local file="$1" label="$2" expected="$3" pattern="$4"
+    local count sample poison
+
+    count="$(grep -E "$pattern" "$file" | wc -l | tr -d ' ')"
+    if [ -z "$count" ]; then count=0; fi
+
+    if [ "$count" -ne "$expected" ]; then
         overall=1
-        log "  -> ${label}: expected Ozaki-GPU marker '[GPU] Ozaki-II:' is missing from stderr"
+        log "  -> ${label}: expected ${expected} dispatch marker lines, got ${count}"
+        log "     pattern: ${pattern}"
+        sample="$(grep -E "$pattern" "$file" | head -n 3 | sed 's/^/       /')"
+        if [ -n "$sample" ]; then
+            log "     sample dispatch lines:"
+            while IFS= read -r line; do log "$line"; done <<< "$sample"
+        fi
+    fi
+
+    poison="$(grep -E '^\[GPU\] Ozaki-II:' "$file" | grep -Ev "$pattern" || true)"
+    if [ -n "$poison" ]; then
+        overall=1
+        log "  -> ${label}: non-dispatch Ozaki marker lines detected (poison guard)"
+        while IFS= read -r line; do log "       $line"; done <<< "$(echo "$poison" | head -n 3)"
     fi
 }
 
@@ -109,7 +127,7 @@ run_case; OUT1="$(cat "$OUT_F")"; ALL_OUT="$OUT1"
 printf '%s\n' "$OUT1"
 printf '%s\n' "$OUT1" | grep -q "SUMMARY total_fail=0" || { overall=1; log "  -> default config produced failures"; }
 printf '%s\n' "$OUT1" | grep -q "VERDICT=FAIL" && { overall=1; log "  -> default config has a FAIL verdict"; }
-require_ozaki_marker "$ERR_F" "case 1"
+require_exact_ozaki_markers "$ERR_F" "case 1" 16 '^\[GPU\] Ozaki-II: N=[0-9]+( \(adaptive\))?, log2\(P\)='
 
 # ── Case 2: adaptive moduli (ESHKOL_OZAKI_ADAPTIVE=1) — OPT-IN / INFORMATIONAL.
 #    Adaptive can reduce the moduli count below the tuned N=16 point; the
@@ -120,7 +138,7 @@ require_ozaki_marker "$ERR_F" "case 1"
 log "=== Case 2: adaptive moduli (opt-in, approximate) — informational ==="
 run_case ESHKOL_OZAKI_ADAPTIVE=1; OUT2="$(cat "$OUT_F")"
 printf '%s\n' "$OUT2"
-require_ozaki_marker "$ERR_F" "case 2"
+require_exact_ozaki_markers "$ERR_F" "case 2" 16 '^\[GPU\] Ozaki-II: N=[0-9]+( \(adaptive\))?, log2\(P\)='
 if printf '%s\n' "$OUT2" | grep -q "SUMMARY total_fail=0"; then
     log "  -> adaptive is bit-exact on this run"
 else
@@ -138,7 +156,7 @@ log "=== Case 3: out-of-range ESHKOL_OZAKI_NUM_MODULI=32 -> loud clamp, still co
 run_case ESHKOL_OZAKI_NUM_MODULI=32; OUT3="$(cat "$OUT_F")"
 printf '%s\n' "$OUT3"
 grep -qi "out of range" "$ERR_F" || { overall=1; log "  -> expected a loud out-of-range warning on stderr, none seen"; }
-require_ozaki_marker "$ERR_F" "case 3"
+require_exact_ozaki_markers "$ERR_F" "case 3" 16 '^\[GPU\] Ozaki-II: N=[0-9]+( \(adaptive\))?, log2\(P\)='
 printf '%s\n' "$OUT3" | grep -q "SUMMARY total_fail=0" || { overall=1; log "  -> clamped run still incorrect"; }
 
 # ── verdict ─────────────────────────────────────────────────────────────────

--- a/tests/gpu/ozaki_fast_gate.sh
+++ b/tests/gpu/ozaki_fast_gate.sh
@@ -83,26 +83,52 @@ OUT="$(cat "$OUT_F")"
 printf '%s\n' "$OUT"
 
 overall=0
+require_exact_fast_markers() {
+    local file="$1" label="$2" expected="$3" pattern="$4"
+    local count sample poison
+
+    count="$(grep -E "$pattern" "$file" | wc -l | tr -d ' ')"
+    if [ -z "$count" ]; then count=0; fi
+
+    if [ "$count" -ne "$expected" ]; then
+        overall=1
+        log "  -> ${label}: expected ${expected} fast dispatch marker lines, got ${count}"
+        log "     pattern: ${pattern}"
+        sample="$(grep -E "$pattern" "$file" | head -n 3 | sed 's/^/       /')"
+        if [ -n "$sample" ]; then
+            log "     sample dispatch lines:"
+            while IFS= read -r line; do log "$line"; done <<< "$sample"
+        fi
+    fi
+
+    poison="$(grep -E '^\[GPU\] Ozaki-II FAST:' "$file" | grep -Ev "$pattern" || true)"
+    if [ -n "$poison" ]; then
+        overall=1
+        log "  -> ${label}: non-dispatch FAST marker lines detected (poison guard)"
+        while IFS= read -r line; do log "       $line"; done <<< "$(echo "$poison" | head -n 3)"
+    fi
+}
 
 # (1) accuracy: no FAIL verdicts, total_fail=0 (all probes <= 1e-7)
 printf '%s\n' "$OUT" | grep -q "SUMMARY total_fail=0" || { overall=1; log "  -> fast tier exceeded the 1e-7 bound on some regime"; }
 printf '%s\n' "$OUT" | grep -q "VERDICT=FAIL" && { overall=1; log "  -> fast tier has a FAIL verdict"; }
 
 # (2) the fast path actually engaged (marker present)…
-if ! grep -q "\[GPU\] Ozaki-II FAST" "$ERR_F"; then
-    overall=1; log "  -> fast-tier marker '[GPU] Ozaki-II FAST' NOT seen — path did not engage"
-fi
+# ...with exactly sixteen explicit dispatch markers.
+FAST_DISPATCH_PATTERN='^\[GPU\] Ozaki-II FAST: n_mod='
+require_exact_fast_markers "$ERR_F" "fast run" 16 "$FAST_DISPATCH_PATTERN"
+
 # …and never silently fell back to the exact tier (which would be near-bit-exact)
 if grep -q "falling back to exact tier" "$ERR_F"; then
     overall=1; log "  -> fast dispatch fell back to the exact tier (not a genuine fast-path run)"
 fi
 
-MODULI="$(grep -o "Ozaki-II FAST tier ENABLED: N=[0-9]* moduli" "$ERR_F" | head -1)"
+FAST_MODULI="$(grep -E "${FAST_DISPATCH_PATTERN}[0-9]+" "$ERR_F" | head -n 1 | tr ' ' '\n' | grep -m1 '^n_mod=' | cut -d= -f2)"
 SNIP="$(printf '%s\n' "$OUT" | grep -E 'REGIME=|SUMMARY' | head -20)"
 rm -f "$OUT_F" "$ERR_F"
 
 if [ "$overall" -eq 0 ]; then
-    pass "Ozaki-II fast tier (${MODULI:-fast}) within 1e-7 across integer/fractional/pi_e/wide at K<=4096; GPU split + df32 CRT reconstruction engaged"
+    pass "Ozaki-II fast tier (${FAST_MODULI:-fast}) within 1e-7 across integer/fractional/pi_e/wide at K<=4096; GPU split + df32 CRT reconstruction engaged"
 else
     fail "Ozaki-II fast-tier gate failed; output:\n$SNIP"
 fi

--- a/tests/gpu/ozaki_fast_gate.sh
+++ b/tests/gpu/ozaki_fast_gate.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# tests/gpu/ozaki_fast_gate.sh — Ozaki-II REDUCED-PRECISION fast-tier gate.
+#
+# Drives the opt-in fully-GPU Ozaki-II fast tier (ESHKOL_SF64_KERNEL=ozaki-fast:
+# GPU residue split + df32 CRT reconstruction, fewer moduli) and asserts:
+#
+#   1. ACCURACY — every probe across the four data regimes (integer, fractional,
+#      pi/e, wide-magnitude) at K up to 4096 is within the documented ~1e-8 tier
+#      bound (rel err <= 1e-7 vs an independent in-process CPU f64 reference).
+#   2. THE FAST PATH ACTUALLY ENGAGES — the dispatch prints its "[GPU] Ozaki-II
+#      FAST" marker AND the accuracy is the reduced-precision signature (NOT the
+#      exact tier's ~1e-14): a run that silently fell back to the exact/serial
+#      tier would be near-bit-exact, so we assert the marker is present and the
+#      reconstruction never fell back (no "falling back to exact tier" on stderr).
+#
+# This is a companion to ozaki_correctness_gate.sh, which pins the DEFAULT
+# (exact, bit-exact N=16) path and MUST keep passing untouched. This gate governs
+# only the opt-in fast tier and never affects the default.
+#
+# Requires a real Metal (macOS) GPU. On a GPU-less host it SKIPS cleanly (exit 0).
+#
+# Usage:  ESHKOL_RUN=/path/to/eshkol-run tests/gpu/ozaki_fast_gate.sh
+set -u
+cd "$(dirname "$0")/../.."
+REPO_ROOT="$(pwd)"
+TEST_ESK="$REPO_ROOT/tests/gpu/ozaki_fast_test.esk"
+
+TRACE_DIR="$REPO_ROOT/scripts/icc_traces"
+TRACE_FILE="$TRACE_DIR/ozaki_fast.jsonl"
+emit_trace() {  # emit_trace <value> <snippet>
+    local value="$1" snippet="$2"
+    mkdir -p "$TRACE_DIR"
+    local esnip
+    if command -v python3 >/dev/null 2>&1; then
+        esnip="$(printf '%s' "$snippet" | python3 -c 'import json,sys; sys.stdout.write(json.dumps(sys.stdin.read()))')"
+    else
+        esnip="$(printf '%s' "$snippet" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')"
+        esnip="\"$esnip\""
+    fi
+    printf '{"kind":"ozaki_fast","name":"ozaki_fast_gate","value":"%s","snippet":%s,"confidence":0.95}\n' \
+        "$value" "$esnip" >> "${TRACE_FILE:?}"
+}
+
+log()  { printf '%s\n' "$*"; }
+skip() { log "SKIP: $*"; exit 0; }
+fail() { log "FAIL: $*"; emit_trace FAIL "$*"; exit 1; }
+pass() { log "PASS: $*"; emit_trace PASS "$*"; exit 0; }
+
+# ── GPU presence ────────────────────────────────────────────────────────────
+if [ "$(uname -s)" = "Darwin" ]; then
+    :  # Metal present on all supported macOS hosts
+elif command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then
+    skip "Ozaki-II fast tier is a Metal-only kernel; no Metal GPU on this host"
+else
+    skip "no Metal GPU detected"
+fi
+
+# ── locate eshkol-run ───────────────────────────────────────────────────────
+BIN="${ESHKOL_RUN:-}"
+if [ -z "$BIN" ]; then
+    for d in build-metalfast build-ozaki build build-gpu-gate build-*; do
+        if [ -x "$REPO_ROOT/$d/eshkol-run" ]; then BIN="$REPO_ROOT/$d/eshkol-run"; break; fi
+    done
+fi
+[ -n "$BIN" ] && [ -x "$BIN" ] || skip "no eshkol-run binary found (set ESHKOL_RUN)"
+log "using eshkol-run: $BIN"
+
+# Force every matmul through the GPU + select the opt-in fast tier (default 10
+# moduli = the documented ~1e-8 tier).
+FORCE_FAST=(
+  ESHKOL_GPU_MATMUL_THRESHOLD=0
+  ESHKOL_BLAS_PEAK_GFLOPS=0.001
+  ESHKOL_GPU_PEAK_GFLOPS=1000000
+  ESHKOL_GPU_WAIT_TIMEOUT=300
+  ESHKOL_SF64_KERNEL=ozaki-fast
+)
+
+OUT_F="$(mktemp)"; ERR_F="$(mktemp)"
+env "${FORCE_FAST[@]}" "$BIN" -r "$TEST_ESK" >"$OUT_F" 2>"$ERR_F"
+OUT="$(cat "$OUT_F")"
+printf '%s\n' "$OUT"
+
+overall=0
+
+# (1) accuracy: no FAIL verdicts, total_fail=0 (all probes <= 1e-7)
+printf '%s\n' "$OUT" | grep -q "SUMMARY total_fail=0" || { overall=1; log "  -> fast tier exceeded the 1e-7 bound on some regime"; }
+printf '%s\n' "$OUT" | grep -q "VERDICT=FAIL" && { overall=1; log "  -> fast tier has a FAIL verdict"; }
+
+# (2) the fast path actually engaged (marker present)…
+if ! grep -q "Ozaki-II FAST" "$ERR_F"; then
+    overall=1; log "  -> fast-tier marker '[GPU] Ozaki-II FAST' NOT seen — path did not engage"
+fi
+# …and never silently fell back to the exact tier (which would be near-bit-exact)
+if grep -q "falling back to exact tier" "$ERR_F"; then
+    overall=1; log "  -> fast dispatch fell back to the exact tier (not a genuine fast-path run)"
+fi
+
+MODULI="$(grep -o "Ozaki-II FAST tier ENABLED: N=[0-9]* moduli" "$ERR_F" | head -1)"
+SNIP="$(printf '%s\n' "$OUT" | grep -E 'REGIME=|SUMMARY' | head -20)"
+rm -f "$OUT_F" "$ERR_F"
+
+if [ "$overall" -eq 0 ]; then
+    pass "Ozaki-II fast tier (${MODULI:-fast}) within 1e-7 across integer/fractional/pi_e/wide at K<=4096; GPU split + df32 CRT reconstruction engaged"
+else
+    fail "Ozaki-II fast-tier gate failed; output:\n$SNIP"
+fi

--- a/tests/gpu/ozaki_fast_gate.sh
+++ b/tests/gpu/ozaki_fast_gate.sh
@@ -69,6 +69,8 @@ log "using eshkol-run: $BIN"
 # moduli = the documented ~1e-8 tier).
 FORCE_FAST=(
   ESHKOL_GPU_MATMUL_THRESHOLD=0
+  ESHKOL_GPU_THRESHOLD=1
+  ESHKOL_GPU_VERBOSE=1
   ESHKOL_BLAS_PEAK_GFLOPS=0.001
   ESHKOL_GPU_PEAK_GFLOPS=1000000
   ESHKOL_GPU_WAIT_TIMEOUT=300
@@ -87,7 +89,7 @@ printf '%s\n' "$OUT" | grep -q "SUMMARY total_fail=0" || { overall=1; log "  -> 
 printf '%s\n' "$OUT" | grep -q "VERDICT=FAIL" && { overall=1; log "  -> fast tier has a FAIL verdict"; }
 
 # (2) the fast path actually engaged (marker present)…
-if ! grep -q "Ozaki-II FAST" "$ERR_F"; then
+if ! grep -q "\[GPU\] Ozaki-II FAST" "$ERR_F"; then
     overall=1; log "  -> fast-tier marker '[GPU] Ozaki-II FAST' NOT seen — path did not engage"
 fi
 # …and never silently fell back to the exact tier (which would be near-bit-exact)

--- a/tests/gpu/ozaki_fast_gate.sh
+++ b/tests/gpu/ozaki_fast_gate.sh
@@ -84,7 +84,7 @@ printf '%s\n' "$OUT"
 
 overall=0
 require_exact_fast_markers() {
-    local file="$1" label="$2" expected="$3" pattern="$4"
+    local file="$1" label="$2" expected="$3" pattern="$4" init_pattern="$5"
     local count sample poison
 
     count="$(grep -E "$pattern" "$file" | wc -l | tr -d ' ')"
@@ -102,6 +102,9 @@ require_exact_fast_markers() {
     fi
 
     poison="$(grep -E '^\[GPU\] Ozaki-II FAST:' "$file" | grep -Ev "$pattern" || true)"
+    if [ -n "$init_pattern" ]; then
+        poison="$(printf '%s' "$poison" | grep -Ev "$init_pattern" || true)"
+    fi
     if [ -n "$poison" ]; then
         overall=1
         log "  -> ${label}: non-dispatch FAST marker lines detected (poison guard)"
@@ -116,7 +119,8 @@ printf '%s\n' "$OUT" | grep -q "VERDICT=FAIL" && { overall=1; log "  -> fast tie
 # (2) the fast path actually engaged (marker present)…
 # ...with exactly sixteen explicit dispatch markers.
 FAST_DISPATCH_PATTERN='^\[GPU\] Ozaki-II FAST: n_mod='
-require_exact_fast_markers "$ERR_F" "fast run" 16 "$FAST_DISPATCH_PATTERN"
+FAST_INIT_PATTERN='^\[GPU\] Ozaki-II FAST: N=[0-9]+ moduli'
+require_exact_fast_markers "$ERR_F" "fast run" 16 "$FAST_DISPATCH_PATTERN" "$FAST_INIT_PATTERN"
 
 # …and never silently fell back to the exact tier (which would be near-bit-exact)
 if grep -q "falling back to exact tier" "$ERR_F"; then

--- a/tests/gpu/ozaki_fast_test.esk
+++ b/tests/gpu/ozaki_fast_test.esk
@@ -1,0 +1,70 @@
+;; ozaki_fast_test.esk — Ozaki-II REDUCED-PRECISION fast-tier accuracy probe.
+;;
+;; Companion to ozaki_correctness_test.esk, but for the opt-in fully-GPU fast
+;; tier (ESHKOL_OZAKI_FAST=1 / ESHKOL_SF64_KERNEL=ozaki-fast): GPU residue split
+;; + df32 CRT reconstruction. This tier is REDUCED precision — its accuracy knob
+;; is the moduli count — so the threshold here is the documented fast-tier bound
+;; (rel err <= 1e-7 for the default ~1e-8 config), NOT the exact tier's ~1e-9.
+;;
+;; Same shape as the exact probe: an independent in-process CPU f64 triple-loop
+;; reference at a 5x5 grid of probe positions, across four data regimes and K up
+;; to 4096. Verdict is decided here so it does not depend on display precision.
+
+(define TOL 1e-7)          ;; reduced-precision fast tier: documented ~1e-8 bound, gate at 1e-7
+(define total-fail 0)
+
+(define (fillA regime i)
+  (cond ((= regime 0) (exact->inexact (- (modulo i 7) 3)))                                  ;; integer (incl. negatives)
+        ((= regime 1) (+ 1.0 (* 0.5 (exact->inexact (modulo i 7)))))                        ;; fractional O(1)
+        ((= regime 2) (* 3.141592653589793 (+ 1.0 (exact->inexact (modulo i 11)))))         ;; pi multiples
+        (else (* (expt 2.0 (exact->inexact (- (modulo i 20) 10)))                           ;; wide magnitude 2^[-10,9]
+                 (+ 1.0 (* 0.1 (exact->inexact (modulo i 3))))))))
+(define (fillB regime i)
+  (cond ((= regime 0) (exact->inexact (- (modulo i 5) 2)))
+        ((= regime 1) (+ 0.5 (* 0.25 (exact->inexact (modulo i 5)))))
+        ((= regime 2) (* 2.718281828459045 (- (exact->inexact (modulo i 9)) 4.0)))          ;; e multiples (incl. negatives)
+        (else (* (expt 2.0 (exact->inexact (- (modulo i 18) 9)))
+                 (+ 1.0 (* 0.1 (exact->inexact (modulo i 4))))))))
+(define (rname regime)
+  (cond ((= regime 0) "integer") ((= regime 1) "fractional") ((= regime 2) "pi_e") (else "wide_range")))
+
+;; Probe a 5x5 grid of output positions against an independent CPU f64 reference.
+(define (check regime N Ad Bd Cd)
+  (let ((maxrel 0.0))
+    (do ((pr 0 (+ pr 1))) ((>= pr 5))
+      (do ((pc 0 (+ pc 1))) ((>= pc 5))
+        (let ((ii (quotient (* pr (- N 1)) 4))
+              (jj (quotient (* pc (- N 1)) 4))
+              (ref 0.0))
+          (do ((k 0 (+ k 1))) ((>= k N))
+            (set! ref (+ ref (* (vector-ref Ad (+ (* ii N) k))
+                                (vector-ref Bd (+ (* k N) jj))))))
+          (let* ((cij (vector-ref Cd (+ (* ii N) jj)))
+                 (denom (if (> (abs ref) 1e-9) (abs ref) 1.0))
+                 (rel (/ (abs (- cij ref)) denom)))
+            (when (> rel maxrel) (set! maxrel rel))))))
+    (let ((pass (< maxrel TOL)))
+      (when (not pass) (set! total-fail (+ total-fail 1)))
+      (display "REGIME=") (display (rname regime))
+      (display " N=") (display N)
+      (display " MAXREL=") (display maxrel)
+      (display " VERDICT=") (display (if pass "PASS" "FAIL"))
+      (newline))))
+
+(define sizes (vector 512 1024 2048 4096))
+(do ((r 0 (+ r 1))) ((>= r 4))
+  (do ((si 0 (+ si 1))) ((>= si 4))
+    (let* ((N (vector-ref sizes si))
+           (size (* N N))
+           (Ad (make-vector size 0.0))
+           (Bd (make-vector size 0.0)))
+      (do ((i 0 (+ i 1))) ((>= i size))
+        (vector-set! Ad i (fillA r i))
+        (vector-set! Bd i (fillB r i)))
+      (let* ((A (reshape Ad N N))
+             (B (reshape Bd N N))
+             (C (matmul A B))
+             (Cd (tensor-data C)))
+        (check r N Ad Bd Cd)))))
+
+(display "SUMMARY total_fail=") (display total-fail) (newline)


### PR DESCRIPTION
## Summary

Adds an opt-in reduced-precision, fully GPU-resident Ozaki-II tier for Metal. Select it with `ESHKOL_SF64_KERNEL=ozaki-fast` or `ESHKOL_OZAKI_FAST=1`; default DGEMM and fixed-N=16 exact Ozaki remain unchanged.

The fast tier performs cap-limited prime-power residue splitting, MPS f32 GEMMs, and df32 fractional-CRT reconstruction on GPU. The host uploads A/B once, performs one O(N²) exponent pass, and downloads C.

## Measured M2 Ultra results

| tier | N=4096 | N=8192 | vs AMX dgemm at N=8192 |
|---|---:|---:|---:|
| fast, 10 moduli | ~1080 GF | ~1448 GF | 1.32x; fails pi/e gate |
| **fast, 11 (default)** | **~1081 GF** | **~1384 GF** | **1.26x** |
| fast, 12 moduli | ~1022 GF | ~1278 GF | 1.16x |
| exact, 16 moduli | ~140 GF | ~143 GF | 0.13x |
| AMX f64 dgemm | ~1080 GF | ~1099 GF | 1.00x |

The default 11-modulus tier's worst measured relative error across integer, fractional, pi/e, and wide-range regimes at K<=4096 is about `2.4e-8`, within its `1e-7` contract.

## Hardware gates and hardening

Verified on the exact rebased head on Atlas (M2 Ultra), for JIT and AOT:

- Fixed-N=16 correctness: literal PASS; exact and clamp summaries have zero failures.
- Adaptive policy: every `MAXREL < 1e-6`.
- Clamp: zero failures and the required warning.
- Fast tier: literal PASS at `n_mod=11`, zero failures, no fallback.
- Every exact/adaptive/clamp/fast run has exactly 16 dispatch-specific GPU markers and one accepted init marker.

The shell gates exclude initialization lines from dispatch and poison assertions. Synthetic probes prove that each gate accepts exactly 16 dispatch markers plus init, but rejects zero markers, 17 markers, and 16 markers plus poison.

There is no Darwin/runtime-presence post-run skip: missing Metal dispatch evidence fails on macOS. Non-Darwin and missing-binary preflight skips remain unchanged.

## Verification

- Fresh RelWithDebInfo Ninja Metal build: PASS.
- Real Atlas JIT correctness and fast gates: PASS.
- Exact-head AOT exact/adaptive/clamp/fast assertions: PASS.
- ICC indexed with both runtime traces; source drift zero; pre-commit zero blockers.
- Accepted hardening patch appears exactly once; rejected Darwin-skip patch is absent.

## Files

- `lib/backend/gpu/gpu_memory.mm`
- `lib/backend/gpu/metal_softfloat.h`
- `tests/gpu/ozaki_correctness_gate.sh`
- `tests/gpu/ozaki_fast_gate.sh`
- `tests/gpu/ozaki_fast_test.esk`
- `.icc/completion-oracles.yaml`
- `CHANGELOG.md`
- `docs/breakdown/GPU_ACCELERATION.md`
