### PR TITLE
chore(coverage): regenerate the language-surface manifest so master passes its own gate

### DIFF
--- a/tests/coverage/language_surface.json
+++ b/tests/coverage/language_surface.json
@@ -3356,6 +3356,7 @@
     {
       "name": "error-object-message",
       "ids": [
+        711,
         712
       ],
       "arity": 1,
@@ -3369,7 +3370,8 @@
     {
       "name": "error-object?",
       "ids": [
-        711
+        711,
+        714
       ],
       "arity": 1,
       "backends": [


### PR DESCRIPTION
## What

Regenerates `tests/coverage/language_surface.json`. Generated output only: adds native id `711` to `error-object-message` and `714` to `error-object?`. No surface entries added or removed, no behaviour change.

## Why this is urgent

**master is currently failing its own `surface-manifest` gate.** #360 rebound `error-object?` and `error-object-message` to their correct native slots — they had been misbound by one, so the predicate returned the message string instead of a boolean — but the manifest was not regenerated. The committed manifest therefore stopped describing the real native tables.

The consequence is not confined to master: every open branch inherits the red gate the moment it merges master. That is how #367 and #373 both went red on `surface-manifest` immediately after being brought up to date, with no fault of their own.

Verified: after regeneration, `python3 scripts/gen_language_surface.py` leaves the tree clean, so the gate passes.

## Note

This is the gate added in #366 working exactly as intended — it caught a real drift between the manifest and the native tables within hours of being introduced. The drift entered because #360 changed native slot bindings without the regeneration step, which the gate now makes impossible to miss.