### PR TITLE
fix(codegen): compound accessors raise on off-end access in call position

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4703,6 +4703,33 @@ if(ESHKOL_BUILD_TESTS AND NOT WIN32)
             PASS_REGULAR_EXPRESSION "PASS: VM first-class builtin families"
             FAIL_REGULAR_EXPRESSION "FAIL:|undefined variable|fatal runtime error")
 
+    # Compound accessors in call position must raise exactly like their plain
+    # car/cdr composition when an intermediate value is not a pair. Run the
+    # same differential-by-construction family test on both engines.
+    add_test(
+        NAME compound_accessor_raise_native_smoke
+        COMMAND sh -c
+            "cd '${CMAKE_CURRENT_SOURCE_DIR}' && '$<TARGET_FILE:eshkol-run>' -r tests/integration/compound_accessor_raise_test.esk -L'${CMAKE_CURRENT_BINARY_DIR}'"
+    )
+    set_tests_properties(compound_accessor_raise_native_smoke
+        PROPERTIES
+            TIMEOUT 300
+            ENVIRONMENT "ESHKOL_JIT_CACHE=0"
+            PASS_REGULAR_EXPRESSION "PASS: compound accessors raise like car/cdr composition"
+            FAIL_REGULAR_EXPRESSION "FAIL:|Undefined variable|LLVM module verification failed|fatal signal")
+
+    add_test(
+        NAME compound_accessor_raise_vm_smoke
+        COMMAND sh -c
+            "cd '${CMAKE_CURRENT_SOURCE_DIR}' && '$<TARGET_FILE:eshkol-vm-standalone-test>' tests/integration/compound_accessor_raise_test.esk"
+    )
+    set_tests_properties(compound_accessor_raise_vm_smoke
+        PROPERTIES
+            TIMEOUT 300
+            ENVIRONMENT "ESHKOL_VM_NO_DISASM=1"
+            PASS_REGULAR_EXPRESSION "PASS: compound accessors raise like car/cdr composition"
+            FAIL_REGULAR_EXPRESSION "FAIL:|undefined variable|fatal runtime error")
+
     # SW-27, VM side. The VM's closures carry their rest-arg shape natively, so
     # this defect class does not exist on this engine either. Pinned for the
     # same reason as the builtins case above.

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -39095,36 +39095,27 @@ private:
         // Multiple arguments: build improper list where last element is the terminal
         // (list* 1 2 3 4) => (1 . (2 . (3 . 4)))  (4 is terminal, not null)
         
-        // Start with the last element as terminal
-        Value* result = codegenAST(&op->call_op.variables[op->call_op.num_vars - 1]);
-        if (!result) return ConstantInt::get(int64_type, 0);
+        // Start with the last element as terminal.  Keep the full tagged value
+        // here: a proper-list terminal is already a HEAP_PTR tagged_value, and
+        // reducing it through detectValueType() would reclassify its payload as
+        // an INT64 before storing the cdr.
+        Value* result_tagged = ensureTaggedValue(
+            codegenAST(&op->call_op.variables[op->call_op.num_vars - 1]));
         
         // Build cons chain from second-to-last element backwards to first
-        bool consed = false;
         for (int64_t i = op->call_op.num_vars - 2; i >= 0; i--) {
             Value* element = codegenAST(&op->call_op.variables[i]);
             if (element) {
-                // Create cons cell: (element . result) with type preservation
-                TypedValue element_typed = detectValueType(element);
-                TypedValue result_typed = detectValueType(result);
-                result = codegenTaggedArenaConsCell(element_typed, result_typed);
-                consed = true;
+                // Create the cons cell from complete tagged values so both the
+                // element and the terminal retain their runtime type tags.
+                Value* element_tagged = ensureTaggedValue(element);
+                Value* cons_cell = codegenTaggedArenaConsCellFromTaggedValue(
+                    element_tagged, result_tagged);
+                result_tagged = packPtrToTaggedValue(cons_cell, ESHKOL_VALUE_HEAP_PTR);
             }
         }
 
