### PR TITLE
fix(parity): fg-marginal native marginal + rationalize VM dispatch (SW-07, SW-08)

### DIFF
--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -7779,7 +7779,16 @@ static void vm_dispatch_native(VM* vm, int fid) {
         case 348: { Value b_v = vm_pop(vm), a_v = vm_pop(vm);
             vm_push(vm, INT_VAL(vm_rational_gcd((int64_t)as_number(a_v), (int64_t)as_number(b_v)))); break; }
         case 349: { Value tol = vm_pop(vm), x = vm_pop(vm);
-            VmRational* r = vm_rationalize(rat_arena, as_number(x), as_number(tol));
+            /* as_number_vm, NOT as_number: `rationalize` is the one operation
+             * whose arguments are USUALLY exact rationals — the R7RS-small
+             * example is `(rationalize (exact .3) 1/10) => 1/3` — and the
+             * plain as_number() reads a VAL_RATIONAL's heap index through the
+             * int64 arm of the union and answers 0.0.  Both arguments then
+             * became 0, and `(rationalize 1/3 1/10000)` returned the exact
+             * integer 0 with exit 0 where the native engine returns 1/3
+             * (SW-08).  Rationals, bignums and duals all need the heap-aware
+             * coercion, exactly as native calls 342-347 above already do. */
+            VmRational* r = vm_rationalize(rat_arena, as_number_vm(vm, x), as_number_vm(vm, tol));
             if (!r) { vm_push(vm, NIL_VAL); break; }
             if (r->denom == 1) { vm_push(vm, INT_VAL(r->num)); break; }
             int32_t ptr = heap_alloc(&vm->heap); if (ptr < 0) { vm->error = 1; break; }
@@ -9064,6 +9073,17 @@ static void vm_dispatch_native(VM* vm, int fid) {
             var_dims[nd++] = (d > 0) ? d : 2;   /* a non-positive dim is not a
                                                  * variable domain; binary is
                                                  * the documented default */
+        }
+        /* A BARE SCALAR dims argument means "every variable has this many
+         * states", so `(make-factor-graph 2 2)` is a two-variable graph and
+         * `(fg-marginal fg 1)` is a marginal rather than `()`.  Read as a
+         * one-element sequence it hits the clamp below and cuts num_vars to 1,
+         * where the native engine broadcasts — SW-07's own reproducer.  Only a
+         * genuine scalar LEAF broadcasts: a short sequence is an operand
+         * mismatch, not a broadcast, and still clamps. */
+        if (nd == 1 && nv > 1 && vm_tensor_collection_len(vm, dims_val) < 0) {
+            for (int i = 1; i < nv && i < 64; i++) var_dims[i] = var_dims[0];
+            nd = (nv < 64) ? nv : 64;
         }
         if (nd == 0) {                          /* dims omitted/unreadable */
             int want = (nv > 0 && nv < 64) ? nv : 0;

--- a/lib/core/inference.cpp
+++ b/lib/core/inference.cpp
@@ -88,10 +88,16 @@ static bool extract_doubles_from_vector(const eshkol_tagged_value_t* tv,
     return true;
 }
 
-/* Read numeric elements from a tensor (#(…)) OR a Scheme vector ((vector …)) as
- * doubles into out[0..max-1]; returns the count read (0 if neither / empty).
+/* Read numeric elements from a tensor (#(…)), a Scheme vector ((vector …)) OR a
+ * proper list ('(…)) as doubles into out[0..max-1]; returns the count read
+ * (0 if none of those / empty).
  * Lets the FG builtins accept runtime-constructed vectors, not only tensor
- * literals (bug-QQ-2). INT64 elements promote to double. */
+ * literals (bug-QQ-2). INT64 elements promote to double.
+ *
+ * The list spelling is not cosmetic: the VM's native dispatch has always read
+ * `(2 2)` for both the factor-graph dims and the fg-add-factor! variable
+ * indices, and `tests/vm/vm_kb_tensor_test.esk` uses it, so a native path that
+ * rejected it answered `()` where the VM answered the marginal (SW-07). */
 static uint32_t fg_read_numeric(const eshkol_tagged_value_t* tv, double* out, uint32_t max) {
     if (!tv || tv->type != ESHKOL_VALUE_HEAP_PTR || !tv->data.ptr_val) return 0;
     void* ptr = (void*)(uintptr_t)tv->data.ptr_val;
@@ -111,6 +117,21 @@ static uint32_t fg_read_numeric(const eshkol_tagged_value_t* tv, double* out, ui
             uint8_t et = elems[i].type & 0x0F;
             out[i] = (et == ESHKOL_VALUE_DOUBLE) ? elems[i].data.double_val
                    : (et == ESHKOL_VALUE_INT64) ? (double)elems[i].data.int_val : 0.0;
+        }
+        return n;
+    }
+    if (hdr->subtype == HEAP_SUBTYPE_CONS) {
+        uint32_t n = 0;
+        eshkol_tagged_value_t cur = *tv;
+        while (n < max && ESHKOL_IS_CONS_COMPAT(cur)) {
+            const arena_tagged_cons_cell_t* cell =
+                (const arena_tagged_cons_cell_t*)(uintptr_t)cur.data.ptr_val;
+            if (!cell) break;
+            uint8_t et = cell->car.type & 0x0F;
+            if (et != ESHKOL_VALUE_DOUBLE && et != ESHKOL_VALUE_INT64) return 0;
+            out[n++] = (et == ESHKOL_VALUE_DOUBLE) ? cell->car.data.double_val
+                                                   : (double)cell->car.data.int_val;
+            cur = cell->cdr;
         }
         return n;
     }
@@ -748,10 +769,11 @@ double eshkol_expected_free_energy(arena_t* arena,
 /**
  * @brief Tagged-value entry point for factor-graph construction, called from LLVM codegen.
  *
- * Unpacks @p num_vars_tv (must be a tagged INT64) and @p var_dims_tv (a
- * tensor or Scheme vector of per-variable state counts, via fg_read_numeric())
- * and forwards to eshkol_make_factor_graph(). Sets @p result to a HEAP_PTR on
- * success or the tagged NULL value on any type mismatch or allocation failure.
+ * Unpacks @p num_vars_tv (must be a tagged INT64) and @p var_dims_tv (a tensor,
+ * Scheme vector or list of per-variable state counts, via fg_read_numeric(), or
+ * a bare number broadcast to every variable) and forwards to
+ * eshkol_make_factor_graph(). Sets @p result to a HEAP_PTR on success or the
+ * tagged NULL value on any type mismatch or allocation failure.
  */
 void eshkol_make_factor_graph_tagged(arena_t* arena,
     const eshkol_tagged_value_t* num_vars_tv,
@@ -774,9 +796,24 @@ void eshkol_make_factor_graph_tagged(arena_t* arena,
         return;
     }
 
-    /* Extract var_dims from a tensor (#(…)) OR a runtime vector ((vector …)). */
+    /* Extract var_dims from a tensor (#(…)), a runtime vector ((vector …)), a
+     * list ('(…)), or a BARE SCALAR meaning "every variable has this many
+     * states".  The scalar spelling is what the VM has always accepted, and
+     * `(make-factor-graph 2 2)` silently produced `()` here — and therefore
+     * `()` from every later fg-marginal — because a tagged INT64 is not a heap
+     * pointer and fg_read_numeric answered 0 (SW-07). */
     double* dims_buf = (double*)alloca(num_vars * sizeof(double));
-    if (fg_read_numeric(var_dims_tv, dims_buf, num_vars) < num_vars) {
+    uint8_t dims_tag = var_dims_tv->type & 0x0F;
+    if (dims_tag == ESHKOL_VALUE_INT64 || dims_tag == ESHKOL_VALUE_DOUBLE) {
+        double d = (dims_tag == ESHKOL_VALUE_INT64)
+                       ? (double)var_dims_tv->data.int_val
+                       : var_dims_tv->data.double_val;
+        if (d < 1.0) {
+            result->type = ESHKOL_VALUE_NULL;
+            return;
+        }
+        for (uint32_t i = 0; i < num_vars; i++) dims_buf[i] = d;
+    } else if (fg_read_numeric(var_dims_tv, dims_buf, num_vars) < num_vars) {
         result->type = ESHKOL_VALUE_NULL;
         return;
     }

--- a/lib/core/logic_builtins.cpp
+++ b/lib/core/logic_builtins.cpp
@@ -55,6 +55,13 @@ void eshkol_fg_marginal_tagged(arena_t* arena,
         result->data.raw_val = 0;
         return;
     }
+    /* arena_allocate_tensor_full sets num_dimensions/total_elements but leaves
+     * the dimensions[] array UNWRITTEN — every other caller fills it in.  This
+     * one did not, so a correctly computed marginal was handed back with an
+     * unset extent and printed as `#()`: the documented
+     * `(fg-marginal (make-factor-graph 2 #(2 2)) 0)` answered `#()` natively
+     * where the VM answered `#(0.5 0.5)` (SW-07). */
+    if (t->dimensions) t->dimensions[0] = n_states;
 
     /* Beliefs are log-probabilities → convert to probabilities via exp.
      * Normalize so they sum to 1. */

--- a/lib/core/rational.cpp
+++ b/lib/core/rational.cpp
@@ -934,8 +934,14 @@ extern "C" void eshkol_rationalize_tagged(
     double eps = tagged_to_double(epsilon);
     if (eps < 0) eps = -eps;
 
-    /* Handle exact integers: if x is int and eps >= 0, return x */
-    if (x->type == ESHKOL_VALUE_INT64 && eps >= 0.0) {
+    /* A zero tolerance pins the answer to x itself. Taking it here keeps an
+     * exact integer exact past 2^53, where the double round-trip below would
+     * not. This must stay narrowed to eps == 0: the old form fired for EVERY
+     * exact-integer x and any tolerance at all, so `(rationalize 3 1)`
+     * answered 3 while the VM answered 2. R7RS-small 6.2.6 makes 2 right —
+     * with q1 = q2 = 1, r1 is simpler than r2 when |p1| <= |p2|, so the
+     * simplest rational in [2,4] is the one nearest zero. */
+    if ((x->type & 0x0F) == ESHKOL_VALUE_INT64 && eps == 0.0) {
         result->type = ESHKOL_VALUE_INT64;
         result->data.int_val = x->data.int_val;
         return;
@@ -968,27 +974,26 @@ extern "C" void eshkol_rationalize_tagged(
     int64_t a_num = 0, a_den = 1;  /* left bound: 0/1 */
     int64_t b_num = 1, b_den = 0;  /* right bound: 1/0 = infinity */
 
-    /* First, advance past integers: floor(lo) */
-    int64_t int_part = (int64_t)lo;
-    if ((double)int_part > lo) int_part--;
+    /* If an integer is in range it is the simplest rational there, and the
+     * simplest INTEGER in range is the one with the smallest |numerator| —
+     * on this already-non-negative domain that is ceil(lo), not floor(lo)+1.
+     * Testing floor(lo)+1 first answered 3 for [2,4] where 2 is simpler.
+     * Same rule as the VM's vm_rationalize(), which this must agree with. */
+    int64_t lo_int = (int64_t)ceil(lo);
+    if ((double)lo_int <= hi) {
+        int64_t val = negative ? -lo_int : lo_int;
+        result->type = ESHKOL_VALUE_INT64;
+        result->data.int_val = val;
+        return;
+    }
+
+    /* No integer in range: bracket the interval by its two nearest integers
+     * and start the Stern-Brocot mediant search between them. */
+    int64_t int_part = lo_int - 1;
     a_num = int_part;
     a_den = 1;
     b_num = int_part + 1;
     b_den = 1;
-
-    /* If an integer is in range, return it */
-    if ((double)b_num >= lo && (double)b_num <= hi) {
-        int64_t val = negative ? -b_num : b_num;
-        result->type = ESHKOL_VALUE_INT64;
-        result->data.int_val = val;
-        return;
-    }
-    if ((double)a_num >= lo && (double)a_num <= hi) {
-        int64_t val = negative ? -a_num : a_num;
-        result->type = ESHKOL_VALUE_INT64;
-        result->data.int_val = val;
-        return;
-    }
 
     /* Mediant search between a_num/a_den and b_num/b_den */
     for (int iter = 0; iter < 1000; iter++) {

--- a/tests/differential/corpus/43_rationalize.esk
+++ b/tests/differential/corpus/43_rationalize.esk
@@ -1,0 +1,25 @@
+;; R7RS `rationalize` across the native axes (jit / jit-nocache / aot-O0 /
+;; aot-O2). Paired with tests/vm_parity/corpus/58_rationalize_r7rs.esk, which
+;; runs the same operation on BOTH engines; this file pins the native axes to
+;; each other so an optimisation level can never change the answer.
+;;
+;; R7RS-small 6.2.6 example: (rationalize (exact .3) 1/10) => 1/3.
+
+(define (show label v)
+  (display label) (display " = ") (display v)
+  (display " exact=") (display (exact? v)) (newline))
+
+(show "spec" (rationalize 3/10 1/10))
+(show "tight" (rationalize 1/3 1/10000))
+(show "negative" (rationalize -3/10 1/10))
+(show "zero-tolerance" (rationalize 3/10 0))
+(show "integer-interval" (rationalize 3 1))
+(show "negative-integer-interval" (rationalize -3 1))
+(show "spans-zero" (rationalize 0 1))
+(show "spans-zero-2" (rationalize 1/10 1/2))
+(show "two-sevenths" (rationalize 2/7 1/100))
+(show "three-quarters" (rationalize 3/4 1/100))
+
+(display "spec-example ")
+(display (if (= (rationalize 3/10 1/10) 1/3) "PASS" "FAIL"))
+(newline)

--- a/tests/differential/corpus/44_factor_graph_marginal.esk
+++ b/tests/differential/corpus/44_factor_graph_marginal.esk
@@ -1,0 +1,33 @@
+;; Factor-graph marginals across the native axes (jit / jit-nocache / aot-O0 /
+;; aot-O2). Paired with tests/vm_parity/corpus/57_factor_graph_marginal.esk,
+;; which runs the same program on BOTH engines.
+;;
+;; A graph with no factors and no inference run carries the uniform prior
+;; log(1/dim), so the marginal of a d-state variable is 1/d in every slot.
+;; Dims 2 and 4 keep every expected value an exact binary fraction.
+
+(define (show label v) (display label) (display " = ") (display v) (newline))
+
+(define fg-tensor (make-factor-graph 2 #(2 2)))
+(define fg-list   (make-factor-graph 2 '(2 2)))
+(define fg-scalar (make-factor-graph 2 2))
+(define fg-ragged (make-factor-graph 2 #(2 4)))
+
+(show "tensor-dims var0" (fg-marginal fg-tensor 0))
+(show "tensor-dims var1" (fg-marginal fg-tensor 1))
+(show "list-dims   var0" (fg-marginal fg-list 0))
+(show "list-dims   var1" (fg-marginal fg-list 1))
+(show "scalar-dims var0" (fg-marginal fg-scalar 0))
+(show "scalar-dims var1" (fg-marginal fg-scalar 1))
+(show "ragged var0" (fg-marginal fg-ragged 0))
+(show "ragged var1" (fg-marginal fg-ragged 1))
+
+(define m (fg-marginal fg-tensor 0))
+(show "shape" (tensor-shape m))
+(display "uniform-2 ")
+(display (if (and (= (tensor-ref m 0) 0.5) (= (tensor-ref m 1) 0.5))
+             "PASS" "FAIL"))
+(newline)
+(display "extent-2 ")
+(display (if (equal? (tensor-shape m) '(2)) "PASS" "FAIL"))
+(newline)

--- a/tests/rational/rationalize_test.esk
+++ b/tests/rational/rationalize_test.esk
@@ -13,14 +13,40 @@
     (display "FAIL: rationalize 0.3 0.1 not rational"))
 (newline)
 
-;; (rationalize 3 1) should return 3 (integer is simplest)
+;; (rationalize 3 1) should return 2, NOT 3.
+;; R7RS-small 6.2.6 orders simplicity by |p1| <= |p2| and q1 <= q2, so among
+;; the integers 2, 3 and 4 in [3-1, 3+1] — all with denominator 1 — the
+;; simplest is the one with the smallest numerator. This row used to expect 3,
+;; which is what the native engine returned by taking any exact-integer x as
+;; its own answer and ignoring the tolerance; the VM answered 2 all along.
 (define r2 (rationalize 3 1))
 (display "rationalize 3 1 = ")
 (display r2)
 (newline)
-(if (= r2 3)
-    (display "PASS: rationalize 3 1 = 3")
-    (display "FAIL: rationalize 3 1 != 3"))
+(if (= r2 2)
+    (display "PASS: rationalize 3 1 = 2")
+    (display "FAIL: rationalize 3 1 != 2"))
+(newline)
+
+;; The R7RS-small worked example, in the exact form the spec prints:
+;;   (rationalize (exact .3) 1/10)  =>  1/3
+(define r2b (rationalize 3/10 1/10))
+(display "rationalize 3/10 1/10 = ")
+(display r2b)
+(newline)
+(if (= r2b 1/3)
+    (display "PASS: rationalize 3/10 1/10 = 1/3")
+    (display "FAIL: rationalize 3/10 1/10 != 1/3"))
+(newline)
+
+;; A zero tolerance can only answer x itself, and it stays exact.
+(define r2c (rationalize 3/10 0))
+(display "rationalize 3/10 0 = ")
+(display r2c)
+(newline)
+(if (and (= r2c 3/10) (exact? r2c))
+    (display "PASS: rationalize 3/10 0 = 3/10 exact")
+    (display "FAIL: rationalize 3/10 0 != exact 3/10"))
 (newline)
 
 ;; (rationalize 0.5 0.0) should return 1/2 (exact)

--- a/tests/vm_parity/ENGINE_PARITY_BASELINE.json
+++ b/tests/vm_parity/ENGINE_PARITY_BASELINE.json
@@ -104,6 +104,8 @@
     "tests/vm_parity/corpus/54_logic_var_kb_query.esk",
     "tests/vm_parity/corpus/55_truthiness.esk",
     "tests/vm_parity/corpus/56_factor_graph_inference.esk",
+    "tests/vm_parity/corpus/57_factor_graph_marginal.esk",
+    "tests/vm_parity/corpus/58_rationalize_r7rs.esk",
     "tests/vm_parity/corpus/read_write_roundtrip.esk",
     "tests/vm_parity/corpus/region_handle_contract.esk",
     "tests/vm_parity/corpus/with_region_lowering.esk"

--- a/tests/vm_parity/corpus/57_factor_graph_marginal.esk
+++ b/tests/vm_parity/corpus/57_factor_graph_marginal.esk
@@ -1,0 +1,68 @@
+;; VM-parity differential over `fg-marginal` on a freshly built factor graph
+;; (SW-07).
+;;
+;; A graph that has had no factor added and no inference run carries the
+;; UNIFORM PRIOR that eshkol_make_factor_graph() installs — log(1/dim) in every
+;; belief slot — so the marginal of a d-state variable is exactly 1/d in every
+;; component, on every engine, for every accepted spelling of the dims
+;; argument. That is the arithmetic, not an engine's opinion, which is why the
+;; expected values are written out here as well as compared across engines.
+;;
+;; Before the fix each engine was wrong on a different spelling and neither
+;; said so: native answered `#()` for the documented `#(2 2)` (the result
+;; tensor's extent was never written) and `()` for `'(2 2)` and `2` (dims read
+;; rejected both), while the VM answered `()` for `#(2 2)` (a `#(...)` literal
+;; reaches its mini-compiler as a VECTOR, not a tensor, so it fell through to
+;; the bare-scalar arm and built one zero-state variable) and truncated
+;; `(make-factor-graph 2 2)` to a single variable.
+;;
+;; Dims are 2 and 4 deliberately: 1/2 and 1/4 are exact binary fractions, so
+;; the printed form cannot differ between two correct engines for
+;; float-formatting reasons.
+
+(define (show label v) (display label) (display " = ") (display v) (newline))
+
+;; ---- the three accepted dims spellings must build the same graph ----
+(define fg-tensor (make-factor-graph 2 #(2 2)))
+(define fg-list   (make-factor-graph 2 '(2 2)))
+(define fg-scalar (make-factor-graph 2 2))
+
+(show "tensor-dims var0" (fg-marginal fg-tensor 0))
+(show "tensor-dims var1" (fg-marginal fg-tensor 1))
+(show "list-dims   var0" (fg-marginal fg-list 0))
+(show "list-dims   var1" (fg-marginal fg-list 1))
+(show "scalar-dims var0" (fg-marginal fg-scalar 0))
+(show "scalar-dims var1" (fg-marginal fg-scalar 1))
+
+;; ---- a ragged graph: per-variable dims must not be broadcast ----
+(define fg-ragged (make-factor-graph 2 #(2 4)))
+(show "ragged var0" (fg-marginal fg-ragged 0))
+(show "ragged var1" (fg-marginal fg-ragged 1))
+
+;; ---- the marginal is a real tensor, not just something that prints ----
+(define m (fg-marginal fg-tensor 0))
+(show "shape" (tensor-shape m))
+(show "elem0" (tensor-ref m 0))
+(show "elem1" (tensor-ref m 1))
+
+;; ---- explicit arithmetic oracle: uniform prior over d states = 1/d ----
+(display "uniform-2 ")
+(display (if (and (= (tensor-ref m 0) 0.5) (= (tensor-ref m 1) 0.5))
+             "PASS" "FAIL"))
+(newline)
+
+;; The extent has to be right too, not only the element values: the native
+;; result tensor used to carry shape (0) with the correct probabilities inside
+;; it, which prints as #() and makes every consumer read an empty distribution.
+(display "extent-2 ")
+(display (if (equal? (tensor-shape m) '(2)) "PASS" "FAIL"))
+(newline)
+
+(define r (fg-marginal fg-ragged 1))
+(display "uniform-4 ")
+(display (if (and (= (tensor-ref r 0) 0.25) (= (tensor-ref r 3) 0.25))
+             "PASS" "FAIL"))
+(newline)
+
+;; ---- an out-of-range variable index is the empty answer on both engines ----
+(show "out-of-range" (fg-marginal fg-tensor 7))

--- a/tests/vm_parity/corpus/58_rationalize_r7rs.esk
+++ b/tests/vm_parity/corpus/58_rationalize_r7rs.esk
@@ -1,0 +1,58 @@
+;; VM-parity differential over R7RS `rationalize` (SW-08).
+;;
+;; R7RS-small 6.2.6: "The rationalize procedure returns the simplest rational
+;; number differing from x by no more than y. A rational number r1 is simpler
+;; than another rational number r2 if r1 = p1/q1 and r2 = p2/q2 (in lowest
+;; terms) and |p1| <= |p2| and q1 <= q2", with the worked example
+;;
+;;     (rationalize (exact .3) 1/10)  =>  1/3
+;;
+;; The interesting arguments are therefore EXACT RATIONALS, which is exactly
+;; the tag the VM's native-call 349 did not unwrap: it read them through the
+;; plain as_number(), got 0.0 for both x and the tolerance, and answered the
+;; exact integer 0 with exit 0 for every input on this page while native
+;; answered 1/3.
+;;
+;; The integer rows are the mirror defect, on the other engine: native took an
+;; exact-integer x as its own answer no matter how wide the tolerance, so
+;; `(rationalize 3 1)` was 3 where the simplicity order above makes 2 the
+;; answer (|2| <= |3|, denominators both 1) and the VM already said 2.
+
+(define (show label v)
+  (display label) (display " = ") (display v)
+  (display " exact=") (display (exact? v)) (newline))
+
+;; ---- the R7RS worked example, in exact form ----
+(show "spec 3/10 within 1/10" (rationalize 3/10 1/10))
+
+;; ---- the same answer approached from the other side of 1/3 ----
+(show "1/3 within 1/10000" (rationalize 1/3 1/10000))
+
+;; ---- sign is carried, simplicity is not affected by it ----
+(show "-3/10 within 1/10" (rationalize -3/10 1/10))
+
+;; ---- a zero tolerance can only answer x itself ----
+(show "3/10 within 0" (rationalize 3/10 0))
+
+;; ---- an interval containing an integer answers with an integer ----
+(show "3 within 1" (rationalize 3 1))
+(show "-3 within 1" (rationalize -3 1))
+
+;; ---- an interval containing zero answers zero ----
+(show "0 within 1" (rationalize 0 1))
+(show "1/10 within 1/2" (rationalize 1/10 1/2))
+
+;; ---- a wider tolerance can only give a simpler answer ----
+(show "2/7 within 1/100" (rationalize 2/7 1/100))
+(show "3/4 within 1/100" (rationalize 3/4 1/100))
+
+;; ---- explicit R7RS oracle, so agreement on a wrong answer still fails ----
+(display "spec-example ")
+(display (if (= (rationalize 3/10 1/10) 1/3) "PASS" "FAIL"))
+(newline)
+(display "simplest-integer ")
+(display (if (= (rationalize 3 1) 2) "PASS" "FAIL"))
+(newline)
+(display "zero-tolerance-identity ")
+(display (if (= (rationalize 3/10 0) 3/10) "PASS" "FAIL"))
+(newline)


### PR DESCRIPTION
Two silent engine divergences from the v1.3.4 skipped-flaws ledger: **SW-07**
(`fg-marginal`) and **SW-08** (`rationalize`). Both returned a wrong value with
exit 0 and no diagnostic. In both cases each engine was wrong on a *different*
spelling of the same call, so neither could serve as the other's oracle — which
is why nothing in the tree noticed.

## SW-07 — `fg-marginal`

A factor graph with no factor added and no inference run carries the uniform
prior `log(1/dim)` that `eshkol_make_factor_graph()` installs, so the marginal
of a d-state variable is exactly `1/d` in every component. Four independent
defects stood between that arithmetic and the answer:

| where | defect |
|---|---|
| `lib/core/logic_builtins.cpp:52` | The result tensor is allocated with `arena_allocate_tensor_full()`, which sets `num_dimensions` and `total_elements` but leaves `dimensions[]` **unwritten**. Every other caller in the tree fills it in; this one did not. The documented `(fg-marginal (make-factor-graph 2 #(2 2)) 0)` therefore printed `#()` with a correctly computed distribution inside it, shape `(0)`. |
| `lib/core/inference.cpp` `fg_read_numeric()` | Read a tensor or a vector, but not a proper list. `'(2 2)` — the spelling `tests/vm/vm_kb_tensor_test.esk` uses and the VM has always accepted — made `make-factor-graph` answer the tagged NULL, and every later `fg-marginal` answered `()`. |
| `lib/core/inference.cpp` `eshkol_make_factor_graph_tagged()` | No arm for a bare scalar dims argument. A tagged INT64 is not a heap pointer, so the ledger's own reproducer `(make-factor-graph 2 2)` also produced `()`. A scalar now broadcasts: every variable gets that many states. |
| `lib/backend/vm_native.c` native call 520 | Matched `HEAP_TENSOR` only, but a `#(2 2)` literal reaches the VM's mini-compiler as a **VECTOR**. It fell through to the bare-scalar arm, `as_number()` of a heap vector is `0`, and the VM built one zero-state variable — so for the *documented* spelling the VM was the wrong side. The same arm read a scalar as a one-element dims list and then clamped `num_vars` down to that length, truncating `(make-factor-graph 2 2)` to a single variable. |

## SW-08 — `rationalize`

R7RS-small 6.2.6 returns the simplest rational within the tolerance, ordered by
`|p1| <= |p2|` and `q1 <= q2`, with the worked example
`(rationalize (exact .3) 1/10) => 1/3`. The interesting arguments are exact
rationals, and:

- `lib/backend/vm_native.c` native call 349 coerced both arguments with the
  plain `as_number()`, which reads a `VAL_RATIONAL`'s heap index through the
  int64 arm of the union and answers `0.0`. Both arguments became 0, so the VM
  answered the exact integer `0` for every rational input. Native calls 342-347
  already special-case `VAL_RATIONAL`; 349 now uses the heap-aware
  `as_number_vm()`, which also covers bignum and dual arguments. That function's
  own doc comment describes this failure mode exactly.
- `lib/core/rational.cpp` took any exact-integer `x` as its own answer whatever
  the tolerance, and its integer-in-range test tried `floor(lo)+1` before
  `ceil(lo)`. Both made `(rationalize 3 1)` answer `3` where `2` is simpler
  (`|2| <= |3|`, denominators both 1) — and where the VM already answered `2`.
  The exact-integer shortcut is narrowed to a **zero** tolerance, where it is
  what keeps an integer beyond 2^53 exact through the double round-trip, and the
  integer selection now takes `ceil(lo)`, matching `vm_rationalize()`.

This second half is a native-side divergence found while building the parity
corpus, not in the ledger's SW-08 text. It is fixed here because a parity corpus
that routes around a live divergence is exactly the silence the ledger exists to
end. `tests/rational/rationalize_test.esk`'s `(rationalize 3 1)` row is
corrected from 3 to 2 with the spec citation.

## Coverage

- `tests/vm_parity/corpus/57_factor_graph_marginal.esk` and
  `58_rationalize_r7rs.esk` — **both engines**, over every accepted spelling,
  carrying explicit R7RS and uniform-prior oracles (plus an extent oracle for
  the tensor shape), so agreement on a wrong answer still fails.
- `tests/differential/corpus/43_rationalize.esk` and
  `44_factor_graph_marginal.esk` — pin the native jit / jit-nocache / aot-O0 /
  aot-O2 axes to each other.
- `tests/rational/rationalize_test.esk` — gains the spec example and the
  zero-tolerance identity.

**Revert-validate.** With the four source files reverted to `origin/master` and
the tests kept, on a full rebuild: `57` prints `#()`/`()` natively against
`#(0.5 0.5)`/`()` on the VM (parity FAIL) and its `extent-2` oracle FAILs;
`58`'s `simplest-integer` FAILs natively and `spec-example` +
`zero-tolerance-identity` FAIL on the VM. Restoring the fix turns all of them
green.

## Gates (RelWithDebInfo, LLVM 21, arm64-apple-darwin24.1.0)

| gate | result |
|---|---|
| `ctest --test-dir build` | **144/144** passed |
| `scripts/run_vm_parity.sh` | **158 passed, 0 failed** (audit + corpus + oos + fatal; +4 checks from the two new corpus programs) |
| `scripts/run_engine_parity_coverage.py` | **OK** — 102 programs both engines ran clean, 7 divergent (all baselined, **0 new**), 0 regressed, 136/1114 constructs with differential evidence (12.21%, floor 10.95%) |
| `scripts/run_differential.sh tests/differential/corpus/` | 264/270 axis pairs agree across 45 programs; the one divergent program is `37_sort.esk`, pre-existing (LE-01, first-class builtins) and untouched here. Both new programs pass 6/6 axis pairs each. |
| `scripts/run_rational_tests.sh` | 3/3 |
| `scripts/run_logic_tests.sh` | 7/7 |
| `scripts/run_v1_2_edge_cases_tests.sh` | 100/100 |
| `icc chain --preset correctness` (scoped to `lib/core`, `lib/backend`, `tests/vm_parity`, `tests/differential`, `tests/rational`) | both steps MEASURED (417 / 192 scanned), **0 files flagged by more than one detector** |

## Ratchet

`ENGINE_PARITY_BASELINE.json`: `divergent_programs` is **unchanged at 8**.
Neither defect was represented there. #413's merge already took it from 10 to 8
by removing `inference_test.esk` and `continuous_learning.esk`; the remaining
`workspace_test.esk` is a `ws-step!` defect this change does not touch. Both new parity programs are added to
`both_ran_programs`, so a future VM regression that stops running them is a
REGRESSED program rather than a silent reclassification to native-only.

## Also observed, not fixed here

`(vector-ref <marginal-tensor> 0)` answers `0.5` natively and `()` on the VM —
a separate silent divergence in `vector-ref` over a tensor, outside this PR's
scope and not currently ledgered.

---

## Rebased onto master `8ff91b1e` (2026-08-13)

Six squash merges landed under this PR (#413 #418 #419 #420 #423 #428). Rebased, two conflicts:

1. **`lib/backend/vm_native.c` native call 520.** #413 replaced the whole dims-reading block with one unified sequence reader, `vm_fg_seq_doubles()`, that already handles tensor / vector / list / scalar-leaf. **That supersedes this PR's original VM vector arm and is the better structure**, so HEAD's version was taken wholesale. What #413 does *not* do is broadcast: a bare scalar reads as a one-element sequence and the `if (nd < nv) nv = nd` clamp below still cuts `(make-factor-graph 2 2)` to a single variable, where the native half of this PR builds two. Re-resolved as a scalar-**leaf**-only broadcast layered on top of #413's reader — a *short* sequence is an operand mismatch, not a broadcast, and still clamps. The `rationalize` hunk in the same file merged clean.
2. **`tests/vm_parity/ENGINE_PARITY_BASELINE.json`.** Union: kept #413's `56_factor_graph_inference.esk` and this PR's two entries.

No `docs/KNOWN_ISSUES.md` conflict — this PR does not touch it.

**Corpus renumbered** off master's new files (`54_take_drop_srfi1_order`, `54_complex_transcendentals`, `55_inexact_exact_exactness`, `56_factor_graph_inference`, `56_lexical_shadow_nearest_binding`, `42_ad_capture_global_shadow`, `42_diff_quoted_raises`):

| was | now |
|---|---|
| `tests/vm_parity/corpus/56_factor_graph_marginal.esk` | `57_factor_graph_marginal.esk` |
| `tests/vm_parity/corpus/57_rationalize_r7rs.esk` | `58_rationalize_r7rs.esk` |
| `tests/differential/corpus/42_rationalize.esk` | `43_rationalize.esk` |
| `tests/differential/corpus/43_factor_graph_marginal.esk` | `44_factor_graph_marginal.esk` |

Cross-references inside the paired files were updated with them. Full rebuild before re-running anything; all gate numbers in the table above are post-rebase measurements, and both defects re-verified fixed on both engines across all three dims spellings.

## Stale ratchet entry found while re-measuring (not this PR's to retire)

`tests/parser/special_forms_test.esk` is still listed in `divergent_programs` but now **agrees on both engines** at `fc3c1257` — stable over three runs under the gate's own normalisation, and it references neither `rationalize` nor any factor-graph builtin, so it is not this change. One of today's merges fixed it (most likely #428's nearest-enclosing-binding fix) without tightening the ratchet. Left in place here so this PR does not take on another lane's risk or credit; flagged for whoever owns that lane. The ratchet is shrink-only, so the entry is currently silence, not tolerance.
