### PR TITLE
feat(oracle): real v1.4-connection completion oracle replacing the placeholder

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -1165,11 +1165,58 @@ oracles:
         action: run_ad_sparse_gate
 
   # -----------------------------------------------------------------
-  # v1.4-connection readiness -- adds the AD infrastructure track
-  # assigned to v1.4 without replacing the networking/resource theme.
+  # v1.4-connection readiness — the "resource-sound systems profile"
+  # (docs/design/adr/0000-unified-trajectory.md Stage 3 / v1.4.0).
+  #
+  # This used to carry exactly one criterion for the entire release theme:
+  # a runtime_event nothing ever emitted (kind v1_4_connection / name
+  # connection_theme_deliverables, action replace_with_v1_4_connection_
+  # oracle). `icc readiness` graded that stub as a permanent, uninformative
+  # FAIL — it could never distinguish "hasn't started" from "half done"
+  # from "shipped". scripts/run_v14_connection_gate.sh replaces it: one
+  # criterion per deliverable from ROADMAP.md's v1.4-connection section,
+  # docs/COMPILER_ROADMAP.md's v1.4 Networking/Concurrency/Wire-formats/
+  # Linear-types sections (#145/#146/#148/#150/#156-#160/#161-#163/#175),
+  # docs/design/adr/0004-type-system-trajectory.md's v1.4 resource-sound
+  # exit gates, and docs/design/adr/0010-closed-loop-assurance.md's A8/
+  # A10-A13 assurance gaps.
+  #
+  # Investigation (2026-08-25) found several v1.4 deliverables already
+  # SHIPPED — real primitives with real round-trip tests already running in
+  # CI, just never wired into this oracle (same pattern as the P4/P6/P11 AD
+  # criteria below, and as the event_loop_works criterion that shipped in
+  # v1.3.4 but sat ungated until the eshkol-compiler-readiness target
+  # picked it up — see the comment above line ~513): the HTTP server
+  # (#145), Prometheus /metrics (#148, plus a NEW real over-HTTP round-trip
+  # test added alongside this gate — tests/v1_2_edge_cases/
+  # metrics_http_roundtrip_test.sh), Unix domain sockets (real primitives,
+  # real round-trip test, just never given a real AF_UNIX listener until
+  # this gate supplies one), resource limits (#150, a real CTest gate
+  # nothing ever invoked), threads/mutex/condvar (#156), channels (#157),
+  # the async event loop (#158, already gated elsewhere — re-emitted here
+  # under this family to prove the new oracle's own wiring end-to-end),
+  # promises/futures (#160), MessagePack (#162), and CAS + Merkle trees
+  # (#175). Genuinely absent: TCP/UDP/TLS, a WebSocket SERVER (only a
+  # client exists), fibers/coroutines, semaphores/barriers, Protocol
+  # Buffers, static (compile-time) rejection of a leaked or double-closed
+  # socket, the borrow pattern wired to real resources, v1.4.1's OALR ABI
+  # v2 and portable tail transfer (Stage 4 — included here per the task
+  # that authored this stanza, explicitly labelled v1.4.1-STAGE so it is
+  # never mistaken for a v1.4.0 blocker), assurance gaps A10-A12, and the
+  # distribution items. See scripts/run_v14_connection_gate.sh for the
+  # exact evidence (or absence-of-evidence grep) behind every PASS/FAIL.
+  #
+  # DISTRIBUTION criteria near the end of this list are marked PENDING R7:
+  # ~/Desktop/Selene/ESHKOL-ROADMAP-v135-to-v20-DRAFT.md section 5 records
+  # an UNRESOLVED maintainer ruling on whether W6 distributed execution
+  # ships as two tiers (PJRT/XLA scale + a native deterministic-allreduce
+  # mesh) or Tier 1 only. This oracle measures only the three items that
+  # draft stages for v1.4.0 regardless of how R7 is ruled (PJRT client
+  # spike, XLA multi-device single-host, native collectives over sockets)
+  # and does not commit the project to either branch of that ruling.
   # -----------------------------------------------------------------
-  - name: v1.4-release
-    aliases: [v1.4, release-1.4, connection]
+  - name: v1.4-connection
+    aliases: [v1.4, v1.4-release, release-1.4, connection]
     requires:
       - runtime_event:
           event_kinds: [ad_exact]
@@ -1208,13 +1255,306 @@ oracles:
         label: Portable event loop (kqueue/epoll/IOCP) round-trips a pipe through event-loop-poll and releases the kernel resource on close
         action: run_icc_smoke
 
+      # ─────────────────────────────────────────────────────────
+      # Networking (#145/#146/#148/#150/#161)
+      # ─────────────────────────────────────────────────────────
       - runtime_event:
           event_kinds: [v1_4_connection]
-          event_names: ["connection_theme_deliverables"]
+          event_names: ["v14_http_server_roundtrip"]
           event_values: ["PASS"]
         severity: high
