### PR TITLE
release: cut v1.3.4-evolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Eshkol will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.4-evolve] - 2026-07-23
+## [1.3.4-evolve] - 2026-07-31
 
 A resident-correctness release over v1.3.3-evolve. Every defect surfaced by
 long-duration resident workloads is fixed at the architectural root: automatic
@@ -25,6 +25,23 @@ a round-tripping numeric printer. It also hardens the toolchain (transitive
 FFI-link discovery with fatal link failures, Homebrew-compatible
 system-dependency builds) and the assurance surface (dynamic edge coverage
 across every new-feature family).
+
+The second half of the cycle is a consumer-hardening correctness wave, and its
+organising principle is that a wrong answer must not be able to look like a
+right one. An emitted compile-time error now prevents artifact emission and
+execution, which turned a family of silent wrong answers into build failures
+and exposed the rest: exactness is now decided by an operand's runtime tag
+rather than by a result's value shape, on the native flonum integer-division
+family and on the bytecode VM's whole numeric surface; automatic
+differentiation answers exactly at exact points, survives per-iteration nursery
+reclamation, and no longer produces zeros above gradient arity 16;
+`define-library` and `import` resolve same-unit libraries on all three back
+ends; and `--shared-lib` links a real, C-ABI-correct shared library instead of
+exiting zero with no artifact. Alongside those corrections the release adds a
+portable event loop (kqueue / epoll / IOCP), a fixed-point and `i128`
+exact-accumulation engine, the qLLM bridge implementation that its documented
+backward rules were waiting for, embedding and Fréchet-mean backward passes,
+and a release gate that finally reads CTest results as oracle evidence.
 
 ### Added
 
@@ -307,6 +324,109 @@ across every new-feature family).
   earlier PES). Adds differentiable quantum-chemistry examples (five programs)
   and an arbitrary-order-AD H2 vibrational-frequency example.
   (`docs/design/MOONLAB_INTEGRATION.md`, `examples/`)
+
+- **Portable event loop (ESH-0011).** A new event-loop primitive —
+  `make-event-loop`, `event-loop-add-fd!`, `event-loop-remove-fd!`,
+  `event-loop-poll`, `event-loop-close`, `event-loop-backend` — wrapping kqueue
+  on macOS/BSD, epoll on Linux/Android, and IOCP (plus WSAPoll /
+  `PeekNamedPipe` readiness) on Windows, with a fail-closed stub on
+  WebAssembly. Exactly one platform backend is compiled in, selected in
+  `CMakeLists.txt` the same way the GPU layer selects its `gpu_memory`
+  implementation. The portable half — handle registry, argument validation,
+  generation-tagged handles, result coalescing — lives in
+  `lib/core/event_loop.c` and is shared by every backend *and* by the bytecode
+  VM, so there is no native/VM parity surface to maintain separately.
+  Verified: a pipe read/write round-trip completing inside its timeout, an idle
+  poll that waits its budget and returns rather than hanging, and 1,000
+  sequential open/close cycles that never exhaust the descriptor table (the
+  macOS default limit is 256, so a leak would fail long before 1,000).
+  (`lib/core/event_loop.c`, `lib/core/event_loop_*.c`)
+
+- **Fixed-point / `i128` exact-accumulation engine.** A fully additive module:
+  `esk_i128`, a parametric `fixed<W,F>` with explicit per-operation rounding,
+  and a block-scaled `dot_exact` reduction over an i128 accumulator. Its
+  purpose is order-independent bit-exact reduction — the same reduction over
+  the same elements produces byte-identical results regardless of summation
+  order, which an f64 accumulator cannot guarantee. Measured: 200 shuffles ×
+  4,096 elements and 50 matmul contraction orders are byte-identical under the
+  exact path, while an f64 control drifts about 1.5e-06 between orderings on
+  the same inputs; and the exact path is *faster* than an f64 double-double
+  baseline (13.6 GB/s vs 4.3 GB/s), so exactness is not a throughput trade-off
+  here. Standalone suite 84/84. `ESHKOL_FIXED_POINT_ENGINE` defaults ON and is
+  forced OFF on MSVC/ClangCL, which lack the GCC/Clang `__int128` ABI the
+  engine relies on. The `eshkol-fixedpoint` shared library is a self-contained
+  C11 module depending only on libc and libm — no LLVM, no `eshkol-static` — so
+  it is consumable independently of the rest of the toolchain.
+  (`lib/math/fixed_point/`, `tests/fixed_point/`)
+
+- **The qLLM bridge is implemented, not just declared.**
+  `inc/eshkol/bridge/qllm_bridge.h` declared 17 functions and
+  `docs/api/bridge/qllm_bridge.md` reported all 20 of its symbols documented,
+  but **none of the 17 was defined anywhere in the tree**. The consequence ran
+  deeper than a missing entry point: the bridge's *backward* half already
+  shipped — `lib/bridge/tensor_backward.cpp` implements exact gradient rules
+  for 11 of 13 tensor AD node types and is compiled into the main library —
+  and was unreachable, because nothing ever created a node of those types. All
+  17 functions are now implemented in `lib/bridge/qllm_bridge.cpp`: each
+  computes the forward value and, when a tape is supplied, records a node of
+  the canonical `ad_node_type_t` with the exact input wiring the matching
+  backward rule reads, so those gradient rules now run. Where a backward rule
+  cannot differentiate a shape exactly, the forward **refuses** rather than
+  recording a node whose gradient would be wrong (matmul is 2-D only; softmax
+  takes only the axis its rule normalises over) — exact AD or an explicit
+  error, never a silent zero. Lifecycle is a real `dlopen` resolving a known
+  qLLM entry point, so `ready()` reports a fact. `ESHKOL_QLLM_ENABLED` is a new
+  CMake option, OFF by default per `docs/SDNC.md` §13; ON without a
+  discoverable library is a configure-time `FATAL_ERROR` naming
+  `ESHKOL_QLLM_ROOT`, because an explicit opt-in that silently does nothing is
+  worse than no option at all. A new `lib/backend/sdnc_isa.h` makes the SDNC
+  ISA, state-vector layout and type tags a single source shared by producer and
+  consumer, closing a live divergence: the producer emitted `OP_SWAP = 83`
+  while the consumer's private copy stopped at `OP_COUNT = 83` and rejected
+  that opcode outright — a drift across a file format, where a renumbering
+  changes behaviour silently instead of failing to link. New ctest:
+  `qllm_bridge_gradcheck`.
+
+- **Embedding backward pass and Fréchet-mean derivative.** Two backward rules
+  that previously refused outright. The embedding forward `y[i,:] =
+  W[idx[i],:]` is a gather, so its adjoint is the scatter-add `dW[idx[i],:] +=
+  dy[i,:]`; `tensor_embedding_backward` could not compute it because the lookup
+  indices were not on the AD node at all. The node contract now carries them
+  (`input1` = weights, `input2` = the index node, `params = [num_indices,
+  d_model, vocab_size]`), and the two properties that carry correctness are
+  asserted directly: duplicate indices **accumulate** (assigning instead is the
+  classic scatter-add bug, and it under-counts every repeated token), and
+  unselected rows are **bitwise** zero (the adjoint of a gather is genuinely
+  sparse). The integer-valued index operand gets no gradient — left untouched
+  rather than seeded with a zero that would read as "differentiated, came out
+  zero" — and a missing, fractional, or out-of-range index raises instead of
+  scattering into the wrong row. The weighted Fréchet (Karcher) mean on the
+  Poincaré ball gets its derivative by implicit differentiation of the
+  first-order optimality condition rather than by unrolling the solver. Fixed
+  on the way: `eshkol_tensor_backward_dispatch` bracketed each node's backward
+  in a scope on the **global** arena, and `arena_pop_scope` rewinds over
+  everything allocated since the push — including the destination gradient
+  buffers allocated lazily from that same arena on first accumulation, which
+  the upstream node then read back as reclaimed memory. Temporaries now get
+  their own arena: two lifetimes, two arenas, and no allocation site needs to
+  know whether a backward scope is open above it.
+
+- **CTest results are completion-oracle evidence.** No oracle criterion
+  anywhere consumed a CTest result: the only `ctest` mentions in
+  `.icc/completion-oracles.yaml` were `action:` strings, and the nine
+  `test_evidence` criteria were index-level ("the tests exist and are
+  runnable"), not execution-backed — so a red CTest run could not turn the
+  release gate red. `scripts/run_ctest_gate.sh` now runs CTest, parses the
+  per-test verdicts, and emits `kind: "ctest"` and `kind: "test_result"` trace
+  events, with a roll-up per named group and one for the whole suite. **A group
+  whose regex matches no configured test is reported ABSENT and fails the
+  gate**, so a pillar cannot quietly stop being covered because its tests were
+  renamed or configured out. Eight criteria are wired under
+  `eshkol-compiler-readiness`, including the fixed-point engine, the
+  exact-input AD identity tier, the runtime-closure arity spread, same-unit
+  `define-library`, the self-checking VM surface suite, VM parity, and the
+  event loop — several of which had shipped into this cut with a working CTest
+  gate that the release target never looked at.
 
 ### Changed
 
@@ -985,6 +1105,294 @@ across every new-feature family).
   `if`/`cond` is no longer rejected as a double-use by the branch sum-counting —
   so valid conditional linear gates type-check. Externally contributed.
   (`lib/types/type_checker.cpp`)
