### PR TITLE
feat(assurance): ledger-integrity and oracle-schema gates with self-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,69 @@ jobs:
           set -euo pipefail
           python3 scripts/test_language_coverage_gate.py -v
 
+  # v1.3.5 assurance wave 1: three release gates that used to be doctrine
+  # living only in prose (a memory file, a script's docstring) rather than
+  # something that could actually fail a PR. All three are pure Python over
+  # committed YAML — no compiler, no eshkol-run binary — so, like
+  # surface-manifest above, this belongs in a fast required job rather than
+  # only inside the heavy matrix or (for gate_no_silent_wrong.py) nowhere at
+  # all, which is where it lived before this job existed.
+  #
+  #   - gate_no_silent_wrong.py checks .icc/silent-wrong-ledger.yaml: no open,
+  #     unwaived SILENT-WRONG flaw ships. It existed on master already but
+  #     was never wired into any CI workflow — a gate nobody runs is not a
+  #     gate.
+  #   - check_ledger_integrity.py checks the SAME ledger for the structural
+  #     defect gate_no_silent_wrong.py does not look for: duplicate ids
+  #     across the whole file. A textual git merge does not conflict when two
+  #     branches independently allocate the same next-free id, so this class
+  #     of bug is invisible to code review. SW-33 collided three times this
+  #     way, SW-35 twice and SW-42 twice, before being resolved by hand.
+  #   - check_oracle_schema.py checks .icc/completion-oracles.yaml, the file
+  #     `icc readiness` reads to grade this repo's release criteria. PR #429
+  #     dropped a list-item opener while adding a criterion and broke the
+  #     YAML parse; the sharper failure mode the gate is built for is the one
+  #     where the file still parses but a criterion silently normalises to
+  #     nothing (a `runtime_event` with no `event_kinds`, a duplicated
+  #     criterion id) — readiness keeps running and prints a verdict computed
+  #     over fewer criteria than the file's author wrote, with nothing in the
+  #     output to say so.
+  #
+  # Each gate also carries a `--self-test` mode exercised here: it feeds the
+  # gate deliberately-broken fixtures (malformed YAML, a duplicate id, a
+  # missing required field) and asserts the gate goes RED on every one of
+  # them, plus a well-formed fixture asserting it does not fail on
+  # everything indiscriminately. A gate that cannot fail is not a gate.
+  assurance-gates:
+    name: assurance-gates
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install PyYAML
+        shell: bash
+        run: python3 -m pip install --quiet --disable-pip-version-check pyyaml
+
+      - name: Self-test — each gate must be able to fail
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/gate_no_silent_wrong.py --self-test
+          python3 scripts/check_ledger_integrity.py --self-test
+          python3 scripts/check_oracle_schema.py --self-test
+
+      - name: No open, unwaived SILENT-WRONG flaw ships
+        shell: bash
+        run: python3 scripts/gate_no_silent_wrong.py --no-trace
+
+      - name: Silent-wrong ledger has no duplicate ids and every entry is well-formed
+        shell: bash
+        run: python3 scripts/check_ledger_integrity.py --no-trace
+
+      - name: Completion-oracle file parses and every criterion is gradeable
+        shell: bash
+        run: python3 scripts/check_oracle_schema.py --no-trace
+
   # Moonlab is deliberately opt-in, so keep its networked macOS coverage in a
   # separate advisory job. `continue-on-error` makes the lane informative
   # without turning the default required CI set into a Moonlab availability

--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -82,6 +82,40 @@ oracles:
         label: 'No open, unwaived SILENT-WRONG flaw ships: every entry in .icc/silent-wrong-ledger.yaml whose bucket is SILENT-WRONG (or which is IN-FLIGHT but silent_wrong_class) is closed/fixed/guarded with evidence, or carries an owner/reason/unexpired waiver — wrong values, wrong derivatives and wrong memory outcomes with no diagnostic and exit 0 are tag-blocking'
         action: python3 scripts/gate_no_silent_wrong.py
 
