### PR TITLE
ci: move docs-only skip from trigger paths-ignore to a job-level gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,15 @@ on:
     # not spin up the full compile/test/wasm/asan matrix. Research ADRs and
     # documentation live under docs/ and **/*.md; skip CI when a change touches
     # only those. A change that also touches code still runs the full matrix.
+    #
+    # Kept here deliberately (unlike pull_request below): branch protection's
+    # required contexts are read off the SHA that GitHub associates with the
+    # PR, which the pull_request-triggered run always supplies once the
+    # `changes` job exists; nothing here needs to gate a merge. A push run
+    # that never starts because a commit was pure docs (e.g. a docs-only
+    # branch pushed straight to master, or a squash-merge landing on
+    # master/develop) is simply less CI to run, not a missing required
+    # check on anyone's PR.
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
@@ -16,13 +25,18 @@ on:
       - 'LICENSE'
   pull_request:
     branches: [master]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'notes/**'
-      - 'press/**'
-      - '.swarm/**'
-      - 'LICENSE'
+    # NOTE: deliberately NO paths-ignore here (see the `changes` job below).
+    # A trigger-level paths-ignore on `pull_request` means GitHub never
+    # starts this workflow at all for a docs-only PR, so none of its jobs —
+    # including the ones branch protection has marked required — ever
+    # report a status for that PR's head SHA. A required context that never
+    # reports blocks the PR forever; branch protection has no timeout, only
+    # "hasn't reported yet". A context that reports SKIPPED satisfies
+    # branch protection. So the workflow now always starts on
+    # pull_request, and the docs-only decision is pushed down to a fast
+    # `changes` job whose `docs_only` output every heavy job's `if:` reads
+    # — same path list as before, just evaluated after the workflow starts
+    # instead of before.
   schedule:
     # Weekly touch of the Windows LLVM SDK caches so actions/cache's 7-day
     # idle-eviction can never strand a run on the cold download+extract path
@@ -45,6 +59,70 @@ env:
   CUDA_PACKAGE_SERIES: '12-4'
 
 jobs:
