### PR TITLE
fix(honesty): convert three silent-wrong paths to loud errors (SW-06, SW-09/SW-09b, SW-22)

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -189,16 +189,74 @@ entries:
       docs/KNOWN_ISSUES.md); this PR only stops the VM from silently
       coercing an i128 operand to 0.0 via as_number_vm(). Native is
       unchanged (LE-03 already raised "Type error in +: expected number,
-      vector, or tensor, got heap-object"). NOTE: generic `*` over i128 is
-      the SAME shape of bug and remains open/unfixed on the VM — only `+`
-      (the literal SW-09 repro) was converted here; see
-      docs/KNOWN_ISSUES.md's i128 entry.
-    fixed_by: "branch fix/silent-to-loud-sw06-09-22 (PR converting SW-06/SW-09/SW-22)"
+      vector, or tensor, got heap-object"). SW-09b (below), landed in the
+      same PR before merge, converts the rest of the family (`- * / modulo`,
+      unary `-`, `abs`, `= < > <= >=`) the same way — the family is no
+      longer split between "+ fixed" and "everything else open".
+    fixed_by: "branch fix/silent-to-loud-sw06-09-22 (PR converting SW-06/SW-09/SW-22, SW-09b same PR)"
     evidence: >-
       lib/backend/vm_tests.c source_test_expect "i128-add-raises" (VM
-      standalone self-test, 62/62 passing). Revert-validated: reverting the
+      standalone self-test, 73/73 passing). Revert-validated: reverting the
       guard reproduces the original "no" (silent 0, uncaught) output on the
       pre-fix VM binary.
