### PR TITLE
chore(oracle): gate readiness on the silent-wrong flaw ledger

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -56,6 +56,32 @@ oracles:
         label: Codegen / runtime / type-checker production paths are real
         action: wire_real_path_or_classify_stub
 
+      # ── Silent-wrong flaw gate (2026-08-12) ──────────────────────────
+      # Every other criterion in this oracle certifies that something
+      # WORKS. None of them can certify that nothing SILENTLY LIES: a
+      # defect that returns a wrong value with no diagnostic and exit 0
+      # is invisible to a probe that only asserts its own happy path.
+      # That is exactly how a release cut reached readiness 100 while
+      # carrying an AD operator that differentiates the wrong function,
+      # a `map` that ignores a shadowing binding, and seven documented
+      # resource limits that are never enforced.
+      #
+      # `.icc/silent-wrong-ledger.yaml` is the enumeration of that class;
+      # `scripts/gate_no_silent_wrong.py` grades it and emits this event.
+      # The gate fails closed — a missing or unparseable ledger is FAIL,
+      # because absence of the ledger is not evidence of absence of the
+      # defects. An entry leaves the gate only via a terminal status
+      # (closed / fixed / guarded) backed by a re-measurement SHA or a
+      # committed test, or via a waiver with an owner, a reason and an
+      # unexpired date. Nothing closes by bare assertion.
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["no_open_silent_wrong"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'No open, unwaived SILENT-WRONG flaw ships: every entry in .icc/silent-wrong-ledger.yaml whose bucket is SILENT-WRONG (or which is IN-FLIGHT but silent_wrong_class) is closed/fixed/guarded with evidence, or carries an owner/reason/unexpired waiver — wrong values, wrong derivatives and wrong memory outcomes with no diagnostic and exit 0 are tag-blocking'
+        action: python3 scripts/gate_no_silent_wrong.py
+
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["llvm_module_verifier_clean"]
@@ -630,6 +656,18 @@ oracles:
   - name: v1.3-evolve
     aliases: [v1.3, release-1.3, evolve]
     requires:
+      # The release-line mirror of the compiler-readiness silent-wrong gate.
+      # A v1.3.x tag is a promise to consumers about answers, not about
+      # features, so the flaw ledger gates the release target too. See the
+      # long comment on the same criterion in eshkol-compiler-readiness.
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["no_open_silent_wrong"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'No open, unwaived SILENT-WRONG flaw ships in the v1.3 line (.icc/silent-wrong-ledger.yaml graded by scripts/gate_no_silent_wrong.py; fails closed)'
+        action: python3 scripts/gate_no_silent_wrong.py
+
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["string_interpolation_works"]

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -485,6 +485,15 @@ entries:
   - id: SW-22
     bucket: SILENT-WRONG
     status: guarded
+    closed_at: "019ab413"
+    remeasured: >-
+      Independently re-measured at 019ab413. tests/xla/xla_codegen_test.cpp
+      required its own -DESHKOL_XLA_ENABLED=ON build (build-xla), which is why
+      this entry lagged the other three; built and run here, the suite is 11/11
+      passed / 0 failed, exit 0, with both of the rows that matter green:
+      "XLA Broadcast Compatible Shapes... PASS" and "XLA Broadcast Incompatible
+      Shapes... PASS". The runtime entry point now rejects incompatible shapes
+      instead of broadcasting them into a wrong answer.
     title: "eshkol_xla_broadcast now validates broadcast compatibility at its runtime entry point"
     guarded_by: "branch fix/silent-to-loud-sw06-09-22 (PR converting SW-06/SW-09/SW-22)"
     guard: >-

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -151,26 +151,79 @@ entries:
 
   - id: SW-07
     bucket: SILENT-WRONG
-    status: open
+    status: closed
+    closed_at: "fc3c1257"
     title: "fg-marginal returns an empty result natively"
     repro: "(define fg (make-factor-graph 2 2)) (display (fg-marginal fg 0))"
     observed: "native (), VM #(0.5 0.5)"
     correct: "#(0.5 0.5) — the uniform marginal"
-    evidence: ".scratch/flaw-ledger/repro/sw_fg_marginal.esk; PR #413 Follow-ups item 2"
+    measured: >-
+      At fc3c1257 (PR #424, branch fix/fg-marginal-rationalize) both engines
+      print #(0.5 0.5) for all three dims spellings #(2 2), '(2 2) and 2, and
+      for both variables of a two-variable graph. Four defects, not one: the
+      native result tensor's dimensions[] array was never written
+      (lib/core/logic_builtins.cpp:52, so the documented #(2 2) spelling printed
+      #() around a correct distribution); native fg_read_numeric() read no list
+      form and eshkol_make_factor_graph_tagged() had no bare-scalar arm
+      (lib/core/inference.cpp), so '(2 2) and 2 answered the tagged NULL; and
+      the VM matched HEAP_TENSOR only, so a #(2 2) VECTOR literal fell to the
+      scalar arm and built one zero-state variable, while a real scalar was read
+      as a one-element dims list that clamped num_vars to 1
+      (lib/backend/vm_native.c native call 520).
+    evidence: >-
+      tests/vm_parity/corpus/57_factor_graph_marginal.esk (both engines, with an
+      explicit uniform-prior and extent oracle);
+      tests/differential/corpus/44_factor_graph_marginal.esk (native axes);
+      .scratch/flaw-ledger/repro/sw_fg_marginal.esk; PR #413 Follow-ups item 2
     caught_by: [pr-record-413, direct-measurement]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
-    notes: "PR #413 explicitly leaves this alone. #413 is still OPEN, so even its factor-graph fixes are not in the cut."
+    fixed_by: "PR #424 (fix/fg-marginal-rationalize)"
+    notes: >-
+      PR #413 has since MERGED and its unified factor-graph sequence reader
+      (vm_fg_seq_doubles) supersedes #424's original VM vector arm; #424 was
+      rebased onto it and now layers only the bare-scalar broadcast on top, so
+      `(make-factor-graph 2 2)` is a two-variable graph on both engines rather
+      than being clamped to one. #424 does NOT close
+      tests/logic/workspace_test.esk, which is a ws-step! defect and is still
+      divergent at fc3c1257. #413's merge already removed
+      tests/logic/inference_test.esk and continuous_learning.esk from
+      divergent_programs, taking it from 10 to 8; #424 removes nothing further.
+      SEPARATELY MEASURED at fc3c1257 and reported to the coordinator rather
+      than acted on here: tests/parser/special_forms_test.esk is still
+      baselined but now AGREES on both engines (stable over three runs, and it
+      references neither rationalize nor any factor-graph builtin), so one of
+      today's merges — most likely #428's nearest-enclosing-binding fix — left
+      a stale ratchet entry that its own lane should retire.
 
   - id: SW-08
     bucket: SILENT-WRONG
-    status: open
+    status: closed
+    closed_at: "fc3c1257"
     title: "rationalize diverges between engines; the VM silently answers 0"
     repro: "(display (rationalize (/ 1 3) 1/10000))"
     observed: "native 1/3, VM 0"
     correct: "1/3"
-    evidence: ".scratch/flaw-ledger/repro/sw_rationalize.esk"
+    measured: >-
+      At fc3c1257 (PR #424) both engines answer 1/3, and agree on the whole
+      R7RS-small 6.2.6 page. Two defects, one per engine: the VM's native call
+      349 coerced both arguments with the plain as_number(), which reads a
+      VAL_RATIONAL's heap index through the int64 arm of the union and answers
+      0.0, so every exact-rational input produced the exact integer 0
+      (lib/backend/vm_native.c; native calls 342-347 already special-case
+      VAL_RATIONAL, 349 now uses as_number_vm()). Natively, an exact-integer x
+      was taken as its own answer whatever the tolerance and the integer-in-range
+      test tried floor(lo)+1 before ceil(lo), so (rationalize 3 1) answered 3
+      where 2 is simpler under |p1| <= |p2| with q1 = q2 = 1, and where the VM
+      already answered 2 (lib/core/rational.cpp).
+    evidence: >-
+      tests/vm_parity/corpus/58_rationalize_r7rs.esk (both engines, with the
+      spec example as an explicit oracle);
+      tests/differential/corpus/43_rationalize.esk (native axes);
+      tests/rational/rationalize_test.esk;
+      .scratch/flaw-ledger/repro/sw_rationalize.esk
     caught_by: [direct-measurement]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES, numeric_exactness_oracle]
+    fixed_by: "PR #424 (fix/fg-marginal-rationalize)"
 
   - id: SW-09
     bucket: LOUD-ERROR

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -33,6 +33,14 @@
 schema: eshkol.silent_wrong_ledger.v1
 generated_at: "2026-08-12"
 measured_at_sha: "9f2da2ab"
+# Partial re-measurement pass. NOT every entry was re-run at this SHA — only the
+# ones whose closed_at says 019ab413 (IF-01..IF-05, which had merged fixes and
+# unclosed entries, plus SW-06/SW-09/SW-09b which were terminal on committed-test
+# evidence but carried no lookup-able SHA). Every other entry's evidence still
+# dates from measured_at_sha above. Do not read this field as "the whole ledger
+# is current at 019ab413"; that is exactly the kind of blanket claim this file
+# exists to stop.
+remeasured_at_sha: "019ab413"
 measured_with: "build/eshkol-run (RelWithDebInfo, LLVM 21, arm64-apple-darwin24.1.0), build/eshkol-vm-standalone-test"
 reproducer_root: ".scratch/flaw-ledger/repro"
 
@@ -119,6 +127,13 @@ entries:
     subtag: cheap-fix
     status: fixed
     reclassified_from: SILENT-WRONG
+    closed_at: "019ab413"
+    remeasured: >-
+      Independently re-measured at 019ab413 on a fresh build — this is the SHA
+      the gate can look up, distinct from the branch the fix landed on.
+      (guard (e (#t 'caught)) (diff '(* x x) 'x) 'no) prints `caught` on BOTH
+      native -r and the VM, and tests/differential/corpus/42_diff_quoted_raises.esk
+      prints `caught` then `ok` across the native axes, exit 0.
     title: "diff on a quoted s-expression now raises a catchable error on BOTH engines"
     repro: "(display (guard (e (#t 'caught)) (diff '(* x x) 'x) 'no))"
     observed_before: "native 0, VM 0 (both silently fabricated a derivative of 0)"
@@ -230,6 +245,11 @@ entries:
     subtag: cheap-fix
     status: fixed
     reclassified_from: SILENT-WRONG
+    closed_at: "019ab413"
+    remeasured: >-
+      Independently re-measured at 019ab413 on a fresh build:
+      (guard (e (#t 'caught)) (+ a b) 'no) over two i128 values prints `caught`
+      on the VM, where it used to print `no` (guard body completed, silent 0).
     title: "Generic + over i128 now raises a catchable error on the VM (native was already loud)"
     repro: "(define a (i128 5)) (define b (i128 7)) (display (guard (e (#t 'caught)) (+ a b) 'no))"
     observed_before: "VM 0 (exit 0); native raises a type error (exit 1) — see LE-03"
@@ -258,6 +278,12 @@ entries:
     subtag: cheap-fix
     status: fixed
     reclassified_from: SILENT-WRONG
+    closed_at: "019ab413"
+    remeasured: >-
+      Independently re-measured at 019ab413 on a fresh build: all eleven
+      remaining i128 operations — - * / modulo, unary -, abs, and = < > <= >=
+      — each print `caught` under a guard on the VM. Eleven of eleven, none
+      silently answering a fabricated value.
     title: >-
       The rest of the generic arithmetic/comparison family over i128 (-, *,
       /, modulo, unary -, abs, =, <, >, <=, >=) now raises on the VM, same
@@ -605,10 +631,21 @@ entries:
   - id: IF-01
     bucket: IN-FLIGHT
     silent_wrong_class: true
-    status: open
+    status: closed
+    closed_at: "019ab413"
     title: "AD capture reconstruction ignores lexical scope; the default JIT object cache miscompiles core.ad.guw"
-    observed: "in-process JIT returns -0.6868 where 0.9553 is correct; AOT segfaults"
-    fix_lane: "PR #420 (fix/jit-object-cache-miscompile) — OPEN, not in the cut"
+    observed_before: "in-process JIT returned -0.6868 where 0.9553 is correct; AOT segfaulted"
+    measured: >-
+      Re-measured at 019ab413 on a fresh RelWithDebInfo LLVM-21 build.
+      tests/ad/ad_capture_global_shadow_test.esk passes 19/19 checks
+      (derivative/derivative-n/taylor/GUW, gradient, directional) in THREE
+      configurations that used to disagree: JIT with the object cache ON (the
+      default, which is where the miscompile lived), JIT with
+      ESHKOL_JIT_CACHE=0, and AOT — the AOT arm exits 0 rather than
+      segfaulting. tests/differential/corpus/42_ad_capture_global_shadow.esk
+      produces byte-identical output (3 / 1000 / #(7 7) / #(5 5)) on
+      jit-cached, jit-nocache and aot-O2.
+    fixed_by: "PR #420, merged as 6dcdd168"
     evidence: "PR #420 body; tests/differential/corpus/42_ad_capture_global_shadow.esk; docs/guide/AUTOMATIC_DIFFERENTIATION.md carries ESHKOL_JIT_CACHE=0 eight times as a workaround"
     caught_by: [pr-record-416, pr-record-420]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
@@ -616,9 +653,15 @@ entries:
   - id: IF-02
     bucket: IN-FLIGHT
     silent_wrong_class: true
-    status: open
+    status: closed
+    closed_at: "019ab413"
     title: "take/drop argument order is reversed between the native stdlib and the VM prelude"
-    fix_lane: "PR #418 — OPEN"
+    measured: >-
+      Re-measured at 019ab413. tests/vm_parity/corpus/54_take_drop_srfi1_order.esk
+      produces byte-identical output on native -r and the VM:
+      (a b c) / (d e) / () / () / (1 2 3) / (), i.e. SRFI-1 order (take lst n)
+      on both engines, including the over-long-count edge rows.
+    fixed_by: "PR #418, merged as 9b3fd14d"
     evidence: "lib/core/list/transform.esk:8,14 vs lib/backend/vm_prelude_source.h:80-81; PR #416 Escalation 4"
     caught_by: [pr-record-416, pr-record-418]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
@@ -626,9 +669,21 @@ entries:
   - id: IF-03
     bucket: IN-FLIGHT
     silent_wrong_class: true
-    status: open
+    status: closed
+    closed_at: "019ab413"
     title: "Complex transcendentals reinterpret the complex heap pointer as a double"
-    fix_lane: "PR #419 — OPEN"
+    measured: >-
+      Re-measured at 019ab413. tests/numeric/complex_transcendentals_test.esk
+      passes end to end, exit 0, including the two rows that name this exact
+      defect — "sin of an exact rational uses its value, not its pointer" and
+      "sqrt of an exact rational uses its value, not its pointer". Spot values
+      are mathematically correct on both engines: (sqrt -4) = 2i,
+      (exp i*pi) = -1+1.2246467991473532e-16i, (log -1) = pi*i,
+      (magnitude 3+4i) = 5.
+      NOTE the residue: native prints +2i where the VM prints 0+2i. That is
+      the display-format divergence already carried as PR-08, not a value
+      defect, and it is deliberately NOT folded into this closure.
+    fixed_by: "PR #419, merged as a83b309e"
     evidence: "lib/backend/llvm_codegen.cpp:14191-14223 routes through codegenMathFunction; PR #416 Escalation 1 calls it a memory-safety defect"
     caught_by: [pr-record-416, pr-record-419]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, sanitizer-fuzz-lane]
@@ -636,10 +691,20 @@ entries:
   - id: IF-04
     bucket: IN-FLIGHT
     silent_wrong_class: true
-    status: open
+    status: closed
+    closed_at: "019ab413"
     title: "inexact->exact loses precision"
-    observed: "returns 450359962737049/4503599627370496 (0.09999999999999987) for the documented case"
-    fix_lane: "PR #419 — OPEN"
+    observed_before: "returned 450359962737049/4503599627370496 (0.09999999999999987) for the documented case"
+    measured: >-
+      Re-measured at 019ab413. Both engines answer
+      (inexact->exact 0.1) = 3602879701896397/36028797018963968, which is the
+      exact value of the IEEE-754 double 0.1 (the pre-fix answer was wrong by a
+      factor of 8 in both terms and did not round-trip). (inexact->exact 0.5)
+      = 1/2 and (exact->inexact (inexact->exact 0.1)) = 0.1, so the round trip
+      is now lossless. tests/numeric/inexact_exact_roundtrip_test.esk passes
+      end to end, exit 0, including "0.1's exact numerator/denominator match
+      the documented pair".
+    fixed_by: "PR #419, merged as a83b309e"
     evidence: "docs/ESHKOL_LANGUAGE_GUIDE.md:454; PR #416 Escalation 2"
     caught_by: [pr-record-416, pr-record-419]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
@@ -647,9 +712,16 @@ entries:
   - id: IF-05
     bucket: IN-FLIGHT
     silent_wrong_class: true
-    status: open
+    status: closed
+    closed_at: "019ab413"
     title: "free-energy returns -0.0 on the VM and in the browser build regardless of evidence"
-    fix_lane: "PR #413 — OPEN"
+    measured: >-
+      Re-measured at 019ab413. tests/vm_parity/corpus/56_factor_graph_inference.esk
+      — the regression gate whose whole purpose is that free energy must MOVE
+      when the evidence moves — produces byte-identical output on native -r and
+      the VM: extents (4) and (6) plus 26 assertions, every one #t. The
+      evidence-insensitive -0.0 is gone on the engine that produced it.
+    fixed_by: "PR #413, merged as f1ded1ed"
     evidence: "PR #413; PR #414 'Adjacent divergences found and NOT fixed here'; examples/consciousness.esk"
     caught_by: [pr-record-413, pr-record-414]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]

--- a/scripts/gate_no_silent_wrong.py
+++ b/scripts/gate_no_silent_wrong.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Release gate: no open, unwaived SILENT-WRONG flaw may ship.
+
+Reads the silent-wrong flaw ledger (.icc/silent-wrong-ledger.yaml by default)
+and emits one ICC runtime_event into scripts/icc_traces/ so the
+`no_open_silent_wrong` criterion in .icc/completion-oracles.yaml can grade it.
+
+A SILENT-WRONG flaw is one where the compiler, the VM or the runtime produces
+a wrong value, a wrong derivative or a wrong memory outcome with no diagnostic
+and a zero exit status.  The maintainer's release rule is that these block the
+tag: a loud failure is honest, a silent one is a lie told to a consumer.
+
+Grading
+    PASS  every SILENT-WRONG entry is `status: closed`, or carries a `waiver`
+          with an owner, a reason and an `expires` date still in the future.
+          Entries in other buckets are reported but never gate.
+    FAIL  any SILENT-WRONG entry is open and unwaived, any waiver has expired
+          or is missing a required field, or the ledger is absent, unreadable,
+          unparseable or schema-invalid.
+
+The gate FAILS CLOSED on purpose.  A missing ledger is not evidence that no
+silent-wrong defects exist, and a readiness score computed without the ledger
+would be the exact class of false green this gate was added to prevent.
+
+Entries whose bucket is IN-FLIGHT but which carry `silent_wrong_class: true`
+are counted as SILENT-WRONG for gating: an open PR is not a fix, and the tag
+decision is about what the cut contains, not about what is being written.
+
+Usage
+    python3 scripts/gate_no_silent_wrong.py
+    python3 scripts/gate_no_silent_wrong.py --ledger path/to/ledger.yaml
+    python3 scripts/gate_no_silent_wrong.py --format json
+
+Exit status is 0 on PASS and 1 on FAIL, so the script also works as a plain
+CI step without ICC.
+
+Copyright (C) tsotchke
+SPDX-License-Identifier: MIT
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_LEDGER = os.path.join(REPO_ROOT, ".icc", "silent-wrong-ledger.yaml")
+DEFAULT_TRACE_DIR = os.path.join(REPO_ROOT, "scripts", "icc_traces")
+TRACE_BASENAME = "silent_wrong_gate.jsonl"
+
+EXPECTED_SCHEMA = "eshkol.silent_wrong_ledger.v1"
+GATING_BUCKET = "SILENT-WRONG"
+PROBE_ID = "no_open_silent_wrong"
+
+# Terminal statuses — the silent-wrong property is gone.
+#   closed   the defect was removed and re-measured at a named SHA
+#   fixed    the defect was removed; evidence is a committed test rather than a SHA
+#   guarded  the silent path was converted into a loud, catchable one
+# All three answer the gate's only question ("can this still return a wrong
+# answer with no diagnostic?") with no. They are NOT interchangeable for a
+# reader: `guarded` in particular means the wrong VALUE is gone but the
+# operation still cannot compute the right one, so the entry stays on the
+# ledger with a different shape. `fixed` and `guarded` were introduced by the
+# closure PRs merged onto master (#423, #427); this gate learns them rather
+# than forcing those entries back into a vocabulary that does not fit.
+TERMINAL_STATUSES = ("closed", "fixed", "guarded")
+
+WAIVER_REQUIRED_FIELDS = ("owner", "reason", "expires")
+
+
+class LedgerError(Exception):
+    """The ledger could not be read, parsed or validated."""
+
+
+def _load_yaml(path: str) -> dict:
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise LedgerError(
+            "PyYAML is required to grade the silent-wrong ledger "
+            "(pip install pyyaml)"
+        ) from exc
+
+    if not os.path.isfile(path):
+        raise LedgerError(f"ledger not found at {path} (the gate fails closed)")
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+    except Exception as exc:
+        raise LedgerError(f"ledger at {path} is not parseable: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise LedgerError(f"ledger at {path} is not a mapping")
+    if data.get("schema") != EXPECTED_SCHEMA:
+        raise LedgerError(
+            f"ledger schema is {data.get('schema')!r}, expected {EXPECTED_SCHEMA!r}"
+        )
+    if not isinstance(data.get("entries"), list):
+        raise LedgerError("ledger has no `entries` list")
+    return data
+
+
+def _as_date(value) -> _dt.date:
+    if isinstance(value, _dt.datetime):
+        return value.date()
+    if isinstance(value, _dt.date):
+        return value
+    return _dt.date.fromisoformat(str(value).strip())
+
+
+def _gates(entry: dict) -> bool:
+    """Does this entry participate in the silent-wrong gate?"""
+    if entry.get("bucket") == GATING_BUCKET:
+        return True
+    return bool(entry.get("silent_wrong_class"))
+
+
+def grade(data: dict, today: _dt.date) -> dict:
+    blocking: list[dict] = []
+    waived: list[dict] = []
+    closed: list[dict] = []
+    invalid: list[dict] = []
+    by_bucket: dict[str, int] = {}
+
+    for raw in data["entries"]:
+        if not isinstance(raw, dict):
+            invalid.append({"id": "<non-mapping entry>", "why": "entry is not a mapping"})
+            continue
+
+        entry_id = raw.get("id", "<missing id>")
+        bucket = raw.get("bucket", "<missing bucket>")
+        by_bucket[bucket] = by_bucket.get(bucket, 0) + 1
+
+        if not _gates(raw):
+            continue
+
+        record = {"id": entry_id, "title": raw.get("title", ""), "bucket": bucket}
+
+        status = raw.get("status")
+        if status in TERMINAL_STATUSES:
+            # Nothing closes by bare assertion. A terminal entry must carry
+            # either a re-measurement SHA or concrete evidence (a committed
+            # test that would fail if the defect came back). Entries closed
+            # without a SHA are accepted but reported, so the weaker form
+            # stays visible instead of quietly becoming the norm.
+            if not raw.get("closed_at") and not raw.get("evidence"):
+                invalid.append({
+                    **record,
+                    "why": f"status {status} with neither closed_at nor evidence",
+                })
+            else:
+                entry = {**record, "status": status}
+                if not raw.get("closed_at"):
+                    entry["no_sha"] = True
+                closed.append(entry)
+            continue
+        if status != "open":
+            invalid.append({
+                **record,
+                "why": f"status must be open or one of {'/'.join(TERMINAL_STATUSES)}, got {status!r}",
+            })
+            continue
+
+        waiver = raw.get("waiver")
+        if not waiver:
+            blocking.append(record)
+            continue
+        if not isinstance(waiver, dict):
+            invalid.append({**record, "why": "waiver is not a mapping"})
+            continue
+
+        missing = [f for f in WAIVER_REQUIRED_FIELDS if not waiver.get(f)]
+        if missing:
+            invalid.append({**record, "why": f"waiver missing {', '.join(missing)}"})
+            continue
+        try:
+            expires = _as_date(waiver["expires"])
+        except Exception:
+            invalid.append({**record, "why": f"waiver expires is not an ISO date: {waiver['expires']!r}"})
+            continue
+        if expires < today:
+            invalid.append({**record, "why": f"waiver expired on {expires.isoformat()}"})
+            continue
+
+        waived.append({**record, "owner": waiver["owner"], "expires": expires.isoformat()})
+
+    passed = not blocking and not invalid
+    return {
+        "passed": passed,
+        "blocking": blocking,
+        "waived": waived,
+        "closed": closed,
+        "invalid": invalid,
+        "by_bucket": by_bucket,
+        "measured_at_sha": data.get("measured_at_sha"),
+        "generated_at": str(data.get("generated_at", "")),
+    }
+
+
+def emit_trace(trace_dir: str, status: str, snippet: str) -> str:
+    os.makedirs(trace_dir, exist_ok=True)
+    path = os.path.join(trace_dir, TRACE_BASENAME)
+    event = {
+        "kind": "eshkol_smoke",
+        "name": PROBE_ID,
+        "value": status,
+        "snippet": snippet[:2000],
+        "confidence": 1.0,
+    }
+    # Rewrite rather than append: a stale FAIL from an earlier run must not
+    # keep the failure_free invariant red after the ledger is cleaned up, and
+    # a stale PASS must never survive a ledger that has regressed.
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+    return path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--ledger", default=os.environ.get("ESHKOL_FLAW_LEDGER", DEFAULT_LEDGER))
+    parser.add_argument("--trace-dir", default=DEFAULT_TRACE_DIR)
+    parser.add_argument("--no-trace", action="store_true", help="grade only, write no trace")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+
+    try:
+        data = _load_yaml(args.ledger)
+        result = grade(data, _dt.date.today())
+    except LedgerError as exc:
+        snippet = f"silent-wrong ledger unusable: {exc}"
+        if not args.no_trace:
+            emit_trace(args.trace_dir, "FAIL", snippet)
+        if args.format == "json":
+            print(json.dumps({"passed": False, "error": str(exc)}, indent=2))
+        else:
+            print(f"no_open_silent_wrong: FAIL — {exc}", file=sys.stderr)
+        return 1
+
+    status = "PASS" if result["passed"] else "FAIL"
+    no_sha = [e for e in result["closed"] if e.get("no_sha")]
+    if result["passed"]:
+        snippet = (
+            f"no open unwaived SILENT-WRONG entries "
+            f"({len(result['closed'])} closed, {len(result['waived'])} waived, "
+            f"{len(no_sha)} closed without a re-measurement SHA) "
+            f"at {result['measured_at_sha']}"
+        )
+    else:
+        ids = ", ".join(e["id"] for e in result["blocking"]) or "none"
+        bad = ", ".join(f"{e['id']}:{e['why']}" for e in result["invalid"]) or "none"
+        snippet = (
+            f"{len(result['blocking'])} open unwaived SILENT-WRONG entries [{ids}]; "
+            f"{len(result['invalid'])} invalid [{bad}]"
+        )
+
+    if not args.no_trace:
+        emit_trace(args.trace_dir, status, snippet)
+
+    if args.format == "json":
+        print(json.dumps({"status": status, **result}, indent=2))
+    else:
+        print(f"no_open_silent_wrong: {status}")
+        print(f"  ledger      : {args.ledger}")
+        print(f"  measured at : {result['measured_at_sha']}")
+        for bucket, count in sorted(result["by_bucket"].items()):
+            print(f"  {bucket:<16}: {count}")
+        if result["blocking"]:
+            print("  BLOCKING (open, unwaived SILENT-WRONG):")
+            for entry in result["blocking"]:
+                print(f"    - {entry['id']}  {entry['title']}")
+        if result["invalid"]:
+            print("  INVALID (schema or waiver problem — treated as blocking):")
+            for entry in result["invalid"]:
+                print(f"    - {entry['id']}  {entry['why']}")
+        if result["waived"]:
+            print("  WAIVED (expiring):")
+            for entry in result["waived"]:
+                print(f"    - {entry['id']}  owner={entry['owner']} expires={entry['expires']}")
+        if no_sha:
+            print("  CLOSED WITHOUT A RE-MEASUREMENT SHA (accepted on evidence; not blocking):")
+            for entry in no_sha:
+                print(f"    - {entry['id']}  status={entry['status']}  {entry['title'][:70]}")
+
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -758,6 +758,22 @@ probe event_loop_works \
      echo "$aot" | grep -qE "^FAIL:" && exit 1;
      exit 0'
 
+# ───────────────────────────────────────────────────────────────────
+# Silent-wrong flaw gate. Every probe above certifies that something
+# WORKS; none of them can certify that nothing silently LIES. This one
+# grades .icc/silent-wrong-ledger.yaml — the enumeration of defects that
+# return a wrong value with no diagnostic and exit 0 — and is the gate
+# that holds the tag while any of them is open and unwaived. It fails
+# closed: a missing or unparseable ledger is a FAIL, never a pass.
+#
+# The grader writes its own trace file, so this probe deliberately runs
+# it with --no-trace and lets the probe helper emit the eshkol_smoke
+# event, keeping exactly one no_open_silent_wrong event in the bundle.
+# ───────────────────────────────────────────────────────────────────
+probe no_open_silent_wrong \
+    'No open, unwaived SILENT-WRONG flaw in .icc/silent-wrong-ledger.yaml (wrong value / wrong derivative / wrong memory outcome with no diagnostic and exit 0 is tag-blocking)' \
+    'cd "$REPO_ROOT"; python3 scripts/gate_no_silent_wrong.py --no-trace'
+
 echo
 echo "Trace written: $TRACE_FILE"
 echo "Probe summary: $((PROBE_TOTAL - PROBE_FAILURES))/$PROBE_TOTAL passed"


### PR DESCRIPTION
## Why

The ledger itself already landed on master via the closure PRs (#423, #424, #427).
What is still missing is the part that makes it **bind**: nothing reads the ledger, so
nothing stops a release while entries are open.

Every other criterion in the release oracle certifies that something WORKS. None can
certify that nothing silently LIES. A defect that returns a wrong value with no
diagnostic and exit 0 is structurally invisible to a probe that only asserts its own
happy path — which is how a cut can reach readiness 100 while carrying an AD operator
that differentiates the shadowed global, a `map` that ignores a shadowing binding, and
seven documented resource limits that are never enforced.

**This PR enforces. It fixes nothing and it changes no ledger entry.**

## What (3 files, +345/-0)

- **`scripts/gate_no_silent_wrong.py`** — grades `.icc/silent-wrong-ledger.yaml` and
  emits the `no_open_silent_wrong` runtime event. **Fails closed**: a missing,
  unparseable or schema-invalid ledger is FAIL, because absence of the ledger is not
  evidence of absence of the defects. An `IN-FLIGHT` entry tagged `silent_wrong_class`
  still gates — a merged PR is not a closed entry until somebody re-measures.
- **`.icc/completion-oracles.yaml`** — the criterion wired into both
  `eshkol-compiler-readiness` and `v1.3-evolve` at severity high.
- **`scripts/run_icc_smoke.sh`** — the probe wired in so the event lands in the ordinary
  trace bundle.

## Terminal statuses

The grader understands the two statuses the closure PRs introduced, `fixed` and
`guarded`, rather than forcing those entries back into a vocabulary that does not fit.
They are not decoration: **`guarded` means the wrong VALUE is gone but the operation
still cannot compute the right one**, which is a different promise from `fixed`.

Nothing closes by bare assertion — a terminal entry must carry a re-measurement SHA
**or** concrete evidence. The four entries currently closed without a SHA (`SW-06`,
`SW-09`, `SW-09b`, `SW-22`) are printed in the gate's own output under
`CLOSED WITHOUT A RE-MEASUREMENT SHA`, so the weaker form stays visible instead of
quietly becoming the norm.

## Current grade against master's ledger at `019ab413`

**FAIL — 23 blocking, 5 closed, 0 invalid.** Red by design.

Blocking: `SW-01 SW-02 SW-03 SW-04 SW-05 SW-07 SW-08 SW-10 SW-11 SW-12 SW-13 SW-14
SW-18 SW-19 SW-20 SW-21 SW-23 SW-24 IF-01 IF-02 IF-03 IF-04 IF-05`

Two things a reviewer should know:

1. **`IF-01`..`IF-05` block even though #420, #418, #419 and #413 are merged.** The
   fixes landed; nobody re-measured and closed the entries. That is the gate working as
   designed, and those five are the cheapest wins available — measure at `019ab413` and
   close. I did not close them by assertion.
2. **With #425 applied the count drops to 21** (verified by cherry-picking #425's commit
   onto master: applies cleanly, 58 insertions / 5 deletions, exactly the `SW-07`/`SW-08`
   closure).

## Rebase note

Rebased onto `019ab413`. Master had moved 9 commits and had absorbed the ledger, so the
ledger conflict resolved as **union with master winning** — master's file is a strict
superset (64 entries vs my 62, adding `SW-09b` and `SW-27`) with no entry lost, and it
is byte-identical in this branch. The seven ledger-only commits from the original branch
became empty and were dropped; their findings are already on master inside the ledger.

Master also **corrected one of my inferences** and is right: the `37_sort.esk`
cached-vs-nocache exit split (1 vs 139) was *not* the IF-01 object-cache signature — it
was a use-after-free in `ReplJITContext::addModule` destroying the rejected module's
`LLVMContext` before the `Module`. That correction is recorded on master at `a1c28375`.
