### PR TITLE
fix(vm): captured-parameter set! writeback (SW-25); VM heap-growth guard (SW-14 NEEDS-DECISION)

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -629,12 +629,93 @@ entries:
   - id: SW-14
     bucket: SILENT-WRONG
     status: open
+    resolution: NEEDS-DECISION
     title: "with-region on the VM never reclaims — silent unbounded memory growth"
     observed: "A VM program using regions computes the right answer and never gets the memory back; the VM heap has no escape evacuator"
-    evidence: "docs/KNOWN_ISSUES.md:211"
+    evidence: >-
+      docs/KNOWN_ISSUES.md, section "Region handles and `with-region` on the
+      VM"; reproducer tests/memory/vm_region_growth_watchdog_test.esk; guard
+      gated by tests/memory/vm_region_growth_watchdog_test.sh and the
+      icc-smoke probe vm_region_growth_watchdog
     caught_by: [KNOWN_ISSUES]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
     notes: "Classified silent because a long-running VM process degrades with no diagnostic and exit 0."
+    measured:
+      at_sha: "2ae3787f"
+      with: "build/eshkol-vm-standalone-test (RelWithDebInfo, LLVM 21, arm64-apple-darwin24.1.0)"
+      fixture: "20000 iterations x 200 conses per iteration, /usr/bin/time -l peak RSS"
+      with_region_wrapper: "1,503,297,536 bytes"
+      without_region_wrapper: "1,504,067,584 bytes"
+      finding: >-
+        The two are the SAME to within 0.06% — the wrapped run is fractionally
+        SMALLER, i.e. the difference is allocator noise, not reclamation.
+        `with-region` does not reclaim
+        less than native — it reclaims NOTHING, and so does everything else:
+        the bytecode VM has no heap reclamation of any kind. heap_alloc()
+        (lib/backend/vm_core.c) bump-allocates from an arena that is never
+        released and hands out a monotonically increasing object index that is
+        never recycled; vm_region_pop() exists (lib/backend/vm_arena.h) but no
+        bytecode ever calls it, because compile_form_with_region()
+        (lib/backend/vm_compiler.c) lowers the form to `begin`.
+    root_cause: >-
+      lib/backend/vm_compiler.c::compile_form_with_region() emits no region
+      bracket at all: the region specifier is recognised and skipped and the
+      body is lowered exactly like `begin`. That is deliberate and documented
+      in the function's own comment — a real push/pop there would free the
+      object graph the body just returned, because the VM heap has no escape
+      evacuator to promote a kept value out with. The missing evacuator, not
+      the missing bracket, is the defect.
+    why_not_fixed_here: >-
+      NEEDS-DECISION: a correct fix is a VM-heap escape evacuator, which is a
+      campaign of the same size as the native ESH-0214c/ESH-0214d work
+      (multiple dedicated PRs), not a patch. It requires, at minimum:
+      (1) ROOT ENUMERATION over the operand stack plus ~15 Value-carrying side
+          tables inside `struct VM` (outputs, handler_stack.promise_mark,
+          current_exception, wind_stack, parameter_bindings, promise_eval_head,
+          lru_caches, event_emitters, channels, timers, exit_handlers, ...) —
+          a missed root frees live memory;
+      (2) PER-SUBTYPE INTERIOR TRAVERSAL for all 27 HeapTypes plus their
+          arena-allocated payloads (VmVector.items, VmString.data,
+          VmBignum.limbs, VmSubstitution.terms, VmFact.args/datum_ptr,
+          VmFactorGraph's five pointer arrays, VmContinuation's six saved
+          arrays, VmParameter.save_stack, ...) — this is exactly the coverage
+          problem ESH-0214d had to close natively, and it still carries a
+          documented watchlist there;
+      (3) a MUTATION WRITE BARRIER at every VM channel that can store a Value
+          into a longer-lived container (~130 candidate sites across
+          vm_native.c/vm_run.c) or, in its place, a full mark from roots;
+      (4) INDEX-SPACE recycling or compaction, because the object table index
+          is a monotone counter — freeing only the arena still leaks 8 bytes
+          per object and still terminates at ESHKOL_VM_HEAP_MAX_SIZE.
+      The failure mode of a partial implementation is STRICTLY WORSE than the
+      defect: a missed root or an uncovered subtype turns an honest leak into
+      a dangling object index, which on the VM aliases a live object and
+      produces a silently wrong VALUE rather than a crash. Shipping that under
+      a SILENT-WRONG closure would invert the ledger's own contract.
+    interim_guard_landed: >-
+      The SILENT half is closed on this branch even though the reclamation is
+      not. Two guards, neither of which changes any answer:
+      (a) the first region form executed on the VM prints a one-time note to
+          stderr naming the boundary (vm_region_reclaim_notice(),
+          lib/backend/vm_core.c; called from compile_form_with_region() and
+          from native 2210 region-open). ESHKOL_VM_REGION_QUIET=1 silences it.
+      (b) the VM arena is sampled every 4096 allocations and crossing
+          ESHKOL_VM_HEAP_BUDGET_MB (default 1024) prints a diagnostic naming
+          the size, the budget and the cause (heap_check_budget()).
+          ESHKOL_VM_HEAP_BUDGET_FATAL=1 makes it exit nonzero so a lane can
+          gate on it; ESHKOL_VM_HEAP_BUDGET_MB=0 disables it.
+      Gated by tests/memory/vm_region_growth_watchdog_test.sh (8/8) and by the
+      icc-smoke probe vm_region_growth_watchdog, so the guard cannot be
+      removed silently. Documented in docs/KNOWN_ISSUES.md,
+      docs/reference/runtime/memory-model.md and
+      docs/reference/runtime/environment-variables.md.
+    decision_requested: >-
+      Choose one: (A) accept the interim guard for v1.3.4 and schedule the
+      VM-heap evacuator as a v1.3.5 campaign — the growth is now loud, named
+      and gate-pinned, and the docs no longer imply otherwise; or (B) hold the
+      tag for the evacuator campaign. Recommendation: (A). Option (B) lands a
+      moving collector in the VM core days before a release, where the cost of
+      an incomplete root or subtype list is a silently wrong value.
 
   - id: SW-15
     bucket: SILENT-WRONG
@@ -802,6 +883,84 @@ entries:
       PR #428 (tests/vm_parity/corpus/56_lexical_shadow_nearest_binding.esk); the two
       changes touch different functions in vm_compiler.c and are independent.
 
+  - id: SW-25
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "2ae3787f"
+    closed_by: "branch fix/vm-region-and-upvalue"
+    title: "VM set! on a captured parameter inside an immediately-invoked inner closure doesn't propagate back to the outer binding"
+    repro: "(define (f n) ((lambda () (set! n (+ n 1)))) n) (display (f 5))"
+    observed: "VM 5"
+    correct: "6 — native answers 6"
+    cross_engine: "native prints 6 (correct) under both default and ESHKOL_JIT_CACHE=0 JIT"
+    observed_after: >-
+      the VM answers 6. Verified together with the whole class at depths 1-3, with
+      stored as well as immediately-invoked closures, with two closures sharing one
+      capture, from inside a loop, through a closure that outlives the frame that
+      bound the parameter, on `lambda` parameters as well as `define` parameters, and
+      on let* / letrec / letrec* bindings — byte-identical to native on every line
+      (tests/vm_parity/corpus/62_mutable_capture_writeback.esk).
+    root_cause: >-
+      lib/backend/vm_compiler.c: compile_form_let() had always run needs_boxing()
+      (lib/backend/vm_parser.c:941) over its bindings, so a `let`-bound variable that
+      is both `set!`-mutated and captured by a nested lambda is stored in a shared
+      1-element vector and every closure reads and writes the same cell. PARAMETERS
+      never got that treatment: compile_form_define() (the fixed-parameter loop),
+      compile_form_lambda() and compile_form_lambda_2() called add_local() for each
+      parameter and went straight to the body. OP_CLOSURE therefore copied the
+      parameter's VALUE into the closure's upvalue array and the inner `set!` mutated
+      a private copy that was discarded when the closure returned. The open-slot relay
+      (native calls 151/252) is not an alternative: it aliases an absolute VM stack
+      slot and is deliberately restricted to the top-level chunk, because a function's
+      frame is destroyed on return. The same gap existed in compile_form_let_star(),
+      whose own doc comment said "No mutable-capture boxing (unlike plain `let`)", and
+      in compile_form_letrec() / compile_form_letrec_star().
+    fix: >-
+      vm_box_mutable_captured_params() (lib/backend/vm_compiler.c) heap-boxes every
+      parameter that needs_boxing() reports as mutated-and-captured, by emitting
+      GET_LOCAL / VEC_CREATE 1 / SET_LOCAL at function entry — after OP_PACK_REST,
+      which reads the raw argument window — and marking the Local `boxed`, so every
+      later read and write compiles through the existing boxed paths and a nested
+      closure captures the BOX. Called from all three parameter-binding forms.
+      let* boxes at its binding site with the scan widened to the later initializers
+      plus the body (sequential binding); letrec and letrec* create the box with the
+      placeholder, before any initializer runs, so the box pointer is already final
+      when an initializer's closure captures it, and store initializers through
+      VEC_SET. One mechanism, four binding forms, no new opcode and no ABI change.
+    evidence: >-
+      tests/vm_parity/corpus/62_mutable_capture_writeback.esk (VM-vs-native on the
+      native, vm-src and vm-eskb axes; scripts/run_vm_parity.sh) and
+      tests/differential/corpus/50_mutable_capture_writeback.esk (native axes).
+      tests/vm_parity/corpus/56_lexical_shadow_nearest_binding.esk carried a comment
+      declining to assert this defect; the comment now points at the fix instead.
+      Revert-validated: restoring lib/backend/vm_compiler.c alone reproduces VM 5.
+    renumbered: >-
+      The corpus files were 59_ (vm_parity) and 47_ (differential) when this
+      branch was written. Master's #433 then took both numbers for
+      vector_ref_tensor_indexed_access. Because these are ADDED files with
+      different names at the same index, git reports no conflict and the two
+      would simply have coexisted — the numbering would have stopped being a
+      total order silently. Renumbered on rebase to 62_ and 50_, the next free
+      indices on master once PR #438's 61_/49_ are accounted for.
+    caught_by: [direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, KNOWN_ISSUES]
+    notes: >-
+      Same FAMILY as SW-01/SW-02/SW-24 (a binding is not honoured across a closure
+      boundary) but a distinct mechanism: not name resolution, which PR #428/#429
+      fixed, but the absence of a shared binding CELL. Two adjacent defects were
+      measured while class-killing this one and are NOT fixed here, because both are
+      native-side and out of this entry's scope:
+      (1) a mutated+captured REST parameter does not write back on the NATIVE axes —
+          `(define (r . xs) ((lambda () (set! xs (cons 99 xs)))) (car xs))` is 99 on
+          the VM after this fix and 1 natively;
+      (2) `(do ((i 0 (+ i 1)) (acc 0)) ((= i 3) acc) ((lambda () (set! acc (+ acc i)))))`
+          is killed by SIGKILL (exit 137) natively and answers 0 on the VM.
+      Neither is baked into a gate here; both are recorded so the next pass starts
+      from measurement rather than rediscovery. A third, pre-existing and LOUD, is
+      that an internal `(define (bump) (set! n ...))` capturing an enclosing
+      parameter is a fatal VM runtime error on unmodified master — loud, so not a
+      silent-wrong entry.
+
   - id: SW-26
     bucket: SILENT-WRONG
     status: closed
@@ -855,6 +1014,7 @@ entries:
       those closures, on the same builtin family — the SW-07 fix corrected fg-marginal's VALUE
       but not every VM consumer of it. Maintainer ruling 2026-08-13 reversed the earlier
       waive-to-v1.3.5 default for this entry: fixed before tag, no waiver.
+
 
   - id: SW-27
     bucket: SILENT-WRONG

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -47,6 +47,15 @@ reproducer_root: ".scratch/flaw-ledger/repro"
 buckets:
   SILENT-WRONG: "Wrong value / wrong derivative / wrong memory outcome, no diagnostic, exit 0. TAG-BLOCKING."
   LOUD-ERROR: "Fails with a visible diagnostic, crash or non-zero exit. Bad, but honest. Sub-tagged cheap-fix or structural."
+  LOUD-LIMITATION: >-
+    A capability the engine does not implement, which ANNOUNCES itself at the
+    point of use and again when it starts to bite. Not a wrong answer and not a
+    failure: the program is correct, and the gap is named on stderr and in the
+    docs rather than discovered. Distinct from LOUD-ERROR, which fails; a
+    LOUD-LIMITATION succeeds while doing less than the surface suggests, so the
+    announcement IS the honesty. Not tag-blocking. An entry may only enter this
+    bucket by maintainer ruling, and only once the announcement is gated by a
+    test that fails if it is removed.
   PARITY-RATCHET: "Engine divergence already tracked by a shrink-only ratchet gate."
   DOC-DEBT: "Documentation claim versus measured reality; allowlisted or ledgered."
   IN-FLIGHT: "Has an open PR or an active fix lane at the time of this cut."
@@ -627,10 +636,10 @@ entries:
     notes: "Excused by an XFAIL row, so the wasm gate is green while the defect ships in the browser build."
 
   - id: SW-14
-    bucket: SILENT-WRONG
+    bucket: LOUD-LIMITATION
     status: open
-    resolution: NEEDS-DECISION
-    title: "with-region on the VM never reclaims — silent unbounded memory growth"
+    disposition: "v1.3.5 flagship: VM OALR Stage-1 evacuator port"
+    title: "The bytecode VM does not reclaim: with-region is a pass-through there (native reclaims; VM announces that it does not)"
     observed: "A VM program using regions computes the right answer and never gets the memory back; the VM heap has no escape evacuator"
     evidence: >-
       docs/KNOWN_ISSUES.md, section "Region handles and `with-region` on the
