### PR TITLE
fix(vm): pop do-loop variables and box captured ones (LE-10, SW-34)

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -1001,48 +1001,72 @@ entries:
 
   - id: SW-34
     bucket: SILENT-WRONG
-    status: open
-    title: "VM: a `do` loop variable captured and mutated by a body closure loses the mutation inside a procedure and in a nested loop"
-    repro: >-
-      (define (f n) (do ((i 0 (+ i 1)) (a 0)) ((= i n) a) ((lambda () (set! a (+ a 1)))))) (display (f 5))
-    observed: "VM 0 — exit 0, no diagnostic"
-    correct: "5 — native answers 5 after the LE-09 fix"
-    affected_measured:
-      - "(define (f n) (do ((i 0 (+ i 1)) (a 0)) ((= i n) a) ((lambda () (set! a (+ a 1)))))) (f 5) -> VM 0, native 5"
-      - "(do ((i 0 (+ i 1)) (t 0)) ((= i 3) t) (do ((j 0 (+ j 1))) ((= j 2)) ((lambda () (set! t (+ t 1)))))) -> VM 2, native 6"
-    unaffected_measured:
-      - "the same loop at TOP LEVEL: (do ((i 0 (+ i 1)) (acc 0)) ((= i 3) acc) ((lambda () (set! acc (+ acc i))))) -> VM 3, native 3"
-      - "a read-only capture: (do ((i 0 (+ i 1)) (s 0)) ((= i 4) s) (set! s (+ s ((lambda () i))))) -> VM 6, native 6"
-    discovered_by: >-
-      class-killing LE-09 on the native side. Every `do` shape the native fix
-      had to handle was run on both engines; these two are the ones where the VM
-      answers wrongly and native answers correctly.
-    not_fixed_here: >-
-      NOT a native defect and NOT closed by branch fix/native-rest-capture-and-do-loop,
-      which changes lib/backend/llvm_codegen.cpp only. Measured against BOTH the
-      VM at this SHA and the VM on the SW-25 branch fix/vm-region-and-upvalue:
-      identical wrong answers, so PR #435's parameter/let boxing does not reach
-      `do` bindings. The likely shape of the fix is the same mechanism applied to
-      compile_form_do()'s bindings — the SW-25 entry's own root_cause names
-      compile_form_let() as the only binding form that had ever run
-      needs_boxing() — but that is a VM-compiler change and wants its own
-      measurement lane.
+    status: closed
+    closed_at: "2ae3787f"
+    closed_by: "branch fix/vm-do-loop-capture"
+    title: "A `do` loop variable captured and mutated by a body closure loses the mutation inside a procedure"
+    repro: "(define (f n) (do ((i 0 (+ i 1)) (a 0)) ((= i n) a) ((lambda () (set! a (+ a 1)))))) (display (f 5))"
+    observed: "VM 0"
+    correct: "5 — native answers 5"
+    cross_engine: >-
+      the nested-loop form
+      (do ((i 0 (+ i 1)) (t 0)) ((= i 3) t) (do ((j 0 (+ j 1))) ((= j 2)) ((lambda () (set! t (+ t 1))))))
+      was VM 2, native 6. The same loop at TOP LEVEL was already correct on the
+      VM (3), which is the tell: only the root chunk has the open-slot relay.
+    observed_after: "VM 5 and VM 6, byte-identical to native across 19 shapes"
+    root_cause: >-
+      lib/backend/vm_compiler.c::compile_form_do() bound its loop variables
+      with a bare add_local(). compile_form_let() has always run needs_boxing()
+      (lib/backend/vm_parser.c) over its bindings, so a `let` variable that is
+      both set!-mutated and captured by a nested lambda lives in a shared
+      1-element vector; a `do` variable never got that treatment, so OP_CLOSURE
+      copied its VALUE into the closure's upvalue array and the inner set!
+      mutated a private copy discarded at the end of the iteration. The
+      top-level case was correct only because the root chunk aliases an
+      absolute VM stack slot through the open-slot relay (native calls
+      151/252), which is deliberately restricted to the root chunk because a
+      function's frame dies on return.
+    fix: >-
+      compile_form_do() boxes every loop variable needs_boxing() reports as
+      mutated-and-captured, scanning the test, the results, the body AND every
+      step expression, since a do variable is in scope for all four. A boxed
+      variable's step store goes through VEC_SET into the same cell. The step
+      values are held in anonymous locals first so that parallel update (R7RS
+      4.2.4 — every step sees the pre-step values) is preserved while still
+      giving VEC_SET its box and index UNDER the value.
+    residue_found_and_fixed: >-
+      Boxing a `do` variable exposed a PRE-EXISTING defect in
+      compile_form_set(): both of its boxed paths (local and upvalue) left TWO
+      values on the operand stack, because OP_VEC_SET pushes NIL and the shared
+      tail pushes the NIL that `set!` evaluates to, while every caller pops
+      one. Inside a frame about to RETURN the surplus was absorbed and
+      invisible, which is why it had never been seen; in a `do` body — inline
+      statements each followed by exactly one OP_POP — it accumulated once per
+      iteration until the operand stack overflowed (STACK OVERFLOW, fatal).
+      Fixed at the root by discarding VEC_SET's NIL in both paths.
     evidence: >-
-      tests/vm_parity/corpus/60_do_loop_closure_capture.esk documents both
-      shapes in its SCOPE comment and deliberately does NOT assert them, so this
-      entry is visible from the corpus rather than only from the ledger. The
-      native side of both shapes IS gated, in
-      tests/integration/rest_capture_and_do_closure_test.esk and
-      tests/differential/corpus/48_rest_capture_and_do_closure.esk.
-    caught_by: [direct-measurement, le-09-class-kill]
+      tests/vm_parity/corpus/61_do_loop_variable_binding.esk and
+      tests/differential/corpus/49_do_loop_variable_binding.esk.
+      Revert-validated: restoring lib/backend/vm_compiler.c reproduces VM 0 for
+      the filed reproducer and VM 2 for the nested form.
+    caught_by: [pr-437-class-kill]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity, differential-corpus, KNOWN_ISSUES]
     notes: >-
