### PR TITLE
chore(quantum): bump Moonlab pin to v1.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,10 +216,27 @@ if(ESHKOL_QUANTUM_ENABLED)
 
     FetchContent_Declare(moonlab
         GIT_REPOSITORY "${ESHKOL_MOONLAB_REPO}"
-        # Moonlab v1.2.0: adds MOONLAB_API vqe_compute_qgt (QNG/QGT, needed by the
-        # quantum-chemistry examples) and the smooth first-principles H2/LiH PES.
-        # Pinned by the tag's commit SHA; ABI frozen per the Moonlab release note.
-        GIT_TAG e441957b22698ce93ad4868d585ac7ca3baa281f
+        # Moonlab v1.2.0 (the real tagged release, 2026-07-30 -- the previous
+        # comment here calling e441957b "v1.2.0" was written ahead of any actual
+        # Moonlab tag; no Moonlab tag ever pointed at e441957b). 84 commits ahead
+        # of the prior pin: exact analytic QGT for all three ansatz types
+        # (hardware-efficient/UCCSD/symmetry-preserving, replacing central-
+        # difference state derivatives), a UCCSD particle-number-preserving
+        # double-excitation fix + corrected LiH Hartree-Fock reference,
+        # additive-only vqe_optimizer_t hyperparameters (beta1/beta2/epsilon/
+        # qng_regularization) and pauli_hamiltonian_t hf_reference fields, ELF
+        # NODELETE shared-library residency, and POVM/entropy-pool hardening.
+        # None of it touches the signatures Eshkol links: vqe_compute_qgt,
+        # vqe_compute_energy, vqe_solver_create, vqe_gradient_at_parameters,
+        # vqe_exact_ground_state_energy, vqe_solve, moonlab_vqe_gradient,
+        # moonlab_qrng_bytes/moonlab_next_u64, or the ML-KEM (crypto/mlkem/*)
+        # entry points -- none of the ML-KEM sources changed in this range.
+        # Pinned by the tag's peeled commit SHA (the v1.2.0 *tag object* itself
+        # is f8e552759b19dc459b093b9ff4abaacaa22befbb; git peels it to this
+        # commit automatically, but this repo's convention -- and FetchContent's
+        # own ref-cache comparison -- wants the resolved commit, not the tag
+        # object). ABI additive-only per the Moonlab release note.
+        GIT_TAG 4bf83a6c47e7f1c53db14fcb2a61053499fd82df
         GIT_SHALLOW FALSE
     )
     FetchContent_MakeAvailable(moonlab)


### PR DESCRIPTION
## Summary

Bumps the opt-in Moonlab quantum dependency (`ESHKOL_QUANTUM_ENABLED=ON`) from
`e441957b22698ce93ad4868d585ac7ca3baa281f` to Moonlab's real, newly-cut
`v1.2.0` tag, peeled commit `4bf83a6c47e7f1c53db14fcb2a61053499fd82df` (tag
object `f8e552759b19dc459b093b9ff4abaacaa22befbb`, released 2026-07-30), 84
commits ahead of the prior pin.

**Sequencing update (2026-08-24): the hold is cleared.** `v1.3.4-evolve` has
shipped (`origin/master` is exactly the tagged commit, `694c3179`). This PR
is rebased onto that master, re-verified at the new base, and ready for
review/merge.

## Naming note (worth flagging)

