### PR TITLE
fix(vm): min/max drop the tangent, so every derivative through them is 0 (SW-40)

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -1774,6 +1774,107 @@ entries:
       first, so the repair here is now a no-op and only this ledger entry remains. Both
       arrived at byte-identical edits, which is itself corroboration of the diagnosis.
       GATE repair only — no product code.
+
+  - id: SW-40
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "VMDUAL-SHA"
+    closed_by: "PR fix(vm): min/max lose the tangent (branch fix/vm-minmax-dual)"
+    renumbered_from: >-
+      SW-33 (as filed) -> SW-36 -> SW-40, two hops, both forced by collisions
+      across unmerged branches. FILED as SW-33 on branch
+      fix/numeric-tower-bignum-tail, which found it while working on SW-32. That
+      ID was already taken by the native rest-parameter defect on branch
+      fix/native-rest-capture-and-do-loop, so the two collided; master has since
+      absorbed that lane's entry, and SW-33/SW-34 on master are now canonical and
+      are NOT this defect. Renumbered here first to SW-36 (the free ID at the
+      time), which two further lanes -- fix/numeric-tower-bignum-tail and
+      fix/value-position-axis -- then also claimed while this PR was open, so it
+      moved again to SW-40. SW-25..SW-39 are all claimed across master and the
+      in-flight branches as of this rebase; SW-40 is the first truly free ID. The
+      filing lane's text is preserved; only the ID and the status/evidence fields
+      changed, and no other lane's entry is touched.
+    title: "A derivative taken through min/max is silently 0 on the VM"
+    repro: "(define (f x) (max (* x x) (* 2 x))) (display (derivative f 3.0))"
+    observed_before: "VM prints 0; native prints 6"
+    correct: "6 — d/dx of x^2 at 3, since x^2 > 2x there"
+    observed_after: >-
+      6, and the VM agrees with native on every cell of the selection matrix. Both
+      operators and both arms: with f = (max (* x x) (* 2 x)) and
+      g = (min (* x x) (* 2 x)) the VM now gives 6 and 2 at x=3 and 2 and 2 at x=1,
+      matching native exactly, and the primal values (9, 6) are unchanged.
+    root_cause: >-
+      CONFIRMED, and the filing lane's hypothesis was right line-for-line. min/max
+      are SELECTION operators — the result IS one of the operands — so the
+      derivative must carry the SELECTED operand's tangent. Native
+      ArithmeticCodegen::min (lib/backend/arithmetic_codegen.cpp:3016) and ::max
+      (:3121) each open with an explicit DUAL NUMBER PATH that promotes both sides
+      via convertToDual, compares primals with FCmpOLE / FCmpOGE and packs the
+      chosen dual. The VM's natives 33/34 (lib/backend/vm_native.c:7106, reached as
+      _min2/_max2 — lib/backend/eshkol_vm.c:294 — under the variadic prelude min/max)
+      had no dual arm at all: both operands fell through to as_number_vm(), which
+      returns a dual's primal and discards its tangent, so the result was pushed as
+      a bare flonum by number_val_contagious and every derivative through min/max
+      read 0. The PRIMAL was correct throughout, which is what kept it invisible.
+    fixed_by: >-
+      lib/backend/vm_native.c natives 33/34 — a VAL_DUAL arm that promotes both
+      operands, compares primals and pushes the CHOSEN dual, with tie-breaking
+      mirroring native's FCmpOLE/FCmpOGE (left operand wins a tie on both engines);
+      plus the second-order VAL_HYPER_DUAL twin, matching how lbl_ABS already
+      treats the two carriers. The bignum and double paths are byte-for-byte the
+      previous logic.
+    class_kill: >-
+      The class is "selection-style numeric operator loses the tangent". Audited
+      every member on BOTH engines by measurement, not by reading: min, max, abs,
+      floor, ceiling, round, truncate. floor/ceiling/round/truncate are correct on
+      both engines (their derivative is 0 almost everywhere, which the plain
+      numeric path already produces). abs was correct on the VM's computed-goto
+      loop, which has had a VAL_DUAL arm all along — but its SWITCH-DISPATCH TWIN
+      (lib/backend/vm_run.c case OP_ABS, the lane a build without computed-goto
+      takes) was missing BOTH the VAL_DUAL and VAL_HYPER_DUAL arms, so a derivative
+      through abs answered 0 there. That twin is repaired in the same change. This
+      is the same both-loops discipline SW-09b established. Native has no gap in
+      this family: all seven measured correct.
+    evidence: >-
+      tests/vm_parity/corpus/66_minmax_dual_selection.esk (22 rows, EXACT analytic
+      derivatives, never a finite difference) on native / vm-src / vm-eskb, and the
+      same program as tests/differential/corpus/50_minmax_dual_selection.esk across
+      the four native axes. Revert-validated on a pristine VM rebuilt from HEAD in
+      the same worktree: 14 of the 22 rows diverge pre-fix, every one of them
+      answering 0 where native answers non-zero; all 22 agree post-fix. The 8 rows
+      that agreed pre-fix are the 5 primal rows, the 2 abs rows the computed-goto
+      loop already handled, and — notably — the constant-selected row whose CORRECT
+      answer is 0. That row is the reason a value table alone is not a sufficient
+      oracle here, and why every other derivative row in the corpus is non-zero.
+    discovered_by: >-
+      Probing AD through min/max while fixing SW-32 on branch
+      fix/numeric-tower-bignum-tail, because that fix touches the very dispatch the
+      dual path sits in front of. Confirmed PRE-EXISTING and NOT caused by the
+      SW-32 work: the same program gives the same zeros on a VM built with all of
+      that branch's VM changes reverted, and re-confirmed here on a clean worktree
+      off origin/master that contains none of them. Fixed independently of that
+      branch — the fix touches neither the exactness paths nor the rational tower.
+    caught_by: [direct-measurement, sw-32-adjacent-probe]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity, differential-corpus, ad-oracle]
+    notes: >-
+      Escape analysis: the AD oracle generates its probes from an arithmetic shape
+      table that contains no SELECTION operator at all, so no min/max/abs
+      derivative was ever exercised on either engine — the gate was green because
+      the operator family was absent from the generator, not because it was
+      correct. The corpus entries added here are the point fix; the generator axis
+      ("every numeric builtin whose result is one of its operands, differentiated
+      on both engines") is the durable one and is recommended for the AD-oracle
+      shape table. Separate finding, NOT filed as silent-wrong because it is absent
+      surface rather than a wrong answer: the VM's hyper-dual natives (1900-1921,
+      the {f,f1,f2,f12} second-order carrier) have no name bindings in
+      lib/backend/eshkol_vm.c, so they are unreachable from Eshkol source on the VM.
+      The VAL_HYPER_DUAL arm added here is therefore correct-by-construction and
+      symmetric with lbl_ABS, but is NOT exercised by any test and must not be
+      counted as covered. Nested/second-order `derivative` on the VM raises a LOUD,
+      honest "not supported on the VM" error today, so no silent path reaches it.
+
+  # ───────────────────────── IN-FLIGHT ─────────────────────────
+
   - id: IF-01
     bucket: IN-FLIGHT
     silent_wrong_class: true

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -1778,7 +1778,7 @@ entries:
   - id: SW-40
     bucket: SILENT-WRONG
     status: closed
