### PR TITLE
fix(numeric): complex transcendentals and exact inexact->exact

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2081,6 +2081,7 @@ endif()
 set(ESHKOL_RUNTIME_CORE_SRC
   lib/core/ad_tape_builtins.c
   lib/core/bignum.cpp
+  lib/core/complex_math.cpp
   lib/core/rational.cpp
   lib/core/i128_runtime.cpp
   lib/core/runtime.cpp

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -2126,7 +2126,7 @@ All standard arithmetic operators (`+`, `-`, `*`, `/`, `quotient`, `remainder`, 
 
 #### Conversion
 - `(exact->inexact n)` — Converts to double (may lose precision for large bignums)
-- `(inexact->exact n)` — Converts double to nearest integer
+- `(inexact->exact n)` — Returns the operand's exact value: an exact integer for a whole double (a bignum when it exceeds int64), a rational otherwise. `(inexact->exact 0.1)` is `3602879701896397/36028797018963968`, the exact value of that double, so `(exact->inexact (inexact->exact x))` reproduces `x` bit-for-bit
 - `(number->string n)` — Works correctly with bignums (not pointer bits)
 - `(string->number s)` — Parses large integers as bignums when they exceed int64 range
 
@@ -2170,6 +2170,16 @@ First-class complex number type with full AD support.
 
 ### Arithmetic
 All standard operators (`+`, `-`, `*`, `/`) work with complex numbers. Division uses Smith's formula for numerical stability with large magnitudes.
+
+### Transcendental Functions
+`sqrt`, `exp`, `log`, `exp2`, `log2`, `log10`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh` and `expt` all accept complex arguments, on the principal branch with C99 Annex G branch cuts. `floor`, `ceiling`, `truncate`, `round`, `cbrt` and `abs` are real-domain only and signal a catchable type error on a complex (use `magnitude` for `|z|`).
+
+```scheme
+(sqrt (make-rectangular -1.0 0.0))    ; => 0.0+1.0i
+(exp (make-rectangular 0.0 3.14159))  ; => -1.0+0.0i (approximately)
+(expt (make-rectangular 0.0 1.0)
+      (make-rectangular 0.0 1.0))     ; => 0.20787957635076193 (i^i)
+```
 
 ```scheme
 (define z1 (make-rectangular 3.0 4.0))

--- a/docs/COMPLETE_LANGUAGE_SPECIFICATION.md
+++ b/docs/COMPLETE_LANGUAGE_SPECIFICATION.md
@@ -3073,7 +3073,7 @@ exact    exact     exact    inexact   inexact
 1. Arithmetic on two exact values produces an exact result when mathematically defined.
 2. Arithmetic involving at least one inexact operand produces an inexact result.
 3. `exact->inexact` converts to the nearest IEEE 754 double. Precision loss is possible for bignums with magnitude > 2^53.
-4. `inexact->exact` converts a double to the nearest rational representation via continued fraction expansion.
+4. `inexact->exact` returns the operand's EXACT value, never a nearby one. A finite IEEE 754 double is exactly `mantissa * 2^exponent` with a 53-bit integer mantissa, and that is what the conversion returns: `(inexact->exact 0.1)` is `3602879701896397/36028797018963968`. A whole-valued double becomes an exact integer (promoting to a bignum past int64 range, so `(inexact->exact 1e300)` is an exact 301-digit integer); a fractional one becomes a rational with a power-of-two denominator (subnormals need a bignum denominator, up to 2^1074). The conversion is therefore lossless in both directions: `(exact->inexact (inexact->exact x))` reproduces `x` bit-for-bit for every finite `x`. Infinities and NaN have no exact value and signal an error.
 
 #### 14.3.2 Mixed-Exactness Dispatch
 
@@ -3186,7 +3186,28 @@ result_imag = (b - a * r) / denom
 - `(real-part z)` -- Returns the real component as a double.
 - `(imag-part z)` -- Returns the imaginary component as a double.
 
-#### 15.3.3 Promotion from Real
+#### 15.3.3 Transcendental Functions
+
+The math builtins extend to the complex domain on the principal branch, with
+the branch cuts of C99 Annex G (signed zero selects the branch, so
+`(sqrt (make-rectangular -1.0 0.0))` is `0.0+1.0i` and
+`(sqrt (make-rectangular -1.0 -0.0))` is `0.0-1.0i`):
+
+`sqrt`, `exp`, `log`, `exp2`, `log2`, `log10`, `sin`, `cos`, `tan`, `asin`,
+`acos`, `atan`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, and `expt`
+with a complex base, a complex exponent, or both.
+
+The remaining math builtins are defined on the reals only — `floor`,
+`ceiling`, `truncate`, `round`, `cbrt` and `abs` (the complex counterpart of
+`abs` is `magnitude`). Applying one to a complex signals a catchable type
+error naming the procedure; it never coerces.
+
+**Implementation:** one shared core, `inc/eshkol/core/complex_math.h`. The
+native runtime exposes each function as `eshkol_complex_<name>` for the LLVM
+back end to call, and the bytecode VM compiles the same header in, so both
+engines return identical bits.
+
+#### 15.3.4 Promotion from Real
 
 When a real number is used in a context requiring a complex (e.g., arithmetic with a complex operand), it is promoted to complex with `imag = 0.0`. The `convertToComplex` codegen path handles INT64, DOUBLE, and HEAP_PTR (bignum) inputs, converting bignums via `eshkol_bignum_to_double` before constructing the complex.
 

--- a/inc/eshkol/backend/complex_codegen.h
+++ b/inc/eshkol/backend/complex_codegen.h
@@ -27,6 +27,8 @@
 
 #include <llvm/IR/Value.h>
 
+#include <string>
+
 namespace eshkol {
 
 class CodegenContext;
@@ -148,6 +150,45 @@ public:
     llvm::Value* complexAngle(llvm::Value* z);
 
     /**
+     * Map an Eshkol math-builtin name to the complex runtime it dispatches to.
+     *
+     * Returns the `eshkol_complex_<suffix>` suffix for every builtin whose
+     * complex extension is defined (principal branch, C99 Annex G), or
+     * nullptr for the real-domain-only builtins (`floor`, `ceiling`,
+     * `truncate`, `round`, `fabs`, `cbrt`). A nullptr answer means the caller
+     * must raise a typed error — it must never fall through to the scalar
+     * path, which would read the complex heap pointer as a double.
+     *
+     * @param func_name Builtin name as it appears in the dispatch table.
+     * @return Runtime suffix, or nullptr when there is no complex extension.
+     */
+    static const char* complexRuntimeSuffix(const std::string& func_name);
+
+    /**
+     * Emit a call to a unary complex runtime function.
+     *
+     * Spills @p z to a stack slot, calls
+     * `void eshkol_complex_<suffix>(const complex*, complex*)`, and reloads
+     * the result. The runtime is the shared core in
+     * `<eshkol/core/complex_math.h>`, which the VM also uses, so both engines
+     * produce identical bits.
+     *
+     * @param z Operand complex-number struct value.
+     * @param suffix Runtime suffix from complexRuntimeSuffix().
+     * @return Complex-number struct value holding the result.
+     */
+    llvm::Value* complexUnaryRuntime(llvm::Value* z, const char* suffix);
+
+    /**
+     * Emit a call to the binary complex runtime `eshkol_complex_pow`.
+     *
+     * @param a Base.
+     * @param b Exponent.
+     * @return Complex-number struct value holding a^b (principal branch).
+     */
+    llvm::Value* complexPow(llvm::Value* a, llvm::Value* b);
+
+    /**
      * Complex exponential: exp(a+bi) = exp(a)(cos(b) + i*sin(b))
      */
     llvm::Value* complexExp(llvm::Value* z);
@@ -192,8 +233,6 @@ private:
     llvm::Function* getSqrtIntrinsic();
     llvm::Function* getSinIntrinsic();
     llvm::Function* getCosIntrinsic();
-    llvm::Function* getExpIntrinsic();
-    llvm::Function* getLogIntrinsic();
     llvm::Function* getAtan2Intrinsic();
 };
 

--- a/inc/eshkol/core/complex_math.h
+++ b/inc/eshkol/core/complex_math.h
@@ -1,0 +1,306 @@
+/**
+ * @file complex_math.h
+ * @brief Pure complex transcendental core, shared by the native runtime and
+ *        the bytecode VM.
+ *
+ * This header is the SINGLE source of truth for every complex-domain
+ * transcendental Eshkol implements. Both engines include it:
+ *
+ *   * the native runtime (`lib/core/complex_math.cpp`) wraps each function in
+ *     an `extern "C"` symbol (`eshkol_complex_sqrt`, ...) that the LLVM
+ *     back end emits calls to;
+ *   * the bytecode VM (`lib/backend/vm_complex.c`) calls the inline functions
+ *     directly.
+ *
+ * Because both engines evaluate the same expressions in the same order, the
+ * two back ends agree bit-for-bit — engine parity is a property of the code
+ * layout, not of a hand-maintained pair of implementations that can drift.
+ * This mirrors the arrangement already used for i128 (`<eshkol/core/i128.h>`).
+ *
+ * Everything is written in the C/C++ common subset over plain `double` pairs:
+ * no `_Complex`, no `std::complex`, so a C translation unit and a C++
+ * translation unit both compile it without a language-specific shim.
+ *
+ * Branch cuts follow C99 Annex G / R7RS 6.2.6 (the principal branch):
+ *   * `sqrt`  — cut along the negative real axis, continuous from above;
+ *   * `log`   — cut along the negative real axis, imaginary part in (-pi, pi];
+ *   * `asin`/`acos`  — cuts outside [-1, 1] on the real axis;
+ *   * `atan`  — cuts outside [-i, i] on the imaginary axis.
+ * Signed zero is respected where it selects the branch, so
+ * `sqrt(-1 + 0i) = 0 + 1i` and `sqrt(-1 - 0i) = 0 - 1i`.
+ *
+ * Copyright (C) Tsotchke Corporation. MIT License.
+ */
+
+#ifndef ESHKOL_CORE_COMPLEX_MATH_H
+#define ESHKOL_CORE_COMPLEX_MATH_H
+
+#include <math.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief A complex value as a bare pair of IEEE-754 doubles.
+ *
+ * Layout-compatible with `eshkol_complex_number_t` (native runtime) and
+ * `VmComplex` (VM): both are `{ double real; double imag; }` with no padding,
+ * so a pointer to either can be reinterpreted as this type.
+ */
+typedef struct eshkol_cpx {
+    double re;
+    double im;
+} eshkol_cpx;
+
+/** @brief Build a complex value from its two components. */
+static inline eshkol_cpx eshkol_cpx_make(double re, double im) {
+    eshkol_cpx z;
+    z.re = re;
+    z.im = im;
+    return z;
+}
+
+/* ─────────────────────────────── arithmetic ─────────────────────────────── */
+
+/** @brief Sum of two complex values. */
+static inline eshkol_cpx eshkol_cpx_add(eshkol_cpx a, eshkol_cpx b) {
+    return eshkol_cpx_make(a.re + b.re, a.im + b.im);
+}
+
+/** @brief Difference of two complex values. */
+static inline eshkol_cpx eshkol_cpx_sub(eshkol_cpx a, eshkol_cpx b) {
+    return eshkol_cpx_make(a.re - b.re, a.im - b.im);
+}
+
+/** @brief Product of two complex values: (ac - bd) + (ad + bc)i. */
+static inline eshkol_cpx eshkol_cpx_mul(eshkol_cpx a, eshkol_cpx b) {
+    return eshkol_cpx_make(a.re * b.re - a.im * b.im,
+                           a.re * b.im + a.im * b.re);
+}
+
+/**
+ * @brief Quotient of two complex values via Smith's formula.
+ *
+ * Smith's algorithm scales by the larger denominator component first, so the
+ * intermediate `c*c + d*d` that would overflow for operands near DBL_MAX is
+ * never formed. This matches the division already documented for `/` in
+ * COMPLETE_LANGUAGE_SPECIFICATION.md 15.2.2.
+ */
+static inline eshkol_cpx eshkol_cpx_div(eshkol_cpx a, eshkol_cpx b) {
+    double r, den;
+    if (fabs(b.im) >= fabs(b.re)) {
+        if (b.im == 0.0) {
+            /* Both components zero: division by exact complex zero. Let IEEE
+             * produce the infinity/NaN pattern instead of inventing one. */
+            return eshkol_cpx_make(a.re / b.re, a.im / b.re);
+        }
+        r = b.re / b.im;
+        den = b.re * r + b.im;
+        return eshkol_cpx_make((a.re * r + a.im) / den,
+                               (a.im * r - a.re) / den);
+    }
+    r = b.im / b.re;
+    den = b.im * r + b.re;
+    return eshkol_cpx_make((a.re + a.im * r) / den,
+                           (a.im - a.re * r) / den);
+}
+
+/** @brief Scale a complex value by a real factor. */
+static inline eshkol_cpx eshkol_cpx_scale(eshkol_cpx z, double s) {
+    return eshkol_cpx_make(z.re * s, z.im * s);
+}
+
+/** @brief Multiply by i: i(a+bi) = -b + ai. */
+static inline eshkol_cpx eshkol_cpx_mul_i(eshkol_cpx z) {
+    return eshkol_cpx_make(-z.im, z.re);
+}
+
+/** @brief Divide by i, i.e. multiply by -i: -i(a+bi) = b - ai. */
+static inline eshkol_cpx eshkol_cpx_div_i(eshkol_cpx z) {
+    return eshkol_cpx_make(z.im, -z.re);
+}
+
+/** @brief Overflow-safe magnitude |a+bi|, computed with `hypot`. */
+static inline double eshkol_cpx_abs(eshkol_cpx z) {
+    return hypot(z.re, z.im);
+}
+
+/** @brief Principal argument arg(a+bi) = atan2(b, a), in (-pi, pi]. */
+static inline double eshkol_cpx_arg(eshkol_cpx z) {
+    return atan2(z.im, z.re);
+}
+
+/* ────────────────────────── roots, exp and log ─────────────────────────── */
+
+/**
+ * @brief Principal square root.
+ *
+ * Uses the half-angle identity in its numerically stable algebraic form
+ * (C99 Annex G): one `hypot`, one `sqrt` and one division, with the branch
+ * selected by `copysign` on the imaginary part. Computing it in polar form
+ * instead (`sqrt(r) * (cos(t/2) + i sin(t/2))`) loses the exact zero: for
+ * `-1 + 0i` the polar route returns `6.1e-17 + 1i` where the exact principal
+ * value — and what ESHKOL_LANGUAGE_GUIDE.md documents — is `0 + 1i`.
+ */
+static inline eshkol_cpx eshkol_cpx_sqrt(eshkol_cpx z) {
+    double t;
+    if (z.re == 0.0 && z.im == 0.0) {
+        /* sqrt(+-0 +- 0i) = +0 with the imaginary sign preserved. */
+        return eshkol_cpx_make(0.0, z.im);
+    }
+    t = sqrt((fabs(z.re) + hypot(z.re, z.im)) * 0.5);
+    if (z.re >= 0.0) {
+        return eshkol_cpx_make(t, z.im / (2.0 * t));
+    }
+    return eshkol_cpx_make(fabs(z.im) / (2.0 * t), copysign(t, z.im));
+}
+
+/** @brief Complex exponential: exp(a+bi) = exp(a)(cos b + i sin b). */
+static inline eshkol_cpx eshkol_cpx_exp(eshkol_cpx z) {
+    double ea = exp(z.re);
+    return eshkol_cpx_make(ea * cos(z.im), ea * sin(z.im));
+}
+
+/** @brief Principal natural logarithm: log|z| + i arg(z). */
+static inline eshkol_cpx eshkol_cpx_log(eshkol_cpx z) {
+    return eshkol_cpx_make(log(hypot(z.re, z.im)), atan2(z.im, z.re));
+}
+
+/** @brief Base-2 logarithm: log(z) / log(2). */
+static inline eshkol_cpx eshkol_cpx_log2(eshkol_cpx z) {
+    return eshkol_cpx_scale(eshkol_cpx_log(z), 1.0 / M_LN2);
+}
+
+/** @brief Base-10 logarithm: log(z) / log(10). */
+static inline eshkol_cpx eshkol_cpx_log10(eshkol_cpx z) {
+    return eshkol_cpx_scale(eshkol_cpx_log(z), 1.0 / M_LN10);
+}
+
+/** @brief Base-2 exponential: exp(z * log 2). */
+static inline eshkol_cpx eshkol_cpx_exp2(eshkol_cpx z) {
+    return eshkol_cpx_exp(eshkol_cpx_scale(z, M_LN2));
+}
+
+/** @brief Principal power: a^b = exp(b log a), with 0^0 = 1 per R7RS. */
+static inline eshkol_cpx eshkol_cpx_pow(eshkol_cpx a, eshkol_cpx b) {
+    if (a.re == 0.0 && a.im == 0.0) {
+        if (b.re == 0.0 && b.im == 0.0) return eshkol_cpx_make(1.0, 0.0);
+        return eshkol_cpx_make(0.0, 0.0);
+    }
+    return eshkol_cpx_exp(eshkol_cpx_mul(b, eshkol_cpx_log(a)));
+}
+
+/* ──────────────────────────── circular trig ────────────────────────────── */
+
+/** @brief sin(a+bi) = sin a cosh b + i cos a sinh b. */
+static inline eshkol_cpx eshkol_cpx_sin(eshkol_cpx z) {
+    return eshkol_cpx_make(sin(z.re) * cosh(z.im), cos(z.re) * sinh(z.im));
+}
+
+/** @brief cos(a+bi) = cos a cosh b - i sin a sinh b. */
+static inline eshkol_cpx eshkol_cpx_cos(eshkol_cpx z) {
+    return eshkol_cpx_make(cos(z.re) * cosh(z.im), -sin(z.re) * sinh(z.im));
+}
+
+/**
+ * @brief tan(a+bi) = (sin 2a + i sinh 2b) / (cos 2a + cosh 2b).
+ *
+ * The double-angle form is used rather than sin(z)/cos(z): its denominator is
+ * a sum of a bounded and a positive term, so it never cancels, and it stays
+ * finite for large |b| where sin(z) and cos(z) both overflow.
+ */
+static inline eshkol_cpx eshkol_cpx_tan(eshkol_cpx z) {
+    double den;
+    if (fabs(z.im) > 350.0) {
+        /* cosh(2b) overflows; tan converges to +-i to well beyond 1 ulp. */
+        return eshkol_cpx_make(0.0, z.im > 0.0 ? 1.0 : -1.0);
+    }
+    den = cos(2.0 * z.re) + cosh(2.0 * z.im);
+    return eshkol_cpx_make(sin(2.0 * z.re) / den, sinh(2.0 * z.im) / den);
+}
+
+/* ─────────────────────────── hyperbolic trig ───────────────────────────── */
+
+/** @brief sinh(a+bi) = sinh a cos b + i cosh a sin b. */
+static inline eshkol_cpx eshkol_cpx_sinh(eshkol_cpx z) {
+    return eshkol_cpx_make(sinh(z.re) * cos(z.im), cosh(z.re) * sin(z.im));
+}
+
+/** @brief cosh(a+bi) = cosh a cos b + i sinh a sin b. */
+static inline eshkol_cpx eshkol_cpx_cosh(eshkol_cpx z) {
+    return eshkol_cpx_make(cosh(z.re) * cos(z.im), sinh(z.re) * sin(z.im));
+}
+
+/**
+ * @brief tanh(a+bi) = (sinh 2a + i sin 2b) / (cosh 2a + cos 2b).
+ *
+ * Double-angle form, stable for the same reason as ::eshkol_cpx_tan.
+ */
+static inline eshkol_cpx eshkol_cpx_tanh(eshkol_cpx z) {
+    double den;
+    if (fabs(z.re) > 350.0) {
+        return eshkol_cpx_make(z.re > 0.0 ? 1.0 : -1.0, 0.0);
+    }
+    den = cosh(2.0 * z.re) + cos(2.0 * z.im);
+    return eshkol_cpx_make(sinh(2.0 * z.re) / den, sin(2.0 * z.im) / den);
+}
+
+/* ────────────────────────── inverse functions ──────────────────────────── */
+
+/** @brief asin(z) = -i log(iz + sqrt(1 - z^2)). */
+static inline eshkol_cpx eshkol_cpx_asin(eshkol_cpx z) {
+    eshkol_cpx one = eshkol_cpx_make(1.0, 0.0);
+    eshkol_cpx root = eshkol_cpx_sqrt(eshkol_cpx_sub(one, eshkol_cpx_mul(z, z)));
+    eshkol_cpx inner = eshkol_cpx_add(eshkol_cpx_mul_i(z), root);
+    return eshkol_cpx_div_i(eshkol_cpx_log(inner));
+}
+
+/** @brief acos(z) = pi/2 - asin(z). */
+static inline eshkol_cpx eshkol_cpx_acos(eshkol_cpx z) {
+    eshkol_cpx s = eshkol_cpx_asin(z);
+    return eshkol_cpx_make(M_PI_2 - s.re, -s.im);
+}
+
+/** @brief atan(z) = (i/2)(log(1 - iz) - log(1 + iz)). */
+static inline eshkol_cpx eshkol_cpx_atan(eshkol_cpx z) {
+    eshkol_cpx one = eshkol_cpx_make(1.0, 0.0);
+    eshkol_cpx iz = eshkol_cpx_mul_i(z);
+    eshkol_cpx lo = eshkol_cpx_log(eshkol_cpx_sub(one, iz));
+    eshkol_cpx hi = eshkol_cpx_log(eshkol_cpx_add(one, iz));
+    return eshkol_cpx_scale(eshkol_cpx_mul_i(eshkol_cpx_sub(lo, hi)), 0.5);
+}
+
+/** @brief asinh(z) = log(z + sqrt(z^2 + 1)). */
+static inline eshkol_cpx eshkol_cpx_asinh(eshkol_cpx z) {
+    eshkol_cpx one = eshkol_cpx_make(1.0, 0.0);
+    eshkol_cpx root = eshkol_cpx_sqrt(eshkol_cpx_add(eshkol_cpx_mul(z, z), one));
+    return eshkol_cpx_log(eshkol_cpx_add(z, root));
+}
+
+/**
+ * @brief acosh(z) = log(z + sqrt(z+1) sqrt(z-1)).
+ *
+ * The product of two separate square roots (rather than `sqrt(z^2 - 1)`) is
+ * what places the branch cut on (-inf, 1] as C99 Annex G requires.
+ */
+static inline eshkol_cpx eshkol_cpx_acosh(eshkol_cpx z) {
+    eshkol_cpx one = eshkol_cpx_make(1.0, 0.0);
+    eshkol_cpx rp = eshkol_cpx_sqrt(eshkol_cpx_add(z, one));
+    eshkol_cpx rm = eshkol_cpx_sqrt(eshkol_cpx_sub(z, one));
+    return eshkol_cpx_log(eshkol_cpx_add(z, eshkol_cpx_mul(rp, rm)));
+}
+
+/** @brief atanh(z) = (log(1 + z) - log(1 - z)) / 2. */
+static inline eshkol_cpx eshkol_cpx_atanh(eshkol_cpx z) {
+    eshkol_cpx one = eshkol_cpx_make(1.0, 0.0);
+    eshkol_cpx hi = eshkol_cpx_log(eshkol_cpx_add(one, z));
+    eshkol_cpx lo = eshkol_cpx_log(eshkol_cpx_sub(one, z));
+    return eshkol_cpx_scale(eshkol_cpx_sub(hi, lo), 0.5);
+}
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
+#endif /* ESHKOL_CORE_COMPLEX_MATH_H */

--- a/inc/eshkol/core/complex_math.h
+++ b/inc/eshkol/core/complex_math.h
@@ -37,6 +37,26 @@
 
 #include <math.h>
 
+/* MSVC/clang-cl only expose the POSIX math constants (M_PI, M_LN2, ...)
+ * when _USE_MATH_DEFINES is defined before <math.h> is first included, and
+ * that define is out of this header's control (it comes from whichever
+ * translation unit includes us first). Guard each constant this header
+ * actually uses so both engines (native runtime + bytecode VM) build on
+ * Windows without relying on caller-side defines. Mirrors the M_PI/M_E
+ * guard already used for the same reason in lib/quantum/quantum_rng.c.
+ */
+#ifndef M_LN2
+#define M_LN2 0.693147180559945309417232121458176568
+#endif
+
+#ifndef M_LN10
+#define M_LN10 2.302585092994045684017991454684364208
+#endif
+
+#ifndef M_PI_2
+#define M_PI_2 1.570796326794896619231321691639751442
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/inc/eshkol/core/rational.h
+++ b/inc/eshkol/core/rational.h
@@ -218,6 +218,39 @@ int64_t eshkol_rational_truncate(void* r);
  */
 int64_t eshkol_rational_round(void* r);
 
+/**
+ * @brief Exact IEEE-754 double to rational (R7RS `inexact->exact`).
+ *
+ * A finite double is exactly `mantissa * 2^exponent`, and this returns that
+ * value — never a nearby approximation. `(inexact->exact 0.1)` is
+ * 3602879701896397/36028797018963968, as documented in
+ * ESHKOL_LANGUAGE_GUIDE.md; `(exact->inexact (inexact->exact x))` reproduces
+ * `x` bit-for-bit for every finite `x`, subnormals included. Whole values come
+ * back with denominator 1 and a bignum numerator when they exceed int64.
+ *
+ * @param arena Arena to allocate the result from.
+ * @param d Value to convert; must be finite (a non-finite input reports an
+ *          error and yields 0/1, since infinities and NaN have no exact value).
+ * @return Newly allocated rational pointer.
+ */
+void* eshkol_double_to_rational(void* arena, double d);
+
+/**
+ * @brief Exact `inexact->exact` producing a tagged value.
+ *
+ * The entry point both back ends call. Exactness conversion changes the value's
+ * SHAPE — a whole double becomes an exact integer (int64, or a bignum beyond
+ * int64 range), a fractional one becomes a rational — so the choice is made
+ * here once rather than duplicated in each engine's dispatch, where an
+ * `fptosi` on a value past 2^63 was undefined behaviour.
+ *
+ * @param arena Arena to allocate any heap result from.
+ * @param d Value to convert.
+ * @param out Receives the exact result.
+ */
+void eshkol_double_to_exact_tagged(void* arena, double d,
+                                   eshkol_tagged_value_t* out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/backend/arithmetic_codegen.cpp
+++ b/lib/backend/arithmetic_codegen.cpp
@@ -2201,6 +2201,24 @@ llvm::Value* ArithmeticCodegen::abs(llvm::Value* operand) {
             llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_DOUBLE));
 
         llvm::Function* func = ctx_.builder().GetInsertBlock()->getParent();
+
+        // Task #113: R7RS defines `abs` on the reals; the complex counterpart
+        // is `magnitude`. Without this guard a complex operand fell through to
+        // the int64 arm below and printed its heap address
+        // (`(abs (make-rectangular 3.0 4.0))` => 4698660432). Raise instead —
+        // emitRaise closes the block with `unreachable`, so the arms below
+        // keep their existing PHI structure untouched.
+        {
+            llvm::BasicBlock* abs_cpx_bb = llvm::BasicBlock::Create(ctx_.context(), "abs_complex", func);
+            llvm::BasicBlock* abs_real_bb = llvm::BasicBlock::Create(ctx_.context(), "abs_real", func);
+            llvm::Value* is_complex = ctx_.builder().CreateICmpEQ(base_type,
+                llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_COMPLEX));
+            ctx_.builder().CreateCondBr(is_complex, abs_cpx_bb, abs_real_bb);
+            ctx_.builder().SetInsertPoint(abs_cpx_bb);
+            ctx_.emitRaise("abs: argument is a complex number and abs is defined "
+                           "on the reals only (use magnitude for |z|)");
+            ctx_.builder().SetInsertPoint(abs_real_bb);
+        }
         llvm::BasicBlock* heap_bb = llvm::BasicBlock::Create(ctx_.context(), "abs_heap", func);
         llvm::BasicBlock* check_dbl = llvm::BasicBlock::Create(ctx_.context(), "abs_check_dbl", func);
         llvm::BasicBlock* double_bb = llvm::BasicBlock::Create(ctx_.context(), "abs_double", func);
@@ -2499,16 +2517,37 @@ llvm::Value* ArithmeticCodegen::extractAsDouble(llvm::Value* tagged_val) {
     ctx_.builder().CreateBr(merge_bb);
     non_numeric_bb = ctx_.builder().GetInsertBlock();
 
-    // Int path: SIToFP
+    // Int path: SIToFP.
+    //
+    // Task #113 — this is the last arm of the dispatch, so before the guard
+    // below it was reached by EVERY tag the arms above did not claim, not just
+    // ESHKOL_VALUE_INT64. A complex (tag 7), a port, a bool — all had their
+    // 64-bit payload sign-converted to a double, which for the pointer-carrying
+    // tags means an address is read as a number and leaked to the program
+    // (`(abs (make-rectangular 3.0 4.0))` returned 4698660432). Only a genuine
+    // INT64 is converted now; anything else falls to the same 0.0 the
+    // non-numeric heap arm already yields, so no payload is ever reinterpreted.
     ctx_.builder().SetInsertPoint(int_bb);
+    llvm::Value* is_int64 = ctx_.builder().CreateICmpEQ(base_type,
+        llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_INT64));
+    llvm::BasicBlock* real_int_bb = llvm::BasicBlock::Create(ctx_.context(), "ead_real_int", func);
+    llvm::BasicBlock* non_numeric_tag_bb = llvm::BasicBlock::Create(ctx_.context(), "ead_non_numeric_tag", func);
+    ctx_.builder().CreateCondBr(is_int64, real_int_bb, non_numeric_tag_bb);
+
+    ctx_.builder().SetInsertPoint(real_int_bb);
     llvm::Value* int_val = tagged_.unpackInt64(tagged_val);
     llvm::Value* int_as_dbl = ctx_.builder().CreateSIToFP(int_val, ctx_.doubleType());
     ctx_.builder().CreateBr(merge_bb);
-    int_bb = ctx_.builder().GetInsertBlock();
+    real_int_bb = ctx_.builder().GetInsertBlock();
+
+    ctx_.builder().SetInsertPoint(non_numeric_tag_bb);
+    llvm::Value* tag_zero_fallback = llvm::ConstantFP::get(ctx_.doubleType(), 0.0);
+    ctx_.builder().CreateBr(merge_bb);
+    non_numeric_tag_bb = ctx_.builder().GetInsertBlock();
 
     // Merge
     ctx_.builder().SetInsertPoint(merge_bb);
-    llvm::PHINode* phi = ctx_.builder().CreatePHI(ctx_.doubleType(), 8, "as_double");
+    llvm::PHINode* phi = ctx_.builder().CreatePHI(ctx_.doubleType(), 9, "as_double");
     phi->addIncoming(ad_val, ad_bb);
     phi->addIncoming(dual_val, dual_bb);
     phi->addIncoming(dbl_val, dbl_bb);
@@ -2516,7 +2555,8 @@ llvm::Value* ArithmeticCodegen::extractAsDouble(llvm::Value* tagged_val) {
     phi->addIncoming(bn_dbl, actual_bignum_bb);
     phi->addIncoming(twr_c0_val, ead_taylor_bb);
     phi->addIncoming(zero_fallback, non_numeric_bb);
-    phi->addIncoming(int_as_dbl, int_bb);
+    phi->addIncoming(int_as_dbl, real_int_bb);
+    phi->addIncoming(tag_zero_fallback, non_numeric_tag_bb);
     return phi;
 }
 

--- a/lib/backend/arithmetic_codegen.cpp
+++ b/lib/backend/arithmetic_codegen.cpp
@@ -2877,6 +2877,32 @@ llvm::Value* ArithmeticCodegen::pow(llvm::Value* base, llvm::Value* exponent) {
         llvm::BasicBlock* pow_twr_exit = ctx_.builder().GetInsertBlock();
         ctx_.builder().SetInsertPoint(pow_after_taylor);
 
+        // Task #113 — complex `expt`, on the same footing as complex +/-/*//.
+        //
+        // The complex case used to live in llvm_codegen.cpp's `expt` branch,
+        // where it tested only the BASE and then read the exponent with
+        // extractDoubleFromTagged: `(expt i i)` reinterpreted the exponent's
+        // heap pointer and returned 1 instead of e^(-pi/2). Promoting both
+        // operands and calling the shared runtime handles every mixture —
+        // complex base, complex exponent, or both — with one branch.
+        llvm::BasicBlock* pow_complex = llvm::BasicBlock::Create(ctx_.context(), "pow_complex", func);
+        llvm::BasicBlock* pow_after_complex = llvm::BasicBlock::Create(ctx_.context(), "pow_after_complex", func);
+        llvm::Value* pow_base_is_cpx = ctx_.builder().CreateICmpEQ(base_base,
+            llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_COMPLEX));
+        llvm::Value* pow_exp_is_cpx = ctx_.builder().CreateICmpEQ(exp_base,
+            llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_COMPLEX));
+        ctx_.builder().CreateCondBr(
+            ctx_.builder().CreateOr(pow_base_is_cpx, pow_exp_is_cpx),
+            pow_complex, pow_after_complex);
+        ctx_.builder().SetInsertPoint(pow_complex);
+        llvm::Value* pow_base_z = convertToComplex(base, pow_base_is_cpx, base_base);
+        llvm::Value* pow_exp_z = convertToComplex(exponent, pow_exp_is_cpx, exp_base);
+        llvm::Value* pow_cpx = complex_.packComplexToTagged(
+            complex_.complexPow(pow_base_z, pow_exp_z));
+        ctx_.builder().CreateBr(merge);
+        llvm::BasicBlock* pow_cpx_exit = ctx_.builder().GetInsertBlock();
+        ctx_.builder().SetInsertPoint(pow_after_complex);
+
         // Check for dual numbers
         llvm::Value* base_is_dual = ctx_.builder().CreateICmpEQ(base_base,
             llvm::ConstantInt::get(ctx_.int8Type(), ESHKOL_VALUE_DUAL_NUMBER));