-        // codegenTaggedArenaConsCell returns a raw i64 (PtrToInt of the cons
-        // cell pointer). Callers like `(define x (list* ...))` route the return
-        // value through ensureTaggedValue which tags any raw i64 as INT64, not
-        // HEAP_PTR. That leaves @x holding an INT64 tag over the pointer bits
-        // and `(car x)` correctly rejects it as "not a pair". Lift the result
-        // to a properly tagged HEAP_PTR struct so downstream conversions keep
-        // the cons identity. (Matches cons/allocConsCell which packs HEAP_PTR.)
-        if (consed) {
-            Value* result_ptr = builder->CreateIntToPtr(result, ptr_type);
-            return tagged_->packHeapPtr(result_ptr);
-        }
-
-        return result;
+        return result_tagged;
     }
 
     // Production implementation: Acons (association constructor)

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -35588,8 +35588,37 @@ private:
 
         Value* current = codegenAST(&op->call_op.variables[0]);
         if (!current) return nullptr;
+        current = ensureTaggedValue(current);
 
         Function* current_func = builder->GetInsertBlock()->getParent();
+
+        // Compound accessors are specified as ordinary right-to-left car/cdr
+        // composition. Guard every intermediate with the same pair contract
+        // instead of treating a null/non-pair as a value and continuing.
+        auto emitIsPair = [&](Value* value) -> Value* {
+            Value* base_type = getBaseType(getTaggedValueType(value));
+            Value* is_legacy_type = builder->CreateICmpEQ(base_type,
+                ConstantInt::get(int8_type, ESHKOL_VALUE_CONS_PTR));
+            Value* ptr_int = safeExtractInt64(value);
+            Value* is_nonnull = builder->CreateICmpNE(ptr_int,
+                ConstantInt::get(int64_type, 0));
+            Value* is_legacy_pair = builder->CreateAnd(is_legacy_type, is_nonnull);
+            Value* is_heap_pair = tagged_->isCons(value);
+            return builder->CreateOr(is_legacy_pair, is_heap_pair);
+        };
+
+        auto emitNotPairRaise = [&](char step, const std::string& prefix) {
+            FunctionCallee raise_not_pair = module->getOrInsertFunction(
+                "eshkol_raise_not_pair",
+                FunctionType::get(void_type, {builder->getPtrTy()}, false));
+            const char* message = step == 'a'
+                ? "car: argument is not a pair"
+                : "cdr: argument is not a pair";
+            Value* error_message = builder->CreateGlobalStringPtr(
+                message, prefix + "_not_pair");
+            builder->CreateCall(raise_not_pair, {error_message});
+            builder->CreateUnreachable();
+        };
 
         // VECTOR/TENSOR OPTIMIZATION: For flat vectors, compound accessors can directly index
         // Pattern like "ad" (cadr) = element 1, "add" (caddr) = element 2, etc.
@@ -35614,6 +35643,20 @@ private:
                 Value* is_heap_ptr = builder->CreateICmpEQ(input_base_type,
                     ConstantInt::get(int8_type, ESHKOL_VALUE_HEAP_PTR));
 
+                BasicBlock* subtype_probe = BasicBlock::Create(*context,
+                    "compound_subtype_probe", current_func);
+                BasicBlock* vector_opt = BasicBlock::Create(*context,
+                    "compound_vector_opt", current_func);
+                BasicBlock* list_fallback = BasicBlock::Create(*context,
+                    "compound_list_fallback", current_func);
+                BasicBlock* compound_final = BasicBlock::Create(*context,
+                    "compound_final", current_func);
+
+                // Reading ptr-8 is only valid for a HEAP_PTR. Non-heap values
+                // take the checked list path and raise there.
+                builder->CreateCondBr(is_heap_ptr, subtype_probe, list_fallback);
+                builder->SetInsertPoint(subtype_probe);
+
                 // If HEAP_PTR, read the subtype from the object header to distinguish cons/vector/tensor
                 Value* obj_ptr_int = unpackInt64FromTaggedValue(current);
                 Value* obj_ptr = builder->CreateIntToPtr(obj_ptr_int, builder->getPtrTy());
