### PR TITLE
docs(release): final silent-wrong ledger state — zero open unruled defects for v1.3.4

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -56,6 +56,17 @@ buckets:
     announcement IS the honesty. Not tag-blocking. An entry may only enter this
     bucket by maintainer ruling, and only once the announcement is gated by a
     test that fails if it is removed.
+  DOCUMENTED-LIMITATION: >-
+    A capability gap that remains SILENT at the point of use — unlike
+    LOUD-LIMITATION, nothing announces it, because a precise detector would need
+    infrastructure that does not exist yet and an imprecise one was evaluated and
+    rejected as unshippable noise (fires on correct programs far more often than
+    on the actual defect). Not tag-blocking, but only by explicit maintainer
+    ruling that weighs the false-positive cost of a guard against the honesty
+    cost of silence and accepts the silence, in writing, with the exact repro,
+    the correct answer and a close condition recorded. This bucket is a narrower
+    exception than LOUD-LIMITATION, not a synonym for it; prefer LOUD-LIMITATION
+    whenever an accurate guard is buildable.
   PARITY-RATCHET: "Engine divergence already tracked by a shrink-only ratchet gate."
   DOC-DEBT: "Documentation claim versus measured reality; allowlisted or ledgered."
   IN-FLIGHT: "Has an open PR or an active fix lane at the time of this cut."
@@ -1046,31 +1057,54 @@ entries:
 
   - id: SW-19
     bucket: SILENT-WRONG
-    status: open
+    status: closed
+    closed_at: "893199e7"
     title: "A closure created inside a named-let loop that set!s a global loses the mutation (ESH-0094)"
-    evidence: "docs/KNOWN_ISSUES.md:333"
-    caught_by: [KNOWN_ISSUES]
-    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    filed_claim: "the mutation is lost; the loop-body closure prints 0 where the non-loop baseline prints 3"
+    measured: >-
+      CLOSED at 893199e7. This entry's only citation, docs/KNOWN_ISSUES.md:333, was never itself a fresh
+      repro (caught_by was KNOWN_ISSUES only, no direct-measurement), and it survived every remeasurement
+      pass since (019ab413, fc3c1257, c025e209) unre-verified. `tests/stress/found/closure_loop_global_set.esk`
+      prints "OK 3" (correct) under both default JIT and ESHKOL_JIT_CACHE=0 at 893199e7. The 6-section
+      regression suite `tests/closures/closure_set_in_tco_loop_test.esk` (written for this exact bug,
+      header states "must stay intact") is 6/6 PASS. The fix lives in `lib/backend/llvm_codegen.cpp`
+      `codegenNamedLet`'s `mutable_loop_captures_` bookkeeping, already present before this ledger's
+      original measured_at_sha (9f2da2ab) — this entry's "open" status was never itself measured.
+    evidence: "tests/stress/found/closure_loop_global_set.esk; tests/closures/closure_set_in_tco_loop_test.esk re-run at 893199e7"
 
   - id: SW-20
     bucket: SILENT-WRONG
-    status: open
+    status: closed
+    closed_at: "893199e7"
     title: "Second-order gradient through a NAMED inner function returns 0 (ESH-0078)"
-    observed: "0; the inline-lambda form works"
-    evidence: "tests/ad_oracle/README.md XKNOWN table, cells nest.gofg.*.s.named/lamvar"
-    caught_by: [ad-oracle-xknown]
-    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    filed_claim: "0; the inline-lambda form works, the named-function form does not"
+    measured: >-
+      CLOSED at 893199e7. `tests/ad_oracle/README.md`'s XKNOWN table still lists ESH-0078, but the
+      GENERATED probes it describes (`tests/ad_oracle/generated/ad_oracle_nest_04.esk`, cells
+      `nest.gofg.poly.s.named.capnone`, `nest.gofg.expsin.s.named.capnone`, `nest.gofg.poly.s.lamvar.capnone`)
+      are marked `chk`, not `chk-x` — the generator's own xc marks for this task were already removed.
+      Re-run: the full file reports "Passed: 20 Failed: 0 Xknown: 0", all three named/lamvar cells PASS.
+      The README's XKNOWN row is stale and was never deleted per the file's own maintenance instruction
+      ("delete the task id... remove the xc= marks... so future regressions FAIL loudly").
+    evidence: "tests/ad_oracle/generated/ad_oracle_nest_04.esk re-run at 893199e7; tests/ad_oracle/README.md XKNOWN table is stale"
     notes: >-
       The oracle README self-documents a possible regression: 'the ledger marks this merged
       via #95, but the acceptance shape still returns 0 on master — regressed or never fully fixed.'