+      # ── Assurance wave 1 (2026-08-24) ─────────────────────────────────
+      # The silent-wrong gate above answers "is every KNOWN flaw closed or
+      # waived" but assumes its own input — the ledger file — is trustworthy.
+      # It is a text file merged like any other: SW-33 was independently
+      # allocated on three separate branches, SW-35 twice and SW-42 twice,
+      # none of which conflicted in git because a textual merge does not
+      # notice two branches picking the same next-free id. This criterion is
+      # the check that would have caught each collision before merge instead
+      # of after.
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["ledger_integrity_clean"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'Silent-wrong ledger has no duplicate ids across the whole file and every entry has id/bucket/status/title plus closure evidence when not open (scripts/check_ledger_integrity.py)'
+        action: python3 scripts/check_ledger_integrity.py
+
+      # This oracle's own definition lives in a YAML file merged the same
+      # way the ledger is. PR #429 dropped a list-item opener while adding a
+      # criterion and broke the parse outright (icc readiness blocked, score
+      # 85) until c8449f8a restored it by hand. The sharper failure this
+      # criterion is built for is quieter: the file still parses but a
+      # criterion silently normalises to nothing (a runtime_event with no
+      # event_kinds, a duplicated criterion id) and readiness keeps running,
+      # grading fewer criteria than this file's author wrote, with nothing
+      # in the output to say so.
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["oracle_schema_clean"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'This completion-oracle file parses and every criterion in every oracle validates to the same count declared — no criterion is silently dropped by the grader (scripts/check_oracle_schema.py)'
+        action: python3 scripts/check_oracle_schema.py
+
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["llvm_module_verifier_clean"]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4416,6 +4416,67 @@ if(ESHKOL_BUILD_TESTS)
                     --eshkol-vm $<TARGET_FILE:eshkol-vm-standalone-test>
         )
     endif()
+
+    # Assurance-wave-1 gates (v1.3.5): three ledger/oracle release gates that
+    # used to live only as prose in a memory file or as a script nobody ran in
+    # CI. Each gets two ctest entries: the gate run against the REAL committed
+    # ledger/oracle file (must PASS today, and regress loudly the day either
+    # file breaks), and its --self-test mode (must demonstrate the gate can
+    # actually go red on deliberately-broken input — "a gate that cannot fail
+    # is not a gate"). All three are pure Python over checked-out files; none
+    # needs a compiled artifact, so they are guarded on ESHKOL_PYTHON3_EXECUTABLE
+    # alone, same as the validators above.
+    if(ESHKOL_PYTHON3_EXECUTABLE AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/gate_no_silent_wrong.py")
+        add_test(
+            NAME no_silent_wrong_gate
+            COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/gate_no_silent_wrong.py"
+                    --no-trace
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+        add_test(
+            NAME no_silent_wrong_gate_selftest
+            COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/gate_no_silent_wrong.py"
+                    --self-test
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+        set_tests_properties(no_silent_wrong_gate no_silent_wrong_gate_selftest PROPERTIES TIMEOUT 60)
+    endif()
+    if(ESHKOL_PYTHON3_EXECUTABLE AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_ledger_integrity.py")
+        add_test(
+            NAME ledger_integrity_gate
+            COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_ledger_integrity.py"
+                    --no-trace
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+        add_test(
+            NAME ledger_integrity_gate_selftest
+            COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_ledger_integrity.py"
+                    --self-test
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+        set_tests_properties(ledger_integrity_gate ledger_integrity_gate_selftest PROPERTIES TIMEOUT 60)
+    endif()
+    if(ESHKOL_PYTHON3_EXECUTABLE AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_oracle_schema.py")
+        add_test(
+            NAME oracle_schema_gate
+            COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_oracle_schema.py"
+                    --no-trace
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+        add_test(
+            NAME oracle_schema_gate_selftest
+            COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_oracle_schema.py"
+                    --self-test
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+        set_tests_properties(oracle_schema_gate oracle_schema_gate_selftest PROPERTIES TIMEOUT 60)
+    endif()
 endif()
 
 if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/pointer_type_surface_test.cpp")

--- a/scripts/check_ledger_integrity.py
+++ b/scripts/check_ledger_integrity.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Release gate: the silent-wrong flaw ledger is a well-formed ledger.
+
+`.icc/silent-wrong-ledger.yaml` is hand-edited by every branch that opens or
+closes a flaw, and it is merged like any other text file: two branches that
+each add an entry near the same place produce a textual merge, not a content
+merge, and git happily accepts it even when the result is unusable as a
+ledger. This gate is the check that a bare `git merge` cannot perform.
+
+It answers three questions a YAML parser alone does not:
+
+  1. Does the file parse at all? A stray `- id:` at the wrong indent, an
+     unclosed quote, or a duplicated block key breaks every consumer
+     downstream (gate_no_silent_wrong.py, the completion-oracle criteria that
+     read its trace) with no signal beyond a stack trace nobody was watching
+     for.
+
+  2. Does every id appear exactly once ACROSS THE WHOLE LEDGER? A textual
+     merge does not conflict when two branches each independently pick the
+     same next-free id — both edits "apply" cleanly and the file still
+     parses. The result is two entries answering to one name: a lookup finds
+     whichever one comes first, edits meant for one land on the other, and a
+     human auditing "is SW-42 closed" gets an arbitrary answer. This is not
+     hypothetical: SW-33 was independently allocated three times, SW-35 twice
+     and SW-42 twice, on stacked branches that never conflicted with each
+     other. The ledger's own `renumbered_from` fields record how each
+     collision was eventually resolved by hand; this gate exists so the next
+     one is caught before merge instead of after.
+
+  3. Does every entry carry the minimum shape a reader (or gate_no_silent_
+     wrong.py) needs to make sense of it: an `id`, a `bucket` that is one of
+     the buckets this file itself declares, a `status` from the vocabulary
+     the gate understands, a `title`, and — for any entry whose status is not
+     `open` — at least one closure-evidence field naming what closed it
+     (`closed_at`, `evidence`, `fixed_by`, `resolution` or `guarded_by`).
+     "Believed fixed" with nothing to point at is not evidence; the ledger's
+     own header states this as INVARIANT 1 and 3.
+
+Grading
+    PASS  the file parses, has no duplicate id anywhere in `entries`, and
+          every entry satisfies the minimum shape above.
+    FAIL  a parse error, any duplicate id, or any entry missing a required
+          field / carrying a bucket or status this gate does not recognise /
+          closed-like with no closure evidence.
+
+The gate FAILS CLOSED: a missing or unparseable ledger is FAIL, never a silent
+pass, for the same reason gate_no_silent_wrong.py fails closed — absence of
+the ledger is not evidence of an absence of defects in it.
+
+Usage
+    python3 scripts/check_ledger_integrity.py
+    python3 scripts/check_ledger_integrity.py --ledger path/to/ledger.yaml
+    python3 scripts/check_ledger_integrity.py --format json
+    python3 scripts/check_ledger_integrity.py --self-test
+
+Exit status is 0 on PASS and 1 on FAIL (including under --self-test, where it
+reports whether the gate itself is capable of failing).
+
+Copyright (C) tsotchke
+SPDX-License-Identifier: MIT
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import sys
+import tempfile
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_LEDGER = os.path.join(REPO_ROOT, ".icc", "silent-wrong-ledger.yaml")
+DEFAULT_TRACE_DIR = os.path.join(REPO_ROOT, "scripts", "icc_traces")
+TRACE_BASENAME = "ledger_integrity_gate.jsonl"
+PROBE_ID = "ledger_integrity_clean"
+
+KNOWN_STATUSES = ("open", "closed", "fixed", "guarded")
+TERMINAL_STATUSES = ("closed", "fixed", "guarded")
+CLOSURE_EVIDENCE_FIELDS = ("closed_at", "evidence", "fixed_by", "resolution", "guarded_by")
+REQUIRED_ENTRY_FIELDS = ("id", "bucket", "status", "title")
+
+
+class LedgerIntegrityError(Exception):
+    """The ledger could not be read or parsed at all."""
+
+
+def _load_yaml(path: str) -> object:
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise LedgerIntegrityError(
+            "PyYAML is required to check the ledger (pip install pyyaml)"
+        ) from exc
+
+    if not os.path.isfile(path):
+        raise LedgerIntegrityError(f"ledger not found at {path} (the gate fails closed)")
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            return yaml.safe_load(handle)
+    except Exception as exc:
+        raise LedgerIntegrityError(f"ledger at {path} is not parseable: {exc}") from exc
+
+
+def check(data: object) -> dict:
+    """Validate a parsed ledger document. Never raises; returns a report."""
+
+    errors: list[str] = []
+
+    if not isinstance(data, dict):
+        return {"passed": False, "errors": ["ledger document is not a mapping"],
+                "entry_count": 0, "duplicate_ids": {}, "bucket_counts": {}}
+
+    buckets = data.get("buckets")
+    declared_buckets = set(buckets.keys()) if isinstance(buckets, dict) else set()
+    if not declared_buckets:
+        errors.append("ledger has no `buckets` mapping (or it is empty) — nothing to validate entry buckets against")
+
+    entries = data.get("entries")
+    if not isinstance(entries, list):
+        errors.append("ledger has no `entries` list")
+        entries = []
+
+    seen_ids: dict[str, int] = {}
+    duplicate_ids: dict[str, int] = {}
+    bucket_counts: dict[str, int] = {}
+
+    for position, raw in enumerate(entries, start=1):
+        if not isinstance(raw, dict):
+            errors.append(f"entry #{position} is not a mapping")
+            continue
+
+        label = f"entry #{position}"
+        entry_id = raw.get("id")
+        if entry_id:
+            label = f"entry #{position} ({entry_id!r})"
+            key = str(entry_id)
+            if key in seen_ids:
+                duplicate_ids[key] = duplicate_ids.get(key, seen_ids[key]) + 1
+            else:
+                seen_ids[key] = 1
+
+        missing = [f for f in REQUIRED_ENTRY_FIELDS if not raw.get(f)]
+        if missing:
+            errors.append(f"{label} is missing required field(s): {', '.join(missing)}")
+            # Still keep validating what IS present below — a missing id
+            # should not hide an unrelated missing-evidence problem.
+
+        bucket = raw.get("bucket")
+        if bucket:
+            bucket_counts[bucket] = bucket_counts.get(bucket, 0) + 1
+            if declared_buckets and bucket not in declared_buckets:
+                errors.append(f"{label} has bucket {bucket!r}, which is not declared in `buckets`")
+
+        status = raw.get("status")
+        if status is not None and status not in KNOWN_STATUSES:
+            errors.append(
+                f"{label} has status {status!r}, expected one of {'/'.join(KNOWN_STATUSES)}"
+            )
+        elif status in TERMINAL_STATUSES:
+            if not any(raw.get(field) for field in CLOSURE_EVIDENCE_FIELDS):
+                errors.append(
+                    f"{label} has status {status!r} but no closure evidence "
+                    f"({'/'.join(CLOSURE_EVIDENCE_FIELDS)})"
+                )
+
+    # Duplicate ids that only ever collide with themselves are recorded once
+    # above (seen_ids counts the FIRST occurrence, duplicate_ids the rest);
+    # normalise to "how many times each id appears" for reporting.
+    occurrence_counts: dict[str, int] = {}
+    for raw in entries:
+        if isinstance(raw, dict) and raw.get("id"):
+            key = str(raw["id"])
+            occurrence_counts[key] = occurrence_counts.get(key, 0) + 1
+    true_duplicates = {k: v for k, v in occurrence_counts.items() if v > 1}
+    for entry_id, count in sorted(true_duplicates.items()):
+        errors.append(f"id {entry_id!r} is used by {count} entries (must be unique across the whole ledger)")
+
+    passed = not errors
+    return {
+        "passed": passed,
+        "errors": errors,
+        "entry_count": len(entries),
+        "duplicate_ids": true_duplicates,
+        "bucket_counts": bucket_counts,
+    }
+
+
+def emit_trace(trace_dir: str, status: str, snippet: str) -> str:
+    os.makedirs(trace_dir, exist_ok=True)
+    path = os.path.join(trace_dir, TRACE_BASENAME)
+    event = {
+        "kind": "eshkol_smoke",
+        "name": PROBE_ID,
+        "value": status,
+        "snippet": snippet[:2000],
+        "confidence": 1.0,
+    }
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+    return path
+
+
+# ───────────────────────────── self-test ─────────────────────────────
+#
+# "A gate that cannot fail is not a gate." Each fixture below feeds the gate
+# deliberately-broken input and asserts it grades FAIL; one well-formed
+# fixture asserts the gate does NOT grade every input FAIL regardless of
+# content (a gate that always fails is exactly as useless as one that never
+# does).
+
+_GOOD_LEDGER = """
+schema: eshkol.silent_wrong_ledger.v1
+buckets:
+  SILENT-WRONG: "wrong value, no diagnostic, exit 0"
+entries:
+  - id: SW-SELFTEST-01
+    bucket: SILENT-WRONG
+    status: closed
+    title: "self-test entry, closed with evidence"
+    closed_at: "deadbeef"
+  - id: SW-SELFTEST-02
+    bucket: SILENT-WRONG
+    status: open
+    title: "self-test entry, open"
+"""
+
+_MALFORMED_YAML = """
+schema: eshkol.silent_wrong_ledger.v1
+entries:
+  - id: SW-X
+    bucket: SILENT-WRONG
+      status: open
+    title: "broken indentation opens a block-mapping the parser cannot close"
+"""
+
+_DUPLICATE_ID_LEDGER = """
+schema: eshkol.silent_wrong_ledger.v1
+buckets:
+  SILENT-WRONG: "wrong value, no diagnostic, exit 0"
+entries:
+  - id: SW-42
+    bucket: SILENT-WRONG
+    status: closed
+    title: "first SW-42, allocated on one branch"
+    closed_at: "aaaaaaaa"
+  - id: SW-42
+    bucket: SILENT-WRONG
+    status: open
+    title: "second SW-42, allocated independently on another branch"
+"""
+
+_MISSING_FIELD_LEDGER = """
+schema: eshkol.silent_wrong_ledger.v1
+buckets:
+  SILENT-WRONG: "wrong value, no diagnostic, exit 0"
+entries:
+  - id: SW-INCOMPLETE
+    status: open
+    title: "entry with no bucket at all"
+  - id: SW-UNEVIDENCED
+    bucket: SILENT-WRONG
+    status: closed
+    title: "closed with nothing pointing at what closed it"
+"""
+
+
+def _run_fixture(name: str, text: str, tmp_dir: str) -> tuple[bool, str]:
+    path = os.path.join(tmp_dir, name + ".yaml")
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(text)
+    try:
+        data = _load_yaml(path)
+    except LedgerIntegrityError as exc:
+        return False, f"parse error (expected for a malformed-YAML fixture): {exc}"
+    result = check(data)
+    return result["passed"], "; ".join(result["errors"]) or "no errors"
+
+
+def self_test() -> bool:
+    """Run the gate against fixtures with known-bad and known-good shape.
+
+    Fixtures live in a temp directory INSIDE the repo (never /tmp) so the
+    gate is exercised against real files on disk exactly as it runs in CI,
+    and the directory is removed before this function returns.
+    """
+
+    cases = [
+        ("malformed_yaml", _MALFORMED_YAML, False),
+        ("duplicate_id", _DUPLICATE_ID_LEDGER, False),
+        ("missing_field", _MISSING_FIELD_LEDGER, False),
+        ("well_formed", _GOOD_LEDGER, True),
+    ]
+
+    all_ok = True
+    with tempfile.TemporaryDirectory(dir=REPO_ROOT, prefix=".selftest-ledger-integrity-") as tmp_dir:
+        print("check_ledger_integrity.py self-test:")
+        for name, text, expect_pass in cases:
+            passed, detail = _run_fixture(name, text, tmp_dir)
+            ok = passed == expect_pass
+            all_ok = all_ok and ok
+            verdict = "OK" if ok else "GATE IS BROKEN"
+            print(f"  [{verdict}] {name}: expected passed={expect_pass}, got passed={passed}")
+            print(f"           {detail}")
+
+    if all_ok:
+        print("self-test: PASS — the gate fails on every broken fixture and passes the well-formed one")
+    else:
+        print("self-test: FAIL — the gate did not discriminate broken input from good input", file=sys.stderr)
+    return all_ok
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--ledger", default=os.environ.get("ESHKOL_FLAW_LEDGER", DEFAULT_LEDGER))
+    parser.add_argument("--trace-dir", default=DEFAULT_TRACE_DIR)
+    parser.add_argument("--no-trace", action="store_true", help="grade only, write no trace")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--self-test", action="store_true", help="run built-in red/green fixtures and exit")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return 0 if self_test() else 1
+
+    try:
+        data = _load_yaml(args.ledger)
+        result = check(data)
+    except LedgerIntegrityError as exc:
+        snippet = f"ledger unusable: {exc}"
+        if not args.no_trace:
+            emit_trace(args.trace_dir, "FAIL", snippet)
+        if args.format == "json":
+            print(json.dumps({"passed": False, "error": str(exc)}, indent=2))
+        else:
+            print(f"{PROBE_ID}: FAIL — {exc}", file=sys.stderr)
+        return 1
+
+    status = "PASS" if result["passed"] else "FAIL"
+    if result["passed"]:
+        snippet = (
+            f"{result['entry_count']} entries, no duplicate ids, "
+            f"all required fields present across {len(result['bucket_counts'])} buckets"
+        )
+    else:
+        snippet = f"{len(result['errors'])} integrity error(s): " + "; ".join(result["errors"][:5])
+
+    if not args.no_trace:
+        emit_trace(args.trace_dir, status, snippet)
+
+    if args.format == "json":
+        print(json.dumps({"status": status, **result}, indent=2))
+    else:
+        print(f"{PROBE_ID}: {status}")
+        print(f"  ledger      : {args.ledger}")
+        print(f"  entries     : {result['entry_count']}")
+        for bucket, count in sorted(result.get("bucket_counts", {}).items()):
+            print(f"  {bucket:<24}: {count}")
+        if result["duplicate_ids"]:
+            print("  DUPLICATE IDS:")
+            for entry_id, count in sorted(result["duplicate_ids"].items()):
+                print(f"    - {entry_id}  used by {count} entries")
+        if result["errors"]:
+            print("  ERRORS:")
+            for error in result["errors"]:
+                print(f"    - {error}")
+
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_oracle_schema.py
+++ b/scripts/check_oracle_schema.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+"""Release gate: `.icc/completion-oracles.yaml` parses and every criterion has
+the shape ICC's completion-oracle grader needs to actually grade it.
+
+Motivating incident: PR #429 added a new `higher_order_shadowing_oracle`
+criterion but dropped the previous entry's `action:` field and the new
+entry's `- runtime_event:` list-item opener. The new criterion's keys landed
+INSIDE the previous criterion's `runtime_event` mapping — a well-formed-
+looking edit that in fact broke the YAML parse (`ParserError: while parsing a
+block mapping expected <block end>, but found <block mapping start>`). ICC's
+own loader (`completion_oracle_config.load_completion_oracle_configs`)
+already rejects an unparseable file outright and reports 0 criteria loaded;
+what it CANNOT do from outside this repo is fail a PR before merge, because
+nothing ran it. `icc readiness` was left blocked on an unparseable oracle
+file (score 85) until commit c8449f8a restored the missing lines by hand —
+after the breakage had already landed on the branch that fed the release
+gate.
+
+The sharper failure mode this gate is built to catch is not "the file fails
+to parse" — that one is at least loud. It's the one where the file DOES
+parse (YAML is very permissive) but a chunk of criteria collapses into
+something the grader treats as fewer, or different, criteria than the file's
+author wrote: a `runtime_event:` with no `event_kinds`, two compact keys on
+one criterion, a duplicated criterion id shadowing an earlier one. Every one
+of those keeps `icc readiness` running to completion and printing a verdict
+— just a verdict computed over less evidence than the author thinks they
+wired in. That is a readiness score of 100 computed by grading 2 of 43
+criteria while silently dropping the other 41: vacuous green, worse than a
+loud failure because it looks identical to a real pass.
+
+This gate re-derives ICC's own per-criterion required-key rules (read
+directly from `completion_oracle_config._normalize_criterion` in the ICC
+source at /Users/tyr/Desktop/infinite_context_coder/scripts/, since ICC is a
+private tool this repo does not vendor or depend on at build time) for the
+criterion kinds this file actually uses today: `runtime_event`,
+`no_contract_gap`, `no_stubbed_paths` and `test_evidence`. Other recognised
+kinds are accepted structurally without a deep per-kind check; extend
+`REQUIRED_KEYS_BY_KIND` here the day this file adopts one of them.
+
+Checks
+    (a) The file parses as YAML and its top level is `{oracles: [...]}`.
+    (b) Every oracle has a `name` and a non-empty `requires` (or `criteria`)
+        list, and no two oracles share a `name` or an alias token (either
+        would make target resolution pick one arbitrarily).
+    (c) Every criterion is a mapping with exactly one way to tell what kind
+        it is (an explicit `kind:` field, XOR exactly one compact key), a
+        `label`, a `severity` in {high, medium, low}, and an `action` — the
+        convention every criterion in this file already follows.
+    (d) The required payload key(s) for that criterion's kind are present
+        and non-empty (`event_kinds` for `runtime_event`, `gap_kinds` for
+        `no_contract_gap`, `contract_kinds` for `contract_kind`, `name` for
+        `runtime_check`).
+    (e) No two criteria in the same oracle declare the same explicit `id`
+        (an id one criterion's edit was meant for landing on another).
+    (f) DECLARED vs VALID criteria per oracle: the count of criteria the file
+        says an oracle has, before normalisation, versus the count that
+        actually validated. These are always printed, even on PASS, because
+        a gap between them — as opposed to a gate failure — is exactly the
+        "graded 2 of 43" shape: a human scanning green output would not
+        otherwise notice that the file quietly lost criteria.
+
+Grading
+    PASS  the file parses, and every oracle/criterion satisfies (b)-(e).
+    FAIL  a parse error, or any oracle/criterion violates (b)-(e). declared
+          != valid for any oracle is ALSO a hard FAIL, not just a printed
+          count — a criterion that fails to validate is a criterion ICC will
+          never grade, silently.
+
+The gate FAILS CLOSED: a missing or unparseable oracle file is FAIL.
+
+Usage
+    python3 scripts/check_oracle_schema.py
+    python3 scripts/check_oracle_schema.py --oracles path/to/completion-oracles.yaml
+    python3 scripts/check_oracle_schema.py --format json
+    python3 scripts/check_oracle_schema.py --self-test
+
+Exit status is 0 on PASS and 1 on FAIL.
+
+Copyright (C) tsotchke
+SPDX-License-Identifier: MIT
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_ORACLES = os.path.join(REPO_ROOT, ".icc", "completion-oracles.yaml")
+DEFAULT_TRACE_DIR = os.path.join(REPO_ROOT, "scripts", "icc_traces")
+TRACE_BASENAME = "oracle_schema_gate.jsonl"
+PROBE_ID = "oracle_schema_clean"
+
+# The compact keys ICC's loader recognises (completion_oracles.COMPACT_CRITERION_KEYS)
+# plus the full kind vocabulary (completion_oracles.VALID_CRITERION_KINDS), so a
+# criterion using a kind this gate does not deep-validate is still accepted
+# rather than rejected as "unknown".
+COMPACT_KEYS = (
+    "runtime_check",
+    "runtime_event",
+    "contract_kind",
+    "runtime_or_contract",
+    "no_contract_gap",
+    "no_stubbed_paths",
+    "test_evidence",
+    "doc_truth",
+)
+KNOWN_KINDS = frozenset(COMPACT_KEYS) | frozenset({
+    "model_verified",
+    "capability_exercised",
+    "audit_pattern_clean",
+    "physics_bounds",
+    "execution_source",
+    "performance_budget",
+})
+VALID_SEVERITIES = ("high", "medium", "low")
+
+# Required payload key per kind, and how to read it out of the compact or
+# explicit form. `None` means "no additional required key beyond the kind
+# itself" (test_evidence, no_stubbed_paths, doc_truth all default their
+# payload when absent, per ICC's _normalize_criterion).
+REQUIRED_KEYS_BY_KIND: dict[str, str | None] = {
+    "runtime_check": "name",
+    "runtime_event": "event_kinds",
+    "contract_kind": "contract_kinds",
+    "runtime_or_contract": None,  # event_kinds OR contract_kinds; checked specially
+    "no_contract_gap": "gap_kinds",
+    "no_stubbed_paths": None,
+    "test_evidence": None,
+    "doc_truth": None,
+}
+
+
+class OracleSchemaError(Exception):
+    """The oracle file could not be read or parsed at all."""
+
+
+def _load_yaml(path: str) -> object:
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise OracleSchemaError(
+            "PyYAML is required to check the oracle file (pip install pyyaml)"
+        ) from exc
+
+    if not os.path.isfile(path):
+        raise OracleSchemaError(f"oracle file not found at {path} (the gate fails closed)")
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            return yaml.safe_load(handle)
+    except Exception as exc:
+        raise OracleSchemaError(f"oracle file at {path} is not parseable: {exc}") from exc
+
+
+def _as_list(value: object) -> list:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return [item for item in value if item is not None]
+    return [value]
+
+
+def _payload_value(criterion: dict, kind: str, plural_key: str) -> list:
+    """Read a kind's payload out of either the compact or the explicit form."""
+
+    if kind in criterion and plural_key not in criterion:
+        # Compact form: `runtime_event: eshkol_smoke` or `runtime_event: {...}`.
+        raw = criterion[kind]
+        if isinstance(raw, dict):
+            return _as_list(raw.get(plural_key))
+        return _as_list(raw)
+    return _as_list(criterion.get(plural_key))
+
+
+def _classify_criterion(raw: dict, oracle_name: str, position: int) -> tuple[dict | None, list[str]]:
+    """Normalise one criterion. Returns (info, errors). info is None if the
+    criterion could not even be classified (errors will be non-empty)."""
+
+    label_for_error = f"oracle {oracle_name!r} criterion #{position}"
+    if raw.get("id"):
+        label_for_error += f" (id={raw['id']!r})"
+
+    if not isinstance(raw, dict):
+        return None, [f"{label_for_error}: is not a mapping"]
+
+    errors: list[str] = []
+
+    for key in ("id", "kind", "label", "severity", "action"):
+        if key in raw and not isinstance(raw[key], str):
+            errors.append(f"{label_for_error}: field {key!r} must be a string")
+
+    if errors:
+        return None, errors
+
+    if "kind" in raw:
+        kind = raw["kind"]
+    else:
+        present_compact = [key for key in COMPACT_KEYS if key in raw]
+        if len(present_compact) == 0:
+            return None, [f"{label_for_error}: has no `kind` field and no compact requirement key "
+                          f"(expected one of {', '.join(COMPACT_KEYS)})"]
+        if len(present_compact) > 1:
+            return None, [f"{label_for_error}: has multiple compact requirement keys: "
+                          f"{', '.join(present_compact)} (ambiguous — which one is the kind?)"]
+        kind = present_compact[0]
+
+    if kind not in KNOWN_KINDS:
+        return None, [f"{label_for_error}: has unrecognised kind {kind!r}"]
+
+    if not raw.get("label"):
+        errors.append(f"{label_for_error}: missing `label`")
+    severity = raw.get("severity")
+    if not severity:
+        errors.append(f"{label_for_error}: missing `severity`")
+    elif severity not in VALID_SEVERITIES:
+        errors.append(f"{label_for_error}: severity {severity!r} not one of {'/'.join(VALID_SEVERITIES)}")
+    if not raw.get("action") and not raw.get("recommended_action"):
+        errors.append(f"{label_for_error}: missing `action`")
+
+    if kind == "runtime_or_contract":
+        event_kinds = _payload_value(raw, kind, "event_kinds")
+        contract_kinds = _payload_value(raw, kind, "contract_kinds")
+        if not event_kinds and not contract_kinds:
+            errors.append(f"{label_for_error}: runtime_or_contract requires event_kinds or contract_kinds")
+    else:
+        required_key = REQUIRED_KEYS_BY_KIND.get(kind)
+        if required_key:
+            values = _payload_value(raw, kind, required_key)
+            if not values:
+                errors.append(f"{label_for_error}: {kind} requires non-empty `{required_key}`")
+
+    if errors:
+        return None, errors
+
+    return {"kind": kind, "id": raw.get("id")}, []
+
+
+def check(data: object) -> dict:
+    """Validate a parsed oracle document. Never raises; returns a report."""
+
+    errors: list[str] = []
+
+    if not isinstance(data, dict):
+        return {"passed": False, "errors": ["oracle document is not a mapping"], "oracles": []}
+
+    oracles_raw = data.get("oracles")
+    if not isinstance(oracles_raw, list):
+        return {"passed": False, "errors": ["oracle document has no top-level `oracles` list"], "oracles": []}
+
+    oracle_reports: list[dict] = []
+    seen_name_tokens: dict[str, str] = {}  # casefolded token -> owning oracle name
+
+    for oindex, oracle in enumerate(oracles_raw, start=1):
+        if not isinstance(oracle, dict):
+            errors.append(f"oracle #{oindex} is not a mapping")
+            continue
+
+        name = oracle.get("name") or oracle.get("target")
+        if not name:
+            errors.append(f"oracle #{oindex} is missing required key `name`")
+            name = f"<unnamed #{oindex}>"
+
+        tokens = [str(name)] + [str(a) for a in _as_list(oracle.get("aliases"))]
+        for token in tokens:
+            folded = token.casefold()
+            owner = seen_name_tokens.get(folded)
+            if owner is not None and owner != name:
+                errors.append(
+                    f"oracle {name!r} shares name/alias token {token!r} with oracle {owner!r} "
+                    "(target resolution would pick one arbitrarily)"
+                )
+            else:
+                seen_name_tokens[folded] = name
+
+        raw_criteria = oracle.get("requires")
+        if raw_criteria is None:
+            raw_criteria = oracle.get("criteria")
+        if not isinstance(raw_criteria, list):
+            errors.append(f"oracle {name!r} has no `requires`/`criteria` list")
+            raw_criteria = []
+        declared_count = len(raw_criteria)
+        if declared_count == 0:
+            errors.append(f"oracle {name!r} has zero criteria — it would pass vacuously on anything")
+
+        valid_count = 0
+        seen_ids: dict[str, int] = {}
+        for cindex, raw_criterion in enumerate(raw_criteria, start=1):
+            info, crit_errors = _classify_criterion(raw_criterion, str(name), cindex)
+            if crit_errors:
+                errors.extend(crit_errors)
+                continue
+            valid_count += 1
+            explicit_id = info.get("id") if info else None
+            if explicit_id:
+                if explicit_id in seen_ids:
+                    errors.append(
+                        f"oracle {name!r} has duplicate criterion id {explicit_id!r} "
+                        f"(criteria #{seen_ids[explicit_id]} and #{cindex})"
+                    )
+                else:
+                    seen_ids[explicit_id] = cindex
+
+        if valid_count != declared_count:
+            errors.append(
+                f"oracle {name!r}: declared {declared_count} criteria but only {valid_count} "
+                "validated — the rest would be silently dropped by the grader"
+            )
+
+        oracle_reports.append({
+            "name": str(name),
+            "declared_criteria": declared_count,
+            "valid_criteria": valid_count,
+        })
+
+    passed = not errors
+    return {"passed": passed, "errors": errors, "oracles": oracle_reports}
+
+
+def emit_trace(trace_dir: str, status: str, snippet: str) -> str:
+    os.makedirs(trace_dir, exist_ok=True)
+    path = os.path.join(trace_dir, TRACE_BASENAME)
+    event = {
+        "kind": "eshkol_smoke",
+        "name": PROBE_ID,
+        "value": status,
+        "snippet": snippet[:2000],
+        "confidence": 1.0,
+    }
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+    return path
+
+
+# ───────────────────────────── self-test ─────────────────────────────
+
+_GOOD_ORACLES = """
+oracles:
+  - name: selftest-oracle
+    aliases: [selftest]
+    requires:
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["selftest_probe"]
+          event_values: ["PASS"]
+        severity: high
+        label: self-test probe passes
+        action: ./scripts/run_selftest.sh
+      - test_evidence: true
+        severity: medium
+        label: self-test fixtures are indexed
+        action: ctest -R selftest
+"""
+
+# Reproduces the #429 class of defect: a criterion's keys land inside the
+# previous criterion's mapping because the list-item opener and the previous
+# entry's closing field were both dropped. YAML rejects this outright.
+_MALFORMED_YAML = """
+oracles:
+  - name: selftest-oracle
+    requires:
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+        severity: high
+        label: first criterion, missing its action AND the next opener
+          event_names: ["stray_key_inside_previous_mapping"]
+        severity: high
+        label: second criterion never got its own list item
+        action: ./scripts/run_selftest.sh
+"""
+
+# Parses fine, but the runtime_event criterion has no event_kinds: this is
+# the "parses but grades nothing" shape the gate exists to catch, since a
+# parser alone accepts this file without complaint.
+_MISSING_REQUIRED_KEY_ORACLES = """
+oracles:
+  - name: selftest-oracle
+    requires:
+      - runtime_event:
+          event_names: ["no_event_kinds_here"]
+        severity: high
+        label: runtime_event with no event_kinds
+        action: ./scripts/run_selftest.sh
+"""
+
+_DUPLICATE_CRITERION_ID_ORACLES = """
+oracles:
+  - name: selftest-oracle
+    requires:
+      - id: probe-a
+        runtime_event:
+          event_kinds: [eshkol_smoke]
+        severity: high
+        label: first probe
+        action: ./scripts/run_selftest.sh
+      - id: probe-a
+        runtime_event:
+          event_kinds: [eshkol_smoke]
+        severity: high
+        label: second probe, id collides with the first
+        action: ./scripts/run_selftest.sh
+"""
+
+
+def _run_fixture(name: str, text: str, tmp_dir: str) -> tuple[bool, str]:
+    path = os.path.join(tmp_dir, name + ".yaml")
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(text)
+    try:
+        data = _load_yaml(path)
+    except OracleSchemaError as exc:
+        return False, f"parse error (expected for a malformed-YAML fixture): {exc}"
+    result = check(data)
+    return result["passed"], "; ".join(result["errors"]) or "no errors"
+
+
+def self_test() -> bool:
+    cases = [
+        ("malformed_yaml", _MALFORMED_YAML, False),
+        ("missing_required_key", _MISSING_REQUIRED_KEY_ORACLES, False),
+        ("duplicate_criterion_id", _DUPLICATE_CRITERION_ID_ORACLES, False),
+        ("well_formed", _GOOD_ORACLES, True),
+    ]
+
+    all_ok = True
+    with tempfile.TemporaryDirectory(dir=REPO_ROOT, prefix=".selftest-oracle-schema-") as tmp_dir:
+        print("check_oracle_schema.py self-test:")
+        for name, text, expect_pass in cases:
+            passed, detail = _run_fixture(name, text, tmp_dir)
+            ok = passed == expect_pass
+            all_ok = all_ok and ok
+            verdict = "OK" if ok else "GATE IS BROKEN"
+            print(f"  [{verdict}] {name}: expected passed={expect_pass}, got passed={passed}")
+            print(f"           {detail}")
+
+    if all_ok:
+        print("self-test: PASS — the gate fails on every broken fixture and passes the well-formed one")
+    else:
+        print("self-test: FAIL — the gate did not discriminate broken input from good input", file=sys.stderr)
+    return all_ok
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--oracles", default=os.environ.get("ESHKOL_ORACLE_FILE", DEFAULT_ORACLES))
+    parser.add_argument("--trace-dir", default=DEFAULT_TRACE_DIR)
+    parser.add_argument("--no-trace", action="store_true", help="grade only, write no trace")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--self-test", action="store_true", help="run built-in red/green fixtures and exit")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return 0 if self_test() else 1
+
+    try:
+        data = _load_yaml(args.oracles)
+        result = check(data)
+    except OracleSchemaError as exc:
+        snippet = f"oracle file unusable: {exc}"
+        if not args.no_trace:
+            emit_trace(args.trace_dir, "FAIL", snippet)
+        if args.format == "json":
+            print(json.dumps({"passed": False, "error": str(exc)}, indent=2))
+        else:
+            print(f"{PROBE_ID}: FAIL — {exc}", file=sys.stderr)
+        return 1
+
+    total_declared = sum(o["declared_criteria"] for o in result["oracles"])
+    total_valid = sum(o["valid_criteria"] for o in result["oracles"])
+    status = "PASS" if result["passed"] else "FAIL"
+    if result["passed"]:
+        snippet = (
+            f"{len(result['oracles'])} oracles, {total_valid}/{total_declared} criteria "
+            "declared and graded, no schema errors"
+        )
+    else:
+        snippet = f"{len(result['errors'])} schema error(s): " + "; ".join(result["errors"][:5])
+
+    if not args.no_trace:
+        emit_trace(args.trace_dir, status, snippet)
+
+    if args.format == "json":
+        print(json.dumps({"status": status, "total_declared_criteria": total_declared,
+                           "total_valid_criteria": total_valid, **result}, indent=2))
+    else:
+        print(f"{PROBE_ID}: {status}")
+        print(f"  oracle file : {args.oracles}")
+        print(f"  oracles     : {len(result['oracles'])}")
+        print(f"  criteria    : {total_valid}/{total_declared} graded (declared/valid — a human's vacuity check)")
+        for o in result["oracles"]:
+            marker = "" if o["valid_criteria"] == o["declared_criteria"] else "  <-- MISMATCH"
+            print(f"    - {o['name']:<40} {o['valid_criteria']:>3}/{o['declared_criteria']:<3}{marker}")
+        if result["errors"]:
+            print("  ERRORS:")
+            for error in result["errors"]:
+                print(f"    - {error}")
+
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gate_no_silent_wrong.py
+++ b/scripts/gate_no_silent_wrong.py
@@ -30,6 +30,7 @@ Usage
     python3 scripts/gate_no_silent_wrong.py
     python3 scripts/gate_no_silent_wrong.py --ledger path/to/ledger.yaml
     python3 scripts/gate_no_silent_wrong.py --format json
+    python3 scripts/gate_no_silent_wrong.py --self-test
 
 Exit status is 0 on PASS and 1 on FAIL, so the script also works as a plain
 CI step without ICC.
@@ -45,6 +46,7 @@ import datetime as _dt
 import json
 import os
 import sys
+import tempfile
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEFAULT_LEDGER = os.path.join(REPO_ROOT, ".icc", "silent-wrong-ledger.yaml")
@@ -218,13 +220,118 @@ def emit_trace(trace_dir: str, status: str, snippet: str) -> str:
     return path
 
 
+# ───────────────────────────── self-test ─────────────────────────────
+#
+# "A gate that cannot fail is not a gate." Each fixture feeds grade() (or the
+# YAML loader) deliberately-broken input and asserts a FAIL; one well-formed
+# fixture asserts the gate does not fail on everything indiscriminately.
+
+_MALFORMED_YAML = """
+schema: eshkol.silent_wrong_ledger.v1
+entries:
+  - id: SW-X
+    bucket: SILENT-WRONG
+      status: open
+"""
+
+_WRONG_SCHEMA_LEDGER = """
+schema: eshkol.some_other_ledger.v1
+entries: []
+"""
+
+_OPEN_UNWAIVED_LEDGER = """
+schema: eshkol.silent_wrong_ledger.v1
+entries:
+  - id: SW-SELFTEST-OPEN
+    bucket: SILENT-WRONG
+    status: open
+    title: "open with no waiver at all"
+"""
+
+_EXPIRED_WAIVER_LEDGER = """
+schema: eshkol.silent_wrong_ledger.v1
+entries:
+  - id: SW-SELFTEST-EXPIRED
+    bucket: SILENT-WRONG
+    status: open
+    title: "waiver expired last year"
+    waiver:
+      owner: nobody
+      reason: "self-test fixture"
+      expires: "2020-01-01"
+"""
+
+_GOOD_LEDGER = """
+schema: eshkol.silent_wrong_ledger.v1
+entries:
+  - id: SW-SELFTEST-CLOSED
+    bucket: SILENT-WRONG
+    status: closed
+    title: "closed with a re-measurement SHA"
+    closed_at: "deadbeef"
+  - id: SW-SELFTEST-WAIVED
+    bucket: SILENT-WRONG
+    status: open
+    title: "open with an unexpired waiver"
+    waiver:
+      owner: someone
+      reason: "self-test fixture"
+      expires: "2999-01-01"
+"""
+
+
+def _run_fixture(name: str, text: str, tmp_dir: str) -> tuple[bool, str]:
+    path = os.path.join(tmp_dir, name + ".yaml")
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(text)
+    try:
+        data = _load_yaml(path)
+    except LedgerError as exc:
+        return False, f"ledger error (expected for a malformed/wrong-schema fixture): {exc}"
+    result = grade(data, _dt.date.today())
+    ids = ", ".join(e["id"] for e in result["blocking"]) or "none"
+    bad = ", ".join(f"{e['id']}:{e['why']}" for e in result["invalid"]) or "none"
+    return result["passed"], f"blocking=[{ids}] invalid=[{bad}]"
+
+
+def self_test() -> bool:
+    cases = [
+        ("malformed_yaml", _MALFORMED_YAML, False),
+        ("wrong_schema", _WRONG_SCHEMA_LEDGER, False),
+        ("open_unwaived", _OPEN_UNWAIVED_LEDGER, False),
+        ("expired_waiver", _EXPIRED_WAIVER_LEDGER, False),
+        ("well_formed", _GOOD_LEDGER, True),
+    ]
+
+    all_ok = True
+    with tempfile.TemporaryDirectory(dir=REPO_ROOT, prefix=".selftest-no-silent-wrong-") as tmp_dir:
+        print("gate_no_silent_wrong.py self-test:")
+        for name, text, expect_pass in cases:
+            passed, detail = _run_fixture(name, text, tmp_dir)
+            ok = passed == expect_pass
+            all_ok = all_ok and ok
+            verdict = "OK" if ok else "GATE IS BROKEN"
+            print(f"  [{verdict}] {name}: expected passed={expect_pass}, got passed={passed}")
+            print(f"           {detail}")
+
+    if all_ok:
+        print("self-test: PASS — the gate fails on every broken fixture and passes the well-formed one")
+    else:
+        print("self-test: FAIL — the gate did not discriminate broken input from good input", file=sys.stderr)
+    return all_ok
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--ledger", default=os.environ.get("ESHKOL_FLAW_LEDGER", DEFAULT_LEDGER))
     parser.add_argument("--trace-dir", default=DEFAULT_TRACE_DIR)
     parser.add_argument("--no-trace", action="store_true", help="grade only, write no trace")
     parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--self-test", action="store_true", help="run built-in red/green fixtures and exit")
     args = parser.parse_args(argv)
+
+    if args.self_test:
+        return 0 if self_test() else 1
 
     try:
         data = _load_yaml(args.ledger)


### PR DESCRIPTION
## Summary

v1.3.5 assurance wave 1: converts three release doctrines that lived only as prose (a ledger's own header, a script nobody wired into CI) into enforced CI gates, each with a self-test that proves it can actually go red.

- **Ledger integrity gate** (`scripts/check_ledger_integrity.py`, new): fails on a YAML parse error, on any duplicate `id` across the whole `.icc/silent-wrong-ledger.yaml`, and on any entry missing `id`/`bucket`/`status`/`title` or (when not `open`) closure evidence.
  - Motivating incidents: SW-33 was independently allocated on three separate branches, SW-35 twice and SW-42 twice. None of these collided in `git merge` — a textual merge does not notice two branches picking the same next-free id — so the only entries that ever caught them were the ledger's own `renumbered_from` audit-trail notes, written by hand after the fact. This gate is the check that would have caught each collision before merge.
- **Oracle schema gate** (`scripts/check_oracle_schema.py`, new): fails on a YAML parse error in `.icc/completion-oracles.yaml`, and on any criterion that is structurally invalid for its kind (a `runtime_event` with no `event_kinds`, a `no_contract_gap` with no `gap_kinds`, ambiguous/missing kind, duplicate criterion id within an oracle). It also always prints a declared-vs-graded criteria count per oracle, so a human scanning green output can spot vacuity.
  - Motivating incident: PR #429 added a criterion but dropped the previous entry's `action:` field and the new entry's `- runtime_event:` list-item opener, so the new criterion's keys landed inside the previous one's mapping — a well-formed-looking diff that broke the YAML parse outright (`icc readiness` blocked at score 85 until commit `c8449f8a` restored it by hand). The gate's sharper target is the quieter version of the same defect class: a file that still parses but where a criterion silently normalises to nothing, so `icc readiness` keeps running and grades fewer criteria than its author wrote, with nothing in the output to say so.
- **`gate_no_silent_wrong.py`**: added a `--self-test` mode (it graded the release ledger already, but had never been wired into any CI workflow at all — a gate nobody runs is not a gate).

All three gates are also now wired as new `runtime_event` criteria (`ledger_integrity_clean`, `oracle_schema_clean`) into the `eshkol-compiler-readiness` oracle in `.icc/completion-oracles.yaml`, alongside the existing `no_open_silent_wrong` criterion.

## Self-test evidence

Each gate carries deliberately-broken fixtures (malformed YAML, a duplicate id, a missing required field / missing payload key) plus one well-formed fixture, generated into a temp directory inside the repo (never `/tmp`) and cleaned up immediately. `--self-test` asserts the gate grades every broken fixture FAIL and the well-formed one PASS — a gate that cannot fail is not a gate.

```
python3 scripts/gate_no_silent_wrong.py --self-test      # 5/5 fixtures behave as expected
python3 scripts/check_ledger_integrity.py --self-test    # 4/4 fixtures behave as expected
python3 scripts/check_oracle_schema.py --self-test       # 4/4 fixtures behave as expected
```

## CI wiring

New fast job `assurance-gates` in `.github/workflows/ci.yml`, modeled on the existing `surface-manifest` job (pure Python over checked-out files, `ubuntu-22.04`, no compiler/build step): runs all three self-tests, then all three gates against the real committed `.icc/` files. `.icc/` is not in `paths-ignore`, so ledger/oracle edits already trigger this job.

Also wired as `ctest` entries (`no_silent_wrong_gate[_selftest]`, `ledger_integrity_gate[_selftest]`, `oracle_schema_gate[_selftest]`) guarded on `ESHKOL_PYTHON3_EXECUTABLE`, next to the existing Python-based validators in `CMakeLists.txt`.

## Test plan

- [x] `python3 scripts/gate_no_silent_wrong.py` — PASS against the current ledger
- [x] `python3 scripts/check_ledger_integrity.py` — PASS against the current ledger (86 entries, 0 duplicate ids)
- [x] `python3 scripts/check_oracle_schema.py` — PASS against the current oracle file (35 oracles, 262/262 criteria graded)
- [x] All three `--self-test` modes: every broken fixture FAILs, the well-formed fixture PASSes
- [x] Cross-checked `check_oracle_schema.py`'s criteria counts against ICC's own `completion_oracle_config.load_completion_oracle_configs` loader — zero discrepancy
- [x] `ctest --test-dir build -R "no_silent_wrong_gate|ledger_integrity_gate|oracle_schema_gate"` green