### PR TITLE
fix(vm): shared closure-upvalue capacity — a large procedure no longer corrupts the next define

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -264,6 +264,13 @@ oracles:
         action: ./scripts/run_icc_smoke.sh
       - runtime_event:
           event_kinds: [eshkol_smoke]
+          event_names: ["eshkol-vm-large-proc"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'VM closure-upvalue capacity: the compiler''s upvalue cap and the runtime closure array''s capacity are one shared constant (ESHKOL_VM_MAX_CLOSURE_UPVALUES) — a procedure referencing up to 32 distinct top-level procedures runs correctly and the top-level define compiled right after it is never corrupted (17-32 upvalues used to silently strand values on the operand stack via a hardcoded 16-slot runtime array), and one past the shared capacity fails the compile loudly instead of continuing with a missing capture (SW-45)'
+        action: ./scripts/run_icc_smoke.sh
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
           event_names: ["linear_solve_full_f64_oracle"]
           event_values: ["PASS"]
         severity: high

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -3027,6 +3027,142 @@ entries:
       double*-demotion / exactness-across-the-FFI-boundary issue is an explicitly
       different, still-open v1.4.0 lane and is not touched here.
 
+  - id: SW-45
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "fix/vm-large-proc-define"
+    closed_by: "branch fix/vm-large-proc-define"
+    note: >-
+      SW-44 was reserved by PR #458 (pybind capsule-lifetime fix) at the time
+      this entry was first filed on the pre-#458 base; it was renumbered to
+      SW-45 then, and confirmed still the next free id after rebasing onto
+      origin/master with #458 merged and SW-44 present (verified via `grep -o
+      'id: SW-[0-9]*b*' .icc/silent-wrong-ledger.yaml | sort -V | uniq -d`
+      returning empty).
+    title: "A VM procedure referencing more than 16 distinct top-level procedures silently corrupts the next top-level define"
+    repro: >-
+      A single bytecode-VM procedure that calls 17 or more DISTINCT other
+      top-level procedures (each such call resolves as a free-variable
+      reference through the same upvalue-capture machinery as any other
+      captured name, so the procedure's own closure must relay one upvalue
+      per distinct name) compiled and ran fine — the corruption showed up in
+      the TOP-LEVEL DEFINE COMPILED RIGHT AFTER IT. Minimal form: 17
+      `(define (helperK x) ...)` procedures, one `(define (big i) (+ i
+      (helper0 i) ... (helper16 i)))`, then `(define (probe x) (+ x 1))`;
+      calling `(probe 41)` failed. Discovered via
+      tests/memory/vm_region_evac_subtype_coverage_test.esk on
+      feat/vm-region-evacuator, whose phase-2 fixture originally called ~20
+      distinct constructor procedures (make-fact, make-kb, make-workspace,
+      tensor, ...) from one procedure; its header documents the same defect
+      and the two-procedure split used as a workaround, which this fix makes
+      unnecessary (verified: tests/vm/closure_upvalue_capacity_surface_regression.esk's
+      case C re-merges that exact shape into one procedure and passes).
+    observed: >-
+      Calling the procedure defined immediately after the big one raised
+      "ERROR: calling non-function at pc=... argc=... type=0" (VAL_NIL in the
+      minimal repro; a stray leaked upvalue Value in general — the original
+      report's "reads back as an integer" is a different manifestation of the
+      identical leak: which stray operand-stack value lands in the corrupted
+      slot depends on what else was on the stack at the time). Exit path was
+      always through a hard runtime error in every reproduction attempted, but
+      the value corruption itself carried NO diagnostic and would have exited
+      0 (a `define` bound to a non-closure value only fails when something
+      tries to CALL it; a define whose corrupted value happens to go unused
+      would silently carry the wrong value with exit 0). Preceded by "UPVALUE
+      INDEX OUT OF BOUNDS" on stderr from an unrelated GET_UPVALUE access,
+      itself a symptom of the same stack desync.
+    correct: >-
+      The procedure compiled right after a large procedure must always read
+      back as its own closure, regardless of how many distinct top-level
+      procedures the large procedure calls, up to the documented capacity;
+      beyond that capacity the compiler must refuse to compile at all rather
+      than emit a program that runs with a missing capture.
+    root_cause: >-
+      Two independent limits on the same quantity, never kept in sync. The
+      compiler's per-scope upvalue cap (MAX_UPVALUES, lib/backend/vm_parser.c)
+      was 32, enforced when registering a new upvalue in the free-variable
+      resolution walk (lib/backend/vm_compiler.c, both the plain-reference
+      path in compile_expr_impl and the compile_form_set_bang path). The
+      RUNTIME closure representation (HeapObject.closure.upvalues[16] /
+      open_slots[16] in lib/backend/vm_core.c) was fixed at HALF that, 16, and
+      nothing enforced parity between the two. A closure needing 17-32
+      upvalues compiled cleanly under the 32 cap: the compiler emitted exactly
+      that many upvalue-capture push instructions (OP_GET_LOCAL/OP_GET_UPVALUE)
+      followed by one OP_CLOSURE encoding the true count in its operand. At
+      runtime, OP_CLOSURE (lib/backend/vm_run.c, both the computed-goto
+      dispatch's lbl_CLOSURE and the switch dispatch's case OP_CLOSURE)
+      silently clamped that count to 16 (`if (n_upvalues > 16) n_upvalues =
+      16;`) and then only popped the CLAMPED count of values off the operand
+      stack (`for (int i = n_upvalues - 1; i >= 0; i--) { ...upvalues[i] =
+      vm_pop(vm); }`) — leaving the excess (count - 16) values the compiler
+      had already pushed permanently stranded on the stack. Every stack-slot
+      offset the compiler had computed at compile time for the rest of the
+      program (every subsequent top-level define's binding slot, every local
+      variable's frame offset) assumed those values would be consumed; from
+      that point on the runtime stack held (count - 16) more live values than
+      the compiler's bookkeeping expected, so the next top-level `define`'s
+      OP_SET_LOCAL/local-slot bookkeeping landed on a slot that actually held
+      one of the stranded values instead of the newly constructed closure.
+    fix: >-
+      inc/eshkol/backend/vm_limits.h now defines
+      ESHKOL_VM_MAX_CLOSURE_UPVALUES=32 as the single shared constant: it is
+      aliased to MAX_UPVALUES for the compiler (lib/backend/vm_parser.c) and
+      used directly to size HeapObject.closure.upvalues[]/open_slots[] in
+      lib/backend/vm_core.c, so the two limits cannot diverge again (a
+      `#error` guards it against ever exceeding the CLOSURE instruction's
+      8-bit upvalue-count operand field). lib/backend/vm_run.c's two
+      OP_CLOSURE handlers no longer clamp: if the encoded count ever exceeds
+      the shared capacity (only reachable via a corrupted or
+      build-mismatched .eskb, since the compiler now enforces the identical
+      bound) they report a fatal runtime error and refuse to run rather than
+      silently popping fewer values than were pushed. lib/backend/vm_native.c's
+      upvalue-closing loop (native 252, letrec-style leaked-closure handling)
+      had the same hardcoded 16 and is fixed the same way. Symmetrically,
+      lib/backend/vm_compiler.c's two upvalue-registration sites (the
+      plain-reference read path and the `set!` path) now call
+      vm_compile_error() and fail the whole compilation — via the existing
+      fail-closed g_vm_compile_failed flag both compile drivers already
+      checked (eshkol_vm.c's JIT-run and ESKB-emit paths) — when a scope
+      would need MORE than the shared capacity, instead of leaving that
+      upvalue's index at -1 and continuing.
+    evidence: >-
+      tests/vm/closure_upvalue_capacity_surface_regression.esk (wired into
+      scripts/run_vm_surface_tests.sh's existing *_surface_regression.esk
+      glob, no script change needed): case A pins the historical minimum (17,
+      one past the old 16-slot capacity), case B pins the full new capacity
+      (32) as a margin so the fix is not merely correct at the boundary, and
+      case C re-merges the original evacuator-fixture shape (20 distinct
+      `vector-set!` constructor calls in one procedure) into a single
+      procedure and checks the define compiled right after it. All three
+      check BOTH the big procedure's own return value and that the following
+      define is callable and correct.
+      tests/closures/closure_upvalue_capacity_ok_test.esk (32, must run
+      correctly) and closure_upvalue_capacity_overflow_test.esk (33, must
+      fail the compile loudly) are exercised by
+      tests/closures/closure_upvalue_capacity_overflow_gate.sh, wired into
+      CTest as closure_upvalue_capacity_overflow_gate, covering both the
+      in-process compile-and-run path (eshkol-vm-standalone-test <src.esk>)
+      and the two-step build path (eshkol-run --profile hosted-vm
+      --emit-eskb, then load and run the .eskb) so the ESKB writer/reader
+      round-trip is covered too. ICC probe eshkol-vm-large-proc
+      (scripts/run_icc_smoke.sh) runs both and requires all three surface
+      cases to print PASS with no ERROR/FAIL, plus a clean run of the
+      overflow gate.
+    caught_by: [region-evacuator-fixture-development]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-surface-regression-suite, vm-parity]
+    notes: >-
+      The evacuator fixture's own header (tests/memory/vm_region_evac_subtype_coverage_test.esk
+      on feat/vm-region-evacuator) had already named this defect precisely —
+      "a single procedure carrying all twenty constructors trips an unrelated
+      VM binding-slot defect (the following top-level `define` reads back as
+      an integer)" — and worked around it by splitting phase 2 across
+      `heavy-a`/`heavy-b` rather than fixing it, since fixing the VM compiler
+      was out of scope for that branch. This entry closes the root cause so
+      that workaround is no longer necessary (though the evacuator branch
+      itself is untouched by this fix). Reproduces identically with `begin`
+      in place of `with-region`, confirming it has nothing to do with
+      regions — it is purely a function-body-size-driven upvalue count.
+
   # ───────────────────────── PARITY-RATCHET ─────────────────────────
 
   - id: PR-01

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4043,6 +4043,31 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run AND
         FAIL_REGULAR_EXPRESSION "FAIL:")
 endif()
 