+
+  - id: SW-09b
+    bucket: LOUD-ERROR
+    subtag: cheap-fix
+    status: fixed
+    reclassified_from: SILENT-WRONG
+    title: >-
+      The rest of the generic arithmetic/comparison family over i128 (-, *,
+      /, modulo, unary -, abs, =, <, >, <=, >=) now raises on the VM, same
+      as SW-09's +
+    repro: >-
+      (define a (i128 5)) (define b (i128 7)) (display (guard (e (#t
+      'caught)) (* a b) 'no)) — and the same shape for -, /, modulo, (- a),
+      (abs a), =, <, >, <=, >=.
+    observed_before: >-
+      Every one of these opcodes silently answered a fabricated value with
+      exit 0 on the VM (e.g. `*` printed 'no', meaning the guard body ran to
+      completion and returned its non-exceptional value, exactly like SW-09
+      before its fix). Confirmed by direct measurement: not caught by the
+      original SW-09 fix, which converted only `+`.
+    observed_after: >-
+      All twelve opcodes now raise a catchable "i128 arithmetic/comparison
+      is not supported on the VM" error: `+ - * / modulo` (binary
+      arithmetic), unary `-` and `abs` (unary arithmetic), `= < > <= >=`
+      (comparison). Fixed in BOTH of vm_run.c's independent dispatch
+      implementations — the threaded/computed-goto loop (lbl_ADD, lbl_SUB,
+      lbl_MUL, lbl_DIV, lbl_MOD, lbl_NEG, lbl_ABS, lbl_EQ, lbl_LT, lbl_GT,
+      lbl_LE, lbl_GE) and the switch-based fallback compiled only on
+      non-GCC/non-Clang toolchains (OP_ADD, OP_SUB, OP_MUL, OP_DIV, OP_MOD,
+      OP_NEG, OP_ABS, OP_EQ, OP_LT, OP_GT, OP_LE, OP_GE) — this platform can
+      only execute the threaded loop, so the switch-based twin was verified
+      by temporarily forcing its compilation (flipping the `#if
+      defined(__GNUC__) || defined(__clang__)` guard to `#if 0`, confirming
+      a clean build and all 12 opcodes raising, then reverting). No i128
+      opcodes were implemented — this is still a missing-opcode-branch gap,
+      not the v1.3.5 real fix; only the silent-wrong path changed. The
+      dedicated `i128-*`/`i128=?`/`i128<?`/etc. comparison and arithmetic
+      surface (docs/KNOWN_ISSUES.md) is unaffected and was already correct.
+    fixed_by: "branch fix/silent-to-loud-sw06-09-22 (PR converting SW-06/SW-09/SW-22)"
+    evidence: >-
+      lib/backend/vm_tests.c source_test_expect entries i128-sub-raises,
+      i128-mul-raises, i128-div-raises, i128-modulo-raises, i128-neg-raises,
+      i128-abs-raises, i128-eq-raises, i128-lt-raises, i128-gt-raises,
+      i128-le-raises, i128-ge-raises (VM standalone self-test, 73/73
+      passing, up from 62/62 pre-family-fix). ctest 142/142, VM parity
+      144/144 (0 failed) after the family-wide change — no regression.
+      Revert-validated at MUL specifically (temporarily `#if 0`-disabling
+      just the lbl_MUL guard reproduced the original silent 'no' output;
+      restoring it reproduced 'caught'), plus the family-wide instance of
+      the same pattern already proved once for SW-09's `+`.
+    caught_by: [direct-measurement, coordinator-review]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, i128_native_type_oracle]
+    notes: >-
+      Filed because the original SW-09 fix explicitly scoped itself to `+`
+      (the literal ledger repro) and left the rest of the family open in
+      KNOWN_ISSUES rather than silently dropping them — this entry closes
+      that gap in the same PR, before merge, so no silent-wrong i128 path
+      ships.
     caught_by: [KNOWN_ISSUES, direct-measurement]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, i128_native_type_oracle]
     notes: "Native half was already LOUD-ERROR (see LE-03); this PR fixes the VM half."

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -1,0 +1,826 @@
+# Silent-wrong flaw ledger — the release gate's input.
+#
+# CONTRACT
+#   A SILENT-WRONG flaw is one where the compiler, the VM, or the runtime
+#   produces a wrong value, a wrong derivative, or a wrong memory outcome
+#   with NO diagnostic and a zero exit status. The maintainer's release
+#   philosophy is that these are tag-blocking: a loud failure is honest, a
+#   silent one is a lie told to a consumer.
+#
+#   `scripts/gate_no_silent_wrong.py` reads this file and emits the
+#   `no_open_silent_wrong` runtime_event consumed by the
+#   `eshkol-compiler-readiness` and `v1.3-evolve` oracles in
+#   .icc/completion-oracles.yaml. The gate is PASS only when every entry
+#   whose `bucket` is SILENT-WRONG has `status: closed` or a `waiver` block
+#   with an owner, a reason and an expiry date that has not passed.
+#
+#   The gate FAILS CLOSED. A missing, unparseable or schema-invalid ledger
+#   is a FAIL, never a pass — absence of the ledger is not evidence of an
+#   absence of silent-wrong defects.
+#
+# INVARIANTS (the same discipline as .icc/doc-claims-allowlist.yaml)
+#   1. Every entry cites a reproducer that a reader can run, and the exact
+#      observed-vs-correct values. "Believed fixed" is not a status.
+#   2. A waiver is scaffolding with an expiry, not a tolerance. It names an
+#      owner, a reason, and a date. An expired waiver is a FAIL.
+#   3. Entries only close by measurement at a named SHA, recorded in
+#      `closed_at`. Closing by assertion is forbidden.
+#   4. Growth is a finding: a NEW SILENT-WRONG entry appearing in a PR must
+#      be justified in that PR's body.
+#   5. The buckets other than SILENT-WRONG are carried here for one ledger,
+#      one truth — but only SILENT-WRONG gates the release.
+
+schema: eshkol.silent_wrong_ledger.v1
+generated_at: "2026-08-12"
+measured_at_sha: "9f2da2ab"
+measured_with: "build/eshkol-run (RelWithDebInfo, LLVM 21, arm64-apple-darwin24.1.0), build/eshkol-vm-standalone-test"
+reproducer_root: ".scratch/flaw-ledger/repro"
+
+buckets:
+  SILENT-WRONG: "Wrong value / wrong derivative / wrong memory outcome, no diagnostic, exit 0. TAG-BLOCKING."
+  LOUD-ERROR: "Fails with a visible diagnostic, crash or non-zero exit. Bad, but honest. Sub-tagged cheap-fix or structural."
+  PARITY-RATCHET: "Engine divergence already tracked by a shrink-only ratchet gate."
+  DOC-DEBT: "Documentation claim versus measured reality; allowlisted or ledgered."
+  IN-FLIGHT: "Has an open PR or an active fix lane at the time of this cut."
+
+entries:
+
+  # ───────────────────────── SILENT-WRONG ─────────────────────────
+
+  - id: SW-01
+    bucket: SILENT-WRONG
+    status: open
+    title: "AD differentiates the shadowed global, not the parameter"
+    repro: "(define (f x) (* x x)) (define (g f x) (derivative f x)) (display (g (lambda (y) (* 2 y)) 3.0))"
+    observed: "native 6"
+    correct: "2"
+    cross_engine: "VM answers 2 (correct); native is the wrong side"
+    evidence: ".scratch/flaw-ledger/repro/sw_ad_shadow.esk; docs/KNOWN_ISSUES.md:249"
+    caught_by: [KNOWN_ISSUES, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ad_adversarial_fd_oracle]
+    notes: "Named in KNOWN_ISSUES as 'the highest-priority open AD defect'. No fix lane."
+
+  - id: SW-02
+    bucket: SILENT-WRONG
+    status: open
+    title: "map resolves the mapped procedure from the global table, ignoring a shadowing binding"
+    repro: "(define (scale x) (* x 100)) (define (apply-map scale lst) (map scale lst)) (display (apply-map (lambda (x) (+ x 10)) (list 1 2 3)))"
+    observed: "native (100 200 300)"
+    correct: "(11 12 13)"
+    cross_engine: "VM answers (11 12 13) (correct)"
+    evidence: "lib/backend/map_codegen.cpp; PR #420 body, 'Adjacent defects found, deliberately NOT fixed here'"
+    caught_by: [pr-record-420, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
+    notes: >-
+      #420 states a candidate guard on map_codegen.cpp was built and measured to be a
+      no-op, so the substitution happens upstream in name resolution. #420 does NOT fix
+      it and explicitly says it 'wants its own task' — this is NOT in flight.
+
+  - id: SW-03
+    bucket: SILENT-WRONG
+    status: open
+    title: "The Taylor tower cannot nest: derivative-n of derivative-n returns 0"
+    repro: "(define (f x) (* x x x x)) (display (derivative-n (lambda (y) (derivative-n f y 1)) 2.0 1))"
+    observed: "0"
+    correct: "48"
+    cross_engine: "VM errors (rc=1) — loud on that side"
+    evidence: ".scratch/flaw-ledger/repro/sw_taylor_nest.esk; docs/KNOWN_ISSUES.md:256"
+    caught_by: [KNOWN_ISSUES, pr-record-417, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: SW-04
+    bucket: SILENT-WRONG
+    status: open
+    title: "derivative-n applied to a derivative CLOSURE returns 0"
+    repro: "(define (f x) (* x x x x)) (define df (derivative f)) (display (derivative-n df 2.0 1))"
+    observed: "0"
+    correct: "48"
+    evidence: ".scratch/flaw-ledger/repro/sw_deriv_closure.esk; docs/KNOWN_ISSUES.md:288"
+    caught_by: [KNOWN_ISSUES, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: SW-05
+    bucket: SILENT-WRONG
+    status: open
+    title: "Curried gradient-of-gradient returns a zero matrix (ESH-0096)"
+    repro: "(define (f v) (* (vector-ref v 0) (vector-ref v 0) (vector-ref v 0))) (define g (gradient f)) (display (jacobian g (vector 2.0)))"
+    observed: "#((0))"
+    correct: "#((12)) — (hessian f (vector 2.0)) returns #((12)) on the same build"
+    evidence: ".scratch/flaw-ledger/repro/sw_gofg.esk; docs/KNOWN_ISSUES.md:279"
+    caught_by: [KNOWN_ISSUES, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, pr-record-416]
+    notes: >-
+      PR #416 measured ESH-0096 as CLOSED and proposed deleting the KNOWN_ISSUES entry.
+      Direct measurement at 9f2da2ab contradicts that for the curried jacobian route.
+      Do not accept #416's close of ESH-0096.
+
+  - id: SW-06
+    bucket: LOUD-ERROR
+    subtag: cheap-fix
+    status: fixed
+    reclassified_from: SILENT-WRONG
+    title: "diff on a quoted s-expression now raises a catchable error on BOTH engines"
+    repro: "(display (guard (e (#t 'caught)) (diff '(* x x) 'x) 'no))"
+    observed_before: "native 0, VM 0 (both silently fabricated a derivative of 0)"
+    observed_after: >-
+      both engines now print 'caught' — native raises via eshkol_raise() /
+      eshkol_make_exception_with_header() from codegenDiff()
+      (lib/backend/llvm_codegen.cpp), the VM raises via vm_raise_error_msg()
+      from native call 393 (lib/backend/vm_native.c, shared with
+      `derivative`). Neither engine attempts real symbolic differentiation of
+      quoted data — that feature remains unimplemented and is v1.3.5 scope;
+      this PR only converts the silent wrong answer into an honest, R7RS
+      guard-catchable exception. The unquoted form, e.g. (diff (* x x) x),
+      is unaffected and still returns the correct symbolic derivative.
+    fixed_by: "branch fix/silent-to-loud-sw06-09-22 (PR converting SW-06/SW-09/SW-22)"
+    evidence: >-
+      tests/differential/corpus/42_diff_quoted_raises.esk (all 4 native axes
+      agree, exit 0, guard catches — see tests/differential/README.md for the
+      axis matrix); lib/backend/vm_tests.c source_test_expect
+      "diff-quoted-expr-raises" and "derivative-non-callable-raises" (VM
+      standalone self-test, 62/62 passing). Revert-validated: reverting the
+      guard reproduces the original "no" (unguarded) output on both engines.
+    caught_by: [direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES, all-differential-gates]
+    notes: >-
+      Shared-defect blindness (pre-fix): both engines agreed on the wrong
+      answer, so no native-vs-VM differential axis could ever see it — the
+      new corpus entry closes that specific blind spot going forward. This
+      is the class the P8 reference-free property oracles were meant to
+      close more generally.
+
+  - id: SW-07
+    bucket: SILENT-WRONG
+    status: open
+    title: "fg-marginal returns an empty result natively"
+    repro: "(define fg (make-factor-graph 2 2)) (display (fg-marginal fg 0))"
+    observed: "native (), VM #(0.5 0.5)"
+    correct: "#(0.5 0.5) — the uniform marginal"
+    evidence: ".scratch/flaw-ledger/repro/sw_fg_marginal.esk; PR #413 Follow-ups item 2"
+    caught_by: [pr-record-413, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
+    notes: "PR #413 explicitly leaves this alone. #413 is still OPEN, so even its factor-graph fixes are not in the cut."
+
+  - id: SW-08
+    bucket: SILENT-WRONG
+    status: open
+    title: "rationalize diverges between engines; the VM silently answers 0"
+    repro: "(display (rationalize (/ 1 3) 1/10000))"
+    observed: "native 1/3, VM 0"
+    correct: "1/3"
+    evidence: ".scratch/flaw-ledger/repro/sw_rationalize.esk"
+    caught_by: [direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES, numeric_exactness_oracle]
+
+  - id: SW-09
+    bucket: LOUD-ERROR
+    subtag: cheap-fix
+    status: fixed
+    reclassified_from: SILENT-WRONG
+    title: "Generic + over i128 now raises a catchable error on the VM (native was already loud)"
+    repro: "(define a (i128 5)) (define b (i128 7)) (display (guard (e (#t 'caught)) (+ a b) 'no))"
+    observed_before: "VM 0 (exit 0); native raises a type error (exit 1) — see LE-03"
+    observed_after: >-
+      VM now prints 'caught' (raised via vm_raise_error_msg() in both the
+      switch-based OP_ADD and the threaded lbl_ADD interpreter loops,
+      lib/backend/vm_run.c — the VM has two independent dispatch
+      implementations of every opcode and both needed the guard). No i128
+      opcodes were implemented (that is v1.3.5 scope, tracked
+      docs/KNOWN_ISSUES.md); this PR only stops the VM from silently
+      coercing an i128 operand to 0.0 via as_number_vm(). Native is
+      unchanged (LE-03 already raised "Type error in +: expected number,
+      vector, or tensor, got heap-object"). NOTE: generic `*` over i128 is
+      the SAME shape of bug and remains open/unfixed on the VM — only `+`
+      (the literal SW-09 repro) was converted here; see
+      docs/KNOWN_ISSUES.md's i128 entry.
+    fixed_by: "branch fix/silent-to-loud-sw06-09-22 (PR converting SW-06/SW-09/SW-22)"
+    evidence: >-
+      lib/backend/vm_tests.c source_test_expect "i128-add-raises" (VM
+      standalone self-test, 62/62 passing). Revert-validated: reverting the
+      guard reproduces the original "no" (silent 0, uncaught) output on the
+      pre-fix VM binary.
+    caught_by: [KNOWN_ISSUES, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, i128_native_type_oracle]
+    notes: "Native half was already LOUD-ERROR (see LE-03); this PR fixes the VM half."
+
+  - id: SW-10
+    bucket: SILENT-WRONG
+    status: open
+    title: "Seven documented resource-limit environment variables are accepted and never enforced"
+    repro: "ESHKOL_MAX_HEAP=1 ESHKOL_ENFORCE_LIMITS=1 eshkol-run -r a-20M-iteration-loop.esk"
+    observed: >-
+      Runs to completion, prints 199999990000000, exit 0. ESHKOL_TIMEOUT_MS=500 prints
+      'ERROR: Execution timeout: 500ms limit exceeded' and then runs to completion and exits 0.
+    correct: "The documented limit is applied, or the variable is documented as inert"
+    variables: [ESHKOL_MAX_HEAP, ESHKOL_TIMEOUT_MS, ESHKOL_MAX_STACK, ESHKOL_MAX_TENSOR_ELEMS, ESHKOL_MAX_STRING_LEN, ESHKOL_ENFORCE_LIMITS, ESHKOL_LIMIT_WARNINGS]
+    evidence: >-
+      lib/core/resource_limits.cpp parses into g_limits and nothing consults it.
+      Exhaustive grep over lib/, inc/ and exe/ for eshkol_check_tensor_size,
+      eshkol_check_string_length, eshkol_is_timed_out and eshkol_track_allocation returns
+      15 hits: 11 declarations in inc/eshkol/core/resource_limits.h and 4 definitions in
+      lib/core/resource_limits.cpp. ZERO call sites anywhere else — the enforcement
+      functions are written, compiled, and never invoked. Documented as controls at docs/breakdown/RUNTIME_CONFIGURATION.md:27-33,
+      docs/reference/runtime/environment-variables.md:65-73, docs/API_REFERENCE.md:4396-4402.
+    caught_by: [pr-record-416, direct-measurement, doc-source-crosscheck]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
+    notes: >-
+      A consumer setting a heap ceiling to contain untrusted code gets no containment
+      and no warning. #416 adds honest 'Accepted, not enforced in v1.3.4' status columns
+      but #416 is UNMERGED, so the cut still documents them as controls.
+
+  - id: SW-11
+    bucket: SILENT-WRONG
+    status: open
+    title: "(the <type> expr) is a runtime no-op, so a false ascription is never caught"
+    repro: "(display (the string (+ 1 2)))"
+    observed: "3, exit 0"
+    correct: "a type error, or a doc that does not call it an assertion"
+    evidence: ".scratch/flaw-ledger/repro/sw_the.esk; docs/FEATURE_MATRIX.md:72,804"
+    caught_by: [direct-measurement, doc-source-crosscheck]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    notes: "Documented as a 'trusted assertion to the checker; runtime no-op (byte-identical IR)'. Documented-by-design, but the word 'assertion' is the lie."
+
+  - id: SW-12
+    bucket: SILENT-WRONG
+    status: open
+    title: "Six tensor ops carry two independent backward implementations with no differential test between them"
+    ops: [matmul, layernorm, transpose, sum, embedding, attention]
+    evidence: >-
+      lib/backend/tensor_backward.cpp defines eshkol_backward_{matmul,layernorm,transpose,sum,embedding,attention};
+      lib/bridge/tensor_backward.cpp defines tensor_{matmul,layernorm,transpose,sum,embedding,attention}_backward.
+      tests/bridge/qllm_bridge_gradcheck_test.cpp gradchecks the BRIDGE half against finite
+      differences for matmul/gelu/softmax/layernorm/rmsnorm/silu/cross-entropy and explicitly
+      EXCLUDES attention and embedding. No test compares the two implementations on the same input.
+    caught_by: [direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, duplicate-implementations-detector]
+    notes: >-
+      ICC's duplicate-implementations detector did not flag this pair: the two files are
+      not textually similar, so a lexical clone detector cannot see a semantic duplicate.
+      That is a concrete ICC detector gap, not a scoping choice. The correctness chain's
+      other half, `contradictions`, returned 30 findings at this SHA and every one is a
+      constant_disagreement or env_default_disagreement on a build/tuning symbol — it
+      compares symbol VALUES, never behaviour, docs or test-harness metadata.
+
+  - id: SW-13
+    bucket: SILENT-WRONG
+    status: open
+    title: "WASM batch compile mis-evaluates the first macro when a program has two or more define-syntax forms"
+    observed: "(dbl 21) => (* 2 21) prints a garbage bignum, value varies per build"
+    correct: "42"
+    evidence: "tests/wasm_diff/EXCLUSIONS.tsv (XFAIL row, 16_define_syntax.esk); reaffirmed in PR #413 and #418"
+    caught_by: [parity-baselines, pr-record-413, pr-record-418]
+    missed_by: [icc-correctness-chain, icc-readiness]
+    notes: "Excused by an XFAIL row, so the wasm gate is green while the defect ships in the browser build."
+
+  - id: SW-14
+    bucket: SILENT-WRONG
+    status: open
+    title: "with-region on the VM never reclaims — silent unbounded memory growth"
+    observed: "A VM program using regions computes the right answer and never gets the memory back; the VM heap has no escape evacuator"
+    evidence: "docs/KNOWN_ISSUES.md:211"
+    caught_by: [KNOWN_ISSUES]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    notes: "Classified silent because a long-running VM process degrades with no diagnostic and exit 0."
+
+  - id: SW-15
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "9f2da2ab"
+    title: "Out-of-range tensor-set! returns without writing, natively"
+    filed_claim: "the lost write is undetectable by the program; the VM raises"
+    measured: "both engines print 'caught' twice — native raises. The filed reproducer is STALE."
+    evidence: "tests/vm_parity/found/tensor_set_oob_silent_native.esk re-run at 9f2da2ab"
+
+  - id: SW-16
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "9f2da2ab"
+    title: "Multi-dimensional tensor-ref with an out-of-range component reads the wrong element, natively"
+    filed_claim: "reads (0 2) of a 2x2 when the flat offset happens to land in range; the VM raises"
+    measured: "both engines print 'caught' — native raises. The filed reproducer is STALE."
+    evidence: "tests/vm_parity/found/tensor_ref_component_oob_native.esk re-run at 9f2da2ab"
+
+  - id: SW-17
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "9f2da2ab"
+    title: "Native (tensor <rectangular nested collection>) flattens the outer level and zero-fills"
+    filed_claim: "native #(0 0) shape (2); the VM builds the correct rank-N tensor"
+    measured: "both engines print #((1 2) (3 4)) with shape (2 2) — correct. The filed reproducer is STALE."
+    evidence: "tests/vm_parity/found/tensor_nested_collection_native.esk re-run at 9f2da2ab"
+
+  - id: SW-18
+    bucket: SILENT-WRONG
+    status: open
+    title: "Exact rational arithmetic degrades to double once a bignum is involved (ESH-0105)"
+    evidence: "docs/KNOWN_ISSUES.md:371; tests/vm_parity/found/bignum_exact_rational.esk"
+    caught_by: [KNOWN_ISSUES, parity-baselines]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: SW-19
+    bucket: SILENT-WRONG
+    status: open
+    title: "A closure created inside a named-let loop that set!s a global loses the mutation (ESH-0094)"
+    evidence: "docs/KNOWN_ISSUES.md:333"
+    caught_by: [KNOWN_ISSUES]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: SW-20
+    bucket: SILENT-WRONG
+    status: open
+    title: "Second-order gradient through a NAMED inner function returns 0 (ESH-0078)"
+    observed: "0; the inline-lambda form works"
+    evidence: "tests/ad_oracle/README.md XKNOWN table, cells nest.gofg.*.s.named/lamvar"
+    caught_by: [ad-oracle-xknown]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    notes: >-
+      The oracle README self-documents a possible regression: 'the ledger marks this merged
+      via #95, but the acceptance shape still returns 0 on master — regressed or never fully fixed.'
+
+  - id: SW-21
+    bucket: SILENT-WRONG
+    status: open
+    title: "Vector-param gradient over an inner derivative returns zeros (ESH-0093)"
+    evidence: "tests/ad_oracle/README.md XKNOWN, cells nest.gofd.*.v2; tests/ad_oracle/generated/ad_oracle_nest_04.esk:98,100,106,108"
+    caught_by: [ad-oracle-xknown]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: SW-22
+    bucket: SILENT-WRONG
+    status: guarded
+    title: "eshkol_xla_broadcast now validates broadcast compatibility at its runtime entry point"
+    guarded_by: "branch fix/silent-to-loud-sw06-09-22 (PR converting SW-06/SW-09/SW-22)"
+    guard: >-
+      lib/backend/xla/xla_runtime.cpp eshkol_xla_broadcast() now rejects
+      (returns nullptr) whenever the source rank exceeds the target rank, or
+      any right-aligned source dimension is neither 1 nor equal to the
+      corresponding target dimension — the same NumPy broadcast rule
+      XLATypes::broadcastShape() (lib/backend/xla/xla_types.cpp) already
+      applies at compile time, added here as the runtime's own guard for
+      callers that reach this entry point directly. This closes the actual
+      memory-safety defect: before the guard, an incompatible source
+      dimension NARROWER than the target read past the end of the source
+      buffer during the stride-multiplication loop, not merely computing a
+      wrong numeric answer.
+    why_not_closed: >-
+      Kept as `guarded` rather than `closed` because (1) XLACodegen::
+      emitBroadcast() — the LLVM IR emission path — has zero callers
+      anywhere in the compiler today (grep confirms; the XLA broadcast
+      bridge is not yet wired into any user-reachable codegen path, and
+      ESHKOL_XLA_ENABLED defaults OFF), so there is no live user-facing
+      "loud error" to observe end-to-end yet; and (2) no caller of
+      eshkol_xla_broadcast() — including the dead emitBroadcast() path —
+      currently null-checks its return value, so a null result is a guard
+      against the worse outcome (OOB read / silent wrong answer), not yet a
+      polished user-facing diagnostic. The guard is real and tested; closing
+      the ledger entry is deferred until the bridge has a reachable caller
+      that turns the null into a proper Eshkol-level error.
+    evidence: >-
+      tests/xla/xla_codegen_test.cpp test_xla_broadcast_compatible (two
+      NumPy-rule broadcasts, exact value comparison) and
+      test_xla_broadcast_incompatible (three incompatible-shape cases, all
+      correctly rejected) — built and run with -DESHKOL_XLA_ENABLED=ON,
+      11/11 xla_codegen_test PASS. Revert-validated: with the guard
+      temporarily `#if 0`'d out, test_xla_broadcast_incompatible fails
+      exactly as expected (proving the guard is load-bearing), then passes
+      again once restored. docs/breakdown/XLA_BACKEND.md:705 updated to
+      describe the guard instead of its absence.
+    caught_by: [doc-source-crosscheck]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: SW-23
+    bucket: SILENT-WRONG
+    status: open
+    title: "A confirmed native/VM divergence is excluded from every gate by README policy"
+    evidence: "tests/differential/found/003_global_set_from_function_lost.esk; tests/differential/README.md states found/ is evidence, not gate input"
+    caught_by: [parity-baselines]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: SW-24
+    bucket: SILENT-WRONG
+    status: open
+    title: "The VM ignores a user redefinition of + : opcode dispatch bypasses the user binding"
+    repro: "(define + (lambda (a b) (* a b))) (display (+ 3 4))"
+    observed: "VM 7"
+    correct: "12 — native answers 12"
+    evidence: >-
+      tests/parser/test_function_shadowing.esk, run on both engines at 9f2da2ab. The test
+      prints its own verdict: native "PASS: Function shadowing works!", VM "FAIL: Expected 12".
+      The program is listed in ENGINE_PARITY_BASELINE.json divergent_programs, so the parity
+      gate is green while the test says FAIL out loud.
+    caught_by: [parity-baselines, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
+    notes: >-
+      THE SAME ROOT CLASS AS SW-01 AND SW-02. Name resolution does not respect shadowing,
+      and it surfaces on both engines in different subsystems: native ignores the shadowing
+      binding in AD (SW-01) and in map (SW-02); the VM ignores it in arithmetic opcode
+      dispatch (this entry). Treat the three as one defect family with one root cause, not
+      as three unrelated tickets. A user who redefines + gets a wrong number and no
+      diagnostic — the most basic Scheme capability there is.
+
+  # ───────────────────────── IN-FLIGHT ─────────────────────────
+
+  - id: IF-01
+    bucket: IN-FLIGHT
+    silent_wrong_class: true
+    status: open
+    title: "AD capture reconstruction ignores lexical scope; the default JIT object cache miscompiles core.ad.guw"
+    observed: "in-process JIT returns -0.6868 where 0.9553 is correct; AOT segfaults"
+    fix_lane: "PR #420 (fix/jit-object-cache-miscompile) — OPEN, not in the cut"
+    evidence: "PR #420 body; tests/differential/corpus/42_ad_capture_global_shadow.esk; docs/guide/AUTOMATIC_DIFFERENTIATION.md carries ESHKOL_JIT_CACHE=0 eight times as a workaround"
+    caught_by: [pr-record-416, pr-record-420]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: IF-02
+    bucket: IN-FLIGHT
+    silent_wrong_class: true
+    status: open
+    title: "take/drop argument order is reversed between the native stdlib and the VM prelude"
+    fix_lane: "PR #418 — OPEN"
+    evidence: "lib/core/list/transform.esk:8,14 vs lib/backend/vm_prelude_source.h:80-81; PR #416 Escalation 4"
+    caught_by: [pr-record-416, pr-record-418]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: IF-03
+    bucket: IN-FLIGHT
+    silent_wrong_class: true
+    status: open
+    title: "Complex transcendentals reinterpret the complex heap pointer as a double"
+    fix_lane: "PR #419 — OPEN"
+    evidence: "lib/backend/llvm_codegen.cpp:14191-14223 routes through codegenMathFunction; PR #416 Escalation 1 calls it a memory-safety defect"
+    caught_by: [pr-record-416, pr-record-419]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, sanitizer-fuzz-lane]
+
+  - id: IF-04
+    bucket: IN-FLIGHT
+    silent_wrong_class: true
+    status: open
+    title: "inexact->exact loses precision"
+    observed: "returns 450359962737049/4503599627370496 (0.09999999999999987) for the documented case"
+    fix_lane: "PR #419 — OPEN"
+    evidence: "docs/ESHKOL_LANGUAGE_GUIDE.md:454; PR #416 Escalation 2"
+    caught_by: [pr-record-416, pr-record-419]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: IF-05
+    bucket: IN-FLIGHT
+    silent_wrong_class: true
+    status: open
+    title: "free-energy returns -0.0 on the VM and in the browser build regardless of evidence"
+    fix_lane: "PR #413 — OPEN"
+    evidence: "PR #413; PR #414 'Adjacent divergences found and NOT fixed here'; examples/consciousness.esk"
+    caught_by: [pr-record-413, pr-record-414]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: IF-06
+    bucket: IN-FLIGHT
+    silent_wrong_class: false
+    status: open
+    title: "A non-store value passed to a memory-store accessor SIGSEGVs at address 0"
+    fix_lane: "PR #418 — OPEN"
+    evidence: "lib/core/memory_store.esk; PR #416 Escalation 5. No test in tests/ exercises memory-store-append! at all."
+    caught_by: [pr-record-416]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: IF-07
+    bucket: IN-FLIGHT
+    silent_wrong_class: false
+    status: open
+    title: "void* is not accepted as an extern type name; it warns and silently defaults to int64"
+    fix_lane: "PR #418 — OPEN"
+    evidence: "mapStringToType in lib/backend/llvm_codegen.cpp; PR #416 Escalation 6"
+    caught_by: [pr-record-416]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  # ───────────────────────── LOUD-ERROR ─────────────────────────
+
+  - id: LE-01
+    bucket: LOUD-ERROR
+    subtag: structural
+    status: open
+    title: "Builtins are call-position-only; passing one as a first-class value SIGSEGVs (exit 139)"
+    repro: "(define (ap f a b) (f a b)) (display (ap string<? \"a\" \"b\"))"
+    observed: "SIGSEGV at address 0x0, exit 139"
+    affected_measured: ["string<?", "string>?", "string=?", "char<?", "char=?", "string-append", "vector-ref", "car", "expt", "min", "max"]
+    unaffected_measured: ["+", "<", "eq?"]
+    evidence: ".scratch/flaw-ledger/repro/fc_tmp.esk; tests/differential/corpus/37_sort.esk"
+    caught_by: [pr-record-420, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, KNOWN_ISSUES]
+    notes: >-
+      PR #420 describes this as 'Undefined variable'. At 9f2da2ab it is a SIGSEGV, which is
+      strictly worse, and it is a FAMILY, not one builtin. It is the failure_free blocker
+      that holds icc readiness at 77 on #420's branch.
+
+  - id: LE-02
+    bucket: LOUD-ERROR
+    subtag: structural
+    status: open
+    title: "hessian over a lambda capturing its enclosing function's parameter fails LLVM verification"
+    repro: "(define (hwrap q) (hessian (lambda (t) (* q t t t)) 2.0)) (display (hwrap 2.0))"
+    observed: "ERROR: LLVM module verification failed: Incorrect number of arguments passed to called function! exit 1"
+    evidence: "PR #420's tests/ad/ad_capture_global_shadow_test.esk lines 25-29 document it as NOT covered; hessian capture path in lib/backend/autodiff_codegen.cpp"
+    caught_by: [pr-record-420, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
+    notes: "NOT in flight. #420 explicitly excludes it so its own gate is not red for the wrong reason."
+
+  - id: LE-03
+    bucket: LOUD-ERROR
+    subtag: cheap-fix
+    status: open
+    title: "Generic + over i128 raises a type error natively"
+    observed: "Type error in +: expected number, vector, or tensor, got heap-object; exit 1"
+    evidence: ".scratch/flaw-ledger/repro/sw_i128.esk; docs/KNOWN_ISSUES.md:262"
+    caught_by: [KNOWN_ISSUES, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    notes: "Paired with SW-09, the silent VM half."
+
+  - id: LE-04
+    bucket: LOUD-ERROR
+    subtag: cheap-fix
+    status: open
+    title: "sort argument order is reversed between engines"
+    observed: "native accepts (sort lst <) and errors on (sort < lst) with 'cdr: argument is not a pair'; the VM is the exact mirror"
+    evidence: ".scratch/flaw-ledger/repro/sw_sort_order.esk, sw_sort_vmorder.esk; PR #418 body"
+    caught_by: [pr-record-418, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
+    notes: "Same class as IF-02 take/drop, but sort is NOT fixed by #418 and has no test."
+
+  - id: LE-05
+    bucket: LOUD-ERROR
+    subtag: structural
+    status: open
+    title: "(load \"path.esk\") is not resolvable on the VM lane"
+    observed: "vm-src: WARNING undefined variable 'load' then ERROR: calling non-function, fatal"
+    evidence: ".scratch/flaw-ledger/repro/sw_load_path.esk; docs/KNOWN_ISSUES.md:269"
+    caught_by: [KNOWN_ISSUES, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    notes: >-
+      KNOWN_ISSUES:269 says the VM 'silently ignores a path literal'. On the vm-src lane at
+      9f2da2ab it is LOUD. The doc overstates the severity; the entry needs correcting either way.
+
+  - id: LE-06
+    bucket: LOUD-ERROR
+    subtag: structural
+    status: open
+    title: "Vector-param AD op capturing a local function parameter fails LLVM verification (ESH-0097)"
+    observed: "PtrToInt source must be pointer, on both -r and AOT"
+    evidence: "tests/ad_oracle/README.md XKNOWN; docs/KNOWN_ISSUES.md:299"
+    caught_by: [KNOWN_ISSUES, ad-oracle-xknown]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: LE-07
+    bucket: LOUD-ERROR
+    subtag: structural
+    status: open
+    title: "VM frame overflow prints to stderr and then exits 0 with empty stdout"
+    evidence: "tests/vm_parity/found/frame_overflow_exit_zero.esk; tests/vm_parity/found/when_tail_call_no_tco.esk"
+    caught_by: [parity-baselines]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    notes: "Loud on stderr but exit 0 — silent to any caller that checks the exit status. Borderline SILENT-WRONG."
+
+  - id: LE-08
+    bucket: LOUD-ERROR
+    subtag: structural
+    status: open
+    title: "VM top-level mutual recursion grouping breaks on interleaved non-define expressions"
+    evidence: "docs/KNOWN_ISSUES.md:195"
+    caught_by: [KNOWN_ISSUES]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  # ───────────────────────── PARITY-RATCHET ─────────────────────────
+
+  - id: PR-01
+    bucket: PARITY-RATCHET
+    status: open
+    title: "ENGINE_PARITY_BASELINE.json excuses 10 divergent programs"
+    count: 10
+    evidence: "tests/vm_parity/ENGINE_PARITY_BASELINE.json; PR #414 body names each"
+    highest_priority: "tests/parser/test_function_shadowing.esk — a user + is ignored by opcode dispatch (VM 7, native 12). Promoted to SW-24."
+    measured: >-
+      All 10 were re-run on both engines at 9f2da2ab. NINE diverge only in output FORMATTING
+      (the VM's newline-per-call behaviour splits lines differently); exactly ONE,
+      test_function_shadowing.esk, is a real VALUE divergence, and that program prints
+      "FAIL: Expected 12" on the VM while the gate stays green. The baseline conflates
+      cosmetic drift with a wrong answer and hides the wrong answer among nine harmless rows.
+    caught_by: [parity-baselines, pr-record-414]
+    missed_by: [icc-correctness-chain, icc-smoke]
+    notes: >-
+      The baseline stores program PATHS only — no operation, no per-engine outputs. Nothing in
+      the repo can reconstruct what diverges without a rebuild and a re-run. PR #413 would
+      ratchet 10 -> 8 but #413 is OPEN, so the cut carries 10.
+
+  - id: PR-02
+    bucket: PARITY-RATCHET
+    status: open
+    title: "SURFACE_BASELINE.tsv excuses 323 names native resolves and the VM does not"
+    count: 323
+    evidence: "tests/vm_parity/SURFACE_BASELINE.tsv"
+    caught_by: [parity-baselines]
+    notes: "All carry ledger status NO-ROW, i.e. absent from PARITY.tsv entirely, so the 956-row parity accounting understates the real delta by about a third."
+
+  - id: PR-03
+    bucket: PARITY-RATCHET
+    status: open
+    title: "arity_parity_baseline.json excuses 331 native-vs-VM divergence keys, 62 of them on correct-arity correct-type calls"
+    count: 331
+    correct_class_count: 62
+    evidence: "tests/escape_matrix/arity_parity_baseline.json"
+    caught_by: [parity-baselines]
+
+  - id: PR-04
+    bucket: PARITY-RATCHET
+    status: open
+    title: "five_way_baseline.json excuses doc/manifest/native/VM/provide disagreements including user-facing names"
+    evidence: "tests/escape_matrix/five_way_baseline.json; native_missing entries include force, region-open, hodge-star, geodesic-distance, tensor-reduce-sum"
+    caught_by: [parity-baselines]
+
+  - id: PR-05
+    bucket: PARITY-RATCHET
+    status: open
+    title: "PARITY.tsv carries 331 gap rows; 38 reproducers sit under tests/vm_parity/found/"
+    evidence: "tests/vm_parity/PARITY.tsv; tests/vm_parity/found/"
+    caught_by: [parity-baselines]
+
+  - id: PR-06
+    bucket: PARITY-RATCHET
+    status: open
+    title: "wasm EXCLUSIONS.tsv carries 1 XFAIL and 2 exclusions"
+    evidence: "tests/wasm_diff/EXCLUSIONS.tsv"
+    caught_by: [parity-baselines]
+    notes: "The XFAIL is SW-13, a silent wrong answer in the shipped browser build."
+
+  - id: PR-07
+    bucket: PARITY-RATCHET
+    status: open
+    title: "inexact->exact is an accepted permanent engine divergence: the VM reports a fatal error where native promotes to bignum"
+    evidence: "tests/vm_parity/PARITY.tsv inexact->exact row (added by PR #419, OPEN)"
+    caught_by: [pr-record-419]
+
+  - id: PR-08
+    bucket: PARITY-RATCHET
+    status: open
+    title: "Complex display format differs: native 2+i, VM 2+1i"
+    evidence: "tests/vm_parity/found/complex_display_format.esk (on #419's branch, OPEN)"
+    caught_by: [pr-record-419]
+
+  - id: PR-09
+    bucket: PARITY-RATCHET
+    status: open
+    title: "18 baselined ODR collisions and 57 dead guard tokens ship in the cut"
+    evidence: "icc odr-audit; icc guard-liveness; PR #414 verification table"
+    caught_by: [pr-record-414, icc-odr-audit]
+
+  - id: PR-10
+    bucket: PARITY-RATCHET
+    status: open
+    title: "The engine-parity gate reports PASS while 89.86 percent of the language surface has never been differentially compared"
+    measured: >-
+      scripts/icc_traces/engine_parity_coverage.jsonl at 9f2da2ab reads
+      "113/1114 constructs with differential evidence (10.14%), 10 divergent program(s), 0 new"
+      and its value is PASS. scripts/icc_traces/surface_parity.jsonl reads
+      "2506 probed / 318 divergences / 0 new" and its value is also PASS.
+    evidence: "scripts/icc_traces/engine_parity_coverage.jsonl; scripts/icc_traces/surface_parity.jsonl"
+    caught_by: [direct-measurement]
+    missed_by: [icc-correctness-chain, icc-readiness]
+    notes: >-
+      This is the structural reason the AD and numeric silent-wrong entries escaped. Both
+      probes grade NON-GROWTH ("0 new"), not correctness, so a defect that has been present
+      since before the baseline is permanently invisible and the gate is green anyway.
+      SW-01, SW-02, SW-06 and SW-08 all live in the 1001 constructs (89.86 percent) that
+      have no differential evidence at all. A coverage percentage that low should itself be
+      a criterion: the gate needs a rising floor on constructs-with-evidence, not only a
+      ceiling on new divergences.
+
+  - id: PR-11
+    bucket: PARITY-RATCHET
+    status: open
+    title: "The invariant named for silent wrong answers is an existence check, not a threshold check"
+    measured: >-
+      icc architecture-verify at 9f2da2ab: INV-engine-semantic-parity, kind "exercise",
+      severity critical, incident tag "vm-parity-silent-wrong-answer", grades PASS with the
+      detail "capability 'engine_semantic_parity' exercised within 30d (1 event(s))".
+      The single event it accepted carries the payload "113/1114 constructs with differential
+      evidence (10.14%), 10 divergent program(s), 0 new".
+    evidence: "icc architecture-verify --repo eshkol-v134-release --model .icc/architecture-model.yaml"
+    caught_by: [direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    notes: >-
+      The invariant whose incident name is literally vm-parity-silent-wrong-answer is
+      satisfied by ONE event existing inside a 30-day window, whatever that event says. It
+      would pass identically at 1 percent coverage. An "exercise" invariant proves a probe
+      RAN; it cannot prove the probe found anything, and severity critical on an existence
+      check reads as far stronger assurance than it delivers. Pair every exercise invariant
+      with a threshold on its own payload — this is the same shape as PR-10 and the two
+      should be fixed together.
+
+  # ───────────────────────── DOC-DEBT ─────────────────────────
+
+  - id: DD-01
+    bucket: DOC-DEBT
+    status: open
+    title: "77 doc claims are allowlisted against ICC's doc-typed-claims detector"
+    count: 77
+    evidence: ".icc/doc-claims-allowlist.yaml on branch docs/icc-doc-probe-v134 (PR #416, OPEN)"
+    breakdown: "69 DETECTOR-MISATTRIBUTION, 8 EXEMPT-HISTORICAL; zero describe a runtime defect"
+    caught_by: [pr-record-416]
+    notes: "The allowlist itself is not shipped — #416 is unmerged — so the cut has neither the allowlist nor the doc fixes."
+
+  - id: DD-02
+    bucket: DOC-DEBT
+    status: open
+    title: "91 wrong numeric claims that two prior ICC audit passes flagged were never fixed"
+    count: 91
+    evidence: "PR #416 headline finding; docs/DESIGN.md, docs/ESHKOL_V1_ARCHITECTURE.md, press/ESHKOL_PRESS_INFORMATION_SHEET.md, docs/breakdown/COMPILER_ARCHITECTURE.md"
+    caught_by: [pr-record-416, icc-doc-typed-claims]
+    notes: "Two of the affected files are press copy that ships with the release."
+
+  - id: DD-03
+    bucket: DOC-DEBT
+    status: open
+    title: "KNOWN_ISSUES.md parity counts are stale against the shipped PARITY.tsv"
+    evidence: "docs/KNOWN_ISSUES.md:379 says 951 rows / 578 supported / 329 gap; PARITY.tsv is 956 / 581 / 331"
+    caught_by: [direct-measurement]
+    missed_by: [icc-doc-typed-claims]
+
+  - id: DD-04
+    bucket: DOC-DEBT
+    status: open
+    title: "ESH-0095 is claimed resolved in KNOWN_ISSUES and still carried as an XKNOWN excuse in the AD oracle"
+    evidence: "docs/KNOWN_ISSUES.md:45 vs tests/ad_oracle/README.md XKNOWN table"
+    measured: "(hessian f (tensor 1.0 2.0)) returns #((2 0) (0 2)) correctly at 9f2da2ab — the XKNOWN excuse is stale and should be deleted"
+    caught_by: [direct-measurement]
+    missed_by: [icc-correctness-chain, icc-readiness]
+
+  - id: DD-05
+    bucket: DOC-DEBT
+    status: open
+    title: "PR #417 would re-introduce two now-false known-limitation claims into the docs and four into the public site"
+    evidence: "PR #417 adds 'Quoted pattern-variable queries never match' (fixed by merged #414) and 'Factor-graph free energy is wrong in the browser build only' (#413 shows it is VM-wide, not browser-only), plus four site/src/main.esk strings"
+    caught_by: [pr-record-414, pr-record-416, pr-record-417]
+    notes: "Merge-blocking for #417. Both #414 and #416 flag it in writing; nobody has edited #417's branch."
+
+  - id: DD-06
+    bucket: DOC-DEBT
+    status: open
+    title: "MEMORY_MANAGEMENT.md names a file that does not exist, links to a different one, and carries a line count 3.5x the real total"
+    evidence: "docs/breakdown/MEMORY_MANAGEMENT.md; introduced by merged PR #409, flagged by #416"
+    caught_by: [pr-record-416]
+
+  - id: DD-07
+    bucket: DOC-DEBT
+    status: open
+    title: "The merged doc-example harness has three defects that make it miss the files it was built to check"
+    evidence: "scripts/doc_audit/extract_examples.py EXPECT_RE matches only =>; check_output_blocks.py collect() skips only blank lines between fences; neither runner sets ESHKOL_JIT_CACHE=0. PR #411 is merged."
+    caught_by: [pr-record-416]
+
+  - id: DD-08
+    bucket: DOC-DEBT
+    status: open
+    title: "docs/TEST_COVERAGE.md per-suite counts are the v1.1-era inventory and have drifted"
+    evidence: "PR #417 adds the provenance note; #417 is OPEN"
+    caught_by: [pr-record-417]
+
+  - id: DD-09
+    bucket: DOC-DEBT
+    status: open
+    title: "Runtime limits are documented as controls in three places while being inert"
+    evidence: "See SW-10. The honest status columns exist only on #416's unmerged branch."
+    caught_by: [pr-record-416, direct-measurement]
+
+  - id: DD-10
+    bucket: DOC-DEBT
+    status: open
+    title: "Documented no-ops in shipped surface"
+    items:
+      - "eshkol-run -D NAME[=VALUE] accepted, no macro, no warning (docs/reference/runtime/eshkol-run.md:79)"
+      - "eshkol-run -fPIC accepted as a no-op (docs/reference/runtime/eshkol-run.md:39)"
+      - "provide is advisory; the compiler generates no linkage restriction (docs/breakdown/MODULE_SYSTEM.md:444)"
+      - "manifold gyro-transport ships a first-order approximation with no signal (docs/reference/stdlib/manifold.md:144)"
+    caught_by: [doc-source-crosscheck]
+
+  - id: DD-12
+    bucket: DOC-DEBT
+    status: open
+    title: "13 of the 38 filed vm_parity reproducers are stale and nothing re-verifies them"
+    measured: >-
+      Every file under tests/vm_parity/found/ was re-run on both engines at 9f2da2ab.
+      25 still diverge; 13 now AGREE and print the CORRECT value: exact_division_lost (1/3),
+      expt_bignum_to_float, float_display_1e10 (1e+10), force_returns_promise (3),
+      iota_returns_empty, map_two_lists_eskb_route, modulo_inexact_collapsed_vm,
+      splice_middle_order, tensor_nested_collection_native, tensor_ref_component_oob_native,
+      tensor_set_oob_silent_native, write_does_not_quote, and one further row.
+    evidence: ".scratch/flaw-ledger/found/results.txt"
+    caught_by: [direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, parity-baselines]
+    notes: >-
+      found/ is documented as evidence rather than gate input, so no harness ever re-runs it.
+      A filed reproducer that silently becomes stale is the mirror image of a silent defect:
+      it makes the project look worse than it is and, more dangerously, trains readers to
+      discount the 25 that are still real. Re-running found/ belongs in the parity gate.
+
+  - id: DD-11
+    bucket: DOC-DEBT
+    status: open
+    title: "68 header symbols and 59 shipped .esk exports have no documentation anywhere"
+    evidence: "PR #416 Appendix A; the drafted doc comments were reverted and the patch kept only in an uncommitted .scratch path"
+    caught_by: [pr-record-416]

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -261,16 +261,23 @@ block ordinary use.
   "differentiate a tower" runtime step inside the emitted derivative wrapper.
 - **`i128` has no branch in the generic arithmetic opcodes.** The dedicated
   `i128-add` / `-sub` / `-mul` / `-neg` / shift / comparison / division surface
-  is complete and bit-identical on both engines. Generic `+` / `*` over `i128`
-  values is not wired on **either** side. For `+`, both engines now raise a
-  catchable error rather than silently computing — native reports a type
-  error and the VM reports "i128 arithmetic is not supported on the VM"
-  (previously the VM silently answered `0`; fixed as part of the
-  skipped-flaws ledger's SW-09 entry). `*` is unchanged: native is fatal and
-  the VM still silently answers a wrong value (same missing-opcode-branch
-  class as `+`, not yet converted). Use the `i128-*` operators; `i128`
-  deliberately lives off the numeric tower and never auto-promotes, so this
-  is a missing opcode branch rather than a tower-contagion question.
+  is complete and bit-identical on both engines. Generic arithmetic and
+  comparison over `i128` values is not wired on **either** side — no i128
+  opcodes exist in the bytecode interpreter (that is unchanged, still
+  v1.3.5 scope for the real fix). What changed: every generic arithmetic
+  and comparison opcode on the VM (`+ - * / modulo`, unary `-`, `abs`, and
+  `= < > <= >=`, in both of `vm_run.c`'s interpreter loops — the threaded/
+  computed-goto dispatch and the switch-based fallback) now raises a
+  catchable "i128 arithmetic/comparison is not supported on the VM" error
+  instead of silently coercing an i128 operand to `0.0` and computing a
+  wrong answer (fixed as part of the skipped-flaws ledger's SW-09 entry;
+  originally only `+` was converted, the rest of the family followed in
+  the same PR before merge). Native already raised a type error for the
+  whole family before this change (LE-03) and is unaffected. Use the
+  `i128-*` operators (`i128-add`, `i128-mul`, `i128=?`, …) for i128
+  arithmetic and comparison on either engine; `i128` deliberately lives
+  off the numeric tower and never auto-promotes, so this is a missing
+  opcode branch rather than a tower-contagion question.
 - **The VM lane ignores a path-literal `(load "x.esk")`.** After the
   load-path unification (#407) the native, JIT and AOT paths share one resolver.
   The VM lane still resolves only the CWD `lib/<dotted>` form and silently

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -262,10 +262,15 @@ block ordinary use.
 - **`i128` has no branch in the generic arithmetic opcodes.** The dedicated
   `i128-add` / `-sub` / `-mul` / `-neg` / shift / comparison / division surface
   is complete and bit-identical on both engines. Generic `+` / `*` over `i128`
-  values is not wired on **either** side: native is fatal and the VM answers a
-  wrong value. Use the `i128-*` operators; `i128` deliberately lives off the
-  numeric tower and never auto-promotes, so this is a missing opcode branch
-  rather than a tower-contagion question.
+  values is not wired on **either** side. For `+`, both engines now raise a
+  catchable error rather than silently computing — native reports a type
+  error and the VM reports "i128 arithmetic is not supported on the VM"
+  (previously the VM silently answered `0`; fixed as part of the
+  skipped-flaws ledger's SW-09 entry). `*` is unchanged: native is fatal and
+  the VM still silently answers a wrong value (same missing-opcode-branch
+  class as `+`, not yet converted). Use the `i128-*` operators; `i128`
+  deliberately lives off the numeric tower and never auto-promotes, so this
+  is a missing opcode branch rather than a tower-contagion question.
 - **The VM lane ignores a path-literal `(load "x.esk")`.** After the
   load-path unification (#407) the native, JIT and AOT paths share one resolver.
   The VM lane still resolves only the CWD `lib/<dotted>` form and silently

--- a/docs/breakdown/XLA_BACKEND.md
+++ b/docs/breakdown/XLA_BACKEND.md
@@ -702,9 +702,12 @@ Eshkol's broadcast follows NumPy semantics with right-alignment:
 | `[4, 1]` | `[4, 3]` | `[4, 3]` — second dim expanded |
 | `[]` (scalar) | `[4, 3]` | `[4, 3]` — treated as `[1, 1]` |
 
-**Implementation note**: `eshkol_xla_broadcast` does not validate broadcast compatibility.
-Passing incompatible shapes produces undefined memory reads. Shape compatibility must be
-verified at the codegen level before emission.
+**Implementation note**: `eshkol_xla_broadcast` validates broadcast compatibility at the
+runtime entry point (right-aligned dimension check: compatible iff equal or source is 1,
+and the source rank does not exceed the target rank). An incompatible call returns a null
+tensor pointer rather than performing the out-of-bounds read that used to be silently
+possible. This is a guard at the runtime boundary, not a substitute for checking shapes
+earlier — callers should still verify compatibility at the codegen level before emission.
 
 The `XLATypes::broadcastShape` static method (`inc/eshkol/backend/xla/xla_types.h:161`)
 computes the result shape at compile time and checks compatibility.

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -32195,7 +32195,57 @@ private:
             eshkol_error("Invalid diff operation");
             return nullptr;
         }
-        
+
+        // SW-06 (skipped-flaws ledger, .icc/silent-wrong-ledger.yaml):
+        // `(diff 'expr 'x)` — a QUOTED s-expression, e.g. `(diff '(* x x)
+        // 'x)` — used to reach buildSymbolicDerivative() with a top-level
+        // ESHKOL_QUOTE_OP node. differentiateOperationSymbolic() has no rule
+        // for it, so it fell through `op->op != ESHKOL_CALL_OP` and returned
+        // the AST for the constant 0 — indistinguishable from a correct "this
+        // expression doesn't depend on x" answer. Symbolic differentiation of
+        // already-quoted DATA is not implemented (unlike an unquoted
+        // expression literal, e.g. `(diff (* x x) x)`, which the rules below
+        // DO handle correctly — this check does not touch that path). Raise
+        // a real, guard-catchable Scheme exception instead of fabricating a
+        // derivative, mirroring the non-exhaustive `match` diagnostic below.
+        if (op->diff_op.expression->type == ESHKOL_OP &&
+            op->diff_op.expression->operation.op == ESHKOL_QUOTE_OP) {
+            Function* raise_func = module->getFunction("eshkol_raise");
+            if (!raise_func) {
+                FunctionType* raise_type = FunctionType::get(builder->getVoidTy(),
+                    {builder->getPtrTy()}, false);
+                raise_func = Function::Create(raise_type, Function::ExternalLinkage,
+                    "eshkol_raise", module.get());
+                raise_func->setDoesNotReturn();
+            }
+            Function* make_exc_func = module->getFunction("eshkol_make_exception_with_header");
+            if (!make_exc_func) {
+                FunctionType* make_type = FunctionType::get(builder->getPtrTy(),
+                    {builder->getInt32Ty(), builder->getPtrTy()}, false);
+                make_exc_func = Function::Create(make_type, Function::ExternalLinkage,
+                    "eshkol_make_exception_with_header", module.get());
+            }
+            Value* error_msg = codegenString(
+                "diff: symbolic differentiation of a quoted expression is not yet "
+                "implemented (pass an unquoted expression, e.g. (diff (* x x) x), "
+                "not (diff '(* x x) 'x))");
+            Value* exc_type = ConstantInt::get(builder->getInt32Ty(), ESHKOL_EXCEPTION_ERROR);
+            Value* exception = builder->CreateCall(make_exc_func, {exc_type, error_msg});
+            builder->CreateCall(raise_func, {exception});
+            builder->CreateUnreachable();
+            // codegenAST callers expect to keep emitting into the block this
+            // function leaves the builder positioned in (e.g. `guard`'s
+            // try-block epilogue branches to its merge block right after
+            // this call returns) — CreateUnreachable() above terminates the
+            // current block, so a fresh, unreachable-but-unterminated block
+            // is required here, exactly like the borrow-violation raise
+            // above (codegenSet's "mutation of borrowed value" path).
+            Function* current_func = builder->GetInsertBlock()->getParent();
+            BasicBlock* after_raise_bb = BasicBlock::Create(*context, "diff_quote_unreachable", current_func);
+            builder->SetInsertPoint(after_raise_bb);
+            return packNullToTaggedValue();
+        }
+
         const char* var = op->diff_op.variable;
         eshkol_info("Building symbolic derivative S-expression for %s", var);
         

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -7896,6 +7896,23 @@ static void vm_dispatch_native(VM* vm, int fid) {
     }
     case 393: { /* derivative: (derivative f x) → f'(x) using forward-mode dual numbers */
         Value x_val = vm_pop(vm), f_val = vm_pop(vm);
+        /* SW-06: `diff` compiles to this same native call (see
+         * eshkol_compiler.c's "diff" entry, both aliased to fid 393), so
+         * `(diff '(* x x) 'x)` — a QUOTED s-expression, not a callable —
+         * reaches here as f_val. vm_ad_call_closure() -> vm_call_closure_
+         * from_native() silently returns NIL_VAL for anything that isn't
+         * VAL_CLOSURE, which then falls into "non-dual result = constant
+         * function" below and pushes a fabricated 0 — indistinguishable
+         * from a correct zero derivative. Symbolic differentiation of
+         * already-quoted data is not implemented (v1.3.5 tracker); raise
+         * instead of guessing. */
+        if (f_val.type != VAL_CLOSURE) {
+            vm_raise_error_msg(vm,
+                "derivative: the first argument must be a callable function; "
+                "symbolic differentiation of a quoted expression (e.g. "
+                "(diff '(* x x) 'x)) is not yet implemented on the VM");
+            break;
+        }
         /* ESH-0369: the VM's forward-mode carrier is a FLAT VmDual {value,
          * tangent} — one perturbation, no nesting level. A point that is
          * ALREADY a dual therefore means an enclosing differentiation is live

--- a/lib/backend/vm_run.c
+++ b/lib/backend/vm_run.c
@@ -274,6 +274,16 @@ void vm_run(VM* vm) {
             vm_push(vm, number_val_contagious(a, b, as_number_vm(vm, a) + as_number_vm(vm, b))); } DISPATCH(); }
     lbl_SUB: { int b_sp = vm->sp - 1, a_sp = vm->sp - 2;
         Value b = vm_pop(vm), a = vm_pop(vm);
+        /* SW-09b: same family as lbl_ADD's guard — every arithmetic/
+         * comparison opcode that falls through to as_number_vm() misreads
+         * a heap-boxed VAL_I128 as 0.0. */
+        if (a.type == VAL_I128 || b.type == VAL_I128) {
+            vm_raise_error_msg(vm,
+                "-: i128 arithmetic is not supported on the VM (no i128 opcodes "
+                "are implemented in the bytecode interpreter); use the native "
+                "backend");
+            DISPATCH();
+        }
         if (a.type == VAL_HYPER_DUAL || b.type == VAL_HYPER_DUAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 1906); }
         else if (a.type == VAL_DUAL || b.type == VAL_DUAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 374); }
         else if (a.type == VAL_RATIONAL || b.type == VAL_RATIONAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 332); }
@@ -285,6 +295,14 @@ void vm_run(VM* vm) {
             vm_push(vm, number_val_contagious(a, b, as_number_vm(vm, a) - as_number_vm(vm, b))); } DISPATCH(); }
     lbl_MUL: { int b_sp = vm->sp - 1, a_sp = vm->sp - 2;
         Value b = vm_pop(vm), a = vm_pop(vm);
+        /* SW-09b: see lbl_ADD/lbl_SUB. */
+        if (a.type == VAL_I128 || b.type == VAL_I128) {
+            vm_raise_error_msg(vm,
+                "*: i128 arithmetic is not supported on the VM (no i128 opcodes "
+                "are implemented in the bytecode interpreter); use the native "
+                "backend");
+            DISPATCH();
+        }
         if (a.type == VAL_HYPER_DUAL || b.type == VAL_HYPER_DUAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 1907); }
         else if (a.type == VAL_DUAL || b.type == VAL_DUAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 375); }
         else if (a.type == VAL_RATIONAL || b.type == VAL_RATIONAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 333); }
@@ -296,6 +314,14 @@ void vm_run(VM* vm) {
             vm_push(vm, number_val_contagious(a, b, as_number_vm(vm, a) * as_number_vm(vm, b))); } DISPATCH(); }
     lbl_DIV: { int b_sp = vm->sp - 1, a_sp = vm->sp - 2;
         Value b = vm_pop(vm), a = vm_pop(vm);
+        /* SW-09b: see lbl_ADD/lbl_SUB/lbl_MUL. */
+        if (a.type == VAL_I128 || b.type == VAL_I128) {
+            vm_raise_error_msg(vm,
+                "/: i128 arithmetic is not supported on the VM (no i128 opcodes "
+                "are implemented in the bytecode interpreter); use the native "
+                "backend");
+            DISPATCH();
+        }
         if (a.type == VAL_HYPER_DUAL || b.type == VAL_HYPER_DUAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 1908); }
         else if (a.type == VAL_DUAL || b.type == VAL_DUAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 376); }
         else if (a.type == VAL_RATIONAL || b.type == VAL_RATIONAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 334); }
@@ -324,6 +350,15 @@ void vm_run(VM* vm) {
         vm_push(vm, number_val_contagious(a, b, as_number_vm(vm, a) / bd)); } DISPATCH(); }
     lbl_MOD: {
         Value b = vm_pop(vm), a = vm_pop(vm);
+        /* SW-09b: see lbl_ADD. modulo's double path (fmod) reads a
+         * heap-boxed VAL_I128 as 0.0 exactly like the other arithmetic ops. */
+        if (a.type == VAL_I128 || b.type == VAL_I128) {
+            vm_raise_error_msg(vm,
+                "modulo: i128 arithmetic is not supported on the VM (no i128 "
+                "opcodes are implemented in the bytecode interpreter); use the "
+                "native backend");
+            DISPATCH();
+        }
         if (vm_either_bignum(a, b)) { vm->ad_node_map[vm->sp] = -1; vm_bignum_arith(vm, a, b, 'm'); DISPATCH(); }
         if (a.type == VAL_INT && b.type == VAL_INT) {
             if (b.as.i == 0) { fprintf(stderr, "MODULO BY ZERO\n"); vm->error = 1; goto vm_exit; }
@@ -338,6 +373,15 @@ void vm_run(VM* vm) {
         DISPATCH();
     }
     lbl_NEG: { int a_sp = vm->sp - 1; Value a = vm_pop(vm);
+        /* SW-09b: see lbl_ADD. Unary negate has the same fall-through-to-
+         * double shape as the binary ops. */
+        if (a.type == VAL_I128) {
+            vm_raise_error_msg(vm,
+                "-: i128 arithmetic is not supported on the VM (no i128 opcodes "
+                "are implemented in the bytecode interpreter); use the native "
+                "backend");
+            DISPATCH();
+        }
         if (a.type == VAL_HYPER_DUAL) { vm_push(vm, a); vm_dispatch_native(vm, 1909); }
         else if (a.type == VAL_DUAL) { vm_push(vm, a); vm_dispatch_native(vm, 384); }
         /* A rational must negate in the rational domain: falling through to the
@@ -349,6 +393,14 @@ void vm_run(VM* vm) {
             else vm_push(vm, INT_VAL(-a.as.i)); }
         else { VM_AD_UNARY(vm, a_sp, ad_neg); vm_push(vm, number_val_contagious1(a, -as_number_vm(vm, a))); } DISPATCH(); }
     lbl_ABS: { int a_sp = vm->sp - 1; Value a = vm_pop(vm);
+        /* SW-09b: see lbl_NEG. */
+        if (a.type == VAL_I128) {
+            vm_raise_error_msg(vm,
+                "abs: i128 arithmetic is not supported on the VM (no i128 "
+                "opcodes are implemented in the bytecode interpreter); use the "
+                "native backend");
+            DISPATCH();
+        }
         if (a.type == VAL_HYPER_DUAL) { vm_push(vm, a); vm_dispatch_native(vm, 1916); }
         else if (a.type == VAL_DUAL) { vm_push(vm, a); vm_dispatch_native(vm, 383); }
         /* See lbl_NEG: (abs 1/3) answered 0 through the double path. */
@@ -362,22 +414,66 @@ void vm_run(VM* vm) {
     /* --- Comparison --- */
 
     lbl_EQ: { Value b = vm_pop(vm), a = vm_pop(vm);
+        /* SW-09b: generic comparison over i128 has the identical bug shape
+         * as generic arithmetic — as_number_vm() reads a heap-boxed
+         * VAL_I128 as 0.0, so e.g. (= (i128 5) (i128 5)) silently answered
+         * #t via 0.0==0.0 regardless of the real values. The dedicated
+         * `i128-*?` comparison surface (KNOWN_ISSUES.md) is unaffected. */
+        if (a.type == VAL_I128 || b.type == VAL_I128) {
+            vm_raise_error_msg(vm,
+                "=: i128 comparison is not supported on the VM (no i128 opcodes "
+                "are implemented in the bytecode interpreter); use i128=? or "
+                "the native backend");
+            DISPATCH();
+        }
         if (vm_either_bignum(a, b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm, a, b) == 0)); DISPATCH(); }
         if (a.type == VAL_INT && b.type == VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i == b.as.i)); DISPATCH(); }
         vm_push(vm, BOOL_VAL(as_number_vm(vm, a) == as_number_vm(vm, b))); DISPATCH(); }
     lbl_LT: { Value b = vm_pop(vm), a = vm_pop(vm);
+        /* SW-09b: see lbl_EQ. */
+        if (a.type == VAL_I128 || b.type == VAL_I128) {
+            vm_raise_error_msg(vm,
+                "<: i128 comparison is not supported on the VM (no i128 opcodes "
+                "are implemented in the bytecode interpreter); use i128<? or "
+                "the native backend");
+            DISPATCH();
+        }
         if (vm_either_bignum(a, b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm, a, b) <  0)); DISPATCH(); }
         if (a.type == VAL_INT && b.type == VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i <  b.as.i)); DISPATCH(); }
         vm_push(vm, BOOL_VAL(as_number_vm(vm, a) <  as_number_vm(vm, b))); DISPATCH(); }
     lbl_GT: { Value b = vm_pop(vm), a = vm_pop(vm);
+        /* SW-09b: see lbl_EQ. */
+        if (a.type == VAL_I128 || b.type == VAL_I128) {
+            vm_raise_error_msg(vm,
+                ">: i128 comparison is not supported on the VM (no i128 opcodes "
+                "are implemented in the bytecode interpreter); use i128>? or "
+                "the native backend");
+            DISPATCH();
+        }
         if (vm_either_bignum(a, b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm, a, b) >  0)); DISPATCH(); }
         if (a.type == VAL_INT && b.type == VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i >  b.as.i)); DISPATCH(); }
         vm_push(vm, BOOL_VAL(as_number_vm(vm, a) >  as_number_vm(vm, b))); DISPATCH(); }
     lbl_LE: { Value b = vm_pop(vm), a = vm_pop(vm);
+        /* SW-09b: see lbl_EQ. */
+        if (a.type == VAL_I128 || b.type == VAL_I128) {
+            vm_raise_error_msg(vm,
+                "<=: i128 comparison is not supported on the VM (no i128 opcodes "
+                "are implemented in the bytecode interpreter); use i128<=? or "
+                "the native backend");
+            DISPATCH();
+        }
         if (vm_either_bignum(a, b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm, a, b) <= 0)); DISPATCH(); }
         if (a.type == VAL_INT && b.type == VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i <= b.as.i)); DISPATCH(); }
         vm_push(vm, BOOL_VAL(as_number_vm(vm, a) <= as_number_vm(vm, b))); DISPATCH(); }
     lbl_GE: { Value b = vm_pop(vm), a = vm_pop(vm);
+        /* SW-09b: see lbl_EQ. */
+        if (a.type == VAL_I128 || b.type == VAL_I128) {
+            vm_raise_error_msg(vm,
+                ">=: i128 comparison is not supported on the VM (no i128 opcodes "
+                "are implemented in the bytecode interpreter); use i128>=? or "
+                "the native backend");
+            DISPATCH();
+        }
         if (vm_either_bignum(a, b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm, a, b) >= 0)); DISPATCH(); }
         if (a.type == VAL_INT && b.type == VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i >= b.as.i)); DISPATCH(); }
         vm_push(vm, BOOL_VAL(as_number_vm(vm, a) >= as_number_vm(vm, b))); DISPATCH(); }
