### PR TITLE
fix(macro): syntax-rules hygiene — template-introduced bindings (SW-30)

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -1478,31 +1478,183 @@ entries:
 
   - id: SW-30
     bucket: SILENT-WRONG
-    status: open
-    title: "VM syntax-rules hygiene loses a template-introduced binding and corrupts a same-named top-level variable; native captures instead"
-    repro: "(define-syntax hyg (syntax-rules () ((_ e) (let ((tmp 100)) (+ tmp e))))) (define tmp 7) (display (hyg 1)) (display tmp)"
-    observed: "VM prints 1 then (); native prints 101 then 7"
-    correct: "101 then 7 for this shape; for (hyg tmp) R7RS requires 107, and native prints 200 — so BOTH engines are wrong on capture, and they diverge on the binding itself"
+    status: fixed
+    title: "syntax-rules hygiene for TEMPLATE-INTRODUCED BINDINGS: the VM lost the binding and corrupted a same-named top-level variable; both engines captured"
+    repro: "(define-syntax hyg (syntax-rules () ((_ e) (let ((tmp 100)) (+ tmp e))))) (define tmp 7) (display (hyg 1)) (display tmp) (display (hyg tmp))"
+    observed_before: "VM printed 1 then () then 0; native printed 101 then 7 then 200"
+    observed_after: >-
+      Both engines print 101, 7, 107 — the R7RS 4.3.2 answers. Verified on native -r,
+      vm-src, vm-eskb and the wasm32 build.
+    root_cause: >-
+      TWO independent defects, neither of which was the one hypothesised when this entry
+      was filed. The original note guessed "the VM's expander does gensym renaming that is
+      applied inconsistently between binder and reference". That is not what the code did:
+      vm_macro_gensym() had ZERO callers outside its own self-test, and neither expander
+      contained any renaming, mark, syntactic closure or definition-environment machinery
+      at all.
+
+      (1) THE VM COLUMN WAS NOT A HYGIENE DEFECT. `define-syntax` compiled to nothing
+      (lib/backend/vm_compiler.c), while every top-level and body driver POPs after a form
+      that bound nothing. That POP therefore discarded a LIVE stack value and shifted every
+      later local down one slot, so a template's `let` wrote slot k while the body read slot
+      k+1. Hence (hyg 1) => 1 and the user's `tmp` reading back as (). The identical hazard
+      was already documented and handled three cases earlier in the same function, for
+      (provide)/(export), whose in-code comment says the OP_NIL "is not decorative". Fixed
+      by emitting OP_NIL for define-syntax as well. This is a CLASS: any no-emit top-level
+      special form has the same exposure.
+
+      (2) NEITHER ENGINE RENAMED TEMPLATE-INTRODUCED BINDERS, so both captured. Native
+      substituteBindings() emitted every non-pattern-variable identifier verbatim
+      (lib/frontend/macro_expander.cpp), and the VM's vm_macro_instantiate() did the same
+      (lib/backend/vm_macro.c). Fixed by alpha-renaming, in both expanders, the identifiers
+      a template BINDS ITSELF — scope by scope, and before any caller code is substituted
+      in, which is what makes it safe: at that point every symbol in the tree came from the
+      macro definition, so no caller identifier can be touched. Covered forms: let, let*,
+      letrec, letrec*, named let, lambda (including a rest parameter). Pattern variables are
+      never renamed. Quoted and quasiquoted data are walked in datum mode so a gensym cannot
+      leak into program OUTPUT (without that, (let ((z 5)) (list 'z z)) printed (_h0.z 5)).
+
+      A THIRD defect fell out while pinning the classic swap!: native substituted a set!
+      VALUE but never its TARGET, because the target is a bare char* rather than an AST
+      node, so ((_ x y) (let ((tmp x)) (set! x y) (set! y tmp))) failed to compile with
+      "set!: undefined variable 'x'". R7RS 4.3.2 substitutes a pattern variable wherever it
+      occurs in a template, assignment targets included. Fixed.
     measured: >-
-      Three shapes measured side by side. (hyg 1): native 101, VM 1 — the VM loses the
-      template's `let` binding entirely, so (+ tmp e) reads an unbound tmp as 0.
-      (display tmp) after (define tmp 7): native 7, VM () — the VM's expansion corrupts the
-      user's same-named top-level variable. (sw 3 4) with template ((_ a b) (let ((t a))
-      (+ t b))): native 7, VM 4. Confirmed PRE-EXISTING and unchanged by the SW-13 fix:
-      identical outputs before and after.
-    discovered_by: >-
-      Found while writing the SW-13 multi-macro corpus program, which was asked to include
-      hygiene checks. It could not: no template-binder hygiene shape agrees between the two
-      engines, so none can be pinned as a parity row. Reported here instead of being
-      quietly dropped from the test file, and the corpus program says so in a comment.
+      An 18-cell hygiene matrix was run against both engines before and after. BEFORE:
+      the VM answered 0 of 18 correctly, native 3 of 18, and the two engines disagreed on
+      14 cells. AFTER: both engines agree on all 18 and 17 are R7RS-correct. The single
+      remaining wrong cell is referential transparency for a template's FREE identifiers,
+      which is a different defect with a different root cause and is filed as SW-35.
+    fixed_by: "branch fix/syntax-rules-hygiene (PR stacked on #432)"
+    evidence: >-
+      tests/vm_parity/corpus/68_syntax_rules_hygiene.esk — 15 sections covering the
+      template binder surviving at all, not corrupting a same-named user variable, the
+      capture case where the operand IS the colliding name, use-site shadowing, nested
+      macro invocation with both templates binding the same name, a recursive macro with
+      a colliding global, a template-introduced lambda parameter, let*/letrec/named-let
+      binders, nested template scopes, two invocations not sharing a binding, quoted and
+      quasiquoted symbols keeping their literal names, and set! on pattern variables.
+      Gated by vm-parity (native vs vm-src vs vm-eskb) AND by the wasm execute-and-diff
+      lane, so it is pinned in the browser build too.
+      tests/differential/corpus/51_syntax_rules_hygiene.esk pins the same semantics across
+      the native jit-cache / jit-nocache / aot-O0 / aot-O2 axes; the JIT axis matters
+      because the REPL re-feeds saved define-syntax ASTs into a fresh expander per eval,
+      restarting the fresh-name counter.
+      REVERT-VALIDATED: all four changes were individually reverted on a built tree and
+      68_syntax_rules_hygiene.esk detects each one. Without the OP_NIL the VM prints
+      1|2|100|200|101|...; without the VM renamer it prints 200 for 107, #f for 42 and
+      leaks a <closure@741>; without the native renamer native does the same; without the
+      set! target fix native fails to compile; without datum mode both print (_h28.z 5 9).
     caught_by: [direct-measurement, sw-13-corpus-authoring]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity, differential-corpus, KNOWN_ISSUES]
     notes: >-
