### PR TITLE
fix(codegen): emit a single !dbg attachment per declaration so -g builds compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3085,6 +3085,29 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
                 FAIL_REGULAR_EXPRESSION "FAIL:")
     endif()
     if(NOT WIN32 AND
+       EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/debug_info_emission_test.sh")
+        # `-g` builds must actually build. Every top-level define used to be
+        # handed a definition DISubprogram at declaration time, so the bodyless
+        # `:external` stdlib defines (@caadr, @cadar, @caddr, @cddr, ...) failed
+        # LLVM's "function declaration may only have a unique !dbg attachment"
+        # check and no output was ever produced. Asserts on artifacts and
+        # behaviour -- compiles, links, runs correctly at every -O level, and the
+        # emitted DWARF names user functions and carries source line rows -- so a
+        # compiler that stops producing output cannot pass.
+        add_test(
+            NAME debug_info_emission_test
+            COMMAND bash
+                    "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/debug_info_emission_test.sh"
+                    $<TARGET_FILE:eshkol-run>
+                    "${CMAKE_CURRENT_BINARY_DIR}"
+        )
+        set_tests_properties(debug_info_emission_test
+            PROPERTIES
+                TIMEOUT 900
+                PASS_REGULAR_EXPRESSION "PASS: debug_info_emission_test"
+                FAIL_REGULAR_EXPRESSION "FAIL:")
+    endif()
+    if(NOT WIN32 AND
        EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/runtime_archive_resolution_test.sh")
         # RC B3: a compiler must link its OWN runtime. The archive co-located
         # with the running eshkol-run (resolved through its real path) beats one

--- a/lib/backend/arithmetic_codegen.cpp
+++ b/lib/backend/arithmetic_codegen.cpp
@@ -166,14 +166,27 @@ llvm::Function* ArithmeticCodegen::getOrEmitBinaryOutline(
     llvm::BasicBlock* saved_block = ctx_.builder().GetInsertBlock();
     llvm::BasicBlock::iterator saved_pt;
     if (saved_block) saved_pt = ctx_.builder().GetInsertPoint();
+    // DWARF DEBUG INFO: the current debug location belongs to the caller, and
+    // `fn` is a different function with no DISubprogram of its own -- emitting
+    // the helper body under the caller's location both mis-scopes every
+    // instruction in `fn` and, because the entry-block alloca hoists inside
+    // emitBody reset the shared builder's location via
+    // SetInsertPoint(BB, BB->begin()), leaves the caller with *no* location
+    // afterwards. That produced "inlinable function call in a function with
+    // debug info must have a !dbg location" on the first user call emitted
+    // after any arithmetic operation. Save it, clear it for the helper, restore
+    // it with the insertion point.
+    llvm::DebugLoc saved_loc = ctx_.builder().getCurrentDebugLocation();
 
     llvm::BasicBlock* entry = llvm::BasicBlock::Create(ctx_.context(), "entry", fn);
     ctx_.builder().SetInsertPoint(entry);
+    ctx_.builder().SetCurrentDebugLocation(llvm::DebugLoc());
     llvm::Value* result = emitBody(fn->getArg(0), fn->getArg(1));
     ctx_.builder().CreateRet(result);
 
     // Restore the caller's insertion point.
     if (saved_block) ctx_.builder().SetInsertPoint(saved_block, saved_pt);
+    ctx_.builder().SetCurrentDebugLocation(saved_loc);
 
     return fn;
 }

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -364,6 +364,91 @@ static void coerceIntegerBinaryOperandTypes(llvm::Module& module) {
     }
 }
 
+/* DWARF DEBUG INFO: enforce LLVM's function-level debug-location invariants as
+ * the last step before module verification.
+ *
+ * A debug location is only meaningful inside the function whose DISubprogram
+ * scopes it, and LLVM enforces that:
+ *
+ *   "!dbg attachment points at wrong subprogram for function"
+ *   "inlinable function call in a function with debug info must have a !dbg
+ *    location"
+ *
+ * Both failures come from one property of the backend: the current debug
+ * location lives on a single shared IRBuilder whose insertion point is moved
+ * across function boundaries by dozens of call sites -- entry-block alloca
+ * hoists, out-of-line arithmetic helpers, lambda and nested-function bodies, AD
+ * and tensor thunks. IRBuilderBase::SetInsertPoint(BB, IP) *overwrites* the
+ * current location as a side effect when IP != BB->end() and leaves it alone
+ * when IP == BB->end(), so a location can both leak into a function it does not
+ * describe and silently go missing on the way back out. Restoring an insertion
+ * point is not enough; the location has to be restored with it, at every one of
+ * those sites.
+ *
+ * Codegen anchors locations at the boundaries it owns -- see
+ * anchorDebugLocation, which is what makes the emitted line attribution
+ * accurate. This pass is the invariant behind that: like
+ * coerceCallArgIntegerTypes above, centralising here is the fix that does not
+ * require every insertion-point helper in the backend to be individually
+ * correct for -g builds to verify.
+ *
+ *   * function with no subprogram -> its instructions carry no debug location,
+ *     rather than one scoped to whichever function was emitted around it;
+ *   * function with a subprogram  -> every instruction's location is scoped to
+ *     that subprogram. A wrong-scope location keeps its line and column (the
+ *     line was real, only the scope was inherited); a missing one inherits the
+ *     nearest preceding valid location, so line tables degrade gracefully
+ *     instead of collapsing onto the function's opening line.
+ */
+static void normalizeDebugLocations(llvm::Module& module, llvm::LLVMContext& ctx) {
+    using namespace llvm;
+
+    auto scopedToSubprogram = [](const DebugLoc& dl, DISubprogram* sp) -> bool {
+        if (!dl) return false;
+        auto* local = dyn_cast_or_null<DILocalScope>(dl->getScope());
+        if (!local || local->getSubprogram() != sp) return false;
+        if (dl.getInlinedAt() && dl->getInlinedAtScope()->getSubprogram() != sp) {
+            return false;
+        }
+        return true;
+    };
+
+    for (Function& F : module) {
+        if (F.isDeclaration()) continue;
+
+        DISubprogram* sp = F.getSubprogram();
+        if (!sp) {
+            for (BasicBlock& BB : F) {
+                for (Instruction& I : BB) {
+                    if (I.getDebugLoc()) I.setDebugLoc(DebugLoc());
+                }
+            }
+            continue;
+        }
+
+        unsigned anchor_line = sp->getScopeLine();
+        if (anchor_line == 0) anchor_line = sp->getLine();
+        if (anchor_line == 0) anchor_line = 1;
+        DebugLoc last = DILocation::get(ctx, anchor_line, 0, sp);
+
+        for (BasicBlock& BB : F) {
+            for (Instruction& I : BB) {
+                DebugLoc dl = I.getDebugLoc();
+                if (scopedToSubprogram(dl, sp)) {
+                    last = dl;
+                    continue;
+                }
+                if (dl) {
+                    I.setDebugLoc(DILocation::get(ctx, dl.getLine(), dl.getCol(), sp));
+                } else {
+                    I.setDebugLoc(last);
+                }
+                last = I.getDebugLoc();
+            }
+        }
+    }
+}
+
 // Run LLVM optimization passes on a module before codegen
 static void optimizeModule(llvm::Module& module, llvm::TargetMachine* TM, bool is_wasm = false) {
     // Always coerce mismatched integer types first.  On native this is a no-op;
@@ -3429,6 +3514,15 @@ public:
             coerceCallArgIntegerTypes(*module);
             coerceIntegerBinaryOperandTypes(*module);
 
+            // DWARF DEBUG INFO: make every instruction's debug location belong
+            // to the function that contains it. Without this, a single backend
+            // helper that moves the shared builder's insertion point without
+            // carrying the location along makes the whole -g build fail
+            // verification. See normalizeDebugLocations.
+            if (emit_debug_info_) {
+                normalizeDebugLocations(*module, *context);
+            }
+
             // Verify the module
             std::string error_str;
             std::string ir_str;
@@ -4353,8 +4447,11 @@ private:
         
         // Save old insertion point
         IRBuilderBase::InsertPoint old_ip = builder->saveIP();
+        DebugLoc old_debug_loc = builder->getCurrentDebugLocation();
         builder->SetInsertPoint(entry);
-        
+        // Runtime helper with no DISubprogram; drop any inherited location.
+        anchorDebugLocationToCurrentFunction();
+
         // Get parameters
         auto arg_it = display_tensor_recursive_func->arg_begin();
         Value* elements = &*arg_it++;
@@ -4533,11 +4630,143 @@ private:
         
         // Restore insertion point
         builder->restoreIP(old_ip);
-        
+        builder->SetCurrentDebugLocation(old_debug_loc);
+        anchorDebugLocationToCurrentFunction();
+
         function_table["displayTensorRecursive"] = display_tensor_recursive_func;
         eshkol_debug("Created recursive N-dimensional tensor display helper function");
     }
-    
+
+    // DWARF DEBUG INFO: build the DISubprogram for an Eshkol `define`d function.
+    //
+    // `is_definition` decides the *flavour* of the node, and that distinction is
+    // load-bearing for LLVM's verifier, not cosmetic:
+    //
+    //   * a definition subprogram is a *distinct* MDNode owned by the compile
+    //     unit -- it is what produces a DW_TAG_subprogram with code ranges, and
+    //     it is the only kind an LLVM Function *with a body* may carry;
+    //   * a declaration subprogram is *uniqued* and unit-less -- the only kind a
+    //     bodyless Function may carry ("function declaration may only have a
+    //     unique !dbg attachment", Verifier::visitFunction).
+    //
+    // Attaching a definition subprogram to a function that never receives a body
+    // is therefore a hard IR verification error, which is exactly what broke
+    // every `-g` build: `createFunctionDeclaration` runs over *all* top-level
+    // defines, including the `:external` ones that a `(require <stdlib module>)`
+    // produces, whose bodies live in the pre-linked stdlib object and are skipped
+    // by codegenFunctionDefinition. So `@caar`, `@cadr`, `@caadr`, `@cadar`,
+    // `@caddr`, `@cddr`, ... all ended up as declarations wearing a definition
+    // subprogram and the module failed to verify before a single byte of output
+    // was written.
+    //
+    // The invariant is now structural rather than predicted: declarations get the
+    // declaration flavour here, and codegenFunctionDefinition upgrades to the
+    // definition flavour at the point it actually creates the entry block. A
+    // function can only ever carry a definition subprogram if it has a body.
+    DISubprogram* createDefineSubprogram(Function* function,
+                                        const char* func_name,
+                                        unsigned line_no,
+                                        uint64_t num_params,
+                                        bool is_variadic,
+                                        bool is_definition) {
+        if (!emit_debug_info_ || !di_builder_ || !di_file_ || !function || !func_name) {
+            return nullptr;
+        }
+
+        // Subroutine type: return + parameters, all left unspecified (Eshkol
+        // values are dynamically tagged, so there is no single DWARF type).
+        SmallVector<Metadata*, 8> di_param_types;
+        di_param_types.push_back(nullptr);            // return type
+        for (uint64_t i = 0; i < num_params; ++i) {
+            di_param_types.push_back(nullptr);        // parameter types
+        }
+        if (is_variadic) {
+            di_param_types.push_back(nullptr);        // rest parameter
+        }
+        DISubroutineType* di_func_type = di_builder_->createSubroutineType(
+            di_builder_->getOrCreateTypeArray(di_param_types));
+
+        // The linkage name must match the LLVM symbol or the verifier rejects the
+        // attachment ("!dbg attachment points at wrong subprogram for function").
+        // In REPL mode the symbol is the versioned `f__rvN` name.
+        return di_builder_->createFunction(
+            di_file_,                    // Scope (file)
+            func_name,                   // Source-level name
+            function->getName(),         // Linkage name
+            di_file_,                    // File
+            line_no,                     // Line number
+            di_func_type,                // Type
+            line_no,                     // Scope line
+            DINode::FlagPrototyped,
+            is_definition ? DISubprogram::SPFlagDefinition
+                          : DISubprogram::SPFlagZero);
+    }
+
+    // DWARF DEBUG INFO: re-anchor the builder's current debug location to the
+    // function we are emitting into *right now*.
+    //
+    // IRBuilder's current debug location is sticky, but codegen moves the
+    // insertion point across function boundaries constantly (lambda bodies,
+    // nested defines, pre-generated helpers, AD/tensor thunks). A DILocation is
+    // only legal inside the function whose DISubprogram scopes it, so an
+    // inherited location is an IR verification error, not a cosmetic slip:
+    //
+    //   * a location scoped to another function's subprogram gives
+    //     "!dbg attachment points at wrong subprogram for function" -- e.g. the
+    //     entry-block allocas of `make-counter` were still scoped to `fact`,
+    //     simply because `fact`'s body was emitted just before it;
+    //   * no location at all, in a function that has debug info, gives
+    //     "inlinable function call in a function with debug info must have a
+    //     !dbg location" for every call in the entry scaffolding emitted before
+    //     the first AST node was visited.
+    //
+    // Both are the same defect -- trusting a sticky location across a scope
+    // change -- so the location is derived from the current insertion point
+    // instead of being trusted to still apply.
+    //
+    // `line == 0` means "no source position of its own": keep the current line
+    // if it is already scoped to this function, otherwise fall back to the
+    // function's scope line.
+    void anchorDebugLocation(unsigned line, unsigned column) {
+        if (!emit_debug_info_) return;
+        BasicBlock* bb = builder->GetInsertBlock();
+        if (!bb) return;
+        Function* fn = bb->getParent();
+        DISubprogram* sp = fn ? fn->getSubprogram() : nullptr;
+        if (!sp) {
+            // Synthetic helper with no debug info of its own (__lambda_init__,
+            // display thunks, worker trampolines). It must not inherit a
+            // location scoped to a real function's subprogram.
+            if (builder->getCurrentDebugLocation()) {
+                builder->SetCurrentDebugLocation(DebugLoc());
+            }
+            return;
+        }
+
+        DebugLoc cur = builder->getCurrentDebugLocation();
+        bool scope_ok = false;
+        if (cur) {
+            if (auto* local = dyn_cast_or_null<DILocalScope>(cur->getScope())) {
+                scope_ok = (local->getSubprogram() == sp);
+            }
+        }
+
+        unsigned l = line;
+        if (l == 0) {
+            if (scope_ok) return;            // already valid here; leave it alone
+            l = sp->getScopeLine();
+            if (l == 0) l = sp->getLine();
+            if (l == 0) l = 1;
+        }
+        if (scope_ok && cur.getLine() == l && cur.getCol() == column) return;
+        builder->SetCurrentDebugLocation(DILocation::get(*context, l, column, sp));
+    }
+
+    // Anchor to the start of whatever function is now being emitted into. Called
+    // right after a function body's entry block becomes the insertion point, and
+    // after an insertion-point restore that crosses a function boundary.
+    void anchorDebugLocationToCurrentFunction() { anchorDebugLocation(0, 0); }
+
     void createFunctionDeclaration(const eshkol_ast_t* ast) {
         if (ast->type != ESHKOL_OP || ast->operation.op != ESHKOL_DEFINE_OP ||
             !ast->operation.define_op.is_function) {
@@ -4669,34 +4898,21 @@ private:
         // ESH-0187: record the full define node (params + body) for P2 mono.
         function_def_ast[func_name] = ast;
 
-        // DWARF DEBUG INFO: Attach DISubprogram to function for source-level debugging
+        // DWARF DEBUG INFO: attach a *declaration* subprogram. This function has
+        // no body yet, and may never get one (`:external` defines resolve to the
+        // pre-linked stdlib object). codegenFunctionDefinition upgrades this to a
+        // definition subprogram at the moment it creates the entry block -- see
+        // createDefineSubprogram for why the flavour must track the body.
         if (emit_debug_info_ && di_builder_ && di_file_) {
-            // Create subroutine type (all args as unspecified type for now)
-            SmallVector<Metadata*, 8> di_param_types;
-            di_param_types.push_back(nullptr); // Return type (unspecified)
-            for (uint64_t i = 0; i < num_params; ++i) {
-                di_param_types.push_back(nullptr); // Parameter types (unspecified)
-            }
-            if (is_variadic) {
-                di_param_types.push_back(nullptr); // Rest parameter
-            }
-            DISubroutineType* di_func_type = di_builder_->createSubroutineType(
-                di_builder_->getOrCreateTypeArray(di_param_types));
-
             unsigned line_no = ast->line > 0 ? ast->line : 1;
-            DISubprogram* di_sp = di_builder_->createFunction(
-                di_file_,              // Scope (file)
-                func_name,             // Name
-                function->getName(),   // Linkage name
-                di_file_,              // File
-                line_no,               // Line number
-                di_func_type,          // Type
-                line_no,               // Scope line
-                DINode::FlagPrototyped,
-                DISubprogram::SPFlagDefinition);
-
-            function->setSubprogram(di_sp);
-            eshkol_debug("Attached DISubprogram to %s at line %u", func_name, line_no);
+            DISubprogram* di_sp = createDefineSubprogram(
+                function, func_name, line_no, num_params, is_variadic,
+                /*is_definition=*/false);
+            if (di_sp) {
+                function->setSubprogram(di_sp);
+                eshkol_debug("Attached declaration DISubprogram to %s at line %u",
+                             func_name, line_no);
+            }
         }
 
         registerContextFunction(func_name, function);
@@ -4721,6 +4937,8 @@ private:
 
         builder->SetInsertPoint(init_entry);
         current_function = init_func;
+        // __lambda_init__ has no DISubprogram; drop any inherited location.
+        anchorDebugLocationToCurrentFunction();
 
         for (size_t i = 0; i < num_asts; i++) {
             // Look for (define var (lambda ...)) patterns
@@ -9420,17 +9638,12 @@ private:
             }
         }
 
-        // DWARF DEBUG INFO: Set source location on builder for subsequent instructions
-        if (emit_debug_info_ && ast->line > 0 && builder->GetInsertBlock()) {
-            Function* cur_fn = builder->GetInsertBlock()->getParent();
-            if (cur_fn) {
-                DISubprogram* sp = cur_fn->getSubprogram();
-                if (sp) {
-                    builder->SetCurrentDebugLocation(
-                        DILocation::get(*context, ast->line, ast->column, sp));
-                }
-            }
-        }
+        // DWARF DEBUG INFO: Set source location on builder for subsequent
+        // instructions. Always re-anchored to the function being emitted into --
+        // a node with no line of its own must still not leave a location scoped
+        // to a previously emitted function in place. See anchorDebugLocation.
+        anchorDebugLocation(ast->line > 0 ? ast->line : 0,
+                            ast->line > 0 ? ast->column : 0);
 
         emitLanguageCoverage(ast);
 
@@ -11098,6 +11311,35 @@ private:
         BasicBlock* entry = BasicBlock::Create(*context, "entry", function);
         builder->SetInsertPoint(entry);
 
+        // DWARF DEBUG INFO: this function is now a definition, so upgrade the
+        // declaration subprogram createFunctionDeclaration attached into a real
+        // definition subprogram. Must happen before any body instruction is
+        // emitted, because codegenAST reads current_function->getSubprogram() to
+        // build each instruction's DILocation scope, and a DILocation scope has
+        // to be the definition node.
+        if (emit_debug_info_ && di_builder_ && di_file_) {
+            DISubprogram* existing = function->getSubprogram();
+            if (!existing || !existing->isDefinition()) {
+                bool is_variadic = op->define_op.is_variadic && op->define_op.rest_param;
+                unsigned line_no = ast->line > 0 ? ast->line
+                                                 : (existing ? existing->getLine() : 1);
+                DISubprogram* def_sp = createDefineSubprogram(
+                    function, func_name, line_no,
+                    op->define_op.num_params, is_variadic,
+                    /*is_definition=*/true);
+                if (def_sp) {
+                    function->setSubprogram(def_sp);
+                    eshkol_debug("Upgraded %s to definition DISubprogram at line %u",
+                                 func_name, line_no);
+                }
+            }
+            // The entry scaffolding below (recursion-depth check, parameter
+            // allocas, TCO setup) is emitted before the first codegenAST call,
+            // so it needs a location of its own rather than whichever function
+            // was emitted previously.
+            anchorDebugLocationToCurrentFunction();
+        }
+
         // Set current function
         Function* prev_function = current_function;
         current_function = function;
@@ -11741,8 +11983,12 @@ private:
         // Create basic block for function body
         BasicBlock* entry = BasicBlock::Create(*context, "entry", nested_func);
         IRBuilderBase::InsertPoint old_point = builder->saveIP();
+        DebugLoc old_debug_loc = builder->getCurrentDebugLocation();
 
         builder->SetInsertPoint(entry);
+        // nested_func carries no DISubprogram of its own, so the enclosing
+        // function's location must not follow us in here.
+        anchorDebugLocationToCurrentFunction();
 
         // Save and set current function
         Function* prev_function = current_function;
@@ -11850,6 +12096,8 @@ private:
         symbol_table = prev_symbols;
         current_function = prev_function;
         builder->restoreIP(old_point);
+        builder->SetCurrentDebugLocation(old_debug_loc);
+        anchorDebugLocationToCurrentFunction();
 
         // CLOSURE MUTATION FIX: Update outer scope to use GlobalVariables for captured variables
         // This ensures that both the nested function and outer scope share the same storage
@@ -27172,8 +27420,13 @@ private:
         // Create basic block for lambda body
         BasicBlock* entry = BasicBlock::Create(*context, "entry", lambda_func);
         IRBuilderBase::InsertPoint old_point = builder->saveIP();
+        DebugLoc old_debug_loc = builder->getCurrentDebugLocation();
 
         builder->SetInsertPoint(entry);
+        // Anchor into the lambda before any of its entry scaffolding is emitted;
+        // otherwise the recursion-depth call below is scoped to the *enclosing*
+        // function's subprogram. Restored together with old_point at the end.
+        anchorDebugLocationToCurrentFunction();
 
         // STACK OVERFLOW PROTECTION: Check recursion depth at function entry
         {
@@ -27533,6 +27786,11 @@ private:
                     lambda_name.c_str(), (unsigned long long)op->lambda_op.num_params, free_vars.size());
 
         builder->restoreIP(old_point);
+        // The insertion point is back in the enclosing function, so the lambda's
+        // debug location must go with it -- the caller emits closure-allocation
+        // instructions immediately after this point.
+        builder->SetCurrentDebugLocation(old_debug_loc);
+        anchorDebugLocationToCurrentFunction();
 
         // NOTE: Inline S-expression generation for lambdas inside functions was disabled
         // because codegenLambdaToSExpr creates branching control flow (via codegenTaggedArenaConsCellFromTaggedValue)

--- a/tests/toolchain/debug_info_emission_test.sh
+++ b/tests/toolchain/debug_info_emission_test.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) tsotchke
+#
+# SPDX-License-Identifier: MIT
+#
+# Regression guard for `-g` (DWARF debug info) code generation.
+#
+# `-g` builds were completely broken and invisible for an entire release line.
+# Every top-level define -- including the `:external` stdlib defines a
+# `(require ...)` produces, whose bodies live in the pre-linked stdlib object --
+# was handed a *definition* DISubprogram at declaration time. A bodyless LLVM
+# function may only carry a uniqued declaration subprogram, so the module failed
+# verification before a single byte of output existed:
+#
+#   function declaration may only have a unique !dbg attachment
+#   ptr @caadr
+#
+# The only assertion covering `-g` at the time checked that an "-O2/-O3" marker
+# was *absent* from the log -- a condition a compiler that never produces output
+# satisfies for free. So this test asserts on artifacts and behaviour instead:
+#
+#   1. -g compiles, links, and the binary runs with the expected output, over
+#      the very list accessors that used to break it (caadr/cadar/caddr/cddr);
+#   2. -g composes with every explicit optimization level (-O0..-O3);
+#   3. the debug info is actually *useful*, not merely present: the emitted
+#      DWARF names the user's functions and carries line entries pointing at the
+#      .esk source. Skipped only if no DWARF reader exists on the host.
+#
+# Every one of those fails loudly if the compiler stops producing output.
+#
+# Usage: debug_info_emission_test.sh <path-to-eshkol-run> <build-dir>
+
+set -u
+
+TEST_NAME="debug_info_emission_test"
+ESHKOL_RUN="${1:-}"
+BUILD_DIR="${2:-}"
+
+fail() {
+    echo "FAIL: $TEST_NAME: $*"
+    exit 1
+}
+
+if [ -z "$ESHKOL_RUN" ] || [ ! -x "$ESHKOL_RUN" ]; then
+    fail "eshkol-run not executable: '$ESHKOL_RUN'"
+fi
+if [ -z "$BUILD_DIR" ] || [ ! -d "$BUILD_DIR" ]; then
+    fail "build directory not found: '$BUILD_DIR'"
+fi
+
+ESHKOL_RUN="$(cd "$(dirname "$ESHKOL_RUN")" && pwd)/$(basename "$ESHKOL_RUN")"
+BUILD_DIR="$(cd "$BUILD_DIR" && pwd)"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-debuginfo.XXXXXX")" || fail "mktemp failed"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+SRC="$WORK/debug_info_probe.esk"
+cat > "$SRC" <<'ESK'
+(define nested (list 1 (list 20 21) (list 30 (list 31 32)) 4))
+
+(define (double x)
+  (* x 2))
+
+(define (describe lst)
+  (double (car lst)))
+
+(define (main)
+  (display (caadr nested))
+  (newline)
+  (display (cadar (list (list 100 101) 2)))
+  (newline)
+  (display (car (caddr nested)))
+  (newline)
+  (display (cddr (list 1 2 3 4)))
+  (newline)
+  (display (describe (list 7 8)))
+  (newline)
+  0)
+ESK
+
+EXPECTED="20
+101
+30
+(3 4)
+14"
+
+# --- 1 + 2: -g alone and -g with each explicit optimization level -----------
+for opt in "" "-O0" "-O1" "-O2" "-O3"; do
+    label="-g ${opt:-(default opt level)}"
+    bin="$WORK/probe$(echo "${opt:-def}" | tr -d '-')"
+    rm -f "$bin" "$bin.tmp.o"
+
+    log="$WORK/compile.log"
+    if ! ( cd "$WORK" && "$ESHKOL_RUN" -g $opt -L"$BUILD_DIR" "$SRC" -o "$bin" ) \
+            > "$log" 2>&1; then
+        echo "--- compiler output ---"
+        tail -20 "$log"
+        fail "'$label' failed to compile (exit non-zero)"
+    fi
+    [ -x "$bin" ] || fail "'$label' reported success but produced no executable"
+
+    actual="$("$bin" 2>&1)" || fail "'$label' binary exited non-zero"
+    if [ "$actual" != "$EXPECTED" ]; then
+        echo "--- expected ---"; echo "$EXPECTED"
+        echo "--- actual ---";   echo "$actual"
+        fail "'$label' binary produced the wrong output"
+    fi
+    echo "  ok: $label compiles, links and runs correctly"
+done
+
+# --- 3: the debug info has to be usable ------------------------------------
+# The DWARF lives in the object file the driver leaves beside the executable
+# (that object is also what a debugger follows via the Mach-O debug map), so
+# read whichever of the two the host's reader understands.
+DWARF_TOOL=""
+for candidate in llvm-dwarfdump dwarfdump; do
+    if command -v "$candidate" >/dev/null 2>&1; then DWARF_TOOL="$candidate"; break; fi
+done
+# objdump can read the line table too, and exists on hosts with neither above.
+if [ -z "$DWARF_TOOL" ] && command -v objdump >/dev/null 2>&1; then
+    DWARF_TOOL="objdump"
+fi
+
+if [ -z "$DWARF_TOOL" ]; then
+    echo "  skip: no DWARF reader on this host (llvm-dwarfdump/dwarfdump/objdump)"
+else
+    OBJ="$WORK/probedef.tmp.o"
+    TARGET="$OBJ"
+    [ -f "$TARGET" ] || TARGET="$WORK/probedef"
+    [ -e "$TARGET" ] || fail "neither the -g object nor the executable exists to inspect"
+
+    if [ "$DWARF_TOOL" = "objdump" ]; then
+        info="$(objdump --dwarf=info "$TARGET" 2>/dev/null)"
+        lines="$(objdump --dwarf=decodedline "$TARGET" 2>/dev/null)"
+    else
+        info="$("$DWARF_TOOL" --debug-info "$TARGET" 2>/dev/null)"
+        lines="$("$DWARF_TOOL" --debug-line "$TARGET" 2>/dev/null)"
+    fi
+
+    if [ -z "$info" ]; then
+        fail "no .debug_info in the -g output: debug info was not emitted at all"
+    fi
+    # A user function must be named in the DWARF. Present-but-useless debug info
+    # (a compile unit and nothing else) fails here rather than passing quietly.
+    for fn in double describe; do
+        case "$info" in
+            *"\"$fn\""*|*"$fn"*) ;;
+            *) fail "DWARF does not name the user function '$fn'" ;;
+        esac
+    done
+    case "$info" in
+        *debug_info_probe.esk*) ;;
+        *) fail "DWARF does not reference the .esk source file" ;;
+    esac
+    if [ -z "$lines" ]; then
+        fail "no line-number program in the -g output: line attribution unusable"
+    fi
+    # Require actual line rows, not just an empty line-table header.
+    if ! printf '%s\n' "$lines" | grep -qE '(0x0*[0-9a-f]{4,}[[:space:]]+[0-9]+[[:space:]]+[0-9]+)|(debug_info_probe\.esk[[:space:]]*:?[[:space:]]*[0-9]+)'; then
+        echo "--- line table ---"
+        printf '%s\n' "$lines" | head -20
+        fail "line table has no source rows: -g emitted debug info that cannot attribute code"
+    fi
+    echo "  ok: DWARF names user functions and carries source line rows ($DWARF_TOOL)"
+fi
+
+echo "PASS: $TEST_NAME"
+exit 0