-      Growth justified per invariant 4: this is a NEW SILENT-WRONG entry opened
-      by a PR that closes two others. It is recorded rather than fixed because
-      fixing it means changing the VM compiler's binding forms days before a
-      tag, on a mechanism whose native counterpart took this whole lane to get
-      right, and because the class-kill measurement that found it is the only
-      thing that makes a VM fix verifiable.
+      The fourth binding form of the SW-25 family (parameters, let*, letrec,
+      letrec* were closed by PR #435; `do` is closed here), and the same root
+      cause: a binding that is mutated across a closure boundary needs a shared
+      CELL, and only `let` ever had one.
+      FOUR native-side `do` shapes were held out of the corpus while this fix
+      was written, because the NATIVE engine was wrong or failed on them at the
+      pre-#437 base — capture in a STEP (native 0, VM 8), capture in a RESULT
+      (native: LLVM module verification failed, VM 10), a step that must see a
+      body closure's mutation (native 30, VM 33), and a read-only capture
+      (native: no output, VM 6). PR #437 landed on master and fixed the native
+      side of all four; on the rebased tree the two engines AGREE on every one,
+      at exactly the values the VM already produced, and all four are now
+      asserted in both corpus files. The exclusion list is empty — which is the
+      point of having written the measured pairs down rather than only naming
+      the shapes.
 
   # ───────────────────────── IN-FLIGHT ─────────────────────────
 
@@ -1418,42 +1442,78 @@ entries:
 
   - id: LE-10
     bucket: LOUD-ERROR
-    subtag: codegen
-    status: open
-    title: "VM: a `do` loop with a body closure poisons a LATER `do` loop in the same program — heap-object limit, fatal call, or hang"
-    repro: >-
-      (display (do ((i 0 (+ i 1)) (s 0)) ((= i 4) s) (set! s (+ s ((lambda () i)))))) (newline)
-      (display (do ((i 0 (+ i 1))) ((= i 3) i) ((lambda (i) i) 99)))
+    subtag: cheap-fix
+    status: closed
+    closed_at: "2ae3787f"
+    closed_by: "branch fix/vm-do-loop-capture"
+    title: "A `do` loop poisons a LATER `do` in the same program (VM heap object limit / calling non-function / hang)"
+    repro: "(display (do ((i 0 (+ i 1)) (a 0)) ((= i 3) a) ((lambda () (set! a (+ a 1)))))) (display (do ((k 0 (+ k 1)) (b 0)) ((= k 4) b) (set! b (+ b 10))))"
     observed: >-
-      "ERROR: VM heap object limit reached (ESHKOL_VM_HEAP_MAX_SIZE=16777216
-      objects)" then "VM terminated on a fatal runtime error", exit 1, after the
-      FIRST loop has already printed its correct answer.
-    correct: "6 then 3 — native prints both"
-    affected_measured:
-      - "second `do` after a body-closure `do`: heap-object limit, exit 1"
-      - "a let-bound (not immediately invoked) body closure, when any top-level form precedes the loop: \"ERROR: calling non-function\", exit 1"
-      - "a longer sequence of the same shapes: hangs until the CPU limit fires (exit 152)"
-    unaffected_measured:
-      - "either loop ALONE in its own program: both correct"
-      - "two body-closure `do` loops with disjoint variable names: both correct"
-    discovered_by: >-
-      assembling tests/vm_parity/corpus/60_do_loop_closure_capture.esk while
-      class-killing LE-09. Each candidate line was correct on the VM in
-      isolation and the file still failed, which is what identified the defect
-      as sequence-dependent rather than shape-dependent.
-    not_fixed_here: >-
-      VM-side. Branch fix/native-rest-capture-and-do-loop changes
-      lib/backend/llvm_codegen.cpp only. Reproduces identically on the VM at
-      this SHA and on the SW-25 branch fix/vm-region-and-upvalue, so PR #435
-      neither causes nor fixes it. LOUD, so it does not gate the release, but it
-      is the reason the vm-parity corpus file added by that branch is two lines
-      long, and that constraint should not be mistaken for a small class.
+      as filed: "ERROR: VM heap object limit reached
+      (ESHKOL_VM_HEAP_MAX_SIZE=16777216 objects)", exit 1, after the first loop
+      printed its correct answer; a let-bound body closure additionally gave
+      "ERROR: calling non-function" whenever a top-level form preceded the
+      loop, and longer sequences hung. Each shape was correct ALONE, which is
+      what identified it as sequence-dependent.
+    measured: >-
+      RE-MEASURED at 2ae3787f and found WIDER, and partly SILENT, than filed.
+      The reproducer above answers 3 then 13 on the VM where native answers 3
+      then 40 — a wrong VALUE with exit 0 and no diagnostic, not a loud error.
+      It also needs NEITHER a closure NOR a capture: two ordinary sequential
+      `do` loops diverge the same way, and the minimal case is a `do` followed
+      by a `define`:
+        (do ((i 0 (+ i 1))) ((= i 2)) 1) (define q 42) (display q)
+      which is 2 on the VM and 42 natively. The loud shapes this entry was
+      filed for are the same corruption landing on a slot whose stranded junk
+      happens to be a loop counter or a callee.
+    root_cause: >-
+      lib/backend/vm_compiler.c::compile_form_do() never popped its loop
+      variables. compile_form_let() ends with OP_POPN; compile_form_do() ended
+      by decrementing the compiler's own c->n_locals — a COMPILE-TIME
+      bookkeeping change with no runtime effect — so every `do` form stranded
+      one operand-stack value per loop variable. Top-level bindings live in
+      stack slots handed out by counting (add_local), and the top-level driver
+      emits exactly one OP_POP per expression that grew no local, so the
+      stranded values shift every later slot. This is the SAME slot-shift
+      corruption already documented on compile_form_require() and
+      compile_form_with_region() in that file, reached a third way.
+    fix: >-
+      compile_form_do() emits OP_POPN for its loop variables at the loop exit,
+      keeping the result on top, exactly as compile_form_let() does; the result
+      expressions are compiled out of tail position when there are locals to
+      pop, because a TAIL_CALL would skip the OP_POPN. The same rewrite removed
+      a second latent hazard: the function used to emit a complete first
+      version of the loop and then "discard" it with `c->code_len = loop_top`,
+      leftover debugging scaffolding that compiled the body and steps TWICE.
+      Rewinding code_len un-emits code and none of the constant-pool, upvalue,
+      closure-PC or global repatch-array side effects the discarded pass had
+      already caused.
     evidence: >-
-      tests/vm_parity/corpus/60_do_loop_closure_capture.esk SCOPE comment names
-      both shapes; the native side of both runs green in
-      tests/differential/corpus/48_rest_capture_and_do_closure.esk.
-    caught_by: [direct-measurement, le-09-class-kill]
-    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity, differential-corpus, KNOWN_ISSUES]
+      tests/vm_parity/corpus/61_do_loop_variable_binding.esk (VM-vs-native on
+      the native, vm-src and vm-eskb axes) and
+      tests/differential/corpus/49_do_loop_variable_binding.esk.
+      Revert-validated: with lib/backend/vm_compiler.c restored, the corpus
+      file HANGS on the VM (killed at 25s) and the individual shapes answer 2,
+      00, 2 and 0 where the fixed VM and native both answer 42, 50, 6 and 4.
+    filed_shapes_measured: >-
+      The two shapes PR #437 filed this entry against, carried over from its
+      wording so the union loses no evidence, and re-run on the fixed VM:
+        (display (do ((i 0 (+ i 1)) (s 0)) ((= i 4) s) (set! s (+ s ((lambda () i))))))
+        (display (do ((i 0 (+ i 1))) ((= i 3) i) ((lambda (i) i) 99)))
+      filed as "heap object limit reached" then a fatal error, exit 1, after
+      the first loop had printed its correct answer; correct is 6 then 3, which
+      native prints. Also filed: a let-bound (not immediately invoked) body
+      closure gave "ERROR: calling non-function" whenever any top-level form
+      preceded the loop, and longer sequences hung.
+    caught_by: [pr-437-class-kill, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity, differential-corpus]
+    notes: >-
+      Filed as LOUD-ERROR by PR #437's class-kill, on the shapes it happened to
+      hit. Re-measurement found the same root cause also produces SILENT wrong
+      values, so the entry was closed on the wider evidence rather than on the
+      loud shapes alone. Had it been closed only against the filed reproducer,
+      the `do`-then-`define` case would still be shipping.
+
 
   # ───────────────────────── PARITY-RATCHET ─────────────────────────
 

