### PR TITLE
fix(release): keep durable coverage corpus complete

### DIFF
--- a/scripts/run_vm_tests.sh
+++ b/scripts/run_vm_tests.sh
@@ -5,6 +5,8 @@ set -e
 
 BUILD_DIR="${BUILD_DIR:-build}"
 VM="${BUILD_DIR}/eshkol-vm-standalone-test"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIRST_CLASS_TEST="$ROOT_DIR/tests/integration/vm_first_class_builtin_families_test.esk"
 
 if [ ! -x "$VM" ]; then
     echo "eshkol-vm-standalone-test not found at $VM - build first." >&2
@@ -29,6 +31,7 @@ source "$ESHKOL_TEST_LIB"
 eshkol_test_isolation_init "vm"
 
 OUT_TMP="$ESHKOL_TEST_TMPDIR/vm_standalone_tests.log"
+FIRST_CLASS_OUT="$ESHKOL_TEST_TMPDIR/vm_first_class_builtin_families.log"
 cleanup_output() {
     eshkol_test_isolation_cleanup
 }
@@ -73,9 +76,30 @@ if [ "$rc" -eq 0 ]; then
         exit 1
     fi
 
+    # Keep the first-class builtin-family integration program in the complete
+    # traced corpus.  CTest also owns this test, but the executable-language
+    # coverage gate consumes run_all_tests.sh traces; omitting it there silently
+    # dropped execution evidence for the deep car/cdr accessor family.
+    set +e
+    ESHKOL_VM_NO_DISASM=1 "$VM" "$FIRST_CLASS_TEST" >"$FIRST_CLASS_OUT" 2>&1
+    first_class_rc=$?
+    set -e
+    if [ "$first_class_rc" -ne 0 ] || \
+       eshkol_test_output_has_failure "$FIRST_CLASS_OUT" || \
+       ! eshkol_test_output_has_marker "$FIRST_CLASS_OUT" \
+           'PASS: VM first-class builtin families'; then
+        tail -80 "$FIRST_CLASS_OUT"
+        echo ""
+        echo "VM first-class builtin-family integration did not produce its pass marker."
+        echo "Passed: 1"
+        echo "Failed: 1"
+        exit 1
+    fi
+
     grep "Source tests: " "$OUT_TMP" | tail -1
+    grep "PASS: VM first-class builtin families" "$FIRST_CLASS_OUT" | tail -1
     echo ""
-    echo "Passed: 1"
+    echo "Passed: 2"
     echo "Failed: 0"
     exit 0
 fi

--- a/scripts/test_run_sicp_smoke_gate.sh
+++ b/scripts/test_run_sicp_smoke_gate.sh
@@ -19,9 +19,14 @@ fail() {
 
 [ -f "$SMOKE" ] || fail "missing smoke script: $SMOKE"
 
-WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-sicp-smoke-gate.XXXXXX")" || exit 1
+TEST_ISOLATION="$ROOT/scripts/lib/test_isolation.sh"
+[ -r "$TEST_ISOLATION" ] || fail "missing test isolation helper: $TEST_ISOLATION"
+ESHKOL_TEST_ISOLATION_NO_TRAP=1
+source "$TEST_ISOLATION"
+eshkol_test_isolation_init "sicp-smoke-gate"
+WORK="$ESHKOL_TEST_TMPDIR"
 cleanup() {
-    [ -n "${WORK:-}" ] && [ -d "$WORK" ] && rm -rf -- "$WORK"
+    eshkol_test_isolation_cleanup
 }
 trap cleanup EXIT
 
@@ -41,6 +46,8 @@ setup_fake_repo() {
     # gate would have passed a harness with no detection at all.
     cp "$ROOT/scripts/lib/test_isolation.sh" "$FAKE/scripts/lib/test_isolation.sh" \
         || fail "copy test_isolation.sh"
+    cp "$ROOT/scripts/lib/durable_work_root.sh" "$FAKE/scripts/lib/durable_work_root.sh" \
+        || fail "copy durable_work_root.sh"
 
     cat > "$FAKE/tests/sicp/ch1_newton.esk" <<'ESK'
 (display "fake sicp probe") (newline)
@@ -103,13 +110,23 @@ SH_TAIL
 
 run_smoke() {
     local label="$1"
+    local smoke_durable_root=""
     shift
     LAST_OUT="$WORK/${label}.out"
     : "${LAST_OUT:?LAST_OUT must be set}"
+    if [ -n "${ESHKOL_DURABLE_WORK_ROOT:-}" ]; then
+        # Each synthetic smoke invocation needs its own durable root.  The fake
+        # repository is exercised repeatedly with the same isolation label, and
+        # reusing the outer root would correctly trip the stale-evidence guard on
+        # the second invocation.  Keep every nested run below this fixture's
+        # already-claimed durable directory while preserving fail-closed claims.
+        smoke_durable_root="$WORK/durable-$label"
+    fi
     # The smoke script's timeout shim uses perl; force a portable locale so
     # macOS hosts without C.UTF-8 do not fail before the fake runner executes.
     if [ -n "${RUN_BUILD_DIR:-}" ]; then
         BUILD_DIR="$RUN_BUILD_DIR" \
+            ESHKOL_DURABLE_WORK_ROOT="$smoke_durable_root" \
             ESHKOL_JIT_CACHE_DIR="$WORK/jit-cache-$label" \
             LC_ALL=C LC_CTYPE=C LANG=C \
             "$FAKE/scripts/run_sicp_smoke.sh" "$@" >"${LAST_OUT:?}" 2>&1
@@ -118,6 +135,7 @@ run_smoke() {
         # aggregate harness.  This branch is specifically the default-build
         # behavior test, so it must exercise the fake repo's `build/` runner.
         BUILD_DIR=build \
+            ESHKOL_DURABLE_WORK_ROOT="$smoke_durable_root" \
             ESHKOL_JIT_CACHE_DIR="$WORK/jit-cache-$label" \
             LC_ALL=C LC_CTYPE=C LANG=C \
             "$FAKE/scripts/run_sicp_smoke.sh" "$@" >"${LAST_OUT:?}" 2>&1


### PR DESCRIPTION
## Summary

- route the synthetic SICP gate fixture through shared test isolation in durable mode
- copy the durable helper into its fake repository and give repeated nested smoke invocations distinct retained roots
- execute the first-class VM builtin-family integration program in the complete traced corpus so all deep car/cdr selectors retain execution evidence

## Validation

- default and durable SICP gate fixture: PASS
- VM standalone source corpus: 73/73 plus first-class builtin-family PASS
- added trace closes all 13 list-pair coverage deficits without lowering the 100% policy floor
- ICC freshness, guard, pre-commit, and diff checks: PASS