@@ -35627,15 +35670,9 @@ private:
                 Value* is_tensor_subtype = builder->CreateICmpEQ(subtype,
                     ConstantInt::get(int8_type, HEAP_SUBTYPE_TENSOR));
 
-                // It's a vector/tensor type if HEAP_PTR AND (subtype==VECTOR OR subtype==TENSOR)
+                // It's a vector/tensor type when its heap subtype says so.
                 Value* is_vector_or_tensor = builder->CreateOr(is_vector_subtype, is_tensor_subtype);
-                Value* is_vector_type = builder->CreateAnd(is_heap_ptr, is_vector_or_tensor);
-
-                BasicBlock* vector_opt = BasicBlock::Create(*context, "compound_vector_opt", current_func);
-                BasicBlock* list_fallback = BasicBlock::Create(*context, "compound_list_fallback", current_func);
-                BasicBlock* compound_final = BasicBlock::Create(*context, "compound_final", current_func);
-
-                builder->CreateCondBr(is_vector_type, vector_opt, list_fallback);
+                builder->CreateCondBr(is_vector_or_tensor, vector_opt, list_fallback);
 
                 // VECTOR OPTIMIZATION: Directly return element at index d_count
                 builder->SetInsertPoint(vector_opt);
@@ -35746,37 +35783,20 @@ private:
                 for (int i = pattern.length() - 1; i >= 0; i--) {
                     char c = pattern[i];
 
-                    // FIX: Check for NULL by type, not by data value
-                    // A NULL tagged value has type=ESHKOL_VALUE_NULL, data is irrelevant
-                    Value* result_type = getTaggedValueType(list_result);
-                    Value* result_base_type = getBaseType(result_type);
-                    Value* is_null_type = builder->CreateICmpEQ(result_base_type,
-                        ConstantInt::get(int8_type, ESHKOL_VALUE_NULL));
-
-                    // Also check for CONS_PTR with null pointer (0)
-                    Value* is_cons_type = builder->CreateICmpEQ(result_base_type,
-                        ConstantInt::get(int8_type, ESHKOL_VALUE_HEAP_PTR));
+                    Value* is_pair = emitIsPair(list_result);
                     Value* ptr_int = safeExtractInt64(list_result);
-                    Value* is_null_ptr = builder->CreateICmpEQ(ptr_int,
-                        ConstantInt::get(int64_type, 0));
-                    Value* is_cons_null = builder->CreateAnd(is_cons_type, is_null_ptr);
-
-                    // Either NULL type or cons with null pointer
-                    Value* is_null = builder->CreateOr(is_null_type, is_cons_null);
 
                     BasicBlock* null_block = BasicBlock::Create(*context,
-                        std::string("fb_") + c + "_null", current_func);
+                        std::string("fb_") + c + "_not_pair", current_func);
                     BasicBlock* valid_block = BasicBlock::Create(*context,
                         std::string("fb_") + c + "_valid", current_func);
                     BasicBlock* continue_block = BasicBlock::Create(*context,
                         std::string("fb_") + c + "_continue", current_func);
 
-                    builder->CreateCondBr(is_null, null_block, valid_block);
+                    builder->CreateCondBr(is_pair, valid_block, null_block);
 
                     builder->SetInsertPoint(null_block);
-                    // FIX: Use proper NULL tagged value, not Int64 with 0
-                    Value* null_tagged = packNullToTaggedValue();
-                    builder->CreateBr(continue_block);
+                    emitNotPairRaise(c, std::string("fb_") + c);
 
                     builder->SetInsertPoint(valid_block);
                     Value* cons_ptr = builder->CreateIntToPtr(ptr_int, builder->getPtrTy());
@@ -36020,8 +36040,7 @@ private:
                     builder->CreateBr(continue_block);
 
                     builder->SetInsertPoint(continue_block);
