### PR TITLE
build: system-dependency resolution for all FetchContent deps — Homebrew-compatible builds (fixes #342)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1054,8 +1054,12 @@ jobs:
           cd /tmp/tap
 
           formula=Formula/eshkol.rb
-          sed -i -E "s|url \"https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/[^\"]+\"|url \"${tarball_url}\"|" "$formula"
-          sed -i -E "s|sha256 \"[0-9a-f]{64}\"|sha256 \"${sha}\"|" "$formula"
+          # Only rewrite the TOP-LEVEL url/sha256 (2-space indent). The formula
+          # also carries `resource` blocks whose own sha256 lines (4-space
+          # indent) pin the bundled agent-FFI dependencies — those must survive
+          # the bump untouched, so both substitutions are anchored to column 3.
+          sed -i -E "s|^  url \"https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/[^\"]+\"|  url \"${tarball_url}\"|" "$formula"
+          sed -i -E "s|^  sha256 \"[0-9a-f]{64}\"|  sha256 \"${sha}\"|" "$formula"
 
           if git diff --quiet; then
             echo "::notice::Formula already at ${tag}; nothing to do."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3966,6 +3966,51 @@ endif()
 # runtime, but never silently disable or reduce it merely because of the host.
 option(ESHKOL_BUILD_AGENT_FFI "Build agent FFI modules" ON)
 
+# ──────────────────────────────────────────────────────────────────────────
+# Packaged / system-dependency resolution for the bundled agent-FFI native
+# dependencies (PCRE2, SQLite, zlib, tree-sitter + grammars, Yoga, curl).
+#
+# The default developer/release build downloads each dependency at pinned,
+# reproducible revisions via FetchContent (the block much further below).  That
+# is incompatible with sandboxed packaging environments such as Homebrew, which
+# inject a CMake dependency provider that refuses ALL FetchContent population
+# ("Refusing to populate dependency '<dep>' with FetchContent while building in
+# Homebrew, please use a formula dependency or add a resource to the formula").
+#
+# Two orthogonal, CMake-native escape hatches make a packaged build succeed
+# without a single network fetch, while leaving the default build byte-for-byte
+# unchanged:
+#
+#   * ESHKOL_USE_SYSTEM_PCRE2 links an installed PCRE2 (e.g. the Homebrew
+#     `pcre2` formula) under the same target name the bundled build defines,
+#     instead of fetching and compiling the pinned source.
+#
+#   * FETCHCONTENT_SOURCE_DIR_<UPPERCASE_NAME> points each remaining
+#     FetchContent dependency at a pre-staged source tree (a Homebrew
+#     `resource`).  CMake honors this natively: when set, the source-dir
+#     override "overrides everything else" — FetchContent_MakeAvailable() skips
+#     the dependency provider (so the Homebrew trap never fires) and performs no
+#     download (see the stock FetchContent.cmake).
+#
+# ESHKOL_HOMEBREW_BUILD is an umbrella that turns the packaging contract on: it
+# defaults ESHKOL_USE_SYSTEM_PCRE2 to ON and enables FETCHCONTENT_FULLY_
+# DISCONNECTED so any dependency the packager forgot to stage fails fast rather
+# than silently reaching the network.
+option(ESHKOL_HOMEBREW_BUILD
+    "Resolve bundled agent-FFI dependencies from system packages / staged resources (no FetchContent downloads)"
+    OFF)
+if(ESHKOL_HOMEBREW_BUILD)
+    set(_eshkol_use_system_pcre2_default ON)
+    if(NOT DEFINED FETCHCONTENT_FULLY_DISCONNECTED)
+        set(FETCHCONTENT_FULLY_DISCONNECTED ON)
+    endif()
+else()
+    set(_eshkol_use_system_pcre2_default OFF)
+endif()
+option(ESHKOL_USE_SYSTEM_PCRE2
+    "Link the system-provided PCRE2 (8-bit) instead of building the pinned source"
+    ${_eshkol_use_system_pcre2_default})
+
 if(ESHKOL_BUILD_AGENT_FFI)
     set(AGENT_FFI_DIR "${CMAKE_SOURCE_DIR}/lib/agent/c")
 
@@ -4023,29 +4068,70 @@ if(ESHKOL_BUILD_AGENT_FFI)
         # MSYS, vcpkg, a distro pkg-config database, or the release runner.
         # Build immutable upstream revisions on every host and package the
         # resulting static archives next to eshkol-agent-ffi.
+        #
+        # Exception: sandboxed packagers (see ESHKOL_HOMEBREW_BUILD /
+        # ESHKOL_USE_SYSTEM_PCRE2 / FETCHCONTENT_SOURCE_DIR_<name> above) may
+        # opt into resolving these from a system package or a pre-staged
+        # resource of the SAME pinned revision.  The default build below is
+        # unaffected.
         include(FetchContent)
         set(_eshkol_saved_build_shared_libs "${BUILD_SHARED_LIBS}")
         set(_eshkol_saved_build_testing "${BUILD_TESTING}")
         set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
         set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
 
-        set(PCRE2_BUILD_PCRE2_8 ON CACHE BOOL "" FORCE)
-        set(PCRE2_BUILD_PCRE2_16 OFF CACHE BOOL "" FORCE)
-        set(PCRE2_BUILD_PCRE2_32 OFF CACHE BOOL "" FORCE)
-        set(PCRE2_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-        set(PCRE2_BUILD_PCRE2GREP OFF CACHE BOOL "" FORCE)
-        set(PCRE2_BUILD_PCRE2TEST OFF CACHE BOOL "" FORCE)
-        set(PCRE2_SUPPORT_JIT ON CACHE BOOL "" FORCE)
-        set(PCRE2_STATIC_PIC ON CACHE BOOL "" FORCE)
-        set(PCRE2_INSTALL OFF CACHE BOOL "" FORCE)
-        FetchContent_Declare(eshkol_pcre2
-            GIT_REPOSITORY https://github.com/PCRE2Project/pcre2.git
-            GIT_TAG f454e231fe5006dd7ff8f4693fd2b8eb94333429
-            GIT_SHALLOW FALSE
-        )
-        FetchContent_MakeAvailable(eshkol_pcre2)
-        if(NOT TARGET pcre2-8-static)
-            message(FATAL_ERROR "Pinned PCRE2 did not define pcre2-8-static")
+        if(ESHKOL_USE_SYSTEM_PCRE2)
+            # Resolve PCRE2 from an installed package (e.g. the Homebrew
+            # `pcre2` formula).  Import its static 8-bit archive under the exact
+            # target name the bundled build defines (pcre2-8-static) so every
+            # downstream link / packaging copy / AOT-link reference below is
+            # identical and needs no change.
+            find_package(PkgConfig QUIET)
+            if(PkgConfig_FOUND)
+                pkg_check_modules(ESHKOL_SYS_PCRE2 QUIET libpcre2-8)
+            endif()
+            find_path(ESHKOL_SYS_PCRE2_INCLUDE_DIR
+                NAMES pcre2.h
+                HINTS ${ESHKOL_SYS_PCRE2_INCLUDE_DIRS} ${ESHKOL_SYS_PCRE2_INCLUDEDIR})
+            # Prefer the static archive so the packaged agent closure stays
+            # self-contained, matching the bundled-build contract.
+            set(_eshkol_saved_lib_suffixes "${CMAKE_FIND_LIBRARY_SUFFIXES}")
+            set(CMAKE_FIND_LIBRARY_SUFFIXES "${CMAKE_STATIC_LIBRARY_SUFFIX}")
+            find_library(ESHKOL_SYS_PCRE2_LIBRARY
+                NAMES pcre2-8
+                HINTS ${ESHKOL_SYS_PCRE2_LIBRARY_DIRS} ${ESHKOL_SYS_PCRE2_LIBDIR})
+            set(CMAKE_FIND_LIBRARY_SUFFIXES "${_eshkol_saved_lib_suffixes}")
+            if(NOT ESHKOL_SYS_PCRE2_LIBRARY OR NOT ESHKOL_SYS_PCRE2_INCLUDE_DIR)
+                message(FATAL_ERROR
+                    "ESHKOL_USE_SYSTEM_PCRE2=ON but a static libpcre2-8 archive and "
+                    "pcre2.h could not be located. Install the PCRE2 development "
+                    "package (Homebrew: `brew install pcre2`).")
+            endif()
+            add_library(pcre2-8-static STATIC IMPORTED GLOBAL)
+            set_target_properties(pcre2-8-static PROPERTIES
+                IMPORTED_LOCATION "${ESHKOL_SYS_PCRE2_LIBRARY}"
+                INTERFACE_INCLUDE_DIRECTORIES "${ESHKOL_SYS_PCRE2_INCLUDE_DIR}"
+                INTERFACE_COMPILE_DEFINITIONS "PCRE2_CODE_UNIT_WIDTH=8;PCRE2_STATIC=1")
+            message(STATUS "Agent FFI: system PCRE2 (${ESHKOL_SYS_PCRE2_LIBRARY})")
+        else()
+            set(PCRE2_BUILD_PCRE2_8 ON CACHE BOOL "" FORCE)
+            set(PCRE2_BUILD_PCRE2_16 OFF CACHE BOOL "" FORCE)
+            set(PCRE2_BUILD_PCRE2_32 OFF CACHE BOOL "" FORCE)
+            set(PCRE2_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+            set(PCRE2_BUILD_PCRE2GREP OFF CACHE BOOL "" FORCE)
+            set(PCRE2_BUILD_PCRE2TEST OFF CACHE BOOL "" FORCE)
+            set(PCRE2_SUPPORT_JIT ON CACHE BOOL "" FORCE)
+            set(PCRE2_STATIC_PIC ON CACHE BOOL "" FORCE)
+            set(PCRE2_INSTALL OFF CACHE BOOL "" FORCE)
+            FetchContent_Declare(eshkol_pcre2
+                GIT_REPOSITORY https://github.com/PCRE2Project/pcre2.git
+                GIT_TAG f454e231fe5006dd7ff8f4693fd2b8eb94333429
+                GIT_SHALLOW FALSE
+            )
+            FetchContent_MakeAvailable(eshkol_pcre2)
+            if(NOT TARGET pcre2-8-static)
+                message(FATAL_ERROR "Pinned PCRE2 did not define pcre2-8-static")
+            endif()
         endif()
 
         if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")

--- a/packaging/homebrew/eshkol.rb
+++ b/packaging/homebrew/eshkol.rb
@@ -1,8 +1,11 @@
-# typed: strict
+# typed: false
 # frozen_string_literal: true
 
 # Homebrew formula for Eshkol
-# This file should be copied to a homebrew-eshkol tap repository
+# This file is the canonical formula; it is mirrored to the tsotchke/homebrew-eshkol
+# tap. The release workflow (.github/workflows/release.yml, bump-homebrew-tap job)
+# rewrites ONLY the top-level `url` and top-level `sha256` on each release — the
+# resource pins below are preserved.
 #
 # Usage:
 #   brew tap tsotchke/eshkol
@@ -23,7 +26,82 @@ class Eshkol < Formula
   # and Intrinsic::sponentry/frameaddress lowering that landed in LLVM 21,
   # and the bytecode VM ABI assumes LLVM 21's tagged_value_t struct layout.
   depends_on "llvm@21"
+  # PCRE2 powers the (require agent.regex) FFI. Homebrew forbids the vendored
+  # FetchContent build during a formula build, so we link the real formula and
+  # pass -DESHKOL_USE_SYSTEM_PCRE2=ON (see the install block).
+  depends_on "pcre2"
   depends_on "readline"
+
+  on_linux do
+    # The native HTTP client links a minimal static libcurl on Linux (macOS uses
+    # NSURLSession and needs no curl); curl's TLS backend here is OpenSSL, which
+    # CMake's find_package(OpenSSL) locates via Homebrew's dependency search path.
+    depends_on "openssl@3"
+
+    resource "curl" do
+      url "https://github.com/curl/curl.git", revision: "a05f34973e6c4bb629d018f7cb51487be1c904d8"
+    end
+  end
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Bundled agent-FFI native dependencies.
+  #
+  # Homebrew installs a CMake dependency provider that refuses any live
+  # FetchContent population during a formula build. Instead of downloading these
+  # at configure time, we provide each pinned dependency as a Homebrew `resource`
+  # and stage it into FETCHCONTENT_SOURCE_DIR_<NAME> (see the install block). With
+  # that override set, CMake uses the staged tree and never invokes the provider.
+  #
+  # The revisions below MUST match the GIT_TAG / URL pins in CMakeLists.txt.
+  # ──────────────────────────────────────────────────────────────────────────
+  resource "sqlite-amalgamation" do
+    url "https://www.sqlite.org/2026/sqlite-amalgamation-3530300.zip"
+    sha256 "646421e12aac110282ef8cc68f1a62d4bb15fc7b8f09da0b53e29ee690500431"
+  end
+
+  resource "zlib" do
+    url "https://github.com/madler/zlib.git", revision: "51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf"
+  end
+
+  resource "tree-sitter" do
+    url "https://github.com/tree-sitter/tree-sitter.git", revision: "cd5b087cd9f45ca6d93ab1954f6b7c8534f324d2"
+  end
+
+  resource "yoga" do
+    url "https://github.com/facebook/yoga.git", revision: "042f5013152eb81c1552dec945b88f7b95ca350f"
+  end
+
+  # tree-sitter grammars: parser.c is checked in and compiled source-only.
+  resource "ts-javascript" do
+    url "https://github.com/tree-sitter/tree-sitter-javascript.git", revision: "58404d8cf191d69f2674a8fd507bd5776f46cb11"
+  end
+  resource "ts-typescript" do
+    url "https://github.com/tree-sitter/tree-sitter-typescript.git", revision: "75b3874edb2dc714fb1fd77a32013d0f8699989f"
+  end
+  resource "ts-python" do
+    url "https://github.com/tree-sitter/tree-sitter-python.git", revision: "26855eabccb19c6abf499fbc5b8dc7cc9ab8bc64"
+  end
+  resource "ts-rust" do
+    url "https://github.com/tree-sitter/tree-sitter-rust.git", revision: "77a3747266f4d621d0757825e6b11edcbf991ca5"
+  end
+  resource "ts-go" do
+    url "https://github.com/tree-sitter/tree-sitter-go.git", revision: "2346a3ab1bb3857b48b29d779a1ef9799a248cd7"
+  end
+  resource "ts-c" do
+    url "https://github.com/tree-sitter/tree-sitter-c.git", revision: "b780e47fc780ddc8da13afa35a3f4ed5c157823d"
+  end
+  resource "ts-cpp" do
+    url "https://github.com/tree-sitter/tree-sitter-cpp.git", revision: "8b5b49eb196bec7040441bee33b2c9a4838d6967"
+  end
+  resource "ts-java" do
+    url "https://github.com/tree-sitter/tree-sitter-java.git", revision: "e10607b45ff745f5f876bfa3e94fbcc6b44bdc11"
+  end
+  resource "ts-ruby" do
+    url "https://github.com/tree-sitter/tree-sitter-ruby.git", revision: "ad907a69da0c8a4f7a943a7fe012712208da6dee"
+  end
+  resource "ts-bash" do
+    url "https://github.com/tree-sitter/tree-sitter-bash.git", revision: "a06c2e4415e9bc0346c6b86d401879ffb44058f7"
+  end
 
   def install
     # Set LLVM paths for build and runtime
@@ -40,6 +118,49 @@ class Eshkol < Formula
     # Set runtime library path so eshkol-run can find LLVM when generating stdlib.o
     ENV["DYLD_FALLBACK_LIBRARY_PATH"] = llvm.opt_lib
 
+    # Stage the bundled agent-FFI dependency sources so CMake resolves them from
+    # disk instead of populating them with FetchContent (which Homebrew forbids).
+    # The FETCHCONTENT_SOURCE_DIR_<NAME> keys are the uppercased FetchContent
+    # content names declared in CMakeLists.txt.
+    deps_root = buildpath/"agent-ffi-deps"
+    staged = {
+      "ESHKOL_SQLITE_AMALGAMATION" => "sqlite-amalgamation",
+      "ESHKOL_ZLIB"                => "zlib",
+      "ESHKOL_TREE_SITTER"         => "tree-sitter",
+      "ESHKOL_YOGA"                => "yoga",
+      "ESHKOL_TS_JAVASCRIPT"       => "ts-javascript",
+      "ESHKOL_TS_TYPESCRIPT"       => "ts-typescript",
+      "ESHKOL_TS_PYTHON"           => "ts-python",
+      "ESHKOL_TS_RUST"             => "ts-rust",
+      "ESHKOL_TS_GO"               => "ts-go",
+      "ESHKOL_TS_C"                => "ts-c",
+      "ESHKOL_TS_CPP"              => "ts-cpp",
+      "ESHKOL_TS_JAVA"             => "ts-java",
+      "ESHKOL_TS_RUBY"             => "ts-ruby",
+      "ESHKOL_TS_BASH"             => "ts-bash",
+    }
+    staged["ESHKOL_CURL"] = "curl" if OS.linux?
+
+    fetchcontent_args = staged.map do |var, res_name|
+      target = deps_root/res_name
+      resource(res_name).stage(target.to_s)
+      # SQLite is consumed as ${SOURCE_DIR}/sqlite3.c; point at the directory
+      # that actually contains it (the zip may unpack into a subdirectory).
+      src_dir = target
+      if var == "ESHKOL_SQLITE_AMALGAMATION"
+        sqlite_c = Dir[target/"**/sqlite3.c"].first
+        odie "staged sqlite amalgamation is missing sqlite3.c" if sqlite_c.nil?
+        src_dir = Pathname.new(sqlite_c).dirname
+      end
+      "-DFETCHCONTENT_SOURCE_DIR_#{var}=#{src_dir}"
+    end
+
+    homebrew_dep_args = [
+      "-DESHKOL_HOMEBREW_BUILD=ON",
+      "-DESHKOL_USE_SYSTEM_PCRE2=ON",
+      "-DFETCHCONTENT_FULLY_DISCONNECTED=ON",
+    ]
+
     # Configure with explicit LLVM paths and proper RPATH
     # CMAKE_BUILD_WITH_INSTALL_RPATH ensures rpath is set at build time (needed for stdlib.o generation)
     system "cmake", "-B", "build", "-G", "Ninja",
@@ -50,6 +171,8 @@ class Eshkol < Formula
            "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON",
            "-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON",
            "-DCMAKE_MACOSX_RPATH=ON",
+           *homebrew_dep_args,
+           *fetchcontent_args,
            *std_cmake_args
 
     # Build eshkol-run first (without stdlib to avoid chicken-egg problem)
@@ -71,28 +194,47 @@ class Eshkol < Formula
     bin.install "build/eshkol-run"
     bin.install "build/eshkol-repl"
 
-    # Install library files to lib/eshkol/ (primary location)
+    # Install library files to lib/eshkol/ (primary location).
+    # eshkol-run resolves its runtime archive as <prefix>/lib/eshkol; it prefers
+    # libeshkol-runtime.a and falls back to the legacy libeshkol-static.a, so the
+    # PRIMARY runtime archive (libeshkol-runtime.a) must be installed too —
+    # without it, stdlib.o's runtime references are unresolved and no user
+    # program links.
     (lib/"eshkol").mkpath
     (lib/"eshkol").install "build/stdlib.o"
     (lib/"eshkol").install "build/stdlib.bc"
+    (lib/"eshkol").install "build/libeshkol-runtime.a"
     (lib/"eshkol").install "build/libeshkol-static.a"
+
+    # eshkol-run force-loads libeshkol-agent-ffi.a and replays its dependency
+    # closure (the stable-named eshkol-agent-*.a archives) at AOT link time for
+    # programs that (require agent.*). eshkol-run resolves all of them beside the
+    # runtime archive, so they must land in the same lib/eshkol directory.
+    (lib/"eshkol").install "build/libeshkol-agent-ffi.a" if File.exist?("build/libeshkol-agent-ffi.a")
+    Dir["build/eshkol-agent-*.a"].each { |archive| (lib/"eshkol").install archive }
 
     # Create symlinks in lib/ for convenience
     lib.install_symlink(lib/"eshkol/stdlib.o")
     lib.install_symlink(lib/"eshkol/stdlib.bc")
+    lib.install_symlink(lib/"eshkol/libeshkol-runtime.a")
     lib.install_symlink(lib/"eshkol/libeshkol-static.a")
 
-    # Install library source files
-    (share/"eshkol").install "lib/stdlib.esk"
-    (share/"eshkol/core").install Dir["lib/core/*"] if Dir.exist?("lib/core")
-    (share/"eshkol/math").install Dir["lib/math/*"] if Dir.exist?("lib/math")
-    (share/"eshkol").install "lib/math.esk" if File.exist?("lib/math.esk")
-    (share/"eshkol/signal").install Dir["lib/signal/*"] if Dir.exist?("lib/signal")
-    (share/"eshkol/ml").install Dir["lib/ml/*"] if Dir.exist?("lib/ml")
-    (share/"eshkol/random").install Dir["lib/random/*"] if Dir.exist?("lib/random")
-    (share/"eshkol/web").install Dir["lib/web/*"] if Dir.exist?("lib/web")
-    (share/"eshkol/tensor").install Dir["lib/tensor/*"] if Dir.exist?("lib/tensor")
-    (share/"eshkol/quantum").install Dir["lib/quantum/*"] if Dir.exist?("lib/quantum")
+    # Install module sources. eshkol-run resolves (require …) against the
+    # directory that contains stdlib.esk, discovered as <prefix>/share/eshkol/lib.
+    # A dotted module maps under it (agent.regex -> share/eshkol/lib/agent/regex.esk),
+    # so every runtime module must live below share/eshkol/lib — not share/eshkol.
+    esklib = share/"eshkol/lib"
+    esklib.mkpath
+    esklib.install "lib/stdlib.esk"
+    esklib.install "lib/math.esk" if File.exist?("lib/math.esk")
+    esklib.install "lib/tensorcore.esk" if File.exist?("lib/tensorcore.esk")
+    # core carries nested submodules (core/…/….esk); install the whole tree.
+    %w[core math signal ml random web tensor quantum].each do |mod|
+      esklib.install "lib/#{mod}" if Dir.exist?("lib/#{mod}")
+    end
+    # Agent modules: install the .esk wrappers only (skip the bundled C sources
+    # under lib/agent/c) so (require agent.regex) etc. resolve.
+    (esklib/"agent").install Dir["lib/agent/*.esk"] if Dir.exist?("lib/agent")
   end
 
   def caveats
@@ -110,9 +252,17 @@ class Eshkol < Formula
   end
 
   test do
-    # Test basic compilation
-    (testpath/"hello.esk").write('(display "Hello, World!")')
-    system "#{bin}/eshkol-run", "hello.esk", "-L#{lib}"
+    # Basic compilation + execution.
+    (testpath/"hello.esk").write('(display "Hello, World!")(newline)')
+    system bin/"eshkol-run", "hello.esk"
     assert_path_exists testpath/"a.out"
+    assert_equal "Hello, World!", shell_output("#{testpath}/a.out").strip
+
+    # (require …) must resolve against the installed module tree, and the runtime
+    # archive must link — a keg missing libeshkol-runtime.a or the share/eshkol/lib
+    # module sources fails here.
+    (testpath/"mods.esk").write("(require stdlib)(display (length (list 1 2 3)))(newline)")
+    system bin/"eshkol-run", "mods.esk", "-o", "mods"
+    assert_equal "3", shell_output("#{testpath}/mods").strip
   end
 end

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -71,12 +71,15 @@ import sys
 path, tag, sha = sys.argv[1:]
 with open(path) as f:
     src = f.read()
+# Only rewrite the TOP-LEVEL url/sha256 (2-space indent, anchored with (?m)^  ).
+# The formula also carries `resource` blocks whose own url/sha256 lines (deeper
+# indent) pin the bundled agent-FFI dependencies and must be left untouched.
 src = re.sub(
-    r'url "https://github\.com/tsotchke/eshkol/archive/(refs/tags/)?[^"]+"',
-    f'url "https://github.com/tsotchke/eshkol/archive/refs/tags/{tag}.tar.gz"',
+    r'(?m)^  url "https://github\.com/tsotchke/eshkol/archive/(refs/tags/)?[^"]+"',
+    f'  url "https://github.com/tsotchke/eshkol/archive/refs/tags/{tag}.tar.gz"',
     src,
 )
-src = re.sub(r'sha256 "[^"]*"', f'sha256 "{sha}"', src)
+src = re.sub(r'(?m)^  sha256 "[^"]*"', f'  sha256 "{sha}"', src)
 with open(path, "w") as f:
     f.write(src)
 print(f"==> updated {path}")


### PR DESCRIPTION
## Problem

Homebrew 4.x+ installs a CMake dependency provider (`trap_fetchcontent_provider.cmake`, injected via `CMAKE_PROJECT_TOP_LEVEL_INCLUDES`) that **refuses all FetchContent population** during a formula build:

```
Refusing to populate dependency 'eshkol_pcre2' with FetchContent while
building in Homebrew, please use a formula dependency or add a resource
to the formula.
```

`brew install tsotchke/eshkol/eshkol` therefore fails at configure time on the first agent-FFI dependency (`eshkol_pcre2` at CMakeLists.txt). Because the release workflow auto-bumps the tap, **the next release would ship a broken install**.

## Fix (two layers, default build byte-for-byte unchanged)

### CMake (`CMakeLists.txt`)
Every bundled agent-FFI dependency becomes resolvable with **zero live FetchContent downloads**, while the default developer/release path is untouched:

- **`ESHKOL_HOMEBREW_BUILD`** (OFF) — umbrella: defaults `ESHKOL_USE_SYSTEM_PCRE2=ON` and enables `FETCHCONTENT_FULLY_DISCONNECTED` so a missing staged dependency fails fast instead of reaching the network.
- **`ESHKOL_USE_SYSTEM_PCRE2`** (OFF) — imports an installed PCRE2 (Homebrew `pcre2`) as an `IMPORTED STATIC` target under the exact name the bundled build defines (`pcre2-8-static`), so every downstream link / packaging copy / AOT-link reference is identical and needs no change.
- **`FETCHCONTENT_SOURCE_DIR_<NAME>`** (CMake-native) resolves the remaining deps from pre-staged resources. When set, CMake's `FetchContent_MakeAvailable()` skips the dependency provider entirely (so the Homebrew trap never fires) and performs no download.

The stock FetchContent path (all flags off) is unchanged: the original pcre2 logic is preserved verbatim inside the `else()` branch.

### Formula (`packaging/homebrew/eshkol.rb`)
- `depends_on "pcre2"`; pass `-DESHKOL_HOMEBREW_BUILD=ON -DESHKOL_USE_SYSTEM_PCRE2=ON`.
- `resource` blocks pinning the **same revisions** as CMakeLists.txt for sqlite / zlib / tree-sitter + 10 grammars / yoga (+ curl on Linux); each staged into `FETCHCONTENT_SOURCE_DIR_<NAME>`.
- Installs `libeshkol-agent-ffi.a` and the stable-named `eshkol-agent-*.a` archives so `(require agent.*)` AOT links work on a packaged install (previously never shipped).
- `on_linux`: libcurl resource + `openssl@3` for the native HTTP client (macOS uses NSURLSession — no curl).

### Release plumbing (`release.yml`, `update-homebrew-formula.sh`)
Anchor the auto-bump `url`/`sha256` substitutions to the **top-level** (2-space indent) so the new `resource` sha256 pins survive a release bump.

## Dependency inventory

| Dep | Homebrew formula? | Resolution chosen |
|-----|-------------------|-------------------|
| pcre2 | yes (`pcre2`) | system, imported static `pcre2-8-static` |
| sqlite (amalgamation) | yes, but custom compile-defines required | `resource` (URL zip) + `FETCHCONTENT_SOURCE_DIR` |
| zlib | yes | `resource` (git rev) + `FETCHCONTENT_SOURCE_DIR` |
| tree-sitter runtime | yes | `resource` (git rev) — kept staged to keep parser-ABI in lockstep with grammars |
| tree-sitter grammars ×10 | no | `resource` (git rev) each |
| yoga | no | `resource` (git rev) |
| curl (Linux only) | yes | `resource` (git rev); macOS uses NSURLSession |
| eigen | Windows/MSVC only | n/a (not reached on macOS/Linux) |
| moonlab | opt-in `ESHKOL_QUANTUM_ENABLED=OFF` | n/a (not reached by default) |

Nothing mandatorily requires FetchContent under `ESHKOL_HOMEBREW_BUILD`.

## Verification (macOS arm64, LLVM 21.1.8)

1. **Homebrew constraint simulated with the real trap provider** (`-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=…/trap_fetchcontent_provider.cmake` + `ESHKOL_HOMEBREW_BUILD=ON` + `ESHKOL_USE_SYSTEM_PCRE2=ON` + `FETCHCONTENT_SOURCE_DIR_*` staged): configure completes, **0 "Refusing to populate", 0 downloads**; full `eshkol-run` build; `eshkol-run hello.esk` compiles+runs.
2. **System-PCRE2 regex end-to-end**: `tests/toolchain/release-agent-smoke.esk` (`regex-compile`/`regex-match?`) AOT-compiled+run → "release agent smoke", exit 0.
3. **Default path** (`ESHKOL_USE_SYSTEM_PCRE2=OFF`, pcre2 built from pinned source → `pcre2-8-static`): full build + smoke pass — the default path is unaffected.
4. **`brew install --build-from-source`** of the fix-branch source in a local tap: builds under Homebrew's real sandbox + trap; install + `test do` pass.
5. Both auto-bump mechanisms simulated: only the top-level `url`/`sha256` change; the resource sha256 is preserved.

Fixes #342