@@ -998,6 +1094,14 @@ vm_exit:
             else if (a.type==VAL_INT && b.type==VAL_INT) { int64_t r; if (__builtin_add_overflow(a.as.i,b.as.i,&r)) vm_bignum_arith(vm,a,b,'+'); else vm_push(vm, INT_VAL(r)); }
             else vm_push(vm, number_val_contagious(a, b, as_number_vm(vm,a) + as_number_vm(vm,b))); break; }
         case OP_SUB: { Value b = vm_pop(vm), a = vm_pop(vm);
+            /* SW-09b: switch-based twin of lbl_SUB. */
+            if (a.type == VAL_I128 || b.type == VAL_I128) {
+                vm_raise_error_msg(vm,
+                    "-: i128 arithmetic is not supported on the VM (no i128 opcodes "
+                    "are implemented in the bytecode interpreter); use the native "
+                    "backend");
+                break;
+            }
             if (a.type==VAL_HYPER_DUAL||b.type==VAL_HYPER_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,1906); }
             else if (a.type==VAL_DUAL||b.type==VAL_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,374); }
             else if (a.type==VAL_RATIONAL||b.type==VAL_RATIONAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,332); }
@@ -1006,6 +1110,14 @@ vm_exit:
             else if (a.type==VAL_INT && b.type==VAL_INT) { int64_t r; if (__builtin_sub_overflow(a.as.i,b.as.i,&r)) vm_bignum_arith(vm,a,b,'-'); else vm_push(vm, INT_VAL(r)); }
             else vm_push(vm, number_val_contagious(a, b, as_number_vm(vm,a) - as_number_vm(vm,b))); break; }
         case OP_MUL: { Value b = vm_pop(vm), a = vm_pop(vm);
+            /* SW-09b: switch-based twin of lbl_MUL. */
+            if (a.type == VAL_I128 || b.type == VAL_I128) {
+                vm_raise_error_msg(vm,
+                    "*: i128 arithmetic is not supported on the VM (no i128 opcodes "
+                    "are implemented in the bytecode interpreter); use the native "
+                    "backend");
+                break;
+            }
             if (a.type==VAL_HYPER_DUAL||b.type==VAL_HYPER_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,1907); }
             else if (a.type==VAL_DUAL||b.type==VAL_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,375); }
             else if (a.type==VAL_RATIONAL||b.type==VAL_RATIONAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,333); }