--- a/lib/backend/vm_compiler.c
+++ b/lib/backend/vm_compiler.c
@@ -2152,11 +2152,21 @@ static void compile_form_set_bang(FuncChunk* c, Node* node, int tail) {
     }
 
     if (slot >= 0 && is_boxed) {
-        /* Boxed local: emit GET_LOCAL(box), CONST(0), compile(value), VEC_SET */
+        /* Boxed local: emit GET_LOCAL(box), CONST(0), compile(value), VEC_SET.
+         *
+         * OP_VEC_SET pops its three operands and PUSHES NIL, but the shared
+         * tail below already pushes the NIL that `set!` evaluates to. Without
+         * this POP the boxed paths left TWO values where every caller pops
+         * one, so each execution stranded one operand-stack value. Inside a
+         * frame that is about to RETURN the surplus was absorbed and invisible;
+         * in a bytecode loop compiled into the SAME chunk — a `do` body, whose
+         * statements are followed by exactly one OP_POP each — it accumulated
+         * once per iteration until the operand stack overflowed. */
         chunk_emit(c, OP_GET_LOCAL, slot);  /* push box (vector) */
         chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL(0))); /* index 0 */
         compile_expr(c, node->children[2], 0); /* compile new value */
         chunk_emit(c, OP_VEC_SET, 0);       /* box[0] = value */
