### PR TITLE
fix(oracle): absent evidence must not read as ready — close the gpu-execution false green (A13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,24 @@ jobs:
   # missing required field) and asserts the gate goes RED on every one of
   # them, plus a well-formed fixture asserting it does not fail on
   # everything indiscriminately. A gate that cannot fail is not a gate.
+  #
+  # v1.3.5 assurance wave 2 (2026-08-25, F19 / ADR-0010 A13): the 2026-08-25
+  # architectural audit measured `icc readiness --target gpu-execution`
+  # returning `ready/94` with ZERO evidence, because its sole criterion was
+  # `severity: medium` and ICC's grader degrades an absent-evidence miss to
+  # WARN rather than FAIL unless severity is `high`. Fixed in
+  # .icc/completion-oracles.yaml (every criterion whose label asserts a
+  # correctness/capability claim is now `severity: high`, with explicit
+  # ADVISORY comments on the handful that are legitimately fixture
+  # bookkeeping). Two new gates keep it fixed:
+  #   - audit_oracle_false_green.py re-derives ICC's own status arithmetic
+  #     and fails if ANY oracle target has zero severity:high criteria —
+  #     the exact condition that let gpu-execution escape `blocked` on
+  #     total absence of evidence.
+  #   - check_evidence_staleness.py arms the other half of ADR-0010 A13
+  #     ("no evidence in N days = FAIL"), which ICC's `runtime_event`
+  #     grading path has no support for (only `performance_budget` does) —
+  #     see the script's docstring. Repo-side until that lands upstream.
   assurance-gates:
     name: assurance-gates
     if: github.event_name != 'schedule'
@@ -280,6 +298,8 @@ jobs:
           python3 scripts/gate_no_silent_wrong.py --self-test
           python3 scripts/check_ledger_integrity.py --self-test
           python3 scripts/check_oracle_schema.py --self-test
+          python3 scripts/audit_oracle_false_green.py --self-test
+          python3 scripts/check_evidence_staleness.py --self-test
 
       - name: No open, unwaived SILENT-WRONG flaw ships
         shell: bash
@@ -292,6 +312,14 @@ jobs:
       - name: Completion-oracle file parses and every criterion is gradeable
         shell: bash
         run: python3 scripts/check_oracle_schema.py --no-trace
+
+      - name: No oracle target can read ready on zero evidence (F19 / A13)
+        shell: bash
+        run: python3 scripts/audit_oracle_false_green.py --no-trace
+
+      - name: No high-severity criterion's evidence is stale (ADR-0010 A13)
+        shell: bash
+        run: python3 scripts/check_evidence_staleness.py --no-trace
 
   # Moonlab is deliberately opt-in, so keep its networked macOS coverage in a
   # separate advisory job. `continue-on-error` makes the lane informative

--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -2479,6 +2479,19 @@ oracles:
   # a workstation/laptop with a dGPU or Apple Silicon Metal, the Jetson
   # AGX Xavier under nix/jetson/). See docs on wiring a self-hosted
   # GPU runner in .github/workflows/gpu-execution-gate.yml.
+  #
+  # severity: high (was `medium` until the 2026-08-25 architectural audit,
+  # finding F19 / ADR-0010 gap A13). `medium` meant a criterion with ZERO
+  # evidence degraded to WARN instead of FAIL, and because this is the
+  # target's ONLY criterion, `icc readiness --target gpu-execution` read
+  # `Status: ready  Score: 94` on a host that had never executed a single
+  # GPU kernel — a measured false green, not a hypothetical one. The four
+  # Ozaki targets below are the control: same file, same host, same absent
+  # GPU evidence, `severity: high`, correctly `blocked`. This criterion
+  # asserts a correctness claim (GPU output matches the CPU reference), so
+  # absent evidence must FAIL, not WARN — see the false-green sweep in
+  # scripts/audit_oracle_false_green.py, which fails closed if this ever
+  # regresses back to a non-`high` severity.
   # ─────────────────────────────────────────────────────────────────
   - name: gpu-execution
     aliases: [gpu-execution-gate, gpu-correctness, p-gpu-execution]
@@ -2487,7 +2500,7 @@ oracles:
           event_kinds: [gpu_execution]
           event_names: ["gpu_execution_gate"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: GPU-accelerated tensor ops (matmul, elementwise, transpose, reduce) match the CPU reference within tolerance on a real GPU device
         action: ./tests/gpu/gpu_correctness_gate.sh
 

--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -148,11 +148,14 @@ oracles:
         label: 'FFI boundary fails closed: an arity error is fatal under -r AND AOT (never a null binding, never a written binary, named diagnostic preserved), and an argument whose type cannot be an address is rejected at every `extern` pointer parameter with a catchable type error instead of being dereferenced'
         action: ./scripts/run_icc_smoke.sh
 
+      # severity: high (raised in the F19 false-green sweep, 2026-08-25):
+      # this asserts measured behaviour (the REPL/JIT exit cleanly), not
+      # test-fixture presence, so absent evidence must FAIL, not WARN.
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["jit_repl_clean_exit"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: eshkol-repl + eshkol-run -r return cleanly on a smoke input
         action: ./scripts/run_icc_smoke.sh
 
@@ -260,11 +263,13 @@ oracles:
         severity: high
         label: 'Closure mutation: a closure made in a named-let/TCO loop that set!s a captured global keeps the mutation, not a snapshot (ESH-0094)'
         action: ./scripts/run_icc_smoke.sh
+      # severity: high (F19 false-green sweep): "match a reference" is a
+      # correctness claim, not fixture bookkeeping.
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["stdlib_sort_filter_scale_oracle"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: 'Stdlib scale: sort (2M) and filter (1M) are tail-recursive and match a reference sort/filter (ESH-0098/0108)'
         action: ./scripts/run_icc_smoke.sh
       - runtime_event:
@@ -403,11 +408,13 @@ oracles:
         severity: high
         label: 'P8 axis-5 (concurrency fuzz): seeded parallel-map worker corpora (scope-op-heavy / allocating / string / mixed-#f closures × n∈{4,15,16,17,64} × 20 repeats) deep-equal the serial-map oracle every run — retro-catches the #331 shared-arena scope-stack race'
         action: ./scripts/run_p8_escape.sh
+      # severity: high (F19 false-green sweep): "agree ... fails the gate"
+      # is a measured cross-surface invariant, not fixture bookkeeping.
       - runtime_event:
           event_kinds: [escape_matrix]
           event_names: ["five_way_surface_agreement"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: 'P8 axis-6 (five-way surface): doc ↔ manifest ↔ native-registration ↔ VM-dispatch ↔ module-provide agree for every builtin — shrink-only baseline ratchet; a NEW doc-orphan or backend asymmetry (the ad-pow native-missing class) fails the gate'
         action: ./scripts/run_p8_escape.sh
       - runtime_event:
@@ -417,11 +424,13 @@ oracles:
         severity: high
         label: 'P8 axis-7 (fault injection): every toolchain fault cell (broken --lib under -r/AOT, malformed under -r/AOT, bad output dir, undefined symbol, missing source under -r/AOT, unreadable source, unresolved require under -r/AOT, bounded hang) exits NONZERO with a diagnostic — retro-guards the #334 exit-0-masking class; all 12 cells are hard gates since the ESH-0361 residue was fixed in #354 and its five XKNOWN cells were promoted, so zero XKNOWN and zero XPASS is the passing state'
         action: ./scripts/run_p8_escape.sh
+      # severity: high (F19 false-green sweep): a measured memory-safety
+      # invariant (flat RSS), not fixture bookkeeping.
       - runtime_event:
           event_kinds: [escape_matrix]
           event_names: ["p8_mem_profiles_suite"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: 'P8 axis-8 (memory profiles): peak RSS is FLAT in the iteration count across workload shapes (AD-training step loop / resident KB tick / proof-search churn / parallel-map batch × auto-scope|with-region) — a leak that scales RSS with work (the training-loop OOM class) trips the machine-independent ratio invariant'
         action: ./scripts/run_p8_escape.sh
 
@@ -571,11 +580,22 @@ oracles:
         label: Coverage is certified by executed/dispatched runtime evidence only; the monotonic execution deficit ledger did not grow and execution-backed coverage did not regress (lexical name-presence earns zero credit)
         action: ./scripts/run_language_coverage.sh
 
+      # ADVISORY (F19 false-green sweep, kept at medium): `test_evidence`
+      # criteria certify that a test/fixture is indexed and runnable, not
+      # that a measured behaviour holds — the actual coverage/execution
+      # claims are the three `runtime_event` criteria above, all
+      # severity:high. This is fixture bookkeeping, not a standalone
+      # correctness claim, so absent evidence degrading to WARN is correct.
       - test_evidence: true
         severity: medium
         label: Language-surface manifest, policy, and exposure-engine tests are indexed
         action: python3 scripts/gen_language_surface.py --check
 
+      # ADVISORY (same reasoning as above): certifies the anti-gaming
+      # guard's OWN test suite is indexed/runnable, not a runtime
+      # measurement in its own right — the guard's actual effect is
+      # already load-bearing inside `execution_backed_language_coverage`
+      # above, severity:high.
       - test_evidence: true
         severity: medium
         label: Build-free execution-backed gate guard (name-presence earns no credit; deficit ratchet is monotonic)
@@ -614,11 +634,13 @@ oracles:
         label: process-spawn-argv runs argv directly without shell interpretation
         action: ./scripts/run_icc_smoke.sh
 
+      # severity: high (F19 false-green sweep): measured runtime behaviour
+      # (the PID returned is the real child PID), not fixture bookkeeping.
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["subprocess_pid_exposed"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: process-pid returns the real OS PID of the spawned child
         action: ./scripts/run_icc_smoke.sh
 
@@ -638,6 +660,10 @@ oracles:
         label: eshkol-run -o produces binaries that link agent FFI when (require agent.…) appears
         action: ./scripts/run_icc_smoke.sh
 
+      # ADVISORY (F19 false-green sweep, kept at medium): `test_evidence`
+      # certifies fixtures are indexed and runnable, not that a runtime
+      # measurement holds — the six criteria above already cover the FFI
+      # surface's actual behaviour at severity:high.
       - test_evidence: true
         severity: medium
         label: Agent FFI smoke tests indexed (http_server_smoke_test, etc.)
@@ -660,15 +686,25 @@ oracles:
         label: build/stdlib.o exists and loads at JIT and AOT link time
         action: cmake --build build --target stdlib
 
+      # ADVISORY (F19 false-green sweep, kept at medium): `test_evidence`
+      # certifies a test exists per module, not that the module's behaviour
+      # is measured correct — `stdlib_o_loads` above (severity:high) plus
+      # the no_stubbed_paths criterion below cover the actual claims.
       - test_evidence: true
         severity: medium
         label: Each stdlib module has a regression test
         action: add_test_per_stdlib_module
 
+      # severity: high (F19 false-green sweep): a real-vs-fake-implementation
+      # claim, the same class as `Codegen / runtime / type-checker production
+      # paths are real` in eshkol-compiler-readiness (already severity:high)
+      # — a stdlib function that shells out instead of computing is a stub
+      # wearing a passing test, exactly the defect class this repo's audits
+      # keep finding, and absent evidence must not read as "not shelling out".
       - no_stubbed_paths:
           - production_fallback
           - external_backend_required
-        severity: medium
+        severity: high
         label: Stdlib functions don't shell-out for things they should compute
         action: replace_shell_fallback_with_native_path
 
@@ -687,11 +723,13 @@ oracles:
         label: model-save / model-load preserve weights bit-exact
         action: verify_with_tensor_io_test
 
+      # severity: high (F19 false-green sweep): measured output-shape
+      # correctness, not fixture bookkeeping.
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["image_io_works"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: image-read returns a tensor of the correct shape
         action: run_image_io_test
 
@@ -711,11 +749,13 @@ oracles:
         label: parallel-map closures using scope-based reclamation (internal loops / memv) never race the shared arena scope stack
         action: run_parallel_map_scope_reclaim_test
 
+      # severity: high (F19 false-green sweep): measured diagnostic-quality
+      # behaviour, not fixture bookkeeping.
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["error_messages_have_source_locations"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: Compile errors include file:line:col + caret
         action: keep_eshkol_error_at_pipeline
 
@@ -928,27 +968,36 @@ oracles:
         label: 'P3 JET8 route is subsumed by tagged Taylor towers without regression'
         action: run_mono_equiv_ad_taylor_gate
 
+      # severity: high (F19 false-green sweep): measured cache-correctness
+      # behaviour (hit + invalidate-on-edit), not fixture bookkeeping.
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["jit_cache_hit_invalidates"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: 'eshkol-run -r persistent cache hits and source edits invalidate'
         action: ./scripts/run_icc_smoke.sh
 
+      # severity: high (F19 false-green sweep): asserts a real platform code
+      # path executed rather than a bundled fallback — the same
+      # real-vs-fake-implementation claim already raised for stdlib-ready's
+      # no_stubbed_paths criterion.
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["native_image_io_no_stb"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: 'image-read uses platform APIs, not bundled deps/stb'
         action: ./scripts/run_icc_smoke.sh
 
+      # severity: high (F19 false-green sweep): measured behaviour (the PGO
+      # pipeline actually produces a working profile-guided binary), not
+      # fixture bookkeeping.
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["pgo_pipeline_works"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: 'cmake -DESHKOL_PGO=generate/use supports a profile-guided binary'
         action: ./scripts/run_icc_smoke.sh
 
@@ -1067,11 +1116,14 @@ oracles:
   - name: ad-taylor-campaign
     aliases: [ad-taylor, arbitrary-order-ad, taylor-tower]
     requires:
+      # severity: high (F19 false-green sweep): "matches analytic
+      # derivatives" is a numerical-correctness claim, not fixture
+      # bookkeeping -- consistent with every sibling P1-P10 criterion below.
       - runtime_event:
           event_kinds: [ad_depth]
           event_names: ["ad_taylor_p0_poc"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: P0 recurrence POC matches analytic derivatives to d=8
         action: tests/ad_taylor_poc/run.sh
 
@@ -1155,19 +1207,23 @@ oracles:
         label: P10 checkpointed high-order reverse matches dense tape within memory budget
         action: run_ad_reverse_highorder_gate
 
+      # severity: high (F19 false-green sweep): a convergence claim, the
+      # same class as every other P-phase criterion in this campaign.
       - runtime_event:
           event_kinds: [ad_numerics]
           event_names: ["ad_taylor_p11_user_numerics"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: P11 Taylor-series ODE, root, inversion, and continuation APIs converge
         action: run_ad_numerics_gate
 
+      # severity: high (F19 false-green sweep): "match dense recovery" is a
+      # numerical-correctness claim, not fixture bookkeeping.
       - runtime_event:
           event_kinds: [ad_sparse]
           event_names: ["ad_taylor_p12_sparse_highorder_tensors"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: P12 sparse high-order tensors match dense recovery on tractable cases
         action: run_ad_sparse_gate
 
@@ -1194,11 +1250,13 @@ oracles:
         label: P6 exact-coefficient towers pass rational/bignum symbolic oracle
         action: run_ad_exact_taylor_gate
 
+      # severity: high (F19 false-green sweep): a convergence claim, the
+      # same class as every high-severity sibling criterion in this target.
       - runtime_event:
           event_kinds: [ad_numerics]
           event_names: ["ad_taylor_p11_user_numerics"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: P11 tower-based user numerics converge on ODE/root/inversion examples
         action: run_ad_numerics_gate
 
@@ -1254,11 +1312,19 @@ oracles:
         label: P9 differentiable control-flow oracle passes through loops, branches, recursion, and closures
         action: run_ad_control_flow_gate
 
+      # severity: high (F19 false-green sweep): this is the SAME
+      # `ad_taylor_p10_checkpointed_reverse` event already gated at
+      # severity:high in ad-taylor-campaign ("matches dense tape within
+      # memory budget"). Leaving the v1.5-release label at medium would not
+      # actually widen coverage on a real release run (the campaign target
+      # already blocks on this event's absence), but the softer severity
+      # here was inconsistent with the identical evidence elsewhere and
+      # would misread as "advisory" to anyone scoring v1.5-release alone.
       - runtime_event:
           event_kinds: [ad_reverse_highorder]
           event_names: ["ad_taylor_p10_checkpointed_reverse"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: P10 checkpointed high-order reverse begins the v1.5 to v1.7 memory-scaling bridge
         action: run_ad_reverse_highorder_gate
 
@@ -1291,11 +1357,13 @@ oracles:
         label: All 71 programs produce bit-identical PRINT outputs (paper §4.4)
         action: ./scripts/run_sdnc_oracle.sh
 
+      # severity: high (F19 false-green sweep): a bit-agreement claim, the
+      # same class as `output_agreement` above (already severity:high).
       - runtime_event:
           event_kinds: [sdnc_paper_suite]
           event_names: ["trace_agreement"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: Full per-step state agrees for all 71 programs (extended check)
         action: ./scripts/run_sdnc_oracle.sh
 
@@ -1342,11 +1410,14 @@ oracles:
         label: build/stdlib.o builds without warnings
         action: touch lib/stdlib.esk && cmake --build build --target stdlib
 
+      # severity: high (F19 false-green sweep): "compiles end-to-end" is a
+      # measured behaviour, not fixture bookkeeping -- the other two
+      # criteria in this no-regression gate are already severity:high.
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["example_agent_compiles"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: examples/agent.esk compiles end-to-end
         action: ./build/eshkol-run examples/agent.esk -o /tmp/selene
 
@@ -1407,25 +1478,28 @@ oracles:
         severity: high
         label: 100k-iteration gradient loop RSS plateaus under r
         action: ./scripts/run_stress.sh
+      # severity: high (F19 false-green sweep) x3: the same measured-bound
+      # class as every other stress_smoke criterion above, already
+      # severity:high -- these three were the only outliers in this target.
       - runtime_event:
           event_kinds: [stress_smoke]
           event_names: ["stress_num_bignum_expt_1e1000_r"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: 10^1000 bignum expt + string round-trip under r
         action: ./scripts/run_stress.sh
       - runtime_event:
           event_kinds: [stress_smoke]
           event_names: ["stress_par_spawn_join_100x_r"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: 100x parallel spawn/join deterministic across 3 repetitions under r
         action: ./scripts/run_stress.sh
       - runtime_event:
           event_kinds: [stress_smoke]
           event_names: ["stress_jit_cache_probe_r"]
           event_values: ["PASS"]
-        severity: medium
+        severity: high
         label: 50 sequential -r invocations stay under the warm-path ceiling
         action: ./scripts/run_stress.sh
 

--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -116,6 +116,37 @@ oracles:
         label: 'This completion-oracle file parses and every criterion in every oracle validates to the same count declared — no criterion is silently dropped by the grader (scripts/check_oracle_schema.py)'
         action: python3 scripts/check_oracle_schema.py
 
+      # 2026-08-25 (F19 / ADR-0010 A13): every oracle target now carries at
+      # least one severity:high criterion, so absent evidence forces
+      # `blocked` (scripts/audit_oracle_false_green.py enforces that
+      # invariant below). This criterion covers the OTHER half of A13's
+      # proposal: evidence that exists but is stale. ICC's own grader has
+      # no `max_age_days` support for `runtime_event` criteria (only
+      # `performance_budget` — see scripts/check_evidence_staleness.py's
+      # docstring for the exact code path), so staleness is graded here,
+      # repo-side, over the trace corpus, and fed back in as an ordinary
+      # eshkol_smoke event the same way the schema/ledger gates above are.
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["evidence_staleness_clean"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'No severity:high criterion''s newest matching runtime-event evidence is older than the configured window (default 14 days; scripts/check_evidence_staleness.py --max-age-days / $ESHKOL_EVIDENCE_MAX_AGE_DAYS)'
+        action: python3 scripts/check_evidence_staleness.py
+
+      # 2026-08-25 (F19 / ADR-0010 A13): no oracle target may read `ready`
+      # (or escape `blocked`) purely because it has zero severity:high
+      # criteria — the exact mechanism that let gpu-execution read
+      # `ready/94` on a host that had run no GPU code at all. This
+      # criterion is this file's own regression test against that class.
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["oracle_false_green_clean"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'Every oracle target has at least one severity:high criterion, so total absence of evidence forces `blocked` rather than `ready`/`incomplete` (scripts/audit_oracle_false_green.py)'
+        action: python3 scripts/audit_oracle_false_green.py
+
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["llvm_module_verifier_clean"]

--- a/scripts/audit_oracle_false_green.py
+++ b/scripts/audit_oracle_false_green.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Release gate: no `.icc/completion-oracles.yaml` target can read `ready`
+(or any non-`blocked` status) while every one of its criteria has zero
+evidence.
+
+Motivating incident: the 2026-08-25 architectural audit (F19) measured
+`icc readiness --target gpu-execution` returning `Status: ready  Score: 94`
+on a host that had never run a single GPU kernel and a trace directory with
+no `gpu_execution` record anywhere in it. The mechanism is ICC's own,
+unmodified and correct in isolation: `completion_oracle_criteria.py`'s
+`_status_for_missing(severity)` returns `FAIL` only when a criterion's
+declared `severity` is `high`; `medium` and `low` degrade a zero-evidence
+miss to `WARN`. `readiness_service.py`'s status rule then only forces
+`blocked` when at least one oracle criterion is `FAIL` (or a `high`-severity
+graph gap exists, or a runtime check FAILed) --  a target whose criteria are
+ALL `medium`/`low` can clear `score >= 90` on pure absence and read `ready`.
+
+That is not a bug in ICC's grader -- it is a bug in *this repo's* severity
+declarations. Proof: the four Ozaki targets in the same file, scored on the
+same host with the same absent evidence, correctly return `blocked` because
+every one of their criteria is `severity: high`. `gpu-execution` was the
+only oracle target in the file with a `requires` list that has *zero*
+`high`-severity entries.
+
+This gate re-derives ICC's own status arithmetic (`_status_for_missing`,
+and the `blocked`/`ready`/`incomplete` rule in `readiness_service.py`'s
+`build_readiness_payload`) locally, in this repo, over
+`.icc/completion-oracles.yaml`, and asks one question per target: "if
+every criterion in this target had zero evidence right now, would ICC's
+status rule still call it `blocked`?" A target is a FALSE-GREEN RISK when
+the answer is no -- i.e. the target has no `high`-severity criterion, so
+total absence of evidence cannot force `blocked` and the target is free to
+read `ready` (if the approximated score clears 90) or `incomplete`
+(if it does not, which is still not the `blocked` a correctness gate with
+zero evidence should read).
+
+The predicted score here is an APPROXIMATION: it replays only the
+oracle-criteria terms of ICC's score formula (`-8` per criterion `FAIL`,
+`-3` per criterion `WARN`), not the cross-cutting graph-gap / liveness /
+stubbed-path / runtime-check terms that also feed a real `icc readiness`
+run and vary repo-registration to repo-registration (measured: the F19
+audit's registration read `gpu-execution` at score 94, a fresh registration
+of the same file in this script's own worktree read it at 90 -- both
+`ready`, same defect, different incidental score). The STATUS classification
+(would zero evidence force `blocked`?) does not depend on those terms and is
+exact; only the printed score is a lower-bound estimate, and is labelled as
+such.
+
+Checks
+    For every oracle target in the file:
+      - criteria count, severity histogram
+      - predicted oracle-criteria-only score and status if EVERY criterion
+        in the target had zero evidence right now
+      - `false_green_risk`: true iff that predicted status is not `blocked`
+        (i.e. the target has no `high`-severity criterion, so it cannot be
+        forced blocked purely by absent evidence)
+
+Grading
+    PASS  no target is a false_green_risk (every target has at least one
+          `high`-severity criterion, so total absence of evidence forces
+          `blocked` for every target in the file).
+    FAIL  one or more targets have zero `high`-severity criteria.
+
+The gate FAILS CLOSED: a missing or unparseable oracle file is FAIL.
+
+Usage
+    python3 scripts/audit_oracle_false_green.py
+    python3 scripts/audit_oracle_false_green.py --oracles path/to/file.yaml
+    python3 scripts/audit_oracle_false_green.py --format json
+    python3 scripts/audit_oracle_false_green.py --self-test
+
+Exit status is 0 on PASS and 1 on FAIL.
+
+Copyright (C) tsotchke
+SPDX-License-Identifier: MIT
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_ORACLES = os.path.join(REPO_ROOT, ".icc", "completion-oracles.yaml")
+DEFAULT_TRACE_DIR = os.path.join(REPO_ROOT, "scripts", "icc_traces")
+TRACE_BASENAME = "oracle_false_green_gate.jsonl"
+PROBE_ID = "oracle_false_green_clean"
+
+VALID_SEVERITIES = ("high", "medium", "low")
+
+# Mirrors completion_oracle_criteria._status_for_missing exactly: FAIL only
+# for `high`; everything else (including a missing/invalid severity, which
+# ICC's own normalizer defaults to `medium`) degrades to WARN.
+def _status_for_missing(severity: str) -> str:
+    return "FAIL" if severity == "high" else "WARN"
+
+
+class OracleAuditError(Exception):
+    """The oracle file could not be read or parsed at all."""
+
+
+def _load_yaml(path: str) -> object:
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise OracleAuditError(
+            "PyYAML is required to audit the oracle file (pip install pyyaml)"
+        ) from exc
+
+    if not os.path.isfile(path):
+        raise OracleAuditError(f"oracle file not found at {path} (the gate fails closed)")
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            return yaml.safe_load(handle)
+    except Exception as exc:
+        raise OracleAuditError(f"oracle file at {path} is not parseable: {exc}") from exc
+
+
+def _criteria_of(oracle: dict) -> list:
+    raw = oracle.get("requires")
+    if raw is None:
+        raw = oracle.get("criteria")
+    if not isinstance(raw, list):
+        return []
+    return [c for c in raw if isinstance(c, dict)]
+
+
+def _severity_of(criterion: dict) -> str:
+    severity = criterion.get("severity")
+    return severity if severity in VALID_SEVERITIES else "medium"
+
+
+def _label_of(criterion: dict) -> str:
+    return str(criterion.get("label") or criterion.get("id") or "<unlabeled criterion>")
+
+
+def audit_target(oracle: dict) -> dict:
+    """Predict the target's status/score if every criterion had zero evidence."""
+
+    name = str(oracle.get("name") or oracle.get("target") or "<unnamed>")
+    criteria = _criteria_of(oracle)
+
+    histogram = {"high": 0, "medium": 0, "low": 0}
+    non_high: list[dict] = []
+    for criterion in criteria:
+        severity = _severity_of(criterion)
+        histogram[severity] += 1
+        if severity != "high":
+            non_high.append({
+                "label": _label_of(criterion),
+                "severity": severity,
+                "kind": criterion.get("kind") or next(
+                    (k for k in criterion if k not in
+                     ("id", "label", "severity", "action", "recommended_action")),
+                    "unknown",
+                ),
+            })
+
+    fail_count = histogram["high"]
+    warn_count = histogram["medium"] + histogram["low"]
+    predicted_score = max(0, 100 - 8 * fail_count - 3 * warn_count)
+    if fail_count > 0:
+        predicted_status = "blocked"
+    elif predicted_score >= 90:
+        predicted_status = "ready"
+    else:
+        predicted_status = "incomplete"
+
+    false_green_risk = predicted_status != "blocked"
+
+    return {
+        "name": name,
+        "criteria_count": len(criteria),
+        "severity_histogram": histogram,
+        "predicted_score_on_zero_evidence": predicted_score,
+        "predicted_status_on_zero_evidence": predicted_status,
+        "false_green_risk": false_green_risk,
+        "non_high_criteria": non_high,
+    }
+
+
+def audit(data: object) -> dict:
+    """Audit a parsed oracle document. Never raises; returns a report."""
+
+    if not isinstance(data, dict):
+        return {"passed": False, "errors": ["oracle document is not a mapping"], "targets": []}
+
+    oracles_raw = data.get("oracles")
+    if not isinstance(oracles_raw, list):
+        return {"passed": False, "errors": ["oracle document has no top-level `oracles` list"], "targets": []}
+
+    targets = [audit_target(o) for o in oracles_raw if isinstance(o, dict)]
+    risky = [t for t in targets if t["false_green_risk"]]
+    passed = not risky
+    errors = [
+        f"target {t['name']!r} has zero `severity: high` criteria "
+        f"({t['criteria_count']} criteria, all medium/low) -- it predicts "
+        f"`{t['predicted_status_on_zero_evidence']}` on TOTAL ABSENCE of evidence"
+        for t in risky
+    ]
+    return {"passed": passed, "errors": errors, "targets": targets, "risky_targets": [t["name"] for t in risky]}
+
+
+def emit_trace(trace_dir: str, status: str, snippet: str) -> str:
+    os.makedirs(trace_dir, exist_ok=True)
+    path = os.path.join(trace_dir, TRACE_BASENAME)
+    event = {
+        "kind": "eshkol_smoke",
+        "name": PROBE_ID,
+        "value": status,
+        "snippet": snippet[:2000],
+        "confidence": 1.0,
+    }
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+    return path
+
+
+# ───────────────────────────── self-test ─────────────────────────────
+
+# Reproduces the F19 shape exactly: one criterion, severity medium, nothing
+# else in the target -- must be flagged as a false-green risk.
+_RISKY_ORACLES = """
+oracles:
+  - name: selftest-gpu-like
+    requires:
+      - runtime_event:
+          event_kinds: [gpu_execution]
+          event_names: ["gpu_execution_gate"]
+          event_values: ["PASS"]
+        severity: medium
+        label: GPU tensor ops match the CPU reference within tolerance
+        action: ./tests/gpu/gpu_correctness_gate.sh
+"""
+
+# The fixed shape: same criterion, severity high -- must NOT be flagged.
+_FIXED_ORACLES = """
+oracles:
+  - name: selftest-gpu-like-fixed
+    requires:
+      - runtime_event:
+          event_kinds: [gpu_execution]
+          event_names: ["gpu_execution_gate"]
+          event_values: ["PASS"]
+        severity: high
+        label: GPU tensor ops match the CPU reference within tolerance
+        action: ./tests/gpu/gpu_correctness_gate.sh
+"""
+
+# A multi-criterion target where every criterion is medium/low -- also a
+# risk, and score-wise would predict `incomplete` rather than `ready` at 4+
+# criteria, but `incomplete` is still not `blocked` so it must still flag.
+_RISKY_MULTI_ORACLES = """
+oracles:
+  - name: selftest-multi-medium
+    requires:
+      - test_evidence: true
+        severity: medium
+        label: fixture A indexed
+        action: ctest -R a
+      - test_evidence: true
+        severity: medium
+        label: fixture B indexed
+        action: ctest -R b
+      - test_evidence: true
+        severity: low
+        label: fixture C indexed
+        action: ctest -R c
+      - test_evidence: true
+        severity: low
+        label: fixture D indexed
+        action: ctest -R d
+"""
+
+# A target with a mix, at least one high -- must NOT be flagged, since one
+# high-severity miss already forces `blocked` on zero evidence.
+_MIXED_SAFE_ORACLES = """
+oracles:
+  - name: selftest-mixed-safe
+    requires:
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+        severity: high
+        label: the load-bearing correctness claim
+        action: ./scripts/run_selftest.sh
+      - test_evidence: true
+        severity: medium
+        label: an explicitly advisory bookkeeping criterion
+        action: ctest -R advisory
+"""
+
+
+def _run_fixture(name: str, text: str, tmp_dir: str) -> dict:
+    path = os.path.join(tmp_dir, name + ".yaml")
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(text)
+    data = _load_yaml(path)
+    return audit(data)
+
+
+def self_test() -> bool:
+    cases = [
+        ("risky_single_medium (reproduces F19's gpu-execution shape)", _RISKY_ORACLES, False),
+        ("fixed_single_high", _FIXED_ORACLES, True),
+        ("risky_multi_medium_low", _RISKY_MULTI_ORACLES, False),
+        ("mixed_one_high_is_safe", _MIXED_SAFE_ORACLES, True),
+    ]
+
+    all_ok = True
+    with tempfile.TemporaryDirectory(dir=REPO_ROOT, prefix=".selftest-oracle-false-green-") as tmp_dir:
+        print("audit_oracle_false_green.py self-test:")
+        for name, text, expect_passed in cases:
+            result = _run_fixture(name, text, tmp_dir)
+            ok = result["passed"] == expect_passed
+            all_ok = all_ok and ok
+            verdict = "OK" if ok else "GATE IS BROKEN"
+            print(f"  [{verdict}] {name}: expected passed={expect_passed}, got passed={result['passed']}")
+            for t in result["targets"]:
+                print(
+                    f"           {t['name']}: {t['criteria_count']} criteria "
+                    f"{t['severity_histogram']} -> predicted "
+                    f"{t['predicted_status_on_zero_evidence']}/{t['predicted_score_on_zero_evidence']} "
+                    f"false_green_risk={t['false_green_risk']}"
+                )
+
+    if all_ok:
+        print("self-test: PASS -- the detector flags every zero-high-severity target "
+              "and clears every target with at least one high-severity criterion")
+    else:
+        print("self-test: FAIL -- the detector did not discriminate risky input from safe input", file=sys.stderr)
+    return all_ok
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--oracles", default=os.environ.get("ESHKOL_ORACLE_FILE", DEFAULT_ORACLES))
+    parser.add_argument("--trace-dir", default=DEFAULT_TRACE_DIR)
+    parser.add_argument("--no-trace", action="store_true", help="grade only, write no trace")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--self-test", action="store_true", help="run built-in red/green fixtures and exit")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return 0 if self_test() else 1
+
+    try:
+        data = _load_yaml(args.oracles)
+    except OracleAuditError as exc:
+        snippet = f"oracle file unusable: {exc}"
+        if not args.no_trace:
+            emit_trace(args.trace_dir, "FAIL", snippet)
+        if args.format == "json":
+            print(json.dumps({"passed": False, "error": str(exc)}, indent=2))
+        else:
+            print(f"{PROBE_ID}: FAIL -- {exc}", file=sys.stderr)
+        return 1
+
+    result = audit(data)
+    status = "PASS" if result["passed"] else "FAIL"
+    if result["passed"]:
+        snippet = f"{len(result['targets'])} targets, all carry >=1 severity:high criterion -- none can go ready on zero evidence"
+    else:
+        snippet = f"{len(result['risky_targets'])} false-green-risk target(s): " + ", ".join(result["risky_targets"])
+
+    if not args.no_trace:
+        emit_trace(args.trace_dir, status, snippet)
+
+    if args.format == "json":
+        print(json.dumps({"status": status, **result}, indent=2))
+    else:
+        print(f"{PROBE_ID}: {status}")
+        print(f"  oracle file : {args.oracles}")
+        print(f"  targets     : {len(result['targets'])}")
+        print()
+        header = f"{'target':<32} {'crit':>4}  {'high':>4} {'med':>4} {'low':>4}   {'pred.status':<11} {'pred.score':>10}  risk"
+        print(header)
+        print("-" * len(header))
+        for t in sorted(result["targets"], key=lambda t: (not t["false_green_risk"], t["name"])):
+            h = t["severity_histogram"]
+            marker = "  <-- FALSE-GREEN RISK" if t["false_green_risk"] else ""
+            print(
+                f"{t['name']:<32} {t['criteria_count']:>4}  {h['high']:>4} {h['medium']:>4} {h['low']:>4}   "
+                f"{t['predicted_status_on_zero_evidence']:<11} {t['predicted_score_on_zero_evidence']:>10}{marker}"
+            )
+        if result["errors"]:
+            print("\n  ERRORS:")
+            for error in result["errors"]:
+                print(f"    - {error}")
+
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_evidence_staleness.py
+++ b/scripts/check_evidence_staleness.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""Release gate: runtime-event evidence backing a `severity: high`
+`.icc/completion-oracles.yaml` criterion must not be older than N days.
+
+Motivating gap: ADR-0010 gap A13 ("GPU/quantum correctness produce no
+hosted evidence; fail *open* to SKIP") names its own proposed fix --
+"no evidence in N days = FAIL" -- and, as of the 2026-08-25 architectural
+audit (finding F19), `.icc/completion-oracles.yaml` implemented it for
+ZERO targets. The severity fix in this same changeset (F19) closes the
+"zero evidence at all" half of A13: every criterion is now `severity:high`
+(or an explicit ADVISORY), so a target with NO trace record for a
+criterion's `event_kinds` correctly reads `blocked`. This script closes
+the other half: a trace record that DOES exist but is old enough that it
+no longer says anything true about the current tree.
+
+Why this is a repo-side script and not a `max_age_days:` key in the oracle
+YAML itself: ICC's own grader
+(`completion_oracle_criteria._evaluate_criterion` /
+`_status_for_evidence`, in the private ICC tool this repo does not vendor)
+only consults a criterion's `max_age_days` for the `performance_budget`
+kind -- `_status_for_evidence`, which grades `runtime_event` (the kind
+every criterion in this file uses), never reads staleness at all, and
+`runtime_event`'s own trace records do not carry a `timestamp` field
+(see e.g. `check_oracle_schema.py`'s `emit_trace`, which never wrote
+one). Declaring `max_age_days` on a `runtime_event` criterion in the YAML
+would be silently ignored, which is a worse failure mode than not
+declaring it -- it would read as a staleness rule while enforcing nothing.
+So until ICC's `runtime_event` grading path gains the same `max_age_days`
+support `performance_budget` already has, staleness is enforced HERE, as
+its own repo-side gate over the trace corpus, with its own PASS/FAIL
+verdict fed back into the oracle file as an ordinary `eshkol_smoke`
+runtime_event (the same pattern `check_oracle_schema.py`,
+`check_ledger_integrity.py` and `gate_no_silent_wrong.py` already use) so
+`icc readiness` still sees the result even though it cannot compute it
+itself. See the note filed for the ICC feedback channel at
+~/.tsotchke/state/feedback/ for the upstream ask.
+
+What "freshness" means for a trace record here, in order of preference:
+    1. an explicit numeric `timestamp` field on the JSON record itself
+       (epoch seconds) -- if a probe ever starts emitting one, this script
+       already prefers it over (2) without any further change.
+    2. the mtime of the `.jsonl` file the record was read from. Every
+       probe in this repo (`run_icc_smoke.sh`, `run_stress.sh`, the gate
+       scripts themselves) OVERWRITES or appends to its trace file each
+       run, so file mtime is a faithful proxy for "when was this evidence
+       last produced" even though the JSON payload itself is undated.
+
+Default staleness window: 14 days (`--max-age-days`, env
+`ESHKOL_EVIDENCE_MAX_AGE_DAYS`). Rationale: this repo cuts CI-visible
+commits and merges daily-to-several-times-daily (see CHANGELOG.md), so a
+14-day-old GPU/stress/AD trace was produced against a tree that is, on
+this project's own cadence, many merges stale -- long enough to survive a
+missed weekend or a single delayed nightly run, short enough that a trace
+cannot silently outlive the feature it was measuring by a release cycle.
+Override per-CI-lane or per-workstation with `--max-age-days` if a
+slower-moving evidence class (e.g. a quarterly hosted-GPU run) needs a
+wider window; that is a deliberate, visible choice, not a silent default.
+
+Checks
+    For every `severity: high` `runtime_event` criterion in every oracle
+    target: find the newest matching trace record across `--trace-dir`
+    (matched by `event_kinds`, and by `event_names`/`event_values` when the
+    criterion declares them). If none exists, this gate has nothing to say
+    -- that is the absence case the severity fix already handles. If one
+    exists, compute its age; a criterion whose newest matching evidence is
+    older than `--max-age-days` is STALE.
+
+Grading
+    PASS  no `severity: high` criterion has evidence, and every criterion
+          that DOES have evidence has evidence newer than the window.
+    FAIL  at least one criterion's newest matching evidence has aged past
+          the window.
+
+The gate FAILS CLOSED: a missing or unparseable oracle file is FAIL. A
+missing trace directory is PASS-with-nothing-to-check (same "absence is
+not this gate's job" stance as above) unless `--require-trace-dir` is set.
+
+Usage
+    python3 scripts/check_evidence_staleness.py
+    python3 scripts/check_evidence_staleness.py --max-age-days 7
+    python3 scripts/check_evidence_staleness.py --trace-dir scripts/icc_traces
+    python3 scripts/check_evidence_staleness.py --format json
+    python3 scripts/check_evidence_staleness.py --self-test
+
+Exit status is 0 on PASS and 1 on FAIL.
+
+Copyright (C) tsotchke
+SPDX-License-Identifier: MIT
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+import tempfile
+import time
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_ORACLES = os.path.join(REPO_ROOT, ".icc", "completion-oracles.yaml")
+DEFAULT_TRACE_DIR = os.path.join(REPO_ROOT, "scripts", "icc_traces")
+TRACE_BASENAME = "evidence_staleness_gate.jsonl"
+PROBE_ID = "evidence_staleness_clean"
+DEFAULT_MAX_AGE_DAYS = 14.0
+
+
+class StalenessGateError(Exception):
+    """The oracle file could not be read or parsed at all."""
+
+
+def _load_yaml(path: str) -> object:
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise StalenessGateError(
+            "PyYAML is required to check evidence staleness (pip install pyyaml)"
+        ) from exc
+
+    if not os.path.isfile(path):
+        raise StalenessGateError(f"oracle file not found at {path} (the gate fails closed)")
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            return yaml.safe_load(handle)
+    except Exception as exc:
+        raise StalenessGateError(f"oracle file at {path} is not parseable: {exc}") from exc
+
+
+def _as_list(value: object) -> list:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
+
+def _criteria_of(oracle: dict) -> list:
+    raw = oracle.get("requires")
+    if raw is None:
+        raw = oracle.get("criteria")
+    if not isinstance(raw, list):
+        return []
+    return [c for c in raw if isinstance(c, dict)]
+
+
+def high_severity_runtime_event_criteria(data: dict) -> list[dict]:
+    """Every `severity: high` `runtime_event` criterion across every target."""
+
+    out: list[dict] = []
+    for oracle in _as_list(data.get("oracles")):
+        if not isinstance(oracle, dict):
+            continue
+        oracle_name = str(oracle.get("name") or oracle.get("target") or "<unnamed>")
+        for criterion in _criteria_of(oracle):
+            if criterion.get("severity") != "high":
+                continue
+            if "runtime_event" not in criterion and criterion.get("kind") != "runtime_event":
+                continue
+            raw = criterion.get("runtime_event")
+            payload = raw if isinstance(raw, dict) else {}
+            event_kinds = set(str(k) for k in _as_list(payload.get("event_kinds") or criterion.get("event_kinds")))
+            if not event_kinds:
+                continue
+            out.append({
+                "oracle": oracle_name,
+                "label": str(criterion.get("label") or "<unlabeled>"),
+                "event_kinds": event_kinds,
+                "event_names": set(str(n) for n in _as_list(payload.get("event_names") or criterion.get("event_names"))),
+                "event_values": set(str(v) for v in _as_list(payload.get("event_values") or criterion.get("event_values"))),
+            })
+    return out
+
+
+def _load_trace_records(trace_dir: str) -> list[dict]:
+    """Every JSON record from every `*.jsonl` file in `trace_dir`, each
+    tagged with `_file` and `_file_mtime` for the file-mtime fallback."""
+
+    records: list[dict] = []
+    for path in sorted(glob.glob(os.path.join(trace_dir, "*.jsonl"))):
+        try:
+            file_mtime = os.path.getmtime(path)
+        except OSError:
+            continue
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                for line in handle:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(record, dict):
+                        continue
+                    record["_file"] = path
+                    record["_file_mtime"] = file_mtime
+                    records.append(record)
+        except OSError:
+            continue
+    return records
+
+
+def _record_age_days(record: dict, now: float) -> tuple[float, str]:
+    """(age_days, source) -- source is "record_timestamp" or "file_mtime"."""
+
+    stamp = record.get("timestamp")
+    if isinstance(stamp, (int, float)):
+        return max(0.0, (now - float(stamp)) / 86400.0), "record_timestamp"
+    return max(0.0, (now - float(record["_file_mtime"])) / 86400.0), "file_mtime"
+
+
+def _record_matches(record: dict, criterion: dict) -> bool:
+    if str(record.get("kind")) not in criterion["event_kinds"]:
+        return False
+    if criterion["event_names"] and str(record.get("name")) not in criterion["event_names"]:
+        return False
+    if criterion["event_values"]:
+        value = record.get("value")
+        if str(value) not in criterion["event_values"]:
+            return False
+    return True
+
+
+def check(
+    data: object,
+    trace_dir: str,
+    max_age_days: float,
+    now: float | None = None,
+    require_trace_dir: bool = False,
+) -> dict:
+    """Never raises; returns a report."""
+
+    now = time.time() if now is None else now
+
+    if not isinstance(data, dict):
+        return {"passed": False, "errors": ["oracle document is not a mapping"], "criteria": []}
+
+    criteria = high_severity_runtime_event_criteria(data)
+
+    if not os.path.isdir(trace_dir):
+        if require_trace_dir:
+            return {
+                "passed": False,
+                "errors": [f"trace directory {trace_dir} does not exist (--require-trace-dir set)"],
+                "criteria": [],
+            }
+        return {
+            "passed": True,
+            "errors": [],
+            "criteria": [],
+            "note": f"trace directory {trace_dir} does not exist -- nothing to check "
+                    "(absence-of-evidence is the severity gate's job, not this one's)",
+        }
+
+    records = _load_trace_records(trace_dir)
+
+    rows: list[dict] = []
+    stale: list[dict] = []
+    for criterion in criteria:
+        matches = [r for r in records if _record_matches(r, criterion)]
+        if not matches:
+            continue  # no evidence at all: out of scope for staleness
+        ages = [(_record_age_days(r, now), r) for r in matches]
+        (best_age, source), newest_record = min(ages, key=lambda pair: pair[0][0])
+        row = {
+            "oracle": criterion["oracle"],
+            "label": criterion["label"],
+            "age_days": round(best_age, 2),
+            "age_source": source,
+            "trace_file": newest_record.get("_file"),
+            "is_stale": best_age > max_age_days,
+        }
+        rows.append(row)
+        if row["is_stale"]:
+            stale.append(row)
+
+    errors = [
+        f"{row['oracle']!r} / {row['label']!r}: newest matching evidence is "
+        f"{row['age_days']:.1f} days old (source: {row['age_source']}, "
+        f"{row['trace_file']}), past the {max_age_days:g}-day window"
+        for row in stale
+    ]
+    return {"passed": not errors, "errors": errors, "criteria": rows, "max_age_days": max_age_days}
+
+
+def emit_trace(trace_dir: str, status: str, snippet: str) -> str:
+    os.makedirs(trace_dir, exist_ok=True)
+    path = os.path.join(trace_dir, TRACE_BASENAME)
+    event = {
+        "kind": "eshkol_smoke",
+        "name": PROBE_ID,
+        "value": status,
+        "snippet": snippet[:2000],
+        "confidence": 1.0,
+    }
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+    return path
+
+
+# ───────────────────────────── self-test ─────────────────────────────
+
+_SELFTEST_ORACLES = """
+oracles:
+  - name: selftest-staleness
+    requires:
+      - runtime_event:
+          event_kinds: [selftest_kind]
+          event_names: ["selftest_probe"]
+          event_values: ["PASS"]
+        severity: high
+        label: self-test staleness probe
+        action: ./scripts/run_selftest.sh
+"""
+
+
+def _write_trace(trace_dir: str, filename: str, record: dict, mtime: float | None = None) -> None:
+    path = os.path.join(trace_dir, filename)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+
+
+def self_test() -> bool:
+    now = time.time()
+    cases: list[tuple[str, bool]] = []
+
+    with tempfile.TemporaryDirectory(dir=REPO_ROOT, prefix=".selftest-evidence-staleness-") as tmp_dir:
+        oracle_path = os.path.join(tmp_dir, "oracles.yaml")
+        with open(oracle_path, "w", encoding="utf-8") as handle:
+            handle.write(_SELFTEST_ORACLES)
+        data = _load_yaml(oracle_path)
+
+        # Case 1: fresh trace (mtime = now) -> PASS.
+        fresh_dir = os.path.join(tmp_dir, "fresh")
+        os.makedirs(fresh_dir)
+        _write_trace(
+            fresh_dir, "selftest.jsonl",
+            {"kind": "selftest_kind", "name": "selftest_probe", "value": "PASS"},
+            mtime=now,
+        )
+        result = check(data, fresh_dir, max_age_days=14.0, now=now)
+        cases.append(("fresh_trace_passes", result["passed"] is True))
+
+        # Case 2: backdated trace (mtime = 20 days ago, past the 14-day
+        # default window) -> FAIL. This is the actual "prove it can go RED"
+        # requirement: a trace file whose mtime is deliberately set into the
+        # past via os.utime, exactly reproducing what a stale GPU/stress
+        # trace nobody re-ran in three weeks looks like on disk.
+        stale_dir = os.path.join(tmp_dir, "stale")
+        os.makedirs(stale_dir)
+        backdated = now - 20 * 86400.0
+        _write_trace(
+            stale_dir, "selftest.jsonl",
+            {"kind": "selftest_kind", "name": "selftest_probe", "value": "PASS"},
+            mtime=backdated,
+        )
+        result = check(data, stale_dir, max_age_days=14.0, now=now)
+        cases.append(("backdated_trace_fails", result["passed"] is False and len(result["errors"]) == 1))
+
+        # Case 3: explicit record timestamp overrides file mtime, and a
+        # stale explicit timestamp is caught even with a fresh file mtime.
+        ts_dir = os.path.join(tmp_dir, "explicit_timestamp")
+        os.makedirs(ts_dir)
+        _write_trace(
+            ts_dir, "selftest.jsonl",
+            {"kind": "selftest_kind", "name": "selftest_probe", "value": "PASS", "timestamp": backdated},
+            mtime=now,
+        )
+        result = check(data, ts_dir, max_age_days=14.0, now=now)
+        cases.append(("explicit_stale_timestamp_beats_fresh_mtime", result["passed"] is False))
+
+        # Case 4: no matching evidence at all -> PASS (absence is the
+        # severity gate's job, not this one's).
+        empty_dir = os.path.join(tmp_dir, "empty")
+        os.makedirs(empty_dir)
+        result = check(data, empty_dir, max_age_days=14.0, now=now)
+        cases.append(("no_evidence_is_not_this_gates_job", result["passed"] is True and not result["criteria"]))
+
+        # Case 5: missing trace dir -> PASS unless --require-trace-dir.
+        missing_dir = os.path.join(tmp_dir, "does-not-exist")
+        result = check(data, missing_dir, max_age_days=14.0, now=now)
+        cases.append(("missing_trace_dir_passes_by_default", result["passed"] is True))
+        result = check(data, missing_dir, max_age_days=14.0, now=now, require_trace_dir=True)
+        cases.append(("missing_trace_dir_fails_when_required", result["passed"] is False))
+
+    all_ok = True
+    print("check_evidence_staleness.py self-test:")
+    for name, ok in cases:
+        all_ok = all_ok and ok
+        verdict = "OK" if ok else "GATE IS BROKEN"
+        print(f"  [{verdict}] {name}")
+
+    if all_ok:
+        print("self-test: PASS -- the gate goes RED on backdated evidence and does not "
+              "false-positive on fresh, absent, or missing-directory cases")
+    else:
+        print("self-test: FAIL -- the staleness gate did not discriminate correctly", file=sys.stderr)
+    return all_ok
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--oracles", default=os.environ.get("ESHKOL_ORACLE_FILE", DEFAULT_ORACLES))
+    parser.add_argument("--trace-dir", default=os.environ.get("ESHKOL_TRACE_DIR", DEFAULT_TRACE_DIR))
+    parser.add_argument(
+        "--max-age-days", type=float,
+        default=float(os.environ.get("ESHKOL_EVIDENCE_MAX_AGE_DAYS", DEFAULT_MAX_AGE_DAYS)),
+    )
+    parser.add_argument("--require-trace-dir", action="store_true")
+    parser.add_argument("--emit-trace-dir", default=DEFAULT_TRACE_DIR,
+                         help="where this gate's own PASS/FAIL trace is written (default: --trace-dir's usual home)")
+    parser.add_argument("--no-trace", action="store_true", help="grade only, write no trace")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--self-test", action="store_true", help="run built-in red/green fixtures and exit")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return 0 if self_test() else 1
+
+    try:
+        data = _load_yaml(args.oracles)
+    except StalenessGateError as exc:
+        snippet = f"oracle file unusable: {exc}"
+        if not args.no_trace:
+            emit_trace(args.emit_trace_dir, "FAIL", snippet)
+        if args.format == "json":
+            print(json.dumps({"passed": False, "error": str(exc)}, indent=2))
+        else:
+            print(f"{PROBE_ID}: FAIL -- {exc}", file=sys.stderr)
+        return 1
+
+    result = check(data, args.trace_dir, args.max_age_days, require_trace_dir=args.require_trace_dir)
+    status = "PASS" if result["passed"] else "FAIL"
+    if result["passed"]:
+        checked = len(result.get("criteria", []))
+        snippet = result.get("note") or f"{checked} criteria had matching evidence, none past {args.max_age_days:g} days"
+    else:
+        snippet = f"{len(result['errors'])} stale criterion/criteria: " + "; ".join(result["errors"][:5])
+
+    if not args.no_trace:
+        emit_trace(args.emit_trace_dir, status, snippet)
+
+    if args.format == "json":
+        print(json.dumps({"status": status, **result}, indent=2))
+    else:
+        print(f"{PROBE_ID}: {status}")
+        print(f"  oracle file    : {args.oracles}")
+        print(f"  trace dir      : {args.trace_dir}")
+        print(f"  max age (days) : {args.max_age_days:g}")
+        if result.get("note"):
+            print(f"  note           : {result['note']}")
+        if result.get("criteria"):
+            print(f"  criteria with evidence : {len(result['criteria'])}")
+            for row in result["criteria"]:
+                marker = "  <-- STALE" if row["is_stale"] else ""
+                print(f"    - {row['oracle']:<28} {row['age_days']:>7.2f}d ({row['age_source']}){marker}")
+        if result["errors"]:
+            print("  ERRORS:")
+            for error in result["errors"]:
+                print(f"    - {error}")
+
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
# Summary

`icc readiness --target gpu-execution` read `ready/94` on a host that had
executed zero GPU kernels — a measured false green (2026-08-25 architectural
audit, finding F19; ADR-0010 gap A13 demonstrated rather than merely
predicted). The mechanism: the target's one criterion was `severity: medium`,
and ICC's grader (`_status_for_missing`) degrades a zero-evidence miss to
`WARN` unless severity is `high`; `WARN` costs only 3 score points, so the
target cleared the `ready` threshold on pure absence. The four Ozaki targets
in the same file, on the same host, with the same absent GPU evidence,
correctly read `blocked/89` because their criteria are `severity: high` —
proof the fix is the severity declaration, not the oracle format.

This PR (1) audits every oracle target for the same shape, not just
`gpu-execution`, (2) raises severities so absent evidence blocks for every
criterion that asserts a correctness/capability claim, keeping four
criteria explicitly advisory with a comment justifying each, (3) arms the
staleness half of ADR-0010 A13 ("no evidence in N days = FAIL") as a
repo-side gate, since ICC's `runtime_event` grading has no `max_age_days`
support today, and (4) proves both new gates can actually go RED.

## 1. Full per-target false-green audit (`scripts/audit_oracle_false_green.py`)

New gate: for every oracle target, predicts whether TOTAL absence of
evidence would let ICC's own status rule escape `blocked` (it can only be
forced `blocked` by a `severity: high` criterion FAILing). **Before this PR,
`gpu-execution` was the only one of 35 targets with zero `severity: high`
criteria** — every other target already had at least one, so this was a
single-target defect at the target-classification level. Full before-table:

```
target                           crit  high  med  low   pred.status pred.score  risk
------------------------------------------------------------------------------------
gpu-execution                       1     0    1    0   ready               97  <-- FALSE-GREEN RISK
ad-depth                            1     1    0    0   blocked             92
ad-oracle                           1     1    0    0   blocked             92
ad-taylor-campaign                 13    10    3    0   blocked             11
agent-ffi-ready                     7     5    2    0   blocked             54
cuda-ozaki-int8-correctness         1     1    0    0   blocked             92
depth-coverage                      1     1    0    0   blocked             92
differential-clean                  2     2    0    0   blocked             84
edge-matrix                         1     1    0    0   blocked             92
eshkol-compiler-readiness          48    44    4    0   blocked              0
generative-differential             2     2    0    0   blocked             84
metamorphic-laws                    1     1    0    0   blocked             92
metaprog-depth                      1     1    0    0   blocked             92
nesting-depth                       1     1    0    0   blocked             92
no-regression                       3     2    1    0   blocked             81
numeric-depth                       1     1    0    0   blocked             92
ozaki-certification                 1     1    0    0   blocked             92
ozaki-ii-correctness                1     1    0    0   blocked             92
ozaki-ii-fast                       1     1    0    0   blocked             92
recursion-depth                     1     1    0    0   blocked             92
reference-diff                      2     2    0    0   blocked             84
sanitizer-fuzz-clean                3     3    0    0   blocked             76
sdnc-paper-reproducibility          4     3    1    0   blocked             73
sicp-completeness                  88    88    0    0   blocked              0
stdlib-ready                        3     1    2    0   blocked             86
stress-budget                       9     6    3    0   blocked             43
tensor-collection-depth             1     1    0    0   blocked             92
total-language-coverage             5     3    2    0   blocked             70
v1.2-release                        8     6    2    0   blocked             46
v1.3-evolve                        34    31    3    0   blocked              0
v1.3.4-edge-coverage                7     7    0    0   blocked             44
v1.4-release                        5     4    1    0   blocked             65
v1.5-release                        5     4    1    0   blocked             65
vm-parity                           2     2    0    0   blocked             84
wasm-execute-diff                   1     1    0    0   blocked             92
```

**But target-level was not the whole story.** 14 targets carried individual
`medium`-severity criteria that assert measured correctness/capability
claims even though their target was already correctly `blocked` by other
`high` criteria — each one a latent false green for that *specific* claim:
if the other high-severity criteria in the same target ever got evidence
and passed, that one correctness claim could go unverified forever without
ever blocking the target. Swept 22 of these to `severity: high` (see §2).

After the fix, every one of the 35 targets predicts `blocked` on total
absence of evidence — 0 remaining false-green risks:

```
target                           crit  high  med  low   pred.status pred.score  risk
------------------------------------------------------------------------------------
(all 35 targets, sorted)          ...   ...    0    0   blocked   0-92   (none flagged)
```

Full after-table and script output are in the evidence directory /
`scripts/audit_oracle_false_green.py --no-trace`.

## 2. Severity sweep — 23 criteria raised, 4 kept explicitly advisory

- `gpu-execution`'s sole criterion (F19's own target): `medium` → `high`.
- 22 more criteria across `eshkol-compiler-readiness`, `total-language-coverage`,
  `agent-ffi-ready`, `stdlib-ready`, `v1.2-release`, `v1.3-evolve`,
  `ad-taylor-campaign`, `v1.4-release`, `v1.5-release`,
  `sdnc-paper-reproducibility`, `no-regression`, `stress-budget`: `medium` →
  `high`, each with an inline comment explaining why it is a measured
  correctness/capability claim (output shape, numerical convergence,
  bit-agreement, cache-invalidation behaviour, a real-vs-stub code path,
  a stress-budget ceiling) rather than fixture bookkeeping.
- 4 criteria kept at `medium`, each with an explicit `# ADVISORY:` comment:
  `total-language-coverage`'s two `test_evidence` criteria ("tests are
  indexed", "the anti-gaming guard's own test suite is indexed"),
  `agent-ffi-ready`'s "smoke tests indexed", and `stdlib-ready`'s "each
  module has a regression test" — all `test_evidence`-kind criteria
  certifying fixture *presence*, not measured behaviour; the actual
  behavioural claims each one supports are already covered by sibling
  `severity: high` criteria in the same target.

`scripts/check_oracle_schema.py` still passes at 268/268 criteria graded
(up from 266 — two new criteria wire the gates below into
`eshkol-compiler-readiness`).

## 3. Staleness (ADR-0010 A13's own proposal, armed for the first time)

ADR-0010 A13 proposes "no evidence in N days = FAIL." Investigated wiring
`max_age_days:` directly onto the `runtime_event` criteria this file uses,
and found ICC's grader never reads `max_age_days` on that code path — only
`performance_budget` criteria get it — and `runtime_event` trace records
carry no `timestamp` field to begin with (`check_oracle_schema.py`'s
`emit_trace` never wrote one, and neither does any sibling gate). Declaring
the key would be silently ignored: worse than not declaring it.

`scripts/check_evidence_staleness.py` implements it repo-side: for every
`severity: high` `runtime_event` criterion, finds the newest matching trace
record (by `event_kinds`/`event_names`/`event_values`) across `--trace-dir`,
prefers an explicit record `timestamp` if present else the trace file's
mtime, and FAILs if that age exceeds `--max-age-days` (**default 14 days**,
`$ESHKOL_EVIDENCE_MAX_AGE_DAYS`). Absence of evidence is out of scope — §1/§2
already handle that. 14 days: this repo merges daily-to-several-times-daily
(see CHANGELOG.md cadence), so a 14-day-old trace was measured against a
tree many merges stale — long enough to survive a missed weekend or one
delayed nightly run, short enough that evidence cannot silently outlive the
feature it measured by a release cycle. Fully configurable per-lane.

Wired into `eshkol-compiler-readiness` as an ordinary `eshkol_smoke`
`runtime_event` criterion (same pattern as `check_oracle_schema.py` /
`gate_no_silent_wrong.py`), so `icc readiness` sees the verdict even though
it cannot compute it. Filed the upstream ICC gap at
`~/.tsotchke/state/feedback/2026-08-25-note-to-icc-runtime-event-staleness.md`
(outside this repo): `runtime_event` grading needs the same `max_age_days`
support `performance_budget` already has, plus a `timestamp` field on
emitted trace records.

## 4. Self-tests — both gates prove they can go RED

- `audit_oracle_false_green.py --self-test`: 4 fixtures — a single
  `medium` criterion (reproduces F19's exact shape) flags RED; the same
  criterion at `high` clears GREEN; a 4-criterion all-medium/low target
  flags RED (predicts `incomplete`, still not `blocked`); a target with one
  `high` among a `medium` sibling clears GREEN. All pass.
- `check_evidence_staleness.py --self-test`: 6 cases — a trace backdated 20
  days via `os.utime` past the 14-day default FAILs; an explicit stale
  `timestamp` field fails even under a fresh file mtime; a fresh trace, an
  absent-evidence case, and a missing trace directory all PASS (with
  `--require-trace-dir` flipping the last one to FAIL). All pass.
- Also demonstrated end-to-end against the REAL oracle file: a genuinely
  backdated `gpu_execution`-kind trace correctly FAILs the real
  `gpu-execution` criterion (`age_days=20.00`, `source=file_mtime`) —
  evidence saved under `.worktrees/v135/evidence/false-green/staleness_demo*`.

## Before / after (`icc readiness --target gpu-execution`)

The 2026-08-25 audit measured `ready/94` on its own registration. Re-measured
independently on a fresh registration of this same file, before any fix:

```
Status: ready    Score: 90
| WARN | medium | gpu_execution | 0 evidence |
Oracle: incomplete
```

After this PR (same trace directory — still zero GPU evidence, because no
GPU code ran):

```
Status: blocked  Score: 85
| FAIL | high   | gpu_execution | 0 evidence |
Oracle: blocked
```

(Absolute scores differ slightly between registrations/hosts due to
cross-cutting graph-gap/runtime-check terms unrelated to this fix — the
load-bearing change is `ready`→`blocked` and `WARN`→`FAIL`, which is exact
and reproducible.)

## Verification

- `python3 scripts/check_oracle_schema.py` — PASS (268/268 criteria)
- `python3 scripts/check_ledger_integrity.py` — PASS
- `python3 scripts/gate_no_silent_wrong.py` — PASS
- `python3 scripts/audit_oracle_false_green.py` — PASS (0/35 targets vulnerable)
- `python3 scripts/check_evidence_staleness.py` — PASS
- All five `--self-test` — PASS
- ctest — see CI / evidence directory
- Wired into `.github/workflows/ci.yml`'s `assurance-gates` job, following
  the existing fast no-compiler-needed pattern.
- ICC: registered `eshkol-false-green`, `index --force`, `build-memory`,
  `guard-diff` clean, `pre-commit-check` PASS.

Not merging — opening for review per instructions.
