### PR TITLE
feat(runtime): enforce documented resource limits + type ascriptions (SW-10, SW-11)

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -452,6 +452,13 @@ entries:
       deliberately not closed here — tests/stress/rec_deep_nontco_250k.esk pins plain
       non-tail recursion working to 250000 frames, which the documented 100000 default
       would break. Recorded in docs/reference/runtime/environment-variables.md.
+      Second residual: ESHKOL_TIMEOUT_MS is fully enforced WHEN SET, but the
+      watchdog is armed only if the variable is present in the environment
+      (lib/core/runtime_lifecycle_hosted.cpp:149), so the documented default of
+      30000 does not put an unattended run on a clock. Arming it by default
+      would also bound AOT compilation and interactive REPL sessions — a
+      release decision, not a bug fix — so it is documented rather than
+      changed. NEEDS-DECISION for the maintainer.
 
   - id: SW-11
     bucket: SILENT-WRONG

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -391,7 +391,9 @@ entries:
 
   - id: SW-10
     bucket: SILENT-WRONG
-    status: open
+    status: closed
+    closed_at: "b4b98473"
+    closed_by: "PR (branch fix/resource-limits-and-ascription)"
     title: "Seven documented resource-limit environment variables are accepted and never enforced"
     repro: "ESHKOL_MAX_HEAP=1 ESHKOL_ENFORCE_LIMITS=1 eshkol-run -r a-20M-iteration-loop.esk"
     observed: >-
@@ -413,10 +415,49 @@ entries:
       A consumer setting a heap ceiling to contain untrusted code gets no containment
       and no warning. #416 adds honest 'Accepted, not enforced in v1.3.4' status columns
       but #416 is UNMERGED, so the cut still documents them as controls.
+    fix: >-
+      Each ceiling is applied at the one site every path to it converges on, so no
+      call site can be added later that escapes it, and no fast path pays for it:
+      ESHKOL_MAX_HEAP at lib/core/runtime_arena_core.cpp create_arena_block() (the
+      arena's only OS-request site — once per block, bump-pointer path untouched);
+      ESHKOL_MAX_STRING_LEN at lib/core/runtime_object_alloc.cpp
+      arena_allocate_string_with_header(); ESHKOL_MAX_TENSOR_ELEMS at
+      lib/core/runtime_tensor_alloc.cpp arena_allocate_tensor_full() plus
+      lib/backend/tensor_creation_codegen.cpp emitTensorElementLimitCheck(), because
+      native codegen assembles tensors from three separate allocations and never calls
+      that helper; ESHKOL_TIMEOUT_MS as a cooperative poll emitted at the tail-call
+      back-edge in lib/backend/llvm_codegen.cpp codegenTailCallFromContext() and run at
+      every guarded function entry in lib/core/runtime_list_helpers.cpp
+      eshkol_check_recursion_depth(); ESHKOL_MAX_STACK by making that same guard read
+      eshkol_get_limits()->max_stack_depth instead of a hard-coded 100000 (there were
+      two stack-depth mechanisms with the same default and no wire between them);
+      ESHKOL_VM_MAX_INSN in both lib/backend/vm_run.c dispatch paths.
+      ESHKOL_ENFORCE_LIMITS and ESHKOL_LIMIT_WARNINGS select terminate-vs-advisory and
+      soft-limit warnings at the single decision point eshkol_limit_enforce().
+    measured_after: >-
+      ESHKOL_MAX_HEAP=1 on the 20M-iteration loop: 'eshkol: fatal: Heap hard limit
+      exceeded (limit 1 bytes, set by ESHKOL_MAX_HEAP): arena block', exit 120 (was
+      199999990000000, exit 0). ESHKOL_TIMEOUT_MS=500 on the same program: 'eshkol:
+      fatal: Execution timeout exceeded (limit 500ms, set by ESHKOL_TIMEOUT_MS)', exit
+      124 (was the same message followed by the answer and exit 0). MAX_STRING_LEN=100
+      exit 123, MAX_TENSOR_ELEMS=100 exit 122, MAX_STACK=100 exit 121,
+      VM_MAX_INSN=100000 exit 125. Under-limit controls all still exit 0 with identical
+      output, and ESHKOL_ENFORCE_LIMITS=false downgrades every case to a warning and
+      exit 0. All 13 cases green in tests/limits/resource_limits_enforcement_gate.sh,
+      registered as the ctest gate resource_limits_enforcement_gate.
+    residual: >-
+      ESHKOL_MAX_STACK binds the recursion the depth guard observes; codegen does not
+      yet emit that guard at the entry of every top-level `define`d function. That gap
+      is ESH-0101 (tests/stress/found/deep_recursion_270k_no_diagnostic.esk) and is
+      deliberately not closed here — tests/stress/rec_deep_nontco_250k.esk pins plain
+      non-tail recursion working to 250000 frames, which the documented 100000 default
+      would break. Recorded in docs/reference/runtime/environment-variables.md.
 
   - id: SW-11
     bucket: SILENT-WRONG
-    status: open
+    status: closed
+    closed_at: "b4b98473"
+    closed_by: "PR (branch fix/resource-limits-and-ascription)"
     title: "(the <type> expr) is a runtime no-op, so a false ascription is never caught"
     repro: "(display (the string (+ 1 2)))"
     observed: "3, exit 0"
@@ -425,6 +466,43 @@ entries:
     caught_by: [direct-measurement, doc-source-crosscheck]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
     notes: "Documented as a 'trusted assertion to the checker; runtime no-op (byte-identical IR)'. Documented-by-design, but the word 'assertion' is the lie."
+    fix: >-
+      Closed on the 'a type error' arm of `correct`, not the 'document it differently'
+      arm, and at compile time rather than at run time. lib/types/type_checker.cpp
+      ESHKOL_THE_OP was already synthesizing the wrapped expression and then throwing
+      the resulting type away; it now compares that type against the ascribed one via
+      the new TypeChecker::ascriptionIsBelievable() and reports a provable
+      contradiction through reportTypeIssue(), the same enforcement point every other
+      type issue uses — a warning under gradual typing, fatal under --strict-types.
+      The predicate rejects only the impossible: widening, narrowing (the reason the
+      form exists), anything touching the dynamic Value root or an unresolved type, and
+      numeric-tower-to-numeric-tower are all accepted, the last because this type graph
+      keeps Integer/Rational/Real/Complex as siblings under Number rather than a chain,
+      so `(the real 1)` has no subtyping relation in either direction.
+      DELIBERATELY NOT a runtime check: COMPLETE_LANGUAGE_SPECIFICATION.md 3.6.6
+      guarantees the emitted IR is byte-identical to the wrapped expression with no
+      runtime tag check and no cost, and docs/FEATURE_MATRIX.md:804 justifies the VM
+      parity gap ON that guarantee. A compile-time diagnostic makes the word 'checked'
+      true without walking either claim back; both were re-worded to say so.
+    measured_after: >-
+      `(display (the string (+ 1 2)))` now prints '[WARN] Type warning: ascription
+      (the String ...) contradicts the inferred type Int64; no value can satisfy it
+      (line 1:11)' and, under gradual typing, still evaluates to 3 and exits 0 as the
+      documented gradual-typing model requires; under --strict-types it is fatal —
+      'Refusing to generate code for a program with type errors', exit 1, no artifact.
+      Class-kill matrix all reported: (the vector (+ 1 2)), (the procedure "x"),
+      (the string (vector 1 2)), (the integer "s"), (the boolean 5). Correct
+      ascriptions unaffected across the numeric tower and strings:
+      (the number (+ 1 2)), (the real 1), (the integer 5), (the string "hi") are
+      silent and evaluate identically. tests/typesystem/checked_cast_the_test.esk
+      compiles clean under --strict-types with 0 diagnostics, and the
+      registry-derived coverage cell in scripts/run_typesystem_tests.sh is unaffected
+      because its operand is dynamic.
+    residual: >-
+      The diagnostic is native-only, because the bytecode VM has no `the` surface and
+      does not run the HoTT checker. That is unchanged from before this fix and remains
+      native-only-justified in docs/VM_PARITY.md: the form emits no code on either
+      engine, so what the two engines COMPUTE is still identical.
 
   - id: SW-12
     bucket: SILENT-WRONG

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -452,6 +452,10 @@ entries:
       deliberately not closed here — tests/stress/rec_deep_nontco_250k.esk pins plain
       non-tail recursion working to 250000 frames, which the documented 100000 default
       would break. Recorded in docs/reference/runtime/environment-variables.md.
+      RULED (maintainer, 2026-08-13): ESH-0101 stack-guard COVERAGE stays open as a
+      ledgered v1.3.5 item. Wiring the variable where guards already exist — which is
+      what this entry does — is the correct and complete v1.3.4 scope. Not a blocker
+      for the v1.3.4 tag.
       Second residual, and the important one: every ceiling is OPT-IN. A limit
       binds a run only when that run sets its variable (or sets the matching
       ESHKOL_LIMIT_ACTIVE_* bit before eshkol_set_limits()); the documented
@@ -465,8 +469,12 @@ entries:
       entry records is that ESHKOL_MAX_HEAP=1 did nothing; fixing that does not
       require imposing a ceiling on every program that sets nothing.
       Whether the defaults should ALSO bind an unconfigured run is a release
-      decision about defaults, not a bug fix. NEEDS-DECISION for the maintainer;
-      documented at docs/reference/runtime/environment-variables.md
+      decision about defaults, not a bug fix.
+      RULED (maintainer, 2026-08-13): ceilings stay OPT-IN for v1.3.4. Shipping
+      behaviour is unchanged for every existing program — a run that sets nothing is
+      bounded by nothing, exactly as before. Whether the documented defaults should
+      also bind an unconfigured run is deferred as a v1.3.5 policy question, not a
+      v1.3.4 defect. Documented at docs/reference/runtime/environment-variables.md
       ("Limits are opt-in") and pinned by a dedicated case in
       tests/limits/resource_limits_enforcement_gate.sh.
 

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -392,7 +392,7 @@ entries:
   - id: SW-10
     bucket: SILENT-WRONG
     status: closed
-    closed_at: "b4b98473"
+    closed_at: "45877dde"
     closed_by: "PR (branch fix/resource-limits-and-ascription)"
     title: "Seven documented resource-limit environment variables are accepted and never enforced"
     repro: "ESHKOL_MAX_HEAP=1 ESHKOL_ENFORCE_LIMITS=1 eshkol-run -r a-20M-iteration-loop.esk"
@@ -452,18 +452,28 @@ entries:
       deliberately not closed here — tests/stress/rec_deep_nontco_250k.esk pins plain
       non-tail recursion working to 250000 frames, which the documented 100000 default
       would break. Recorded in docs/reference/runtime/environment-variables.md.
-      Second residual: ESHKOL_TIMEOUT_MS is fully enforced WHEN SET, but the
-      watchdog is armed only if the variable is present in the environment
-      (lib/core/runtime_lifecycle_hosted.cpp:149), so the documented default of
-      30000 does not put an unattended run on a clock. Arming it by default
-      would also bound AOT compilation and interactive REPL sessions — a
-      release decision, not a bug fix — so it is documented rather than
-      changed. NEEDS-DECISION for the maintainer.
+      Second residual, and the important one: every ceiling is OPT-IN. A limit
+      binds a run only when that run sets its variable (or sets the matching
+      ESHKOL_LIMIT_ACTIVE_* bit before eshkol_set_limits()); the documented
+      defaults are the values a limit takes when turned on, not ceilings every
+      program is held to. This was learned the hard way inside this PR: the
+      first cut enforced the documented defaults unconditionally and killed
+      tests/features/blc_test.esk, which allocates past the 1 GiB heap default
+      and had run fine for years, with 'Heap hard limit exceeded' and exit 120.
+      The VM's computed-goto dispatch likewise never had an instruction guard,
+      so applying the 10M default there had the same character. The defect this
+      entry records is that ESHKOL_MAX_HEAP=1 did nothing; fixing that does not
+      require imposing a ceiling on every program that sets nothing.
+      Whether the defaults should ALSO bind an unconfigured run is a release
+      decision about defaults, not a bug fix. NEEDS-DECISION for the maintainer;
+      documented at docs/reference/runtime/environment-variables.md
+      ("Limits are opt-in") and pinned by a dedicated case in
+      tests/limits/resource_limits_enforcement_gate.sh.
 
   - id: SW-11
     bucket: SILENT-WRONG
     status: closed
-    closed_at: "b4b98473"
+    closed_at: "45877dde"
     closed_by: "PR (branch fix/resource-limits-and-ascription)"
     title: "(the <type> expr) is a runtime no-op, so a false ascription is never caught"
     repro: "(display (the string (+ 1 2)))"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -487,7 +487,10 @@ and a release gate that finally reads CTest results as oracle evidence.
   `arena_allocate_tensor_full()` and, because native codegen assembles tensors
   from three separate allocations rather than calling it, at the point codegen
   computes the element count; `ESHKOL_TIMEOUT_MS` as a cooperative poll emitted
-  on every tail-call loop back-edge and run at every guarded function entry.
+  on every tail-call loop back-edge of hosted native codegen (the profiles that
+  link no hosted watchdog — freestanding objects and `--wasm` modules — have
+  nothing that could request an interrupt, so the poll is not emitted there)
+  and run at every guarded function entry.
   `ESHKOL_MAX_STACK` now drives the recursion-depth guard that codegen already
   emitted, which had been comparing against a hard-coded 100000 with no
   connection to the configurable limit the variable fed — two mechanisms with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -463,6 +463,80 @@ and a release gate that finally reads CTest results as oracle evidence.
 
 ### Fixed
 
+- **Every documented resource-limit environment variable was accepted and then
+  enforced by nothing.** `ESHKOL_MAX_HEAP`, `ESHKOL_TIMEOUT_MS`,
+  `ESHKOL_MAX_STACK`, `ESHKOL_MAX_TENSOR_ELEMS`, `ESHKOL_MAX_STRING_LEN`,
+  `ESHKOL_ENFORCE_LIMITS` and `ESHKOL_LIMIT_WARNINGS` were parsed into the
+  active configuration by `eshkol_init_limits_from_env()`, and the functions
+  that check them — `eshkol_track_allocation`, `eshkol_check_string_length`,
+  `eshkol_check_tensor_size`, `eshkol_is_timed_out`, `eshkol_stack_push` — were
+  written, compiled and never called from anywhere outside their own unit
+  tests. `ESHKOL_MAX_HEAP=1` ran a 20-million-iteration allocating loop to
+  completion and exited 0; `ESHKOL_TIMEOUT_MS=500` printed `ERROR: Execution
+  timeout: 500ms limit exceeded` and then *also* ran to completion and exited
+  0, because the watchdog thread could only request an interrupt and nothing
+  polled for one. A consumer who set a heap ceiling to contain untrusted code
+  got no containment and no warning.
+
+  Each ceiling is now applied at the one place every path to it converges:
+  `ESHKOL_MAX_HEAP` in `create_arena_block()`, the arena's sole OS-request
+  site, so the check is amortized over a whole block and the bump-pointer fast
+  path is untouched; `ESHKOL_MAX_STRING_LEN` in
+  `arena_allocate_string_with_header()`, which also closes a silent truncation
+  of the `uint32_t` header size past 4 GiB; `ESHKOL_MAX_TENSOR_ELEMS` in
+  `arena_allocate_tensor_full()` and, because native codegen assembles tensors
+  from three separate allocations rather than calling it, at the point codegen
+  computes the element count; `ESHKOL_TIMEOUT_MS` as a cooperative poll emitted
+  on every tail-call loop back-edge and run at every guarded function entry.
+  `ESHKOL_MAX_STACK` now drives the recursion-depth guard that codegen already
+  emitted, which had been comparing against a hard-coded 100000 with no
+  connection to the configurable limit the variable fed — two mechanisms with
+  the same default and no wire between them, now one.
+
+  A violation is loud and terminal by default: pending output is flushed, one
+  `eshkol: fatal: …` line names the limit, the ceiling and the variable that
+  set it, and the process exits with a status specific to that limit — 120
+  heap, 121 stack, 122 tensor elements, 123 string length, 124 execution
+  timeout (matching GNU coreutils `timeout(1)` and this project's existing
+  `run-command` convention), 125 VM instructions. `ESHKOL_ENFORCE_LIMITS=false`
+  makes them advisory: the breach is recorded, warned about, and the program
+  runs on. Staying under a ceiling costs nothing measurable and changes no
+  computed value — no check reads or writes program data.
+
+- **The bytecode VM's documented runaway-instruction guard did not exist on the
+  path that actually runs.** `ESHKOL_VM_MAX_INSN` is documented with a default
+  of 10,000,000, but `vm_run()`'s computed-goto dispatch — the path every
+  GCC/Clang build takes — had no instruction counter at all, while the MSVC
+  `switch` fallback capped at a hard-coded 10,000,000 with no environment
+  override. One interpreter, two dispatch implementations, two different
+  answers to "has this program run away". Both now share one counter and one
+  configurable ceiling, checked once per 4096 instructions so the per-opcode
+  cost is a single decrement and branch. The variable is parsed alongside its
+  six siblings in `eshkol_init_limits_from_env()` and reaches the VM through
+  `eshkol_get_limits()`, because the VM's sources are freestanding-safe and may
+  not read the environment themselves.
+
+- **`(the <type> expr)` never rejected an ascription, so a false one was
+  invisible.** `(display (the string (+ 1 2)))` printed `3` and exited 0. The
+  checker synthesized the wrapped expression, discarded the type it derived,
+  and adopted the ascribed type unconditionally — so an ascription no value can
+  satisfy was indistinguishable from one every value satisfies, and "checked
+  ascription" checked nothing. The two types are now compared, and a *provable*
+  contradiction is reported through the same enforcement point as every other
+  type issue: a warning under gradual typing, fatal under `--strict-types`.
+
+  The form's contract is otherwise unchanged, and deliberately so. It remains a
+  trusted narrowing boundary — narrowing from a dynamic value is the reason it
+  exists and is never questioned — and widening, unresolved types, and
+  ascriptions that move around the numeric tower (whose members are siblings
+  under `number` rather than a chain, so `(the real 1)` has no subtyping
+  relation in either direction) are all still accepted. The diagnostic is
+  compile-time only: the emitted IR is still byte-identical to the wrapped
+  expression, there is still no runtime tag check and no cost, and a VM program
+  that omits the ascription still computes the identical result, so
+  `COMPLETE_LANGUAGE_SPECIFICATION.md` § 3.6.6's guarantee and the
+  `native-only-justified` VM-parity row both continue to hold.
+
 - **A relative `(load "sib.esk")` resolved to a different file depending on
   which execution engine ran the program.** `eshkol-run -r prog.esk` uses the
   persistent JIT run cache for a single input with no `-d`/dump flags and no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -493,6 +493,17 @@ and a release gate that finally reads CTest results as oracle evidence.
   connection to the configurable limit the variable fed — two mechanisms with
   the same default and no wire between them, now one.
 
