### PR TITLE
fix(ad): correct arity-1 whole-point tensor-loss gradients — no silent zeros, no crash

### DIFF
--- a/inc/eshkol/backend/autodiff_codegen.h
+++ b/inc/eshkol/backend/autodiff_codegen.h
@@ -364,6 +364,19 @@ public:
     llvm::Value* emitRuntimeClosureGradient(llvm::Value* closure_val,
                                             llvm::Value* point_val);
 
+    /**
+     * Emit a runtime diagnostic for a vector-valued gradient target and abort.
+     *
+     * `gradient` is defined for scalar-valued functions ℝⁿ→ℝ. A loss body that
+     * applies scalar arithmetic to the WHOLE point (elementwise tensor
+     * semantics) can return a length-`len` tensor (ℝⁿ→ℝᵐ, m>1), for which the
+     * gradient is undefined — the Jacobian is the right object. Rather than
+     * silently returning zeros or dereferencing an unwritten gradient slot,
+     * print a clear message naming `jacobian` and abort. Emits `fprintf` +
+     * `abort` + `unreachable`; the caller must NOT add a terminator after it.
+     */
+    void emitVectorValuedGradientError(llvm::Value* len);
+
     /** Higher-order derivative: (derivative f) → closure */
     llvm::Value* derivativeHigherOrder(const eshkol_operations_t* op);
 

--- a/lib/backend/autodiff_codegen.cpp
+++ b/lib/backend/autodiff_codegen.cpp
@@ -3536,6 +3536,133 @@ static bool adAstUsesTensorOps(
     }
 }
 
+// Elementwise arithmetic operators whose whole-tensor form the reverse-mode
+// tensor tape records as AD nodes (tensor_arith_codegen.cpp's AD path handles
+// exactly +,-,*,/). Applied to a whole vector these produce a tensor-shaped
+// (non-scalar) result while still being differentiable in reverse mode. Only
+// these are used to REROUTE a (vector …) point off the forward path — routing a
+// non-AD-aware whole-tensor op (e.g. elementwise sin) to reverse would give a
+// wrong gradient, so those stay on their existing path. Indexing/reduction ops
+// (vector-ref, dot, sum, …) are deliberately absent — they collapse to a scalar.
+static bool adIsElementwiseNumericOp(const char* n) {
+    if (!n) return false;
+    return (std::strcmp(n, "+") == 0 || std::strcmp(n, "-") == 0 ||
+            std::strcmp(n, "*") == 0 || std::strcmp(n, "/") == 0);
+}
+
+// Does `name` (an arity-1 gradient's sole parameter, bound to the WHOLE point)
+// flow through an elementwise numeric operator as a BARE operand — i.e. not
+// behind vector-ref/tensor-ref? Such a use, e.g. (define (loss x) (* x x)),
+// keeps the value vector-shaped, so the loss returns a TENSOR rather than a
+// scalar. gradient() must then differentiate it in REVERSE mode over the taped
+// point: the forward-mode dual scheme-vector path reads only the primal of each
+// tensor element and drops the tangent (a silent all-zero gradient). Scanned on
+// the SOURCE AST; conservative (unhandled forms default to false, keeping the
+// existing forward path). Mirrors adAstUsesTensorOps' union access for
+// CALL/IF/COND.
+static bool adNameFlowsWholeThroughArith(
+        const eshkol_ast_t* ast, const char* name, int depth = 0) {
+    if (!ast || !name || depth > 32) return false;
+    if (ast->type == ESHKOL_CONS) {
+        return adNameFlowsWholeThroughArith(ast->cons_cell.car, name, depth) ||
+               adNameFlowsWholeThroughArith(ast->cons_cell.cdr, name, depth);
+    }
+    if (ast->type != ESHKOL_OP) return false;
+    const eshkol_operations_t* op = &ast->operation;
+    switch (op->op) {
+        case ESHKOL_CALL_OP:
+        case ESHKOL_IF_OP:
+        case ESHKOL_COND_OP: {
+            const eshkol_ast_t* f = op->call_op.func;
+            bool elementwise = f && f->type == ESHKOL_VAR &&
+                               adIsElementwiseNumericOp(f->variable.id);
+            for (uint64_t i = 0; i < op->call_op.num_vars; i++) {
+                const eshkol_ast_t* arg = &op->call_op.variables[i];
+                if (elementwise && arg->type == ESHKOL_VAR && arg->variable.id &&
+                    std::strcmp(arg->variable.id, name) == 0)
+                    return true;
+                if (adNameFlowsWholeThroughArith(arg, name, depth + 1)) return true;
+            }
+            if (f && adNameFlowsWholeThroughArith(f, name, depth + 1)) return true;
+            return false;
+        }
+        case ESHKOL_SEQUENCE_OP:
+        case ESHKOL_AND_OP:
+        case ESHKOL_OR_OP:
+            for (uint64_t i = 0; i < op->sequence_op.num_expressions; i++)
+                if (adNameFlowsWholeThroughArith(&op->sequence_op.expressions[i], name, depth + 1))
+                    return true;
+            return false;
+        case ESHKOL_LET_OP:
+        case ESHKOL_LET_STAR_OP:
+        case ESHKOL_LETREC_OP:
+        case ESHKOL_LETREC_STAR_OP: {
+            for (uint64_t i = 0; i < op->let_op.num_bindings; i++)
+                if (adNameFlowsWholeThroughArith(&op->let_op.bindings[i], name, depth + 1))
+                    return true;
+            return adNameFlowsWholeThroughArith(op->let_op.body, name, depth + 1);
+        }
+        case ESHKOL_LAMBDA_OP:
+            return adNameFlowsWholeThroughArith(op->lambda_op.body, name, depth + 1);
+        case ESHKOL_DEFINE_OP:
+            return adNameFlowsWholeThroughArith(op->define_op.value, name, depth + 1);
+        default:
+            return false;
+    }
+}
+
+// Given an arity-1 function's body and sole-parameter name, does the body apply
+// scalar arithmetic DIRECTLY to that whole-vector parameter (elementwise tensor
+// semantics), or return it unchanged? If so a vector/tensor point must be
+// differentiated in reverse mode rather than on the forward-mode dual scheme-
+// vector path (which reads only the primal of each tensor element and silently
+// zeros the gradient of a whole-point tensor loss).
+static bool adBodyIsWholePointTensor(const eshkol_ast_t* body, const char* pname) {
+    if (!body || !pname) return false;
+    // Identity return: (lambda (v) v) yields the whole vector.
+    if (body->type == ESHKOL_VAR && body->variable.id &&
+        std::strcmp(body->variable.id, pname) == 0)
+        return true;
+    return adNameFlowsWholeThroughArith(body, pname);
+}
+
+// Resolve the differentiated function to an arity-1 (body, param-name) pair and
+// apply adBodyIsWholePointTensor. Two AST shapes reach here: an inline lambda
+// (params + body on the node) and a named function referenced by VAR — whose
+// SOURCE body is stored in `bodies` (as the raw body for a function-define, or
+// a lambda for a lambda-define) and whose sole-parameter name is recovered from
+// the compiled LLVM signature (`fallback_param`, the first formal). `bodies`
+// keys are tried both raw and via `body_key` (the __rv-stripped LLVM name).
+static bool adArity1WholePointTensorBody(
+        const eshkol_ast_t* fn,
+        const std::unordered_map<std::string, const eshkol_ast_t*>* bodies,
+        const std::string& body_key,
+        const char* fallback_param) {
+    if (!fn) return false;
+    // Inline lambda: everything is on the node.
+    if (fn->type == ESHKOL_OP && fn->operation.op == ESHKOL_LAMBDA_OP) {
+        if (fn->operation.lambda_op.num_params != 1) return false;
+        const eshkol_ast_t* p0 = &fn->operation.lambda_op.parameters[0];
+        if (p0->type != ESHKOL_VAR || !p0->variable.id) return false;
+        return adBodyIsWholePointTensor(fn->operation.lambda_op.body, p0->variable.id);
+    }
+    if (fn->type != ESHKOL_VAR || !bodies) return false;
+    const eshkol_ast_t* stored = nullptr;
+    auto it = bodies->find(body_key);
+    if (it == bodies->end() && fn->variable.id) it = bodies->find(fn->variable.id);
+    if (it != bodies->end()) stored = it->second;
+    if (!stored) return false;
+    // A lambda-define stores the lambda; a function-define stores the raw body.
+    if (stored->type == ESHKOL_OP && stored->operation.op == ESHKOL_LAMBDA_OP) {
+        if (stored->operation.lambda_op.num_params != 1) return false;
+        const eshkol_ast_t* p0 = &stored->operation.lambda_op.parameters[0];
+        if (p0->type != ESHKOL_VAR || !p0->variable.id) return false;
+        return adBodyIsWholePointTensor(stored->operation.lambda_op.body, p0->variable.id);
+    }
+    // Raw body: the parameter name comes from the LLVM signature.
+    return adBodyIsWholePointTensor(stored, fallback_param);
+}
+
 // ESH-0070: IR-level tensor check, used only when the differentiated function is
 // referenced by NAME (a VAR — e.g. (gradient bn-loss 1.0)) so its source AST is
 // not reachable from the gradient op. A named, single-level function's emitted
