### PR TITLE
fix(codegen): rest-parameter capture writeback + do-loop captured-var crash

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -705,6 +705,123 @@ entries:
       defect: (zset-union …) in core.dbsp SIGSEGVs in CALL POSITION too, so it is a
       different bug and this entry's oracle can say nothing about it.
 
+  - id: SW-33
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "2ae3787f"
+    closed_by: "branch fix/native-rest-capture-and-do-loop"
+    title: "NATIVE: a mutated + captured REST parameter does not write back; the closure mutates a private copy"
+    repro: "(define (f . rest) ((lambda () (set! rest (cons 99 rest)))) (car rest)) (display (f 1 2 3))"
+    observed: "native 1 — exit 0, no diagnostic, on every native axis"
+    correct: "99"
+    cross_engine: >-
+      the VM is wrong the same way at this SHA (also 1) and is fixed on the
+      SW-25 branch fix/vm-region-and-upvalue, measured with that branch's build:
+      VM 99. So the two halves of one class are closed by two PRs; neither
+      engine is the oracle for the other here, which is why this entry's gates
+      are the four NATIVE axes and an absolute expected value, not a parity
+      comparison.
+    discovered_by: >-
+      recorded as adjacent finding (1) in SW-25's notes while class-killing the
+      VM half. Measured rather than rediscovered.
+    root_cause: >-
+      ASSIGNMENT CONVERSION (ESH-0074) boxes a set!-mutated parameter into an
+      alloca so that (a) codegenSet has a storage location and (b) every closure
+      capturing it shares ONE cell — codegenLambda's capture emission then
+      pointer-passes that alloca instead of copying its value. Both boxing loops
+      iterated only the FIXED parameters: lib/backend/llvm_codegen.cpp:12692
+      (codegenFunctionDefinition, `for i < op->define_op.num_params`) and
+      lib/backend/llvm_codegen.cpp:29678 (codegenLambda, same shape). The REST
+      parameter is the LLVM argument that FOLLOWS the fixed ones — the
+      symbol-table loops twenty lines above each site walk exactly that order —
+      so it never got a box, stayed a by-value Argument, and the closure copied
+      the list VALUE into its environment slot. The inner set! then mutated a
+      private copy discarded on return, while the outer read still read the raw
+      Argument. Confirmed in IR: `define @f(%eshkol_tagged_value %rest)` with
+      `store %rest, ptr %<env slot>` and `(car rest)` reading `%rest` directly,
+      versus the boxed `%n = alloca` a fixed parameter gets.
+      The outer guards also required `op->define_op.parameters` /
+      `op->lambda_op.parameters` to be non-null, so a rest-ONLY signature could
+      not have been reached even if the loop had run.
+    fix: >-
+      Both sites now box the rest parameter on the same terms as a fixed one —
+      `astSetsVar(body, rest_param)` decides, the box is the alloca that the
+      iterator already points at after the fixed loop, and the outer guard no
+      longer requires a non-empty fixed parameter list. No new mechanism, no ABI
+      change: the existing capture machinery pointer-passes the box because it
+      is an alloca like any other.
+    evidence: >-
+      tests/integration/rest_capture_and_do_closure_test.esk, 23/23 checks on
+      all four native axes (ctest lanes rest_capture_and_do_closure_{smoke,
+      nocache_smoke,aot_o0_smoke,aot_o2_smoke}); the rest-parameter half covers
+      depths 1-3, immediately-invoked AND stored closures, a closure that
+      outlives the frame that bound the rest parameter, two closures sharing one
+      cell, two instantiations NOT sharing one, `lambda` as well as `define`
+      rest parameters, a rest parameter after two fixed parameters, and the two
+      controls (mutated-but-uncaptured, captured-but-unmutated).
+      tests/differential/corpus/48_rest_capture_and_do_closure.esk covers the
+      native axes.
+      Revert-validated against a build of the same tree without the codegen
+      change (worktree eshkol-wt-vmmem, whose diff touches no native codegen):
+      it answers 1 for the reproducer and cannot compile the class-kill test at
+      all, refusing with "set!: variable 'xs' is not mutable (not an alloca,
+      global, or capture pointer)".
+    caught_by: [direct-measurement, sw-25-adjacent-finding]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity, differential-corpus, KNOWN_ISSUES]
+    notes: >-
+      Same FAMILY as SW-25 — a binding is not honoured across a closure boundary
+      because there is no shared CELL — but the opposite engine and a different
+      omission: the VM's parameter loop never boxed ANY parameter, native's
+      boxed every parameter except the one the loop bound could not reach.
+      A control worth keeping: `(define (r . xs) (set! xs (cons 3 xs)) (car xs))`
+      — mutated but NOT captured — was a LOUD refusal before this change
+      ("variable 'xs' is not mutable"), not a wrong answer, and now answers 3.
+
+  - id: SW-34
+    bucket: SILENT-WRONG
+    status: open
+    title: "VM: a `do` loop variable captured and mutated by a body closure loses the mutation inside a procedure and in a nested loop"
+    repro: >-
+      (define (f n) (do ((i 0 (+ i 1)) (a 0)) ((= i n) a) ((lambda () (set! a (+ a 1)))))) (display (f 5))
+    observed: "VM 0 — exit 0, no diagnostic"
+    correct: "5 — native answers 5 after the LE-09 fix"
+    affected_measured:
+      - "(define (f n) (do ((i 0 (+ i 1)) (a 0)) ((= i n) a) ((lambda () (set! a (+ a 1)))))) (f 5) -> VM 0, native 5"
+      - "(do ((i 0 (+ i 1)) (t 0)) ((= i 3) t) (do ((j 0 (+ j 1))) ((= j 2)) ((lambda () (set! t (+ t 1)))))) -> VM 2, native 6"
+    unaffected_measured:
+      - "the same loop at TOP LEVEL: (do ((i 0 (+ i 1)) (acc 0)) ((= i 3) acc) ((lambda () (set! acc (+ acc i))))) -> VM 3, native 3"
+      - "a read-only capture: (do ((i 0 (+ i 1)) (s 0)) ((= i 4) s) (set! s (+ s ((lambda () i))))) -> VM 6, native 6"
+    discovered_by: >-
+      class-killing LE-09 on the native side. Every `do` shape the native fix
+      had to handle was run on both engines; these two are the ones where the VM
+      answers wrongly and native answers correctly.
+    not_fixed_here: >-
+      NOT a native defect and NOT closed by branch fix/native-rest-capture-and-do-loop,
+      which changes lib/backend/llvm_codegen.cpp only. Measured against BOTH the
+      VM at this SHA and the VM on the SW-25 branch fix/vm-region-and-upvalue:
+      identical wrong answers, so PR #435's parameter/let boxing does not reach
+      `do` bindings. The likely shape of the fix is the same mechanism applied to
+      compile_form_do()'s bindings — the SW-25 entry's own root_cause names
+      compile_form_let() as the only binding form that had ever run
+      needs_boxing() — but that is a VM-compiler change and wants its own
+      measurement lane.
+    evidence: >-
+      tests/vm_parity/corpus/60_do_loop_closure_capture.esk documents both
+      shapes in its SCOPE comment and deliberately does NOT assert them, so this
+      entry is visible from the corpus rather than only from the ledger. The
+      native side of both shapes IS gated, in
+      tests/integration/rest_capture_and_do_closure_test.esk and
+      tests/differential/corpus/48_rest_capture_and_do_closure.esk.
+    caught_by: [direct-measurement, le-09-class-kill]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity, differential-corpus, KNOWN_ISSUES]
+    notes: >-
+      Growth justified per invariant 4: this is a NEW SILENT-WRONG entry opened
+      by a PR that closes two others. It is recorded rather than fixed because
+      fixing it means changing the VM compiler's binding forms days before a
+      tag, on a mechanism whose native counterpart took this whole lane to get
+      right, and because the class-kill measurement that found it is the only
+      thing that makes a VM fix verifiable.
+
   # ───────────────────────── IN-FLIGHT ─────────────────────────
 
   - id: IF-01
@@ -986,6 +1103,135 @@ entries:
     evidence: "docs/KNOWN_ISSUES.md:195"
     caught_by: [KNOWN_ISSUES]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: LE-09
