### PR TITLE
fix(modules): one resolver for require/import/load — every execution engine agrees

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -344,6 +344,13 @@ oracles:
         severity: high
         label: 'R7RS-small 5.6.1 same-unit libraries: a (define-library (m …) …) written in the compilation unit being compiled is importable by the forms below it with no filesystem search, its export surface is the union of its export clauses, only/except/rename/prefix work over it, require shares the registry, and an import written ABOVE its define-library is refused as the forward reference it is. Gated on all three substrates, because the JIT (ReplJITContext::execute), the AOT lane (process_requires) and the VM (its own reader and module machinery) resolve imports at three independent call sites.'
         action: ./scripts/run_ctest_gate.sh
+      - runtime_event:
+          event_kinds: [ctest]
+          event_names: ["module_load_path_engine_parity_gate"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'One command, one answer: a relative (load "sib.esk") resolves identically on every execution engine `eshkol-run` can pick — the persistent JIT run cache, the in-process JIT reached by every cache-bypass switch (ESHKOL_JIT_CACHE=0, -d, --dump-ast/--dump-ir, several inputs, an active $ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR), and the AOT lane. The documented order (docs/reference/language/modules.md) is the requiring FILE''s directory, then the working directory, then $ESHKOL_PATH/-I, then the install; both tiers are pinned, with a same-named decoy planted in the working directory so a cwd-rooted lane fails on a DIFFERENT ANSWER rather than merely on an error. The engines carried separate copies of the search order and disagreed, which is why the qllm suite — whose exporters load a sibling library — aborted under run_language_coverage.sh (it sets the coverage trace dir) while passing under every other harness.'
+        action: ./scripts/run_ctest_gate.sh
 
       # ─────────────────────────────────────────────────────────────
       # VM SURFACE + PARITY ROLL-UPS pulled into the release gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -343,6 +343,36 @@ across every new-feature family).
 
 ### Fixed
 
+- **A relative `(load "sib.esk")` resolved to a different file depending on
+  which execution engine ran the program.** `eshkol-run -r prog.esk` uses the
+  persistent JIT run cache for a single input with no `-d`/dump flags and no
+  `$ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR`, and the in-process LLVM JIT otherwise.
+  Each engine carried its own copy of the module search order, and the copies
+  disagreed about the first tier: the AOT lane (and therefore the run cache)
+  looked beside the **source file**, the in-process JIT looked in the process's
+  **working directory**. The same command on the same file therefore printed
+  one answer with the cache warm and `Module not found:` — or, with a
+  same-named file in the working directory, a *silently different* answer —
+  with it bypassed. A third copy in the JIT's path-form `(import "…")` handler
+  searched cwd-then-`lib/` only, and `process_imports` in the AOT lane searched
+  the source directory only. Resolution now happens once, in
+  `eshkol::platform::resolve_module_source_path()`, which every lane calls and
+  none may shadow; the requiring file is established by the same scope that
+  attributes source text, so nested loads root at their own file rather than at
+  the outermost one. The order is the documented one — requiring file's
+  directory, working directory, `$ESHKOL_PATH`/`-I`, install, build-tree
+  fallback (`docs/reference/language/modules.md`) — so both spellings the test
+  corpus uses (sibling-relative and project-root-relative) keep resolving.
+  Path literals written without `.esk` are now probed with and without the
+  extension in every tier, not only against the working directory. New CTest
+  gate `load_path_engine_parity_test` runs one program through all four lanes
+  and demands byte-identical output, with a same-named decoy planted in the
+  working directory so a cwd-rooted regression fails on a different answer
+  rather than on a missing file. Found because `run_language_coverage.sh` sets
+  the coverage trace dir, which bypasses the cache: the entire qllm oracle
+  suite — whose exporters `(load "qllm_oracle_lib.esk")` from a sibling —
+  aborted under it while passing under every other harness.
+
 - **`(tensor (list (list …) (list …)))` built a rank-1 tensor of zeros, and the
   rank-2 read that followed segfaulted.** `(tensor X)` on a single collection
   argument walked exactly ONE level of `X`, coercing every element with

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3604,6 +3604,26 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
                 PASS_REGULAR_EXPRESSION "PASS: transitive_ffi_link_test"
                 FAIL_REGULAR_EXPRESSION "FAIL:")
     endif()
