### PR TITLE
fix(codegen): higher-order builtins ignore shadowing bindings

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -194,6 +194,10 @@ oracles:
           event_values: ["PASS"]
         severity: high
         label: 'AD capture scoping: a differentiand lambda capturing its enclosing function''s parameter is never substituted by a same-named top-level global — and the cached (-r AOT) and uncached (in-process JIT) routes produce byte-identical output (task #114)'
+          event_names: ["higher_order_shadowing_oracle"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'Lexical scope in higher-order builtins: map/for-each/filter/fold/reduce/remove call the shadowing binding (parameter or local), never a same-named top-level procedure — static procedure-operand resolution declines when locally shadowed, and the VM upvalue search is innermost-first; gated on JIT, AOT, and the standalone VM (ESH-0070 class)'
         action: ./scripts/run_icc_smoke.sh
       - runtime_event:
           event_kinds: [eshkol_smoke]

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -49,32 +49,81 @@ entries:
 
   - id: SW-01
     bucket: SILENT-WRONG
-    status: open
+    status: closed
+    closed_at: "c025e209"
+    closed_by: "PR #429 (branch fix/map-shadowing-resolution)"
     title: "AD differentiates the shadowed global, not the parameter"
     repro: "(define (f x) (* x x)) (define (g f x) (derivative f x)) (display (g (lambda (y) (* 2 y)) 3.0))"
     observed: "native 6"
     correct: "2"
     cross_engine: "VM answers 2 (correct); native is the wrong side"
-    evidence: ".scratch/flaw-ledger/repro/sw_ad_shadow.esk; docs/KNOWN_ISSUES.md:249"
+    observed_after: >-
+      both engines answer 2. The AD operators reach their differentiand through
+      resolveLambdaFunction, the same static procedure-operand resolution map and
+      reduce use, so the shared guard fixes AD and the higher-order builtins at
+      one site: isShadowedByLocalRuntimeBinding() (lib/backend/llvm_codegen.cpp)
+      declines static resolution when the name is bound to an llvm::Argument of
+      the current function or an AllocaInst it owns, and AD falls back to its
+      runtime-closure dispatch. The unshadowed static path is unchanged —
+      (derivative sqf 3.0) still resolves statically and still answers 6.
+    fixed_by: "PR #429 (branch fix/map-shadowing-resolution) — isShadowedByLocalRuntimeBinding() in lib/backend/llvm_codegen.cpp, resolveLambdaFunction VAR branch"
+    evidence: >-
+      tests/codegen/higher_order_shadowing_test.esk checks 'derivative-param-shadow'
+      (2.0) and 'derivative-global-static' (6.0) on the JIT and AOT ctest lanes;
+      tests/codegen/higher_order_shadowing_vm_test.esk pins the same pair on the VM;
+      tests/differential/corpus/45_higher_order_shadowing.esk agrees on every native
+      axis. Revert-validated: with isShadowedByLocalRuntimeBinding() forced to
+      return false and the compiler rebuilt, the shadowing shapes regress and the
+      builtin-name crossing shape SIGSEGVs; restored, all pass.
     caught_by: [KNOWN_ISSUES, direct-measurement]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ad_adversarial_fd_oracle]
-    notes: "Named in KNOWN_ISSUES as 'the highest-priority open AD defect'. No fix lane."
+    notes: >-
+      Named in KNOWN_ISSUES as 'the highest-priority open AD defect'. Closed as one
+      of the three-entry shadowing family SW-01 / SW-02 / SW-24 — one root cause
+      (name resolution ignoring lexical shadowing), two engines, three subsystems.
+      Gated by the higher_order_shadowing_oracle smoke probe (JIT + AOT + VM).
 
   - id: SW-02
     bucket: SILENT-WRONG
-    status: open
+    status: closed
+    closed_at: "c025e209"
+    closed_by: "PR #429 (branch fix/map-shadowing-resolution)"
     title: "map resolves the mapped procedure from the global table, ignoring a shadowing binding"
     repro: "(define (scale x) (* x 100)) (define (apply-map scale lst) (map scale lst)) (display (apply-map (lambda (x) (+ x 10)) (list 1 2 3)))"
     observed: "native (100 200 300)"
     correct: "(11 12 13)"
     cross_engine: "VM answers (11 12 13) (correct)"
-    evidence: "lib/backend/map_codegen.cpp; PR #420 body, 'Adjacent defects found, deliberately NOT fixed here'"
+    observed_after: >-
+      native answers (11 12 13). #420's finding was right about the mechanism: the
+      substitution happens upstream of map_codegen.cpp, in resolveLambdaFunction,
+      which is why a map-only guard measured as a no-op — the resolver ran first
+      on the non-capturing repro. BOTH sites needed the guard, plus a third:
+      MapCodegen::map's compile-time closure detection reads the GLOBAL <name>_func
+      entry independently of the resolver (so a shadowed CAPTURING top-level lambda
+      was substituted even with the resolver guarded), and codegenRemove's predicate
+      lookup did the same function_table / unscoped-_func scan. reduce gained the
+      runtime-closure fallback map already had, since declining static resolution
+      without one would have traded the silent wrong answer for a crash.
+    fixed_by: "PR #429 (branch fix/map-shadowing-resolution) — three native sites guarded by isShadowedByLocalRuntimeBinding(): resolveLambdaFunction, MapCodegen::map, codegenRemove"
+    evidence: >-
+      tests/codegen/higher_order_shadowing_test.esk, 26 checks across
+      map / for-each / filter / fold-left / fold-right / reduce / remove with
+      shadowing parameters, the capturing-global map shadow, let-bound shadows,
+      and the unshadowed static paths pinned so the guard cannot regress them
+      (ctest lanes higher_order_shadowing_{jit,aot}_smoke);
+      tests/differential/corpus/45_higher_order_shadowing.esk agrees on every
+      native axis. Revert-validated per SW-01.
     caught_by: [pr-record-420, direct-measurement]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
     notes: >-
-      #420 states a candidate guard on map_codegen.cpp was built and measured to be a
-      no-op, so the substitution happens upstream in name resolution. #420 does NOT fix
-      it and explicitly says it 'wants its own task' — this is NOT in flight.
+      Identical-by-construction on every native axis, so no differential pairing
+      could ever have seen it — every axis was wrong the same way. That is the
+      escape-analysis finding, and why the closing gate is a self-checking
+      expected-value test on three engines rather than an axis comparison.
+      Interaction pinned with PR #427 (first-class builtin wrappers): a local
+      binding of a BUILTIN name must beat the wrapper, and an unshadowed builtin
+      name must still reach it — both halves in the same test files and corpus
+      entry, on both engines.
 
   - id: SW-03
     bucket: SILENT-WRONG
@@ -456,16 +505,33 @@ entries:
 
   - id: SW-24
     bucket: SILENT-WRONG
-    status: open
+    status: closed
+    closed_at: "c025e209"
+    closed_by: "PR #429 (branch fix/map-shadowing-resolution)"
     title: "The VM ignores a user redefinition of + : opcode dispatch bypasses the user binding"
     repro: "(define + (lambda (a b) (* a b))) (display (+ 3 4))"
     observed: "VM 7"
     correct: "12 — native answers 12"
+    observed_after: >-
+      the VM answers 12, and tests/parser/test_function_shadowing.esk prints
+      "PASS: Function shadowing works!" on both engines. vm_head_user_rebound()
+      (lib/backend/vm_compiler.c) walks the scope chain before any of
+      compile_expr's builtin fast paths: a head symbol bound by USER code — a
+      local of any chunk on the chain, or a root-chunk slot at or above the
+      user-locals watermark — compiles as a plain call through that binding.
+      Preamble and prelude slots sit BELOW the watermark and keep the fast
+      paths, so the stdlib cannot be hijacked and the prelude compiles exactly
+      as before; a watermark of 0 means user code has not started, so nothing
+      counts as a rebinding while the prelude itself is being compiled.
+    fixed_by: "PR #429 (branch fix/map-shadowing-resolution) — vm_head_user_rebound() in lib/backend/vm_compiler.c"
     evidence: >-
-      tests/parser/test_function_shadowing.esk, run on both engines at 9f2da2ab. The test
-      prints its own verdict: native "PASS: Function shadowing works!", VM "FAIL: Expected 12".
-      The program is listed in ENGINE_PARITY_BASELINE.json divergent_programs, so the parity
-      gate is green while the test says FAIL out loud.
+      tests/codegen/operator_rebinding_test.esk on the JIT, AOT and VM ctest lanes
+      (operator_rebinding_{jit,aot,vm}_smoke);
+      tests/differential/corpus/46_operator_rebinding.esk on the native axes;
+      tests/parser/test_function_shadowing.esk REMOVED from
+      ENGINE_PARITY_BASELINE.json divergent_programs — the parity ratchet
+      tightens rather than the gate being told to expect the divergence.
+      Revert-validated: reverting vm_compiler.c alone reproduces VM 7.
     caught_by: [parity-baselines, direct-measurement]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
     notes: >-
@@ -474,7 +540,11 @@ entries:
       binding in AD (SW-01) and in map (SW-02); the VM ignores it in arithmetic opcode
       dispatch (this entry). Treat the three as one defect family with one root cause, not
       as three unrelated tickets. A user who redefines + gets a wrong number and no
