### PR TITLE
chore(oracle): close SW-07 and SW-08 by measurement (fixed by #424)

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -56,6 +56,30 @@ oracles:
         label: Codegen / runtime / type-checker production paths are real
         action: wire_real_path_or_classify_stub
 
+      # ── Silent-wrong flaw gate (2026-08-12) ──────────────────────────
+      # Every other criterion in this oracle certifies that something
+      # WORKS. None of them can certify that nothing SILENTLY LIES: a
+      # defect that returns a wrong value with no diagnostic and exit 0
+      # is invisible to a probe that only asserts its own happy path.
+      # That is exactly how a release cut reached readiness 100 while
+      # carrying an AD operator that differentiates the wrong function,
+      # a `map` that ignores a shadowing binding, and seven documented
+      # resource limits that are never enforced.
+      #
+      # `.icc/silent-wrong-ledger.yaml` is the enumeration of that class;
+      # `scripts/gate_no_silent_wrong.py` grades it and emits this event.
+      # The gate fails closed — a missing or unparseable ledger is FAIL,
+      # because absence of the ledger is not evidence of absence of the
+      # defects. Entries close only by measurement at a named SHA, and a
+      # waiver needs an owner, a reason and an unexpired date.
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["no_open_silent_wrong"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'No open, unwaived SILENT-WRONG flaw ships: every entry in .icc/silent-wrong-ledger.yaml whose bucket is SILENT-WRONG (or which is IN-FLIGHT but silent_wrong_class) is closed at a named SHA or carries an owner/reason/unexpired waiver — wrong values, wrong derivatives and wrong memory outcomes with no diagnostic and exit 0 are tag-blocking'
+        action: python3 scripts/gate_no_silent_wrong.py
+
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["llvm_module_verifier_clean"]
@@ -623,6 +647,18 @@ oracles:
   - name: v1.3-evolve
     aliases: [v1.3, release-1.3, evolve]
     requires:
+      # The release-line mirror of the compiler-readiness silent-wrong gate.
+      # A v1.3.x tag is a promise to consumers about answers, not about
+      # features, so the flaw ledger gates the release target too. See the
+      # long comment on the same criterion in eshkol-compiler-readiness.
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["no_open_silent_wrong"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'No open, unwaived SILENT-WRONG flaw ships in the v1.3 line (.icc/silent-wrong-ledger.yaml graded by scripts/gate_no_silent_wrong.py; fails closed)'
+        action: python3 scripts/gate_no_silent_wrong.py
+
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["string_interpolation_works"]

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -430,12 +430,24 @@ entries:
     affected_measured: ["string<?", "string>?", "string=?", "char<?", "char=?", "string-append", "vector-ref", "car", "expt", "min", "max"]
     unaffected_measured: ["+", "<", "eq?"]
     evidence: ".scratch/flaw-ledger/repro/fc_tmp.esk; tests/differential/corpus/37_sort.esk"
-    caught_by: [pr-record-420, direct-measurement]
+    axis_dependent_failure: >-
+      scripts/icc_traces/differential_smoke at 9f2da2ab records 37_sort.esk failing a
+      DIFFERENT way on every compilation axis: jit rc=1, jit-nocache rc=139 (SIGSEGV),
+      aot-o0 rc=125, aot-o2 rc=125. Six pairwise axis comparisons FAIL plus the
+      differential_corpus_clean roll-up ("1/41 corpus programs diverge across axes").
+      The cached-JIT-versus-nocache split (1 vs 139) is the same object-cache signature as
+      IF-01, so the two are probably one root cause seen from two directions.
+    readiness_impact: >-
+      MEASURED at 9f2da2ab: icc readiness eshkol-compiler-readiness is BLOCKED at score 77,
+      and this defect is the whole of the failure_free FAIL apart from one stale event.
+      LE-01 is the single item standing between the cut and a green readiness run.
+    caught_by: [pr-record-420, direct-measurement, icc-readiness]
     missed_by: [icc-correctness-chain, icc-smoke, KNOWN_ISSUES]
     notes: >-
       PR #420 describes this as 'Undefined variable'. At 9f2da2ab it is a SIGSEGV, which is
-      strictly worse, and it is a FAMILY, not one builtin. It is the failure_free blocker
-      that holds icc readiness at 77 on #420's branch.
+      strictly worse, and it is a FAMILY of at least 11 builtins, not one. Note the honest
+      detector working: readiness is red BECAUSE this is real. Do not baseline 37_sort.esk
+      to make the number go green.
 
   - id: LE-02
     bucket: LOUD-ERROR

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -566,6 +566,27 @@ entries:
     evidence: "icc odr-audit; icc guard-liveness; PR #414 verification table"
     caught_by: [pr-record-414, icc-odr-audit]
 
+  - id: PR-10
+    bucket: PARITY-RATCHET
+    status: open
+    title: "The engine-parity gate reports PASS while 89.86 percent of the language surface has never been differentially compared"
+    measured: >-
+      scripts/icc_traces/engine_parity_coverage.jsonl at 9f2da2ab reads
+      "113/1114 constructs with differential evidence (10.14%), 10 divergent program(s), 0 new"
+      and its value is PASS. scripts/icc_traces/surface_parity.jsonl reads
+      "2506 probed / 318 divergences / 0 new" and its value is also PASS.
+    evidence: "scripts/icc_traces/engine_parity_coverage.jsonl; scripts/icc_traces/surface_parity.jsonl"
+    caught_by: [direct-measurement]
+    missed_by: [icc-correctness-chain, icc-readiness]
+    notes: >-
+      This is the structural reason the AD and numeric silent-wrong entries escaped. Both
+      probes grade NON-GROWTH ("0 new"), not correctness, so a defect that has been present
+      since before the baseline is permanently invisible and the gate is green anyway.
+      SW-01, SW-02, SW-06 and SW-08 all live in the 1001 constructs (89.86 percent) that
+      have no differential evidence at all. A coverage percentage that low should itself be
+      a criterion: the gate needs a rising floor on constructs-with-evidence, not only a
+      ceiling on new divergences.
+
   # ───────────────────────── DOC-DEBT ─────────────────────────
 
   - id: DD-01

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -215,7 +215,10 @@ entries:
     notes: >-
       ICC's duplicate-implementations detector did not flag this pair: the two files are
       not textually similar, so a lexical clone detector cannot see a semantic duplicate.
-      That is a concrete ICC detector gap, not a scoping choice.
+      That is a concrete ICC detector gap, not a scoping choice. The correctness chain's
+      other half, `contradictions`, returned 30 findings at this SHA and every one is a
+      constant_disagreement or env_default_disagreement on a build/tuning symbol — it
+      compares symbol VALUES, never behaviour, docs or test-harness metadata.
 
   - id: SW-13
     bucket: SILENT-WRONG

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -131,26 +131,79 @@ entries:
 
   - id: SW-07
     bucket: SILENT-WRONG
-    status: open
+    status: closed
+    closed_at: "fc3c1257"
     title: "fg-marginal returns an empty result natively"
     repro: "(define fg (make-factor-graph 2 2)) (display (fg-marginal fg 0))"
     observed: "native (), VM #(0.5 0.5)"
     correct: "#(0.5 0.5) — the uniform marginal"
-    evidence: ".scratch/flaw-ledger/repro/sw_fg_marginal.esk; PR #413 Follow-ups item 2"
+    measured: >-
+      At fc3c1257 (PR #424, branch fix/fg-marginal-rationalize) both engines
+      print #(0.5 0.5) for all three dims spellings #(2 2), '(2 2) and 2, and
+      for both variables of a two-variable graph. Four defects, not one: the
+      native result tensor's dimensions[] array was never written
+      (lib/core/logic_builtins.cpp:52, so the documented #(2 2) spelling printed
+      #() around a correct distribution); native fg_read_numeric() read no list
+      form and eshkol_make_factor_graph_tagged() had no bare-scalar arm
+      (lib/core/inference.cpp), so '(2 2) and 2 answered the tagged NULL; and
+      the VM matched HEAP_TENSOR only, so a #(2 2) VECTOR literal fell to the
+      scalar arm and built one zero-state variable, while a real scalar was read
+      as a one-element dims list that clamped num_vars to 1
+      (lib/backend/vm_native.c native call 520).
+    evidence: >-
+      tests/vm_parity/corpus/57_factor_graph_marginal.esk (both engines, with an
+      explicit uniform-prior and extent oracle);
+      tests/differential/corpus/44_factor_graph_marginal.esk (native axes);
+      .scratch/flaw-ledger/repro/sw_fg_marginal.esk; PR #413 Follow-ups item 2
     caught_by: [pr-record-413, direct-measurement]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
-    notes: "PR #413 explicitly leaves this alone. #413 is still OPEN, so even its factor-graph fixes are not in the cut."
+    fixed_by: "PR #424 (fix/fg-marginal-rationalize)"
+    notes: >-
+      PR #413 has since MERGED and its unified factor-graph sequence reader
+      (vm_fg_seq_doubles) supersedes #424's original VM vector arm; #424 was
+      rebased onto it and now layers only the bare-scalar broadcast on top, so
+      `(make-factor-graph 2 2)` is a two-variable graph on both engines rather
+      than being clamped to one. #424 does NOT close
+      tests/logic/workspace_test.esk, which is a ws-step! defect and is still
+      divergent at fc3c1257. #413's merge already removed
+      tests/logic/inference_test.esk and continuous_learning.esk from
+      divergent_programs, taking it from 10 to 8; #424 removes nothing further.
+      SEPARATELY MEASURED at fc3c1257 and reported to the coordinator rather
+      than acted on here: tests/parser/special_forms_test.esk is still
+      baselined but now AGREES on both engines (stable over three runs, and it
+      references neither rationalize nor any factor-graph builtin), so one of
+      today's merges — most likely #428's nearest-enclosing-binding fix — left
+      a stale ratchet entry that its own lane should retire.
 
   - id: SW-08
     bucket: SILENT-WRONG
-    status: open
+    status: closed
+    closed_at: "fc3c1257"
     title: "rationalize diverges between engines; the VM silently answers 0"
     repro: "(display (rationalize (/ 1 3) 1/10000))"
     observed: "native 1/3, VM 0"
     correct: "1/3"
-    evidence: ".scratch/flaw-ledger/repro/sw_rationalize.esk"
+    measured: >-
+      At fc3c1257 (PR #424) both engines answer 1/3, and agree on the whole
+      R7RS-small 6.2.6 page. Two defects, one per engine: the VM's native call
+      349 coerced both arguments with the plain as_number(), which reads a
+      VAL_RATIONAL's heap index through the int64 arm of the union and answers
+      0.0, so every exact-rational input produced the exact integer 0
+      (lib/backend/vm_native.c; native calls 342-347 already special-case
+      VAL_RATIONAL, 349 now uses as_number_vm()). Natively, an exact-integer x
+      was taken as its own answer whatever the tolerance and the integer-in-range
+      test tried floor(lo)+1 before ceil(lo), so (rationalize 3 1) answered 3
+      where 2 is simpler under |p1| <= |p2| with q1 = q2 = 1, and where the VM
+      already answered 2 (lib/core/rational.cpp).
+    evidence: >-
+      tests/vm_parity/corpus/58_rationalize_r7rs.esk (both engines, with the
+      spec example as an explicit oracle);
+      tests/differential/corpus/43_rationalize.esk (native axes);
+      tests/rational/rationalize_test.esk;
+      .scratch/flaw-ledger/repro/sw_rationalize.esk
     caught_by: [direct-measurement]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES, numeric_exactness_oracle]
+    fixed_by: "PR #424 (fix/fg-marginal-rationalize)"
 
   - id: SW-09
     bucket: SILENT-WRONG

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -175,10 +175,12 @@ entries:
     correct: "The documented limit is applied, or the variable is documented as inert"
     variables: [ESHKOL_MAX_HEAP, ESHKOL_TIMEOUT_MS, ESHKOL_MAX_STACK, ESHKOL_MAX_TENSOR_ELEMS, ESHKOL_MAX_STRING_LEN, ESHKOL_ENFORCE_LIMITS, ESHKOL_LIMIT_WARNINGS]
     evidence: >-
-      lib/core/resource_limits.cpp parses into g_limits and nothing consults it;
-      eshkol_check_tensor_size / eshkol_check_string_length / eshkol_stack_push /
-      eshkol_is_timed_out / eshkol_track_allocation have zero call sites outside their
-      own definitions. Documented as controls at docs/breakdown/RUNTIME_CONFIGURATION.md:27-33,
+      lib/core/resource_limits.cpp parses into g_limits and nothing consults it.
+      Exhaustive grep over lib/, inc/ and exe/ for eshkol_check_tensor_size,
+      eshkol_check_string_length, eshkol_is_timed_out and eshkol_track_allocation returns
+      15 hits: 11 declarations in inc/eshkol/core/resource_limits.h and 4 definitions in
+      lib/core/resource_limits.cpp. ZERO call sites anywhere else — the enforcement
+      functions are written, compiled, and never invoked. Documented as controls at docs/breakdown/RUNTIME_CONFIGURATION.md:27-33,
       docs/reference/runtime/environment-variables.md:65-73, docs/API_REFERENCE.md:4396-4402.
     caught_by: [pr-record-416, direct-measurement, doc-source-crosscheck]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -243,30 +243,30 @@ entries:
 
   - id: SW-15
     bucket: SILENT-WRONG
-    status: open
+    status: closed
+    closed_at: "9f2da2ab"
     title: "Out-of-range tensor-set! returns without writing, natively"
-    observed: "the lost write is undetectable by the program; the VM raises"
-    evidence: "tests/vm_parity/found/tensor_set_oob_silent_native.esk"
-    caught_by: [parity-baselines]
-    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    filed_claim: "the lost write is undetectable by the program; the VM raises"
+    measured: "both engines print 'caught' twice — native raises. The filed reproducer is STALE."
+    evidence: "tests/vm_parity/found/tensor_set_oob_silent_native.esk re-run at 9f2da2ab"
 
   - id: SW-16
     bucket: SILENT-WRONG
-    status: open
+    status: closed
+    closed_at: "9f2da2ab"
     title: "Multi-dimensional tensor-ref with an out-of-range component reads the wrong element, natively"
-    observed: "reads (0 2) of a 2x2 when the flat offset happens to land in range; the VM raises"
-    evidence: "tests/vm_parity/found/tensor_ref_component_oob_native.esk"
-    caught_by: [parity-baselines]
-    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    filed_claim: "reads (0 2) of a 2x2 when the flat offset happens to land in range; the VM raises"
+    measured: "both engines print 'caught' — native raises. The filed reproducer is STALE."
+    evidence: "tests/vm_parity/found/tensor_ref_component_oob_native.esk re-run at 9f2da2ab"
 
   - id: SW-17
     bucket: SILENT-WRONG
-    status: open
+    status: closed
+    closed_at: "9f2da2ab"
     title: "Native (tensor <rectangular nested collection>) flattens the outer level and zero-fills"
-    observed: "native #(0 0) shape (2); the VM builds the correct rank-N tensor"
-    evidence: "tests/vm_parity/found/tensor_nested_collection_native.esk"
-    caught_by: [parity-baselines, KNOWN_ISSUES]
-    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    filed_claim: "native #(0 0) shape (2); the VM builds the correct rank-N tensor"
+    measured: "both engines print #((1 2) (3 4)) with shape (2 2) — correct. The filed reproducer is STALE."
+    evidence: "tests/vm_parity/found/tensor_nested_collection_native.esk re-run at 9f2da2ab"
 
   - id: SW-18
     bucket: SILENT-WRONG
@@ -650,6 +650,26 @@ entries:
       - "provide is advisory; the compiler generates no linkage restriction (docs/breakdown/MODULE_SYSTEM.md:444)"
       - "manifold gyro-transport ships a first-order approximation with no signal (docs/reference/stdlib/manifold.md:144)"
     caught_by: [doc-source-crosscheck]
+
+  - id: DD-12
+    bucket: DOC-DEBT
+    status: open
+    title: "13 of the 38 filed vm_parity reproducers are stale and nothing re-verifies them"
+    measured: >-
+      Every file under tests/vm_parity/found/ was re-run on both engines at 9f2da2ab.
+      25 still diverge; 13 now AGREE and print the CORRECT value: exact_division_lost (1/3),
+      expt_bignum_to_float, float_display_1e10 (1e+10), force_returns_promise (3),
+      iota_returns_empty, map_two_lists_eskb_route, modulo_inexact_collapsed_vm,
+      splice_middle_order, tensor_nested_collection_native, tensor_ref_component_oob_native,
+      tensor_set_oob_silent_native, write_does_not_quote, and one further row.
+    evidence: ".scratch/flaw-ledger/found/results.txt"
+    caught_by: [direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, parity-baselines]
+    notes: >-
+      found/ is documented as evidence rather than gate input, so no harness ever re-runs it.
+      A filed reproducer that silently becomes stale is the mirror image of a silent defect:
+      it makes the project look worse than it is and, more dangerously, trains readers to
+      discount the 25 that are still real. Re-running found/ belongs in the parity gate.
 
   - id: DD-11
     bucket: DOC-DEBT

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -1,0 +1,656 @@
+# Silent-wrong flaw ledger — the release gate's input.
+#
+# CONTRACT
+#   A SILENT-WRONG flaw is one where the compiler, the VM, or the runtime
+#   produces a wrong value, a wrong derivative, or a wrong memory outcome
+#   with NO diagnostic and a zero exit status. The maintainer's release
+#   philosophy is that these are tag-blocking: a loud failure is honest, a
+#   silent one is a lie told to a consumer.
+#
+#   `scripts/gate_no_silent_wrong.py` reads this file and emits the
+#   `no_open_silent_wrong` runtime_event consumed by the
+#   `eshkol-compiler-readiness` and `v1.3-evolve` oracles in
+#   .icc/completion-oracles.yaml. The gate is PASS only when every entry
+#   whose `bucket` is SILENT-WRONG has `status: closed` or a `waiver` block
+#   with an owner, a reason and an expiry date that has not passed.
+#
+#   The gate FAILS CLOSED. A missing, unparseable or schema-invalid ledger
+#   is a FAIL, never a pass — absence of the ledger is not evidence of an
+#   absence of silent-wrong defects.
+#
+# INVARIANTS (the same discipline as .icc/doc-claims-allowlist.yaml)
+#   1. Every entry cites a reproducer that a reader can run, and the exact
+#      observed-vs-correct values. "Believed fixed" is not a status.
+#   2. A waiver is scaffolding with an expiry, not a tolerance. It names an
+#      owner, a reason, and a date. An expired waiver is a FAIL.
+#   3. Entries only close by measurement at a named SHA, recorded in
+#      `closed_at`. Closing by assertion is forbidden.
+#   4. Growth is a finding: a NEW SILENT-WRONG entry appearing in a PR must
+#      be justified in that PR's body.
+#   5. The buckets other than SILENT-WRONG are carried here for one ledger,
+#      one truth — but only SILENT-WRONG gates the release.
+
+schema: eshkol.silent_wrong_ledger.v1
+generated_at: "2026-08-12"
+measured_at_sha: "9f2da2ab"
+measured_with: "build/eshkol-run (RelWithDebInfo, LLVM 21, arm64-apple-darwin24.1.0), build/eshkol-vm-standalone-test"
+reproducer_root: ".scratch/flaw-ledger/repro"
+
+buckets:
+  SILENT-WRONG: "Wrong value / wrong derivative / wrong memory outcome, no diagnostic, exit 0. TAG-BLOCKING."
+  LOUD-ERROR: "Fails with a visible diagnostic, crash or non-zero exit. Bad, but honest. Sub-tagged cheap-fix or structural."
+  PARITY-RATCHET: "Engine divergence already tracked by a shrink-only ratchet gate."
+  DOC-DEBT: "Documentation claim versus measured reality; allowlisted or ledgered."
+  IN-FLIGHT: "Has an open PR or an active fix lane at the time of this cut."
+
+entries:
+
+  # ───────────────────────── SILENT-WRONG ─────────────────────────
+
+  - id: SW-01
+    bucket: SILENT-WRONG
+    status: open
+    title: "AD differentiates the shadowed global, not the parameter"
+    repro: "(define (f x) (* x x)) (define (g f x) (derivative f x)) (display (g (lambda (y) (* 2 y)) 3.0))"
+    observed: "native 6"
+    correct: "2"
+    cross_engine: "VM answers 2 (correct); native is the wrong side"
+    evidence: ".scratch/flaw-ledger/repro/sw_ad_shadow.esk; docs/KNOWN_ISSUES.md:249"
+    caught_by: [KNOWN_ISSUES, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ad_adversarial_fd_oracle]
+    notes: "Named in KNOWN_ISSUES as 'the highest-priority open AD defect'. No fix lane."
+
+  - id: SW-02
+    bucket: SILENT-WRONG
+    status: open
+    title: "map resolves the mapped procedure from the global table, ignoring a shadowing binding"
+    repro: "(define (scale x) (* x 100)) (define (apply-map scale lst) (map scale lst)) (display (apply-map (lambda (x) (+ x 10)) (list 1 2 3)))"
+    observed: "native (100 200 300)"
+    correct: "(11 12 13)"
+    cross_engine: "VM answers (11 12 13) (correct)"
+    evidence: "lib/backend/map_codegen.cpp; PR #420 body, 'Adjacent defects found, deliberately NOT fixed here'"
+    caught_by: [pr-record-420, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
+    notes: >-
+      #420 states a candidate guard on map_codegen.cpp was built and measured to be a
+      no-op, so the substitution happens upstream in name resolution. #420 does NOT fix
+      it and explicitly says it 'wants its own task' — this is NOT in flight.
+
+  - id: SW-03
+    bucket: SILENT-WRONG
+    status: open
+    title: "The Taylor tower cannot nest: derivative-n of derivative-n returns 0"
+    repro: "(define (f x) (* x x x x)) (display (derivative-n (lambda (y) (derivative-n f y 1)) 2.0 1))"
+    observed: "0"
+    correct: "48"
+    cross_engine: "VM errors (rc=1) — loud on that side"
+    evidence: ".scratch/flaw-ledger/repro/sw_taylor_nest.esk; docs/KNOWN_ISSUES.md:256"
+    caught_by: [KNOWN_ISSUES, pr-record-417, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: SW-04
+    bucket: SILENT-WRONG
+    status: open
+    title: "derivative-n applied to a derivative CLOSURE returns 0"
+    repro: "(define (f x) (* x x x x)) (define df (derivative f)) (display (derivative-n df 2.0 1))"
+    observed: "0"
+    correct: "48"
+    evidence: ".scratch/flaw-ledger/repro/sw_deriv_closure.esk; docs/KNOWN_ISSUES.md:288"
+    caught_by: [KNOWN_ISSUES, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: SW-05
+    bucket: SILENT-WRONG
+    status: open
+    title: "Curried gradient-of-gradient returns a zero matrix (ESH-0096)"
+    repro: "(define (f v) (* (vector-ref v 0) (vector-ref v 0) (vector-ref v 0))) (define g (gradient f)) (display (jacobian g (vector 2.0)))"
+    observed: "#((0))"
+    correct: "#((12)) — (hessian f (vector 2.0)) returns #((12)) on the same build"
+    evidence: ".scratch/flaw-ledger/repro/sw_gofg.esk; docs/KNOWN_ISSUES.md:279"
+    caught_by: [KNOWN_ISSUES, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, pr-record-416]
+    notes: >-
+      PR #416 measured ESH-0096 as CLOSED and proposed deleting the KNOWN_ISSUES entry.
+      Direct measurement at 9f2da2ab contradicts that for the curried jacobian route.
+      Do not accept #416's close of ESH-0096.
+
+  - id: SW-06
+    bucket: SILENT-WRONG
+    status: open
+    title: "diff on a quoted s-expression silently returns 0 on BOTH engines"
+    repro: "(display (diff '(* x x) 'x))"
+    observed: "native 0, VM 0"
+    correct: "a symbolic derivative, not 0"
+    evidence: ".scratch/flaw-ledger/repro/sw_diff_quoted.esk"
+    caught_by: [direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES, all-differential-gates]
+    notes: >-
+      Shared-defect blindness: both engines agree on the wrong answer, so no
+      native-vs-VM differential axis can ever see it. This is the class the P8
+      reference-free property oracles were meant to close.
+
+  - id: SW-07
+    bucket: SILENT-WRONG
+    status: open
+    title: "fg-marginal returns an empty result natively"
+    repro: "(define fg (make-factor-graph 2 2)) (display (fg-marginal fg 0))"
+    observed: "native (), VM #(0.5 0.5)"
+    correct: "#(0.5 0.5) — the uniform marginal"
+    evidence: ".scratch/flaw-ledger/repro/sw_fg_marginal.esk; PR #413 Follow-ups item 2"
+    caught_by: [pr-record-413, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
+    notes: "PR #413 explicitly leaves this alone. #413 is still OPEN, so even its factor-graph fixes are not in the cut."
+
+  - id: SW-08
+    bucket: SILENT-WRONG
+    status: open
+    title: "rationalize diverges between engines; the VM silently answers 0"
+    repro: "(display (rationalize (/ 1 3) 1/10000))"
+    observed: "native 1/3, VM 0"
+    correct: "1/3"
+    evidence: ".scratch/flaw-ledger/repro/sw_rationalize.esk"
+    caught_by: [direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES, numeric_exactness_oracle]
+
+  - id: SW-09
+    bucket: SILENT-WRONG
+    status: open
+    title: "Generic + over i128 answers 0 on the VM"
+    repro: "(define a (i128 5)) (define b (i128 7)) (display (+ a b))"
+    observed: "VM 0 (exit 0); native raises a type error (exit 1)"
+    correct: "12"
+    evidence: ".scratch/flaw-ledger/repro/sw_i128.esk; docs/KNOWN_ISSUES.md:262"
+    caught_by: [KNOWN_ISSUES, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, i128_native_type_oracle]
+    notes: "Native half is LOUD-ERROR (see LE-03); the VM half is the silent one."
+
+  - id: SW-10
+    bucket: SILENT-WRONG
+    status: open
+    title: "Seven documented resource-limit environment variables are accepted and never enforced"
+    repro: "ESHKOL_MAX_HEAP=1 ESHKOL_ENFORCE_LIMITS=1 eshkol-run -r a-20M-iteration-loop.esk"
+    observed: >-
+      Runs to completion, prints 199999990000000, exit 0. ESHKOL_TIMEOUT_MS=500 prints
+      'ERROR: Execution timeout: 500ms limit exceeded' and then runs to completion and exits 0.
+    correct: "The documented limit is applied, or the variable is documented as inert"
+    variables: [ESHKOL_MAX_HEAP, ESHKOL_TIMEOUT_MS, ESHKOL_MAX_STACK, ESHKOL_MAX_TENSOR_ELEMS, ESHKOL_MAX_STRING_LEN, ESHKOL_ENFORCE_LIMITS, ESHKOL_LIMIT_WARNINGS]
+    evidence: >-
+      lib/core/resource_limits.cpp parses into g_limits and nothing consults it;
+      eshkol_check_tensor_size / eshkol_check_string_length / eshkol_stack_push /
+      eshkol_is_timed_out / eshkol_track_allocation have zero call sites outside their
+      own definitions. Documented as controls at docs/breakdown/RUNTIME_CONFIGURATION.md:27-33,
+      docs/reference/runtime/environment-variables.md:65-73, docs/API_REFERENCE.md:4396-4402.
+    caught_by: [pr-record-416, direct-measurement, doc-source-crosscheck]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
+    notes: >-
+      A consumer setting a heap ceiling to contain untrusted code gets no containment
+      and no warning. #416 adds honest 'Accepted, not enforced in v1.3.4' status columns
+      but #416 is UNMERGED, so the cut still documents them as controls.
+
+  - id: SW-11
+    bucket: SILENT-WRONG
+    status: open
+    title: "(the <type> expr) is a runtime no-op, so a false ascription is never caught"
+    repro: "(display (the string (+ 1 2)))"
+    observed: "3, exit 0"
+    correct: "a type error, or a doc that does not call it an assertion"
+    evidence: ".scratch/flaw-ledger/repro/sw_the.esk; docs/FEATURE_MATRIX.md:72,804"
+    caught_by: [direct-measurement, doc-source-crosscheck]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    notes: "Documented as a 'trusted assertion to the checker; runtime no-op (byte-identical IR)'. Documented-by-design, but the word 'assertion' is the lie."
+
+  - id: SW-12
+    bucket: SILENT-WRONG
+    status: open
+    title: "Six tensor ops carry two independent backward implementations with no differential test between them"
+    ops: [matmul, layernorm, transpose, sum, embedding, attention]
+    evidence: >-
+      lib/backend/tensor_backward.cpp defines eshkol_backward_{matmul,layernorm,transpose,sum,embedding,attention};
+      lib/bridge/tensor_backward.cpp defines tensor_{matmul,layernorm,transpose,sum,embedding,attention}_backward.
+      tests/bridge/qllm_bridge_gradcheck_test.cpp gradchecks the BRIDGE half against finite
+      differences for matmul/gelu/softmax/layernorm/rmsnorm/silu/cross-entropy and explicitly
+      EXCLUDES attention and embedding. No test compares the two implementations on the same input.
+    caught_by: [direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, duplicate-implementations-detector]
+    notes: >-
+      ICC's duplicate-implementations detector did not flag this pair: the two files are
+      not textually similar, so a lexical clone detector cannot see a semantic duplicate.
+      That is a concrete ICC detector gap, not a scoping choice.
+
+  - id: SW-13
+    bucket: SILENT-WRONG
+    status: open
+    title: "WASM batch compile mis-evaluates the first macro when a program has two or more define-syntax forms"
+    observed: "(dbl 21) => (* 2 21) prints a garbage bignum, value varies per build"
+    correct: "42"
+    evidence: "tests/wasm_diff/EXCLUSIONS.tsv (XFAIL row, 16_define_syntax.esk); reaffirmed in PR #413 and #418"
+    caught_by: [parity-baselines, pr-record-413, pr-record-418]
+    missed_by: [icc-correctness-chain, icc-readiness]
+    notes: "Excused by an XFAIL row, so the wasm gate is green while the defect ships in the browser build."
+
+  - id: SW-14
+    bucket: SILENT-WRONG
+    status: open
+    title: "with-region on the VM never reclaims — silent unbounded memory growth"
+    observed: "A VM program using regions computes the right answer and never gets the memory back; the VM heap has no escape evacuator"
+    evidence: "docs/KNOWN_ISSUES.md:211"
+    caught_by: [KNOWN_ISSUES]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    notes: "Classified silent because a long-running VM process degrades with no diagnostic and exit 0."
+
+  - id: SW-15
+    bucket: SILENT-WRONG
+    status: open
+    title: "Out-of-range tensor-set! returns without writing, natively"
+    observed: "the lost write is undetectable by the program; the VM raises"
+    evidence: "tests/vm_parity/found/tensor_set_oob_silent_native.esk"
+    caught_by: [parity-baselines]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: SW-16
+    bucket: SILENT-WRONG
+    status: open
+    title: "Multi-dimensional tensor-ref with an out-of-range component reads the wrong element, natively"
+    observed: "reads (0 2) of a 2x2 when the flat offset happens to land in range; the VM raises"
+    evidence: "tests/vm_parity/found/tensor_ref_component_oob_native.esk"
+    caught_by: [parity-baselines]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: SW-17
+    bucket: SILENT-WRONG
+    status: open
+    title: "Native (tensor <rectangular nested collection>) flattens the outer level and zero-fills"
+    observed: "native #(0 0) shape (2); the VM builds the correct rank-N tensor"
+    evidence: "tests/vm_parity/found/tensor_nested_collection_native.esk"
+    caught_by: [parity-baselines, KNOWN_ISSUES]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: SW-18
+    bucket: SILENT-WRONG
+    status: open
+    title: "Exact rational arithmetic degrades to double once a bignum is involved (ESH-0105)"
+    evidence: "docs/KNOWN_ISSUES.md:371; tests/vm_parity/found/bignum_exact_rational.esk"
+    caught_by: [KNOWN_ISSUES, parity-baselines]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: SW-19
+    bucket: SILENT-WRONG
+    status: open
+    title: "A closure created inside a named-let loop that set!s a global loses the mutation (ESH-0094)"
+    evidence: "docs/KNOWN_ISSUES.md:333"
+    caught_by: [KNOWN_ISSUES]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: SW-20
+    bucket: SILENT-WRONG
+    status: open
+    title: "Second-order gradient through a NAMED inner function returns 0 (ESH-0078)"
+    observed: "0; the inline-lambda form works"
+    evidence: "tests/ad_oracle/README.md XKNOWN table, cells nest.gofg.*.s.named/lamvar"
+    caught_by: [ad-oracle-xknown]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    notes: >-
+      The oracle README self-documents a possible regression: 'the ledger marks this merged
+      via #95, but the acceptance shape still returns 0 on master — regressed or never fully fixed.'
+
+  - id: SW-21
+    bucket: SILENT-WRONG
+    status: open
+    title: "Vector-param gradient over an inner derivative returns zeros (ESH-0093)"
+    evidence: "tests/ad_oracle/README.md XKNOWN, cells nest.gofd.*.v2; tests/ad_oracle/generated/ad_oracle_nest_04.esk:98,100,106,108"
+    caught_by: [ad-oracle-xknown]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: SW-22
+    bucket: SILENT-WRONG
+    status: open
+    title: "eshkol_xla_broadcast does not validate broadcast compatibility"
+    evidence: "docs/breakdown/XLA_BACKEND.md:705"
+    caught_by: [doc-source-crosscheck]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: SW-23
+    bucket: SILENT-WRONG
+    status: open
+    title: "A confirmed native/VM divergence is excluded from every gate by README policy"
+    evidence: "tests/differential/found/003_global_set_from_function_lost.esk; tests/differential/README.md states found/ is evidence, not gate input"
+    caught_by: [parity-baselines]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  # ───────────────────────── IN-FLIGHT ─────────────────────────
+
+  - id: IF-01
+    bucket: IN-FLIGHT
+    silent_wrong_class: true
+    status: open
+    title: "AD capture reconstruction ignores lexical scope; the default JIT object cache miscompiles core.ad.guw"
+    observed: "in-process JIT returns -0.6868 where 0.9553 is correct; AOT segfaults"
+    fix_lane: "PR #420 (fix/jit-object-cache-miscompile) — OPEN, not in the cut"
+    evidence: "PR #420 body; tests/differential/corpus/42_ad_capture_global_shadow.esk; docs/guide/AUTOMATIC_DIFFERENTIATION.md carries ESHKOL_JIT_CACHE=0 eight times as a workaround"
+    caught_by: [pr-record-416, pr-record-420]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: IF-02
+    bucket: IN-FLIGHT
+    silent_wrong_class: true
+    status: open
+    title: "take/drop argument order is reversed between the native stdlib and the VM prelude"
+    fix_lane: "PR #418 — OPEN"
+    evidence: "lib/core/list/transform.esk:8,14 vs lib/backend/vm_prelude_source.h:80-81; PR #416 Escalation 4"
+    caught_by: [pr-record-416, pr-record-418]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: IF-03
+    bucket: IN-FLIGHT
+    silent_wrong_class: true
+    status: open
+    title: "Complex transcendentals reinterpret the complex heap pointer as a double"
+    fix_lane: "PR #419 — OPEN"
+    evidence: "lib/backend/llvm_codegen.cpp:14191-14223 routes through codegenMathFunction; PR #416 Escalation 1 calls it a memory-safety defect"
+    caught_by: [pr-record-416, pr-record-419]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, sanitizer-fuzz-lane]
+
+  - id: IF-04
+    bucket: IN-FLIGHT
+    silent_wrong_class: true
+    status: open
+    title: "inexact->exact loses precision"
+    observed: "returns 450359962737049/4503599627370496 (0.09999999999999987) for the documented case"
+    fix_lane: "PR #419 — OPEN"
+    evidence: "docs/ESHKOL_LANGUAGE_GUIDE.md:454; PR #416 Escalation 2"
+    caught_by: [pr-record-416, pr-record-419]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: IF-05
+    bucket: IN-FLIGHT
+    silent_wrong_class: true
+    status: open
+    title: "free-energy returns -0.0 on the VM and in the browser build regardless of evidence"
+    fix_lane: "PR #413 — OPEN"
+    evidence: "PR #413; PR #414 'Adjacent divergences found and NOT fixed here'; examples/consciousness.esk"
+    caught_by: [pr-record-413, pr-record-414]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: IF-06
+    bucket: IN-FLIGHT
+    silent_wrong_class: false
+    status: open
+    title: "A non-store value passed to a memory-store accessor SIGSEGVs at address 0"
+    fix_lane: "PR #418 — OPEN"
+    evidence: "lib/core/memory_store.esk; PR #416 Escalation 5. No test in tests/ exercises memory-store-append! at all."
+    caught_by: [pr-record-416]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: IF-07
+    bucket: IN-FLIGHT
+    silent_wrong_class: false
+    status: open
+    title: "void* is not accepted as an extern type name; it warns and silently defaults to int64"
+    fix_lane: "PR #418 — OPEN"
+    evidence: "mapStringToType in lib/backend/llvm_codegen.cpp; PR #416 Escalation 6"
+    caught_by: [pr-record-416]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  # ───────────────────────── LOUD-ERROR ─────────────────────────
+
+  - id: LE-01
+    bucket: LOUD-ERROR
+    subtag: structural
+    status: open
+    title: "Builtins are call-position-only; passing one as a first-class value SIGSEGVs (exit 139)"
+    repro: "(define (ap f a b) (f a b)) (display (ap string<? \"a\" \"b\"))"
+    observed: "SIGSEGV at address 0x0, exit 139"
+    affected_measured: ["string<?", "string>?", "string=?", "char<?", "char=?", "string-append", "vector-ref", "car", "expt", "min", "max"]
+    unaffected_measured: ["+", "<", "eq?"]
+    evidence: ".scratch/flaw-ledger/repro/fc_tmp.esk; tests/differential/corpus/37_sort.esk"
+    caught_by: [pr-record-420, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, KNOWN_ISSUES]
+    notes: >-
+      PR #420 describes this as 'Undefined variable'. At 9f2da2ab it is a SIGSEGV, which is
+      strictly worse, and it is a FAMILY, not one builtin. It is the failure_free blocker
+      that holds icc readiness at 77 on #420's branch.
+
+  - id: LE-02
+    bucket: LOUD-ERROR
+    subtag: structural
+    status: open
+    title: "hessian over a lambda capturing its enclosing function's parameter fails LLVM verification"
+    repro: "(define (hwrap q) (hessian (lambda (t) (* q t t t)) 2.0)) (display (hwrap 2.0))"
+    observed: "ERROR: LLVM module verification failed: Incorrect number of arguments passed to called function! exit 1"
+    evidence: "PR #420's tests/ad/ad_capture_global_shadow_test.esk lines 25-29 document it as NOT covered; hessian capture path in lib/backend/autodiff_codegen.cpp"
+    caught_by: [pr-record-420, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
+    notes: "NOT in flight. #420 explicitly excludes it so its own gate is not red for the wrong reason."
+
+  - id: LE-03
+    bucket: LOUD-ERROR
+    subtag: cheap-fix
+    status: open
+    title: "Generic + over i128 raises a type error natively"
+    observed: "Type error in +: expected number, vector, or tensor, got heap-object; exit 1"
+    evidence: ".scratch/flaw-ledger/repro/sw_i128.esk; docs/KNOWN_ISSUES.md:262"
+    caught_by: [KNOWN_ISSUES, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    notes: "Paired with SW-09, the silent VM half."
+
+  - id: LE-04
+    bucket: LOUD-ERROR
+    subtag: cheap-fix
+    status: open
+    title: "sort argument order is reversed between engines"
+    observed: "native accepts (sort lst <) and errors on (sort < lst) with 'cdr: argument is not a pair'; the VM is the exact mirror"
+    evidence: ".scratch/flaw-ledger/repro/sw_sort_order.esk, sw_sort_vmorder.esk; PR #418 body"
+    caught_by: [pr-record-418, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
+    notes: "Same class as IF-02 take/drop, but sort is NOT fixed by #418 and has no test."
+
+  - id: LE-05
+    bucket: LOUD-ERROR
+    subtag: structural
+    status: open
+    title: "(load \"path.esk\") is not resolvable on the VM lane"
+    observed: "vm-src: WARNING undefined variable 'load' then ERROR: calling non-function, fatal"
+    evidence: ".scratch/flaw-ledger/repro/sw_load_path.esk; docs/KNOWN_ISSUES.md:269"
+    caught_by: [KNOWN_ISSUES, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    notes: >-
+      KNOWN_ISSUES:269 says the VM 'silently ignores a path literal'. On the vm-src lane at
+      9f2da2ab it is LOUD. The doc overstates the severity; the entry needs correcting either way.
+
+  - id: LE-06
+    bucket: LOUD-ERROR
+    subtag: structural
+    status: open
+    title: "Vector-param AD op capturing a local function parameter fails LLVM verification (ESH-0097)"
+    observed: "PtrToInt source must be pointer, on both -r and AOT"
+    evidence: "tests/ad_oracle/README.md XKNOWN; docs/KNOWN_ISSUES.md:299"
+    caught_by: [KNOWN_ISSUES, ad-oracle-xknown]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: LE-07
+    bucket: LOUD-ERROR
+    subtag: structural
+    status: open
+    title: "VM frame overflow prints to stderr and then exits 0 with empty stdout"
+    evidence: "tests/vm_parity/found/frame_overflow_exit_zero.esk; tests/vm_parity/found/when_tail_call_no_tco.esk"
+    caught_by: [parity-baselines]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    notes: "Loud on stderr but exit 0 — silent to any caller that checks the exit status. Borderline SILENT-WRONG."
+
+  - id: LE-08
+    bucket: LOUD-ERROR
+    subtag: structural
+    status: open
+    title: "VM top-level mutual recursion grouping breaks on interleaved non-define expressions"
+    evidence: "docs/KNOWN_ISSUES.md:195"
+    caught_by: [KNOWN_ISSUES]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  # ───────────────────────── PARITY-RATCHET ─────────────────────────
+
+  - id: PR-01
+    bucket: PARITY-RATCHET
+    status: open
+    title: "ENGINE_PARITY_BASELINE.json excuses 10 divergent programs"
+    count: 10
+    evidence: "tests/vm_parity/ENGINE_PARITY_BASELINE.json; PR #414 body names each"
+    highest_priority: "tests/parser/test_function_shadowing.esk — a user + is ignored by opcode dispatch (VM 7, native 12)"
+    caught_by: [parity-baselines, pr-record-414]
+    missed_by: [icc-correctness-chain, icc-smoke]
+    notes: >-
+      The baseline stores program PATHS only — no operation, no per-engine outputs. Nothing in
+      the repo can reconstruct what diverges without a rebuild and a re-run. PR #413 would
+      ratchet 10 -> 8 but #413 is OPEN, so the cut carries 10.
+
+  - id: PR-02
+    bucket: PARITY-RATCHET
+    status: open
+    title: "SURFACE_BASELINE.tsv excuses 323 names native resolves and the VM does not"
+    count: 323
+    evidence: "tests/vm_parity/SURFACE_BASELINE.tsv"
+    caught_by: [parity-baselines]
+    notes: "All carry ledger status NO-ROW, i.e. absent from PARITY.tsv entirely, so the 956-row parity accounting understates the real delta by about a third."
+
+  - id: PR-03
+    bucket: PARITY-RATCHET
+    status: open
+    title: "arity_parity_baseline.json excuses 331 native-vs-VM divergence keys, 62 of them on correct-arity correct-type calls"
+    count: 331
+    correct_class_count: 62
+    evidence: "tests/escape_matrix/arity_parity_baseline.json"
+    caught_by: [parity-baselines]
+
+  - id: PR-04
+    bucket: PARITY-RATCHET
+    status: open
+    title: "five_way_baseline.json excuses doc/manifest/native/VM/provide disagreements including user-facing names"
+    evidence: "tests/escape_matrix/five_way_baseline.json; native_missing entries include force, region-open, hodge-star, geodesic-distance, tensor-reduce-sum"
+    caught_by: [parity-baselines]
+
+  - id: PR-05
+    bucket: PARITY-RATCHET
+    status: open
+    title: "PARITY.tsv carries 331 gap rows; 38 reproducers sit under tests/vm_parity/found/"
+    evidence: "tests/vm_parity/PARITY.tsv; tests/vm_parity/found/"
+    caught_by: [parity-baselines]
+
+  - id: PR-06
+    bucket: PARITY-RATCHET
+    status: open
+    title: "wasm EXCLUSIONS.tsv carries 1 XFAIL and 2 exclusions"
+    evidence: "tests/wasm_diff/EXCLUSIONS.tsv"
+    caught_by: [parity-baselines]
+    notes: "The XFAIL is SW-13, a silent wrong answer in the shipped browser build."
+
+  - id: PR-07
+    bucket: PARITY-RATCHET
+    status: open
+    title: "inexact->exact is an accepted permanent engine divergence: the VM reports a fatal error where native promotes to bignum"
+    evidence: "tests/vm_parity/PARITY.tsv inexact->exact row (added by PR #419, OPEN)"
+    caught_by: [pr-record-419]
+
+  - id: PR-08
+    bucket: PARITY-RATCHET
+    status: open
+    title: "Complex display format differs: native 2+i, VM 2+1i"
+    evidence: "tests/vm_parity/found/complex_display_format.esk (on #419's branch, OPEN)"
+    caught_by: [pr-record-419]
+
+  - id: PR-09
+    bucket: PARITY-RATCHET
+    status: open
+    title: "18 baselined ODR collisions and 57 dead guard tokens ship in the cut"
+    evidence: "icc odr-audit; icc guard-liveness; PR #414 verification table"
+    caught_by: [pr-record-414, icc-odr-audit]
+
+  # ───────────────────────── DOC-DEBT ─────────────────────────
+
+  - id: DD-01
+    bucket: DOC-DEBT
+    status: open
+    title: "77 doc claims are allowlisted against ICC's doc-typed-claims detector"
+    count: 77
+    evidence: ".icc/doc-claims-allowlist.yaml on branch docs/icc-doc-probe-v134 (PR #416, OPEN)"
+    breakdown: "69 DETECTOR-MISATTRIBUTION, 8 EXEMPT-HISTORICAL; zero describe a runtime defect"
+    caught_by: [pr-record-416]
+    notes: "The allowlist itself is not shipped — #416 is unmerged — so the cut has neither the allowlist nor the doc fixes."
+
+  - id: DD-02
+    bucket: DOC-DEBT
+    status: open
+    title: "91 wrong numeric claims that two prior ICC audit passes flagged were never fixed"
+    count: 91
+    evidence: "PR #416 headline finding; docs/DESIGN.md, docs/ESHKOL_V1_ARCHITECTURE.md, press/ESHKOL_PRESS_INFORMATION_SHEET.md, docs/breakdown/COMPILER_ARCHITECTURE.md"
+    caught_by: [pr-record-416, icc-doc-typed-claims]
+    notes: "Two of the affected files are press copy that ships with the release."
+
+  - id: DD-03
+    bucket: DOC-DEBT
+    status: open
+    title: "KNOWN_ISSUES.md parity counts are stale against the shipped PARITY.tsv"
+    evidence: "docs/KNOWN_ISSUES.md:379 says 951 rows / 578 supported / 329 gap; PARITY.tsv is 956 / 581 / 331"
+    caught_by: [direct-measurement]
+    missed_by: [icc-doc-typed-claims]
+
+  - id: DD-04
+    bucket: DOC-DEBT
+    status: open
+    title: "ESH-0095 is claimed resolved in KNOWN_ISSUES and still carried as an XKNOWN excuse in the AD oracle"
+    evidence: "docs/KNOWN_ISSUES.md:45 vs tests/ad_oracle/README.md XKNOWN table"
+    measured: "(hessian f (tensor 1.0 2.0)) returns #((2 0) (0 2)) correctly at 9f2da2ab — the XKNOWN excuse is stale and should be deleted"
+    caught_by: [direct-measurement]
+    missed_by: [icc-correctness-chain, icc-readiness]
+
+  - id: DD-05
+    bucket: DOC-DEBT
+    status: open
+    title: "PR #417 would re-introduce two now-false known-limitation claims into the docs and four into the public site"
+    evidence: "PR #417 adds 'Quoted pattern-variable queries never match' (fixed by merged #414) and 'Factor-graph free energy is wrong in the browser build only' (#413 shows it is VM-wide, not browser-only), plus four site/src/main.esk strings"
+    caught_by: [pr-record-414, pr-record-416, pr-record-417]
+    notes: "Merge-blocking for #417. Both #414 and #416 flag it in writing; nobody has edited #417's branch."
+
+  - id: DD-06
+    bucket: DOC-DEBT
+    status: open
+    title: "MEMORY_MANAGEMENT.md names a file that does not exist, links to a different one, and carries a line count 3.5x the real total"
+    evidence: "docs/breakdown/MEMORY_MANAGEMENT.md; introduced by merged PR #409, flagged by #416"
+    caught_by: [pr-record-416]
+
+  - id: DD-07
+    bucket: DOC-DEBT
+    status: open
+    title: "The merged doc-example harness has three defects that make it miss the files it was built to check"
+    evidence: "scripts/doc_audit/extract_examples.py EXPECT_RE matches only =>; check_output_blocks.py collect() skips only blank lines between fences; neither runner sets ESHKOL_JIT_CACHE=0. PR #411 is merged."
+    caught_by: [pr-record-416]
+
+  - id: DD-08
+    bucket: DOC-DEBT
+    status: open
+    title: "docs/TEST_COVERAGE.md per-suite counts are the v1.1-era inventory and have drifted"
+    evidence: "PR #417 adds the provenance note; #417 is OPEN"
+    caught_by: [pr-record-417]
+
+  - id: DD-09
+    bucket: DOC-DEBT
+    status: open
+    title: "Runtime limits are documented as controls in three places while being inert"
+    evidence: "See SW-10. The honest status columns exist only on #416's unmerged branch."
+    caught_by: [pr-record-416, direct-measurement]
+
+  - id: DD-10
+    bucket: DOC-DEBT
+    status: open
+    title: "Documented no-ops in shipped surface"
+    items:
+      - "eshkol-run -D NAME[=VALUE] accepted, no macro, no warning (docs/reference/runtime/eshkol-run.md:79)"
+      - "eshkol-run -fPIC accepted as a no-op (docs/reference/runtime/eshkol-run.md:39)"
+      - "provide is advisory; the compiler generates no linkage restriction (docs/breakdown/MODULE_SYSTEM.md:444)"
+      - "manifold gyro-transport ships a first-order approximation with no signal (docs/reference/stdlib/manifold.md:144)"
+    caught_by: [doc-source-crosscheck]
+
+  - id: DD-11
+    bucket: DOC-DEBT
+    status: open
+    title: "68 header symbols and 59 shipped .esk exports have no documentation anywhere"
+    evidence: "PR #416 Appendix A; the drafted doc comments were reverted and the patch kept only in an uncommitted .scratch path"
+    caught_by: [pr-record-416]

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -322,6 +322,28 @@ entries:
     caught_by: [parity-baselines]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
 
+  - id: SW-24
+    bucket: SILENT-WRONG
+    status: open
+    title: "The VM ignores a user redefinition of + : opcode dispatch bypasses the user binding"
+    repro: "(define + (lambda (a b) (* a b))) (display (+ 3 4))"
+    observed: "VM 7"
+    correct: "12 — native answers 12"
+    evidence: >-
+      tests/parser/test_function_shadowing.esk, run on both engines at 9f2da2ab. The test
+      prints its own verdict: native "PASS: Function shadowing works!", VM "FAIL: Expected 12".
+      The program is listed in ENGINE_PARITY_BASELINE.json divergent_programs, so the parity
+      gate is green while the test says FAIL out loud.
+    caught_by: [parity-baselines, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
+    notes: >-
+      THE SAME ROOT CLASS AS SW-01 AND SW-02. Name resolution does not respect shadowing,
+      and it surfaces on both engines in different subsystems: native ignores the shadowing
+      binding in AD (SW-01) and in map (SW-02); the VM ignores it in arithmetic opcode
+      dispatch (this entry). Treat the three as one defect family with one root cause, not
+      as three unrelated tickets. A user who redefines + gets a wrong number and no
+      diagnostic — the most basic Scheme capability there is.
+
   # ───────────────────────── IN-FLIGHT ─────────────────────────
 
   - id: IF-01
@@ -499,7 +521,13 @@ entries:
     title: "ENGINE_PARITY_BASELINE.json excuses 10 divergent programs"
     count: 10
     evidence: "tests/vm_parity/ENGINE_PARITY_BASELINE.json; PR #414 body names each"
-    highest_priority: "tests/parser/test_function_shadowing.esk — a user + is ignored by opcode dispatch (VM 7, native 12)"
+    highest_priority: "tests/parser/test_function_shadowing.esk — a user + is ignored by opcode dispatch (VM 7, native 12). Promoted to SW-24."
+    measured: >-
+      All 10 were re-run on both engines at 9f2da2ab. NINE diverge only in output FORMATTING
+      (the VM's newline-per-call behaviour splits lines differently); exactly ONE,
+      test_function_shadowing.esk, is a real VALUE divergence, and that program prints
+      "FAIL: Expected 12" on the VM while the gate stays green. The baseline conflates
+      cosmetic drift with a wrong answer and hides the wrong answer among nine harmless rows.
     caught_by: [parity-baselines, pr-record-414]
     missed_by: [icc-correctness-chain, icc-smoke]
     notes: >-

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -589,6 +589,28 @@ entries:
       a criterion: the gate needs a rising floor on constructs-with-evidence, not only a
       ceiling on new divergences.
 
+  - id: PR-11
+    bucket: PARITY-RATCHET
+    status: open
+    title: "The invariant named for silent wrong answers is an existence check, not a threshold check"
+    measured: >-
+      icc architecture-verify at 9f2da2ab: INV-engine-semantic-parity, kind "exercise",
+      severity critical, incident tag "vm-parity-silent-wrong-answer", grades PASS with the
+      detail "capability 'engine_semantic_parity' exercised within 30d (1 event(s))".
+      The single event it accepted carries the payload "113/1114 constructs with differential
+      evidence (10.14%), 10 divergent program(s), 0 new".
+    evidence: "icc architecture-verify --repo eshkol-v134-release --model .icc/architecture-model.yaml"
+    caught_by: [direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    notes: >-
+      The invariant whose incident name is literally vm-parity-silent-wrong-answer is
+      satisfied by ONE event existing inside a 30-day window, whatever that event says. It
+      would pass identically at 1 percent coverage. An "exercise" invariant proves a probe
+      RAN; it cannot prove the probe found anything, and severity critical on an existence
+      check reads as far stronger assurance than it delivers. Pair every exercise invariant
+      with a threshold on its own payload — this is the same shape as PR-10 and the two
+      should be fixed together.
+
   # ───────────────────────── DOC-DEBT ─────────────────────────
 
   - id: DD-01

--- a/scripts/gate_no_silent_wrong.py
+++ b/scripts/gate_no_silent_wrong.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Release gate: no open, unwaived SILENT-WRONG flaw may ship.
+
+Reads the silent-wrong flaw ledger (.icc/silent-wrong-ledger.yaml by default)
+and emits one ICC runtime_event into scripts/icc_traces/ so the
+`no_open_silent_wrong` criterion in .icc/completion-oracles.yaml can grade it.
+
+A SILENT-WRONG flaw is one where the compiler, the VM or the runtime produces
+a wrong value, a wrong derivative or a wrong memory outcome with no diagnostic
+and a zero exit status.  The maintainer's release rule is that these block the
+tag: a loud failure is honest, a silent one is a lie told to a consumer.
+
+Grading
+    PASS  every SILENT-WRONG entry is `status: closed`, or carries a `waiver`
+          with an owner, a reason and an `expires` date still in the future.
+          Entries in other buckets are reported but never gate.
+    FAIL  any SILENT-WRONG entry is open and unwaived, any waiver has expired
+          or is missing a required field, or the ledger is absent, unreadable,
+          unparseable or schema-invalid.
+
+The gate FAILS CLOSED on purpose.  A missing ledger is not evidence that no
+silent-wrong defects exist, and a readiness score computed without the ledger
+would be the exact class of false green this gate was added to prevent.
+
+Entries whose bucket is IN-FLIGHT but which carry `silent_wrong_class: true`
+are counted as SILENT-WRONG for gating: an open PR is not a fix, and the tag
+decision is about what the cut contains, not about what is being written.
+
+Usage
+    python3 scripts/gate_no_silent_wrong.py
+    python3 scripts/gate_no_silent_wrong.py --ledger path/to/ledger.yaml
+    python3 scripts/gate_no_silent_wrong.py --format json
+
+Exit status is 0 on PASS and 1 on FAIL, so the script also works as a plain
+CI step without ICC.
+
+Copyright (C) tsotchke
+SPDX-License-Identifier: MIT
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_LEDGER = os.path.join(REPO_ROOT, ".icc", "silent-wrong-ledger.yaml")
+DEFAULT_TRACE_DIR = os.path.join(REPO_ROOT, "scripts", "icc_traces")
+TRACE_BASENAME = "silent_wrong_gate.jsonl"
+
+EXPECTED_SCHEMA = "eshkol.silent_wrong_ledger.v1"
+GATING_BUCKET = "SILENT-WRONG"
+PROBE_ID = "no_open_silent_wrong"
+
+WAIVER_REQUIRED_FIELDS = ("owner", "reason", "expires")
+
+
+class LedgerError(Exception):
+    """The ledger could not be read, parsed or validated."""
+
+
+def _load_yaml(path: str) -> dict:
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise LedgerError(
+            "PyYAML is required to grade the silent-wrong ledger "
+            "(pip install pyyaml)"
+        ) from exc
+
+    if not os.path.isfile(path):
+        raise LedgerError(f"ledger not found at {path} (the gate fails closed)")
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+    except Exception as exc:
+        raise LedgerError(f"ledger at {path} is not parseable: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise LedgerError(f"ledger at {path} is not a mapping")
+    if data.get("schema") != EXPECTED_SCHEMA:
+        raise LedgerError(
+            f"ledger schema is {data.get('schema')!r}, expected {EXPECTED_SCHEMA!r}"
+        )
+    if not isinstance(data.get("entries"), list):
+        raise LedgerError("ledger has no `entries` list")
+    return data
+
+
+def _as_date(value) -> _dt.date:
+    if isinstance(value, _dt.datetime):
+        return value.date()
+    if isinstance(value, _dt.date):
+        return value
+    return _dt.date.fromisoformat(str(value).strip())
+
+
+def _gates(entry: dict) -> bool:
+    """Does this entry participate in the silent-wrong gate?"""
+    if entry.get("bucket") == GATING_BUCKET:
+        return True
+    return bool(entry.get("silent_wrong_class"))
+
+
+def grade(data: dict, today: _dt.date) -> dict:
+    blocking: list[dict] = []
+    waived: list[dict] = []
+    closed: list[dict] = []
+    invalid: list[dict] = []
+    by_bucket: dict[str, int] = {}
+
+    for raw in data["entries"]:
+        if not isinstance(raw, dict):
+            invalid.append({"id": "<non-mapping entry>", "why": "entry is not a mapping"})
+            continue
+
+        entry_id = raw.get("id", "<missing id>")
+        bucket = raw.get("bucket", "<missing bucket>")
+        by_bucket[bucket] = by_bucket.get(bucket, 0) + 1
+
+        if not _gates(raw):
+            continue
+
+        record = {"id": entry_id, "title": raw.get("title", ""), "bucket": bucket}
+
+        status = raw.get("status")
+        if status == "closed":
+            if not raw.get("closed_at"):
+                invalid.append({**record, "why": "status closed without closed_at SHA"})
+            else:
+                closed.append(record)
+            continue
+        if status != "open":
+            invalid.append({**record, "why": f"status must be open or closed, got {status!r}"})
+            continue
+
+        waiver = raw.get("waiver")
+        if not waiver:
+            blocking.append(record)
+            continue
+        if not isinstance(waiver, dict):
+            invalid.append({**record, "why": "waiver is not a mapping"})
+            continue
+
+        missing = [f for f in WAIVER_REQUIRED_FIELDS if not waiver.get(f)]
+        if missing:
+            invalid.append({**record, "why": f"waiver missing {', '.join(missing)}"})
+            continue
+        try:
+            expires = _as_date(waiver["expires"])
+        except Exception:
+            invalid.append({**record, "why": f"waiver expires is not an ISO date: {waiver['expires']!r}"})
+            continue
+        if expires < today:
+            invalid.append({**record, "why": f"waiver expired on {expires.isoformat()}"})
+            continue
+
+        waived.append({**record, "owner": waiver["owner"], "expires": expires.isoformat()})
+
+    passed = not blocking and not invalid
+    return {
+        "passed": passed,
+        "blocking": blocking,
+        "waived": waived,
+        "closed": closed,
+        "invalid": invalid,
+        "by_bucket": by_bucket,
+        "measured_at_sha": data.get("measured_at_sha"),
+        "generated_at": str(data.get("generated_at", "")),
+    }
+
+
+def emit_trace(trace_dir: str, status: str, snippet: str) -> str:
+    os.makedirs(trace_dir, exist_ok=True)
+    path = os.path.join(trace_dir, TRACE_BASENAME)
+    event = {
+        "kind": "eshkol_smoke",
+        "name": PROBE_ID,
+        "value": status,
+        "snippet": snippet[:2000],
+        "confidence": 1.0,
+    }
+    # Rewrite rather than append: a stale FAIL from an earlier run must not
+    # keep the failure_free invariant red after the ledger is cleaned up, and
+    # a stale PASS must never survive a ledger that has regressed.
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+    return path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--ledger", default=os.environ.get("ESHKOL_FLAW_LEDGER", DEFAULT_LEDGER))
+    parser.add_argument("--trace-dir", default=DEFAULT_TRACE_DIR)
+    parser.add_argument("--no-trace", action="store_true", help="grade only, write no trace")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+
+    try:
+        data = _load_yaml(args.ledger)
+        result = grade(data, _dt.date.today())
+    except LedgerError as exc:
+        snippet = f"silent-wrong ledger unusable: {exc}"
+        if not args.no_trace:
+            emit_trace(args.trace_dir, "FAIL", snippet)
+        if args.format == "json":
+            print(json.dumps({"passed": False, "error": str(exc)}, indent=2))
+        else:
+            print(f"no_open_silent_wrong: FAIL — {exc}", file=sys.stderr)
+        return 1
+
+    status = "PASS" if result["passed"] else "FAIL"
+    if result["passed"]:
+        snippet = (
+            f"no open unwaived SILENT-WRONG entries "
+            f"({len(result['closed'])} closed, {len(result['waived'])} waived) "
+            f"at {result['measured_at_sha']}"
+        )
+    else:
+        ids = ", ".join(e["id"] for e in result["blocking"]) or "none"
+        bad = ", ".join(f"{e['id']}:{e['why']}" for e in result["invalid"]) or "none"
+        snippet = (
+            f"{len(result['blocking'])} open unwaived SILENT-WRONG entries [{ids}]; "
+            f"{len(result['invalid'])} invalid [{bad}]"
+        )
+
+    if not args.no_trace:
+        emit_trace(args.trace_dir, status, snippet)
+
+    if args.format == "json":
+        print(json.dumps({"status": status, **result}, indent=2))
+    else:
+        print(f"no_open_silent_wrong: {status}")
+        print(f"  ledger      : {args.ledger}")
+        print(f"  measured at : {result['measured_at_sha']}")
+        for bucket, count in sorted(result["by_bucket"].items()):
+            print(f"  {bucket:<16}: {count}")
+        if result["blocking"]:
+            print("  BLOCKING (open, unwaived SILENT-WRONG):")
+            for entry in result["blocking"]:
+                print(f"    - {entry['id']}  {entry['title']}")
+        if result["invalid"]:
+            print("  INVALID (schema or waiver problem — treated as blocking):")
+            for entry in result["invalid"]:
+                print(f"    - {entry['id']}  {entry['why']}")
+        if result["waived"]:
+            print("  WAIVED (expiring):")
+            for entry in result["waived"]:
+                print(f"    - {entry['id']}  owner={entry['owner']} expires={entry['expires']}")
+
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -731,6 +731,22 @@ probe event_loop_works \
      echo "$aot" | grep -qE "^FAIL:" && exit 1;
      exit 0'
 
+# ───────────────────────────────────────────────────────────────────
+# Silent-wrong flaw gate. Every probe above certifies that something
+# WORKS; none of them can certify that nothing silently LIES. This one
+# grades .icc/silent-wrong-ledger.yaml — the enumeration of defects that
+# return a wrong value with no diagnostic and exit 0 — and is the gate
+# that holds the tag while any of them is open and unwaived. It fails
+# closed: a missing or unparseable ledger is a FAIL, never a pass.
+#
+# The grader writes its own trace file, so this probe deliberately runs
+# it with --no-trace and lets the probe helper emit the eshkol_smoke
+# event, keeping exactly one no_open_silent_wrong event in the bundle.
+# ───────────────────────────────────────────────────────────────────
+probe no_open_silent_wrong \
+    'No open, unwaived SILENT-WRONG flaw in .icc/silent-wrong-ledger.yaml (wrong value / wrong derivative / wrong memory outcome with no diagnostic and exit 0 is tag-blocking)' \
+    'cd "$REPO_ROOT"; python3 scripts/gate_no_silent_wrong.py --no-trace'
+
 echo
 echo "Trace written: $TRACE_FILE"
 echo "Probe summary: $((PROBE_TOTAL - PROBE_FAILURES))/$PROBE_TOTAL passed"


### PR DESCRIPTION
Stacked on #421, which owns `.icc/silent-wrong-ledger.yaml`. Marks SW-07 (`fg-marginal`) and SW-08 (`rationalize`) **closed**, `closed_at: 5b848fa4`, `fixed_by: PR #424` — with the measured evidence rather than an assertion, per the ledger's invariant 3.

`scripts/gate_no_silent_wrong.py` goes from **26 blocking entries to 24** on this ledger.

Both entries turned out to be more than the ledger recorded, and in both cases each engine was wrong on a different spelling, which is why nothing in the tree noticed:

- **SW-07** is four defects. The native result tensor's `dimensions[]` array was never written, so the *documented* `#(2 2)` form printed `#()` around a correct distribution (shape `(0)`). Native dims parsing accepted neither a list nor a bare scalar, so `'(2 2)` and the ledger's own `(make-factor-graph 2 2)` reproducer answered `()`. And the VM matched `HEAP_TENSOR` only, so a `#(2 2)` VECTOR literal fell through to its bare-scalar arm and built one zero-state variable, while a real scalar was read as a one-element dims list that clamped `num_vars` to 1.
- **SW-08** is two defects, one per engine. The VM read both arguments through the non-heap-aware `as_number()`, so every exact-rational input answered the exact integer `0`. Natively an exact-integer `x` was taken as its own answer whatever the tolerance, so `(rationalize 3 1)` answered `3` where R7RS-small 6.2.6 makes `2` the simplest rational in `[2,4]` — and where the VM already answered `2`.

The SW-07 notes record what #424 does **not** close: the three baselined logic-suite divergences (`inference_test.esk`, `continuous_learning.esk`, `workspace_test.esk`) are `fg-infer!`, `free-energy` and `ws-step!` defects, still divergent at 5b848fa4, so `ENGINE_PARITY_BASELINE.json`'s `divergent_programs` stays at 10.

Split out rather than committed onto `chore/no-silent-wrong-oracle` directly so #421's lane stays under its author's control.