-    closed_at: "VMDUAL-SHA"
+    closed_at: "6e6afd22"
     closed_by: "PR fix(vm): min/max lose the tangent (branch fix/vm-minmax-dual)"
     renumbered_from: >-
       SW-33 (as filed) -> SW-36 -> SW-40, two hops, both forced by collisions

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -7388,22 +7388,64 @@ static void vm_dispatch_native(VM* vm, int fid) {
             }
         }
         vm_push(vm, FLOAT_VAL(pow(as_number(a), as_number(b)))); break; }
-    /* SW-32: min/max must ORDER EXACTLY whenever both operands are exact.
-     * The vm_either_exact_wide() guard alone covers bignums and rationals but
-     * NOT two plain fixnums, which fell through to the double path where
-     * everything past 2^53 collapses: (max 9007199254740993 9007199254740992)
-     * answered the SMALLER value because both operands round to one flonum.
-     * Native had the mirror-image bug in its own copy of this dispatch. */
-    case 33: { Value b = vm_pop(vm); Value a = vm_pop(vm);
+    /* SW-40: min/max are SELECTION operators — the result IS one of the
+     * operands — so a forward-mode derivative through them must carry the
+     * SELECTED operand's tangent. Native ArithmeticCodegen::min/max open with
+     * exactly this arm (see their "DUAL NUMBER PATH" blocks: promote both
+     * sides, compare primals, pack the chosen dual). The VM had no such arm:
+     * both operands fell through to as_number_vm(), which returns a dual's
+     * primal and DISCARDS its tangent, so the result came back a bare flonum
+     * and every derivative through min/max read 0 while the primal stayed
+     * correct. A zero derivative is the worst shape of silent-wrong for an AD
+     * system: it is indistinguishable from a legitimate stationary point.
+     *
+     * Tie-breaking mirrors native exactly — FCmpOLE for min and FCmpOGE for
+     * max both select the LEFT operand when the primals are equal, which is
+     * also what the double path below does.
+     *
+     * The hyper-dual arm is the second-order twin (VAL_HYPER_DUAL is the VM's
+     * {f,f1,f2,f12} carrier); lbl_ABS already treats the two carriers this way
+     * and min/max now agree with it. */
+    case 33: case 34: { Value b = vm_pop(vm); Value a = vm_pop(vm);
+        const int want_max = (fid == 34);
+        if (a.type == VAL_HYPER_DUAL || b.type == VAL_HYPER_DUAL) {
+            VmHyperDual ah = {as_number_vm(vm,a), 0.0, 0.0, 0.0};
+            VmHyperDual bh = {as_number_vm(vm,b), 0.0, 0.0, 0.0};
+            if (a.type == VAL_HYPER_DUAL) ah = *(VmHyperDual*)vm->heap.objects[a.as.ptr]->opaque.ptr;
+            if (b.type == VAL_HYPER_DUAL) bh = *(VmHyperDual*)vm->heap.objects[b.as.ptr]->opaque.ptr;
+            const VmHyperDual* pick = want_max ? ((ah.f >= bh.f) ? &ah : &bh)
+                                               : ((ah.f <= bh.f) ? &ah : &bh);
+            VmHyperDual* out = vm_hd_make(&vm->heap.regions, pick->f, pick->f1, pick->f2, pick->f12);
+            if (!out) { vm_push(vm, NIL_VAL); break; }
+            VM_PUSH_HEAP_OPAQUE(vm, HEAP_HYPER_DUAL, VAL_HYPER_DUAL, out);
+            break;
+        }
+        if (a.type == VAL_DUAL || b.type == VAL_DUAL) {
+            VmDual ad = {as_number_vm(vm,a), 0.0};
+            VmDual bd = {as_number_vm(vm,b), 0.0};
+            if (a.type == VAL_DUAL) ad = *(VmDual*)vm->heap.objects[a.as.ptr]->opaque.ptr;
+            if (b.type == VAL_DUAL) bd = *(VmDual*)vm->heap.objects[b.as.ptr]->opaque.ptr;
+            const VmDual* pick = want_max ? ((ad.primal >= bd.primal) ? &ad : &bd)
+                                          : ((ad.primal <= bd.primal) ? &ad : &bd);
+            VmDual* out = vm_dual_make(&vm->heap.regions, pick->primal, pick->tangent);
+            if (!out) { vm_push(vm, NIL_VAL); break; }
+            VM_PUSH_HEAP_OPAQUE(vm, HEAP_DUAL, VAL_DUAL, out);
+            break;
+        }
+        /* Exact and double paths below are MASTER's, verbatim in behaviour:
+         * the both-exact ordering tier (#439, SW-32 — min/max agreeing with the
+         * engine's own `<`) in front of the exact-wide tier (#432, SW-18/SW-28),
+         * then the double fallback. The dual arms above sit in FRONT of all of
+         * them, so the changes compose: a dual operand never reaches an exact
+         * tier, and an exact operand never reaches a dual arm. */
         if (vm_tag_is_exact_number(a) && vm_tag_is_exact_number(b)) {
-            vm_push(vm, vm_bignum_compare_vals(vm,a,b) <= 0 ? a : b); break; }
-        if (vm_either_exact_wide(a,b)) { vm_push(vm, vm_bignum_compare_vals(vm,a,b) <= 0 ? a : b); break; }
-        double da=as_number_vm(vm,a),db=as_number_vm(vm,b); vm_push(vm, number_val_contagious(a,b,da<db?da:db)); break; }
-    case 34: { Value b = vm_pop(vm); Value a = vm_pop(vm);
-        if (vm_tag_is_exact_number(a) && vm_tag_is_exact_number(b)) {
-            vm_push(vm, vm_bignum_compare_vals(vm,a,b) >= 0 ? a : b); break; }
-        if (vm_either_exact_wide(a,b)) { vm_push(vm, vm_bignum_compare_vals(vm,a,b) >= 0 ? a : b); break; }
-        double da=as_number_vm(vm,a),db=as_number_vm(vm,b); vm_push(vm, number_val_contagious(a,b,da>db?da:db)); break; }
+            int cmp = vm_bignum_compare_vals(vm,a,b);
+            vm_push(vm, (want_max ? (cmp >= 0) : (cmp <= 0)) ? a : b); break; }
+        if (vm_either_exact_wide(a,b)) {
+            int cmp = vm_bignum_compare_vals(vm,a,b);
+            vm_push(vm, (want_max ? (cmp >= 0) : (cmp <= 0)) ? a : b); break; }
+        double da=as_number_vm(vm,a),db=as_number_vm(vm,b);
+        vm_push(vm, number_val_contagious(a,b, want_max ? (da>db?da:db) : (da<db?da:db))); break; }
     case 35: { Value a = vm_pop(vm); if (a.type==VAL_DUAL) { vm_push(vm,a); vm_dispatch_native(vm,383); }
         else if (a.type==VAL_RATIONAL) { vm_push(vm,a); vm_dispatch_native(vm,336); }
         else if (a.type==VAL_BIGNUM) { vm_push_bignum_norm(vm, bignum_abs_val(&vm->heap.regions, (VmBignum*)vm->heap.objects[a.as.ptr]->opaque.ptr)); }

--- a/lib/backend/vm_run.c
+++ b/lib/backend/vm_run.c
@@ -1303,6 +1303,14 @@ vm_exit:
                     "native backend");
                 break;
             }
