### PR TITLE
fix(vm+tensor): vector-ref over tensors + dual-backward differential coverage (SW-26, SW-12)

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -446,6 +446,62 @@ entries:
       other half, `contradictions`, returned 30 findings at this SHA and every one is a
       constant_disagreement or env_default_disagreement on a build/tuning symbol — it
       compares symbol VALUES, never behaviour, docs or test-harness metadata.
+    measured: >-
+      Direct differential built on branch fix/vector-ref-tensor-and-backward-diff (commit f55e0336)
+      (tests/backend/tensor_backward_dual_impl_gradcheck_test.cpp, new; plus one added check in
+      tests/backend/tensor_embedding_backward_gradcheck_test.cpp): identical inputs and an
+      identical upstream cotangent fed to BOTH implementations, diffed directly against each
+      other, with central finite differences of a THIRD, independently-written forward as the
+      tie-breaking oracle per the task ruling ("finite differences arbitrate").
+
+      5 of 6 ops AGREE, to machine precision or exactly:
+        matmul     max|native-bridge| = 0.0 (both operands), FD max diff 1.8e-10 / 9.6e-11
+        layernorm  max|native-bridge| = 6.9e-17 (dx) / 0.0 (dgamma), FD max diff 2.9e-10 / 1.9e-10
+        transpose  max|native-bridge| = 0.0, FD max diff 5.1e-11
+        sum        max|native-bridge| = 0.0, FD max diff 9.2e-12
+        embedding  max|native-bridge| = 0.0 (exact scatter-add on both sides; already had
+                   independent FD/closed-form coverage in ESH-0230's test, this adds the direct
+                   bridge-vs-native diff on the identical fixture)
+      transpose and sum have no AD_NODE_TENSOR_{TRANSPOSE,SUM} forward producer anywhere in the
+      tree (same situation embedding was in before PR #392 / ESH-0230), so their bridge side was
+      exercised by hand-building the node per tensor_{transpose,sum}_backward's documented
+      contract, the same technique tests/backend/tensor_embedding_backward_gradcheck_test.cpp
+      already used for embedding.
+
+      attention is NOT a numeric disagreement: eshkol_backward_attention (native) is exact and
+      FD-validated here (max diff 2.3e-11 / 6.5e-11 / 4.2e-11 across dQ/dK/dV). tensor_attention_backward
+      (bridge) unconditionally calls eshkol_fatal() by design — asserted via a fork-based death
+      test, PASS (it does refuse). ad_tensor_attention's forward (lib/bridge/qllm_bridge.cpp)
+      does not retain the `causal` flag or the softmax attention weights on the node, so an
+      exact bridge adjoint cannot be computed from what the node carries even in principle: this
+      is a forward-plumbing gap, not a wrong formula to arbitrate between two answers.
+    ops_status:
+      matmul: agree
+      layernorm: agree
+      transpose: agree
+      sum: agree
+      embedding: agree
+      attention: "NEEDS-DECISION — native exact+FD-validated; bridge unconditionally refuses
+        (loud, not silent) because its forward does not retain enough state (causal flag,
+        attention weights) for an exact adjoint. Implementing the bridge side needs a
+        forward-contract change (thread `causal` through AD_NODE_TENSOR_ATTENTION's params,
+        retain or recompute the attention-weight matrix) — a real feature addition, not a
+        differential-test fix. `scaled-dot-attention` already provides an exact,
+        scalar-decomposed, differentiable attention path elsewhere in the tree, which is why the
+        bridge node has had no producer's backward filled in. Maintainer must decide: implement
+        the bridge backward now, or accept the loud refusal as the standing contract."
+    status_rationale: >-
+      Ledger ruling: SW-12 closes only if all six ops are verified agreeing or fixed. 5/6
+      verified agreeing to machine precision; attention has no comparable bridge VALUE to
+      arbitrate (one side refuses loudly), so it is neither "agreeing" nor "fixed" by this PR.
+      Left OPEN with the measurement above rather than guessing whether the maintainer wants the
+      bridge attention backward implemented or the refusal accepted as the standing contract.
+    evidence_new: >-
+      tests/backend/tensor_backward_dual_impl_gradcheck_test.cpp (matmul/layernorm/transpose/sum
+      direct diff + FD; attention native FD + bridge refusal assertion);
+      tests/backend/tensor_embedding_backward_gradcheck_test.cpp check 10 (direct bridge-vs-native
+      diff, added to the existing ESH-0230 coverage); tests/bridge/qllm_bridge_gradcheck_test.cpp
+      header comment updated to point at both instead of describing them as excluded.
 
   - id: SW-13
     bucket: SILENT-WRONG
@@ -633,6 +689,60 @@ entries:
       walking the enclosing-scope chain outermost-first — was fixed separately by
       PR #428 (tests/vm_parity/corpus/56_lexical_shadow_nearest_binding.esk); the two
       changes touch different functions in vm_compiler.c and are independent.
+
+  - id: SW-26
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "b6b2d32f"
+    closed_by: "branch fix/vector-ref-tensor-and-backward-diff, commit b6b2d32f"
+    title: "vector-ref into an fg-marginal result answers empty on the VM"
+    repro: "(define fg (make-factor-graph 2 2)) (define m (fg-marginal fg 0)) (display (vector-ref m 0))"
+    observed: "VM ()"
+    correct: "0.5 — native answers 0.5"
+    cross_engine: >-
+      native prints 0.5 under both default and ESHKOL_JIT_CACHE=0 JIT. Displaying the whole
+      marginal, `(display m)`, prints #(0.5 0.5) correctly on BOTH engines (the SW-07 fix from
+      PR #424 holds) — only indexing into the result with vector-ref diverged on the VM.
+    root_cause: >-
+      fg-marginal returns a HEAP_TENSOR (VAL_TENSOR) value, not a HEAP_VECTOR. Every VM
+      vector-ref call site — the threaded-dispatch fast path (lbl_VEC_REF), the switch-dispatch
+      fallback (OP_VEC_REF), and the indirect/higher-order native call (vm_native.c case 219) —
+      matched only `vec_val.type == VAL_VECTOR` and fell through to a fabricated NIL_VAL for
+      anything else, including VAL_TENSOR, with no diagnostic. `vector-set!` (case 220,
+      OP_VEC_SET, lbl_VEC_SET) and `vector-length` (case 221, OP_VEC_LEN, lbl_VEC_LEN) had the
+      identical gap — silently a no-op and 0 respectively. Native's collection codegen
+      (CollectionCodegen::vectorRef/vectorSet/vectorLength, lib/backend/collection_codegen.cpp)
+      already dispatches on the heap-object header subtype and has always had a tensor arm,
+      which is why native was correct and only the VM diverged.
+    fixed_by: >-
+      lib/backend/vm_native.c: added a VAL_TENSOR arm to native calls 219 (vector-ref), 220
+      (vector-set!) and 221 (vector-length), backed by three new static helpers
+      (vm_vecref_tensor_path, vm_vecset_tensor_path, vm_veclen_tensor_path) that mirror
+      CollectionCodegen's native semantics exactly: vector-ref on a rank<=1 tensor returns the
+      flat-indexed scalar element (bounds-checked against total element count); on a rank>1
+      tensor it returns a row VIEW of rank n_dims-1 via the existing vm_tensor_slice() (no
+      copy), bounds-checked against shape[0]; vector-set! always bounds-checks against the flat
+      total (native does not special-case N-D row addressing for the mutating op either);
+      vector-length answers the flat total element count. lib/backend/vm_run.c: added the same
+      VAL_TENSOR arm to both interpreter loops (lbl_VEC_REF/lbl_VEC_SET/lbl_VEC_LEN and
+      OP_VEC_REF/OP_VEC_SET/OP_VEC_LEN), calling the shared helpers so the two dispatch
+      implementations cannot re-diverge.
+    evidence: >-
+      tests/vm_parity/corpus/59_vector_ref_tensor_indexed_access.esk (both engines: vector-ref
+      and vector-length on the fg-marginal 1-D tensor, vector-set!+vector-ref round-trip on an
+      independent tensor, vector-ref row-view on a rank-2 tensor, and a catchable out-of-range
+      vector-ref); tests/differential/corpus/47_vector_ref_tensor_indexed_access.esk (native
+      JIT/AOT axes). Revert-validated: reverting the vm_native.c/vm_run.c hunks alone reproduces
+      the VM FAIL on all vector-ref/vector-length assertions in the corpus file with the fix
+      applied everywhere else; reapplying restores 0 FAIL.
+    caught_by: [direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
+    notes: >-
+      Found by #424's author during the correctness wave, filed here after independent
+      re-measurement. Distinct from SW-07/SW-08 (both closed): this is a residual found after
+      those closures, on the same builtin family — the SW-07 fix corrected fg-marginal's VALUE
+      but not every VM consumer of it. Maintainer ruling 2026-08-13 reversed the earlier
+      waive-to-v1.3.5 default for this entry: fixed before tag, no waiver.
 
   - id: SW-27
     bucket: SILENT-WRONG

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4109,6 +4109,28 @@ if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/backend/frec
         PASS_REGULAR_EXPRESSION "0 failed")
 endif()
 
+# SW-12: direct differential check between the two independent tensor-backward
+# implementations (lib/backend/tensor_backward.cpp "native" raw-buffer kernels
+# vs lib/bridge/tensor_backward.cpp "bridge" node-based rules) for matmul,
+# layernorm, transpose, sum and attention on identical inputs, plus central
+# finite differences as the tie-breaking oracle. Embedding's bridge-vs-native
+# comparison lives in tensor_embedding_backward_gradcheck_test.cpp above.
+if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/backend/tensor_backward_dual_impl_gradcheck_test.cpp")
+    add_executable(tensor_backward_dual_impl_gradcheck_test
+        tests/backend/tensor_backward_dual_impl_gradcheck_test.cpp)
+    target_compile_features(tensor_backward_dual_impl_gradcheck_test PRIVATE cxx_std_17)
+    target_include_directories(tensor_backward_dual_impl_gradcheck_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+    eshkol_target_llvm_includes(tensor_backward_dual_impl_gradcheck_test)
+    if(LLVM_LIBRARY_DIRS)
+        target_link_directories(tensor_backward_dual_impl_gradcheck_test PRIVATE ${LLVM_LIBRARY_DIRS})
+    endif()
+    target_link_libraries(tensor_backward_dual_impl_gradcheck_test PRIVATE eshkol-static ${ESHKOL_EXTRA_LINK_LIBS} ${LLVM_LIBS_LIST} ${LLVM_SYSTEM_LIBS_LIST})
+    add_test(NAME tensor_backward_dual_impl_gradcheck
+             COMMAND tensor_backward_dual_impl_gradcheck_test)
+    set_tests_properties(tensor_backward_dual_impl_gradcheck PROPERTIES
+        PASS_REGULAR_EXPRESSION "0 failed")
+endif()
+
 if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/core/runtime_arena_core_test.cpp")
     add_executable(runtime_arena_core_test tests/core/runtime_arena_core_test.cpp)
     target_compile_features(runtime_arena_core_test PRIVATE cxx_std_17)

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -5226,6 +5226,94 @@ static VmTensor* vm_tensor_operand(VM* vm, Value v, const char* op_name) {
     return NULL;
 }
 
+/**
+ * @brief SW-26: `(vector-ref t idx)` where `t` is a HEAP_TENSOR, not a
+ *         HEAP_VECTOR — e.g. the tensor `fg-marginal` returns. Before this
+ *         fix every vector-ref call site (native cases 219/OP_VEC_REF/
+ *         lbl_VEC_REF) matched only VAL_VECTOR and silently answered `()`
+ *         for anything else, even though `display` on the same tensor value
+ *         formats it correctly (the value itself is fine; only indexed
+ *         access was missing the arm).
+ *
+ * Mirrors CollectionCodegen::vectorRef's native-codegen tensor dispatch
+ * (collection_codegen.cpp) exactly: a tensor of rank <= 1 bounds-checks
+ * `idx` against the total element count and answers the scalar element; a
+ * tensor of rank > 1 bounds-checks `idx` against shape[0] (row count) and
+ * answers a view of rank n_dims-1 that shares the source's backing store
+ * (vm_tensor_slice — no copy), exactly like indexing the first axis of a
+ * nested vector would.
+ *
+ * On success PUSHES the result and returns 1. On an out-of-range index this
+ * RAISES a catchable "vector-ref: index out of bounds" error and returns 0
+ * without pushing. `vm_tensor_operand` returning NULL without having raised
+ * (the corrupted-heap-pointer sentinel case) is likewise a silent "return 0,
+ * push nothing" per its own documented contract above.
+ */
+static int vm_vecref_tensor_path(VM* vm, Value tensor_val, Value idx_val) {
+    VmTensor* t = vm_tensor_operand(vm, tensor_val, "vector-ref");
+    if (!t) return 0;
+    int64_t idx = (int64_t)as_number(idx_val);
+    if (t->n_dims <= 1) {
+        if (idx < 0 || idx >= t->total) {
+            vm_raise_error_msg(vm, "vector-ref: index out of bounds");
+            return 0;
+        }
+        vm_push(vm, FLOAT_VAL(t->data[idx]));
+        return 1;
+    }
+    if (idx < 0 || idx >= t->shape[0]) {
+        vm_raise_error_msg(vm, "vector-ref: index out of bounds");
+        return 0;
+    }
+    VmTensor* row = vm_tensor_slice(&vm->heap.regions, t, idx);
+    if (!row) {
+        vm_raise_error_msg(vm, "vector-ref: index out of bounds");
+        return 0;
+    }
+    int32_t p = heap_alloc(&vm->heap);
+    if (p < 0) { vm->error = 1; return 0; }
+    vm->heap.objects[p]->type = HEAP_TENSOR;
+    vm->heap.objects[p]->opaque.ptr = row;
+    vm_push(vm, (Value){.type = VAL_TENSOR, .as.ptr = p});
+    return 1;
+}
+
+/**
+ * @brief SW-26 sibling: `(vector-set! t idx val)` where `t` is a HEAP_TENSOR.
+ *
+ * Mirrors CollectionCodegen::vectorSet's tensor path: unlike vector-ref,
+ * native does NOT special-case N-D row addressing here — `idx` is always
+ * bounds-checked against the FLAT total element count regardless of rank,
+ * and the value is stored as a double directly into the flat data buffer.
+ *
+ * Returns 1 on success (caller still pushes the void result, matching the
+ * VAL_VECTOR path's convention). On an out-of-range index this RAISES a
+ * catchable "vector-set!: index out of bounds" error and returns 0.
+ */
+static int vm_vecset_tensor_path(VM* vm, Value tensor_val, Value idx_val, Value val) {
+    VmTensor* t = vm_tensor_operand(vm, tensor_val, "vector-set!");
+    if (!t) return 0;
+    int64_t idx = (int64_t)as_number(idx_val);
+    if (idx < 0 || idx >= t->total) {
+        vm_raise_error_msg(vm, "vector-set!: index out of bounds");
+        return 0;
+    }
+    t->data[idx] = as_number(val);
+    return 1;
+}
+
+/**
+ * @brief SW-26 sibling: `(vector-length t)` where `t` is a HEAP_TENSOR.
+ * Mirrors CollectionCodegen::vectorLength's tensor path: the flat total
+ * element count, not shape[0]. Silently answers 0 for a malformed operand,
+ * matching vector-length's existing non-VAL_VECTOR fallback (this builtin
+ * has never raised on a type mismatch).
+ */
+static int64_t vm_veclen_tensor_path(VM* vm, Value tensor_val) {
+    VmTensor* t = vm_tensor_operand(vm, tensor_val, "vector-length");
+    return t ? t->total : 0;
+}
+
 /* quantum-random / -int / -range (dispatch cases 1860-1862 below) used to be
  * backed by a VM-only xorshift64* PRNG that was numerically divergent from
  * the eshkol_qrng_* generator the LLVM AOT/JIT backend used for the same
@@ -13653,6 +13741,9 @@ static void vm_dispatch_native(VM* vm, int fid) {
                 break;
             }
             vm_push(vm, v->items[idx]);
+        } else if (vec_v.type == VAL_TENSOR) {
+            /* SW-26: e.g. (vector-ref (fg-marginal fg 0) 0). */
+            vm_vecref_tensor_path(vm, vec_v, idx_v);
         } else vm_push(vm, NIL_VAL); break; }
     case 220: { /* vector-set! */
         Value val = vm_pop(vm), idx_v = vm_pop(vm), vec_v = vm_pop(vm);
@@ -13664,12 +13755,19 @@ static void vm_dispatch_native(VM* vm, int fid) {
                 break;
             }
             v->items[idx] = val;
-        } vm_push(vm, NIL_VAL); break; }
+        } else if (vec_v.type == VAL_TENSOR) {
+            /* SW-26 sibling gap. */
+            if (!vm_vecset_tensor_path(vm, vec_v, idx_v, val)) break;
+        }
+        vm_push(vm, NIL_VAL); break; }
     case 221: { /* vector-length */
         Value v = vm_pop(vm);
         if (v.type == VAL_VECTOR) {
             VmVector* vec = (VmVector*)vm->heap.objects[v.as.ptr]->opaque.ptr;
             vm_push(vm, INT_VAL(vec ? vec->len : 0));
+        } else if (v.type == VAL_TENSOR) {
+            /* SW-26 sibling gap. */
+            vm_push(vm, INT_VAL(vm_veclen_tensor_path(vm, v)));
         } else vm_push(vm, INT_VAL(0)); break; }
     case 222: { /* string->list */
         Value s_val = vm_pop(vm);

--- a/lib/backend/vm_run.c
+++ b/lib/backend/vm_run.c
@@ -817,6 +817,11 @@ void vm_run(VM* vm) {
      * vm_raise_error_msg() in vm_native.c. */
     lbl_VEC_REF: {
         Value idx = vm_pop(vm), vec_val = vm_pop(vm);
+        if (vec_val.type == VAL_TENSOR) {
+            /* SW-26: e.g. (vector-ref (fg-marginal fg 0) 0). */
+            vm_vecref_tensor_path(vm, vec_val, idx);
+            DISPATCH();
+        }
         if (vec_val.type != VAL_VECTOR) { vm_push(vm, NIL_VAL); DISPATCH(); }
         VmVector* vec = (VmVector*)vm->heap.objects[vec_val.as.ptr]->opaque.ptr;
         int i = (int)as_number(idx);
@@ -838,6 +843,9 @@ void vm_run(VM* vm) {
                 DISPATCH();
             }
             vec->items[i] = val;
+        } else if (vec_val.type == VAL_TENSOR) {
+            /* SW-26 sibling gap. */
+            if (!vm_vecset_tensor_path(vm, vec_val, idx, val)) DISPATCH();
         }
         vm_push(vm, NIL_VAL);
         DISPATCH();
@@ -848,6 +856,9 @@ void vm_run(VM* vm) {
         if (vec_val.type == VAL_VECTOR) {
             VmVector* vec = (VmVector*)vm->heap.objects[vec_val.as.ptr]->opaque.ptr;
             vm_push(vm, INT_VAL(vec ? vec->len : 0));
+        } else if (vec_val.type == VAL_TENSOR) {
+            /* SW-26 sibling gap. */
+            vm_push(vm, INT_VAL(vm_veclen_tensor_path(vm, vec_val)));
         } else vm_push(vm, INT_VAL(0));
         DISPATCH();
     }
@@ -1602,6 +1613,11 @@ vm_exit:
          * codegen — see vm_raise_error_msg() in vm_native.c. */
         case OP_VEC_REF: {
             Value idx = vm_pop(vm), vec_val = vm_pop(vm);
+            if (vec_val.type == VAL_TENSOR) {
+                /* SW-26: e.g. (vector-ref (fg-marginal fg 0) 0). */
+                vm_vecref_tensor_path(vm, vec_val, idx);
+                break;
+            }
             if (vec_val.type != VAL_VECTOR) { vm_push(vm, NIL_VAL); break; }
             VmVector* vec = (VmVector*)vm->heap.objects[vec_val.as.ptr]->opaque.ptr;
             int i = (int)as_number(idx);
@@ -1623,6 +1639,9 @@ vm_exit:
                     break;
                 }
                 vec->items[i] = val;
+            } else if (vec_val.type == VAL_TENSOR) {
+                /* SW-26 sibling gap. */
+                if (!vm_vecset_tensor_path(vm, vec_val, idx, val)) break;
             }
             vm_push(vm, NIL_VAL);
             break;
@@ -1633,6 +1652,9 @@ vm_exit:
             if (vec_val.type == VAL_VECTOR) {
                 VmVector* vec = (VmVector*)vm->heap.objects[vec_val.as.ptr]->opaque.ptr;
                 vm_push(vm, INT_VAL(vec ? vec->len : 0));
+            } else if (vec_val.type == VAL_TENSOR) {
+                /* SW-26 sibling gap. */
+                vm_push(vm, INT_VAL(vm_veclen_tensor_path(vm, vec_val)));
             } else vm_push(vm, INT_VAL(0));
             break;
         }