@@ -2958,8 +2984,9 @@ llvm::Value* ArithmeticCodegen::pow(llvm::Value* base, llvm::Value* exponent) {
 
         // Merge paths
         ctx_.builder().SetInsertPoint(merge);
-        llvm::PHINode* phi = ctx_.builder().CreatePHI(ctx_.taggedValueType(), 4, "pow_result");
+        llvm::PHINode* phi = ctx_.builder().CreatePHI(ctx_.taggedValueType(), 5, "pow_result");
         phi->addIncoming(pow_twr, pow_twr_exit);
+        phi->addIncoming(pow_cpx, pow_cpx_exit);
         phi->addIncoming(dual_tagged, dual_exit);
         phi->addIncoming(exact_result, exact_exit);
         phi->addIncoming(regular_tagged, regular_exit);

--- a/lib/backend/complex_codegen.cpp
+++ b/lib/backend/complex_codegen.cpp
@@ -421,154 +421,147 @@ llvm::Value* ComplexCodegen::complexAngle(llvm::Value* z) {
 }
 
 /**
- * @brief Emit IR for the complex exponential: exp(a+bi) = exp(a)(cos(b) + i*sin(b)).
+ * @brief Map an Eshkol math builtin to its complex runtime, or nullptr.
+ *
+ * The supported set is the R7RS 6.2.6 transcendental surface plus Eshkol's
+ * own `exp2`/`log2`/`log10`, all on the principal branch. The functions
+ * deliberately absent are the ones whose domain is the real line only —
+ * `floor`, `ceiling`, `truncate`, `round`, `fabs`, `cbrt` — plus `abs`,
+ * which R7RS defines for reals (the complex counterpart is `magnitude`).
+ * For those the caller raises a typed error rather than coercing.
+ */
+const char* ComplexCodegen::complexRuntimeSuffix(const std::string& func_name) {
+    if (func_name == "sqrt")  return "sqrt";
+    if (func_name == "exp")   return "exp";
+    if (func_name == "log")   return "log";
+    if (func_name == "exp2")  return "exp2";
+    if (func_name == "log2")  return "log2";
+    if (func_name == "log10") return "log10";
+    if (func_name == "sin")   return "sin";
+    if (func_name == "cos")   return "cos";
+    if (func_name == "tan")   return "tan";
+    if (func_name == "asin")  return "asin";
+    if (func_name == "acos")  return "acos";
+    if (func_name == "atan")  return "atan";
+    if (func_name == "sinh")  return "sinh";
+    if (func_name == "cosh")  return "cosh";
+    if (func_name == "tanh")  return "tanh";
+    if (func_name == "asinh") return "asinh";
+    if (func_name == "acosh") return "acosh";
+    if (func_name == "atanh") return "atanh";
+    return nullptr;
+}
+
+/**
+ * @brief Emit `eshkol_complex_<suffix>(&z, &out)` and reload the result.
+ *
+ * The transcendentals live in the runtime rather than in emitted IR for two
+ * reasons. First, correctness: the polar-form square root this replaced could
+ * not produce the exact `0.0+1.0i` that ESHKOL_LANGUAGE_GUIDE.md documents
+ * for `(sqrt (make-rectangular -1.0 0.0))`, because `cos(pi/2)` is 6.1e-17,
+ * not zero. Second, engine parity: `<eshkol/core/complex_math.h>` is compiled
+ * into the VM as well, so native and VM evaluate the same expression tree and
+ * agree bit-for-bit instead of drifting between two hand-written copies.
+ */
+llvm::Value* ComplexCodegen::complexUnaryRuntime(llvm::Value* z, const char* suffix) {
+    llvm::IRBuilderBase::InsertPoint saved_ip = ctx_.builder().saveIP();
+    llvm::Function* func = ctx_.builder().GetInsertBlock()->getParent();
+    llvm::BasicBlock& entry = func->getEntryBlock();
+    ctx_.builder().SetInsertPoint(&entry, entry.begin());
+    llvm::Value* in_slot = ctx_.builder().CreateAlloca(
+        ctx_.complexNumberType(), nullptr, "cpx_in");
+    llvm::Value* out_slot = ctx_.builder().CreateAlloca(
+        ctx_.complexNumberType(), nullptr, "cpx_out");
+    ctx_.builder().restoreIP(saved_ip);
+
+    ctx_.builder().CreateStore(z, in_slot);
+
+    llvm::FunctionType* ft = llvm::FunctionType::get(
+        ctx_.builder().getVoidTy(), {ctx_.ptrType(), ctx_.ptrType()}, false);
+    llvm::FunctionCallee fn = ctx_.module().getOrInsertFunction(
+        std::string("eshkol_complex_") + suffix, ft);
+    ctx_.builder().CreateCall(fn, {in_slot, out_slot});
+
+    return ctx_.builder().CreateLoad(ctx_.complexNumberType(), out_slot,
+                                     "cpx_result");
+}
+
+/** @brief Emit `eshkol_complex_pow(&a, &b, &out)` for the principal a^b. */
+llvm::Value* ComplexCodegen::complexPow(llvm::Value* a, llvm::Value* b) {
+    llvm::IRBuilderBase::InsertPoint saved_ip = ctx_.builder().saveIP();
+    llvm::Function* func = ctx_.builder().GetInsertBlock()->getParent();
+    llvm::BasicBlock& entry = func->getEntryBlock();
+    ctx_.builder().SetInsertPoint(&entry, entry.begin());
+    llvm::Value* a_slot = ctx_.builder().CreateAlloca(
+        ctx_.complexNumberType(), nullptr, "cpx_pow_a");
+    llvm::Value* b_slot = ctx_.builder().CreateAlloca(
+        ctx_.complexNumberType(), nullptr, "cpx_pow_b");
+    llvm::Value* out_slot = ctx_.builder().CreateAlloca(
+        ctx_.complexNumberType(), nullptr, "cpx_pow_out");
+    ctx_.builder().restoreIP(saved_ip);
+
+    ctx_.builder().CreateStore(a, a_slot);
+    ctx_.builder().CreateStore(b, b_slot);
+
+    llvm::FunctionType* ft = llvm::FunctionType::get(
+        ctx_.builder().getVoidTy(),
+        {ctx_.ptrType(), ctx_.ptrType(), ctx_.ptrType()}, false);
+    llvm::FunctionCallee fn = ctx_.module().getOrInsertFunction(
+        "eshkol_complex_pow", ft);
+    ctx_.builder().CreateCall(fn, {a_slot, b_slot, out_slot});
+
+    return ctx_.builder().CreateLoad(ctx_.complexNumberType(), out_slot,
+                                     "cpx_pow_result");
+}
+
+/**
+ * @brief Complex exponential exp(a+bi), via the shared runtime core.
  *
  * @param z Operand complex-number struct value.
- * @return Newly built complex-number struct value holding exp(z).
+ * @return Complex-number struct value holding exp(z).
  */
 llvm::Value* ComplexCodegen::complexExp(llvm::Value* z) {
-    // exp(a+bi) = exp(a)(cos(b) + i*sin(b))
-    llvm::Value* a = getComplexReal(z);
-    llvm::Value* b = getComplexImag(z);
-
-    llvm::Function* exp_fn = getExpIntrinsic();
-    llvm::Function* sin_fn = getSinIntrinsic();
-    llvm::Function* cos_fn = getCosIntrinsic();
-
-    llvm::Value* exp_a = ctx_.builder().CreateCall(exp_fn, {a}, "exp_a");
-    llvm::Value* cos_b = ctx_.builder().CreateCall(cos_fn, {b}, "cos_b");
-    llvm::Value* sin_b = ctx_.builder().CreateCall(sin_fn, {b}, "sin_b");
-
-    llvm::Value* real = ctx_.builder().CreateFMul(exp_a, cos_b, "exp_real");
-    llvm::Value* imag = ctx_.builder().CreateFMul(exp_a, sin_b, "exp_imag");
-
-    return createComplex(real, imag);
+    return complexUnaryRuntime(z, "exp");
 }
 
 /**
- * @brief Emit IR for the complex natural logarithm: log(z) = log|z| + i*arg(z).
+ * @brief Principal complex natural logarithm, via the shared runtime core.
  *
  * @param z Operand complex-number struct value.
- * @return Newly built complex-number struct value holding log(z).
+ * @return Complex-number struct value holding log(z).
  */
 llvm::Value* ComplexCodegen::complexLog(llvm::Value* z) {
-    // log(z) = log|z| + i*arg(z)
-    llvm::Value* mag = complexMagnitude(z);
-    llvm::Value* ang = complexAngle(z);
-
-    llvm::Function* log_fn = getLogIntrinsic();
-    llvm::Value* real = ctx_.builder().CreateCall(log_fn, {mag}, "log_mag");
-
-    return createComplex(real, ang);
+    return complexUnaryRuntime(z, "log");
 }
 
 /**
- * @brief Emit IR for the principal complex square root, via polar form:
- * sqrt(z) = sqrt(|z|) * (cos(arg(z)/2) + i*sin(arg(z)/2)).
+ * @brief Principal complex square root, via the shared runtime core.
  *
  * @param z Operand complex-number struct value.
- * @return Newly built complex-number struct value holding sqrt(z).
+ * @return Complex-number struct value holding sqrt(z).
  */
 llvm::Value* ComplexCodegen::complexSqrt(llvm::Value* z) {
-    // sqrt(z) = sqrt(|z|) * (cos(arg(z)/2) + i*sin(arg(z)/2))
-    llvm::Value* mag = complexMagnitude(z);
-    llvm::Value* ang = complexAngle(z);
-
-    llvm::Function* sqrt_fn = getSqrtIntrinsic();
-    llvm::Function* sin_fn = getSinIntrinsic();
-    llvm::Function* cos_fn = getCosIntrinsic();
-
-    llvm::Value* sqrt_mag = ctx_.builder().CreateCall(sqrt_fn, {mag}, "sqrt_mag");
-    llvm::Value* half_ang = ctx_.builder().CreateFMul(ang,
-        llvm::ConstantFP::get(ctx_.doubleType(), 0.5), "half_ang");
-
-    llvm::Value* cos_half = ctx_.builder().CreateCall(cos_fn, {half_ang}, "cos_half");
-    llvm::Value* sin_half = ctx_.builder().CreateCall(sin_fn, {half_ang}, "sin_half");
-
-    llvm::Value* real = ctx_.builder().CreateFMul(sqrt_mag, cos_half, "sqrt_real");
-    llvm::Value* imag = ctx_.builder().CreateFMul(sqrt_mag, sin_half, "sqrt_imag");
-
-    return createComplex(real, imag);
+    return complexUnaryRuntime(z, "sqrt");
 }
 
 /**
- * @brief Emit IR for the complex sine: sin(a+bi) = sin(a)cosh(b) + i*cos(a)sinh(b).
- *
- * cosh(b) and sinh(b) are computed from exp(b) and exp(-b) since LLVM has no
- * direct hyperbolic-trig intrinsics.
+ * @brief Complex sine, via the shared runtime core.
  *
  * @param z Operand complex-number struct value.
- * @return Newly built complex-number struct value holding sin(z).
+ * @return Complex-number struct value holding sin(z).
  */
 llvm::Value* ComplexCodegen::complexSin(llvm::Value* z) {
-    // sin(a+bi) = sin(a)cosh(b) + i*cos(a)sinh(b)
-    // Using: cosh(x) = (exp(x) + exp(-x))/2, sinh(x) = (exp(x) - exp(-x))/2
-    llvm::Value* a = getComplexReal(z);
-    llvm::Value* b = getComplexImag(z);
-
-    llvm::Function* sin_fn = getSinIntrinsic();
-    llvm::Function* cos_fn = getCosIntrinsic();
-    llvm::Function* exp_fn = getExpIntrinsic();
-
-    llvm::Value* sin_a = ctx_.builder().CreateCall(sin_fn, {a}, "sin_a");
-    llvm::Value* cos_a = ctx_.builder().CreateCall(cos_fn, {a}, "cos_a");
-
-    // cosh(b) = (exp(b) + exp(-b)) / 2
-    llvm::Value* exp_b = ctx_.builder().CreateCall(exp_fn, {b}, "exp_b");
-    llvm::Value* neg_b = ctx_.builder().CreateFNeg(b, "neg_b");
-    llvm::Value* exp_neg_b = ctx_.builder().CreateCall(exp_fn, {neg_b}, "exp_neg_b");
-    llvm::Value* cosh_b = ctx_.builder().CreateFMul(
-        ctx_.builder().CreateFAdd(exp_b, exp_neg_b, "sum"),
-        llvm::ConstantFP::get(ctx_.doubleType(), 0.5), "cosh_b");
-
-    // sinh(b) = (exp(b) - exp(-b)) / 2
-    llvm::Value* sinh_b = ctx_.builder().CreateFMul(
-        ctx_.builder().CreateFSub(exp_b, exp_neg_b, "diff"),
-        llvm::ConstantFP::get(ctx_.doubleType(), 0.5), "sinh_b");
-
-    llvm::Value* real = ctx_.builder().CreateFMul(sin_a, cosh_b, "sin_real");
-    llvm::Value* imag = ctx_.builder().CreateFMul(cos_a, sinh_b, "sin_imag");
-
-    return createComplex(real, imag);
+    return complexUnaryRuntime(z, "sin");
 }
 
 /**
- * @brief Emit IR for the complex cosine: cos(a+bi) = cos(a)cosh(b) - i*sin(a)sinh(b).
- *
- * cosh(b) and sinh(b) are computed from exp(b) and exp(-b) since LLVM has no
- * direct hyperbolic-trig intrinsics.
+ * @brief Complex cosine, via the shared runtime core.
  *
  * @param z Operand complex-number struct value.
- * @return Newly built complex-number struct value holding cos(z).
+ * @return Complex-number struct value holding cos(z).
  */
 llvm::Value* ComplexCodegen::complexCos(llvm::Value* z) {
-    // cos(a+bi) = cos(a)cosh(b) - i*sin(a)sinh(b)
-    llvm::Value* a = getComplexReal(z);
-    llvm::Value* b = getComplexImag(z);
-
-    llvm::Function* sin_fn = getSinIntrinsic();
-    llvm::Function* cos_fn = getCosIntrinsic();
-    llvm::Function* exp_fn = getExpIntrinsic();
-
-    llvm::Value* sin_a = ctx_.builder().CreateCall(sin_fn, {a}, "sin_a");
-    llvm::Value* cos_a = ctx_.builder().CreateCall(cos_fn, {a}, "cos_a");
-
-    // cosh(b) and sinh(b) as above
-    llvm::Value* exp_b = ctx_.builder().CreateCall(exp_fn, {b}, "exp_b");
-    llvm::Value* neg_b = ctx_.builder().CreateFNeg(b, "neg_b");
-    llvm::Value* exp_neg_b = ctx_.builder().CreateCall(exp_fn, {neg_b}, "exp_neg_b");
-    llvm::Value* cosh_b = ctx_.builder().CreateFMul(
-        ctx_.builder().CreateFAdd(exp_b, exp_neg_b, "sum"),
-        llvm::ConstantFP::get(ctx_.doubleType(), 0.5), "cosh_b");
-    llvm::Value* sinh_b = ctx_.builder().CreateFMul(
-        ctx_.builder().CreateFSub(exp_b, exp_neg_b, "diff"),
-        llvm::ConstantFP::get(ctx_.doubleType(), 0.5), "sinh_b");
-
-    llvm::Value* real = ctx_.builder().CreateFMul(cos_a, cosh_b, "cos_real");
-    llvm::Value* imag_pos = ctx_.builder().CreateFMul(sin_a, sinh_b, "temp");
-    llvm::Value* imag = ctx_.builder().CreateFNeg(imag_pos, "cos_imag");
-
-    return createComplex(real, imag);
+    return complexUnaryRuntime(z, "cos");
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -617,18 +610,6 @@ llvm::Function* ComplexCodegen::getSinIntrinsic() {
 llvm::Function* ComplexCodegen::getCosIntrinsic() {
     return ESHKOL_GET_INTRINSIC(&ctx_.module(),
         llvm::Intrinsic::cos, {ctx_.doubleType()});
-}
-
-/** @brief Get (or declare) the LLVM `exp` double-precision intrinsic for the current module. */
-llvm::Function* ComplexCodegen::getExpIntrinsic() {
-    return ESHKOL_GET_INTRINSIC(&ctx_.module(),
-        llvm::Intrinsic::exp, {ctx_.doubleType()});
-}
-
-/** @brief Get (or declare) the LLVM `log` double-precision intrinsic for the current module. */
-llvm::Function* ComplexCodegen::getLogIntrinsic() {
-    return ESHKOL_GET_INTRINSIC(&ctx_.module(),
-        llvm::Intrinsic::log, {ctx_.doubleType()});
 }
 
 /**

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -20872,7 +20872,19 @@ private:
         // There is no third outcome. The pointer is never reinterpreted.
         const char* mf_cpx_suffix = eshkol::ComplexCodegen::complexRuntimeSuffix(func_name);
         BasicBlock* mf_cpx_done = BasicBlock::Create(*context, (func_name + "_cpx_done").c_str(), current_func);
-        Value* mf_cpx_slot = builder->CreateAlloca(tagged_value_type, nullptr, (func_name + "_cpx_slot").c_str());
+        // The slot lives in the ENTRY block: this dispatch is emitted for every
+        // math builtin, so a math call inside a loop body would otherwise
+        // re-adjust the stack pointer on every iteration (the hazard
+        // CodegenContext::emitRaiseFmt documents for its own buffer, and the
+        // one the flat-RSS AOT gate watches).
+        Value* mf_cpx_slot = nullptr;
+        {
+            IRBuilderBase::InsertPoint mf_cpx_ip = builder->saveIP();
+            BasicBlock& mf_entry = current_func->getEntryBlock();
+            builder->SetInsertPoint(&mf_entry, mf_entry.begin());
+            mf_cpx_slot = builder->CreateAlloca(tagged_value_type, nullptr, (func_name + "_cpx_slot").c_str());
+            builder->restoreIP(mf_cpx_ip);
+        }
         {
             BasicBlock* cpx_path = BasicBlock::Create(*context, (func_name + "_cpx_path").c_str(), current_func);
             BasicBlock* cpx_cont = BasicBlock::Create(*context, (func_name + "_cpx_cont").c_str(), current_func);

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -2102,9 +2102,12 @@ public:
 
         // Type conversions
         function_return_types["exact->inexact"] = BuiltinTypes::Float64;
-        function_return_types["inexact->exact"] = BuiltinTypes::Int64;
+        // inexact->exact is NOT integer-valued: the exact value of a
+        // fractional double is a rational (and of a huge one, a bignum), so
+        // the static claim has to be the general Number, not Int64.
+        function_return_types["inexact->exact"] = BuiltinTypes::Number;
         function_return_types["inexact"] = BuiltinTypes::Float64;
-        function_return_types["exact"] = BuiltinTypes::Int64;
+        function_return_types["exact"] = BuiltinTypes::Number;
         function_return_types["exact-integer?"] = BuiltinTypes::Boolean;
         function_return_types["square"] = BuiltinTypes::Number;
         function_return_types["volatile-load"] = BuiltinTypes::Value;
@@ -15013,38 +15016,40 @@ private:
             BasicBlock* convert_bb = BasicBlock::Create(*context, "inexact_to_exact", cur_func);
             BasicBlock* merge_bb = BasicBlock::Create(*context, "merge_exact", cur_func);
             builder->CreateCondBr(already_exact, merge_bb, convert_bb);
-            // Convert double to exact: whole numbers → int64, fractional → rational
+            // Convert the double to its EXACT value in the runtime.
+            //
+            // This branch used to decide the result shape itself:
+            //
+            //     is_whole ? fptosi(d) : eshkol_double_to_rational(arena, d)
+            //
+            // Both arms were wrong. `fptosi` is undefined once |d| >= 2^63, so
+            // `(inexact->exact 1e300)` returned the garbage 4347791012 instead
+            // of an exact bignum integer; and the rational arm called a
+            // conversion that capped its denominator at 2^52, so
+            // `(inexact->exact 0.1)` returned 450359962737049/4503599627370496
+            // — the exact value of a DIFFERENT double — where the documented
+            // answer is 3602879701896397/36028797018963968. Both engines now
+            // call one runtime entry point that reads the operand's actual
+            // mantissa and exponent and picks int64 / bignum / rational there.
             builder->SetInsertPoint(convert_bb);
             Value* dbl_val = builder->CreateBitCast(data, double_type);
-            Function* floor_fn = ESHKOL_GET_INTRINSIC(module.get(), Intrinsic::floor, {double_type});
-            Value* floored = builder->CreateCall(floor_fn, {dbl_val});
-            Value* is_whole = builder->CreateFCmpOEQ(dbl_val, floored);
-            BasicBlock* int_convert_bb = BasicBlock::Create(*context, "i2e_int", cur_func);
-            BasicBlock* rat_convert_bb = BasicBlock::Create(*context, "i2e_rat", cur_func);
-            builder->CreateCondBr(is_whole, int_convert_bb, rat_convert_bb);
-            // Whole number → int64
-            builder->SetInsertPoint(int_convert_bb);
-            Value* int_val = builder->CreateFPToSI(dbl_val, int64_type);
-            Value* int_converted = packInt64ToTaggedValue(int_val);
-            builder->CreateBr(merge_bb);
-            BasicBlock* int_convert_end = builder->GetInsertBlock();
-            // Fractional → rational via runtime
-            builder->SetInsertPoint(rat_convert_bb);
-            FunctionType* d2r_ft = FunctionType::get(
-                PointerType::getUnqual(*context),
-                {PointerType::getUnqual(*context), double_type}, false);
-            FunctionCallee d2r_fn = module->getOrInsertFunction("eshkol_double_to_rational", d2r_ft);
+            Value* exact_slot = builder->CreateAlloca(tagged_value_type, nullptr, "i2e_slot");
+            FunctionType* d2e_ft = FunctionType::get(
+                void_type,
+                {PointerType::getUnqual(*context), double_type,
+                 PointerType::getUnqual(*context)}, false);
+            FunctionCallee d2e_fn = module->getOrInsertFunction(
+                "eshkol_double_to_exact_tagged", d2e_ft);
             Value* arena_ptr = builder->CreateLoad(PointerType::getUnqual(*context), global_arena);
-            Value* rat_ptr = builder->CreateCall(d2r_fn, {arena_ptr, dbl_val}, "rat_from_dbl");
-            Value* rat_converted = packPtrToTaggedValue(rat_ptr, ESHKOL_VALUE_HEAP_PTR);
+            builder->CreateCall(d2e_fn, {arena_ptr, dbl_val, exact_slot});
+            Value* converted_exact = builder->CreateLoad(tagged_value_type, exact_slot, "i2e_result");
             builder->CreateBr(merge_bb);
-            BasicBlock* rat_convert_end = builder->GetInsertBlock();
+            BasicBlock* convert_end = builder->GetInsertBlock();
             // Merge
             builder->SetInsertPoint(merge_bb);
-            PHINode* phi = builder->CreatePHI(tagged_value_type, 3);
+            PHINode* phi = builder->CreatePHI(tagged_value_type, 2);
             phi->addIncoming(arg, cur_block);
-            phi->addIncoming(int_converted, int_convert_end);
-            phi->addIncoming(rat_converted, rat_convert_end);
+            phi->addIncoming(converted_exact, convert_end);
             return phi;
         }
         // R7RS exact-integer?: true if exact and integer (int64 or bignum)
@@ -20908,6 +20913,51 @@ private:
         BasicBlock* regular_path = BasicBlock::Create(*context, (func_name + "_regular_path").c_str(), current_func);
         BasicBlock* merge = BasicBlock::Create(*context, (func_name + "_merge").c_str(), current_func);
 
+        // TASK #113 — COMPLEX OPERAND PATH (memory-safety class kill).
+        //
+        // A complex tagged value carries a HEAP POINTER in its payload. Every
+        // scalar path below ends in either `extractAsDouble` or an
+        // `SIToFP(unpackInt64(...))`, both of which would read that pointer's
+        // bits as an IEEE double: `(sqrt (make-rectangular -1.0 0.0))` used to
+        // print 73278.56614317723 and `(exp (make-rectangular 0.0 3.14159))`
+        // printed +inf.0 — a different garbage value on every run, and an
+        // address leak to boot. This branch is emitted FIRST, before anything
+        // touches the payload, and it has exactly two outcomes:
+        //
+        //   * the builtin has a principal-branch complex extension: dispatch to
+        //     the shared runtime core (`<eshkol/core/complex_math.h>`, the same
+        //     code the VM compiles in) and return a complex;
+        //   * it does not (the real-domain-only `floor`/`ceiling`/`truncate`/
+        //     `round`/`fabs`/`cbrt`): raise a catchable, typed error naming the
+        //     procedure.
+        //
+        // There is no third outcome. The pointer is never reinterpreted.
+        const char* mf_cpx_suffix = eshkol::ComplexCodegen::complexRuntimeSuffix(func_name);
+        BasicBlock* mf_cpx_done = BasicBlock::Create(*context, (func_name + "_cpx_done").c_str(), current_func);
+        Value* mf_cpx_slot = builder->CreateAlloca(tagged_value_type, nullptr, (func_name + "_cpx_slot").c_str());
+        {
+            BasicBlock* cpx_path = BasicBlock::Create(*context, (func_name + "_cpx_path").c_str(), current_func);
+            BasicBlock* cpx_cont = BasicBlock::Create(*context, (func_name + "_cpx_cont").c_str(), current_func);
+            Value* arg_is_complex = builder->CreateICmpEQ(arg_base_type,
+                ConstantInt::get(int8_type, ESHKOL_VALUE_COMPLEX));
+            builder->CreateCondBr(arg_is_complex, cpx_path, cpx_cont);
+
+            builder->SetInsertPoint(cpx_path);
+            if (mf_cpx_suffix) {
+                Value* cpx_in = complex_->unpackComplexFromTagged(arg_tagged);
+                Value* cpx_res = complex_->complexUnaryRuntime(cpx_in, mf_cpx_suffix);
+                builder->CreateStore(complex_->packComplexToTagged(cpx_res), mf_cpx_slot);
+                builder->CreateBr(mf_cpx_done);
+            } else {
+                // emitRaise() closes the block with `unreachable`, so this path
+                // never reaches the merge and never needs a PHI incoming.
+                ctx_->emitRaise((func_name +
+                    ": argument is a complex number and this procedure is defined "
+                    "on the reals only (use real-part, magnitude or angle first)").c_str());
+            }
+            builder->SetInsertPoint(cpx_cont);
+        }
+
         // ESH-0186: Taylor-tower operand — route to the arbitrary-order kernel
         // before any scalar/tensor handling. Wraps the rest of the function so a
         // tower `sin`/`cos`/`exp`/`log`/... returns a tower, not a misread double.
@@ -21276,12 +21326,19 @@ private:
             promo_phi->addIncoming(real_tagged, real_exit);
             tagged_regular_result = promo_phi;
         } else {
-            // Non-rounding functions: always compute on double
-            Value* arg_is_double = builder->CreateICmpEQ(arg_base_type,
-                ConstantInt::get(int8_type, ESHKOL_VALUE_DOUBLE));
-            Value* arg_double = builder->CreateSelect(arg_is_double,
-                unpackDoubleFromTaggedValue(arg_tagged),
-                builder->CreateSIToFP(unpackInt64FromTaggedValue(arg_tagged), double_type));
+            // Non-rounding functions: always compute on double.
+            //
+            // Task #113 — the two-way `select(is_double, unpackDouble,
+            // SIToFP(unpackInt64))` this replaces treated EVERY non-double tag
+            // as an int64, so a rational or bignum operand had its heap pointer
+            // sign-converted into a double: `(sin (/ 1 2))` returned
+            // 0.9241426121154859 (sin of an address) instead of sin(0.5).
+            // extractAsDouble dispatches on the real tag — int64, double,
+            // bignum, rational, Taylor primal — and yields 0.0 for anything
+            // non-numeric rather than reinterpreting a pointer. Complex is
+            // already handled by the dedicated branch at the top of this
+            // function and can never reach here.
+            Value* arg_double = arith_->extractAsDouble(arg_tagged);
             Value* result_double = builder->CreateCall(function_table[func_name], {arg_double});
             tagged_regular_result = packDoubleToTaggedValue(result_double);
         }
@@ -21314,9 +21371,14 @@ private:
             builder->CreateStore(mf_final, mf_twr_slot);
             builder->CreateBr(mf_twr_done);
             builder->SetInsertPoint(mf_twr_done);
-            return builder->CreateLoad(tagged_value_type, mf_twr_slot);
+            mf_final = builder->CreateLoad(tagged_value_type, mf_twr_slot);
         }
-        return mf_final;
+        // Task #113: merge the complex early-path (always emitted) last, so it
+        // is the outermost of the three operand-shape dispatches.
+        builder->CreateStore(mf_final, mf_cpx_slot);
+        builder->CreateBr(mf_cpx_done);
+        builder->SetInsertPoint(mf_cpx_done);
+        return builder->CreateLoad(tagged_value_type, mf_cpx_slot);
     }
 
     // Polymorphic abs - handles AD/dual, then delegates to ArithmeticCodegen::abs

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -14353,75 +14353,13 @@ private:
             Value* base = typedValueToTaggedValue(tv_base);
             Value* exp_val = typedValueToTaggedValue(tv_exp);
 
-            // Check if base is complex — needs complex exponentiation
-            Value* base_type = builder->CreateExtractValue(base, {0}, "expt_base_type");
-            Value* base_is_complex = builder->CreateICmpEQ(base_type,
-                ConstantInt::get(int8_type, ESHKOL_VALUE_COMPLEX));
-
-            Function* cur_func = builder->GetInsertBlock()->getParent();
-            BasicBlock* complex_expt_bb = BasicBlock::Create(*context, "expt_complex", cur_func);
-            BasicBlock* regular_expt_bb = BasicBlock::Create(*context, "expt_regular", cur_func);
-            BasicBlock* expt_merge_bb = BasicBlock::Create(*context, "expt_merge", cur_func);
-
-            builder->CreateCondBr(base_is_complex, complex_expt_bb, regular_expt_bb);
-
-            // Complex exponentiation: z^n via exp(n * ln(z))
-            builder->SetInsertPoint(complex_expt_bb);
-            Value* z = unpackComplexFromTagged(base);
-            Value* re = getComplexReal(z);
-            Value* im = getComplexImag(z);
-
-            // Compute ln(z) = ln(|z|) + i*atan2(imag, real)
-            Function* sqrt_fn = ESHKOL_GET_INTRINSIC(module.get(), Intrinsic::sqrt, {double_type});
-            Function* log_fn = ESHKOL_GET_INTRINSIC(module.get(), Intrinsic::log, {double_type});
-            Function* cos_fn = ESHKOL_GET_INTRINSIC(module.get(), Intrinsic::cos, {double_type});
-            Function* sin_fn = ESHKOL_GET_INTRINSIC(module.get(), Intrinsic::sin, {double_type});
-            Function* exp_fn = ESHKOL_GET_INTRINSIC(module.get(), Intrinsic::exp, {double_type});
-
-            // |z| = sqrt(re^2 + im^2)
-            Value* re2 = builder->CreateFMul(re, re);
-            Value* im2 = builder->CreateFMul(im, im);
-            Value* mag = builder->CreateCall(sqrt_fn, {builder->CreateFAdd(re2, im2)});
-
-            // atan2(im, re)
-            FunctionType* atan2_ft = FunctionType::get(double_type, {double_type, double_type}, false);
-            FunctionCallee atan2_fn = module->getOrInsertFunction("atan2", atan2_ft);
-            Value* carg = builder->CreateCall(atan2_fn, {im, re}, "carg");
-
-            // ln(z) = ln(|z|) + i*arg
-            Value* ln_r = builder->CreateCall(log_fn, {mag}, "ln_mag");
-
-            // n (exponent as double)
-            Value* n = extractDoubleFromTagged(exp_val);
-
-            // n * ln(z) = n*ln_r + i*n*ln_i
-            Value* prod_r = builder->CreateFMul(n, ln_r);
-            Value* prod_i = builder->CreateFMul(n, carg);
-
-            // exp(prod_r + i*prod_i) = e^prod_r * (cos(prod_i) + i*sin(prod_i))
-            Value* e_pow = builder->CreateCall(exp_fn, {prod_r});
-            Value* cos_val = builder->CreateCall(cos_fn, {prod_i});
-            Value* sin_val = builder->CreateCall(sin_fn, {prod_i});
-            Value* result_re = builder->CreateFMul(e_pow, cos_val);
-            Value* result_im = builder->CreateFMul(e_pow, sin_val);
-
-            Value* result_complex = createComplexNumber(result_re, result_im);
-            Value* complex_tagged = packComplexToTagged(result_complex);
-            builder->CreateBr(expt_merge_bb);
-            BasicBlock* complex_expt_exit = builder->GetInsertBlock();
-
-            // Regular path: non-complex base
-            builder->SetInsertPoint(regular_expt_bb);
-            Value* regular_result = arith_->pow(base, exp_val);
-            builder->CreateBr(expt_merge_bb);
-            BasicBlock* regular_expt_exit = builder->GetInsertBlock();
-
-            // Merge
-            builder->SetInsertPoint(expt_merge_bb);
-            PHINode* expt_phi = builder->CreatePHI(tagged_value_type, 2);
-            expt_phi->addIncoming(complex_tagged, complex_expt_exit);
-            expt_phi->addIncoming(regular_result, regular_expt_exit);
-            return expt_phi;
+            // Complex operands are handled inside ArithmeticCodegen::pow,
+            // alongside complex +/-/*//. Task #113: the hand-rolled block that
+            // used to live here tested only the BASE for ESHKOL_VALUE_COMPLEX
+            // and then read the exponent with extractDoubleFromTagged, so a
+            // complex exponent had its heap pointer reinterpreted —
+            // `(expt i i)` returned 1 instead of e^(-pi/2) = 0.2078795763...
+            return arith_->pow(base, exp_val);
         }
 
         // Logical operators (short-circuit)

--- a/lib/backend/vm_complex.c
+++ b/lib/backend/vm_complex.c
@@ -11,6 +11,7 @@
  */
 
 #include "vm_numeric.h"
+#include <eshkol/core/complex_math.h>
 #include <math.h>
 #include <stdio.h>
 
@@ -106,61 +107,90 @@ static VmComplex* vm_complex_div(VmRegionStack* rs, const VmComplex* a, const Vm
     }
 }
 
-/** @brief Native call 311: principal complex square root, via the
- *         magnitude-based half-angle formula (sign of imag chosen to match
- *         @p z's imaginary sign). */
+/*
+ * ── Transcendentals: the shared core ──────────────────────────────────────
+ *
+ * Task #113. These used to be hand-written here and hand-written again in the
+ * LLVM back end, which is how the two engines came to disagree: the native
+ * polar-form sqrt returned 6.1e-17+1i for `(sqrt (make-rectangular -1.0 0.0))`
+ * where this file's half-angle form returned the documented 0.0+1.0i. Both now
+ * evaluate the SAME expressions from <eshkol/core/complex_math.h>, so the
+ * engines agree bit-for-bit by construction rather than by review.
+ */
+
+/** @brief Convert a VM complex to the shared pair type. */
+static eshkol_cpx vm_cpx_in(const VmComplex* z) {
+    return eshkol_cpx_make(z->real, z->imag);
+}
+
+/** @brief Allocate a VM complex from a shared-core result. */
+static VmComplex* vm_cpx_out(VmRegionStack* rs, eshkol_cpx v) {
+    return vm_complex_new(rs, v.re, v.im);
+}
+
+/** @brief Native call 311: principal complex square root. */
 static VmComplex* vm_complex_sqrt(VmRegionStack* rs, const VmComplex* z) {
-    double r = vm_complex_magnitude(z);
-    double real = sqrt((r + z->real) / 2.0);
-    double imag = sqrt((r - z->real) / 2.0);
-    if (z->imag < 0) imag = -imag;
-    return vm_complex_new(rs, real, imag);
+    return vm_cpx_out(rs, eshkol_cpx_sqrt(vm_cpx_in(z)));
 }
 
-/** @brief Native call 312: complex exponential, e^(a+bi) = e^a * (cos(b) +
- *         i*sin(b)). */
+/** @brief Native call 312: complex exponential. */
 static VmComplex* vm_complex_exp(VmRegionStack* rs, const VmComplex* z) {
-    double ea = exp(z->real);
-    return vm_complex_new(rs, ea * cos(z->imag), ea * sin(z->imag));
+    return vm_cpx_out(rs, eshkol_cpx_exp(vm_cpx_in(z)));
 }
 
-/** @brief Native call 313: principal complex natural log, (log|z|,
- *         angle(z)). */
+/** @brief Native call 313: principal complex natural logarithm. */
 static VmComplex* vm_complex_log(VmRegionStack* rs, const VmComplex* z) {
-    return vm_complex_new(rs, log(vm_complex_magnitude(z)), vm_complex_angle(z));
+    return vm_cpx_out(rs, eshkol_cpx_log(vm_cpx_in(z)));
 }
 
-/** @brief Native call 314: complex sin, sin(a+bi) = sin(a)*cosh(b) +
- *         i*cos(a)*sinh(b). */
+/** @brief Native call 314: complex sine. */
 static VmComplex* vm_complex_sin(VmRegionStack* rs, const VmComplex* z) {
-    return vm_complex_new(rs,
-        sin(z->real) * cosh(z->imag),
-        cos(z->real) * sinh(z->imag));
+    return vm_cpx_out(rs, eshkol_cpx_sin(vm_cpx_in(z)));
 }
 
-/** @brief Native call 315: complex cos, cos(a+bi) = cos(a)*cosh(b) -
- *         i*sin(a)*sinh(b). */
+/** @brief Native call 315: complex cosine. */
 static VmComplex* vm_complex_cos(VmRegionStack* rs, const VmComplex* z) {
-    return vm_complex_new(rs,
-        cos(z->real) * cosh(z->imag),
-        -sin(z->real) * sinh(z->imag));
+    return vm_cpx_out(rs, eshkol_cpx_cos(vm_cpx_in(z)));
 }
 
-/** @brief Native call 316: complex tan, computed as sin(z)/cos(z). */
+/** @brief Native call 316: complex tangent. */
 static VmComplex* vm_complex_tan(VmRegionStack* rs, const VmComplex* z) {
-    VmComplex* s = vm_complex_sin(rs, z);
-    VmComplex* c = vm_complex_cos(rs, z);
-    if (!s || !c) return NULL;
-    return vm_complex_div(rs, s, c);
+    return vm_cpx_out(rs, eshkol_cpx_tan(vm_cpx_in(z)));
 }
 
-/** @brief Native call 318: complex exponentiation, a^b = exp(b * log(a)). */
+/** @brief Complex arcsine (principal branch). */
+static VmComplex* vm_complex_asin(VmRegionStack* rs, const VmComplex* z) {
+    return vm_cpx_out(rs, eshkol_cpx_asin(vm_cpx_in(z)));
+}
+
+/** @brief Complex arccosine (principal branch). */
+static VmComplex* vm_complex_acos(VmRegionStack* rs, const VmComplex* z) {
+    return vm_cpx_out(rs, eshkol_cpx_acos(vm_cpx_in(z)));
+}
+
+/** @brief Complex arctangent (principal branch). */
+static VmComplex* vm_complex_atan(VmRegionStack* rs, const VmComplex* z) {
+    return vm_cpx_out(rs, eshkol_cpx_atan(vm_cpx_in(z)));
+}
+
+/** @brief Complex hyperbolic sine. */
+static VmComplex* vm_complex_sinh(VmRegionStack* rs, const VmComplex* z) {
+    return vm_cpx_out(rs, eshkol_cpx_sinh(vm_cpx_in(z)));
+}
+
+/** @brief Complex hyperbolic cosine. */
+static VmComplex* vm_complex_cosh(VmRegionStack* rs, const VmComplex* z) {
+    return vm_cpx_out(rs, eshkol_cpx_cosh(vm_cpx_in(z)));
+}
+
+/** @brief Complex hyperbolic tangent. */
+static VmComplex* vm_complex_tanh(VmRegionStack* rs, const VmComplex* z) {
+    return vm_cpx_out(rs, eshkol_cpx_tanh(vm_cpx_in(z)));
+}
+
+/** @brief Native call 318: complex exponentiation, a^b = exp(b log a). */
 static VmComplex* vm_complex_expt(VmRegionStack* rs, const VmComplex* a, const VmComplex* b) {
-    VmComplex* log_a = vm_complex_log(rs, a);
-    if (!log_a) return NULL;
-    VmComplex* b_log_a = vm_complex_mul(rs, b, log_a);
-    if (!b_log_a) return NULL;
-    return vm_complex_exp(rs, b_log_a);
+    return vm_cpx_out(rs, eshkol_cpx_pow(vm_cpx_in(a), vm_cpx_in(b)));
 }
 
 /* ── Self-Test ── */

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -6580,6 +6580,44 @@ static int vm_math_complex_dispatch(VM* vm, Value a, int fid) {
     return 1;
 }
 
+/**
+ * @brief Task #113 — R7RS real-to-complex promotion for `sqrt` and `log`.
+ *
+ * The square root (and natural log) of a NEGATIVE EXACT real is not a real
+ * number: docs/reference/language/numeric-tower.md documents
+ * `(display (sqrt -1))` printing `+i`, and the native back end has promoted
+ * since the numeric tower landed. The VM answered NaN, so the two engines
+ * disagreed on a documented example.
+ *
+ * Promotion is exactness-aware, exactly as on the native side: an INEXACT
+ * negative keeps IEEE semantics (NaN for sqrt, -inf for log), so the
+ * documented floating-point behaviour and the infinity/NaN suite are
+ * untouched.
+ *
+ * @param vm Interpreter state.
+ * @param a Already-popped operand.
+ * @param is_sqrt Non-zero for `sqrt`, zero for `log`.
+ * @return 1 when a promoted complex result has been pushed.
+ */
+static int vm_math_promote_negative(VM* vm, Value a, int is_sqrt) {
+    double x, re, im;
+    VmComplex* z;
+    int32_t ptr;
+    if (a.type != VAL_INT && a.type != VAL_BIGNUM && a.type != VAL_RATIONAL) return 0;
+    x = as_number_vm(vm, a);
+    if (!(x < 0.0)) return 0;
+    if (is_sqrt) { re = 0.0; im = sqrt(-x); }
+    else         { re = log(-x); im = 3.14159265358979323846; }
+    z = vm_complex_new(&vm->heap.regions, re, im);
+    if (!z) { vm->error = 1; return 1; }
+    ptr = heap_alloc(&vm->heap);
+    if (ptr < 0) { vm->error = 1; return 1; }
+    vm->heap.objects[ptr]->type = HEAP_COMPLEX;
+    vm->heap.objects[ptr]->opaque.ptr = z;
+    vm_push(vm, (Value){.type = VAL_COMPLEX, .as.ptr = ptr});
+    return 1;
+}
+
 static void vm_dispatch_native(VM* vm, int fid) {
     vm_timers_poll_due(vm);
     if (fid >= ESHKOL_VM_HOST_NATIVE_BASE) {
@@ -6616,8 +6654,8 @@ static void vm_dispatch_native(VM* vm, int fid) {
     case 21: { int _in = (vm->active_tape && vm->sp>0) ? vm->ad_node_map[vm->sp-1] : -1; Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 21)) break; int _d = (a.type==VAL_DUAL); if (_d) { vm_push(vm,a); vm_dispatch_native(vm,378); } else vm_push(vm, FLOAT_VAL(cos(as_number(a)))); VM_AD_TRACE_UNARY(vm, _in, ad_cos, _d); break; }
     case 22: { Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 22)) break; if (a.type==VAL_DUAL) { /* tan = sin/cos */ vm_push(vm,a); vm_dispatch_native(vm,377); Value s=vm_pop(vm); vm_push(vm,a); vm_dispatch_native(vm,378); Value c=vm_pop(vm); vm_push(vm,s); vm_push(vm,c); vm_dispatch_native(vm,376); } else vm_push(vm, FLOAT_VAL(tan(as_number(a)))); break; }
     case 23: { int _in = (vm->active_tape && vm->sp>0) ? vm->ad_node_map[vm->sp-1] : -1; Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 23)) break; int _d = (a.type==VAL_DUAL); if (_d) { vm_push(vm,a); vm_dispatch_native(vm,379); } else vm_push(vm, FLOAT_VAL(exp(as_number(a)))); VM_AD_TRACE_UNARY(vm, _in, ad_exp, _d); break; }
