### PR TITLE
feat(testing): the value-position axis — close SW-34/SW-35, kill the class that produced them

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -251,6 +251,38 @@ oracles:
         action: ./scripts/run_icc_smoke.sh
 
       # ─────────────────────────────────────────────────────────────
+      # THE VALUE-POSITION AXIS (scripts/run_value_position_sweep.py).
+      #
+      # Builtins are lowered inline at the call site; referencing one as a
+      # VALUE goes through different codegen. Four defects have been found
+      # living there while call position was correct — LE-01 (no value
+      # representation at all), SW-27 (rest-arg procedures lost their
+      # variadic flag, silently), SW-31, SW-35 (rounding returned a
+      # rational's heap address). None was caught by any criterion above,
+      # and structurally none could be: the differential corpus compares
+      # execution AXES against each other, and these defects are wrong
+      # identically on every axis.
+      #
+      # The sweep's oracle is differential BY CONSTRUCTION — call position
+      # versus value position for the same call in the same program — so it
+      # asserts no expected values and cannot certify a wrong answer.
+      # ─────────────────────────────────────────────────────────────
+      - runtime_event:
+          event_kinds: [runtime_event]
+          event_names: ["value_position_sweep"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'the VALUE-POSITION axis is clean: every builtin the manifest can type answers the same referenced as a value — passed to a higher-order procedure, stored, returned, reached through a builtin combinator — as it does in call position, on every execution axis'
+        action: python3 scripts/run_value_position_sweep.py
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["value_position_axis"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'the value-position axis probe is wired into the smoke harness, so the blind spot that produced SW-27/SW-31/SW-34/SW-35 one at a time is gated rather than rediscovered'
+        action: ./scripts/run_icc_smoke.sh
+
+      # ─────────────────────────────────────────────────────────────
       # P8 "escape-closure" pillar (scripts/run_p8_escape.sh). Each axis
       # is built so that a 2026-07 externally-reported bug CLASS would have
       # been caught by our own framework first; retro-catch evidence

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -1993,6 +1993,250 @@ entries:
     caught_by: [pr-record-416]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
 
+  - id: SW-41
+    bucket: PARITY-RATCHET
+    status: closed
+    closed_at: "fix/value-position-axis"
+    closed_by: "PR stacked on #439 (branch fix/value-position-axis)"
+    title: "complex? cannot be used as a first-class value natively, though the VM binds it"
+    repro: "(display (map complex? (list 1 2)))"
+    observed: >-
+      native -r fails to compile: "Undefined variable: complex?" followed by
+      "Failed to resolve procedure for map". The VM resolves it and answers (#t #t).
+    correct: "both engines should bind it; it is an R7RS 6.2.1 procedure"
+    measured: >-
+      In CALL position (complex? 5) works on both engines. Only the value position
+      diverges. Found while building the SW-31 predicate matrix, which had to drop
+      complex? from its first-class section for exactly this reason — the file says so in
+      a comment rather than quietly omitting it.
+    caught_by: [direct-measurement, sw-31-corpus-authoring]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity, differential-corpus]
+    notes: >-
+      Classified PARITY-RATCHET rather than SILENT-WRONG: native fails LOUDLY at compile
+      time, so nothing computes a wrong answer. It is a binding-table gap on the native
+      side, and it blocks one row of the predicate matrix from being gated.
+    root_cause: >-
+      complex? had no row in the codegen's first-class builtin table
+      (lookupInlineBuiltin, lib/backend/llvm_codegen.cpp). Reading a bare builtin name as
+      a value consults that table; a name absent from it falls through to
+      "Undefined variable". Call position never consults it, which is why the two
+      positions disagreed.
+    fix: >-
+      The R7RS numeric-tower predicate family is now listed as a FAMILY — number?,
+      complex?, real?, rational?, integer?, exact?, inexact?, exact-integer?, nan?,
+      infinite?, finite? — together with the type predicates, rather than name-by-name
+      as need arises. Name-by-name is how the gap appeared, so the fix removes the
+      mode of failure and not just the instance.
+    verified_at: >-
+      tests/integration/first_class_predicates_test.esk, gated on the JIT lane, the AOT
+      lane and the VM (first_class_predicates_{runtime,aot,vm}_smoke). The oracle is
+      differential: every predicate is compared against the identical application in call
+      position in the same program, through BOTH value-position routes (a user
+      higher-order procedure, and map). The predicate matrix no longer needs its
+      complex? exclusion.
+    id_collision_note: >-
+      The ID SW-34 was allocated concurrently by more than one lane. THIS closure refers
+      to the entry whose title is "complex? cannot be used as a first-class value
+      natively, though the VM binds it", filed on branch
+      fix/numeric-tower-bignum-tail with repro "(display (map complex? (list 1 2)))".
+      It does not speak to whatever else may carry the number SW-34 elsewhere;
+      reconciliation happens at merge.
+    renumbered_from: >-
+      Filed as SW-34 on branch fix/numeric-tower-bignum-tail (PR #439), which did not carry
+      the entry into master. Renumbered TWICE as master moved underneath this PR, each time
+      because the number had been taken by a defect that reached master first and which is
+      not renumbered here:
+        SW-34 -> SW-40   master's SW-34 is #438's "`do` loop variable captured and mutated
+                         by a body closure loses the mutation"
+        SW-40 -> SW-41   master's SW-40 is #443's "a derivative taken through min/max is
+                         silently 0 on the VM"
+      Cite this defect as SW-41. Note for anyone auditing the second hop: git reported NO
+      conflict on that rebase, because the two SW-40 entries landed in different regions of
+      the file. A clean auto-merge is not evidence of a correct ledger; the duplicate was
+      caught by parsing the YAML and counting IDs, which is the check worth keeping.
+
+  - id: SW-35
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "fix/value-position-axis"
+    closed_by: "PR stacked on #439 (branch fix/value-position-axis)"
+    title: "Natively, floor/ceiling/truncate/round used as FIRST-CLASS VALUES return a rational's heap pointer as a number"
+    repro: "(display (map floor (list 7/3 -7/3 (/ (expt 2 100) 3))))"
+    observed: >-
+      native prints something like (4966570936 4966571152 4966571728) — the values are
+      HEAP ADDRESSES, they change between runs of the same binary, and (exact? …) on each
+      is #f. The same call in CALL position, (floor 7/3), correctly prints 2.
+    correct: "(2 -3 422550200076076467165567735125), which the VM prints"
+    measured: >-
+      Whole-list probe across the tower: (map floor (list 7/3 -7/3 (/ (expt 2 100) 3) 2.7 5))
+      gives garbage for the three RATIONALS and correct answers for 2.7 and 5, on all four
+      of floor/ceiling/truncate/round. The VM is correct for every element. Varies per run,
+      which is the signature of an address being printed rather than a value.
+    root_cause_hypothesis: >-
+      The exactness/rational handling for these four lives in the CALL-POSITION lowering
+      (the rational_path block in lib/backend/llvm_codegen.cpp). The value-position route —
+      the builtin wrapper `map` receives — does not go through that lowering and appears to
+      extract the tagged operand as a plain number, which for a rational HEAP_PTR reads the
+      pointer. Same FAMILY as SW-27 (rest-arg procedures referenced as values taking a
+      different ABI from the same procedure in call position), though a different mechanism.
+      Not traced to a line; filed for scoping.
+    discovered_by: >-
+      Probing the first-class route while closing SW-29, because SW-31 had just shown that
+      the value-position route of a builtin can carry its own independent defect.
+    pre_existing: >-
+      Confirmed, NOT introduced by the SW-29 fix. Reproduced on a native binary built with
+      llvm_codegen.cpp, rational.cpp and rational.h reverted to 92bbacd4 (and stdlib.o
+      rebuilt so the comparison was honest): the same per-run-varying addresses appear.
+      The SW-29 fix touches only the call-position block, which is why call position is
+      correct on both the old and new binaries.
+    caught_by: [direct-measurement, sw-29-adjacent-probe]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity, differential-corpus, KNOWN_ISSUES]
+    notes: >-
+      The escape analysis is the same one SW-27 already wrote down and which SW-31 just
+      confirmed a second time: builtins need a VALUE-POSITION axis in the higher-order
+      sweep, not only call-position coverage. Three independent defects have now been
+      found in that blind spot.
+    root_cause: >-
+      CONFIRMED, and the filed hypothesis was right. These four have TWO implementations.
+      The call-position lowering (codegenMathFunction, the is_rounding_func block in
+      lib/backend/llvm_codegen.cpp) dispatches on exactness: exact integers and bignums
+      are the identity, rationals go through eshkol_rational_<op>_tagged, only inexact
+      reals reach libm. The value-position route used createBuiltinUnaryMathFunction, a
+      SECOND hand-written wrapper that unpacks the tagged operand as a double — which for
+      a rational reads its HEAP POINTER. There were also TWO value-position routes, and
+      both were wrong: codegenVariable (a builtin reached through a user higher-order
+      procedure) and resolveLambdaFunction (a builtin reached through map/for-each/
+      filter/sort). Fixing only the first left (h floor 7/3) correct while
+      (map floor (list 7/3)) still printed an address.
+    fix: >-
+      Both routes now go through the generic inline-builtin wrapper, which GENERATES its
+      body by re-entering codegenCall — so the exactness-aware lowering IS the wrapper
+      body and cannot drift from it. This is the LE-01 mechanism applied to a second
+      instance of the LE-01 shape (a duplicated implementation diverging from the
+      authoritative one), rather than a second patch to the duplicate.
+    verified_at: >-
+      tests/integration/first_class_rounding_test.esk, gated on the JIT and AOT lanes.
+      Covers all four operators over rationals (positive and negative), a rational whose
+      floor EXCEEDS int64 — (/ (expt 2 100) 3), which an int64-returning entry point
+      cannot carry at all — exact integers, bignums, inexact reals including R7RS
+      round-half-to-even, and exactness of the results. Both value-position routes are
+      exercised. The ledger's stated correct answer
+      (2 -3 422550200076076467165567735125) is reproduced exactly.
+    id_provenance: >-
+      Filed as SW-35 on branch fix/numeric-tower-bignum-tail (PR #439) and NOT carried by
+      that PR's merge, so SW-35 was free on master and the number is retained unchanged.
+
+  - id: SW-36
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "fix/value-position-axis"
+    closed_by: "PR stacked on #439 (branch fix/value-position-axis)"
+    title: "make-string as a first-class value silently DROPPED a supplied fill character"
+    repro: "(define (h2 f a b) (f a b)) (display (h2 make-string 3 #\\x))"
+    observed: '"   " — three spaces, exit 0, no diagnostic'
+    correct: '"xxx", which (make-string 3 #\\x) returns in call position'
+    root_cause: >-
+      The first-class builtin table introduced by LE-01 (#427) listed make-string at
+      arity 1. A fixed-arity closure passes exactly `arity` arguments to the wrapper, so
+      the second argument never reached the lowering at all. The name-to-arity table is
+      maintained by hand, and a row that disagrees with the builtin it wraps produces a
+      wrong answer rather than an error.
+    fix: >-
+      Row corrected to arity 2. R7RS 6.7 makes make-string optional-argument —
+      (make-string k [char]) — and the closure ABI carries ONE arity, so the row wraps
+      the FULL form. That choice is not arbitrary: R7RS says that when char is omitted
+      "the contents are unspecified", so the 1-argument value reference differing from
+      the 1-argument call is CONFORMING, whereas dropping a fill character the caller
+      supplied is a wrong answer. Wrap the form whose result is specified.
+    discovered_by: >-
+      scripts/run_value_position_sweep.py, on its first run. This defect had been live
+      on master since #427 merged and no other gate saw it.
+    caught_by: [value-position-sweep]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity, differential-corpus]
+    notes: >-
+      Worth recording as evidence about the sweep rather than about make-string: the
+      defect was introduced BY a fix for this same family, and found by the gate built
+      alongside it, on the first run, in under two minutes. A hand-maintained arity table
+      needs a mechanical check; this is that check.
+
+  - id: SW-37
+    bucket: LOUD-ERROR
+    subtag: structural
+    status: closed
+    closed_at: "fix/value-position-axis"
+    closed_by: "PR stacked on #439 (branch fix/value-position-axis)"
+    title: "pow as a first-class value SIGSEGVs"
+    repro: "(define (h2 f a b) (f a b)) (display (h2 pow 2 10))"
+    observed: "SIGSEGV; (pow 2 10) in call position returns 1024"
+    correct: "1024"
+    root_cause: >-
+      Residue of the LE-01 class. `pow` sits in the codegen function table as a raw libm
+      symbol with a double,double->double signature, and it appears in neither the
+      math-builtin set nor the first-class builtin table, so a reference to it reached
+      the raw-Function* fallback in codegenVariable. The closure dispatcher then called a
+      foreign-ABI symbol with the closure calling convention, which is undefined
+      behaviour.
+    fix: >-
+      Added to the first-class builtin table at arity 2, so the reference is lowered as a
+      closure-ABI wrapper whose body is generated from the call-position lowering.
+    discovered_by: "scripts/run_value_position_sweep.py, first run"
+    caught_by: [value-position-sweep]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity, differential-corpus]
+
+  - id: SW-38
+    bucket: SILENT-WRONG
+    status: open
+    title: "On the VM, cadr and caddr used as FIRST-CLASS VALUES return the empty list"
+    repro: "(define (h1 f a) (f a)) (display (h1 cadr (list 1 2 3)))"
+    observed: "VM prints () — exit 0, no diagnostic. Call position (cadr (list 1 2 3)) prints 2."
+    correct: "2 for cadr, 6 for caddr — what call position returns on the same engine"
+    measured: >-
+      All four value-position routes on the VM (passed to a higher-order procedure,
+      stored in a variable, returned from a procedure, reached through map) answer ().
+      All four NATIVE axes answer correctly. Reproduced by
+      scripts/run_value_position_sweep.py --axis vm.
+    discovered_by: >-
+      The value-position sweep's VM axis, on its first full run. This is the case the VM
+      axis exists for: the four native axes agree with each other, so no axis-versus-axis
+      differential can see a VM-only value-position defect.
+    scope_note: >-
+      NOT fixed here, deliberately. The lane that built the sweep works on the NATIVE
+      value-position lowering; this defect is in the VM's own value representation for
+      the c[ad]+r accessors, a different subsystem. Filed precisely rather than fixed
+      badly. Ratcheted in tests/value_position/BASELINE.json so the gate stays honest
+      about it instead of silently tolerating it.
+    caught_by: [value-position-sweep]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity, differential-corpus]
+    notes: >-
+      SILENT-WRONG on the VM: () is a legitimate Scheme value, so a caller sees a wrong
+      answer rather than an error, and () is truthy in Scheme, so a predicate written
+      over it takes the wrong branch.
+
+  - id: SW-39
+    bucket: LOUD-ERROR
+    subtag: structural
+    status: open
+    title: "On the VM, string-length / string-ref / vref used as FIRST-CLASS VALUES abort the VM"
+    repro: "(define (h1 f a) (f a)) (display (h1 string-length \"hello\"))"
+    observed: >-
+      The VM terminates with a fatal runtime error and produces no output for the probe;
+      call position (string-length "hello") answers 5 on the same engine.
+    correct: "5 — what call position returns"
+    measured: >-
+      Three value-position routes on the VM (passed, stored, returned) abort;
+      string-ref and vref behave the same way. All four NATIVE axes are correct.
+      Reproduced by scripts/run_value_position_sweep.py --axis vm.
+    discovered_by: "The value-position sweep's VM axis, first full run"
+    scope_note: >-
+      NOT fixed here, deliberately — same reasoning as SW-38. Ratcheted in
+      tests/value_position/BASELINE.json.
+    caught_by: [value-position-sweep]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity, differential-corpus]
+    notes: >-
+      Loud rather than silent, so it does not gate a release on its own — but it means
+      any VM program that passes one of these accessors to a higher-order procedure dies
+      rather than running.
+
   # ───────────────────────── LOUD-ERROR ─────────────────────────
 
   - id: LE-01

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4721,7 +4721,23 @@ if(ESHKOL_BUILD_TESTS AND NOT WIN32)
                 ENVIRONMENT "ESHKOL_VM_NO_DISASM=1"
                 PASS_REGULAR_EXPRESSION "PASS: higher-order shadowing \\(vm\\)"
                 FAIL_REGULAR_EXPRESSION "FAIL:|TOTAL FAILURES|undefined variable|fatal runtime error")