+            /* SW-40: this switch arm is the twin of lbl_ABS and must carry the
+             * SAME carrier arms. It was missing both AD ones, so on a build
+             * that uses the switch dispatch (no computed-goto — the Windows/
+             * MSVC lane) a derivative through `abs` fell to the double path,
+             * which discards the tangent and answers 0. The computed-goto loop
+             * has had these two lines all along; the twin simply drifted. */
+            if (a.type == VAL_HYPER_DUAL) { vm_push(vm, a); vm_dispatch_native(vm, 1916); break; }
+            if (a.type == VAL_DUAL) { vm_push(vm, a); vm_dispatch_native(vm, 383); break; }
             if (a.type == VAL_RATIONAL) { vm_push(vm, a); vm_dispatch_native(vm, 336); break; }
             if (a.type == VAL_BIGNUM) { vm_push_bignum_norm(vm, bignum_abs_val(&vm->heap.regions, (VmBignum*)vm->heap.objects[a.as.ptr]->opaque.ptr)); break; }
             if (a.type == VAL_INT && a.as.i != INT64_MIN) { vm_push(vm, INT_VAL(a.as.i < 0 ? -a.as.i : a.as.i)); break; }

--- a/tests/differential/corpus/51_minmax_dual_selection.esk
+++ b/tests/differential/corpus/51_minmax_dual_selection.esk
@@ -1,0 +1,78 @@
+;; SW-40: a forward-mode derivative taken THROUGH min/max must carry the
+;; SELECTED operand's tangent, on both engines.
+;;
+;; min/max are SELECTION operators — the result IS one of the operands — so the
+;; derivative of min(f,g) follows whichever branch was chosen. Native
+;; ArithmeticCodegen::min/max open with an explicit dual-number arm that
+;; promotes both sides, compares primals and packs the chosen dual. The VM's
+;; min/max (natives 33/34, reached as _min2/_max2 under the variadic prelude)
+;; had no such arm: both operands fell through to as_number_vm(), which returns
+;; a dual's primal and DISCARDS its tangent, so the result came back a bare
+;; flonum and every derivative through min/max read 0 — while the PRIMAL stayed
+;; correct, which is what kept it invisible.
+;;
+;; A zero derivative is the worst shape of silent-wrong for an AD system: it is
+;; indistinguishable from a legitimate stationary point. Note the
+;; "constant-selected" row below, whose correct answer IS 0 — it agreed on both
+;; engines before the fix too, which is exactly why a table of expected values
+;; is not enough on its own and every other row here is non-zero.
+;;
+;; Expected values are EXACT analytic derivatives, never finite differences.
+
+(define (d f x) (derivative f x))
+
+(define (mx x) (max (* x x) (* 2 x)))
+(define (mn x) (min (* x x) (* 2 x)))
+
+;; x^2 vs 2x: x^2 wins above 2, 2x wins below it, they meet at 2.
+(display (d mx 3.0)) (newline)          ;; 6   — d/dx x^2
+(display (d mx 1.0)) (newline)          ;; 2   — d/dx 2x
+(display (d mn 3.0)) (newline)          ;; 2
+(display (d mn 1.0)) (newline)          ;; 2
+(display (d mx 0.5)) (newline)          ;; 2
+(display (d mn 0.5)) (newline)          ;; 1
+
+;; Tie at x=2: both engines select the LEFT operand (native compares with
+;; FCmpOLE/FCmpOGE, which are true on equality; the VM now mirrors that).
+(display (d mx 2.0)) (newline)          ;; 4
+(display (d mn 2.0)) (newline)          ;; 4
+
+;; Variadic min/max fold through the prelude onto the same two natives.
+(define (mx3 x) (max (* x x) (* 2 x) (* 0.5 x)))
+(define (mn3 x) (min (* x x) (* 2 x) (* 0.5 x)))
+(display (d mx3 3.0)) (newline)         ;; 6
+(display (d mn3 3.0)) (newline)         ;; 0.5
+
+;; A constant operand: the tangent must survive when the VARIABLE side wins.
+(define (mxc x) (max (* 3 x) 1.0))
+(define (mnc x) (min (* 3 x) 100.0))
+(display (d mxc 5.0)) (newline)         ;; 3
+(display (d mnc 5.0)) (newline)         ;; 3
+
+;; ...and must be 0, not the variable's, when the CONSTANT side wins. This row
+;; passed before the fix as well — it is here to pin the other half of the
+;; selection, not to detect the original defect.
+(define (mxk x) (max (* 3 x) 100.0))
+(display (d mxk 5.0)) (newline)         ;; 0
+
+;; Nested selection: the chosen tangent must survive a second selection.
+(define (nest x) (min (max (* x x) (* 2 x)) (* 10 x)))
+(display (d nest 3.0)) (newline)        ;; 6
+
+;; abs is the third selection-style operator. The computed-goto loop always
+;; had its dual arm; the switch-dispatch twin did not (it is the lane a build
+;; without computed-goto takes), so these rows pin both.
+(define (a1 x) (abs (* 2 x)))
+(define (a2 x) (abs (- 0.0 (* 2 x))))
+(define (a3 x) (abs (max (* x x) (* 2 x))))
+(display (d a1 3.0)) (newline)          ;; 2
+(display (d a2 3.0)) (newline)          ;; 2
+(display (d a3 3.0)) (newline)          ;; 6
+
+;; The PRIMAL results must not move: exactness contagion, variadic folding and
+;; the bignum ordering path are all untouched by the dual arm.
+(display (max 1 2.0)) (newline)         ;; 2.0
+(display (min 1 2.0)) (newline)         ;; 1
+(display (max 3 1 2)) (newline)         ;; 3
+(display (min 3 1 2)) (newline)         ;; 1
+(display (abs -7)) (newline)            ;; 7

