### PR TITLE
docs: fix phantom API names, dead links, and nav orphans (v1.3.4 audit)

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -21,7 +21,7 @@ This comprehensive reference documents all special forms, functions, and operati
 9. [System Operations](#system-operations)
 10. [Hash Tables](#hash-tables)
 11. [Type System](#type-system)
-12. [Standard Library](#standard-library) (25+ modules)
+12. [Standard Library](#standard-library-reference) (25+ modules)
 13. [Exact Arithmetic](#exact-arithmetic) (v1.1)
 14. [Complex Numbers](#complex-numbers) (v1.1)
 15. [Continuations & Control Flow](#continuations--control-flow) (v1.1)
@@ -2321,7 +2321,7 @@ heterogeneous workloads.
 **Thread pool sizing:** Defaults to `std::thread::hardware_concurrency()` (number of logical
 cores). Can be tuned via environment variable `ESHKOL_NUM_THREADS`.
 
-**Implementation:** [system_codegen.cpp](lib/backend/system_codegen.cpp).
+**Implementation:** [system_codegen.cpp](../lib/backend/system_codegen.cpp).
 
 ### `parallel-map`
 
@@ -2450,9 +2450,9 @@ holds the codegen methods (`codegenMakeFactorGraph`, `codegenFGAddFactor`,
 `codegenWSStep`, plus the logic-engine entry points); the dispatch
 table lives in `LLVMCodeGenerator::codegenSpecialOperation` in
 [lib/backend/llvm_codegen.cpp](../lib/backend/llvm_codegen.cpp).
-Runtime: [logic.h](inc/eshkol/backend/logic.h) / [logic.cpp](lib/backend/logic.cpp),
-[inference.h](inc/eshkol/backend/inference.h) / [inference.cpp](lib/backend/inference.cpp),
-[workspace.h](inc/eshkol/backend/workspace.h) / [workspace.cpp](lib/backend/workspace.cpp).
+Runtime: [logic.h](../inc/eshkol/core/logic.h) / [logic.cpp](../lib/core/logic.cpp),
+[inference.h](../inc/eshkol/core/inference.h) / [inference.cpp](../lib/core/inference.cpp),
+[workspace.h](../inc/eshkol/core/workspace.h) / [workspace.cpp](../lib/core/workspace.cpp).
 
 ### Logic Programming
 
@@ -3071,7 +3071,7 @@ for large tensors, automatic GPU dispatch above cost model thresholds, and seaml
 with Eshkol's automatic differentiation system via `gradient`.
 
 **Architecture:** Operations are dispatched in `LLVMCodeGenerator::codegenCall` in [lib/backend/llvm_codegen.cpp](../lib/backend/llvm_codegen.cpp)
-and implemented in [tensor_codegen.cpp](lib/backend/tensor_codegen.cpp). Backward passes are
+and implemented in [tensor_codegen.cpp](../lib/backend/tensor_codegen.cpp). Backward passes are
 available for AD integration (e.g., `tensorReluBackward`, `tensorSigmoidBackward`).
 
 ### Activation Functions
@@ -4192,8 +4192,8 @@ GPU acceleration via Metal (Apple Silicon) and CUDA (NVIDIA). Dispatch is automa
 on a cost model comparing CPU (cBLAS/SIMD) vs GPU throughput, accounting for data transfer
 latency.
 
-**Implementation:** [gpu_memory.mm](lib/backend/gpu/gpu_memory.mm) (Metal),
-[system_codegen.cpp](lib/backend/system_codegen.cpp) (dispatch logic).
+**Implementation:** [gpu_memory.mm](../lib/backend/gpu/gpu_memory.mm) (Metal),
+[system_codegen.cpp](../lib/backend/system_codegen.cpp) (dispatch logic).
 
 ### Automatic Dispatch
 
@@ -4267,7 +4267,7 @@ eliminating intermediate tensor allocations and enabling whole-graph optimizatio
 **Architecture:** Eshkol tensor IR → StableHLO dialect → MLIR optimization passes →
 target-specific code (CPU with SIMD / GPU via Metal or CUDA).
 
-**Implementation:** [xla_runtime.cpp](lib/backend/xla/xla_runtime.cpp).
+**Implementation:** [xla_runtime.cpp](../lib/backend/xla/xla_runtime.cpp).
 
 ### Operation Fusion
 
@@ -4329,7 +4329,7 @@ Built-in Cooley-Tukey radix-2 FFT:
 
 #### Convolution
 - `(convolve signal kernel)` — Direct convolution O(N*M)
-- `(fft-convolve signal kernel)` — FFT-based convolution O(N log N)
+- `(fast-convolve signal kernel)` — FFT-based convolution O(N log N)
 
 #### Filters
 - `(fir-filter coefficients signal)` — FIR filter application
@@ -7064,8 +7064,8 @@ for composability and custom pipelines.
 ## Implementation Statistics
 
 **Codebase Size**: ~232,000 lines of production C++
-**Main Backend**: [llvm_codegen.cpp](lib/backend/llvm_codegen.cpp) — 34,928 lines
-**Tensor Codegen**: [tensor_codegen.cpp](lib/backend/tensor_codegen.cpp) — 20,000+ lines
+**Main Backend**: [llvm_codegen.cpp](../lib/backend/llvm_codegen.cpp) — 34,928 lines
+**Tensor Codegen**: [tensor_codegen.cpp](../lib/backend/tensor_codegen.cpp) — 20,000+ lines
 **Compiler Modules**: 21 specialized code generators
 **Test Suite**: 37 suites, 528 self-reported tests
 **Verified Operations**: 555+ builtins, 300+ standard library functions

--- a/docs/ESHKOL_LANGUAGE_GUIDE.md
+++ b/docs/ESHKOL_LANGUAGE_GUIDE.md
@@ -190,11 +190,11 @@ Eshkol v1.1 ships with over 555 built-in functions. They span arithmetic, math, 
 
 **GPU:** `gpu-matmul`, `gpu-elementwise`, `gpu-reduce`, `gpu-softmax`, `gpu-transpose`
 
-**Signal Processing:** `fft`, `ifft`, `convolve`, `fir-filter`, `iir-filter`, `butterworth-lowpass`, `window-hamming`, `window-hann`
+**Signal Processing:** `fft`, `ifft`, `convolve`, `fir-filter`, `iir-filter`, `butterworth-lowpass`, `hamming-window`, `hann-window`
 
 **Consciousness Engine:** `unify`, `walk`, `make-substitution`, `make-fact`, `make-kb`, `kb-assert!`, `kb-query`, `make-factor-graph`, `fg-add-factor!`, `fg-infer!`, `fg-update-cpt!`, `free-energy`, `expected-free-energy`, `make-workspace`, `ws-register!`, `ws-step!`
 
-**Web Platform:** `web-create-element`, `web-set-text`, `web-add-event-listener`, `web-canvas-*`
+**Web Platform:** `web-create-element`, `web-set-text-content`, `web-add-event-listener`, `web-canvas-*`
 
 ---
 
@@ -816,8 +816,8 @@ Eshkol v1.1 includes a built-in signal processing library for spectral analysis,
 ```scheme
 ;; Apply window functions before FFT to reduce spectral leakage
 (define n 1024)
-(define hamming-win (window-hamming n))
-(define hann-win (window-hann n))
+(define hamming-win (hamming-window n))
+(define hann-win (hann-window n))
 
 (define windowed-signal (tensor-mul signal hamming-win))
 (define spectrum (fft windowed-signal))
@@ -869,13 +869,13 @@ eshkol-run program.esk --wasm -o program.wasm
 ```scheme
 ;; Create and manipulate DOM elements
 (define heading (web-create-element "h1"))
-(web-set-text heading "Hello from Eshkol!")
+(web-set-text-content heading "Hello from Eshkol!")
 
 (define button (web-create-element "button"))
-(web-set-text button "Click me")
+(web-set-text-content button "Click me")
 (web-add-event-listener button "click"
   (lambda (event)
-    (web-set-text heading "Clicked!")))
+    (web-set-text-content heading "Clicked!")))
 ```
 
 ### Canvas API

--- a/docs/ESHKOL_QUICK_REFERENCE.md
+++ b/docs/ESHKOL_QUICK_REFERENCE.md
@@ -407,8 +407,8 @@ for the full walkthrough.
 (ifft spectrum)                ;; Inverse FFT
 
 ;; Window functions
-(window-hamming n)             ;; Hamming window of size n
-(window-hann n)                ;; Hann window of size n
+(hamming-window n)             ;; Hamming window of size n
+(hann-window n)                ;; Hann window of size n
 
 ;; Convolution
 (convolve signal kernel)       ;; linear convolution
@@ -430,15 +430,18 @@ for the full walkthrough.
 
 ;; DOM manipulation
 (web-create-element tag)           ;; create element
-(web-set-text elem text)           ;; set text content
+(web-set-text-content elem text)   ;; set text content
 (web-add-event-listener elem event handler)  ;; attach handler
 
 ;; Canvas API
-(web-canvas-create w h)            ;; create canvas
-(web-canvas-clear canvas)          ;; clear canvas
-(web-canvas-fill-rect canvas x y w h color)
-(web-canvas-stroke-circle canvas cx cy r color)
-(web-canvas-draw-text canvas text x y color)
+(define ctx (web-get-context-2d canvas))    ;; get 2D drawing context
+(web-canvas-clear-rect ctx x y w h)          ;; clear a rect
+(web-canvas-fill-style ctx color)
+(web-canvas-fill-rect ctx x y w h)
+(web-canvas-begin-path ctx)
+(web-canvas-arc ctx cx cy r 0 6.283185)       ;; circle via full-turn arc
+(web-canvas-stroke ctx)
+(web-canvas-fill-text ctx text x y)           ;; draw text
 (web-request-animation-frame callback)
 ```
 

--- a/docs/ESHKOL_V1_ARCHITECTURE.md
+++ b/docs/ESHKOL_V1_ARCHITECTURE.md
@@ -50,7 +50,7 @@ Eshkol is a production-grade compiler implementing a Scheme-like language with:
 | Bytecode VM | 64 core opcodes, 550+ native calls, ~41,000 lines |
 | Main codegen | 33,962 lines ([`lib/backend/llvm_codegen.cpp`](../lib/backend/llvm_codegen.cpp)) |
 | Parser | 8,368 lines ([`lib/frontend/parser.cpp`](../lib/frontend/parser.cpp)) |
-| Memory manager | 6,186 lines ([`lib/core/arena_memory.cpp`](../lib/core/arena_memory.cpp)) |
+| Memory manager | 6,186 lines ([`lib/core/arena_memory.cpp`](../lib/core/arena_memory.h)) |
 | Weight matrix transformer | ~6,800 lines, 126/126 inline + 123/123 traced, 3-way verified |
 | Test suite | 528 self-reported tests across 37 suites (0 failures) |
 
@@ -107,7 +107,7 @@ Eshkol is a production-grade compiler implementing a Scheme-like language with:
 
 ## Memory Architecture (OALR)
 
-**Implementation**: [`lib/core/arena_memory.cpp`](../lib/core/arena_memory.cpp) (6,186 lines)
+**Implementation**: [`lib/core/arena_memory.cpp`](../lib/core/arena_memory.h) (6,186 lines)
 
 ### Core Principles
 
@@ -1159,7 +1159,7 @@ Where n = number of operations.
 
 ## Build System
 
-**Implementation**: [`CMakeLists.txt`](../CMakeLists.txt:1) (281 lines)
+**Implementation**: [`CMakeLists.txt`](../CMakeLists.txt) (281 lines)
 
 ### Requirements
 
@@ -1263,7 +1263,7 @@ Each test verifies:
 These features are **designed but not implemented**. See roadmap documents for details:
 
 - **Native Quantum Types**: Qubit, qreg, quantum gates (design in `QUANTUM_STOCHASTIC_COMPUTING_ARCHITECTURE.md`)
-  - **What IS implemented**: Quantum RNG ([`lib/quantum/quantum_rng.c`](../lib/quantum/quantum_rng.c:1))
+  - **What IS implemented**: Quantum RNG ([`lib/quantum/quantum_rng.c`](../lib/quantum/quantum_rng.c))
 
 - **Multimedia**: Windows, graphics, audio, GPIO (design in `MULTIMEDIA_SYSTEM_ARCHITECTURE.md`)
 
@@ -1273,7 +1273,7 @@ These features are **designed but not implemented**. See roadmap documents for d
 
 **Note**: Logic programming, previously listed as unimplemented, shipped in v1.1 as part of the Consciousness Engine (see [v1.1 Architecture Extensions](#v11-architecture-extensions)).
 
-**See**: [`ROADMAP.md`](ROADMAP.md) for future releases.
+**See**: [`ROADMAP.md`](../ROADMAP.md) for future releases.
 
 ---
 
@@ -1283,7 +1283,7 @@ These features are **designed but not implemented**. See roadmap documents for d
 
 - [`inc/eshkol/eshkol.h`](../inc/eshkol/eshkol.h) - Main system header (1,912 lines)
 - [`lib/backend/llvm_codegen.cpp`](../lib/backend/llvm_codegen.cpp) - Core codegen (33,999 lines)
-- [`lib/core/arena_memory.cpp`](../lib/core/arena_memory.cpp) - Memory manager (6,186 lines)
+- [`lib/core/arena_memory.cpp`](../lib/core/arena_memory.h) - Memory manager (6,186 lines)
 - [`lib/frontend/parser.cpp`](../lib/frontend/parser.cpp) - S-expr parser (8,368 lines)
 - [`lib/types/type_checker.cpp`](../lib/types/type_checker.cpp) - Type inference (2,048 lines)
 - [`lib/repl/repl_jit.cpp`](../lib/repl/repl_jit.cpp) - JIT compiler (3,382 lines)
@@ -1341,14 +1341,14 @@ Eshkol v1.1 provides an optional XLA compilation path for tensor-heavy workloads
 Two GPU backends provide hardware-accelerated tensor operations:
 
 **Metal (Apple Silicon)**:
-- [`gpu_memory.mm`](../lib/backend/gpu/gpu_memory.mm:1): Objective-C++ Metal API integration
+- [`gpu_memory.mm`](../lib/backend/gpu/gpu_memory.mm): Objective-C++ Metal API integration
 - Software float64 (SF64) emulation — Metal lacks native float64 support
 - [`metal_softfloat.h`](../lib/backend/gpu/metal_softfloat.h): IEEE 754 double-precision arithmetic in Metal shading language
 - Shader source embedded at build time; no runtime file I/O
 
 **CUDA**:
 - [`gpu_memory_cuda.cpp`](../lib/backend/gpu/gpu_memory_cuda.cpp): CUDA API integration
-- [`gpu_cuda_kernels.cu`](../lib/backend/gpu/gpu_cuda_kernels.cu:1): Native float64 kernels, cuBLAS for matrix operations
+- [`gpu_cuda_kernels.cu`](../lib/backend/gpu/gpu_cuda_kernels.cu): Native float64 kernels, cuBLAS for matrix operations
 - [`gpu_memory_stub.cpp`](../lib/backend/gpu/gpu_memory_stub.cpp): No-op stub for builds without GPU support
 
 **Cost-Model Dispatch**:

--- a/docs/FEATURE_MATRIX.md
+++ b/docs/FEATURE_MATRIX.md
@@ -450,8 +450,8 @@ This matrix lists every implemented and planned feature in the Eshkol ecosystem.
 | Tool | Status | Purpose | Notes |
 |------|--------|---------|-------|
 | **Compiler Tools** |
-| `eshkol-compile` | Yes | Ahead-of-time compiler | Produces executables |
-| `eshkol-run` | Yes | Script runner | Compile + execute |
+| `eshkol-run` (AOT mode, `eshkol-run in.esk -o out`) | Yes | Ahead-of-time compiler | Produces executables |
+| `eshkol-run` (JIT mode, `eshkol-run -r`) | Yes | Script runner | Compile + execute |
 | `eshkol-repl` | Yes | Interactive shell | JIT-based with stdlib |
 | `eshkol-pkg` | Yes | Package manager | Registry support |
 | `eshkol-lsp` | Yes | Language server | IDE integration |

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1234,7 +1234,7 @@ eshkol-run --wasm app.esk -o app.wasm
 ## Next Steps
 
 - **[API Reference](API_REFERENCE.md)** — Complete function documentation (555+ builtins)
-- **[Examples](../../examples/)** — Runnable programs demonstrating AD, tensors, parallelism, consciousness engine
+- **[Examples](../examples/)** — Runnable programs demonstrating AD, tensors, parallelism, consciousness engine
 - **[Consciousness Engine](breakdown/CONSCIOUSNESS_ENGINE.md)** — Logic programming, factor graphs, global workspace
 - **[Automatic Differentiation](breakdown/AUTODIFF.md)** — Forward/reverse mode, vector calculus operators
 - **[Machine Learning](breakdown/MACHINE_LEARNING.md)** — Neural network training, optimizers, activations

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ pages and lets them fan out to their siblings.
 - [Scheme Compatibility](breakdown/SCHEME_COMPATIBILITY.md) — R7RS compliance and migration guide
 - [Function Composition](breakdown/FUNCTION_COMPOSITION.md) — closures, lambda registry, mutable captures
 - [Long-Running Loops](LONG_RUNNING_LOOPS.md) — tail-call and loop behaviour for long-lived processes
+- [Binary Lambda Calculus in Eshkol](guide/BINARY_LAMBDA_CALCULUS.md) — the `core.blc` module: De Bruijn-indexed lambda terms as bit strings, encode/decode/reduce
 
 ## Automatic Differentiation
 
@@ -156,6 +157,23 @@ pages and lets them fan out to their siblings.
 - [Compilation Guide (breakdown)](breakdown/COMPILATION_GUIDE.md) — LLVM compilation, debugging, troubleshooting
 - [Hardening Status](HARDENING.md) — per-module hardening audit and mitigation record
 - [Self-Differentiating Neural Computer (SDNC)](SDNC.md) — v1.2 paper artefact
+- [Generated API Reference](api/README.md) — Doxygen-comment-derived per-header symbol pages (`scripts/gen_api_docs.py`), fans out via [INDEX.md](api/INDEX.md)
+- [AD Staged Kernel Handoff](design/AD_STAGED_KERNEL_HANDOFF.md) — compiler work needed for staged dense-tensor training kernels
+
+Architecture Decision Records (`docs/design/adr/`) — design proposals and decisions, not all yet implemented (see each doc's own `Status:` line):
+
+- [ADR 0000 — Unified architectural trajectory](design/adr/0000-unified-trajectory.md)
+- [ADR 0001 — Concurrent, resident-grade OALR](design/adr/0001-oalr-concurrent-resident.md)
+- [ADR 0002 — Staged dense-tensor reverse-mode AD and `value_and_grad`](design/adr/0002-ad-alt-architect.md)
+- [ADR 0002 — Dense tensor AD nodes and a staged value-and-grad kernel](design/adr/0002-ad-staged-dense-kernels.md)
+- [VM/LLVM parity conformance matrix + modularization notes](design/adr/0003-codegen-vm-parity.md)
+- [ADR 0004 — One quantitative dependent type system for Eshkol](design/adr/0004-type-system-trajectory.md)
+- [ADR 0005 — Lambda foundations to resident programs-as-weights](design/adr/0005-lambda-foundations-programs-to-weights.md)
+- [ADR 0006 — Binding-resolved libraries and proper tail invocation](design/adr/0006-language-conformance-modules.md)
+- [ADR 0007 — PGO, whole-program optimization, and staged training throughput](design/adr/0007-performance-pgo-wpo.md)
+- [ADR 0008 — One semantic tooling core for Eshkol developer experience](design/adr/0008-dev-experience-tooling.md)
+- [ADR 0009 — Native DBSP-style incremental dataflow](design/adr/0009-incremental-dataflow-dbsp.md) — see also [reference/stdlib/dbsp.md](reference/stdlib/dbsp.md) for the implemented subset
+- [ADR 0010 — Closed-loop assurance architecture](design/adr/0010-closed-loop-assurance.md)
 
 ## Testing and Quality Gates
 
@@ -178,6 +196,7 @@ Engineering reports (`docs/reports/`) — see the [reports directory index](repo
 
 - [SICP-Completeness Report](reports/SICP_COMPLETENESS_REPORT.md) — release gate: 100% of the SICP book, executable
 - [Reference-Implementation Differential Report](reports/REFERENCE_DIFFERENTIAL_REPORT.md) — external R7RS ground-truth conformance oracle (P7a)
+- [Generative Multi-Oracle Differential Report](reports/GENERATIVE_DIFFERENTIAL_REPORT.md) — generated closed R7RS-small program family cross-checked against every installed reference implementation (P7c)
 - [Sanitizer Fuzz Report](reports/SANITIZER_FUZZ_REPORT.md)
 - [Metamorphic Report](reports/METAMORPHIC_REPORT.md) — P7c property-style harness results
 - [Sweep Gate Report](reports/SWEEP_GATE_REPORT.md) — full gate matrix re-verification

--- a/docs/STDLIB_V1_2_API.md
+++ b/docs/STDLIB_V1_2_API.md
@@ -1468,7 +1468,7 @@ real code.
 
 **Source**: [`lib/core/data/base64.esk`](../lib/core/data/base64.esk) (the
 standard base64 primitives, pure Eshkol) plus the base64url variants from
-[`lib/core/url.esk`](../lib/core/url.esk:185-214) built on top.
+[`lib/core/url.esk`](../lib/core/url.esk) built on top.
 **Auto-loaded**: yes, via `(require stdlib)` (which pulls in both
 `core.data.base64` and `core.url`).
 **Direct import**: `(require core.data.base64)` and/or `(require core.url)`.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -47,6 +47,10 @@ This directory indexes Eshkol's architecture documentation.
 - Native freestanding and VM freestanding architecture
 - BSP contracts and downstream kernel handoff
 
+### TensorCore Integration
+
+**[TensorCore compiler-adapter ownership](tensorcore-adapter.md)** - ownership boundary between Eshkol and the TensorCore integration: AST/IR lowering, LLVM declarations, calling conventions, and packaging live in Eshkol; public C ABI, status/dtype/backend values, buffers, kernels, transports, and device discovery live in TensorCore.
+
 ## See Also
 
 - [API Reference](../API_REFERENCE.md) - Complete function reference

--- a/docs/breakdown/AUTODIFF.md
+++ b/docs/breakdown/AUTODIFF.md
@@ -53,7 +53,7 @@ All three modes compute **exact derivatives** (not numerical approximations) by 
 
 ## Symbolic Differentiation
 
-**Implementation:** [`lib/backend/autodiff_codegen.cpp`](lib/backend/autodiff_codegen.cpp)
+**Implementation:** [`lib/backend/autodiff_codegen.cpp`](../../lib/backend/autodiff_codegen.cpp)
 
 Symbolic differentiation transforms ASTs at **compile-time** using 12 differentiation rules:
 
@@ -94,7 +94,7 @@ Symbolic differentiation transforms ASTs at **compile-time** using 12 differenti
 
 ## Forward-Mode AD (Dual Numbers)
 
-**Implementation:** [`lib/backend/autodiff_codegen.cpp`](lib/backend/autodiff_codegen.cpp)
+**Implementation:** [`lib/backend/autodiff_codegen.cpp`](../../lib/backend/autodiff_codegen.cpp)
 
 Forward-mode AD uses **dual numbers** to compute derivatives in a single forward pass. Each dual number stores both the function value and its derivative:
 
@@ -107,7 +107,7 @@ typedef struct eshkol_dual_number {
 } eshkol_dual_number_t;  // 16 bytes
 ```
 
-**Tagged value type:** [`ESHKOL_VALUE_DUAL_NUMBER`](inc/eshkol/eshkol.h) (type = 6)
+**Tagged value type:** [`ESHKOL_VALUE_DUAL_NUMBER`](../../inc/eshkol/eshkol.h) (type = 6)
 
 ### Dual Number Arithmetic
 
@@ -144,7 +144,7 @@ dual_div(a, b) = {a.value / b.value, (a.deriv * b.value - a.value * b.deriv) / (
 
 ## Reverse-Mode AD (Computational Graph)
 
-**Implementation:** [`lib/backend/autodiff_codegen.cpp`](lib/backend/autodiff_codegen.cpp)
+**Implementation:** [`lib/backend/autodiff_codegen.cpp`](../../lib/backend/autodiff_codegen.cpp)
 
 Reverse-mode AD builds a **computational graph** during the forward pass, then propagates gradients backward from outputs to inputs. This is the foundation of neural network training.
 
@@ -216,7 +216,7 @@ typedef struct ad_tape {
 } ad_tape_t;
 ```
 
-**Nested gradient support:** 32-level tape stack for computing higher-order derivatives (implementation: [`lib/backend/autodiff_codegen.cpp`](lib/backend/autodiff_codegen.cpp))
+**Nested gradient support:** 32-level tape stack for computing higher-order derivatives (implementation: [`lib/backend/autodiff_codegen.cpp`](../../lib/backend/autodiff_codegen.cpp))
 
 ### Example: Reverse-Mode AD
 
@@ -328,10 +328,10 @@ Exact nested higher-order differentiation is done by nesting the **scalar**
 
 | Component | File | Lines | Purpose |
 |-----------|------|-------|---------|
-| **AD Codegen** | [`lib/backend/autodiff_codegen.cpp`](lib/backend/autodiff_codegen.cpp) | 9,205 | All 3 AD modes, vector calculus |
-| **AD Runtime** | [`inc/eshkol/eshkol.h:565-603`](inc/eshkol/eshkol.h) | 38 | AD node structures, tape definition |
-| **Dual Numbers** | [`inc/eshkol/eshkol.h:135-144`](inc/eshkol/eshkol.h) | 10 | Forward-mode dual number struct |
-| **Type System** | [`lib/backend/type_system.cpp`](lib/backend/type_system.cpp) | 287 | AD type generation (dual_t, ad_node_t) |
+| **AD Codegen** | [`lib/backend/autodiff_codegen.cpp`](../../lib/backend/autodiff_codegen.cpp) | 9,205 | All 3 AD modes, vector calculus |
+| **AD Runtime** | [`inc/eshkol/eshkol.h:565-603`](../../inc/eshkol/eshkol.h) | 38 | AD node structures, tape definition |
+| **Dual Numbers** | [`inc/eshkol/eshkol.h:135-144`](../../inc/eshkol/eshkol.h) | 10 | Forward-mode dual number struct |
+| **Type System** | [`lib/backend/type_system.cpp`](../../lib/backend/type_system.cpp) | 287 | AD type generation (dual_t, ad_node_t) |
 
 ### AD Mode Detection
 
@@ -512,13 +512,13 @@ Where n = number of operations in the function.
 ;; Returns: #(6.0)
 ```
 
-**Implementation:** Closures check argument types at runtime and dispatch to the appropriate code path ([`lib/backend/function_codegen.cpp`](lib/backend/function_codegen.cpp)).
+**Implementation:** Closures check argument types at runtime and dispatch to the appropriate code path ([`lib/backend/function_codegen.cpp`](../../lib/backend/function_codegen.cpp)).
 
 ---
 
 ## Integration with Tensors
 
-Autodiff works seamlessly with tensor operations. The [`vref`](lib/backend/tensor_codegen.cpp) operation creates AD nodes when in AD mode:
+Autodiff works seamlessly with tensor operations. The [`vref`](../../lib/backend/tensor_codegen.cpp) operation creates AD nodes when in AD mode:
 
 ```scheme
 ;; Gradient of tensor sum

--- a/docs/breakdown/COMPILER_ARCHITECTURE.md
+++ b/docs/breakdown/COMPILER_ARCHITECTURE.md
@@ -84,7 +84,7 @@ The compiler executes a 5-phase pipeline. Source files (`.esk`) enter at Phase 1
 
 ### Macro System
 
-**Implementation:** [`lib/frontend/macro_expander.cpp`](lib/frontend/macro_expander.cpp) (861 lines)
+**Implementation:** [`lib/frontend/macro_expander.cpp`](../../lib/frontend/macro_expander.cpp) (861 lines)
 
 Hygienic macro expansion runs before parsing. The system supports:
 
@@ -109,7 +109,7 @@ Several R7RS derived forms (`case-lambda`, `parameterize`, `cond-expand`, `defin
 
 ### S-Expression Parser
 
-**Implementation:** [`lib/frontend/parser.cpp`](lib/frontend/parser.cpp) (8,368 lines)
+**Implementation:** [`lib/frontend/parser.cpp`](../../lib/frontend/parser.cpp) (8,368 lines)
 
 The parser is a recursive descent processor that builds an AST from S-expressions:
 
@@ -141,7 +141,7 @@ typedef struct eshkol_ast {
 ```
 
 **Key responsibilities:**
-- 94 operation types (see `eshkol_op_t` enum in [`inc/eshkol/eshkol.h`](inc/eshkol/eshkol.h))
+- 94 operation types (see `eshkol_op_t` enum in [`inc/eshkol/eshkol.h`](../../inc/eshkol/eshkol.h))
 - Internal define to `letrec*` transformation (all define names, wherever they appear in the body; a value define's initializer stays at its source position)
 - `delay`/`delay-force` desugaring to promise constructors
 - `define-record-type` to vector operation transformation
@@ -155,7 +155,7 @@ typedef struct eshkol_ast {
 
 ## Type Checking (HoTT System)
 
-**Implementation:** [`lib/types/type_checker.cpp`](lib/types/type_checker.cpp) (2,048 lines)
+**Implementation:** [`lib/types/type_checker.cpp`](../../lib/types/type_checker.cpp) (2,048 lines)
 
 Eshkol uses a Homotopy Type Theory-inspired type system with a universe hierarchy:
 
@@ -207,7 +207,7 @@ typedef struct hott_type_expr {
 
 ## LLVM Backend
 
-**Implementation:** [`lib/backend/llvm_codegen.cpp`](lib/backend/llvm_codegen.cpp) (33,999 lines)
+**Implementation:** [`lib/backend/llvm_codegen.cpp`](../../lib/backend/llvm_codegen.cpp) (33,999 lines)
 
 The LLVM backend is the heart of the compiler. It translates ASTs to LLVM IR and orchestrates 21 specialized codegen modules.
 
@@ -366,27 +366,27 @@ The LLVM backend distributes code generation across 21 specialized modules total
 
 | Module | Source File | Lines | Responsibility |
 |:---|:---|---:|:---|
-| **Main Codegen** | [`llvm_codegen.cpp`](lib/backend/llvm_codegen.cpp) | 33,962 | Orchestrator, AST dispatch, builtins, consciousness engine |
-| **Autodiff** | [`autodiff_codegen.cpp`](lib/backend/autodiff_codegen.cpp) | 9,205 | Forward/reverse/symbolic AD modes |
-| **String/IO** | [`string_io_codegen.cpp`](lib/backend/string_io_codegen.cpp) | 3,293 | String ops, display/write, file I/O, JSON, CSV |
-| **Parallel LLVM** | [`parallel_llvm_codegen.cpp`](lib/backend/parallel_llvm_codegen.cpp) | 2,601 | Work-stealing parallelism LLVM IR generation |
-| **Arithmetic** | [`arithmetic_codegen.cpp`](lib/backend/arithmetic_codegen.cpp) | 2,491 | +, -, *, /, bignum, rational, complex dispatch |
-| **Collections** | [`collection_codegen.cpp`](lib/backend/collection_codegen.cpp) | 2,348 | Vector, list, cons, bytevector operations |
-| **System** | [`system_codegen.cpp`](lib/backend/system_codegen.cpp) | 1,752 | System, environment, time, process, eval support |
-| **Tensor (dispatch)** | [`tensor_codegen.cpp`](lib/backend/tensor_codegen.cpp) | 1,540 | Entry/dispatch shell; per-domain ops live in `tensor_*_codegen.cpp` siblings |
-| **Thread Pool** | [`thread_pool.cpp`](lib/backend/thread_pool.cpp) | 1,350 | Work-stealing thread pool runtime |
-| **Tensor Backward** | [`tensor_backward.cpp`](lib/backend/tensor_backward.cpp) | 1,321 | Backward-mode AD gradient computation for tensors |
-| **BLAS Backend** | [`blas_backend.cpp`](lib/backend/blas_backend.cpp) | 1,253 | BLAS dispatch, GPU cost model calibration |
-| **Bindings** | [`binding_codegen.cpp`](lib/backend/binding_codegen.cpp) | 1,242 | let/let*/letrec/letrec* with TCO context save/restore |
-| **Call/Apply** | [`call_apply_codegen.cpp`](lib/backend/call_apply_codegen.cpp) | 1,025 | Function calls, apply, partial application, variadic |
-| **Parallel** | [`parallel_codegen.cpp`](lib/backend/parallel_codegen.cpp) | 945 | parallel-map/fold/filter/for-each runtime |
-| **Map** | [`map_codegen.cpp`](lib/backend/map_codegen.cpp) | 879 | map/for-each/fold with closure dispatch |
-| **Control Flow** | [`control_flow_codegen.cpp`](lib/backend/control_flow_codegen.cpp) | 874 | if/cond/case/match/when/unless/call-cc/guard |
-| **Tagged Values** | [`tagged_value_codegen.cpp`](lib/backend/tagged_value_codegen.cpp) | 717 | Pack/unpack tagged values, type extraction |
-| **Hash** | [`hash_codegen.cpp`](lib/backend/hash_codegen.cpp) | 603 | make-hash, hash-ref, hash-set!, hash-for-each |
-| **Homoiconic** | [`homoiconic_codegen.cpp`](lib/backend/homoiconic_codegen.cpp) | 601 | Code-as-data, quote, lambda S-expressions, eval |
-| **Tail Calls** | [`tail_call_codegen.cpp`](lib/backend/tail_call_codegen.cpp) | 503 | TCO transformation, trampoline runtime |
-| **Complex** | [`complex_codegen.cpp`](lib/backend/complex_codegen.cpp) | 499 | Complex number arithmetic (Smith's formula division) |
+| **Main Codegen** | [`llvm_codegen.cpp`](../../lib/backend/llvm_codegen.cpp) | 33,962 | Orchestrator, AST dispatch, builtins, consciousness engine |
+| **Autodiff** | [`autodiff_codegen.cpp`](../../lib/backend/autodiff_codegen.cpp) | 9,205 | Forward/reverse/symbolic AD modes |
+| **String/IO** | [`string_io_codegen.cpp`](../../lib/backend/string_io_codegen.cpp) | 3,293 | String ops, display/write, file I/O, JSON, CSV |
+| **Parallel LLVM** | [`parallel_llvm_codegen.cpp`](../../lib/backend/parallel_llvm_codegen.cpp) | 2,601 | Work-stealing parallelism LLVM IR generation |
+| **Arithmetic** | [`arithmetic_codegen.cpp`](../../lib/backend/arithmetic_codegen.cpp) | 2,491 | +, -, *, /, bignum, rational, complex dispatch |
+| **Collections** | [`collection_codegen.cpp`](../../lib/backend/collection_codegen.cpp) | 2,348 | Vector, list, cons, bytevector operations |
+| **System** | [`system_codegen.cpp`](../../lib/backend/system_codegen.cpp) | 1,752 | System, environment, time, process, eval support |
+| **Tensor (dispatch)** | [`tensor_codegen.cpp`](../../lib/backend/tensor_codegen.cpp) | 1,540 | Entry/dispatch shell; per-domain ops live in `tensor_*_codegen.cpp` siblings |
+| **Thread Pool** | [`thread_pool.cpp`](../../lib/backend/thread_pool.cpp) | 1,350 | Work-stealing thread pool runtime |
+| **Tensor Backward** | [`tensor_backward.cpp`](../../lib/backend/tensor_backward.cpp) | 1,321 | Backward-mode AD gradient computation for tensors |
+| **BLAS Backend** | [`blas_backend.cpp`](../../lib/backend/blas_backend.cpp) | 1,253 | BLAS dispatch, GPU cost model calibration |
+| **Bindings** | [`binding_codegen.cpp`](../../lib/backend/binding_codegen.cpp) | 1,242 | let/let*/letrec/letrec* with TCO context save/restore |
+| **Call/Apply** | [`call_apply_codegen.cpp`](../../lib/backend/call_apply_codegen.cpp) | 1,025 | Function calls, apply, partial application, variadic |
+| **Parallel** | [`parallel_codegen.cpp`](../../lib/backend/parallel_codegen.cpp) | 945 | parallel-map/fold/filter/for-each runtime |
+| **Map** | [`map_codegen.cpp`](../../lib/backend/map_codegen.cpp) | 879 | map/for-each/fold with closure dispatch |
+| **Control Flow** | [`control_flow_codegen.cpp`](../../lib/backend/control_flow_codegen.cpp) | 874 | if/cond/case/match/when/unless/call-cc/guard |
+| **Tagged Values** | [`tagged_value_codegen.cpp`](../../lib/backend/tagged_value_codegen.cpp) | 717 | Pack/unpack tagged values, type extraction |
+| **Hash** | [`hash_codegen.cpp`](../../lib/backend/hash_codegen.cpp) | 603 | make-hash, hash-ref, hash-set!, hash-for-each |
+| **Homoiconic** | [`homoiconic_codegen.cpp`](../../lib/backend/homoiconic_codegen.cpp) | 601 | Code-as-data, quote, lambda S-expressions, eval |
+| **Tail Calls** | [`tail_call_codegen.cpp`](../../lib/backend/tail_call_codegen.cpp) | 503 | TCO transformation, trampoline runtime |
+| **Complex** | [`complex_codegen.cpp`](../../lib/backend/complex_codegen.cpp) | 499 | Complex number arithmetic (Smith's formula division) |
 
 The original `tensor_codegen.cpp` was decomposed in v1.2 into thirteen per-domain modules (`tensor_activation_codegen.cpp`, `tensor_arith_codegen.cpp`, `tensor_conv_codegen.cpp`, `tensor_creation_codegen.cpp`, `tensor_dataloader_codegen.cpp`, `tensor_extras_codegen.cpp`, `tensor_linalg_codegen.cpp`, `tensor_loss_codegen.cpp`, `tensor_reduce_codegen.cpp`, `tensor_shape_codegen.cpp`, `tensor_training_codegen.cpp`, `tensor_transformer_codegen.cpp`, `tensorcore_codegen.cpp`), totalling approximately 20,500 lines re-exported through the dispatcher above.
 
@@ -394,12 +394,12 @@ The original `tensor_codegen.cpp` was decomposed in v1.2 into thirteen per-domai
 
 | Component | Source Files | Lines | Purpose |
 |:---|:---|---:|:---|
-| Type System | [`type_system.cpp`](lib/backend/type_system.cpp) | ~300 | LLVM type creation and caching |
-| Codegen Context | [`codegen_context.cpp`](lib/backend/codegen_context.cpp) | ~200 | Shared state for module communication |
-| Function Cache | [`function_cache.cpp`](lib/backend/function_cache.cpp) | ~250 | Lazy-loaded C library function declarations |
-| Builtin Declarations | [`builtin_declarations.cpp`](lib/backend/builtin_declarations.cpp) | ~350 | Runtime function declarations (deep_equal, display, registry) |
-| Memory Codegen | [`memory_codegen.cpp`](lib/backend/memory_codegen.cpp) | ~300 | Arena allocation IR generation |
-| CPU Features | [`cpu_features.cpp`](lib/backend/cpu_features.cpp) | ~100 | SIMD capability detection |
+| Type System | [`type_system.cpp`](../../lib/backend/type_system.cpp) | ~300 | LLVM type creation and caching |
+| Codegen Context | [`codegen_context.cpp`](../../lib/backend/codegen_context.cpp) | ~200 | Shared state for module communication |
+| Function Cache | [`function_cache.cpp`](../../lib/backend/function_cache.cpp) | ~250 | Lazy-loaded C library function declarations |
+| Builtin Declarations | [`builtin_declarations.cpp`](../../lib/backend/builtin_declarations.cpp) | ~350 | Runtime function declarations (deep_equal, display, registry) |
+| Memory Codegen | [`memory_codegen.cpp`](../../lib/backend/memory_codegen.cpp) | ~300 | Arena allocation IR generation |
+| CPU Features | [`cpu_features.cpp`](../../lib/backend/cpu_features.cpp) | ~100 | SIMD capability detection |
 | XLA/StableHLO | 5 files in `lib/backend/xla/` | 4,003 | Tensor compilation via MLIR pipeline |
 | GPU/Metal | `lib/backend/gpu/gpu_memory.mm`, `metal_softfloat.h` | 8,888 | Metal compute, SF64 software float64, CUDA stubs |
 
@@ -424,7 +424,7 @@ ArithmeticCodegen depends on TensorCodegen, AutodiffCodegen, and ComplexCodegen 
 
 ### GPU Dispatch (SIMD -> cBLAS -> Metal)
 
-**Implementation:** [`blas_backend.cpp`](lib/backend/blas_backend.cpp) (890 lines), [`gpu_memory.mm`](lib/backend/gpu/gpu_memory.mm) (3,786 lines)
+**Implementation:** [`blas_backend.cpp`](../../lib/backend/blas_backend.cpp) (890 lines), [`gpu_memory.mm`](../../lib/backend/gpu/gpu_memory.mm) (3,786 lines)
 
 The cost model selects the optimal compute backend based on tensor dimensions:
 
@@ -434,7 +434,7 @@ The cost model selects the optimal compute backend based on tensor dimensions:
 | cBLAS (Apple Accelerate AMX) | 1,100 GFLOPS | 5 us | 17 to ~1B elements |
 | Metal GPU (SF64 software float64) | 200 GFLOPS | 200 us | >1B elements (GPU genuinely faster) |
 
-**SF64 (Software Float64):** Metal GPUs lack native float64. SF64 emulates double precision using double-double arithmetic (two 32-bit mantissas for ~100-bit effective precision). Implemented in [`metal_softfloat.h`](lib/backend/gpu/metal_softfloat.h) (4,076 lines).
+**SF64 (Software Float64):** Metal GPUs lack native float64. SF64 emulates double precision using double-double arithmetic (two 32-bit mantissas for ~100-bit effective precision). Implemented in [`metal_softfloat.h`](../../lib/backend/gpu/metal_softfloat.h) (4,076 lines).
 
 **Cost model calibration:** Measured values are `blas_peak_gflops=1100` (Apple AMX) and `gpu_peak_gflops=200` (SF64). Configurable via environment variables `ESHKOL_BLAS_PEAK_GFLOPS` and `ESHKOL_GPU_PEAK_GFLOPS`.
 
@@ -442,7 +442,7 @@ The Metal shader source is embedded at build time via a CMake custom command tha
 
 ### Parallel Primitives
 
-**Implementation:** [`parallel_codegen.cpp`](lib/backend/parallel_codegen.cpp) (705 lines), [`parallel_llvm_codegen.cpp`](lib/backend/parallel_llvm_codegen.cpp) (2,401 lines), [`thread_pool.cpp`](lib/backend/thread_pool.cpp) (1,131 lines)
+**Implementation:** [`parallel_codegen.cpp`](../../lib/backend/parallel_codegen.cpp) (705 lines), [`parallel_llvm_codegen.cpp`](../../lib/backend/parallel_llvm_codegen.cpp) (2,401 lines), [`thread_pool.cpp`](../../lib/backend/thread_pool.cpp) (1,131 lines)
 
 Four parallel higher-order functions with work-stealing scheduling:
 
@@ -457,9 +457,9 @@ Worker functions use `LinkOnceODRLinkage` to prevent duplicate symbol errors whe
 
 ### Consciousness Engine Codegen
 
-**Runtime:** [`lib/core/logic.cpp`](lib/core/logic.cpp) (805 lines), [`lib/core/inference.cpp`](lib/core/inference.cpp) (912 lines), [`lib/core/workspace.cpp`](lib/core/workspace.cpp) (308 lines)
+**Runtime:** [`lib/core/logic.cpp`](../../lib/core/logic.cpp) (805 lines), [`lib/core/inference.cpp`](../../lib/core/inference.cpp) (912 lines), [`lib/core/workspace.cpp`](../../lib/core/workspace.cpp) (308 lines)
 
-**Codegen:** Dispatched directly from [`llvm_codegen.cpp`](lib/backend/llvm_codegen.cpp) (not a separate module)
+**Codegen:** Dispatched directly from [`llvm_codegen.cpp`](../../lib/backend/llvm_codegen.cpp) (not a separate module)
 
 22 builtins across three theoretical frameworks:
 
@@ -475,7 +475,7 @@ Logic variables use syntax `?x` (parsed as `ESHKOL_LOGIC_VAR_OP`), which is R7RS
 
 ### Exact Arithmetic Dispatch
 
-**Implementation:** [`arithmetic_codegen.cpp`](lib/backend/arithmetic_codegen.cpp) (2,332 lines)
+**Implementation:** [`arithmetic_codegen.cpp`](../../lib/backend/arithmetic_codegen.cpp) (2,332 lines)
 
 The full R7RS numeric tower with automatic precision promotion:
 
@@ -503,7 +503,7 @@ All arithmetic operations (`+`, `-`, `*`, `/`, comparison, `abs`, `min`, `max`, 
 
 ### First-Class Continuations
 
-**Implementation:** [`control_flow_codegen.cpp`](lib/backend/control_flow_codegen.cpp) (800 lines), with `call/cc` and `dynamic-wind` dispatch in [`llvm_codegen.cpp`](lib/backend/llvm_codegen.cpp)
+**Implementation:** [`control_flow_codegen.cpp`](../../lib/backend/control_flow_codegen.cpp) (800 lines), with `call/cc` and `dynamic-wind` dispatch in [`llvm_codegen.cpp`](../../lib/backend/llvm_codegen.cpp)
 
 - `call/cc` -- single-shot continuations via setjmp/longjmp
 - `dynamic-wind` -- before/after thunks with proper unwinding on non-local exit
@@ -515,7 +515,7 @@ Continuations are `HEAP_PTR` objects with `HEAP_SUBTYPE_PROMISE` (for promises) 
 
 ### Machine Learning Framework (75+ Builtins)
 
-**Implementation:** [`tensor_codegen.cpp`](lib/backend/tensor_codegen.cpp) (1,540-line dispatcher; ~19,200 lines across twelve sibling `tensor_*_codegen.cpp` files after the v1.2 split), [`tensor_backward.cpp`](lib/backend/tensor_backward.cpp) (1,321 lines)
+**Implementation:** [`tensor_codegen.cpp`](../../lib/backend/tensor_codegen.cpp) (1,540-line dispatcher; ~19,200 lines across twelve sibling `tensor_*_codegen.cpp` files after the v1.2 split), [`tensor_backward.cpp`](../../lib/backend/tensor_backward.cpp) (1,321 lines)
 
 Categories: activations (16), loss functions (14), optimizers (5+3), weight initializers (5), LR schedulers (4), CNN layers (7), transformer operations (8), data loading (6), plus tensor creation/manipulation ops.
 
@@ -591,7 +591,7 @@ builder->CreateStore(new_counter, counter_ptr);
 
 ## JIT Compilation (REPL)
 
-**Implementation:** [`lib/repl/repl_jit.cpp`](lib/repl/repl_jit.cpp) (~2,062 lines)
+**Implementation:** [`lib/repl/repl_jit.cpp`](../../lib/repl/repl_jit.cpp) (~2,062 lines)
 
 The REPL uses **LLVM's LLJIT** (via OrcJIT v2) for interactive execution.
 
@@ -668,7 +668,7 @@ Combined with `-export_dynamic`, this makes `DynamicLibrarySearchGenerator` auto
 
 ## Build System
 
-**Implementation:** [`CMakeLists.txt`](CMakeLists.txt)
+**Implementation:** [`CMakeLists.txt`](../../CMakeLists.txt)
 
 Eshkol uses CMake (minimum 3.14) with C17/C++20 standards.
 
@@ -772,7 +772,7 @@ option(ESHKOL_ENABLE_UBSAN "Enable UB Sanitizer" OFF)
 
 ### eshkol-run (AOT Compiler + Eval)
 
-**Source:** [`exe/eshkol-run.cpp`](exe/eshkol-run.cpp)
+**Source:** [`exe/eshkol-run.cpp`](../../exe/eshkol-run.cpp)
 
 Ahead-of-time compiler that produces native executables:
 
@@ -802,7 +802,7 @@ The `require` system handles module discovery: `(require stdlib)` links with pre
 
 ### eshkol-repl (JIT REPL)
 
-**Source:** [`exe/eshkol-repl.cpp`](exe/eshkol-repl.cpp)
+**Source:** [`exe/eshkol-repl.cpp`](../../exe/eshkol-repl.cpp)
 
 Interactive Read-Eval-Print Loop with readline support:
 
@@ -817,13 +817,13 @@ eshkol-repl
 
 ### eshkol-lsp (Language Server)
 
-**Source:** [`tools/lsp/eshkol_lsp.cpp`](tools/lsp/eshkol_lsp.cpp) (1,018 lines)
+**Source:** [`tools/lsp/eshkol_lsp.cpp`](../../tools/lsp/eshkol_lsp.cpp) (1,018 lines)
 
 LSP server providing completions, hover, go-to-definition, diagnostics, and formatting for IDE integration (VSCode extension available).
 
 ### eshkol-pkg (Package Manager)
 
-**Source:** [`tools/pkg/eshkol_pkg.cpp`](tools/pkg/eshkol_pkg.cpp) (721 lines)
+**Source:** [`tools/pkg/eshkol_pkg.cpp`](../../tools/pkg/eshkol_pkg.cpp) (721 lines)
 
 Package manager with TOML manifests and git-based registry: `eshkol-pkg init/build/run/add/clean`.
 
@@ -833,7 +833,7 @@ Package manager with TOML manifests and git-based registry: `eshkol-pkg init/bui
 
 ### Global Arena
 
-**Implementation:** [`lib/core/arena_memory.cpp`](lib/core/arena_memory.cpp) (~6,200 lines)
+**Implementation:** [`lib/core/arena_memory.cpp`](../../lib/core/arena_memory.h) (~6,200 lines)
 
 - Single allocator for all heap objects
 - 8KB minimum block size, doubling growth strategy
@@ -888,9 +888,9 @@ A dynamic array of AD nodes allocated during the forward pass, topologically sor
 ### Consciousness Engine Runtime
 
 Three C runtime libraries:
-- **Logic** ([`lib/core/logic.cpp`](lib/core/logic.cpp), 805 lines): Robinson's unification, substitution environments, knowledge base query
-- **Inference** ([`lib/core/inference.cpp`](lib/core/inference.cpp), 912 lines): Factor graph construction, belief propagation, free energy computation
-- **Workspace** ([`lib/core/workspace.cpp`](lib/core/workspace.cpp), 308 lines): Module registration, softmax competitive attention, step execution
+- **Logic** ([`lib/core/logic.cpp`](../../lib/core/logic.cpp), 805 lines): Robinson's unification, substitution environments, knowledge base query
+- **Inference** ([`lib/core/inference.cpp`](../../lib/core/inference.cpp), 912 lines): Factor graph construction, belief propagation, free energy computation
+- **Workspace** ([`lib/core/workspace.cpp`](../../lib/core/workspace.cpp), 308 lines): Module registration, softmax competitive attention, step execution
 
 LLVM codegen dispatches to these runtime functions via tagged value calling conventions, with heap subtypes 12-17 identifying consciousness engine objects.
 

--- a/docs/breakdown/FUNCTION_COMPOSITION.md
+++ b/docs/breakdown/FUNCTION_COMPOSITION.md
@@ -27,7 +27,7 @@ Eshkol provides first-class functions with full closure support, enabling functi
 
 ## Closure Implementation
 
-**Implementation:** [`inc/eshkol/eshkol.h:649-658`](inc/eshkol/eshkol.h)
+**Implementation:** [`inc/eshkol/eshkol.h:649-658`](../../inc/eshkol/eshkol.h)
 
 Closures are **40-byte structures** allocated in the global arena:
 
@@ -73,7 +73,7 @@ The environment packing encodes three values in a single `uint64_t`:
 
 ## Lambda Registry (Homoiconicity)
 
-**Implementation:** [`inc/eshkol/eshkol.h:771-791`](inc/eshkol/eshkol.h)
+**Implementation:** [`inc/eshkol/eshkol.h:771-791`](../../inc/eshkol/eshkol.h)
 
 Eshkol maintains a **lambda registry** mapping function pointers to their S-expression representations:
 

--- a/docs/breakdown/MEMORY_MANAGEMENT.md
+++ b/docs/breakdown/MEMORY_MANAGEMENT.md
@@ -40,7 +40,7 @@ The OALR system provides **five ownership modes** for different memory managemen
 | **Shared** | `(shared value)` | Reference-counted shared ownership | Complex shared data |
 | **Weak** | `(weak-ref value)` | Non-owning reference | Breaking reference cycles |
 
-**Implementation:** [`lib/backend/llvm_codegen.cpp`](lib/backend/llvm_codegen.cpp)
+**Implementation:** [`lib/backend/llvm_codegen.cpp`](../../lib/backend/llvm_codegen.cpp)
 
 ### Example: Linear Types
 
@@ -70,7 +70,7 @@ The OALR system provides **five ownership modes** for different memory managemen
 
 ## Arena Allocation
 
-**Implementation:** [`lib/core/arena_memory.cpp`](lib/core/arena_memory.cpp) (6,186 lines)
+**Implementation:** [`lib/core/arena_memory.cpp`](../../lib/core/arena_memory.h) (6,186 lines)
 
 Eshkol uses a **hybrid arena model**: a global arena (`__global_arena`) for the main thread, plus **per-thread arenas** (1 MB each, lazily allocated via `thread_local` storage) for parallel worker threads. The global arena grows automatically as needed; per-thread arenas provide contention-free allocation during parallel operations.
 
@@ -293,10 +293,10 @@ Linear types ensure resources are **consumed exactly once** at compile-time. Att
 
 | Component | File | Lines | Purpose |
 |-----------|------|-------|---------|
-| **Arena Core** | [`lib/core/arena_memory.cpp`](lib/core/arena_memory.cpp) | 6,186 | Arena allocation, object headers, display |
-| **Arena Header** | [`lib/core/arena_memory.h`](lib/core/arena_memory.h) | 156 | Arena API, memory tracking |
-| **Object Headers** | [`inc/eshkol/eshkol.h:274-547`](inc/eshkol/eshkol.h) | 274 | Header structure, access macros |
-| **Memory Codegen** | [`lib/backend/memory_codegen.cpp`](lib/backend/memory_codegen.cpp) | 734 | OALR operator codegen |
+| **Arena Core** | [`lib/core/arena_memory.cpp`](../../lib/core/arena_memory.h) | 6,186 | Arena allocation, object headers, display |
+| **Arena Header** | [`lib/core/arena_memory.h`](../../lib/core/arena_memory.h) | 156 | Arena API, memory tracking |
+| **Object Headers** | [`inc/eshkol/eshkol.h:274-547`](../../inc/eshkol/eshkol.h) | 274 | Header structure, access macros |
+| **Memory Codegen** | [`lib/backend/memory_codegen.cpp`](../../lib/backend/memory_codegen.cpp) | 734 | OALR operator codegen |
 
 ### Allocation Functions
 

--- a/docs/breakdown/OVERVIEW.md
+++ b/docs/breakdown/OVERVIEW.md
@@ -53,7 +53,7 @@ The `vref` operator is AD-aware: when extracting from tensors during gradient co
 
 The compiler executes a 5-phase pipeline:
 
-**Phase 1: Macro Expansion** (861 lines in [macro_expander.cpp](lib/frontend/macro_expander.cpp))
+**Phase 1: Macro Expansion** (861 lines in [macro_expander.cpp](../../lib/frontend/macro_expander.cpp))
 
 Hygienic macro expansion via `syntax-rules` pattern matching. The system supports ellipsis (`...`) for repetition, nested patterns, and scope-safe renaming. Several R7RS derived forms — `case-lambda`, `parameterize`, `cond-expand`, `define-record-type` — are transformed during this phase or the subsequent parse phase.
 
@@ -64,10 +64,10 @@ Hygienic macro expansion via `syntax-rules` pattern matching. The system support
 ;; Output: (if (> x 0) (begin (display x)) #f)
 ```
 
-**Phase 2: S-Expression Parsing** (8,368 lines in [parser.cpp](lib/frontend/parser.cpp))
+**Phase 2: S-Expression Parsing** (8,368 lines in [parser.cpp](../../lib/frontend/parser.cpp))
 
 Builds an AST from S-expressions. The parser is a recursive descent processor that handles:
-- 94 operation types (see `eshkol_op_t` enum in [eshkol.h](inc/eshkol/eshkol.h))
+- 94 operation types (see `eshkol_op_t` enum in [eshkol.h](../../inc/eshkol/eshkol.h))
 - Variadic parameter encoding in lambda/define
 - HoTT type annotation attachment to AST nodes
 - Internal define → `letrec*` transformation (all define names, wherever they appear in the body; a value define's initializer stays at its source position)
@@ -77,7 +77,7 @@ Builds an AST from S-expressions. The parser is a recursive descent processor th
 
 Each AST node includes a `uint32_t inferred_hott_type` field packed as `[TypeId:16][universe:8][flags:8]`, set by the type checker.
 
-**Phase 3: HoTT Type Checking** (1,999 lines in [type_checker.cpp](lib/types/type_checker.cpp))
+**Phase 3: HoTT Type Checking** (1,999 lines in [type_checker.cpp](../../lib/types/type_checker.cpp))
 
 Hindley-Milner-style inference with universe hierarchy extensions. The algorithm:
 
@@ -88,33 +88,33 @@ Hindley-Milner-style inference with universe hierarchy extensions. The algorithm
 
 Unlike traditional type checkers, Eshkol's is **non-blocking**: type errors don't prevent compilation. This enables rapid prototyping but requires runtime type guards for safety (via tagged values).
 
-**Phase 4: LLVM IR Generation** (33,999 lines in [llvm_codegen.cpp](lib/backend/llvm_codegen.cpp) plus roughly thirty specialised modules; the compiler tree as a whole totals about 233,000 lines)
+**Phase 4: LLVM IR Generation** (33,999 lines in [llvm_codegen.cpp](../../lib/backend/llvm_codegen.cpp) plus roughly thirty specialised modules; the compiler tree as a whole totals about 233,000 lines)
 
 Translates ASTs to LLVM IR. The modular architecture distributes code generation across specialized modules:
 
 | Module | Lines | Responsibility |
 |:---|---:|:---|
-| [llvm_codegen.cpp](lib/backend/llvm_codegen.cpp) | 33,999 | Main codegen, dispatch, builtins |
-| [tensor_codegen.cpp](lib/backend/tensor_codegen.cpp) | 1,540 | Tensor-op dispatch shell; per-domain ops live in twelve `tensor_*_codegen.cpp` siblings (~19,200 lines combined) |
-| [autodiff_codegen.cpp](lib/backend/autodiff_codegen.cpp) | 9,205 | Forward/reverse mode AD |
-| [string_io_codegen.cpp](lib/backend/string_io_codegen.cpp) | 2,975 | String, I/O, JSON, CSV operations |
-| [parallel_llvm_codegen.cpp](lib/backend/parallel_llvm_codegen.cpp) | 2,401 | Work-stealing parallelism codegen |
-| [arithmetic_codegen.cpp](lib/backend/arithmetic_codegen.cpp) | 2,332 | Numeric ops, bignum, rational, complex |
-| [collection_codegen.cpp](lib/backend/collection_codegen.cpp) | 2,139 | Vector, list, hash table operations |
-| [system_codegen.cpp](lib/backend/system_codegen.cpp) | 1,192 | System, environment, time, process |
-| [binding_codegen.cpp](lib/backend/binding_codegen.cpp) | 1,178 | let/let\*/letrec/letrec\* with TCO |
-| [thread_pool.cpp](lib/backend/thread_pool.cpp) | 1,131 | Work-stealing thread pool |
-| [tensor_backward.cpp](lib/backend/tensor_backward.cpp) | 1,078 | Backward-mode AD gradients |
-| [call_apply_codegen.cpp](lib/backend/call_apply_codegen.cpp) | 960 | Function calls, apply, partial application |
-| [blas_backend.cpp](lib/backend/blas_backend.cpp) | 890 | BLAS dispatch, GPU cost model |
-| [tagged_value_codegen.cpp](lib/backend/tagged_value_codegen.cpp) | 822 | Tagged value pack/unpack |
-| [control_flow_codegen.cpp](lib/backend/control_flow_codegen.cpp) | 800 | if/cond/case/match/call-cc |
-| [map_codegen.cpp](lib/backend/map_codegen.cpp) | 784 | map/for-each/fold with closures |
-| [parallel_codegen.cpp](lib/backend/parallel_codegen.cpp) | 705 | parallel-map/fold/filter/for-each |
-| [homoiconic_codegen.cpp](lib/backend/homoiconic_codegen.cpp) | 601 | Code-as-data, eval |
-| [hash_codegen.cpp](lib/backend/hash_codegen.cpp) | 603 | Hash operations |
-| [complex_codegen.cpp](lib/backend/complex_codegen.cpp) | 499 | Complex number ops (Smith's formula) |
-| [tail_call_codegen.cpp](lib/backend/tail_call_codegen.cpp) | 497 | TCO transformation |
+| [llvm_codegen.cpp](../../lib/backend/llvm_codegen.cpp) | 33,999 | Main codegen, dispatch, builtins |
+| [tensor_codegen.cpp](../../lib/backend/tensor_codegen.cpp) | 1,540 | Tensor-op dispatch shell; per-domain ops live in twelve `tensor_*_codegen.cpp` siblings (~19,200 lines combined) |
+| [autodiff_codegen.cpp](../../lib/backend/autodiff_codegen.cpp) | 9,205 | Forward/reverse mode AD |
+| [string_io_codegen.cpp](../../lib/backend/string_io_codegen.cpp) | 2,975 | String, I/O, JSON, CSV operations |
+| [parallel_llvm_codegen.cpp](../../lib/backend/parallel_llvm_codegen.cpp) | 2,401 | Work-stealing parallelism codegen |
+| [arithmetic_codegen.cpp](../../lib/backend/arithmetic_codegen.cpp) | 2,332 | Numeric ops, bignum, rational, complex |
+| [collection_codegen.cpp](../../lib/backend/collection_codegen.cpp) | 2,139 | Vector, list, hash table operations |
+| [system_codegen.cpp](../../lib/backend/system_codegen.cpp) | 1,192 | System, environment, time, process |
+| [binding_codegen.cpp](../../lib/backend/binding_codegen.cpp) | 1,178 | let/let\*/letrec/letrec\* with TCO |
+| [thread_pool.cpp](../../lib/backend/thread_pool.cpp) | 1,131 | Work-stealing thread pool |
+| [tensor_backward.cpp](../../lib/backend/tensor_backward.cpp) | 1,078 | Backward-mode AD gradients |
+| [call_apply_codegen.cpp](../../lib/backend/call_apply_codegen.cpp) | 960 | Function calls, apply, partial application |
+| [blas_backend.cpp](../../lib/backend/blas_backend.cpp) | 890 | BLAS dispatch, GPU cost model |
+| [tagged_value_codegen.cpp](../../lib/backend/tagged_value_codegen.cpp) | 822 | Tagged value pack/unpack |
+| [control_flow_codegen.cpp](../../lib/backend/control_flow_codegen.cpp) | 800 | if/cond/case/match/call-cc |
+| [map_codegen.cpp](../../lib/backend/map_codegen.cpp) | 784 | map/for-each/fold with closures |
+| [parallel_codegen.cpp](../../lib/backend/parallel_codegen.cpp) | 705 | parallel-map/fold/filter/for-each |
+| [homoiconic_codegen.cpp](../../lib/backend/homoiconic_codegen.cpp) | 601 | Code-as-data, eval |
+| [hash_codegen.cpp](../../lib/backend/hash_codegen.cpp) | 603 | Hash operations |
+| [complex_codegen.cpp](../../lib/backend/complex_codegen.cpp) | 499 | Complex number ops (Smith's formula) |
+| [tail_call_codegen.cpp](../../lib/backend/tail_call_codegen.cpp) | 497 | TCO transformation |
 
 Additional backend components:
 - **XLA/StableHLO**: 4,003 lines across 5 files — tensor compilation via MLIR
@@ -139,7 +139,7 @@ Eshkol applies LLVM's standard optimization pipeline:
 
 ### Runtime Architecture
 
-**Global Arena** ([arena_memory.cpp](lib/core/arena_memory.cpp), 6,186 lines):
+**Global Arena** ([arena_memory.cpp](../../lib/core/arena_memory.h), 6,186 lines):
 - Single allocator for all heap objects
 - 8KB minimum block size, doubling growth strategy
 - No individual `free()`; memory reclaimed via arena reset
@@ -169,7 +169,7 @@ Closures capture variables by storing **pointers** (not values) to the captured 
   (inc)) ; Returns 2 (mutates same counter)
 ```
 
-**Consciousness Engine Runtime** ([logic.cpp](lib/core/logic.cpp) 805 lines, [inference.cpp](lib/core/inference.cpp) 912 lines, [workspace.cpp](lib/core/workspace.cpp) 308 lines):
+**Consciousness Engine Runtime** ([logic.cpp](../../lib/core/logic.cpp) 805 lines, [inference.cpp](../../lib/core/inference.cpp) 912 lines, [workspace.cpp](../../lib/core/workspace.cpp) 308 lines):
 
 Three C runtime libraries implementing unification with substitutions, factor graph belief propagation, and global workspace softmax competition. LLVM codegen dispatches to these via tagged value calling conventions.
 
@@ -228,7 +228,7 @@ v1.1-accelerate adds eight major feature systems to the v1.0-foundation core:
 
 ### Machine Learning Framework (75+ Builtins)
 
-A complete ML framework implemented as compiler-level builtins. The dispatch entry point is [tensor_codegen.cpp](lib/backend/tensor_codegen.cpp) (1,540 lines after the v1.2 split); the per-domain implementations live in twelve `tensor_*_codegen.cpp` siblings (~19,200 lines combined) with SIMD acceleration and automatic GPU dispatch:
+A complete ML framework implemented as compiler-level builtins. The dispatch entry point is [tensor_codegen.cpp](../../lib/backend/tensor_codegen.cpp) (1,540 lines after the v1.2 split); the per-domain implementations live in twelve `tensor_*_codegen.cpp` siblings (~19,200 lines combined) with SIMD acceleration and automatic GPU dispatch:
 
 - **Activations** (16): relu, relu6, sigmoid, tanh, gelu, swish, mish, softmax, log-softmax, softplus, softsign, leaky-relu, prelu, elu, selu, celu
 - **Loss functions** (14): mse-loss, mae-loss, cross-entropy-loss, bce-loss, huber-loss, kl-div-loss, hinge-loss, smooth-l1-loss, focal-loss, triplet-loss, contrastive-loss, label-smoothing-loss, cosine-embedding-loss
@@ -251,7 +251,7 @@ Three theoretical frameworks unified as compiler primitives:
 
 **Global Workspace Theory** (Baars, 1988): `make-workspace`, `ws-register!`, `ws-step!`, `workspace?`
 
-Implementation: [logic.cpp](lib/core/logic.cpp), [inference.cpp](lib/core/inference.cpp), [workspace.cpp](lib/core/workspace.cpp) (runtime); [llvm_codegen.cpp](lib/backend/llvm_codegen.cpp) (codegen dispatch).
+Implementation: [logic.cpp](../../lib/core/logic.cpp), [inference.cpp](../../lib/core/inference.cpp), [workspace.cpp](../../lib/core/workspace.cpp) (runtime); [llvm_codegen.cpp](../../lib/backend/llvm_codegen.cpp) (codegen dispatch).
 
 ### GPU Acceleration
 
@@ -263,9 +263,9 @@ Adaptive dispatch system with cost model calibration:
 | cBLAS (Apple Accelerate AMX) | 1,100 GFLOPS | 5 us | 17 to ~1B elements |
 | Metal GPU (SF64 software float64) | 200 GFLOPS | 200 us | >1B elements |
 
-**SF64 (Software Float64):** Metal GPUs lack native float64 — SF64 emulates double precision using double-double arithmetic (two 32-bit mantissas combined for ~100-bit effective precision). Implemented in [metal_softfloat.h](lib/backend/gpu/metal_softfloat.h) (4,076 lines) and [gpu_memory.mm](lib/backend/gpu/gpu_memory.mm) (3,786 lines).
+**SF64 (Software Float64):** Metal GPUs lack native float64 — SF64 emulates double precision using double-double arithmetic (two 32-bit mantissas combined for ~100-bit effective precision). Implemented in [metal_softfloat.h](../../lib/backend/gpu/metal_softfloat.h) (4,076 lines) and [gpu_memory.mm](../../lib/backend/gpu/gpu_memory.mm) (3,786 lines).
 
-**Cost model dispatch** ([blas_backend.cpp](lib/backend/blas_backend.cpp)): Automatically selects the optimal backend based on tensor size and compute intensity. Configurable via environment variables (`ESHKOL_GPU_PRECISION`, `ESHKOL_BLAS_PEAK_GFLOPS`, `ESHKOL_GPU_PEAK_GFLOPS`).
+**Cost model dispatch** ([blas_backend.cpp](../../lib/backend/blas_backend.cpp)): Automatically selects the optimal backend based on tensor size and compute intensity. Configurable via environment variables (`ESHKOL_GPU_PRECISION`, `ESHKOL_BLAS_PEAK_GFLOPS`, `ESHKOL_GPU_PEAK_GFLOPS`).
 
 ### Parallel Computing
 
@@ -276,7 +276,7 @@ Work-stealing thread pool with parallel higher-order functions:
 - `parallel-filter` — parallel predicate-based selection
 - `parallel-for-each` — parallel side-effecting iteration
 
-Implementation: [parallel_codegen.cpp](lib/backend/parallel_codegen.cpp) (705 lines), [parallel_llvm_codegen.cpp](lib/backend/parallel_llvm_codegen.cpp) (2,401 lines), [thread_pool.cpp](lib/backend/thread_pool.cpp) (1,131 lines). Worker functions use `LinkOnceODRLinkage` for safe parallel compilation.
+Implementation: [parallel_codegen.cpp](../../lib/backend/parallel_codegen.cpp) (705 lines), [parallel_llvm_codegen.cpp](../../lib/backend/parallel_llvm_codegen.cpp) (2,401 lines), [thread_pool.cpp](../../lib/backend/thread_pool.cpp) (1,131 lines). Worker functions use `LinkOnceODRLinkage` for safe parallel compilation.
 
 ### Signal Processing
 
@@ -288,7 +288,7 @@ FFT-based spectral analysis and digital filtering:
 - **FIR/IIR filters**: Direct-form implementation
 - **Convolution**: Linear and fast (FFT-based) convolution
 
-Implementation: [lib/signal/fft.esk](lib/signal/fft.esk), [lib/signal/filters.esk](lib/signal/filters.esk).
+Implementation: [lib/signal/fft.esk](../../lib/signal/fft.esk), [lib/signal/filters.esk](../../lib/signal/filters.esk).
 
 ### Exact Arithmetic (Full Numeric Tower)
 
@@ -318,7 +318,7 @@ Compile Eshkol programs to WebAssembly with 73 DOM/Canvas/Event API bindings:
 eshkol-run --wasm app.esk            # compile to WASM
 ```
 
-The [lib/web/web.esk](lib/web/web.esk) module provides browser interop via an integer handle system:
+The [lib/web/web.esk](../../lib/web/web.esk) module provides browser interop via an integer handle system:
 - DOM element creation, tree manipulation, attributes, CSS classes
 - Event handling (click, keyboard, mouse, timer events)
 - Canvas 2D drawing API (rectangles, paths, arcs, text, transforms)
@@ -386,7 +386,9 @@ simulates an 83-instruction bytecode VM with native reverse-mode AD.
 
 - **JSON Schema validation** (Draft 7 subset): `(json-schema-valid? schema value)` for experiment-manifest enforcement.
 - **Image I/O** (native ImageIO/CoreGraphics, GDI+, or system libpng/libjpeg/libwebp): `(image-read)`, `(image-write)`, `(image-resize)`, `(image-to-grayscale)` returning tensors of shape `(H W C)`.
-- **CSV/DataFrame extensions**: `(read-csv)` with type inference, column selection, filter, group-by.
+- **CSV/DataFrame extensions**: `(csv-parse-typed str)` with type inference,
+  `(csv-select df names)` for column selection, `(csv-filter df pred)` for row
+  filtering. Group-by is not yet implemented.
 - **Terminal plotting** (pure stdlib): `(sparkline list)`, `(bar-chart pairs)` via Unicode block characters — zero dependencies.
 - **Source-located error messages**: `file.esk:line:col: error: …` with caret + underline for the failing span.
 - **AArch64 Linux**: codegen now uses `CodeModel::Large` and `-fuse-ld=lld` to handle the runtime's >128 MiB text section without `R_AARCH64_CALL26` overflows.
@@ -527,10 +529,10 @@ Eshkol v1.2.1-scale represents a **mature, production-ready implementation** for
 
 ### Tooling
 
-- **REPL JIT** ([repl_jit.cpp](lib/repl/repl_jit.cpp), 2,062 lines): LLVM OrcJIT with stdlib preloading, 237 precompiled functions, 305 globals
-- **LSP server** ([eshkol_lsp.cpp](tools/lsp/eshkol_lsp.cpp), 1,018 lines): Completions, hover, go-to-definition, diagnostics, formatting
-- **VSCode extension** ([tools/vscode-eshkol/](tools/vscode-eshkol/)): Syntax highlighting, LSP integration, build tasks
-- **Package manager** ([eshkol_pkg.cpp](tools/pkg/eshkol_pkg.cpp), 721 lines): eshkol-pkg init/build/run/add/clean, TOML manifests, git-based registry
+- **REPL JIT** ([repl_jit.cpp](../../lib/repl/repl_jit.cpp), 2,062 lines): LLVM OrcJIT with stdlib preloading, 237 precompiled functions, 305 globals
+- **LSP server** ([eshkol_lsp.cpp](../../tools/lsp/eshkol_lsp.cpp), 1,018 lines): Completions, hover, go-to-definition, diagnostics, formatting
+- **VSCode extension** ([tools/vscode-eshkol/](../../tools/vscode-eshkol/)): Syntax highlighting, LSP integration, build tasks
+- **Package manager** ([eshkol_pkg.cpp](../../tools/pkg/eshkol_pkg.cpp), 721 lines): eshkol-pkg init/build/run/add/clean, TOML manifests, git-based registry
 - **Docker images**: Debian debug/release, Ubuntu release, CUDA, XLA
 - **CI/CD**: GitHub Actions for continuous integration and release automation
 - **Homebrew**: `brew install eshkol` via tap

--- a/docs/breakdown/SCHEME_COMPATIBILITY.md
+++ b/docs/breakdown/SCHEME_COMPATIBILITY.md
@@ -31,9 +31,9 @@ The R7RS-small standard defines 244 standard procedures and ~30 special forms. E
 Most well-formed R7RS Scheme programs compile and run in Eshkol without modification.
 
 **Implementation references:**
-- Parser: [parser.cpp](lib/frontend/parser.cpp) (8,368 lines)
-- Code generation: [llvm_codegen.cpp](lib/backend/llvm_codegen.cpp) (33,999 lines)
-- Type checker: [type_checker.cpp](lib/types/type_checker.cpp) (2,048 lines)
+- Parser: [parser.cpp](../../lib/frontend/parser.cpp) (8,368 lines)
+- Code generation: [llvm_codegen.cpp](../../lib/backend/llvm_codegen.cpp) (33,999 lines)
+- Type checker: [type_checker.cpp](../../lib/types/type_checker.cpp) (2,048 lines)
 
 ---
 
@@ -691,7 +691,7 @@ Module discovery is automatic: `collect_all_submodules()` recursively discovers 
 
 ## Macro System
 
-Eshkol implements R7RS hygienic macros via `syntax-rules` pattern matching ([macro_expander.cpp](lib/frontend/macro_expander.cpp), 861 lines).
+Eshkol implements R7RS hygienic macros via `syntax-rules` pattern matching ([macro_expander.cpp](../../lib/frontend/macro_expander.cpp), 861 lines).
 
 ```scheme
 ;; Pattern-based macros
@@ -793,7 +793,7 @@ Full R7RS 6.9 bytevector support:
 
 Eshkol implements proper tail calls as required by R7RS. Functions in tail position are compiled to loop-back branches rather than recursive calls, preventing stack overflow.
 
-**Implementation:** The `TailCallContext` in [binding_codegen.h](inc/eshkol/backend/binding_codegen.h) tracks whether a call is in tail position. When TCO is active, `codegenCall` emits a branch back to the function entry point instead of a call instruction.
+**Implementation:** The `TailCallContext` in [binding_codegen.h](../../inc/eshkol/backend/binding_codegen.h) tracks whether a call is in tail position. When TCO is active, `codegenCall` emits a branch back to the function entry point instead of a call instruction.
 
 ```scheme
 ;; This runs in O(1) stack space

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -83,7 +83,7 @@ For detailed component documentation, see:
 
 ### Runtime System
 
-**Arena Memory** - [`lib/core/arena_memory.cpp`](../../lib/core/arena_memory.cpp)
+**Arena Memory** - [`lib/core/arena_memory.cpp`](../../lib/core/arena_memory.h)
 - Global arena allocation
 - Object header management
 - Display system

--- a/docs/vision/SCIENTIFIC_COMPUTING.md
+++ b/docs/vision/SCIENTIFIC_COMPUTING.md
@@ -532,7 +532,7 @@ quantum_step(ctx)          // Full mixing round
 
 ### N-Dimensional Display
 
-**Recursive tensor display** from [`lib/core/arena_memory.cpp`](../../lib/core/arena_memory.cpp):
+**Recursive tensor display** from [`lib/core/arena_memory.cpp`](../../lib/core/arena_memory.h):
 ```scheme
 (define T (tensor 2 2 2  1 2 3 4 5 6 7 8))
 (display T)

--- a/site/static/content/api_reference.html
+++ b/site/static/content/api_reference.html
@@ -3882,7 +3882,7 @@ beta</li>
 <ul>
 <li><code>(convolve signal kernel)</code> — Direct convolution
 O(N*M)</li>
-<li><code>(fft-convolve signal kernel)</code> — FFT-based convolution
+<li><code>(fast-convolve signal kernel)</code> — FFT-based convolution
 O(N log N)</li>
 </ul>
 <h4 id="filters">Filters</h4>

--- a/site/static/content/eshkol_language_guide.html
+++ b/site/static/content/eshkol_language_guide.html
@@ -397,7 +397,7 @@ also accepts <code>#(...)</code> tensor literals),
 <p><strong>Signal Processing:</strong> <code>fft</code>,
 <code>ifft</code>, <code>convolve</code>, <code>fir-filter</code>,
 <code>iir-filter</code>, <code>butterworth-lowpass</code>,
-<code>window-hamming</code>, <code>window-hann</code></p>
+<code>hamming-window</code>, <code>hann-window</code></p>
 <p><strong>Consciousness Engine:</strong> <code>unify</code>,
 <code>walk</code>, <code>make-substitution</code>,
 <code>make-fact</code>, <code>make-kb</code>, <code>kb-assert!</code>,
@@ -407,7 +407,7 @@ also accepts <code>#(...)</code> tensor literals),
 <code>expected-free-energy</code>, <code>make-workspace</code>,
 <code>ws-register!</code>, <code>ws-step!</code></p>
 <p><strong>Web Platform:</strong> <code>web-create-element</code>,
-<code>web-set-text</code>, <code>web-add-event-listener</code>,
+<code>web-set-text-content</code>, <code>web-add-event-listener</code>,
 <code>web-canvas-*</code></p>
 <hr />
 <h2 id="automatic-differentiation">Automatic Differentiation</h2>
@@ -912,8 +912,8 @@ with no interpreter overhead.</p>
 <h3 id="windowing-functions">Windowing Functions</h3>
 <pre class="scheme"><code>;; Apply window functions before FFT to reduce spectral leakage
 (define n 1024)
-(define hamming-win (window-hamming n))
-(define hann-win (window-hann n))
+(define hamming-win (hamming-window n))
+(define hann-win (hann-window n))
 
 (define windowed-signal (tensor-mul signal hamming-win))
 (define spectrum (fft windowed-signal))</code></pre>
@@ -947,13 +947,13 @@ eshkol-run program.esk --wasm -o program.wasm
 <h3 id="dom-api">DOM API</h3>
 <pre class="scheme"><code>;; Create and manipulate DOM elements
 (define heading (web-create-element &quot;h1&quot;))
-(web-set-text heading &quot;Hello from Eshkol!&quot;)
+(web-set-text-content heading &quot;Hello from Eshkol!&quot;)
 
 (define button (web-create-element &quot;button&quot;))
-(web-set-text button &quot;Click me&quot;)
+(web-set-text-content button &quot;Click me&quot;)
 (web-add-event-listener button &quot;click&quot;
   (lambda (event)
-    (web-set-text heading &quot;Clicked!&quot;)))</code></pre>
+    (web-set-text-content heading &quot;Clicked!&quot;)))</code></pre>
 <h3 id="canvas-api">Canvas API</h3>
 <pre class="scheme"><code>;; 2D canvas drawing
 (define canvas (web-canvas-create 800 600))

--- a/site/static/content/eshkol_quick_reference.html
+++ b/site/static/content/eshkol_quick_reference.html
@@ -344,8 +344,8 @@ Handling</h2>
 (ifft spectrum)                ;; Inverse FFT
 
 ;; Window functions
-(window-hamming n)             ;; Hamming window of size n
-(window-hann n)                ;; Hann window of size n
+(hamming-window n)             ;; Hamming window of size n
+(hann-window n)                ;; Hann window of size n
 
 ;; Convolution
 (convolve signal kernel)       ;; linear convolution
@@ -363,15 +363,18 @@ Handling</h2>
 
 ;; DOM manipulation
 (web-create-element tag)           ;; create element
-(web-set-text elem text)           ;; set text content
+(web-set-text-content elem text)   ;; set text content
 (web-add-event-listener elem event handler)  ;; attach handler
 
 ;; Canvas API
-(web-canvas-create w h)            ;; create canvas
-(web-canvas-clear canvas)          ;; clear canvas
-(web-canvas-fill-rect canvas x y w h color)
-(web-canvas-stroke-circle canvas cx cy r color)
-(web-canvas-draw-text canvas text x y color)
+(define ctx (web-get-context-2d canvas))    ;; get 2D drawing context
+(web-canvas-clear-rect ctx x y w h)          ;; clear a rect
+(web-canvas-fill-style ctx color)
+(web-canvas-fill-rect ctx x y w h)
+(web-canvas-begin-path ctx)
+(web-canvas-arc ctx cx cy r 0 6.283185)       ;; circle via full-turn arc
+(web-canvas-stroke ctx)
+(web-canvas-fill-text ctx text x y)           ;; draw text
 (web-request-animation-frame callback)</code></pre>
 <h2 id="math-functions">Math Functions</h2>
 <pre class="scheme"><code>;; Arithmetic

--- a/site/static/content/feature_matrix.html
+++ b/site/static/content/feature_matrix.html
@@ -2375,13 +2375,13 @@ opener</td>
 <td></td>
 </tr>
 <tr>
-<td><code>eshkol-compile</code></td>
+<td><code>eshkol-run</code> (AOT mode, <code>eshkol-run in.esk -o out</code>)</td>
 <td>Yes</td>
 <td>Ahead-of-time compiler</td>
 <td>Produces executables</td>
 </tr>
 <tr>
-<td><code>eshkol-run</code></td>
+<td><code>eshkol-run</code> (JIT mode, <code>eshkol-run -r</code>)</td>
 <td>Yes</td>
 <td>Script runner</td>
 <td>Compile + execute</td>


### PR DESCRIPTION
## Summary

PHANTOM-NAME + NAVIGATION half of the v1.3.4 pre-tag documentation audit. Scope: every function/builtin/special-form name mentioned in public docs must exist in the release; every internal doc link must resolve; the nav index must reach every doc. Does not touch example-execution correctness or numeric/prose claims (owned by sibling audits).

Existence was checked against `tests/coverage/language_surface.json` (1114 unique names) unioned with every `(define ...)`/`(define-syntax ...)`/`(extern ...)` name found in `lib/**/*.esk`, `examples/**/*.esk`, `site/**/*.esk`, and `tests/**/*.esk` (12,904 names total).

## Phantom-name table

| Name in doc | Disposition | Real name / fix | Files |
|---|---|---|---|
| `fft-convolve` | RENAME | `fast-convolve` | API_REFERENCE.md |
| `window-hamming` | RENAME | `hamming-window` | ESHKOL_LANGUAGE_GUIDE.md, ESHKOL_QUICK_REFERENCE.md |
| `window-hann` | RENAME | `hann-window` | ESHKOL_LANGUAGE_GUIDE.md, ESHKOL_QUICK_REFERENCE.md |
| `web-set-text` | RENAME | `web-set-text-content` | ESHKOL_LANGUAGE_GUIDE.md (incl. a worked example that wouldn't have compiled), ESHKOL_QUICK_REFERENCE.md |
| `web-canvas-create` | REMOVAL/rewrite | composed from `web-get-context-2d` | ESHKOL_QUICK_REFERENCE.md |
| `web-canvas-clear` | RENAME | `web-canvas-clear-rect` | ESHKOL_QUICK_REFERENCE.md |
| `web-canvas-stroke-circle` | REMOVAL/rewrite | composed from `web-canvas-begin-path`+`web-canvas-arc`+`web-canvas-stroke` | ESHKOL_QUICK_REFERENCE.md |
| `web-canvas-draw-text` | RENAME | `web-canvas-fill-text` | ESHKOL_QUICK_REFERENCE.md |
| `read-csv` | RENAME | `csv-parse-typed`/`csv-select`/`csv-filter` (group-by stated as not-yet-implemented, not silently dropped) | breakdown/OVERVIEW.md |
| `eshkol-compile` | REMOVAL | no such CMake target exists; folded into the `eshkol-run` row (AOT is `eshkol-run in.esk -o out`) | FEATURE_MATRIX.md |
| `take-n`/`drop-n` (list_sort.md) | **ESCALATE, not fixed** | describes helpers removed by #266's rewrite to a bottom-up vector merge sort; the cited 100k-element crash (ESH-0098) appears resolved (oracle now expects 2M). Confirming + rewriting is execution-correctness verification, outside NAMES/LINKS scope. |
| `autodiff-gradient`, `vector-gradient` | **verified clean** | the two previously-reported phantom names — confirmed absent from every public doc and from the codebase. No action needed. |

Every `site/static/content/*.html` fragment mirroring an edited doc was updated to match (these are pandoc-rendered, checked-in artifacts per `scripts/build-site.sh`). A full site rebuild with a version-matched `eshkol-run` is still recommended before the tag — the locally available `eshkol-run` is v1.3.3, not v1.3.4, so it was not used to regenerate.

## Link-fix count

**174 broken internal links → 19 residual** (all 19 are documented, not silently left):
- ~140 links missing a `../` depth prefix (docs/breakdown/*.md, API_REFERENCE.md, ESHKOL_V1_ARCHITECTURE.md, vision/, components/)
- API_REFERENCE.md pointed `logic.h`/`inference.h`/`workspace.h` (+`.cpp`) at `lib/backend/`+`inc/eshkol/backend/`; real location is `lib/core/`+`inc/eshkol/core/`
- `arena_memory.cpp` no longer exists (header-only now) — 8 references across 5 docs corrected to `arena_memory.h`
- 4 links carried an illegal `path:N`/`path:N-M` line-locator suffix — stripped
- one over-corrected depth (`../../examples/` → `../examples/`), one link missing a prefix entirely (`ROADMAP.md` → `../ROADMAP.md`)
- one TOC anchor mismatch (`#standard-library` → `#standard-library-reference`)

**Residual 19**: `file.md#L123-L456` GitHub blob-style line-range citations in `design/adr/0004` and `design/adr/0007` — the target files exist, but the fragment isn't a real heading anchor on GitHub's rendered-markdown view (blob/raw view only). Re-verifying current line numbers in three separate target docs is out of this pass's mechanical-fix scope; flagged rather than guessed at.

## Orphan count

**Before: 264/345 docs reachable from `docs/README.md` (81 orphans). After: 345/345 (0 orphans).**

Root causes fixed:
- the entire generated `docs/api/**` Doxygen symbol tree (67 files) had no nav entry at all
- 11 of 12 ADRs under `docs/design/adr/` + `design/AD_STAGED_KERNEL_HANDOFF.md` had no nav entry (added, each labelled with its own `Status:`)
- `guide/BINARY_LAMBDA_CALCULUS.md`, `reports/GENERATIVE_DIFFERENTIAL_REPORT.md`, `architecture/tensorcore-adapter.md` were each missing from their own directory's index page

## ICC verdicts

- `icc phantom-api --repo eshkol-v134-release`: 15 PHANTOM-class findings, all C/C++ declaration-vs-definition (not doc-level). 14 are TensorCore external-ABI-boundary externs never mentioned in any public doc. The 1 doc-referenced hit (`eshkol_backward_multihead_attention`) is a false positive — defined at `lib/backend/tensor_backward.cpp:719`, called at line 1314; matches the task's documented ICC gap.
- `icc fts-search` on `fft-convolve` corroborated `fast-convolve` as the real name (already correctly used in `SIGNAL_PROCESSING.md`) and surfaced the `window-hamming`/`window-hann` miss hiding inside a fenced code example.
- `icc impact-analysis --repo eshkol-v134-release --paths <21 changed files>`: `seed_symbol_count: 0`, `impacted_symbol_count: 0` — pure documentation change, zero code-graph impact.

## Test plan

- [x] Custom link/anchor checker: 0 broken links besides the 19 documented residual line-range citations
- [x] Nav-reachability BFS from `docs/README.md`: 345/345 docs reachable (was 264/345)
- [x] Every renamed identifier spot-checked against `lib/**/*.esk` defines/externs or `lib/backend/*.cpp` dispatch tables
- [x] `icc impact-analysis` confirms zero code-graph impact
- [ ] Not run: full build + `scripts/build-site.sh` regeneration (no version-matched `eshkol-run` available locally) — recommend before tag

Do not merge — awaiting coordinator review alongside the sibling example-execution and claims/numbers audits.