+    bucket: LOUD-ERROR
+    subtag: codegen
+    status: closed
+    closed_at: "2ae3787f"
+    closed_by: "branch fix/native-rest-capture-and-do-loop"
+    title: "NATIVE: a `do` loop whose body creates a closure over a loop variable never terminates and is SIGKILLed (exit 137)"
+    repro: "(display (do ((i 0 (+ i 1)) (acc 0)) ((= i 3) acc) ((lambda () (set! acc (+ acc i))))))"
+    observed: >-
+      killed by SIGKILL, exit 137, under the default `-r` and under
+      ESHKOL_JIT_CACHE=0. Under an explicit CPU limit the same run exits 152
+      (SIGXCPU) with no output, which is what identifies it as a runaway loop
+      rather than an allocator fault.
+    correct: "3 — the VM answers 3"
+    affected_measured:
+      - "mutating capture: ((lambda () (set! acc (+ acc i)))) -> runaway"
+      - "READ-ONLY capture: (set! s (+ s ((lambda () i)))) -> runaway; mutation is not required"
+      - "let-bound body closure -> LLVM verification failure, \"Instruction does not dominate all uses\" on the arena_allocate, i.e. the compile is rejected rather than run"
+      - "named let in the body capturing the loop variables -> same verification failure"
+    unaffected_measured:
+      - "a `do` body with no closure at all"
+      - "a body lambda whose PARAMETER shadows the loop variable, so nothing is captured"
+    root_cause: >-
+      lib/backend/llvm_codegen.cpp, codegenDo (var_allocas at ~24282, step store
+      at ~24371 before this change). A `do` variable is READ from three places
+      emitted at three different times — the header test first, the body second,
+      the step expressions third — but codegenDo wrote the step result to the
+      stack alloca it had cached in var_allocas, while every read went through
+      symbol_table. codegenLambda's capture emission ("CLOSURE ESCAPE FIX",
+      ~30036) REBINDS a captured stack alloca to fresh arena storage mid-body
+      and repoints symbol_table at it, seeding the new cell ONCE in the
+      pre-header. The variable therefore split in two: the step read the arena
+      cell and wrote the stack alloca that the header test had already been
+      compiled against. IR at the defect:
+        do_loop_step: %i.load68 = load ptr %8        ; arena cell, never advanced
+                      %99 = add %i.load68, 1
+                      store %99, ptr %i_do           ; stack alloca
+        do_loop_header: %i.load = load ptr %i_do     ; reads 1 forever
+      `(= i 3)` never became true, and each iteration allocated a fresh closure
+      in the arena, so the loop consumed memory without bound until the OS
+      killed it. The same rebinding, when it happened inside the loop body
+      rather than the pre-header, produced an arena_allocate that did not
+      dominate its uses — invalid IR, which is the AOT-side symptom.
+    fix: >-
+      The storage class is now decided BEFORE the loop is emitted, mirroring
+      codegenNamedLet, which has always arena-moved its captured cells up front.
+      doFormCapturesVar() asks whether any lambda or named let in the bindings,
+      test, results or body captures the variable; if so the loop variable's
+      cell is arena storage from the start, which is what the capture machinery
+      would have converged on anyway — and being an already-pointer-typed
+      CallInst it takes codegenLambda's "existing arena storage" branch, which
+      pointer-passes WITHOUT rebinding anything. Otherwise the variable keeps
+      its stack alloca and stays promotable, so closure-free `do` loops are
+      byte-identical to before. The predicate reuses astSetsVar's traversal
+      rather than a second copy of it: that walk is now astScanVar(ast, var,
+      VarScanMode), with SetTarget and ClosureCapture node tests over one
+      shared, already-proven-complete recursion.
+      An INVARIANT backs it up at the end of codegenDo: if any loop variable was
+      arena-moved anyway, the capture analysis missed a form, and codegen now
+      FAILS LOUDLY with a diagnostic instead of emitting a loop that cannot
+      terminate. That guard is what caught the two design corrections below
+      during class-kill.
+    evidence: >-
+      tests/integration/rest_capture_and_do_closure_test.esk, 23/23 checks on
+      all four native axes (ctest lanes rest_capture_and_do_closure_*): mutating
+      and read-only captures, an immediately-invoked closure and a let-bound
+      one, a named let in the body, a nested `do` closing over the OUTER
+      variable, a loop inside a procedure with a runtime trip count, closures
+      stored out of the loop and called after it finished, and the two controls.
+      tests/differential/corpus/48_rest_capture_and_do_closure.esk on the native
+      axes; tests/vm_parity/corpus/60_do_loop_closure_capture.esk pins the
+      reproducer VM-vs-native.
+      Revert-validated against a build of the same tree without the codegen
+      change (worktree eshkol-wt-vmmem): the reproducer runs until the CPU limit
+      fires, and the let-bound and named-let shapes fail LLVM verification.
+    caught_by: [direct-measurement, sw-25-adjacent-finding]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity, differential-corpus, KNOWN_ISSUES]
+    notes: >-
+      Two design corrections were forced by the codegenDo invariant during
+      class-kill, and both are recorded because they are the non-obvious part.
+      (1) An internal `(define (bump) …)` in the body is NOT a ClosureCapture
+      site: codegenFunctionDefinition captures through module-level storage
+      (`<fn>_nested_N_capture_<var>`) re-seeded from the enclosing binding on
+      every execution, which does not split the loop — forcing arena storage for
+      it turned a correct 3 into a type error, measured. `(define bump (lambda …))`
+      is a different shape and IS caught, by the LAMBDA_OP case.
+      (2) The invariant is narrowed to the arena-move signature (a pointer-typed
+      CallInst) for the same reason, so the legitimate module-storage rebinding
+      is not flagged.
+
+  - id: LE-10
+    bucket: LOUD-ERROR
+    subtag: codegen
+    status: open
+    title: "VM: a `do` loop with a body closure poisons a LATER `do` loop in the same program — heap-object limit, fatal call, or hang"
+    repro: >-
+      (display (do ((i 0 (+ i 1)) (s 0)) ((= i 4) s) (set! s (+ s ((lambda () i)))))) (newline)
+      (display (do ((i 0 (+ i 1))) ((= i 3) i) ((lambda (i) i) 99)))
+    observed: >-
+      "ERROR: VM heap object limit reached (ESHKOL_VM_HEAP_MAX_SIZE=16777216
+      objects)" then "VM terminated on a fatal runtime error", exit 1, after the
+      FIRST loop has already printed its correct answer.
+    correct: "6 then 3 — native prints both"
+    affected_measured:
+      - "second `do` after a body-closure `do`: heap-object limit, exit 1"
+      - "a let-bound (not immediately invoked) body closure, when any top-level form precedes the loop: \"ERROR: calling non-function\", exit 1"
+      - "a longer sequence of the same shapes: hangs until the CPU limit fires (exit 152)"
+    unaffected_measured:
+      - "either loop ALONE in its own program: both correct"
+      - "two body-closure `do` loops with disjoint variable names: both correct"
+    discovered_by: >-
+      assembling tests/vm_parity/corpus/60_do_loop_closure_capture.esk while
+      class-killing LE-09. Each candidate line was correct on the VM in
+      isolation and the file still failed, which is what identified the defect
+      as sequence-dependent rather than shape-dependent.
+    not_fixed_here: >-
+      VM-side. Branch fix/native-rest-capture-and-do-loop changes
+      lib/backend/llvm_codegen.cpp only. Reproduces identically on the VM at
+      this SHA and on the SW-25 branch fix/vm-region-and-upvalue, so PR #435
+      neither causes nor fixes it. LOUD, so it does not gate the release, but it
+      is the reason the vm-parity corpus file added by that branch is two lines
+      long, and that constraint should not be mistaken for a small class.
+    evidence: >-
+      tests/vm_parity/corpus/60_do_loop_closure_capture.esk SCOPE comment names
+      both shapes; the native side of both runs green in
+      tests/differential/corpus/48_rest_capture_and_do_closure.esk.
+    caught_by: [direct-measurement, le-09-class-kill]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity, differential-corpus, KNOWN_ISSUES]
 
   # ───────────────────────── PARITY-RATCHET ─────────────────────────
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4802,6 +4802,60 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run AND
             TIMEOUT 600
             PASS_REGULAR_EXPRESSION "PASS: first-class variadics — 0 failures"
             FAIL_REGULAR_EXPRESSION "FAIL:|Undefined variable|LLVM module verification failed|fatal signal")
+
+    # SW-33 / LE-09: capture of a REST parameter and of a `do` loop variable.
+    # Gated on all four native axes because the two defects failed differently
+    # and at different times: SW-33 was a SILENT wrong answer on every axis
+    # (`(f 1 2 3)` -> 1 instead of 99, exit 0), while LE-09 was an infinite loop
+    # that exhausted the arena (SIGKILL, exit 137) under the JIT and, for the
+    # let-bound-closure shape, IR that failed LLVM verification with
+    # "Instruction does not dominate all uses" under AOT. A TIMEOUT alone would
+    # not catch the silent half and the PASS regex alone would not catch the
+    # runaway, so both are set.
+    add_test(
+        NAME rest_capture_and_do_closure_smoke
+        COMMAND sh -c
+            "cd '${CMAKE_CURRENT_SOURCE_DIR}' && '$<TARGET_FILE:eshkol-run>' -r tests/integration/rest_capture_and_do_closure_test.esk -L'${CMAKE_CURRENT_BINARY_DIR}'"
+    )
+    set_tests_properties(rest_capture_and_do_closure_smoke
+        PROPERTIES
+            TIMEOUT 300
+            PASS_REGULAR_EXPRESSION "PASS: rest capture and do closure - 0 failures"
+            FAIL_REGULAR_EXPRESSION "FAIL:|not mutable|LLVM module verification failed|fatal signal")
+
+    add_test(
+        NAME rest_capture_and_do_closure_nocache_smoke
+        COMMAND sh -c
+            "cd '${CMAKE_CURRENT_SOURCE_DIR}' && '$<TARGET_FILE:eshkol-run>' -r tests/integration/rest_capture_and_do_closure_test.esk -L'${CMAKE_CURRENT_BINARY_DIR}'"
+    )
+    set_tests_properties(rest_capture_and_do_closure_nocache_smoke
+        PROPERTIES
+            TIMEOUT 300
+            ENVIRONMENT "ESHKOL_JIT_CACHE=0"
+            PASS_REGULAR_EXPRESSION "PASS: rest capture and do closure - 0 failures"
+            FAIL_REGULAR_EXPRESSION "FAIL:|not mutable|LLVM module verification failed|fatal signal")
+
+    add_test(
+        NAME rest_capture_and_do_closure_aot_o0_smoke
+        COMMAND sh -c
+            "cd '${CMAKE_CURRENT_SOURCE_DIR}' && '$<TARGET_FILE:eshkol-run>' -O0 -o '${CMAKE_CURRENT_BINARY_DIR}/rest_capture_and_do_closure_aot_o0' tests/integration/rest_capture_and_do_closure_test.esk -L'${CMAKE_CURRENT_BINARY_DIR}' && '${CMAKE_CURRENT_BINARY_DIR}/rest_capture_and_do_closure_aot_o0'"
+    )
+    set_tests_properties(rest_capture_and_do_closure_aot_o0_smoke
+        PROPERTIES
+            TIMEOUT 600
+            PASS_REGULAR_EXPRESSION "PASS: rest capture and do closure - 0 failures"
+            FAIL_REGULAR_EXPRESSION "FAIL:|not mutable|LLVM module verification failed|fatal signal")
+
+    add_test(
+        NAME rest_capture_and_do_closure_aot_o2_smoke
+        COMMAND sh -c
+            "cd '${CMAKE_CURRENT_SOURCE_DIR}' && '$<TARGET_FILE:eshkol-run>' -O2 -o '${CMAKE_CURRENT_BINARY_DIR}/rest_capture_and_do_closure_aot_o2' tests/integration/rest_capture_and_do_closure_test.esk -L'${CMAKE_CURRENT_BINARY_DIR}' && '${CMAKE_CURRENT_BINARY_DIR}/rest_capture_and_do_closure_aot_o2'"
+    )
+    set_tests_properties(rest_capture_and_do_closure_aot_o2_smoke
+        PROPERTIES
+            TIMEOUT 600
+            PASS_REGULAR_EXPRESSION "PASS: rest capture and do closure - 0 failures"
+            FAIL_REGULAR_EXPRESSION "FAIL:|not mutable|LLVM module verification failed|fatal signal")
 endif()
 
 if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/vm/test_vm_c_api.cpp")

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -12689,20 +12689,40 @@ private:
         // set!-mutated bindings (make-counter, make-account sibling closures).
         // Skip when TCO already promoted parameters to *_tco allocas (the
         // self-recursive / named-let path keeps its own loopvar handling).
