### PR TITLE
TEST (throwaway, will be closed): docs-only proof for PR #455

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -280,3 +280,5 @@ Missing something? This index links every document tracked under `docs/`, plus
 the adjacent `examples/`, `tests/`, `tools/icc_extras/`, `press/`, and
 `nix/jetson/` documentation. If you land on a page that isn't reachable from
 here, that's a bug in this index — please open an issue or fix it directly.
+
+<!-- ci-wave proof PR: docs-only test, throwaway, will be closed -->


### PR DESCRIPTION
Throwaway proof PR for #455, based on #455's branch (base=ci/docs-only-contexts, temporarily includes a TEMP-TEST-ONLY trigger-widening commit that will be reverted before #455 is finalized — see #455's evidence dir). This PR itself touches only `docs/README.md`. Expect: docs_only=true, every heavy job reports SKIPPED. Will be closed and branch deleted after verification.