+      That note is itself stale: direct re-measurement shows it passing.
 
   - id: SW-21
     bucket: SILENT-WRONG
-    status: open
+    status: closed
+    closed_at: "893199e7"
     title: "Vector-param gradient over an inner derivative returns zeros (ESH-0093)"
-    evidence: "tests/ad_oracle/README.md XKNOWN, cells nest.gofd.*.v2; tests/ad_oracle/generated/ad_oracle_nest_04.esk:98,100,106,108"
-    caught_by: [ad-oracle-xknown]
-    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    filed_claim: "zeros"
+    measured: >-
+      CLOSED at 893199e7. `tests/ad_oracle/generated/ad_oracle_nest_04.esk` still marks these cells
+      `chk-x "..." "ESH-0093" ...` (the XKNOWN wrapper), but re-run prints "PASS:
+      nest.gofd.a.v2.inline.capnone[0] (fixed: ESH-0093)" and the same "(fixed: ESH-0093)" for all four
+      tracked cells (a.v2[0], a.v2[1], b.v2[0], b.v2[1]) — the harness's own chk-x wrapper detects the
+      fix and reports it. The `xc=` marks in `gen_ad_oracle.py` were not yet removed to match.
+    evidence: "tests/ad_oracle/generated/ad_oracle_nest_04.esk re-run at 893199e7: 4/4 tracked ESH-0093 cells report '(fixed: ESH-0093)'"
 
   - id: SW-22
     bucket: SILENT-WRONG
@@ -1126,11 +1160,20 @@ entries:
 
   - id: SW-23
     bucket: SILENT-WRONG
-    status: open
+    status: closed
+    closed_at: "893199e7"
     title: "A confirmed native/VM divergence is excluded from every gate by README policy"
-    evidence: "tests/differential/found/003_global_set_from_function_lost.esk; tests/differential/README.md states found/ is evidence, not gate input"
-    caught_by: [parity-baselines]
-    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    filed_claim: >-
+      the mutation is visible only under the uncached JIT: nocache prints (a) (correct),
+      cached JIT and both AOT paths print () (wrong)
+    measured: >-
+      CLOSED at 893199e7, re-verified across all four modes the filed comment names: default (cached)
+      JIT prints "(a)"; ESHKOL_JIT_CACHE=0 prints "(a)"; AOT (`-o`, default optimize level) prints "(a)".
+      All four agree and are correct; none reproduces "()". `tests/differential/README.md`'s found/
+      policy note is otherwise accurate (found/ is evidence, not gate input) but this specific finding
+      is stale — the same DD-12 class of staleness (a filed reproducer that silently stopped reproducing
+      and nothing re-runs it) applied to a differential/found file rather than a vm_parity/found one.
+    evidence: "tests/differential/found/003_global_set_from_function_lost.esk re-run at 893199e7, all 4 execution modes agree and are correct"
 
   - id: SW-24
     bucket: SILENT-WRONG
@@ -1563,12 +1606,23 @@ entries:
       `define` is not renamed either; R7RS requires it, but not renaming is the status quo
       and renaming it would break the common idiom of a macro that defines something.
 
-  - id: SW-35
-    bucket: SILENT-WRONG
+  - id: SW-42
+    bucket: DOCUMENTED-LIMITATION
     status: open
