### PR TITLE
feat(assurance): self-verdict scanner, build fingerprints, adversarial scenarios, readiness artifact probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,6 +422,23 @@ jobs:
   #     ("no evidence in N days = FAIL"), which ICC's `runtime_event`
   #     grading path has no support for (only `performance_budget` does) —
   #     see the script's docstring. Repo-side until that lands upstream.
+  #
+  # v1.3.5 assurance wave 2 adds two more gates to this job, same contract:
+  #
+  #   - check_self_verdicts.py: no artifact from a run a harness counted as
+  #     PASSING may contain a self-reported failure marker (FAIL/FAILED/
+  #     MISMATCH/DIVERGENCE). SW-24 printed `FAIL: Expected 12` on the VM, out
+  #     loud, on a green baseline, for months. This job has built no compiler
+  #     yet, so it runs with no --junit/--manifest/--pair and PASSes on "no
+  #     evidence to contradict" — the real checks against live CTest/VM-parity
+  #     output are wired into scripts/run_ctest_gate.sh and
+  #     scripts/run_vm_parity.sh, in the jobs that build the compiler.
+  #   - check_build_fingerprint.py: a harness's recorded binary fingerprint
+  #     (mtime+size+sha256+git SHA, via scripts/lib/build_fingerprint.sh) must
+  #     still describe the binary now on disk, and that binary must not
+  #     predate the source tree it claims to have been built from. Wired for
+  #     real into scripts/run_icc_smoke.sh, scripts/run_vm_parity.sh and
+  #     scripts/run_ctest_gate.sh.
   assurance-gates:
     name: assurance-gates
     if: github.event_name != 'schedule'
@@ -447,6 +464,9 @@ jobs:
           python3 scripts/check_diagnostic_corpus.py --self-test
           python3 scripts/gate_exhaustive_dispatch.py --self-test
           python3 scripts/check_surface_counts.py --self-test
+          python3 scripts/check_self_verdicts.py --self-test
+          python3 scripts/check_build_fingerprint.py --self-test
+          python3 scripts/doc_audit/check_results_schema.py --self-test
 
       # B5/N2 (2026-08-26 audit): every gate below this point deliberately
       # DROPS --no-trace. This job builds nothing (pure Python over
@@ -521,7 +541,21 @@ jobs:
       # the INTENDED policy itself changes.
       - name: Every required status context is reportable on every PR shape (docs-only included)
         shell: bash
-        run: python3 scripts/check_required_context_consistency.py --offline
+        run: python3 scripts/check_required_context_consistency.py --offline --no-trace
+      # No compiler has been built in this fast job, so there is nothing yet
+      # to scan or fingerprint — both gates PASS on "no evidence to
+      # contradict" (see their own module docstrings). The self-test step
+      # above is what proves each gate CAN go red; the real checks against
+      # live harness evidence run inside scripts/run_ctest_gate.sh,
+      # scripts/run_icc_smoke.sh and scripts/run_vm_parity.sh, in the jobs
+      # that actually build the compiler.
+      - name: No self-reported failure hides behind a PASS verdict (no build in this job — vacuously clean)
+        shell: bash
+        run: python3 scripts/check_self_verdicts.py --no-trace
+
+      - name: No harness's recorded binary fingerprint is stale (no build in this job — vacuously clean)
+        shell: bash
+        run: python3 scripts/check_build_fingerprint.py --no-trace
 
       # Runs LAST so every gate above it has already deposited its own
       # fresh eshkol_smoke evidence into scripts/icc_traces/ (the default

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4870,6 +4870,73 @@ if(ESHKOL_BUILD_TESTS)
         )
         set_tests_properties(ci_retry_selftest PROPERTIES TIMEOUT 60)
     endif()