-    endif()
+    
+    # SW-34: the ENTIRE predicate family first-class, on the VM. `complex?`
+    # was a loud compile-time failure natively while the VM bound it fine, so
+    # this file runs unchanged on both engines and the two gates below and
+    # here are the same assertions on two implementations.
+    add_test(
+        NAME first_class_predicates_vm_smoke
+        COMMAND sh -c
+            "cd '${CMAKE_CURRENT_SOURCE_DIR}' && '$<TARGET_FILE:eshkol-vm-standalone-test>' tests/integration/first_class_predicates_test.esk"
+    )
+    set_tests_properties(first_class_predicates_vm_smoke
+        PROPERTIES
+            TIMEOUT 300
+            ENVIRONMENT "ESHKOL_VM_NO_DISASM=1"
+            PASS_REGULAR_EXPRESSION "PASS: first-class predicates — 0 failures"
+            FAIL_REGULAR_EXPRESSION "FAIL:|undefined variable|fatal runtime error")
+endif()
     # SW-24 isolated shape on the VM engine — the engine the defect lived on
     # ((+ 3 4) with a rebound + emitted OP_ADD and printed 7).
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/codegen/operator_rebinding_test.esk")
@@ -4961,6 +4977,77 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run AND
             TIMEOUT 600
             PASS_REGULAR_EXPRESSION "PASS: rest capture and do closure - 0 failures"
             FAIL_REGULAR_EXPRESSION "FAIL:|not mutable|LLVM module verification failed|fatal signal")
