### PR TITLE
fix(vm): resolve free variables to the nearest enclosing binding

### DIFF
--- a/lib/backend/vm_compiler.c
+++ b/lib/backend/vm_compiler.c
@@ -2143,7 +2143,10 @@ static void compile_form_set_bang(FuncChunk* c, Node* node, int tail) {
         for (FuncChunk* p = c; p && depth < 32; p = p->enclosing)
             chain[depth++] = p;
         int found = 0;
-        for (int d = depth - 1; d >= 1 && !found; d--) {
+        /* Nearest enclosing scope first — see the read path's note. Walking
+         * outermost-first made `set!` on a shadowed name assign the TOP-LEVEL
+         * binding rather than the nearer one the reference reads. */
+        for (int d = 1; d < depth && !found; d++) {
             int enc_slot = resolve_local(chain[d], name);
             if (enc_slot >= 0) {
                 /* Check if the source variable is boxed */
@@ -2768,8 +2771,16 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
             for (FuncChunk* p = c; p && depth < 32; p = p->enclosing)
                 chain[depth++] = p;
 
-            /* Search from the outermost scope inward */
-            for (int d = depth - 1; d >= 1; d--) {
+            /* Search from the NEAREST enclosing scope outward. chain[0] is the
+             * current chunk and chain[depth-1] is `main`, and the VM binds every
+             * top-level define to a stack slot in `main` (see resolve_local's
+             * note), so walking outermost-first resolved a free variable to the
+             * TOP-LEVEL binding whenever one shared its name — the inverse of
+             * lexical scoping. `(define qg 100.0) (define (g qg) ((lambda (t)
+             * (* qg t)) 2.0))` returned 200 instead of 3, silently, because the
+             * lambda captured main's `qg` rather than g's parameter. Nearest
+             * binding wins, as R7RS 4.1.1 requires. */
+            for (int d = 1; d < depth; d++) {
                 int enc_slot = resolve_local(chain[d], node->symbol);
                 if (enc_slot >= 0) {
                     /* Found at level d. Check if it's boxed at the source. */

--- a/tests/vm_parity/corpus/56_lexical_shadow_nearest_binding.esk
+++ b/tests/vm_parity/corpus/56_lexical_shadow_nearest_binding.esk
@@ -1,0 +1,94 @@
+;; R7RS 4.1.1 -- a free variable resolves to the NEAREST enclosing binding,
+;; identically on both substrates.
+;;
+;; "The variable must be bound ... it refers to the binding of the innermost
+;; region containing the variable reference."  A top-level define of the same
+;; name is the OUTERMOST such region, so it must lose to any enclosing
+;; parameter or let binding.
+;;
+;; The VM's upvalue resolver walked the enclosing FuncChunk chain
+;; outermost-first, and the VM binds every top-level define to a stack slot in
+;; `main` -- the outermost chunk -- so a lambda closing over its enclosing
+;; function's parameter captured the TOP-LEVEL binding whenever the two shared
+;; a name.  Silently: no diagnostic, a plausible number, wrong.  Native has
+;; always resolved these correctly, so every line below is a native-vs-VM
+;; differential.
+;;
+;; Numeric output only -- the VM prints a procedure as <closure@N> where native
+;; prints its source form, so no procedure is ever displayed here.
+
+;; ── the base case: parameter shadows a same-named global ──────────────────
+;; qg is 100 at the top level and 1.5 as g's parameter; the lambda closes over
+;; the parameter, so this is 1.5 * 2 = 3, not 100 * 2 = 200.
+(define qg 100.0)
+(define (g qg) ((lambda (t) (* qg t)) 2.0))
+(display (g 1.5))
+(newline)
+
+;; ── the same capture reached through a let-bound lambda ───────────────────
+(define (h qg) (let ((f (lambda (t) (* qg t)))) (f 2.0)))
+(display (h 1.5))
+(newline)
+
+;; ── and through a higher-order call, where the lambda escapes its scope ───
+(define (k qg) (car (map (lambda (t) (* qg t)) (list 2.0))))
+(display (k 1.5))
+(newline)
+
+;; ── a LET binding, not a parameter, shadowing the global ──────────────────
+(define zz 100.0)
+(define (m w) (let ((zz (* w 3.0))) ((lambda (t) (* zz t)) 2.0)))
+(display (m 1.5))
+(newline)
+
+;; ── three levels deep: the MIDDLE binding wins, not the outermost ─────────
+;; p is 100 at top level, 7 in outer, 2 in mid; the innermost lambda must see
+;; mid's 2, so 2 * 10 = 20.
+(define p 100)
+(define (outer p)
+  (define (mid p) ((lambda (t) (* p t)) 10))
+  (mid 2))
+(display (outer 7))
+(newline)
+
+;; ── set! through a shadowed name must NOT reach the top-level binding ─────
+;; The inner set! targets bump's parameter, so the top-level ss is untouched
+;; and still reads 100.  The VM's set! resolver walked the same chain in the
+;; same wrong order, so it assigned main's slot and this printed 101.
+;;
+;; Only the top-level binding is asserted here, deliberately.  Reading the
+;; mutated value BACK out of the parameter exercises a separate, pre-existing
+;; VM gap -- `set!` on a captured parameter from inside a closure does not
+;; propagate to the enclosing frame, so `(define (f n) ((lambda () (set! n (+ n
+;; 1)))) n)` returns the unincremented n on the VM and the incremented one
+;; natively, with no shadowing involved at all and on unmodified master.  That
+;; is a boxing/upvalue-writeback defect in its own right; asserting it here
+;; would make this file red for a defect it is not about.
+(define ss 100)
+(define (bump ss) ((lambda () (set! ss (+ ss 1)))) 0)
+(display (bump 5))
+(newline)
+(display ss)
+(newline)
+
+;; ── controls: capture that is NOT shadowed must still reach the global ────
+(define gonly 11)
+(define (uses-global x) ((lambda (t) (* gonly t)) x))
+(display (uses-global 3))
+(newline)
+
+;; ── control: ordinary enclosing capture with no same-named global ─────────
+(define (plain a) ((lambda (t) (+ a t)) 4))
+(display (plain 6))
+(newline)
+
+;; ── control: top-level self-recursion still resolves to itself ────────────
+(define (fact n) (if (< n 2) 1 (* n (fact (- n 1)))))
+(display (fact 5))
+(newline)
+
+;; ── control: a shadowing parameter that is itself passed on ───────────────
+(define acc 1000)
+(define (chain acc) ((lambda (t) ((lambda (u) (+ acc u)) t)) 5))
+(display (chain 20))
+(newline)


### PR DESCRIPTION
## What this is

The VM resolved a lambda's free variable to a same-named **top-level** binding
instead of the enclosing function's parameter. Silently — no diagnostic, a
plausible number, wrong:

```scheme
(define qg 100.0)
(define (g qg) ((lambda (t) (* qg t)) 2.0))
(g 1.5)        ; VM => 200, native => 3
```

It reproduces through a bare application, a `let`-bound lambda and `map` alike,
and it is not AD-specific — it was found while testing `hessian` over capturing
lambdas (#426) but has nothing to do with AD.

## Root cause

`lib/backend/vm_compiler.c` walks the enclosing `FuncChunk` chain to resolve a
name that is not a local of the current chunk. `chain[0]` is the current chunk
and `chain[depth-1]` is `main` — and the VM binds **every top-level define to a
stack slot in `main`** (see `resolve_local`'s own note at the top of the file).
Both walks started at the outermost end and returned on the first hit:

```c
/* Search from the outermost scope inward */
for (int d = depth - 1; d >= 1; d--) {          /* :2770 read path  */
for (int d = depth - 1; d >= 1 && !found; d--)  /* :2146 set! path  */
```

So the top-level binding was found first and shadowed the nearer one — the
inverse of the innermost-region rule in R7RS 4.1.1. The `set!` path had the same
walk, so a mutation through a shadowed name assigned the **top-level** binding:
the global in the example above came back `101` where native leaves it `100`.

## The fix

Both loops now search from the nearest enclosing scope outward
(`for (int d = 1; d < depth; d++)`). The relay loop that threads an upvalue
registration through each intermediate level is unchanged and is
order-independent once the source level is chosen.

**Nothing changes at chain depth 2** — a top-level procedure referring to another
top-level name, including self-recursion and mutual recursion — because there the
nearest and the outermost enclosing scope are the same chunk (`main`). Only depth
3 and deeper, a lambda nested inside a procedure, can differ, which is exactly
the shadowing case. That is why the blast radius is small despite the resolver
being on every non-local name.

## Retro-catch

`tests/vm_parity/corpus/56_lexical_shadow_nearest_binding.esk`, 11 displayed
values, run on the pre-fix and post-fix VM at this same SHA against native:

| | native | VM pre-fix | VM post-fix |
|---|---|---|---|
| parameter shadows global | 3 | **200** | 3 |
| via let-bound lambda | 3 | **200** | 3 |
| via `map` | 3 | **200** | 3 |
| let binding shadows global | 9 | **200** | 9 |
| three levels, middle wins | 20 | **1000** | 20 |
| `set!` must not reach top level | 100 | **101** | 100 |
| unshadowed global capture (control) | 33 | 33 | 33 |
| ordinary enclosing capture (control) | 10 | 10 | 10 |
| top-level self-recursion (control) | 120 | 120 | 120 |
| nested shadowing parameter | 25 | **1005** | 25 |

7 of 11 wrong before, all 11 agreeing after, and the three controls unchanged
throughout.

## Gates

| gate | result |
|---|---|
| `ctest` | **142/142** |
| `scripts/run_vm_parity.sh` | **148 passed, 0 failed** (144 pre-existing + the 4 contributed by the new corpus file) |
| `scripts/run_ad_oracle.sh` | **60/60** (0 xknown, 0 failed, 0 crashed, 0 hung) |
| `scripts/run_differential.sh --with-vm` | **280/287 axis pairs across 41 programs**; 2 divergent programs, **both pre-existing** — see below |
| `icc guard-diff` (lib/inc/exe) | PASS |
| `icc gate-semantics-audit` (lib/inc) | PASS, 0 findings |
| `icc source-drift` | not stale, 0 changed |
| `icc chain --preset engine-health --path-prefix lib/backend` | 4 steps MEASURED, 0 errored, 0 no-data; no finding on any changed line |
| `icc pre-commit-check` | PASS, 0 blockers |

The two divergent programs, both verified pre-existing rather than taken on
trust:

* `37_sort.esk` — the documented `string<?`-as-a-first-class-value defect,
  divergent since the file was added.
* `17_mutual_recursion.esk` — diverges **only** on the `vm-src-vs-vm-eskb` pair,
  which is the bytecode-serialization route, and only surfaces under the opt-in
  `--with-vm` axes. The pre-fix binary fails it identically: same error, same
  `pc=5202 sp=746 fp=743`. Its VM-source output is byte-identical before and
  after this change. A separate eskb defect.

## Adjacent defect found, NOT fixed here

`set!` on a captured parameter from inside a closure does not propagate back to
the enclosing frame on the VM:

```scheme
(define (f n) ((lambda () (set! n (+ n 1)))) n)
(f 5)          ; VM => 5, native => 6
```

No shadowing is involved, and it reproduces on unmodified master, so it is
independent of this change — a boxing/upvalue-writeback gap rather than a
resolution-order one. The new corpus file therefore asserts only that the
**top-level** binding is left alone by the shadowed `set!` (which this PR does
fix, 101 → 100) and deliberately does not read the mutated value back, so the
file is not red for a defect it is not about.