@@ -1014,6 +1126,14 @@ vm_exit:
             else if (a.type==VAL_INT && b.type==VAL_INT) { int64_t r; if (__builtin_mul_overflow(a.as.i,b.as.i,&r)) vm_bignum_arith(vm,a,b,'*'); else vm_push(vm, INT_VAL(r)); }
             else vm_push(vm, number_val_contagious(a, b, as_number_vm(vm,a) * as_number_vm(vm,b))); break; }
         case OP_DIV: { Value b = vm_pop(vm), a = vm_pop(vm);
+            /* SW-09b: switch-based twin of lbl_DIV. */
+            if (a.type == VAL_I128 || b.type == VAL_I128) {
+                vm_raise_error_msg(vm,
+                    "/: i128 arithmetic is not supported on the VM (no i128 opcodes "
+                    "are implemented in the bytecode interpreter); use the native "
+                    "backend");
+                break;
+            }
             if (a.type==VAL_HYPER_DUAL||b.type==VAL_HYPER_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,1908); }
             else if (a.type==VAL_DUAL||b.type==VAL_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,376); }
             else if (a.type==VAL_RATIONAL||b.type==VAL_RATIONAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,334); }
@@ -1035,6 +1155,14 @@ vm_exit:
             vm_push(vm, number_val_contagious(a, b, as_number_vm(vm,a) / bd)); } break; }
         case OP_MOD: {
             Value b = vm_pop(vm), a = vm_pop(vm);
+            /* SW-09b: switch-based twin of lbl_MOD. */
+            if (a.type == VAL_I128 || b.type == VAL_I128) {
+                vm_raise_error_msg(vm,
+                    "modulo: i128 arithmetic is not supported on the VM (no i128 "
+                    "opcodes are implemented in the bytecode interpreter); use the "
+                    "native backend");
+                break;
+            }
             if (vm_either_bignum(a, b)) { vm_bignum_arith(vm, a, b, 'm'); break; }
             if (a.type == VAL_INT && b.type == VAL_INT) {
                 if (b.as.i == 0) { fprintf(stderr, "MODULO BY ZERO\n"); vm->error = 1; break; }
@@ -1049,6 +1177,14 @@ vm_exit:
             break;
         }
         case OP_NEG: { Value a = vm_pop(vm);
+            /* SW-09b: switch-based twin of lbl_NEG. */
+            if (a.type == VAL_I128) {
+                vm_raise_error_msg(vm,
+                    "-: i128 arithmetic is not supported on the VM (no i128 opcodes "
+                    "are implemented in the bytecode interpreter); use the native "
+                    "backend");
+                break;
+            }
             /* See the threaded lbl_NEG: a rational needs the rational domain;
              * the double path below reads its heap pointer as 0.0. */
             if (a.type == VAL_RATIONAL) { vm_push(vm, a); vm_dispatch_native(vm, 335); break; }
@@ -1057,6 +1193,14 @@ vm_exit:
             if (a.type == VAL_INT) { vm_push_bignum_norm(vm, bignum_neg(&vm->heap.regions, bignum_from_int64(&vm->heap.regions, a.as.i))); break; }
             vm_push(vm, number_val_contagious1(a, -as_number_vm(vm, a))); break; }
         case OP_ABS: { Value a = vm_pop(vm);
+            /* SW-09b: switch-based twin of lbl_ABS. */
+            if (a.type == VAL_I128) {
+                vm_raise_error_msg(vm,
+                    "abs: i128 arithmetic is not supported on the VM (no i128 "
+                    "opcodes are implemented in the bytecode interpreter); use the "
+                    "native backend");
+                break;
+            }
             if (a.type == VAL_RATIONAL) { vm_push(vm, a); vm_dispatch_native(vm, 336); break; }
             if (a.type == VAL_BIGNUM) { vm_push_bignum_norm(vm, bignum_abs_val(&vm->heap.regions, (VmBignum*)vm->heap.objects[a.as.ptr]->opaque.ptr)); break; }
             if (a.type == VAL_INT && a.as.i != INT64_MIN) { vm_push(vm, INT_VAL(a.as.i < 0 ? -a.as.i : a.as.i)); break; }
@@ -1065,22 +1209,62 @@ vm_exit:
 
         /* Comparison — push proper booleans */
         case OP_EQ: { Value b = vm_pop(vm), a = vm_pop(vm);
+            /* SW-09b: switch-based twin of lbl_EQ. */
+            if (a.type == VAL_I128 || b.type == VAL_I128) {
+                vm_raise_error_msg(vm,
+                    "=: i128 comparison is not supported on the VM (no i128 opcodes "
+                    "are implemented in the bytecode interpreter); use i128=? or "
+                    "the native backend");
+                break;
+            }
             if (vm_either_bignum(a,b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm,a,b) == 0)); break; }
             if (a.type==VAL_INT && b.type==VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i == b.as.i)); break; }
             vm_push(vm, BOOL_VAL(as_number_vm(vm,a) == as_number_vm(vm,b))); break; }
         case OP_LT: { Value b = vm_pop(vm), a = vm_pop(vm);
+            /* SW-09b: switch-based twin of lbl_LT. */
+            if (a.type == VAL_I128 || b.type == VAL_I128) {
+                vm_raise_error_msg(vm,
+                    "<: i128 comparison is not supported on the VM (no i128 opcodes "
+                    "are implemented in the bytecode interpreter); use i128<? or "
+                    "the native backend");
+                break;
+            }
             if (vm_either_bignum(a,b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm,a,b) <  0)); break; }
             if (a.type==VAL_INT && b.type==VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i <  b.as.i)); break; }
             vm_push(vm, BOOL_VAL(as_number_vm(vm,a) <  as_number_vm(vm,b))); break; }
         case OP_GT: { Value b = vm_pop(vm), a = vm_pop(vm);
+            /* SW-09b: switch-based twin of lbl_GT. */
+            if (a.type == VAL_I128 || b.type == VAL_I128) {
+                vm_raise_error_msg(vm,
+                    ">: i128 comparison is not supported on the VM (no i128 opcodes "
+                    "are implemented in the bytecode interpreter); use i128>? or "
+                    "the native backend");
+                break;
+            }
             if (vm_either_bignum(a,b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm,a,b) >  0)); break; }
             if (a.type==VAL_INT && b.type==VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i >  b.as.i)); break; }
             vm_push(vm, BOOL_VAL(as_number_vm(vm,a) >  as_number_vm(vm,b))); break; }
         case OP_LE: { Value b = vm_pop(vm), a = vm_pop(vm);
+            /* SW-09b: switch-based twin of lbl_LE. */
+            if (a.type == VAL_I128 || b.type == VAL_I128) {
+                vm_raise_error_msg(vm,
+                    "<=: i128 comparison is not supported on the VM (no i128 opcodes "
+                    "are implemented in the bytecode interpreter); use i128<=? or "
+                    "the native backend");
+                break;
+            }
             if (vm_either_bignum(a,b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm,a,b) <= 0)); break; }
             if (a.type==VAL_INT && b.type==VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i <= b.as.i)); break; }
             vm_push(vm, BOOL_VAL(as_number_vm(vm,a) <= as_number_vm(vm,b))); break; }
         case OP_GE: { Value b = vm_pop(vm), a = vm_pop(vm);
+            /* SW-09b: switch-based twin of lbl_GE. */
+            if (a.type == VAL_I128 || b.type == VAL_I128) {
+                vm_raise_error_msg(vm,
+                    ">=: i128 comparison is not supported on the VM (no i128 opcodes "
+                    "are implemented in the bytecode interpreter); use i128>=? or "
+                    "the native backend");
+                break;
+            }
             if (vm_either_bignum(a,b)) { vm_push(vm, BOOL_VAL(vm_bignum_compare_vals(vm,a,b) >= 0)); break; }
             if (a.type==VAL_INT && b.type==VAL_INT) { vm_push(vm, BOOL_VAL(a.as.i >= b.as.i)); break; }
             vm_push(vm, BOOL_VAL(as_number_vm(vm,a) >= as_number_vm(vm,b))); break; }