+# SW-45 gate: the bytecode VM's per-scope closure-upvalue capacity
+# (ESHKOL_VM_MAX_CLOSURE_UPVALUES, inc/eshkol/backend/vm_limits.h) is enforced
+# consistently by both the compiler and the runtime — a procedure needing up
+# to the shared capacity runs correctly (and does not corrupt the top-level
+# `define` compiled right after it, which is what this defect used to do
+# silently), and one past the capacity fails the compile loudly instead.
+if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run AND
+   EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/closures/closure_upvalue_capacity_overflow_gate.sh")
+    if(TARGET eshkol-vm-standalone-test)
+        set(ESHKOL_UV_GATE_VM "$<TARGET_FILE:eshkol-vm-standalone-test>")
+    else()
+        set(ESHKOL_UV_GATE_VM "none")
+    endif()
+    add_test(NAME closure_upvalue_capacity_overflow_gate
+        COMMAND bash
+            "${CMAKE_CURRENT_SOURCE_DIR}/tests/closures/closure_upvalue_capacity_overflow_gate.sh"
+            "$<TARGET_FILE:eshkol-run>"
+            "${ESHKOL_UV_GATE_VM}"
+            "${CMAKE_CURRENT_BINARY_DIR}/closure-upvalue-capacity-gate")
+    set_tests_properties(closure_upvalue_capacity_overflow_gate PROPERTIES
+        TIMEOUT 300
+        PASS_REGULAR_EXPRESSION "PASS: closure upvalue capacity enforced"
+        FAIL_REGULAR_EXPRESSION "FAIL:")
+endif()
+
 if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/core/linear_solve_hosted_control_test.cpp")
     add_executable(linear_solve_hosted_control_test
         tests/core/linear_solve_hosted_control_test.cpp)

--- a/inc/eshkol/backend/vm_limits.h
+++ b/inc/eshkol/backend/vm_limits.h
@@ -44,6 +44,36 @@
 #define ESHKOL_VM_MAX_CODE 100000
 #endif
 
+/* Per-closure upvalue capacity: the SINGLE source of truth shared by the
+ * compiler (vm_parser.c's MAX_UPVALUES, which bounds how many free variables
+ * one lexical scope may register) and the runtime closure representation
+ * (vm_core.c's HeapObject.closure.upvalues[]/open_slots[] fixed arrays, and
+ * every OP_CLOSURE/OP_GET_UPVALUE/OP_SET_UPVALUE/native-131/151 site in
+ * vm_run.c and vm_native.c that indexes them).
+ *
+ * These two counts used to be independent literals — MAX_UPVALUES 32 at
+ * compile time, a bare `16` baked into the closure arrays and every runtime
+ * access at execution time. A closure needing between 17 and 32 upvalues
+ * compiled cleanly (under the compiler's limit) and then, at OP_CLOSURE, had
+ * its upvalue count silently clamped to 16: the runtime popped only 16 of
+ * the >16 values the compiler had pushed to feed it, stranding the rest on
+ * the operand stack. Nothing about that clamp was visible — no error, exit
+ * 0 — so every stack slot computed at compile time for the REST OF THE
+ * PROGRAM was off by the leaked count from then on, and the next top-level
+ * `define` silently read back whatever stray value the leak had left in its
+ * slot instead of its own closure. A single procedure with ~20 constructor
+ * calls (one small closure captured per call) was enough to cross 16.
+ *
+ * Fixing the mismatch requires both limits to be THIS constant, everywhere,
+ * so they can never diverge again; see MAX_UPVALUES below. Raising it is
+ * free (an array bound, not a growth path) — 32 comfortably covers ordinary
+ * programs, and vm_compile_error() below now refuses to compile silently
+ * past it rather than letting a legitimately-larger closure fall through the
+ * old silent-drop. */
+#ifndef ESHKOL_VM_MAX_CLOSURE_UPVALUES
+#define ESHKOL_VM_MAX_CLOSURE_UPVALUES 32
+#endif
+
 /* Runaway-instruction guard for the bytecode interpreter: the number of
  * instructions vm_run() will execute before deciding the program is not going
  * to terminate. Unlike the capacities above this is a *default*, not a fixed
@@ -82,6 +112,17 @@
 #error "ESHKOL_VM_MAX_CODE must be positive"
 #endif
 
+#if ESHKOL_VM_MAX_CLOSURE_UPVALUES <= 0
+#error "ESHKOL_VM_MAX_CLOSURE_UPVALUES must be positive"
+#endif
+
+/* The CLOSURE instruction packs the upvalue count into an 8-bit operand
+ * field (bits 16..23, see OP_CLOSURE in vm_run.c) — this must never silently
+ * truncate the way the closure-array size once did. */
+#if ESHKOL_VM_MAX_CLOSURE_UPVALUES > 255
+#error "ESHKOL_VM_MAX_CLOSURE_UPVALUES must fit the OP_CLOSURE operand's 8-bit upvalue-count field (<= 255)"
+#endif
+
 /* Legacy aliases used inside the current unity-built VM components. Keep these
  * local to VM sources; new build/profile code should use the ESHKOL_VM_* names. */
 #undef HEAP_SIZE