-      tests/vm_parity/corpus/16_define_syntax.esk already carried the hint in a comment
-      ("recursive macros and macros that set! their operands diverge"), but the plain
-      template-introduced `let` binding was not among the shapes it named. Sizing this is
-      a real piece of work — the VM's expander does gensym renaming that is applied
-      inconsistently between binder and reference — so it is filed rather than fixed here.
+      tests/vm_parity/corpus/16_define_syntax.esk carried the hint in a comment
+      ("recursive macros and macros that set! their operands diverge") and
+      61_multi_macro_batch.esk (59_ before master's corpus renumber) said outright that no template-binder hygiene shape could be
+      pinned as a parity row. Both statements are now false and 59's comment has been
+      corrected to point at 63.
+      RESIDUAL, deliberately not claimed as fixed: (a) referential transparency for free
+      template identifiers — SW-35; (b) a template-introduced `do` loop variable is still
+      captured, IDENTICALLY on both engines. `do` was left out on purpose: the native
+      expander stores a do-loop in the generic call_op layout, where the loop variables are
+      untyped nested lists rather than an addressable binding array, so a scope-correct
+      rename is not reachable there, and renaming on the VM alone would have made the two
+      engines disagree on a shape neither fully supports. (c) A template-introduced
+      `define` is not renamed either; R7RS requires it, but not renaming is the status quo
+      and renaming it would break the common idiom of a macro that defines something.
+
+  - id: SW-35
+    bucket: SILENT-WRONG
+    status: open
+    needs_decision: true
+    renumbered_from: SW-33
+    renumbered_because: >-
+      Filed as SW-33 on the pre-rebase stack. While this branch was in review,
+      master's #437 landed its own SW-33 (mutated + captured REST parameter) and
+      SW-34, and #432 was rebased onto that master. Both entries then existed
+      under the same id — a textual merge, not a conflict, so nothing flagged it.
+      Master's SW-33 is `closed` and keeps the id; this open entry moves to the
+      next truly-free id. Re-surveyed against master's canonical ledger after
+      #432 merged as 6acc9030 and #430/#434/#435/#438/#439/#441 landed: master's
+      highest id is still SW-34 and it has no SW-35, so SW-35 is the correct
+      free id and needed no second move.
+    title: "syntax-rules templates have no REFERENTIAL TRANSPARENCY: a free identifier in a template resolves at the USE site, not the macro-definition site (both engines, identically)"
+    repro: "(define (helper x) (* x 10)) (define-syntax usehelp (syntax-rules () ((_ a) (helper a)))) (display (let ((helper (lambda (x) (- x)))) (usehelp 5)))"
+    observed: "native -5, VM -5, exit 0 on both, no diagnostic"
+    correct: >-
+      50. R7RS 4.3.2: an identifier that appears in a template as a free reference refers
+      to the binding it had in the MACRO-DEFINITION environment, so `helper` must be the
+      top-level helper regardless of what the use site binds.
+    measured: >-
+      Cell 7 of the 18-cell hygiene matrix run for SW-30. It is the ONLY cell of the 18
+      that is still wrong after SW-30's fix, and both engines are wrong in exactly the same
+      way, so it is a shared semantic gap and NOT an engine divergence.
+    root_cause: >-
+      Neither engine captures a macro-definition environment, so there is nothing to
+      resolve a free template identifier against. Native `eshkol_macro_def_t`
+      (inc/eshkol/eshkol.h) carries only name, literals and rules — no environment, no
+      scope id, no phase. The VM's `VmMacro` (lib/backend/vm_macro.c) is the same, and its
+      registry is a flat process-global array with no scoping at all (which is also why
+      let-syntax/letrec-syntax fake their scope by saving and restoring g_n_macros). A free
+      template identifier is therefore emitted as a plain name and resolved by ordinary
+      lexical lookup at the use site.
+    why_not_fixed_here: >-
+      NEEDS-DECISION. This is the half of hygiene that genuinely requires infrastructure
+      neither expander has. SW-30's capture half was fixable by alpha-renaming, because
+      renaming is a pure rewrite of the template before any caller code enters it.
+      Referential transparency is not: it requires every identifier to carry the
+      environment it was written in, which means syntax objects (or marks / scope sets)
+      threaded through the reader, both expanders, and both name-resolution paths — native
+      resolves at LLVM codegen, the VM at compile time against a flat local table. That is
+      a cross-cutting representation change, not a localised fix, and it is exactly the
+      "full alpha-renaming/marks infrastructure that does not exist in either expander"
+      case the maintainer policy says to stop and report rather than improvise.
+    interim_considered_and_rejected: >-
+      Raising a loud "unsupported hygiene case" error at a free template identifier was
+      considered and REJECTED as unshippable: every template contains free identifiers
+      (`+`, `if`, `list`, `cond`, every builtin and every user helper), so the error would
+      fire on essentially every macro in the language, including all 42 .esk files in this
+      repo that use define-syntax. The mis-binding only occurs when the USE site actually
+      shadows one of those names, which is rare and is not detectable at expansion time
+      without the very environment tracking that is missing. A precise detector — compare a
+      template's free identifiers against the bindings visible at the use site and raise
+      only on an actual collision — is implementable but needs the use-site environment
+      plumbed into the expander, which is roughly half the work of doing it properly.
+      Recommend deciding between the real fix and an explicit documented limitation rather
+      than shipping a guard that either screams constantly or needs the missing machinery.
+    real_fix_sketch: >-
+      Give each macro definition an environment handle at registration time, and wrap
+      template identifiers in a syntax object carrying that handle. Minimum viable shape:
+      (1) add an env/scope id to eshkol_macro_def_t and VmMacro, assigned when
+      define-syntax is registered; (2) when instantiating, tag each free template
+      identifier with that id instead of emitting a bare name; (3) at name resolution,
+      prefer the binding visible in the tagged environment over the use-site binding.
+      Steps 1-2 are contained in the two expanders; step 3 is the expensive one because it
+      touches native LLVM-codegen name lookup and the VM's local-slot resolution. Marks /
+      scope sets (Flatt) are the principled version and would subsume the alpha-renaming
+      added for SW-30, but are a substantially larger rewrite.
+    effort: >-
+      Rough sizing, NOT a commitment: the env-handle route is a moderate change to each
+      expander plus a real change to each resolver, and it needs its own differential and
+      parity corpus because it changes what a name means. The scope-set rewrite is a
+      significantly larger piece of work touching the reader as well, and would be the
+      right shape only if macro-defining-macros and let-syntax scoping are also in scope.
+      Both are larger than the SW-30 fix that preceded them.
+    caught_by: [direct-measurement, sw-30-hygiene-matrix]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity, differential-corpus, KNOWN_ISSUES]
+    notes: >-
+      Filed rather than fixed, and NOT folded into SW-30's close: SW-30 names
+      template-introduced BINDINGS and that surface is genuinely fixed and gated. This is
+      the other half of R7RS hygiene and has a different root cause, a different blast
+      radius and a different price. The two engines AGREE here, so no parity row is
+      blocked by it; it is a shared semantic gap against the standard.
+      A separate, unrelated observation from the same matrix run, filed here only so it is
+      not lost: a macro named `inner` cannot be defined on the native engine at all —
+      (define-syntax inner (syntax-rules () ((_ x) (+ 10 x)))) (inner 1) fails with
+      "no matching pattern for macro 'inner'" followed by a spurious "Circular macro
+      expansion detected". The same program with the macro renamed works. That is a
+      reserved-name collision in the native frontend, is LOUD (exit 1) rather than silent,
+      and is out of scope for this entry.
 
   - id: SW-31
     bucket: SILENT-WRONG

--- a/inc/eshkol/frontend/macro_expander.h
+++ b/inc/eshkol/frontend/macro_expander.h
@@ -129,6 +129,49 @@ private:
     };
     using Bindings = std::map<std::string, Binding>;
 
+    // ── Hygiene: alpha-renaming of template-introduced binders (R7RS 4.3.2)
+    //
+    // A template may bind identifiers of its own, as in
+    //     ((_ e) (let ((tmp 100)) (+ tmp e)))
+    // R7RS requires that `tmp` be FRESH: it may not capture a `tmp` the caller
+    // passes in through `e`, and the caller's `tmp` may not capture it.  Without
+    // renaming, (hyg tmp) expands to (let ((tmp 100)) (+ tmp tmp)) and yields
+    // 200 where R7RS requires 107 — filed as SW-30.
+    //
+    // `active_renames_` maps a template-introduced binder to its fresh name and
+    // is scoped by save/restore around each binding form, so a name is renamed
+    // only inside the extent that introduced it.  A template identifier that is
+    // FREE (referring to the macro-definition environment) is left alone.
+    //
+    // Pattern variables are never renamed: they are replaced by caller code,
+    // which must keep its own names.  The rename is decided at the binder,
+    // before its value is substituted, precisely so caller code is never
+    // touched.
+    //
+    // NOT covered: referential transparency for a template's free identifiers.
+    // eshkol_macro_def_t carries no definition environment, so a free template
+    // identifier is still resolved at the USE site.  This closes the capture
+    // half of hygiene only — see the SW-30 ledger entry.
+    std::map<std::string, std::string> active_renames_;
+    uint64_t rename_counter_ = 0;
+
+    // True while substituting inside QUOTED DATA, where symbols are data
+    // rather than identifiers and must keep their literal names. Without this
+    // a template's own gensym leaks into the program's OUTPUT: the template
+    // (let ((tmp 5)) (list 'tmp tmp)) would print (_h0.tmp 5). Set by quote
+    // and quasiquote, cleared again by unquote / unquote-splicing.
+    bool in_datum_ = false;
+
+    // Allocate a fresh name for `name` and bind it in `active_renames_`.
+    // The counter is monotonic across the whole expansion, so two invocations
+    // of the same macro get distinct names — required, since their bindings
+    // are distinct.
+    std::string freshName(const std::string& name);
+
+    // True if `name` is a template identifier eligible for renaming: not a
+    // pattern variable (those carry caller code) and not the `_` wildcard.
+    static bool isRenameableBinder(const std::string& name, const Bindings& bindings);
+
     /**
      * Register a macro definition.
      */