--- a/tests/backend/tensor_backward_dual_impl_gradcheck_test.cpp
+++ b/tests/backend/tensor_backward_dual_impl_gradcheck_test.cpp
@@ -1,0 +1,592 @@
+/**
+ * @file tensor_backward_dual_impl_gradcheck_test.cpp
+ * @brief SW-12: direct differential check between the TWO independent
+ *        backward implementations for matmul / layernorm / transpose / sum /
+ *        embedding / attention.
+ *
+ * `lib/backend/tensor_backward.cpp` defines `eshkol_backward_{matmul,
+ * layernorm,transpose,sum,embedding,attention}` — raw-buffer kernels called
+ * from the AD_NODE_{MATMUL,LAYERNORM,TRANSPOSE,SUM,EMBEDDING,ATTENTION}
+ * dispatch arms (the "native" tensor-op path). `lib/bridge/tensor_backward.cpp`
+ * defines `tensor_{matmul,layernorm,transpose,sum,embedding,attention}_backward`
+ * — node-based rules called from the AD_NODE_TENSOR_{MATMUL,LAYERNORM,
+ * TRANSPOSE,SUM,EMBEDDING,ATTENTION} arms (the qLLM-bridge path). Nothing in
+ * the tree ever compared the two on identical inputs before this file; each
+ * was only ever checked against finite differences of its OWN forward, which
+ * cannot catch a bug both implementations happen to share (e.g. a
+ * convention that is internally self-consistent but wrong), and cannot catch
+ * the two disagreeing with each other while each looks locally fine.
+ *
+ * Method, per op: build IDENTICAL inputs and an identical upstream cotangent,
+ * run both implementations, and diff their output gradients directly. Central
+ * finite differences of an independently-written (third) forward function
+ * serve as the tie-breaking oracle per the task's ruling: "finite differences
+ * arbitrate; fix the wrong one".
+ *
+ *   matmul, layernorm, transpose, sum:  both sides have exact closed-form
+ *     rules; this file asserts they agree with each other AND with FD.
+ *   embedding:  already covered end-to-end (including a bridge-vs-native
+ *     comparison) by tensor_embedding_backward_gradcheck_test.cpp; not
+ *     duplicated here.
+ *   attention:  the NATIVE rule (eshkol_backward_attention) is exact and is
+ *     FD-validated here. The BRIDGE rule (tensor_attention_backward) is an
+ *     unconditional refusal by design (see the comment at its definition) —
+ *     its forward (ad_tensor_attention, lib/bridge/qllm_bridge.cpp) does not
+ *     even retain the `causal` flag or the softmax weights the backward would
+ *     need, so there is no "wrong value" to arbitrate: it is a genuine
+ *     forward-plumbing gap, not a numeric disagreement. This file asserts the
+ *     CURRENT contract (native exact + FD-checked, bridge loudly refuses)
+ *     instead of silently excluding the op, and files the fix as
+ *     NEEDS-DECISION (see the block comment at attention_check() below and
+ *     the ledger entry).
+ *
+ * Copyright (C) tsotchke
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include "eshkol/eshkol.h"
+#include "eshkol/backend/tensor_backward.h"
+#include "eshkol/bridge/qllm_bridge.h"
+
+#if !defined(_WIN32)
+#include <sys/wait.h>
+#include <unistd.h>
+#define ESHKOL_HAVE_FORK_DEATH_TESTS 1
+#endif
+
+extern "C" {
+    typedef struct arena arena_t;
+    arena_t* get_global_arena(void);
+    void* arena_allocate_zeroed(arena_t* arena, size_t size);
+    ad_tape_t* arena_allocate_tape(arena_t* arena, size_t initial_capacity);
+    ad_node_t* arena_allocate_ad_node(arena_t* arena);
+}
+
+namespace {
+
+int g_passed = 0;
+int g_failed = 0;
+
+void report(const char* name, bool ok, const char* detail = nullptr) {
+    std::printf("  %-46s %s", name, ok ? "PASS" : "FAIL");
+    if (detail) std::printf("   [%s]", detail);
+    std::printf("\n");
+    if (ok) ++g_passed; else ++g_failed;
+}
+
+unsigned long g_rng = 0xD1B54A32D192ED03UL;
+double urand() { /* deterministic uniform in [-1, 1] */
+    g_rng ^= g_rng << 13; g_rng ^= g_rng >> 7; g_rng ^= g_rng << 17;
+    return ((double)(g_rng >> 11) / (double)(1UL << 53)) * 2.0 - 1.0;
+}
+
+double max_abs_diff(const double* a, const double* b, size_t n) {
+    double worst = 0.0;
+    for (size_t i = 0; i < n; i++) {
+        double d = std::fabs(a[i] - b[i]);
+        if (d > worst) worst = d;
+    }
+    return worst;
+}
+
+double* zeros(size_t n) {
+    return (double*)arena_allocate_zeroed(get_global_arena(), n * sizeof(double));
+}
+
+/** @brief Build a leaf AD node wrapping a copy of @p data, shape @p shape. */
+ad_node_t* var_node(const double* data, const int64_t* shape, size_t ndim) {
+    ad_node_t* n = arena_allocate_ad_node(get_global_arena());
+    size_t count = 1;
+    for (size_t i = 0; i < ndim; ++i) count *= (size_t)shape[i];
+    double* buf = zeros(count);
+    std::memcpy(buf, data, count * sizeof(double));
+    int64_t* sh = (int64_t*)arena_allocate_zeroed(get_global_arena(), ndim * sizeof(int64_t));
+    std::memcpy(sh, shape, ndim * sizeof(int64_t));
+    n->type = AD_NODE_VARIABLE;
+    n->tensor_value = buf;
+    n->shape = sh;
+    n->ndim = ndim;
+    return n;
+}
+
+/*******************************************************************************
+ * MATMUL — Y[M,N] = X[M,K] @ W[K,N]
+ ******************************************************************************/
+
+void matmul_forward_ref(const double* X, const double* W, double* Y,
+                        int64_t M, int64_t K, int64_t N) {
+    for (int64_t i = 0; i < M; i++)
+        for (int64_t j = 0; j < N; j++) {
+            double s = 0.0;
+            for (int64_t k = 0; k < K; k++) s += X[i * K + k] * W[k * N + j];
+            Y[i * N + j] = s;
+        }
+}
+
+double matmul_probe(const double* X, const double* W, const double* cotan,
+                    int64_t M, int64_t K, int64_t N) {
+    std::vector<double> Y((size_t)(M * N));
+    matmul_forward_ref(X, W, Y.data(), M, K, N);
+    double L = 0.0;
+    for (int64_t i = 0; i < M * N; i++) L += cotan[i] * Y[i];
+    return L;
+}
+
+void matmul_check() {
+    constexpr int64_t M = 3, K = 4, N = 2;
+    double X[M * K], W[K * N], cotan[M * N];
+    for (auto& v : X) v = urand();
+    for (auto& v : W) v = urand();
+    for (auto& v : cotan) v = urand();
+
+    /* -- native -- */
+    double dX_native[M * K] = {0}, dW_native[K * N] = {0};
+    eshkol_backward_matmul(cotan, X, W, dX_native, dW_native, M, K, N);
+
+    /* -- bridge -- */
+    ad_tape_t* tape = arena_allocate_tape(get_global_arena(), 8);
+    int64_t shX[2] = {M, K}, shW[2] = {K, N};
+    ad_node_t* xn = var_node(X, shX, 2);
+    ad_node_t* wn = var_node(W, shW, 2);
+    ad_node_t* node = ad_tensor_matmul(tape, xn, wn);
+    double* cotan_buf = zeros((size_t)(M * N));
+    std::memcpy(cotan_buf, cotan, sizeof(cotan));
+    node->tensor_gradient = cotan_buf;
+    eshkol_tensor_backward_dispatch(node);
+    const double* dX_bridge = (const double*)xn->tensor_gradient;
+    const double* dW_bridge = (const double*)wn->tensor_gradient;
+
+    /* -- direct native-vs-bridge -- */
+    double d_dX = max_abs_diff(dX_native, dX_bridge, M * K);
+    double d_dW = max_abs_diff(dW_native, dW_bridge, K * N);
+    char detail[128];
+    std::snprintf(detail, sizeof detail, "max|dX diff|=%.3e max|dW diff|=%.3e", d_dX, d_dW);
+    report("matmul: native vs bridge", d_dX < 1e-9 && d_dW < 1e-9, detail);
+
+    /* -- finite-difference oracle (against native; bridge already agrees) -- */
+    const double h = 1e-6;
+    std::vector<double> fdX((size_t)(M * K)), fdW((size_t)(K * N));
+    for (int64_t i = 0; i < M * K; i++) {
+        double save = X[i];
+        X[i] = save + h; double Lp = matmul_probe(X, W, cotan, M, K, N);
+        X[i] = save - h; double Lm = matmul_probe(X, W, cotan, M, K, N);
+        X[i] = save;
+        fdX[i] = (Lp - Lm) / (2.0 * h);
+    }
+    for (int64_t i = 0; i < K * N; i++) {
+        double save = W[i];
+        W[i] = save + h; double Lp = matmul_probe(X, W, cotan, M, K, N);
+        W[i] = save - h; double Lm = matmul_probe(X, W, cotan, M, K, N);
+        W[i] = save;
+        fdW[i] = (Lp - Lm) / (2.0 * h);
+    }
+    double fd_dX = max_abs_diff(dX_native, fdX.data(), M * K);
+    double fd_dW = max_abs_diff(dW_native, fdW.data(), K * N);
+    std::snprintf(detail, sizeof detail, "max|dX-fd|=%.3e max|dW-fd|=%.3e", fd_dX, fd_dW);
+    report("matmul: native vs finite differences", fd_dX < 1e-6 && fd_dW < 1e-6, detail);
+}
+
+/*******************************************************************************
+ * LAYERNORM — per-row y = gamma*(x-mean)/sqrt(var+eps)   (beta omitted: the
+ * bridge rule computes no dbeta at all, so there is nothing to compare there)
+ ******************************************************************************/
+
+void layernorm_forward_ref(const double* X, const double* G, double* Y,
+                           int64_t rows, int64_t width, double eps) {
+    for (int64_t r = 0; r < rows; r++) {
+        const double* xr = &X[r * width];
+        double* yr = &Y[r * width];
+        double mean = 0.0;
+        for (int64_t i = 0; i < width; i++) mean += xr[i];
+        mean /= (double)width;
+        double var = 0.0;
+        for (int64_t i = 0; i < width; i++) { double d = xr[i] - mean; var += d * d; }
+        var /= (double)width;
+        double inv = 1.0 / std::sqrt(var + eps);
+        for (int64_t i = 0; i < width; i++) yr[i] = (xr[i] - mean) * inv * G[i];
+    }
+}
+
+double layernorm_probe(const double* X, const double* G, const double* cotan,
+                       int64_t rows, int64_t width, double eps) {
+    std::vector<double> Y((size_t)(rows * width));
+    layernorm_forward_ref(X, G, Y.data(), rows, width, eps);
+    double L = 0.0;
+    for (int64_t i = 0; i < rows * width; i++) L += cotan[i] * Y[i];
+    return L;
+}
+
+void layernorm_check() {
+    constexpr int64_t rows = 3, width = 4;
+    const double eps = 1e-5;
+    double X[rows * width], G[width], cotan[rows * width];
+    for (auto& v : X) v = urand();
+    for (auto& v : G) v = 1.0 + 0.3 * urand();
+    for (auto& v : cotan) v = urand();
+
+    /* -- native -- */
+    double saved_mean[rows], saved_inv_std[rows];
+    for (int64_t r = 0; r < rows; r++) {
+        const double* xr = &X[r * width];
+        double mean = 0.0;
+        for (int64_t i = 0; i < width; i++) mean += xr[i];
+        mean /= (double)width;
+        double var = 0.0;
+        for (int64_t i = 0; i < width; i++) { double d = xr[i] - mean; var += d * d; }
+        var /= (double)width;
+        saved_mean[r] = mean;
+        saved_inv_std[r] = 1.0 / std::sqrt(var + eps);
+    }
+    double dX_native[rows * width] = {0}, dG_native[width] = {0}, dBeta_scratch[width] = {0};
+    eshkol_backward_layernorm(cotan, X, saved_mean, saved_inv_std, G,
+                              dX_native, dG_native, dBeta_scratch, rows, width);
+
+    /* -- bridge -- */
+    ad_tape_t* tape = arena_allocate_tape(get_global_arena(), 8);
+    int64_t shX[2] = {rows, width}, shG[1] = {width};
+    ad_node_t* xn = var_node(X, shX, 2);
+    ad_node_t* gn = var_node(G, shG, 1);
+    ad_node_t* node = ad_tensor_layernorm(tape, xn, gn, nullptr, eps);
+    double* cotan_buf = zeros((size_t)(rows * width));
+    std::memcpy(cotan_buf, cotan, sizeof(cotan));
+    node->tensor_gradient = cotan_buf;
+    eshkol_tensor_backward_dispatch(node);
+    const double* dX_bridge = (const double*)xn->tensor_gradient;
+    const double* dG_bridge = (const double*)gn->tensor_gradient;
+
+    double d_dX = max_abs_diff(dX_native, dX_bridge, rows * width);
+    double d_dG = max_abs_diff(dG_native, dG_bridge, width);
+    char detail[128];
+    std::snprintf(detail, sizeof detail, "max|dX diff|=%.3e max|dGamma diff|=%.3e", d_dX, d_dG);
+    report("layernorm: native vs bridge", d_dX < 1e-9 && d_dG < 1e-9, detail);
+
+    const double h = 1e-6;
+    std::vector<double> fdX((size_t)(rows * width)), fdG((size_t)width);
+    for (int64_t i = 0; i < rows * width; i++) {
+        double save = X[i];
+        X[i] = save + h; double Lp = layernorm_probe(X, G, cotan, rows, width, eps);
+        X[i] = save - h; double Lm = layernorm_probe(X, G, cotan, rows, width, eps);
+        X[i] = save;
+        fdX[i] = (Lp - Lm) / (2.0 * h);
+    }
+    for (int64_t i = 0; i < width; i++) {
+        double save = G[i];
+        G[i] = save + h; double Lp = layernorm_probe(X, G, cotan, rows, width, eps);
+        G[i] = save - h; double Lm = layernorm_probe(X, G, cotan, rows, width, eps);
+        G[i] = save;
+        fdG[i] = (Lp - Lm) / (2.0 * h);
+    }
+    double fd_dX = max_abs_diff(dX_native, fdX.data(), rows * width);
+    double fd_dG = max_abs_diff(dG_native, fdG.data(), width);
+    std::snprintf(detail, sizeof detail, "max|dX-fd|=%.3e max|dGamma-fd|=%.3e", fd_dX, fd_dG);
+    report("layernorm: native vs finite differences", fd_dX < 1e-6 && fd_dG < 1e-6, detail);
+}
+
+/*******************************************************************************
+ * TRANSPOSE — Y[rows,cols] = X[cols,rows]^T, i.e. Y[i,j] = X[j,i].
+ * AD_NODE_TENSOR_TRANSPOSE has no forward producer anywhere in the tree (only
+ * the enum + backward dispatch entry exist), so the bridge side is exercised
+ * by hand-building the node exactly per tensor_transpose_backward's contract
+ * (same technique tests/backend/tensor_embedding_backward_gradcheck_test.cpp
+ * uses for AD_NODE_TENSOR_EMBEDDING).
+ ******************************************************************************/
+
+void transpose_forward_ref(const double* X, double* Y, int64_t rows, int64_t cols) {
+    for (int64_t i = 0; i < rows; i++)
+        for (int64_t j = 0; j < cols; j++)
+            Y[i * cols + j] = X[j * rows + i];
+}
+
+double transpose_probe(const double* X, const double* cotan, int64_t rows, int64_t cols) {
+    std::vector<double> Y((size_t)(rows * cols));
+    transpose_forward_ref(X, Y.data(), rows, cols);
+    double L = 0.0;
+    for (int64_t i = 0; i < rows * cols; i++) L += cotan[i] * Y[i];
+    return L;
+}
+
+void transpose_check() {
+    constexpr int64_t rows = 3, cols = 2;   /* X: (cols,rows), Y: (rows,cols) */
+    double X[cols * rows], cotan[rows * cols];
+    for (auto& v : X) v = urand();
+    for (auto& v : cotan) v = urand();
+
+    /* -- native -- */
+    double dX_native[cols * rows] = {0};
+    eshkol_backward_transpose(cotan, dX_native, rows, cols);
+
+    /* -- bridge: hand-built AD_NODE_TENSOR_TRANSPOSE (no producer exists) -- */
+    ad_node_t in{};
+    ad_node_t node{};
+    node.type = AD_NODE_TENSOR_TRANSPOSE;
+    node.input1 = &in;
+    int64_t out_shape[2] = {rows, cols};
+    node.shape = out_shape;
+    node.ndim = 2;
+    double* cotan_buf = zeros((size_t)(rows * cols));
+    std::memcpy(cotan_buf, cotan, sizeof(cotan));
+    node.tensor_gradient = cotan_buf;
+    eshkol_tensor_backward_dispatch(&node);
+    const double* dX_bridge = (const double*)in.tensor_gradient;
+
+    double d_dX = dX_bridge ? max_abs_diff(dX_native, dX_bridge, cols * rows) : -1.0;
+    char detail[96];
+    std::snprintf(detail, sizeof detail, "max|dX diff|=%.3e", d_dX);
+    report("transpose: native vs bridge", dX_bridge && d_dX < 1e-9, detail);
+
+    const double h = 1e-6;
+    std::vector<double> fdX((size_t)(cols * rows));
+    for (int64_t i = 0; i < cols * rows; i++) {
+        double save = X[i];
+        X[i] = save + h; double Lp = transpose_probe(X, cotan, rows, cols);
+        X[i] = save - h; double Lm = transpose_probe(X, cotan, rows, cols);
+        X[i] = save;
+        fdX[i] = (Lp - Lm) / (2.0 * h);
+    }
+    double fd_dX = max_abs_diff(dX_native, fdX.data(), cols * rows);
+    std::snprintf(detail, sizeof detail, "max|dX-fd|=%.3e", fd_dX);
+    report("transpose: native vs finite differences", fd_dX < 1e-6, detail);
+}
+
+/*******************************************************************************
+ * SUM — full reduction to a scalar: Y = sum(X). AD_NODE_TENSOR_SUM also has
+ * no forward producer; hand-built per tensor_sum_backward's contract.
+ ******************************************************************************/
+
+double sum_forward_ref(const double* X, int64_t n) {
+    double s = 0.0;
+    for (int64_t i = 0; i < n; i++) s += X[i];
+    return s;
+}
+
+void sum_check() {
+    constexpr int64_t n = 5;
+    double X[n];
+    for (auto& v : X) v = urand();
+    double cotan = urand();   /* upstream gradient of the scalar output */
+
+    /* -- native -- */
+    double dX_native[n] = {0};
+    eshkol_backward_sum(cotan, dX_native, n);
+
+    /* -- bridge -- */
+    ad_node_t in{};
+    int64_t in_shape[1] = {n};
+    in.shape = in_shape;
+    in.ndim = 1;
+    ad_node_t node{};
+    node.type = AD_NODE_TENSOR_SUM;
+    node.input1 = &in;
+    double cotan_buf[1] = {cotan};
+    node.tensor_gradient = cotan_buf;
+    eshkol_tensor_backward_dispatch(&node);
+    const double* dX_bridge = (const double*)in.tensor_gradient;
+
+    double d_dX = dX_bridge ? max_abs_diff(dX_native, dX_bridge, n) : -1.0;
+    char detail[96];
+    std::snprintf(detail, sizeof detail, "max|dX diff|=%.3e", d_dX);
+    report("sum: native vs bridge", dX_bridge && d_dX < 1e-9, detail);
+
+    const double h = 1e-6;
+    std::vector<double> fdX((size_t)n);
+    for (int64_t i = 0; i < n; i++) {
+        double save = X[i];
+        X[i] = save + h; double Lp = cotan * sum_forward_ref(X, n);
+        X[i] = save - h; double Lm = cotan * sum_forward_ref(X, n);
+        X[i] = save;
+        fdX[i] = (Lp - Lm) / (2.0 * h);
+    }
+    double fd_dX = max_abs_diff(dX_native, fdX.data(), n);
+    std::snprintf(detail, sizeof detail, "max|dX-fd|=%.3e", fd_dX);
+    report("sum: native vs finite differences", fd_dX < 1e-6, detail);
+}
+
+/*******************************************************************************
+ * ATTENTION — single-head scaled dot-product attention.
+ *
+ * NATIVE (eshkol_backward_attention) is exact; FD-validated below.
+ *
+ * BRIDGE (tensor_attention_backward) unconditionally calls eshkol_fatal() —
+ * see the comment at its definition in lib/bridge/tensor_backward.cpp. This
+ * is not a numeric disagreement to arbitrate: ad_tensor_attention's forward
+ * (lib/bridge/qllm_bridge.cpp) never retains the `causal` flag or the
+ * softmax attention weights on the node, so an exact adjoint cannot be
+ * computed from what the node carries even in principle — the gap is
+ * upstream, in the forward's contract, not a bug in a formula. Implementing
+ * it exactly needs a forward-side change (thread `causal` through
+ * AD_NODE_TENSOR_ATTENTION's params, and either retain the attention-weight
+ * matrix or recompute it in the backward), which is a real feature addition
+ * beyond a differential-test fix.
+ *
+ * NEEDS-DECISION (recorded for the ledger): should the bridge attention
+ * backward be implemented now (real work: extend the node contract +
+ * mirror the native 5-step chain rule already proven exact below), or is the
+ * existing hard refusal (loud, not silent) an acceptable placeholder because
+ * `scaled-dot-attention` already provides an exact, differentiable,
+ * scalar-decomposed attention path elsewhere in the tree? This file asserts
+ * the CURRENT contract (native exact, bridge refuses) so a future change to
+ * either side is caught, and the ledger records the finding without
+ * guessing which of "implement it" or "leave it refusing" the maintainer
+ * prefers.
+ ******************************************************************************/
+
+void attention_forward_ref(const double* Q, const double* K, const double* V,
+                           double* attn, double* out,
+                           int64_t seq_q, int64_t seq_k, int64_t d_k, int64_t d_v,
+                           double scale) {
+    for (int64_t i = 0; i < seq_q; i++) {
+        double mx = -1e300;
+        std::vector<double> row(seq_k);
+        for (int64_t j = 0; j < seq_k; j++) {
+            double dot = 0.0;
+            for (int64_t d = 0; d < d_k; d++) dot += Q[i * d_k + d] * K[j * d_k + d];
+            row[j] = dot * scale;
+            if (row[j] > mx) mx = row[j];
+        }
+        double sum = 0.0;
+        for (int64_t j = 0; j < seq_k; j++) { row[j] = std::exp(row[j] - mx); sum += row[j]; }
+        for (int64_t j = 0; j < seq_k; j++) attn[i * seq_k + j] = row[j] / sum;
+        for (int64_t d = 0; d < d_v; d++) {
+            double acc = 0.0;
+            for (int64_t j = 0; j < seq_k; j++) acc += attn[i * seq_k + j] * V[j * d_v + d];
+            out[i * d_v + d] = acc;
+        }
+    }
+}
+
+double attention_probe(const double* Q, const double* K, const double* V,
+                       const double* cotan,
+                       int64_t seq_q, int64_t seq_k, int64_t d_k, int64_t d_v, double scale) {
+    std::vector<double> attn((size_t)(seq_q * seq_k)), out((size_t)(seq_q * d_v));
+    attention_forward_ref(Q, K, V, attn.data(), out.data(), seq_q, seq_k, d_k, d_v, scale);
+    double L = 0.0;
+    for (int64_t i = 0; i < seq_q * d_v; i++) L += cotan[i] * out[i];
+    return L;
+}
+
+#if defined(ESHKOL_HAVE_FORK_DEATH_TESTS)
+/** @brief Run @p body in a forked child; true iff it terminated abnormally
+ *  (signal) or exited nonzero — i.e. it "refused" rather than returning a
+ *  value. Mirrors tests/backend/tensor_embedding_backward_gradcheck_test.cpp. */
+bool refuses(void (*body)()) {
+    std::fflush(stdout);
+    std::fflush(stderr);
+    pid_t pid = fork();
+    if (pid < 0) return false;
+    if (pid == 0) {
+        FILE* devnull = std::freopen("/dev/null", "w", stderr);
+        (void)devnull;
+        body();
+        std::_Exit(0);   /* reached only if the call did NOT refuse */
+    }
+    int status = 0;
+    if (waitpid(pid, &status, 0) < 0) return false;
+    if (WIFSIGNALED(status)) return true;
+    return WIFEXITED(status) && WEXITSTATUS(status) != 0;
+}
+
+constexpr int64_t kAttnSeqQ = 2, kAttnSeqK = 3, kAttnDK = 4, kAttnDV = 3;
+double g_attn_Q[kAttnSeqQ * kAttnDK];
+double g_attn_K[kAttnSeqK * kAttnDK];
+double g_attn_V[kAttnSeqK * kAttnDV];
+double g_attn_cotan[kAttnSeqQ * kAttnDV];
+
+void body_bridge_attention_backward() {
+    int64_t shQ[2] = {kAttnSeqQ, kAttnDK}, shK[2] = {kAttnSeqK, kAttnDK}, shV[2] = {kAttnSeqK, kAttnDV};
+    ad_node_t qn{}; qn.type = AD_NODE_VARIABLE; qn.tensor_value = g_attn_Q; qn.shape = shQ; qn.ndim = 2;
+    ad_node_t kn{}; kn.type = AD_NODE_VARIABLE; kn.tensor_value = g_attn_K; kn.shape = shK; kn.ndim = 2;
+    ad_node_t vn{}; vn.type = AD_NODE_VARIABLE; vn.tensor_value = g_attn_V; vn.shape = shV; vn.ndim = 2;
+    ad_node_t node{};
+    node.type = AD_NODE_TENSOR_ATTENTION;
+    node.input1 = &qn; node.input2 = &kn; node.input3 = &vn;
+    int64_t shO[2] = {kAttnSeqQ, kAttnDV};
+    node.shape = shO; node.ndim = 2;
+    node.tensor_gradient = g_attn_cotan;
+    node.params.attention_params.num_heads = 1;
+    node.params.attention_params.head_dim = kAttnDK;
+    eshkol_tensor_backward_dispatch(&node);
+}
+#endif  /* ESHKOL_HAVE_FORK_DEATH_TESTS */
+
+void attention_check() {
+    constexpr int64_t seq_q = 2, seq_k = 3, d_k = 4, d_v = 3;
+    double Q[seq_q * d_k], K[seq_k * d_k], V[seq_k * d_v], cotan[seq_q * d_v];
+    for (auto& v : Q) v = urand();
+    for (auto& v : K) v = urand();
+    for (auto& v : V) v = urand();
+    for (auto& v : cotan) v = urand();
+    double scale = 1.0 / std::sqrt((double)d_k);
+
+    /* -- native: exact, needs the forward's saved attention weights -- */
+    std::vector<double> attn((size_t)(seq_q * seq_k)), out((size_t)(seq_q * d_v));
+    attention_forward_ref(Q, K, V, attn.data(), out.data(), seq_q, seq_k, d_k, d_v, scale);
+
+    double dQ_native[seq_q * d_k] = {0}, dK_native[seq_k * d_k] = {0}, dV_native[seq_k * d_v] = {0};
+    eshkol_backward_attention(cotan, Q, K, V, attn.data(), dQ_native, dK_native, dV_native,
+                              seq_q, seq_k, d_k, d_v, scale);
+
+    const double h = 1e-6;
+    std::vector<double> fdQ((size_t)(seq_q * d_k)), fdK((size_t)(seq_k * d_k)), fdV((size_t)(seq_k * d_v));
+    for (int64_t i = 0; i < seq_q * d_k; i++) {
+        double save = Q[i];
+        Q[i] = save + h; double Lp = attention_probe(Q, K, V, cotan, seq_q, seq_k, d_k, d_v, scale);
+        Q[i] = save - h; double Lm = attention_probe(Q, K, V, cotan, seq_q, seq_k, d_k, d_v, scale);
+        Q[i] = save;
+        fdQ[i] = (Lp - Lm) / (2.0 * h);
+    }
+    for (int64_t i = 0; i < seq_k * d_k; i++) {
+        double save = K[i];
+        K[i] = save + h; double Lp = attention_probe(Q, K, V, cotan, seq_q, seq_k, d_k, d_v, scale);
+        K[i] = save - h; double Lm = attention_probe(Q, K, V, cotan, seq_q, seq_k, d_k, d_v, scale);
+        K[i] = save;
+        fdK[i] = (Lp - Lm) / (2.0 * h);
+    }
+    for (int64_t i = 0; i < seq_k * d_v; i++) {
+        double save = V[i];
+        V[i] = save + h; double Lp = attention_probe(Q, K, V, cotan, seq_q, seq_k, d_k, d_v, scale);
+        V[i] = save - h; double Lm = attention_probe(Q, K, V, cotan, seq_q, seq_k, d_k, d_v, scale);
+        V[i] = save;
+        fdV[i] = (Lp - Lm) / (2.0 * h);
+    }
+    double fd_dQ = max_abs_diff(dQ_native, fdQ.data(), seq_q * d_k);
+    double fd_dK = max_abs_diff(dK_native, fdK.data(), seq_k * d_k);
+    double fd_dV = max_abs_diff(dV_native, fdV.data(), seq_k * d_v);
+    char detail[160];
+    std::snprintf(detail, sizeof detail, "max|dQ-fd|=%.3e max|dK-fd|=%.3e max|dV-fd|=%.3e",
+                 fd_dQ, fd_dK, fd_dV);
+    report("attention: native vs finite differences", fd_dQ < 1e-6 && fd_dK < 1e-6 && fd_dV < 1e-6, detail);
+
+#if defined(ESHKOL_HAVE_FORK_DEATH_TESTS)
+    std::memcpy(g_attn_Q, Q, sizeof(g_attn_Q));
+    std::memcpy(g_attn_K, K, sizeof(g_attn_K));
+    std::memcpy(g_attn_V, V, sizeof(g_attn_V));
+    std::memcpy(g_attn_cotan, cotan, sizeof(g_attn_cotan));
+    report("attention: bridge backward refuses (NEEDS-DECISION, see block comment)",
+          refuses(&body_bridge_attention_backward));
+#else
+    std::printf("  (bridge attention refusal check skipped: no fork on this platform)\n");
+#endif
+}
+
+}  // namespace
+
+int main() {
+    std::printf("=== dual-backward differential check (SW-12) ===\n");
+
+    matmul_check();
+    layernorm_check();
+    transpose_check();
+    sum_check();
+    attention_check();
+
+    std::printf("(embedding: bridge-vs-native comparison lives in "
+               "tensor_embedding_backward_gradcheck_test.cpp, checks 1/2/9)\n");
+
+    std::printf("=== Results: %d passed, %d failed ===\n", g_passed, g_failed);
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/backend/tensor_embedding_backward_gradcheck_test.cpp
+++ b/tests/backend/tensor_embedding_backward_gradcheck_test.cpp
@@ -237,6 +237,12 @@ int main() {
     Fixture f;
     f.dispatch();
     const double* got = f.grad();
+    /* Snapshot now: check 5 below dispatches a SECOND time to test arena-scope
+     * survival, which doubles w.tensor_gradient's contents via +=. Checks 2-4
+     * run before that second dispatch and read the live pointer safely; check
+     * 10 runs after it, so it needs its own single-dispatch copy. */
+    std::vector<double> got_snapshot;
+    if (got) got_snapshot.assign(got, got + w_total);
     if (!got) {
         report("scatter-add vs closed form", false, "no gradient buffer produced");
     } else {
@@ -356,18 +362,37 @@ int main() {
 #endif
 
     /* ---- 9. the native (non-bridge) scatter also accumulates ----------- */
+    std::vector<double> dW(w_total, 0.0);
     {
         /* eshkol_backward_embedding is the AD_NODE_EMBEDDING rule; it takes the
          * indices as int64 rather than off the node. Same duplicate-index
          * property, so cover it here rather than leaving it unexercised. */
         const int64_t idx_i64[kNumIndices] = { 3, 0, 3, 1 };
-        std::vector<double> dW(w_total, 0.0);
         eshkol_backward_embedding(kCotangent, idx_i64, dW.data(),
                                   kNumIndices, kDModel, kVocab);
         double worst = max_abs_diff(dW.data(), want.data(), w_total);
         char detail[96];
         std::snprintf(detail, sizeof detail, "max abs err = %.3e", worst);
         report("native scatter accumulates duplicates", worst == 0.0, detail);
+    }
+
+    /* ---- 10. SW-12: DIRECT bridge-vs-native comparison on the same inputs --
+     * Checks 1 and 9 each compare their own implementation against the closed
+     * form `want` separately; both landing on zero error makes them equal to
+     * each other only transitively. This check diffs got_snapshot (bridge,
+     * AD_NODE_TENSOR_EMBEDDING via the Fixture above, captured after its
+     * single dispatch in check 1 — check 5 below deliberately dispatches a
+     * second time, which would otherwise double `got`) against `dW` (native,
+     * eshkol_backward_embedding called directly above) element-by-element on
+     * the identical kWeights/kIndices/kCotangent fixture — the direct
+     * differential comparison SW-12 asks for. */
+    if (!got_snapshot.empty()) {
+        double worst = max_abs_diff(got_snapshot.data(), dW.data(), w_total);
+        char detail[96];
+        std::snprintf(detail, sizeof detail, "max abs err = %.3e", worst);
+        report("SW-12: bridge vs native, same inputs", worst == 0.0, detail);
+    } else {
+        report("SW-12: bridge vs native, same inputs", false, "no bridge gradient");
     }
 
     std::printf("=== Results: %d passed, %d failed ===\n", g_passed, g_failed);

--- a/tests/bridge/qllm_bridge_gradcheck_test.cpp
+++ b/tests/bridge/qllm_bridge_gradcheck_test.cpp
@@ -21,11 +21,25 @@
  * precision, so the finite-difference floor sits far below the 1e-6 bar the
  * SDNC gradient check already uses.
  *
- * Coverage: every bridge op that has an exact backward rule registered in
- * get_tensor_backward_fn — matmul, gelu, softmax, layernorm, rmsnorm, silu and
- * cross-entropy. Attention and embedding are deliberately excluded: their
- * backward rules raise an explicit unsupported-op error rather than return an
- * approximate gradient, which is the existing hard constraint in this area.
+ * Coverage: every bridge op whose forward/backward pair fits this file's
+ * single-scalar-loss pipeline shape — matmul, gelu, softmax, layernorm,
+ * rmsnorm, silu and cross-entropy. Embedding and attention are covered
+ * elsewhere instead of being silently skipped here (SW-12):
+ *   - embedding's backward (tensor_embedding_backward, an indexed
+ *     scatter-add) IS implemented and exact; it takes an index tensor rather
+ *     than this file's x/w pipeline shape, so it is gradchecked in
+ *     tests/backend/tensor_embedding_backward_gradcheck_test.cpp, which also
+ *     diffs it directly against the non-bridge implementation
+ *     (eshkol_backward_embedding) on identical inputs.
+ *   - attention's backward (tensor_attention_backward) still unconditionally
+ *     refuses (eshkol_fatal) — its forward, ad_tensor_attention, does not
+ *     retain the causal flag or the softmax weights an exact adjoint would
+ *     need, a real forward-plumbing gap rather than a wrong formula. This is
+ *     asserted (not silently skipped) in
+ *     tests/backend/tensor_backward_dual_impl_gradcheck_test.cpp, alongside
+ *     an FD-validated check that the non-bridge implementation
+ *     (eshkol_backward_attention) is exact. See that file's block comment for
+ *     the NEEDS-DECISION on whether to implement the bridge side.
  *
  * Also covered: the float32 interop round-trip and the bridge lifecycle, which
  * are the other four symbols the header declared and nothing defined.

--- a/tests/differential/corpus/47_vector_ref_tensor_indexed_access.esk
+++ b/tests/differential/corpus/47_vector_ref_tensor_indexed_access.esk
@@ -1,0 +1,48 @@
+;; SW-26: `vector-ref` / `vector-set!` / `vector-length` applied to a
+;; TENSOR-typed value (e.g. what `fg-marginal` returns), across native's
+;; JIT/AOT axes. See tests/vm_parity/corpus/59_vector_ref_tensor_indexed_access.esk
+;; for the matching native-vs-VM differential (that is where the bug actually
+;; lived: the VM's vector-ref/-set!/-length fast paths and native-call cases
+;; only recognized VAL_VECTOR, not VAL_TENSOR).
+
+(define (show label v) (display label) (display " = ") (display v) (newline))
+
+(define fg (make-factor-graph 2 #(2 2)))
+(define m (fg-marginal fg 0))
+
+(show "vector-ref elem0" (vector-ref m 0))
+(show "vector-ref elem1" (vector-ref m 1))
+(display "vector-ref-uniform-2 ")
+(display (if (and (= (vector-ref m 0) 0.5) (= (vector-ref m 1) 0.5))
+             "PASS" "FAIL"))
+(newline)
+
+(show "vector-length" (vector-length m))
+(display "vector-length-2 ")
+(display (if (= (vector-length m) 2) "PASS" "FAIL"))
+(newline)
+
+(define t (make-tensor '(3) 0.0))
+(vector-set! t 0 10.0)
+(vector-set! t 1 20.0)
+(vector-set! t 2 30.0)
+(display "vector-set-roundtrip ")
+(display (if (and (= (vector-ref t 0) 10.0)
+                  (= (vector-ref t 1) 20.0)
+                  (= (vector-ref t 2) 30.0))
+             "PASS" "FAIL"))
+(newline)
+
+(define t2 (make-tensor '(2 3) 0.0))
+(vector-set! t2 0 1.0) (vector-set! t2 1 2.0) (vector-set! t2 2 3.0)
+(vector-set! t2 3 4.0) (vector-set! t2 4 5.0) (vector-set! t2 5 6.0)
+(define row0 (vector-ref t2 0))
+(display "row0-shape ")
+(display (if (equal? (tensor-shape row0) '(3)) "PASS" "FAIL"))
+(newline)
+(display "row0-values ")
+(display (if (and (= (tensor-ref row0 0) 1.0)
+                  (= (tensor-ref row0 1) 2.0)
+                  (= (tensor-ref row0 2) 3.0))
+             "PASS" "FAIL"))
+(newline)

--- a/tests/vm_parity/corpus/59_vector_ref_tensor_indexed_access.esk
+++ b/tests/vm_parity/corpus/59_vector_ref_tensor_indexed_access.esk
@@ -1,0 +1,74 @@
+;; VM-parity differential over `vector-ref` / `vector-set!` / `vector-length`
+;; applied to a TENSOR-typed value (SW-26).
+;;
+;; `fg-marginal` returns a tensor (SW-07/SW-08, PR #424). Displaying the whole
+;; value already worked on both engines before this fix — the tensor DATA was
+;; fine — but indexing into it with `vector-ref` diverged: native answered the
+;; element (native's collection codegen dispatches on the heap-object header
+;; subtype and has a tensor arm), while the VM's OP_VEC_REF / lbl_VEC_REF fast
+;; paths and the vector-ref native call (case 219) matched only VAL_VECTOR and
+;; fell through to `()` for anything else, silently. Exit 0, no diagnostic.
+;;
+;; vector-set! and vector-length had the identical gap (cases 220/221 and the
+;; OP_VEC_SET/OP_VEC_LEN and lbl_VEC_SET/lbl_VEC_LEN fast paths) — this file
+;; exercises the whole indexed-access family, not only the reported symptom.
+;;
+;; A graph with no factors and no inference run carries the uniform prior
+;; log(1/dim), so a d-state variable's marginal is 1/d in every slot — see
+;; tests/vm_parity/corpus/57_factor_graph_marginal.esk for the same oracle.
+
+(define (show label v) (display label) (display " = ") (display v) (newline))
+
+(define fg (make-factor-graph 2 #(2 2)))
+(define m (fg-marginal fg 0))
+
+;; ---- vector-ref on a 1-D tensor: the reported symptom -------------------
+(show "vector-ref elem0" (vector-ref m 0))
+(show "vector-ref elem1" (vector-ref m 1))
+(display "vector-ref-uniform-2 ")
+(display (if (and (= (vector-ref m 0) 0.5) (= (vector-ref m 1) 0.5))
+             "PASS" "FAIL"))
+(newline)
+
+;; ---- vector-length on the same tensor: flat total element count ---------
+(show "vector-length" (vector-length m))
+(display "vector-length-2 ")
+(display (if (= (vector-length m) 2) "PASS" "FAIL"))
+(newline)
+
+;; ---- vector-set! on an independent tensor, then read back with vector-ref
+(define t (make-tensor '(3) 0.0))
+(vector-set! t 0 10.0)
+(vector-set! t 1 20.0)
+(vector-set! t 2 30.0)
+(show "vector-set!+ref elem0" (vector-ref t 0))
+(show "vector-set!+ref elem1" (vector-ref t 1))
+(show "vector-set!+ref elem2" (vector-ref t 2))
+(display "vector-set-roundtrip ")
+(display (if (and (= (vector-ref t 0) 10.0)
+                  (= (vector-ref t 1) 20.0)
+                  (= (vector-ref t 2) 30.0))
+             "PASS" "FAIL"))
+(newline)
+
+;; ---- vector-ref on a rank>1 tensor returns a row view, not the flat elem -
+(define t2 (make-tensor '(2 3) 0.0))
+(vector-set! t2 0 1.0) (vector-set! t2 1 2.0) (vector-set! t2 2 3.0)
+(vector-set! t2 3 4.0) (vector-set! t2 4 5.0) (vector-set! t2 5 6.0)
+(define row0 (vector-ref t2 0))
+(show "row0" row0)
+(display "row0-shape ")
+(display (if (equal? (tensor-shape row0) '(3)) "PASS" "FAIL"))
+(newline)
+(display "row0-values ")
+(display (if (and (= (tensor-ref row0 0) 1.0)
+                  (= (tensor-ref row0 1) 2.0)
+                  (= (tensor-ref row0 2) 3.0))
+             "PASS" "FAIL"))
+(newline)
+
+;; ---- out-of-range vector-ref on a tensor is a catchable error, on both --
+(display "oob-catchable ")
+(display (guard (e (#t "caught"))
+           (vector-ref m 99)))
+(newline)


### PR DESCRIPTION
## Summary

- **SW-26 (closed)**: the VM's `vector-ref`/`vector-set!`/`vector-length` matched only `VAL_VECTOR` at every call site (both interpreter dispatch loops in `vm_run.c`, and native calls 219/220/221 in `vm_native.c`) and silently fell through to a fabricated `()`/no-op/`0` for a `VAL_TENSOR` operand — e.g. `(vector-ref (fg-marginal fg 0) 0)` answered `()` on the VM where native answered `0.5`, exit 0, no diagnostic. Three new shared helpers mirror native's `CollectionCodegen::vectorRef/vectorSet/vectorLength` tensor-arm semantics exactly (flat scalar for rank<=1, row view via the existing `vm_tensor_slice()` for rank>1 `vector-ref`, flat-total bounds for `vector-set!`, flat-total count for `vector-length`), wired into all six call sites so the two dispatch implementations cannot re-diverge.
- **SW-12 (stays open, findings recorded)**: built the differential test comparing the two independent tensor-backward implementations (`lib/backend/tensor_backward.cpp` vs `lib/bridge/tensor_backward.cpp`) directly against each other on identical inputs, with central finite differences of a third, independently-written forward as the tie-breaking oracle. matmul/layernorm/transpose/sum/embedding **agree to machine precision**. attention is not a value disagreement to arbitrate: native (`eshkol_backward_attention`) is exact and FD-validated; bridge (`tensor_attention_backward`) unconditionally refuses (`eshkol_fatal`) because its forward doesn't retain the causal flag or attention weights an exact adjoint needs — filed **NEEDS-DECISION** in the ledger rather than guessed at.

## Root causes

- SW-26: `fg-marginal` returns a `HEAP_TENSOR`, not a `HEAP_VECTOR`. Every VM vector-ref/-set!/-length site type-checked only `VAL_VECTOR`. Native's collection codegen already dispatches on the heap-object header subtype and has always had a tensor arm, so only the VM diverged.
- SW-12/attention: `ad_tensor_attention`'s forward (`lib/bridge/qllm_bridge.cpp`) never retains the `causal` flag or the softmax attention-weight matrix on the node, so an exact bridge adjoint can't be computed from what the node carries even in principle — a forward-plumbing gap, not a wrong formula.

## Gates (fresh rebuild post-reboot, `build-quantum`, `-DESHKOL_QUANTUM_ENABLED=ON`)

- `ctest --test-dir build-quantum`: **165/165** (baseline 164/164 + 1 new: `tensor_backward_dual_impl_gradcheck`)
- `scripts/run_differential.sh`: **294/294** axis pairs across 49 programs (baseline 288/288 + 1 new corpus file × 6 axis pairs), zero divergences
- `scripts/run_vm_parity.sh`: **160/0** (corpus + audit + oos + fatal), including the new `59_vector_ref_tensor_indexed_access.esk` on both `native-vs-vm-src` and `native-vs-vm-eskb`
- `scripts/run_icc_smoke.sh`: **41/60 probes PASS, 0 FAIL**, confirmed clean through `generative_differential_oracle` on two separate runs. Could not complete past `language_surface_coverage_floor` (its nested `run_all_tests.sh`) on this host: `uptime` showed load average 22–28 with **29 concurrent `run_icc_smoke.sh`/`run_all_tests.sh` processes** running system-wide from other parallel fix lanes sharing this machine (confirmed via `ps`/`pgrep` — the stuck PID accumulated only ~2.7s of CPU time over 15+ minutes elapsed, i.e. almost entirely scheduler-starved, not deadlocked). Killed and reran once per instruction; stalled identically the second time for the same reason. This is host contention, not a defect introduced here — every probe that DID complete is 0 FAIL on two independent runs, and the code-level gates (ctest/differential/vm_parity) most directly tied to these changes are all clean.
- Revert-validated: reverting the `vm_native.c`/`vm_run.c` hunks alone reproduces the VM FAIL on `59_vector_ref_tensor_indexed_access.esk`'s vector-ref/vector-length assertions; reapplying restores 0 FAIL.

## Ledger

`.icc/silent-wrong-ledger.yaml`: SW-26 closed at `b6b2d32f`; SW-12 left open with the full measurement (`ops_status` per op, `NEEDS-DECISION` for attention) since only 5/6 ops are verified agreeing — per the ledger's own rule, SW-12 closes only if all six are agreeing or fixed.

## Test plan

- [x] `ctest --test-dir build-quantum` — 165/165
- [x] `scripts/run_differential.sh` — 294/294
- [x] `scripts/run_vm_parity.sh` — 160/0
- [x] `scripts/run_icc_smoke.sh` — 41/60 clean (host-contention stall past that point, not a regression; see above)
- [x] Revert-validate SW-26 fix