@@ -98,5 +139,8 @@
 
 #undef MAX_CODE
 #define MAX_CODE ESHKOL_VM_MAX_CODE
+
+#undef MAX_UPVALUES
+#define MAX_UPVALUES ESHKOL_VM_MAX_CLOSURE_UPVALUES
 
 #endif /* ESHKOL_BACKEND_VM_LIMITS_H */

--- a/lib/backend/vm_compiler.c
+++ b/lib/backend/vm_compiler.c
@@ -2354,6 +2354,23 @@ static void compile_form_set_bang(FuncChunk* c, Node* node, int tail) {
                         fc->upvalues[fc->n_upvalues].is_local = prev_is_local;
                         fc->upvalues[fc->n_upvalues].boxed = var_boxed;
                         fc->n_upvalues++;
+                    } else if (uv_idx < 0) {
+                        /* MAX_UPVALUES exhausted: this scope already relays
+                         * MAX_UPVALUES distinct free variables through to its
+                         * closures and cannot add `name`. Silently continuing
+                         * left uv_idx (and every later use of it as an
+                         * enclosing_slot/operand) at -1, which is exactly the
+                         * fixed-limit-corrupts-silently shape this rule
+                         * exists to prevent — fail the compile instead. */
+                        char msg[256];
+                        snprintf(msg, sizeof(msg),
+                                 "closure exceeds the %d-upvalue capture limit (variable '%s')",
+                                 MAX_UPVALUES, name);
+                        vm_compile_error(msg,
+                                         "a single lexical scope may capture at most "
+                                         "MAX_UPVALUES distinct free variables into its "
+                                         "nested closures; split the procedure into "
+                                         "smaller ones so fewer are captured together.");
                     }
                     prev_slot = uv_idx;
                     prev_is_local = 0;
@@ -3075,6 +3092,21 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
                             fc->upvalues[fc->n_upvalues].is_local = prev_is_local;
                             fc->upvalues[fc->n_upvalues].boxed = var_boxed;
                             fc->n_upvalues++;
+                        } else if (uv_idx < 0) {
+                            /* MAX_UPVALUES exhausted — see the identical
+                             * branch in compile_form_set_bang() for why this
+                             * must fail the compile rather than continue with
+                             * uv_idx (and its downstream enclosing_slot uses)
+                             * left at -1. */
+                            char msg[256];
+                            snprintf(msg, sizeof(msg),
+                                     "closure exceeds the %d-upvalue capture limit (variable '%s')",
+                                     MAX_UPVALUES, node->symbol);
+                            vm_compile_error(msg,
+                                             "a single lexical scope may capture at most "
+                                             "MAX_UPVALUES distinct free variables into its "
+                                             "nested closures; split the procedure into "
+                                             "smaller ones so fewer are captured together.");
                         }
                         prev_slot = uv_idx;
                         prev_is_local = 0;

