### PR TITLE
fix(p8): quote the property oracle's symbol atoms so it pins something

### DIFF
--- a/scripts/p8/gen_property_oracles.py
+++ b/scripts/p8/gen_property_oracles.py
@@ -97,7 +97,19 @@ _DATA_ATOMS = [
     "#\\a", "#\\Z", "#\\space", "#\\newline",
     "\"plain\"", "\"with space\"", "\"tab\\ttab\"", "\"nl\\nnl\"",
     "\"quote\\\"inside\"", "\"back\\\\slash\"", "\"\"",
-    "sym", "another-symbol", "with->arrow", "|weird sym|",
+    # Symbols must be QUOTED. These atoms are emitted into evaluated
+    # constructor calls -- `(vector 0 sym)` -- so a bare symbol is a variable
+    # reference, not symbol data. Unquoted, the generated program referenced
+    # undefined variables; the compiler printed a diagnostic for each and
+    # emitted a binary anyway, so this oracle passed while pinning nothing.
+    #
+    # `|weird sym|` is deliberately absent: the reader does not yet implement
+    # R7RS 7.1.1 vertical-line symbol syntax, so `'|weird sym|` lexes as the
+    # two tokens `'|weird` and `sym|` and the latter becomes an undefined
+    # variable. That gap is pinned by
+    # tests/vm_parity/found/r7rs_pipe_delimited_symbol.esk -- restore this atom
+    # once the reader supports it.
+    "'sym", "'another-symbol", "'with->arrow",
     "#t", "#f",
 ]
 

--- a/tests/vm_parity/found/r7rs_pipe_delimited_symbol.esk
+++ b/tests/vm_parity/found/r7rs_pipe_delimited_symbol.esk
@@ -1,0 +1,45 @@
+;; FOUND: the reader does not implement R7RS 7.1.1 vertical-line symbols.
+;;
+;; R7RS 7.1.1 gives three identifier productions, the second being
+;;   <identifier> -> <vertical line> <symbol element>* <vertical line>
+;; so |weird sym| is a single symbol whose name contains a space, and
+;; (symbol? '|weird sym|) must be #t.
+;;
+;; Eshkol lexes '|weird sym| as TWO tokens -- '|weird and sym| -- so the
+;; second becomes a variable reference:
+;;
+;;     error: Undefined variable: sym|
+;;        3 | (display '|weird sym|)
+;;          |                  ^
+;;
+;; and (symbol? '|weird sym|) additionally reports "Type predicate requires
+;; exactly 1 argument", because the split produces two arguments.
+;;
+;; HOW THIS STAYED HIDDEN: scripts/p8/gen_property_oracles.py listed
+;; |weird sym| among its datum atoms, emitted UNQUOTED into evaluated
+;; constructor calls. The generated program therefore referenced undefined
+;; variables, the compiler printed a diagnostic for each one and emitted a
+;; binary anyway, and the property oracle passed. The oracle was green while
+;; pinning nothing. Making an emitted error diagnostic fatal exposed it.
+;;
+;; Expected output once the reader is fixed:
+;;   #t
+;;   weird sym
+;;   #t
+;;   3
+
+(display (symbol? '|weird sym|))
+(newline)
+(display '|weird sym|)
+(newline)
+;; A vertical-line symbol must survive a write/read round trip.
+(display (equal? (read (open-input-string
+                         (let ((o (open-output-string)))
+                           (write '|weird sym| o)
+                           (get-output-string o))))
+                 '|weird sym|))
+(newline)
+;; And must be usable as data inside a collection, which is the shape the
+;; property oracle generates.
+(display (vector-length (vector 0 '|weird sym| 2)))
+(newline)


### PR DESCRIPTION
## Another false green, and the R7RS gap it was hiding

`scripts/p8/gen_property_oracles.py` listed symbol atoms — `sym`, `another-symbol`, `with->arrow`, `|weird sym|` — and emitted them **unquoted** into evaluated constructor calls such as `(vector 0 with->arrow)`. A bare symbol there is a *variable reference*, not symbol data, so the generated program referenced undefined variables. The compiler printed a diagnostic for each and emitted a binary anyway, and the oracle passed.

**The P8 property-oracle family has therefore been green while pinning nothing.** It surfaced as an `axis-4 CRASH prop_datart.esk` on #373 once an emitted diagnostic became fatal — the crash was the symptom, this is the cause. It is not #373's defect.

## Measured, under a build where diagnostics are fatal

| file | before | after |
|---|---|---|
| `prop_datart.esk` | compiled with 19 ignored `Undefined variable` diagnostics; oracle passed | **60/0, zero errors** |
| `prop_alg.esk` | — | **150/0, zero errors** |

## `|weird sym|` is removed, not quoted — and the gap is pinned

Quoting is not sufficient for that one. The reader does not implement **R7RS §7.1.1 vertical-line symbol syntax**, so `'|weird sym|` lexes as two tokens, `'|weird` and `sym|`, and the second becomes an undefined variable:

```
error: Undefined variable: sym|
   3 | (display '|weird sym|)
     |                  ^
```

`(symbol? '|weird sym|)` additionally reports "Type predicate requires exactly 1 argument", from the same split producing two arguments.

Rather than leave that undocumented, it is pinned by a new reproduction at `tests/vm_parity/found/r7rs_pipe_delimited_symbol.esk`, stating the R7RS production, the observed behaviour, how the oracle hid it, and the expected output once the reader supports it. The atom should be restored then. Under the project rule that documented capability gets built rather than walked back, **R7RS §7.1.1 vertical-line symbols are a build item**, not a narrowed claim.

## Why this matters beyond one file

Same family as the harness defects in #367 and the `private_extern_no_crash_test` fixture: a gate that reports success while asserting nothing. This one had a compounding effect, because the generator produces the corpus that a whole adversarial pillar runs on.