-        if (!use_tco && op->define_op.parameters && op->define_op.value) {
+        if (!use_tco && op->define_op.value) {
             auto box_arg_it = function->arg_begin();
-            for (uint64_t i = 0; i < op->define_op.num_params && box_arg_it != function->arg_end(); ++i, ++box_arg_it) {
-                if (op->define_op.parameters[i].type == ESHKOL_VAR &&
-                    op->define_op.parameters[i].variable.id) {
-                    std::string pname = op->define_op.parameters[i].variable.id;
-                    if (astSetsVar(op->define_op.value, pname)) {
-                        AllocaInst* box = builder->CreateAlloca(tagged_value_type, nullptr, pname);
-                        builder->CreateStore(&(*box_arg_it), box);
-                        symbol_table[pname] = box;
-                        eshkol_debug("Assignment conversion: boxed set!-mutated param %s in %s",
-                                     pname.c_str(), func_name);
+            if (op->define_op.parameters) {
+                for (uint64_t i = 0; i < op->define_op.num_params && box_arg_it != function->arg_end(); ++i, ++box_arg_it) {
+                    if (op->define_op.parameters[i].type == ESHKOL_VAR &&
+                        op->define_op.parameters[i].variable.id) {
+                        std::string pname = op->define_op.parameters[i].variable.id;
+                        if (astSetsVar(op->define_op.value, pname)) {
+                            AllocaInst* box = builder->CreateAlloca(tagged_value_type, nullptr, pname);
+                            builder->CreateStore(&(*box_arg_it), box);
+                            symbol_table[pname] = box;
+                            eshkol_debug("Assignment conversion: boxed set!-mutated param %s in %s",
+                                         pname.c_str(), func_name);
+                        }
                     }
                 }
+            }
+            // ESH-0074b: the REST parameter is a binding exactly like a fixed one.
+            // It arrives as the by-value Argument that follows the fixed params (the
+            // symbol-table loop above walks the same order), so without a box a
+            // nested closure capturing it copies the LIST VALUE into its environment
+            // and the inner set! mutates a private copy that is discarded on return:
+            //   (define (f . rest) ((lambda () (set! rest (cons 99 rest)))) (car rest))
+            // answered 1 instead of 99, with exit 0 and no diagnostic. Boxing here
+            // routes every later read/write through the same alloca, so the existing
+            // capture machinery pointer-passes ONE cell.
+            if (is_variadic && box_arg_it != function->arg_end() &&
+                astSetsVar(op->define_op.value, op->define_op.rest_param)) {
+                std::string pname = op->define_op.rest_param;
+                AllocaInst* box = builder->CreateAlloca(tagged_value_type, nullptr, pname);
+                builder->CreateStore(&(*box_arg_it), box);
+                symbol_table[pname] = box;
+                eshkol_debug("Assignment conversion: boxed set!-mutated rest param %s in %s",
+                             pname.c_str(), func_name);
             }
         }
 
@@ -24228,6 +24248,21 @@ private:
     //                   call_op.variables = body expressions
     // Where bindings-list is CALL_OP with CONS bindings (var, CONS(init, step))
     // And test-clause is CONS(test, results-list)
+    // ESH-0074c: does any closure created ANYWHERE in this `do` form capture
+    // `var`? `main_cons` carries the bindings (inits and steps), the test and the
+    // result expressions; `op->call_op.variables[]` carries the body commands.
+    // Every one of them can build a closure, and any of them doing so forces the
+    // loop variable onto a shared cell — see codegenDo's storage-class comment.
+    bool doFormCapturesVar(const eshkol_operations_t* op,
+                           const eshkol_ast_t* main_cons,
+                           const std::string& var) {
+        if (astVarCapturedByNestedClosure(main_cons, var)) return true;
+        for (uint64_t i = 0; i < op->call_op.num_vars; i++) {
+            if (astVarCapturedByNestedClosure(&op->call_op.variables[i], var)) return true;
+        }
+        return false;
+    }
+
     Value* codegenDo(const eshkol_operations_t* op) {
         if (!op->call_op.func || op->call_op.func->type != ESHKOL_CONS) {
             eshkol_warn("do requires properly formed structure");
@@ -24278,8 +24313,49 @@ private:
                 var_names.push_back(var_name);
                 step_exprs.push_back(step_ast);
 
-                // Create alloca for loop variable
-                Value* alloca = builder->CreateAlloca(tagged_value_type, nullptr, var_name + "_do");
+                // ESH-0074c: choose the loop variable's STORAGE CLASS *before* any
+                // of the loop is emitted.
+                //
+                // A `do` variable is read from three places emitted at three
+                // different times — the header test (first), the body (second) and
+                // the step expressions (third) — but codegenDo writes the step
+                // result to the cell it cached here. The closure-capture machinery
+                // (codegenLambda, "CLOSURE ESCAPE FIX") *rebinds* a captured stack
+                // alloca to fresh arena storage mid-body and repoints symbol_table
+                // at it, so a closure over a `do` variable used to split the
+                // variable in two: the step read the arena cell and wrote the stack
+                // alloca, while the header test kept reading the stale alloca it had
+                // already been emitted against. `(= i 3)` then never became true —
+                // an INFINITE LOOP whose every iteration allocated a fresh closure,
+                // i.e. unbounded arena growth ending in SIGKILL (exit 137):
+                //     (do ((i 0 (+ i 1)) (acc 0)) ((= i 3) acc)
+                //         ((lambda () (set! acc (+ acc i)))))
+                // Merely *reading* a loop variable from a body closure was enough;
+                // mutation was not required.
+                //
+                // Deciding up front removes the ordering hazard entirely rather than
+                // patching one of its three symptoms: when a closure in this form
+                // captures the variable, the cell is arena storage from the start,
+                // which is what the capture machinery would have converged on anyway
+                // — and because arena storage is already a pointer-typed CallInst it
+                // takes codegenLambda's "existing arena storage" branch, which
+                // pointer-passes WITHOUT rebinding anything. Otherwise the variable
+                // keeps its stack alloca and stays promotable by mem2reg, so
+                // closure-free `do` loops are unchanged.
+                const bool needs_shared_cell = doFormCapturesVar(op, main_cons, var_name);
+
+                Value* alloca = nullptr;
+                if (needs_shared_cell) {
+                    Value* arena_ptr = builder->CreateLoad(
+                        PointerType::getUnqual(*context), global_arena);
+                    alloca = builder->CreateCall(getArenaAllocateFunc(),
+                                                 {arena_ptr, sizeConst(16)},
+                                                 var_name + "_do_cell");
+                    eshkol_debug("do: loop variable '%s' is captured by a closure, "
+                                 "using shared arena storage", var_name.c_str());
+                } else {
+                    alloca = builder->CreateAlloca(tagged_value_type, nullptr, var_name + "_do");
+                }
                 var_allocas.push_back(alloca);
 
                 // Evaluate init expression and store
@@ -24361,6 +24437,35 @@ private:
             }
             Value* step_val = typedValueToTaggedValue(step_tv);
             new_values.push_back(step_val);
+        }
+
+        // ESH-0074c: INVARIANT — no loop variable may have been arena-moved while
+        // the loop was being compiled.
+        //
+        // The arena move is the rebinding that splits the loop: it seeds the new
+        // cell ONCE, in the pre-header, so a step that reads the moved cell and
+        // writes the stack alloca the header test was compiled against never makes
+        // the test true. The storage-class decision above is supposed to make that
+        // move unnecessary by handing the capture machinery arena storage from the
+        // start, so seeing one here means the capture analysis missed a form — and
+        // the symptom would be an infinite loop that exhausts the arena, not a
+        // wrong answer. Fail loudly at compile time instead.
+        //
+        // Deliberately narrow: a nested `(define (f) …)` capture legitimately
+        // repoints the binding at module-level capture storage, and re-seeds it
+        // from the loop's own cell on every iteration, so it does NOT split the
+        // loop and is not flagged. The arena move is identified by its signature —
+        // a pointer-typed CallInst that is not the cell we chose.
+        for (size_t i = 0; i < var_names.size(); i++) {
+            auto sym_it = symbol_table.find(var_names[i]);
+            if (sym_it == symbol_table.end() || sym_it->second == var_allocas[i]) continue;
+            if (isa<CallInst>(sym_it->second) && sym_it->second->getType()->isPointerTy()) {
+                eshkol_error("do: loop variable '%s' was arena-moved while the loop "
+                             "body was compiled; the loop test and the step update "
+                             "no longer share a cell",
+                             var_names[i].c_str());
+                markFatalCodegenError();
+            }
         }
 
         // NORETURN SAFETY: Only update variables and loop back if block is not terminated
@@ -28025,6 +28130,46 @@ private:
     }
     // ===== END TAIL CALL OPTIMIZATION SUPPORT =====
 
+    // ESH-0074c: which node test astScanVar() applies while walking. See the
+    // comment on astScanVar for the contract.
+    enum class VarScanMode { SetTarget, ClosureCapture };
+
+    // True iff `var` is bound by this parameter list (so an inner reference to it
+    // is the PARAMETER, not a capture of the enclosing binding).
+    bool paramListShadows(const eshkol_ast_t* params, uint64_t num_params,
+                          const char* rest_param, const std::string& var) {
+        if (rest_param && var == rest_param) return true;
+        if (!params) return false;
+        for (uint64_t i = 0; i < num_params; i++) {
+            if (params[i].type == ESHKOL_VAR && params[i].variable.id &&
+                var == params[i].variable.id) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Same question for a let/named-let binding list, whose entries are
+    // (variable value) pairs.
+    bool bindingListShadows(const eshkol_ast_t* bindings, uint64_t num_bindings,
+                            const std::string& var) {
+        if (!bindings) return false;
+        for (uint64_t i = 0; i < num_bindings; i++) {
+            const eshkol_ast_t* b = &bindings[i];
+            const eshkol_ast_t* name_ast = nullptr;
+            if (b->type == ESHKOL_CONS) {
+                name_ast = b->cons_cell.car;
+            } else if (b->type == ESHKOL_VAR) {
+                name_ast = b;
+            }
+            if (name_ast && name_ast->type == ESHKOL_VAR && name_ast->variable.id &&
+                var == name_ast->variable.id) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     // Helper function to find free variables in a lambda body
     // bound_vars tracks all variable names bound by enclosing lambdas (for nested closure support)
     // CLOSURE-OVER-NAMED-LET-LOOPVAR FIX: Returns true iff `var` is the target of
@@ -28048,7 +28193,20 @@ private:
     // `false` silently miscompiles a mutation. So every structural container the
     // parser can produce is walked, and `default: return false` is now reached
     // only by genuine leaves (literals, quote, type annotations, macro defs).
-    bool astSetsVar(const eshkol_ast_t* ast, const std::string& var) {
+    //
+    // ESH-0074c: that completeness is scarce, so the traversal is shared rather
+    // than copied. `VarScanMode` selects which NODE TEST is applied while the
+    // walk itself stays byte-identical:
+    //   SetTarget      — `var` is the target of a set! (the original predicate).
+    //   ClosureCapture — `var` is referenced from inside a form whose capture
+    //                    machinery SHARES the enclosing cell by pointer, and which
+    //                    arena-moves a stack alloca to do it: a lambda or a named
+    //                    let. Internal function defines capture through
+    //                    module-level storage instead and are excluded on purpose
+    //                    (see the DEFINE_OP case).
+    // The second mode drives codegenDo's storage-class decision; see
+    // doFormCapturesVar().
+    bool astScanVar(const eshkol_ast_t* ast, const std::string& var, VarScanMode mode) {
         if (!ast) return false;
         // Walk raw cons structure: `do` bindings ((var init step) ...), cond/case
         // clauses and every other list-shaped payload live in CONS cells, not in
@@ -28057,15 +28215,16 @@ private:
         // node, so walking cons cells cannot manufacture a false positive out of
         // a literal list.
         if (ast->type == ESHKOL_CONS) {
-            return astSetsVar(ast->cons_cell.car, var) ||
-                   astSetsVar(ast->cons_cell.cdr, var);
+            return astScanVar(ast->cons_cell.car, var, mode) ||
+                   astScanVar(ast->cons_cell.cdr, var, mode);
         }
         if (ast->type != ESHKOL_OP) return false;
         const eshkol_operations_t* op = &ast->operation;
         switch (op->op) {
             case ESHKOL_SET_OP:
-                if (op->set_op.name && var == op->set_op.name) return true;
-                return astSetsVar(op->set_op.value, var);
+                if (mode == VarScanMode::SetTarget &&
+                    op->set_op.name && var == op->set_op.name) return true;
+                return astScanVar(op->set_op.value, var, mode);
             // ---- call_op layout: func + variables[] --------------------------
             case ESHKOL_CALL_OP:
             case ESHKOL_IF_OP:
@@ -28117,9 +28276,9 @@ private:
             case ESHKOL_SDNC_IMPROVE_OP:
             case ESHKOL_SDNC_PRED_OP:
             case ESHKOL_MAKE_PARAMETER_OP: {
-                if (op->call_op.func && astSetsVar(op->call_op.func, var)) return true;
+                if (op->call_op.func && astScanVar(op->call_op.func, var, mode)) return true;
                 for (uint64_t i = 0; i < op->call_op.num_vars; i++) {
-                    if (astSetsVar(&op->call_op.variables[i], var)) return true;
+                    if (astScanVar(&op->call_op.variables[i], var, mode)) return true;
                 }
                 return false;
             }
@@ -28128,128 +28287,168 @@ private:
             case ESHKOL_AND_OP:
             case ESHKOL_OR_OP:
                 for (uint64_t i = 0; i < op->sequence_op.num_expressions; i++) {
-                    if (astSetsVar(&op->sequence_op.expressions[i], var)) return true;
+                    if (astScanVar(&op->sequence_op.expressions[i], var, mode)) return true;
                 }
                 return false;
             case ESHKOL_LET_OP:
             case ESHKOL_LET_STAR_OP:
             case ESHKOL_LETREC_OP:
             case ESHKOL_LETREC_STAR_OP: {
-                for (uint64_t i = 0; i < op->let_op.num_bindings; i++) {
-                    if (astSetsVar(&op->let_op.bindings[i], var)) return true;
+                // ESH-0074c: a NAMED let compiles to a loop procedure that takes
+                // its free variables as capture arguments, so it captures `var`
+                // exactly like a lambda would.
+                if (mode == VarScanMode::ClosureCapture &&
+                    op->op == ESHKOL_LET_OP && op->let_op.name &&
+                    !bindingListShadows(op->let_op.bindings, op->let_op.num_bindings, var) &&
+                    astReferencesVar(op->let_op.body, var)) {
+                    return true;
                 }
-                return astSetsVar(op->let_op.body, var);
+                for (uint64_t i = 0; i < op->let_op.num_bindings; i++) {
+                    if (astScanVar(&op->let_op.bindings[i], var, mode)) return true;
+                }
+                return astScanVar(op->let_op.body, var, mode);
             }
             case ESHKOL_LAMBDA_OP:
-                return astSetsVar(op->lambda_op.body, var);
+                if (mode == VarScanMode::ClosureCapture &&
+                    !paramListShadows(op->lambda_op.parameters, op->lambda_op.num_params,
+                                      op->lambda_op.is_variadic ? op->lambda_op.rest_param : nullptr,
+                                      var) &&
+                    astReferencesVar(op->lambda_op.body, var)) {
+                    return true;
+                }
+                return astScanVar(op->lambda_op.body, var, mode);
             case ESHKOL_DEFINE_OP:
-                return astSetsVar(op->define_op.value, var);
+                // NOT a ClosureCapture site, deliberately. An internal
+                // `(define (bump) …)` is compiled by codegenFunctionDefinition,
+                // whose capture mechanism is MODULE-LEVEL capture storage
+                // (`<fn>_nested_N_capture_<var>`) re-seeded from the enclosing
+                // binding at every execution of the define — it never arena-moves
+                // the enclosing cell, so it does not split a `do` loop and it does
+                // not want one either. Measured: forcing arena storage for
+                //     (do ((i 0 (+ i 1)) (a 0)) ((= i 3) a)
+                //         (define (bump) (set! a (+ a i))) (bump))
+                // turned a correct 3 into a type error. `(define bump (lambda …))`
+                // is a different shape and is caught by the LAMBDA_OP case above.
+                return astScanVar(op->define_op.value, var, mode);
             // ---- named layouts ----------------------------------------------
             case ESHKOL_GUARD_OP: {
                 for (uint64_t i = 0; i < op->guard_op.num_clauses; i++) {
-                    if (astSetsVar(&op->guard_op.clauses[i], var)) return true;
+                    if (astScanVar(&op->guard_op.clauses[i], var, mode)) return true;
                 }
                 for (uint64_t i = 0; i < op->guard_op.num_body_exprs; i++) {
-                    if (astSetsVar(&op->guard_op.body[i], var)) return true;
+                    if (astScanVar(&op->guard_op.body[i], var, mode)) return true;
                 }
                 return false;
             }
             case ESHKOL_WITH_REGION_OP:
                 for (uint64_t i = 0; i < op->with_region_op.num_body_exprs; i++) {
-                    if (astSetsVar(&op->with_region_op.body[i], var)) return true;
+                    if (astScanVar(&op->with_region_op.body[i], var, mode)) return true;
                 }
                 return false;
             case ESHKOL_RAISE_OP:
-                return astSetsVar(op->raise_op.exception, var);
+                return astScanVar(op->raise_op.exception, var, mode);
             case ESHKOL_VALUES_OP:
                 for (uint64_t i = 0; i < op->values_op.num_values; i++) {
-                    if (astSetsVar(&op->values_op.expressions[i], var)) return true;
+                    if (astScanVar(&op->values_op.expressions[i], var, mode)) return true;
                 }
                 return false;
             case ESHKOL_CALL_WITH_VALUES_OP:
-                return astSetsVar(op->call_with_values_op.producer, var) ||
-                       astSetsVar(op->call_with_values_op.consumer, var);
+                return astScanVar(op->call_with_values_op.producer, var, mode) ||
+                       astScanVar(op->call_with_values_op.consumer, var, mode);
             case ESHKOL_LET_VALUES_OP:
             case ESHKOL_LET_STAR_VALUES_OP: {
                 for (uint64_t i = 0; i < op->let_values_op.num_bindings; i++) {
-                    if (astSetsVar(&op->let_values_op.producers[i], var)) return true;
+                    if (astScanVar(&op->let_values_op.producers[i], var, mode)) return true;
                 }
-                return astSetsVar(op->let_values_op.body, var);
+                return astScanVar(op->let_values_op.body, var, mode);
             }
             case ESHKOL_MATCH_OP: {
-                if (astSetsVar(op->match_op.expr, var)) return true;
+                if (astScanVar(op->match_op.expr, var, mode)) return true;
                 for (uint64_t i = 0; i < op->match_op.num_clauses; i++) {
-                    if (astSetsVar(op->match_op.clauses[i].guard, var)) return true;
-                    if (astSetsVar(op->match_op.clauses[i].body, var)) return true;
+                    if (astScanVar(op->match_op.clauses[i].guard, var, mode)) return true;
+                    if (astScanVar(op->match_op.clauses[i].body, var, mode)) return true;
                 }
                 return false;
             }
             case ESHKOL_CALL_CC_OP:
-                return astSetsVar(op->call_cc_op.proc, var);
+                return astScanVar(op->call_cc_op.proc, var, mode);
             case ESHKOL_DYNAMIC_WIND_OP:
-                return astSetsVar(op->dynamic_wind_op.before, var) ||
-                       astSetsVar(op->dynamic_wind_op.thunk, var) ||
-                       astSetsVar(op->dynamic_wind_op.after, var);
+                return astScanVar(op->dynamic_wind_op.before, var, mode) ||
+                       astScanVar(op->dynamic_wind_op.thunk, var, mode) ||
+                       astScanVar(op->dynamic_wind_op.after, var, mode);
             case ESHKOL_OWNED_OP:
-                return astSetsVar(op->owned_op.value, var);
+                return astScanVar(op->owned_op.value, var, mode);
             case ESHKOL_MOVE_OP:
-                return astSetsVar(op->move_op.value, var);
+                return astScanVar(op->move_op.value, var, mode);
             case ESHKOL_BORROW_OP: {
-                if (astSetsVar(op->borrow_op.value, var)) return true;
+                if (astScanVar(op->borrow_op.value, var, mode)) return true;
                 for (uint64_t i = 0; i < op->borrow_op.num_body_exprs; i++) {
-                    if (astSetsVar(&op->borrow_op.body[i], var)) return true;
+                    if (astScanVar(&op->borrow_op.body[i], var, mode)) return true;
                 }
                 return false;
             }
             case ESHKOL_SHARED_OP:
-                return astSetsVar(op->shared_op.value, var);
+                return astScanVar(op->shared_op.value, var, mode);
             case ESHKOL_WEAK_REF_OP:
-                return astSetsVar(op->weak_ref_op.value, var);
+                return astScanVar(op->weak_ref_op.value, var, mode);
             case ESHKOL_COMPOSE_OP:
-                return astSetsVar(op->compose_op.func_a, var) ||
-                       astSetsVar(op->compose_op.func_b, var);
+                return astScanVar(op->compose_op.func_a, var, mode) ||
+                       astScanVar(op->compose_op.func_b, var, mode);
             case ESHKOL_TENSOR_OP:
                 for (uint64_t i = 0; i < op->tensor_op.total_elements; i++) {
-                    if (astSetsVar(&op->tensor_op.elements[i], var)) return true;
+                    if (astScanVar(&op->tensor_op.elements[i], var, mode)) return true;
                 }
                 return false;
             // ---- automatic-differentiation ops: each has its OWN union member
             // (function/point/…), NOT the call_op layout — see eshkol.h.
             case ESHKOL_DIFF_OP:
-                return astSetsVar(op->diff_op.expression, var);
+                return astScanVar(op->diff_op.expression, var, mode);
             case ESHKOL_DERIVATIVE_OP:
-                return astSetsVar(op->derivative_op.function, var) ||
-                       astSetsVar(op->derivative_op.point, var);
+                return astScanVar(op->derivative_op.function, var, mode) ||
+                       astScanVar(op->derivative_op.point, var, mode);
             case ESHKOL_TAYLOR_OP:
             case ESHKOL_DERIVATIVE_N_OP:
-                return astSetsVar(op->taylor_op.function, var) ||
-                       astSetsVar(op->taylor_op.point, var) ||
-                       astSetsVar(op->taylor_op.order, var);
+                return astScanVar(op->taylor_op.function, var, mode) ||
+                       astScanVar(op->taylor_op.point, var, mode) ||
+                       astScanVar(op->taylor_op.order, var, mode);
             case ESHKOL_GRADIENT_OP:
-                return astSetsVar(op->gradient_op.function, var) ||
-                       astSetsVar(op->gradient_op.point, var);
+                return astScanVar(op->gradient_op.function, var, mode) ||
+                       astScanVar(op->gradient_op.point, var, mode);
             case ESHKOL_JACOBIAN_OP:
-                return astSetsVar(op->jacobian_op.function, var) ||
-                       astSetsVar(op->jacobian_op.point, var);
+                return astScanVar(op->jacobian_op.function, var, mode) ||
+                       astScanVar(op->jacobian_op.point, var, mode);
             case ESHKOL_HESSIAN_OP:
-                return astSetsVar(op->hessian_op.function, var) ||
-                       astSetsVar(op->hessian_op.point, var);
+                return astScanVar(op->hessian_op.function, var, mode) ||
+                       astScanVar(op->hessian_op.point, var, mode);
             case ESHKOL_DIVERGENCE_OP:
-                return astSetsVar(op->divergence_op.function, var) ||
-                       astSetsVar(op->divergence_op.point, var);
+                return astScanVar(op->divergence_op.function, var, mode) ||
+                       astScanVar(op->divergence_op.point, var, mode);
             case ESHKOL_CURL_OP:
-                return astSetsVar(op->curl_op.function, var) ||
-                       astSetsVar(op->curl_op.point, var);
+                return astScanVar(op->curl_op.function, var, mode) ||
+                       astScanVar(op->curl_op.point, var, mode);
             case ESHKOL_LAPLACIAN_OP:
-                return astSetsVar(op->laplacian_op.function, var) ||
-                       astSetsVar(op->laplacian_op.point, var);
+                return astScanVar(op->laplacian_op.function, var, mode) ||
+                       astScanVar(op->laplacian_op.point, var, mode);
             case ESHKOL_DIRECTIONAL_DERIV_OP:
-                return astSetsVar(op->directional_deriv_op.function, var) ||
-                       astSetsVar(op->directional_deriv_op.point, var) ||
-                       astSetsVar(op->directional_deriv_op.direction, var);
+                return astScanVar(op->directional_deriv_op.function, var, mode) ||
+                       astScanVar(op->directional_deriv_op.point, var, mode) ||
+                       astScanVar(op->directional_deriv_op.direction, var, mode);
             default:
                 return false;
         }
+    }
+
+    // Returns true iff `var` is the target of a set! anywhere in `ast`.
+    bool astSetsVar(const eshkol_ast_t* ast, const std::string& var) {
+        return astScanVar(ast, var, VarScanMode::SetTarget);
+    }
+
+    // ESH-0074c: returns true iff some closure created inside `ast` captures
+    // `var` THROUGH THE POINTER-SHARING PATH — i.e. `var` is referenced from the
+    // body of a lambda or a named let and is not shadowed by that form's own
+    // bindings. Drives codegenDo's storage-class decision.
+    bool astVarCapturedByNestedClosure(const eshkol_ast_t* ast, const std::string& var) {
+        return astScanVar(ast, var, VarScanMode::ClosureCapture);
     }
 
     bool astReferencesVar(const eshkol_ast_t* ast, const std::string& var) {
@@ -29675,19 +29874,32 @@ private:
         // set!-mutated needs a mutable cell so set! works and so nested closures
         // capturing it share ONE cell. Skip when TCO already promoted params to
         // *_tco allocas (use_binding_tco re-binds params above).
-        if (!use_binding_tco && op->lambda_op.parameters && op->lambda_op.body) {
+        if (!use_binding_tco && op->lambda_op.body) {
             auto box_arg_it = lambda_func->arg_begin();
-            for (uint64_t i = 0; i < op->lambda_op.num_params && box_arg_it != lambda_func->arg_end(); ++i, ++box_arg_it) {
-                if (op->lambda_op.parameters[i].type == ESHKOL_VAR &&
-                    op->lambda_op.parameters[i].variable.id) {
-                    std::string pname = op->lambda_op.parameters[i].variable.id;
-                    if (astSetsVar(op->lambda_op.body, pname)) {
-                        AllocaInst* box = builder->CreateAlloca(tagged_value_type, nullptr, pname);
-                        builder->CreateStore(&(*box_arg_it), box);
-                        symbol_table[pname] = box;
-                        eshkol_debug("Assignment conversion: boxed set!-mutated lambda param %s", pname.c_str());
+            if (op->lambda_op.parameters) {
+                for (uint64_t i = 0; i < op->lambda_op.num_params && box_arg_it != lambda_func->arg_end(); ++i, ++box_arg_it) {
+                    if (op->lambda_op.parameters[i].type == ESHKOL_VAR &&
+                        op->lambda_op.parameters[i].variable.id) {
+                        std::string pname = op->lambda_op.parameters[i].variable.id;
+                        if (astSetsVar(op->lambda_op.body, pname)) {
+                            AllocaInst* box = builder->CreateAlloca(tagged_value_type, nullptr, pname);
+                            builder->CreateStore(&(*box_arg_it), box);
+                            symbol_table[pname] = box;
+                            eshkol_debug("Assignment conversion: boxed set!-mutated lambda param %s", pname.c_str());
+                        }
                     }
                 }
+            }
+            // ESH-0074b: same gap for a variadic LAMBDA's rest parameter. The rest
+            // argument sits immediately after the fixed params and before the
+            // capture parameters, which is exactly where box_arg_it now points.
+            if (is_variadic && box_arg_it != lambda_func->arg_end() &&
+                astSetsVar(op->lambda_op.body, op->lambda_op.rest_param)) {
+                std::string pname = op->lambda_op.rest_param;
+                AllocaInst* box = builder->CreateAlloca(tagged_value_type, nullptr, pname);
+                builder->CreateStore(&(*box_arg_it), box);
+                symbol_table[pname] = box;
+                eshkol_debug("Assignment conversion: boxed set!-mutated lambda rest param %s", pname.c_str());
             }
         }
 

--- a/tests/differential/corpus/48_rest_capture_and_do_closure.esk
+++ b/tests/differential/corpus/48_rest_capture_and_do_closure.esk
@@ -1,0 +1,93 @@
+;; SW-33 / LE-09 — capture of a REST parameter and of a `do` loop variable.
+;;
+;; SW-33: assignment conversion (ESH-0074) boxes a set!-mutated parameter into
+;; an alloca so set! has a storage location and every closure capturing it
+;; shares ONE cell. Both boxing loops walked only the FIXED parameters, so a
+;; variadic procedure's REST parameter stayed a by-value LLVM Argument: the
+;; closure copied the list VALUE into its environment and the inner set!
+;; mutated a private copy discarded on return. Silently, exit 0.
+;;
+;; LE-09: codegenDo cached the stack alloca it allocated for each loop
+;; variable and wrote step results there, while every read went through the
+;; symbol table — which the closure-capture machinery rebinds to fresh arena
+;; storage mid-body. The step then read the arena cell and wrote the alloca
+;; the loop test had already been compiled against, so the test never became
+;; true: an infinite loop allocating one closure per iteration until the arena
+;; exhausted memory (SIGKILL, exit 137). Under -O0/-O2 the same rebinding also
+;; produced an arena_allocate that did not dominate its uses, i.e. IR that
+;; failed LLVM verification outright.
+;;
+;; Both are native-side, so this file exercises the four native axes.
+;; Numeric and list output only.
+
+;; ── mutated + captured rest parameter ─────────────────────────────────────
+(define (rest-only . xs) ((lambda () (set! xs (cons 99 xs)))) (car xs))
+(display (rest-only 1 2 3)) (newline)              ; 99
+
+(define (rest-after-fixed a b . xs) ((lambda () (set! xs (cons 99 xs)))) (list a b (car xs)))
+(display (rest-after-fixed 7 8 1 2)) (newline)     ; (7 8 99)
+
+(define (rest-depth-3 . xs)
+  ((lambda () ((lambda () ((lambda () (set! xs (cons 77 xs))))))))
+  (car xs))
+(display (rest-depth-3 1)) (newline)               ; 77
+
+(define (rest-stored . xs)
+  (define bump (lambda () (set! xs (cons 5 xs))))
+  (bump) (bump)
+  (length xs))
+(display (rest-stored 1 2)) (newline)              ; 4
+
+(define (rest-escape . xs) (lambda () (set! xs (cons 1 xs)) (length xs)))
+(define counter (rest-escape 9))
+(display (counter)) (newline)                      ; 2
+(display (counter)) (newline)                      ; 3
+(define other (rest-escape 9))
+(display (other)) (newline)                        ; 2 — separate cell
+
+(define rest-lambda (lambda xs ((lambda () (set! xs (cons 42 xs)))) (car xs)))
+(display (rest-lambda 1 2)) (newline)              ; 42
+
+(define (rest-not-captured . xs) (set! xs (cons 3 xs)) (car xs))
+(display (rest-not-captured 1)) (newline)          ; 3
+
+(define (rest-not-mutated . xs) ((lambda () (car xs))))
+(display (rest-not-mutated 4 5)) (newline)         ; 4
+
+;; ── closure over a `do` loop variable ─────────────────────────────────────
+(display (do ((i 0 (+ i 1)) (acc 0)) ((= i 3) acc)
+             ((lambda () (set! acc (+ acc i))))))
+(newline)                                          ; 3
+
+(display (do ((i 0 (+ i 1)) (s 0)) ((= i 4) s)
+             (set! s (+ s ((lambda () i))))))
+(newline)                                          ; 6 — read-only capture
+
+(display (do ((i 0 (+ i 1)) (a 0)) ((= i 3) a)
+             (let ((f (lambda () (set! a (+ a i))))) (f))))
+(newline)                                          ; 3 — let-bound closure
+
+(display (do ((i 0 (+ i 1)) (a 0)) ((= i 3) a)
+             (let loop ((k 0))
+               (if (< k 2) (begin (set! a (+ a i)) (loop (+ k 1))) a))))
+(newline)                                          ; 6 — named let captures
+
+(display (do ((i 0 (+ i 1)) (t 0)) ((= i 3) t)
+             (do ((j 0 (+ j 1))) ((= j 2))
+                 ((lambda () (set! t (+ t 1)))))))
+(newline)                                          ; 6 — nested do
+
+(define (do-in-proc n)
+  (do ((i 0 (+ i 1)) (a 0)) ((= i n) a)
+      ((lambda () (set! a (+ a 1))))))
+(display (do-in-proc 5)) (newline)                 ; 5
+
+(define stored
+  (do ((i 0 (+ i 1)) (acc '())) ((= i 3) acc)
+      (set! acc (cons (lambda () i) acc))))
+(display (length stored)) (newline)                ; 3
+(display (map (lambda (f) (f)) stored)) (newline)  ; (3 3 3)
+
+;; controls: no closure, and a shadowing lambda parameter
+(display (do ((i 0 (+ i 1)) (a 0)) ((= i 3) a) (set! a (+ a i)))) (newline)  ; 3
+(display (do ((i 0 (+ i 1))) ((= i 3) i) ((lambda (i) i) 99))) (newline)     ; 3

--- a/tests/integration/rest_capture_and_do_closure_test.esk
+++ b/tests/integration/rest_capture_and_do_closure_test.esk
@@ -1,0 +1,203 @@
+;;; rest_capture_and_do_closure_test.esk
+;;;
+;;; Class-kill test for two NATIVE-engine capture defects.
+;;;
+;;; SW-33 (silent wrong) — a REST parameter that is both set!-mutated and
+;;; captured by a nested closure did not write back:
+;;;
+;;;   (define (f . rest) ((lambda () (set! rest (cons 99 rest)))) (car rest))
+;;;   (f 1 2 3)   => 1        ; exit 0, no diagnostic. Correct answer: 99
+;;;
+;;; Assignment conversion (ESH-0074) boxes a set!-mutated parameter into an
+;;; alloca so set! has a storage location and every closure capturing it shares
+;;; ONE cell. Both boxing loops walked only the FIXED parameters, so the rest
+;;; parameter stayed a by-value LLVM Argument: the closure copied the list
+;;; VALUE into its environment and the inner set! mutated a private copy that
+;;; was discarded on return.
+;;;
+;;; LE-09 (loud crash) — a `do` loop whose body creates a closure over a loop
+;;; variable was SIGKILLed (exit 137):
+;;;
+;;;   (do ((i 0 (+ i 1)) (acc 0)) ((= i 3) acc)
+;;;       ((lambda () (set! acc (+ acc i)))))
+;;;
+;;; codegenDo cached the stack alloca it had allocated for each loop variable
+;;; and wrote step results there, while every READ went through the symbol
+;;; table — which the closure-capture machinery rebinds to fresh arena storage
+;;; mid-body. The step then read the arena cell and wrote the stack alloca the
+;;; header test had already been compiled against, so `(= i 3)` never became
+;;; true: an infinite loop allocating one closure per iteration until the arena
+;;; exhausted memory. Merely READING a loop variable from a body closure was
+;;; enough; mutation was not required.
+;;;
+;;; Each check states the R7RS-required answer, so the test cannot pass by
+;;; agreeing with a wrong expectation, and the controls at the end pin the
+;;; behaviour the fixes must NOT change.
+
+(define failures 0)
+
+(define (check name got want)
+  (if (equal? got want)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! failures (+ failures 1))
+             (display "FAIL: ") (display name)
+             (display " got ") (display got)
+             (display " want ") (display want) (newline))))
+
+;; ---------------------------------------------------------------------------
+;; SW-33 — mutated + captured REST parameter
+;; ---------------------------------------------------------------------------
+
+;; depth 1, immediately-invoked closure, rest-only signature
+(define (r-only . xs) ((lambda () (set! xs (cons 99 xs)))) (car xs))
+(check "rest-only, depth 1, immediately invoked" (r-only 1 2 3) 99)
+
+;; fixed parameters before the rest parameter (the boxing walk must land on the
+;; argument that follows them)
+(define (r-fixed a b . xs) ((lambda () (set! xs (cons 99 xs)))) (list a b (car xs)))
+(check "rest after two fixed params" (r-fixed 7 8 1 2) (list 7 8 99))
+
+;; depth 2 and depth 3
+(define (r-d2 . xs) ((lambda () ((lambda () (set! xs (cons 88 xs)))))) (car xs))
+(check "rest, depth 2" (r-d2 1) 88)
+
+(define (r-d3 . xs) ((lambda () ((lambda () ((lambda () (set! xs (cons 77 xs)))))))) (car xs))
+(check "rest, depth 3" (r-d3 1) 77)
+
+;; STORED closure rather than immediately invoked, called twice
+(define (r-stored . xs)
+  (define bump (lambda () (set! xs (cons 5 xs))))
+  (bump)
+  (bump)
+  (length xs))
+(check "rest, stored closure called twice" (r-stored 1 2) 4)
+
+;; a closure that OUTLIVES the frame that bound the rest parameter
+(define (r-escape . xs) (lambda () (set! xs (cons 1 xs)) (length xs)))
+(define counter (r-escape 9))
+(check "rest, escaped closure, first call" (counter) 2)
+(check "rest, escaped closure, second call" (counter) 3)
+
+;; two closures sharing ONE cell
+(define (r-shared . xs)
+  (let ((push (lambda () (set! xs (cons 1 xs))))
+        (size (lambda () (length xs))))
+    (push)
+    (push)
+    (size)))
+(check "rest, two closures share one cell" (r-shared 7) 3)
+
+;; a variadic LAMBDA's rest parameter, not only a define's
+(define r-lambda (lambda xs ((lambda () (set! xs (cons 42 xs)))) (car xs)))
+(check "variadic lambda rest parameter" (r-lambda 1 2) 42)
+
+;; two instantiations must NOT share a cell
+(define a-counter (r-escape 1))
+(define b-counter (r-escape 1))
+(check "two instantiations, independent cells (a)" (a-counter) 2)
+(check "two instantiations, independent cells (b)" (b-counter) 2)
+
+;; controls: mutated but NOT captured, and captured but NOT mutated
+(define (r-nocapture . xs) (set! xs (cons 3 xs)) (car xs))
+(check "control: rest mutated, not captured" (r-nocapture 1) 3)
+
+(define (r-nomutate . xs) ((lambda () (car xs))))
+(check "control: rest captured, not mutated" (r-nomutate 4 5) 4)
+
+;; ---------------------------------------------------------------------------
+;; LE-09 — `do` loop variable captured by a body closure
+;; ---------------------------------------------------------------------------
+
+;; the ledger reproducer: mutated capture
+(check "do: closure mutates a loop variable"
+       (do ((i 0 (+ i 1)) (acc 0)) ((= i 3) acc)
+           ((lambda () (set! acc (+ acc i)))))
+       3)
+
+;; READ-ONLY capture is enough to trigger the defect
+(check "do: closure only reads a loop variable"
+       (do ((i 0 (+ i 1)) (s 0)) ((= i 4) s)
+           (set! s (+ s ((lambda () i)))))
+       6)
+
+;; the capture happens in a `let`-bound closure inside the body
+(check "do: let-bound closure captures a loop variable"
+       (do ((i 0 (+ i 1)) (a 0)) ((= i 3) a)
+           (let ((f (lambda () (set! a (+ a i))))) (f)))
+       3)
+
+;; a named let in the body captures the loop variables
+(check "do: named let in the body captures loop variables"
+       (do ((i 0 (+ i 1)) (a 0)) ((= i 3) a)
+           (let loop ((k 0))
+             (if (< k 2)
+                 (begin (set! a (+ a i)) (loop (+ k 1)))
+                 a)))
+       6)
+
+;; nested `do`, inner body closing over the OUTER loop variable
+(check "do: nested loop, closure over the outer variable"
+       (do ((i 0 (+ i 1)) (t 0)) ((= i 3) t)
+           (do ((j 0 (+ j 1))) ((= j 2))
+               ((lambda () (set! t (+ t 1))))))
+       6)
+
+;; the loop runs inside a procedure, with a runtime trip count
+(define (do-in-proc n)
+  (do ((i 0 (+ i 1)) (a 0)) ((= i n) a)
+      ((lambda () (set! a (+ a 1))))))
+(check "do: inside a procedure, runtime bound" (do-in-proc 5) 5)
+
+;; closures STORED out of the loop, then called after it finished
+(define stored-closures
+  (do ((i 0 (+ i 1)) (acc '())) ((= i 3) acc)
+      (set! acc (cons (lambda () i) acc))))
+(check "do: closures stored out of the loop, count" (length stored-closures) 3)
+(check "do: closures stored out of the loop, values"
+       (map (lambda (f) (f)) stored-closures)
+       (list 3 3 3))
+
+;; the loop runs inside a lambda rather than a define
+(define do-in-lambda
+  (lambda (n) (do ((i 0 (+ i 1)) (a 0)) ((= i n) a) ((lambda () (set! a (+ a i)))))))
+(check "do: inside a lambda" (do-in-lambda 4) 6)
+
+;; the capture is in the STEP, the TEST and the RESULT position rather than the
+;; body. These are the ordering hazards the storage-class decision exists to
+;; remove: a capture in the test or the step is compiled AFTER the header was
+;; emitted, so a decision made on the fly could never have been consistent.
+(check "do: closure in a step expression"
+       (do ((i 0 ((lambda () (+ i 1)))) (a 0)) ((= i 3) a) (set! a (+ a i)))
+       3)
+
+(check "do: closure in the test expression"
+       (do ((i 0 (+ i 1)) (a 0)) (((lambda () (= i 3))) a) (set! a (+ a i)))
+       3)
+
+(check "do: closure in the result expression"
+       (do ((i 0 (+ i 1)) (a 0)) ((= i 3) ((lambda () a))) (set! a (+ a i)))
+       3)
+
+;; both defects at once: a rest parameter captured and mutated from inside a
+;; `do` body
+(define (rest-in-do . xs)
+  (do ((i 0 (+ i 1))) ((= i 2) (length xs))
+      ((lambda () (set! xs (cons i xs))))))
+(check "rest parameter captured inside a do body" (rest-in-do 9) 3)
+
+;; controls
+(check "control: do with no closure at all"
+       (do ((i 0 (+ i 1)) (a 0)) ((= i 3) a) (set! a (+ a i)))
+       3)
+
+(check "control: lambda parameter shadows the loop variable"
+       (do ((i 0 (+ i 1))) ((= i 3) i) ((lambda (i) i) 99))
+       3)
+
+;; ---------------------------------------------------------------------------
+
+(newline)
+(if (= failures 0)
+    (begin (display "PASS: rest capture and do closure - 0 failures") (newline))
+    (begin (display "FAIL: rest capture and do closure - ")
+           (display failures) (display " failures") (newline)))

--- a/tests/vm_parity/corpus/60_do_loop_closure_capture.esk
+++ b/tests/vm_parity/corpus/60_do_loop_closure_capture.esk
@@ -1,0 +1,42 @@
+;; LE-09 — a `do` loop whose body creates a closure over a loop variable must
+;; produce the same value on the VM and natively.
+;;
+;; codegenDo cached the stack alloca it allocated for each loop variable and
+;; wrote step results there, while every read went through the symbol table —
+;; which the closure-capture machinery rebinds to fresh arena storage mid-body.
+;; The step then read the arena cell and wrote the alloca the loop test had
+;; already been compiled against, so the test never became true: an infinite
+;; loop allocating one closure per iteration until memory was exhausted
+;; (SIGKILL, exit 137). The VM answered 3 all along, which is what makes this a
+;; parity case rather than a native-only differential.
+;;
+;; SCOPE — deliberately two lines. This file asserts only the shapes the VM is
+;; ALREADY correct on at this SHA. Every adjacent shape was MEASURED, and the
+;; ones excluded are excluded because the VM, not native, is wrong on them:
+;;
+;;   * `do` inside a procedure, body closure mutating a loop variable — VM 0,
+;;     native 5                                                      (SW-34)
+;;   * nested `do`, inner body closing over the OUTER loop variable — VM 2,
+;;     native 6                                                      (SW-34)
+;;   * a second `do` in the same program after one whose body closes over a
+;;     loop variable — VM exhausts ESHKOL_VM_HEAP_MAX_SIZE and dies, or hangs
+;;                                                                   (LE-10)
+;;   * a let-bound (not immediately invoked) body closure, when any top-level
+;;     form precedes the loop — VM "calling non-function"            (LE-10)
+;;
+;; All of those DO run on the native axes, in
+;; tests/differential/corpus/48_rest_capture_and_do_closure.esk and
+;; tests/integration/rest_capture_and_do_closure_test.esk. Pinning them here
+;; would gate this PR on VM defects it does not fix.
+;;
+;; Numeric output only.
+
+;; the LE-09 reproducer: a body closure mutates a loop variable
+(display (do ((i 0 (+ i 1)) (acc 0)) ((= i 3) acc)
+             ((lambda () (set! acc (+ acc i))))))
+(newline)
+
+;; control: the same arithmetic with no closure, so the loop variable keeps its
+;; stack alloca and the storage-class decision is not exercised
+(display (do ((i 0 (+ i 1)) (a 0)) ((= i 3) a) (set! a (+ a i))))
+(newline)


### PR DESCRIPTION
Two NATIVE-engine capture defects. Both were recorded as adjacent findings in
SW-25's notes on `fix/vm-region-and-upvalue` (PR #435) and explicitly left for
this lane; both are fixed at the root, class-killed on all four native axes,
and revert-validated.

The class-kill also measured two VM-side defects that this change does not fix.
They are filed with their reproducers rather than worked around, and one of them
is a **new SILENT-WRONG entry** — justified below, per ledger invariant 4.

## SW-33 — mutated + captured REST parameter does not write back

```scheme
(define (f . rest) ((lambda () (set! rest (cons 99 rest)))) (car rest))
(display (f 1 2 3))     ; 1 — exit 0, no diagnostic. Correct: 99
```

### Root cause

`lib/backend/llvm_codegen.cpp:12692` (`codegenFunctionDefinition`) and
`lib/backend/llvm_codegen.cpp:29678` (`codegenLambda`).

ASSIGNMENT CONVERSION (ESH-0074) boxes a `set!`-mutated parameter into an alloca
so that (a) `codegenSet` has a storage location and (b) every closure capturing
it shares ONE cell — `codegenLambda`'s capture emission then pointer-passes that
alloca instead of copying its value. Both boxing loops iterated only the FIXED
parameters:

```cpp
for (uint64_t i = 0; i < op->define_op.num_params && box_arg_it != function->arg_end(); ++i, ++box_arg_it)
```

The REST parameter is the LLVM argument that **follows** the fixed ones — the
symbol-table loops twenty lines above each site walk exactly that order — so it
never got a box. Confirmed in IR:

```llvm
define %eshkol_tagged_value @f(%eshkol_tagged_value %rest) {
  store %eshkol_tagged_value %rest, ptr %188      ; closure env slot: the VALUE
  ...
  %425 = extractvalue %eshkol_tagged_value %rest, 0   ; (car rest) reads the raw Argument
```

versus the `%n = alloca` a fixed parameter gets. The inner `set!` mutated a
private copy discarded on return.

Both outer guards additionally required `op->define_op.parameters` /
`op->lambda_op.parameters` to be non-null, so a rest-ONLY signature could not
have been reached even if the loop had run.

### Fix

Both sites box the rest parameter on the same terms as a fixed one —
`astSetsVar(body, rest_param)` decides, the box is the alloca the iterator
already points at after the fixed loop, and the outer guard no longer requires a
non-empty fixed parameter list. No new mechanism, no ABI change: the existing
capture machinery pointer-passes the box because it is an alloca like any other.

### Cross-engine note

The VM is wrong the same way at this SHA (also `1`) and is fixed by PR #435,
measured with that branch's build (VM `99`). Two halves of one class, two PRs;
neither engine is the oracle for the other here, which is why this entry's gates
are the four NATIVE axes against absolute expected values, not a parity
comparison.

## LE-09 — `do` loop with a captured loop variable never terminates (SIGKILL)

```scheme
(do ((i 0 (+ i 1)) (acc 0)) ((= i 3) acc)
    ((lambda () (set! acc (+ acc i)))))
```

SIGKILL, exit 137, on both `-r` routes. Under an explicit CPU limit the same run
exits 152 (SIGXCPU) with no output — which is what identifies it as a runaway
loop rather than an allocator fault. Correct answer: `3`, which the VM gives.

### Root cause

`lib/backend/llvm_codegen.cpp`, `codegenDo` — `var_allocas` at ~24282, the step
store at ~24371.

A `do` variable is READ from three places emitted at three different times — the
header test first, the body second, the step expressions third — but `codegenDo`
wrote the step result to the stack alloca it had cached in `var_allocas`, while
every read went through `symbol_table`. `codegenLambda`'s capture emission
("CLOSURE ESCAPE FIX", ~30036) **rebinds** a captured stack alloca to fresh arena
storage mid-body and repoints `symbol_table` at it, seeding the new cell ONCE in
the pre-header. The variable split in two:

```llvm
do_loop_step:
  %i.load68 = load %eshkol_tagged_value, ptr %8      ; ARENA cell — never advanced
  %99 = call @__eshkol_arith_add(%i.load68, 1)
  store %eshkol_tagged_value %99, ptr %i_do          ; STACK alloca
  br label %do_loop_header

do_loop_header:
  %i.load = load %eshkol_tagged_value, ptr %i_do     ; reads 1 forever
```

`(= i 3)` never became true, and each iteration allocated a fresh closure in the
arena, so the loop consumed memory without bound until the OS killed it.

Measured, and wider than the ledger note said:

| shape | before |
|---|---|
| mutating capture (the ledger reproducer) | runaway, exit 137 |
| **read-only** capture `(set! s (+ s ((lambda () i))))` | runaway — mutation is not required |
| let-bound body closure | `LLVM module verification failed: Instruction does not dominate all uses` on the `arena_allocate` |
| named let in the body | same verification failure |
| body with no closure | correct, unchanged |
| body lambda whose PARAMETER shadows the loop variable | correct, unchanged |

### Fix

The storage class is decided **before** the loop is emitted, mirroring
`codegenNamedLet`, which has always arena-moved its captured cells up front.
`doFormCapturesVar()` asks whether any lambda or named let in the bindings, test,
results or body captures the variable. If so the cell is arena storage from the
start — which is what the capture machinery would have converged on anyway, and
being an already-pointer-typed `CallInst` it takes `codegenLambda`'s "existing
arena storage" branch, which pointer-passes **without rebinding anything**.
Otherwise the variable keeps its stack alloca and stays promotable by mem2reg,
so closure-free `do` loops are unchanged. Verified in IR:

```llvm
; (do ((i 0 (+ i 1)) (a 0)) ((= i 3) a) (set! a (+ a i)))   — no closure
  %i_do = alloca %eshkol_tagged_value
  %a_do = alloca %eshkol_tagged_value

; the reproducer                                            — captured
  %i_do_cell   = call ptr @arena_allocate(ptr %7, i64 16)
  %acc_do_cell = call ptr @arena_allocate(ptr %8, i64 16)
```

Deciding up front removes the ordering hazard instead of patching one of its
three symptoms. It is the only order-independent formulation: a capture in the
**test** or a **step** is compiled *after* the header was emitted, so a decision
made on the fly could never be consistent. Both of those shapes are in the
class-kill.

An INVARIANT closes the loop at the end of `codegenDo`: if any loop variable was
arena-moved anyway, the capture analysis missed a form, and codegen now FAILS
LOUDLY with a diagnostic instead of emitting a loop that cannot terminate. It is
narrowed to the arena-move signature (a pointer-typed `CallInst`) so that the
legitimate module-storage rebinding below is not flagged.

### The predicate, and two corrections the invariant forced

The capture analysis reuses `astSetsVar`'s traversal rather than adding a fourth
copy of it. That walk is now `astScanVar(ast, var, VarScanMode)` with two node
tests over one shared recursion — `SetTarget` (the original predicate,
behaviourally unchanged) and `ClosureCapture`. `astSetsVar` remains as a
one-line wrapper. The traversal's completeness is the scarce thing here; its own
comment records why, and it is now shared instead of re-derived.

The invariant caught two design errors during class-kill, and both are the
non-obvious part of this change:

1. **A zero-argument `(define (bump) …)` is still a closure.** The first draft
   tested `num_params > 0`; `is_function` is the right test.
2. **…but an internal function define is NOT a `ClosureCapture` site at all.**
   `codegenFunctionDefinition` captures through module-level storage
   (`<fn>_nested_N_capture_<var>`) re-seeded from the enclosing binding on every
   execution, which does not split the loop and does not want a shared cell.
   Forcing arena storage for
   `(do ((i 0 (+ i 1)) (a 0)) ((= i 3) a) (define (bump) (set! a (+ a i))) (bump))`
   turned a correct `3` into a type error — measured against a pre-fix build, not
   assumed. `(define bump (lambda …))` is a different shape and IS caught, by the
   `LAMBDA_OP` case.

## Class-kill

`tests/integration/rest_capture_and_do_closure_test.esk` — **29/29 checks**,
identical on all four native axes.

* rest parameters: depths 1-3; immediately-invoked AND stored closures; a
  closure that outlives the frame that bound the rest parameter; two closures
  sharing one cell; two instantiations NOT sharing one; `lambda` as well as
  `define` rest parameters; a rest parameter after two fixed parameters
* `do` loops: mutating and read-only captures; immediately-invoked and let-bound
  closures; a named let in the body; a nested `do` closing over the OUTER
  variable; a loop inside a procedure with a runtime trip count; a loop inside a
  lambda; closures stored out of the loop and called after it finished; captures
  in the **step**, **test** and **result** positions
* both defects at once: a rest parameter captured and mutated from inside a `do`
  body
* controls: mutated-but-uncaptured rest, captured-but-unmutated rest, a `do` with
  no closure, and a body lambda whose parameter shadows the loop variable

`tests/differential/corpus/48_rest_capture_and_do_closure.esk` covers the native
axes. `tests/vm_parity/corpus/60_do_loop_closure_capture.esk` pins the LE-09
reproducer VM-vs-native.

**Revert-validated** against a build of the same tree without the codegen change
(worktree `eshkol-wt-vmmem`, whose diff touches no native codegen — confirmed
with `git diff origin/master...HEAD -- lib/backend/llvm_codegen.cpp`, empty):

* the SW-33 reproducer answers `1`
* the class-kill test does not compile at all, refusing with
  `set!: variable 'xs' is not mutable (not an alloca, global, or capture pointer)`
  and `LLVM module verification failed: Instruction does not dominate all uses`
* the LE-09 reproducer runs until the CPU limit fires

## Gates

Clean build of this tree, RelWithDebInfo, arm64-apple-darwin24.1.0.

| gate | result |
|---|---|
| `ctest --test-dir build` | **168/168** (164 baseline + the 4 lanes added here) |
| `scripts/run_vm_parity.sh` | **160/160** (158 baseline + 2 for the new corpus file) |
| `scripts/run_differential.sh` | **294/294** axis pairs over 49 programs (288/288 over 48 baseline); all 6 pairs of the new program pass |
| `scripts/gate_no_silent_wrong.py` | 14 open unwaived SILENT-WRONG — 13 pre-existing and unchanged, plus SW-34 opened here |

`scripts/run_icc_smoke.sh` was **not** run as a whole, and that is reported
rather than papered over: another worktree on this host had a smoke run in
flight and the 1-minute load average was 11-13. PR #435 already recorded one
contention false-red from exactly that situation, so a full run here would not
have been honest evidence. Path-scoped probes were run instead, chosen for what
this diff touches:

| probe | result |
|---|---|
| `llvm_module_verifier_clean` | PASS |
| `closure_set_tco_loop_oracle` (ESH-0094, closure in a TCO loop set!s a capture) | PASS |
| `ad_capture_global_shadow_oracle` | PASS, 19/19 checks |
| `higher_order_shadowing_oracle` (JIT axis) | PASS |
| `define_loop_flat_rss_aot` (ESH-0214b loop/arena RSS gate) | PASS |
| `stdlib_compiles_clean` | PASS (full stdlib rebuild, exit 0) |
| `engine_semantic_parity` | PASS — 203 programs / 1114-construct surface, 6 divergent and **0 regressed**, construct coverage 136/1114 (12.21%) holding its floor |

## Two VM defects found by the class-kill, filed not fixed

Both are VM-side; this diff changes `lib/backend/llvm_codegen.cpp` only. Both
reproduce identically on the VM at this SHA **and** on PR #435's branch, so #435
neither causes nor fixes them.

**SW-34 (SILENT-WRONG, open — this is the ledger growth).** A `do` loop variable
captured and mutated by a body closure loses the mutation when the loop is inside
a procedure, and in a nested loop:

```scheme
(define (f n) (do ((i 0 (+ i 1)) (a 0)) ((= i n) a) ((lambda () (set! a (+ a 1))))))
(f 5)                                  ; VM 0, native 5

(do ((i 0 (+ i 1)) (t 0)) ((= i 3) t)
    (do ((j 0 (+ j 1))) ((= j 2)) ((lambda () (set! t (+ t 1))))))
                                       ; VM 2, native 6
```

The same loop at top level is correct on the VM (`3`), as is a read-only capture
(`6`). The likely shape of the fix is #435's mechanism applied to
`compile_form_do()`'s bindings — SW-25's own root cause names `compile_form_let()`
as the only binding form that had ever run `needs_boxing()` — but that is a
VM-compiler change and wants its own measurement lane. Opening it is the honest
record of a wrong value produced with exit 0.

**LE-10 (LOUD-ERROR, open).** A `do` loop with a body closure poisons a *later*
`do` loop in the same program: `ERROR: VM heap object limit reached
(ESHKOL_VM_HEAP_MAX_SIZE=16777216 objects)`, exit 1, after the first loop has
already printed its correct answer. A let-bound body closure additionally gives
`ERROR: calling non-function` whenever any top-level form precedes the loop, and
longer sequences hang. Each shape is correct **alone**, which is what identifies
the defect as sequence-dependent rather than shape-dependent.

This is why `tests/vm_parity/corpus/60_do_loop_closure_capture.esk` is two lines
long. Its SCOPE comment names every excluded shape and the measured VM answer for
each, so the exclusions are auditable from the corpus rather than only from the
ledger — and every one of them still runs, green, on the native axes.