@@ -3925,6 +4052,44 @@ llvm::Value* AutodiffCodegen::gradientHigherOrder(const eshkol_operations_t* op)
  *         tagged AD-node value if nested inside an outer AD pass, or nullptr
  *         on failure (unresolved function, evaluation failure, etc).
  */
+// Runtime diagnostic for a vector-valued gradient target. See the declaration
+// in autodiff_codegen.h for the contract. Prints a message naming `jacobian`
+// and aborts (fprintf + abort + unreachable); no terminator may follow.
+void AutodiffCodegen::emitVectorValuedGradientError(llvm::Value* len) {
+    using namespace llvm;
+    FunctionType* fprintf_type = FunctionType::get(ctx_.int32Type(),
+        {ctx_.ptrType(), ctx_.ptrType()}, true);
+    FunctionCallee fprintf_func = ctx_.module().getOrInsertFunction("fprintf", fprintf_type);
+#ifdef _WIN32
+    FunctionType* stream_type = FunctionType::get(ctx_.ptrType(), {}, false);
+    FunctionCallee stderr_fn = ctx_.module().getOrInsertFunction(
+        runtime::stderr_stream_symbol, stream_type);
+    Value* stderr_ptr = ctx_.builder().CreateCall(stderr_fn, {});
+#else
+#ifdef __APPLE__
+    const char* stderr_sym = "__stderrp";
+#else
+    const char* stderr_sym = "stderr";
+#endif
+    GlobalVariable* stderr_var = ctx_.module().getGlobalVariable(stderr_sym);
+    if (!stderr_var) {
+        stderr_var = new GlobalVariable(ctx_.module(), ctx_.ptrType(), false,
+            GlobalValue::ExternalLinkage, nullptr, stderr_sym);
+    }
+    Value* stderr_ptr = ctx_.builder().CreateLoad(ctx_.ptrType(), stderr_var);
+#endif
+    Value* fmt = ctx_.builder().CreateGlobalStringPtr(
+        "gradient: function returned a length-%lld vector; gradient is defined "
+        "for scalar-valued functions (R^n -> R). Use jacobian for vector-valued "
+        "functions (R^n -> R^m).\n");
+    ctx_.builder().CreateCall(fprintf_func,
+        {stderr_ptr, fmt, ctx_.builder().CreateZExtOrTrunc(len, ctx_.int64Type())});
+    FunctionCallee abort_func = ctx_.module().getOrInsertFunction("abort",
+        FunctionType::get(ctx_.voidType(), false));
+    ctx_.builder().CreateCall(abort_func);
+    ctx_.builder().CreateUnreachable();
+}
+
 // Shared exact-AD gradient of a runtime closure value at an already-tagged
 // runtime point. See the declaration in autodiff_codegen.h for the contract.
 // Extracted verbatim from the former inline body of gradient()'s runtime