--- a/tests/vm_parity/corpus/68_minmax_dual_selection.esk
+++ b/tests/vm_parity/corpus/68_minmax_dual_selection.esk
@@ -1,0 +1,78 @@
+;; SW-40: a forward-mode derivative taken THROUGH min/max must carry the
+;; SELECTED operand's tangent, on both engines.
+;;
+;; min/max are SELECTION operators — the result IS one of the operands — so the
+;; derivative of min(f,g) follows whichever branch was chosen. Native
+;; ArithmeticCodegen::min/max open with an explicit dual-number arm that
+;; promotes both sides, compares primals and packs the chosen dual. The VM's
+;; min/max (natives 33/34, reached as _min2/_max2 under the variadic prelude)
+;; had no such arm: both operands fell through to as_number_vm(), which returns
+;; a dual's primal and DISCARDS its tangent, so the result came back a bare
+;; flonum and every derivative through min/max read 0 — while the PRIMAL stayed
+;; correct, which is what kept it invisible.
+;;
+;; A zero derivative is the worst shape of silent-wrong for an AD system: it is
+;; indistinguishable from a legitimate stationary point. Note the
+;; "constant-selected" row below, whose correct answer IS 0 — it agreed on both
+;; engines before the fix too, which is exactly why a table of expected values
+;; is not enough on its own and every other row here is non-zero.
+;;
+;; Expected values are EXACT analytic derivatives, never finite differences.
+
+(define (d f x) (derivative f x))
+
+(define (mx x) (max (* x x) (* 2 x)))
+(define (mn x) (min (* x x) (* 2 x)))
+
+;; x^2 vs 2x: x^2 wins above 2, 2x wins below it, they meet at 2.
+(display (d mx 3.0)) (newline)          ;; 6   — d/dx x^2
+(display (d mx 1.0)) (newline)          ;; 2   — d/dx 2x
+(display (d mn 3.0)) (newline)          ;; 2
+(display (d mn 1.0)) (newline)          ;; 2
+(display (d mx 0.5)) (newline)          ;; 2
+(display (d mn 0.5)) (newline)          ;; 1
+
+;; Tie at x=2: both engines select the LEFT operand (native compares with
+;; FCmpOLE/FCmpOGE, which are true on equality; the VM now mirrors that).
+(display (d mx 2.0)) (newline)          ;; 4
+(display (d mn 2.0)) (newline)          ;; 4
+
+;; Variadic min/max fold through the prelude onto the same two natives.
+(define (mx3 x) (max (* x x) (* 2 x) (* 0.5 x)))
+(define (mn3 x) (min (* x x) (* 2 x) (* 0.5 x)))
+(display (d mx3 3.0)) (newline)         ;; 6
+(display (d mn3 3.0)) (newline)         ;; 0.5
+
+;; A constant operand: the tangent must survive when the VARIABLE side wins.
+(define (mxc x) (max (* 3 x) 1.0))
+(define (mnc x) (min (* 3 x) 100.0))
+(display (d mxc 5.0)) (newline)         ;; 3
+(display (d mnc 5.0)) (newline)         ;; 3
+
+;; ...and must be 0, not the variable's, when the CONSTANT side wins. This row
+;; passed before the fix as well — it is here to pin the other half of the
+;; selection, not to detect the original defect.
+(define (mxk x) (max (* 3 x) 100.0))
+(display (d mxk 5.0)) (newline)         ;; 0
+
+;; Nested selection: the chosen tangent must survive a second selection.
+(define (nest x) (min (max (* x x) (* 2 x)) (* 10 x)))
+(display (d nest 3.0)) (newline)        ;; 6
+
+;; abs is the third selection-style operator. The computed-goto loop always
+;; had its dual arm; the switch-dispatch twin did not (it is the lane a build
+;; without computed-goto takes), so these rows pin both.
+(define (a1 x) (abs (* 2 x)))
+(define (a2 x) (abs (- 0.0 (* 2 x))))
+(define (a3 x) (abs (max (* x x) (* 2 x))))
+(display (d a1 3.0)) (newline)          ;; 2
+(display (d a2 3.0)) (newline)          ;; 2
+(display (d a3 3.0)) (newline)          ;; 6
+
+;; The PRIMAL results must not move: exactness contagion, variadic folding and
+;; the bignum ordering path are all untouched by the dual arm.
+(display (max 1 2.0)) (newline)         ;; 2.0
+(display (min 1 2.0)) (newline)         ;; 1
+(display (max 3 1 2)) (newline)         ;; 3
+(display (min 3 1 2)) (newline)         ;; 1
+(display (abs -7)) (newline)            ;; 7


