### PR TITLE
test(gpu): certify exact Metal Ozaki against i128

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -2026,6 +2026,24 @@ oracles:
         label: Ozaki-II CRT exact DGEMM (shipped fixed N=16) is bit-exact vs an independent CPU f64 reference across integer/fractional/pi-e/wide-magnitude regimes at K<=4096, with out-of-range moduli clamped loudly and opt-in adaptive free of gross CRT error
         action: ./tests/gpu/ozaki_correctness_gate.sh
 
+  # Ozaki-II certification. This gate validates a deterministic integer witness
+  # on real Metal fixed-N16 dispatch, sampling 512x512 output tiles and checking
+  # every sample against an independent native-i128 reference with signed
+  # magnitude < 2^58. It also explicitly requires both cached JIT and AOT execution to pass,
+  # verifies Apple Accelerate disagrees with the identical witness on at least one
+  # sampled output, and asserts no CPU fallback path was used.
+  # ─────────────────────────────────────────────────────────────────
+  - name: ozaki-certification
+    aliases: [ozaki-exact-reference, exact-reference-certification, p-ozaki-certification]
+    requires:
+      - runtime_event:
+          event_kinds: [ozaki_certification]
+          event_names: ["ozaki_certification_gate"]
+          event_values: ["PASS"]
+        severity: high
+        label: Metal fixed-N16 exact Ozaki dispatch certification checks that every sampled deterministic 512x512 integer-witness output matches an independent native-i128 reference with signed magnitude < 2^58, where the native-i128 reference is converted to correctly rounded f64 before equality comparison, that both cached JIT and AOT execute successfully, that Apple Accelerate on the identical witness disagrees on at least one sampled output, and that no CPU fallback path is used
+        action: ./tests/gpu/ozaki_certification_gate.sh
+
   # ─────────────────────────────────────────────────────────────────
   # INT8 tensor-core Ozaki f64 GEMM (CUDA, opt-in). Recovers FP64-accurate
   # C = A*B from the INT8 (IMMA) tensor cores via per-row/col-scaled 7-bit

--- a/docs/breakdown/GPU_ACCELERATION.md
+++ b/docs/breakdown/GPU_ACCELERATION.md
@@ -463,6 +463,10 @@ bit 0 prevents deallocation of externally-owned memory.
 | `ESHKOL_OZAKI_ADAPTIVE` | `1` | exact tier: adaptive (approximate) moduli minimisation |
 | `ESHKOL_OZAKI_PROFILE` | `1` | prints per-matmul internal pipeline ms + effective GFLOP/s (exact and fast tiers) |
 
+#### Exact-reference certification gate (opt-in)
+
+`tests/gpu/ozaki_certification_gate.sh` runs a deterministic `512x512` integer-valued f64 witness. It uses an independent sampled native-`i128` dot-product oracle with a proven bound below `2^58`, then converts oracle sums to correctly rounded f64. On the identical witness, Apple Accelerate must differ on at least one sample while fixed-`N16` Metal exact Ozaki (`ozaki`) must match every sampled reference. The script exercises both default cached-JIT and AOT and requires real fixed-`N16` Metal dispatch markers, explicitly rejecting CPU fallback. ICC oracle name is `ozaki-certification`. This is a correctness-only certification witness: no default-dispatch change and no performance claim.
+
 The default DGEMM tier is unchanged; both `ozaki` and `ozaki-fast` are opt-in.
 See section 3 (Ozaki-II CRT DGEMM) for the accuracy/throughput tables.
 

