### PR TITLE
fix(bindings): NumPy capsule keeps the tensor buffer alive — close the zero-copy lifetime hazard

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -2929,6 +2929,104 @@ entries:
       answer on the native side that differs by input (pointer-address-dependent), and a
       different but equally wrong answer (0) on the VM.
 
+  - id: SW-44
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "fix/pybind-capsule-lifetime"
+    closed_by: "branch fix/pybind-capsule-lifetime"
+    family: interop/lifetime
+    title: "Python bindings: a NumPy array from a tensor eval keeps no claim on the FFI context, so deleting the Context while the array is still live lets shutdown corrupt its backing memory (audit H1)"
+    repro: >-
+      tests/bindings/python_capsule_lifetime_test.py — construct eshkol.Context(),
+      evaluate a tensor literal to get a zero-copy NumPy array, register a shutdown
+      hook through the public eshkol_register_shutdown_hook() C API (the same
+      documented mechanism a real embedder uses to free its own arena-backed state on
+      shutdown — demonstrated in-tree by
+      tests/core/runtime_shutdown_teardown_race_test.cpp) that overwrites the array's
+      backing bytes, `del` the Context while the array is still referenced, then read
+      the array.
+    observed: >-
+      pre-fix (bindings/python/eshkol_module.cpp before this branch, with the two
+      enabling fixes below already applied so the module runs at all): `del ctx` calls
+      eshkol_ffi_shutdown() unconditionally and immediately, synchronously running
+      every registered shutdown hook before the array's own reference is ever
+      released. The array's bytes are silently overwritten (0xEF fill). Exit 0, no
+      diagnostic, no exception, no crash — the array just reads the wrong values.
+    correct: >-
+      the original tensor values ([1.0, 2.0, 3.0, 4.0] in the repro). Shutdown must be
+      deferred until every NumPy array (or view/slice/reshape derived from one)
+      exported from the context has been released — not merely until the Python
+      `Context` wrapper object itself is deleted.
+    root_cause: >-
+      bindings/python/eshkol_module.cpp's ffi_value_to_python() built each tensor's
+      NumPy array with a `base` capsule whose deleter was a stateless no-op ("arena
+      managed") and which held no reference back to the owning eshkol_ffi_context_t.
+      EshkolContext::~EshkolContext() called eshkol_ffi_shutdown() on the raw context
+      pointer unconditionally, with nothing to stop that call from running while an
+      exported array was still alive and referencing arena memory that a shutdown hook
+      (or a future teardown path) is free to reclaim or overwrite. The comment marked
+      "Zero-copy caveat (audit H1)" documented the hazard in the source but did not
+      close it.
+    fix: >-
+      bindings/python/eshkol_module.cpp: EshkolContext now holds the context as
+      EshkolCtxHandle (std::shared_ptr<eshkol_ffi_context_t> with eshkol_ffi_shutdown
+      as its deleter) instead of a raw pointer. ffi_value_to_python() threads that
+      shared handle through, and for every tensor it exports attaches a second,
+      independent copy of the shared_ptr to the returned array's `base` capsule
+      (heap-allocated, freed by the capsule's own destructor). NumPy keeps `base` alive
+      for as long as the array — or any view/slice/reshape derived from it — is alive,
+      so eshkol_ffi_shutdown() (the shared_ptr's deleter) only actually runs once every
+      holder, including every live array's capsule, has released its reference.
+      Deleting the Python Context object no longer invalidates arrays it already
+      produced. Two further, narrower fixes were required to make this defect (and its
+      fix) reachable and testable at all — both pre-existing, both unrelated to the
+      capsule logic itself, both necessary enabling plumbing rather than new
+      capability: (1) CMakeLists.txt's ESHKOL_PYTHON_BINDINGS block force-loaded only
+      eshkol-static, not eshkol-repl-lib, so the eval-bridge's static-constructor
+      registrar (BridgeRegistrar, lib/repl/eval_bridge_impl.cpp) was always linked out
+      and eshkol_ffi_init() always failed with "JIT runtime is not linked" — the
+      module never actually initialized under this build option before now; (2)
+      eshkol_ffi_eval() (lib/ffi/eshkol_ffi.cpp) wrapped its result-carrying AST in a
+      synthetic `(define __eshkol_ffi_result_N__ ...)` and tried to read the value
+      back via lookupSymbol(), a mechanism that predates and is defeated by
+      ReplJITContext::executeTagged()'s newer thread-local "last value" capture (which
+      does not fire for a top-level DEFINE) — ctx->execute()'s already-correctly
+      captured return value was being discarded, so every eval() unconditionally
+      returned null/None regardless of the source expression. Neither (1) nor (2) is
+      specific to tensors; fixing them is what let this ledger entry's repro (and the
+      pre-existing tests/v1_2_edge_cases/python_ffi_test.py, 19/19 passing at this SHA
+      for the first time) exercise the actual capsule code path at all.
+    evidence: >-
+      tests/bindings/python_capsule_lifetime_test.py, wired into ctest as
+      python_bindings_capsule_lifetime (ESHKOL_PYTHON_BINDINGS=ON). Red/green
+      demonstrated by hand at branch head: reverting only
+      bindings/python/eshkol_module.cpp to its pre-fix content (keeping the two
+      enabling fixes) reproduces the exact failure — "shutdown hook did NOT fire while
+      the array was still live" and "array values are intact after del(ctx)" both
+      FAIL, exit 1; restoring the fix, both PASS, exit 0. Full ctest suite 185/185 and
+      tests/v1_2_edge_cases/python_ffi_test.py 19/19 pass at the same SHA (RelWithDebInfo,
+      LLVM 21, arm64-apple-darwin24.1.0). Also run green under
+      -DESHKOL_ENABLE_ASAN=ON -DESHKOL_ENABLE_UBSAN=ON (ASAN_OPTIONS=detect_leaks=0)
+      to confirm the shared_ptr/capsule mechanism itself introduces no memory error;
+      ASan does not additionally flag the repro's own poison step because it
+      overwrites still-allocated memory (this ledger entry's shape is a wrong VALUE at
+      exit 0, which is what SILENT-WRONG requires — a sanitizer-caught crash would be
+      a LOUD-ERROR, a different bucket).
+    caught_by: [maintainer-ratified-plan, direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    notes: >-
+      The arena the tensor's data lives in is process-lifetime in the current hosted
+      runtime, and no production code registers a shutdown hook against it today — so
+      this was a latent hazard rather than a crash-on-every-run, and the repro
+      registers its own hook through the same public, documented mechanism
+      (eshkol_register_shutdown_hook) any embedder is free to use for exactly that
+      purpose, which is the scenario the pre-fix "audit H1" comment warned about.
+      Before this branch, ctest carried zero binding-level tests for
+      bindings/python/eshkol_module.cpp — python_bindings_capsule_lifetime is the
+      first. Scope: this closes only the capsule lifetime hazard. The separate
+      double*-demotion / exactness-across-the-FFI-boundary issue is an explicitly
+      different, still-open v1.4.0 lane and is not touched here.
+
   # ───────────────────────── PARITY-RATCHET ─────────────────────────
 
   - id: PR-01

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6446,14 +6446,32 @@ if(ESHKOL_PYTHON_BINDINGS)
         if(LLVM_LIBRARY_DIRS)
             target_link_directories(eshkol_py PRIVATE ${LLVM_LIBRARY_DIRS})
         endif()
-        # Force-load eshkol-static so JIT can resolve all runtime symbols
+        # Force-load eshkol-static AND eshkol-repl-lib so JIT can resolve
+        # all runtime symbols. Force-loading eshkol-static alone (the
+        # previous state of this block) is not enough: eshkol-repl-lib's
+        # eval_bridge_impl.cpp carries the strong eshkol_eval_jit_get_*
+        # overrides behind a static-constructor registrar
+        # (BridgeRegistrar in lib/repl/eval_bridge_impl.cpp), and nothing
+        # else in this module references that translation unit by symbol.
+        # Without force-loading the archive itself, the linker drops it
+        # entirely, eshkol_ffi_init() finds every eval_bridge accessor
+        # null, and every Context() construction fails at runtime with
+        # "JIT runtime is not linked" — the module never actually worked.
+        # This mirrors the eshkol-run / eshkol-agent-ffi-consumer force-load
+        # pairs elsewhere in this file (see the "-Wl,-force_load,PATH"
+        # comment on eshkol-run above): ld64's -force_load only applies to
+        # the single archive immediately following it, so each archive
+        # needs its own flag on Apple; --whole-archive/--no-whole-archive
+        # brackets the whole list on ELF/COFF linkers instead.
         if(APPLE)
             target_link_libraries(eshkol_py PRIVATE eshkol-repl-lib
-                "-Wl,-force_load" "$<TARGET_FILE:eshkol-static>"
                 ${ESHKOL_EXTRA_LINK_LIBS} ${LLVM_LIBS_LIST} ${LLVM_SYSTEM_LIBS_LIST})
+            target_link_options(eshkol_py PRIVATE
+                "-Wl,-force_load,$<TARGET_FILE:eshkol-static>"
+                "-Wl,-force_load,$<TARGET_FILE:eshkol-repl-lib>")
         else()
             target_link_libraries(eshkol_py PRIVATE eshkol-repl-lib
-                "-Wl,--whole-archive" "$<TARGET_FILE:eshkol-static>" "-Wl,--no-whole-archive"
+                "-Wl,--whole-archive" "$<TARGET_FILE:eshkol-static>" "$<TARGET_FILE:eshkol-repl-lib>" "-Wl,--no-whole-archive"
                 ${ESHKOL_EXTRA_LINK_LIBS} ${LLVM_LIBS_LIST} ${LLVM_SYSTEM_LIBS_LIST})
         endif()
         if(TARGET eshkol-agent-ffi)
@@ -6468,6 +6486,31 @@ if(ESHKOL_PYTHON_BINDINGS)
         endif()
         set_target_properties(eshkol_py PROPERTIES OUTPUT_NAME "eshkol")
         message(STATUS "Python bindings: ENABLED (pybind11 ${pybind11_VERSION})")
+
+        # ctest wiring for the Python binding regression suite. There was no
+        # prior wiring at all — tests/v1_2_edge_cases/python_ffi_test.py and
+        # tests/stdlib/v12_python_test.py both predate this and have always
+        # been loose scripts a developer had to remember to run by hand.
+        # audit H1 (the NumPy tensor capsule lifetime fix) is the first
+        # binding-level fix in this repo to need reliable proof it stays
+        # fixed, so it gets the first real ctest entry; the two pre-existing
+        # scripts are unaffected and remain available for manual runs.
+        #
+        # ESHKOL_PYTHON3_EXECUTABLE is discovered earlier in this file (see
+        # its find_program(... NAMES python3 python) call above) and is the
+        # same interpreter every other Python-script ctest in this project
+        # uses. ESHKOL_PYTHON_MODULE_DIR points the test at THIS build's
+        # eshkol_py output directory directly via a generator expression,
+        # so it resolves correctly regardless of the build directory name
+        # (build, build-asan, build-xla, ...) — unlike the two older scripts'
+        # hardcoded "../../build" relative guess.
+        if(ESHKOL_BUILD_TESTS AND ESHKOL_PYTHON3_EXECUTABLE)
+            add_test(NAME python_bindings_capsule_lifetime
+                     COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                             "${CMAKE_CURRENT_SOURCE_DIR}/tests/bindings/python_capsule_lifetime_test.py")
+            set_tests_properties(python_bindings_capsule_lifetime PROPERTIES
+                ENVIRONMENT "ESHKOL_PYTHON_MODULE_DIR=$<TARGET_FILE_DIR:eshkol_py>")
+        endif()
     else()
         message(STATUS "Python bindings: pybind11 not found, skipping")
     endif()

--- a/bindings/python/eshkol_module.cpp
+++ b/bindings/python/eshkol_module.cpp
@@ -20,16 +20,38 @@
 
 #include <eshkol/eshkol_ffi.h>
 
+#include <memory>
 #include <string>
 #include <stdexcept>
 
 namespace py = pybind11;
 
 /**
+ * Shared ownership handle for an eshkol_ffi_context_t.
+ *
+ * The real teardown (eshkol_ffi_shutdown, which tears down the process-wide
+ * JIT/runtime state the context was keeping resident) only runs once every
+ * holder of one of these shared_ptrs has released it. EshkolContext holds
+ * one for its own lifetime; every NumPy array exported from that context
+ * (see the tensor branch of ffi_value_to_python below) holds a second,
+ * independent copy inside its base capsule. This is what closes audit H1:
+ * as long as any exported array — or any NumPy view derived from it, since
+ * NumPy propagates `base` through slicing/reshaping — is alive, the
+ * context cannot be shut down out from under it, even if the Python
+ * `Context` object that produced the array has already been deleted.
+ */
+using EshkolCtxHandle = std::shared_ptr<eshkol_ffi_context_t>;
+
+/**
  * Convert an Eshkol FFI value to a Python object.
  * Handles: null, int, double, bool, string, pair/list, tensor.
+ *
+ * @param ctx  Shared-ownership handle to the owning context. Threaded
+ *             through recursion only so the tensor branch can attach a
+ *             strong reference to any NumPy array it hands back — see
+ *             EshkolCtxHandle above.
  */
-static py::object ffi_value_to_python(eshkol_ffi_context_t* ctx, eshkol_ffi_value_t val) {
+static py::object ffi_value_to_python(const EshkolCtxHandle& ctx, eshkol_ffi_value_t val) {
     switch (eshkol_ffi_type(val)) {
         case ESHKOL_FFI_TYPE_NULL:
             return py::none();
@@ -71,14 +93,22 @@ static py::object ffi_value_to_python(eshkol_ffi_context_t* ctx, eshkol_ffi_valu
              * arrays with wrong ndim and misinterpreted strides). If
              * ndim is suspicious (≤0 or > 64) we fall back to 1-D.
              *
-             * Zero-copy caveat (audit H1): the capsule deleter is a
-             * no-op because the arena is process-lifetime. If a
-             * caller destroys the FFI context (arena reset) while
-             * numpy still references the array, reads see freed
-             * memory. For now we document this lifecycle; full
-             * refcounting is a follow-up. Callers that need
-             * lifetime-decoupled arrays can .copy() on the Python
-             * side. */
+             * Zero-copy lifetime (audit H1, fixed): the tensor's backing
+             * storage is owned by the Eshkol runtime the context keeps
+             * resident, not by this array. The array's `base` is a
+             * capsule holding a strong reference (EshkolCtxHandle) to
+             * that context. NumPy keeps `base` alive for as long as this
+             * array — or any view/slice/reshape derived from it — is
+             * alive, and the capsule's destructor is the only thing that
+             * releases our copy of the shared_ptr. So even if the Python
+             * `Context` object is deleted (or every other reference to it
+             * dropped) while this array is still around, the underlying
+             * eshkol_ffi_shutdown() is deferred until the capsule itself
+             * is destroyed — i.e. until this is the last live reference.
+             * Callers that need a fully independent, lifetime-decoupled
+             * array can still .copy() on the Python side; that is no
+             * longer required for correctness, only to avoid pinning the
+             * context's resources. */
             double* tdata = eshkol_ffi_tensor_data(val);
             if (tdata) {
                 int64_t size = eshkol_ffi_tensor_size(val);
@@ -95,8 +125,15 @@ static py::object ffi_value_to_python(eshkol_ffi_context_t* ctx, eshkol_ffi_valu
                     for (int i = n - 2; i >= 0; i--) {
                         strides_v[i] = strides_v[i + 1] * shape_v[i + 1];
                     }
-                    auto capsule = py::capsule(tdata, [](void*) { /* arena-managed */ });
-                    return py::array_t<double>(shape_v, strides_v, tdata, capsule);
+                    /* Stateless deleter (no captures, so it decays to the
+                     * plain `void(*)(void*)` pybind11::capsule expects);
+                     * the state lives in the heap-allocated shared_ptr
+                     * copy the deleter frees. */
+                    auto* owner = new EshkolCtxHandle(ctx);
+                    py::capsule owner_capsule(owner, [](void* p) {
+                        delete static_cast<EshkolCtxHandle*>(p);
+                    });
+                    return py::array_t<double>(shape_v, strides_v, tdata, owner_capsule);
                 }
             }
 
@@ -111,27 +148,35 @@ static py::object ffi_value_to_python(eshkol_ffi_context_t* ctx, eshkol_ffi_valu
 
 /**
  * Eshkol evaluation context — wraps eshkol_ffi_context_t.
+ *
+ * The underlying handle is held via EshkolCtxHandle (shared_ptr with
+ * eshkol_ffi_shutdown as its deleter) rather than a raw pointer. This
+ * object's own destruction only releases ITS copy of that shared_ptr;
+ * the real eshkol_ffi_shutdown() call happens whenever the LAST copy
+ * goes away, which may be a NumPy array exported from this context
+ * (see the capsule attached in ffi_value_to_python) outliving the
+ * EshkolContext object itself. That deferral is audit H1's fix: a
+ * Context can be deleted, or fall out of scope, while arrays it
+ * produced are still in use, without invalidating them.
  */
 class EshkolContext {
 public:
     EshkolContext() {
-        ctx_ = eshkol_ffi_init();
-        if (!ctx_) {
+        eshkol_ffi_context_t* raw = eshkol_ffi_init();
+        if (!raw) {
             throw std::runtime_error("Failed to initialize Eshkol runtime");
         }
+        ctx_ = EshkolCtxHandle(raw, eshkol_ffi_shutdown);
     }
 
-    ~EshkolContext() {
-        if (ctx_) {
-            eshkol_ffi_shutdown(ctx_);
-            ctx_ = nullptr;
-        }
-    }
+    /* No custom destructor needed: ctx_'s shared_ptr deleter
+     * (eshkol_ffi_shutdown) runs automatically once this is the last
+     * reference — see the EshkolCtxHandle comment above. */
 
     /* Evaluate Eshkol source code, return Python value */
     py::object eval(const std::string& source) {
         eshkol_ffi_value_t result;
-        int rc = eshkol_ffi_eval(ctx_, source.c_str(), &result);
+        int rc = eshkol_ffi_eval(ctx_.get(), source.c_str(), &result);
         if (rc != 0) {
             const char* err = eshkol_ffi_last_error();
             throw std::runtime_error(err ? err : "Evaluation failed");
@@ -142,7 +187,7 @@ public:
     /* Evaluate and return as double (convenience for numeric work) */
     double eval_double(const std::string& source) {
         double result;
-        int rc = eshkol_ffi_eval_double(ctx_, source.c_str(), &result);
+        int rc = eshkol_ffi_eval_double(ctx_.get(), source.c_str(), &result);
         if (rc != 0) {
             const char* err = eshkol_ffi_last_error();
             throw std::runtime_error(err ? err : "Evaluation failed");
@@ -171,7 +216,7 @@ public:
         if (path.find('\0') != std::string::npos) {
             throw py::value_error("eval_file: path contains NUL byte");
         }
-        int rc = eshkol_ffi_eval_file(ctx_, path.c_str());
+        int rc = eshkol_ffi_eval_file(ctx_.get(), path.c_str());
         if (rc != 0) {
             const char* err = eshkol_ffi_last_error();
             throw std::runtime_error(err ? err : "File evaluation failed");
@@ -270,7 +315,7 @@ public:
     }
 
 private:
-    eshkol_ffi_context_t* ctx_;
+    EshkolCtxHandle ctx_;
 
     /* Non-copyable */
     EshkolContext(const EshkolContext&) = delete;

--- a/lib/ffi/eshkol_ffi.cpp
+++ b/lib/ffi/eshkol_ffi.cpp
@@ -154,13 +154,6 @@ extern "C" void eshkol_ffi_shutdown(eshkol_ffi_context_t* ctx) {
  * Evaluation — in-process JIT via ReplJITContext
  * ============================================================================ */
 
-/* Unique-name counter for FFI result globals. The JIT entry function returns
- * an i32 exit code, not the expression value, so to capture the value we wrap
- * the last AST in (define __eshkol_ffi_result_N__ <expr>) and read the stored
- * tagged_value out of that named global after execution. Thread-safety: atomic
- * increment — concurrent FFI calls do not collide on counter values. */
-static std::atomic<uint64_t> g_ffi_result_counter{0};
-
 extern "C" int eshkol_ffi_eval(eshkol_ffi_context_t* ctx,
                                 const char* source,
                                 eshkol_ffi_value_t* result) {
@@ -207,78 +200,38 @@ extern "C" int eshkol_ffi_eval(eshkol_ffi_context_t* ctx,
         return -1;
     }
 
-    /* Determine which AST carries the value we want to return. If there is
-     * no result slot, every AST is executed purely for effect. Otherwise the
-     * LAST AST is wrapped in a unique (define __eshkol_ffi_result_N__ ...)
-     * so the JIT-emitted main stores its value into a named global that we
-     * can read back via lookupSymbol. This is the same pattern used by
-     * eshkol_eval (introspection.cpp:727); copying it here keeps the FFI
-     * aligned with the Scheme-level eval and avoids the old display+reparse
-     * round-trip that lost type information (lists → "(1 2 3)" strings). */
+    /* Determine which AST carries the value we want to return: the LAST
+     * one parsed, if a result slot was provided. We used to wrap that
+     * AST in a synthetic (define __eshkol_ffi_result_N__ ...) and read
+     * the value back out of that named global via lookupSymbol() after
+     * execution — mirroring what eshkol_eval() (introspection.cpp) did
+     * at the time this was written. That stopped working once the REPL
+     * JIT grew its own "last value" capture (ReplJITContext::executeTagged,
+     * lib/repl/repl_jit.cpp): the JIT-compiled body for a genuine
+     * top-level EXPRESSION emits a call that stashes its tagged value in
+     * a thread-local slot, which executeTagged() reads back directly —
+     * but a top-level DEFINE does not emit that capture call (defines
+     * are conventionally valueless at the REPL), so wrapping the
+     * caller's expression in one made it invisible to the very
+     * mechanism meant to surface it, and ctx->lookup() on the synthetic
+     * global name always came back 0 (every eval() unconditionally
+     * returned null to Python). ctx->execute() already returns the
+     * correctly captured eshkol_tagged_value_t for a plain expression
+     * (see eshkol_eval_jit_execute_fn_t in eval_bridge.h) — the fix
+     * below simply stops discarding it and stops wrapping. */
     const size_t last = asts.size() - 1;
-    eshkol_ast_t* wrapper = nullptr;
-    std::string result_name;
 
-    /* Some top-level forms (define / import / require / provide) have no
-     * expression value — don't wrap them, the wrapper would be semantically
-     * invalid. */
-    bool last_is_valueless = false;
-    if (asts[last].type == ESHKOL_OP) {
-        uint64_t op = asts[last].operation.op;
-        if (op == ESHKOL_DEFINE_OP || op == ESHKOL_IMPORT_OP ||
-            op == ESHKOL_REQUIRE_OP || op == ESHKOL_PROVIDE_OP) {
-            last_is_valueless = true;
-        }
-    }
-
-    if (result && !last_is_valueless) {
-        uint64_t id = g_ffi_result_counter.fetch_add(1, std::memory_order_relaxed);
-        char name_buf[64];
-        snprintf(name_buf, sizeof(name_buf), "__eshkol_ffi_result_%llu__",
-                 (unsigned long long)id);
-        result_name = name_buf;
-
-        wrapper = eshkol_alloc_symbolic_ast();
-        if (!wrapper) {
-            ffi_set_error("Failed to allocate FFI result wrapper AST");
-            for (auto& a : asts) eshkol_ast_clean(&a);
-            return -1;
-        }
-        /* The wrapper owns a heap-allocated copy of the original AST so the
-         * caller's vector-cleanup path stays intact. */
-        eshkol_ast_t* inner = eshkol_alloc_symbolic_ast();
-        if (!inner) {
-            eshkol_free_sexp_ast(wrapper);
-            ffi_set_error("Failed to allocate FFI inner AST");
-            for (auto& a : asts) eshkol_ast_clean(&a);
-            return -1;
-        }
-        *inner = asts[last];
-        /* Transfer ownership: clear the slot in the vector so
-         * eshkol_ast_clean below doesn't double-free the subtree. */
-        std::memset(&asts[last], 0, sizeof(eshkol_ast_t));
-
-        wrapper->type = ESHKOL_OP;
-        wrapper->operation.op = ESHKOL_DEFINE_OP;
-        wrapper->operation.define_op.name = strdup(name_buf);
-        wrapper->operation.define_op.value = inner;
-        wrapper->operation.define_op.is_function = 0;
-        wrapper->operation.define_op.parameters = nullptr;
-        wrapper->operation.define_op.num_params = 0;
-        wrapper->operation.define_op.is_variadic = 0;
-        wrapper->operation.define_op.rest_param = nullptr;
-        wrapper->operation.define_op.is_external = 0;
-        wrapper->operation.define_op.return_type = nullptr;
-        wrapper->operation.define_op.param_types = nullptr;
-    }
-
-    /* Execute all preceding ASTs for side effects, plus the last one (either
-     * as-is if no result is wanted, or through the DEFINE wrapper).
+    /* Execute every AST in source order; the last one's tagged value
+     * (if any — top-level define/import/require/provide are valueless
+     * and naturally come back null) is what a caller with a non-null
+     * result slot receives.
      *
      * Install a top-level exception handler so any unhandled Eshkol raise
      * longjmps back here instead of calling exit(1) and killing the Python
      * host process. On setjmp(...)==1 path, pull the raised value via
      * eshkol_get_raised_value and translate to a C FFI error + -1 return. */
+    eshkol_tagged_value_t last_value;
+    std::memset(&last_value, 0, sizeof(last_value));
     jmp_buf ffi_jmp;
     bool unwound = false;
     if (setjmp(ffi_jmp) != 0) {
@@ -297,21 +250,22 @@ extern "C" int eshkol_ffi_eval(eshkol_ffi_context_t* ctx,
 
     if (!unwound) {
         for (size_t i = 0; i < asts.size(); i++) {
-            eshkol_ast_t* to_run = (i == last && wrapper) ? wrapper : &asts[i];
+            eshkol_ast_t* to_run = &asts[i];
             if (to_run->type == ESHKOL_INVALID) continue;
             try {
-                ctx->execute(ctx->jit, to_run);
+                eshkol_tagged_value_t v = ctx->execute(ctx->jit, to_run);
+                if (i == last) {
+                    last_value = v;
+                }
             } catch (const std::exception& e) {
                 eshkol_pop_exception_handler();
                 ffi_set_error("JIT execution failed: %s", e.what());
                 for (auto& a : asts) eshkol_ast_clean(&a);
-                if (wrapper) eshkol_free_sexp_ast(wrapper);
                 return -1;
             } catch (...) {
                 eshkol_pop_exception_handler();
                 ffi_set_error("JIT execution failed (unknown error)");
                 for (auto& a : asts) eshkol_ast_clean(&a);
-                if (wrapper) eshkol_free_sexp_ast(wrapper);
                 return -1;
             }
         }
@@ -332,22 +286,13 @@ extern "C" int eshkol_ffi_eval(eshkol_ffi_context_t* ctx,
         }
         ffi_set_error("Eshkol exception: %s", msg);
         for (auto& a : asts) eshkol_ast_clean(&a);
-        if (wrapper) eshkol_free_sexp_ast(wrapper);
         return -1;
     }
 
-    /* If we wrapped the last AST, read back the stored tagged_value. */
-    if (wrapper) {
-        uint64_t addr = ctx->lookup(ctx->jit, result_name.c_str());
-        if (addr != 0 && result) {
-            eshkol_tagged_value_t tv;
-            std::memcpy(&tv, reinterpret_cast<void*>(addr), sizeof(tv));
-            *result = to_ffi(tv);
-        }
-        eshkol_free_sexp_ast(wrapper);
+    if (result) {
+        *result = to_ffi(last_value);
     }
 
-    /* Clean up the non-wrapped ASTs. */
     for (auto& a : asts) eshkol_ast_clean(&a);
 
     return 0;

--- a/tests/bindings/python_capsule_lifetime_test.py
+++ b/tests/bindings/python_capsule_lifetime_test.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Audit H1 regression test: NumPy capsule lifetime for the Python bindings.
+
+bindings/python/eshkol_module.cpp's tensor branch of ffi_value_to_python
+hands back a zero-copy NumPy array whose data pointer aliases memory owned
+by the Eshkol runtime (the FFI context's arena). Before the fix, the
+array's `base` capsule had a no-op deleter and held no reference back to
+the context — so deleting the Python `Context` object while the array was
+still alive called eshkol_ffi_shutdown() immediately, with nothing to stop
+it, and any later read of the array was a read of memory the context no
+longer guaranteed was valid.
+
+The fix (see EshkolCtxHandle in eshkol_module.cpp) makes every exported
+array's capsule hold its own strong reference (std::shared_ptr) to the
+context. eshkol_ffi_shutdown() — the shared_ptr's deleter — only actually
+runs once every holder, including every live array's capsule, has let go.
+Deleting the Context object no longer invalidates arrays it already
+produced.
+
+This test proves the tie is real without needing the runtime to already
+have a hook that frees the arena on shutdown (it doesn't, today — the
+arena is process-lifetime, which is exactly why this was a *latent*
+hazard rather than a crash-on-every-run). It registers its OWN hook
+through the same public, documented mechanism a real embedder would use
+to free its own arena-backed state on shutdown — eshkol_register_shutdown_hook(),
+declared in inc/eshkol/core/runtime.h and demonstrated in-tree by
+tests/core/runtime_shutdown_teardown_race_test.cpp — and has that hook
+overwrite the exact bytes backing a live NumPy array. That models
+precisely the scenario the audit H1 comment describes ("if a caller
+destroys the FFI context ... while numpy still references the array,
+reads see freed memory"): whatever a shutdown hook does to arena-backed
+state, it must not touch memory a live NumPy array still depends on.
+
+  BEFORE the fix: deleting the Context runs eshkol_ffi_shutdown()
+  synchronously, the hook fires immediately, and the array's data is
+  silently corrupted — a textbook SILENT-WRONG defect (wrong values, no
+  diagnostic, exit 0; see .icc/silent-wrong-ledger.yaml SW-44).
+
+  AFTER the fix: the array's capsule keeps the context alive, shutdown
+  (and therefore the hook) is deferred until the array itself is
+  released, so the read always sees the original, correct values.
+
+Wired into ctest as python_bindings_capsule_lifetime when
+ESHKOL_PYTHON_BINDINGS is ON and pybind11 + numpy are available; skips
+(exit 0) otherwise, matching the existing eshkol Python binding test
+convention (tests/stdlib/v12_python_test.py).
+"""
+import ctypes
+import gc
+import os
+import sys
+
+# CMake sets ESHKOL_PYTHON_MODULE_DIR to the eshkol_py build output
+# directory so this runs correctly regardless of the build directory name
+# (build, build-asan, build-xla, ...). Fall back to the historical
+# "<repo>/build" convention used by the other loose binding test scripts
+# for a plain manual run.
+sys.path.insert(0, os.environ.get(
+    "ESHKOL_PYTHON_MODULE_DIR",
+    os.path.join(os.path.dirname(__file__), "..", "..", "build")))
+
+PASS = 0
+FAIL = 0
+
+
+def check(name, cond):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        print(f"PASS: {name}")
+    else:
+        FAIL += 1
+        print(f"FAIL: {name}")
+
+
+def main():
+    try:
+        import eshkol
+    except ImportError as e:
+        print(f"SKIP: eshkol Python module not built ({e})")
+        return 0
+
+    try:
+        import numpy as np
+    except ImportError:
+        print("SKIP: numpy not installed")
+        return 0
+
+    # eshkol_py force-loads / whole-archives libeshkol-static.a and links
+    # eshkol-repl-lib (see CMakeLists.txt's ESHKOL_PYTHON_BINDINGS block),
+    # so the extension's own dynamic symbol table carries the full public
+    # C FFI, including eshkol_register_shutdown_hook. Re-dlopen()ing the
+    # exact file Python already imported just bumps its refcount and
+    # hands back the same loaded image — this is not a second copy of the
+    # runtime, just a handle we can call C functions through.
+    libeshkol = ctypes.CDLL(eshkol.__file__)
+
+    HOOK_FN = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_void_p, ctypes.c_int)
+    libeshkol.eshkol_register_shutdown_hook.restype = ctypes.c_uint32
+    libeshkol.eshkol_register_shutdown_hook.argtypes = [
+        HOOK_FN, ctypes.c_void_p, ctypes.c_char_p,
+    ]
+
+    fired = {"count": 0}
+
+    def make_poison_hook(addr, nbytes, pattern):
+        def hook(_ctx, _reason):
+            ctypes.memset(addr, pattern, nbytes)
+            fired["count"] += 1
+            return 0
+        # Keep the ctypes callback trampoline alive for the whole test —
+        # letting it get garbage-collected while still registered with the
+        # runtime would itself be a (different, ctypes-level) UAF.
+        return HOOK_FN(hook)
+
+    # ---- Core scenario: delete the Context while a NumPy array it
+    #      produced is still alive. The array must keep reading the
+    #      correct, original values — never freed/poisoned memory, and
+    #      never a crash. ----
+    ctx = eshkol.Context()
+    a = ctx.eval("#(1.0 2.0 3.0 4.0)")
+    check("tensor eval produced a numpy array", isinstance(a, np.ndarray))
+    expected = list(a)  # snapshot before anything can touch the buffer
+
+    addr = a.ctypes.data
+    nbytes = a.nbytes
+    hook_ref = make_poison_hook(addr, nbytes, 0xEF)
+    hook_id = libeshkol.eshkol_register_shutdown_hook(hook_ref, None, b"h1-poison-test")
+    check("shutdown hook registered", hook_id != 0)
+
+    # CPython refcounting deallocates `ctx` here synchronously (no cycles
+    # are involved), so this is the deterministic point where, pre-fix,
+    # eshkol_ffi_shutdown() ran and the hook fired. gc.collect() is
+    # belt-and-suspenders for any non-refcounting Python implementation.
+    del ctx
+    gc.collect()
+
+    # This is the discriminating check: on the unfixed binding, the hook
+    # has already fired by this point and `a`'s bytes are 0xEF, not the
+    # original values.
+    check("shutdown hook did NOT fire while the array was still live",
+          fired["count"] == 0)
+    check("array values are intact after del(ctx)",
+          list(a) == expected)
+
+    # Releasing the array's own reference must finally let shutdown (and
+    # therefore the hook) run — the fix defers teardown, it does not leak
+    # it forever.
+    del a
+    gc.collect()
+    check("shutdown hook fired once the last live reference was released",
+          fired["count"] == 1)
+
+    print()
+    print("=== Summary ===")
+    print(f"Passed: {PASS}")
+    print(f"Failed: {FAIL}")
+    if FAIL == 0:
+        print("RESULT: ALL PASS")
+        return 0
+    print("RESULT: FAILURES DETECTED")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Root cause

`bindings/python/eshkol_module.cpp` exported each Eshkol tensor as a zero-copy NumPy array backed by arena memory, with a `base` capsule whose deleter was a stateless no-op ("arena managed") and which held no reference back to the owning `eshkol_ffi_context_t`. `EshkolContext::~EshkolContext()` called `eshkol_ffi_shutdown()` on the raw context pointer unconditionally, with nothing to stop that call from running while an exported array — or a NumPy view derived from it — was still alive and depending on that memory staying valid. The in-code comment ("Zero-copy caveat (audit H1)") documented the hazard but never closed it; the documented workaround was "callers `.copy()`", i.e. an admission the zero-copy path was unsafe for ordinary use.

## Mechanism chosen, and why

`EshkolContext` now holds the context as `EshkolCtxHandle` (`std::shared_ptr<eshkol_ffi_context_t>` with `eshkol_ffi_shutdown` as its deleter) instead of a raw pointer. `ffi_value_to_python()` threads that shared handle through, and for every tensor it exports attaches a **second, independent copy** of the shared_ptr to the returned array's `base` capsule (heap-allocated, freed by the capsule's own destructor).

This is the "refcount the context from each exported capsule" option from the three suggested in the plan, and it's the one that matches the existing ownership model: the C FFI already treats `eshkol_ffi_context_t` as a single-owner handle whose destruction is a single explicit call (`eshkol_ffi_shutdown`); there is no separate per-tensor allocation to pin, and the backing arena is a process-wide singleton shared across contexts, so a "copy on context teardown" or "pin the buffer independently of the context" design would either be wasted work (copying data nobody asked to decouple) or would misrepresent an arena resource as if it were independently ownable. Refcounting the *handle* at the C++ binding boundary requires no change to the public C FFI ABI, works with the context type being fully opaque (the `shared_ptr` deleter is type-erased, so the incomplete `eshkol_ffi_context_t` is fine), and NumPy already propagates `base` correctly through slicing/reshaping — no new mechanism, just closing an existing capability the code wasn't using.

The pin is released properly: once every holder — the `Context` wrapper object and every live array's capsule — has dropped its reference, the shared_ptr's refcount hits zero and `eshkol_ffi_shutdown()` runs, exactly once, via the deleter. Nothing leaks the context forever.

## Two necessary, narrower enabling fixes

Both pre-existing, both unrelated to the capsule logic, both required just to make this defect (and its fix) reachable and testable through the actual compiled module at all:

1. **`CMakeLists.txt`'s `ESHKOL_PYTHON_BINDINGS` block force-loaded only `eshkol-static`, not `eshkol-repl-lib`.** `eshkol-repl-lib`'s `eval_bridge_impl.cpp` carries the strong `eshkol_eval_jit_get_*` overrides behind a static-constructor registrar, and nothing else in the module referenced that translation unit by symbol, so ld64/`ld` dropped the archive entirely. `eshkol_ffi_init()` always found every eval-bridge accessor null and failed with "JIT runtime is not linked" — **the Python module never actually initialized under this build option before this branch.** Fixed by force-loading both archives (mirroring the existing `eshkol-run` force-load pair elsewhere in the same file).
2. **`eshkol_ffi_eval()` wrapped its result-carrying AST in a synthetic `(define __eshkol_ffi_result_N__ ...)`** and tried to read the value back via `lookupSymbol()` — a mechanism that predates, and is defeated by, `ReplJITContext::executeTagged()`'s newer thread-local "last value" capture (which does not fire for a top-level `DEFINE`, since defines are conventionally valueless at the REPL). `ctx->execute()`'s already-correctly-captured return value was being discarded, so **every `eval()` unconditionally returned `None`/null regardless of the source expression.** Fixed by using `ctx->execute()`'s return value directly and dropping the dead wrapper/lookup path.

Neither is new capability — they're what made `ctx.eval(...)` (and therefore the tensor/capsule path under test) work at all. As a side effect, the previously-inert `tests/v1_2_edge_cases/python_ffi_test.py` now passes in full (19/19) for what appears to be the first time.

## Test

`tests/bindings/python_capsule_lifetime_test.py`, wired into ctest as `python_bindings_capsule_lifetime` behind `ESHKOL_PYTHON_BINDINGS` (there was no prior ctest wiring for the Python bindings at all). It registers a shutdown hook through the public, documented `eshkol_register_shutdown_hook()` C API — the same mechanism `tests/core/runtime_shutdown_teardown_race_test.cpp` demonstrates for freeing arena-backed state on shutdown — that overwrites a live array's backing bytes, `del`s the `Context` while the array is still referenced, and asserts the array is untouched until its own last reference is released.

**Red/green, demonstrated by hand at branch head:** reverting only `bindings/python/eshkol_module.cpp` to its pre-fix content (keeping the two enabling fixes) reproduces the exact failure:
```
FAIL: shutdown hook did NOT fire while the array was still live
FAIL: array values are intact after del(ctx)
Passed: 3 / Failed: 2, RESULT: FAILURES DETECTED (exit 1)
```
Restoring the fix:
```
PASS: shutdown hook did NOT fire while the array was still live
PASS: array values are intact after del(ctx)
PASS: shutdown hook fired once the last live reference was released
Passed: 5 / Failed: 0, RESULT: ALL PASS (exit 0)
```

**Full verification at this branch's head:**
- `cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DESHKOL_PYTHON_BINDINGS=ON ...` (plus the flags in the task spec) → full `ninja` build green.
- `ctest --test-dir build -j 6`: **185/185 passed**, including the new `python_bindings_capsule_lifetime`.
- `tests/v1_2_edge_cases/python_ffi_test.py`: **19/19 passed**.
- ASan+UBSan build (`-DESHKOL_ENABLE_ASAN=ON -DESHKOL_ENABLE_UBSAN=ON`, `ASAN_OPTIONS=detect_leaks=0:halt_on_error=1`): both `python_capsule_lifetime_test.py` and `python_ffi_test.py` pass clean, no sanitizer reports. (The repro's own poison step overwrites still-allocated memory rather than freed memory, so ASan doesn't additionally flag it — this ledger entry's shape is a wrong *value* at exit 0, which is what the SILENT-WRONG bucket requires; a sanitizer-caught crash would be a different bucket, LOUD-ERROR. ASan here is confirming the shared_ptr/capsule mechanism itself introduces no memory error, per the task's "poison/ASan is the detector" instruction.)

## Ledger

Adds `.icc/silent-wrong-ledger.yaml` **SW-44** (family: interop/lifetime; next free id after SW-43), closed with reproduction, root cause, fix, and evidence per the established schema. `grep -o 'id: SW-[0-9]*b*' .icc/silent-wrong-ledger.yaml | sort -V | uniq -d` is empty (no id collision) and `python3 scripts/gate_no_silent_wrong.py` reports **PASS**.

## Scope

Lifetime safety only. The separate double\*-demotion / exactness-across-the-FFI-boundary issue is an explicitly different, still-open v1.4.0 lane and is not touched here.

## Test plan
- [x] `ctest --test-dir build -j 6` — 185/185 passed
- [x] `tests/v1_2_edge_cases/python_ffi_test.py` — 19/19 passed
- [x] New regression test demonstrated red (pre-fix) and green (post-fix)
- [x] ASan+UBSan run of both binding test scripts — clean
- [x] `.icc/silent-wrong-ledger.yaml` SW-44 id-unique and `scripts/gate_no_silent_wrong.py` PASS
- [x] ICC `guard-diff` / `pre-commit-check` — 0 violations, 0 rollback risks (1 informational warning: deleted-line count exceeds the default threshold, from removing the now-dead wrapper/lookup mechanism in `eshkol_ffi_eval()` and the no-op capsule code — expected and reviewed)