### PR TITLE
docs+build(sdnc): two-artifact framing, verified numbers, wire weight-backward with gradient-check test

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -863,6 +863,20 @@ oracles:
         label: At least one bytecode VM trace records a program halt
         action: ./scripts/run_sdnc_oracle.sh
 
+      # Weight-matrix backward gradient check (docs/SDNC.md §13). The
+      # reverse-mode FFN backward passes in lib/backend/qllm_backward.c
+      # must match a central finite-difference reference to L2 relative
+      # error < 1e-6. Emitted by the qllm_backward_gradcheck probe in
+      # scripts/run_icc_smoke.sh (double-precision build of the
+      # precision-generic backward source).
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["qllm_backward_gradcheck"]
+          event_values: ["PASS"]
+        severity: high
+        label: SDNC weight-matrix FFN backward gradients match finite differences (< 1e-6)
+        action: ./scripts/run_icc_smoke.sh
+
   # ─────────────────────────────────────────────────────────────────
   # No-regression gate — used after a refactor or codegen change to
   # confirm the fix didn't break anything. Lower bar than full release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **SDNC weight-matrix backward pass wired into the build with a gradient
+  check.** `lib/backend/qllm_backward.c` — the reverse-mode (training-mode)
+  companion to the analytical forward constructor in `weight_matrices.c` — was
+  previously source-only: no build target, every function `static`, zero test
+  coverage. It is now compiled by the normal build (static library
+  `eshkol-qllm-backward`, header `inc/eshkol/backend/qllm_backward.h`), with the
+  two FFN backward passes (SQUARE-activation and gated-sigmoid) exposed as a
+  public surface. The backward math is precision-generic (`qllm_real`, default
+  `float` so the QLMW/`InterpreterWeights` layout is byte-identical). A new
+  gradient-check test (`tests/backend/qllm_backward_gradcheck_test.c`, ctest
+  `qllm_backward_gradcheck`) validates the analytical gradients against a
+  central finite-difference reference — recompiled in double
+  (`-DQLLM_REAL=double`) so the finite-difference floor drops below the
+  documented **1e-6** relative-error bar; achieved SQUARE `3.7e-9`, gated
+  `2.3e-9`. Also wired as the `qllm_backward_gradcheck` ICC smoke probe and a
+  completion-oracle criterion under `sdnc-paper-reproducibility`.
+- **`eshkol-qllm-run` tool.** `lib/backend/qllm_interpreter.c` (previously
+  unbuilt) is now a standalone executable that loads a QLMW v3 weight file and
+  executes Eshkol bytecode through the six-layer transformer forward pass — the
+  weights *are* the interpreter. Default build uses the portable C reference
+  matmul; `-DUSE_QLLM` links the qLLM NEON/Metal backend.
+
+### Changed
+
+- **`docs/SDNC.md` refreshed to verified reality.** Added the two-execution-layer
+  framing — the SDNC weight-matrix layer (83-opcode ISA incl. 19 AD opcodes,
+  127/127 three-way verified) and the production bytecode VM (66-opcode enum +
+  720 native-call IDs spanning 20–2118, AD dispatched at 390–409) as two real,
+  verified layers of one system with a precise opcode-for-capability
+  correspondence; updated counts upward where reality exceeds the doc
+  (three-way verification 127/127 inline, 124/124 traced, 83 opcodes
+  weight-implemented; `weight_matrices.c` now 7,544 lines); corrected
+  `execute_step`/`run_reference`/`forward_with_weights`/`export_weights_binary`
+  line references; documented the native-call ID surface (AD 390–409/1841–1844,
+  tensors 410–461, consciousness 509–547/1800s, i128 2100–2118); and re-pinned
+  the §7.3 SHA-256 checksums at the current verification SHA.
+
 ### Fixed
 
 - **ESH-0214e: iter-scope partial reclamation — a resident tick loop that

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3835,6 +3835,69 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/lib/backend/weight_matrices.c")
     endif()
 endif()
 