-    case 24: { int _in = (vm->active_tape && vm->sp>0) ? vm->ad_node_map[vm->sp-1] : -1; Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 24)) break; int _d = (a.type==VAL_DUAL); if (_d) { vm_push(vm,a); vm_dispatch_native(vm,380); } else vm_push(vm, FLOAT_VAL(log(as_number(a)))); VM_AD_TRACE_UNARY(vm, _in, ad_log, _d); break; }
-    case 25: { int _in = (vm->active_tape && vm->sp>0) ? vm->ad_node_map[vm->sp-1] : -1; Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 25)) break; int _d = (a.type==VAL_DUAL); if (_d) { vm_push(vm,a); vm_dispatch_native(vm,381); } else vm_push(vm, FLOAT_VAL(sqrt(as_number(a)))); VM_AD_TRACE_UNARY(vm, _in, ad_sqrt, _d); break; }
+    case 24: { int _in = (vm->active_tape && vm->sp>0) ? vm->ad_node_map[vm->sp-1] : -1; Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 24)) break; if (vm_math_promote_negative(vm, a, 0)) break; int _d = (a.type==VAL_DUAL); if (_d) { vm_push(vm,a); vm_dispatch_native(vm,380); } else vm_push(vm, FLOAT_VAL(log(as_number(a)))); VM_AD_TRACE_UNARY(vm, _in, ad_log, _d); break; }
+    case 25: { int _in = (vm->active_tape && vm->sp>0) ? vm->ad_node_map[vm->sp-1] : -1; Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 25)) break; if (vm_math_promote_negative(vm, a, 1)) break; int _d = (a.type==VAL_DUAL); if (_d) { vm_push(vm,a); vm_dispatch_native(vm,381); } else vm_push(vm, FLOAT_VAL(sqrt(as_number(a)))); VM_AD_TRACE_UNARY(vm, _in, ad_sqrt, _d); break; }
     /* floor/ceiling/round preserve exactness: (floor 2.5) is the INEXACT 2.0,
      * not the exact 2 — the integral result shape must not decide the tag. */
     case 26: { Value a = vm_pop(vm); vm_push(vm, number_val_contagious1(a, floor(as_number_vm(vm,a)))); break; }