-                    PHINode* result_phi = builder->CreatePHI(tagged_value_type, 2);
-                    result_phi->addIncoming(null_tagged, null_block);
+                    PHINode* result_phi = builder->CreatePHI(tagged_value_type, 1);
                     result_phi->addIncoming(extract_phi, merge_block);
 
                     list_result = result_phi;
@@ -36045,27 +36064,23 @@ private:
         for (int i = pattern.length() - 1; i >= 0; i--) {
             char c = pattern[i];
             
+            Value* is_pair = emitIsPair(current);
+
             // CRITICAL FIX: Safely extract i64 from possibly-tagged value
             Value* ptr_int = safeExtractInt64(current);
             
-            // NULL CHECK
-            Value* is_null = builder->CreateICmpEQ(ptr_int,
-                ConstantInt::get(int64_type, 0));
-            
             BasicBlock* null_block = BasicBlock::Create(*context,
-                std::string("compound_") + c + "_null", current_func);
+                std::string("compound_") + c + "_not_pair", current_func);
             BasicBlock* valid_block = BasicBlock::Create(*context,
                 std::string("compound_") + c + "_valid", current_func);
             BasicBlock* continue_block = BasicBlock::Create(*context,
                 std::string("compound_") + c + "_continue", current_func);
             
-            builder->CreateCondBr(is_null, null_block, valid_block);
+            builder->CreateCondBr(is_pair, valid_block, null_block);
             
-            // NULL: return null tagged value
+            // A failed intermediate car/cdr raises; it is never a value.
             builder->SetInsertPoint(null_block);
-            // FIX: Use proper NULL tagged value, not Int64 with 0
-            Value* null_tagged = packNullToTaggedValue();
-            builder->CreateBr(continue_block);
+            emitNotPairRaise(c, std::string("compound_") + c);
             
             // VALID: extract car or cdr using tagged cons cell helpers
             builder->SetInsertPoint(valid_block);
@@ -36269,10 +36284,9 @@ private:
             extract_phi->addIncoming(tagged_int, int_block);
             builder->CreateBr(continue_block);
             
-            // Continue: merge null and valid results
+            // Continue with the successfully extracted result.
             builder->SetInsertPoint(continue_block);
-            PHINode* result_phi = builder->CreatePHI(tagged_value_type, 2);
-            result_phi->addIncoming(null_tagged, null_block);
+            PHINode* result_phi = builder->CreatePHI(tagged_value_type, 1);
             result_phi->addIncoming(extract_phi, merge_block);
             
             current = result_phi;

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -7654,15 +7654,19 @@ static void vm_dispatch_native(VM* vm, int fid) {
         };
         Value result = vm_pop(vm);
         const char* path = accessor_paths[fid];
+        int raised = 0;
         for (const char* step = path; *step; step++) {
             if (result.type != VAL_PAIR) {
-                result = NIL_VAL;
+                vm_raise_error_msg(vm, *step == 'a'
+                    ? "car: argument is not a pair"
+                    : "cdr: argument is not a pair");
+                raised = 1;
                 break;
             }
             HeapObject* pair = vm->heap.objects[result.as.ptr];
             result = (*step == 'a') ? pair->cons.car : pair->cons.cdr;
         }
-        vm_push(vm, result);
+        if (!raised) vm_push(vm, result);
         break;
     }
 

--- a/lib/backend/vm_run.c
+++ b/lib/backend/vm_run.c
@@ -816,13 +816,19 @@ void vm_run(VM* vm) {
     }
     lbl_CAR: {
         Value pair = vm_pop(vm);
-        if (pair.type != VAL_PAIR) { fprintf(stderr, "CAR on non-pair\n"); vm->error = 1; goto vm_exit; }
+        if (pair.type != VAL_PAIR) {
+            vm_raise_error_msg(vm, "car: argument is not a pair");
+            DISPATCH();
+        }
         vm_push(vm, vm->heap.objects[pair.as.ptr]->cons.car);
         DISPATCH();
     }
     lbl_CDR: {
         Value pair = vm_pop(vm);
-        if (pair.type != VAL_PAIR) { fprintf(stderr, "CDR on non-pair\n"); vm->error = 1; goto vm_exit; }
+        if (pair.type != VAL_PAIR) {
+            vm_raise_error_msg(vm, "cdr: argument is not a pair");
+            DISPATCH();
+        }
         vm_push(vm, vm->heap.objects[pair.as.ptr]->cons.cdr);
         DISPATCH();
     }