+    if(NOT WIN32 AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/load_path_engine_parity_test.sh")
+        # One command, one answer: the persistent JIT run cache, the in-process
+        # JIT (every bypass switch), and the AOT lane must resolve a relative
+        # (load …) identically — the requiring FILE's directory first, then the
+        # working directory, per docs/reference/language/modules.md. The lanes
+        # once carried separate copies of that order and disagreed, so the same
+        # file printed different results depending only on whether the cache was
+        # in play. See platform::resolve_module_source_path().
+        add_test(
+            NAME load_path_engine_parity_test
+            COMMAND bash
+                    "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/load_path_engine_parity_test.sh"
+                    $<TARGET_FILE:eshkol-run>
+        )
+        set_tests_properties(load_path_engine_parity_test
+            PROPERTIES
+                TIMEOUT 300
+                PASS_REGULAR_EXPRESSION "PASS: load_path_engine_parity_test"
+                FAIL_REGULAR_EXPRESSION "FAIL:")
+    endif()
     if(NOT WIN32 AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/driver_fault_exit_code_test.sh")
         # ESH-0361 (found by the P8 escape-closure fault-injection matrix): the
         # driver must never MASK a fault with a zero exit. A missing/unreadable

--- a/docs/reference/language/modules.md
+++ b/docs/reference/language/modules.md
@@ -17,6 +17,24 @@ compiler, while a project's own sources always come first. See
 [environment variables](../runtime/environment-variables.md#resolution-precedence)
 for the same rule applied to the native artifacts.
 
+The search runs top to bottom and the first match wins, so the two rules that
+matter most are independent: a program that lives beside its helpers keeps
+finding them wherever you run it from (step 1), and a project-rooted spelling
+like `(load "tests/fixtures/dep.esk")` keeps working from the project root
+(step 2).
+
+This order is a property of the **language**, not of how you happen to run the
+program. `eshkol-run` chooses among several execution engines — a persistent
+JIT run cache, an in-process JIT (used whenever the cache is bypassed: `-d`,
+`--dump-ast`, `--dump-ir`, several input files, or an active
+`$ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR`), an AOT compile, and the VM — and every
+one of them resolves `require`, `import` and `load` through the same resolver,
+`eshkol::platform::resolve_module_source_path`. A program cannot load different
+files because of which engine ran it. The `load_path_engine_parity_test` CTest
+gate holds every engine to identical output on the same source, with a
+same-named decoy planted in the working directory so a lane that regressed to
+cwd-rooted resolution fails on a different answer rather than a missing file.
+
 ## `provide` / `require`
 
 ```

--- a/docs/reference/stdlib/module-system.md
+++ b/docs/reference/stdlib/module-system.md
@@ -30,7 +30,11 @@ A consumer pulls the module in with `(require <module-name>)`:
 
 ## Module-name → file resolution
 
-`resolve_module_path` (eshkol-run.cpp) maps a dotted module name to a file:
+`eshkol::platform::resolve_module_source_path` (`lib/core/platform_runtime.cpp`,
+declared in `inc/eshkol/platform_runtime.h`) maps a dotted module name to a
+file. It is the single authority: the AOT driver, the in-process JIT and the
+persistent `-r` run cache all call it, so no execution engine can resolve a
+module differently from another.
 
 - **Dotted names** have each `.` rewritten to `/` and `.esk` appended:
   - `core.strings`   → `lib/core/strings.esk`
@@ -48,19 +52,27 @@ A consumer pulls the module in with `(require <module-name>)`:
 
 For each resolved `path_part`, the loader tries, in order:
 
-1. the requiring file's directory (`base_dir`);
-2. the current working directory / project root (so a project-rooted module
-   like `src.core.x` resolves against `./src/...`, matching the JIT resolver);
-3. the library directory `lib/` (auto-discovered relative to the `eshkol-run`
-   binary and the cwd);
-4. **directory-as-module**: if `lib/web.esk` is absent, `lib/web/web.esk` then
-   `lib/web/index.esk` are tried, so `(require web)` can find a package entry
-   point;
-5. each colon-separated (`;` on Windows) entry of `$ESHKOL_PATH`. Empty
-   segments, missing directories, and non-directory entries are silently
-   skipped (flagged only in debug mode).
+1. the requiring file's directory (`base_dir`) — the directory of the file that
+   wrote the `require`/`import`/`load`, so a program keeps finding its own
+   helpers no matter which directory you run it from;
+2. the current working directory / project root, so a project-rooted module
+   like `src.core.x` resolves against `./src/...`;
+3. each colon-separated (`;` on Windows) entry of `$ESHKOL_PATH`, which the
+   `-I` flags are merged into. Empty segments, missing directories, and
+   non-directory entries are silently skipped. `$ESHKOL_PATH` precedes the
+   install for the same reason `$ESHKOL_LIB_DIR` precedes every archive
+   location: a location you asked for must not be outranked by a copy that
+   ships with the compiler;
+4. the library directory `lib/` (auto-discovered relative to the `eshkol-run`
+   binary and the cwd), including **directory-as-module**: if `lib/web.esk` is
+   absent, `lib/web/web.esk` then `lib/web/index.esk` are tried, so
+   `(require web)` can find a package entry point;
+5. `lib/…` and `../lib/…` relative to the working directory — the build-tree
+   fallback for a layout whose module root resolved elsewhere.
 
-The first match wins and its canonical path is used.
+The first match wins and its canonical path is used. A path literal written
+without the `.esk` extension is probed both as written and with the extension
+appended, in every tier.
 
 ## `(require stdlib)` vs individual modules
 

--- a/docs/reference/stdlib/module-system.md
+++ b/docs/reference/stdlib/module-system.md
@@ -59,7 +59,8 @@ For each resolved `path_part`, the loader tries, in order:
    like `src.core.x` resolves against `./src/...`;
 3. each colon-separated (`;` on Windows) entry of `$ESHKOL_PATH`, which the
    `-I` flags are merged into. Empty segments, missing directories, and
-   non-directory entries are silently skipped. `$ESHKOL_PATH` precedes the
+   non-directory entries are skipped (flagged only in debug mode).
+   `$ESHKOL_PATH` precedes the
    install for the same reason `$ESHKOL_LIB_DIR` precedes every archive
    location: a location you asked for must not be outranked by a copy that
    ships with the compiler;

--- a/exe/eshkol-run.cpp
+++ b/exe/eshkol-run.cpp
@@ -4033,6 +4033,15 @@ int main(int argc, char **argv)
     // alike — rather than only the stage it happens to sit next to.
     const unsigned long diagnostics_at_startup = eshkol_diagnostic_error_count();
 
+    // Let the shared module resolver explain a skipped search-path entry under
+    // -d. The resolver cannot call the logger itself — it has to keep linking
+    // standalone (see set_module_search_diagnostic) — so the driver, which is
+    // what owns -d in the first place, supplies the sink.
+    eshkol::platform::set_module_search_diagnostic(
+        [](const char* message, const char* detail) {
+            eshkol_debug("%s: %s", message, detail);
+        });
+
     int ch = 0;
 
     uint8_t debug_mode = 0;

--- a/exe/eshkol-run.cpp
+++ b/exe/eshkol-run.cpp
@@ -2226,6 +2226,11 @@ static EscapeAnalyzer g_escape_analyzer;
 // Forward declarations
 static void process_imports(std::vector<eshkol_ast_t>& asts, const std::string& base_dir, bool debug_mode);
 static void load_file_asts(const std::string& filepath, std::vector<eshkol_ast_t>& asts, bool debug_mode);
+// Module tree root (lib/), resolved once by find_lib_dir() before any of the
+// require/import/load lanes run. Declared here because process_imports() —
+// which sits above find_lib_dir() — now shares the one resolver and so needs
+// the same lib_dir tier every other lane passes.
+static std::string g_lib_dir;
 static bool g_source_parse_failed = false;
 // ESH-0361: a required module that does not resolve on ANY search path is a hard
 // dependency failure. process_requires() prints "Module '…' not found" and used
@@ -2374,20 +2379,17 @@ static void process_imports(std::vector<eshkol_ast_t>& asts, const std::string& 
             // This is an import statement
             std::string import_path = ast.operation.import_op.path;
 
-            // Resolve relative paths
-            std::filesystem::path resolved_path;
-            if (import_path[0] == '/') {
-                // Absolute path
-                resolved_path = import_path;
-            } else {
-                // Relative to base directory
-                resolved_path = std::filesystem::path(base_dir) / import_path;
-            }
-
-            if (!std::filesystem::exists(resolved_path)) {
-                eshkol_error("Import file not found: %s", resolved_path.c_str());
+            // Same search order as `require`/`load` — a path-form `import`
+            // is the same question asked with different syntax, so it goes
+            // through the same resolver rather than a private base_dir-only
+            // rule that answered differently from every other lane.
+            std::string resolved = eshkol::platform::resolve_module_source_path(
+                import_path, base_dir, g_lib_dir);
+            if (resolved.empty()) {
+                eshkol_error("Import file not found: %s", import_path.c_str());
                 continue;
             }
+            std::filesystem::path resolved_path(resolved);
 
             // Load the imported file
             std::vector<eshkol_ast_t> file_asts;
@@ -2634,174 +2636,37 @@ static bool requires_stdlib_module_explicitly(const std::vector<eshkol_ast_t>& a
 // to source-resolve it and fails. That makes the -r run-cache fall back to the
 // in-process JIT every run. install_module_roots() encodes that order (and
 // puts $ESHKOL_LIB_DIR ahead of it, and the system prefixes last).
+//
+// The selection itself lives in platform::module_source_root() so the
+// in-process JIT cannot drift from it; only the user-facing note about where
+// the tree came from is the driver's business.
 static std::string find_lib_dir()
 {
-    const auto roots = eshkol::platform::install_module_roots();
-
-    // The Eshkol module tree is the one that actually carries stdlib.esk.
-    // Prefer the first root that has it — that check is what keeps a
-    // downstream project's unrelated lib/ (or an archive-only lib/ in a
-    // release package) from being mistaken for the module tree.
-    for (const auto& root : roots) {
-        std::error_code ec;
-        if (std::filesystem::exists(root.path / "stdlib.esk", ec)) {
-            eshkol::platform::ResolvedInstallArtifact resolved{
-                root.path.string(), root.origin, root.path};
-            report_artifact_resolution("module source tree", resolved,
-                                       /*verify_version=*/false);
-            return root.path.string();
-        }
+    const auto root = eshkol::platform::module_source_root();
+    if (root.origin == eshkol::platform::InstallOrigin::NotFound) {
+        return {};
     }
 
-    // No root carried stdlib.esk. Fall back to the first directory that at
-    // least exists, so a partial install still resolves user modules — but
-    // never promote $ESHKOL_LIB_DIR here: it names a directory of native
-    // archives, and accepting it as the module root would point (require …)
-    // at a build directory with no .esk files in it.
-    for (const auto& root : roots) {
-        if (root.origin == eshkol::platform::InstallOrigin::EnvOverride) {
-            continue;
-        }
-        std::error_code ec;
-        if (std::filesystem::is_directory(root.path, ec)) {
-            return root.path.string();
-        }
+    std::error_code ec;
+    if (std::filesystem::exists(root.path / "stdlib.esk", ec)) {
+        eshkol::platform::ResolvedInstallArtifact resolved{
+            root.path.string(), root.origin, root.path};
+        report_artifact_resolution("module source tree", resolved,
+                                   /*verify_version=*/false);
     }
-
-    return {};
+    return root.path.string();
 }
 
-// Convert symbolic module name to file path
-// e.g., "data.json" -> "lib/data/json.esk"
-//       "core.strings" -> "lib/core/strings.esk"
+// Resolve a module name / path literal to a source file.
 //
-// Path-literal exception: `(load "...")` strings are stored verbatim by
-// the parser since 5992fdb-era fixes; they may legitimately contain
-// dots in directory names (e.g. macOS $TMPDIR=/var/folders/<hash>.<r>/T,
-// or any project cache dir like build.v2/).  Detect path-like strings
-// and skip the dot-to-slash rewrite entirely.
+// Thin forwarder onto platform::resolve_module_source_path(), which is the
+// single authority shared with the in-process JIT. The AOT lane and the JIT
+// lane used to carry separate copies of the search order and disagreed about
+// what a relative `(load "…")` means — see the header for the full contract.
 static std::string resolve_module_path(const std::string& module_name, const std::string& base_dir, const std::string& lib_dir)
 {
-    bool is_path_literal =
-        !module_name.empty() &&
-        (module_name[0] == '/' ||
-         module_name.rfind("./", 0) == 0 ||
-         module_name.rfind("../", 0) == 0 ||
-         module_name.find('/') != std::string::npos ||
-         (module_name.size() > 4 &&
-          module_name.compare(module_name.size() - 4, 4, ".esk") == 0));
-
-    std::string path_part;
-    if (is_path_literal) {
-        path_part = module_name;
-        if (path_part.size() < 4 ||
-            path_part.compare(path_part.size() - 4, 4, ".esk") != 0) {
-            if (!std::filesystem::exists(path_part)) {
-                path_part += ".esk";
-            }
-        }
-    } else {
-        // Convert dots to path separators (dotted module name)
-        path_part = module_name;
-        for (char& c : path_part) {
-            if (c == '.') c = '/';
-        }
-        path_part += ".esk";
-    }
-
-    // Search order:
-    // 1. The requiring file's own directory (relative to base_dir)
-    // 2. The cwd / project root
-    // 3. Environment variable $ESHKOL_PATH (colon-separated) — the explicit
-    //    override, which the `-I` flags are merged into
-    // 4. The installed library directory (lib/)
-    //
-    // The program's own sources come first, then the paths the user named
-    // explicitly, then the install. $ESHKOL_PATH ahead of lib/ is the same
-    // rule ESHKOL_LIB_DIR follows for archives: a location the user asked for
-    // must not be silently outranked by a copy that ships with the compiler.
-    // (Before this ordering, `-I mytree` could not override an installed
-    // core.* module at all.)
-
-    // Try current directory first
-    std::filesystem::path current_path = std::filesystem::path(base_dir) / path_part;
-    if (std::filesystem::exists(current_path)) {
-        return std::filesystem::canonical(current_path).string();
-    }
-
-    // Try the cwd / project root. A dotted module like `src.core.encoder.x` is
-    // rooted at the project, not at the requiring file's directory — so a file in
-    // tests/gates/ that (require src.core...) must resolve against ./src/..., not
-    // tests/gates/src/.... The in-process JIT resolver already searches cwd; match
-    // it here so the AOT path (and thus the -r persistent run-cache) resolves the
-    // SAME modules. Without this, any program whose required user module is found
-    // by the JIT but not by AOT falls back to in-process JIT on every run — slow,
-    // and on arm64 Linux/Windows it also hits the AArch64 Branch26 JIT limit.
-    if (base_dir != ".") {
-        std::filesystem::path cwd_path = std::filesystem::path(".") / path_part;
-        if (std::filesystem::exists(cwd_path)) {
-            return std::filesystem::canonical(cwd_path).string();
-        }
-    }
-
-    // Try $ESHKOL_PATH. Empty segments, non-existent directories, and
-    // files-posing-as-dirs are silently ignored (they can't hold
-    // modules) but flagged in debug mode so "module not found" errors
-    // are easy to trace to a misconfigured path. Known pitfalls:
-    //   ESHKOL_PATH=":x"           → empty leading segment
-    //   ESHKOL_PATH="/does/not/exist" → valid syntax, wrong content
-    //   ESHKOL_PATH="/etc/passwd"  → file instead of directory
-    const char* eshkol_path = std::getenv("ESHKOL_PATH");
-    if (eshkol_path) {
-        std::stringstream ss(eshkol_path);
-        std::string search_dir;
-        while (std::getline(ss, search_dir, eshkol_path_separator)) {
-            if (search_dir.empty()) continue;
-            std::error_code ec;
-            std::filesystem::path dir_path(search_dir);
-            if (!std::filesystem::exists(dir_path, ec)) {
-                eshkol_debug("ESHKOL_PATH entry does not exist: %s", search_dir.c_str());
-                continue;
-            }
-            if (!std::filesystem::is_directory(dir_path, ec)) {
-                eshkol_debug("ESHKOL_PATH entry is not a directory: %s", search_dir.c_str());
-                continue;
-            }
-            std::filesystem::path env_path = dir_path / path_part;
-            if (std::filesystem::exists(env_path, ec)) {
-                return std::filesystem::canonical(env_path, ec).string();
-            }
-        }
-    }
-
-    // Try library directory
-    if (!lib_dir.empty()) {
-        std::filesystem::path lib_path = std::filesystem::path(lib_dir) / path_part;
-        if (std::filesystem::exists(lib_path)) {
-            return std::filesystem::canonical(lib_path).string();
-        }
-        // Directory-as-module: if lib/web.esk doesn't exist, try lib/web/web.esk
-        // This allows (require web) to find lib/web/web.esk as the package entry point
-        std::filesystem::path dir_module = std::filesystem::path(lib_dir) / module_name;
-        if (std::filesystem::is_directory(dir_module)) {
-            // Try same-name entry point: lib/web/web.esk
-            std::filesystem::path entry = dir_module / (module_name + ".esk");
-            if (std::filesystem::exists(entry)) {
-                return std::filesystem::canonical(entry).string();
-            }
-            // Try index.esk: lib/web/index.esk
-            std::filesystem::path index = dir_module / "index.esk";
-            if (std::filesystem::exists(index)) {
-                return std::filesystem::canonical(index).string();
-            }
-        }
-    }
-
-    return "";  // Not found
+    return eshkol::platform::resolve_module_source_path(module_name, base_dir, lib_dir);
 }
-
-// Global library directory (cached)
-static std::string g_lib_dir;
 
 // Is `module_name` an agent.* module whose native symbols actually live in
 // the optional eshkol-agent-ffi archive (and its libcurl/sqlite3/pcre2/
@@ -4698,6 +4563,14 @@ int main(int argc, char **argv)
             if (debug_mode) {
                 eshkol_info("JIT running: %s", filepath.c_str());
             }
+
+            // Tier 1 of the module search path for everything this file
+            // loads. Without it the in-process JIT resolved a relative
+            // `(load "sib.esk")` against the process's working directory
+            // while the AOT lane (and therefore the persistent -r run cache)
+            // resolved it beside the source file — the same command giving
+            // two answers depending only on whether the cache was in play.
+            eshkol::platform::ScopedRequiringFile requiring_file(filepath);
 
             // Set source context so runtime type errors carry a
             // "file:line:col:" prefix (v1.3 source-span errors), matching

--- a/inc/eshkol/platform_runtime.h
+++ b/inc/eshkol/platform_runtime.h
@@ -217,6 +217,26 @@ InstallArtifactNote describe_install_artifact(std::string_view label,
 // The order is the one documented in docs/reference/language/modules.md.
 
 /**
+ * @brief Sink for "why was this search-path entry skipped" diagnostics.
+ * @param message What happened, e.g. "ESHKOL_PATH entry is not a directory".
+ * @param detail  The entry it happened to.
+ */
+using ModuleSearchDiagnostic = void (*)(const char* message, const char* detail);
+
+/**
+ * @brief Install (or clear, with `nullptr`) the module-search diagnostic sink.
+ *
+ * The resolver deliberately does NOT call the logger itself: this translation
+ * unit has to keep linking on its own — `cuda_runtime_link_args_test` links
+ * `platform_runtime.cpp.o` plus a single test TU and nothing else — and a
+ * direct `eshkol_debug()` left an undefined `eshkol_printf` in exactly that
+ * link. Whoever owns the `-d` flag installs the sink instead; with none
+ * installed the entries are skipped silently, which is what a standalone
+ * link needs.
+ */
+void set_module_search_diagnostic(ModuleSearchDiagnostic sink);
+
+/**
  * @brief Locate the Eshkol module source tree (the directory that carries
  *        `stdlib.esk` beside the `core/`, `agent/`, … subtrees).
  *

--- a/inc/eshkol/platform_runtime.h
+++ b/inc/eshkol/platform_runtime.h
@@ -198,6 +198,113 @@ InstallArtifactNote describe_install_artifact(std::string_view label,
                                              const ResolvedInstallArtifact& artifact,
                                              bool verify_version = true);
 
+// ---------------------------------------------------------------------------
+// Module source resolution — `(require m)`, `(import "…")`, `(load "…")`
+// ---------------------------------------------------------------------------
+//
+// ONE resolver, used by every execution path of the driver.  `eshkol-run -r`
+// alone reaches the language through two engines — the persistent JIT run
+// cache (which compiles ahead of time) and the in-process LLVM JIT (used
+// whenever the cache is bypassed: `ESHKOL_JIT_CACHE=0`, `-d`, `--dump-ast`,
+// `--dump-ir`, several inputs, or an active
+// `$ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR`).  While each engine carried its own
+// copy of the search order they disagreed about what a relative `(load "…")`
+// means: the AOT copy resolved it against the requiring FILE's directory, the
+// JIT copy against the process's working directory.  One command, two answers
+// — so the resolver lives here, below both, and neither engine may keep a
+// private copy.
+//
+// The order is the one documented in docs/reference/language/modules.md.
+
+/**
+ * @brief Locate the Eshkol module source tree (the directory that carries
+ *        `stdlib.esk` beside the `core/`, `agent/`, … subtrees).
+ *
+ * Prefers the first install_module_roots() entry that actually carries
+ * `stdlib.esk` — that check is what keeps a downstream project's unrelated
+ * `lib/`, or a release package's archive-only `lib/`, from being mistaken for
+ * the module tree.  Falling back, returns the first root that is merely a
+ * directory, never `$ESHKOL_LIB_DIR` (it names a directory of native
+ * archives; accepting it would point `(require …)` at a tree with no `.esk`
+ * files in it).
+ *
+ * @return The resolved root; `origin == InstallOrigin::NotFound` and an empty
+ *         path when no candidate exists.
+ */
+InstallSearchRoot module_source_root();
+
+/**
+ * @brief Resolve a module name or path literal to an existing `.esk` source
+ *        file — the single authority behind `require`, `import` and `load`.
+ *
+ * @p module_name is either a dotted module name (`core.list.transform`, whose
+ * dots become directory separators before `.esk` is appended) or a path
+ * literal — a string that starts with `/`, `./` or `../`, contains a `/`, or
+ * ends in `.esk`.  Path literals are taken verbatim, with no dot-to-slash
+ * rewrite, which is what makes `(load "some/dir.v2/file.esk")` work on a
+ * directory whose name contains a dot (macOS `$TMPDIR` is
+ * `/var/folders/<hash>.<rand>/T`).  A path literal without the extension is
+ * probed both as given and with `.esk` appended, in each tier, so the
+ * extension is optional wherever the file actually lives rather than only in
+ * the working directory.
+ *
+ * Search order (docs/reference/language/modules.md):
+ *   1. @p base_dir — the directory of the file doing the require/import/load;
+ *   2. the process working directory (the project root), so a project-rooted
+ *      dotted name like `src.core.x` resolves against `./src/…`;
+ *   3. `$ESHKOL_PATH` (the `-I` flags are merged into it), highest-priority
+ *      user override, deliberately ahead of the install for the same reason
+ *      `$ESHKOL_LIB_DIR` precedes every archive location;
+ *   4. @p lib_dir, including directory-as-module entry points
+ *      (`<lib>/web/web.esk`, then `<lib>/web/index.esk`);
+ *   5. `lib/…` and `../lib/…` relative to the working directory — the
+ *      build-tree fallback for a layout whose `lib_dir` resolved elsewhere.
+ *
+ * Empty, missing and non-directory `$ESHKOL_PATH` segments are skipped.
+ *
+ * @param module_name Dotted module name or path literal, exactly as written.
+ * @param base_dir    Requiring file's directory; `"."` when there is none.
+ * @param lib_dir     Module tree root, as returned by module_source_root();
+ *                    may be empty.
+ * @return Canonical path of the first match, or an empty string when the
+ *         module is not on any tier.
+ */
+std::string resolve_module_source_path(const std::string& module_name,
+                                       const std::string& base_dir,
+                                       const std::string& lib_dir);
+
+/**
+ * @brief Declare, for the duration of the scope, which source file's forms
+ *        are being compiled — tier 1 of resolve_module_source_path().
+ *
+ * Nested loads stack: while `a/main.esk` loads `a/helper.esk`, which loads
+ * `"util.esk"`, the innermost scope is `a/helper.esk`, so `util.esk` is looked
+ * for beside `helper.esk` — not beside the outermost file and not in the
+ * working directory.  Both engines push the same scopes, which is what makes
+ * their answers identical.
+ *
+ * A pseudo-path (`"<repl>"`, `""`) pushes nothing, leaving resolution rooted
+ * at the working directory — the right answer for an expression typed at the
+ * REPL or passed with `-e`.
+ */
+class ScopedRequiringFile {
+public:
+    explicit ScopedRequiringFile(const std::string& source_path);
+    ~ScopedRequiringFile();
+
+    ScopedRequiringFile(const ScopedRequiringFile&) = delete;
+    ScopedRequiringFile& operator=(const ScopedRequiringFile&) = delete;
+
+private:
+    bool pushed_ = false;
+};
+
+/**
+ * @brief Directory of the innermost active ScopedRequiringFile.
+ * @return That directory, or `"."` when no source file is being compiled.
+ */
+std::string current_requiring_directory();
+
 /**
  * @brief Get the current user's home directory.
  * @return Value of the `HOME` environment variable; on Windows, falls back

--- a/lib/core/platform_runtime.cpp
+++ b/lib/core/platform_runtime.cpp
@@ -8,6 +8,7 @@
 #include <eshkol/platform_runtime.h>
 #include <eshkol/build_config.h>
 #include <eshkol/eshkol.h>
+#include <eshkol/logger.h>
 
 #include <algorithm>
 #include <array>
@@ -884,7 +885,19 @@ std::string resolve_module_source_path(const std::string& module_name,
             if (search_dir.empty()) continue;
             std::error_code ec;
             std::filesystem::path dir(search_dir);
-            if (!std::filesystem::is_directory(dir, ec) || ec) continue;
+            // Flagged in debug mode so a "module not found" is easy to trace
+            // back to a misconfigured path. Known pitfalls:
+            //   ESHKOL_PATH=":x"              → empty leading segment
+            //   ESHKOL_PATH="/does/not/exist" → valid syntax, wrong content
+            //   ESHKOL_PATH="/etc/passwd"     → a file, not a directory
+            if (!std::filesystem::exists(dir, ec) || ec) {
+                eshkol_debug("ESHKOL_PATH entry does not exist: %s", search_dir.c_str());
+                continue;
+            }
+            if (!std::filesystem::is_directory(dir, ec) || ec) {
+                eshkol_debug("ESHKOL_PATH entry is not a directory: %s", search_dir.c_str());
+                continue;
+            }
             if (auto found = probe_module_dir(dir, candidates); !found.empty()) {
                 return found;
             }

--- a/lib/core/platform_runtime.cpp
+++ b/lib/core/platform_runtime.cpp
@@ -720,6 +720,233 @@ ResolvedInstallArtifact resolve_install_artifact(
     return {};
 }
 
+// ---------------------------------------------------------------------------
+// Module source resolution — the single authority for require/import/load
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/** @brief `$ESHKOL_PATH` entry separator: `;` on Windows, `:` elsewhere. */
+constexpr char module_path_separator =
+#ifdef _WIN32
+    ';';
+#else
+    ':';
+#endif
+
+/** @brief Stack of directories pushed by ScopedRequiringFile.
+ *
+ *  Thread-local: module resolution is a compile-time activity that happens on
+ *  the thread driving the compilation, and a runtime worker thread must never
+ *  inherit a half-built stack from it. */
+thread_local std::vector<std::string> g_requiring_dirs;
+
+/** @brief Canonical path of @p candidate when it names an existing regular
+ *  file (symlinks followed), else an empty string.
+ *
+ *  Regular-file — not merely "exists" — because a directory that happens to
+ *  share a module's spelling is not a module: accepting it produced a path
+ *  that every later open() failed on, one tier too late to try the next
+ *  candidate. */
+std::string module_file_if_regular(const std::filesystem::path& candidate) {
+    std::error_code ec;
+    if (!std::filesystem::is_regular_file(candidate, ec) || ec) {
+        return {};
+    }
+    auto canonical = std::filesystem::weakly_canonical(candidate, ec);
+    if (ec) {
+        canonical = std::filesystem::absolute(candidate, ec);
+        if (ec) return {};
+    }
+    return canonical.string();
+}
+
+/** @brief The relative file names @p module_name may be spelled as.
+ *
+ *  A dotted module name yields exactly one (`a/b.esk`).  A path literal
+ *  yields the verbatim spelling and, when it does not already end in `.esk`,
+ *  the extension-appended one — both probed inside every tier, so an omitted
+ *  extension resolves wherever the file lives rather than only when the
+ *  working directory happens to hold it. */
+std::vector<std::string> module_path_candidates(const std::string& module_name) {
+    const bool is_path_literal =
+        !module_name.empty() &&
+        (module_name[0] == '/' ||
+         module_name.rfind("./", 0) == 0 ||
+         module_name.rfind("../", 0) == 0 ||
+         module_name.find('/') != std::string::npos ||
+         (module_name.size() > 4 &&
+          module_name.compare(module_name.size() - 4, 4, ".esk") == 0));
+
+    if (!is_path_literal) {
+        std::string dotted = module_name;
+        for (char& c : dotted) {
+            if (c == '.') c = '/';
+        }
+        return {dotted + ".esk"};
+    }
+
+    const bool has_extension =
+        module_name.size() >= 4 &&
+        module_name.compare(module_name.size() - 4, 4, ".esk") == 0;
+    if (has_extension) {
+        return {module_name};
+    }
+    return {module_name, module_name + ".esk"};
+}
+
+/** @brief First candidate of @p candidates that exists under @p dir. */
+std::string probe_module_dir(const std::filesystem::path& dir,
+                             const std::vector<std::string>& candidates) {
+    for (const auto& candidate : candidates) {
+        auto resolved = module_file_if_regular(dir / candidate);
+        if (!resolved.empty()) {
+            return resolved;
+        }
+    }
+    return {};
+}
+
+} // namespace
+
+InstallSearchRoot module_source_root() {
+    const auto roots = install_module_roots();
+
+    // The Eshkol module tree is the one that actually carries stdlib.esk.
+    for (const auto& root : roots) {
+        std::error_code ec;
+        if (std::filesystem::exists(root.path / "stdlib.esk", ec)) {
+            return root;
+        }
+    }
+
+    // No root carried stdlib.esk. Fall back to the first directory that at
+    // least exists, so a partial install still resolves user modules — but
+    // never promote $ESHKOL_LIB_DIR here: it names a directory of native
+    // archives, and accepting it as the module root would point (require …)
+    // at a build directory with no .esk files in it.
+    for (const auto& root : roots) {
+        if (root.origin == InstallOrigin::EnvOverride) {
+            continue;
+        }
+        std::error_code ec;
+        if (std::filesystem::is_directory(root.path, ec)) {
+            return root;
+        }
+    }
+
+    return {};
+}
+
+std::string resolve_module_source_path(const std::string& module_name,
+                                       const std::string& base_dir,
+                                       const std::string& lib_dir) {
+    if (module_name.empty()) {
+        return {};
+    }
+
+    const auto candidates = module_path_candidates(module_name);
+
+    // An absolute path literal names exactly one file; the tiers below are
+    // about *finding* a relative one and must not be consulted for it.
+    if (module_name[0] == '/' || std::filesystem::path(module_name).is_absolute()) {
+        return probe_module_dir(std::filesystem::path(), candidates);
+    }
+
+    // Tier 1: the directory of the file doing the require/import/load. A
+    // program's own sources come before anything else, so moving the program
+    // does not change which files it loads.
+    const std::string effective_base = base_dir.empty() ? std::string(".") : base_dir;
+    if (auto found = probe_module_dir(effective_base, candidates); !found.empty()) {
+        return found;
+    }
+
+    // Tier 2: the working directory / project root. A dotted module like
+    // `src.core.encoder.x` is rooted at the project, not at the requiring
+    // file's directory — so a file in tests/gates/ that (require src.core…)
+    // resolves against ./src/…, not tests/gates/src/….
+    if (effective_base != ".") {
+        if (auto found = probe_module_dir(".", candidates); !found.empty()) {
+            return found;
+        }
+    }
+
+    // Tier 3: $ESHKOL_PATH — the explicit override, which the `-I` flags are
+    // merged into. Ahead of the install for the same reason $ESHKOL_LIB_DIR
+    // precedes every archive location: a location the user asked for must not
+    // be silently outranked by a copy that ships with the compiler. Empty
+    // segments, missing directories and files-posing-as-directories are
+    // skipped — they cannot hold modules.
+    if (const char* eshkol_path = std::getenv("ESHKOL_PATH")) {
+        std::stringstream stream(eshkol_path);
+        std::string search_dir;
+        while (std::getline(stream, search_dir, module_path_separator)) {
+            if (search_dir.empty()) continue;
+            std::error_code ec;
+            std::filesystem::path dir(search_dir);
+            if (!std::filesystem::is_directory(dir, ec) || ec) continue;
+            if (auto found = probe_module_dir(dir, candidates); !found.empty()) {
+                return found;
+            }
+        }
+    }
+
+    // Tier 4: the installed library directory, including directory-as-module
+    // entry points so `(require web)` finds lib/web/web.esk or lib/web/index.esk.
+    if (!lib_dir.empty()) {
+        if (auto found = probe_module_dir(lib_dir, candidates); !found.empty()) {
+            return found;
+        }
+        std::error_code ec;
+        std::filesystem::path dir_module = std::filesystem::path(lib_dir) / module_name;
+        if (std::filesystem::is_directory(dir_module, ec) && !ec) {
+            auto entry = module_file_if_regular(dir_module / (module_name + ".esk"));
+            if (!entry.empty()) return entry;
+            auto index = module_file_if_regular(dir_module / "index.esk");
+            if (!index.empty()) return index;
+        }
+    }
+
+    // Tier 5: build-tree fallback. A layout whose module root resolved
+    // elsewhere (or not at all) can still be running out of a tree with a
+    // plain lib/ beside or above the working directory.
+    for (const char* fallback : {"lib", "../lib"}) {
+        if (auto found = probe_module_dir(fallback, candidates); !found.empty()) {
+            return found;
+        }
+    }
+
+    return {};
+}
+
+ScopedRequiringFile::ScopedRequiringFile(const std::string& source_path) {
+    if (source_path.empty()) {
+        return;
+    }
+    // Pseudo-paths ("<repl>", "<string>", "-e") name no directory; leaving the
+    // stack untouched keeps resolution rooted at the working directory, which
+    // is the right answer for a form that came from a terminal or a flag.
+    if (source_path.front() == '<') {
+        return;
+    }
+    std::string dir = std::filesystem::path(source_path).parent_path().string();
+    if (dir.empty()) {
+        dir = ".";
+    }
+    g_requiring_dirs.push_back(std::move(dir));
+    pushed_ = true;
+}
+
+ScopedRequiringFile::~ScopedRequiringFile() {
+    if (pushed_ && !g_requiring_dirs.empty()) {
+        g_requiring_dirs.pop_back();
+    }
+}
+
+std::string current_requiring_directory() {
+    return g_requiring_dirs.empty() ? std::string(".") : g_requiring_dirs.back();
+}
+
 std::string archive_build_version(const std::filesystem::path& artifact) {
     std::error_code ec;
     if (!std::filesystem::is_regular_file(artifact, ec) || ec) {

--- a/lib/core/platform_runtime.cpp
+++ b/lib/core/platform_runtime.cpp
@@ -8,7 +8,6 @@
 #include <eshkol/platform_runtime.h>
 #include <eshkol/build_config.h>
 #include <eshkol/eshkol.h>
-#include <eshkol/logger.h>
 
 #include <algorithm>
 #include <array>
@@ -735,6 +734,23 @@ constexpr char module_path_separator =
     ':';
 #endif
 
+/** @brief Optional sink for module-search diagnostics; null unless a driver
+ *  installs one.
+ *
+ *  This file must keep linking on its OWN — `cuda_runtime_link_args_test`
+ *  links `platform_runtime.cpp.o` plus one test TU and nothing else — so the
+ *  resolver cannot call the logger directly: doing so left an undefined
+ *  `eshkol_printf` in that link on every Linux lane. The diagnostic is
+ *  therefore injected by whoever owns the `-d` flag. */
+ModuleSearchDiagnostic g_module_search_diagnostic = nullptr;
+
+/** @brief Report a skipped search-path entry, if anyone is listening. */
+void note_module_search(const char* message, const std::string& detail) {
+    if (g_module_search_diagnostic) {
+        g_module_search_diagnostic(message, detail.c_str());
+    }
+}
+
 /** @brief Stack of directories pushed by ScopedRequiringFile.
  *
  *  Thread-local: module resolution is a compile-time activity that happens on
@@ -809,6 +825,10 @@ std::string probe_module_dir(const std::filesystem::path& dir,
 }
 
 } // namespace
+
+void set_module_search_diagnostic(ModuleSearchDiagnostic sink) {
+    g_module_search_diagnostic = sink;
+}
 
 InstallSearchRoot module_source_root() {
     const auto roots = install_module_roots();
@@ -891,11 +911,11 @@ std::string resolve_module_source_path(const std::string& module_name,
             //   ESHKOL_PATH="/does/not/exist" → valid syntax, wrong content
             //   ESHKOL_PATH="/etc/passwd"     → a file, not a directory
             if (!std::filesystem::exists(dir, ec) || ec) {
-                eshkol_debug("ESHKOL_PATH entry does not exist: %s", search_dir.c_str());
+                note_module_search("ESHKOL_PATH entry does not exist", search_dir);
                 continue;
             }
             if (!std::filesystem::is_directory(dir, ec) || ec) {
-                eshkol_debug("ESHKOL_PATH entry is not a directory: %s", search_dir.c_str());
+                note_module_search("ESHKOL_PATH entry is not a directory", search_dir);
                 continue;
             }
             if (auto found = probe_module_dir(dir, candidates); !found.empty()) {

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -698,7 +698,13 @@ namespace eshkol {
 
 // Forward declarations for static helper functions
 static std::vector<eshkol_ast_t> parseAllAstsFromString(const std::string& content);
-static std::string resolveModulePath(const std::string& module_name, const std::string& base_dir = ".");
+// base_dir defaults to the directory of the file currently being compiled —
+// NOT to the process's working directory. The old `= "."` default was the
+// whole of the JIT/AOT divergence: every call site took it, so the in-process
+// JIT never knew which file was doing the require/import/load.
+static std::string resolveModulePath(const std::string& module_name,
+                                     const std::string& base_dir =
+                                         platform::current_requiring_directory());
 
 /**
  * Scoped parser/codegen provenance for nested module loads.
@@ -706,6 +712,12 @@ static std::string resolveModulePath(const std::string& module_name, const std::
  * Requiring a module can recursively require another module. A one-way
  * eshkol_set_source_context() call would leave the caller attributed to the
  * last dependency compiled, so preserve and restore all active source text.
+ *
+ * The same scope also establishes the requiring file for module resolution:
+ * "these forms came from this file" is one fact, and answering it in two
+ * places is exactly how the two lanes drifted apart. Every site that
+ * attributes source text therefore also roots the search path, and no site
+ * can do one without the other.
  */
 class ScopedSourceContext {
 public:
@@ -713,6 +725,7 @@ public:
         : previous_path_(eshkol_get_source_context_path())
         , previous_text_(eshkol_get_source_context_text())
         , previous_parse_path_(eshkol_get_parse_source_context())
+        , requiring_file_(path)
     {
         eshkol_set_source_context(path.c_str(), text.c_str());
     }
@@ -729,6 +742,7 @@ private:
     std::string previous_path_;
     std::string previous_text_;
     std::string previous_parse_path_;
+    platform::ScopedRequiringFile requiring_file_;
 };
 
 /**
@@ -3091,154 +3105,40 @@ static std::vector<eshkol_ast_t> parseAllAstsFromString(const std::string& conte
  * @brief Searches a set of platform-specific candidate paths for the Eshkol `lib` directory (module source root).
  * @return The first existing candidate directory path, or an empty string if none is found.
  */
-// Find the lib directory (matches eshkol-run.cpp find_lib_dir())
+// Find the lib directory. The selection rule itself lives in
+// platform::module_source_root(), shared with the AOT driver, so the two
+// lanes cannot disagree about which tree carries stdlib.esk.
 static std::string findLibDir() {
-    // Prefer the Eshkol installation that actually owns stdlib.esk.  A
-    // release package also contains ../lib for native archives; accepting the
-    // first existing directory therefore selects the archive directory and
-    // makes installed source modules such as agent.regex invisible to the
-    // cache-disabled JIT.  platform::install_module_roots() supplies the
-    // shared precedence — $ESHKOL_LIB_DIR, then the real executable's install
-    // tree, then the cwd, then the system prefixes — so the executable-
-    // relative installed source tree wins over a downstream project's
-    // unrelated lib/ directory.
-    const auto roots = platform::install_module_roots();
-
-    for (const auto& root : roots) {
-        std::error_code ec;
-        if (std::filesystem::exists(root.path / "stdlib.esk", ec)) {
-            return root.path.string();
-        }
-    }
-
-    for (const auto& root : roots) {
-        if (root.origin == platform::InstallOrigin::EnvOverride) {
-            continue;
-        }
-        std::error_code ec;
-        if (std::filesystem::is_directory(root.path, ec)) {
-            return root.path.string();
-        }
-    }
-
-    return {};
+    return platform::module_source_root().path.string();
 }
 
 // Global lib directory cache
 static std::string g_lib_dir;
 
-// Helper to resolve module path (e.g., "core.functional.compose" -> "lib/core/functional/compose.esk")
-// Matches eshkol-run.cpp module resolution logic
 /**
- * @brief Resolves a `(require ...)` module name (or literal `(load ...)` path) to a canonical, existing `.esk` file path.
+ * @brief Resolves a `(require ...)` module name (or a literal `(load ...)` /
+ *        `(import "...")` path) to a canonical, existing `.esk` file path.
  *
- * If @p module_name already looks like a path literal (absolute, `./`,
- * `../`, contains a `/`, or ends in `.esk`), it is used as-is (appending
- * `.esk` only if missing and the bare path does not already exist);
- * otherwise dots are converted to path separators and `.esk` appended (e.g.
- * "core.functional.compose" -> "core/functional/compose.esk"). The resulting
- * relative path is then searched for, in order: @p base_dir, the cached
- * library directory (found via findLibDir(), memoized in g_lib_dir),
- * each colon/semicolon-separated directory in `$ESHKOL_PATH`, and finally a
- * short list of legacy fallback paths.
- * @return The canonicalized absolute path of the first match found, or "" if
- * the module could not be located anywhere.
+ * Delegates in full to platform::resolve_module_source_path(), the resolver
+ * the AOT driver also uses; see its declaration for the search order. @p
+ * base_dir defaults to the directory of the file currently being compiled
+ * (platform::current_requiring_directory()), which every ScopedSourceContext
+ * establishes.
+ * @return The canonicalized absolute path of the first match, or "" if the
+ * module is not on any tier of the search path.
  */
 static std::string resolveModulePath(const std::string& module_name, const std::string& base_dir) {
-    // PATH-LITERAL DETECTION:
-    //
-    // `(load "...")` strings are stored in module_names verbatim (the
-    // parser used to mangle them into dotted form, but that broke
-    // any path whose directory components contain dots — common on
-    // macOS where $TMPDIR is /var/folders/<hash>.<rand>/T, and on
-    // any project that uses cache dirs like build.v2/).  Treat
-    // anything that looks like a literal path as one and skip the
-    // dot-to-slash rewrite entirely.
-    bool is_path_literal =
-        !module_name.empty() &&
-        (module_name[0] == '/' ||
-         module_name.rfind("./", 0) == 0 ||
-         module_name.rfind("../", 0) == 0 ||
-         module_name.find('/') != std::string::npos ||
-         (module_name.size() > 4 &&
-          module_name.compare(module_name.size() - 4, 4, ".esk") == 0));
-
-    std::string path_part;
-    if (is_path_literal) {
-        path_part = module_name;
-        // Add .esk if the user omitted it (and the path doesn't already
-        // point at an existing file as-given).
-        if (path_part.size() < 4 ||
-            path_part.compare(path_part.size() - 4, 4, ".esk") != 0) {
-            // Only append if the bare path doesn't exist; users may load
-            // a file with a non-.esk extension on purpose.
-            if (!std::filesystem::exists(path_part)) {
-                path_part += ".esk";
-            }
-        }
-    } else {
-        // Convert dots to path separators (dotted module name)
-        path_part = module_name;
-        for (char& c : path_part) {
-            if (c == '.') c = '/';
-        }
-        path_part += ".esk";
-    }
-
     // Initialize lib dir if needed
     if (g_lib_dir.empty()) {
         g_lib_dir = findLibDir();
     }
 
-    // Search order (kept identical to eshkol-run.cpp resolve_module_path):
-    // 1. The requiring file's own directory (the program's own sources)
-    // 2. $ESHKOL_PATH — the explicit override, which `-I` flags feed into
-    // 3. The installed library directory (lib/)
-    // The override precedes the install for the same reason ESHKOL_LIB_DIR
-    // precedes every archive location: a search path the user named must not
-    // be silently outranked by a copy that happens to ship with the compiler.
-
-    // Try current directory first
-    std::filesystem::path current_path = std::filesystem::path(base_dir) / path_part;
-    if (std::filesystem::exists(current_path)) {
-        return std::filesystem::canonical(current_path).string();
-    }
-
-    // Try $ESHKOL_PATH
-    const char* eshkol_path = std::getenv("ESHKOL_PATH");
-    if (eshkol_path) {
-        std::stringstream ss(eshkol_path);
-        std::string search_dir;
-        while (std::getline(ss, search_dir, eshkol_path_separator)) {
-            std::filesystem::path env_path = std::filesystem::path(search_dir) / path_part;
-            if (std::filesystem::exists(env_path)) {
-                return std::filesystem::canonical(env_path).string();
-            }
-        }
-    }
-
-    // Try library directory
-    if (!g_lib_dir.empty()) {
-        std::filesystem::path lib_path = std::filesystem::path(g_lib_dir) / path_part;
-        if (std::filesystem::exists(lib_path)) {
-            return std::filesystem::canonical(lib_path).string();
-        }
-    }
-
-    // Legacy fallback paths
-    std::vector<std::string> fallback_paths = {
-        "lib/" + path_part,
-        path_part,
-        "../lib/" + path_part,
-    };
-
-    for (const auto& p : fallback_paths) {
-        if (std::filesystem::exists(p)) {
-            return std::filesystem::canonical(p).string();
-        }
-    }
-
-    return "";
+    // One resolver, shared with the AOT driver. Everything about the search
+    // order — path-literal detection, the requiring file's directory ahead of
+    // the working directory, $ESHKOL_PATH ahead of the install, the
+    // directory-as-module entry points — is stated once, in
+    // platform::resolve_module_source_path().
+    return platform::resolve_module_source_path(module_name, base_dir, g_lib_dir);
 }
 
 /**
@@ -3644,22 +3544,13 @@ void* ReplJITContext::execute(eshkol_ast_t* ast) {
         if (ast->operation.op == ESHKOL_IMPORT_OP && ast->operation.import_op.path) {
             std::string import_path = ast->operation.import_op.path;
 
-            // Resolve relative paths
-            if (!std::filesystem::path(import_path).is_absolute()) {
-                if (!std::filesystem::exists(import_path)) {
-                    // Try relative to lib/
-                    std::string lib_path = "lib/" + import_path;
-                    if (std::filesystem::exists(lib_path)) {
-                        import_path = lib_path;
-                    }
-                }
-            }
-
-            // Check if already loaded
-            std::string canonical_path;
-            try {
-                canonical_path = std::filesystem::canonical(import_path).string();
-            } catch (...) {
+            // A path-form `import` asks the same question as `require` and
+            // `load`, so it gets the same answer from the same resolver —
+            // rooted at the importing file, then the working directory, then
+            // $ESHKOL_PATH, then the install. The private cwd-plus-"lib/"
+            // rule this replaced was a third dialect of the search path.
+            std::string canonical_path = resolveModulePath(import_path);
+            if (canonical_path.empty()) {
                 std::cerr << "Import file not found: " << import_path << std::endl;
                 return nullptr;
             }

--- a/scripts/run_ctest_gate.sh
+++ b/scripts/run_ctest_gate.sh
@@ -83,6 +83,7 @@ fixed_point_exact_accumulation_gate	^fixedpoint_	Fixed-point / i128 exact-accumu
 exact_input_ad_identity_gate	^(exact_point_ad|exact_taylor)_(runtime|aot)_smoke$	Exact-input AD identity tier
 runtime_closure_arity_spread_gate	^runtime_closure_arity_spread_	Runtime-closure gradient arity spread
 define_library_same_unit_gate	^define_library_same_unit_	R7RS same-unit define-library resolution
+module_load_path_engine_parity_gate	^load_path_engine_parity_test$	Relative (load …) resolves identically on every execution engine
 GROUPS
 )
 

--- a/tests/toolchain/load_path_engine_parity_test.sh
+++ b/tests/toolchain/load_path_engine_parity_test.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# load_path_engine_parity_test.sh — one command, one answer.
+#
+# WHAT THIS GUARDS
+#   `eshkol-run -r prog.esk` reaches the language through more than one engine.
+#   With a single input file and no -d/--dump-*/coverage tracing it goes through
+#   the persistent JIT run cache, which compiles ahead of time; bypass the cache
+#   (ESHKOL_JIT_CACHE=0, or -d, or --dump-ast/--dump-ir, or several inputs, or an
+#   active $ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR) and it goes through the
+#   in-process LLVM JIT instead. `eshkol-run prog.esk -o prog` is a third lane.
+#
+#   Those lanes each carried their own copy of the module search order, and the
+#   copies disagreed: the AOT copy resolved a relative `(load "sib.esk")` beside
+#   the SOURCE FILE, the JIT copy against the process's WORKING DIRECTORY. So
+#   the same command on the same file printed one answer with the cache warm and
+#   a different one (or "Module not found") with it bypassed — a divergence that
+#   surfaced only in whichever harness happened to set one of the bypass
+#   switches. run_language_coverage.sh sets the coverage trace dir, so the whole
+#   qllm suite aborted under it while passing everywhere else.
+#
+#   The contract is documented in docs/reference/language/modules.md: the
+#   requiring FILE's directory first, then the working directory, then
+#   $ESHKOL_PATH/-I, then the install. This test pins BOTH halves of it and
+#   demands every engine agree byte for byte.
+#
+# WHY A DECOY
+#   A same-named file is planted in the working directory. A lane that resolves
+#   against the cwd finds the decoy and prints a DIFFERENT number — so this test
+#   fails on a difference, not merely on an error. Deleting the decoy would let
+#   a cwd-rooted lane pass by accident.
+#
+# USAGE
+#   bash tests/toolchain/load_path_engine_parity_test.sh [path/to/eshkol-run]
+set -uo pipefail
+
+ESHKOL_RUN="${1:-${ESHKOL_RUN:-}}"
+if [ -z "$ESHKOL_RUN" ]; then
+    for candidate in ./build/eshkol-run ./build-verify/eshkol-run ./b/eshkol-run; do
+        if [ -x "$candidate" ]; then ESHKOL_RUN="$candidate"; break; fi
+    done
+fi
+if [ -z "$ESHKOL_RUN" ] || [ ! -x "$ESHKOL_RUN" ]; then
+    echo "FAIL: load_path_engine_parity_test could not locate an executable eshkol-run" >&2
+    exit 1
+fi
+case "$ESHKOL_RUN" in
+    /*) : ;;
+    *) ESHKOL_RUN="$(pwd)/$ESHKOL_RUN" ;;
+esac
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-load-parity.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+failures=0
+fail() { echo "FAIL: $*" >&2; failures=$((failures + 1)); }
+
+# ── fixture ──────────────────────────────────────────────────────────────
+# proj/main.esk       loads a sibling, and a file one directory down
+# proj/sib.esk        the sibling that must win over the cwd decoy
+# proj/nested/deep.esk    loads ITS OWN sibling — the search root must follow
+# proj/nested/deeper.esk  the load stack down, not stay pinned at main.esk
+mkdir -p "$tmpdir/proj/nested" "$tmpdir/elsewhere/shared"
+
+cat > "$tmpdir/proj/sib.esk" <<'EOF'
+(define (sib-value) 21)
+EOF
+
+cat > "$tmpdir/proj/nested/deeper.esk" <<'EOF'
+(define (deeper-value) 100)
+EOF
+
+cat > "$tmpdir/proj/nested/deep.esk" <<'EOF'
+(load "deeper.esk")
+(define (deep-value) (+ (deeper-value) 5))
+EOF
+
+cat > "$tmpdir/proj/main.esk" <<'EOF'
+(load "sib.esk")
+(load "nested/deep.esk")
+(display (* 2 (sib-value)))
+(newline)
+(display (deep-value))
+(newline)
+EOF
+
+# The decoy: same spelling, different answer, sitting in the working directory.
+cat > "$tmpdir/elsewhere/sib.esk" <<'EOF'
+(define (sib-value) 999)
+EOF
+
+# The other half of the contract: a program whose load target exists ONLY
+# relative to the working directory (the repo-root spelling the corpus uses,
+# e.g. (load "tests/.../fixture.esk") run from the repo root). Tier 2 must
+# still fire, or that whole camp of tests stops resolving.
+cat > "$tmpdir/elsewhere/shared/helper.esk" <<'EOF'
+(define (helper-value) 7)
+EOF
+cat > "$tmpdir/proj/cwdrel.esk" <<'EOF'
+(load "shared/helper.esk")
+(display (* 3 (helper-value)))
+(newline)
+EOF
+
+expected_main=$'42\n105'
+expected_cwdrel=$'21'
+
+# ── engines ──────────────────────────────────────────────────────────────
+# Each runs with cwd = $tmpdir/elsewhere, i.e. NOT the source file's directory,
+# which is the only condition under which the two rules differ at all.
+run_engine() { # engine-name source-file -> stdout on fd 1
+    local engine="$1" src="$2"
+    local out rc
+    case "$engine" in
+        jit-cache)
+            out="$(cd "$tmpdir/elsewhere" && \
+                ESHKOL_JIT_CACHE_DIR="$tmpdir/cache" \
+                "$ESHKOL_RUN" -r "$src" 2>/dev/null)"
+            rc=$?
+            ;;
+        jit-in-process)
+            out="$(cd "$tmpdir/elsewhere" && \
+                ESHKOL_JIT_CACHE=0 \
+                "$ESHKOL_RUN" -r "$src" 2>/dev/null)"
+            rc=$?
+            ;;
+        jit-coverage-trace)
+            # The exact bypass run_language_coverage.sh takes.
+            mkdir -p "$tmpdir/covtrace"
+            out="$(cd "$tmpdir/elsewhere" && \
+                ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR="$tmpdir/covtrace" \
+                "$ESHKOL_RUN" -r "$src" 2>/dev/null)"
+            rc=$?
+            ;;
+        aot)
+            local bin="$tmpdir/aot-$(basename "$src" .esk)"
+            if ! (cd "$tmpdir/elsewhere" && \
+                    "$ESHKOL_RUN" "$src" -o "$bin" >/dev/null 2>&1); then
+                echo "__COMPILE_FAILED__"
+                return 1
+            fi
+            out="$(cd "$tmpdir/elsewhere" && "$bin" 2>/dev/null)"
+            rc=$?
+            ;;
+        *)
+            echo "__UNKNOWN_ENGINE__"; return 1 ;;
+    esac
+    printf '%s' "$out"
+    return "$rc"
+}
+
+ENGINES="jit-cache jit-in-process jit-coverage-trace aot"
+
+check_program() { # label source-file expected
+    local label="$1" src="$2" expected="$3"
+    local baseline="" baseline_engine="" agreed=0 total=0
+    for engine in $ENGINES; do
+        local got rc
+        total=$((total + 1))
+        got="$(run_engine "$engine" "$src")"
+        rc=$?
+        if [ "$rc" -ne 0 ]; then
+            fail "$label: engine '$engine' exited $rc (output: ${got//$'\n'/ | })"
+            continue
+        fi
+        if [ "$got" != "$expected" ]; then
+            fail "$label: engine '$engine' produced '${got//$'\n'/ | }', expected '${expected//$'\n'/ | }'"
+            continue
+        fi
+        if [ -z "$baseline_engine" ]; then
+            baseline="$got"; baseline_engine="$engine"; agreed=1
+        elif [ "$got" != "$baseline" ]; then
+            fail "$label: engine '$engine' disagrees with '$baseline_engine' — one command, two answers"
+        else
+            agreed=$((agreed + 1))
+        fi
+    done
+    # Report the count that actually agreed, never the count attempted: a line
+    # reading "4 engines agree" above two FAILs is how a parity test stops
+    # being read.
+    echo "  $label: $agreed/$total engines agree on '${baseline//$'\n'/ | }'"
+}
+
+echo "load_path_engine_parity_test: source-file-relative load, cwd holds a decoy"
+check_program "file-relative load (+ nested, + decoy in cwd)" \
+    "$tmpdir/proj/main.esk" "$expected_main"
+
+echo "load_path_engine_parity_test: cwd-relative load (project-root spelling)"
+check_program "cwd-relative load" \
+    "$tmpdir/proj/cwdrel.esk" "$expected_cwdrel"
+
+# ── the decoy must genuinely be reachable ────────────────────────────────
+# If the decoy could never be found by anything, its presence proves nothing.
+# Run a program FROM the working directory that loads it: that must print 1998,
+# confirming the file is loadable and that the 42 above is a real precedence
+# decision rather than an inability to see the decoy at all.
+cat > "$tmpdir/elsewhere/decoy_probe.esk" <<'EOF'
+(load "sib.esk")
+(display (* 2 (sib-value)))
+(newline)
+EOF
+decoy_out="$(cd "$tmpdir/elsewhere" && ESHKOL_JIT_CACHE=0 \
+    "$ESHKOL_RUN" -r "$tmpdir/elsewhere/decoy_probe.esk" 2>/dev/null)"
+if [ "$decoy_out" != "1998" ]; then
+    fail "decoy control: expected 1998 from the cwd copy, got '$decoy_out' (the decoy is not reachable, so the precedence assertion above is vacuous)"
+else
+    echo "  decoy control: the cwd copy is reachable (1998) and correctly loses to the sibling"
+fi
+
+if [ "$failures" -ne 0 ]; then
+    echo "FAIL: load_path_engine_parity_test — $failures check(s) failed" >&2
+    exit 1
+fi
+
+echo "PASS: load_path_engine_parity_test"
+exit 0


### PR DESCRIPTION
## Root cause: two execution paths, two answers

`eshkol-run -r prog.esk` does not name one engine. With a single input file, no
`-d`/`--dump-ast`/`--dump-ir`, and no `$ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR`, it
goes through the persistent JIT run cache, which compiles ahead of time. Set any
of those switches (or `ESHKOL_JIT_CACHE=0`) and it goes through the in-process
LLVM JIT instead. `eshkol-run prog.esk -o prog` is a third lane.

Each lane carried its own copy of the module search order, and the copies
disagreed about the very first tier:

| lane | resolver | first tier |
|---|---|---|
| AOT / persistent `-r` run cache | `exe/eshkol-run.cpp` `resolve_module_path` | the requiring **file's** directory |
| in-process JIT | `lib/repl/repl_jit.cpp` `resolveModulePath` | `base_dir` defaulted to `"."` — the process **working directory** |

The JIT copy's `base_dir = "."` default was taken by its only call site, so that
engine never knew which file was doing the `require`/`import`/`load`. Two more
private copies existed: the JIT's path-form `(import "…")` handler searched
cwd-then-`lib/` only, and the AOT `process_imports` searched the source
directory only. The comment in `repl_jit.cpp` even claimed the orders were
"kept identical to eshkol-run.cpp" — they had not been for some time.

## Repro, both ways (pre-fix)

```
$ mkdir -p sub
$ printf '(define (sib-value) 21)\n' > sub/sib.esk
$ printf '(load "sib.esk")\n(display (* 2 (sib-value)))\n(newline)\n' > sub/main.esk
$ cd /tmp

$ eshkol-run -r $PWD/sub/main.esk                          # persistent run cache
42

$ ESHKOL_JIT_CACHE=0 eshkol-run -r $PWD/sub/main.esk       # in-process JIT
Module not found: sib.esk
     ERROR: JIT dependency load failed: required module could not be loaded: sib.esk
(exit 1)

$ ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR=/tmp/tr eshkol-run -r $PWD/sub/main.esk
Module not found: sib.esk
     ERROR: JIT dependency load failed: required module could not be loaded: sib.esk

$ eshkol-run $PWD/sub/main.esk -o m && ./m                 # AOT
42
```

Same command, same file, two answers. And with a same-named file in the working
directory it is worse than an error: the bypass lanes load a *different program*
and print a different number, silently.

After this change all four print `42`.

## Contract decision

**Unchanged — and taken from the docs, which already stated it.**
`docs/reference/language/modules.md` has always documented the search path as:

1. the directory of the file doing the `require`/`import`/`load`
2. the project root (the current working directory)
3. `-I DIR`, then `$ESHKOL_PATH`
4. the compiler's bundled `lib/`

So this is not a new semantic. It is the AOT lane's behaviour — the documented
one — applied to the lane that had drifted off it. The code moved to the docs,
not the other way round.

The corpus confirms the chain is the only rule that works. Surveying every
relative `(load …)` in the tree turns up two disjoint camps, with nothing that
resolves in both:

- **sibling-relative (needs tier 1):** the whole `tests/qllm_oracle` suite
  (`(load "qllm_oracle_lib.esk")`, five exporters), `tests/build_integration`
  (CMake runs it with cwd = the *build* dir), the generated fixtures in
  `tests/toolchain/transitive_ffi_link_test.sh` and
  `tests/v1_3_edge_cases/jit_cache_test.sh`,
  `tests/bug_BB_xfile_indirector_regression.esk`
- **project-root-relative (needs tier 2):** `tests/load/load_relative_subdir_test.esk`
  (a dedicated regression whose header states the cwd contract explicitly),
  `tests/tensor/embedding_operand_via_module_*` (two ctest cases, both of which
  `cd` to the source root first — the cwd tier is deliberate there, not
  incidental), `tests/stress/stress_fd_exhaustion.esk`, and eleven `(load …)`
  forms across seven files under `tests/v1_2_edge_cases`

Dropping either tier breaks a camp; keeping the chain breaks nothing. This is
the option that breaks zero existing tests *and* gives `load` the same
file-relative behaviour `include` has.

## Fix shape: one resolver, not a second patched copy

Resolution now happens once, in **`eshkol::platform::resolve_module_source_path()`**
(`lib/core/platform_runtime.cpp`, declared in `inc/eshkol/platform_runtime.h`) —
a translation unit both the driver and the REPL JIT already link. Both former
copies are thin forwarders; neither may shadow it. The module-tree selection
rule that was duplicated the same way (`find_lib_dir` / `findLibDir`) collapses
into `platform::module_source_root()`.

"Which file is doing the loading" is established by the **same scope that
attributes source text** — `ScopedSourceContext` owns a
`platform::ScopedRequiringFile` — so the two facts cannot drift apart, and a
nested load roots at its own file rather than at the outermost one
(`a/main.esk` → `a/helper.esk` → `"util.esk"` finds `a/util.esk`). The `-r`
driver loop pushes the same scope for the entry file. A pseudo-path (`<repl>`,
`-e`) pushes nothing, leaving resolution rooted at the working directory, which
is right for a form typed at a terminal.

Two incidental sharp edges went with it, both strict improvements:

- a path literal written without `.esk` is probed with **and** without the
  extension in every tier, not only against the working directory
- a directory that happens to share a module's spelling no longer wins the
  lookup only to fail at `open()` (regular-file check, not `exists`)

## Test evidence

New `tests/toolchain/load_path_engine_parity_test.sh`, wired as CTest
`load_path_engine_parity_test`, as a `run_ctest_gate.sh` group
(`module_load_path_engine_parity_gate`), and as a release-oracle criterion in
`.icc/completion-oracles.yaml`.

It runs one program through **all four lanes** — run cache, `ESHKOL_JIT_CACHE=0`,
the coverage-trace bypass, and AOT — from a working directory that is *not* the
source directory, and demands byte-identical output. A same-named decoy is
planted in the working directory, with a control run proving the decoy is
genuinely reachable, so a cwd-rooted lane fails on a **different answer** rather
than merely on a missing file. Tier 2 is pinned by a second, project-root-relative
program in the same test.

```
$ bash tests/toolchain/load_path_engine_parity_test.sh   # fixed build
  file-relative load (+ nested, + decoy in cwd): 4/4 engines agree on '42 | 105'
  cwd-relative load: 4/4 engines agree on '21'
  decoy control: the cwd copy is reachable (1998) and correctly loses to the sibling
PASS: load_path_engine_parity_test                        exit 0

$ bash tests/toolchain/load_path_engine_parity_test.sh   # pre-fix build
FAIL: engine 'jit-in-process' exited 1
FAIL: engine 'jit-coverage-trace' exited 1
  file-relative load (+ nested, + decoy in cwd): 2/4 engines agree
FAIL: load_path_engine_parity_test — 2 check(s) failed    exit 1
```

Both camps of the existing corpus were also verified by hand on both cache
settings: `tests/load/load_relative_subdir_test.esk`,
`tests/qllm_oracle/sphere_ops.esk` (11/11),
`tests/v1_2_edge_cases/cross_file_apply_test.esk` (7/7), and
`tests/tensor/embedding_operand_via_module_test.esk` — all PASS with the cache
on and with `ESHKOL_JIT_CACHE=0`.

### Full batteries (this branch, merged with master `46b87a6e`)

| Gate | Result |
|---|---|
| CTest gate (`run_ctest_gate.sh`) | **PASS — 140/140**, all 5 groups green incl. the new `module_load_path_engine_parity_gate (1/1)` |
| ICC smoke (`run_icc_smoke.sh`) | **56/56 probes PASS**, zero failures — including `language_surface_coverage_floor` |
| Language surface coverage | **1091/1091 (100.0%) execution-backed**, floor PASS, deficit ratchet PASS, high-risk uncovered 0 |
| VM parity | **140 passed, 0 failed** |
| SICP smoke | **88/88 gate probes PASS**, 0 xfail, 0 XPASS |
| Reference differential | **PASS** (every program agrees) |

### ICC verdicts

| Analysis | Result |
|---|---|
| guard-liveness | 276 tokens / 57 dead — **identical to the `eshkol-v134-release` baseline**; the diff adds exactly one guard site (`#ifdef _WIN32` for the path separator) and zero dead guards |
| odr-audit | 18 collisions — **identical to baseline**, no new duplicate definitions |
| impact-analysis (vs `41299d3c`) | 11 changed paths, 367 seed symbols, 5238 impacted symbols, 1382 impacted paths |
| contract gaps / stubbed paths | 0 / 0 |

## Why this was the release blocker

`scripts/run_language_coverage.sh` sets `ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR`,
which bypasses the run cache. The qllm oracle exporters load a sibling library,
so the whole suite aborted under that one harness while passing under every
other. That took out the `language_surface_coverage_floor` probe, which was the
**sole** FAIL in the readiness oracle on master 41299d3c:

```
runtime_checks: failure_free = FAIL
  eshkol_smoke / language_surface_coverage_floor = FAIL
readiness (master 41299d3c, repo eshkol-v134-release): 88 / blocked
```

With the fix, traces regenerated from scratch on this branch:

```
runtime_checks : 2/2 PASS   (failure_free is now PASS)
completion oracle: 38/38 PASS
contract gaps  : 0    stubbed paths: 0

READINESS: 100 — status: ready
```

**88 (blocked) → 100 (ready).** The coverage floor was the only thing standing
between the two, and the `failure_free` runtime check it was failing is now
green. The 38th criterion is this PR's own
`module_load_path_engine_parity_gate`, so the fix arrives already gated.

## Not in scope — filed, not silently left

The bytecode VM lane (`--profile hosted-vm -B`) is a fourth engine with its own
loader in `lib/backend/vm_compiler.c`. It resolves only `lib/<dotted>.esk` and
`<dotted-as-slash>.esk`, both cwd-relative, and it ignores a path-literal
`(load "sib.esk")` **entirely and silently** — `eshkol_emit_eskb()` is handed
source *text* with no path, so file-relative resolution is not expressible there
without threading the source path through that API. That is a separate change
with its own risk surface and it does not gate this release; it is stated here
so it is a known item rather than an assumption.
