### PR TITLE
fix(types): linear-type scope leak + branch over-restriction, with honest enforcement-scope docs (#320)

### DIFF
--- a/inc/eshkol/types/type_checker.h
+++ b/inc/eshkol/types/type_checker.h
@@ -128,6 +128,18 @@ public:
                                            const std::vector<hott_type_expr_t*>& type_args) const;
 
     // Linear type binding (Phase 6)
+    //
+    // Enforcement scope — what "use exactly once" actually covers today (#320):
+    //  * Enforced: `define` and `lambda` PARAMETERS typed TYPE_FLAG_LINEAR. Such
+    //    a parameter must be referenced exactly once in the body; over/under-use
+    //    is reported at scope exit via checkLinearConstraints().
+    //  * NOT enforced: `let`/`let*`/`letrec` bindings — they are bound via the
+    //    plain bind() path (synthesizeLet), never bindLinear(), so a linear-typed
+    //    let binding is not use-once checked. (A known gap, not a guarantee.)
+    //  * Static, not dynamic: a use is counted where a linear variable NAME
+    //    appears. A closure that captures a linear variable counts as ONE static
+    //    use regardless of how many times the closure is later invoked (0 or many
+    //    dynamic duplications are invisible to this check).
     /** Bind @p name as a linear variable of the given type (must be used exactly once). */
     void bindLinear(const std::string& name, TypeId type);
     /** Record a use of the linear variable @p name, incrementing its usage count. */

--- a/inc/eshkol/types/type_checker.h
+++ b/inc/eshkol/types/type_checker.h
@@ -147,6 +147,23 @@ public:
     /** True if all linear variables in scope were used exactly once. */
     bool checkLinearConstraints() const;
 
+    // Branch-exclusive linear accounting (#320 item 2). Mutually-exclusive
+    // branches (if/cond) must charge the MAX linear use across them, not the sum
+    // — e.g. (if b (X q) (Z q)) consumes the linear q exactly once at runtime.
+    /** Capture the current per-variable linear usage counts. */
+    std::map<std::string, int> snapshotLinearUsage() const { return linear_usage_count_; }
+    /** Restore linear usage counts to a previous snapshot (rewind a branch). */
+    void restoreLinearUsage(const std::map<std::string, int>& snap) { linear_usage_count_ = snap; }
+    /** Merge another branch's usage counts in by taking the per-variable max. */
+    void mergeMaxLinearUsage(const std::map<std::string, int>& other) {
+        for (const auto& kv : other) {
+            auto it = linear_usage_count_.find(kv.first);
+            if (it == linear_usage_count_.end() || kv.second > it->second) {
+                linear_usage_count_[kv.first] = kv.second;
+            }
+        }
+    }
+
 private:
     // Stack of scopes, each scope is a map from name to type
     std::vector<std::map<std::string, TypeId>> scopes_;

--- a/inc/eshkol/types/type_checker.h
+++ b/inc/eshkol/types/type_checker.h
@@ -163,6 +163,15 @@ private:
     // Linear type tracking
     std::set<std::string> linear_vars_;
     std::map<std::string, int> linear_usage_count_;  // 0=unused, 1=used, 2+=overused
+
+    // Per-scope record of names bound linear (via bindLinear) in each active
+    // scope, parallel to scopes_. popScope() uses it to remove exactly this
+    // scope's linear tracking — restoring any shadowed outer binding — so a
+    // linear variable and its over/under-use diagnostics do not leak into
+    // sibling defines/lambdas (#320). had_prior/prior_count carry the shadowed
+    // outer usage count to restore when this scope exits.
+    struct LinearScopeEntry { std::string name; bool had_prior; int prior_count; };
+    std::vector<std::vector<LinearScopeEntry>> linear_scope_saves_;
 };
 
 /**

--- a/lib/types/type_checker.cpp
+++ b/lib/types/type_checker.cpp
@@ -22,6 +22,7 @@ namespace eshkol::hott {
 Context::Context() {
     // Start with global scope
     scopes_.push_back({});
+    linear_scope_saves_.push_back({});
 }
 
 /**
@@ -29,6 +30,7 @@ Context::Context() {
  */
 void Context::pushScope() {
     scopes_.push_back({});
+    linear_scope_saves_.push_back({});
 }
 
 /**
@@ -39,6 +41,22 @@ void Context::pushScope() {
  */
 void Context::popScope() {
     if (scopes_.size() > 1) {
+        // Tear down this scope's linear tracking so linear variables — and their
+        // over/under-use diagnostics — do not leak into sibling defines/lambdas
+        // (#320). A binding that shadowed an outer linear variable restores the
+        // outer usage count; a fresh binding is removed outright. Usage of a
+        // non-shadowed outer linear variable is left intact so it still
+        // propagates up to the enclosing scope's constraint check.
+        auto& saves = linear_scope_saves_.back();
+        for (auto it = saves.rbegin(); it != saves.rend(); ++it) {
+            if (it->had_prior) {
+                linear_usage_count_[it->name] = it->prior_count;
+            } else {
+                linear_vars_.erase(it->name);
+                linear_usage_count_.erase(it->name);
+            }
+        }
+        linear_scope_saves_.pop_back();
         scopes_.pop_back();
     }
 }
