### PR TITLE
fix: repair the defects and tests exposed by honest failure detection

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -3763,12 +3763,13 @@ return the adjusted learning rate as a scalar — they do not modify any state.
 
 #### `cosine-annealing-lr`
 
-**Syntax:** `(cosine-annealing-lr step total base-lr)` → Number
+**Syntax:** `(cosine-annealing-lr base-lr min-lr step total)` → Number
 
-Cosine annealing: η_t = base-lr · 0.5 · (1 + cos(π · step / total)).
+Cosine annealing: η_t = min-lr + 0.5 · (base-lr − min-lr) · (1 + cos(π · step / total)).
 
-Smoothly decays from `base-lr` to approximately 0 over `total` steps following a cosine curve.
-The gradual decay avoids the abrupt drops of step-based schedules.
+Smoothly decays from `base-lr` to `min-lr` over `total` steps following a cosine curve
+(pass `0.0` for `min-lr` to decay to approximately 0). The gradual decay avoids the abrupt
+drops of step-based schedules.
 
 **Use case:** Standard for transformer training (BERT, GPT).
 
@@ -3776,7 +3777,7 @@ The gradual decay avoids the abrupt drops of step-based schedules.
 
 #### `step-decay-lr`
 
-**Syntax:** `(step-decay-lr step size γ base-lr)` → Number
+**Syntax:** `(step-decay-lr base-lr γ step size)` → Number
 
 Step decay: η_t = base-lr · γ^⌊step/size⌋.
 
@@ -3788,7 +3789,7 @@ Reduces the learning rate by factor γ every `size` steps. Common values: γ = 0
 
 #### `linear-warmup-lr`
 
-**Syntax:** `(linear-warmup-lr step warmup base-lr)` → Number
+**Syntax:** `(linear-warmup-lr base-lr step warmup)` → Number
 
 Linear warmup: η_t = base-lr · min(step / warmup, 1).
 
@@ -3805,7 +3806,7 @@ statistics before taking large steps.
 
 #### `exponential-decay-lr`
 
-**Syntax:** `(exponential-decay-lr step γ base-lr)` → Number
+**Syntax:** `(exponential-decay-lr base-lr γ step)` → Number
 
 Exponential decay: η_t = base-lr · γ^step.
 
@@ -3819,8 +3820,8 @@ Continuous exponential decay — more aggressive than step decay as it reduces e
 ;; Warmup for 1000 steps, then cosine decay for 9000 steps
 (define (lr-schedule step)
   (if (< step 1000)
-    (linear-warmup-lr step 1000 0.001)
-    (cosine-annealing-lr (- step 1000) 9000 0.001)))
+    (linear-warmup-lr 0.001 step 1000)
+    (cosine-annealing-lr 0.001 0.0 (- step 1000) 9000)))
 
 (lr-schedule 0)       ; => 0.0 (start of warmup)
 (lr-schedule 500)     ; => 0.0005 (mid-warmup)
@@ -4151,8 +4152,8 @@ a complete neural network training pipeline.
 
          ;; Learning rate schedule
          (lr (if (< step 1000)
-               (linear-warmup-lr step 1000 0.001)
-               (cosine-annealing-lr (- step 1000) 9000 0.001))))
+               (linear-warmup-lr 0.001 step 1000)
+               (cosine-annealing-lr 0.001 0.0 (- step 1000) 9000))))
 
     ;; Gradient clipping
     (clip-grad-norm! (car grads) 1.0)