+        chunk_emit(c, OP_POP, 0);           /* discard VEC_SET's NIL */
     } else if (slot >= 0) {
         /* Unboxed local: direct SET_LOCAL */
         compile_expr(c, node->children[2], 0);
@@ -2212,11 +2222,14 @@ static void compile_form_set_bang(FuncChunk* c, Node* node, int tail) {
                 }
                 if (final_uv >= 0) {
                     if (var_boxed) {
-                        /* Boxed upvalue: GET_UPVALUE(box), CONST 0, value, VEC_SET */
+                        /* Boxed upvalue: GET_UPVALUE(box), CONST 0, value,
+                         * VEC_SET — then discard VEC_SET's NIL, for the same
+                         * reason as the boxed-local path above. */
                         chunk_emit(c, OP_GET_UPVALUE, final_uv);
                         chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL(0)));
                         compile_expr(c, node->children[2], 0);
                         chunk_emit(c, OP_VEC_SET, 0);
+                        chunk_emit(c, OP_POP, 0);
                     } else {
                         compile_expr(c, node->children[2], 0);
                         chunk_emit(c, OP_SET_UPVALUE, final_uv);
@@ -2234,129 +2247,188 @@ static void compile_form_set_bang(FuncChunk* c, Node* node, int tail) {
 
 /**
  * @brief Compile `(do ((var init [step])...) (test result...) body...)`.
- *        Initializes loop variables, then loops: evaluate the exit test;
- *        if true, evaluate the result expressions (last one in tail
- *        position) and exit; if false, run the body, evaluate all step
- *        expressions before storing any of them (so each step can
- *        reference the pre-step values of the others — parallel update),
- *        then loop back. Note: the function briefly emits a first,
- *        differently-structured attempt at this loop (see the inline
- *        commentary explaining the JUMP_IF_FALSE polarity confusion) before
- *        resetting `c->code_len` back to loop_top and re-emitting the
- *        correct version — the first attempt's bytecode is discarded.
+ *
+ * Emits: bind the loop variables, then loop — evaluate the exit test; if true,
+ * evaluate the result expressions (last one in tail position when the scope
+ * needs no cleanup) and leave the loop; if false, run the body, evaluate ALL
+ * step expressions before storing any of them (so each step sees the pre-step
+ * values of the others — R7RS 4.2.4 parallel update), then loop back.
+ *
+ * THREE DEFECTS THIS REPLACES.
+ *
+ *  1. THE LOOP VARIABLES WERE NEVER POPPED (LE-10, and a silent-wrong case
+ *     wider than the one that entry was filed for). `compile_form_let()` ends
+ *     with `OP_POPN n_let_locals`; this function ended by decrementing
+ *     `c->n_locals` — a COMPILE-TIME bookkeeping change with no runtime
+ *     effect — so every `do` form stranded one operand-stack value per loop
+ *     variable. Top-level bindings live in stack slots the compiler hands out
+ *     by counting (`add_local`), and the top-level driver emits exactly one
+ *     `OP_POP` per expression that grew no local, so the stranded values shift
+ *     every later slot. This is the same corruption documented on
+ *     compile_form_require() and compile_form_with_region(), reached a third
+ *     way. It needed no closure and no capture to bite:
+ *
+ *         (do ((i 0 (+ i 1))) ((= i 2)) 1)
+ *         (define q 42)
+ *         (display q)          ; VM 2, native 42 — q read the stranded `i`
+ *
+ *     Two sequential `do` loops miscompiled the second one the same way
+ *     (VM 13, native 40). The loud shapes LE-10 records — "VM heap object
+ *     limit reached", "calling non-function", and hangs — are the same
+ *     stranding landing on a slot whose junk happens to be a loop counter or
+ *     a callee.
+ *
+ *  2. THE BODY AND STEPS WERE COMPILED TWICE. The function used to emit a
+ *     complete first version of the loop, then "discard" it with
+ *     `c->code_len = loop_top` and re-emit — leftover scaffolding from a
+ *     debugging session, its reasoning still in the source as commentary about
+ *     JUMP_IF_FALSE polarity. Rewinding `code_len` un-emits CODE and nothing
+ *     else: the discarded pass had already appended to the constant pool,
+ *     registered upvalues, written closure PC constants pointing into the
+ *     region about to be overwritten, and pushed entries onto the global
+ *     forward-reference repatch arrays. Compiling a body for its side effects
+ *     and throwing the code away is not a discard; the correct structure is
+ *     simply emitted once below.
+ *
+ *  3. A MUTATED-AND-CAPTURED LOOP VARIABLE WAS CAPTURED BY VALUE (SW-34).
+ *     `compile_form_let()` has always run `needs_boxing()` over its bindings;
+ *     this function bound its variables with a bare `add_local()`, so
+ *     `OP_CLOSURE` copied the variable's VALUE into the closure's upvalue
+ *     array and an inner `set!` mutated a private copy:
+ *
+ *         (define (f n)
+ *           (do ((i 0 (+ i 1)) (a 0)) ((= i n) a)
+ *               ((lambda () (set! a (+ a 1))))))
+ *         (f 5)                ; VM 0, native 5
+ *
+ *     The same loop at TOP LEVEL was correct, which is the tell: the top-level
+ *     chunk has the open-slot relay (native calls 151/252) aliasing an
+ *     absolute VM stack slot, and that relay is deliberately restricted to the
+ *     root chunk because a function's frame dies on return. Boxing is the
+ *     mechanism that works at every depth — the same fix, and the same
+ *     `needs_boxing()` predicate, that the `let` binding form already used.
+ *
+ * A do variable is in scope for the test, the results, the body AND every step
+ * expression, so the capture scan covers all four; a variable captured only by
+ * a step or a result is boxed just the same.
  */
 static void compile_form_do(FuncChunk* c, Node* node, int tail) {
     Node* head = node->children[0];
-    (void)head; (void)tail;
+    (void)head;
+    int saved_locals = c->n_locals;
     c->scope_depth++;
     Node* vars = node->children[1];
     Node* test = node->children[2];
 
-    /* Initialize loop variables */
+    /* Everything a do variable is in scope for, for needs_boxing(). */
+    Node* scope_nodes[64];
+    int n_scope = 0;
+    if (test && test->type == N_LIST)
+        for (int i = 0; i < test->n_children && n_scope < 64; i++)
+            scope_nodes[n_scope++] = test->children[i];
+    for (int i = 3; i < node->n_children && n_scope < 64; i++)
+        scope_nodes[n_scope++] = node->children[i];
+    for (int i = 0; i < vars->n_children && n_scope < 64; i++) {
+        Node* b = vars->children[i];
+        if (b->type == N_LIST && b->n_children >= 3) scope_nodes[n_scope++] = b->children[2];
+    }
+
+    /* Bind the loop variables, boxing the ones a nested lambda both captures
+     * and `set!`s so every closure shares one cell (SW-34). */
     for (int i = 0; i < vars->n_children; i++) {
         Node* b = vars->children[i];
         if (b->type == N_LIST && b->n_children >= 2 && b->children[0]->type == N_SYMBOL) {
+            const char* vname = b->children[0]->symbol;
+            int box = needs_boxing(scope_nodes, n_scope, vname);
             compile_expr(c, b->children[1], 0);
-            add_local(c, b->children[0]->symbol);
+            if (box) chunk_emit(c, OP_VEC_CREATE, 1);
+            add_local(c, vname);
+            if (box) c->locals[c->n_locals - 1].boxed = 1;
         }
     }
+    int n_do_locals = c->n_locals - saved_locals;
 
-    /* Loop top */
-    int loop_top = c->code_len;
+    if (test && test->type == N_LIST && test->n_children >= 1) {
+        int loop_top = c->code_len;
 
-    /* Test */
-    if (test->type == N_LIST && test->n_children >= 1) {
+        /* Exit test. TRUE means leave the loop, so the body is the FALSE arm. */
         compile_expr(c, test->children[0], 0);
-        int jexit = placeholder(c);
+        int jbody = placeholder(c);           /* JUMP_IF_FALSE -> body */
 
-        /* Body (if any) */
-        for (int i = 3; i < node->n_children; i++) {
-            compile_expr(c, node->children[i], 0);
-            chunk_emit(c, OP_POP, 0);
-        }
-
-        /* Step — evaluate ALL step expressions, then store (parallel) */
-        int step_count = 0;
-        for (int i = 0; i < vars->n_children; i++) {
-            Node* b = vars->children[i];
-            if (b->type == N_LIST && b->n_children >= 3) {
-                compile_expr(c, b->children[2], 0);
-                step_count++;
+        /* Exit arm: the result sequence. Not in tail position when locals
+         * still have to be popped — a TAIL_CALL would skip the OP_POPN. */
+        int result_tail = (n_do_locals > 0) ? 0 : tail;
+        if (test->n_children >= 2) {
+            for (int i = 1; i < test->n_children; i++) {
+                int is_last = (i == test->n_children - 1);
+                compile_expr(c, test->children[i], is_last ? result_tail : 0);
+                if (!is_last) chunk_emit(c, OP_POP, 0);
             }
-        }
-        /* Store in reverse order */
-        for (int i = vars->n_children - 1; i >= 0; i--) {
-            Node* b = vars->children[i];
-            if (b->type == N_LIST && b->n_children >= 3) {
-                int slot = resolve_local(c, b->children[0]->symbol);
-                if (slot >= 0) chunk_emit(c, OP_SET_LOCAL, slot);
-            }
-        }
-
-        /* Loop back */
-        chunk_emit(c, OP_LOOP, loop_top);
-
-        /* Exit: evaluate result expression */
-        patch(c, jexit, OP_JUMP_IF_FALSE, c->code_len - 1);
-        /* Wait — JUMP_IF_FALSE jumps when false. The test is the EXIT condition.
-         * When test is TRUE → exit. When FALSE → continue loop.
-         * So: if test is true → DON'T jump (fall through to exit).
-         *     if test is false → jump back to loop.
-         * Need: JUMP_IF_FALSE → loop_body, then after body+step → LOOP back.
-         * After LOOP: exit point. */
-        /* Actually restructure: test → if FALSE, do body+step+loop. If TRUE, exit. */
-        /* Current: test → jexit (JUMP_IF_FALSE to ???). Body. Step. LOOP.
-         * jexit should point to AFTER the LOOP (the exit point).
-         * But JUMP_IF_FALSE jumps when FALSE. If test is FALSE → continue loop body.
-         * If test is TRUE → skip to exit.
-         * So JUMP_IF_FALSE should jump PAST the exit... no.
-         *
-         * Let me use: NOT test → JUMP_IF_FALSE to exit. */
-        /* Restart: */
-        c->code_len = loop_top; /* redo from loop top */
-        compile_expr(c, test->children[0], 0);
-        /* test is TRUE when loop should exit */
-        int jbody = placeholder(c); /* JUMP_IF_FALSE → body (continue loop) */
-        /* Exit: result */
-        if (test->n_children >= 2)
-            compile_expr(c, test->children[1], tail);
-        else
+        } else {
             chunk_emit(c, OP_NIL, 0);
-        int jexit2 = placeholder(c); /* JUMP over body+step */
+        }
+        int jexit = placeholder(c);           /* JUMP -> past body+step */
 
-        /* Body */
-        int body_start = c->code_len;
-        patch(c, jbody, OP_JUMP_IF_FALSE, body_start);
-
+        /* Body. */
+        patch(c, jbody, OP_JUMP_IF_FALSE, c->code_len);
         for (int i = 3; i < node->n_children; i++) {
             compile_expr(c, node->children[i], 0);
             chunk_emit(c, OP_POP, 0);
         }
 
-        /* Step */
-        step_count = 0;
+        /* Steps: evaluate every step expression BEFORE storing any of them, so
+         * each one sees the pre-step values (R7RS parallel update). The values
+         * are held in anonymous locals rather than being consumed straight off
+         * the stack, because a boxed variable is written with VEC_SET, which
+         * needs its box and index UNDER the value — an order a bare push/store
+         * pair cannot produce. The placeholder name is unspellable as a Scheme
+         * symbol, so resolve_local() can never match it. */
+        int n_steps = 0;
         for (int i = 0; i < vars->n_children; i++) {
             Node* b = vars->children[i];
             if (b->type == N_LIST && b->n_children >= 3) {
                 compile_expr(c, b->children[2], 0);
-                step_count++;
+                add_local(c, " do step");
+                n_steps++;
             }
         }
-        for (int i = vars->n_children - 1; i >= 0; i--) {
+        int step_base = c->n_locals - n_steps;
+        int step_i = 0;
+        for (int i = 0; i < vars->n_children; i++) {
             Node* b = vars->children[i];
-            if (b->type == N_LIST && b->n_children >= 3) {
-                int slot = resolve_local(c, b->children[0]->symbol);
-                if (slot >= 0) chunk_emit(c, OP_SET_LOCAL, slot);
+            if (!(b->type == N_LIST && b->n_children >= 3)) continue;
+            int tmp_slot = c->locals[step_base + step_i].slot;
+            step_i++;
+            int slot = resolve_local(c, b->children[0]->symbol);
+            if (slot < 0) continue;
+            int boxed = 0;
+            for (int li = c->n_locals - 1; li >= 0; li--)
+                if (c->locals[li].slot == slot && c->locals[li].boxed) { boxed = 1; break; }
+            if (boxed) {
+                chunk_emit(c, OP_GET_LOCAL, slot);                       /* box   */
+                chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL(0))); /* index */
+                chunk_emit(c, OP_GET_LOCAL, tmp_slot);                   /* value */
+                chunk_emit(c, OP_VEC_SET, 0);
+                chunk_emit(c, OP_POP, 0);       /* VEC_SET pushes NIL */
+            } else {
+                chunk_emit(c, OP_GET_LOCAL, tmp_slot);
+                chunk_emit(c, OP_SET_LOCAL, slot);
             }
         }
+        for (int i = 0; i < n_steps; i++) chunk_emit(c, OP_POP, 0);
+        c->n_locals -= n_steps;
 
         chunk_emit(c, OP_LOOP, loop_top);
-        patch(c, jexit2, OP_JUMP, c->code_len);
+        patch(c, jexit, OP_JUMP, c->code_len);
+    } else {
+        /* Malformed `(do (bindings))` with no test clause: still leave exactly
+         * one value, so the caller's balancing OP_POP has something to take. */
+        chunk_emit(c, OP_NIL, 0);
     }
 
-    /* Pop locals */
-    while (c->n_locals > 0 && c->locals[c->n_locals-1].depth == c->scope_depth)
-        c->n_locals--;
+    /* Drop the loop variables, keeping the result on top (LE-10). */
+    if (n_do_locals > 0) chunk_emit(c, OP_POPN, n_do_locals);
+    c->n_locals = saved_locals;
     c->scope_depth--;
     return;
 }

--- a/tests/differential/corpus/49_do_loop_variable_binding.esk
+++ b/tests/differential/corpus/49_do_loop_variable_binding.esk
@@ -1,0 +1,164 @@
+;; SW-34 / LE-10 companion on the NATIVE axes.
+;;
+;; The two defects these programs pin are VM-side (compile_form_do never popped
+;; its loop variables, and a captured+mutated loop variable was captured by
+;; value); this file is the native-axis half, so a later native change cannot
+;; drift the answers these programs are asserted against on the VM. The
+;; VM-vs-native assertion for the same programs lives in
+;; tests/vm_parity/corpus/61_do_loop_variable_binding.esk.
+;;
+;; Four `do` shapes were held out of both files while they were written,
+;; because the native engine was wrong or failed on them (capture in a STEP,
+;; capture in a RESULT, a step expression that must see a body closure's
+;; mutation, and a read-only capture). PR #437 fixed the native side; all four
+;; are now asserted at the end of this file.
+
+;; -- LE-10: a `do` must not strand its loop variables -----------------------
+;; The classic slot-shift tell: a top-level binding made AFTER a do loop.
+(do ((i 0 (+ i 1))) ((= i 2)) 1)
+(define after-do 42)
+(display after-do)
+(newline)
+
+;; Two sequential do loops: the second used to inherit the first's slots.
+(display (do ((i 0 (+ i 1)) (a 0)) ((= i 3) a) (set! a (+ a 1))))
+(newline)
+(display (do ((k 0 (+ k 1)) (b 0)) ((= k 4) b) (set! b (+ b 10))))
+(newline)
+
+;; A closure-carrying do followed by a plain do -- the shape LE-10 was filed
+;; for, where the stranded junk landed on a loop counter or a callee.
+(display (do ((i 0 (+ i 1)) (a 0)) ((= i 3) a) ((lambda () (set! a (+ a 1))))))
+(newline)
+(display (do ((k 0 (+ k 1)) (b 0)) ((= k 4) b) (set! b (+ b 10))))
+(newline)
+
+;; Three in a row, alternating shapes.
+(display (do ((i 0 (+ i 1)) (a 0)) ((= i 2) a) ((lambda () (set! a (+ a 5))))))
+(newline)
+(display (do ((i 0 (+ i 1)) (a 100)) ((= i 2) a) (set! a (+ a 1))))
+(newline)
+(display (do ((i 0 (+ i 1)) (a 0)) ((= i 6) a) ((lambda () (set! a (+ a 2))))))
+(newline)
+
+;; -- SW-34: a captured + mutated loop variable is one shared cell -----------
+;; Inside a procedure, with a runtime trip count. The filed reproducer.
+(define (accumulate n)
+  (do ((i 0 (+ i 1)) (a 0)) ((= i n) a)
+      ((lambda () (set! a (+ a 1))))))
+(display (accumulate 5))
+(newline)
+(display (accumulate 0))
+(newline)
+
+;; Nested loops, the inner body closing over the OUTER loop's variable.
+(display (do ((i 0 (+ i 1)) (t 0)) ((= i 3) t)
+             (do ((j 0 (+ j 1))) ((= j 2))
+                 ((lambda () (set! t (+ t 1)))))))
+(newline)
+
+;; A stored closure called twice per iteration, so the writeback accumulates.
+;; Also the shape that exposed defect 4: a boxed set! in an inline loop body.
+(define (stored n)
+  (do ((i 0 (+ i 1)) (a 0)) ((= i n) a)
+      (let ((bump (lambda () (set! a (+ a 3)))))
+        (bump)
+        (bump))))
+(display (stored 4))
+(newline)
+
+;; Depth 2 and depth 3 closures over the loop variable.
+(define (deep2 n)
+  (do ((i 0 (+ i 1)) (a 0)) ((= i n) a)
+      ((lambda () ((lambda () (set! a (+ a 1))))))))
+(display (deep2 4))
+(newline)
+
+(define (deep3 n)
+  (do ((i 0 (+ i 1)) (a 0)) ((= i n) a)
+      ((lambda () ((lambda () ((lambda () (set! a (+ a 10))))))))))
+(display (deep3 3))
+(newline)
+
+;; Two closures over ONE loop variable: the mutator and the reader must agree.
+(define (share n)
+  (do ((i 0 (+ i 1)) (a 0)) ((= i n) a)
+      (let ((inc (lambda () (set! a (+ a 1))))
+            (get (lambda () a)))
+        (inc)
+        (set! a (get)))))
+(display (share 4))
+(newline)
+
+;; A do loop inside a lambda rather than a define.
+(display ((lambda (n)
+            (do ((i 0 (+ i 1)) (a 0)) ((= i n) a)
+                ((lambda () (set! a (+ a 4))))))
+          3))
+(newline)
+
+;; -- controls --------------------------------------------------------------
+;; Parallel update: each step sees the PRE-step values of the others.
+(display (do ((x 1 y) (y 2 x) (n 0 (+ n 1))) ((= n 3) (list x y)) 1))
+(newline)
+
+;; A do with no closure at all is unchanged.
+(display (do ((i 0 (+ i 1)) (s 0 (+ s i))) ((= i 5) s) 1))
+(newline)
+
+;; A body lambda whose PARAMETER shadows the loop variable must win.
+(display (do ((i 0 (+ i 1)) (a 0)) ((= i 3) a)
+             (set! a ((lambda (a) (+ a 1)) 10))))
+(newline)
+
+;; An empty body.
+(display (do ((i 0 (+ i 1))) ((= i 4) i)))
+(newline)
+
+;; A do in tail position of a procedure.
+(define (tail-do n) (do ((i 0 (+ i 1)) (a 0)) ((= i n) a) (set! a (+ a 7))))
+(display (tail-do 3))
+(newline)
+
+;; Multiple result expressions: the sequence runs, the last is the value.
+(display (do ((i 0 (+ i 1)) (a 0)) ((= i 2) (set! a (+ a 1)) a) (set! a (+ a 100))))
+(newline)
+
+;; -- promoted from the SCOPE exclusion list ---------------------------------
+;; These four shapes were excluded when this file was written: the VM answered
+;; each correctly after the fix above, but the NATIVE engine was wrong or
+;; failed on all four at that base commit. PR #437 fixed the native side, and
+;; with both changes present the two engines agree on every one -- at exactly
+;; the values the VM already produced. Promoted rather than left in a comment,
+;; because an exclusion nobody re-runs is an exclusion that becomes permanent.
+
+;; A step expression that must observe the body closure's mutation.
+;; Per iteration: body +10, then step +1. Was VM 33 / native 30.
+(define (stepped n)
+  (do ((i 0 (+ i 1)) (a 0 (+ a 1))) ((= i n) a)
+      ((lambda () (set! a (+ a 10))))))
+(display (stepped 3))
+(newline)
+
+;; A capture in the STEP position. Was VM 8 / native 0.
+(define (step-capture n)
+  (do ((i 0 (+ i 1)) (a 0 ((lambda () (+ a 2))))) ((= i n) a)
+      1))
+(display (step-capture 4))
+(newline)
+
+;; A capture in the RESULT position. Was VM 10 / native: LLVM module
+;; verification failed (Instruction does not dominate all uses).
+(define (result-capture n)
+  (do ((i 0 (+ i 1)) (a 0)) ((= i n) ((lambda () (* a 2))))
+      (set! a (+ a 1))))
+(display (result-capture 5))
+(newline)
+
+;; A read-only capture -- mutation is not required to trip the native defect.
+;; Was VM 6 / native: no output.
+(define (readonly-capture n)
+  (do ((i 0 (+ i 1)) (s 0)) ((= i n) s)
+      (set! s (+ s ((lambda () i))))))
+(display (readonly-capture 4))
+(newline)

--- a/tests/vm_parity/corpus/61_do_loop_variable_binding.esk
+++ b/tests/vm_parity/corpus/61_do_loop_variable_binding.esk
@@ -1,0 +1,189 @@
+;; SW-34 and LE-10 -- `do` loop variables must be popped at loop exit, and a
+;; loop variable a body closure captures and `set!`s must be shared through one
+;; cell, on the VM exactly as natively.
+;;
+;; THREE DEFECTS, ONE FUNCTION (compile_form_do, lib/backend/vm_compiler.c),
+;; plus one in compile_form_set that only this one could expose.
+;;
+;; 1. THE LOOP VARIABLES WERE NEVER POPPED (LE-10, and a silent case wider than
+;;    the one that entry was filed for). compile_form_let() ends with OP_POPN;
+;;    compile_form_do() only decremented the compiler's own n_locals, which has
+;;    no runtime effect, so every `do` stranded one operand-stack value per
+;;    loop variable and shifted every later slot. No closure, no capture:
+;;        (do ((i 0 (+ i 1))) ((= i 2)) 1) (define q 42) (display q)
+;;    was 2 on the VM and 42 natively.
+;;
+;; 2. THE BODY AND STEPS WERE COMPILED TWICE -- a first version was emitted and
+;;    "discarded" by rewinding code_len, which un-emits code and none of the
+;;    constant-pool, upvalue, closure-PC or repatch side effects it caused.
+;;
+;; 3. A CAPTURED + MUTATED LOOP VARIABLE WAS CAPTURED BY VALUE (SW-34), so the
+;;    mutation was lost. The same loop at TOP LEVEL was correct, because only
+;;    the root chunk has the open-slot relay (native calls 151/252).
+;;
+;; 4. Exposed by 3: compile_form_set()'s BOXED paths left TWO values on the
+;;    operand stack (OP_VEC_SET pushes NIL, and the shared tail pushes another)
+;;    where every caller pops one. Inside a frame about to RETURN the surplus
+;;    was absorbed; in a `do` body -- statements compiled into the same chunk,
+;;    one OP_POP each -- it accumulated per iteration until the stack overflowed.
+;;
+;; Every line below is a native-vs-VM differential. Numeric and list output
+;; only: the VM prints a procedure as <closure@N> where native prints its
+;; source form, so no procedure is ever displayed.
+;;
+;; SCOPE -- nothing is excluded. Four shapes were held out while this file was
+;; written, because the VM answered each correctly after the fix above but the
+;; NATIVE engine was wrong or failed on all four. PR #437 fixed the native
+;; side; with both on master the engines agree on every one, at exactly the
+;; values the VM already produced, and all four are asserted at the end of this
+;; file.
+
+;; -- LE-10: a `do` must not strand its loop variables -----------------------
+;; The classic slot-shift tell: a top-level binding made AFTER a do loop.
+(do ((i 0 (+ i 1))) ((= i 2)) 1)
+(define after-do 42)
+(display after-do)
+(newline)
+
+;; Two sequential do loops: the second used to inherit the first's slots.
+(display (do ((i 0 (+ i 1)) (a 0)) ((= i 3) a) (set! a (+ a 1))))
+(newline)
+(display (do ((k 0 (+ k 1)) (b 0)) ((= k 4) b) (set! b (+ b 10))))
+(newline)
+
+;; A closure-carrying do followed by a plain do -- the shape LE-10 was filed
+;; for, where the stranded junk landed on a loop counter or a callee.
+(display (do ((i 0 (+ i 1)) (a 0)) ((= i 3) a) ((lambda () (set! a (+ a 1))))))
+(newline)
+(display (do ((k 0 (+ k 1)) (b 0)) ((= k 4) b) (set! b (+ b 10))))
+(newline)
+
+;; Three in a row, alternating shapes.
+(display (do ((i 0 (+ i 1)) (a 0)) ((= i 2) a) ((lambda () (set! a (+ a 5))))))
+(newline)
+(display (do ((i 0 (+ i 1)) (a 100)) ((= i 2) a) (set! a (+ a 1))))
+(newline)
+(display (do ((i 0 (+ i 1)) (a 0)) ((= i 6) a) ((lambda () (set! a (+ a 2))))))
+(newline)
+
+;; -- SW-34: a captured + mutated loop variable is one shared cell -----------
+;; Inside a procedure, with a runtime trip count. The filed reproducer.
+(define (accumulate n)
+  (do ((i 0 (+ i 1)) (a 0)) ((= i n) a)
+      ((lambda () (set! a (+ a 1))))))
+(display (accumulate 5))
+(newline)
+(display (accumulate 0))
+(newline)
+
+;; Nested loops, the inner body closing over the OUTER loop's variable.
+(display (do ((i 0 (+ i 1)) (t 0)) ((= i 3) t)
+             (do ((j 0 (+ j 1))) ((= j 2))
+                 ((lambda () (set! t (+ t 1)))))))
+(newline)
+
+;; A stored closure called twice per iteration, so the writeback accumulates.
+;; Also the shape that exposed defect 4: a boxed set! in an inline loop body.
+(define (stored n)
+  (do ((i 0 (+ i 1)) (a 0)) ((= i n) a)
+      (let ((bump (lambda () (set! a (+ a 3)))))
+        (bump)
+        (bump))))
+(display (stored 4))
+(newline)
+
+;; Depth 2 and depth 3 closures over the loop variable.
+(define (deep2 n)
+  (do ((i 0 (+ i 1)) (a 0)) ((= i n) a)
+      ((lambda () ((lambda () (set! a (+ a 1))))))))
+(display (deep2 4))
+(newline)
+
+(define (deep3 n)
+  (do ((i 0 (+ i 1)) (a 0)) ((= i n) a)
+      ((lambda () ((lambda () ((lambda () (set! a (+ a 10))))))))))
+(display (deep3 3))
+(newline)
+
+;; Two closures over ONE loop variable: the mutator and the reader must agree.
+(define (share n)
+  (do ((i 0 (+ i 1)) (a 0)) ((= i n) a)
+      (let ((inc (lambda () (set! a (+ a 1))))
+            (get (lambda () a)))
+        (inc)
+        (set! a (get)))))
+(display (share 4))
+(newline)
+
+;; A do loop inside a lambda rather than a define.
+(display ((lambda (n)
+            (do ((i 0 (+ i 1)) (a 0)) ((= i n) a)
+                ((lambda () (set! a (+ a 4))))))
+          3))
+(newline)
+
+;; -- controls --------------------------------------------------------------
+;; Parallel update: each step sees the PRE-step values of the others.
+(display (do ((x 1 y) (y 2 x) (n 0 (+ n 1))) ((= n 3) (list x y)) 1))
+(newline)
+
+;; A do with no closure at all is unchanged.
+(display (do ((i 0 (+ i 1)) (s 0 (+ s i))) ((= i 5) s) 1))
+(newline)
+
+;; A body lambda whose PARAMETER shadows the loop variable must win.
+(display (do ((i 0 (+ i 1)) (a 0)) ((= i 3) a)
+             (set! a ((lambda (a) (+ a 1)) 10))))
+(newline)
+
+;; An empty body.
+(display (do ((i 0 (+ i 1))) ((= i 4) i)))
+(newline)
+
+;; A do in tail position of a procedure.
+(define (tail-do n) (do ((i 0 (+ i 1)) (a 0)) ((= i n) a) (set! a (+ a 7))))
+(display (tail-do 3))
+(newline)
+
+;; Multiple result expressions: the sequence runs, the last is the value.
+(display (do ((i 0 (+ i 1)) (a 0)) ((= i 2) (set! a (+ a 1)) a) (set! a (+ a 100))))
+(newline)
+
+;; -- promoted from the SCOPE exclusion list ---------------------------------
+;; These four shapes were excluded when this file was written: the VM answered
+;; each correctly after the fix above, but the NATIVE engine was wrong or
+;; failed on all four at that base commit. PR #437 fixed the native side, and
+;; with both changes present the two engines agree on every one -- at exactly
+;; the values the VM already produced. Promoted rather than left in a comment,
+;; because an exclusion nobody re-runs is an exclusion that becomes permanent.
+
+;; A step expression that must observe the body closure's mutation.
+;; Per iteration: body +10, then step +1. Was VM 33 / native 30.
+(define (stepped n)
+  (do ((i 0 (+ i 1)) (a 0 (+ a 1))) ((= i n) a)
+      ((lambda () (set! a (+ a 10))))))
+(display (stepped 3))
+(newline)
+
+;; A capture in the STEP position. Was VM 8 / native 0.
+(define (step-capture n)
+  (do ((i 0 (+ i 1)) (a 0 ((lambda () (+ a 2))))) ((= i n) a)
+      1))
+(display (step-capture 4))
+(newline)
+
+;; A capture in the RESULT position. Was VM 10 / native: LLVM module
+;; verification failed (Instruction does not dominate all uses).
+(define (result-capture n)
+  (do ((i 0 (+ i 1)) (a 0)) ((= i n) ((lambda () (* a 2))))
+      (set! a (+ a 1))))
+(display (result-capture 5))
+(newline)
+
+;; A read-only capture -- mutation is not required to trip the native defect.
+;; Was VM 6 / native: no output.
+(define (readonly-capture n)
+  (do ((i 0 (+ i 1)) (s 0)) ((= i n) s)
+      (set! s (+ s ((lambda () i))))))
+(display (readonly-capture 4))
+(newline)


### PR DESCRIPTION
Two VM defects from PR #437's class-kill, both fixed at the root, plus a
pre-existing third that the second one exposed. Everything here is in
`lib/backend/vm_compiler.c`; no native codegen is touched.

Based on `origin/master`, **not** stacked on #435 — the fix needs only
`needs_boxing()`, which is already on master. #435's
`vm_box_mutable_captured_params()` is for parameters, which arrive from the
caller; a `do` variable is bound like a `let` variable and boxes at its binding
site.

## LE-10 — the loop variables were never popped, and it is wider than filed

`compile_form_let()` ends with `OP_POPN`. `compile_form_do()` ended by
decrementing the compiler's own `c->n_locals` — a **compile-time** bookkeeping
change with no runtime effect — so every `do` form stranded one operand-stack
value per loop variable. Top-level bindings live in stack slots handed out by
counting (`add_local`), and the top-level driver emits exactly one `OP_POP` per
expression that grew no local, so the stranded values shift every later slot.
Same slot-shift corruption already documented on `compile_form_require()` and
`compile_form_with_region()` in this file, reached a third way.

**Re-measurement changed the entry.** It was filed LOUD (heap-object limit,
`calling non-function`, hangs) on the shapes #437's class-kill happened to hit.
The same root cause also produces **silent wrong values**, and needs *neither a
closure nor a capture*:

```scheme
(do ((i 0 (+ i 1))) ((= i 2)) 1)
(define q 42)
(display q)              ; VM 2, native 42 — exit 0, no diagnostic
```

Two ordinary sequential `do` loops diverge the same way (VM `3` then `13`,
native `3` then `40`). The loud shapes are the same corruption landing on a slot
whose stranded junk happens to be a loop counter or a callee. **Closing this
against only the filed reproducer would have left the `do`-then-`define` case
shipping.**

**Fix.** Emit `OP_POPN` for the loop variables at the exit, keeping the result
on top, exactly as `compile_form_let()` does; compile the result expressions out
of tail position when there are locals to pop, since a `TAIL_CALL` would skip
the `OP_POPN`.

**Second hazard removed by the same rewrite.** The function used to emit a
complete first version of the loop and then "discard" it with
`c->code_len = loop_top` — leftover debugging scaffolding, its reasoning about
`JUMP_IF_FALSE` polarity still sitting in the source as commentary. That
compiled the body and steps **twice**. Rewinding `code_len` un-emits CODE and
nothing else: the discarded pass had already appended to the constant pool,
registered upvalues, written closure PC constants pointing into the region about
to be overwritten, and pushed entries onto the global forward-reference repatch
arrays. The correct structure is now emitted once.

## SW-34 — a captured and mutated loop variable was captured by value

```scheme
(define (f n) (do ((i 0 (+ i 1)) (a 0)) ((= i n) a)
                  ((lambda () (set! a (+ a 1))))))
(f 5)                    ; VM 0, native 5
```

`compile_form_let()` has always run `needs_boxing()` over its bindings; a `do`
variable was bound with a bare `add_local()`, so `OP_CLOSURE` copied its VALUE
into the closure's upvalue array and the inner `set!` mutated a private copy.
The same loop **at top level was already correct**, which is the tell: only the
root chunk has the open-slot relay (native calls 151/252), and that relay is
deliberately restricted to the root chunk because a function's frame dies on
return.

**Fix.** Box every loop variable `needs_boxing()` reports as
mutated-and-captured, scanning the test, the results, the body **and** every
step expression, since a `do` variable is in scope for all four. A boxed
variable's step store goes through `VEC_SET` into the same cell. Step values are
held in anonymous locals first, so R7RS 4.2.4 parallel update (every step sees
the pre-step values) is preserved while still giving `VEC_SET` its box and index
*under* the value.

This is the fourth binding form of the SW-25 family — parameters, `let*`,
`letrec`, `letrec*` were closed by #435; `do` is closed here. Same root cause
throughout: a binding mutated across a closure boundary needs a shared **cell**,
and only `let` ever had one.

## Residue, fixed at the root: `compile_form_set` left two values

Boxing a `do` variable exposed a **pre-existing** defect. Both boxed paths of
`compile_form_set()` (local and upvalue) left **two** values on the operand
stack — `OP_VEC_SET` pops three and pushes NIL, and the shared tail pushes the
NIL that `set!` evaluates to — where every caller pops one.

Inside a frame about to `RETURN` the surplus was absorbed, which is why it had
never been seen. In a `do` body, whose inline statements are each followed by
exactly one `OP_POP`, it accumulated once per iteration until the operand stack
overflowed. Found by disassembly, not by guessing:

```
[5220] VECST  0     ; box[0] = a+1  -> pushes NIL
[5221] NIL    0     ; set! returns void -> pushes another
[5222] POP    0     ; only one taken
```

## Class-kill

`tests/vm_parity/corpus/61_do_loop_variable_binding.esk` — **23 shapes,
byte-identical VM-vs-native**: sequential and nested loops, a binding made after
a loop, depths 1-3, stored and immediately-invoked closures, two closures
sharing one variable, a loop inside a lambda and inside a define with a runtime
trip count, parallel update, tail position, multiple result expressions, and
controls (no closure, a shadowing body parameter, an empty body).
`tests/differential/corpus/49_do_loop_variable_binding.esk` covers the native
axes.

**Four native-side shapes were held out** while this branch was written, each
with its measured pair recorded in the corpus SCOPE comment. **They are now
promoted.** #437 landed on master and fixed the native side of all four; with
both changes present the engines agree on every one — at exactly the values the
VM already produced:

| shape | agreed value | native before #437 |
|---|---|---|
| step that must see a body closure's mutation | **33** | 30 |
| capture in the **step** | **8** | 0 |
| capture in the **result** | **10** | LLVM module verification failed |
| read-only capture | **6** | no output |

All four are asserted in both corpus files and the exclusion list is empty.
Writing the measured pairs down rather than only naming the shapes is what made
this a re-run instead of a re-derivation.

**Revert-validated.** With `lib/backend/vm_compiler.c` restored, the corpus file
**hangs** on the VM (killed at 25s), and the individual shapes answer `2`, `00`,
`2` and `0` where the fixed VM and native both answer `42`, `50`, `6` and `4`.

## Ledger

SW-34 and LE-10 both **closed** with measured evidence. Neither existed on
`master` (both were opened by #437, unmerged), so both are added here as closed
rather than edited in place. LE-10's entry records that re-measurement found it
wider and partly silent than filed, and why it was closed on the wider evidence.
`gate_no_silent_wrong.py` blocking count is **unchanged at 13**.

## Gates

Rebased onto master (which absorbed #431, #433, #436, #437), then a clean
`--fresh` + `--clean-first` rebuild. RelWithDebInfo, LLVM 21,
arm64-apple-darwin24.1.0.

**Rebase:** one conflict, `.icc/silent-wrong-ledger.yaml`, resolved as a union
with closed entries winning — master's LE-09 (closed by #437) kept, and master's
**open** SW-34 and LE-10 superseded in place by the closed entries here, with
master's filed reproducers and measured shapes folded in so no evidence is lost.
`lib/backend/vm_compiler.c` rebased without conflict.

| gate | result |
|---|---|
| `ctest --test-dir build` | **173/173** |
| `scripts/run_vm_parity.sh` | **164/164** |
| `scripts/run_differential.sh` | **306/306** axis pairs over 51 programs |
| `scripts/gate_no_silent_wrong.py` | **11 -> 10** blockers vs master; single delta is SW-34 |

`scripts/run_icc_smoke.sh` was **not** run as a whole, reported rather than
papered over: the host had three other worktrees compiling and a 1-minute load
average of 7-13, and PR #435 already recorded one contention false-red from
exactly that situation. Path-scoped probes were run verbatim from the smoke
script instead, chosen for what this diff touches:

| probe | result |
|---|---|
| `closure_set_tco_loop_oracle` (ESH-0094 — closure in a TCO loop `set!`s a capture) | PASS |
| `stdlib_sort_filter_scale_oracle` | PASS |
| `higher_order_shadowing_oracle` (JIT) | PASS |
| `ad_forward_over_reverse_oracle` | PASS |
| #437's own `rest_capture_and_do_closure_test.esk` | PASS |
| `define_loop_flat_rss_aot` | PASS |