@@ -720,6 +738,13 @@ void BorrowChecker::addError(BorrowError::Kind kind, const std::string& var,
 void Context::bindLinear(const std::string& name, TypeId type) {
     // Bind the variable normally
     bind(name, type);
+    // Record what this scope is about to overwrite so popScope() can restore a
+    // shadowed outer linear binding (or drop a fresh one) — see popScope (#320).
+    if (!linear_scope_saves_.empty()) {
+        bool had_prior = linear_vars_.count(name) > 0;
+        int prior_count = had_prior ? linear_usage_count_[name] : 0;
+        linear_scope_saves_.back().push_back({name, had_prior, prior_count});
+    }
     // Mark it as linear
     linear_vars_.insert(name);
     linear_usage_count_[name] = 0;  // Unused initially

--- a/lib/types/type_checker.cpp
+++ b/lib/types/type_checker.cpp
@@ -2941,6 +2941,9 @@ TypeCheckResult TypeChecker::synthesizeLet(eshkol_ast_t* expr) {
 
         binding_names.push_back(name);
         binding_types.push_back(binding_type);
+        // NOTE(#320): let bindings use plain bind(), not bindLinear(), so a
+        // linear-typed let binding is NOT use-once checked. Linearity is enforced
+        // only on define/lambda parameters today; see Context's linear API docs.
         ctx_.bind(name, binding_type);
     }
 

--- a/lib/types/type_checker.cpp
+++ b/lib/types/type_checker.cpp
@@ -3171,6 +3171,11 @@ TypeCheckResult TypeChecker::synthesizeIf(eshkol_ast_t* expr) {
         }
     }
 
+    // Snapshot linear usage before the branches so mutually-exclusive branches
+    // are charged the MAX linear use across them, not the sum (#320 item 2):
+    // (if b (X q) (Z q)) consumes the linear q exactly once at runtime.
+    auto linear_before = ctx_.snapshotLinearUsage();
+
     TypeCheckResult then_type;
     if (!active.empty()) {
         ctx_.pushScope();
@@ -3185,8 +3190,16 @@ TypeCheckResult TypeChecker::synthesizeIf(eshkol_ast_t* expr) {
     if (!then_type.success) return then_type;
 
     if (expr->operation.call_op.num_vars >= 3) {
+        // Rewind linear usage to the pre-branch baseline, synthesize the else
+        // branch from that same baseline, then charge max(then, else) per linear
+        // variable — the two branches are mutually exclusive at runtime.
+        auto after_then = ctx_.snapshotLinearUsage();
+        ctx_.restoreLinearUsage(linear_before);
+
         auto else_type = synthesize(&expr->operation.call_op.variables[2]);
         if (!else_type.success) return else_type;
+
+        ctx_.mergeMaxLinearUsage(after_then);
 
         TypeId then_t = then_type.inferred_type;
         TypeId else_t = else_type.inferred_type;

--- a/tests/types/type_checker_test.cpp
+++ b/tests/types/type_checker_test.cpp
@@ -602,6 +602,50 @@ TEST(context_linear_constraints) {
     ASSERT_TRUE(ctx.checkLinearConstraints());
 }
 
+TEST(context_linear_scope_no_leak) {
+    // #320 item 1: a linear violation in one scope must not leak into a sibling
+    // scope's constraint check. Previously popScope() never cleared
+    // linear_vars_/linear_usage_count_, so a define's over/under-use diagnostic
+    // was misattributed to the next define.
+    Context ctx;
+
+    // Scope A: linear 'q' used twice — a no-cloning violation, correctly caught.
+    ctx.pushScope();
+    ctx.bindLinear("q", BuiltinTypes::Int64);
+    ctx.useLinear("q");
+    ctx.useLinear("q");
+    ASSERT_FALSE(ctx.checkLinearConstraints());
+    ctx.popScope();
+
+    // Scope B (sibling): a fresh, valid linear 'r' used exactly once.
+    ctx.pushScope();
+    ctx.bindLinear("r", BuiltinTypes::Int64);
+    ctx.useLinear("r");
+    ASSERT_TRUE(ctx.checkLinearConstraints());   // must pass — no leaked 'q'
+    ASSERT_TRUE(ctx.getOverusedLinear().empty()); // 'q' must not resurface here
+    ASSERT_FALSE(ctx.isLinear("q"));              // 'q' gone once its scope closed
+    ctx.popScope();
+}
+
+TEST(context_linear_scope_shadowing) {
+    // #320 item 1: a nested linear binding that shadows an outer one must not,
+    // on scope exit, erase the outer variable's linear tracking (that would be a
+    // false negative — an unchecked outer linear variable).
+    Context ctx;
+    ctx.pushScope();
+    ctx.bindLinear("q", BuiltinTypes::Int64);   // outer q
+    ctx.pushScope();
+    ctx.bindLinear("q", BuiltinTypes::Int64);   // inner q shadows outer
+    ctx.useLinear("q");                          // consumes the INNER q
+    ASSERT_TRUE(ctx.checkLinearConstraints());
+    ctx.popScope();                              // restores outer q (still unused)
+    ASSERT_TRUE(ctx.isLinear("q"));              // outer q still tracked
+    ASSERT_FALSE(ctx.isLinearUsed("q"));         // inner use did not count for outer
+    ctx.useLinear("q");                          // now consume outer q
+    ASSERT_TRUE(ctx.checkLinearConstraints());
+    ctx.popScope();
+}
+
 // ============================================================================
 // TypeChecker Tests
 // ============================================================================
@@ -840,6 +884,8 @@ int main() {
     RUN_TEST(context_scope_shadowing);
     RUN_TEST(context_linear_binding);
     RUN_TEST(context_linear_constraints);
+    RUN_TEST(context_linear_scope_no_leak);
+    RUN_TEST(context_linear_scope_shadowing);
 
     std::cout << std::endl << "--- TypeChecker Tests ---" << std::endl;
     RUN_TEST(type_checker_unsafe_context);

--- a/tests/types/type_checker_test.cpp
+++ b/tests/types/type_checker_test.cpp
@@ -646,6 +646,24 @@ TEST(context_linear_scope_shadowing) {
     ctx.popScope();
 }
 
+TEST(context_linear_branch_max_not_sum) {
+    // #320 item 2: a linear variable used once in each of two mutually-exclusive
+    // branches is consumed once at runtime — charge max(then, else), not the sum.
+    // This exercises the snapshot/restore/merge helpers synthesizeIf() relies on.
+    Context ctx;
+    ctx.bindLinear("q", BuiltinTypes::Int64);
+
+    auto before = ctx.snapshotLinearUsage();      // q: 0
+    ctx.useLinear("q");                            // then-branch consumes q -> 1
+    auto after_then = ctx.snapshotLinearUsage();   // q: 1
+    ctx.restoreLinearUsage(before);                // rewind for the else branch
+    ctx.useLinear("q");                            // else-branch consumes q -> 1
+    ctx.mergeMaxLinearUsage(after_then);           // max(1, 1) = 1, NOT 2
+
+    ASSERT_TRUE(ctx.checkLinearConstraints());     // q used exactly once
+    ASSERT_TRUE(ctx.getOverusedLinear().empty());
+}
+
 // ============================================================================
 // TypeChecker Tests
 // ============================================================================
@@ -886,6 +904,7 @@ int main() {
     RUN_TEST(context_linear_constraints);
     RUN_TEST(context_linear_scope_no_leak);
     RUN_TEST(context_linear_scope_shadowing);
+    RUN_TEST(context_linear_branch_max_not_sum);
 
     std::cout << std::endl << "--- TypeChecker Tests ---" << std::endl;
     RUN_TEST(type_checker_unsafe_context);

--- a/tests/typesystem/qubit_linear_if_branches_test.esk
+++ b/tests/typesystem/qubit_linear_if_branches_test.esk
@@ -1,0 +1,15 @@
+;; Type System Test: a linear qubit used once per exclusive if-branch is valid
+;; EXPECT-MODE: strict-types
+;; EXPECT-NO-STDERR: consumed more than once
+;; EXPECT-NO-STDERR: was not consumed
+
+;; A single-qubit gate consumes a qubit and returns a fresh one. In (if b then
+;; else) the two branches are mutually exclusive, so using q exactly once in
+;; each branch consumes it exactly once at runtime — it is NOT a clone. Linear
+;; checking must charge the MAX use across the branches, not the sum (#320
+;; item 2); summing wrongly rejected this as "consumed more than once".
+(define (h (q : Qubit)) : Qubit q)
+(define (z (q : Qubit)) : Qubit q)
+
+(define (pick (b : Bool) (q : Qubit)) : Qubit
+  (if b (h q) (z q)))


### PR DESCRIPTION
## Summary

Fixes the two linearity bugs from #320 (items 1 & 2) and documents the enforcement scope honestly (item 3). These must land before the linear quantum stdlib is built on the `Qubit` type.

- **Scope leak (item 1):** `Context::linear_vars_`/`linear_usage_count_` were never torn down by `popScope()`, and one `Context` spans the whole program (`typeCheckProgram`), so a linear over/under-use in one `define` contaminated the `checkLinearConstraints()` of every later `define`/`lambda` — a false positive misattributed to an unrelated construct.
- **Branch over-restriction (item 2):** `synthesizeIf()` synthesized the then- and else-branches sequentially, so a linear variable used once in *each* branch was counted twice and rejected — even though the branches are mutually exclusive and consume it once at runtime.
- **Enforcement-scope docs (item 3):** states what "use exactly once" actually covers, so callers don't over-trust it.

## Behavior

```scheme
;; Item 1 — a violation in one define no longer contaminates the next.
(define (bad-clone (q : Qubit)) (cons q q))   ; correctly: 'q' consumed more than once
(define (good (p : Qubit)) : Qubit p)         ; BEFORE: also flagged for 'q' (leak); NOW: clean

;; Item 2 — a linear qubit used once per exclusive branch is valid.
(define (h (q : Qubit)) : Qubit q)
(define (z (q : Qubit)) : Qubit q)
(define (pick (b : Bool) (q : Qubit)) : Qubit
  (if b (h q) (z q)))                         ; BEFORE: 'q' consumed more than once; NOW: clean
```

## Changes (159 insertions)

- `inc/eshkol/types/type_checker.h` — per-scope `linear_scope_saves_` (parallel to `scopes_`) recording names bound linear in each scope; branch-exclusive helpers `snapshotLinearUsage`/`restoreLinearUsage`/`mergeMaxLinearUsage`; a doc block on the enforcement scope.
- `lib/types/type_checker.cpp` — `popScope()` removes this scope's linear tracking, **restoring a shadowed outer binding** rather than erasing it (shadowing soundness), and leaves non-shadowed outer usage intact so it still propagates up; `synthesizeIf()` snapshots usage before the branches and merges by per-variable **max**; a `NOTE` at the `let` binding site (`let` uses plain `bind`, not linear-tracked).
- `tests/types/type_checker_test.cpp` — `context_linear_scope_no_leak`, `context_linear_scope_shadowing`, `context_linear_branch_max_not_sum`.
- `tests/typesystem/qubit_linear_if_branches_test.esk` — the end-to-end `(if b (h q) (z q))` case.

`cond` desugars to nested `if` via the macro expander, so item 2 covers it too.

## Testing

```sh
bash scripts/run_typesystem_tests.sh          # qubit_linear_if_branches_test.esk
```

The C++ unit tests (`tests/types/type_checker_test.cpp`) aren't wired into CMake — I ran them by linking the file against `libeshkol-static.a`; the full 64-test type-checker suite is green. Each new test **fails without its fix and passes with it** (verified by reverting each fix in turn); e.g. without item 2 the `.esk` case reports `linear variable 'q' was consumed more than once (line 14:2)`. Verified against a full build (LLVM 21 + CUDA 13).

## Notes for review — two `#320` items I left for your call

- **4a (unify the two clone diagnostics):** there are two mechanisms with different wording *and* location — an eager per-use `"used more than once"` (`type_checker.cpp:1131`, at the use-site) and a batch `"was consumed more than once"` (`getOverusedLinear`, at the `define`). Merging them is a UX choice (which message/location wins) — your call. Happy to fold them into one if you tell me which you prefer.
- **4b (delete the dead `LinearContext`):** it's unreferenced in `lib/`/`inc/` (superseded by `Context`'s linear tracking + `BorrowChecker`) but still has ~11 unit-test references. Removing a tested class (and its tests) felt like your decision — say the word and I'll do it in a follow-up.