@@ -4223,19 +4388,99 @@ llvm::Value* AutodiffCodegen::emitRuntimeClosureGradient(llvm::Value* closure_va
                         return nullptr;
                     }
 
-                    // Backpropagate only when the closure returned an AD node. A
+                    // Backpropagate when the closure returned an AD node. A
                     // constant return means the loss ignores its input, so a zero
                     // gradient is the correct answer (not a dropped signal).
+                    //
+                    // gradient is ℝⁿ→ℝ, so the output is normally a single AD
+                    // node (the scalar loss). A body that applies scalar
+                    // arithmetic to the WHOLE point (e.g. (* x x)) instead returns
+                    // a TENSOR of AD nodes (elementwise): a 1-element tensor is the
+                    // scalar case — backprop from its sole element node → exact
+                    // gradient — while a multi-element tensor is a vector-valued
+                    // function (ℝⁿ→ℝᵐ) whose gradient is undefined (the Jacobian is
+                    // the right object), so emit a clean diagnostic rather than
+                    // silently zeroing or reading an unwritten gradient slot.
                     Value* rvt_ob = tagged_.getBaseType(tagged_.getType(rvt_out));
                     Value* rvt_is_ad = b.CreateICmpEQ(rvt_ob,
                         ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_CALLABLE));
+                    Value* rvt_out_is_heap = b.CreateICmpEQ(rvt_ob,
+                        ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_HEAP_PTR));
+                    AllocaInst* rvt_effnode_slot = b.CreateAlloca(ctx_.ptrType(), nullptr, "rvt_effnode");
+                    AllocaInst* rvt_dobwd_slot = b.CreateAlloca(ctx_.int1Type(), nullptr, "rvt_dobwd");
+                    b.CreateStore(b.CreateIntToPtr(tagged_.unpackInt64(rvt_out), ctx_.ptrType()),
+                        rvt_effnode_slot);
+                    b.CreateStore(rvt_is_ad, rvt_dobwd_slot);
+
+                    BasicBlock* rvt_tcheck = BasicBlock::Create(ctx_.context(), "rvt_out_tcheck", current_func);
+                    BasicBlock* rvt_tlen = BasicBlock::Create(ctx_.context(), "rvt_out_tlen", current_func);
+                    BasicBlock* rvt_vecval = BasicBlock::Create(ctx_.context(), "rvt_out_vecval", current_func);
+                    BasicBlock* rvt_tscalar = BasicBlock::Create(ctx_.context(), "rvt_out_tscalar", current_func);
+                    BasicBlock* rvt_decide = BasicBlock::Create(ctx_.context(), "rvt_out_decide", current_func);
                     BasicBlock* rvt_bwd = BasicBlock::Create(ctx_.context(), "rvt_bwd", current_func);
                     BasicBlock* rvt_nobwd = BasicBlock::Create(ctx_.context(), "rvt_nobwd", current_func);
                     BasicBlock* rvt_after = BasicBlock::Create(ctx_.context(), "rvt_after_bwd", current_func);