--- a/lib/backend/vm_run.c
+++ b/lib/backend/vm_run.c
@@ -249,6 +249,20 @@ void vm_run(VM* vm) {
 
     lbl_ADD: { int b_sp = vm->sp - 1, a_sp = vm->sp - 2;
         Value b = vm_pop(vm), a = vm_pop(vm);
+        /* SW-09: neither operand check below recognizes VAL_I128, so a
+         * generic `+` over i128 values used to fall all the way through to
+         * the double path, where as_number_vm() reads a heap-boxed i128 as
+         * 0.0 — silently answering 0 with exit 0. The VM has no i128
+         * opcodes (that is v1.3.5 scope); raise instead of fabricating a
+         * result. The native engine already raises for the same case
+         * (LE-03, "Type error in +: expected number, vector, or tensor"). */
+        if (a.type == VAL_I128 || b.type == VAL_I128) {
+            vm_raise_error_msg(vm,
+                "+: i128 arithmetic is not supported on the VM (no i128 opcodes "
+                "are implemented in the bytecode interpreter); use the native "
+                "backend");
+            DISPATCH();
+        }
         if (a.type == VAL_HYPER_DUAL || b.type == VAL_HYPER_DUAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 1905); }
         else if (a.type == VAL_DUAL || b.type == VAL_DUAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 373); }
         else if (a.type == VAL_RATIONAL || b.type == VAL_RATIONAL) { vm_push(vm, a); vm_push(vm, b); vm_dispatch_native(vm, 331); }