-        label: Placeholder for v1.4 networking, TLS, event loop, and linear resource deliverables
-        action: replace_with_v1_4_connection_oracle
+        label: 'HTTP server (#145): http-server-create/-accept/-respond/-close round-trip a real GET request over loopback (fork+client, tests/v1_2_edge_cases/http_server_smoke_test.sh)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_metrics_http_roundtrip"]
+          event_values: ["PASS"]
+        severity: medium
+        label: 'Prometheus metrics + /metrics endpoint (#148): a real GET /metrics over loopback returns Prometheus text-exposition format (HELP/TYPE preamble + counter value) — tests/v1_2_edge_cases/metrics_http_roundtrip_test.sh, added alongside this gate (the primitive and the endpoint route already existed; no test had driven a real HTTP round trip against /metrics before)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_unix_socket_roundtrip"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'Unix domain sockets for local IPC: unix-socket-connect/socket-send/socket-recv/socket-close round-trip against a REAL AF_UNIX listener (tests/vm/unix_socket_surface_regression.esk T1-T8, driven with ESHKOL_VM_UNIX_SOCKET_TEST set for the first time by this gate — previously only the hermetic negative paths ran by default anywhere)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_resource_limits_enforced"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'Resource limits (#150): CPU/wall-time/memory/tensor-element/string-length/stack ceilings terminate with their documented ESHKOL_EXIT_LIMIT_* exit codes and name the violated variable on stderr; an unreached ceiling changes nothing; ESHKOL_ENFORCE_LIMITS=false downgrades a breach to a warning (tests/limits/resource_limits_enforcement_gate.sh, CMake-registered but never invoked via ctest by any CI workflow until this gate)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_tcp_roundtrip"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'TCP sockets (#161): listen/accept/connect/read/write/close, local/remote addr, non-blocking mode, error objects — NOT YET IMPLEMENTED (no tcp-connect/tcp-listen/tcp-accept primitive exists anywhere in lib/, inc/, or tests/)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_udp_roundtrip"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'UDP sockets (#161): bind/sendto/recvfrom — NOT YET IMPLEMENTED (no udp-socket/udp-bind primitive exists anywhere in lib/, inc/, or tests/)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_tls_handshake_verified"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'TLS/SSL via system libraries: server and client contexts, certificate/key loading, peer verification, a local self-signed-cert smoke handshake — NOT YET IMPLEMENTED (no TLS primitive exists anywhere in lib/, inc/, or tests/)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_websocket_server_echo"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'WebSocket SERVER (#146): upgrade handshake, text/binary frames, close/ping/pong, backpressure — NOT YET IMPLEMENTED for the server side (only a WebSocket CLIENT exists — lib/core/system_builtins.c websocket-connect/-send/-receive/-close performs the client-side opening handshake against a remote server; there is no Sec-WebSocket-Accept computation or listen/accept loop anywhere)'
+        action: run_v14_connection_gate
+
+      # ─────────────────────────────────────────────────────────
+      # Concurrency (#156-#160, M3)
+      # ─────────────────────────────────────────────────────────
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_async_io_event_loop"]
+          event_values: ["PASS"]
+        severity: low
+        label: 'Same evidence as the event_loop_works criterion above, re-emitted under the v1_4_connection family so this new oracle proves its own trace wiring end-to-end rather than relying solely on a criterion authored under a different kind before this stanza existed'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_threads_mutex_condvar"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'Threads + mutex + condvars (#156): real pthread-backed make-mutex/mutex-lock!/make-condvar/make-thread/thread-join (lib/core/threads.esk + lib/core/threads.c); 8 parallel-map workers x 1000 mutex-protected increments on a shared cell preserve the exact total — a real race would lose increments (tests/v1_2_edge_cases/threads_mutex_concurrency_test.esk, CI-wired via the *.esk glob but never fed to this oracle)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_channels_csp"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'Channels, CSP bounded/unbounded (#157): real bounded-ring-buffer make-channel/channel-send!/-recv!/-try-send!/-try-recv!/-close! built on core.threads (lib/core/channels.esk); parallel-map producer/consumer traffic preserves the total and drains the channel to empty (tests/v1_2_edge_cases/channels_test.esk)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_promises_futures"]
+          event_values: ["PASS"]
+        severity: medium
+        label: 'Promises/futures (#160): future/force/force-future are real pthread-backed VM builtins (a live pthread mutex+cond per future); core.threads'' make-thread is built directly on (future thunk); multiple futures resolve independently and force actually runs the thunk (regression #222 — pre-fix, force silently fell through to "return as-is") — tests/v1_2_edge_cases/future_force_test.esk'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_atomics_surface"]
+          event_values: ["PASS"]
+        severity: medium
+        label: 'Atomic ops (CAS, fetch-add): atomic-store!/-load/-exchange!/-compare-exchange!/-fetch-add!/-sub!/-and!/-or!/-xor! with explicit memory-order args are correct SEQUENTIALLY (tests/ffi/low_level_memory_surface_test.esk) — no cross-thread contention probe exists yet, so this criterion certifies the primitive surface only, not cross-thread atomicity'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_fibers_coroutines"]
+          event_values: ["PASS"]
+        severity: medium
+        label: 'Fibers/coroutines (#159): lightweight cooperative tasks — NOT YET IMPLEMENTED (no make-fiber/fiber-*/coroutine primitive exists anywhere in lib/ or tests/)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_semaphores_barriers"]
+          event_values: ["PASS"]
+        severity: low
+        label: 'Semaphores/barriers — NOT YET IMPLEMENTED (no make-semaphore/make-barrier primitive exists; the only "barrier" hits in the tree are the GC region write-barrier in lib/core/runtime_regions.cpp, unrelated to concurrency)'
+        action: run_v14_connection_gate
+
+      # ─────────────────────────────────────────────────────────
+      # Wire formats (#162/#163/#175)
+      # ─────────────────────────────────────────────────────────
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_msgpack_roundtrip"]
+          event_values: ["PASS"]
+        severity: medium
+        label: 'MessagePack (#162): encode/decode round-trips nil/bool/signed+unsigned int/fixstr-str8-str16/bin8-bin16/fixarray-array16/fixmap-map16 against exact wire bytes (lib/core/msgpack.esk — a documented deterministic subset, no ext-type hooks, no int64/float) — tests/v1_2_edge_cases/msgpack_test.esk via core.testing''s run-tests'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_cas_merkle_roundtrip"]
+          event_values: ["PASS"]
+        severity: medium
+        label: 'Content-addressable storage + Merkle trees (#175): tree build/determinism/order-sensitivity, inclusion-proof verify (valid/tampered/empty), and full CAS put/get/dedup round-trip (lib/core/merkle.esk + lib/core/merkle.c) — tests/v1_2_edge_cases/merkle_test.esk'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_protobuf_roundtrip"]
+          event_values: ["PASS"]
+        severity: medium
+        label: 'Protocol Buffers, proto3 (#163): a parser/compiler subset sufficient for generated encoders/decoders — NOT YET IMPLEMENTED (lib/core/onnx_export.c hand-writes protobuf wire bytes for ONE fixed ONNX schema; no .proto parser or schema compiler exists)'
+        action: run_v14_connection_gate
+
+      # ─────────────────────────────────────────────────────────
+      # Linear resource types + borrow pattern
+      # (docs/design/adr/0004-type-system-trajectory.md "v1.4: the
+      # resource-sound systems profile")
+      # ─────────────────────────────────────────────────────────
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_linear_consume_exactly_once_static"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'Generative linear/affine kernel (ADR-0004): Context::bindLinear/useLinear/checkLinearConstraints is wired into the real checking pass and already enforces exactly-once consumption STATICALLY on the Qubit type (which carries TYPE_FLAG_LINEAR, the same mechanism ADR-0004 proposes reusing for Own/socket typestate) — a program that uses a linear Qubit twice is REJECTED under --strict-types, not merely warned (tests/typesystem/qubit_no_cloning_test.esk, EXPECT-COMPILE: fail)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_socket_leak_rejected_statically"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'A program that opens a socket/file/thread resource and never closes it on every path FAILS TO COMPILE with a static type error (negative test — the v1.4 exit gate ADR-0004 calls "every resource acquisition has a statically verified consume/cleanup path") — NOT YET IMPLEMENTED: no ESHKOL_VALUE_SOCKET / linear socket type exists; real OS resources (lib/core/system_builtins.c) are plain runtime integers checked only DYNAMICALLY ("use-after-close fails closed... a catchable condition")'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_double_close_rejected_statically"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'Double-close and use-after-close on a typed handle are STATIC errors when the type checker can see them (ADR-0004: "the compiler should reject double-close and obvious use-after-close where the type checker can see it") — NOT YET IMPLEMENTED: same gap as v14_socket_leak_rejected_statically — today both are only dynamic, catchable, runtime errors'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_borrow_pattern_honored"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'Borrow pattern for temporary resource access: a borrowed handle used after its borrow scope ends is rejected — NOT YET IMPLEMENTED for real resources: the BorrowChecker class (Owned/Moved/Dropped/BorrowedShared/BorrowedMut, move/drop/borrowShared/borrowMut) exists in lib/types/type_checker.cpp, but only canBorrowMut/getState are wired into the real checking pass (one mutation-target call site); move/drop/borrowShared/returnBorrow are exercised only by isolated gtest unit tests, never reachable by compiling an actual .esk program'
+        action: run_v14_connection_gate
+
+      # ─────────────────────────────────────────────────────────
+      # v1.4.1-STAGE (docs/design/adr/0000-unified-trajectory.md Stage 4:
+      # "OALR ABI v2 and portable tail transfer"). v1.4.1 is its own
+      # release, one stage AFTER v1.4.0-connection (this target); these
+      # two criteria are included per the task that authored this stanza
+      # and are explicitly labelled so a v1.4.0 readiness reader does not
+      # mistake them for blocking the v1.4.0 cut.
+      # ─────────────────────────────────────────────────────────
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_1_oalr_abi_v2_header"]
+          event_values: ["PASS"]
+        severity: low
+        label: 'v1.4.1-STAGE (S4): OALR ABI v2 — 8->32 byte header, exact layout descriptors ("every pointer-bearing layout registers a descriptor or startup fails"), alias-preserving escape ledgers, structured cross-thread transfer capsules — NOT YET IMPLEMENTED (the object header is still eshkol_object_header_t, statically asserted at 8 bytes in inc/eshkol/eshkol.h; zero hits anywhere for ESHKOL_MEMORY_ABI_V2 or a layout-descriptor/escape-ledger/transfer-capsule concept; design-only per ADR-0000/0004)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_1_portable_tail_transfer"]
+          event_values: ["PASS"]
+        severity: low
+        label: 'v1.4.1-STAGE (S4): portable tail transfer — internal i128 tagged-return ABI, a general tail-transfer dispatcher, heap-owned continuation chains, verified musttail on every target backend — NOT YET IMPLEMENTED (musttail is emitted conditionally on the LLVM backend only for matching self/named-let tail calls; docs/reference/language/tail-calls.md documents mutual tail recursion as a KNOWN, UNFIXED limitation — SIGILL past ~500k depth — and no VM-backend equivalent exists)'
+        action: run_v14_connection_gate
+
+      # ─────────────────────────────────────────────────────────
+      # Assurance (docs/design/adr/0010-closed-loop-assurance.md A8,
+      # A10-A13 — all target v1.4)
+      # ─────────────────────────────────────────────────────────
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_assurance_a8_tsan_lane"]
+          event_values: ["PASS"]
+        severity: medium
+        label: 'A8 — race/concurrency detection: a required (not merely advisory) nightly TSan lane over the generated concurrency corpus. The lane is real (.github/workflows/adversarial-nightly.yml, -DESHKOL_ENABLE_TSAN=ON, TSAN_OPTIONS=halt_on_error=1) but this fast local gate cannot rebuild a TSan-enabled LLVM toolchain to reproduce it, and "required" (branch-protection-blocking) is a policy step no local probe can verify — only a real nightly CI run feeds this event PASS'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_assurance_a10_packaging_manifest"]
+          event_values: ["PASS"]
+        severity: low
+        label: 'A10 — toolchain-driver/type-checker/packaging manifest categories (toolchain_flag/type_diagnostic/package_surface) + a packaging lane that installs and runs the artifact — NOT YET IMPLEMENTED (ADR-0010''s own gap table marks this row "Planned"; no such manifest categories exist in .icc/architecture-model.yaml or .icc/completion-oracles.yaml; adversarial-nightly.yml''s homebrew install step is a partial precursor, not the manifest-driven lane A10 asks for)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_assurance_a11_diagnostic_corpus"]
+          event_values: ["PASS"]
+        severity: low
+        label: 'A11 — diagnostic golden-corpus (input -> expected diagnostic code + span), gated per surface family — NOT YET IMPLEMENTED (no such corpus directory exists anywhere under tests/)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_assurance_a12_lsan_lane"]
+          event_values: ["PASS"]
+        severity: medium
+        label: 'A12 — an LSan lane with an arena/JIT-cache suppression file (not blanket detect_leaks=0), plus region_evac POISON extended to the VM route — NOT YET IMPLEMENTED (.github/workflows/ci.yml''s ASan lanes explicitly set detect_leaks=0; lib/backend/vm_core.c has zero ESHKOL_ARENA_POISON hits)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_assurance_a13_hosted_gpu_lane"]
+          event_values: ["PASS"]
+        severity: low
+        label: 'A13 — a scheduled self-hosted (Jetson/Metal) GPU/quantum lane so the GPU oracles have recurring hosted evidence, with "no evidence in N days" as WARN rather than a silent pass. The lane already matches this ask (.github/workflows/gpu-execution-gate.yml, daily cron, runs-on: [self-hosted, gpu], emits a ::warning when no runner is registered), but this box has no self-hosted GPU runner registered, so only a real scheduled run on the registered runner feeds this event PASS'
+        action: run_v14_connection_gate
+
+      # ─────────────────────────────────────────────────────────
+      # Distribution (W6) — PENDING MAINTAINER RULING R7. See
+      # ~/Desktop/Selene/ESHKOL-ROADMAP-v135-to-v20-DRAFT.md section 5:
+      # whether W6 ships as two tiers (PJRT/XLA scale + a native
+      # deterministic-allreduce mesh) or Tier 1 only is UNRESOLVED. These
+      # three criteria cover only the items that draft stages for v1.4.0
+      # regardless of how R7 is ruled — NOT the v1.5.0+ Tier-2 bit-
+      # identical-allreduce mesh gate, which is out of v1.4 scope either
+      # way. This oracle does not commit the project to either branch of
+      # R7; low severity reflects "scope pending R7", not "unimportant".
+      # ─────────────────────────────────────────────────────────
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_distribution_pjrt_client_spike"]
+          event_values: ["PASS"]
+        severity: low
+        label: 'PENDING R7 — distribution scope not yet ruled. v1.4.0-staged item (per the draft ladder): a PJRT client spike — NOT YET IMPLEMENTED (zero "pjrt"/"PJRT" hits anywhere in the repo — code, headers, docs, or build)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_distribution_xla_multi_device_single_host"]
+          event_values: ["PASS"]
+        severity: low
+        label: 'PENDING R7 — distribution scope not yet ruled. v1.4.0-staged item: XLA multi-device single-host execution — NOT YET IMPLEMENTED (lib/backend/xla/ has zero hits for device_ordinal/num_replicas/num_partitions; docs/breakdown/GPU_ACCELERATION.md documents device-0-only enumeration and a single CUDA stream for all operations — XLA execution is single-device only today)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_distribution_native_collectives_over_sockets"]
+          event_values: ["PASS"]
+        severity: low
+        label: 'PENDING R7 — distribution scope not yet ruled. v1.4.0-staged item: native collectives over the v1.4.0 socket layer — NOT YET IMPLEMENTED (zero allreduce/sharding/GSPMD/replica hits in lib/backend/xla/ or lib/backend/gpu/; the only "distributed" module in the repo is pure-value Lamport/vector-clock/CRDT math, explicitly independent of sockets/async I/O)'
+        action: run_v14_connection_gate
+
+      - runtime_event:
+          event_kinds: [v1_4_connection]
+          event_names: ["v14_connection_sweep_clean"]
+          event_values: ["PASS"]
+        severity: low
+        label: 'Running-total sweep: every v1.4-connection probe above is green. Expected FAIL until the release actually ships — this criterion is a progress counter, not a release gate (see scripts/run_v14_connection_gate.sh''s summary line for the live pass/fail count)'
+        action: run_v14_connection_gate
 
   # -----------------------------------------------------------------
   # v1.5-intelligence readiness -- high-order AD gates for the

--- a/scripts/run_v14_connection_gate.sh
+++ b/scripts/run_v14_connection_gate.sh
@@ -1,0 +1,416 @@
+#!/usr/bin/env bash
+# run_v14_connection_gate.sh — the v1.4-connection completion-oracle harness.
+#
+# .icc/completion-oracles.yaml's `v1.4-connection` target used to carry
+# exactly one criterion for the whole release theme: a runtime_event nothing
+# ever emitted (kind v1_4_connection / name connection_theme_deliverables,
+# action `replace_with_v1_4_connection_oracle`). `icc readiness` graded that
+# stub as a permanent, uninformative FAIL — it could never distinguish "v1.4
+# hasn't started" from "v1.4 is half done" from "v1.4 shipped".
+#
+# This script is the replacement: ONE runtime_event probe per v1.4 deliverable
+# (docs/COMPILER_ROADMAP.md's Networking/Concurrency/Wire-formats/Linear-types
+# sections, ROADMAP.md's v1.4-connection list, docs/design/adr/0004's
+# "resource-sound systems profile" exit gates, docs/design/adr/0000's Stage 3
+# (v1.4.0) and Stage 4 (v1.4.1) gates, and docs/design/adr/0010's A8/A10-A13
+# assurance gaps), each bound to real evidence:
+#
+#   * where a real, working primitive AND a real round-trip test already
+#     exist, this script RUNS that evidence today and reports the actual
+#     PASS/FAIL it produces (most of these were shipped ahead of the
+#     roadmap's checkboxes and were simply never wired into the ICC oracle —
+#     see the per-probe comments below for exactly what exists and where);
+#   * where the deliverable genuinely does not exist yet, this script emits
+#     an honest FAIL with a `not yet implemented` snippet pointing at the
+#     grep that proves the absence, so the criterion is real and gradeable
+#     the moment someone lands the feature (swap the stub body for a real
+#     probe; the .icc/completion-oracles.yaml criterion does not change);
+#   * where the evidence lives in scheduled CI (nightly TSan, self-hosted
+#     GPU) rather than something this fast local gate can reproduce, this
+#     script says so explicitly rather than faking a PASS or silently
+#     skipping the criterion.
+#
+# This script never fabricates a PASS. A criterion is PASS only when the
+# thing it claims was actually exercised, this run, and produced the
+# claimed result.
+#
+# Usage: scripts/run_v14_connection_gate.sh
+#   BUILD_DIR   (env, default "build")   the CMake build directory
+#   TRACE_DIR   (env, default scripts/icc_traces)
+
+set -u
+export LC_ALL=C LC_CTYPE=C LANG=C
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+BUILD_DIR="${BUILD_DIR:-build}"
+case "$BUILD_DIR" in
+    /*) BUILD_DIR_PATH="$BUILD_DIR" ;;
+    *)  BUILD_DIR_PATH="$REPO_ROOT/$BUILD_DIR" ;;
+esac
+ESHKOL_RUN="$BUILD_DIR_PATH/eshkol-run"
+VM_RUN="$BUILD_DIR_PATH/eshkol-vm-standalone-test"
+
+TRACE_DIR="${TRACE_DIR:-$REPO_ROOT/scripts/icc_traces}"
+TRACE_FILE="$TRACE_DIR/v1_4_connection.jsonl"
+mkdir -p "$TRACE_DIR"
+: > "$TRACE_FILE"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-v14-gate.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+PROBE_TOTAL=0
+PROBE_FAILURES=0
+
+emit_event() { # name PASS|FAIL snippet
+    python3 -c '
+import json, sys
+print(json.dumps({"kind": "v1_4_connection", "name": sys.argv[1], "value": sys.argv[2],
+                  "snippet": sys.argv[3], "confidence": 0.95}, ensure_ascii=False))
+' "$1" "$2" "$3" >> "$TRACE_FILE"
+}
+
+# A probe that actually runs a command and grades PASS/FAIL on its exit code.
+probe_run() {
+    local probe_id="$1" label="$2" cmd="$3"
+    local out status snippet
+    PROBE_TOTAL=$((PROBE_TOTAL + 1))
+    out=$(eval "$cmd" 2>&1)
+    status=$?
+    if [ "$status" -eq 0 ]; then
+        emit_event "$probe_id" PASS "${label}: OK"
+        printf '  \xE2\x9C\x93 %-42s %s\n' "$probe_id" "$label"
+    else
+        PROBE_FAILURES=$((PROBE_FAILURES + 1))
+        snippet=$(printf '%s' "$out" | tail -c 220)
+        emit_event "$probe_id" FAIL "$snippet"
+        printf '  \xE2\x9C\x97 %-42s %s (exit %d)\n' "$probe_id" "$label" "$status"
+    fi
+}
+
+# A deliverable that does not exist in the tree yet. Emits an honest FAIL
+# with the evidence that it is absent, so the criterion stays real (never
+# silently dropped) until someone lands the feature and swaps this stub for
+# a probe_run call.
+probe_not_yet_implemented() {
+    local probe_id="$1" reason="$2"
+    PROBE_TOTAL=$((PROBE_TOTAL + 1))
+    PROBE_FAILURES=$((PROBE_FAILURES + 1))
+    emit_event "$probe_id" FAIL "NOT YET IMPLEMENTED: $reason"
+    printf '  \xE2\x9C\x97 %-42s NOT YET IMPLEMENTED: %s\n' "$probe_id" "$reason"
+}
+
+# A deliverable whose evidence lives in scheduled/self-hosted CI (nightly
+# TSan, self-hosted GPU) that this fast local gate cannot reproduce without
+# a multi-hour toolchain rebuild or hardware this box does not have. Says so
+# rather than faking local evidence.
+probe_external_ci_evidence() {
+    local probe_id="$1" workflow="$2" reason="$3"
+    PROBE_TOTAL=$((PROBE_TOTAL + 1))
+    PROBE_FAILURES=$((PROBE_FAILURES + 1))
+    emit_event "$probe_id" FAIL "EVIDENCE IS EXTERNAL CI, NOT LOCAL: $workflow — $reason"
+    printf '  \xE2\x9C\x97 %-42s EXTERNAL CI EVIDENCE (%s): %s\n' "$probe_id" "$workflow" "$reason"
+}
+
+echo "Running v1.4-connection oracle probes -> $TRACE_FILE"
+echo
+
+if [ ! -x "$ESHKOL_RUN" ]; then
+    echo "run_v14_connection_gate.sh: $ESHKOL_RUN not found - run \`cmake --build $BUILD_DIR_PATH\` first." >&2
+    exit 2
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Networking (docs/COMPILER_ROADMAP.md #145/#146/#148/#150/#161,
+# ROADMAP.md v1.4-connection)
+# ─────────────────────────────────────────────────────────────────
+
+# #145 HTTP server: real primitives (lib/agent/c/agent_http_server.c
+# http-server-create/-accept/-respond/-close, real bind/listen/accept/recv/
+# send) + a real fork+client+server round trip over loopback, already
+# CI-wired via the tests/v1_2_edge_cases/*.esk glob.
+probe_run v14_http_server_roundtrip \
+    'HTTP server (#145): real fork+client GET /health over loopback round-trips' \
+    'BUILD_DIR="$BUILD_DIR_PATH" ./tests/v1_2_edge_cases/http_server_smoke_test.sh'
+
+# #148 Prometheus metrics + /metrics endpoint: lib/core/metrics.esk
+# (make-counter/counter-inc!/metrics-render) is real and wired into
+# http-standard-response's /metrics route (lib/core/http_server.esk). No
+# existing test drove a real GET /metrics over a socket before this gate;
+# tests/v1_2_edge_cases/metrics_http_roundtrip_test.sh (added alongside this
+# script) does.
+probe_run v14_metrics_http_roundtrip \
+    'Prometheus /metrics (#148): real GET /metrics over loopback returns HELP/TYPE + counter value' \
+    'BUILD_DIR="$BUILD_DIR_PATH" ./tests/v1_2_edge_cases/metrics_http_roundtrip_test.sh'
+
+# Unix domain sockets: unix-socket-connect/socket-send/socket-recv/
+# socket-close are real VM builtins (tests/vm/unix_socket_surface_regression.esk)
+# but the real round-trip (T2-T5) is gated behind ESHKOL_VM_UNIX_SOCKET_TEST,
+# which no CI workflow ever sets — only the hermetic negative paths run by
+# default. This probe supplies the missing half: a real AF_UNIX listener.
+run_unix_socket_roundtrip() {
+    local sock="$WORK/v14_unix_socket_probe.sock"
+    local module="$WORK/unix_socket_test.eskb"
+    local out="$WORK/unix_socket_test.out"
+    rm -f "$sock"
+    python3 - "$sock" > "$WORK/unix_socket_listener.out" 2>&1 <<'PYEOF' &
+import socket, sys, os
+path = sys.argv[1]
+if os.path.exists(path):
+    os.remove(path)
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.settimeout(15)
+s.bind(path)
+s.listen(1)
+conn, _ = s.accept()
+data = conn.recv(256)
+if data == b"vm-socket-ping":
+    conn.sendall(b"vm-socket-pong")
+conn.close()
+s.close()
+PYEOF
+    local listener_pid=$!
+    local waited=0
+    while [ ! -S "$sock" ] && [ "$waited" -lt 50 ]; do sleep 0.1; waited=$((waited + 1)); done
+    "$ESHKOL_RUN" --profile hosted-vm --emit-eskb "$module" \
+        tests/vm/unix_socket_surface_regression.esk >"$WORK/unix_socket_compile.out" 2>&1 || true
+    ESHKOL_VM_UNIX_SOCKET_TEST="$sock" "$VM_RUN" "$module" >"$out" 2>&1
+    local rc=$?
+    wait "$listener_pid" 2>/dev/null
+    rm -f "$sock"
+    if [ "$rc" -ne 0 ]; then return "$rc"; fi
+    grep -q "^FAIL" "$out" && return 1
+    grep -q "T4 socket-recv reads response string:" "$out" || return 1
+    return 0
+}
+if [ -x "$VM_RUN" ]; then
+    if run_unix_socket_roundtrip; then
+        PROBE_TOTAL=$((PROBE_TOTAL + 1))
+        emit_event v14_unix_socket_roundtrip PASS \
+            "unix-socket-connect/socket-send/socket-recv/socket-close round-trip against a real AF_UNIX listener (T1-T8 of tests/vm/unix_socket_surface_regression.esk, driven with ESHKOL_VM_UNIX_SOCKET_TEST set for the first time by this gate)"
+        printf '  \xE2\x9C\x93 %-42s %s\n' v14_unix_socket_roundtrip "Unix domain socket real round-trip"
+    else
+        PROBE_TOTAL=$((PROBE_TOTAL + 1)); PROBE_FAILURES=$((PROBE_FAILURES + 1))
+        emit_event v14_unix_socket_roundtrip FAIL "real AF_UNIX round-trip against tests/vm/unix_socket_surface_regression.esk failed"
+        printf '  \xE2\x9C\x97 %-42s FAILED\n' v14_unix_socket_roundtrip
+    fi
+else
+    probe_not_yet_implemented v14_unix_socket_roundtrip "eshkol-vm-standalone-test not built"
+fi
+
+# #150 Resource limits: real enforcement (lib/core/resource_limits.cpp,
+# ESHKOL_MAX_HEAP/ESHKOL_TIMEOUT_MS/etc.) with a real CTest gate
+# (tests/limits/resource_limits_enforcement_gate.sh) that CMake registers
+# but no CI workflow ever runs via ctest. Invoke it directly.
+if [ -x "$VM_RUN" ]; then
+    probe_run v14_resource_limits_enforced \
+        'Resource limits (#150): CPU/wall-time/memory/tensor/string/stack ceilings terminate with documented exit codes, and an unreached ceiling changes nothing' \
+        '"$REPO_ROOT/tests/limits/resource_limits_enforcement_gate.sh" "$ESHKOL_RUN" "$VM_RUN" "$WORK/limits"'
+else
+    probe_not_yet_implemented v14_resource_limits_enforced "eshkol-vm-standalone-test not built"
+fi
+
+# TCP/UDP/TLS/WebSocket-server: confirmed absent by direct grep (tcp-connect,
+# tcp-listen, udp-socket, udp-bind, tls-connect, tls-context, make-tls: zero
+# hits anywhere in lib/, inc/, tests/). WebSocket: only a CLIENT exists
+# (lib/core/system_builtins.c websocket-connect/-send/-receive/-close,
+# performs the client-side opening handshake); there is no server-side
+# accept/upgrade path (no Sec-WebSocket-Accept computation, no listen loop).
+probe_not_yet_implemented v14_tcp_roundtrip \
+    'no tcp-connect/tcp-listen/tcp-accept primitive exists (grep lib/ inc/ tests/ for tcp-connect|tcp-listen: no hits)'
+probe_not_yet_implemented v14_udp_roundtrip \
+    'no udp-socket/udp-bind primitive exists (grep lib/ inc/ tests/ for udp-socket|udp-bind: no hits)'
+probe_not_yet_implemented v14_tls_handshake_verified \
+    'no TLS primitive exists (grep lib/ inc/ tests/ for tls-connect|tls-context|make-tls: no hits)'
+probe_not_yet_implemented v14_websocket_server_echo \
+    'only a WebSocket CLIENT exists (lib/core/system_builtins.c websocket-connect/-send/-receive/-close); no server-side upgrade/accept path'
+
+# ─────────────────────────────────────────────────────────────────
+# Concurrency (docs/COMPILER_ROADMAP.md #156-#160, M3)
+# ─────────────────────────────────────────────────────────────────
+
+# #158 already ships (v1.3.4) and already gates release readiness under
+# kind eshkol_smoke/event_loop_works (.icc/completion-oracles.yaml). This
+# probe re-emits the SAME evidence under the v1_4_connection family so the
+# new oracle proves its own wiring end-to-end rather than relying solely on
+# a criterion authored under a different kind before this stanza existed.
+if [ -x "$ESHKOL_RUN" ]; then
+    probe_run v14_async_io_event_loop \
+        'Async I/O event loop (#158): kqueue/epoll/IOCP pipe round-trip via event-loop-poll, timeout, close-then-use fails closed, 1000 open/close cycles' \
+        '"$ESHKOL_RUN" -r tests/v1_3_edge_cases/event_loop_test.esk 2>&1 | grep -q "PASS: event_loop_test"'
+fi
+
+# #156 threads + mutex + condvar: real pthread-backed core.threads.esk
+# (make-mutex/mutex-lock!/make-condvar/make-thread/thread-join), and a real
+# concurrency test — 8 parallel-map workers x 1000 mutex-protected
+# increments on a shared cell, asserting the exact total (a real race would
+# lose increments) — already CI-wired via the tests/v1_2_edge_cases/*.esk
+# glob but never fed to the ICC oracle.
+probe_run v14_threads_mutex_condvar \
+    'Threads + mutex + condvar (#156): 8 parallel-map workers x 1000 mutex-protected increments preserve the exact total' \
+    '"$ESHKOL_RUN" -r tests/v1_2_edge_cases/threads_mutex_concurrency_test.esk 2>&1 | grep -q "PASS: mutex-protected counter is consistent across threads"'
+
+# #157 channels: real bounded-ring-buffer CSP channels (lib/core/channels.esk)
+# built on core.threads, with a real parallel-map producer/consumer test.
+probe_run v14_channels_csp \
+    'Channels (#157): parallel-map producer/consumer traffic over a bounded CSP channel preserves the total and drains cleanly' \
+    '"$ESHKOL_RUN" -r tests/v1_2_edge_cases/channels_test.esk 2>&1 | grep -q "^Failed: 0$"'
+
+# #160 promises/futures: future/force/force-future are real pthread-backed
+# VM builtins (lib/backend/vm_region_evac.c: "thunk/result Values, plus a
+# live pthread mutex+cond"); core.threads' make-thread is built directly on
+# (future thunk). tests/v1_2_edge_cases/future_force_test.esk is the #222
+# regression that proves force actually runs the thunk (pre-fix it silently
+# fell through to "return as-is").
+probe_run v14_promises_futures \
+    'Promises/futures (#160): future/force run the thunk and multiple futures resolve independently (regression #222)' \
+    '"$ESHKOL_RUN" -r tests/v1_2_edge_cases/future_force_test.esk 2>&1 | grep -q "^Failed: 0$"'
+
+# Atomic ops (unlisted #-number, "Atomic ops (CAS, fetch-add)" in the
+# Concurrency table): real atomic-store!/-load/-exchange!/-compare-exchange!/
+# -fetch-add!/-fetch-sub!/-fetch-and!/-fetch-or!/-fetch-xor! with explicit
+# memory-order args. The only test today is SEQUENTIAL (API-shape) — no
+# cross-thread CAS-under-contention probe exists, so this criterion proves
+# the primitive surface only, not cross-thread atomicity; the label says so.
+probe_run v14_atomics_surface \
+    'Atomic ops: store/load/exchange/compare-exchange/fetch-add/sub/and/or/xor are correct SEQUENTIALLY (no cross-thread contention probe exists yet)' \
+    '"$ESHKOL_RUN" -r tests/ffi/low_level_memory_surface_test.esk 2>&1 | grep -q "Low-level FFI surface:.*0 failed"'
+
+# #159 fibers/coroutines, and semaphores/barriers: confirmed absent.
+probe_not_yet_implemented v14_fibers_coroutines \
+    'no make-fiber/fiber-*/coroutine primitive exists anywhere in lib/ or tests/'
+probe_not_yet_implemented v14_semaphores_barriers \
+    'no make-semaphore/make-barrier primitive exists; the only "barrier" hits in the tree are the GC region write-barrier (lib/core/runtime_regions.cpp), unrelated to concurrency'
+
+# ─────────────────────────────────────────────────────────────────
+# Wire formats (docs/COMPILER_ROADMAP.md #162/#163/#175)
+# ─────────────────────────────────────────────────────────────────
+
+# #162 MessagePack: lib/core/msgpack.esk is a real, complete encoder/decoder
+# over the deterministic subset (nil/bool/signed+unsigned ints to 32-bit/
+# fixstr-str8-str16/bin8-bin16/fixarray-array16/fixmap-map16 — no ext-type
+# hooks, no int64/float, a documented v1.8 wire-format substrate subset).
+# tests/v1_2_edge_cases/msgpack_test.esk round-trips every type against
+# exact wire bytes via core.testing's run-tests.
+probe_run v14_msgpack_roundtrip \
+    'MessagePack (#162): encode/decode round-trips nil/bool/int/string/bin/array/map against exact wire bytes (deterministic subset; no ext-types, no int64/float)' \
+    '"$ESHKOL_RUN" -r tests/v1_2_edge_cases/msgpack_test.esk 2>&1 | grep -q "RESULT: OK"'
+
+# #175 CAS + Merkle trees: lib/core/merkle.esk (merkle-leaf/-inode/-tree/
+# -leaves/-proof/-verify plus make-cas/cas-put!/cas-get/cas-has?) backed by
+# lib/core/merkle.c hash primitives. tests/v1_2_edge_cases/merkle_test.esk
+# self-checks tree build/determinism/order-sensitivity, inclusion-proof
+# verify (valid/tampered/empty), and full CAS round-trip incl. dedup.
+probe_run v14_cas_merkle_roundtrip \
+    'Content-addressable storage + Merkle trees (#175): tree build, inclusion-proof verify (valid/tampered/empty), CAS put/get/dedup round-trip' \
+    '"$ESHKOL_RUN" -r tests/v1_2_edge_cases/merkle_test.esk 2>&1 | grep -q "^Failed: 0$"'
+
+# #163 Protocol Buffers: confirmed absent. lib/core/onnx_export.c writes
+# protobuf wire bytes BY HAND for ONNX export (no .proto parser, no schema
+# compiler, no generated encoders/decoders) -- that is a one-off exporter,
+# not #163's "proto3 parser/compiler subset sufficient for generated
+# encoders/decoders".
+probe_not_yet_implemented v14_protobuf_roundtrip \
+    'no .proto parser/schema compiler exists; lib/core/onnx_export.c hand-writes protobuf wire bytes for ONE fixed ONNX schema, not a general proto3 subset'
+
+# ─────────────────────────────────────────────────────────────────
+# Linear resource types + borrow pattern (docs/design/adr/0004-type-
+# system-trajectory.md "v1.4: the resource-sound systems profile")
+# ─────────────────────────────────────────────────────────────────
+
+# The generative linear/affine kernel is real and wired into the checker:
+# Context::bindLinear/useLinear/checkLinearConstraints (lib/types/
+# type_checker.cpp), exercised end-to-end today on the Qubit type (which
+# carries TYPE_FLAG_LINEAR, same mechanism ADR-0004 proposes reusing for
+# Own/socket typestate) via a real negative compile-fail fixture: a program
+# that clones a linear Qubit must FAIL to compile under --strict-types (a
+# type error, not a warning -- gradual/default mode only warns, which is
+# why this probe passes --strict-types explicitly).
+probe_run v14_linear_consume_exactly_once_static \
+    'Linear/affine kernel (ADR-0004): a program that uses a linear Qubit twice is REJECTED at compile time under --strict-types (no-cloning), proving the same mechanism v1.4 needs for Own/socket typestate' \
+    '"$ESHKOL_RUN" --strict-types tests/typesystem/qubit_no_cloning_test.esk -o "$WORK/qubit_bad" >/dev/null 2>&1; rc=$?; [ "$rc" -ne 0 ] && [ ! -e "$WORK/qubit_bad" ]'
+
+# The v1.4 deliverable itself -- Own/socket typestate rejecting a leaked or
+# double-closed socket -- is NOT yet built: real OS resources (files,
+# sockets, event-loop handles in lib/core/system_builtins.c) are plain
+# runtime integers checked DYNAMICALLY ("use-after-close fails closed... a
+# catchable condition", system_builtins.c) -- there is no ESHKOL_VALUE_SOCKET
+# linear type, so nothing today makes a leaked socket a STATIC type error.
+probe_not_yet_implemented v14_socket_leak_rejected_statically \
+    'no ESHKOL_VALUE_SOCKET / linear socket type exists; sockets are plain runtime file descriptors with only DYNAMIC use-after-close guards (lib/core/system_builtins.c), not a static Own/Borrow typestate'
+probe_not_yet_implemented v14_double_close_rejected_statically \
+    'double-close on a real socket/file handle is a dynamic catchable error today, not a static type error -- same gap as v14_socket_leak_rejected_statically'
+
+# BorrowChecker (Owned/Moved/Dropped/BorrowedShared/BorrowedMut states,
+# move/drop/borrowShared/borrowMut) exists in lib/types/type_checker.cpp but
+# is almost entirely UNWIRED: only canBorrowMut/getState are called, at one
+# mutation-target check site. move()/drop()/borrowShared()/returnBorrow()
+# are exercised only by isolated gtest unit tests, never by real program
+# compilation -- so no .esk program can observe borrow-pattern enforcement
+# today.
+probe_not_yet_implemented v14_borrow_pattern_honored \
+    'BorrowChecker class exists (lib/types/type_checker.cpp) but only canBorrowMut/getState are wired into the real checking pass; move/drop/borrowShared/returnBorrow are unit-tested in isolation only, never reachable by compiling an actual .esk program'
+
+# ─────────────────────────────────────────────────────────────────
+# Stage 4 / v1.4.1 (docs/design/adr/0000-unified-trajectory.md Stage 4:
+# "OALR ABI v2 and portable tail transfer"). NOTE: v1.4.1 is its own
+# release, one stage AFTER v1.4.0-connection (which this oracle targets),
+# per the ADR's own staging and the maintainer-reviewed draft ladder
+# (v1.4.0 "the systems profile" [S3] vs v1.4.1 "the ABI release" [S4]).
+# These two criteria are included here because the task that authored this
+# oracle explicitly asked for S4 coverage; they are scoped and labelled as
+# v1.4.1-stage so a v1.4.0 readiness reader does not mistake them for
+# blocking the v1.4.0 cut.
+# ─────────────────────────────────────────────────────────────────
+probe_not_yet_implemented v14_1_oalr_abi_v2_header \
+    'v1.4.1-STAGE (S4): the object header is still eshkol_object_header_t, statically asserted at 8 bytes (inc/eshkol/eshkol.h); zero hits anywhere for ESHKOL_MEMORY_ABI_V2, a 32-byte header, layout descriptors, escape ledgers, or transfer capsules -- design-only per ADR-0000/0004, nothing started'
+probe_not_yet_implemented v14_1_portable_tail_transfer \
+    'v1.4.1-STAGE (S4): musttail is emitted conditionally on the LLVM backend only for matching self/named-let tail calls; docs/reference/language/tail-calls.md documents mutual tail recursion as a KNOWN, UNFIXED limitation (SIGILL past ~500k depth); no VM-backend musttail equivalent, no heap-owned continuation chains, no general tail-transfer dispatcher exist'
+
+# ─────────────────────────────────────────────────────────────────
+# Assurance (docs/design/adr/0010-closed-loop-assurance.md A8, A10-A13)
+# ─────────────────────────────────────────────────────────────────
+probe_external_ci_evidence v14_assurance_a8_tsan_lane \
+    '.github/workflows/adversarial-nightly.yml (nightly cron, -DESHKOL_ENABLE_TSAN=ON, generated concurrency corpus under TSAN_OPTIONS=halt_on_error=1)' \
+    'a TSan-enabled LLVM build is multi-hour; this fast local gate does not rebuild the toolchain. The lane is real and runs nightly, but "required" (branch-protection-blocking, per ADR-0010 A8''s v1.4 target) is a policy step this gate cannot itself verify -- only a real nightly CI run can feed this event PASS.'
+probe_not_yet_implemented v14_assurance_a10_packaging_manifest \
+    'A10 is marked "Planned" in ADR-0010''s own gap table; no toolchain_flag/type_diagnostic/package_surface manifest categories exist in .icc/architecture-model.yaml or .icc/completion-oracles.yaml. Partial: adversarial-nightly.yml does install the homebrew formula, but that is not the manifest-driven packaging LANE A10 asks for'
+probe_not_yet_implemented v14_assurance_a11_diagnostic_corpus \
+    'no diagnostic golden-corpus (input -> expected diagnostic code + span) directory exists anywhere under tests/'
+probe_not_yet_implemented v14_assurance_a12_lsan_lane \
+    'ASan lanes explicitly set detect_leaks=0 (.github/workflows/ci.yml) -- leak detection is OFF, not gated with a suppression file; lib/backend/vm_core.c has zero ESHKOL_ARENA_POISON hits, so the region_evac POISON extension to the VM route A12 asks for has not landed either'
+probe_external_ci_evidence v14_assurance_a13_hosted_gpu_lane \
+    '.github/workflows/gpu-execution-gate.yml (daily cron, runs-on: [self-hosted, gpu], emits a ::warning when no runner is registered)' \
+    'this box has no self-hosted GPU runner registered; the lane and its staleness-WARN rule are real and already match A13''s ask, but only a real scheduled run on the registered runner can feed this event PASS'
+
+# ─────────────────────────────────────────────────────────────────
+# Distribution (W6, PENDING MAINTAINER RULING R7 -- see
+# ~/Desktop/Selene/ESHKOL-ROADMAP-v135-to-v20-DRAFT.md section 5). The
+# two-tier-vs-Tier-1-only scope decision has NOT been made; these three
+# criteria cover only the items explicitly staged for v1.4.0 in that draft
+# (PJRT client spike, XLA multi-device single-host, native collectives over
+# sockets) -- NOT the v1.5.0+ Tier-2 bit-identical-allreduce mesh gate,
+# which is out of v1.4 scope regardless of how R7 is ruled. This oracle
+# does not commit the project to either branch of R7; it only measures
+# whether the v1.4.0-staged spike work exists.
+# ─────────────────────────────────────────────────────────────────
+probe_not_yet_implemented v14_distribution_pjrt_client_spike \
+    'PENDING R7: no "pjrt"/"PJRT" reference exists anywhere in the repo (code, headers, docs, build) -- confirmed by a whole-tree case-insensitive grep'
+probe_not_yet_implemented v14_distribution_xla_multi_device_single_host \
+    'PENDING R7: lib/backend/xla/ has zero hits for device_ordinal/num_replicas/num_partitions; docs/breakdown/GPU_ACCELERATION.md documents device-0-only enumeration and a single CUDA stream for all operations -- XLA execution is single-device only today'
+probe_not_yet_implemented v14_distribution_native_collectives_over_sockets \
+    'PENDING R7: zero hits for allreduce/all_reduce/sharding/GSPMD/replica in lib/backend/xla/ or lib/backend/gpu/; the only "distributed" module in the repo (docs/reference/stdlib/distributed.md) is pure-value Lamport/vector-clock/CRDT math, explicitly independent of sockets/async I/O'
+
+echo
+echo "Passed: $((PROBE_TOTAL - PROBE_FAILURES))"
+echo "Failed: $PROBE_FAILURES"
+echo "Total:  $PROBE_TOTAL"
+echo "Trace written: $TRACE_FILE"
+
+if [ "$PROBE_FAILURES" -eq 0 ]; then
+    emit_event v14_connection_sweep_clean PASS "all $PROBE_TOTAL v1.4-connection probes green"
+else
+    emit_event v14_connection_sweep_clean FAIL "$PROBE_FAILURES of $PROBE_TOTAL v1.4-connection probes not satisfied (expected -- v1.4-connection has not shipped; this sweep is the honest running count, not a release gate)"
+fi
+
+exit 0

--- a/tests/v1_2_edge_cases/metrics_http_roundtrip_test.sh
+++ b/tests/v1_2_edge_cases/metrics_http_roundtrip_test.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# metrics_http_roundtrip_test.sh — Prometheus /metrics endpoint round-trip (#148).
+#
+# docs/COMPILER_ROADMAP.md #148 asks for a "Prometheus metrics primitive +
+# /metrics endpoint" — counters, gauges, histograms, and the standard
+# /metrics helper. lib/core/metrics.esk (make-counter, counter-inc!,
+# metrics-render) and lib/core/http_server.esk's http-standard-response
+# already wire "/metrics" -> (metrics-render) (see http_server.esk around
+# the http-standard-response definition), but no existing test drove an
+# actual GET /metrics over a real loopback socket before this file: the
+# only coverage was tests/stdlib/metrics_test.esk, which exercises the
+# metrics module in isolation (never over HTTP), and the http-server
+# round-trip tests (http_server_smoke_test.sh, tests/vm/http_server_
+# surface_regression.esk) which only ever hit /health or custom routes.
+#
+# This spins up the loopback HTTP server (mirrors http_server_smoke_test.sh's
+# fork+client pattern), registers a counter, increments it, then forks a
+# client that performs a real GET /metrics and asserts the response is
+# Prometheus text-exposition format containing the counter's HELP/TYPE
+# preamble and current value.
+#
+# Runs through the JIT (eshkol-run -r), matching the rest of the v1.2
+# edge-case suite's system-builtin coverage.
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+RUN="$ROOT/${BUILD_DIR:-build}/eshkol-run"
+
+if [ ! -x "$RUN" ]; then
+    echo "SKIP: $RUN not built"
+    exit 0
+fi
+
+WORK=$(mktemp -d -t eshkol_metrics_http.XXXXXX)
+trap 'rm -rf "$WORK"' EXIT
+RUN_TIMEOUT="${ESHKOL_METRICS_HTTP_SMOKE_TIMEOUT:-120}"
+
+run_with_timeout() {
+    local seconds="$1"
+    shift
+
+    local timeout_marker="$WORK/timeout"
+    rm -f "$timeout_marker"
+
+    "$@" &
+    local cmd_pid=$!
+
+    (
+        sleep "$seconds"
+        if kill -0 "$cmd_pid" 2>/dev/null; then
+            touch "$timeout_marker"
+            kill "$cmd_pid" 2>/dev/null || true
+            sleep 1
+            kill -9 "$cmd_pid" 2>/dev/null || true
+        fi
+    ) &
+    local watchdog_pid=$!
+
+    wait "$cmd_pid"
+    local rc=$?
+
+    kill "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+
+    if [ -f "$timeout_marker" ]; then
+        return 124
+    fi
+    return "$rc"
+}
+
+cat > "$WORK/metrics_http.esk" <<'EOF'
+(require stdlib)
+(require core.http_server)
+(require core.metrics)
+
+(define passed 0)
+(define failed 0)
+(define (check label expected actual)
+  (if (equal? expected actual)
+      (begin (display "PASS: ") (display label) (newline)
+             (set! passed (+ passed 1)))
+      (begin (display "FAIL: ") (display label)
+             (display " (expected ") (display expected)
+             (display ", got ") (display actual) (display ")") (newline)
+             (set! failed (+ failed 1)))))
+
+(define (string-contains? haystack needle)
+  (let ((nlen (string-length needle))
+        (hlen (string-length haystack)))
+    (let loop ((i 0))
+      (cond
+        ((> (+ i nlen) hlen) #f)
+        ((string=? (substring haystack i (+ i nlen)) needle) #t)
+        (else (loop (+ i 1)))))))
+
+;; ── Register a counter so /metrics has real exposition text to check ──
+(define probe-counter
+  (make-counter "eshkol_v14_oracle_probe_total"
+                "v1.4-connection oracle metrics round-trip probe" '()))
+(counter-inc! probe-counter '())
+(counter-inc! probe-counter '())
+
+;; ── Server up ──────────────────────────────────────────────────────
+(define (server-handle? h)
+  (and (number? h) (> h 0)))
+
+(define (candidate-port attempt)
+  (+ 21000 (remainder (+ (getpid) attempt) 20000)))
+
+(define (create-server-with-retry attempts)
+  (let loop ((attempt 0))
+    (let ((srv (http-server-create (candidate-port attempt))))
+      (if (server-handle? srv)
+          srv
+          (if (< attempt attempts)
+              (begin (sleep-ms 50) (loop (+ attempt 1)))
+              srv)))))
+
+(define srv (create-server-with-retry 5))
+(if (not (server-handle? srv))
+    (begin
+      (display "SKIP: http-server-create unavailable") (newline)
+      (exit 0))
+    #t)
+
+(check "http-server-create returns positive handle" #t (server-handle? srv))
+
+(define port (if (server-handle? srv) (http-server-port srv) #f))
+
+(define url
+  (string-append "http://127.0.0.1:" (number->string port) "/metrics"))
+(define marker-path
+  (string-append "/tmp/eshkol-metrics-http-client-"
+                 (number->string (getpid))
+                 ".txt"))
+
+;; ── Concurrent client ─────────────────────────────────────────────
+(define client-pid
+  (if (and (number? port) (> port 0))
+      (fork)
+      #f))
+
+(if (and (number? client-pid) (= client-pid 0))
+    (begin
+      (sleep-ms 50)
+      (let ((response (http-request "GET" url "" "" 5000)))
+        (if (and response
+                 (= (car response) 200)
+                 (string? (caddr response))
+                 (string-contains? (caddr response) "eshkol_v14_oracle_probe_total")
+                 (string-contains? (caddr response) "# TYPE")
+                 (string-contains? (caddr response) "# HELP"))
+            (let ((out (open-output-file marker-path)))
+              (write-string "ok" out)
+              (close-port out))
+            #f))
+      (exit 0))
+    #t)
+
+;; ── Server-side accept, route through http-route-request (falls back
+;;    to the standard /metrics route) ────────────────────────────────
+(define request
+  (if (and (number? client-pid) (> client-pid 0))
+      (http-server-accept srv 4096 2000)
+      #f))
+(check "accept returned a string" #t (string? request))
+(check "request mentions /metrics" #t
+       (and (string? request) (string-contains? request "/metrics")))
+
+(if (and (number? client-pid) (> client-pid 0) request)
+    (http-server-respond-response srv (http-route-request request '()))
+    #f)
+
+(if (and (number? client-pid) (> client-pid 0) (not request))
+    (process-kill client-pid 15)
+    #f)
+
+(define client-status
+  (if (and (number? client-pid) (> client-pid 0))
+      (process-wait client-pid)
+      #f))
+(check "client exited cleanly" 0 client-status)
+(check "client saw counter name + HELP/TYPE preamble over real HTTP" #t
+       (and (file-exists? marker-path)
+            (= (file-size marker-path) 2)))
+
+(if (server-handle? srv) (http-server-close srv) #f)
+(if (file-exists? marker-path) (delete-file marker-path) #f)
+
+(display "---") (newline)
+(display "Passed: ") (display passed) (newline)
+(display "Failed: ") (display failed) (newline)
+(if (> failed 0) (exit 1) (exit 0))
+EOF
+
+ESHKOL_PATH="$ROOT" run_with_timeout "$RUN_TIMEOUT" "$RUN" -r "$WORK/metrics_http.esk"
+rc=$?
+if [ "$rc" -eq 124 ]; then
+    echo "FAIL: metrics http roundtrip timed out after ${RUN_TIMEOUT}s"
+fi
+exit "$rc"


### PR DESCRIPTION
## Summary

`.icc/completion-oracles.yaml`'s `v1.4-connection` target (previously named `v1.4-release`) carried exactly **one** criterion for the entire release theme:

```yaml
- runtime_event:
    event_kinds: [v1_4_connection]
    event_names: ["connection_theme_deliverables"]
    event_values: ["PASS"]
  severity: high
  label: Placeholder for v1.4 networking, TLS, event loop, and linear resource deliverables
  action: replace_with_v1_4_connection_oracle
```

Nothing in the repo ever emitted `connection_theme_deliverables`. `icc readiness` graded it as a permanent, uninformative FAIL — it could never distinguish "hasn't started" from "half done" from "shipped".

This PR replaces it with **one criterion per v1.4 deliverable**, each bound to a `runtime_event` a real harness (`scripts/run_v14_connection_gate.sh`, new) actually emits, sourced from:
- `ROADMAP.md`'s v1.4-connection section
- `docs/COMPILER_ROADMAP.md`'s v1.4 Networking/Concurrency/Wire-formats/Linear-types sections (#145/#146/#148/#150/#156–#160/#161–#163/#175)
- `docs/design/adr/0004-type-system-trajectory.md`'s v1.4 "resource-sound systems profile" exit gates
- `docs/design/adr/0000-unified-trajectory.md` Stage 3 (v1.4.0) and Stage 4 (v1.4.1 — included per request, explicitly labelled `v14_1_*` / "v1.4.1-STAGE" so it's never mistaken for a v1.4.0 blocker)
- `docs/design/adr/0010-closed-loop-assurance.md`'s A8, A10–A13 assurance gaps
- `~/Desktop/Selene/ESHKOL-ROADMAP-v135-to-v20-DRAFT.md`'s W6 distribution staging (read-only reference, not committed to this repo)

**Investigation finding:** several v1.4 deliverables already ship — real primitives with real round-trip tests already running in CI — just never wired into this oracle (the same pattern as the pre-existing P4/P6/P11 AD criteria in this same stanza, and as the `event_loop_works` criterion that shipped in v1.3.4 but sat ungated until a later commit gave it a home). This PR wires those in with **real evidence, not fabricated PASS**, and is equally honest about what genuinely does not exist yet.

## Criteria table

| Deliverable | Event name | Action | Satisfiable today? |
|---|---|---|---|
| HTTP server (#145) | `v14_http_server_roundtrip` | `run_v14_connection_gate` | **YES** — real fork+client GET round trip already in CI, now oracle-wired |
| Prometheus /metrics (#148) | `v14_metrics_http_roundtrip` | `run_v14_connection_gate` | **YES** — new real GET /metrics test added (`tests/v1_2_edge_cases/metrics_http_roundtrip_test.sh`); primitive + route already existed |
| Unix domain sockets | `v14_unix_socket_roundtrip` | `run_v14_connection_gate` | **YES** — real primitives + real round trip; gate supplies the first-ever AF_UNIX listener for the existing test |
| Resource limits (#150) | `v14_resource_limits_enforced` | `run_v14_connection_gate` | **YES** — real CTest gate existed, never invoked by any CI workflow |
| TCP sockets (#161) | `v14_tcp_roundtrip` | `run_v14_connection_gate` | no — no primitive exists |
| UDP sockets (#161) | `v14_udp_roundtrip` | `run_v14_connection_gate` | no — no primitive exists |
| TLS/SSL | `v14_tls_handshake_verified` | `run_v14_connection_gate` | no — no primitive exists |
| WebSocket SERVER (#146) | `v14_websocket_server_echo` | `run_v14_connection_gate` | no — client-only exists |
| Async I/O event loop (#158) | `v14_async_io_event_loop` | `run_v14_connection_gate` | **YES** — shipped v1.3.4; re-emitted under this family to prove the new oracle's own wiring |
| Threads + mutex + condvar (#156) | `v14_threads_mutex_condvar` | `run_v14_connection_gate` | **YES** — real pthread-backed, real concurrency test, CI-wired but never oracle-wired |
| Channels, CSP (#157) | `v14_channels_csp` | `run_v14_connection_gate` | **YES** — same pattern as threads |
| Promises/futures (#160) | `v14_promises_futures` | `run_v14_connection_gate` | **YES** — real pthread-backed VM builtins, regression #222 test |
| Atomic ops | `v14_atomics_surface` | `run_v14_connection_gate` | **PARTIAL** — real primitive, sequential-only test; no cross-thread contention probe exists (label says so) |
| Fibers/coroutines (#159) | `v14_fibers_coroutines` | `run_v14_connection_gate` | no — no primitive exists |
| Semaphores/barriers | `v14_semaphores_barriers` | `run_v14_connection_gate` | no — no primitive exists |
| MessagePack (#162) | `v14_msgpack_roundtrip` | `run_v14_connection_gate` | **YES** — real, complete deterministic subset, CI-wired but never oracle-wired |
| CAS + Merkle trees (#175) | `v14_cas_merkle_roundtrip` | `run_v14_connection_gate` | **YES** — same pattern |
| Protocol Buffers (#163) | `v14_protobuf_roundtrip` | `run_v14_connection_gate` | no — only a one-off hand-written ONNX protobuf exporter exists, not a proto3 subset |
| Linear consume-exactly-once (static) | `v14_linear_consume_exactly_once_static` | `run_v14_connection_gate` | **YES** — the generative linear/affine kernel is real and already rejects Qubit no-cloning under `--strict-types` (proves the mechanism v1.4 needs for sockets) |
| Socket leak rejected statically | `v14_socket_leak_rejected_statically` | `run_v14_connection_gate` | no — no `ESHKOL_VALUE_SOCKET`/linear socket type; only dynamic guards |
| Double-close rejected statically | `v14_double_close_rejected_statically` | `run_v14_connection_gate` | no — same gap |
| Borrow pattern honored | `v14_borrow_pattern_honored` | `run_v14_connection_gate` | no — `BorrowChecker` exists, unit-tested only, not wired to real resources |
| v1.4.1-STAGE: OALR ABI v2 | `v14_1_oalr_abi_v2_header` | `run_v14_connection_gate` | no — design-only, header still 8 bytes |
| v1.4.1-STAGE: portable tail transfer | `v14_1_portable_tail_transfer` | `run_v14_connection_gate` | no — mutual tail recursion is a documented, unfixed limitation |
| Assurance A8 (TSan lane) | `v14_assurance_a8_tsan_lane` | `run_v14_connection_gate` | **CONFIGURED, not locally verifiable** — real nightly lane exists (`adversarial-nightly.yml`); this fast gate can't rebuild a TSan LLVM toolchain |
| Assurance A10 (packaging manifest) | `v14_assurance_a10_packaging_manifest` | `run_v14_connection_gate` | no — ADR marks itself "Planned" |
| Assurance A11 (diagnostic corpus) | `v14_assurance_a11_diagnostic_corpus` | `run_v14_connection_gate` | no — no corpus exists |
| Assurance A12 (LSan lane) | `v14_assurance_a12_lsan_lane` | `run_v14_connection_gate` | no — ASan lanes explicitly set `detect_leaks=0` |
| Assurance A13 (hosted GPU lane) | `v14_assurance_a13_hosted_gpu_lane` | `run_v14_connection_gate` | **CONFIGURED, not locally verifiable** — real scheduled lane exists (`gpu-execution-gate.yml`); no self-hosted runner on this box |
| Distribution: PJRT client spike | `v14_distribution_pjrt_client_spike` | `run_v14_connection_gate` | no — **PENDING R7**; zero references anywhere |
| Distribution: XLA multi-device single-host | `v14_distribution_xla_multi_device_single_host` | `run_v14_connection_gate` | no — **PENDING R7**; confirmed single-device only |
| Distribution: native collectives over sockets | `v14_distribution_native_collectives_over_sockets` | `run_v14_connection_gate` | no — **PENDING R7**; nothing exists |
| Running-total sweep | `v14_connection_sweep_clean` | `run_v14_connection_gate` | informational only — expected FAIL until the release ships |

Plus the four pre-existing criteria carried over unchanged: P4 GUW multivariate, P6 exact-coefficient towers, P11 tower-based user numerics (AD infrastructure track, `ad_exact`/`ad_numerics`), and the pre-existing `event_loop_works` criterion.

**Result: 12 of 32 new deliverable criteria are satisfiable today with real evidence** (plus 2 configured-but-not-locally-verifiable and 1 partial). The rest are honest FAILs naming exactly what's missing, each a real, gradeable criterion the moment the feature lands — swap the stub body in `run_v14_connection_gate.sh` for a real probe; the oracle criterion itself does not need to change.

## Distribution scope is PENDING maintainer ruling R7

`~/Desktop/Selene/ESHKOL-ROADMAP-v135-to-v20-DRAFT.md` §5 records an **unresolved** maintainer ruling (R7): whether W6 distributed execution ships as two tiers (PJRT/XLA scale + a native deterministic-allreduce mesh) or Tier 1 only. The three distribution criteria in this oracle cover **only** the items that draft explicitly stages for v1.4.0 regardless of how R7 is ruled (PJRT client spike, XLA multi-device single-host, native collectives over sockets) — **not** the v1.5.0+ Tier-2 bit-identical-allreduce mesh gate. This PR does not commit the project to either branch of R7; the criteria are marked `PENDING R7` in their labels and given `low` severity to reflect "scope pending ruling," not "unimportant."

## Readiness — before

Against the original placeholder-only stanza (`target: v1.4-release`, `--oracle-file` pointed at the pre-change file from `origin/master`):

```
# Readiness: `v1.4-release`

Repo: `eshkol-v14-oracle`  Status: `blocked`  Score: `28`

Contract gaps: `1`  Liveness actions: `0`  Liveness scanned: `0` (skipped)  Stub/fallback paths: `10`  External backend deps: `21`  Runtime checks: `2`  Oracle: `blocked`

## Completion Oracle

| Status | Severity | Criterion | Evidence | Action |
|---|---|---|---:|---|
| FAIL | high | `ad_exact` | 0 | `run_ad_exact_taylor_gate` |
| FAIL | high | `ad_exact` | 0 | `run_ad_exact_taylor_gate` |
| WARN | medium | `ad_numerics` | 0 | `run_ad_numerics_gate` |
| PASS | high | `eshkol_smoke` | 1 | `keep` |
| FAIL | high | `v1_4_connection` | 0 | `replace_with_v1_4_connection_oracle` |
```

Five criteria total; the one that was supposed to measure the entire release theme is a dead stub that can never turn PASS.

## Readiness — after

```
# Readiness: `v1.4-connection`

Repo: `eshkol-v14-oracle`  Status: `blocked`  Score: `0`

Contract gaps: `1`  Liveness actions: `0`  Liveness scanned: `0` (skipped)  Stub/fallback paths: `10`  External backend deps: `21`  Runtime checks: `2`  Oracle: `blocked`

## Completion Oracle

| Status | Severity | Criterion | Evidence | Action |
|---|---|---|---:|---|
| FAIL | high | `ad_exact` | 0 | `run_ad_exact_taylor_gate` |
| FAIL | high | `ad_exact` | 0 | `run_ad_exact_taylor_gate` |
| WARN | medium | `ad_numerics` | 0 | `run_ad_numerics_gate` |
| PASS | high | `eshkol_smoke` | 1 | `keep` |
| PASS | high | `v1_4_connection` | 1 | `keep` |  ← v14_http_server_roundtrip
| PASS | medium | `v1_4_connection` | 1 | `keep` |  ← v14_metrics_http_roundtrip
| PASS | high | `v1_4_connection` | 1 | `keep` |  ← v14_unix_socket_roundtrip
| PASS | high | `v1_4_connection` | 1 | `keep` |  ← v14_resource_limits_enforced
| FAIL | high | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_tcp_roundtrip
| FAIL | high | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_udp_roundtrip
| FAIL | high | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_tls_handshake_verified
| FAIL | high | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_websocket_server_echo
| PASS | low | `v1_4_connection` | 1 | `keep` |  ← v14_async_io_event_loop
| PASS | high | `v1_4_connection` | 1 | `keep` |  ← v14_threads_mutex_condvar
| PASS | high | `v1_4_connection` | 1 | `keep` |  ← v14_channels_csp
| PASS | medium | `v1_4_connection` | 1 | `keep` |  ← v14_promises_futures
| PASS | medium | `v1_4_connection` | 1 | `keep` |  ← v14_atomics_surface
| WARN | medium | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_fibers_coroutines
| WARN | low | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_semaphores_barriers
| PASS | medium | `v1_4_connection` | 1 | `keep` |  ← v14_msgpack_roundtrip
| PASS | medium | `v1_4_connection` | 1 | `keep` |  ← v14_cas_merkle_roundtrip
| WARN | medium | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_protobuf_roundtrip
| PASS | high | `v1_4_connection` | 1 | `keep` |  ← v14_linear_consume_exactly_once_static
| FAIL | high | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_socket_leak_rejected_statically
| FAIL | high | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_double_close_rejected_statically
| FAIL | high | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_borrow_pattern_honored
| WARN | low | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_1_oalr_abi_v2_header
| WARN | low | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_1_portable_tail_transfer
| WARN | medium | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_assurance_a8_tsan_lane
| WARN | low | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_assurance_a10_packaging_manifest
| WARN | low | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_assurance_a11_diagnostic_corpus
| WARN | medium | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_assurance_a12_lsan_lane
| WARN | low | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_assurance_a13_hosted_gpu_lane
| WARN | low | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_distribution_pjrt_client_spike
| WARN | low | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_distribution_xla_multi_device_single_host
| WARN | low | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_distribution_native_collectives_over_sockets
| WARN | low | `v1_4_connection` | 0 | `run_v14_connection_gate` |  ← v14_connection_sweep_clean
```

37 criteria total (33 under `v1_4_connection`, 12 of them PASS with real evidence this run).

**The overall score dropped from 28 to 0. This is not a regression — it is the whole point.** The old score of 28 was computed over 5 criteria, one of which (the placeholder) could never pass and told nobody anything about actual v1.4 progress. The new score of 0 is computed over 37 real, individually-graded criteria for a release theme that genuinely has not shipped yet — a large majority of its high-severity criteria (TCP/UDP/TLS, static resource safety, the WebSocket server) are real gaps, honestly reported. As each ships, its criterion flips PASS and the score climbs criterion-by-criterion instead of staying stuck at a number that never moved and never could.

## Verification

- `python3 scripts/check_oracle_schema.py` → **PASS** (37/37 criteria valid under `v1.4-connection`, no other target regressed: 297/297 total across all 35 targets)
- `python3 scripts/check_ledger_integrity.py` → **PASS** (unaffected by this change)
- `icc readiness --repo eshkol-v14-oracle --target v1.4-connection --trace-dir scripts/icc_traces --format markdown` → runs, enumerates all 37 criteria, grades from real trace evidence (see above)
- `ctest -R resource_limits` → 2/2 passed (the two CTest targets this PR's gate now invokes)
- ICC: registered `eshkol-v14-oracle`, `index --force`, `build-memory`, `guard-diff --staged` → PASS, `pre-commit-check` → PASS

## Identity / hygiene

- Commit author: `tsotchke <tsotchkele@gmail.com>` (verified via `git log --format='%an %ae'`)
- No `--no-verify`, no stash, no force-push
- No files under `/tmp`; evidence lives under `.worktrees/v135/evidence/v14-oracle/` in the working tree that produced this PR (not committed)

Do not merge — awaiting review.