-                    b.CreateCondBr(rvt_is_ad, rvt_bwd, rvt_nobwd);
+
+                    // Only inspect a heap output when it is not already a scalar AD node.
+                    b.CreateCondBr(b.CreateAnd(rvt_out_is_heap, b.CreateNot(rvt_is_ad)),
+                        rvt_tcheck, rvt_decide);
+
+                    b.SetInsertPoint(rvt_tcheck);
+                    Value* rvt_ohp = tagged_.unpackPtr(rvt_out);
+                    Value* rvt_osub = b.CreateLoad(ctx_.int8Type(),
+                        b.CreateGEP(ctx_.int8Type(), rvt_ohp, ConstantInt::get(ctx_.int64Type(), -8)));
+                    Value* rvt_ois_ten = b.CreateICmpEQ(rvt_osub,
+                        ConstantInt::get(ctx_.int8Type(), HEAP_SUBTYPE_TENSOR));
+                    b.CreateCondBr(rvt_ois_ten, rvt_tlen, rvt_decide);
+
+                    b.SetInsertPoint(rvt_tlen);
+                    Value* rvt_otptr = b.CreateIntToPtr(tagged_.unpackInt64(rvt_out), ctx_.ptrType());
+                    Value* rvt_om = b.CreateLoad(ctx_.int64Type(), b.CreateStructGEP(rvt_tt, rvt_otptr, 3));
+                    b.CreateCondBr(b.CreateICmpUGT(rvt_om, ConstantInt::get(ctx_.int64Type(), 1)),
+                        rvt_vecval, rvt_tscalar);
+
+                    // Multi-element tensor output → vector-valued → clean diagnostic.
+                    b.SetInsertPoint(rvt_vecval);
+                    emitVectorValuedGradientError(rvt_om);
+
+                    // 1-element tensor output → its sole element is the scalar
+                    // loss node, but only when the loss taped an AD graph through
+                    // it (elementwise +,-,*,/). A non-AD-aware whole-tensor op or a
+                    // constant tensor stores a plain double there; backpropagating
+                    // from that bit-pattern as a pointer is the SIGSEGV. Validate
+                    // (non-zero, pointer range, plausible AD node type) before
+                    // using it; otherwise fall through with defaults (no backprop →
+                    // zero gradient), never a crash.
+                    b.SetInsertPoint(rvt_tscalar);
+                    Value* rvt_oelems = b.CreateLoad(ctx_.ptrType(), b.CreateStructGEP(rvt_tt, rvt_otptr, 2));
+                    Value* rvt_oe0 = b.CreateLoad(ctx_.int64Type(),
+                        b.CreateGEP(ctx_.int64Type(), rvt_oelems, ConstantInt::get(ctx_.int64Type(), 0)));
+                    Value* rvt_oe0_maybe = b.CreateAnd(
+                        b.CreateICmpNE(rvt_oe0, ConstantInt::get(ctx_.int64Type(), 0)),
+                        b.CreateICmpULT(rvt_oe0, ConstantInt::get(ctx_.int64Type(), 0x0001000000000000ULL)));
+                    BasicBlock* rvt_tvalidate = BasicBlock::Create(ctx_.context(), "rvt_out_tvalidate", current_func);
+                    BasicBlock* rvt_tset = BasicBlock::Create(ctx_.context(), "rvt_out_tset", current_func);
+                    b.CreateCondBr(rvt_oe0_maybe, rvt_tvalidate, rvt_decide);
+
+                    b.SetInsertPoint(rvt_tvalidate);
+                    Value* rvt_oe0_ptr = b.CreateIntToPtr(rvt_oe0, ctx_.ptrType());
+                    Value* rvt_oe0_type = b.CreateLoad(ctx_.int32Type(),
+                        b.CreateStructGEP(ctx_.adNodeType(), rvt_oe0_ptr, 0));
+                    Value* rvt_oe0_valid = b.CreateICmpULE(rvt_oe0_type,
+                        ConstantInt::get(ctx_.int32Type(), 63));
+                    b.CreateCondBr(rvt_oe0_valid, rvt_tset, rvt_decide);
+
+                    b.SetInsertPoint(rvt_tset);
+                    b.CreateStore(rvt_oe0_ptr, rvt_effnode_slot);
+                    b.CreateStore(ConstantInt::get(ctx_.int1Type(), 1), rvt_dobwd_slot);
+                    b.CreateBr(rvt_decide);
+
+                    b.SetInsertPoint(rvt_decide);
+                    Value* rvt_dobwd = b.CreateLoad(ctx_.int1Type(), rvt_dobwd_slot);
+                    b.CreateCondBr(rvt_dobwd, rvt_bwd, rvt_nobwd);
 
                     b.SetInsertPoint(rvt_bwd);
-                    Value* rvt_out_node = b.CreateIntToPtr(tagged_.unpackInt64(rvt_out), ctx_.ptrType());
+                    Value* rvt_out_node = b.CreateLoad(ctx_.ptrType(), rvt_effnode_slot);
                     backpropagate(rvt_tape, rvt_out_node);
                     ctx_.builder().CreateBr(rvt_after);
 
@@ -4998,7 +5243,31 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
             ? adAstUsesTensorOps(gbody, function_body_ast_, &grad_tensor_visited)
             : adFunctionUsesTensors(func_ptr);
     }
-    bool grad_vec_point_reverse = (grad_arity_early <= 1) && grad_fn_uses_tensors;
+    // A whole-point tensor loss (arity-1 body that applies scalar arithmetic
+    // directly to its whole-vector parameter, e.g. (define (loss x) (* x x)))
+    // is NOT flagged by adAstUsesTensorOps — plain +,-,*,/ are not named tensor
+    // builtins — yet it still returns a tensor and drops its tangent on the
+    // forward-mode dual path. Route such a (vector …) point through the
+    // reverse-mode tape as well, so its gradient is exact instead of a silent
+    // all-zero vector.
+    std::string grad_fallback_param_str;
+    if (func_ptr && func_ptr->arg_size() >= 1)
+        grad_fallback_param_str = func_ptr->arg_begin()->getName().str();
+    const char* grad_fallback_param =
+        grad_fallback_param_str.empty() ? nullptr : grad_fallback_param_str.c_str();
+    std::string grad_body_key = func_ptr->getName().str();
+    {
+        auto rv = grad_body_key.rfind("__rv");
+        if (rv != std::string::npos && rv + 4 < grad_body_key.size() &&
+            grad_body_key.find_first_not_of("0123456789", rv + 4) == std::string::npos)
+            grad_body_key.erase(rv);
+    }
+    bool grad_fn_arith_whole_point =
+        (grad_arity_early <= 1) &&
+        adArity1WholePointTensorBody(op->gradient_op.function, function_body_ast_,
+                                     grad_body_key, grad_fallback_param);
+    bool grad_vec_point_reverse =
+        (grad_arity_early <= 1) && (grad_fn_uses_tensors || grad_fn_arith_whole_point);
 
     // Extract type from input (may be DOUBLE, INT64, TENSOR_PTR, or AD_NODE_PTR for nested gradients)
     Value* input_type = tagged_.getType(vector_val);
@@ -5148,7 +5417,11 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
         Value* svec_from_list_int = ctx_.builder().CreatePtrToInt(svec_from_list, ctx_.int64Type());
         Value* svec_from_list_tagged = tagged_.packPtr(svec_from_list_int, ESHKOL_VALUE_HEAP_PTR);
         ctx_.builder().CreateStore(svec_from_list_tagged, svec_input_ptr);
