### PR TITLE
feat(types): linear Qubit type + enforce linear params in define (Phase 6)

### DIFF
--- a/inc/eshkol/types/hott_types.h
+++ b/inc/eshkol/types/hott_types.h
@@ -251,6 +251,11 @@ namespace BuiltinTypes {
     inline constexpr TypeId Buffer{111, Universe::U1, 0};
     inline constexpr TypeId Stream{112, Universe::U1, TYPE_FLAG_LINEAR};
 
+    // Quantum qubit — a linear resource: the no-cloning theorem as a type.
+    // Runtime is an integer index into a Moonlab state; the type system forbids
+    // using a qubit more than once (a clone) just like Handle/Stream.
+    inline constexpr TypeId Qubit{113, Universe::U0, TYPE_FLAG_LINEAR};
+
     // Proposition types (U2, Proof - erased at runtime)
     inline constexpr TypeId Eq{200, Universe::U2, TYPE_FLAG_PROOF};
     inline constexpr TypeId LessThan{201, Universe::U2, TYPE_FLAG_PROOF};

--- a/lib/types/hott_types.cpp
+++ b/lib/types/hott_types.cpp
@@ -212,6 +212,11 @@ void TypeEnvironment::initializeBuiltinTypes() {
                        RuntimeRep::Pointer);
     types_[Stream.id].id.flags |= TYPE_FLAG_LINEAR;
 
+    // Qubit — a linear quantum resource (no-cloning). Runtime is an integer
+    // index into a Moonlab state; the type system forbids using it twice.
+    registerBuiltinType(Qubit.id, "Qubit", Universe::U0, TYPE_FLAG_LINEAR,
+                        RuntimeRep::Int64);
+
     // ===== Proposition types (U2, Proof - erased at runtime) =====
     registerBuiltinType(Eq.id, "Eq", Universe::U2, TYPE_FLAG_PROOF,
                         RuntimeRep::Erased);

--- a/lib/types/type_checker.cpp
+++ b/lib/types/type_checker.cpp
@@ -2737,7 +2737,12 @@ TypeCheckResult TypeChecker::synthesizeDefine(eshkol_ast_t* expr) {
         for (size_t i = 0; i < def.num_params; i++) {
             if (def.parameters && def.parameters[i].type == ESHKOL_VAR &&
                 def.parameters[i].variable.id) {
-                ctx_.bind(def.parameters[i].variable.id, param_types[i]);
+                // Register linear parameters for use-once checking
+                if (param_types[i].flags & TYPE_FLAG_LINEAR) {
+                    ctx_.bindLinear(def.parameters[i].variable.id, param_types[i]);
+                } else {
+                    ctx_.bind(def.parameters[i].variable.id, param_types[i]);
+                }
             }
         }
 
@@ -2754,6 +2759,16 @@ TypeCheckResult TypeChecker::synthesizeDefine(eshkol_ast_t* expr) {
                 def.parameters[i].variable.id) {
                 auto narrowed = ctx_.lookup(def.parameters[i].variable.id);
                 narrowed_param_types.push_back(narrowed ? *narrowed : param_types[i]);
+            }
+        }
+
+        // Check linear variable constraints before popping scope
+        if (!ctx_.checkLinearConstraints()) {
+            for (const auto& name : ctx_.getUnusedLinear()) {
+                reportTypeIssue("linear variable '" + name + "' was not consumed", expr);
+            }
+            for (const auto& name : ctx_.getOverusedLinear()) {
+                reportTypeIssue("linear variable '" + name + "' was consumed more than once", expr);
             }
         }
 

--- a/tests/typesystem/qubit_linear_valid_test.esk
+++ b/tests/typesystem/qubit_linear_valid_test.esk
@@ -1,0 +1,12 @@
+;; Type System Test: a qubit threaded through gates (used once) type-checks clean
+;; EXPECT-MODE: strict-types
+;; EXPECT-NO-STDERR: consumed more than once
+;; EXPECT-NO-STDERR: was not consumed
+
+;; A single-qubit gate consumes a qubit and yields a fresh one. Threading each
+;; qubit through gates, using it exactly once, is linearly valid — no cloning,
+;; no dropping — so it type-checks with no linearity errors even in strict mode.
+(define (h (q : Qubit)) : Qubit q)
+
+(define (circuit (q : Qubit)) : Qubit
+  (h (h q)))

--- a/tests/typesystem/qubit_no_cloning_test.esk
+++ b/tests/typesystem/qubit_no_cloning_test.esk
@@ -1,0 +1,9 @@
+;; Type System Test: a qubit is linear — cloning it is rejected (no-cloning)
+;; EXPECT-MODE: strict-types
+;; EXPECT-STDERR: linear variable 'q' was consumed more than once
+
+;; The Qubit type carries TYPE_FLAG_LINEAR: a qubit must be used exactly once.
+;; Passing the same qubit to both inputs of a two-qubit gate is a clone, which
+;; the no-cloning theorem forbids — caught here at compile time.
+(define (bad-clone (q : Qubit))
+  (cons q q))          ; q used twice -> no-cloning violation


### PR DESCRIPTION
## Summary

Adds a `Qubit` builtin type flagged `TYPE_FLAG_LINEAR` (alongside `Handle` /
`Stream`) — the no-cloning theorem as a type: a qubit must be used exactly once.

While wiring it up I found that Phase 6 linear-parameter checking was **inert for
defined functions**, and this PR fixes that too. `synthesizeLambda` binds linear
params and runs `checkLinearConstraints()`, but `synthesizeDefine` — the path
every top-level `(define (f …) …)` takes — did neither. So no `define`d function
enforced linearity (not `Qubit`, not `Handle`, not `Stream`). `synthesizeDefine`
now mirrors `synthesizeLambda`.

Addresses the roadmap item **"Qubit type with linear resource tracking (no-cloning
enforced at compile time)"** (`ROADMAP.md`), as a plain-linear first cut.

