### PR TITLE
fix(ad): hessian arity over parameter-capturing lambdas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3535,6 +3535,35 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
             TIMEOUT 600
             PASS_REGULAR_EXPRESSION "PASS: exact-coefficient Taylor tier"
             FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
+    # `hessian` over a lambda that CAPTURES free variables. A capturing lambda
+    # is lowered with one extra pointer parameter per capture; the scalar
+    # Hessian arm called it with the seeded jet ALONE, so
+    # `(define (hwrap q) (hessian (lambda (t) (* q t t t)) 2.0))` failed LLVM
+    # module verification ("Incorrect number of arguments passed to called
+    # function") on every route. BOTH lanes: the failure was a verifier abort
+    # in the JIT and a compile failure in AOT, and `laplacian` delegates to
+    # `hessian`, so both operators regress together.
+    add_test(
+        NAME hessian_capture_arity_runtime_smoke
+        COMMAND $<TARGET_FILE:eshkol-run>
+                -r "${CMAKE_CURRENT_SOURCE_DIR}/tests/ad/hessian_capture_arity_test.esk"
+                -L"${CMAKE_CURRENT_BINARY_DIR}"
+    )
+    set_tests_properties(hessian_capture_arity_runtime_smoke
+        PROPERTIES
+            TIMEOUT 300
+            PASS_REGULAR_EXPRESSION "PASS: hessian over parameter-capturing lambdas"
+            FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
+    add_test(
+        NAME hessian_capture_arity_aot_smoke
+        COMMAND sh -c
+            "'$<TARGET_FILE:eshkol-run>' -o '${CMAKE_CURRENT_BINARY_DIR}/hessian_capture_arity_aot' '${CMAKE_CURRENT_SOURCE_DIR}/tests/ad/hessian_capture_arity_test.esk' -L'${CMAKE_CURRENT_BINARY_DIR}' && '${CMAKE_CURRENT_BINARY_DIR}/hessian_capture_arity_aot'"
+    )
+    set_tests_properties(hessian_capture_arity_aot_smoke
+        PROPERTIES
+            TIMEOUT 600
+            PASS_REGULAR_EXPRESSION "PASS: hessian over parameter-capturing lambdas"
+            FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
     add_test(
         NAME empty_collection_runtime_smoke
         COMMAND $<TARGET_FILE:eshkol-run>

--- a/lib/backend/autodiff_codegen.cpp
+++ b/lib/backend/autodiff_codegen.cpp
@@ -9474,7 +9474,23 @@ llvm::Value* AutodiffCodegen::hessianJetPath(const eshkol_operations_t* op) {
 
             Value* fres;
             if (scalar_func_ptr) {
-                fres = ctx_.builder().CreateCall(scalar_func_ptr, {x_jet});
+                // A lambda with free variables is lowered with one EXTRA
+                // pointer parameter per capture, appended after its user
+                // arguments, and every caller must reconstruct them. This arm
+                // passed the seeded jet ALONE, so any capturing differentiand
+                // — the ordinary case of a lambda closing over its enclosing
+                // function's parameters, e.g.
+                //     (define (hwrap q) (hessian (lambda (t) (* q t t t)) 2.0))
+                // — emitted a call whose arity disagreed with the callee and
+                // failed LLVM module verification ("Incorrect number of
+                // arguments passed to called function"). Every other AD call
+                // site in this file already goes through the shared resolver
+                // (resolveGradientCaptures / loadCapturesForAutodiff); this one
+                // now does too. The call is a no-op when the callee has no
+                // captures, so the non-capturing scalar Hessian is unchanged.
+                std::vector<Value*> scalar_hess_args{x_jet};
+                resolveGradientCaptures(scalar_func_ptr, scalar_hess_args, "hessian-scalar");
+                fres = ctx_.builder().CreateCall(scalar_func_ptr, scalar_hess_args);
             } else {
                 fres = closure_call_callback_(hessian_closure_val, {x_jet}, "hessian-scalar", callback_context_);
             }

--- a/tests/ad/hessian_capture_arity_test.esk
+++ b/tests/ad/hessian_capture_arity_test.esk
@@ -1,0 +1,113 @@
+;;; tests/ad/hessian_capture_arity_test.esk
+;;; ─────────────────────────────────────────────────────────────────────────
+;;;  `hessian` over a lambda that CAPTURES free variables.
+;;;
+;;;  A lambda whose free variables are its enclosing function's parameters is
+;;;  lowered to an LLVM function with EXTRA parameters — one pointer per
+;;;  capture — after its single user argument. Every other AD call site in
+;;;  autodiff_codegen.cpp reconstructs those capture arguments before calling
+;;;  the differentiand (resolveGradientCaptures / loadCapturesForAutodiff).
+;;;  The SCALAR arm of hessianJetPath did not: it called the lambda with the
+;;;  seeded jet alone, so
+;;;
+;;;      (define (hwrap q) (hessian (lambda (t) (* q t t t)) 2.0))
+;;;
+;;;  failed LLVM module verification with
+;;;      "Incorrect number of arguments passed to called function"
+;;;  for ANY capturing lambda, with or without a shadowing global. Fixed by
+;;;  routing that call through the same shared capture resolver.
+;;;
+;;;  Covered here: 1, 2 and 3 captures; captures from a `let` rather than a
+;;;  parameter; a capture whose name also exists as a top-level global (the
+;;;  resolver must pick the LEXICALLY visible parameter); an exact point (the
+;;;  exact-tower route) as well as an inexact one; the vector-point
+;;;  forward-over-forward arm; and the multi-parameter arm.
+;;;
+;;;  Prints a PASS/FAIL summary and exits non-zero on any failure.
+;;; ─────────────────────────────────────────────────────────────────────────
+
+(define pass 0)
+(define fail 0)
+(define (approx= a b) (< (abs (- a b)) 1e-6))
+(define (chk label v)
+  (display "  [") (display (if v "PASS" "FAIL")) (display "] ")
+  (display label) (newline)
+  (if v (set! pass (+ pass 1)) (set! fail (+ fail 1))))
+
+;; ── 1 capture, inexact point ───────────────────────────────────────────────
+;; f(t) = q t^3 ; f''(t) = 6 q t ; at t = 2 -> 12 q
+(define (h1 q) (hessian (lambda (t) (* q t t t)) 2.0))
+(chk "1 capture, inexact point  (q=1.5 -> 18)" (approx= (h1 1.5) 18.0))
+(chk "1 capture, inexact point  (q=-2.0 -> -24)" (approx= (h1 -2.0) -24.0))
+
+;; ── 1 capture, EXACT point (exact-tower route) ─────────────────────────────
+(define (h1e q) (hessian (lambda (t) (* q t t t)) 2))
+(chk "1 capture, exact point    (q=1.5 -> 18)" (approx= (h1e 1.5) 18.0))
+
+;; ── 2 captures ─────────────────────────────────────────────────────────────
+;; f(t) = a t^2 + b t^3 ; f''(t) = 2a + 6 b t ; at t = 2 -> 2a + 12b
+(define (h2 a b) (hessian (lambda (t) (+ (* a t t) (* b t t t))) 2.0))
+(chk "2 captures (a=3,b=0.5 -> 12)" (approx= (h2 3.0 0.5) 12.0))
+
+;; ── 3 captures ─────────────────────────────────────────────────────────────
+;; f(t) = a t^2 + b t^3 + c t^4 ; f''(t) = 2a + 6 b t + 12 c t^2
+;; at t = 2 -> 2a + 12b + 48c
+(define (h3 a b c)
+  (hessian (lambda (t) (+ (* a t t) (* b t t t) (* c t t t t))) 2.0))
+(chk "3 captures (a=1,b=2,c=0.25 -> 38)" (approx= (h3 1.0 2.0 0.25) 38.0))
+
+;; ── capture of a LET binding, not a parameter ──────────────────────────────
+(define (h1let q)
+  (let ((k (* 2.0 q)))
+    (hessian (lambda (t) (* k t t t)) 2.0)))
+(chk "let-bound capture (q=1.5 -> 36)" (approx= (h1let 1.5) 36.0))
+
+;; ── capture whose name ALSO exists as a top-level global ───────────────────
+;; The lambda's free variable `qg` is the enclosing PARAMETER, which lexically
+;; shadows the global. Resolving the capture to the global would silently
+;; answer 12*100 = 1200 instead of 12*1.5 = 18.
+(define qg 100.0)
+(define (h1shadow qg) (hessian (lambda (t) (* qg t t t)) 2.0))
+(chk "capture shadows a global (-> 18, not 1200)" (approx= (h1shadow 1.5) 18.0))
+
+;; ── two AD operators over the same captures, in one function ───────────────
+;; Guards against the capture reconstruction being consumed by the first call.
+(define (h1twice q)
+  (+ (hessian (lambda (t) (* q t t t)) 2.0)
+     (hessian (lambda (t) (* q t t)) 3.0)))
+(chk "two hessians, same captures (q=1.5 -> 21)" (approx= (h1twice 1.5) 21.0))
+
+;; ── derivative/gradient agree with hessian on the same capturing lambda ────
+;; f'(t) = 3 q t^2 -> at t=2, q=1.5 : 18
+(define (d1 q) (derivative (lambda (t) (* q t t t)) 2.0))
+(chk "derivative of the same lambda (q=1.5 -> 18)" (approx= (d1 1.5) 18.0))
+
+;; ── laplacian delegates to hessian, so it inherits the same call ───────────
+;; Laplacian of a 1-D field IS f''(x).
+(define (l1 q) (laplacian (lambda (t) (* q t t t)) 2.0))
+(chk "laplacian of the same lambda (q=1.5 -> 18)" (approx= (l1 1.5) 18.0))
+
+;; ── VECTOR point, 1 capture (forward-over-forward arm) ─────────────────────
+;; f(v) = q * (v.v) ; H = 2q I
+(define (hvec q) (hessian (lambda (v) (* q (tensor-dot v v))) (vector 1.0 2.0)))
+(define hv (hvec 1.5))
+(chk "vector point H[0][0] = 3" (approx= (tensor-ref hv 0 0) 3.0))
+(chk "vector point H[1][1] = 3" (approx= (tensor-ref hv 1 1) 3.0))
+(chk "vector point H[0][1] = 0" (approx= (tensor-ref hv 0 1) 0.0))
+
+;; ── MULTI-PARAMETER loss with a capture (multi-param arm) ──────────────────
+;; f(x,y) = q x^2 + x y ; H = [[2q, 1],[1, 0]]
+(define (hmulti q)
+  (hessian (lambda (x y) (+ (* q x x) (* x y))) (vector 1.0 2.0)))
+(define hm (hmulti 1.5))
+(chk "multi-param H[0][0] = 3" (approx= (tensor-ref hm 0 0) 3.0))
+(chk "multi-param H[0][1] = 1" (approx= (tensor-ref hm 0 1) 1.0))
+(chk "multi-param H[1][1] = 0" (approx= (tensor-ref hm 1 1) 0.0))
+
+(newline)
+(display "Passed: ") (display pass) (newline)
+(display "Failed: ") (display fail) (newline)
+(if (= fail 0)
+    (begin (display "PASS: hessian over parameter-capturing lambdas") (newline))
+    (begin (display "FAIL: hessian over parameter-capturing lambdas") (newline)
+           (exit 1)))

--- a/tests/differential/corpus/43_ad_hessian_capture.esk
+++ b/tests/differential/corpus/43_ad_hessian_capture.esk
@@ -1,0 +1,35 @@
+;; automatic differentiation: hessian over a lambda that CAPTURES free variables
+;;
+;; The differentiated lambda's free variables are its enclosing function's
+;; parameters, so the lowered LLVM function carries extra capture parameters
+;; after its single user argument. The scalar hessian arm used to call it with
+;; the seeded jet alone ("Incorrect number of arguments passed to called
+;; function"). Self-contained: no require, runs on every axis.
+
+;; f(t) = q t^3  ->  f''(t) = 6 q t
+(define (h1 q) (hessian (lambda (t) (* q t t t)) 2.0))
+(display (h1 1.5)) (newline)
+(display (h1 -2.0)) (newline)
+
+;; f(t) = a t^2 + b t^3  ->  f''(t) = 2a + 6 b t
+(define (h2 a b) (hessian (lambda (t) (+ (* a t t) (* b t t t))) 2.0))
+(display (h2 3.0 0.5)) (newline)
+
+;; three captures: f(t) = a t^2 + b t^3 + c t^4
+(define (h3 a b c)
+  (hessian (lambda (t) (+ (* a t t) (* b t t t) (* c t t t t))) 2.0))
+(display (h3 1.0 2.0 0.25)) (newline)
+
+;; capture of a let binding rather than a parameter
+(define (h1let q)
+  (let ((k (* 2.0 q)))
+    (hessian (lambda (t) (* k t t t)) 2.0)))
+(display (h1let 1.5)) (newline)
+
+;; laplacian delegates to hessian, so it exercises the same call
+(define (l1 q) (laplacian (lambda (t) (* q t t t)) 2.0))
+(display (l1 1.5)) (newline)
+
+;; derivative over the same capturing lambda, for cross-operator agreement
+(define (d1 q) (derivative (lambda (t) (* q t t t)) 2.0))
+(display (d1 1.5)) (newline)


### PR DESCRIPTION
## What this is

`hessian` over a lambda that captures free variables did not compile. Any
program shaped like

```scheme
(define (hwrap q) (hessian (lambda (t) (* q t t t)) 2.0))
```

died in LLVM module verification with

```
Incorrect number of arguments passed to called function!
  %1070 = call %eshkol_tagged_value @__repl_batch_0_lambda_1(%eshkol_tagged_value %1069)
```

on every route — in-process JIT, the `-r` run cache, and direct AOT — with or
without any shadowing global. `laplacian` builds an `ESHKOL_HESSIAN_OP` and
calls `hessian()`, so it carried the same failure.

## Root cause

A lambda with free variables is lowered to an LLVM function carrying one
**extra pointer parameter per capture**, appended after its user arguments, and
every caller has to reconstruct those arguments from the enclosing scope.
`lib/backend/autodiff_codegen.cpp` does exactly that at every one of its
differentiand call sites — through `resolveGradientCaptures` (the derivative
monolith, `gradientJetPath`, the multi-parameter Hessian arm at 9594) or
`loadCapturesForAutodiff` (the Jacobian test/AD calls, the vector
forward-over-forward Hessian arm at 9968).

Every one but the **scalar arm of `hessianJetPath`**, which called the callee
with the seeded jet alone:

```cpp
fres = ctx_.builder().CreateCall(scalar_func_ptr, {x_jet});
```

That is a one-argument call to an (1 + n_captures)-parameter function, so it is
invalid IR the moment the differentiand captures anything. Nothing upstream
masked it: `hess_known_arity` is read from the **user** arity table, so a
`(lambda (t) …)` closing over `q` is correctly classified single-parameter and
correctly routed to the scalar arm — the arm just did not supply the captures.
This is a missing call, not a wrong one; there is no scoping component and no
shadowing global is required to trigger it.

## The fix

`lib/backend/autodiff_codegen.cpp:9475-9495` — the scalar arm now builds its
argument list and runs it through the same shared resolver as every other AD
call site:

```cpp
std::vector<Value*> scalar_hess_args{x_jet};
resolveGradientCaptures(scalar_func_ptr, scalar_hess_args, "hessian-scalar");
fres = ctx_.builder().CreateCall(scalar_func_ptr, scalar_hess_args);
```

`resolveGradientCaptures` returns immediately when the callee's parameter count
does not exceed the arguments already supplied, so a non-capturing scalar
Hessian emits byte-identical IR to before. Using the shared resolver rather than
a local reconstruction also means this site inherits the corrections that were
made to it — ESH-0070 local-before-global raw-name lookup, #296 transitive
`captured_<var>` forwarding, ESH-0221 TCO loop-carried allocas — instead of
becoming a fourth copy of the same loop that has to be fixed again later.

## Retro-catch

With only the 3-line call reverted and everything else held fixed, at this same
SHA:

| route | pre-fix | post-fix |
|---|---|---|
| `-r` in-process JIT (`ESHKOL_JIT_CACHE=0`) | verifier abort, exit 1 | 16/16 |
| `-r` with the run cache | verifier abort, exit 1 | 16/16 |
| direct AOT | compile failure, exit 1 | 16/16 |
| `tests/differential/corpus/43_ad_hessian_capture.esk` | verifier abort on every axis | all axis pairs agree |

The pre-fix diagnostic is verbatim the one reported.

## Tests

`tests/ad/hessian_capture_arity_test.esk` — 16 checks, registered in CTest on
both lanes (`hessian_capture_arity_runtime_smoke`,
`hessian_capture_arity_aot_smoke`). Covers 1, 2 and 3 captures; a capture that
is a `let` binding rather than a parameter; a capture whose name also exists as
a top-level global (the parameter must win, 18 not 1200); an exact point (the
exact-tower route) as well as an inexact one; two Hessians over the same
captures in one function; `derivative` and `laplacian` over the same capturing
lambda; the vector-point forward-over-forward arm; and the multi-parameter arm.
Every expected value is analytic.

`tests/differential/corpus/43_ad_hessian_capture.esk` — the escape analysis. The
corpus had AD programs (29, 30) and it had capture/shadowing programs, but it
had no `hessian` at all, which is why four independent execution axes never
disagreed about a program that could not be compiled on any of them. The file is
self-contained (no `require`) so it runs on all four native axes, and it also
runs green under `--with-vm`.

## Gates

| gate | result |
|---|---|
| `ctest` | **144/144** (142 pre-existing + the 2 added here) |
| `scripts/run_vm_parity.sh` | **144 passed, 0 failed** |
| `scripts/run_ad_oracle.sh` | **60/60** (0 xknown, 0 failed, 0 crashed, 0 hung) |
| `scripts/run_differential.sh` | **246/252 axis pairs across 42 programs**; the new `43_ad_hessian_capture.esk` passes all 6. The only divergent program is `37_sort.esk`, pre-existing since it was added and unrelated (`string<?` as a first-class value) |
| `scripts/run_icc_smoke.sh` | **58/58, gate PASS** (a first run read 57/58 only because `language_surface_coverage_floor` exits 2 without a `build-quantum/eshkol-run`; that runner was built and the probe passes) |
| `icc architecture-verify` | **9 PASS / 0 FAIL / 0 UNCHECKABLE** across 9 invariants, drift refs 0 |
| `icc readiness --target eshkol-compiler-readiness` (both trace routes) | **77**, blocked on exactly two criteria, **both pre-existing and unrelated**: `failure_free` (the five `37_sort.esk` differential events) and one `artifact_without_test_or_trace` contract gap at `scripts/doc_audit/run_examples.py:107` |
| `icc guard-diff` (lib/inc/exe) | PASS |
| `icc gate-semantics-audit` (lib/inc) | PASS, 0 findings |
| `icc source-drift` | not stale, 0 changed |
| `icc chain --preset engine-health --path-prefix lib/backend` | 4 steps MEASURED, 0 errored, 0 no-data; no finding on the changed lines |
| `icc pre-commit-check` | PASS, 0 blockers |

## Adjacent defect found, tracked separately (SW-01)

The **VM** resolves a lambda's free variable to a same-named top-level binding
instead of the enclosing function's parameter, with no AD involved:

```scheme
(define qg 100.0)
(define (g qg) ((lambda (t) (* qg t)) 2.0))
(g 1.5)   ; VM => 200, native => 3
```

Root cause located: `lib/backend/vm_compiler.c:2770` (read path) and `:2146`
(`set!` path) walk the enclosing-scope chain **outermost-first** —
`/* Search from the outermost scope inward */ for (int d = depth - 1; d >= 1; d--)`.
`chain[0]` is the current chunk and `chain[depth-1]` is `main`, and the VM binds
every top-level `define` to a stack slot in `main`, so the top-level binding is
found first and shadows the nearer enclosing one. That is the inverse of lexical
scoping, and it is systematic — it reproduces through a bare application, a
`let`-bound lambda and `map` alike.

Different engine, different subsystem, its own gate; it is being fixed on its own
branch rather than here, so this PR's retro-catch evidence stays about the one
defect it fixes. The shadowing case is therefore covered in the CTest file
(native) and kept out of the differential corpus file, so the corpus entry stays
correct on every axis it runs on rather than baking a known wrong VM answer into
a shared reference.