+    # SW-34: the ENTIRE R7RS predicate family as first-class values, on both
+    # native axes. `complex?` was a LOUD compile-time "Undefined variable" the
+    # moment the bare name was read as a value, while call position answered
+    # correctly. The file also exercises both value-position ROUTES — a user
+    # higher-order procedure (codegenVariable) and `map`
+    # (resolveLambdaFunction) — because those are separate codegen sites that
+    # have disagreed before.
+    add_test(
+        NAME first_class_predicates_runtime_smoke
+        COMMAND sh -c
+            "cd '${CMAKE_CURRENT_SOURCE_DIR}' && '$<TARGET_FILE:eshkol-run>' -r tests/integration/first_class_predicates_test.esk -L'${CMAKE_CURRENT_BINARY_DIR}'"
+    )
+    set_tests_properties(first_class_predicates_runtime_smoke
+        PROPERTIES
+            TIMEOUT 300
+            PASS_REGULAR_EXPRESSION "PASS: first-class predicates — 0 failures"
+            FAIL_REGULAR_EXPRESSION "FAIL:|Undefined variable|LLVM module verification failed|fatal signal")
+
+    add_test(
+        NAME first_class_predicates_aot_smoke
+        COMMAND sh -c
+            "cd '${CMAKE_CURRENT_SOURCE_DIR}' && '$<TARGET_FILE:eshkol-run>' -O2 -o '${CMAKE_CURRENT_BINARY_DIR}/first_class_predicates_aot' tests/integration/first_class_predicates_test.esk -L'${CMAKE_CURRENT_BINARY_DIR}' && '${CMAKE_CURRENT_BINARY_DIR}/first_class_predicates_aot'"
+    )
+    set_tests_properties(first_class_predicates_aot_smoke
+        PROPERTIES
+            TIMEOUT 600
+            PASS_REGULAR_EXPRESSION "PASS: first-class predicates — 0 failures"
+            FAIL_REGULAR_EXPRESSION "FAIL:|Undefined variable|LLVM module verification failed|fatal signal")
+
+    # SW-35: the exactness-aware rounding builtins reached as VALUES through
+    # BOTH routes. The whole-tower probe is the one that showed heap addresses
+    # where numbers belonged.
+    add_test(
+        NAME first_class_rounding_runtime_smoke
+        COMMAND sh -c
+            "cd '${CMAKE_CURRENT_SOURCE_DIR}' && '$<TARGET_FILE:eshkol-run>' -r tests/integration/first_class_rounding_test.esk -L'${CMAKE_CURRENT_BINARY_DIR}'"
+    )
+    set_tests_properties(first_class_rounding_runtime_smoke
+        PROPERTIES
+            TIMEOUT 300
+            PASS_REGULAR_EXPRESSION "PASS: first-class rounding — 0 failures"
+            FAIL_REGULAR_EXPRESSION "FAIL:|Undefined variable|LLVM module verification failed|fatal signal")
+
+    add_test(
+        NAME first_class_rounding_aot_smoke
+        COMMAND sh -c
+            "cd '${CMAKE_CURRENT_SOURCE_DIR}' && '$<TARGET_FILE:eshkol-run>' -O2 -o '${CMAKE_CURRENT_BINARY_DIR}/first_class_rounding_aot' tests/integration/first_class_rounding_test.esk -L'${CMAKE_CURRENT_BINARY_DIR}' && '${CMAKE_CURRENT_BINARY_DIR}/first_class_rounding_aot'"
+    )
+    set_tests_properties(first_class_rounding_aot_smoke
+        PROPERTIES
+            TIMEOUT 600
+            PASS_REGULAR_EXPRESSION "PASS: first-class rounding — 0 failures"
+            FAIL_REGULAR_EXPRESSION "FAIL:|Undefined variable|LLVM module verification failed|fatal signal")
+
+    # THE VALUE-POSITION AXIS itself, as a ctest lane.
+    #
+    # The four gates above pin four specific families. This one pins the
+    # PROPERTY over the whole builtin table the manifest can type: no builtin
+    # may answer differently as a value than it does in call position. It is
+    # the gate that makes the next SW-27/SW-31/SW-34/SW-35 fail here on the
+    # day it is introduced instead of being found by hand months later.
+    add_test(
+        NAME value_position_axis_sweep
+        COMMAND sh -c
+            "cd '${CMAKE_CURRENT_SOURCE_DIR}' && BUILD_DIR='${CMAKE_CURRENT_BINARY_DIR}' python3 scripts/run_value_position_sweep.py --quiet"
+    )
+    set_tests_properties(value_position_axis_sweep
+        PROPERTIES
+            TIMEOUT 1800
+            PASS_REGULAR_EXPRESSION "value-position sweep: OK"
+            FAIL_REGULAR_EXPRESSION "value-position discrepancy")
 endif()
 
 if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/vm/test_vm_c_api.cpp")

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -11231,6 +11231,38 @@ private:
             }
         }
 
+        // SW-35: the ROUNDING builtins are handled by the generic
+        // inline-builtin wrapper further down, NOT by the hand-written
+        // createBuiltinUnaryMathFunction below, and they are excluded here so
+        // they reach it.
+        //
+        // createBuiltinUnaryMathFunction is a SECOND, hand-written
+        // implementation of each math builtin: it unpacks the tagged operand
+        // as a double and calls the C library function. For sin/cos/exp that
+        // is the whole semantics. For floor/ceiling/truncate/round it is not
+        // — their call-position lowering (codegenMathFunction, the
+        // is_rounding_func block) dispatches on EXACTNESS first: exact
+        // integers and bignums are the identity, rationals go to
+        // eshkol_rational_<op>_tagged, and only inexact reals reach libm.
+        // The hand-written wrapper knew none of that, so it read a rational's
+        // HEAP POINTER as a double and returned the address as a number:
+        //
+        //   (map floor (list 7/3 -7/3 2.7 5))
+        //     => (6176988088 6176988304 2 5)   addresses, varying per run
+        //   (floor 7/3) => 2                   call position, correct
+        //
+        // That is the LE-01 failure mode exactly — a duplicated
+        // implementation drifting from the authoritative one — so the fix is
+        // the LE-01 mechanism rather than a second patch to the duplicate:
+        // the generic wrapper generates its body by re-entering codegenCall,
+        // which IS the exactness-aware lowering. The remaining math builtins
+        // stay on the old factory because it carries AD/dual dispatch they
+        // depend on; the sweep in scripts/run_value_position_sweep.py is what
+        // keeps that claim honest.
+        static const std::set<std::string> rounding_builtins = {
+            "floor", "ceil", "ceiling", "round", "trunc", "truncate"
+        };
+
         // BUILTIN FIRST-CLASS FIX: Check math builtins FIRST before function_table lookup
         // This prevents returning raw C functions (double->double) which cause ABI mismatch
         // when called through closure dispatch (tagged_value->tagged_value)
@@ -11243,11 +11275,18 @@ private:
             "sinh", "cosh", "tanh", "asinh", "acosh", "atanh",
             // Power/Root
             "sqrt", "cbrt",
-            // Absolute/Rounding
-            "abs", "fabs", "floor", "ceil", "round", "trunc",
-            // Scheme-style names
-            "ceiling", "truncate"
+            // Absolute
+            "abs", "fabs"
         };