## Behavior

```scheme
;; rejected — q used twice (a clone)
(define (bad-clone (q : Qubit)) (cons q q))
;; -> linear variable 'q' was consumed more than once

;; clean — each qubit threaded through gates, used exactly once
(define (h (q : Qubit)) : Qubit q)
(define (circuit (q : Qubit)) : Qubit (h (h q)))
```

Under `--strict-types` these are hard type errors; in gradual mode they are
warnings, consistent with the rest of the type checker.

## Changes (47 insertions, 1 deletion)

- `inc/eshkol/types/hott_types.h`, `lib/types/hott_types.cpp` — register `Qubit`
  (U0, `TYPE_FLAG_LINEAR`, runtime rep `Int64`), following the `Handle`/`Stream`
  pattern.
- `lib/types/type_checker.cpp` — `synthesizeDefine` now binds linear params with
  `bindLinear` and runs `checkLinearConstraints()` before popping the scope,
  reusing the exact logic and comments from `synthesizeLambda`.
- `tests/typesystem/qubit_no_cloning_test.esk` — clone rejected (`EXPECT-STDERR`).
- `tests/typesystem/qubit_linear_valid_test.esk` — valid threading type-checks
  clean (`EXPECT-NO-STDERR`).

## Testing

```sh
bash scripts/run_typesystem_tests.sh
```

Both new tests pass. Verified against LLVM 21 with `-DESHKOL_QUANTUM_ENABLED=ON`;
the existing quantum lane (`tests/quantum/`, Moonlab) is unaffected
(`bell_chsh_test` still S≈2.82, `quantum_smoke_test` Bell 200/200).

## Notes for review (three things I found but did **not** change)

1. **`Handle`/`Stream` linear annotations are silently non-linear.**
   `registerTypeFamily` sets their flag on `types_[id]` *after* registration, but
   `name_to_id_` keeps the flag-less `TypeId`, so `resolveType("Handle")` loses
   `TYPE_FLAG_LINEAR`. Their linear checking never fired either (same
   `synthesizeDefine` gap + this). `Qubit` avoids it by registering the flag
   inline via `registerBuiltinType`. I did **not** fix `Handle`/`Stream` here:
   enabling their linearity could surface violations in existing code, so it's
   your call whether to do that in a follow-up.

2. **Externs don't carry HoTT types.** The extern type parser
   (`llvm_codegen.cpp`, "Unknown type … defaulting to int64") is separate from
   `resolveType`, so a gate primitive declared `(extern Qubit … Qubit …)` loses
   the `Qubit` type at the FFI boundary. Not needed for this PR (the check is on
   the caller's `(q : Qubit)` params), but relevant for a linear quantum stdlib.

3. **Severity is a design choice.** Linear-type violations follow the type
   checker's gradual policy (warn by default, error under `--strict-types`),
   whereas ownership violations (use-after-move) are *always* hard errors. If you
   want no-cloning enforced regardless of `--strict-types`, that's a one-line
   escalation — happy to do it, but it's your policy call.

## Scope / non-goals

A linear quantum stdlib (gate primitives threading `Qubit` values, running on
Moonlab) is a natural follow-up and needs (2) above; this PR is just the type +
the enforcement + tests. Does not touch `Handle`/`Stream`.