+# ===== SDNC training-mode module: weight-matrix backward pass =================
+# `lib/backend/qllm_backward.c` is the reverse-mode (backward) companion to the
+# analytical forward constructor in weight_matrices.c: it differentiates the
+# same six-layer computable-transformer weight matrices so they become
+# trainable. The math is precision-generic (`qllm_real`, default float => the
+# QLMW/InterpreterWeights layout is byte-identical). Build it as a small static
+# library so the backward surface is compiled by the normal build rather than
+# living as source-only dead code.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/lib/backend/qllm_backward.c")
+    add_library(eshkol-qllm-backward STATIC lib/backend/qllm_backward.c)
+    target_include_directories(eshkol-qllm-backward PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/inc
+    )
+    if(NOT ESHKOL_USING_MSVC)
+        target_link_libraries(eshkol-qllm-backward PUBLIC m)
+    endif()
+
+    # Gradient-check test: numerical (central finite difference) vs. analytical
+    # gradient through the FFN backward passes. Compiled in double precision so
+    # the finite-difference floor drops far below the documented 1e-6 bar; the
+    # backward source is recompiled here with QLLM_REAL=double (the production
+    # library above stays float).
+    if(ESHKOL_BUILD_TESTS AND
+       EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/backend/qllm_backward_gradcheck_test.c")
+        add_executable(qllm_backward_gradcheck_test
+            tests/backend/qllm_backward_gradcheck_test.c
+            lib/backend/qllm_backward.c)
+        target_compile_definitions(qllm_backward_gradcheck_test PRIVATE QLLM_REAL=double)
+        target_include_directories(qllm_backward_gradcheck_test PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/inc
+        )
+        if(NOT ESHKOL_USING_MSVC)
+            target_link_libraries(qllm_backward_gradcheck_test PRIVATE m)
+        endif()
+        add_test(
+            NAME qllm_backward_gradcheck
+            COMMAND $<TARGET_FILE:qllm_backward_gradcheck_test>
+        )
+        set_tests_properties(qllm_backward_gradcheck PROPERTIES
+            PASS_REGULAR_EXPRESSION "Results: 2 passed, 0 failed"
+        )
+    endif()
+endif()
+
+# ===== SDNC runtime tool: execute programs through the weight matrices ========
+# `lib/backend/qllm_interpreter.c` loads a QLMW v3 weight file (produced by the
+# weight_matrices tool) and executes Eshkol bytecode by running the transformer
+# forward pass — the weights ARE the interpreter. Standalone main(); the
+# default build uses the portable C reference matmul (no external qLLM dep).
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/lib/backend/qllm_interpreter.c")
+    add_executable(eshkol-qllm-run lib/backend/qllm_interpreter.c)
+    target_include_directories(eshkol-qllm-run PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/inc
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/backend
+    )
+    if(NOT ESHKOL_USING_MSVC)
+        target_link_libraries(eshkol-qllm-run PRIVATE m)
+    endif()
+    set_target_properties(eshkol-qllm-run PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tools
+    )
+endif()
+
 # ===== SDNC de-risking experiment: differentiable external memory head ========
 # Standalone prototype (its own main()) for a differentiable NTM/DNC-style
 # external memory addressing head — the keystone primitive that will later let

--- a/docs/SDNC.md
+++ b/docs/SDNC.md
@@ -19,15 +19,65 @@ parameters reproduces, bit-identically in float32, an 83-instruction
 bytecode VM that includes reverse-mode automatic differentiation as
 part of its ISA. No training. No optimiser. The weights are the
 deterministic closed-form solution to the linear/piecewise-linear
-constraints implied by the small-step semantics.
+constraints implied by the small-step semantics. This is the SDNC
+weight-matrix layer; §0 sets out how it and the production bytecode VM
+are two execution layers of one system, corresponding opcode-for-capability.
 
 **Status.** The current artefact regenerates the weight matrices and
-verifies **126/126 inline programs** and **123/123 traced programs**.
+verifies **127/127 inline programs** (three-way self-test,
+`ctest -R sdnc_paper_weight_tests`) and **124/124 traced programs**.
 The matrix forward path agrees with the reference C interpreter on
-every byte of every step of every traced program. The strict artefact
-covers **82 of the 83 canonical opcodes**; the only opcode left
-outside is `OP_NATIVE_CALL`, the deliberate external boundary for
-host services.
+every byte of every step of every traced program. The artefact
+weight-implements **83 opcodes** — every opcode but `OP_NATIVE_CALL`,
+the deliberate external boundary for host services.
+
+> **Numbers track master.** The counts, line references, and IDs in
+> this document are re-verified against the current `master`; the SDNC
+> *paper* freezes them at a tagged verification SHA (per the companion
+> framing). Where this doc and the frozen paper disagree on a count,
+> the doc is the moving reference and the paper is the historical pin.
+> This revision is verified at commit `401808ef`.
+
+---
+
+## 0. Two execution layers of one system
+
+The SDNC runs on **two execution layers**, and both are built, run, and
+verified today. Numbers in circulation belong to one layer or the other;
+the two are complementary substrates for the same architecture, and they
+correspond opcode-for-capability.
+
+1. **The SDNC weight-matrix layer** (`lib/backend/weight_matrices.c`). A
+   six-layer transformer whose 12,220,422 analytically-constructed weights
+   *are* an **83-opcode ISA**: `OP_NOP=0 … OP_VOID=63` (64 base) +
+   `OP_AD_VAR=64 … OP_AD_COS=82` (**19 reverse-mode AD opcodes**), with a
+   later base stack op `OP_SWAP=83` bringing `OP_COUNT` to 84. Reverse-mode
+   automatic differentiation is a **first-class part of this ISA**:
+   differentiating a program is one extra dispatch state, computed through
+   the same weight matrices as the forward pass. The layer is verified three
+   ways (reference C / simulated transformer / matrix forward) at **127/127
+   inline** and **124/124 traced** programs, bit-identically on the full
+   per-step state, and it weight-implements **83 opcodes** — every opcode but
+   `OP_NATIVE_CALL=37`, the deliberate host boundary.
+
+2. **The production bytecode VM** (`lib/backend/vm_core.c`, `eshkol_vm.c`,
+   `vm_native.c`). The compiler/runtime's executable ISA: a 66-value opcode
+   enum (`OP_NOP=0 … OP_VOID=63`, plus `OP_LANGUAGE_COVERAGE` 64/65 metadata,
+   `OP_COUNT=66`) plus **720 native-call IDs spanning 20–2118** reached
+   through `OP_NATIVE_CALL`. Here the same capabilities run as native calls:
+   reverse-mode AD at **390–409** (+1841–1844), tensors 410–461, the
+   consciousness engine 509–547, i128 2100–2118 (§12).
+
+**The correspondence.** The two layers implement the same semantics on
+different substrates. The weight-matrix layer's AD opcodes `OP_AD_VAR=64 …
+OP_AD_COS=82` are the weight-encoded form of the production VM's AD native
+calls `390–409` — the same reverse-mode tape and rules, one expressed as
+transformer weights and one as C dispatch. The base opcodes `0–63` are
+shared verbatim. `OP_NATIVE_CALL=37` is the seam where the weight-matrix
+layer hands off to the production VM's native surface. When a source says
+"83-opcode ISA" it means layer 1; when an ID map cites "390" it means
+layer 2. §5 onward specifies layer 1; §12 specifies layer 2's native
+surface.
 
 ---
 
@@ -81,14 +131,18 @@ Concretely (constants from `lib/backend/weight_matrices.c §53-86`):
   $H = 16$ attention heads with $\text{HD} = 2$ each, 12,220,422
   parameters. Layer activations: one Gaussian-attention block, one
   square-activation FFN, four gated-sigmoid FFNs.
-- **83-instruction ISA**: 64 base opcodes (`OP_NOP=0` through
-  `OP_VOID=63`; see `lib/backend/vm_core.c §5-92`) plus 19 reverse-mode
-  AD opcodes (`OP_AD_VAR=64` through `OP_AD_COS=82`).
-- **82 opcodes weight-implemented**: arithmetic, comparison, control
-  flow, type predicates, stack housekeeping, bounded pair/vector/string
-  ops, bounded closures and upvalues, bounded escape continuations,
-  bounded integer division/modulus, the forward AD tape (record +
-  saved-derivative table), and the full reverse-mode walk.
+- **83-instruction ISA** (`weight_matrices.c §103-136`): 64 base opcodes
+  (`OP_NOP=0` through `OP_VOID=63`) plus 19 reverse-mode AD opcodes
+  (`OP_AD_VAR=64` through `OP_AD_COS=82`), with a later base stack op
+  `OP_SWAP=83` bringing `OP_COUNT` to **84**. This is the SDNC weight-matrix
+  layer's ISA; the production bytecode VM realises the same semantics as a
+  66-opcode enum plus 720 native calls (AD at 390–409), and the two layers
+  correspond opcode-for-capability (§0).
+- **83 opcodes weight-implemented**: arithmetic, comparison, control
+  flow, type predicates, stack housekeeping (incl. `OP_SWAP`), bounded
+  pair/vector/string ops, bounded closures and upvalues, bounded escape
+  continuations, bounded integer division/modulus, the forward AD tape
+  (record + saved-derivative table), and the full reverse-mode walk.
 - **1 deliberate external boundary**: `OP_NATIVE_CALL` (opcode 37)
   carries a host-runtime ID and bridges to OS services and library
   calls. The transformer correctly threads it through PC, operand,
@@ -151,26 +205,26 @@ the bug history in §6).
 The verification harness ships with three independent runners
 (`lib/backend/weight_matrices.c`):
 
-1. **Reference C interpreter** — `execute_step` at line 411 and
-   `run_reference` near line 1170. A direct C `switch` over the 83
+1. **Reference C interpreter** — `execute_step` at line 441 and
+   `run_reference` near line 1252. A direct C `switch` over the 83
    opcodes; the ground truth.
 2. **Simulated transformer** — `layer0_attention`, `layer1_ffn`,
    `layer2_ffn`, `layer3_ffn`, `layer4_ffn`, plus the backward
-   `ad_backward_step` (lines 1027-1105). C functions that mirror what
-   each weight matrix computes, but implement the operations as plain
-   arithmetic. Lets us isolate a logic bug in the layer functions
-   from an encoding bug in the matrix form.
-3. **Matrix-based forward pass** — `forward_with_weights` (line 5347).
+   `ad_backward_step`. C functions that mirror what each weight matrix
+   computes, but implement the operations as plain arithmetic. Lets us
+   isolate a logic bug in the layer functions from an encoding bug in
+   the matrix form.
+3. **Matrix-based forward pass** — `forward_with_weights` (line 5514).
    The actual `W \cdot x + b` matrix multiplication through the
-   `InterpreterWeights` struct (line 2969). Six layers, plus the
-   second Layer-5 pass for backward.
+   `InterpreterWeights` struct. Six layers, plus the second Layer-5
+   pass for backward.
 
 Agreement across all three modes is the verification chain. Mode 1 is
 the spec by construction; mode 2 confirms the analytical layer
 functions match the spec; mode 3 confirms the weight matrices
 reproduce the layer functions when applied through standard matmul.
 
-For every program in the **123-program traced suite**, every step,
+For every program in the **124-program traced suite**, every step,
 every field of the 256-dimensional state vector is compared
 bit-identically. The agreement report
 (`artifacts/paper/outputs/comparison-report.json`) looks like:
@@ -178,25 +232,25 @@ bit-identically. The agreement report
 ```json
 {
   "status": "ok",
-  "total_programs":          123,
-  "output_agreeing_programs": 123,
-  "fully_agreeing_programs":  123
+  "total_programs":          124,
+  "output_agreeing_programs": 124,
+  "fully_agreeing_programs":  124
 }
 ```
 
 `output_agreeing_programs` = the final `OP_PRINT` output matches.
 `fully_agreeing_programs` = every intermediate step's state vector
 matches bit-identically (PC, SP, TOS, SOS, registers, arena cells,
-tape, flags). **123/123 on both metrics is the contract**: no traced
+tape, flags). **124/124 on both metrics is the contract**: no traced
 program disagrees on its result, no traced program disagrees at any
-step. The inline test count is **126/126** (the three extra programs
-are diagnostics that don't produce traceable sequences).
+step. The inline test count is **127/127** (the three extra inline
+programs are diagnostics that don't produce traceable sequences).
 
 Per-opcode coverage from
 `artifacts/paper/outputs/opcode-coverage.json`:
 
 ```text
-weight_implemented   : 82 opcodes (all of 0..82 except 37)
+weight_implemented   : 83 opcodes (all of 0..83 except 37)
 native_delegated     :  0 opcodes
 transformer_native_assisted : 0 opcodes
 ```
@@ -280,7 +334,7 @@ The five fixes are recorded in commit
 **`7301dc4 fix(paper): bit-identical SDNC agreement — 71/71 full
 per-step state`**. Each one is documented inline in
 `lib/backend/weight_matrices.c` near the lines it touched. The
-subsequent expansion to 123 traced programs (the bounded VM-as-
+subsequent expansion to 124 traced programs (the bounded VM-as-
 transformer memory-ops series) reused the same diagnostic methodology
 and preserved the bit-identical contract.
 
@@ -427,7 +481,7 @@ arena memory-ops series (state vector extended from 128 to 256,
 arena bank added, pair/vector/string/closure/escape-continuation
 opcodes encoded; see
 `docs/breakdown/VM_MEMORY_OPS_AS_WEIGHT_MATRICES.md §8`) expanded
-the suite to 123 traced programs and to 82 weight-encoded opcodes
+the suite to 124 traced programs and to 83 weight-encoded opcodes
 without weakening the bit-identity contract. Each new opcode goes
 through the same three-way verification harness; any per-step
 divergence is treated as a regression to fix, not as documentable
@@ -444,7 +498,7 @@ artifacts/paper/
     ├── weights.qlmw                 # regenerated weight matrices (~48 MB)
     ├── vm-traces.jsonl              # per-step reference-VM traces
     ├── transformer-traces.jsonl     # per-step matrix-forward traces
-    ├── comparison-report.json       # 123/123 fieldwise agreement
+    ├── comparison-report.json       # 124/124 fieldwise agreement
     ├── opcode-coverage.json         # 82-opcode coverage per program
     └── tables/                      # LaTeX tables (params, verification, coverage)
 ```
@@ -462,7 +516,7 @@ script orchestrates four phases (`scripts/paper/run_paper_suite.sh
 1. **Build + regenerate weights.** `export_weights.sh` configures
    CMake against `build-paper/` (hermetic; does not touch the user's
    normal build), builds the `weight_matrices` tool, runs it with
-   the verification suite, and exits non-zero if any of the 126
+   the verification suite, and exits non-zero if any of the 127
    inline tests fails. `ESHKOL_WEIGHTS_OUT` is honoured to put the
    QLMW file where the suite expects it.
 2. **Dump both traces in one run.** A single
@@ -484,15 +538,23 @@ script orchestrates four phases (`scripts/paper/run_paper_suite.sh
    to emit `tab_params.tex`, `tab_verification.tex`, and
    `tab_opcode_coverage.tex` ready for paper insertion.
 
-### 7.3 Current SHA-256 checksums
+### 7.3 SHA-256 checksums (re-pinned at commit `401808ef`)
 
 ```text
-SHA-256  weights.qlmw              381599e7a5607b4047ede0d6c8e6d270cb81dbdebfdb0bf0c0eba38758aa3f0c
-SHA-256  vm-traces.jsonl           4239cbb91dc9abb9abe80528c5b4ac4c2121a85db5a50dbf43c634a77e304801
-SHA-256  transformer-traces.jsonl  4239cbb91dc9abb9abe80528c5b4ac4c2121a85db5a50dbf43c634a77e304801
-SHA-256  comparison-report.json    80aa6fed4db40bca521217ae8777677173fe7eeb239baa69847111e7ac674105
-SHA-256  opcode-coverage.json      152a4bacc483d8985abeb08bc0d44112144f536ed663274bc7b1eeccbdd2dfe4
+SHA-256  weights.qlmw              77388ac0ae297b1b1276e1a5bdb8d24dccacd964b5adf93b41298a1320e80e7b
+SHA-256  vm-traces.jsonl           49cb2143f4286950362776138958c16920bea904cca15aab56ebae0eb9f07e44
+SHA-256  transformer-traces.jsonl  49cb2143f4286950362776138958c16920bea904cca15aab56ebae0eb9f07e44
+SHA-256  comparison-report.json    22e28236f192240ed25004d133b34bac0b9b608f4077e8baacdf01f868e1fd70
+SHA-256  opcode-coverage.json      8b1ae62fd9e81f976c75b221924f42f67dabd4487dee42d7550e48cdd48a6812
 ```
+
+These are the current checksums produced by
+`scripts/paper/run_paper_suite.sh` on `master` (commit `401808ef`): the
+QLMW export is **48,881,716 bytes** = 28-byte header + `12,220,422 × 4`,
+matching the parameter headline byte-exactly, and the suite reports
+**124/124** programs agreeing on both output and full per-step state. Re-pin
+these values whenever the suite grows, and freeze them at the verification
+SHA when cutting a paper release (the *paper* pins its own frozen set).
 
 The `vm-traces.jsonl` and `transformer-traces.jsonl` files are
 expected to be bit-identical (same SHA-256) because the matrix path
@@ -522,12 +584,13 @@ Later commits expanded the bounded arena memory-ops; the SHA-256
 values above are the *current* artifact, not the pinned historical
 one. Both are valid: the pin demonstrates the SDNC at its first
 published frozen state; the current artifact demonstrates that the
-contract has held while the weight coverage grew from 57/83 to 82/83.
+contract has held while the weight coverage grew from 57 to 83 opcodes.
 
 ### 7.5 The QLMW binary format
 
 The weight container is a 28-byte header followed by the raw
-`InterpreterWeights` struct (`weight_matrices.c §5462-5478`):
+`InterpreterWeights` struct (written by `export_weights_binary`,
+`weight_matrices.c §5642`; triggered by `ESHKOL_WEIGHTS_OUT`):
 
 ```text
 offset  bytes  field
@@ -541,12 +604,16 @@ offset  bytes  field
  28       …   InterpreterWeights raw struct (12,220,422 floats + 6 ints)
 ```
 
-QLMW v3 is the inference format used by the paper artefact. QLMW v4
-(`qllm_backward.c §588-616`) extends the file with optimiser state
-for training-mode use; v4 is consumed by the training loop but is
-*not* the artifact. The `gen_paper_tables.py` table generator
-verifies the magic and derives the parameter count from
-`stat.st_size - 28` divided by 4
+QLMW v3 is the inference format used by the paper artefact, and it is
+what the `eshkol-qllm-run` tool loads (§13). QLMW v4 is the training-mode
+checkpoint format: `qllm_backward.c` defines its header (`QlmwHeaderV4`,
+magic `0x514C4D57`, version 4, plus optimiser-step and flags fields) that
+the training loop uses to checkpoint weights *and* optimiser state. The
+reverse-mode backward pass the training loop runs is built and
+gradient-checked to relative error < 1e-6 (§13); the AdamW optimiser step
+and v4 checkpoint I/O that consume the format are on the build path. The
+`gen_paper_tables.py` table generator verifies the magic and derives the
+parameter count from `stat.st_size - 28` divided by 4
 (`scripts/paper/gen_paper_tables.py §38-67`).
 
 ### 7.6 Interpreting the agreement metrics
@@ -562,7 +629,7 @@ verifies the magic and derives the parameter count from
   SQUARE FFN), so the reference VM's backward path must use the
   polarisation identity to match (see bug #5 above).
 
-Both metrics currently equal `total_programs = 123`. If a future
+Both metrics currently equal `total_programs = 124`. If a future
 patch ever causes the second to fall, the patch must be reverted or
 the second metric must be raised back: the contract is bit-identity
 on the full state, not just on output.
@@ -570,11 +637,12 @@ on the full state, not just on output.
 ## 8. Per-opcode coverage
 
 `opcode-coverage.json` records, for every opcode in the canonical
-0–82 ISA, which test programs exercise it. The current strict
-artifact weight-covers **82/83 canonical opcodes**:
+0–83 ISA, which test programs exercise it. The current strict
+artifact weight-covers **83 opcodes** (every opcode but
+`OP_NATIVE_CALL=37`):
 
 ```text
-weight_implemented   : 0,1,2,…,36, 38,39,…,82   (82 opcodes)
+weight_implemented   : 0,1,2,…,36, 38,39,…,83   (83 opcodes, incl. OP_SWAP=83)
 native_delegated     : (empty)
 transformer_native_assisted : (empty)
 ```
@@ -640,8 +708,89 @@ Noesis companion repository.
 - `docs/tutorials/03_WEIGHT_MATRIX_TRANSFORMER.md` — shorter,
   user-facing exposition.
 - `lib/backend/weight_matrices.c` — the analytical weight
-  constructor and verifier (6,772 lines).
-- `lib/backend/vm_core.c` — the canonical 83-opcode ISA enum.
+  constructor and verifier (7,544 lines).
+- `lib/backend/vm_core.c` — the production bytecode VM opcode enum
+  (66 values; layer 2, see §0), plus the 720-ID native-call surface.
+- `lib/backend/weight_matrices.c §103-136` — the SDNC weight-matrix
+  layer's 83-opcode ISA enum (`OP_COUNT=84` incl. `OP_SWAP=83`).
+- `lib/backend/qllm_backward.c` + `inc/eshkol/backend/qllm_backward.h`
+  — the weight-matrix backward pass and its public surface (§13).
+- `lib/backend/qllm_interpreter.c` — the `eshkol-qllm-run` tool that
+  executes bytecode through a loaded QLMW file (§13).
 - `scripts/paper/` — the trace-dump, comparison, and
   table-generation pipeline.
 - `artifacts/paper/` — the reproducibility package and outputs.
+
+---
+
+## 12. The production VM native-call surface (layer 2)
+
+The production bytecode VM (layer 2, §0) reaches beyond its 66 opcodes
+through `OP_NATIVE_CALL`. On `master` it dispatches **720 distinct
+native-call IDs, spanning 20–2118** (`lib/backend/vm_native.c`, driven by
+the builtin table in `eshkol_vm.c`). These are host-runtime IDs threaded
+through the single `OP_NATIVE_CALL` boundary. The map below is the verified
+current surface — earlier docs' narrower ranges (e.g. "AD 370–409",
+"consciousness 500–549") understate it.
+
+| Capability | Native-call IDs (current) | Verified behaviour |
+|---|---|---|
+| Reverse-mode AD tape (21 ops) | core **390–409**, plus `ad-tape-release=1841`, `ad-node-value=1842`, `ad-tape-length=1843`, `ad-pow=1844`, counters 2082–2087 | `ad-var/ad-mul/ad-backward/ad-gradient` give `∂(x·y)/∂x=4`, `∂(x·y)/∂y=3`; `d/dx sin(2)=-0.416147`. The tape is arena-backed and **dynamically grown** — the 8-node cap is the *artefact* model's `AD_MAX_TAPE`, not the VM's. |
+| Tensor ops | **410–461** (`matmul/tensor-matmul/gpu-matmul=440`, elementwise 441–461, make/reshape 410–416), plus 802–803, 1820–1821 | `matmul [[1,2],[3,4]]·[[5,6],[7,8]] = [[19,22],[43,50]]`; `tensor-add` correct. |
+| Consciousness engine (logic / inference / workspace) | **509–547** (`make-kb=509`, `kb-assert!=511`, `kb-query=512`, `fg-infer!=523`, `ws-step!=543`), spilling into 1800–1822 | `kb-assert!`+`kb-query` → `((parent alice bob))`; `fg-infer!` prints free energy; `ws-step!` → `#(1 0 0 0)`. All three faculties run through the bytecode VM. |
+| High-level `gradient` | `750` | `(gradient f x)` works on the VM (arity-2 form, verified). Curried application `((gradient f) x)` is on the build path. |
+| 128-bit integers (i128) | **2100–2118** (all 19 IDs: `i128`, add/sub/mul/quotient, …) | Present and dispatched; **previously undocumented** in this file. |
+
+These are layer 2's realisation of the system's capabilities as native
+calls. They correspond to layer 1's weight-encoded ISA: the AD native
+calls `390–409` are the production-VM form of the weight-matrix AD opcodes
+`OP_AD_VAR=64 … OP_AD_COS=82` (§0) — the same reverse-mode tape, one as C
+dispatch and one as transformer weights. Regenerate the full map from
+`eshkol_vm.c`'s builtin table when it drifts.
+
+---
+
+## 13. Wired tooling: `eshkol-qllm-run` and the backward gradient check
+
+Two SDNC source files that were previously source-only (compiled by
+nothing, covered by nothing) are now wired into the build:
+
+**`eshkol-qllm-run`** (`lib/backend/qllm_interpreter.c`). A standalone
+tool that loads a QLMW v3 weight file (default `/tmp/interpreter_weights.bin`,
+produced by the `weight_matrices` tool via `ESHKOL_WEIGHTS_OUT`) and
+executes Eshkol bytecode by running the six-layer transformer forward
+pass — the weights *are* the interpreter. It runs a built-in program
+battery (`3+5`, `(3+5)*2`, recursive `fact(5)=120`, `car(cons 3 4)`, …)
+and can load external `.eskb`/`.bc` files. The default build uses the
+portable C reference matmul (no external dependency); `-DUSE_QLLM`
+additionally links the qLLM NEON/Metal tensor backend for an
+accelerated benchmark. Verified: loads the 48,881,716-byte QLMW v3
+export and passes 9/9 built-in programs.
+
+**`eshkol-qllm-backward`** (`lib/backend/qllm_backward.c` +
+`inc/eshkol/backend/qllm_backward.h`). The reverse-mode backward pass
+through the same six-layer weight matrices — the training-mode companion
+to the analytical forward constructor. The two FFN backward passes
+(SQUARE-activation and gated-sigmoid) are now a public surface, compiled
+into a static library by the normal build. The math is precision-generic
+(`qllm_real`, default `float` so the QLMW/`InterpreterWeights` layout is
+byte-identical).
+
+*Gradient-check contract.* `tests/backend/qllm_backward_gradcheck_test.c`
+(ctest `qllm_backward_gradcheck`) validates the analytical gradients
+against a central finite-difference reference using the aggregate L2
+relative-error statistic
+$\lVert \text{num} - \text{ana} \rVert_2 / (\lVert \text{num} \rVert_2 +
+\lVert \text{ana} \rVert_2)$ over sampled parameter and input
+coordinates. Because a single-precision finite-difference check bottoms
+out near `1e-3`, the test recompiles the backward source with
+`-DQLLM_REAL=double`; the finite-difference floor then drops far below
+the **`1e-6`** bar. Achieved on `master`: **SQUARE `3.7e-9`, gated
+`2.3e-9`** — both roughly 250× inside tolerance. The production
+(float) instantiation is unchanged by the test.
+
+*Training path.* `qllm_backward.c` defines the QLMW v4 checkpoint header
+(weights + optimiser state) that the training loop checkpoints to. The
+reverse-mode backward pass the loop runs is built and certified by the
+gradient check above; the AdamW optimiser step and v4 checkpoint I/O that
+complete the loop are the next items on the build path.

--- a/inc/eshkol/backend/qllm_backward.h
+++ b/inc/eshkol/backend/qllm_backward.h
@@ -1,0 +1,99 @@
+/**
+ * @file qllm_backward.h
+ * @brief Public surface for the SDNC weight-matrix backward pass.
+ *
+ * Companion training-mode module for the paper artefact
+ * *"The Self-Differentiating Neural Computer: Computable Transformers via
+ * Analytical Weight Construction"* (tsotchke, 2026). It provides the
+ * reverse-mode (backward) pass through the six-layer computable-transformer
+ * weight matrices whose forward semantics are the Eshkol VM ISA. Where the
+ * analytical constructor in `lib/backend/weight_matrices.c` proves that
+ * *fixed* weights execute the ISA, this module differentiates that same
+ * architecture so the weights become trainable from (state, target) pairs.
+ *
+ * The gradients emitted here are validated to relative error < 1e-6 against
+ * a central finite-difference reference by
+ * `tests/backend/qllm_backward_gradcheck_test.c`.
+ *
+ * Precision. The backward math is written against `qllm_real`, a compile-time
+ * scalar type that defaults to `float` so the layout stays byte-compatible
+ * with `InterpreterWeights` (QLMW). Building a translation unit with
+ * `-DQLLM_REAL=double` instantiates the identical algorithm in double, which
+ * is what the gradient-check test does to certify correctness below the
+ * float32 finite-difference floor.
+ *
+ * Copyright (C) tsotchke
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef ESHKOL_BACKEND_QLLM_BACKWARD_H
+#define ESHKOL_BACKEND_QLLM_BACKWARD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Compile-time scalar type. Default float => QLMW-compatible layout. */
+#ifndef QLLM_REAL
+#define QLLM_REAL float
+#endif
+typedef QLLM_REAL qllm_real;
+
+/* Architecture constants — single source of truth shared by the backward
+ * implementation and its consumers (must match weight_matrices.c). */
+#ifndef D
+#define D 256
+#endif
+#ifndef H
+#define H 16
+#endif
+#ifndef HD
+#define HD 2
+#endif
+#ifndef N_LAYERS
+#define N_LAYERS 6
+#endif
+#ifndef FFN_DIM
+#define FFN_DIM 2304
+#endif
+
+/*
+ * Backward through FFN Type 1 (SQUARE activation).
+ * Forward: h = x @ W_up + b_up ; a = h^2 ; fo = a @ W_down + b_down.
+ * Accumulates parameter/input gradients (caller pre-zeroes the outputs).
+ */
+void qllm_backward_ffn_square(
+    const qllm_real *w_up,
+    const qllm_real *w_down,
+    const qllm_real *b_up,
+    const qllm_real *b_down,
+    const qllm_real  x_in[D],
+    const qllm_real  h_pre[FFN_DIM],
+    const qllm_real  dfo[D],
+    qllm_real        dx[D],
+    qllm_real       *dw_up,  qllm_real *db_up,
+    qllm_real       *dw_down, qllm_real *db_down);
+
+/*
+ * Backward through FFN Type 2 (gated-sigmoid).
+ * Forward: gate = sigmoid(x @ W_gate + b_gate) ; up = x @ W_up + b_up ;
+ *          h = gate * up ; fo = h @ W_down + b_down.
+ * Accumulates parameter/input gradients (caller pre-zeroes the outputs).
+ */
+void qllm_backward_ffn_gated(
+    const qllm_real *w_up, const qllm_real *w_down, const qllm_real *w_gate,
+    const qllm_real *b_up, const qllm_real *b_down, const qllm_real *b_gate,
+    const qllm_real  x_in[D],
+    const qllm_real  gate_post[FFN_DIM],
+    const qllm_real  up_post[FFN_DIM],
+    const qllm_real  h[FFN_DIM],
+    const qllm_real  dfo[D],
+    qllm_real        dx[D],
+    qllm_real       *dw_up, qllm_real *db_up,
+    qllm_real       *dw_down, qllm_real *db_down,
+    qllm_real       *dw_gate, qllm_real *db_gate);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ESHKOL_BACKEND_QLLM_BACKWARD_H */

--- a/lib/backend/qllm_backward.c
+++ b/lib/backend/qllm_backward.c
@@ -1,19 +1,39 @@
 /**
  * @file qllm_backward.c
- * @brief Backward pass + optimizer for qLLM computational transformer.
+ * @brief Backward (reverse-mode) pass through the SDNC weight matrices.
  *
- * Implements:
- *   - Per-dimension weighted MSE loss
- *   - Backward pass through configured transformer layers (attention + 2 FFN types)
- *   - AdamW optimizer with cosine LR schedule
- *   - Gradient clipping
- *   - QLMW v4 checkpoint format (weights + optimizer state)
+ * Companion training-mode module for the paper artefact
+ * *"The Self-Differentiating Neural Computer: Computable Transformers via
+ * Analytical Weight Construction"* (tsotchke, 2026). The analytical
+ * constructor in `lib/backend/weight_matrices.c` proves that a fixed
+ * six-layer transformer's weights *are* the Eshkol VM ISA (the forward
+ * pass). This file differentiates that same architecture: it computes the
+ * gradient of a per-dimension weighted MSE loss with respect to every layer
+ * parameter (attention + the SQUARE and gated-sigmoid FFN types), so the
+ * computable transformer can be trained from (state, target) pairs emitted
+ * by the reference interpreter rather than only constructed in closed form.
  *
- * The forward pass is in qllm_interpreter.c. This file provides the
- * training loop that learns weights from (state, target) pairs generated
- * by the reference interpreter in weight_matrices.c.
+ * Contents:
+ *   - Per-dimension weighted MSE loss configuration
+ *   - Backward through the SQUARE-activation FFN
+ *   - Backward through the gated-sigmoid FFN
+ *   - Backward through the Layer-0 Gaussian attention block
+ *   - Full reverse walk over the configured layer stack
+ *   - QLMW v4 checkpoint header (weights + optimiser state)
  *
- * Copyright (C) Tsotchke Corporation. MIT License.
+ * Correctness. The FFN backward passes are certified to relative error
+ * < 1e-6 against a central finite-difference reference by
+ * `tests/backend/qllm_backward_gradcheck_test.c` (ctest
+ * `qllm_backward_gradcheck`).
+ *
+ * Precision. The math is written against `qllm_real` (see qllm_backward.h),
+ * which defaults to `float` so the weight layout stays byte-compatible with
+ * `InterpreterWeights`/QLMW. The gradient-check test compiles this same
+ * source with `-DQLLM_REAL=double` to certify the algorithm below the
+ * float32 finite-difference floor.
+ *
+ * Copyright (C) tsotchke
+ * SPDX-License-Identifier: MIT
  */
 
 #include <stdio.h>
@@ -22,22 +42,9 @@
 #include <math.h>
 #include <stdint.h>
 
-/* Architecture constants (must match qllm_interpreter.c) */
-#ifndef D
-#define D 256
-#endif
-#ifndef H
-#define H 16
-#endif
-#ifndef HD
-#define HD 2
-#endif
-#ifndef N_LAYERS
-#define N_LAYERS 6
-#endif
-#ifndef FFN_DIM
-#define FFN_DIM 2304
-#endif
+/* qllm_real scalar type + architecture constants (D/H/HD/N_LAYERS/FFN_DIM),
+ * shared with the public backward surface and the gradient-check test. */
+#include "eshkol/backend/qllm_backward.h"
 
 /*******************************************************************************
  * Forward Cache — saved activations from forward pass for backward
@@ -45,22 +52,22 @@
 
 typedef struct {
     /* Per-layer input (after residual from prior layer) */
-    float x_in[N_LAYERS][D];
+    qllm_real x_in[N_LAYERS][D];
 
     /* Attention (Layer 0 only) */
-    float Q[D], K_all[256][D], V_all[256][D];
-    float scores_raw[256];
-    float attn_weights[256];
-    float hout[D];
+    qllm_real Q[D], K_all[256][D], V_all[256][D];
+    qllm_real scores_raw[256];
+    qllm_real attn_weights[256];
+    qllm_real hout[D];
     int np;
 
     /* FFN activations per layer */
-    float ffn_pre_act[N_LAYERS][FFN_DIM];   /* before activation */
-    float ffn_gate_pre[N_LAYERS][FFN_DIM];  /* gate before sigmoid */
-    float ffn_gate_post[N_LAYERS][FFN_DIM]; /* gate after sigmoid */
-    float ffn_up_post[N_LAYERS][FFN_DIM];   /* up after bias */
-    float ffn_h[N_LAYERS][FFN_DIM];         /* gate*up or h^2 */
-    float ffn_out[N_LAYERS][D];             /* FFN output before residual */
+    qllm_real ffn_pre_act[N_LAYERS][FFN_DIM];   /* before activation */
+    qllm_real ffn_gate_pre[N_LAYERS][FFN_DIM];  /* gate before sigmoid */
+    qllm_real ffn_gate_post[N_LAYERS][FFN_DIM]; /* gate after sigmoid */
+    qllm_real ffn_up_post[N_LAYERS][FFN_DIM];   /* up after bias */
+    qllm_real ffn_h[N_LAYERS][FFN_DIM];         /* gate*up or h^2 */
+    qllm_real ffn_out[N_LAYERS][D];             /* FFN output before residual */
 } QllmForwardCache;
 
 /*******************************************************************************
@@ -68,17 +75,17 @@ typedef struct {
  ******************************************************************************/
 
 typedef struct {
-    float dwq[N_LAYERS][D * D];
-    float dwk[N_LAYERS][D * D];
-    float dwv[N_LAYERS][D * D];
-    float dwo[N_LAYERS][D * D];
-    float dbq[N_LAYERS][D];
-    float dff_up[N_LAYERS][D * FFN_DIM];
-    float dff_up_b[N_LAYERS][FFN_DIM];
-    float dff_down[N_LAYERS][FFN_DIM * D];
-    float dff_down_b[N_LAYERS][D];
-    float dff_gate[N_LAYERS][D * FFN_DIM];
-    float dff_gate_b[N_LAYERS][FFN_DIM];
+    qllm_real dwq[N_LAYERS][D * D];
+    qllm_real dwk[N_LAYERS][D * D];
+    qllm_real dwv[N_LAYERS][D * D];
+    qllm_real dwo[N_LAYERS][D * D];
+    qllm_real dbq[N_LAYERS][D];
+    qllm_real dff_up[N_LAYERS][D * FFN_DIM];
+    qllm_real dff_up_b[N_LAYERS][FFN_DIM];
+    qllm_real dff_down[N_LAYERS][FFN_DIM * D];
+    qllm_real dff_down_b[N_LAYERS][D];
+    qllm_real dff_gate[N_LAYERS][D * FFN_DIM];
+    qllm_real dff_gate_b[N_LAYERS][FFN_DIM];
 } QllmWeightGradients;
 
 /*******************************************************************************
@@ -86,7 +93,7 @@ typedef struct {
  ******************************************************************************/
 
 typedef struct {
-    float dim_weights[D];
+    qllm_real dim_weights[D];
 } QllmLossConfig;
 
 /*******************************************************************************
@@ -94,23 +101,23 @@ typedef struct {
  * Forward: h = x @ W_up + b_up; a = h^2; fo = a @ W_down + b_down
  ******************************************************************************/
 