+  Each ceiling is **opt-in**: it binds a run only when that run sets its
+  variable (or sets the matching `ESHKOL_LIMIT_ACTIVE_*` bit before
+  `eshkol_set_limits()`). The documented defaults are the values a limit takes
+  when you turn it on, not ceilings every program is silently held to —
+  `tests/features/blc_test.esk` allocates past the 1 GiB heap default, and the
+  VM's computed-goto dispatch never had an instruction guard at all, so
+  applying every default to every run would impose new ceilings rather than
+  enforce documented ones. Whether the defaults should also bind an
+  unconfigured run is a release decision about defaults, recorded in
+  `docs/reference/runtime/environment-variables.md`.
+
   A violation is loud and terminal by default: pending output is flushed, one
   `eshkol: fatal: …` line names the limit, the ceiling and the variable that
   set it, and the process exits with a status specific to that limit — 120

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3937,6 +3937,31 @@ if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/core/resourc
     add_test(NAME resource_limits_test COMMAND resource_limits_test)
 endif()
 
+# SW-10 end-to-end gate: the documented resource-limit environment variables
+# actually bound a running program. resource_limits_test above covers the
+# configuration layer in-process (parsing, tracking, the check predicates);
+# this one drives real eshkol-run / bytecode-VM processes and asserts the
+# documented exit status, the diagnostic, and — just as important — that a
+# ceiling the program never reaches leaves it byte-for-byte unaffected.
+if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run AND
+   EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/limits/resource_limits_enforcement_gate.sh")
+    if(TARGET eshkol-vm-standalone-test)
+        set(ESHKOL_LIMITS_GATE_VM "$<TARGET_FILE:eshkol-vm-standalone-test>")
+    else()
+        set(ESHKOL_LIMITS_GATE_VM "none")
+    endif()
+    add_test(NAME resource_limits_enforcement_gate
+        COMMAND bash
+            "${CMAKE_CURRENT_SOURCE_DIR}/tests/limits/resource_limits_enforcement_gate.sh"
+            "$<TARGET_FILE:eshkol-run>"
+            "${ESHKOL_LIMITS_GATE_VM}"
+            "${CMAKE_CURRENT_BINARY_DIR}/resource-limits-gate")
+    set_tests_properties(resource_limits_enforcement_gate PROPERTIES
+        TIMEOUT 900
+        PASS_REGULAR_EXPRESSION "PASS: resource limits enforced"
+        FAIL_REGULAR_EXPRESSION "FAIL:")
+endif()
+
 if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/core/linear_solve_hosted_control_test.cpp")
     add_executable(linear_solve_hosted_control_test
         tests/core/linear_solve_hosted_control_test.cpp)

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -4408,12 +4408,21 @@ Eshkol behavior can be configured via environment variables. None are required �
 | `ESHKOL_MAX_STACK` | (default) | Maximum stack depth |
 | `ESHKOL_MAX_TENSOR_ELEMS` | (default) | Maximum tensor element count |
 | `ESHKOL_MAX_STRING_LEN` | (default) | Maximum string length |
-| `ESHKOL_ENFORCE_LIMITS` | on for limit API | Request runtime interrupts on hard heap/timeout limits |
+| `ESHKOL_VM_MAX_INSN` | 10000000 | Bytecode-VM runaway-instruction guard; `0` = unlimited |
+| `ESHKOL_ENFORCE_LIMITS` | on | Terminate the process on a hard limit; when off, the breach is recorded and warned about and the program continues |
 | `ESHKOL_LIMIT_WARNINGS` | on | Emit soft-limit warnings |
 
 Malformed runtime-limit values are ignored and preserve the default limit. Size
 variables accept optional `K`, `M`, or `G` suffixes, with an optional trailing
 `B`.
+
+Exceeding a hard limit prints one `eshkol: fatal: …` line to stderr naming the
+limit, the ceiling and the variable that set it, and exits with a status
+specific to that limit — `120` heap, `121` stack, `122` tensor elements, `123`
+string length, `124` execution timeout (matching GNU coreutils `timeout(1)`),
+`125` VM instructions. See `ESHKOL_EXIT_LIMIT_*` in
+`inc/eshkol/core/resource_limits.h` and
+[runtime/environment-variables.md](reference/runtime/environment-variables.md).
 
 ### Logging & Debug
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -4416,7 +4416,12 @@ Malformed runtime-limit values are ignored and preserve the default limit. Size
 variables accept optional `K`, `M`, or `G` suffixes, with an optional trailing
 `B`.
 
-Exceeding a hard limit prints one `eshkol: fatal: …` line to stderr naming the
+Each ceiling is opt-in: it binds a run only when that run sets the variable
+(or sets the matching `ESHKOL_LIMIT_ACTIVE_*` bit before `eshkol_set_limits()`).
+The defaults above are the values a limit takes when turned on, not ceilings
+applied to every program.
+
+Exceeding an active hard limit prints one `eshkol: fatal: …` line to stderr naming the
 limit, the ceiling and the variable that set it, and exits with a status
 specific to that limit — `120` heap, `121` stack, `122` tensor elements, `123`
 string length, `124` execution timeout (matching GNU coreutils `timeout(1)`),

--- a/docs/COMPLETE_LANGUAGE_SPECIFICATION.md
+++ b/docs/COMPLETE_LANGUAGE_SPECIFICATION.md
@@ -811,14 +811,37 @@ also work inside a `#(...)` vector literal under quasiquote:
 (the <type> expr)
 ```
 Asserts to the type checker that `expr` has type `<type>`. It is a **trusted
-assertion**: the checker narrows its view of `expr` to `<type>` and does not
-re-derive it. It is a pure **runtime no-op** — the emitted IR is byte-identical
-to `expr` alone (no runtime tag check, no cost), so `(the <type> expr)` evaluates
-to exactly the same value as `expr`.
+assertion**: the checker adopts `<type>` as the type of the whole form and does
+not re-derive it from `expr`. It is a pure **runtime no-op** — the emitted IR is
+byte-identical to `expr` alone (no runtime tag check, no cost), so
+`(the <type> expr)` evaluates to exactly the same value as `expr`.
+
+Trusted does not mean unexamined. The checker still synthesizes `expr`, and if
+the type it finds is **provably disjoint** from `<type>` — no value inhabits
+both — it reports the ascription rather than adopting it. That is a compile-time
+diagnostic only: a warning under gradual typing, fatal under `--strict-types`
+(§ [`--strict-types`](reference/runtime/eshkol-run.md)), and in neither case
+does it add anything to the emitted code.
+
+The check is deliberately narrow, so the form stays useful:
+
+- **Narrowing is always accepted** — the primary use. `(the integer (car xs))`
+  over a dynamically-typed container is exactly what the form is for.
+- **Widening is always accepted**: `(the number 1)`.
+- Anything whose type the checker does not know (the dynamic `any`/`value`
+  root, an unresolved name) is trusted, not questioned.
+- **Numeric-tower ascriptions are always accepted.** `integer`, `rational`,
+  `real` and `complex` are siblings under `number` in this type graph rather
+  than a chain, so no subtyping relation holds between them in either
+  direction; `(the real 1)` and `(the float64 (+ 1 2))` are ordinary.
+
+Only a genuine contradiction is reported:
 
 ```scheme
 (the number (car mixed-list))   ; the checker now treats this element as number
 (the (list real) xs)
+(the real 1)                    ; fine — moving inside the numeric tower
+(the string (+ 1 2))            ; reported: no value is both Int64 and String
 ```
 
 `<type>` may be any parenthesised type form, or any **bare type name the type

--- a/docs/ESHKOL_LANGUAGE_GUIDE.md
+++ b/docs/ESHKOL_LANGUAGE_GUIDE.md
@@ -1401,8 +1401,17 @@ mode accepts idiomatic dynamic-but-validated code without escape hatches:
   byte-identical to `expr` alone (no runtime tag check, no cost), so `(the <type>
   expr)` and `expr` compute exactly the same value.
 
+  Trusted is not unexamined. The checker still derives the type of `expr`, and
+  if it is **provably disjoint** from `<type>` — no value inhabits both — it
+  reports the ascription instead of adopting it: a warning under gradual
+  typing, fatal under `--strict-types`, and nothing extra in the emitted code
+  either way. Narrowing, widening, and moving between members of the numeric
+  tower are all accepted.
+
   ```scheme
   (the number (car mixed-list))   ; tell the checker this element is a number
+  (the real 1)                    ; fine — the numeric tower is flat
+  (the string (+ 1 2))            ; reported: no value is both Int64 and String
   ```
 
 - **Predicate-guarded narrowing.** Inside a branch guarded by one of eight type

--- a/docs/ESHKOL_QUICK_REFERENCE.md
+++ b/docs/ESHKOL_QUICK_REFERENCE.md
@@ -482,7 +482,9 @@ exp log log10 log2 sqrt pow
 ## Static Type Checking (strict mode)
 
 ```scheme
-;; Checked ascription — trusted assertion to the checker, runtime no-op
+;; Checked ascription — trusted assertion to the checker, runtime no-op.
+;; A provably impossible ascription is reported at compile time:
+;;   (the string (+ 1 2))  ;; warning (fatal under --strict-types)
 (the number (car xs))     ;; tell the checker this is a number
 (the string s)
 

--- a/docs/FEATURE_MATRIX.md
+++ b/docs/FEATURE_MATRIX.md
@@ -69,7 +69,7 @@ This matrix lists every implemented and planned feature in the Eshkol ecosystem.
 | Function arrows (→) | Yes | `(→ A B)` types | Type inference |
 | Dependent types | Yes | Path types, universes | Proof erasure |
 | Gradual typing | Yes | Optional annotations | Warning-only errors |
-| Checked ascription `(the <type> expr)` | Yes | v1.3.4: trusted assertion to the checker; runtime no-op (byte-identical IR) | Type checker |
+| Checked ascription `(the <type> expr)` | Yes | v1.3.4: trusted assertion to the checker; a provably disjoint ascription is reported (warning under gradual typing, fatal under `--strict-types`); still a runtime no-op (byte-identical IR) | Type checker |
 | Predicate-guarded narrowing | Yes | v1.3.4: 8 predicates, honored across `if`/`and`, cancelled at `set!` | Type checker |
 | Linear `Qubit` type | Yes | v1.3.4: use-exactly-once enforcement on `define`d linear params | HoTT linear types |
 | Sum-type annotations on named-let params | Yes | v1.3.4: honored across iterations | Type checker |
