### PR TITLE
fix(test-harness): guard eshkol_test_isolation_prune_stale against an empty temp root

### DIFF
--- a/scripts/lib/test_isolation.sh
+++ b/scripts/lib/test_isolation.sh
@@ -108,6 +108,13 @@ eshkol_test_isolation_prune_stale() {
     local count
     count=$(find "$root" -maxdepth 1 -type d -name 'eshkol-test.*' 2>/dev/null | wc -l | tr -d ' ')
     [ -n "$count" ] || return 0
+    # Nothing to prune in an empty root. Without this, every glob below
+    # ("$root"/eshkol-test.*) stays a literal, unmatched pattern, and the
+    # commands it feeds (du, ls) exit non-zero on that literal path. Under a
+    # caller's `set -euo pipefail` that non-zero status is fatal, so an empty
+    # temp root silently kills the *calling* test suite instead of just
+    # finding nothing to prune.
+    [ "$count" -gt 0 ] || return 0
     if [ "$count" -gt "$max_dirs" ]; then
         # ls -dt sorts newest first; tail past the cap is the overflow.
         # shellcheck disable=SC2012
@@ -129,6 +136,13 @@ eshkol_test_isolation_prune_stale() {
     local min_age total oldest
     min_age="${ESHKOL_TEST_TMP_MIN_AGE_MIN:-120}"
     while :; do
+        # Same hazard as the count-sweep guard above, reachable from inside
+        # this loop: each iteration deletes one directory, so a set that
+        # started non-empty can drain to zero before the loop exits. Recheck
+        # before the glob-into-du call below rather than trusting the $count
+        # captured before the loop started.
+        count=$(find "$root" -maxdepth 1 -type d -name 'eshkol-test.*' 2>/dev/null | wc -l | tr -d ' ')
+        [ -n "$count" ] && [ "$count" -gt 0 ] || return 0
         total=$(du -sm -- "$root"/eshkol-test.* 2>/dev/null | awk '{s+=$1} END {print s+0}')
         [ -n "$total" ] || return 0
         [ "$total" -le "$max_mb" ] && return 0


### PR DESCRIPTION
## Summary

`scripts/lib/test_isolation.sh`'s `eshkol_test_isolation_prune_stale` globs
`"$root"/eshkol-test.*` directly into `du`/`ls`. When the temp root contains
zero `eshkol-test.*` directories, that glob stays a literal, unmatched
pattern. `du` exits non-zero on the literal path, and under a caller's
`set -euo pipefail` that non-zero status is fatal for the assignment — the
calling suite dies silently (`2>/dev/null` swallows the diagnostic, so there
is no visible error at all).

This is exactly what happened to `run_language_coverage.sh`: it died with
exit 1 and zero output, which made the `language_surface_coverage_floor` ICC
probe read as a false red. The coverage floor itself is fine — it is
1091/100% green once the harness is allowed to finish.

Root fix: after the count-based sweep, return early when there is nothing to
prune (`[ "$count" -gt 0 ] || return 0`).

While auditing the file for other instances of the same glob-into-command
hazard, one more turned up in the same function: the size-based sweep loop
deletes directories one at a time and rechecks the total each iteration, so
a non-empty set can drain to zero *inside* the loop and then re-glob an
empty root on the next pass, hitting the identical crash. Fixed the same
way — recompute the live count via `find` and return before the `du` call
if it has reached zero, instead of trusting the count captured before the
loop started.

No other glob-into-command site in the file shares the hazard: the age and
count sweeps already use `find -name` (which handles zero matches cleanly),
and the remaining `"$root"/eshkol-test.*` glob (the `ls -dt` count-overflow
sweep) only executes inside an `if [ "$count" -gt "$max_dirs" ]` block,
which already guarantees at least one match exists.

## Evidence

Deterministic repro against an isolated `ESHKOL_TEST_TMP_ROOT`, before and
after this patch:

| scenario | before | after |
|---|---|---|
| empty temp root | rc=1, no output (silent abort) | rc=0, `PRUNE_OK` |
| one `eshkol-test.*` dir present | rc=0 | rc=0 (unchanged) |
| single oversized dir that the size sweep must delete down to zero | rc=1, no output (silent abort) | rc=0, `PRUNE_OK`, 0 dirs remaining |

Ran the actual harness this probe wraps end to end,
`./scripts/run_language_coverage.sh`, with `ESHKOL_TEST_TMP_ROOT` pointed at
an empty directory (the exact false-red condition) and a full core + quantum
build. It completed clean instead of dying at the prune step:

    EXITCODE=0
    Language-surface coverage (runtime execution evidence)
      surface constructs : 1091
      EXECUTION-backed   : 1091 (100.0%)  [the only gated number]
      policy floor       : 1091 constructs, 100.00% — PASS
      deficit ratchet    : baseline 1091 covered / 0 deficit — PASS
      high-risk uncovered: 0 — COMPLETE

Confirms the floor itself was never the problem — 1091/100% green, exactly
as suspected; the only thing broken was the harness's own empty-root prune
step aborting before that number could even be measured.

## Probes / ICC

- `scripts/run_icc_smoke.sh` has no per-probe filter, so the
  `language_surface_coverage_floor` probe was exercised directly via its
  underlying command, `./scripts/run_language_coverage.sh`, with
  `ESHKOL_TEST_TMP_ROOT` pointed at an empty directory to reproduce the exact
  false-red condition — full run (core + quantum corpora) passes clean, see
  above.
- ICC impact-analysis (`--repo eshkol-v134-release --paths
  scripts/lib/test_isolation.sh`): 22 seed symbols, 25 impacted symbols
  across 4 paths (`scripts/lib/test_isolation.sh`,
  `scripts/run_edge_coverage_v134.sh`, `scripts/run_features_tests.sh`,
  `scripts/run_p8_escape.sh`) — small, expected blast radius for a shared
  test-isolation helper; no unexpected consumers.

Not a functional change to any suite's pass/fail semantics — purely removes
a harness-level false abort.