### PR DESCRIPTION
## The blocker

`eshkol-run -g <file> -o <bin>` could not compile anything at all. The identical
command without `-g` succeeded, so the entire debug-info surface has been dead
and invisible for a whole release line:

```
function declaration may only have a unique !dbg attachment
ptr @caadr
...
     ERROR: Failed to generate LLVM IR
```

It stayed invisible because the only assertion covering `-g` checked that an
`-O2/-O3` marker was **absent** from the `-d` log — free for a compiler that
never produces output. Run against the broken compiler, that suite reports
**7/7 PASS**.

## Root cause — three defects in debug-metadata attachment

**1. A definition subprogram on a function that never gets a body.**
`createFunctionDeclaration` attached a `DISubprogram` built with
`SPFlagDefinition` to *every* top-level define. DIBuilder makes a definition
subprogram a `distinct` MDNode owned by the compile unit, and LLVM's verifier
allows a bodyless `Function` to carry only a *uniqued* declaration subprogram
(`Verifier::visitFunction`). The declaration pre-pass runs over the `:external`
defines that `(require <stdlib module>)` produces — bodies live in the pre-linked
stdlib object and are skipped by `codegenFunctionDefinition` — so `@caar`,
`@cadr`, `@cdar`, `@cddr`, `@caaar`, `@caadr`, `@cadar`, `@caddr`, `@partial`,
`@flip`, `@trampoline` and every other unused stdlib accessor became a
declaration wearing a definition subprogram.