--- a/lib/backend/vm_compiler.c
+++ b/lib/backend/vm_compiler.c
@@ -3705,9 +3705,19 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
         return;
     }
 
-    /* (define-syntax name (syntax-rules (literals...) (pattern template) ...)) */
+    /* (define-syntax name (syntax-rules (literals...) (pattern template) ...))
+     *
+     * The OP_NIL is not decorative — same discipline as (provide)/(export)
+     * directly above.  define-syntax binds no runtime local, and every
+     * top-level and body driver POPs after a form that bound nothing, so
+     * returning without pushing makes that POP discard a LIVE value and
+     * shift every later local down one slot.  That was the real mechanism
+     * behind SW-30's VM column: the template's `let` wrote slot k while the
+     * body read slot k+1, so (hyg 1) printed 1 instead of 101 and the user's
+     * same-named top-level variable read back as (). */
     if (is_sym(head, "define-syntax") && node->n_children >= 3) {
         vm_macro_define_syntax((const MacroNode*)node);
+        chunk_emit(c, OP_NIL, 0);
         return;
     }
 

--- a/lib/backend/vm_macro.c
+++ b/lib/backend/vm_macro.c
@@ -519,6 +519,265 @@ static int vm_macro_match(const MacroNode* pattern, const MacroNode* input,
  * in the bound list.
  ******************************************************************************/
 
+/*******************************************************************************
+ * Hygiene: alpha-renaming of template-introduced binders (R7RS 4.3.2)
+ *
+ * A `syntax-rules` template may introduce its own bindings, as in
+ *
+ *     (define-syntax hyg (syntax-rules () ((_ e) (let ((tmp 100)) (+ tmp e)))))
+ *
+ * R7RS requires `tmp` here to be a FRESH identifier: it may not capture a
+ * `tmp` the caller passes in through the pattern variable `e`, and the
+ * caller's `tmp` may not capture the template's.  Without renaming,
+ * (hyg tmp) expands to (let ((tmp 100)) (+ tmp tmp)) and evaluates to 200
+ * instead of the required 107 — the classic capture failure, filed as SW-30.
+ *
+ * This pass runs on the template ALONE, before vm_macro_instantiate()
+ * substitutes any user code into it.  That ordering is what makes it safe:
+ * at this point every symbol in the tree came from the macro definition, so
+ * renaming cannot touch a caller's identifier.  Symbols that ARE pattern
+ * variables are left alone precisely because they will be replaced by user
+ * code, which must keep its own names.
+ *
+ * Scope is tracked properly rather than renaming the whole template: a name
+ * is renamed only within the extent of the binding form that introduced it,
+ * so a template that also references the same name FREELY (meaning the
+ * macro-definition environment) keeps that reference intact.
+ *
+ * NOT covered (see the SW-30 ledger entry): referential transparency for
+ * free identifiers in templates.  A template's free identifier is still
+ * resolved at the USE site, not the definition site, because neither engine
+ * captures a macro-definition environment.  This pass closes the capture
+ * half of hygiene only.
+ ******************************************************************************/
+
+#define MAX_RENAMES 64
+
+typedef struct {
+    char from[64];
+    char to[64];
+} MacroRename;
+
+typedef struct {
+    MacroRename r[MAX_RENAMES];
+    int         n;
+    /* 1 while walking QUOTED DATA, where symbols are data rather than
+     * identifiers and must keep their literal names.  Carried in the rename
+     * environment so it scopes exactly like one: (quasiquote ...) sets it,
+     * (unquote ...) / (unquote-splicing ...) clear it again. */
+    int         datum;
+} MacroRenames;
+
+/** @brief Innermost-wins lookup of a renamed template identifier.  Returns
+ *         NULL inside quoted data, where symbols are not identifiers. */
+static const char* macro_renames_lookup(const MacroRenames* rn, const char* name) {
+    if (!rn || rn->datum) return NULL;
+    for (int i = rn->n - 1; i >= 0; i--) {
+        if (strcmp(rn->r[i].from, name) == 0) return rn->r[i].to;
+    }
+    return NULL;
+}
+
+/** @brief Bind @p from to a fresh name for the current scope.  The counter
+ *         is global and monotonic, so two invocations of the same macro get
+ *         distinct names — which is required: their bindings are distinct. */
+static void macro_renames_push(MacroRenames* rn, const char* from) {
+    if (!rn || rn->n >= MAX_RENAMES) return;   /* over budget: leave unrenamed */
+    snprintf(rn->r[rn->n].from, sizeof(rn->r[rn->n].from), "%s", from);
+    snprintf(rn->r[rn->n].to, sizeof(rn->r[rn->n].to), "_h%d.%.40s",
+             g_gensym_counter++, from);
+    rn->n++;
+}
+
+/** @brief True if @p n is a template symbol eligible for renaming: a plain
+ *         symbol that is NOT a pattern variable (those carry user code),
+ *         not the ellipsis marker and not the `_` wildcard. */
+static int macro_is_template_binder(const MacroNode* n, const MacroBindings* bindings) {
+    return n && n->type == N_SYMBOL &&
+           !is_ellipsis(n) &&
+           strcmp(n->symbol, "_") != 0 &&
+           strcmp(n->symbol, ".") != 0 &&
+           macro_bindings_lookup(bindings, n->symbol) == NULL;
+}
+
+static MacroNode* vm_macro_alpha_rename(const MacroNode* t,
+                                        const MacroBindings* bindings,
+                                        const MacroRenames* rn);
+
+/** @brief Add every template-introduced name in a lambda formals list (a
+ *         symbol rest-arg, or a possibly dotted list) to @p out. */
+static void macro_renames_add_formals(MacroRenames* out, const MacroNode* formals,
+                                      const MacroBindings* bindings) {
+    if (!formals) return;
+    if (formals->type == N_SYMBOL) {
+        if (macro_is_template_binder(formals, bindings))
+            macro_renames_push(out, formals->symbol);
+        return;
+    }
+    if (formals->type != N_LIST) return;
+    for (int i = 0; i < formals->n_children; i++) {
+        if (macro_is_template_binder(formals->children[i], bindings))
+            macro_renames_push(out, formals->children[i]->symbol);
+    }
+}
+
+/** @brief Rename the children of @p t from index @p start, appending to @p out. */
+static void macro_rename_rest(MacroNode* out, const MacroNode* t, int start,
+                              const MacroBindings* bindings, const MacroRenames* rn) {
+    for (int i = start; i < t->n_children; i++)
+        macro_node_add_child(out, vm_macro_alpha_rename(t->children[i], bindings, rn));
+}
+
+/**
+ * @brief Rewrite a template so that every identifier it BINDS itself is a
+ *        fresh name, consistently at the binder and at every reference
+ *        within that binder's scope.
+ * @return A newly-allocated template tree (caller frees).
+ */
+static MacroNode* vm_macro_alpha_rename(const MacroNode* t,
+                                        const MacroBindings* bindings,
+                                        const MacroRenames* rn) {
+    if (!t) return NULL;
+
+    if (t->type == N_SYMBOL) {
+        MacroNode* c = macro_node_deep_copy(t);
+        const char* to = macro_renames_lookup(rn, t->symbol);
+        /* Copy first, then overwrite only the name, so every other field
+         * (exactness/char tags — see the SW-13 deep-copy fix) survives. */
+        if (c && to) snprintf(c->symbol, sizeof(c->symbol), "%s", to);
+        return c;
+    }
+
+    if (t->type != N_LIST) return macro_node_deep_copy(t);
+
+    const MacroNode* head = t->n_children > 0 ? t->children[0] : NULL;
+    const char* h = (head && head->type == N_SYMBOL) ? head->symbol : NULL;
+
+    /* Quoted data: symbols are DATA, not identifiers, and keep their literal
+     * names — otherwise a template's own gensym leaks into the program's
+     * OUTPUT, e.g. (let ((tmp 5)) (list 'tmp tmp)) printing (_h0.tmp 5).
+     * Pattern variables inside quoted data are still substituted, because
+     * vm_macro_instantiate() walks this subtree afterwards. */
+    if (h && (strcmp(h, "quote") == 0 || strcmp(h, "quasiquote") == 0)) {
+        MacroRenames d = *rn;
+        d.datum = 1;
+        MacroNode* out = macro_make_list();
+        if (!out) return NULL;
+        macro_node_add_child(out, macro_node_deep_copy(head));
+        macro_rename_rest(out, t, 1, bindings, &d);
+        return out;
+    }
+    /* (unquote e) / (unquote-splicing e) escape back to identifier position. */
+    if (h && (strcmp(h, "unquote") == 0 || strcmp(h, "unquote-splicing") == 0)) {
+        MacroRenames d = *rn;
+        d.datum = 0;
+        MacroNode* out = macro_make_list();
+        if (!out) return NULL;
+        macro_node_add_child(out, macro_node_deep_copy(head));
+        macro_rename_rest(out, t, 1, bindings, &d);
+        return out;
+    }
+
+    /* Inside quoted data nothing binds — a list is just a list. */
+    if (rn && rn->datum) {
+        MacroNode* out = macro_make_list();
+        if (!out) return NULL;
+        macro_rename_rest(out, t, 0, bindings, rn);
+        return out;
+    }
+
+    /* (lambda <formals> body ...) */
+    if (h && strcmp(h, "lambda") == 0 && t->n_children >= 2) {
+        MacroRenames inner = *rn;
+        macro_renames_add_formals(&inner, t->children[1], bindings);
+        MacroNode* out = macro_make_list();
+        if (!out) return NULL;
+        macro_node_add_child(out, macro_node_deep_copy(head));
+        macro_node_add_child(out, vm_macro_alpha_rename(t->children[1], bindings, &inner));
+        macro_rename_rest(out, t, 2, bindings, &inner);
+        return out;
+    }
+
+    /* (let ((v e) ...) body ...), (let name ((v e) ...) body ...),
+     * (let* ...), (letrec ...), (letrec* ...) */
+    if (h && (strcmp(h, "let") == 0 || strcmp(h, "let*") == 0 ||
+              strcmp(h, "letrec") == 0 || strcmp(h, "letrec*") == 0)) {
+        int named = (strcmp(h, "let") == 0) && t->n_children >= 3 &&
+                    t->children[1]->type == N_SYMBOL;
+        int bidx  = named ? 2 : 1;
+        int seq   = (strcmp(h, "let*") == 0);
+        int rec   = (strcmp(h, "letrec") == 0 || strcmp(h, "letrec*") == 0);
+
+        if (t->n_children > bidx && t->children[bidx]->type == N_LIST) {
+            const MacroNode* blist = t->children[bidx];
+            MacroRenames inner = *rn;
+
+            /* letrec/letrec*: every binder is visible in every init. */
+            if (rec) {
+                for (int i = 0; i < blist->n_children; i++) {
+                    const MacroNode* b = blist->children[i];
+                    if (b->type == N_LIST && b->n_children >= 1 &&
+                        macro_is_template_binder(b->children[0], bindings))
+                        macro_renames_push(&inner, b->children[0]->symbol);
+                }
+            }
+            /* A named let's loop variable is bound in the body. */
+            if (named && macro_is_template_binder(t->children[1], bindings))
+                macro_renames_push(&inner, t->children[1]->symbol);
+
+            MacroNode* out = macro_make_list();
+            if (!out) return NULL;
+            macro_node_add_child(out, macro_node_deep_copy(head));
+            if (named)
+                macro_node_add_child(out, vm_macro_alpha_rename(t->children[1], bindings, &inner));
+
+            MacroNode* nb = macro_make_list();
+            for (int i = 0; nb && i < blist->n_children; i++) {
+                const MacroNode* b = blist->children[i];
+                if (b->type != N_LIST || b->n_children < 1) {
+                    macro_node_add_child(nb, vm_macro_alpha_rename(b, bindings, &inner));
+                    continue;
+                }
+                /* An init is evaluated OUTSIDE its own binder for let, in the
+                 * bindings so far for let*, and in the full group for letrec. */
+                const MacroRenames* init_env = (rec || seq) ? &inner : rn;
+                MacroNode* nbind = macro_make_list();
+                if (!nbind) break;
+                MacroNode* inits[8];
+                int ni = 0;
+                for (int j = 1; j < b->n_children && ni < 8; j++)
+                    inits[ni++] = vm_macro_alpha_rename(b->children[j], bindings, init_env);
+
+                if (!rec && macro_is_template_binder(b->children[0], bindings))
+                    macro_renames_push(&inner, b->children[0]->symbol);
+
+                macro_node_add_child(nbind,
+                    vm_macro_alpha_rename(b->children[0], bindings, &inner));
+                for (int j = 0; j < ni; j++) macro_node_add_child(nbind, inits[j]);
+                macro_node_add_child(nb, nbind);
+            }
+            macro_node_add_child(out, nb);
+            macro_rename_rest(out, t, bidx + 1, bindings, &inner);
+            return out;
+        }
+    }
+
+    /* `do` is deliberately NOT renamed here.  The native expander stores a
+     * do-loop in the generic call_op layout, where the loop variables are
+     * untyped nested lists rather than an addressable binding array, so a
+     * scope-correct rename is not reachable there.  Renaming on this engine
+     * alone would make the two engines disagree on a shape neither fully
+     * supports — the opposite of what SW-30 asks for.  A template-introduced
+     * `do` variable therefore still captures, identically on both engines,
+     * and is recorded as the residual in the SW-30 ledger entry. */
+
+    /* Any other list: structure-preserving map. */
+    MacroNode* out = macro_make_list();
+    if (!out) return NULL;
+    macro_rename_rest(out, t, 0, bindings, rn);
+    return out;
+}
+
 /**
  * @brief Walk a syntax-rules template AST, replacing pattern-variable
  *        symbols with their matched @p bindings. An ellipsis in the
@@ -650,8 +909,21 @@ static MacroNode* vm_macro_expand_once(const MacroNode* node) {
 
         if (vm_macro_match(macro->rules[r].pattern, node,
                            &bindings, macro->literals, macro->n_literals)) {
-            MacroNode* expanded = vm_macro_instantiate(macro->rules[r].template_node,
-                                                       &bindings);
+            /* Hygiene (R7RS 4.3.2): give every identifier the template BINDS
+             * itself a fresh name before any user code is substituted in, so
+             * a template binder can neither capture nor be captured by an
+             * operand.  Done on the template alone — at this point no user
+             * code is present, so nothing of the caller's can be renamed. */
+            MacroRenames renames;
+            renames.n = 0;
+            renames.datum = 0;
+            MacroNode* hygienic = vm_macro_alpha_rename(macro->rules[r].template_node,
+                                                        &bindings, &renames);
+            MacroNode* expanded = vm_macro_instantiate(
+                hygienic ? hygienic : macro->rules[r].template_node, &bindings);
+            /* instantiate() deep-copies everything it keeps, so the renamed
+             * template is ours to free. */
+            if (hygienic) macro_node_free(hygienic);
             macro_bindings_cleanup(&bindings);
             return expanded;
         }

