### PR TITLE
feat(bridge): exact attention backward — closes SW-12

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -541,6 +541,7 @@ entries:
   - id: SW-12
     bucket: SILENT-WRONG
     status: closed
+    closed_at: "1b2682f6"
     title: "Six tensor ops carry two independent backward implementations with no differential test between them"
     ops: [matmul, layernorm, transpose, sum, embedding, attention]
     evidence: >-

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -540,7 +540,7 @@ entries:
 
   - id: SW-12
     bucket: SILENT-WRONG
-    status: open
+    status: closed
     title: "Six tensor ops carry two independent backward implementations with no differential test between them"
     ops: [matmul, layernorm, transpose, sum, embedding, attention]
     evidence: >-
@@ -580,40 +580,89 @@ entries:
       contract, the same technique tests/backend/tensor_embedding_backward_gradcheck_test.cpp
       already used for embedding.
 
-      attention is NOT a numeric disagreement: eshkol_backward_attention (native) is exact and
-      FD-validated here (max diff 2.3e-11 / 6.5e-11 / 4.2e-11 across dQ/dK/dV). tensor_attention_backward
-      (bridge) unconditionally calls eshkol_fatal() by design — asserted via a fork-based death
-      test, PASS (it does refuse). ad_tensor_attention's forward (lib/bridge/qllm_bridge.cpp)
-      does not retain the `causal` flag or the softmax attention weights on the node, so an
-      exact bridge adjoint cannot be computed from what the node carries even in principle: this
-      is a forward-plumbing gap, not a wrong formula to arbitrate between two answers.
+      attention was, at that SHA, NOT a numeric disagreement: eshkol_backward_attention (native)
+      was exact and FD-validated (max diff 2.3e-11 / 6.5e-11 / 4.2e-11 across dQ/dK/dV) while
+      tensor_attention_backward (bridge) unconditionally called eshkol_fatal(), because
+      ad_tensor_attention's forward (lib/bridge/qllm_bridge.cpp) retained neither the `causal`
+      flag nor the softmax attention weights an exact adjoint needs. That was a forward-plumbing
+      gap, not a wrong formula — recorded as NEEDS-DECISION and referred to the maintainer.
+    resolution: >-
+      Maintainer ruling: FIX IT — no refusal path ships. Implemented on branch
+      fix/bridge-attention-backward (stacked on fix/vector-ref-tensor-and-backward-diff).
+
+      FORWARD (lib/bridge/qllm_bridge.cpp, ad_tensor_attention) now retains what the adjoint
+      needs, in the mechanism the node struct already provides for exactly this and that the
+      native AD_NODE_ATTENTION arm already uses (saved_tensors):
+        node->saved_tensors[0]  dense [batch, num_heads, seq, seq] softmax weight matrix,
+                                masked entries left at EXACTLY zero
+        node->num_saved         1
+        node->params as int64[6]  [num_heads, head_dim, causal, scale_bits, 0, 0]
+                                (scale bit-cast from double, the "scale_bits" convention already
+                                used by the AD_NODE_ATTENTION params and the Frechet rule;
+                                slots [0]/[1] deliberately coincide with the named
+                                attention_params fields so both spellings read the same slots)
+      Forward VALUES are unchanged — the retained row is the same softmax row the forward already
+      computed, hoisted out of the inner product loop.
+
+      BACKWARD (lib/bridge/tensor_backward.cpp, tensor_attention_backward) is now the exact
+      adjoint, per (batch, head) column slice of the [batch, seq, dim] operands:
+        dV[j] = sum_i A[i][j] dO[i]
+        dA[i][j] = <dO[i], V[j]>
+        dS[i][j] = A[i][j] (dA[i][j] - sum_k A[i][k] dA[i][k]) * scale     (softmax Jacobian
+                   diag(y) - y y^T applied row-wise, one row dot product per row: O(seq^2))
+        dQ[i] = sum_j dS[i][j] K[j]      dK[j] = sum_i dS[i][j] Q[i]
+      Causal masking is carried by the retained zeros — every term above has a factor A[i][j], so
+      masked positions contribute exactly zero with no mask test, and the summations still run
+      over the full [0, seq) range. That keeps the accumulation ORDER identical between the causal
+      and non-causal cases and identical to the native kernel's loop nest, which is what the
+      no-fast-math / deterministic-gradient rule requires. The rule is written independently of
+      eshkol_backward_attention rather than delegating to it, so the differential below compares
+      two implementations and not a thing to itself. The eshkol_fatal refusal is retained ONLY
+      for contract violations (no retained weights, missing operand, params that do not partition
+      dim, unusable scale, or a recorded `causal` flag that disagrees with the retained weights —
+      an exact-equality cross-check, since masked entries are exactly zero).
+
+      MEASURED, ctest -R tensor_backward_dual_impl_gradcheck (21 checks, 21 pass), both masking
+      modes at two shapes, native-vs-bridge max abs diff across dQ/dK/dV:
+        small [batch 1, heads 1, seq 3, head_dim 4] noncausal  1.4e-17 / 1.4e-17 / 5.6e-17
+        small                                       causal     2.8e-17 / 1.4e-17 / 0.0
+        moderate [batch 2, heads 3, seq 5, head_dim 4] noncausal 5.6e-17 / 5.6e-17 / 1.1e-16
+        moderate                                      causal    4.2e-17 / 3.8e-17 / 2.2e-16
+      i.e. at or below the 1e-16 machine-epsilon floor, far inside the 1e-9 bar the other five ops
+      are held to (the residual is BLAS-vs-scalar summation order: the native kernel is
+      cblas_dgemm-backed, the bridge rule is plain loops). FD is the third oracle: bridge-vs-FD and
+      native-vs-FD max diff 1.0e-10 .. 1.4e-09 on the moderate shapes, bar 1e-6 — and the two
+      grads' FD residuals are identical to every printed digit, which is the same statement as the
+      1e-17 agreement. The bridge FORWARD is also diffed against the reference forward (0.0).
     ops_status:
       matmul: agree
       layernorm: agree
       transpose: agree
       sum: agree
       embedding: agree
-      attention: "NEEDS-DECISION — native exact+FD-validated; bridge unconditionally refuses
-        (loud, not silent) because its forward does not retain enough state (causal flag,
-        attention weights) for an exact adjoint. Implementing the bridge side needs a
-        forward-contract change (thread `causal` through AD_NODE_TENSOR_ATTENTION's params,
-        retain or recompute the attention-weight matrix) — a real feature addition, not a
-        differential-test fix. `scaled-dot-attention` already provides an exact,
-        scalar-decomposed, differentiable attention path elsewhere in the tree, which is why the
-        bridge node has had no producer's backward filled in. Maintainer must decide: implement
-        the bridge backward now, or accept the loud refusal as the standing contract."
+      attention: agree
     status_rationale: >-
-      Ledger ruling: SW-12 closes only if all six ops are verified agreeing or fixed. 5/6
-      verified agreeing to machine precision; attention has no comparable bridge VALUE to
-      arbitrate (one side refuses loudly), so it is neither "agreeing" nor "fixed" by this PR.
-      Left OPEN with the measurement above rather than guessing whether the maintainer wants the
-      bridge attention backward implemented or the refusal accepted as the standing contract.
+      Ledger ruling: SW-12 closes only if all six ops are verified agreeing or fixed. All six are
+      now verified agreeing on identical inputs, five to machine precision or exactly and
+      attention to <= 2.2e-16 across four shape/masking cells, with finite differences of an
+      independently-written third forward arbitrating in every case. The attention NEEDS-DECISION
+      was resolved by the maintainer as FIX IT and the fix is in this branch; no refusal path
+      remains for a well-formed node. Closing.
     evidence_new: >-
