### PR TITLE
fix(memory): iter-scope partial reclamation — evacuate barrier-recorded escapees, then reset (ESH-0214e)

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -406,6 +406,27 @@ oracles:
         label: 'ESH-0214b v1.3.1: AOT guard-wrapped define loop stays under the 200MB flat-RSS ceiling'
         action: ./scripts/run_icc_smoke.sh
 
+      # ESH-0214e: closes the ESH-0214 series. ESH-0214b's automatic
+      # per-iteration reclamation was all-or-nothing — it rejected any loop body
+      # that mutated persistent state, so a resident tick loop that mutates every
+      # tick got NO reclamation and leaked one tick's transient garbage forever.
+      # ESH-0214e lowers a mutating-but-escape-safe loop with a per-loop nursery
+      # region that reuses the 48h-validated with-region deep-promotion path: the
+      # write barrier promotes each persistent-mutation escapee out of the
+      # nursery, the loop-carried out-values are promoted at each back edge, then
+      # the nursery is reset. The gate compiles the tick loop AOT (flat RSS +
+      # correct read-back of KB/workspace/list), re-runs it under
+      # ESHKOL_ARENA_POISON=1 (a missed escapee crashes at 0xCB.. instead of
+      # reading recycled memory), checks the JIT path, and A/Bs against the
+      # explicit with-region twin.
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["iter_scope_partial_reclaim"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'ESH-0214e: resident tick loop that mutates persistent state every tick (hash-table-set!/vector-set!/set-cdr!) reclaims transient garbage automatically via a nursery region — AOT flat RSS, correct read-back, clean under ESHKOL_ARENA_POISON=1, within 10x of the with-region baseline'
+        action: ./scripts/run_icc_smoke.sh
+
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["reader_fuzz_smoke"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **ESH-0214e: iter-scope partial reclamation — a resident tick loop that
+  mutates persistent state every tick no longer leaks.** This closes the
+  ESH-0214 memory-management series. ESH-0214b's automatic per-iteration
+  arena reclamation was *all-or-nothing*: the static escape analysis rejected a
+  loop body outright the moment it contained any persistent mutation, because a
+  value the iteration allocates and then stores into outer/persistent state
+  would dangle when the per-iteration arena scope was rewound. So a daemon/tick
+  loop that mutates a knowledge base / workspace / growing list on **every**
+  iteration got **no** reclamation and leaked one iteration's transient garbage
+  forever — measured at ~3,366 bytes/tick (linear, unbounded; ~355 MB at
+  100,000 ticks). ESH-0214e lowers a mutating-but-escape-safe loop with a
+  **per-loop nursery region** instead of rejecting it, reusing — verbatim — the
+  `with-region` deep-transitive escape-promotion path validated over a 48-hour
+  resident run (ESH-0214c/d), not a second evacuator: every iteration allocation
+  lands in the nursery arena, each of the six mutation channels' *existing*
+  write barriers promotes any persistent-mutation escapee out of the nursery at
+  the store, each TCO back edge promotes the loop-carried out-values out and then
+  resets the nursery, and the loop exit escapes the result and tears the nursery
+  down. The reclamation is sound by the same invariant as `with-region`'s
+  `region_pop` (after promotion no surviving object points into the reset span) —
+  textbook deterministic generational minor collection (nursery = young
+  generation, write barrier = remembered set, back-edge recycle = minor
+  collection), with no tracing pause. Admitted mutators are the five *structural*
+  channels barriered unconditionally on the mutated structure pointer
+  (`vector-set!`, `vector-fill!`, `hash-table-set!`, `set-car!`, `set-cdr!`);
+  `set!` is deliberately excluded (its barrier fires only for globals, and
+  proving a `set!` target is global rather than a shadowing enclosing-scope local
+  needs lexical resolution this downward-only analysis lacks). Non-mutating loops
+  keep the exact ESH-0214b arena-scope path (zero change to the
+  `define_loop_flat_rss_aot` gate). After the fix the same tick loop is flat at
+  34 MB — **identical to its explicit `with-region` twin** — with every stored
+  value reading back correct, JIT and AOT, and clean under
+  `ESHKOL_ARENA_POISON=1`. Adds `tests/memory/iter_scope_partial_reclaim_test.esk`
+  / `.sh` (+ the `with-region` baseline twin) and the
+  `iter_scope_partial_reclaim` ICC oracle.
+  (`lib/core/runtime_regions.cpp`, `lib/backend/llvm_codegen.cpp`,
+  `inc/eshkol/backend/binding_codegen.h`)
+
 ### Added
 
 - **INT8 tensor-core Ozaki f64 GEMM (CUDA, opt-in).** A new f64 GPU matmul path

--- a/inc/eshkol/backend/binding_codegen.h
+++ b/inc/eshkol/backend/binding_codegen.h
@@ -295,6 +295,23 @@ public:
                                               // back edge must end it (pop/commit)
                                               // before jumping to the loop header
 
+        // ESH-0214e: iter-scope PARTIAL RECLAMATION for mutating loops. When the
+        // loop body is escape-safe but contains a barriered structural mutation
+        // (vector-set!/vector-fill!/hash-table-set!/set-car!/set-cdr!), the loop
+        // is lowered with a per-loop NURSERY REGION instead of the arena-scope
+        // path: iteration allocations land in `nursery_region`'s arena, the
+        // existing write barriers promote persistent-mutation escapees out of it,
+        // and each back edge calls eshkol_iter_nursery_recycle (promote the
+        // loop-carried out-values, then reset the nursery). `iter_nursery` and
+        // `iter_scope` are mutually exclusive. `nursery_region` is the
+        // region_create result; `nursery_saved_arena` is the eshkol_region_enter
+        // displaced-arena token restored by eshkol_region_leave at loop exit.
+        // Both are SSA values produced in the loop's setup block, which dominates
+        // every back edge and the exit.
+        bool iter_nursery = false;
+        llvm::Value* nursery_region = nullptr;
+        llvm::Value* nursery_saved_arena = nullptr;
+
         // --- ESH-0222: tail calls through `guard` inside a TCO loop ---
         //
         // A self-call that textually appears inside a `guard`'s protected body

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -11127,8 +11127,17 @@ private:
         // through the loop-carried args / return value. The define's own name
         // is the loop name, so its self-tail-calls are recognized as back
         // edges by the analysis (local_fns) and by codegenTailCallFromContext.
+        bool define_iter_needs_nursery = false;  // ESH-0214e
         bool define_iter_scope_safe = is_tail_rec &&
-            loopBodyIterScopeSafe(op->define_op.value, func_name);
+            loopBodyIterScopeSafe(op->define_op.value, func_name, &define_iter_needs_nursery);
+        // ESH-0214e: mutating-but-safe define loops use the nursery-region path;
+        // non-mutating ones keep the arena-scope path. Mutually exclusive.
+        bool define_iter_nursery = define_iter_scope_safe && define_iter_needs_nursery;
+        bool define_iter_arena_scope = define_iter_scope_safe && !define_iter_needs_nursery;
+        // Held in locals (not just tco_ctx) because the base-case return paths
+        // below run AFTER the "Clear TCO context" block zeroes the nursery fields.
+        Value* define_nursery_region = nullptr;       // ESH-0214e
+        Value* define_nursery_saved_arena = nullptr;  // ESH-0214e
         if (is_tail_rec) {
             use_tco = true;
             eshkol_debug("TCO: Enabling tail call optimization for define %s", func_name);
@@ -11141,7 +11150,10 @@ private:
             // define TCO path too, gated on the escape analysis above. When
             // unsafe this is false, so a define's back edges never inherit a
             // stale iter_scope from an enclosing context.
-            tco_ctx.iter_scope = define_iter_scope_safe;
+            tco_ctx.iter_scope = define_iter_arena_scope;
+            tco_ctx.iter_nursery = define_iter_nursery;     // ESH-0214e
+            tco_ctx.nursery_region = nullptr;               // ESH-0214e (set at open)
+            tco_ctx.nursery_saved_arena = nullptr;          // ESH-0214e
             tco_ctx.param_allocas.clear();
             tco_ctx.param_names.clear();
 
@@ -11167,6 +11179,16 @@ private:
                 }
             }
 
+            // ESH-0214e: open the loop's nursery region ONCE in the setup block
+            // (before branching into the header) for a mutating-but-safe define
+            // loop — same as codegenNamedLet. Records region + saved-arena into
+            // tco_ctx (SSA values dominating the loop).
+            if (define_iter_nursery) {
+                emitIterNurseryOpen(tco_ctx);
+                define_nursery_region = tco_ctx.nursery_region;
+                define_nursery_saved_arena = tco_ctx.nursery_saved_arena;
+            }
+
             // Create loop header block
             tco_loop_bb = BasicBlock::Create(*context, "tco_loop", function);
             tco_ctx.loop_header = tco_loop_bb;
@@ -11181,8 +11203,8 @@ private:
             // which ends the scope when tco_ctx.iter_scope is set) and the
             // define's base-case return below -- ends it with
             // eshkol_arena_iter_scope_end, so pushes and releases stay strictly
-            // balanced (LIFO).
-            if (define_iter_scope_safe) {
+            // balanced (LIFO). (Nursery loops use the region path opened above.)
+            if (define_iter_arena_scope) {
                 Value* iter_arena_ptr = getArenaPtr();
                 if (iter_arena_ptr) {
                     builder->CreateCall(getArenaPushScopeFunc(), {iter_arena_ptr});
@@ -11258,6 +11280,13 @@ private:
             // ESH-0214b (Bug 1): clear iter_scope too so a later, non-tail
             // define's back edges never inherit this loop's stale flag.
             binding_->getTCOContext().iter_scope = false;
+            // ESH-0214e: likewise clear the nursery flag/handles. The base-case
+            // return paths below use the LOCAL define_nursery_* captured above,
+            // so zeroing tco_ctx here is safe and prevents a later non-tail
+            // define from inheriting a stale nursery region.
+            binding_->getTCOContext().iter_nursery = false;
+            binding_->getTCOContext().nursery_region = nullptr;
+            binding_->getTCOContext().nursery_saved_arena = nullptr;
         }
         eshkol_debug("Function %s body_result: %p", func_name, body_result);
 
@@ -11290,8 +11319,10 @@ private:
                 // The result is the only datum flowing out; the runtime helper
                 // pops (reclaims) unless it points into the iteration span, in
                 // which case it commits (keeps the memory, balanced stack).
-                if (use_tco && define_iter_scope_safe) {
+                if (use_tco && define_iter_arena_scope) {
                     emitIterScopeEnd({body_result});
+                } else if (use_tco && define_iter_nursery && define_nursery_region) {
+                    body_result = emitIterNurseryClose(body_result, define_nursery_saved_arena);
                 }
                 builder->CreateRet(body_result);
             }
@@ -11312,8 +11343,10 @@ private:
                     ESHKOL_VALUE_CALLABLE);  // CRITICAL: Mark as LAMBDA_SEXPR, not CONS_PTR
                 // ESH-0214b (Bug 1): balance the per-iteration scope on this
                 // exit path too (see the tagged-value case above).
-                if (use_tco && define_iter_scope_safe) {
+                if (use_tco && define_iter_arena_scope) {
                     emitIterScopeEnd({func_tagged});
+                } else if (use_tco && define_iter_nursery && define_nursery_region) {
+                    func_tagged = emitIterNurseryClose(func_tagged, define_nursery_saved_arena);
                 }
                 builder->CreateRet(func_tagged);
             }
@@ -11323,8 +11356,10 @@ private:
                 Value* tagged = typedValueToTaggedValue(typed);
                 // ESH-0214b (Bug 1): balance the per-iteration scope on this
                 // exit path too (see the tagged-value case above).
-                if (use_tco && define_iter_scope_safe) {
+                if (use_tco && define_iter_arena_scope) {
                     emitIterScopeEnd({tagged});
+                } else if (use_tco && define_iter_nursery && define_nursery_region) {
+                    tagged = emitIterNurseryClose(tagged, define_nursery_saved_arena);
                 }
                 builder->CreateRet(tagged);
             }
@@ -11335,8 +11370,10 @@ private:
                 ConstantInt::get(int64_type, 0), true);
             // ESH-0214b (Bug 1): balance the per-iteration scope on this exit
             // path too (see the tagged-value case above).
-            if (use_tco && define_iter_scope_safe) {
+            if (use_tco && define_iter_arena_scope) {
                 emitIterScopeEnd({null_tagged});
+            } else if (use_tco && define_iter_nursery && define_nursery_region) {
+                null_tagged = emitIterNurseryClose(null_tagged, define_nursery_saved_arena);
             }
             builder->CreateRet(null_tagged);
         }
@@ -24721,6 +24758,41 @@ private:
     // Memo for per-user-function analysis results (name -> safe?)
     std::unordered_map<std::string, bool> iter_scope_fn_memo;
 
+    // ESH-0214e: parallel memo recording whether an escape-safe user function's
+    // body contains a barriered structural mutation, so a loop that calls it is
+    // lowered with a nursery region even on a memo hit (a mutation reached only
+    // through a called define must still flip the whole loop to nursery mode, or
+    // the arena-scope path would rewind a slot the mutation stored into
+    // persistent state). Keyed identically to iter_scope_fn_memo.
+    std::unordered_map<std::string, bool> iter_scope_fn_nursery_memo;
+
+    // ESH-0214e: set by iterScopeSafeExpr while analyzing ONE loop body when it
+    // admits a barriered structural mutation (see iterScopeNurseryMutators).
+    // loopBodyIterScopeSafe resets it before each analysis and reports it out.
+    // Mutation channels admitted here MUST be exactly the ones whose codegen
+    // unconditionally emits eshkol_region_write_barrier_into on the mutated
+    // structure pointer, so a nursery-allocated value stored into persistent
+    // state is deep-promoted out of the nursery at the store.
+    bool iter_scope_needs_nursery_ = false;
+
+    // The structural mutators admitted into iter-scope under ESH-0214e. Each is
+    // barriered UNCONDITIONALLY at its codegen site on the mutated structure's
+    // pointer (collection_codegen.cpp vector-set!/vector-fill!, hash_codegen.cpp
+    // hash-table-set!, llvm_codegen.cpp set-car!/set-cdr!), so the write barrier
+    // promotes any nursery value they store into an outer/persistent structure.
+    // set! is deliberately EXCLUDED: its barrier fires only for GlobalVariable
+    // targets, and proving a set! target is global (not a shadowing enclosing-
+    // scope local, whose alloca is NOT barriered) needs full lexical resolution
+    // this downward-only analysis does not have — admitting it unsoundly would
+    // reintroduce exactly the dangling-pointer corruption this series closes.
+    static const std::set<std::string>& iterScopeNurseryMutators() {
+        static const std::set<std::string> s = {
+            "vector-set!", "vector-fill!", "hash-table-set!",
+            "set-car!", "set-cdr!",
+        };
+        return s;
+    }
+
     // ═════════════════════════════════════════════════════════════════════
     // ESH-0214c: PARALLEL-WORKER REACHABILITY (whole-program pre-pass)
     //
@@ -25025,6 +25097,24 @@ private:
                 }
                 const std::string name = op->call_op.func->variable.id;
 