--- a/lib/frontend/macro_expander.cpp
+++ b/lib/frontend/macro_expander.cpp
@@ -513,6 +513,11 @@ eshkol_ast_t MacroExpander::instantiateTemplate(const eshkol_macro_template_t* t
         return null_ast;
     }
 
+    // Each instantiation starts from an empty rename scope: renames are local
+    // to one expansion of one template. The counter is NOT reset, so names
+    // stay unique across the whole run.
+    active_renames_.clear();
+
     switch (tmpl->type) {
         case MACRO_TPL_LITERAL:
             // The template is stored as a literal AST
@@ -934,6 +939,33 @@ std::vector<eshkol_ast_t> MacroExpander::substituteBindingsInList(const eshkol_a
  *
  * @return The substituted AST subtree.
  */
+/**
+ * @brief Allocate a fresh name for a template-introduced binder and bind it in
+ * the active rename scope (R7RS 4.3.2 hygiene).
+ *
+ * The counter is monotonic across the whole expansion run, so two invocations
+ * of the same macro receive distinct names — which is required, because their
+ * bindings are distinct. The `.` in the generated name mirrors the VM
+ * expander's format so the two engines are recognisably doing the same thing.
+ */
+std::string MacroExpander::freshName(const std::string& name) {
+    std::string fresh = "_h" + std::to_string(rename_counter_++) + "." + name;
+    active_renames_[name] = fresh;
+    return fresh;
+}
+
+/**
+ * @brief Reports whether a template identifier in a binder position may be
+ * alpha-renamed.
+ *
+ * Pattern variables may not: they are replaced by caller code, which must keep
+ * the caller's own names. `_` is not an identifier.
+ */
+bool MacroExpander::isRenameableBinder(const std::string& name, const Bindings& bindings) {
+    if (name.empty() || name == "_") return false;
+    return bindings.find(name) == bindings.end();
+}
+
 eshkol_ast_t MacroExpander::substituteBindings(const eshkol_ast_t& ast,
                                                  const Bindings& bindings) {
     // Check if this is a variable that should be substituted
@@ -942,6 +974,17 @@ eshkol_ast_t MacroExpander::substituteBindings(const eshkol_ast_t& ast,
         auto it = bindings.find(name);
         if (it != bindings.end() && matchTreeHasValue(it->second.tree)) {
             return copyAst(matchTreeFirstScalar(it->second.tree));
+        }
+        // Hygiene: a template identifier bound by the template itself carries
+        // the fresh name allocated at its binder (R7RS 4.3.2). Anything else
+        // is free in the template and is emitted verbatim.
+        auto rn = active_renames_.find(name);
+        if (!in_datum_ && rn != active_renames_.end()) {
+            eshkol_ast_t result = copyAst(ast);
+            // copyAst() strdup()s the id, so this must be free()/strdup() too.
+            free(result.variable.id);
+            result.variable.id = strdup(rn->second.c_str());
+            return result;
         }
         return copyAst(ast);
     }
@@ -979,7 +1022,17 @@ eshkol_ast_t MacroExpander::substituteBindings(const eshkol_ast_t& ast,
             case ESHKOL_QUASIQUOTE_OP:
             case ESHKOL_UNQUOTE_OP:
             case ESHKOL_UNQUOTE_SPLICING_OP:
-            case ESHKOL_QUOTE_OP:
+            case ESHKOL_QUOTE_OP: {
+                // Hygiene: a symbol in quoted data is DATA, so it keeps its
+                // literal name; unquote escapes back to identifier position.
+                // Pattern-variable substitution is unaffected either way.
+                const bool saved_datum = in_datum_;
+                if (op->op == ESHKOL_QUOTE_OP || op->op == ESHKOL_QUASIQUOTE_OP) {
+                    in_datum_ = true;
+                } else if (op->op == ESHKOL_UNQUOTE_OP ||
+                           op->op == ESHKOL_UNQUOTE_SPLICING_OP) {
+                    in_datum_ = false;
+                }
                 if (op->call_op.func) {
                     eshkol_ast_t* new_func = new eshkol_ast_t;
                     *new_func = substituteBindings(*op->call_op.func, bindings);
@@ -999,7 +1052,9 @@ eshkol_ast_t MacroExpander::substituteBindings(const eshkol_ast_t& ast,
                         op->call_op.variables = nullptr;
                     }
                 }
+                in_datum_ = saved_datum;
                 break;
+            }
 
             case ESHKOL_SEQUENCE_OP:
             case ESHKOL_AND_OP:
@@ -1030,22 +1085,115 @@ eshkol_ast_t MacroExpander::substituteBindings(const eshkol_ast_t& ast,
                 }
                 break;
 
-            case ESHKOL_LAMBDA_OP:
+            case ESHKOL_LAMBDA_OP: {
+                // Hygiene: a template-introduced parameter is fresh in the body.
+                auto saved_renames = active_renames_;
+                if (op->lambda_op.num_params > 0 && op->lambda_op.parameters) {
+                    eshkol_ast_t* new_params = new eshkol_ast_t[op->lambda_op.num_params];
+                    for (uint64_t i = 0; i < op->lambda_op.num_params; i++) {
+                        const eshkol_ast_t& p = op->lambda_op.parameters[i];
+                        if (p.type == ESHKOL_VAR && p.variable.id &&
+                            isRenameableBinder(p.variable.id, bindings)) {
+                            freshName(p.variable.id);
+                        }
+                        new_params[i] = substituteBindings(p, bindings);
+                    }
+                    op->lambda_op.parameters = new_params;
+                }
+                if (op->lambda_op.rest_param &&
+                    isRenameableBinder(op->lambda_op.rest_param, bindings)) {
+                    op->lambda_op.rest_param =
+                        strdup(freshName(op->lambda_op.rest_param).c_str());
+                }
                 if (op->lambda_op.body) {
                     eshkol_ast_t* new_body = new eshkol_ast_t;
                     *new_body = substituteBindings(*op->lambda_op.body, bindings);
                     op->lambda_op.body = new_body;
                 }
+                active_renames_ = saved_renames;
                 break;
+            }
 
             case ESHKOL_LET_OP:
             case ESHKOL_LET_STAR_OP:
             case ESHKOL_LETREC_OP:
-            case ESHKOL_LETREC_STAR_OP:
-                if (op->let_op.num_bindings > 0 && op->let_op.bindings) {
-                    eshkol_ast_t* new_bindings = new eshkol_ast_t[op->let_op.num_bindings];
+            case ESHKOL_LETREC_STAR_OP: {
+                // Hygiene: each template-introduced binder gets a fresh name,
+                // visible exactly where the binding construct makes it visible.
+                //   let          inits see the OUTER scope
+                //   let*         init i sees binders 0..i-1
+                //   letrec(*)    every init sees every binder
+                //   named let    the loop name is bound in the body
+                const bool is_rec = (op->op == ESHKOL_LETREC_OP ||
+                                     op->op == ESHKOL_LETREC_STAR_OP);
+                const bool is_seq = (op->op == ESHKOL_LET_STAR_OP);
+                auto saved_renames = active_renames_;
+
+                if (is_rec && op->let_op.num_bindings > 0 && op->let_op.bindings) {
                     for (uint64_t i = 0; i < op->let_op.num_bindings; i++) {
-                        new_bindings[i] = substituteBindings(op->let_op.bindings[i], bindings);
+                        const eshkol_ast_t& b = op->let_op.bindings[i];
+                        if (b.type == ESHKOL_CONS && b.cons_cell.car &&
+                            b.cons_cell.car->type == ESHKOL_VAR &&
+                            b.cons_cell.car->variable.id &&
+                            isRenameableBinder(b.cons_cell.car->variable.id, bindings)) {
+                            freshName(b.cons_cell.car->variable.id);
+                        }
+                    }
+                }
+                if (op->let_op.name && isRenameableBinder(op->let_op.name, bindings)) {
+                    op->let_op.name = strdup(freshName(op->let_op.name).c_str());
+                }
+
+                if (op->let_op.num_bindings > 0 && op->let_op.bindings) {
+                    const uint64_t n = op->let_op.num_bindings;
+                    eshkol_ast_t* new_bindings = new eshkol_ast_t[n];
+                    std::vector<eshkol_ast_t> inits(n);
+                    std::vector<bool> is_cons(n, false);
+
+                    // Pass 1 — inits. For plain `let` every init is substituted
+                    // while NO binder of this group is in scope (that is what
+                    // makes `let` parallel); `let*` accumulates as it goes;
+                    // `letrec` already has the whole group in scope.
+                    for (uint64_t i = 0; i < n; i++) {
+                        const eshkol_ast_t& b = op->let_op.bindings[i];
+                        if (b.type != ESHKOL_CONS || !b.cons_cell.car) continue;
+                        is_cons[i] = true;
+                        inits[i] = b.cons_cell.cdr
+                            ? substituteBindings(*b.cons_cell.cdr, bindings)
+                            : eshkol_ast_t{};
+                        if (is_seq && b.cons_cell.car->type == ESHKOL_VAR &&
+                            b.cons_cell.car->variable.id &&
+                            isRenameableBinder(b.cons_cell.car->variable.id, bindings)) {
+                            freshName(b.cons_cell.car->variable.id);
+                        }
+                    }
+
+                    // Pass 2 — binders. For plain `let` they all enter scope
+                    // together, after every init has been substituted.
+                    if (!is_rec && !is_seq) {
+                        for (uint64_t i = 0; i < n; i++) {
+                            if (!is_cons[i]) continue;
+                            const eshkol_ast_t* car = op->let_op.bindings[i].cons_cell.car;
+                            if (car->type == ESHKOL_VAR && car->variable.id &&
+                                isRenameableBinder(car->variable.id, bindings)) {
+                                freshName(car->variable.id);
+                            }
+                        }
+                    }
+
+                    for (uint64_t i = 0; i < n; i++) {
+                        const eshkol_ast_t& b = op->let_op.bindings[i];
+                        if (!is_cons[i]) {
+                            new_bindings[i] = substituteBindings(b, bindings);
+                            continue;
+                        }
+                        eshkol_ast_t nb;
+                        nb.type = ESHKOL_CONS;
+                        nb.cons_cell.car = new eshkol_ast_t;
+                        *nb.cons_cell.car = substituteBindings(*b.cons_cell.car, bindings);
+                        nb.cons_cell.cdr = new eshkol_ast_t;
+                        *nb.cons_cell.cdr = inits[i];
+                        new_bindings[i] = nb;
                     }
                     op->let_op.bindings = new_bindings;
                 }
@@ -1054,7 +1202,9 @@ eshkol_ast_t MacroExpander::substituteBindings(const eshkol_ast_t& ast,
                     *new_body = substituteBindings(*op->let_op.body, bindings);
                     op->let_op.body = new_body;
                 }
+                active_renames_ = saved_renames;
                 break;
+            }
 
             case ESHKOL_MATCH_OP:
                 if (op->match_op.expr) {
@@ -1101,6 +1251,31 @@ eshkol_ast_t MacroExpander::substituteBindings(const eshkol_ast_t& ast,
                 break;
 
             case ESHKOL_SET_OP:
+                // The TARGET is a bare char*, not an AST node, so it was never
+                // reached by the substitution walk. A template like
+                //     ((_ a b) (let ((tmp a)) (set! a b) (set! b tmp)))
+                // therefore emitted a literal `a`, and the classic swap! macro
+                // failed to compile with "set!: undefined variable 'a'".
+                // R7RS 4.3.2: a pattern variable is substituted wherever it
+                // occurs in the template, assignment targets included.
+                if (op->set_op.name) {
+                    std::string target = op->set_op.name;
+                    auto it = bindings.find(target);
+                    if (it != bindings.end() && matchTreeHasValue(it->second.tree)) {
+                        const eshkol_ast_t& v = matchTreeFirstScalar(it->second.tree);
+                        if (v.type == ESHKOL_VAR && v.variable.id) {
+                            op->set_op.name = strdup(v.variable.id);
+                        }
+                        // A non-identifier operand in a set! target position is
+                        // a user error; leave the name alone so the compiler
+                        // reports it rather than silently mutating something.
+                    } else {
+                        auto rn = active_renames_.find(target);
+                        if (rn != active_renames_.end()) {
+                            op->set_op.name = strdup(rn->second.c_str());
+                        }
+                    }
+                }
                 if (op->set_op.value) {
                     eshkol_ast_t* new_val = new eshkol_ast_t;
                     *new_val = substituteBindings(*op->set_op.value, bindings);

--- a/tests/differential/corpus/51_syntax_rules_hygiene.esk
+++ b/tests/differential/corpus/51_syntax_rules_hygiene.esk
@@ -1,0 +1,48 @@
+;; syntax-rules hygiene for template-introduced bindings (R7RS 4.3.2), SW-30.
+;;
+;; The parity row lives in tests/vm_parity/corpus/68_syntax_rules_hygiene.esk;
+;; this file pins the same semantics across the NATIVE axes (jit-cache,
+;; jit-nocache, aot-O0, aot-O2). The axis that matters here is the JIT one:
+;; the REPL re-feeds saved define-syntax ASTs into a FRESH MacroExpander on
+;; every evaluation, so the fresh-name counter restarts. These programs would
+;; diverge across axes if a renamed binder ever escaped its own scope.
+
+(define-syntax hyg
+  (syntax-rules () ((_ e) (let ((tmp 100)) (+ tmp e)))))
+
+(define tmp 7)
+(display (hyg 1)) (newline)                  ; 101 — template binding survives
+(display tmp) (newline)                      ; 7   — user variable untouched
+(display (hyg tmp)) (newline)                ; 107 — operand is NOT captured
+(display (let ((tmp 99)) (hyg tmp))) (newline)   ; 199 — use-site binding safe
+(display (hyg (hyg 1))) (newline)            ; 201 — two invocations, two bindings
+
+;; A recursive macro whose template binds, with a colliding global.
+(define-syntax my-or
+  (syntax-rules ()
+    ((_ a) a)
+    ((_ a b ...) (let ((t a)) (if t t (my-or b ...))))))
+(define t 42)
+(display (my-or #f #f t)) (newline)          ; 42
+
+;; Nested macro invocation, both templates binding the same name.
+(define-syntax mac-a
+  (syntax-rules () ((_ x) (let ((s 10)) (+ s x)))))
+(define-syntax mac-b
+  (syntax-rules () ((_ y) (let ((s 200)) (+ s (mac-a y))))))
+(display (mac-b 1)) (newline)                ; 211
+
+;; set! on a pattern variable, plus a colliding template binder.
+(define-syntax swap!
+  (syntax-rules () ((_ x y) (let ((tv x)) (set! x y) (set! y tv)))))
+(define tv 5)
+(define other 9)
+(swap! tv other)
+(display tv) (newline)                       ; 9
+(display other) (newline)                    ; 5
+
+;; A quoted symbol is data: the renamer must not leak a gensym into output.
+(define-syntax qm
+  (syntax-rules () ((_ e) (let ((z 5)) (list 'z z e)))))
+(define z 3)
+(display (qm z)) (newline)                   ; (z 5 3)

--- a/tests/vm_parity/corpus/61_multi_macro_batch.esk
+++ b/tests/vm_parity/corpus/61_multi_macro_batch.esk
@@ -22,11 +22,11 @@
 ;     where the VM peephole used to splice `CONST 0 + ADD` across the `else`
 ;     label and delete the enclosing `+` outright
 ;
-; NOT covered here, deliberately: syntax-rules HYGIENE for a binding introduced
-; by the template.  Both engines are wrong and they disagree with each other
-; (native captures, the VM loses the binding and corrupts a same-named
-; top-level variable), so it cannot be pinned as a parity row yet — filed
-; separately rather than folded into this file.
+; NOT covered here: syntax-rules HYGIENE for a binding introduced by the
+; template.  That surface now has its own parity file,
+; 68_syntax_rules_hygiene.esk (SW-30).  When this file was written neither
+; engine was hygienic and the two disagreed, so no such shape could be pinned;
+; both expanders now alpha-rename template-introduced binders and agree.
 
 (define-syntax dbl
   (syntax-rules () ((_ e) (* 2 e))))

--- a/tests/vm_parity/corpus/68_syntax_rules_hygiene.esk
+++ b/tests/vm_parity/corpus/68_syntax_rules_hygiene.esk
@@ -1,0 +1,137 @@
+; SW-30 class-kill: syntax-rules HYGIENE for bindings introduced by the
+; template (R7RS 4.3.2).
+;
+; This file is the shape 61_multi_macro_batch.esk said it could not carry:
+;
+;   "NOT covered here, deliberately: syntax-rules HYGIENE for a binding
+;    introduced by the template.  Both engines are wrong and they disagree
+;    with each other ... so it cannot be pinned as a parity row yet"
+;
+; Two independent defects made that true, and both are fixed:
+;
+;   1. The VM's column was not a hygiene defect at all.  `define-syntax`
+;      compiled to NOTHING, while every top-level and body driver POPs after
+;      a form that bound nothing.  That POP therefore discarded a LIVE value
+;      and shifted every later local down one slot, so the template's `let`
+;      wrote slot k while the body read slot k+1.  (hyg 1) printed 1 instead
+;      of 101 and a same-named user variable read back as ().  Fixed by
+;      emitting OP_NIL, exactly as (provide)/(export) already did.
+;
+;   2. NEITHER engine renamed template-introduced binders, so a template's
+;      `tmp` captured a caller's `tmp` passed in through a pattern variable.
+;      Both expanders now alpha-rename the identifiers a template BINDS
+;      itself, scope by scope, before any caller code is substituted in.
+;
+; Every row below is a value both engines now produce and R7RS requires.
+;
+; STILL NOT HYGIENIC, on BOTH engines identically (see the SW-30 ledger
+; entry): referential transparency for a template's FREE identifiers.  A
+; free identifier in a template is resolved at the USE site, not at the
+; macro-definition site, because neither engine captures a macro-definition
+; environment.  That case is deliberately absent here rather than pinned at
+; a wrong value.
+
+; ── 1. A template-introduced binding survives at all ──────────────────────
+(define-syntax hyg
+  (syntax-rules () ((_ e) (let ((tmp 100)) (+ tmp e)))))
+
+(display (hyg 1)) (newline)                  ; 101
+
+; ── 2. ...and does not corrupt a same-named user variable ─────────────────
+(define tmp 7)
+(display (hyg 1)) (newline)                  ; 101
+(display tmp) (newline)                      ; 7   (untouched)
+
+; ── 3. The capture case: the operand IS the colliding name ────────────────
+; Unhygienic expansion gives (let ((tmp 100)) (+ tmp tmp)) = 200.
+(display (hyg tmp)) (newline)                ; 107
+
+; ── 4. A use-site binding of the same name is not captured either ─────────
+(display (let ((tmp 99)) (hyg tmp))) (newline)   ; 199
+
+; ── 5. Nested macro invocation, both templates binding the same name ──────
+(define-syntax mac-a
+  (syntax-rules () ((_ x) (let ((t 10)) (+ t x)))))
+(define-syntax mac-b
+  (syntax-rules () ((_ y) (let ((t 200)) (+ t (mac-a y))))))
+(display (mac-b 1)) (newline)                ; 211
+
+; ── 6. Recursive macro whose template binds, with a colliding global ──────
+(define-syntax my-or
+  (syntax-rules ()
+    ((_ a) a)
+    ((_ a b ...) (let ((t a)) (if t t (my-or b ...))))))
+(define t 42)
+(display (my-or #f #f t)) (newline)          ; 42
+(display (my-or #f t)) (newline)             ; 42
+
+; ── 7. Template-introduced lambda parameter ───────────────────────────────
+(define-syntax lam
+  (syntax-rules () ((_ e) ((lambda (q) (* q 2)) e))))
+(define q 21)
+(display (lam q)) (newline)                  ; 42
+
+; ── 8. let* binders are sequential and still fresh ────────────────────────
+(define-syntax ls
+  (syntax-rules () ((_ e) (let* ((a 1) (b (+ a 1))) (+ a b e)))))
+(define a 100)
+(define b 200)
+(display (ls a)) (newline)                   ; 103
+(display (ls b)) (newline)                   ; 203
+
+; ── 9. letrec: the binder is visible in its own init, and still fresh ─────
+(define-syntax lr
+  (syntax-rules ()
+    ((_ e) (letrec ((f (lambda (n) (if (= n 0) e (f (- n 1)))))) (f 3)))))
+(define f 9)
+(display (lr 7)) (newline)                   ; 7
+(display (lr f)) (newline)                   ; 9
+
+; ── 10. Nested template scopes: the inner binder shadows the outer one ────
+(define-syntax nest
+  (syntax-rules () ((_ e) (let ((v 1)) (let ((v 2)) (+ v e))))))
+(define v 50)
+(display (nest v)) (newline)                 ; 52
+
+; ── 11. Two invocations must not share a binding ──────────────────────────
+(display (hyg (hyg 1))) (newline)            ; 201
+
+; ── 12. Named let: loop name and loop variables are all fresh ─────────────
+(define-syntax nl
+  (syntax-rules ()
+    ((_ e) (let loop ((i 0) (acc 0))
+             (if (= i 3) (+ acc e) (loop (+ i 1) (+ acc i)))))))
+(define i 100)
+(define acc 200)
+(display (nl i)) (newline)                   ; 103
+(display (nl acc)) (newline)                 ; 203
+
+; ── 13. A quoted symbol is DATA and keeps its literal name ────────────────
+; The renamer must not leak its gensym into the program's OUTPUT.
+(define-syntax qm
+  (syntax-rules () ((_ e) (let ((z 5)) (list 'z z e)))))
+(define z 9)
+(display (qm z)) (newline)                   ; (z 5 9)
+
+; ── 14. ...and the same holds through quasiquote/unquote ──────────────────
+(define-syntax qqm
+  (syntax-rules () ((_ e) (let ((z 5)) `(z ,z ,e)))))
+(display (qqm z)) (newline)                  ; (z 5 9)
+
+; ── 15. set! on a pattern variable: the classic swap! ─────────────────────
+; The native expander substituted a set! VALUE but never its TARGET (the
+; target is a bare char*, not an AST node), so this template used to fail to
+; compile with "set!: undefined variable 'a'".  With the target substituted
+; and `tmp` renamed, the swap works even when an operand is named `tmp`.
+(define-syntax swap!
+  (syntax-rules () ((_ x y) (let ((tmp x)) (set! x y) (set! y tmp)))))
+(define s1 1)
+(define s2 2)
+(swap! s1 s2)
+(display s1) (newline)                       ; 2
+(display s2) (newline)                       ; 1
+
+(define w 5)
+(swap! w tmp)                                ; operand collides with the binder
+(display w) (newline)                        ; 7
+(display tmp) (newline)                      ; 5


### PR DESCRIPTION
**Retargeted to `master`** — #432 merged as `6acc9030`. This branch was rebased onto master replaying only its own commit.

Two renumberings were needed across the two hops, both mechanical and both caught by survey rather than by conflict:

- **Corpus files → next-free on master.** `65_` and `49_` are taken there by the numeric-predicate and do-loop rows, so the hygiene parity row is **`68_syntax_rules_hygiene.esk`** and the differential row **`51_syntax_rules_hygiene.esk`**. The `59_multi_macro_batch.esk` whose comment this branch corrects is now `61_multi_macro_batch.esk`; the edit followed the rename.
- **Ledger `SW-33` → `SW-35`.** Master's #437 landed its own `SW-33` (mutated + captured REST parameter) while this was in review, and the rebase merged the two entries **textually rather than conflicting**, so nothing flagged the duplicate id. Master's `SW-33` is `closed` and keeps it. Re-surveyed against master's canonical ledger after #430/#432/#434/#435/#438/#439/#441 all landed: master's highest id is `SW-34` and it has no `SW-35`, so `SW-35` is correct and needed no second move. The entry carries `renumbered_from: SW-33` with the reason.

Ledger merge was **union with the close winning** on `SW-30`, which master still carried as `open`. All gate counts below are re-measured on master.

Closes **SW-30**. The filed hypothesis was wrong and there were two independent defects, only one of which is a hygiene defect at all.

## The VM column was not a hygiene defect

The ledger entry guessed *"the VM's expander does gensym renaming that is applied inconsistently between binder and reference."* It does not. `vm_macro_gensym()` had **zero callers** outside its own self-test, and neither expander contained any renaming, mark, syntactic closure or definition-environment machinery whatsoever.

What actually happened is a **stack-slot shift**. `define-syntax` compiled to *nothing*, while every top-level and body driver POPs after a form that bound nothing. That POP therefore discarded a **live** value and shifted every later local down one slot, so a template's `let` wrote slot *k* while the body read slot *k+1*.

The identical hazard was already documented and handled **three cases earlier in the same function**, for `(provide)`/`(export)`:

```c
/* ... The OP_NIL is not decorative: the top-level and body compilers POP after
 * any form that bound nothing, so returning without pushing would make
 * that POP discard a live value and shift every later binding down a slot ... */
```

`define-syntax` now emits it too. **This is a class**: any no-emit top-level special form has the same exposure (`syntax-error` is the next one).

One line, and the whole VM column of SW-30 changes:

| | before | after |
|---|---|---|
| `(hyg 1)` | `1` | `101` |
| `(display tmp)` after `(define tmp 7)` | `()` | `7` |
| nested macro, both templates binding | `239` | `211` |

## Neither engine renamed template-introduced binders

Both **captured**. `substituteBindings()` and `vm_macro_instantiate()` each emitted every non-pattern-variable identifier verbatim, so `(hyg tmp)` gave `200` where R7RS 4.3.2 requires `107`.

Both expanders now **alpha-rename the identifiers a template binds itself**, scope by scope, *before any caller code is substituted in*. That ordering is what makes it safe: at that point every symbol in the tree came from the macro definition, so no caller identifier can be touched. Pattern variables are never renamed — they carry caller code, which must keep its own names.

Covered forms: `let`, `let*`, `letrec`, `letrec*`, named `let`, `lambda` (including a rest parameter), with the scoping each one actually has — a plain `let`'s inits are substituted while *no* binder of its group is in scope, `let*` accumulates, `letrec` has the whole group in scope for every init.

Quoted and quasiquoted data are walked in **datum mode**. Without that the renamer leaks its own gensym into the program's **output**: `(let ((z 5)) (list 'z z))` printed `(_h0.z 5)`.

## `set!` targets were never substituted on native

Found while pinning the classic `swap!`. A `set!` target is a bare `char*`, not an AST node, so the substitution walk never reached it:

```scheme
(define-syntax swap! (syntax-rules () ((_ x y) (let ((tmp x)) (set! x y) (set! y tmp)))))
```

failed to compile with `set!: undefined variable 'x'`. R7RS substitutes a pattern variable wherever it occurs in a template, assignment targets included.

## Hygiene matrix

18 cells, measured against both engines before and after. **Before: VM 0/18, native 3/18, engines disagreed on 14.** **After: both engines agree on all 18; 17 are R7RS-correct.**

| # | cell | R7RS | native before | VM before | both after |
|---|---|---|---|---|---|
| 1 | template `let` binding survives | 101 | 101 | **1** | 101 |
| 2 | ...and same-named user variable intact | 101, 7 | 101, 7 | **1**, *(dropped)* | 101, 7 |
| 3 | **capture**: operand IS the colliding name | 107 | **200** | **0** | 107 |
| 4 | use-site binding of the same name | 199 | **200** | **0** | 199 |
| 5 | nested macro, both templates binding | 211 | 211 | **239** | 211 |
| 6 | recursive macro + colliding global | 5 | **#f** | **0** | 5 |
| 7 | **free identifier → definition site** | 50 | **-5** | *(slot shift)* | **-5** — see SW-35 |
| 8 | template lambda parameter | 41 | 41 | **1** | 41 |
| 9 | `swap!` with colliding operand | 2 1 | **compile error** | **238** | 2 1 |
| 10 | recursive macro w/ ellipsis | 42 | **#f** | — | 42 |
| 11 | `let*` binders sequential + fresh | 103, 203 | — | — | 103, 203 |
| 12 | `letrec` binder in its own init | 7, 9 | — | — | 7, 9 |
| 13 | nested template scopes shadowing | 52 | — | — | 52 |
| 14 | two invocations don't share a binding | 201 | — | — | 201 |
| 15 | quoted symbol keeps its name | `(z 5 9)` | **`(_h0.z 5 9)`** | — | `(z 5 9)` |
| 16 | named `let` loop name + vars fresh | 103, 203 | — | — | 103, 203 |
| 17 | lambda param, colliding global | 42 | — | — | 42 |
| 18 | quasiquote/unquote keeps names | `(z 5 9)` | **`(_h0.z 5 9)`** | **`(_h0.z 5 9)`** | `(z 5 9)` |

Cells 10-18 could not be measured meaningfully "before" on the VM: the slot shift corrupted the program state ahead of the shape under test.

## NEEDS-DECISION — SW-35, referential transparency

Cell 7 is the one still-wrong cell, and **both engines are wrong identically**, so it blocks no parity row. Filed as **SW-35** with a full design sketch rather than improvised.

```scheme
(define (helper x) (* x 10))
(define-syntax usehelp (syntax-rules () ((_ a) (helper a))))
(display (let ((helper (lambda (x) (- x)))) (usehelp 5)))
;; both engines: -5      R7RS 4.3.2: 50
```

**Why it is not fixed here.** SW-30's capture half was fixable because renaming is a pure rewrite of the template before caller code enters it. Referential transparency is not: it needs every identifier to carry the environment it was written in — syntax objects (or marks / scope sets) threaded through the reader, both expanders and **both name-resolution paths**. Native resolves at LLVM codegen; the VM resolves at compile time against a flat local table, and its macro registry is a process-global array with no scoping at all (which is also why `let-syntax`/`letrec-syntax` fake their scope by saving and restoring `g_n_macros`). `eshkol_macro_def_t` and `VmMacro` both carry no environment field. This is precisely the *"full alpha-renaming/marks infrastructure that does not exist in either expander"* case the policy says to stop and report.

**The loud-error interim was considered and rejected as unshippable.** Every template contains free identifiers — `+`, `if`, `list`, `cond`, every builtin and every user helper — so an "unsupported hygiene case" error at a free template identifier would fire on essentially every macro in the language, including all 42 `.esk` files in this repo that use `define-syntax`. The mis-binding only occurs when the use site actually *shadows* one of those names, and detecting that at expansion time needs the very environment tracking that is missing. A precise collision detector is implementable but needs the use-site environment plumbed into the expander — roughly half the work of doing it properly. The ledger entry records this reasoning and sketches the env-handle route and the scope-set route with rough sizing.

## Also left uncovered, on purpose and identically on both engines

A template-introduced **`do`** loop variable still captures. Native stores a do-loop in the generic `call_op` layout, where the loop variables are untyped nested lists rather than an addressable binding array, so a scope-correct rename is not reachable there. Renaming it on the VM alone would have made the two engines disagree on a shape neither fully supports — the opposite of what SW-30 asks for. Recorded in the ledger. Likewise a template-introduced `define` is not renamed; R7RS requires it, but not renaming is the status quo and renaming would break the common idiom of a macro that defines something.

## Tests

- **`tests/vm_parity/corpus/68_syntax_rules_hygiene.esk`** — 15 sections. Gated by vm-parity on native / vm-src / vm-eskb **and** by the wasm execute-and-diff lane, so it is pinned in the browser build too.
- **`tests/differential/corpus/51_syntax_rules_hygiene.esk`** — the same semantics across native jit-cache / jit-nocache / aot-O0 / aot-O2. The JIT axis matters: the REPL re-feeds saved `define-syntax` ASTs into a fresh expander per eval, restarting the fresh-name counter.
- `61_multi_macro_batch.esk` said outright that no template-binder hygiene shape could be pinned as a parity row. That comment is now false and has been corrected to point at 68.

**Revert-validated** — all four changes were individually reverted on a built tree and `68` detects each one:

| reverted | 63 prints |
|---|---|
| VM `OP_NIL` | `1｜2｜100｜200｜101｜…` |
| VM renamer | `200` for 107, `#f` for 42, a leaked `<closure@741>` |
| native renamer | same wrong values on native |
| native `set!` target | fails to compile |
| datum mode | `(_h28.z 5 9)` |

## Gates

| gate | result |
|---|---|
| ctest (`run_ctest_gate.sh`) | **174/174** |
| vm-parity | **182 passed, 0 failed** |
| differential | **324/324 across 54 programs** |
| wasm execute-and-diff | **73 passed, 0 failed, 0 xfail**, 2 excluded |
| macros | **8/8** |
| SICP smoke | **88/88** |
| metaprog depth | **496/496** |
| edge matrix | **576/576 PASS**, 0 assert-fail / crash / compile-err / hang |

`wasm_68_syntax_rules_hygiene: PASS` in the actual wasm32 environment is the load-bearing evidence that macros ship hygienically in the browser.

**ICC probes, reported honestly.** ICC smoke: **59/61 probes pass, 2 fail** (#432's baseline on the same harness was 60/61).

`language_surface_coverage_floor` is RED and it is an **environment** result, not a code one: `run_language_coverage.sh` requires a second, quantum-enabled build tree (`build-quantum/eshkol-run`, `-DESHKOL_QUANTUM_ENABLED=ON`) that this worktree does not have, and it exits before running any coverage at all. Nothing in this branch touches that surface. This is the one probe difference from #432's 60/61 and it is purely the missing build directory.

`no_open_silent_wrong` remains red exactly as on #432: this branch **closes SW-30** and **files SW-35**, so the blocking count stays at **15** rather than dropping — one closed, one newly measured. That is a discovery result, not a regression. The grader accepts SW-30 as `status: fixed` on committed-test evidence.

Every other probe passes, including `generative_differential_oracle` (generated R7RS programs agreeing across chibi / JIT / AOT-O0 / AOT-O2 / VM plus metamorphic, no new divergence vs baseline) and `surface_parity_execution_backed`, both of which execute macro-bearing surface on both engines.

## Ledger

- **SW-30 → `status: fixed`**, retitled to the surface actually fixed, with the corrected root cause (the filed hypothesis is explicitly marked wrong), the before/after matrix, the revert-validation record, and the residual list.
- **SW-35 filed** (renumbered from SW-33, see below) — referential transparency, `needs_decision: true`, with root cause, the rejected interim and why, the real-fix sketch and rough effort.
- One unrelated observation recorded in SW-35's notes so it is not lost: a macro named `inner` cannot be defined on native at all — `(define-syntax inner (syntax-rules () ((_ x) (+ 10 x))))` then `(inner 1)` fails with *"no matching pattern for macro 'inner'"* plus a spurious *"Circular macro expansion detected"*, while the same program with the macro renamed works. A reserved-name collision in the native frontend. It is **loud** (exit 1), not silent, and out of scope here.