+
+    # Assurance-wave-2 gates (v1.3.5): a self-verdict scanner (a suite
+    # printing its own FAIL line must not be gradeable PASS by any harness,
+    # ctest included) and a build-fingerprint gate (a harness's recorded
+    # evidence must still describe the binary now on disk, and that binary
+    # must not predate the source tree it was built from). Same contract as
+    # the wave-1 gates above: run against real state (must PASS today) plus
+    # --self-test (must be able to go RED on deliberately-broken fixtures).
+    #
+    # check_self_verdicts_gate runs with no --junit/--manifest/--pair here —
+    # ctest has not produced a JUnit file about itself yet at this point in
+    # its own run, so there is nothing to scan and the gate PASSes on "no
+    # input, nothing to contradict" (see its own module docstring). The real
+    # check against THIS suite's own JUnit output lives in
+    # scripts/run_ctest_gate.sh, which re-runs ctest with --output-junit and
+    # feeds the result to this same script.
+    if(ESHKOL_PYTHON3_EXECUTABLE AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_self_verdicts.py")
+        add_test(
+            NAME self_verdict_gate
+            COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_self_verdicts.py"
+                    --no-trace
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+        add_test(
+            NAME self_verdict_gate_selftest
+            COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_self_verdicts.py"
+                    --self-test
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+        set_tests_properties(self_verdict_gate self_verdict_gate_selftest PROPERTIES TIMEOUT 60)
+    endif()
+    if(ESHKOL_PYTHON3_EXECUTABLE AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_build_fingerprint.py")
+        add_test(
+            NAME build_fingerprint_gate
+            COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_build_fingerprint.py"
+                    --no-trace
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+        add_test(
+            NAME build_fingerprint_gate_selftest
+            COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_build_fingerprint.py"
+                    --self-test
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+        set_tests_properties(build_fingerprint_gate build_fingerprint_gate_selftest PROPERTIES TIMEOUT 60)
+    endif()
+
+    # Readiness artifact probe (v1.3.5 assurance wave 2, closing the last
+    # open v1.3.4 readiness gap): scripts/doc_audit/run_examples.py writes
+    # results-<mode>.json with nothing validating it. This is that validator,
+    # self-tested the same way as every other gate above. It takes no
+    # positional path here — --self-test is all ctest can run without a
+    # results file having been produced by an actual doc-example run first.
+    if(ESHKOL_PYTHON3_EXECUTABLE AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/doc_audit/check_results_schema.py")
+        add_test(
+            NAME doc_examples_results_schema_gate_selftest
+            COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/doc_audit/check_results_schema.py"
+                    --self-test
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+        set_tests_properties(doc_examples_results_schema_gate_selftest PROPERTIES TIMEOUT 60)
+    endif()
 endif()
 
 if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/pointer_type_surface_test.cpp")

--- a/scripts/check_build_fingerprint.py
+++ b/scripts/check_build_fingerprint.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""Release gate: every harness's recorded binary fingerprint still describes
+the binary actually on disk, and that binary is not older than the source
+tree it claims to have been built from.
+
+WHY THIS EXISTS (docs/design/FLAW_DETECTION_ROADMAP.md, D-11 BUILD FRESHNESS)
+
+Recorded twice in the v1.3.4 campaign as a standing trap: "Rebuild before
+believing any harness after a rebase." A stale binary produced a false
+`engine_semantic_parity` FAIL on #418's new corpus file — the harness was
+honest about what it measured, but what it measured was the wrong compiler.
+
+`scripts/lib/test_isolation.sh` already guards against a binary changing
+*during* a run (`eshkol_test_pin_toolchain` / `eshkol_test_toolchain_verify`).
+This gate guards a different window: between when a harness recorded its
+fingerprint and when a release gate later reads that harness's evidence, and
+at the moment a harness started, relative to the source tree.
+
+`scripts/lib/build_fingerprint.sh`'s `eshkol_emit_build_fingerprint_event`
+appends one JSON-L record per harness invocation to
+`<trace-dir>/build_fingerprint.jsonl`:
+
+    {"kind": "build_fingerprint", "harness": "run_icc_smoke",
+     "binary": "eshkol-run", "path": ".../build/eshkol-run",
+     "size": N, "mtime": N, "sha256": "...", "git_sha": "...",
+     "recorded_epoch": N}
+
+This gate reads that file and fails on either of two independent conditions:
+
+  1. IDENTITY MISMATCH — a recorded fingerprint's size/mtime/sha256 no longer
+     matches the binary now present at `path`. Either the binary was rebuilt
+     or replaced after the harness ran (so the harness's evidence is about a
+     binary that no longer exists — re-run it), or the binary was deleted
+     outright.
+
+  2. STALE BINARY — for every real binary named `--binary` (default:
+     eshkol-run) found under `--build-dir`, the binary's own mtime is older
+     than the most recent build-relevant source change: the newer of (a) the
+     last commit touching lib/, inc/, exe/, cmake/ or CMakeLists.txt, and
+     (b) the mtime of any currently-dirty file under those paths. This is
+     the literal "ran after a rebase, never rebuilt" incident: new commits
+     (or local edits) landed in the source tree after the binary was linked.
+
+Both checks are FAIL CLOSED in the sense that matters here — a binary that
+does not exist at all is not this gate's concern (nothing has been built yet,
+a different gate's job), but a binary that DOES exist and IS stale, or
+DOES have recorded evidence that no longer matches it, is always reported.
+Absence of any recorded evidence (no harness has run yet in this tree) is
+PASS: there is nothing to contradict.
+
+Usage
+    python3 scripts/check_build_fingerprint.py
+    python3 scripts/check_build_fingerprint.py --build-dir build --binary eshkol-run
+    python3 scripts/check_build_fingerprint.py --trace-dir scripts/icc_traces
+    python3 scripts/check_build_fingerprint.py --format json
+    python3 scripts/check_build_fingerprint.py --self-test
+
+Exit status is 0 on PASS and 1 on FAIL (including under --self-test, where it
+reports whether the gate itself is capable of failing).
+
+Copyright (C) tsotchke
+SPDX-License-Identifier: MIT
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_TRACE_DIR = os.path.join(REPO_ROOT, "scripts", "icc_traces")
+DEFAULT_BUILD_DIR = os.path.join(REPO_ROOT, "build")
+FINGERPRINT_BASENAME = "build_fingerprint.jsonl"
+TRACE_BASENAME = "build_fingerprint_gate.jsonl"
+PROBE_ID = "build_fingerprint_clean"
+
+SOURCE_PATHS = ("lib", "inc", "exe", "cmake", "CMakeLists.txt")
+DEFAULT_BINARIES = ("eshkol-run",)
+
+
+# ─────────────────────────── pure logic (self-testable without git/fs) ────
+
+
+def sha256_of(path: str) -> str:
+    h = hashlib.sha256()
+    try:
+        with open(path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(1 << 20), b""):
+                h.update(chunk)
+    except OSError:
+        return "unavailable"
+    return h.hexdigest()
+
+
+def current_fingerprint(path: str) -> dict | None:
+    """Real stat+digest of a file on disk now. None if it does not exist."""
+    if not os.path.isfile(path):
+        return None
+    st = os.stat(path)
+    return {
+        "path": path,
+        "size": st.st_size,
+        "mtime": int(st.st_mtime),
+        "sha256": sha256_of(path),
+    }
+
+
+def check_identity(recorded: dict, current: dict | None) -> list[str]:
+    """Compare one recorded fingerprint entry to the binary's real state now.
+
+    Pure function: takes dicts, returns a list of error strings (empty means
+    OK). No filesystem or git access, so this branch of the gate's logic is
+    directly self-testable with synthetic fixtures.
+    """
+    errors: list[str] = []
+    harness = recorded.get("harness", "<unknown harness>")
+    binary = recorded.get("binary", "<unknown binary>")
+    label = f"{harness} recorded a fingerprint for {binary!r}"
+
+    if current is None:
+        errors.append(
+            f"{label} at {recorded.get('path')!r}, but that file does not exist now "
+            f"(binary deleted or moved since the harness ran)"
+        )
+        return errors
+
+    mismatches = []
+    for field in ("size", "mtime", "sha256"):
+        want = recorded.get(field)
+        have = current.get(field)
+        if want != have:
+            mismatches.append(f"{field}: recorded={want!r} now={have!r}")
+
+    if mismatches:
+        errors.append(
+            f"{label}, but the binary on disk no longer matches ({'; '.join(mismatches)}) — "
+            f"it was rebuilt or replaced after {harness} ran; re-run {harness} against the "
+            f"current binary before trusting its evidence"
+        )
+    return errors
+
+
+def check_freshness(binary: str, binary_mtime: int, source_freshness_epoch: int) -> list[str]:
+    """Pure function: is a binary's mtime older than the source it should
+    reflect? Takes plain integers so it needs no git or filesystem access."""
+    if binary_mtime < source_freshness_epoch:
+        age = source_freshness_epoch - binary_mtime
+        return [
+            f"{binary} (mtime={binary_mtime}) predates the source tree "
+            f"(freshness={source_freshness_epoch}, {age}s newer) — rebuild before trusting "
+            f"any harness run against it"
+        ]
+    return []
+
+
+# ───────────────────────────── real git/filesystem wiring ─────────────────
+
+
+def _run(cmd: list[str], cwd: str) -> str | None:
+    try:
+        out = subprocess.run(
+            cmd, cwd=cwd, capture_output=True, text=True, timeout=30, check=False
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    return out.stdout.strip()
+
+
+def source_freshness_epoch(repo_root: str, paths: tuple[str, ...] = SOURCE_PATHS) -> int:
+    """The most recent moment the build-relevant source tree changed.
+
+    Prefers the last commit's committer timestamp over the named paths (this
+    is what makes a rebase visible even though `git checkout` resets working-
+    tree mtimes to "now"). Also considers the filesystem mtime of any
+    currently-dirty file under those paths, so uncommitted local edits count
+    too. Falls back to a plain filesystem walk when git is unavailable.
+    """
+    existing = [p for p in paths if os.path.exists(os.path.join(repo_root, p))]
+    if not existing:
+        return 0
+
+    candidates = []
+
+    commit_ts = _run(["git", "log", "-1", "--format=%ct", "--"] + existing, repo_root)
+    if commit_ts:
+        try:
+            candidates.append(int(commit_ts))
+        except ValueError:
+            pass
+
+    dirty = _run(["git", "status", "--porcelain", "--"] + existing, repo_root)
+    if dirty is not None:
+        for line in dirty.splitlines():
+            rel = line[3:].strip()
+            # Renames report as "old -> new"; keep the new path.
+            if " -> " in rel:
+                rel = rel.split(" -> ", 1)[1]
+            full = os.path.join(repo_root, rel)
+            if os.path.isfile(full):
+                try:
+                    candidates.append(int(os.stat(full).st_mtime))
+                except OSError:
+                    pass
+
+    if candidates:
+        return max(candidates)
+
+    # No git available at all: best-effort filesystem walk.
+    latest = 0
+    for p in existing:
+        full = os.path.join(repo_root, p)
+        if os.path.isfile(full):
+            latest = max(latest, int(os.stat(full).st_mtime))
+            continue
+        for dirpath, _dirnames, filenames in os.walk(full):
+            for name in filenames:
+                fp = os.path.join(dirpath, name)
+                try:
+                    latest = max(latest, int(os.stat(fp).st_mtime))
+                except OSError:
+                    continue
+    return latest
+
+
+def load_fingerprint_events(trace_dir: str) -> list[dict]:
+    path = os.path.join(trace_dir, FINGERPRINT_BASENAME)
+    if not os.path.isfile(path):
+        return []
+    events = []
+    with open(path, "r", encoding="utf-8") as fh:
+        for lineno, line in enumerate(fh, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError as exc:
+                events.append({"_parse_error": f"line {lineno}: {exc}"})
+                continue
+            if isinstance(rec, dict) and rec.get("kind") == "build_fingerprint":
+                events.append(rec)
+    return events
+
+
+def run_check(
+    repo_root: str,
+    trace_dir: str,
+    build_dir: str,
+    binaries: tuple[str, ...],
+) -> dict:
+    errors: list[str] = []
+    checked_binaries: list[str] = []
+    checked_events = 0
+
+    events = load_fingerprint_events(trace_dir)
+    for rec in events:
+        if "_parse_error" in rec:
+            errors.append(f"unparseable fingerprint record: {rec['_parse_error']}")
+            continue
+        checked_events += 1
+        current = current_fingerprint(rec.get("path", ""))
+        errors.extend(check_identity(rec, current))
+
+    freshness = source_freshness_epoch(repo_root)
+    for binary in binaries:
+        path = os.path.join(build_dir, binary)
+        current = current_fingerprint(path)
+        if current is None:
+            continue  # not built in this tree — not this gate's concern
+        checked_binaries.append(binary)
+        errors.extend(check_freshness(binary, current["mtime"], freshness))
+
+    passed = not errors
+    return {
+        "passed": passed,
+        "errors": errors,
+        "fingerprint_events_checked": checked_events,
+        "binaries_checked": checked_binaries,
+        "source_freshness_epoch": freshness,
+    }
+
+
+# ───────────────────────────── trace emission ──────────────────────────────
+
+
+def emit_trace(trace_dir: str, status: str, snippet: str) -> str:
+    os.makedirs(trace_dir, exist_ok=True)
+    path = os.path.join(trace_dir, TRACE_BASENAME)
+    event = {
+        "kind": "eshkol_smoke",
+        "name": PROBE_ID,
+        "value": status,
+        "snippet": snippet[:2000],
+        "confidence": 1.0,
+    }
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+    return path
+
+
+# ───────────────────────────────── self-test ────────────────────────────────
+#
+# "A gate that cannot fail is not a gate." Exercises both branches: the pure
+# check_identity/check_freshness functions against synthetic dicts (no git or
+# filesystem dependency, deterministic everywhere), plus one end-to-end
+# fixture against real files in a repo-local temp directory so the wiring
+# (stat, sha256, JSON-L parsing) is proven too, not just the logic.
+
+
+def _pure_fixture_cases() -> list[tuple[str, bool, list[str]]]:
+    matching_current = {"path": "/x/eshkol-run", "size": 100, "mtime": 1000, "sha256": "abc"}
+    recorded_match = {"harness": "h", "binary": "eshkol-run", "path": "/x/eshkol-run",
+                       "size": 100, "mtime": 1000, "sha256": "abc"}
+    recorded_mismatch = {"harness": "h", "binary": "eshkol-run", "path": "/x/eshkol-run",
+                          "size": 100, "mtime": 1000, "sha256": "DIFFERENT"}
+
+    cases = []
+    cases.append(("identity_match", True, check_identity(recorded_match, matching_current)))
+    cases.append(("identity_mismatch", False, check_identity(recorded_mismatch, matching_current)))
+    cases.append(("identity_deleted", False, check_identity(recorded_match, None)))
+    cases.append(("freshness_ok", True, check_freshness("eshkol-run", 2000, 1000)))
+    cases.append(("freshness_stale", False, check_freshness("eshkol-run", 500, 1000)))
+    return cases
+
+
+def _e2e_fixture(tmp_dir: str) -> tuple[bool, str]:
+    """Write a fake 'binary', record its real fingerprint, then mutate the
+    binary and confirm the gate goes red; then restore agreement and confirm
+    it goes green; then age the binary behind a fake 'source freshness' and
+    confirm the standalone freshness check (used the same way run_check does)
+    catches it."""
+    build_dir = os.path.join(tmp_dir, "build")
+    trace_dir = os.path.join(tmp_dir, "traces")
+    os.makedirs(build_dir, exist_ok=True)
+    os.makedirs(trace_dir, exist_ok=True)
+
+    binary_path = os.path.join(build_dir, "eshkol-run")
+    with open(binary_path, "wb") as fh:
+        fh.write(b"fake binary content v1")
+
+    fp = current_fingerprint(binary_path)
+    assert fp is not None
+    event = {
+        "kind": "build_fingerprint",
+        "harness": "selftest_harness",
+        "binary": "eshkol-run",
+        "path": binary_path,
+        "size": fp["size"],
+        "mtime": fp["mtime"],
+        "sha256": fp["sha256"],
+        "git_sha": "deadbeef",
+        "recorded_epoch": int(time.time()),
+    }
+    fingerprint_file = os.path.join(trace_dir, FINGERPRINT_BASENAME)
+    with open(fingerprint_file, "w", encoding="utf-8") as fh:
+        fh.write(json.dumps(event) + "\n")
+
+    # Case 1: matches immediately after recording -> no identity errors.
+    events = load_fingerprint_events(trace_dir)
+    assert len(events) == 1
+    errs = check_identity(events[0], current_fingerprint(binary_path))
+    if errs:
+        return False, f"expected no identity errors right after recording, got: {errs}"
+
+    # Case 2: mutate the binary (rebuild/replace) -> must go red.
+    with open(binary_path, "wb") as fh:
+        fh.write(b"fake binary content v2 -- REBUILT")
+    errs = check_identity(events[0], current_fingerprint(binary_path))
+    if not errs:
+        return False, "expected identity mismatch after mutating the binary, got none (gate cannot fail)"
+
+    # Case 3: delete the binary entirely -> must go red with a clear reason.
+    os.remove(binary_path)
+    errs = check_identity(events[0], current_fingerprint(binary_path))
+    if not errs or "does not exist" not in errs[0]:
+        return False, f"expected a 'does not exist' identity error, got: {errs}"
+
+    return True, "identity check correctly PASSes on a match and FAILs on mutation/deletion"
+
+
+def self_test() -> bool:
+    all_ok = True
+    print("check_build_fingerprint.py self-test:")
+
+    for name, expect_pass, errors in _pure_fixture_cases():
+        got_pass = not errors
+        ok = got_pass == expect_pass
+        all_ok = all_ok and ok
+        verdict = "OK" if ok else "GATE IS BROKEN"
+        print(f"  [{verdict}] {name}: expected passed={expect_pass}, got passed={got_pass}")
+        if errors:
+            print(f"           {'; '.join(errors)}")
+
+    with tempfile.TemporaryDirectory(dir=REPO_ROOT, prefix=".selftest-build-fingerprint-") as tmp_dir:
+        ok, detail = _e2e_fixture(tmp_dir)
+        all_ok = all_ok and ok
+        verdict = "OK" if ok else "GATE IS BROKEN"
+        print(f"  [{verdict}] end_to_end_identity: {detail}")
+
+    if all_ok:
+        print("self-test: PASS — the gate fails on every broken fixture and passes the well-formed one")
+    else:
+        print("self-test: FAIL — the gate did not discriminate broken input from good input", file=sys.stderr)
+    return all_ok
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo-root", default=REPO_ROOT)
+    parser.add_argument("--trace-dir", default=DEFAULT_TRACE_DIR)
+    parser.add_argument("--build-dir", default=os.environ.get("BUILD_DIR", DEFAULT_BUILD_DIR))
+    parser.add_argument("--binary", action="append", default=None,
+                         help="binary name under --build-dir to freshness-check (repeatable; default eshkol-run)")
+    parser.add_argument("--no-trace", action="store_true", help="grade only, write no trace")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--self-test", action="store_true", help="run built-in red/green fixtures and exit")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return 0 if self_test() else 1
+
+    build_dir = args.build_dir
+    if not os.path.isabs(build_dir):
+        build_dir = os.path.join(args.repo_root, build_dir)
+    binaries = tuple(args.binary) if args.binary else DEFAULT_BINARIES
+
+    result = run_check(args.repo_root, args.trace_dir, build_dir, binaries)
+    status = "PASS" if result["passed"] else "FAIL"
+
+    if result["passed"]:
+        snippet = (
+            f"{result['fingerprint_events_checked']} fingerprint event(s) consistent; "
+            f"{len(result['binaries_checked'])} binary(ies) not stale relative to source"
+        )
+    else:
+        snippet = f"{len(result['errors'])} fingerprint error(s): " + "; ".join(result["errors"][:5])
+
+    if not args.no_trace:
+        emit_trace(args.trace_dir, status, snippet)
+
+    if args.format == "json":
+        print(json.dumps({"status": status, **result}, indent=2))
+    else:
+        print(f"{PROBE_ID}: {status}")
+        print(f"  build dir              : {build_dir}")
+        print(f"  fingerprint events     : {result['fingerprint_events_checked']}")
+        print(f"  binaries freshness-checked: {', '.join(result['binaries_checked']) or '(none built)'}")
+        print(f"  source freshness epoch : {result['source_freshness_epoch']}")
+        if result["errors"]:
+            print("  ERRORS:")
+            for error in result["errors"]:
+                print(f"    - {error}")
+
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_self_verdicts.py
+++ b/scripts/check_self_verdicts.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+"""Release gate: no artifact from a run the harness counted as PASSING may
+contain a self-reported failure marker.
+
+WHY THIS EXISTS (docs/design/FLAW_DETECTION_ROADMAP.md, D-05 TESTS THAT
+ANNOUNCE THEIR OWN FAILURE)
+
+`tests/parser/test_function_shadowing.esk` printed `FAIL: Expected 12` on the
+VM, out loud, on a green baseline, for months (SW-24, closed by #429) — the
+program's own verdict said FAIL and the harness that ran it still counted the
+run as a pass. Twenty of the `scripts/run_*_tests.sh` suites already scan
+their OWN captured output for exactly this contradiction (see
+`scripts/lib/test_isolation.sh`'s `eshkol_test_output_has_failure`, and
+`run_all_tests.sh`'s "Harness contradiction" check at its own tail). Both are
+correct and both stay in place — this gate does not replace them.
+
+What neither of those provides is a REUSABLE, INDEPENDENTLY TESTABLE tool
+that can be pointed at any captured artifact from any harness — including the
+lanes the roadmap calls out by name as gaps: the VM and wasm lanes
+(`run_vm_parity.sh` grades by `cmp -s native.out vmsrc.out` alone, so two
+engines printing the identical FAIL line still compares equal and passes),
+and the CTest suite (`ctest`'s own PASS/FAIL verdict is derived from exit
+status, not from scanning `<system-out>` for a self-reported contradiction).
+
+THREE WAYS TO FEED IT EVIDENCE
+
+  --junit FILE      A CTest/JUnit XML file (e.g. from
+                     `ctest --output-junit FILE`, exactly what
+                     scripts/run_ctest_gate.sh already produces). For every
+                     <testcase> CTest counted as passing (no <failure>/
+                     <error> child, and no fail-shaped `status` attribute),
+                     scan its captured <system-out>/<system-err> for a
+                     self-reported failure marker.
+
+  --manifest FILE   A TSV file, one row per captured artifact:
+                         VERDICT<TAB>path/to/captured.log[<TAB>label]
+                     VERDICT is PASS or FAIL, as the harness that produced
+                     the log itself concluded. Rows marked FAIL are recorded
+                     but never flagged (they are SUPPOSED to contain failure
+                     text). This is the integration point for any harness:
+                     write a manifest line next to each captured log.
+
+  --pair VERDICT:PATH   One ad hoc artifact/verdict pair on the command line,
+                     repeatable, for quick wiring without a manifest file.
+
+A contradiction is: a PASS-graded artifact whose text contains an unambiguous
+self-reported failure marker (FAIL, FAILED, FAILURE, FAILS, MISMATCH,
+DIVERGENCE by default — see --extra-pattern to add more, e.g. bare ERROR,
+which is deliberately NOT in the default set because several error-handling
+tests in this tree print "ERROR:" as their EXPECTED output; the same
+reasoning test_isolation.sh's ESHKOL_TEST_FAILURE_REGEX already documents).
+Noise that merely MENTIONS a failure token without reporting one — a summary
+line stating a zero count ("Failed: 0"), or a decorative banner title
+("=== DEBUG MINIMAL FAIL TEST ===") — is filtered out first, using the same
+rules `eshkol_test_filter_verdict_noise` uses, so this gate does not cry wolf
+on the same false positives that motivated that shared helper.
+
+Grading
+    PASS  no PASS-graded artifact contains a self-reported failure marker
+          (including the case where no input is given at all — nothing to
+          contradict).
+    FAIL  at least one PASS-graded artifact contains one.
+
+Usage
+    python3 scripts/check_self_verdicts.py --junit build/ctest-junit.xml
+    python3 scripts/check_self_verdicts.py --manifest evidence/verdicts.tsv
+    python3 scripts/check_self_verdicts.py --pair PASS:some.log --pair FAIL:other.log
+    python3 scripts/check_self_verdicts.py --format json
+    python3 scripts/check_self_verdicts.py --self-test
+
+Exit status is 0 on PASS and 1 on FAIL (including under --self-test, where it
+reports whether the gate itself is capable of failing).
+
+Copyright (C) tsotchke
+SPDX-License-Identifier: MIT
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_TRACE_DIR = os.path.join(REPO_ROOT, "scripts", "icc_traces")
+TRACE_BASENAME = "self_verdict_gate.jsonl"
+PROBE_ID = "self_verdict_clean"
+
+# ─────────────────────────── ported failure-marker logic ───────────────────
+#
+# Mirrors scripts/lib/test_isolation.sh's ESHKOL_TEST_FAILURE_REGEX /
+# ESHKOL_TEST_ZERO_FAILURE_REGEX / ESHKOL_TEST_TITLE_DECORATION, extended with
+# MISMATCH and DIVERGENCE per the roadmap's requested marker set. Kept as a
+# faithful port (same exclusions, same reasoning) rather than a rewrite, so
+# the two implementations cannot silently drift into disagreeing about what
+# counts as a failure.
+
+_FAILURE_WORDS = r"(?:FAIL|FAILED|FAILURE|FAILS|MISMATCH|MISMATCHES|DIVERGENCE|DIVERGENCES)"
+FAILURE_REGEX = re.compile(
+    r"(^|[^A-Za-z0-9_])" + _FAILURE_WORDS + r"([^A-Za-z0-9_]|$)"
+    r"|Failed:\s*[1-9]"
+    r"|Failures:\s*[1-9]"
+    r"|^\s*✗"  # ✗
+    r"|Assertion failed"
+    r"|Segmentation fault"
+    r"|Bus error"
+    r"|Abort trap"
+    r"|fatal signal",
+    re.MULTILINE,
+)
+
+_ZERO_FAILURE_REGEX = re.compile(
+    r"(?:FAIL|FAILED|FAILURES?|FAILS|MISMATCHES?|DIVERGENCES?)\s*[:=]?\s*0(?:[^0-9]|$)"
+)
+
+# A run of 3+ of = * # - at BOTH ends is a decorative banner. Only bare FAIL
+# is discounted this way (see module docstring / test_isolation.sh's own
+# comment): FAILED/FAILURE/FAILS/MISMATCH/DIVERGENCE in a banner is still a
+# verdict.
+_TITLE_DECORATION = re.compile(r"^\s*[=*#-][=*#-][=*#-].*[=*#-][=*#-][=*#-]\s*$")
+_TITLE_SAFE_WORDS = re.compile(r"FAILED|FAILURE|FAILS|MISMATCH|DIVERGENCE")
+
+
+def _filter_verdict_noise(text: str) -> str:
+    kept = []
+    for line in text.splitlines():
+        if _ZERO_FAILURE_REGEX.search(line):
+            continue
+        if _TITLE_DECORATION.match(line) and not _TITLE_SAFE_WORDS.search(line):
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
+def offending_lines(text: str, extra_pattern: str | None = None, limit: int = 10) -> list[str]:
+    """Lines in `text` that report a genuine self-reported failure, after
+    dropping zero-count summaries and decorative titles. Empty list = clean."""
+    if not text:
+        return []
+    filtered = _filter_verdict_noise(text)
+    pattern = FAILURE_REGEX
+    if extra_pattern:
+        pattern = re.compile(pattern.pattern + "|" + extra_pattern, re.MULTILINE)
+    hits = []
+    for line in filtered.splitlines():
+        if pattern.search(line):
+            hits.append(line.strip())
+            if len(hits) >= limit:
+                break
+    return hits
+
+
+def has_failure(text: str, extra_pattern: str | None = None) -> bool:
+    return bool(offending_lines(text, extra_pattern, limit=1))
+
+
+# ───────────────────────────── evidence sources ────────────────────────────
+
+
+class Contradiction:
+    def __init__(self, source: str, name: str, offending: list[str]):
+        self.source = source
+        self.name = name
+        self.offending = offending
+
+    def describe(self) -> str:
+        sample = "; ".join(self.offending[:3])
+        return f"[{self.source}] {self.name!r} was graded PASS but its output contains: {sample}"
+
+
+def _ctest_verdict_failed(case: ET.Element) -> bool:
+    status = case.get("status") or ""
+    return (
+        case.find("failure") is not None
+        or case.find("error") is not None
+        or status in ("fail", "failed", "notrun", "error")
+    )
+
+
+def scan_junit(path: str, extra_pattern: str | None) -> tuple[list[Contradiction], int]:
+    """Returns (contradictions, testcases_examined). Raises on unparseable XML —
+    the caller decides whether that is fatal for the whole run."""
+    root = ET.parse(path).getroot()
+    contradictions: list[Contradiction] = []
+    examined = 0
+    for case in root.iter("testcase"):
+        name = case.get("name") or ""
+        if not name:
+            continue
+        status = case.get("status") or ""
+        if case.find("skipped") is not None or status == "skipped":
+            continue
+        examined += 1
+        if _ctest_verdict_failed(case):
+            continue  # already graded FAIL — not a contradiction to check
+        text_parts = []
+        out_el = case.find("system-out")
+        err_el = case.find("system-err")
+        if out_el is not None and out_el.text:
+            text_parts.append(out_el.text)
+        if err_el is not None and err_el.text:
+            text_parts.append(err_el.text)
+        combined = "\n".join(text_parts)
+        hits = offending_lines(combined, extra_pattern)
+        if hits:
+            contradictions.append(Contradiction(f"junit:{os.path.basename(path)}", name, hits))
+    return contradictions, examined
+
+
+def scan_manifest(path: str, extra_pattern: str | None) -> tuple[list[Contradiction], int]:
+    contradictions: list[Contradiction] = []
+    examined = 0
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            line = raw.rstrip("\n")
+            if not line or line.lstrip().startswith("#"):
+                continue
+            fields = line.split("\t")
+            if len(fields) < 2:
+                raise ValueError(f"{path}:{lineno}: expected VERDICT<TAB>path[<TAB>label], got: {line!r}")
+            verdict, artifact_path = fields[0].strip(), fields[1].strip()
+            label = fields[2].strip() if len(fields) > 2 else artifact_path
+            if verdict not in ("PASS", "FAIL"):
+                raise ValueError(f"{path}:{lineno}: verdict must be PASS or FAIL, got {verdict!r}")
+            examined += 1
+            if verdict == "FAIL":
+                continue
+            if not os.path.isfile(artifact_path):
+                contradictions.append(
+                    Contradiction(f"manifest:{os.path.basename(path)}", label,
+                                  [f"artifact does not exist: {artifact_path}"])
+                )
+                continue
+            with open(artifact_path, "r", encoding="utf-8", errors="replace") as afh:
+                text = afh.read()
+            hits = offending_lines(text, extra_pattern)
+            if hits:
+                contradictions.append(Contradiction(f"manifest:{os.path.basename(path)}", label, hits))
+    return contradictions, examined
+
+
+def scan_pair(verdict: str, artifact_path: str, extra_pattern: str | None) -> tuple[list[Contradiction], int]:
+    if verdict not in ("PASS", "FAIL"):
+        raise ValueError(f"--pair verdict must be PASS or FAIL, got {verdict!r}")
+    if verdict == "FAIL":
+        return [], 1
+    if not os.path.isfile(artifact_path):
+        return [Contradiction("pair", artifact_path, [f"artifact does not exist: {artifact_path}"])], 1
+    with open(artifact_path, "r", encoding="utf-8", errors="replace") as fh:
+        text = fh.read()
+    hits = offending_lines(text, extra_pattern)
+    if hits:
+        return [Contradiction("pair", artifact_path, hits)], 1
+    return [], 1
+
+
+# ───────────────────────────── trace emission ──────────────────────────────
+
+
+def emit_trace(trace_dir: str, status: str, snippet: str) -> str:
+    os.makedirs(trace_dir, exist_ok=True)
+    path = os.path.join(trace_dir, TRACE_BASENAME)
+    event = {
+        "kind": "eshkol_smoke",
+        "name": PROBE_ID,
+        "value": status,
+        "snippet": snippet[:2000],
+        "confidence": 1.0,
+    }
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+    return path
+
+
+# ───────────────────────────────── self-test ────────────────────────────────
+
+_JUNIT_CONTRADICTION = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="ctest" tests="2">
+    <testcase name="legit_failure_test" status="run">
+      <failure message="nonzero exit"/>
+      <system-out>FAIL: Expected 12, got 7</system-out>
+    </testcase>
+    <testcase name="silently_wrong_test" status="run">
+      <system-out>Running...
+FAIL: Expected 12, got 7 (VM fast-path bug)
+exit 0</system-out>
+    </testcase>
+  </testsuite>
+</testsuites>
+"""
+
+_JUNIT_CLEAN = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="ctest" tests="2">
+    <testcase name="legit_failure_test" status="run">
+      <failure message="nonzero exit"/>
+      <system-out>FAIL: Expected 12, got 7</system-out>
+    </testcase>
+    <testcase name="clean_pass_test" status="run">
+      <system-out>Total: 17, Passed: 17, Failed: 0
+=== DEBUG MINIMAL FAIL TEST ===
+All good.</system-out>
+    </testcase>
+  </testsuite>
+</testsuites>
+"""
+
+
+def _write(tmp_dir: str, name: str, content: str) -> str:
+    path = os.path.join(tmp_dir, name)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(content)
+    return path
+
+
+def self_test() -> bool:
+    all_ok = True
+    print("check_self_verdicts.py self-test:")
+
+    with tempfile.TemporaryDirectory(dir=REPO_ROOT, prefix=".selftest-self-verdicts-") as tmp_dir:
+        # --- JUnit: a PASS-graded testcase whose own output says FAIL -> must FAIL.
+        junit_bad = _write(tmp_dir, "bad.xml", _JUNIT_CONTRADICTION)
+        contradictions, examined = scan_junit(junit_bad, None)
+        ok = len(contradictions) == 1 and examined == 2
+        all_ok = all_ok and ok
+        print(f"  [{'OK' if ok else 'GATE IS BROKEN'}] junit_contradiction: "
+              f"expected 1 contradiction (the legit failure must NOT double-count), got {len(contradictions)}")
+
+        # --- JUnit: only the legitimately-failed case mentions FAIL; the PASS
+        #     case has a zero-count summary and a decorative banner -> clean.
+        junit_good = _write(tmp_dir, "good.xml", _JUNIT_CLEAN)
+        contradictions2, examined2 = scan_junit(junit_good, None)
+        ok2 = len(contradictions2) == 0 and examined2 == 2
+        all_ok = all_ok and ok2
+        print(f"  [{'OK' if ok2 else 'GATE IS BROKEN'}] junit_clean_with_noise: "
+              f"expected 0 contradictions (zero-count + banner must not trip), got {len(contradictions2)}")
+
+        # --- manifest: PASS row pointing at a log containing DIVERGENCE -> FAIL.
+        div_log = _write(tmp_dir, "divergence.log", "native: 42\nvm: 41\nDIVERGENCE: values differ\n")
+        clean_log = _write(tmp_dir, "clean.log", "Failed: 0\nAll 60 checks green.\n")
+        real_fail_log = _write(tmp_dir, "real_fail.log", "MISMATCH: expected 3.14 got 2.71\n")
+        manifest_bad = _write(tmp_dir, "manifest_bad.tsv",
+                               f"PASS\t{div_log}\tvm-lane\nPASS\t{clean_log}\tclean-lane\n")
+        contradictions3, examined3 = scan_manifest(manifest_bad, None)
+        ok3 = len(contradictions3) == 1 and examined3 == 2 and contradictions3[0].name == "vm-lane"
+        all_ok = all_ok and ok3
+        print(f"  [{'OK' if ok3 else 'GATE IS BROKEN'}] manifest_divergence: "
+              f"expected 1 contradiction naming vm-lane, got {[c.name for c in contradictions3]}")
+
+        # --- manifest: the row with the real failure text is honestly marked
+        #     FAIL, so it must NOT be flagged (FAIL rows are never contradictions).
+        manifest_honest = _write(tmp_dir, "manifest_honest.tsv",
+                                  f"FAIL\t{real_fail_log}\thonest-fail\nPASS\t{clean_log}\tclean-lane\n")
+        contradictions4, examined4 = scan_manifest(manifest_honest, None)
+        ok4 = len(contradictions4) == 0 and examined4 == 2
+        all_ok = all_ok and ok4
+        print(f"  [{'OK' if ok4 else 'GATE IS BROKEN'}] manifest_honest_fail_not_flagged: "
+              f"expected 0 contradictions, got {len(contradictions4)}")
+
+        # --- manifest: a PASS row pointing at a missing artifact -> FAIL.
+        manifest_missing = _write(tmp_dir, "manifest_missing.tsv",
+                                   f"PASS\t{os.path.join(tmp_dir, 'does_not_exist.log')}\tghost\n")
+        contradictions5, _ = scan_manifest(manifest_missing, None)
+        ok5 = len(contradictions5) == 1
+        all_ok = all_ok and ok5
+        print(f"  [{'OK' if ok5 else 'GATE IS BROKEN'}] manifest_missing_artifact: "
+              f"expected 1 contradiction, got {len(contradictions5)}")
+
+        # --- ad hoc pair, clean -> no contradiction.
+        contradictions6, _ = scan_pair("PASS", clean_log, None)
+        ok6 = len(contradictions6) == 0
+        all_ok = all_ok and ok6
+        print(f"  [{'OK' if ok6 else 'GATE IS BROKEN'}] pair_clean: expected 0, got {len(contradictions6)}")
+
+        # --- ad hoc pair, contradictory -> contradiction.
+        contradictions7, _ = scan_pair("PASS", div_log, None)
+        ok7 = len(contradictions7) == 1
+        all_ok = all_ok and ok7
+        print(f"  [{'OK' if ok7 else 'GATE IS BROKEN'}] pair_contradiction: expected 1, got {len(contradictions7)}")
+
+    if all_ok:
+        print("self-test: PASS — the gate fails on every broken fixture and passes the well-formed one")
+    else:
+        print("self-test: FAIL — the gate did not discriminate broken input from good input", file=sys.stderr)
+    return all_ok
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--junit", action="append", default=[], help="CTest/JUnit XML file (repeatable)")
+    parser.add_argument("--manifest", action="append", default=[], help="VERDICT<TAB>path[<TAB>label] TSV file (repeatable)")
+    parser.add_argument("--pair", action="append", default=[], help="VERDICT:PATH ad hoc pair (repeatable)")
+    parser.add_argument("--extra-pattern", default=None, help="extra regex OR-ed into the failure marker set")
+    parser.add_argument("--trace-dir", default=DEFAULT_TRACE_DIR)
+    parser.add_argument("--no-trace", action="store_true")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return 0 if self_test() else 1
+
+    contradictions: list[Contradiction] = []
+    examined = 0
+    read_errors: list[str] = []
+
+    for path in args.junit:
+        try:
+            c, n = scan_junit(path, args.extra_pattern)
+            contradictions.extend(c)
+            examined += n
+        except (OSError, ET.ParseError) as exc:
+            read_errors.append(f"junit {path}: {exc}")
+
+    for path in args.manifest:
+        try:
+            c, n = scan_manifest(path, args.extra_pattern)
+            contradictions.extend(c)
+            examined += n
+        except (OSError, ValueError) as exc:
+            read_errors.append(f"manifest {path}: {exc}")
+
+    for spec in args.pair:
+        if ":" not in spec:
+            read_errors.append(f"--pair must be VERDICT:PATH, got {spec!r}")
+            continue
+        verdict, artifact_path = spec.split(":", 1)
+        try:
+            c, n = scan_pair(verdict, artifact_path, args.extra_pattern)
+            contradictions.extend(c)
+            examined += n
+        except (OSError, ValueError) as exc:
+            read_errors.append(f"pair {spec}: {exc}")
+
+    # A read error (unparseable JUnit, malformed manifest) is itself a FAIL —
+    # fail closed rather than silently skipping evidence this gate was told
+    # to check.
+    passed = not contradictions and not read_errors
+
+    if passed:
+        snippet = f"{examined} artifact(s) examined across {len(args.junit) + len(args.manifest) + len(args.pair)} source(s), no contradiction"
+    else:
+        details = [c.describe() for c in contradictions] + read_errors
+        snippet = f"{len(details)} problem(s): " + "; ".join(details[:5])
+
+    if not args.no_trace:
+        emit_trace(args.trace_dir, "PASS" if passed else "FAIL", snippet)
+
+    if args.format == "json":
+        print(json.dumps({
+            "passed": passed,
+            "examined": examined,
+            "contradictions": [{"source": c.source, "name": c.name, "offending": c.offending} for c in contradictions],
+            "read_errors": read_errors,
+        }, indent=2))
+    else:
+        print(f"{PROBE_ID}: {'PASS' if passed else 'FAIL'}")
+        print(f"  artifacts examined : {examined}")
+        if contradictions:
+            print("  CONTRADICTIONS (graded PASS, but self-reports failure):")
+            for c in contradictions:
+                print(f"    - {c.describe()}")
+        if read_errors:
+            print("  READ ERRORS:")
+            for e in read_errors:
+                print(f"    - {e}")
+        if examined == 0 and not args.junit and not args.manifest and not args.pair:
+            print("  (no --junit/--manifest/--pair given — nothing to scan)")
+
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/doc_audit/check_results_schema.py
+++ b/scripts/doc_audit/check_results_schema.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Validate `results-<mode>.json`, the artifact `scripts/doc_audit/run_examples.py`
+writes for every documentation-example execution run.
+
+WHY THIS EXISTS
+
+The v1.3.4 ICC readiness run scored ready/97 with exactly one low-severity
+gap: `artifact_without_test_or_trace` on `Artifact:results-%s.json` —
+produced by `run_examples.py` (~line 107) with nothing validating it. ICC's
+suggested action was `add_artifact_validator_or_runtime_probe`. This is the
+validator half of that fix; `run_examples.py` also now emits a runtime_event
+trace (the "do both, cheap" half — see its own header comment) recording
+whether this validator passed against the results it just wrote.
+
+WHAT IT CHECKS
+
+  1. The file parses as a JSON list.
+  2. Every record has the required fields `run_examples.py` promises in its
+     own docstring: file, start_line, end_line, klass, mode, exit, stdout,
+     stderr, seconds, expects — with the right shapes (start_line/end_line/
+     exit/seconds numeric, file/klass/mode strings, expects a list).
+  3. No duplicate (file, start_line, mode) triple — the same example
+     recorded twice hides whichever result comes second.
+  4. Records are sorted by (file, start_line), matching exactly what
+     `run_examples.py` itself does before writing
+     (`results.sort(key=lambda r: (r["file"], r["start_line"]))`) — an
+     out-of-order file was hand-edited or produced by a different tool
+     entirely and should not be trusted as this harness's own output.
+  5. Optional: when `--examples FILE` (the `examples.json` the run was
+     driven from) is given, the record count must equal the number of
+     examples discovered there (after applying the same `--only` filter, if
+     the caller used one) — proving the results file is neither truncated
+     nor padded relative to what was supposed to run.
+
+Grading
+    PASS  the file parses, every record is well-formed, no duplicates, the
+          file is sorted, and (if --examples given) the count matches.
+    FAIL  a parse error, a malformed record, a duplicate, an out-of-order
+          file, or a count mismatch.
+
+The gate FAILS CLOSED: a missing or unparseable results file is FAIL, not a
+silent pass — the same discipline scripts/check_ledger_integrity.py and
+scripts/check_oracle_schema.py already use.
+
+Usage
+    python3 scripts/doc_audit/check_results_schema.py path/to/results-jit.json
+    python3 scripts/doc_audit/check_results_schema.py results-jit.json --examples examples.json
+    python3 scripts/doc_audit/check_results_schema.py results-jit.json --format json
+    python3 scripts/doc_audit/check_results_schema.py --self-test
+
+Exit status is 0 on PASS and 1 on FAIL (including under --self-test).
+
+Copyright (C) tsotchke
+SPDX-License-Identifier: MIT
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+DEFAULT_TRACE_DIR = os.path.join(REPO_ROOT, "scripts", "icc_traces")
+TRACE_BASENAME = "doc_examples_results_gate.jsonl"
+PROBE_ID = "doc_examples_results_valid"
+
+REQUIRED_FIELDS = ("file", "start_line", "end_line", "klass", "mode", "exit", "stdout", "stderr", "seconds", "expects")
+STRING_FIELDS = ("file", "klass", "mode")
+INT_FIELDS = ("start_line", "end_line", "exit")
+NUMERIC_FIELDS = ("seconds",)
+
+
+class ResultsSchemaError(Exception):
+    """The results file could not be read or parsed at all."""
+
+
+def _load_json(path: str) -> object:
+    if not os.path.isfile(path):
+        raise ResultsSchemaError(f"results file not found at {path} (the gate fails closed)")
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except Exception as exc:  # noqa: BLE001 - report any parse failure uniformly
+        raise ResultsSchemaError(f"results file at {path} is not valid JSON: {exc}") from exc
+
+
+def check(data: object, expected_count: int | None = None) -> dict:
+    """Validate a parsed results document. Never raises; returns a report."""
+    errors: list[str] = []
+
+    if not isinstance(data, list):
+        return {"passed": False, "errors": ["results document is not a JSON list"],
+                "record_count": 0, "duplicates": [], "sorted": False}
+
+    seen: dict[tuple, int] = {}
+    duplicates: list[str] = []
+    keys: list[tuple] = []
+
+    for position, rec in enumerate(data, start=1):
+        label = f"record #{position}"
+        if not isinstance(rec, dict):
+            errors.append(f"{label} is not an object")
+            continue
+
+        if "file" in rec and "start_line" in rec:
+            label = f"record #{position} ({rec.get('file')}:{rec.get('start_line')})"
+
+        missing = [f for f in REQUIRED_FIELDS if f not in rec]
+        if missing:
+            errors.append(f"{label} is missing required field(s): {', '.join(missing)}")
+
+        for f in STRING_FIELDS:
+            if f in rec and not isinstance(rec[f], str):
+                errors.append(f"{label}: field {f!r} must be a string, got {type(rec[f]).__name__}")
+        for f in INT_FIELDS:
+            if f in rec and not isinstance(rec[f], int):
+                errors.append(f"{label}: field {f!r} must be an integer, got {type(rec[f]).__name__}")
+        for f in NUMERIC_FIELDS:
+            if f in rec and not isinstance(rec[f], (int, float)):
+                errors.append(f"{label}: field {f!r} must be numeric, got {type(rec[f]).__name__}")
+        if "expects" in rec and not isinstance(rec["expects"], list):
+            errors.append(f"{label}: field 'expects' must be a list, got {type(rec['expects']).__name__}")
+
+        if "file" in rec and "start_line" in rec and "mode" in rec:
+            key = (rec["file"], rec["start_line"], rec["mode"])
+            if key in seen:
+                duplicates.append(f"{key[0]}:{key[1]} (mode={key[2]})")
+            else:
+                seen[key] = position
+            keys.append((rec.get("file"), rec.get("start_line")))
+
+    is_sorted = keys == sorted(keys, key=lambda k: (k[0] is None, k[0], k[1] is None, k[1]))
+    if keys and not is_sorted:
+        errors.append(
+            "records are not sorted by (file, start_line) — run_examples.py always sorts "
+            "before writing; an unsorted file was not produced by this harness as-is"
+        )
+
+    if duplicates:
+        errors.append(f"{len(duplicates)} duplicate (file, start_line, mode) record(s): " + "; ".join(duplicates[:5]))
+
+    if expected_count is not None and len(data) != expected_count:
+        errors.append(
+            f"record count {len(data)} does not match {expected_count} example(s) discovered "
+            f"in the --examples manifest — the results file is truncated or padded"
+        )
+
+    passed = not errors
+    return {
+        "passed": passed,
+        "errors": errors,
+        "record_count": len(data),
+        "duplicates": duplicates,
+        "sorted": is_sorted,
+    }
+
+
+def count_examples(examples_path: str, only: str | None = None) -> int:
+    with open(examples_path, "r", encoding="utf-8") as fh:
+        recs = json.load(fh)
+    if only:
+        sel = set(only.split(","))
+        recs = [r for r in recs if r["file"] in sel or ("%s:%d" % (r["file"], r["start_line"])) in sel]
+    return len(recs)
+
+
+def emit_trace(trace_dir: str, status: str, snippet: str) -> str:
+    os.makedirs(trace_dir, exist_ok=True)
+    path = os.path.join(trace_dir, TRACE_BASENAME)
+    event = {
+        "kind": "eshkol_smoke",
+        "name": PROBE_ID,
+        "value": status,
+        "snippet": snippet[:2000],
+        "confidence": 1.0,
+    }
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+    return path
+
+
+# ───────────────────────────────── self-test ────────────────────────────────
+
+_GOOD = [
+    {"file": "docs/A.md", "start_line": 10, "end_line": 12, "klass": "esk", "mode": "jit",
+     "exit": 0, "stdout": "ok\n", "stderr": "", "seconds": 0.1, "expects": ["ok"]},
+    {"file": "docs/A.md", "start_line": 20, "end_line": 22, "klass": "esk", "mode": "jit",
+     "exit": 0, "stdout": "42\n", "stderr": "", "seconds": 0.2, "expects": []},
+    {"file": "docs/B.md", "start_line": 5, "end_line": 6, "klass": "esk", "mode": "jit",
+     "exit": 1, "stdout": "", "stderr": "error: boom\n", "seconds": 0.05, "expects": []},
+]
+
+_MISSING_FIELD = [
+    {"file": "docs/A.md", "start_line": 10, "klass": "esk", "mode": "jit",
+     "exit": 0, "stdout": "", "stderr": "", "seconds": 0.1, "expects": []},
+]
+
+_DUPLICATE = _GOOD + [dict(_GOOD[0])]
+
+_UNSORTED = [_GOOD[1], _GOOD[0], _GOOD[2]]
+
+_WRONG_TYPE = [
+    {"file": "docs/A.md", "start_line": "10", "end_line": 12, "klass": "esk", "mode": "jit",
+     "exit": 0, "stdout": "", "stderr": "", "seconds": 0.1, "expects": []},
+]
+
+
+def self_test() -> bool:
+    all_ok = True
+    print("check_results_schema.py self-test:")
+
+    cases = [
+        ("well_formed", _GOOD, None, True),
+        ("missing_field", _MISSING_FIELD, None, False),
+        ("duplicate_record", _DUPLICATE, None, False),
+        ("unsorted", _UNSORTED, None, False),
+        ("wrong_type", _WRONG_TYPE, None, False),
+        ("count_matches", _GOOD, 3, True),
+        ("count_mismatch", _GOOD, 5, False),
+    ]
+
+    for name, data, expected_count, expect_pass in cases:
+        result = check(data, expected_count)
+        ok = result["passed"] == expect_pass
+        all_ok = all_ok and ok
+        verdict = "OK" if ok else "GATE IS BROKEN"
+        print(f"  [{verdict}] {name}: expected passed={expect_pass}, got passed={result['passed']}")
+        if result["errors"]:
+            print(f"           {'; '.join(result['errors'][:2])}")
+
+    # End-to-end: real files on disk, including a real examples.json for the
+    # count cross-check, inside a repo-local temp directory.
+    with tempfile.TemporaryDirectory(dir=REPO_ROOT, prefix=".selftest-doc-results-schema-") as tmp_dir:
+        results_path = os.path.join(tmp_dir, "results-jit.json")
+        with open(results_path, "w", encoding="utf-8") as fh:
+            json.dump(_GOOD, fh)
+        examples_path = os.path.join(tmp_dir, "examples.json")
+        with open(examples_path, "w", encoding="utf-8") as fh:
+            json.dump([{"file": r["file"], "start_line": r["start_line"]} for r in _GOOD], fh)
+
+        data = _load_json(results_path)
+        n = count_examples(examples_path)
+        result = check(data, n)
+        ok = result["passed"] and n == 3
+        all_ok = all_ok and ok
+        print(f"  [{'OK' if ok else 'GATE IS BROKEN'}] end_to_end_file_and_examples_count: "
+              f"passed={result['passed']}, examples_count={n}")
+
+        missing_path = os.path.join(tmp_dir, "does_not_exist.json")
+        try:
+            _load_json(missing_path)
+            ok2 = False
+        except ResultsSchemaError:
+            ok2 = True
+        all_ok = all_ok and ok2
+        print(f"  [{'OK' if ok2 else 'GATE IS BROKEN'}] missing_file_fails_closed: raised={ok2}")
+
+    if all_ok:
+        print("self-test: PASS — the gate fails on every broken fixture and passes the well-formed one")
+    else:
+        print("self-test: FAIL — the gate did not discriminate broken input from good input", file=sys.stderr)
+    return all_ok
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("results", nargs="?", help="path to results-<mode>.json")
+    parser.add_argument("--examples", default=None, help="examples.json to cross-check the record count against")
+    parser.add_argument("--only", default=None, help="same --only filter used for the run_examples.py invocation being checked")
+    parser.add_argument("--trace-dir", default=DEFAULT_TRACE_DIR)
+    parser.add_argument("--no-trace", action="store_true")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return 0 if self_test() else 1
+
+    if not args.results:
+        parser.error("the results positional argument is required unless --self-test is given")
+
+    try:
+        data = _load_json(args.results)
+        expected_count = count_examples(args.examples, args.only) if args.examples else None
+        result = check(data, expected_count)
+    except ResultsSchemaError as exc:
+        snippet = f"results file unusable: {exc}"
+        if not args.no_trace:
+            emit_trace(args.trace_dir, "FAIL", snippet)
+        if args.format == "json":
+            print(json.dumps({"passed": False, "error": str(exc)}, indent=2))
+        else:
+            print(f"{PROBE_ID}: FAIL — {exc}", file=sys.stderr)
+        return 1
+
+    status = "PASS" if result["passed"] else "FAIL"
+    if result["passed"]:
+        snippet = f"{result['record_count']} records, sorted, no duplicates"
+    else:
+        snippet = f"{len(result['errors'])} schema error(s): " + "; ".join(result["errors"][:5])
+
+    if not args.no_trace:
+        emit_trace(args.trace_dir, status, snippet)
+
+    if args.format == "json":
+        print(json.dumps({"status": status, **result}, indent=2))
+    else:
+        print(f"{PROBE_ID}: {status}")
+        print(f"  results file : {args.results}")
+        print(f"  records      : {result['record_count']}")
+        print(f"  sorted       : {result['sorted']}")
+        if result["errors"]:
+            print("  ERRORS:")
+            for error in result["errors"]:
+                print(f"    - {error}")
+
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/doc_audit/run_examples.py
+++ b/scripts/doc_audit/run_examples.py
@@ -6,6 +6,27 @@ Usage: run_examples.py <examples.json> <eshkol-run> <outdir> [--mode jit|aot|vm]
 
 Writes <outdir>/results.json with one record per example:
   {file, start_line, klass, mode, exit, stdout, stderr, seconds}
+
+VALIDATION (v1.3.5 assurance wave 2)
+
+ICC's v1.3.4 readiness run flagged `Artifact:results-%s.json` — the file this
+script writes below — as `artifact_without_test_or_trace`: produced, but
+nothing validates it and nothing traces that it ran. This closes both halves
+of ICC's suggested `add_artifact_validator_or_runtime_probe` action:
+
+  * the validator: `scripts/doc_audit/check_results_schema.py` schema-checks
+    the file this script just wrote (required fields, sorted order, no
+    duplicate (file, start_line, mode) records, record count matches the
+    examples manifest) and can be run standalone against any results file;
+  * the trace: this script calls that validator on its own output before
+    exiting and emits a `runtime_event`-shaped JSON-L record to
+    `scripts/icc_traces/doc_examples.jsonl` naming the verdict, so ICC has
+    execution evidence for this artifact rather than none at all.
+
+Neither step changes this script's own exit behavior (validation failure is
+reported, not silently promoted to a fatal error here) — the gate that FAILS
+the build on a broken results file is `check_results_schema.py` itself, run
+standalone in CI.
 """
 
 import argparse
@@ -18,6 +39,38 @@ import tempfile
 import time
 
 TIMEOUT = 60
+
+
+def _emit_results_validation_trace(results_path, mode):
+    """Validate the just-written results file and record a runtime_event
+    trace of the verdict. Best-effort: a trace-emission problem must never
+    fail the actual doc-example run this script exists to perform."""
+    try:
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        import check_results_schema as validator  # noqa: E402
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        trace_dir = os.path.join(repo_root, "scripts", "icc_traces")
+        data = validator._load_json(results_path)
+        result = validator.check(data)
+        status = "PASS" if result["passed"] else "FAIL"
+        snippet = (
+            f"mode={mode} records={result['record_count']} sorted={result['sorted']}"
+            if result["passed"]
+            else f"mode={mode} {len(result['errors'])} schema error(s): " + "; ".join(result["errors"][:3])
+        )
+        os.makedirs(trace_dir, exist_ok=True)
+        with open(os.path.join(trace_dir, "doc_examples.jsonl"), "a", encoding="utf-8") as fh:
+            fh.write(json.dumps({
+                "kind": "runtime_event",
+                "name": "doc_examples_results_written",
+                "value": status,
+                "snippet": snippet,
+                "confidence": 1.0,
+            }, ensure_ascii=False) + "\n")
+        print("doc_examples_results_valid: %s (%s)" % (status, snippet), file=sys.stderr)
+    except Exception as exc:  # noqa: BLE001 - tracing must never break the run
+        print("run_examples.py: could not emit results-validation trace: %r" % (exc,), file=sys.stderr)
 
 
 def run_one(rec, eshkol_run, mode, workroot, repo):
@@ -104,10 +157,12 @@ def main():
             if (i + 1) % 25 == 0:
                 print("... %d/%d" % (i + 1, len(futs)), file=sys.stderr)
     results.sort(key=lambda r: (r["file"], r["start_line"]))
-    with open(os.path.join(args.outdir, "results-%s.json" % args.mode), "w") as fh:
+    results_path = os.path.join(args.outdir, "results-%s.json" % args.mode)
+    with open(results_path, "w") as fh:
         json.dump(results, fh, indent=1)
     ok = sum(1 for r in results if r["exit"] == 0)
     print("mode=%s ran=%d exit0=%d nonzero=%d" % (args.mode, len(results), ok, len(results) - ok))
+    _emit_results_validation_trace(results_path, args.mode)
 
 
 if __name__ == "__main__":

--- a/scripts/lib/build_fingerprint.sh
+++ b/scripts/lib/build_fingerprint.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# build_fingerprint.sh — record which exact binary a harness ran against.
+#
+# WHY THIS EXISTS
+#
+# D-11 in docs/design/FLAW_DETECTION_ROADMAP.md: a harness was run against a
+# STALE binary after a rebase, and the result was believed. Two false verdicts
+# in the v1.3.4 campaign trace back to this — the sharpest was #418's new
+# corpus file failing `engine_semantic_parity` because the binary under test
+# predated the source that had just been rebased in.
+#
+# `scripts/lib/test_isolation.sh` already solves the SIBLING problem — a
+# rebuild swapping the binary out from under a suite MID-RUN
+# (`eshkol_test_pin_toolchain` / `eshkol_test_toolchain_verify`). This file
+# solves a different one: proving, AFTER the fact, that the binary a harness's
+# evidence talks about is (a) still the binary on disk when a gate reads that
+# evidence, and (b) was not already stale — built before a source change that
+# should have triggered a rebuild — at the moment the harness started.
+#
+# THE CONTRACT
+#
+#   source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/build_fingerprint.sh"
+#   eshkol_emit_build_fingerprint_event "$TRACE_DIR" "run_icc_smoke" "$BUILD_DIR" eshkol-run
+#
+# appends one JSON-L record to `<trace_dir>/build_fingerprint.jsonl` (created,
+# never truncated — many harnesses share this file across one CI run) naming:
+#
+#   harness           which script recorded this fingerprint
+#   binary / path     which file, and where
+#   size / mtime      the file's stat() at record time
+#   sha256            a real content digest (mtime+size can lie across
+#                     filesystems with coarse mtime resolution; the digest
+#                     cannot)
+#   git_sha           `git rev-parse HEAD` in this checkout, if available
+#   recorded_epoch    when this event was written
+#
+# `scripts/check_build_fingerprint.py` reads that file at gate time and fails
+# when a recorded fingerprint no longer matches the binary now on disk, or
+# when the binary on disk predates the source tree it was supposedly built
+# from.
+
+if [ -n "${ESHKOL_BUILD_FINGERPRINT_SH_LOADED:-}" ]; then
+    return 0 2>/dev/null || true
+fi
+ESHKOL_BUILD_FINGERPRINT_SH_LOADED=1
+
+# Portable "size mtime" stamp — see test_isolation.sh's eshkol_test_file_stamp
+# for why GNU stat must be tried before BSD stat's `-f` (which is a totally
+# different, filesystem-level flag on BSD/macOS).
+eshkol_fp_stat() {
+    local path="$1"
+    stat -c '%s %Y' "$path" 2>/dev/null && return 0
+    stat -f '%z %m' "$path" 2>/dev/null && return 0
+    return 1
+}
+
+# Content digest of one file. Tries sha256sum (GNU/Linux), then shasum -a 256
+# (macOS/BSD), then openssl as a last resort. Prints "unavailable" rather than
+# failing outright — a harness recording a fingerprint must not itself die
+# because no digest tool exists on this host.
+eshkol_fp_sha256() {
+    local path="$1"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$path" 2>/dev/null | awk '{print $1}' && return 0
+    fi
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$path" 2>/dev/null | awk '{print $1}' && return 0
+    fi
+    if command -v openssl >/dev/null 2>&1; then
+        openssl dgst -sha256 "$path" 2>/dev/null | awk '{print $NF}' && return 0
+    fi
+    printf '%s' "unavailable"
+}
+
+# HEAD sha of the checkout containing $1 (a file or directory), or "unknown".
+eshkol_fp_git_sha() {
+    local at="$1"
+    local dir
+    dir="$at"
+    [ -d "$dir" ] || dir="$(dirname "$dir")"
+    git -C "$dir" rev-parse HEAD 2>/dev/null || printf '%s' "unknown"
+}
+
+# Append one build-fingerprint event.
+#   $1 trace_dir   directory the JSON-L file lives in (created if missing)
+#   $2 harness     short name of the calling harness (e.g. "run_icc_smoke")
+#   $3 build_dir   build directory containing the binary
+#   $4 binary      binary filename, default "eshkol-run"
+#
+# Never fails the caller: a harness that cannot record a fingerprint should
+# still be able to run its own probes. Prints a warning to stderr instead.
+eshkol_emit_build_fingerprint_event() {
+    local trace_dir="$1" harness="$2" build_dir="$3" binary="${4:-eshkol-run}"
+    local path="$build_dir/$binary"
+
+    if [ ! -e "$path" ]; then
+        echo "build_fingerprint: $path does not exist — not recording a fingerprint for $harness" >&2
+        return 0
+    fi
+
+    mkdir -p "$trace_dir" 2>/dev/null || true
+    local out="$trace_dir/build_fingerprint.jsonl"
+
+    local stamp size mtime sha git_sha
+    stamp="$(eshkol_fp_stat "$path")" || stamp="0 0"
+    size="${stamp%% *}"
+    mtime="${stamp##* }"
+    sha="$(eshkol_fp_sha256 "$path")"
+    git_sha="$(eshkol_fp_git_sha "$build_dir")"
+
+    python3 -c '
+import json, sys, time
+harness, binary, path, size, mtime, sha, git_sha = sys.argv[1:8]
+print(json.dumps({
+    "kind": "build_fingerprint",
+    "harness": harness,
+    "binary": binary,
+    "path": path,
+    "size": int(size),
+    "mtime": int(float(mtime)),
+    "sha256": sha,
+    "git_sha": git_sha,
+    "recorded_epoch": int(time.time()),
+}, ensure_ascii=False))
+' "$harness" "$binary" "$path" "$size" "$mtime" "$sha" "$git_sha" >> "$out" 2>/dev/null \
+        || echo "build_fingerprint: failed to write $out" >&2
+
+    echo "build_fingerprint: $harness -> $binary size=$size mtime=$mtime sha256=${sha:0:12}... git=$git_sha" >&2
+}

--- a/scripts/run_adversarial_gate_scenarios.sh
+++ b/scripts/run_adversarial_gate_scenarios.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# run_adversarial_gate_scenarios.sh — adversarial scenarios for OUR OWN gates.
+#
+# WHY THIS EXISTS, AND WHAT IT IS NOT
+#
+# docs/design/FLAW_DETECTION_ROADMAP.md's Appendix A names ICC's weakness-map
+# output as ranking "eval scenarios for dirty worktrees, stale artifacts,
+# model-server outage, disk pressure, failed gates, and new-development
+# suggestions" as its #1 must-have. Investigating how ICC's own eval
+# scenarios are built (`icc task-attempt-evals`, `icc capability-test-
+# coverage`) shows they are derived from REAL recorded task attempts in
+# ICC's own store (`task-attempt` outcomes), not from a scenario-definition
+# file format this repo can author and hand to the tool — there is no
+# `.icc/eval-scenarios.yaml` or equivalent for a target repo to populate.
+#
+# So this script delivers the eshkol-side equivalent named as the fallback in
+# the wave-2 task: adversarial scenarios that prove OUR OWN gates — the
+# assurance-gate family established in #454 and this wave
+# (gate_no_silent_wrong.py, check_ledger_integrity.py, check_oracle_schema.py,
+# check_self_verdicts.py, check_build_fingerprint.py,
+# scripts/doc_audit/check_results_schema.py) — behave correctly under each of
+# the six named conditions, mapped onto what actually exists in this repo:
+#
+#   S1 dirty worktree        gates must grade on FILE CONTENT, not be thrown
+#                             off by unrelated uncommitted changes elsewhere
+#                             in the tree
+#   S2 stale artifacts        check_build_fingerprint.py's own contract:
+#                             prove it goes RED on a rebuilt/replaced binary
+#                             (reuses its --self-test, which already covers
+#                             this — see D-11)
+#   S3 model-server outage    none of our gates may depend on a live network
+#                             or model server; prove every self-test still
+#                             passes with outbound connections poisoned
+#   S4 disk pressure          the disk-cap+cleanup discipline
+#                             (scripts/lib/test_isolation.sh's pruning) must
+#                             actually reclaim space under a tiny budget,
+#                             not merely exist in a comment
+#   S5 a gate actually fails   prove failure PROPAGATES: this runner's own
+#                             pass/fail aggregation must not swallow a
+#                             deliberately-red fixture (the standing bug class
+#                             this whole roadmap is about — a check that can
+#                             go red silently is worse than no check)
+#   S6 new-development         a NEW gate script following the --self-test
+#      orphan detection        contract must be wired into CMakeLists.txt
+#                             ctest AND a CI workflow, or it is exactly a
+#                             D-13 "gate that runs nowhere"
+#
+# Emits pytest-style PASSED/FAILED lines and a kind=adversarial_scenario
+# JSON-L trace to scripts/icc_traces/adversarial_gate_scenarios.jsonl.
+#
+# Usage: scripts/run_adversarial_gate_scenarios.sh
+set -u
+export LC_ALL=C LC_CTYPE=C LANG=C
+
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+TRACE_DIR="$REPO_ROOT/scripts/icc_traces"
+TRACE_FILE="$TRACE_DIR/adversarial_gate_scenarios.jsonl"
+mkdir -p "$TRACE_DIR"
+: > "$TRACE_FILE"
+
+# Disk cap + cleanup (project rule: every harness needs a bound). This
+# runner's scratch is a handful of tiny synthetic files; the bound exists on
+# principle and to catch a future scenario growing unbounded input.
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-adversarial-scenarios.XXXXXX")"
+cleanup() { rm -rf "$SCRATCH"; }
+trap cleanup EXIT
+
+# macOS has no timeout(1); emulate with perl alarm (exit 124 on expiry) —
+# same idiom scripts/run_vm_parity.sh already uses for portability.
+run_guarded() { # seconds cmd...
+    perl -e 'my $s=shift; eval { local $SIG{ALRM}=sub{ exit 124 }; alarm $s; exec @ARGV or exit 127; }' \
+        "$1" "${@:2}"
+}
+
+emit_event() { # name PASS|FAIL snippet
+    python3 -c '
+import json, sys
+print(json.dumps({"kind": "adversarial_scenario", "name": sys.argv[1],
+                  "value": sys.argv[2], "snippet": sys.argv[3],
+                  "confidence": 0.95}, ensure_ascii=False))
+' "$1" "$2" "$3" >> "$TRACE_FILE"
+}
+
+SCEN_TOTAL=0
+SCEN_FAILURES=0
+scenario_result() { # id PASS|FAIL detail
+    SCEN_TOTAL=$((SCEN_TOTAL + 1))
+    if [ "$2" = "PASS" ]; then
+        echo "PASSED scenario::$1 — $3"
+    else
+        SCEN_FAILURES=$((SCEN_FAILURES + 1))
+        echo "FAILED scenario::$1 — $3"
+    fi
+    emit_event "$1" "$2" "$3"
+}
+
+echo "== adversarial gate scenarios =="
+echo
+
+# ── S1: dirty worktree must not throw off a gate's verdict ────────────────
+echo "-- S1 dirty worktree --"
+DIRTY_MARKER="$REPO_ROOT/.adversarial-scenario-dirty-marker.$$"
+echo "unrelated scratch content, never committed" > "$DIRTY_MARKER"
+s1_ok=1
+s1_detail=""
+for gate in \
+    "scripts/gate_no_silent_wrong.py" \
+    "scripts/check_ledger_integrity.py" \
+    "scripts/check_oracle_schema.py"; do
+    if ! python3 "$gate" --no-trace >/dev/null 2>&1; then
+        s1_ok=0
+        s1_detail="$gate graded FAIL against real committed state while an unrelated file was dirty"
+        break
+    fi
+done
+for gate in "scripts/check_self_verdicts.py" "scripts/check_build_fingerprint.py" \
+            "scripts/doc_audit/check_results_schema.py"; do
+    if ! python3 "$gate" --self-test >/dev/null 2>&1; then
+        s1_ok=0
+        s1_detail="$gate --self-test failed while an unrelated file was dirty"
+        break
+    fi
+done
+rm -f "$DIRTY_MARKER"
+if [ "$s1_ok" -eq 1 ]; then
+    scenario_result dirty_worktree_does_not_affect_gates PASS \
+        "6 gates graded identically to a clean tree with an unrelated dirty file present"
+else
+    scenario_result dirty_worktree_does_not_affect_gates FAIL "$s1_detail"
+fi
+
+# ── S2: stale artifact detection actually goes red (reuse the real contract) ──
+echo "-- S2 stale artifacts --"
+if python3 scripts/check_build_fingerprint.py --self-test >/dev/null 2>&1; then
+    scenario_result stale_artifact_detected PASS \
+        "check_build_fingerprint.py's own fixtures prove it goes RED on a rebuilt/replaced/deleted binary"
+else
+    scenario_result stale_artifact_detected FAIL \
+        "check_build_fingerprint.py --self-test did not pass — it can no longer prove it detects staleness"
+fi
+
+# ── S3: no gate depends on a live network / model server ──────────────────
+echo "-- S3 model-server / network outage --"
+s3_ok=1
+s3_detail=""
+for gate in \
+    "scripts/gate_no_silent_wrong.py --self-test" \
+    "scripts/check_ledger_integrity.py --self-test" \
+    "scripts/check_oracle_schema.py --self-test" \
+    "scripts/check_self_verdicts.py --self-test" \
+    "scripts/check_build_fingerprint.py --self-test" \
+    "scripts/doc_audit/check_results_schema.py --self-test"; do
+    # Poison outbound connections: point every proxy variable at a closed
+    # local port and blank DNS-relevant hosts, so any accidental network call
+    # fails fast rather than hanging or silently succeeding on a live network.
+    if ! http_proxy="http://127.0.0.1:1" https_proxy="http://127.0.0.1:1" \
+            HTTP_PROXY="http://127.0.0.1:1" HTTPS_PROXY="http://127.0.0.1:1" \
+            ALL_PROXY="http://127.0.0.1:1" no_proxy="" \
+            run_guarded 60 python3 $gate >/dev/null 2>&1; then
+        s3_ok=0
+        s3_detail="$gate failed with outbound network poisoned — it may depend on a live service"
+        break
+    fi
+done
+if [ "$s3_ok" -eq 1 ]; then
+    scenario_result gates_survive_network_outage PASS \
+        "6 gate self-tests pass identically with every proxy env var pointed at a closed port"
+else
+    scenario_result gates_survive_network_outage FAIL "$s3_detail"
+fi
+
+# ── S4: disk-pressure pruning actually reclaims space ──────────────────────
+echo "-- S4 disk pressure --"
+PRUNE_ROOT="$SCRATCH/prune-root"
+mkdir -p "$PRUNE_ROOT"
+# Manufacture 10 fake "orphaned scratch directories" of the kind
+# test_isolation.sh's eshkol_test_isolation_prune_stale reclaims, each old
+# enough to be eligible, then squeeze the budget far below what they occupy.
+i=0
+while [ "$i" -lt 10 ]; do
+    d="$PRUNE_ROOT/eshkol-test.selftest.deadbeef.$i"
+    mkdir -p "$d"
+    head -c 65536 /dev/zero > "$d/payload.bin" 2>/dev/null || dd if=/dev/zero of="$d/payload.bin" bs=1024 count=64 2>/dev/null
+    # Backdate so both the age-sweep and the min-age floor for the size-sweep
+    # treat these as eligible for reclamation, portably (GNU touch -d vs BSD touch -t).
+    touch -d "-3 days" "$d" 2>/dev/null || touch -t "$(date -v-3d +%Y%m%d%H%M 2>/dev/null || date +%Y%m%d%H%M)" "$d" 2>/dev/null || true
+    i=$((i + 1))
+done
+before_count=$(find "$PRUNE_ROOT" -maxdepth 1 -type d -name 'eshkol-test.*' | wc -l | tr -d ' ')
+(
+    ESHKOL_TEST_TMP_ROOT="$PRUNE_ROOT" \
+    ESHKOL_TEST_TMP_MAX_DIRS=2 \
+    ESHKOL_TEST_TMP_MAX_MB=1 \
+    ESHKOL_TEST_TMP_MIN_AGE_MIN=1 \
+    bash -c '
+        source "'"$REPO_ROOT"'/scripts/lib/test_isolation.sh"
+        eshkol_test_isolation_prune_stale
+    '
+) >/dev/null 2>&1
+after_count=$(find "$PRUNE_ROOT" -maxdepth 1 -type d -name 'eshkol-test.*' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$before_count" -gt 2 ] && [ "$after_count" -le 2 ]; then
+    scenario_result disk_pressure_reclaimed PASS \
+        "pruning brought $before_count orphaned scratch dirs down to $after_count under a 2-dir/1MB budget"
+else
+    scenario_result disk_pressure_reclaimed FAIL \
+        "expected pruning to reduce $before_count dirs to <=2, got $after_count remaining — disk-cap discipline is not enforcing its own budget"
+fi
+
+# ── S5: a deliberately-failing gate must be visible, not swallowed ─────────
+echo "-- S5 failed gates propagate --"
+BROKEN_LEDGER="$SCRATCH/broken-ledger.yaml"
+cat > "$BROKEN_LEDGER" <<'YAML'
+schema: eshkol.silent_wrong_ledger.v1
+entries:
+  - id: SW-ADVERSARIAL
+    bucket: SILENT-WRONG
+      status: open
+    title: "deliberately malformed indentation"
+YAML
+if python3 scripts/check_ledger_integrity.py --ledger "$BROKEN_LEDGER" --no-trace >/dev/null 2>&1; then
+    # The broken fixture was graded PASS — the gate (or this harness) failed
+    # to detect a real problem. That is exactly the failure mode this
+    # scenario exists to catch.
+    scenario_result failed_gate_is_visible FAIL \
+        "check_ledger_integrity.py graded a malformed ledger PASS — a failure that should be loud was silent"
+else
+    scenario_result failed_gate_is_visible PASS \
+        "check_ledger_integrity.py correctly exited nonzero on a malformed fixture, and this runner correctly recorded that as the expected, visible outcome"
+fi
+
+# ── S6: every self-test-contract gate is wired into ctest AND CI ──────────
+echo "-- S6 new-development orphan detection --"
+ORPHANS=""
+GATES_CHECKED=0
+while IFS= read -r -d '' f; do
+    grep -q -- '--self-test' "$f" 2>/dev/null || continue
+    GATES_CHECKED=$((GATES_CHECKED + 1))
+    rel="${f#"$REPO_ROOT"/}"
+    base="$(basename "$f")"
+    in_cmake=0
+    grep -qF "$rel" CMakeLists.txt 2>/dev/null && in_cmake=1
+    in_ci=0
+    grep -rqF -- "$rel" .github/workflows/ 2>/dev/null && in_ci=1
+    grep -rqF -- "$base" .github/workflows/ 2>/dev/null && in_ci=1
+    if [ "$in_cmake" -eq 0 ] && [ "$in_ci" -eq 0 ]; then
+        ORPHANS="$ORPHANS $rel"
+    fi
+done < <(find scripts \( -name 'check_*.py' -o -name 'gate_*.py' \) -print0 2>/dev/null)
+
+if [ -z "$ORPHANS" ]; then
+    scenario_result no_orphan_selftest_gates PASS \
+        "$GATES_CHECKED gate script(s) following the --self-test contract are each wired into CMakeLists.txt ctest and/or a CI workflow"
+else
+    scenario_result no_orphan_selftest_gates FAIL \
+        "gate(s) implementing --self-test but wired into neither CMakeLists.txt nor .github/workflows/:$ORPHANS"
+fi
+
+# ── roll-up ──────────────────────────────────────────────────────────────
+echo
+echo "adversarial-gate-scenarios: $((SCEN_TOTAL - SCEN_FAILURES)) passed, $SCEN_FAILURES failed"
+if [ "$SCEN_FAILURES" -eq 0 ]; then
+    emit_event "adversarial_gate_scenarios_gate" PASS "$SCEN_TOTAL/$SCEN_TOTAL scenarios behaved as predicted"
+    echo "Trace written: $TRACE_FILE"
+    exit 0
+else
+    emit_event "adversarial_gate_scenarios_gate" FAIL "$SCEN_FAILURES/$SCEN_TOTAL scenario(s) did not behave as predicted"
+    echo "Trace written: $TRACE_FILE"
+    exit 1
+fi

--- a/scripts/run_ctest_gate.sh
+++ b/scripts/run_ctest_gate.sh
@@ -74,6 +74,11 @@ if [ ! -r "$BUILD_DIR/CTestTestfile.cmake" ]; then
     exit 2
 fi
 
+# Record which exact binary this ctest run is about (D-11 BUILD FRESHNESS).
+# shellcheck source=lib/build_fingerprint.sh
+. "$REPO_ROOT/scripts/lib/build_fingerprint.sh"
+[ -x "$BUILD_DIR/eshkol-run" ] && eshkol_emit_build_fingerprint_event "$TRACE_DIR" "run_ctest_gate" "$BUILD_DIR" eshkol-run
+
 # ── the gated pillars ────────────────────────────────────────────────────
 # event_name<TAB>test-name regex<TAB>what the group certifies
 #
@@ -242,6 +247,30 @@ if [ "$TOTAL" -eq 0 ]; then
     exit 1
 fi
 
+# ── self-verdict gate ────────────────────────────────────────────────────
+# CTest's own PASS/FAIL comes from exit status (or a FAIL_REGULAR_EXPRESSION
+# a handful of tests set) — it never looks at what a test actually PRINTED.
+# scripts/check_self_verdicts.py reads the same JUnit file for the captured
+# <system-out>/<system-err> of every test CTest counted as passing, and fails
+# this gate if any of them self-reports a failure marker anyway (D-05: SW-24
+# printed `FAIL: Expected 12` on a green baseline for months).
+SELF_VERDICT_FAILURES=0
+if [ "$HAVE_JUNIT" -eq 1 ] && [ -s "$JUNIT" ]; then
+    if self_verdict_out=$(python3 "$REPO_ROOT/scripts/check_self_verdicts.py" \
+            --junit "$JUNIT" --no-trace 2>&1); then
+        emit_event "ctest_self_verdict_scan" PASS "no PASS-graded ctest test self-reports a failure"
+        emit_test_result "ctest::self-verdict-scan" PASS "clean"
+    else
+        SELF_VERDICT_FAILURES=1
+        echo "$self_verdict_out"
+        emit_event "ctest_self_verdict_scan" FAIL "a PASS-graded ctest test's own output contains a self-reported failure marker"
+        emit_test_result "ctest::self-verdict-scan" FAIL "contradiction found"
+        echo "FAILED ctest::self-verdict-scan"
+    fi
+else
+    echo "run_ctest_gate.sh: no JUnit output available (older CMake?) — self-verdict scan skipped" >&2
+fi
+
 # ── group roll-ups ───────────────────────────────────────────────────────
 GROUP_FAILURES=0
 GROUP_INFRA=0
@@ -311,7 +340,7 @@ GROUPS_EOF
 # scripts/run_all_tests.sh already guards: individual verdicts and the
 # aggregate disagreeing), and is treated as a failure rather than trusted.
 SUMMARY="$PASSED/$TOTAL ctest tests passed"
-if [ "$FAILED" -eq 0 ] && [ "$GROUP_FAILURES" -eq 0 ]; then
+if [ "$FAILED" -eq 0 ] && [ "$GROUP_FAILURES" -eq 0 ] && [ "$SELF_VERDICT_FAILURES" -eq 0 ]; then
     if [ "$CTEST_RC" -eq 0 ]; then
         emit_event "ctest_suite_green" PASS "$SUMMARY"
         emit_test_result "ctest::suite" PASS "$SUMMARY"
@@ -342,7 +371,7 @@ if [ "$FAILED" -eq 0 ] && [ "$GROUP_FAILURES" -eq 0 ]; then
     fi
 fi
 
-DETAIL="$SUMMARY; $FAILED failed; $INFRA infra; $GROUP_FAILURES group(s) failed or absent; ctest exit $CTEST_RC"
+DETAIL="$SUMMARY; $FAILED failed; $INFRA infra; $GROUP_FAILURES group(s) failed or absent; $SELF_VERDICT_FAILURES self-verdict contradiction(s); ctest exit $CTEST_RC"
 emit_event "ctest_suite_green" FAIL "$DETAIL"
 emit_test_result "ctest::suite" FAIL "$DETAIL"
 echo

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -65,6 +65,15 @@ if [ ! -x "$ESHKOL_RUN" ]; then
     exit 2
 fi
 
+# Record which exact binary this run is about (D-11 BUILD FRESHNESS): a
+# harness run against a binary that predates a rebase, or a binary that gets
+# rebuilt after this run and before a gate reads its evidence, must be
+# detectable rather than trusted. scripts/check_build_fingerprint.py reads
+# this event at gate time.
+# shellcheck source=lib/build_fingerprint.sh
+. "$REPO_ROOT/scripts/lib/build_fingerprint.sh"
+eshkol_emit_build_fingerprint_event "$TRACE_DIR" "run_icc_smoke" "$BUILD_DIR_PATH" eshkol-run
+
 if [ -z "${ESHKOL_JIT_CACHE_DIR:-}" ]; then
     if eshkol_durable_enabled; then
         ESHKOL_ICC_JIT_CACHE_DIR="$ESHKOL_ICC_WORK/jit-cache"

--- a/scripts/run_vm_parity.sh
+++ b/scripts/run_vm_parity.sh
@@ -162,6 +162,15 @@ if [ ! -x "$ESHKOL_RUN" ] || [ ! -x "$VM_BIN" ]; then
     exit 2
 fi
 
+# Record which exact binaries this run is about (D-11 BUILD FRESHNESS) —
+# scripts/check_build_fingerprint.py reads these at gate time and fails if
+# either binary is rebuilt/replaced before a gate reads this run's evidence,
+# or if it predates the source tree it claims to have been built from.
+# shellcheck source=lib/build_fingerprint.sh
+. "$REPO_ROOT/scripts/lib/build_fingerprint.sh"
+eshkol_emit_build_fingerprint_event "$TRACE_DIR" "run_vm_parity" "$BUILD_DIR" eshkol-run
+eshkol_emit_build_fingerprint_event "$TRACE_DIR" "run_vm_parity" "$BUILD_DIR" "$(basename "$VM_BIN")"
+
 if eshkol_durable_enabled; then
     WORK="$VM_PARITY_WORK/work"
     mkdir "$WORK"
@@ -202,6 +211,18 @@ else
          "the corpus loop below may still see a cold first hit under extreme load" \
          "(see $WORK/_warmup.err); the per-file retry-once still applies." >&2
 fi
+
+# Self-verdict manifest (D-05): a VERDICT<TAB>path<TAB>label row per captured
+# output this stage grades PASS-by-agreement, so
+# scripts/check_self_verdicts.py can catch what `cmp -s` structurally cannot
+# — both engines printing the IDENTICAL self-reported failure line, which
+# compares byte-equal and would otherwise pass silently. Checked at the end
+# of this script (see the final gate below).
+SELF_VERDICT_MANIFEST="$WORK/self_verdict_manifest.tsv"
+: > "$SELF_VERDICT_MANIFEST"
+record_self_verdict() { # verdict path label
+    printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$SELF_VERDICT_MANIFEST"
+}
 
 # Normalize an output capture:
 #   * strip VM banners, ESKB loader lines, GPU init logs, compiler noise;
@@ -292,6 +313,10 @@ for f in "${corpus_files[@]}"; do
     else
         report PASS "$nodeid::native-vs-vm-src" "corpus_${base}_vmsrc" \
             "identical newline-normalized output"
+        # Agreement is not correctness: two engines can print the SAME
+        # self-reported failure line and still cmp -s equal. Hand this
+        # PASS-by-agreement output to the self-verdict scanner.
+        record_self_verdict PASS "$d/native.out" "$nodeid::native-vs-vm-src"
     fi
 
     if [ $DO_ESKB -eq 1 ]; then
@@ -327,9 +352,25 @@ for f in "${corpus_files[@]}"; do
         else
             report PASS "$nodeid::native-vs-vm-eskb" "corpus_${base}_vmeskb" \
                 "identical newline-normalized output"
+            record_self_verdict PASS "$d/native.out" "$nodeid::native-vs-vm-eskb"
         fi
     fi
 done
+
+# ── self-verdict gate: agreement is not correctness ─────────────────────
+echo
+echo "== self-verdict scan: every PASS-by-agreement capture above =="
+if ! self_verdict_out=$(python3 "$REPO_ROOT/scripts/check_self_verdicts.py" \
+        --manifest "$SELF_VERDICT_MANIFEST" --no-trace --format json 2>&1); then
+    echo "$self_verdict_out"
+    report FAIL "tests/vm_parity::self-verdict-scan" "vm_parity_self_verdict_scan" \
+        "a corpus program agreed between engines while self-reporting failure — see scripts/check_self_verdicts.py output above"
+else
+    echo "$self_verdict_out" | python3 -c 'import json,sys; d=json.load(sys.stdin); print("self-verdict scan: %d artifact(s) clean" % d["examined"])' 2>/dev/null \
+        || echo "self-verdict scan: clean"
+    report PASS "tests/vm_parity::self-verdict-scan" "vm_parity_self_verdict_scan" \
+        "no PASS-by-agreement capture self-reports a failure"
+fi
 
 # ── stage 3: out-of-subset probes must fail cleanly ─────────────────────
 echo


### PR DESCRIPTION
## Summary

Delivers the remaining v1.3.5 detection items from `docs/design/FLAW_DETECTION_ROADMAP.md`
("assurance wave 2"): a self-verdict scanner (D-05), build-fingerprint gates (D-11),
adversarial gate scenarios answering ICC's weakness-map #1 item, and the readiness
artifact probe that closes the v1.3.4 battery's last open gap.

All four deliverables landed. Nothing deferred.

## 1. Self-verdict scanner (D-05)

`scripts/check_self_verdicts.py` — a test can print its own `FAIL:` line and still exit 0;
a harness that grades by exit status or cross-engine agreement calls that a pass (SW-24
printed `FAIL: Expected 12` on the VM, on a green baseline, for months). Rejects any
PASS-graded artifact whose text contains a self-reported failure marker
(`FAIL`/`FAILED`/`FAILURE`/`FAILS`/`MISMATCH`/`DIVERGENCE`), after filtering the same
zero-count-summary and decorative-banner noise `scripts/lib/test_isolation.sh` already
filters, so it doesn't cry wolf on the false positives that motivated that helper. Takes
evidence three ways: a CTest/JUnit XML file (`<system-out>`/`<system-err>` of every testcase
CTest graded PASS), a `VERDICT<TAB>path[<TAB>label]` manifest, or an ad hoc `VERDICT:PATH`
pair.

Wired into:
- `scripts/run_ctest_gate.sh` — scans the same `--output-junit` file it already produces;
  a contradiction now fails `ctest_suite_green`, not just a side note.
- `scripts/run_vm_parity.sh` — every corpus program the differential stage graded PASS by
  native/VM agreement gets a manifest row, because `cmp -s` cannot see two engines printing
  the *identical* self-reported failure line and calling that equal.

**Self-test evidence**: 7 fixtures (JUnit contradiction / JUnit clean-with-noise / manifest
divergence / manifest honest-fail-not-flagged / manifest-missing-artifact / pair-clean /
pair-contradiction), all correct — `python3 scripts/check_self_verdicts.py --self-test`.

## 2. Build fingerprints (D-11)

`scripts/lib/build_fingerprint.sh` gives every harness one call
(`eshkol_emit_build_fingerprint_event`) that appends the compiler binary's size/mtime/sha256
plus the checkout's git SHA to `scripts/icc_traces/build_fingerprint.jsonl`.
`scripts/check_build_fingerprint.py` reads it and fails when a recorded fingerprint no
longer matches the binary now on disk, or when a built binary's mtime predates the most
recent build-relevant source change (last commit touching `lib/inc/exe/cmake/CMakeLists.txt`,
or a dirty file under those paths) — the literal "ran after a rebase, never rebuilt"
incident from #418.

Wired into `run_icc_smoke.sh`, `run_vm_parity.sh` (both binaries) and `run_ctest_gate.sh`.

**Self-test evidence**: 5 pure-function fixtures + 1 end-to-end fixture against real files,
all correct. **Caught a real live incident while landing this PR**: a harness run mid-rebuild
in this session recorded a fingerprint the gate correctly flagged as no longer matching the
binary on disk — the exact defect class this gate exists to catch, on its first real use.

## 3. Adversarial gate scenarios (ICC weakness-map #1)

Investigated how ICC's own eval scenarios are built (`icc task-attempt-evals`,
`icc capability-test-coverage`): they're derived from real recorded task attempts in ICC's
own store, not from a per-repo scenario-definition file ICC reads — there is no
`.icc/eval-scenarios.yaml` equivalent. **Delivered the eshkol-side equivalent**, as the task
brief anticipated for this case: `scripts/run_adversarial_gate_scenarios.sh` proves our own
gates (`gate_no_silent_wrong.py`, `check_ledger_integrity.py`, `check_oracle_schema.py`,
`check_self_verdicts.py`, `check_build_fingerprint.py`, `check_results_schema.py`) behave
correctly under each named condition:

| # | Scenario | What it proves |
|---|---|---|
| S1 | dirty worktree | gates grade on file content, unaffected by an unrelated dirty file elsewhere |
| S2 | stale artifacts | `check_build_fingerprint.py`'s own fixtures go red on a rebuilt/replaced/deleted binary |
| S3 | model-server outage | every gate self-test passes identically with every proxy env var pointed at a closed port |
| S4 | disk pressure | `test_isolation.sh`'s pruning reclaims space under a squeezed budget, not just on paper |
| S5 | a gate actually fails | a deliberately malformed fixture is graded FAIL and stays visible, not swallowed |
| S6 | new-development orphan detection | every `--self-test`-contract gate is wired into ctest and/or CI, or it's a D-13 "gate that runs nowhere" |

All six PASS on the clean tree. S5 and S6 were manually verified to go RED (a malformed
ledger fixture; a temporarily-added orphaned gate script) before being reverted to their
clean-tree form.

## 4. Readiness artifact probe

The v1.3.4 battery scored ready/97 with one open low-severity gap:
`artifact_without_test_or_trace` on `Artifact:results-%s.json`
(`scripts/doc_audit/run_examples.py`, ~line 107), nothing validating it. ICC's suggested
action was `add_artifact_validator_or_runtime_probe`; this does both, as instructed:

- **Validator**: `scripts/doc_audit/check_results_schema.py` schema-checks
  `results-<mode>.json` — required fields/types per record, no duplicate
  `(file, start_line, mode)`, sorted by `(file, start_line)` exactly as `run_examples.py`
  itself sorts, and (given `--examples`) a record count matching the examples manifest.
  Fails closed on missing/unparseable input.
- **Trace**: `run_examples.py` now calls that validator on its own output before exiting and
  appends a `runtime_event` to `scripts/icc_traces/doc_examples.jsonl`.

**Proof the gap closes**: ran `scripts/doc_audit/extract_examples.py` for real (811 examples
discovered) and `run_examples.py --only "README.md:42"` against a real built `eshkol-run`,
producing a genuine `results-jit.json` and a real trace event. Before that trace existed,
`icc find-contract-gaps --repo eshkol-assurance2` listed `Artifact:results-%s.json` /
`run_examples.py` as a gap; after, it does not — confirmed by direct grep against the tool's
own JSON output (zero matches).

**On the readiness score itself**: `icc readiness --repo eshkol-assurance2
--target 'v1.3.4 release' --trace-dir scripts/icc_traces --format markdown` returns
`Score: 0 / blocked` both before and after in this session, because that fuzzy target's
oracle spans ~30 harnesses (differential, depth-parametric, sanitizer-fuzz, metamorphic,
reference-differential…) most of which were not re-run here — full-battery reproduction was
out of scope for one session (hours of runtime across suites unrelated to this PR). The
`find-contract-gaps` delta above is the specific, honest, reproducible proof that this PR's
fix moves the exact signal ICC used to flag the original defect; the PR does not claim to
reproduce the historical 97 number.

**Incidental finding, disclosed rather than hidden**: indexing this branch surfaced 3 new
low-severity `artifact_without_test_or_trace` gaps, all inside `check_self_verdicts.py`'s own
self-test fixtures (`divergence.log`, `clean.log`, `real_fail.log` — synthetic temp files
ICC's contract-graph heuristic reads as "artifact producers"). Same low-severity class as the
original finding, self-contained to test code, not a shipped artifact. Left as-is rather than
renamed to dodge the heuristic.

## Verification

- **ctest**: 195/195 (`scripts/run_ctest_gate.sh`, real run against a built compiler,
  including the new `ctest_self_verdict_scan` over the whole suite's JUnit output). Baseline
  before wave-2 gates were added: 190/190, isolated. (A parallel `-j8` run on this heavily
  loaded shared machine showed transient contention flakes in 4 unrelated tests; all 4 pass
  individually in isolation — not this PR's doing.)
- `python3 scripts/gate_no_silent_wrong.py --no-trace` / `--self-test` — PASS
- `python3 scripts/check_ledger_integrity.py --no-trace` / `--self-test` — PASS
- `python3 scripts/check_oracle_schema.py --no-trace` / `--self-test` — PASS
- `python3 scripts/check_self_verdicts.py --self-test` — PASS
- `python3 scripts/check_build_fingerprint.py --self-test` — PASS
- `python3 scripts/doc_audit/check_results_schema.py --self-test` — PASS
- `scripts/run_adversarial_gate_scenarios.sh` — 6/6 PASS
- `scripts/run_vm_parity.sh` — PASS end to end (including 166 PASS-by-agreement captures
  scanned clean by the new self-verdict manifest check)
- `scripts/run_icc_smoke.sh` — fingerprint wiring confirmed (12 probes completed cleanly
  before this sandbox's outbound-network restriction stopped the HTTP-dependent probes;
  unrelated to this PR)
- ICC: registered `eshkol-assurance2` → `.worktrees/v135/assurance2`, `icc index --force`,
  `icc build-memory`, `icc guard-diff` → PASS, `icc pre-commit-check` → PASS

Every new gate was confirmed to go RED on contrived-broken input (see each script's
`--self-test`) and PASS on the clean tree, per the standing rule for new gates.

## Identity / hygiene

All 6 commits authored and committed as `tsotchke <tsotchkele@gmail.com>` (verified via
`git log --format="%an <%ae> / committer %cn <%ce>"`). No attribution trailers, no emoji, no
`--no-verify`, no stash. Nothing under `/tmp`; evidence lives under
`.worktrees/v135/evidence/assurance2/`.
