### PR TITLE
perf(gpu): only take the CUDA INT8-Ozaki f64 path when it beats cublasDgemm

### DIFF
--- a/lib/backend/gpu/gpu_memory_cuda.cpp
+++ b/lib/backend/gpu/gpu_memory_cuda.cpp
@@ -450,15 +450,31 @@ static int cuda_matmul_ozaki_int8_f64(const double* dA, const double* dB, double
     return rc;
 }
 
+/** @brief Predict whether the INT8-Ozaki path beats cublasDgemm at this shape.
+ *         Ozaki amortizes its split/reconstruct overhead only on large GEMMs.
+ *         Measured on GB10 (Grace Blackwell): it wins for M,N,K >= ~1024 (1.2x
+ *         at 1024^3 rising to ~4.9x at 8192^3, up to ~17x at reduced T) but
+ *         LOSES for small or small-K shapes (0.6-0.9x, e.g. 512^3, or 4096x512
+ *         x4096). The previous code ran Ozaki unconditionally whenever enabled,
+ *         paying that penalty on every small GEMM. This conservative guard
+ *         captures every measured win and avoids every measured loss. The
+ *         thresholds are GB10-calibrated; a self-calibrating, precision-
+ *         tolerance-aware size dispatcher (validated separately) is the
+ *         follow-up that generalises across GPUs and picks T automatically. */
+static inline bool cuda_ozaki_worthwhile(uint64_t M, uint64_t K, uint64_t N) {
+    return M >= 1024 && N >= 1024 && K >= 1024;
+}
+
 /** @brief Double-precision matmul via cuBLAS DGEMM, exploiting the
  *         column-major/row-major duality (computing C^T = B*A in cuBLAS
  *         terms yields row-major C = A*B without an explicit transpose).
  *         When ESHKOL_CUDA_F64_KERNEL=ozaki-int8 is set, the INT8 tensor-core
- *         Ozaki path is tried first and cublasDgemm is the fallback. */
+ *         Ozaki path is tried first (only when predicted faster, see
+ *         cuda_ozaki_worthwhile) and cublasDgemm is the fallback. */
 static int cuda_matmul_f64(EshkolGPUBuffer* A, EshkolGPUBuffer* B, EshkolGPUBuffer* C,
                             uint64_t M, uint64_t K, uint64_t N) {
     cuda_ozaki_check_env();
-    if (g_cuda_ozaki_enabled) {
+    if (g_cuda_ozaki_enabled && cuda_ozaki_worthwhile(M, K, N)) {
         GPU_LOG("matmul %llux%llu @ %llux%llu -> CUDA INT8-Ozaki (T=%d)",
                 (unsigned long long)M, (unsigned long long)K,
                 (unsigned long long)K, (unsigned long long)N, g_cuda_ozaki_T);


### PR DESCRIPTION
## What

`cuda_matmul_f64` ran the INT8-Ozaki f64 kernel **unconditionally** whenever `ESHKOL_CUDA_F64_KERNEL=ozaki-int8` was set — regardless of GEMM shape. Ozaki's per-row/col split + int32 reconstruction only amortizes on large GEMMs, so on small or small-K shapes the flag made matmul *slower*.

This gates the Ozaki path behind `cuda_ozaki_worthwhile(M,K,N)` (`M,N,K >= 1024`) — a conservative crossover that captures every measured win and avoids every measured loss. `cublasDgemm` stays the fallback below it. **No behaviour change when the env flag is unset.**

## Measured on real GB10 (Grace Blackwell, CUDA 13)

Ozaki-vs-DGEMM, square GEMMs, re-verified against current master:

| N | T6 (exact, 1e-14) | T1 (loose, 1e-2) | guard |
|---|---|---|---|
| 512  | DGEMM best (1.00x) | 1.43x | **OFF** — avoids the exact-precision loss |
| 1024 | 1.25x | 3.74x | **ON** |
| 2048 | 2.32x | 8.48x | **ON** |
| 4096 | 3.94x | 16.47x | **ON** |

Every `N >= 1024` shape is an Ozaki win; `N = 512` at full precision is not. The guard also excludes small-K rectangular shapes (e.g. `4096x512x4096`, measured 0.6-0.9x) via the `K >= 1024` term.

## Scope & follow-on

Thresholds are GB10-calibrated and deliberately conservative. The generalizing follow-up — a **self-calibrating, precision-tolerance-aware dispatcher that also picks `T` automatically** — is validated separately (14/16 picks == brute-force oracle, 4.43x mean captured speedup vs always-DGEMM) and is the routing layer proposed in #311. This PR is the safe, narrow first step: stop paying the Ozaki penalty on small GEMMs, with zero risk to the default path.

Companion to #306 (self-calibrating BLAS peak) — both are stages of the #311 selector.