@@ -6628,6 +6666,24 @@ static void vm_dispatch_native(VM* vm, int fid) {
     case 31: { Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 31)) break; vm_push(vm, FLOAT_VAL(atan(as_number_vm(vm,a)))); break; }
     case 32: { Value b = vm_pop(vm); Value a = vm_pop(vm);
         if (a.type==VAL_DUAL||b.type==VAL_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,385); break; }
+        /* Task #113: a complex base OR exponent promotes both and takes the
+         * principal a^b = exp(b log a). Without it as_number() answered 0 for
+         * the complex side and (expt z 2) silently became 0^2. */
+        if (a.type==VAL_COMPLEX || b.type==VAL_COMPLEX) {
+            VmComplex az32 = { as_number(a), 0.0 }, bz32 = { as_number(b), 0.0 };
+            VmComplex* rz32;
+            int32_t pz32;
+            if (a.type==VAL_COMPLEX) az32 = *(VmComplex*)vm->heap.objects[a.as.ptr]->opaque.ptr;
+            if (b.type==VAL_COMPLEX) bz32 = *(VmComplex*)vm->heap.objects[b.as.ptr]->opaque.ptr;
+            rz32 = vm_complex_expt(&vm->heap.regions, &az32, &bz32);
+            if (!rz32) { vm->error = 1; break; }
+            pz32 = heap_alloc(&vm->heap);
+            if (pz32 < 0) { vm->error = 1; break; }
+            vm->heap.objects[pz32]->type = HEAP_COMPLEX;
+            vm->heap.objects[pz32]->opaque.ptr = rz32;
+            vm_push(vm, (Value){.type = VAL_COMPLEX, .as.ptr = pz32});
+            break;
+        }
         /* Exact integer base with a non-negative integer exponent → exact
          * result: an int64 while it fits, promoting to a bignum on overflow
          * (matching the native path). Previously always used pow() and

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -6534,6 +6534,52 @@ static Value vm_force_promise_value(VM* vm, Value initial) {
     return final;
 }
 
+/**
+ * @brief Task #113 — complex-operand dispatch for the scalar math builtins.
+ *
+ * The unary math opcodes all reduce their operand with `as_number()`, which
+ * answers 0 for a VAL_COMPLEX: `(sqrt (make-rectangular -1.0 0.0))` computed
+ * sqrt(0) and printed 0, `(exp z)` printed 1. Silently wrong on every complex
+ * input. This routes the complex case to the shared transcendental core
+ * (<eshkol/core/complex_math.h>) that the native back end also calls, so both
+ * engines return the same bits.
+ *
+ * @param vm Interpreter state.
+ * @param a Already-popped operand.
+ * @param fid Native call id of the math builtin.
+ * @return 1 when @p a was complex and a result (or a fatal error) has been
+ *         pushed/recorded; 0 when the caller must handle @p a itself.
+ */
+static int vm_math_complex_dispatch(VM* vm, Value a, int fid) {
+    VmComplex z;
+    VmComplex* result = NULL;
+    int32_t ptr;
+    if (a.type != VAL_COMPLEX) return 0;
+    z = *(VmComplex*)vm->heap.objects[a.as.ptr]->opaque.ptr;
+    switch (fid) {
+        case 20:  result = vm_complex_sin (&vm->heap.regions, &z); break;
+        case 21:  result = vm_complex_cos (&vm->heap.regions, &z); break;
+        case 22:  result = vm_complex_tan (&vm->heap.regions, &z); break;
+        case 23:  result = vm_complex_exp (&vm->heap.regions, &z); break;
+        case 24:  result = vm_complex_log (&vm->heap.regions, &z); break;
+        case 25:  result = vm_complex_sqrt(&vm->heap.regions, &z); break;
+        case 29:  result = vm_complex_asin(&vm->heap.regions, &z); break;
+        case 30:  result = vm_complex_acos(&vm->heap.regions, &z); break;
+        case 31:  result = vm_complex_atan(&vm->heap.regions, &z); break;
+        case 720: result = vm_complex_cosh(&vm->heap.regions, &z); break;
+        case 721: result = vm_complex_sinh(&vm->heap.regions, &z); break;
+        case 722: result = vm_complex_tanh(&vm->heap.regions, &z); break;
+        default: return 0;
+    }
+    if (!result) { vm->error = 1; return 1; }
+    ptr = heap_alloc(&vm->heap);
+    if (ptr < 0) { vm->error = 1; return 1; }
+    vm->heap.objects[ptr]->type = HEAP_COMPLEX;
+    vm->heap.objects[ptr]->opaque.ptr = result;
+    vm_push(vm, (Value){.type = VAL_COMPLEX, .as.ptr = ptr});
+    return 1;
+}
+
 static void vm_dispatch_native(VM* vm, int fid) {
     vm_timers_poll_due(vm);
     if (fid >= ESHKOL_VM_HOST_NATIVE_BASE) {
@@ -6566,20 +6612,20 @@ static void vm_dispatch_native(VM* vm, int fid) {
             ? tape_fn((AdTape*)(vm)->active_tape, (in_node)) : -1; \
     } \
 } while (0)
-    case 20: { int _in = (vm->active_tape && vm->sp>0) ? vm->ad_node_map[vm->sp-1] : -1; Value a = vm_pop(vm); int _d = (a.type==VAL_DUAL); if (_d) { vm_push(vm,a); vm_dispatch_native(vm,377); } else vm_push(vm, FLOAT_VAL(sin(as_number(a)))); VM_AD_TRACE_UNARY(vm, _in, ad_sin, _d); break; }
-    case 21: { int _in = (vm->active_tape && vm->sp>0) ? vm->ad_node_map[vm->sp-1] : -1; Value a = vm_pop(vm); int _d = (a.type==VAL_DUAL); if (_d) { vm_push(vm,a); vm_dispatch_native(vm,378); } else vm_push(vm, FLOAT_VAL(cos(as_number(a)))); VM_AD_TRACE_UNARY(vm, _in, ad_cos, _d); break; }
-    case 22: { Value a = vm_pop(vm); if (a.type==VAL_DUAL) { /* tan = sin/cos */ vm_push(vm,a); vm_dispatch_native(vm,377); Value s=vm_pop(vm); vm_push(vm,a); vm_dispatch_native(vm,378); Value c=vm_pop(vm); vm_push(vm,s); vm_push(vm,c); vm_dispatch_native(vm,376); } else vm_push(vm, FLOAT_VAL(tan(as_number(a)))); break; }
-    case 23: { int _in = (vm->active_tape && vm->sp>0) ? vm->ad_node_map[vm->sp-1] : -1; Value a = vm_pop(vm); int _d = (a.type==VAL_DUAL); if (_d) { vm_push(vm,a); vm_dispatch_native(vm,379); } else vm_push(vm, FLOAT_VAL(exp(as_number(a)))); VM_AD_TRACE_UNARY(vm, _in, ad_exp, _d); break; }
-    case 24: { int _in = (vm->active_tape && vm->sp>0) ? vm->ad_node_map[vm->sp-1] : -1; Value a = vm_pop(vm); int _d = (a.type==VAL_DUAL); if (_d) { vm_push(vm,a); vm_dispatch_native(vm,380); } else vm_push(vm, FLOAT_VAL(log(as_number(a)))); VM_AD_TRACE_UNARY(vm, _in, ad_log, _d); break; }
-    case 25: { int _in = (vm->active_tape && vm->sp>0) ? vm->ad_node_map[vm->sp-1] : -1; Value a = vm_pop(vm); int _d = (a.type==VAL_DUAL); if (_d) { vm_push(vm,a); vm_dispatch_native(vm,381); } else vm_push(vm, FLOAT_VAL(sqrt(as_number(a)))); VM_AD_TRACE_UNARY(vm, _in, ad_sqrt, _d); break; }
+    case 20: { int _in = (vm->active_tape && vm->sp>0) ? vm->ad_node_map[vm->sp-1] : -1; Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 20)) break; int _d = (a.type==VAL_DUAL); if (_d) { vm_push(vm,a); vm_dispatch_native(vm,377); } else vm_push(vm, FLOAT_VAL(sin(as_number(a)))); VM_AD_TRACE_UNARY(vm, _in, ad_sin, _d); break; }
+    case 21: { int _in = (vm->active_tape && vm->sp>0) ? vm->ad_node_map[vm->sp-1] : -1; Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 21)) break; int _d = (a.type==VAL_DUAL); if (_d) { vm_push(vm,a); vm_dispatch_native(vm,378); } else vm_push(vm, FLOAT_VAL(cos(as_number(a)))); VM_AD_TRACE_UNARY(vm, _in, ad_cos, _d); break; }
+    case 22: { Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 22)) break; if (a.type==VAL_DUAL) { /* tan = sin/cos */ vm_push(vm,a); vm_dispatch_native(vm,377); Value s=vm_pop(vm); vm_push(vm,a); vm_dispatch_native(vm,378); Value c=vm_pop(vm); vm_push(vm,s); vm_push(vm,c); vm_dispatch_native(vm,376); } else vm_push(vm, FLOAT_VAL(tan(as_number(a)))); break; }
+    case 23: { int _in = (vm->active_tape && vm->sp>0) ? vm->ad_node_map[vm->sp-1] : -1; Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 23)) break; int _d = (a.type==VAL_DUAL); if (_d) { vm_push(vm,a); vm_dispatch_native(vm,379); } else vm_push(vm, FLOAT_VAL(exp(as_number(a)))); VM_AD_TRACE_UNARY(vm, _in, ad_exp, _d); break; }
+    case 24: { int _in = (vm->active_tape && vm->sp>0) ? vm->ad_node_map[vm->sp-1] : -1; Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 24)) break; int _d = (a.type==VAL_DUAL); if (_d) { vm_push(vm,a); vm_dispatch_native(vm,380); } else vm_push(vm, FLOAT_VAL(log(as_number(a)))); VM_AD_TRACE_UNARY(vm, _in, ad_log, _d); break; }
+    case 25: { int _in = (vm->active_tape && vm->sp>0) ? vm->ad_node_map[vm->sp-1] : -1; Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 25)) break; int _d = (a.type==VAL_DUAL); if (_d) { vm_push(vm,a); vm_dispatch_native(vm,381); } else vm_push(vm, FLOAT_VAL(sqrt(as_number(a)))); VM_AD_TRACE_UNARY(vm, _in, ad_sqrt, _d); break; }
     /* floor/ceiling/round preserve exactness: (floor 2.5) is the INEXACT 2.0,
      * not the exact 2 — the integral result shape must not decide the tag. */
     case 26: { Value a = vm_pop(vm); vm_push(vm, number_val_contagious1(a, floor(as_number_vm(vm,a)))); break; }
     case 27: { Value a = vm_pop(vm); vm_push(vm, number_val_contagious1(a, ceil(as_number_vm(vm,a)))); break; }
     case 28: { Value a = vm_pop(vm); vm_push(vm, number_val_contagious1(a, vm_round_half_even(as_number_vm(vm,a)))); break; }