The node's flavour now tracks the body instead of predicting it: the declaration
pass attaches the declaration flavour, and `codegenFunctionDefinition` upgrades
to the definition flavour where it creates the entry block.

**2. A sticky debug location inherited across function boundaries.**
The current debug location lives on one shared `IRBuilder` whose insertion point
moves between functions constantly. A `DILocation` is only legal inside the
function whose subprogram scopes it, so `make-counter`'s entry-block allocas were
rejected for being scoped to `fact` — purely because `fact` was emitted just
before it. Locations are now re-anchored to the function being emitted into
(`anchorDebugLocation`), on entry to each body and at every AST node, and
restored with the insertion point when a nested body returns.

**3. A debug location silently lost on the way back out.**
`IRBuilderBase::SetInsertPoint(BB, IP)` *overwrites* the current location from
the instruction at `IP` when `IP != BB->end()` and leaves it untouched when
`IP == BB->end()`. `ArithmeticCodegen::getOrEmitBinaryOutline` emits an
out-of-line helper into a different function, whose own entry-block alloca hoists
reset the shared location to a location-less alloca; restoring the caller's
insertion point at `end()` did not restore the location. The first user call
emitted after any arithmetic operation therefore had no `!dbg` at all:

```
inlinable function call in a function with debug info must have a !dbg location
  %93 = call %eshkol_tagged_value @fact(%eshkol_tagged_value %92)
```

