### PR TITLE
fix(test-isolation): try GNU stat -c before BSD stat -f in fingerprint

### DIFF
--- a/scripts/lib/test_isolation.sh
+++ b/scripts/lib/test_isolation.sh
@@ -268,11 +268,16 @@ ESHKOL_TEST_PIN_ARTIFACTS="eshkol-run stdlib.o stdlib.bc eshkol-vm-standalone-te
 
 # Portable "size mtime" stamp for one file. BSD stat and GNU stat disagree on
 # flags, so try both; a missing file stamps as "-" (absent is a stable state).
+# GNU must be tried first: GNU `stat -f` is not "BSD -f" at all, it means
+# --file-system and succeeds with filesystem-level numbers (free blocks/
+# inodes) instead of failing, so a BSD-first order silently fingerprints the
+# filesystem rather than the file — any unrelated fs activity between two
+# snapshots then reads as "the compiler binary changed during this run".
 eshkol_test_file_stamp() {
     local path="$1"
     [ -e "$path" ] || { printf '%s' '-'; return 0; }
-    stat -f '%z %m' "$path" 2>/dev/null && return 0
     stat -c '%s %Y' "$path" 2>/dev/null && return 0
+    stat -f '%z %m' "$path" 2>/dev/null && return 0
     # Last resort: content digest.
     cksum < "$path" 2>/dev/null || printf '%s' '?'
 }


### PR DESCRIPTION
## Summary

`scripts/lib/test_isolation.sh`'s toolchain-fingerprint guard misfires on
Linux, declaring fully-green test runs "INVALID RUN: the compiler binary
changed during this run" (exit 3) even though nothing about the toolchain
changed. This has made every Linux lite lane's job conclusion non-informative
since #367 merged the isolation guard.

## Root cause

`eshkol_test_file_stamp()` tries `stat -f '%z %m'` before `stat -c '%s %Y'`:

```sh
stat -f '%z %m' "$path" 2>/dev/null && return 0
stat -c '%s %Y' "$path" 2>/dev/null && return 0
```

On BSD/macOS, `-f` is the format flag, so this is the right tool and it
returns cleanly. On GNU coreutils, `-f`/`--file-system` is a boolean flag
that takes no argument — it does not accept a following format string at
all. When given one anyway, GNU `stat` parses the quoted format string as an
extra file operand, fails to find a file by that literal name, and (for the
operand that does exist) falls back to printing its default multi-line
**filesystem** status block (free blocks, free inodes, etc.) instead of the
requested per-file size/mtime. That block/inode text ends up embedded ahead
of the real size+mtime line in the "fingerprint". Free block/inode counts
drift under any unrelated filesystem activity on the machine, so two
fingerprints taken instants apart around an otherwise completely untouched
build tree can differ — which the guard reads as "the compiler binary
changed during this run" and aborts the suite.

## Fix

Reorder the two `stat` calls: try GNU's `stat -c '%s %Y'` first (it fails
cleanly, with nothing printed to stdout, when run against BSD `stat`, which
does not understand `-c`), then fall back to BSD's `stat -f '%z %m'`. This
is a straight reorder of two existing lines plus an explanatory comment —
no new logic. Checked the rest of the file for other `stat -f`-first call
sites; this is the only one.

## Verification

### 1. macOS/BSD (local) — fallback path still works, fingerprint is stable

```
$ eshkol_test_file_stamp <file>
0 1785424001

$ eshkol_test_toolchain_fingerprint <build-dir>   # call 1
eshkol-run=0 1785424001
stdlib.o=-
...

# touch an unrelated file elsewhere, then call again
$ eshkol_test_toolchain_fingerprint <build-dir>   # call 2
eshkol-run=0 1785424001
stdlib.o=-
...
```
Identical across both calls — BSD `stat -f` fallback still resolves size+mtime correctly and the reordering is a no-op on macOS.

### 2. Linux mesh node (Ubuntu 24.04, GNU coreutils 9.4) — demonstrates the bug and the fix

Raw semantics — GNU `-f` is not a format flag:

```
$ stat -c "%s %Y" testfile.txt
6 1785424018

$ stat -f testfile.txt
  File: "testfile.txt"
    ID: 6de178b6c666f382 Namelen: 255     Type: ext2/ext3
Block size: 4096       Fundamental block size: 4096
Blocks: Total: 119822904  Free: 9166563    Available: 3061533
Inodes: Total: 30507008   Free: 24741325
```

Sourcing the **original** (pre-fix) library and calling the real
`eshkol_test_toolchain_fingerprint`, twice, with unrelated disk churn
(50 MB written and removed) in between:

```
===================== ORIGINAL (buggy, stat -f tried first) =====================
--- fingerprint call 1 ---
eshkol-run=  File: "bd/eshkol-run"
    ID: 6de178b6c666f382 Namelen: 255     Type: ext2/ext3
Block size: 4096       Fundamental block size: 4096
Blocks: Total: 119822904  Free: 9166583    Available: 3061553
Inodes: Total: 30507008   Free: 24741325
0 1785424182
stdlib.o=  File: "bd/stdlib.o"
    ID: 6de178b6c666f382 Namelen: 255     Type: ext2/ext3
Block size: 4096       Fundamental block size: 4096
Blocks: Total: 119822904  Free: 9166583    Available: 3061553
Inodes: Total: 30507008   Free: 24741325
0 1785424182
...
--- fingerprint call 2 ---
(same polluted block/inode dump repeated ahead of the real "0 1785424182" line)
```

The filesystem status dump is embedded directly into what is supposed to be
a clean per-file "size mtime" fingerprint — exactly the kind of noise that
flips between snapshots on a live, multi-tenant runner and trips the
"compiler binary changed" guard.

Sourcing the **fixed** library and repeating the same procedure:

```
===================== FIXED (stat -c tried first) =====================
--- fingerprint call 1 ---
eshkol-run=0 1785424182
stdlib.o=0 1785424182
stdlib.bc=-
eshkol-repl=-
eshkol-vm-standalone-test=-
libeshkol-runtime.a=-
libeshkol-static.a=-
libeshkol-agent-ffi.a=-

--- fingerprint call 2 --- (after 50MB churn written+removed)
eshkol-run=0 1785424182
stdlib.o=0 1785424182
... (identical)

--- diff of two back-to-back calls ---
IDENTICAL
```

Clean, deterministic `size mtime` output, stable across calls regardless of
unrelated filesystem activity.

## Impact

This un-reds every Linux lite lane. Job conclusions on Linux have been
non-informative since the isolation guard from #367 merged — green test
output has been getting reported as a hard failure (exit 3) due to this
guard, not due to any actual test regression.