+                // ESH-0214e: a barriered structural mutator (vector-set! /
+                // vector-fill! / hash-table-set! / set-car! / set-cdr!) is
+                // ADMITTED, and flips this loop to nursery-region lowering. Its
+                // codegen unconditionally promotes any nursery value it stores
+                // into the mutated structure out of the nursery (write barrier on
+                // the structure pointer), so the store no longer defeats
+                // reclamation. Its arguments are ordinary expressions and must
+                // themselves be escape-safe. Checked BEFORE the trailing-'!'
+                // hard-disable below so these five names are not swept up by it.
+                if (iterScopeNurseryMutators().count(name)) {
+                    for (uint64_t i = 0; i < op->call_op.num_vars; i++) {
+                        if (!iterScopeSafeExpr(&op->call_op.variables[i],
+                                               local_fns, analyzing, depth + 1)) return false;
+                    }
+                    iter_scope_needs_nursery_ = true;
+                    return true;
+                }
+
                 // Mutators by convention: any name ending in '!' writes into
                 // pre-existing structure -- the one channel the dynamic check
                 // cannot see. Hard-disable.
@@ -25236,7 +25326,19 @@ private:
                              std::set<std::string>& analyzing,
                              int depth) {
         auto memo_it = iter_scope_fn_memo.find(name);
-        if (memo_it != iter_scope_fn_memo.end()) return memo_it->second;
+        if (memo_it != iter_scope_fn_memo.end()) {
+            // ESH-0214e: a memo HIT must still propagate the callee's nursery
+            // requirement into the loop being analyzed now — a barriered
+            // mutation reached only through this cached-safe define must still
+            // flip the whole loop to nursery lowering, or the arena-scope path
+            // would rewind a slot the mutation stored into persistent state.
+            if (memo_it->second) {
+                auto nit = iter_scope_fn_nursery_memo.find(name);
+                if (nit != iter_scope_fn_nursery_memo.end() && nit->second)
+                    iter_scope_needs_nursery_ = true;
+            }
+            return memo_it->second;
+        }
         if (analyzing.count(name)) return true;  // inductive: cycle back-edge
 
         auto ast_it = function_body_ast.find(name);
@@ -25244,9 +25346,17 @@ private:
 
         analyzing.insert(name);
         std::set<std::string> callee_local_fns;
+        // ESH-0214e: isolate THIS function's own nursery requirement so it can be
+        // memoized per-function, then fold it back into the caller's running
+        // accumulation (only when the function is actually escape-safe).
+        bool saved_nursery = iter_scope_needs_nursery_;
+        iter_scope_needs_nursery_ = false;
         bool ok = iterScopeSafeExpr(ast_it->second, callee_local_fns, analyzing, depth + 1);
+        bool fn_nursery = iter_scope_needs_nursery_;
+        iter_scope_needs_nursery_ = saved_nursery || (ok && fn_nursery);
         analyzing.erase(name);
         iter_scope_fn_memo[name] = ok;
+        iter_scope_fn_nursery_memo[name] = ok && fn_nursery;
         return ok;
     }
 
