### PR TITLE
chore(quantum): bump Moonlab pin to v1.2.0 (QGT + smooth PES)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,10 @@ if(ESHKOL_QUANTUM_ENABLED)
 
     FetchContent_Declare(moonlab
         GIT_REPOSITORY "${ESHKOL_MOONLAB_REPO}"
-        GIT_TAG d2503460246da893c28b59845bb32689aa9602fc
+        # Moonlab v1.2.0: adds MOONLAB_API vqe_compute_qgt (QNG/QGT, needed by the
+        # quantum-chemistry examples) and the smooth first-principles H2/LiH PES.
+        # Pinned by the tag's commit SHA; ABI frozen per the Moonlab release note.
+        GIT_TAG e441957b22698ce93ad4868d585ac7ca3baa281f
         GIT_SHALLOW FALSE
     )
     FetchContent_MakeAvailable(moonlab)

--- a/tests/quantum/vqe_test.esk
+++ b/tests/quantum/vqe_test.esk
@@ -5,15 +5,17 @@
 ;;   cmake --build build-quantum --target eshkol-run
 ;;   build-quantum/eshkol-run tests/quantum/vqe_test.esk
 ;;
-;; H2 at 0.735 Å takes Moonlab's equilibrium-coefficient path.  The familiar
-;; minimal-basis literature result is about -1.137 Ha; this pinned Moonlab
-;; coefficient set's direct-diagonalization oracle returns -1.142170640288 Ha
-;; (including its nuclear-repulsion term).  VQE must recover that exact oracle
-;; within the specified tolerance.
+;; H2 at 0.735 Å takes Moonlab's first-principles STO-3G path (v1.2.0's
+;; smooth PES).  The familiar minimal-basis literature result is about
+;; -1.137 Ha; this pinned Moonlab release's direct-diagonalization oracle
+;; returns -1.142200155381 Ha (including its nuclear-repulsion term; the
+;; pre-v1.2.0 coefficient set gave -1.142170640288, shifted -2.95e-5 Ha by
+;; the smooth-PES change).  VQE must recover the exact oracle within the
+;; specified tolerance.
 
 (require agent.quantum)
 
-(define h2-moonlab-exact-energy -1.142170640288)
+(define h2-moonlab-exact-energy -1.142200155381)
 (define exact-tolerance 0.000001)
 (define vqe-tolerance 0.000001)
 


### PR DESCRIPTION
One-line pin bump `d2503460` → `e441957b` (**Moonlab v1.2.0** tag). Brings `MOONLAB_API vqe_compute_qgt` (QNG/quantum geometric tensor — the symbol PR #299 links) and the merged smooth first-principles H2/LiH PES (makes the H2-vibrational example physical). ABI frozen per the Moonlab release response (`notes/RESPONSE_to_eshkol_pr299.md` on the Moonlab side). Verification = the `quantum-macos` advisory lane building+running the full quantum gate suite against the new pin. On green: merge this, then merge #299 (closes #297).