### PR TITLE
fix(p6): classify ESHKOL_THE_OP in the depth-coverage registry

### DIFF
--- a/scripts/depth_coverage_registry.json
+++ b/scripts/depth_coverage_registry.json
@@ -70,6 +70,7 @@
     "ESHKOL_DIRECTIONAL_DERIV_OP": {"class": "composable", "pillar": "P6a", "note": "directional-derivative nesting"},
     "ESHKOL_TYPE_ANNOTATION_OP": {"class": "composable", "pillar": null, "gap_task": "ESH-0141", "note": "nested type expressions (arrow/forall) — no pillar sweeps type-expression nesting depth"},
     "ESHKOL_FORALL_OP": {"class": "composable", "pillar": null, "gap_task": "ESH-0141", "note": "nested polymorphic type quantifiers — un-swept"},
+    "ESHKOL_THE_OP": {"class": "composable", "pillar": null, "gap_task": "ESH-0141", "note": "(the type expr) ascription — expr and type_expr both nest (the expr can itself be another (the ...) form; the type_expr can be an arrow/forall) — same un-swept type-expression nesting depth as ESHKOL_TYPE_ANNOTATION_OP"},
     "ESHKOL_GUARD_OP": {"class": "composable", "pillar": "P6c", "note": "nested guard/raise"},
     "ESHKOL_RAISE_OP": {"class": "composable", "pillar": "P6c", "note": "nested guard/raise"},
     "ESHKOL_LET_VALUES_OP": {"class": "composable", "pillar": "P6c", "note": "nested multiple-values binding"},


### PR DESCRIPTION
## Summary

`python3 scripts/check_depth_coverage.py` was failing on master (db257547) because `ESHKOL_THE_OP` exists in the op enum (`inc/eshkol/eshkol.h`) but had no entry in `scripts/depth_coverage_registry.json` — the gate treats any enum op with no registry entry as an unclassified-op error, distinct from the 10 already-tracked depth-sweep gaps.

## What the op is

`ESHKOL_THE_OP` implements `(the type expr)` — a type-ascription form that tells the checker to treat `expr` as `type`, and is a runtime no-op (it evaluates `expr` verbatim). See `inc/eshkol/eshkol.h:2247`, `lib/frontend/parser.cpp:4780-4820`, `lib/types/type_checker.cpp:1187`.

## Classification

Both operands of `(the type expr)` can nest:
- `type_expr` can itself be an arrow/forall type expression.
- `expr` can itself be another `(the ...)` form.

This is exactly the nesting hazard already registered for `ESHKOL_TYPE_ANNOTATION_OP` and `ESHKOL_FORALL_OP`, both of which are `class: composable` with `gap_task: ESH-0141` ("no pillar sweeps type-expression nesting depth"). `ESHKOL_THE_OP` is classified the same way, under the same tracked gap, rather than being added as a new untracked gap or misclassified as a leaf.

## Verification

- `python3 scripts/check_depth_coverage.py` now exits 0 (gate PASSED, 94 total composables, 11 tracked gaps including this one).
- No pillar-specific depth harness applies here since this op joins an already-un-swept gap (ESH-0141), not a swept pillar.
- ICC `guard-diff` and `pre-commit-check` both PASS on this change.