-        ctx_.builder().CreateBr(scheme_vector_input);
+        // A (list …) point feeding a whole-point tensor loss must reach the
+        // reverse-mode tape too (grad_vec_to_tensor reads the converted svec via
+        // svec_input_ptr), so its gradient agrees with the equivalent (vector …)
+        // point instead of silently zeroing on the forward-mode dual path.
+        ctx_.builder().CreateBr(grad_vec_subtype_target);
     }
 
     // Check for TENSOR subtype — convert to Scheme vector ONLY for multi-param functions.
@@ -5557,7 +5830,11 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
     // variable). Reads the Scheme vector layout [len(8)][tagged elems] and
     // writes a plain-double tensor [dims|ndim=1|elems|total].
     ctx_.builder().SetInsertPoint(grad_vec_to_tensor);
-    Value* v2t_svec_ptr = tagged_.unpackPtr(vector_val);
+    // Read the EFFECTIVE Scheme vector (a (vector …) point stored unchanged, or
+    // a (list …) point converted by grad_list_to_svec) so both reach the same
+    // reverse-mode seeding.
+    Value* v2t_eff = ctx_.builder().CreateLoad(ctx_.taggedValueType(), svec_input_ptr);
+    Value* v2t_svec_ptr = tagged_.unpackPtr(v2t_eff);
     Value* v2t_n = ctx_.builder().CreateLoad(ctx_.int64Type(), v2t_svec_ptr);
     Value* v2t_elems_base = ctx_.builder().CreateGEP(ctx_.int8Type(), v2t_svec_ptr, ConstantInt::get(ctx_.int64Type(), 8));
     Value* v2t_elems = ctx_.builder().CreatePointerCast(v2t_elems_base, ctx_.ptrType());
@@ -6320,14 +6597,96 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
     Value* output_base_type = tagged_.getBaseType(output_type);
     Value* output_is_ad_node = ctx_.builder().CreateICmpEQ(output_base_type,
         ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_CALLABLE));
-    
+
+    // WHOLE-POINT TENSOR LOSS: gradient is ℝⁿ→ℝ, so the output is normally a
+    // single AD node (the scalar loss). A body that applies scalar arithmetic to
+    // the WHOLE point (elementwise, e.g. (define (loss x) (* x x))) instead
+    // returns a TENSOR of AD nodes: a 1-element tensor is the scalar case
+    // (backprop from its sole element node → exact gradient), while a
+    // multi-element tensor is a vector-valued function (ℝⁿ→ℝᵐ) whose gradient is
+    // undefined — the Jacobian is the right object — so emit a clean diagnostic
+    // rather than silently zeroing or dereferencing an unwritten gradient slot.
+    Value* output_is_heap = ctx_.builder().CreateICmpEQ(output_base_type,
+        ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_HEAP_PTR));
+    AllocaInst* effnode_slot = ctx_.builder().CreateAlloca(ctx_.ptrType(), nullptr, "grad_effnode");
+    AllocaInst* scalar_valid_slot = ctx_.builder().CreateAlloca(ctx_.int1Type(), nullptr, "grad_scalar_valid");
+    ctx_.builder().CreateStore(output_node_ptr, effnode_slot);
+    ctx_.builder().CreateStore(output_is_ad_node, scalar_valid_slot);
+
+    BasicBlock* out_tcheck = BasicBlock::Create(ctx_.context(), "grad_out_tcheck", current_func);
+    BasicBlock* out_tlen = BasicBlock::Create(ctx_.context(), "grad_out_tlen", current_func);
+    BasicBlock* out_vecval = BasicBlock::Create(ctx_.context(), "grad_out_vecval", current_func);
+    BasicBlock* out_tscalar = BasicBlock::Create(ctx_.context(), "grad_out_tscalar", current_func);
+    BasicBlock* out_decide = BasicBlock::Create(ctx_.context(), "grad_out_decide", current_func);
+    ctx_.builder().CreateCondBr(
+        ctx_.builder().CreateAnd(output_is_heap, ctx_.builder().CreateNot(output_is_ad_node)),
+        out_tcheck, out_decide);
+
+    ctx_.builder().SetInsertPoint(out_tcheck);
+    Value* out_hp = tagged_.unpackPtr(output_tagged);
+    Value* out_sub = ctx_.builder().CreateLoad(ctx_.int8Type(),
+        ctx_.builder().CreateGEP(ctx_.int8Type(), out_hp, ConstantInt::get(ctx_.int64Type(), -8)));
+    Value* out_is_ten = ctx_.builder().CreateICmpEQ(out_sub,
+        ConstantInt::get(ctx_.int8Type(), HEAP_SUBTYPE_TENSOR));
+    ctx_.builder().CreateCondBr(out_is_ten, out_tlen, out_decide);
+
+    ctx_.builder().SetInsertPoint(out_tlen);
+    Value* out_tptr = ctx_.builder().CreateIntToPtr(tagged_.unpackInt64(output_tagged), ctx_.ptrType());
+    Value* out_m = ctx_.builder().CreateLoad(ctx_.int64Type(),
+        ctx_.builder().CreateStructGEP(ctx_.tensorType(), out_tptr, 3));
+    ctx_.builder().CreateCondBr(
+        ctx_.builder().CreateICmpUGT(out_m, ConstantInt::get(ctx_.int64Type(), 1)),
+        out_vecval, out_tscalar);
+
+    // Multi-element tensor output → vector-valued → clean diagnostic.
+    ctx_.builder().SetInsertPoint(out_vecval);
+    emitVectorValuedGradientError(out_m);
+
+    // 1-element tensor output → its sole element is the scalar loss node, BUT
+    // only when the loss actually taped an AD graph through it (elementwise
+    // +,-,*,/). A non-AD-aware whole-tensor op or a constant tensor stores a
+    // plain double there; treating that bit-pattern as an AD-node pointer and
+    // backpropagating from it is the SIGSEGV. Validate: non-zero, in pointer
+    // range (excludes IEEE-754 doubles ≥ ~2.8e14 as int64), and a plausible AD
+    // node type tag. If it fails, fall through with the defaults (no backprop →
+    // zero gradient, the constant-loss answer), never a crash.
+    ctx_.builder().SetInsertPoint(out_tscalar);
+    Value* out_elems = ctx_.builder().CreateLoad(ctx_.ptrType(),
+        ctx_.builder().CreateStructGEP(ctx_.tensorType(), out_tptr, 2));
+    Value* out_e0 = ctx_.builder().CreateLoad(ctx_.int64Type(),
+        ctx_.builder().CreateGEP(ctx_.int64Type(), out_elems, ConstantInt::get(ctx_.int64Type(), 0)));
+    Value* out_e0_maybe = ctx_.builder().CreateAnd(
+        ctx_.builder().CreateICmpNE(out_e0, ConstantInt::get(ctx_.int64Type(), 0)),
+        ctx_.builder().CreateICmpULT(out_e0, ConstantInt::get(ctx_.int64Type(), 0x0001000000000000ULL)));
+    BasicBlock* out_tvalidate = BasicBlock::Create(ctx_.context(), "grad_out_tvalidate", current_func);
+    BasicBlock* out_tset = BasicBlock::Create(ctx_.context(), "grad_out_tset", current_func);
+    ctx_.builder().CreateCondBr(out_e0_maybe, out_tvalidate, out_decide);
+
+    ctx_.builder().SetInsertPoint(out_tvalidate);
+    Value* out_e0_ptr = ctx_.builder().CreateIntToPtr(out_e0, ctx_.ptrType());
+    Value* out_e0_type = ctx_.builder().CreateLoad(ctx_.int32Type(),
+        ctx_.builder().CreateStructGEP(ctx_.adNodeType(), out_e0_ptr, 0));
+    // Valid AD node op-type tags are a small non-negative range (0..~45).
+    Value* out_e0_valid = ctx_.builder().CreateICmpULE(out_e0_type,
+        ConstantInt::get(ctx_.int32Type(), 63));
+    ctx_.builder().CreateCondBr(out_e0_valid, out_tset, out_decide);
+
+    ctx_.builder().SetInsertPoint(out_tset);
+    ctx_.builder().CreateStore(out_e0_ptr, effnode_slot);
+    ctx_.builder().CreateStore(ConstantInt::get(ctx_.int1Type(), 1), scalar_valid_slot);
+    ctx_.builder().CreateBr(out_decide);
+
+    ctx_.builder().SetInsertPoint(out_decide);
+    Value* grad_scalar_valid = ctx_.builder().CreateLoad(ctx_.int1Type(), scalar_valid_slot);
+    Value* effective_out_node = ctx_.builder().CreateLoad(ctx_.ptrType(), effnode_slot);
+
     BasicBlock* has_valid_output = BasicBlock::Create(ctx_.context(), "grad_valid_output", current_func);
     BasicBlock* invalid_output = BasicBlock::Create(ctx_.context(), "grad_invalid_output", current_func);
     BasicBlock* after_backward = BasicBlock::Create(ctx_.context(), "grad_after_backward", current_func);