@@ -965,6 +979,17 @@ vm_exit:
 
         /* Arithmetic */
         case OP_ADD: { Value b = vm_pop(vm), a = vm_pop(vm);
+            /* SW-09: see the identical guard in lbl_ADD above — this switch-
+             * based loop is the non-computed-goto twin of the same opcode
+             * and must reject i128 operands the same way, not silently
+             * coerce them to 0.0 via as_number_vm(). */
+            if (a.type == VAL_I128 || b.type == VAL_I128) {
+                vm_raise_error_msg(vm,
+                    "+: i128 arithmetic is not supported on the VM (no i128 opcodes "
+                    "are implemented in the bytecode interpreter); use the native "
+                    "backend");
+                break;
+            }
             if (a.type==VAL_HYPER_DUAL||b.type==VAL_HYPER_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,1905); }
             else if (a.type==VAL_DUAL||b.type==VAL_DUAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,373); }
             else if (a.type==VAL_RATIONAL||b.type==VAL_RATIONAL) { vm_push(vm,a); vm_push(vm,b); vm_dispatch_native(vm,331); }

--- a/lib/backend/vm_tests.c
+++ b/lib/backend/vm_tests.c
@@ -888,6 +888,18 @@ static int run_source_tests(void) {
     source_test_expect("region-handle-fabricated-token-not-live",
         "(display (region-open? 987654321))", "#f");
 
+    /* SW-06 / SW-09 (skipped-flaws ledger, .icc/silent-wrong-ledger.yaml):
+     * both used to silently answer 0 with exit 0 instead of raising. Pin the
+     * loud-error behavior here so the VM source-test suite regresses if
+     * either guard is ever removed. */
+    source_test_expect("diff-quoted-expr-raises",
+        "(display (guard (e (#t 'caught)) (diff '(* x x) 'x) 'no))", "caught");
+    source_test_expect("derivative-non-callable-raises",
+        "(display (guard (e (#t 'caught)) (derivative 5 1.0) 'no))", "caught");
+    source_test_expect("i128-add-raises",
+        "(define a (i128 5)) (define b (i128 7))"
+        "(display (guard (e (#t 'caught)) (+ a b) 'no))", "caught");
+
     printf("\n  Source tests: %d/%d passed\n", source_test_pass, source_test_count);
     return source_test_count - source_test_pass;
 }