+      lib/bridge/qllm_bridge.cpp (ad_tensor_attention retains the attention weights and the causal
+      flag); lib/bridge/tensor_backward.cpp (tensor_attention_backward, exact adjoint replacing the
+      unconditional refusal);
       tests/backend/tensor_backward_dual_impl_gradcheck_test.cpp (matmul/layernorm/transpose/sum
-      direct diff + FD; attention native FD + bridge refusal assertion);
+      direct diff + FD; attention direct diff + FD at two shapes x causal/non-causal through the
+      REAL producer ad_tensor_attention and the real dispatch path, plus a fork death test that the
+      rule still refuses a node with no retained weights);
       tests/backend/tensor_embedding_backward_gradcheck_test.cpp check 10 (direct bridge-vs-native
-      diff, added to the existing ESH-0230 coverage); tests/bridge/qllm_bridge_gradcheck_test.cpp
-      header comment updated to point at both instead of describing them as excluded.
+      diff, added to the existing ESH-0230 coverage);
+      tests/bridge/qllm_bridge_gradcheck_test.cpp (attention and causal-attention pipelines added —
+      no op is excluded from that suite any more; embedding remains gradchecked in its own file
+      because it takes an index tensor, not that file's x/w pipeline shape);
+      docs/breakdown/AUTODIFF.md (the "attention backward is a v1.2 value-passthrough stub" section
+      replaced with the shipped exact rule on both paths).
 
   - id: SW-13
     bucket: SILENT-WRONG

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5211,7 +5211,10 @@ if(ESHKOL_BUILD_TESTS AND
         eshkol-static ${ESHKOL_EXTRA_LINK_LIBS} ${LLVM_LIBS_LIST} ${LLVM_SYSTEM_LIBS_LIST})
     add_test(NAME qllm_bridge_gradcheck COMMAND qllm_bridge_gradcheck_test)
     set_tests_properties(qllm_bridge_gradcheck PROPERTIES
-        PASS_REGULAR_EXPRESSION "Results: 7 passed, 0 failed"
+        # 5 pipeline gradchecks + attention + causal attention + conversion
+        # + lifecycle. The count is pinned deliberately: "0 failed" would stay
+        # green if a check silently stopped running.
+        PASS_REGULAR_EXPRESSION "Results: 9 passed, 0 failed"
     )
 endif()
 

--- a/docs/breakdown/AUTODIFF.md
+++ b/docs/breakdown/AUTODIFF.md
@@ -547,24 +547,43 @@ Eshkol v1.1 introduces a full reverse-mode backward pass for tensor operations, 
 | Convolution | conv2d | `eshkol_backward_conv2d` |
 | Normalization | batch norm, layer norm | `eshkol_backward_batchnorm`, `eshkol_backward_layernorm` |
 | Linear algebra | matmul | `eshkol_backward_matmul` |
-| Attention | single-head | `tensor_attention_backward` — **stub in v1.2** (see Known limitations below) |
+| Attention | single-head, multi-head (causal and non-causal) | `eshkol_backward_attention` (native path), `tensor_attention_backward` (qLLM-bridge path) — both exact |
 | Embedding | embedding lookup | `tensor_embedding_backward` — exact indexed scatter-add |
 
 **Matmul backward** implements the standard matrix calculus rules: for a forward pass `C = A @ B` where A is (M,K), B is (K,N), and C is (M,N), the backward pass computes `dA = grad_C @ B^T` and `dB = A^T @ grad_C`. Both input matrices are saved during the forward pass in the `ad_node_t.saved_tensors` array.
 
-**Attention backward** in v1.2-scale is a value-passthrough stub
-(`tensor_attention_backward` at `lib/bridge/tensor_backward.cpp`).
-It accumulates `dy` into the V input's gradient slot only; gradients
-into Q and K are zero, and the softmax chain through
-`softmax(Q K^T / sqrt(d)) V` is skipped. The runtime prints a
-one-shot stderr warning the first time the function is invoked so the
-limitation cannot hit silently during training. The full backward —
-`d_V = attn^T @ grad_out`, `d_attn = grad_out @ V^T`,
-`d_scores[i][j] = attn[i][j] * (d_attn[i][j] - dot(attn[i], d_attn[i]))`,
-then `d_Q = d_scores @ K` and `d_K = d_scores^T @ Q`, decomposed per-head
-for multi-head with backprop through (W_Q, W_K, W_V, W_O) — ships in
-v1.3-evolve as part of the attention-codegen rewrite. Training attention
-layers under v1.2 will not converge correctly.
+**Attention backward** is exact on both implementations, and the two are
+checked directly against each other by `ctest -R tensor_backward_dual_impl_gradcheck`
+(SW-12). The adjoint of `O = softmax(Q K^T * scale) V` is
+
+- `d_V = attn^T @ grad_out`
+- `d_attn = grad_out @ V^T`
+- `d_scores[i][j] = attn[i][j] * (d_attn[i][j] - dot(attn[i], d_attn[i])) * scale`
+  (the softmax Jacobian `diag(y) - y y^T` applied row-wise, one row dot
+  product per row, so the rule is O(seq^2) not O(seq^3))
+- `d_Q = d_scores @ K`, `d_K = d_scores^T @ Q`
+
+`eshkol_backward_attention` (`lib/backend/tensor_backward.cpp`) is the
+raw-buffer kernel for the native `AD_NODE_ATTENTION` path, BLAS-accelerated
+when `ESHKOL_BLAS_ENABLED`. `tensor_attention_backward`
+(`lib/bridge/tensor_backward.cpp`) is the independently written node-based rule
+for the qLLM-bridge `AD_NODE_TENSOR_ATTENTION` path; it applies the same
+adjoint per `(batch, head)` column slice of the `[batch, seq, dim]` operands.
+
+**Causal masking** is carried by the attention weights the forward retains, not
+by a mask test in the backward. `ad_tensor_attention`
+(`lib/bridge/qllm_bridge.cpp`) writes the dense `[batch, num_heads, seq, seq]`
+weight matrix into `node->saved_tensors[0]` with masked entries left at exactly
+zero, and records `[num_heads, head_dim, causal, scale_bits]` in the node's
+`params`. Every term of the adjoint carries a factor `attn[i][j]`, so masked
+positions contribute exactly zero while the summations still run over the full
+range — which keeps the accumulation order identical between the causal and
+non-causal cases and identical to the native kernel's, as the bit-for-bit
+gradient-determinism rule requires. The backward cross-checks the recorded
+`causal` flag against the retained weights and refuses if they disagree.
+
+Multi-head backprop through the projection weights `(W_Q, W_K, W_V, W_O)` is a
+separate rule, `eshkol_backward_multihead_attention`, on the native path.
 
 **Embedding backward** is the exact indexed scatter-add
 (`tensor_embedding_backward` at `lib/bridge/tensor_backward.cpp`, ESH-0230).

--- a/lib/bridge/qllm_bridge.cpp
+++ b/lib/bridge/qllm_bridge.cpp
@@ -513,6 +513,22 @@ extern "C" ad_node_t* ad_tensor_attention(ad_tape_t* tape,
     size_t batch = (size_t)q->shape[0];
     size_t seq   = (size_t)q->shape[1];
     size_t dim   = (size_t)q->shape[2];
+    /* K and V are indexed with Q's strides below, so a shape mismatch is an
+     * out-of-bounds read, not a broadcast. Refuse it here. */
+    for (size_t d = 0; d < 3; ++d) {
+        if (k->shape[d] != q->shape[d] || v->shape[d] != q->shape[d]) {
+            eshkol_error("qllm bridge: ad_tensor_attention needs Q, K and V to share "
+                         "one [batch, seq, dim] shape (dimension %zu: Q=%lld K=%lld V=%lld)",
+                         d, (long long)q->shape[d], (long long)k->shape[d],
+                         (long long)v->shape[d]);
+            return nullptr;
+        }
+    }
+    if (batch == 0 || seq == 0 || dim == 0) {
+        eshkol_error("qllm bridge: ad_tensor_attention got a degenerate shape "
+                     "[%zu, %zu, %zu]", batch, seq, dim);
+        return nullptr;
+    }
     if (dim % (size_t)num_heads != 0) {
         eshkol_error("qllm bridge: ad_tensor_attention dim %zu not divisible by %d heads",
                      dim, num_heads);
@@ -526,8 +542,33 @@ extern "C" ad_node_t* ad_tensor_attention(ad_tape_t* tape,
     double* O = alloc_doubles(batch * seq * dim);
     if (!O) return nullptr;
 
-    double* scores = (double*)alloc_doubles(seq);
-    if (!scores) return nullptr;
+    /* RETAINED FOR THE ADJOINT (SW-12).
+     *
+     * tensor_attention_backward needs the softmax attention weights A and it
+     * needs to know which entries the causal mask removed. Both are recorded
+     * here, at forward time, in the mechanism the node struct already provides
+     * for exactly this ("Saved tensors for backward pass") and that the
+     * non-bridge AD_NODE_ATTENTION arm already uses for its own attention
+     * weights (lib/backend/tensor_backward.cpp, saved_tensors[3]).
+     *
+     * The buffer is the DENSE [batch, num_heads, seq, seq] weight matrix, with
+     * masked-out entries left at EXACTLY zero. Storing the mask as zeros in A
+     * rather than as a separate bitmap is what makes the causal case fall out
+     * of the same code path as the non-causal one: every term of the adjoint
+     * below carries a factor of A[i][j], so a zero weight contributes exactly
+     * zero to dQ/dK/dV without a single mask test. The `causal` flag is still
+     * recorded in params so the backward can validate the retained weights
+     * against the shape the forward actually ran (and so a future rule can
+     * recompute rather than retain without guessing).
+     *
+     * Recomputing A in the backward instead was the alternative; it was
+     * rejected because it would have to re-derive the softmax max-shift and
+     * the mask, i.e. duplicate the forward, and any drift between the two
+     * copies is precisely the silently-wrong-gradient class SW-12 exists to
+     * close. */
+    double* A = alloc_doubles(batch * (size_t)num_heads * seq * seq);
+    if (!A) return nullptr;
+
     double scale = 1.0 / std::sqrt((double)head_dim);
 
     for (size_t b = 0; b < batch; ++b) {
@@ -535,26 +576,30 @@ extern "C" ad_node_t* ad_tensor_attention(ad_tape_t* tape,
             size_t off = (size_t)h * head_dim;
             for (size_t i = 0; i < seq; ++i) {
                 size_t qi = (b * seq + i) * dim + off;
+                /* Row of A for this (b, h, i). Already zero-filled, so the
+                 * masked tail stays exactly zero. */
+                double* arow = &A[((b * (size_t)num_heads + (size_t)h) * seq + i) * seq];
                 size_t limit = causal ? (i + 1) : seq;
                 double mx = -HUGE_VAL;
                 for (size_t j = 0; j < limit; ++j) {
                     size_t kj = (b * seq + j) * dim + off;
                     double dot = 0.0;
                     for (size_t d = 0; d < head_dim; ++d) dot += Q[qi + d] * K[kj + d];
-                    scores[j] = dot * scale;
-                    if (scores[j] > mx) mx = scores[j];
+                    arow[j] = dot * scale;
+                    if (arow[j] > mx) mx = arow[j];
                 }
                 double sum = 0.0;
                 for (size_t j = 0; j < limit; ++j) {
-                    scores[j] = std::exp(scores[j] - mx);
-                    sum += scores[j];
+                    arow[j] = std::exp(arow[j] - mx);
+                    sum += arow[j];
                 }
                 if (sum <= 0.0) sum = 1.0;
+                for (size_t j = 0; j < limit; ++j) arow[j] /= sum;
                 for (size_t d = 0; d < head_dim; ++d) {
                     double acc = 0.0;
                     for (size_t j = 0; j < limit; ++j) {
                         size_t vj = (b * seq + j) * dim + off;
-                        acc += (scores[j] / sum) * V[vj + d];
+                        acc += arow[j] * V[vj + d];
                     }
                     O[(b * seq + i) * dim + off + d] = acc;
                 }
@@ -566,8 +611,32 @@ extern "C" ad_node_t* ad_tensor_attention(ad_tape_t* tape,
                                 q->shape, q->ndim, q, k, v);
     if (node) {
         node->input4 = nullptr;
-        node->params.attention_params.num_heads = num_heads;
-        node->params.attention_params.head_dim = (int64_t)head_dim;
+        /* params as int64[6] — the layout tensor_attention_backward reads:
+         *   [0] num_heads   [1] head_dim   [2] causal (0/1)
+         *   [3] scale bit-cast from double (the "scale_bits" convention used
+         *       by the AD_NODE_ATTENTION params and the Frechet rule)
+         *   [4] [5] reserved, zero
+         * [0]/[1] deliberately coincide with the named attention_params
+         * fields so both spellings read the same slots. */
+        int64_t* p = (int64_t*)&node->params;
+        p[0] = (int64_t)num_heads;
+        p[1] = (int64_t)head_dim;
+        p[2] = causal ? 1 : 0;
+        std::memcpy(&p[3], &scale, sizeof scale);
+        p[4] = 0;
+        p[5] = 0;
+
+        double** saved = (double**)arena_allocate_zeroed(get_global_arena(),
+                                                         sizeof(double*));
+        if (!saved) {
+            eshkol_error("qllm bridge: ad_tensor_attention could not retain the "
+                         "attention weights; refusing to record a node whose "
+                         "backward would have nothing exact to work from");
+            return nullptr;
+        }
+        saved[0] = A;
+        node->saved_tensors = (void**)saved;
+        node->num_saved = 1;
     }
     return node;
 }

--- a/lib/bridge/tensor_backward.cpp
+++ b/lib/bridge/tensor_backward.cpp
@@ -1278,28 +1278,268 @@ extern "C" void tensor_frechet_mean_backward(ad_node_t* node) {
     }
 }
 
-/** @brief Backward pass for attention: a conservative identity-like
- *  pass-through for the value input only. Proper scaled-dot-product
- *  backward requires the Q/K/V split in the node — stubbed here to at
- *  least propagate a non-zero signal. The exact formulation (5-step chain
- *  through softmax(QK^T/√d)V) lands with the full attention codegen
- *  rewrite. */
+/*******************************************************************************
+ * Attention Backward — exact adjoint of multi-head scaled dot-product
+ * attention, causal and non-causal (SW-12)
+ *
+ * FORWARD (ad_tensor_attention, lib/bridge/qllm_bridge.cpp). Q, K, V are
+ * [batch, seq, dim] with dim = num_heads * head_dim, so head h of batch b owns
+ * the column slice [h*head_dim, (h+1)*head_dim) of every row. Per (b, h):
+ *
+ *     S[i][j] = scale * <Q[b,i,h], K[b,j,h]>,   scale = 1/sqrt(head_dim)
+ *     A[i][j] = softmax_j(S[i][j])              (row-wise; causal => j <= i)
+ *     O[b,i,h] = sum_j A[i][j] * V[b,j,h]
+ *
+ * BACKWARD. Each (b, h) pair is an independent single-head attention — the
+ * heads never mix in the forward, so their adjoints never mix either, and the
+ * whole rule is that 2-D adjoint applied on each column slice:
+ *
+ *     dV[j] = sum_i A[i][j] * dO[i]                    (seq x head_dim)
+ *     dA[i][j] = <dO[i], V[j]>                         (seq x seq)
+ *     dS[i][j] = A[i][j] * (dA[i][j] - sum_k A[i][k] dA[i][k]) * scale
+ *     dQ[i] = sum_j dS[i][j] * K[j]
+ *     dK[j] = sum_i dS[i][j] * Q[i]
+ *
+ * The dS line IS the softmax Jacobian: for a row y = softmax(s),
+ * dL/ds = J^T dL/dy with J = diag(y) - y y^T, i.e.
+ * dL/ds_j = y_j (dL/dy_j - sum_k y_k dL/dy_k). The row dot product is computed
+ * once per row, which is what makes the rule O(seq^2) rather than O(seq^3).
+ *
+ * CAUSAL MASKING is handled entirely by the retained weights. The forward
+ * leaves A[i][j] at EXACTLY zero for j > i, and every term above carries a
+ * factor A[i][j]: dV and dA vanish there, the row dot product picks up nothing
+ * from the masked tail, and dS[i][j] = 0 * (...) = 0 kills the dQ/dK
+ * contributions. So the masked positions contribute exactly zero without a
+ * single mask test, and the summations still run over the full [0, seq) range
+ * — which keeps the accumulation ORDER identical between the causal and
+ * non-causal cases and identical to the non-bridge kernel's
+ * (eshkol_backward_attention, lib/backend/tensor_backward.cpp), as the
+ * bit-for-bit determinism rule requires. Skipping the masked j instead would
+ * change nothing numerically (x + 0.0 == x for every finite x) but would make
+ * the two implementations' orders diverge for no gain.
+ *
+ * NODE CONTRACT
+ *   node->input1/2/3        Q, K, V nodes, each [batch, seq, dim]
+ *   node->shape/ndim        output shape, [batch, seq, dim]
+ *   node->tensor_gradient   upstream dL/dO, batch*seq*dim doubles
+ *   node->saved_tensors[0]  retained attention weights A, dense
+ *                           [batch, num_heads, seq, seq], masked entries zero
+ *   node->num_saved         >= 1
+ *   node->params as int64[6]  [num_heads, head_dim, causal, scale_bits, 0, 0]
+ *
+ * This rule is written independently of eshkol_backward_attention rather than
+ * delegating to it: the two implementations are the two sides of the SW-12
+ * differential check, and a delegation would make that check compare a thing
+ * to itself.
+ ******************************************************************************/
+
+/** @brief Backward pass for the qLLM-bridge attention node: the exact adjoint
+ *  of multi-head scaled dot-product attention (dQ, dK, dV through the softmax
+ *  Jacobian), with causal masking carried by the forward's retained weights.
+ *  See the block comment above for the derivation and the node contract. */
 extern "C" void tensor_attention_backward(ad_node_t* node) {
-    (void)node;
+    if (!node || !node->tensor_gradient) return;
+
+    ad_node_t* q_node = node->input1;
+    ad_node_t* k_node = node->input2;
+    ad_node_t* v_node = node->input3;
+
     /* HARD CONSTRAINT (exact AD or an explicit error, never a silent/plausible
-     * zero): the qLLM-bridge attention AD node has no exact backward. The former
-     * value-passthrough stub flowed dy into V only — skipping Q, K, and the
-     * softmax(Q K^T / sqrt(d)) chain — so it returned a plausible-but-WRONG
-     * gradient. Rather than corrupt a training run, refuse the operation.
-     *
-     * NOTE: the differentiable attention path used by `(gradient …
-     * (scaled-dot-attention …))` decomposes to scalar AD nodes in
-     * tensor_transformer_codegen.cpp and does NOT reach here; this stub only
-     * fires if the bridge AD_NODE_TENSOR_ATTENTION node is ever backpropagated. */
-    eshkol_fatal("unsupported AD op: exact backward for the qLLM-bridge tensor "
-                 "attention node is not implemented; refusing to return an "
-                 "approximate (wrong) gradient. Differentiate attention through "
-                 "scaled-dot-attention instead (that path is exact).");
+     * zero). Before this rule existed the node carried neither the attention
+     * weights nor the causal flag, and the backward could only refuse. Both are
+     * now part of the contract, so a node arriving without them means the
+     * PRODUCER did not follow it — refusing here is what stops a mis-wired
+     * forward from training on a gradient reconstructed from guesses. */
+    if (!q_node || !k_node || !v_node) {
+        eshkol_fatal("attention backward: node->input1/2/3 must carry the Q, K "
+                     "and V operands (SW-12 contract: inputs [batch, seq, dim], "
+                     "saved_tensors[0] = attention weights "
+                     "[batch, num_heads, seq, seq], params = "
+                     "[num_heads, head_dim, causal, scale_bits]); refusing to "
+                     "invent an operand.");
+        return;
+    }
+    if (!node->saved_tensors || node->num_saved < 1 || !node->saved_tensors[0]) {
+        eshkol_fatal("attention backward: node->saved_tensors[0] must carry the "
+                     "softmax attention weights retained by the forward "
+                     "(ad_tensor_attention). Recomputing them here would have to "
+                     "re-derive the causal mask and the softmax shift, and any "
+                     "drift from the forward is a silently-wrong gradient; "
+                     "refusing instead.");
+        return;
+    }
+
+    const int64_t* p = (const int64_t*)&node->params;
+    int64_t num_heads = p[0];
+    int64_t head_dim  = p[1];
+    int64_t causal    = p[2];
+    double scale;
+    std::memcpy(&scale, &p[3], sizeof scale);
+
+    if (node->ndim != 3 || !node->shape) {
+        eshkol_fatal("attention backward: expected a [batch, seq, dim] node "
+                     "(got %zu-D); the bridge forward records exactly that "
+                     "shape.", node->ndim);
+        return;
+    }
+    int64_t batch = node->shape[0];
+    int64_t seq   = node->shape[1];
+    int64_t dim   = node->shape[2];
+
+    if (num_heads <= 0 || head_dim <= 0 || num_heads * head_dim != dim) {
+        eshkol_fatal("attention backward: params [num_heads=%lld, head_dim=%lld] "
+                     "do not partition dim=%lld; the forward must record the "
+                     "head split it actually used.",
+                     (long long)num_heads, (long long)head_dim, (long long)dim);
+        return;
+    }
+    if (batch <= 0 || seq <= 0) {
+        eshkol_fatal("attention backward: degenerate shape (batch=%lld, seq=%lld).",
+                     (long long)batch, (long long)seq);
+        return;
+    }
+    /* scale is bit-cast out of the params; a zero/non-finite slot means the
+     * producer never wrote it, and silently substituting 1/sqrt(head_dim) would
+     * hide a forward that used something else. */
+    if (!(scale > 0.0) || scale != scale || scale > 1e300) {
+        eshkol_fatal("attention backward: params[3] holds %.17g, not a usable "
+                     "softmax scale; the forward must bit-cast its scale into "
+                     "that slot.", scale);
+        return;
+    }
+    const double* dO = (const double*)node->tensor_gradient;
+    const double* A  = (const double*)node->saved_tensors[0];
+    const double* Q  = (const double*)q_node->tensor_value;
+    const double* K  = (const double*)k_node->tensor_value;
+    const double* V  = (const double*)v_node->tensor_value;
+    if (!Q || !K || !V) {
+        eshkol_fatal("attention backward: Q/K/V nodes must still carry their "
+                     "forward values; refusing to differentiate against a "
+                     "released operand.");
+        return;
+    }
+
+    /* Q, K and V are indexed with the OUTPUT's strides, the same way the
+     * forward indexed them, so an operand of a different shape would be read
+     * and written out of bounds. The forward already refuses that; check it
+     * here too, because this rule also has to hold for nodes it did not
+     * build. */
+    size_t total = (size_t)(batch * seq * dim);
+    const ad_node_t* operands[3] = { q_node, k_node, v_node };
+    const char* operand_names[3] = { "Q", "K", "V" };
+    for (int idx = 0; idx < 3; idx++) {
+        size_t have = (operands[idx]->shape && operands[idx]->ndim > 0)
+                    ? tensor_size(operands[idx]->shape, operands[idx]->ndim) : 0;
+        if (have != total) {
+            eshkol_fatal("attention backward: operand %s holds %zu elements but "
+                         "the output shape [%lld, %lld, %lld] needs %zu; every "
+                         "operand is indexed with the output's strides.",
+                         operand_names[idx], have,
+                         (long long)batch, (long long)seq, (long long)dim, total);
+            return;
+        }
+    }
+
+    if (q_node->tensor_gradient == NULL) q_node->tensor_gradient = alloc_grad(total);
+    if (k_node->tensor_gradient == NULL) k_node->tensor_gradient = alloc_grad(total);
+    if (v_node->tensor_gradient == NULL) v_node->tensor_gradient = alloc_grad(total);
+    double* dQ = (double*)q_node->tensor_gradient;
+    double* dK = (double*)k_node->tensor_gradient;
+    double* dV = (double*)v_node->tensor_gradient;
+    if (!dQ || !dK || !dV) return;
+
+    /* The causal flag and the retained weights are two records of the same
+     * fact, and the adjoint trusts the weights. If they disagree — a forward
+     * that masked differently from what it recorded, or params written by a
+     * different producer — every masked position would silently pick up a
+     * gradient it must not have. Cross-check them instead: under a causal mask
+     * the forward leaves j > i at EXACTLY zero, so this is an equality test,
+     * not a tolerance. */
+    if (causal) {
+        for (int64_t bh = 0; bh < batch * num_heads; bh++) {
+            const double* Ah = &A[(size_t)(bh * seq * seq)];
+            for (int64_t i = 0; i < seq; i++)
+                for (int64_t j = i + 1; j < seq; j++)
+                    if (Ah[i * seq + j] != 0.0) {
+                        eshkol_fatal("attention backward: params say causal but "
+                                     "the retained weight A[%lld][%lld][%lld] is "
+                                     "%.17g, not zero; the mask the forward ran "
+                                     "and the mask it recorded disagree.",
+                                     (long long)bh, (long long)i, (long long)j,
+                                     Ah[i * seq + j]);
+                        return;
+                    }
+        }
+    }
+
+    /* Per-head scratch. Plain std::vector, not the arena: the dispatcher runs
+     * this rule inside a scope it pops on return, and the persistent gradient
+     * buffers above must not share a lifetime with these. (Same reasoning as
+     * FrechetGeometry earlier in this file.) */
+    std::vector<double> dA((size_t)(seq * seq));
+    std::vector<double> dS((size_t)(seq * seq));
+
+    for (int64_t b = 0; b < batch; b++) {
+        for (int64_t h = 0; h < num_heads; h++) {
+            const int64_t off = h * head_dim;
+            const double* Ah = &A[(size_t)(((b * num_heads) + h) * seq * seq)];
+
+            /* dV[j][d] = sum_i A[i][j] * dO[i][d] — j-major, matching the
+             * non-bridge kernel's loop nest. */
+            for (int64_t j = 0; j < seq; j++) {
+                double* dVj = &dV[(size_t)((b * seq + j) * dim + off)];
+                for (int64_t d = 0; d < head_dim; d++) {
+                    double acc = 0.0;
+                    for (int64_t i = 0; i < seq; i++)
+                        acc += Ah[i * seq + j] * dO[(b * seq + i) * dim + off + d];
+                    dVj[d] += acc;
+                }
+            }
+
+            /* dA[i][j] = <dO[i], V[j]> */
+            for (int64_t i = 0; i < seq; i++) {
+                const double* dOi = &dO[(size_t)((b * seq + i) * dim + off)];
+                for (int64_t j = 0; j < seq; j++) {
+                    const double* Vj = &V[(size_t)((b * seq + j) * dim + off)];
+                    double acc = 0.0;
+                    for (int64_t d = 0; d < head_dim; d++) acc += dOi[d] * Vj[d];
+                    dA[(size_t)(i * seq + j)] = acc;
+                }
+            }
+
+            /* Softmax Jacobian, one row dot product per row. */
+            for (int64_t i = 0; i < seq; i++) {
+                double dot = 0.0;
+                for (int64_t j = 0; j < seq; j++)
+                    dot += Ah[i * seq + j] * dA[(size_t)(i * seq + j)];
+                for (int64_t j = 0; j < seq; j++)
+                    dS[(size_t)(i * seq + j)] =
+                        Ah[i * seq + j] * (dA[(size_t)(i * seq + j)] - dot) * scale;
+            }
+
+            /* dQ[i][d] = sum_j dS[i][j] * K[j][d] */
+            for (int64_t i = 0; i < seq; i++) {
+                double* dQi = &dQ[(size_t)((b * seq + i) * dim + off)];
+                for (int64_t d = 0; d < head_dim; d++) {
+                    double acc = 0.0;
+                    for (int64_t j = 0; j < seq; j++)
+                        acc += dS[(size_t)(i * seq + j)] * K[(b * seq + j) * dim + off + d];
+                    dQi[d] += acc;
+                }
+            }
+
+            /* dK[j][d] = sum_i dS[i][j] * Q[i][d] */
+            for (int64_t j = 0; j < seq; j++) {
+                double* dKj = &dK[(size_t)((b * seq + j) * dim + off)];
+                for (int64_t d = 0; d < head_dim; d++) {
+                    double acc = 0.0;
+                    for (int64_t i = 0; i < seq; i++)
+                        acc += dS[(size_t)(i * seq + j)] * Q[(b * seq + i) * dim + off + d];
+                    dKj[d] += acc;
+                }
+            }
+        }
+    }
 }
 
 /*******************************************************************************

--- a/tests/backend/tensor_backward_dual_impl_gradcheck_test.cpp
+++ b/tests/backend/tensor_backward_dual_impl_gradcheck_test.cpp
@@ -28,22 +28,22 @@
  *   embedding:  already covered end-to-end (including a bridge-vs-native
  *     comparison) by tensor_embedding_backward_gradcheck_test.cpp; not
  *     duplicated here.
- *   attention:  the NATIVE rule (eshkol_backward_attention) is exact and is
- *     FD-validated here. The BRIDGE rule (tensor_attention_backward) is an
- *     unconditional refusal by design (see the comment at its definition) —
- *     its forward (ad_tensor_attention, lib/bridge/qllm_bridge.cpp) does not
- *     even retain the `causal` flag or the softmax weights the backward would
- *     need, so there is no "wrong value" to arbitrate: it is a genuine
- *     forward-plumbing gap, not a numeric disagreement. This file asserts the
- *     CURRENT contract (native exact + FD-checked, bridge loudly refuses)
- *     instead of silently excluding the op, and files the fix as
- *     NEEDS-DECISION (see the block comment at attention_check() below and
- *     the ledger entry).
+ *   attention:  both sides are now exact and are diffed against each other
+ *     here, causal and non-causal, at two shapes, with FD as the third
+ *     oracle. The bridge side used to be an unconditional eshkol_fatal
+ *     refusal because its forward retained neither the softmax weights nor
+ *     the causal flag; the forward now retains both (see
+ *     ad_tensor_attention in lib/bridge/qllm_bridge.cpp) and the exact
+ *     adjoint is implemented against that contract. The refusal is retained
+ *     for the contract VIOLATION only — a node presented without the
+ *     retained weights — and that is asserted below too, so the fix cannot
+ *     regress into a silent zero.
  *
  * Copyright (C) tsotchke
  * SPDX-License-Identifier: MIT
  */
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
@@ -407,66 +407,130 @@ void sum_check() {
 }
 
 /*******************************************************************************
- * ATTENTION — single-head scaled dot-product attention.
+ * ATTENTION — multi-head scaled dot-product attention, causal and non-causal.
  *
- * NATIVE (eshkol_backward_attention) is exact; FD-validated below.
+ * Both implementations are exact, and this is the op the two were furthest
+ * apart on: until the SW-12 fix the bridge rule was an unconditional
+ * eshkol_fatal because ad_tensor_attention retained neither the softmax
+ * weights nor the causal flag. The forward now retains the dense
+ * [batch, num_heads, seq, seq] weight matrix (masked entries exactly zero) in
+ * node->saved_tensors[0] and records [num_heads, head_dim, causal, scale_bits]
+ * in params, and tensor_attention_backward computes the exact adjoint from
+ * them.
  *
- * BRIDGE (tensor_attention_backward) unconditionally calls eshkol_fatal() —
- * see the comment at its definition in lib/bridge/tensor_backward.cpp. This
- * is not a numeric disagreement to arbitrate: ad_tensor_attention's forward
- * (lib/bridge/qllm_bridge.cpp) never retains the `causal` flag or the
- * softmax attention weights on the node, so an exact adjoint cannot be
- * computed from what the node carries even in principle — the gap is
- * upstream, in the forward's contract, not a bug in a formula. Implementing
- * it exactly needs a forward-side change (thread `causal` through
- * AD_NODE_TENSOR_ATTENTION's params, and either retain the attention-weight
- * matrix or recompute it in the backward), which is a real feature addition
- * beyond a differential-test fix.
+ * THREE oracles, per shape and per masking mode:
+ *   bridge   ad_tensor_attention -> eshkol_tensor_backward_dispatch, i.e. the
+ *            real producer and the real dispatch path, not a hand-built node.
+ *   native   eshkol_backward_attention, applied per (batch, head) column slice
+ *            of the [batch, seq, dim] operands, fed the attention weights from
+ *            the reference forward below. Feeding it causal weights (zeros
+ *            above the diagonal) is exactly how the causal adjoint falls out of
+ *            an unmasked kernel: every term carries a factor attn[i][j].
+ *   FD       central differences of the reference forward, which is written
+ *            independently of both.
  *
- * NEEDS-DECISION (recorded for the ledger): should the bridge attention
- * backward be implemented now (real work: extend the node contract +
- * mirror the native 5-step chain rule already proven exact below), or is the
- * existing hard refusal (loud, not silent) an acceptable placeholder because
- * `scaled-dot-attention` already provides an exact, differentiable,
- * scalar-decomposed attention path elsewhere in the tree? This file asserts
- * the CURRENT contract (native exact, bridge refuses) so a future change to
- * either side is caught, and the ledger records the finding without
- * guessing which of "implement it" or "leave it refusing" the maintainer
- * prefers.
+ * The bridge-vs-native bar is the same 1e-9 the other five ops are held to.
+ * The two do not share code — the native kernel is BLAS-backed where the
+ * bridge rule is plain loops — so they are not expected to be bit-identical,
+ * only to agree far inside that bar.
  ******************************************************************************/
 
+/** @brief Reference forward for multi-head attention over [batch, seq, dim],
+ *  written independently of both implementations. Fills @p attn with the dense
+ *  [batch, heads, seq, seq] weight matrix (masked entries left at zero) and
+ *  @p out with the [batch, seq, dim] output. */
 void attention_forward_ref(const double* Q, const double* K, const double* V,
                            double* attn, double* out,
-                           int64_t seq_q, int64_t seq_k, int64_t d_k, int64_t d_v,
-                           double scale) {
-    for (int64_t i = 0; i < seq_q; i++) {
-        double mx = -1e300;
-        std::vector<double> row(seq_k);
-        for (int64_t j = 0; j < seq_k; j++) {
-            double dot = 0.0;
-            for (int64_t d = 0; d < d_k; d++) dot += Q[i * d_k + d] * K[j * d_k + d];
-            row[j] = dot * scale;
-            if (row[j] > mx) mx = row[j];
-        }
-        double sum = 0.0;
-        for (int64_t j = 0; j < seq_k; j++) { row[j] = std::exp(row[j] - mx); sum += row[j]; }
-        for (int64_t j = 0; j < seq_k; j++) attn[i * seq_k + j] = row[j] / sum;
-        for (int64_t d = 0; d < d_v; d++) {
-            double acc = 0.0;
-            for (int64_t j = 0; j < seq_k; j++) acc += attn[i * seq_k + j] * V[j * d_v + d];
-            out[i * d_v + d] = acc;
+                           int64_t batch, int64_t heads, int64_t seq, int64_t head_dim,
+                           bool causal) {
+    const int64_t dim = heads * head_dim;
+    const double scale = 1.0 / std::sqrt((double)head_dim);
+    std::vector<double> row((size_t)seq);
+
+    for (int64_t b = 0; b < batch; b++) {
+        for (int64_t hh = 0; hh < heads; hh++) {
+            const int64_t off = hh * head_dim;
+            double* Ah = &attn[(size_t)(((b * heads) + hh) * seq * seq)];
+            for (int64_t i = 0; i < seq; i++) {
+                const int64_t limit = causal ? (i + 1) : seq;
+                double mx = -1e300;
+                for (int64_t j = 0; j < limit; j++) {
+                    double dot = 0.0;
+                    for (int64_t d = 0; d < head_dim; d++)
+                        dot += Q[(b * seq + i) * dim + off + d] * K[(b * seq + j) * dim + off + d];
+                    row[(size_t)j] = dot * scale;
+                    if (row[(size_t)j] > mx) mx = row[(size_t)j];
+                }
+                double sum = 0.0;
+                for (int64_t j = 0; j < limit; j++) {
+                    row[(size_t)j] = std::exp(row[(size_t)j] - mx);
+                    sum += row[(size_t)j];
+                }
+                for (int64_t j = 0; j < limit; j++) Ah[i * seq + j] = row[(size_t)j] / sum;
+                for (int64_t j = limit; j < seq; j++) Ah[i * seq + j] = 0.0;
+                for (int64_t d = 0; d < head_dim; d++) {
+                    double acc = 0.0;
+                    for (int64_t j = 0; j < seq; j++)
+                        acc += Ah[i * seq + j] * V[(b * seq + j) * dim + off + d];
+                    out[(b * seq + i) * dim + off + d] = acc;
+                }
+            }
         }
     }
 }
 
+/** @brief Scalar probe L = <cotan, attention(Q,K,V)> for the FD oracle. */
 double attention_probe(const double* Q, const double* K, const double* V,
                        const double* cotan,
-                       int64_t seq_q, int64_t seq_k, int64_t d_k, int64_t d_v, double scale) {
-    std::vector<double> attn((size_t)(seq_q * seq_k)), out((size_t)(seq_q * d_v));
-    attention_forward_ref(Q, K, V, attn.data(), out.data(), seq_q, seq_k, d_k, d_v, scale);
+                       int64_t batch, int64_t heads, int64_t seq, int64_t head_dim,
+                       bool causal) {
+    const int64_t dim = heads * head_dim;
+    std::vector<double> attn((size_t)(batch * heads * seq * seq));
+    std::vector<double> out((size_t)(batch * seq * dim));
+    attention_forward_ref(Q, K, V, attn.data(), out.data(), batch, heads, seq, head_dim, causal);
     double L = 0.0;
-    for (int64_t i = 0; i < seq_q * d_v; i++) L += cotan[i] * out[i];
+    for (int64_t i = 0; i < batch * seq * dim; i++) L += cotan[i] * out[i];
     return L;
+}
+
+/** @brief Run the NATIVE kernel (eshkol_backward_attention) over the same
+ *  [batch, seq, dim] layout the bridge uses, one (batch, head) slice at a
+ *  time: gather the slice into the contiguous [seq, head_dim] buffers the
+ *  kernel expects, run it, scatter the per-head gradients back. */
+void attention_native_batched(const double* Q, const double* K, const double* V,
+                              const double* attn, const double* cotan,
+                              double* dQ, double* dK, double* dV,
+                              int64_t batch, int64_t heads, int64_t seq, int64_t head_dim) {
+    const int64_t dim = heads * head_dim;
+    const double scale = 1.0 / std::sqrt((double)head_dim);
+    const size_t slice = (size_t)(seq * head_dim);
+    std::vector<double> qs(slice), ks(slice), vs(slice), gs(slice);
+    std::vector<double> dq(slice), dk(slice), dv(slice);
+
+    for (int64_t b = 0; b < batch; b++) {
+        for (int64_t hh = 0; hh < heads; hh++) {
+            const int64_t off = hh * head_dim;
+            for (int64_t i = 0; i < seq; i++)
+                for (int64_t d = 0; d < head_dim; d++) {
+                    size_t src = (size_t)((b * seq + i) * dim + off + d);
+                    size_t dst = (size_t)(i * head_dim + d);
+                    qs[dst] = Q[src]; ks[dst] = K[src]; vs[dst] = V[src]; gs[dst] = cotan[src];
+                }
+            std::fill(dq.begin(), dq.end(), 0.0);
+            std::fill(dk.begin(), dk.end(), 0.0);
+            std::fill(dv.begin(), dv.end(), 0.0);
+            eshkol_backward_attention(gs.data(), qs.data(), ks.data(), vs.data(),
+                                      &attn[(size_t)(((b * heads) + hh) * seq * seq)],
+                                      dq.data(), dk.data(), dv.data(),
+                                      seq, seq, head_dim, head_dim, scale);
+            for (int64_t i = 0; i < seq; i++)
+                for (int64_t d = 0; d < head_dim; d++) {
+                    size_t dst = (size_t)((b * seq + i) * dim + off + d);
+                    size_t src = (size_t)(i * head_dim + d);
+                    dQ[dst] += dq[src]; dK[dst] += dk[src]; dV[dst] += dv[src];
+                }
+        }
+    }
 }
 
 #if defined(ESHKOL_HAVE_FORK_DEATH_TESTS)
@@ -490,84 +554,147 @@ bool refuses(void (*body)()) {
     return WIFEXITED(status) && WEXITSTATUS(status) != 0;
 }
 
-constexpr int64_t kAttnSeqQ = 2, kAttnSeqK = 3, kAttnDK = 4, kAttnDV = 3;
-double g_attn_Q[kAttnSeqQ * kAttnDK];
-double g_attn_K[kAttnSeqK * kAttnDK];
-double g_attn_V[kAttnSeqK * kAttnDV];
-double g_attn_cotan[kAttnSeqQ * kAttnDV];
+constexpr int64_t kBadSeq = 3, kBadHeadDim = 4;
+double g_attn_Q[kBadSeq * kBadHeadDim];
+double g_attn_K[kBadSeq * kBadHeadDim];
+double g_attn_V[kBadSeq * kBadHeadDim];
+double g_attn_cotan[kBadSeq * kBadHeadDim];
 
-void body_bridge_attention_backward() {
-    int64_t shQ[2] = {kAttnSeqQ, kAttnDK}, shK[2] = {kAttnSeqK, kAttnDK}, shV[2] = {kAttnSeqK, kAttnDV};
-    ad_node_t qn{}; qn.type = AD_NODE_VARIABLE; qn.tensor_value = g_attn_Q; qn.shape = shQ; qn.ndim = 2;
-    ad_node_t kn{}; kn.type = AD_NODE_VARIABLE; kn.tensor_value = g_attn_K; kn.shape = shK; kn.ndim = 2;
-    ad_node_t vn{}; vn.type = AD_NODE_VARIABLE; vn.tensor_value = g_attn_V; vn.shape = shV; vn.ndim = 2;
+/** @brief A node built the way a producer that did NOT retain the attention
+ *  weights would build it. The exact adjoint is unobtainable from that, so the
+ *  rule must still refuse rather than reconstruct one — this is the half of
+ *  the old unconditional refusal that stays. */
+void body_bridge_attention_unretained() {
+    int64_t sh[3] = {1, kBadSeq, kBadHeadDim};
+    ad_node_t qn{}; qn.type = AD_NODE_VARIABLE; qn.tensor_value = g_attn_Q; qn.shape = sh; qn.ndim = 3;
+    ad_node_t kn{}; kn.type = AD_NODE_VARIABLE; kn.tensor_value = g_attn_K; kn.shape = sh; kn.ndim = 3;
+    ad_node_t vn{}; vn.type = AD_NODE_VARIABLE; vn.tensor_value = g_attn_V; vn.shape = sh; vn.ndim = 3;
     ad_node_t node{};
     node.type = AD_NODE_TENSOR_ATTENTION;
     node.input1 = &qn; node.input2 = &kn; node.input3 = &vn;
-    int64_t shO[2] = {kAttnSeqQ, kAttnDV};
-    node.shape = shO; node.ndim = 2;
+    node.shape = sh; node.ndim = 3;
     node.tensor_gradient = g_attn_cotan;
     node.params.attention_params.num_heads = 1;
-    node.params.attention_params.head_dim = kAttnDK;
+    node.params.attention_params.head_dim = kBadHeadDim;
+    node.saved_tensors = nullptr;   /* the whole point */
+    node.num_saved = 0;
     eshkol_tensor_backward_dispatch(&node);
 }
 #endif  /* ESHKOL_HAVE_FORK_DEATH_TESTS */
 
-void attention_check() {
-    constexpr int64_t seq_q = 2, seq_k = 3, d_k = 4, d_v = 3;
-    double Q[seq_q * d_k], K[seq_k * d_k], V[seq_k * d_v], cotan[seq_q * d_v];
-    for (auto& v : Q) v = urand();
-    for (auto& v : K) v = urand();
-    for (auto& v : V) v = urand();
-    for (auto& v : cotan) v = urand();
-    double scale = 1.0 / std::sqrt((double)d_k);
+/** @brief One shape x masking-mode cell: bridge vs native vs FD. */
+void attention_case(int64_t batch, int64_t heads, int64_t seq, int64_t head_dim,
+                    bool causal, const char* label) {
+    const int64_t dim = heads * head_dim;
+    const size_t n = (size_t)(batch * seq * dim);
 
-    /* -- native: exact, needs the forward's saved attention weights -- */
-    std::vector<double> attn((size_t)(seq_q * seq_k)), out((size_t)(seq_q * d_v));
-    attention_forward_ref(Q, K, V, attn.data(), out.data(), seq_q, seq_k, d_k, d_v, scale);
+    std::vector<double> Q(n), K(n), V(n), cotan(n);
+    for (auto& x : Q) x = urand();
+    for (auto& x : K) x = urand();
+    for (auto& x : V) x = urand();
+    for (auto& x : cotan) x = urand();
 
-    double dQ_native[seq_q * d_k] = {0}, dK_native[seq_k * d_k] = {0}, dV_native[seq_k * d_v] = {0};
-    eshkol_backward_attention(cotan, Q, K, V, attn.data(), dQ_native, dK_native, dV_native,
-                              seq_q, seq_k, d_k, d_v, scale);
+    /* -- reference forward: attention weights for the native kernel -- */
+    std::vector<double> attn((size_t)(batch * heads * seq * seq)), out(n);
+    attention_forward_ref(Q.data(), K.data(), V.data(), attn.data(), out.data(),
+                          batch, heads, seq, head_dim, causal);
 
+    /* -- native -- */
+    std::vector<double> dQ_native(n, 0.0), dK_native(n, 0.0), dV_native(n, 0.0);
+    attention_native_batched(Q.data(), K.data(), V.data(), attn.data(), cotan.data(),
+                             dQ_native.data(), dK_native.data(), dV_native.data(),
+                             batch, heads, seq, head_dim);
+
+    /* -- bridge: real forward producer, real backward dispatch -- */
+    ad_tape_t* tape = arena_allocate_tape(get_global_arena(), 8);
+    int64_t sh[3] = {batch, seq, dim};
+    ad_node_t* qn = var_node(Q.data(), sh, 3);
+    ad_node_t* kn = var_node(K.data(), sh, 3);
+    ad_node_t* vn = var_node(V.data(), sh, 3);
+    ad_node_t* node = ad_tensor_attention(tape, qn, kn, vn, (int)heads, causal);
+
+    char name[128], detail[192];
+    if (!node) {
+        std::snprintf(name, sizeof name, "attention[%s]: native vs bridge", label);
+        report(name, false, "bridge forward refused");
+        return;
+    }
+
+    /* The forward must also agree with the reference forward — a bridge
+     * adjoint that matches an incorrect forward would prove nothing. */
+    double fwd_diff = max_abs_diff(out.data(), (const double*)node->tensor_value, n);
+
+    double* cotan_buf = zeros(n);
+    std::memcpy(cotan_buf, cotan.data(), n * sizeof(double));
+    node->tensor_gradient = cotan_buf;
+    eshkol_tensor_backward_dispatch(node);
+
+    const double* dQ_bridge = (const double*)qn->tensor_gradient;
+    const double* dK_bridge = (const double*)kn->tensor_gradient;
+    const double* dV_bridge = (const double*)vn->tensor_gradient;
+
+    double d_dQ = dQ_bridge ? max_abs_diff(dQ_native.data(), dQ_bridge, n) : -1.0;
+    double d_dK = dK_bridge ? max_abs_diff(dK_native.data(), dK_bridge, n) : -1.0;
+    double d_dV = dV_bridge ? max_abs_diff(dV_native.data(), dV_bridge, n) : -1.0;
+
+    std::snprintf(name, sizeof name, "attention[%s]: native vs bridge", label);
+    std::snprintf(detail, sizeof detail,
+                  "max|dQ diff|=%.3e max|dK diff|=%.3e max|dV diff|=%.3e fwd=%.3e",
+                  d_dQ, d_dK, d_dV, fwd_diff);
+    report(name, dQ_bridge && dK_bridge && dV_bridge &&
+                 d_dQ < 1e-9 && d_dK < 1e-9 && d_dV < 1e-9 && fwd_diff < 1e-12, detail);
+
+    /* -- finite differences, the third oracle -- */
     const double h = 1e-6;
-    std::vector<double> fdQ((size_t)(seq_q * d_k)), fdK((size_t)(seq_k * d_k)), fdV((size_t)(seq_k * d_v));
-    for (int64_t i = 0; i < seq_q * d_k; i++) {
-        double save = Q[i];
-        Q[i] = save + h; double Lp = attention_probe(Q, K, V, cotan, seq_q, seq_k, d_k, d_v, scale);
-        Q[i] = save - h; double Lm = attention_probe(Q, K, V, cotan, seq_q, seq_k, d_k, d_v, scale);
-        Q[i] = save;
-        fdQ[i] = (Lp - Lm) / (2.0 * h);
+    std::vector<double> fdQ(n), fdK(n), fdV(n);
+    double* tensors[3] = { Q.data(), K.data(), V.data() };
+    std::vector<double>* fds[3] = { &fdQ, &fdK, &fdV };
+    for (int t = 0; t < 3; t++) {
+        for (size_t i = 0; i < n; i++) {
+            double save = tensors[t][i];
+            tensors[t][i] = save + h;
+            double Lp = attention_probe(Q.data(), K.data(), V.data(), cotan.data(),
+                                        batch, heads, seq, head_dim, causal);
+            tensors[t][i] = save - h;
+            double Lm = attention_probe(Q.data(), K.data(), V.data(), cotan.data(),
+                                        batch, heads, seq, head_dim, causal);
+            tensors[t][i] = save;
+            (*fds[t])[i] = (Lp - Lm) / (2.0 * h);
+        }
     }
-    for (int64_t i = 0; i < seq_k * d_k; i++) {
-        double save = K[i];
-        K[i] = save + h; double Lp = attention_probe(Q, K, V, cotan, seq_q, seq_k, d_k, d_v, scale);
-        K[i] = save - h; double Lm = attention_probe(Q, K, V, cotan, seq_q, seq_k, d_k, d_v, scale);
-        K[i] = save;
-        fdK[i] = (Lp - Lm) / (2.0 * h);
-    }
-    for (int64_t i = 0; i < seq_k * d_v; i++) {
-        double save = V[i];
-        V[i] = save + h; double Lp = attention_probe(Q, K, V, cotan, seq_q, seq_k, d_k, d_v, scale);
-        V[i] = save - h; double Lm = attention_probe(Q, K, V, cotan, seq_q, seq_k, d_k, d_v, scale);
-        V[i] = save;
-        fdV[i] = (Lp - Lm) / (2.0 * h);
-    }
-    double fd_dQ = max_abs_diff(dQ_native, fdQ.data(), seq_q * d_k);
-    double fd_dK = max_abs_diff(dK_native, fdK.data(), seq_k * d_k);
-    double fd_dV = max_abs_diff(dV_native, fdV.data(), seq_k * d_v);
-    char detail[160];
+    double fd_dQ = dQ_bridge ? max_abs_diff(dQ_bridge, fdQ.data(), n) : 1.0;
+    double fd_dK = dK_bridge ? max_abs_diff(dK_bridge, fdK.data(), n) : 1.0;
+    double fd_dV = dV_bridge ? max_abs_diff(dV_bridge, fdV.data(), n) : 1.0;
+    std::snprintf(name, sizeof name, "attention[%s]: bridge vs finite differences", label);
     std::snprintf(detail, sizeof detail, "max|dQ-fd|=%.3e max|dK-fd|=%.3e max|dV-fd|=%.3e",
-                 fd_dQ, fd_dK, fd_dV);
-    report("attention: native vs finite differences", fd_dQ < 1e-6 && fd_dK < 1e-6 && fd_dV < 1e-6, detail);
+                  fd_dQ, fd_dK, fd_dV);
+    report(name, fd_dQ < 1e-6 && fd_dK < 1e-6 && fd_dV < 1e-6, detail);
+
+    double nfd_dQ = max_abs_diff(dQ_native.data(), fdQ.data(), n);
+    double nfd_dK = max_abs_diff(dK_native.data(), fdK.data(), n);
+    double nfd_dV = max_abs_diff(dV_native.data(), fdV.data(), n);
+    std::snprintf(name, sizeof name, "attention[%s]: native vs finite differences", label);
+    std::snprintf(detail, sizeof detail, "max|dQ-fd|=%.3e max|dK-fd|=%.3e max|dV-fd|=%.3e",
+                  nfd_dQ, nfd_dK, nfd_dV);
+    report(name, nfd_dQ < 1e-6 && nfd_dK < 1e-6 && nfd_dV < 1e-6, detail);
+}
+
+void attention_check() {
+    /* small: one batch, one head — the plain 2-D case both kernels reduce to.
+     * moderate: several batches and heads, seq > head_dim, so a head-slicing
+     * or stride error cannot cancel out. Both run masked and unmasked. */
+    attention_case(1, 1, 3, 4, false, "small,noncausal");
+    attention_case(1, 1, 3, 4, true,  "small,causal");
+    attention_case(2, 3, 5, 4, false, "moderate,noncausal");
+    attention_case(2, 3, 5, 4, true,  "moderate,causal");
 
 #if defined(ESHKOL_HAVE_FORK_DEATH_TESTS)
-    std::memcpy(g_attn_Q, Q, sizeof(g_attn_Q));
-    std::memcpy(g_attn_K, K, sizeof(g_attn_K));
-    std::memcpy(g_attn_V, V, sizeof(g_attn_V));
-    std::memcpy(g_attn_cotan, cotan, sizeof(g_attn_cotan));
-    report("attention: bridge backward refuses (NEEDS-DECISION, see block comment)",
-          refuses(&body_bridge_attention_backward));
+    for (auto& x : g_attn_Q) x = urand();
+    for (auto& x : g_attn_K) x = urand();
+    for (auto& x : g_attn_V) x = urand();
+    for (auto& x : g_attn_cotan) x = urand();
+    report("attention: bridge refuses a node with no retained weights",
+          refuses(&body_bridge_attention_unretained));
 #else
     std::printf("  (bridge attention refusal check skipped: no fork on this platform)\n");
 #endif

--- a/tests/bridge/qllm_bridge_gradcheck_test.cpp
+++ b/tests/bridge/qllm_bridge_gradcheck_test.cpp
@@ -23,23 +23,22 @@
  *
  * Coverage: every bridge op whose forward/backward pair fits this file's
  * single-scalar-loss pipeline shape — matmul, gelu, softmax, layernorm,
- * rmsnorm, silu and cross-entropy. Embedding and attention are covered
- * elsewhere instead of being silently skipped here (SW-12):
+ * rmsnorm, silu, cross-entropy, and attention (causal and non-causal). No op
+ * is excluded from the suite; the one that does not fit the pipeline shape is
+ * gradchecked elsewhere and named here (SW-12):
  *   - embedding's backward (tensor_embedding_backward, an indexed
- *     scatter-add) IS implemented and exact; it takes an index tensor rather
- *     than this file's x/w pipeline shape, so it is gradchecked in
+ *     scatter-add) takes an index tensor rather than this file's x/w pipeline
+ *     shape, so it is gradchecked in
  *     tests/backend/tensor_embedding_backward_gradcheck_test.cpp, which also
  *     diffs it directly against the non-bridge implementation
  *     (eshkol_backward_embedding) on identical inputs.
- *   - attention's backward (tensor_attention_backward) still unconditionally
- *     refuses (eshkol_fatal) — its forward, ad_tensor_attention, does not
- *     retain the causal flag or the softmax weights an exact adjoint would
- *     need, a real forward-plumbing gap rather than a wrong formula. This is
- *     asserted (not silently skipped) in
- *     tests/backend/tensor_backward_dual_impl_gradcheck_test.cpp, alongside
- *     an FD-validated check that the non-bridge implementation
- *     (eshkol_backward_attention) is exact. See that file's block comment for
- *     the NEEDS-DECISION on whether to implement the bridge side.
+ *
+ * Attention runs through the same pipeline as everything else here: a
+ * [1, ROWS, COLS] attention followed by cross-entropy, once unmasked and once
+ * causally masked. Its forward retains the softmax weights and the causal flag
+ * the exact adjoint needs, so both masking modes are gradcheckable; the direct
+ * bridge-vs-native differential for the op lives in
+ * tests/backend/tensor_backward_dual_impl_gradcheck_test.cpp.
  *
  * Also covered: the float32 interop round-trip and the bridge lifecycle, which
  * are the other four symbols the header declared and nothing defined.
@@ -148,7 +147,8 @@ static void init_fixtures(void) {
 
 /* Which pipeline a check runs. Each ends in cross-entropy so the loss is a
  * scalar and the finite-difference reference is well defined. */
-enum Pipeline { P_MATMUL_GELU, P_LAYERNORM, P_RMSNORM, P_SILU, P_SOFTMAX };
+enum Pipeline { P_MATMUL_GELU, P_LAYERNORM, P_RMSNORM, P_SILU, P_SOFTMAX,
+                P_ATTENTION, P_ATTENTION_CAUSAL };
 
 /**
  * @brief Run one pipeline. With @p tape non-null the ops are recorded;
@@ -177,6 +177,18 @@ static double run_pipeline(Pipeline p, ad_tape_t* tape,
         ad_node_t* mm = ad_tensor_matmul(tape, xn, wn);
         if (!mm) return NAN;
         h = ad_tensor_gelu(tape, mm);
+    } else if (p == P_ATTENTION || p == P_ATTENTION_CAUSAL) {
+        /* Attention wants [batch, seq, dim]; the same ROWS*COLS input viewed as
+         * one batch of ROWS tokens. Q, K and V are the SAME node on purpose:
+         * the finite-difference sweep then validates dQ + dK + dV together, so
+         * a rule that dropped any one of the three paths (which is exactly
+         * what the old value-passthrough stub did) shows up immediately. The
+         * three are separated again, against the non-bridge kernel, in
+         * tests/backend/tensor_backward_dual_impl_gradcheck_test.cpp. */
+        const int64_t sh_attn[3] = { 1, ROWS, COLS };
+        xn = var_node(x, sh_attn, 3);
+        h = ad_tensor_attention(tape, xn, xn, xn, /*num_heads=*/1,
+                                /*causal=*/p == P_ATTENTION_CAUSAL);
     } else {
         /* The remaining ops are elementwise / row-wise: drive them directly
          * with a [ROWS, COLS] input so no matmul is in the path. */
@@ -330,6 +342,8 @@ int main(void) {
         { P_RMSNORM,     "rmsnorm+xent"     },
         { P_SILU,        "silu+xent"        },
         { P_SOFTMAX,     "softmax+xent"     },
+        { P_ATTENTION,        "attention+xent"        },
+        { P_ATTENTION_CAUSAL, "causal attention+xent" },
     };
     for (auto& c : cases) {
         if (check(c.p, c.name) < TOLERANCE) ++passed; else ++failed;


### PR DESCRIPTION
Stacked on #433 (`fix/vector-ref-tensor-and-backward-diff`), which built the dual-backward differential harness. Retarget to `master` if #433 lands first.

#433 measured six tensor ops that carry two independent backward implementations. Five agreed to machine precision. Attention did not disagree — it had nothing to compare: `tensor_attention_backward` unconditionally called `eshkol_fatal` because `ad_tensor_attention`'s forward retained neither the softmax attention weights nor the `causal` flag an exact adjoint needs. That was a forward-plumbing gap, and it was filed as NEEDS-DECISION. Ruling: fix it, no refusal path ships. This PR is that fix.

## What the forward now retains

`ad_tensor_attention` (`lib/bridge/qllm_bridge.cpp`) records what the adjoint needs, using the mechanism the node struct already provides for exactly this and that the non-bridge `AD_NODE_ATTENTION` arm already uses for its own attention weights:

| slot | contents |
|---|---|
| `node->saved_tensors[0]` | dense `[batch, num_heads, seq, seq]` softmax weight matrix, masked entries left at **exactly** zero |
| `node->num_saved` | 1 |
| `node->params` as `int64[6]` | `[num_heads, head_dim, causal, scale_bits, 0, 0]` |

`scale_bits` is the scale bit-cast from `double` — the convention the `AD_NODE_ATTENTION` params and the Fréchet rule already use. Slots `[0]`/`[1]` deliberately coincide with the named `attention_params` fields, so both spellings read the same storage.

Forward **values are unchanged**: the retained row is the same softmax row the forward already computed, hoisted out of the inner product loop. The forward additionally now refuses mismatched or degenerate Q/K/V shapes, which it previously read out of bounds (K and V are indexed with Q's strides).

## The adjoint

Applied per `(batch, head)` column slice of the `[batch, seq, dim]` operands — the heads never mix in the forward, so their adjoints never mix either:

```
dV[j]    = sum_i A[i][j] dO[i]
dA[i][j] = <dO[i], V[j]>
dS[i][j] = A[i][j] (dA[i][j] - sum_k A[i][k] dA[i][k]) * scale
dQ[i]    = sum_j dS[i][j] K[j]        dK[j] = sum_i dS[i][j] Q[i]
```

The `dS` line is the softmax Jacobian `diag(y) - y yᵀ` applied row-wise, with one row dot product per row — that is what makes the rule O(seq²) rather than O(seq³).

**Causal masking is carried by the retained zeros, not by a mask test.** Every term above has a factor `A[i][j]`, so masked positions contribute exactly zero while the summations still run over the full `[0, seq)` range. That keeps the accumulation **order** identical between the causal and non-causal cases and identical to the native kernel's loop nest, which is what the no-fast-math / deterministic-gradient rule requires. Skipping masked `j` instead would change nothing numerically (`x + 0.0 == x` for finite `x`) but would make the two implementations' summation orders diverge for no gain.

The rule is written **independently** of `eshkol_backward_attention` rather than delegating to it. Delegating would have been less code, but it would make the SW-12 differential compare a thing to itself.

`eshkol_fatal` is retained for contract **violations** only — no retained weights, a missing or wrongly-shaped operand, params that do not partition `dim`, an unusable scale, or a recorded `causal` flag that disagrees with the retained weights (an exact-equality cross-check, since masked entries are exactly zero). A fork death test asserts a node built without retained weights still refuses, so the fix cannot regress into a silent zero.

## Agreement

Native vs bridge, identical inputs, max abs diff across dQ/dK/dV:

| case | dQ | dK | dV |
|---|---|---|---|
| small `[b 1, h 1, seq 3, hd 4]` non-causal | 1.4e-17 | 1.4e-17 | 5.6e-17 |
| small causal | 2.8e-17 | 1.4e-17 | 0.0 |
| moderate `[b 2, h 3, seq 5, hd 4]` non-causal | 5.6e-17 | 5.6e-17 | 1.1e-16 |
| moderate causal | 4.2e-17 | 3.8e-17 | 2.2e-16 |

At the machine-epsilon floor, far inside the 1e-9 bar the other five ops are held to. The residual is BLAS-vs-scalar summation order — the native kernel is `cblas_dgemm`-backed, the bridge rule is plain loops.

Central finite differences of an independently written third forward arbitrate: bridge-vs-FD and native-vs-FD land at 1.0e-10 .. 1.4e-09 against a 1e-6 bar, and are identical to every printed digit on both sides — which is the same statement as the 1e-17 agreement. The bridge **forward** is also diffed against that reference forward (0.0).

## Tests

- `tests/backend/tensor_backward_dual_impl_gradcheck_test.cpp` — attention now diffed native-vs-bridge at two shapes × causal/non-causal, through the **real producer** `ad_tensor_attention` and the real dispatch path rather than a hand-built node, plus FD on both sides and the refusal death test. **11 → 21 checks.**
- `tests/bridge/qllm_bridge_gradcheck_test.cpp` — attention and causal-attention pipelines added. No op is excluded from that suite any more; embedding stays gradchecked in its own file because it takes an index tensor, not this suite's x/w pipeline shape. **7 → 9 checks**, and the count is pinned in ctest (`"0 failed"` alone would stay green if a check silently stopped running).
- `docs/breakdown/AUTODIFF.md` — the "attention backward is a v1.2 value-passthrough stub … training attention layers under v1.2 will not converge correctly" section replaced with the shipped exact rule on both paths.

## Ledger

`SW-12` → **closed**, `closed_at: 73c1f9e6`, with all six ops (matmul, layernorm, transpose, sum, embedding, attention) recorded as agreeing. `scripts/gate_no_silent_wrong.py` blocking count 13 → 12.

## Gates

| gate | result |
|---|---|
| `ctest` | 165 / 165 |
| `tensor_backward_dual_impl_gradcheck` | 21 / 21 |
| `qllm_bridge_gradcheck` | 9 / 9 |
| `tensor_embedding_backward_gradcheck` | 10 / 10 |
| `scripts/run_differential.sh` | 294 / 294 axis pairs over 49 programs |
| `scripts/run_vm_parity.sh` | 160 / 160 |
| `scripts/gate_no_silent_wrong.py` | SW-12 no longer blocking (12 pre-existing entries remain) |