That site now saves and restores the location with the insertion point. Because
~30 insertion-point helpers across the backend share the hazard,
`normalizeDebugLocations` enforces the invariant module-wide immediately before
verification, alongside the existing `coerceCallArgIntegerTypes` /
`coerceIntegerBinaryOperandTypes` normalizations. It runs only when `-g` is set,
so non-debug builds are bit-identical.

## The debug info is useful, not merely present

`lldb` resolves a breakpoint by `.esk` file and line, prints the Eshkol source,
and produces a symbolicated backtrace with a distinct line **and column** per
frame:

```
(lldb) breakpoint set --file lineinfo.esk --line 2
Breakpoint 1: where = li.bin`alpha + 8 at lineinfo.esk:2:6
   1   	(define (alpha a)
-> 2   	  (+ a 1))
(lldb) bt
  * frame #0: li.bin`alpha       at lineinfo.esk:2:6
    frame #1: li.bin`beta        at lineinfo.esk:4:13
    frame #2: li.bin`scheme_main at lineinfo.esk:6:18
```

`dwarfdump` shows `DW_TAG_subprogram` DIEs naming each user function with
`decl_file`/`decl_line` — including lambdas (`nontrivial_lambda_0` at line 5,
`nontrivial_lambda_1` at line 17) — plus a populated line-number program. The
same object built without `-g` has 0 subprogram DIEs and 0 line rows, so the
assertion is not vacuous.

## Flag matrix

| combination | before | after |
| --- | --- | --- |
| `-g -o` | FAIL, no output | compiles, links, runs correctly |
| `-g -O0 -o` | FAIL | pass |
| `-g -O1 -o` | FAIL | pass |
| `-g -O2 -o` | FAIL | pass |
| `-g -O3 -o` | FAIL | pass |
| `-g -c` (object only) | FAIL | pass |
| `-g` (no `-o`, ephemeral) | FAIL | pass |
| `-g -r` (JIT) | ran | ran — `-g` is a **no-op** on this path (see below) |
| `-g --profile hosted-vm` | emitted ESKB | emitted ESKB — `-g` not applicable (bytecode, no LLVM/DWARF) |

Two honest notes, both pre-existing and outside this change:

* **`-g -r` silently ignores `-g`.** `eshkol_enable_debug_info` is called only on
  the AOT path (`exe/eshkol-run.cpp`); the in-process JIT never receives it. `-r`
  works with `-g`, but no DWARF is produced. Making JIT frames debuggable needs a
  JIT debug listener, which is a feature, not this fix.
* **`--shared-lib` fails identically with and without `-g`** on a program with a
  user `main` (library-mode codegen error), and returns exit 0 while producing no
  library for one that lacks it. `-g`-independent, so untouched here.

## The test a dead compiler cannot satisfy

`scripts/run_codegen_optlevel_tests.sh` is **already repaired by #367** — its
`check_not_optimized` now requires exit 0 plus non-silent `-d` output. Verified
directly against the broken compiler:

* master's script: `-o -g stays unoptimized` → **PASS** (7/7, the sleeper)
* #367's script: `-o -g stays unoptimized` → **COMPILE FAIL (exit 1)**, suite red

So that file is left alone — no collision with #367.

Added instead: `tests/toolchain/debug_info_emission_test.sh` (ctest
`debug_info_emission_test`), asserting on artifacts and behaviour — `-g` compiles,
links and runs with the expected output over the very accessors that used to break
it, at `-g` and `-g` with each of `-O0..-O3`, and the emitted DWARF names user
functions and carries source line rows. Against the pre-fix compiler it goes red
with the original diagnostic.

## Verification

* flag matrix above: 12/12 green
* `-g` vs no-`-g` sweep over a 176-file repo-wide sample of `tests/**/*.esk`:
  171 compile clean both ways, **0** compile without `-g` and fail with it, 5 fail
  identically with and without `-g` (pre-existing, `-g`-independent)
* full `ctest`: green
* `scripts/run_vm_parity.sh`: 80 passed, 0 failed
* new `debug_info_emission_test` proven able to fail