@@ -25255,7 +25365,9 @@ private:
     // per-iteration scope reclamation? `loop_name` is the name whose
     // self-tail-calls are the loop's back edges (the named-let name, or the
     // define's own function name).
-    bool loopBodyIterScopeSafe(const eshkol_ast_t* body, const std::string& loop_name) {
+    bool loopBodyIterScopeSafe(const eshkol_ast_t* body, const std::string& loop_name,
+                               bool* out_needs_nursery = nullptr) {
+        if (out_needs_nursery) *out_needs_nursery = false;
         static const bool disabled = (getenv("ESHKOL_NO_ITER_SCOPE") != nullptr);
         if (disabled || !body) return false;
         // ESH-0214c: reject outright if this loop's body is reachable (via
@@ -25265,6 +25377,9 @@ private:
         // feature pushes/pops lives in __global_arena, which every worker
         // thread shares without synchronization; concurrent scope ops from
         // multiple threads race and corrupt it (parallel_flags_byte_regression.esk).
+        // The ESH-0214e nursery region stack is likewise thread-local, so the
+        // same rejection covers the nursery path (a mutating loop reachable from
+        // a worker keeps its pre-feature behavior: no reclamation).
         if (parallel_worker_ast_nodes.count((const void*)body)) {
             eshkol_debug("ESH-0214c: loop '%s' iter-scope disabled "
                          "(reachable from a parallel/future callback)", loop_name.c_str());
@@ -25272,9 +25387,13 @@ private:
         }
         std::set<std::string> local_fns = {loop_name};
         std::set<std::string> analyzing;
+        iter_scope_needs_nursery_ = false;  // ESH-0214e: reset per loop analysis
         bool ok = iterScopeSafeExpr(body, local_fns, analyzing, 0);
-        eshkol_debug("ESH-0214b: loop '%s' iter-scope %s",
-                     loop_name.c_str(), ok ? "ENABLED" : "disabled (analysis)");
+        bool nursery = ok && iter_scope_needs_nursery_;
+        if (out_needs_nursery) *out_needs_nursery = nursery;
+        eshkol_debug("ESH-0214b/e: loop '%s' iter-scope %s%s",
+                     loop_name.c_str(), ok ? "ENABLED" : "disabled (analysis)",
+                     nursery ? " [nursery: partial reclamation]" : "");
         return ok;
     }
 
@@ -25311,6 +25430,120 @@ private:
             {arena_ptr, arr, ConstantInt::get(int64_type, (uint64_t)n)});
     }
     // ═══════════════════ END ESH-0214b ═══════════════════
+
+    // ═══════════════════ ESH-0214e: nursery lowering for mutating loops ═══════
+    // A loop whose body is escape-safe AND contains a barriered structural
+    // mutation is lowered with a per-loop NURSERY REGION instead of the
+    // arena-scope path. These three emitters reuse the EXACT runtime entry points
+    // codegenWithRegion emits (region_create/push/enter/escape/pop/leave), so the
+    // nursery converges on the 48-h-validated with-region deep-promotion path
+    // rather than forking a second evacuator. See runtime_regions.cpp
+    // (eshkol_iter_nursery_recycle) for the runtime side.
+    struct IterNurseryFns {
+        FunctionCallee create, push, pop, enter, leave, recycle, escape_into;
+    };
+    IterNurseryFns getIterNurseryFns() {
+        PointerType* p = PointerType::get(*context, 0);
+        IterNurseryFns f;
+        f.create = module->getOrInsertFunction("region_create",
+            FunctionType::get(p, {p, int64_type}, false));
+        f.push = module->getOrInsertFunction("region_push",
+            FunctionType::get(void_type, {p}, false));
+        f.pop = module->getOrInsertFunction("region_pop",
+            FunctionType::get(void_type, {}, false));
+        f.enter = module->getOrInsertFunction("eshkol_region_enter",
+            FunctionType::get(p, {p}, false));
+        f.leave = module->getOrInsertFunction("eshkol_region_leave",
+            FunctionType::get(void_type, {p}, false));
+        f.recycle = module->getOrInsertFunction("eshkol_iter_nursery_recycle",
+            FunctionType::get(void_type, {p, p, int64_type}, false));
+        f.escape_into = module->getOrInsertFunction("region_escape_tagged_value_into",
+            FunctionType::get(void_type, {p, p}, false));
+        return f;
+    }
+
+    // Open the loop's nursery region in the current (setup) block, ONCE per loop
+    // activation. Stashes the region ptr and the eshkol_region_enter displaced-
+    // arena token into tco_ctx — both SSA values in the setup block, which
+    // dominates every back edge and the loop exit.
+    void emitIterNurseryOpen(eshkol::BindingCodegen::TailCallContext& tco_ctx) {
+        IterNurseryFns f = getIterNurseryFns();
+        Value* name = builder->CreateGlobalString("iter-nursery", "iter_nursery_name");
+        // Generous first-block size: a tick body's transient burst usually fits
+        // one block, so steady-state reset keeps a single block and never mallocs.
+        Value* size_hint = ConstantInt::get(int64_type, (uint64_t)65536);
+        Value* region = builder->CreateCall(f.create, {name, size_hint}, "iter_nursery");
+        builder->CreateCall(f.push, {region});
+        Value* saved = builder->CreateCall(f.enter, {region}, "iter_nursery_saved_arena");
+        tco_ctx.nursery_region = region;
+        tco_ctx.nursery_saved_arena = saved;
+    }
+
+    // End-of-iteration recycle at a TCO back edge: store the loop-carried
+    // out-values into an entry-hoisted scratch array, call the runtime recycle
+    // (promote them out of the nursery + reset the nursery), then load the
+    // PROMOTED values back so the caller stores those into the loop's parameter
+    // allocas (the originals are about to be reclaimed).
+    std::vector<Value*> emitIterNurseryRecycle(const std::vector<Value*>& out_values,
+                                               Value* region) {
+        IterNurseryFns f = getIterNurseryFns();
+        const size_t n = out_values.size();
+        ArrayType* arr_type = ArrayType::get(tagged_value_type, n ? n : 1);
+        Function* current_func = builder->GetInsertBlock()->getParent();
+        IRBuilderBase::InsertPoint saved_ip = builder->saveIP();
+        if (current_func && !current_func->empty()) {
+            BasicBlock& entry_bb = current_func->getEntryBlock();
+            builder->SetInsertPoint(&entry_bb, entry_bb.begin());
+        }
+        Value* arr = builder->CreateAlloca(arr_type, nullptr, "iter_nursery_vals");
+        builder->restoreIP(saved_ip);
+        for (size_t i = 0; i < n; i++) {
+            Value* slot = builder->CreateConstInBoundsGEP2_64(arr_type, arr, 0, i);
+            builder->CreateStore(out_values[i], slot);
+        }
+        builder->CreateCall(f.recycle,
+            {region, arr, ConstantInt::get(int64_type, (uint64_t)n)});
+        std::vector<Value*> promoted;
+        promoted.reserve(n);
+        for (size_t i = 0; i < n; i++) {
+            Value* slot = builder->CreateConstInBoundsGEP2_64(arr_type, arr, 0, i);
+            promoted.push_back(builder->CreateLoad(tagged_value_type, slot,
+                                                   "iter_nursery_promoted"));
+        }
+        return promoted;
+    }
+
+    // Loop exit: escape the result out of the nursery (same as with-region's
+    // result escape), then tear the nursery down — region_pop frees its arena,
+    // eshkol_region_leave restores the displaced allocation arena (@p saved_arena
+    // is the eshkol_region_enter token from emitIterNurseryOpen). Returns the
+    // escaped result value to return from the loop. Takes @p saved_arena
+    // explicitly so the caller may hold it in a local past any tco_ctx reset.
+    Value* emitIterNurseryClose(Value* result, Value* saved_arena) {
+        IterNurseryFns f = getIterNurseryFns();
+        Value* escaped = result;
+        if (result && result->getType() == tagged_value_type) {
+            Function* current_func = builder->GetInsertBlock()->getParent();
+            IRBuilderBase::InsertPoint saved_ip = builder->saveIP();
+            if (current_func && !current_func->empty()) {
+                BasicBlock& entry_bb = current_func->getEntryBlock();
+                builder->SetInsertPoint(&entry_bb, entry_bb.begin());
+            }
+            AllocaInst* in_slot = builder->CreateAlloca(tagged_value_type, nullptr,
+                                                        "iter_nursery_result_in");
+            AllocaInst* out_slot = builder->CreateAlloca(tagged_value_type, nullptr,
+                                                         "iter_nursery_result_out");
+            builder->restoreIP(saved_ip);
+            builder->CreateStore(result, in_slot);
+            builder->CreateCall(f.escape_into, {out_slot, in_slot});
+            escaped = builder->CreateLoad(tagged_value_type, out_slot,
+                                          "iter_nursery_escaped_result");
+        }
+        builder->CreateCall(f.pop, {});
+        builder->CreateCall(f.leave, {saved_arena});
+        return escaped;
+    }
+    // ═══════════════════ END ESH-0214e ═══════════════════
 
     // Generate a tail call as a jump back to loop header (TCO transformation)
     // Uses the binding module's TCO context