The comment this PR replaces already said "Moonlab v1.2.0" next to the old
SHA. That was written by an earlier pin-bump (#325, merged 2026-07-23) ahead
of Moonlab ever cutting an actual `v1.2.0` git tag -- no Moonlab tag has ever
pointed at `e441957b`. The real `v1.2.0` tag was cut 84 commits later, on
2026-07-30. This PR moves the pin to the tag that actually exists.

Separately: the SHA `f8e552759b19dc459b093b9ff4abaacaa22befbb` is the
annotated tag *object's* own SHA, not a commit -- `GET /repos/.../git/commits/f8e55275...`
404s. `git checkout`/`FetchContent` will resolve it to the right commit either
way (verified locally), but this repo's own convention -- and the existing
comment's own words, "pinned by the tag's commit SHA" -- pins the peeled
commit, matching the precedent for the current pin and for v1.1.0
(`99ff0402f374da4c1d305ae6418ec84c798c9a84`). `GIT_TAG` is therefore set to
the peeled commit `4bf83a6c47e7f1c53db14fcb2a61053499fd82df`, with both SHAs
recorded in the adjacent comment for cross-reference.

## API review (all 84 commits, against the exact Moonlab headers Eshkol's FFI includes)

Reviewed every commit in `e441957b...v1.2.0` against the eight headers
Eshkol actually links against (`quantum/state.h`, `quantum/gates.h`,
`quantum/measurement.h`, `utils/quantum_entropy.h`, `algorithms/vqe.h`,
`applications/bell_test.h`, `applications/moonlab_export.h`,
`crypto/mlkem/mlkem.h`), plus a byte-level diff of each at both SHAs (the
GitHub compare API reports a spurious 0/0 additions/deletions for several of
these files across the full 84-commit range despite individual commits
showing real changes -- confirmed by fetching both blobs directly and
diffing).

**No signature or ABI break on any symbol Eshkol calls.**

- **State prep / gates** (`state.c`, `state.h`, `gates.c`, `gates.h`):
  byte-identical.
- **Bell / CHSH** (`bell_test.c`, `bell_test.h`): byte-identical. The one
  CHSH-bounds-calibration commit in this range
  (`50d03751 Calibrate the CHSH test bounds to the shot noise they actually
  carry`) touches only a JavaScript-binding integration test, not the C
  library Eshkol links.
- **ML-KEM / FIPS-203** (`crypto/mlkem/*`): zero files touched anywhere in
  the 84-commit range. `moonlab_mlkem{512,768,1024}_{keygen,encaps}_qrng` /
  `_decaps` are untouched.
- **QRNG** (`moonlab_qrng_bytes`, `moonlab_next_u64` in
  `moonlab_export.h`): signatures unchanged. `entropy_pool.c` gained a mutex
  around background-thread flag writes (a TSan-driven data-race fix) -- pure
  internal hardening, no observable behavior change.
- **Measurement / POVM** (`measurement.c`): hardening only (rejects
  malformed/degenerate POVM structures with extra NULL/size/finiteness
  checks). Eshkol calls `quantum_measure`/`measurement_expectation_z`, never
  the POVM API, so this has no effect on Eshkol.
- **VQE** (`vqe.h`/`vqe.c`/`vqe_qng.c`) -- the one area with real content
  changes:
  - `vqe_optimizer_t` gained four trailing hyperparameter fields
    (`beta1`/`beta2`/`epsilon`/`qng_regularization`) and a new
    `vqe_optimizer_set_hyperparams()` setter. Additive only, and safe: Eshkol
    only ever holds an opaque pointer returned by `vqe_optimizer_create()`
    and never allocates or takes `sizeof()` of the struct itself.
  - `pauli_hamiltonian_t` gained a trailing `hf_reference` field. Same
    opaque-pointer safety argument.
  - The UCCSD ansatz's double-excitation gate is now genuinely
    particle-number-preserving (it previously was not), and LiH's
    Hartree-Fock reference, previously left uninitialized, is now set
    correctly. **Eshkol never builds a UCCSD ansatz** --
    `create_default_vqe_solver()` in `lib/agent/c/agent_quantum.c` only ever
    calls `vqe_create_hardware_efficient_ansatz()` -- so this fix cannot
    change any current Eshkol VQE result. Flagged anyway since it is the
    single largest functional change in this range.
  - `vqe_compute_qgt()` -- the exact function `eshkol_vqe_qgt_compute()`
    calls -- now uses exact analytic state derivatives (generator insertion)
    for the hardware-efficient ansatz instead of central finite differences.
    Same signature. This is the ansatz Eshkol actually uses for QGT. No
    Eshkol test currently pins numeric QGT values (grepped `tests/`; only
    `lib/agent/quantum.esk` exposes the `vqe-qgt` wrapper, with no test
    coverage), so nothing breaks -- flagging as a pre-existing coverage gap
    worth closing later, and as a net-positive accuracy improvement.
  - H2 Hamiltonian coefficients (`h2_sto3g.h`) are unchanged -- it only
    gained a `MOONLAB_API` export-visibility annotation Eshkol doesn't rely
    on directly. Confirmed by battery evidence below: the existing oracle
    constant in `tests/quantum/vqe_test.esk`
    (`h2-moonlab-exact-energy = -1.142200155381`) still matches to 1.3e-15.
- **Shared-library residency** (`moonlab_export.h` doc comment + ELF
  `NODELETE`): documentation + linker-flag hardening for consumers that
  `dlopen`/`dlclose` the library. Eshkol links `quantumsim` as a normal CMake
  target, not via `dlopen`, so not applicable today, but a plus if that ever
  changes.
- Everything else making up the bulk of the 84 commits -- Clifford/stabilizer
  tableau, union-find QEC decoding, topological/anyon braiding, Python/JS/Rust
  bindings and packaging, wheel/cibuildwheel, CI/release infra, fuzz corpora
  -- touches source Eshkol's FFI never includes.

## Battery evidence -- rebased onto master (2026-08-24)

Rebased `chore/bump-moonlab-v120` onto `origin/master` at `694c3179`
(`v1.3.4-evolve`), clean rebase, no conflicts. New head: `5656cac2`. Diff
vs. master is exactly the one `CMakeLists.txt` hunk (the `GIT_TAG` line +
comment); nothing else changed. `git diff origin/master...HEAD --stat`:
`CMakeLists.txt | 25 +++++++++++++++++++++----`, 1 file. Identity verified
on the sole commit ahead of master: author/committer both
`tsotchke <tsotchkele@gmail.com>`.

Moonlab was fetched fresh at configure time; `build-quantum/_deps/moonlab-src`
resolved `GIT_TAG` to `4bf83a6c47e7f1c53db14fcb2a61053499fd82df` exactly, as
pinned.

Two full builds from this SHA, `-G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`:
`build-quantum` (`-DESHKOL_QUANTUM_ENABLED=ON`, 517/517 targets, "Quantum:
ENABLED (agent.quantum -> Moonlab quantumsim)") and `build` (`=OFF`, 422/422
targets, "Quantum: DISABLED"). Both green.

- **Bell determinism**: `quantum_smoke_test.esk` -- `Bell-pair correlation
  over 200 shots: 200/200 PASS`.
- **VQE suite**: `vqe_test.esk` -- H2 exact `-1.142200155381327` Ha vs VQE
  `-1.1422001553813284` Ha, `|VQE - exact| = 1.3322676295501878e-15`. PASS.
  `quantum_surface_coverage_test.esk` -- 3/3 PASS (gate surface, LiH/H2O
  Hamiltonian construction).
- **S3 differentiable-VQE** (adjoint vs fd vs compose): `vqe_ad_test.esk` --
  `max |g_eshkol - g_moonlab| = 0` (adjoint), `max |g_eshkol - g_fd| =
  4.504048523035209e-11` (fd), `max |g_(E^2) - 2E*g_moonlab| = 0` (compose).
  5/5 PASS, including the nested-define and let-bound-helper custom-VJP
  regressions from #296. `vqe_ad_adversarial.esk` -- 3/3 PASS (per-parameter
  AD-vs-FD errors 1.4e-11 to 4.5e-11). `BUILD_DIR=build-quantum
  ESHKOL_QUANTUM_ENABLED=ON scripts/run_ad_adversarial.sh --quick` -- 8/8
  PASS including the opt-in quantum probe.
