### PR TITLE
fix(ad): AD capture reconstruction must respect lexical scope (closes the core.ad.guw miscompile)

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -190,6 +190,13 @@ oracles:
         action: ./scripts/run_icc_smoke.sh
       - runtime_event:
           event_kinds: [eshkol_smoke]
+          event_names: ["ad_capture_global_shadow_oracle"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'AD capture scoping: a differentiand lambda capturing its enclosing function''s parameter is never substituted by a same-named top-level global — and the cached (-r AOT) and uncached (in-process JIT) routes produce byte-identical output (task #114)'
+        action: ./scripts/run_icc_smoke.sh
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
           event_names: ["linear_solve_full_f64_oracle"]
           event_values: ["PASS"]
         severity: high

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3074,6 +3074,37 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
             TIMEOUT 300
             PASS_REGULAR_EXPRESSION "PASS: GUW multivariate"
             FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
+    # Task #114: AD capture reconstruction must resolve free variables with the
+    # same local-then-global scope rule codegenLambda used, so an enclosing
+    # function's parameter is never replaced by a same-named top-level global.
+    # Run under BOTH engines: the run-cache-ON `-r` route (which compiles AOT in
+    # a child process, where every top-level global is pre-registered before any
+    # body is emitted) and the in-process JIT route. The defect was AOT-fatal
+    # (SIGSEGV) and JIT-silent (wrong derivative), so one route alone is not a
+    # gate — cf. PR #407's rule that cached and uncached must be identical.
+    add_test(
+        NAME ad_capture_global_shadow_cached
+        COMMAND $<TARGET_FILE:eshkol-run>
+                -r "${CMAKE_CURRENT_SOURCE_DIR}/tests/ad/ad_capture_global_shadow_test.esk"
+                -L"${CMAKE_CURRENT_BINARY_DIR}"
+    )
+    set_tests_properties(ad_capture_global_shadow_cached
+        PROPERTIES
+            TIMEOUT 300
+            PASS_REGULAR_EXPRESSION "PASS: ad_capture_global_shadow"
+            FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
+    add_test(
+        NAME ad_capture_global_shadow_uncached
+        COMMAND $<TARGET_FILE:eshkol-run>
+                -r "${CMAKE_CURRENT_SOURCE_DIR}/tests/ad/ad_capture_global_shadow_test.esk"
+                -L"${CMAKE_CURRENT_BINARY_DIR}"
+    )
+    set_tests_properties(ad_capture_global_shadow_uncached
+        PROPERTIES
+            TIMEOUT 300
+            ENVIRONMENT "ESHKOL_JIT_CACHE=0"
+            PASS_REGULAR_EXPRESSION "PASS: ad_capture_global_shadow"
+            FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
     add_test(
         NAME sparse_tensors_runtime_smoke
         COMMAND $<TARGET_FILE:eshkol-run>

--- a/docs/guide/AUTOMATIC_DIFFERENTIATION.md
+++ b/docs/guide/AUTOMATIC_DIFFERENTIATION.md
@@ -28,8 +28,9 @@ What makes Eshkol's AD unusual:
 This guide is example-driven. **Every snippet below was run with
 `./build/eshkol-run -r <file>` and the output shown is the real output** — no
 invented numbers. Snippets that `(require core.ad.*)` a library module were run
-with a library search path (`-L build`) and with the JIT object cache disabled
-(`ESHKOL_JIT_CACHE=0`); this is noted where it applies. The design and proofs
+with a library search path (`-L build`); this is noted where it applies. Nothing
+here needs the JIT run cache turned off — the cached (`-r`, AOT) and uncached
+(in-process JIT) routes are gated byte-identical. The design and proofs
 behind all of this live in
 [`docs/design/AD_TAYLOR_TOWER.md`](../design/AD_TAYLOR_TOWER.md).
 
@@ -310,7 +311,7 @@ primitive, just orchestration over `taylor`.
 (display (gradient-n f xs 3)) (newline)
 ```
 
-Run with `ESHKOL_JIT_CACHE=0 ./build/eshkol-run -r ex.esk -L build`. Output:
+Run with `./build/eshkol-run -r ex.esk -L build`. Output:
 
 ```
 5.30118
@@ -353,7 +354,7 @@ and compose cleanly.
 (display (tensor-sum A)) (newline)             ; sum(A)
 ```
 
-Run with `ESHKOL_JIT_CACHE=0 ./build/eshkol-run -r ex.esk -L build`. Output:
+Run with `./build/eshkol-run -r ex.esk -L build`. Output:
 
 ```
 36.8475
@@ -394,7 +395,7 @@ optimization. Load `core.ad.taylor_models`.
 (display (interval-contains? (tm-eval tm 0.25) (exp 0.25))) (newline)
 ```
 
-Run with `ESHKOL_JIT_CACHE=0 ./build/eshkol-run -r ex.esk -L build`. Output:
+Run with `./build/eshkol-run -r ex.esk -L build`. Output:
 
 ```
 0.35127
@@ -447,7 +448,7 @@ m of them.
 (display (sparse-hessian-colors sp)) (newline)    ; AD passes used
 ```
 
-Run with `ESHKOL_JIT_CACHE=0 ./build/eshkol-run -r ex.esk -L build`. Output:
+Run with `./build/eshkol-run -r ex.esk -L build`. Output:
 
 ```
 2
@@ -522,7 +523,7 @@ segments during the backward sweep rather than storing them all.
 (display (checkpoint-block-size n)) (newline)   ; ~sqrt(100)
 ```
 
-Run with `ESHKOL_JIT_CACHE=0 ./build/eshkol-run -r ex.esk -L build`. Output:
+Run with `./build/eshkol-run -r ex.esk -L build`. Output:
 
 ```
 -3.31007e-08
@@ -605,7 +606,7 @@ purely on `taylor`.
 (display (taylor-inverse-series (lambda (x) (+ x (* x x))) 0.0 5)) (newline)
 ```
 
-Run with `ESHKOL_JIT_CACHE=0 ./build/eshkol-run -r ex.esk -L build`. Output:
+Run with `./build/eshkol-run -r ex.esk -L build`. Output:
 
 ```
 0.367879
@@ -775,11 +776,10 @@ for the arity-recovery mechanism.
 | `core.ad.tape` | `make-tape`, `tape-input`, `tape-mul`/`-add`/…, `tape-gradient`, `tape-node-count`, … | explicit reverse-mode tape (Scheme level) |
 
 **Running module examples:** because these modules are loaded via `require`,
-run them with the build directory on the library path and the JIT object cache
-disabled:
+run them with the build directory on the library path:
 
 ```
-ESHKOL_JIT_CACHE=0 ./build/eshkol-run -r your-file.esk -L build
+./build/eshkol-run -r your-file.esk -L build
 ```
 
 The built-in-operator examples in §1–§2 need only `./build/eshkol-run -r

--- a/lib/backend/autodiff_codegen.cpp
+++ b/lib/backend/autodiff_codegen.cpp
@@ -3386,13 +3386,37 @@ llvm::Value* AutodiffCodegen::codegenDerivativeMonolith(const eshkol_operations_
             // This handles lambdas inside functions where captures are function parameters
             // (not stored as GlobalVariables with _capture_ keys)
             // Also handles top-level global variables that are captured by lambdas
+            //
+            // ESH-0070 SCOPING INVARIANT (see resolveGradientCaptures, and the
+            // "Try local symbol table first" loop in llvm_codegen.cpp's nested-
+            // function capture emission): the raw-name lookup MUST prefer the
+            // LOCAL symbol table, because it has to resolve the SAME storage the
+            // lambda's own free-variable capture resolved. codegenLambda searches
+            // local-then-global, so a parameter/let binding lexically shadows a
+            // same-named top-level global there; searching global-first here
+            // silently picks the shadowed global instead.
+            //
+            // Task #114: this is what miscompiled core.ad.guw. `taylor-propagate`
+            // is `(define (taylor-propagate f xs v K) (taylor (lambda (t) (f (guw-line-point xs v t))) 0.0 K))`,
+            // so the tower lambda captures the PARAMETERS `f`/`xs`/`v`. A user
+            // program that merely defines a top-level `(define xs (vector ...))`
+            // made this lookup find `@eshkol_g_xs` and pack its ADDRESS as the
+            // capture, so the callee read the global's storage cell as if it were
+            // the base-point vector — `vector-ref: index out of bounds`. Every
+            // documented core.ad.guw example uses `xs` as the base-point name,
+            // which is why the AD guide carried an ESHKOL_JIT_CACHE=0 workaround
+            // (the `-r` persistent run cache compiles AOT, where all top-level
+            // globals are pre-registered; the in-process JIT happened not to have
+            // the colliding global installed yet, so it silently did the right
+            // thing and the divergence looked like a cache defect).
             if (!found) {
-                it = global_symbol_table_->find(var_name);
-                found_in_global = (it != global_symbol_table_->end());
-                if (!found_in_global) {
-                    it = symbol_table_->find(var_name);
+                it = symbol_table_->find(var_name);
+                found = (it != symbol_table_->end());
+                if (!found) {
+                    it = global_symbol_table_->find(var_name);
+                    found = (it != global_symbol_table_->end());
+                    found_in_global = found;
                 }
-                found = found_in_global ? (it != global_symbol_table_->end()) : (it != symbol_table_->end());
                 if (found) {
                     eshkol_debug("Derivative: found capture '%s' via plain variable name", var_name.c_str());
                 }
@@ -6697,14 +6721,20 @@ llvm::Value* AutodiffCodegen::gradientJetPath(const eshkol_operations_t* op) {
 
             bool found = found_in_global ? (it != global_symbol_table_->end()) : (it != symbol_table_->end());
 
-            // FALLBACK: Try raw variable name (for top-level global variables)
+            // FALLBACK: Try raw variable name, LOCAL first (ESH-0070 / task #114).
+            // The lambda's own capture emission resolves free variables
+            // local-then-global, so a parameter or let binding lexically shadows a
+            // same-named top-level global; this reconstruction must agree with it
+            // or it forwards the wrong storage in the wrong ABI. See the long note
+            // in codegenDerivativeMonolith.
             if (!found) {
-                it = global_symbol_table_->find(var_name);
-                found_in_global = (it != global_symbol_table_->end());
-                if (!found_in_global) {
-                    it = symbol_table_->find(var_name);
+                it = symbol_table_->find(var_name);
+                found = (it != symbol_table_->end());
+                if (!found) {
+                    it = global_symbol_table_->find(var_name);
+                    found = (it != global_symbol_table_->end());
+                    found_in_global = found;
                 }
-                found = found_in_global ? (it != global_symbol_table_->end()) : (it != symbol_table_->end());
                 if (found) {
                     eshkol_debug("Gradient: found capture '%s' via raw variable name", var_name.c_str());
                 }
@@ -11070,14 +11100,17 @@ std::vector<llvm::Value*> AutodiffCodegen::loadCapturesForAutodiff(
 
         bool found = found_in_global ? (it != global_symbol_table_->end()) : (it != symbol_table_->end());
 
-        // FALLBACK: Try raw variable name (for top-level global variables)
+        // FALLBACK: Try raw variable name, LOCAL first (ESH-0070 / task #114).
+        // Must agree with codegenLambda's own local-then-global free-variable
+        // resolution; see the long note in codegenDerivativeMonolith.
         if (!found) {
-            it = global_symbol_table_->find(var_name);
-            found_in_global = (it != global_symbol_table_->end());
-            if (!found_in_global) {
-                it = symbol_table_->find(var_name);
+            it = symbol_table_->find(var_name);
+            found = (it != symbol_table_->end());
+            if (!found) {
+                it = global_symbol_table_->find(var_name);
+                found = (it != global_symbol_table_->end());
+                found_in_global = found;
             }
-            found = found_in_global ? (it != global_symbol_table_->end()) : (it != symbol_table_->end());
             if (found) {
                 eshkol_debug("%s: found capture '%s' via raw variable name", context_name.c_str(), var_name.c_str());
             }

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -557,6 +557,33 @@ probe stdlib_sort_filter_scale_oracle 'stdlib sort (2M) and filter (1M) are tail
     'cd "$REPO_ROOT"; out=$(ESHKOL_PATH="$REPO_ROOT/lib" "$ESHKOL_RUN" -r tests/stdlib/sort_filter_scale_test.esk 2>&1) || exit 1; echo "$out" | grep -qE "Failed:[[:space:]]+0" || exit 1'
 probe ad_forward_over_reverse_oracle 'jacobian/hessian differentiating through an inner forward-mode derivative is exact, not silent-zero (ESH-0120/0121)' \
     'cd "$REPO_ROOT"; out=$(ESHKOL_PATH="$REPO_ROOT/lib" "$ESHKOL_RUN" -r tests/ad/forward_over_reverse_test.esk 2>&1) || exit 1; echo "$out" | grep -qE "Failed:[[:space:]]+0" || exit 1'
+# Task #114. Two claims in one probe, because the defect needed both to be
+# visible: (1) an AD operator differentiating a lambda that captures its
+# ENCLOSING FUNCTION'S PARAMETER must never read a same-named top-level global
+# instead — the reconstruction has to use codegenLambda's own local-then-global
+# scope rule; and (2) the cached `-r` route (which compiles AOT in a child) and
+# the uncached in-process JIT route must produce BYTE-IDENTICAL output, the
+# PR #407 invariant. Pre-fix, core.ad.guw's documented example died with
+# `vector-ref: index out of bounds` under the default cache-on `-r` and printed
+# correct values under ESHKOL_JIT_CACHE=0, and the AD guide carried the
+# ESHKOL_JIT_CACHE=0 workaround eight times. Byte-comparing the two routes is
+# what turns that class from "a workaround in a doc" into a gate.
+probe ad_capture_global_shadow_oracle 'AD capture reconstruction respects lexical scope (parameter shadows same-named global), and the cached -r/AOT route is byte-identical to the uncached in-process JIT route (task #114)' \
+    'cd "$REPO_ROOT"; t=tests/ad/ad_capture_global_shadow_test.esk;
+     cold=$(mktemp -d) || exit 1;
+     a=$(ESHKOL_JIT_CACHE_DIR="$cold" "$ESHKOL_RUN" -r "$t" -L"$BUILD_DIR_PATH" 2>/dev/null); ra=$?;
+     b=$(ESHKOL_JIT_CACHE_DIR="$cold" "$ESHKOL_RUN" -r "$t" -L"$BUILD_DIR_PATH" 2>/dev/null); rb=$?;
+     c=$(ESHKOL_JIT_CACHE=0 "$ESHKOL_RUN" -r "$t" -L"$BUILD_DIR_PATH" 2>/dev/null); rc=$?;
+     rm -rf "$cold";
+     [ "$ra" -eq 0 ] && [ "$rb" -eq 0 ] && [ "$rc" -eq 0 ] || exit 1;
+     [ "$a" = "$b" ] && [ "$b" = "$c" ] || exit 1;
+     printf "%s" "$c" | grep -q "PASS: ad_capture_global_shadow" || exit 1;
+     printf "%s" "$c" | grep -q "FAIL:" && exit 1;
+     bin=$(mktemp) || exit 1;
+     "$ESHKOL_RUN" "$t" -o "$bin" -L"$BUILD_DIR_PATH" >/dev/null 2>&1 || { rm -f "$bin"; exit 1; };
+     d=$("$bin" 2>/dev/null); rd=$?; rm -f "$bin";
+     [ "$rd" -eq 0 ] && [ "$d" = "$c" ] || exit 1;
+     exit 0'
 probe linear_solve_full_f64_oracle 'linear-solve: mixed-precision IR dense solver reaches full-f64 residual (<=1e-12, computed in-test) on well-conditioned/identity systems and raises catchably on singular/dimension-mismatch — verified on JIT, AOT, and the VM' \
     'cd "$REPO_ROOT"; t=tests/features/linear_solve_test.esk;
      out=$(ESHKOL_PATH="$REPO_ROOT/lib" "$ESHKOL_RUN" -r "$t" 2>/dev/null) || exit 1;

--- a/tests/ad/ad_capture_global_shadow_test.esk
+++ b/tests/ad/ad_capture_global_shadow_test.esk
@@ -1,0 +1,155 @@
+;; ─────────────────────────────────────────────────────────────────────────
+;;  AD capture reconstruction must respect lexical scope  (task #114)
+;; ─────────────────────────────────────────────────────────────────────────
+;;
+;;  When an AD operator differentiates a lambda, the backend REBUILDS that
+;;  lambda's capture argument list from its LLVM parameter names. codegenLambda
+;;  itself resolves a free variable local-then-global, so an enclosing
+;;  function's PARAMETER lexically shadows a same-named top-level global. Three
+;;  of the reconstruction paths searched global-first, so they forwarded the
+;;  global's storage — packed as an address — where the lambda expected the
+;;  captured value. Reading that cell as the captured object produced garbage:
+;;  for a captured vector, `vector-ref: index out of bounds`.
+;;
+;;  RETRO-CATCH: every check below is written so the differentiand is a lambda
+;;  whose free variables are the enclosing function's parameters, AND a
+;;  top-level global of the same name exists with a DIFFERENT value. A correct
+;;  compiler never reads the global; a global-first resolver reads it (or its
+;;  address) and the check fails. Verified to FAIL before the fix.
+;;
+;;  Covers all three previously global-first resolvers:
+;;    codegenDerivativeMonolith  — `derivative`, `derivative-n`, `taylor`
+;;    gradientJetPath            — `gradient`
+;;    loadCapturesForAutodiff    — `directional-derivative` family
+;;
+;;  NOT covered here: `hessian` over a lambda that captures its enclosing
+;;  function's parameter fails LLVM verification ("Incorrect number of
+;;  arguments passed to called function") REGARDLESS of any shadowing global —
+;;  a separate, pre-existing arity defect in the hessian capture path, not a
+;;  scoping one. Adding it here would make this gate red for the wrong reason.
+;;
+;;  Runs identically under -r (JIT), -r with the persistent run cache (AOT),
+;;  and plain AOT. Prints a PASS/FAIL summary and exits non-zero on any failure.
+;; ─────────────────────────────────────────────────────────────────────────
+
+(require core.ad.guw)
+
+(define npass 0)
+(define nfail 0)
+
+(define (nth lst i) (if (<= i 0) (car lst) (nth (cdr lst) (- i 1))))
+
+(define (rel-ok got want)
+  (let ((d (abs (- got want))))
+    (or (< d 1e-9)
+        (< (/ d (+ 1e-30 (abs want))) 1e-9))))
+
+(define (check name got want)
+  (if (rel-ok got want)
+      (set! npass (+ npass 1))
+      (begin (set! nfail (+ nfail 1))
+             (display "FAIL: ") (display name)
+             (display " got=") (display got)
+             (display " want=") (display want) (newline))))
+
+;; ─────────────────────────────────────────────────────────────────────────
+;;  The decoys. Every name here is ALSO a parameter of a function whose body
+;;  builds a differentiand lambda — in this file and in core.ad.guw
+;;  (`(define (taylor-propagate f xs v K) (taylor (lambda (t) (f (guw-line-point xs v t))) 0.0 K))`).
+;;  Their VALUES are deliberately wrong for every use below, so any leak is
+;;  numerically visible rather than accidentally correct.
+;; ─────────────────────────────────────────────────────────────────────────
+(define xs (vector 9.0 9.0 9.0 9.0 9.0))   ; wrong length AND wrong values
+(define v  (vector 9.0 9.0 9.0 9.0 9.0))
+(define a  1000.0)
+(define base (vector 7.0 7.0))
+(define pt (vector 5.0 5.0))
+
+;; ── 1. taylor / GUW through a module (the #114 reproducer verbatim) ───────
+;;    f(x,y) = x^3 y^2 + sin(x y) at (1.0, 0.5)
+(define (f2 w)
+  (let ((x (vector-ref w 0)) (y (vector-ref w 1)))
+    (+ (* x x x y y) (sin (* x y)))))
+(define pt2 (vector 1.0 0.5))
+(define S (sin 0.5)) (define C (cos 0.5))
+
+(check "guw mixed-partial xxy (module capture vs global xs)"
+       (mixed-partial f2 pt2 (list 0 0 1))
+       (- (- (* 12.0 1.0 0.5) (* C 1.0 0.5 0.5)) (* 2.0 S 0.5)))
+(check "guw mixed-partial xyy (module capture vs global xs)"
+       (mixed-partial f2 pt2 (list 0 1 1))
+       (- (- (* 6.0 1.0 1.0) (* C 1.0 1.0 0.5)) (* 2.0 S 1.0)))
+
+;;    taylor-propagate directly: g(t) = (2+t)^2 (3+t) = 12 + 16t + 7t^2 + t^3
+(define (fp w) (* (vector-ref w 0) (vector-ref w 0) (vector-ref w 1)))
+(define tp (taylor-propagate fp (vector 2.0 3.0) (vector 1.0 1.0) 3))
+(check "taylor-propagate c1 (module capture vs global xs/v)" (nth tp 1) 16.0)
+(check "taylor-propagate c2 (module capture vs global xs/v)" (nth tp 2) 7.0)
+(check "taylor-propagate c3 (module capture vs global xs/v)" (nth tp 3) 1.0)
+
+;; ── 2. derivative / derivative-n over a parameter-capturing lambda ────────
+;;    h(t) = sin(a + t); d/dt at 0 = cos(a). `a` is the PARAMETER, and the
+;;    top-level global `a` is 1000.0.
+(define (dwrap a) (derivative (lambda (t) (sin (+ a t))) 0.0))
+(check "derivative captures parameter a, not global a" (dwrap 0.3) (cos 0.3))
+
+(define (dnwrap a k) (derivative-n (lambda (t) (sin (+ a t))) 0.0 k))
+(check "derivative-n order 2 captures parameter a" (dnwrap 0.3 2) (- 0.0 (sin 0.3)))
+(check "derivative-n order 3 captures parameter a" (dnwrap 0.3 3) (- 0.0 (cos 0.3)))
+
+;;    taylor over a parameter-capturing lambda (same monolith path)
+(define (twrap a k) (taylor (lambda (t) (* (+ a t) (+ a t))) 0.0 k))
+(define tw (twrap 2.0 2))
+(check "taylor c0 captures parameter a" (nth tw 0) 4.0)
+(check "taylor c1 captures parameter a" (nth tw 1) 4.0)
+(check "taylor c2 captures parameter a" (nth tw 2) 1.0)
+
+;; ── 3. gradient over a lambda capturing a parameter VECTOR ────────────────
+;;    L(w) = w0*base0 + w1*base1 ; dL/dw = base. Global `base` is #(7 7).
+(define (gwrap base)
+  (gradient (lambda (w) (+ (* (vector-ref w 0) (vector-ref base 0))
+                           (* (vector-ref w 1) (vector-ref base 1))))
+            (vector 1.0 1.0)))
+(define gw (gwrap (vector 2.0 3.0)))
+(check "gradient captures parameter base[0], not global base" (vector-ref gw 0) 2.0)
+(check "gradient captures parameter base[1], not global base" (vector-ref gw 1) 3.0)
+
+;;    and a scalar-parameter capture through gradient
+(define (gscal a) (gradient (lambda (t) (* a t t)) 2.0))
+(check "gradient captures parameter a (scalar)" (gscal 0.5) 2.0)
+
+;; ── 4. directional derivative over a lambda capturing a parameter vector ──
+;;    D_dir [w . pt] = dir . pt. Global `pt` is #(5 5).
+(define (ddwrap pt dir)
+  (directional-derivative
+    (lambda (w) (+ (* (vector-ref w 0) (vector-ref pt 0))
+                   (* (vector-ref w 1) (vector-ref pt 1))))
+    (vector 1.0 1.0)
+    dir))
+(check "directional-derivative captures parameter pt, not global pt"
+       (ddwrap (vector 2.0 3.0) (vector 1.0 0.0)) 2.0)
+
+;; ── 5. the globals must be UNTOUCHED by all of the above ─────────────────
+(check "global a unchanged" a 1000.0)
+(check "global base[0] unchanged" (vector-ref base 0) 7.0)
+(check "global xs length unchanged" (vector-length xs) 5)
+(check "global xs[0] unchanged" (vector-ref xs 0) 9.0)
+
+;; ── summary ──────────────────────────────────────────────────────────────
+(display "----") (newline)
+(if (= nfail 0)
+    (begin
+      (display "PASS: ad_capture_global_shadow ")
+      (display npass)
+      (display "/")
+      (display npass)
+      (display " checks (derivative/derivative-n/taylor/GUW, gradient, directional)")
+      (newline))
+    (begin
+      (display "FAIL: ad_capture_global_shadow ")
+      (display nfail)
+      (display " of ")
+      (display (+ npass nfail))
+      (display " checks failed")
+      (newline)
+      (exit 1)))

--- a/tests/differential/corpus/42_ad_capture_global_shadow.esk
+++ b/tests/differential/corpus/42_ad_capture_global_shadow.esk
@@ -1,0 +1,57 @@
+;; AD over a lambda whose free variables are the ENCLOSING FUNCTION'S
+;; PARAMETERS, while top-level globals of the same names exist with different
+;; values.  Escape-analysis axis for task #114: the corpus already had AD files
+;; (29/30) and a shadowing file (39), but nothing that CROSSED them — and the
+;; defect lived exactly at the crossing.  The backend rebuilds a differentiated
+;; lambda's capture list from its LLVM parameter names; a global-first raw-name
+;; lookup there substitutes the global for the shadowed parameter.  Pre-fix this
+;; file segfaults on the AOT axes and prints silently wrong numbers on the JIT
+;; axes, so every axis pair diverges.
+;;
+;; Deliberately self-contained: no (require ...), so it runs on every axis with
+;; no library search path.
+
+(define a 1000.0)
+(define base (vector 7.0 7.0))
+(define pt (vector 5.0 5.0))
+
+;; derivative: d/dt sin(a + t) at 0 = cos(a), with `a` the PARAMETER
+(define (dwrap a) (derivative (lambda (t) (sin (+ a t))) 0.0))
+(display (dwrap 0.3)) (newline)
+(display (dwrap 0.0)) (newline)
+
+;; derivative-n: higher orders through the same capture
+(define (dnwrap a k) (derivative-n (lambda (t) (sin (+ a t))) 0.0 k))
+(display (dnwrap 0.3 1)) (newline)
+(display (dnwrap 0.3 2)) (newline)
+(display (dnwrap 0.3 3)) (newline)
+
+;; taylor: the tower path, same capture
+(define (twrap a k) (taylor (lambda (t) (* (+ a t) (+ a t))) 0.0 k))
+(display (twrap 2.0 2)) (newline)
+
+;; gradient over a captured parameter VECTOR
+(define (gwrap base)
+  (gradient (lambda (w) (+ (* (vector-ref w 0) (vector-ref base 0))
+                           (* (vector-ref w 1) (vector-ref base 1))))
+            (vector 1.0 1.0)))
+(display (gwrap (vector 2.0 3.0))) (newline)
+
+;; gradient over a captured scalar parameter
+(define (gscal a) (gradient (lambda (t) (* a t t)) 2.0))
+(display (gscal 0.5)) (newline)
+
+;; directional derivative over a captured parameter vector
+(define (ddwrap pt dir)
+  (directional-derivative
+    (lambda (w) (+ (* (vector-ref w 0) (vector-ref pt 0))
+                   (* (vector-ref w 1) (vector-ref pt 1))))
+    (vector 1.0 1.0)
+    dir))
+(display (ddwrap (vector 2.0 3.0) (vector 1.0 0.0))) (newline)
+(display (ddwrap (vector 2.0 3.0) (vector 0.0 1.0))) (newline)
+
+;; the shadowed globals must survive untouched
+(display a) (newline)
+(display base) (newline)
+(display pt) (newline)


### PR DESCRIPTION
## What this is

The `-r` "JIT object cache" miscompile of `core.ad.guw` is not a cache defect.
It is a **lexical-scoping defect in the AD backend's capture reconstruction**,
and the cache only decided which of two wrong-or-right outcomes you got.

`docs/guide/AUTOMATIC_DIFFERENTIATION.md`'s GUW example died with
`vector-ref: index out of bounds` under the default `-r`, and printed the
documented values under `ESHKOL_JIT_CACHE=0`. That guide carried the
`ESHKOL_JIT_CACHE=0` workaround eight times. All eight are removed here.

## Mechanism

When an AD operator differentiates a lambda, the backend rebuilds that lambda's
capture argument list from its LLVM parameter names. If the
`<lambda>_capture_<var>` key is absent — the normal case for a lambda whose free
variables are its enclosing function's **parameters** — it falls back to a
raw-name lookup. Three of those fallbacks searched the **global** symbol table
before the local one.

`codegenLambda`'s own free-variable capture emission searches **local then
global** ("Try local symbol table first", `llvm_codegen.cpp`), so a parameter or
let binding lexically shadows a same-named top-level global there. The
global-first reconstruction therefore forwarded a *different storage than the
lambda captured*, in a *different ABI*: the global's address packed as an int64
pointer-marker, which the callee's single load then reads as if it were the
captured value.

`core.ad.guw` is

```scheme
(define (taylor-propagate f xs v K)
  (taylor (lambda (t) (f (guw-line-point xs v t))) 0.0 K))
```

so the tower lambda captures the parameters `f`, `xs`, `v`. Any user program
that merely defines a top-level `(define xs (vector ...))` — the name every
documented example uses for the base point — made the lookup find
`@eshkol_g_xs`, and the tower read the global's storage cell as the base-point
vector. The IR diff between a program with the global named `xs` and one named
`xsQQ` is exactly one instruction:

```llvm
; correct (no colliding global)
store %eshkol_tagged_value %xs, ptr %deriv_capture_value146

; miscompiled (global `xs` exists)
store %eshkol_tagged_value { i8 1, i8 16, i16 0, i32 0,
                             i64 ptrtoint (ptr @eshkol_g_xs to i64) },
      ptr %deriv_capture_storage
```

`resolveGradientCaptures` was already corrected for this exact class (ESH-0070 —
a named-let carry pointer shadowing a global). The same reordering now lands in
the three sites that were missed: `codegenDerivativeMonolith` (serving
`derivative`, `derivative-n` and the `taylor` tower), `gradientJetPath`, and
`loadCapturesForAutodiff` (the `directional-derivative` family).

## Why it looked like a cache bug

`-r` with the cache ON does not use the in-process JIT at all: it spawns a child
`eshkol-run` that **AOT-compiles** the program to a standalone binary, caches
it, and executes it. `ESHKOL_JIT_CACHE=0` is the only route that reaches the
in-process `ReplJITContext`. In AOT all top-level globals are registered before
any body is emitted, so the colliding global is always visible; the in-process
JIT compiles incrementally and had not yet installed it. Same defect, two
engines, opposite visible outcomes.

The defect is **not** AOT-only. The retro-catch shows the in-process JIT
returning a silently wrong derivative (`-0.6868` where `0.9553` is correct)
while AOT segfaults.

## Verification

| gate | result |
|---|---|
| `ctest` | 142/142 (140 pre-existing + the 2 added here) |
| `scripts/run_vm_parity.sh` | 140 passed, 0 failed |
| `scripts/run_icc_smoke.sh` | **57/57** (gate PASS), including the new `ad_capture_global_shadow_oracle` |
| `icc architecture-verify` | 8 PASS / 0 FAIL / 0 UNCHECKABLE |
| `icc guard-liveness` | `ok: true`, unchanged — this diff introduces zero preprocessor directives |
| `icc readiness --target eshkol-compiler-readiness` | 77, blocked on exactly two criteria, **both pre-existing and unrelated**: `failure_free` (the five `37_sort.esk` differential events below) and one `artifact_without_test_or_trace` contract gap at `scripts/doc_audit/run_examples.py:107` |
| `scripts/run_ad_oracle.sh` | 60/60 |
| `scripts/run_ad_adversarial.sh --quick` | 7/7 |
| `scripts/run_ml_tests.sh` | 100% |
| `scripts/run_differential.sh` | 246/252 axis pairs; the 6 misses are all `37_sort.esk`, pre-existing since the file was added on 2026-07-02. `string<?` is a builtin only in call position, so passing it as a first-class value (`(sort lst string<?)`) is `Undefined variable` — with or without `-L build`, on every axis. A separate builtin-as-value defect, not a route divergence |
| AD guide examples, cache-on | all six `require`-ing examples produce the documented values, byte-identical to the uncached route |

**Retro-catch evidence.** With `lib/backend/autodiff_codegen.cpp` reverted to the
parent commit and everything else held fixed:

* `ESHKOL_JIT_CACHE=0 ... -r tests/ad/ad_capture_global_shadow_test.esk` → 5 of
  19 checks FAIL with wrong values, exit 1
* the AOT build of the same file → `SIGSEGV`
* `tests/differential/corpus/42_ad_capture_global_shadow.esk` → all 6 axis pairs
  diverge

With the fix: 19/19 on the in-process JIT, on cache-on `-r`, and on direct AOT,
all three byte-identical.

## Escape analysis

The differential corpus already had AD programs (`29_ad_derivative`,
`30_ad_gradient`) and a shadowing program (`39_letrec_shadow`) — but nothing
that **crossed** them, and the defect lived exactly at the crossing. The new
corpus file is that crossing, self-contained so it runs on all four native axes.
The new ICC probe adds the orthogonal assertion the guide's workaround was
standing in for: cached and uncached routes must be **byte-identical**, the
PR #407 rule, now enforced rather than documented around.

## Adjacent defects found, deliberately NOT fixed here

1. **`hessian` over a parameter-capturing lambda fails LLVM verification** —
   `(define (hwrap q) (hessian (lambda (t) (* q t t t)) 2.0))` gives
   "Incorrect number of arguments passed to called function", with or without any
   shadowing global. An arity defect in the hessian capture path, not a scoping
   one; noted in the test file so nobody mistakes its absence for an oversight.
2. **`map` ignores a shadowing binding entirely** — same root class, different
   resolver, and it is wrong on BOTH engines so no differential axis can see it:

   ```scheme
   (define fn (lambda (x) (* x 100)))
   (define (apply-map fn lst) (map fn lst))
   (apply-map (lambda (x) (+ x 10)) '(1 2 3))   ; => (100 200 300), want (11 12 13)
   ```

   `map_codegen.cpp` identifies the mapped procedure at compile time from the
   GLOBAL `<name>_func` entry. Guarding that branch on local shadowing is *not*
   sufficient — a candidate guard was written, built and measured to be a no-op,
   so the substitution happens further upstream in name resolution. That needs
   its own investigation lane; expanding this PR into `map` dispatch on an
   unvalidated hypothesis would be the wrong trade.

Both want their own task.