--- a/docs/internal/ESHKOL_V1_LANGUAGE_REFERENCE.md
+++ b/docs/internal/ESHKOL_V1_LANGUAGE_REFERENCE.md
@@ -2807,7 +2807,8 @@ Eshkol supports exact rational numbers as pairs of arbitrary-precision integers.
 ```scheme
 (display (rational? 1/3))       ; => #t
 (display (rational? 42))        ; => #t  (integers are rational)
-(display (rational? 3.14))      ; => #f
+(display (rational? 3.14))      ; => #t  (R7RS: every finite real is rational)
+(display (exact-rational? 3.14)); => #f  (exact-only predicate)
 (display (exact? 1/3))          ; => #t
 (display (exact? 42))           ; => #t
 (display (inexact? 3.14))       ; => #t

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -15423,48 +15423,42 @@ private:
         // Layout: [header(-8) | numerator(i64,+0) | denominator(i64,+8)]
         // =========================================================================
         if (func_name == "rational?" || func_name == "exact-rational?") {
+            // Exact rationals: fixnum, bignum, or a heap RATIONAL. `rational?`
+            // additionally covers the *inexact* rationals, because R7RS §6.2.5
+            // requires the tower to nest — integer? ⊆ rational? ⊆ real? — and
+            // every finite flonum is a rational number (only +inf.0, -inf.0 and
+            // +nan.0 are real-but-not-rational). Excluding flonums here made the
+            // tower self-contradictory: `(integer? 3.0)` answered #t while
+            // `(rational? 3.0)` answered #f. `exact-rational?` keeps the
+            // exact-only meaning — that is what the separate name is for.
+            const bool exact_only = (func_name == "exact-rational?");
+
             TypedValue tv = codegenTypedAST(&op->call_op.variables[0]);
             if (!tv.llvm_value) return nullptr;
             Value* arg = typedValueToTaggedValue(tv);
 
-            // Rational? is true for: INT64 (integers are rational) OR HEAP_PTR+RATIONAL
-            Value* type_tag = builder->CreateExtractValue(arg, {0});
-            Value* is_int = builder->CreateICmpEQ(type_tag,
+            Value* base_type = getBaseType(getTaggedValueType(arg));
+            Value* is_int = builder->CreateICmpEQ(base_type,
                 ConstantInt::get(int8_type, ESHKOL_VALUE_INT64));
+            Value* is_bignum = isHeapSubtype(arg, HEAP_SUBTYPE_BIGNUM);
+            Value* is_ratio = isHeapSubtype(arg, HEAP_SUBTYPE_RATIONAL);
 
-            Function* current_func = builder->GetInsertBlock()->getParent();
-            BasicBlock* check_heap_bb = BasicBlock::Create(*context, "rat_check_heap", current_func);
-            BasicBlock* true_bb = BasicBlock::Create(*context, "rat_true", current_func);
-            BasicBlock* false_bb = BasicBlock::Create(*context, "rat_false", current_func);
-            BasicBlock* merge_bb = BasicBlock::Create(*context, "rat_merge", current_func);
+            Value* result = builder->CreateOr(builder->CreateOr(is_int, is_bignum), is_ratio);
 
-            builder->CreateCondBr(is_int, true_bb, check_heap_bb);
+            if (!exact_only) {
+                Value* is_double = builder->CreateICmpEQ(base_type,
+                    ConstantInt::get(int8_type, ESHKOL_VALUE_DOUBLE));
+                Value* dbl_val = unpackDoubleFromTaggedValue(arg);
+                Function* fabs_fn = ESHKOL_GET_INTRINSIC(module.get(), Intrinsic::fabs, {double_type});
+                Value* magnitude = builder->CreateCall(fabs_fn, {dbl_val});
+                // Ordered compare: false for NaN as well as for the infinities.
+                Value* is_finite = builder->CreateFCmpOLT(magnitude,
+                    ConstantFP::getInfinity(double_type));
+                result = builder->CreateOr(result,
+                    builder->CreateAnd(is_double, is_finite));
+            }
 
-            builder->SetInsertPoint(check_heap_bb);
-            Value* is_heap = builder->CreateICmpEQ(type_tag,
-                ConstantInt::get(int8_type, ESHKOL_VALUE_HEAP_PTR));
-            BasicBlock* check_sub_bb = BasicBlock::Create(*context, "rat_check_sub", current_func);
-            builder->CreateCondBr(is_heap, check_sub_bb, false_bb);
-
-            builder->SetInsertPoint(check_sub_bb);
-            Value* ptr = builder->CreateIntToPtr(
-                builder->CreateExtractValue(arg, {4}), PointerType::getUnqual(*context));
-            Value* header = builder->CreateLoad(int8_type,
-                builder->CreateGEP(int8_type, ptr, ConstantInt::get(int64_type, -8)));
-            Value* is_rational = builder->CreateICmpEQ(header,
-                ConstantInt::get(int8_type, HEAP_SUBTYPE_RATIONAL));
-            builder->CreateCondBr(is_rational, true_bb, false_bb);
-
-            builder->SetInsertPoint(true_bb);
-            builder->CreateBr(merge_bb);
-            builder->SetInsertPoint(false_bb);
-            builder->CreateBr(merge_bb);
-
-            builder->SetInsertPoint(merge_bb);
-            PHINode* phi = builder->CreatePHI(Type::getInt1Ty(*context), 2);
-            phi->addIncoming(ConstantInt::getTrue(*context), true_bb);
-            phi->addIncoming(ConstantInt::getFalse(*context), false_bb);
-            return packBoolToTaggedValue(phi);
+            return packBoolToTaggedValue(result);
         }
 
         // (numerator x) / (denominator x): route through the runtime so
@@ -34088,23 +34082,33 @@ private:
         if (!x_typed.llvm_value) return nullptr;
 
         // R7RS: complex? returns #t for any number (integer, real, complex)
-        // since the numeric tower is integer ⊂ rational ⊂ real ⊂ complex
+        // since the numeric tower is integer ⊂ rational ⊂ real ⊂ complex —
+        // and #f for everything that is not a number.
+        //
+        // HEAP_PTR is the *consolidated* pointer tag: bignums and rationals
+        // share it with strings, symbols, pairs, vectors, hash tables and every
+        // other heap object, and are told apart by the header subtype. Accepting
+        // the bare tag therefore reported `(complex? "hello")`, `(complex? 'foo)`
+        // and `(complex? '(1 2 3))` as #t. Match the numeric-subtype test that
+        // `number?` and `real?` already use.
         Value* x_tagged = typedValueToTaggedValue(x_typed);
-        Value* type_tag = builder->CreateExtractValue(x_tagged, {0}, "type");
+        Value* type_tag = getBaseType(getTaggedValueType(x_tagged));
 
-        // Check for any numeric type: INT64, DOUBLE, COMPLEX, or HEAP_PTR (bignum/rational)
         Value* is_int = builder->CreateICmpEQ(type_tag,
             ConstantInt::get(int8_type, ESHKOL_VALUE_INT64));
         Value* is_double = builder->CreateICmpEQ(type_tag,
             ConstantInt::get(int8_type, ESHKOL_VALUE_DOUBLE));
         Value* is_complex = builder->CreateICmpEQ(type_tag,
             ConstantInt::get(int8_type, ESHKOL_VALUE_COMPLEX));
-        Value* is_heap = builder->CreateICmpEQ(type_tag,
-            ConstantInt::get(int8_type, ESHKOL_VALUE_HEAP_PTR));
+        Value* is_bignum = isHeapSubtype(x_tagged, HEAP_SUBTYPE_BIGNUM);
+        Value* is_rational = isHeapSubtype(x_tagged, HEAP_SUBTYPE_RATIONAL);
+        Value* is_ad = isCallableSubtype(x_tagged, CALLABLE_SUBTYPE_AD_NODE);
 
         Value* is_numeric = builder->CreateOr(is_int, is_double);
         is_numeric = builder->CreateOr(is_numeric, is_complex);
-        is_numeric = builder->CreateOr(is_numeric, is_heap);
+        is_numeric = builder->CreateOr(is_numeric, is_bignum);
+        is_numeric = builder->CreateOr(is_numeric, is_rational);
+        is_numeric = builder->CreateOr(is_numeric, is_ad);
 
         return packBoolToTaggedValue(is_numeric);
     }

