### PR TITLE
TEST (throwaway, will be closed): mixed docs+code proof for PR #455

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -280,3 +280,5 @@ Missing something? This index links every document tracked under `docs/`, plus
 the adjacent `examples/`, `tests/`, `tools/icc_extras/`, `press/`, and
 `nix/jetson/` documentation. If you land on a page that isn't reachable from
 here, that's a bug in this index — please open an issue or fix it directly.
+
+<!-- ci-wave proof PR: mixed test, throwaway, will be closed -->

--- a/lib/backend/vm_core.c
+++ b/lib/backend/vm_core.c
@@ -1,3 +1,4 @@
+/* ci-wave proof PR: mixed (docs+code) test, throwaway, will be closed. */
 #include "eshkol/backend/vm_limits.h"
 
 #ifndef ESHKOL_VM_NATIVE_POLICY_DESKTOP


### PR DESCRIPTION
Throwaway proof PR for #455. Touches `docs/README.md` (doc) and `lib/backend/vm_core.c` (comment-only). Expect: the full matrix RUNS exactly as today (docs_only must be false). This is the safety-critical direction — getting the predicate wrong here would let real code changes skip required builds. Will be closed and branch deleted after verification.