### PR TITLE
perf(dispatch): self-calibrate BLAS peak safely

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2445,12 +2445,18 @@ if(ESHKOL_BLAS_ENABLED AND BLAS_LIBRARIES)
 endif()
 
 if(ESHKOL_BUILD_TESTS AND ESHKOL_BLAS_ENABLED)
+    find_package(Threads REQUIRED)
+    add_executable(eshkol-blas-peak-calibration-test
+        tests/backend/blas_peak_calibration_test.cpp)
+    target_link_libraries(eshkol-blas-peak-calibration-test PRIVATE Threads::Threads)
     add_executable(eshkol-blas-provider-test
         tests/backend/blas_provider_test.cpp)
     target_include_directories(eshkol-blas-provider-test PRIVATE
         ${CMAKE_SOURCE_DIR}/inc)
     target_link_libraries(eshkol-blas-provider-test PRIVATE eshkol-runtime)
     if(BUILD_TESTING)
+        add_test(NAME blas-peak-calibration COMMAND eshkol-blas-peak-calibration-test)
+        set_tests_properties(blas-peak-calibration PROPERTIES TIMEOUT 30)
         add_test(NAME blas-provider COMMAND eshkol-blas-provider-test)
         set_tests_properties(blas-provider PROPERTIES TIMEOUT 30)
     endif()

--- a/lib/backend/blas_backend.cpp
+++ b/lib/backend/blas_backend.cpp
@@ -10,6 +10,11 @@
 #include "eshkol/logger.h"
 #include <cstdlib>
 