--- a/lib/backend/vm_core.c
+++ b/lib/backend/vm_core.c
@@ -268,11 +268,17 @@ typedef struct {
              * expand a point to a callable's true signature. */
             int32_t arity;
             int32_t n_upvalues;
-            Value upvalues[16];
+            /* Capacity MUST equal the compiler's MAX_UPVALUES (both are
+             * ESHKOL_VM_MAX_CLOSURE_UPVALUES, see vm_limits.h) — a closure
+             * whose upvalue count the compiler allowed but this array
+             * couldn't hold is exactly the defect that let a large
+             * procedure's OP_CLOSURE silently strand values on the operand
+             * stack and corrupt whatever top-level `define` compiled next. */
+            Value upvalues[ESHKOL_VM_MAX_CLOSURE_UPVALUES];
             /* -1 means closed/captured-by-value; otherwise this is an
              * absolute VM stack slot shared by every closure that captures
              * the same live top-level binding. */
-            int32_t open_slots[16];
+            int32_t open_slots[ESHKOL_VM_MAX_CLOSURE_UPVALUES];
         } closure;
         struct { void* ptr; int subtype; } opaque;  /* for complex, rational, tensor, logic, etc. */
     };

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -14160,7 +14160,7 @@ static void vm_dispatch_native(VM* vm, int fid) {
             cl_val.as.ptr < vm->heap.next_free) {
             HeapObject* cl = vm->heap.objects[cl_val.as.ptr];
             if (cl && cl->type == HEAP_CLOSURE) {
-                for (int i = 0; i < cl->closure.n_upvalues && i < 16; i++) {
+                for (int i = 0; i < cl->closure.n_upvalues && i < ESHKOL_VM_MAX_CLOSURE_UPVALUES; i++) {
                     int32_t open_slot = cl->closure.open_slots[i];
                     if (open_slot < 0) continue;
                     if (open_slot < STACK_SIZE)

--- a/lib/backend/vm_parser.c
+++ b/lib/backend/vm_parser.c
@@ -619,7 +619,19 @@ typedef struct {
     int code_len;
 } ChunkEntry;
 
+/* MAX_UPVALUES is normally already provided (as an alias for
+ * ESHKOL_VM_MAX_CLOSURE_UPVALUES) by eshkol/backend/vm_limits.h, included
+ * above — this is only a fallback for a build of this file in isolation. It
+ * MUST equal the runtime closure representation's upvalue-array capacity
+ * (vm_core.c's HeapObject.closure.upvalues[]/open_slots[]); see the
+ * ESHKOL_VM_MAX_CLOSURE_UPVALUES comment in vm_limits.h for why these two
+ * counts have to come from the same constant rather than independent
+ * literals — a closure whose upvalue count fits the compiler's limit but not
+ * the runtime array's is exactly how a large procedure silently corrupted
+ * the top-level define compiled right after it. */
+#ifndef MAX_UPVALUES
 #define MAX_UPVALUES 32
+#endif
 #define CHUNK_INIT_CODE 256
 #define CHUNK_INIT_CONSTS 64
 #define CHUNK_INIT_LOCALS 32

--- a/lib/backend/vm_run.c
+++ b/lib/backend/vm_run.c
@@ -650,7 +650,25 @@ void vm_run(VM* vm) {
     lbl_CLOSURE: {
         int const_idx = instr.operand & 0xFFFF;
         int n_upvalues = (instr.operand >> 16) & 0xFF;
-        if (n_upvalues > 16) n_upvalues = 16;
+        /* n_upvalues is the count the COMPILER pushed onto the operand stack
+         * to feed this closure (func.n_upvalues, bounded at compile time by
+         * MAX_UPVALUES). It must never exceed the runtime closure's array
+         * capacity: the two are the same constant (ESHKOL_VM_MAX_CLOSURE_
+         * UPVALUES, see vm_limits.h), so this can only fire on a corrupted
+         * or build-mismatched .eskb. Previously this silently clamped to a
+         * hardcoded 16 and then popped only the clamped count — leaving the
+         * excess already-pushed values stranded on the stack, which
+         * desynced every stack-slot offset the compiler had computed for
+         * the rest of the program. A too-small limit must fail loudly
+         * instead of running on with a corrupted stack. */
+        if (n_upvalues > ESHKOL_VM_MAX_CLOSURE_UPVALUES) {
+            fprintf(stderr,
+                    "ERROR: OP_CLOSURE upvalue count %d exceeds runtime capacity %d "
+                    "(pc=%d) — refusing to run a program with a corrupted or "
+                    "build-mismatched closure encoding\n",
+                    n_upvalues, ESHKOL_VM_MAX_CLOSURE_UPVALUES, vm->pc - 1);
+            vm->error = 1; goto vm_exit;
+        }
         Value func_const = vm->constants[const_idx];
         int32_t func_pc = (int32_t)func_const.as.i;
         /* Arity packed by the compiler in bits 32..40 of the func-PC constant
@@ -664,7 +682,7 @@ void vm_run(VM* vm) {
         vm->heap.objects[ptr]->closure.func_pc = func_pc;
         vm->heap.objects[ptr]->closure.arity = clo_arity;
         vm->heap.objects[ptr]->closure.n_upvalues = n_upvalues;
-        for (int i = 0; i < 16; i++)
+        for (int i = 0; i < ESHKOL_VM_MAX_CLOSURE_UPVALUES; i++)
             vm->heap.objects[ptr]->closure.open_slots[i] = -1;
         for (int i = n_upvalues - 1; i >= 0; i--) {
             vm->heap.objects[ptr]->closure.upvalues[i] = vm_pop(vm);
@@ -1465,7 +1483,22 @@ vm_exit:
             /* Operand: low 16 bits = constant pool index, bits 16-23 = n_upvalues */
             int const_idx = instr.operand & 0xFFFF;
             int n_upvalues = (instr.operand >> 16) & 0xFF;
-            if (n_upvalues > 16) n_upvalues = 16;
+            /* See the identical check in lbl_CLOSURE above: n_upvalues must
+             * never exceed the runtime closure array's capacity, because the
+             * compiler already pushed exactly this many values to feed it.
+             * Silently clamping and popping fewer than were pushed strands
+             * the excess on the operand stack and desyncs every later
+             * stack-slot offset the compiler computed — the mechanism behind
+             * a large procedure corrupting the top-level define compiled
+             * right after it. Fail loudly instead. */
+            if (n_upvalues > ESHKOL_VM_MAX_CLOSURE_UPVALUES) {
+                fprintf(stderr,
+                        "ERROR: OP_CLOSURE upvalue count %d exceeds runtime capacity %d "
+                        "(pc=%d) — refusing to run a program with a corrupted or "
+                        "build-mismatched closure encoding\n",
+                        n_upvalues, ESHKOL_VM_MAX_CLOSURE_UPVALUES, vm->pc - 1);
+                vm->error = 1; break;
+            }
             Value func_const = vm->constants[const_idx];
             int32_t func_pc = (int32_t)func_const.as.i;
             int32_t clo_arity = ((func_const.as.i >> 40) & 1)
@@ -1476,7 +1509,7 @@ vm_exit:
             vm->heap.objects[ptr]->closure.func_pc = func_pc;
             vm->heap.objects[ptr]->closure.arity = clo_arity;
             vm->heap.objects[ptr]->closure.n_upvalues = n_upvalues;
-            for (int i = 0; i < 16; i++)
+            for (int i = 0; i < ESHKOL_VM_MAX_CLOSURE_UPVALUES; i++)
                 vm->heap.objects[ptr]->closure.open_slots[i] = -1;
             /* Pop upvalues from stack (pushed before CLOSURE, in reverse order) */
             for (int i = n_upvalues - 1; i >= 0; i--) {

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -694,6 +694,33 @@ probe higher_order_shadowing_oracle 'map/for-each/filter/fold/reduce/remove call
      printf "%s" "$c" | grep -q "PASS: higher-order shadowing (vm)" || exit 1;
      printf "%s" "$c" | grep -q "FAIL:" && exit 1;
      exit 0'
+# SW-45. A single VM procedure that references more than 16 distinct
+# top-level procedures (every call is a free-variable reference resolved as
+# an upvalue, exactly like a captured variable) needed to relay more than 16
+# upvalues to its own closure. The compiler capped that count at 32
+# (MAX_UPVALUES) but the runtime closure representation's arrays were fixed
+# at 16 (HeapObject.closure.upvalues[]/open_slots[], vm_core.c); OP_CLOSURE
+# silently clamped to 16 and popped only 16 of the >16 values the compiler
+# had pushed, stranding the rest on the operand stack with no diagnostic and
+# exit 0. Every stack-slot offset computed for the rest of the program was
+# off by the leaked count from then on, so the very next top-level `define`
+# read back a stray leaked value instead of its own closure — discovered via
+# a VM evacuator fixture with ~20 constructor calls in one procedure
+# corrupting the define compiled right after it. Fixed by sharing one
+# constant (ESHKOL_VM_MAX_CLOSURE_UPVALUES, inc/eshkol/backend/vm_limits.h)
+# between the compiler's cap and the runtime array capacity, and by failing
+# the compile loudly (never silently) if a scope still needs more upvalues
+# than that shared capacity holds.
+probe eshkol-vm-large-proc 'a VM procedure calling up to 32 distinct top-level procedures (17-32 used to silently corrupt the define compiled right after it) runs correctly, and one past the shared capacity fails the compile loudly instead (SW-45)' \
+    'cd "$REPO_ROOT";
+     vm="$BUILD_DIR_PATH/eshkol-vm-standalone-test";
+     [ -x "$vm" ] || exit 1;
+     out=$(ESHKOL_VM_NO_DISASM=1 "$vm" tests/vm/closure_upvalue_capacity_surface_regression.esk 2>&1) || exit 1;
+     [ "$(printf "%s" "$out" | grep -c "^PASS$")" -eq 3 ] || exit 1;
+     printf "%s" "$out" | grep -q "^FAIL$" && exit 1;
+     printf "%s" "$out" | grep -q "ERROR:" && exit 1;
+     bash tests/closures/closure_upvalue_capacity_overflow_gate.sh "$ESHKOL_RUN" "$vm" "$(mktemp -d)" >/dev/null 2>&1 || exit 1;
+     exit 0'
 probe linear_solve_full_f64_oracle 'linear-solve: mixed-precision IR dense solver reaches full-f64 residual (<=1e-12, computed in-test) on well-conditioned/identity systems and raises catchably on singular/dimension-mismatch — verified on JIT, AOT, and the VM' \
     'cd "$REPO_ROOT"; t=tests/features/linear_solve_test.esk;
      out=$(ESHKOL_PATH="$REPO_ROOT/lib" "$ESHKOL_RUN" -r "$t" 2>/dev/null) || exit 1;

--- a/tests/closures/closure_upvalue_capacity_ok_test.esk
+++ b/tests/closures/closure_upvalue_capacity_ok_test.esk
@@ -1,0 +1,48 @@
+;; SW-45 companion: a single procedure calling exactly 32 distinct
+;; top-level procedures — the full shared capacity
+;; (ESHKOL_VM_MAX_CLOSURE_UPVALUES, inc/eshkol/backend/vm_limits.h) — compiles
+;; and runs correctly, and the top-level `define` compiled right after it
+;; (`probe`) is unaffected. Companion to
+;; closure_upvalue_capacity_overflow_test.esk (33 calls, one past the
+;; capacity, which must instead fail the compile loudly) and to
+;; tests/vm/closure_upvalue_capacity_surface_regression.esk (the standalone-VM
+;; version of this same boundary, plus the original vector-set! discovery
+;; shape). Run by closure_upvalue_capacity_overflow_gate.sh.
+
+(define (helper0 x) (+ x 0))
+(define (helper1 x) (+ x 1))
+(define (helper2 x) (+ x 2))
+(define (helper3 x) (+ x 3))
+(define (helper4 x) (+ x 4))
+(define (helper5 x) (+ x 5))
+(define (helper6 x) (+ x 6))
+(define (helper7 x) (+ x 7))
+(define (helper8 x) (+ x 8))
+(define (helper9 x) (+ x 9))
+(define (helper10 x) (+ x 10))
+(define (helper11 x) (+ x 11))
+(define (helper12 x) (+ x 12))
+(define (helper13 x) (+ x 13))
+(define (helper14 x) (+ x 14))
+(define (helper15 x) (+ x 15))
+(define (helper16 x) (+ x 16))
+(define (helper17 x) (+ x 17))
+(define (helper18 x) (+ x 18))
+(define (helper19 x) (+ x 19))
+(define (helper20 x) (+ x 20))
+(define (helper21 x) (+ x 21))
+(define (helper22 x) (+ x 22))
+(define (helper23 x) (+ x 23))
+(define (helper24 x) (+ x 24))
+(define (helper25 x) (+ x 25))
+(define (helper26 x) (+ x 26))
+(define (helper27 x) (+ x 27))
+(define (helper28 x) (+ x 28))
+(define (helper29 x) (+ x 29))
+(define (helper30 x) (+ x 30))
+(define (helper31 x) (+ x 31))
+(define (big i)
+  (+ i (helper0 i) (helper1 i) (helper2 i) (helper3 i) (helper4 i) (helper5 i) (helper6 i) (helper7 i) (helper8 i) (helper9 i) (helper10 i) (helper11 i) (helper12 i) (helper13 i) (helper14 i) (helper15 i) (helper16 i) (helper17 i) (helper18 i) (helper19 i) (helper20 i) (helper21 i) (helper22 i) (helper23 i) (helper24 i) (helper25 i) (helper26 i) (helper27 i) (helper28 i) (helper29 i) (helper30 i) (helper31 i)))
+(define (probe x) (+ x 1))
+
+(display (if (and (= (big 0) 496) (= (probe 41) 42)) "PASS" "FAIL")) (newline)

--- a/tests/closures/closure_upvalue_capacity_overflow_gate.sh
+++ b/tests/closures/closure_upvalue_capacity_overflow_gate.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# SW-45 gate: the shared closure-upvalue capacity is enforced consistently —
+# up to it a program runs correctly (including the top-level `define`
+# compiled right after the big procedure), and one past it the compiler
+# refuses LOUDLY instead of silently corrupting the runtime stack.
+#
+# Before the fix, the compiler capped a scope's upvalue count at 32
+# (MAX_UPVALUES, lib/backend/vm_parser.c) but the runtime closure
+# representation's arrays (vm_core.c's HeapObject.closure.upvalues[]/
+# open_slots[]) were fixed at 16. A closure needing 17-32 upvalues compiled
+# cleanly and then had its count silently clamped to 16 at OP_CLOSURE
+# (lib/backend/vm_run.c): the runtime popped only 16 of the >16 values the
+# compiler had pushed to feed it, stranding the rest on the operand stack —
+# no error, exit 0 — and every stack-slot offset computed for the rest of the
+# program was off by the leaked count from then on. The next top-level
+# `define` read back a stray leaked value instead of its own closure.
+#
+# inc/eshkol/backend/vm_limits.h now defines ESHKOL_VM_MAX_CLOSURE_UPVALUES as
+# the single shared constant for both the compiler's cap and the runtime
+# array capacity, so this gate's two cases pin what "shared" has to mean:
+#
+#   1. AT the capacity (32 distinct top-level calls in one procedure): the
+#      procedure computes the right answer AND the define compiled right
+#      after it is still callable and correct — not just present.
+#   2. ONE PAST the capacity (33): the compile fails loudly (nonzero exit,
+#      the "closure exceeds the ... upvalue capture limit" diagnostic on
+#      stderr, and "refusing to run a program that failed to compile") —
+#      never a silent corruption, and never a bare crash with no diagnostic.
+#
+# Usage: closure_upvalue_capacity_overflow_gate.sh <eshkol-run> <vm-standalone> <workdir>
+
+set -u
+
+ESHKOL_RUN="${1:?usage: $0 <eshkol-run> <vm-standalone> <workdir>}"
+VM_RUN="${2:?missing vm standalone binary}"
+WORK="${3:?missing work dir}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+mkdir -p "$WORK" || exit 1
+
+OK_SRC="$ROOT_DIR/tests/closures/closure_upvalue_capacity_ok_test.esk"
+OVERFLOW_SRC="$ROOT_DIR/tests/closures/closure_upvalue_capacity_overflow_test.esk"
+
+PASS=0
+FAIL=0
+
+check_ok() { # label engine src
+    local label="$1" engine="$2" src="$3"
+    local out="$WORK/ok.$$"
+    "$engine" "$src" >"$out" 2>&1
+    local rc=$?
+    if [ "$rc" -eq 0 ] && grep -q "^PASS$" "$out"; then
+        PASS=$((PASS + 1))
+        echo "PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: $label — exit $rc, output:"
+        sed -n '1,20p' "$out"
+    fi
+    rm -f "$out"
+}
+
+check_refuses() { # label engine src
+    local label="$1" engine="$2" src="$3"
+    local out="$WORK/overflow.$$"
+    "$engine" "$src" >"$out" 2>&1
+    local rc=$?
+    local ok=true
+    if [ "$rc" -eq 0 ]; then
+        ok=false
+        echo "FAIL: $label — compiled and ran to completion (exit 0); the capacity is not enforced"
+    fi
+    if ! grep -qF "upvalue capture limit" "$out"; then
+        ok=false
+        echo "FAIL: $label — missing the expected 'upvalue capture limit' diagnostic"
+    fi
+    if ! grep -qE "refusing to (run|emit bytecode for)" "$out"; then
+        ok=false
+        echo "FAIL: $label — missing the fail-closed 'refusing to run/emit' message; a diagnostic that still executes (or still emits bytecode) is exactly the silent-corruption shape this gate exists to catch"
+    fi
+    if $ok; then
+        PASS=$((PASS + 1))
+        echo "PASS: $label"
+    else
+        sed -n '1,20p' "$out"
+    fi
+    rm -f "$out"
+}
+
+if [ ! -f "$OK_SRC" ] || [ ! -f "$OVERFLOW_SRC" ]; then
+    echo "FAIL: fixture(s) missing ($OK_SRC / $OVERFLOW_SRC)"
+    exit 2
+fi
+
+# NOTE: this defect and its fix are specific to the bytecode-VM compile path
+# (lib/backend/vm_compiler.c / vm_core.c / vm_run.c). eshkol-run's `-r`
+# defaults to the native LLVM JIT — a wholly separate closure representation
+# with no fixed upvalue-array capacity — so it is not exercised here; running
+# either fixture through it proves nothing about this defect. The VM path is
+# reached two ways: compiling straight to bytecode and executing in one
+# process (eshkol-vm-standalone-test <src.esk>), and the two-step route a
+# real build uses (eshkol-run --profile hosted-vm --emit-eskb, then load and
+# run the .eskb on the standalone VM) — both are checked below.
+
+if [ ! -x "$VM_RUN" ]; then
+    echo "SKIP: bytecode VM standalone binary not built ($VM_RUN)"
+    echo "PASS: closure upvalue capacity enforced (gate skipped, no VM binary)"
+    exit 0
+fi
+
+# --- standalone bytecode VM: compile-and-run in one process -----------------
+
+run_vm() { ESHKOL_VM_NO_DISASM=1 "$VM_RUN" "$1"; }
+check_ok "eshkol-vm-standalone-test: 32-upvalue procedure runs correctly and the following define survives" \
+    run_vm "$OK_SRC"
+check_refuses "eshkol-vm-standalone-test: 33-upvalue procedure fails the compile loudly" \
+    run_vm "$OVERFLOW_SRC"
+
+# --- eshkol-run --profile hosted-vm --emit-eskb, then run the .eskb --------
+# Mirrors scripts/run_vm_surface_tests.sh's two-step route, so the ESKB
+# writer/reader round-trip is covered too, not just the in-process compiler.
+
+compile_and_run_eskb() { # src
+    local src="$1"
+    local eskb="$WORK/$(basename "$src" .esk).eskb"
+    rm -f "$eskb"
+    "$ESHKOL_RUN" --profile hosted-vm --emit-eskb "$eskb" "$src"
+    local compile_rc=$?
+    if [ ! -s "$eskb" ]; then
+        # Compilation refused to emit bytecode (the fail-closed path) — that
+        # IS a result for check_refuses to see; report the compile step's own
+        # exit/diagnostic rather than trying to run a nonexistent module.
+        return "$compile_rc"
+    fi
+    ESHKOL_VM_NO_DISASM=1 "$VM_RUN" "$eskb"
+}
+check_ok "eshkol-run --emit-eskb + VM: 32-upvalue procedure runs correctly and the following define survives" \
+    compile_and_run_eskb "$OK_SRC"
+check_refuses "eshkol-run --emit-eskb: 33-upvalue procedure fails the compile loudly (refuses to emit bytecode)" \
+    compile_and_run_eskb "$OVERFLOW_SRC"
+
+# --- summary ------------------------------------------------------------------
+
+echo
+echo "closure-upvalue-capacity enforcement: $PASS passed, $FAIL failed"
+if [ "$FAIL" -ne 0 ]; then
+    exit 1
+fi
+echo "PASS: closure upvalue capacity enforced"
+exit 0

--- a/tests/closures/closure_upvalue_capacity_overflow_test.esk
+++ b/tests/closures/closure_upvalue_capacity_overflow_test.esk
@@ -1,0 +1,53 @@
+;; SW-45 companion: a single procedure calling 33 distinct top-level
+;; procedures — one past the shared upvalue capacity
+;; (ESHKOL_VM_MAX_CLOSURE_UPVALUES, inc/eshkol/backend/vm_limits.h). Before the
+;; SW-45 fix, a closure needing between 17 and 32 upvalues compiled cleanly
+;; (under the compiler's old 32-slot cap) and then silently corrupted the
+;; runtime stack at OP_CLOSURE (the runtime array was only 16 slots). Above
+;; the shared capacity there is no silent path left to take: the compiler's
+;; own upvalue-resolution now refuses to add a 33rd capture and fails the
+;; whole compilation loudly (vm_compile_error(), lib/backend/vm_compiler.c)
+;; instead of leaving the missing capture's index at -1. A build that instead
+;; runs this file to completion, or crashes it without the expected
+;; diagnostic, has regressed the fail-closed guarantee. Run by
+;; closure_upvalue_capacity_overflow_gate.sh, which expects a NONZERO exit and
+;; the diagnostic below — not a PASS/FAIL print.
+
+(define (helper0 x) (+ x 0))
+(define (helper1 x) (+ x 1))
+(define (helper2 x) (+ x 2))
+(define (helper3 x) (+ x 3))
+(define (helper4 x) (+ x 4))
+(define (helper5 x) (+ x 5))
+(define (helper6 x) (+ x 6))
+(define (helper7 x) (+ x 7))
+(define (helper8 x) (+ x 8))
+(define (helper9 x) (+ x 9))
+(define (helper10 x) (+ x 10))
+(define (helper11 x) (+ x 11))
+(define (helper12 x) (+ x 12))
+(define (helper13 x) (+ x 13))
+(define (helper14 x) (+ x 14))
+(define (helper15 x) (+ x 15))
+(define (helper16 x) (+ x 16))
+(define (helper17 x) (+ x 17))
+(define (helper18 x) (+ x 18))
+(define (helper19 x) (+ x 19))
+(define (helper20 x) (+ x 20))
+(define (helper21 x) (+ x 21))
+(define (helper22 x) (+ x 22))
+(define (helper23 x) (+ x 23))
+(define (helper24 x) (+ x 24))
+(define (helper25 x) (+ x 25))
+(define (helper26 x) (+ x 26))
+(define (helper27 x) (+ x 27))
+(define (helper28 x) (+ x 28))
+(define (helper29 x) (+ x 29))
+(define (helper30 x) (+ x 30))
+(define (helper31 x) (+ x 31))
+(define (helper32 x) (+ x 32))
+(define (big i)
+  (+ i (helper0 i) (helper1 i) (helper2 i) (helper3 i) (helper4 i) (helper5 i) (helper6 i) (helper7 i) (helper8 i) (helper9 i) (helper10 i) (helper11 i) (helper12 i) (helper13 i) (helper14 i) (helper15 i) (helper16 i) (helper17 i) (helper18 i) (helper19 i) (helper20 i) (helper21 i) (helper22 i) (helper23 i) (helper24 i) (helper25 i) (helper26 i) (helper27 i) (helper28 i) (helper29 i) (helper30 i) (helper31 i) (helper32 i)))
+(define (probe x) (+ x 1))
+
+(display (if (and (= (big 0) 528) (= (probe 41) 42)) "PASS" "FAIL")) (newline)

--- a/tests/vm/closure_upvalue_capacity_surface_regression.esk
+++ b/tests/vm/closure_upvalue_capacity_surface_regression.esk
@@ -1,0 +1,187 @@
+;; Standalone VM closure-upvalue-capacity regression (SW-45).
+;;
+;; WHAT BROKE. A procedure's own closure captures one upvalue for every
+;; DISTINCT name it references that lives in an enclosing scope — and that
+;; includes an ordinary call to another top-level `define`d procedure, not
+;; just a variable read: `(make-fact ...)`, `(length x)`, `(string-append
+;; ...)` are each resolved as a free-variable reference to that procedure's
+;; own top-level binding, exactly like any other name. So a procedure calling
+;; N distinct top-level procedures needs N upvalues to relay them.
+;;
+;; The compiler capped that count at 32 (MAX_UPVALUES, vm_parser.c) and
+;; enforced it. The runtime closure representation's `upvalues`/`open_slots`
+;; arrays (vm_core.c's HeapObject.closure) were fixed at 16 — HALF the
+;; compiler's limit, and nothing kept the two in sync. A closure needing 17
+;; to 32 upvalues compiled cleanly and then, at OP_CLOSURE (vm_run.c), had
+;; its count silently clamped to 16: the runtime popped only 16 of the >16
+;; values the compiler had pushed to feed it, stranding the rest on the
+;; operand stack. No error, exit 0 — but every stack-slot offset the compiler
+;; had computed for the REST OF THE PROGRAM was now off by the leaked count,
+;; so the very next top-level `define` read back whatever stray value the
+;; leak left in its slot instead of its own closure, and calling it failed
+;; with "calling non-function". This is how it was found: a VM evacuator
+;; fixture with one procedure carrying ~20 constructor calls (each a
+;; distinct top-level procedure) corrupted the `define` compiled right after
+;; it (see tests/memory/vm_region_evac_subtype_coverage_test.esk on
+;; feat/vm-region-evacuator, whose header documents the same defect and why
+;; that fixture is split across two procedures as a workaround).
+;;
+;; THE FIX. inc/eshkol/backend/vm_limits.h now defines
+;; ESHKOL_VM_MAX_CLOSURE_UPVALUES as the single source of truth for BOTH the
+;; compiler's cap (vm_parser.c's MAX_UPVALUES) and the runtime array capacity
+;; (vm_core.c), so they cannot diverge again. OP_CLOSURE (vm_run.c, both the
+;; computed-goto and switch dispatch loops) no longer silently clamps — an
+;; encoded upvalue count exceeding the shared capacity is now a fatal runtime
+;; error (only reachable via a corrupted or build-mismatched .eskb, since the
+;; compiler enforces the same bound). And the compiler's own capacity check
+;; (vm_compiler.c, both the read and `set!` upvalue-resolution paths) now
+;; calls vm_compile_error() and refuses to run the program when a single
+;; lexical scope needs more than the shared limit, instead of silently
+;; leaving the missing capture's index at -1.
+;;
+;; THIS FILE pins three points: just past the OLD broken threshold (17, which
+;; used to corrupt everything compiled after it), the full NEW capacity (32,
+;; proving there is real headroom rather than a bare pass at the boundary),
+;; and the ORIGINAL discovery shape (a procedure built from `vector-set!`
+;; constructor calls, matching the evacuator fixture almost exactly). Each
+;; case is followed immediately by another top-level `define` — the binding
+;; the defect used to corrupt — and checks that the SECOND define reads back
+;; as its own callable, not a stray leaked value.
+;;
+;; A negative companion (a scope needing 33 upvalues, one past the new shared
+;; capacity, must now fail the compile LOUDLY rather than corrupt anything)
+;; lives in tests/closures/closure_upvalue_capacity_overflow_test.esk /
+;; .sh, gated separately because "refuses to compile" is the PASSING outcome
+;; there and does not fit this suite's convention of a clean, error-free run.
+
+;; ── Case A: minimal — 17 distinct top-level calls (old capacity was 16) ────
+(define (a-helper0 x) (+ x 0))
+(define (a-helper1 x) (+ x 1))
+(define (a-helper2 x) (+ x 2))
+(define (a-helper3 x) (+ x 3))
+(define (a-helper4 x) (+ x 4))
+(define (a-helper5 x) (+ x 5))
+(define (a-helper6 x) (+ x 6))
+(define (a-helper7 x) (+ x 7))
+(define (a-helper8 x) (+ x 8))
+(define (a-helper9 x) (+ x 9))
+(define (a-helper10 x) (+ x 10))
+(define (a-helper11 x) (+ x 11))
+(define (a-helper12 x) (+ x 12))
+(define (a-helper13 x) (+ x 13))
+(define (a-helper14 x) (+ x 14))
+(define (a-helper15 x) (+ x 15))
+(define (a-helper16 x) (+ x 16))
+(define (a-big i)
+  (+ i (a-helper0 i) (a-helper1 i) (a-helper2 i) (a-helper3 i) (a-helper4 i)
+     (a-helper5 i) (a-helper6 i) (a-helper7 i) (a-helper8 i) (a-helper9 i)
+     (a-helper10 i) (a-helper11 i) (a-helper12 i) (a-helper13 i)
+     (a-helper14 i) (a-helper15 i) (a-helper16 i)))
+;; The define this defect used to corrupt.
+(define (a-probe x) (+ x 1))
+
+(display (if (and (= (a-big 0) 136) (= (a-probe 41) 42)) "PASS" "FAIL"))
+(display ": 17-upvalue procedure (one past the old 16-slot capacity) leaves the next define intact")
+(newline)
+
+;; ── Case B: margin — the full new capacity, 32 distinct top-level calls ───
+(define (b-helper0 x) (+ x 0))
+(define (b-helper1 x) (+ x 1))
+(define (b-helper2 x) (+ x 2))
+(define (b-helper3 x) (+ x 3))
+(define (b-helper4 x) (+ x 4))
+(define (b-helper5 x) (+ x 5))
+(define (b-helper6 x) (+ x 6))
+(define (b-helper7 x) (+ x 7))
+(define (b-helper8 x) (+ x 8))
+(define (b-helper9 x) (+ x 9))
+(define (b-helper10 x) (+ x 10))
+(define (b-helper11 x) (+ x 11))
+(define (b-helper12 x) (+ x 12))
+(define (b-helper13 x) (+ x 13))
+(define (b-helper14 x) (+ x 14))
+(define (b-helper15 x) (+ x 15))
+(define (b-helper16 x) (+ x 16))
+(define (b-helper17 x) (+ x 17))
+(define (b-helper18 x) (+ x 18))
+(define (b-helper19 x) (+ x 19))
+(define (b-helper20 x) (+ x 20))
+(define (b-helper21 x) (+ x 21))
+(define (b-helper22 x) (+ x 22))
+(define (b-helper23 x) (+ x 23))
+(define (b-helper24 x) (+ x 24))
+(define (b-helper25 x) (+ x 25))
+(define (b-helper26 x) (+ x 26))
+(define (b-helper27 x) (+ x 27))
+(define (b-helper28 x) (+ x 28))
+(define (b-helper29 x) (+ x 29))
+(define (b-helper30 x) (+ x 30))
+(define (b-helper31 x) (+ x 31))
+(define (b-big i)
+  (+ i (b-helper0 i) (b-helper1 i) (b-helper2 i) (b-helper3 i) (b-helper4 i)
+     (b-helper5 i) (b-helper6 i) (b-helper7 i) (b-helper8 i) (b-helper9 i)
+     (b-helper10 i) (b-helper11 i) (b-helper12 i) (b-helper13 i)
+     (b-helper14 i) (b-helper15 i) (b-helper16 i) (b-helper17 i)
+     (b-helper18 i) (b-helper19 i) (b-helper20 i) (b-helper21 i)
+     (b-helper22 i) (b-helper23 i) (b-helper24 i) (b-helper25 i)
+     (b-helper26 i) (b-helper27 i) (b-helper28 i) (b-helper29 i)
+     (b-helper30 i) (b-helper31 i)))
+;; The define this defect used to corrupt.
+(define (b-probe x) (+ x 1))
+
+(display (if (and (= (b-big 0) 496) (= (b-probe 41) 42)) "PASS" "FAIL"))
+(display ": 32-upvalue procedure (the full new shared capacity) leaves the next define intact")
+(newline)
+
+;; ── Case C: original discovery shape — vector-set! constructor calls ──────
+;; Mirrors the evacuator fixture almost exactly: one procedure whose body is
+;; ~20 `vector-set!` calls, each constructing a value via a DIFFERENT
+;; top-level procedure (each one more distinct upvalue to relay).
+(define c-slots (make-vector 20 0))
+(define (c-big i)
+  (begin
+    (vector-set! c-slots 0 (list i (car (make-list 1 i))))
+    (vector-set! c-slots 1 (let ((n i)) (lambda (x) (+ x n))))
+    (vector-set! c-slots 2 (string-append "s" (number->string i)))
+    (vector-set! c-slots 3 (string->symbol (string-append "sym" (number->string i))))
+    (vector-set! c-slots 4 (vector i i "v"))
+    (vector-set! c-slots 5 (/ (+ i 1) 7))
+    (vector-set! c-slots 6 (+ (expt 2 100) i))
+    (vector-set! c-slots 7 (/ (+ (expt 2 100) i) 3))
+    (vector-set! c-slots 8 (make-rectangular (+ i 1) 2))
+    (vector-set! c-slots 9 (let ((b (make-bytevector 4 0)))
+                             (bytevector-u8-set! b 0 (modulo i 251))
+                             b))
+    (vector-set! c-slots 10 (delay (+ i 1)))
+    (vector-set! c-slots 11 (let ((h (make-hash-table)))
+                              (hash-set! h 7 (+ i 100))
+                              h))
+    (vector-set! c-slots 12 (make-parameter (+ i 1000)))
+    (vector-set! c-slots 13 (call-with-values
+                             (lambda () (values i i))
+                             (lambda (p q) (list p q))))
+    (vector-set! c-slots 14 (make-fact 'r i (+ i 1)))
+    (vector-set! c-slots 15 (let ((kb (make-kb)))
+                              (kb-assert! kb (make-fact 'r i (+ i 1)))
+                              kb))
+    (vector-set! c-slots 16 (let ((ws (make-workspace 4 2)))
+                              (ws-register! ws "m" (lambda (x) (cons 1.0 x)))
+                              ws))
+    (vector-set! c-slots 17 (let ((fg (make-factor-graph 3 #(2 2 2))))
+                              (fg-add-factor! fg #(0 1) #(0.1 0.2 0.3 0.4))
+                              fg))
+    (vector-set! c-slots 18 (make-substitution))
+    (vector-set! c-slots 19 (tensor (+ i 5) 2 3 4))
+    0))
+(define c-r (c-big 7))
+;; The define this defect used to corrupt.
+(define (c-probe x) (+ x 1))
+
+(display (if (and (= c-r 0)
+                   (fact? (vector-ref c-slots 14))
+                   (workspace? (vector-ref c-slots 16))
+                   (tensor? (vector-ref c-slots 19))
+                   (= (c-probe 41) 42))
+             "PASS" "FAIL"))
+(display ": 20 vector-set! constructor calls (original discovery shape) leaves the next define intact")
+(newline)


### PR DESCRIPTION
## Summary

- **Root cause (SW-45)**: the bytecode VM compiler capped a lexical scope's upvalue count at 32 (`MAX_UPVALUES`, `lib/backend/vm_parser.c`), but the *runtime* closure representation (`HeapObject.closure.upvalues[]`/`open_slots[]`, `lib/backend/vm_core.c`) was hardcoded at 16 — half that, with nothing keeping the two in sync. A procedure referencing 17-32 *distinct top-level procedures* (every such call resolves as a free-variable reference through the same upvalue-capture machinery as any other captured name, so the procedure's own closure has to relay one upvalue per distinct name) compiled cleanly under the 32 cap. At `OP_CLOSURE` (`lib/backend/vm_run.c`, both the computed-goto and switch dispatch loops), the runtime silently clamped the count to 16 and popped only 16 of the `>16` values the compiler had already pushed to feed it — stranding the rest on the operand stack with **no diagnostic and exit 0**. Every stack-slot offset the compiler had computed for the rest of the program was off by the leaked count from then on, so the very next top-level `define` read back a stray leaked value instead of its own closure, and calling it failed with "calling non-function".
- Discovered via `tests/memory/vm_region_evac_subtype_coverage_test.esk` on `feat/vm-region-evacuator`, whose header already named this exact defect and worked around it by splitting one 20-constructor-call procedure (`heavy-a`/`heavy-b`) into two. This fix makes that split unnecessary (verified — see test evidence below), though the evacuator branch itself is untouched.
- **Minimal repro**: one procedure calling 17 distinct top-level helper procedures, followed by a second `define`; calling the second procedure fails. Reproduces with plain `begin`, nothing to do with `with-region`.

## Fix

- `inc/eshkol/backend/vm_limits.h` now defines `ESHKOL_VM_MAX_CLOSURE_UPVALUES=32` as the single shared constant for both the compiler's cap (aliased to `MAX_UPVALUES`) and the runtime closure array capacity, guarded by a `#error` against ever exceeding the `OP_CLOSURE` operand's 8-bit upvalue-count field.
- `lib/backend/vm_run.c`'s two `OP_CLOSURE` handlers no longer clamp: an encoded count exceeding the shared capacity (only reachable via a corrupted/build-mismatched `.eskb`) is now a fatal runtime error instead of a silent stack-imbalance.
- `lib/backend/vm_compiler.c`'s two upvalue-registration sites (plain-reference read path and `set!` path) now call the existing `vm_compile_error()` fail-closed mechanism and refuse to compile when a scope needs more upvalues than the shared capacity holds, instead of leaving the missing capture's index at `-1` and continuing.
- `lib/backend/vm_native.c`'s upvalue-closing loop (native 252) had the same hardcoded `16` and is fixed the same way.

A too-small limit now either has real headroom (32, shared, enforced identically at compile and run time) or fails loudly — never silently.

## Test plan

- [x] `tests/vm/closure_upvalue_capacity_surface_regression.esk` (auto-discovered by `scripts/run_vm_surface_tests.sh`'s existing `*_surface_regression.esk` glob): case A (17, the historical minimum), case B (32, full capacity as margin), case C (the original 20-`vector-set!`-constructor shape, re-merged into one procedure) — each checks both the big procedure's own answer and that the `define` compiled right after it is callable and correct.
- [x] `tests/closures/closure_upvalue_capacity_{ok,overflow}_test.esk` + `closure_upvalue_capacity_overflow_gate.sh`, wired into CTest as `closure_upvalue_capacity_overflow_gate`: 32 upvalues runs correctly, 33 fails the compile loudly (nonzero exit + diagnostic), on both the in-process VM and the `eshkol-run --emit-eskb` + VM round-trip.
- [x] `ctest --test-dir build -j6`: **185/185 passed**
- [x] `BUILD_DIR=build bash scripts/run_vm_tests.sh`: green (73/73 source tests + first-class builtin families)
- [x] `bash scripts/run_vm_parity.sh`: **184/184 passed**
- [x] `BUILD_DIR=build bash scripts/run_vm_surface_tests.sh`: 57/57 passed (includes the new regression file)
- [x] `scripts/run_icc_smoke.sh`: new `eshkol-vm-large-proc` probe registered and green (63/64 probes passed overall; the one unrelated failure, `language_surface_coverage_floor`, is a pre-existing environmental gap — it requires a separate `build-quantum` CMake configuration this task's build flags don't produce, and is unrelated to this fix)
- [x] `.icc/completion-oracles.yaml`: `eshkol-vm-large-proc` wired into the `eshkol-compiler-readiness` oracle's requirements
- [x] `.icc/silent-wrong-ledger.yaml`: SW-45 added and closed on this branch; `python3 scripts/gate_no_silent_wrong.py` — PASS
- [x] ICC: registered `eshkol-vm-large-proc`, `index --force`, `build-memory`, `guard-diff --staged` (ok, no violations), `pre-commit-check` — **PASS, 0 blockers**