@@ -25424,6 +25657,13 @@ private:
         // the span being rewound, so releasing first is safe.
         if (tco_ctx.iter_scope) {
             emitIterScopeEnd(new_values);
+        } else if (tco_ctx.iter_nursery && tco_ctx.nursery_region) {
+            // ESH-0214e: promote the loop-carried out-values out of the nursery
+            // (the write barrier already promoted every persistent-mutation
+            // escapee at its store), THEN reset the nursery. The recycle returns
+            // the PROMOTED values (surviving in the enclosing arena); store those
+            // into the parameter allocas since the originals are now reclaimed.
+            new_values = emitIterNurseryRecycle(new_values, tco_ctx.nursery_region);
         }
 
         // Store all new values to parameter allocas
@@ -27755,8 +27995,14 @@ private:
         // form (a non-TCO loop is real recursion; each activation is its own
         // dynamic extent). See the analysis block above codegenTailCall-
         // FromContext for the safety argument.
+        bool iter_needs_nursery = false;  // ESH-0214e
         bool iter_scope_safe = all_tail &&
-            loopBodyIterScopeSafe(op->let_op.body, loop_name);
+            loopBodyIterScopeSafe(op->let_op.body, loop_name, &iter_needs_nursery);
+        // ESH-0214e: a mutating-but-escape-safe loop uses the nursery-region path
+        // (partial reclamation); a non-mutating one keeps the arena-scope path.
+        // The two are mutually exclusive.
+        bool iter_nursery = iter_scope_safe && iter_needs_nursery;
+        bool iter_arena_scope = iter_scope_safe && !iter_needs_nursery;
 
         // NESTED NAMED LET FIX: Save TCO context to prevent corruption by nested named lets
         // Each named let saves the outer TCO state, does its work, then restores it
@@ -27767,13 +28013,19 @@ private:
         std::vector<AllocaInst*> saved_tco_param_allocas = tco_ctx.param_allocas;
         std::vector<std::string> saved_tco_param_names = tco_ctx.param_names;
         bool saved_tco_iter_scope = tco_ctx.iter_scope;
+        bool saved_tco_iter_nursery = tco_ctx.iter_nursery;               // ESH-0214e
+        llvm::Value* saved_tco_nursery_region = tco_ctx.nursery_region;   // ESH-0214e
+        llvm::Value* saved_tco_nursery_saved_arena = tco_ctx.nursery_saved_arena; // ESH-0214e
         unsigned saved_tco_open_guard_handlers = tco_ctx.open_guard_handlers;  // ESH-0222
         llvm::Value* saved_tco_loop_stack_save = tco_ctx.loop_stack_save;      // ESH-0222
 
         // Set up TCO context for this named let only when sound.
         tco_ctx.func_name = loop_name;
         tco_ctx.enabled = all_tail;
-        tco_ctx.iter_scope = iter_scope_safe;
+        tco_ctx.iter_scope = iter_arena_scope;
+        tco_ctx.iter_nursery = iter_nursery;               // ESH-0214e
+        tco_ctx.nursery_region = nullptr;                  // ESH-0214e (set at open)
+        tco_ctx.nursery_saved_arena = nullptr;             // ESH-0214e
         tco_ctx.param_allocas.clear();
         tco_ctx.param_names.clear();
 
@@ -27791,6 +28043,15 @@ private:
             tco_ctx.param_names.push_back(param_names[i]);
         }
 
+        // ESH-0214e: open the loop's nursery region ONCE, in the setup block
+        // (before branching into the header), when the body mutates persistent
+        // state through a barriered channel. Routes all iteration allocations
+        // into the nursery arena; each back edge recycles it. Records the region
+        // + displaced-arena token into tco_ctx (SSA values dominating the loop).
+        if (iter_nursery) {
+            emitIterNurseryOpen(tco_ctx);
+        }
+
         // Create loop header block for TCO
         BasicBlock* tco_loop_bb = BasicBlock::Create(*context, "tco_loop", loop_func);
         tco_ctx.loop_header = tco_loop_bb;
@@ -27803,8 +28064,9 @@ private:
         // the iteration -- each TCO back edge (codegenTailCallFromContext)
         // and the loop's exit return below -- ends it with
         // eshkol_arena_iter_scope_end, so pushes and releases stay strictly
