### PR TITLE
fix(ad): emit the runtime-closure gradient arity spread once, out of line — unblocks the Windows lanes on #383 and makes the arity-32 ceiling real

### DIFF
--- a/inc/eshkol/backend/autodiff_codegen.h
+++ b/inc/eshkol/backend/autodiff_codegen.h
@@ -906,6 +906,26 @@ public:
         closure_call_callback_ = callback;
     }
 
+    /** Runtime-closure arity spread for gradients.
+     *
+     * Calls a runtime closure with its own declared number of scalar arguments,
+     * taken from a gradient's dual-element array; arity 0/1 and the variadic
+     * sentinel get the whole point as one vector argument, and an arity above
+     * the supported ceiling raises. The dispatch is emitted once per module,
+     * out of line (getOrCreateGradSpreadHelper in llvm_codegen.cpp) — inlining
+     * one fully expanded closure call per arity at every gradient site cost
+     * ~1.03M lines of stdlib IR and pushed Windows compiles over the CI budget.
+     *
+     * Arguments: (closure, whole-point vector, dual-element array, declared
+     * arity, context).
+     */
+    using GradientSpreadCallCallback = llvm::Value* (*)(llvm::Value*, llvm::Value*,
+                                                        llvm::Value*, llvm::Value*, void*);
+    /** Set the out-of-line gradient arity-spread callback. */
+    void setGradientSpreadCallCallback(GradientSpreadCallCallback callback) {
+        gradient_spread_call_callback_ = callback;
+    }
+
     /** Function arity table — maps function name to parameter count */
     void setFunctionArityTable(std::unordered_map<std::string, uint64_t>* table) {
         function_arity_table_ = table;
@@ -975,6 +995,7 @@ private:
     int derivative_ho_counter_ = 0;
     void* binding_opaque_ = nullptr;
     ClosureCallCallback closure_call_callback_ = nullptr;
+    GradientSpreadCallCallback gradient_spread_call_callback_ = nullptr;
     std::unordered_map<std::string, uint64_t>* function_arity_table_ = nullptr;
     std::unordered_map<std::string, const eshkol_ast_t*>* function_body_ast_ = nullptr;
     std::unordered_map<std::string, const eshkol_ast_t*>* function_def_ast_ = nullptr;

--- a/lib/backend/autodiff_codegen.cpp
+++ b/lib/backend/autodiff_codegen.cpp
@@ -4903,95 +4903,37 @@ llvm::Value* AutodiffCodegen::emitRuntimeClosureGradient(llvm::Value* closure_va
                     ctx_.builder().CreateLoad(ctx_.int8Type(), clo_arity_ptr), ctx_.int64Type());
 
                 /* Arity of a RUNTIME closure is only known at run time, so the
-                 * spread is a switch with one call site per arity. The ceiling
-                 * was 8, and arity 9+ fell into the vectorized default: an
-                 * arity-12 loss reached through a wrapper (e.g.
-                 * (define (gwrap f p) (gradient f p))) was called with ONE
-                 * vector argument, so it produced nothing at all while the
-                 * same loss called directly by name was correct. Raised to 32,
-                 * and anything above it now raises a named error instead of
-                 * silently taking the vector path — see gcall_too_many below. */
-                const int GRAD_MAX_ARITY = 32;
-                /* Sentinel the closure ABI uses for a variadic callable; it
-                 * legitimately wants the vectorized single-argument form. */
-                const uint64_t GRAD_VARIADIC_ARITY = 255;
-                BasicBlock* gcall_default = BasicBlock::Create(ctx_.context(), "grad_call_vec", current_func);
-                BasicBlock* gcall_merge = BasicBlock::Create(ctx_.context(), "grad_call_merge", current_func);
+                 * point has to be spread into that many scalar arguments by a
+                 * dispatch on the arity. The ceiling was 8, and arity 9+ fell
+                 * into the vectorized default: an arity-12 loss reached through
+                 * a wrapper (e.g. (define (gwrap f p) (gradient f p))) was
+                 * called with ONE vector argument, so it produced nothing at all
+                 * while the same loss called directly by name was correct. The
+                 * ceiling is now GRAD_MAX_ARITY (32) and anything above it
+                 * raises a named error instead of silently taking the vector
+                 * path.
+                 *
+                 * The dispatch itself is emitted ONCE PER MODULE, out of line —
+                 * getOrCreateGradSpreadHelper() in llvm_codegen.cpp, which also
+                 * documents why: inlining one fully expanded closure call per
+                 * arity here cost ~1.03M lines of stdlib IR across the six
+                 * gradient sites (2.7x the whole stdlib) and, because Windows
+                 * cannot discard weak_any stdlib definitions, +92s of opt/llc on
+                 * every user compile. The helper owns the ceiling, the raise and
+                 * the arity-0/1/variadic vector form. */
+                if (!gradient_spread_call_callback_) {
+                    eshkol_error("gradient: runtime-closure arity spread helper not configured");
+                    return nullptr;
+                }
                 // ESH-0093: the callee body runs one forward level deeper
                 adPertLevelStore(ctx_.builder().CreateAdd(rt_pert_level,
                     ConstantInt::get(ctx_.int64Type(), 1)));
-                SwitchInst* gcall_sw = ctx_.builder().CreateSwitch(clo_arity, gcall_default, GRAD_MAX_ARITY);
-
-                std::vector<std::pair<BasicBlock*, Value*>> gcall_variants;
-                for (int k = 1; k <= GRAD_MAX_ARITY; k++) {
-                    BasicBlock* case_bb = BasicBlock::Create(ctx_.context(),
-                        "grad_call_a" + std::to_string(k), current_func);
-                    gcall_sw->addCase(ConstantInt::get(ctx_.int64Type(), k), case_bb);
-                    ctx_.builder().SetInsertPoint(case_bb);
-                    std::vector<Value*> cargs;
-                    if (k == 1) {
-                        cargs.push_back(dual_vec_tagged);  // vectorized single-arg function
-                    } else {
-                        for (int j = 0; j < k; j++) {
-                            Value* ep = ctx_.builder().CreateGEP(ctx_.taggedValueType(), dual_elems_typed,
-                                ConstantInt::get(ctx_.int64Type(), j));
-                            cargs.push_back(ctx_.builder().CreateLoad(ctx_.taggedValueType(), ep));
-                        }
-                    }
-                    Value* r = closure_call_callback_(closure_val, cargs, "autodiff", callback_context_);
-                    BasicBlock* cexit = ctx_.builder().GetInsertBlock();  // closure call may add blocks
-                    ctx_.builder().CreateBr(gcall_merge);
-                    gcall_variants.push_back({cexit, r});
+                Value* call_result = gradient_spread_call_callback_(closure_val, dual_vec_tagged,
+                    dual_elems_typed, clo_arity, callback_context_);
+                if (!call_result) {
+                    eshkol_error("gradient: failed to call runtime closure");
+                    return nullptr;
                 }
-                // Default: arity 0 (unreadable), variadic, or above the spread
-                // ceiling. The first two legitimately want the vectorized
-                // single-argument form; the third is a real limit and says so
-                // rather than quietly mis-calling the loss.
-                ctx_.builder().SetInsertPoint(gcall_default);
-                BasicBlock* gcall_vec = BasicBlock::Create(ctx_.context(), "grad_call_vec_ok", current_func);
-                BasicBlock* gcall_too_many = BasicBlock::Create(ctx_.context(), "grad_call_arity_over", current_func);
-                Value* over_ceiling = ctx_.builder().CreateAnd(
-                    ctx_.builder().CreateICmpUGT(clo_arity,
-                        ConstantInt::get(ctx_.int64Type(), GRAD_MAX_ARITY)),
-                    ctx_.builder().CreateICmpNE(clo_arity,
-                        ConstantInt::get(ctx_.int64Type(), GRAD_VARIADIC_ARITY)));
-                ctx_.builder().CreateCondBr(over_ceiling, gcall_too_many, gcall_vec);
-
-                ctx_.builder().SetInsertPoint(gcall_too_many);
-                {
-                    llvm::Function* arity_err_fn =
-                        ctx_.module().getFunction("eshkol_type_error_with_operand");
-                    if (!arity_err_fn) {
-                        llvm::FunctionType* ft = llvm::FunctionType::get(
-                            ctx_.builder().getVoidTy(),
-                            {ctx_.builder().getPtrTy(), ctx_.builder().getPtrTy(),
-                             ctx_.builder().getPtrTy()}, false);
-                        arity_err_fn = llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
-                            "eshkol_type_error_with_operand", &ctx_.module());
-                        arity_err_fn->setDoesNotReturn();
-                    }
-                    Value* slot = ctx_.builder().CreateAlloca(ctx_.taggedValueType(), nullptr,
-                                                              "grad_arity_err_slot");
-                    ctx_.builder().CreateStore(closure_val, slot);
-                    Value* proc = ctx_.builder().CreateGlobalString("gradient", "grad_arity_proc");
-                    Value* expected = ctx_.builder().CreateGlobalString(
-                        "callable whose argument count is at most 32 (a loss with more "
-                        "coordinates must take its point as one vector argument)",
-                        "grad_arity_expected");
-                    ctx_.builder().CreateCall(arity_err_fn, {proc, expected, slot});
-                    ctx_.builder().CreateUnreachable();
-                }
-
-                ctx_.builder().SetInsertPoint(gcall_vec);
-                Value* gdef_r = closure_call_callback_(closure_val,
-                    std::vector<Value*>{dual_vec_tagged}, "autodiff", callback_context_);
-                BasicBlock* gdef_exit = ctx_.builder().GetInsertBlock();
-                ctx_.builder().CreateBr(gcall_merge);
-                gcall_variants.push_back({gdef_exit, gdef_r});
-
-                ctx_.builder().SetInsertPoint(gcall_merge);
-                PHINode* call_result = ctx_.builder().CreatePHI(ctx_.taggedValueType(), gcall_variants.size());
-                for (auto& cv : gcall_variants) call_result->addIncoming(cv.second, cv.first);
 
                 // ESH-0093: pop the perturbation level
                 adPertLevelStore(rt_pert_level);

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -1367,6 +1367,9 @@ namespace ControlFlowCallbacks {
     static llvm::Value* codegenLambdaWrapper(const eshkol_operations_t* op, void* context);
     static llvm::Value* closureCallWrapper(llvm::Value* closure, const std::vector<llvm::Value*>& args, void* context);
     static llvm::Value* closureCallWithInfoWrapper(llvm::Value* closure, const std::vector<llvm::Value*>& args, const char* info, void* context);
+    static llvm::Value* gradientSpreadCallWrapper(llvm::Value* closure, llvm::Value* point_vector,
+                                                  llvm::Value* dual_elems, llvm::Value* declared_arity,
+                                                  void* context);
     static llvm::Function* getClosureAllocWrapper(void* context);
     static llvm::Function* getConsSetPtrWrapper(void* context);
     static llvm::Value* resolveLambdaWrapper(const eshkol_ast_t* ast, size_t arity, void* context);
@@ -1415,6 +1418,9 @@ class EshkolLLVMCodeGen {
     friend llvm::Value* ControlFlowCallbacks::applyBuiltinWrapper(const std::string& func_name, const std::vector<llvm::Value*>& args, llvm::Value* arg_count, void* context);
     friend llvm::Value* ControlFlowCallbacks::applyForwardRefWrapper(const std::string& func_name, llvm::Value* list_int, void* context);
     friend llvm::Value* ControlFlowCallbacks::closureCallWithInfoWrapper(llvm::Value* closure, const std::vector<llvm::Value*>& args, const char* info, void* context);
+    friend llvm::Value* ControlFlowCallbacks::gradientSpreadCallWrapper(llvm::Value* closure, llvm::Value* point_vector,
+                                                                        llvm::Value* dual_elems, llvm::Value* declared_arity,
+                                                                        void* context);
     friend llvm::Function* ControlFlowCallbacks::getClosureAllocWrapper(void* context);
 
 private:
@@ -4342,6 +4348,7 @@ private:
         autodiff_->setResolveLambdaCallback(ControlFlowCallbacks::resolveLambdaWrapper);
         // Calculus extraction: wire closure call, arity table, captures, closure alloc
         autodiff_->setClosureCallCallback(ControlFlowCallbacks::closureCallWithInfoWrapper);
+        autodiff_->setGradientSpreadCallCallback(ControlFlowCallbacks::gradientSpreadCallWrapper);
         autodiff_->setFunctionArityTable(&function_arity_table);
         autodiff_->setFunctionBodyAstTable(&function_body_ast);
         autodiff_->setFunctionDefAstTable(&function_def_ast);
@@ -7667,14 +7674,72 @@ private:
         return packPtrToTaggedValue(param_ptr, ESHKOL_VALUE_HEAP_PTR);
     }
 
+    /* Argument source for a RUNTIME-COUNTED closure call (see codegenClosureCall).
+     *
+     * Normally a call site knows statically how many arguments it passes, so
+     * `call_args` carries them. A caller that only learns the count at run time
+     * — the AD gradient spreading a point into a runtime closure's declared
+     * number of scalar parameters — instead hands over a staging array plus the
+     * runtime count. The dispatcher already switches on a runtime argument
+     * count (it has to: `fixed_params` comes from the closure), so this mode
+     * reuses that one switch instead of making the caller emit a separate,
+     * fully expanded closure call per possible arity.
+     *
+     * Contract for the caller:
+     *   - `args_ptr` points to `width` contiguous tagged_value slots,
+     *   - slots [0, count) hold the live arguments,
+     *   - slots [count, width) are initialised to tagged null (they are loaded
+     *     unconditionally, and are what the arity-mismatch padding reads),
+     *   - `count` is already clamped to [0, width].
+     */
+    struct ClosureSpreadArgs {
+        Value* args_ptr = nullptr;
+        Value* count = nullptr;
+        int width = 0;
+    };
+
     // Runtime closure call dispatcher - supports variadic closures with up to 16 captures
     // This is essential for N-dimensional lambda calculus and AD operations
     Value* codegenClosureCall(Value* func_result, const std::vector<Value*>& call_args,
                               const char* caller_info = "unknown",
-                              bool parameter_dispatch = true) {
+                              bool parameter_dispatch = true,
+                              const ClosureSpreadArgs* spread = nullptr) {
         func_result = ensureTaggedValue(func_result);
         Function* current_func = builder->GetInsertBlock()->getParent();
         BasicBlock* merge_bb = BasicBlock::Create(*context, "call_merge", current_func);
+
+        // Spread mode: the arguments live in the caller's staging array rather
+        // than in call_args, and the count is a runtime value. Load every slot
+        // once here, in the block that dominates both the variadic and the
+        // non-variadic dispatch, so each arm can share them (the static path
+        // hoists its padded-array loads for the same reason).
+        ArrayType* spread_args_type = spread
+            ? ArrayType::get(tagged_value_type, spread->width) : nullptr;
+        std::vector<Value*> spread_arg_vals;
+        Value* spread_count = nullptr;
+        if (spread) {
+            spread_arg_vals.reserve((size_t)spread->width);
+            for (int i = 0; i < spread->width; i++) {
+                spread_arg_vals.push_back(builder->CreateLoad(tagged_value_type,
+                    builder->CreateGEP(spread_args_type, spread->args_ptr,
+                        {ConstantInt::get(int64_type, 0), ConstantInt::get(int64_type, i)}),
+                    "spread_arg"));
+            }
+            // Re-clamp here rather than trusting the caller: this value feeds
+            // both dispatches, and neither may select an arm that does not exist.
+            spread_count = builder->CreateSelect(
+                builder->CreateICmpUGT(spread->count,
+                    ConstantInt::get(int64_type, spread->width)),
+                ConstantInt::get(int64_type, spread->width), spread->count,
+                "spread_count");
+        }
+        // A spread call always carries at least one argument (the caller routes
+        // the zero-argument case to a static call), so the "no arguments" forms
+        // below stay bound to the static path.
+        const bool have_first_arg = spread ? true : !call_args.empty();
+        auto firstArg = [&]() -> Value* {
+            return spread ? spread_arg_vals[0] : call_args[0];
+        };
 
         // A parameter object is both a heap object and a procedure.  Dispatch
         // it before the ordinary closure path so it never gets interpreted as
@@ -7693,11 +7758,11 @@ private:
             Value* parameter_bits = unpackInt64FromTaggedValue(func_result);
             Value* parameter_ptr = builder->CreateIntToPtr(parameter_bits, ptr_type,
                                                            "call_parameter_handle");
-            if (call_args.empty()) {
+            if (!have_first_arg) {
                 parameter_result = codegenParameterRef(parameter_ptr);
             } else {
                 Value* converted = codegenParameterConverterFor(
-                    parameter_ptr, call_args[0], "parameter-procedure-converter");
+                    parameter_ptr, firstArg(), "parameter-procedure-converter");
                 parameter_result = codegenParameterSet(parameter_ptr, converted);
             }
             builder->CreateBr(merge_bb);
@@ -7766,7 +7831,7 @@ private:
                 ConstantInt::get(
                     int64_type,
                     offsetof(eshkol_continuation_state_t, value)));
-            Value* invoke_value = call_args.empty() ? packNullToTaggedValue() : call_args[0];
+            Value* invoke_value = have_first_arg ? firstArg() : packNullToTaggedValue();
             builder->CreateStore(invoke_value, value_slot);
 
             // Unwind dynamic-wind stack before longjmp
@@ -7852,7 +7917,17 @@ private:
         // If so, we need to handle all arguments with polymorphic arithmetic instead of
         // using the fixed-arity function stored in the closure
         // Only do this check if we have arguments (skip for empty arg calls)
-        if (!call_args.empty()) {
+        //
+        // Spread mode skips this fold, and that is a value-preserving skip, not
+        // a dropped case. The fold exists so a 2-ary builtin closure can absorb
+        // MORE than two arguments (`(fold + …)`); with exactly two it computes
+        // polymorphicOp(a, b), which is verbatim the body of the function the
+        // closure points at (createBuiltinArithmeticFunction emits
+        // `builtin_<op>_2arg(a, b) = polymorphicOp(a, b)`), so calling through
+        // the pointer gives the identical value. Those four closures are arity
+        // 2, and a spread arm is only entered when the closure's declared arity
+        // equals the arm, so no other arm can be one of them.
+        if (!spread && !call_args.empty()) {
             Function* builtin_add = createBuiltinArithmeticFunction("+", 2);
             Function* builtin_sub = createBuiltinArithmeticFunction("-", 2);
             Function* builtin_mul = createBuiltinArithmeticFunction("*", 2);
@@ -8091,6 +8166,19 @@ private:
             arg_ptrs.push_back(builder->CreateAlloca(tagged_value_type, nullptr, "var_arg_ptr"));
             rest_ptrs.push_back(builder->CreateAlloca(tagged_value_type, nullptr, "var_rest_ptr"));
         }
+        // Spread mode builds the rest list with a runtime loop instead of an
+        // unrolled chain, so it needs one car slot, one accumulator and one
+        // index rather than a slot pair per static argument.
+        Value* spread_car_slot = nullptr;
+        Value* spread_rest_slot = nullptr;
+        Value* spread_rest_acc = nullptr;
+        Value* spread_rest_idx = nullptr;
+        if (spread) {
+            spread_car_slot = builder->CreateAlloca(tagged_value_type, nullptr, "var_spread_car");
+            spread_rest_slot = builder->CreateAlloca(tagged_value_type, nullptr, "var_spread_cdr");
+            spread_rest_acc = builder->CreateAlloca(tagged_value_type, nullptr, "var_spread_rest");
+            spread_rest_idx = builder->CreateAlloca(int64_type, nullptr, "var_spread_i");
+        }
 
         // Restore insertion point
         builder->restoreIP(saved_ip);
@@ -8102,8 +8190,63 @@ private:
         // list is built once per fixed-arity arm, then specialize only the
         // final call by capture count.
         const int MAX_VARIADIC_FIXED_LIMIT = 16;
-        const int max_variadic_fixed =
-            std::min<int>(MAX_VARIADIC_FIXED_LIMIT, (int)call_args.size());
+        const int max_variadic_fixed = std::min<int>(MAX_VARIADIC_FIXED_LIMIT,
+            spread ? spread->width : (int)call_args.size());
+
+        /* Spread mode: build the rest list ONCE, with a runtime loop bounded
+         * below by the runtime `fixed_params`, instead of an unrolled cons chain
+         * per fixed-arity arm. Arm f is reached only when fixed_params == f, so
+         * a list consed from slots [fixed_params, count) is exactly the list
+         * that arm's unrolled chain would have produced — same elements, same
+         * order, built back to front the same way. Emitting it once is also what
+         * keeps the arm count from multiplying the cons chains: the unrolled
+         * form costs O(width²) cons sites per call.
+         */
+        Value* spread_rest_list = nullptr;
+        if (spread) {
+            Value* null_rest = packPtrToTaggedValue(
+                ConstantInt::get(int64_type, 0), ESHKOL_VALUE_NULL);
+            builder->CreateStore(null_rest, spread_rest_acc);
+            builder->CreateStore(
+                builder->CreateSub(spread_count, ConstantInt::get(int64_type, 1)),
+                spread_rest_idx);
+
+            BasicBlock* rest_cond = BasicBlock::Create(*context, "var_spread_rest_cond", current_func);
+            BasicBlock* rest_body = BasicBlock::Create(*context, "var_spread_rest_body", current_func);
+            BasicBlock* rest_done = BasicBlock::Create(*context, "var_spread_rest_done", current_func);
+            builder->CreateBr(rest_cond);
+
+            builder->SetInsertPoint(rest_cond);
+            Value* rest_i = builder->CreateLoad(int64_type, spread_rest_idx);
+            // Signed: the index walks down to fixed_params - 1, and count may be 0.
+            builder->CreateCondBr(builder->CreateICmpSGE(rest_i, fixed_params),
+                                  rest_body, rest_done);
+
+            builder->SetInsertPoint(rest_body);
+            Value* rest_arena = builder->CreateLoad(PointerType::getUnqual(*context), global_arena);
+            Value* rest_cons = builder->CreateCall(getArenaAllocateConsWithHeaderFunc(), {rest_arena});
+            Value* rest_elem = builder->CreateLoad(tagged_value_type,
+                builder->CreateGEP(spread_args_type, spread->args_ptr,
+                    {ConstantInt::get(int64_type, 0), rest_i}));
+            builder->CreateStore(rest_elem, spread_car_slot);
+            builder->CreateCall(getTaggedConsSetTaggedValueFunc(),
+                {rest_cons, ConstantInt::get(int1_type, 0), spread_car_slot});
+            builder->CreateStore(builder->CreateLoad(tagged_value_type, spread_rest_acc),
+                                 spread_rest_slot);
+            builder->CreateCall(getTaggedConsSetTaggedValueFunc(),
+                {rest_cons, ConstantInt::get(int1_type, 1), spread_rest_slot});
+            builder->CreateStore(
+                packPtrToTaggedValue(builder->CreatePtrToInt(rest_cons, int64_type),
+                                     ESHKOL_VALUE_HEAP_PTR),
+                spread_rest_acc);
+            builder->CreateStore(builder->CreateSub(rest_i, ConstantInt::get(int64_type, 1)),
+                                 spread_rest_idx);
+            builder->CreateBr(rest_cond);
+
+            builder->SetInsertPoint(rest_done);
+            spread_rest_list = builder->CreateLoad(tagged_value_type, spread_rest_acc,
+                                                   "var_spread_rest_list");
+        }
         // Hoist the capture-slot GEPs once (loop-invariant across every
         // fixed-arity arm; each over-provisions the same MAX capture pointers).
         // Recomputing them per arm would be O(fixed · MAX_CAP) GEPs and inflate
@@ -8127,22 +8270,25 @@ private:
             var_fixed_sw->addCase(ConstantInt::get(int64_type, fixed_count), fixed_bb);
             builder->SetInsertPoint(fixed_bb);
 
-            Value* rest_list = packPtrToTaggedValue(
-                ConstantInt::get(int64_type, 0), ESHKOL_VALUE_NULL);
-            for (int64_t i = (int64_t)call_args.size() - 1; i >= fixed_count; i--) {
-                Value* arena_ptr = builder->CreateLoad(PointerType::getUnqual(*context), global_arena);
-                Value* cons_cell = builder->CreateCall(getArenaAllocateConsWithHeaderFunc(), {arena_ptr});
+            Value* rest_list = spread_rest_list;
+            if (!spread) {
+                rest_list = packPtrToTaggedValue(
+                    ConstantInt::get(int64_type, 0), ESHKOL_VALUE_NULL);
+                for (int64_t i = (int64_t)call_args.size() - 1; i >= fixed_count; i--) {
+                    Value* arena_ptr = builder->CreateLoad(PointerType::getUnqual(*context), global_arena);
+                    Value* cons_cell = builder->CreateCall(getArenaAllocateConsWithHeaderFunc(), {arena_ptr});
 
-                builder->CreateStore(call_args[(size_t)i], arg_ptrs[(size_t)i]);
-                builder->CreateCall(getTaggedConsSetTaggedValueFunc(),
-                    {cons_cell, ConstantInt::get(int1_type, 0), arg_ptrs[(size_t)i]});
+                    builder->CreateStore(call_args[(size_t)i], arg_ptrs[(size_t)i]);
+                    builder->CreateCall(getTaggedConsSetTaggedValueFunc(),
+                        {cons_cell, ConstantInt::get(int1_type, 0), arg_ptrs[(size_t)i]});
 
-                builder->CreateStore(rest_list, rest_ptrs[(size_t)i]);
-                builder->CreateCall(getTaggedConsSetTaggedValueFunc(),
-                    {cons_cell, ConstantInt::get(int1_type, 1), rest_ptrs[(size_t)i]});
+                    builder->CreateStore(rest_list, rest_ptrs[(size_t)i]);
+                    builder->CreateCall(getTaggedConsSetTaggedValueFunc(),
+                        {cons_cell, ConstantInt::get(int1_type, 1), rest_ptrs[(size_t)i]});
 
-                Value* cons_int = builder->CreatePtrToInt(cons_cell, int64_type);
-                rest_list = packPtrToTaggedValue(cons_int, ESHKOL_VALUE_HEAP_PTR);
+                    Value* cons_int = builder->CreatePtrToInt(cons_cell, int64_type);
+                    rest_list = packPtrToTaggedValue(cons_int, ESHKOL_VALUE_HEAP_PTR);
+                }
             }
 
             // OVER-PROVISION captures (see the non-variadic switch comment):
@@ -8150,7 +8296,11 @@ private:
             // N. No per-capture switch, so one call per fixed-arity arm.
             std::vector<Value*> full_args;
             for (int i = 0; i < fixed_count; i++) {
-                if ((size_t)i < call_args.size()) {
+                if (spread) {
+                    // Slots at or beyond the runtime count hold tagged null,
+                    // which is the same padding the static path emits below.
+                    full_args.push_back(spread_arg_vals[(size_t)i]);
+                } else if ((size_t)i < call_args.size()) {
                     full_args.push_back(call_args[(size_t)i]);
                 } else {
                     full_args.push_back(packPtrToTaggedValue(
@@ -8199,35 +8349,49 @@ private:
         // preserves the existing partial-application/Y-combinator padding path
         // without emitting the full 16x32 worst-case matrix at every call site.
         const int MAX_CALL_ARGS_LIMIT = 16;
-        const int max_call_args = std::min<int>(
-            MAX_CALL_ARGS_LIMIT,
-            std::max<int>((int)call_args.size(), 4));
-        IRBuilderBase::InsertPoint saved_ip_nonvar = builder->saveIP();
-        builder->SetInsertPoint(&entry_block, entry_block.begin());
-
-        // Alloca array for padded arguments
+        // Spread mode dispatches over the caller's staging width, so its arms
+        // cover every arity the caller can pass — the static cushion below is
+        // for call sites whose argument count is fixed.
+        const int max_call_args = spread
+            ? spread->width
+            : std::min<int>(MAX_CALL_ARGS_LIMIT,
+                            std::max<int>((int)call_args.size(), 4));
         ArrayType* padded_args_type = ArrayType::get(tagged_value_type, max_call_args);
-        Value* padded_args_array = builder->CreateAlloca(padded_args_type, nullptr, "padded_args");
+        Value* padded_args_array = nullptr;
+        if (spread) {
+            // The caller already provided the array, already padded with tagged
+            // null past the live count.
+            padded_args_array = spread->args_ptr;
+        } else {
+            IRBuilderBase::InsertPoint saved_ip_nonvar = builder->saveIP();
+            builder->SetInsertPoint(&entry_block, entry_block.begin());
 
-        builder->restoreIP(saved_ip_nonvar);
+            // Alloca array for padded arguments
+            padded_args_array = builder->CreateAlloca(padded_args_type, nullptr, "padded_args");
 
-        // Store actual call_args into array
-        for (size_t i = 0; i < call_args.size() && i < (size_t)max_call_args; i++) {
-            Value* slot_ptr = builder->CreateGEP(padded_args_type, padded_args_array,
-                {ConstantInt::get(int64_type, 0), ConstantInt::get(int64_type, i)});
-            builder->CreateStore(call_args[i], slot_ptr);
+            builder->restoreIP(saved_ip_nonvar);
+
+            // Store actual call_args into array
+            for (size_t i = 0; i < call_args.size() && i < (size_t)max_call_args; i++) {
+                Value* slot_ptr = builder->CreateGEP(padded_args_type, padded_args_array,
+                    {ConstantInt::get(int64_type, 0), ConstantInt::get(int64_type, i)});
+                builder->CreateStore(call_args[i], slot_ptr);
+            }
+
+            // Fill remaining slots with undefined (null) values for arity mismatch handling
+            Value* undef_val = packNullToTaggedValue();
+            for (size_t i = call_args.size(); i < (size_t)max_call_args; i++) {
+                Value* slot_ptr = builder->CreateGEP(padded_args_type, padded_args_array,
+                    {ConstantInt::get(int64_type, 0), ConstantInt::get(int64_type, i)});
+                builder->CreateStore(undef_val, slot_ptr);
+            }
         }
 
-        // Fill remaining slots with undefined (null) values for arity mismatch handling
-        Value* undef_val = packNullToTaggedValue();
-        for (size_t i = call_args.size(); i < (size_t)max_call_args; i++) {
-            Value* slot_ptr = builder->CreateGEP(padded_args_type, padded_args_array,
-                {ConstantInt::get(int64_type, 0), ConstantInt::get(int64_type, i)});
-            builder->CreateStore(undef_val, slot_ptr);
-        }
-
-        // Determine actual arg count to use: max(call_args.size(), fixed_params)
-        Value* call_args_count = ConstantInt::get(int64_type, call_args.size());
+        // Determine actual arg count to use: max(argument count, fixed_params).
+        // Spread mode's argument count is a runtime value; everything downstream
+        // already treats this as one.
+        Value* call_args_count = spread
+            ? spread_count : ConstantInt::get(int64_type, call_args.size());
         Value* use_fixed = builder->CreateICmpUGT(fixed_params, call_args_count);
         Value* actual_arg_count = builder->CreateSelect(use_fixed, fixed_params, call_args_count,
             "actual_arg_count");
@@ -8247,11 +8411,17 @@ private:
         // dominates all arm blocks) and let the arms share them — O(MAX_ARGS +
         // MAX_CAP).
         std::vector<Value*> hoisted_arg_vals;
-        hoisted_arg_vals.reserve((size_t)max_call_args);
-        for (int i = 0; i < max_call_args; i++) {
-            Value* arg_ptr = builder->CreateGEP(padded_args_type, padded_args_array,
-                {ConstantInt::get(int64_type, 0), ConstantInt::get(int64_type, i)});
-            hoisted_arg_vals.push_back(builder->CreateLoad(tagged_value_type, arg_ptr));
+        if (spread) {
+            // Already loaded once, before the variadic split, so both dispatches
+            // share them.
+            hoisted_arg_vals = spread_arg_vals;
+        } else {
+            hoisted_arg_vals.reserve((size_t)max_call_args);
+            for (int i = 0; i < max_call_args; i++) {
+                Value* arg_ptr = builder->CreateGEP(padded_args_type, padded_args_array,
+                    {ConstantInt::get(int64_type, 0), ConstantInt::get(int64_type, i)});
+                hoisted_arg_vals.push_back(builder->CreateLoad(tagged_value_type, arg_ptr));
+            }
         }
         std::vector<Value*> hoisted_cap_ptrs;
         hoisted_cap_ptrs.reserve((size_t)MAX_CLOSURE_DISPATCH_CAPTURES);
@@ -8360,22 +8530,53 @@ private:
         Value* direct_func_ptr_i64 = unpackInt64FromTaggedValue(func_result);
         Value* direct_func_ptr = builder->CreateIntToPtr(direct_func_ptr_i64, PointerType::getUnqual(*context));
 
-        std::vector<Type*> direct_param_types(call_args.size(), tagged_value_type);
-        FunctionType* direct_func_type = FunctionType::get(tagged_value_type, direct_param_types, false);
+        // A raw function pointer has no closure metadata to read, so the call
+        // shape is the argument count itself: static here, and in spread mode a
+        // runtime count, which needs the same one-arm-per-count dispatch as the
+        // closure path above.
+        std::vector<std::pair<BasicBlock*, Value*>> direct_results;
+        if (spread) {
+            BasicBlock* direct_default = BasicBlock::Create(*context, "do_direct_default", current_func);
+            SwitchInst* direct_sw = builder->CreateSwitch(spread_count, direct_default,
+                max_call_args + 1);
+            for (int arg_count = 0; arg_count <= max_call_args; arg_count++) {
+                BasicBlock* arm = BasicBlock::Create(*context,
+                    "do_direct_args_" + std::to_string(arg_count), current_func);
+                direct_sw->addCase(ConstantInt::get(int64_type, arg_count), arm);
+                builder->SetInsertPoint(arm);
+                std::vector<Value*> direct_args(spread_arg_vals.begin(),
+                                                spread_arg_vals.begin() + arg_count);
+                std::vector<Type*> direct_types((size_t)arg_count, tagged_value_type);
+                Value* r = builder->CreateCall(
+                    FunctionType::get(tagged_value_type, direct_types, false),
+                    direct_func_ptr, direct_args);
+                builder->CreateBr(merge_bb);
+                direct_results.push_back({builder->GetInsertBlock(), r});
+            }
+            builder->SetInsertPoint(direct_default);
+            direct_results.push_back({direct_default, packNullToTaggedValue()});
+            builder->CreateBr(merge_bb);
+        } else {
+            std::vector<Type*> direct_param_types(call_args.size(), tagged_value_type);
+            FunctionType* direct_func_type = FunctionType::get(tagged_value_type, direct_param_types, false);
 
-        Value* direct_result = builder->CreateCall(direct_func_type, direct_func_ptr, call_args);
-        builder->CreateBr(merge_bb);
-        BasicBlock* direct_exit_bb = builder->GetInsertBlock();
+            Value* direct_result = builder->CreateCall(direct_func_type, direct_func_ptr, call_args);
+            builder->CreateBr(merge_bb);
+            direct_results.push_back({builder->GetInsertBlock(), direct_result});
+        }
 
         // MERGE: PHI node to select result from all paths
         builder->SetInsertPoint(merge_bb);
         PHINode* phi = builder->CreatePHI(tagged_value_type,
-                                          results.size() + (parameter_dispatch ? 3 : 2),
+                                          results.size() + direct_results.size()
+                                              + (parameter_dispatch ? 2 : 1),
                                           "call_result");
         for (auto& [bb, val] : results) {
             phi->addIncoming(val, bb);
         }
-        phi->addIncoming(direct_result, direct_exit_bb);
+        for (auto& [bb, val] : direct_results) {
+            phi->addIncoming(val, bb);
+        }
         phi->addIncoming(as_is_result, as_is_exit_bb);
         if (parameter_dispatch) {
             phi->addIncoming(ensureTaggedValue(parameter_result), parameter_exit_bb);
@@ -8384,6 +8585,174 @@ private:
         return phi;
     }
 
+    /* ================= runtime-closure arity spread (AD gradient) =============
+     *
+     * A gradient of a RUNTIME closure has to call that closure with its own
+     * declared number of scalar arguments, and that number is only known at run
+     * time. GRAD_MAX_ARITY is the supported ceiling; above it the call raises a
+     * named error instead of quietly taking the single-vector path (which would
+     * leave the loss's remaining parameters uninitialised — the silent wrong
+     * answer that raising the ceiling from 8 fixed).
+     *
+     * The dispatch is emitted ONCE PER MODULE, out of line, and every gradient
+     * site calls it. It used to be inlined at each site as a switch with one
+     * fully expanded closure call per arity, whose per-arity cost grows with the
+     * arity (n-ary arithmetic fold, unrolled variadic rest-list chain). With the
+     * ceiling at 32 and six gradient sites in the standard library that came to
+     * ~1.03M lines of IR — 2.7x the entire stdlib (585,967 -> 1,561,902 lines,
+     * stdlib.bc 6.65MB -> 19.76MB). Platforms that emit stdlib definitions
+     * `linkonce_odr` discard the unused ones early; Windows/COFF emits them
+     * `weak_any` (see sexprGlobalLinkage), which cannot be discarded, so every
+     * user compile ran opt and llc over all of it: measured LLVM work per
+     * compile went 25.4s -> 117.7s and every GPU/XLA test hit the harness's 120s
+     * compile budget.
+     *
+     * Out of line the arity dispatch happens once, and it is the closure
+     * dispatcher's OWN runtime argument-count switch (ClosureSpreadArgs) rather
+     * than a second, per-arity one layered on top. Raising the ceiling now costs
+     * one more arm in one function instead of 24 fully expanded calls at every
+     * gradient site.
+     */
+    static constexpr int GRAD_MAX_ARITY = 32;
+    /* Sentinel the closure ABI uses for a variadic callable; it legitimately
+     * wants the vectorized single-argument form. */
+    static constexpr uint64_t GRAD_VARIADIC_ARITY = 255;
+
+    Function* getOrCreateGradSpreadHelper() {
+        const char* helper_name = "__eshkol_ad_gradient_spread_call";
+        if (Function* existing = module->getFunction(helper_name)) {
+            return existing;
+        }
+
+        // (closure, whole-point vector, dual-element array, declared arity)
+        FunctionType* helper_type = FunctionType::get(
+            tagged_value_type,
+            {tagged_value_type, tagged_value_type, PointerType::getUnqual(*context), int64_type},
+            false);
+        // Module-local: the only callers are this module's gradient sites, so it
+        // never needs to be a discardable-or-not linkonce/weak definition.
+        Function* helper = Function::Create(helper_type, Function::InternalLinkage,
+                                           helper_name, module.get());
+        Value* closure_arg = helper->getArg(0);
+        Value* vector_arg = helper->getArg(1);
+        Value* elems_arg = helper->getArg(2);
+        Value* arity_arg = helper->getArg(3);
+        closure_arg->setName("closure");
+        vector_arg->setName("point_vector");
+        elems_arg->setName("dual_elems");
+        arity_arg->setName("declared_arity");
+
+        IRBuilderBase::InsertPoint saved = builder->saveIP();
+        BasicBlock* entry = BasicBlock::Create(*context, "entry", helper);
+        builder->SetInsertPoint(entry);
+
+        ArrayType* args_type = ArrayType::get(tagged_value_type, GRAD_MAX_ARITY);
+        Value* args_array = builder->CreateAlloca(args_type, nullptr, "grad_spread_args");
+        Value* null_tagged = packNullToTaggedValue();
+        for (int i = 0; i < GRAD_MAX_ARITY; i++) {
+            builder->CreateStore(null_tagged, builder->CreateGEP(args_type, args_array,
+                {ConstantInt::get(int64_type, 0), ConstantInt::get(int64_type, i)}));
+        }
+
+        BasicBlock* over_bb = BasicBlock::Create(*context, "grad_arity_over", helper);
+        BasicBlock* within_bb = BasicBlock::Create(*context, "grad_arity_ok", helper);
+        BasicBlock* vector_bb = BasicBlock::Create(*context, "grad_call_vector", helper);
+        BasicBlock* spread_bb = BasicBlock::Create(*context, "grad_call_spread", helper);
+        BasicBlock* done_bb = BasicBlock::Create(*context, "grad_call_done", helper);
+
+        Value* over_ceiling = builder->CreateAnd(
+            builder->CreateICmpUGT(arity_arg, ConstantInt::get(int64_type, GRAD_MAX_ARITY)),
+            builder->CreateICmpNE(arity_arg, ConstantInt::get(int64_type, GRAD_VARIADIC_ARITY)));
+        builder->CreateCondBr(over_ceiling, over_bb, within_bb);
+
+        builder->SetInsertPoint(over_bb);
+        {
+            Function* arity_err_fn = module->getFunction("eshkol_type_error_with_operand");
+            if (!arity_err_fn) {
+                FunctionType* ft = FunctionType::get(builder->getVoidTy(),
+                    {builder->getPtrTy(), builder->getPtrTy(), builder->getPtrTy()}, false);
+                arity_err_fn = Function::Create(ft, Function::ExternalLinkage,
+                    "eshkol_type_error_with_operand", module.get());
+                arity_err_fn->setDoesNotReturn();
+            }
+            Value* slot = builder->CreateAlloca(tagged_value_type, nullptr, "grad_arity_err_slot");
+            builder->CreateStore(closure_arg, slot);
+            Value* proc = builder->CreateGlobalString("gradient", "grad_arity_proc");
+            Value* expected = builder->CreateGlobalString(
+                "callable whose argument count is at most "
+                + std::to_string(GRAD_MAX_ARITY)
+                + " (a loss with more coordinates must take its point as one "
+                  "vector argument)",
+                "grad_arity_expected");
+            builder->CreateCall(arity_err_fn, {proc, expected, slot});
+            builder->CreateUnreachable();
+        }
+
+        // Arity 1 is the vectorized single-argument loss; arity 0 (unreadable)
+        // and the variadic sentinel legitimately want that same form.
+        builder->SetInsertPoint(within_bb);
+        Value* wants_vector = builder->CreateOr(
+            builder->CreateICmpULE(arity_arg, ConstantInt::get(int64_type, 1)),
+            builder->CreateICmpEQ(arity_arg, ConstantInt::get(int64_type, GRAD_VARIADIC_ARITY)));
+        builder->CreateCondBr(wants_vector, vector_bb, spread_bb);
+
+        builder->SetInsertPoint(vector_bb);
+        Value* vector_result = ensureTaggedValue(codegenClosureCall(closure_arg,
+            std::vector<Value*>{vector_arg}, "autodiff"));
+        BasicBlock* vector_exit = builder->GetInsertBlock();
+        builder->CreateBr(done_bb);
+
+        // Arity 2..GRAD_MAX_ARITY: stage that many dual elements and let the
+        // closure dispatcher spread them (see ClosureSpreadArgs).
+        builder->SetInsertPoint(spread_bb);
+        Value* copy_idx = builder->CreateAlloca(int64_type, nullptr, "grad_spread_i");
+        builder->CreateStore(ConstantInt::get(int64_type, 0), copy_idx);
+        BasicBlock* copy_cond = BasicBlock::Create(*context, "grad_spread_copy_cond", helper);
+        BasicBlock* copy_body = BasicBlock::Create(*context, "grad_spread_copy_body", helper);
+        BasicBlock* copy_done = BasicBlock::Create(*context, "grad_spread_copy_done", helper);
+        builder->CreateBr(copy_cond);
+
+        builder->SetInsertPoint(copy_cond);
+        Value* ci = builder->CreateLoad(int64_type, copy_idx);
+        builder->CreateCondBr(builder->CreateICmpULT(ci, arity_arg), copy_body, copy_done);
+
+        builder->SetInsertPoint(copy_body);
+        // Reads exactly the elements the inlined per-arity cases read: the
+        // dual vector's slots [0, arity).
+        Value* src = builder->CreateLoad(tagged_value_type,
+            builder->CreateGEP(tagged_value_type, elems_arg, ci));
+        builder->CreateStore(src, builder->CreateGEP(args_type, args_array,
+            {ConstantInt::get(int64_type, 0), ci}));
+        builder->CreateStore(builder->CreateAdd(ci, ConstantInt::get(int64_type, 1)), copy_idx);
+        builder->CreateBr(copy_cond);
+
+        builder->SetInsertPoint(copy_done);
+        ClosureSpreadArgs spread_args;
+        spread_args.args_ptr = args_array;
+        spread_args.count = arity_arg;
+        spread_args.width = GRAD_MAX_ARITY;
+        Value* spread_result = ensureTaggedValue(codegenClosureCall(closure_arg,
+            std::vector<Value*>{}, "autodiff", true, &spread_args));
+        BasicBlock* spread_exit = builder->GetInsertBlock();
+        builder->CreateBr(done_bb);
+
+        builder->SetInsertPoint(done_bb);
+        PHINode* result = builder->CreatePHI(tagged_value_type, 2, "grad_call_result");
+        result->addIncoming(vector_result, vector_exit);
+        result->addIncoming(spread_result, spread_exit);
+        builder->CreateRet(result);
+
+        if (saved.isSet()) builder->restoreIP(saved);
+        return helper;
+    }
+
+    Value* codegenGradientSpreadCall(Value* closure_val, Value* point_vector,
+                                     Value* dual_elems, Value* declared_arity) {
+        Function* helper = getOrCreateGradSpreadHelper();
+        return builder->CreateCall(helper, {ensureTaggedValue(closure_val),
+                                            ensureTaggedValue(point_vector),
+                                            dual_elems, declared_arity});
+    }
 
     // MIGRATED: Delegates to TaggedValueCodegen
     Value* getTaggedValueType(Value* tagged_val) {
@@ -39182,6 +39551,13 @@ namespace ControlFlowCallbacks {
     llvm::Value* closureCallWithInfoWrapper(llvm::Value* closure, const std::vector<llvm::Value*>& args, const char* info, void* context) {
         auto* codegen = static_cast<EshkolLLVMCodeGen*>(context);
         return codegen->codegenClosureCall(closure, args, info);
+    }
+
+    llvm::Value* gradientSpreadCallWrapper(llvm::Value* closure, llvm::Value* point_vector,
+                                           llvm::Value* dual_elems, llvm::Value* declared_arity,
+                                           void* context) {
+        auto* codegen = static_cast<EshkolLLVMCodeGen*>(context);
+        return codegen->codegenGradientSpreadCall(closure, point_vector, dual_elems, declared_arity);
     }
 
     llvm::Function* getClosureAllocWrapper(void* context) {

--- a/tests/autodiff/runtime_closure_arity_spread_test.esk
+++ b/tests/autodiff/runtime_closure_arity_spread_test.esk
@@ -1,0 +1,130 @@
+; Runtime-closure gradient: the arity spread, across the whole supported range.
+;
+; A loss reached as a VALUE (through a wrapper, a parameter, a variable) has no
+; compile-time arity, so the gradient has to call it with its declared number of
+; scalar arguments decided at run time. That dispatch is emitted once per module,
+; out of line (getOrCreateGradSpreadHelper in lib/backend/llvm_codegen.cpp);
+; before it existed the spread was inlined per gradient site as one fully
+; expanded closure call per arity, and only arities up to the closure
+; dispatcher's static argument arm count actually worked:
+;
+;   arity 17-32, no captures -> SIGSEGV
+;   arity 17-31, captured    -> SILENT all-zero gradient
+;   arity 32,    captured    -> "Type error in *: ... got pair"
+;
+; each of which the declared ceiling of 32 claimed was supported. This file
+; pins the claim: f(x) = sum_i (i+1) x_i^2 has grad_i = 2(i+1) x_i, so at
+; x_i = 1 every index is its own witness (2, 4, 6, ...), and a wrong or dropped
+; argument shows up as a specific wrong number rather than a plausible one.
+
+(define (gwrap f p) (gradient f p))
+
+(define (check name got want)
+  (display (if (< (abs (- got want)) 1e-9) "PASS" "FAIL"))
+  (display ": ") (display name)
+  (display " expected ") (display want)
+  (display " got ") (display got)
+  (newline))
+
+; --- plain closures, arity 2 .. 32 (the spread's whole range) ---
+(define (loss2 x0 x1) (+ (* 1 (* x0 x0)) (* 2 (* x1 x1))))
+(define g2 (gwrap loss2 (list 1.0 1.0)))
+(check "arity 2: length" (vector-length g2) 2)
+(check "arity 2: grad[0]" (vector-ref g2 0) 2.0)
+(check "arity 2: grad[1]" (vector-ref g2 1) 4.0)
+(define (loss3 x0 x1 x2) (+ (* 1 (* x0 x0)) (* 2 (* x1 x1)) (* 3 (* x2 x2))))
+(define g3 (gwrap loss3 (list 1.0 1.0 1.0)))
+(check "arity 3: length" (vector-length g3) 3)
+(check "arity 3: grad[0]" (vector-ref g3 0) 2.0)
+(check "arity 3: grad[2]" (vector-ref g3 2) 6.0)
+(define (loss8 x0 x1 x2 x3 x4 x5 x6 x7) (+ (* 1 (* x0 x0)) (* 2 (* x1 x1)) (* 3 (* x2 x2)) (* 4 (* x3 x3)) (* 5 (* x4 x4)) (* 6 (* x5 x5)) (* 7 (* x6 x6)) (* 8 (* x7 x7))))
+(define g8 (gwrap loss8 (list 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0)))
+(check "arity 8: length" (vector-length g8) 8)
+(check "arity 8: grad[0]" (vector-ref g8 0) 2.0)
+(check "arity 8: grad[7]" (vector-ref g8 7) 16.0)
+(define (loss9 x0 x1 x2 x3 x4 x5 x6 x7 x8) (+ (* 1 (* x0 x0)) (* 2 (* x1 x1)) (* 3 (* x2 x2)) (* 4 (* x3 x3)) (* 5 (* x4 x4)) (* 6 (* x5 x5)) (* 7 (* x6 x6)) (* 8 (* x7 x7)) (* 9 (* x8 x8))))
+(define g9 (gwrap loss9 (list 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0)))
+(check "arity 9: length" (vector-length g9) 9)
+(check "arity 9: grad[0]" (vector-ref g9 0) 2.0)
+(check "arity 9: grad[8]" (vector-ref g9 8) 18.0)
+(define (loss12 x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11) (+ (* 1 (* x0 x0)) (* 2 (* x1 x1)) (* 3 (* x2 x2)) (* 4 (* x3 x3)) (* 5 (* x4 x4)) (* 6 (* x5 x5)) (* 7 (* x6 x6)) (* 8 (* x7 x7)) (* 9 (* x8 x8)) (* 10 (* x9 x9)) (* 11 (* x10 x10)) (* 12 (* x11 x11))))
+(define g12 (gwrap loss12 (list 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0)))
+(check "arity 12: length" (vector-length g12) 12)
+(check "arity 12: grad[0]" (vector-ref g12 0) 2.0)
+(check "arity 12: grad[11]" (vector-ref g12 11) 24.0)
+(define (loss16 x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15) (+ (* 1 (* x0 x0)) (* 2 (* x1 x1)) (* 3 (* x2 x2)) (* 4 (* x3 x3)) (* 5 (* x4 x4)) (* 6 (* x5 x5)) (* 7 (* x6 x6)) (* 8 (* x7 x7)) (* 9 (* x8 x8)) (* 10 (* x9 x9)) (* 11 (* x10 x10)) (* 12 (* x11 x11)) (* 13 (* x12 x12)) (* 14 (* x13 x13)) (* 15 (* x14 x14)) (* 16 (* x15 x15))))
+(define g16 (gwrap loss16 (list 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0)))
+(check "arity 16: length" (vector-length g16) 16)
+(check "arity 16: grad[0]" (vector-ref g16 0) 2.0)
+(check "arity 16: grad[15]" (vector-ref g16 15) 32.0)
+(define (loss17 x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16) (+ (* 1 (* x0 x0)) (* 2 (* x1 x1)) (* 3 (* x2 x2)) (* 4 (* x3 x3)) (* 5 (* x4 x4)) (* 6 (* x5 x5)) (* 7 (* x6 x6)) (* 8 (* x7 x7)) (* 9 (* x8 x8)) (* 10 (* x9 x9)) (* 11 (* x10 x10)) (* 12 (* x11 x11)) (* 13 (* x12 x12)) (* 14 (* x13 x13)) (* 15 (* x14 x14)) (* 16 (* x15 x15)) (* 17 (* x16 x16))))
+(define g17 (gwrap loss17 (list 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0)))
+(check "arity 17: length" (vector-length g17) 17)
+(check "arity 17: grad[0]" (vector-ref g17 0) 2.0)
+(check "arity 17: grad[16]" (vector-ref g17 16) 34.0)
+(define (loss20 x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19) (+ (* 1 (* x0 x0)) (* 2 (* x1 x1)) (* 3 (* x2 x2)) (* 4 (* x3 x3)) (* 5 (* x4 x4)) (* 6 (* x5 x5)) (* 7 (* x6 x6)) (* 8 (* x7 x7)) (* 9 (* x8 x8)) (* 10 (* x9 x9)) (* 11 (* x10 x10)) (* 12 (* x11 x11)) (* 13 (* x12 x12)) (* 14 (* x13 x13)) (* 15 (* x14 x14)) (* 16 (* x15 x15)) (* 17 (* x16 x16)) (* 18 (* x17 x17)) (* 19 (* x18 x18)) (* 20 (* x19 x19))))
+(define g20 (gwrap loss20 (list 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0)))
+(check "arity 20: length" (vector-length g20) 20)
+(check "arity 20: grad[0]" (vector-ref g20 0) 2.0)
+(check "arity 20: grad[19]" (vector-ref g20 19) 40.0)
+(define (loss31 x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30) (+ (* 1 (* x0 x0)) (* 2 (* x1 x1)) (* 3 (* x2 x2)) (* 4 (* x3 x3)) (* 5 (* x4 x4)) (* 6 (* x5 x5)) (* 7 (* x6 x6)) (* 8 (* x7 x7)) (* 9 (* x8 x8)) (* 10 (* x9 x9)) (* 11 (* x10 x10)) (* 12 (* x11 x11)) (* 13 (* x12 x12)) (* 14 (* x13 x13)) (* 15 (* x14 x14)) (* 16 (* x15 x15)) (* 17 (* x16 x16)) (* 18 (* x17 x17)) (* 19 (* x18 x18)) (* 20 (* x19 x19)) (* 21 (* x20 x20)) (* 22 (* x21 x21)) (* 23 (* x22 x22)) (* 24 (* x23 x23)) (* 25 (* x24 x24)) (* 26 (* x25 x25)) (* 27 (* x26 x26)) (* 28 (* x27 x27)) (* 29 (* x28 x28)) (* 30 (* x29 x29)) (* 31 (* x30 x30))))
+(define g31 (gwrap loss31 (list 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0)))
+(check "arity 31: length" (vector-length g31) 31)
+(check "arity 31: grad[0]" (vector-ref g31 0) 2.0)
+(check "arity 31: grad[30]" (vector-ref g31 30) 62.0)
+(define (loss32 x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31) (+ (* 1 (* x0 x0)) (* 2 (* x1 x1)) (* 3 (* x2 x2)) (* 4 (* x3 x3)) (* 5 (* x4 x4)) (* 6 (* x5 x5)) (* 7 (* x6 x6)) (* 8 (* x7 x7)) (* 9 (* x8 x8)) (* 10 (* x9 x9)) (* 11 (* x10 x10)) (* 12 (* x11 x11)) (* 13 (* x12 x12)) (* 14 (* x13 x13)) (* 15 (* x14 x14)) (* 16 (* x15 x15)) (* 17 (* x16 x16)) (* 18 (* x17 x17)) (* 19 (* x18 x18)) (* 20 (* x19 x19)) (* 21 (* x20 x20)) (* 22 (* x21 x21)) (* 23 (* x22 x22)) (* 24 (* x23 x23)) (* 25 (* x24 x24)) (* 26 (* x25 x25)) (* 27 (* x26 x26)) (* 28 (* x27 x27)) (* 29 (* x28 x28)) (* 30 (* x29 x29)) (* 31 (* x30 x30)) (* 32 (* x31 x31))))
+(define g32 (gwrap loss32 (list 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0)))
+(check "arity 32: length" (vector-length g32) 32)
+(check "arity 32: grad[0]" (vector-ref g32 0) 2.0)
+(check "arity 32: grad[31]" (vector-ref g32 31) 64.0)
+
+; --- closures that CAPTURE: the callee reads its captures positionally
+;     after its own k arguments, so a mis-sized argument list corrupts
+;     the captures rather than the arguments (this is what returned a
+;     silent all-zero gradient at arity 20) ---
+(define (mkloss2 s) (lambda (x0 x1) (* s (+ (* 1 (* x0 x0)) (* 2 (* x1 x1))))))
+(define c2 (gwrap (mkloss2 3.0) (list 1.0 1.0)))
+(check "captured arity 2: grad[0]" (vector-ref c2 0) 6.0)
+(check "captured arity 2: grad[1]" (vector-ref c2 1) 12.0)
+(define (mkloss12 s) (lambda (x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11) (* s (+ (* 1 (* x0 x0)) (* 2 (* x1 x1)) (* 3 (* x2 x2)) (* 4 (* x3 x3)) (* 5 (* x4 x4)) (* 6 (* x5 x5)) (* 7 (* x6 x6)) (* 8 (* x7 x7)) (* 9 (* x8 x8)) (* 10 (* x9 x9)) (* 11 (* x10 x10)) (* 12 (* x11 x11))))))
+(define c12 (gwrap (mkloss12 3.0) (list 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0)))
+(check "captured arity 12: grad[0]" (vector-ref c12 0) 6.0)
+(check "captured arity 12: grad[11]" (vector-ref c12 11) 72.0)
+(define (mkloss20 s) (lambda (x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19) (* s (+ (* 1 (* x0 x0)) (* 2 (* x1 x1)) (* 3 (* x2 x2)) (* 4 (* x3 x3)) (* 5 (* x4 x4)) (* 6 (* x5 x5)) (* 7 (* x6 x6)) (* 8 (* x7 x7)) (* 9 (* x8 x8)) (* 10 (* x9 x9)) (* 11 (* x10 x10)) (* 12 (* x11 x11)) (* 13 (* x12 x12)) (* 14 (* x13 x13)) (* 15 (* x14 x14)) (* 16 (* x15 x15)) (* 17 (* x16 x16)) (* 18 (* x17 x17)) (* 19 (* x18 x18)) (* 20 (* x19 x19))))))
+(define c20 (gwrap (mkloss20 3.0) (list 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0)))
+(check "captured arity 20: grad[0]" (vector-ref c20 0) 6.0)
+(check "captured arity 20: grad[19]" (vector-ref c20 19) 120.0)
+(define (mkloss32 s) (lambda (x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31) (* s (+ (* 1 (* x0 x0)) (* 2 (* x1 x1)) (* 3 (* x2 x2)) (* 4 (* x3 x3)) (* 5 (* x4 x4)) (* 6 (* x5 x5)) (* 7 (* x6 x6)) (* 8 (* x7 x7)) (* 9 (* x8 x8)) (* 10 (* x9 x9)) (* 11 (* x10 x10)) (* 12 (* x11 x11)) (* 13 (* x12 x12)) (* 14 (* x13 x13)) (* 15 (* x14 x14)) (* 16 (* x15 x15)) (* 17 (* x16 x16)) (* 18 (* x17 x17)) (* 19 (* x18 x18)) (* 20 (* x19 x19)) (* 21 (* x20 x20)) (* 22 (* x21 x21)) (* 23 (* x22 x22)) (* 24 (* x23 x23)) (* 25 (* x24 x24)) (* 26 (* x25 x25)) (* 27 (* x26 x26)) (* 28 (* x27 x27)) (* 29 (* x28 x28)) (* 30 (* x29 x29)) (* 31 (* x30 x30)) (* 32 (* x31 x31))))))
+(define c32 (gwrap (mkloss32 3.0) (list 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0)))
+(check "captured arity 32: grad[0]" (vector-ref c32 0) 6.0)
+(check "captured arity 32: grad[31]" (vector-ref c32 31) 192.0)
+
+; --- the forms that must NOT be spread: arity 1 takes the whole point as
+;     one vector argument, a scalar point is one dual, and a variadic
+;     loss's fixed parameters are its declared arity ---
+(define (v1 v) (+ (* 1 (* (vref v 0) (vref v 0))) (* 2 (* (vref v 1) (vref v 1))) (* 3 (* (vref v 2) (vref v 2)))))
+(define gv (gwrap v1 (vector 2.0 3.0 4.0)))
+(check "arity 1 vector point: grad[0]" (vector-ref gv 0) 4.0)
+(check "arity 1 vector point: grad[2]" (vector-ref gv 2) 24.0)
+(define gt (gwrap v1 #(2.0 3.0 4.0)))
+(check "arity 1 tensor point: grad[0]" (vector-ref gt 0) 4.0)
+(check "arity 1 tensor point: grad[2]" (vector-ref gt 2) 24.0)
+(define (sq x) (* x x))
+(check "scalar point" (gwrap sq 3.0) 6.0)
+(define (vlo a b . rest) (+ (* 1 (* a a)) (* 2 (* b b))))
+(define gvar (gwrap vlo (list 1.0 1.0)))
+(check "variadic loss: grad[0]" (vector-ref gvar 0) 2.0)
+(check "variadic loss: grad[1]" (vector-ref gvar 1) 4.0)
+
+; --- a builtin arithmetic procedure used as the loss: the dispatcher's
+;     n-ary fold is not emitted in spread mode, because with exactly two
+;     arguments the function the closure points at computes the same
+;     polymorphic operation ---
+(define plus +)
+(define gplus (gwrap plus (list 2.0 5.0)))
+(check "builtin + as loss: grad[0]" (vector-ref gplus 0) 1.0)
+(check "builtin + as loss: grad[1]" (vector-ref gplus 1) 1.0)
+(define times *)
+(define gtimes (gwrap times (list 2.0 5.0)))
+(check "builtin * as loss: grad[0]" (vector-ref gtimes 0) 5.0)
+(check "builtin * as loss: grad[1]" (vector-ref gtimes 1) 2.0)


### PR DESCRIPTION
Fixes the Windows merge blocker on #383 without lowering the gradient arity ceiling, and closes the
silent-wrong-answer hole that the ceiling was hiding above arity 16.

Base is `integrate/v134-tensor-cluster`, so this folds into #383 rather than landing separately.

## The mechanism

A gradient of a RUNTIME closure — one reached as a value, through a wrapper, a parameter or a
variable — has to call that closure with its own declared number of scalar arguments, and that
number is only known at run time. `AutodiffCodegen::emitRuntimeClosureGradient` spread it with a
switch carrying **one fully expanded closure call per arity**, inlined at every gradient site.

Per-arity cost is not constant: `codegenClosureCall` expands the n-ary arithmetic fold over its
argument list and an unrolled variadic rest-list chain, so case `k` costs O(k) to O(k^2) lines.
Measured from the emitted stdlib IR of this PR's base, per gradient site:

| arity | 1 | 2 | 4 | 8 | 16 | 24 | 32 |
|---|---|---|---|---|---|---|---|
| IR lines for that one case | 669 | 778 | 1,034 | 1,864 | 4,628 | 8,221 | ~11,800 |

So raising the ceiling 8 -> 32 (correct — arity 9+ had been silently taking the single-vector path
and producing nothing) did not cost 4x, it cost 18x: the six stdlib gradient sites went from ~9,500
to ~171,000 lines each.

**This PR emits the spread ONCE PER MODULE, out of line, and makes the arity dispatch the closure
dispatcher's OWN runtime argument-count switch rather than a second per-arity one layered on top.**

1. `codegenClosureCall` gains an opt-in `ClosureSpreadArgs` descriptor — a staging array of `width`
   tagged slots plus a runtime count. In that mode the argument values come from the array rather
   than a static `call_args`, the dispatch count is the runtime one, and the variadic rest list is
   built by a single runtime loop bounded below by the runtime `fixed_params` instead of an
   unrolled cons chain per fixed-arity arm. **Without a descriptor every existing call site emits
   byte-identical IR** — see the per-function diff below.
2. A new module-local helper `__eshkol_ad_gradient_spread_call(closure, point_vector, dual_elems,
   declared_arity)` (`getOrCreateGradSpreadHelper`, `InternalLinkage`, emitted lazily once) owns the
   whole contract: the arity 0/1/variadic-sentinel vector form, the staging copy, the spread call,
   and the named raise above `GRAD_MAX_ARITY`.
3. `emitRuntimeClosureGradient`'s 32-case switch becomes one call to that helper. The
   perturbation-level push/pop stay at the call site, so ordering around the call is unchanged.

`GRAD_MAX_ARITY` is still 32 and still raises above it with the same message. Lifting it later now
costs one more arm in one function instead of 24 fully expanded calls at every gradient site.

The arithmetic fold is deliberately not emitted in spread mode. That is value-preserving, not a
dropped case: the fold exists so a 2-ary builtin closure can absorb MORE than two arguments
(`(fold + ...)`); with exactly two it computes `polymorphicOp(a, b)`, which is verbatim the body of
the function the closure points at (`createBuiltinArithmeticFunction` emits
`builtin_<op>_2arg(a, b) = polymorphicOp(a, b)`). Those four closures are arity 2, and a spread arm
is entered only when the closure's declared arity equals the arm. Pinned by test: `+` and `*` used
as the loss through a wrapper.

## Sizes

macOS arm64, Release, same tree, same flags. "base" is this PR's parent `a43d216c`; "master" is the
exact-master reference build at `028b190f`.

| stdlib artifact | master `028b190f` | base (#383/#384) | **this PR** | vs base | vs master |
|---|---|---|---|---|---|
| disassembled IR | 586,301 lines | 1,561,902 | **527,343** | 0.34x | 0.90x |
| `stdlib.bc` | 6,654,064 B | 19,764,624 B | **6,004,048 B** | 0.30x | 0.90x |
| `stdlib.o` | 4,988,680 B | 11,747,176 B | **4,536,800 B** | 0.39x | 0.91x |

Below master, because master's 48 inline expansions (6 sites x 8 arities) also collapse into the one
shared dispatch.

**Per-function diff against the base build: exactly the five gradient-carrying functions changed,
plus the new helper. The other 727 stdlib definitions are line-for-line identical.**

| function | base | this PR |
|---|---|---|
| `stdlib_lambda_118` (two sites) | 355,821 | 10,128 |
| `stdlib_lambda_113` | 179,672 | 6,826 |
| `stdlib_lambda_120` | 178,569 | 5,723 |
| `conjugate-gradient` | 178,784 | 5,930 |
| `stdlib_lambda_112` | 177,493 | 4,647 |
| `__eshkol_ad_gradient_spread_call` | — | added |

## Windows timing

Real Windows x64 host, same tool, same flags, same machine, three IR modules, two repetitions.
LLVM 22.1.4 (the msys64 toolchain present on that host today); #383's earlier numbers were taken
with LLVM 21.1.8, so absolute seconds are not comparable across the two runs — master is therefore
re-measured here as the control arm.

| stage | master `028b190f` | base (#383/#384) | **this PR** |
|---|---|---|---|
| `opt -O2` | 8.4 / 8.3 s | 46.4 / 30.5 s | **7.4 / 7.4 s** |
| `llc -O2 -filetype=obj` | 29.1 / 22.5 s | 124.3 / 103.5 s | **18.2 / 18.3 s** |
| **LLVM work per compile** | **37.5 / 30.8 s** | **170.7 / 134.0 s** | **25.7 / 25.7 s** |
| emitted object | 5,399,552 B | 12,729,648 B | **4,880,928 B** |

base/master = 4.4x here (4.6x in #383's LLVM 21 run — the ratio reproduces). This PR is 0.7-0.8x of
master, so the Windows lanes get back more headroom than they had before the cluster: against the
harness's 120 s compile budget and master's 46-116 s tests, this removes the +92 s of stdlib LLVM
work per compile that made all 17 `windows-x64-cuda` and 13/14 `windows-arm64-xla` tests report
`COMPILE TIMEOUT (120s)`.

## A silent wrong answer above arity 16, fixed as a consequence

The ceiling said 32 but `codegenClosureCall` clamped its argument arms at `MAX_CALL_ARGS_LIMIT = 16`,
so arms 17-32 called the loss with 16 tagged arguments. The callee then read its remaining
parameters — and its captures, which follow positionally — out of the capture pointer registers.
Measured on the base build, gradient reached through `(define (gwrap f p) (gradient f p))`:

| loss | base | this PR |
|---|---|---|
| arity 2-16, plain or captured | correct | correct (unchanged) |
| arity 17-32, no captures | **SIGSEGV** | correct |
| arity 17-31, captured | **silent all-zero gradient** | correct |
| arity 32, captured | `Type error in *: ... got pair` | correct |

In spread mode the arms cover the caller's staging width, so the declared ceiling is now the real
ceiling. `tests/autodiff/runtime_closure_arity_spread_test.esk` pins it: 49 checks over arities 2-32
plain and captured, plus the forms that must NOT be spread (arity-1 vector point, tensor point,
scalar point, variadic loss) and builtin arithmetic as the loss. On the base build that file dies at
check 19 with SIGSEGV.

## Verification

All on macOS arm64, Release, this branch:

| gate | result |
|---|---|
| `run_autodiff_tests.sh` | **59/59** (includes the new file) |
| `run_ad_oracle.sh` | **60/60** |
| `run_ad_adversarial.sh` | **46/46** |
| `run_ml_tests.sh` | **44/44** |
| `run_features_tests.sh` | 39/39 |
| `run_memory_tests.sh` | 20/20 |
| `run_stdlib_tests.sh` | 20/20 |
| `ctest` | **113/113** |
| `run_vm_parity.sh` (both axes) | **114 passed, 0 failed** — including `45_gradient_runtime_closure_arity.esk`, #384's own evidence file for this exact path, byte-identical native vs `vm-src` vs `vm-eskb` |
| `run_icc_smoke.sh` | 52/55 — the same three fail identically on the base tree |
| new spread test under JIT, `ESHKOL_JIT_CACHE=0`, and AOT | 49/49 each |
| ICC probe `vm_gradient_parity` | green: the callable-arity spec (direct / wrapped / curried, 2- and 3-arg scalar spread, arity-1 whole-vector, non-polynomial) is 25/25 on the VM and byte-identical to native |

The three ICC smoke failures were re-run on the unmodified base tree and fail there identically:
`define_library_import_works` (exit 1), `language_surface_coverage_floor` (exit 2 — needs a
quantum-enabled build directory), `p8_escape_matrix_green` (exit 1 — the arity ratchet baseline is
deliberately not re-anchored on this branch). Zero delta from this change.

Gradient values across the boundary cases, base vs this PR, identical everywhere the base was not
broken:

| case | base | this PR |
|---|---|---|
| direct-named 1000-parameter loss (len/g0/g63/g64/g999) | 1000 / 2 / 128 / 130 / 2000 | same |
| wrapper-reached arity-1 loss over 1000 coordinates | 1000 / 2 / 128 / 130 / 2000 | same |
| wrapper-reached arity 65 | named ceiling raise | same |
| wrapper-reached arity 2-16, plain and captured | correct | same |
| `+` / `*` as the loss through a wrapper | `#(1 1)` / `#(5 2)` | same |
| variadic loss `(lambda (a b . rest) ...)` | `#(2 4)` | same |
| tensor and `(vector ...)` points (reverse-mode path) | correct | same |

## `apply` was evaluated and is NOT covered — with reasons

`CallApplyCodegen::applyClosure` has a matrix, but not this defect's shape. It is already
array-based: it extracts the list into a stack array and switches on a runtime
`(arg_count, capture_count)` index, and each of its 81 cases is GEP + load + one direct call — no
inlined closure dispatcher per case. In the stdlib it occurs at exactly ONE site costing 5,314 IR
lines (1% of this PR's stdlib IR), and it is byte-identical on master, on the base branch and here.

Unifying it with the closure dispatcher is a separate change with its own ABI risk: `applyClosure`
passes exactly `cc` capture VALUES per case, while `codegenClosureCall` over-provisions 64 capture
POINTERS and lets the callee read its own N. The two conventions would have to be reconciled first,
and doing that inside a Windows-timing fix would put an unrelated ABI change on the critical path.
Recorded as follow-up, not folded in.

## ICC

- `impact-analysis --repo eshkol-v134-release` over the four changed paths: 740 seed symbols, 5,948
  impacted symbols, 1,378 impacted paths at depth 8 — it edits the compiler core, so the stdlib and
  test surface are downstream; gate it as such.
- `guard-liveness --path-prefix lib/backend`: `dead_count` 38, identical to the v1.3.4 release-tree
  baseline, and **zero findings in either touched file** — the guard sites this adds are live. The
  ceiling raise is additionally proven live at run time: a wrapper-reached arity-65 loss raises the
  named error.
- `pre-commit-check`: PASS, 0 blockers.
