### PR TITLE
fix(jit): register nursery runtime helpers

### DIFF
--- a/lib/core/arena_memory.h
+++ b/lib/core/arena_memory.h
@@ -640,6 +640,14 @@ arena_tagged_cons_cell_t* region_escape_tagged_cons_cell(const arena_tagged_cons
 eshkol_tagged_value_t region_escape_tagged_value(eshkol_tagged_value_t val);
 void region_escape_tagged_value_into(eshkol_tagged_value_t* out, const eshkol_tagged_value_t* val);
 
+// Promote loop-carried values out of an automatic iteration nursery, then
+// recycle that nursery at the tail-call back edge.  The JIT registers this
+// explicitly because static host binaries do not expose it through dlsym on
+// every supported platform.
+void eshkol_iter_nursery_recycle(eshkol_region_t* region,
+                                 eshkol_tagged_value_t* vals,
+                                 uint64_t n);
+
 // Region write barrier (ESH-0214c): promote a value's in-region subgraph when it
 // is stored (by set-car!/set-cdr!/vector-set!/hash-table-set!/global set!) into a
 // destination that outlives the value's region. Fast path (no active region) is a

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -1018,6 +1018,11 @@ void ReplJITContext::registerRuntimeSymbols() {
     ADD_SYMBOL(arena_pop_scope);
     ADD_SYMBOL(arena_commit_scope);
     ADD_SYMBOL(eshkol_arena_iter_scope_end);
+    // ESH-0214e nursery lowering emits both helpers.  Static Windows hosts do
+    // not make them discoverable through the process symbol generator, so keep
+    // this explicit resolver closure in lockstep with the code generator.
+    ADD_SYMBOL(region_escape_tagged_value_into);
+    ADD_SYMBOL(eshkol_iter_nursery_recycle);
     ADD_SYMBOL(arena_reset);
     ADD_SYMBOL(arena_get_used_memory);
     ADD_SYMBOL(arena_get_total_memory);

--- a/tests/toolchain/release_workflow_surface_test.cpp
+++ b/tests/toolchain/release_workflow_surface_test.cpp
@@ -376,6 +376,18 @@ int main(int argc, char** argv) {
                          "cache-disabled package JIT reported a module-loading failure",
                          "package verifier fails closed on JIT module diagnostics");
 
+    // ESH-0214e's mutating-loop nursery lowering emits these two runtime calls.
+    // They must be in the manual map: process-wide lookup does not expose static
+    // runtime members from Windows hosts, and the package cache-disabled smoke
+    // intentionally makes that omission fatal.
+    ok = ok &&
+         expect_contains(repl_jit,
+                         "ADD_SYMBOL(region_escape_tagged_value_into);",
+                         "JIT registers the nursery result-escape helper") &&
+         expect_contains(repl_jit,
+                         "ADD_SYMBOL(eshkol_iter_nursery_recycle);",
+                         "JIT registers the nursery back-edge recycle helper");
+
     ok = ok &&
          expect_contains(repl_jit,
                          "static void configure_jit_target_machine_builder(",

--- a/tests/toolchain/windows-smoke.esk
+++ b/tests/toolchain/windows-smoke.esk
@@ -1,1 +1,16 @@
+;;; Forces ESH-0214e nursery lowering in the relocated, cache-disabled package
+;;; JIT smoke.  Keep the established output string: verify_release_package.py
+;;; checks it on every packaged platform.
+(define package-smoke-state (make-vector 1 0))
+
+(define (package-smoke-loop n)
+  (if (= n 0)
+      n
+      (begin
+        ;; A persistent structural mutation makes the automatic iter-scope
+        ;; analysis select the nursery path, which emits both runtime helpers.
+        (vector-set! package-smoke-state 0 (list n))
+        (package-smoke-loop (- n 1)))))
+
+(package-smoke-loop 1)
 (display "hello from windows smoke")


### PR DESCRIPTION
## Root cause

The v1.3.4 release dry run built and tested successfully, but all five Windows package lanes failed the relocated cache-disabled package JIT smoke because the JIT host did not explicitly expose region_escape_tagged_value_into. The same nursery lowering path also emits eshkol_iter_nursery_recycle, which was absent from both the registry and its public declaration.

## Fix

- explicitly register both nursery runtime helpers in ReplJITContext
- declare eshkol_iter_nursery_recycle in arena_memory.h
- make the Windows package smoke force ESH-0214e nursery lowering
- assert both registrations in the release workflow surface test

## Verification

- clean RelWithDebInfo configure and full 421-target Ninja build
- focused CTest: 6/6 passed
- cache-disabled windows-smoke.esk: passed with expected output
- ICC freshness: FRESH
- ICC pre-commit: PASS
- ICC guard-diff: PASS
- author and committer: tsotchkele@gmail.com

This PR does not create or push a release tag.