- **CHSH gate lane**: `bell_chsh_test.esk` -- `CHSH S over 16000 shots:
  2.826`, within `(2.4, 2.95]`. PASS.
- **ML-KEM / PQC suite**: `pqc_mlkem_test.esk` -- 9/9 PASS (all three
  security levels' sizes, deterministic NIST KAT vectors, and the three
  invalid-input rejection cases).
- **Quantum-random integration**: `tests/features/quantum_random_test.esk`
  -- 11/11 PASS (JIT). `tests/vm/quantum_random_regression.esk` -- 7/7 PASS
  via the VM engine (`eshkol-vm-standalone-test`, per `run_vm_parity.sh`'s
  convention).
- **Differentiable-chemistry examples** (exercise the two things v1.2.0
  actually adds -- exact analytic QGT and the smooth first-principles PES),
  all run to completion on `build-quantum`, exit 0:
  - `examples/vqe_h2.esk` -- reverse-mode gradient descent on the H2
    expectation value, `-1.0830 Ha -> -1.1421333189606426 Ha` over 200
    steps against exact `-1.142170640288229 Ha`.
  - `examples/qng_vqe.esk` -- exercises `vqe_compute_qgt` directly: QGT
    (quantum-natural-gradient) descent converges to
    `-1.1421706402882286 Ha` (exact `-1.142170640288229 Ha`, agreement to
    ~1e-10) by step 30, visibly outpacing vanilla gradient descent
    (`-1.1418227561668124 Ha` at step 40) on the same Hamiltonian.
  - `examples/h2_vibrational_quantum.esk` -- exercises the smooth PES fix:
    finite-difference vibrational frequency over geometry gives
    `omega = 4935.9 cm^-1`, consistent with the independent exact
    Taylor-tower AD route (`5003 cm^-1`); the FD route is only well-behaved
    because Moonlab's PES is now smooth.
- **Full ctest**, both configs: **184/184 passed** on `build-quantum`
  (189.6s) and **184/184 passed** on `build` (187.2s).

## ICC

- `index --repo eshkol-moonlab406 --force`: 3067 files indexed, OK.
- `build-memory --repo eshkol-moonlab406`: OK.
- `guard-diff --repo eshkol-moonlab406`: `ok: true`, 0 violations, 0
  warnings (working tree clean at the pushed SHA).
- `pre-commit-check --repo eshkol-moonlab406`: **PASS**, 0 blockers.

## Merge readiness

`v1.3.4-evolve` has shipped and `origin/master` sits exactly at that tag, so
the sequencing hold from when this PR was opened is satisfied. Rebased,
re-verified at the new base (identity, quantum suite, both ctest configs,
and the three v1.2.0-specific chemistry examples all green), and marked
ready for review. Left for a human/coordinator merge -- not merged by this
pass.
