### PR TITLE
Guard matmul tensor reads inside a defined function (#309)

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -179,6 +179,13 @@ oracles:
         severity: high
         label: 'linear-solve: mixed-precision iterative-refinement dense solver reaches full-f64 backward residual (<=1e-12, computed independently) on well-conditioned/identity systems and raises catchably on singular/dimension-mismatch — verified on JIT, AOT, and the VM'
         action: ./scripts/run_icc_smoke.sh
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["matmul_tensor_read_scope_oracle"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'matmul-tensor scope (#309): a matmul result read via tensor-ref/tensor-data from inside a defined function (captured global, argument, in-function matmul, nested define, closure, with-region escape, large GPU/BLAS-dispatched matmul) returns the same data as a top-level read — never silent zeros; verified on JIT and AOT'
+        action: ./scripts/run_icc_smoke.sh
 
   # ─────────────────────────────────────────────────────────────────
   # TOTAL-LANGUAGE completion — unlike the compiler-readiness ratchet above,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **matmul tensor reads inside a defined function (#309) — verified resolved
+  and now guarded.** #309 reported that a `matmul` result read back via
+  `tensor-ref`/`tensor-data` from inside a `define`d function returned zeros,
+  while only top-level reads were correct. The symptom was a mis-attribution of
+  the Ozaki-II CRT-overflow/precision defect fixed in #307 (above): once #307
+  landed, in-function reads return the identical correct data as top-level
+  reads. This was reconfirmed by rebuilding at the #307 merge commit and at
+  current master — the tensor read + arena + matmul codegen/runtime path is
+  byte-identical between them — and exercised on JIT, AOT and the forced-GPU
+  Ozaki path across captured-global / argument / in-function-matmul /
+  nested-define / closure-capture / `with-region`-escape / large
+  (GPU/BLAS-dispatched) forms; every in-function read matched the top-level
+  read. Adds `tests/tensor/matmul_read_in_define_test.esk`
+  (`matmul_read_in_define_jit_smoke` + `matmul_read_in_define_aot_smoke` CTests)
+  and the `matmul_tensor_read_scope_oracle` ICC gate so the scope contract can
+  never silently regress, and retires the defensive "read only at top level"
+  work-around comments in the Ozaki correctness/certification fixtures.
 - **Ozaki-II exact DGEMM correctness (Metal).** The opt-in CRT matmul
   (`ESHKOL_SF64_KERNEL=ozaki`) silently produced 5-30% numerical errors on any
   non-integer input, and returned NaN/garbage when asked for more than 16

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2834,6 +2834,31 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
     )
     set_tests_properties(tensor_integer_shaped_literal_runtime_smoke
         PROPERTIES PASS_REGULAR_EXPRESSION "#\\(\\(1 2\\) \\(3 4\\)\\)")
+    # #309 regression guard: a matmul result read via tensor-ref/tensor-data
+    # from INSIDE a defined function (captured global, argument, in-function
+    # matmul, nested define, closure, with-region escape, and a large
+    # GPU/BLAS-dispatched matmul) must return the SAME values as a top-level
+    # read — never zeros. Verified on both -r (JIT) and AOT.
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/tensor/matmul_read_in_define_test.esk")
+        add_test(
+            NAME matmul_read_in_define_jit_smoke
+            COMMAND $<TARGET_FILE:eshkol-run> -r
+                    "${CMAKE_CURRENT_SOURCE_DIR}/tests/tensor/matmul_read_in_define_test.esk"
+        )
+        set_tests_properties(matmul_read_in_define_jit_smoke PROPERTIES
+            TIMEOUT 120
+            PASS_REGULAR_EXPRESSION "PASS: matmul tensor reads inside defined functions match top-level"
+            FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
+        add_test(
+            NAME matmul_read_in_define_aot_smoke
+            COMMAND sh -c
+                "'$<TARGET_FILE:eshkol-run>' -o '${CMAKE_CURRENT_BINARY_DIR}/matmul_read_in_define_aot' '${CMAKE_CURRENT_SOURCE_DIR}/tests/tensor/matmul_read_in_define_test.esk' && '${CMAKE_CURRENT_BINARY_DIR}/matmul_read_in_define_aot'"
+        )
+        set_tests_properties(matmul_read_in_define_aot_smoke PROPERTIES
+            TIMEOUT 180
+            PASS_REGULAR_EXPRESSION "PASS: matmul tensor reads inside defined functions match top-level"
+            FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
+    endif()
     add_test(
         NAME autodiff_tensor_reductions_runtime_smoke
         COMMAND $<TARGET_FILE:eshkol-run>

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -515,6 +515,18 @@ probe linear_solve_full_f64_oracle 'linear-solve: mixed-precision IR dense solve
      fi;
      exit 0'
 
+probe matmul_tensor_read_scope_oracle 'matmul-tensor scope (#309): a matmul result read via tensor-ref/tensor-data from INSIDE a defined function (captured global, argument, in-function matmul, nested define, closure, with-region escape, large GPU/BLAS-dispatched matmul) returns the SAME data as a top-level read — never zeros; verified on JIT and AOT' \
+    'cd "$REPO_ROOT"; t=tests/tensor/matmul_read_in_define_test.esk;
+     out=$("$ESHKOL_RUN" -r "$t" 2>/dev/null) || exit 1;
+     printf "%s" "$out" | grep -q "PASS: matmul tensor reads inside defined functions match top-level" || exit 1;
+     printf "%s" "$out" | grep -q "FAIL:" && exit 1;
+     bin=$(mktemp) || exit 1;
+     "$ESHKOL_RUN" "$t" -o "$bin" >/dev/null 2>&1 || { rm -f "$bin"; exit 1; };
+     out=$("$bin" 2>/dev/null); rc=$?; rm -f "$bin"; [ "$rc" -eq 0 ] || exit 1;
+     printf "%s" "$out" | grep -q "PASS: matmul tensor reads inside defined functions match top-level" || exit 1;
+     printf "%s" "$out" | grep -q "FAIL:" && exit 1;
+     exit 0'
+
 echo
 echo "Trace written: $TRACE_FILE"
 echo "Probe summary: $((PROBE_TOTAL - PROBE_FAILURES))/$PROBE_TOTAL passed"

--- a/tests/gpu/ozaki_certification_test.esk
+++ b/tests/gpu/ozaki_certification_test.esk
@@ -42,8 +42,11 @@
 (define Ai (make-vector SIZE (i128 0)))
 (define Bi (make-vector SIZE (i128 0)))
 
-;; Populate top-level vectors first (#309 posture): matrix assembly + tensor-data are
-;; deterministic and live at top level.
+;; Populate top-level vectors first: matrix assembly + tensor-data are
+;; deterministic and live at top level. (Historically framed as a "#309 posture"
+;; work-around; #309 — matmul tensor read inside a define reading zeros — was a
+;; mis-attribution of the #307 CRT defect and does not reproduce. In-function
+;; reads are guarded directly by tests/tensor/matmul_read_in_define_test.esk.)
 (do ((idx 0 (+ idx 1)))
     ((>= idx SIZE))
   (let* ((r (quotient idx N))

--- a/tests/gpu/ozaki_correctness_test.esk
+++ b/tests/gpu/ozaki_correctness_test.esk
@@ -17,9 +17,15 @@
 ;; consistent numerical error cannot hide.
 ;;
 ;; NOTE: the matmul and its `tensor-data` read are done at TOP-LEVEL scope and
-;; only PLAIN VECTORS are handed to the checker — reading a tensor produced by
-;; `matmul` from inside a `define`d function currently reads zeros (a separate
-;; compiler-scope issue), so the probe must not touch the tensor object itself.
+;; only PLAIN VECTORS are handed to the checker. This was originally a
+;; work-around for #309 ("matmul tensor read inside a define returns zeros"),
+;; which turned out to be a mis-attribution of the very CRT-overflow/precision
+;; defect this file fixes: once #307 landed, reading a matmul tensor via
+;; tensor-ref/tensor-data from inside a defined function returns the identical
+;; correct data as a top-level read (guarded directly by
+;; tests/tensor/matmul_read_in_define_test.esk on JIT+AOT). The top-level read
+;; is kept here purely so the correctness verdict cannot depend on `display`
+;; digit count — it is no longer a scope work-around.
 ;;
 ;; Verdict is decided here (integer relative-error threshold), so it does not
 ;; depend on how many digits `display` prints.

--- a/tests/tensor/matmul_read_in_define_test.esk
+++ b/tests/tensor/matmul_read_in_define_test.esk
@@ -1,0 +1,137 @@
+;; tests/tensor/matmul_read_in_define_test.esk — regression guard for #309.
+;;
+;; #309 reported that a `matmul` result read back via `tensor-ref`/`tensor-data`
+;; from INSIDE a `define`d function returned zeros, while only TOP-LEVEL reads
+;; returned correct data. That symptom was a mis-attribution of the Ozaki-II
+;; CRT-overflow/precision defect fixed in #307: once #307 landed, in-function
+;; reads return the identical correct data as top-level reads (verified on JIT,
+;; AOT, and the forced-GPU Ozaki path, at both the #307 merge and current master
+;; — the tensor read + arena + matmul codegen path is byte-identical between
+;; them). The Ozaki correctness/certification fixtures still carried a defensive
+;; "read the tensor only at top level, hand plain vectors to the checker"
+;; work-around; this test actively exercises the previously-avoided path so the
+;; work-around can be retired and any real regression of the scope contract turns
+;; the suite red instead of hiding behind a top-level read.
+;;
+;; Contract exercised: for a matmul result C, `(tensor-ref C i j)` and
+;; `(tensor-data C)` return the SAME values whether evaluated at top level or
+;; inside a defined function — as a captured global, as a passed argument, as a
+;; freshly-computed local, through a nested internal define, through a closure,
+;; and after escaping a `with-region`. Every read is compared against the exact
+;; expected product; ANY mismatch (a zero or otherwise) prints FAIL.
+;;
+;; Runs identically under `-r` (JIT) and AOT (compile + run).
+
+;; A (2x3) * B (3x2) = C (2x2):
+;;   A = [[0,1,2],[3,4,5]]  B = [[0,1],[2,3],[4,5]]
+;;   C = [[10,13],[28,40]]
+(define A (reshape (arange 6) 2 3))
+(define B (reshape (arange 6) 3 2))
+(define C (matmul A B))
+
+;; Expected reference values (independent of any tensor read).
+(define e00 10.0) (define e01 13.0) (define e10 28.0) (define e11 40.0)
+
+(define fails 0)
+(define (chk label got want)
+  (if (= got want)
+      (begin (display "  ok   ") (display label) (display " = ") (display got) (newline))
+      (begin
+        (set! fails (+ fails 1))
+        (display "  FAIL ") (display label)
+        (display " got=") (display got) (display " want=") (display want) (newline))))
+
+;; Ground truth: TOP-LEVEL reads (the path #309 said was the only correct one).
+(display "top-level reads:") (newline)
+(chk "top tensor-ref[0][0]" (tensor-ref C 0 0) e00)
+(chk "top tensor-ref[1][1]" (tensor-ref C 1 1) e11)
+(let ((cd (tensor-data C)))
+  (chk "top tensor-data[0]" (vector-ref cd 0) e00)
+  (chk "top tensor-data[3]" (vector-ref cd 3) e11))
+
+;; (1) matmul result read inside a define, captured as a GLOBAL.
+(display "read inside define (captured global):") (newline)
+(define (g-ref) (tensor-ref C 0 1))
+(define (g-data-mid) (vector-ref (tensor-data C) 2))
+(chk "global tensor-ref[0][1]" (g-ref) e01)
+(chk "global tensor-data[2]" (g-data-mid) e10)
+
+;; (2) matmul result PASSED as an argument, read inside the callee.
+(display "read inside define (argument):") (newline)
+(define (a-ref t i j) (tensor-ref t i j))
+(define (a-data-first t) (vector-ref (tensor-data t) 0))
+(chk "arg tensor-ref[1][0]" (a-ref C 1 0) e10)
+(chk "arg tensor-data[0]" (a-data-first C) e00)
+
+;; (3) matmul COMPUTED and read inside the same defined function.
+(display "matmul + read inside the same define:") (newline)
+(define (local-ref) (let ((c (matmul A B))) (tensor-ref c 1 1)))
+(define (local-data) (let ((c (matmul A B))) (vector-ref (tensor-data c) 1)))
+(chk "local tensor-ref[1][1]" (local-ref) e11)
+(chk "local tensor-data[1]" (local-data) e01)
+
+;; (3b) matmul as a DIRECT argument to the reader (no let binding).
+(chk "direct tensor-ref[0][0]" ((lambda () (tensor-ref (matmul A B) 0 0))) e00)
+
+;; (4) NESTED internal define reading the captured result.
+(display "nested internal define:") (newline)
+(define (outer)
+  (let ((c (matmul A B)))
+    (define (inner) (tensor-ref c 1 0))
+    (inner)))
+(chk "nested tensor-ref[1][0]" (outer) e10)
+
+;; (5) CLOSURE capturing a matmul result, read when later invoked.
+(display "closure capture:") (newline)
+(define (make-reader)
+  (let ((c (matmul A B)))
+    (lambda () (tensor-ref c 0 1))))
+(define reader (make-reader))
+(chk "closure tensor-ref[0][1]" (reader) e01)
+
+;; (6) matmul result ESCAPING a with-region, read afterwards (deep-evac path).
+(display "with-region escape:") (newline)
+(define escaped 0)
+(with-region
+  (set! escaped (matmul A B)))
+(define (esc-ref) (tensor-ref escaped 1 1))
+(chk "escaped tensor-ref[1][1]" (esc-ref) e11)
+(chk "escaped tensor-data[0]" (vector-ref (tensor-data escaped) 0) e00)
+
+;; (7) Larger matmul (routes through the GPU/BLAS dispatch), read inside a
+;; define at a few probe positions against an independent scalar reference.
+(display "large matmul read inside define:") (newline)
+(define NN 64)
+(define szz (* NN NN))
+(define Ad (make-vector szz 0.0))
+(define Bd (make-vector szz 0.0))
+(do ((i 0 (+ i 1))) ((>= i szz))
+  (vector-set! Ad i (+ 1.0 (* 0.5 (exact->inexact (modulo i 7)))))
+  (vector-set! Bd i (+ 0.5 (* 0.25 (exact->inexact (modulo i 5))))))
+(define AL (reshape Ad NN NN))
+(define BL (reshape Bd NN NN))
+(define CL (matmul AL BL))
+(define (probe-in-fn ii jj)
+  ;; touch the tensor object inside a defined function (the #309-avoided path)
+  (let ((got (tensor-ref CL ii jj))
+        (ref 0.0))
+    (do ((k 0 (+ k 1))) ((>= k NN))
+      (set! ref (+ ref (* (vector-ref Ad (+ (* ii NN) k))
+                          (vector-ref Bd (+ (* k NN) jj))))))
+    (let ((rel (/ (abs (- got ref)) (if (> (abs ref) 1e-9) (abs ref) 1.0))))
+      (if (< rel 1e-9)
+          (begin (display "  ok   large[") (display ii) (display "][") (display jj)
+                 (display "] rel<1e-9") (newline))
+          (begin (set! fails (+ fails 1))
+                 (display "  FAIL large[") (display ii) (display "][") (display jj)
+                 (display "] got=") (display got) (display " ref=") (display ref) (newline))))))
+(probe-in-fn 0 0)
+(probe-in-fn 31 31)
+(probe-in-fn 63 63)
+(probe-in-fn 17 48)
+
+(newline)
+(if (= fails 0)
+    (begin (display "PASS: matmul tensor reads inside defined functions match top-level (#309)") (newline))
+    (begin (display "FAIL: ") (display fails)
+           (display " in-function matmul read(s) diverged from top-level (#309 regression)") (newline)))


### PR DESCRIPTION
## Summary

#309 reported that a `matmul` result read back via `tensor-ref`/`tensor-data`
from **inside a `define`d function** returned zeros, while only **top-level**
reads returned correct data. It surfaced during the Ozaki-II correctness work
(#307), whose test carried a work-around: do the matmul + `tensor-data` read at
top level and hand only plain vectors to the checker.

**Finding: the reported bug does not reproduce.** The "reads-zeros-inside-a-define"
symptom was a mis-attribution of the Ozaki-II CRT-overflow / precision-truncation
defect that **#307 itself fixed**. After #307, reading a matmul tensor from inside
a defined function returns the identical correct data as a top-level read. This PR
verifies that end-to-end and installs a permanent regression guard so the scope
contract can never silently regress, and retires the now-misleading work-around
comments.

This is **not a codegen change** — none was needed. It is a verification +
guard PR.

## Reproduction attempts (all correct, never zeros)

Ran the exact #309 shape and every adjacent form, on JIT (`-r`), AOT
(`-o`, at `-O0/-O2/-O3`), and the forced-GPU Ozaki path
(`ESHKOL_SF64_KERNEL=ozaki` + low dispatch threshold):

- matmul result read via `tensor-ref` **and** `tensor-data` inside a define, as a
  captured global, a passed argument, a freshly-computed local, a direct
  (no-`let`) argument, through a nested internal `define`, through a closure, and
  after escaping a `with-region`;
- small (2×3·3×2, CPU BLAS) **and** large (512×512 / 1024×1024, GPU-dispatched)
  matrices, probed against an independent scalar reference at a grid of positions;
- the maintainer's own `ozaki_correctness_test.esk` / `ozaki_certification_test.esk`
  harnesses, modified to touch the tensor object inside the checker — bit-identical
  to the top-level `tensor-data` read, `mismatches=0`.

In every case the in-function read equaled the top-level read.

## Root cause

The tensor read + arena + matmul codegen/runtime path (`tensor_codegen.cpp`,
`tensor_creation_codegen.cpp`, `runtime_tensor_alloc.cpp`, `runtime_arena_core.cpp`,
`binding_codegen.cpp`, `blas_backend.cpp`, `codegenMatmul` in `llvm_codegen.cpp`)
is **byte-identical** between the #307 merge commit (`f115bb9d`) and current master
(`cddadded`). I rebuilt `eshkol-run` at `f115bb9d` — the exact commit whose comment
first claimed the zeros — and the in-function reads are already correct there too
(JIT, AOT, GPU). The only behavioural delta since #307 in this area is an additive,
opt-in GPU fast tier; the standard result copy-back is unchanged. The pre-#307 "zeros"
observed during Ozaki development were the CRT-overflow/precision defect (which for
some regimes zeroed/garbled outputs); restructuring to "top-level + plain vectors"
coincidentally sidestepped the true defect, and the scope framing was then
cargo-culted into #312/#318 as a defensive posture. #307's fix resolved the actual
defect; #309's scope framing describes a bug that is not present.

## What this PR adds

- **`tests/tensor/matmul_read_in_define_test.esk`** — actively reads a matmul result
  via `tensor-ref`/`tensor-data` from inside defined functions (captured global /
  argument / in-function matmul / direct arg / nested define / closure /
  `with-region` escape / large GPU-dispatched), comparing every read to the exact
  expected product; prints `PASS`/`FAIL`.
- **CTests** `matmul_read_in_define_jit_smoke` (`-r`) and
  `matmul_read_in_define_aot_smoke` (compile + run) — both green.
- **ICC gate** `matmul_tensor_read_scope_oracle` (JIT + AOT) in
  `scripts/run_icc_smoke.sh` + `.icc/completion-oracles.yaml`.
- Retires the misleading "read only at top level / reads zeros" comments in
  `tests/gpu/ozaki_correctness_test.esk` and `ozaki_certification_test.esk`
  (comment-only; gate logic untouched).
- CHANGELOG entry under Fixed.

## Test evidence

`ctest -R matmul_read_in_define`:
```
1/2 Test #12: matmul_read_in_define_jit_smoke ...   Passed    0.54 sec
2/2 Test #13: matmul_read_in_define_aot_smoke ...   Passed    0.99 sec
100% tests passed, 0 tests failed out of 2
```

Regression test output (identical on JIT and AOT), tail:
```
with-region escape:
  ok   escaped tensor-ref[1][1] = 40
  ok   escaped tensor-data[0] = 10
large matmul read inside define:
  ok   large[0][0] rel<1e-9
  ok   large[31][31] rel<1e-9
  ok   large[63][63] rel<1e-9
  ok   large[17][48] rel<1e-9

PASS: matmul tensor reads inside defined functions match top-level (#309)
```

No-regression: `tensor_integer_*`, `tensorcore_language_aot_smoke`,
`autodiff_tensor_reductions_runtime_smoke`, `sparse_tensors_runtime_smoke`,
`tensor_tower_runtime_smoke`, `ml/matmul_test.esk`, and the Ozaki
correctness/certification fixtures all still pass. (The two `tensorcore_*_test`
C++ targets show "Not Run" only because this targeted build did not compile them;
unrelated to this change.)

## Note on the VM

The `hosted-vm` backend has *separate, scope-independent* matmul defects
(rejects `reshape`/`arange` operands with a type error; wrong literal-matmul
values) — but its in-function read equals its top-level read, so it does not
exhibit #309 either. Those are pre-existing VM matmul bugs, out of scope here;
flagging for a follow-up.

Fixes #309