+#ifdef ESHKOL_BLAS_ENABLED
+#include "blas_peak_calibration.h"
+#include <chrono>
+#endif
+
 // Forward declarations for arena allocation (avoid full include to prevent type conflicts with XLA stubs)
 extern "C" {
     typedef struct arena arena_t;
@@ -66,12 +71,19 @@ struct CostModelParams {
     double simd_peak_gflops = 25;        // Peak throughput
     double simd_efficiency_scale = 1000; // Saturates quickly
 
-    // Calibration state
-    bool calibrated = false;
-    int sample_count = 0;
 };
 
 static CostModelParams g_cost_model;
+
+#ifdef ESHKOL_BLAS_ENABLED
+static eshkol::blas::detail::PeakCalibration g_blas_peak(
+    g_cost_model.blas_peak_gflops);
+
+// Ignore timer noise and undersaturated skinny GEMMs; calibration samples must
+// come from sufficiently large, well-shaped production BLAS work.
+constexpr size_t kCalibrationMinimumDimension = 128;
+constexpr double kCalibrationMinimumFlops = 10000000.0;
+#endif
 
 // GPU matmul threshold: override via ESHKOL_GPU_MATMUL_THRESHOLD env var
 // Default 1B elements — GPU only for super-massive matrices
@@ -111,7 +123,11 @@ inline DispatchCost estimate_matmul_cost(uint64_t M, uint64_t K, uint64_t N) {
 
     // BLAS: good for medium-large matrices, has fixed overhead
     double blas_efficiency = std::min(1.0, elements / p.blas_efficiency_scale);
-    double blas_compute = flops / (p.blas_peak_gflops * blas_efficiency * 1e9) * 1e9;
+    double blas_peak = p.blas_peak_gflops;
+#ifdef ESHKOL_BLAS_ENABLED
+    blas_peak = g_blas_peak.effective();
+#endif
+    double blas_compute = flops / (blas_peak * blas_efficiency * 1e9) * 1e9;
     double blas_ns = p.blas_overhead_ns + blas_compute;
 
     // GPU: high overhead but massive parallelism for large matrices
@@ -169,6 +185,9 @@ struct CostModelInitializer {
     CostModelInitializer() {
         if (const char* env = std::getenv("ESHKOL_BLAS_PEAK_GFLOPS")) {
             g_cost_model.blas_peak_gflops = std::atof(env);
+#ifdef ESHKOL_BLAS_ENABLED
+            g_blas_peak.override(g_cost_model.blas_peak_gflops);
+#endif
         }
         if (const char* env = std::getenv("ESHKOL_GPU_PEAK_GFLOPS")) {
             g_cost_model.gpu_peak_gflops = std::atof(env);
@@ -256,6 +275,15 @@ void matmul(const double* A, const double* B, double* C,
     // Simple C = A * B (no transpose, alpha=1, beta=0)
     // A is M x K, B is K x N, C is M x N
     // All row-major
+    const double flops = 2.0 * static_cast<double>(M) *
+                         static_cast<double>(K) * static_cast<double>(N);
+    const bool calibrate = g_blas_peak.enabled() &&
+                           M >= kCalibrationMinimumDimension &&
+                           K >= kCalibrationMinimumDimension &&
+                           N >= kCalibrationMinimumDimension &&
+                           flops >= kCalibrationMinimumFlops;
+    const auto start = calibrate ? std::chrono::steady_clock::now()
+                                 : std::chrono::steady_clock::time_point{};
     cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
                 static_cast<int>(M), static_cast<int>(N), static_cast<int>(K),
                 1.0,  // alpha
@@ -263,6 +291,13 @@ void matmul(const double* A, const double* B, double* C,
                 B, static_cast<int>(N),   // ldb = N for row-major B[K][N]
                 0.0,  // beta
                 C, static_cast<int>(N));  // ldc = N for row-major C[M][N]
+    if (calibrate) {
+        const double seconds = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - start).count();
+        if (seconds > 0.0) {
+            g_blas_peak.record(flops / seconds / 1e9);
+        }
+    }
 }
 
 // Matmul backward: given C = A @ B, accumulate gradients dA and dB

--- a/lib/backend/blas_peak_calibration.h
+++ b/lib/backend/blas_peak_calibration.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <atomic>
+#include <cmath>
+
+namespace eshkol::blas::detail {
+
+// Process-wide BLAS throughput calibration.  The configured peak is a
+// deterministic fallback; successful observations form a separate monotonic
+// high-water mark so the first real sample can be below (and replace) it.
+class PeakCalibration {
+public:
+    explicit PeakCalibration(double fallback) : fallback_(fallback) {}
+
+    void disable() {
+        enabled_.store(false, std::memory_order_relaxed);
+    }
+
+    bool enabled() const {
+        return enabled_.load(std::memory_order_relaxed);
+    }
+
+    // An explicit operator override is authoritative for the process.
+    void override(double fallback) {
+        fallback_.store(fallback, std::memory_order_relaxed);
+        disable();
+    }
+
+    bool record(double sample) {
+        if (!enabled() || !std::isfinite(sample) || sample <= 0.0) {
+            return false;
+        }
+
+        samples_.fetch_add(1, std::memory_order_relaxed);
+        double current = measured_.load(std::memory_order_relaxed);
+        while (sample > current &&
+               !measured_.compare_exchange_weak(
+                   current, sample, std::memory_order_relaxed,
+                   std::memory_order_relaxed)) {
+        }
+        return true;
+    }
+
+    double effective() const {
+        const double measured = measured_.load(std::memory_order_relaxed);
+        if (enabled() && measured > 0.0) {
+            return measured;
+        }
+        return fallback_.load(std::memory_order_relaxed);
+    }
+
+    unsigned samples() const {
+        return samples_.load(std::memory_order_relaxed);
+    }
+
+private:
+    std::atomic<double> fallback_;
+    std::atomic<double> measured_{0.0};
+    std::atomic<unsigned> samples_{0};
+    std::atomic<bool> enabled_{true};
+};
+
+}  // namespace eshkol::blas::detail

--- a/tests/backend/blas_peak_calibration_test.cpp
+++ b/tests/backend/blas_peak_calibration_test.cpp
@@ -1,0 +1,81 @@
+#include "../../lib/backend/blas_peak_calibration.h"
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <thread>
+#include <vector>
+
+namespace {
+
+bool expect(bool condition, const char* message) {
+    if (!condition) {
+        std::fprintf(stderr, "FAIL: %s\n", message);
+        return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+int main() {
+    using eshkol::blas::detail::PeakCalibration;
+
+    PeakCalibration calibration(1100.0);
+    if (!expect(calibration.effective() == 1100.0, "fallback is effective before samples") ||
+        !expect(calibration.record(405.0), "first valid sample is recorded") ||
+        !expect(calibration.effective() == 405.0,
+                "first sample below fallback replaces fallback") ||
+        !expect(calibration.record(300.0), "lower valid sample is recorded") ||
+        !expect(calibration.effective() == 405.0,
+                "lower sample does not reduce high-water") ||
+        !expect(calibration.record(750.0), "higher valid sample is recorded") ||
+        !expect(calibration.effective() == 750.0,
+                "higher sample raises high-water")) {
+        return 1;
+    }
+
+    const unsigned valid_samples = calibration.samples();
+    if (!expect(!calibration.record(std::numeric_limits<double>::quiet_NaN()),
+                "NaN sample is rejected") ||
+        !expect(!calibration.record(std::numeric_limits<double>::infinity()),
+                "infinite sample is rejected") ||
+        !expect(!calibration.record(0.0), "zero sample is rejected") ||
+        !expect(!calibration.record(-1.0), "negative sample is rejected") ||
+        !expect(calibration.samples() == valid_samples,
+                "invalid samples do not change sample count")) {
+        return 1;
+    }
+
+    calibration.override(42.0);
+    if (!expect(!calibration.enabled(), "override disables calibration") ||
+        !expect(calibration.effective() == 42.0,
+                "override fallback is authoritative after samples") ||
+        !expect(!calibration.record(1000.0), "samples after override are rejected") ||
+        !expect(calibration.samples() == valid_samples,
+                "rejected override sample does not change count")) {
+        return 1;
+    }
+
+    constexpr int kWriterCount = 16;
+    PeakCalibration concurrent(1.0);
+    std::vector<std::thread> writers;
+    writers.reserve(kWriterCount);
+    for (int value = 1; value <= kWriterCount; ++value) {
+        writers.emplace_back([&concurrent, value] {
+            concurrent.record(static_cast<double>(value));
+        });
+    }
+    for (auto& writer : writers) {
+        writer.join();
+    }
+
+    if (!expect(concurrent.effective() == static_cast<double>(kWriterCount),
+                "concurrent writers retain the exact maximum") ||
+        !expect(concurrent.samples() == static_cast<unsigned>(kWriterCount),
+                "concurrent valid writers retain the exact sample count")) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/tests/backend/blas_provider_test.cpp
+++ b/tests/backend/blas_provider_test.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <vector>
 
 namespace {
 
@@ -81,6 +82,17 @@ int main() {
     daxpy(3, 0.5, sx, 2, sy, 2);
     const double expected_sy[] = {5, 7, 9};
     ok = expect_vector("daxpy stride", sy, expected_sy, 3, 2) && ok;
+    constexpr size_t calibration_dimension = 192;
+    const double calibration_expected = static_cast<double>(calibration_dimension);
+    std::vector<double> large_a(calibration_dimension * calibration_dimension, 1.0);
+    std::vector<double> large_b(calibration_dimension * calibration_dimension, 1.0);
+    std::vector<double> large_c(calibration_dimension * calibration_dimension, 0.0);
+    matmul(large_a.data(), large_b.data(), large_c.data(), calibration_dimension,
+           calibration_dimension, calibration_dimension);
+    const double calibration_actual[] = {large_c.front(), large_c.back()};
+    const double calibration_expected_values[] = {calibration_expected, calibration_expected};
+    ok = expect_vector("matmul calibration-sized result", calibration_actual,
+                       calibration_expected_values, 2) && ok;
 
     if (!ok) return 1;
     std::printf("BLAS provider (%s): PASS\n", getBackendName());

--- a/tests/gpu/ozaki_certification_gate.sh
+++ b/tests/gpu/ozaki_certification_gate.sh
@@ -47,13 +47,28 @@ fi
 
 otool -L "$BIN" | grep -q '/Accelerate\.framework/' || fail "eshkol-run is not linked against Accelerate"
 
-TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-ozaki-certification.XXXXXX")"
-cleanup_tmp() {
-    if [ -n "${TMP_DIR:-}" ] && [ -d "$TMP_DIR" ]; then
-        rm -rf "$TMP_DIR"
-    fi
-}
-trap cleanup_tmp EXIT
+if [ -n "${ESHKOL_OZAKI_WORK_DIR:-}" ]; then
+    case "$ESHKOL_OZAKI_WORK_DIR" in
+        /*) ;;
+        *) fail "ESHKOL_OZAKI_WORK_DIR must be an absolute path" ;;
+    esac
+    [ ! -e "$ESHKOL_OZAKI_WORK_DIR" ] && [ ! -L "$ESHKOL_OZAKI_WORK_DIR" ] || \
+        fail "ESHKOL_OZAKI_WORK_DIR already exists: $ESHKOL_OZAKI_WORK_DIR"
+    OZAKI_WORK_PARENT="$(dirname "$ESHKOL_OZAKI_WORK_DIR")"
+    [ -d "$OZAKI_WORK_PARENT" ] || \
+        fail "ESHKOL_OZAKI_WORK_DIR parent does not exist: $OZAKI_WORK_PARENT"
+    mkdir "$ESHKOL_OZAKI_WORK_DIR" || \
+        fail "could not create ESHKOL_OZAKI_WORK_DIR: $ESHKOL_OZAKI_WORK_DIR"
+    TMP_DIR="$ESHKOL_OZAKI_WORK_DIR"
+else
+    TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-ozaki-certification.XXXXXX")"
+    cleanup_tmp() {
+        if [ -n "${TMP_DIR:-}" ] && [ -d "$TMP_DIR" ]; then
+            rm -rf "$TMP_DIR"
+        fi
+    }
+    trap cleanup_tmp EXIT
+fi
 JIT_CACHE_BLAS_DIR="$TMP_DIR/jit-cache-blas"
 JIT_CACHE_EXACT_DIR="$TMP_DIR/jit-cache-exact"
 mkdir -p "$JIT_CACHE_BLAS_DIR" "$JIT_CACHE_EXACT_DIR"


### PR DESCRIPTION
## What

Integrates the intended performance contribution from #306 onto current master while preserving Richard Hoekstra as co-author.

- measures sufficiently large real cblas_dgemm calls and feeds a monotonic observed GFLOP/s high-water into adaptive dispatch
- uses relaxed atomics for race-free concurrent sampling
- keeps ESHKOL_BLAS_PEAK_GFLOPS authoritative and disables calibration/timing when it is set
- excludes undersized and skinny GEMMs from timing noise
- compile-isolates calibration from no-BLAS and WebAssembly builds
- adds direct fallback, invalid-sample, override, and concurrent-writer tests
- exercises the production timed wrapper with a 192-cubed provider case
- adds an opt-in durable Ozaki gate work directory while preserving the existing default behavior

## Why a successor PR

GitHub currently renders #306 from a stale fork topology as 1,716 commits and 3,287 changed files. Merging that branch directly would be unsafe. This branch ports the intended 2d138758 change onto current master, hardens it, and retains contributor credit.

## Local validation

- focused BLAS calibration/provider CTest: 2/2 passed
- no-BLAS compile surface: passed
- ICC guard and pre-commit: passed
- ICC full index, memory, graph, search, and substrate stores: fresh at ac9f7d37
- branch author and committer: tsotchkele@gmail.com

The actual Ozaki gate BLAS JIT/AOT contract passes. Its exact Metal lane is currently unavailable on this host; an unchanged pre-#306 binary fails that lane identically in a same-session control run, so this is not attributed to the patch. Required cross-platform CI remains the merge gate.

Supersedes the unsafe branch topology of #306; after this PR lands, #306 can be closed as integrated.