@@ -1629,13 +1635,19 @@ vm_exit:
         }
         case OP_CAR: {
             Value pair = vm_pop(vm);
-            if (pair.type != VAL_PAIR) { fprintf(stderr, "CAR on non-pair\n"); vm->error = 1; break; }
+            if (pair.type != VAL_PAIR) {
+                vm_raise_error_msg(vm, "car: argument is not a pair");
+                break;
+            }
             vm_push(vm, vm->heap.objects[pair.as.ptr]->cons.car);
             break;
         }
         case OP_CDR: {
             Value pair = vm_pop(vm);
-            if (pair.type != VAL_PAIR) { fprintf(stderr, "CDR on non-pair\n"); vm->error = 1; break; }
+            if (pair.type != VAL_PAIR) {
+                vm_raise_error_msg(vm, "cdr: argument is not a pair");
+                break;
+            }
             vm_push(vm, vm->heap.objects[pair.as.ptr]->cons.cdr);
             break;
         }

--- a/tests/integration/compound_accessor_raise_test.esk
+++ b/tests/integration/compound_accessor_raise_test.esk
@@ -1,0 +1,70 @@
+;;; Compound-accessor failure contract, shared by the native and VM engines.
+;;; Each call-position spelling is compared with the equivalent explicit
+;;; car/cdr chain. Both routes must raise on an off-end or scalar intermediate.
+
+(define failures 0)
+
+(define (check label actual expected)
+  (if (equal? actual expected)
+      #t
+      (begin
+        (set! failures (+ failures 1))
+        (display (string-append "FAIL: " label)))))
+
+(define (raises? thunk)
+  (guard (condition (#t #t))
+    (thunk)
+    #f))
+
+(define (check-off-end label direct composed)
+  (let ((direct-raised (raises? direct))
+        (composed-raised (raises? composed)))
+    (check (string-append label " matches composition")
+           direct-raised composed-raised)
+    (check (string-append label " raises") direct-raised #t)))
+
+;; These are all 13 c[ad]+r spellings intercepted by the native helper. The
+;; shapes deliberately run off the end or reach a scalar before completion.
+(check-off-end "cadr off-end"
+               (lambda () (cadr (list 7)))
+               (lambda () (car (cdr (list 7)))))
+(check-off-end "caddr off-end"
+               (lambda () (caddr (list 7 8)))
+               (lambda () (car (cdr (cdr (list 7 8))))))
+(check-off-end "cadddr off-end"
+               (lambda () (cadddr (list 7 8)))
+               (lambda () (car (cdr (cdr (cdr (list 7 8)))))))
+(check-off-end "caar scalar"
+               (lambda () (caar (list 7)))
+               (lambda () (car (car (list 7)))))
+(check-off-end "cdar scalar"
+               (lambda () (cdar (list 7)))
+               (lambda () (cdr (car (list 7)))))
+(check-off-end "cddr off-end"
+               (lambda () (cddr (list 7)))
+               (lambda () (cdr (cdr (list 7)))))
+(check-off-end "caaar scalar"
+               (lambda () (caaar (list 7)))
+               (lambda () (car (car (car (list 7))))))
+(check-off-end "caadr off-end"
+               (lambda () (caadr (list 7)))
+               (lambda () (car (car (cdr (list 7))))))
+(check-off-end "cadar scalar"
+               (lambda () (cadar (list 7)))
+               (lambda () (car (cdr (car (list 7))))))
+(check-off-end "cdaar scalar"
+               (lambda () (cdaar (list 7)))
+               (lambda () (cdr (car (car (list 7))))))
+(check-off-end "cdadr off-end"
+               (lambda () (cdadr (list 7)))
+               (lambda () (cdr (car (cdr (list 7))))))
+(check-off-end "cddar scalar"
+               (lambda () (cddar (list 7)))
+               (lambda () (cdr (cdr (car (list 7))))))
+(check-off-end "cdddr off-end"
+               (lambda () (cdddr (list 7 8)))
+               (lambda () (cdr (cdr (cdr (list 7 8))))))
+
+(if (= failures 0)
+    (display "PASS: compound accessors raise like car/cdr composition")
+    (display "FAIL: compound accessor raise contract"))

--- a/tests/integration/vm_first_class_builtin_families_test.esk
+++ b/tests/integration/vm_first_class_builtin_families_test.esk
@@ -15,6 +15,11 @@
 (define (h1 f a) (f a))
 (define (h2 f a b) (f a b))
 
+(define (raises? thunk)
+  (guard (condition (#t #t))
+    (thunk)
+    #f))
+
 ;; Every branch has at least four elements at every level, so all c[ad]+r
 ;; accessors through four levels are valid on this shared value.
 (define access-leaf (list 1 2 3 4 5))
@@ -83,6 +88,13 @@
 (check-accessor "cddadr" cddadr stored-cddadr access-tree (cddadr access-tree))
 (check-accessor "cdddar" cdddar stored-cdddar access-tree (cdddar access-tree))
 (check-accessor "cddddr" cddddr stored-cddddr access-tree (cddddr access-tree))
+
+;; The first-class VM dispatcher must preserve the checked car/cdr failure
+;; contract too; it must not fabricate () when the path runs off the list.
+(check "cadddr passed off-end raises"
+       (raises? (lambda () (h1 cadddr (list 7 8)))) #t)
+(check "cadddr stored off-end raises"
+       (raises? (lambda () (h1 stored-cadddr (list 7 8)))) #t)
 
 (define string-value "hello")
 (define vector-value (vector 10 20 30))

--- a/tests/lists/list_star_test.esk
+++ b/tests/lists/list_star_test.esk
@@ -4,6 +4,14 @@
 
 (require stdlib)
 
+(define (check name expected actual)
+  (if (equal? expected actual)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (display "FAIL: ") (display name)
+             (display " -- expected ") (write expected)
+             (display ", got ") (write actual)
+             (newline))))
+
 (display "Testing list* function:")
 (newline)
 
@@ -29,6 +37,8 @@
 (define tail-after-third (cdr (cdr (cdr improper-list))))
 (display "Terminal (should be 99): ") (display tail-after-third)
 (newline)
+(check "list* scalar terminal stays scalar" 99 tail-after-third)
+(check "list* scalar terminal is not a pair" #f (pair? tail-after-third))
 
 ;; Test list* with proper list terminal
 (define mixed-list (list* 10 20 (list 30 40)))
@@ -38,8 +48,14 @@
 (newline)
 (display "Second: ") (display (cadr mixed-list))
 (newline)
+(define proper-list-terminal (cdr (cdr mixed-list)))
+(check "list* proper-list terminal remains a pair" #t (pair? proper-list-terminal))
 (display "Third: ") (display (caddr mixed-list))
 (newline)
+(check "list* direct caddr reaches proper-list terminal" 30 (caddr mixed-list))
+(check "list* explicit car/cdr reaches proper-list terminal"
+       30
+       (car (cdr (cdr mixed-list))))
 
 (display "List* test completed!")
 (newline)


### PR DESCRIPTION
Summary:
- make direct compound-accessor lowering raise on every non-pair intermediate instead of synthesizing the empty list
- make VM call-position and first-class compound accessors use the same catchable car/cdr contract
- add differential-by-construction off-end coverage for all 13 directly lowered compound accessors on both engines

Tests:
- ctest: 183/183 passed
- value_position_axis_sweep: 424 comparisons, 0 new findings
- vm-parity: 184 passed, 0 failed
- differential: 330/330 axis pairs agree across 55 programs