### PR TITLE
fix(harness): portable shebangs and PATH-searched subprocess tools

### DIFF
--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Master Build Script - Build all targets locally via Docker + native
 #

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Build Debian package for Eshkol
 #

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Docker Build Script - Build Eshkol for Linux via Docker
 #

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # macOS Build Script - Build Eshkol natively on macOS
 #

--- a/scripts/build-site-content.sh
+++ b/scripts/build-site-content.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build site content: Convert markdown docs to HTML fragments for the website.
 # These HTML fragments are fetched by the WASM app at runtime via web-load-content.
 

--- a/scripts/build_stablehlo.sh
+++ b/scripts/build_stablehlo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build StableHLO with LLVM for Eshkol XLA backend
 #
 # This script builds LLVM/MLIR and StableHLO with all necessary targets

--- a/scripts/lib/test_isolation.sh
+++ b/scripts/lib/test_isolation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # test_isolation.sh — per-run, per-repo-root isolation for the shell test suites.
 #
 # WHY THIS EXISTS

--- a/scripts/make-docker.sh
+++ b/scripts/make-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Build Eshkol packages using Docker
 #

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Complete Test Suite
 # Runs all test suites and reports aggregate results

--- a/scripts/run_all_tests_with_output.sh
+++ b/scripts/run_all_tests_with_output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Complete Test Suite (Verbose Output)
 # Runs all test suites with full output displayed

--- a/scripts/run_autodiff_tests.sh
+++ b/scripts/run_autodiff_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Autodiff Test Suite
 # Runs all automatic differentiation tests and reports results

--- a/scripts/run_autodiff_tests_with_output.sh
+++ b/scripts/run_autodiff_tests_with_output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Autodiff Test Suite with Full Output Capture
 # Shows complete compilation and runtime output for all tests

--- a/scripts/run_benchmark_tests.sh
+++ b/scripts/run_benchmark_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Benchmark Test Suite
 # Runs benchmark tests (timing, BLAS, SIMD) — validates they compile and run

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run Eshkol performance benchmarks
 # Usage: ./scripts/run_benchmarks.sh [benchmark_name]
 

--- a/scripts/run_bignum_tests.sh
+++ b/scripts/run_bignum_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Bignum Test Suite
 # Tests arbitrary-precision integer operations

--- a/scripts/run_codegen_optlevel_tests.sh
+++ b/scripts/run_codegen_optlevel_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Generated-Code Optimization-Level Test Suite
 #

--- a/scripts/run_codegen_tests.sh
+++ b/scripts/run_codegen_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Codegen Test Suite
 # Runs codegen-level tests (arithmetic, etc.)

--- a/scripts/run_complex_tests.sh
+++ b/scripts/run_complex_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Complex Number & FFT Test Suite
 # Runs all complex arithmetic and FFT tests

--- a/scripts/run_complex_tests_with_output.sh
+++ b/scripts/run_complex_tests_with_output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Complex Number & FFT Test Suite with Full Output Capture
 # Shows complete compilation and runtime output for all tests

--- a/scripts/run_control_flow_tests.sh
+++ b/scripts/run_control_flow_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Control Flow Test Suite
 # Runs all control flow tests and reports results

--- a/scripts/run_cpp_type_tests.sh
+++ b/scripts/run_cpp_type_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol HoTT Type Checker C++ Unit Tests
 # Compiles and runs the C++ type system tests

--- a/scripts/run_dbsp_gate.sh
+++ b/scripts/run_dbsp_gate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # core.dbsp acceptance gate (ADR 0009, v1.5.0 incremental-dataflow slice).
 #

--- a/scripts/run_error_handling_tests.sh
+++ b/scripts/run_error_handling_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Error Handling Test Suite
 # Tests exception handling: guard, with-exception-handler, raise

--- a/scripts/run_examples_tests.sh
+++ b/scripts/run_examples_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Examples Test Suite
 # Tests all examples and categorizes them by status

--- a/scripts/run_examples_tests_with_output.sh
+++ b/scripts/run_examples_tests_with_output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Examples Test Suite (Verbose Output)
 # Same as run_examples_tests.sh but shows compile/runtime output for debugging

--- a/scripts/run_features_tests.sh
+++ b/scripts/run_features_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Features Test Suite
 # Runs all feature tests and reports results

--- a/scripts/run_features_tests_with_output.sh
+++ b/scripts/run_features_tests_with_output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Features Test Suite with Full Output Capture
 # Shows complete compilation and runtime output for all tests

--- a/scripts/run_ffi_tests.sh
+++ b/scripts/run_ffi_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol FFI Test Suite
 # Runs all tests/ffi/*.esk tests (extern declarations, string<->C marshalling,

--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol GPU Test Suite
 # Runs all GPU and softfloat tests

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -158,7 +158,7 @@ probe subprocess_argv_safe "process-spawn-argv runs argv directly" \
     'tmp=$(mktemp).esk;
      cat > "$tmp" <<EOF
 (require agent.subprocess)