-        // balanced (LIFO) across nested loops.
-        if (iter_scope_safe) {
+        // balanced (LIFO) across nested loops. (Nursery loops use the region
+        // path opened above instead, so this is gated on iter_arena_scope.)
+        if (iter_arena_scope) {
             Value* iter_arena_ptr = getArenaPtr();
             if (iter_arena_ptr) {
                 builder->CreateCall(getArenaPushScopeFunc(), {iter_arena_ptr});
@@ -27848,8 +28110,13 @@ private:
             // arena scope. The result value is the only datum flowing out; the
             // runtime helper pops (reclaims) when it cannot point into the
             // iteration span, and commits (keeps the memory) when it might.
-            if (iter_scope_safe && body_result->getType() == tagged_value_type) {
+            if (iter_arena_scope && body_result->getType() == tagged_value_type) {
                 emitIterScopeEnd({body_result});
+            } else if (iter_nursery && tco_ctx.nursery_region) {
+                // ESH-0214e: escape the result out of the nursery, then tear the
+                // nursery down (region_pop frees its arena, region_leave restores
+                // the displaced allocation arena).
+                body_result = emitIterNurseryClose(body_result, tco_ctx.nursery_saved_arena);
             }
             builder->CreateRet(body_result);
         }
@@ -27883,6 +28150,9 @@ private:
         tco_ctx.param_allocas = saved_tco_param_allocas;
         tco_ctx.param_names = saved_tco_param_names;
         tco_ctx.iter_scope = saved_tco_iter_scope;
+        tco_ctx.iter_nursery = saved_tco_iter_nursery;                  // ESH-0214e
+        tco_ctx.nursery_region = saved_tco_nursery_region;              // ESH-0214e
+        tco_ctx.nursery_saved_arena = saved_tco_nursery_saved_arena;    // ESH-0214e
         tco_ctx.open_guard_handlers = saved_tco_open_guard_handlers;  // ESH-0222
         tco_ctx.loop_stack_save = saved_tco_loop_stack_save;          // ESH-0222
 

--- a/lib/core/runtime_regions.cpp
+++ b/lib/core/runtime_regions.cpp
@@ -1624,3 +1624,118 @@ extern "C" void eshkol_region_write_barrier_range(const void* dst,
         eshkol_region_write_barrier_into(&slots[i], dst, &slots[i]);
     }
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// ESH-0214e: iter-scope PARTIAL RECLAMATION for mutating tick-loops.
+//
+// ESH-0214b's automatic per-iteration reclamation (arena_push_scope /
+// eshkol_arena_iter_scope_end, runtime_arena_core.cpp) is all-or-nothing: the
+// static gate (iterScopeSafeExpr) rejects a loop body outright the moment it
+// contains any persistent mutation, because a value the iteration allocates and
+// then stores into outer/persistent state would dangle when the scope is
+// rewound, and the shallow out-value span test at the back edge cannot see that
+// store. A resident tick loop that mutates persistent state EVERY tick
+// therefore got NO reclamation and leaked one iteration's transient garbage per
+// tick, unbounded (~3 KB/tick, linear).
+//
+// The fix does not fork a second evacuator or a second reclamation policy. It
+// reuses, verbatim, the with-region machinery whose deep-transitive escape
+// promotion has been validated over a 48-h resident run (ESH-0214c/d):
+//
+//   * The loop runs inside a NURSERY REGION (region_create/region_push/
+//     eshkol_region_enter, opened once per activation), so every iteration
+//     allocation lands in the nursery arena and region_index_owning() can
+//     classify it. Each of the six mutation channels' EXISTING write barriers
+//     (eshkol_region_write_barrier_into) then deep-promotes any barrier-recorded
+//     escapee — a nursery value stored into persistent/outer state — out of the
+//     nursery into the enclosing arena at the store, exactly as inside a
+//     with-region body. The barrier IS the escape-root record: it evacuates
+//     each escapee out of the tick arena the instant it becomes reachable from
+//     persistent state.
+//
+//   * eshkol_iter_nursery_recycle (below) runs at each TCO back edge. It
+//     promotes the loop-carried out-values (the freshly evaluated tail-call
+//     args, which the barrier never sees) out of the nursery via the SAME
+//     evacuator (region_escape_tagged_value_impl), then arena_reset()s the
+//     nursery — reclaiming the whole iteration's transient garbage — as if no
+//     mutation had happened. Its forwarding map (whose keys reference the arena
+//     just reset) is dropped so no stale entry survives into the next
+//     iteration's promotions.
+//
+// The reclamation is sound by the SAME invariant as with-region's region_pop:
+// after promotion no surviving object holds a pointer into the region being
+// freed (here, into the span being reset). This is textbook generational minor
+// collection (Appel) — the nursery is the young generation, the write barrier
+// is the remembered set, and recycle is the minor collection — but fully
+// deterministic (bounded per-iteration work, no tracing pause), which preserves
+// Eshkol's no-GC determinism.
+//
+// FALLBACK (correctness over reclamation): if the region stack is not in the
+// expected shape at a back edge (the nursery is not the innermost active
+// region — an unbalanced region op in the body, which well-formed codegen never
+// emits), recycle RETAINS this iteration (skips promotion AND reset) rather than
+// evacuate from the wrong region. Retention is bounded: the next well-formed
+// back edge resets the whole arena, reclaiming the retained bytes too.
+// ───────────────────────────────────────────────────────────────────────────
+
+extern "C" int eshkol_arena_poison_enabled(void);
+
+/**
+ * @brief End-of-iteration recycle for an ESH-0214e nursery loop (see block above).
+ *
+ * @param region  The loop's nursery region (opened once at loop entry).
+ * @param vals    The loop-carried out-values (tail-call args) about to flow into
+ *                the next iteration; each is promoted out of the nursery IN
+ *                PLACE so the caller stores the promoted (surviving) value into
+ *                the loop's parameter slot.
+ * @param n       Number of out-values.
+ */
+extern "C" void eshkol_iter_nursery_recycle(eshkol_region_t* region,
+                                            eshkol_tagged_value_t* vals,
+                                            uint64_t n) {
+    if (!region) return;
+
+    // Fallback guard: only recycle when this nursery is the innermost active
+    // region, i.e. the iteration body left the region stack exactly as it found
+    // it. Otherwise retain (skip promotion + reset) — never evacuate from the
+    // wrong region. Bounded: a later well-formed recycle reclaims these bytes.
+    if (region_current() != region) return;
+
+    // 1. Promote every loop-carried out-value out of the nursery into the
+    //    enclosing arena (region->escape_base). This is the identical evacuator
+    //    and code path as with-region's result escape
+    //    (region_escape_tagged_value); it shares the nursery region's forwarding
+    //    map, so any structure an out-value shares with a barrier-promoted
+    //    escapee from the same iteration stays shared (eq?-preserving). Values
+    //    already living outside the nursery (immediates, or pointers into the
+    //    enclosing/global arena) are returned unchanged and cost only a region
+    //    ownership probe.
+    if (vals) {
+        for (uint64_t i = 0; i < n; ++i) {
+            vals[i] = region_escape_tagged_value_impl(vals[i]);
+        }
+    }
+
+    // 2. Under the poison allocator, stamp the bytes about to be recycled with
+    //    0xCB so any interior pointer we FAILED to promote out (a missed escape
+    //    root) dereferences an obvious 0xCB.. address and crashes loudly instead
+    //    of silently reading recycled memory — the dangling-pointer tripwire the
+    //    ESH-0214 memory-model tests rely on.
+    if (eshkol_arena_poison_enabled() && region->arena) {
+        for (arena_block_t* b = region->arena->current_block; b; b = b->next) {
+            if (b->used) std::memset(b->memory, 0xCB, b->used);
+        }
+    }
+
+    // 3. Reset the nursery arena: reclaim ALL of this iteration's transient
+    //    garbage (bump pointer back to zero, free any spilled blocks, keep the
+    //    first block). O(1) on the steady-state single-block case — no per-
+    //    iteration malloc/free churn (the reason a persistent nursery + reset is
+    //    used instead of region_create/destroy per iteration).
+    arena_reset(region->arena);
+
+    // 4. Drop the forwarding map: its keys reference the arena just reset and
+    //    MUST NOT alias a fresh object that reuses the same address next
+    //    iteration. It is lazily recreated on the next escape/barrier promotion.
+    region_free_fwd_map(region);
+}

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -464,6 +464,16 @@ probe define_loop_flat_rss_aot 'ESH-0214b: AOT guard-wrapped define loop keeps R
      ## above a 200MB ceiling.
      bash tests/memory/define_loop_flat_rss_aot_test.sh'
 
+probe iter_scope_partial_reclaim 'ESH-0214e: resident tick loop that MUTATES persistent state every tick reclaims transient garbage automatically (nursery region) — AOT flat RSS + correct + clean under ESHKOL_ARENA_POISON=1' \
+    'cd "$REPO_ROOT";
+     ## ESH-0214e: iter-scope partial reclamation. A guard-wrapped self-tail
+     ## define loop that hash-table-set!/vector-set!/set-cdr!s persistent state
+     ## every tick used to be REJECTED by the all-or-nothing gate and leaked one
+     ## tick of transient garbage forever; now it runs inside a per-loop nursery
+     ## region that promotes escapees out and resets each tick. The gate also
+     ## re-runs the binary under ESHKOL_ARENA_POISON=1 (dangling-ptr tripwire).
+     bash tests/memory/iter_scope_partial_reclaim_test.sh'
+
 probe reader_fuzz_smoke 'seeded adversarial reader harness: no crash/hang, depth guard graceful (fixed-seed smoke pass)' \
     'cd "$REPO_ROOT" && bash scripts/run_reader_fuzz.sh --smoke'
 

--- a/tests/memory/iter_scope_partial_reclaim_baseline.esk
+++ b/tests/memory/iter_scope_partial_reclaim_baseline.esk
@@ -1,0 +1,88 @@
+;;; tests/memory/iter_scope_partial_reclaim_baseline.esk — the with-region
+;;; (path B) twin of iter_scope_partial_reclaim_test.esk, for a same-workload
+;;; A/B of automatic ESH-0214e reclamation vs explicit per-iteration
+;;; with-region. Same tick counts, same transient burst, same persistent
+;;; channels; the transient scratch + KB/workspace mutations run inside a
+;;; per-iteration (with-region ...) whose region_pop reclaims the transient
+;;; garbage while the ESH-0214c write barrier promotes the stored values out.
+;;; The persistent list grows OUTSIDE the region (its cell must outlive the
+;;; region as the loop-carried tail), which is why the automatic path — where
+;;; the growing cell is nursery-allocated and promoted automatically — is the
+;;; strictly more general result.
+;;;
+;;; This is the acceptance baseline: automatic peak RSS must land within ~10x
+;;; of this (both are flat; the pre-fix automatic path leaks unboundedly).
+
+(define ticks 100000)
+(define kb-slots 256)
+(define ws-slots 64)
+(define scratch-len 200)
+(define grow-every 1000)
+
+(define kb (make-hash-table))
+(define workspace (make-vector ws-slots 0))
+(define trail (cons 'head '()))
+
+(define (tick i tail)
+  (guard (e (#t tail))
+    (if (>= i ticks)
+        i
+        (begin
+          (with-region 'tick
+            (let ((scratch (make-vector scratch-len i)))
+              (hash-table-set! kb (modulo i kb-slots)
+                               (list i (* i 2) (vector-length scratch)))
+              (vector-set! workspace (modulo i ws-slots) (list i (* i 3)))))
+          (if (= (modulo i grow-every) 0)
+              (let ((cell (cons i '())))
+                (set-cdr! tail cell)
+                (tick (+ i 1) cell))
+              (tick (+ i 1) tail))))))
+
+(define result (tick 0 trail))
+
+(define (verify-kb k ok)
+  (if (>= k kb-slots)
+      ok
+      (let* ((entry (hash-table-ref kb k #f))
+             (last-i (+ k (* (quotient (- ticks 1 k) kb-slots) kb-slots))))
+        (verify-kb (+ k 1)
+                   (and ok (pair? entry)
+                        (= (car entry) last-i)
+                        (= (cadr entry) (* last-i 2))
+                        (= (caddr entry) scratch-len))))))
+
+(define (verify-ws s ok)
+  (if (>= s ws-slots)
+      ok
+      (let* ((entry (vector-ref workspace s))
+             (last-i (+ s (* (quotient (- ticks 1 s) ws-slots) ws-slots))))
+        (verify-ws (+ s 1)
+                   (and ok (pair? entry)
+                        (= (car entry) last-i)
+                        (= (cadr entry) (* last-i 3)))))))
+
+(define (verify-trail cell expect ok)
+  (if (null? cell)
+      (and ok (= expect (* grow-every (quotient (+ ticks (- grow-every 1)) grow-every))))
+      (verify-trail (cdr cell) (+ expect grow-every)
+                    (and ok (= (car cell) expect)))))
+
+(define kb-ok (verify-kb 0 #t))
+(define ws-ok (verify-ws 0 #t))
+(define trail-ok (verify-trail (cdr trail) 0 #t))
+
+(display "[iter_scope_partial_reclaim_baseline] ticks=")
+(display result)
+(display "/")
+(display ticks)
+(display " kb-ok=")
+(display kb-ok)
+(display " ws-ok=")
+(display ws-ok)
+(display " trail-ok=")
+(display trail-ok)
+(newline)
+(if (and (= result ticks) kb-ok ws-ok trail-ok)
+    (begin (display "PASS") (newline))
+    (begin (display "FAIL") (newline) (exit 1)))

--- a/tests/memory/iter_scope_partial_reclaim_test.esk
+++ b/tests/memory/iter_scope_partial_reclaim_test.esk
@@ -1,0 +1,113 @@
+;;; tests/memory/iter_scope_partial_reclaim_test.esk — ESH-0214e reproducer
+;;; and flat-RSS gate, driven by iter_scope_partial_reclaim_test.sh.
+;;;
+;;; The resident tick-loop shape that DEFEATED ESH-0214b's automatic
+;;; per-iteration reclamation: a guard-wrapped self-tail define loop that
+;;; MUTATES persistent state EVERY tick through three barriered channels —
+;;;   (a) hash-table-set!  into a persistent global knowledge base,
+;;;   (b) vector-set!      into a persistent global workspace,
+;;;   (c) set-cdr!         to grow a persistent global list periodically —
+;;; while also allocating a chunk of transient garbage per tick that must die
+;;; with the tick.
+;;;
+;;; Before ESH-0214e the static gate rejected this body outright the moment it
+;;; saw a persistent mutation (all-or-nothing), so the loop got NO reclamation
+;;; and leaked one tick's transient garbage forever (~thousands of bytes/tick,
+;;; unbounded). ESH-0214e lowers a mutating-but-escape-safe loop with a
+;;; per-loop NURSERY REGION: the existing write barriers promote each
+;;; persistent-mutation escapee out of the nursery at the store, the loop-
+;;; carried out-values are promoted at each back edge, and the nursery is then
+;;; reset — reclaiming the transient garbage as if no mutation happened, while
+;;; every stored value reads back correct.
+;;;
+;;; This file exercises the AUTOMATIC path (no explicit with-region). Its
+;;; with-region twin, iter_scope_partial_reclaim_baseline.esk, wraps the same
+;;; body in (with-region ...) and is the flat-RSS acceptance target the
+;;; automatic path must match. The KB/workspace use a BOUNDED key space so the
+;;; only unbounded per-tick allocation is transient garbage — making flat RSS
+;;; the clean pass/fail signal.
+
+(define ticks 100000)
+(define kb-slots 256)                       ; bounded KB key space (overwrites)
+(define ws-slots 64)                         ; bounded workspace
+(define scratch-len 200)                     ; transient garbage per tick (~3.2KB)
+(define grow-every 1000)                      ; grow the persistent list this often
+
+(define kb (make-hash-table))                ; persistent knowledge base
+(define workspace (make-vector ws-slots 0))  ; persistent workspace
+(define trail (cons 'head '()))              ; persistent growing list (sentinel head)
+
+;; Self-tail-recursive daemon loop, wrapped in a catch-all guard (the resident
+;; error-boundary shape). `tail` is the current last cell of `trail`.
+(define (tick i tail)
+  (guard (e (#t tail))                        ; catch-all boundary: keeps the loop resident
+    (if (>= i ticks)
+        i
+        (begin
+          ;; transient garbage — dead at the end of this tick, must be reclaimed
+          (let ((scratch (make-vector scratch-len i)))
+            ;; (a) persistent KB mutation (hash-table-set!, bounded key space)
+            (hash-table-set! kb (modulo i kb-slots)
+                             (list i (* i 2) (vector-length scratch)))
+            ;; (b) persistent workspace mutation (vector-set!)
+            (vector-set! workspace (modulo i ws-slots) (list i (* i 3))))
+          ;; (c) grow the persistent global list periodically (set-cdr!)
+          (if (= (modulo i grow-every) 0)
+              (let ((cell (cons i '())))
+                (set-cdr! tail cell)
+                (tick (+ i 1) cell))
+              (tick (+ i 1) tail))))))
+
+(define result (tick 0 trail))
+
+;; ─── Correctness read-back (run AFTER the loop; no iter-scope constraint) ───
+
+;; KB: slot k holds the list from the last tick i<ticks with (modulo i kb-slots)=k.
+(define (verify-kb k ok)
+  (if (>= k kb-slots)
+      ok
+      (let* ((entry (hash-table-ref kb k #f))
+             (last-i (+ k (* (quotient (- ticks 1 k) kb-slots) kb-slots))))
+        (verify-kb (+ k 1)
+                   (and ok (pair? entry)
+                        (= (car entry) last-i)
+                        (= (cadr entry) (* last-i 2))
+                        (= (caddr entry) scratch-len))))))
+
+;; Workspace: slot s holds (list last-i (* last-i 3)) for the last writer last-i.
+(define (verify-ws s ok)
+  (if (>= s ws-slots)
+      ok
+      (let* ((entry (vector-ref workspace s))
+             (last-i (+ s (* (quotient (- ticks 1 s) ws-slots) ws-slots))))
+        (verify-ws (+ s 1)
+                   (and ok (pair? entry)
+                        (= (car entry) last-i)
+                        (= (cadr entry) (* last-i 3)))))))
+
+;; Trail: sentinel head + one cell per grow tick (i = 0, grow-every, 2*grow-every…).
+;; Every cell must read back its intact integer in ascending order.
+(define (verify-trail cell expect ok)
+  (if (null? cell)
+      (and ok (= expect (* grow-every (quotient (+ ticks (- grow-every 1)) grow-every))))
+      (verify-trail (cdr cell) (+ expect grow-every)
+                    (and ok (= (car cell) expect)))))
+
+(define kb-ok (verify-kb 0 #t))
+(define ws-ok (verify-ws 0 #t))
+(define trail-ok (verify-trail (cdr trail) 0 #t))
+
+(display "[iter_scope_partial_reclaim_test] ticks=")
+(display result)
+(display "/")
+(display ticks)
+(display " kb-ok=")
+(display kb-ok)
+(display " ws-ok=")
+(display ws-ok)
+(display " trail-ok=")
+(display trail-ok)
+(newline)
+(if (and (= result ticks) kb-ok ws-ok trail-ok)
+    (begin (display "PASS") (newline))
+    (begin (display "FAIL") (newline) (exit 1)))

--- a/tests/memory/iter_scope_partial_reclaim_test.sh
+++ b/tests/memory/iter_scope_partial_reclaim_test.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# tests/memory/iter_scope_partial_reclaim_test.sh — ESH-0214e flat-RSS
+# + correctness + poison gate for iter-scope PARTIAL RECLAMATION.
+#
+# ESH-0214e teaches automatic per-iteration reclamation to survive persistent
+# mutation. A resident tick loop that mutates persistent state EVERY tick
+# (hash-table-set! / vector-set! / set-cdr!) used to be REJECTED outright by
+# the all-or-nothing static gate, so it got no reclamation and leaked one
+# tick's transient garbage forever. ESH-0214e lowers such a loop with a per-
+# loop NURSERY REGION: the write barrier promotes each persistent-mutation
+# escapee out of the nursery, the loop-carried out-values are promoted at each
+# back edge, then the nursery is reset — reclaiming the transient garbage while
+# every stored value reads back correct.
+#
+# This gate:
+#   1. compiles tests/memory/iter_scope_partial_reclaim_test.esk AOT (fix ON,
+#      default build), runs it, and FAILS if peak RSS exceeds the flat ceiling
+#      or the program does not print PASS (correctness);
+#   2. runs the same AOT binary under ESHKOL_ARENA_POISON=1 so any escapee the
+#      nursery reset FAILED to promote out dereferences a 0xCB.. address and
+#      crashes loudly instead of reading recycled memory (dangling-ptr tripwire);
+#   3. runs the source under the JIT (-r) and requires PASS (correctness, JIT);
+#   4. compiles + runs the with-region twin
+#      (iter_scope_partial_reclaim_baseline.esk) as the flat-RSS acceptance
+#      baseline, and requires automatic peak RSS within 10x of it;
+#   5. ADVISORY: recompiles with ESHKOL_NO_ITER_SCOPE=1 (fix disabled) and
+#      reports its peak RSS + the bytes/tick the fix removes (the "before").
+#
+# Usage: tests/memory/iter_scope_partial_reclaim_test.sh [--ceiling-mb N] [--timeout S]
+#   BUILD_DIR env var selects the build directory (default: build).
+#   ESHKOL_RUN env var overrides the eshkol-run binary path directly.
+set -u
+export LC_ALL=C LC_CTYPE=C LANG=C
+cd "$(dirname "$0")/../.."
+REPO_ROOT="$(pwd)"
+
+BUILD_DIR="${BUILD_DIR:-build}"
+if [ -z "${ESHKOL_RUN:-}" ]; then
+    case "$BUILD_DIR" in
+        /*) ESHKOL_RUN="$BUILD_DIR/eshkol-run" ;;
+        *) ESHKOL_RUN="$REPO_ROOT/$BUILD_DIR/eshkol-run" ;;
+    esac
+fi
+if [ ! -x "$ESHKOL_RUN" ]; then
+    echo "iter_scope_partial_reclaim_test.sh: $ESHKOL_RUN not found — run \`cmake --build $BUILD_DIR --target eshkol-run stdlib\` first." >&2
+    exit 2
+fi
+
+SRC="$REPO_ROOT/tests/memory/iter_scope_partial_reclaim_test.esk"
+BASELINE="$REPO_ROOT/tests/memory/iter_scope_partial_reclaim_baseline.esk"
+for f in "$SRC" "$BASELINE"; do
+    [ -f "$f" ] || { echo "iter_scope_partial_reclaim_test.sh: $f not found." >&2; exit 2; }
+done
+TICKS=$(awk '/^\(define ticks /{print $3; exit}' "$SRC" | tr -d ')')
+[ -n "$TICKS" ] || TICKS=100000
+
+CEILING_MB=150
+TIMEOUT_S=120
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --ceiling-mb) shift; CEILING_MB="${1:-$CEILING_MB}" ;;
+        --timeout) shift; TIMEOUT_S="${1:-$TIMEOUT_S}" ;;
+        *) echo "iter_scope_partial_reclaim_test.sh: unknown argument: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+# Detect the peak-RSS-reporting `time` flavor (macOS BSD `-l`, Linux GNU `-v`).
+TIME_MODE=""
+if /usr/bin/time -l true >/dev/null 2>/tmp/.ispr_probe.$$; then
+    grep -q "maximum resident set size" /tmp/.ispr_probe.$$ 2>/dev/null && TIME_MODE="bsd"
+fi
+if [ -z "$TIME_MODE" ] && /usr/bin/time -v true >/tmp/.ispr_probe.$$ 2>&1; then
+    grep -qi "Maximum resident set size" /tmp/.ispr_probe.$$ 2>/dev/null && TIME_MODE="gnu"
+fi
+rm -f /tmp/.ispr_probe.$$
+if [ -z "$TIME_MODE" ]; then
+    echo "iter_scope_partial_reclaim_test.sh: no peak-RSS-reporting /usr/bin/time on this host — cannot gate." >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-ispr.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# run_aot <src> <bin> <run-env...> -> FR_COMPILE_RC FR_RUN_RC FR_RSS_MB FR_OUT
+run_aot() {
+    local src="$1" bin="$2"; shift 2
+    local clog="$WORK/compile_$(basename "$bin").log"
+    local rout="$WORK/run_$(basename "$bin").out"
+    local tlog="$WORK/time_$(basename "$bin").log"
+    ( cd "$WORK" && "$ESHKOL_RUN" "$src" -o "$bin" ) > "$clog" 2>&1
+    FR_COMPILE_RC=$?
+    if [ "$FR_COMPILE_RC" -ne 0 ]; then FR_RUN_RC=127; FR_RSS_MB=0; FR_OUT="$clog"; return; fi
+    chmod +x "$bin"
+    if [ "$TIME_MODE" = "bsd" ]; then
+        ( cd "$WORK" && env "$@" /usr/bin/time -l perl -e 'my $s=shift; alarm $s; exec @ARGV; die "exec: $!\n"' \
+            "$TIMEOUT_S" "$bin" ) > "$rout" 2> "$tlog"
+        FR_RUN_RC=$?
+        FR_RSS_MB=$(awk '/maximum resident set size/{printf "%d", $1/1048576}' "$tlog")
+    else
+        ( cd "$WORK" && env "$@" /usr/bin/time -v perl -e 'my $s=shift; alarm $s; exec @ARGV; die "exec: $!\n"' \
+            "$TIMEOUT_S" "$bin" ) > "$rout" 2> "$tlog"
+        FR_RUN_RC=$?
+        FR_RSS_MB=$(awk -F: '/Maximum resident set size/{printf "%d", $2/1024}' "$tlog")
+    fi
+    [ -n "$FR_RSS_MB" ] || FR_RSS_MB=0
+    FR_OUT="$rout"
+}
+
+echo "=========================================================="
+echo "  ESH-0214e iter-scope partial-reclamation gate"
+echo "  ticks=$TICKS  ceiling=${CEILING_MB}MB  time-mode=${TIME_MODE}"
+echo "=========================================================="
+echo
+
+fail=0
+
+# ── 1. AOT gate: fix ON ──────────────────────────────────────────────────────
+echo "--- [1] AOT compile + run (automatic nursery, fix ON) ---"
+run_aot "$SRC" "$WORK/ispr_fix_on"
+on_rc=$FR_RUN_RC; on_rss=$FR_RSS_MB; on_out="$FR_OUT"
+if [ "$FR_COMPILE_RC" -ne 0 ]; then
+    echo "FAIL: AOT compile failed."; cat "$on_out"; fail=1
+elif [ "$on_rc" -ne 0 ] || ! grep -q "^PASS$" "$on_out"; then
+    echo "FAIL: AOT binary did not complete cleanly / correctly (exit=$on_rc):"; cat "$on_out"; fail=1
+else
+    grep -h "iter_scope_partial_reclaim_test" "$on_out"
+    echo "  exit=$on_rc  peak_rss=${on_rss}MB"
+    if [ "$on_rss" -gt "$CEILING_MB" ]; then
+        echo "FAIL: peak RSS ${on_rss}MB exceeds ceiling ${CEILING_MB}MB (reintroduced per-tick leak?)"; fail=1
+    else
+        echo "PASS: automatic path flat + correct at ${on_rss}MB (< ${CEILING_MB}MB)."
+    fi
+fi
+echo
+
+# ── 2. Poison run (dangling-pointer tripwire) ────────────────────────────────
+echo "--- [2] re-run fix-ON binary under ESHKOL_ARENA_POISON=1 ---"
+if [ -x "$WORK/ispr_fix_on" ]; then
+    if [ "$TIME_MODE" = "bsd" ]; then
+        ( cd "$WORK" && ESHKOL_ARENA_POISON=1 /usr/bin/time -l perl -e 'my $s=shift; alarm $s; exec @ARGV; die' \
+            "$TIMEOUT_S" "$WORK/ispr_fix_on" ) > "$WORK/poison.out" 2>/dev/null
+    else
+        ( cd "$WORK" && ESHKOL_ARENA_POISON=1 /usr/bin/time -v perl -e 'my $s=shift; alarm $s; exec @ARGV; die' \
+            "$TIMEOUT_S" "$WORK/ispr_fix_on" ) > "$WORK/poison.out" 2>/dev/null
+    fi
+    prc=$?
+    if [ "$prc" -ne 0 ] || ! grep -q "^PASS$" "$WORK/poison.out"; then
+        echo "FAIL: poison run crashed or mis-verified (exit=$prc) — a nursery escapee was NOT promoted out:"; cat "$WORK/poison.out"; fail=1
+    else
+        echo "PASS: clean + correct under ESHKOL_ARENA_POISON=1 (no dangling nursery pointer)."
+    fi
+else
+    echo "SKIP: fix-ON binary unavailable."
+fi
+echo
+
+# ── 3. JIT correctness ───────────────────────────────────────────────────────
+echo "--- [3] JIT (-r) correctness ---"
+( cd "$REPO_ROOT" && ESHKOL_PATH="$REPO_ROOT/lib" "$ESHKOL_RUN" -r "$SRC" ) > "$WORK/jit.out" 2>&1
+jrc=$?
+if [ "$jrc" -ne 0 ] || ! grep -q "^PASS$" "$WORK/jit.out"; then
+    echo "FAIL: JIT run crashed or mis-verified (exit=$jrc):"; tail -5 "$WORK/jit.out"; fail=1
+else
+    grep -h "iter_scope_partial_reclaim_test" "$WORK/jit.out"; echo "PASS: JIT flat + correct."
+fi
+echo
+
+# ── 4. with-region baseline A/B ──────────────────────────────────────────────
+echo "--- [4] with-region baseline (acceptance target) ---"
+run_aot "$BASELINE" "$WORK/ispr_baseline"
+base_rss=$FR_RSS_MB; base_out="$FR_OUT"
+if [ "$FR_COMPILE_RC" -ne 0 ] || [ "$FR_RUN_RC" -ne 0 ] || ! grep -q "^PASS$" "$base_out"; then
+    echo "  (baseline compile/run failed — skipping A/B comparison)"; cat "$base_out" 2>/dev/null | tail -3
+else
+    echo "  with-region baseline peak_rss=${base_rss}MB   automatic peak_rss=${on_rss}MB"
+    # automatic within 10x of baseline (both flat; pre-fix automatic is unbounded)
+    if [ "$base_rss" -gt 0 ] && [ "$on_rss" -gt $((base_rss * 10)) ]; then
+        echo "FAIL: automatic ${on_rss}MB exceeds 10x the with-region baseline ${base_rss}MB."; fail=1
+    else
+        echo "PASS: automatic within 10x of with-region baseline."
+    fi
+fi
+echo
+
+# ── 5. ADVISORY: fix OFF (ESHKOL_NO_ITER_SCOPE=1) — the "before" ─────────────
+echo "--- [5] advisory: AOT with ESHKOL_NO_ITER_SCOPE=1 at COMPILE time (fix OFF) ---"
+( cd "$WORK" && ESHKOL_NO_ITER_SCOPE=1 "$ESHKOL_RUN" "$SRC" -o "$WORK/ispr_fix_off" ) > "$WORK/compile_off.log" 2>&1
+if [ $? -ne 0 ]; then
+    echo "  (advisory) compile with fix OFF failed — skipping."
+else
+    chmod +x "$WORK/ispr_fix_off"
+    if [ "$TIME_MODE" = "bsd" ]; then
+        ( cd "$WORK" && /usr/bin/time -l perl -e 'my $s=shift; alarm $s; exec @ARGV; die' "$TIMEOUT_S" "$WORK/ispr_fix_off" ) > "$WORK/off.out" 2> "$WORK/off.time"
+        off_rss=$(awk '/maximum resident set size/{printf "%d", $1/1048576}' "$WORK/off.time")
+    else
+        ( cd "$WORK" && /usr/bin/time -v perl -e 'my $s=shift; alarm $s; exec @ARGV; die' "$TIMEOUT_S" "$WORK/ispr_fix_off" ) > "$WORK/off.out" 2> "$WORK/off.time"
+        off_rss=$(awk -F: '/Maximum resident set size/{printf "%d", $2/1024}' "$WORK/off.time")
+    fi
+    [ -n "$off_rss" ] || off_rss=0
+    echo "  (advisory) fix-OFF peak_rss=${off_rss}MB   fix-ON peak_rss=${on_rss}MB"
+    if [ "$off_rss" -gt "$on_rss" ] && [ "$TICKS" -gt 0 ]; then
+        # bytes/tick the fix removes = (delta MB * 2^20) / ticks
+        bpt=$(awk -v d="$((off_rss - on_rss))" -v t="$TICKS" 'BEGIN{printf "%.1f", (d*1048576.0)/t}')
+        echo "  (advisory) fix removes ~${bpt} bytes/tick of transient leak over $TICKS ticks."
+        [ "$off_rss" -gt "$CEILING_MB" ] && echo "  (advisory) confirms the gate WOULD catch the regression: ${off_rss}MB > ${CEILING_MB}MB."
+    fi
+fi
+echo
+
+if [ "$fail" -eq 0 ]; then
+    echo "iter_scope_partial_reclaim_test.sh: PASS"
+else
+    echo "iter_scope_partial_reclaim_test.sh: FAIL"
+fi
+exit "$fail"


### PR DESCRIPTION
## ESH-0214e — iter-scope partial reclamation (closes the ESH-0214 series)

### The defect
ESH-0214b's automatic per-iteration arena reclamation is **all-or-nothing**: the static escape analysis rejects a loop body the moment it contains any persistent mutation, because a value the iteration allocates and then stores into outer/persistent state would dangle when the per-iteration arena scope is rewound, and the shallow out-value span test at the back edge cannot see that store. So a **resident tick-loop that mutates persistent state on every iteration** (a knowledge base via `hash-table-set!`, a workspace via `vector-set!`, a growing list via `set-cdr!`) gets **no** reclamation and retains one iteration's transient garbage forever — measured here at **~3,366 bytes/tick, linear and unbounded** (~355 MB at 100,000 ticks).

### The design (architectural, per the R2 region-memory research)
Replace the all-or-nothing bail with partial reclamation, **reusing the `with-region` deep-transitive escape-promotion path validated over a 48-hour resident run (ESH-0214c/d)** rather than forking a second evacuator. A mutating-but-escape-safe loop is lowered with a **per-loop nursery region**:

- `region_create` / `region_push` / `eshkol_region_enter` open the nursery **once per loop activation**, so every iteration allocation lands in the nursery arena and `region_index_owning()` can classify it;
- the six mutation channels' **existing** write barriers deep-promote each *barrier-recorded escapee* — a nursery value stored into persistent state — out of the nursery into the enclosing arena **at the store**;
- **`eshkol_iter_nursery_recycle`** (new) runs at each TCO back edge: it promotes the loop-carried out-values out via the **same** evacuator (`region_escape_tagged_value`), then `arena_reset()`s the nursery and drops its forwarding map (whose keys reference the just-reset span);
- the loop exit escapes the result and `region_pop`/`region_leave` tear the nursery down.

Sound by the **same invariant as `with-region`'s `region_pop`**: after promotion no surviving object points into the reset span. This is deterministic generational minor collection (nursery = young generation, write barrier = remembered set, back-edge recycle = minor collection) — no tracing pause, preserving Eshkol's no-GC determinism. **Fallback (correctness over reclamation):** if the nursery is not the innermost active region at a back edge, recycle retains that iteration (skips the reset); retention is bounded — the next well-formed back edge reclaims it.

Admitted mutators are the five **structural** channels barriered *unconditionally* on the mutated structure pointer: `vector-set!`, `vector-fill!`, `hash-table-set!`, `set-car!`, `set-cdr!`. `set!` is deliberately **excluded** — its barrier fires only for globals, and proving a `set!` target is global (not a shadowing enclosing-scope local, whose alloca is not barriered) needs lexical resolution this downward-only analysis lacks; admitting it unsoundly would reintroduce the exact dangling-pointer corruption this series closes. **Non-mutating loops keep the exact ESH-0214b arena-scope path** — zero change to the `define_loop_flat_rss_aot` gate.

### Before / after (measured, this PR's reproducer, 100,000 ticks)
| | automatic (this loop) | explicit `with-region` twin |
|---|---|---|
| **before** (fix off, `ESHKOL_NO_ITER_SCOPE=1`) | **355 MB** (~3,366 B/tick, unbounded) | — |
| **after** (fix on) | **34 MB, flat** | **34 MB, flat** |

The automatic path is **indistinguishable from the explicit `with-region` twin** (34 MB = 34 MB), and the fix removes **~3,366 bytes/tick** of transient leak.

### Verification battery (all green; real output in the gate)
- **(a)** New reproducer `tests/memory/iter_scope_partial_reclaim_test.esk` — a 100k-tick guard-wrapped self-tail loop that mutates a global KB (`hash-table-set!`), workspace (`vector-set!`) and growing list (`set-cdr!`) every tick, asserting correct final KB/workspace/list read-back **and** peak RSS < 150 MB. **PASS, JIT and AOT.**
- **(b)** `ESHKOL_ARENA_POISON=1` on the new test **and** the region/evac suites (`region_deep_escape`, `region_evac_rational_bignum`, `region_simple`, `auto_iter_scope`, `region_evac_subtype_coverage`) — **all clean** (a missed escapee would dereference `0xCB..` and crash).
- **(c)** Existing gates unchanged and green: `define_loop_flat_rss_aot` (7 MB flat, non-mutating path untouched), `region_evac_subtype_coverage` (112 MB, poison), `region_mutating_loop_flat_rss` (76 MB), full `tests/memory/`, `guard`/`dynamic-wind`/`callcc` interaction tests.
- **(d)** Generative differential oracle smoke — **0 divergences**, 0 new.
- **(e)** with-region twin `iter_scope_partial_reclaim_baseline.esk` at its 34 MB baseline; automatic within 10x (equal).
- Edge cases verified (JIT + AOT + poison): **named-let** mutating loops, a loop **returning a nursery-allocated accumulator** (result escape), and **nested** mutating loops (inner nursery under outer nursery).

### Files
- `lib/core/runtime_regions.cpp` — `eshkol_iter_nursery_recycle` (promote out-values, poison, reset, drop fwd-map).
- `lib/backend/llvm_codegen.cpp` — relax `iterScopeSafeExpr` to admit the five barriered structural mutators + track the nursery requirement (through the per-function memo); nursery open/recycle/close emitters; wire the named-let and self-tail `define` lowering paths + the TCO back edge.
- `inc/eshkol/backend/binding_codegen.h` — `TailCallContext` nursery fields.
- Tests + `iter_scope_partial_reclaim` ICC oracle + CHANGELOG.

Internal tracking handle: **ESH-0214e**.