@@ -639,7 +648,46 @@ entries:
       icc-smoke probe vm_region_growth_watchdog
     caught_by: [KNOWN_ISSUES]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
-    notes: "Classified silent because a long-running VM process degrades with no diagnostic and exit 0."
+    reclassified:
+      from: SILENT-WRONG
+      to: LOUD-LIMITATION
+      "on": "2026-08-13"
+      by: "maintainer ruling"
+      why: >-
+        The entry was filed SILENT because a long-running VM process degraded
+        with no diagnostic and exit 0. That premise no longer holds: the two
+        guards below announce the limitation at the point of use and again when
+        it starts to bite, and a gate fails if either is removed. What remains
+        is a capability the VM does not implement, stated plainly — a
+        limitation, not a wrong answer. The reclassification is a change of
+        CATEGORY, not a claim that anything was fixed: the VM still reclaims
+        nothing, and status stays `open` until the evacuator lands.
+        NOT a waiver — waivers expire and this has a build item instead.
+    guard: >-
+      (a) the first region form executed on the VM prints a one-time note to
+          stderr naming the boundary (vm_region_reclaim_notice(),
+          lib/backend/vm_core.c; called from compile_form_with_region() and
+          from native 2210 region-open). ESHKOL_VM_REGION_QUIET=1 silences it.
+      (b) the VM arena is sampled every 4096 allocations and crossing
+          ESHKOL_VM_HEAP_BUDGET_MB (default 1024) prints a diagnostic naming
+          the size, the budget and the cause (heap_check_budget()).
+          ESHKOL_VM_HEAP_BUDGET_FATAL=1 makes it exit nonzero so a lane can
+          gate on it; ESHKOL_VM_HEAP_BUDGET_MB=0 disables it.
+      Neither changes any answer — the gate asserts that too
+      (vm_region_growth_watchdog_test.sh::answers_unchanged).
+    docs_corrected: >-
+      Maintainer ruling 2026-08-13 also required the docs to stop promising
+      reclamation engine-neutrally. docs/reference/runtime/memory-model.md,
+      docs/KNOWN_ISSUES.md and docs/reference/runtime/environment-variables.md
+      now state plainly that the NATIVE engine implements region reclaim (OALR)
+      and the VM engine does not yet reclaim, with the watchdog and budget
+      environment variables documented as the current VM behaviour.
+    notes: >-
+      Filed as SILENT on the premise that the growth was undiagnosed; see
+      `reclassified` for why that premise no longer holds. The measurement
+      below is the reason the entry is not merely "with-region is weaker on the
+      VM": the VM has NO reclamation at all, so `with-region` is not degraded
+      there, it is inert.
     measured:
       at_sha: "2ae3787f"
       with: "build/eshkol-vm-standalone-test (RelWithDebInfo, LLVM 21, arm64-apple-darwin24.1.0)"
@@ -665,10 +713,11 @@ entries:
       object graph the body just returned, because the VM heap has no escape
       evacuator to promote a kept value out with. The missing evacuator, not
       the missing bracket, is the defect.