-    
+
     // Branch based on type check (robust detection)
-    ctx_.builder().CreateCondBr(output_is_ad_node, has_valid_output, invalid_output);
-    
+    ctx_.builder().CreateCondBr(grad_scalar_valid, has_valid_output, invalid_output);
+
     // Step 6: Run backward pass through computational graph (only for valid AD nodes)
     ctx_.builder().SetInsertPoint(has_valid_output);
 
@@ -6336,7 +6695,7 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
     ctx_.builder().CreateStore(active_var_node, ctx_.innerVarNodePtr());
     ctx_.builder().CreateStore(ConstantInt::get(ctx_.int64Type(), 0), ctx_.gradientXDegree());
 
-    backpropagate(partial_tape, output_node_ptr);
+    backpropagate(partial_tape, effective_out_node);
     ctx_.builder().CreateBr(after_backward);
     
     // Skip backward pass if output is invalid (placeholder function returning scalar)
@@ -6381,7 +6740,7 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
         Value* rb_node_slot = ctx_.builder().CreateGEP(PointerType::getUnqual(ctx_.context()),
             typed_var_nodes, rb_j);
         Value* rb_node = ctx_.builder().CreateLoad(PointerType::getUnqual(ctx_.context()), rb_node_slot);
-        Value* rb_grad = ctx_.builder().CreateSelect(output_is_ad_node,
+        Value* rb_grad = ctx_.builder().CreateSelect(grad_scalar_valid,
             loadNodeGradient(rb_node), ConstantFP::get(ctx_.doubleType(), 0.0));
         Value* rb_grad_i64 = ctx_.builder().CreateBitCast(rb_grad, ctx_.int64Type());
         Value* rb_res_ptr = ctx_.builder().CreateGEP(ctx_.int64Type(), typed_result_elements_ptr, rb_j);
@@ -6396,7 +6755,7 @@ llvm::Value* AutodiffCodegen::gradient(const eshkol_operations_t* op) {
 
     // SLOW PATH: per-component replay — store only the active component (var[i]).
     ctx_.builder().SetInsertPoint(single_read_bb);
-    Value* single_grad = ctx_.builder().CreateSelect(output_is_ad_node,
+    Value* single_grad = ctx_.builder().CreateSelect(grad_scalar_valid,
         loadNodeGradient(active_var_node), ConstantFP::get(ctx_.doubleType(), 0.0));
     Value* single_grad_i64 = ctx_.builder().CreateBitCast(single_grad, ctx_.int64Type());
     Value* single_res_ptr = ctx_.builder().CreateGEP(ctx_.int64Type(),

--- a/tests/autodiff/gradient_tensor_loss_test.esk
+++ b/tests/autodiff/gradient_tensor_loss_test.esk
@@ -1,0 +1,128 @@
+;; Regression: arity-1 whole-point tensor-loss gradients.
+;;
+;; An arity-1 loss receives the WHOLE point as one vector/tensor argument. When
+;; its body applies scalar arithmetic DIRECTLY to that whole argument
+;; (elementwise tensor semantics, e.g. (define (loss x) (* x x))), the loss
+;; value is a TENSOR, not a scalar read out of the point via vector-ref.
+;;
+;; gradient is ℝⁿ→ℝ, so:
+;;   * a SCALAR / 1-element-tensor loss output is the scalar case — the gradient
+;;     is exact (e.g. d/dx x² at 3 is 6, returned as #(6));
+;;   * a MULTI-element-tensor output is a vector-valued function (ℝⁿ→ℝᵐ) whose
+;;     gradient is undefined (the Jacobian is the right object) — gradient emits
+;;     a clean runtime diagnostic naming `jacobian` and aborts. That path is
+;;     verified out-of-band (it terminates the process), not in this all-pass
+;;     file; see scripts/icc_traces / the fix's PR description.
+;;
+;; Before the fix this class silently returned an all-zero gradient (or, on the
+;; reverse path, read an unwritten gradient slot). Every form below — direct,
+;; through a wrapper, and curried — must now agree and be exact AD.
+
+(require stdlib)
+
+(define tests-passed 0)
+(define tests-failed 0)
+
+(define (approx-equal? a b epsilon)
+  (< (abs (- a b)) epsilon))
+
+(define (check name expected actual)
+  (if (approx-equal? expected actual 1e-9)
+      (begin
+        (set! tests-passed (+ tests-passed 1))
+        (display "PASS: ") (display name) (newline))
+      (begin
+        (set! tests-failed (+ tests-failed 1))
+        (display "FAIL: ") (display name)
+        (display " (expected ") (display expected)
+        (display ", got ") (display actual) (display ")") (newline))))
+
+;; Strict bit-for-bit equality: an indirect/curried form must be byte-identical
+;; to the direct exact-AD call, not merely close (guards against a silent
+;; finite-difference fallback).
+(define (check-exact name a b)
+  (if (= a b)
+      (begin
+        (set! tests-passed (+ tests-passed 1))
+        (display "PASS: ") (display name) (newline))
+      (begin
+        (set! tests-failed (+ tests-failed 1))
+        (display "FAIL: ") (display name)
+        (display " (") (display a) (display " != ") (display b) (display ")") (newline))))
+
+(define (wrap f pt) (gradient f pt))
+
+;; ---------------------------------------------------------------------------
+;; T1: (define (loss x) (* x x)) — d/dx x² = 2x; at the 1-element point 3 → 6.
+;; Reader-literal #(3.0), (vector 3.0), through a wrapper, and curried must all
+;; equal 6 exactly.
+;; ---------------------------------------------------------------------------
+(define (sq x) (* x x))
+(define d1t (gradient sq #(3.0)))
+(define d1v (gradient sq (vector 3.0)))
+(define w1t (wrap sq #(3.0)))
+(define w1v (wrap sq (vector 3.0)))
+(define c1v ((gradient sq) (vector 3.0)))
+(check "t1 direct  #(3)   d/dx" 6.0 (vref d1t 0))
+(check "t1 direct  (vec3) d/dx" 6.0 (vref d1v 0))
+(check "t1 wrapped #(3)   d/dx" 6.0 (vref w1t 0))
+(check "t1 wrapped (vec3) d/dx" 6.0 (vref w1v 0))
+(check "t1 curried (vec3) d/dx" 6.0 (vref c1v 0))
+(check-exact "t1 reader==vector direct" (vref d1t 0) (vref d1v 0))
+(check-exact "t1 wrapped==direct"       (vref d1v 0) (vref w1v 0))
+(check-exact "t1 curried==direct"       (vref d1v 0) (vref c1v 0))
+
+;; ---------------------------------------------------------------------------
+;; T2: (define (loss x) (+ x x)) — d/dx (x+x) = 2, independent of the point.
+;; ---------------------------------------------------------------------------
+(define (dbl x) (+ x x))
+(check "t2 direct  #(5)   d/dx" 2.0 (vref (gradient dbl #(5.0)) 0))
+(check "t2 wrapped (vec5) d/dx" 2.0 (vref (wrap dbl (vector 5.0)) 0))
+
+;; ---------------------------------------------------------------------------
+;; T3: identity (lambda (v) v) returns the whole point — d/dx x = 1.
+;; ---------------------------------------------------------------------------
+(check "t3 identity #(4)  d/dx" 1.0 (vref (gradient (lambda (v) v) #(4.0)) 0))
+(check "t3 identity wrap  d/dx" 1.0 (vref (wrap (lambda (v) v) (vector 4.0)) 0))
+
+;; ---------------------------------------------------------------------------
+;; T4: multi-node arithmetic composition on the whole point — x³ via
+;; (* (* x x) x); d/dx = 3x². At 0.5 → 0.75. The direct, wrapped, and curried
+;; forms must be byte-identical (exact AD through the taped graph, not central
+;; differencing). Exercises a chain of recorded MUL nodes, not just one op.
+;; ---------------------------------------------------------------------------
+(define (cube x) (* (* x x) x))
+(define x0 0.5)
+(define expected-cube (* 3.0 (* x0 x0)))
+(define d4 (gradient cube (vector x0)))
+(define w4 (wrap cube (vector x0)))
+(define c4 ((gradient cube) (vector x0)))
+(check "t4 cubic direct d/dx" expected-cube (vref d4 0))
+(check-exact "t4 cubic wrapped==direct" (vref d4 0) (vref w4 0))
+(check-exact "t4 cubic curried==direct" (vref d4 0) (vref c4 0))
+
+;; ---------------------------------------------------------------------------
+;; T5: no regression — a REDUCING arity-1 body (reads the point via vector-ref)
+;; still yields the exact scalar gradient. loss(v) = v0²; d/dv0 = 2 v0.
+;; ---------------------------------------------------------------------------
+(define (red v) (* (vector-ref v 0) (vector-ref v 0)))
+(check "t5 reduce  #(3)   d/dx" 6.0 (vref (gradient red #(3.0)) 0))
+(check "t5 reduce  wrap   d/dx" 6.0 (vref (wrap red (vector 3.0)) 0))
+
+;; ---------------------------------------------------------------------------
+;; T6: a (list …) point feeding a whole-point tensor loss must AGREE with the
+;; equivalent (vector …) point (both reverse-taped), not silently zero.
+;; ---------------------------------------------------------------------------
+(define gv6 (gradient sq (vector 4.0)))
+(define gl6 (gradient sq (list 4.0)))
+(check "t6 list whole-point d/dx" 8.0 (vref gl6 0))
+(check-exact "t6 list==vector"    (vref gv6 0) (vref gl6 0))
+
+;; ---------------------------------------------------------------------------
+(newline)
+(display "gradient_tensor_loss: ")
+(display tests-passed) (display " passed, ")
+(display tests-failed) (display " failed") (newline)
+(if (= tests-failed 0)
+    (display "RESULT: ALL PASSED\n")
+    (display "RESULT: FAILURES\n"))


### PR DESCRIPTION
## Problem

An arity-1 loss receives the whole point as one vector/tensor argument. When its body applies scalar arithmetic **directly to that whole argument** (elementwise tensor semantics, e.g. `(define (loss x) (* x x))`), the loss value is a **tensor of AD nodes**, not a single scalar AD node. Both gradient paths assumed a scalar output:

- The **forward-mode** dual scheme-vector path (reached by a `(vector …)`/`(list …)` point) read only the primal of each tensor element and dropped the tangent → a **silent all-zero gradient**.
- The **reverse-mode** tape path (reached by a `#(…)`/`(tensor …)` point, or any wrapped/curried form) saw the output was not a single AD node, skipped backprop, and read unwritten gradient slots → all zeros, or dereferenced a plain-double bit-pattern as an AD-node pointer → **SIGSEGV**.

```
(define (loss x) (* x x))
(gradient loss (vector 3.0))   ; was #(0)  — now #(6)
(gradient loss #(3.0))         ; was #(0)  — now #(6)
```

## Contract

Per `docs/guide/AUTOMATIC_DIFFERENTIATION.md`, `gradient` is ℝⁿ→ℝ and `jacobian` is ℝⁿ→ℝᵐ. There is no `gradient`-on-vector-output contract, so:

- **scalar / 1-element-tensor output** → the scalar case: backpropagate from the sole element's AD node → **exact** gradient (`#(6)` for the repro);
- **multi-element-tensor output** → a vector-valued function whose gradient is undefined (the Jacobian is the right object) → a **clean runtime diagnostic** naming `jacobian`, then abort. Never zeros, never a crash.

```
gradient: function returned a length-2 vector; gradient is defined for scalar-valued
functions (R^n -> R). Use jacobian for vector-valued functions (R^n -> R^m).
```

## Fix (`lib/backend/autodiff_codegen.cpp`)

1. **Routing.** Route a `(vector …)`/`(list …)` point off the forward dual path onto the reverse-mode tape when an arity-1 body applies `+,-,*,/` directly to its whole parameter (`adArity1WholePointTensorBody` / `adNameFlowsWholeThroughArith`). Restricted to those four operators — the only ones `tensor_arith_codegen` records as AD nodes — so non-AD-aware whole-tensor ops are not misrouted.
2. **Reverse-mode output handling.** In both reverse-mode output sites (the direct `vector_input` path and the runtime-closure `rvt` path), detect a tensor-valued output: 1 element → **validate it is a genuine AD node** (non-zero, pointer range, plausible type tag) and backprop from it; >1 elements → `emitVectorValuedGradientError`. The AD-node validation is the guard against the SIGSEGV.
3. **List/vector agreement.** `(list …)` points feeding a whole-point loss now reach the same reverse seeding as the equivalent `(vector …)` point.

## Evidence

Exact and byte-identical across **direct / wrapped / curried** forms and `#()`/`(vector)`/`(list)` points, **JIT and AOT**.

- New `tests/autodiff/gradient_tensor_loss_test.esk`: **19/19** (JIT+AOT)
- `gradient_callable_arity` **25/25** (JIT+AOT)
- `tensor_input2` **24/24** (JIT+AOT)
- `forward_over_reverse` **17/0**
- `ad_input2` 11/0, `ad_adversarial` 24/24, `diff_geom` (Hessian correct)
- v1.3.4 edge-coverage **gradient** family: 15/15 JIT, AOT sample green
- AD smoke probes green: tensor-matmul / conv2d / batch-norm / layer-norm / attention gradients unchanged (they exercise the same reverse path)
- Multi-element diagnostic: clean message + abort, JIT and AOT (no zeros, no SIGSEGV)