### PR TITLE
fix(reader): quoted datum kinds (#229 residue); fences for #244 and R7RS 6.2.6 division signs

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -3376,6 +3376,208 @@ entries:
       on non-AArch64 targets where LLVM 21 refuses aggregate-return musttail
       (ESH-0171). Each of those was measured on this branch at 5,000,000 hops
       and each fails LOUDLY with the same fatal-signal diagnostic.
+  - id: SW-54
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "ced761fd"
+    closed_by: "branch fix/v135-correctness-debt (PR: v1.3.5 correctness debt)"
+    family: reader/quoted-data
+    renumbered_from: >-
+      SW-46 (collision). Filed as SW-46 on branch fix/v135-correctness-debt,
+      independently of two OTHER branches that each also claimed SW-46 in
+      parallel (feat/linearity-complete, renumbered to SW-53, and
+      feat/ad-structural-gate, which keeps SW-46 as the rightful holder per
+      SW-47's own reservation note and its external cross-references). Moves
+      to SW-54, the next id free across the whole ledger after SW-53. The two
+      sibling entries below (originally filed as SW-47, SW-48 in the same
+      commit) move to SW-55 and SW-56 for the same reason and are renumbered
+      together so this family's internal cross-references stay consistent.
+    title: "native: a quoted vector literal is dropped by the reader, so a function body containing (or X '#()) answers () for every input"
+    repro: >-
+      (define (g x) (or x '#()))
+      (display (g 7))
+      — build/eshkol-run -r, and the same file compiled AOT with -o. Also
+      tests/v1_3_edge_cases/quoted_datum_kinds_test.esk, whose first block is exactly
+      this shape.
+    observed: >-
+      `()`. Exit 0, empty stderr, no diagnostic. (vector? (g 7)) is #f and
+      (null? (g 7)) is #t on both native axes — the argument is gone, not merely
+      mis-printed. This is the residue of #229 that ICC's capability roadmap ranks
+      first (.icc/assistant-goals.yaml::or-null-miscompile-root-cause, "the codegen
+      path that replaces a function body containing (or X null-literal) with return
+      null"); the earlier #229 fix repaired the and/or ARGUMENT loops, one layer above
+      the surviving hole. The blast radius is wider than `or`: any quoted vector
+      literal anywhere is affected, and where its abandoned tokens do NOT balance the
+      failure flips from silent to loud — '#(1 2) at top level swallowed the rest of
+      the file and died with "source parsing failed; refusing to compile a truncated
+      program", which is why the defect read as two unrelated bugs.
+    correct: >-
+      7 — `or` returns its first non-#f operand. And, per R7RS 7.1.2 (<vector> is a
+      <datum>), (vector? '#(1 2)) is #t, (vector-length '#()) is 0, and
+      (vector-ref '#(9 8) 1) is 8. chibi-scheme 0.12.0 agrees on every row.
+    root_cause: >-
+      lib/frontend/parser.cpp parse_quoted_data_with_token() dispatched on exactly two
+      token kinds — TOKEN_LPAREN and TOKEN_QUOTE — and sent every other token to
+      parse_atom(). parse_atom() has no case for TOKEN_VECTOR_START, TOKEN_BACKQUOTE,
+      TOKEN_COMMA or TOKEN_COMMA_AT: it returns an empty node AND leaves the datum's
+      own tokens unconsumed in the stream. Whether that is silent or loud is decided
+      by whether the abandoned tokens happen to balance. `'#()` leaves exactly one,
+      the `)` the enclosing form wanted anyway, so the program compiles clean and the
+      quoted datum has silently become `()`. `'#(1 2)` leaves `1 2 )`, which
+      desynchronises the reader and truncates the program. This is the identical
+      partial-dispatch shape #229 fixed in the `and` / `or` argument loops
+      (`if LPAREN parse_list else parse_atom`), surviving one layer deeper in the
+      quoted-data reader.
+    fix: >-
+      lib/frontend/parser.cpp: parse_quoted_data_with_token() now gives every legal
+      datum token a branch. TOKEN_VECTOR_START reads a quoted vector into the same 1-D
+      ESHKOL_TENSOR_OP the quasiquote reader already builds, recursing through
+      parse_quoted_data_with_token so elements stay DATA (symbols stay symbols).
+      TOKEN_BACKQUOTE / TOKEN_COMMA / TOKEN_COMMA_AT join TOKEN_QUOTE in wrapping
+      their datum in the matching homoiconic op, so '(a ,b) reads as the list
+      (a (unquote b)) per R7RS 4.1.2 — exactly as ''a already read as (quote a), and
+      codegenQuotedOperation already had the arms to render all three.
+      lib/backend/llvm_codegen.cpp: codegenQuotedOperation() gains an ESHKOL_TENSOR_OP
+      arm that materialises the elements as a list and vectorises it through
+      eshkol_list_to_vector_sret — the same machinery codegenQuasiquote's vector
+      template uses. Without that arm the op would have hit `default` and returned
+      null, reproducing the wrong answer one layer lower.
+    evidence: >-
+      tests/v1_3_edge_cases/quoted_datum_kinds_test.esk — 41 checks, 41 passed on
+      native JIT, native AOT and the VM at ced761fd; registered in ctest as
+      v1_3_quoted_datum_kinds_runtime_smoke. Negative controls in the same file pin
+      that '(vector 1 2) is still the three-element LIST it reads as and that an
+      unquoted #(...) still evaluates its elements, so the fix cannot be satisfied by
+      guessing from the head symbol. External ground truth:
+      tests/reference-diff/corpus/0035_quote_datum_kinds.scm — 36/36 AGREE with
+      chibi-scheme 0.12.0 through scripts/run_reference_differential.sh.
+      Cross-engine: tests/vm_parity/corpus/71_quoted_datum_kinds.esk passes both
+      native-vs-vm-src and native-vs-vm-eskb (190 passed, 0 failed).
+      Full gate table in the PR body; ctest 193/193 at this SHA.
+    caught_by: [direct-measurement, reference-diff]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity, reference-diff-corpus-pre-0035]
+    notes: >-
+      Filed as one of three defects re-hunted for v1.3.5; the other two (#244 REPL
+      no-return IR, #197 srem-vs-modulo) did NOT reproduce and are recorded as fences
+      rather than fixes in d1080ce7. The lesson worth keeping is that #229 was closed
+      on the symptom's location rather than on the bug CLASS: the same
+      "dispatch on a few token kinds, fall through to parse_atom" pattern was still
+      live in the quoted-data reader, and the memory note from the original hunt even
+      lists `(or x '#())` as a known-failing shape that was never chased. Three
+      further copies of the pattern are flagged in the #229 memory note at
+      parser.cpp ~3199 and ~7343; they were not touched here and remain unaudited.
+
+  - id: SW-55
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "ced761fd"
+    closed_by: "branch fix/v135-correctness-debt (PR: v1.3.5 correctness debt)"
+    family: reader/quoted-data
+    renumbered_from: >-
+      SW-47 (collision). Filed as SW-47 on branch fix/v135-correctness-debt,
+      independently of master's own SW-47 (fix/ad-guarantees-real, PR #474,
+      which keeps that id). Moves to SW-55 — see the sibling SW-54 entry
+      above for the full renumbering rationale for this family of three.
+    title: "VM: a quoted vector literal compiles to the LIST (vector …) instead of a vector"
+    repro: >-
+      (display (vector? '#(1 2))) (newline)
+      (display (vector-ref '#(9 8) 1)) (newline)
+      (display '#(1 2)) (newline)
+      — build/eshkol-vm-standalone-test on the source, and on an --emit-eskb of it.
+    observed: >-
+      #f, (), (vector 1 2). Exit 0, no diagnostic. Native (post-SW-54) and
+      chibi-scheme both say #t, 8, #(1 2). The `()` is the worst of the three: a
+      vector-ref of a valid index answering the empty list looks like a missing entry
+      rather than a type error.
+    correct: "#t, 8, #(1 2) — R7RS 7.1.2 makes <vector> a <datum>, so '#(…) is a vector literal."
+    root_cause: >-
+      lib/backend/vm_parser.c's reader desugars `#(1 2)` into the call node
+      `(vector 1 2)`. That is correct for an evaluated position — vm_compiler.c lowers
+      the head symbol `vector` to OP_VEC_CREATE — but under `quote` the node reached
+      compile_quote()'s generic N_LIST arm, which built a cons chain from its
+      children, tag symbol included. Nothing in the tree recorded that the list had
+      come from the READER's `#(` rather than from a hand-written parenthesised form,
+      so compile_quote had no way to tell the vector literal apart from the ordinary
+      list '(vector 1 2) — which must keep quoting as a list.
+    fix: >-
+      lib/backend/vm_parser.c: Node gains an `is_vector` reader-origin marker, set only
+      by the `#(` branch of the reader — the same discipline `is_verbatim` already uses
+      to keep the vertical-bar symbol `|.|` apart from the dotted-pair delimiter. The
+      field is safe to add: every Node is calloc'd, and the macro expander's
+      macro_node_deep_copy() copies the whole struct, so it survives expansion.
+      compile_quote() gains a preceding arm that, for a marked node, allocates the
+      vector once via make-vector(n, 0) (native 218) and fills it slot by slot with
+      compile_quote'd elements. That shape keeps the operand stack at CONSTANT depth,
+      so a literal's member count is bounded by the code/constant arrays rather than by
+      ESHKOL_VM_STACK_SIZE; vm_compiler.c's evaluated path switches to the same shape
+      past VM_VEC_LITERAL_STACK_CHUNK elements, and the quoted path simply always takes
+      it rather than carrying a second threshold that could drift out of sync.
+    evidence: >-
+      tests/vm_parity/corpus/71_quoted_datum_kinds.esk — PASSED
+      native-vs-vm-src and native-vs-vm-eskb at ced761fd (scripts/run_vm_parity.sh:
+      190 passed, 0 failed). tests/v1_3_edge_cases/quoted_datum_kinds_test.esk runs
+      41/41 on eshkol-vm-standalone-test as well as on both native axes.
+      scripts/run_vm_tests.sh 73/73 source tests at this SHA.
+    caught_by: [direct-measurement, vm-parity]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity-corpus-pre-71]
+    notes: >-
+      Found while proving SW-54: the native side could not read '#(…) at all, so no
+      differential harness had ever compared the two engines on a quoted vector, and
+      the VM's independent wrong answer sat behind the native one. Fixing native alone
+      would have converted a shared blind spot into a live native-vs-VM divergence.
+
+  - id: SW-56
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "ced761fd"
+    closed_by: "branch fix/v135-correctness-debt (PR: v1.3.5 correctness debt)"
+    family: reader/quoted-data
+    renumbered_from: >-
+      SW-48 (collision). Filed as SW-48 on branch fix/v135-correctness-debt,
+      independently of master's own SW-48 (DOC-DEBT, ad/architecture family,
+      which keeps that id). Moves to SW-56 — see the sibling SW-54 entry
+      above for the full renumbering rationale for this family of three.
+    title: "VM: quoting a character or an inexact literal silently converts it — '(#\\a) becomes (97), '(2.0) becomes the exact 2"
+    repro: >-
+      (display '(#\a #\b)) (newline)
+      (display (char? (car '(#\a)))) (newline)
+      (display (exact? (car '(2.0)))) (newline)
+      — build/eshkol-vm-standalone-test.
+    observed: >-
+      (97 98), #f, #t. Exit 0, no diagnostic. Native and chibi-scheme both say
+      (a b), #t, #f. The exactness row is the more dangerous of the two: a quoted
+      table of inexact constants silently becomes a table of exact integers, and every
+      downstream exactness-contagion decision is then made on the wrong premise.
+    correct: "(a b), #t, #f — quote SELECTS a value; R7RS gives it no conversion role, and 6.2.1 exactness is a property of the literal."
+    root_cause: >-
+      lib/backend/vm_parser.c compile_quote()'s N_NUMBER arm tested only the `is_int`
+      reader flag and then fell back on a value-shape heuristic
+      (`v == (int64_t)v && fabs(v) < 1e15` -> emit an exact int). It read neither
+      `is_char` nor `is_inexact`, both of which the reader had faithfully recorded and
+      which compile_expr()'s numeric arm — the EVALUATED path for the identical
+      literal — does consult. So the same token compiled to two different values
+      depending only on whether a `quote` stood in front of it.
+    fix: >-
+      lib/backend/vm_parser.c: compile_quote()'s numeric arm now mirrors
+      compile_expr()'s discrimination exactly — is_char emits the codepoint plus
+      native 228 (the VAL_CHAR tagger, keeping the ESKB constant-pool format
+      unchanged), is_int emits the exact int64 from `ival`, and the integral-value
+      heuristic is gated behind `!is_inexact` so a literal written 2.0 stays a
+      flonum.
+    evidence: >-
+      tests/v1_3_edge_cases/quoted_datum_kinds_test.esk rows "quoted char stays a
+      char", "quoted char value", "quoted char in a vector", "quoted inexact stays
+      inexact", "quoted inexact value", "quoted exact stays exact" — 41/41 on the VM
+      and on both native axes at ced761fd. tests/vm_parity/corpus/71_quoted_datum_kinds.esk
+      carries the same predicates as a native-vs-VM differential (PASSED both routes).
+    caught_by: [direct-measurement]
+    missed_by: [icc-correctness-chain, icc-smoke, icc-readiness, ctest, vm-parity]
+    notes: >-
+      Third member of the same family as SW-54 and SW-55 and found the same way: a
+      datum's KIND being dropped at the quote boundary. Worth noting that the reader
+      was never at fault in any of the three — it recorded is_char, is_inexact and the
+      vector origin correctly every time. The loss was always downstream, in a
+      consumer that read a subset of what the reader had written down.
 
   # ───────────────────────── PARITY-RATCHET ─────────────────────────
 
@@ -3632,11 +3834,24 @@ entries:
       it makes the project look worse than it is and, more dangerously, trains readers to
       discount the 25 that are still real. Re-running found/ belongs in the parity gate.
 
-  - id: SW-46
+  - id: SW-53
     bucket: SILENT-WRONG
     status: closed
     closed_at: "feat/linearity-complete"
     closed_by: "branch feat/linearity-complete"
+    renumbered_from: >-
+      SW-46 (collision). Filed as SW-46 on branch feat/linearity-complete
+      (PR #471), independently of the SW-47 entry's note recording that id
+      as reserved for the in-flight AD carrier-wave lane
+      (feat/ad-structural-gate, PR #487). Both #471 and #487 landed on
+      master claiming SW-46, invisible to review since a textual merge does
+      not conflict on two branches picking the same next-free id. Moves to
+      SW-53, the next id free across the whole ledger (highest prior id in
+      use was SW-52): #487's entry keeps SW-46, being the rightful holder
+      per SW-47's own reservation note and carrying three external
+      cross-references (.icc/architecture-model.yaml,
+      .icc/completion-oracles.yaml, tests/ad/ad_vm_exactness_gate.sh) this
+      entry has none of.
     family: engine-parity/type-system
     title: "The bytecode VM enforced NO linear (no-cloning) typing at all: it ran a qubit clone to completion with exit 0 and no diagnostic, and --emit-eskb wrote the bytecode for it"
     repro: >-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3825,7 +3825,7 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
                 PASS_REGULAR_EXPRESSION "PASS: ad_input2_test"
                 FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
     endif()
-    # SW-46/47/48: a quoted datum must keep its KIND. Guards the #229 residue
+    # SW-54/55/56: a quoted datum must keep its KIND. Guards the #229 residue
     # ((or x '#()) answering () for every input), quoted vectors on both
     # engines, and quoted char/inexact literals on the VM.
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/v1_3_edge_cases/quoted_datum_kinds_test.esk")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3825,6 +3825,55 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
                 PASS_REGULAR_EXPRESSION "PASS: ad_input2_test"
                 FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
     endif()
+    # SW-46/47/48: a quoted datum must keep its KIND. Guards the #229 residue
+    # ((or x '#()) answering () for every input), quoted vectors on both
+    # engines, and quoted char/inexact literals on the VM.
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/v1_3_edge_cases/quoted_datum_kinds_test.esk")
+        add_test(
+            NAME v1_3_quoted_datum_kinds_runtime_smoke
+            COMMAND $<TARGET_FILE:eshkol-run>
+                    -r "${CMAKE_CURRENT_SOURCE_DIR}/tests/v1_3_edge_cases/quoted_datum_kinds_test.esk"
+                    -L"${CMAKE_CURRENT_BINARY_DIR}"
+        )
+        set_tests_properties(v1_3_quoted_datum_kinds_runtime_smoke
+            PROPERTIES
+                TIMEOUT 300
+                PASS_REGULAR_EXPRESSION "PASS: quoted_datum_kinds_test"
+                FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
+    endif()
+    # #244 fence: a no-return form terminates its basic block, so no caller may
+    # keep emitting into it. Driven through every argument/operand position a
+    # naive caller can create; a regression shows up as a verifier failure,
+    # which the FAIL_REGULAR_EXPRESSION below catches directly.
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/v1_3_edge_cases/noreturn_terminator_test.esk")
+        add_test(
+            NAME v1_3_noreturn_terminator_runtime_smoke
+            COMMAND $<TARGET_FILE:eshkol-run>
+                    -r "${CMAKE_CURRENT_SOURCE_DIR}/tests/v1_3_edge_cases/noreturn_terminator_test.esk"
+                    -L"${CMAKE_CURRENT_BINARY_DIR}"
+        )
+        set_tests_properties(v1_3_noreturn_terminator_runtime_smoke
+            PROPERTIES
+                TIMEOUT 300
+                PASS_REGULAR_EXPRESSION "PASS: noreturn_terminator_test"
+                FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|Terminator found|fatal signal")
+    endif()
+    # R7RS 6.2.6 integer-division SIGN pinning (PR #197's latent srem-vs-modulo
+    # concern). The negative-DIVISOR rows are the load-bearing ones: a bare
+    # `srem` passes every positive-divisor case.
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/numeric/integer_division_sign_test.esk")
+        add_test(
+            NAME numeric_integer_division_sign_smoke
+            COMMAND $<TARGET_FILE:eshkol-run>
+                    -r "${CMAKE_CURRENT_SOURCE_DIR}/tests/numeric/integer_division_sign_test.esk"
+                    -L"${CMAKE_CURRENT_BINARY_DIR}"
+        )
+        set_tests_properties(numeric_integer_division_sign_smoke
+            PROPERTIES
+                TIMEOUT 300
+                PASS_REGULAR_EXPRESSION "PASS: integer_division_sign_test"
+                FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
+    endif()
     # ESH-0011 portable event loop. Registered on EVERY platform, Windows
     # included: the IOCP backend must be exercised, not merely compiled, and
     # `make-pipe` now works there so the pipe round-trip is genuinely runnable.

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -34084,6 +34084,42 @@ private:
                     ESHKOL_VALUE_HEAP_PTR);
             }
 
+            case ESHKOL_TENSOR_OP: {
+                // Quoted vector literal '#(…). The reader emits a 1-D
+                // TENSOR_OP whose elements are quoted data. Materialise the
+                // elements as a list — reusing the same cons machinery every
+                // other quoted-data path uses, so symbols/chars/nested vectors
+                // all render identically — then vectorise it via
+                // eshkol_list_to_vector_sret, exactly as codegenQuasiquote's
+                // vector-template arm does. The result is a heterogeneous
+                // Scheme vector, per R7RS 6.8.
+                //
+                // Without this arm the default case returned null, so a quoted
+                // vector would silently become () — the same wrong-answer shape
+                // the reader fix removed one layer up.
+                uint64_t n = op->tensor_op.total_elements;
+                const eshkol_ast_t* elems = op->tensor_op.elements;
+                Value* acc = packNullToTaggedValue();
+                for (int64_t i = (int64_t)n - 1; i >= 0; --i) {
+                    Value* elem_val = codegenQuotedAST(&elems[i]);
+                    Value* cons_int = codegenTaggedArenaConsCellFromTaggedValue(
+                        ensureTaggedValue(elem_val), ensureTaggedValue(acc));
+                    acc = packPtrToTaggedValue(
+                        builder->CreateIntToPtr(cons_int, builder->getPtrTy()),
+                        ESHKOL_VALUE_HEAP_PTR);
+                }
+                Value* list_slot = builder->CreateAlloca(tagged_value_type);
+                Value* vec_slot = builder->CreateAlloca(tagged_value_type);
+                builder->CreateStore(ensureTaggedValue(acc), list_slot);
+                llvm::FunctionCallee l2v_fn =
+                    module->getOrInsertFunction("eshkol_list_to_vector_sret",
+                        FunctionType::get(Type::getVoidTy(*context),
+                            {PointerType::getUnqual(*context),
+                             PointerType::getUnqual(*context)}, false));
+                builder->CreateCall(l2v_fn, {vec_slot, list_slot});
+                return builder->CreateLoad(tagged_value_type, vec_slot);
+            }
+
             case ESHKOL_QUASIQUOTE_OP:
             case ESHKOL_UNQUOTE_OP:
             case ESHKOL_UNQUOTE_SPLICING_OP: {

--- a/lib/backend/vm_parser.c
+++ b/lib/backend/vm_parser.c
@@ -27,6 +27,16 @@ typedef struct Node {
                        * other post-parse dot check) tell them apart -- the native
                        * parser makes the same distinction via Token::verbatim /
                        * token_is_dot_delimiter(). */
+    int is_vector;    /* N_LIST node that the reader built from a `#(...)` VECTOR
+                       * literal rather than from a parenthesised form. The reader
+                       * desugars `#(1 2)` to the call node `(vector 1 2)`, which is
+                       * right for an evaluated position but wrong under `quote`:
+                       * R7RS 7.1.2 makes `<vector>` a `<datum>`, so `'#(1 2)` is the
+                       * VECTOR #(1 2), not the three-element list `(vector 1 2)`.
+                       * Only the reader sets this flag, so a hand-written
+                       * `'(vector 1 2)` still quotes as the list it reads as — the
+                       * same discipline `is_verbatim` uses to keep `|.|` apart from
+                       * the dotted-pair delimiter. */
     int64_t ival;     /* exact int64 value when is_int; avoids the precision loss of
                        * routing large integer literals (up to INT64_MAX) through the
                        * double numval field. */
@@ -499,6 +509,7 @@ static Node* parse_sexp(void) {
             Node* vec = make_node(N_LIST); if (!vec) return NULL;
             Node* tag = make_node(N_SYMBOL); if (!tag) { free_node(vec); return NULL; }
             strncpy(tag->symbol, "vector", 127); tag->symbol[127] = 0;
+            vec->is_vector = 1;   /* reader-origin marker; see the Node field note */
             add_child(vec, tag);
             while (1) { skip_ws(); if (!*src_ptr || *src_ptr == ')') break; Node* el = parse_sexp(); if (!el) break; add_child(vec, el); }
             if (*src_ptr == ')') src_ptr++;
@@ -1082,10 +1093,26 @@ static int needs_boxing(Node* body_nodes[], int n_bodies, const char* name) {
 static void compile_quote(FuncChunk* c, Node* datum) {
     if (!datum) { chunk_emit(c, OP_NIL, 0); return; }
     if (datum->type == N_NUMBER) {
+        /* Same three-way discrimination compile_expr() applies to an evaluated
+         * numeric literal — quoting a datum must not change WHAT the datum is.
+         * This branch used to test only `is_int`, dropping both of the other
+         * reader flags with exit 0 and no diagnostic:
+         *   - `is_char`:    '(#\a #\b) answered the integer list (97 98), so
+         *                   (char? (car '(#\a))) was #f where native and chibi
+         *                   say #t;
+         *   - `is_inexact`: '(2.0) answered the EXACT 2, so
+         *                   (exact? (car '(2.0))) was #t where native and chibi
+         *                   say #f — R7RS 6.2.1 exactness is a property of the
+         *                   literal, and quote is not an exactness conversion. */
         double v = datum->numval;
-        if (datum->is_int)
+        if (datum->is_char) {
+            /* Codepoint + native 228 tags it VAL_CHAR at runtime, exactly as
+             * the evaluated path does; keeps the ESKB constant pool unchanged. */
+            chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL((int64_t)v)));
+            chunk_emit(c, OP_NATIVE_CALL, 228);
+        } else if (datum->is_int)
             chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL(datum->ival)));
-        else if (v == (int64_t)v && fabs(v) < 1e15)
+        else if (!datum->is_inexact && v == (int64_t)v && fabs(v) < 1e15)
             chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL((int64_t)v)));
         else
             chunk_emit(c, OP_CONST, chunk_add_const(c, FLOAT_VAL(v)));
@@ -1111,6 +1138,42 @@ static void compile_quote(FuncChunk* c, Node* datum) {
             chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL(pack)));
         }
         chunk_emit(c, OP_NATIVE_CALL, 101);
+        return;
+    }
+    if (datum->type == N_LIST && datum->is_vector) {
+        /* Quoted vector literal '#(…). R7RS 7.1.2: a vector IS a datum, so the
+         * quoted form must produce a VECTOR whose elements are themselves
+         * quoted data — not the `(vector …)` list the reader's desugaring
+         * spells. Before this arm, `'#(1 2)` fell through to the N_LIST case
+         * and answered the list `(vector 1 2)` with exit 0: `(vector? '#(1 2))`
+         * was #f and `(vector-ref '#(9 8) 1)` was () where native and chibi
+         * both say #t and 8.
+         *
+         * Built at CONSTANT operand-stack depth — allocate once via
+         * make-vector(n, 0) (native 218), then fill slot by slot — so a
+         * literal's member count is bounded by the code/constant arrays rather
+         * than by ESHKOL_VM_STACK_SIZE. That is the same reason vm_compiler.c's
+         * evaluated `(vector …)` path switches to this shape past
+         * VM_VEC_LITERAL_STACK_CHUNK elements; a quoted literal is compiled
+         * once, so it simply always takes the safe shape instead of carrying a
+         * second threshold that could drift. */
+        int n_elems = datum->n_children - 1;   /* children[0] is the "vector" tag */
+        chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL(n_elems)));
+        chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL(0)));
+        chunk_emit(c, OP_NATIVE_CALL, 218);   /* make-vector(n, fill) */
+        int saved_locals = c->n_locals;
+        add_local(c, "__quoted_vec_literal__");
+        for (int i = 1; i < datum->n_children; i++) {
+            chunk_emit(c, OP_DUP, 0);                                    /* vec */
+            chunk_emit(c, OP_CONST, chunk_add_const(c, INT_VAL(i - 1))); /* idx */
+            int elem_locals = c->n_locals;
+            add_local(c, "__quoted_vec_idx__");
+            compile_quote(c, datum->children[i]);                        /* val */
+            c->n_locals = elem_locals;
+            chunk_emit(c, OP_VEC_SET, 0);   /* pops val, idx, vec; pushes nil */
+            chunk_emit(c, OP_POP, 0);       /* drop the nil */
+        }
+        c->n_locals = saved_locals;
         return;
     }
     if (datum->type == N_LIST) {

--- a/lib/frontend/parser.cpp
+++ b/lib/frontend/parser.cpp
@@ -2526,25 +2526,90 @@ static eshkol_ast_t parse_quoted_data(SchemeTokenizer& tokenizer) {
  * @brief Parses a quoted datum whose first token, @p token, has already been consumed.
  *
  * Dispatches on @p token: `(` begins a (possibly dotted) quoted list via
- * parse_quoted_list_internal(); a nested quote token recurses and wraps
- * the result in an ESHKOL_QUOTE_OP node; anything else is parsed as a
- * literal atom via parse_atom(). Unlike expression parsing, quoted data is
- * treated as literal — symbols and lists are not evaluated as calls.
+ * parse_quoted_list_internal(); `#(` begins a quoted vector literal
+ * (R7RS 7.1.2 `<vector>` is a `<datum>`) parsed into a 1-D ESHKOL_TENSOR_OP
+ * of quoted elements; a nested quote / quasiquote / unquote / unquote-splicing
+ * token recurses and wraps the result in the matching homoiconic op node
+ * (inside a quote those markers are DATA, so `'(a ,b)` is the two-element list
+ * `(a (unquote b))`); anything else is parsed as a literal atom via
+ * parse_atom(). Unlike expression parsing, quoted data is treated as literal —
+ * symbols and lists are not evaluated as calls.
+ *
+ * ESH-0229-residue: this dispatch used to be a bare
+ * `if (LPAREN) … else parse_atom(token)`, the same partial-dispatch shape that
+ * #229 fixed in the `and` / `or` argument loops. `parse_atom` has no case for
+ * TOKEN_VECTOR_START / TOKEN_BACKQUOTE / TOKEN_COMMA / TOKEN_COMMA_AT, so it
+ * returned an empty node and left the datum's own tokens in the stream. When
+ * those leftovers happened to balance — `'#()` in `(or x '#())`, whose only
+ * leftover is the `)` the enclosing form wanted anyway — the program compiled
+ * and ran with exit 0 while the quoted datum had silently become `()`: the
+ * function body `(or x '#())` answered `()` for every input, including `(g 7)`.
+ * When they did not balance, the whole rest of the file was swallowed and the
+ * compile failed with "source parsing failed". One partial dispatch, two
+ * failure modes; the fix is to give every legal datum token a real branch.
  */
 static eshkol_ast_t parse_quoted_data_with_token(SchemeTokenizer& tokenizer, Token token) {
     if (token.type == TOKEN_LPAREN) {
         // Parse a list without requiring a symbol as first element
         return parse_quoted_list_internal(tokenizer);
-    } else if (token.type == TOKEN_QUOTE) {
-        // Nested quote - parse recursively
-        eshkol_ast_t quoted = parse_quoted_data(tokenizer);
-        eshkol_ast_t ast;
+    } else if (token.type == TOKEN_VECTOR_START) {
+        // Quoted vector literal: '#(1 two "three"). R7RS 7.1.2 makes a vector
+        // a datum, so its elements are quoted data (symbols stay symbols, not
+        // variable references) and nesting is arbitrary. Represented as the
+        // same 1-D TENSOR_OP the quasiquote reader builds, which
+        // codegenQuotedOperation materialises into a Scheme vector.
+        std::vector<eshkol_ast_t> elements;
+        while (true) {
+            Token elem_token = tokenizer.nextToken();
+            if (elem_token.type == TOKEN_RPAREN) break;
+            if (elem_token.type == TOKEN_EOF) {
+                PARSE_ERROR_AT(elem_token,
+                    "unexpected end of input in quoted vector #(...)");
+                return {.type = ESHKOL_INVALID};
+            }
+            eshkol_ast_t elem = parse_quoted_data_with_token(tokenizer, elem_token);
+            if (elem.type == ESHKOL_INVALID) return elem;
+            elements.push_back(elem);
+        }
+        eshkol_ast_t ast = {};
         ast.type = ESHKOL_OP;
-        ast.operation.op = ESHKOL_QUOTE_OP;
+        ast.line = token.line;
+        ast.column = token.column;
+        ast.operation.op = ESHKOL_TENSOR_OP;
+        ast.operation.tensor_op.num_dimensions = 1;
+        ast.operation.tensor_op.dimensions = new uint64_t[1];
+        ast.operation.tensor_op.dimensions[0] = elements.size();
+        ast.operation.tensor_op.total_elements = elements.size();
+        ast.operation.tensor_op.elements =
+            elements.empty() ? nullptr : new eshkol_ast_t[elements.size()];
+        for (size_t i = 0; i < elements.size(); i++) {
+            ast.operation.tensor_op.elements[i] = elements[i];
+        }
+        return ast;
+    } else if (token.type == TOKEN_QUOTE ||
+               token.type == TOKEN_BACKQUOTE ||
+               token.type == TOKEN_COMMA ||
+               token.type == TOKEN_COMMA_AT) {
+        // Nested reader macro inside quoted data. All four are DATA here, not
+        // evaluation: R7RS 4.1.2 says `''a` reads as `(quote a)`, and by the
+        // same rule `'(a ,b)` reads as `(a (unquote b))`. Wrap the inner datum
+        // in the matching homoiconic op — codegenQuotedOperation renders each
+        // as the two-element list `(<tag> <datum>)`.
+        eshkol_ast_t inner = parse_quoted_data(tokenizer);
+        if (inner.type == ESHKOL_INVALID) return inner;
+        eshkol_ast_t ast = {};
+        ast.type = ESHKOL_OP;
+        ast.line = token.line;
+        ast.column = token.column;
+        ast.operation.op =
+            token.type == TOKEN_QUOTE     ? ESHKOL_QUOTE_OP :
+            token.type == TOKEN_BACKQUOTE ? ESHKOL_QUASIQUOTE_OP :
+            token.type == TOKEN_COMMA     ? ESHKOL_UNQUOTE_OP :
+                                            ESHKOL_UNQUOTE_SPLICING_OP;
         ast.operation.call_op.func = nullptr;
         ast.operation.call_op.num_vars = 1;
         ast.operation.call_op.variables = new eshkol_ast_t[1];
-        ast.operation.call_op.variables[0] = quoted;
+        ast.operation.call_op.variables[0] = inner;
         return ast;
     } else {
         // Atom

--- a/tests/numeric/integer_division_sign_test.esk
+++ b/tests/numeric/integer_division_sign_test.esk
@@ -1,0 +1,77 @@
+;; integer_division_sign_test.esk — R7RS 6.2.6 integer-division SIGN pinning.
+;;
+;; PR #197 flagged as latent the possibility that `ArithmeticCodegen::mod` and
+;; the `modulo` lowering emit a bare LLVM `srem`. `srem` is C remainder: the
+;; sign of the result follows the DIVIDEND. R7RS `modulo` / `floor-remainder`
+;; require the sign to follow the DIVISOR, and only `remainder` /
+;; `truncate-remainder` follow the dividend. A bare `srem` would therefore
+;; answer -1 for (modulo -7 3) where the spec says 2 — a wrong value with exit
+;; zero and no diagnostic.
+;;
+;; Measurement at the head of this branch says both native paths and the VM
+;; already apply the floor-mod sign correction, so this file is a FENCE, not a
+;; fix: it pins the exact spec cases so a future "simplification" back to a
+;; bare srem cannot land silently. The negative-DIVISOR rows are the ones that
+;; matter — every engine gets (modulo -7 3) right by accident when the sign
+;; correction is missing but the divisor is positive and the dividend is not.
+;;
+;; Ground truth is R7RS 6.2.6 plus chibi-scheme 0.12.0; the same assertions
+;; ride the reference-differential corpus as
+;; tests/reference-diff/corpus/0036_numeric_division_signs.scm.
+
+(define passed 0)
+(define failed 0)
+(define (check name cond)
+  (if cond
+      (begin (display "PASS: ") (display name) (newline)
+             (set! passed (+ passed 1)))
+      (begin (display "FAIL: ") (display name) (newline)
+             (set! failed (+ failed 1)))))
+
+;; --- modulo: sign follows the DIVISOR (R7RS 6.2.6) ---
+(check "(modulo 7 3) = 1"     (= (modulo 7 3) 1))
+(check "(modulo -7 3) = 2"    (= (modulo -7 3) 2))
+(check "(modulo 7 -3) = -2"   (= (modulo 7 -3) -2))
+(check "(modulo -7 -3) = -1"  (= (modulo -7 -3) -1))
+(check "(modulo 6 3) = 0"     (= (modulo 6 3) 0))
+(check "(modulo -6 3) = 0"    (= (modulo -6 3) 0))
+(check "(modulo 6 -3) = 0"    (= (modulo 6 -3) 0))
+(check "(modulo 0 3) = 0"     (= (modulo 0 3) 0))
+(check "(modulo 1 -3) = -2"   (= (modulo 1 -3) -2))
+(check "(modulo -1 3) = 2"    (= (modulo -1 3) 2))
+
+;; --- remainder: sign follows the DIVIDEND ---
+(check "(remainder 7 3) = 1"     (= (remainder 7 3) 1))
+(check "(remainder -7 3) = -1"   (= (remainder -7 3) -1))
+(check "(remainder 7 -3) = 1"    (= (remainder 7 -3) 1))
+(check "(remainder -7 -3) = -1"  (= (remainder -7 -3) -1))
+(check "(remainder 0 3) = 0"     (= (remainder 0 3) 0))
+
+;; The two disagree exactly when the operands' signs differ. If a future
+;; refactor collapses them onto one lowering, these four rows break.
+(check "modulo /= remainder (-7 3)" (not (= (modulo -7 3) (remainder -7 3))))
+(check "modulo /= remainder (7 -3)" (not (= (modulo 7 -3) (remainder 7 -3))))
+(check "modulo = remainder (7 3)"   (= (modulo 7 3) (remainder 7 3)))
+(check "modulo = remainder (-7 -3)" (= (modulo -7 -3) (remainder -7 -3)))
+
+;; --- quotient: TRUNCATES toward zero ---
+(check "(quotient 7 3) = 2"     (= (quotient 7 3) 2))
+(check "(quotient -7 3) = -2"   (= (quotient -7 3) -2))
+(check "(quotient 7 -3) = -2"   (= (quotient 7 -3) -2))
+(check "(quotient -7 -3) = 2"   (= (quotient -7 -3) 2))
+
+;; --- the division identities the two families must satisfy ---
+(check "n = d*q + r (-7 3)"  (= -7 (+ (* 3 (quotient -7 3)) (remainder -7 3))))
+(check "n = d*q + r (7 -3)"  (= 7 (+ (* -3 (quotient 7 -3)) (remainder 7 -3))))
+
+;; --- bignum operands take the runtime dispatcher, not the int64 fast path ---
+(check "bignum modulo neg dividend" (= (modulo (- (expt 10 20)) 3) 2))
+(check "bignum modulo neg divisor"  (= (modulo (expt 10 20) -3) -2))
+(check "bignum remainder neg"       (= (remainder (- (expt 10 20)) 3) -1))
+
+;; --- Summary ---
+(display "Results: ") (display passed) (display " passed, ")
+(display failed) (display " failed") (newline)
+(if (= failed 0)
+    (begin (display "PASS: integer_division_sign_test") (newline) (exit 0))
+    (begin (display "FAIL: integer_division_sign_test") (newline) (exit 1)))

--- a/tests/reference-diff/corpus/0035_quote_datum_kinds.scm
+++ b/tests/reference-diff/corpus/0035_quote_datum_kinds.scm
@@ -1,6 +1,6 @@
 ;; quote / datum_kinds  (R7RS-small portable; reference-differential corpus)
 ;;
-;; SW-46/47/48. R7RS 7.1.2 makes <vector> a <datum>, so '#(...) is a vector
+;; SW-54/55/56. R7RS 7.1.2 makes <vector> a <datum>, so '#(...) is a vector
 ;; literal, and 4.1.2 makes ' , ` inside quoted data ordinary list structure.
 ;; Predicates rather than printed datums, so a divergence is a value mismatch
 ;; and not a printing convention.

--- a/tests/reference-diff/corpus/0035_quote_datum_kinds.scm
+++ b/tests/reference-diff/corpus/0035_quote_datum_kinds.scm
@@ -1,0 +1,33 @@
+;; quote / datum_kinds  (R7RS-small portable; reference-differential corpus)
+;;
+;; SW-46/47/48. R7RS 7.1.2 makes <vector> a <datum>, so '#(...) is a vector
+;; literal, and 4.1.2 makes ' , ` inside quoted data ordinary list structure.
+;; Predicates rather than printed datums, so a divergence is a value mismatch
+;; and not a printing convention.
+(display (vector? '#(1 2)))(newline)
+(display (vector-length '#(1 2)))(newline)
+(display (vector-ref '#(9 8) 1))(newline)
+(display (vector? '#()))(newline)
+(display (vector-length '#()))(newline)
+(display (null? '#()))(newline)
+(display (equal? '#(1 2) (vector 1 2)))(newline)
+(display (symbol? (vector-ref '#(a b) 0)))(newline)
+(display (eq? (vector-ref '#(a b) 1) 'b))(newline)
+(display (string? (vector-ref '#("x") 0)))(newline)
+(display (vector? (vector-ref '#(#(1) #(2)) 0)))(newline)
+(display (vector-ref (vector-ref '#(#(1) #(2)) 1) 0))(newline)
+(display (vector? (car (cdr '(a #(1 2) b)))))(newline)
+(display (length '(a #(1 2) b)))(newline)
+(display (char? (car '(#\a))))(newline)
+(display (char? (vector-ref '#(#\a #\b) 1)))(newline)
+(display (exact? (car '(2.0))))(newline)
+(display (exact? (car '(2))))(newline)
+(display (list? ''a))(newline)
+(display (eq? (car ''a) 'quote))(newline)
+(display (length '(a ,b)))(newline)
+(display (eq? (car (car (cdr '(a ,b)))) 'unquote))(newline)
+(display (eq? (car (car (cdr '(a `b)))) 'quasiquote))(newline)
+(display (list? '(vector 1 2)))(newline)
+(display (vector? '(vector 1 2)))(newline)
+(display (eq? (car '(vector 1 2)) 'vector))(newline)
+(display (length '(vector 1 2)))(newline)

--- a/tests/reference-diff/corpus/0036_numeric_division_signs.scm
+++ b/tests/reference-diff/corpus/0036_numeric_division_signs.scm
@@ -1,0 +1,34 @@
+;; numeric / division_signs  (R7RS-small portable; reference-differential corpus)
+;;
+;; R7RS 6.2.6: `modulo` / `floor-remainder` take the sign of the DIVISOR,
+;; `remainder` / `truncate-remainder` take the sign of the DIVIDEND, and
+;; `quotient` truncates toward zero. A lowering that emits a bare machine
+;; remainder (`srem`, C semantics) passes every positive-divisor case and
+;; fails only the rows below — which is why the negative-divisor rows are
+;; here rather than one representative case per operator.
+(display (modulo 7 3))(newline)
+(display (modulo -7 3))(newline)
+(display (modulo 7 -3))(newline)
+(display (modulo -7 -3))(newline)
+(display (modulo 1 -3))(newline)
+(display (modulo -1 3))(newline)
+(display (modulo -6 3))(newline)
+(display (remainder 7 3))(newline)
+(display (remainder -7 3))(newline)
+(display (remainder 7 -3))(newline)
+(display (remainder -7 -3))(newline)
+(display (quotient 7 3))(newline)
+(display (quotient -7 3))(newline)
+(display (quotient 7 -3))(newline)
+(display (quotient -7 -3))(newline)
+(display (floor-quotient 7 -3))(newline)
+(display (floor-remainder 7 -3))(newline)
+(display (floor-quotient -7 3))(newline)
+(display (floor-remainder -7 3))(newline)
+(display (truncate-quotient 7 -3))(newline)
+(display (truncate-remainder 7 -3))(newline)
+(display (= -7 (+ (* 3 (quotient -7 3)) (remainder -7 3))))(newline)
+(display (= 7 (+ (* -3 (quotient 7 -3)) (remainder 7 -3))))(newline)
+(display (modulo (- (expt 10 20)) 3))(newline)
+(display (modulo (expt 10 20) -3))(newline)
+(display (remainder (- (expt 10 20)) 3))(newline)

--- a/tests/v1_3_edge_cases/noreturn_terminator_test.esk
+++ b/tests/v1_3_edge_cases/noreturn_terminator_test.esk
@@ -1,0 +1,85 @@
+;; noreturn_terminator_test.esk — #244 regression fence.
+;;
+;; A no-return form (`raise`, `error`) lowers to a call plus `unreachable`,
+;; which TERMINATES the current LLVM basic block. Any caller that keeps
+;; emitting into that block afterwards produces IR the verifier rejects with
+;; "Terminator found in the middle of a basic block!". #244 was exactly that:
+;; codegenRaise left the IRBuilder's insert point inside the block it had just
+;; terminated, so every naive caller — a `display` whose argument raises, an
+;; argument slot mid-call, a `let` initialiser — appended dead IR after the
+;; terminator. Commit 89e51ff7 fixed the contract (switch to a fresh
+;; `post_raise_dead` block immediately after CreateUnreachable, the pattern
+;; codegenError already used).
+;;
+;; The fix is a CONTRACT, not a case, so this test is a matrix rather than a
+;; single probe: it drives a no-return form through every emission context a
+;; naive caller can create. It is intentionally structured so a verifier
+;; failure is loud — the run aborts before the trailing PASS line, and the
+;; ctest FAIL_REGULAR_EXPRESSION matches "LLVM module verification failed".
+;;
+;; Every raise is caught by `guard`, so a clean run reaches the end and prints
+;; the summary. Any NEW no-return codegen helper (abort, longjmp, ...) that
+;; forgets to switch blocks should get a row here.
+
+(define passed 0)
+(define failed 0)
+(define (check name cond)
+  (if cond
+      (begin (display "PASS: ") (display name) (newline)
+             (set! passed (+ passed 1)))
+      (begin (display "FAIL: ") (display name) (newline)
+             (set! failed (+ failed 1)))))
+
+;; caught? — #t when the thunk raises and the guard catches it.
+(define (caught? thunk)
+  (guard (e (#t #t))
+    (thunk)
+    #f))
+
+;; --- raise in every argument / operand position a naive caller can emit ---
+(check "raise as display argument"   (caught? (lambda () (display (raise "x")))))
+(check "raise as arithmetic operand" (caught? (lambda () (+ 1 (raise "x")))))
+(check "raise as car argument"       (caught? (lambda () (car (raise "x")))))
+(check "raise mid list constructor"  (caught? (lambda () (list 1 (raise "x") 3))))
+(check "raise mid vector literal"    (caught? (lambda () (vector 1 (raise "x")))))
+(check "raise as string-append arg"  (caught? (lambda () (string-append "a" (raise "x")))))
+(check "raise inside apply args"     (caught? (lambda () (apply + (list 1 (raise "x"))))))
+(check "raise as let initialiser"    (caught? (lambda () (let ((y (raise "x"))) y))))
+(check "raise as if test"            (caught? (lambda () (if (raise "x") 1 2))))
+(check "raise as cond test"          (caught? (lambda () (cond ((raise "x") 1) (else 2)))))
+(check "raise as and operand"        (caught? (lambda () (and 1 (raise "x")))))
+(check "raise as or operand"         (caught? (lambda () (or #f (raise "x")))))
+(check "raise mid begin"             (caught? (lambda () (begin (raise "x") 5))))
+(check "raise in immediate lambda"   (caught? (lambda () ((lambda () (raise "x"))))))
+(check "raise inside call/cc"        (caught? (lambda () (call/cc (lambda (k) (raise "x"))))))
+(check "raise inside dynamic-wind"   (caught? (lambda ()
+                                                (dynamic-wind (lambda () 1)
+                                                              (lambda () (raise "x"))
+                                                              (lambda () 2)))))
+(check "raise inside a named let"    (caught? (lambda ()
+                                                (let loop ((i 0))
+                                                  (if (> i 2) (raise "x") (loop (+ i 1)))))))
+
+;; --- error takes the same no-return path; same matrix, abbreviated ---
+(check "error as arithmetic operand" (caught? (lambda () (+ 1 (error "bad")))))
+(check "error mid begin"             (caught? (lambda () (begin (error "bad") 5))))
+(check "error with irritants"        (caught? (lambda () (error "bad" 1 2))))
+
+;; --- a procedure whose body raises unconditionally ---
+;; The tail position gets `unreachable` as the function's own terminator; the
+;; caller must still be able to emit its own continuation.
+(define (always-raises) (raise "x"))
+(define (always-errors) (error "x"))
+(check "unconditional raise body"    (caught? (lambda () (always-raises))))
+(check "unconditional error body"    (caught? (lambda () (always-errors))))
+(check "raise body value is used"    (caught? (lambda () (+ 1 (always-raises)))))
+
+;; --- reaching this point at all is the structural half of the test ---
+(check "module survived verification" #t)
+
+;; --- Summary ---
+(display "Results: ") (display passed) (display " passed, ")
+(display failed) (display " failed") (newline)
+(if (= failed 0)
+    (begin (display "PASS: noreturn_terminator_test") (newline) (exit 0))
+    (begin (display "FAIL: noreturn_terminator_test") (newline) (exit 1)))

--- a/tests/v1_3_edge_cases/quoted_datum_kinds_test.esk
+++ b/tests/v1_3_edge_cases/quoted_datum_kinds_test.esk
@@ -1,0 +1,103 @@
+;; quoted_datum_kinds_test.esk — SW-46 / SW-47 / SW-48 regression.
+;;
+;; A quoted datum must keep its KIND. `quote` selects a value; it never
+;; converts one datum kind into another. Three shipped defects broke that:
+;;
+;;   SW-46 (native)  the reader's quoted-data dispatch had no branch for `#(`,
+;;                   so `'#(...)` fell through to parse_atom, which returns an
+;;                   empty node and leaves the vector's own tokens in the
+;;                   stream. Where the leftovers happened to balance — `'#()`
+;;                   as the last argument of an enclosing form — the program
+;;                   compiled and ran with exit 0 while the datum had silently
+;;                   become `()`. This is the residue of #229: the function
+;;                   body `(or x '#())` answered `()` for EVERY input,
+;;                   `(g 7)` included.
+;;   SW-47 (VM)      the VM reader desugars `#(1 2)` to the call node
+;;                   `(vector 1 2)`; compile_quote then quoted that node as a
+;;                   LIST, so `(vector? '#(1 2))` was #f and
+;;                   `(vector-ref '#(9 8) 1)` was ().
+;;   SW-48 (VM)      compile_quote's numeric arm read only the `is_int` reader
+;;                   flag, dropping `is_char` and `is_inexact`: `'(#\a)` became
+;;                   the integer list `(97)` and `'(2.0)` became the EXACT 2.
+;;
+;; Ground truth for every check below is chibi-scheme 0.12.0; the same
+;; assertions ride the reference-differential corpus
+;; (tests/reference-diff/corpus/0035_quote_datum_kinds.scm) and the VM parity
+;; corpus (tests/vm_parity/corpus/quoted_datum_kinds.esk).
+
+(define passed 0)
+(define failed 0)
+(define (check name cond)
+  (if cond
+      (begin (display "PASS: ") (display name) (newline)
+             (set! passed (+ passed 1)))
+      (begin (display "FAIL: ") (display name) (newline)
+             (set! failed (+ failed 1)))))
+
+;; --- SW-46: the #229 residue itself. The body must return its argument. ---
+(define (or-vec x) (or x '#()))
+(define (or-nil x) (or x '()))
+(define (and-vec x) (and x '#()))
+
+(check "(or x '#()) returns x"        (= (or-vec 7) 7))
+(check "(or x '#()) fallback is a vector" (vector? (or-vec #f)))
+(check "(or x '#()) fallback is empty"    (= (vector-length (or-vec #f)) 0))
+(check "(or x '()) returns x"         (= (or-nil 7) 7))
+(check "(or x '()) fallback is null"  (null? (or-nil #f)))
+(check "(and x '#()) is the vector"   (vector? (and-vec 7)))
+(check "(and #f '#()) is #f"          (not (and-vec #f)))
+
+;; --- Quoted vectors are vectors, everywhere they can appear ---
+(check "'#(1 2) is a vector"          (vector? '#(1 2)))
+(check "'#(1 2) length"               (= (vector-length '#(1 2)) 2))
+(check "'#(9 8) ref 0"                (= (vector-ref '#(9 8) 0) 9))
+(check "'#(9 8) ref 1"                (= (vector-ref '#(9 8) 1) 8))
+(check "'#() is a vector"             (vector? '#()))
+(check "'#() is empty"                (= (vector-length '#()) 0))
+(check "'#() is not null"             (not (null? '#())))
+(check "quoted vector equal? built"   (equal? '#(1 2) (vector 1 2)))
+(check "vector inside quoted list"    (vector? (car (cdr '(a #(1 2) b)))))
+(check "quoted list around vector"    (= (length '(a #(1 2) b)) 3))
+(check "nested quoted vectors"        (vector? (vector-ref '#(#(1) #(2)) 0)))
+(check "nested quoted vector ref"     (= (vector-ref (vector-ref '#(#(1) #(2)) 1) 0) 2))
+
+;; Elements of a quoted vector are DATA: symbols stay symbols.
+(check "quoted vector holds symbols"  (symbol? (vector-ref '#(a b) 0)))
+(check "quoted vector symbol value"   (eq? (vector-ref '#(a b) 1) 'b))
+(check "quoted vector holds strings"  (string? (vector-ref '#("x") 0)))
+(check "quoted vector holds booleans" (eq? (vector-ref '#(#t) 0) #t))
+(check "quoted vector holds a list"   (list? (vector-ref '#((1 2)) 0)))
+
+;; --- SW-48: char-ness and exactness survive quoting ---
+(check "quoted char stays a char"     (char? (car '(#\a))))
+(check "quoted char value"            (char=? (car '(#\a)) #\a))
+(check "quoted char in a vector"      (char? (vector-ref '#(#\a #\b) 0)))
+(check "quoted inexact stays inexact" (not (exact? (car '(2.0)))))
+(check "quoted inexact value"         (= (car '(2.0)) 2))
+(check "quoted exact stays exact"     (exact? (car '(2))))
+
+;; --- Nested reader macros under quote are DATA, not evaluation (R7RS 4.1.2) ---
+(check "''a is a list"                (list? ''a))
+(check "''a head is quote"            (eq? (car ''a) 'quote))
+(check "'(a ,b) length"               (= (length '(a ,b)) 2))
+(check "'(a ,b) tail head is unquote" (eq? (car (car (cdr '(a ,b)))) 'unquote))
+(check "'(a `b) tail is quasiquote"   (eq? (car (car (cdr '(a `b)))) 'quasiquote))
+
+;; --- Negative controls: only the READER's #( makes a vector ---
+;; A hand-written (vector 1 2) inside quote is still the three-element LIST it
+;; reads as. If this ever flips, the fix has started guessing from the head
+;; symbol instead of the reader's own record of what it read.
+(check "'(vector 1 2) is a list"      (list? '(vector 1 2)))
+(check "'(vector 1 2) is not a vector" (not (vector? '(vector 1 2))))
+(check "'(vector 1 2) car is a symbol" (eq? (car '(vector 1 2)) 'vector))
+(check "'(vector 1 2) length"         (= (length '(vector 1 2)) 3))
+;; And an UNQUOTED #( still evaluates its elements into a vector.
+(check "unquoted #(1 2) is a vector"  (vector? #(1 2)))
+(check "unquoted #( evaluates"        (= (vector-ref #((+ 1 2)) 0) 3))
+
+;; --- Summary ---
+(display "Results: ") (display passed) (display " passed, ")
+(display failed) (display " failed") (newline)
+(if (= failed 0)
+    (begin (display "PASS: quoted_datum_kinds_test") (newline) (exit 0))
+    (begin (display "FAIL: quoted_datum_kinds_test") (newline) (exit 1)))

--- a/tests/v1_3_edge_cases/quoted_datum_kinds_test.esk
+++ b/tests/v1_3_edge_cases/quoted_datum_kinds_test.esk
@@ -1,9 +1,9 @@
-;; quoted_datum_kinds_test.esk — SW-46 / SW-47 / SW-48 regression.
+;; quoted_datum_kinds_test.esk — SW-54 / SW-55 / SW-56 regression.
 ;;
 ;; A quoted datum must keep its KIND. `quote` selects a value; it never
 ;; converts one datum kind into another. Three shipped defects broke that:
 ;;
-;;   SW-46 (native)  the reader's quoted-data dispatch had no branch for `#(`,
+;;   SW-54 (native)  the reader's quoted-data dispatch had no branch for `#(`,
 ;;                   so `'#(...)` fell through to parse_atom, which returns an
 ;;                   empty node and leaves the vector's own tokens in the
 ;;                   stream. Where the leftovers happened to balance — `'#()`
@@ -12,11 +12,11 @@
 ;;                   become `()`. This is the residue of #229: the function
 ;;                   body `(or x '#())` answered `()` for EVERY input,
 ;;                   `(g 7)` included.
-;;   SW-47 (VM)      the VM reader desugars `#(1 2)` to the call node
+;;   SW-55 (VM)      the VM reader desugars `#(1 2)` to the call node
 ;;                   `(vector 1 2)`; compile_quote then quoted that node as a
 ;;                   LIST, so `(vector? '#(1 2))` was #f and
 ;;                   `(vector-ref '#(9 8) 1)` was ().
-;;   SW-48 (VM)      compile_quote's numeric arm read only the `is_int` reader
+;;   SW-56 (VM)      compile_quote's numeric arm read only the `is_int` reader
 ;;                   flag, dropping `is_char` and `is_inexact`: `'(#\a)` became
 ;;                   the integer list `(97)` and `'(2.0)` became the EXACT 2.
 ;;
@@ -34,7 +34,7 @@
       (begin (display "FAIL: ") (display name) (newline)
              (set! failed (+ failed 1)))))
 
-;; --- SW-46: the #229 residue itself. The body must return its argument. ---
+;; --- SW-54: the #229 residue itself. The body must return its argument. ---
 (define (or-vec x) (or x '#()))
 (define (or-nil x) (or x '()))
 (define (and-vec x) (and x '#()))
@@ -68,7 +68,7 @@
 (check "quoted vector holds booleans" (eq? (vector-ref '#(#t) 0) #t))
 (check "quoted vector holds a list"   (list? (vector-ref '#((1 2)) 0)))
 
-;; --- SW-48: char-ness and exactness survive quoting ---
+;; --- SW-56: char-ness and exactness survive quoting ---
 (check "quoted char stays a char"     (char? (car '(#\a))))
 (check "quoted char value"            (char=? (car '(#\a)) #\a))
 (check "quoted char in a vector"      (char? (vector-ref '#(#\a #\b) 0)))

--- a/tests/vm_parity/corpus/71_quoted_datum_kinds.esk
+++ b/tests/vm_parity/corpus/71_quoted_datum_kinds.esk
@@ -1,4 +1,4 @@
-; SW-46 / SW-47 / SW-48: a quoted datum keeps its KIND on both engines.
+; SW-54 / SW-55 / SW-56: a quoted datum keeps its KIND on both engines.
 ;
 ; Before the fix the two substrates disagreed three ways, all silently and all
 ; with exit 0:

--- a/tests/vm_parity/corpus/71_quoted_datum_kinds.esk
+++ b/tests/vm_parity/corpus/71_quoted_datum_kinds.esk
@@ -1,0 +1,31 @@
+; SW-46 / SW-47 / SW-48: a quoted datum keeps its KIND on both engines.
+;
+; Before the fix the two substrates disagreed three ways, all silently and all
+; with exit 0:
+;   native  '#(...) had no reader branch at all, so (or x '#()) answered ()
+;           for every input;
+;   VM      '#(1 2) quoted as the LIST (vector 1 2), so (vector? '#(1 2)) was #f
+;           and (vector-ref '#(9 8) 1) was ();
+;   VM      '(#\a) quoted as the integer list (97), and '(2.0) as the EXACT 2.
+;
+; Results are printed as predicates and lengths rather than as the datum
+; itself, so a divergence shows up as a value mismatch and not merely as a
+; printing difference.
+(define (or-vec x) (or x '#()))
+(display (or-vec 7)) (newline)
+(display (vector? (or-vec #f))) (newline)
+(display (vector-length (or-vec #f))) (newline)
+(display (vector? '#(1 2))) (newline)
+(display (vector-length '#(1 2))) (newline)
+(display (vector-ref '#(9 8) 1)) (newline)
+(display (vector? '#())) (newline)
+(display (null? '#())) (newline)
+(display (symbol? (vector-ref '#(a b) 0))) (newline)
+(display (vector? (vector-ref '#(#(1) #(2)) 0))) (newline)
+(display (char? (car '(#\a)))) (newline)
+(display (char? (vector-ref '#(#\a #\b) 1))) (newline)
+(display (exact? (car '(2.0)))) (newline)
+(display (exact? (car '(2)))) (newline)
+(display (list? '(vector 1 2))) (newline)
+(display (vector? '(vector 1 2))) (newline)
+(display (length '(vector 1 2))) (newline)


### PR DESCRIPTION
Three long-standing v1.3.5 correctness debts, re-hunted from scratch at `origin/master` (4bf871a0). One reproduced and is fixed; two did not reproduce and are proved gone with evidence, then fenced so they cannot come back silently.

They are delivered as one PR because they are **disjoint**: only defect 1 touches production code (`lib/frontend/parser.cpp`, `lib/backend/llvm_codegen.cpp`, `lib/backend/vm_parser.c`). Defects 2 and 3 add tests only. The three commits split along exactly that line — fix, fences, ledger.

---

## Defect 1 — `(or X '())` miscompile — REPRODUCED and FIXED

ICC's capability roadmap ranks this first (`.icc/assistant-goals.yaml::or-null-miscompile-root-cause`: "the codegen path that replaces a function body containing `(or X null-literal)` with return null"). Lineage: issue #229, whose earlier and/or fix landed but left a residue.

**Reproduced.** Not with `'()` — that shape was genuinely repaired by the #229 fix and is verified correct here. It reproduces with the **vector** null-literal, which the #229 hunt listed as a failing shape and never chased:

```scheme
(define (g x) (or x '#()))
(display (g 7))   ; => ()   ... should be 7
```

Exit 0, empty stderr, no diagnostic. `(vector? (g 7))` is `#f` and `(null? (g 7))` is `#t` on both native axes — the argument is gone, not merely mis-printed.

**Root cause.** `parse_quoted_data_with_token()` dispatched on exactly two token kinds — `(` and `'` — and sent everything else to `parse_atom()`. `parse_atom()` has no case for `TOKEN_VECTOR_START`, `TOKEN_BACKQUOTE`, `TOKEN_COMMA` or `TOKEN_COMMA_AT`: it returns an empty node **and leaves the datum's own tokens in the stream**. That is the identical partial-dispatch shape #229 fixed in the `and`/`or` argument loops, surviving one layer deeper, and whether it is silent or loud is decided by whether the abandoned tokens happen to balance:

| shape | leftover tokens | outcome |
|---|---|---|
| `'#()` as a trailing argument | just `)`, which the enclosing form wanted anyway | **silent wrong answer, exit 0** |
| `'#(1 2)` anywhere | `1 2 )` | reader desynchronises; `source parsing failed; refusing to compile a truncated program` |

Two failure modes from one hole is why this read as two unrelated bugs for so long.

**Two more, found behind it.** Proving the native side exposed that the VM independently gets quoted data wrong — and no differential had ever compared the engines here, because native could not read a quoted vector at all:

- `'#(1 2)` compiles to the **list** `(vector 1 2)` on the VM, so `(vector? '#(1 2))` was `#f` and `(vector-ref '#(9 8) 1)` was `()`.
- `compile_quote`'s numeric arm read only the `is_int` reader flag, dropping `is_char` and `is_inexact`: `'(#\a)` became the integer list `(97)`, and `'(2.0)` became the **exact** 2.

Fixing native alone would have converted a shared blind spot into a live native-vs-VM divergence, so all three are fixed together.

**Fix.**

- `parser.cpp` — every legal datum token gets a real branch. `#(` reads into the same 1-D `TENSOR_OP` the quasiquote reader already builds, recursing so elements stay data; the three reader macros wrap their datum in the matching homoiconic op, so `'(a ,b)` reads as `(a (unquote b))` per R7RS 4.1.2, exactly as `''a` already read as `(quote a)`.
- `llvm_codegen.cpp` — `codegenQuotedOperation()` gains the `TENSOR_OP` arm, materialising elements as a list and vectorising through `eshkol_list_to_vector_sret` (the machinery `codegenQuasiquote`'s vector template already uses). Without it the op would hit `default` and return null, reproducing the wrong answer one layer lower.
- `vm_parser.c` — `Node` gains an `is_vector` **reader-origin marker**, the same discipline `is_verbatim` uses for `|.|`, so a hand-written `'(vector 1 2)` still quotes as the list it reads as. The quoted-vector arm builds at constant operand-stack depth rather than carrying a second copy of `vm_compiler.c`'s element-count threshold. The numeric arm now mirrors `compile_expr()`'s discrimination.

**Ledger:** SW-46 (native), SW-47 (VM vectors), SW-48 (VM chars/exactness) — all `closed`, `closed_at: 490f63f4`, closed by re-measurement.

SW-47 and SW-48 are ledger **growth**, justified here per invariant 4: both were found while proving SW-46, both sat behind it, and leaving either open would have shipped a known divergence.

---

## Defect 2 — REPL/JIT no-return verifier (#244) — DOES NOT REPRODUCE

A no-return form terminates its basic block; a caller that keeps emitting into it produces IR the verifier rejects with `Terminator found in the middle of a basic block!`.

Commit `89e51ff7` fixed the **contract**, not a case: `codegenRaise` switches to a fresh `post_raise_dead` block immediately after `CreateUnreachable` — the pattern `codegenError` already used — so naive callers can stay naive.

**Measured, not assumed.** 30 no-return shapes (raise/error in every argument, operand, initialiser, test, tail and immediate-lambda position, plus `call/cc`, `dynamic-wind`, named `let`, `apply`, `map`) x 2 engines — `eshkol-run -r` batch JIT and the interactive `eshkol-repl`, whose per-form `%entry` was the reported failure site. **60/60 verifier-clean, 0 failures.** Evidence under `.worktrees/v135/evidence/correctness/d2_raise_verifier/`.

Because the fix is a contract rather than a case, the fence is a **matrix** rather than a probe: `tests/v1_3_edge_cases/noreturn_terminator_test.esk` (24 checks), registered in ctest with `Terminator found` in its `FAIL_REGULAR_EXPRESSION`. Any future no-return helper that forgets to switch blocks should get a row.

No ledger entry: nothing reproduced, and a fence is not a flaw.

---

## Defect 3 — `ArithmeticCodegen::mod` srem-vs-modulo (#197) — DOES NOT REPRODUCE

LLVM `srem` is C remainder (sign of the **dividend**); R7RS 6.2.6 `modulo` takes the sign of the **divisor**.

Both native lowerings already fold `srem` into floor semantics — `codegenModulo` for the `modulo`/`floor-remainder` builtin, and `ArithmeticCodegen::mod`, which is live for `floor-quotient` and `floor/`. The VM's `OP_MOD` does the same. Verified against **chibi-scheme 0.12.0** through the repo's existing reference-differential oracle rather than by reading the lowering:

| | native JIT | native AOT | VM | chibi |
|---|---|---|---|---|
| `(modulo -7 3)` | 2 | 2 | 2 | 2 |
| `(modulo 7 -3)` | -2 | -2 | -2 | -2 |
| `(modulo -7 -3)` | -1 | -1 | -1 | -1 |
| `(remainder -7 3)` | -1 | -1 | -1 | -1 |
| `(remainder 7 -3)` | 1 | 1 | 1 | 1 |
| `(floor-quotient 7 -3)` | -3 | -3 | gap* | -3 |

\* `floor-quotient` / `floor-remainder` / `truncate-*` have no VM name binding — a **loud** `undefined variable` warning, already carried in `tests/vm_parity/PARITY.tsv` as `gap`. Not silent, not in scope here.

**The gap was coverage, not correctness.** The reference-diff corpus only had `(modulo -7 3)`, a positive divisor — which a bare `srem` answers correctly. `tests/reference-diff/corpus/0036_numeric_division_signs.scm` and `tests/numeric/integer_division_sign_test.esk` (28 checks) add the negative-divisor rows that actually discriminate, plus the four modulo/remainder agree-and-disagree pairs, quotient's truncation, the `n = d*q + r` identity, and the bignum dispatch path that bypasses the int64 fast path entirely.

No ledger entry: nothing reproduced.

---

## Rebased onto `73cc7cbb`

Rebased past #463 (shared closure-upvalue capacity) and #464 (docs wave). One conflict, in `.icc/silent-wrong-ledger.yaml`: a pure append collision at the tail of the SILENT-WRONG section, since #463 landed SW-45 there. Resolved as a **union** — SW-45 kept verbatim, then SW-46/47/48. No id collides (`grep -o 'id: SW-[0-9]*b*' … | sort -V | uniq -d` is empty; 91 entries, 40 SILENT-WRONG).

`lib/backend/vm_parser.c` auto-merged and was checked by hand rather than trusted: #463 works on the upvalue cap and `ChunkEntry` (~line 729+), this branch on the `Node` datum flags (~30), the `#(` reader (~512) and `compile_quote` (~1108). Both changesets verified present in the merged file, and both sets of ctest registrations verified present in `CMakeLists.txt`.

`closed_at` in all three ledger entries was **repointed to the post-rebase fix commit `ced761fd`** — a `closed_at` naming a SHA that no longer exists would violate the ledger's own "close only by measurement at a named SHA" invariant.

Every gate below was **re-run on the new base**, not carried over. The vector null-literal repro was re-confirmed on all three engines specifically because #463 touched the same file:

```
(define (g x) (or x '#()))
  JIT  g 7 => 7   g #f => #()   vector? (g 7) => #f   null? (g 7) => #f
  AOT  g 7 => 7   g #f => #()   vector? (g 7) => #f   null? (g 7) => #f
  VM   g 7 => 7   g #f => #()   vector? (g 7) => #f   null? (g 7) => #f
```

## Gate table

All run at head `10dfdaa8` on base `73cc7cbb`; logs under `.worktrees/v135/evidence/correctness/*_rebased.log`.

| gate | result |
|---|---|
| build (RelWithDebInfo, LLVM 21, all requested options) | PASS, 0 errors |
| `ctest -j 6` | **194/194**, 100% |
| `scripts/run_vm_tests.sh` | PASS — 73/73 source tests, 2/0 |
| `scripts/run_vm_parity.sh` | PASS — 190 passed, 0 failed (new corpus passes both `vm-src` and `vm-eskb`) |
| `scripts/run_reference_differential.sh` | **36/36 AGREE** with chibi 0.12.0, gate PASS |
| `run_engine_parity_coverage.py --timeout 30` | OK — 0 new divergent, 0 regressed, floor held (13.37% vs 10.95% required) |
| `gate_no_silent_wrong.py` | `no_open_silent_wrong: PASS` |
| `check_ledger_integrity.py` | `ledger_integrity_clean: PASS` — 91 entries |
| `check_oracle_schema.py` | `oracle_schema_clean: PASS` |
| ICC `guard-diff` | PASS — 0 violations |
| ICC `pre-commit-check` | **PASS — 0 blockers** |

Per-defect re-confirmation on the new base: `quoted_datum_kinds_test` 41/41 on JIT, AOT and VM; `noreturn_terminator_test` 24/24 on all three; `integer_division_sign_test` 28/28 on JIT and VM.

ctest baseline: `73cc7cbb` carries 191 tests (190 at 4bf871a0, +1 from #463); this PR adds 3, hence 194.

One informational counter moved with the base and is called out rather than buried: `run_engine_parity_coverage`'s ungated "programs where both engines ran clean" reads 117 here against 118 on the pre-rebase base. The gated numbers are unchanged — divergent set still 5 (baseline permits 7, 0 new), regressions 0, floor 13.37%. The program involved is not in the harness's recorded `both_ran_programs` ratchet (98 entries), so no ratchet is touched; the shift arrived with the new base, where #463 deliberately converts an over-capacity upvalue miscompile from silent into a loud compile failure.

## Follow-up left open, deliberately

The #229 memory note flags **three more copies** of the same `if LPAREN parse_list else parse_atom` pattern at `parser.cpp` ~3199 and ~7343. They were not touched here and remain unaudited — recorded in SW-46's `notes` so the next reader inherits the lead rather than rediscovering it.