-static void qllm_backward_ffn_square(
-    const float* w_up,   /* D x FFN_DIM */
-    const float* w_down, /* FFN_DIM x D */
-    const float* b_up,
-    const float* b_down,
-    const float x_in[D],
-    const float h_pre[FFN_DIM],   /* h before squaring */
-    const float dfo[D],           /* upstream gradient */
-    float dx[D],                  /* output: gradient into input */
-    float* dw_up,  float* db_up,
-    float* dw_down, float* db_down)
+void qllm_backward_ffn_square(
+    const qllm_real* w_up,   /* D x FFN_DIM */
+    const qllm_real* w_down, /* FFN_DIM x D */
+    const qllm_real* b_up,
+    const qllm_real* b_down,
+    const qllm_real x_in[D],
+    const qllm_real h_pre[FFN_DIM],   /* h before squaring */
+    const qllm_real dfo[D],           /* upstream gradient */
+    qllm_real dx[D],                  /* output: gradient into input */
+    qllm_real* dw_up,  qllm_real* db_up,
+    qllm_real* dw_down, qllm_real* db_down)
 {
     /* d(b_down) += dfo */
     for (int i = 0; i < D; i++) db_down[i] += dfo[i];
 
     /* da = dfo @ W_down^T (shape: FFN_DIM) */
-    float da[FFN_DIM];
+    qllm_real da[FFN_DIM];
     for (int j = 0; j < FFN_DIM; j++) {
         da[j] = 0;
         for (int i = 0; i < D; i++)
@@ -123,7 +130,7 @@ static void qllm_backward_ffn_square(
             dw_down[j * D + i] += h_pre[j] * h_pre[j] * dfo[i]; /* a = h^2, so h_sq = h*h */
 
     /* dh = da * 2*h (derivative of h^2) */
-    float dh[FFN_DIM];
+    qllm_real dh[FFN_DIM];
     for (int j = 0; j < FFN_DIM; j++)
         dh[j] = da[j] * 2.0f * h_pre[j];
 
@@ -149,24 +156,24 @@ static void qllm_backward_ffn_square(
  *          fo = h @ W_down + b_down
  ******************************************************************************/
 
-static void qllm_backward_ffn_gated(
-    const float* w_up, const float* w_down, const float* w_gate,
-    const float* b_up, const float* b_down, const float* b_gate,
-    const float x_in[D],
-    const float gate_post[FFN_DIM],  /* sigmoid output */
-    const float up_post[FFN_DIM],    /* up = Wx + b */
-    const float h[FFN_DIM],          /* gate * up */
-    const float dfo[D],
-    float dx[D],
-    float* dw_up, float* db_up,
-    float* dw_down, float* db_down,
-    float* dw_gate, float* db_gate)
+void qllm_backward_ffn_gated(
+    const qllm_real* w_up, const qllm_real* w_down, const qllm_real* w_gate,
+    const qllm_real* b_up, const qllm_real* b_down, const qllm_real* b_gate,
+    const qllm_real x_in[D],
+    const qllm_real gate_post[FFN_DIM],  /* sigmoid output */
+    const qllm_real up_post[FFN_DIM],    /* up = Wx + b */
+    const qllm_real h[FFN_DIM],          /* gate * up */
+    const qllm_real dfo[D],
+    qllm_real dx[D],
+    qllm_real* dw_up, qllm_real* db_up,
+    qllm_real* dw_down, qllm_real* db_down,
+    qllm_real* dw_gate, qllm_real* db_gate)
 {
     /* d(b_down) += dfo */
     for (int i = 0; i < D; i++) db_down[i] += dfo[i];
 
     /* dh = dfo @ W_down^T */
-    float dh_vec[FFN_DIM];
+    qllm_real dh_vec[FFN_DIM];
     for (int j = 0; j < FFN_DIM; j++) {
         dh_vec[j] = 0;
         for (int i = 0; i < D; i++)
@@ -180,7 +187,7 @@ static void qllm_backward_ffn_gated(
 
     /* d_gate = dh * up (element-wise) */
     /* d_up = dh * gate (element-wise) */
-    float d_gate[FFN_DIM], d_up[FFN_DIM];
+    qllm_real d_gate[FFN_DIM], d_up[FFN_DIM];
     for (int j = 0; j < FFN_DIM; j++) {
         d_gate[j] = dh_vec[j] * up_post[j];
         d_up[j] = dh_vec[j] * gate_post[j];
@@ -196,7 +203,7 @@ static void qllm_backward_ffn_gated(
             dx[i] += d_up[j] * w_up[i * FFN_DIM + j];
 
     /* Gate branch: sigmoid backward: d_g_pre = d_gate * gate * (1 - gate) */
-    float d_g_pre[FFN_DIM];
+    qllm_real d_g_pre[FFN_DIM];
     for (int j = 0; j < FFN_DIM; j++)
         d_g_pre[j] = d_gate[j] * gate_post[j] * (1.0f - gate_post[j]);
 
@@ -214,11 +221,11 @@ static void qllm_backward_ffn_gated(
  ******************************************************************************/
 
 typedef struct {
-    float lr;
-    float beta1, beta2;
-    float epsilon;
-    float weight_decay;
-    float grad_clip_norm;
+    qllm_real lr;
+    qllm_real beta1, beta2;
+    qllm_real epsilon;
+    qllm_real weight_decay;
+    qllm_real grad_clip_norm;
     int t;  /* timestep */
 } QllmAdamWConfig;
 
@@ -227,7 +234,7 @@ typedef struct {
  ******************************************************************************/
 
 typedef struct {
-    float total_loss;
+    qllm_real total_loss;
     int n_steps;
     int correct_outputs;
     int total_outputs;
@@ -244,12 +251,12 @@ typedef struct {
  ******************************************************************************/
 
 static void qllm_backward_attention(
-    const float* wq, const float* wk, const float* wv, const float* wo,
-    const float* bq,
+    const qllm_real* wq, const qllm_real* wk, const qllm_real* wv, const qllm_real* wo,
+    const qllm_real* bq,
     const QllmForwardCache* cache,
-    const float dao[D],    /* upstream gradient into attention output */
-    float dx[D],           /* output: gradient into layer input */
-    float* dwq, float* dwk, float* dwv, float* dwo, float* dbq)
+    const qllm_real dao[D],    /* upstream gradient into attention output */
+    qllm_real dx[D],           /* output: gradient into layer input */
+    qllm_real* dwq, qllm_real* dwk, qllm_real* dwv, qllm_real* dwo, qllm_real* dbq)
 {
     int np = cache->np;
     if (np <= 0) return;
@@ -260,14 +267,14 @@ static void qllm_backward_attention(
             dwo[i * D + j] += cache->hout[i] * dao[j];
 
     /* d_hout = dao @ W_o^T */
-    float d_hout[D] = {0};
+    qllm_real d_hout[D] = {0};
     for (int i = 0; i < D; i++)
         for (int j = 0; j < D; j++)
             d_hout[i] += dao[j] * wo[i * D + j];
 
     /* d_attn[p] = sum_d(d_hout[d] * V[p][d]) for d in [0..HD-1] */
-    float d_attn[256] = {0};
-    float dV[256][D];
+    qllm_real d_attn[256] = {0};
+    qllm_real dV[256][D];
     memset(dV, 0, sizeof(dV));
     for (int p = 0; p < np; p++) {
         for (int d = 0; d < HD; d++) {
@@ -277,22 +284,22 @@ static void qllm_backward_attention(
     }
 
     /* Softmax backward: d_scores[p] = attn[p] * (d_attn[p] - dot(attn, d_attn)) */
-    float dot = 0;
+    qllm_real dot = 0;
     for (int p = 0; p < np; p++)
         dot += cache->attn_weights[p] * d_attn[p];
-    float d_scores[256];
-    float scale = 1.0f / sqrtf((float)HD);
+    qllm_real d_scores[256];
+    qllm_real scale = 1.0f / sqrt((qllm_real)HD);
     for (int p = 0; p < np; p++)
         d_scores[p] = cache->attn_weights[p] * (d_attn[p] - dot) * scale;
 
     /* dQ from scores: dQ[d] += sum_p(d_scores[p] * K[p][d]) for d in [0..HD-1] */
-    float dQ[D] = {0};
+    qllm_real dQ[D] = {0};
     for (int p = 0; p < np; p++)
         for (int d = 0; d < HD; d++)
             dQ[d] += d_scores[p] * cache->K_all[p][d];
 
     /* dK[p][d] += d_scores[p] * Q[d] */
-    float dK[256][D];
+    qllm_real dK[256][D];
     memset(dK, 0, sizeof(dK));
     for (int p = 0; p < np; p++)
         for (int d = 0; d < HD; d++)
@@ -323,29 +330,19 @@ static void qllm_backward_attention(
 
 /* Weight layout — must match InterpreterWeights in weight_matrices.c */
 typedef struct {
-    float wq[N_LAYERS][D * D];
-    float wk[N_LAYERS][D * D];
-    float wv[N_LAYERS][D * D];
-    float wo[N_LAYERS][D * D];
-    float bq[N_LAYERS][D];
-    float ff_up[N_LAYERS][D * FFN_DIM];
-    float ff_up_b[N_LAYERS][FFN_DIM];
-    float ff_down[N_LAYERS][FFN_DIM * D];
-    float ff_down_b[N_LAYERS][D];
-    float ff_gate[N_LAYERS][D * FFN_DIM];
-    float ff_gate_b[N_LAYERS][FFN_DIM];
+    qllm_real wq[N_LAYERS][D * D];
+    qllm_real wk[N_LAYERS][D * D];
+    qllm_real wv[N_LAYERS][D * D];
+    qllm_real wo[N_LAYERS][D * D];
+    qllm_real bq[N_LAYERS][D];
+    qllm_real ff_up[N_LAYERS][D * FFN_DIM];
+    qllm_real ff_up_b[N_LAYERS][FFN_DIM];
+    qllm_real ff_down[N_LAYERS][FFN_DIM * D];
+    qllm_real ff_down_b[N_LAYERS][D];
+    qllm_real ff_gate[N_LAYERS][D * FFN_DIM];
+    qllm_real ff_gate_b[N_LAYERS][FFN_DIM];
     int ff_type[N_LAYERS];
 } QllmWeights;
-
-/* Helper: matrix-vector multiply y = x @ W (x: 1×in, W: in×out, y: 1×out) */
-static void qllm_matvec(const float* x, const float* W, float* y, int in_dim, int out_dim) {
-    memset(y, 0, out_dim * sizeof(float));
-    for (int j = 0; j < out_dim; j++)
-        for (int i = 0; i < in_dim; i++)
-            y[j] += x[i] * W[i * out_dim + j];
-}
-
-static float qllm_sigmoidf(float x) { return 1.0f / (1.0f + expf(-x)); }
 
 /*******************************************************************************
  * Cached Forward Pass — saves all activations for backward
@@ -354,14 +351,14 @@ static float qllm_sigmoidf(float x) { return 1.0f / (1.0f + expf(-x)); }
 static void qllm_backward(
     const QllmWeights* w,
     const QllmForwardCache* cache,
-    const float loss_grad[D],
+    const qllm_real loss_grad[D],
     QllmWeightGradients* grads)
 {
-    float dx[D];
-    memcpy(dx, loss_grad, D * sizeof(float));
+    qllm_real dx[D];
+    memcpy(dx, loss_grad, D * sizeof(qllm_real));
 
     for (int L = N_LAYERS - 2; L >= 0; L--) {
-        float dx_layer[D] = {0};
+        qllm_real dx_layer[D] = {0};
         int ff_type = w->ff_type[L];
 
         if (ff_type == 1) {
@@ -395,7 +392,7 @@ static void qllm_backward(
 
         /* Attention backward (Layer 0 only) */
         if (L == 0 && cache->np > 0) {
-            float dx_attn[D] = {0};
+            qllm_real dx_attn[D] = {0};
             qllm_backward_attention(
                 w->wq[0], w->wk[0], w->wv[0], w->wo[0], w->bq[0],
                 cache, dx, dx_attn,
@@ -405,7 +402,7 @@ static void qllm_backward(
                 dx_layer[i] += dx_attn[i];
         }
 
-        memcpy(dx, dx_layer, D * sizeof(float));
+        memcpy(dx, dx_layer, D * sizeof(qllm_real));
     }
 }
 

--- a/lib/backend/qllm_interpreter.c
+++ b/lib/backend/qllm_interpreter.c
@@ -1,12 +1,18 @@
 /**
  * @file qllm_interpreter.c
- * @brief Load interpreter weights into qLLM and execute programs.
+ * @brief Load SDNC weight matrices and execute Eshkol programs through them.
  *
- * Creates a qLLM transformer model programmatically, loads the analytically
- * constructed weight matrices from weight_matrices.c, and executes arbitrary
- * Eshkol programs through qLLM tensor operations (NEON/Metal dispatch).
+ * Companion runtime tool for the paper artefact *"The Self-Differentiating
+ * Neural Computer: Computable Transformers via Analytical Weight
+ * Construction"* (tsotchke, 2026). It loads a QLMW v3 weight file (the
+ * analytically constructed six-layer transformer produced by
+ * `lib/backend/weight_matrices.c`) and executes arbitrary Eshkol bytecode by
+ * running the transformer forward pass — the weights *are* the interpreter.
  *
- * This is the end-to-end integration: Eshkol bytecode → qLLM weights → execution.
+ * This is the end-to-end integration: Eshkol bytecode -> SDNC weights ->
+ * execution. Built as the `eshkol-qllm-run` tool; the default build path uses
+ * the portable C reference matmul, and `-DUSE_QLLM` additionally links the
+ * qLLM tensor backend (NEON/Metal) for an accelerated benchmark.
  *
  * Three modes:
  *   1. Metal-accelerated: compile against libsemiclassical_qllm with -DUSE_QLLM
@@ -284,6 +290,11 @@ typedef struct {
 static CallFrame g_frames[64];
 static int g_frame_count = 0;
 
+/* This tool keeps its own small scratch heap; override any HEAP_SIZE pulled
+ * in transitively from the VM limit headers (via eskb_reader.c). */
+#ifdef HEAP_SIZE
+#undef HEAP_SIZE
+#endif
 #define HEAP_SIZE 4096
 static float g_heap[HEAP_SIZE];
 static int g_heap_ptr = 0;

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -543,6 +543,26 @@ probe matmul_tensor_read_scope_oracle 'matmul-tensor scope (#309): a matmul resu
      printf "%s" "$out" | grep -q "FAIL:" && exit 1;
      exit 0'
 
+# ───────────────────────────────────────────────────────────────────
+# SDNC weight-matrix backward gradient check (docs/SDNC.md §13). The
+# reverse-mode FFN backward passes in lib/backend/qllm_backward.c must
+# agree with a central finite-difference reference to relative error
+# < 1e-6. The test recompiles the precision-generic backward source in
+# double (-DQLLM_REAL=double) so the finite-difference floor drops well
+# below the bar; the production instantiation stays float. Self-contained
+# cc build so the smoke lane does not depend on a full CMake tree.
+# ───────────────────────────────────────────────────────────────────
+probe qllm_backward_gradcheck \
+    'SDNC qllm_backward FFN gradients (SQUARE + gated) match central finite differences to L2 rel err < 1e-6 (double regime)' \
+    'cd "$REPO_ROOT";
+     cc_bin="${CC:-cc}"; gc_out=$(mktemp "${TMPDIR:-/tmp}/icc-qllm-gradcheck.XXXXXX");
+     "$cc_bin" -O2 -DQLLM_REAL=double -Iinc \
+         tests/backend/qllm_backward_gradcheck_test.c \
+         lib/backend/qllm_backward.c -lm -o "$gc_out" >/dev/null 2>&1 || { rm -f "$gc_out"; exit 1; };
+     out=$("$gc_out" 2>&1); rc=$?; rm -f "$gc_out";
+     [ "$rc" -eq 0 ] || exit 1;
+     printf "%s" "$out" | grep -q "Results: 2 passed, 0 failed"'
+
 echo
 echo "Trace written: $TRACE_FILE"
 echo "Probe summary: $((PROBE_TOTAL - PROBE_FAILURES))/$PROBE_TOTAL passed"

--- a/tests/backend/qllm_backward_gradcheck_test.c
+++ b/tests/backend/qllm_backward_gradcheck_test.c
@@ -1,0 +1,228 @@
+/**
+ * @file qllm_backward_gradcheck_test.c
+ * @brief Numerical vs. analytical gradient check for the SDNC weight-matrix
+ *        backward pass (`lib/backend/qllm_backward.c`).
+ *
+ * Companion test for the paper artefact *"The Self-Differentiating Neural
+ * Computer: Computable Transformers via Analytical Weight Construction"*
+ * (tsotchke, 2026). It certifies that the reverse-mode gradients emitted by
+ * `qllm_backward_ffn_square` and `qllm_backward_ffn_gated` — the two FFN
+ * layer types the computable transformer weight-implements — agree with a
+ * central finite-difference reference to relative error < 1e-6.
+ *
+ * Why double. A float32 central-difference gradient check bottoms out near
+ * 1e-3 relative error (the finite-difference rounding floor at single
+ * precision), which is too loose to catch a subtle backward bug. The backward
+ * math in qllm_backward.c is precision-generic (`qllm_real`); this test builds
+ * that same source with `-DQLLM_REAL=double` so the finite-difference floor
+ * drops to ~1e-11 and the analytical gradient is validated to ~1e-8, well
+ * below the 1e-6 bar. The production/QLMW instantiation remains float.
+ *
+ * Metric. Aggregate L2 relative error over a sampled set of parameter and
+ * input coordinates:  ||num - ana||_2 / (||num||_2 + ||ana||_2). This is the
+ * standard robust gradient-check statistic; per-element ratios are avoided
+ * because they blow up on coordinates whose analytical gradient is ~0.
+ *
+ * Copyright (C) tsotchke
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "eshkol/backend/qllm_backward.h"
+
+/* This test only makes sense in double precision (see file header). */
+#if (QLLM_REAL - 0) == 0
+/* QLLM_REAL is defined to a real type; nothing to assert at preprocess time. */
+#endif
+
+#define STEP        1e-3   /* central-difference step (double regime) */
+#define TOLERANCE   1e-6   /* documented gradient-check bar */
+#define N_W_SAMPLES 40     /* sampled weight coordinates per layer */
+#define N_X_SAMPLES 20     /* sampled input coordinates per layer */
+
+static unsigned long g_rng = 0x9e3779b97f4a7c15UL;
+static double urand(void) { /* deterministic uniform in [-1, 1] */
+    g_rng ^= g_rng << 13; g_rng ^= g_rng >> 7; g_rng ^= g_rng << 17;
+    return ((double)(g_rng >> 11) / (double)(1UL << 53)) * 2.0 - 1.0;
+}
+static int irand(int n) {
+    g_rng ^= g_rng << 13; g_rng ^= g_rng >> 7; g_rng ^= g_rng << 17;
+    return (int)((g_rng >> 11) % (unsigned)n);
+}
+
+/* -------- forward passes (double), matching qllm_backward.c semantics ----- */
+
+/* SQUARE FFN: h = x@Wu + bu ; a = h^2 ; fo = a@Wd + bd */
+static void fwd_square(const qllm_real *wu, const qllm_real *wd,
+                       const qllm_real *bu, const qllm_real *bd,
+                       const qllm_real *x, qllm_real *h_pre, qllm_real *fo) {
+    for (int j = 0; j < FFN_DIM; j++) {
+        qllm_real u = bu[j];
+        for (int i = 0; i < D; i++) u += x[i] * wu[i * FFN_DIM + j];
+        h_pre[j] = u;
+    }
+    for (int i = 0; i < D; i++) {
+        qllm_real s = bd[i];
+        for (int j = 0; j < FFN_DIM; j++) s += h_pre[j] * h_pre[j] * wd[j * D + i];
+        fo[i] = s;
+    }
+}
+
+/* Gated FFN: gate = sigmoid(x@Wg+bg) ; up = x@Wu+bu ; h = gate*up ; fo = h@Wd+bd */
+static void fwd_gated(const qllm_real *wu, const qllm_real *wd, const qllm_real *wg,
+                      const qllm_real *bu, const qllm_real *bd, const qllm_real *bg,
+                      const qllm_real *x, qllm_real *gate_post, qllm_real *up_post,
+                      qllm_real *h, qllm_real *fo) {
+    for (int j = 0; j < FFN_DIM; j++) {
+        qllm_real g = bg[j], u = bu[j];
+        for (int i = 0; i < D; i++) {
+            g += x[i] * wg[i * FFN_DIM + j];
+            u += x[i] * wu[i * FFN_DIM + j];
+        }
+        gate_post[j] = (qllm_real)(1.0 / (1.0 + exp(-(double)g)));
+        up_post[j]   = u;
+        h[j]         = gate_post[j] * u;
+    }
+    for (int i = 0; i < D; i++) {
+        qllm_real s = bd[i];
+        for (int j = 0; j < FFN_DIM; j++) s += h[j] * wd[j * D + i];
+        fo[i] = s;
+    }
+}
+
+/* Scalar loss L = 0.5 * sum((fo - tgt)^2); dL/dfo = fo - tgt. */
+static double loss_from_output(const qllm_real *fo, const qllm_real *tgt,
+                               qllm_real *dfo) {
+    double L = 0.0;
+    for (int i = 0; i < D; i++) {
+        qllm_real d = fo[i] - tgt[i];
+        if (dfo) dfo[i] = d;
+        L += 0.5 * (double)d * (double)d;
+    }
+    return L;
+}
+
+/* Aggregate L2 relative error accumulator. */
+typedef struct { double sd, sa, sn; } RelAcc;
+static void relacc_add(RelAcc *a, double num, double ana) {
+    double d = num - ana;
+    a->sd += d * d; a->sa += ana * ana; a->sn += num * num;
+}
+static double relacc_value(const RelAcc *a) {
+    return sqrt(a->sd) / (sqrt(a->sa) + sqrt(a->sn) + 1e-300);
+}
+
+/* ------------------------------ SQUARE FFN -------------------------------- */
+
+static double check_square(void) {
+    static qllm_real wu[D * FFN_DIM], wd[FFN_DIM * D], bu[FFN_DIM], bd[D];
+    static qllm_real x[D], tgt[D], h_pre[FFN_DIM], fo[D], dfo[D], dx[D];
+    static qllm_real dwu[D * FFN_DIM], dwd[FFN_DIM * D], dbu[FFN_DIM], dbd[D];
+
+    for (int i = 0; i < D * FFN_DIM; i++) wu[i] = urand() * 0.05;
+    for (int i = 0; i < FFN_DIM * D; i++) wd[i] = urand() * 0.05;
+    for (int j = 0; j < FFN_DIM; j++) bu[j] = urand() * 0.01;
+    for (int i = 0; i < D; i++) { bd[i] = urand() * 0.01; x[i] = urand() * 0.3; tgt[i] = urand(); }
+
+    fwd_square(wu, wd, bu, bd, x, h_pre, fo);
+    (void)loss_from_output(fo, tgt, dfo);
+    qllm_backward_ffn_square(wu, wd, bu, bd, x, h_pre, dfo, dx, dwu, dbu, dwd, dbd);
+
+    RelAcc acc = {0, 0, 0};
+    for (int s = 0; s < N_W_SAMPLES; s++) {
+        int idx = irand(D * FFN_DIM); qllm_real sv = wu[idx];
+        wu[idx] = sv + (qllm_real)STEP; fwd_square(wu, wd, bu, bd, x, h_pre, fo);
+        double Lp = loss_from_output(fo, tgt, NULL);
+        wu[idx] = sv - (qllm_real)STEP; fwd_square(wu, wd, bu, bd, x, h_pre, fo);
+        double Lm = loss_from_output(fo, tgt, NULL);
+        wu[idx] = sv;
+        relacc_add(&acc, (Lp - Lm) / (2.0 * STEP), (double)dwu[idx]);
+    }
+    for (int s = 0; s < N_X_SAMPLES; s++) {
+        int idx = irand(D); qllm_real sv = x[idx];
+        x[idx] = sv + (qllm_real)STEP; fwd_square(wu, wd, bu, bd, x, h_pre, fo);
+        double Lp = loss_from_output(fo, tgt, NULL);
+        x[idx] = sv - (qllm_real)STEP; fwd_square(wu, wd, bu, bd, x, h_pre, fo);
+        double Lm = loss_from_output(fo, tgt, NULL);
+        x[idx] = sv;
+        relacc_add(&acc, (Lp - Lm) / (2.0 * STEP), (double)dx[idx]);
+    }
+    return relacc_value(&acc);
+}
+
+/* ------------------------------- gated FFN -------------------------------- */
+
+static double check_gated(void) {
+    static qllm_real wu[D * FFN_DIM], wd[FFN_DIM * D], wg[D * FFN_DIM];
+    static qllm_real bu[FFN_DIM], bd[D], bg[FFN_DIM];
+    static qllm_real x[D], tgt[D];
+    static qllm_real gate_post[FFN_DIM], up_post[FFN_DIM], h[FFN_DIM], fo[D], dfo[D], dx[D];
+    static qllm_real dwu[D * FFN_DIM], dwd[FFN_DIM * D], dwg[D * FFN_DIM];
+    static qllm_real dbu[FFN_DIM], dbd[D], dbg[FFN_DIM];
+
+    for (int i = 0; i < D * FFN_DIM; i++) { wu[i] = urand() * 0.05; wg[i] = urand() * 0.05; }
+    for (int i = 0; i < FFN_DIM * D; i++) wd[i] = urand() * 0.05;
+    for (int j = 0; j < FFN_DIM; j++) { bu[j] = urand() * 0.01; bg[j] = urand() * 0.01; }
+    for (int i = 0; i < D; i++) { bd[i] = urand() * 0.01; x[i] = urand(); tgt[i] = urand(); }
+
+    fwd_gated(wu, wd, wg, bu, bd, bg, x, gate_post, up_post, h, fo);
+    (void)loss_from_output(fo, tgt, dfo);
+    qllm_backward_ffn_gated(wu, wd, wg, bu, bd, bg, x, gate_post, up_post, h,
+                            dfo, dx, dwu, dbu, dwd, dbd, dwg, dbg);
+
+    RelAcc acc = {0, 0, 0};
+    /* sample W_up, W_gate, W_down and the input */
+    const qllm_real *wsrc[3] = { wu, wg, wd };
+    qllm_real *wgrad[3] = { dwu, dwg, dwd };
+    int wlen[3] = { D * FFN_DIM, D * FFN_DIM, FFN_DIM * D };
+    for (int b = 0; b < 3; b++) {
+        qllm_real *w = (qllm_real *)wsrc[b];
+        for (int s = 0; s < N_W_SAMPLES; s++) {
+            int idx = irand(wlen[b]); qllm_real sv = w[idx];
+            w[idx] = sv + (qllm_real)STEP;
+            fwd_gated(wu, wd, wg, bu, bd, bg, x, gate_post, up_post, h, fo);
+            double Lp = loss_from_output(fo, tgt, NULL);
+            w[idx] = sv - (qllm_real)STEP;
+            fwd_gated(wu, wd, wg, bu, bd, bg, x, gate_post, up_post, h, fo);
+            double Lm = loss_from_output(fo, tgt, NULL);
+            w[idx] = sv;
+            relacc_add(&acc, (Lp - Lm) / (2.0 * STEP), (double)wgrad[b][idx]);
+        }
+    }
+    for (int s = 0; s < N_X_SAMPLES; s++) {
+        int idx = irand(D); qllm_real sv = x[idx];
+        x[idx] = sv + (qllm_real)STEP;
+        fwd_gated(wu, wd, wg, bu, bd, bg, x, gate_post, up_post, h, fo);
+        double Lp = loss_from_output(fo, tgt, NULL);
+        x[idx] = sv - (qllm_real)STEP;
+        fwd_gated(wu, wd, wg, bu, bd, bg, x, gate_post, up_post, h, fo);
+        double Lm = loss_from_output(fo, tgt, NULL);
+        x[idx] = sv;
+        relacc_add(&acc, (Lp - Lm) / (2.0 * STEP), (double)dx[idx]);
+    }
+    return relacc_value(&acc);
+}
+
+int main(void) {
+    printf("=== SDNC qllm_backward gradient check (QLLM_REAL=%s) ===\n",
+           sizeof(qllm_real) == sizeof(double) ? "double" : "float");
+
+    double sq = check_square();
+    double ga = check_gated();
+
+    int ok_sq = (sq < TOLERANCE);
+    int ok_ga = (ga < TOLERANCE);
+
+    printf("  SQUARE FFN backward: L2 rel err = %.3e  (tol %.0e)  %s\n",
+           sq, (double)TOLERANCE, ok_sq ? "PASS" : "FAIL");
+    printf("  gated  FFN backward: L2 rel err = %.3e  (tol %.0e)  %s\n",
+           ga, (double)TOLERANCE, ok_ga ? "PASS" : "FAIL");
+
+    int passed = ok_sq + ok_ga, failed = (!ok_sq) + (!ok_ga);
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    return failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Refreshes `docs/SDNC.md` to verified reality and wires the two previously-dead SDNC paper-source files into the build with test coverage. Follows the completed SDNC capability audit.

### Part A — docs/SDNC.md
- **Two-execution-layer framing (new §0).** The SDNC runs on two real, verified layers of one system, with a precise opcode-for-capability correspondence:
  - *Weight-matrix layer* (`weight_matrices.c`): an 83-opcode ISA including 19 reverse-mode AD opcodes (`OP_AD_VAR=64 … OP_AD_COS=82`, + `OP_SWAP=83`, `OP_COUNT=84`), verified three ways at **127/127 inline** and **124/124 traced**, bit-identical on the full per-step state, weight-implementing **83 opcodes** (all but `OP_NATIVE_CALL=37`).
  - *Production bytecode VM* (`vm_core.c`/`eshkol_vm.c`/`vm_native.c`): a 66-opcode enum plus **720 native-call IDs spanning 20–2118**. The weight-matrix AD opcodes `64–82` correspond to the production VM's AD native calls `390–409` (same reverse-mode tape, two substrates).
- **Numbers updated upward** where reality exceeds the doc: 126→127 inline, 123→124 traced, 82→83 weight-implemented opcodes; `weight_matrices.c` now 7,544 lines; corrected `execute_step`/`run_reference`/`forward_with_weights`/`export_weights_binary` line refs.
- **New §12** documents the native-call ID surface (AD 390–409/1841–1844, tensors 410–461, consciousness 509–547/1800s, i128 2100–2118).
- **Re-pinned §7.3 SHA-256 checksums** at the current verification SHA (regenerated via the paper suite; QLMW 48,881,716 bytes = 28-byte header + 12,220,422×4).

### Part B — wire the dead files
- **`qllm_backward.c`** → new static library `eshkol-qllm-backward` + public header `inc/eshkol/backend/qllm_backward.h`. The two FFN backward passes are un-static'd; the math is precision-generic (`qllm_real`, default `float` so the QLMW/`InterpreterWeights` layout is byte-identical). New gradient-check test (`tests/backend/qllm_backward_gradcheck_test.c`, ctest `qllm_backward_gradcheck`): analytical vs. central finite-difference gradients, recompiled in double (`-DQLLM_REAL=double`) so the FD floor drops below the **1e-6** bar. **Achieved: SQUARE 3.7e-9, gated 2.3e-9.**
- **`qllm_interpreter.c`** → wired as the `eshkol-qllm-run` tool. It loads a QLMW v3 weight file and executes bytecode through the transformer forward pass (the weights *are* the interpreter). **Verified 9/9 built-in programs.** Wired rather than archived because it is a real, runnable QLMW loader/executor.
- Both files carry the SDNC-paper file-level doc comment.
- **ICC (append-only):** `qllm_backward_gradcheck` criterion on the `sdnc-paper-reproducibility` oracle + smoke probe in `run_icc_smoke.sh`. CHANGELOG appended.

## Verification
- Full Release build green; **`sdnc_paper_weight_tests` 127/127** (ctest); **`qllm_backward_gradcheck` green**; `eshkol-qllm-run` 9/9.
- New qllm targets also build under Debug (both configs).
- `run_vm_parity.sh` shares no sources with the changed files; CMake edits are additive-only (unaffected).

## Blueprint items (ahead of implementation, doc stays)
- QLMW v4 training loop: the reverse-mode backward pass is built and gradient-checked; the AdamW optimiser step + v4 checkpoint I/O that consume the format remain to be built.
- Curried `((gradient f) x)` on the VM (arity-2 `(gradient f x)` works today).