### PR TITLE
feat(types): predicate narrowing, honored sum annotations, checked casts, numeric-join accumulators

### DIFF
--- a/inc/eshkol/eshkol.h
+++ b/inc/eshkol/eshkol.h
@@ -2206,6 +2206,9 @@ typedef enum {
     ESHKOL_SDNC_SET_PARAMS_OP,      // (sdnc-set-params! θ vec) -> θ
     ESHKOL_SDNC_IMPROVE_OP,         // (sdnc-improve! θ data steps lr) -> θ
     ESHKOL_SDNC_PRED_OP,            // (sdnc? x) -> bool
+    // Expression-level type ascription (checked cast). Appended at the end to
+    // preserve the numeric value of every existing operator.
+    ESHKOL_THE_OP,                  // (the type expr) - ascribe expr's type to the checker; runtime no-op (evaluates expr verbatim)
 } eshkol_op_t;
 
 struct eshkol_ast;
@@ -2404,6 +2407,10 @@ typedef struct eshkol_operation {
             char *name;                     // Name being annotated
             hott_type_expr_t *type_expr;    // The type expression
         } type_annotation_op;
+        struct {
+            hott_type_expr_t *type_expr;    // Ascribed type
+            struct eshkol_ast *expr;        // Wrapped expression (evaluated verbatim at runtime)
+        } the_op;                           // (the type expr) - expression-level checked cast
         struct {
             char **type_vars;               // Quantified type variable names
             uint64_t num_vars;

--- a/inc/eshkol/types/hott_types.h
+++ b/inc/eshkol/types/hott_types.h
@@ -452,6 +452,22 @@ private:
     // Next pair type ID (allocated dynamically)
     mutable uint16_t next_pair_type_id_ = 300;  // Pair types in range 300-499
 
+    // Sum type member cache: maps a synthetic Sum TypeId → its member arms.
+    // Sum types (written `(+ A B ...)` in annotations) let a single binding
+    // stand for a value that may take any one of several concrete types
+    // (e.g. `(+ boolean (vector any))` for an accumulator that starts #f and
+    // later becomes a vector). They are a compile-time-only refinement: at
+    // runtime every value already carries its own tag, so a sum has no
+    // distinct representation and collapses to Pair for codegen purposes.
+    mutable std::map<uint16_t, std::vector<TypeId>> sum_member_cache_;
+
+    // Next sum type ID. Deliberately placed in a high range that the other
+    // dynamic allocators (pairs 300-499, functions 500-999) and user types
+    // (1000+) do not realistically reach, so ids stay disjoint without
+    // perturbing any existing allocation (which would risk shifting the
+    // TypeIds packed into AST nodes and thus codegen).
+    mutable uint16_t next_sum_type_id_ = 60000;  // Sum types in range 60000+
+
 public:
     /**
      * Construct a TypeEnvironment with all builtin types registered.
@@ -698,6 +714,38 @@ public:
      * Check if a TypeId represents a tracked pair type (with known element types).
      */
     bool isTrackedPairType(TypeId id) const;
+
+    // ========== Sum Type Tracking ==========
+
+    /**
+     * Create or retrieve a synthetic sum type over the given member arms.
+     *
+     * A sum type accepts a value if it fits any one arm, and is itself a
+     * subtype of some T if *every* arm is a subtype of T. Nested sums are
+     * flattened and duplicate arms removed. A degenerate sum with a single
+     * distinct arm collapses to that arm; an empty member list yields Value.
+     */
+    TypeId makeSumType(const std::vector<TypeId>& members) const;
+
+    /**
+     * Get the member arms of a sum TypeId, or nullopt if @p id is not a sum.
+     */
+    std::optional<std::vector<TypeId>> getSumMembers(TypeId id) const;
+
+    /**
+     * Check whether a TypeId represents a synthetic sum type.
+     */
+    bool isSumType(TypeId id) const;
+
+    /**
+     * Collapse a type to its codegen-facing representation. Sum types have no
+     * distinct runtime representation (values are tagged), so they collapse to
+     * Pair — the same TypeId a `(+ ...)` annotation resolved to before sum
+     * tracking existed. Non-sum types are returned unchanged. Used when
+     * writing a node's inferred type into the AST so that adding sum-type
+     * precision to the checker never perturbs generated code.
+     */
+    TypeId codegenReprOf(TypeId id) const;
 
 private:
     /**

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -10866,6 +10866,12 @@ private:
                 // but generate no runtime code (proof erasure)
                 return packNullToTaggedValue();
 
+            // Expression-level checked cast (the <type> <expr>): the type is
+            // erased; the value is exactly that of the wrapped expression. Pure
+            // passthrough — emits identical IR to writing <expr> directly.
+            case ESHKOL_THE_OP:
+                return codegenAST(op->the_op.expr);
+
             // Multiple Return Values operations
             case ESHKOL_VALUES_OP:
                 return codegenValues(op);

--- a/lib/core/printer.cpp
+++ b/lib/core/printer.cpp
@@ -102,6 +102,7 @@ static const char* op_to_string(eshkol_op_t op) {
         case ESHKOL_LAPLACIAN_OP: return "LAPLACIAN_OP";
         case ESHKOL_DIRECTIONAL_DERIV_OP: return "DIRECTIONAL_DERIV_OP";
         case ESHKOL_TYPE_ANNOTATION_OP: return "TYPE_ANNOTATION_OP";
+        case ESHKOL_THE_OP: return "THE_OP";
         case ESHKOL_FORALL_OP: return "FORALL_OP";
         case ESHKOL_GUARD_OP: return "GUARD_OP";
         case ESHKOL_RAISE_OP: return "RAISE_OP";

--- a/lib/frontend/macro_expander.cpp
+++ b/lib/frontend/macro_expander.cpp
@@ -411,6 +411,16 @@ eshkol_ast_t MacroExpander::expandNode(const eshkol_ast_t& ast) {
                 }
                 break;
 
+            case ESHKOL_THE_OP:
+                // Expand macros inside the wrapped expression of a (the T e)
+                // ascription; the type expression carries no macro calls.
+                if (op->the_op.expr) {
+                    eshkol_ast_t* new_expr = new eshkol_ast_t;
+                    *new_expr = expandNode(*op->the_op.expr);
+                    op->the_op.expr = new_expr;
+                }
+                break;
+
             default:
                 break;
         }

--- a/lib/frontend/parser.cpp
+++ b/lib/frontend/parser.cpp
@@ -2848,7 +2848,15 @@ static void collectVariableReferences(const eshkol_ast_t* ast, std::set<std::str
                         collectVariableReferences(&ast->operation.sequence_op.expressions[i], refs);
                     }
                     break;
-                    
+
+                case ESHKOL_THE_OP:
+                    // (the T e): the wrapped expression may reference captured
+                    // variables — collect them so closures capture correctly.
+                    if (ast->operation.the_op.expr) {
+                        collectVariableReferences(ast->operation.the_op.expr, refs);
+                    }
+                    break;
+
                 case ESHKOL_DERIVATIVE_OP:
                     if (ast->operation.derivative_op.function) {
                         collectVariableReferences(ast->operation.derivative_op.function, refs);
@@ -4640,6 +4648,64 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
 
         eshkol_debug("Parsed type annotation for '%s'", name_token.value.c_str());
         return ast;
+    }
+
+    // Handle expression-level type ascription: (the <type> <expr>)
+    //
+    // This is a checked cast: it asserts <expr> has <type> to the type checker
+    // (letting a value recovered from a dynamic container — e.g.
+    // (the string (cdr (assoc key alist))) — satisfy a typed parameter without
+    // reconstruction) and is a pure no-op at runtime, evaluating exactly to
+    // <expr>. `the` is only special in head position; used as an ordinary
+    // identifier elsewhere it is unaffected.
+    if (token.type == TOKEN_SYMBOL && token.value == "the") {
+        // Look ahead: (the <type> <expr>). We must not steal the identifier
+        // `the` when it heads something that is not a type ascription (e.g. a
+        // user procedure named `the`); in that case fall through to the
+        // ordinary call path below. An ascription's second element is a type:
+        // either a parenthesised type form `(vector any)` or a primitive type
+        // name. A bare non-type symbol keeps `the` an ordinary call head.
+        Token t2 = tokenizer.peekToken();  // non-destructive (pushes back)
+        auto isPrimitiveTypeName = [](const std::string& n) {
+            std::string l = n;
+            for (auto& c : l) c = std::tolower((unsigned char)c);
+            return l == "integer" || l == "int" || l == "int64" ||
+                   l == "real" || l == "float" || l == "double" || l == "float64" ||
+                   l == "boolean" || l == "bool" || l == "string" || l == "str" ||
+                   l == "char" || l == "character" || l == "symbol" ||
+                   l == "null" || l == "nil" || l == "any" ||
+                   l == "nothing" || l == "never";
+        };
+        bool looks_like_ascription =
+            (t2.type == TOKEN_LPAREN) ||
+            (t2.type == TOKEN_SYMBOL && isPrimitiveTypeName(t2.value));
+        if (looks_like_ascription) {
+            hott_type_expr_t* type_expr = parseTypeExpression(tokenizer);
+            if (!type_expr) {
+                PARSE_ERROR_AT(token, "failed to parse type expression in (the ...) ascription");
+                ast.type = ESHKOL_INVALID;
+                return ast;
+            }
+            eshkol_ast_t inner = parse_expression(tokenizer);
+            if (inner.type == ESHKOL_INVALID) {
+                hott_free_type_expr(type_expr);
+                ast.type = ESHKOL_INVALID;
+                return ast;
+            }
+            Token rparen = tokenizer.nextToken();
+            if (rparen.type != TOKEN_RPAREN) {
+                PARSE_ERROR_AT(token, "expected ) after (the type expr) ascription");
+                hott_free_type_expr(type_expr);
+                ast.type = ESHKOL_INVALID;
+                return ast;
+            }
+            ast.type = ESHKOL_OP;
+            ast.operation.op = ESHKOL_THE_OP;
+            ast.operation.the_op.type_expr = type_expr;
+            ast.operation.the_op.expr = new eshkol_ast_t(inner);
+            return ast;
+        }
+        // else: not an ascription — fall through to ordinary symbol handling.
     }
 
     // First element should determine the operation

--- a/lib/types/hott_types.cpp
+++ b/lib/types/hott_types.cpp
@@ -9,6 +9,7 @@
 #include <eshkol/types/hott_types.h>
 #include <eshkol/eshkol.h>
 #include <algorithm>
+#include <functional>
 #include <stdexcept>
 
 namespace eshkol::hott {
@@ -422,6 +423,16 @@ const TypeNode* TypeEnvironment::getTypeNode(TypeId id) const {
  * types; otherwise returns the registered name, or "unknown" if @p id is not registered.
  */
 std::string TypeEnvironment::getTypeName(TypeId id) const {
+    // Check if this is a synthetic sum type
+    auto sum_members = getSumMembers(id);
+    if (sum_members) {
+        std::string result = "(+";
+        for (const auto& m : *sum_members) {
+            result += " " + getTypeName(m);
+        }
+        result += ")";
+        return result;
+    }
     // Check if this is a tracked pair type
     auto pair_elems = getPairElementTypes(id);
     if (pair_elems) {
@@ -461,6 +472,32 @@ bool TypeEnvironment::isSubtype(TypeId sub, TypeId super) const {
 bool TypeEnvironment::isSubtypeUncached(TypeId sub, TypeId super) const {
     // Reflexivity
     if (sub == super) return true;
+
+    // Sum types. `sub <: (+ A B ...)` holds when sub fits any one arm; this is
+    // the rule that lets a value of a concrete arm type (e.g. Vector) satisfy a
+    // parameter declared with an explicit sum annotation. `(+ A B ...) <: super`
+    // holds when *every* arm is a subtype of super (the sum is subsumed only by
+    // a type that covers all its cases, e.g. (+ integer real) <: number).
+    {
+        auto super_members = getSumMembers(super);
+        if (super_members) {
+            for (const auto& arm : *super_members) {
+                if (isSubtype(sub, arm)) return true;
+            }
+            // Fall through so a sum sub can still be checked arm-by-arm below,
+            // but a non-sum sub that matched no arm is not a subtype.
+        }
+        auto sub_members = getSumMembers(sub);
+        if (sub_members) {
+            for (const auto& arm : *sub_members) {
+                if (!isSubtype(arm, super)) return false;
+            }
+            return true;
+        }
+        if (super_members) {
+            return false;  // non-sum sub matched no arm of the sum super
+        }
+    }
 
     // Tracked pair types are subtypes of Pair (and Pair's supertypes)
     if (isTrackedPairType(sub)) {
@@ -1035,6 +1072,91 @@ std::optional<std::pair<TypeId, TypeId>> TypeEnvironment::getPairElementTypes(Ty
  */
 bool TypeEnvironment::isTrackedPairType(TypeId id) const {
     return pair_element_cache_.find(id.id) != pair_element_cache_.end();
+}
+
+// ============================================================================
+// SUM TYPE TRACKING
+// ============================================================================
+
+/**
+ * @brief Create or retrieve a synthetic sum type over @p members.
+ *
+ * Flattens nested sums, de-duplicates arms (by id), and collapses degenerate
+ * cases (empty → Value, single arm → that arm). Otherwise searches the cache
+ * for an existing sum with the same normalized arm set and reuses it, or
+ * allocates a fresh id from next_sum_type_id_.
+ */
+TypeId TypeEnvironment::makeSumType(const std::vector<TypeId>& members) const {
+    // Normalize: flatten nested sums and de-duplicate arms preserving order.
+    std::vector<TypeId> arms;
+    std::function<void(const std::vector<TypeId>&)> flatten =
+        [&](const std::vector<TypeId>& ms) {
+            for (const auto& m : ms) {
+                auto nested = getSumMembers(m);
+                if (nested) {
+                    flatten(*nested);
+                    continue;
+                }
+                bool seen = false;
+                for (const auto& a : arms) {
+                    if (a.id == m.id) { seen = true; break; }
+                }
+                if (!seen) arms.push_back(m);
+            }
+        };
+    flatten(members);
+
+    if (arms.empty()) return BuiltinTypes::Value;
+    if (arms.size() == 1) return arms[0];
+
+    // Reuse an existing sum with the same arm set (order-insensitive).
+    for (const auto& entry : sum_member_cache_) {
+        if (entry.second.size() != arms.size()) continue;
+        bool match = true;
+        for (const auto& a : arms) {
+            bool found = false;
+            for (const auto& b : entry.second) {
+                if (a.id == b.id) { found = true; break; }
+            }
+            if (!found) { match = false; break; }
+        }
+        if (match) {
+            return TypeId{entry.first, Universe::U1, 0};
+        }
+    }
+
+    uint16_t type_id = next_sum_type_id_++;
+    sum_member_cache_[type_id] = arms;
+    return TypeId{type_id, Universe::U1, 0};
+}
+
+/**
+ * @brief Get the member arms of a sum TypeId, or nullopt if not a sum.
+ */
+std::optional<std::vector<TypeId>> TypeEnvironment::getSumMembers(TypeId id) const {
+    auto it = sum_member_cache_.find(id.id);
+    if (it != sum_member_cache_.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+/**
+ * @brief Check whether a TypeId represents a synthetic sum type.
+ */
+bool TypeEnvironment::isSumType(TypeId id) const {
+    return sum_member_cache_.find(id.id) != sum_member_cache_.end();
+}
+
+/**
+ * @brief Collapse a sum type to Pair (its historical codegen representation);
+ * pass non-sum types through unchanged.
+ */
+TypeId TypeEnvironment::codegenReprOf(TypeId id) const {
+    if (isSumType(id)) {
+        return BuiltinTypes::Pair;
+    }
+    return id;
 }
 
 } // namespace eshkol::hott

--- a/lib/types/type_checker.cpp
+++ b/lib/types/type_checker.cpp
@@ -830,9 +830,20 @@ TypeChecker::TypeChecker(TypeEnvironment& env, bool strict_types, bool unsafe_mo
  * synthesis/checking rule records its result type on the AST node it typed.
  * Failed results pass through without touching @p expr.
  */
-static TypeCheckResult storeAndReturn(eshkol_ast_t* expr, TypeCheckResult result) {
+static TypeCheckResult storeAndReturn(eshkol_ast_t* expr, TypeCheckResult result,
+                                      const TypeEnvironment* env = nullptr) {
     if (result.success && expr) {
-        expr->inferred_hott_type = result.inferred_type.pack();
+        // Sum types are a checker-only refinement with no distinct runtime
+        // representation. Collapse them to their codegen-facing form (Pair)
+        // before writing the AST's inferred type so that adding sum precision
+        // never changes what codegen reads from inferred_hott_type. The
+        // TypeCheckResult itself still carries the true (sum) type upward for
+        // subtype checks.
+        TypeId stored = result.inferred_type;
+        if (env) {
+            stored = env->codegenReprOf(stored);
+        }
+        expr->inferred_hott_type = stored.pack();
     }
     return result;
 }
@@ -963,7 +974,7 @@ TypeCheckResult TypeChecker::synthesize(eshkol_ast_t* expr) {
             return TypeCheckResult::error("Cannot synthesize type for this expression");
     }
 
-    return storeAndReturn(expr, result);
+    return storeAndReturn(expr, result, &env_);
 }
 
 /**
@@ -1147,6 +1158,21 @@ TypeCheckResult TypeChecker::synthesizeOperation(eshkol_ast_t* expr) {
 
         case ESHKOL_CALL_OP:
             return synthesizeApplication(expr);
+
+        case ESHKOL_THE_OP: {
+            // Expression-level checked cast (the <type> <expr>): a trusted
+            // ascription. Still synthesize the inner expression so nested type
+            // errors are reported, but the ascribed type is what flows onward,
+            // letting a value recovered from a dynamic container satisfy a typed
+            // context without reconstruction. Runtime is unaffected — codegen
+            // evaluates the inner expression verbatim. This is a gradual-typing
+            // trust boundary (no runtime check), consistent with `--strict-types`
+            // as a whole-program refinement rather than a soundness proof.
+            if (expr->operation.the_op.expr) {
+                synthesize(expr->operation.the_op.expr);
+            }
+            return TypeCheckResult::ok(resolveType(expr->operation.the_op.type_expr));
+        }
 
         case ESHKOL_DEFINE_TYPE_OP: {
             // Type definition - register alias and return null
@@ -1496,6 +1522,14 @@ TypeCheckResult TypeChecker::synthesizeApplication(eshkol_ast_t* expr) {
     const bool has_builtin_name = func_expr->type == ESHKOL_VAR && func_expr->variable.id;
     if (has_builtin_name) {
         builtin_name = func_expr->variable.id;
+    }
+
+    // `if` is lowered by the parser to a call to the builtin "if" (func == "if",
+    // args = condition/then/else). Route it to synthesizeIf() BEFORE the generic
+    // argument pre-synthesis below, so the then-branch is synthesized under
+    // predicate-guarded narrowing rather than being eagerly checked without it.
+    if (has_builtin_name && builtin_name == "if" && call.num_vars >= 2) {
+        return synthesizeIf(expr);
     }
 
     const auto should_skip_builtin_designator_arg = [&](size_t index) {
@@ -2619,9 +2653,27 @@ TypeCheckResult TypeChecker::synthesizeApplication(eshkol_ast_t* expr) {
                     // Skip check if either is Value (unknown/top type) or same type
                     if (expected != BuiltinTypes::Value && actual != BuiltinTypes::Value &&
                         expected != actual) {
-                        // Check if types are compatible via LCS
-                        auto lcs = env_.leastCommonSupertype(expected, actual);
-                        if (!lcs || *lcs != expected) {
+                        // The argument is acceptable when it is a subtype of the
+                        // parameter. isSubtype() subsumes the earlier LCS test for
+                        // the ordinary hierarchy and additionally accepts a value
+                        // of any arm of an explicit sum parameter (item 1) —
+                        // e.g. Vector <: (+ boolean (vector any)).
+                        bool compatible = env_.isSubtype(actual, expected);
+
+                        // Numeric-tower join (item 4): a numeric accumulator
+                        // declared/inferred at one rung (e.g. Float64 from a 0.0
+                        // seed) recombined with a value widened to Number through
+                        // heterogeneous records must not error on the recursive
+                        // call — all operands are real and the tower promotes them
+                        // at runtime regardless. Two numeric types are always
+                        // reconcilable to their join, so accept. A non-numeric
+                        // actual (e.g. String) is still rejected below.
+                        if (!compatible &&
+                            isNumericType(env_, expected) && isNumericType(env_, actual)) {
+                            compatible = true;
+                        }
+
+                        if (!compatible) {
                             std::string msg = "argument " + std::to_string(i + 1) + " of '" +
                                 std::string(func_expr->type == ESHKOL_VAR ? func_expr->variable.id : "<lambda>") +
                                 "': expected " + env_.getTypeName(expected) +
@@ -2891,32 +2943,220 @@ TypeCheckResult TypeChecker::synthesizeLet(eshkol_ast_t* expr) {
     return body_result;
 }
 
+// ============================================================================
+// PREDICATE-GUARDED NARROWING (occurrence typing, minimal viable)
+// ============================================================================
+
+/**
+ * @brief Map a type-predicate builtin name to the type it proves in its
+ * true branch. Returns Invalid for names that are not narrowing predicates.
+ *
+ * Deliberately restricted to the eight canonical single-type predicates whose
+ * true-branch refinement is exact and unambiguous. Numeric sub-predicates
+ * (integer?/real?) and disjunctive ones (list?) are intentionally excluded to
+ * keep the refinement sound and conservative.
+ */
+static TypeId narrowTypeForPredicate(const std::string& pred) {
+    if (pred == "number?")    return BuiltinTypes::Number;
+    if (pred == "string?")    return BuiltinTypes::String;
+    if (pred == "vector?")    return BuiltinTypes::Vector;
+    if (pred == "pair?")      return BuiltinTypes::Pair;
+    if (pred == "boolean?")   return BuiltinTypes::Boolean;
+    if (pred == "procedure?") return BuiltinTypes::Function;
+    if (pred == "null?")      return BuiltinTypes::Null;
+    if (pred == "symbol?")    return BuiltinTypes::Symbol;
+    return BuiltinTypes::Invalid;
+}
+
+/**
+ * @brief A single occurrence-typing refinement: variable @c var is known to
+ * have type @c type on the guarded path.
+ */
+struct PredicateNarrowing {
+    std::string var;
+    TypeId type;
+};
+
+/**
+ * @brief True if @p e is a call `(pred? x)` where pred? is a narrowing
+ * predicate and x is a plain variable; on success fills @p out.
+ */
+static bool matchPredicateGuard(const eshkol_ast_t* e, PredicateNarrowing& out) {
+    if (!e || e->type != ESHKOL_OP) return false;
+    if (e->operation.op != ESHKOL_CALL_OP) return false;
+    const auto& call = e->operation.call_op;
+    if (!call.func || call.func->type != ESHKOL_VAR || !call.func->variable.id) return false;
+    if (call.num_vars != 1) return false;
+    const eshkol_ast_t& arg = call.variables[0];
+    if (arg.type != ESHKOL_VAR || !arg.variable.id) return false;
+    TypeId t = narrowTypeForPredicate(call.func->variable.id);
+    if (!t.isValid()) return false;
+    out.var = arg.variable.id;
+    out.type = t;
+    return true;
+}
+
+/**
+ * @brief Collect the occurrence-typing refinements implied on the true path of
+ * a condition @p cond.
+ *
+ * Handles a bare predicate guard `(pred? x)` and an `and` chain
+ * `(and (pred? x) (pred? y) ...)` — every predicate conjunct contributes a
+ * refinement, since the whole `and` being true means each conjunct is true.
+ * Non-predicate conjuncts are simply ignored (they impose no refinement).
+ */
+static std::vector<PredicateNarrowing> collectPredicateNarrowings(const eshkol_ast_t* cond) {
+    std::vector<PredicateNarrowing> result;
+    if (!cond) return result;
+
+    PredicateNarrowing pn;
+    if (matchPredicateGuard(cond, pn)) {
+        result.push_back(pn);
+        return result;
+    }
+
+    if (cond->type == ESHKOL_OP && cond->operation.op == ESHKOL_AND_OP) {
+        const auto& seq = cond->operation.sequence_op;
+        for (uint64_t i = 0; i < seq.num_expressions; ++i) {
+            PredicateNarrowing conj;
+            if (matchPredicateGuard(&seq.expressions[i], conj)) {
+                result.push_back(conj);
+            }
+        }
+    }
+    return result;
+}
+
+/**
+ * @brief True if @p e mutates @p var anywhere within it (a `set!` whose target
+ * is @p var). Recurses through all operation shapes conservatively.
+ *
+ * Used to cancel narrowing: if the guarded branch reassigns the refined
+ * variable, the refinement no longer holds for uses after the assignment, so
+ * (being conservative and not doing full flow analysis) we drop the
+ * refinement for the whole branch.
+ */
+static bool exprAssignsVar(const eshkol_ast_t* e, const std::string& var) {
+    if (!e) return false;
+    if (e->type == ESHKOL_OP && e->operation.op == ESHKOL_SET_OP) {
+        if (e->operation.set_op.name && var == e->operation.set_op.name) {
+            return true;
+        }
+        if (exprAssignsVar(e->operation.set_op.value, var)) return true;
+        return false;
+    }
+    if (e->type != ESHKOL_OP) {
+        // cons cells / literals / bare vars cannot contain a set!
+        if (e->type == ESHKOL_CONS) {
+            return exprAssignsVar(e->cons_cell.car, var) ||
+                   exprAssignsVar(e->cons_cell.cdr, var);
+        }
+        return false;
+    }
+
+    // Generic conservative descent: most compound forms are laid out as a
+    // call_op (func + variables) or a sequence_op (expressions). Scanning both
+    // covers if/begin/let-bodies/applications/and/or without enumerating every
+    // op kind. Anything we don't structurally recognise is treated as "might
+    // assign" only if it actually is a set!, handled above; otherwise we scan
+    // the two common child layouts.
+    const auto& op = e->operation;
+    switch (op.op) {
+        case ESHKOL_SEQUENCE_OP:
+        case ESHKOL_AND_OP:
+        case ESHKOL_OR_OP:
+            for (uint64_t i = 0; i < op.sequence_op.num_expressions; ++i) {
+                if (exprAssignsVar(&op.sequence_op.expressions[i], var)) return true;
+            }
+            return false;
+        case ESHKOL_IF_OP:
+        case ESHKOL_CALL_OP: {
+            if (op.call_op.func && exprAssignsVar(op.call_op.func, var)) return true;
+            for (uint64_t i = 0; i < op.call_op.num_vars; ++i) {
+                if (exprAssignsVar(&op.call_op.variables[i], var)) return true;
+            }
+            return false;
+        }
+        case ESHKOL_LET_OP:
+        case ESHKOL_LET_STAR_OP:
+        case ESHKOL_LETREC_OP:
+        case ESHKOL_LETREC_STAR_OP: {
+            const auto& let = op.let_op;
+            for (uint64_t i = 0; i < let.num_bindings; ++i) {
+                if (exprAssignsVar(&let.bindings[i], var)) return true;
+            }
+            if (exprAssignsVar(let.body, var)) return true;
+            return false;
+        }
+        default:
+            // Any other compound form (cond/case/when/unless/do/guard/match, …)
+            // has an op-specific union layout we do not walk here. Rather than
+            // risk missing a `set!` nested inside one — which would make the
+            // narrowing unsound — we conservatively assume such a branch MIGHT
+            // reassign the variable and cancel the refinement. This only forgoes
+            // precision (the branch behaves as it did before narrowing existed);
+            // it never accepts an unsound program.
+            return true;
+    }
+}
+
 /**
  * @brief Synthesis rule for `if` expressions: type is the least common
  * supertype (LCS) of the branch types.
  *
- * Requires at least a condition and a then-branch (error otherwise); the
- * condition itself is not type-checked here. Synthesizes the then-branch
- * type, and if an else-branch is present, synthesizes it too. As a
- * special case for named-let recursive loops (where a recursive call
+ * The condition itself is not type-checked here, but it is inspected for
+ * predicate-guarded narrowing (occurrence typing): when the condition is a
+ * type predicate on a variable — `(number? c)` — or an `and` chain of such
+ * predicates, the guarded variable(s) are refined to the predicted type while
+ * synthesizing the then-branch, so idiomatic `(if (number? c) (+ c 1) …)` on a
+ * value typed number-or-#f checks cleanly. The refinement is conservative:
+ * it is dropped entirely for any variable the then-branch reassigns (`set!`).
+ *
+ * As a special case for named-let recursive loops (where a recursive-call
  * branch often still carries the placeholder BuiltinTypes::Value while the
- * base-case branch has a concrete type), if exactly one branch is Value,
- * the other (concrete) branch's type is preferred outright rather than
- * computing an LCS. Otherwise the result is
- * TypeEnvironment::leastCommonSupertype() of the two branch types. With no
- * else-branch, the then-branch's type is returned directly.
+ * base-case branch has a concrete type), if exactly one branch is Value, the
+ * other (concrete) branch's type is preferred outright rather than computing
+ * an LCS. Otherwise the result is TypeEnvironment::leastCommonSupertype() of
+ * the two branch types. With no else-branch, the then-branch's type is
+ * returned directly.
  * @return The then-branch's TypeCheckResult if there is no else-branch or
  * synthesis of a branch fails; otherwise the LCS (or preferred concrete
  * branch type) of both branches.
  */
 TypeCheckResult TypeChecker::synthesizeIf(eshkol_ast_t* expr) {
     // if has: condition, then-branch, else-branch
-    // For now, just synthesize branches and take LCS
     if (expr->operation.call_op.num_vars < 2) {
         return errorAt(expr, "if requires condition and then-branch");
     }
 
-    auto then_type = synthesize(&expr->operation.call_op.variables[1]);
+    eshkol_ast_t* cond = &expr->operation.call_op.variables[0];
+    eshkol_ast_t* then_branch = &expr->operation.call_op.variables[1];
+
+    // Compute narrowings from the condition's structure *before* synthesizing
+    // it, then synthesize the condition for its side effects (type-checking any
+    // nested expressions and recording their inferred types) — matching the
+    // pre-synthesis the generic application path used to perform.
+    std::vector<PredicateNarrowing> narrowings = collectPredicateNarrowings(cond);
+    synthesize(cond);
+    // Drop any refinement whose variable is reassigned inside the branch.
+    std::vector<PredicateNarrowing> active;
+    for (const auto& n : narrowings) {
+        if (!exprAssignsVar(then_branch, n.var)) {
+            active.push_back(n);
+        }
+    }
+
+    TypeCheckResult then_type;
+    if (!active.empty()) {
+        ctx_.pushScope();
+        for (const auto& n : active) {
+            ctx_.bind(n.var, n.type);
+        }
+        then_type = synthesize(then_branch);
+        ctx_.popScope();
+    } else {
+        then_type = synthesize(then_branch);
+    }
     if (!then_type.success) return then_type;
 
     if (expr->operation.call_op.num_vars >= 3) {
@@ -3093,8 +3333,17 @@ TypeId TypeChecker::resolveType(const hott_type_expr_t* type_expr) {
         case HOTT_TYPE_PRODUCT:
             return BuiltinTypes::Pair;  // Product types represented as pairs at runtime
 
-        case HOTT_TYPE_SUM:
-            return BuiltinTypes::Pair;  // Sum types represented as tagged cons pairs: (tag . value)
+        case HOTT_TYPE_SUM: {
+            // Honor the explicit sum: resolve both arms and build a synthetic
+            // sum TypeId so a value of either arm is accepted where the sum is
+            // expected (and the sum is accepted only where every arm fits).
+            // Runtime representation is unchanged — sums collapse to Pair for
+            // codegen (see codegenReprOf / storeAndReturn).
+            std::vector<TypeId> arms;
+            if (type_expr->sum.left)  arms.push_back(resolveType(type_expr->sum.left));
+            if (type_expr->sum.right) arms.push_back(resolveType(type_expr->sum.right));
+            return env_.makeSumType(arms);
+        }
 
         case HOTT_TYPE_FORALL:
             // Polymorphic types are erased at runtime — tagged values handle polymorphism

--- a/tests/typesystem/checked_cast_the_nested_error_test.esk
+++ b/tests/typesystem/checked_cast_the_nested_error_test.esk
@@ -1,0 +1,16 @@
+;; Type System Test: a checked cast still type-checks its wrapped expression, so
+;; nested errors are not hidden by the ascription (item 3 — no soundness loss).
+;;
+;; The ascribed type is string, but the wrapped expression references an unbound
+;; variable, which must still be reported.
+;; EXPECT-MODE: strict-types
+;; EXPECT-STDERR: error
+;; EXPECT-STDERR: no-such-variable
+
+(define (needs-string (s : string)) (string-length s))
+
+(define (broken)
+  (needs-string (the string no-such-variable)))
+
+(display (broken))
+(newline)

--- a/tests/typesystem/checked_cast_the_test.esk
+++ b/tests/typesystem/checked_cast_the_test.esk
@@ -1,0 +1,18 @@
+;; Type System Test: expression-level checked cast (the <type> <expr>) (item 3).
+;;
+;; `v` is declared string-or-number (a heterogeneous slot). At this call site we
+;; know it holds a string, so `(the string v)` asserts that to the checker,
+;; letting it satisfy the string parameter of needs-string. The cast is a pure
+;; runtime no-op — it evaluates exactly to v. Without it, passing the sum-typed
+;; value to a string parameter reports "expected String, got (+ String Number)".
+;; EXPECT-MODE: strict-types
+;; EXPECT-NO-STDERR: [ERROR]
+;; EXPECT-NO-STDERR: [WARN]
+
+(define (needs-string (s : string)) (string-length s))
+
+(define (name-length (v : (+ string number)))
+  (needs-string (the string v)))
+
+(display (name-length "hello"))   ;; runtime: the-cast is a no-op, length = 5
+(newline)

--- a/tests/typesystem/numeric_join_accumulator_test.esk
+++ b/tests/typesystem/numeric_join_accumulator_test.esk
@@ -1,0 +1,22 @@
+;; Type System Test: stable numeric subtyping across a recursive accumulator
+;; (item 4).
+;;
+;; `acc` is seeded with 0.0 (Float64). On the recursive call it is replaced by a
+;; value widened to Number (running-total returns Number). Since every operand is
+;; real, the recursive argument must unify with the accumulator at their numeric
+;; join instead of erroring "expected Float64, got Number".
+;; EXPECT-MODE: strict-types
+;; EXPECT-NO-STDERR: [ERROR]
+;; EXPECT-NO-STDERR: [WARN]
+
+;; Both params numeric -> returns Number (the numeric-tower supertype)
+(define (running-total (a : number) (b : number)) (+ a b))
+
+(define (sum-vector (recs : (vector any)))
+  (let loop ((i 0) (acc 0.0))
+    (if (>= i 3)
+        acc
+        (loop (+ i 1) (running-total acc (vector-ref recs i))))))
+
+(display (sum-vector (vector 1.0 2.0 3.0)))   ;; runtime: 0+1+2+3 = 6.0
+(newline)

--- a/tests/typesystem/numeric_join_nonnumeric_reject_test.esk
+++ b/tests/typesystem/numeric_join_nonnumeric_reject_test.esk
@@ -1,0 +1,17 @@
+;; Type System Test: the numeric-join relaxation only reconciles numeric types —
+;; a genuinely non-numeric recursive argument is still rejected (item 4, no
+;; soundness loss).
+;;
+;; The accumulator is Float64; passing a string on the recursive call must error.
+;; EXPECT-MODE: strict-types
+;; EXPECT-STDERR: [ERROR]
+;; EXPECT-STDERR: got String
+
+(define (bad-loop n)
+  (let loop ((i 0) (acc 0.0))
+    (if (>= i n)
+        acc
+        (loop (+ i 1) "not numeric"))))
+
+(display (bad-loop 0))
+(newline)

--- a/tests/typesystem/predicate_narrowing_setbang_reject_test.esk
+++ b/tests/typesystem/predicate_narrowing_setbang_reject_test.esk
@@ -1,0 +1,21 @@
+;; Type System Test: narrowing is conservatively cancelled when the guarded
+;; variable is reassigned inside the branch (item 2 — soundness).
+;;
+;; Even though c is guarded by (number? c), the branch reassigns c via set!, so
+;; the refinement no longer holds and c reverts to Boolean — the numeric use
+;; must therefore still error. This proves the narrowing is not unsound.
+;; EXPECT-MODE: strict-types
+;; EXPECT-STDERR: [ERROR]
+;; EXPECT-STDERR: expected Number, got Boolean
+
+(define (needs-number (n : number)) (+ n 1))
+
+(define (use-setbang (c : boolean))
+  (if (number? c)
+      (begin
+        (set! c #t)          ;; reassignment cancels the narrowing
+        (needs-number c))    ;; c is Boolean again -> error
+      0))
+
+(display (use-setbang #f))
+(newline)

--- a/tests/typesystem/predicate_narrowing_test.esk
+++ b/tests/typesystem/predicate_narrowing_test.esk
@@ -1,0 +1,28 @@
+;; Type System Test: predicate-guarded narrowing / occurrence typing (item 2).
+;;
+;; `c` is declared boolean (a number-or-#f sentinel modelled as boolean). Inside
+;; the true branch of `(number? c)` it must be narrowed to Number so it can flow
+;; into a numeric parameter — without narrowing this reported
+;; "expected Number, got Boolean".
+;; EXPECT-MODE: strict-types
+;; EXPECT-NO-STDERR: [ERROR]
+;; EXPECT-NO-STDERR: [WARN]
+
+(define (needs-number (n : number)) (+ n 1))
+
+;; number? guard narrows c to Number in the then-branch
+(define (use-if (c : boolean))
+  (if (number? c)
+      (needs-number c)
+      0))
+
+;; and-chain guard narrows c to Number for the then-branch as well
+(define (use-and (c : boolean))
+  (if (and (number? c) #t)
+      (needs-number c)
+      0))
+
+(display (use-if #f))
+(newline)
+(display (use-and #f))
+(newline)

--- a/tests/typesystem/predicate_narrowing_unguarded_reject_test.esk
+++ b/tests/typesystem/predicate_narrowing_unguarded_reject_test.esk
@@ -1,0 +1,15 @@
+;; Type System Test: narrowing is guard-scoped — a boolean-typed value used in a
+;; numeric parameter WITHOUT a predicate guard is still rejected (item 2, no
+;; false acceptance).
+;; EXPECT-MODE: strict-types
+;; EXPECT-STDERR: [ERROR]
+;; EXPECT-STDERR: expected Number, got Boolean
+
+(define (needs-number (n : number)) (+ n 1))
+
+;; No (number? c) guard: c stays Boolean, so this must error.
+(define (use-unguarded (c : boolean))
+  (needs-number c))
+
+(display (use-unguarded #f))
+(newline)

--- a/tests/typesystem/sum_annotation_honored_test.esk
+++ b/tests/typesystem/sum_annotation_honored_test.esk
@@ -1,0 +1,20 @@
+;; Type System Test: explicit sum-type annotations are honored on named-let
+;; parameters and through recursive calls (item 1).
+;;
+;; The accumulator `acc` is annotated `(+ boolean (vector any))`: it starts as
+;; #f (the boolean arm) and, on the recursive call, becomes a vector (the vector
+;; arm). Both arms must be accepted — previously the sum collapsed to Pair and
+;; the recursive call reported "expected Pair, got Vector".
+;; EXPECT-MODE: strict-types
+;; EXPECT-NO-STDERR: [ERROR]
+;; EXPECT-NO-STDERR: [WARN]
+
+(define (build n)
+  (let loop ((i 0)
+             (acc : (+ boolean (vector any)) #f))
+    (if (>= i n)
+        acc
+        (loop (+ i 1) (vector 1 2 3)))))
+
+(display (build 0))
+(newline)

--- a/tests/typesystem/sum_annotation_reject_test.esk
+++ b/tests/typesystem/sum_annotation_reject_test.esk
@@ -1,0 +1,18 @@
+;; Type System Test: a value outside every arm of an explicit sum annotation is
+;; still rejected (item 1 — no soundness loss).
+;;
+;; `acc` accepts boolean or vector; passing a string on the recursive call must
+;; error, since string is neither arm.
+;; EXPECT-MODE: strict-types
+;; EXPECT-STDERR: [ERROR]
+;; EXPECT-STDERR: got String
+
+(define (build n)
+  (let loop ((i 0)
+             (acc : (+ boolean (vector any)) #f))
+    (if (>= i n)
+        acc
+        (loop (+ i 1) "not an arm"))))
+
+(display (build 0))
+(newline)

--- a/tests/vm_parity/PARITY.tsv
+++ b/tests/vm_parity/PARITY.tsv
@@ -588,6 +588,7 @@ op:SUBSTITUTION_PRED	vm-supported	BUILTINS fid 506
 op:SYNTAX_ERROR	native-only-justified	parse-time form handled by the native front-end
 op:TAYLOR	gap	arbitrary-order Taylor-series AD operator not implemented on VM surface
 op:TENSOR	vm-supported	tensor/make-tensor fids 410+
+op:THE	native-only-justified	expression-level type ascription (the T e); a type-checker-only refinement that lowers to its wrapped operand at codegen (pure passthrough, no distinct runtime effect) — not yet surfaced in the bytecode VM parser
 op:TYPE_ANNOTATION	native-only-justified	static type syntax, erased before codegen
 op:UNIFY	vm-supported	BUILTINS fid 502
 op:UNLESS	vm-supported	vm_compiler special-form dispatch


### PR DESCRIPTION
## Summary

Four gradual/HoTT type-checker semantic refinements so idiomatic dynamic-but-validated code passes `--strict-types` without erasing to `any`. **All four are diagnostics-only**: they change what the checker *accepts*, never what codegen emits (verified byte-identical LLVM IR on a touched-pattern program) and never runtime behavior. Every `.esk` that ran before runs identically after.

## The four semantics

**1. Honored explicit sum types.** `(+ A B ...)` annotations previously collapsed to `Pair`, so a named-let accumulator annotated `(+ boolean (vector any))` reported `expected Pair, got Vector` on the arm that stored a vector. `TypeEnvironment` now tracks synthetic sum `TypeId`s (`makeSumType`/`getSumMembers`/`isSumType`) with proper subtyping — a value of any arm satisfies the sum, and the sum is subsumed only by a type covering *every* arm (`(+ integer real) <: number`). Sums have no distinct runtime representation, so they collapse to `Pair` (`codegenReprOf`) before a node's inferred type is written to the AST, keeping codegen untouched.

**2. Predicate-guarded narrowing (occurrence typing, minimal viable).** In the true branch of `(number? c)` — and `and`-chains of such guards used as an if-condition — the guarded variable is refined to the predicted type (`number?`/`string?`/`vector?`/`pair?`/`boolean?`/`procedure?`/`null?`/`symbol?`). Conservative by design: the refinement is cancelled for any variable the branch reassigns via `set!`, and for branch shapes not structurally modelled — so it only ever forgoes precision, never accepts an unsound program.

**3. Expression-level checked cast `(the <type> <expr>)`.** *Design decision (item 3):* a trusted **ascription** that fits Eshkol's existing `(: x type)` annotation grammar. It asserts the wrapped expression's type to the checker — letting a value recovered from a dynamic container (`(the string (cdr (assoc key alist)))`) satisfy a typed context without reconstruction — while remaining a pure runtime **no-op**: codegen evaluates the operand verbatim, emitting IR identical to writing the operand directly. The wrapped expression is still type-checked, so nested errors are not hidden. `the` is only special in head position and only when its second element is a type; used as an ordinary identifier it is unaffected. New `ESHKOL_THE_OP` is a native-only lowering (pure passthrough); the VM parity manifest carries a justified row for it.

**4. Stable numeric subtyping across recursive accumulators.** An accumulator seeded `0.0` (Float64) recombined with values widened to `Number` no longer errors `expected Float64, got Number` on the recursive call: two numeric operands reconcile at their tower join. Non-numeric arguments are still rejected.

## Tests

`tests/typesystem/` gains 9 standalone `.esk` cases (strict + gradual), each asserting strict-mode passes where it must and, crucially, that **genuinely wrong types still error** (no soundness loss):

- sum: honored (accept both arms) + reject (value outside every arm)
- narrowing: `if` + `and` positive; unguarded reject; `set!`-cancelled reject (soundness)
- cast: positive (sum-typed slot → string param via `the`) + nested-error reject
- numeric-join: positive accumulator + non-numeric reject

## Verification

- **Diagnostic reduction:** a synthetic bundle mirroring items 1/2/4 emits **6 → 0** diagnostics under `--strict-types` (2 sum + 2 narrowing + 2 numeric-join).
- **Codegen unchanged:** before/after LLVM IR on that bundle is **byte-identical** (empty diff).
- **No regression:** full `ctest` **89/89**, typesystem suite **19/19**, `run_vm_parity.sh` **68/0**, generative differential smoke **PASS (0 divergences)**.