--- a/lib/backend/vm_tests.c
+++ b/lib/backend/vm_tests.c
@@ -900,6 +900,45 @@ static int run_source_tests(void) {
         "(define a (i128 5)) (define b (i128 7))"
         "(display (guard (e (#t 'caught)) (+ a b) 'no))", "caught");
 
+    /* SW-09b: the i128-misread bug shape is not unique to `+` — every
+     * arithmetic/comparison opcode that falls through to as_number_vm()
+     * (both the threaded lbl_* and switch-based OP_* dispatch loops in
+     * lib/backend/vm_run.c) has the identical defect. Pin the whole family:
+     * -, *, /, modulo, unary -, abs, =, <, >, <=, >=. */
+    source_test_expect("i128-sub-raises",
+        "(define a (i128 5)) (define b (i128 7))"
+        "(display (guard (e (#t 'caught)) (- a b) 'no))", "caught");
+    source_test_expect("i128-mul-raises",
+        "(define a (i128 5)) (define b (i128 7))"
+        "(display (guard (e (#t 'caught)) (* a b) 'no))", "caught");
+    source_test_expect("i128-div-raises",
+        "(define a (i128 5)) (define b (i128 7))"
+        "(display (guard (e (#t 'caught)) (/ a b) 'no))", "caught");
+    source_test_expect("i128-modulo-raises",
+        "(define a (i128 5)) (define b (i128 7))"
+        "(display (guard (e (#t 'caught)) (modulo a b) 'no))", "caught");
+    source_test_expect("i128-neg-raises",
+        "(define a (i128 5))"
+        "(display (guard (e (#t 'caught)) (- a) 'no))", "caught");
+    source_test_expect("i128-abs-raises",
+        "(define a (i128 5))"
+        "(display (guard (e (#t 'caught)) (abs a) 'no))", "caught");
+    source_test_expect("i128-eq-raises",
+        "(define a (i128 5)) (define b (i128 7))"
+        "(display (guard (e (#t 'caught)) (= a b) 'no))", "caught");
+    source_test_expect("i128-lt-raises",
+        "(define a (i128 5)) (define b (i128 7))"
+        "(display (guard (e (#t 'caught)) (< a b) 'no))", "caught");
+    source_test_expect("i128-gt-raises",
+        "(define a (i128 5)) (define b (i128 7))"
+        "(display (guard (e (#t 'caught)) (> a b) 'no))", "caught");
+    source_test_expect("i128-le-raises",
+        "(define a (i128 5)) (define b (i128 7))"
+        "(display (guard (e (#t 'caught)) (<= a b) 'no))", "caught");
+    source_test_expect("i128-ge-raises",
+        "(define a (i128 5)) (define b (i128 7))"
+        "(display (guard (e (#t 'caught)) (>= a b) 'no))", "caught");
+
     printf("\n  Source tests: %d/%d passed\n", source_test_pass, source_test_count);
     return source_test_count - source_test_pass;
 }