+  # Job-level replacement for the old trigger-level `paths-ignore` on
+  # pull_request (see the comment on that trigger above). Computes the exact
+  # same docs-only predicate — same path list, same "any non-matching file
+  # makes it false" semantics — but as a job output every heavy job below can
+  # gate on, so those jobs still get scheduled and can report a SKIPPED
+  # status rather than never starting. Deliberately plain git + bash rather
+  # than a vendored paths-filter action: this repo has no other third-party
+  # filtering action in its supply chain, and the predicate is a single
+  # `git diff --name-only` plus a case match.
+  changes:
+    name: changes
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-22.04
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine whether this change is docs-only
+        id: filter
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+            changed_files="$(git diff --name-only "$base...$head")"
+          else
+            before="${{ github.event.before }}"
+            if [[ -z "$before" || "$before" == "0000000000000000000000000000000000000000" ]]; then
+              # First push of a branch, or force-push with no usable
+              # `before`: nothing to diff against, so don't claim docs-only.
+              changed_files="__unknown__"
+            else
+              changed_files="$(git diff --name-only "$before" "${{ github.sha }}")"
+            fi
+          fi
+
+          echo "Changed files:"
+          printf '%s\n' "$changed_files"
+
+          # Exactly the path list the old trigger-level paths-ignore used:
+          #   **/*.md, docs/**, notes/**, press/**, .swarm/**, LICENSE
+          # A case pattern's `*` matches `/` too (that restriction is a
+          # filename-globbing thing, not general shell pattern matching), so
+          # `*.md` here already behaves like `**/*.md` and `docs/*` like
+          # `docs/**`.
+          docs_only=true
+          if [[ -z "$changed_files" ]]; then
+            docs_only=false
+          fi
+          while IFS= read -r f; do
+            [[ -z "$f" ]] && continue
+            case "$f" in
+              __unknown__) docs_only=false ;;
+              *.md|docs/*|notes/*|press/*|.swarm/*|LICENSE) ;;
+              *) docs_only=false ;;
+            esac
+          done <<< "$changed_files"
+
+          echo "docs_only=$docs_only" | tee -a "$GITHUB_OUTPUT"
+
   # The language-surface manifest is the ground truth the execution-backed
   # coverage floor is measured against, so a stale manifest fails the coverage
   # gate. That gate lives in the quantum lane, which is both advisory and the
@@ -105,7 +183,8 @@ jobs:
   # gate; branch-protection configuration must not add this check as required.
   quantum-macos:
     name: quantum-macos (advisory)
-    if: github.event_name != 'schedule'
+    needs: changes
+    if: github.event_name != 'schedule' && needs.changes.outputs.docs_only == 'false'
     runs-on: macos-14
     continue-on-error: true
     timeout-minutes: 120
@@ -257,7 +336,8 @@ jobs:
 
   unix-matrix:
     name: ${{ matrix.name }}
-    if: github.event_name != 'schedule'
+    needs: changes
+    if: github.event_name != 'schedule' && needs.changes.outputs.docs_only == 'false'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -603,7 +683,8 @@ jobs:
   # own curl entirely; a miss here falls back unchanged to that curl.
   prefetch-windows-llvm-archives:
     name: prefetch-windows-llvm-archives (${{ matrix.arch }})
-    if: github.event_name != 'schedule'
+    needs: changes
+    if: github.event_name != 'schedule' && needs.changes.outputs.docs_only == 'false'
     runs-on: ubuntu-22.04
     continue-on-error: true
     strategy:
@@ -646,8 +727,8 @@ jobs:
 
   windows-matrix:
     name: ${{ matrix.name }}
-    if: github.event_name != 'schedule'
-    needs: prefetch-windows-llvm-archives
+    needs: [changes, prefetch-windows-llvm-archives]
+    if: github.event_name != 'schedule' && needs.changes.outputs.docs_only == 'false'
     runs-on: ${{ matrix.runner }}
     # windows-arm64-lite alone (full build+test, LLVM SDK cache-hit so no
     # extraction) has run ~51 minutes end to end; windows-x64-cuda adds the
@@ -1021,7 +1102,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   wasm-execute-diff:
     name: wasm-execute-diff
-    if: github.event_name != 'schedule'
+    needs: changes
+    if: github.event_name != 'schedule' && needs.changes.outputs.docs_only == 'false'
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,51 @@ jobs:
           path: ${{ runner.temp }}/eshkol-language-coverage
           if-no-files-found: error
 
+  # ─────────────────────────────────────────────────────────────────────
+  # Stub job that exists ONLY to satisfy branch protection's literal
+  # per-lane required context names on a docs-only PR. This is not
+  # optional decoration: GitHub Actions does NOT expand a matrix job's
+  # `${{ matrix.x }}` name expressions into individual check runs when the
+  # job itself is skipped via a job-level `if:` — a skipped matrix job
+  # instead produces exactly ONE check run, named with the literal,
+  # unresolved string "${{ matrix.name }}" (verified empirically; see the
+  # proof-PR evidence under .worktrees/v135/evidence/ci-wave/). That
+  # unresolved name matches none of branch protection's required contexts,
+  # so without this stub, `linux-x64-xla`, `linux-arm64-xla`,
+  # `linux-x64-cuda`, `linux-arm64-cuda`, `linux-x64-asan-ubsan`,
+  # `windows-arm64-xla`, and `windows-x64-cuda` would each go right back to
+  # never reporting on a docs-only PR — the exact permanent-block failure
+  # this whole change exists to fix. `wasm-execute-diff` needs no such stub
+  # because it isn't matrix-based; its job-level skip already produces a
+  # correctly-named, SKIPPED check run.
+  #
+  # This job's own matrix DOES expand correctly, because it only runs
+  # (job-level `if` true) on docs-only PRs — the opposite condition from
+  # unix-matrix/windows-matrix — so its check runs and theirs are never
+  # produced for the same PR at once, and the real matrix legs below take
+  # over normally the moment a change touches non-doc paths.
+  # ─────────────────────────────────────────────────────────────────────
+  docs-only-required-context-stubs:
+    name: ${{ matrix.name }}
+    needs: changes
+    if: github.event_name != 'schedule' && needs.changes.outputs.docs_only == 'true'
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        name:
+          - linux-x64-xla
+          - linux-arm64-xla
+          - linux-x64-cuda
+          - linux-arm64-cuda
+          - linux-x64-asan-ubsan
+          - windows-arm64-xla
+          - windows-x64-cuda
+    steps:
+      - name: Docs-only PR — real lane skipped, this stub satisfies branch protection
+        shell: bash
+        run: |
+          echo "docs-only PR: ${{ matrix.name }} did not run. See the unix-matrix / windows-matrix jobs (reported skipped under an unresolved matrix.name check run) for why. This stub exists solely to give branch protection's required context '${{ matrix.name }}' a status."
+
   unix-matrix:
     name: ${{ matrix.name }}
     needs: changes


### PR DESCRIPTION
## Problem

`ci.yml`'s `pull_request` trigger has had `paths-ignore` (`**/*.md`, `docs/**`, `notes/**`, `press/**`, `.swarm/**`, `LICENSE`) since before this PR. When a PR touches only those paths, GitHub never starts this workflow for that PR's head SHA at all. Branch protection's required contexts are currently:

```
guard, linux-x64-xla, linux-arm64-xla, linux-x64-cuda, linux-arm64-cuda,
linux-x64-asan-ubsan, wasm-execute-diff, windows-arm64-xla, windows-x64-cuda
```

`guard` comes from `identity-guard.yml`, which has no path filter and always reports. The other 8 all come from jobs inside `ci.yml`. For a docs-only PR none of them ever starts, so none of them ever reports a status — and a required context with **no** status blocks a PR forever (there is no timeout, only "hasn't reported yet"). This is the exact reason PR #444 (docs-only) cannot merge.

## Fix, round 1

Move the docs-only decision from the trigger level to job level:

- Removed `paths-ignore` from the `pull_request` trigger. The workflow now always starts for a PR against master.
- Added a `changes` job that computes `docs_only` via `git diff --name-only` against the PR's merge-base (`base...head`), using the exact same path list the old `paths-ignore` used.
- Every heavy job (`quantum-macos`, `unix-matrix`, `prefetch-windows-llvm-archives`, `windows-matrix`, `wasm-execute-diff`) has `needs: changes` and `if: <existing condition> && needs.changes.outputs.docs_only == 'false'`.

## Fix, round 2 — a real GitHub Actions gap this uncovered

Round 1 alone is **not sufficient** and a throwaway proof PR caught why: GitHub Actions does **not** expand a matrix job's `${{ matrix.x }}` name expression into per-leg check runs when the job is skipped via a job-level `if:`. A skipped matrix job produces exactly **one** check run, named with the literal, unresolved string `"${{ matrix.name }}"`. That string matches none of branch protection's required contexts, so `linux-x64-xla`, `linux-arm64-xla`, `linux-x64-cuda`, `linux-arm64-cuda`, `linux-x64-asan-ubsan`, `windows-arm64-xla`, and `windows-x64-cuda` (all matrix-derived) would have gone right back to never reporting on a docs-only PR — the exact permanent-block failure this PR exists to fix. Only `wasm-execute-diff` (not matrix-based) worked correctly under round 1 alone.

Added `docs-only-required-context-stubs`: a tiny job with a matrix over exactly those 7 required names, gated on the *opposite* condition (`docs_only == 'true'`). Because this job actually runs when it's the docs-only case, its matrix expands normally and each leg gets a correctly-named, fast, passing check run. It never runs alongside the real `unix-matrix`/`windows-matrix` legs (mutually exclusive `if:` conditions), so there's no name collision either way.

## push trigger: paths-ignore kept

`paths-ignore` stays on `push` (`branches: [master, develop, feat/**]`). Branch-protection required contexts are evaluated against the SHA associated with a PR, and the `pull_request`-triggered run (fixed above) always supplies that. A push whose commit is pure docs simply skips the whole workflow — strictly less CI cost, not a missing required check for anyone.

## Proof (evidence under `.worktrees/v135/evidence/ci-wave/` in the working tree, not committed to this branch)

Two throwaway PRs were opened stacked on this branch (to isolate the diff being measured from this PR's own `ci.yml` change — `pull_request` only fires against `branches: [master]`, so testing directly against `master` while this PR is unmerged unavoidably includes this PR's own `ci.yml` diff and forces `docs_only=false`; a temporary trigger-widening commit was pushed to this branch, used only for the throwaway PRs, then rebased back out — this branch's final history has no trace of it):

1. **Docs-only test** (one `.md` file only): all 9 required contexts reported — 7 SUCCESS (`guard`, `changes`-adjacent `surface-manifest` not required but included, `linux-x64-xla`, `linux-arm64-xla`, `linux-x64-cuda`, `linux-arm64-cuda`, `linux-x64-asan-ubsan`, `windows-arm64-xla`, `windows-x64-cuda` via the stub job) + 1 SKIPPED (`wasm-execute-diff`). Confirmed via both `gh pr checks` and the raw `commits/.../check-runs` API.
2. **Mixed test** (a `.md` file + a comment-only change in a `.c` file): `changes` job logged `Changed files: docs/README.md, lib/backend/vm_core.c` -> `docs_only=false`, and the full matrix was scheduled and reached `in_progress` (confirmed via job status, then cancelled to conserve CI minutes since completion wasn't needed for the proof). This is the safety-critical direction — getting the predicate wrong here would let real code changes skip required builds.

Both throwaway PRs (and their branches) have been closed/deleted.

## Not merging

Opened for review/CI signal only — not merging without a maintainer's go-ahead. This PR's own CI run (base=master, so `docs_only=false` since it touches `ci.yml`) is running the full matrix as expected.