### PR TITLE
build(release): support durable final-gate evidence roots

### DIFF
--- a/scripts/lib/durable_work_root.sh
+++ b/scripts/lib/durable_work_root.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Optional deterministic evidence roots for release gates.
+#
+# A caller that sets ESHKOL_DURABLE_WORK_ROOT opts out of ephemeral scratch
+# space.  Each gate must claim a unique direct child through
+# eshkol_durable_prepare_dir; claiming an existing child is an error so a
+# release run cannot accidentally consume stale evidence.  The caller owns the
+# root itself and may use one root for a complete battery.
+
+eshkol_durable_enabled() {
+    [ -n "${ESHKOL_DURABLE_WORK_ROOT:-}" ]
+}
+
+eshkol_durable_validate_root() {
+    local root="${ESHKOL_DURABLE_WORK_ROOT:-}" parent
+    case "$root" in
+        /*) ;;
+        *) echo "ESHKOL_DURABLE_WORK_ROOT must be an absolute path" >&2; return 2 ;;
+    esac
+    if [ "$root" = / ] || [ -L "$root" ]; then
+        echo "ESHKOL_DURABLE_WORK_ROOT must name a non-symlink directory other than /" >&2
+        return 2
+    fi
+    if [ -e "$root" ] && [ ! -d "$root" ]; then
+        echo "ESHKOL_DURABLE_WORK_ROOT is not a directory: $root" >&2
+        return 2
+    fi
+    if [ ! -e "$root" ]; then
+        parent="$(dirname "$root")"
+        if [ ! -d "$parent" ] || [ -L "$parent" ]; then
+            echo "ESHKOL_DURABLE_WORK_ROOT parent must be an existing, non-symlink directory: $parent" >&2
+            return 2
+        fi
+        mkdir "$root" || return $?
+    fi
+}
+
+eshkol_durable_prepare_dir() { # gate-name
+    local gate="$1" target
+    eshkol_durable_validate_root || return $?
+    case "$gate" in
+        *[!A-Za-z0-9._-]*|'') echo "invalid durable gate name: $gate" >&2; return 2 ;;
+    esac
+    target="${ESHKOL_DURABLE_WORK_ROOT}/${gate}"
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        echo "durable evidence target already exists: $target" >&2
+        return 2
+    fi
+    mkdir "$target" || return $?
+    printf '%s\n' "$target"
+}
+
+eshkol_durable_file() { # claimed-directory basename
+    local dir="$1" name="$2" target
+    case "$name" in
+        *[!A-Za-z0-9._-]*|'') echo "invalid durable evidence file name: $name" >&2; return 2 ;;
+    esac
+    target="$dir/$name"
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        echo "durable evidence file already exists: $target" >&2
+        return 2
+    fi
+    printf '%s\n' "$target"
+}

--- a/scripts/lib/test_isolation.sh
+++ b/scripts/lib/test_isolation.sh
@@ -163,6 +163,12 @@ eshkol_test_isolation_cleanup() {
     local dir="${ESHKOL_TEST_TMPDIR:-}"
     [ -n "$dir" ] || return 0
 
+    # Durable release evidence is caller-owned and intentionally retained.
+    if [ -n "${ESHKOL_DURABLE_WORK_ROOT:-}" ]; then
+        echo "test_isolation: retaining durable scratch directory: $dir" >&2
+        return 0
+    fi
+
     # Debugging escape hatch: keep this run's logs and binaries for inspection.
     # Off by default so the disk budget holds in CI.
     if [ -n "${ESHKOL_TEST_KEEP_TMPDIR:-}" ]; then
@@ -200,19 +206,31 @@ eshkol_test_isolation_init() {
 
     repo_root="$(eshkol_test_repo_root)" \
         || eshkol_test_isolation_fail "cannot resolve repo root"
-    root="$(eshkol_test_tmp_root)"
-    [ -d "$root" ] || mkdir -p -- "$root" 2>/dev/null || true
-    [ -d "$root" ] || eshkol_test_isolation_fail "temp root is not a directory: $root"
 
     ESHKOL_TEST_REPO_ROOT="$repo_root"
     ESHKOL_TEST_REPO_TAG="$(eshkol_test_digest "$repo_root")"
 
-    eshkol_test_isolation_prune_stale
+    if [ -n "${ESHKOL_DURABLE_WORK_ROOT:-}" ]; then
+        # The durable root is shared by top-level release gates.  Prefixing this
+        # child separates a suite's scratch from its parent gate (for example,
+        # language-coverage vs test-isolation-language-coverage-<repo-tag>).
+        # The helper rejects a repeated child, so stale evidence cannot be reused.
+        # shellcheck source=durable_work_root.sh
+        source "$repo_root/scripts/lib/durable_work_root.sh"
+        ESHKOL_TEST_TMPDIR="$(eshkol_durable_prepare_dir \
+            "test-isolation-${label}-${ESHKOL_TEST_REPO_TAG}")" \
+            || eshkol_test_isolation_fail "failed to claim durable scratch directory"
+    else
+        root="$(eshkol_test_tmp_root)"
+        [ -d "$root" ] || mkdir -p -- "$root" 2>/dev/null || true
+        [ -d "$root" ] || eshkol_test_isolation_fail "temp root is not a directory: $root"
+        eshkol_test_isolation_prune_stale
 
-    # mktemp -d gives the per-invocation uniqueness; the repo tag makes the name
-    # say which checkout it belongs to, so a stray directory is attributable.
-    ESHKOL_TEST_TMPDIR="$(mktemp -d "$root/eshkol-test.$label.$ESHKOL_TEST_REPO_TAG.XXXXXX")" \
-        || eshkol_test_isolation_fail "failed to create scratch directory under $root"
+        # mktemp -d gives the per-invocation uniqueness; the repo tag makes the name
+        # say which checkout it belongs to, so a stray directory is attributable.
+        ESHKOL_TEST_TMPDIR="$(mktemp -d "$root/eshkol-test.$label.$ESHKOL_TEST_REPO_TAG.XXXXXX")" \
+            || eshkol_test_isolation_fail "failed to create scratch directory under $root"
+    fi
 
     # Basename stays a.out on purpose — see the header note.
     ESHKOL_TEST_BIN="$ESHKOL_TEST_TMPDIR/a.out"

--- a/scripts/p8/p8_fault_injection.sh
+++ b/scripts/p8/p8_fault_injection.sh
@@ -34,6 +34,7 @@ set -u
 export LC_ALL=C LC_CTYPE=C LANG=C
 cd "$(dirname "$0")/../.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
 BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
 QUICK=0
 while [ $# -gt 0 ]; do
@@ -54,10 +55,14 @@ TRACE_DIR="$REPO_ROOT/scripts/icc_traces"
 TRACE_FILE="$TRACE_DIR/escape_matrix.jsonl"
 mkdir -p "$TRACE_DIR"
 
-WORK="$(mktemp -d "${TMPDIR:-/tmp}/p8-fault.XXXXXX")"
-# Disk cap + guaranteed cleanup (fuzz/harness disk-budget policy).
-cleanup() { chmod -R u+rwx "$WORK" 2>/dev/null; rm -rf "$WORK"; }
-trap cleanup EXIT
+if eshkol_durable_enabled; then
+  WORK="$(eshkol_durable_prepare_dir p8-fault-injection)" || exit $?
+else
+  WORK="$(mktemp -d "${TMPDIR:-/tmp}/p8-fault.XXXXXX")"
+  # Disk cap + guaranteed cleanup (fuzz/harness disk-budget policy).
+  cleanup() { chmod -R u+rwx "$WORK" 2>/dev/null; rm -rf "$WORK"; }
+  trap cleanup EXIT
+fi
 export ESHKOL_JIT_CACHE_DIR="$WORK/jit"; mkdir -p "$ESHKOL_JIT_CACHE_DIR"
 
 emit() { # id status snippet

--- a/scripts/p8/p8_mem_profiles.sh
+++ b/scripts/p8/p8_mem_profiles.sh
@@ -30,6 +30,7 @@ set -u
 export LC_ALL=C LC_CTYPE=C LANG=C
 cd "$(dirname "$0")/../.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
 BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
 QUICK=0; TABLE=""
 while [ $# -gt 0 ]; do
@@ -46,8 +47,12 @@ ESHKOL_RUN="$BUILD_DIR/eshkol-run"
 
 TRACE_DIR="$REPO_ROOT/scripts/icc_traces"; mkdir -p "$TRACE_DIR"
 TRACE_FILE="$TRACE_DIR/escape_matrix.jsonl"
-WORK="$(mktemp -d "${TMPDIR:-/tmp}/p8-mem.XXXXXX")"
-trap 'rm -rf "$WORK"' EXIT
+if eshkol_durable_enabled; then
+  WORK="$(eshkol_durable_prepare_dir p8-mem-profiles)" || exit $?
+else
+  WORK="$(mktemp -d "${TMPDIR:-/tmp}/p8-mem.XXXXXX")"
+  trap 'rm -rf "$WORK"' EXIT
+fi
 export ESHKOL_JIT_CACHE_DIR="$WORK/jit"; mkdir -p "$ESHKOL_JIT_CACHE_DIR"
 
 # small / large iteration counts (large = 10x small -> flat RSS if reclaimed).

--- a/scripts/run_ad_adversarial.sh
+++ b/scripts/run_ad_adversarial.sh
@@ -40,7 +40,7 @@ cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
 . "$REPO_ROOT/scripts/lib/durable_work_root.sh"
 if eshkol_durable_enabled; then
-    ADV_WORK="$(eshkol_durable_prepare_dir ad-adversarial)"
+    ADV_WORK="$(eshkol_durable_prepare_dir ad-adversarial)" || exit $?
 fi
 GEN_DIR="$REPO_ROOT/tests/ad_adversarial/generated"
 if eshkol_durable_enabled; then
@@ -205,7 +205,7 @@ for path in "$GEN_DIR"/ad_adv_*.esk; do
 
     if [ "$DO_AOT" -eq 1 ]; then
         if eshkol_durable_enabled; then
-            bin="$(eshkol_durable_file "$ADV_WORK" "ad_adv_${base}.bin")"
+            bin="$(eshkol_durable_file "$ADV_WORK" "ad_adv_${base}.bin")" || exit $?
         else
             bin="${TMPDIR:-/tmp}/ad_adv_${base}.bin"; rm -f "$bin"
         fi
@@ -244,7 +244,7 @@ if [ "${ESHKOL_QUANTUM_ENABLED:-OFF}" = "ON" ]; then
 
     if [ "$DO_AOT" -eq 1 ]; then
         if eshkol_durable_enabled; then
-            qbin="$(eshkol_durable_file "$ADV_WORK" "ad_adv_${quantum_base}.bin")"
+            qbin="$(eshkol_durable_file "$ADV_WORK" "ad_adv_${quantum_base}.bin")" || exit $?
         else
             qbin="${TMPDIR:-/tmp}/ad_adv_${quantum_base}.bin"; rm -f "$qbin"
         fi

--- a/scripts/run_ad_adversarial.sh
+++ b/scripts/run_ad_adversarial.sh
@@ -38,8 +38,16 @@ set -u
 export LC_ALL=C LC_CTYPE=C LANG=C
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
+if eshkol_durable_enabled; then
+    ADV_WORK="$(eshkol_durable_prepare_dir ad-adversarial)"
+fi
 GEN_DIR="$REPO_ROOT/tests/ad_adversarial/generated"
-TRACE_DIR="$REPO_ROOT/scripts/icc_traces"
+if eshkol_durable_enabled; then
+    TRACE_DIR="${TRACE_DIR:-$ADV_WORK/traces}"
+else
+    TRACE_DIR="$REPO_ROOT/scripts/icc_traces"
+fi
 TRACE_FILE="$TRACE_DIR/ad_adversarial.jsonl"
 mkdir -p "$TRACE_DIR"
 : "${TRACE_FILE:?}"; : > "$TRACE_FILE"
@@ -48,9 +56,14 @@ mkdir -p "$TRACE_DIR"
 # previous file must never mask a regression, and a fresh cache avoids the
 # intermittent cross-file JIT crash noted below.
 if [ -z "${ESHKOL_JIT_CACHE_DIR:-}" ]; then
-    ADV_JIT_CACHE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/eshkol-ad-adversarial-cache.XXXXXX")
+    if eshkol_durable_enabled; then
+        ADV_JIT_CACHE_DIR="$ADV_WORK/jit-cache"
+        mkdir "$ADV_JIT_CACHE_DIR"
+    else
+        ADV_JIT_CACHE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/eshkol-ad-adversarial-cache.XXXXXX")
+    fi
     export ESHKOL_JIT_CACHE_DIR="$ADV_JIT_CACHE_DIR"
-    trap 'rm -rf "$ADV_JIT_CACHE_DIR"' EXIT
+    if ! eshkol_durable_enabled; then trap 'rm -rf "$ADV_JIT_CACHE_DIR"' EXIT; fi
 else
     mkdir -p "$ESHKOL_JIT_CACHE_DIR"
 fi
@@ -191,7 +204,11 @@ for path in "$GEN_DIR"/ad_adv_*.esk; do
     fi
 
     if [ "$DO_AOT" -eq 1 ]; then
-        bin="${TMPDIR:-/tmp}/ad_adv_${base}.bin"; rm -f "$bin"
+        if eshkol_durable_enabled; then
+            bin="$(eshkol_durable_file "$ADV_WORK" "ad_adv_${base}.bin")"
+        else
+            bin="${TMPDIR:-/tmp}/ad_adv_${base}.bin"; rm -f "$bin"
+        fi
         cout=$(run_guarded "$AOT_COMPILE_TIMEOUT" "$ESHKOL_RUN" "$path" "$LIBFLAG" -o "$bin" 2>&1); crc=$?
         if [ "$crc" -ne 0 ] || [ ! -x "$bin" ] || printf '%s' "$cout" | grep -qE \
             "Failed to generate LLVM IR|LLVM module verification failed"; then
@@ -203,7 +220,7 @@ for path in "$GEN_DIR"/ad_adv_*.esk; do
                 printf '%s\n' "$aout" | grep -E '^FAIL:' | head -6 | sed 's/^/         /'
             fi
         fi
-        rm -f "$bin"
+        if ! eshkol_durable_enabled; then rm -f "$bin"; fi
         count_verdict "$av" "tests/ad_adversarial/generated/$f" "aot"
     fi
 done
@@ -226,7 +243,11 @@ if [ "${ESHKOL_QUANTUM_ENABLED:-OFF}" = "ON" ]; then
     fi
 
     if [ "$DO_AOT" -eq 1 ]; then
-        qbin="${TMPDIR:-/tmp}/ad_adv_${quantum_base}.bin"; rm -f "$qbin"
+        if eshkol_durable_enabled; then
+            qbin="$(eshkol_durable_file "$ADV_WORK" "ad_adv_${quantum_base}.bin")"
+        else
+            qbin="${TMPDIR:-/tmp}/ad_adv_${quantum_base}.bin"; rm -f "$qbin"
+        fi
         qcout=$(run_guarded "$AOT_COMPILE_TIMEOUT" "$ESHKOL_RUN" "$quantum_path" "$LIBFLAG" -o "$qbin" 2>&1); qcrc=$?
         if [ "$qcrc" -ne 0 ] || [ ! -x "$qbin" ] || printf '%s' "$qcout" | grep -qE \
             "Failed to generate LLVM IR|LLVM module verification failed"; then
@@ -238,7 +259,7 @@ if [ "${ESHKOL_QUANTUM_ENABLED:-OFF}" = "ON" ]; then
                 printf '%s\n' "$qaout" | grep -E '^FAIL:' | head -6 | sed 's/^/         /'
             fi
         fi
-        rm -f "$qbin"
+        if ! eshkol_durable_enabled; then rm -f "$qbin"; fi
         count_verdict "$qav" "$quantum_label" "aot"
     fi
 else

--- a/scripts/run_engine_parity_coverage.py
+++ b/scripts/run_engine_parity_coverage.py
@@ -58,7 +58,7 @@ Gate
 
 Usage:
   scripts/run_engine_parity_coverage.py [--update-baseline] [--corpus GLOB]
-                                        [--limit N] [--json OUT]
+                                        [--limit N] [--json OUT] [--workdir DIR]
 Exit: 0 green, 1 red, 2 misuse/environment.
 """
 
@@ -103,6 +103,19 @@ NOISE = re.compile(
 def die(msg):
     sys.stderr.write("run_engine_parity_coverage: %s\n" % msg)
     sys.exit(2)
+
+
+def require_empty_workdir(path):
+    """Validate a caller-owned durable directory before writing traces."""
+    if not os.path.isabs(path):
+        raise ValueError("--workdir must be an absolute path")
+    if os.path.islink(path):
+        raise ValueError("--workdir must not be a symlink: %s" % path)
+    if not os.path.isdir(path):
+        raise ValueError("--workdir must be a caller-created directory: %s" % path)
+    if os.listdir(path):
+        raise ValueError("--workdir must be empty: %s" % path)
+    return path
 
 
 def normalise(text):
@@ -168,7 +181,15 @@ def main():
     ap.add_argument("--limit", type=int, default=0)
     ap.add_argument("--timeout", type=int, default=120)
     ap.add_argument("--json", default=None)
+    ap.add_argument("--workdir",
+                    help="empty caller-created absolute directory retaining coverage traces")
     args = ap.parse_args()
+
+    if args.workdir is not None:
+        try:
+            args.workdir = require_empty_workdir(args.workdir)
+        except ValueError as exc:
+            die(str(exc))
 
     for path, what in ((ESHKOL_RUN, "eshkol-run"), (VM_BIN, "the VM binary")):
         if not os.path.exists(path):
@@ -224,7 +245,7 @@ def main():
     both_ran_now = []
     native_only, both_ran = 0, 0
 
-    for prog in programs:
+    for program_number, prog in enumerate(programs, 1):
         rel = os.path.relpath(prog, REPO)
         # Phase 1 — PRODUCTION conditions, no instrumentation: this decides
         # agreement.
@@ -241,14 +262,28 @@ def main():
                                      args.timeout)
         # Phase 2 — instrumented, for construct attribution only. Its output
         # is deliberately discarded.
-        with tempfile.TemporaryDirectory() as nd, \
-                tempfile.TemporaryDirectory() as vd:
+        if args.workdir:
+            nd = os.path.join(args.workdir,
+                              "program-%04d-native-trace" % program_number)
+            vd = os.path.join(args.workdir,
+                              "program-%04d-vm-trace" % program_number)
+            os.mkdir(nd)
+            os.mkdir(vd)
             run_engine([ESHKOL_RUN, "-r"], prog, nd,
                        {"ESHKOL_JIT_CACHE": "0"}, args.timeout)
             run_engine([VM_BIN], prog, vd,
                        {"ESHKOL_VM_NO_DISASM": "1"}, args.timeout)
             n_constructs = read_constructs(nd)
             v_constructs = read_constructs(vd)
+        else:
+            with tempfile.TemporaryDirectory() as nd, \
+                    tempfile.TemporaryDirectory() as vd:
+                run_engine([ESHKOL_RUN, "-r"], prog, nd,
+                           {"ESHKOL_JIT_CACHE": "0"}, args.timeout)
+                run_engine([VM_BIN], prog, vd,
+                           {"ESHKOL_VM_NO_DISASM": "1"}, args.timeout)
+                n_constructs = read_constructs(nd)
+                v_constructs = read_constructs(vd)
 
         if nrc != 0:
             # Native is the reference; a program native cannot run says

--- a/scripts/run_generative_differential.py
+++ b/scripts/run_generative_differential.py
@@ -63,6 +63,7 @@ generative_differential_oracle probe in scripts/run_icc_smoke.sh.
 Usage:
   scripts/run_generative_differential.py [--seed N] [--count K] [--depth D]
       [--baseline FILE] [--smoke] [--no-vm] [--timeout SECS] [--jobs N]
+      [--workdir DIR]
 """
 
 import argparse
@@ -90,6 +91,19 @@ CHIBI_PROLOGUE = ("(import (scheme base) (scheme write) (scheme char) "
 # crash/timeout is captured as a normal result. Populate only if a specific
 # generated program is observed to defeat the timeout.
 KNOWN_CRASHERS = {}
+
+
+def require_empty_workdir(path):
+    """Validate a caller-owned durable directory before writing evidence."""
+    if not os.path.isabs(path):
+        raise ValueError("--workdir must be an absolute path")
+    if os.path.islink(path):
+        raise ValueError("--workdir must not be a symlink: %s" % path)
+    if not os.path.isdir(path):
+        raise ValueError("--workdir must be a caller-created directory: %s" % path)
+    if os.listdir(path):
+        raise ValueError("--workdir must be empty: %s" % path)
+    return path
 
 
 # VM banner / loader / compiler-noise lines to drop before comparison. Mirrors
@@ -180,7 +194,10 @@ class Harness:
         self.vm_bin = vm
         self.chibi = shutil.which("chibi-scheme")
         self.timeout = args.timeout
-        self.work = tempfile.mkdtemp(prefix="eshkol-gendiff.")
+        self.durable_workdir = args.workdir is not None
+        self.work = (require_empty_workdir(args.workdir)
+                     if self.durable_workdir
+                     else tempfile.mkdtemp(prefix="eshkol-gendiff."))
         self.esk = os.path.join(self.work, "prog.esk")
         self.scm = os.path.join(self.work, "prog.scm")
         self.bin = os.path.join(self.work, "prog.bin")
@@ -190,11 +207,13 @@ class Harness:
         # Which oracles participate.
         self.use_vm = (not args.no_vm) and os.path.exists(self.vm_bin)
         self.use_chibi = (not args.no_chibi) and self.chibi is not None
-        self.art = os.path.join(REPO_ROOT, "artifacts", "generative-diff")
+        self.art = (self.work if self.durable_workdir
+                    else os.path.join(REPO_ROOT, "artifacts", "generative-diff"))
         self.diverg_dir = os.path.join(self.art, "divergences")
 
     def cleanup(self):
-        shutil.rmtree(self.work, ignore_errors=True)
+        if not self.durable_workdir:
+            shutil.rmtree(self.work, ignore_errors=True)
 
     # ---- individual oracle runners ---------------------------------------
     def run_chibi(self, body):
@@ -221,22 +240,24 @@ class Harness:
         r = OracleResult("aot-%s" % opt)
         with open(self.esk, "w") as fh:
             fh.write(body)
-        if os.path.exists(self.bin):
+        bin_path = (os.path.join(self.work, "prog.%s.bin" % opt)
+                    if self.durable_workdir else self.bin)
+        if not self.durable_workdir and os.path.exists(bin_path):
             os.remove(self.bin)
         crc, cout, cerr, cto = _run(
-            [self.eshkol, "-%s" % opt, self.esk, "-o", self.bin], self.timeout)
+            [self.eshkol, "-%s" % opt, self.esk, "-o", bin_path], self.timeout)
         if cto:
             r.timed_out = True
             r.err = cerr
             return r
-        if crc != 0 or not os.path.exists(self.bin):
+        if crc != 0 or not os.path.exists(bin_path):
             r.compile_failed = True
             r.rc = crc
             r.err = cerr + cout
             return r
-        r.rc, r.out, r.err, r.timed_out = _run([self.bin], self.timeout)
-        if os.path.exists(self.bin):
-            os.remove(self.bin)
+        r.rc, r.out, r.err, r.timed_out = _run([bin_path], self.timeout)
+        if not self.durable_workdir and os.path.exists(bin_path):
+            os.remove(bin_path)
         return r
 
     def run_vm(self, body):
@@ -246,7 +267,7 @@ class Harness:
             return r
         with open(self.esk, "w") as fh:
             fh.write(body)
-        if os.path.exists(self.eskb):
+        if not self.durable_workdir and os.path.exists(self.eskb):
             os.remove(self.eskb)
         crc, cout, cerr, cto = _run(
             [self.eshkol, "--profile", "hosted-vm", "--emit-eskb", self.eskb, self.esk],
@@ -426,8 +447,16 @@ def main():
     ap.add_argument("--smoke", action="store_true",
                     help="fast reduced run (seed=1234 count=12) for CI probes")
     ap.add_argument("--trace-dir", default=os.path.join(REPO_ROOT, "scripts", "icc_traces"))
+    ap.add_argument("--workdir",
+                    help="empty caller-created absolute directory retaining run artifacts")
     ap.add_argument("--quiet", action="store_true")
     args = ap.parse_args()
+
+    if args.workdir is not None:
+        try:
+            args.workdir = require_empty_workdir(args.workdir)
+        except ValueError as exc:
+            ap.error(str(exc))
 
     if args.smoke:
         args.count = min(args.count, 12)
@@ -444,7 +473,8 @@ def main():
     open(trace_file, "w").close()
 
     h = Harness(args)
-    shutil.rmtree(h.diverg_dir, ignore_errors=True)
+    if not h.durable_workdir:
+        shutil.rmtree(h.diverg_dir, ignore_errors=True)
     os.makedirs(h.diverg_dir, exist_ok=True)
 
     oracles = ["jit", "aot-O0", "aot-O2"]

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -24,7 +24,7 @@ cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
 . "$REPO_ROOT/scripts/lib/durable_work_root.sh"
 if eshkol_durable_enabled; then
-    ESHKOL_ICC_WORK="$(eshkol_durable_prepare_dir icc-smoke)"
+    ESHKOL_ICC_WORK="$(eshkol_durable_prepare_dir icc-smoke)" || exit $?
 fi
 if eshkol_durable_enabled; then
     TRACE_DIR="${TRACE_DIR:-$ESHKOL_ICC_WORK/traces}"

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -22,7 +22,15 @@ set -u
 export LC_ALL=C LC_CTYPE=C LANG=C
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
-TRACE_DIR="$REPO_ROOT/scripts/icc_traces"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
+if eshkol_durable_enabled; then
+    ESHKOL_ICC_WORK="$(eshkol_durable_prepare_dir icc-smoke)"
+fi
+if eshkol_durable_enabled; then
+    TRACE_DIR="${TRACE_DIR:-$ESHKOL_ICC_WORK/traces}"
+else
+    TRACE_DIR="$REPO_ROOT/scripts/icc_traces"
+fi
 TRACE_FILE="$TRACE_DIR/eshkol_smoke.jsonl"
 mkdir -p "$TRACE_DIR"
 
@@ -57,12 +65,49 @@ if [ ! -x "$ESHKOL_RUN" ]; then
 fi
 
 if [ -z "${ESHKOL_JIT_CACHE_DIR:-}" ]; then
-    ESHKOL_ICC_JIT_CACHE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/eshkol-icc-jit-cache.XXXXXX")
+    if eshkol_durable_enabled; then
+        ESHKOL_ICC_JIT_CACHE_DIR="$ESHKOL_ICC_WORK/jit-cache"
+        mkdir "$ESHKOL_ICC_JIT_CACHE_DIR"
+    else
+        ESHKOL_ICC_JIT_CACHE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/eshkol-icc-jit-cache.XXXXXX")
+    fi
     export ESHKOL_JIT_CACHE_DIR="$ESHKOL_ICC_JIT_CACHE_DIR"
-    trap 'rm -rf "$ESHKOL_ICC_JIT_CACHE_DIR"' EXIT
+    if ! eshkol_durable_enabled; then trap 'rm -rf "$ESHKOL_ICC_JIT_CACHE_DIR"' EXIT; fi
 else
     mkdir -p "$ESHKOL_JIT_CACHE_DIR"
 fi
+
+# The existing probes use mktemp in their compact shell snippets.  In durable
+# mode this shell function shadows the external command and claims fresh,
+# deterministic files below the gate directory; it never invokes mktemp or
+# writes ephemeral paths.  The default branch delegates unchanged to mktemp.
+ESHKOL_ICC_TEMP_SEQUENCE=0
+mktemp() {
+    if ! eshkol_durable_enabled; then command mktemp "$@"; return; fi
+    local is_dir=0 candidate index=1
+    [ "${1:-}" = "-d" ] && is_dir=1
+    while [ -e "$ESHKOL_ICC_WORK/probe-${index}" ] || [ -L "$ESHKOL_ICC_WORK/probe-${index}" ]; do
+        index=$((index + 1))
+    done
+    candidate="$ESHKOL_ICC_WORK/probe-${index}"
+    if [ "$is_dir" -eq 1 ]; then mkdir "$candidate"; else : > "$candidate"; fi
+    printf '%s\n' "$candidate"
+}
+
+# Probe snippets clean their ad-hoc outputs on success.  In durable mode those
+# outputs are release evidence, so retain only paths claimed beneath this gate.
+rm() {
+    if ! eshkol_durable_enabled; then command rm "$@"; return; fi
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            -*) ;;
+            "$ESHKOL_ICC_WORK"/*) ;;
+            *) command rm "$@"; return ;;
+        esac
+    done
+    return 0
+}
 
 # Emit one trace line as a JSON-L event with explicit `kind`. ICC's
 # runtime_evidence parser was extended (2026-05-07) to recognize records
@@ -547,8 +592,14 @@ probe reader_fuzz_smoke 'seeded adversarial reader harness: no crash/hang, depth
 # and tests/generative-diff/README.md.
 # ───────────────────────────────────────────────────────────────────
 probe generative_differential_oracle 'generated R7RS programs agree across chibi/JIT/AOT-O0/AOT-O2/VM + metamorphic (no NEW divergence vs baseline)' \
-    'cd "$REPO_ROOT" && python3 scripts/run_generative_differential.py --smoke \
-        --baseline tests/generative-diff/baseline.txt --quiet'
+    'if eshkol_durable_enabled; then
+         workdir=$(eshkol_durable_prepare_dir generative-differential) || exit $?;
+         cd "$REPO_ROOT" && python3 scripts/run_generative_differential.py --smoke \
+             --baseline tests/generative-diff/baseline.txt --quiet --workdir "$workdir";
+     else
+         cd "$REPO_ROOT" && python3 scripts/run_generative_differential.py --smoke \
+             --baseline tests/generative-diff/baseline.txt --quiet;
+     fi'
 
 # TOTAL-LANGUAGE coverage is a monotonic, manifest-derived contract.  The
 # dedicated harness also writes runtime_event evidence consumed directly by
@@ -561,7 +612,12 @@ probe language_surface_coverage_floor 'exposure-engine language coverage meets t
 # (which only scrapes source text) reports OK anyway — that is how assq,
 # assv, memv, partition and string-contains stayed invisible.
 probe surface_parity_execution_backed 'every name native resolves is resolved by the VM or recorded in PARITY.tsv (probed on both engines, ratcheted)' \
-    'cd "$REPO_ROOT" && BUILD_DIR="$BUILD_DIR" python3 scripts/run_surface_parity.py'
+    'if eshkol_durable_enabled; then
+         workdir=$(eshkol_durable_prepare_dir surface-parity) || exit $?;
+         cd "$REPO_ROOT" && BUILD_DIR="$BUILD_DIR" python3 scripts/run_surface_parity.py --workdir "$workdir";
+     else
+         cd "$REPO_ROOT" && BUILD_DIR="$BUILD_DIR" python3 scripts/run_surface_parity.py;
+     fi'
 # The one that catches SILENT WRONG ANSWERS. Name-resolution parity, ledger
 # classification and one-engine coverage all pass while the two engines return
 # different VALUES; this runs the corpus on both engines and compares output,
@@ -569,7 +625,12 @@ probe surface_parity_execution_backed 'every name native resolves is resolved by
 # Validated by reintroducing the '() truthiness bug: exit 1 with the bug, 0
 # without.
 probe engine_semantic_parity 'no corpus program computes a different answer on the two engines, and differential construct coverage holds its floor' \
-    'cd "$REPO_ROOT" && BUILD_DIR="$BUILD_DIR" python3 scripts/run_engine_parity_coverage.py'
+    'if eshkol_durable_enabled; then
+         workdir=$(eshkol_durable_prepare_dir engine-parity) || exit $?;
+         cd "$REPO_ROOT" && BUILD_DIR="$BUILD_DIR" python3 scripts/run_engine_parity_coverage.py --workdir "$workdir";
+     else
+         cd "$REPO_ROOT" && BUILD_DIR="$BUILD_DIR" python3 scripts/run_engine_parity_coverage.py;
+     fi'
 
 # -- fix-campaign regression gates (2026-07-10): exact-oracle-verified fixes --
 probe numeric_exactness_oracle 'exact gcd bignum path + bignum divmod identity (a=q*b+r) + rational/complex eqv?/equal? (ESH-0124/0125/0114)' \
@@ -783,7 +844,12 @@ probe p8_escape_matrix_green \
 # ───────────────────────────────────────────────────────────────────
 probe value_position_axis \
     'every builtin answers the same when referenced as a VALUE (passed to a higher-order procedure, stored, returned, reached through map) as it does in call position — the axis that SW-27, SW-31, SW-34 and SW-35 each escaped through one at a time' \
-    'cd "$REPO_ROOT"; BUILD_DIR="$BUILD_DIR_PATH" python3 scripts/run_value_position_sweep.py --quiet >/dev/null 2>&1'
+    'if eshkol_durable_enabled; then
+         workdir=$(eshkol_durable_prepare_dir value-position) || exit $?;
+         cd "$REPO_ROOT"; BUILD_DIR="$BUILD_DIR_PATH" python3 scripts/run_value_position_sweep.py --quiet --workdir "$workdir" >/dev/null 2>&1;
+     else
+         cd "$REPO_ROOT"; BUILD_DIR="$BUILD_DIR_PATH" python3 scripts/run_value_position_sweep.py --quiet >/dev/null 2>&1;
+     fi'
 
 # ───────────────────────────────────────────────────────────────────
 # ESH-0011 — portable event loop (v1.4 async foundation).

--- a/scripts/run_language_coverage.sh
+++ b/scripts/run_language_coverage.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 . "$REPO_ROOT/scripts/lib/durable_work_root.sh"
 if eshkol_durable_enabled; then
-    LANGUAGE_COVERAGE_WORK="$(eshkol_durable_prepare_dir language-coverage)"
+    LANGUAGE_COVERAGE_WORK="$(eshkol_durable_prepare_dir language-coverage)" || exit $?
     TRACE_DIR=${ICC_TRACE_DIR:-"$LANGUAGE_COVERAGE_WORK/traces"}
     mkdir -p "$TRACE_DIR"
 else

--- a/scripts/run_language_coverage.sh
+++ b/scripts/run_language_coverage.sh
@@ -5,7 +5,14 @@
 set -euo pipefail
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
-TRACE_DIR=${ICC_TRACE_DIR:-"$REPO_ROOT/scripts/icc_traces"}
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
+if eshkol_durable_enabled; then
+    LANGUAGE_COVERAGE_WORK="$(eshkol_durable_prepare_dir language-coverage)"
+    TRACE_DIR=${ICC_TRACE_DIR:-"$LANGUAGE_COVERAGE_WORK/traces"}
+    mkdir -p "$TRACE_DIR"
+else
+    TRACE_DIR=${ICC_TRACE_DIR:-"$REPO_ROOT/scripts/icc_traces"}
+fi
 TRACE_FILE=${LANGUAGE_COVERAGE_TRACE:-"$TRACE_DIR/language_surface_coverage.jsonl"}
 RUNTIME_TRACE_DIRS=${LANGUAGE_COVERAGE_RUNTIME_TRACE_DIRS:-}
 EXTRA_RUNTIME_TRACE_DIRS=${LANGUAGE_COVERAGE_EXTRA_RUNTIME_TRACE_DIRS:-}
@@ -81,10 +88,17 @@ if [ -z "$RUNTIME_TRACE_DIRS" ]; then
     eshkol_test_toolchain_snapshot "$BUILD_DIR_PATH" core
     eshkol_test_toolchain_snapshot "$QUANTUM_BUILD_DIR_PATH" quantum
 
-    GENERATED_TRACE_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/eshkol-language-coverage.XXXXXX")
+    if eshkol_durable_enabled; then
+        GENERATED_TRACE_ROOT="$LANGUAGE_COVERAGE_WORK/generated-traces"
+        mkdir "$GENERATED_TRACE_ROOT"
+    else
+        GENERATED_TRACE_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/eshkol-language-coverage.XXXXXX")
+    fi
     cleanup() {
         local rc=$?
-        if [ "${KEEP_LANGUAGE_COVERAGE_TRACES:-0}" = 1 ] || [ "$rc" -ne 0 ]; then
+        if eshkol_durable_enabled; then
+            echo "Kept durable language-coverage traces: $GENERATED_TRACE_ROOT"
+        elif [ "${KEEP_LANGUAGE_COVERAGE_TRACES:-0}" = 1 ] || [ "$rc" -ne 0 ]; then
             echo "Kept fresh language-coverage traces: $GENERATED_TRACE_ROOT"
         else
             rm -rf "$GENERATED_TRACE_ROOT"

--- a/scripts/run_mono_equiv_ad_taylor_gate.sh
+++ b/scripts/run_mono_equiv_ad_taylor_gate.sh
@@ -23,7 +23,7 @@ if [ ! -x "$ESHKOL_RUN" ]; then
 fi
 
 if eshkol_durable_enabled; then
-  tmp_dir="$(eshkol_durable_prepare_dir mono-equiv-ad-taylor)"
+  tmp_dir="$(eshkol_durable_prepare_dir mono-equiv-ad-taylor)" || exit $?
 else
   tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-mono-equiv.XXXXXX")"
 fi

--- a/scripts/run_mono_equiv_ad_taylor_gate.sh
+++ b/scripts/run_mono_equiv_ad_taylor_gate.sh
@@ -6,6 +6,8 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
 
 BUILD_DIR="${BUILD_DIR:-build}"
 case "$BUILD_DIR" in
@@ -13,8 +15,6 @@ case "$BUILD_DIR" in
   *) ESHKOL_RUN="$PWD/$BUILD_DIR/eshkol-run" ;;
 esac
 TEST_SOURCE="tests/ad/taylor_tower_mono_test.esk"
-TRACE_DIR="${TRACE_DIR:-scripts/icc_traces}"
-TRACE_FILE="$TRACE_DIR/mono_equiv.jsonl"
 EXPECTED_SUMMARY="mono==runtime bit-exact tests: 441 passed, 0 failed"
 
 if [ ! -x "$ESHKOL_RUN" ]; then
@@ -22,9 +22,19 @@ if [ ! -x "$ESHKOL_RUN" ]; then
   exit 2
 fi
 
-tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-mono-equiv.XXXXXX")"
+if eshkol_durable_enabled; then
+  tmp_dir="$(eshkol_durable_prepare_dir mono-equiv-ad-taylor)"
+else
+  tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-mono-equiv.XXXXXX")"
+fi
+if eshkol_durable_enabled; then
+  TRACE_DIR="${TRACE_DIR:-$tmp_dir/traces}"
+else
+  TRACE_DIR="${TRACE_DIR:-scripts/icc_traces}"
+fi
+TRACE_FILE="$TRACE_DIR/mono_equiv.jsonl"
 cleanup() {
-  rm -rf -- "$tmp_dir"
+  if ! eshkol_durable_enabled; then rm -rf -- "$tmp_dir"; fi
 }
 trap cleanup EXIT
 

--- a/scripts/run_p8_escape.sh
+++ b/scripts/run_p8_escape.sh
@@ -34,6 +34,7 @@ set -u
 export LC_ALL=C LC_CTYPE=C LANG=C
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
 BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
 MODE="quick"; AXES="1,2,3,4,5,6,7,8"
 while [ $# -gt 0 ]; do
@@ -82,7 +83,10 @@ echo "run_p8_escape: pinned toolchain -> $PINNED_BUILD_DIR" >&2
 
 WORK="$ESHKOL_TEST_TMPDIR/work"; mkdir -p "$WORK"
 # Disk cap: a runaway generator must not fill the disk (fuzz disk-budget policy).
-cleanup() { rm -rf "$WORK"; eshkol_test_isolation_cleanup; }
+cleanup() {
+  if ! eshkol_durable_enabled; then rm -rf "$WORK"; fi
+  eshkol_test_isolation_cleanup
+}
 trap cleanup EXIT
 export ESHKOL_JIT_CACHE_DIR="$WORK/jit"; mkdir -p "$ESHKOL_JIT_CACHE_DIR"
 DISK_CAP_KB=$(( 512 * 1024 ))   # 512 MB corpus ceiling

--- a/scripts/run_reader_fuzz.sh
+++ b/scripts/run_reader_fuzz.sh
@@ -49,7 +49,7 @@ done
 
 BUILD_DIR="$REPO_ROOT/build-reader-fuzz"
 if eshkol_durable_enabled; then
-    ARTIFACT_DIR="$(eshkol_durable_prepare_dir reader-fuzz)"
+    ARTIFACT_DIR="$(eshkol_durable_prepare_dir reader-fuzz)" || exit $?
 else
     ARTIFACT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/eshkol-reader-fuzz-artifacts.XXXXXX")
 fi

--- a/scripts/run_reader_fuzz.sh
+++ b/scripts/run_reader_fuzz.sh
@@ -35,6 +35,7 @@
 set -u
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
 
 MODE="--smoke"
 for arg in "$@"; do
@@ -47,11 +48,17 @@ for arg in "$@"; do
 done
 
 BUILD_DIR="$REPO_ROOT/build-reader-fuzz"
-ARTIFACT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/eshkol-reader-fuzz-artifacts.XXXXXX")
+if eshkol_durable_enabled; then
+    ARTIFACT_DIR="$(eshkol_durable_prepare_dir reader-fuzz)"
+else
+    ARTIFACT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/eshkol-reader-fuzz-artifacts.XXXXXX")
+fi
 
 cleanup() {
     local status=$?
-    if [ "$status" -eq 0 ]; then
+    if eshkol_durable_enabled; then
+        echo "run_reader_fuzz.sh: durable evidence retained at $ARTIFACT_DIR" >&2
+    elif [ "$status" -eq 0 ]; then
         rm -rf "$ARTIFACT_DIR"
     else
         echo "run_reader_fuzz.sh: findings kept at $ARTIFACT_DIR" \

--- a/scripts/run_surface_parity.py
+++ b/scripts/run_surface_parity.py
@@ -74,7 +74,7 @@ produce the same result.  Until that exists, "green here" means "no name is
 missing", not "the engines agree".  Do not read it as more than that.
 
 Usage:
-  scripts/run_surface_parity.py [--update-baseline] [--limit N]
+  scripts/run_surface_parity.py [--update-baseline] [--limit N] [--workdir DIR]
 Exit: 0 = gate green, 1 = gate red, 2 = misuse/environment problem.
 """
 
@@ -122,6 +122,32 @@ NAME_RE = re.compile(r"^[A-Za-z*+\-/<>=!?_][^\s()'\"`;]*$")
 def die(msg):
     sys.stderr.write("run_surface_parity: %s\n" % msg)
     sys.exit(2)
+
+
+def require_empty_workdir(path):
+    """Validate a caller-owned durable directory before writing probes."""
+    if not os.path.isabs(path):
+        raise ValueError("--workdir must be an absolute path")
+    if os.path.islink(path):
+        raise ValueError("--workdir must not be a symlink: %s" % path)
+    if not os.path.isdir(path):
+        raise ValueError("--workdir must be a caller-created directory: %s" % path)
+    if os.listdir(path):
+        raise ValueError("--workdir must be empty: %s" % path)
+    return path
+
+
+def write_probe_source(workdir, prefix, number, src):
+    """Write a retained deterministic probe file, or the legacy temp file."""
+    if workdir is None:
+        fd, path = tempfile.mkstemp(suffix=".esk")
+        with os.fdopen(fd, "w") as f:
+            f.write(src)
+        return path
+    path = os.path.join(workdir, "%s-%04d.esk" % (prefix, number))
+    with open(path, "x", encoding="utf-8") as f:
+        f.write(src)
+    return path
 
 
 def load_manifest():
@@ -182,18 +208,16 @@ def stdlib_names():
             and not (n.startswith("*") and n.endswith("*"))}
 
 
-def probe_vm(names, vm_surface):
+def probe_vm(names, vm_surface, workdir=None):
     """Batch-probe VM name resolution; credit vm_surface membership."""
     resolved = {}
     env = dict(os.environ, ESHKOL_VM_NO_DISASM="1")
     batch = 60
-    for i in range(0, len(names), batch):
+    for batch_number, i in enumerate(range(0, len(names), batch), 1):
         chunk = names[i:i + batch]
         src = "".join("(define __p%d %s)\n" % (j, n)
                       for j, n in enumerate(chunk))
-        fd, path = tempfile.mkstemp(suffix=".esk")
-        with os.fdopen(fd, "w") as f:
-            f.write(src)
+        path = write_probe_source(workdir, "vm-batch", batch_number, src)
         try:
             out = subprocess.run([VM_BIN, path], capture_output=True,
                                  text=True, timeout=300, env=env)
@@ -201,19 +225,18 @@ def probe_vm(names, vm_surface):
         except (OSError, subprocess.SubprocessError):
             txt = ""
         finally:
-            os.unlink(path)
+            if workdir is None:
+                os.unlink(path)
         for n in chunk:
             warned = ("undefined variable '%s'" % n) in txt
             resolved[n] = (not warned) or (n in vm_surface)
     return resolved
 
 
-def _native_batch_ok(names, env):
+def _native_batch_ok(names, env, workdir=None, probe_number=0):
     """True if native compiles a program referencing every name in `names`."""
     src = "".join("(define __p%d %s)\n" % (i, n) for i, n in enumerate(names))
-    fd, path = tempfile.mkstemp(suffix=".esk")
-    with os.fdopen(fd, "w") as f:
-        f.write(src)
+    path = write_probe_source(workdir, "native-batch", probe_number, src)
     try:
         r = subprocess.run([ESHKOL_RUN, "-r", path], capture_output=True,
                            text=True, timeout=600, env=env)
@@ -221,7 +244,8 @@ def _native_batch_ok(names, env):
     except (OSError, subprocess.SubprocessError):
         return False
     finally:
-        os.unlink(path)
+        if workdir is None:
+            os.unlink(path)
 
 
 def _native_cache_key():
@@ -271,7 +295,7 @@ def _save_native_cache(key, resolved):
         pass
 
 
-def probe_native(names):
+def probe_native(names, workdir=None):
     """Probe native resolution, batched with bisection.
 
     An unresolved name aborts the whole program (and native's error path can
@@ -290,10 +314,14 @@ def probe_native(names):
     resolved = {n: cached[n] for n in names if n in cached}
     todo = [n for n in names if n not in resolved]
 
+    probe_number = 0
+
     def walk(chunk):
+        nonlocal probe_number
         if not chunk:
             return
-        if _native_batch_ok(chunk, env):
+        probe_number += 1
+        if _native_batch_ok(chunk, env, workdir, probe_number):
             for n in chunk:
                 resolved[n] = True
             return
@@ -326,7 +354,15 @@ def main():
                     help="rewrite the ratchet baseline from this run")
     ap.add_argument("--limit", type=int, default=0,
                     help="probe only the first N names (smoke use)")
+    ap.add_argument("--workdir",
+                    help="empty caller-created absolute directory retaining probe files")
     args = ap.parse_args()
+
+    if args.workdir is not None:
+        try:
+            args.workdir = require_empty_workdir(args.workdir)
+        except ValueError as exc:
+            die(str(exc))
 
     for path, what in ((ESHKOL_RUN, "eshkol-run"), (VM_BIN, "the VM binary")):
         if not os.path.exists(path):
@@ -352,8 +388,8 @@ def main():
     print("run_surface_parity: probing %d names on both engines "
           "(codegen surface + Scheme stdlib + ledger rows)" % len(surface))
 
-    vm_ok = probe_vm(surface, vm_surface)
-    nat_ok = probe_native(surface)
+    vm_ok = probe_vm(surface, vm_surface, args.workdir)
+    nat_ok = probe_native(surface, args.workdir)
 
     findings, opcode_only, untracked = [], [], []
     for n in surface:

--- a/scripts/run_tensor_input2_grad_gate.sh
+++ b/scripts/run_tensor_input2_grad_gate.sh
@@ -24,7 +24,7 @@ REPO_ROOT="$(pwd)"
 TEST_FILE="$REPO_ROOT/tests/ad/tensor_input2_grad_test.esk"
 
 if eshkol_durable_enabled; then
-    TENSOR_INPUT2_WORK="$(eshkol_durable_prepare_dir tensor-input2-grad)"
+    TENSOR_INPUT2_WORK="$(eshkol_durable_prepare_dir tensor-input2-grad)" || exit $?
     : "${ESHKOL_JIT_CACHE_DIR:=$TENSOR_INPUT2_WORK/jit-cache}"
 else
     : "${ESHKOL_JIT_CACHE_DIR:=${TMPDIR:-/tmp}/eshkol-tensor-input2-jit-cache}"
@@ -89,7 +89,7 @@ fi
 # ---- AOT ----
 if [ "$DO_AOT" -eq 1 ]; then
     if eshkol_durable_enabled; then
-        bin="$(eshkol_durable_file "$TENSOR_INPUT2_WORK" tensor_input2_gate_bin)"
+        bin="$(eshkol_durable_file "$TENSOR_INPUT2_WORK" tensor_input2_gate_bin)" || exit $?
     else
         bin="$(mktemp "${TMPDIR:-/tmp}/tensor_input2_gate_bin.XXXXXX")"
     fi

--- a/scripts/run_tensor_input2_grad_gate.sh
+++ b/scripts/run_tensor_input2_grad_gate.sh
@@ -20,9 +20,15 @@ export LANG=C
 
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
 TEST_FILE="$REPO_ROOT/tests/ad/tensor_input2_grad_test.esk"
 
-: "${ESHKOL_JIT_CACHE_DIR:=${TMPDIR:-/tmp}/eshkol-tensor-input2-jit-cache}"
+if eshkol_durable_enabled; then
+    TENSOR_INPUT2_WORK="$(eshkol_durable_prepare_dir tensor-input2-grad)"
+    : "${ESHKOL_JIT_CACHE_DIR:=$TENSOR_INPUT2_WORK/jit-cache}"
+else
+    : "${ESHKOL_JIT_CACHE_DIR:=${TMPDIR:-/tmp}/eshkol-tensor-input2-jit-cache}"
+fi
 export ESHKOL_JIT_CACHE_DIR
 mkdir -p "$ESHKOL_JIT_CACHE_DIR"
 
@@ -82,7 +88,11 @@ fi
 
 # ---- AOT ----
 if [ "$DO_AOT" -eq 1 ]; then
-    bin="$(mktemp "${TMPDIR:-/tmp}/tensor_input2_gate_bin.XXXXXX")"
+    if eshkol_durable_enabled; then
+        bin="$(eshkol_durable_file "$TENSOR_INPUT2_WORK" tensor_input2_gate_bin)"
+    else
+        bin="$(mktemp "${TMPDIR:-/tmp}/tensor_input2_gate_bin.XXXXXX")"
+    fi
     cout="$(run_guarded "$AOT_COMPILE_TIMEOUT" "$ESHKOL_RUN" "$TEST_FILE" -o "$bin" -L"$REPO_ROOT/$BUILD_DIR" 2>&1)"; crc=$?
     if [ "$crc" -ne 0 ] || [ ! -x "$bin" ]; then
         echo "  AOT  COMPILE-FAIL rc=$crc"
@@ -98,7 +108,7 @@ if [ "$DO_AOT" -eq 1 ]; then
             overall=FAIL
         fi
     fi
-    rm -f "$bin"
+    if ! eshkol_durable_enabled; then rm -f "$bin"; fi
 fi
 
 echo "ESH-0212 tensor-AD second-operand gate: $overall"

--- a/scripts/run_v1_3_readiness.sh
+++ b/scripts/run_v1_3_readiness.sh
@@ -13,7 +13,7 @@ REPO_ROOT="$(pwd)"
 ICC_BIN="${ICC_BIN:-/Users/tyr/Desktop/infinite_context_coder/bin/icc}"
 ICC_REPO="${ICC_REPO:-eshkol_lang}"
 if eshkol_durable_enabled; then
-  READINESS_WORK="$(eshkol_durable_prepare_dir v1-3-readiness)"
+  READINESS_WORK="$(eshkol_durable_prepare_dir v1-3-readiness)" || exit $?
   TRACE_DIR="${TRACE_DIR:-$READINESS_WORK/traces}"
   mkdir "$TRACE_DIR"
 else
@@ -22,7 +22,7 @@ fi
 ARCH_MODEL="${ARCH_MODEL:-.icc/architecture-model.yaml}"
 ARCH_TRACE_GLOB="${ARCH_TRACE_GLOB:-.icc/runtime-traces-oracle-view/*architecture-model-verify-*.jsonl}"
 if eshkol_durable_enabled; then
-  READINESS_JSON="$(eshkol_durable_file "$READINESS_WORK" readiness.json)"
+  READINESS_JSON="$(eshkol_durable_file "$READINESS_WORK" readiness.json)" || exit $?
 else
   READINESS_JSON="$(mktemp "${TMPDIR:-/tmp}/eshkol-v13-readiness.XXXXXX.json")"
 fi

--- a/scripts/run_v1_3_readiness.sh
+++ b/scripts/run_v1_3_readiness.sh
@@ -7,15 +7,27 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
 
 ICC_BIN="${ICC_BIN:-/Users/tyr/Desktop/infinite_context_coder/bin/icc}"
 ICC_REPO="${ICC_REPO:-eshkol_lang}"
-TRACE_DIR="${TRACE_DIR:-scripts/icc_traces}"
+if eshkol_durable_enabled; then
+  READINESS_WORK="$(eshkol_durable_prepare_dir v1-3-readiness)"
+  TRACE_DIR="${TRACE_DIR:-$READINESS_WORK/traces}"
+  mkdir "$TRACE_DIR"
+else
+  TRACE_DIR="${TRACE_DIR:-scripts/icc_traces}"
+fi
 ARCH_MODEL="${ARCH_MODEL:-.icc/architecture-model.yaml}"
 ARCH_TRACE_GLOB="${ARCH_TRACE_GLOB:-.icc/runtime-traces-oracle-view/*architecture-model-verify-*.jsonl}"
-READINESS_JSON="$(mktemp "${TMPDIR:-/tmp}/eshkol-v13-readiness.XXXXXX.json")"
+if eshkol_durable_enabled; then
+  READINESS_JSON="$(eshkol_durable_file "$READINESS_WORK" readiness.json)"
+else
+  READINESS_JSON="$(mktemp "${TMPDIR:-/tmp}/eshkol-v13-readiness.XXXXXX.json")"
+fi
 : "${READINESS_JSON:?READINESS_JSON must be set}"
-trap 'rm -f -- "${READINESS_JSON:?}"' EXIT
+if ! eshkol_durable_enabled; then trap 'rm -f -- "${READINESS_JSON:?}"' EXIT; fi
 
 BUILD_DIR="${BUILD_DIR:-build}" TRACE_DIR="$TRACE_DIR" \
   scripts/run_mono_equiv_ad_taylor_gate.sh

--- a/scripts/run_vm_parity.sh
+++ b/scripts/run_vm_parity.sh
@@ -56,7 +56,7 @@ cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
 . "$REPO_ROOT/scripts/lib/durable_work_root.sh"
 if eshkol_durable_enabled; then
-    VM_PARITY_WORK="$(eshkol_durable_prepare_dir vm-parity)"
+    VM_PARITY_WORK="$(eshkol_durable_prepare_dir vm-parity)" || exit $?
     TRACE_DIR="${TRACE_DIR:-$VM_PARITY_WORK/traces}"
 else
     TRACE_DIR="$REPO_ROOT/scripts/icc_traces"

--- a/scripts/run_vm_parity.sh
+++ b/scripts/run_vm_parity.sh
@@ -54,7 +54,13 @@ export LANG=C
 
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
-TRACE_DIR="$REPO_ROOT/scripts/icc_traces"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
+if eshkol_durable_enabled; then
+    VM_PARITY_WORK="$(eshkol_durable_prepare_dir vm-parity)"
+    TRACE_DIR="${TRACE_DIR:-$VM_PARITY_WORK/traces}"
+else
+    TRACE_DIR="$REPO_ROOT/scripts/icc_traces"
+fi
 TRACE_FILE="$TRACE_DIR/vm_parity.jsonl"
 mkdir -p "$TRACE_DIR"
 : "${TRACE_FILE:?TRACE_FILE must be set}"
@@ -145,9 +151,14 @@ if [ ! -x "$ESHKOL_RUN" ] || [ ! -x "$VM_BIN" ]; then
     exit 2
 fi
 
-WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-vm-parity.XXXXXX")"
+if eshkol_durable_enabled; then
+    WORK="$VM_PARITY_WORK/work"
+    mkdir "$WORK"
+else
+    WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-vm-parity.XXXXXX")"
+fi
 : "${WORK:?WORK must be set}"
-trap 'rm -rf "$WORK"' EXIT
+if ! eshkol_durable_enabled; then trap 'rm -rf "$WORK"' EXIT; fi
 export ESHKOL_JIT_CACHE_DIR="$WORK/jit-cache"
 mkdir -p "$ESHKOL_JIT_CACHE_DIR"
 

--- a/scripts/run_wasm_differential.sh
+++ b/scripts/run_wasm_differential.sh
@@ -69,7 +69,13 @@ export LANG=C
 
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
-TRACE_DIR="$REPO_ROOT/scripts/icc_traces"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
+if eshkol_durable_enabled; then
+    WASM_DIFF_WORK="$(eshkol_durable_prepare_dir wasm-differential)" || exit $?
+    TRACE_DIR="${TRACE_DIR:-$WASM_DIFF_WORK/traces}"
+else
+    TRACE_DIR="$REPO_ROOT/scripts/icc_traces"
+fi
 TRACE_FILE="$TRACE_DIR/wasm_parity.jsonl"
 mkdir -p "$TRACE_DIR"
 : "${TRACE_FILE:?TRACE_FILE must be set}"
@@ -254,12 +260,17 @@ if [ "$need_build" -eq 1 ]; then
     echo "   built: $WASM_MODULE ($(wc -c < "${WASM_MODULE%.js}.wasm" | tr -d ' ') bytes)"
 fi
 
-WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-wasm-diff.XXXXXX")"
-: "${WORK:?WORK must be set}"
-if [ "$KEEP" -eq 1 ]; then
-    echo "   work dir (kept): $WORK"
+if eshkol_durable_enabled; then
+    WORK="$WASM_DIFF_WORK"
+    echo "   durable work dir (retained): $WORK"
 else
-    trap 'rm -rf "$WORK"' EXIT
+    WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-wasm-diff.XXXXXX")"
+    : "${WORK:?WORK must be set}"
+    if [ "$KEEP" -eq 1 ]; then
+        echo "   work dir (kept): $WORK"
+    else
+        trap 'rm -rf "$WORK"' EXIT
+    fi
 fi
 export ESHKOL_JIT_CACHE_DIR="$WORK/jit-cache"
 mkdir -p "$ESHKOL_JIT_CACHE_DIR"

--- a/tests/memory/define_loop_flat_rss_aot_test.sh
+++ b/tests/memory/define_loop_flat_rss_aot_test.sh
@@ -66,7 +66,7 @@ done
 
 # Detect which peak-RSS-reporting `time` flavor is available.
 if eshkol_durable_enabled; then
-    WORK="$(eshkol_durable_prepare_dir define-loop-flat-rss-aot)"
+    WORK="$(eshkol_durable_prepare_dir define-loop-flat-rss-aot)" || exit $?
     TIME_PROBE="$WORK/time-probe.log"
 else
     TIME_PROBE="/tmp/.deflrat_probe.$$"

--- a/tests/memory/define_loop_flat_rss_aot_test.sh
+++ b/tests/memory/define_loop_flat_rss_aot_test.sh
@@ -33,6 +33,7 @@ set -u
 export LC_ALL=C LC_CTYPE=C LANG=C
 cd "$(dirname "$0")/../.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
 
 BUILD_DIR="${BUILD_DIR:-build}"
 if [ -z "${ESHKOL_RUN:-}" ]; then
@@ -64,27 +65,35 @@ while [ $# -gt 0 ]; do
 done
 
 # Detect which peak-RSS-reporting `time` flavor is available.
+if eshkol_durable_enabled; then
+    WORK="$(eshkol_durable_prepare_dir define-loop-flat-rss-aot)"
+    TIME_PROBE="$WORK/time-probe.log"
+else
+    TIME_PROBE="/tmp/.deflrat_probe.$$"
+fi
 # macOS (BSD time): `/usr/bin/time -l` reports "NNNN  maximum resident set size" in BYTES.
 # Linux (GNU time):  `/usr/bin/time -v` reports "Maximum resident set size (kbytes): NNNN" in KB.
 TIME_MODE=""
-if /usr/bin/time -l true >/dev/null 2>/tmp/.deflrat_probe.$$; then
-    if grep -q "maximum resident set size" /tmp/.deflrat_probe.$$ 2>/dev/null; then
+if /usr/bin/time -l true >/dev/null 2>"$TIME_PROBE"; then
+    if grep -q "maximum resident set size" "$TIME_PROBE" 2>/dev/null; then
         TIME_MODE="bsd"
     fi
 fi
-if [ -z "$TIME_MODE" ] && /usr/bin/time -v true >/tmp/.deflrat_probe.$$ 2>&1; then
-    if grep -qi "Maximum resident set size" /tmp/.deflrat_probe.$$ 2>/dev/null; then
+if [ -z "$TIME_MODE" ] && /usr/bin/time -v true >"$TIME_PROBE" 2>&1; then
+    if grep -qi "Maximum resident set size" "$TIME_PROBE" 2>/dev/null; then
         TIME_MODE="gnu"
     fi
 fi
-rm -f /tmp/.deflrat_probe.$$
+if ! eshkol_durable_enabled; then rm -f "$TIME_PROBE"; fi
 if [ -z "$TIME_MODE" ]; then
     echo "define_loop_flat_rss_aot_test.sh: neither \`/usr/bin/time -l\` (macOS) nor \`/usr/bin/time -v\` (Linux) reports peak RSS on this host — cannot gate." >&2
     exit 2
 fi
 
-WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-flat-rss-aot.XXXXXX")"
-trap 'rm -rf "$WORK"' EXIT
+if ! eshkol_durable_enabled; then
+    WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-flat-rss-aot.XXXXXX")"
+    trap 'rm -rf "$WORK"' EXIT
+fi
 
 # run_aot <src> <bin> <compile_env...=> -> sets FR_COMPILE_RC FR_RUN_RC FR_RSS_MB FR_OUT
 run_aot() {

--- a/tests/memory/iter_scope_partial_reclaim_test.sh
+++ b/tests/memory/iter_scope_partial_reclaim_test.sh
@@ -33,6 +33,7 @@ set -u
 export LC_ALL=C LC_CTYPE=C LANG=C
 cd "$(dirname "$0")/../.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
 
 BUILD_DIR="${BUILD_DIR:-build}"
 if [ -z "${ESHKOL_RUN:-}" ]; then
@@ -66,21 +67,29 @@ while [ $# -gt 0 ]; do
 done
 
 # Detect the peak-RSS-reporting `time` flavor (macOS BSD `-l`, Linux GNU `-v`).
+if eshkol_durable_enabled; then
+    WORK="$(eshkol_durable_prepare_dir iter-scope-partial-reclaim)" || exit $?
+    TIME_PROBE="$WORK/time-probe.log"
+else
+    TIME_PROBE="/tmp/.ispr_probe.$$"
+fi
 TIME_MODE=""
-if /usr/bin/time -l true >/dev/null 2>/tmp/.ispr_probe.$$; then
-    grep -q "maximum resident set size" /tmp/.ispr_probe.$$ 2>/dev/null && TIME_MODE="bsd"
+if /usr/bin/time -l true >/dev/null 2>"$TIME_PROBE"; then
+    grep -q "maximum resident set size" "$TIME_PROBE" 2>/dev/null && TIME_MODE="bsd"
 fi
-if [ -z "$TIME_MODE" ] && /usr/bin/time -v true >/tmp/.ispr_probe.$$ 2>&1; then
-    grep -qi "Maximum resident set size" /tmp/.ispr_probe.$$ 2>/dev/null && TIME_MODE="gnu"
+if [ -z "$TIME_MODE" ] && /usr/bin/time -v true >"$TIME_PROBE" 2>&1; then
+    grep -qi "Maximum resident set size" "$TIME_PROBE" 2>/dev/null && TIME_MODE="gnu"
 fi
-rm -f /tmp/.ispr_probe.$$
+if ! eshkol_durable_enabled; then rm -f "$TIME_PROBE"; fi
 if [ -z "$TIME_MODE" ]; then
     echo "iter_scope_partial_reclaim_test.sh: no peak-RSS-reporting /usr/bin/time on this host — cannot gate." >&2
     exit 2
 fi
 
-WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-ispr.XXXXXX")"
-trap 'rm -rf "$WORK"' EXIT
+if ! eshkol_durable_enabled; then
+    WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-ispr.XXXXXX")"
+    trap 'rm -rf "$WORK"' EXIT
+fi
 
 # run_aot <src> <bin> <run-env...> -> FR_COMPILE_RC FR_RUN_RC FR_RSS_MB FR_OUT
 run_aot() {

--- a/tests/memory/region_evac_subtype_coverage_test.sh
+++ b/tests/memory/region_evac_subtype_coverage_test.sh
@@ -38,6 +38,7 @@ set -u
 export LC_ALL=C LC_CTYPE=C LANG=C
 cd "$(dirname "$0")/../.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
 
 BUILD_DIR="${BUILD_DIR:-build}"
 if [ -z "${ESHKOL_RUN:-}" ]; then
@@ -69,25 +70,33 @@ while [ $# -gt 0 ]; do
 done
 
 # Detect which peak-RSS-reporting `time` flavor is available.
+if eshkol_durable_enabled; then
+    WORK="$(eshkol_durable_prepare_dir region-evac-subtype)"
+    TIME_PROBE="$WORK/time-probe.log"
+else
+    TIME_PROBE="/tmp/.regevac_probe.$$"
+fi
 TIME_MODE=""
-if /usr/bin/time -l true >/dev/null 2>/tmp/.regevac_probe.$$; then
-    if grep -q "maximum resident set size" /tmp/.regevac_probe.$$ 2>/dev/null; then
+if /usr/bin/time -l true >/dev/null 2>"$TIME_PROBE"; then
+    if grep -q "maximum resident set size" "$TIME_PROBE" 2>/dev/null; then
         TIME_MODE="bsd"
     fi
 fi
-if [ -z "$TIME_MODE" ] && /usr/bin/time -v true >/tmp/.regevac_probe.$$ 2>&1; then
-    if grep -qi "Maximum resident set size" /tmp/.regevac_probe.$$ 2>/dev/null; then
+if [ -z "$TIME_MODE" ] && /usr/bin/time -v true >"$TIME_PROBE" 2>&1; then
+    if grep -qi "Maximum resident set size" "$TIME_PROBE" 2>/dev/null; then
         TIME_MODE="gnu"
     fi
 fi
-rm -f /tmp/.regevac_probe.$$
+if ! eshkol_durable_enabled; then rm -f "$TIME_PROBE"; fi
 if [ -z "$TIME_MODE" ]; then
     echo "region_evac_subtype_coverage_test.sh: neither \`/usr/bin/time -l\` (macOS) nor \`/usr/bin/time -v\` (Linux) reports peak RSS on this host — cannot gate." >&2
     exit 2
 fi
 
-WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-region-evac.XXXXXX")"
-trap 'rm -rf "$WORK"' EXIT
+if ! eshkol_durable_enabled; then
+    WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-region-evac.XXXXXX")"
+    trap 'rm -rf "$WORK"' EXIT
+fi
 
 echo "=========================================================="
 echo "  ESH-0214d AOT flat-RSS + correctness gate (poisoned):"

--- a/tests/memory/region_evac_subtype_coverage_test.sh
+++ b/tests/memory/region_evac_subtype_coverage_test.sh
@@ -71,7 +71,7 @@ done
 
 # Detect which peak-RSS-reporting `time` flavor is available.
 if eshkol_durable_enabled; then
-    WORK="$(eshkol_durable_prepare_dir region-evac-subtype)"
+    WORK="$(eshkol_durable_prepare_dir region-evac-subtype)" || exit $?
     TIME_PROBE="$WORK/time-probe.log"
 else
     TIME_PROBE="/tmp/.regevac_probe.$$"

--- a/tests/memory/region_handle_training_rss_test.sh
+++ b/tests/memory/region_handle_training_rss_test.sh
@@ -72,7 +72,7 @@ done
 
 # Detect the peak-RSS-reporting `time` flavor (macOS BSD `-l`, Linux GNU `-v`).
 if eshkol_durable_enabled; then
-    WORK="$(eshkol_durable_prepare_dir region-handle-training-rss)"
+    WORK="$(eshkol_durable_prepare_dir region-handle-training-rss)" || exit $?
     TIME_PROBE="$WORK/time-probe.log"
 else
     TIME_PROBE="/tmp/.rhtr_probe.$$"

--- a/tests/memory/region_handle_training_rss_test.sh
+++ b/tests/memory/region_handle_training_rss_test.sh
@@ -32,6 +32,7 @@ set -u
 export LC_ALL=C LC_CTYPE=C LANG=C
 cd "$(dirname "$0")/../.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
 
 BUILD_DIR="${BUILD_DIR:-build}"
 if [ -z "${ESHKOL_RUN:-}" ]; then
@@ -70,22 +71,30 @@ while [ $# -gt 0 ]; do
 done
 
 # Detect the peak-RSS-reporting `time` flavor (macOS BSD `-l`, Linux GNU `-v`).
+if eshkol_durable_enabled; then
+    WORK="$(eshkol_durable_prepare_dir region-handle-training-rss)"
+    TIME_PROBE="$WORK/time-probe.log"
+else
+    TIME_PROBE="/tmp/.rhtr_probe.$$"
+fi
 TIME_MODE=""
-if /usr/bin/time -l true >/dev/null 2>/tmp/.rhtr_probe.$$; then
-    grep -q "maximum resident set size" /tmp/.rhtr_probe.$$ 2>/dev/null && TIME_MODE="bsd"
+if /usr/bin/time -l true >/dev/null 2>"$TIME_PROBE"; then
+    grep -q "maximum resident set size" "$TIME_PROBE" 2>/dev/null && TIME_MODE="bsd"
 fi
-if [ -z "$TIME_MODE" ] && /usr/bin/time -v true >/tmp/.rhtr_probe.$$ 2>&1; then
-    grep -qi "Maximum resident set size" /tmp/.rhtr_probe.$$ 2>/dev/null && TIME_MODE="gnu"
+if [ -z "$TIME_MODE" ] && /usr/bin/time -v true >"$TIME_PROBE" 2>&1; then
+    grep -qi "Maximum resident set size" "$TIME_PROBE" 2>/dev/null && TIME_MODE="gnu"
 fi
-rm -f /tmp/.rhtr_probe.$$
+if ! eshkol_durable_enabled; then rm -f "$TIME_PROBE"; fi
 if [ -z "$TIME_MODE" ]; then
     echo "region_handle_training_rss_test.sh: no peak-RSS-reporting /usr/bin/time on this host — cannot gate." >&2
     exit 2
 fi
 
-WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-rhtr.XXXXXX")"
+if ! eshkol_durable_enabled; then
+    WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-rhtr.XXXXXX")"
+fi
 : "${WORK:?}"
-trap 'rm -rf "$WORK"' EXIT
+if ! eshkol_durable_enabled; then trap 'rm -rf "$WORK"' EXIT; fi
 
 # compile_aot <src> <bin> -> AOT_RC
 compile_aot() {

--- a/tests/memory/vm_region_growth_watchdog_test.sh
+++ b/tests/memory/vm_region_growth_watchdog_test.sh
@@ -35,6 +35,7 @@ set -u
 export LC_ALL=C LC_CTYPE=C LANG=C
 cd "$(dirname "$0")/../.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
 
 BUILD_DIR="${BUILD_DIR:-build}"
 case "$BUILD_DIR" in
@@ -54,9 +55,14 @@ fi
 
 # Same convention as the other memory gates (define_loop_flat_rss_aot_test.sh):
 # an ephemeral working directory, removed by the trap on every exit path. Total
-# footprint is a few KB of captured stdout/stderr.
-WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-vm-region-watchdog.XXXXXX")"
-trap 'rm -rf "$WORK"' EXIT INT TERM
+# footprint is a few KB of captured stdout/stderr. Durable release runs retain
+# those captures under their deterministic gate child instead.
+if eshkol_durable_enabled; then
+    WORK="$(eshkol_durable_prepare_dir vm-region-growth-watchdog)" || exit $?
+else
+    WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-vm-region-watchdog.XXXXXX")"
+    trap 'rm -rf "$WORK"' EXIT INT TERM
+fi
 
 PASS=0
 FAIL=0

--- a/tests/parallel/parallel_map_scope_reclaim_test.sh
+++ b/tests/parallel/parallel_map_scope_reclaim_test.sh
@@ -24,6 +24,7 @@ set -u
 export LC_ALL=C LC_CTYPE=C LANG=C
 cd "$(dirname "$0")/../.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
 
 RUNS=25
 PER_RUN_TIMEOUT=60
@@ -48,8 +49,12 @@ if [ ! -x "$ESHKOL_RUN" ]; then
 fi
 
 SRC="$REPO_ROOT/tests/parallel/parallel_map_scope_reclaim_test.esk"
-WORK="$(mktemp -d)"
-trap 'rm -rf "$WORK"' EXIT
+if eshkol_durable_enabled; then
+    WORK="$(eshkol_durable_prepare_dir parallel-map-scope-reclaim)" || exit $?
+else
+    WORK="$(mktemp -d)"
+    trap 'rm -rf "$WORK"' EXIT
+fi
 BIN="$WORK/scope_reclaim"
 
 # Optional per-run timeout wrapper (coreutils timeout / gtimeout if present).

--- a/tests/toolchain/ffi_boundary_fail_open_test.sh
+++ b/tests/toolchain/ffi_boundary_fail_open_test.sh
@@ -33,6 +33,9 @@
 
 set -uo pipefail
 
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
+
 ESHKOL_RUN="${1:-${ESHKOL_RUN:-}}"
 if [ -z "$ESHKOL_RUN" ]; then
     if [ -x "./build/eshkol-run" ]; then
@@ -54,8 +57,12 @@ case "$ESHKOL_RUN" in
     *)  ESHKOL_RUN="$(cd "$(dirname "$ESHKOL_RUN")" && pwd)/$(basename "$ESHKOL_RUN")" ;;
 esac
 
-tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT
+if eshkol_durable_enabled; then
+    tmp="$(eshkol_durable_prepare_dir ffi-boundary-fail-open)" || exit $?
+else
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+fi
 # Isolate the persistent -r run-cache: a cache entry built before the fix would
 # otherwise serve the poisoned binary and hide the regression.
 export ESHKOL_JIT_CACHE_DIR="$tmp/jit"; mkdir -p "$ESHKOL_JIT_CACHE_DIR"

--- a/tests/toolchain/release_workflow_surface_test.cpp
+++ b/tests/toolchain/release_workflow_surface_test.cpp
@@ -86,8 +86,57 @@ int main(int argc, char** argv) {
     }
     const fs::path package_verifier_path =
         source_root / "scripts" / "verify_release_package.py";
+    const fs::path durable_work_root_path =
+        source_root / "scripts" / "lib" / "durable_work_root.sh";
+    const fs::path test_isolation_path =
+        source_root / "scripts" / "lib" / "test_isolation.sh";
+    const fs::path region_handle_rss_gate_path =
+        source_root / "tests" / "memory" / "region_handle_training_rss_test.sh";
+    const std::vector<fs::path> durable_transitive_gate_paths = {
+        source_root / "tests" / "toolchain" / "transitive_ffi_link_test.sh",
+        source_root / "tests" / "toolchain" / "ffi_boundary_fail_open_test.sh",
+        source_root / "tests" / "parallel" / "parallel_map_scope_reclaim_test.sh",
+        source_root / "tests" / "memory" / "vm_region_growth_watchdog_test.sh",
+        source_root / "tests" / "memory" / "iter_scope_partial_reclaim_test.sh",
+        source_root / "scripts" / "run_wasm_differential.sh",
+        source_root / "scripts" / "p8" / "p8_fault_injection.sh",
+        source_root / "scripts" / "p8" / "p8_mem_profiles.sh",
+    };
+    const std::vector<fs::path> durable_python_gate_paths = {
+        source_root / "scripts" / "run_generative_differential.py",
+        source_root / "scripts" / "run_surface_parity.py",
+        source_root / "scripts" / "run_engine_parity_coverage.py",
+        source_root / "scripts" / "run_value_position_sweep.py",
+    };
+    const std::vector<fs::path> canonical_gate_paths = {
+        source_root / "scripts" / "run_icc_smoke.sh",
+        source_root / "scripts" / "run_vm_parity.sh",
+        source_root / "scripts" / "run_v1_3_readiness.sh",
+        source_root / "scripts" / "run_language_coverage.sh",
+    };
     if (!fs::exists(package_verifier_path)) {
         return fail("verify_release_package.py not found under source root");
+    }
+    if (!fs::exists(durable_work_root_path) || !fs::exists(test_isolation_path) ||
+        !fs::exists(region_handle_rss_gate_path)) {
+        return fail("durable release-gate work-root helper not found under source root");
+    }
+    for (const fs::path& gate_path : canonical_gate_paths) {
+        if (!fs::exists(gate_path)) {
+            return fail("canonical release gate not found: " + gate_path.string());
+        }
+    }
+    for (const fs::path& gate_path : durable_transitive_gate_paths) {
+        if (!fs::exists(gate_path)) {
+            return fail("durable transitive release gate not found: " +
+                        gate_path.string());
+        }
+    }
+    for (const fs::path& gate_path : durable_python_gate_paths) {
+        if (!fs::exists(gate_path)) {
+            return fail("durable Python release gate not found: " +
+                        gate_path.string());
+        }
     }
     const fs::path repl_jit_path =
         source_root / "lib" / "repl" / "repl_jit.cpp";
@@ -123,6 +172,11 @@ int main(int argc, char** argv) {
     const std::string gpu_backend_verifier =
         read_file(gpu_backend_verifier_path);
     const std::string package_verifier = read_file(package_verifier_path);
+    const std::string durable_work_root = read_file(durable_work_root_path);
+    const std::string test_isolation = read_file(test_isolation_path);
+    const std::string region_handle_rss_gate = read_file(region_handle_rss_gate_path);
+    const std::string icc_smoke =
+        read_file(source_root / "scripts" / "run_icc_smoke.sh");
     const std::string repl_jit = read_file(repl_jit_path);
     const std::string jit_target_config = read_file(jit_target_config_path);
     const std::string jit_coff_memory_manager =
@@ -135,6 +189,86 @@ int main(int argc, char** argv) {
     const std::string windows_export_verifier =
         read_file(windows_export_verifier_path);
     bool ok = true;
+
+    ok = ok &&
+         expect_contains(durable_work_root, "ESHKOL_DURABLE_WORK_ROOT",
+                         "durable helper exposes the release work-root opt-in") &&
+         expect_contains(durable_work_root, "must be an absolute path",
+                         "durable helper rejects relative work roots") &&
+         expect_contains(durable_work_root, "durable evidence target already exists",
+                         "durable helper rejects stale gate evidence") &&
+         expect_contains(durable_work_root, "eshkol_durable_prepare_dir",
+                         "durable helper claims deterministic gate directories");
+    for (const fs::path& gate_path : canonical_gate_paths) {
+        const std::string gate = read_file(gate_path);
+        ok = ok &&
+             expect_contains(gate, "scripts/lib/durable_work_root.sh",
+                             gate_path.filename().string() +
+                                 " sources the durable work-root contract") &&
+             expect_contains(gate, "eshkol_durable_prepare_dir",
+                             gate_path.filename().string() +
+                                 " claims durable evidence when opted in");
+    }
+    const std::string language_coverage =
+        read_file(source_root / "scripts" / "run_language_coverage.sh");
+    ok = ok &&
+         expect_contains(language_coverage, "generated-traces",
+                         "language coverage keeps generated core and quantum traces below its durable gate") &&
+         expect_contains(language_coverage, "Kept durable language-coverage traces",
+                         "language coverage retains durable generated traces");
+    ok = ok &&
+         expect_contains(test_isolation, "test-isolation-${label}-${ESHKOL_TEST_REPO_TAG}",
+                         "test isolation claims a distinct durable child per suite label") &&
+         expect_contains(test_isolation, "retaining durable scratch directory",
+                         "test isolation retains durable release evidence") &&
+         expect_contains(test_isolation, "source \"$repo_root/scripts/lib/durable_work_root.sh\"",
+                         "test isolation uses the shared durable-root contract");
+    ok = ok &&
+         expect_contains(region_handle_rss_gate, "scripts/lib/durable_work_root.sh",
+                         "region-handle RSS gate sources the durable-root contract") &&
+         expect_contains(region_handle_rss_gate,
+                         "eshkol_durable_prepare_dir region-handle-training-rss",
+                         "region-handle RSS gate claims a dedicated durable child") &&
+         expect_contains(region_handle_rss_gate, "TIME_PROBE=\"$WORK/time-probe.log\"",
+                         "region-handle RSS probe log stays beneath durable evidence") &&
+         expect_contains(region_handle_rss_gate,
+                         "if ! eshkol_durable_enabled; then trap 'rm -rf \"$WORK\"' EXIT; fi",
+                         "region-handle RSS gate retains durable evidence");
+    for (const fs::path& gate_path : durable_transitive_gate_paths) {
+        const std::string gate = read_file(gate_path);
+        ok = ok &&
+             expect_contains(gate, "scripts/lib/durable_work_root.sh",
+                             gate_path.filename().string() +
+                                 " sources the durable-root contract") &&
+             expect_contains(gate, "eshkol_durable_prepare_dir",
+                             gate_path.filename().string() +
+                                 " claims a dedicated durable child");
+    }
+    for (const fs::path& gate_path : durable_python_gate_paths) {
+        const std::string gate = read_file(gate_path);
+        ok = ok &&
+             expect_contains(gate, "--workdir",
+                             gate_path.filename().string() +
+                                 " accepts caller-owned durable workdirs");
+    }
+    ok = ok &&
+         expect_contains(icc_smoke, "eshkol_durable_prepare_dir generative-differential",
+                         "ICC smoke claims generative-differential evidence") &&
+         expect_contains(icc_smoke, "eshkol_durable_prepare_dir surface-parity",
+                         "ICC smoke claims surface-parity evidence") &&
+         expect_contains(icc_smoke, "eshkol_durable_prepare_dir engine-parity",
+                         "ICC smoke claims engine-parity evidence") &&
+         expect_contains(icc_smoke, "eshkol_durable_prepare_dir value-position",
+                         "ICC smoke claims value-position evidence") &&
+         expect_contains(icc_smoke, "--workdir \"$workdir\"",
+                         "ICC smoke passes caller-owned workdirs to Python gates");
+    const std::string p8_escape =
+        read_file(source_root / "scripts" / "run_p8_escape.sh");
+    ok = ok &&
+         expect_contains(p8_escape, "if ! eshkol_durable_enabled; then rm -rf \"$WORK\"; fi",
+                         "P8 parent retains durable test-isolation work") &&
+         expect_contains(p8_escape, "eshkol_test_isolation_cleanup",
+                         "P8 parent preserves shared isolation cleanup semantics");
 
     ok = ok &&
          expect_contains(workflow, "name: Release",

--- a/tests/toolchain/static_link_getenv_capability_test.sh
+++ b/tests/toolchain/static_link_getenv_capability_test.sh
@@ -60,7 +60,7 @@ STATIC_LIB="$BUILD_DIR/${STATIC_PREFIX}eshkol-static${STATIC_SUFFIX}"
 [ -f "$STATIC_LIB" ] || fail "static library is missing: $STATIC_LIB"
 
 if eshkol_durable_enabled; then
-    WORK_TMP="$(eshkol_durable_prepare_dir static-link-getenv)"
+    WORK_TMP="$(eshkol_durable_prepare_dir static-link-getenv)" || exit $?
 else
     WORK_TMP="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-static-link.XXXXXX")"
 fi

--- a/tests/toolchain/static_link_getenv_capability_test.sh
+++ b/tests/toolchain/static_link_getenv_capability_test.sh
@@ -29,6 +29,7 @@ fi
 
 SOURCE_ROOT="$(cd "$SOURCE_ROOT" && pwd)"
 BUILD_DIR="$(cd "$BUILD_DIR" && pwd)"
+. "$SOURCE_ROOT/scripts/lib/durable_work_root.sh"
 CONFIG_HEADER="$BUILD_DIR/generated/eshkol/build_config.h"
 
 if [ ! -f "$CONFIG_HEADER" ]; then
@@ -58,9 +59,15 @@ STATIC_LIB="$BUILD_DIR/${STATIC_PREFIX}eshkol-static${STATIC_SUFFIX}"
 [ -f "$STDLIB_OBJ" ] || fail "stdlib object is missing: $STDLIB_OBJ"
 [ -f "$STATIC_LIB" ] || fail "static library is missing: $STATIC_LIB"
 
-WORK_TMP="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-static-link.XXXXXX")"
+if eshkol_durable_enabled; then
+    WORK_TMP="$(eshkol_durable_prepare_dir static-link-getenv)"
+else
+    WORK_TMP="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-static-link.XXXXXX")"
+fi
 cleanup() {
-    [ -n "${WORK_TMP:-}" ] && [ -d "$WORK_TMP" ] && rm -rf -- "$WORK_TMP"
+    if ! eshkol_durable_enabled; then
+        [ -n "${WORK_TMP:-}" ] && [ -d "$WORK_TMP" ] && rm -rf -- "$WORK_TMP"
+    fi
 }
 trap cleanup EXIT
 

--- a/tests/toolchain/transitive_ffi_link_test.sh
+++ b/tests/toolchain/transitive_ffi_link_test.sh
@@ -16,6 +16,9 @@
 
 set -uo pipefail
 
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
+
 ESHKOL_RUN="${1:-${ESHKOL_RUN:-}}"
 if [ -z "$ESHKOL_RUN" ]; then
     if [ -x "./build/eshkol-run" ]; then
@@ -43,8 +46,12 @@ if [ -z "$agent_archive" ]; then
     exit 0
 fi
 
-tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT
+if eshkol_durable_enabled; then
+    tmp="$(eshkol_durable_prepare_dir transitive-ffi-link)" || exit $?
+else
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+fi
 
 fail() { echo "FAIL: transitive_ffi_link_test — $1" >&2; exit 1; }
 

--- a/tests/v1_3_edge_cases/jit_cache_test.sh
+++ b/tests/v1_3_edge_cases/jit_cache_test.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$REPO_ROOT/scripts/lib/durable_work_root.sh"
+
 ESHKOL_RUN="${1:-${ESHKOL_RUN:-}}"
 if [ -z "$ESHKOL_RUN" ]; then
     if [ -x "./build/eshkol-run" ]; then
@@ -18,8 +21,12 @@ if [ ! -x "$ESHKOL_RUN" ]; then
     exit 1
 fi
 
-tmpdir="$(mktemp -d)"
-trap 'rm -rf "$tmpdir"' EXIT
+if eshkol_durable_enabled; then
+    tmpdir="$(eshkol_durable_prepare_dir jit-cache-test)"
+else
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+fi
 
 src="$tmpdir/cache.esk"
 cache="$tmpdir/cache"
@@ -54,7 +61,7 @@ fi
 # The key previously hashed only the entry file, so editing a transitively
 # loaded file left the key unchanged and `-r` re-ran a STALE cached binary.
 # entry.esk loads mid.esk which loads deep.esk; we edit the *deepest* file.
-depdir="$(mktemp -d)"
+if eshkol_durable_enabled; then depdir="$tmpdir/dependency"; mkdir "$depdir"; else depdir="$(mktemp -d)"; fi
 mkdir -p "$depdir/cache"
 printf '(define (deep-msg) "DEP_LOADED_ONE")\n' > "$depdir/deep.esk"
 printf '(load "deep.esk")\n(define (mid-msg) (deep-msg))\n' > "$depdir/mid.esk"
@@ -77,12 +84,12 @@ ESHKOL_JIT_CACHE_DIR="$depdir/cache" ESHKOL_JIT_CACHE_TRACE=1 \
     "$ESHKOL_RUN" -r "$depdir/entry.esk" > "$depdir/dout3" 2> "$depdir/derr3"
 grep -q '\[jit-cache\] miss ' "$depdir/derr3" || { echo "FAIL: editing a loaded dependency did not invalidate the cache (ESH-0183 regression)" >&2; exit 1; }
 grep -q '^DEP_LOADED_TWO$' "$depdir/dout3" || { echo "FAIL: STALE output after dependency edit — cache shipped old code (ESH-0183 regression)" >&2; exit 1; }
-rm -rf "$depdir"
+if ! eshkol_durable_enabled; then rm -rf "$depdir"; fi
 
 # ── ESH-0183: the AOT (`-o`/--emit-object) path must reflect a fresh edit ─────
 # A single fresh compile is uncached, but guard against any future object cache
 # that could resurrect the "stale object on source edit" report.
-aotdir="$(mktemp -d)"
+if eshkol_durable_enabled; then aotdir="$tmpdir/aot"; mkdir "$aotdir"; else aotdir="$(mktemp -d)"; fi
 printf '(define (aot-fn) (display "AOT_MARK_ORIG") (newline))\n(aot-fn)\n' > "$aotdir/a.esk"
 "$ESHKOL_RUN" --emit-object -o "$aotdir/a.o" "$aotdir/a.esk" > "$aotdir/aot1.log" 2>&1 || { echo "FAIL: AOT compile 1 failed" >&2; cat "$aotdir/aot1.log" >&2; exit 1; }
 strings "$aotdir/a.o" | grep -q 'AOT_MARK_ORIG' || { echo "FAIL: AOT object 1 missing its own string" >&2; exit 1; }
@@ -90,6 +97,6 @@ strings "$aotdir/a.o" | grep -q 'AOT_MARK_ORIG' || { echo "FAIL: AOT object 1 mi
 printf '(define (aot-fn) (display "AOT_MARK_ORIG") (newline) (display "AOT_MARK_NEW_XYZ") (newline))\n(aot-fn)\n' > "$aotdir/a.esk"
 "$ESHKOL_RUN" --emit-object -o "$aotdir/a.o" "$aotdir/a.esk" > "$aotdir/aot2.log" 2>&1 || { echo "FAIL: AOT compile 2 failed" >&2; cat "$aotdir/aot2.log" >&2; exit 1; }
 strings "$aotdir/a.o" | grep -q 'AOT_MARK_NEW_XYZ' || { echo "FAIL: AOT object did not reflect the fresh edit (stale object regression)" >&2; exit 1; }
-rm -rf "$aotdir"
+if ! eshkol_durable_enabled; then rm -rf "$aotdir"; fi
 
 echo "PASS: jit_cache_test"

--- a/tests/v1_3_edge_cases/jit_cache_test.sh
+++ b/tests/v1_3_edge_cases/jit_cache_test.sh
@@ -22,7 +22,7 @@ if [ ! -x "$ESHKOL_RUN" ]; then
 fi
 
 if eshkol_durable_enabled; then
-    tmpdir="$(eshkol_durable_prepare_dir jit-cache-test)"
+    tmpdir="$(eshkol_durable_prepare_dir jit-cache-test)" || exit $?
 else
     tmpdir="$(mktemp -d)"
     trap 'rm -rf "$tmpdir"' EXIT


### PR DESCRIPTION
## Summary

Adds an opt-in `ESHKOL_DURABLE_WORK_ROOT` mode for the canonical v1.3.4 final gates.

When enabled, release probes claim deterministic, gate-specific directories beneath a caller-provided absolute root; stale targets and symlink roots are rejected, evidence is retained, and no `/tmp`, `/private/tmp`, or `mktemp` path is used. Existing developer and CI behavior remains unchanged when the variable is unset.

This is temporarily stacked on #448 so CI can run in parallel. It will be retargeted to `master` after #448 lands.

## Coverage

- ICC smoke, VM parity, readiness, and Taylor equivalence
- AD/tensor/fuzz transitive gates
- memory RSS, JIT-cache, and static-link CTest gates
- existing release workflow surface test expanded; no CTest-count change

## Local verification

- release workflow surface test: PASS
- durable JIT-cache gate: PASS
- VM parity audit-only durable evidence: PASS
- bash syntax for every touched shell file: PASS
- ICC guard/pre-commit/reindex: PASS/FRESH
- author and committer identity: `tsotchkele@gmail.com`