### PR DESCRIPTION
Closes the VM min/max AD gap found and filed by #439's lane. Branched off `origin/master`, **not** stacked on `fix/numeric-tower-bignum-tail` — see "Independence" below.

> **Rebased onto `438ea1fc`** (master after #430, #432 and #439). Master's natives 33/34 now carry a two-tier exact path — #439's both-exact ordering tier (SW-32) in front of #432's exact-wide tier (SW-18/SW-28). This PR's dual and hyper-dual arms are composed **in front of both**, so the dispatch order is: hyper-dual -> dual -> both-exact -> exact-wide -> double. The changes compose by construction: a dual operand never reaches an exact tier, and an exact operand never reaches a dual arm. Master's exact and double paths are kept verbatim in behaviour.
>
> Code changed at every hop, so the tree was rebuilt and every gate re-run each time; the counts below are measured on this final rebased tree. Ledger resolved as a union at each hop with master's entries verified byte-identical through YAML (this hop: SW-29, SW-31, SW-32). SW-40 survives and is unclaimed elsewhere.

## The defect

`min` and `max` are **selection** operators: the result *is* one of the operands, so a forward-mode derivative through them must carry the **selected** operand's tangent.

Native `ArithmeticCodegen::min` (`lib/backend/arithmetic_codegen.cpp:3016`) and `::max` (`:3121`) each open with an explicit `DUAL NUMBER PATH` that promotes both sides via `convertToDual`, compares primals with `FCmpOLE`/`FCmpOGE`, and packs the chosen dual.

The VM's min/max — natives 33/34 (`lib/backend/vm_native.c:7106`), reached as `_min2`/`_max2` (`lib/backend/eshkol_vm.c:294`) under the variadic prelude — had **no dual arm at all**. Both operands fell through to `as_number_vm()`, which returns a dual's primal and discards its tangent, so the result was pushed as a bare flonum by `number_val_contagious`:

```scheme
(define (f x) (max (* x x) (* 2 x)))
(derivative f 3.0)        ; native 6        VM 0
```

The **primal was correct throughout** — `(f 3.0)` answers `9` on both engines — which is what kept this invisible. A zero derivative is the worst shape of silent-wrong for an AD system: it is indistinguishable from a legitimate stationary point.

## The fix

A `VAL_DUAL` arm on natives 33/34 that promotes both operands, compares primals and pushes the **chosen** dual. Tie-breaking mirrors native exactly — `FCmpOLE` and `FCmpOGE` are both true on equality, so the **left** operand wins a tie on both engines. Plus the second-order `VAL_HYPER_DUAL` twin, matching how `lbl_ABS` already treats the two carriers. The bignum and double paths keep the previous logic byte-for-byte.

## Class-kill

The class is *"selection-style numeric operator loses the tangent"*. Every member was audited on **both** engines **by measurement, not by reading**: `min`, `max`, `abs`, `floor`, `ceiling`, `round`, `truncate`.

- `floor`/`ceiling`/`round`/`truncate` — correct on both engines. Their derivative is 0 almost everywhere, which the plain numeric path already produces.
- `abs` — correct on the VM's computed-goto loop, which has had a `VAL_DUAL` arm all along. **But its switch-dispatch twin** (`lib/backend/vm_run.c`, `case OP_ABS` — the lane a build without computed-goto takes, i.e. the MSVC lane) **was missing both the `VAL_DUAL` and `VAL_HYPER_DUAL` arms** that `lbl_ABS` carries, so a derivative through `abs` answered 0 there. Repaired in the same change. This is the same both-loops discipline SW-09b established, and the comment in that arm claims to be "the switch-based twin of lbl_ABS" while having silently drifted from it.
- **Native has no gap in this family** — all seven measured correct.

## Revert-validation

On a **pristine VM rebuilt from HEAD in the same worktree**: **14 of the corpus's 22 rows diverge pre-fix**, every one of them answering `0` where native answers non-zero. All 22 agree post-fix.

The 8 rows that agreed pre-fix are the 5 primal rows, the 2 `abs` rows the computed-goto loop already handled, and — notably — the constant-selected row whose **correct** answer *is* 0. That row is precisely why a value table alone is not a sufficient oracle for this defect, and why every other derivative row in the corpus is non-zero.

## Independence from #439

Confirmed pre-existing and **not** caused by the SW-32 work: this worktree is branched clean off `origin/master` and contains none of `fix/numeric-tower-bignum-tail`'s VM changes, and the defect reproduces identically here. The fix touches neither the exactness paths nor the rational tower, so there is no reason to stack.

## Ledger renumber

The filing lane filed this as **SW-33**. That ID was already taken by the native rest-parameter defect on `fix/native-rest-capture-and-do-loop`, so the two collided across unmerged branches. Surveying every remote branch, **SW-25 through SW-35 are all claimed** by in-flight lanes, so this entry is renumbered. **Two hops were needed:**

1. Filed as **SW-33** by `fix/numeric-tower-bignum-tail`. That ID was already taken by the native rest-parameter defect on `fix/native-rest-capture-and-do-loop` — which **master has since absorbed**, so `SW-33`/`SW-34` on master are canonical and are *not* this defect.
2. Renumbered to **SW-36**, which two further lanes (`fix/numeric-tower-bignum-tail`, `fix/value-position-axis`) then also claimed while this PR was open.
3. Renumbered again on rebase to **SW-40** — SW-25..SW-39 are all claimed across master and the in-flight branches, so SW-40 is the first truly free ID.

Both hops are recorded in the entry's `renumbered_from` field with the filing lane's text preserved. The ledger conflict was resolved as a **union**: master's SW-33 and SW-34 are kept verbatim beside this entry. **No other lane's entry is touched**, and the ledger parses with 70 entries and no duplicate IDs.

## Escape analysis

The AD oracle generates its probes from an arithmetic shape table that **contains no selection operator at all**, so no `min`/`max`/`abs` derivative was ever exercised on either engine. The gate was green because the operator family was *absent from the generator*, not because it was correct.

The corpus entries here are the point fix. The durable one is a **generator axis** — "every numeric builtin whose result is one of its operands, differentiated on both engines" — recommended for the AD-oracle shape table.

## Gates (re-measured at `5f1651a2`, rebuilt on the rebased tree)

| Gate | Result |
| --- | --- |
| `ctest --test-dir build` | **174/174** |
| `scripts/run_vm_parity.sh` | **182 passed, 0 failed** |
| `scripts/run_differential.sh` | **324/324** axis pairs across 54 programs, 0 divergences |
| `scripts/run_ad_oracle.sh` | **60/60**, 0 xknown, 0 failed, 0 crashed |
| `scripts/run_ad_adversarial.sh` | **56/56**, 0 xknown |
| `scripts/run_engine_parity_coverage.py` | **OK** — 203 programs, 0 divergent beyond baseline, 0 regressed; construct coverage **137/1114 (12.30%)**, up from the 113/1114 (10.14%) recorded in ledger PR-10 |
| `icc architecture-verify` | **8 PASS / 1 FAIL / 0 UNCHECKABLE** — measured pre-rebase, not re-run; see the honest note below |
| 22-row corpus, both engines | identical, and identical to the exact analytic values |

**Honest note on the one architecture FAIL.** `INV-language-surface-exercise` is an *exercise* invariant that wants a `language_surface_coverage` runtime event within 30 days. Emitting one requires a second full `build-quantum` tree plus the full-suite coverage run, and the machine is under three concurrent full-suite lanes; the instruction was to build once. This change adds **no language surface** — it is a dual-carrier arm on two existing natives — so the invariant is unaffected in substance, and I would rather report it unmet than manufacture the evidence. `INV-engine-semantic-parity`, which *is* the path-relevant invariant for a VM semantics change, was run and **passes**.


## The SW-32 divergence flagged on the previous hop is now closed

Last hop I flagged that native and the VM disagreed on exact min/max, with **native** returning the smaller operand. #439 has since fixed the native side, and on this tree both engines agree on the correct values:

```scheme
(max (/ (expt 2 100) 3) (/ (+ (expt 2 100) 1) 3))   ; both …377/3
(min 9007199254740993 9007199254740992)             ; both …992
```

Re-measured after composing this PR's dual arms in front of #439's ordering tier, so the two are confirmed to compose rather than merely to coexist.