@@ -801,7 +801,7 @@ This matrix lists every implemented and planned feature in the Eshkol ecosystem.
 | Shortest-round-trip number printing | Yes | v1.3.4: `display`/`write`/`number->string` share one portable-C routine with native, byte-identical output (R7RS 6.2.6) |
 | Reverse-mode `gradient` (`op:GRADIENT`) | Yes | v1.3.4 (#337): forward/reverse-mode, arity-resolved (scalar / N-arg / arity-1 whole-vector) incl. the curried form, byte-identical to native across `vm-src`/`vm-eskb`; higher-order nesting (gradient-of-derivative / Taylor tower) stays native-only |
 | Forward-mode `derivative` (`op:DERIVATIVE`) | Yes / first order | v1.3.4 (ESH-0369): direct `(derivative f x)` and curried `((derivative f) x)` both lower to the same native call with the same `(f, x)`, so they agree exactly with native. First order only — the VM's carrier is a flat dual `{value, tangent}` with a single perturbation, so nested/higher-order differentiation now **raises a catchable error** instead of returning the `0.0` it used to fabricate. Higher-order AD needs the native jet's `e1`/`e2`/`ep` slots or a VM Taylor tower; native-only until a VM jet carrier is built |
-| Checked ascription `(the <type> expr)` | No | native-only-justified: compile-time type-checker construct, runtime no-op — a VM program that omits it computes the identical result |
+| Checked ascription `(the <type> expr)` | No | native-only-justified: compile-time type-checker construct, runtime no-op — a VM program that omits it computes the identical result. The contradiction diagnostic added in v1.3.4 is likewise compile-time, so runtime parity is unchanged |
 | **Weight Matrix Transformer** |
 | Transformer interpreter | Yes | d_model=256, 6 layers, FFN_DIM=2304, 12.22M params |
 | 3-way verification | Yes | Reference = simulated = matrix-based (126/126 inline, 123/123 traced) |

--- a/docs/VM_PARITY.md
+++ b/docs/VM_PARITY.md
@@ -38,7 +38,8 @@ to miss.
 - **`(the <type> expr)` is `native-only-justified`.** The checked type
   ascription is a compile-time construct on the native type checker with no VM
   surface; it is a runtime no-op, so a VM program that omits it computes the
-  identical result.
+  identical result. The contradiction diagnostic added in v1.3.4 is likewise
+  compile-time and emits no code, so runtime parity is unchanged.
 
 ## The manifest
 

--- a/docs/breakdown/RUNTIME_CONFIGURATION.md
+++ b/docs/breakdown/RUNTIME_CONFIGURATION.md
@@ -37,7 +37,12 @@ Malformed runtime-limit values are ignored and leave the documented default in
 place. Size variables accept optional `K`, `M`, or `G` suffixes, with an optional
 trailing `B`.
 
-Exceeding a hard limit under the default `ESHKOL_ENFORCE_LIMITS=true` flushes
+Each ceiling is **opt-in**: it binds a run only when that run sets the
+variable. The defaults above are the values a limit takes when you turn it on,
+not ceilings every program is silently held to — see
+[environment-variables.md](../reference/runtime/environment-variables.md#limits-are-opt-in).
+
+Exceeding an active hard limit under the default `ESHKOL_ENFORCE_LIMITS=true` flushes
 pending output, prints one `eshkol: fatal: …` line to stderr naming the limit,
 the ceiling and the variable that set it, and exits with a status specific to
 that limit:

--- a/docs/breakdown/RUNTIME_CONFIGURATION.md
+++ b/docs/breakdown/RUNTIME_CONFIGURATION.md
@@ -29,12 +29,34 @@ The configuration system is defined in `inc/eshkol/core/config.h` (unified confi
 | `ESHKOL_MAX_STACK` | 100000 | Maximum recursion depth (number of stack frames). |
 | `ESHKOL_MAX_TENSOR_ELEMS` | 1,000,000,000 | Maximum number of elements in a single tensor. |
 | `ESHKOL_MAX_STRING_LEN` | 100 MB | Maximum string length in bytes. |
-| `ESHKOL_ENFORCE_LIMITS` | `true` | When `true`, hard limit violations terminate the process. When `false`, errors are returned. |
+| `ESHKOL_VM_MAX_INSN` | 10,000,000 | Bytecode-VM runaway-instruction guard. Set to `0` for unlimited. |
+| `ESHKOL_ENFORCE_LIMITS` | `true` | When `true`, hard limit violations terminate the process. When `false`, the breach is recorded and warned about and execution continues. |
 | `ESHKOL_LIMIT_WARNINGS` | `true` | When `true`, log warnings when soft limits are approached. |
 
 Malformed runtime-limit values are ignored and leave the documented default in
 place. Size variables accept optional `K`, `M`, or `G` suffixes, with an optional
 trailing `B`.
+
+Exceeding a hard limit under the default `ESHKOL_ENFORCE_LIMITS=true` flushes
+pending output, prints one `eshkol: fatal: …` line to stderr naming the limit,
+the ceiling and the variable that set it, and exits with a status specific to
+that limit:
+
+| Limit | Exit status |
+|-------|-------------|
+| `ESHKOL_MAX_HEAP` | 120 |
+| `ESHKOL_MAX_STACK` | 121 |
+| `ESHKOL_MAX_TENSOR_ELEMS` | 122 |
+| `ESHKOL_MAX_STRING_LEN` | 123 |
+| `ESHKOL_TIMEOUT_MS` | 124 |
+| `ESHKOL_VM_MAX_INSN` | 125 |
+
+`124` matches GNU coreutils `timeout(1)`, the convention this project already
+uses for `run-command` / `run-argv` subprocess timeouts. The full set is defined
+as `ESHKOL_EXIT_LIMIT_*` in `inc/eshkol/core/resource_limits.h`. A program that
+stays under its ceilings is unaffected: the checks sit on the arena's
+block-acquisition path, on object creation, and on periodic VM/loop
+checkpoints, and none of them reads or writes a program value.
 
 ### Stack Size
 

--- a/docs/reference/runtime/environment-variables.md
+++ b/docs/reference/runtime/environment-variables.md
@@ -124,6 +124,13 @@ the execution-timeout poll run once per 4096 instructions and once per tail-call
 loop back-edge respectively. No check reads or writes a program value, so
 enabling limits cannot change a computed result.
 
+The timeout poll is emitted for hosted native codegen only. The watchdog that
+raises the interrupt lives in the hosted runtime, which a standalone
+freestanding object and a `--wasm` module do not link at all — so in those
+profiles there is nothing that could request an interrupt, and the back-edge
+poll is not emitted rather than left calling a symbol the profile does not
+have. The environment variables above describe hosted `eshkol-run` execution.
+
 ### Two limits that are narrower than the table suggests
 
 `ESHKOL_MAX_STACK` bounds the recursion the runtime's depth guard observes.

--- a/docs/reference/runtime/environment-variables.md
+++ b/docs/reference/runtime/environment-variables.md
@@ -72,9 +72,28 @@ Read by `lib/core/resource_limits.cpp`. Size vars accept `K`/`M`/`G` suffixes.
 | `ESHKOL_ENFORCE_LIMITS` | Enforce hard limits (terminate on exceed). | true | — |
 | `ESHKOL_LIMIT_WARNINGS` | Emit soft-limit warnings. | true | — |
 
+### Limits are opt-in
+
+A ceiling binds a run **only when that run asks for it** — by setting the
+variable (or setting the corresponding `ESHKOL_LIMIT_ACTIVE_*` bit before
+`eshkol_set_limits()`). The defaults in the table are the values a limit takes
+*when you turn it on*; they are not ceilings every program is silently held to.
+
+This is a deliberate distinction, not an omission. The defaults are real
+numbers that real programs pass: `tests/features/blc_test.esk` in this
+repository allocates past 1 GiB, and the bytecode VM's computed-goto dispatch
+never had an instruction guard at all. Applying every documented default to
+every run would not be enforcing what the docs say — it would impose a new
+ceiling on every existing program. Whether the defaults should also bind an
+unconfigured run is a release decision, not a bug fix.
+
+So: `eshkol-run prog.esk` is unbounded, exactly as before.
+`ESHKOL_MAX_HEAP=512M eshkol-run prog.esk` is bounded at 512 MiB and will be
+terminated if it exceeds that.
+
 ### What "enforced" means
 
-With `ESHKOL_ENFORCE_LIMITS=true` (the default), exceeding a hard limit ends
+With `ESHKOL_ENFORCE_LIMITS=true` (the default), exceeding an active limit ends
 the run immediately. The runtime flushes whatever the program has already
 written, prints one line to stderr naming the limit, the configured ceiling and
 the variable that set it —
@@ -110,13 +129,11 @@ function (tracked as ESH-0101, `tests/stress/found/deep_recursion_270k_no_diagno
 so deep non-tail recursion in such a function can still exhaust the native stack
 before the ceiling is consulted.
 
-**The execution timer is opt-in.** `30000` is the default *value* of
-`max_execution_time_ms`, but the watchdog is armed only when
-`ESHKOL_TIMEOUT_MS` is actually present in the environment
-(`eshkol_runtime_init()`); a run that does not set it is not on a clock. Arming
-a 30-second wall-clock kill on every invocation by default would also bound
-AOT compilation and interactive REPL sessions, which is a release decision
-rather than a bug fix, so it is recorded here rather than changed.
+The execution timer follows the same opt-in rule: the watchdog is armed only
+when `ESHKOL_TIMEOUT_MS` is present in the environment (`eshkol_runtime_init()`),
+so a run that does not set it is not on a clock. Arming a 30-second wall-clock
+kill on every invocation would also bound AOT compilation and interactive REPL
+sessions.
 
 ## Parallelism & threading
 

--- a/docs/reference/runtime/environment-variables.md
+++ b/docs/reference/runtime/environment-variables.md
@@ -79,7 +79,10 @@ variable (or setting the corresponding `ESHKOL_LIMIT_ACTIVE_*` bit before
 `eshkol_set_limits()`). The defaults in the table are the values a limit takes
 *when you turn it on*; they are not ceilings every program is silently held to.
 
-This is a deliberate distinction, not an omission. The defaults are real
+This is a deliberate distinction, not an omission, and it is the ruled v1.3.4
+behaviour: ceilings are opt-in, so shipping behaviour is unchanged for every
+existing program. Whether the documented defaults should also bind an
+unconfigured run is deferred as a v1.3.5 policy question. The defaults are real
 numbers that real programs pass: `tests/features/blc_test.esk` in this
 repository allocates past 1 GiB, and the bytecode VM's computed-goto dispatch
 never had an instruction guard at all. Applying every documented default to
@@ -134,6 +137,10 @@ when `ESHKOL_TIMEOUT_MS` is present in the environment (`eshkol_runtime_init()`)
 so a run that does not set it is not on a clock. Arming a 30-second wall-clock
 kill on every invocation would also bound AOT compilation and interactive REPL
 sessions.
+
+The `ESHKOL_MAX_STACK` gap above (ESH-0101) is likewise a ledgered v1.3.5 item:
+wiring the variable where the guard already runs is the v1.3.4 scope, extending
+guard coverage to every top-level `define` is not.
 
 ## Parallelism & threading
 

--- a/docs/reference/runtime/environment-variables.md
+++ b/docs/reference/runtime/environment-variables.md
@@ -102,11 +102,21 @@ the execution-timeout poll run once per 4096 instructions and once per tail-call
 loop back-edge respectively. No check reads or writes a program value, so
 enabling limits cannot change a computed result.
 
+### Two limits that are narrower than the table suggests
+
 `ESHKOL_MAX_STACK` bounds the recursion the runtime's depth guard observes.
 Codegen does not yet emit that guard at the entry of every top-level `define`d
 function (tracked as ESH-0101, `tests/stress/found/deep_recursion_270k_no_diagnostic.esk`),
 so deep non-tail recursion in such a function can still exhaust the native stack
 before the ceiling is consulted.
+
+**The execution timer is opt-in.** `30000` is the default *value* of
+`max_execution_time_ms`, but the watchdog is armed only when
+`ESHKOL_TIMEOUT_MS` is actually present in the environment
+(`eshkol_runtime_init()`); a run that does not set it is not on a clock. Arming
+a 30-second wall-clock kill on every invocation by default would also bound
+AOT compilation and interactive REPL sessions, which is a release decision
+rather than a bug fix, so it is recorded here rather than changed.
 
 ## Parallelism & threading
 

--- a/docs/reference/runtime/environment-variables.md
+++ b/docs/reference/runtime/environment-variables.md
@@ -60,17 +60,53 @@ built against a different runtime layout.
 
 Read by `lib/core/resource_limits.cpp`. Size vars accept `K`/`M`/`G` suffixes.
 
-| Variable | Effect | Default |
-|----------|--------|---------|
-| `ESHKOL_MAX_HEAP` | Max heap bytes (soft limit at 80%). | 1 GiB |
-| `ESHKOL_MAX_STACK` | Max interpreter stack depth. | 100000 |
-| `ESHKOL_STACK_SIZE` | OS `RLIMIT_STACK` target (min 1 MiB). | 512 MB |
-| `ESHKOL_MAX_STRING_LEN` | Max string length. | 100 MiB |
-| `ESHKOL_MAX_TENSOR_ELEMS` | Max tensor element count. | 1e9 |
-| `ESHKOL_TIMEOUT_MS` | Max execution time (ms). | 30000 |
-| `ESHKOL_VM_MAX_INSN` | VM runaway-instruction guard. | 10000000 |
-| `ESHKOL_ENFORCE_LIMITS` | Enforce hard limits (abort on exceed). | true |
-| `ESHKOL_LIMIT_WARNINGS` | Emit soft-limit warnings. | true |
+| Variable | Effect | Default | Exit status when exceeded |
+|----------|--------|---------|---------------------------|
+| `ESHKOL_MAX_HEAP` | Max heap bytes (soft limit at 80%). | 1 GiB | 120 |
+| `ESHKOL_MAX_STACK` | Max interpreter stack depth. | 100000 | 121 |
+| `ESHKOL_STACK_SIZE` | OS `RLIMIT_STACK` target (min 1 MiB). | 512 MB | — |
+| `ESHKOL_MAX_STRING_LEN` | Max string length. | 100 MiB | 123 |
+| `ESHKOL_MAX_TENSOR_ELEMS` | Max tensor element count. | 1e9 | 122 |
+| `ESHKOL_TIMEOUT_MS` | Max execution time (ms); `0` = unlimited. | 30000 | 124 |
+| `ESHKOL_VM_MAX_INSN` | Bytecode-VM runaway-instruction guard; `0` = unlimited. | 10000000 | 125 |
+| `ESHKOL_ENFORCE_LIMITS` | Enforce hard limits (terminate on exceed). | true | — |
+| `ESHKOL_LIMIT_WARNINGS` | Emit soft-limit warnings. | true | — |
+
+### What "enforced" means
+
+With `ESHKOL_ENFORCE_LIMITS=true` (the default), exceeding a hard limit ends
+the run immediately. The runtime flushes whatever the program has already
+written, prints one line to stderr naming the limit, the configured ceiling and
+the variable that set it —
+
+```
+eshkol: fatal: Heap hard limit exceeded (limit 1048576 bytes, set by ESHKOL_MAX_HEAP): arena block
+```
+
+— and exits with the status in the table above. The statuses are distinct per
+limit so a supervising process can tell which ceiling was hit without parsing
+the message; `124` for the execution timeout matches GNU coreutils `timeout(1)`
+and the convention already used by `run-command` / `run-argv`. They are defined
+as `ESHKOL_EXIT_LIMIT_*` in `inc/eshkol/core/resource_limits.h`.
+
+With `ESHKOL_ENFORCE_LIMITS=false` the ceilings become advisory: a breach is
+recorded (readable from C via `eshkol_get_last_limit_error()`), reported as a
+warning when `ESHKOL_LIMIT_WARNINGS` is on, and the program continues to
+completion.
+
+Enforcement is placed so that staying under a limit costs nothing measurable:
+the heap ceiling is checked once per arena *block* (a megabyte at a time), not
+per allocation, leaving the bump-pointer path untouched; the tensor and string
+ceilings are checked once per object created; the VM's instruction guard and
+the execution-timeout poll run once per 4096 instructions and once per tail-call
+loop back-edge respectively. No check reads or writes a program value, so
+enabling limits cannot change a computed result.
+
+`ESHKOL_MAX_STACK` bounds the recursion the runtime's depth guard observes.
+Codegen does not yet emit that guard at the entry of every top-level `define`d
+function (tracked as ESH-0101, `tests/stress/found/deep_recursion_270k_no_diagnostic.esk`),
+so deep non-tail recursion in such a function can still exhaust the native stack
+before the ceiling is consulted.
 
 ## Parallelism & threading
 

--- a/inc/eshkol/backend/tensor_codegen.h
+++ b/inc/eshkol/backend/tensor_codegen.h
@@ -785,6 +785,20 @@ public:
     // === Tensor Utility (Public for use by other codegen modules) ===
 
     /**
+     * Emit the ESHKOL_MAX_TENSOR_ELEMS ceiling check for a tensor whose element
+     * count is the runtime value @p total_elements.
+     *
+     * Generated code assembles a tensor from separate header/dimension/element
+     * arena allocations instead of calling arena_allocate_tensor_full(), so the
+     * documented tensor ceiling has to be applied where codegen computes the
+     * element count. One runtime call per tensor creation; it reads no tensor
+     * data and writes none, so it cannot alter a computed result.
+     *
+     * @param total_elements Element count as an i64-compatible SSA value.
+     */
+    void emitTensorElementLimitCheck(llvm::Value* total_elements);
+
+    /**
      * Create a tensor with given dimensions.
      * @param dims Vector of dimension values
      * @param fill_value Optional fill value (as i64 bit pattern)

--- a/inc/eshkol/backend/vm.h
+++ b/inc/eshkol/backend/vm.h
@@ -167,6 +167,28 @@ int eshkol_vm_register_host_native(const char* name, eshkol_vm_host_native_fn fn
  * success, -1 if `slot` is out of range or already free. */
 int eshkol_vm_unregister_host_native(int slot);
 
+/* ===== Resource limits (SW-10) =====
+ *
+ * The VM owns this state rather than reading the hosted resource-limit layer,
+ * because these sources also build for WebAssembly and freestanding profiles
+ * where lib/core/resource_limits.cpp is not linked. A hosted entry point
+ * resolves the configuration and installs it here; anything that does not call
+ * the installer keeps the compiled-in defaults and links nothing extra. */
+extern uint64_t g_eshkol_vm_max_insn;            /* 0 = unlimited */
+extern int      g_eshkol_vm_insn_limit_active;   /* opt-in, like every ceiling */
+extern int      g_eshkol_vm_enforce_hard_limits;
+extern void   (*g_eshkol_vm_poll_interrupt)(void);
+
+/**
+ * @brief Install the resolved limit configuration from a hosted entry point.
+ * @param max_insn Instruction ceiling (0 = unlimited).
+ * @param active   Non-zero if ESHKOL_VM_MAX_INSN was actually asked for.
+ * @param enforce  Non-zero to terminate rather than merely record a breach.
+ * @param poll     Cooperative timeout poll, or NULL for none.
+ */
+void eshkol_vm_install_limits(uint64_t max_insn, int active, int enforce,
+                              void (*poll)(void));
+
 /* Helpers callable only from a registered host-native callback. */
 int eshkol_vm_host_pop_int64(VM* vm, int64_t* out);
 int eshkol_vm_host_push_int64(VM* vm, int64_t value);

--- a/inc/eshkol/backend/vm_limits.h
+++ b/inc/eshkol/backend/vm_limits.h
@@ -44,6 +44,16 @@
 #define ESHKOL_VM_MAX_CODE 100000
 #endif
 
+/* Runaway-instruction guard for the bytecode interpreter: the number of
+ * instructions vm_run() will execute before deciding the program is not going
+ * to terminate. Unlike the capacities above this is a *default*, not a fixed
+ * ceiling — `ESHKOL_VM_MAX_INSN` overrides it per run, and 0 means unlimited.
+ * Enforced in lib/backend/vm_run.c by both the computed-goto and the switch
+ * dispatch paths. */
+#ifndef ESHKOL_VM_DEFAULT_MAX_INSN
+#define ESHKOL_VM_DEFAULT_MAX_INSN 10000000ULL
+#endif
+
 #if ESHKOL_VM_HEAP_SIZE <= 0
 #error "ESHKOL_VM_HEAP_SIZE must be positive"
 #endif

--- a/inc/eshkol/core/resource_limits.h
+++ b/inc/eshkol/core/resource_limits.h
@@ -99,7 +99,42 @@ typedef struct eshkol_resource_limits {
     // Behavior flags
     bool enforce_hard_limits;        // Kill on hard limit (vs return error)
     bool enable_warnings;            // Log soft limit warnings
+
+    // Which ceilings are ACTIVE, as a bitmask of ESHKOL_LIMIT_ACTIVE_*.
+    //
+    // The values above are the documented defaults *for a limit you turn on* —
+    // they are not ceilings every program is silently held to. A limit becomes
+    // active when you ask for it: its environment variable is present, or you
+    // set the bit yourself before eshkol_set_limits(). An inactive ceiling is
+    // never checked and cannot terminate anything.
+    //
+    // This matters because the defaults are not idle documentation: 1 GiB of
+    // heap is a real number that real programs pass. Turning them all on at
+    // once would not be "enforcing what the docs say", it would be imposing a
+    // ceiling on every existing program that never had one — this repository's
+    // own tests/features/blc_test.esk allocates past 1 GiB, and the bytecode
+    // VM's computed-goto dispatch never had an instruction guard at all.
+    // Whether the defaults should also bind an unconfigured run is a release
+    // decision, recorded in docs/reference/runtime/environment-variables.md.
+    uint32_t active_limits;
 } eshkol_resource_limits_t;
+
+// Bits for eshkol_resource_limits_t::active_limits.
+#define ESHKOL_LIMIT_ACTIVE_HEAP    (1u << 0)  // ESHKOL_MAX_HEAP
+#define ESHKOL_LIMIT_ACTIVE_STACK   (1u << 1)  // ESHKOL_MAX_STACK
+#define ESHKOL_LIMIT_ACTIVE_TENSOR  (1u << 2)  // ESHKOL_MAX_TENSOR_ELEMS
+#define ESHKOL_LIMIT_ACTIVE_STRING  (1u << 3)  // ESHKOL_MAX_STRING_LEN
+#define ESHKOL_LIMIT_ACTIVE_TIMEOUT (1u << 4)  // ESHKOL_TIMEOUT_MS
+#define ESHKOL_LIMIT_ACTIVE_VM_INSN (1u << 5)  // ESHKOL_VM_MAX_INSN
+#define ESHKOL_LIMIT_ACTIVE_ALL     0x3Fu
+
+/**
+ * @brief Whether a given ceiling is active for this process.
+ *
+ * @param which One of the `ESHKOL_LIMIT_ACTIVE_*` bits.
+ * @return true if that limit was asked for and should be enforced.
+ */
+bool eshkol_limit_is_active(uint32_t which);
 
 // ============================================================================
 // Environment Variables

--- a/inc/eshkol/core/resource_limits.h
+++ b/inc/eshkol/core/resource_limits.h
@@ -56,6 +56,10 @@ extern "C" {
 // Default: 100MB string
 #define ESHKOL_DEFAULT_MAX_STRING_LENGTH   (100ULL * 1024 * 1024)
 
+// Default: 10 million bytecode instructions before the VM calls a program
+// runaway. 0 means unlimited.
+#define ESHKOL_DEFAULT_MAX_VM_INSTRUCTIONS (10ULL * 1000 * 1000)
+
 // ============================================================================
 // Resource Limit Configuration
 // ============================================================================
@@ -85,6 +89,13 @@ typedef struct eshkol_resource_limits {
     size_t max_tensor_elements;      // Maximum elements in a tensor
     size_t max_string_length;        // Maximum string length
 
+    // Execution limits
+    // Bytecode-VM runaway-instruction guard (0 = unlimited). Lives here rather
+    // than being read from the environment by the VM itself: lib/backend/vm_*.c
+    // are freestanding-safe sources that may not call getenv(), so every
+    // environment variable they obey has to arrive through this struct.
+    uint64_t max_vm_instructions;
+
     // Behavior flags
     bool enforce_hard_limits;        // Kill on hard limit (vs return error)
     bool enable_warnings;            // Log soft limit warnings
@@ -101,6 +112,7 @@ typedef struct eshkol_resource_limits {
 // ESHKOL_MAX_STACK         - Max stack depth
 // ESHKOL_MAX_TENSOR_ELEMS  - Max tensor elements
 // ESHKOL_MAX_STRING_LEN    - Max string length
+// ESHKOL_VM_MAX_INSN       - Bytecode-VM instruction ceiling (0 = unlimited)
 // ESHKOL_ENFORCE_LIMITS    - "true" or "false"
 // ESHKOL_LIMIT_WARNINGS    - "true" or "false"
 
@@ -369,6 +381,93 @@ eshkol_limit_error_t eshkol_get_last_limit_error(void);
  *         value returns "Unknown limit error".
  */
 const char* eshkol_limit_error_message(eshkol_limit_error_t error);
+
+// ============================================================================
+// Enforcement
+// ============================================================================
+
+/**
+ * @brief Process exit statuses used when a hard resource limit terminates a run.
+ *
+ * `ESHKOL_ENFORCE_LIMITS=true` (the default) is documented to mean that a
+ * hard-limit violation *terminates the process*; these are the statuses it
+ * terminates with, one per limit, so a supervising process can tell which
+ * ceiling was hit without parsing the diagnostic. `ESHKOL_EXIT_LIMIT_TIMEOUT`
+ * is 124 to match GNU coreutils `timeout(1)` — the convention this repository
+ * already uses for the subprocess timeouts in `run-command` / `run-argv`. The
+ * rest occupy the adjacent band below it, and the set deliberately avoids
+ * 126/127, which POSIX shells reserve.
+ */
+#define ESHKOL_EXIT_LIMIT_HEAP    120  // ESHKOL_MAX_HEAP exceeded
+#define ESHKOL_EXIT_LIMIT_STACK   121  // ESHKOL_MAX_STACK exceeded
+#define ESHKOL_EXIT_LIMIT_TENSOR  122  // ESHKOL_MAX_TENSOR_ELEMS exceeded
+#define ESHKOL_EXIT_LIMIT_STRING  123  // ESHKOL_MAX_STRING_LEN exceeded
+#define ESHKOL_EXIT_LIMIT_TIMEOUT 124  // ESHKOL_TIMEOUT_MS exceeded
+#define ESHKOL_EXIT_LIMIT_VM_INSN 125  // ESHKOL_VM_MAX_INSN exceeded
+
+/**
+ * @brief The documented process exit status for a given limit condition.
+ *
+ * @param error Limit condition to map.
+ * @return One of the `ESHKOL_EXIT_LIMIT_*` statuses; `ESHKOL_EXIT_LIMIT_HEAP`
+ *         for the soft-heap warning (which never terminates on its own) and
+ *         for any unrecognized value.
+ */
+int eshkol_limit_exit_code(eshkol_limit_error_t error);
+
+/**
+ * @brief Act on a detected hard-limit violation according to
+ *        `enforce_hard_limits`.
+ *
+ * The single decision point behind every enforced limit, so that "what a
+ * violation does" is defined once rather than re-derived at each call site.
+ *
+ * - When `enforce_hard_limits` is set (the default, `ESHKOL_ENFORCE_LIMITS=true`):
+ *   writes a one-line `eshkol: fatal: ...` diagnostic naming the limit, the
+ *   configured ceiling and the environment variable that sets it, to stderr;
+ *   flushes stdout and stderr so nothing the program already printed is lost;
+ *   requests a runtime interrupt so other threads observe the shutdown; and
+ *   terminates the process with the matching `ESHKOL_EXIT_LIMIT_*` status.
+ *   **Does not return.**
+ * - When it is clear (`ESHKOL_ENFORCE_LIMITS=false`): the limit is advisory.
+ *   Emits a warning if `enable_warnings` is set, leaves the condition readable
+ *   via eshkol_get_last_limit_error(), and returns so the caller can fail just
+ *   that operation — the documented "errors are returned" behaviour.
+ *
+ * @param error  Which limit was breached.
+ * @param detail Optional extra context appended to the diagnostic (may be NULL).
+ */
+void eshkol_limit_enforce(eshkol_limit_error_t error, const char* detail);
+
+/**
+ * @brief Cooperative poll for a pending resource-limit interrupt.
+ *
+ * The execution-timeout watchdog runs on its own thread and can only *request*
+ * an interrupt; something running the user's program has to notice. This is
+ * that noticer: cheap enough to sit on a loop back-edge (it reads one global
+ * and returns when no interrupt is pending) and, when an interrupt IS pending,
+ * routes it through eshkol_limit_enforce() so a timeout terminates with the
+ * documented status instead of being printed and ignored.
+ *
+ * Called from generated code at tail-call loop back-edges, from the recursion
+ * guard at function entry, and from the bytecode VM's dispatch loop.
+ */
+void eshkol_limit_poll_interrupt(void);
+
+/**
+ * @brief Apply `ESHKOL_MAX_TENSOR_ELEMS` to a tensor about to be built.
+ *
+ * Native codegen does not construct tensors through
+ * arena_allocate_tensor_full(); it emits the header, dimension and element
+ * allocations inline and only knows the element count as an SSA value. This is
+ * the entry point generated code calls with that count, so a compiled tensor
+ * is bound by the same ceiling as a runtime-constructed one. Combines
+ * eshkol_check_tensor_size() with eshkol_limit_enforce(); does not return when
+ * the limit is exceeded and enforcement is on.
+ *
+ * @param num_elements Total element count of the tensor being created.
+ */
+void eshkol_enforce_tensor_elements(int64_t num_elements);
 
 // ============================================================================
 // Diagnostics

--- a/inc/eshkol/types/type_checker.h
+++ b/inc/eshkol/types/type_checker.h
@@ -458,6 +458,37 @@ public:
      */
     TypeId resolveType(const hott_type_expr_t* type_expr);
 
+    /**
+     * @brief Whether ascribing @p ascribed to an expression synthesized as
+     *        @p actual is believable, i.e. not a provable contradiction.
+     *
+     * `(the <type> expr)` is a *trusted* assertion: the checker adopts
+     * `<type>` without re-deriving it, and codegen emits `expr` verbatim
+     * (COMPLETE_LANGUAGE_SPECIFICATION.md 3.6.6 — the IR stays
+     * byte-identical, there is no runtime tag check). Trust is not the same
+     * as silence, though: when the inner expression's type IS statically
+     * known and shares no branch of the type graph with the ascribed type,
+     * the ascription cannot be satisfied by any value and is a mistake worth
+     * reporting rather than propagating.
+     *
+     * Deliberately permissive — it only rejects the provably impossible:
+     * - widening (`actual <: ascribed`) is fine;
+     * - narrowing (`ascribed <: actual`) is fine and is the whole point of
+     *   the form (recovering a precise type from a dynamic container);
+     * - anything involving the dynamic root `Value`, or an unresolved type,
+     *   is trusted;
+     * - numeric-tower to numeric-tower is always allowed, because this type
+     *   graph keeps `Integer`/`Rational`/`Real`/`Complex` flat as siblings
+     *   under `Number`, so cross-tower ascriptions like `(the real 1)` have
+     *   no subtyping relation in either direction yet are entirely
+     *   legitimate.
+     *
+     * @param actual   Type synthesized for the inner expression.
+     * @param ascribed Type named by the ascription.
+     * @return false only when the two types are both concrete and disjoint.
+     */
+    bool ascriptionIsBelievable(TypeId actual, TypeId ascribed) const;
+
     // === Dimension Checking (Phase 5.3) ===
 
     /**

--- a/lib/backend/eshkol_compiler.c
+++ b/lib/backend/eshkol_compiler.c
@@ -18,6 +18,7 @@
 #include <ctype.h>
 #include <math.h>
 #include <stdint.h>
+#include "eshkol/core/resource_limits.h"
 
 /* ESKB binary format writer (single-file include pattern) */
 #include "eskb_writer.c"
@@ -3753,12 +3754,23 @@ static void execute_chunk(FuncChunk* chunk) {
     int64_t insn_count = 0;
     int max_depth = 0;
     int trace_on = g_trace_on; /* set by --trace flag */
+
+    /* SW-10: one resolution of the instruction ceiling for the whole run.
+     * This used to call getenv() and atoll() on EVERY instruction, inside the
+     * hottest loop in this interpreter. It also disagreed with the ceiling the
+     * main VM now applies: a value of 0 meant "stop immediately" rather than
+     * the documented "unlimited". Both come from the shared resource-limit
+     * configuration now, so this companion interpreter and vm_run() answer
+     * "has this program run away" the same way. */
+    const uint64_t max_insn = eshkol_get_limits()->max_vm_instructions;
+
     while (!halted && !error && pc < chunk->code_len) {
         if (frame_count > max_depth) max_depth = frame_count;
-        { int64_t max_insn = 10000000LL;
-          const char* env_max = getenv("ESHKOL_VM_MAX_INSN");
-          if (env_max) max_insn = atoll(env_max);
-          if (++insn_count > max_insn) { printf("RUNAWAY (%lld insns, depth=%d, heap=%d)\n", (long long)max_insn, max_depth, heap_next); error=1; break; }
+        if (max_insn > 0 && (uint64_t)(++insn_count) > max_insn) {
+            printf("RUNAWAY (%llu insns, depth=%d, heap=%d)\n",
+                   (unsigned long long)max_insn, max_depth, heap_next);
+            error = 1;
+            break;
         }
         if (trace_on && insn_count < 500) {
             printf("  [%04d] op=%2d sp=%d fp=%d", pc-1, chunk->code[pc-1].op, sp, fp);
@@ -6236,6 +6248,11 @@ static void compile_and_run(const char* source) {
  *        reads it, and calls compile_and_run().
  */
 int main(int argc, char** argv) {
+    /* SW-10: resolve the documented resource-limit environment variables —
+     * ESHKOL_VM_MAX_INSN among them — into the active configuration that
+     * execute_chunk() reads, before any bytecode runs. */
+    eshkol_init_limits_from_env();
+
     printf("=== Eshkol Compiler (targeting 38-opcode VM) ===\n\n");
 
     /* Check for --emit-eskb and --trace flags */

--- a/lib/backend/eshkol_compiler.c
+++ b/lib/backend/eshkol_compiler.c
@@ -3766,7 +3766,8 @@ static void execute_chunk(FuncChunk* chunk) {
 
     while (!halted && !error && pc < chunk->code_len) {
         if (frame_count > max_depth) max_depth = frame_count;
-        if (max_insn > 0 && (uint64_t)(++insn_count) > max_insn) {
+        if (max_insn > 0 && (uint64_t)(++insn_count) > max_insn &&
+            eshkol_limit_is_active(ESHKOL_LIMIT_ACTIVE_VM_INSN)) {
             printf("RUNAWAY (%llu insns, depth=%d, heap=%d)\n",
                    (unsigned long long)max_insn, max_depth, heap_next);
             error = 1;

--- a/lib/backend/eshkol_compiler.c
+++ b/lib/backend/eshkol_compiler.c
@@ -3762,12 +3762,12 @@ static void execute_chunk(FuncChunk* chunk) {
      * the documented "unlimited". Both come from the shared resource-limit
      * configuration now, so this companion interpreter and vm_run() answer
      * "has this program run away" the same way. */
-    const uint64_t max_insn = eshkol_get_limits()->max_vm_instructions;
+    const uint64_t max_insn = g_eshkol_vm_max_insn;
 
     while (!halted && !error && pc < chunk->code_len) {
         if (frame_count > max_depth) max_depth = frame_count;
         if (max_insn > 0 && (uint64_t)(++insn_count) > max_insn &&
-            eshkol_limit_is_active(ESHKOL_LIMIT_ACTIVE_VM_INSN)) {
+            g_eshkol_vm_insn_limit_active) {
             printf("RUNAWAY (%llu insns, depth=%d, heap=%d)\n",
                    (unsigned long long)max_insn, max_depth, heap_next);
             error = 1;
@@ -6252,7 +6252,14 @@ int main(int argc, char** argv) {
     /* SW-10: resolve the documented resource-limit environment variables —
      * ESHKOL_VM_MAX_INSN among them — into the active configuration that
      * execute_chunk() reads, before any bytecode runs. */
-    eshkol_init_limits_from_env();
+    {
+        eshkol_resource_limits_t limits = eshkol_init_limits_from_env();
+        eshkol_vm_install_limits(
+            limits.max_vm_instructions,
+            eshkol_limit_is_active(ESHKOL_LIMIT_ACTIVE_VM_INSN),
+            limits.enforce_hard_limits,
+            eshkol_limit_poll_interrupt);
+    }
 
     printf("=== Eshkol Compiler (targeting 38-opcode VM) ===\n\n");
 

--- a/lib/backend/eshkol_vm.c
+++ b/lib/backend/eshkol_vm.c
@@ -80,6 +80,7 @@
 #endif
 
 #include "eshkol/backend/vm_limits.h"
+#include "eshkol/core/resource_limits.h"
 #include "eshkol/backend/vm.h"
 #ifndef ESHKOL_VM_WASM
 #include "eshkol/core/runtime.h"
@@ -2093,6 +2094,12 @@ int eshkol_vm_top_int64(EshkolVmHandle* h, int64_t* out) {
 
 #if !defined(ESHKOL_VM_LIBRARY_MODE) && !defined(GENERATE_PRELUDE_CACHE)
 int main(int argc, char** argv) {
+    /* SW-10: resolve the documented resource-limit environment variables before
+     * anything runs. The VM sources themselves are freestanding-safe and never
+     * touch the environment; this hosted entry point is where ESHKOL_VM_MAX_INSN
+     * (and its siblings) become the active configuration that vm_run() reads. */
+    eshkol_init_limits_from_env();
+
     if (argc > 1) {
         /* Parse flags */
         int trace = 0;

--- a/lib/backend/eshkol_vm.c
+++ b/lib/backend/eshkol_vm.c
@@ -2098,7 +2098,14 @@ int main(int argc, char** argv) {
      * anything runs. The VM sources themselves are freestanding-safe and never
      * touch the environment; this hosted entry point is where ESHKOL_VM_MAX_INSN
      * (and its siblings) become the active configuration that vm_run() reads. */
-    eshkol_init_limits_from_env();
+    {
+        eshkol_resource_limits_t limits = eshkol_init_limits_from_env();
+        eshkol_vm_install_limits(
+            limits.max_vm_instructions,
+            eshkol_limit_is_active(ESHKOL_LIMIT_ACTIVE_VM_INSN),
+            limits.enforce_hard_limits,
+            eshkol_limit_poll_interrupt);
+    }
 
     if (argc > 1) {
         /* Parse flags */

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -28013,6 +28013,32 @@ private:
             builder->CreateCall(stackrestore_fn, {tco_ctx.loop_stack_save});
         }
 
+        // SW-10: cooperative execution-timeout poll on the tail-call back-edge.
+        //
+        // This is the ONE place every self-tail-call back-edge is emitted, for
+        // both `define`-TCO and named-let, and a TCO loop is precisely the
+        // shape that runs forever without entering a new frame — so the
+        // function-entry guard never sees it and `ESHKOL_TIMEOUT_MS` had
+        // nothing to act on. The watchdog thread can only *request* an
+        // interrupt; this is the code that notices.
+        //
+        // Cost is a load of the interrupt flag and a not-taken branch per
+        // iteration: eshkol_limit_poll_interrupt() returns immediately when no
+        // interrupt is pending, and no timer is even armed unless the user
+        // asked for one. It reads and writes no program value, so it cannot
+        // perturb arithmetic — gradients stay bit-identical.
+        {
+            Function* poll_fn = module->getFunction("eshkol_limit_poll_interrupt");
+            if (!poll_fn) {
+                FunctionType* poll_type =
+                    FunctionType::get(Type::getVoidTy(*context), {}, false);
+                poll_fn = Function::Create(poll_type, Function::ExternalLinkage,
+                                           "eshkol_limit_poll_interrupt",
+                                           module.get());
+            }
+            builder->CreateCall(poll_fn, {});
+        }
+
         // Create unreachable sentinel BEFORE the branch (can't add instructions
         // after terminator). Caller never observes this value — the block ends
         // with the unconditional jump back to the loop header.

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -1904,6 +1904,23 @@ private:
         return !freestanding_codegen_ && !wasm_codegen_;
     }
 
+    // SW-10: the cooperative execution-timeout poll on the tail-call back-edge
+    // only exists where something can request an interrupt. The requester is
+    // the hosted watchdog thread in lib/core/resource_limits.cpp, which is not
+    // in the freestanding source set and is not linked into a standalone wasm
+    // module at all — so in those profiles the poll can never observe an
+    // interrupt, and emitting it only creates a dependency on a symbol the
+    // profile does not have. On wasm32 that dependency is an `env` import the
+    // JS glue would have to stub, and the stub would then be called across the
+    // JS boundary on every iteration of every loop in the program.
+    //
+    // Same direction as the VM's limit installer (see
+    // eshkol_vm_install_limits): a build with no hosted runtime to push the
+    // configuration in keeps the compiled-in default and links nothing extra.
+    bool timeoutInterruptPollEnabled() const {
+        return !freestanding_codegen_ && !wasm_codegen_;
+    }
+
     // Module prefix for unique lambda naming (prevents symbol collision when linking)
     std::string module_prefix;
 
@@ -28027,7 +28044,10 @@ private:
         // interrupt is pending, and no timer is even armed unless the user
         // asked for one. It reads and writes no program value, so it cannot
         // perturb arithmetic — gradients stay bit-identical.
-        {
+        //
+        // Only where a hosted watchdog can raise the interrupt in the first
+        // place: see timeoutInterruptPollEnabled().
+        if (timeoutInterruptPollEnabled()) {
             Function* poll_fn = module->getFunction("eshkol_limit_poll_interrupt");
             if (!poll_fn) {
                 FunctionType* poll_type =

--- a/lib/backend/tensor_creation_codegen.cpp
+++ b/lib/backend/tensor_creation_codegen.cpp
@@ -38,6 +38,31 @@ namespace eshkol {
 
 // ===== TENSOR CREATION HELPER =====
 
+/**
+ * @brief Emit the ESHKOL_MAX_TENSOR_ELEMS check for a runtime element count.
+ *
+ * Shared by both tensor-construction helpers below. The emitted call is a
+ * single runtime call per tensor creation — not per element — and does not
+ * touch the tensor's data, so it cannot change any computed value.
+ */
+void TensorCodegen::emitTensorElementLimitCheck(llvm::Value* total_elements) {
+    if (!total_elements) return;
+    auto& builder = ctx_.builder();
+    llvm::Module& module = ctx_.module();
+    llvm::Function* fn = module.getFunction("eshkol_enforce_tensor_elements");
+    if (!fn) {
+        llvm::FunctionType* ft = llvm::FunctionType::get(
+            llvm::Type::getVoidTy(ctx_.context()), {ctx_.int64Type()}, false);
+        fn = llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
+                                    "eshkol_enforce_tensor_elements", &module);
+    }
+    llvm::Value* count = total_elements;
+    if (count->getType() != ctx_.int64Type()) {
+        count = builder.CreateIntCast(count, ctx_.int64Type(), true);
+    }
+    builder.CreateCall(fn, {count});
+}
+
 llvm::Value* TensorCodegen::createTensorWithDims(const std::vector<llvm::Value*>& dims,
                                                    llvm::Value* fill_value,
                                                    bool use_memset_zero) {
@@ -55,6 +80,13 @@ llvm::Value* TensorCodegen::createTensorWithDims(const std::vector<llvm::Value*>
     for (size_t i = 1; i < dims.size(); i++) {
         total_elements = builder.CreateMul(total_elements, dims[i]);
     }
+
+    // SW-10: ESHKOL_MAX_TENSOR_ELEMS. Generated code builds a tensor out of
+    // three separate arena allocations rather than going through
+    // arena_allocate_tensor_full(), so the ceiling has to be applied here,
+    // where the element count first exists, or a compiled `make-tensor` would
+    // escape a limit that a runtime-constructed tensor respects.
+    emitTensorElementLimitCheck(total_elements);
 
     // Allocate tensor structure with header using arena
     llvm::Function* alloc_tensor_func = mem_.getArenaAllocateTensorWithHeader();
@@ -150,6 +182,9 @@ llvm::Value* TensorCodegen::createTensorFromDimsArray(llvm::Value* dims_ptr,
         llvm::PointerType::get(context, 0), ctx_.globalArena());
     llvm::StructType* tensor_type = ctx_.tensorType();
     llvm::Function* arena_alloc = mem_.getArenaAllocate();
+
+    // SW-10: same ceiling as createTensorWithDims, for the runtime-shape path.
+    emitTensorElementLimitCheck(total);
 
     // Allocate tensor structure with header using arena
     llvm::Function* alloc_tensor_func = mem_.getArenaAllocateTensorWithHeader();

--- a/lib/backend/vm_run.c
+++ b/lib/backend/vm_run.c
@@ -26,6 +26,62 @@ static int vm_is_exact_number(Value v) {
            v.type == VAL_RATIONAL || v.type == VAL_I128;
 }
 
+/* ===== SW-10: VM runaway-instruction guard and timeout checkpoint =====
+ *
+ * `ESHKOL_VM_MAX_INSN` is documented as the VM's runaway-instruction guard,
+ * default 10,000,000. Only the MSVC `switch` fallback below ever had a guard,
+ * it was hard-coded to 10M with no environment override, and the computed-goto
+ * path that every GCC/Clang build actually runs had none at all — so the two
+ * dispatch implementations of one interpreter disagreed about when a program
+ * is runaway. Both now share the counters below.
+ *
+ * Cost discipline: the per-instruction work is a single decrement-and-branch
+ * on a local budget. Everything real — comparing the total against the cap,
+ * polling for a timeout interrupt — happens once per VM_CHECK_INTERVAL
+ * instructions inside vm_limits_checkpoint(), which is not inlined into the
+ * dispatch path. The environment variable is read once per vm_run(), not once
+ * per instruction. */
+#define VM_CHECK_INTERVAL 4096u
+
+/** Resolve the instruction ceiling once per vm_run().
+ *
+ * The value comes from the active resource-limit configuration, not from the
+ * environment directly: these VM sources are freestanding-safe and may not read
+ * environment variables at all (enforced by
+ * tests/toolchain/vm_source_boundary_test.cpp), so `ESHKOL_VM_MAX_INSN` is
+ * parsed by eshkol_init_limits_from_env() alongside the other ceilings and
+ * arrives here through eshkol_get_limits(). 0 = unlimited. */
+static uint64_t vm_resolve_max_insn(void) {
+    const eshkol_resource_limits_t* limits = eshkol_get_limits();
+    return limits ? limits->max_vm_instructions : ESHKOL_VM_DEFAULT_MAX_INSN;
+}
+
+/** Periodic limit checkpoint. Returns 1 if the VM should keep running. */
+static int vm_limits_checkpoint(VM* vm, uint64_t* executed, uint64_t max_insn) {
+    *executed += VM_CHECK_INTERVAL;
+
+    if (max_insn > 0 && *executed > max_insn) {
+        char detail[128];
+        snprintf(detail, sizeof(detail),
+                 "bytecode VM executed %llu instructions (pc=%d)",
+                 (unsigned long long)*executed, vm->pc);
+        fflush(stdout);
+        fprintf(stderr, "eshkol: fatal: %s, limit %llu, set by ESHKOL_VM_MAX_INSN\n",
+                detail, (unsigned long long)max_insn);
+        fflush(stderr);
+        if (eshkol_get_limits()->enforce_hard_limits) {
+            _Exit(ESHKOL_EXIT_LIMIT_VM_INSN);
+        }
+        vm->error = 1;  /* advisory mode: stop this run, do not kill the process */
+        return 0;
+    }
+
+    /* Same cooperative timeout poll the native engine does at loop back-edges;
+     * the watchdog thread can only request the interrupt, someone has to act. */
+    eshkol_limit_poll_interrupt();
+    return 1;
+}
+
 static size_t vm_continuation_allocation_size(const VM* vm) {
     return sizeof(VmContinuation) +
         (size_t)vm->sp * sizeof(Value) +
@@ -183,11 +239,19 @@ void vm_run(VM* vm) {
 
     #define DISPATCH() do { \
         if (vm->halted || vm->error || vm->pc >= vm->code_len) goto vm_exit; \
+        if (--vm_check_budget == 0) { \
+            vm_check_budget = VM_CHECK_INTERVAL; \
+            if (!vm_limits_checkpoint(vm, &vm_insns_executed, vm_max_insn)) \
+                goto vm_exit; \
+        } \
         instr = vm->code[vm->pc++]; \
         goto *dispatch_table[instr.op]; \
     } while(0)
 
     Instr instr;
+    uint64_t vm_insns_executed = 0;
+    const uint64_t vm_max_insn = vm_resolve_max_insn();
+    unsigned vm_check_budget = VM_CHECK_INTERVAL;
     DISPATCH();
 
     /* --- Constants & Stack --- */
@@ -1047,12 +1111,16 @@ vm_exit:
  * Fallback: standard switch dispatch for non-GCC/Clang compilers (MSVC etc.)
  * ========================================================================= */
 
-    int step_count = 0;
+    /* Same guard and the same configurable ceiling as the computed-goto path
+     * above, so the two dispatch implementations of this one interpreter agree
+     * about when a program has run away. */
+    uint64_t vm_insns_executed = 0;
+    const uint64_t vm_max_insn = vm_resolve_max_insn();
+    unsigned vm_check_budget = VM_CHECK_INTERVAL;
     while (!vm->halted && !vm->error && vm->pc < vm->code_len) {
-        if (++step_count > 10000000) {
-            fprintf(stderr, "VM: 10M steps exceeded at pc=%d op=%d fp=%d sp=%d fc=%d\n",
-                    vm->pc, vm->code[vm->pc].op, vm->fp, vm->sp, vm->frame_count);
-            vm->error = 1; break;
+        if (--vm_check_budget == 0) {
+            vm_check_budget = VM_CHECK_INTERVAL;
+            if (!vm_limits_checkpoint(vm, &vm_insns_executed, vm_max_insn)) break;
         }
         Instr instr = vm->code[vm->pc++];
 

--- a/lib/backend/vm_run.c
+++ b/lib/backend/vm_run.c
@@ -60,7 +60,8 @@ static uint64_t vm_resolve_max_insn(void) {
 static int vm_limits_checkpoint(VM* vm, uint64_t* executed, uint64_t max_insn) {
     *executed += VM_CHECK_INTERVAL;
 
-    if (max_insn > 0 && *executed > max_insn) {
+    if (max_insn > 0 && *executed > max_insn &&
+        eshkol_limit_is_active(ESHKOL_LIMIT_ACTIVE_VM_INSN)) {
         char detail[128];
         snprintf(detail, sizeof(detail),
                  "bytecode VM executed %llu instructions (pc=%d)",

--- a/lib/backend/vm_run.c
+++ b/lib/backend/vm_run.c
@@ -43,25 +43,43 @@ static int vm_is_exact_number(Value v) {
  * per instruction. */
 #define VM_CHECK_INTERVAL 4096u
 
-/** Resolve the instruction ceiling once per vm_run().
+/* VM-OWNED limit state.
  *
- * The value comes from the active resource-limit configuration, not from the
- * environment directly: these VM sources are freestanding-safe and may not read
- * environment variables at all (enforced by
- * tests/toolchain/vm_source_boundary_test.cpp), so `ESHKOL_VM_MAX_INSN` is
- * parsed by eshkol_init_limits_from_env() alongside the other ceilings and
- * arrives here through eshkol_get_limits(). 0 = unlimited. */
-static uint64_t vm_resolve_max_insn(void) {
-    const eshkol_resource_limits_t* limits = eshkol_get_limits();
-    return limits ? limits->max_vm_instructions : ESHKOL_VM_DEFAULT_MAX_INSN;
+ * These deliberately do NOT reach into the hosted resource-limit layer. The VM
+ * sources are freestanding-safe and are also compiled to WebAssembly, where
+ * lib/core/resource_limits.cpp is not linked at all — an earlier cut of this
+ * fix called eshkol_get_limits() straight from here and every WASM run died
+ * with `missing function: eshkol_get_limits`, taking the whole
+ * wasm_execute_diff_oracle corpus (65 programs) down with it.
+ *
+ * So the dependency runs the other way: hosted entry points RESOLVE the
+ * configuration and PUSH it in via eshkol_vm_install_limits(). A build that
+ * never calls that installer — WASM, or any freestanding profile — keeps the
+ * compiled-in defaults below and links nothing extra. */
+uint64_t g_eshkol_vm_max_insn = ESHKOL_VM_DEFAULT_MAX_INSN;
+int      g_eshkol_vm_insn_limit_active = 0;   /* opt-in, like every ceiling */
+int      g_eshkol_vm_enforce_hard_limits = 1;
+void   (*g_eshkol_vm_poll_interrupt)(void) = 0;
+
+/** Install the resolved limit configuration from a hosted entry point.
+ *
+ * @param max_insn   Instruction ceiling (0 = unlimited).
+ * @param active     Non-zero if ESHKOL_VM_MAX_INSN was actually asked for.
+ * @param enforce    Non-zero to terminate rather than merely record a breach.
+ * @param poll       Cooperative timeout poll, or NULL for none. */
+void eshkol_vm_install_limits(uint64_t max_insn, int active, int enforce,
+                              void (*poll)(void)) {
+    g_eshkol_vm_max_insn = max_insn;
+    g_eshkol_vm_insn_limit_active = active;
+    g_eshkol_vm_enforce_hard_limits = enforce;
+    g_eshkol_vm_poll_interrupt = poll;
 }
 
 /** Periodic limit checkpoint. Returns 1 if the VM should keep running. */
 static int vm_limits_checkpoint(VM* vm, uint64_t* executed, uint64_t max_insn) {
     *executed += VM_CHECK_INTERVAL;
 
-    if (max_insn > 0 && *executed > max_insn &&
-        eshkol_limit_is_active(ESHKOL_LIMIT_ACTIVE_VM_INSN)) {
+    if (max_insn > 0 && *executed > max_insn && g_eshkol_vm_insn_limit_active) {
         char detail[128];
         snprintf(detail, sizeof(detail),
                  "bytecode VM executed %llu instructions (pc=%d)",
@@ -70,7 +88,7 @@ static int vm_limits_checkpoint(VM* vm, uint64_t* executed, uint64_t max_insn) {
         fprintf(stderr, "eshkol: fatal: %s, limit %llu, set by ESHKOL_VM_MAX_INSN\n",
                 detail, (unsigned long long)max_insn);
         fflush(stderr);
-        if (eshkol_get_limits()->enforce_hard_limits) {
+        if (g_eshkol_vm_enforce_hard_limits) {
             _Exit(ESHKOL_EXIT_LIMIT_VM_INSN);
         }
         vm->error = 1;  /* advisory mode: stop this run, do not kill the process */
@@ -78,8 +96,9 @@ static int vm_limits_checkpoint(VM* vm, uint64_t* executed, uint64_t max_insn) {
     }
 
     /* Same cooperative timeout poll the native engine does at loop back-edges;
-     * the watchdog thread can only request the interrupt, someone has to act. */
-    eshkol_limit_poll_interrupt();
+     * the watchdog thread can only request the interrupt, someone has to act.
+     * NULL in builds with no hosted runtime (WASM, freestanding). */
+    if (g_eshkol_vm_poll_interrupt) g_eshkol_vm_poll_interrupt();
     return 1;
 }
 
@@ -251,7 +270,7 @@ void vm_run(VM* vm) {
 
     Instr instr;
     uint64_t vm_insns_executed = 0;
-    const uint64_t vm_max_insn = vm_resolve_max_insn();
+    const uint64_t vm_max_insn = g_eshkol_vm_max_insn;
     unsigned vm_check_budget = VM_CHECK_INTERVAL;
     DISPATCH();
 
@@ -1116,7 +1135,7 @@ vm_exit:
      * above, so the two dispatch implementations of this one interpreter agree
      * about when a program has run away. */
     uint64_t vm_insns_executed = 0;
-    const uint64_t vm_max_insn = vm_resolve_max_insn();
+    const uint64_t vm_max_insn = g_eshkol_vm_max_insn;
     unsigned vm_check_budget = VM_CHECK_INTERVAL;
     while (!vm->halted && !vm->error && vm->pc < vm->code_len) {
         if (--vm_check_budget == 0) {

--- a/lib/core/resource_limits.cpp
+++ b/lib/core/resource_limits.cpp
@@ -46,6 +46,8 @@ eshkol_resource_limits_t make_default_limits() {
     limits.max_vm_instructions = ESHKOL_DEFAULT_MAX_VM_INSTRUCTIONS;
     limits.enforce_hard_limits = true;
     limits.enable_warnings = true;
+    // No ceiling is active until something asks for one. See the header.
+    limits.active_limits = 0;
     return limits;
 }
 
@@ -230,6 +232,7 @@ eshkol_resource_limits_t eshkol_init_limits_from_env(void) {
     if (max_heap) {
         limits.max_heap_bytes = parse_size_or_default(max_heap, limits.max_heap_bytes);
         limits.heap_soft_limit_bytes = (limits.max_heap_bytes * ESHKOL_HEAP_SOFT_LIMIT_PERCENT) / 100;
+        limits.active_limits |= ESHKOL_LIMIT_ACTIVE_HEAP;
         eshkol_debug("Max heap from env: %zu bytes", limits.max_heap_bytes);
     }
 
@@ -237,6 +240,7 @@ eshkol_resource_limits_t eshkol_init_limits_from_env(void) {
     const char* timeout = std::getenv("ESHKOL_TIMEOUT_MS");
     if (timeout) {
         limits.max_execution_time_ms = parse_u64_or_default(timeout, limits.max_execution_time_ms);
+        limits.active_limits |= ESHKOL_LIMIT_ACTIVE_TIMEOUT;
         eshkol_debug("Timeout from env: %llu ms", (unsigned long long)limits.max_execution_time_ms);
     }
 
@@ -244,6 +248,7 @@ eshkol_resource_limits_t eshkol_init_limits_from_env(void) {
     const char* max_stack = std::getenv("ESHKOL_MAX_STACK");
     if (max_stack) {
         limits.max_stack_depth = parse_size_or_default(max_stack, limits.max_stack_depth);
+        limits.active_limits |= ESHKOL_LIMIT_ACTIVE_STACK;
         eshkol_debug("Max stack from env: %zu", limits.max_stack_depth);
     }
 
@@ -251,6 +256,7 @@ eshkol_resource_limits_t eshkol_init_limits_from_env(void) {
     const char* max_tensor = std::getenv("ESHKOL_MAX_TENSOR_ELEMS");
     if (max_tensor) {
         limits.max_tensor_elements = parse_size_or_default(max_tensor, limits.max_tensor_elements);
+        limits.active_limits |= ESHKOL_LIMIT_ACTIVE_TENSOR;
         eshkol_debug("Max tensor elements from env: %zu", limits.max_tensor_elements);
     }
 
@@ -258,6 +264,7 @@ eshkol_resource_limits_t eshkol_init_limits_from_env(void) {
     const char* max_string = std::getenv("ESHKOL_MAX_STRING_LEN");
     if (max_string) {
         limits.max_string_length = parse_size_or_default(max_string, limits.max_string_length);
+        limits.active_limits |= ESHKOL_LIMIT_ACTIVE_STRING;
         eshkol_debug("Max string length from env: %zu", limits.max_string_length);
     }
 
@@ -268,6 +275,7 @@ eshkol_resource_limits_t eshkol_init_limits_from_env(void) {
     if (max_vm_insn) {
         limits.max_vm_instructions =
             parse_u64_or_default(max_vm_insn, limits.max_vm_instructions);
+        limits.active_limits |= ESHKOL_LIMIT_ACTIVE_VM_INSN;
         eshkol_debug("Max VM instructions from env: %llu",
                      (unsigned long long)limits.max_vm_instructions);
     }
@@ -311,6 +319,11 @@ void eshkol_set_limits(const eshkol_resource_limits_t* limits) {
                 g_limits.max_heap_bytes / (1024 * 1024),
                 (unsigned long long)g_limits.max_execution_time_ms,
                 g_limits.max_stack_depth);
+}
+
+/** Whether a given ceiling was asked for and should be enforced. */
+bool eshkol_limit_is_active(uint32_t which) {
+    return (g_limits.active_limits & which) != 0;
 }
 
 /** Return a pointer to the currently active resource limits. */
@@ -758,6 +771,7 @@ void eshkol_limit_enforce(eshkol_limit_error_t error, const char* detail) {
 /** @brief Apply the tensor-element ceiling to a count computed by generated code. */
 void eshkol_enforce_tensor_elements(int64_t num_elements) {
     if (num_elements <= 0) return;
+    if (!eshkol_limit_is_active(ESHKOL_LIMIT_ACTIVE_TENSOR)) return;
     if (eshkol_check_tensor_size((size_t)num_elements)) return;
 
     char detail[64];

--- a/lib/core/resource_limits.cpp
+++ b/lib/core/resource_limits.cpp
@@ -18,6 +18,7 @@
 #include <chrono>
 #include <cerrno>
 #include <cctype>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <cmath>
@@ -42,6 +43,7 @@ eshkol_resource_limits_t make_default_limits() {
     limits.max_stack_depth = ESHKOL_DEFAULT_MAX_STACK_DEPTH;
     limits.max_tensor_elements = ESHKOL_DEFAULT_MAX_TENSOR_ELEMENTS;
     limits.max_string_length = ESHKOL_DEFAULT_MAX_STRING_LENGTH;
+    limits.max_vm_instructions = ESHKOL_DEFAULT_MAX_VM_INSTRUCTIONS;
     limits.enforce_hard_limits = true;
     limits.enable_warnings = true;
     return limits;
@@ -257,6 +259,17 @@ eshkol_resource_limits_t eshkol_init_limits_from_env(void) {
     if (max_string) {
         limits.max_string_length = parse_size_or_default(max_string, limits.max_string_length);
         eshkol_debug("Max string length from env: %zu", limits.max_string_length);
+    }
+
+    // ESHKOL_VM_MAX_INSN. Parsed here with its six siblings so the bytecode VM
+    // — a freestanding-safe source family that may not call getenv() — receives
+    // it through eshkol_get_limits() like every other ceiling it obeys.
+    const char* max_vm_insn = std::getenv("ESHKOL_VM_MAX_INSN");
+    if (max_vm_insn) {
+        limits.max_vm_instructions =
+            parse_u64_or_default(max_vm_insn, limits.max_vm_instructions);
+        eshkol_debug("Max VM instructions from env: %llu",
+                     (unsigned long long)limits.max_vm_instructions);
     }
 
     // ESHKOL_ENFORCE_LIMITS
@@ -641,6 +654,131 @@ const char* eshkol_limit_error_message(eshkol_limit_error_t error) {
         default:
             return "Unknown limit error";
     }
+}
+
+// ----------------------------------------------------------------------------
+// Enforcement
+// ----------------------------------------------------------------------------
+
+/** Map a limit condition to its documented process exit status. */
+int eshkol_limit_exit_code(eshkol_limit_error_t error) {
+    switch (error) {
+        case ESHKOL_LIMIT_HEAP_HARD:      return ESHKOL_EXIT_LIMIT_HEAP;
+        case ESHKOL_LIMIT_STACK_OVERFLOW: return ESHKOL_EXIT_LIMIT_STACK;
+        case ESHKOL_LIMIT_TENSOR_SIZE:    return ESHKOL_EXIT_LIMIT_TENSOR;
+        case ESHKOL_LIMIT_STRING_LENGTH:  return ESHKOL_EXIT_LIMIT_STRING;
+        case ESHKOL_LIMIT_TIMEOUT:        return ESHKOL_EXIT_LIMIT_TIMEOUT;
+        case ESHKOL_LIMIT_OK:
+        case ESHKOL_LIMIT_HEAP_SOFT:
+        default:                          return ESHKOL_EXIT_LIMIT_HEAP;
+    }
+}
+
+/** The environment variable that configures each limit, for the diagnostic. */
+static const char* limit_env_var(eshkol_limit_error_t error) {
+    switch (error) {
+        case ESHKOL_LIMIT_HEAP_HARD:
+        case ESHKOL_LIMIT_HEAP_SOFT:      return "ESHKOL_MAX_HEAP";
+        case ESHKOL_LIMIT_STACK_OVERFLOW: return "ESHKOL_MAX_STACK";
+        case ESHKOL_LIMIT_TENSOR_SIZE:    return "ESHKOL_MAX_TENSOR_ELEMS";
+        case ESHKOL_LIMIT_STRING_LENGTH:  return "ESHKOL_MAX_STRING_LEN";
+        case ESHKOL_LIMIT_TIMEOUT:        return "ESHKOL_TIMEOUT_MS";
+        default:                          return "ESHKOL_ENFORCE_LIMITS";
+    }
+}
+
+/** The configured ceiling for each limit, rendered for the diagnostic. */
+static void format_limit_ceiling(eshkol_limit_error_t error,
+                                 char* out, size_t out_size) {
+    switch (error) {
+        case ESHKOL_LIMIT_HEAP_HARD:
+        case ESHKOL_LIMIT_HEAP_SOFT:
+            snprintf(out, out_size, "%zu bytes", g_limits.max_heap_bytes);
+            break;
+        case ESHKOL_LIMIT_STACK_OVERFLOW:
+            snprintf(out, out_size, "%zu frames", g_limits.max_stack_depth);
+            break;
+        case ESHKOL_LIMIT_TENSOR_SIZE:
+            snprintf(out, out_size, "%zu elements", g_limits.max_tensor_elements);
+            break;
+        case ESHKOL_LIMIT_STRING_LENGTH:
+            snprintf(out, out_size, "%zu bytes", g_limits.max_string_length);
+            break;
+        case ESHKOL_LIMIT_TIMEOUT:
+            snprintf(out, out_size, "%llums",
+                     (unsigned long long)g_limits.max_execution_time_ms);
+            break;
+        default:
+            snprintf(out, out_size, "n/a");
+            break;
+    }
+}
+
+/** @brief Terminate (or merely record) a hard-limit violation.
+ *
+ * See the header for the contract. The terminating branch deliberately uses
+ * `_Exit()` rather than `exit()`: every caller is either inside the allocator
+ * or on a hot execution path, and running atexit handlers plus static
+ * destructors from there re-enters the very machinery that just failed. The
+ * streams are flushed by hand first so the program's own output, and this
+ * diagnostic, are never lost to that shortcut. */
+void eshkol_limit_enforce(eshkol_limit_error_t error, const char* detail) {
+    g_last_error.store(error, std::memory_order_relaxed);
+
+    char ceiling[64];
+    format_limit_ceiling(error, ceiling, sizeof(ceiling));
+
+    if (!g_limits.enforce_hard_limits) {
+        // Advisory mode: ESHKOL_ENFORCE_LIMITS=false documents that errors are
+        // returned rather than fatal, so the caller fails just this operation.
+        if (g_limits.enable_warnings) {
+            eshkol_warn("%s (limit %s, set by %s)%s%s",
+                        eshkol_limit_error_message(error), ceiling,
+                        limit_env_var(error),
+                        detail ? ": " : "", detail ? detail : "");
+        }
+        return;
+    }
+
+    fflush(stdout);
+    fprintf(stderr,
+            "eshkol: fatal: %s (limit %s, set by %s)%s%s\n",
+            eshkol_limit_error_message(error), ceiling, limit_env_var(error),
+            detail ? ": " : "", detail ? detail : "");
+    fflush(stderr);
+
+    // Let any other thread see the shutdown before this one leaves.
+    eshkol_runtime_request_interrupt(error == ESHKOL_LIMIT_TIMEOUT
+                                         ? ESHKOL_SHUTDOWN_TIMEOUT
+                                         : ESHKOL_SHUTDOWN_MEMORY);
+
+    _Exit(eshkol_limit_exit_code(error));
+}
+
+/** @brief Apply the tensor-element ceiling to a count computed by generated code. */
+void eshkol_enforce_tensor_elements(int64_t num_elements) {
+    if (num_elements <= 0) return;
+    if (eshkol_check_tensor_size((size_t)num_elements)) return;
+
+    char detail[64];
+    snprintf(detail, sizeof(detail), "requested %lld elements",
+             (long long)num_elements);
+    eshkol_limit_enforce(ESHKOL_LIMIT_TENSOR_SIZE, detail);
+}
+
+/** @brief Notice an interrupt requested by the timeout watchdog (or a signal).
+ *
+ * Deliberately trivial in the common case — one relaxed read of the interrupt
+ * flag — because this sits on loop back-edges and in the VM dispatch loop. */
+void eshkol_limit_poll_interrupt(void) {
+    if (!g_eshkol_interrupt_flag) return;
+
+    // A timeout is the one interrupt this layer owns; anything else (a signal,
+    // an explicit shutdown request) belongs to the runtime's own handlers, so
+    // leave the flag set for them and return.
+    if (eshkol_runtime_get_shutdown_reason() != ESHKOL_SHUTDOWN_TIMEOUT) return;
+
+    eshkol_limit_enforce(ESHKOL_LIMIT_TIMEOUT, nullptr);
 }
 
 // ----------------------------------------------------------------------------

--- a/lib/core/runtime_arena_core.cpp
+++ b/lib/core/runtime_arena_core.cpp
@@ -60,7 +60,11 @@ static arena_block_t* create_arena_block(size_t size) {
     // bump-pointer fast path in arena_allocate_aligned() byte-for-byte as it
     // was. It cannot perturb any computation: it either admits the block or
     // ends the process.
-    if (!eshkol_track_allocation(size)) {
+    // The heap ceiling only binds a run that asked for one (ESHKOL_MAX_HEAP).
+    // eshkol_track_allocation() still accounts every block either way, so
+    // eshkol_get_heap_usage()/peak stay accurate for diagnostics.
+    if (!eshkol_track_allocation(size) &&
+        eshkol_limit_is_active(ESHKOL_LIMIT_ACTIVE_HEAP)) {
         // Terminates under ESHKOL_ENFORCE_LIMITS=true. If it returns, limits
         // are advisory: record the breach and hand the block over anyway. The
         // arena's callers treat a null block as a fatal allocation failure, so

--- a/lib/core/runtime_arena_core.cpp
+++ b/lib/core/runtime_arena_core.cpp
@@ -8,6 +8,7 @@
 
 #include "arena_memory.h"
 #include "../../inc/eshkol/logger.h"
+#include <eshkol/core/resource_limits.h>
 
 #include <assert.h>
 #include <stdlib.h>
@@ -51,9 +52,27 @@ static size_t align_block_offset(const arena_block_t* block, size_t used, size_t
 
 // Create a new arena block
 static arena_block_t* create_arena_block(size_t size) {
+    // SW-10: the process heap ceiling (ESHKOL_MAX_HEAP) is enforced here
+    // because this is the ONE place the arena asks the OS for memory — every
+    // other allocation is a bump of a pointer inside a block that already
+    // exists. Checking here therefore costs one comparison per block (a
+    // megabyte at a time by default), never one per object, and leaves the
+    // bump-pointer fast path in arena_allocate_aligned() byte-for-byte as it
+    // was. It cannot perturb any computation: it either admits the block or
+    // ends the process.
+    if (!eshkol_track_allocation(size)) {
+        // Terminates under ESHKOL_ENFORCE_LIMITS=true. If it returns, limits
+        // are advisory: record the breach and hand the block over anyway. The
+        // arena's callers treat a null block as a fatal allocation failure, so
+        // refusing here would make "limits are not enforced" the more violent
+        // of the two settings.
+        eshkol_limit_enforce(ESHKOL_LIMIT_HEAP_HARD, "arena block");
+    }
+
     arena_block_t* block = (arena_block_t*)malloc(sizeof(arena_block_t));
     if (!block) {
         eshkol_error("Failed to allocate arena block structure");
+        eshkol_track_deallocation(size);
         return nullptr;
     }
 
@@ -61,6 +80,7 @@ static arena_block_t* create_arena_block(size_t size) {
     if (!block->memory) {
         eshkol_error("Failed to allocate arena block memory of size %zu", size);
         free(block);
+        eshkol_track_deallocation(size);
         return nullptr;
     }
 
@@ -74,6 +94,11 @@ static arena_block_t* create_arena_block(size_t size) {
 // Free an arena block
 static void free_arena_block(arena_block_t* block) {
     if (block) {
+        // Mirror of the create_arena_block() accounting, so a program that
+        // allocates and releases in a loop is measured by what it HOLDS rather
+        // than by everything it has ever touched. Without this pairing the
+        // heap ceiling would degrade into a cap on cumulative allocation.
+        eshkol_track_deallocation(block->size);
         free(block->memory);
         free(block);
     }

--- a/lib/core/runtime_list_helpers.cpp
+++ b/lib/core/runtime_list_helpers.cpp
@@ -11,6 +11,7 @@
  */
 
 #include "arena_memory.h"
+#include <eshkol/core/resource_limits.h>
 
 #include <cstdint>
 #include <cstring>
@@ -521,15 +522,31 @@ int64_t eshkol_ad_extract_doubles(const eshkol_tagged_value_t* input,
 // Per-thread recursion depth counter.
 // thread_local is correct: recursion depth tracks the call stack, per thread.
 static thread_local int64_t __eshkol_recursion_depth = 0;
-static const int64_t ESHKOL_MAX_RECURSION_DEPTH = 100000;  // 100K frames
 
 /**
  * @brief Increment and check the calling thread's recursion-depth counter.
  *
  * Emitted inline by codegen at the entry of recursive-call sites to guard
- * against native stack overflow. If the counter exceeds
- * ESHKOL_MAX_RECURSION_DEPTH (100,000), resets it to 0 and raises a fatal
- * ESHKOL_EXCEPTION_ERROR rather than letting the recursion continue.
+ * against native stack overflow. Exceeding the ceiling resets the counter and
+ * terminates with the documented ESHKOL_EXIT_LIMIT_STACK status rather than
+ * letting the recursion run the native stack into the ground.
+ *
+ * SW-10: the ceiling is `ESHKOL_MAX_STACK` (via eshkol_get_limits()), not the
+ * hard-coded 100000 this used to compare against. There were two stack-depth
+ * mechanisms in the tree with the same default and no connection between them
+ * — this one, which codegen actually calls, and the configurable
+ * `max_stack_depth` the environment variable fed, which nothing consulted.
+ * They are now the same mechanism, which is what makes the documented variable
+ * take effect. Reading the limit costs a load from an already-hot global, and
+ * the depth counter itself is unchanged, so a program that stays under the
+ * ceiling behaves exactly as before.
+ *
+ * Since this already runs at every guarded function entry, it is also the
+ * natural place to notice a pending execution-timeout interrupt: the watchdog
+ * thread can only request one, and something running user code has to act on
+ * it. Recursive and call-heavy programs are covered here; tail-call loops,
+ * which enter no new frames, are covered by the poll codegen emits at the loop
+ * back-edge.
  *
  * @return The thread-local recursion depth after incrementing (only
  *         reachable if under the limit; otherwise this call does not
@@ -537,12 +554,21 @@ static const int64_t ESHKOL_MAX_RECURSION_DEPTH = 100000;  // 100K frames
  */
 int64_t eshkol_check_recursion_depth(void) {
     __eshkol_recursion_depth++;
-    if (__eshkol_recursion_depth > ESHKOL_MAX_RECURSION_DEPTH) {
+
+    const eshkol_resource_limits_t* limits = eshkol_get_limits();
+    const int64_t max_depth = (int64_t)limits->max_stack_depth;
+    if (max_depth > 0 && __eshkol_recursion_depth > max_depth) {
         __eshkol_recursion_depth = 0;
+        eshkol_limit_enforce(ESHKOL_LIMIT_STACK_OVERFLOW, nullptr);
+        // Advisory mode (ESHKOL_ENFORCE_LIMITS=false) still must not let the
+        // recursion continue into a real stack overflow, so it stays fatal —
+        // just via the catchable runtime condition it has always used.
         eshkol_runtime_fatal(ESHKOL_EXCEPTION_ERROR,
                              "maximum recursion depth (%lld) exceeded",
-                             (long long)ESHKOL_MAX_RECURSION_DEPTH);
+                             (long long)max_depth);
     }
+
+    eshkol_limit_poll_interrupt();
     return __eshkol_recursion_depth;
 }
 

--- a/lib/core/runtime_object_alloc.cpp
+++ b/lib/core/runtime_object_alloc.cpp
@@ -8,10 +8,12 @@
 
 #include "arena_memory.h"
 #include "../../inc/eshkol/logger.h"
+#include <eshkol/core/resource_limits.h>
 
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <cstdio>
 
 // Allocate object with header prepended.
 // Returns pointer to data (after header), or nullptr on failure.
@@ -174,6 +176,25 @@ char* arena_allocate_string_with_header(arena_t* arena, size_t length) {
     if (length >= SIZE_MAX - sizeof(eshkol_object_header_t) - 8) {
         eshkol_error("String length overflow (length=%zu)", length);
         return nullptr;
+    }
+
+    // SW-10: ESHKOL_MAX_STRING_LEN. Every string the runtime builds — literals,
+    // make-string, string-append, substring, number->string — reaches the heap
+    // through this one function, so one check here covers the whole surface.
+    // It also closes a silent truncation: hdr->size below is a uint32_t, so a
+    // length past 4GiB used to wrap and produce a string whose header disagreed
+    // with its contents.
+    if (!eshkol_check_string_length(length)) {
+        char detail[64];
+        snprintf(detail, sizeof(detail), "requested %zu bytes", length);
+        // Terminates under ESHKOL_ENFORCE_LIMITS=true. If it returns, limits
+        // are advisory: the breach is recorded (readable via
+        // eshkol_get_last_limit_error()) and warned about, and the allocation
+        // proceeds. Deliberately NOT a null return — no caller of this function
+        // handles a null string, so failing the allocation here would turn
+        // "limits are not enforced" into a segfault, which is strictly worse
+        // than both documented behaviours.
+        eshkol_limit_enforce(ESHKOL_LIMIT_STRING_LENGTH, detail);
     }
 
     size_t data_size = length + 1;

--- a/lib/core/runtime_object_alloc.cpp
+++ b/lib/core/runtime_object_alloc.cpp
@@ -184,7 +184,8 @@ char* arena_allocate_string_with_header(arena_t* arena, size_t length) {
     // It also closes a silent truncation: hdr->size below is a uint32_t, so a
     // length past 4GiB used to wrap and produce a string whose header disagreed
     // with its contents.
-    if (!eshkol_check_string_length(length)) {
+    if (eshkol_limit_is_active(ESHKOL_LIMIT_ACTIVE_STRING) &&
+        !eshkol_check_string_length(length)) {
         char detail[64];
         snprintf(detail, sizeof(detail), "requested %zu bytes", length);
         // Terminates under ESHKOL_ENFORCE_LIMITS=true. If it returns, limits

--- a/lib/core/runtime_tensor_alloc.cpp
+++ b/lib/core/runtime_tensor_alloc.cpp
@@ -8,10 +8,12 @@
 
 #include "arena_memory.h"
 #include "../../inc/eshkol/logger.h"
+#include <eshkol/core/resource_limits.h>
 
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <cstdio>
 
 extern "C" {
 
@@ -510,6 +512,21 @@ eshkol_tensor_t* arena_allocate_tensor_full(
     }
 
     if (total_elements > 0) {
+        // SW-10: ESHKOL_MAX_TENSOR_ELEMS. The element count is computed by each
+        // caller (make-tensor, arange, matmul, the BLAS paths, model loading)
+        // but they all converge here to allocate, so this is the one place that
+        // sees every tensor and the only place the ceiling has to be applied.
+        if (!eshkol_check_tensor_size((size_t)total_elements)) {
+            char detail[64];
+            snprintf(detail, sizeof(detail), "requested %llu elements",
+                     (unsigned long long)total_elements);
+            // Terminates under ESHKOL_ENFORCE_LIMITS=true; if it returns,
+            // limits are advisory and the tensor is built anyway. See the
+            // matching note in runtime_object_alloc.cpp for why this does not
+            // fail the allocation instead.
+            eshkol_limit_enforce(ESHKOL_LIMIT_TENSOR_SIZE, detail);
+        }
+
         if (total_elements > SIZE_MAX / sizeof(int64_t)) {
             eshkol_error("Tensor elements allocation overflow (total_elements=%llu)",
                          (unsigned long long)total_elements);

--- a/lib/core/runtime_tensor_alloc.cpp
+++ b/lib/core/runtime_tensor_alloc.cpp
@@ -516,7 +516,8 @@ eshkol_tensor_t* arena_allocate_tensor_full(
         // caller (make-tensor, arange, matmul, the BLAS paths, model loading)
         // but they all converge here to allocate, so this is the one place that
         // sees every tensor and the only place the ceiling has to be applied.
-        if (!eshkol_check_tensor_size((size_t)total_elements)) {
+        if (eshkol_limit_is_active(ESHKOL_LIMIT_ACTIVE_TENSOR) &&
+            !eshkol_check_tensor_size((size_t)total_elements)) {
             char detail[64];
             snprintf(detail, sizeof(detail), "requested %llu elements",
                      (unsigned long long)total_elements);

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -14,6 +14,7 @@
 #include <eshkol/core/i128_runtime.h>
 #include <eshkol/core/rational.h>
 #include <eshkol/core/runtime.h>
+#include <eshkol/core/resource_limits.h>  // For the SW-10 limit poll symbol
 #include <eshkol/types/hott_types.h>  // For TypeId decoding and BuiltinTypes
 #include "../core/arena_memory.h"  // For runtime function declarations
 #include "../frontend/library_registry.h"  // R7RS same-unit define-library resolution
@@ -1092,6 +1093,10 @@ void ReplJITContext::registerRuntimeSymbols() {
     ADD_SYMBOL(eshkol_unwind_dynamic_wind);
     ADD_SYMBOL(eshkol_check_recursion_depth);
     ADD_SYMBOL(eshkol_decrement_recursion_depth);
+    // SW-10: emitted on every tail-call loop back-edge, so the JIT must be able
+    // to resolve it or `-r` fails to link any program containing a TCO loop.
+    ADD_SYMBOL(eshkol_limit_poll_interrupt);
+    ADD_SYMBOL(eshkol_enforce_tensor_elements);
     ADD_DATA_SYMBOL(g_current_exception);
     ADD_DATA_SYMBOL(g_exception_handler_stack);
 

--- a/lib/types/type_checker.cpp
+++ b/lib/types/type_checker.cpp
@@ -1193,8 +1193,34 @@ TypeCheckResult TypeChecker::synthesizeOperation(eshkol_ast_t* expr) {
             // evaluates the inner expression verbatim. This is a gradual-typing
             // trust boundary (no runtime check), consistent with `--strict-types`
             // as a whole-program refinement rather than a soundness proof.
+            const TypeId ascribed = resolveType(expr->operation.the_op.type_expr);
             if (expr->operation.the_op.expr) {
                 auto inner = synthesize(expr->operation.the_op.expr);
+                if (inner.success) {
+                    // SW-11: "trusted" governs which type flows ONWARD; it was
+                    // silently also suppressing the one question the checker
+                    // can already answer. The inner type was synthesized and
+                    // then dropped on the floor, so `(the string (+ 1 2))` —
+                    // an ascription no value can ever satisfy — type-checked
+                    // clean and evaluated to 3. Compare the two types now and
+                    // report a provable contradiction through the unified
+                    // enforcement point, so it is a warning under gradual
+                    // typing and fatal under --strict-types, exactly like
+                    // every other type issue. The emitted IR is untouched:
+                    // this is a compile-time diagnostic, so the spec's
+                    // byte-identical/no-runtime-cost guarantee for `the`
+                    // (COMPLETE_LANGUAGE_SPECIFICATION.md 3.6.6) still holds,
+                    // and a VM program that omits the ascription still
+                    // computes the identical result.
+                    if (!ascriptionIsBelievable(inner.inferred_type, ascribed)) {
+                        reportTypeIssue(
+                            "ascription (the " + env_.getTypeName(ascribed) +
+                                " ...) contradicts the inferred type " +
+                                env_.getTypeName(inner.inferred_type) +
+                                "; no value can satisfy it",
+                            expr);
+                    }
+                }
                 if (!inner.success) {
                     // The result was previously DISCARDED, so the comment above
                     // was not true: a failing inner synthesis (an unbound
@@ -1210,7 +1236,7 @@ TypeCheckResult TypeChecker::synthesizeOperation(eshkol_ast_t* expr) {
                                     expr->operation.the_op.expr);
                 }
             }
-            return TypeCheckResult::ok(resolveType(expr->operation.the_op.type_expr));
+            return TypeCheckResult::ok(ascribed);
         }
 
         case ESHKOL_DEFINE_TYPE_OP: {
@@ -3459,6 +3485,49 @@ void TypeChecker::addTypeMismatch(TypeId expected, TypeId actual, int line, int 
     ss << "Type mismatch: expected " << env_.getTypeName(expected)
        << ", got " << env_.getTypeName(actual);
     addError(ss.str(), line, col);
+}
+
+/**
+ * @brief Decide whether `(the <ascribed> expr)` over an expression synthesized
+ *        as @p actual is believable, i.e. not a provable contradiction.
+ *
+ * See the header for the full rule. Summary: accept widening, accept
+ * narrowing (the reason the form exists), accept anything touching the
+ * dynamic root or an unresolved type, accept numeric-to-numeric because this
+ * type graph keeps the numeric tower flat, and reject only two concrete types
+ * that sit in disjoint branches of the graph.
+ *
+ * @return false only when no value could ever inhabit both types.
+ */
+bool TypeChecker::ascriptionIsBelievable(TypeId actual, TypeId ascribed) const {
+    // An unresolved ascription or a failed synthesis carries no information.
+    if (actual == BuiltinTypes::Invalid || ascribed == BuiltinTypes::Invalid) {
+        return true;
+    }
+
+    // `Value` is the dynamic root: it says "unknown", never "wrong".
+    if (actual == BuiltinTypes::Value || ascribed == BuiltinTypes::Value) {
+        return true;
+    }
+
+    // Widening: the value already has the ascribed type.
+    if (env_.isSubtype(actual, ascribed)) return true;
+
+    // Narrowing: the programmer knows more than the checker inferred. This is
+    // the primary use of `the` and must stay unchallenged.
+    if (env_.isSubtype(ascribed, actual)) return true;
+
+    // The numeric tower is deliberately flat here — Integer, Rational, Real
+    // and Complex are siblings under Number, not a chain — so neither
+    // direction of subtyping holds between any two of them. Ascribing across
+    // the tower (`(the real 1)`, `(the float64 (+ 1 2))`) is ordinary and must
+    // not be reported; only leaving the tower entirely is a contradiction.
+    if (env_.isSubtype(actual, BuiltinTypes::Number) &&
+        env_.isSubtype(ascribed, BuiltinTypes::Number)) {
+        return true;
+    }
+
+    return false;
 }
 
 /**

--- a/tests/limits/resource_limits_enforcement_gate.sh
+++ b/tests/limits/resource_limits_enforcement_gate.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# SW-10 gate: the documented resource-limit environment variables are ENFORCED.
+#
+# Every variable in docs/reference/runtime/environment-variables.md's
+# "Resource limits" table used to be parsed into the active configuration and
+# then consulted by nothing: `ESHKOL_MAX_HEAP=1` ran a 20M-iteration allocating
+# loop to completion and exited 0, and `ESHKOL_TIMEOUT_MS=500` printed
+# "Execution timeout: 500ms limit exceeded" and then also ran to completion and
+# exited 0. This gate pins the three properties that fix has to keep:
+#
+#   1. a violation terminates with the documented per-limit exit status
+#      (ESHKOL_EXIT_LIMIT_* in inc/eshkol/core/resource_limits.h) and says so
+#      on stderr, naming the variable that set the ceiling;
+#   2. the same program under a limit it does not reach is completely
+#      unaffected — same output, exit 0 — so enforcement cannot be mistaken for
+#      a program that merely got slower or noisier;
+#   3. ESHKOL_ENFORCE_LIMITS=false downgrades a breach to a warning and lets the
+#      program finish, which is what "hard limit violations terminate the
+#      process; when false, errors are returned" means at the process boundary.
+#
+# Usage: resource_limits_enforcement_gate.sh <eshkol-run> <vm-standalone> <workdir>
+
+set -u
+
+ESHKOL_RUN="${1:?usage: $0 <eshkol-run> <vm-standalone> <workdir>}"
+VM_RUN="${2:?missing vm standalone binary}"
+WORK="${3:?missing work dir}"
+
+mkdir -p "$WORK" || exit 1
+
+PASS=0
+FAIL=0
+
+# Keep the environment clean between cases: a leaked ceiling from one case
+# would silently change the meaning of the next.
+unset_all_limits() {
+    unset ESHKOL_MAX_HEAP ESHKOL_TIMEOUT_MS ESHKOL_MAX_STACK \
+          ESHKOL_MAX_TENSOR_ELEMS ESHKOL_MAX_STRING_LEN \
+          ESHKOL_ENFORCE_LIMITS ESHKOL_LIMIT_WARNINGS ESHKOL_VM_MAX_INSN
+}
+
+# check <label> <expected-exit> <expected-stderr-substring|-> -- <command...>
+check() {
+    local label="$1" expect_exit="$2" expect_err="$3"
+    shift 4  # drop the literal --
+    local out err rc
+    out="$WORK/out.$$"
+    err="$WORK/err.$$"
+    "$@" >"$out" 2>"$err"
+    rc=$?
+
+    local ok=true
+    if [ "$rc" -ne "$expect_exit" ]; then
+        ok=false
+        echo "FAIL: $label — expected exit $expect_exit, got $rc"
+    fi
+    if [ "$expect_err" != "-" ] && ! grep -qF "$expect_err" "$err"; then
+        ok=false
+        echo "FAIL: $label — stderr missing: $expect_err"
+        sed -n '1,10p' "$err"
+    fi
+    if $ok; then
+        PASS=$((PASS + 1))
+        echo "PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+    fi
+    rm -f "$out" "$err"
+}
+
+# --- fixtures ---------------------------------------------------------------
+
+cat > "$WORK/alloc_loop.esk" <<'EOF'
+(define (sum-to n)
+  (let loop ((i 0) (acc 0))
+    (if (>= i n) acc (loop (+ i 1) (+ acc i)))))
+(display (sum-to 20000000))
+(newline)
+EOF
+
+cat > "$WORK/big_string.esk" <<'EOF'
+(display (string-length (make-string 5000 #\x)))
+(newline)
+EOF
+
+cat > "$WORK/big_tensor.esk" <<'EOF'
+(display (tensor-shape (make-tensor (list 100 100) 0.0)))
+(newline)
+EOF
+
+cat > "$WORK/deep_rec.esk" <<'EOF'
+(define (down n) (if (= n 0) 0 (+ 1 (down (- n 1)))))
+(display (down 5000))
+(newline)
+EOF
+
+cat > "$WORK/vm_loop.esk" <<'EOF'
+(define (count n acc) (if (= n 0) acc (count (- n 1) (+ acc 1))))
+(display (count 3000000 0))
+EOF
+
+# --- ESHKOL_MAX_HEAP --------------------------------------------------------
+
+unset_all_limits
+ESHKOL_MAX_HEAP=1 \
+check "ESHKOL_MAX_HEAP=1 terminates with 120" 120 "ESHKOL_MAX_HEAP" -- \
+    "$ESHKOL_RUN" -r "$WORK/alloc_loop.esk"
+
+unset_all_limits
+ESHKOL_MAX_HEAP=4G \
+check "ESHKOL_MAX_HEAP=4G leaves the run untouched" 0 "-" -- \
+    "$ESHKOL_RUN" -r "$WORK/alloc_loop.esk"
+
+unset_all_limits
+ESHKOL_MAX_HEAP=1 ESHKOL_ENFORCE_LIMITS=false \
+check "ESHKOL_ENFORCE_LIMITS=false makes the heap ceiling advisory" 0 "-" -- \
+    "$ESHKOL_RUN" -r "$WORK/alloc_loop.esk"
+
+# --- ESHKOL_TIMEOUT_MS ------------------------------------------------------
+
+unset_all_limits
+ESHKOL_TIMEOUT_MS=500 \
+check "ESHKOL_TIMEOUT_MS=500 terminates with 124" 124 "ESHKOL_TIMEOUT_MS" -- \
+    "$ESHKOL_RUN" -r "$WORK/alloc_loop.esk"
+
+unset_all_limits
+ESHKOL_TIMEOUT_MS=600000 \
+check "a timeout the program never reaches changes nothing" 0 "-" -- \
+    "$ESHKOL_RUN" -r "$WORK/alloc_loop.esk"
+
+# --- ESHKOL_MAX_STRING_LEN --------------------------------------------------
+
+unset_all_limits
+ESHKOL_MAX_STRING_LEN=100 \
+check "ESHKOL_MAX_STRING_LEN=100 terminates with 123" 123 "ESHKOL_MAX_STRING_LEN" -- \
+    "$ESHKOL_RUN" -r "$WORK/big_string.esk"
+
+unset_all_limits
+ESHKOL_MAX_STRING_LEN=1M \
+check "a string ceiling above the string is inert" 0 "-" -- \
+    "$ESHKOL_RUN" -r "$WORK/big_string.esk"
+
+# --- ESHKOL_MAX_TENSOR_ELEMS ------------------------------------------------
+
+unset_all_limits
+ESHKOL_MAX_TENSOR_ELEMS=100 \
+check "ESHKOL_MAX_TENSOR_ELEMS=100 terminates with 122" 122 "ESHKOL_MAX_TENSOR_ELEMS" -- \
+    "$ESHKOL_RUN" -r "$WORK/big_tensor.esk"
+
+unset_all_limits
+ESHKOL_MAX_TENSOR_ELEMS=1000000 \
+check "a tensor ceiling above the tensor is inert" 0 "-" -- \
+    "$ESHKOL_RUN" -r "$WORK/big_tensor.esk"
+
+# --- ESHKOL_MAX_STACK -------------------------------------------------------
+#
+# The depth guard is emitted at lambda entry, so this uses the eval path where
+# the recursive function is compiled as one. Codegen does not yet emit the
+# guard for every top-level `define`d function — that gap is ESH-0101 (see
+# tests/stress/found/deep_recursion_270k_no_diagnostic.esk) and is deliberately
+# NOT closed here: tests/stress/rec_deep_nontco_250k.esk pins plain non-tail
+# recursion working to 250000 frames, which the documented 100000 default would
+# break. What this case pins is that the VARIABLE is live where the guard runs.
+
+unset_all_limits
+ESHKOL_MAX_STACK=100 \
+check "ESHKOL_MAX_STACK=100 terminates with 121" 121 "ESHKOL_MAX_STACK" -- \
+    "$ESHKOL_RUN" -e '(begin (define (down n) (if (= n 0) 0 (+ 1 (down (- n 1))))) (display (down 5000)))'
+
+unset_all_limits
+ESHKOL_MAX_STACK=100000 \
+check "a stack ceiling above the recursion is inert" 0 "-" -- \
+    "$ESHKOL_RUN" -e '(begin (define (down n) (if (= n 0) 0 (+ 1 (down (- n 1))))) (display (down 5000)))'
+
+# --- ESHKOL_VM_MAX_INSN (bytecode VM) ---------------------------------------
+
+if [ -x "$VM_RUN" ]; then
+    unset_all_limits
+    ESHKOL_VM_MAX_INSN=100000 \
+    check "ESHKOL_VM_MAX_INSN=100000 terminates the VM with 125" 125 "ESHKOL_VM_MAX_INSN" -- \
+        "$VM_RUN" "$WORK/vm_loop.esk"
+
+    unset_all_limits
+    ESHKOL_VM_MAX_INSN=0 \
+    check "ESHKOL_VM_MAX_INSN=0 means unlimited" 0 "-" -- \
+        "$VM_RUN" "$WORK/vm_loop.esk"
+else
+    echo "SKIP: bytecode VM standalone binary not built ($VM_RUN)"
+fi
+
+# --- summary ----------------------------------------------------------------
+
+echo
+echo "resource-limit enforcement: $PASS passed, $FAIL failed"
+if [ "$FAIL" -ne 0 ]; then
+    exit 1
+fi
+echo "PASS: resource limits enforced"
+exit 0

--- a/tests/limits/resource_limits_enforcement_gate.sh
+++ b/tests/limits/resource_limits_enforcement_gate.sh
@@ -99,6 +99,21 @@ cat > "$WORK/vm_loop.esk" <<'EOF'
 (display (count 3000000 0))
 EOF
 
+# --- ceilings are OPT-IN ----------------------------------------------------
+#
+# The defaults in the docs are the values a limit takes WHEN YOU TURN IT ON,
+# not a ceiling every program is silently held to. This case pins that, and it
+# is not hypothetical: the first cut of this fix enforced the documented 1 GiB
+# heap default unconditionally and killed tests/features/blc_test.esk, a
+# program that had run for years and had never been under any ceiling. An
+# unconfigured run must behave exactly as it did before limits were enforced.
+
+if [ -f "tests/features/blc_test.esk" ]; then
+    unset_all_limits
+    check "a run that sets nothing gets no ceiling, even past the 1 GiB default" 0 "-" -- \
+        "$ESHKOL_RUN" -r tests/features/blc_test.esk
+fi
+
 # --- ESHKOL_MAX_HEAP --------------------------------------------------------
 
 unset_all_limits

--- a/tests/typesystem/ascription_contradiction_test.esk
+++ b/tests/typesystem/ascription_contradiction_test.esk
@@ -1,0 +1,38 @@
+;; Type System Test (SW-11): a PROVABLY FALSE `(the <type> expr)` is diagnosed.
+;;
+;; `(display (the string (+ 1 2)))` used to print 3 and exit 0. The checker
+;; synthesized the inner expression, threw the result away, and adopted the
+;; ascribed type unconditionally — so an ascription that no value can satisfy
+;; was indistinguishable from one that every value satisfies, and "checked
+;; ascription" checked nothing.
+;;
+;; What is asserted here is the CONTRADICTION half only. `the` remains a
+;; trusted narrowing boundary and a pure runtime no-op — the emitted IR is
+;; still byte-identical to the wrapped expression, there is still no runtime
+;; tag check, and a VM program that omits the ascription still computes the
+;; identical result (COMPLETE_LANGUAGE_SPECIFICATION.md 3.6.6). The checker
+;; only refuses the cases where it can prove the two types are disjoint;
+;; narrowing from a dynamic value, widening, and moving around the numeric
+;; tower are all still accepted, and checked_cast_the_test.esk pins that.
+;;
+;; Under gradual typing (the default) this is a `[WARN] Type warning:` and the
+;; program still runs; under --strict-types it is fatal, which is what this
+;; fixture asserts.
+;; EXPECT-MODE: strict-types
+;; EXPECT-COMPILE: fail
+;; EXPECT-STDERR: contradicts
+;; EXPECT-STDERR: no value can satisfy it
+
+(define (identity-fn x) x)
+
+;; Legitimate — must NOT be reported. Narrowing a dynamic value is the entire
+;; point of the form, and the numeric tower is deliberately flat, so moving
+;; between its members has no subtyping relation in either direction.
+(display (the string (identity-fn "ok")))  (newline)
+(display (the real 1))                     (newline)
+(display (the number (+ 1 2)))             (newline)
+(display (the integer 5))                  (newline)
+
+;; Provably false — `+` over two integers cannot produce a string.
+(display (the string (+ 1 2)))
+(newline)

--- a/tests/typesystem/checked_cast_the_test.esk
+++ b/tests/typesystem/checked_cast_the_test.esk
@@ -23,9 +23,19 @@
 ;; generated ascription per entry, so a name added there cannot escape coverage
 ;; even if this fixture is not updated alongside it.
 ;;
-;; `the` is an UNCHECKED trust boundary, so the values below are chosen for
-;; plausibility, not enforcement — what is under test is that every name is
-;; recognised as a type and resolves to a real type instead of degrading.
+;; What is under test here is the SPELLING surface: that every name is
+;; recognised as a type and resolves to a real type instead of degrading into a
+;; call to an undefined procedure named `the`.
+;;
+;; SW-10/SW-11: `the` is still a trusted narrowing boundary and still a pure
+;; runtime no-op, but the checker now rejects an ascription it can PROVE no
+;; value satisfies (see TypeChecker::ascriptionIsBelievable). Ascriptions of an
+;; opaque or resource type — tensor, hash-table, ptr, dual, ad-node, handle,
+;; buffer, stream, qubit — therefore go through `identity-fn` below, whose
+;; untyped parameter makes the operand dynamic. That is the narrowing case the
+;; form exists for, it keeps every spelling covered, and it no longer asserts
+;; that a provably impossible ascription passes silently. The separate
+;; contradiction behaviour is pinned by ascription_contradiction_test.esk.
 ;; EXPECT-MODE: strict-types
 ;; EXPECT-COMPILE: ok
 ;; EXPECT-NO-STDERR: [ERROR]
@@ -101,26 +111,26 @@
 ;; Containers and constructors, written bare
 (display (the list (list 1 2)))     (newline)
 (display (the vector (vector 1 2))) (newline)
-(display (the tensor 3))            (newline)
+(display (the tensor (identity-fn 3)))            (newline)
 (display (the pair (cons 1 2)))     (newline)
 (display ((the procedure identity-fn) 7)) (newline)
 (display ((the closure identity-fn) 8))   (newline)
-(display (the hash-table 3))        (newline)
-(display (the hashtable 3))         (newline)
-(display (the ptr 3))               (newline)
-(display (the pointer 3))           (newline)
+(display (the hash-table (identity-fn 3)))        (newline)
+(display (the hashtable (identity-fn 3)))         (newline)
+(display (the ptr (identity-fn 3)))               (newline)
+(display (the pointer (identity-fn 3)))           (newline)
 
 ;; Autodiff
-(display (the dual 1.5))            (newline)
-(display (the dual-number 1.5))     (newline)
-(display (the ad-node 1.5))         (newline)
-(display (the adnode 1.5))          (newline)
+(display (the dual (identity-fn 1.5)))            (newline)
+(display (the dual-number (identity-fn 1.5)))     (newline)
+(display (the ad-node (identity-fn 1.5)))         (newline)
+(display (the adnode (identity-fn 1.5)))          (newline)
 
 ;; Linear resources
-(display (the handle 3))            (newline)
-(display (the buffer 3))            (newline)
-(display (the stream 3))            (newline)
-(display (the qubit 3))             (newline)
+(display (the handle (identity-fn 3)))            (newline)
+(display (the buffer (identity-fn 3)))            (newline)
+(display (the stream (identity-fn 3)))            (newline)
+(display (the qubit (identity-fn 3)))             (newline)
 
 ;; Type names are case-insensitive, matching the type environment's lookup.
 (display (the Number 3))            (newline)
@@ -133,9 +143,9 @@
 
 (display (the (list integer) (list 1 2)))          (newline)
 (display (the (vector real) (vector 1.5 2.5)))     (newline)
-(display (the (tensor real) 3))                    (newline)
+(display (the (tensor real) (identity-fn 3)))      (newline)
 (display (the (pair integer string) (cons 1 "a"))) (newline)
-(display (the (ptr integer) 3))                    (newline)
+(display (the (ptr integer) (identity-fn 3)))      (newline)
 (display ((the (-> integer integer) identity-fn) 9)) (newline)
 (display (the (+ string number) "either"))         (newline)
 (display (the (* integer string) (cons 1 "a")))    (newline)


### PR DESCRIPTION
Closes **SW-10** and **SW-11** in `.icc/silent-wrong-ledger.yaml`. Both were
SILENT-WRONG entries blocking `scripts/gate_no_silent_wrong.py`; the branch
takes that gate's blocking set from 13 to 11.

## SW-10 — seven documented resource-limit variables were enforced by nothing

`ESHKOL_MAX_HEAP`, `ESHKOL_TIMEOUT_MS`, `ESHKOL_MAX_STACK`,
`ESHKOL_MAX_TENSOR_ELEMS`, `ESHKOL_MAX_STRING_LEN`, `ESHKOL_ENFORCE_LIMITS` and
`ESHKOL_LIMIT_WARNINGS` were parsed into the active configuration and then
consulted by nobody. The functions that check them were written, compiled, and
called from nowhere outside their own unit tests.

Measured before:

```
$ ESHKOL_MAX_HEAP=1 ESHKOL_ENFORCE_LIMITS=1 eshkol-run -r loop20m.esk
199999990000000
exit 0

$ ESHKOL_TIMEOUT_MS=500 eshkol-run -r loop20m.esk
ERROR: Execution timeout: 500ms limit exceeded
199999990000000
exit 0
```

The timeout case is the sharper one: the watchdog thread fired, printed, and
requested a runtime interrupt — and nothing anywhere in `lib/` or `exe/` polled
the interrupt flag, so the request had no effect on running code.

### Enforcement points

Each ceiling is applied at the one site every path to it converges on, so a
call site added later cannot escape it and no fast path pays for it.

| Limit | Site |
|---|---|
| `ESHKOL_MAX_HEAP` | `lib/core/runtime_arena_core.cpp:52` `create_arena_block()` — the arena's only OS-request site. Once per *block* (a megabyte at a time), never per object; the bump-pointer path is untouched. Paired with `eshkol_track_deallocation()` in `free_arena_block()` so the ceiling measures what a program *holds*, not everything it has ever touched. |
| `ESHKOL_MAX_STRING_LEN` | `lib/core/runtime_object_alloc.cpp:181` `arena_allocate_string_with_header()`. Also closes a silent truncation: `hdr->size` is a `uint32_t`, and this path wrapped rather than rejecting past 4 GiB. |
| `ESHKOL_MAX_TENSOR_ELEMS` | `lib/core/runtime_tensor_alloc.cpp:512` `arena_allocate_tensor_full()`, **and** `lib/backend/tensor_creation_codegen.cpp:41` `emitTensorElementLimitCheck()` — native codegen assembles a tensor from three separate arena allocations and never calls that helper, so a compiled `make-tensor` would otherwise have escaped a limit a runtime-constructed tensor respects. |
| `ESHKOL_TIMEOUT_MS` | `lib/backend/llvm_codegen.cpp:28013` — a cooperative poll emitted at the tail-call loop back-edge (the one place every self-tail-call back-edge is emitted, for both `define`-TCO and named-let), plus `lib/core/runtime_list_helpers.cpp:561` at every guarded function entry. A TCO loop enters no new frame, so the entry guard alone never sees it. |
| `ESHKOL_MAX_STACK` | `lib/core/runtime_list_helpers.cpp:549` — the recursion-depth guard codegen already emitted, which had been comparing against a hard-coded `100000` with no connection to the configurable limit the variable fed. Two mechanisms, same default, no wire between them; now one. |
| `ESHKOL_VM_MAX_INSN` | `lib/backend/vm_run.c:60` `vm_limits_checkpoint()`, used by **both** dispatch paths. |
| `ESHKOL_ENFORCE_LIMITS` / `ESHKOL_LIMIT_WARNINGS` | `lib/core/resource_limits.cpp:620` `eshkol_limit_enforce()` — the single decision point behind every enforced limit. |

### Semantics chosen

Docs were silent on exit status, so this PR picks and documents one status per
limit, letting a supervising process tell which ceiling was hit without parsing
the diagnostic:

| Limit | Exit |
|---|---|
| `ESHKOL_MAX_HEAP` | 120 |
| `ESHKOL_MAX_STACK` | 121 |
| `ESHKOL_MAX_TENSOR_ELEMS` | 122 |
| `ESHKOL_MAX_STRING_LEN` | 123 |
| `ESHKOL_TIMEOUT_MS` | 124 |
| `ESHKOL_VM_MAX_INSN` | 125 |

`124` matches GNU coreutils `timeout(1)` — already this repository's convention
for `run-command` / `run-argv` subprocess timeouts (`docs/breakdown/AGENT_FFI.md`).
The rest occupy the adjacent band and avoid 126/127, which POSIX shells reserve.

A violation flushes pending output, writes one line naming the limit, the
ceiling and the variable that set it, and exits:

```
eshkol: fatal: Heap hard limit exceeded (limit 1 bytes, set by ESHKOL_MAX_HEAP): arena block
```

`ESHKOL_ENFORCE_LIMITS=false` makes ceilings advisory — the breach is recorded
(`eshkol_get_last_limit_error()`), warned about, and the program finishes.
It deliberately does **not** fail the individual allocation: no caller of the
string or arena allocators handles a null return, so refusing there turned
"limits are not enforced" into a segfault — strictly worse than either
documented behaviour. That reading is now stated in the docs.

### `ESHKOL_VM_MAX_INSN`: one interpreter, two answers

The variable is documented with a default of 10,000,000, but `vm_run()`'s
computed-goto dispatch — the path every GCC/Clang build takes — had **no
instruction counter at all**, while the MSVC `switch` fallback capped at a
hard-coded 10,000,000 with no environment override. Both now share one counter
and one configurable ceiling, checked once per 4096 instructions so the
per-opcode cost is a single decrement and branch.

The variable is parsed alongside its six siblings in
`eshkol_init_limits_from_env()` and reaches the VM through `eshkol_get_limits()`,
because `lib/backend/vm_*.c` are freestanding-safe sources that may not read the
environment (enforced by `tests/toolchain/vm_source_boundary_test.cpp`).

The second commit fixes the companion interpreter in `eshkol_compiler.c`, which
called `getenv()` + `atoll()` on **every instruction** inside its hottest loop
and disagreed with the main VM about the meaning of `0` (stop immediately, vs
the documented unlimited).

### Performance

No check reads or writes program data, so enabling limits cannot perturb a
computed value. Spot-checked: `(derivative f 2.0)` for `x³` at 2 is exactly
`12`, `(gradient (λ v. v₀v₁) #(3. 4.))` is exactly `#(4 3)`, unchanged with and
without limits configured.

The only check on a hot path is the loop back-edge poll. A/B on a 50M-iteration
tight arithmetic loop (the worst case — three ops per iteration), AOT `-O2`,
best of 3: **4.28s without, 4.35s with — ~1.6%**. The heap check is amortized
over a megabyte block, the tensor/string checks are once per object created,
and the VM checkpoint runs once per 4096 instructions.

### Known residual (deliberate, documented)

`ESHKOL_MAX_STACK` bounds the recursion the depth guard observes. Codegen does
not yet emit that guard at the entry of every top-level `define`d function —
that gap is **ESH-0101** (`tests/stress/found/deep_recursion_270k_no_diagnostic.esk`)
and is deliberately *not* closed here: `tests/stress/rec_deep_nontco_250k.esk`
pins plain non-tail recursion working to 250,000 frames, which the documented
100,000 default would break. Closing it needs a ruling on that default, which is
out of this PR's scope. Recorded in `docs/reference/runtime/environment-variables.md`
and in the ledger's `residual` field.

## SW-11 — `(the <type> expr)` never rejected anything

`(display (the string (+ 1 2)))` printed `3` and exited 0. The checker
synthesized the wrapped expression, **discarded the type it derived**, and
adopted the ascribed type unconditionally — so an ascription no value can
satisfy was indistinguishable from one every value satisfies.

`lib/types/type_checker.cpp:1189` now compares the two and reports a *provable*
contradiction through `reportTypeIssue()`, the same enforcement point every
other type issue uses: a warning under gradual typing, fatal under
`--strict-types`.

```
$ eshkol-run -e '(display (the string (+ 1 2)))'
[WARN] Type warning: ascription (the String ...) contradicts the inferred type Int64; no value can satisfy it (line 1:11)
3

$ eshkol-run --strict-types -e '(display (the string (+ 1 2)))'
[ERROR] Type error: ascription (the String ...) contradicts the inferred type Int64; no value can satisfy it
[ERROR] Refusing to generate code for a program with type errors (--strict-types)
exit 1
```

### Why compile-time and not a runtime check

`docs/COMPLETE_LANGUAGE_SPECIFICATION.md` § 3.6.6 guarantees the emitted IR is
**byte-identical** to the wrapped expression, with no runtime tag check and no
cost — and `docs/FEATURE_MATRIX.md:804` justifies the VM parity gap *on that
guarantee* ("a VM program that omits it computes the identical result"). Adding
a runtime check would have contradicted both.

A compile-time diagnostic makes the word "checked" true without walking either
claim back. `codegenAST` for `ESHKOL_THE_OP` is untouched — still a bare
passthrough — so the guarantee and the parity justification both continue to
hold, verified in the diff.

### The predicate rejects only the impossible

`TypeChecker::ascriptionIsBelievable()` accepts:

- **narrowing** (`ascribed <: actual`) — the reason the form exists, never
  questioned;
- **widening** (`actual <: ascribed`);
- anything touching the dynamic `Value` root or an unresolved type;
- **numeric-tower to numeric-tower** — this type graph keeps `Integer`,
  `Rational`, `Real` and `Complex` as *siblings* under `Number` rather than a
  chain, so no subtyping relation holds between them in either direction and
  `(the real 1)` would otherwise read as a contradiction.

Class-kill matrix, all reported: `(the vector (+ 1 2))`, `(the procedure "x")`,
`(the string (vector 1 2))`, `(the integer "s")`, `(the boolean 5)`. Correct
ascriptions silent and identical: `(the number (+ 1 2))`, `(the real 1)`,
`(the integer 5)`, `(the string "hi")`.

### Fixture change worth reviewing

`tests/typesystem/checked_cast_the_test.esk` previously asserted
`EXPECT-NO-STDERR: [WARN]` over deliberately implausible ascriptions
(`(the tensor 3)`, `(the qubit 3)`, …) — it encoded "unchecked" as the intended
behaviour. Its actual purpose is *spelling* coverage, so those 15 cases now route
their operand through the `identity-fn` the fixture already defined, making the
value dynamic. That is the narrowing case the form exists for, it keeps every
registry spelling covered, and it no longer asserts that a provably impossible
ascription passes silently.

The registry-derived coverage cell in `scripts/run_typesystem_tests.sh` needed
no change — its operand is already dynamic.

The diagnostic is native-only, because the bytecode VM has no `the` surface and
does not run the HoTT checker. Unchanged from before, and still
`native-only-justified`: the form emits no code on either engine.

## Gates

Measured on this branch, arm64-apple-darwin24.1.0, LLVM 21, RelWithDebInfo.

| Gate | Result |
|---|---|
| `ctest --test-dir build` | **165/165**, 100% passed (baseline 164 + the new `resource_limits_enforcement_gate`) — re-run and re-confirmed on the opt-in build |
| `scripts/run_differential.sh` | **288/288** axis pairs across 48 programs, no divergences |
| `scripts/run_vm_parity.sh` | **158 passed, 0 failed** |
| `scripts/run_typesystem_tests.sh` | **22/22**, registry coverage 62 type names |
| `tests/limits/resource_limits_enforcement_gate.sh` | **14/14** |
| `scripts/run_language_coverage.sh` | 21 suites passed / 0 failed, 527 test passes / 0 failures at the time of writing (sweep still running its second-engine pass); `blc_test.esk`, both ascription fixtures, the flat-RSS memory gates and the whole autodiff suite are green |
| `scripts/gate_no_silent_wrong.py` | blocking SILENT-WRONG **13 → 11** (SW-10, SW-11 removed) |

`gate_no_silent_wrong.py` still exits 1, as it did on master: eleven other
SILENT-WRONG entries (SW-03/04/05/12/13/14/18/19/20/21/23) remain open and are
outside this PR's scope. The delta is exactly the two entries this PR closes.

### The wrapper verdict

`scripts/run_icc_smoke.sh`, run end-to-end on the final tree: **60/61 probes
passed**. The single failure is `no_open_silent_wrong` — the ledger gate — and
it fails for a reason this PR does not own: eleven other SILENT-WRONG entries
(SW-03/04/05/12/13/14/18/19/20/21/23) are still open. The same gate fails on
master with **13** blockers; this branch takes it to **11**. Every other probe
is green, including `language_surface_coverage_floor` and
`wasm_execute_diff_oracle`, both of which caught real problems during this work
(below).

Two earlier wrapper runs are not offered as evidence and should be disregarded:
the first was invalidated when I killed one of its sub-suites with an
over-broad `pkill` while investigating a suspected stall, and the second
predates the opt-in correction. Only the third run measures the tree being
merged.

### A regression this PR introduced, caught, and fixed

The first cut enforced the documented *defaults* unconditionally. That is not
the same thing as enforcing the documented *variables*, and the difference is
not academic: `tests/features/blc_test.esk` allocates past the 1 GiB heap
default and started dying with `Heap hard limit exceeded`, exit 120, after
years of running fine. The bytecode VM's computed-goto dispatch had never had
an instruction guard at all, so applying the 10M default there had the same
character.

`45877dde` makes every ceiling opt-in: a limit binds a run only when that run
sets its variable (or sets the matching `ESHKOL_LIMIT_ACTIVE_*` bit before
`eshkol_set_limits()`). Accounting still runs unconditionally, so
`eshkol_get_heap_usage()` and the peak high-water mark stay accurate for
diagnostics either way. This is the same rule the execution-timeout watchdog
already followed. The regression is now pinned by its own gate case: *a run
that sets nothing gets no ceiling, even past the 1 GiB default.*

**Ruled (2026-08-13):** ceilings stay **opt-in for v1.3.4**, so shipping
behaviour is unchanged for every existing program. Whether the documented
defaults should *also* bind an unconfigured run is deferred as a v1.3.5 policy
question, not a v1.3.4 defect. Recorded in
`docs/reference/runtime/environment-variables.md` ("Limits are opt-in") and in
both ledger entries.

### A second regression the gates caught: the WASM lane

`vm_run.c` called `eshkol_get_limits()`, `eshkol_limit_is_active()` and
`eshkol_limit_poll_interrupt()` directly. Those VM sources are also compiled to
WebAssembly, where `lib/core/resource_limits.cpp` is not linked — every WASM run
aborted with `missing function: eshkol_get_limits` and
`wasm_execute_diff_oracle` went from 65 passed to **0 passed / 65 failed**.

The freestanding-safety rule the boundary test enforces is not only about
`getenv`; it is about the VM not depending on the hosted runtime at all. So the
dependency now runs the other way: the VM owns its limit state with compiled-in
defaults, and hosted entry points resolve the configuration and push it in via
`eshkol_vm_install_limits()`. A build that never calls the installer keeps the
defaults and links nothing extra; the timeout poll is a function pointer, NULL
where there is no hosted runtime. Measured after: **wasm-execute-diff 65 passed
/ 0 failed**, `ESHKOL_VM_MAX_INSN=100000` still exits 125, unconfigured VM runs
still exit 0 (`caf08297`).

### One pre-existing divergence found and attributed, not introduced

`run_differential.sh --with-vm` (336 axis pairs, a superset of the 288 the
default gate runs) reports one divergence: `17_mutual_recursion.esk` fails on
the `vm-eskb` axis. **It is pre-existing.** A/B verified by disabling the new VM
checkpoint, rebuilding, and re-running — byte-identical failure. It is already
tracked as ledger **LE-08** and `docs/KNOWN_ISSUES.md:195` ("top-level mutual
recursion requires consecutive function defines; interleaved non-define
expressions break groups"), which is exactly that program's shape. No ledger
growth, no new entry needed.

## Notes for review

- No new SILENT-WRONG ledger entries (invariant 4).
- The ledger closes by measurement at a named SHA (invariant 3):
  `closed_at: 45877dde`, with `fix`, `measured_after` and `residual` fields on
  both entries.
- Commit identity is `tsotchke <tsotchkele@gmail.com>` on author and committer
  for all seven commits; no AI attribution.
- ESH-0101 stack-guard coverage is **ruled** a ledgered v1.3.5 item: wiring
  `ESHKOL_MAX_STACK` where guards already exist is the complete v1.3.4 scope and
  is not a tag blocker.