--- a/scripts/run_all_tests.ps1
+++ b/scripts/run_all_tests.ps1
@@ -1603,7 +1603,7 @@ switch ($Mode) {
         $suiteResults += Invoke-TimedCompileRunSuite -SuiteName "optimization" -Title "Eshkol Optimization Algorithms Tests" -Patterns @("tests/ml/*optimization*.esk") -TimeoutSec 60 -FailRegex "FAIL:"
         $suiteResults += Invoke-ExamplesSuite
         $suiteResults += Invoke-XlaSuite
-        $suiteResults += Invoke-SimpleCompileRunSuite -SuiteName "gpu" -Title "Eshkol GPU Test Suite" -Patterns @("tests/gpu/*.esk") -FailRegex "^FAIL:|Failed:\s+[1-9]"
+        $suiteResults += Invoke-SimpleCompileRunSuite -SuiteName "gpu" -Title "Eshkol GPU Test Suite" -Patterns @("tests/gpu/*.esk") -FailRegex "^FAIL:|Failed:\s+[1-9]" -ExcludeNames @("ozaki_certification_test.esk")
         $suiteResults += Invoke-SimpleCompileRunSuite -SuiteName "error_handling" -Title "Eshkol Error Handling Tests" -Patterns @("tests/error_handling/*.esk") -FailRegex "^FAIL:|Failed:\s+[1-9]"
         $suiteResults += Invoke-SimpleCompileRunSuite -SuiteName "macros" -Title "Eshkol Macros Tests" -Patterns @("tests/macros/*.esk") -FailRegex "^FAIL:|Failed:\s+[1-9]"
         $suiteResults += Invoke-ReplSuite
@@ -1619,7 +1619,7 @@ switch ($Mode) {
         $suiteResults += Invoke-XlaSuite
     }
     "gpu" {
-        $suiteResults += Invoke-SimpleCompileRunSuite -SuiteName "gpu" -Title "Eshkol GPU Test Suite" -Patterns @("tests/gpu/*.esk") -FailRegex "^FAIL:|Failed:\s+[1-9]"
+        $suiteResults += Invoke-SimpleCompileRunSuite -SuiteName "gpu" -Title "Eshkol GPU Test Suite" -Patterns @("tests/gpu/*.esk") -FailRegex "^FAIL:|Failed:\s+[1-9]" -ExcludeNames @("ozaki_certification_test.esk")
     }
     "windows-lite" {
         # This mode is intentionally a bounded hosted-runner smoke suite.

--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -49,6 +49,10 @@ echo ""
 # Run each test
 for test_file in tests/gpu/*.esk; do
     test_name=$(basename "$test_file")
+    if [ "$test_name" = "ozaki_certification_test.esk" ]; then
+        echo -e "${YELLOW}SKIP: Metal-only ozaki certification fixture${NC}"
+        continue
+    fi
     printf "Testing %-50s " "$test_name"
 
     # Clean up stale temp files before each test

--- a/tests/gpu/ozaki_certification_gate.sh
+++ b/tests/gpu/ozaki_certification_gate.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -u
+cd "$(dirname "$0")/../.."
+REPO_ROOT="$(pwd)"
+TEST_ESK="$REPO_ROOT/tests/gpu/ozaki_certification_test.esk"
+TRACE_DIR="$REPO_ROOT/scripts/icc_traces"
+TRACE_FILE="$TRACE_DIR/ozaki_certification.jsonl"
+
+emit_trace() { # emit_trace <value> <reason>
+    local value="$1"
+    local reason="$2"
+    mkdir -p "$TRACE_DIR"
+    local snippet
+    if command -v python3 >/dev/null 2>&1; then
+        snippet="$(printf '%s' "$reason" | python3 -c 'import json,sys; sys.stdout.write(json.dumps(sys.stdin.read()))')"
+    else
+        snippet="$(printf '%s' "$reason" | sed -e 's/\\/\\\\/g' -e 's/"/\\\"/g')"
+        snippet="\"$snippet\""
+    fi
+    printf '{"kind":"ozaki_certification","name":"ozaki_certification_gate","value":"%s","confidence":0.95,"snippet":%s}\n' \
+        "$value" "$snippet" >> "$TRACE_FILE"
+}
+
+log() { printf '%s\n' "$*"; }
+skip() { log "SKIP: $*"; exit 0; }
+fail() { log "FAIL: $*"; emit_trace FAIL "$*"; exit 1; }
+pass() { log "PASS: $*"; emit_trace PASS "$*"; exit 0; }
+
+UNAME_S="$(uname -s)"
+[ "$UNAME_S" = "Darwin" ] || skip "Ozaki certification requires macOS/Metal"
+
+BIN="${ESHKOL_RUN:-}"
+if [ -z "$BIN" ]; then
+    for d in build-ozaki build build-gpu-gate build-*; do
+        if [ -x "$REPO_ROOT/$d/eshkol-run" ]; then
+            BIN="$REPO_ROOT/$d/eshkol-run"
+            break
+        fi
+    done
+fi
+[ -n "$BIN" ] && [ -x "$BIN" ] || skip "no eshkol-run binary found (set ESHKOL_RUN)"
+log "using eshkol-run: $BIN"
+
+if ! command -v otool >/dev/null 2>&1; then
+    fail "otool unavailable in PATH"
+fi
+
+otool -L "$BIN" | grep -q '/Accelerate\.framework/' || fail "eshkol-run is not linked against Accelerate"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-ozaki-certification.XXXXXX")"
+cleanup_tmp() {
+    if [ -n "${TMP_DIR:-}" ] && [ -d "$TMP_DIR" ]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+trap cleanup_tmp EXIT
+JIT_CACHE_BLAS_DIR="$TMP_DIR/jit-cache-blas"
+JIT_CACHE_EXACT_DIR="$TMP_DIR/jit-cache-exact"
+mkdir -p "$JIT_CACHE_BLAS_DIR" "$JIT_CACHE_EXACT_DIR"
+
+AOT_BIN="$TMP_DIR/ozaki_certification_aot"
+"$BIN" "$TEST_ESK" -o "$AOT_BIN"
+aot_compile_rc=$?
+[ "$aot_compile_rc" -eq 0 ] || fail "AOT compilation exited with status $aot_compile_rc"
+[ -x "$AOT_BIN" ] || fail "AOT binary missing or not executable: $AOT_BIN"
+otool -L "$AOT_BIN" | grep -q '/Accelerate\.framework/' || fail "AOT binary is not linked against Accelerate"
+
+# -r exercises the default cached-object path; use separate JIT cache dirs per mode so
+# BLAS and exact lanes compile/execute independently but remain cached-path true.
+BLAS_ENV=(
+  ESHKOL_OZAKI_CERT_MODE=blas
+  ESHKOL_GPU_MATMUL_THRESHOLD=999999999999
+  ESHKOL_GPU_THRESHOLD=999999999999
+  ESHKOL_GPU_VERBOSE=1
+  ESHKOL_JIT_CACHE_DIR="$JIT_CACHE_BLAS_DIR"
+)
+
+EXACT_ENV=(
+  ESHKOL_OZAKI_CERT_MODE=exact
+  ESHKOL_GPU_MATMUL_THRESHOLD=0
+  ESHKOL_GPU_THRESHOLD=1
+  ESHKOL_GPU_VERBOSE=1
+  ESHKOL_BLAS_PEAK_GFLOPS=0.001
+  ESHKOL_GPU_PEAK_GFLOPS=1000000
+  ESHKOL_GPU_WAIT_TIMEOUT=300
+  ESHKOL_SF64_KERNEL=ozaki
+  ESHKOL_OZAKI_NUM_MODULI=16
+  ESHKOL_OZAKI_ADAPTIVE=0
+  ESHKOL_JIT_CACHE_DIR="$JIT_CACHE_EXACT_DIR"
+)
+
+BLAS_SUMMARY_RE='^SUMMARY mode=blas total_samples=25 mismatches=[1-9][0-9]* max_dot_bits=58 verdict=PASS$'
+EXACT_SUMMARY_RE='^SUMMARY mode=exact total_samples=25 mismatches=0 max_dot_bits=58 verdict=PASS$'
+INIT_LINE_RE='^\[GPU\] Ozaki-II: N=16 moduli, log2\(P\)='
+DISPATCH_LINE_RE='^\[GPU\] Ozaki-II: N=16, log2\(P\)='
+REJECT_DISPATCH_RE='^\[GPU\] Ozaki-II: N=[0-9]+( \(adaptive\))?, log2\(P\)='
+REJECT_FALLBACK='matmul dispatch failed, falling back to CPU BLAS'
+
+RUN_COUNTER=0
+RUN_OUT=""
+RUN_ERR=""
+RUN_RC=0
+run_case() {  # run_case <label> <env-array-name> <cmd...>
+    local label="$1"
+    local env_name="$2"
+    shift 2
+    local env_cmd=()
+    case "$env_name" in
+        BLAS_ENV) env_cmd=("${BLAS_ENV[@]}") ;;
+        EXACT_ENV) env_cmd=("${EXACT_ENV[@]}") ;;
+        *) fail "unknown env array: $env_name" ;;
+    esac
+
+    RUN_COUNTER=$((RUN_COUNTER + 1))
+    RUN_OUT="$TMP_DIR/ozaki-certification-run-${RUN_COUNTER}.out"
+    RUN_ERR="$TMP_DIR/ozaki-certification-run-${RUN_COUNTER}.err"
+
+    env "${env_cmd[@]}" "$@" >"$RUN_OUT" 2>"$RUN_ERR"
+    RUN_RC=$?
+
+    log "--- $label stdout ---"
+    cat "$RUN_OUT"
+    log "--- $label stderr ---"
+    cat "$RUN_ERR"
+}
+
+extract_mismatches() { # extract_mismatches <summary-line>
+    printf '%s\n' "$1" | sed -nE 's/^SUMMARY mode=[a-z]+ total_samples=25 mismatches=([0-9]+) .*/\1/p'
+}
+
+run_case "JIT BLAS" BLAS_ENV "$BIN" -r "$TEST_ESK"
+BLAS_JIT_RC="$RUN_RC"
+BLAS_JIT_SUMMARY="$(cat "$RUN_OUT")"
+BLAS_JIT_ERR="$RUN_ERR"
+[ "$BLAS_JIT_RC" -eq 0 ] || fail "JIT BLAS execution failed with status $BLAS_JIT_RC"
+printf '%s\n' "$BLAS_JIT_SUMMARY" | grep -qE "$BLAS_SUMMARY_RE" || fail "JIT BLAS summary did not match expected Accelerate mismatch contract"
+BLAS_JIT_MISMATCHES="$(extract_mismatches "$BLAS_JIT_SUMMARY")"
+[ -n "$BLAS_JIT_MISMATCHES" ] || fail "JIT BLAS summary missing mismatch count"
+[ "$BLAS_JIT_MISMATCHES" -gt 0 ] || fail "JIT BLAS mismatches must be > 0"
+grep -Eq "$REJECT_DISPATCH_RE" "$BLAS_JIT_ERR" && fail "JIT BLAS execution printed forbidden Ozaki-II real dispatch line"
+grep -Fq "$REJECT_FALLBACK" "$BLAS_JIT_ERR" && fail "JIT BLAS execution fell back to CPU BLAS"
+
+run_case "AOT BLAS" BLAS_ENV "$AOT_BIN"
+BLAS_AOT_RC="$RUN_RC"
+BLAS_AOT_SUMMARY="$(cat "$RUN_OUT")"
+BLAS_AOT_ERR="$RUN_ERR"
+[ "$BLAS_AOT_RC" -eq 0 ] || fail "AOT BLAS execution failed with status $BLAS_AOT_RC"
+printf '%s\n' "$BLAS_AOT_SUMMARY" | grep -qE "$BLAS_SUMMARY_RE" || fail "AOT BLAS summary did not match expected Accelerate mismatch contract"
+BLAS_AOT_MISMATCHES="$(extract_mismatches "$BLAS_AOT_SUMMARY")"
+[ -n "$BLAS_AOT_MISMATCHES" ] || fail "AOT BLAS summary missing mismatch count"
+[ "$BLAS_AOT_MISMATCHES" -gt 0 ] || fail "AOT BLAS mismatches must be > 0"
+grep -Eq "$REJECT_DISPATCH_RE" "$BLAS_AOT_ERR" && fail "AOT BLAS execution printed forbidden Ozaki-II real dispatch line"
+grep -Fq "$REJECT_FALLBACK" "$BLAS_AOT_ERR" && fail "AOT BLAS execution fell back to CPU BLAS"
+
+run_case "JIT EXACT" EXACT_ENV "$BIN" -r "$TEST_ESK"
+EXACT_JIT_RC="$RUN_RC"
+EXACT_JIT_SUMMARY="$(cat "$RUN_OUT")"
+EXACT_JIT_ERR="$RUN_ERR"
+[ "$EXACT_JIT_RC" -eq 0 ] || fail "JIT exact execution failed with status $EXACT_JIT_RC"
+printf '%s\n' "$EXACT_JIT_SUMMARY" | grep -qE "$EXACT_SUMMARY_RE" || fail "JIT exact summary was incorrect"
+[ "$(grep -cE "$INIT_LINE_RE" "$EXACT_JIT_ERR")" -eq 1 ] || fail "JIT exact stderr must contain exactly one init line"
+[ "$(grep -cE "$DISPATCH_LINE_RE" "$EXACT_JIT_ERR")" -eq 1 ] || fail "JIT exact stderr must contain exactly one dispatch line"
+grep -E '^\[GPU\] Ozaki-II:' "$EXACT_JIT_ERR" | grep -Ev "$INIT_LINE_RE|$DISPATCH_LINE_RE" >/dev/null && fail "JIT exact stderr contains unexpected Ozaki-II lines"
+grep -Fq "$REJECT_FALLBACK" "$EXACT_JIT_ERR" && fail "JIT exact execution fell back to CPU BLAS"
+
+run_case "AOT EXACT" EXACT_ENV "$AOT_BIN"
+EXACT_AOT_RC="$RUN_RC"
+EXACT_AOT_SUMMARY="$(cat "$RUN_OUT")"
+EXACT_AOT_ERR="$RUN_ERR"
+[ "$EXACT_AOT_RC" -eq 0 ] || fail "AOT exact execution failed with status $EXACT_AOT_RC"
+printf '%s\n' "$EXACT_AOT_SUMMARY" | grep -qE "$EXACT_SUMMARY_RE" || fail "AOT exact summary was incorrect"
+[ "$(grep -cE "$INIT_LINE_RE" "$EXACT_AOT_ERR")" -eq 1 ] || fail "AOT exact stderr must contain exactly one init line"
+[ "$(grep -cE "$DISPATCH_LINE_RE" "$EXACT_AOT_ERR")" -eq 1 ] || fail "AOT exact stderr must contain exactly one dispatch line"
+grep -E '^\[GPU\] Ozaki-II:' "$EXACT_AOT_ERR" | grep -Ev "$INIT_LINE_RE|$DISPATCH_LINE_RE" >/dev/null && fail "AOT exact stderr contains unexpected Ozaki-II lines"
+grep -Fq "$REJECT_FALLBACK" "$EXACT_AOT_ERR" && fail "AOT exact execution fell back to CPU BLAS"
+
+pass "JIT and AOT both prove Accelerate mismatch>0 in BLAS mode (JIT:$BLAS_JIT_MISMATCHES AOT:$BLAS_AOT_MISMATCHES) and fixed-N16 Metal exact mismatch=0"

--- a/tests/gpu/ozaki_certification_test.esk
+++ b/tests/gpu/ozaki_certification_test.esk
@@ -1,0 +1,115 @@
+;; tests/gpu/ozaki_certification_test.esk — Metal exact Ozaki certificate witness.
+;;
+;; This fixture uses a single deterministic 512x512 problem with integer-valued
+;; f64 matrices (explicitly built from `i128` then converted with
+;; `exact->inexact`) to make every controlled conversion visible. Entries are
+;; bounded by 16,777,472, so each 512-term dot-product is < 2^58.
+;;
+;; There are two execution modes (selected by `ESHKOL_OZAKI_CERT_MODE`):
+;; - exact (default): force Metal exact Ozaki and require every sampled cell to
+;;   match an independent native i128 reference.
+;; - blas: force the CPU BLAS/CPU fallback path and require at least one sampled
+;;   mismatch against the same i128 oracle on the identical input.
+
+(define N 512)
+(define K 512)
+(define SIZE (* N N))
+(define max-dot-bits 58)
+
+(define sample-points (vector 0 128 256 384 511))
+(define sample-count 5)
+(define total-samples 25)
+
+(define mode (or (getenv "ESHKOL_OZAKI_CERT_MODE") "exact"))
+(define is-exact? (string=? mode "exact"))
+(define is-blas? (string=? mode "blas"))
+
+(define (sample-point idx)
+  (vector-ref sample-points idx))
+
+(define (a-value row col)
+  (let* ((mag (+ 16777216 (modulo (+ (* row 97) (* col 53)) 257)))
+         (sign (if (= (modulo (+ (* row 131) (* col 13)) 2) 0) 1 -1)))
+    (* sign mag)))
+
+(define (b-value row col)
+  (let* ((mag (+ 16777216 (modulo (+ (* row 71) (* col 29) (* row col)) 257)))
+         (sign (if (= (modulo (+ (* row 73) (* col 23)) 2) 0) 1 -1)))
+    (* sign mag)))
+
+(define Ad (make-vector SIZE 0.0))
+(define Bd (make-vector SIZE 0.0))
+(define Ai (make-vector SIZE (i128 0)))
+(define Bi (make-vector SIZE (i128 0)))
+
+;; Populate top-level vectors first (#309 posture): matrix assembly + tensor-data are
+;; deterministic and live at top level.
+(do ((idx 0 (+ idx 1)))
+    ((>= idx SIZE))
+  (let* ((r (quotient idx N))
+         (c (modulo idx N))
+         (av (a-value r c))
+         (bv (b-value r c)))
+    (vector-set! Ad idx (exact->inexact av))
+    (vector-set! Bd idx (exact->inexact bv))
+    (vector-set! Ai idx (i128 av))
+    (vector-set! Bi idx (i128 bv))))
+
+;; Real matmul + plain-vector read exactly once at top-level (single tensor-data touch).
+(define A (reshape Ad N K))
+(define B (reshape Bd K N))
+(define C (matmul A B))
+(define Cd (tensor-data C))
+
+(define total-fail 0)
+
+(define (sample-ref row col)
+  ;; Independent reference in native i128 arithmetic only.
+  (let ((acc (i128 0)))
+    (do ((k 0 (+ k 1)))
+        ((>= k K) acc)
+      (set! acc
+            (i128-add acc
+                      (i128-mul (vector-ref Ai (+ (* row K) k))
+                                (vector-ref Bi (+ (* k N) col))))))))
+
+(define (check-sample row col)
+  (let* ((idx (+ (* row N) col))
+         (ref (sample-ref row col))
+         ;; Expected is computed with the required exact cast path.
+         (expected (exact->inexact (i128->int ref)))
+         (got (vector-ref Cd idx)))
+    (if (not (= got expected))
+        (begin
+          (set! total-fail (+ total-fail 1))
+          (display "MISMATCH row=") (display row)
+          (display " col=") (display col)
+          (display " ref(i128)=") (display ref)
+          (display " got(f64)=") (display got)
+          (display " expected(f64)=") (display expected)
+          (display "\n")))))
+
+(do ((ri 0 (+ ri 1)))
+    ((>= ri sample-count))
+  (let ((r (sample-point ri)))
+    (do ((ci 0 (+ ci 1)))
+        ((>= ci sample-count))
+      (let ((c (sample-point ci)))
+        (check-sample r c)))))
+
+;; K=512 and |entry| <= 16,777,472 imply signed dot magnitude < 2^58.
+(define mode-ok?
+  (or (and is-blas? (> total-fail 0))
+      (and is-exact? (= total-fail 0))))
+
+(define verdict (if mode-ok? "PASS" "FAIL"))
+(display "SUMMARY mode=") (display mode)
+(display " total_samples=") (display total-samples)
+(display " mismatches=") (display total-fail)
+(display " max_dot_bits=") (display max-dot-bits)
+(display " verdict=") (display verdict)
+(display "\n")
+
+(if mode-ok?
+    (exit 0)
+    (exit 1))


### PR DESCRIPTION
## Summary

- add a deterministic 512x512 integer-valued f64 witness with an independent native-i128 sampled reference (`|dot| < 2^58`)
- add a real-Metal certification gate covering default cached JIT and AOT: Apple Accelerate must disagree on at least one identical-input sample, while fixed-N16 exact Ozaki must match every sample with genuine dispatch markers and no CPU fallback
- register the high-severity `ozaki-certification` ICC oracle and document the opt-in correctness witness without changing default dispatch or making a performance claim

## Verification

- `bash -n tests/gpu/ozaki_certification_gate.sh`
- real Metal certification: PASS (Accelerate mismatches JIT=23, AOT=23; fixed-N16 Ozaki mismatches JIT=0, AOT=0)
- `tests/gpu/ozaki_correctness_gate.sh`: PASS across integer/fractional/pi-e/wide regimes through K=4096
- `tests/gpu/ozaki_fast_gate.sh`: PASS across all 16 existing regimes
- full CTest: 87/87 PASS
- ICC completion oracle: complete; readiness: 100 with both configured trace routes
- YAML parse, unknown-mode negative contract, `git diff --check`, and exact four-path audit: PASS

Non-Metal hosts exit successfully without emitting false PASS evidence; Atlas executes the hardware verdict.
