### PR TITLE
fix(tests): stdlib_display_test references the real arithmetic wrapper name

### DIFF
--- a/tests/lists/stdlib_display_test.esk
+++ b/tests/lists/stdlib_display_test.esk
@@ -8,7 +8,7 @@
 (display "add: ") (display add) (newline)
 (display "sub: ") (display sub) (newline)
 (display "mul: ") (display mul) (newline)
-(display "div: ") (display div) (newline)
+(display "divide: ") (display divide) (newline)
 
 ;; Comparison operators (core.operators.compare)
 (display "eq: ") (display eq) (newline)


### PR DESCRIPTION
## Summary
- `tests/lists/stdlib_display_test.esk` displayed a symbol named `div`, which is defined nowhere. `core.operators.arithmetic` (`lib/core/operators/arithmetic.esk`) only ever provides `add`/`sub`/`mul`/`divide` — the division wrapper was renamed from `div` to `divide` in `fee0bc9b` because a function named `div` is emitted as a weak external that collides with libc's `div(int,int)->div_t`, corrupting the 16-byte tagged-value ABI (documented in `docs/reference/stdlib/operators_arithmetic.md`, Known issues: "None. The division wrapper used to be named div ... renamed to divide to avoid the collision").
- The test file predates that rename and was never updated. Under #373's fatal compile diagnostics, referencing the undefined `div` now hard-fails compilation instead of silently doing nothing, so `run_list_tests.sh` goes red.
- Ruling: no doc promises a `div` builtin — the doc explicitly documents the opposite (the wrapper is `divide`, not `div`, and explains why). This is a phantom/stale test reference, not a missing builtin. Fix: use the real spelling.

## Evidence
Verified against a #373-era build (branch `fix/compile-errors-are-fatal`):
- Before: `(display div)` -> `error: Undefined variable: div`, compile exit 1 (reproduces the reported failure).
- After: `(display divide)` -> compiles and runs, prints `divide: (lambda (x y) (/ x y))`, exit 0.
- Full suites green on the same build: `run_list_tests.sh` 129/129, `run_stdlib_tests.sh` 20/20.

## Test plan
- [x] Reproduced the original failure against a #373-era build
- [x] Fix compiles and runs clean
- [x] `run_list_tests.sh` 129/129 pass
- [x] `run_stdlib_tests.sh` 20/20 pass