+
+#### Automatic differentiation
+
+- **`gradient` returned a silently wrong gradient whenever the function filled
+  a vector with `vector-set!` inside a loop.** The derivative was attributed to
+  the *last* element written, for every element read. Primal values stayed
+  exact, the compiler exited 0 and stderr was empty, so a Jacobian assembled
+  row by row — the standard idiom — came out uniform garbage while looking
+  entirely plausible:
+
+  ```scheme
+  (define (vscale v s)
+    (let* ((n (vector-length v)) (o (make-vector n 0.0)))
+      (let loop ((i 0))
+        (if (< i n) (begin (vector-set! o i (* (vector-ref v i) s)) (loop (+ i 1)))))
+      o))
+  (gradient (lambda (v) (vector-ref (vscale v 3.0) 0)) (vector 0.6 -0.8))
+  ;; before: #(0 3)        after: #(3 0)
+  ```
+
+  Root cause, found by bisecting 94 commits: the iter-scope partial-reclamation
+  work (ESH-0214e, above) gives such a loop a nursery `arena_reset()` per
+  tail-call back edge, and the write barrier that must promote escapees tested
+  `ESHKOL_IS_ANY_PTR_TYPE`, which **excludes** `DUAL_NUMBER` — a dual number is
+  tagged in the immediate block but its data field addresses a headerless
+  16-byte `{value, derivative}` pair in the nursery. The reset recycled it, the
+  same address was reallocated on the next iteration, the primal survived and
+  the tangent was silently corrupted. Fixed at the root with one shared
+  "carries an arena pointer" predicate consulted by the write barrier, the
+  `with-region` escape path and the nursery recycle alike (headerless payloads
+  — dual and complex — get flat forwarded copies); tape-retained AD nodes now
+  allocate from the tape's owning arena; and `evac_kind_for` reports
+  live-interior-graph AD nodes in **every** build, not only instrumented ones.
+
+- **`derivative`, `gradient` and `hessian` returned garbage at exact
+  (rational or bignum) points, and lost exactness where the tower keeps it.**
+  An exact rational or bignum is an ordinary number that happens to be
+  HEAP-tagged, so its tagged data field holds a *pointer*. Every AD entry point
+  turned its point into a double by *reinterpreting* that field, choosing the
+  reinterpretation from the shapes it expected rather than from the tag the
+  value actually carries — so the compiler differentiated at the rational
+  object's **address**. `SIToFP` over a pointer yields a value of heap
+  magnitude, a bitcast yields a denormal near 5e-314, and failing the scalar
+  test routed the point down the *collection* path, where the rational object
+  was dereferenced as `[dims][rank][elems]` (SIGSEGV). One authority per
+  question now dispatches on the runtime tag —
+  `eshkol_ad_seed_to_double` / `eshkol_ad_point_to_double` convert int64,
+  double, bignum, rational, a jet's primal and a tower's `c[0]`, and **refuse**
+  a non-numeric point with a catchable type error instead of inventing a number
+  for it; `eshkol_ad_point_is_scalar` decides scalar-versus-collection once for
+  every operator. Fixing that produced a correct *double*, which exposed the
+  second half: the Taylor carrier `derivative-n` uses can hold exact
+  coefficients and nothing routed the other operators to it, so
+  `(derivative f 1/3)` answered `0.6666666666666666` where
+  `(derivative-n f 1/3 1)` answered `2/3`. At an exact point the operators now
+  run the same Taylor-tower pass, so the contract is an identity in value *and*
+  in exactness — `(derivative f x)` = `(derivative-n f x 1)`,
+  `(hessian f x)` = `(derivative-n f x 2)` — keeping `+ - * /` and
+  non-negative-integer `expt` exact and demoting to f64 at the first
+  transcendental, per R7RS exactness contagion.
+
+- **A gradient of a runtime closure with declared arity 17-32 crashed, silently
+  returned all zeros, or raised a type error.** Reaching a closure as a value —
+  through a wrapper, a parameter or a variable — means its argument count is
+  known only at run time, and the spread that supplies those arguments was
+  clamped by a `MAX_CALL_ARGS_LIMIT` of 16, so the declared ceiling above 16
+  was fictional. The spread is now emitted **once per module, out of line**
+  (`__eshkol_ad_gradient_spread_call`, internal linkage), with the arity
+  dispatch performed by the closure dispatcher's own runtime argument-count
+  switch rather than a second per-arity one layered on top, and the variadic
+  rest list built by a single runtime loop instead of an unrolled cons chain
+  per arm. The ceiling of 32 is now real, and every existing call site without
+  the new descriptor emits byte-identical IR. The out-of-line form is also
+  substantially *smaller* than what preceded the arity widening — the shipped
+  `stdlib.bc` is 6,004,048 bytes against 6,654,064 before — which restores
+  Windows compile times, where COFF cannot discard the weak-linkage expansion
+  that the inline spread multiplied at every gradient site.
+
+#### Numeric tower and exactness
+
+- **The bytecode VM decided a numeric result's exactness from its *value*
+  rather than from its operands' tags, so inexact arithmetic silently became
+  exact.**
+
+  ```
+  (/ (- 2.0 1.0) (+ 2.0 1.0))                        VM 1/3  native 0.3333333333333333
+  (* 0.5493061443340549 (/ (- 2.0 1.0) (+ 2.0 1.0)))  VM 0    native 0.1831020481113516
+  ```
+
+  `number_val()` collapsed any integral-valued double to the exact `VAL_INT`,
+  and the compile-time constant folder repeated the same value-shape test on
+  folded literals, so `(- 2.0 1.0)` produced the exact integer 1 and
+  `(+ 2.0 1.0)` the exact 3 — after which `OP_DIV` correctly divided two exact
+  integers and answered `1/3`. R7RS 6.2.2 requires inexactness to be
+  contagious: an inexact computation must not change numeric domain because an
+  intermediate landed on an integer. Fixed at the constructor —
+  `number_val_contagious()` decides exactness from the operand tags and is used
+  by every arithmetic opcode and numeric builtin — and the folder now folds by
+  the parser's literal exactness flags, declining to fold an exact literal it
+  cannot represent (an integer wider than `int64`) rather than silently making
+  it inexact. Independently, the rational-domain natives built both operands as
+  `{(int64_t)as_number(v), 1}`, which can only carry an exact fixnum: a flonum
+  was **truncated into the numerator**, so `(* 0.5493061443340549 1/3)`
+  evaluated `(* 0 1/3)` and answered the exact 0, and `(+ 0.5 1/3)` answered
+  `1/3`. Every mixed flonum/ratnum `+ - * /` was wrong, in both operand orders.
+  Divergent native-versus-VM numeric combinations drop from 79 to 20; the
+  remainder are bignum-over-bignum rationals not representable in the VM's
+  rational type, now answered as a correctly-rounded inexact value and recorded
+  as a justified parity row rather than left silent.
+
+- **Native flonum `modulo`, `remainder`, `quotient` and the floor-division
+  family were wrong across the board.** These are the native side of R7RS
+  6.2.6, and a VM-parity differential sweep proved native was the wrong side:
+
+  | expression | before | after |
+  |---|---|---|
+  | `(modulo 5.5 2.0)` | `6192449487634432` | `1.5` |
+  | `(modulo 5.0 3)` | `0` | `2.0` |
+  | `(remainder 5.5 2.0)` | `-0.5` | `1.5` |
+  | `(remainder 7.0 2.0)` | `-1.0` | `1.0` |
+  | `(exact? (quotient 7.0 2.0))` | `#t` | `#f` |
+  | `(quotient 1e20 3.0)` | `9223372036854774784` | `3.3333333333333332e19` |
+  | `(quotient 5.0 0.0)` | `9223372036854774784` | raises |
+  | `(remainder 5.5 0.0)` | `+nan.0` | raises |
+  | `(/ (expt 2 100) 0.0)` | `0` | `+inf.0` |
+  | `(floor-remainder 7.0 2.0)` | `7881299347898368` | `1.0` |
+  | `(floor-quotient (expt 2 100) 3)` | `1745178066` | exact |
+
+  `modulo` and `remainder` had no flonum path at all, so both operands went
+  through the int64 unpack and the result was the `SRem` of two IEEE-754 bit
+  patterns; `remainder` additionally called the C library's `remainder()`,
+  which is IEEE round-to-**nearest**, a different function from Scheme's
+  truncated one. `quotient`'s double path `FPToSI`'d the truncated quotient
+  into an int64 and packed it **exact**, breaking contagion by construction and
+  saturating to one constant past 2^63 — a plausible integer is the worst shape
+  a wrong answer can take, and `(quotient 5.0 0.0)` returned that same
+  constant. `modulo` and `remainder` now have a flonum path built on `frem`
+  (which is exactly C's `fmod`), `quotient` keeps its value as a double, the
+  floor-division family is representation-polymorphic so `floor-remainder`
+  genuinely **is** `modulo` as R7RS defines it, and a zero divisor raises
+  uniformly across all of them including the mixed-bignum route. Fixed
+  alongside: assignment conversion's `set!` scan had no case for `do` and never
+  descended into cons-cell subtrees, so `(set! n …)` in a `do` body reported
+  `variable 'n' is not mutable` and lost the assignment.
+
+#### Language, modules and diagnostics
+
+- **A compile-time error did not stop the build.** The compiler printed
+  `ERROR: …` and then emitted, linked and *ran* a binary anyway, so a diagnosed
+  program produced a wrong answer instead of a failed build. This is the
+  mechanism that made this release's other defects silent: every one of them
+  was reported at compile time, and every report was ignored. Reporting an
+  error is one call at any of 805 sites across `lib/` and `exe/`, while
+  propagating one is a return path through every enclosing frame — and the
+  codegen frames recover by substituting a placeholder value and carrying on.
+  All 805 sites funnel through four primitives in `lib/core/logger.cpp`, so an
+  authoritative error tally now lives in one place and every path increments it
+  for free; an emitted error-severity diagnostic prevents artifact emission and
+  execution.
+
+- **`define-library` validated its library name and threw it away, so an
+  `import` could not see a library defined in the same file.**
+
+  ```scheme
+  (define-library (smoke v1_3) (export greet)
+    (begin (define (greet who) (string-append "hi " who))))
+  (import (smoke v1_3))
+  (greet "world")
+  ```
+
+  reported `Module 'smoke.v1_3' not found` about a library written one line
+  above the import, because `import` had nothing to consult but a filesystem
+  search that can only ever find a library living in some *other* file.
+  R7RS-small 5.6.1 defines a library by its `define-library` form and lets the
+  forms that follow import it, so the unit's own libraries now come first in
+  the resolution order — libraries established earlier in this compilation
+  unit, then precompiled stdlib modules, then the search path — on all three
+  back ends. Because a library becomes resolvable by being *processed* rather
+  than by living in a particular file, the ordering rule falls out rather than
+  being special-cased: an import above its `define-library` still fails, now
+  with a diagnostic naming the line the library is defined on. The VM lane was
+  the real gap — it knew none of `define-library`, `import` or `export`, and
+  compiled the program above into bytecode that warned about five undefined
+  variables and then died at run time calling a non-function, while the same
+  file ran on JIT and AOT. Three latent VM defects were fixed with it:
+  `(provide …)` emitted nothing at all, so the `OP_POP` after a form that bound
+  nothing discarded a **live** value and shifted every later binding down a
+  slot; the module loader compiled a required file's top-level forms without
+  that POP discipline, desynchronising `n_locals` from the real stack depth;
+  and a compile-time defect flag now stops both VM drivers, so
+  `compile_and_run()` refuses to execute and the ESKB emitter refuses to write
+  bytecode rather than leaving the process looking like it produced a good
+  artifact.
+
+#### Driver, linking and browser targets
+
+- **`--shared-lib` never linked a shared library, and exited 0 anyway.** The
+  documented capability raised `--compile-only`, wrote `<name>.o` and
+  `<name>.bc`, and exited zero with no library anywhere. Making it link exposed
+  why it could never have worked as documented: LLVM's calling convention for a
+  first-class-struct return is not the platform C calling convention for the
+  same struct. `eshkol_tagged_value_t` is 16 bytes passed internally as an LLVM
+  struct of five fields, which the backend flattens into one return register
+  *per field* — so a C caller compiled against the public header followed AAPCS,
+  read the first two registers, and got the flags byte masquerading as the
+  payload; with two tagged parameters the flattened fields overflow the
+  argument registers outright. Library-mode codegen now emits, for each
+  exported top-level function, a thunk that owns the exported name and speaks
+  the platform C ABI, forwarding to the unwrapped body: `[2 x i64]` in and out
+  on AArch64, x86-64 SysV, riscv64, ppc64le and loongarch64, `sret` plus
+  by-pointer on Windows x64, and a diagnostic refusal on 32-bit targets, which
+  neither shape models. Only the *linked-library* flavour gets thunks; the
+  relocatable `--shared-lib -c` object is linked into other Eshkol modules that
+  call with the internal convention and stays unwrapped. A second defect
+  surfaced with it: the runtime archives were not position-independent, so a
+  `thread_local` in `runtime_autodiff.cpp` got the local-exec TLS model and the
+  library could not be produced at all on ELF (`relocation R_X86_64_TPOFF32 …
+  can not be used when making a shared object`). `POSITION_INDEPENDENT_CODE`
+  now applies to the object libraries feeding `libeshkol-runtime.a` and
+  `libeshkol-agent-ffi.a` — on the object libraries, not the archives, where it
+  would have been a silent no-op that looked like a fix.
+
+- **The browser WASM glue was missing import stubs, so programs reaching them
+  failed to instantiate.** `eshkol_write_value`, `eshkol_write_value_to_port`
+  (the explicit-port form of `write`) and `eshkol_builtin_arena_used` had no
+  `env` import stubs in either `web/eshkol-repl.js` or
+  `site/static/eshkol-runtime.js`. Verified the authoritative way — by
+  compiling a program that reaches those symbols with `--wasm` and diffing the
+  module's real `env` imports against the glue, rather than trusting the import
+  scanner. The environment-independent half of the execution-backed coverage
+  gate also moves into the fast `surface-manifest` job, making it a **required**
+  check so a deliberately broken policy floor or deficit ratchet can no longer
+  hide behind a `continue-on-error` lane.
+
+- **The checked-in browser artifacts were stale against the release tree.**
+  `site/static/eshkol-vm.wasm` was last rebuilt on 25 July and the WASM
+  differential caught `42_iota_srfi1` and `52_numeric_tag_dispatch` failing
+  against it once those corpus files landed. Both checked-in artifacts are
+  regenerated from the current source through their canonical recipes —
+  `eshkol-site.wasm` 226,764 bytes, `eshkol-vm.wasm` 708,844 bytes (was
+  696,657) — with the pandoc-rendered documentation fragments under
+  `site/static/content/` refreshed to match current docs.
+
+#### Test harness and release gates
+
+- **Every green Linux test run was reported as an invalid run.** The
+  toolchain-fingerprint guard in `scripts/lib/test_isolation.sh` tried
+  `stat -f '%z %m'` before `stat -c '%s %Y'`. On BSD/macOS `-f` is the format
+  flag and this is correct; on GNU coreutils `-f` is `--file-system` and takes
+  no argument, so the "fingerprint" became free-block and inode counters, which
+  change between samples — declaring `INVALID RUN: the compiler binary changed
+  during this run` (exit 3) on fully passing runs. This had made every Linux
+  lane's job conclusion non-informative since the isolation guard landed, on
+  any branch, and plausibly accounts for much of the project's recorded
+  "unreliable Linux runner" history. GNU is tried first now, with the BSD form
+  as the fallback.
+
+- **A test suite could die silently when its temp root was already clean.**
+  `eshkol_test_isolation_prune_stale` globbed `"$root"/eshkol-test.*` straight
+  into `du`; with zero matching directories the glob stays a literal unmatched
+  pattern, `du` exits non-zero, and under a caller's `set -euo pipefail` that
+  status is fatal for the assignment — with `2>/dev/null` swallowing the
+  diagnostic, so there was no visible error at all. This is what killed
+  `run_language_coverage.sh` (exit 1, zero output), making the
+  `language_surface_coverage_floor` probe read as a false red when the coverage
+  floor was in fact green. Fixed by returning early when there is nothing to
+  prune, in both the count-based sweep and the size-based loop, which can drain
+  to zero *inside* the loop and re-glob an empty root on the next pass.
+
+- **The five-way surface baseline is re-anchored for the region-handle
+  rename.** The P8 axis-6 baseline is a shrink-only ratchet, and current master
+  produces the same disagreement count (640) with a different *set*: four
+  `ad-*` entries resolved and four `region-open`/`region-close` entries
+  appeared, a 4-for-4 swap a shrink-only ratchet cannot absorb, so the gate
+  read FAIL with nothing regressed. The four new entries record a genuine,
+  pre-existing cross-backend naming asymmetry — the VM dispatch table registers
+  `_region-open` / `_region-close-list` while the native backend registers
+  `region-open` / `region-close` — which stays open as a tracked build item
+  rather than being resolved by editing the baseline.
+
+- **A stale test reference became a build failure once diagnostics were
+  fatal.** `tests/lists/stdlib_display_test.esk` displayed a symbol named
+  `div`, which is defined nowhere: the division wrapper in
+  `core.operators.arithmetic` was renamed `div` to `divide` because a function
+  named `div` is emitted as a weak external that collides with libc's
+  `div(int,int)` and corrupts the 16-byte tagged-value ABI. The test predated
+  the rename and had been silently doing nothing; it now uses the real
+  spelling.
 
 ### Documentation
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if(POLICY CMP0091)
     cmake_policy(SET CMP0091 NEW)
 endif()
 
-set(ESHKOL_VERSION "1.3.3")
+set(ESHKOL_VERSION "1.3.4")
 
 project("Eshkol" VERSION ${ESHKOL_VERSION} LANGUAGES C CXX)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -383,8 +383,12 @@ eshkol/
 
 v1.0-foundation, v1.1-accelerate, v1.2-scale, and v1.3.0-evolve (arbitrary-order
 AD, full R7RS conformance, closure/TCO/memory hardening) are **complete**, and
-v1.3.3 has landed further robustness for long-running, resident programs plus
-comprehensive C-API documentation. We welcome contributions for upcoming releases:
+v1.3.1 through v1.3.4-evolve have landed further robustness for long-running,
+resident programs, an opt-in differentiable quantum stack, and a
+consumer-hardening correctness wave (automatic per-iteration reclamation,
+race-free `parallel-map`, exact gradients through every callable form, R7RS
+exactness contagion on both engines). We welcome contributions for upcoming
+releases:
 
 ### Immediate Priorities (v1.4-connection - July 2026)
 1. **TCP/UDP Sockets**: Linear resource types with guaranteed close

--- a/README.md
+++ b/README.md
@@ -665,8 +665,22 @@ Execute: `eshkol-run gradient.esk -o gradient && ./gradient`
 - **Hardening**: subprocess shell-injection fix, Python FFI AST-injection fix, integer-overflow guards (arena/KB/image), path-traversal defence, ReDoS protection, sanitizer-clean ASan/UBSan CI lane
 - **87-test edge/security suite**: regression coverage for symbol consistency, AD tape state, parser line tracking, stdlib symbol resolution, HTTP/server smoke behavior, and every fix in this release
 
-### v1.3.3-evolve Release Candidate
+### v1.3.4-evolve Release
 
+- **Consumer-hardening correctness wave**: an emitted compile-time error now
+  prevents artifact emission and execution, so a diagnosed program fails the
+  build instead of producing a wrong answer. Exactness is decided from an
+  operand's runtime tag rather than a result's value shape, on the native
+  flonum integer-division family and across the bytecode VM's numeric surface;
+  automatic differentiation answers exactly at exact (rational/bignum) points,
+  survives per-iteration nursery reclamation, and no longer returns zeros above
+  gradient arity 16; `define-library`/`import` resolve same-unit libraries on
+  all three back ends; and `--shared-lib` links a real, C-ABI-correct shared
+  library.
+- **New capability**: a portable event loop (kqueue / epoll / IOCP, fail-closed
+  on WASM), a fixed-point and `i128` exact-accumulation engine with
+  order-independent bit-exact reductions, the qLLM bridge implementation, and
+  embedding / Fréchet-mean backward passes.
 - **Portable 16-file release payload**: 15 platform archives plus
   `SHA256SUMS.txt`. Linux x64/ARM64 ship Lite, XLA, and CUDA; macOS x64/ARM64
   ship Lite and XLA; Windows x64 ships Lite, XLA, and CUDA; Windows ARM64
@@ -676,15 +690,15 @@ Execute: `eshkol-run gradient.esk -o gradient && ./gradient`
   cache links, image-codec dependencies, generic ARM64 stdlib code,
   architecture-matched compiler-rt, and CUDA consumer paths are verified by
   the release workflow rather than inferred from builder-local success.
-- **Complete executable evidence**: 44/44 suites and 716/716 tests, CTest
-  76/76, SICP 88/88 under JIT and AOT, 1,057/1,057 declared executable
-  language surfaces, and ICC architecture/readiness at 8/8 and 100/100, as
-  recorded in the
-  [release-candidate readiness report](docs/internal/RELEASE_READINESS_REPORT.md).
-- **Explicit VM scope**: the supported shared corpus passes 68/68 across
-  native LLVM, VM source, and emitted ESKB. This is not a claim of complete
-  backend parity: the current 916-row ratchet classifies 540 VM-supported
-  entries, 44 justified native-only entries, and 332 explicit gaps in
+- **Execution-backed evidence**: CTest 139/139 on the release commit, and
+  1,091/1,091 declared executable language surfaces — every declared construct
+  earns its row by dispatching or executing in a passing run, with lexical
+  name-presence demoted to a diagnostic that earns no release credit. CTest
+  results are now completion-oracle evidence in their own right, so a red suite
+  turns the release gate red.
+- **Explicit VM scope**: this is not a claim of complete backend parity. The
+  951-row ratchet classifies 578 VM-supported entries, 44 justified
+  native-only entries, and 329 explicit gaps in
   [`tests/vm_parity/PARITY.tsv`](tests/vm_parity/PARITY.tsv); see
   [VM Parity](docs/VM_PARITY.md) for the enforced contract.
 

--- a/README.md
+++ b/README.md
@@ -694,11 +694,12 @@ Execute: `eshkol-run gradient.esk -o gradient && ./gradient`
   aggregate suite 45/45 suites and 770 individual tests, CTest 139/139, the
   SICP full-book gate 88/88 probes across all five chapters under both `-r` and
   AOT, and the reference-Scheme differential oracle 34/34 AGREE against
-  chibi-scheme 0.12.0. The language surface is 1,091/1,091 — every declared
-  construct earns its row by dispatching or executing in a passing run, with
-  lexical name-presence demoted to a diagnostic that earns no release credit.
-  CTest results are now completion-oracle evidence in their own right, so a red
-  suite turns the release gate red.
+  chibi-scheme 0.12.0. The language-surface gate enforces a monotonic floor of
+  1,091 declared constructs at 100% execution-backed coverage: a construct
+  earns its row by dispatching or executing in a passing run, and lexical
+  name-presence is a diagnostic only, earning no release credit. CTest results
+  are now completion-oracle evidence in their own right, so a red suite turns
+  the release gate red.
 - **Explicit VM scope**: this is not a claim of complete backend parity. The
   951-row ratchet classifies 578 VM-supported entries, 44 justified
   native-only entries, and 329 explicit gaps in

--- a/README.md
+++ b/README.md
@@ -690,12 +690,15 @@ Execute: `eshkol-run gradient.esk -o gradient && ./gradient`
   cache links, image-codec dependencies, generic ARM64 stdlib code,
   architecture-matched compiler-rt, and CUDA consumer paths are verified by
   the release workflow rather than inferred from builder-local success.
-- **Execution-backed evidence**: CTest 139/139 on the release commit, and
-  1,091/1,091 declared executable language surfaces — every declared construct
-  earns its row by dispatching or executing in a passing run, with lexical
-  name-presence demoted to a diagnostic that earns no release credit. CTest
-  results are now completion-oracle evidence in their own right, so a red suite
-  turns the release gate red.
+- **Execution-backed evidence**, all measured on the release commit: the
+  aggregate suite 45/45 suites and 770 individual tests, CTest 139/139, the
+  SICP full-book gate 88/88 probes across all five chapters under both `-r` and
+  AOT, and the reference-Scheme differential oracle 34/34 AGREE against
+  chibi-scheme 0.12.0. The language surface is 1,091/1,091 — every declared
+  construct earns its row by dispatching or executing in a passing run, with
+  lexical name-presence demoted to a diagnostic that earns no release credit.
+  CTest results are now completion-oracle evidence in their own right, so a red
+  suite turns the release gate red.
 - **Explicit VM scope**: this is not a claim of complete backend parity. The
   951-row ratchet classifies 578 VM-supported entries, 44 justified
   native-only entries, and 329 explicit gaps in

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -127,8 +127,9 @@ results as evidence.
   at an exact point all five operators now run the same Taylor-tower pass
   `derivative-n` runs, so `(derivative f x)` equals `(derivative-n f x 1)` and
   `(hessian f x)` equals `(derivative-n f x 2)` in value **and** in exactness.
-  `(derivative (lambda (x) (* x x x)) 1/3)` is `1/3`, exact, where it used to
-  be `0.6666666666666666` at best. The tier keeps `+ - * /` and
+  `(derivative (lambda (x) (* x x x)) 1/3)` is `1/3` with `exact?` true, where
+  the operators previously either crashed or, once the crash was fixed,
+  returned only the nearest `double`. The tier keeps `+ - * /` and
   non-negative-integer `expt` exact and demotes to f64 at the first
   transcendental, per R7RS exactness contagion.
 - **Gradients through loop-filled vectors are correct again.** `(gradient f x)`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,26 @@ linear solver, and a native 128-bit integer type — lands alongside a Moonlab
 v1.2.0 quantum pin, full hosted-VM tensor-matmul parity, and a round-tripping
 numeric printer, over a hardened toolchain and a broadened assurance surface.
 
+The second half of the cycle is a consumer-hardening correctness wave, and it
+has one organising principle: a wrong answer must not be able to look like a
+right one. The change that made the rest possible is that an emitted
+compile-time error now prevents artifact emission and execution — the compiler
+used to diagnose a program and then build and run it anyway. That turned a
+family of silent wrong answers into build failures, and the wave that followed
+fixed them at the root. Exactness is now decided from an operand's runtime tag
+rather than from a result's value shape, both on the native flonum
+integer-division family and across the bytecode VM's numeric surface.
+Automatic differentiation answers exactly at exact points, survives
+per-iteration nursery reclamation, and no longer returns zeros above gradient
+arity 16. `define-library` and `import` resolve same-unit libraries on all
+three back ends, including a VM lane that previously knew none of those forms.
+`--shared-lib` links a real, C-ABI-correct shared library instead of exiting
+zero with no artifact. Alongside those corrections the release adds a portable
+event loop, a fixed-point and `i128` exact-accumulation engine, the qLLM bridge
+implementation its documented backward rules had been waiting for, embedding
+and Fréchet-mean backward passes, and a release gate that finally reads CTest
+results as evidence.
+
 ## Highlights
 
 ### Automatic memory reclamation matches explicit regions
@@ -80,6 +100,150 @@ numeric printer, over a hardened toolchain and a broadened assurance surface.
   node-pointer array now grows from the tape's owning arena, so it is reclaimed
   with the region at `region_pop` instead of accreting residual memory each step.
 
+### A diagnosed program no longer builds and runs
+
+- **An emitted error diagnostic prevents artifact emission and execution.** The
+  compiler used to print `ERROR: …` and then emit, link and run a binary
+  anyway, so a diagnosed program produced a wrong answer instead of a failed
+  build. This is the mechanism that kept the rest of this release's defects
+  quiet: each of them was reported at compile time, and every report was
+  ignored. Reporting an error is one call at any of 805 sites; propagating one
+  is a return path through every enclosing frame, and the codegen frames
+  recover by substituting a placeholder and carrying on. All 805 sites funnel
+  through four logging primitives, so an authoritative error state now lives in
+  one place and every path contributes to it. Downstream, this converted a
+  family of silent wrong answers into build failures — including several fixed
+  in this release, which is how they were found.
+
+### Differentiation is exact at exact points, and survives automatic reclamation
+
+- **`derivative`, `gradient` and `hessian` at exact points.** At a rational or
+  bignum point these three used to return garbage — an exact number is
+  HEAP-tagged, so its data field holds a pointer, and every AD entry point
+  reinterpreted that field as a number, differentiating at the object's
+  address. One authority per question now dispatches on the runtime tag, and
+  refuses a non-numeric point with a catchable type error rather than inventing
+  a number for it. With the crash gone, the exactness gap behind it closed too:
+  at an exact point all five operators now run the same Taylor-tower pass
+  `derivative-n` runs, so `(derivative f x)` equals `(derivative-n f x 1)` and
+  `(hessian f x)` equals `(derivative-n f x 2)` in value **and** in exactness.
+  `(derivative (lambda (x) (* x x x)) 1/3)` is `1/3`, exact, where it used to
+  be `0.6666666666666666` at best. The tier keeps `+ - * /` and
+  non-negative-integer `expt` exact and demotes to f64 at the first
+  transcendental, per R7RS exactness contagion.
+- **Gradients through loop-filled vectors are correct again.** `(gradient f x)`
+  returned a silently wrong gradient whenever `f` filled a vector with
+  `vector-set!` inside a loop and then selected a component: the derivative was
+  attributed to the last element written, for every element read. Primal values
+  stayed exact and stderr was empty, so a row-by-row Jacobian — the standard
+  idiom — came out uniform garbage while looking plausible. The per-iteration
+  nursery introduced by the reclamation work above resets its arena on each
+  back edge, and the write barrier that must promote escapees did not recognise
+  a dual number as pointer-carrying, so the tangent was recycled underneath the
+  computation. The barrier, the `with-region` escape path and the nursery
+  recycle now share one predicate, and tape-retained AD nodes allocate from the
+  tape's owning arena.
+- **Gradient arity above 16 works, rather than returning zeros.** A gradient of
+  a closure reached as a value had its argument spread clamped at 16, so a
+  declared arity of 17 to 32 crashed, silently produced an all-zero gradient,
+  or raised a type error. The spread is now emitted once per module out of
+  line, with the arity dispatch done by the closure dispatcher's own runtime
+  argument-count switch, so the ceiling of 32 is real. The out-of-line form is
+  also smaller than what preceded the widening, which restores compile times on
+  Windows, where the linkage the inline spread used cannot be discarded.
+- **Embedding and Fréchet-mean backward passes.** Two rules that previously
+  refused outright now compute. The embedding adjoint is a scatter-add;
+  duplicate indices accumulate and unselected rows are bitwise zero, both
+  asserted directly because both have failure modes that stay the right shape
+  and magnitude. The weighted Fréchet (Karcher) mean on the Poincaré ball is
+  differentiated by implicit differentiation of its optimality condition rather
+  than by unrolling the solver.
+
+### Exactness across the numeric tower
+
+- **The bytecode VM kept inexactness.** The VM decided a numeric result's
+  domain from its *value* rather than from its operands' tags, so
+  `(/ (- 2.0 1.0) (+ 2.0 1.0))` answered the exact `1/3` where native answered
+  `0.3333333333333333`: any integral-valued double collapsed to an exact
+  integer, in both the runtime constructor and the constant folder.
+  Independently, the rational natives truncated a flonum operand into an int64
+  numerator, so `(* 0.5493061443340549 1/3)` evaluated `(* 0 1/3)` and answered
+  the exact 0. Exactness is now decided from operand tags throughout, and the
+  folder folds by the parser's literal exactness flags. Divergent native-vs-VM
+  numeric combinations drop from 79 to 20, and the remainder — bignum-over-
+  bignum rationals the VM's rational type cannot represent — are answered as a
+  correctly-rounded inexact value and recorded as a justified parity row rather
+  than left silent.
+- **Native flonum integer division follows R7RS 6.2.6.** `modulo` and
+  `remainder` had no flonum path, so both operands went through the int64
+  unpack and the answer was the remainder of two IEEE-754 *bit patterns*
+  (`(modulo 5.5 2.0)` returned `6192449487634432`); `remainder` also called the
+  C library's round-to-nearest `remainder()`, a different function from
+  Scheme's truncated one. `quotient`'s double path narrowed to int64 and packed
+  the result exact, so it broke contagion by construction and saturated to a
+  single plausible-looking constant past 2^63 — the same constant it returned
+  for division by `0.0`. The floor-division family was int64-only, so
+  `floor-remainder` disagreed with the `modulo` that R7RS defines it to equal.
+  All of these are fixed, a zero divisor now raises uniformly across the
+  family including the mixed-bignum route, and `(/ (expt 2 100) 0.0)` is
+  `+inf.0` rather than `0`.
+
+### Modules
+
+- **`define-library` and `import` resolve libraries defined in the same file,
+  on all three back ends.** `define-library` validated its library name and
+  discarded it, so `import` had nothing to consult but a filesystem search that
+  can only find a library living in some *other* file — and reported
+  `Module 'smoke.v1_3' not found` about a library written one line above.
+  R7RS-small 5.6.1 defines a library by its form and lets the forms that follow
+  import it, so a unit's own libraries now come first in the resolution order,
+  ahead of precompiled stdlib modules and the search path. A library becomes
+  resolvable by being processed rather than by living in a particular file, so
+  an import placed *above* its `define-library` still fails, now with a
+  diagnostic naming the line the library is defined on. The bytecode VM was the
+  real gap: it knew none of `define-library`, `import` or `export`, and
+  compiled such a program into bytecode that warned about undefined variables
+  and then died at run time, while the same file ran on JIT and AOT. Three
+  latent VM defects were fixed with it, including a `provide` that emitted
+  nothing and left a stray `OP_POP` discarding a live value — shifting every
+  later binding down a slot.
+
+### New runtime capability
+
+- **A portable event loop.** `make-event-loop`, `event-loop-add-fd!`,
+  `event-loop-remove-fd!`, `event-loop-poll`, `event-loop-close` and
+  `event-loop-backend` wrap kqueue on macOS and BSD, epoll on Linux and
+  Android, and IOCP on Windows, with a fail-closed stub on WebAssembly. Exactly
+  one backend is compiled in, and the portable half — handle registry, argument
+  validation, generation-tagged handles, result coalescing — is shared by every
+  backend and by the bytecode VM, so there is no native/VM parity surface to
+  maintain separately. Verified with a pipe round-trip inside its timeout, an
+  idle poll that waits its budget and returns rather than hanging, and 1,000
+  sequential open/close cycles that never exhaust the descriptor table.
+- **A fixed-point and `i128` exact-accumulation engine.** `esk_i128`, a
+  parametric `fixed<W,F>` with explicit per-operation rounding, and a
+  block-scaled `dot_exact` reduction over an i128 accumulator, for reductions
+  that must be bit-exact regardless of summation order. 200 shuffles of 4,096
+  elements and 50 matmul contraction orders are byte-identical under the exact
+  path, while an f64 control drifts about 1.5e-06 between orderings on the same
+  inputs — and the exact path measured *faster* than an f64 double-double
+  baseline (13.6 GB/s against 4.3 GB/s), so exactness is not paid for in
+  throughput here. `ESHKOL_FIXED_POINT_ENGINE` is ON by default and forced OFF
+  on MSVC and ClangCL, which lack the `__int128` ABI it relies on. The
+  `eshkol-fixedpoint` shared library is self-contained C11 over libc and libm,
+  so it is consumable without the rest of the toolchain.
+- **The qLLM bridge is implemented.** Its header declared 17 functions and the
+  generated API documentation reported them all documented, but none was
+  defined anywhere in the tree — while the bridge's *backward* half had already
+  shipped, with exact gradient rules for 11 of 13 tensor AD node types
+  compiled into the runtime and unreachable, because nothing ever created a
+  node of those types. All 17 are now implemented and record canonical AD tape
+  nodes, so those rules run. Where a backward rule cannot differentiate a shape
+  exactly the forward refuses rather than recording a node whose gradient would
+  be wrong. `ESHKOL_QLLM_ENABLED` is opt-in and OFF by default, and turning it
+  on without a discoverable library is a configure-time error rather than a
+  silent no-op.
+
 ### High-precision numerics
 
 - **Ozaki-II exact DGEMM** recovers full-f64 `C = A*B` from reduced-precision
@@ -137,6 +301,30 @@ numeric printer, over a hardened toolchain and a broadened assurance surface.
 
 ### Toolchain and packaging
 
+- **`--shared-lib` links a real, C-ABI-correct shared library.** The documented
+  flag raised `--compile-only`, wrote an object and a bitcode file, and exited
+  zero with no library anywhere. Making it link exposed why it could never have
+  worked as documented: LLVM's calling convention for a first-class-struct
+  return is not the platform C calling convention for the same struct, so a C
+  caller compiled against the public header read the tagged value's flags byte
+  as the payload. Library-mode codegen now emits a platform-C-ABI thunk per
+  exported top-level function — `[2 x i64]` on AArch64, x86-64 SysV, riscv64,
+  ppc64le and loongarch64, `sret` plus by-pointer on Windows x64, and a
+  diagnostic refusal on 32-bit targets, which neither shape models. The
+  relocatable `--shared-lib -c` object, which other Eshkol modules call with
+  the internal convention, stays unwrapped. Separately, the runtime archives
+  are now position-independent: a `thread_local` compiled non-PIC took the
+  local-exec TLS model, so on ELF hosts the library could not be produced at
+  all.
+- **The browser WASM glue is complete, and the checked-in artifacts are
+  current.** `eshkol_write_value`, `eshkol_write_value_to_port` and
+  `eshkol_builtin_arena_used` had no `env` import stubs in the browser glue,
+  so programs reaching them failed to instantiate; the gap was verified by
+  compiling a program that reaches those symbols and diffing the module's real
+  imports against the glue, rather than by trusting the import scanner. Both
+  checked-in artifacts (`eshkol-site.wasm`, `eshkol-vm.wasm`) are regenerated
+  from current source through their canonical recipes, closing WASM
+  differential failures against the release tree.
 - **Transitive FFI-link discovery, with fatal link failures under `-r`.** Native
   agent-FFI link requirements now propagate through the full transitive
   `(load …)` / `(import …)` / `(require …)` source closure, so a dependency
@@ -170,6 +358,38 @@ numeric printer, over a hardened toolchain and a broadened assurance surface.
   is now gated against native rather than only checked for a valid binary;
   divergences are tracked per file (EXCLUDED / XFAIL, with an unexpected match
   failing the gate).
+- **CTest results are release-gate evidence.** No completion-oracle criterion
+  consumed a CTest result at all — the test-evidence criteria were index-level
+  ("the tests exist and are runnable"), so a red CTest run could not turn the
+  release gate red, and a pillar could ship with a perfectly good CTest gate
+  that the target judging the cut never looked at. `scripts/run_ctest_gate.sh`
+  now emits per-test, per-group and whole-suite trace events, and a group whose
+  regex matches no configured test is reported ABSENT and **fails** the gate,
+  so a pillar cannot quietly stop being covered because its tests were renamed
+  or configured out. Eight criteria are wired, covering the fixed-point engine,
+  the exact-input AD identity tier, the runtime-closure arity spread, same-unit
+  `define-library`, the self-checking VM surface suite, VM parity and the event
+  loop.
+- **Display-only tests assert.** A recurring test shape — `display` the
+  computed values, print an unconditional pass banner, and leave the expected
+  values in a comment — meant the harness saw exit 0 and the comparison the
+  comment described was never written. The first wave of that sweep is in this
+  release; each test it turns red is a previously hidden defect.
+- **Two harness defects that produced false verdicts are fixed.** The
+  toolchain-fingerprint guard tried the BSD `stat -f` format before the GNU
+  `stat -c` one; on GNU coreutils `-f` means `--file-system`, so the
+  "fingerprint" was free-block and inode counters and every green Linux run was
+  declared `INVALID RUN` (exit 3). And the stale-directory prune globbed an
+  unmatched pattern into `du`, which under `set -euo pipefail` killed the
+  calling suite silently — which is what made the language-coverage floor read
+  as a false red when it was in fact green.
+- **The five-way surface baseline is re-anchored.** The P8 axis-6 ratchet is
+  shrink-only, and current master produces the same disagreement count with a
+  different set — four AD entries resolved, four region-handle entries appeared
+  — which a shrink-only ratchet cannot absorb. The four new entries record a
+  genuine, pre-existing cross-backend naming asymmetry between the VM's
+  `_region-open` and the native `region-open`; it stays open as a tracked build
+  item rather than being resolved by editing the baseline.
 
 ---
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,6 +1,6 @@
-# Eshkol v1.3.3 API Reference
+# Eshkol v1.3.4 API Reference
 
-**Version**: 1.3.3
+**Version**: 1.3.4
 **Last Updated**: 2026-07-08
 **Audience**: Scientific Computing & AI Systems Programming
 

--- a/docs/COMPLETE_LANGUAGE_SPECIFICATION.md
+++ b/docs/COMPLETE_LANGUAGE_SPECIFICATION.md
@@ -1,6 +1,6 @@
 # Eshkol Language - Complete Technical Specification
 
-**Version:** v1.3.3
+**Version:** v1.3.4
 **Generated:** 2026-07-08
 **Status:** Comprehensive implementation documentation from source code
 
@@ -4131,9 +4131,26 @@ Keep original name (exported via `provide`)
 
 ## 26. Version Information
 
-**Current Version:** v1.3.3
+**Current Version:** v1.3.4
 
 **Version History:**
+- v1.3.4-evolve - Consumer-hardening correctness wave: automatic per-iteration
+  memory reclamation that matches explicit `with-region`, race-free
+  `parallel-map`, exact gradients through every callable form and at exact
+  (rational/bignum) points, R7RS-correct exactness contagion on both the native
+  and bytecode-VM numeric paths, same-unit `define-library`/`import` resolution
+  on all three back ends, an emitted error diagnostic that prevents artifact
+  emission, a portable event-loop primitive, a fixed-point/i128
+  exact-accumulation engine, and the high-precision numerics wave (Ozaki-II
+  exact and reduced-precision GEMM tiers, mixed-precision `linear-solve`,
+  native `i128`). See [CHANGELOG.md](../CHANGELOG.md).
+- v1.3.3-evolve - Opt-in differentiable quantum computing (Moonlab VQE/CHSH),
+  ML-KEM post-quantum cryptography, `core.dbsp` incremental dataflow, real
+  `make-parameter`/`parameterize` dynamic parameters, and bignum-capable exact
+  rationals. See [CHANGELOG.md](../CHANGELOG.md).
+- v1.3.2-evolve - Thread-safe regions and deeper region-escape evacuation
+  (ESH-0214d subtype coverage), plus the nine-cluster architectural research
+  ADRs. See [CHANGELOG.md](../CHANGELOG.md).
 - v1.3.1 - Robustness for long-running, resident programs: per-iteration
   arena reclamation for define-loops guarded by a catch-all handler, an
   iterative reader so large persisted structures load without native stack

--- a/docs/ESHKOL_LANGUAGE_GUIDE.md
+++ b/docs/ESHKOL_LANGUAGE_GUIDE.md
@@ -1135,7 +1135,7 @@ Map Eshkol names to C names:
 
 ```
 $ ./eshkol-repl
-Eshkol REPL v1.3.3
+Eshkol REPL v1.3.4
 Type :help for assistance, :quit to exit
 
 eshkol> (define (square x) (* x x))
@@ -1531,5 +1531,5 @@ MIT License - Copyright (C) tsotchke
 ---
 
 <p align="center">
-<strong>Eshkol v1.3.3</strong>: Where functional programming meets scientific computing, GPU acceleration, and machine consciousness.
+<strong>Eshkol v1.3.4</strong>: Where functional programming meets scientific computing, GPU acceleration, and machine consciousness.
 </p>

--- a/docs/ESHKOL_QUICK_REFERENCE.md
+++ b/docs/ESHKOL_QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Eshkol Quick Reference Card
 
-**v1.3.3** -- 555+ built-in functions
+**v1.3.4** -- 555+ built-in functions
 
 ## Basics
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ pages and lets them fan out to their siblings.
 
 - [Language Guide](ESHKOL_LANGUAGE_GUIDE.md) — tutorial-style introduction to the language
 - [Language Reference index](reference/language/INDEX.md) — complete, example-verified function and syntax reference (binding/mutation, control flow, error handling, pattern matching, modules, continuations, and more)
-- [Complete Language Specification](COMPLETE_LANGUAGE_SPECIFICATION.md) — full technical specification, v1.3.0-evolve
+- [Complete Language Specification](COMPLETE_LANGUAGE_SPECIFICATION.md) — full technical specification, v1.3.4-evolve
 - [Quick Reference](ESHKOL_QUICK_REFERENCE.md) — one-page cheat sheet, 555+ builtins
 - [API Reference](API_REFERENCE.md) — comprehensive function documentation
 - [Standard Library API index](reference/stdlib/INDEX.md) — module-by-function map of the standard library (58 modules, 638 symbols)

--- a/inc/eshkol/eshkol.h
+++ b/inc/eshkol/eshkol.h
@@ -16,8 +16,8 @@
  */
 #define ESHKOL_VERSION_MAJOR 1
 #define ESHKOL_VERSION_MINOR 3
-#define ESHKOL_VERSION_PATCH 3
-#define ESHKOL_VERSION_STRING "1.3.3-evolve"
+#define ESHKOL_VERSION_PATCH 4
+#define ESHKOL_VERSION_STRING "1.3.4-evolve"
 
 #include <stdint.h>
 #include <stdbool.h>

--- a/press/ESHKOL_DESCRIPTION_COPY.md
+++ b/press/ESHKOL_DESCRIPTION_COPY.md
@@ -242,11 +242,12 @@ Each item below cites the file or measurement that grounds the claim.
   and the bytecode VM) and an AD-vs-finite-difference adversarial oracle (147
   probes / 436 component checks across 21 generated files under JIT and AOT; a
   zero AD gradient where finite differences are nonzero is a hard failure).
-  Release gates green on the v1.3.3-evolve SHA: ICC readiness oracle 100/100
-  (trace-verified); the aggregate suite 44/44 suites and 716/716 tests; SICP
-  full-book gate 88/88 probes across all five chapters under both `-r` and
-  AOT; reference-Scheme differential oracle 34/34 AGREE. See
-  *docs/TESTING.md*.
+  Release gates green on the v1.3.4-evolve cut: the aggregate suite 45/45
+  suites and 770 individual tests; CTest 139/139, which as of this release is
+  itself completion-oracle evidence rather than advice; SICP full-book gate
+  88/88 probes across all five chapters under both `-r` and AOT;
+  reference-Scheme differential oracle 34/34 AGREE against chibi-scheme
+  0.12.0. See *docs/TESTING.md*.
 
 - **Binary Lambda Calculus (`core.blc`, v1.3.2-evolve).** A pure-Eshkol
   implementation of John Tromp's BLC: De Bruijn-indexed terms as homoiconic

--- a/press/ESHKOL_DESCRIPTION_COPY.md
+++ b/press/ESHKOL_DESCRIPTION_COPY.md
@@ -356,7 +356,7 @@ release builds produce byte-identical `build/stdlib.bc` and `build/eshkol-run`
 |:---|:---|
 | Project | Eshkol |
 | Version | v1.3.4-evolve |
-| Release date | 23 July 2026 (builds on v1.3.3-evolve, 16 July 2026; v1.3.2-evolve, 9 July 2026; v1.3.1-evolve and v1.3.0-evolve, 7 July 2026) |
+| Release date | 31 July 2026 (builds on v1.3.3-evolve, 16 July 2026; v1.3.2-evolve, 9 July 2026; v1.3.1-evolve and v1.3.0-evolve, 7 July 2026) |
 | Implementation | C17 runtime, C++20 compiler |
 | Backend | LLVM 21 (version-enforced) |
 | Platforms | macOS Intel and Apple Silicon, Linux x86-64 and ARM64, Windows x86-64 and ARM64 via Visual Studio 2022 + ClangCL |

--- a/press/ESHKOL_PRESS_INFORMATION_SHEET.md
+++ b/press/ESHKOL_PRESS_INFORMATION_SHEET.md
@@ -18,7 +18,7 @@ it carries.
 | Project | Eshkol |
 | Version | v1.3.4-evolve |
 | Builds on | v1.3.3-evolve (16 July 2026), v1.3.2-evolve (9 July 2026), v1.3.1-evolve, v1.3.0-evolve (7 July 2026) |
-| Release date | 23 July 2026 |
+| Release date | 31 July 2026 |
 | Licence | MIT |
 | Source | https://github.com/tsotchke/eshkol |
 | Website | https://eshkol.ai |
@@ -987,7 +987,7 @@ link errors.
 @software{eshkol2026,
   title    = {Eshkol: A Programming Language for Mathematical Computing},
   author   = {tsotchke},
-  version  = {1.3.3-evolve},
+  version  = {1.3.4-evolve},
   year     = {2026},
   url      = {https://github.com/tsotchke/eshkol}
 }

--- a/site/static/content/api_reference.html
+++ b/site/static/content/api_reference.html
@@ -1,5 +1,5 @@
-<h1 id="eshkol-v1.3.3-api-reference">Eshkol v1.3.3 API Reference</h1>
-<p><strong>Version</strong>: 1.3.3 <strong>Last Updated</strong>:
+<h1 id="eshkol-v1.3.4-api-reference">Eshkol v1.3.4 API Reference</h1>
+<p><strong>Version</strong>: 1.3.4 <strong>Last Updated</strong>:
 2026-07-08 <strong>Audience</strong>: Scientific Computing &amp; AI
 Systems Programming</p>
 <p>This comprehensive reference documents all special forms, functions,

--- a/site/static/content/complete_language_specification.html
+++ b/site/static/content/complete_language_specification.html
@@ -1,6 +1,6 @@
 <h1 id="eshkol-language---complete-technical-specification">Eshkol
 Language - Complete Technical Specification</h1>
-<p><strong>Version:</strong> v1.3.3 <strong>Generated:</strong>
+<p><strong>Version:</strong> v1.3.4 <strong>Generated:</strong>
 2026-07-08 <strong>Status:</strong> Comprehensive implementation
 documentation from source code</p>
 <hr />
@@ -3920,8 +3920,28 @@ Automatic handler cleanup</p>
 <code>provide</code>)</p>
 <hr />
 <h2 id="version-information">26. Version Information</h2>
-<p><strong>Current Version:</strong> v1.3.3</p>
-<p><strong>Version History:</strong> - v1.3.1 - Robustness for
+<p><strong>Current Version:</strong> v1.3.4</p>
+<p><strong>Version History:</strong> - v1.3.4-evolve -
+Consumer-hardening correctness wave: automatic per-iteration memory
+reclamation that matches explicit <code>with-region</code>, race-free
+<code>parallel-map</code>, exact gradients through every callable form
+and at exact (rational/bignum) points, R7RS-correct exactness contagion
+on both the native and bytecode-VM numeric paths, same-unit
+<code>define-library</code>/<code>import</code> resolution on all three
+back ends, an emitted error diagnostic that prevents artifact emission,
+a portable event-loop primitive, a fixed-point/i128 exact-accumulation
+engine, and the high-precision numerics wave (Ozaki-II exact and
+reduced-precision GEMM tiers, mixed-precision <code>linear-solve</code>,
+native <code>i128</code>). See <a
+href="../CHANGELOG.md">CHANGELOG.md</a>. - v1.3.3-evolve - Opt-in
+differentiable quantum computing (Moonlab VQE/CHSH), ML-KEM post-quantum
+cryptography, <code>core.dbsp</code> incremental dataflow, real
+<code>make-parameter</code>/<code>parameterize</code> dynamic
+parameters, and bignum-capable exact rationals. See <a
+href="../CHANGELOG.md">CHANGELOG.md</a>. - v1.3.2-evolve - Thread-safe
+regions and deeper region-escape evacuation (ESH-0214d subtype
+coverage), plus the nine-cluster architectural research ADRs. See <a
+href="../CHANGELOG.md">CHANGELOG.md</a>. - v1.3.1 - Robustness for
 long-running, resident programs: per-iteration arena reclamation for
 define-loops guarded by a catch-all handler, an iterative reader so
 large persisted structures load without native stack overflow, and

--- a/site/static/content/contributing.html
+++ b/site/static/content/contributing.html
@@ -403,9 +403,13 @@ reviews.</li>
 Contribution (v1.4+)</h2>
 <p>v1.0-foundation, v1.1-accelerate, v1.2-scale, and v1.3.0-evolve
 (arbitrary-order AD, full R7RS conformance, closure/TCO/memory
-hardening) are <strong>complete</strong>, and v1.3.3 has landed further
-robustness for long-running, resident programs plus comprehensive C-API
-documentation. We welcome contributions for upcoming releases:</p>
+hardening) are <strong>complete</strong>, and v1.3.1 through
+v1.3.4-evolve have landed further robustness for long-running, resident
+programs, an opt-in differentiable quantum stack, and a
+consumer-hardening correctness wave (automatic per-iteration
+reclamation, race-free <code>parallel-map</code>, exact gradients
+through every callable form, R7RS exactness contagion on both engines).
+We welcome contributions for upcoming releases:</p>
 <h3 id="immediate-priorities-v1.4-connection---july-2026">Immediate
 Priorities (v1.4-connection - July 2026)</h3>
 <ol type="1">

--- a/site/static/content/eshkol_language_guide.html
+++ b/site/static/content/eshkol_language_guide.html
@@ -1145,7 +1145,7 @@ detection</li>
 :history   Show command history</code></pre>
 <h3 id="example-session">Example Session</h3>
 <pre><code>$ ./eshkol-repl
-Eshkol REPL v1.3.3
+Eshkol REPL v1.3.4
 Type :help for assistance, :quit to exit
 
 eshkol&gt; (define (square x) (* x x))
@@ -1737,6 +1737,6 @@ integration</label></li>
 <p>MIT License - Copyright (C) tsotchke</p>
 <hr />
 <p align="center">
-<strong>Eshkol v1.3.3</strong>: Where functional programming meets
+<strong>Eshkol v1.3.4</strong>: Where functional programming meets
 scientific computing, GPU acceleration, and machine consciousness.
 </p>

--- a/site/static/content/eshkol_quick_reference.html
+++ b/site/static/content/eshkol_quick_reference.html
@@ -1,5 +1,5 @@
 <h1 id="eshkol-quick-reference-card">Eshkol Quick Reference Card</h1>
-<p><strong>v1.3.3</strong> – 555+ built-in functions</p>
+<p><strong>v1.3.4</strong> – 555+ built-in functions</p>
 <h2 id="basics">Basics</h2>
 <pre class="scheme"><code>;; Variables
 (define x 42)

--- a/tests/qllm_oracle/README.md
+++ b/tests/qllm_oracle/README.md
@@ -44,7 +44,7 @@ VJP tests.
 {
   "schema_version": 1,
   "primitive": "poincare_project",
-  "eshkol_version": "1.3.3",
+  "eshkol_version": "1.3.4",
   "generator": "tests/qllm_oracle/poincare_project.esk",
   "reference": "python/qllm/torch_geometric.py::poincare_project",
   "formula": "conf = clamp_min(1 - c*|x|^2, eps); out = 0.25 * conf^2 * grad",

--- a/tests/qllm_oracle/golden/poincare_exp_log_basepoint.json
+++ b/tests/qllm_oracle/golden/poincare_exp_log_basepoint.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "primitive": "poincare_exp_log_basepoint",
-  "eshkol_version": "1.3.3",
+  "eshkol_version": "1.3.4",
   "generator": "tests/qllm_oracle/poincare_maps.esk",
   "reference": "standard Mobius/Ganea exp_x and log_x, qllm-clamped artanh",
   "formula": "lambda_x = 2/(1-c|x|^2); exp_x(v) = x (+)_c tanh(sqrt(c) lambda_x |v|/2) v/(sqrt(c)|v|); log_x(y) = (2/(sqrt(c) lambda_x)) artanh(sqrt(c)|u|) u/|u|, u = (-x) (+)_c y",

--- a/tests/qllm_oracle/golden/poincare_exp_map_origin.json
+++ b/tests/qllm_oracle/golden/poincare_exp_map_origin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "primitive": "poincare_exp_map_origin",
-  "eshkol_version": "1.3.3",
+  "eshkol_version": "1.3.4",
   "generator": "tests/qllm_oracle/poincare_maps.esk",
   "reference": "src/model/grr.c::fast_exp_map_origin",
   "formula": "t = sqrt(c)|v|; out = v * tanh(t)/t",

--- a/tests/qllm_oracle/golden/poincare_log_map_origin.json
+++ b/tests/qllm_oracle/golden/poincare_log_map_origin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "primitive": "poincare_log_map_origin",
-  "eshkol_version": "1.3.3",
+  "eshkol_version": "1.3.4",
   "generator": "tests/qllm_oracle/poincare_maps.esk",
   "reference": "src/model/grr.c::fast_log_map_origin",
   "formula": "t = sqrt(c)|y| clamped to 1-1e-7 inside artanh; out = y * artanh(t)/(sqrt(c)|y|)",

--- a/tests/qllm_oracle/golden/poincare_project.json
+++ b/tests/qllm_oracle/golden/poincare_project.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "primitive": "poincare_project",
-  "eshkol_version": "1.3.3",
+  "eshkol_version": "1.3.4",
   "generator": "tests/qllm_oracle/poincare_project.esk",
   "reference": "python/qllm/torch_geometric.py::poincare_project",
   "formula": "conf = clamp_min(1 - c*|x|^2, eps); out = 0.25 * conf^2 * grad",

--- a/tests/qllm_oracle/golden/poincare_project_exact.json
+++ b/tests/qllm_oracle/golden/poincare_project_exact.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "primitive": "poincare_project.exact_rational",
-  "eshkol_version": "1.3.3",
+  "eshkol_version": "1.3.4",
   "generator": "tests/qllm_oracle/poincare_project.esk",
   "reference": "python/qllm/torch_geometric.py::poincare_project",
   "ad_mode": "forward_taylor_tower_exact_rational",

--- a/tests/qllm_oracle/golden/poincare_retract.json
+++ b/tests/qllm_oracle/golden/poincare_retract.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "primitive": "poincare_retract",
-  "eshkol_version": "1.3.3",
+  "eshkol_version": "1.3.4",
   "generator": "tests/qllm_oracle/poincare_retract.esk",
   "reference": "python/qllm/torch_geometric.py::poincare_retract",
   "formula": "z = x + step; scale = sqrt(((1-eps)/c) / clamp_min(|z|^2, eps)) if |z|^2 > (1-eps)/c else 1; out = z * scale",

--- a/tests/qllm_oracle/golden/sheaf_ee_step.json
+++ b/tests/qllm_oracle/golden/sheaf_ee_step.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "primitive": "sheaf_attention_ee",
-  "eshkol_version": "1.3.3",
+  "eshkol_version": "1.3.4",
   "generator": "tests/qllm_oracle/sheaf_ee_step.esk",
   "reference": "python/qllm/torch_geometric.py::sheaf_attention_ee",
   "formula": "w_ij = cos(Q_i,K_j)+eps on kept upper-triangular edges, symmetrised; V_new = V - dt*(deg*V - w V)",

--- a/tests/qllm_oracle/golden/sphere_project.json
+++ b/tests/qllm_oracle/golden/sphere_project.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "primitive": "sphere_project",
-  "eshkol_version": "1.3.3",
+  "eshkol_version": "1.3.4",
   "generator": "tests/qllm_oracle/sphere_ops.esk",
   "reference": "python/qllm/torch_geometric.py::sphere_project",
   "formula": "out = grad - <grad, x> * x",

--- a/tests/qllm_oracle/golden/sphere_retract.json
+++ b/tests/qllm_oracle/golden/sphere_retract.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "primitive": "sphere_retract",
-  "eshkol_version": "1.3.3",
+  "eshkol_version": "1.3.4",
   "generator": "tests/qllm_oracle/sphere_ops.esk",
   "reference": "python/qllm/torch_geometric.py::sphere_retract",
   "formula": "z = x + step; out = z / clamp_min(|z|, eps) when |z| > eps, else x",

--- a/tests/qllm_oracle/qllm_oracle_lib.esk
+++ b/tests/qllm_oracle/qllm_oracle_lib.esk
@@ -281,7 +281,7 @@
 
 ;; Standard header written by every exporter. `generator` is the .esk path
 ;; relative to the repository root; `reference` is the qLLM source of truth.
-(define ESHKOL-VERSION "1.3.3")
+(define ESHKOL-VERSION "1.3.4")
 (define SCHEMA-VERSION 1)
 
 (define (json-header primitive generator reference formula)


### PR DESCRIPTION
Prepares the v1.3.4-evolve cut on top of the completed merge train (master
`41299d3c`). Documentation and version metadata only — no compiler, runtime or
test behaviour is changed by this branch.

## Scope

**Version bump.** `CMakeLists.txt` `ESHKOL_VERSION` 1.3.3 -> 1.3.4;
`inc/eshkol/eshkol.h` `ESHKOL_VERSION_PATCH` 3 -> 4 and
`ESHKOL_VERSION_STRING` `"1.3.3-evolve"` -> `"1.3.4-evolve"`. The same sweep
the previous cuts carry: the API-reference and language-specification headers,
the specification's *Current Version* and its version history (which gains
contiguous v1.3.2 / v1.3.3 / v1.3.4 entries — it previously jumped from v1.3.1
to v1.3.0), the language guide's REPL banner and footer, the quick-reference
header, `CONTRIBUTING.md`'s "what has landed" paragraph, and the press release
dates plus the BibTeX citation version. `cmake/build_config.h.in` carries no
version string and needs no change. The README badge was already
`v1.3.4-evolve`.

**CHANGELOG.** The `[1.3.4-evolve]` section is completed from the merge log for
the second half of the cycle, and re-dated 2026-07-31. Grouped by theme:

- *Added* — the portable event loop (kqueue / epoll / IOCP, fail-closed on
  WASM) (#399); the fixed-point / `i128` exact-accumulation engine (#390); the
  qLLM bridge implementation, which its already-shipped backward rules were
  waiting for (#386); embedding and Fréchet-mean backward passes (#392); and
  CTest results as completion-oracle evidence (#403).
- *Fixed — automatic differentiation* — dual numbers recycled by the
  iter-scope nursery, producing silently wrong gradients through loop-filled
  vectors (#396); exact-input `derivative`/`gradient`/`hessian` routed through
  the Taylor tower, with the identity contract against `derivative-n` (#393);
  the arity 17-32 gradient hole behind the out-of-line spread (#398).
- *Fixed — numeric tower* — VM exactness decided from operand tags rather than
  result shape (#394); native flonum `modulo`/`remainder`/`quotient` and the
  floor-division family (#379); SRFI-1 `iota` (#397, already recorded).
- *Fixed — language and modules* — an emitted error diagnostic prevents
  artifact emission and execution (#373); same-unit `define-library`/`import`
  on all three back ends (#402). The #383 tensor cluster (#357 / #359 / #362 /
  #364 / #365 / #374 / #384), `with-region` VM lowering (#380) and escaped
  named-let closures plus tensor nests (#381) were already recorded by their
  own merges.
- *Fixed — driver, linking and browser targets* — `--shared-lib` links a real,
  C-ABI-correct shared library (#377); the browser WASM glue import stubs and
  the coverage guards becoming required (#385); the regenerated site and VM
  WASM artifacts (#387).
- *Fixed — test harness and release gates* — the GNU/BSD `stat` fingerprint
  (#395); the empty-temp-root prune (#404); the five-way escape baseline
  re-anchor (#401); display-only tests that now assert (#378); the stale
  `div`/`divide` test reference (#388).

**RELEASE_NOTES.** The same wave as consumer-facing narrative, under the
release policy's consumer-hardening framing: a wrong answer must not be able to
look like a right one. Each item is stated as the behaviour a user observes,
with the numbers taken from the merged PRs rather than restated from memory.

**Site fragments and test provenance.** The WASM site fetches
`site/static/content/*.html` at runtime; those are pandoc renders of the root
and `docs/` markdown, so five of them went stale against the version strings
this cut bumps. Regenerated through the canonical
`scripts/build-site-content.sh` recipe rather than hand-edited — the diff is
exactly the version strings plus the specification's new history entries — and
`scripts/verify_site_release.py` still reports PASS. Separately, the qLLM
gradient-oracle exporters stamp every golden JSON with `ESHKOL-VERSION`, which
still read 1.3.3; the constant and the nine stamped fields are bumped together,
which is exactly what a regeneration produces for that field. The gate reads
those files for parseability and self-checking finite differences, never for
this stamp, so no numeric value is touched.

**README.** The release section is retitled to v1.3.4-evolve and its evidence
numbers are re-stated from the current tree. The stale 68/68 shared-corpus
figure is dropped rather than carried forward unverified.

## Build and sanity verification

Fresh build directory, complete FetchContent donor, agent FFI **on**
(`-DESHKOL_BUILD_AGENT_FFI=ON`), RelWithDebInfo, macOS arm64:

- `ninja` — exit 0, 418/418 targets.
- `eshkol-run --version` -> `Eshkol Compiler v1.3.4-evolve`.
- `ctest` — **139/139, 100%**, 110.4 s.
- `eshkol-run -r` on a hello program -> `hello from eshkol v1.3.4-evolve`.
- Probe program, identical output on **JIT (`-r`), AOT, and the bytecode VM**:

  | probe | result | pins |
  |---|---|---|
  | `(gradient f (vector 2.0 5.0))`, `f = x²y + 3y` | `#(20 7)` | gradient |
  | `(derivative (lambda (x) (* x x x)) 1/3)` | `1/3`, `exact? #t` | #393 |
  | `(/ (- 2.0 1.0) (+ 2.0 1.0))` | `0.3333333333333333` | #394 |
  | `(modulo 5.5 2.0)` | `1.5` | #379 |
  | `(iota 5 1)` | `(1 2 3 4 5)` | #397 |
  | same-unit `define-library` + `import` | `hi world` on JIT and VM | #402 |

### Full gate battery, measured on this branch

- `scripts/run_all_tests.sh` — **45/45 suites, 770 individual tests, 100%**,
  exit 0, working tree clean afterwards.
- `scripts/run_sicp_smoke.sh` — **88/88** gate probes across all five chapters
  under both `-r` and AOT; 0 xfail, 0 XPASS.
- `scripts/run_reference_differential.sh` — **34/34 AGREE**, 0 divergences,
  against chibi-scheme 0.12.0. Gate PASS.
- `scripts/run_ctest_gate.sh` — PASS, 139/139, with every wired group green:
  `fixed_point_exact_accumulation_gate` 5/5, `exact_input_ad_identity_gate`
  4/4, `runtime_closure_arity_spread_gate` 2/2,
  `define_library_same_unit_gate` 3/3. This is the emitter that makes CTest
  readable by the release oracle at all, so these four groups are the first
  release-gated evidence the #390 / #393 / #398 / #402 pillars have had.
- `scripts/run_qllm_oracle_tests.sh` — gate PASS, 10/10, run after the
  provenance bump; the exporters regenerated all nine goldens in place and the
  result is byte-identical to what is committed here, so the version-stamp
  change is a verified no-op on the numbers.
- `scripts/verify_site_release.py` — PASS, both before and after the fragment
  re-render.

## ICC

Repo `eshkol-v134-release` (checkout `/Users/tyr/Desktop/eshkol-wt-release`),
re-indexed on this branch head.

- `impact-analysis --since 41299d3c` — 12 changed paths, 94 seed symbols, 313
  impacted symbols, 37 impacted paths. All of it flows from
  `inc/eshkol/eshkol.h`; the other eleven paths are Markdown and one CMake
  scalar.
- `guard-liveness` — 276 tokens / 57 dead. Dead count is unchanged from the
  recorded baseline; the token delta against the 274 recorded at master
  `6bd24b76` comes from the merges landed after that baseline, not from this
  branch: `git diff 41299d3c..HEAD` adds **zero** preprocessor conditionals
  (verified by grep over the diff).
- `pre-commit-check` — **PASS**, 0 blockers.

## Readiness: 88, blocked — one cause, and it is not this branch

`icc readiness --repo eshkol-v134-release --target eshkol-compiler-readiness
--trace-dir scripts/icc_traces` after regenerating every trace:
**score 88, status `blocked`**. Every completion-oracle criterion PASSES,
including all eight #403 wired this cycle (`ctest_suite_green`,
`fixed_point_exact_accumulation_gate`, `exact_input_ad_identity_gate`,
`runtime_closure_arity_spread_gate`, `define_library_same_unit_gate`,
`vm_surface_regression_suite`, `vm_parity_gate`, `event_loop_works`).

The block is entirely the `failure_free` runtime check, which consumes **any**
FAIL event in the traces whether or not a criterion references it. Two were
present and both are now attributed:

1. `qllm_oracle_gate` — a measurement artifact of running the coverage sweep
   concurrently with other work; that sweep re-runs the oracle itself.
   Standalone it is 10/10 PASS (confirmed twice) and the trace is rewritten
   clean.
2. `language_surface_coverage_floor` — **a real, pre-existing master-side
   defect, described below.** The coverage floor itself is not the problem:
   `run_language_coverage.sh` exits 1 because the qLLM oracle suite fails
   *inside* it, aborting the run before it ever computes a surface total.

### The defect: two JIT paths disagree about relative `(load)` resolution

Two files are enough, no qLLM involvement:

```scheme
;; sib.esk
(define (hi) "hello from sibling")
(provide hi)

;; main.esk
(load "sib.esk")
(display (hi))
```

```
$ eshkol-run -r main.esk                     # from any cwd
hello from sibling
$ ESHKOL_JIT_CACHE=0 eshkol-run -r main.esk  # from any cwd but the file's own
Module not found: sib.esk
ERROR: JIT dependency load failed: required module could not be loaded: sib.esk
```

`exe/eshkol-run.cpp:4649` takes the persistent-JIT-cache path **only** for a
single input file with no debug mode, no `--dump-ast`, no `--dump-ir` and no
`ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR`. That path resolves a relative `(load)`
against the **source file's directory**. Every other case falls through to the
inline `ReplJITContext` path, which resolves it against the **process working
directory**. Confirmed by running the bypassed path from the file's own
directory, where it succeeds.

So every cache-bypass trigger reproduces it — `ESHKOL_JIT_CACHE=0`, `-d`,
`--dump-ast`, `--dump-ir`, multiple input files, and the coverage trace
variable. That last one is why `run_all_tests.sh` passes the qLLM oracle
(10/10, cached path) while `run_language_coverage.sh` fails it (bypassed path,
run from the repo root).

This is the release's own defect class — two paths of one command silently
disagreeing, visible only when instrumentation flips which one runs. It is
**not** introduced here: this branch changes no compiler, driver or runtime
source, and the identical binary passes with the variable unset. It wants its
own root-cause PR (one resolution authority for both paths) rather than being
bundled into a version cut, so it is reported, not patched here.

## Evidence anchors

- **Readiness.** `icc readiness --repo eshkol-v134-release --trace-dir
  scripts/icc_traces`, run after regenerating traces with
  `scripts/run_icc_smoke.sh` and — new this cut — `BUILD_DIR=<build>
  ./scripts/run_ctest_gate.sh`, which is what makes CTest results readable by
  the release oracle at all (#403). Oracle definitions live in
  `.icc/completion-oracles.yaml` under `eshkol-compiler-readiness`; the
  readiness quartet that clears the remaining functional blockers (#402, #403,
  #401, #404) is all merged in this train.
- **Mesh calibration.** `mesh gates run --lane eshkol --ref <sha>` over
  `computer_mesh/gates/eshkol/` + `eshkol_gate.py`; verdict documents land
  under `computer_mesh/.icc/runtime/eshkol-gate/`. Lane set is 15 lanes / 11
  active / 7 required, with four declared gaps (windows-arm64 has no node,
  macos-x64 awaits an Intel Mac, two XLA lanes await StableHLO). Reuse lanes
  report BLOCKED rather than green on a missing or mismatched `.gate-built-sha`
  stamp, so a stale-binary result cannot be read as a pass.

## Tagging

**Tagging is the maintainer's action, after this merges.** This branch
deliberately creates no tag and moves no ref. The cut is prepared only: version
metadata, CHANGELOG, release notes and the README release section.
