### PR TITLE
fix(ad): hessian/laplacian at a VAR-bound vector point silently returned 0

### DIFF
--- a/lib/backend/autodiff_codegen.cpp
+++ b/lib/backend/autodiff_codegen.cpp
@@ -8841,10 +8841,16 @@ llvm::Value* AutodiffCodegen::hessian(const eshkol_operations_t* op) {
     // to a raw double / raw int (a pure scalar expression). Everything else that
     // is not a provable collection — VAR, general call, general op, (the …) — is
     // decided at runtime.
+    // Only a PROVABLY scalar point short-circuits the runtime dispatch: a numeric
+    // literal, or a value the callback already lowered to a raw double. An i64
+    // value is NOT provably scalar — a VAR/call/(the …) point bound to a vector
+    // evaluates to a pointer-as-int64, and hard-classifying it scalar here read
+    // that pointer as a double and returned 0 (hessian/laplacian at a VAR-bound
+    // vector point). Defer every i64/ambiguous case to the runtime tag check
+    // below, exactly as gradient() does. (#320-followup)
     bool hess_ast_scalar_lit =
         (hpoint->type == ESHKOL_INT64 || hpoint->type == ESHKOL_DOUBLE) ||
-        typed_raw_->getType()->isDoubleTy() ||
-        (typed_raw_->getType()->isIntegerTy(64) && hpoint->type != ESHKOL_TENSOR);
+        typed_raw_->getType()->isDoubleTy();
     // A statically-known MULTI-parameter loss (arity > 1) can only be
     // differentiated at a COLLECTION point — its N coordinates unpacked into N
     // scalar args — never at a scalar. Emitting the 1-arg scalar path for it

--- a/tests/autodiff/varbound_point_matrix_test.esk
+++ b/tests/autodiff/varbound_point_matrix_test.esk
@@ -100,6 +100,22 @@
 (check "hess arity2 VAR H[0][1]"  0.0 (vector-ref (vector-ref (hessian l-arity2 pv2) 0) 1))
 (check "hess arity2 #(lit) H[0][0]" 2.0 (vector-ref (vector-ref (hessian l-arity2 #(3.0 4.0)) 0) 0))
 
+;; ── arity-1 loss over a length-3 vector: hessian AND laplacian at a VAR-bound
+;;    MULTI-element point. This is the case #339's fix left uncovered for the
+;;    arity-1 Hessian: a VAR bound to a length-N vector evaluates to a
+;;    pointer-as-int64, which the AST-kind test in AutodiffCodegen::hessian
+;;    mis-classified as a provable scalar → the pointer was read as a double and
+;;    hessian/laplacian silently returned 0. laplacian = trace(Hessian) inherits
+;;    the same fix. f(v) = v0^2*v1 + v2^3 ⇒ H = diag(2*v1, 0, 6*v2), trace = 15.
+(define (l-field v) (+ (* (vector-ref v 0) (vector-ref v 0) (vector-ref v 1))
+                       (* (vector-ref v 2) (vector-ref v 2) (vector-ref v 2))))
+(define pv3 (vector 2.0 3.0 1.5))
+(check "hess field #(lit) H[0][0]"   6.0 (vector-ref (vector-ref (hessian l-field #(2.0 3.0 1.5)) 0) 0))
+(check "hess field VAR-vec H[0][0]"  6.0 (vector-ref (vector-ref (hessian l-field pv3) 0) 0))
+(check "hess field VAR-vec H[2][2]"  9.0 (vector-ref (vector-ref (hessian l-field pv3) 2) 2))
+(check "laplacian field #(lit)"     15.0 (laplacian l-field #(2.0 3.0 1.5)))
+(check "laplacian field VAR-vec"    15.0 (laplacian l-field pv3))
+
 ;; ───────────────────────────────────────────────────────────────────────────
 (newline)
 (display "varbound_point_matrix: ")


### PR DESCRIPTION
## Summary

`(hessian f p)` and `(laplacian f p)` silently returned **0** when the point `p` was a *variable* bound to a length‑N vector — while the identical point written as a `#(…)` literal gave the correct answer.

The differentiation point must be classified by its **runtime value**, never by its AST node kind (#339/#340). `gradient`/`jacobian`/`curl`/`divergence` already do this. `AutodiffCodegen::hessian` still had one AST‑kind short‑circuit: `hess_ast_scalar_lit` treated *any* i64‑valued point whose AST was not a tensor literal as a "provable scalar". A `VAR` (or general expression / `(the …)`) bound to a vector evaluates to a pointer‑as‑int64 with a non‑tensor AST, so it hit that branch — the pointer was read as a double, `f` was called with a scalar where it expected a vector, and the result was 0. `laplacian`, being `trace(Hessian)`, inherited the same silent 0.

#343 fixed the arity‑2 / length‑1 cases; this closes the remaining one — the **arity‑1 Hessian over a length‑N vector point**.

## Behavior

```scheme
(define (f v) (+ (* (vector-ref v 0) (vector-ref v 0) (vector-ref v 1))
                 (* (vector-ref v 2) (vector-ref v 2) (vector-ref v 2))))
;; H(f) = diag(2*v1, 0, 6*v2), trace = 15 at (2,3,1.5)

(hessian f #(2.0 3.0 1.5))        ; => #((6 4 0) (4 0 0) (0 0 9))   ✓ (already worked)
(define p (vector 2.0 3.0 1.5))
(hessian f p)                     ; BEFORE: 0        NOW: #((6 4 0) (4 0 0) (0 0 9))
(laplacian f p)                   ; BEFORE: 0        NOW: 15
```

## Changes (24 insertions, 2 deletions)

- `lib/backend/autodiff_codegen.cpp` — drop the i64 short‑circuit from `hess_ast_scalar_lit`. Only a numeric literal or a value the callback already lowered to a raw double is treated as provably scalar; every ambiguous i64 / `VAR` / call point now defers to the runtime tag check already present below (`hess_rt_dispatch`), exactly as `gradient()` does. A genuine scalar still routes to the scalar path via its `INT64`/`DOUBLE` tag.
- `tests/autodiff/varbound_point_matrix_test.esk` — add the arity‑1 length‑3 Hessian + Laplacian cases at a VAR‑bound point (and their `#(…)` literal controls).

## Testing

```sh
bash scripts/run_autodiff_tests.sh    # or run varbound_point_matrix_test.esk directly
```

Verified against a full build (LLVM 21). `varbound_point_matrix_test.esk` now has **38 checks, all pass** (the 5 new `hess field`/`laplacian field` cases return 0 without the fix). Regression‑checked: scalar `hessian` at a literal / VAR‑bound double / VAR‑bound int and `derivative` are unchanged (all `f''(2)=12` for `x³`), and the existing AD adversarial field suite stays green (24/24).

## Notes for review

- `directional-derivative` routes its point through `gradient` and was already correct; `jacobian`/`curl`/`divergence` classify by runtime tag and were unaffected — this was specific to the `hessian` point path (and `laplacian` via it).