--- a/lib/backend/tensor_codegen.cpp
+++ b/lib/backend/tensor_codegen.cpp
@@ -487,10 +487,17 @@ llvm::Value* TensorCodegen::tensorGet(const eshkol_operations_t* op) {
     // funneled it through `eshkol_unwrap_list_index`, which returns
     // only the *car* — collapsing every (0 _ _) read on a 3D tensor
     // to flat[0]. Fix: in the 1-arg case, route through
-    // `eshkol_tensor_linear_from_index_arg` to compute the full
+    // `eshkol_tensor_slice_offset_from_index_arg` to compute the full
     // row-major offset, and use `eshkol_tensor_index_arg_count` to
     // decide scalar-vs-slice the same way the multi-arg path does.
     // The multi-arg path keeps the original per-arg unwrap.
+    //
+    // That helper — rather than `eshkol_tensor_linear_from_index_arg` — because
+    // a *bare scalar* index here is also a partial index and must be scaled by
+    // the remaining dimensions: `(tensor-get M 1)` on a 2x3 is row 1, exactly
+    // like `(tensor-get M (list 1))`. The shared helper leaves a scalar
+    // unscaled (that is `tensor-ref`'s flat-index contract), which made the two
+    // spellings disagree and let an index past dims[0] slice past the end.
     llvm::Function* unwrap_fn = ctx_.module().getFunction("eshkol_unwrap_list_index");
     if (!unwrap_fn) {
         llvm::FunctionType* ft = llvm::FunctionType::get(
@@ -505,14 +512,14 @@ llvm::Value* TensorCodegen::tensorGet(const eshkol_operations_t* op) {
     llvm::Value* runtime_index_count = nullptr;
 
     if (num_indices == 1) {
-        llvm::Function* lin_fn = ctx_.module().getFunction("eshkol_tensor_linear_from_index_arg");
+        llvm::Function* lin_fn = ctx_.module().getFunction("eshkol_tensor_slice_offset_from_index_arg");
         if (!lin_fn) {
             llvm::FunctionType* ft = llvm::FunctionType::get(
                 ctx_.int64Type(),
                 {ctx_.ptrType(), ctx_.ptrType(), ctx_.int64Type()}, false);
             lin_fn = llvm::Function::Create(
                 ft, llvm::Function::ExternalLinkage,
-                "eshkol_tensor_linear_from_index_arg", &ctx_.module());
+                "eshkol_tensor_slice_offset_from_index_arg", &ctx_.module());
         }
         llvm::Function* count_fn = ctx_.module().getFunction("eshkol_tensor_index_arg_count");
         if (!count_fn) {

--- a/lib/core/runtime_tensor_index.cpp
+++ b/lib/core/runtime_tensor_index.cpp
@@ -155,6 +155,61 @@ int64_t eshkol_tensor_linear_from_index_arg(
 }
 
 /**
+ * @brief Row-major offset for a `tensor-get` index argument, treating a bare
+ *        scalar as a partial (one-dimension) index.
+ *
+ * `tensor-get` is the dimension-aware accessor: partial indexing returns a
+ * sub-tensor view. Both spellings of a partial index must therefore agree —
+ * on a 2x3 tensor `M`, `(tensor-get M 1)` and `(tensor-get M (list 1))` are
+ * the same access and both are documented to yield row 1
+ * (docs/API_REFERENCE.md "tensor-get", docs/breakdown/VECTOR_OPERATIONS.md).
+ *
+ * eshkol_tensor_linear_from_index_arg() cannot be used for this: its bare-scalar
+ * case deliberately returns the index unscaled, because `tensor-ref`/`vref`
+ * define a single scalar index as a *flat* index (`(tensor-ref M 1)` => 2 on
+ * that same tensor) and route through it via eshkol_vref_unwrap_index().
+ * Sharing one helper made the two `tensor-get` spellings disagree: the scalar
+ * form returned a slice starting at flat[i] instead of flat[i * stride0], so
+ * `(tensor-get M 1)` came back as `#(2 3 4)` — and, for `i` past dims[0], read
+ * beyond the tensor.
+ *
+ * A cons index list already carries the partial-index scaling, so it is
+ * delegated unchanged; a bare scalar indexes dimension 0 and is scaled by the
+ * product of the remaining (unindexed) dimensions. For a 1-D tensor the two
+ * are identical (there is nothing left to scale by).
+ *
+ * @param tv_in Tagged index argument: a cons list of per-dimension indices,
+ *              or a bare scalar index selecting along dimension 0.
+ * @param dims  Array of @p ndim dimension sizes (row-major, outermost first).
+ * @param ndim  Number of dimensions in @p dims.
+ * @return      Linear (flat) row-major offset of the addressed element or
+ *              sub-block, or 0 if @p tv_in is NULL.
+ */
+int64_t eshkol_tensor_slice_offset_from_index_arg(
+    const eshkol_tagged_value_t* tv_in,
+    const int64_t* dims,
+    int64_t ndim) {
+    if (!tv_in) return 0;
+
+    const eshkol_tagged_value_t tv = *tv_in;
+    const uint8_t base_type = eshkol_base_type(tv.type);
+    if (base_type == ESHKOL_VALUE_HEAP_PTR && tv.data.ptr_val != 0) {
+        const eshkol_object_header_t* header =
+            ESHKOL_GET_HEADER((void*)tv.data.ptr_val);
+        if (header->subtype == HEAP_SUBTYPE_CONS) {
+            return eshkol_tensor_linear_from_index_arg(tv_in, dims, ndim);
+        }
+    }
+
+    int64_t linear = tagged_to_int64(tv);
+    if (!dims || ndim <= 1) return linear;
+    for (int64_t k = 1; k < ndim; k++) {
+        linear *= dims[k];
+    }
+    return linear;
+}
+
+/**
  * @brief Compute the index to use for a `(vector-ref v idx)`-style access, tensor-aware.
  *
  * If @p vec_tv_in is a HEAP_PTR to an object whose header reports

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -256,6 +256,8 @@ extern "C" {
     int64_t eshkol_unwrap_list_index(const eshkol_tagged_value_t* tv);
     int64_t eshkol_tensor_linear_from_index_arg(const eshkol_tagged_value_t* tv,
                                                 const int64_t* dims, int64_t ndim);
+    int64_t eshkol_tensor_slice_offset_from_index_arg(const eshkol_tagged_value_t* tv,
+                                                     const int64_t* dims, int64_t ndim);
     int64_t eshkol_tensor_index_arg_count(const eshkol_tagged_value_t* tv);
     int64_t eshkol_vref_unwrap_index(const eshkol_tagged_value_t* vec_tv,
                                      const eshkol_tagged_value_t* idx_tv);
@@ -1485,6 +1487,7 @@ void ReplJITContext::registerRuntimeSymbols() {
     ADD_SYMBOL(eshkol_utf8_substring);
     ADD_SYMBOL(eshkol_unwrap_list_index);
     ADD_SYMBOL(eshkol_tensor_linear_from_index_arg);
+    ADD_SYMBOL(eshkol_tensor_slice_offset_from_index_arg);
     ADD_SYMBOL(eshkol_tensor_index_arg_count);
     ADD_SYMBOL(eshkol_vref_unwrap_index);
     ADD_SYMBOL(eshkol_tensor_rect_fill);

--- a/tests/features/extreme_stress_test.esk
+++ b/tests/features/extreme_stress_test.esk
@@ -348,13 +348,16 @@
 (check "Trampoline even(1000)" #t (local-trampoline (lambda () (t-even 1000))))
 (check "Trampoline odd(999)" #t (local-trampoline (lambda () (t-odd 999))))
 
-;; Trampolined sum for stress test
-(define (t-sum n acc)
+;; Trampolined sum for stress test.
+;; Named t-trampoline-sum, not t-sum: Section 7 already binds `t-sum` to a
+;; tensor, and this file's two uses of the name are unrelated.
+(define (t-trampoline-sum n acc)
   (if (= n 0)
       acc
-      (lambda () (t-sum (- n 1) (+ acc n)))))
+      (lambda () (t-trampoline-sum (- n 1) (+ acc n)))))
 
-(check "Trampoline sum(500)" 125250 (local-trampoline (lambda () (t-sum 500 0))))
+(check "Trampoline sum(500)" 125250
+       (local-trampoline (lambda () (t-trampoline-sum 500 0))))
 
 ;; =============================================================================
 ;; SECTION 11: FUNCTION COMPOSITION CHAINS

--- a/tests/features/quantum_random_test.esk
+++ b/tests/features/quantum_random_test.esk
@@ -1,5 +1,18 @@
 ;; Quantum Random Number Generation Test Suite
 ;; Tests: quantum-random, quantum-random-int, quantum-random-range
+;;
+;; Documented contracts (docs/reference/agent/quantum.md):
+;;   (quantum-random)              -> double in [0, 1)
+;;   (quantum-random-int bound)    -> integer in [0, bound)
+;;   (quantum-random-range min max) -> integer in [min, max], INCLUSIVE
+;;
+;; The range cases used to assert a half-open floating-point interval
+;; (>= min and < max) against that inclusive integer range, so they failed
+;; whenever the draw landed on `max` — 1 run in 6 for a 6-wide range, and one
+;; run in 2 for (quantum-random-range 0.0 1.0), which can only return 0 or 1.
+;; That was the whole of this file's intermittency; the generator itself is
+;; sound. They now assert the documented contract: an integer, inclusive of
+;; both endpoints.
 
 (display "TEST: quantum random number generation") (newline)
 
@@ -35,16 +48,16 @@
 (display ": (quantum-random-int 1) should always be 0")
 (newline)
 
-;; --- Test 6: quantum-random-range in [5.0, 10.0) ---
-(define r6 (quantum-random-range 5.0 10.0))
-(display (if (and (>= r6 5.0) (< r6 10.0)) "PASS" "FAIL"))
-(display ": (quantum-random-range 5.0 10.0) should be >= 5.0 and < 10.0")
+;; --- Test 6: quantum-random-range in [5, 10] (inclusive) ---
+(define r6 (quantum-random-range 5 10))
+(display (if (and (integer? r6) (>= r6 5) (<= r6 10)) "PASS" "FAIL"))
+(display ": (quantum-random-range 5 10) should be an integer in [5, 10]")
 (newline)
 
-;; --- Test 7: quantum-random-range in [0.0, 1.0) ---
-(define r7 (quantum-random-range 0.0 1.0))
-(display (if (and (>= r7 0.0) (< r7 1.0)) "PASS" "FAIL"))
-(display ": (quantum-random-range 0.0 1.0) should be >= 0.0 and < 1.0")
+;; --- Test 7: quantum-random-range in [0, 1] (inclusive) ---
+(define r7 (quantum-random-range 0 1))
+(display (if (and (integer? r7) (or (= r7 0) (= r7 1))) "PASS" "FAIL"))
+(display ": (quantum-random-range 0 1) should be 0 or 1")
 (newline)
 
 ;; --- Test 8: two calls to quantum-random should (almost certainly) differ ---
@@ -61,7 +74,13 @@
 (newline)
 
 ;; --- Test 10: quantum-random-range with negative bounds ---
-(define r10 (quantum-random-range -10.0 -5.0))
-(display (if (and (>= r10 -10.0) (< r10 -5.0)) "PASS" "FAIL"))
-(display ": (quantum-random-range -10.0 -5.0) should be >= -10.0 and < -5.0")
+(define r10 (quantum-random-range -10 -5))
+(display (if (and (integer? r10) (>= r10 -10) (<= r10 -5)) "PASS" "FAIL"))
+(display ": (quantum-random-range -10 -5) should be an integer in [-10, -5]")
+(newline)
+
+;; --- Test 11: quantum-random-range with min = max is that value ---
+(define r11 (quantum-random-range 7 7))
+(display (if (= r11 7) "PASS" "FAIL"))
+(display ": (quantum-random-range 7 7) should be 7")
 (newline)

--- a/tests/ml/conv_test.esk
+++ b/tests/ml/conv_test.esk
@@ -58,6 +58,8 @@
     (newline))
 
   ;; Test Batch Norm
+  ;; (batch-norm input γ β ε [axis]) — 4 or 5 arguments; γ (scale), β (shift)
+  ;; and ε are required (docs/API_REFERENCE.md, tensor_conv_codegen.cpp).
   (display "-- Testing Batch Norm --")
   (newline)
   (let* ((input (reshape #(1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0) 2 4)))
@@ -65,10 +67,11 @@
     (display input)
     (newline)
     (display "batch-norm result: ")
-    (display (batch-norm input))
+    (display (batch-norm input 1.0 0.0 0.00001))
     (newline))
 
   ;; Test Layer Norm
+  ;; (layer-norm input γ β ε [axis]) — same required arguments as batch-norm.
   (display "-- Testing Layer Norm --")
   (newline)
   (let* ((input (reshape #(1.0 2.0 3.0 4.0) 1 4)))
@@ -76,7 +79,7 @@
     (display input)
     (newline)
     (display "layer-norm result: ")
-    (display (layer-norm input))
+    (display (layer-norm input 1.0 0.0 0.00001))
     (newline))
 
   (display "=== Convolution & Pooling Tests Complete ===")

--- a/tests/ml/lr_scheduler_test.esk
+++ b/tests/ml/lr_scheduler_test.esk
@@ -1,5 +1,19 @@
 ;;; Learning Rate Scheduler Test Suite
 ;;; Tests for linear-warmup-lr, step-decay-lr, exponential-decay-lr, cosine-annealing-lr
+;;;
+;;; Argument order matches the shipped builtins (lib/backend/tensor_training_codegen.cpp,
+;;; documented in docs/API_REFERENCE.md and docs/breakdown/MACHINE_LEARNING.md) —
+;;; every scheduler takes base-lr FIRST:
+;;;
+;;;   (linear-warmup-lr      base-lr step warmup)
+;;;   (step-decay-lr         base-lr gamma epoch step-size)
+;;;   (exponential-decay-lr  base-lr gamma epoch)
+;;;   (cosine-annealing-lr   base-lr min-lr step total)
+;;;
+;;; This file previously called them step-first (and cosine-annealing-lr with 3
+;;; arguments), so eleven of the twelve cases were passing the learning rate in
+;;; as a step counter and the three cosine cases did not even satisfy the
+;;; builtin's arity. The expected values below are unchanged; only the calls are.
 
 (require stdlib)
 
@@ -13,7 +27,7 @@
 ;; Test 1: Linear warmup at step 0 returns 0.0
 ;; ============================================================
 (display "TEST: linear-warmup-lr at step 0") (newline)
-(let ((lr (linear-warmup-lr 0 100 0.01)))
+(let ((lr (linear-warmup-lr 0.01 0 100)))
   (display (if (approx= lr 0.0 0.0001)
                "PASS" "FAIL"))
   (display ": linear-warmup-lr returns 0.0 at step 0") (newline))
@@ -22,7 +36,7 @@
 ;; Test 2: Linear warmup halfway returns half of base-lr
 ;; ============================================================
 (display "TEST: linear-warmup-lr at halfway") (newline)
-(let ((lr (linear-warmup-lr 50 100 0.01)))
+(let ((lr (linear-warmup-lr 0.01 50 100)))
   (display (if (approx= lr 0.005 0.0001)
                "PASS" "FAIL"))
   (display ": linear-warmup-lr returns 0.005 at step 50/100") (newline))
@@ -31,7 +45,7 @@
 ;; Test 3: Linear warmup at final step returns full base-lr
 ;; ============================================================
 (display "TEST: linear-warmup-lr at full warmup") (newline)
-(let ((lr (linear-warmup-lr 100 100 0.01)))
+(let ((lr (linear-warmup-lr 0.01 100 100)))
   (display (if (approx= lr 0.01 0.0001)
                "PASS" "FAIL"))
   (display ": linear-warmup-lr returns base-lr at warmup-steps") (newline))
@@ -40,7 +54,7 @@
 ;; Test 4: Step decay at step 0 returns base-lr (no decay yet)
 ;; ============================================================
 (display "TEST: step-decay-lr at step 0") (newline)
-(let ((lr (step-decay-lr 0 10 0.1 0.01)))
+(let ((lr (step-decay-lr 0.01 0.1 0 10)))
   (display (if (approx= lr 0.01 0.0001)
                "PASS" "FAIL"))
   (display ": step-decay-lr returns base-lr at step 0") (newline))
@@ -50,7 +64,7 @@
 ;; base-lr * gamma^(floor(10/10)) = 0.01 * 0.1 = 0.001
 ;; ============================================================
 (display "TEST: step-decay-lr after one period") (newline)
-(let ((lr (step-decay-lr 10 10 0.1 0.01)))
+(let ((lr (step-decay-lr 0.01 0.1 10 10)))
   (display (if (approx= lr 0.001 0.0001)
                "PASS" "FAIL"))
   (display ": step-decay-lr decays by gamma after step-size steps") (newline))
@@ -60,7 +74,7 @@
 ;; base-lr * gamma^(floor(20/10)) = 0.01 * 0.1^2 = 0.0001
 ;; ============================================================
 (display "TEST: step-decay-lr after two periods") (newline)
-(let ((lr (step-decay-lr 20 10 0.1 0.01)))
+(let ((lr (step-decay-lr 0.01 0.1 20 10)))
   (display (if (approx= lr 0.0001 0.0001)
                "PASS" "FAIL"))
   (display ": step-decay-lr decays by gamma^2 after 2 periods") (newline))
@@ -70,7 +84,7 @@
 ;; base-lr * gamma^0 = 0.01 * 1 = 0.01
 ;; ============================================================
 (display "TEST: exponential-decay-lr at step 0") (newline)
-(let ((lr (exponential-decay-lr 0 0.9 0.01)))
+(let ((lr (exponential-decay-lr 0.01 0.9 0)))
   (display (if (approx= lr 0.01 0.0001)
                "PASS" "FAIL"))
   (display ": exponential-decay-lr returns base-lr at step 0") (newline))
@@ -80,7 +94,7 @@
 ;; base-lr * gamma^1 = 0.01 * 0.9 = 0.009
 ;; ============================================================
 (display "TEST: exponential-decay-lr at step 1") (newline)
-(let ((lr (exponential-decay-lr 1 0.9 0.01)))
+(let ((lr (exponential-decay-lr 0.01 0.9 1)))
   (display (if (approx= lr 0.009 0.0001)
                "PASS" "FAIL"))
   (display ": exponential-decay-lr applies gamma once at step 1") (newline))
@@ -90,39 +104,49 @@
 ;; base-lr * gamma^10 = 0.01 * 0.9^10 = 0.01 * 0.3486784401 ~ 0.003487
 ;; ============================================================
 (display "TEST: exponential-decay-lr at step 10") (newline)
-(let ((lr (exponential-decay-lr 10 0.9 0.01)))
+(let ((lr (exponential-decay-lr 0.01 0.9 10)))
   (display (if (approx= lr 0.003487 0.0001)
                "PASS" "FAIL"))
   (display ": exponential-decay-lr at step 10 matches gamma^10") (newline))
 
 ;; ============================================================
 ;; Test 10: Cosine annealing at step 0 returns full base-lr
-;; lr = base-lr * 0.5 * (1 + cos(0 * pi / total)) = base-lr
+;; min-lr = 0, so lr = 0.5 * base-lr * (1 + cos(0 * pi / total)) = base-lr
 ;; ============================================================
 (display "TEST: cosine-annealing-lr at step 0") (newline)
-(let ((lr (cosine-annealing-lr 0 100 0.01)))
+(let ((lr (cosine-annealing-lr 0.01 0.0 0 100)))
   (display (if (approx= lr 0.01 0.0001)
                "PASS" "FAIL"))
   (display ": cosine-annealing-lr returns base-lr at step 0") (newline))
 
 ;; ============================================================
 ;; Test 11: Cosine annealing at halfway returns ~half base-lr
-;; lr = base-lr * 0.5 * (1 + cos(50 * pi / 100)) = 0.01 * 0.5 * (1 + 0) = 0.005
+;; lr = 0.5 * base-lr * (1 + cos(50 * pi / 100)) = 0.01 * 0.5 * (1 + 0) = 0.005
 ;; ============================================================
 (display "TEST: cosine-annealing-lr at halfway") (newline)
-(let ((lr (cosine-annealing-lr 50 100 0.01)))
+(let ((lr (cosine-annealing-lr 0.01 0.0 50 100)))
   (display (if (approx= lr 0.005 0.0001)
                "PASS" "FAIL"))
   (display ": cosine-annealing-lr returns ~0.005 at halfway") (newline))
 
 ;; ============================================================
 ;; Test 12: Cosine annealing at final step decays to ~0
-;; lr = base-lr * 0.5 * (1 + cos(pi)) = 0.01 * 0.5 * (1 - 1) = 0.0
+;; lr = 0.5 * base-lr * (1 + cos(pi)) = 0.01 * 0.5 * (1 - 1) = 0.0
 ;; ============================================================
 (display "TEST: cosine-annealing-lr at end") (newline)
-(let ((lr (cosine-annealing-lr 100 100 0.01)))
+(let ((lr (cosine-annealing-lr 0.01 0.0 100 100)))
   (display (if (approx= lr 0.0 0.0001)
                "PASS" "FAIL"))
   (display ": cosine-annealing-lr decays to ~0 at total-steps") (newline))
+
+;; ============================================================
+;; Test 13: Cosine annealing honours a non-zero floor (min-lr)
+;; lr = min-lr + 0.5 * (base-lr - min-lr) * (1 + cos(pi)) = min-lr
+;; ============================================================
+(display "TEST: cosine-annealing-lr floor at end") (newline)
+(let ((lr (cosine-annealing-lr 0.01 0.001 100 100)))
+  (display (if (approx= lr 0.001 0.0001)
+               "PASS" "FAIL"))
+  (display ": cosine-annealing-lr decays to min-lr at total-steps") (newline))
 
 (display "=== LEARNING RATE SCHEDULER TESTS COMPLETE ===") (newline)

--- a/tests/numeric/rational_edge_test.esk
+++ b/tests/numeric/rational_edge_test.esk
@@ -45,9 +45,16 @@
 (display (if (exact? 3/7) "PASS" "FAIL")) (display ": 3/7 is exact") (newline)
 
 ; 10. rational? predicate
+;    R7RS 6.2.5: the tower nests (integer? ⊆ rational? ⊆ real?), and every
+;    FINITE real is a rational number — so an inexact 1.5 is rational, while
+;    the infinities and NaN are not. `exact-rational?` is the exact-only
+;    predicate; that distinction is what separates the two names.
 (display (if (rational? 1/2) "PASS" "FAIL")) (display ": rational? on 1/2") (newline)
 (display (if (rational? 3) "PASS" "FAIL")) (display ": rational? on integer 3") (newline)
-(display (if (not (rational? 1.5)) "PASS" "FAIL")) (display ": rational? on 1.5 is false") (newline)
+(display (if (rational? 1.5) "PASS" "FAIL")) (display ": rational? on inexact 1.5 is true") (newline)
+(display (if (not (exact-rational? 1.5)) "PASS" "FAIL")) (display ": exact-rational? on 1.5 is false") (newline)
+(display (if (exact-rational? 1/2) "PASS" "FAIL")) (display ": exact-rational? on 1/2 is true") (newline)
+(display (if (rational? 3.0) "PASS" "FAIL")) (display ": rational? agrees with integer? on 3.0") (newline)
 
 ; 11. numerator/denominator accessors
 (display (if (= (numerator 3/7) 3) "PASS" "FAIL")) (display ": numerator of 3/7 is 3") (newline)

--- a/tests/parser/sexpr_test.esk
+++ b/tests/parser/sexpr_test.esk
@@ -107,10 +107,31 @@
 (test-case "vector? true" #t (vector? vec1))
 (test-case "vector? list" #f (vector? '(1 2 3)))
 
-;; Nested vectors
-(define vec2 #(#(1 2) #(3 4)))
+;; Nested vectors.
+;;
+;; NOTE: `#(#(1 2) #(3 4))` is NOT a vector of vectors in Eshkol — the reader
+;; treats a nested `#(...)` literal as 2-D *tensor* syntax and builds a 2x2
+;; tensor (lib/frontend/parser.cpp: "Handles recursive nesting: #(#(1 2) #(3 4))
+;; → 2D tensor [2,2]"). That literal form is relied on by docs, examples and the
+;; VM-parity corpus (e.g. `(matmul #(#(1 2) #(3 4)) #(#(5 6) #(7 8)))`), and the
+;; printer keeps the two apart: a rank-2 tensor prints as `#((1 2) (3 4))`,
+;; a real vector of vectors as `#(#(1 2) #(3 4))`.
+;;
+;; So build the R7RS vector-of-vectors with `vector`, and pin the tensor-literal
+;; reading separately rather than conflating them.
+(define vec2 (vector (vector 1 2) (vector 3 4)))
 (test-case "nested vector length" 2 (vector-length vec2))
-(test-case "nested vector-ref" #(1 2) (vector-ref vec2 0))
+(test-case "nested vector-ref" (vector 1 2) (vector-ref vec2 0))
+(test-case "nested vector-ref 1" (vector 3 4) (vector-ref vec2 1))
+
+;; Nested `#(...)` literal: a 2-D tensor. Pin the rank/extent and the row
+;; reads, which are what the literal syntax means. Deliberately NOT pinning
+;; `vector-length` of a rank-2 literal here — that observable belongs to the
+;; tensor-literal generality work, not to this parser test.
+(define tensor2x2 #(#(1 2) #(3 4)))
+(test-case "nested literal is a 2x2 tensor" (list 2 2) (tensor-shape tensor2x2))
+(test-case "nested literal row 0" #(1 2) (tensor-get tensor2x2 0))
+(test-case "nested literal row 1" #(3 4) (tensor-get tensor2x2 1))
 
 ;; ============================================================================
 ;; Test: Quoted Expressions

--- a/tests/rational/rational_arithmetic_test.esk
+++ b/tests/rational/rational_arithmetic_test.esk
@@ -64,6 +64,11 @@
 
 (display (rational? 3.14))
 (newline)
+; Expected: #t (R7RS: every finite real is rational; use exact-rational? for
+;                the exact-only test)
+
+(display (exact-rational? 3.14))
+(newline)
 ; Expected: #f
 
 ; Numerator/denominator access


### PR DESCRIPTION
Honest failure detection (#367) made several long-standing failures visible. Each is triaged here as a product defect or a wrong test, and fixed on that side. Two cases are deliberately left red and reported rather than papered over.

## Per-case verdicts

| File | Case | Expected | Observed | Side | Fix |
|---|---|---|---|---|---|
| `ml/lr_scheduler_test` | 10 of 12 scheduler cases | e.g. 0.005 at step 50/100 | learning rate passed in as a step counter; cosine called with 3 of 4 args | test (+ doc) | calls corrected to the shipped `base-lr`-first API; `API_REFERENCE.md` order corrected |
| `types/type_predicate_matrix` | `complex?` on string / symbol / list | `#f` | `#t` | **product** | `complex?` accepted the bare consolidated `HEAP_PTR` tag; now uses the numeric header-subtype test `number?`/`real?` use |
| `types/type_predicate_matrix` | `rational?` on `3.14` | `#t` | `#f` | **product** | tower did not nest (`(integer? 3.0)`=#t vs `(rational? 3.0)`=#f); `rational?` now covers finite flonums, `exact-rational?` stays exact-only |
| `parser/sexpr_test` | nested vector length | 2 | 4 | test | `#(#(1 2) #(3 4))` is Eshkol's 2-D tensor literal; the R7RS vector-of-vectors case now builds with `vector`. Parser flattening untouched |
| `features/ultimate_math_stress` | `H[1,1]` | 12 | 2 | **product** | `tensor-get`'s scalar partial index sliced from `flat[i]` instead of `flat[i*stride0]` |
| `features/extreme_stress` | trampoline `sum(500)` | 125250 | a tensor | test | `t-sum` was bound twice in one file; trampoline function renamed |
| `features/extreme_stress` | `d²/dx²(x⁴)` at 2 | ~48 | 0 | **product, left red** | see below |
| `features/quantum_random` | 3 range cases, intermittent | in range | draw equal to `max` | test | `quantum-random-range` is documented inclusive-integer; assertions now match. 60 consecutive runs clean |
| `ml/conv_test` | `batch-norm` / `layer-norm` | — | called with 1 of 4 required args | test | pass gamma, beta, epsilon |

## Product fixes

**`tensor-get` partial-index offset.** `(tensor-get M 1)` on a 2x3 is documented to be row 1, and `(tensor-get M (list 1))` already was. The scalar spelling reused `eshkol_tensor_linear_from_index_arg`, whose bare-scalar case must stay unscaled because `tensor-ref`/`vref` define a single index as a *flat* index. The two spellings of one access therefore disagreed, and an index past `dims[0]` sliced past the end of the tensor. `tensor-get` now uses a dedicated `eshkol_tensor_slice_offset_from_index_arg`; `tensor-ref` and `tensor-set!` are untouched.

**`complex?`** answered `#t` for strings, symbols and pairs — it accepted the consolidated pointer tag that bignums and rationals share with every other heap object.

**`rational?`** answered `#f` for every flonum, making the tower self-contradictory. R7RS 6.2.5 requires `integer?` ⊆ `rational?` ⊆ `real?`, and every finite real is rational; `EXACT_ARITHMETIC.md` claims full 6.2.5 conformance. `exact-rational?` keeps the exact-only meaning. Two tests and one reference example that had encoded the old answer are corrected with the rule cited.

## Left red on purpose

- `(derivative (derivative f))` through a variable-bound derivative closure raises `Failed to resolve function for higher-order derivative` at compile time and then **silently returns 0**. The maths is not the problem: `(derivative-n f 2.0 2)` and `(derivative (lambda (x) (derivative f4 x)) 2.0)` both return exactly 48. Only the curried spelling fails to resolve, in `autodiff_codegen.cpp` (`derivativeHigherOrder`), which is under active change on another branch.
- A top-level `define` that rebinds a name from a value to a procedure is not honoured as R7RS 5.3.1 requires (`(define g 42)` then `(define (g x) …)` leaves the call site on the stale binding).

## Verification

- `ctest` 96/96.
- `run_ml_tests` 43/43, `run_parser_tests` 31/31, `run_types_tests` 13/13, `run_numeric_tests` 11/11, `run_rational_tests` 3/3, `run_numeric_depth` all sweeps PASS.
- `run_features_tests` 35/36 — the one remaining failure is `extreme_stress_test`, on the higher-order-derivative case above.
- Suites verified both standalone and with #367's detection merged locally; no expectation was weakened.