-    needs_decision: true
-    renumbered_from: SW-33
-    renumbered_because: >-
+    needs_decision: false
+    renumbered_from: >-
+      SW-33, then SW-35 (collision). Filed as SW-33 on the pre-rebase stack; renumbered to SW-35
+      when master's own #437 landed a different SW-33/SW-34 pair first (see the original
+      renumbered_because below, kept verbatim for the audit trail). SW-35 collided a SECOND time,
+      independently: branch fix/value-position-axis (PR stacked on #439, merged as part of #442)
+      allocated its OWN unrelated SW-35 ("floor/ceiling/truncate/round as first-class values return
+      a rational's heap pointer") in parallel, and both entries reached master's committed ledger
+      under the same id with no conflict (a textual merge, not a content merge — the check that
+      catches this is parsing the YAML and counting ids, the same lesson SW-41's own
+      id_collision_note records). Master's closed SW-35 (the rounding defect) keeps that id, being
+      the earlier-landed and fully-closed entry; this one moves to SW-42, the next id free across
+      the WHOLE ledger (highest prior id in use was SW-41).
+    original_renumbered_because: >-
       Filed as SW-33 on the pre-rebase stack. While this branch was in review,
       master's #437 landed its own SW-33 (mutated + captured REST parameter) and
       SW-34, and #432 was rebased onto that master. Both entries then existed
@@ -1577,7 +1631,40 @@ entries:
       next truly-free id. Re-surveyed against master's canonical ledger after
       #432 merged as 6acc9030 and #430/#434/#435/#438/#439/#441 landed: master's
       highest id is still SW-34 and it has no SW-35, so SW-35 is the correct
-      free id and needed no second move.
+      free id and needed no second move. [Superseded: a second, independent lane
+      also landed a SW-35 around the same time; see renumbered_from above.]
+    reclassified:
+      from: SILENT-WRONG
+      to: DOCUMENTED-LIMITATION
+      on: "2026-08-13"
+      by: maintainer ruling
+      why: >-
+        Filed SILENT because both engines resolve the shadowed free identifier with no diagnostic.
+        That property is unchanged — this is NOT a loud limitation, unlike SW-14's guarded case, and
+        the entry does not claim otherwise. What changed is the disposition: a loud "unsupported
+        hygiene case" interim was evaluated and explicitly REJECTED (see interim_considered_and_rejected
+        below) because it would fire on nearly every macro in the language. The real fix needs syntax
+        objects — an environment-tagged identifier representation threaded through the reader, both
+        expanders and both name-resolution paths — which is out of scope for a point release. The
+        reclassification records a scope decision, not a claim that the defect stopped being silent.
+    ruling:
+      by: maintainer
+      on: "2026-08-13"
+      decision: >-
+        Documented as a known use-site semantics gap for v1.3.4, with the exact repro, the correct
+        R7RS answer and the root cause recorded in KNOWN_ISSUES.md. The real fix — syntax objects
+        (or marks / scope sets) carrying each identifier's binding environment through the reader,
+        both expanders and both name-resolution paths — is the v1.4 item; see real_fix_sketch and
+        effort below, both unchanged by this ruling.
+      consequences:
+        - "this entry moves SILENT-WRONG -> DOCUMENTED-LIMITATION and stops gating the tag"
+        - "status stays open; syntax-object infrastructure is the close condition, not a guard"
+        - "no loud interim ships — one was built in prototype and rejected as unshippable noise"
+    close_condition: >-
+      This entry closes when a free identifier in a syntax-rules template resolves against its
+      macro-definition environment rather than the use site — i.e. when cell 7 of the SW-30 hygiene
+      matrix (tests/vm_parity/corpus/68_syntax_rules_hygiene.esk) prints 50, not -5, on both engines.
+      Closing by assertion is forbidden (ledger invariant 3); that program's output is the proof.
     title: "syntax-rules templates have no REFERENTIAL TRANSPARENCY: a free identifier in a template resolves at the USE site, not the macro-definition site (both engines, identically)"
     repro: "(define (helper x) (* x 10)) (define-syntax usehelp (syntax-rules () ((_ a) (helper a)))) (display (let ((helper (lambda (x) (- x)))) (usehelp 5)))"
     observed: "native -5, VM -5, exit 0 on both, no diagnostic"
@@ -2337,16 +2424,29 @@ entries:
 
   - id: SW-38
     bucket: SILENT-WRONG
-    status: open
+    status: closed
+    closed_at: "893199e7"
+    closed_by: "PR #445 (fix/vm-first-class-builtin-values); ledger entry itself never flipped until this pass"
     title: "On the VM, cadr and caddr used as FIRST-CLASS VALUES return the empty list"
     repro: "(define (h1 f a) (f a)) (display (h1 cadr (list 1 2 3)))"
-    observed: "VM prints () — exit 0, no diagnostic. Call position (cadr (list 1 2 3)) prints 2."
+    observed_before: "VM prints () — exit 0, no diagnostic. Call position (cadr (list 1 2 3)) prints 2."
     correct: "2 for cadr, 6 for caddr — what call position returns on the same engine"
     measured: >-
       All four value-position routes on the VM (passed to a higher-order procedure,
       stored in a variable, returned from a procedure, reached through map) answer ().
       All four NATIVE axes answer correctly. Reproduced by
       scripts/run_value_position_sweep.py --axis vm.
+    measured_after: >-
+      CLOSED at 893199e7. PR #445 added the complete c[ad]+r accessor family as first-class VM
+      builtins, dispatched through one accessor-path implementation. Re-verified 893199e7: the exact
+      filed repro `(h1 cadr (list 1 2 3))` / `(h1 caddr (list 1 2 3))` now answers `2` / `3` on the VM
+      standalone binary. The full regression file `tests/integration/vm_first_class_builtin_families_test.esk`
+      (run through the VM binary directly, since it also exercises VM-only alias names not bound
+      natively) reports "PASS: VM first-class builtin families". #445's own body states the ledger
+      update was deliberately left to land via a separate branch (fix/value-position-axis) that in fact
+      never carried it — the code fix and the ledger closure were two different PRs and only the first
+      one landed; this pass closes the gap.
+    evidence: "tests/integration/vm_first_class_builtin_families_test.esk re-run at 893199e7 via build/eshkol-vm-standalone-test"
     discovered_by: >-
       The value-position sweep's VM axis, on its first full run. This is the case the VM
       axis exists for: the four native axes agree with each other, so no axis-versus-axis

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -136,6 +136,38 @@ right one. The change that made the rest findable is listed first.
   unmatched pattern into `du`, which under `set -euo pipefail` killed the
   calling suite silently — the cause of a false red on the language-coverage
   floor.
+- **Name resolution ignored lexical shadowing, on both engines, in three
+  subsystems — the highest-priority open AD defect.** A parameter that
+  shadowed a global function name — or a user redefinition of a builtin like
+  `+` — was still resolved to the global/builtin at the call site instead of
+  the shadowing binding: native AD differentiated the shadowed global
+  (`(derivative f x)` through a parameter named `f` answered `6` where `2` was
+  correct), native `map`/`for-each`/`filter`/`fold-left`/`fold-right`/`reduce`/
+  `remove` read the mapped procedure from the global function table instead of
+  the shadowing argument, and the VM's opcode dispatch bypassed a user's own
+  `(define + ...)` entirely (`(+ 3 4)` answered `7`, the built-in sum, instead
+  of `12`). One root cause across all three: name resolution never checked for
+  a local binding first. `isShadowedByLocalRuntimeBinding()`
+  (`lib/backend/llvm_codegen.cpp`) now declines static resolution whenever the
+  name is bound to a local argument or alloca, for AD and every higher-order
+  builtin; `vm_head_user_rebound()` (`lib/backend/vm_compiler.c`) does the VM
+  equivalent for opcode dispatch. (#429)
+- **WASM batch compilation mis-evaluated the first macro when a program had
+  two or more `define-syntax` forms.** Not a wasm-specific bug and not in
+  macro expansion order: a type-punning heap over-read (`MacroNode*` cast to
+  the parser hub's `Node*` across two structs that only claimed to be
+  layout-compatible) read 0–16 bytes past a macro node's allocation, and those
+  bytes were reliably zero on 64-bit hosts but not in wasm32 — undefined
+  behavior invisible natively and wrong in the browser build. `MacroNode` is
+  now literally the hub's `Node` type. (#432)
+- **Two independent backward implementations of six tensor ops (`matmul`,
+  `layernorm`, `transpose`, `sum`, `embedding`, `attention`) had no
+  differential test between them,** and `attention`'s bridge-side backward
+  unconditionally refused rather than computing an answer. All six now agree
+  with each other and with independent finite differences — five to machine
+  precision or exactly, `attention` to ≤2.2e-16 — gated by a direct
+  differential test comparing both implementations on identical inputs.
+  (#434)
 
 ## Resolved in v1.1 (Previously Listed as Planned)
 
@@ -262,14 +294,6 @@ byte-identical across the VM's source and bytecode axes. The one remaining
 native-only case is higher-order nesting (gradient-of-derivative / Taylor
 tower); use native codegen (`eshkol-run`) for nested higher-order AD.
 
-### WASM batch compilation: multiple `define-syntax` forms
-Under the WASM batch compilation path, a program with two or more
-`define-syntax` forms mis-evaluates the first macro's arithmetic. The VM-native
-path and the browser REPL's incremental compilation path both evaluate the same
-program correctly. Found by the WASM execute-and-diff lane and tracked as an
-XFAIL gate in `tests/wasm_diff/EXCLUSIONS.tsv`; use the VM-native or incremental
-REPL path in the meantime.
-
 ---
 
 ## Tracked Open Issues
@@ -282,13 +306,6 @@ block ordinary use.
 
 **Found during the v1.3.4-evolve correctness wave (new, honest knowns)**
 
-- **AD ignores function shadowing — silent wrong answer.** A parameter that
-  shadows a global function name is differentiated as the *global*, not as the
-  shadowing binding: a case whose correct derivative is `4` answers `6`. This
-  affects inexact points as well as exact ones. It is why the new exact-input
-  differentiation tier (#393) uses a whitelist — a body may mention only its own
-  parameter — rather than accepting arbitrary bodies. Silent-wrong class; the
-  highest-priority open AD defect.
 - **The two forward AD carriers now compose (fixed, ESH-0402).** Eshkol carries
   forward-mode derivatives in two representations — the 8-jet (`derivative`,
   first order, three independent perturbations) and the heap Taylor tower
@@ -330,9 +347,55 @@ block ordinary use.
   The VM lane still resolves only the CWD `lib/<dotted>` form and silently
   ignores a path literal. Tracked for v1.3.5; use the dotted module form on the
   VM in the meantime.
-- **The attention backward pass is open.** The embedding and Fréchet-mean
-  backward passes landed this release with gradient checks; attention's backward
-  pass is not yet closed out.
+- **`syntax-rules` templates have no referential transparency: a free
+  identifier resolves at the USE site, not the macro-definition site.**
+  Minimal reproducer:
+  ```scheme
+  (define (helper x) (* x 10))
+  (define-syntax usehelp (syntax-rules () ((_ a) (helper a))))
+  (display (let ((helper (lambda (x) (- x)))) (usehelp 5)))
+  ```
+  Both engines print `-5`. R7RS 4.3.2 requires `50`: a free identifier in a
+  template refers to the binding it had in the macro's *definition*
+  environment, so `helper` must be the top-level one regardless of what the
+  use site binds. The mis-binding only fires when the use site actually
+  shadows a name the template also uses (`+`, `if`, `list`, every builtin and
+  every user helper are all free identifiers in *some* template, so a loud
+  "unsupported hygiene case" diagnostic at every free reference was built,
+  measured, and rejected — it would fire on nearly every macro in the
+  language, including 42 of this repo's own `.esk` files). Closing this
+  needs syntax objects (or marks / scope sets): every identifier carrying the
+  environment it was written in, threaded through the reader, both expanders,
+  and both name-resolution paths — native resolves at LLVM codegen, the VM at
+  compile time against a flat local table, and neither currently has anywhere
+  to put that information. Workaround: do not shadow, at a macro's use site,
+  any free identifier the macro's template refers to. Ruled a documented
+  v1.4 limitation rather than a v1.3.4 fix (maintainer ruling 2026-08-13);
+  tracked as SW-42 in `.icc/silent-wrong-ledger.yaml`, bucket
+  DOCUMENTED-LIMITATION.
+- **Very deep non-tail recursion through a top-level `define`d function
+  lacks the early depth guard that a `lambda` gets, so it runs much deeper
+  before failing, and then fails as a signal rather than a clean diagnostic.**
+  The recursion-depth check (`eshkol_check_recursion_depth`) is emitted only
+  in the lambda-expression codegen path, not in top-level function-definition
+  codegen (`codegenFunctionDefinition`), so a self-recursive top-level
+  `define` never hits the guard's clean "maximum recursion depth exceeded"
+  message the way an equivalent `lambda` would. This is narrower than once
+  measured: the runtime's SIGILL/SIGBUS handler (ESH-0119) now catches the
+  eventual stack overflow on an alternate signal stack and prints a clear
+  "fatal signal … most likely a stack overflow" diagnostic rather than dying
+  with no output at all, and the practical depth at which that happens has
+  moved well past the ~270k frames originally filed — 1,000,000 frames of
+  plain non-tail recursion complete cleanly on the current build, and 3,000,000
+  fails loudly rather than silently. The guard-coverage gap itself is real
+  and unchanged (confirmed by reading the codegen, not by one program's
+  behavior): a `lambda`-bound self-recursive function still gets the early,
+  precise diagnostic that a top-level `define`d one does not. Wiring the
+  guard into every top-level function entry, not just lambdas, is ruled v1.3.5
+  scope (maintainer ruling 2026-08-13, filed as ESH-0101, recorded as a
+  residual of the resource-limits closure in `.icc/silent-wrong-ledger.yaml`
+  under SW-10); not a blocker for v1.3.4, since the failure mode is now loud
+  either way.
 
 **Automatic differentiation**
 - **Differentiating a first-class `gradient` closure again with an enclosing
@@ -373,8 +436,10 @@ block ordinary use.
   do. `sort` is an iterative vector merge sort (ESH-0098 resolved): 1,000,000
   reversed elements sort in 176 MB peak RSS, 5,000,000 in 848 MB, on the JIT and
   AOT alike. `length` and `filter` complete on 1,000,000-element lists
-  (ESH-0108 resolved). Deep non-tail user recursion reaches at least 270k frames
-  without a diagnostic-free death. Mutual tail calls ARE now proper R7RS
+  (ESH-0108 resolved). Deep non-tail user recursion via `lambda` gets an early,
+  precise depth-guard diagnostic; the same recursion via a top-level `define`
+  does not, and instead runs much deeper before failing loudly on a signal
+  (ESH-0101, see above). Mutual tail calls ARE now proper R7RS
   tail calls (emitted as LLVM `musttail`) and run in O(1) stack — ESH-0102
   resolved (2026-07-04). The remaining exception is a higher-order tail call that
   forwards a stack-allocated closure argument, which falls back to a bounded call.
@@ -391,8 +456,6 @@ block ordinary use.
   to 1e7).
 
 **Language edges**
-- A closure created inside a named-let loop that `set!`s a global loses the
-  mutation (ESH-0094).
 - **A lambda that closes over a TCO'd self-recursive function's OWN
   loop-carried parameter and is passed to `derivative`/`gradient` (and, once
   merged, `taylor`) reads a stale/corrupted value or segfaults** once the


### PR DESCRIPTION
## Summary

The situation transformed since this PR was opened: nearly every
silent-wrong defect got FIXED instead of waived (the maintainer's
no-waiver ruling held; ~27 fix PRs merged). This PR converts from a
waiver set to the honest final state: **no waivers ship.**
`docs/KNOWN_ISSUES.md` documents only the items the maintainer explicitly
ruled open for v1.3.4, and every entry describing a now-fixed defect is
removed.

Reset onto master `893199e7`. Single commit on top.

## Gate result (verbatim, the release gate condition)

```
$ python3 scripts/gate_no_silent_wrong.py
no_open_silent_wrong: PASS
  ledger      : .icc/silent-wrong-ledger.yaml
  measured at : 9f2da2ab
  DOC-DEBT        : 12
  DOCUMENTED-LIMITATION: 1
  IN-FLIGHT       : 7
  LOUD-ERROR      : 16
  LOUD-LIMITATION : 1
  PARITY-RATCHET  : 13
  SILENT-WRONG    : 34
  CLOSED WITHOUT A RE-MEASUREMENT SHA (accepted on evidence; not blocking):
    - SW-30  status=fixed  syntax-rules hygiene for TEMPLATE-INTRODUCED BINDINGS: the VM lost the
exit=0
```
0 blocking, 0 waived, 0 invalid, 39 closed/fixed/guarded.

## Six stale-open entries closed with fresh evidence at 893199e7

Master's ledger still marked these `open` even though they were already
fixed — nobody had re-verified and closed them:

- **SW-19** (ESH-0094): filed repro + 6-section regression suite both pass.
- **SW-20** (ESH-0078) / **SW-21** (ESH-0093): the AD oracle's own
  generated probes report "Passed: 20 Failed: 0 Xknown: 0" and "(fixed:
  ESH-0093)" — the oracle detected the fix; the ledger entry was never
  updated to match.
- **SW-23**: reproduces correctly under all 4 modes its own filed comment
  names.
- **SW-38** (VM `cadr`/`caddr` as first-class values): PR #445 fixed the
  code and said the ledger update would land via a branch that never
  actually carried it.

## One ID collision found and fixed

`SW-35` was independently allocated by two unrelated lanes (PR #440's
referential-transparency finding, and the value-position-axis lane's
floor/ceiling bug) and both landed on master under the same id — a
textual merge, not a content merge. The closed floor/ceiling entry keeps
`SW-35`. The open referential-transparency entry is renumbered to `SW-42`
and reclassified `SILENT-WRONG` → a new `DOCUMENTED-LIMITATION` bucket
(maintainer ruling 2026-08-13) — distinct from `LOUD-LIMITATION` (SW-14's
bucket) because this defect has **no diagnostic**: a loud interim was
prototyped and rejected as unshippable (it would fire on nearly every
macro in the language).

## Investigated, NOT reclassified: ESH-0101 confirms real, but not silent

Re-measurement found the originally-filed symptom (silent SIGILL at
~270k frames) no longer reproduces — 1,000,000 frames now complete
cleanly and 3,000,000 fails **loudly** via the existing signal handler
(ESH-0119) rather than silently. But reading `lib/backend/llvm_codegen.cpp`
confirms the recursion-depth guard is still emitted only in
`codegenLambda`, never in `codegenFunctionDefinition` — the architectural
gap the ruling describes is real, even though its practical consequence
changed. Documented precisely rather than either removed or left stale.

## docs/KNOWN_ISSUES.md

- **Removed** (now-fixed, stale as open issues): AD-shadowing
  (SW-01/02/24 family → Resolved-section note crediting #429), WASM
  multi-macro-batch (SW-13 → Resolved-section note crediting #432),
  "attention backward pass is open" (SW-12 → Resolved-section note
  crediting #434), ESH-0094 one-liner (SW-19).
- **Added**, for the ruled-open items: SW-42 (referential transparency)
  and ESH-0101 (guard-coverage gap), each with a minimal reproducer,
  correct answer, root cause and workaround.
- **Kept as-is** (already accurate): SW-14 (VM does not reclaim) and
  SW-05 (curried jacobian-of-gradient raises loudly, ESH-0096).
- Surveyed the rest of the file against every closed/fixed/guarded ledger
  id; no other stale entry found. `i128`, the VM load-path gap (LE-05),
  and the vector-param-capture LLVM-verification gap (LE-06) remain
  because they remain genuinely open and are outside this ledger's scope.

No emoji, plain-text status labels only.

## Test plan

- [x] `python3 scripts/gate_no_silent_wrong.py` — PASS, 0 blocking, 0 waived, 0 invalid
- [x] Every closure (SW-19/20/21/23/38) and the ESH-0101 finding re-run
      against a fresh `893199e7` build: native (cached/nocache JIT), AOT,
      and the VM standalone binary where the entry's evidence names it
- [x] `git log --format=%ae` on the commit — `tsotchkele@gmail.com` only