-    case 29: { Value a = vm_pop(vm); vm_push(vm, FLOAT_VAL(asin(as_number_vm(vm,a)))); break; }
-    case 30: { Value a = vm_pop(vm); vm_push(vm, FLOAT_VAL(acos(as_number_vm(vm,a)))); break; }
-    case 31: { Value a = vm_pop(vm); vm_push(vm, FLOAT_VAL(atan(as_number_vm(vm,a)))); break; }
+    case 29: { Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 29)) break; vm_push(vm, FLOAT_VAL(asin(as_number_vm(vm,a)))); break; }
+    case 30: { Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 30)) break; vm_push(vm, FLOAT_VAL(acos(as_number_vm(vm,a)))); break; }
+    case 31: { Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 31)) break; vm_push(vm, FLOAT_VAL(atan(as_number_vm(vm,a)))); break; }
     case 32: { Value b = vm_pop(vm); Value a = vm_pop(vm);
         if (a.type==VAL_DUAL||b.type==VAL_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,385); break; }
         /* Exact integer base with a non-negative integer exponent → exact
@@ -12869,7 +12915,64 @@ static void vm_dispatch_native(VM* vm, int fid) {
         break;
     }
     case 213: { Value a = vm_pop(vm); vm_push(vm, FLOAT_VAL(as_number_vm(vm, a))); break; }  /* exact->inexact */