--- a/lib/backend/xla/xla_runtime.cpp
+++ b/lib/backend/xla/xla_runtime.cpp
@@ -895,6 +895,30 @@ extern "C" void* eshkol_xla_broadcast(
 
     if (!data || tgt_rank <= 0) return nullptr;
     if (tgt_rank > 16 || src_rank > 16) return nullptr;  // P1: tgt_strides[16]/src_strides[16] stack arrays
+    if (src_rank < 0) return nullptr;
+    if (src_rank > tgt_rank) return nullptr;  // SW-22: broadcasting never reduces rank
+
+    // SW-22: validate NumPy-style broadcast compatibility per right-aligned
+    // dimension pair before computing any strides. A source dimension may
+    // broadcast only if it equals the corresponding target dimension or
+    // equals 1 (docs/breakdown/XLA_BACKEND.md "Broadcast Semantics"; mirrors
+    // XLATypes::broadcastShape() in lib/backend/xla/xla_types.cpp, which
+    // already applies this rule at compile time — this is the runtime's own
+    // guard for callers that reach this entry point directly). Previously
+    // nothing checked this here: an incompatible source dimension > 1 fed
+    // straight into the stride multiplication below, and whenever that
+    // dimension was NARROWER than the target it produced an out-of-bounds
+    // read of `data` — a memory-safety defect, not merely a wrong answer.
+    {
+        const int64_t rank_offset = tgt_rank - src_rank;
+        for (int64_t d = 0; d < tgt_rank; d++) {
+            const int64_t src_d = d - rank_offset;
+            if (src_d < 0) continue;  // implicit leading 1 — always compatible
+            const uint64_t src_dim = src_shape[src_d];
+            const uint64_t tgt_dim = tgt_shape[d];
+            if (src_dim != tgt_dim && src_dim != 1) return nullptr;
+        }
+    }
 
     uint64_t total = 1;
     for (int64_t i = 0; i < tgt_rank; i++) total *= tgt_shape[i];

--- a/tests/differential/corpus/42_diff_quoted_raises.esk
+++ b/tests/differential/corpus/42_diff_quoted_raises.esk
@@ -1,0 +1,18 @@
+;; SW-06 (skipped-flaws ledger, .icc/silent-wrong-ledger.yaml): `(diff 'expr
+;; 'x)` on a QUOTED s-expression used to silently answer 0 on every axis —
+;; "shared-defect blindness" in the ledger's own words, since both engines
+;; agreeing on the same wrong value means no native-vs-VM differential axis
+;; could ever see it. A guard-wrapped assertion closes that blind spot: if a
+;; future change makes any native axis stop raising (or start raising a
+;; DIFFERENT way that a guard can't catch), this file diverges from the
+;; other axes and the corpus runner goes red.
+;;
+;; Also pins that the fix did not regress the real, working feature: diff
+;; over an UNQUOTED expression (the documented/supported form) must still
+;; run to completion without raising.
+
+(display (guard (e (#t "caught")) (diff '(* x x) 'x) "no"))
+(newline)
+
+(display (guard (e (#t "raised")) (diff (* x x) x) "ok"))
+(newline)

--- a/tests/xla/xla_codegen_test.cpp
+++ b/tests/xla/xla_codegen_test.cpp
@@ -49,6 +49,21 @@ extern "C" void* eshkol_xla_matmul(
     int64_t a_rank,
     int64_t b_rank);
 
+// SW-06/SW-09/SW-22 (skipped-flaws ledger): eshkol_xla_broadcast performed no
+// broadcast-compatibility validation, so an incompatible source dimension
+// (not 1 and not equal to the target) fed straight into the stride
+// multiplication and produced an out-of-bounds read of `data` whenever that
+// dimension was narrower than the target — a memory-safety defect, not
+// merely a wrong numeric answer (docs/breakdown/XLA_BACKEND.md "Broadcast
+// Semantics"). This is the guarded entry point under test.
+extern "C" void* eshkol_xla_broadcast(
+    void* arena,
+    const double* data,
+    const uint64_t* src_shape,
+    int64_t src_rank,
+    const uint64_t* tgt_shape,
+    int64_t tgt_rank);
+
 // Arena allocator — use the real Eshkol arena
 typedef struct arena arena_t;
 extern "C" arena_t* arena_create(size_t default_block_size);
@@ -298,6 +313,94 @@ bool test_xla_matmul_large() {
     return true;
 }
 
+// ===== Test: XLA Broadcast — compatible shapes (NumPy rules) =====
+bool test_xla_broadcast_compatible() {
+    std::cout << "Test: XLA Broadcast Compatible Shapes... ";
+
+    // [3] -> [2, 3]: prepend an implicit leading 1, then expand it to 2.
+    {
+        double src_data[] = {1.0, 2.0, 3.0};
+        uint64_t src_shape[] = {3};
+        uint64_t tgt_shape[] = {2, 3};
+
+        void* result = eshkol_xla_broadcast(g_test_arena, src_data, src_shape, 1, tgt_shape, 2);
+        TEST_ASSERT(result != nullptr, "Broadcast [3]->[2,3] should succeed");
+
+        auto* tensor = static_cast<EshkolTensor*>(result);
+        TEST_ASSERT(tensor->num_dimensions == 2, "Result should have 2 dimensions");
+        TEST_ASSERT(tensor->dimensions[0] == 2 && tensor->dimensions[1] == 3,
+            "Result shape should be [2,3]");
+        double expected[] = {1.0, 2.0, 3.0, 1.0, 2.0, 3.0};
+        for (int i = 0; i < 6; i++) {
+            TEST_ASSERT_NEAR(read_element(tensor, i), expected[i], 1e-10,
+                "Broadcast [3]->[2,3] value mismatch at index " + std::to_string(i));
+        }
+    }
+
+    // [4, 1] -> [4, 3]: the trailing size-1 dimension expands.
+    {
+        double src_data[] = {10.0, 20.0, 30.0, 40.0};
+        uint64_t src_shape[] = {4, 1};
+        uint64_t tgt_shape[] = {4, 3};
+
+        void* result = eshkol_xla_broadcast(g_test_arena, src_data, src_shape, 2, tgt_shape, 2);
+        TEST_ASSERT(result != nullptr, "Broadcast [4,1]->[4,3] should succeed");
+
+        auto* tensor = static_cast<EshkolTensor*>(result);
+        double expected[] = {10.0, 10.0, 10.0, 20.0, 20.0, 20.0,
+                              30.0, 30.0, 30.0, 40.0, 40.0, 40.0};
+        for (int i = 0; i < 12; i++) {
+            TEST_ASSERT_NEAR(read_element(tensor, i), expected[i], 1e-10,
+                "Broadcast [4,1]->[4,3] value mismatch at index " + std::to_string(i));
+        }
+    }
+
+    std::cout << "PASS" << std::endl;
+    return true;
+}
+
+// ===== Test: XLA Broadcast — incompatible shapes must be rejected =====
+bool test_xla_broadcast_incompatible() {
+    std::cout << "Test: XLA Broadcast Incompatible Shapes... ";
+
+    // [2] -> [4, 3]: trailing dim 2 vs target 3 — neither equal nor 1.
+    // Before the SW-22 guard this read past the end of `src_data` (2
+    // elements) for 2 of every 3 output positions instead of failing.
+    {
+        double src_data[] = {1.0, 2.0};
+        uint64_t src_shape[] = {2};
+        uint64_t tgt_shape[] = {4, 3};
+
+        void* result = eshkol_xla_broadcast(g_test_arena, src_data, src_shape, 1, tgt_shape, 2);
+        TEST_ASSERT(result == nullptr, "Broadcast [2]->[4,3] must be rejected (trailing dim mismatch)");
+    }
+
+    // [3, 3] -> [3]: source has MORE dimensions than the target — broadcast
+    // never reduces rank.
+    {
+        double src_data[9] = {0};
+        uint64_t src_shape[] = {3, 3};
+        uint64_t tgt_shape[] = {3};
+
+        void* result = eshkol_xla_broadcast(g_test_arena, src_data, src_shape, 2, tgt_shape, 1);
+        TEST_ASSERT(result == nullptr, "Broadcast [3,3]->[3] must be rejected (source rank > target rank)");
+    }
+
+    // [5, 2] -> [5, 4]: leading dim matches, trailing dim 2 vs 4 — neither
+    // equal nor 1.
+    {
+        double src_data[10] = {0};
+        uint64_t src_shape[] = {5, 2};
+        uint64_t tgt_shape[] = {5, 4};
+
+        void* result = eshkol_xla_broadcast(g_test_arena, src_data, src_shape, 2, tgt_shape, 2);
+        TEST_ASSERT(result == nullptr, "Broadcast [5,2]->[5,4] must be rejected (trailing dim mismatch)");
+    }
+
+    std::cout << "PASS" << std::endl;
+    return true;
+}
+
 // ===== Test: XLA Threshold Function =====
 bool test_xla_threshold() {
     std::cout << "Test: XLA Threshold... ";
@@ -352,6 +455,10 @@ int main() {
     run_test(test_xla_matmul_dim_mismatch);
     run_test(test_xla_matmul_invalid_rank);
     run_test(test_xla_matmul_large);
+
+    // Broadcast tests (SW-22)
+    run_test(test_xla_broadcast_compatible);
+    run_test(test_xla_broadcast_incompatible);
 
     // Threshold tests
     run_test(test_xla_threshold);


### PR DESCRIPTION
## Summary

Maintainer-ordered pre-tag scope: full feature work for these three
defects is deferred to v1.3.5, but shipping a silently wrong answer is
forbidden while shipping a clear error is acceptable. This PR converts
three entries from the skipped-flaws ledger (`.icc/silent-wrong-ledger.yaml`)
to an honest failure mode without implementing the underlying deferred
features.

- **SW-06** — `(diff 'expr 'x)` on a quoted s-expression silently returned
  a fabricated derivative of `0` on both engines. Real symbolic
  differentiation of quoted data is not implemented (v1.3.5 scope); both
  engines now raise a guard-catchable exception instead.
  - Native: `codegenDiff()` in `lib/backend/llvm_codegen.cpp` raises via
    `eshkol_raise()` / `eshkol_make_exception_with_header()` when the
    diff expression is a top-level quote, mirroring the existing
    non-exhaustive-`match` diagnostic pattern.
  - VM: native call 393 (shared by `derivative` and `diff`) in
    `lib/backend/vm_native.c` raises via `vm_raise_error_msg()` when the
    first argument isn't a callable closure.
  - The unquoted, documented form (`(diff (* x x) x)`) is untouched and
    still returns the correct symbolic derivative.

- **SW-09** — generic `+` over `i128` values silently answered `0` on the
  VM (native already raised a type error — LE-03). No i128 opcodes are
  implemented (unchanged, v1.3.5 scope); the VM's two independent
  `OP_ADD` implementations (switch-based and threaded/computed-goto, both
  in `lib/backend/vm_run.c`) now raise instead of silently coercing an
  i128 operand to `0.0` via `as_number_vm()`. Generic `*` over i128 has
  the same shape of bug and remains open — only the literal SW-09 repro
  (`+`) is converted here; noted in `docs/KNOWN_ISSUES.md`.

- **SW-22** — `eshkol_xla_broadcast()` performed no broadcast-compatibility
  validation, so an incompatible source dimension narrower than the
  target read past the end of the source buffer — a memory-safety
  defect, not merely a wrong answer. Adds a NumPy-style compatibility
  guard (mirroring `XLATypes::broadcastShape()`) that rejects
  incompatible shapes before any stride computation. Marked `guarded`
  rather than `closed` in the ledger: the XLA broadcast bridge has no
  live caller yet (`ESHKOL_XLA_ENABLED` defaults OFF, `emitBroadcast()`
  is unwired into codegen), so this closes the memory-safety defect
  without yet having an end-to-end user-facing diagnostic.

## Test plan

- [x] `ctest --test-dir build`: **142/142 passed**
- [x] `scripts/run_vm_parity.sh`: **144 passed, 0 failed**
- [x] `scripts/run_error_handling_tests.sh`: **7/7 passed**
- [x] Differential corpus (`scripts/run_differential.sh tests/differential/corpus/`):
      **246/252 axis pairs agree across 42 programs**; sole divergence is
      the pre-existing `37_sort.esk` (LE-01), unrelated and unchanged —
      confirmed identical on unmodified master (240/246 across 41 programs).
- [x] New differential entry `tests/differential/corpus/42_diff_quoted_raises.esk`
      agrees on all 4 native axes (jit / jit-nocache / aot-o0 / aot-o2).
- [x] VM standalone self-test (`eshkol-vm-standalone-test`) additions —
      `diff-quoted-expr-raises`, `derivative-non-callable-raises`,
      `i128-add-raises` — **62/62 source tests passing**.
- [x] XLA codegen test (`-DESHKOL_XLA_ENABLED=ON`) additions —
      `test_xla_broadcast_compatible`, `test_xla_broadcast_incompatible` —
      **11/11 passing**.
- [x] All three fixes **revert-validated**: temporarily undoing each guard
      reproduces the original silent-wrong/OOB behavior against both this
      branch and an unmodified baseline build, confirming the new tests
      are load-bearing.
- [x] ICC `architecture-verify`: **8/9 PASS** (`INV-engine-semantic-parity`
      now passes after regenerating evidence via
      `run_engine_parity_coverage.py`, 195 programs / 1114 constructs, 10
      pre-existing divergences matching the `PARITY-RATCHET` baseline, 0
      regressed). The one remaining FAIL, `INV-language-surface-exercise`,
      needs a `build-quantum` runner this environment doesn't have — a
      documented pre-existing gap, unrelated to this change.
- [x] ICC `guard-diff` / `gate-semantics-audit` / `pre-commit-check`: all
      **PASS**, 0 findings, scoped to `lib`/`inc`/`exe`.

Not run to completion: the full `scripts/run_icc_smoke.sh` (58-probe
release harness) was started but did not finish within the session —
it reached probe 44/58 and then stalled on `surface_parity_execution_backed`,
matching previously documented behavior for that probe on this machine
under concurrent load. This is a release-level gate, not scoped to this
3-file PR; the targeted path-scoped ICC chain above covers the change.