-    why_not_fixed_here: >-
-      NEEDS-DECISION: a correct fix is a VM-heap escape evacuator, which is a
-      campaign of the same size as the native ESH-0214c/ESH-0214d work
-      (multiple dedicated PRs), not a patch. It requires, at minimum:
+    scope_of_the_real_fix: >-
+      Sized before the ruling and unchanged by it — this is the v1.3.5 flagship
+      brief. A correct fix is a VM-heap escape evacuator, a campaign of the
+      same size as the native ESH-0214c/ESH-0214d work (multiple dedicated
+      PRs), not a patch. It requires, at minimum:
       (1) ROOT ENUMERATION over the operand stack plus ~15 Value-carrying side
           tables inside `struct VM` (outputs, handler_stack.promise_mark,
           current_exception, wind_stack, parameter_bindings, promise_eval_head,
@@ -690,33 +739,34 @@ entries:
       The failure mode of a partial implementation is STRICTLY WORSE than the
       defect: a missed root or an uncovered subtype turns an honest leak into
       a dangling object index, which on the VM aliases a live object and
-      produces a silently wrong VALUE rather than a crash. Shipping that under
-      a SILENT-WRONG closure would invert the ledger's own contract.
-    interim_guard_landed: >-
-      The SILENT half is closed on this branch even though the reclamation is
-      not. Two guards, neither of which changes any answer:
-      (a) the first region form executed on the VM prints a one-time note to
-          stderr naming the boundary (vm_region_reclaim_notice(),
-          lib/backend/vm_core.c; called from compile_form_with_region() and
-          from native 2210 region-open). ESHKOL_VM_REGION_QUIET=1 silences it.
-      (b) the VM arena is sampled every 4096 allocations and crossing
-          ESHKOL_VM_HEAP_BUDGET_MB (default 1024) prints a diagnostic naming
-          the size, the budget and the cause (heap_check_budget()).
-          ESHKOL_VM_HEAP_BUDGET_FATAL=1 makes it exit nonzero so a lane can
-          gate on it; ESHKOL_VM_HEAP_BUDGET_MB=0 disables it.
-      Gated by tests/memory/vm_region_growth_watchdog_test.sh (8/8) and by the
-      icc-smoke probe vm_region_growth_watchdog, so the guard cannot be
-      removed silently. Documented in docs/KNOWN_ISSUES.md,
-      docs/reference/runtime/memory-model.md and
-      docs/reference/runtime/environment-variables.md.
-    decision_requested: >-
-      Choose one: (A) accept the interim guard for v1.3.4 and schedule the
-      VM-heap evacuator as a v1.3.5 campaign — the growth is now loud, named
-      and gate-pinned, and the docs no longer imply otherwise; or (B) hold the
-      tag for the evacuator campaign. Recommendation: (A). Option (B) lands a
-      moving collector in the VM core days before a release, where the cost of
-      an incomplete root or subtype list is a silently wrong value.
-
+      produces a silently wrong VALUE rather than a crash. That is why the
+      ruling scopes the v1.3.5 port with all 27 subtypes DEEP-WALKED up front
+      rather than leaf-copied and revisited.
+    ruling:
+      "on": "2026-08-13"
+      by: "maintainer"
+      decision: >-
+        The loud guard ships for v1.3.4. The full VM evacuator is the v1.3.5
+        FLAGSHIP item: an OALR Stage-1 port of the native engine's design —
+        Cheney-style copying evacuation with a forwarding map and a mutation
+        write barrier — with all 27 heap subtypes DEEP-WALKED rather than
+        leaf-copied. That last clause is the ESH-0214d lesson written into the
+        scope up front: natively, the subtypes left as shallow leaf copies were
+        exactly the ones that later had to be reopened, so the VM port does not
+        get to defer them.
+      consequences:
+        - "this entry moves SILENT-WRONG -> LOUD-LIMITATION and stops gating the tag"
+        - "status stays open; the evacuator is the close condition, not the guard"
+        - "docs must state the engine split plainly rather than promise reclaim neutrally"
+    close_condition: >-
+      This entry closes when a VM program measurably gets its memory back:
+      the fixture in tests/memory/vm_region_growth_watchdog_test.esk must hold
+      FLAT peak RSS across its iteration count instead of the ~1.5 GB measured
+      above, with the region-escape semantics of
+      docs/reference/runtime/memory-model.md preserved and every one of the 27
+      subtypes covered by a deep-walk test in the shape of
+      tests/memory/region_evac_subtype_coverage_test.sh. Closing by assertion
+      is forbidden (ledger invariant 3); the RSS number is the proof.
   - id: SW-15
     bucket: SILENT-WRONG
     status: closed

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Eshkol is a Scheme-based programming language that unifies functional programmin
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![Version](https://img.shields.io/badge/version-v1.3.4--evolve-blue.svg)](RELEASE_NOTES.md) [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](CMakeLists.txt)
 
-**v1.3.4-evolve** — a resident-correctness release. Automatic per-iteration
-memory reclamation now matches explicit `with-region` even for loops that mutate
-persistent state; `parallel-map` is race-free for collection-valued closures;
+**v1.3.4-evolve** — a resident-correctness release. On the native engine,
+automatic per-iteration memory reclamation now matches explicit `with-region`
+even for loops that mutate persistent state; `parallel-map` is race-free for collection-valued closures;
 gradients are exact through every callable form (indirect and curried, no
 finite-difference fallback); printed floats round-trip (R7RS 6.2.6); and the
 strict type checker accepts idiomatic dynamic-but-validated code. It also lands
@@ -182,12 +182,15 @@ Automatic differentiation is not a library feature—it is intrinsic to the lang
 
 Arena-based allocation with Ownership-Aware Lexical Regions (OALR) eliminates garbage collection entirely, providing O(1) allocation and deterministic deallocation. This architecture ensures predictable performance characteristics essential for real-time systems and production machine learning deployments. As of v1.3.4, **automatic per-iteration reclamation matches explicit `with-region`** even in a resident tick/daemon loop that mutates persistent state every iteration: such a loop is lowered with a per-loop nursery whose write barriers promote escapees and whose back edge resets the nursery, so RSS stays flat without any explicit region annotation. `with-region` remains available for scratch regions but is no longer *required* to get flat RSS in a long-running loop.
 
+**Which engine reclaims.** Everything in this section describes the **native engine** (`eshkol-run`, JIT and AOT). The **bytecode VM** (`eshkol-vm-standalone-test`) evaluates `with-region` and the region handles identically and returns the same values, but **does not reclaim** — the VM heap has no escape evacuator yet, so a resident VM workload grows monotonically. The VM announces this at the first region form and again when the growth crosses a heap budget, and the VM evacuator is the v1.3.5 flagship item (maintainer ruling 2026-08-13). Use `eshkol-run` for workloads that depend on reclamation; see [docs/reference/runtime/memory-model.md](docs/reference/runtime/memory-model.md#which-engine-reclaims).
+
 ```scheme
-;; Automatic scope-based memory management
+;; Automatic scope-based memory management (native engine)
 (with-region 'computation
   (let ((large-dataset (load-training-data)))
     (train-model large-dataset)))
 ;; All memory automatically freed - no GC pauses, ever
+;; (bytecode VM: same value, no reclamation yet)
 
 ;; Explicit ownership semantics when needed
 (define resource (owned (acquire-expensive-resource)))
@@ -355,12 +358,13 @@ differentiable control flow, and tower numerics — every example runnable.
 
 #### Advanced Memory Management
 ```scheme
-;; Arena-based regions with automatic cleanup
+;; Arena-based regions with automatic cleanup (native engine)
 (with-region 'training-session
   (let ((model (initialize-large-model))
         (data (load-training-batch)))
     (gradient-descent-step model data)))
 ;; Memory deterministically freed
+;; (bytecode VM: same value, no reclamation yet)
 
 ;; Ownership and borrowing semantics
 (define resource (owned (acquire-gpu-buffer)))
@@ -741,8 +745,8 @@ multi-pillar adversarial-testing infrastructure.
 - **Robustness**: mutual tail calls are proper O(1)-stack R7RS tail calls on
   AArch64; named-let TCO covers every tail position including through
   `guard`; the closure-capture ceiling is raised 16 → 64; a class of
-  unbounded RSS growth in long-running loops is fixed with automatic
-  per-iteration arena reclamation; a shutdown-teardown race and a deep-
+  unbounded RSS growth in long-running loops is fixed, on the native engine,
+  with automatic per-iteration arena reclamation; a shutdown-teardown race and a deep-
   recursion `SIGILL`-with-no-diagnostic bug are both fixed; `eshkol-run -r`/AOT
   caching now invalidates correctly on transitive `(load ...)`/`(require ...)`
   dependency changes.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -405,13 +405,18 @@ Advanced pattern matching with support for literals, variables, cons patterns, l
 #### `with-region`
 **Syntax**: `(with-region [name size-hint] body...)`
 
-Creates a lexical memory region, automatically freed after body execution.
+Creates a lexical memory region. **On the native engine** (`eshkol-run`, JIT and
+AOT) the region's arena is automatically freed after body execution and the body
+result is deep-copied out so it survives. **On the bytecode VM** the form
+evaluates identically and returns the same value but frees nothing — the VM heap
+has no escape evacuator yet; it announces this at first use. See
+[memory model: which engine reclaims](reference/runtime/memory-model.md#which-engine-reclaims).
 
 **Examples**:
 ```scheme
 (with-region
   (let ((big-data (make-vector 1000000 0)))
-    (process big-data)))  ; Memory freed after block
+    (process big-data)))  ; native: memory freed after block
 ```
 
 **Type**: Region-based memory management  
@@ -2003,7 +2008,8 @@ Compile-time type annotations for gradual typing.
 
 **OALR** (Ownership-Aware Lexical Regions):
 - Arena allocation (bump pointer, O(1) allocation)
-- Lexical region lifetimes (deterministic deallocation)
+- Lexical region lifetimes (deterministic deallocation — native engine; the
+  bytecode VM does not reclaim yet)
 - Zero-copy tensor views (reshape/slice without allocation)
 
 **Allocation Hierarchy**:

--- a/docs/COMPLETE_LANGUAGE_SPECIFICATION.md
+++ b/docs/COMPLETE_LANGUAGE_SPECIFICATION.md
@@ -1832,7 +1832,8 @@ JSON parsing and serialization:
 
 #### 6.1.1 Core Concepts
 - **Arena Allocation:** Bump-pointer allocation in large blocks
-- **Scope-based Cleanup:** Memory freed when scope exits
+- **Scope-based Cleanup:** Memory freed when scope exits (native engine; the
+  bytecode VM does not reclaim yet — see 6.2.1)
 - **No Garbage Collection:** Deterministic, predictable performance
 - **Cache-Friendly:** Linear allocation pattern
 
@@ -1864,15 +1865,25 @@ struct arena {
 
 **Semantics:**
 - Creates a dedicated arena for the body
-- Memory freed when region exits
+- Memory freed when region exits, and the body result is deep-copied out so it
+  survives (**native engine**)
 - Supports nesting (stack of regions)
+
+**Substrate note.** The reclamation half of those semantics is implemented by
+the **native engine** (`eshkol-run`, JIT and AOT) only. On the **bytecode VM**
+all three spellings evaluate the body identically and return the same value —
+the form is value- and effect-transparent — but **nothing is freed**, because
+the VM heap has no escape evacuator yet. A VM program is therefore correct but
+grows monotonically; it announces this at the first region form and again when
+the growth crosses a heap budget. The VM evacuator is the v1.3.5 flagship item.
+See [memory model](reference/runtime/memory-model.md#which-engine-reclaims).
 
 **Example:**
 ```scheme
 (with-region 'temp
   (define data (iota 1000))
   (process data))
-; data's memory freed here
+; native: data's memory freed here; bytecode VM: same value, not yet freed
 ```
 
 #### 6.2.2 `owned` - Mark Ownership
@@ -4165,7 +4176,8 @@ Keep original name (exported via `provide`)
 
 **Version History:**
 - v1.3.4-evolve - Consumer-hardening correctness wave: automatic per-iteration
-  memory reclamation that matches explicit `with-region`, race-free
+  memory reclamation on the native engine that matches explicit `with-region`,
+  race-free
   `parallel-map`, exact gradients through every callable form and at exact
   (rational/bignum) points, R7RS-correct exactness contagion on both the native
   and bytecode-VM numeric paths, same-unit `define-library`/`import` resolution

--- a/docs/ESHKOL_LANGUAGE_GUIDE.md
+++ b/docs/ESHKOL_LANGUAGE_GUIDE.md
@@ -1047,7 +1047,9 @@ Eshkol uses **arena-based memory management** for deterministic, low-latency per
 **Benefits:**
 - **No GC pauses** - Critical for real-time applications
 - **Cache-friendly** - Sequential allocation
-- **Deterministic cleanup** - Memory freed when scope exits
+- **Deterministic cleanup** - Memory freed when scope exits (native engine;
+  the bytecode VM does not reclaim yet — see
+  [memory model](reference/runtime/memory-model.md#which-engine-reclaims))
 - **Fast allocation** - O(1) bump-pointer allocation
 
 ### Tagged Value System

--- a/docs/ESHKOL_V1_ARCHITECTURE.md
+++ b/docs/ESHKOL_V1_ARCHITECTURE.md
@@ -113,7 +113,8 @@ Eshkol is a production-grade compiler implementing a Scheme-like language with:
 
 Eshkol uses **Ownership-Aware Lexical Regions** (OALR) instead of garbage collection:
 
-- **Lexical scoping**: Memory freed when leaving scope
+- **Lexical scoping**: Memory freed when leaving scope (native engine; the
+  bytecode VM evaluates the same forms and does not reclaim yet)
 - **Ownership tracking**: Compile-time analysis prevents leaks
 - **Arena allocation**: Bump-pointer allocation (extremely fast)
 - **Deterministic cleanup**: No GC pauses

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -112,6 +112,8 @@ Eshkol compiles to native machine code via LLVM. Arithmetic and tensor operation
 
 No. Eshkol uses Ownership-Aware Lexical Regions (OALR) — arena-based allocation where memory is freed deterministically at scope boundaries. This provides microsecond-scale worst-case guarantees suitable for real-time systems. As of v1.3.4, a resident tick/daemon loop reclaims its per-iteration garbage automatically — even when it mutates persistent state every iteration — so RSS stays flat without any explicit `with-region` annotation (`with-region` remains available for scratch regions but is no longer required).
 
+This describes the **native engine** (`eshkol-run`, JIT and AOT). The **bytecode VM** does not reclaim yet: `with-region` and the region handles evaluate identically there and return the same values, but nothing is freed, so a resident VM workload grows monotonically. The VM says so at the first region form and again when the growth crosses a heap budget; the VM evacuator is the v1.3.5 flagship item. Use `eshkol-run` for workloads that depend on reclamation — see [memory model](reference/runtime/memory-model.md#which-engine-reclaims).
+
 ### How does GPU dispatch work?
 
 Tensor operations dispatch through a four-tier hierarchy based on operand size:

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -218,6 +218,32 @@ as native — it simply does not get the memory back, because the region arena,
 the allocation-slot hijack and the escape promotion are native-arena constructs
 and the VM heap has no escape evacuator.
 
+**This is not a property of `with-region` alone: the bytecode VM has no heap
+reclamation of any kind.** Measured on
+`tests/memory/vm_region_growth_watchdog_test.esk`, peak RSS is identical with
+and without the `with-region` wrapper — 1.503 GB either way at 20k iterations
+of 200 conses. `with-region` is the designated reclamation mechanism and it is
+inert on this substrate, so a resident VM workload grows monotonically until
+the host gives out.
+
+**That growth is no longer silent.** Two guards now name it (SW-14 in
+`.icc/silent-wrong-ledger.yaml`), gated by
+`tests/memory/vm_region_growth_watchdog_test.sh`:
+
+- The first region form executed on the VM prints a one-time note to stderr
+  saying that regions reclaim nothing here. `ESHKOL_VM_REGION_QUIET=1`
+  silences it.
+- The VM arena is sampled as it grows; crossing `ESHKOL_VM_HEAP_BUDGET_MB`
+  (default 1024) prints a diagnostic naming the size, the budget and the
+  cause. `ESHKOL_VM_HEAP_BUDGET_FATAL=1` makes it exit nonzero so a lane can
+  gate on it; `ESHKOL_VM_HEAP_BUDGET_MB=0` disables the watchdog.
+
+Neither guard changes any answer. **Real VM reclamation remains a build item**,
+and its prerequisite is unchanged: a VM-heap escape evacuator (root enumeration
+over the operand stack and the VM's side tables, per-subtype interior
+traversal for all 27 heap types, and index-space recycling). Use `eshkol-run`
+for workloads that depend on reclamation.
+
 ### Reverse-mode gradient on the VM
 `gradient` now runs on the bytecode VM at full parity with native codegen
 (#337): forward/reverse-mode, arity-resolved (scalar / N-argument / arity-1

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -12,7 +12,9 @@
   leaked one iteration's transient garbage forever. It is now lowered with a
   per-loop nursery region (ESH-0214e), so such a loop is flat at 34 MB —
   identical to its explicit `with-region` twin. `with-region` is no longer
-  required to get flat RSS in a resident loop. See
+  required to get flat RSS in a resident loop. Native engine only — the
+  bytecode VM reclaims neither way (see "Region handles and `with-region` on
+  the VM" below). See
   [memory-model](reference/runtime/memory-model.md#automatic-per-iteration-reclamation-in-resident-loops-esh-0214e).
 - **`parallel-map` corrupted collection-valued results past the parallel
   threshold.** A closure whose body used per-iteration scope reclamation (an
@@ -238,11 +240,19 @@ the host gives out.
   cause. `ESHKOL_VM_HEAP_BUDGET_FATAL=1` makes it exit nonzero so a lane can
   gate on it; `ESHKOL_VM_HEAP_BUDGET_MB=0` disables the watchdog.
 
-Neither guard changes any answer. **Real VM reclamation remains a build item**,
-and its prerequisite is unchanged: a VM-heap escape evacuator (root enumeration
-over the operand stack and the VM's side tables, per-subtype interior
-traversal for all 27 heap types, and index-space recycling). Use `eshkol-run`
-for workloads that depend on reclamation.
+Neither guard changes any answer. **Real VM reclamation is the v1.3.5 flagship
+item** (maintainer ruling 2026-08-13): an OALR Stage-1 port of the native
+engine's design — Cheney-style copying evacuation with a forwarding map and a
+mutation write barrier — with root enumeration over the operand stack and the
+VM's side tables, index-space recycling, and all 27 heap subtypes **deep-walked
+rather than leaf-copied**. That last clause is the ESH-0214d lesson written into
+the scope up front: natively, the subtypes left as shallow leaf copies were
+exactly the ones that had to be reopened later.
+
+Until then, **use `eshkol-run` (the native engine) for workloads that depend on
+reclamation.** Tracked as SW-14 in `.icc/silent-wrong-ledger.yaml`, bucket
+LOUD-LIMITATION — the limitation is announced rather than discovered, and the
+entry stays open until the RSS measurement above goes flat.
 
 ### Reverse-mode gradient on the VM
 `gradient` now runs on the bytecode VM at full parity with native codegen
@@ -353,6 +363,8 @@ block ordinary use.
   from automatic reclamation by design. Wrap each optimization step in an
   explicit `(with-region ...)` to get flat RSS — the tape's node-pointer array is
   now reclaimed with the region (#345), so a per-step `with-region` is fully flat.
+  Native engine only; on the bytecode VM a per-step `with-region` reclaims
+  nothing (see "Region handles and `with-region` on the VM" above).
   A lighter-weight tape mark/release API is planned so a bare training loop can
   reclaim without a per-step region.
 

--- a/docs/LONG_RUNNING_LOOPS.md
+++ b/docs/LONG_RUNNING_LOOPS.md
@@ -131,13 +131,17 @@ In order of preference:
 **Threading state without consing:** prefer a single accumulator value, or
 a small `define-record-type` instance passed by reference, over
 reconstructing a fresh list every iteration. Consing a new list per
-iteration is extra per-tick allocation for no benefit — the arena reclaims
-it at the same rate either way, but a record/scalar avoids the allocation
-and the cons-traversal entirely. This project's automatic per-iteration
-arena-scope reclamation work (ESH-0214/ESH-0214b, `fix/loop-arena-reclamation`,
-not yet merged as of this writing) is complementary: once merged, it
+iteration is extra per-tick allocation for no benefit — on the native engine
+the arena reclaims it at the same rate either way, but a record/scalar avoids
+the allocation and the cons-traversal entirely. Automatic per-iteration
+arena-scope reclamation (ESH-0214/ESH-0214b) shipped and is complementary: it
 further bounds RSS for named-let loops whose static shape qualifies for
 automatic per-iteration scoping, independent of whether guard is used.
+
+All of that is the **native engine**. The bytecode VM reclaims nothing yet —
+neither automatically nor through an explicit `(with-region ...)` — so a
+long-running loop belongs on `eshkol-run`; see
+[memory model](reference/runtime/memory-model.md#which-engine-reclaims).
 `guard`/`call/cc` bodies are expected to be on that feature's rejection
 list for automatic scoping (their handler/continuation state must survive
 past a naive iteration boundary), so the flat-outside-guard pattern remains

--- a/docs/internal/ESHKOL_V1_LANGUAGE_REFERENCE.md
+++ b/docs/internal/ESHKOL_V1_LANGUAGE_REFERENCE.md
@@ -1761,7 +1761,8 @@ nil            ; Alias
 (with-region
   (define data (iota 1000))
   (process data))
-; Memory freed after region exits
+; Memory freed after region exits (native engine; the bytecode VM returns the
+; same value and does not reclaim yet)
 
 ; Named region
 (with-region 'temp

--- a/docs/reference/runtime/INDEX.md
+++ b/docs/reference/runtime/INDEX.md
@@ -19,7 +19,8 @@ Reference documentation for the Eshkol runtime and toolchain (v1.3.4-evolve).
   sandbox.
 - [Memory model](memory-model.md) — 16-byte tagged values, the arena allocator,
   the hybrid global/per-thread model, and `with-region` semantics (incl. the
-  PR #81 reclamation fix).
+  PR #81 reclamation fix). Reclamation is a NATIVE-engine capability; the
+  bytecode VM evaluates the same forms and does not reclaim yet.
 - [Parallelism & threading](parallelism.md) — `parallel-map`/`-fold`/`-filter`/
   `-execute`, `future`/`force`, the work-stealing pool, the serialized-state
   pattern, and the AD-mode-flag limitation.

--- a/docs/reference/runtime/environment-variables.md
+++ b/docs/reference/runtime/environment-variables.md
@@ -72,6 +72,20 @@ Read by `lib/core/resource_limits.cpp`. Size vars accept `K`/`M`/`G` suffixes.
 | `ESHKOL_ENFORCE_LIMITS` | Enforce hard limits (abort on exceed). | true |
 | `ESHKOL_LIMIT_WARNINGS` | Emit soft-limit warnings. | true |
 
+### Bytecode-VM heap growth watchdog
+
+The bytecode VM has no heap reclamation: `(with-region ...)` is the designated
+mechanism and is a pass-through there, so a resident VM workload grows
+monotonically (SW-14; see [Memory model](memory-model.md) and
+`docs/KNOWN_ISSUES.md`). These knobs control the guards that make that growth
+loud instead of silent. Neither guard changes any answer.
+
+| Variable | Effect | Default |
+|----------|--------|---------|
+| `ESHKOL_VM_HEAP_BUDGET_MB` | VM arena size past which a diagnostic names the growth and its cause. `0` disables the watchdog. | 1024 |
+| `ESHKOL_VM_HEAP_BUDGET_FATAL` | Make crossing the budget exit nonzero instead of advisory, so a lane can gate on it. | off |
+| `ESHKOL_VM_REGION_QUIET` | Suppress the one-time note that region forms reclaim nothing on the VM. | off |
+
 ## Parallelism & threading
 
 | Variable | Effect | Default |

--- a/docs/reference/runtime/memory-model.md
+++ b/docs/reference/runtime/memory-model.md
@@ -96,6 +96,22 @@ reclamation on either surface; when it lands, `with-region` should bracket
 through that evacuator's unwind entry point rather than grow a second teardown
 mechanism.
 
+The VM has **no heap reclamation of any kind** — `with-region` is the
+designated mechanism, not an optimisation on top of one. Measured on
+`tests/memory/vm_region_growth_watchdog_test.esk`, a VM run peaks at the same
+RSS with and without the wrapper, so a resident VM workload grows
+monotonically.
+
+Since the point of reaching for a region is the memory, the VM now **says so
+rather than staying quiet** (SW-14). The first region form executed on the VM
+prints a one-time note to stderr; the VM arena is sampled as it grows and
+crossing `ESHKOL_VM_HEAP_BUDGET_MB` prints a diagnostic that names the size,
+the budget and the cause. Neither changes an answer, and both are
+configurable — see
+[Environment variables](environment-variables.md). The behaviour is gated by
+`tests/memory/vm_region_growth_watchdog_test.sh` so it cannot be silently
+dropped.
+
 ```scheme
 ;; Allocations inside the body are freed at region exit; the result escapes.
 (define total
@@ -339,7 +355,9 @@ implementation backs both — but a close reclaims nothing: the VM heap has no
 escape evacuator, which is also why `with-region` is a pass-through there. See
 `tests/vm_parity/PARITY.tsv`. Observable program output is byte-identical
 (`tests/vm_parity/corpus/region_handle_contract.esk` pins it); only the
-reclamation is absent.
+reclamation is absent. `region-open` on the VM emits the same one-time note as
+`with-region` does, for the same reason — see
+[Substrate support](#substrate-support) above.
 
 ## Parallel workers: commit-only reclamation
 

--- a/docs/reference/runtime/memory-model.md
+++ b/docs/reference/runtime/memory-model.md
@@ -1,9 +1,37 @@
 # Memory Model — Tagged Values, Arenas, and Regions
 
 Eshkol uses **arena (region-based) memory management**, not a garbage collector.
-Allocation is O(1) bump-pointer; reclamation is bulk and deterministic at region
-exit. This is a deliberate design choice for real-time, financial, and embedded
-workloads where latency predictability matters — Eshkol will never have a GC.
+Allocation is O(1) bump-pointer; on the native engine reclamation is bulk and
+deterministic at region exit. This is a deliberate design choice for real-time,
+financial, and embedded workloads where latency predictability matters — Eshkol
+will never have a GC.
+
+## Which engine reclaims
+
+**Read this before relying on any reclamation claim on this page.** Eshkol has
+two execution engines and they do not currently share reclamation:
+
+| Engine | Binary | Region reclamation |
+|---|---|---|
+| **Native** (LLVM JIT and AOT) | `eshkol-run` | **Yes** — the full OALR contract on this page: region arenas, escape promotion, the mutation write barrier, and per-loop nursery reclamation. |
+| **Bytecode VM** | `eshkol-vm-standalone-test`, `eshkol-run --profile hosted-vm` | **No, not yet.** `with-region`, `region-open` and `region-close` all resolve, validate and return exactly as natively, but **nothing is freed**. |
+
+The VM's gap is not that regions reclaim *less* there — **the VM has no heap
+reclamation of any kind**, so `with-region` is inert rather than degraded.
+Measured: the same fixture peaks at 1,503,297,536 bytes of RSS *with* the
+`with-region` wrapper and 1,504,067,584 bytes *without* it
+(`tests/memory/vm_region_growth_watchdog_test.esk`). The prerequisite is a
+VM-heap escape evacuator; that port is the **v1.3.5 flagship item** (maintainer
+ruling 2026-08-13, ledger entry SW-14 in `.icc/silent-wrong-ledger.yaml`).
+
+Until it lands the VM **says so** rather than growing quietly — a one-time note
+at the first region form, and a heap-budget diagnostic when the growth starts to
+bite. Both are configurable; see
+[Environment variables](environment-variables.md) and
+[Substrate support](#substrate-support) below.
+
+**Unless a section says otherwise, every reclamation statement on this page
+describes the NATIVE engine.**
 
 ## Tagged values (16 bytes)
 
@@ -54,8 +82,10 @@ The arena API lives in `lib/core/arena_memory.h` (impl in `lib/core/`).
 
 Regions are lexically-scoped arenas layered on top of the allocator
 (`lib/core/runtime_regions.cpp`). A thread-local region stack tracks the active
-region; allocations route to the current region's arena and are reclaimed when
-the region exits.
+region; allocations route to the current region's arena and, **on the native
+engine**, are reclaimed when the region exits. On the bytecode VM the same
+surface evaluates identically and reclaims nothing — see
+[Which engine reclaims](#which-engine-reclaims).
 
 ### Surface syntax
 
@@ -70,9 +100,11 @@ At least one body expression is required, and the region name/size specifier is
 is not a call. Non-final body expressions are evaluated for effect and their
 values discarded, exactly as in `begin`.
 
-The value of the last body expression is returned; because the region's arena is
-freed on exit, a returned heap value is **deep-copied out** into the
-parent/global arena so it survives (the "escape" mechanism). The compiler emits
+The value of the last body expression is returned. **On the native engine**,
+because the region's arena is freed on exit, a returned heap value is
+**deep-copied out** into the parent/global arena so it survives (the "escape"
+mechanism); on the bytecode VM the value is returned unchanged and nothing is
+freed. The compiler emits
 `region_create` → `region_push` → `eshkol_region_enter` → *body* →
 `eshkol_region_unwind_to`, the single shared teardown primitive that also serves
 `region-close`, a `raise` crossing an open region, and a continuation escape: it
@@ -92,9 +124,12 @@ result out with, so a real push/pop there would free the object graph the body
 just returned. This is the same boundary a VM `region-close` declares (see
 [User-reachable region handles](#user-reachable-region-handles-341) below and
 `tests/vm_parity/PARITY.tsv`). A VM-heap evacuator is the prerequisite for VM
-reclamation on either surface; when it lands, `with-region` should bracket
-through that evacuator's unwind entry point rather than grow a second teardown
-mechanism.
+reclamation on either surface. That port is the **v1.3.5 flagship item**
+(maintainer ruling 2026-08-13): an OALR Stage-1 port of the native design —
+Cheney-style copying evacuation with a forwarding map and a mutation write
+barrier, with all 27 heap subtypes deep-walked rather than leaf-copied. When it
+lands, `with-region` brackets through that evacuator's unwind entry point
+rather than growing a second teardown mechanism.
 
 The VM has **no heap reclamation of any kind** — `with-region` is the
 designated mechanism, not an optimisation on top of one. Measured on
@@ -102,18 +137,20 @@ designated mechanism, not an optimisation on top of one. Measured on
 RSS with and without the wrapper, so a resident VM workload grows
 monotonically.
 
-Since the point of reaching for a region is the memory, the VM now **says so
-rather than staying quiet** (SW-14). The first region form executed on the VM
-prints a one-time note to stderr; the VM arena is sampled as it grows and
-crossing `ESHKOL_VM_HEAP_BUDGET_MB` prints a diagnostic that names the size,
-the budget and the cause. Neither changes an answer, and both are
-configurable — see
+Since the point of reaching for a region is the memory, the VM **says so rather
+than staying quiet** (ledger entry SW-14, bucket LOUD-LIMITATION). The first
+region form executed on the VM prints a one-time note to stderr; the VM arena is
+sampled as it grows and crossing `ESHKOL_VM_HEAP_BUDGET_MB` prints a diagnostic
+that names the size, the budget and the cause. Neither changes an answer, and
+both are configurable — see
 [Environment variables](environment-variables.md). The behaviour is gated by
 `tests/memory/vm_region_growth_watchdog_test.sh` so it cannot be silently
 dropped.
 
 ```scheme
-;; Allocations inside the body are freed at region exit; the result escapes.
+;; NATIVE ENGINE. Allocations inside the body are freed at region exit and the
+;; result escapes. Under the bytecode VM this same program computes the same
+;; total and frees nothing.
 (define total
   (with-region ('scratch 65536)
     (let loop ((i 0) (acc 0))
@@ -186,6 +223,11 @@ tool for a scratch region whose entire contents should be freed at a lexical
 boundary; it is simply no longer *required* to achieve flat RSS in a resident
 loop.
 
+**Native engine only.** Both halves of that sentence — the automatic nursery and
+the explicit `with-region` twin — describe `eshkol-run`. On the bytecode VM
+neither reclaims, because neither has anything to reclaim with; see
+[Which engine reclaims](#which-engine-reclaims).
+
 ## User-reachable region handles (#341)
 
 `with-region` is the **recommended default and should stay your first choice**.
@@ -223,7 +265,8 @@ whose only legal uses are `region-close` and `region-open?`. A single numeric
 argument to `region-open` is read as the size hint; a single non-numeric argument
 is read as the debug name. Handles are **per-thread**, like the region stack.
 
-Everything allocated between `region-open` and its `region-close` is reclaimed at
+**On the native engine**, everything allocated between `region-open` and its
+`region-close` is reclaimed at
 the close. The values named in the `region-close` result list are
 **deep-promoted** out first — the same transitive escape evacuator `with-region`
 uses for its result, interior-pointer walk included (ESH-0214c/d), so shared

--- a/docs/tutorials/WHY_ESHKOL.md
+++ b/docs/tutorials/WHY_ESHKOL.md
@@ -123,6 +123,11 @@ Eshkol uses arena allocation with ownership-aware lexical regions (OALR).
 Memory is freed deterministically at scope exit — no GC pauses, no
 unpredictable latency spikes, no "GC took 200ms" in your ML training loop.
 
+This is the **native engine** (`eshkol-run`), which is what you compile and ship
+with. The bytecode VM runs the same programs to the same answers but does not
+reclaim yet, so use `eshkol-run` for anything long-running — see
+[memory model](../reference/runtime/memory-model.md#which-engine-reclaims).
+
 ---
 
 ## 7. One language, every platform

--- a/lib/backend/vm_compiler.c
+++ b/lib/backend/vm_compiler.c
@@ -1790,8 +1790,14 @@ static void compile_form_let(FuncChunk* c, Node* node, int tail) {
 /** @brief Compile `(let* ((var val)...) body...)`: unlike compile_form_let(),
  *         each binding's value expression is compiled with the
  *         previously-bound locals already in scope (sequential, not
- *         parallel, binding). No mutable-capture boxing (unlike plain
- *         `let`). */
+ *         parallel, binding).
+ *
+ *         Mutable-capture boxing (the SW-25 family) applies here exactly as
+ *         it does to plain `let`, with one difference forced by sequential
+ *         binding: a `let*` binding is in scope for every LATER initializer
+ *         as well as for the body, so a nested lambda in a later initializer
+ *         captures it too. The scan therefore covers the remaining
+ *         initializers together with the body. */
 static void compile_form_let_star(FuncChunk* c, Node* node, int tail) {
     Node* head = node->children[0];
     (void)head; (void)tail;
@@ -1801,8 +1807,18 @@ static void compile_form_let_star(FuncChunk* c, Node* node, int tail) {
     for (int i = 0; i < bindings->n_children; i++) {
         Node* b = bindings->children[i];
         if (b->type == N_LIST && b->n_children == 2 && b->children[0]->type == N_SYMBOL) {
+            const char* vname = b->children[0]->symbol;
+            Node* scope_nodes[64];
+            int n_scope = 0;
+            for (int j = i + 1; j < bindings->n_children && n_scope < 64; j++)
+                scope_nodes[n_scope++] = bindings->children[j];
+            for (int j = 2; j < node->n_children && n_scope < 64; j++)
+                scope_nodes[n_scope++] = node->children[j];
+            int box = needs_boxing(scope_nodes, n_scope, vname);
             compile_expr(c, b->children[1], 0);
-            add_local(c, b->children[0]->symbol);
+            if (box) chunk_emit(c, OP_VEC_CREATE, 1);
+            add_local(c, vname);
+            if (box) c->locals[c->n_locals - 1].boxed = 1;
         }
     }
     int n_let_locals = c->n_locals - saved_locals;
@@ -1836,24 +1852,55 @@ static void compile_form_letrec(FuncChunk* c, Node* node, int tail) {
     Node* bindings = node->children[1];
     int n_bindings = 0;
 
-    /* 1. Push NIL placeholders and register names */
+    /* Scope of every letrec binding: all initializers plus the body (the
+     * bindings are mutually visible). Used for the SW-25-family mutable
+     * capture scan below. */
+    Node* scope_nodes[64];
+    int n_scope = 0;
+    for (int i = 0; i < bindings->n_children && n_scope < 64; i++)
+        scope_nodes[n_scope++] = bindings->children[i];
+    for (int i = 2; i < node->n_children && n_scope < 64; i++)
+        scope_nodes[n_scope++] = node->children[i];
+
+    /* 1. Push placeholders and register names. A binding that is both
+     * `set!`-mutated and captured by a nested lambda gets its heap box HERE,
+     * before any initializer runs, so every closure created by an initializer
+     * or by the body captures the SAME box (the box pointer is already final
+     * at capture time; only its contents change). Without the box such a
+     * binding was captured by value and an inner `set!` mutated a private
+     * copy — the same defect SW-25 records for parameters. */
     for (int i = 0; i < bindings->n_children; i++) {
         Node* b = bindings->children[i];
         if (b->type == N_LIST && b->n_children == 2 && b->children[0]->type == N_SYMBOL) {
+            int box = needs_boxing(scope_nodes, n_scope, b->children[0]->symbol);
             chunk_emit(c, OP_NIL, 0);
+            if (box) chunk_emit(c, OP_VEC_CREATE, 1);
             add_local(c, b->children[0]->symbol);
+            if (box) c->locals[c->n_locals - 1].boxed = 1;
             n_bindings++;
         }
     }
     int n_let_locals = c->n_locals - saved_locals;
 
-    /* 2. Compile each initializer and SET_LOCAL */
+    /* 2. Compile each initializer and store it: a plain SET_LOCAL for an
+     * ordinary binding, a VEC_SET into the box for a boxed one. */
     for (int i = 0; i < bindings->n_children; i++) {
         Node* b = bindings->children[i];
         if (b->type == N_LIST && b->n_children == 2 && b->children[0]->type == N_SYMBOL) {
-            compile_expr(c, b->children[1], 0);
             int slot = resolve_local(c, b->children[0]->symbol);
-            if (slot >= 0) chunk_emit(c, OP_SET_LOCAL, slot);
+            int boxed = 0;
+            for (int li = c->n_locals - 1; li >= 0; li--)
+                if (c->locals[li].slot == slot && c->locals[li].boxed) { boxed = 1; break; }
+            if (slot >= 0 && boxed) {
+                chunk_emit(c, OP_GET_LOCAL, slot);                      /* box    */
+                chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL(0)));/* index  */
+                compile_expr(c, b->children[1], 0);                     /* value  */
+                chunk_emit(c, OP_VEC_SET, 0);
+                chunk_emit(c, OP_POP, 0);   /* VEC_SET pushes NIL; discard it */
+            } else {
+                compile_expr(c, b->children[1], 0);
+                if (slot >= 0) chunk_emit(c, OP_SET_LOCAL, slot);
+            }
         }
     }
 
@@ -1889,27 +1936,50 @@ static void compile_form_letrec(FuncChunk* c, Node* node, int tail) {
  *         compile_form_letrec() (NIL placeholders + SET_LOCAL
  *         initializers) but without the open-upvalue patching step —
  *         letrec*'s sequential (rather than "all closures see final
- *         values") semantics don't need it. */
+ *         values") semantics don't need it. Mutable-capture boxing applies
+ *         identically (SW-25 family). */
 static void compile_form_letrec_star(FuncChunk* c, Node* node, int tail) {
     Node* head = node->children[0];
     (void)head; (void)tail;
     int saved_locals = c->n_locals;
     c->scope_depth++;
     Node* bindings = node->children[1];
+
+    Node* scope_nodes[64];
+    int n_scope = 0;
+    for (int i = 0; i < bindings->n_children && n_scope < 64; i++)
+        scope_nodes[n_scope++] = bindings->children[i];
+    for (int i = 2; i < node->n_children && n_scope < 64; i++)
+        scope_nodes[n_scope++] = node->children[i];
+
     for (int i = 0; i < bindings->n_children; i++) {
         Node* b = bindings->children[i];
         if (b->type == N_LIST && b->n_children == 2 && b->children[0]->type == N_SYMBOL) {
+            int box = needs_boxing(scope_nodes, n_scope, b->children[0]->symbol);
             chunk_emit(c, OP_NIL, 0);
+            if (box) chunk_emit(c, OP_VEC_CREATE, 1);
             add_local(c, b->children[0]->symbol);
+            if (box) c->locals[c->n_locals - 1].boxed = 1;
         }
     }
     int n_let_locals = c->n_locals - saved_locals;
     for (int i = 0; i < bindings->n_children; i++) {
         Node* b = bindings->children[i];
         if (b->type == N_LIST && b->n_children == 2 && b->children[0]->type == N_SYMBOL) {
-            compile_expr(c, b->children[1], 0);
             int slot = resolve_local(c, b->children[0]->symbol);
-            if (slot >= 0) chunk_emit(c, OP_SET_LOCAL, slot);
+            int boxed = 0;
+            for (int li = c->n_locals - 1; li >= 0; li--)
+                if (c->locals[li].slot == slot && c->locals[li].boxed) { boxed = 1; break; }
+            if (slot >= 0 && boxed) {
+                chunk_emit(c, OP_GET_LOCAL, slot);
+                chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL(0)));
+                compile_expr(c, b->children[1], 0);
+                chunk_emit(c, OP_VEC_SET, 0);
+                chunk_emit(c, OP_POP, 0);
+            } else {
+                compile_expr(c, b->children[1], 0);
+                if (slot >= 0) chunk_emit(c, OP_SET_LOCAL, slot);
+            }
         }
     }
     {
@@ -1944,6 +2014,71 @@ static const char* param_name(Node* p) {
     if (p->type == N_LIST && p->n_children >= 1 && p->children[0]->type == N_SYMBOL)
         return p->children[0]->symbol;
     return "";
+}
+
+/**
+ * @brief Heap-box every parameter of the just-opened function chunk @p func
+ *        that is both `set!`-mutated and captured by a nested lambda (SW-25).
+ *
+ * THE DEFECT THIS CLOSES. `compile_form_let()` has always run needs_boxing()
+ * over its bindings, so a `let`-bound variable that an inner lambda mutates
+ * lives in a shared 1-element vector and every closure sees the same cell.
+ * PARAMETERS never got that treatment: compile_form_define(),
+ * compile_form_lambda() and compile_form_lambda_2() called add_local() for
+ * each parameter and went straight to the body. A parameter was therefore
+ * captured BY VALUE — OP_CLOSURE copies the enclosing slot into the closure's
+ * upvalue array — so `(define (f n) ((lambda () (set! n (+ n 1)))) n)` mutated
+ * the closure's private copy and answered 5 where native answers 6, with no
+ * diagnostic.
+ *
+ * The open-slot relay (native calls 151/252) is NOT an alternative here: it
+ * aliases an absolute VM stack slot and is deliberately restricted to the
+ * top-level chunk, because a function's frame is destroyed on return and the
+ * alias would outlive it (see compile_form_lambda_2()). Boxing is the
+ * mechanism that works at every depth, and is what native's mutable-capture
+ * lowering does.
+ *
+ * WHY THE WRAP IS EMITTED, NOT THE BINDING REWRITTEN. A `let` boxes at the
+ * binding site because it computes the value itself; a parameter's value is
+ * placed in the frame by the CALLER, so the box has to be installed at
+ * function entry instead: read the incoming argument, wrap it in a 1-element
+ * vector, store it back into the same slot. Every later read/write of that
+ * name compiles through the boxed paths in compile_expr()/compile_form_set()
+ * because the Local is marked `boxed`, and a nested closure capturing it
+ * copies the BOX pointer — which is exactly the sharing that was missing.
+ *
+ * MUST BE CALLED after all parameters (including a rest parameter and its
+ * OP_PACK_REST) are in place and before any body expression is compiled:
+ * OP_PACK_REST reads the raw argument window `sp - fp`, which the wrap would
+ * otherwise disturb.
+ *
+ * @param func       The callee chunk whose locals are exactly its parameters.
+ * @param body_nodes The function's body expressions.
+ * @param n_bodies   Number of entries in @p body_nodes.
+ */
+static void vm_box_mutable_captured_params(FuncChunk* func, Node* body_nodes[],
+                                           int n_bodies) {
+    if (n_bodies <= 0) return;
+    for (int li = 0; li < func->n_locals; li++) {
+        if (func->locals[li].boxed || !func->locals[li].name) continue;
+        if (!needs_boxing(body_nodes, n_bodies, func->locals[li].name)) continue;
+        int slot = func->locals[li].slot;
+        chunk_emit(func, OP_GET_LOCAL, slot);   /* push the incoming argument */
+        chunk_emit(func, OP_VEC_CREATE, 1);     /* wrap it in a 1-element box */
+        chunk_emit(func, OP_SET_LOCAL, slot);   /* store the box back (pops)   */
+        func->locals[li].boxed = 1;
+    }
+}
+
+/**
+ * @brief Collect the body expressions of a function form into @p out for the
+ *        capture/mutation scan, returning how many were collected.
+ */
+static int vm_collect_body_nodes(Node* node, int body_start, Node** out, int max) {
+    int n = 0;
+    for (int i = body_start; i < node->n_children && n < max; i++)
+        out[n++] = node->children[i];
+    return n;
 }
 
 static void compile_form_define(FuncChunk* c, Node* node, int tail) {
@@ -2010,6 +2145,15 @@ static void compile_form_define(FuncChunk* c, Node* node, int tail) {
         if (node->n_children >= 4 && node->children[2]->type == N_SYMBOL
             && strcmp(node->children[2]->symbol, ":") == 0)
             body_start = 4;
+
+        /* SW-25: a parameter that is `set!`-mutated AND captured by a nested
+         * lambda must be shared through a heap box, exactly as a `let` binding
+         * is; otherwise the closure mutates a private copy. */
+        {
+            Node* body_nodes[64];
+            int n_bodies = vm_collect_body_nodes(node, body_start, body_nodes, 64);
+            vm_box_mutable_captured_params(&func, body_nodes, n_bodies);
+        }
 
         /* Compile body expressions */
         for (int i = body_start; i < node->n_children; i++) {
@@ -2381,6 +2525,14 @@ static void compile_form_lambda(FuncChunk* c, Node* node, int tail) {
     /* Emit PACK_REST 0 at function entry: pack ALL args into list at local 0 */
     chunk_emit(&func, OP_PACK_REST, 0);
 
+    /* SW-25: box the rest parameter when the body both mutates and captures
+     * it (must follow OP_PACK_REST, which reads the raw argument window). */
+    {
+        Node* body_nodes[64];
+        int n_bodies = vm_collect_body_nodes(node, 2, body_nodes, 64);
+        vm_box_mutable_captured_params(&func, body_nodes, n_bodies);
+    }
+
     for (int i = 2; i < node->n_children; i++) {
         int is_last = (i == node->n_children - 1);
         compile_expr(&func, node->children[i], is_last);
@@ -2490,6 +2642,13 @@ static void compile_form_lambda_2(FuncChunk* c, Node* node, int tail) {
         /* At function entry: pack extra args from fp+fixed_params to sp into list */
         chunk_emit(&func, OP_PACK_REST, fixed_params);
         func.param_count = 255; /* sentinel: variadic */
+    }
+
+    /* SW-25: box parameters that the body both `set!`s and captures. */
+    {
+        Node* body_nodes[64];
+        int n_bodies = vm_collect_body_nodes(node, 2, body_nodes, 64);
+        vm_box_mutable_captured_params(&func, body_nodes, n_bodies);
     }
 
     for (int i = 2; i < node->n_children; i++) {
@@ -2651,6 +2810,13 @@ static void compile_form_with_region(FuncChunk* c, Node* node, int tail) {
      * tests/vm_parity/found/with_region_explicit_quote_body_vm.esk and on the
      * op:WITH_REGION row of tests/vm_parity/PARITY.tsv. Every DOCUMENTED
      * spelling agrees on both substrates (corpus/with_region_lowering.esk). */
+    /* SW-14: say so. The form is honest about its VALUE and its EFFECTS but
+     * silent about the one thing the user reached for it to get — the memory
+     * back. Announced once per process; ESHKOL_VM_REGION_QUIET=1 silences it.
+     * Announced at COMPILE time because the form has no runtime footprint on
+     * this substrate at all, which is itself the point. */
+    vm_region_reclaim_notice();
+
     int body_start = 1;
     Node* spec = node->children[1];
     if (is_quoted_symbol(spec)) {

--- a/lib/backend/vm_core.c
+++ b/lib/backend/vm_core.c
@@ -283,7 +283,37 @@ typedef struct {
     HeapObject** objects;    /* array of pointers to arena-allocated objects */
     int32_t next_free;
     int32_t capacity;
+    /* SW-14 growth watchdog. The VM heap has no reclamation of any kind —
+     * `(with-region ...)` is the designated mechanism and is a pass-through on
+     * this substrate (see vm_region_reclaim_notice()), so a long-running VM
+     * program's arena grows monotonically. That growth used to be entirely
+     * silent: correct answers, exit 0, and an RSS curve nobody was told about.
+     * These two fields turn it into a NAMED diagnostic at a budget. */
+    uint32_t alloc_tick;         /* allocations since the last budget probe */
+    int      budget_reported;    /* the budget diagnostic is emitted once */
 } Heap;
+
+/** @return the VM arena budget in bytes past which the growth watchdog speaks,
+ *          or 0 when the watchdog is disabled.
+ *
+ * `ESHKOL_VM_HEAP_BUDGET_MB` overrides the default; `0` disables the watchdog
+ * entirely. The default is deliberately far above any test or ordinary
+ * program, so the diagnostic means "this workload really is growing without
+ * bound", never "this program is big".
+ */
+static size_t vm_heap_budget_bytes(void) {
+    static size_t cached = (size_t)-1;
+    if (cached != (size_t)-1) return cached;
+    cached = (size_t)vm_host_env_long("ESHKOL_VM_HEAP_BUDGET_MB", 1024)
+             * 1024u * 1024u;
+    return cached;
+}
+
+/** @return 1 when crossing the budget must be fatal rather than advisory
+ *          (`ESHKOL_VM_HEAP_BUDGET_FATAL=1`), so a CI lane can gate on it. */
+static int vm_heap_budget_fatal(void) {
+    return vm_host_env_flag("ESHKOL_VM_HEAP_BUDGET_FATAL");
+}
 
 /** @brief Initialize the VM heap: sets up its arena region stack and the
  *         object-pointer table (fixed capacity HEAP_SIZE). */
@@ -292,6 +322,80 @@ static void heap_init(Heap* h) {
     h->capacity = HEAP_SIZE;
     h->objects = (HeapObject**)calloc(h->capacity, sizeof(HeapObject*));
     h->next_free = 0;
+    h->alloc_tick = 0;
+    h->budget_reported = 0;
+}
+
+/** @return total bytes the VM's arenas hold: the global arena plus every open
+ *          region's arena. This is the VM's real memory footprint, because
+ *          nothing is ever returned to the allocator (SW-14). */
+static size_t heap_arena_bytes(const Heap* h) {
+    size_t total = h->regions.global_arena.total_allocated;
+    for (int i = 0; i < h->regions.depth; i++)
+        if (h->regions.stack[i]) total += h->regions.stack[i]->arena.total_allocated;
+    return total;
+}
+
+/**
+ * @brief SW-14 growth watchdog: name the VM's unbounded heap growth once it
+ *        crosses the configured budget, instead of letting it stay silent.
+ *
+ * Sampled every 4096 allocations so the per-allocation cost is a counter
+ * increment and a compare. The message is deliberately specific: it names the
+ * substrate boundary that causes the growth, so a reader does not have to
+ * rediscover that `with-region` reclaims nothing here.
+ */
+static void heap_check_budget(Heap* h) {
+    if (h->budget_reported) return;
+    if (++h->alloc_tick < 4096u) return;
+    h->alloc_tick = 0;
+    size_t budget = vm_heap_budget_bytes();
+    if (budget == 0) return;
+    size_t used = heap_arena_bytes(h);
+    if (used < budget) return;
+    h->budget_reported = 1;
+    fprintf(stderr,
+            "eshkol-vm: heap budget exceeded — %.1f MB of arena allocated "
+            "(budget %.0f MB, ESHKOL_VM_HEAP_BUDGET_MB).\n"
+            "  The bytecode VM does not reclaim heap memory: `(with-region ...)` "
+            "is value- and effect-transparent here but frees nothing, because the "
+            "VM heap has no escape evacuator (docs/KNOWN_ISSUES.md, "
+            "docs/reference/runtime/memory-model.md).\n"
+            "  A long-running workload should use the native engine (eshkol-run) "
+            "until VM reclamation lands; set ESHKOL_VM_HEAP_BUDGET_MB=0 to silence "
+            "this, or ESHKOL_VM_HEAP_BUDGET_FATAL=1 to make it fail closed.\n",
+            (double)used / (1024.0 * 1024.0),
+            (double)budget / (1024.0 * 1024.0));
+    if (vm_heap_budget_fatal()) {
+        fprintf(stderr, "eshkol-vm: ERROR: heap budget is fatal "
+                        "(ESHKOL_VM_HEAP_BUDGET_FATAL=1); terminating.\n");
+        exit(1);
+    }
+}
+
+/**
+ * @brief One-time notice that a region form on the bytecode VM reclaims
+ *        nothing (SW-14).
+ *
+ * `with-region`, `region-open` and `region-close` all resolve and behave
+ * identically on both substrates — same handle protocol, same validation, same
+ * error messages — but on the VM they reclaim no memory. A user who reached
+ * for the memory tool and silently got no memory back is the SILENT half of
+ * SW-14; this notice is the loud half. Emitted at most once per process, on
+ * stderr, and suppressed by `ESHKOL_VM_REGION_QUIET=1`.
+ */
+static void vm_region_reclaim_notice(void) {
+    static int said = 0;
+    if (said) return;
+    said = 1;
+    if (vm_host_env_flag("ESHKOL_VM_REGION_QUIET")) return;
+    fprintf(stderr,
+            "eshkol-vm: note: region forms reclaim no memory on the bytecode VM. "
+            "The body runs and its value is returned exactly as natively, but the "
+            "arena is not freed — the VM heap has no escape evacuator "
+            "(docs/reference/runtime/memory-model.md). Use eshkol-run for "
+            "workloads that depend on reclamation; set ESHKOL_VM_REGION_QUIET=1 "
+            "to silence this note.\n");
 }
 
 /** @brief Allocate a new (zeroed) HeapObject slot from the arena and
@@ -333,6 +437,7 @@ static int32_t heap_alloc(Heap* h) {
     if (!obj) { fprintf(stderr, "ARENA OOM\n"); return -1; }
     memset(obj, 0, sizeof(HeapObject));
     h->objects[h->next_free] = obj;
+    heap_check_budget(h);
     return h->next_free++;
 }
 

--- a/lib/backend/vm_io.c
+++ b/lib/backend/vm_io.c
@@ -31,6 +31,34 @@
 #endif
 #endif
 
+/* ── Host policy hooks ──
+ *
+ * The VM CORE component (lib/backend/vm_core.c and friends) is freestanding by
+ * contract — tests/toolchain/vm_source_boundary_test.cpp fails the build if it
+ * so much as names `getenv(`. Core code that needs a host-configurable policy
+ * knob therefore reads it through these two helpers, which live here in the
+ * HOSTED component and are included ahead of vm_core.c in the unity build
+ * (lib/backend/eshkol_vm.c). A freestanding VM supplies its own stubs.
+ */
+
+/** @return the integer value of environment variable @p name, or @p dflt when
+ *          it is unset, empty or unparseable. Negative values are rejected. */
+static long vm_host_env_long(const char* name, long dflt) {
+    const char* e = getenv(name);
+    if (!e || !*e) return dflt;
+    char* end = NULL;
+    long v = strtol(e, &end, 10);
+    if (end == e || v < 0) return dflt;
+    return v;
+}
+
+/** @return 1 when environment variable @p name is set to anything other than
+ *          the empty string or "0". */
+static int vm_host_env_flag(const char* name) {
+    const char* e = getenv(name);
+    return e && *e && *e != '0';
+}
+
 /* ── Port Types ── */
 
 typedef enum { VM_PORT_FILE, VM_PORT_STRING } VmPortKind;

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -15933,6 +15933,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
      * misused handle observes identical output on both substrates.
      * See tests/vm_parity/PARITY.tsv. */
     case 2210: { /* _region-open(name-or-#f, size-or-#f) -> handle token */
+        vm_region_reclaim_notice();   /* SW-14: the close will reclaim nothing */
         Value size_val = vm_pop(vm), name_val = vm_pop(vm);
         const char* name = NULL;
         uint64_t size_hint = 0;

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -500,6 +500,16 @@ probe define_loop_flat_rss_aot 'ESH-0214b: AOT guard-wrapped define loop keeps R
      ## above a 200MB ceiling.
      bash tests/memory/define_loop_flat_rss_aot_test.sh'
 
+probe vm_region_growth_watchdog 'SW-14 interim guard: the bytecode VM NAMES its unbounded heap growth (with-region reclaims nothing there) instead of growing silently — note, budget diagnostic, fail-closed mode, and no change to answers' \
+    'cd "$REPO_ROOT";
+     ## SW-14: the VM heap has no reclamation at all; (with-region ...) is a
+     ## pass-through because the VM heap has no escape evacuator. Measured at
+     ## the branch point: identical peak RSS with and without the wrapper.
+     ## Reclamation is a separate build item; this probe gates the guard that
+     ## makes the growth LOUD, so the guard cannot be silently removed.
+     out=$(BUILD_DIR="$BUILD_DIR_PATH" bash tests/memory/vm_region_growth_watchdog_test.sh 2>&1) || exit 1;
+     printf "%s" "$out" | grep -q "vm_region_growth_watchdog_test.sh: PASS"'
+
 probe iter_scope_partial_reclaim 'ESH-0214e: resident tick loop that MUTATES persistent state every tick reclaims transient garbage automatically (nursery region) — AOT flat RSS + correct + clean under ESHKOL_ARENA_POISON=1' \
     'cd "$REPO_ROOT";
      ## ESH-0214e: iter-scope partial reclamation. A guard-wrapped self-tail

--- a/tests/differential/corpus/50_mutable_capture_writeback.esk
+++ b/tests/differential/corpus/50_mutable_capture_writeback.esk
@@ -1,0 +1,73 @@
+;; SW-25: a `set!` on a captured parameter (or let*/letrec binding) must write
+;; back through the shared binding cell on every axis, not into a private
+;; by-value copy. Filed reproducer: `(define (f n) ((lambda () (set! n (+ n
+;; 1)))) n)` answered 5 on the bytecode VM and 6 natively.
+;;
+;; The native axes are the reference here; the VM axes are compared against
+;; each other (see tests/differential/README.md) and the VM-vs-native
+;; assertion for the same programs lives in
+;; tests/vm_parity/corpus/62_mutable_capture_writeback.esk.
+;;
+;; A rest parameter (`(define (f . xs) ...)`) is deliberately NOT exercised
+;; here: mutating a captured REST parameter does not write back on the native
+;; axes, which is a distinct, native-side instance of the same family and is
+;; filed separately rather than baked into a gate.
+(define (d1 n) ((lambda () (set! n (+ n 1)))) n)
+(display (d1 5)) (newline)
+
+(define (s1 n) (let ((b (lambda () (set! n (* n 2))))) (b) (b) n))
+(display (s1 3)) (newline)
+
+(define (d3 n) ((lambda () ((lambda () ((lambda () (set! n (+ n 100)))))))) n)
+(display (d3 1)) (newline)
+
+(define (share n)
+  (let ((inc (lambda () (set! n (+ n 1))))
+        (get (lambda () n)))
+    (inc) (inc) (inc) (get)))
+(display (share 0)) (newline)
+
+(define (loopy n)
+  (let lp ((i 0))
+    (if (< i 5) (begin ((lambda () (set! n (+ n i)))) (lp (+ i 1))) n)))
+(display (loopy 0)) (newline)
+
+(define (make-counter n) (lambda () (set! n (+ n 1)) n))
+(define counter-a (make-counter 10))
+(counter-a)
+(counter-a)
+(display (counter-a)) (newline)
+
+(define c1 (make-counter 0))
+(define c2 (make-counter 0))
+(c1)
+(c1)
+(display (c1)) (newline)
+(display (c2)) (newline)
+
+(define anon (lambda (n) ((lambda () (set! n (- n 1)))) n))
+(display (anon 9)) (newline)
+
+(define (ls v) (let* ((x v)) ((lambda () (set! x (+ x 7)))) x))
+(display (ls 1)) (newline)
+
+(define (ls2 v) (let* ((x v) (f (lambda () (set! x (* x 3))))) (f) x))
+(display (ls2 2)) (newline)
+
+(define (lr v) (letrec ((x v)) ((lambda () (set! x (+ x 3)))) x))
+(display (lr 1)) (newline)
+
+(define (lrs v) (letrec* ((x v)) ((lambda () (set! x (+ x 4)))) x))
+(display (lrs 1)) (newline)
+
+;; controls
+(define (plain a) ((lambda (t) (+ a t)) 4))
+(display (plain 6)) (newline)
+
+(define (direct n) (set! n (+ n 1)) n)
+(display (direct 41)) (newline)
+
+(define shadowed 100)
+(define (bump shadowed) ((lambda () (set! shadowed (+ shadowed 1)))) shadowed)
+(display (bump 5)) (newline)
+(display shadowed) (newline)

--- a/tests/memory/vm_region_growth_watchdog_test.esk
+++ b/tests/memory/vm_region_growth_watchdog_test.esk
@@ -1,0 +1,34 @@
+;;; tests/memory/vm_region_growth_watchdog_test.esk — SW-14 fixture, gated by
+;;; vm_region_growth_watchdog_test.sh.
+;;;
+;;; A per-iteration `(with-region ...)` around a body that allocates and then
+;;; drops everything it allocated. This is the shape the memory model
+;;; documents as the way to keep a resident loop flat
+;;; (docs/reference/runtime/memory-model.md), and it IS flat natively.
+;;;
+;;; On the bytecode VM it is not flat, and nothing about the program says so:
+;;; the answer is right, the exit status is 0, and RSS climbs until the host
+;;; gives out. Measured at the branch point, this fixture peaks at the same
+;;; RSS with the `with-region` wrapper as without it — the form reclaims
+;;; nothing there.
+;;;
+;;; The gate around this file asserts the interim guard: that the growth is
+;;; NAMED. Keep the allocation volume high enough to cross a 64 MB budget
+;;; quickly and low enough to finish fast.
+(define (scratch-step k)
+  (with-region ('step 65536)
+    (let loop ((i 0) (acc '()))
+      (if (< i 120)
+          (loop (+ i 1) (cons (* i k) acc))
+          (length acc)))))
+
+(define (drive n total)
+  (if (= n 0)
+      total
+      (drive (- n 1) (+ total (scratch-step n)))))
+
+;; 4000 iterations x 120 conses: enough arena to cross a 64 MB budget on every
+;; supported host, and the sum is a pure function of the loop bounds so the
+;; printed answer pins that the guard changed no behaviour.
+(display (drive 4000 0))
+(newline)

--- a/tests/memory/vm_region_growth_watchdog_test.sh
+++ b/tests/memory/vm_region_growth_watchdog_test.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# tests/memory/vm_region_growth_watchdog_test.sh — SW-14 interim guard gate.
+#
+# WHAT SW-14 IS. The bytecode VM has no heap reclamation of ANY kind:
+# `(with-region ...)` is the designated mechanism and is a pure pass-through
+# there, because the VM heap has no escape evacuator to promote a kept value
+# out with (docs/KNOWN_ISSUES.md, docs/reference/runtime/memory-model.md,
+# lib/backend/vm_compiler.c::compile_form_with_region). Measured on this
+# fixture at the branch point: peak RSS is IDENTICAL with and without the
+# `with-region` wrapper — 1.503 GB either way — so the form buys the user
+# nothing and said nothing about it. Correct answers, exit 0, no diagnostic:
+# the definition of SILENT.
+#
+# WHAT THIS GATE PINS. Not reclamation — reclamation is a separate build item
+# (a VM-heap escape evacuator; see the SW-14 entry in
+# .icc/silent-wrong-ledger.yaml). This gate pins the INTERIM guard that
+# converts the silence into a named diagnostic, and it is written so that it
+# FAILS if that guard is ever removed or quietly downgraded:
+#
+#   1. loud-note      a region form on the VM announces, once, that it
+#                     reclaims nothing here.
+#   2. note-silenced  ESHKOL_VM_REGION_QUIET=1 suppresses that note (so the
+#                     note is a diagnostic, not unavoidable noise).
+#   3. loud-growth    crossing ESHKOL_VM_HEAP_BUDGET_MB names the growth,
+#                     the budget and the cause on stderr.
+#   4. fail-closed    ESHKOL_VM_HEAP_BUDGET_FATAL=1 turns that into a nonzero
+#                     exit, so a lane can gate on it.
+#   5. budget-off     ESHKOL_VM_HEAP_BUDGET_MB=0 disables the watchdog.
+#   6. answers        the guard changes no answer: the same program prints the
+#                     same value with the watchdog on, off and fatal-off.
+#
+# Usage: tests/memory/vm_region_growth_watchdog_test.sh
+#   BUILD_DIR env var selects the build directory (default: build).
+set -u
+export LC_ALL=C LC_CTYPE=C LANG=C
+cd "$(dirname "$0")/../.."
+REPO_ROOT="$(pwd)"
+
+BUILD_DIR="${BUILD_DIR:-build}"
+case "$BUILD_DIR" in
+    /*) VM="$BUILD_DIR/eshkol-vm-standalone-test" ;;
+    *)  VM="$REPO_ROOT/$BUILD_DIR/eshkol-vm-standalone-test" ;;
+esac
+if [ ! -x "$VM" ]; then
+    echo "vm_region_growth_watchdog_test.sh: $VM not found — run \`cmake --build $BUILD_DIR\` first." >&2
+    exit 2
+fi
+
+SRC="$REPO_ROOT/tests/memory/vm_region_growth_watchdog_test.esk"
+if [ ! -f "$SRC" ]; then
+    echo "vm_region_growth_watchdog_test.sh: $SRC not found." >&2
+    exit 2
+fi
+
+# Same convention as the other memory gates (define_loop_flat_rss_aot_test.sh):
+# an ephemeral working directory, removed by the trap on every exit path. Total
+# footprint is a few KB of captured stdout/stderr.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-vm-region-watchdog.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+PASS=0
+FAIL=0
+check() { # name condition-description result(0=ok)
+    if [ "$3" -eq 0 ]; then
+        echo "PASSED tests/memory/vm_region_growth_watchdog_test.sh::$1"
+        PASS=$((PASS + 1))
+    else
+        echo "FAILED tests/memory/vm_region_growth_watchdog_test.sh::$1 — $2"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Every compared run sets ESHKOL_VM_NO_DISASM=1 so stdout is the program's own
+# output rather than the VM's disassembly dump; reduce it to the digits printed.
+export ESHKOL_VM_NO_DISASM=1
+answer_of() { tr -cd '0-9' < "$1"; }
+
+echo "  SW-14 interim guard: VM region growth watchdog"
+
+# ── 1/2. the region note, and its silencer ────────────────────────────────
+ESHKOL_VM_HEAP_BUDGET_MB=0 "$VM" "$SRC" >"$WORK/note.out" 2>"$WORK/note.err"
+grep -q "reclaim no memory on the bytecode VM" "$WORK/note.err"
+check loud_note "a VM region form did not announce that it reclaims nothing" $?
+
+ESHKOL_VM_HEAP_BUDGET_MB=0 ESHKOL_VM_REGION_QUIET=1 \
+    "$VM" "$SRC" >"$WORK/quiet.out" 2>"$WORK/quiet.err"
+if grep -q "reclaim no memory on the bytecode VM" "$WORK/quiet.err"; then rc=1; else rc=0; fi
+check note_silenced "ESHKOL_VM_REGION_QUIET=1 did not suppress the region note" $rc
+
+# ── 3. the growth watchdog speaks ─────────────────────────────────────────
+ESHKOL_VM_HEAP_BUDGET_MB=64 "$VM" "$SRC" >"$WORK/budget.out" 2>"$WORK/budget.err"
+BUDGET_RC=$?
+grep -q "heap budget exceeded" "$WORK/budget.err"
+check loud_growth "crossing ESHKOL_VM_HEAP_BUDGET_MB produced no diagnostic" $?
+
+grep -q "does not reclaim heap memory" "$WORK/budget.err"
+check names_cause "the budget diagnostic does not name the VM's missing reclamation" $?
+
+if [ "$BUDGET_RC" -eq 0 ]; then rc=0; else rc=1; fi
+check advisory_by_default "the budget diagnostic is fatal without ESHKOL_VM_HEAP_BUDGET_FATAL" $rc
+
+# ── 4. fail-closed mode ───────────────────────────────────────────────────
+ESHKOL_VM_HEAP_BUDGET_MB=64 ESHKOL_VM_HEAP_BUDGET_FATAL=1 \
+    "$VM" "$SRC" >"$WORK/fatal.out" 2>"$WORK/fatal.err"
+FATAL_RC=$?
+if [ "$FATAL_RC" -ne 0 ]; then rc=0; else rc=1; fi
+check fail_closed "ESHKOL_VM_HEAP_BUDGET_FATAL=1 still exited 0 past the budget" $rc
+
+# ── 5. the watchdog can be turned off ─────────────────────────────────────
+if grep -q "heap budget exceeded" "$WORK/note.err"; then rc=1; else rc=0; fi
+check budget_off "ESHKOL_VM_HEAP_BUDGET_MB=0 did not disable the watchdog" $rc
+
+# ── 6. the guard changes no answer ────────────────────────────────────────
+A_OFF="$(answer_of "$WORK/note.out")"
+A_QUIET="$(answer_of "$WORK/quiet.out")"
+A_BUDGET="$(answer_of "$WORK/budget.out")"
+if [ -n "$A_OFF" ] && [ "$A_OFF" = "$A_QUIET" ] && [ "$A_OFF" = "$A_BUDGET" ]; then rc=0; else rc=1; fi
+check answers_unchanged "the guard changed the program's output ('$A_OFF' / '$A_QUIET' / '$A_BUDGET')" $rc
+
+echo "  vm-region-watchdog: $PASS passed, $FAIL failed"
+if [ "$FAIL" -eq 0 ]; then
+    echo "vm_region_growth_watchdog_test.sh: PASS"
+    exit 0
+fi
+echo "vm_region_growth_watchdog_test.sh: FAIL"
+exit 1

--- a/tests/vm_parity/corpus/56_lexical_shadow_nearest_binding.esk
+++ b/tests/vm_parity/corpus/56_lexical_shadow_nearest_binding.esk
@@ -57,13 +57,13 @@
 ;; same wrong order, so it assigned main's slot and this printed 101.
 ;;
 ;; Only the top-level binding is asserted here, deliberately.  Reading the
-;; mutated value BACK out of the parameter exercises a separate, pre-existing
-;; VM gap -- `set!` on a captured parameter from inside a closure does not
-;; propagate to the enclosing frame, so `(define (f n) ((lambda () (set! n (+ n
-;; 1)))) n)` returns the unincremented n on the VM and the incremented one
-;; natively, with no shadowing involved at all and on unmodified master.  That
-;; is a boxing/upvalue-writeback defect in its own right; asserting it here
-;; would make this file red for a defect it is not about.
+;; mutated value BACK out of the parameter is a SEPARATE defect (SW-25:
+;; `set!` on a captured parameter mutated a private by-value copy, so
+;; `(define (f n) ((lambda () (set! n (+ n 1)))) n)` returned the
+;; unincremented n on the VM), which is now fixed by boxing mutable captured
+;; parameters and asserted on its own in
+;; tests/vm_parity/corpus/62_mutable_capture_writeback.esk.  This file stays
+;; about shadowing.
 (define ss 100)
 (define (bump ss) ((lambda () (set! ss (+ ss 1)))) 0)
 (display (bump 5))

--- a/tests/vm_parity/corpus/62_mutable_capture_writeback.esk
+++ b/tests/vm_parity/corpus/62_mutable_capture_writeback.esk
@@ -1,0 +1,115 @@
+;; SW-25 -- `set!` on a captured PARAMETER must write back through the shared
+;; binding, on the VM exactly as natively.
+;;
+;; THE DEFECT. `(define (f n) ((lambda () (set! n (+ n 1)))) n)` answered 5 on
+;; the bytecode VM where native answers 6: silently, exit 0, no diagnostic.
+;; compile_form_let() had always run needs_boxing() over its bindings, so a
+;; `let`-bound variable that is both `set!`-mutated and captured by a nested
+;; lambda lives in a shared 1-element vector.  PARAMETERS never got that
+;; treatment -- compile_form_define(), compile_form_lambda() and
+;; compile_form_lambda_2() bound each parameter with add_local() and went
+;; straight to the body -- so OP_CLOSURE copied the parameter's value into the
+;; closure's upvalue array and the inner `set!` mutated a private copy.
+;;
+;; The same gap existed in `let*`, `letrec` and `letrec*`, which is why they
+;; are exercised here too: one root cause, four binding forms.
+;;
+;; Every line below is a native-vs-VM differential.  Numeric and list output
+;; only: the VM prints a procedure as <closure@N> where native prints its
+;; source form, so no procedure is ever displayed.
+
+;; -- the filed reproducer: immediately-invoked closure, depth 1 -------------
+(define (d1 n) ((lambda () (set! n (+ n 1)))) n)
+(display (d1 5))
+(newline)
+
+;; -- a STORED closure called twice, so the writeback must accumulate --------
+(define (s1 n) (let ((b (lambda () (set! n (* n 2))))) (b) (b) n))
+(display (s1 3))
+(newline)
+
+;; -- depth 2 and depth 3: the box must relay through every intervening chunk
+(define (d2 n) ((lambda () ((lambda () (set! n (+ n 10)))))) n)
+(display (d2 1))
+(newline)
+
+(define (d3 n) ((lambda () ((lambda () ((lambda () (set! n (+ n 100)))))))) n)
+(display (d3 1))
+(newline)
+
+;; -- TWO closures over ONE capture: the mutator and the reader must agree ---
+(define (share n)
+  (let ((inc (lambda () (set! n (+ n 1))))
+        (get (lambda () n)))
+    (inc) (inc) (inc) (get)))
+(display (share 0))
+(newline)
+
+;; -- mutation from inside a loop -------------------------------------------
+(define (loopy n)
+  (let lp ((i 0))
+    (if (< i 5) (begin ((lambda () (set! n (+ n i)))) (lp (+ i 1))) n)))
+(display (loopy 0))
+(newline)
+
+;; -- a closure that OUTLIVES the frame that bound the parameter -------------
+;; The box is heap-allocated, so the counter keeps counting after make-counter
+;; has returned; the stack-slot alias the VM uses at top level could not.
+(define (make-counter n) (lambda () (set! n (+ n 1)) n))
+(define counter-a (make-counter 10))
+(counter-a)
+(counter-a)
+(display (counter-a))
+(newline)
+
+;; -- two instantiations must NOT share one box -----------------------------
+(define c1 (make-counter 0))
+(define c2 (make-counter 0))
+(c1)
+(c1)
+(display (c1))
+(newline)
+(display (c2))
+(newline)
+
+;; -- a `lambda` parameter, not a `define` parameter -------------------------
+(define anon (lambda (n) ((lambda () (set! n (- n 1)))) n))
+(display (anon 9))
+(newline)
+
+;; -- let* : the binding is in scope for later initializers AND the body -----
+(define (ls v) (let* ((x v)) ((lambda () (set! x (+ x 7)))) x))
+(display (ls 1))
+(newline)
+
+(define (ls2 v) (let* ((x v) (f (lambda () (set! x (* x 3))))) (f) x))
+(display (ls2 2))
+(newline)
+
+;; -- letrec / letrec* : the box is created before any initializer runs ------
+(define (lr v) (letrec ((x v)) ((lambda () (set! x (+ x 3)))) x))
+(display (lr 1))
+(newline)
+
+(define (lrs v) (letrec* ((x v)) ((lambda () (set! x (+ x 4)))) x))
+(display (lrs 1))
+(newline)
+
+;; -- controls: an unmutated capture must still read by value ---------------
+(define (plain a) ((lambda (t) (+ a t)) 4))
+(display (plain 6))
+(newline)
+
+;; -- control: a parameter mutated WITHOUT being captured stays unboxed ------
+(define (direct n) (set! n (+ n 1)) n)
+(display (direct 41))
+(newline)
+
+;; -- control: mutation of a captured parameter must not leak to a same-named
+;; top-level binding (the SW-24/PR #428 shadowing family, re-asserted here) --
+(define shadowed 100)
+(define (bump shadowed) ((lambda () (set! shadowed (+ shadowed 1)))) shadowed)
+(display (bump 5))
+(newline)
+(display shadowed)
+(newline)


### PR DESCRIPTION
Two VM-engine defects from `.icc/silent-wrong-ledger.yaml`. **One is fixed at the
root; the other carries the measurement that changes what it is, ships the guard
that closes its *silent* half, and is now dispositioned by maintainer ruling
(2026-08-13) as the v1.3.5 flagship item.**

## SW-25 — FIXED

```scheme
(define (f n) ((lambda () (set! n (+ n 1)))) n)
(display (f 5))          ; VM 5, native 6 — silently, exit 0, no diagnostic
```

### Root cause

`compile_form_let()` (`lib/backend/vm_compiler.c`) has always run
`needs_boxing()` (`lib/backend/vm_parser.c:941`) over its bindings, so a
`let`-bound variable that is both `set!`-mutated **and** captured by a nested
lambda lives in a shared 1-element vector and every closure reads and writes the
same cell.

**Parameters never got that treatment.** `compile_form_define()` (the
fixed-parameter loop), `compile_form_lambda()` and `compile_form_lambda_2()`
called `add_local()` for each parameter and went straight to the body, so
`OP_CLOSURE` copied the parameter's **value** into the closure's upvalue array
and the inner `set!` mutated a private copy that was discarded on return.

The open-slot relay (native calls 151/252) is not an alternative: it aliases an
absolute VM stack slot and is deliberately restricted to the top-level chunk,
because a function's frame is destroyed on return and the alias would outlive
it.

### Fix

`vm_box_mutable_captured_params()` heap-boxes every parameter `needs_boxing()`
reports as mutated-and-captured, emitting `GET_LOCAL` / `VEC_CREATE 1` /
`SET_LOCAL` at function entry — **after** `OP_PACK_REST`, which reads the raw
argument window — and marking the `Local` `boxed`, so every later read and write
compiles through the existing boxed paths and a nested closure captures the
**box**.

The same gap existed in three more binding forms, all closed with the same
mechanism:

| form | what was wrong |
|---|---|
| `let*` | doc comment literally said *"No mutable-capture boxing (unlike plain `let`)"*; scan now widened to the later initializers plus the body, because a `let*` binding is in scope for both |
| `letrec` | box created with the placeholder, before any initializer runs, so the box pointer is already final when an initializer's closure captures it; initializers store through `VEC_SET` |
| `letrec*` | same |

No new opcode, no ABI change, `eskb` round-trips unchanged.

### Class-kill

`tests/vm_parity/corpus/62_mutable_capture_writeback.esk` — byte-identical VM vs
native on every line: depths 1-3, stored **and** immediately-invoked closures,
two closures sharing one capture, mutation from inside a loop, a closure that
outlives the frame that bound the parameter, `lambda` as well as `define`
parameters, two instantiations *not* sharing a box, `let*`/`letrec`/`letrec*`,
plus controls (unmutated capture, mutated-but-uncaptured parameter, and the
SW-24/#428 shadowing control).
`tests/differential/corpus/50_mutable_capture_writeback.esk` covers the native
axes.

**Revert-validated**: restoring `lib/backend/vm_compiler.c` alone reproduces
VM 5.

### Two adjacent defects found while class-killing, deliberately NOT baked into a gate

Both are **native-side** and out of this entry's scope; recorded in the ledger so
the next pass starts from measurement rather than rediscovery:

1. a mutated+captured **rest** parameter does not write back on the native axes —
   `(define (r . xs) ((lambda () (set! xs (cons 99 xs)))) (car xs))` is `99` on
   the VM after this fix and `1` natively;
2. `(do ((i 0 (+ i 1)) (acc 0)) ((= i 3) acc) ((lambda () (set! acc (+ acc i)))))`
   is killed by SIGKILL (exit 137) natively.

A third, pre-existing and **loud** (so not silent-wrong): an internal
`(define (bump) (set! n ...))` capturing an enclosing parameter is a fatal VM
runtime error on unmodified master.

## SW-14 — LOUD-LIMITATION, silent half closed, evacuator ruled to v1.3.5

### The measurement changes what the entry is

The same 20000 × 200-cons fixture, `/usr/bin/time -l` peak RSS at `2ae3787f`:

| | peak RSS |
|---|---|
| **with** the `with-region` wrapper | 1,503,297,536 bytes |
| **without** it | 1,504,067,584 bytes |

The wrapped run is fractionally *smaller* — the difference is allocator noise.
`with-region` does not reclaim less than native, it reclaims **nothing**, and so
does everything else: **the bytecode VM has no heap reclamation of any kind.**
`heap_alloc()` bump-allocates from an arena that is never released and hands out
a monotone object index that is never recycled; `vm_region_pop()` exists
(`lib/backend/vm_arena.h`) but no bytecode calls it, because
`compile_form_with_region()` lowers the form to `begin`.

### Why it is not fixed here

A correct fix is a **VM-heap escape evacuator** — a campaign the size of the
native ESH-0214c/ESH-0214d work, not a patch. It needs, at minimum:

1. **root enumeration** over the operand stack plus ~15 `Value`-carrying side
   tables in `struct VM` (`outputs`, `handler_stack.promise_mark`,
   `current_exception`, `wind_stack`, `parameter_bindings`, `promise_eval_head`,
   `lru_caches`, `event_emitters`, `channels`, `timers`, `exit_handlers`, …) — a
   missed root frees live memory;
2. **per-subtype interior traversal** for all 27 `HeapType`s and their arena
   payloads (`VmVector.items`, `VmString.data`, `VmBignum.limbs`,
   `VmSubstitution.terms`, `VmFact.args`/`datum_ptr`, `VmFactorGraph`'s five
   pointer arrays, `VmContinuation`'s six saved arrays, `VmParameter.save_stack`,
   …) — exactly the coverage problem ESH-0214d had to close natively, which
   still carries a documented watchlist there;
3. a **mutation write barrier** at every channel that can store a `Value` into a
   longer-lived container (~130 candidate sites across `vm_native.c`/`vm_run.c`),
   or a full mark from roots in its place;
4. **index-space recycling or compaction**, because the object-table index is a
   monotone counter — freeing only the arena still leaks 8 bytes per object and
   still terminates at `ESHKOL_VM_HEAP_MAX_SIZE`.

**A partial implementation is strictly worse than the defect.** Natively a missed
escape dangles into freed arena memory; on the VM it aliases a *live* object
through a recycled index and yields a silently **wrong value**. Landing that
under a SILENT-WRONG closure would invert the ledger's own contract.

### What does land: the silent half

Neither guard changes any answer.

- The first region form executed on the VM prints a **one-time note** naming the
  boundary (`vm_region_reclaim_notice()`), from both
  `compile_form_with_region()` and native 2210 `region-open`.
  `ESHKOL_VM_REGION_QUIET=1` silences it.
- The VM arena is sampled every 4096 allocations; crossing
  `ESHKOL_VM_HEAP_BUDGET_MB` (default 1024) prints a diagnostic naming the size,
  the budget and the cause (`heap_check_budget()`).
  `ESHKOL_VM_HEAP_BUDGET_FATAL=1` makes it exit nonzero so a lane can gate on it;
  `ESHKOL_VM_HEAP_BUDGET_MB=0` disables it.

The env knobs are read through host hooks in the **hosted** `vm_io.c`, because
the VM **core** component is freestanding by contract —
`tests/toolchain/vm_source_boundary_test.cpp` fails the build if `vm_core.c` so
much as names `getenv(`.

Gated by `tests/memory/vm_region_growth_watchdog_test.sh` (8 checks) and the
icc-smoke probe `vm_region_growth_watchdog`, so the guard cannot be removed
silently. Documented in `docs/KNOWN_ISSUES.md`,
`docs/reference/runtime/memory-model.md` and
`docs/reference/runtime/environment-variables.md`.

### Maintainer ruling 2026-08-13 — applied

**The loud guard ships for v1.3.4.** The full VM evacuator is the **v1.3.5
flagship item**: an OALR Stage-1 port of the native design — Cheney-style
copying evacuation with a forwarding map and a mutation write barrier — with all
27 heap subtypes **deep-walked rather than leaf-copied**. That last clause is the
ESH-0214d lesson written into the scope up front: natively, the subtypes left as
shallow leaf copies were exactly the ones that had to be reopened later.

Applied in the second commit:

**1. Docs — a ruled walk-back of an overclaim.** The docs promised region
reclamation *engine-neutrally*, which was true of the native engine and false of
the VM. Nothing the native engine does has changed and the VM never reclaimed;
what changes is that the pages now say which engine they mean.
`docs/reference/runtime/memory-model.md` gains a **Which engine reclaims**
section directly under the title — an engine/binary/reclamation table, the
measured RSS pair, and the rule that *unless a section says otherwise, every
reclamation statement on the page describes the native engine* — plus scoping on
the four remaining neutral claims in its body. Also corrected: `README.md`
(release blurb, OALR feature section, both `with-region` samples, the v1.3.1
history line), `docs/API_REFERENCE.md` (the canonical `with-region` definition),
`docs/FAQ.md`, `docs/COMPLETE_LANGUAGE_SPECIFICATION.md` (6.1.1 and the 6.2.1
semantics list), `docs/KNOWN_ISSUES.md`, `docs/reference/runtime/INDEX.md`,
`docs/LONG_RUNNING_LOOPS.md`, `docs/tutorials/WHY_ESHKOL.md`,
`docs/ESHKOL_LANGUAGE_GUIDE.md`, `docs/ESHKOL_V1_ARCHITECTURE.md`,
`docs/internal/ESHKOL_V1_LANGUAGE_REFERENCE.md`.

**Deliberately not edited, reported instead** — `ANNOUNCEMENT.md`, `press/*`,
`CHANGELOG.md` and `RELEASE_NOTES.md` are published or historical records of
shipped releases (correcting them is history revision, not a doc fix), and
`site/static/content/*.html` is generated by `scripts/build-site.sh` and gated by
`scripts/verify_site_release.py`. All four are also modified in the maintainer's
working tree. Exact file/line inventory is in a comment below.

**2. Ledger.** SW-14 moves `SILENT-WRONG` -> `LOUD-LIMITATION`, **stays OPEN**,
disposition *"v1.3.5 flagship: VM OALR Stage-1 evacuator port"*, with the RSS
measurements as evidence. A `LOUD-LIMITATION` bucket is defined in the ledger's
own vocabulary: *a capability the engine does not implement, which announces
itself at the point of use and again when it starts to bite* — distinct from
`LOUD-ERROR`, which fails; a LOUD-LIMITATION succeeds while doing less than the
surface suggests, so the announcement **is** the honesty. Admissible only by
maintainer ruling and only once the announcement is gated by a test that fails if
it is removed.

The move is a change of **category, not a claim that anything was fixed**, and it
is **not a waiver** — waivers expire, this has a build item. The entry carries
`reclassified` (from/to/on/by/why) and `ruling` (date, decision, consequences) so
it is auditable, plus a `close_condition` that forbids closing by assertion: the
fixture's peak RSS must go flat, with region-escape semantics preserved and all
27 subtypes covered by a deep-walk test.

**Effect on the release gate:** SW-14 stops gating the tag.
`scripts/gate_no_silent_wrong.py` blocking count **13 -> 12**; the 12 that remain
are untouched by this branch.

## Rebase onto master (#431, #433, #436, #437, #441)

**One content conflict**, `.icc/silent-wrong-ledger.yaml`: master's SW-26
(closed by #433) landed exactly where this branch inserts SW-25. Resolved as a
union in id order — both closed, both survive. SW-14's LOUD-LIMITATION
reclassification applied cleanly on top. `lib/backend/vm_compiler.c` and
`lib/backend/vm_native.c` auto-merged. No `.swarm/` hunks exist on this branch,
so #441 required nothing.

**Corpus renumbered — the part that would have gone wrong silently.** These two
files were `59_` (vm_parity) and `47_` (differential); master's #433 has since
taken both numbers for `vector_ref_tensor_indexed_access`. They are *added*
files with *different* names at the same index, so **git reports no conflict**:
the tree would have carried two `59_` and two `47_` files and the numbering
would have quietly stopped being a total order. Renumbered to **`62_`** and
**`50_`** — next free on master once #438's pending `61_`/`49_` are accounted
for — with every cross-reference rewritten through a simultaneous sentinel
mapping so no intermediate name could collide. Provenance is recorded in the
SW-25 entry's `renumbered` field, not only in the commit message.

## Gates

Clean rebuild (`cmake --fresh` + `--clean-first`), RelWithDebInfo, LLVM 21,
arm64-apple-darwin24.1.0.

| gate | result |
|---|---|
| `ctest --test-dir build` | **173/173** |
| `scripts/run_vm_parity.sh` | **164/164** |
| `scripts/run_differential.sh` | **306/306** axis pairs over 51 programs |
| `tests/memory/vm_region_growth_watchdog_test.sh` | **8/8** |
| `scripts/gate_no_silent_wrong.py` | **11 -> 10** blockers vs master; single delta is SW-14 |

Re-run on the rebased tree after a clean `--fresh` + `--clean-first` rebuild.
The single blocking delta is SW-14's ruled reclassification to
`LOUD-LIMITATION`; SW-25 was never on master and is added closed.

The one FAIL is `no_open_silent_wrong`, red on this branch **exactly as it is on
`master`**: 13 open unwaived SILENT-WRONG entries, unchanged by this PR (SW-25
moves from absent to `closed`; SW-14 was already open). Verified with
`python3 scripts/gate_no_silent_wrong.py` before and after — same 13 names.

Three probes are worth quoting because they are the ones that would catch this
change going wrong:

- `surface_parity_execution_backed` — **2507 probed / 318 divergences / 0 new**.
  The ratchet holds; this PR adds no surface divergence.
- `language_surface_coverage_floor` — **1091/1091 constructs execution-backed,
  100.00%, policy floor PASS, deficit ratchet PASS, high-risk uncovered 0**.
  This probe first recorded FAIL inside a smoke run that had three other
  worktrees executing the same sweep concurrently on the host; re-run in
  isolation it exits 0 with the numbers above, and every guard it wraps passes
  standalone (`gen_language_surface.py --check` OK,
  `test_language_coverage_gate.py` 17/17,
  `test_runtime_language_coverage.py` 14/14). Recorded as a contention
  false-red, attributed rather than assumed.
- `p8_escape_matrix_green` — all 8 axes PASS, including axis-3 (native-vs-VM
  arity parity ratchet, no NEW divergence) and axis-8 (flat-RSS invariant across
  workload shapes).

The smoke run itself was interrupted at probe 60 by the host; probes 60-62
(`p8_escape_matrix_green`, `event_loop_works`, `no_open_silent_wrong`) were
therefore executed directly and are reported above.
