### PR TITLE
fix(runtime): restore linear-solve core boundary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2072,6 +2072,7 @@ set(ESHKOL_RUNTIME_HOSTED_SRC
   lib/core/runtime_shutdown_hooks_hosted.cpp
   lib/core/runtime_signals_hosted.cpp
   lib/core/runtime_stack_hosted.cpp
+  lib/core/linear_solve_hosted.cpp
   lib/core/runtime_string_ports_hosted.cpp
   lib/core/system_builtins.c
 )
@@ -3045,6 +3046,30 @@ if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/core/resourc
     endif()
     target_link_libraries(resource_limits_test PRIVATE eshkol-static ${ESHKOL_EXTRA_LINK_LIBS} ${LLVM_LIBS_LIST} ${LLVM_SYSTEM_LIBS_LIST})
     add_test(NAME resource_limits_test COMMAND resource_limits_test)
+endif()
+
+if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/core/linear_solve_hosted_control_test.cpp")
+    add_executable(linear_solve_hosted_control_test
+        tests/core/linear_solve_hosted_control_test.cpp)
+    target_compile_features(linear_solve_hosted_control_test PRIVATE cxx_std_17)
+    target_include_directories(linear_solve_hosted_control_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+    eshkol_target_llvm_includes(linear_solve_hosted_control_test)
+    if(LLVM_LIBRARY_DIRS)
+        target_link_directories(linear_solve_hosted_control_test PRIVATE ${LLVM_LIBRARY_DIRS})
+    endif()
+    target_link_libraries(linear_solve_hosted_control_test PRIVATE
+        eshkol-static ${ESHKOL_EXTRA_LINK_LIBS}
+        ${LLVM_LIBS_LIST} ${LLVM_SYSTEM_LIBS_LIST})
+    add_test(NAME linear_solve_hosted_control_unset
+        COMMAND linear_solve_hosted_control_test unset)
+    add_test(NAME linear_solve_hosted_control_zero
+        COMMAND linear_solve_hosted_control_test zero)
+    add_test(NAME linear_solve_hosted_control_one
+        COMMAND linear_solve_hosted_control_test one)
+    set_tests_properties(linear_solve_hosted_control_zero PROPERTIES
+        ENVIRONMENT "ESHKOL_LINSOLVE_FORCE_DGESV=0")
+    set_tests_properties(linear_solve_hosted_control_one PROPERTIES
+        ENVIRONMENT "ESHKOL_LINSOLVE_FORCE_DGESV=1")
 endif()
 
 if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/core/runtime_signal_handlers_test.cpp")

--- a/inc/eshkol/core/linear_solve.h
+++ b/inc/eshkol/core/linear_solve.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) tsotchke
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef ESHKOL_CORE_LINEAR_SOLVE_H
+#define ESHKOL_CORE_LINEAR_SOLVE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// =====================================================================
+// Solver status codes shared by core and hosted wrappers.
+// =====================================================================
+
+#define ESHKOL_LINSOLVE_OK            0
+#define ESHKOL_LINSOLVE_SINGULAR      1
+#define ESHKOL_LINSOLVE_NOT_SQUARE    2
+#define ESHKOL_LINSOLVE_DIM_MISMATCH  3
+
+// =====================================================================
+// Solver options (bitmask) for deterministic core execution.
+// =====================================================================
+
+// If set, skip the mixed-precision IR path and force a direct LAPACK dgesv
+// solve where that path exists (Apple/Accelerate).
+#define ESHKOL_LINSOLVE_FORCE_DGESV ((uint32_t)1u)
+
+// =====================================================================
+// Core / hosted entry points.
+// =====================================================================
+
+/**
+ * @brief Solve A x = b in the numerical core.
+ *
+ * The core entry is deterministic and does not inspect host process
+ * environment or call hosted-only runtime services. Callers must pass all
+ * behavior controls explicitly in `options`.
+ *
+ * @param a_ndim Rank of A (must be 2).
+ * @param a_dims Shape of A (row-major); a_dims[0] x a_dims[1].
+ * @param b_ndim Rank of b.
+ * @param b_dims Shape of b (product must equal N).
+ * @param A      Row-major N*N f64 coefficient matrix.
+ * @param b      Length-N f64 right-hand side.
+ * @param x      Length-N f64 output solution (caller-allocated).
+ * @param options Solver controls bitmask, e.g. ESHKOL_LINSOLVE_FORCE_DGESV.
+ * @return       ESHKOL_LINSOLVE_OK or a nonzero catchable error code.
+ */
+int64_t eshkol_linear_solve_with_options(
+    int64_t a_ndim, const int64_t* a_dims,
+    int64_t b_ndim, const int64_t* b_dims,
+    const double* A, const double* b, double* x,
+    uint32_t options);
+
+/**
+ * @brief Hosted ABI entry point used by VM/JIT/AOT.
+ *
+ * Preserves the existing public ABI by deriving `options` from
+ * `ESHKOL_LINSOLVE_FORCE_DGESV` in the host process environment.
+ */
+int64_t eshkol_linear_solve(
+    int64_t a_ndim, const int64_t* a_dims,
+    int64_t b_ndim, const int64_t* b_dims,
+    const double* A, const double* b, double* x);
+
+/**
+ * @brief Raise a catchable exception for a nonzero solver status.
+ */
+void eshkol_linear_solve_raise(int64_t status);
+
+/**
+ * @brief Query solver options for the hosted process environment.
+ */
+uint32_t eshkol_linear_solve_query_options(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ESHKOL_CORE_LINEAR_SOLVE_H

--- a/lib/core/linear_solve.cpp
+++ b/lib/core/linear_solve.cpp
@@ -106,7 +106,7 @@ static int64_t linsolve_ir_accelerate(const double* A, const double* b,
     }
 
     if (n == 0) return ESHKOL_LINSOLVE_OK;
-    
+
     double bnorm = cblas_dnrm2(n, b, 1);
     double denom = (bnorm > 0.0) ? bnorm : 1.0;
 

--- a/lib/core/linear_solve.cpp
+++ b/lib/core/linear_solve.cpp
@@ -32,26 +32,12 @@
  */
 
 #include <eshkol/eshkol.h>
+#include <eshkol/core/linear_solve.h>
 
 #include <cmath>
 #include <cstdint>
-#include <cstdlib>
 #include <cstring>
-
-// eshkol_runtime_fatal is defined in runtime_errors_hosted.cpp; it builds a
-// catchable exception and raises it (or exits if unhandled). No public header
-// declares it, so forward-declare it here for the native raise helper.
-extern "C" void eshkol_runtime_fatal(eshkol_exception_type_t type,
-                                     const char* fmt, ...);
-
-// Status codes returned by eshkol_linear_solve(). 0 = a full-f64 solution was
-// produced (via IR or the dgesv fallback); the rest are catchable errors.
-enum {
-    ESHKOL_LINSOLVE_OK          = 0,
-    ESHKOL_LINSOLVE_SINGULAR    = 1,  // A is singular / no unique solution
-    ESHKOL_LINSOLVE_NOT_SQUARE  = 2,  // A is not a square 2-D matrix
-    ESHKOL_LINSOLVE_DIM_MISMATCH = 3  // b length != N
-};
+#include <cstdlib>
 
 // Refinement acceptance: certify the IR solution only once its relative
 // backward residual ||b - Ax|| / ||b|| is at or below this. Well-conditioned
@@ -114,16 +100,13 @@ static int64_t linsolve_dgesv_fallback(const double* A, const double* b,
 
 // Mixed-precision iterative refinement, Apple/Accelerate path.
 static int64_t linsolve_ir_accelerate(const double* A, const double* b,
-                                      double* x, int n) {
-    if (n == 0) return ESHKOL_LINSOLVE_OK;
-
-    // Benchmark hook: force the plain-f64 path so the IR speedup can be
-    // measured against the same-machine dgesv baseline in-tree.
-    if (const char* force = std::getenv("ESHKOL_LINSOLVE_FORCE_DGESV")) {
-        if (force[0] && force[0] != '0')
-            return linsolve_dgesv_fallback(A, b, x, n);
+                                      double* x, int n, uint32_t options) {
+    if ((options & ESHKOL_LINSOLVE_FORCE_DGESV) != 0) {
+        return linsolve_dgesv_fallback(A, b, x, n);
     }
 
+    if (n == 0) return ESHKOL_LINSOLVE_OK;
+    
     double bnorm = cblas_dnrm2(n, b, 1);
     double denom = (bnorm > 0.0) ? bnorm : 1.0;
 
@@ -246,10 +229,10 @@ static int64_t linsolve_lu_f64(const double* A, const double* b,
  * @param x      Length-N f64 output solution (caller-allocated).
  * @return       ESHKOL_LINSOLVE_OK, or a nonzero catchable error code.
  */
-extern "C" int64_t eshkol_linear_solve(
+extern "C" int64_t eshkol_linear_solve_with_options(
     int64_t a_ndim, const int64_t* a_dims,
     int64_t b_ndim, const int64_t* b_dims,
-    const double* A, const double* b, double* x) {
+    const double* A, const double* b, double* x, uint32_t options) {
 
     if (a_ndim != 2 || !a_dims || a_dims[0] != a_dims[1] || a_dims[0] < 0)
         return ESHKOL_LINSOLVE_NOT_SQUARE;
@@ -266,28 +249,9 @@ extern "C" int64_t eshkol_linear_solve(
     if (n == 0) return ESHKOL_LINSOLVE_OK;
 
 #if defined(ESHKOL_BLAS_ACCELERATE)
-    return linsolve_ir_accelerate(A, b, x, (int)n);
+    return linsolve_ir_accelerate(A, b, x, (int)n, options);
 #else
+    (void)options;
     return linsolve_lu_f64(A, b, x, (int)n);
 #endif
-}
-
-/**
- * @brief Raise the catchable exception for a nonzero eshkol_linear_solve()
- *        status. Called only from LLVM-generated native code (the VM raises
- *        through its own condition machinery). Never returns.
- */
-extern "C" void eshkol_linear_solve_raise(int64_t status) {
-    const char* msg;
-    switch (status) {
-        case ESHKOL_LINSOLVE_SINGULAR:
-            msg = "linear-solve: matrix is singular"; break;
-        case ESHKOL_LINSOLVE_NOT_SQUARE:
-            msg = "linear-solve: A must be a square 2-D matrix"; break;
-        case ESHKOL_LINSOLVE_DIM_MISMATCH:
-            msg = "linear-solve: dimension mismatch (b length must equal N)"; break;
-        default:
-            msg = "linear-solve: error"; break;
-    }
-    eshkol_runtime_fatal(ESHKOL_EXCEPTION_ERROR, "%s", msg);
 }

--- a/lib/core/linear_solve_hosted.cpp
+++ b/lib/core/linear_solve_hosted.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) tsotchke
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Hosted wrapper for dense linear solve ABI and error handling.
+ */
+
+#include <eshkol/core/linear_solve.h>
+#include <eshkol/core/runtime.h>
+#include <eshkol/eshkol.h>
+
+#include <cstdlib>
+#include <cstdint>
+
+extern "C" {
+
+// eshkol_runtime_fatal is defined in runtime_errors_hosted.cpp and constructs
+// the catchable runtime exception on fatal paths.
+void eshkol_runtime_fatal(eshkol_exception_type_t type, const char* fmt, ...);
+
+/**
+ * @brief Inspect the hosted environment for the linear-solve control flag.
+ *
+ * Existing semantics are preserved:
+ * - unset: false
+ * - empty string: false
+ * - leading '0': false
+ * - any other non-empty string: true
+ */
+uint32_t eshkol_linear_solve_query_options(void) {
+    const char* force = std::getenv("ESHKOL_LINSOLVE_FORCE_DGESV");
+    if (!force || force[0] == '\0' || force[0] == '0') return 0;
+    return ESHKOL_LINSOLVE_FORCE_DGESV;
+}
+
+/**
+ * @brief Hosted ABI entry point that retains the historical symbol shape.
+ */
+int64_t eshkol_linear_solve(
+    int64_t a_ndim, const int64_t* a_dims,
+    int64_t b_ndim, const int64_t* b_dims,
+    const double* A, const double* b, double* x) {
+    return eshkol_linear_solve_with_options(
+        a_ndim, a_dims, b_ndim, b_dims, A, b, x,
+        eshkol_linear_solve_query_options());
+}
+
+/**
+ * @brief Raise the catchable exception for a nonzero eshkol_linear_solve()
+ *        status.
+ *
+ * The VM path for native execution handles this by catching the runtime
+ * exception. This helper keeps the core independent of hosted runtime internals.
+ */
+void eshkol_linear_solve_raise(int64_t status) {
+    const char* msg;
+    switch (status) {
+        case ESHKOL_LINSOLVE_SINGULAR:
+            msg = "linear-solve: matrix is singular"; break;
+        case ESHKOL_LINSOLVE_NOT_SQUARE:
+            msg = "linear-solve: A must be a square 2-D matrix"; break;
+        case ESHKOL_LINSOLVE_DIM_MISMATCH:
+            msg = "linear-solve: dimension mismatch (b length must equal N)"; break;
+        default:
+            msg = "linear-solve: error"; break;
+    }
+    eshkol_runtime_fatal(ESHKOL_EXCEPTION_ERROR, "%s", msg);
+}
+
+}  // extern "C"

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -500,17 +500,17 @@ probe ad_forward_over_reverse_oracle 'jacobian/hessian differentiating through a
 probe linear_solve_full_f64_oracle 'linear-solve: mixed-precision IR dense solver reaches full-f64 residual (<=1e-12, computed in-test) on well-conditioned/identity systems and raises catchably on singular/dimension-mismatch — verified on JIT, AOT, and the VM' \
     'cd "$REPO_ROOT"; t=tests/features/linear_solve_test.esk;
      out=$(ESHKOL_PATH="$REPO_ROOT/lib" "$ESHKOL_RUN" -r "$t" 2>/dev/null) || exit 1;
-     [ "$(printf "%s" "$out" | grep -c "PASS:")" -eq 6 ] || exit 1;
+     [ "$(printf "%s" "$out" | grep -c "PASS:")" -eq 8 ] || exit 1;
      printf "%s" "$out" | grep -q "FAIL:" && exit 1;
      bin=$(mktemp) || exit 1;
      ESHKOL_PATH="$REPO_ROOT/lib" "$ESHKOL_RUN" "$t" -o "$bin" >/dev/null 2>&1 || { rm -f "$bin"; exit 1; };
      out=$("$bin" 2>/dev/null); rc=$?; rm -f "$bin"; [ "$rc" -eq 0 ] || exit 1;
-     [ "$(printf "%s" "$out" | grep -c "PASS:")" -eq 6 ] || exit 1;
+     [ "$(printf "%s" "$out" | grep -c "PASS:")" -eq 8 ] || exit 1;
      printf "%s" "$out" | grep -q "FAIL:" && exit 1;
      vm="$BUILD_DIR_PATH/eshkol-vm-standalone-test";
      if [ -x "$vm" ]; then
        out=$(ESHKOL_VM_NO_DISASM=1 ESHKOL_PATH="$REPO_ROOT/lib" "$vm" "$t" 2>/dev/null) || exit 1;
-       [ "$(printf "%s" "$out" | grep -c "PASS:")" -eq 6 ] || exit 1;
+       [ "$(printf "%s" "$out" | grep -c "PASS:")" -eq 8 ] || exit 1;
        printf "%s" "$out" | grep -q "FAIL:" && exit 1;
      fi;
      exit 0'

--- a/tests/core/linear_solve_hosted_control_test.cpp
+++ b/tests/core/linear_solve_hosted_control_test.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) tsotchke
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Verify hosted linear-solve environment control and explicit core options.
+ */
+
+#include <eshkol/core/linear_solve.h>
+
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+
+namespace {
+
+int fail(const char* message) {
+    std::cerr << "linear_solve_hosted_control_test: " << message << '\n';
+    return 1;
+}
+
+void set_env(const char* key, const char* value) {
+#ifdef _WIN32
+    if (_putenv_s(key, value) != 0) {
+        std::cerr << "linear_solve_hosted_control_test: _putenv_s failed" << '\n';
+        std::exit(1);
+    }
+#else
+    if (setenv(key, value, 1) != 0) {
+        std::cerr << "linear_solve_hosted_control_test: setenv failed" << '\n';
+        std::exit(1);
+    }
+#endif
+}
+
+void clear_env(const char* key) {
+#ifdef _WIN32
+    if (_putenv_s(key, "") != 0) {
+        std::cerr << "linear_solve_hosted_control_test: _putenv_s clear failed" << '\n';
+        std::exit(1);
+    }
+#else
+    if (unsetenv(key) != 0) {
+        std::cerr << "linear_solve_hosted_control_test: unsetenv failed" << '\n';
+        std::exit(1);
+    }
+#endif
+}
+
+void apply_scenario_env(const char* scenario) {
+    if (std::strcmp(scenario, "unset") == 0) {
+        clear_env("ESHKOL_LINSOLVE_FORCE_DGESV");
+    } else if (std::strcmp(scenario, "zero") == 0) {
+        set_env("ESHKOL_LINSOLVE_FORCE_DGESV", "0");
+    } else if (std::strcmp(scenario, "one") == 0) {
+        set_env("ESHKOL_LINSOLVE_FORCE_DGESV", "1");
+    } else {
+        std::cerr << "linear_solve_hosted_control_test: unknown scenario: " << scenario << '\n';
+        std::exit(1);
+    }
+}
+
+double relative_residual(const double* A, const double* b, const double* x, int n) {
+    double rnorm = 0.0;
+    double bnorm = 0.0;
+    for (int i = 0; i < n; i++) {
+        double row = 0.0;
+        for (int j = 0; j < n; j++) {
+            row += A[i * n + j] * x[j];
+        }
+        const double resid = row - b[i];
+        rnorm += resid * resid;
+        bnorm += b[i] * b[i];
+    }
+    if (bnorm == 0.0) return rnorm == 0.0 ? 0.0 : 1e300;
+    return std::sqrt(rnorm / bnorm);
+}
+
+int run_case(const char* label, const char* scenario, uint32_t expected_query,
+             uint32_t core_options) {
+    apply_scenario_env(scenario);
+    const uint32_t observed = eshkol_linear_solve_query_options();
+    if (observed != expected_query) {
+        std::cerr << "linear_solve_hosted_control_test: " << label
+                  << " query mismatch (observed=" << observed
+                  << ", expected=" << expected_query << ')' << '\n';
+        return fail("query mismatch");
+    }
+
+    const int64_t a_dims[2] = {3, 3};
+    const int64_t b_dims[1] = {3};
+    const double A[9] = {
+        4.0, 1.0, 0.0,
+        1.0, 4.0, 1.0,
+        0.0, 1.0, 4.0
+    };
+    const double b[3] = {6.0, 12.0, 14.0};
+    double x_core[3] = {0.0, 0.0, 0.0};
+    double x_hosted[3] = {0.0, 0.0, 0.0};
+
+    const int64_t status_core = eshkol_linear_solve_with_options(
+        2, a_dims, 1, b_dims, A, b, x_core, core_options);
+    if (status_core != ESHKOL_LINSOLVE_OK) {
+        return fail("core solve failed");
+    }
+
+    if (relative_residual(A, b, x_core, 3) > 1e-12) {
+        return fail("core residual too large");
+    }
+
+    const int64_t status_hosted = eshkol_linear_solve(
+        2, a_dims, 1, b_dims, A, b, x_hosted);
+    if (status_hosted != ESHKOL_LINSOLVE_OK) {
+        return fail("hosted solve failed");
+    }
+
+    if (relative_residual(A, b, x_hosted, 3) > 1e-12) {
+        return fail("hosted residual too large");
+    }
+
+    (void)label;
+    return 0;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        return fail("usage: linear_solve_hosted_control_test <unset|zero|one>");
+    }
+
+    if (std::strcmp(argv[1], "unset") == 0) {
+        return run_case("unset", "unset", 0u, 0u);
+    }
+    if (std::strcmp(argv[1], "zero") == 0) {
+        return run_case("zero", "zero", 0u, 0u);
+    }
+    if (std::strcmp(argv[1], "one") == 0) {
+        return run_case("one", "one", ESHKOL_LINSOLVE_FORCE_DGESV, ESHKOL_LINSOLVE_FORCE_DGESV);
+    }
+    return fail("unknown scenario");
+}

--- a/tests/coverage/language_surface.json
+++ b/tests/coverage/language_surface.json
@@ -14,10 +14,10 @@
     }
   },
   "counts": {
-    "builtins_total": 1009,
+    "builtins_total": 1010,
     "builtins_in_native_closure_table": 427,
-    "builtins_in_vm_table": 680,
-    "builtins_in_llvm_aot_dispatch": 770,
+    "builtins_in_vm_table": 681,
+    "builtins_in_llvm_aot_dispatch": 771,
     "builtins_aot_only": 284,
     "quantum_agent_ffi_builtins": 22,
     "special_forms": 116,
@@ -34,7 +34,7 @@
     "string_char": 42,
     "list_pair": 38,
     "consciousness": 37,
-    "misc": 26,
+    "misc": 27,
     "vector": 23,
     "hash": 22,
     "higher_order": 14,
@@ -5721,6 +5721,18 @@
         "native_llvm"
       ],
       "category": "ffi_system"
+    },
+    {
+      "name": "linear-solve",
+      "ids": [
+        472
+      ],
+      "arity": 2,
+      "backends": [
+        "vm",
+        "native_llvm"
+      ],
+      "category": "misc"
     },
     {
       "name": "linear-warmup-lr",


### PR DESCRIPTION
Restores the hosted/runtime-core dependency boundary for linear-solve while preserving the public ABI and Apple forced-DGESV benchmark control.

- moves environment parsing and fatal-error handling into a hosted wrapper
- makes the numerical core deterministic via explicit option bits
- adds unset/zero/one hosted-control CTests
- ratchets ICC smoke expectations to the merged 8-case JIT/AOT/VM suite

Local acceptance:
- full build succeeded
- 87/87 CTests passed
- JIT, VM, and AOT each reported exactly 8 passed, 0 failed both normally and with ESHKOL_LINSOLVE_FORCE_DGESV=1
- runtime_core_boundary_test passed; core object has no getenv/runtime_fatal import
- git diff --check passed