-    case 214: { Value a = vm_pop(vm); vm_push(vm, INT_VAL((int64_t)as_number_vm(vm, a))); break; } /* inexact->exact */
+    case 214: { /* inexact->exact */
+        Value a = vm_pop(vm);
+        /* Already exact tags pass through unchanged — truncating them to an
+         * int64 was how (inexact->exact 1/2) used to become 0. */
+        if (a.type == VAL_INT || a.type == VAL_RATIONAL || a.type == VAL_BIGNUM) {
+            vm_push(vm, a); break;
+        }
+        double d214 = as_number_vm(vm, a);
+        if (d214 == 0.0) { vm_push(vm, INT_VAL(0)); break; }
+        if (!isfinite(d214)) {
+            fprintf(stderr, "ERROR: inexact->exact: no exact representation for %s\n",
+                    isnan(d214) ? "+nan.0" : (d214 > 0 ? "+inf.0" : "-inf.0"));
+            vm->error = 1; break;
+        }
+        /* Exact expansion: a finite double IS odd_mantissa * 2^exp2. Shared,
+         * digit for digit, with lib/core/rational.cpp — see the comment there
+         * for what the old `(int64_t)as_number(...)` truncation cost. */
+        int e214 = 0;
+        double frac214 = frexp(d214 < 0 ? -d214 : d214, &e214);
+        uint64_t mant214 = (uint64_t)ldexp(frac214, 53);
+        int exp214 = e214 - 53;
+        while (mant214 && (mant214 & 1u) == 0u) { mant214 >>= 1; exp214 += 1; }
+        int64_t num214 = (d214 < 0) ? -(int64_t)mant214 : (int64_t)mant214;
+        if (exp214 >= 0) {
+            /* Whole value. The VM's exact integers are int64 (its rationals
+             * are int64 pairs), so a magnitude past int64 has no exact VM
+             * representation: say so rather than push a wrong number. */
+            if (exp214 < 62 && mant214 < ((uint64_t)1 << (62 - exp214))) {
+                vm_push(vm, INT_VAL(num214 << exp214)); break;
+            }
+            fprintf(stderr, "ERROR: inexact->exact: %g is outside this VM's exact "
+                            "integer range (int64)\n", d214);
+            vm->error = 1; break;
+        }
+        {
+            int shift214 = -exp214;
+            VmArena* i2e_arena;
+            VmRational* i2e_r;
+            int32_t i2e_ptr;
+            if (shift214 >= 63) {
+                /* Subnormals and other tiny values need a denominator past
+                 * 2^62; VmRational is an int64 pair, so it cannot hold them.
+                 * Recorded as a native/VM divergence in
+                 * tests/vm_parity/PARITY.tsv rather than silently rounded. */
+                fprintf(stderr, "ERROR: inexact->exact: %g needs a denominator "
+                                "beyond this VM's int64 rationals\n", d214);
+                vm->error = 1; break;
+            }
+            i2e_arena = vm_active_arena(&vm->heap.regions);
+            i2e_r = vm_rational_make(i2e_arena, num214, (int64_t)1 << shift214);
+            if (!i2e_r) { vm->error = 1; break; }
+            i2e_ptr = heap_alloc(&vm->heap);
+            if (i2e_ptr < 0) { vm->error = 1; break; }
+            vm->heap.objects[i2e_ptr]->type = HEAP_RATIONAL;
+            vm->heap.objects[i2e_ptr]->opaque.ptr = i2e_r;
+            vm_push(vm, (Value){.type = VAL_RATIONAL, .as.ptr = i2e_ptr});
+        }
+        break; }
     case 215: { /* string->number — handles #x/#b/#o/#d prefixes */
         Value a = vm_pop(vm);
         if (a.type != VAL_STRING) { vm_push(vm, BOOL_VAL(0)); break; }
@@ -13414,9 +13517,9 @@ static void vm_dispatch_native(VM* vm, int fid) {
     /* ══════════════════════════════════════════════════════════════════════
      * Math extensions (720-746)
      * ══════════════════════════════════════════════════════════════════════ */
-    case 720: { Value a = vm_pop(vm); vm_push(vm, FLOAT_VAL(cosh(as_number(a)))); break; }
-    case 721: { Value a = vm_pop(vm); vm_push(vm, FLOAT_VAL(sinh(as_number(a)))); break; }
-    case 722: { Value a = vm_pop(vm); vm_push(vm, FLOAT_VAL(tanh(as_number(a)))); break; }
+    case 720: { Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 720)) break; vm_push(vm, FLOAT_VAL(cosh(as_number(a)))); break; }
+    case 721: { Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 721)) break; vm_push(vm, FLOAT_VAL(sinh(as_number(a)))); break; }
+    case 722: { Value a = vm_pop(vm); if (vm_math_complex_dispatch(vm, a, 722)) break; vm_push(vm, FLOAT_VAL(tanh(as_number(a)))); break; }
     case 726: { /* write-line */
         Value s = vm_pop(vm);
         if (s.type == VAL_STRING) { VmString* vs = (VmString*)vm->heap.objects[s.as.ptr]->opaque.ptr;

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -12999,7 +12999,10 @@ static void vm_dispatch_native(VM* vm, int fid) {
              * are int64 pairs), so a magnitude past int64 has no exact VM
              * representation: say so rather than push a wrong number. */
             if (exp214 < 62 && mant214 < ((uint64_t)1 << (62 - exp214))) {
-                vm_push(vm, INT_VAL(num214 << exp214)); break;
+                /* Shift the UNSIGNED magnitude and re-apply the sign:
+                 * a left shift of a negative int64 is undefined. */
+                int64_t whole214 = (int64_t)(mant214 << exp214);
+                vm_push(vm, INT_VAL(d214 < 0 ? -whole214 : whole214)); break;
             }
             fprintf(stderr, "ERROR: inexact->exact: %g is outside this VM's exact "
                             "integer range (int64)\n", d214);

--- a/lib/core/complex_math.cpp
+++ b/lib/core/complex_math.cpp
@@ -1,0 +1,79 @@
+/**
+ * @file complex_math.cpp
+ * @brief Native-runtime symbols for the complex transcendentals.
+ *
+ * Thin `extern "C"` wrappers over the shared inline core in
+ * `<eshkol/core/complex_math.h>`. The LLVM back end emits calls to these
+ * symbols when a math builtin is applied to an ESHKOL_VALUE_COMPLEX operand;
+ * the bytecode VM includes the same header and calls the inline functions
+ * directly, so the two engines compute identical bits.
+ *
+ * Calling convention: operands and results are passed by pointer to a
+ * 16-byte `eshkol_complex_number_t`, so no struct-return ABI variation can
+ * come between the compiler-emitted call and this definition. `out` may alias
+ * `z` — every wrapper computes into a local before storing.
+ *
+ * Before these existed, a complex operand reaching `sin`/`sqrt`/`exp`/... was
+ * routed into the scalar path, which read the tagged value's payload — a HEAP
+ * POINTER — as an IEEE double: `(sqrt (make-rectangular -1.0 0.0))` printed
+ * 73278.56614317723 and `(exp (make-rectangular 0.0 3.14159))` printed
+ * +inf.0. See tests/numeric/complex_transcendentals_test.esk.
+ *
+ * Copyright (C) Tsotchke Corporation. MIT License.
+ */
+
+#include <eshkol/core/complex_math.h>
+#include <eshkol/eshkol.h>
+
+namespace {
+
+/** @brief Reinterpret a runtime complex struct as the shared pair type. */
+inline eshkol_cpx load_cpx(const eshkol_complex_number_t* z) {
+    return eshkol_cpx_make(z->real, z->imag);
+}
+
+/** @brief Store a shared pair back into a runtime complex struct. */
+inline void store_cpx(eshkol_complex_number_t* out, eshkol_cpx v) {
+    out->real = v.re;
+    out->imag = v.im;
+}
+
+}  // namespace
+
+/**
+ * Define one `extern "C"` wrapper per unary complex function. Each is named
+ * `eshkol_complex_<name>` — the name the LLVM back end looks up.
+ */
+#define ESHKOL_DEFINE_COMPLEX_UNARY(name)                                     \
+    extern "C" void eshkol_complex_##name(const eshkol_complex_number_t* z,   \
+                                          eshkol_complex_number_t* out) {     \
+        store_cpx(out, eshkol_cpx_##name(load_cpx(z)));                       \
+    }
+
+ESHKOL_DEFINE_COMPLEX_UNARY(sqrt)
+ESHKOL_DEFINE_COMPLEX_UNARY(exp)
+ESHKOL_DEFINE_COMPLEX_UNARY(log)
+ESHKOL_DEFINE_COMPLEX_UNARY(log2)
+ESHKOL_DEFINE_COMPLEX_UNARY(log10)
+ESHKOL_DEFINE_COMPLEX_UNARY(exp2)
+ESHKOL_DEFINE_COMPLEX_UNARY(sin)
+ESHKOL_DEFINE_COMPLEX_UNARY(cos)
+ESHKOL_DEFINE_COMPLEX_UNARY(tan)
+ESHKOL_DEFINE_COMPLEX_UNARY(asin)
+ESHKOL_DEFINE_COMPLEX_UNARY(acos)
+ESHKOL_DEFINE_COMPLEX_UNARY(atan)
+ESHKOL_DEFINE_COMPLEX_UNARY(sinh)
+ESHKOL_DEFINE_COMPLEX_UNARY(cosh)
+ESHKOL_DEFINE_COMPLEX_UNARY(tanh)
+ESHKOL_DEFINE_COMPLEX_UNARY(asinh)
+ESHKOL_DEFINE_COMPLEX_UNARY(acosh)
+ESHKOL_DEFINE_COMPLEX_UNARY(atanh)
+
+#undef ESHKOL_DEFINE_COMPLEX_UNARY
+
+/** @brief Principal complex power a^b = exp(b log a) (R7RS `expt`). */
+extern "C" void eshkol_complex_pow(const eshkol_complex_number_t* a,
+                                   const eshkol_complex_number_t* b,
+                                   eshkol_complex_number_t* out) {
+    store_cpx(out, eshkol_cpx_pow(load_cpx(a), load_cpx(b)));
+}

--- a/lib/core/rational.cpp
+++ b/lib/core/rational.cpp
@@ -345,14 +345,63 @@ extern "C" int64_t eshkol_rational_denominator(void* r) {
     return ((eshkol_rational_t*)r)->denominator;
 }
 
-/** Convert a rational to its nearest double-precision floating-point value. */
+/** @brief Bit length of a bignum's magnitude; 0 for zero. */
+static int64_t bn_bitlen(const eshkol_bignum_t* a) {
+    const uint64_t* limbs = BIGNUM_LIMBS((eshkol_bignum_t*)a);
+    for (int64_t i = (int64_t)a->num_limbs - 1; i >= 0; --i) {
+        if (limbs[i]) {
+            uint64_t v = limbs[i];
+            int bits = 0;
+            while (v) { v >>= 1; ++bits; }
+            return i * 64 + bits;
+        }
+    }
+    return 0;
+}
+
+/** @brief Convert a rational to its nearest double-precision value.
+ *
+ *  The bignum path divides the two components AFTER scaling them into range
+ *  rather than converting each to a double first. Converting first cannot
+ *  work for the exact values `inexact->exact` now produces: the exact value
+ *  of 1e-300 is a 53-bit numerator over 2^1049, and 2^1049 exceeds DBL_MAX,
+ *  so `bignum_to_double(den)` was +inf and the whole rational came back 0 —
+ *  `(exact->inexact (inexact->exact 1e-300))` was 0, not 1e-300.
+ *
+ *  Scaling one side by a power of two leaves the quotient with ~55 significant
+ *  bits, well inside double range, and `ldexp` puts the exponent back (with
+ *  correct gradual underflow into the subnormals). */
 extern "C" double eshkol_rational_to_double(void* r) {
     eshkol_rational_t* rat = (eshkol_rational_t*)r;
-    if (rat->is_big) {
+    if (!rat->is_big) {
+        return (double)rat->numerator / (double)rat->denominator;
+    }
+    if (eshkol_bignum_is_zero(rat->big_num)) return 0.0;
+
+    arena_t* arena = arena_get_thread_local();
+    int64_t nb = bn_bitlen(rat->big_num);
+    int64_t db = bn_bitlen(rat->big_den);
+    int64_t k = 55 - (nb - db);   /* target quotient width: ~55 bits */
+
+    const eshkol_bignum_t* num = rat->big_num;
+    const eshkol_bignum_t* den = rat->big_den;
+    if (k > 0) {
+        num = eshkol_bignum_shift(arena, num, k);
+    } else if (k < 0) {
+        den = eshkol_bignum_shift(arena, den, -k);
+    }
+    if (!num || !den) {
+        /* Scratch allocation failed — fall back to the component quotient,
+         * which is at least right for in-range magnitudes. */
         return eshkol_bignum_to_double(rat->big_num) /
                eshkol_bignum_to_double(rat->big_den);
     }
-    return (double)rat->numerator / (double)rat->denominator;
+    eshkol_bignum_t* q = eshkol_bignum_div(arena, num, den);
+    if (!q) {
+        return eshkol_bignum_to_double(rat->big_num) /
+               eshkol_bignum_to_double(rat->big_den);
+    }
+    return ldexp(eshkol_bignum_to_double(q), (int)-k);
 }
 
 /** Return non-zero if the rational represents an integer (denominator == 1). */

--- a/lib/core/rational.cpp
+++ b/lib/core/rational.cpp
@@ -31,6 +31,10 @@ extern "C" arena_t* arena_get_thread_local(void);
  * through the public bignum API (lib/core/bignum.cpp); this file never
  * degrades an exact rational to double. */
 
+/** Tag a bignum as an exact integer, demoting to INT64 when it fits.
+ *  Defined below; declared here for eshkol_double_to_exact_tagged(). */
+static eshkol_tagged_value_t bignum_to_tagged_int(eshkol_bignum_t* b);
+
 /** True if bignum @p a equals the int64 constant @p k. */
 static inline bool bn_equals_i64(const eshkol_bignum_t* a, int64_t k) {
     int64_t v;
@@ -358,19 +362,147 @@ extern "C" int eshkol_rational_is_integer(void* r) {
     return rat->denominator == 1;
 }
 
-/* Convert IEEE 754 double to exact rational (R7RS inexact->exact) */
+/* ===== Exact double -> rational (R7RS inexact->exact) =====
+ *
+ * A finite IEEE-754 double IS a rational: it is exactly mantissa * 2^exponent
+ * with a 53-bit integer mantissa. `inexact->exact` must return THAT number,
+ * not a nearby one — ESHKOL_LANGUAGE_GUIDE.md documents
+ * `(inexact->exact 0.1)` => 3602879701896397/36028797018963968, the exact
+ * value of the double 0.1.
+ *
+ * The previous implementation multiplied by 2 until the value looked integral
+ * *or* the denominator reached 2^52, then truncated:
+ *
+ *     while (abs_d != floor(abs_d) && den < (1LL << 52)) { abs_d *= 2; den *= 2; }
+ *     num = (int64_t)abs_d;
+ *
+ * 0.1 needs 2^55, so the loop hit its cap with abs_d = 450359962737049.6 and
+ * the cast threw away the .6, yielding 450359962737049/4503599627370496 — a
+ * DIFFERENT double, which is why `(exact->inexact (inexact->exact 0.1))` came
+ * back as 0.09999999999999987. The cap also made every subnormal collapse to
+ * 0 and every |x| >= 2^63 overflow the cast.
+ *
+ * Decomposing the bits instead is exact by construction and needs no loop:
+ * `frexp` gives the normalized significand, scaling it by 2^53 makes it an
+ * integer (true for subnormals too, since frexp normalizes them), and the
+ * residual power of two becomes the numerator shift or the denominator. */
+
+/** @brief Split a finite non-zero double into odd_mantissa * 2^exp2.
+ *  @param d Input; must be finite and non-zero.
+ *  @param mant_out Receives the mantissa magnitude, always odd.
+ *  @param exp_out Receives the binary exponent.
+ *  @param neg_out Receives 1 when @p d is negative. */
+static void double_decompose_exact(double d, uint64_t* mant_out,
+                                   int* exp_out, int* neg_out) {
+    int e = 0;
+    double frac = frexp(d < 0 ? -d : d, &e);   /* 0.5 <= frac < 1 */
+    uint64_t mant = (uint64_t)ldexp(frac, 53); /* exact: < 2^53 */
+    int exp2 = e - 53;
+    /* Strip trailing zero bits so the pair is already in lowest terms against
+     * any power-of-two denominator — no GCD pass over a 1074-bit number. */
+    while (mant && (mant & 1u) == 0u) {
+        mant >>= 1;
+        exp2 += 1;
+    }
+    *mant_out = mant;
+    *exp_out = exp2;
+    *neg_out = (d < 0) ? 1 : 0;
+}
+
+/** @brief Exact IEEE-754 double -> rational (R7RS `inexact->exact`).
+ *
+ *  Returns the exact value of @p d. Whole-valued doubles come back with
+ *  denominator 1 (promoting the numerator to a bignum when it exceeds int64,
+ *  e.g. 1e300); fractional ones come back as mantissa/2^k, with a bignum
+ *  denominator for subnormals. A non-finite input has no exact value: it
+ *  reports an error and yields 0/1. */
 extern "C" void* eshkol_double_to_rational(void* arena, double d) {
     if (d == 0.0) return eshkol_rational_create(arena, 0, 1);
-    // Scale by powers of 2 until integer (IEEE doubles have at most 53 binary digits)
-    double abs_d = d < 0 ? -d : d;
-    int64_t den = 1;
-    while (abs_d != __builtin_floor(abs_d) && den < (1LL << 52)) {
-        abs_d *= 2.0;
-        den *= 2;
+    if (!std::isfinite(d)) {
+        eshkol_error("inexact->exact: no exact representation for %s",
+                     std::isnan(d) ? "+nan.0" : (d > 0 ? "+inf.0" : "-inf.0"));
+        return eshkol_rational_create(arena, 0, 1);
     }
-    int64_t num = (int64_t)abs_d;
-    if (d < 0) num = -num;
-    return eshkol_rational_create(arena, num, den);  // auto-reduces via GCD
+
+    uint64_t mant;
+    int exp2, neg;
+    double_decompose_exact(d, &mant, &exp2, &neg);
+    int64_t num = neg ? -(int64_t)mant : (int64_t)mant;
+
+    if (exp2 == 0) {
+        return eshkol_rational_create(arena, num, 1);
+    }
+    if (exp2 > 0) {
+        /* Whole number: mantissa << exp2. Fits int64 only for small shifts. */
+        if (exp2 < 62 && mant < (uint64_t)1 << (62 - exp2)) {
+            return eshkol_rational_create(arena, num << exp2, 1);
+        }
+        eshkol_bignum_t* bn = eshkol_bignum_from_int64((arena_t*)arena, num);
+        eshkol_bignum_t* shifted = eshkol_bignum_shift((arena_t*)arena, bn, exp2);
+        eshkol_bignum_t* one = eshkol_bignum_from_int64((arena_t*)arena, 1);
+        return eshkol_rational_create_bn(arena, shifted, one);
+    }
+    /* Fractional: mantissa / 2^(-exp2). */
+    int shift = -exp2;
+    if (shift < 63) {
+        return eshkol_rational_create(arena, num, (int64_t)1 << shift);
+    }
+    eshkol_bignum_t* bn_num = eshkol_bignum_from_int64((arena_t*)arena, num);
+    eshkol_bignum_t* bn_one = eshkol_bignum_from_int64((arena_t*)arena, 1);
+    eshkol_bignum_t* bn_den = eshkol_bignum_shift((arena_t*)arena, bn_one, shift);
+    return eshkol_rational_create_bn(arena, bn_num, bn_den);
+}
+
+/** @brief Exact `inexact->exact` returning a tagged value.
+ *
+ *  The single entry point the back ends call. It exists because exactness
+ *  conversion is not shape-preserving: a whole double becomes an exact INTEGER
+ *  (int64, or a bignum past int64 range), a fractional one becomes a RATIONAL.
+ *  The LLVM back end used to make that choice itself with
+ *  `is_whole ? fptosi(d) : eshkol_double_to_rational(d)`, and the `fptosi` arm
+ *  is undefined once |d| >= 2^63 — `(inexact->exact 1e300)` returned the
+ *  garbage 4347791012. Deciding here keeps one implementation for both engines
+ *  and no undefined cast anywhere.
+ *
+ *  @param arena Allocation arena.
+ *  @param d Value to convert; must be finite.
+ *  @param out Receives the exact result. */
+extern "C" void eshkol_double_to_exact_tagged(void* arena, double d,
+                                              eshkol_tagged_value_t* out) {
+    if (!out) return;
+    if (d == 0.0) {
+        *out = eshkol_make_int64(0, true);
+        return;
+    }
+    if (!std::isfinite(d)) {
+        eshkol_error("inexact->exact: no exact representation for %s",
+                     std::isnan(d) ? "+nan.0" : (d > 0 ? "+inf.0" : "-inf.0"));
+        *out = eshkol_make_int64(0, true);
+        return;
+    }
+
+    uint64_t mant;
+    int exp2, neg;
+    double_decompose_exact(d, &mant, &exp2, &neg);
+    int64_t num = neg ? -(int64_t)mant : (int64_t)mant;
+
+    if (exp2 == 0) {
+        *out = eshkol_make_int64(num, true);
+        return;
+    }
+    if (exp2 > 0) {
+        if (exp2 < 62 && mant < (uint64_t)1 << (62 - exp2)) {
+            *out = eshkol_make_int64(num << exp2, true);
+            return;
+        }
+        eshkol_bignum_t* bn = eshkol_bignum_from_int64((arena_t*)arena, num);
+        eshkol_bignum_t* shifted = eshkol_bignum_shift((arena_t*)arena, bn, exp2);
+        *out = bignum_to_tagged_int(shifted);
+        return;
+    }
+    *out = eshkol_make_ptr(
+        (uint64_t)(uintptr_t)eshkol_double_to_rational(arena, d),
+        ESHKOL_VALUE_HEAP_PTR);
 }
 
 /* Format rational as "num/denom" string into arena-allocated buffer with

--- a/lib/core/rational.cpp
+++ b/lib/core/rational.cpp
@@ -484,7 +484,10 @@ extern "C" void* eshkol_double_to_rational(void* arena, double d) {
     if (exp2 > 0) {
         /* Whole number: mantissa << exp2. Fits int64 only for small shifts. */
         if (exp2 < 62 && mant < (uint64_t)1 << (62 - exp2)) {
-            return eshkol_rational_create(arena, num << exp2, 1);
+            /* Shift the UNSIGNED magnitude and re-apply the sign: a left shift
+             * of a negative int64 is undefined before C++20. */
+            int64_t whole = (int64_t)(mant << exp2);
+            return eshkol_rational_create(arena, neg ? -whole : whole, 1);
         }
         eshkol_bignum_t* bn = eshkol_bignum_from_int64((arena_t*)arena, num);
         eshkol_bignum_t* shifted = eshkol_bignum_shift((arena_t*)arena, bn, exp2);
@@ -541,7 +544,8 @@ extern "C" void eshkol_double_to_exact_tagged(void* arena, double d,
     }
     if (exp2 > 0) {
         if (exp2 < 62 && mant < (uint64_t)1 << (62 - exp2)) {
-            *out = eshkol_make_int64(num << exp2, true);
+            int64_t whole = (int64_t)(mant << exp2);
+            *out = eshkol_make_int64(neg ? -whole : whole, true);
             return;
         }
         eshkol_bignum_t* bn = eshkol_bignum_from_int64((arena_t*)arena, num);

--- a/tests/numeric/complex_transcendentals_test.esk
+++ b/tests/numeric/complex_transcendentals_test.esk
@@ -1,0 +1,111 @@
+(require stdlib)
+
+; Task #113 — complex transcendentals.
+;
+; Before this suite existed, every unary math builtin applied to a complex
+; read the tagged value's HEAP POINTER as an IEEE double. The measured
+; pre-fix answers are quoted next to the assertions that catch them, so this
+; file fails closed on the original defect rather than merely covering the
+; fix: run it against a pre-fix build and the first two cases print FAIL.
+
+(display "TEST: Complex transcendental functions (task #113)") (newline)
+
+(define (chk name ok)
+  (display (if ok "PASS" "FAIL")) (display ": ") (display name) (newline))
+
+; `<=` not `<`: an exactness assertion passes tol 0.0.
+(define (near? a b tol) (<= (abs (- a b)) tol))
+
+; A complex result is checked component-wise. `complex?` is true for reals
+; too (R7RS: every real is a complex), so it can never detect the defect —
+; only the component values can.
+(define (chk-z name z re im tol)
+  (chk name (and (near? (real-part z) re tol)
+                 (near? (imag-part z) im tol))))
+
+(define pi 3.141592653589793)
+
+; ── The two examples documented in docs/ESHKOL_LANGUAGE_GUIDE.md ──────────
+; (sqrt (make-rectangular -1.0 0.0)) ;; -> 0.0+1.0i
+; (exp (make-rectangular 0.0 3.14159)) ;; -> -1.0+0.0i (approximately)
+
+(define doc-sqrt (sqrt (make-rectangular -1.0 0.0)))
+; pre-fix: 73278.56614317723 (an address read as a double)
+(chk "doc: (sqrt (make-rectangular -1.0 0.0)) real part is exactly 0.0"
+     (= (real-part doc-sqrt) 0.0))
+(chk "doc: (sqrt (make-rectangular -1.0 0.0)) imag part is exactly 1.0"
+     (= (imag-part doc-sqrt) 1.0))
+
+(define doc-exp (exp (make-rectangular 0.0 3.14159)))
+; pre-fix: +inf.0
+(chk-z "doc: (exp (make-rectangular 0.0 3.14159)) is -1.0+0.0i approximately"
+       doc-exp -1.0 0.0 1.0e-5)
+
+; ── Exact-valued cases ───────────────────────────────────────────────────
+(chk-z "sqrt(3+4i) = 2+1i exactly"
+       (sqrt (make-rectangular 3.0 4.0)) 2.0 1.0 0.0)
+(chk-z "sqrt(-4+0i) = 0+2i exactly"
+       (sqrt (make-rectangular -4.0 0.0)) 0.0 2.0 0.0)
+
+; Branch cut: sqrt is continuous from above on the negative real axis, so the
+; sign of a zero imaginary part selects the root. (* -1.0 0.0) is -0.0 at run
+; time and in the constant folder.
+(chk-z "sqrt(-1-0i) = 0-1i (principal branch cut)"
+       (sqrt (make-rectangular -1.0 (* -1.0 0.0))) 0.0 -1.0 0.0)
+
+(chk-z "log(-1+0i) = 0+pi i" (log (make-rectangular -1.0 0.0)) 0.0 pi 1.0e-15)
+(chk-z "exp(0+pi i) = -1+0i (Euler)" (exp (make-rectangular 0.0 pi))
+       -1.0 0.0 1.0e-15)
+
+; ── Identities over the whole implemented surface ────────────────────────
+(define z (make-rectangular 0.7 -1.3))
+
+(define (z-near? a b tol)
+  (and (near? (real-part a) (real-part b) tol)
+       (near? (imag-part a) (imag-part b) tol)))
+
+(chk "exp(log z) = z" (z-near? (exp (log z)) z 1.0e-12))
+(chk "sqrt(z)^2 = z" (z-near? (let ((r (sqrt z))) (* r r)) z 1.0e-12))
+(chk "sin^2 z + cos^2 z = 1"
+     (z-near? (+ (* (sin z) (sin z)) (* (cos z) (cos z)))
+              (make-rectangular 1.0 0.0) 1.0e-12))
+(chk "tan z = sin z / cos z" (z-near? (tan z) (/ (sin z) (cos z)) 1.0e-12))
+(chk "cosh^2 z - sinh^2 z = 1"
+     (z-near? (- (* (cosh z) (cosh z)) (* (sinh z) (sinh z)))
+              (make-rectangular 1.0 0.0) 1.0e-12))
+(chk "tanh z = sinh z / cosh z" (z-near? (tanh z) (/ (sinh z) (cosh z)) 1.0e-12))
+(chk "sin(asin z) = z" (z-near? (sin (asin z)) z 1.0e-12))
+(chk "cos(acos z) = z" (z-near? (cos (acos z)) z 1.0e-12))
+(chk "tan(atan z) = z" (z-near? (tan (atan z)) z 1.0e-12))
+(chk "sinh(asinh z) = z" (z-near? (sinh (asinh z)) z 1.0e-12))
+(chk "cosh(acosh z) = z" (z-near? (cosh (acosh z)) z 1.0e-12))
+(chk "tanh(atanh z) = z" (z-near? (tanh (atanh z)) z 1.0e-12))
+(chk "exp2 z = exp(z log 2)"
+     (z-near? (exp2 z) (exp (* z (log (make-rectangular 2.0 0.0)))) 1.0e-12))
+(chk "log2 z = log z / log 2"
+     (z-near? (log2 z) (/ (log z) (log 2.0)) 1.0e-12))
+(chk "log10 z = log z / log 10"
+     (z-near? (log10 z) (/ (log z) (log 10.0)) 1.0e-12))
+
+; i^i = e^(-pi/2), the classic real-valued complex power.
+(chk-z "expt(i, i) = e^(-pi/2)"
+       (expt (make-rectangular 0.0 1.0) (make-rectangular 0.0 1.0))
+       0.20787957635076193 0.0 1.0e-12)
+
+; ── The same reinterpretation, reached through an exact rational ─────────
+; The scalar fallback that misread complex pointers misread rational and
+; bignum pointers too: pre-fix (sin (/ 1 2)) was 0.9241426121154859, the
+; sine of an address.
+(chk "sin of an exact rational uses its value, not its pointer"
+     (near? (sin (/ 1 2)) 0.479425538604203 1.0e-15))
+(chk "sqrt of an exact rational uses its value, not its pointer"
+     (near? (sqrt (/ 1 4)) 0.5 1.0e-15))
+
+; ── Negative real sqrt/log stay in the documented promotion ──────────────
+; docs/reference/language/numeric-tower.md: (display (sqrt -1)) prints "+i".
+(chk-z "(sqrt -1) promotes an exact negative to +i"
+       (sqrt -1) 0.0 1.0 0.0)
+(chk "(sqrt -1.0) keeps IEEE semantics for an inexact negative"
+     (not (= (sqrt -1.0) (sqrt -1.0))))   ; NaN is not equal to itself
+
+(display "Complex transcendental tests complete") (newline)

--- a/tests/numeric/inexact_exact_roundtrip_test.esk
+++ b/tests/numeric/inexact_exact_roundtrip_test.esk
@@ -1,0 +1,88 @@
+(require stdlib)
+
+; inexact->exact must return the operand's EXACT value.
+;
+; A finite double is exactly mantissa * 2^exponent. The pre-fix conversion
+; instead doubled the value until its denominator hit a 2^52 cap and then
+; truncated, so it answered with the exact value of a DIFFERENT double. The
+; measured pre-fix answers are quoted beside the assertions that catch them:
+; run this against a pre-fix build and it fails closed.
+
+(display "TEST: inexact->exact exactness and round-trip") (newline)
+
+(define (chk name ok)
+  (display (if ok "PASS" "FAIL")) (display ": ") (display name) (newline))
+
+; (exact->inexact (inexact->exact x)) must reproduce x. `=` on two doubles is
+; bit equality for every value this suite uses (no NaN, and the one -0.0 case
+; is asserted separately, since the exact value of -0.0 is 0 and converting
+; back gives +0.0 — that is R7RS, not a defect).
+(define (roundtrip? x) (= (exact->inexact (inexact->exact x)) x))
+
+; ── The example documented in docs/ESHKOL_LANGUAGE_GUIDE.md ──────────────
+; (inexact->exact 0.1) ;; -> 3602879701896397/36028797018963968
+; pre-fix: 450359962737049/4503599627370496
+(chk "doc: (inexact->exact 0.1) = 3602879701896397/36028797018963968"
+     (= (inexact->exact 0.1) (/ 3602879701896397 36028797018963968)))
+; (inexact->exact 0.5) ;; -> 1/2
+(chk "doc: (inexact->exact 0.5) = 1/2" (= (inexact->exact 0.5) 1/2))
+
+; The exact value is exact: it must not equal the neighbouring double's.
+(chk "0.1's exact value is not the pre-fix 450359962737049/4503599627370496"
+     (not (= (inexact->exact 0.1) (/ 450359962737049 4503599627370496))))
+
+; ── Round-trip over the probe set ────────────────────────────────────────
+; pre-fix: (exact->inexact (inexact->exact 0.1)) = 0.09999999999999987
+(chk "round-trip 0.1" (roundtrip? 0.1))
+(chk "round-trip 0.2" (roundtrip? 0.2))
+(chk "round-trip 0.3" (roundtrip? 0.3))
+; nearest double to 1/3
+(chk "round-trip 1/3-nearest" (roundtrip? 0.3333333333333333))
+(chk "round-trip pi" (roundtrip? 3.141592653589793))
+(chk "round-trip -0.1 (negative)" (roundtrip? -0.1))
+(chk "round-trip -2.5 (negative, whole halves)" (roundtrip? -2.5))
+
+; Powers of two, exact on both sides of 1.
+(chk "round-trip 0.5" (roundtrip? 0.5))
+(chk "round-trip 0.25" (roundtrip? 0.25))
+(chk "round-trip 2.0" (roundtrip? 2.0))
+(chk "round-trip 1024.0" (roundtrip? 1024.0))
+(chk "round-trip 2^70" (roundtrip? 1180591620717411303424.0))
+
+; Extremes. pre-fix: (inexact->exact 1e300) = 4347791012 (fptosi past 2^63);
+; (inexact->exact 5e-324) = 0 (the 2^52 denominator cap).
+(chk "round-trip 1e300 (past int64)" (roundtrip? 1e300))
+(chk "round-trip 1e-300" (roundtrip? 1e-300))
+(chk "round-trip 5e-324 (smallest subnormal)" (roundtrip? 5e-324))
+(chk "round-trip 2.2250738585072014e-308 (smallest normal)"
+     (roundtrip? 2.2250738585072014e-308))
+
+; ± zero. R7RS: the exact value of -0.0 is 0, so the round trip lands on +0.0.
+(chk "(inexact->exact 0.0) = 0" (= (inexact->exact 0.0) 0))
+(chk "(inexact->exact -0.0) = 0" (= (inexact->exact -0.0) 0))
+(chk "round-trip 0.0" (roundtrip? 0.0))
+
+; ── Result shape ─────────────────────────────────────────────────────────
+(chk "every exact result is exact?" (and (exact? (inexact->exact 0.1))
+                                         (exact? (inexact->exact 3.0))
+                                         (exact? (inexact->exact 1e300))))
+(chk "a whole double converts to an exact integer, not a rational"
+     (exact-integer? (inexact->exact 3.0)))
+(chk "(inexact->exact 3.0) = 3" (= (inexact->exact 3.0) 3))
+(chk "(inexact->exact 1e300) is an exact integer past int64"
+     (and (exact-integer? (inexact->exact 1e300))
+          (> (inexact->exact 1e300) 1000000000000000000)))
+(chk "a fractional double converts to a rational" (rational? (inexact->exact 0.1)))
+(chk "0.1's exact numerator/denominator match the documented pair"
+     (and (= (numerator (inexact->exact 0.1)) 3602879701896397)
+          (= (denominator (inexact->exact 0.1)) 36028797018963968)))
+
+; Already-exact operands pass through untouched.
+(chk "(inexact->exact 1/2) = 1/2" (= (inexact->exact 1/2) 1/2))
+(chk "(inexact->exact 7) = 7" (= (inexact->exact 7) 7))
+
+; `exact` is the R7RS spelling of the same operation.
+(chk "(exact 0.1) agrees with (inexact->exact 0.1)"
+     (= (exact 0.1) (inexact->exact 0.1)))
+
+(display "inexact->exact tests complete") (newline)

--- a/tests/vm_parity/PARITY.tsv
+++ b/tests/vm_parity/PARITY.tsv
@@ -30,7 +30,7 @@ _region-close-list	vm-supported
 _region-open	vm-supported	
 abs	vm-supported	stays in the operand's domain: (abs 1/3) is the exact 1/3 (it used to read the rational's heap pointer as 0) and (abs -2.0) stays inexact (corpus/52_numeric_tag_dispatch.esk)
 acons	gap	no VM name binding
-acos	vm-supported	
+acos	vm-supported	a complex operand routes to the shared complex core (principal branch) rather than collapsing to acos(0) (corpus/54_complex_transcendentals.esk)
 acosh	gap	no VM name binding
 ad-abs	vm-supported	
 ad-add	vm-supported	
@@ -69,7 +69,7 @@ apply	vm-supported
 apply-window	gap	signal faculty has no VM fid coverage
 arange	vm-supported	#322: 1/2/3-arg (arange stop | start stop | start stop step) via a VM-compiler special form; native handler pops (start,stop,step)
 arithmetic-shift	vm-supported	
-asin	vm-supported	
+asin	vm-supported	a complex operand routes to the shared complex core (principal branch) rather than collapsing to asin(0) (corpus/54_complex_transcendentals.esk)
 asinh	gap	no VM name binding
 atan	vm-supported	
 atan2	gap	no VM name binding
@@ -175,8 +175,8 @@ conv1d	gap	ml faculty has no VM fid coverage
 conv2d	gap	ml faculty has no VM fid coverage
 conv3d	gap	ml faculty has no VM fid coverage
 convolve	gap	signal faculty has no VM fid coverage
-cos	vm-supported	
-cosh	vm-supported	
+cos	vm-supported	a complex operand routes to the shared complex core rather than collapsing to cos(0) (corpus/54_complex_transcendentals.esk)
+cosh	vm-supported	a complex operand routes to the shared complex core rather than collapsing to cosh(0) (corpus/54_complex_transcendentals.esk)
 cosine-annealing-lr	gap	ml faculty has no VM fid coverage
 cosine-embedding-loss	gap	ml faculty has no VM fid coverage
 cpu-count	vm-supported	
@@ -252,7 +252,7 @@ exp	vm-supported
 exp2	gap	no VM name binding
 expected-free-energy	vm-supported	
 exponential-decay-lr	gap	ml faculty has no VM fid coverage
-expt	vm-supported	exact integer^nonneg-integer stays exact (int, promoting to bignum on overflow)
+expt	vm-supported	exact integer^nonneg-integer stays exact (int, promoting to bignum on overflow); a complex base OR exponent promotes both and takes the principal exp(b log a), matching native — (expt i i) is 0.20787957635076193 on both engines (corpus/54_complex_transcendentals.esk)
 eye	vm-supported	
 fabs	gap	no VM name binding
 fact?	vm-supported	
@@ -384,7 +384,7 @@ image-read	vm-supported
 image-to-grayscale	vm-supported	
 image-write	vm-supported	
 inexact	gap	no VM name binding
-inexact->exact	vm-supported	
+inexact->exact	vm-supported	returns the operand's EXACT value via the same mantissa*2^exp decomposition as the native runtime, so (inexact->exact 0.1) is 3602879701896397/36028797018963968 on both engines (it used to truncate to an int64, giving 0). VmRational is an int64 pair and VAL_INT is int64, so magnitudes needing a bignum numerator (|x| >= 2^62, e.g. 1e300) or a denominator past 2^62 (subnormals, e.g. 5e-324) have no exact VM representation: the VM reports a fatal error naming the value rather than pushing a wrong number, where native promotes to bignum
 inexact?	vm-supported	
 infinite?	vm-supported	
 inject-left	gap	no VM name binding
@@ -432,7 +432,7 @@ list-copy	gap	no VM name binding
 list-set!	gap	no VM name binding
 list?	vm-supported	
 local-timezone-offset	vm-supported	
-log	vm-supported	
+log	vm-supported	a complex operand takes the principal complex logarithm from the shared core, and a NEGATIVE EXACT real promotes to log|x| + pi i, matching native; an inexact negative keeps IEEE NaN (corpus/54_complex_transcendentals.esk)
 log10	gap	no VM name binding
 log2	gap	no VM name binding
 logic-var?	vm-supported	
@@ -736,8 +736,8 @@ sha256-file	vm-supported
 shell-quote	vm-supported	
 sigmoid	vm-supported	
 silu	gap	ml faculty has no VM fid coverage
-sin	vm-supported	
-sinh	vm-supported	
+sin	vm-supported	a complex operand routes to the shared complex core rather than collapsing to sin(0) (corpus/54_complex_transcendentals.esk)
+sinh	vm-supported	a complex operand routes to the shared complex core rather than collapsing to sinh(0) (corpus/54_complex_transcendentals.esk)
 sleep	native-only-justified	OS/process interface — native runtime only
 sleep-ms	vm-supported	
 slice	gap	tensor linalg/manipulation fid missing in VM
@@ -749,7 +749,7 @@ softmax	vm-supported
 softplus	gap	ml faculty has no VM fid coverage
 split	gap	tensor linalg/manipulation fid missing in VM
 split-at	gap	no VM name binding
-sqrt	vm-supported	
+sqrt	vm-supported	a complex operand takes the principal complex square root from the shared core <eshkol/core/complex_math.h> that the native back end also calls, and a NEGATIVE EXACT real promotes into the complex domain per docs/reference/language/numeric-tower.md ((sqrt -1) is +i on both engines); an inexact negative keeps IEEE NaN. as_number() used to answer 0 for a complex, so the VM silently computed sqrt(0) (corpus/54_complex_transcendentals.esk)
 square	gap	no VM name binding
 squeeze	gap	tensor linalg/manipulation fid missing in VM
 stack	gap	tensor linalg/manipulation fid missing in VM
@@ -803,8 +803,8 @@ symlink-create	vm-supported
 symlink-read	vm-supported	
 system	native-only-justified	OS/process interface — native runtime only
 take	vm-supported	
-tan	vm-supported	
-tanh	vm-supported	
+tan	vm-supported	a complex operand routes to the shared complex core rather than collapsing to tan(0) (corpus/54_complex_transcendentals.esk)
+tanh	vm-supported	a complex operand routes to the shared complex core rather than collapsing to tanh(0) (corpus/54_complex_transcendentals.esk)
 target-intrinsic	native-only-justified	low-level memory/FFI primitive tied to native codegen
 temp-directory	vm-supported	
 tensor	vm-supported	variadic constructor: leading exact-integer dims then product(dims) values, a flat value list, or one rectangular nested collection (vm_compiler (tensor ...) special form -> native 473; the closure form is 474). Was aliased to make-tensor's 2-arg native, so every call silently used only its first two arguments (corpus/39_tensor_constructor.esk); the nested-collection form is ahead of native (found/tensor_nested_collection_native.esk)

--- a/tests/vm_parity/corpus/54_complex_transcendentals.esk
+++ b/tests/vm_parity/corpus/54_complex_transcendentals.esk
@@ -4,41 +4,72 @@
 ;; value: the native back end reinterpreted the heap pointer as a double
 ;; (`(sqrt (make-rectangular -1.0 0.0))` => 73278.56614317723) while the VM's
 ;; as_number() answered 0 and computed f(0) (=> 0). Two different wrong
-;; answers, so this file's differential catches either regression on its own.
+;; answers, so this differential catches either regression on its own.
 ;;
 ;; Both engines now evaluate the SAME expressions from
-;; <eshkol/core/complex_math.h>, so agreement here is bit-for-bit.
+;; <eshkol/core/complex_math.h>, so agreement is bit-for-bit on one host.
 ;;
-;; Components are printed with real-part/imag-part rather than displaying the
-;; complex directly: the two engines format a complex differently (native
-;; "2+i", VM "2+1i" — tests/vm_parity/found/complex_display_format.esk), which
-;; is a display divergence unrelated to the values under test.
+;; TWO KINDS OF ROW, deliberately:
+;;
+;;   raw digits   only for values that are exact on any conforming libm —
+;;                the algebraic square root is one sqrt and one division, so
+;;                sqrt(-1+0i) and sqrt(3+4i) are exactly 0+1i and 2+1i
+;;                everywhere. These rows keep full digit-level sensitivity:
+;;                a reinterpreted pointer cannot land on them.
+;;
+;;   PASS/FAIL    for everything built on exp/log/trig. This corpus is also
+;;                the input to scripts/run_wasm_differential.sh, and wasm32's
+;;                musl libm differs from the host's by an ulp: e^3*sin(4) is
+;;                -15.200784463067956 natively and -15.200784463067954 under
+;;                wasm. That is a libm difference, not a codegen defect, so
+;;                these rows assert the mathematics to a tolerance that every
+;;                libm meets while still failing on any wrong-by-a-pointer
+;;                answer, which is wrong by many orders of magnitude.
+;;
+;; Components are read with real-part/imag-part rather than displaying the
+;; complex directly: the engines format a complex differently (native "2+i",
+;; VM "2+1i" — tests/vm_parity/found/complex_display_format.esk), a display
+;; divergence unrelated to the values under test.
 
-(define (show name z)
+(define (near? a b tol) (<= (abs (- a b)) tol))
+
+(define (show-exact name z)
   (display name) (display " ")
   (display (real-part z)) (display " ")
   (display (imag-part z)) (newline))
 
-;; The two examples documented in docs/ESHKOL_LANGUAGE_GUIDE.md.
-(show "doc-sqrt" (sqrt (make-rectangular -1.0 0.0)))
-(show "doc-exp" (exp (make-rectangular 0.0 3.14159)))
+(define (chk name z re im tol)
+  (display name) (display " ")
+  (display (if (and (near? (real-part z) re tol)
+                    (near? (imag-part z) im tol))
+               "PASS" "FAIL"))
+  (newline))
 
+;; ── exact on any libm ────────────────────────────────────────────────────
+;; The example documented in docs/ESHKOL_LANGUAGE_GUIDE.md.
+(show-exact "doc-sqrt" (sqrt (make-rectangular -1.0 0.0)))
+(show-exact "sqrt" (sqrt (make-rectangular 3.0 4.0)))
+;; The promotion documented in docs/reference/language/numeric-tower.md:
+;; (sqrt -1) is +i.
+(show-exact "sqrt-exact-negative" (sqrt -1))
+
+;; ── asserted to a libm-portable tolerance ────────────────────────────────
 (define z (make-rectangular 3.0 4.0))
-(show "sqrt" (sqrt z))
-(show "exp" (exp z))
-(show "log" (log z))
-(show "sin" (sin z))
-(show "cos" (cos z))
-(show "tan" (tan z))
-(show "asin" (asin z))
-(show "acos" (acos z))
-(show "sinh" (sinh z))
-(show "cosh" (cosh z))
-(show "tanh" (tanh z))
-(show "expt-real-exponent" (expt z 2))
-(show "expt-complex-exponent"
-      (expt (make-rectangular 0.0 1.0) (make-rectangular 0.0 1.0)))
 
-;; The negative-real promotion documented in
-;; docs/reference/language/numeric-tower.md: (sqrt -1) is +i.
-(show "sqrt-exact-negative" (sqrt -1))
+;; The second example documented in docs/ESHKOL_LANGUAGE_GUIDE.md.
+(chk "doc-exp" (exp (make-rectangular 0.0 3.14159)) -1.0 0.0 1.0e-5)
+
+(chk "exp" (exp z) -13.128783081462158 -15.200784463067956 1.0e-12)
+(chk "log" (log z) 1.6094379124341003 0.9272952180016122 1.0e-15)
+(chk "sin" (sin z) 3.853738037919377 -27.016813258003936 1.0e-12)
+(chk "cos" (cos z) -27.034945603074224 -3.8511533348117775 1.0e-12)
+(chk "tan" (tan z) -0.00018734620462947842 0.9993559873814732 1.0e-15)
+(chk "asin" (asin z) 0.6339838656391773 2.3055090312434685 1.0e-15)
+(chk "acos" (acos z) 0.9368124611557193 -2.3055090312434685 1.0e-15)
+(chk "sinh" (sinh z) -6.5481200409110025 -7.619231720321411 1.0e-12)
+(chk "cosh" (cosh z) -6.580663040551157 -7.5815527427465454 1.0e-12)
+(chk "tanh" (tanh z) 1.000709536067233 0.00490825806749606 1.0e-15)
+(chk "expt-real-exponent" (expt z 2) -7.0 24.0 1.0e-13)
+(chk "expt-complex-exponent"
+     (expt (make-rectangular 0.0 1.0) (make-rectangular 0.0 1.0))
+     0.20787957635076193 0.0 1.0e-15)

--- a/tests/vm_parity/corpus/54_complex_transcendentals.esk
+++ b/tests/vm_parity/corpus/54_complex_transcendentals.esk
@@ -1,0 +1,44 @@
+;; VM-parity differential for the complex transcendentals (task #113).
+;;
+;; Both engines used to answer a complex operand from a wrong reading of the
+;; value: the native back end reinterpreted the heap pointer as a double
+;; (`(sqrt (make-rectangular -1.0 0.0))` => 73278.56614317723) while the VM's
+;; as_number() answered 0 and computed f(0) (=> 0). Two different wrong
+;; answers, so this file's differential catches either regression on its own.
+;;
+;; Both engines now evaluate the SAME expressions from
+;; <eshkol/core/complex_math.h>, so agreement here is bit-for-bit.
+;;
+;; Components are printed with real-part/imag-part rather than displaying the
+;; complex directly: the two engines format a complex differently (native
+;; "2+i", VM "2+1i" — tests/vm_parity/found/complex_display_format.esk), which
+;; is a display divergence unrelated to the values under test.
+
+(define (show name z)
+  (display name) (display " ")
+  (display (real-part z)) (display " ")
+  (display (imag-part z)) (newline))
+
+;; The two examples documented in docs/ESHKOL_LANGUAGE_GUIDE.md.
+(show "doc-sqrt" (sqrt (make-rectangular -1.0 0.0)))
+(show "doc-exp" (exp (make-rectangular 0.0 3.14159)))
+
+(define z (make-rectangular 3.0 4.0))
+(show "sqrt" (sqrt z))
+(show "exp" (exp z))
+(show "log" (log z))
+(show "sin" (sin z))
+(show "cos" (cos z))
+(show "tan" (tan z))
+(show "asin" (asin z))
+(show "acos" (acos z))
+(show "sinh" (sinh z))
+(show "cosh" (cosh z))
+(show "tanh" (tanh z))
+(show "expt-real-exponent" (expt z 2))
+(show "expt-complex-exponent"
+      (expt (make-rectangular 0.0 1.0) (make-rectangular 0.0 1.0)))
+
+;; The negative-real promotion documented in
+;; docs/reference/language/numeric-tower.md: (sqrt -1) is +i.
+(show "sqrt-exact-negative" (sqrt -1))

--- a/tests/vm_parity/corpus/55_inexact_exact_exactness.esk
+++ b/tests/vm_parity/corpus/55_inexact_exact_exactness.esk
@@ -1,0 +1,53 @@
+;; VM-parity differential for inexact->exact (task #115 tail item).
+;;
+;; A finite double IS mantissa * 2^exponent, and inexact->exact must return
+;; THAT number. Both engines used to return something else, differently:
+;; native doubled the value until its denominator hit a 2^52 cap and then
+;; truncated (0.1 => 450359962737049/4503599627370496, the exact value of a
+;; different double), while the VM cast straight to an int64 (0.1 => 0).
+;; Both now use the same decomposition, so the documented value appears on
+;; both engines and the round trip is lossless.
+;;
+;; SCOPE: every case here is inside the VM's numeric tower. The VM's exact
+;; integers are int64 and its rationals an int64 pair, so magnitudes needing
+;; a bignum numerator (1e300) or a denominator past 2^62 (the subnormal
+;; 5e-324) are native-only — they are covered in
+;; tests/numeric/inexact_exact_roundtrip_test.esk and recorded against the
+;; `inexact->exact` row of tests/vm_parity/PARITY.tsv, where the VM reports a
+;; fatal error rather than pushing a wrong number.
+
+;; The two examples documented in docs/ESHKOL_LANGUAGE_GUIDE.md.
+(display "doc-0.1 ") (display (inexact->exact 0.1)) (newline)
+(display "doc-0.5 ") (display (inexact->exact 0.5)) (newline)
+
+;; Components, so a formatting change cannot hide a value change.
+(display "num-0.1 ") (display (numerator (inexact->exact 0.1))) (newline)
+(display "den-0.1 ") (display (denominator (inexact->exact 0.1))) (newline)
+
+;; Result shape: a whole double is an exact integer, not a rational.
+(display "whole ") (display (inexact->exact 3.0)) (newline)
+(display "whole-negative ") (display (inexact->exact -2.0)) (newline)
+(display "half-negative ") (display (inexact->exact -2.5)) (newline)
+(display "zero ") (display (inexact->exact 0.0)) (newline)
+
+;; Exactness of the result, on both engines.
+(display "exact? ") (display (exact? (inexact->exact 0.1))) (newline)
+(display "exact-whole? ") (display (exact? (inexact->exact 3.0))) (newline)
+;; `exact-integer?` is deliberately absent: it has no VM name binding
+;; (tests/vm_parity/PARITY.tsv), so it is asserted native-only in
+;; tests/numeric/inexact_exact_roundtrip_test.esk.
+
+;; Round trip: exact->inexact of the exact value reproduces the double.
+(display "roundtrip-0.1 ")
+(display (= (exact->inexact (inexact->exact 0.1)) 0.1)) (newline)
+(display "roundtrip-0.3 ")
+(display (= (exact->inexact (inexact->exact 0.3)) 0.3)) (newline)
+(display "roundtrip-pi ")
+(display (= (exact->inexact (inexact->exact 3.141592653589793))
+            3.141592653589793)) (newline)
+(display "roundtrip-neg ")
+(display (= (exact->inexact (inexact->exact -0.1)) -0.1)) (newline)
+
+;; An already-exact operand passes through untouched.
+(display "passthrough-rational ") (display (inexact->exact 1/2)) (newline)
+(display "passthrough-integer ") (display (inexact->exact 7)) (newline)

--- a/tests/vm_parity/found/complex_display_format.esk
+++ b/tests/vm_parity/found/complex_display_format.esk
@@ -1,0 +1,17 @@
+;; VERIFIED DIVERGENCE (pre-existing, display only): the two engines format a
+;; complex number differently. Native suppresses a unit imaginary part and a
+;; zero real part; the VM always prints both components in full.
+;;
+;;   (display (make-rectangular 2.0 1.0))   native: 2+i     VM: 2+1i
+;;   (display (make-rectangular 0.0 1.0))   native: +i      VM: 0+1i
+;;
+;; The VALUES agree bit-for-bit on both engines — see
+;; tests/vm_parity/corpus/54_complex_transcendentals.esk, which prints
+;; real-part/imag-part precisely so this formatting difference cannot mask a
+;; value regression. Only the printed spelling differs.
+;;
+;; Filed while fixing the complex transcendentals (task #113); untouched by
+;; that fix, which changed no display code on either engine.
+(display (make-rectangular 2.0 1.0)) (newline)
+(display (make-rectangular 0.0 1.0)) (newline)
+(display (make-rectangular 3.0 4.0)) (newline)


### PR DESCRIPTION
Two numeric-tower defects, both of which made the shipped build disagree with
the documentation. Docs-are-blueprint: the documented values are correct and
the build now produces them.

## Fix 1 — complex transcendentals (task #113)

### Mechanism

`ESHKOL_LANGUAGE_GUIDE.md` documents `(sqrt (make-rectangular -1.0 0.0))` as
`0.0+1.0i`. There was no complex square root to reach. A complex tagged value
carries a HEAP POINTER in its payload, and every scalar path in
`codegenMathFunction` ended in either `extractAsDouble` or

```cpp
select(is_double, unpackDouble(arg), SIToFP(unpackInt64(arg)))
```

whose fallback arm treats every non-double tag as an int64. So the pointer was
sign-converted into an IEEE double and libm was called on an address. The
result was not merely wrong, it varied with the heap layout, and it published
a raw address into the program's value space — hence the memory-safety class.

The same fallback caught exact rationals and bignums, which are also
pointer-carrying tags. `(sin (/ 1 2))` returned the sine of an address.

Both halves of the fix are here.

**(a) The complex extensions now exist.** `inc/eshkol/core/complex_math.h` is a
pure C/C++ header — no `_Complex`, no `std::complex`, so one file serves a C
translation unit and a C++ one — holding `sqrt`, `exp`, `log`, `exp2`, `log2`,
`log10`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `sinh`, `cosh`, `tanh`,
`asinh`, `acosh`, `atanh` and `pow` on the principal branch, with C99 Annex G
branch cuts and signed zero respected. The native runtime exposes each as
`eshkol_complex_<name>` (`lib/core/complex_math.cpp`) for the LLVM back end to
call; the VM compiles the same header in and calls the inline functions
directly.

This is one implementation, not two that agree today. The five dead inline
transcendentals in `ComplexCodegen` and the six hand-written ones in
`vm_complex.c` both delegate to it now. That mattered immediately: the native
polar-form square root could not produce the documented value, because
`cos(pi/2)` is 6.1e-17 rather than 0, so it returned `6.1e-17+1i` where the
VM's half-angle form returned `0.0+1.0i`. The algebraic form in the shared core
returns exactly `0.0+1.0i` on both.

**(b) The class is closed.** `codegenMathFunction` now tests for
`ESHKOL_VALUE_COMPLEX` before anything touches the payload, with exactly two
outcomes: dispatch to the complex runtime, or raise a catchable typed error
naming the procedure. There is no third outcome and no coercion. The
real-domain-only builtins — `floor`, `ceiling`, `truncate`, `round`, `fabs`,
`cbrt`, and `abs`, whose complex counterpart is `magnitude` — take the error
path.

`ArithmeticCodegen::extractAsDouble`'s last arm no longer treats every
unclaimed tag as an int64: only a genuine `ESHKOL_VALUE_INT64` is
sign-converted, and anything else yields the same 0.0 the non-numeric heap arm
already produced. That is the class kill — after it, no math path anywhere
reinterprets a pointer as a number, and rationals and bignums reach their
correct conversions instead of the int arm.

The audit of every math routing site turned up two more instances of the same
pattern, both fixed:

* `codegenAbs` -> `ArithmeticCodegen::abs` fell through to the int arm for a
  complex and printed the address (`(abs (make-rectangular 3.0 4.0))` =>
  `4698660432`). It now raises, pointing at `magnitude`.
* `expt`'s complex branch in `llvm_codegen.cpp` tested only the BASE for
  `ESHKOL_VALUE_COMPLEX` and then read the exponent with
  `extractDoubleFromTagged`, so a complex exponent was reinterpreted:
  `(expt i i)` returned `1` instead of `e^(-pi/2)`. That block is deleted;
  complex `expt` now lives in `ArithmeticCodegen::pow` beside complex
  `+`/`-`/`*`//, promoting both operands with `convertToComplex`, so every
  mixture takes one path.

### Before / after

Measured on the pre-fix build at `ebe28a96`, `z = (make-rectangular 3.0 4.0)`:

| expression | before | after |
|---|---|---|
| `(sqrt z)` | `68546.77550403083` | `2+i` |
| `(exp z)` | `+inf.0` | `-13.128783081462158-15.200784463067956i` |
| `(log z)` | `22.270543290569996` | `1.6094379124341003+0.9272952180016122i` |
| `(sin z)` | `-0.8546050291296863` | `3.853738037919377-27.016813258003936i` |
| `(cos z)` | `-0.5192785805194049` | `-27.034945603074224-3.8511533348117775i` |
| `(tan z)` | `1.6457544393124661` | `-0.00018734620462947842+0.9993559873814732i` |
| `(asin z)` | `+nan.0` | `0.6339838656391773+2.3055090312434685i` |
| `(acos z)` | `+nan.0` | `0.9368124611557193-2.3055090312434685i` |
| `(sinh z)` | `+inf.0` | `-6.5481200409110025-7.619231720321411i` |
| `(cosh z)` | `+inf.0` | `-6.580663040551157-7.5815527427465454i` |
| `(tanh z)` | `1` | `1.000709536067233+0.00490825806749606i` |
| `(exp2 z)` | `+inf.0` | `-7.461496614688567+2.8854927255134477i` |
| `(log2 z)` | `32.12960236320831` | `2.321928094887362+1.3378042124509761i` |
| `(log10 z)` | `9.671974060082038` | `0.6989700043360186+0.40271919627337305i` |
| `(abs z)` | `4698660432` (an address) | typed error naming `magnitude` |
| `(expt i i)` | `1` | `0.20787957635076193` |
| `(sin (/ 1 2))` | `0.9241426121154859` | `0.479425538604203` |

### Parity story

The VM was not memory-unsafe here — `as_number()` answered 0 for a complex —
but it was silently wrong, computing `f(0)`: `sqrt` gave 0, `exp` gave 1.
Twelve unary builtins (`sin cos tan exp log sqrt asin acos atan sinh cosh
tanh`) plus `expt` now dispatch complex operands through the shared core, so
the engines converge bit-for-bit rather than agreeing by review.

`sqrt` and `log` of a NEGATIVE EXACT real also converged. The native back end
has promoted into the complex domain since the numeric tower landed, and
`docs/reference/language/numeric-tower.md` documents `(display (sqrt -1))`
printing `+i`; the VM answered NaN, so a documented example disagreed between
engines. Promotion is exactness-aware on both sides, so an inexact negative
keeps IEEE NaN/-inf and the infinity/NaN suite is untouched.

`log2`, `log10`, `exp2`, `asinh`, `acosh` and `atanh` remain native-only names
with no VM binding — a pre-existing gap already carried in `PARITY.tsv`,
unchanged by this PR.

One divergence is filed rather than fixed:
`tests/vm_parity/found/complex_display_format.esk` records that the engines
format a complex differently (native `2+i`, VM `2+1i`). It is display-only,
pre-existing, and touched by no code here; the corpus entry prints
`real-part`/`imag-part` precisely so it cannot mask a value regression.

## Fix 2 — inexact->exact returned a different double's exact value

### Mechanism

Documented: `(inexact->exact 0.1)` => `3602879701896397/36028797018963968`.
Returned: `450359962737049/4503599627370496`.

`eshkol_double_to_rational` doubled its input until the value looked integral
OR the denominator reached 2^52, then cast:

```c
while (abs_d != floor(abs_d) && den < (1LL << 52)) { abs_d *= 2.0; den *= 2; }
int64_t num = (int64_t)abs_d;
```

0.1 needs 2^55. The loop hit its cap with `abs_d = 450359962737049.6` and the
cast discarded the `.6`, so the answer was the exact value of a neighbouring
double. The cap also collapsed every subnormal to 0, and the back end's own
`is_whole` arm used `fptosi`, undefined past 2^63, so `(inexact->exact 1e300)`
returned `4347791012`.

A finite double IS `mantissa * 2^exponent`, so the conversion is a bit
decomposition with no loop and no cap: `frexp` for the significand, scale to a
53-bit integer (exact for subnormals too, since `frexp` normalizes), strip
trailing zero bits, then shift into a numerator or a power-of-two denominator,
promoting to bignum where int64 runs out. Non-finite operands have no exact
value and report an error instead of casting.

`eshkol_double_to_exact_tagged` is the single entry point both engines call, so
the int64 / bignum / rational choice is made once in the runtime rather than by
an undefined cast in each back end.

Fixing the conversion exposed a second defect in the same family:
`eshkol_rational_to_double` converted numerator and denominator to doubles and
divided. The exact value of 1e-300 is a 53-bit numerator over 2^1049, and
2^1049 exceeds DBL_MAX, so the denominator became `+inf` and the round trip
returned 0. It now scales one side by a power of two so the quotient carries
~55 significant bits, divides in the bignum domain, and restores the exponent
with `ldexp`, which underflows gradually into the subnormals.

### Before / after

| expression | before | after |
|---|---|---|
| `(inexact->exact 0.1)` | `450359962737049/4503599627370496` | `3602879701896397/36028797018963968` |
| `(exact->inexact (inexact->exact 0.1))` | `0.09999999999999987` | `0.1` |
| `(inexact->exact 1e300)` | `4347791012` | exact 301-digit integer |
| `(inexact->exact 5e-324)` | `0` | exact 1/2^1074 |
| `(exact->inexact (inexact->exact 1e-300))` | `0` | `1e-300` |

Round-trip verified bit-identical over subnormals, both smallest-normal and
smallest-subnormal, powers of two above and below 1, 2^70, 1e300, 1e-300, 0.1,
the nearest double to 1/3, pi, negatives and both zeros. `-0.0` is the one
value that does not round-trip bitwise: its exact value is 0 and converting
back gives `+0.0`, which is R7RS, and is asserted as such.

### Parity story

The VM cast straight to an int64 (`(inexact->exact 0.1)` => 0). It now performs
the same decomposition over its int64 rationals, so every documented case
converges. Its exact integers are int64 and its rationals an int64 pair, so
magnitudes needing a bignum numerator (1e300) or a denominator past 2^62
(subnormals) have no exact VM representation: it reports a fatal error naming
the value rather than pushing a wrong number, and that limit is recorded
against the `inexact->exact` row of `PARITY.tsv`.

## Documented examples

| doc | example | documented | before | after |
|---|---|---|---|---|
| `ESHKOL_LANGUAGE_GUIDE.md:507` | `(sqrt (make-rectangular -1.0 0.0))` | `0.0+1.0i` | `73278.56614317723` | `0.0+1.0i` (prints `+i`) |
| `ESHKOL_LANGUAGE_GUIDE.md:508` | `(exp (make-rectangular 0.0 3.14159))` | `-1.0+0.0i` (approximately) | `+inf.0` | `-0.9999999999964793+2.65358979335273e-06i` |
| `ESHKOL_LANGUAGE_GUIDE.md:448` | `(inexact->exact 0.5)` | `1/2` | `1/2` | `1/2` |
| `ESHKOL_LANGUAGE_GUIDE.md:449` | `(inexact->exact 0.1)` | `3602879701896397/36028797018963968` | `450359962737049/4503599627370496` | as documented |
| `ESHKOL_QUICK_REFERENCE.md:248` | `(inexact->exact 0.5)` | `1/2` | `1/2` | `1/2` |
| `numeric-tower.md:168` | `(display (sqrt -1))` | `+i` | `+i` native, `+nan.0` VM | `+i` on both engines |

The guide's `0.0+1.0i` is a description of the value; the printed form is `+i`,
which is what `numeric-tower.md` documents as the transcript for the same
value. The tests assert the components, so they are independent of the display
spelling.

## Documentation

Capability grew, so the docs record it, and two descriptions of a MECHANISM
that were wrong beside correct example values are corrected:

* `COMPLETE_LANGUAGE_SPECIFICATION.md` gains section 15.3.3 (the complex math
  surface, the branch cuts, the real-domain-only builtins that raise, the
  shared core), and 14.3.1's `inexact->exact` rule no longer claims "continued
  fraction expansion" — a continued fraction cannot produce the value the guide
  documents.
* `API_REFERENCE.md` gains the complex transcendental entry, and its
  `inexact->exact` line no longer says "Converts double to nearest integer", a
  narrower claim than the guide's own worked example.

Note for the planned cleanup commit: the `KNOWN_ISSUES.md` entry queued for
"complex sqrt/exp/log garbage (task #113)" should not be added — the defect is
fixed here.

## Verification

Run at the branch head, macOS arm64, RelWithDebInfo, agent-FFI ON (and re-run
in full after the hardening commit).

| gate | result |
|---|---|
| `ctest` (full) | 140/140 passed |
| `scripts/run_vm_parity.sh` | 144 passed, 0 failed |
| `scripts/run_wasm_differential.sh` | 58 passed, 0 failed, 1 pre-existing xfail, 2 excluded |
| `scripts/run_numeric_tests.sh` | 14/14 |
| `scripts/run_rational_tests.sh` | 3/3 |
| `scripts/run_complex_tests.sh` | 2/2 |
| `scripts/run_bignum_tests.sh` | all passed |
| `scripts/run_autodiff_tests.sh` | 60/60 |
| `scripts/run_ad_oracle.sh` | 60/60, gate PASS |
| `scripts/run_edge_matrix.sh` | 576/576 |
| `scripts/vm_parity_audit.py` | OK — every codegen symbol VM-supported or waived |

`scripts/run_engine_parity_coverage.py` is not on this base: it arrives with
PR #414, still unmerged. The `run_vm_parity.sh` corpus differential plus the
two new corpus entries cover the same ground for these two fixes.

ICC (`icc` repo `eshkol-numtower`, registered and fully reindexed at the branch
head):

* `impact-analysis --since ebe28a96`: 15 changed paths, 1121 seed symbols,
  9351 impacted symbols across 1500 paths — the expected blast radius for
  `llvm_codegen.cpp` and `extractAsDouble`, and the reason the whole ctest and
  parity surface was re-run rather than a numeric subset.
* `guard-liveness`: 404 files scanned, 1609 guard sites, 277 findings, 57 dead
  — **zero** of them in any file this PR touches.

## Hardening found while reviewing the diff

Two latent items, neither observed as a failure, both fixed in the last commit:

* The complex dispatch is emitted for EVERY math builtin, and its merge slot
  was allocated at the current insert point — so a math call inside a loop body
  would re-adjust the stack pointer on every iteration. That is the hazard
  `CodegenContext::emitRaiseFmt` documents for its own buffer and the one the
  flat-RSS AOT gate watches. The alloca is now in the entry block, matching
  `createComplex` and `emitRaiseFmt`.
* The exact conversion formed a whole value as `num << exp2` with the sign
  already applied. Left-shifting a negative `int64_t` is undefined before
  C++20, and the VM copy is C. Both now shift the unsigned mantissa and apply
  the sign afterwards.

## Tests

* `tests/numeric/complex_transcendentals_test.esk` — 28 assertions: both
  documented examples, exact-valued cases, the branch cut on the negative real
  axis, round-trip identities across the whole implemented surface, `i^i`, the
  rational-operand regression, and the negative-real promotion.
* `tests/numeric/inexact_exact_roundtrip_test.esk` — 31 assertions: the
  documented value and its numerator/denominator, the round-trip probe set, and
  the result shapes.
* `tests/vm_parity/corpus/54_complex_transcendentals.esk` and
  `55_inexact_exact_exactness.esk` — the two-engine differential, which is also
  the wasm-diff corpus.

The tests fail closed on the original defects. Each carries the measured
pre-fix garbage in its comments and asserts against those exact values, and
that was verified by execution, not by inspection: a build of the pre-fix base
`ebe28a96` was made in a scratch worktree and the four files were run against
it.

* `complex_transcendentals_test.esk`: **21 FAIL** pre-fix, 0 after.
* `inexact_exact_roundtrip_test.esk`: **14 FAIL** pre-fix, 0 after.
* Corpus 54 pre-fix: native printed `doc-sqrt 70474.8705284373 0` while the VM
  printed `doc-sqrt 0 0` and `sqrt-exact-negative +nan.0 0` against native's
  `0 1` — the differential fails on both the value and the disagreement.
* Corpus 55 pre-fix: native printed the wrong rational
  `450359962737049/4503599627370496`, the VM printed `0`, and every round-trip
  row printed `#f`.

The complex corpus entry splits deliberately into raw-digit rows (values that
are exact on any conforming libm — the algebraic square root) and
tolerance-asserted PASS/FAIL rows (everything on exp/log/trig). Its first
version printed raw transcendental digits and failed the wasm lane on a genuine
libm difference: e^3·sin(4) is `-15.200784463067956` on the host and
`-15.200784463067954` under wasm32's musl, one ulp apart. That is not a codegen
defect, and `XFAIL` would have been the wrong classification for it. A
pointer-reinterpretation regression is wrong by orders of magnitude, so the
tolerance rows still catch it.