+
+        if (rounding_builtins.count(var_name)) {
+            if (Value* first_class = codegenInlineBuiltinAsValue(var_name)) {
+                return first_class;
+            }
+            // Fall through to the old factory only if the generic path
+            // declined, so a missing table row degrades to the previous
+            // behaviour rather than to "Undefined variable".
+        }
 
         if (math_builtins.count(var_name)) {
             // Use createBuiltinUnaryMathFunction which creates a wrapper with proper ABI
@@ -38429,6 +38468,35 @@ private:
 
             // BUILTIN FIRST-CLASS FIX: Check for builtin math functions FIRST before raw function_table lookup
             // These need wrapper functions that take/return tagged_value_type
+            // SW-35: THE SECOND VALUE-POSITION ROUTE.
+            //
+            // There are two of them, and they were disagreeing. A builtin
+            // reached through a USER higher-order procedure — `(define (h f a)
+            // (f a))` — resolves through codegenVariable; a builtin reached
+            // through `map`/`for-each`/`filter`/`sort` resolves through THIS
+            // function. Fixing the rounding builtins in codegenVariable alone
+            // made `(h floor 7/3)` correct while `(map floor (list 7/3))` still
+            // printed a heap address, because this site kept handing back the
+            // same hand-written createBuiltinUnaryMathFunction wrapper that
+            // reads a rational's pointer as a double.
+            //
+            // Both routes now consult the generic inline-builtin wrapper
+            // first, so the exactness-aware call-position lowering is the
+            // single source of truth for both. The value-position sweep
+            // exercises BOTH routes for exactly this reason — a fix applied to
+            // one of two parallel sites is the shape of defect that keeps
+            // coming back.
+            static const std::set<std::string> rounding_builtins = {
+                "floor", "ceil", "ceiling", "round", "trunc", "truncate"
+            };
+            if (rounding_builtins.count(func_name)) {
+                if (Function* generic = createInlineBuiltinWrapper(func_name, 1)) {
+                    return generic;
+                }
+                // Fall through to the old factory if the generic path
+                // declined, rather than failing to resolve at all.
+            }
+
             static const std::set<std::string> math_builtins = {
                 "sin", "cos", "tan", "exp", "log", "sqrt", "abs", "fabs",
                 "asin", "acos", "atan", "sinh", "cosh", "tanh",
@@ -40220,7 +40288,27 @@ private:
             {"string->number", {1}}, {"number->string", {1}},
             {"string->symbol", {1}}, {"symbol->string", {1}},
             {"string-upcase", {1}}, {"string-downcase", {1}},
-            {"string-set!", {3}}, {"string-fill!", {2}}, {"make-string", {1}},
+            {"string-set!", {3}}, {"string-fill!", {2}},
+            // ARITY MUST MATCH THE FORM BEING WRAPPED. `make-string` was
+            // listed here at arity 1 when LE-01 first populated this table,
+            // which made `(h make-string 3 #\x)` return "   " — the fill
+            // character silently dropped, because a fixed-arity closure passes
+            // exactly `arity` arguments and the second never reached the
+            // lowering. Found by the value-position sweep, which is the point
+            // of the sweep: a table of arities maintained by hand needs a
+            // mechanical check that each row matches what the builtin does.
+            // R7RS `(make-string k [char])` is optional-argument and the
+            // closure ABI carries ONE arity, so the row has to pick a form.
+            // It wraps the FULL one, and that choice is not arbitrary: R7RS
+            // 6.7 says that when `char` is omitted "the contents are
+            // unspecified", so the 1-argument value reference producing
+            // different filler than the 1-argument call does is CONFORMING,
+            // while dropping a fill character the caller actually supplied is
+            // a wrong answer. Wrap the form whose result is specified. The
+            // 1-argument difference is recorded, with that reasoning, in
+            // tests/value_position/BASELINE.json rather than left to be
+            // rediscovered.
+            {"make-string", {2}},
             // Characters
             {"char=?",  {2}}, {"char<?",  {2}}, {"char>?",  {2}},
             {"char<=?", {2}}, {"char>=?", {2}},
@@ -40235,20 +40323,42 @@ private:
             {"vector-fill!", {2}}, {"make-vector", {1}},
             {"vector->list", {1}}, {"list->vector", {1}},
             // Numerics
-            {"expt", {2}}, {"min", {2}}, {"max", {2}},
+            {"expt", {2}}, {"pow", {2}}, {"min", {2}}, {"max", {2}},
             {"modulo", {2}}, {"quotient", {2}}, {"remainder", {2}},
             {"gcd", {2}}, {"lcm", {2}},
             {"exact->inexact", {1}}, {"inexact->exact", {1}},
             {"exact", {1}}, {"inexact", {1}},
             {"numerator", {1}}, {"denominator", {1}},
             {"square", {1}},
+            // Rounding (SW-35). These are routed here instead of to
+            // createBuiltinUnaryMathFunction because their call-position
+            // lowering is EXACTNESS-AWARE — exact integers and bignums are the
+            // identity, rationals go through eshkol_rational_<op>_tagged — and
+            // the hand-written wrapper read a rational's heap pointer as a
+            // double instead. Generating the body from codegenCall is what
+            // makes the value route inherit that lowering rather than
+            // re-implement a subset of it.
+            {"floor", {1}}, {"ceiling", {1}}, {"ceil", {1}},
+            {"truncate", {1}}, {"trunc", {1}}, {"round", {1}},
             // Booleans / symbols / general predicates
             {"not", {1}}, {"boolean=?", {2}}, {"symbol=?", {2}},
-            {"number?", {1}}, {"integer?", {1}}, {"real?", {1}},
-            {"rational?", {1}}, {"exact?", {1}}, {"inexact?", {1}},
-            {"exact-integer?", {1}}, {"string?", {1}}, {"symbol?", {1}},
+            // The R7RS numeric-tower predicate family, complete (SW-34).
+            // `complex?` was the one missing row, and its absence was a LOUD
+            // compile-time "Undefined variable: complex?" the moment the name
+            // was read as a value, while the same name in call position
+            // worked — which is why the predicate matrix carried a documented
+            // exclusion for it. The family is listed as a family, not
+            // name-by-name as need arises, because that is how the gap
+            // appeared in the first place.
+            {"number?", {1}}, {"complex?", {1}}, {"real?", {1}},
+            {"rational?", {1}}, {"integer?", {1}},
+            {"exact?", {1}}, {"inexact?", {1}}, {"exact-integer?", {1}},
+            {"nan?", {1}}, {"infinite?", {1}}, {"finite?", {1}},
+            // Type predicates
+            {"string?", {1}}, {"symbol?", {1}},
             {"vector?", {1}}, {"boolean?", {1}}, {"char?", {1}},
-            {"procedure?", {1}}, {"list?", {1}},
+            {"procedure?", {1}}, {"list?", {1}}, {"null?", {1}},
+            {"pair?", {1}},
             // Lists
             // NOTE: `append` and `string-copy` are deliberately absent. Neither
             // is lowered inline: both are REST-ARG stdlib procedures —

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -766,6 +766,26 @@ probe p8_escape_matrix_green \
     'cd "$REPO_ROOT"; BUILD_DIR="$BUILD_DIR_PATH" bash scripts/run_p8_escape.sh --quick --build-dir "$BUILD_DIR_PATH" >/dev/null 2>&1'
 
 # ───────────────────────────────────────────────────────────────────
+# THE VALUE-POSITION AXIS (SW-27 / SW-31 / SW-34 / SW-35, LE-01).
+#
+# Eshkol lowers most builtins INLINE at the call site, and referencing the
+# same builtin as a VALUE takes a different route through the codegen — in
+# fact two different routes, codegenVariable and resolveLambdaFunction. Four
+# separate defects have been found living in that route while call position
+# was correct, each by hand, each invisible to every other gate here: the
+# differential corpus compares EXECUTION AXES and a value-position defect is
+# usually wrong identically on all of them, so they agree and stay green.
+#
+# This probe closes that blind spot mechanically. For every builtin the
+# manifest can type, it evaluates the SAME call in call position and through
+# three value-position routes in ONE program and compares them, so the oracle
+# needs no expected values and cannot pass by agreeing with a wrong one.
+# ───────────────────────────────────────────────────────────────────
+probe value_position_axis \
+    'every builtin answers the same when referenced as a VALUE (passed to a higher-order procedure, stored, returned, reached through map) as it does in call position — the axis that SW-27, SW-31, SW-34 and SW-35 each escaped through one at a time' \
+    'cd "$REPO_ROOT"; BUILD_DIR="$BUILD_DIR_PATH" python3 scripts/run_value_position_sweep.py --quiet >/dev/null 2>&1'
+
+# ───────────────────────────────────────────────────────────────────
 # ESH-0011 — portable event loop (v1.4 async foundation).
 #
 # Runs the acceptance battery on BOTH native substrates so the probe covers the

--- a/scripts/run_value_position_sweep.py
+++ b/scripts/run_value_position_sweep.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+r"""run_value_position_sweep.py — the VALUE-POSITION axis.
+
+WHY THIS EXISTS
+---------------
+Eshkol lowers most of its builtin surface INLINE at the call site: `codegenCall`
+string-matches the head name and emits the operation directly. That lowering is
+the authoritative one, and it is the only one every other gate exercises.
+Referencing the same builtin as a VALUE — passing it to a higher-order
+procedure, storing it, returning it — takes a different route, and that route
+has repeatedly carried its own independent defect:
+
+  LE-01  builtins had no value representation at all: "Undefined variable:
+         string<?" for `(sort xs string<?)`, or a foreign-ABI function pointer
+         the closure dispatcher called with the wrong convention (SIGSEGV).
+  SW-27  a REST-ARG procedure referenced as a value lost its variadic flag, so
+         its rest parameter received a bare argument instead of a list.
+         `(h append '(1) '(2))` answered `1`. SILENT, exit 0.
+  SW-31  a builtin's value-position route carried its own defect while call
+         position was correct.
+  SW-35  floor/ceiling/truncate/round as values returned a rational's HEAP
+         ADDRESS as a number — addresses that changed between runs.
+
+Four defects, found one at a time, each by somebody probing by hand. Every one
+of them was invisible to every gate the project owns, and the reason is
+structural rather than accidental:
+
+  * the differential corpus compares EXECUTION AXES against each other, and a
+    value-position defect is usually wrong the same way on all four axes, so
+    they agree and the gate is green;
+  * vm-parity excuses native-only programs;
+  * the arity sweep, the surface-parity probe and the language-coverage floor
+    all exercise builtins in CALL POSITION only.
+
+A defect that is wrong identically everywhere is invisible to differential
+testing between engines or axes. The escape analyses for SW-27 and SW-35 both
+prescribed the same fix, in the same words: add a VALUE-POSITION axis. This is
+it.
+
+THE ORACLE IS DIFFERENTIAL BY CONSTRUCTION
+------------------------------------------
+For every builtin the sweep emits ONE program that evaluates the SAME call
+twice — once in call position, once through a higher-order procedure — and
+compares the two results with `equal?` inside the program:
+
+    (define (h2 f a b) (f a b))
+    (probe "call"  (lambda () (expt 2 10)))
+    (probe "value" (lambda () (h2 expt 2 10)))
+
+Nothing here hard-codes what `expt` ought to return. The sweep therefore cannot
+pass by agreeing with a wrong expectation, it needs no reference implementation,
+and it keeps pinning the property if a builtin's semantics legitimately change.
+That is the same shape as the SW-27 oracle, generalised to the whole table.
+
+WHAT IS AND IS NOT A FINDING
+----------------------------
+A builtin is only judged when its CALL POSITION works. If call position raises
+or fails to compile, the name is SKIPPED and reported as `call-position-broken`:
+that may well be a defect, but it is not a value-position discrepancy and this
+gate must not claim it. Reporting someone else's bug as your own finding is how
+a gate loses its meaning.
+
+Four probes per builtin, all compared against call position:
+
+    passed    (h N a…)                  — passed to a USER higher-order procedure
+    stored    (let ((v N)) (h v a…))    — stored in a variable, then called
+    returned  ((lambda () N)) via a HOF — returned from a procedure
+    mapped    (car (map N (list a)))    — reached through a BUILTIN combinator
+                                          (arity-1 builtins only)
+
+These are not redundant with each other, because they are not one code path.
+`passed`/`stored`/`returned` resolve through `codegenVariable`; `mapped`
+resolves through `resolveLambdaFunction`, which is a SEPARATE value-position
+route with its own builtin handling. SW-35 was live in both and they had to be
+fixed independently: after the first fix `(h floor 7/3)` was correct while
+`(map floor (list 7/3))` still printed a heap address. A gate that probed only
+one of the two routes would have certified that half-fix as complete, which is
+the failure mode this whole file exists to prevent.
+
+Likewise LE-01's raw-pointer fallback and SW-27's dropped variadic flag were
+reachable through some of these routes and not others, because each is a
+distinct codegen site.
+
+RATCHET
+-------
+Findings are compared against tests/value_position/BASELINE.json. A NEW finding
+fails the gate; a known one is reported and does not. The baseline is a list of
+`<name>::<probe>` keys with a reason, so an entry cannot be added without saying
+why. Regenerate deliberately with --update-baseline; never to make a red gate
+green.
+
+USAGE
+-----
+    python3 scripts/run_value_position_sweep.py                  # jit, all names
+    python3 scripts/run_value_position_sweep.py --axis aot-o0
+    python3 scripts/run_value_position_sweep.py --all-axes
+    python3 scripts/run_value_position_sweep.py --name expt --name append
+    python3 scripts/run_value_position_sweep.py --update-baseline
+
+Emits pytest-style `PASSED/FAILED <nodeid>::<probe>` lines plus
+`{"kind":"runtime_event","name":"value_position_sweep",...}` JSON-L into
+scripts/icc_traces/value_position_sweep.jsonl for the ICC oracle.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MANIFEST = os.path.join(REPO, "tests", "coverage", "language_surface.json")
+BASELINE = os.path.join(REPO, "tests", "value_position", "BASELINE.json")
+TRACE_DIR = os.path.join(REPO, "scripts", "icc_traces")
+TRACE = os.path.join(TRACE_DIR, "value_position_sweep.jsonl")
+
+BUILD = os.environ.get("BUILD_DIR", os.path.join(REPO, "build"))
+if not os.path.isabs(BUILD):
+    BUILD = os.path.join(REPO, BUILD)
+ESHKOL_RUN = os.path.join(BUILD, "eshkol-run")
+ESHKOL_VM = os.path.join(BUILD, "eshkol-vm-standalone-test")
+
+# Categories whose argument types the manifest lets us synthesise. Kept
+# deliberately identical to the set p8_arity_sweep.py already trusts, so the
+# two axes disagree about coverage rather than about typing.
+CATEGORIES = {"numeric", "predicate", "string_char", "list_pair", "vector",
+              "hash", "higher_order"}
+
+POOLS = {
+    "num":  ["3", "5", "2", "7", "4", "6"],
+    "flo":  ["2.5", "3.5", "1.5"],
+    "str":  ['"hello"', '"abc"', '"xyz"'],
+    "list": ["(list 1 2 3)", "(list 4 5 6)", "(list 7 8)"],
+    "vec":  ["(vector 1 2 3)", "(vector 4 5 6)"],
+    "char": ["#\\a", "#\\z", "#\\m"],
+    "bool": ["#t", "#f"],
+    "fn":   ["(lambda (x) (+ x 1))", "(lambda (x) (* x 2))"],
+}
+
+CAT_ARGS = {
+    "numeric":      ["num"],
+    "predicate":    ["num"],
+    "string_char":  ["str"],
+    "list_pair":    ["list"],
+    "vector":       ["vec"],
+    "hash":         ["hash"],
+    "higher_order": ["fn", "list"],
+}
+
+# Builtins whose result legitimately differs between two evaluations in the
+# same program. Comparing them would flap, so they are excluded BY NAME with a
+# reason rather than by a category guess. An exclusion is a claim about the
+# builtin, so it has to be defensible on its own.
+NONDETERMINISTIC = {
+    "random":                 "returns a different value per call by definition",
+    "random-integer":         "returns a different value per call by definition",
+    "random-real":            "returns a different value per call by definition",
+    "current-time":           "wall clock advances between the two evaluations",
+    "current-second":         "wall clock advances between the two evaluations",
+    "current-jiffy":          "monotonic counter advances between the two evaluations",
+    "current-timestamp":      "wall clock advances between the two evaluations",
+    "current-time-ns":        "wall clock advances between the two evaluations",
+    "monotonic-time-ms":      "monotonic counter advances between the two evaluations",
+    "gensym":                 "each call yields a fresh symbol by definition",
+    "make-uuid":              "each call yields a fresh identifier by definition",
+    "__arena-used":           "arena occupancy changes as the program allocates",
+    "cpu-count":              "environment probe, not a pure function of its arguments",
+    "getpid":                 "environment probe, not a pure function of its arguments",
+}
+
+# Builtins that MUTATE their argument. Evaluating them twice against the same
+# freshly-built argument is fine, but the two evaluations must not share the
+# argument, which the generated program guarantees by rebuilding the argument
+# expression inside each thunk. Listed here only so the reader knows the case
+# was considered rather than missed.
+MUTATING_HINT = ("set!", "fill!", "sort!", "insert!", "delete!", "push!", "pop!")
+
+
+# Per-name argument overrides.
+#
+# The category heuristic types a builtin by its FAMILY, which is right for
+# `string-length` and wrong for `make-string`: both are `string_char`, but one
+# takes a string and the other takes a COUNT. Feeding `(make-string "hello")`
+# does not test make-string, it tests what the compiler does with a type error
+# — and since native accepts it silently, the two positions then disagree about
+# which garbage to produce and the sweep reports a "finding" that is really its
+# own bad input. An oracle that exercises builtins wrongly cannot be trusted
+# when it says something is wrong.
+#
+# Each override is a claim that THIS is how the builtin is meant to be called,
+# so they are written out explicitly rather than derived.
+ARG_OVERRIDES = {
+    "make-string":        ['3', '#\\x'],
+    "make-vector":        ['3', '0'],
+    "list->string":       ['(list #\\a #\\b)'],
+    "string->list":       ['"abc"'],
+    "string-fill!":       ['(make-string 3 #\\a)', '#\\z'],
+    "string-ends-with?":  ['"hello"', '"lo"'],
+    "string-starts-with?":['"hello"', '"he"'],
+    "string-contains":    ['"hello"', '"ell"'],
+    "string-contains?":   ['"hello"', '"ell"'],
+    "string-index":       ['"hello"', '#\\l'],
+    "string-ref":         ['"hello"', '1'],
+    "substring":          ['"hello"', '1', '3'],
+    "string-set!":        ['(make-string 3 #\\a)', '1', '#\\z'],
+    "vector-ref":         ['(vector 1 2 3)', '1'],
+    "vector-set!":        ['(vector 1 2 3)', '1', '9'],
+    "vector-fill!":       ['(make-vector 3 0)', '9'],
+    "list-ref":           ['(list 1 2 3)', '1'],
+    "list-tail":          ['(list 1 2 3)', '1'],
+    "integer->char":      ['65'],
+    "char->integer":      ['#\\a'],
+    "expt":               ['2', '10'],
+    "pow":                ['2', '10'],
+    "exact":              ['2.0'],
+    "inexact":            ['2'],
+}
+
+
+def _h(name):
+    return int(hashlib.sha1(name.encode()).hexdigest(), 16)
+
+
+def pick(pool, name, slot):
+    lst = POOLS[pool]
+    return lst[(_h(name) + slot) % len(lst)]
+
+
+def args_for(name, cat, arity):
+    ov = ARG_OVERRIDES.get(name)
+    if ov is not None:
+        return ov[:arity] if arity <= len(ov) else ov
+    if cat == "hash":
+        out = ["__ht"]
+        for i in range(1, arity):
+            out.append(pick("num", name, i))
+        return out[:arity] if arity else []
+    types = CAT_ARGS.get(cat, ["num"])
+    out = []
+    for i in range(arity):
+        t = types[i] if i < len(types) else types[-1]
+        out.append(pick(t, name, i))
+    return out
+
+
+def build_program(name, cat, arity, args):
+    """One program, four probes: call position plus three value-position routes.
+
+    Every probe rebuilds its own argument expressions, so a mutating builtin
+    cannot make the second evaluation observe the first one's writes.
+
+    Output is bracketed by whitespace-free sentinels because the VM emits a
+    newline after every output op; the reader strips all whitespace from both
+    engines identically and regex-extracts each probe, which makes the
+    comparison newline-insertion-proof.
+    """
+    hof = "h%d" % arity
+    call_args = " ".join(args)
+    head = [
+        "(define (h0 f) (f))",
+        "(define (h1 f a) (f a))",
+        "(define (h2 f a b) (f a b))",
+        "(define (h3 f a b c) (f a b c))",
+        "(define (probe tag thunk)",
+        '  (display "#VP#") (display tag) (display "#")',
+        '  (guard (e (#t (display "ERR")))',
+        "    (write (thunk)))",
+        '  (display "#/VP#"))',
+    ]
+    if cat == "hash":
+        head.append("(define __ht (make-hash-table))")
+        head.append("(hash-table-set! __ht 1 10)")
+
+    body = [
+        # call position — the reference for this program
+        '(probe "call" (lambda () (%s %s)))' % (name, call_args),
+        # passed to a USER higher-order procedure (codegenVariable route)
+        '(probe "passed" (lambda () (%s %s %s)))' % (hof, name, call_args),
+        # stored in a variable first
+        '(probe "stored" (lambda () (let ((vp-slot %s)) (%s vp-slot %s))))'
+        % (name, hof, call_args),
+        # returned from a procedure
+        '(probe "returned" (lambda () (%s ((lambda () %s)) %s)))'
+        % (hof, name, call_args),
+    ]
+    if arity == 1:
+        # Reached through a BUILTIN combinator — resolveLambdaFunction, the
+        # second value-position route. SW-35 was live in both routes and each
+        # needed its own fix, so probing only the user-HOF route would have
+        # certified a half-fix as complete.
+        body.append('(probe "mapped" (lambda () (car (map %s (list %s)))))'
+                    % (name, args[0]))
+    return "\n".join(head) + "\n" + "\n".join(body) + "\n"
+
+
+PROBE_RE = re.compile(r"#VP#(\w+)#(.*?)#/VP#")
+
+# Comparison uses the FULL value; only the human-facing and trace-facing copies
+# are clipped. A gate that prints a megabyte of output is unusable, and one that
+# compares a clipped value is a liar.
+REPORT_CLIP = 120
+
+
+def clip(v):
+    if v is None:
+        return None
+    return v if len(v) <= REPORT_CLIP else v[:REPORT_CLIP] + "...<%d bytes>" % len(v)
+
+
+def parse_probes(out):
+    flat = re.sub(r"\s+", "", out)
+    return dict(PROBE_RE.findall(flat))
+
+
+def run_axis(axis, src, workdir, timeout):
+    path = os.path.join(workdir, "vp.esk")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(src)
+    env = dict(os.environ)
+    env.setdefault("ESHKOL_PATH", os.path.join(REPO, "lib"))
+    try:
+        if axis == "jit":
+            p = subprocess.run([ESHKOL_RUN, "-r", path], capture_output=True,
+                               text=True, errors="replace",
+                               timeout=timeout, env=env, cwd=REPO)
+        elif axis == "jit-nocache":
+            env["ESHKOL_JIT_CACHE"] = "0"
+            p = subprocess.run([ESHKOL_RUN, "-r", path], capture_output=True,
+                               text=True, errors="replace",
+                               timeout=timeout, env=env, cwd=REPO)
+        elif axis in ("aot-o0", "aot-o2"):
+            opt = "-O0" if axis == "aot-o0" else "-O2"
+            binp = os.path.join(workdir, "vp.bin")
+            c = subprocess.run([ESHKOL_RUN, opt, path, "-o", binp],
+                               capture_output=True, text=True,
+                               errors="replace",
+                               timeout=timeout, env=env, cwd=REPO)
+            if c.returncode != 0 or not os.path.exists(binp):
+                return None, "compile-failed"
+            p = subprocess.run([binp], capture_output=True, text=True,
+                               errors="replace",
+                               timeout=timeout, env=env, cwd=REPO)
+        elif axis == "vm":
+            if not os.path.exists(ESHKOL_VM):
+                return None, "vm-binary-missing"
+            env["ESHKOL_VM_NO_DISASM"] = "1"
+            p = subprocess.run([ESHKOL_VM, path], capture_output=True,
+                               text=True, errors="replace",
+                               timeout=timeout, env=env, cwd=REPO)
+        else:
+            raise SystemExit("unknown axis: %s" % axis)
+    except subprocess.TimeoutExpired:
+        return None, "timeout"
+    except (OSError, UnicodeError) as exc:
+        # One builtin must never be able to take the sweep down. A name that
+        # cannot even be run is reported as skipped, with the reason, and the
+        # sweep continues to the next.
+        return None, "runner-error:%s" % type(exc).__name__
+    return parse_probes(p.stdout), None
+
+
+def load_baseline():
+    if not os.path.exists(BASELINE):
+        return {}
+    with open(BASELINE, encoding="utf-8") as f:
+        return json.load(f).get("known_findings", {})
+
+
+def emit_trace(records, summary):
+    os.makedirs(TRACE_DIR, exist_ok=True)
+    with open(TRACE, "w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+        f.write(json.dumps(summary) + "\n")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--axis", action="append", default=[],
+                    choices=["jit", "jit-nocache", "aot-o0", "aot-o2", "vm"])
+    ap.add_argument("--all-axes", action="store_true")
+    ap.add_argument("--name", action="append", default=[],
+                    help="restrict to these builtin names (repeatable)")
+    ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--timeout", type=int, default=90)
+    ap.add_argument("--workdir")
+    ap.add_argument("--update-baseline", action="store_true")
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args()
+
+    # The VM is in --all-axes on purpose. It is a genuinely independent
+    # implementation of the value-position question — its closures carry the
+    # builtin natively — so a defect the four native axes agree on still shows
+    # up as a native-vs-VM difference here. That is the one comparison the
+    # native axes cannot make against each other.
+    axes = args.axis or (["jit", "jit-nocache", "aot-o0", "aot-o2", "vm"]
+                         if args.all_axes else ["jit"])
+
+    if not os.path.exists(ESHKOL_RUN):
+        raise SystemExit("eshkol-run not found at %s (set BUILD_DIR)" % ESHKOL_RUN)
+
+    with open(MANIFEST, encoding="utf-8") as f:
+        manifest = json.load(f)
+
+    cands = [e for e in manifest["builtins"]
+             if isinstance(e.get("arity"), int)
+             and 0 <= e["arity"] <= 3
+             and e.get("category") in CATEGORIES
+             and e["name"] not in NONDETERMINISTIC]
+    if args.name:
+        want = set(args.name)
+        cands = [e for e in cands if e["name"] in want]
+    cands.sort(key=lambda e: e["name"])
+    if args.limit:
+        cands = cands[:args.limit]
+
+    baseline = load_baseline()
+    workdir = args.workdir or tempfile.mkdtemp(prefix="value-position-")
+    os.makedirs(workdir, exist_ok=True)
+
+    records = []
+    new_findings, known_findings, skipped, checked = [], [], [], 0
+    started = time.time()
+
+    for e in cands:
+        name, cat, arity = e["name"], e["category"], e["arity"]
+        src = build_program(name, cat, arity, args_for(name, cat, arity))
+        for axis in axes:
+            probes, err = run_axis(axis, src, workdir, args.timeout)
+            nodeid = "builtins/%s" % name
+            if err or probes is None or "call" not in probes:
+                skipped.append((name, axis, err or "no-call-probe"))
+                records.append({"kind": "runtime_event",
+                                "name": "value_position_probe",
+                                "status": "SKIP", "builtin": name, "axis": axis,
+                                "reason": err or "no-call-probe"})
+                continue
+            ref = probes["call"]
+            if ref == "ERR":
+                # Call position itself is broken. Not this axis's finding.
+                skipped.append((name, axis, "call-position-broken"))
+                records.append({"kind": "runtime_event",
+                                "name": "value_position_probe",
+                                "status": "SKIP", "builtin": name, "axis": axis,
+                                "reason": "call-position-broken"})
+                continue
+            for probe in ("passed", "stored", "returned", "mapped"):
+                if probe not in probes and probe == "mapped":
+                    continue  # only emitted for arity-1 builtins
+                got = probes.get(probe)
+                key = "%s::%s" % (name, probe)
+                checked += 1
+                if got == ref:
+                    if not args.quiet:
+                        print("PASSED %s::%s::%s" % (nodeid, probe, axis))
+                    records.append({"kind": "runtime_event",
+                                    "name": "value_position_probe",
+                                    "status": "PASS", "builtin": name,
+                                    "probe": probe, "axis": axis})
+                    continue
+                finding = {"key": key, "axis": axis, "builtin": name,
+                           "probe": probe, "call_position": clip(ref),
+                           "value_position": clip(got)}
+                if key in baseline:
+                    known_findings.append(finding)
+                    print("FAILED %s::%s::%s  (KNOWN: %s)"
+                          % (nodeid, probe, axis, baseline[key]))
+                else:
+                    new_findings.append(finding)
+                    print("FAILED %s::%s::%s  call=%s value=%s"
+                          % (nodeid, probe, axis, clip(ref), clip(got)))
+                records.append({"kind": "runtime_event",
+                                "name": "value_position_probe",
+                                "status": "FAIL", "builtin": name,
+                                "probe": probe, "axis": axis,
+                                "known": key in baseline,
+                                "call_position": clip(ref),
+                                "value_position": clip(got)})
+
+    elapsed = round(time.time() - started, 1)
+    print()
+    print("value-position sweep: %d builtin(s), %d comparison(s), axes=%s, %.1fs"
+          % (len(cands), checked, ",".join(axes), elapsed))
+    print("  matching call position : %d" % (checked - len(new_findings)
+                                             - len(known_findings)))
+    print("  KNOWN findings         : %d" % len(known_findings))
+    print("  NEW findings           : %d   [the only gated number]"
+          % len(new_findings))
+    exercised = sorted({r["builtin"] for r in records if r["status"] != "SKIP"})
+    unexercised = sorted({name for name, _, _ in skipped} - set(exercised))
+    print("  skipped                : %d probe-run(s)" % len(skipped))
+    print()
+    # Coverage is stated out loud because "0 findings" over a table this size
+    # invites being read as "the whole builtin surface is proven", and it is
+    # not. A name the sweep could not even run is a coverage HOLE, not a pass.
+    print("  builtins actually compared : %d of %d selected"
+          % (len(exercised), len(cands)))
+    print("  builtins NOT exercised     : %d  (%s)"
+          % (len(unexercised), ", ".join(unexercised[:12])
+             + (", …" if len(unexercised) > 12 else "")))
+    print("  -> an unexercised name is an untested name. Extend ARG_OVERRIDES "
+          "to bring one into the gate.")
+
+    if args.update_baseline:
+        entries = {f["key"]: "recorded by --update-baseline; replace with a reason"
+                   for f in new_findings + known_findings}
+        os.makedirs(os.path.dirname(BASELINE), exist_ok=True)
+        with open(BASELINE, "w", encoding="utf-8") as f:
+            json.dump({"_comment": "Value-position ratchet. A NEW key fails the "
+                                   "gate. Each entry needs a reason naming the "
+                                   "ledger ID or the defect. Never regenerate "
+                                   "to turn a red gate green.",
+                       "known_findings": entries}, f, indent=2, sort_keys=True)
+            f.write("\n")
+        print("  baseline rewritten: %d entries" % len(entries))
+
+    ok = not new_findings
+    summary = {"kind": "runtime_event", "name": "value_position_sweep",
+               "status": "PASS" if ok else "FAIL",
+               "builtins": len(cands), "comparisons": checked,
+               "axes": axes, "new_findings": len(new_findings),
+               "known_findings": len(known_findings), "skipped": len(skipped),
+               "builtins_compared": len(exercised),
+               "builtins_unexercised": len(unexercised),
+               "elapsed_s": elapsed}
+    emit_trace(records, summary)
+    print("Trace written: %s" % TRACE)
+
+    if not ok:
+        print()
+        print("FAIL: %d value-position discrepancy(ies) not in the ratchet "
+              "baseline." % len(new_findings))
+        print("Each one is a builtin that computes a different answer when "
+              "referenced as a value than when called directly.")
+        return 1
+    print("value-position sweep: OK — every builtin answers the same as a "
+          "value as it does in call position.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/first_class_predicates_test.esk
+++ b/tests/integration/first_class_predicates_test.esk
@@ -1,0 +1,133 @@
+;;; first_class_predicates_test.esk
+;;;
+;;; SW-34 class-kill test: the ENTIRE R7RS predicate family must work as a
+;;; FIRST-CLASS VALUE, on both engines.
+;;;
+;;; `complex?` was the row missing from the codegen's first-class builtin
+;;; table. Reading the bare name as a value was a LOUD compile-time failure —
+;;;
+;;;     (define (h1 f a) (f a))
+;;;     (display (h1 complex? 1))
+;;;     => error: Undefined variable: complex?
+;;;
+;;; — while `(complex? 1)` in call position answered `#t`, and the VM bound the
+;;; name fine. That asymmetry is why a predicate matrix elsewhere carried a
+;;; documented exclusion for `complex?`: the test had to route around a
+;;; compiler gap, and the comment explaining why is the kind of note that
+;;; quietly becomes permanent.
+;;;
+;;; The fix listed the numeric-tower predicates as a FAMILY rather than
+;;; name-by-name as need arises, because name-by-name is how the gap appeared.
+;;; This test pins the family the same way, for the same reason: the next
+;;; predicate added to the language should fail here on the day it is added,
+;;; not the next time somebody happens to pass one to `filter`.
+;;;
+;;; THE ORACLE IS DIFFERENTIAL. Every check compares the predicate applied
+;;; through a higher-order procedure against the identical application in call
+;;; position, in the same program. Nothing hard-codes what `rational?` ought to
+;;; answer for `5.0`, so the test cannot pass by agreeing with a wrong
+;;; expectation, and it keeps holding if a predicate's semantics legitimately
+;;; change.
+;;;
+;;; Written in the core-Scheme subset so it runs on the native engine (JIT and
+;;; AOT) and on the bytecode VM unchanged.
+
+(define failures 0)
+
+(define (check name ok)
+  (if ok
+      (display (string-append "PASS: " name))
+      (begin (set! failures (+ failures 1))
+             (display (string-append "FAIL: " name)))))
+
+(define (h1 f a) (f a))
+
+;; Two routes, because they are two different codegen sites: a USER
+;; higher-order procedure resolves the name through codegenVariable, while a
+;; BUILTIN combinator resolves it through resolveLambdaFunction. SW-35 was live
+;; in both and each needed its own fix.
+(define (via-hof p v) (h1 p v))
+(define (via-map p v) (car (map p (list v))))
+
+(define (agrees name p v direct)
+  (check (string-append name " via HOF") (eq? (via-hof p v) direct))
+  (check (string-append name " via map") (eq? (via-map p v) direct)))
+
+;; --------------------------------------------------------------------
+;; The numeric tower. complex? is the one that used to fail to compile.
+;; --------------------------------------------------------------------
+(agrees "number? on 42"      number?   42   (number? 42))
+(agrees "number? on 2.5"     number?   2.5  (number? 2.5))
+(agrees "number? on string"  number?   "s"  (number? "s"))
+
+(agrees "complex? on 42"     complex?  42   (complex? 42))
+(agrees "complex? on 2.5"    complex?  2.5  (complex? 2.5))
+(agrees "complex? on string" complex?  "s"  (complex? "s"))
+(agrees "complex? on symbol" complex?  'foo (complex? 'foo))
+
+(agrees "real? on 42"        real?     42   (real? 42))
+(agrees "real? on 2.5"       real?     2.5  (real? 2.5))
+(agrees "real? on string"    real?     "s"  (real? "s"))
+
+(agrees "rational? on 42"    rational? 42   (rational? 42))
+(agrees "rational? on 2.5"   rational? 2.5  (rational? 2.5))
+
+(agrees "integer? on 42"     integer?  42   (integer? 42))
+(agrees "integer? on 2.5"    integer?  2.5  (integer? 2.5))
+
+(agrees "exact? on 42"       exact?    42   (exact? 42))
+(agrees "inexact? on 2.5"    inexact?  2.5  (inexact? 2.5))
+
+;; NOT tested here: `exact-integer?`. It is an undefined variable on the VM in
+;; CALL POSITION too — a standing surface gap ratcheted in
+;; tests/vm_parity/SURFACE_BASELINE.tsv, a different defect from this one, and
+;; not smuggled into this test's scope so that this file can run unchanged on
+;; both engines. The native side covers it through
+;; scripts/run_value_position_sweep.py, which skips a name per-engine rather
+;; than per-file.
+
+;; --------------------------------------------------------------------
+;; Sign and zero predicates.
+;; --------------------------------------------------------------------
+(agrees "zero? on 0"         zero?     0    (zero? 0))
+(agrees "zero? on 5"         zero?     5    (zero? 5))
+(agrees "positive? on 5"     positive? 5    (positive? 5))
+(agrees "negative? on 5"     negative? 5    (negative? 5))
+(agrees "even? on 4"         even?     4    (even? 4))
+(agrees "odd? on 4"          odd?      4    (odd? 4))
+
+;; --------------------------------------------------------------------
+;; Type predicates.
+;; --------------------------------------------------------------------
+(agrees "string? on string"  string?   "s"  (string? "s"))
+(agrees "string? on 42"      string?   42   (string? 42))
+(agrees "symbol? on symbol"  symbol?   'foo (symbol? 'foo))
+(agrees "char? on char"      char?     #\a  (char? #\a))
+(agrees "boolean? on #t"     boolean?  #t   (boolean? #t))
+(agrees "vector? on vector"  vector?   (vector 1 2) (vector? (vector 1 2)))
+(agrees "pair? on list"      pair?     (list 1) (pair? (list 1)))
+(agrees "null? on empty"     null?     '()  (null? '()))
+(agrees "list? on list"      list?     (list 1 2) (list? (list 1 2)))
+(agrees "procedure? on car"  procedure? car (procedure? car))
+
+;; --------------------------------------------------------------------
+;; A predicate is only useful first-class if it survives the routes that make
+;; it first-class in real programs.
+;; --------------------------------------------------------------------
+(define stored-predicate complex?)
+(check "stored in a variable"
+       (eq? (h1 stored-predicate 42) (complex? 42)))
+
+(define (predicate-factory) complex?)
+(check "returned from a procedure"
+       (eq? (h1 (predicate-factory) 42) (complex? 42)))
+
+(check "read out of a list"
+       (eq? (h1 (car (list complex?)) 42) (complex? 42)))
+
+(check "used by filter"
+       (equal? (filter number? (list 1 "a" 2)) (list 1 2)))
+
+(if (= failures 0)
+    (display "PASS: first-class predicates — 0 failures")
+    (display "FAIL: first-class predicates"))

--- a/tests/integration/first_class_rounding_test.esk
+++ b/tests/integration/first_class_rounding_test.esk
@@ -1,0 +1,136 @@
+;;; first_class_rounding_test.esk
+;;;
+;;; SW-35 class-kill test: floor / ceiling / truncate / round used as
+;;; FIRST-CLASS VALUES must answer exactly what they answer in call position,
+;;; across the whole numeric tower.
+;;;
+;;; These four are not plain libm wrappers. Their call-position lowering
+;;; dispatches on EXACTNESS first: an exact integer or a bignum is the
+;;; identity, a RATIONAL goes through eshkol_rational_<op>_tagged and may
+;;; produce a result too large for an int64, and only an inexact real reaches
+;;; libm. The value-position route used a separate, hand-written wrapper that
+;;; knew none of that — it unpacked the tagged operand as a double, which for
+;;; a rational is its HEAP POINTER. So:
+;;;
+;;;     (map floor (list 7/3 -7/3 (/ (expt 2 100) 3)))
+;;;       => (4966570936 4966571152 4966571728)
+;;;
+;;; Those are addresses. They changed between runs of the same binary, and
+;;; `exact?` on each answered #f. `(floor 7/3)` in call position was correct
+;;; throughout, and the VM was correct throughout, so nothing else caught it.
+;;;
+;;; The fix routes these four through the generic wrapper that GENERATES its
+;;; body from the call-position lowering, rather than patching the duplicate —
+;;; the same mechanism, and the same reasoning, as LE-01.
+;;;
+;;; THE ORACLE IS DIFFERENTIAL: every check compares the value-position result
+;;; against the identical call-position expression in the same program. That
+;;; matters more than usual here, because the correct answers include a
+;;; 31-digit bignum that no one should be hand-transcribing into a test.
+;;;
+;;; BOTH value-position routes are exercised. A user higher-order procedure
+;;; resolves the name through codegenVariable; `map` resolves it through
+;;; resolveLambdaFunction. SW-35 was live in both, and fixing only the first
+;;; left `(map floor (list 7/3))` still printing an address while
+;;; `(h floor 7/3)` had become correct.
+
+(require stdlib)
+
+(define failures 0)
+
+(define (check name ok)
+  (if ok
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (set! failures (+ failures 1))
+             (display "FAIL: ") (display name) (newline))))
+
+(define (h1 f a) (f a))
+
+;; route 1: user higher-order procedure   route 2: builtin combinator
+(define (via-hof f v) (h1 f v))
+(define (via-map f v) (car (map f (list v))))
+
+(define (agrees name f v direct)
+  (check (string-append name " via HOF") (equal? (via-hof f v) direct))
+  (check (string-append name " via map") (equal? (via-map f v) direct)))
+
+;; --------------------------------------------------------------------
+;; RATIONALS — the case that returned heap addresses.
+;; --------------------------------------------------------------------
+(agrees "floor 7/3"        floor    7/3  (floor 7/3))
+(agrees "floor -7/3"       floor    -7/3 (floor -7/3))
+(agrees "ceiling 7/3"      ceiling  7/3  (ceiling 7/3))
+(agrees "ceiling -7/3"     ceiling  -7/3 (ceiling -7/3))
+(agrees "truncate 7/3"     truncate 7/3  (truncate 7/3))
+(agrees "truncate -7/3"    truncate -7/3 (truncate -7/3))
+(agrees "round 7/3"        round    7/3  (round 7/3))
+(agrees "round -7/3"       round    -7/3 (round -7/3))
+
+;; A rational whose floor EXCEEDS int64. This is the case an int64-returning
+;; rounding entry point cannot carry at all, so it pins that the value route
+;; reaches the tagged entry point and not merely a fixed version of the old one.
+(define big-ratio (/ (expt 2 100) 3))
+(agrees "floor 2^100/3"    floor    big-ratio (floor big-ratio))
+(agrees "ceiling 2^100/3"  ceiling  big-ratio (ceiling big-ratio))
+(agrees "truncate 2^100/3" truncate big-ratio (truncate big-ratio))
+(agrees "round 2^100/3"    round    big-ratio (round big-ratio))
+
+;; The result must be an exact integer, not a float and not an address.
+(check "floor of a rational is exact"
+       (exact? (via-hof floor 7/3)))
+(check "floor of a big rational is exact"
+       (exact? (via-hof floor big-ratio)))
+(check "floor of a big rational is an integer"
+       (integer? (via-hof floor big-ratio)))
+
+;; --------------------------------------------------------------------
+;; EXACT INTEGERS — identity, and must stay exact.
+;; --------------------------------------------------------------------
+(agrees "floor 5"          floor    5    (floor 5))
+(agrees "ceiling 5"        ceiling  5    (ceiling 5))
+(agrees "truncate -5"      truncate -5   (truncate -5))
+(agrees "round 5"          round    5    (round 5))
+(check "floor of an exact integer stays exact" (exact? (via-hof floor 5)))
+
+;; A bignum is also an exact integer and also the identity.
+(define big-int (expt 2 100))
+(agrees "floor 2^100"      floor    big-int (floor big-int))
+(agrees "round 2^100"      round    big-int (round big-int))
+
+;; --------------------------------------------------------------------
+;; INEXACT REALS — the only case that reaches libm, including R7RS
+;; round-half-to-even.
+;; --------------------------------------------------------------------
+(agrees "floor 2.7"        floor    2.7  (floor 2.7))
+(agrees "floor -2.7"       floor    -2.7 (floor -2.7))
+(agrees "ceiling 2.1"      ceiling  2.1  (ceiling 2.1))
+(agrees "truncate -2.7"    truncate -2.7 (truncate -2.7))
+(agrees "round 2.5"        round    2.5  (round 2.5))
+(agrees "round 3.5"        round    3.5  (round 3.5))
+(agrees "round -2.5"       round    -2.5 (round -2.5))
+
+;; --------------------------------------------------------------------
+;; Whole-tower probe in one list — the shape the defect was found with.
+;; --------------------------------------------------------------------
+(check "map floor over the whole tower"
+       (equal? (map floor (list 7/3 -7/3 big-ratio 2.7 5))
+               (list (floor 7/3) (floor -7/3) (floor big-ratio)
+                     (floor 2.7) (floor 5))))
+
+;; Stored and returned, not only passed.
+(define stored-floor floor)
+(check "stored in a variable" (equal? (h1 stored-floor 7/3) (floor 7/3)))
+
+(define (floor-factory) floor)
+(check "returned from a procedure"
+       (equal? (h1 (floor-factory) 7/3) (floor 7/3)))
+
+(check "read out of a list"
+       (equal? (h1 (car (list floor)) 7/3) (floor 7/3)))
+
+(if (= failures 0)
+    (begin (display "PASS: first-class rounding — 0 failures") (newline))
+    (begin (display "FAIL: first-class rounding — ")
+           (display failures)
+           (display " failure(s)")
+           (newline)))

--- a/tests/value_position/BASELINE.json
+++ b/tests/value_position/BASELINE.json
@@ -1,0 +1,22 @@
+{
+  "_comment": "Value-position ratchet for scripts/run_value_position_sweep.py. A key is <builtin>::<probe>. A NEW key fails the gate; a key listed here is reported on every run and does not. Every entry must carry a reason naming the ledger ID it stands for -- an entry without one is indistinguishable from hiding a bug. NEVER regenerate this file to turn a red gate green; that is the exact move this ratchet exists to prevent. An entry is removed when its ledger ID closes, not when it becomes inconvenient.",
+  "known_findings": {
+    "cadr::passed": "SW-38 (open) - VM only: cadr as a first-class value returns () instead of the element. Native is correct on all four axes.",
+    "cadr::stored": "SW-38 (open) - VM only, same defect reached by storing the procedure in a variable.",
+    "cadr::returned": "SW-38 (open) - VM only, same defect reached by returning the procedure.",
+    "cadr::mapped": "SW-38 (open) - VM only, same defect reached through map.",
+    "caddr::passed": "SW-38 (open) - VM only: caddr as a first-class value returns ().",
+    "caddr::stored": "SW-38 (open) - VM only, same defect via a stored binding.",
+    "caddr::returned": "SW-38 (open) - VM only, same defect via a returned procedure.",
+    "caddr::mapped": "SW-38 (open) - VM only, same defect through map.",
+    "string-length::passed": "SW-39 (open) - VM only: aborts the VM instead of answering. Native is correct.",
+    "string-length::stored": "SW-39 (open) - VM only, same abort via a stored binding.",
+    "string-length::returned": "SW-39 (open) - VM only, same abort via a returned procedure.",
+    "string-ref::passed": "SW-39 (open) - VM only: aborts the VM instead of answering.",
+    "string-ref::stored": "SW-39 (open) - VM only, same abort via a stored binding.",
+    "string-ref::returned": "SW-39 (open) - VM only, same abort via a returned procedure.",
+    "vref::passed": "SW-39 (open) - VM only: aborts the VM instead of answering.",
+    "vref::stored": "SW-39 (open) - VM only, same abort via a stored binding.",
+    "vref::returned": "SW-39 (open) - VM only, same abort via a returned procedure."
+  }
+}


### PR DESCRIPTION
**Stacked on #439** (`fix/numeric-tower-bignum-tail`). Base this on #439's branch, not master; merge #439 first. If #439 rebases, this rebases with it.

## What this is

The **value-position axis** — the gate the escape analyses for SW-27 and SW-35 both prescribed, in the same words — plus the two defects that prompted it and two more the gate found on its first run.

Eshkol lowers most builtins **inline at the call site**. Referencing the same builtin as a **value** takes a different route through the codegen — in fact **two** different routes — and defects keep being found living there while call position is correct: LE-01, SW-27, SW-31, SW-34, SW-35. Five, each found by hand.

That invisibility is structural, not bad luck:

- the differential corpus compares **execution axes against each other**, and a value-position defect is usually wrong *identically* on all four, so they agree and the gate is green;
- vm-parity excuses native-only programs;
- the arity sweep, surface-parity probe and language-coverage floor all exercise builtins in **call position only**.

## The sweep — `scripts/run_value_position_sweep.py`

For every builtin the manifest can type, one program evaluates the **same call** in call position and through three value-position routes, and compares them in-program:

| probe | route | codegen site |
|---|---|---|
| `passed` | `(h N a…)` — user higher-order procedure | `codegenVariable` |
| `stored` | `(let ((v N)) (h v a…))` | `codegenVariable` |
| `returned` | `((lambda () N))` via a HOF | `codegenVariable` |
| `mapped` | `(car (map N (list a)))` — builtin combinator | `resolveLambdaFunction` |

**The oracle is differential by construction.** Nothing hard-codes what a builtin ought to return, so it needs no reference implementation and cannot pass by agreeing with a wrong expectation. A builtin is judged only when its **call position works**; if that raises, the name is skipped and reported — reporting someone else's bug as your own finding is how a gate loses meaning.

`mapped` is **not** redundant with `passed`. SW-35 was live in *both* routes: after the first fix `(h floor 7/3)` was correct while `(map floor (list 7/3))` still printed a heap address. A gate probing one route would have certified that half-fix as complete.

The **VM is in `--all-axes` on purpose** — an independent implementation of the same question, so it catches what four agreeing native axes cannot. It immediately did.

## SW-35 — rounding as a value returned a rational's heap address

`floor`/`ceiling`/`truncate`/`round` had **two implementations**. Call position (`codegenMathFunction`) dispatches on **exactness**: exact integers and bignums are the identity, rationals go through `eshkol_rational_<op>_tagged`, only inexact reals reach libm. The value route used `createBuiltinUnaryMathFunction`, which unpacks the operand as a double — for a rational, that reads its **pointer**:

```
(map floor (list 7/3 -7/3 (/ (expt 2 100) 3)))
  => (4966570936 4966571152 4966571728)   addresses, varying per run
(floor 7/3) => 2                          call position, correct
```

Both routes now go through the generic wrapper that **generates its body by re-entering `codegenCall`**, so the exactness-aware lowering *is* the wrapper body. That is the LE-01 mechanism applied to a second instance of the LE-01 shape, not a second patch to the duplicate. The ledger's stated correct answer `(2 -3 422550200076076467165567735125)` is reproduced exactly.

## SW-34 — `complex?` could not be used as a value at all

Loud compile-time `Undefined variable: complex?` the moment the bare name was read as a value, while call position answered `#t` and the VM bound it fine. No row in the first-class builtin table. The fix lists the R7RS numeric-tower predicates as a **family** rather than name-by-name as need arises — name-by-name is how the gap appeared. The predicate matrix no longer needs its `complex?` exclusion.

## Two more, found by the sweep on its first run, fixed here

- **SW-36** — `make-string` as a value **silently dropped a supplied fill character**: `(h make-string 3 #\x)` → `"   "`, exit 0. The table LE-01 introduced listed it at arity 1, so a fixed-arity closure never passed the second argument. Live on master since #427. Corrected to the full form; R7RS 6.7 leaves the 1-argument contents *unspecified*, so wrapping the form whose result **is** specified is the right choice.
- **SW-37** — `pow` as a value **SIGSEGV'd**: LE-01 residue, a raw libm symbol reaching the foreign-ABI fallback.

## Two found and deliberately NOT fixed here

Both are in the **VM's own** value representation — a different subsystem from this lane's native lowering. Filed precisely and ratcheted rather than fixed badly:

- **SW-38** — VM only: `cadr`/`caddr` as first-class values return `()`. **Silent wrong**, exit 0, and `()` is truthy in Scheme. Native correct on all four axes.
- **SW-39** — VM only: `string-length`/`string-ref`/`vref` as first-class values **abort the VM**. Native correct on all four axes.

**SW-38 is an open SILENT-WRONG entry and therefore gates the release.** That is the honest detector working on the day it was built. It needs a coordinator ruling — dispatch a VM lane, or accept the red — not a quiet reclassification.

## Wired as a permanent gate

- **ctest** — `value_position_axis_sweep`, plus `first_class_predicates_{runtime,aot,vm}_smoke` and `first_class_rounding_{runtime,aot}_smoke`
- **smoke** — probe `value_position_axis` in `scripts/run_icc_smoke.sh`
- **oracle** — two criteria in `.icc/completion-oracles.yaml`, on the sweep's own `runtime_event` and on the smoke probe

## Coverage is stated out loud

**199 of 205** selected builtins are actually compared; **6 are not exercised** and the sweep prints them by name every run. "0 findings" over a table this size invites being read as "the surface is proven", and it is not — an unexercised name is an untested name.

## Measured

| Gate | Result |
|---|---|
| `ctest` | **170/170 PASS** |
| value-position sweep | **2352 comparisons over 5 axes, 0 NEW findings**, 17 known (all SW-38/SW-39, all VM) |
| `run_vm_parity.sh` | **172 passed / 0 failed** |
| differential corpus | **294/294 axis pairs across 49 programs** |

## Ledger ID collision

SW-34 was allocated concurrently by more than one lane. This PR's closure cites the entry **by branch and text** — "complex? cannot be used as a first-class value natively, though the VM binds it", filed on `fix/numeric-tower-bignum-tail` — and speaks only to that one. New entries use SW-36..SW-39, verified free across every remote branch. No other lane's entries were renumbered.
