### PR TITLE
fix(memory,ad): region escape must see every pointer-carrying tag — silent wrong gradients through loop-filled vectors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3053,6 +3053,39 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
             TIMEOUT 300
             PASS_REGULAR_EXPRESSION "PASS: field ops at list point match closed forms and vector point"
             FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
+    # Tape-retained AD nodes vs. per-iteration reclamation.
+    #
+    # ESH-0214e runs an escape-analysed loop body inside a nursery region that is
+    # arena_reset() at every TCO back edge. AD nodes created in the body were
+    # allocated from that nursery while the tape recording them lived outside it,
+    # so the reset recycled them and the next iteration reallocated at the same
+    # addresses — every earlier node's parents resolved to the FINAL iteration's
+    # subgraph. Reverse-mode gradients through a vector filled by vector-set! in
+    # a loop therefore returned the row for the last element written, for every
+    # element read, with exact primals and exit 0. Pins the minimal shape, a
+    # composed vector field against its closed-form Jacobian, and row-index
+    # sensitivity through a mutable selector, on both the JIT and AOT lanes.
+    add_test(
+        NAME tape_nursery_attribution_runtime_smoke
+        COMMAND $<TARGET_FILE:eshkol-run>
+                -r "${CMAKE_CURRENT_SOURCE_DIR}/tests/autodiff/tape_nursery_attribution_test.esk"
+                -L"${CMAKE_CURRENT_BINARY_DIR}"
+    )
+    set_tests_properties(tape_nursery_attribution_runtime_smoke
+        PROPERTIES
+            TIMEOUT 300
+            PASS_REGULAR_EXPRESSION "PASS: tape-retained AD nodes survive per-iteration reclamation"
+            FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
+    add_test(
+        NAME tape_nursery_attribution_aot_smoke
+        COMMAND sh -c
+            "'$<TARGET_FILE:eshkol-run>' -o '${CMAKE_CURRENT_BINARY_DIR}/tape_nursery_attribution_aot' '${CMAKE_CURRENT_SOURCE_DIR}/tests/autodiff/tape_nursery_attribution_test.esk' -L'${CMAKE_CURRENT_BINARY_DIR}' && '${CMAKE_CURRENT_BINARY_DIR}/tape_nursery_attribution_aot'"
+    )
+    set_tests_properties(tape_nursery_attribution_aot_smoke
+        PROPERTIES
+            TIMEOUT 300
+            PASS_REGULAR_EXPRESSION "PASS: tape-retained AD nodes survive per-iteration reclamation"
+            FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
     # Tensor-operand and checkpoint-resume hardening.
     #
     # (1) `embedding` reinterpreted its index/weight operands as tensors without

--- a/lib/core/arena_memory.h
+++ b/lib/core/arena_memory.h
@@ -274,6 +274,14 @@ bool eshkol_deep_equal(const eshkol_tagged_value_t* val1, const eshkol_tagged_va
 eshkol_dual_number_t* arena_allocate_dual_number(arena_t* arena);
 eshkol_dual_number_t* arena_allocate_dual_batch(arena_t* arena, size_t count);
 
+// The arena a tape-retained AD node must be allocated from: the recording
+// tape's owner_arena when a tape is live, else the caller's current arena.
+// An object the tape holds a pointer to lives exactly as long as the tape, so
+// the three allocators below route through this instead of trusting the
+// caller's (possibly nursery/region-scoped) arena. See the definition in
+// runtime_autodiff.cpp for the full invariant and the ESH-0214e interaction.
+arena_t* eshkol_ad_home_arena(arena_t* fallback);
+
 // AD node allocation for computational graphs
 ad_node_t* arena_allocate_ad_node(arena_t* arena);
 ad_node_t* arena_allocate_ad_node_with_header(arena_t* arena);  // For consolidated CALLABLE type

--- a/lib/core/runtime_autodiff.cpp
+++ b/lib/core/runtime_autodiff.cpp
@@ -330,8 +330,10 @@ eshkol_dual_number_t* arena_allocate_dual_batch(arena_t* arena, size_t count) {
  *                    any plausible tag (0..63).
  * @return 1 if @p bits is a live node in @p arena matching @p expect_type, else 0.
  */
-int eshkol_ad_node_probe(const arena_t* arena, uint64_t bits, int32_t expect_type) {
-    if (bits == 0 || !arena) return 0;
+/* Residency-then-tag test against ONE arena. Never dereferences a candidate the
+ * arena does not own (see eshkol_ad_node_probe's contract above). */
+static int ad_node_resident_in(const arena_t* arena, uint64_t bits, int32_t expect_type) {
+    if (!arena) return 0;
     /* A node allocated with an object header has that header 8 bytes below the
      * payload, so require room for both before touching anything. */
     const void* candidate = (const void*)(uintptr_t)bits;
@@ -346,7 +348,63 @@ int eshkol_ad_node_probe(const arena_t* arena, uint64_t bits, int32_t expect_typ
     return (expect_type < 0 || type == expect_type) ? 1 : 0;
 }
 
+int eshkol_ad_node_probe(const arena_t* arena, uint64_t bits, int32_t expect_type) {
+    if (bits == 0) return 0;
+    /* Probe the arena the recording tape's nodes actually live in FIRST (see
+     * eshkol_ad_home_arena): while a nursery/region is active, the caller's
+     * "current arena" is that nursery, but a tape-retained node is deliberately
+     * allocated OUTSIDE it. Probing only the caller's arena there would classify
+     * a live node pointer as an f64 bit pattern and silently drop the whole
+     * subgraph's gradient. Both candidates are residency-verified before any
+     * load, so checking two arenas is no weaker than checking one. */
+    const arena_t* home = eshkol_ad_home_arena((arena_t*)arena);
+    if (ad_node_resident_in(home, bits, expect_type)) return 1;
+    if (home != arena && ad_node_resident_in(arena, bits, expect_type)) return 1;
+    return 0;
+}
+
+/**
+ * @brief The arena a tape-retained AD node must be allocated from.
+ *
+ * INVARIANT (the tape-lifetime rule): an object the AD tape holds a pointer to
+ * lives exactly as long as the tape. `arena_tape_add_node` is a store into
+ * persistent state — the tape header and its `nodes` array, which live in
+ * `tape->owner_arena` — so a node allocated from a shorter-lived arena is a
+ * lifetime error AT THE POINT OF ALLOCATION, not something a later barrier can
+ * repair. #341 established this rule for the tape's pointer ARRAY (it grows from
+ * `owner_arena`); this closes the other half of it for the NODES.
+ *
+ * Concretely: ESH-0214e runs an escape-analysed loop body inside a nursery
+ * region and `arena_reset()`s that nursery at every TCO back edge. AD nodes
+ * created in the body were allocated from the nursery (generated code reads
+ * `__global_arena`, which region entry points at the nursery arena) while the
+ * tape recording them lived outside it. The tape append is not one of the six
+ * barriered mutation channels ESH-0214e's soundness argument enumerates, so
+ * nothing promoted those nodes out; the reset then recycled them and the next
+ * iteration reallocated at the same bump-pointer addresses. Every earlier node's
+ * `input1`/`input2` therefore resolved to the LAST iteration's subgraph, and a
+ * reverse sweep returned that iteration's row for every output component —
+ * silently, with correct primal values (a node's `value` is copied inline).
+ *
+ * Resolving through the recording tape keeps ESH-0214e's reclamation intact for
+ * the case it was built for: a `gradient` call made INSIDE the loop body creates
+ * its tape in the nursery too, so `owner_arena` IS the nursery and the whole
+ * differentiation is still reclaimed at the back edge.
+ *
+ * @param fallback The caller's current allocation arena, used when no tape is
+ *                 recording (forward-mode / non-AD allocation).
+ * @return `__current_ad_tape->owner_arena` when a tape is recording, else @p fallback.
+ */
+arena_t* eshkol_ad_home_arena(arena_t* fallback) {
+    const ad_tape_t* tape = __current_ad_tape;
+    if (tape && tape->owner_arena) return tape->owner_arena;
+    return fallback;
+}
+
 ad_node_t* arena_allocate_ad_node(arena_t* arena) {
+    /* Tape-lifetime rule: a tape-retained node never lives in a shorter-lived
+     * arena than the tape (see eshkol_ad_home_arena). */
+    arena = eshkol_ad_home_arena(arena);
     if (!arena) {
         eshkol_error("Cannot allocate AD node: null arena");
         return nullptr;
@@ -391,6 +449,9 @@ ad_node_t* arena_allocate_ad_node(arena_t* arena) {
  * @return      Pointer to the node payload (past the header), or nullptr on failure.
  */
 ad_node_t* arena_allocate_ad_node_with_header(arena_t* arena) {
+    /* Tape-lifetime rule: a tape-retained node never lives in a shorter-lived
+     * arena than the tape (see eshkol_ad_home_arena). */
+    arena = eshkol_ad_home_arena(arena);
     if (!arena) {
         eshkol_error("Cannot allocate AD node with header: null arena");
         return nullptr;
@@ -443,6 +504,9 @@ ad_node_t* arena_allocate_ad_node_with_header(arena_t* arena) {
  * @return      Pointer to the first element of the array, or nullptr on failure.
  */
 ad_node_t* arena_allocate_ad_batch(arena_t* arena, size_t count) {
+    /* Tape-lifetime rule: a tape-retained node never lives in a shorter-lived
+     * arena than the tape (see eshkol_ad_home_arena). */
+    arena = eshkol_ad_home_arena(arena);
     if (!arena || count == 0) {
         eshkol_error("Invalid parameters for batch AD node allocation");
         return nullptr;

--- a/lib/core/runtime_regions.cpp
+++ b/lib/core/runtime_regions.cpp
@@ -950,6 +950,73 @@ static void region_free_fwd_map(eshkol_region_t* region) {
     }
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// WHICH TAGS CARRY AN ARENA POINTER
+//
+// Every region escape path — the write barrier, the with-region result escape,
+// and the ESH-0214e nursery recycle — has to answer one question first: does
+// this tagged value hold a pointer into the region being reclaimed? It asked
+// ESHKOL_IS_ANY_PTR_TYPE, which enumerates the two CONSOLIDATED pointer tags
+// (HEAP_PTR / CALLABLE) plus ports. That set is NOT the set of pointer-carrying
+// tags.
+//
+// ESHKOL_VALUE_DUAL_NUMBER and ESHKOL_VALUE_COMPLEX sit in the 0-7 block that
+// eshkol_value_type_t labels "IMMEDIATE VALUES — data stored directly in tagged
+// value", but neither is an immediate: both put a POINTER in data.ptr_val,
+// aimed at a headerless 16-byte pair arena-allocated at the operation that
+// produced it (arena_allocate_dual_number; ComplexCodegen::packComplexToTagged).
+// Reading them as immediates made every escape path a silent no-op for them, so
+// a forward-mode dual or a complex number produced inside a region and stored
+// into a structure outside it kept a pointer into the arena about to be
+// recycled — and the next iteration reallocated the same address. The values
+// stayed dereferenceable and plausible, which is why this corrupted answers
+// instead of crashing.
+//
+// The arena-scope half of the same feature (eshkol_arena_iter_scope_end) got
+// this right by inverting the test: only PROVABLY pointer-free immediates
+// (NULL/INT64/DOUBLE/BOOL/CHAR, plus the eof-object) skip the pointer check.
+// These helpers bring the region half into line with that rule.
+//
+// Deliberately NOT included:
+//   SYMBOL (5)   — data.ptr_val is an interned symbol's stable text, owned by
+//                  the interning table rather than a region arena. Copying it
+//                  per escape would both be unnecessary and break the pointer
+//                  identity interning exists to provide.
+//   LOGIC_VAR(10)— data is a var_id integer, not a pointer.
+//   HANDLE/BUFFER/STREAM/EVENT (16-19) — linear resources whose payloads are
+//                  externally owned; duplicating one would duplicate the
+//                  resource. A region-resident one is reported below rather
+//                  than silently copied or silently dropped.
+// ───────────────────────────────────────────────────────────────────────────
+
+/* Byte size of the headerless, self-contained payload a pointer-carrying
+ * IMMEDIATE tag addresses, or 0 when the tag is not one of those. These cannot
+ * go through evac_object: it sizes and classifies an object from the
+ * eshkol_object_header_t 8 bytes below the payload, and these carry no header —
+ * those 8 bytes belong to whatever was allocated before them. A flat copy is
+ * complete for both (two doubles, no interior pointers), and neither has
+ * observable pointer identity, so copying cannot break eq?-style sharing the
+ * way copying an interned symbol would. */
+static size_t region_headerless_payload_size(uint8_t type) {
+    /* Exactness flags may be OR'd into a numeric tag; strip them before
+     * matching. The port flags share those bits but only ever ride on
+     * HEAP_PTR, which is not one of the values matched here. */
+    switch (type & (uint8_t)~(ESHKOL_VALUE_EXACT_FLAG | ESHKOL_VALUE_INEXACT_FLAG)) {
+        case ESHKOL_VALUE_DUAL_NUMBER: return sizeof(eshkol_dual_number_t);
+        case ESHKOL_VALUE_COMPLEX:     return 2 * sizeof(double);
+        default:                       return 0;
+    }
+}
+
+/* Does a value with this tag hold a pointer that a region reclaim could
+ * invalidate? The single predicate every escape path shares. */
+static bool region_value_carries_pointer(uint8_t type) {
+    const bool is_port = ((type & ESHKOL_PORT_ANY_FLAG) != 0) &&
+                         ((type & ESHKOL_VALUE_HEAP_PTR) == ESHKOL_VALUE_HEAP_PTR);
+    return ESHKOL_IS_ANY_PTR_TYPE(type) || is_port ||
+           region_headerless_payload_size(type) != 0;
+}
+
 // Classify an object (given its live original data pointer and the tagged value
 // referencing it) into an EvacKind. Ports are never deep-traversed (they wrap OS
 // resources / fds); they are leaf-copied with care so the escaped port struct is
@@ -969,6 +1036,34 @@ static EvacKind evac_kind_for(const eshkol_tagged_value_t& v, const void* old_da
         // LAMBDA_SEXPR / AD_NODE / PRIMITIVE / CONTINUATION: their interior
         // reference graph is not confidently traversable here and they almost
         // never escape a region via mutation. Kept shallow (documented).
+        //
+        // AD_NODE is the one where a shallow copy is not merely incomplete but
+        // SILENTLY WRONG: input1..input4 / tensor_value / saved_tensors / shape
+        // stay aimed into the dying arena while `value` copies inline, so the
+        // primal stays right and only the derivative is corrupted. Deep-walking
+        // it here cannot fix that either — the tape's nodes[] array still holds
+        // the ORIGINAL pointers, so the recorded evaluation order would refer to
+        // freed memory no matter how the graph is copied. The real invariant is
+        // upstream: a tape-retained node is allocated from the tape's own arena
+        // and is therefore never region-resident to begin with
+        // (eshkol_ad_home_arena, runtime_autodiff.cpp). This warning exists so
+        // that if a node with a live interior graph ever DOES reach the
+        // evacuator, it is reported in EVERY build rather than silently
+        // producing a plausible wrong gradient. Nodes with no inputs (variables
+        // and constants) are self-contained and copy correctly, so they stay
+        // quiet.
+        if (sub == CALLABLE_SUBTYPE_AD_NODE) {
+            const auto* n = (const ad_node_t*)old_data;
+            if (n->input1 || n->input2 || n->input3 || n->input4 ||
+                n->tensor_value || n->saved_tensors) {
+                eshkol_warn("region evacuate: an AD tape node with a live interior "
+                            "graph escaped a region as a shallow copy; its parents "
+                            "point into the arena being reclaimed and gradients "
+                            "through it would be wrong. This must not happen — a "
+                            "tape-retained node is allocated from the tape's own "
+                            "arena (eshkol_ad_home_arena).");
+            }
+        }
         return EVAC_LEAF;
     }
 
@@ -1101,14 +1196,19 @@ static void* evac_object(EvacState& st, void* old_data, const eshkol_tagged_valu
 // leave it untouched.
 static eshkol_tagged_value_t evac_value(EvacState& st, eshkol_tagged_value_t v) {
     const uint8_t type = v.type;
-    const bool is_port = ((type & ESHKOL_PORT_ANY_FLAG) != 0) &&
-                         ((type & ESHKOL_VALUE_HEAP_PTR) == ESHKOL_VALUE_HEAP_PTR);
-    const bool is_heap = ESHKOL_IS_ANY_PTR_TYPE(type) || is_port;
-    if (!is_heap) return v;
+    if (!region_value_carries_pointer(type)) return v;
 
     void* p = (void*)(uintptr_t)v.data.ptr_val;
     if (!p) return v;
     if (region_index_owning(p) <= st.boundary_idx) return v;  // stable relative to dst
+
+    // Headerless fixed-size payload (dual number / complex): a flat copy is the
+    // whole object. evac_raw forwards, so two tagged values sharing one payload
+    // still share it after promotion.
+    if (const size_t raw_size = region_headerless_payload_size(type)) {
+        v.data.ptr_val = (uint64_t)(uintptr_t)evac_raw(st, p, raw_size);
+        return v;
+    }
 
     void* np = evac_object(st, p, v);
     v.data.ptr_val = (uint64_t)(uintptr_t)np;
@@ -1498,12 +1598,7 @@ static eshkol_tagged_value_t region_evacuate_value(eshkol_tagged_value_t val,
  *            made), or @p val unchanged if escaping wasn't needed/possible.
  */
 static eshkol_tagged_value_t region_escape_tagged_value_impl(eshkol_tagged_value_t val) {
-    const uint8_t type = val.type;
-    const bool is_port = ((type & ESHKOL_PORT_ANY_FLAG) != 0) &&
-                         ((type & ESHKOL_VALUE_HEAP_PTR) == ESHKOL_VALUE_HEAP_PTR);
-    const bool is_heap = ESHKOL_IS_ANY_PTR_TYPE(type) || is_port;
-
-    if (!is_heap) return val;
+    if (!region_value_carries_pointer(val.type)) return val;
 
     eshkol_region_t* current = region_current();
     if (!current) return val;
@@ -1586,11 +1681,7 @@ extern "C" void eshkol_region_write_barrier_into(eshkol_tagged_value_t* out,
     // FAST PATH: no active region -> nothing can dangle.
     if (__region_stack_depth == 0) { *out = v; return; }
 
-    const uint8_t type = v.type;
-    const bool is_port = ((type & ESHKOL_PORT_ANY_FLAG) != 0) &&
-                         ((type & ESHKOL_VALUE_HEAP_PTR) == ESHKOL_VALUE_HEAP_PTR);
-    const bool is_heap = ESHKOL_IS_ANY_PTR_TYPE(type) || is_port;
-    if (!is_heap) { *out = v; return; }
+    if (!region_value_carries_pointer(v.type)) { *out = v; return; }
 
     void* vptr = (void*)(uintptr_t)v.data.ptr_val;
     if (!vptr) { *out = v; return; }

--- a/tests/autodiff/tape_nursery_attribution_test.esk
+++ b/tests/autodiff/tape_nursery_attribution_test.esk
@@ -1,0 +1,211 @@
+;; Regression: reverse-mode gradients through a vector filled by vector-set!
+;; inside a loop.
+;;
+;; A tape-retained AD node must live as long as the tape. It did not: an
+;; escape-analysed loop body runs inside an ESH-0214e nursery region that is
+;; arena_reset() at every TCO back edge, and generated code allocated AD nodes
+;; from the current arena — which region entry points at that nursery — while
+;; the tape recording them lived outside it. The tape append is not one of the
+;; barriered mutation channels ESH-0214e's soundness argument enumerates, so
+;; nothing promoted those nodes out; the reset recycled them and the next
+;; iteration reallocated at the same bump-pointer addresses. Every earlier
+;; node's parents therefore resolved to the FINAL iteration's subgraph.
+;;
+;; The failure was silent in the worst way: a node's `value` field copies
+;; inline, so every PRIMAL stayed exact and only the derivative moved. The
+;; gradient came back as the row for the last element written, for every
+;; element read — exit 0, empty stderr. A Jacobian assembled row-by-row was
+;; therefore uniform garbage while looking entirely plausible.
+;;
+;; Three properties are pinned here, all of them execution-backed:
+;;   A. the minimal shape — derivative lands in the component that was read;
+;;   B. a composed vector field (sphere projection) against its closed-form
+;;      Jacobian, so a sign or row swap cannot pass;
+;;   C. row-index sensitivity through a MUTABLE global selector, the idiom a
+;;      row-by-row Jacobian actually uses.
+;; Each group also asserts the primal, so a future regression that moves the
+;; value instead of the derivative is caught by the same file.
+
+(require stdlib)
+
+(define tests-passed 0)
+(define tests-failed 0)
+
+(define (approx-equal? a b epsilon)
+  (< (abs (- a b)) epsilon))
+
+(define (check name expected actual)
+  (if (approx-equal? expected actual 1e-9)
+      (begin
+        (set! tests-passed (+ tests-passed 1))
+        (display "PASS: ") (display name) (newline))
+      (begin
+        (set! tests-failed (+ tests-failed 1))
+        (display "FAIL: ") (display name)
+        (display " (expected ") (display expected)
+        (display ", got ") (display actual) (display ")") (newline))))
+
+;; ---------------------------------------------------------------------------
+;; A. Minimal shape: allocate a vector inside f, fill it with vector-set! in a
+;;    loop, select one component. Distinct per-component scale factors make a
+;;    collapsed attribution impossible to mistake for a correct answer: with
+;;    out_i = v_i * (i+1), row i is e_i * (i+1), so every row differs in BOTH
+;;    position and magnitude.
+;; ---------------------------------------------------------------------------
+
+(define (scale-by-index v)
+  (let* ((n (vector-length v))
+         (o (make-vector n 0.0)))
+    (let loop ((i 0))
+      (if (< i n)
+          (begin
+            (vector-set! o i (* (vector-ref v i) (+ i 1.0)))
+            (loop (+ i 1)))))
+    o))
+
+(define pt3 (vector 1.0 2.0 3.0))
+
+;; primal first: out = (1*1, 2*2, 3*3)
+(define prim3 (scale-by-index pt3))
+(check "A primal out_0" 1.0 (vector-ref prim3 0))
+(check "A primal out_1" 4.0 (vector-ref prim3 1))
+(check "A primal out_2" 9.0 (vector-ref prim3 2))
+
+(define gA0 (gradient (lambda (v) (vector-ref (scale-by-index v) 0)) pt3))
+(define gA1 (gradient (lambda (v) (vector-ref (scale-by-index v) 1)) pt3))
+(define gA2 (gradient (lambda (v) (vector-ref (scale-by-index v) 2)) pt3))
+
+(check "A row0 d out_0/d v_0" 1.0 (vector-ref gA0 0))
+(check "A row0 d out_0/d v_1" 0.0 (vector-ref gA0 1))
+(check "A row0 d out_0/d v_2" 0.0 (vector-ref gA0 2))
+(check "A row1 d out_1/d v_0" 0.0 (vector-ref gA1 0))
+(check "A row1 d out_1/d v_1" 2.0 (vector-ref gA1 1))
+(check "A row1 d out_1/d v_2" 0.0 (vector-ref gA1 2))
+(check "A row2 d out_2/d v_0" 0.0 (vector-ref gA2 0))
+(check "A row2 d out_2/d v_1" 0.0 (vector-ref gA2 1))
+(check "A row2 d out_2/d v_2" 3.0 (vector-ref gA2 2))
+
+;; The historical 6-line reproducer, verbatim in shape: a uniform scale, where
+;; the wrong answer #(0 3) and the right answer #(3 0) hold the SAME multiset of
+;; numbers. Only the position distinguishes them.
+(define (vscale v s)
+  (let* ((n (vector-length v))
+         (o (make-vector n 0.0)))
+    (let loop ((i 0))
+      (if (< i n)
+          (begin
+            (vector-set! o i (* (vector-ref v i) s))
+            (loop (+ i 1)))))
+    o))
+
+(define gU (gradient (lambda (v) (vector-ref (vscale v 3.0) 0)) (vector 0.6 -0.8)))
+(check "A uniform-scale row0 component 0" 3.0 (vector-ref gU 0))
+(check "A uniform-scale row0 component 1" 0.0 (vector-ref gU 1))
+
+;; A reverse-order fill makes the LAST element written index 0, so a
+;; last-write-wins attribution fails here in the mirror direction.
+(define (scale-by-index-reverse v)
+  (let* ((n (vector-length v))
+         (o (make-vector n 0.0)))
+    (let loop ((i (- n 1)))
+      (if (>= i 0)
+          (begin
+            (vector-set! o i (* (vector-ref v i) (+ i 1.0)))
+            (loop (- i 1)))))
+    o))
+
+(define gR2 (gradient (lambda (v) (vector-ref (scale-by-index-reverse v) 2)) pt3))
+(check "A reverse-fill row2 component 0" 0.0 (vector-ref gR2 0))
+(check "A reverse-fill row2 component 1" 0.0 (vector-ref gR2 1))
+(check "A reverse-fill row2 component 2" 3.0 (vector-ref gR2 2))
+
+;; Two reads of the same loop-built vector must accumulate as two DIFFERENT
+;; components, not twice the same one.
+(define gS (gradient (lambda (v) (+ (vector-ref (vscale v 3.0) 0)
+                                    (vector-ref (vscale v 3.0) 1)))
+                     (vector 0.6 -0.8)))
+(check "A sum-of-two-reads component 0" 3.0 (vector-ref gS 0))
+(check "A sum-of-two-reads component 1" 3.0 (vector-ref gS 1))
+
+;; ---------------------------------------------------------------------------
+;; B. Composed vector field: sphere projection of a fixed g at a point x,
+;;      out_i = g_i - <g,x> x_i
+;;    with closed-form Jacobian
+;;      d out_i / d x_j = -(g_j x_i) - <g,x> delta_ij.
+;;    At x = (0.6, -0.8), g = (1.0, 2.0):  <g,x> = -1.0
+;;      out = (1.6, 1.2),  J = [[0.4, -1.2], [0.8, 2.6]]
+;;    Both rows are dense and the two rows are not multiples of each other, so
+;;    neither a row swap nor a sign flip can pass.
+;; ---------------------------------------------------------------------------
+
+(define (dot a b)
+  (let ((n (vector-length a)))
+    (let loop ((i 0) (s 0.0))
+      (if (< i n)
+          (loop (+ i 1) (+ s (* (vector-ref a i) (vector-ref b i))))
+          s))))
+
+(define gvec (vector 1.0 2.0))
+
+(define (sphere-project x)
+  (let* ((n (vector-length x))
+         (d (dot gvec x))
+         (o (make-vector n 0.0)))
+    (let loop ((i 0))
+      (if (< i n)
+          (begin
+            (vector-set! o i (- (vector-ref gvec i) (* d (vector-ref x i))))
+            (loop (+ i 1)))))
+    o))
+
+(define xpt (vector 0.6 -0.8))
+
+(define primB (sphere-project xpt))
+(check "B primal out_0" 1.6 (vector-ref primB 0))
+(check "B primal out_1" 1.2 (vector-ref primB 1))
+
+(define jrow0 (gradient (lambda (x) (vector-ref (sphere-project x) 0)) xpt))
+(define jrow1 (gradient (lambda (x) (vector-ref (sphere-project x) 1)) xpt))
+
+(check "B J[0][0]"  0.4 (vector-ref jrow0 0))
+(check "B J[0][1]" -1.2 (vector-ref jrow0 1))
+(check "B J[1][0]"  0.8 (vector-ref jrow1 0))
+(check "B J[1][1]"  2.6 (vector-ref jrow1 1))
+
+;; ---------------------------------------------------------------------------
+;; C. Row-index sensitivity through a MUTABLE global selector — the shape a
+;;    row-by-row Jacobian assembly actually has. Under the defect the gradient
+;;    was insensitive to the selector, so every row came back identical; here
+;;    each row must equal the row group B computed with a literal index.
+;; ---------------------------------------------------------------------------
+
+(define sel 0)
+
+(define (row-of-sphere x) (vector-ref (sphere-project x) sel))
+
+(set! sel 0)
+(define mrow0 (gradient row-of-sphere xpt))
+(set! sel 1)
+(define mrow1 (gradient row-of-sphere xpt))
+
+(check "C mutable-selector row0 [0]"  0.4 (vector-ref mrow0 0))
+(check "C mutable-selector row0 [1]" -1.2 (vector-ref mrow0 1))
+(check "C mutable-selector row1 [0]"  0.8 (vector-ref mrow1 0))
+(check "C mutable-selector row1 [1]"  2.6 (vector-ref mrow1 1))
+
+;; The two rows must actually differ — an insensitive selector would make the
+;; four checks above pass only if both rows happened to be right, but pinning
+;; the difference states the property directly.
+(check "C rows differ in component 0"
+       -0.4 (- (vector-ref mrow0 0) (vector-ref mrow1 0)))
+(check "C rows differ in component 1"
+       -3.8 (- (vector-ref mrow0 1) (vector-ref mrow1 1)))
+
+;; ---------------------------------------------------------------------------
+(newline)
+(display "tape_nursery_attribution: ")
+(display tests-passed) (display " passed, ")
+(display tests-failed) (display " failed") (newline)
+(if (= tests-failed 0)
+    (display "PASS: tape-retained AD nodes survive per-iteration reclamation\n")
+    (display "RESULT: FAILURES\n"))


### PR DESCRIPTION
## Summary

`(gradient f x)` returned a wrong gradient, silently, whenever `f` filled a
vector with `vector-set!` inside a loop and then selected a component. The
derivative was attributed to the LAST element written, for every element read.
Primal values stayed exact, the compiler exited 0 and stderr was empty, so a
Jacobian assembled row-by-row — the standard idiom — came out uniform garbage
while looking entirely plausible.

Minimal reproducer, no tensors and no geometry:

```scheme
(define (vscale v s)
  (let* ((n (vector-length v)) (o (make-vector n 0.0)))
    (let loop ((i 0))
      (if (< i n) (begin (vector-set! o i (* (vector-ref v i) s)) (loop (+ i 1)))))
    o))
(gradient (lambda (v) (vector-ref (vscale v 3.0) 0)) (vector 0.6 -0.8))
;; before: #(0 3)        after: #(3 0)
```

## Bisect

`git bisect` over the 94 commits between `7d01530c` (good) and `14c50d73` (bad),
one build per step, driven by the reproducer above:

```
7d01530c => #(3 0)   good
631d593d => #(3 0)   good
ea1a5956 => #(0 3)   bad
c9527c86 => #(3 0)   good
6e2215ed => #(0 3)   bad
b8760278 => #(3 0)   good
010053c8 => #(0 3)   bad
9d67e9f1 => #(3 0)   good
first bad commit: 010053c8  "iter-scope partial reclamation — evacuate
                             barrier-recorded escapees, then reset (ESH-0214e)"
```

`ESHKOL_NO_ITER_SCOPE=1` makes every failing case correct on an unpatched
build, which confirms the bisect independently.

## Root cause

ESH-0214e admits `vector-set!` and four sibling mutators into the
iteration-scope analysis and lowers such a loop into a NURSERY REGION that is
`arena_reset()` at every TCO back edge. Its soundness argument is explicit: each
admitted mutator's codegen unconditionally runs `eshkol_region_write_barrier_into`
on the store, so anything the iteration allocated and published to persistent
state is promoted out of the nursery before the reset.

The barrier never fired.

It decides whether a value holds a pointer into the dying region with
`ESHKOL_IS_ANY_PTR_TYPE`, which enumerates the two CONSOLIDATED pointer tags
(`HEAP_PTR` / `CALLABLE`) plus ports. That is not the set of tags that actually
carry a pointer. A forward-mode dual number is tagged `ESHKOL_VALUE_DUAL_NUMBER`,
which sits inside the block `eshkol_value_type_t` labels *"IMMEDIATE VALUES —
data stored directly in tagged value"* — but it is not an immediate:
`data.ptr_val` addresses a headerless 16-byte `{value, derivative}` pair
allocated from the current arena, which inside the loop is the nursery arena.

Classified as an immediate, it was passed through untouched. `arena_reset()`
then recycled the payload and the next iteration reallocated the same address.
Instrumenting the barrier shows both iterations of the reproducer storing
`type=6` at one identical pointer:

```
[barrier] depth=1 type=6 ptr=0x140478000 dst=0x34008f068
[barrier] depth=1 type=6 ptr=0x140478000 dst=0x34008ef48
```

Every slot of the output vector therefore ends up aimed at the final iteration's
dual — which is exactly the observed "last element written wins". The primal
survived because the value word sits right there in the recycled pair; only the
tangent moved. That is why this was silent.

Three predictions of the mechanism, all confirmed before the fix was written:
a reverse-order fill moves the wrong answer to row 0; a 3-element point makes
every row come back as row 2; and summing two reads of the same loop-built
vector yields twice one row instead of the sum of two.

## The fix

**1. Align the region half of the feature with the arena-scope half.**
`eshkol_arena_iter_scope_end` had this right all along: only *provably*
pointer-free immediates (NULL/INT64/DOUBLE/BOOL/CHAR, plus the eof-object) skip
the pointer check; everything else is treated as potentially pointer-carrying.
One shared predicate now answers the question for the write barrier, the
`with-region` result escape, and the nursery recycle. `evac_value` gives the
headerless fixed-size payloads (dual number, complex) a flat forwarded copy —
they cannot go through `evac_object`, which sizes an object from a header these
do not have. Interned symbols, logic vars and the linear resource handles are
deliberately excluded, with the reasoning recorded at the predicate.

**2. A tape-retained AD node lives in the tape's arena.** This is an independent
violation of the same rule that the evacuator cannot repair. A reverse-mode tape
node IS a `CALLABLE`, so the barrier does see it, but `evac_kind_for` leaf-copies
it and its `input1..input4` keep pointing into the arena being reclaimed. Deep
walking would not help either: the tape's own `nodes[]` array still holds the
originals, so the recorded evaluation order would refer to freed memory no matter
how the graph is copied. The lifetime error is at the allocation — an object the
tape retains lives exactly as long as the tape — so the three AD node allocators
now resolve their arena through the recording tape's `owner_arena`, completing
the rule #341 established for the tape's pointer array. `eshkol_ad_node_probe`
resolves the same way, so residency is tested against the arena the nodes are
actually in. ESH-0214e reclamation is unaffected for the case it was built for:
a gradient taken INSIDE the loop body creates its tape in the nursery too, so
`owner_arena` IS the nursery and the whole differentiation is still reclaimed at
the back edge.

**3. No silent leaf copies of live AD graphs.** `evac_kind_for` now reports, in
every build, any AD node with a live interior graph that still reaches the
evacuator, so this class cannot go silent again.

## Before / after

| case | before | after | exact |
|---|---|---|---|
| minimal reproducer, read component 0 | `#(0 3)` | `#(3 0)` | `#(3 0)` |
| 3-element, read component 0 / 1 / 2 | `#(0 0 3)` for all three | `#(1 0 0)`, `#(0 2 0)`, `#(0 0 3)` | same |
| reverse-order fill, read component 2 | `#(1 0)` | `#(0 2)` | `#(0 2)` |
| sum of two reads of one loop-built vector | `#(0 6)` | `#(3 3)` | `#(3 3)` |
| sphere projection Jacobian row 0 / row 1 | rows identical | `#(0.4 -1.2)`, `#(0.8 2.6)` | same |
| row index in a mutable global | insensitive to the index | tracks the index | — |

## Tests

`tests/autodiff/tape_nursery_attribution_test.esk` pins the minimal shape, a
composed vector field against its closed-form Jacobian
(`d out_i/d x_j = -(g_j x_i) - <g,x> delta_ij`, whose two rows are neither
multiples nor permutations of each other, so a sign flip or row swap cannot
pass), and row-index sensitivity through a mutable selector. Every group asserts
the primal too, so a future regression that moves the value instead of the
derivative is caught by the same file.

It runs in CI two ways: `scripts/run_autodiff_tests.sh` globs `tests/autodiff/`
and is part of `run_all_tests.sh` on the core matrix lanes, and it is registered
as an explicit ctest on both the JIT and the AOT lane.

Retro-catch: 15 of its 31 checks pass at the pre-fix SHA, 31/31 after.

## Verification

| suite | result |
|---|---|
| `ctest` (full) | 109/109 |
| `scripts/run_autodiff_tests.sh` | 59/59 |
| `scripts/run_ad_oracle.sh` | 60/60, gate PASS |
| `scripts/run_ad_adversarial.sh` | 46/46, gate PASS |
| `scripts/run_ad_depth.sh` | gate PASS, 0 regressions, 39 cells x 2 lanes |
| `scripts/run_vm_parity.sh` | 104/104 |
| `scripts/run_ml_tests.sh` | 43/43 |
| `scripts/run_v1_2_edge_cases_tests.sh` | 99/99 |
| new regression test, JIT and AOT | 31/31 each |

ICC on `eshkol-v134-release`: `guard-liveness` clean (no dead guard tokens);
`impact-analysis` over the three changed files reports 816 impacted symbols
across 67 paths, which the suites above cover.

## Downstream

The qLLM geometric-primitive oracle gate goes from 4/10 to 10/10 with this fix
applied. That gate re-runs each exporter and self-checks every AD value against
an in-language central finite difference, so it is a real correctness check, not
a comparison against stored vectors. Its committed golden JSON was produced with
the defective build and differs from what the fixed build now exports, so those
vectors need regenerating on top of this change.
