### PR TITLE
fix(oracle): restore completion-oracles.yaml parse — #429's criterion lacked its runtime_event opener

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -220,6 +220,9 @@ oracles:
           event_values: ["PASS"]
         severity: high
         label: 'AD capture scoping: a differentiand lambda capturing its enclosing function''s parameter is never substituted by a same-named top-level global — and the cached (-r AOT) and uncached (in-process JIT) routes produce byte-identical output (task #114)'
+        action: ./scripts/run_icc_smoke.sh
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
           event_names: ["higher_order_shadowing_oracle"]
           event_values: ["PASS"]
         severity: high


### PR DESCRIPTION
## Summary
- `.icc/completion-oracles.yaml` does not parse on `master`, broken by #429
  (`fix(codegen): higher-order builtins ignore shadowing bindings`, merged as
  2ae3787f). This blocks `icc readiness` (reads `blocked`/85) and therefore
  the v1.3.4 release gate.
- #429 added its `higher_order_shadowing_oracle` criterion but omitted the
  preceding criterion's `action:` field plus the new criterion's list-item
  `- runtime_event:` opener. The new criterion's keys landed inside the
  previous criterion's `runtime_event:` mapping, duplicating it and breaking
  the YAML (`ParserError: while parsing a block mapping expected <block end>,
  but found <block mapping start>`, line 217 col 9 -> line 223 col 11).
- This surgical 3-line patch restores the missing `action:` line and the new
  `- runtime_event:` opener, exactly as posted in the SW-25 comment on #435.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.icc/completion-oracles.yaml'))"` parses cleanly (top-level key: `oracles`, a list).
- [x] `icc index` + `icc readiness --target eshkol-compiler-readiness` on this branch loads the oracle file without a parse error: `completion_oracle.oracle_source` resolves, `criterion_count: 41`. (Still reports `blocked`/low score because runtime traces were not regenerated in this worktree — that is expected and out of scope here; the point is it no longer fails on YAML parse.)
- [x] Confirmed both criteria now appear as distinct, well-formed entries with correct label/severity/action:
  - `ad_capture_global_shadow_oracle` ("AD capture scoping: ...", task #114)
  - `higher_order_shadowing_oracle` ("Lexical scope in higher-order builtins: ...", ESH-0070 class) — #429's criterion, now semantically intact and separated from its neighbor.
- [x] Diff is exactly 3 lines added, touching only `.icc/completion-oracles.yaml`.

Not merging — opening for review per release-gate process.