-      diagnostic — the most basic Scheme capability there is.
+      diagnostic — the most basic Scheme capability there is. All three closed together
+      by PR #429. The VM's OTHER manifestation of the family — the upvalue search
+      walking the enclosing-scope chain outermost-first — was fixed separately by
+      PR #428 (tests/vm_parity/corpus/56_lexical_shadow_nearest_binding.esk); the two
+      changes touch different functions in vm_compiler.c and are independent.
 
   - id: SW-27
     bucket: SILENT-WRONG

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3073,6 +3073,62 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
             PASS_REGULAR_EXPRESSION "PASS: internal defines preserve source-order evaluation"
             FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
     endif()
+    # ESH-0070 class: higher-order builtins must respect shadowing bindings.
+    # Static procedure-operand resolution (resolveLambdaFunction, map's
+    # compile-time closure detection, remove's predicate lookup) used to
+    # consult function_table / unscoped <name>_func entries without checking
+    # whether the name is rebound in the current function, so
+    # `(define (apply-map fn lst) (map fn lst))` silently called a same-named
+    # top-level fn. Gated on JIT + AOT (the wrong substitution was
+    # compile-time, so both native lanes must agree) and, separately below,
+    # on the VM whose manifestation was outermost-first upvalue capture.
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/codegen/higher_order_shadowing_test.esk")
+        add_test(
+            NAME higher_order_shadowing_jit_smoke
+            COMMAND $<TARGET_FILE:eshkol-run> -r
+                    "${CMAKE_CURRENT_SOURCE_DIR}/tests/codegen/higher_order_shadowing_test.esk"
+                    -L"${CMAKE_CURRENT_BINARY_DIR}"
+        )
+        set_tests_properties(higher_order_shadowing_jit_smoke PROPERTIES
+            TIMEOUT 120
+            ENVIRONMENT "ESHKOL_JIT_CACHE=0"
+            PASS_REGULAR_EXPRESSION "PASS: higher-order shadowing"
+            FAIL_REGULAR_EXPRESSION "FAIL:|TOTAL FAILURES|LLVM module verification failed|fatal signal")
+        add_test(
+            NAME higher_order_shadowing_aot_smoke
+            COMMAND sh -c
+                "'$<TARGET_FILE:eshkol-run>' -o '${CMAKE_CURRENT_BINARY_DIR}/higher_order_shadowing_aot' '${CMAKE_CURRENT_SOURCE_DIR}/tests/codegen/higher_order_shadowing_test.esk' && '${CMAKE_CURRENT_BINARY_DIR}/higher_order_shadowing_aot'"
+        )
+        set_tests_properties(higher_order_shadowing_aot_smoke PROPERTIES
+            TIMEOUT 180
+            PASS_REGULAR_EXPRESSION "PASS: higher-order shadowing"
+            FAIL_REGULAR_EXPRESSION "FAIL:|TOTAL FAILURES|LLVM module verification failed|fatal signal")
+    endif()
+    # SW-24 (same ESH-0070 class, isolated shape): a user rebinding of an
+    # arithmetic builtin must shadow the builtin dispatch. The VM lane for
+    # this file is registered next to the standalone VM target.
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/codegen/operator_rebinding_test.esk")
+        add_test(
+            NAME operator_rebinding_jit_smoke
+            COMMAND $<TARGET_FILE:eshkol-run> -r
+                    "${CMAKE_CURRENT_SOURCE_DIR}/tests/codegen/operator_rebinding_test.esk"
+                    -L"${CMAKE_CURRENT_BINARY_DIR}"
+        )
+        set_tests_properties(operator_rebinding_jit_smoke PROPERTIES
+            TIMEOUT 120
+            ENVIRONMENT "ESHKOL_JIT_CACHE=0"
+            PASS_REGULAR_EXPRESSION "PASS: operator rebinding shadows builtin dispatch"
+            FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
+        add_test(
+            NAME operator_rebinding_aot_smoke
+            COMMAND sh -c
+                "'$<TARGET_FILE:eshkol-run>' -o '${CMAKE_CURRENT_BINARY_DIR}/operator_rebinding_aot' '${CMAKE_CURRENT_SOURCE_DIR}/tests/codegen/operator_rebinding_test.esk' && '${CMAKE_CURRENT_BINARY_DIR}/operator_rebinding_aot'"
+        )
+        set_tests_properties(operator_rebinding_aot_smoke PROPERTIES
+            TIMEOUT 180
+            PASS_REGULAR_EXPRESSION "PASS: operator rebinding shadows builtin dispatch"
+            FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
+    endif()
     add_test(
         NAME autodiff_tensor_reductions_runtime_smoke
         COMMAND $<TARGET_FILE:eshkol-run>
@@ -4542,6 +4598,40 @@ if(ESHKOL_BUILD_TESTS AND NOT WIN32)
             ENVIRONMENT "ESHKOL_VM_NO_DISASM=1"
             PASS_REGULAR_EXPRESSION "PASS: first-class variadics on the VM — 0 failures"
             FAIL_REGULAR_EXPRESSION "FAIL:|undefined variable|fatal runtime error")
+    # ESH-0070 class on the VM engine: the upvalue search in vm_compiler.c
+    # walked the enclosing-scope chain OUTERMOST first, so a nested lambda
+    # inside a function whose parameter shadowed a same-named top-level
+    # define captured the top-level binding (top-level defines are
+    # root-chunk slots). Companion to higher_order_shadowing_{jit,aot}_smoke
+    # on the native lanes; the file is held to the VM's verified subset.
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/codegen/higher_order_shadowing_vm_test.esk")
+        add_test(
+            NAME higher_order_shadowing_vm_smoke
+            COMMAND sh -c
+                "cd '${CMAKE_CURRENT_SOURCE_DIR}' && '$<TARGET_FILE:eshkol-vm-standalone-test>' tests/codegen/higher_order_shadowing_vm_test.esk"
+        )
+        set_tests_properties(higher_order_shadowing_vm_smoke
+            PROPERTIES
+                TIMEOUT 300
+                ENVIRONMENT "ESHKOL_VM_NO_DISASM=1"
+                PASS_REGULAR_EXPRESSION "PASS: higher-order shadowing \\(vm\\)"
+                FAIL_REGULAR_EXPRESSION "FAIL:|TOTAL FAILURES|undefined variable|fatal runtime error")
+    endif()
+    # SW-24 isolated shape on the VM engine — the engine the defect lived on
+    # ((+ 3 4) with a rebound + emitted OP_ADD and printed 7).
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/codegen/operator_rebinding_test.esk")
+        add_test(
+            NAME operator_rebinding_vm_smoke
+            COMMAND sh -c
+                "cd '${CMAKE_CURRENT_SOURCE_DIR}' && '$<TARGET_FILE:eshkol-vm-standalone-test>' tests/codegen/operator_rebinding_test.esk"
+        )
+        set_tests_properties(operator_rebinding_vm_smoke
+            PROPERTIES
+                TIMEOUT 300
+                ENVIRONMENT "ESHKOL_VM_NO_DISASM=1"
+                PASS_REGULAR_EXPRESSION "PASS: operator rebinding shadows builtin dispatch"
+                FAIL_REGULAR_EXPRESSION "FAIL:|undefined variable|fatal runtime error")
+    endif()
 endif()
 
 # R7RS-small 5.6.1: a `define-library` in the compilation unit being compiled

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -37511,15 +37511,23 @@ private:
         }
 
         Value* proc = resolveLambdaFunction(&op->call_op.variables[0], 2);
-        if (!proc) {
-            eshkol_error("Failed to resolve function for reduce");
-            return nullptr;
-        }
+        Function* proc_fn = proc ? dyn_cast<Function>(proc) : nullptr;
 
-        Function* proc_fn = dyn_cast<Function>(proc);
+        // RUNTIME CLOSURE FALLBACK (ESH-0070 class): when the procedure is
+        // not statically resolvable — a function parameter, a binding that
+        // shadows a same-named top-level function, or a closure produced at
+        // runtime — evaluate the operand and fold by calling the closure
+        // value per element, exactly as map does. Without this, reduce
+        // either substituted the shadowed global (silent wrong results) or
+        // emitted nothing for the call and crashed at runtime.
+        Value* proc_closure = nullptr;
         if (!proc_fn) {
-            eshkol_error("reduce function must be a procedure");
-            return nullptr;
+            proc_closure = codegenAST(&op->call_op.variables[0]);
+            if (!proc_closure) {
+                eshkol_error("Failed to resolve function for reduce");
+                return nullptr;
+            }
+            proc_closure = ensureTaggedValue(proc_closure);
         }
 
         Value* init_val = nullptr;
@@ -37596,8 +37604,16 @@ private:
         Value* elem = extractCarAsTaggedValue(curr);
         Value* acc = builder->CreateLoad(tagged_value_type, acc_ptr);
 
-        // Call proc(acc, elem)
-        Value* new_acc = builder->CreateCall(proc_fn, {acc, elem});
+        // Call proc(acc, elem) — direct call when statically resolved,
+        // closure dispatch otherwise (see fallback above).
+        Value* new_acc = proc_fn
+            ? builder->CreateCall(proc_fn, {acc, elem})
+            : codegenClosureCall(proc_closure, {acc, elem}, "reduce");
+        if (!new_acc) {
+            eshkol_error("reduce: closure dispatch failed");
+            return nullptr;
+        }
+        new_acc = ensureTaggedValue(new_acc);
         builder->CreateStore(new_acc, acc_ptr);
 
         // Move to next
@@ -38023,6 +38039,38 @@ private:
 
     
     // Helper function to resolve lambda/function from AST with arity-specific builtin handling
+    /**
+     * @brief True when @p name is lexically shadowed by a runtime binding of
+     *        the current function (ESH-0070 class).
+     *
+     * A function parameter (llvm::Argument) or local variable (AllocaInst
+     * owned by the current function) shadows any same-named top-level
+     * function. The unscoped <name>_func entries leak into every scope
+     * (preGenerateTopLevelLambdas writes both symbol_table and
+     * global_symbol_table) and function_table is global, so static
+     * procedure resolution MUST decline when this returns true — the only
+     * resolution that agrees with lexical scope is runtime dispatch on the
+     * local value. A scoped <current>.<name>_func entry exempts the name:
+     * it proves the local binding itself is a statically-known lambda
+     * (let-bound or local define), which static resolution handles
+     * correctly via the scoped lookup.
+     */
+    bool isShadowedByLocalRuntimeBinding(const std::string& name) {
+        if (!current_function) return false;
+        auto it = symbol_table.find(name);
+        if (it == symbol_table.end() || !it->second) return false;
+        Value* v = it->second;
+        bool is_param = isa<Argument>(v) &&
+            cast<Argument>(v)->getParent() == current_function;
+        bool is_local_alloca = isa<AllocaInst>(v) &&
+            cast<AllocaInst>(v)->getFunction() == current_function;
+        if (!is_param && !is_local_alloca) return false;
+        std::string scoped_key =
+            current_function->getName().str() + "." + name + "_func";
+        return symbol_table.find(scoped_key) == symbol_table.end() &&
+               global_symbol_table.find(scoped_key) == global_symbol_table.end();
+    }
+
     Value* resolveLambdaFunction(const eshkol_ast_t* func_ast, size_t required_arity = 0) {
         if (!func_ast) {
             eshkol_error("resolveLambdaFunction: func_ast is nullptr");
@@ -38088,6 +38136,26 @@ private:
         if (func_ast->type == ESHKOL_VAR) {
             std::string func_name = func_ast->variable.id;
             eshkol_debug("resolveLambdaFunction: looking for variable '%s'", func_name.c_str());
+
+            // SHADOWING GUARD (ESH-0070 class): a function parameter or local
+            // alloca binding lexically shadows any same-named top-level
+            // function, so the static lookups below would silently
+            // substitute the shadowed top-level function for the local
+            // binding — e.g.
+            //   (define fn (lambda (x) (* x 100)))
+            //   (define (apply-map fn lst) (map fn lst))   ; used global fn
+            // Decline static resolution — callers fall back to runtime
+            // closure dispatch on the local value, which is the only
+            // resolution that agrees with lexical scope. See
+            // isShadowedByLocalRuntimeBinding for the exemption that keeps
+            // let-bound / locally defined lambdas on the scoped static path.
+            if (isShadowedByLocalRuntimeBinding(func_name)) {
+                eshkol_debug("resolveLambdaFunction: '%s' is shadowed by a local "
+                             "binding in '%s' — deferring to runtime dispatch",
+                             func_name.c_str(),
+                             current_function->getName().str().c_str());
+                return nullptr;
+            }
 
             // BUILTIN FIRST-CLASS FIX: Check for builtin math functions FIRST before raw function_table lookup
             // These need wrapper functions that take/return tagged_value_type
@@ -38886,17 +38954,29 @@ private:
         } else if (first_arg->type == ESHKOL_VAR) {
             // Variable - check if it's a function
             std::string var_name = first_arg->variable.id;
-            // Check function table first
-            auto func_it = function_table.find(var_name);
-            if (func_it != function_table.end() && func_it->second) {
-                is_predicate = true;
-                pred_func = func_it->second;
-            } else {
-                // Check for lambda reference
-                auto sym_it = symbol_table.find(var_name + "_func");
-                if (sym_it != symbol_table.end()) {
-                    pred_func = dyn_cast<Function>(sym_it->second);
-                    is_predicate = (pred_func != nullptr);
+
+            // SHADOWING GUARD (ESH-0070 class): function_table and the
+            // unscoped <name>_func entries describe top-level bindings, so
+            // when the name is rebound to a runtime value in the current
+            // function (parameter or local alloca) the lookups below would
+            // substitute the shadowed global as the predicate. Decline
+            // static predicate resolution in that case: the local binding is
+            // a runtime value, and remove's element-based path compares
+            // against exactly that value — the same behavior a non-shadowed
+            // runtime argument gets today.
+            if (!isShadowedByLocalRuntimeBinding(var_name)) {
+                // Check function table first
+                auto func_it = function_table.find(var_name);
+                if (func_it != function_table.end() && func_it->second) {
+                    is_predicate = true;
+                    pred_func = func_it->second;
+                } else {
+                    // Check for lambda reference
+                    auto sym_it = symbol_table.find(var_name + "_func");
+                    if (sym_it != symbol_table.end()) {
+                        pred_func = dyn_cast<Function>(sym_it->second);
+                        is_predicate = (pred_func != nullptr);
+                    }
                 }
             }
         }
@@ -38905,12 +38985,24 @@ private:
         if (!list) return nullptr;
         Value* list_int = safeExtractInt64(list);
 
-        // For element-based removal, get the item value
+        // For non-static-predicate removal, evaluate the operand ONCE.
+        // The value may still be a procedure at runtime — a function
+        // parameter, a binding that shadows a same-named top-level function
+        // (ESH-0070 class), or a closure produced by a call — and SRFI-1
+        // remove semantics require calling it as the predicate. Keep the
+        // tagged value for a runtime CALLABLE dispatch alongside the
+        // element-equality path.
         Value* item_int = nullptr;
+        Value* item_tagged = nullptr;
+        Value* item_is_callable = nullptr;
         if (!is_predicate) {
             Value* item = codegenAST(&op->call_op.variables[0]);
             if (!item) return nullptr;
-            item_int = safeExtractInt64(item);
+            item_tagged = ensureTaggedValue(item);
+            item_int = safeExtractInt64(item_tagged);
+            Value* item_base = getBaseType(getTaggedValueType(item_tagged));
+            item_is_callable = builder->CreateICmpEQ(item_base,
+                ConstantInt::get(int8_type, ESHKOL_VALUE_CALLABLE));
         }
 
         Function* current_func = builder->GetInsertBlock()->getParent();
@@ -38959,12 +39051,39 @@ private:
             // Check if result is truthy (non-zero, non-false)
             Value* pred_result_int = safeExtractInt64(pred_result);
             is_match = builder->CreateICmpNE(pred_result_int, ConstantInt::get(int64_type, 0));
-        } else if (comparison_type == "equal" || comparison_type == "eqv") {
-            // Element-based: Value equality comparison
-            is_match = builder->CreateICmpEQ(input_element, item_int);
-        } else if (comparison_type == "eq") {
-            // Element-based: Pointer equality comparison
-            is_match = builder->CreateICmpEQ(input_element, item_int);
+        } else {
+            // Runtime dispatch (ESH-0070 class): the operand was not a
+            // statically-resolvable predicate — it may be a runtime
+            // procedure value (function parameter / shadowed binding /
+            // closure from a call) or a plain item. Branch on the tagged
+            // type: CALLABLE → call it as the predicate; anything else →
+            // element equality (eq/eqv/equal all compare the extracted
+            // value here, matching the previous behavior).
+            BasicBlock* pred_call_bb = BasicBlock::Create(*context, "remove_pred_call", current_func);
+            BasicBlock* item_cmp_bb = BasicBlock::Create(*context, "remove_item_cmp", current_func);
+            BasicBlock* match_merge_bb = BasicBlock::Create(*context, "remove_match_merge", current_func);
+            builder->CreateCondBr(item_is_callable, pred_call_bb, item_cmp_bb);
+
+            builder->SetInsertPoint(pred_call_bb);
+            Value* rt_pred_result = codegenClosureCall(item_tagged, {input_element_tagged}, "remove");
+            if (!rt_pred_result) {
+                eshkol_error("remove: closure dispatch failed");
+                return nullptr;
+            }
+            Value* rt_pred_int = safeExtractInt64(ensureTaggedValue(rt_pred_result));
+            Value* rt_pred_match = builder->CreateICmpNE(rt_pred_int, ConstantInt::get(int64_type, 0));
+            BasicBlock* pred_call_end = builder->GetInsertBlock();
+            builder->CreateBr(match_merge_bb);
+
+            builder->SetInsertPoint(item_cmp_bb);
+            Value* item_cmp_match = builder->CreateICmpEQ(input_element, item_int);
+            builder->CreateBr(match_merge_bb);
+
+            builder->SetInsertPoint(match_merge_bb);
+            PHINode* match_phi = builder->CreatePHI(int1_type, 2, "remove_is_match");
+            match_phi->addIncoming(rt_pred_match, pred_call_end);
+            match_phi->addIncoming(item_cmp_match, item_cmp_bb);
+            is_match = match_phi;
         }
 
         // If it matches (predicate true or equals item), skip it; otherwise keep it

--- a/lib/backend/map_codegen.cpp
+++ b/lib/backend/map_codegen.cpp
@@ -11,9 +11,11 @@
 #ifdef ESHKOL_LLVM_BACKEND_ENABLED
 
 #include <eshkol/logger.h>
+#include <llvm/IR/Argument.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Instructions.h>
 
 using namespace llvm;
 
@@ -128,7 +130,40 @@ Value* MapCodegen::map(const eshkol_operations_t* op) {
 
     // CLOSURE FIX: Check if the variable contains a closure (CLOSURE_PTR)
     // If so, we need to use mapWithClosure to properly extract captured values
-    if (op->call_op.variables[0].type == ESHKOL_VAR && global_symbol_table_ && nested_function_captures_) {
+    //
+    // SHADOWING GUARD (ESH-0070 class): this branch identifies the mapped
+    // procedure from the GLOBAL <name>_func entry, so a function parameter or
+    // local binding that shadows a same-named capturing top-level lambda
+    // would be silently replaced by the global. If the name is bound to a
+    // runtime value in the current function (Argument or local alloca), skip
+    // the compile-time global-closure detection entirely — the parameter /
+    // runtime-closure fallbacks below dispatch on the local value, which is
+    // the binding lexical scope selects. resolveLambdaFunction applies the
+    // same guard, so the two static paths agree.
+    bool proc_locally_shadowed = false;
+    if (op->call_op.variables[0].type == ESHKOL_VAR && symbol_table_ &&
+        current_function_ && *current_function_) {
+        auto shadow_it = symbol_table_->find(op->call_op.variables[0].variable.id);
+        if (shadow_it != symbol_table_->end() && shadow_it->second) {
+            Value* shadow_v = shadow_it->second;
+            bool is_param = isa<Argument>(shadow_v) &&
+                cast<Argument>(shadow_v)->getParent() == *current_function_;
+            bool is_local_alloca = isa<AllocaInst>(shadow_v) &&
+                cast<AllocaInst>(shadow_v)->getFunction() == *current_function_;
+            if (is_param || is_local_alloca) {
+                std::string shadow_scoped_key =
+                    (*current_function_)->getName().str() + "." +
+                    std::string(op->call_op.variables[0].variable.id) + "_func";
+                proc_locally_shadowed =
+                    symbol_table_->find(shadow_scoped_key) == symbol_table_->end() &&
+                    (!global_symbol_table_ ||
+                     global_symbol_table_->find(shadow_scoped_key) == global_symbol_table_->end());
+            }
+        }
+    }
+
+    if (!proc_locally_shadowed &&
+        op->call_op.variables[0].type == ESHKOL_VAR && global_symbol_table_ && nested_function_captures_) {
         std::string var_name = op->call_op.variables[0].variable.id;
 
         // Check if this variable is known to hold a closure at compile time

--- a/lib/backend/vm_compiler.c
+++ b/lib/backend/vm_compiler.c
@@ -208,6 +208,31 @@ static int vm_redefinition_target_slot(FuncChunk* c, const char* name) {
     return slot;
 }
 
+/** @return 1 when @p name is bound by USER code somewhere in scope — a
+ *          parameter or let/lambda local of any chunk on the scope chain, or
+ *          a root-chunk slot at or above the user-locals watermark.
+ *
+ * SW-24 (ESH-0070 class): the builtin-procedure fast paths in compile_expr
+ * (arithmetic/comparison opcodes, car/cdr chains, display, …) dispatch on
+ * the head SYMBOL alone, so `(define + (lambda (a b) (* a b))) (+ 3 4)`
+ * still emitted OP_ADD and printed 7. A user binding must shadow the fast
+ * path; the preamble/prelude's own bindings (root slots BELOW the
+ * watermark) must not, because the fast paths intentionally implement
+ * exactly those. A watermark of 0 means user code has not started yet (the
+ * prelude itself is being compiled), so nothing counts as a user rebinding.
+ */
+static int vm_head_user_rebound(FuncChunk* c, const char* name) {
+    for (FuncChunk* p = c; p; p = p->enclosing) {
+        int slot = resolve_local(p, name);
+        if (slot >= 0) {
+            if (p->enclosing == NULL)
+                return g_vm_user_locals_base > 0 && slot >= g_vm_user_locals_base;
+            return 1;
+        }
+    }
+    return 0;
+}
+
 static void compile_operands_tracked(FuncChunk* c, Node* node, int first, int last) {
     for (int i = first; i <= last; i++) {
         compile_expr(c, node->children[i], 0);
@@ -2851,6 +2876,38 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
     if (node->type != N_LIST || node->n_children == 0) { chunk_emit(c, OP_NIL, 0); return; }
 
     Node* head = node->children[0];
+
+    /* SW-24 (ESH-0070 class): every fast path below this point dispatches on
+     * the head SYMBOL alone, so a user binding that shadows a builtin name —
+     * `(define + (lambda (a b) (* a b)))`, `(let ((car ...)) ...)` — was
+     * silently bypassed and the opcode/native fast path ran instead
+     * ((+ 3 4) printed 7). If the head symbol resolves to a binding USER
+     * code created (see vm_head_user_rebound; preamble/prelude root slots
+     * below the watermark do not count), compile the form as a plain call
+     * through that binding — the same code the generic fallback at the end
+     * of this function emits. Macros were already dispatched above, so
+     * user-defined syntax is unaffected. */
+    if (head->type == N_SYMBOL && head->symbol &&
+        vm_head_user_rebound(c, head->symbol)) {
+        int argc = node->n_children - 1;
+        int saved_locals = c->n_locals;
+        compile_expr(c, head, 0);  /* push the (rebound) function */
+        add_local(c, "__call_func__");
+        for (int i = 1; i < node->n_children; i++) {
+            compile_expr(c, node->children[i], 0);
+            add_local(c, "__call_arg__");
+        }
+        if (vm_language_coverage_compilation_enabled()) {
+            chunk_emit(c, OP_LANGUAGE_COVERAGE_CALL,
+                       (int)vm_language_coverage_name_hash(head->symbol));
+        }
+        if (tail)
+            chunk_emit(c, OP_TAIL_CALL, argc);
+        else
+            chunk_emit(c, OP_CALL, argc);
+        c->n_locals = saved_locals; /* CALL consumed func+args */
+        return;
+    }
 
     if (is_sym(head, "gpu-matmul") && node->n_children == 3) {
         compile_expr(c, node->children[1], 0);

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -599,6 +599,30 @@ probe ad_capture_global_shadow_oracle 'AD capture reconstruction respects lexica
      d=$("$bin" 2>/dev/null); rd=$?; rm -f "$bin";
      [ "$rd" -eq 0 ] && [ "$d" = "$c" ] || exit 1;
      exit 0'
+# ESH-0070 class: higher-order builtins must respect shadowing bindings.
+# `(define (apply-map fn lst) (map fn lst))` with a same-named top-level fn
+# silently called the GLOBAL fn (map / reduce / remove — static
+# procedure-operand resolution never checked local shadowing; the VM's
+# outermost-first upvalue search had the same class of bug for nested-lambda
+# captures). Gated on JIT + AOT + the standalone VM in one probe because the
+# defect reproduced differently per engine and no differential axis could see
+# it — every engine was wrong the same way on the map case.
+probe higher_order_shadowing_oracle 'map/for-each/filter/fold/reduce/remove call the shadowing binding, not a same-named top-level procedure — JIT, AOT, and VM engines' \
+    'cd "$REPO_ROOT"; t=tests/codegen/higher_order_shadowing_test.esk;
+     a=$(ESHKOL_JIT_CACHE=0 "$ESHKOL_RUN" -r "$t" -L"$BUILD_DIR_PATH" 2>/dev/null) || exit 1;
+     printf "%s" "$a" | grep -q "PASS: higher-order shadowing" || exit 1;
+     printf "%s" "$a" | grep -q "FAIL:" && exit 1;
+     bin=$(mktemp) || exit 1;
+     "$ESHKOL_RUN" "$t" -o "$bin" -L"$BUILD_DIR_PATH" >/dev/null 2>&1 || { rm -f "$bin"; exit 1; };
+     b=$("$bin" 2>/dev/null); rb=$?; rm -f "$bin";
+     [ "$rb" -eq 0 ] || exit 1;
+     printf "%s" "$b" | grep -q "PASS: higher-order shadowing" || exit 1;
+     vm="$BUILD_DIR_PATH/eshkol-vm-standalone-test";
+     [ -x "$vm" ] || exit 1;
+     c=$(ESHKOL_VM_NO_DISASM=1 "$vm" tests/codegen/higher_order_shadowing_vm_test.esk 2>/dev/null) || exit 1;
+     printf "%s" "$c" | grep -q "PASS: higher-order shadowing (vm)" || exit 1;
+     printf "%s" "$c" | grep -q "FAIL:" && exit 1;
+     exit 0'
 probe linear_solve_full_f64_oracle 'linear-solve: mixed-precision IR dense solver reaches full-f64 residual (<=1e-12, computed in-test) on well-conditioned/identity systems and raises catchably on singular/dimension-mismatch — verified on JIT, AOT, and the VM' \
     'cd "$REPO_ROOT"; t=tests/features/linear_solve_test.esk;
      out=$(ESHKOL_PATH="$REPO_ROOT/lib" "$ESHKOL_RUN" -r "$t" 2>/dev/null) || exit 1;

--- a/tests/codegen/higher_order_shadowing_test.esk
+++ b/tests/codegen/higher_order_shadowing_test.esk
@@ -1,0 +1,206 @@
+;;; higher_order_shadowing_test.esk
+;;;
+;;; Higher-order builtins must respect shadowing bindings (ESH-0070 class).
+;;;
+;;; A function parameter (or local binding) that shadows a same-named
+;;; top-level procedure must be the procedure the higher-order builtin
+;;; calls. The static procedure-operand resolution (resolveLambdaFunction,
+;;; map's compile-time closure detection, remove's predicate lookup) used to
+;;; consult the global function_table / unscoped <name>_func entries without
+;;; checking local shadowing, so
+;;;
+;;;   (define fn (lambda (x) (* x 100)))
+;;;   (define (apply-map fn lst) (map fn lst))
+;;;   (apply-map (lambda (x) (+ x 10)) '(1 2 3))
+;;;
+;;; silently returned (100 200 300) instead of (11 12 13). reduce emitted a
+;;; call to the shadowed global with the wrong arity (module verification
+;;; failure), and remove used the shadowed global as its predicate.
+;;;
+;;; Every case below runs against a top-level `fn` that multiplies by 100;
+;;; the shadowing binding always adds 10, so a wrong resolution is loud.
+
+;; The decoy: every shadowing binding below must beat this.
+(define fn (lambda (x) (* x 100)))
+
+;; A capturing decoy for map's compile-time closure branch: it identifies
+;; the mapped procedure from the GLOBAL <name>_func entry when the global
+;; lambda has captures, which is a second, independent wrong-substitution
+;; site from resolveLambdaFunction.
+(define cap-k 100)
+(define gn (lambda (x) (* x cap-k)))
+
+(define failures 0)
+
+(define (check name got want)
+  (if (equal? got want)
+      #t
+      (begin
+        (display "FAIL: ") (display name)
+        (display " got ") (display got)
+        (display " want ") (display want) (newline)
+        (set! failures (+ failures 1))
+        #f)))
+
+;; 1. map with a shadowing parameter (was: used global fn => (100 200 300))
+(define (apply-map fn lst) (map fn lst))
+(check "map-param-shadow"
+       (apply-map (lambda (x) (+ x 10)) (list 1 2 3))
+       (list 11 12 13))
+
+;; 2. map with a shadowing parameter of a CAPTURING global (map's
+;;    compile-time closure branch; was: used global gn => (100 200 300))
+(define (apply-map-cap gn lst) (map gn lst))
+(check "map-param-shadow-capturing-global"
+       (apply-map-cap (lambda (x) (+ x 10)) (list 1 2 3))
+       (list 11 12 13))
+
+;; 3. map with an inline lambda whose body calls the shadowing parameter
+(define (apply-map-inner fn lst) (map (lambda (x) (fn x)) lst))
+(check "map-inner-lambda-shadow"
+       (apply-map-inner (lambda (x) (+ x 10)) (list 1 2 3))
+       (list 11 12 13))
+
+;; 4. for-each: nested lambda captures the shadowing parameter (this was
+;;    the VM manifestation: outermost-first upvalue search captured the
+;;    top-level fn instead of the parameter)
+(define fe-acc '())
+(define (apply-for-each fn lst)
+  (for-each (lambda (x) (set! fe-acc (cons (fn x) fe-acc))) lst))
+(apply-for-each (lambda (x) (+ x 10)) (list 1 2 3))
+(check "for-each-capture-shadow" (reverse fe-acc) (list 11 12 13))
+
+;; 5. for-each: shadowing parameter passed directly
+(define fe2-acc '())
+(define (collect x) (set! fe2-acc (cons x fe2-acc)))
+(define (apply-for-each2 fn lst) (for-each fn lst))
+(apply-for-each2 (lambda (x) (collect (+ x 10))) (list 1 2 3))
+(check "for-each-direct-shadow" (reverse fe2-acc) (list 11 12 13))
+
+;; 6. filter with a shadowing predicate parameter
+(define (apply-filter fn lst) (filter fn lst))
+(check "filter-param-shadow"
+       (apply-filter (lambda (x) (> x 1)) (list 1 2 3))
+       (list 2 3))
+
+;; 7. fold-left with a shadowing parameter
+(define (apply-fold fn lst) (fold-left fn 0 lst))
+(check "fold-left-param-shadow"
+       (apply-fold (lambda (acc x) (+ acc x 10)) (list 1 2 3))
+       36)
+
+;; 8. fold-right with a shadowing parameter
+(define (apply-fold-right fn lst) (fold-right fn 0 lst))
+(check "fold-right-param-shadow"
+       (apply-fold-right (lambda (x acc) (+ acc x 10)) (list 1 2 3))
+       36)
+
+;; 9. reduce with a shadowing parameter (was: called the shadowed global
+;;    with the wrong arity => LLVM module verification failure)
+(define (apply-reduce fn lst) (reduce fn 0 lst))
+(check "reduce-param-shadow"
+       (apply-reduce (lambda (acc x) (+ acc x 10)) (list 1 2 3))
+       36)
+
+;; 10. map with a let-bound shadow (this already worked via the scoped
+;;     <fn>.<name>_func entry — pinned so the guard never regresses it)
+(define (let-shadow-map lst)
+  (let ((fn (lambda (x) (+ x 10))))
+    (map fn lst)))
+(check "map-let-shadow" (let-shadow-map (list 1 2 3)) (list 11 12 13))
+
+;; 11. remove with a shadowing predicate parameter (was: used global fn as
+;;     the predicate — everything truthy => ())
+(define (apply-remove fn lst) (remove fn lst))
+(check "remove-param-shadow"
+       (apply-remove (lambda (x) (> x 1)) (list 1 2 3))
+       (list 1))
+
+;; 12. remove with a runtime ITEM parameter named like the global — the
+;;     shadowing binding is a plain value, so element-removal semantics
+;;     must apply (the same runtime dispatch must NOT call it)
+(define (apply-remove-item fn lst) (remove fn lst))
+(check "remove-item-param-shadow"
+       (apply-remove-item 2 (list 1 2 3))
+       (list 1 3))
+
+;; 13. derivative with a shadowing parameter (SW-01): the AD operators
+;;     resolve their differentiand through the same static
+;;     procedure-operand resolution, so (g (lambda (y) (* 2 y)) 3.0)
+;;     differentiated the GLOBAL f and returned 6 instead of 2
+(define (sqf x) (* x x))
+(define (apply-deriv sqf x) (derivative sqf x))
+(check "derivative-param-shadow"
+       (apply-deriv (lambda (y) (* 2 y)) 3.0)
+       2.0)
+(check "derivative-global-static" (derivative sqf 3.0) 6.0)
+
+;; 14. Non-shadowed static paths must be unchanged
+(check "map-global-static" (map fn (list 1 2 3)) (list 100 200 300))
+(check "map-capturing-global-static" (map gn (list 1 2 3)) (list 100 200 300))
+(define (pos? x) (> x 0))
+(check "remove-global-pred-static" (remove pos? (list 1 -2 3)) (list -2))
+(check "reduce-global-static" (reduce + 0 (list 1 2 3)) 6)
+
+;; 15. let-scoped rebinding of an arithmetic operator (SW-24 class): the
+;;     binding must shadow the operator inside the let body
+(define (let-rebound-star)
+  (let ((* (lambda (a b) (- a b))))
+    (* 10 4)))
+(check "let-rebound-operator" (let-rebound-star) 6)
+
+;; 16. INTERACTION WITH FIRST-CLASS BUILTINS (LE-01, the wrapper closures
+;;     codegenVariable synthesizes for builtins that codegenCall lowers
+;;     inline). Those wrappers make a bare builtin NAME denote a callable
+;;     value; this guard makes a local binding of that same name win. The two
+;;     must compose in one order only: every binding lookup first, the
+;;     builtin wrapper as the last resort. Both halves are pinned here — a
+;;     shadowed builtin name must reach the LOCAL binding, and an unshadowed
+;;     one must still reach the wrapper.
+(define (let-shadow-car lst)
+  (let ((car (lambda (x) 42)))
+    (map car lst)))
+(check "map-let-shadow-builtin" (let-shadow-car (list 1 2 3)) (list 42 42 42))
+
+(define (apply-map-car car lst) (map car lst))
+(check "map-param-shadow-builtin"
+       (apply-map-car (lambda (x) (+ x 10)) (list 1 2 3))
+       (list 11 12 13))
+
+(define (apply-filter-pair? pair? lst) (filter pair? lst))
+(check "filter-param-shadow-builtin"
+       (apply-filter-pair? (lambda (x) (> x 1)) (list 1 2 3))
+       (list 2 3))
+
+;; A shadowed builtin passed as a VALUE (not in call position) through a
+;; user higher-order procedure: `remainder` is one of the inline builtins
+;; whose first-class wrapper LE-01 added, so the parameter binding and the
+;; wrapper are competing for the same name.
+(define (call2 f a b) (f a b))
+(define (pass-shadowed-builtin remainder) (call2 remainder 7 3))
+(check "value-param-shadow-builtin"
+       (pass-shadowed-builtin (lambda (a b) (+ a b)))
+       10)
+
+(define (let-shadow-value)
+  (let ((remainder (lambda (a b) (* a b))))
+    (call2 remainder 7 3)))
+(check "value-let-shadow-builtin" (let-shadow-value) 21)
+
+;; The unshadowed side: the LE-01 wrapper must still be reached, so the
+;; guard cannot have been implemented by simply refusing builtin names.
+(check "value-builtin-unshadowed" (call2 remainder 7 3) 1)
+(check "map-builtin-unshadowed"
+       (map car (list (list 1 2) (list 3 4)))
+       (list 1 3))
+
+;; The SW-24 exact shape (top-level (define + (lambda (a b) (* a b)))) lives
+;; in tests/codegen/operator_rebinding_test.esk: rebinding + AFTER this
+;; file's many earlier uses of + trips a distinct, pre-existing
+;; rebind-after-use divergence (native hoists top-level lambda defines, so
+;; earlier uses already see the rebound +; the VM rebinds sequentially),
+;; which would mask the shadowing defect this file pins.
+
+(if (= failures 0)
+    (begin (display "PASS: higher-order shadowing") (newline))
+    (begin (display "TOTAL FAILURES: ") (display failures) (newline)))

--- a/tests/codegen/higher_order_shadowing_vm_test.esk
+++ b/tests/codegen/higher_order_shadowing_vm_test.esk
@@ -1,0 +1,145 @@
+;;; higher_order_shadowing_vm_test.esk
+;;;
+;;; VM-engine half of tests/codegen/higher_order_shadowing_test.esk, held to
+;;; the VM mini-compiler's verified subset (no `remove` there).
+;;;
+;;; The VM's manifestation of the ESH-0070-class defect was in upvalue
+;;; capture: vm_compiler.c searched the enclosing-scope chain OUTERMOST
+;;; first, so a nested lambda inside a function whose parameter shadowed a
+;;; same-named top-level define captured the TOP-LEVEL binding (top-level
+;;; defines are root-chunk slots). `(define (go fn lst) (for-each (lambda
+;;; (x) (fn x)) lst))` called the global fn. The direct `(map fn lst)` form
+;;; resolved correctly on the VM, so both shapes are pinned here.
+
+(define fn (lambda (x) (* x 100)))
+(define cap-k 100)
+(define gn (lambda (x) (* x cap-k)))
+
+(define failures 0)
+
+(define (check name got want)
+  (if (equal? got want)
+      #t
+      (begin
+        (display "FAIL: ") (display name)
+        (display " got ") (display got)
+        (display " want ") (display want)
+        (set! failures (+ failures 1))
+        #f)))
+
+;; 1. map with a shadowing parameter
+(define (apply-map fn lst) (map fn lst))
+(check "map-param-shadow"
+       (apply-map (lambda (x) (+ x 10)) (list 1 2 3))
+       (list 11 12 13))
+
+;; 2. map with a shadowing parameter of a capturing global
+(define (apply-map-cap gn lst) (map gn lst))
+(check "map-param-shadow-capturing-global"
+       (apply-map-cap (lambda (x) (+ x 10)) (list 1 2 3))
+       (list 11 12 13))
+
+;; The nested-lambda-captures-a-shadowing-parameter shapes (map with an
+;; inner lambda calling fn; for-each whose lambda captures fn) are the VM's
+;; OTHER manifestation of this class: the upvalue resolver walked the
+;; enclosing-scope chain outermost-first, so the lambda captured the
+;; TOP-LEVEL fn. That walk-order fix ships separately (read + set! paths,
+;; with tests/vm_parity/corpus/56_lexical_shadow_nearest_binding.esk); the
+;; native halves of those shapes stay pinned in
+;; tests/codegen/higher_order_shadowing_test.esk.
+
+;; 5. filter with a shadowing predicate parameter
+(define (apply-filter fn lst) (filter fn lst))
+(check "filter-param-shadow"
+       (apply-filter (lambda (x) (> x 1)) (list 1 2 3))
+       (list 2 3))
+
+;; 6. fold-left with a shadowing parameter
+(define (apply-fold fn lst) (fold-left fn 0 lst))
+(check "fold-left-param-shadow"
+       (apply-fold (lambda (acc x) (+ acc x 10)) (list 1 2 3))
+       36)
+
+;; 7. fold-right with a shadowing parameter
+(define (apply-fold-right fn lst) (fold-right fn 0 lst))
+(check "fold-right-param-shadow"
+       (apply-fold-right (lambda (x acc) (+ acc x 10)) (list 1 2 3))
+       36)
+
+;; 8. reduce with a shadowing parameter
+(define (apply-reduce fn lst) (reduce fn 0 lst))
+(check "reduce-param-shadow"
+       (apply-reduce (lambda (acc x) (+ acc x 10)) (list 1 2 3))
+       36)
+
+;; 9. let-bound shadow
+(define (let-shadow-map lst)
+  (let ((fn (lambda (x) (+ x 10))))
+    (map fn lst)))
+(check "map-let-shadow" (let-shadow-map (list 1 2 3)) (list 11 12 13))
+
+;; 10. derivative with a shadowing parameter (SW-01) — the VM resolved this
+;;     correctly already; pinned so both engines stay in agreement
+(define (sqf x) (* x x))
+(define (apply-deriv sqf x) (derivative sqf x))
+(check "derivative-param-shadow"
+       (apply-deriv (lambda (y) (* 2 y)) 3.0)
+       2.0)
+(check "derivative-global-static" (derivative sqf 3.0) 6.0)
+
+;; 11. Non-shadowed globals unchanged
+(check "map-global-static" (map fn (list 1 2 3)) (list 100 200 300))
+(check "map-capturing-global-static" (map gn (list 1 2 3)) (list 100 200 300))
+(check "reduce-global-static" (reduce + 0 (list 1 2 3)) 6)
+
+;; 12. let-scoped rebinding of an arithmetic operator (SW-24 class)
+(define (let-rebound-star)
+  (let ((* (lambda (a b) (- a b))))
+    (* 10 4)))
+(check "let-rebound-operator" (let-rebound-star) 6)
+
+;; 13. Interaction with first-class builtins. On the VM a builtin is a value
+;;     by construction (native dispatch table), so this side needs no
+;;     wrapper synthesis — which is exactly why it is worth pinning: the two
+;;     engines must agree that a local binding of a builtin NAME wins, and
+;;     that an unshadowed builtin name still denotes the builtin.
+(define (let-shadow-car lst)
+  (let ((car (lambda (x) 42)))
+    (map car lst)))
+(check "map-let-shadow-builtin" (let-shadow-car (list 1 2 3)) (list 42 42 42))
+
+(define (apply-map-car car lst) (map car lst))
+(check "map-param-shadow-builtin"
+       (apply-map-car (lambda (x) (+ x 10)) (list 1 2 3))
+       (list 11 12 13))
+
+(define (apply-filter-pair? pair? lst) (filter pair? lst))
+(check "filter-param-shadow-builtin"
+       (apply-filter-pair? (lambda (x) (> x 1)) (list 1 2 3))
+       (list 2 3))
+
+(define (call2 f a b) (f a b))
+(define (pass-shadowed-builtin remainder) (call2 remainder 7 3))
+(check "value-param-shadow-builtin"
+       (pass-shadowed-builtin (lambda (a b) (+ a b)))
+       10)
+
+(define (let-shadow-value)
+  (let ((remainder (lambda (a b) (* a b))))
+    (call2 remainder 7 3)))
+(check "value-let-shadow-builtin" (let-shadow-value) 21)
+
+(check "value-builtin-unshadowed" (call2 remainder 7 3) 1)
+(check "map-builtin-unshadowed"
+       (map car (list (list 1 2) (list 3 4)))
+       (list 1 3))
+
+;; The SW-24 exact shape (top-level + rebind, isolated) lives in
+;; tests/codegen/operator_rebinding_test.esk, which runs on BOTH engines:
+;; rebinding + after this file's earlier uses of + would trip the separate,
+;; pre-existing rebind-after-use hoisting divergence on the native engine,
+;; and the language-coverage sweep runs every tests/codegen/*.esk natively.
+
+(if (= failures 0)
+    (display "PASS: higher-order shadowing (vm)")
+    (begin (display "TOTAL FAILURES: ") (display failures)))

--- a/tests/codegen/operator_rebinding_test.esk
+++ b/tests/codegen/operator_rebinding_test.esk
@@ -1,0 +1,33 @@
+;;; operator_rebinding_test.esk — SW-24 (ESH-0070 class)
+;;;
+;;; A user rebinding of an arithmetic builtin must shadow the builtin
+;;; dispatch. The VM's opcode fast paths dispatched on the head SYMBOL
+;;; alone, so
+;;;
+;;;   (define + (lambda (a b) (* a b)))
+;;;   (+ 3 4)
+;;;
+;;; still emitted OP_ADD and produced 7 (tests/parser/test_function_shadowing.esk
+;;; printed its own FAIL on the VM while sitting greenlit on the engine-parity
+;;; baseline). Fixed by vm_head_user_rebound() in vm_compiler.c: a head symbol
+;;; bound by USER code (any scope-chain local, or a root slot at or above the
+;;; user-locals watermark) compiles as a plain call; preamble/prelude bindings
+;;; below the watermark keep the fast paths.
+;;;
+;;; This file holds the ISOLATED shape: + is rebound before any other use.
+;;; Rebinding + after earlier uses trips a distinct, pre-existing
+;;; rebind-after-use divergence (native hoists top-level lambda defines;
+;;; the VM rebinds sequentially), which is not this test's subject.
+
+(define (let-rebound-star)
+  (let ((* (lambda (a b) (- a b))))
+    (* 10 4)))
+(define lr (let-rebound-star))
+
+(define + (lambda (a b) (* a b)))
+(define tp (+ 3 4))
+
+(if (equal? (list lr tp) (list 6 12))
+    (display "PASS: operator rebinding shadows builtin dispatch")
+    (begin (display "FAIL: got ") (display (list lr tp)) (display " want (6 12)")))
+(newline)

--- a/tests/differential/corpus/45_higher_order_shadowing.esk
+++ b/tests/differential/corpus/45_higher_order_shadowing.esk
@@ -1,0 +1,87 @@
+;; Higher-order builtins vs shadowing bindings (ESH-0070 class).
+;; A parameter that shadows a same-named top-level procedure must be the
+;; procedure map/for-each/filter/fold/reduce call. All axes must agree AND
+;; be right: the global multiplies by 100, every shadow adds 10.
+(define fn (lambda (x) (* x 100)))
+(define cap-k 100)
+(define gn (lambda (x) (* x cap-k)))
+
+(define (apply-map fn lst) (map fn lst))
+(display (apply-map (lambda (x) (+ x 10)) (list 1 2 3))) (newline)
+
+(define (apply-map-cap gn lst) (map gn lst))
+(display (apply-map-cap (lambda (x) (+ x 10)) (list 1 2 3))) (newline)
+
+(define (apply-map-inner fn lst) (map (lambda (x) (fn x)) lst))
+(display (apply-map-inner (lambda (x) (+ x 10)) (list 1 2 3))) (newline)
+
+(define fe-acc '())
+(define (apply-for-each fn lst)
+  (for-each (lambda (x) (set! fe-acc (cons (fn x) fe-acc))) lst))
+(apply-for-each (lambda (x) (+ x 10)) (list 1 2 3))
+(display (reverse fe-acc)) (newline)
+
+(define (apply-filter fn lst) (filter fn lst))
+(display (apply-filter (lambda (x) (> x 1)) (list 1 2 3))) (newline)
+
+(define (apply-fold fn lst) (fold-left fn 0 lst))
+(display (apply-fold (lambda (acc x) (+ acc x 10)) (list 1 2 3))) (newline)
+
+(define (apply-reduce fn lst) (reduce fn 0 lst))
+(display (apply-reduce (lambda (acc x) (+ acc x 10)) (list 1 2 3))) (newline)
+
+(define (let-shadow-map lst)
+  (let ((fn (lambda (x) (+ x 10))))
+    (map fn lst)))
+(display (let-shadow-map (list 1 2 3))) (newline)
+
+(define (apply-remove fn lst) (remove fn lst))
+(display (apply-remove (lambda (x) (> x 1)) (list 1 2 3))) (newline)
+(display (apply-remove 2 (list 1 2 3))) (newline)
+
+;; derivative with a shadowing parameter (SW-01): same static resolution site
+(define (sqf x) (* x x))
+(define (apply-deriv sqf x) (derivative sqf x))
+(display (apply-deriv (lambda (y) (* 2 y)) 3.0)) (newline)
+(display (derivative sqf 3.0)) (newline)
+
+;; non-shadowed statics must stay static-and-right
+(display (map fn (list 1 2 3))) (newline)
+(display (map gn (list 1 2 3))) (newline)
+(display (reduce + 0 (list 1 2 3))) (newline)
+
+;; SW-24 class, let-scoped shape: an operator rebinding must shadow the
+;; builtin dispatch inside its scope. (The top-level + rebind lives in
+;; corpus/46_operator_rebinding.esk — rebinding + after this file's many
+;; earlier + uses trips the separate, pre-existing rebind-after-use
+;; hoisting divergence between the engines.)
+(define (let-rebound-star)
+  (let ((* (lambda (a b) (- a b))))
+    (* 10 4)))
+(display (let-rebound-star)) (newline)
+
+;; Crossing the first-class-builtin wrappers (LE-01): a local binding of a
+;; BUILTIN name must win over the wrapper, and an unshadowed builtin name
+;; must still reach it. Both halves on every axis.
+(define (let-shadow-car lst)
+  (let ((car (lambda (x) 42)))
+    (map car lst)))
+(display (let-shadow-car (list 1 2 3))) (newline)
+
+(define (apply-map-car car lst) (map car lst))
+(display (apply-map-car (lambda (x) (+ x 10)) (list 1 2 3))) (newline)
+
+(define (apply-filter-pair? pair? lst) (filter pair? lst))
+(display (apply-filter-pair? (lambda (x) (> x 1)) (list 1 2 3))) (newline)
+
+(define (call2 f a b) (f a b))
+(define (pass-shadowed-builtin remainder) (call2 remainder 7 3))
+(display (pass-shadowed-builtin (lambda (a b) (+ a b)))) (newline)
+
+(define (let-shadow-value)
+  (let ((remainder (lambda (a b) (* a b))))
+    (call2 remainder 7 3)))
+(display (let-shadow-value)) (newline)
+
+(display (call2 remainder 7 3)) (newline)
+(display (map car (list (list 1 2) (list 3 4)))) (newline)

--- a/tests/differential/corpus/46_operator_rebinding.esk
+++ b/tests/differential/corpus/46_operator_rebinding.esk
@@ -1,0 +1,11 @@
+;; SW-24 (ESH-0070 class): a user rebinding of an arithmetic builtin must
+;; shadow the builtin dispatch on every axis. Isolated shape only — + is
+;; rebound before any other use of + (rebind-after-use is a separate,
+;; pre-existing hoisting divergence between the engines).
+(define (let-rebound-star)
+  (let ((* (lambda (a b) (- a b))))
+    (* 10 4)))
+(display (let-rebound-star)) (newline)
+
+(define + (lambda (a b) (* a b)))
+(display (+ 3 4)) (newline)

--- a/tests/vm_parity/ENGINE_PARITY_BASELINE.json
+++ b/tests/vm_parity/ENGINE_PARITY_BASELINE.json
@@ -5,7 +5,6 @@
     "tests/logic/workspace_test.esk",
     "tests/parser/sexpr_test.esk",
     "tests/parser/special_forms_test.esk",
-    "tests/parser/test_function_shadowing.esk",
     "tests/v1_2_edge_cases/define_record_type_test.esk",
     "tests/v1_2_edge_cases/dual_scalar_compare_test.esk",
     "tests/v1_2_edge_cases/symbol_interning_test.esk"


### PR DESCRIPTION
## Defect

A function parameter or local binding that shadows a same-named top-level procedure was ignored by the higher-order builtins' procedure resolution:

```scheme
(define fn (lambda (x) (* x 100)))
(define (apply-map fn lst) (map fn lst))
(apply-map (lambda (x) (+ x 10)) '(1 2 3))   ; => (100 200 300), want (11 12 13)
```

Silent wrong results, and identical-by-construction on every native axis, so no differential pairing could see it.

## Root cause

**Native codegen — three sites, one shared root.** Static procedure-operand resolution consulted the global `function_table` / unscoped `<name>_func` entries without checking whether the name is rebound in the current function. The unscoped entries leak into every scope because `preGenerateTopLevelLambdas` writes them into `symbol_table` as well as `global_symbol_table` (llvm_codegen.cpp, `symbol_table[var_name + "_func"]` at pre-generation), so even a "local-first" lookup order finds the top-level lambda.

- `resolveLambdaFunction` (map's and reduce's static fast path) substituted the shadowed global. For `reduce` the global's arity then failed LLVM module verification; for `map` it was silent.
- `MapCodegen::map`'s compile-time closure detection identifies the mapped procedure from the **global** `<name>_func` entry, so a shadowed *capturing* top-level lambda was substituted independently of the resolver. (This is why a previous attempt that guarded only the map branch measured as a no-op: for the non-capturing repro the resolver ran first.)
- `codegenRemove`'s predicate lookup did the same `function_table` / unscoped-`_func` scan, so `(remove fn lst)` with a shadowing parameter used the global as the predicate.

**VM engine — two manifestations, one fixed here.** The first — upvalue capture and `set!` walking the enclosing-scope chain **outermost-first**, so a nested lambda inside a function whose parameter shadowed a top-level define captured the *top-level* binding (`(define (go fn lst) (for-each (lambda (x) (fn x)) lst))` called the global `fn`) — is fixed separately by #428 (`fix/vm-lexical-scope-innermost`), whose `corpus/56_lexical_shadow_nearest_binding.esk` pins those shapes. This PR deliberately does not duplicate that hunk; its VM-lane test keeps only shapes that pass without it, and the native halves of the capture shapes stay pinned in this PR's native test.

The second manifestation is fixed here: the builtin-procedure opcode fast paths dispatched on the head **symbol** alone: `(define + (lambda (a b) (* a b))) (+ 3 4)` still emitted `OP_ADD` and printed 7. The committed `tests/parser/test_function_shadowing.esk` literally prints its own FAIL on the VM and sat greenlit on the engine-parity baseline. Fixed with `vm_head_user_rebound()`: a head symbol bound by user code (any scope-chain local, or a root-chunk slot at or above the existing user-locals watermark) compiles as a plain call through that binding; preamble/prelude slots below the watermark keep the fast paths, so the stdlib cannot be hijacked and the prelude compiles exactly as before. This walk is orthogonal to #428's ordering fix (the opcode fast paths never reached name resolution at all), and either merge order is clean — the two changes touch different functions. The baseline entry for `test_function_shadowing.esk` is removed — the parity ratchet tightens.

## Fix

- New `isShadowedByLocalRuntimeBinding()` in llvm_codegen.cpp: true when the name is bound to an `llvm::Argument` of the current function or an `AllocaInst` it owns, and no scoped `<current>.<name>_func` entry marks the binding as a statically-known local lambda (that exemption keeps let-bound / locally defined lambdas on the scoped static path). All three sites decline static resolution when it holds and dispatch on the runtime closure value.
- `reduce` gains the runtime-closure fallback `map` already had — it previously had none, so declining static resolution would have traded the silent wrong result for a crash. Fold loop calls through `codegenClosureCall` when the procedure is a runtime value.
- `remove` now dispatches at runtime on the operand's tag: `CALLABLE` calls it as the predicate, anything else takes the existing element-equality path (SRFI-1 semantics; a runtime procedure argument never worked there before, shadowed or not — it fell into element comparison).
- VM: `vm_head_user_rebound()` in `vm_compiler.c` — see the SW-24 paragraph above. (The upvalue innermost-first walk that this branch originally also carried is #428's, now on master; the rebase drops the duplicate hunk, and `lib/backend/vm_compiler.c` here is SW-24 only.)

**Same site, also fixed: the AD operators.** `resolveLambdaFunction` serves `derivative`/`gradient` too, so `(define (g f x) (derivative f x))` with a same-named top-level `f` differentiated the global — native returned 6 where the correct answer is 2 (the VM was already right). The shared guard makes AD decline the static resolution and fall back to its runtime-closure dispatch; both engines now return 2. Pinned in all three test files (`derivative-param-shadow` / `derivative-global-static`).

## Blast radius checked

`for-each`, `filter`, `fold-left`, `fold-right` are stdlib closures whose procedure arguments flow through normal variable codegen, which is already shadow-correct on both engines — pinned by the new tests, no change needed. Call-position resolution (`(fn x)`) already had its own shadow detection and is untouched. `map` multi-list with a runtime closure keeps its existing single-list limitation (pre-existing, unrelated to shadowing).

Found while validating, pre-existing and unchanged by this PR:

- `tests/differential/corpus/37_sort.esk` failed on all native axes when this branch was cut (`string<?` was not resolvable as a first-class value under `-r`). **#427 fixed it on master**, so after the rebase the differential corpus has no divergences at all.
- Rebinding `+` **after** earlier uses of `+` diverges between the engines: native hoists top-level lambda defines (pre-generation), so the earlier uses already see the rebound `+` (`(reduce + 0 '(1 2 3))` before the rebind returns 0, and a plain earlier `(+ 1 2)` errors with "variable '+' is not a procedure"); the VM rebinds sequentially per R7RS 5.3.1. The new tests use the isolated shape (rebind before first use) so they gate the shadowing defect, not this hoisting divergence.

## Tests

- `tests/codegen/higher_order_shadowing_test.esk` — 26 checks (map/for-each/filter/fold-left/fold-right/reduce/remove/derivative with shadowing parameters, capturing-global map shadow, let-bound shadow, let-scoped operator rebind, runtime item-parameter remove, the #427 builtin-name crossing shapes below, and non-shadowed static paths pinned) — ctest lanes `higher_order_shadowing_jit_smoke` + `higher_order_shadowing_aot_smoke`.
- `tests/codegen/higher_order_shadowing_vm_test.esk` — 20 checks, the VM-subset version (the nested-capture shapes are #428's `corpus/56_lexical_shadow_nearest_binding.esk`), ctest lane `higher_order_shadowing_vm_smoke`.
- `tests/codegen/operator_rebinding_test.esk` — SW-24 isolated shape on JIT + AOT + VM ctest lanes (`operator_rebinding_{jit,aot,vm}_smoke`).
- `tests/differential/corpus/45_higher_order_shadowing.esk` and `46_operator_rebinding.esk` — differential corpus entries (all native axis pairs agree). Renumbered from 43/44 in the rebase: #424 and #426 took 43 and 44 on master.
- `tests/vm_parity/ENGINE_PARITY_BASELINE.json` — `tests/parser/test_function_shadowing.esk` removed from `divergent_programs` (it now agrees; the ratchet tightens).
- Revert-validated on the rebased tree: with `isShadowedByLocalRuntimeBinding()` forced to `return false` and the compiler rebuilt, the shadowing shapes regress and `map-param-shadow-builtin` SIGSEGVs; restored, all pass. `vm_compiler.c`-only revert reproduces VM `7` for SW-24.
- `.icc/silent-wrong-ledger.yaml` — SW-01, SW-02 and SW-24 closed at the fix commit with observed-after values, the site that changed, and the lane that gates each.
- Smoke probe `higher_order_shadowing_oracle` (JIT + AOT + VM in one probe) wired into `scripts/run_icc_smoke.sh` and `.icc/completion-oracles.yaml`.

## Interaction with #427 (first-class builtins), pinned

#427 makes a bare builtin NAME denote a callable value by synthesizing a
closure-ABI wrapper from the call-site lowering. This PR makes a local
binding of a name win over the static/global resolution. The two compose in
exactly one order, and it is the order `codegenVariable` already had:
`symbol_table` and the current function's arguments/captures are consulted
first, and `codegenInlineBuiltinAsValue` is the last resort — #427's own
comment states it ("Reached only after every binding lookup above has
declined, so a user definition of the same name still wins").
`isShadowedByLocalRuntimeBinding()` sits at the TOP of
`resolveLambdaFunction`'s VAR branch, ahead of its math-builtin wrapper, so
the same rule holds on the static procedure-operand path. No ordering
ambiguity, and nothing to choose between.

Both halves are now pinned, in the native test, the VM test and the corpus
entry: a shadowed builtin name must reach the LOCAL binding
(`map-let-shadow-builtin`, `map-param-shadow-builtin`,
`filter-param-shadow-builtin`, `value-param-shadow-builtin`,
`value-let-shadow-builtin`), and an unshadowed one must still reach #427's
wrapper (`value-builtin-unshadowed` = `(call2 remainder 7 3)` → 1,
`map-builtin-unshadowed` → `(1 3)`). The crossing case bites: with the guard
disabled and the compiler rebuilt,

```scheme
(define (apply-map-car car lst) (map car lst))
(apply-map-car (lambda (x) (+ x 10)) '(1 2 3))
```

SIGSEGVs — `resolveLambdaFunction` resolves `car` statically to the builtin
and `map` calls a foreign-ABI symbol with the closure calling convention.
With the guard it answers `(11 12 13)` on JIT, AOT and the VM.

## Gates

Re-measured on a FULL rebuild of the rebased tree (RelWithDebInfo, LLVM 21,
arm64-apple-darwin24.1.0):

- Full ctest: **164/164**.
- VM parity (`scripts/run_vm_parity.sh`): **158 passed, 0 failed**.
- Differential corpus (`scripts/run_differential.sh`): **288/288 axis pairs
  agree across 48 programs — no divergences at all**. (Was 246/252 across 42
  pre-rebase; the 6 disagreeing pairs were `37_sort.esk`, which #427 fixed.)
- Engine parity coverage (`scripts/run_engine_parity_coverage.py`): OK, 202
  programs, 6 divergent (baseline allows 7), 0 regressed, 0 new; differential
  construct coverage 136/1114 (12.21%), floor held.
- ICC smoke (`scripts/run_icc_smoke.sh`): **60/60**, including
  `higher_order_shadowing_oracle` and #420's `ad_capture_global_shadow_oracle`
  (both probes kept — the oracle-file and smoke-script conflicts were unions,
  not replacements). `language_surface_coverage_floor` needs the
  quantum-enabled runner (`cmake -B build-quantum -DESHKOL_QUANTUM_ENABLED=ON`)
  or it exits 2 as a false red; with it, execution-backed language coverage is
  1091/1091 constructs, 100.00%, floor PASS.

## Rebase notes

Rebased onto master after #413 #418 #419 #420 #423 #424 #426 #427 #428. Four
conflicts, all resolved as UNIONS — nothing on either side was dropped:

| File | Conflict | Resolution |
| --- | --- | --- |
| `CMakeLists.txt` | #427's `first_class_builtins_vm_smoke` + `first_class_variadics_vm_smoke` vs this branch's `higher_order_shadowing_vm_smoke` + `operator_rebinding_vm_smoke`, same insertion point | all four lanes kept |
| `.icc/completion-oracles.yaml` | #420's `ad_capture_global_shadow_oracle` criterion vs `higher_order_shadowing_oracle` | both criteria kept |
| `scripts/run_icc_smoke.sh` | the two probes above shared a trailing `exit 0'` line | both probes kept, each terminated |
| `tests/differential/corpus/` | #424 took 43, #426 took 44 | `43_higher_order_shadowing` → `45_`, `44_operator_rebinding` → `46_`, internal cross-reference updated |

`lib/backend/llvm_codegen.cpp`, `lib/backend/map_codegen.cpp` and
`lib/backend/vm_compiler.c` merged clean and the merged diffs are
hunk-for-hunk identical to the pre-rebase ones — verified by comparing
`git diff` stats against both bases.

