### PR TITLE
fix(parallel): scope reclamation commit-only on pool workers — race-free parallel-map

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -340,6 +340,14 @@ oracles:
 
       - runtime_event:
           event_kinds: [eshkol_smoke]
+          event_names: ["parallel_map_scope_reclaim_race"]
+          event_values: ["PASS"]
+        severity: high
+        label: parallel-map closures using scope-based reclamation (internal loops / memv) never race the shared arena scope stack
+        action: run_parallel_map_scope_reclaim_test
+
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
           event_names: ["error_messages_have_source_locations"]
           event_values: ["PASS"]
         severity: medium

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`parallel-map` corrupted results from closures using scope-based
+  reclamation (memory-safety).** A closure mapped in parallel whose body used
+  per-iteration scope reclamation — an internal named-let loop, or a builtin
+  such as `memv` that brackets scratch allocation in a scope push/pop — could
+  return dangling/overlapping structure once the input crossed the parallel
+  threshold, surfacing nondeterministically as `car`/`cdr: argument is not a
+  pair`, `SIGSEGV`/`SIGBUS`, or a hang; serial `map` over the same closure was
+  always correct. Root cause: work-stealing pool workers are all pinned to the
+  single shared thread-safe process arena, but a bump-arena's scope stack
+  (`arena_push_scope`/`arena_pop_scope`/`eshkol_arena_iter_scope_end`) is
+  intrinsically single-threaded — a pop rewinds the arena's shared bump pointer
+  and frees everything allocated since the matching push. Concurrent workers
+  therefore raced that one scope stack, and one worker's pop freed memory
+  another was still using. Fix: on a pool worker operating on a thread-safe
+  (shared) arena, scope operations degrade to **commit-only** (allocations are
+  retained; the shared scope stack is never rewound), which is exactly the
+  established "commit over reclaim = correctness over throughput" fallback.
+  Per-iteration reclamation is deferred for the duration of parallel execution
+  only; single-threaded and per-worker/region arenas keep full reclamation, so
+  the flat-RSS loop behavior is unchanged. Verified with a repeated
+  crash→green AOT/JIT fixture under `ESHKOL_ARENA_POISON=1`, ThreadSanitizer
+  (73 arena data races → 0), and the existing parallel + region-race +
+  per-thread-arena suites. New ICC gate: `parallel_map_scope_reclaim_race`.
+
 - **matmul tensor reads inside a defined function (#309) — verified resolved
   and now guarded.** #309 reported that a `matmul` result read back via
   `tensor-ref`/`tensor-data` from inside a `define`d function returned zeros,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   crash→green AOT/JIT fixture under `ESHKOL_ARENA_POISON=1`, ThreadSanitizer
   (73 arena data races → 0), and the existing parallel + region-race +
   per-thread-arena suites. New ICC gate: `parallel_map_scope_reclaim_race`.
+- **Benign data race on the arena-poison diagnostic flag.** The
+  `eshkol_arena_poison_enabled()` env-var cache was a plain function-local
+  `int`, first-touched concurrently by pool workers (identical value, but a
+  real ThreadSanitizer-visible race). Now a relaxed `std::atomic<int>`.
 
 - **matmul tensor reads inside a defined function (#309) — verified resolved
   and now guarded.** #309 reported that a `matmul` result read back via

--- a/lib/core/runtime_arena_core.cpp
+++ b/lib/core/runtime_arena_core.cpp
@@ -282,9 +282,48 @@ void* arena_allocate_zeroed(arena_t* arena, size_t size) {
     return ptr;
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// Concurrency invariant for scope-based reclamation
+// ─────────────────────────────────────────────────────────────────────────
+// A bump-allocator arena's scope stack (push mark / pop-rewind / commit) is
+// intrinsically single-threaded: it is one per-arena LIFO of (block, used)
+// marks, and a pop rewinds the arena's shared bump pointer and frees/poisons
+// every block allocated since the matching push.
+//
+// While a work-stealing construct is active (parallel-map/-fold/-filter/
+// -execute and async futures) every pool worker is pinned to the SAME
+// thread-safe process arena (the #217 parallel-scope pin), so concurrent
+// workers would push/pop/rewind that single scope stack simultaneously. That
+// is doubly broken: (a) a data race on current_block / current_block->used /
+// current_scope, and (b) a cross-thread LIFO violation — worker A's pop
+// rewinds (and poisons/frees) memory worker B is still using, handing B a
+// dangling / overlapping cons cell. Symptom: nondeterministic "car/cdr:
+// argument is not a pair", SIGSEGV/SIGBUS, or a hang, but only once the input
+// crosses the parallel threshold and the closure body uses scope-based
+// reclamation (an internal named-let loop's per-iteration scope, or a builtin
+// such as memv that brackets scratch in a push/pop pair). Per-op locking would
+// fix (a) but not (b); the scope stack simply cannot be shared.
+//
+// Fix: on a pool worker operating on a thread-safe (shared) arena, scope
+// operations degrade to COMMIT-ONLY — allocations are retained and the shared
+// scope stack is left untouched. This is exactly ESH-0214b's documented safe
+// fallback ("commit = correctness over reclamation"): per-iteration reclamation
+// is deferred for the duration of parallel execution (the shared arena keeps
+// the memory, released at its normal lifetime), which is correct and bounded by
+// the parallel construct. Single-threaded arenas (main thread; the flat-RSS
+// loop path) and non-thread-safe per-worker/region arenas are unaffected, so
+// ESH-0214b reclamation is preserved everywhere it is actually safe.
+static inline bool arena_scope_ops_are_commit_only(const arena_t* arena) {
+    return arena && arena->thread_safe && arena_is_worker_thread();
+}
+
 // Scope management
 void arena_push_scope(arena_t* arena) {
     if (!arena) return;
+    // Concurrent pool worker on the shared arena: do not touch the shared scope
+    // stack (see arena_scope_ops_are_commit_only). The matching pop/commit is
+    // likewise a no-op, so push/pop stay balanced.
+    if (arena_scope_ops_are_commit_only(arena)) return;
 
     arena_scope_t* scope = (arena_scope_t*)malloc(sizeof(arena_scope_t));
     if (!scope) {
@@ -301,6 +340,13 @@ void arena_push_scope(arena_t* arena) {
 }
 
 void arena_pop_scope(arena_t* arena) {
+    // Concurrent pool worker on the shared arena: commit-only. Retain the
+    // iteration's allocations and leave the shared scope stack/bump pointer
+    // untouched — rewinding here would free/poison memory a sibling worker is
+    // still using (see arena_scope_ops_are_commit_only). Balances the no-op
+    // push above.
+    if (arena_scope_ops_are_commit_only(arena)) return;
+
     if (!arena || !arena->current_scope) {
         eshkol_error("Attempted to pop arena scope with no matching push - "
                      "unbalanced scope operations risk memory corruption");
@@ -368,6 +414,11 @@ void arena_pop_scope(arena_t* arena) {
  * before this feature existed), but the scope stack stays balanced so
  * enclosing push/pop pairs keep their LIFO discipline. */
 void arena_commit_scope(arena_t* arena) {
+    // Concurrent pool worker on the shared arena: the no-op push left nothing on
+    // the shared scope stack, and commit already means "retain allocations", so
+    // there is nothing to do (see arena_scope_ops_are_commit_only).
+    if (arena_scope_ops_are_commit_only(arena)) return;
+
     if (!arena || !arena->current_scope) {
         eshkol_error("Attempted to commit arena scope with no matching push");
         return;
@@ -415,6 +466,12 @@ int arena_top_scope_contains(const arena_t* arena, const void* ptr) {
  * so a shallow per-value span test is sufficient -- no transitive walk. */
 void eshkol_arena_iter_scope_end(arena_t* arena, const eshkol_tagged_value_t* vals, uint64_t n) {
     if (!arena) return;
+    // Concurrent pool worker on the shared arena: commit-only. The loop-entry
+    // arena_push_scope was a no-op, so there is no per-iteration scope to end;
+    // retain this iteration's allocations and never rewind the shared arena
+    // (see arena_scope_ops_are_commit_only). Skips the escape test entirely,
+    // which is the conservative (always-commit) direction anyway.
+    if (arena_scope_ops_are_commit_only(arena)) return;
     if (!arena->current_scope) {
         eshkol_error("iter_scope_end with no active arena scope - unbalanced loop scoping");
         return;

--- a/lib/core/runtime_arena_diagnostics_hosted.cpp
+++ b/lib/core/runtime_arena_diagnostics_hosted.cpp
@@ -6,22 +6,32 @@
  * Hosted arena diagnostics policy.
  */
 
+#include <atomic>
 #include <cstdlib>
 
 /**
  * @brief Report whether arena allocation poisoning is enabled for this process.
  *
- * Reads the ESHKOL_ARENA_POISON environment variable once (cached in a
- * function-local static) and enables poisoning unless it is unset, empty,
- * or "0".
+ * Reads the ESHKOL_ARENA_POISON environment variable once (cached in an atomic
+ * function-local static) and enables poisoning unless it is unset, empty, or
+ * "0".
+ *
+ * The cache is an atomic tri-state (-1 = uncomputed, 0/1 = resolved) because
+ * arena allocation runs concurrently on pool workers: the plain-int cache
+ * previously raced (benign, same value, but a real TSan-visible data race) when
+ * multiple workers first touched it simultaneously. Relaxed ordering suffices —
+ * the computed value is idempotent, so a redundant recompute by a racing thread
+ * writes the identical result.
  *
  * @return Non-zero if arena poisoning is enabled, zero otherwise.
  */
 extern "C" int eshkol_arena_poison_enabled(void) {
-    static int poison_enabled = -1;
-    if (poison_enabled < 0) {
+    static std::atomic<int> poison_enabled{-1};
+    int cached = poison_enabled.load(std::memory_order_relaxed);
+    if (cached < 0) {
         const char* env = std::getenv("ESHKOL_ARENA_POISON");
-        poison_enabled = (env && env[0] && env[0] != '0') ? 1 : 0;
+        cached = (env && env[0] && env[0] != '0') ? 1 : 0;
+        poison_enabled.store(cached, std::memory_order_relaxed);
     }
-    return poison_enabled;
+    return cached;
 }

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -417,6 +417,12 @@ probe region_evac_subtype_coverage \
      out=$(ESHKOL_ARENA_POISON=1 BUILD_DIR="$BUILD_DIR_PATH" bash tests/memory/region_evac_subtype_coverage_test.sh 2>&1) || exit 1;
      printf "%s" "$out" | grep -q "region_evac_subtype_coverage_test.sh: PASS"'
 
+probe parallel_map_scope_reclaim_race \
+    'parallel-map over a closure using scope-based reclamation (internal named-let loops + memv) is race-free: workers no longer push/pop/rewind the shared arena scope stack concurrently. AOT, repeated under ESHKOL_ARENA_POISON=1' \
+    'cd "$REPO_ROOT";
+     out=$(BUILD_DIR="$BUILD_DIR_PATH" bash tests/parallel/parallel_map_scope_reclaim_test.sh 2>&1) || exit 1;
+     printf "%s" "$out" | grep -q "parallel_map_scope_reclaim_test.sh: PASS"'
+
 probe jit_cache_hit_invalidates 'eshkol-run -r persistent cache hits and source edits invalidate' \
     'bash "$REPO_ROOT/tests/v1_3_edge_cases/jit_cache_test.sh" "$ESHKOL_RUN"'
 

--- a/tests/parallel/parallel_map_scope_reclaim_test.esk
+++ b/tests/parallel/parallel_map_scope_reclaim_test.esk
@@ -1,0 +1,96 @@
+;;; tests/parallel/parallel_map_scope_reclaim_test.esk
+;;;
+;;; Concurrency × per-iteration-scope-reclamation regression fixture.
+;;;
+;;; parallel-map runs its mapped function on work-stealing pool threads, all
+;;; pinned to the single shared thread-safe process arena (the parallel-scope
+;;; pin). A bump-arena's SCOPE STACK (arena_push_scope / arena_pop_scope /
+;;; eshkol_arena_iter_scope_end) is intrinsically single-threaded: a pop rewinds
+;;; the arena's shared bump pointer and frees the memory allocated since the
+;;; matching push.
+;;;
+;;; A mapped closure whose body uses scope-based reclamation therefore drives
+;;; concurrent push/pop/rewind of that ONE shared scope stack across workers:
+;;;   - an internal named-let loop (per-iteration scope reclamation), and/or
+;;;   - a builtin such as memv that brackets scratch allocation in a push/pop.
+;;; Pre-fix, worker A's pop rewinds/frees memory worker B is still using, so B
+;;; is handed a dangling / overlapping cons cell: "car/cdr: argument is not a
+;;; pair", SIGSEGV/SIGBUS, or a hang — nondeterministically, only once the input
+;;; crosses the parallel threshold. With scope operations degraded to
+;;; commit-only on pool workers, the shared scope stack is never touched
+;;; concurrently and results are deterministic and correct.
+;;;
+;;; The closure below deliberately uses BOTH triggers (internal named-let loops
+;;; and memv), captures a shared list, allocates nested lists, and sometimes
+;;; returns #f. Each parallel-map result is compared against serial map over the
+;;; same closure; a full deep traversal after completion catches dangling
+;;; interior structure.
+
+(define (iota n)
+  (let loop ((i (- n 1)) (acc '()))
+    (if (< i 0) acc (loop (- i 1) (cons i acc)))))
+
+;; internal named-let loop + memv -> emits per-iteration arena scope push/pop
+(define (count-overlap a b)
+  (let loop ((xs a) (c 0))
+    (if (pair? xs)
+        (loop (cdr xs) (if (memv (car xs) b) (+ c 1) c))
+        c)))
+
+(define (build-syms i)
+  (let loop ((k 0) (acc '()))
+    (if (< k 12) (loop (+ k 1) (cons (modulo (+ i k) 7) acc)) acc)))
+
+(define goal (list 0 1 2 3 4 5))
+
+;; captures goal; allocates nested lists; sometimes returns #f
+(define (score p)
+  (let* ((syms (build-syms p))
+         (ov   (count-overlap goal syms))
+         (co   (count-overlap syms goal)))
+    (if (> ov 0)
+        (list p (list ov co) syms goal)
+        #f)))
+
+(define (deep-checksum x)
+  (cond ((pair? x) (+ (deep-checksum (car x)) (deep-checksum (cdr x))))
+        ((number? x) x)
+        (else 0)))
+
+(define (traverse-sum res)
+  (let loop ((r res) (acc 0))
+    (if (pair? r)
+        (loop (cdr r) (+ acc (if (car r) (deep-checksum (car r)) 0)))
+        acc)))
+
+(define (serial-golden n) (traverse-sum (map score (iota n))))
+
+;; Run parallel-map REPS times per size and require every run to match the
+;; serial golden exactly. The race is probabilistic, so repetition raises the
+;; per-invocation trigger probability.
+(define REPS 40)
+
+(define (check-size n)
+  (let ((golden (serial-golden n)))
+    (let loop ((r 0))
+      (if (< r REPS)
+          (let ((got (traverse-sum (parallel-map score (iota n)))))
+            (if (= got golden)
+                (loop (+ r 1))
+                (begin
+                  (display "FAIL: n=") (display n)
+                  (display " rep=") (display r)
+                  (display " golden=") (display golden)
+                  (display " got=") (display got) (newline)
+                  #f)))
+          #t))))
+
+(define (run sizes)
+  (let loop ((s sizes))
+    (if (pair? s)
+        (if (check-size (car s))
+            (loop (cdr s))
+            (begin (display "RESULT: FAIL") (newline) (exit 1)))
+        (begin (display "RESULT: PASS") (newline) (exit 0)))))
+
+(run (list 16 17 20 24 32 48 64 128))

--- a/tests/parallel/parallel_map_scope_reclaim_test.sh
+++ b/tests/parallel/parallel_map_scope_reclaim_test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# tests/parallel/parallel_map_scope_reclaim_test.sh
+#
+# Concurrency regression gate: parallel-map over a closure whose body uses
+# scope-based reclamation (internal named-let loops + memv) must not corrupt
+# results by racing the shared arena's single scope stack across pool workers.
+#
+# A bump-arena scope stack is single-threaded; before the fix, concurrent
+# workers pinned to the shared arena would push/pop/rewind it simultaneously,
+# so one worker's pop freed memory another was using -> "car/cdr: argument is
+# not a pair", SIGSEGV/SIGBUS, or a hang, nondeterministically above the
+# parallel threshold. The fix degrades scope operations to commit-only on pool
+# workers.
+#
+# The race is probabilistic, so this gate compiles the fixture AOT and runs it
+# REPEATEDLY under ESHKOL_ARENA_POISON=1 (freed arena bytes are filled with
+# 0xCB, turning a dangling read into a loud crash instead of a silent stale
+# read). It fails if ANY run crashes, hangs, or does not print "RESULT: PASS".
+#
+# Usage: tests/parallel/parallel_map_scope_reclaim_test.sh [--runs N] [--timeout S]
+#   BUILD_DIR env var selects the build directory (default: build).
+#   ESHKOL_RUN env var overrides the eshkol-run binary path directly.
+set -u
+export LC_ALL=C LC_CTYPE=C LANG=C
+cd "$(dirname "$0")/../.."
+REPO_ROOT="$(pwd)"
+
+RUNS=25
+PER_RUN_TIMEOUT=60
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --runs) RUNS="$2"; shift 2 ;;
+        --timeout) PER_RUN_TIMEOUT="$2"; shift 2 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+BUILD_DIR="${BUILD_DIR:-build}"
+case "$BUILD_DIR" in
+    /*) : ;;
+    *)  BUILD_DIR="$REPO_ROOT/$BUILD_DIR" ;;
+esac
+ESHKOL_RUN="${ESHKOL_RUN:-$BUILD_DIR/eshkol-run}"
+
+if [ ! -x "$ESHKOL_RUN" ]; then
+    echo "parallel_map_scope_reclaim_test.sh: eshkol-run not found at $ESHKOL_RUN" >&2
+    exit 2
+fi
+
+SRC="$REPO_ROOT/tests/parallel/parallel_map_scope_reclaim_test.esk"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+BIN="$WORK/scope_reclaim"
+
+# Optional per-run timeout wrapper (coreutils timeout / gtimeout if present).
+TIMEOUT_BIN=""
+if command -v timeout >/dev/null 2>&1; then TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then TIMEOUT_BIN="gtimeout"; fi
+
+echo "parallel_map_scope_reclaim_test.sh: compiling AOT ..."
+if ! "$ESHKOL_RUN" "$SRC" -o "$BIN" >"$WORK/compile.log" 2>&1; then
+    echo "parallel_map_scope_reclaim_test.sh: FAIL (AOT compile failed)"
+    tail -20 "$WORK/compile.log"
+    exit 1
+fi
+
+echo "parallel_map_scope_reclaim_test.sh: running $RUNS iterations under ESHKOL_ARENA_POISON=1 ..."
+for i in $(seq 1 "$RUNS"); do
+    if [ -n "$TIMEOUT_BIN" ]; then
+        out=$(ESHKOL_ARENA_POISON=1 "$TIMEOUT_BIN" "$PER_RUN_TIMEOUT" "$BIN" 2>&1); rc=$?
+    else
+        out=$(ESHKOL_ARENA_POISON=1 "$BIN" 2>&1); rc=$?
+    fi
+    if [ "$rc" -ne 0 ]; then
+        echo "parallel_map_scope_reclaim_test.sh: FAIL (run $i crashed/timed out, exit $rc)"
+        printf '%s\n' "$out" | tail -5
+        exit 1
+    fi
+    if ! printf '%s\n' "$out" | grep -q "RESULT: PASS"; then
+        echo "parallel_map_scope_reclaim_test.sh: FAIL (run $i did not print RESULT: PASS)"
+        printf '%s\n' "$out" | tail -5
+        exit 1
+    fi
+done
+
+echo "parallel_map_scope_reclaim_test.sh: PASS ($RUNS/$RUNS runs clean under poison)"
+exit 0


### PR DESCRIPTION
## Summary

`parallel-map` could corrupt the results of a mapped closure whose body uses **scope-based reclamation**, once the input crossed the parallel threshold. The corruption was **nondeterministic** (a data race) and surfaced as `car`/`cdr: argument is not a pair`, `SIGSEGV`/`SIGBUS`, or a hang. Serial `map` over the same closure was always correct. This is a memory-safety / concurrency bug.

The load-bearing trigger is a closure that internally uses **per-iteration scope reclamation** — an internal `named-let` loop, or a builtin such as `memv` that brackets scratch allocation in an `arena_push_scope`/`arena_pop_scope` pair. Closures that only build nested lists / strings / return `#f` (no scope ops) never hit it, which is why it evaded earlier synthetic stress.

## Root cause

Work-stealing pool workers are all pinned to the single shared **thread-safe** process arena (the parallel-scope pin). But a bump-allocator arena's **scope stack is intrinsically single-threaded**:

- `arena_push_scope` records a `(block, used)` mark.
- `arena_pop_scope` / `eshkol_arena_iter_scope_end` rewind the arena's shared bump pointer and **free/poison every block allocated since the matching push**.

With every worker sharing that one arena, concurrent workers pushed/popped/rewound the **same** scope stack simultaneously — both a data race on `current_block` / `current_block->used` / `current_scope`, and a fatal **cross-thread LIFO violation**: worker A's pop frees/rewinds memory worker B is still using, handing B a dangling / overlapping cons cell. Per-op locking would fix the torn state but not the semantic violation — the scope stack cannot be shared across concurrently-executing threads.

ThreadSanitizer on the reproducer pinpointed it: **73 data races**, all on `arena_push_scope` / `arena_pop_scope` / `eshkol_arena_iter_scope_end` racing each other and `arena_allocate_aligned` on the same arena across worker threads.

## Fix

On a pool worker operating on a thread-safe (shared) arena, scope operations degrade to **commit-only** — allocations are retained and the shared scope stack is never rewound. This is exactly ESH-0214b's documented safe fallback ("commit = correctness over reclamation"). Per-iteration reclamation is deferred **only for the duration of parallel execution** (the shared arena keeps the memory, released at its normal lifetime). Single-threaded arenas (main thread; the flat-RSS loop path) and non-thread-safe per-worker/region arenas are unaffected, so ESH-0214b reclamation is preserved everywhere it is actually safe.

Gate: `arena->thread_safe && arena_is_worker_thread()`, applied to `arena_push_scope`, `arena_pop_scope`, `arena_commit_scope`, and `eshkol_arena_iter_scope_end` in `lib/core/runtime_arena_core.cpp`.

A second commit fixes a **benign** ThreadSanitizer-visible race the investigation surfaced: `eshkol_arena_poison_enabled()`'s env-var cache was a plain `int` first-touched concurrently by workers → now a relaxed `std::atomic<int>`.

## Before / after (repeated AOT run under `ESHKOL_ARENA_POISON=1`)

```
pre-fix:  run 1 -> SIGSEGV (exit 139); "car: argument is not a pair";
          "cdr: argument is not a pair"; (also intermittent hangs)   [fails immediately]
post-fix: 150/150 runs clean, deterministic checksum
```

## Verification

- **Reduced consumer-free reproducer** (`tests/parallel/parallel_map_scope_reclaim_test.{esk,sh}`): crash→green. Proven to **fail pre-fix** (reverted the fix, rebuilt → SIGSEGV / "not a pair") and **pass post-fix** (25/25 and 150/150 runs clean under poison).
- **ThreadSanitizer**: 73 arena data races → **0** on the same workload, including under `ESHKOL_ARENA_POISON=1`; results correct.
- **Existing suites (under poison)**: `parallel_map_test` OK; `parallel_region_race_test` (N=4000, with-region in workers) 24/24; `parallel_ad_worker_init_test` 8/8 (incl. N=1000 parallel-map); `parallel_flags_byte_regression` PASS.
- **ICC**: new gate `parallel_map_scope_reclaim_race` PASS; `per_thread_arena_works` OK; `generative_differential_oracle` PASS (0 divergences across chibi/JIT/AOT-O0/AOT-O2/VM).
- **Regression**: seven independent parallel-map synthetics (nested lists, strings, region-escape, nested parallel-map, N up to 500) all clean under poison; a 500-item × 30-rep scope-ops stress clean under poison.

## Coordination notes

- Does **not** touch `runtime_regions.cpp`, `llvm_codegen.cpp`, or `binding_codegen.h` (PR the tracked defect's code files) — no code conflict with the in-flight ESH-0214e work.
- Shares append-only additions in `CHANGELOG.md`, `.icc/completion-oracles.yaml`, and `scripts/run_icc_smoke.sh` with the tracked defect; these are trivial text merges. Serialize merge order at the maintainer's discretion.
- The fix lands in the arena/scope core (`runtime_arena_core.cpp`), i.e. beyond the strict parallel-codegen path, but is the architectural root of this race.