-(let ((p (process-spawn-argv (list "/bin/echo" "hello;world|pipe") ".")))
+(let ((p (process-spawn-argv (list "echo" "hello;world|pipe") ".")))
   (process-wait p 5000)
   ;; If the shell were invoked, the ; and | would split commands. argv-safe
   ;; spawn passes the whole string verbatim as one argument.
@@ -172,7 +172,7 @@ probe subprocess_pid_exposed "process-pid returns a real OS PID > 0" \
     'tmp=$(mktemp).esk;
      cat > "$tmp" <<EOF
 (require agent.subprocess)
-(let ((p (process-spawn-argv (list "/bin/sleep" "0.05") ".")))
+(let ((p (process-spawn-argv (list "sleep" "0.05") ".")))
   (let ((pid (process-pid p)))
     (process-wait p 5000)
     (process-destroy p)

--- a/scripts/run_io_tests.sh
+++ b/scripts/run_io_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol I/O Test Suite
 # Runs all I/O tests (read, write, string ports)

--- a/scripts/run_json_tests.sh
+++ b/scripts/run_json_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # JSON Test Suite Validation Script
 # Runs all tests in tests/json/ directory

--- a/scripts/run_json_tests_with_output.sh
+++ b/scripts/run_json_tests_with_output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # JSON Test Suite with Full Output Capture
 # Shows complete compilation and runtime output for all tests

--- a/scripts/run_list_tests.sh
+++ b/scripts/run_list_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Systematic Test Suite Validation Script
 # Runs all tests and reports results

--- a/scripts/run_list_tests_with_output.sh
+++ b/scripts/run_list_tests_with_output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Test Suite Validation Script with Output Capture
 # Runs all tests and saves their output for verification

--- a/scripts/run_logic_tests.sh
+++ b/scripts/run_logic_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run Eshkol Consciousness Engine tests — v1.1-accelerate
 set -e
 

--- a/scripts/run_macros_tests.sh
+++ b/scripts/run_macros_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Macros Test Suite
 # Tests define-syntax / syntax-rules macro system

--- a/scripts/run_manifold_tests.sh
+++ b/scripts/run_manifold_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Compile and run the differential-geometry regression suite.
 
 set -euo pipefail

--- a/scripts/run_memory_tests.sh
+++ b/scripts/run_memory_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Memory Test Suite
 # Runs all memory tests and reports results

--- a/scripts/run_memory_tests_with_output.sh
+++ b/scripts/run_memory_tests_with_output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Memory Test Suite with Full Output Capture
 # Shows complete compilation and runtime output for all tests

--- a/scripts/run_migration_tests.sh
+++ b/scripts/run_migration_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Migration Test Suite
 # Validates type system migration and pointer consolidation

--- a/scripts/run_ml_tests.sh
+++ b/scripts/run_ml_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol ML Test Suite
 # Runs all machine learning tests and reports results

--- a/scripts/run_ml_tests_with_output.sh
+++ b/scripts/run_ml_tests_with_output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # ML Test Suite with Full Output Capture
 # Shows complete compilation and runtime output for all tests

--- a/scripts/run_modules_tests.sh
+++ b/scripts/run_modules_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Modules Test Suite
 # Runs all module tests and reports results

--- a/scripts/run_modules_tests_with_output.sh
+++ b/scripts/run_modules_tests_with_output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Modules Test Suite with Full Output Capture
 # Shows complete compilation and runtime output for all tests

--- a/scripts/run_neural_tests.sh
+++ b/scripts/run_neural_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Neural Network Test Suite
 # Runs all neural network tests and reports results

--- a/scripts/run_neural_tests_with_output.sh
+++ b/scripts/run_neural_tests_with_output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Neural Network Test Suite with Full Output Capture
 # Shows complete compilation and runtime output for all tests

--- a/scripts/run_numeric_tests.sh
+++ b/scripts/run_numeric_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Numeric Regression Test Suite
 # Tests critical numeric bug fixes from v1.1 development

--- a/scripts/run_optimization_tests.sh
+++ b/scripts/run_optimization_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Optimization Algorithms Test Suite
 # Tests gradient descent, Adam, L-BFGS, conjugate gradient

--- a/scripts/run_parallel_tests.sh
+++ b/scripts/run_parallel_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Parallel Primitives Test Suite
 # Tests parallel-map, parallel-fold, parallel-filter, parallel-for-each,

--- a/scripts/run_parser_tests.sh
+++ b/scripts/run_parser_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Parser Test Suite
 # Runs all parser tests and reports results

--- a/scripts/run_parser_tests_with_output.sh
+++ b/scripts/run_parser_tests_with_output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Parser Test Suite with Full Output Capture
 # Shows complete compilation and runtime output for all tests

--- a/scripts/run_r7rs_tests.sh
+++ b/scripts/run_r7rs_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Deterministic R7RS conformance probes. Every source in tests/r7rs is
 # compiled and executed, so language-surface coverage cannot be earned by a

--- a/scripts/run_rational_tests.sh
+++ b/scripts/run_rational_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Rational Number Test Suite
 # Tests rational number (fraction) operations

--- a/scripts/run_repl_tests.sh
+++ b/scripts/run_repl_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol REPL Test Suite
 # Runs all REPL tests and reports results

--- a/scripts/run_repl_tests_with_output.sh
+++ b/scripts/run_repl_tests_with_output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Honour $BUILD_DIR (CI passes it via the matrix); fall back to "build" for plain local runs.
 BUILD_DIR="${BUILD_DIR:-build}"

--- a/scripts/run_signal_tests.sh
+++ b/scripts/run_signal_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Signal Processing Test Suite
 # Tests signal processing filters, windowing, and convolution

--- a/scripts/run_stdlib_tests.sh
+++ b/scripts/run_stdlib_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Stdlib Test Suite
 # Runs all stdlib tests and reports results

--- a/scripts/run_stdlib_tests_with_output.sh
+++ b/scripts/run_stdlib_tests_with_output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Stdlib Test Suite with Full Output Capture
 # Shows complete compilation and runtime output for all tests

--- a/scripts/run_stress_tests.sh
+++ b/scripts/run_stress_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # run_stress_tests.sh — drive the long-running stress harnesses.
 #
 # Not wired into scripts/run_all_tests.sh because these take minutes

--- a/scripts/run_surface_extension_tests.sh
+++ b/scripts/run_surface_extension_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Execute deterministic high-risk extension suites that were previously
 # committed but not wired into the complete CI harness.
 

--- a/scripts/run_system_tests.sh
+++ b/scripts/run_system_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # System Test Suite (Hash Tables, File I/O, etc.)
 # Runs all system-level tests

--- a/scripts/run_system_tests_with_output.sh
+++ b/scripts/run_system_tests_with_output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # System Test Suite with Full Output Capture
 # Shows complete compilation and runtime output for all tests

--- a/scripts/run_tco_tests.sh
+++ b/scripts/run_tco_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol TCO (Tail Call Optimization) Test Suite
 # Tests that TCO works correctly with nested letrec expressions.

--- a/scripts/run_types_tests.sh
+++ b/scripts/run_types_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol HoTT Type System Test Suite
 # Runs all type system tests and reports results

--- a/scripts/run_types_tests_with_output.sh
+++ b/scripts/run_types_tests_with_output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # HoTT Type System Test Suite with Full Output Capture
 # Shows complete compilation and runtime output for all tests

--- a/scripts/run_typesystem_tests.sh
+++ b/scripts/run_typesystem_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Type System Test Suite
 # Checks that the type checker detects the faults it claims to detect AND that

--- a/scripts/run_v1_2_edge_cases.sh
+++ b/scripts/run_v1_2_edge_cases.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # run_v1_2_edge_cases.sh — proper runner for tests/v1_2_edge_cases/
 #
 # Each .esk test may declare a mode header on its first line:

--- a/scripts/run_v1_2_edge_cases_tests.sh
+++ b/scripts/run_v1_2_edge_cases_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run Eshkol v1.2 edge-case + security regression suite.
 #
 # This pulls every .esk file under tests/v1_2_edge_cases/ and treats it

--- a/scripts/run_vm_surface_tests.sh
+++ b/scripts/run_vm_surface_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Compile and execute deterministic extended-surface probes on the hosted VM.
 
 set -euo pipefail

--- a/scripts/run_vm_tests.sh
+++ b/scripts/run_vm_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run the standalone bytecode VM self-tests.
 
 set -e

--- a/scripts/run_web_tests.sh
+++ b/scripts/run_web_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol Web/WASM Test Suite
 # Tests WASM compilation and server functionality

--- a/scripts/run_xla_tests.sh
+++ b/scripts/run_xla_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Eshkol XLA/StableHLO Integration Test Suite
 # Tests XLA backend dispatch and tensor operations

--- a/scripts/test-ci-locally.sh
+++ b/scripts/test-ci-locally.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test GitHub CI Locally
 #

--- a/scripts/test-homebrew.sh
+++ b/scripts/test-homebrew.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Homebrew Formula Test Script
 #

--- a/scripts/test_output_helpers.sh
+++ b/scripts/test_output_helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 test_output_fail() {
     echo "$1" >&2

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # update-homebrew-formula.sh
 #
 # Updates packaging/homebrew/eshkol.rb (and optionally the tsotchke/homebrew-eshkol

--- a/tests/fixed_point/run_fixed_point_tests.sh
+++ b/tests/fixed_point/run_fixed_point_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # run_fixed_point_tests.sh — build + run the fixed-point / i128 / exact-accumulation
 # suite standalone (no CMake, no dependency on the Eshkol build tree). Additive:
 # touches nothing outside this directory + the library it tests.

--- a/tests/fixed_point/test_runner_failures.sh
+++ b/tests/fixed_point/test_runner_failures.sh
@@ -30,7 +30,11 @@ if [ "$(basename "$0")" = "fake-cc" ]; then
         echo "fake-cc: missing -o output" >&2
         exit 43
     fi
-    ln -s /usr/bin/true "$output"
+    # Portability: /usr/bin/true does not exist on every host (e.g. NixOS,
+    # which keeps /usr/bin nearly empty). Emit a tiny POSIX-sh stub instead
+    # of symlinking to an absolute path that may not exist.
+    printf '#!/bin/sh\nexit 0\n' > "$output"
+    chmod +x "$output"
     exit 0
 fi
 

--- a/tests/stress/stress_fd_exhaustion.esk
+++ b/tests/stress/stress_fd_exhaustion.esk
@@ -18,7 +18,7 @@
 (define (loop i fails)
   (if (>= i N)
       fails
-      (let* ((r (run-argv-capture (list "/bin/echo" "ok")))
+      (let* ((r (run-argv-capture (list "echo" "ok")))
              (code (cdr (assoc 'exit-code r))))
         (if (= code 0)
             (loop (+ i 1) fails)

--- a/tests/toolchain/ffi_boundary_fail_open_test.sh
+++ b/tests/toolchain/ffi_boundary_fail_open_test.sh
@@ -26,7 +26,8 @@
 # Asserted here: exit status, the preserved diagnostic wording, the ABSENCE of a
 # written binary on the AOT arity cell, that no cell dies by SIGNAL (128+n, and
 # specifically never 139/SIGSEGV), that the type error is catchable by `guard`,
-# and that a correctly-called spawn still runs /bin/echo and captures its output.
+# and that a correctly-called spawn still runs `echo` (PATH-searched via execvp,
+# portable to hosts without /bin/echo, e.g. NixOS) and captures its output.
 #
 # Self-contained: synthesizes its own fixtures.
 
@@ -103,7 +104,7 @@ ESK
 wrong_type="$tmp/ffi_wrong_type.esk"
 cat > "$wrong_type" <<'ESK'
 (require agent.subprocess)
-(define r (run-argv-capture (list "/bin/echo" "hi") 5000))
+(define r (run-argv-capture (list "echo" "hi") 5000))
 (display r) (newline)
 ESK
 
@@ -113,7 +114,7 @@ catchable="$tmp/ffi_catchable.esk"
 cat > "$catchable" <<'ESK'
 (require agent.subprocess)
 (display (guard (e (#t "caught"))
-           (run-argv-capture (list "/bin/echo" "hi") 5000)
+           (run-argv-capture (list "echo" "hi") 5000)
            "not-reached"))
 (newline)
 ESK
@@ -204,22 +205,22 @@ done
 happy="$tmp/ffi_happy.esk"
 cat > "$happy" <<'ESK'
 (require agent.subprocess)
-(define r (run-argv-capture (list "/bin/echo" "hello-ffi-guard") "."))
+(define r (run-argv-capture (list "echo" "hello-ffi-guard") "."))
 (display "exit=") (display (cdr (assq 'exit-code r))) (newline)
 (display "out=") (display (cdr (assq 'stdout r)))
-(define h (process-spawn-argv (list "/bin/echo" "spawned") "."))
+(define h (process-spawn-argv (list "echo" "spawned") "."))
 (display "spawn-ok=") (display (if (process-running? h) "yes" (if h "yes" "no"))) (newline)
 (process-wait h 10000)
 (process-destroy h)
 ;; #f in a pointer position is LEGAL — it is how Eshkol spells a NULL pointer
 ;; argument. process-spawn passes a NULL envp through a `ptr` parameter, and #f
 ;; for cwd means "inherit the caller's". The guard must not reject either.
-(define h2 (process-spawn "/bin/echo envp-null-ok" "."))
+(define h2 (process-spawn "echo envp-null-ok" "."))
 (process-close-stdin h2)
 (process-wait h2 10000)
 (display (process-read-all-stdout h2 4096))
 (process-destroy h2)
-(define h3 (process-spawn-argv (list "/bin/echo" "cwd-null-ok") #f))
+(define h3 (process-spawn-argv (list "echo" "cwd-null-ok") #f))
 (process-wait h3 10000)
 (display (process-read-all-stdout h3 4096))
 (process-destroy h3)
@@ -339,7 +340,7 @@ echo "  ok: -r bare-extern accepts a string and #f (NULL) in ptr params"
 log="$tmp/happy_r.log"
 ec="$(run "$log" "$ESHKOL_RUN" -r "$happy")"
 [ "$ec" -eq 0 ] || fail "-r correct-arity spawn regressed (exit $ec): $(head -10 "$log" | tr '\n' ' ')"
-grep -q "exit=0" "$log" || fail "-r correct-arity spawn: /bin/echo did not report exit 0"
+grep -q "exit=0" "$log" || fail "-r correct-arity spawn: echo did not report exit 0"
 grep -q "hello-ffi-guard" "$log" || fail "-r correct-arity spawn did not capture child stdout"
 grep -q "spawn-ok=yes" "$log" || fail "-r correct-arity process-spawn-argv returned no handle"
 grep -q "envp-null-ok" "$log" || fail "-r process-spawn with a NULL envp (#f in a ptr param) was rejected"
@@ -355,7 +356,7 @@ if [ "$ec" -eq 0 ] && [ -x "$happy_bin" ]; then
     ec="$(run "$log" "$happy_bin")"
     [ "$ec" -eq 0 ] || fail "AOT correct-arity spawn regressed (exit $ec): $(head -10 "$log" | tr '\n' ' ')"
     grep -q "hello-ffi-guard" "$log" || fail "AOT correct-arity spawn did not capture child stdout"
-    echo "  ok: AOT correct-arity spawn ran /bin/echo and captured its output"
+    echo "  ok: AOT correct-arity spawn ran echo and captured its output"
 else
     echo "  skip: AOT link unavailable here (build exit $ec) — -r positive control already asserted"
 fi

--- a/tests/toolchain/shared_lib_abi_test.sh
+++ b/tests/toolchain/shared_lib_abi_test.sh
@@ -106,6 +106,58 @@ done
 [ -n "$PYTHON" ] \
     || fail "no python3: the ctypes leg is a required second consumer, not an optional one"
 
+# ── ASan interop ───────────────────────────────────────────────────────────────
+# On the linux-x64-asan lane, $ESHKOL_RUN and everything it compiles are built
+# with `-fsanitize=address` (CMakeLists.txt ESHKOL_ENABLE_ASAN), so the
+# `--shared-lib` output produced below is itself ASan-instrumented and depends
+# on the ASan runtime DSO. dlopen()-ing that library from a plain,
+# non-instrumented process (this test's own C harness, or the system python
+# running the ctypes leg) makes ASan's own initialization detect that its
+# runtime was not the first thing loaded into the process and abort with
+# "ASan runtime does not come first in initial library list" -- a harness
+# ordering problem, not a defect in the exported ABI this test exists to check.
+#
+# Detect ASan by asking the dynamic linker what $ESHKOL_RUN itself actually
+# depends on (portable across the gcc/libasan.so and clang/libclang_rt.asan*.so
+# naming schemes, and always the exact path the toolchain resolved) rather than
+# guessing a compiler-specific flag or relying on a lane-set env var that could
+# drift out of sync with the actual build.
+ASAN_RUNTIME=""
+if [ "$(uname -s)" != "Darwin" ] && command -v ldd >/dev/null 2>&1; then
+    ASAN_RUNTIME="$(ldd "$ESHKOL_RUN" 2>/dev/null \
+        | awk '/libasan|libclang_rt\.asan/ { print $3; exit }')"
+fi
+
+run_c_harness() {
+    # Correct preload ordering: put the same ASan runtime the library was
+    # built against first in the process, so the harness stays a real,
+    # ASan-instrumented consumer -- this is the meaningful fix, not a
+    # disabled check.
+    if [ -n "$ASAN_RUNTIME" ]; then
+        LD_PRELOAD="$ASAN_RUNTIME" "$WORK/abi_harness" "$1"
+    else
+        "$WORK/abi_harness" "$1"
+    fi
+}
+
+run_ctypes_harness() {
+    if [ -n "$ASAN_RUNTIME" ]; then
+        # LD_PRELOAD-ing libasan into a live CPython process is a materially
+        # different risk than preloading it ahead of a fresh C harness exec:
+        # CPython's own small-object allocator and internal caches were not
+        # built against ASan's interceptors, and forcing the preload here has
+        # been observed to make the interpreter itself misbehave for reasons
+        # unrelated to the export-ABI contract this test checks. So for this
+        # child ONLY, keep the ctypes leg meaningful (it still performs every
+        # ABI assertion above) while dropping ASan's link-order verification
+        # instead of the correct-ordering fix used for the C harness.
+        ASAN_OPTIONS="${ASAN_OPTIONS:-}:verify_asan_link_order=0" \
+            "$PYTHON" "$WORK/abi_harness.py" "$1"
+    else
+        "$PYTHON" "$WORK/abi_harness.py" "$1"
+    fi
+}
+
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-sharedlibabi.XXXXXX")" || fail "mktemp failed"
 cleanup() { rm -rf "$WORK"; }
 trap cleanup EXIT
@@ -519,8 +571,8 @@ for opt in 0 2; do
         esac
     done
 
-    "$WORK/abi_harness" "$lib_path" || fail "-O$opt: C harness rejected the library ABI"
-    "$PYTHON" "$WORK/abi_harness.py" "$lib_path" \
+    run_c_harness "$lib_path" || fail "-O$opt: C harness rejected the library ABI"
+    run_ctypes_harness "$lib_path" \
         || fail "-O$opt: ctypes harness rejected the library ABI"
 done
 

--- a/tests/toolchain/transitive_ffi_link_test.sh
+++ b/tests/toolchain/transitive_ffi_link_test.sh
@@ -64,7 +64,7 @@ cat > "$tmp/leaf.esk" <<'EOF'
 ;; the agent-FFI archive. Guarded so the test never depends on a spawn actually
 ;; succeeding in a sandbox — the link requirement exists regardless.
 (define (leaf-touch-ffi)
-  (if #f (run-argv-capture (list "/bin/echo" "x")) #t))
+  (if #f (run-argv-capture (list "echo" "x")) #t))
 EOF
 cat > "$tmp/mid.esk" <<'EOF'
 (load "leaf.esk")

--- a/tests/v1_2_edge_cases/ast_dump_let_ops_test.sh
+++ b/tests/v1_2_edge_cases/ast_dump_let_ops_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ast_dump_let_ops_test.sh — AST printer must not read the wrong operation
 # union fields for let-family forms.
 

--- a/tests/v1_2_edge_cases/capability_denied_signal_test.sh
+++ b/tests/v1_2_edge_cases/capability_denied_signal_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ESH-0076: capability-denied runtime operations must be distinguishable from
 # ordinary absent values while preserving the existing false/null return shape.
 

--- a/tests/v1_2_edge_cases/error_diagnostic_is_fatal_test.sh
+++ b/tests/v1_2_edge_cases/error_diagnostic_is_fatal_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # error_diagnostic_is_fatal_test.sh — an emitted error diagnostic must prevent
 # artifact emission and execution, and must exit non-zero.
 #

--- a/tests/v1_2_edge_cases/error_line_marker_test.sh
+++ b/tests/v1_2_edge_cases/error_line_marker_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # error_line_marker_test.sh — verify that compile-time error markers
 # point at the actual source line/column.
 #

--- a/tests/v1_2_edge_cases/forward_ref_named_test.sh
+++ b/tests/v1_2_edge_cases/forward_ref_named_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # forward_ref_named_test.sh — Bug W regression (2026-04-25)
 #
 # Asserts that calling a forward-referenced function that was never

--- a/tests/v1_2_edge_cases/http_server_smoke_test.sh
+++ b/tests/v1_2_edge_cases/http_server_smoke_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # http_server_smoke_test.sh — core HTTP server builtin round-trip (#145).
 #
 # Spins up the loopback HTTP server, forks a child that performs a core

--- a/tests/v1_2_edge_cases/load_path_with_dots_test.sh
+++ b/tests/v1_2_edge_cases/load_path_with_dots_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # load_path_with_dots_test.sh — regression for the resolveModulePath
 # bug where directory components containing dots were silently mangled.
 #

--- a/tests/v1_2_edge_cases/object_build_cli_contract_test.sh
+++ b/tests/v1_2_edge_cases/object_build_cli_contract_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # object_build_cli_contract_test.sh - Noesis Bug LL positive regression.
 #
 # Build systems need an exact object-output contract. This verifies the

--- a/tests/v1_2_edge_cases/object_emit_phase_trace_test.sh
+++ b/tests/v1_2_edge_cases/object_emit_phase_trace_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # object_emit_phase_trace_test.sh — ESH-0088 object-emission diagnostics.
 
 set -u

--- a/tests/v1_2_edge_cases/private_extern_no_crash_test.sh
+++ b/tests/v1_2_edge_cases/private_extern_no_crash_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # private_extern_no_crash_test.sh — EXTERN_OP rename SIGSEGV (2026-04-26)
 #
 # Regression for the union-aliasing bug in update_ast_references:

--- a/tests/v1_2_edge_cases/provide_aot_jit_parity_test.sh
+++ b/tests/v1_2_edge_cases/provide_aot_jit_parity_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # provide_aot_jit_parity_test.sh — Bug Z regression (filed 2026-04-30,
 # closed by Eshkol 1235e0a).
 #

--- a/tests/v1_2_edge_cases/repl_display_persistent_test.sh
+++ b/tests/v1_2_edge_cases/repl_display_persistent_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # repl_display_persistent_test.sh — displayed REPL expressions must not
 # abort the process before the next read.
 

--- a/tests/v1_2_edge_cases/repl_machine_mode_protocol_test.sh
+++ b/tests/v1_2_edge_cases/repl_machine_mode_protocol_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # repl_machine_mode_protocol_test.sh — machine-mode warm worker keeps
 # framing on stderr and user output on stdout.
 

--- a/tests/v1_2_edge_cases/shared_lib_export_abi_test.sh
+++ b/tests/v1_2_edge_cases/shared_lib_export_abi_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) tsotchke
 #

--- a/tests/v1_2_edge_cases/subprocess_shell_argv_test.sh
+++ b/tests/v1_2_edge_cases/subprocess_shell_argv_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # subprocess_shell_argv_test.sh — explicit shell vs argv process semantics.
 
 set -u
@@ -11,7 +11,12 @@ if [ ! -x "$RUN" ]; then
     exit 0
 fi
 
-if [ ! -x /bin/sh ] || [ ! -x /bin/echo ] || [ ! -x /bin/sleep ] || [ ! -x /bin/kill ]; then
+# /bin/sh is POSIX-guaranteed (present even on hosts, like NixOS, whose /bin
+# is otherwise empty); echo/sleep/kill only need to be PATH-searchable, since
+# argv-mode spawns below use bare names and go through execvp(), not an
+# absolute path.
+if [ ! -x /bin/sh ] || ! command -v echo >/dev/null 2>&1 \
+   || ! command -v sleep >/dev/null 2>&1 || ! command -v kill >/dev/null 2>&1; then
     echo "SKIP: POSIX shell tools unavailable"
     exit 0
 fi
@@ -73,10 +78,10 @@ cat > "$WORK/subprocess_api.esk" <<'EOF'
   (run-command-capture "echo hidden >/dev/null; echo visible" "." 5000 4096))
 
 (define argv-result
-  (run-argv-capture (list "/bin/echo" "literal;not-shell") "." 5000 4096))
+  (run-argv-capture (list "echo" "literal;not-shell") "." 5000 4096))
 
 (define argv-metachars
-  (run-argv-capture (list "/bin/echo" "literal|pipe" "literal>redir" "exit 42")
+  (run-argv-capture (list "echo" "literal|pipe" "literal>redir" "exit 42")
                     "." 5000 4096))
 
 (define legacy-simple
@@ -132,7 +137,7 @@ cat > "$WORK/subprocess_api.esk" <<'EOF'
       -999))
 
 (define timeout-proc
-  (process-spawn-argv (list "/bin/sleep" "5") "."))
+  (process-spawn-argv (list "sleep" "5") "."))
 
 (define timeout-pid
   (if timeout-proc (process-pid timeout-proc) 0))
@@ -160,10 +165,10 @@ cat > "$WORK/subprocess_api.esk" <<'EOF'
       (= timeout-exit-code 137)))
 
 (define argv-timeout-result
-  (run-argv-capture (list "/bin/sleep" "5") "." 100 4096))
+  (run-argv-capture (list "sleep" "5") "." 100 4096))
 
 (define destroy-proc
-  (process-spawn-argv (list "/bin/sleep" "30") "."))
+  (process-spawn-argv (list "sleep" "30") "."))
 
 (define destroy-pid
   (if destroy-proc (process-pid destroy-proc) 0))
@@ -173,7 +178,7 @@ cat > "$WORK/subprocess_api.esk" <<'EOF'
 
 (define destroy-kill-check
   (if (> destroy-pid 0)
-      (run-argv-capture (list "/bin/kill" "-0" (number->string destroy-pid))
+      (run-argv-capture (list "kill" "-0" (number->string destroy-pid))
                         "." 5000 4096)
       (list (cons 'exit-code -999)
             (cons 'stdout "")

--- a/tests/vm/vm_system_test.esk
+++ b/tests/vm/vm_system_test.esk
@@ -91,7 +91,7 @@
 (display "=== Process ===") (newline)
 
 ;; process-spawn + process-wait
-(let ((pid (process-spawn "/bin/echo" (list "hello" "from" "eshkol") #f)))
+(let ((pid (process-spawn "echo" (list "hello" "from" "eshkol") #f)))
   (if pid
     (begin
       (display "process-spawn pid: ") (display pid) (newline)


### PR DESCRIPTION
## Summary

Test-harness-only fix for the two real (non-infrastructure) lane failures in
the release-candidate mesh gate run against master `ec8ec7f4` (verdict
`rc-v134-ec8ec7f4`, BLOCKED on `linux-x64-asan` and `linux-arm64`; the third
blocking lane, `wasm`, was a disk-floor setup failure on the runner and is
unrelated to this change). No compiler or runtime source is touched — every
file in this diff is under `scripts/` or `tests/`.

## Item 1 — `/bin/*` portability on NixOS (linux-arm64, xavier)

NixOS keeps only `sh` under `/bin`; nothing else is guaranteed to exist there
or be reachable by an absolute `/bin/...`/`/usr/bin/...` path. Two ctest
cases failed for that reason on the linux-arm64 lane:

- `fixedpoint_runner_failures` — `tests/fixed_point/run_fixed_point_tests.sh`
  had a literal `#!/bin/bash` shebang, so executing it directly failed with
  "bad interpreter: No such file or directory" (rc=8 for the lane).
- `ffi_boundary_fail_open_test` — its positive-control fixture spawned
  `/bin/echo` by absolute path; the exec failed the same way.

Fix classes, matching the argv[0]/PATH-search pattern already established
elsewhere in this suite for the same family of defect:

- Every `#!/bin/bash` shebang under `scripts/` and `tests/` (92 files) is now
  `#!/usr/bin/env bash`. All were plain `#!/bin/bash` with no interpreter
  flags, so this is a pure resolution-mechanism change; every file already
  either used real bash syntax or is otherwise harmless to run under an
  env-resolved bash. `/bin/sh` references are untouched everywhere — NixOS
  does provide `/bin/sh`, which is exactly why the defect was scoped to bash
  specifically.
- `/bin/echo`, `/bin/sleep`, and `/bin/kill` used as subprocess *arguments*
  (not as the shebang of the calling script) are replaced with bare
  PATH-searched names. Every call site goes through
  `lib/agent/c/agent_subprocess.c`'s `execvp()` (or its whitespace-token
  fast path, documented in that file as "identically to execvp-on-tokens"),
  which already performs a PATH search — this is a like-for-like swap, not a
  behavior change. Files touched: `tests/toolchain/ffi_boundary_fail_open_test.sh`,
  `tests/v1_2_edge_cases/subprocess_shell_argv_test.sh`, `tests/vm/vm_system_test.esk`,
  `tests/stress/stress_fd_exhaustion.esk`, `tests/toolchain/transitive_ffi_link_test.sh`
  (dead-code branch), `scripts/run_icc_smoke.sh`.
- `subprocess_shell_argv_test.sh`'s own tool-availability guard checked
  `[ -x /bin/echo ]` etc., so on a host where these tools exist only on PATH
  it was silently *skipping* the suite rather than failing it — quietly
  losing coverage. Switched to `command -v`.
- `tests/fixed_point/test_runner_failures.sh`'s fake-cc stub symlinked to
  `/usr/bin/true`, which also does not exist on NixOS. The shebang fix above
  would have let this code path execute for the first time and hit the same
  class of failure one file over, so it is replaced with a two-line
  `#!/bin/sh` stub written directly (`/bin/sh` being the one guaranteed
  binary).

Absolute `/bin/sh` and `/usr/bin/time` references elsewhere in `tests/` were
left as-is: they are either the test's actual subject (e.g. asserting that
absolute-path spawning of `/bin/sh` works, or normalizing a path string that
is never executed) or already correctly guarded to skip when the tool is
absent, and `/bin/sh`/reasonable `/usr/bin/time` presence is the documented
NixOS contract this lane already relies on elsewhere.

## Item 2 — ASan link-order abort in the shared-lib ABI harness (linux-x64-asan, old-donkey)

`shared_lib_export_abi_test` (delegating to
`tests/toolchain/shared_lib_abi_test.sh`) failed under the `linux-x64-asan`
lane's `-O0` case with:

    ==...==ASan runtime does not come first in initial library list; you
    should either link runtime to your application or manually preload it
    with LD_PRELOAD.

On that lane `eshkol-run` and everything it compiles are built with
`-fsanitize=address` (`ESHKOL_ENABLE_ASAN`), so the `--shared-lib` output
under test is itself ASan-instrumented. `dlopen()`-ing it from this test's
own plain C harness, or from the system Python running the ctypes leg, makes
ASan's own startup detect it was not the first thing loaded into the process
and abort — a harness ordering problem, not the export-ABI defect the test
exists to catch.

Fix, in the harness only:

- Detect ASan by asking the dynamic linker what the already-built
  `eshkol-run` binary depends on (`ldd ... | grep libasan\|libclang_rt.asan`),
  rather than a compiler-specific flag or an environment variable that could
  drift out of sync with the actual build. No-op when ASan is not linked in,
  and on macOS (no `ldd`, and the lane doesn't exist there).
- C harness: `LD_PRELOAD` the exact ASan runtime path resolved above ahead of
  the harness process, so it stays a real ASan-instrumented consumer — the
  correct-ordering fix, not a disabled check.
- ctypes (Python) leg: preloading libasan into a live CPython process is a
  materially different risk (its own small-object allocator was not built
  against ASan's interceptors), so for that child only,
  `ASAN_OPTIONS=verify_asan_link_order=0` keeps every ABI assertion live
  while dropping just the link-order verification, with a comment explaining
  why it's scoped to this one child.

## Files changed

| File | Change |
| --- | --- |
| 92 files under `scripts/*.sh`, `scripts/lib/test_isolation.sh`, `tests/**/*.sh` | `#!/bin/bash` → `#!/usr/bin/env bash` |
| `tests/fixed_point/run_fixed_point_tests.sh` | shebang only (also the file whose bad interpreter failed `fixedpoint_runner_failures`) |
| `tests/fixed_point/test_runner_failures.sh` | shebang + fake-cc stub no longer symlinks `/usr/bin/true` |
| `tests/toolchain/ffi_boundary_fail_open_test.sh` | `/bin/echo` → `echo` at every spawn/capture call site; comment/message wording updated to match |
| `tests/v1_2_edge_cases/subprocess_shell_argv_test.sh` | `/bin/echo`/`/bin/sleep`/`/bin/kill` → bare names; availability guard `-x /bin/...` → `command -v` |
| `tests/vm/vm_system_test.esk` | `/bin/echo` → `echo` (VM `process-spawn`, env `#f` ⇒ already an `execvp` path) |
| `tests/stress/stress_fd_exhaustion.esk` | `/bin/echo` → `echo` in the 5000-iteration spawn loop |
| `tests/toolchain/transitive_ffi_link_test.sh` | `/bin/echo` → `echo` in an unreachable (`if #f ...`) branch, for consistency |
| `scripts/run_icc_smoke.sh` | `/bin/echo`/`/bin/sleep` → bare names in two embedded `.esk` probes |
| `tests/toolchain/shared_lib_abi_test.sh` | new ASan detection + `LD_PRELOAD`/`ASAN_OPTIONS` wrapper around the C and ctypes harness invocations |

## Verification

ICC impact analysis (`icc impact-analysis --since ec8ec7f4`) confirms the
change graph stays entirely inside `scripts/` and `tests/`: 63 impacted
paths, all test/script files, none in `lib/`, `inc/`, or `exe/`.

### atlas (macOS arm64, local)

- Fresh build (`-DCMAKE_BUILD_TYPE=Release -DESHKOL_REQUIRED_LLVM_MAJOR=21
  -DESHKOL_XLA_ENABLED=OFF -DESHKOL_GPU_ENABLED=OFF -DESHKOL_BUILD_TESTS=ON`,
  agent FFI ON): clean.
- `ctest --test-dir build -R
  'fixedpoint_runner_failures|ffi_boundary_fail_open_test|eshkol-pkg-subprocess-timeout'`:
  3/3 PASS.
- `bash scripts/run_v1_2_edge_cases_tests.sh`: 100/100 PASS, including
  `shared_lib_export_abi_test` and `subprocess_shell_argv_test` (the ASan
  wrapper is a correct no-op on Darwin, where `ldd` doesn't exist and the
  lane doesn't run).

### xavier (linux aarch64, NixOS) — mirrors the `linux-arm64` lane

Fresh clone + build inside `nix-shell -p llvmPackages_21.{clang,llvm,lld}
cmake ninja git python3 nodejs gcc pkg-config openssl curl sqlite zlib
libffi libxml2 ncurses libpng libjpeg libwebp readline pcre2` (the lane's
own pure-env recipe), same cmake args as the mesh lane plus
`CC=clang CXX=clang++`:

- `ctest --test-dir build`: **140/140 passed, 0 failed** (was 138/140 on
  this ref before the fix — `ffi_boundary_fail_open_test` and
  `fixedpoint_runner_failures` both now PASS; `eshkol-pkg-subprocess-timeout`
  was already passing).
- `bash scripts/run_v1_2_edge_cases_tests.sh`: **100/100 passed, 0 failed**,
  including `subprocess_shell_argv_test`.

### old-donkey (linux x86_64) — ASan/UBSan build, mirrors `linux-x64-asan`

Fresh clone + build with `-DESHKOL_ENABLE_ASAN=ON -DESHKOL_ENABLE_UBSAN=ON`,
`ASAN_OPTIONS=detect_leaks=0:halt_on_error=1:allocator_may_return_null=1`
(the lane's own env), default `cc`/`c++` (GCC 15, matching the node's own
gate build):

- `tests/toolchain/shared_lib_abi_test.sh` direct: **PASS** at both `-O0`
  and `-O2` — no ASan link-order abort, C harness and ctypes harness both
  agree, negative control still correctly observes the internal-ABI
  corruption.
- `bash scripts/run_v1_2_edge_cases_tests.sh` (BUILD_DIR=build-asan):
  **100/100 passed, 0 failed**, including `shared_lib_export_abi_test`.

## Before / after

| Lane | Before (rc-v134-ec8ec7f4) | After |
| --- | --- | --- |
| linux-arm64 (xavier) | ctest fail, rc=8 — `ffi_boundary_fail_open_test` + `fixedpoint_runner_failures` (138/140) | ctest 140/140; edge-case suite 100/100 |
| linux-x64-asan (old-donkey) | lane fail, rc=1 — `shared_lib_export_abi_test` (`shared_lib_abi_test: -O0: C harness rejected the library ABI`, ASan link-order abort) | `shared_lib_abi_test.sh` PASS at -O0/-O2; edge-case suite 100/100 |

Not merging — opened for review per the release-candidate hardening process.
