### PR TITLE
fix(harness): distinguish infrastructure failure from code failure in emitted traces

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -198,6 +198,29 @@ oracles:
         label: 'Every branch-protection required status context is reportable on every PR shape CI can produce, including docs-only (scripts/check_required_context_consistency.py)'
         action: python3 scripts/check_required_context_consistency.py
 
+      # ── Harness infra-vs-defect taxonomy (2026-08-25 architecture audit,
+      # section 3) ──────────────────────────────────────────────────────
+      # Every runtime_event criterion in THIS oracle — including the ones
+      # above and below this line — depends on the same premise: a probe
+      # that could not obtain a verdict must never publish the same "PASS"
+      # this criterion's own event_values match on for a probe that
+      # genuinely succeeded, and must never publish a false FAIL either. A
+      # 140s cold-start JIT compile killed by a 60s alarm once turned the
+      # HIGH invariant INV-dispatch-table-completeness red through exactly
+      # this channel. scripts/lib/harness_outcome.sh is the shared fix;
+      # this criterion is the regression test proving the PASS/FAIL/INFRA
+      # split it provides is real (tests/harness/harness_outcome_taxonomy_test.sh,
+      # 17 checks: timeout and missing-binary classify INFRA and publish no
+      # test_result, a completed wrong answer and a self-raised crash still
+      # classify FAIL and do publish one, and only INFRA is ever retried).
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["harness_outcome_taxonomy"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'scripts/lib/harness_outcome.sh distinguishes infrastructure failure (timeout, missing binary — INFRA, no false test_result, retried once) from a genuine code defect (wrong answer or self-raised crash — FAIL, always recorded, never retried)'
+        action: bash tests/harness/harness_outcome_taxonomy_test.sh
+
       - runtime_event:
           event_kinds: [eshkol_smoke]
           event_names: ["llvm_module_verifier_clean"]

--- a/scripts/lib/harness_outcome.sh
+++ b/scripts/lib/harness_outcome.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+# harness_outcome.sh — the PASS / FAIL / INFRA / SKIP taxonomy every
+# trace-emitting harness uses to report its own verdict.
+#
+# WHY THIS EXISTS
+#
+# The 2026-08-25 architecture audit (ESHKOL-ARCHITECTURE-AUDIT-2026-08-25.md,
+# note on harness weakness + section 3 VM-parity flake analysis) measured two
+# independent harnesses that could not tell "the code failed" from "the
+# harness could not run", and wrote the indistinguishable red into a trace
+# other tools consume:
+#
+#   (a) scripts/run_vm_parity.sh reported FAIL "2 of 188" where both
+#       failures were `native -r exited 142` (SIGALRM) on
+#       28_multiple_values_complete.esk, caused by a 140-second cold-start
+#       JIT/stdlib compile on a machine at load average 180 across 24 cores.
+#       Direct re-runs: 140.49s, then 0.07s, then 0.06s — exit 0,
+#       byte-identical output every time. That spurious FAIL propagated
+#       through `emit_test_result` into `icc architecture-verify` and turned
+#       the HIGH invariant INV-dispatch-table-completeness red.
+#
+#   (b) The `language_surface_coverage_floor` smoke probe in
+#       scripts/run_icc_smoke.sh reported exit 1 while a direct run of
+#       scripts/run_language_coverage.sh gave exit 0 with 1106/1106
+#       (100.0%), 0 uncovered.  Root cause: scripts/run_language_coverage.sh
+#       reruns the ENTIRE test suite (scripts/run_all_tests.sh, tens of
+#       minutes) as a prerequisite before it ever computes the coverage
+#       floor; under `set -euo pipefail`, ANY single flaky test in that
+#       rerun — an environment-driven flake under concurrent load, not a
+#       coverage regression — aborted the whole script before
+#       scripts/language_coverage.py (which computes the real, already-good,
+#       1106/1106 result) ever ran.  scripts/run_icc_smoke.sh's `probe()`
+#       has no INFRA classification, so the abort landed as a bare FAIL.
+#
+# Both incidents have the same shape: an expensive gate that can report red
+# for environmental reasons, and a trace format with no way to say so. This
+# file is the fix: a shared, small vocabulary every harness can emit, plus a
+# timeout wrapper that actually produces a distinguishable "this timed out"
+# signal (the old exec-then-perl-alarm pattern used by run_vm_parity.sh could
+# not — see eshkol_outcome_guarded below).
+#
+# THE FOUR OUTCOMES
+#
+#   PASS   the code under test produced the correct/expected result.
+#   FAIL   the code under test ran to completion and produced a WRONG
+#          result, or the harness completed a full, valid attempt and the
+#          verdict is negative. A real defect.
+#   INFRA  the harness could not obtain a verdict: timeout, OOM, an
+#          unexpectedly missing dependency/build artifact, a toolchain
+#          changed out from under the run, disk full, network unavailable,
+#          killed by an unrelated signal. Says nothing about correctness.
+#   SKIP   deliberately not run (hardware/toolchain absent BY DESIGN, e.g.
+#          no CUDA GPU on this host). Distinct from INFRA: SKIP is expected
+#          and stable; INFRA is an unexpected environment failure during an
+#          attempted run. (Existing convention: exit 77, see
+#          run_wasm_differential.sh; unchanged by this file.)
+#
+# THE CONTRACT
+#
+#   source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/harness_outcome.sh"
+#
+#   eshkol_outcome_guarded <seconds> <cmd...>
+#     A real, signal-observing timeout wrapper. Prints nothing; the child's
+#     stdout/stderr pass through untouched. Exit code is EXACTLY one of:
+#       <child's own exit code>   the child ran to completion
+#       124                       the child was killed because it exceeded
+#                                 <seconds> (the canonical GNU-timeout code)
+#       128+N                     the child died from signal N it received
+#                                 on ITS OWN (not from our alarm) — e.g. a
+#                                 real SIGSEGV is still 139, unmasked
+#       125                       this wrapper itself could not fork/wait
+#     This replaces the exec-then-`local $SIG{ALRM}`-in-the-same-process
+#     pattern the audit's measured incident traces back to: `exec` replaces
+#     the whole process image, including Perl's own alarm handler, so a
+#     child that is still running when the alarm fires is killed by
+#     SIGALRM under ITS default disposition — exit 128+14 = 142, exactly
+#     the number F13 measured — rather than the wrapper's own controlled
+#     124. `eshkol_outcome_guarded` forks instead of exec'ing directly, so
+#     the alarm always fires in the still-alive parent, which explicitly
+#     TERMs then KILLs the child and reports a stable 124. A real hang is
+#     therefore still caught (nothing here disables or widens the alarm) —
+#     it is just reported as a fact about the CLOCK, not folded into the
+#     child's own exit-code space where it is indistinguishable from a
+#     signal the program under test raised on its own.
+#
+#   eshkol_outcome_classify_exit <exit_code>
+#     Prints exactly one of PASS / FAIL / INFRA for a raw exit code already
+#     captured by the caller (e.g. from eshkol_outcome_guarded, or from any
+#     `run_all_tests.sh`-style prerequisite step). 0 -> PASS. A fixed set of
+#     harness-shaped codes -> INFRA: 124/125 (this file's own timeout
+#     wrapper), 142 (legacy SIGALRM-default-disposition kill — the exact
+#     code the audit measured, recognized for back-compat with any caller
+#     not yet migrated to eshkol_outcome_guarded), 137 (SIGKILL, usually the
+#     OOM killer), 130 (SIGINT, an operator/CI abort), 127 (the universal
+#     shell/exec "command not found" convention — every `exit 127` in this
+#     codebase is an exec-a-child guard's missing-binary sentinel, never a
+#     program's own meaningful exit code, so it is the taxonomy's "missing
+#     dependency/unbuildable" INFRA case). Everything else -> FAIL, on the
+#     principle that an unrecognized nonzero exit is a claim about the CODE
+#     until a harness explicitly says otherwise.
+#
+#   eshkol_outcome_emit_event <trace_file> <kind> <name> <outcome> <snippet> [confidence]
+#     Appends one JSON-L record: {"kind","name","value":<outcome>,"snippet",
+#     "confidence"}. <outcome> is PASS/FAIL/INFRA/SKIP (or "INFRA:<reason>",
+#     stored verbatim in value — completion-oracle criteria match on the
+#     literal string, so a reason suffix does not accidentally satisfy an
+#     `event_values: ["PASS"]` or `["INFRA"]` filter; keep the bare token as
+#     the leading text when a consumer needs to match on it and put detail
+#     in the snippet instead). Safe to call from a `set -e` script — never
+#     exits nonzero itself.
+#
+#   eshkol_outcome_emit_test_result <trace_file> <name> <outcome> <snippet>
+#     Writes the canonical kind:"test_result" event
+#     ({"passed": bool, "summary": ...}) used by ICC's architecture
+#     invariants (e.g. INV-dispatch-table-completeness), but ONLY for
+#     outcome PASS or FAIL. For INFRA or SKIP this function writes NOTHING
+#     and returns 0. See "WHY INFRA EMITS NO test_result" below.
+#
+#   eshkol_outcome_retry_guarded <seconds> <outfile> <errfile> <cmd...>
+#     Runs eshkol_outcome_guarded once, capturing stdout/stderr to the given
+#     files (truncated fresh on each attempt — this function owns the
+#     redirection itself so a retry cannot concatenate a timed-out first
+#     attempt's partial output with the clean second attempt's); if (and
+#     only if) that attempt classifies as INFRA, retries exactly once more
+#     with the same timeout before concluding. Never retries a real FAIL (a
+#     completed run with a wrong answer must not get a second, quieter
+#     chance — only the clock does). Returns the LAST attempt's exit code.
+#     This is the direct fix for incident (a): a cold-start timeout gets one
+#     retry, at which point the JIT cache populated by the first attempt
+#     makes the second attempt fast, exactly as F13 measured (140.49s once,
+#     then 0.07s, then 0.06s).
+#
+# WHY INFRA EMITS NO test_result
+#
+# ICC's architecture-verify reads `test_result` events through
+# `_check_parity_evidence` (used by `intended-invariant` invariants such as
+# INV-dispatch-table-completeness, in
+# ~/Desktop/infinite_context_coder/scripts/architecture_model_service.py).
+# That evaluator is a two-state PASS/FAIL machine with no third state:
+# the newest matching event with `value.passed == true` within the
+# freshness window (`max_age_days`) is PASS; a matching event with
+# `passed == false`, a STALE matching event, or NO matching event at all
+# are ALL "FAIL" for a high/critical-severity invariant (there is no
+# UNCHECKABLE branch in this evaluator; `_status_for_missing("high")` is
+# unconditionally "FAIL"). So a harness cannot, today, publish "I could not
+# get a verdict" through this specific channel without it reading exactly
+# like "the code is wrong" to that one consumer. Given that hard
+# constraint, the safest encoding available without an ICC-side change is:
+# never publish a `passed:false` record for a run that produced no real
+# verdict. Emitting nothing leaves whichever verdict (if any) is already on
+# file inside the freshness window standing, rather than overwriting a
+# possibly-still-valid recent PASS with a false, environment-caused red.
+# This is documented and deliberate, not an oversight — see the "ICC-side
+# change" note below and ~/.tsotchke/state/feedback/ for the request to add
+# a third `outcome` value this evaluator can treat as "leave the standing
+# verdict alone" instead of defaulting every non-pass to FAIL.
+#
+# The richer, domain-specific event streams this file also writes to
+# (kind:"vm_parity", kind:"eshkol_smoke", ...) DO get an explicit INFRA
+# value, because their consumer — ICC's `completion-oracle` `runtime_event`
+# criterion — only ever treats `event_values: ["PASS"]` as satisfying a
+# criterion; INFRA and FAIL are equally "not yet satisfied" to that
+# matcher (see completion_oracle_criteria.py:_event_matches, which filters
+# candidate evidence by exact value membership before any status logic
+# runs), so recording the honest value costs nothing there and is strictly
+# more informative to a human or an audit reading the trace than
+# overloading FAIL.
+#
+# ICC-SIDE CHANGE THIS FILE DOES NOT (AND SHOULD NOT) MAKE
+#
+# `_check_parity_evidence` in architecture_model_service.py could grow a
+# third state — read `value.outcome` if present (INFRA) and, on INFRA,
+# return the PRIOR verdict (PASS/FAIL/UNCHECKABLE) unchanged rather than
+# collapsing to FAIL — so a harness could publish an honest "I tried, no
+# verdict" record instead of relying on silence. That is a change to a
+# different repository (infinite_context_coder) and is out of scope for
+# this PR; it is recorded for the maintainer at
+# ~/.tsotchke/state/feedback/ rather than made here.
+
+if [ -n "${ESHKOL_HARNESS_OUTCOME_SH_LOADED:-}" ]; then
+    return 0 2>/dev/null || true
+fi
+ESHKOL_HARNESS_OUTCOME_SH_LOADED=1
+
+# ── eshkol_outcome_guarded ──────────────────────────────────────────────
+eshkol_outcome_guarded() { # seconds cmd...
+    local secs="$1"; shift
+    perl -e '
+        use POSIX ":sys_wait_h";
+        my $secs = shift @ARGV;
+        my $pid = fork();
+        if (!defined $pid) { exit 125; }
+        if ($pid == 0) {
+            exec { $ARGV[0] } @ARGV or exit 127;
+        }
+        my $timed_out = 0;
+        local $SIG{ALRM} = sub {
+            $timed_out = 1;
+            kill("TERM", $pid);
+            select(undef, undef, undef, 0.5);
+            kill("KILL", $pid);
+        };
+        alarm($secs);
+        my $reaped = waitpid($pid, 0);
+        alarm(0);
+        my $status = $?;
+        if ($reaped != $pid) { exit 125; }
+        if ($timed_out) { exit 124; }
+        if (($status & 127) != 0) {
+            # Child died from a signal we did not send ourselves: a real
+            # crash, not a timeout. Preserve the signal in the exit code
+            # (128+N) rather than folding it into 124.
+            exit (128 + ($status & 127));
+        }
+        exit ($status >> 8);
+    ' "$secs" "$@"
+}
+
+# ── eshkol_outcome_classify_exit ─────────────────────────────────────────
+eshkol_outcome_classify_exit() { # exit_code
+    local rc="$1"
+    case "$rc" in
+        0) printf 'PASS\n' ;;
+        124|125|130|137|142) printf 'INFRA\n' ;;
+        # 127 is the universal shell/exec convention for "command not
+        # found" — in this codebase it is exclusively the sentinel every
+        # exec-a-child guard (this file's eshkol_outcome_guarded included)
+        # emits when the target binary itself is missing, never a program's
+        # own meaningful exit code (verified: every `exit 127` site in
+        # scripts/ is one of these guards). That is the taxonomy's own
+        # "missing dependency/unbuildable" INFRA case, so it belongs here.
+        127) printf 'INFRA\n' ;;
+        *) printf 'FAIL\n' ;;
+    esac
+}
+
+# ── eshkol_outcome_emit_event ────────────────────────────────────────────
+eshkol_outcome_emit_event() { # trace_file kind name outcome snippet [confidence]
+    local trace_file="$1" kind="$2" name="$3" outcome="$4" snippet="$5" confidence="${6:-0.95}"
+    : "${trace_file:?eshkol_outcome_emit_event: trace_file required}"
+    python3 -c '
+import json, sys
+trace_file, kind, name, outcome, snippet, confidence = sys.argv[1:7]
+with open(trace_file, "a") as fh:
+    fh.write(json.dumps({
+        "kind": kind, "name": name, "value": outcome,
+        "snippet": snippet, "confidence": float(confidence),
+    }, ensure_ascii=False))
+    fh.write("\n")
+' "$trace_file" "$kind" "$name" "$outcome" "$snippet" "$confidence"
+}
+
+# ── eshkol_outcome_emit_test_result ──────────────────────────────────────
+# Only PASS/FAIL publish a test_result record; INFRA/SKIP deliberately
+# write nothing. See "WHY INFRA EMITS NO test_result" above.
+eshkol_outcome_emit_test_result() { # trace_file name outcome snippet
+    local trace_file="$1" name="$2" outcome="$3" snippet="$4"
+    : "${trace_file:?eshkol_outcome_emit_test_result: trace_file required}"
+    case "$outcome" in
+        PASS|FAIL) : ;;
+        *) return 0 ;;
+    esac
+    local passed=false
+    [ "$outcome" = "PASS" ] && passed=true
+    python3 -c '
+import json, sys, time
+trace_file, name, passed, snippet = sys.argv[1:5]
+with open(trace_file, "a") as fh:
+    fh.write(json.dumps({
+        "kind": "test_result", "name": name,
+        "value": {"passed": passed == "true", "summary": snippet},
+        "timestamp": time.time(),
+    }, ensure_ascii=False))
+    fh.write("\n")
+' "$trace_file" "$name" "$passed" "$snippet"
+}
+
+# ── eshkol_outcome_retry_guarded ─────────────────────────────────────────
+# Runs eshkol_outcome_guarded once, redirecting stdout/stderr to <outfile>/
+# <errfile> (truncated fresh per attempt so a retry cannot concatenate a
+# timed-out attempt's partial output with the clean retry's); retries
+# exactly once more IFF the first attempt classified as INFRA. Never
+# retries a real FAIL. Returns the last attempt's exit code.
+eshkol_outcome_retry_guarded() { # seconds outfile errfile cmd...
+    local secs="$1" outfile="$2" errfile="$3"; shift 3
+    eshkol_outcome_guarded "$secs" "$@" >"$outfile" 2>"$errfile"
+    local rc=$?
+    [ "$(eshkol_outcome_classify_exit "$rc")" = "INFRA" ] || return "$rc"
+    eshkol_outcome_guarded "$secs" "$@" >"$outfile" 2>"$errfile"
+    return $?
+}

--- a/scripts/run_ad_adversarial.sh
+++ b/scripts/run_ad_adversarial.sh
@@ -39,6 +39,7 @@ export LC_ALL=C LC_CTYPE=C LANG=C
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
 . "$REPO_ROOT/scripts/lib/durable_work_root.sh"
+. "$REPO_ROOT/scripts/lib/harness_outcome.sh"
 if eshkol_durable_enabled; then
     ADV_WORK="$(eshkol_durable_prepare_dir ad-adversarial)" || exit $?
 fi
@@ -114,11 +115,12 @@ JIT_TIMEOUT="${JIT_TIMEOUT:-240}"
 AOT_COMPILE_TIMEOUT="${AOT_COMPILE_TIMEOUT:-300}"
 AOT_RUN_TIMEOUT="${AOT_RUN_TIMEOUT:-120}"
 
-# macOS has no timeout(1); emulate with perl alarm (exit 142 on SIGALRM).
-run_guarded() {
-    perl -e 'my $s=shift; alarm $s; exec @ARGV; die "exec failed: $ARGV[0]: $!\n"' \
-        "$1" "${@:2}"
-}
+# Shared guarded-timeout wrapper (scripts/lib/harness_outcome.sh) — see
+# run_recursion_depth.sh for why the local exec-then-alarm one-liner this
+# replaced reported a self-inflicted timeout as 142 instead of a
+# controlled 124. verdict() below checks 124 first (142 kept for
+# back-compat with any evidence already captured under the old code).
+run_guarded() { eshkol_outcome_guarded "$@"; }
 
 json_escape() {
     printf '%s' "$1" | perl -0pe 's/\\/\\\\/g; s/"/\\"/g; s/\n/\\n/g; s/\r/\\r/g; s/\t/\\t/g; s/([\x00-\x08\x0b\x0c\x0e-\x1f])/sprintf("\\u%04x", ord($1))/ge'
@@ -135,7 +137,7 @@ emit_event() {
 # classify a completed run: args rc out xc -> PASS|FAIL|XKNOWN|CRASH|HANG
 verdict() {
     local rc="$1" out="$2" xc="$3"
-    if [ "$rc" -eq 142 ]; then
+    if [ "$rc" -eq 124 ] || [ "$rc" -eq 142 ]; then
         [ "$xc" -eq 1 ] && { echo XKNOWN; return; }
         echo HANG; return
     fi

--- a/scripts/run_ad_depth.sh
+++ b/scripts/run_ad_depth.sh
@@ -24,6 +24,7 @@
 set -u
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/harness_outcome.sh"
 
 # macOS runner images do not consistently provide C.UTF-8. The Perl alarm
 # wrapper below must not fail before Eshkol is even invoked.
@@ -71,11 +72,15 @@ JIT_TIMEOUT="${JIT_TIMEOUT:-240}"
 AOT_COMPILE_TIMEOUT="${AOT_COMPILE_TIMEOUT:-360}"
 AOT_RUN_TIMEOUT="${AOT_RUN_TIMEOUT:-90}"
 
-# macOS has no timeout(1); emulate with perl alarm (exit 142 on SIGALRM).
-run_guarded() {
-    perl -e 'my $s=shift; alarm $s; exec @ARGV; die "exec failed: $ARGV[0]: $!\n"' \
-        "$1" "${@:2}"
-}
+# Shared guarded-timeout wrapper (scripts/lib/harness_outcome.sh) — see
+# run_recursion_depth.sh for why the local exec-then-alarm one-liner this
+# replaced reported a self-inflicted timeout as 142 (indistinguishable from
+# a real SIGALRM the program raised itself) instead of a controlled 124.
+# is_crash() below only treats rc >= 128 as a crash, so this fix also
+# retires a latent over-classification: a plain timeout used to read as
+# "crash" (142 >= 128) and now correctly reads as a clean (LIMIT-bucketed)
+# nonzero exit instead.
+run_guarded() { eshkol_outcome_guarded "$@"; }
 
 # record RESULT/FDCHK lines from a run into the raw log, tagged by mode+file.
 record() {

--- a/scripts/run_ctest_gate.sh
+++ b/scripts/run_ctest_gate.sh
@@ -49,6 +49,7 @@ export LC_ALL=C LC_CTYPE=C LANG=C
 
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/harness_outcome.sh"
 TRACE_DIR="$REPO_ROOT/scripts/icc_traces"
 TRACE_FILE="$TRACE_DIR/ctest_gate.jsonl"
 mkdir -p "$TRACE_DIR"
@@ -147,48 +148,90 @@ echo
 RESULTS="$(mktemp "${TMPDIR:-/tmp}/eshkol-ctest-results.XXXXXX")"
 if [ "$HAVE_JUNIT" -eq 1 ] && [ -s "$JUNIT" ]; then
     python3 - "$JUNIT" > "$RESULTS" <<'PY'
-import sys, xml.etree.ElementTree as ET
+import re, sys, xml.etree.ElementTree as ET
 root = ET.parse(sys.argv[1]).getroot()
+# CTest reports a per-test TIMEOUT (its own TIMEOUT test property firing,
+# distinct from a test that ran to completion and returned nonzero) as a
+# failed testcase whose <failure>/<error> text names it — CTest itself has
+# no separate JUnit "status" value for it. A timeout is exactly the shape
+# scripts/lib/harness_outcome.sh calls INFRA: the harness could not obtain
+# a verdict in the time budget, which says nothing about whether the code
+# is right. Folding it into FAIL here is the same defect class the
+# 2026-08-25 architecture audit measured in run_vm_parity.sh and
+# run_language_coverage.sh (section 3) — a clock fact reported as a
+# code-correctness verdict.
+TIMEOUT_RE = re.compile(r"\btimeout\b", re.IGNORECASE)
 for case in root.iter("testcase"):
     name = case.get("name") or ""
     if not name:
         continue
     status = case.get("status") or ""
-    failed = (case.find("failure") is not None
-              or case.find("error") is not None
+    failure_el = case.find("failure")
+    error_el = case.find("error")
+    failed = (failure_el is not None or error_el is not None
               or status in ("fail", "failed", "notrun", "error"))
     skipped = case.find("skipped") is not None or status == "skipped"
     if skipped:
         continue
     detail = "%s in %ss" % (status or ("failed" if failed else "passed"),
                             case.get("time") or "?")
+    if failed:
+        failure_text = " ".join(filter(None, [
+            (failure_el.get("message") if failure_el is not None else None),
+            (failure_el.text if failure_el is not None else None),
+            (error_el.get("message") if error_el is not None else None),
+            (error_el.text if error_el is not None else None),
+        ]))
+        if TIMEOUT_RE.search(failure_text) or TIMEOUT_RE.search(status):
+            print("%s\tINFRA\t%s" % (name, detail))
+            continue
     print("%s\t%s\t%s" % (name, "FAIL" if failed else "PASS", detail))
 PY
 else
     # `      1/126 Test   #1: name .......   Passed    0.42 sec`
+    # CTest's console verdict word for a per-test TIMEOUT firing is
+    # literally "Timeout" — recognize it explicitly rather than folding it
+    # into the FAIL bucket with every other non-"Passed" word (see the
+    # JUnit branch above for why: a timeout is INFRA, not a code verdict).
     perl -ne '
         if (m{^\s*\d+/\d+\s+Test\s+#\d+:\s+(\S+)\s+\.+\s*(\**)\s*(\w[\w ]*?)\s+([\d.]+)\s+sec}) {
             my ($n, $verdict, $secs) = ($1, $3, $4);
             $verdict =~ s/\s+$//;
-            my $ok = ($verdict eq "Passed") ? "PASS" : "FAIL";
+            my $ok = ($verdict eq "Passed") ? "PASS"
+                   : ($verdict =~ /timeout/i) ? "INFRA"
+                   : "FAIL";
             print "$n\t$ok\t$verdict in ${secs}s\n";
         }
     ' "$RUN_LOG" > "$RESULTS"
 fi
 
-TOTAL=0; PASSED=0; FAILED=0
+TOTAL=0; PASSED=0; FAILED=0; INFRA=0
 while IFS="$(printf '\t')" read -r name verdict detail; do
     [ -n "$name" ] || continue
     TOTAL=$((TOTAL + 1))
-    if [ "$verdict" = "PASS" ]; then
-        PASSED=$((PASSED + 1))
-        echo "PASSED ctest::$name"
-    else
-        FAILED=$((FAILED + 1))
-        echo "FAILED ctest::$name — $detail"
-    fi
+    case "$verdict" in
+        PASS)
+            PASSED=$((PASSED + 1))
+            echo "PASSED ctest::$name"
+            emit_test_result "ctest::$name" "$verdict" "$detail"
+            ;;
+        INFRA)
+            INFRA=$((INFRA + 1))
+            echo "INFRA  ctest::$name — $detail (no verdict obtained; not counted as a failure)"
+            # Deliberately no emit_test_result call: INFRA must never
+            # publish a passed:false test_result record. See
+            # scripts/lib/harness_outcome.sh, "WHY INFRA EMITS NO
+            # test_result" — writing nothing leaves any prior PASS/FAIL on
+            # file (within its freshness window) standing instead of
+            # overwriting it with an environment-caused false red.
+            ;;
+        *)
+            FAILED=$((FAILED + 1))
+            echo "FAILED ctest::$name — $detail"
+            emit_test_result "ctest::$name" "$verdict" "$detail"
+            ;;
+    esac
     emit_event "ctest_$name" "$verdict" "$detail"
-    emit_test_result "ctest::$name" "$verdict" "$detail"
 done < "$RESULTS"
 
 if [ "$TOTAL" -eq 0 ]; then
@@ -201,19 +244,22 @@ fi
 
 # ── group roll-ups ───────────────────────────────────────────────────────
 GROUP_FAILURES=0
+GROUP_INFRA=0
 while IFS="$(printf '\t')" read -r event regex label; do
     [ -n "${event:-}" ] || continue
-    matched=0; g_pass=0; g_fail=0; first_fail=""
+    matched=0; g_pass=0; g_fail=0; g_infra=0; first_fail=""
     while IFS="$(printf '\t')" read -r name verdict detail; do
         [ -n "$name" ] || continue
         printf '%s' "$name" | grep -Eq "$regex" || continue
         matched=$((matched + 1))
-        if [ "$verdict" = "PASS" ]; then
-            g_pass=$((g_pass + 1))
-        else
-            g_fail=$((g_fail + 1))
-            [ -n "$first_fail" ] || first_fail="$name: $detail"
-        fi
+        case "$verdict" in
+            PASS)  g_pass=$((g_pass + 1)) ;;
+            INFRA) g_infra=$((g_infra + 1)) ;;
+            *)
+                g_fail=$((g_fail + 1))
+                [ -n "$first_fail" ] || first_fail="$name: $detail"
+                ;;
+        esac
     done < "$RESULTS"
 
     if [ "$matched" -eq 0 ]; then
@@ -223,33 +269,80 @@ while IFS="$(printf '\t')" read -r event regex label; do
         echo "FAILED ctest-group::$event — ABSENT (no test matches /$regex/)"
         continue
     fi
-    if [ "$g_fail" -eq 0 ]; then
-        emit_event "$event" PASS "$label: $g_pass/$matched ctest gates green"
-        emit_test_result "ctest-group::$event" PASS "$g_pass/$matched green"
-        echo "PASSED ctest-group::$event ($g_pass/$matched)"
-    else
+    if [ "$g_fail" -gt 0 ]; then
         GROUP_FAILURES=$((GROUP_FAILURES + 1))
         emit_event "$event" FAIL "$label: $g_fail/$matched failed — $first_fail"
         emit_test_result "ctest-group::$event" FAIL "$g_fail/$matched failed"
         echo "FAILED ctest-group::$event ($g_fail/$matched) — $first_fail"
+    elif [ "$g_pass" -eq 0 ]; then
+        # Every matched test in this group hit INFRA (e.g. its own per-test
+        # ctest TIMEOUT) — no defect was observed, but no PASS was either.
+        # Never counted toward GROUP_FAILURES (an unresolved clock fact must
+        # not fail the gate), and never a false PASS either — reported as
+        # its own state, loudly.
+        GROUP_INFRA=$((GROUP_INFRA + 1))
+        emit_event "$event" INFRA "$label: $g_infra/$matched infra (no verdict obtained)"
+        echo "INFRA  ctest-group::$event ($g_infra/$matched) — no verdict obtained"
+    else
+        emit_event "$event" PASS "$label: $g_pass/$matched ctest gates green$([ "$g_infra" -gt 0 ] && printf '; %d infra' "$g_infra")"
+        emit_test_result "ctest-group::$event" PASS "$g_pass/$matched green"
+        echo "PASSED ctest-group::$event ($g_pass/$matched)$([ "$g_infra" -gt 0 ] && printf ' — %d infra (no verdict)' "$g_infra")"
     fi
 done <<GROUPS_EOF
 $CTEST_GATE_GROUPS
 GROUPS_EOF
 
 # ── suite roll-up ────────────────────────────────────────────────────────
+#
+# ctest itself returns nonzero on ANY non-Passed test, timeouts included, so
+# CTEST_RC == 0 used to be required for a green gate — which means a single
+# per-test ctest TIMEOUT (an environment fact: this host was too slow/loaded
+# to finish inside the test's TIMEOUT property) failed the whole suite
+# exactly like a real wrong-answer test would, indistinguishably. That is
+# the same class of defect the 2026-08-25 architecture audit measured in
+# run_vm_parity.sh and run_language_coverage.sh (section 3).
+#
+# The fix: PASS no longer requires CTEST_RC == 0 outright. It requires no
+# real FAILED test and no failed/absent group — and if CTEST_RC is still
+# nonzero, that nonzero must be FULLY explained by counted INFRA tests
+# (INFRA -gt 0), never silently assumed. If CTEST_RC is nonzero for any
+# OTHER reason — every parsed testcase says PASS/INFRA yet ctest itself
+# disagrees — that is a harness contradiction (the same shape
+# scripts/run_all_tests.sh already guards: individual verdicts and the
+# aggregate disagreeing), and is treated as a failure rather than trusted.
 SUMMARY="$PASSED/$TOTAL ctest tests passed"
-if [ "$FAILED" -eq 0 ] && [ "$GROUP_FAILURES" -eq 0 ] && [ "$CTEST_RC" -eq 0 ]; then
-    emit_event "ctest_suite_green" PASS "$SUMMARY"
-    emit_test_result "ctest::suite" PASS "$SUMMARY"
-    echo
-    echo "Trace written: $TRACE_FILE"
-    echo "ctest gate: PASS ($SUMMARY)"
-    rm -f "$RESULTS"
-    exit 0
+if [ "$FAILED" -eq 0 ] && [ "$GROUP_FAILURES" -eq 0 ]; then
+    if [ "$CTEST_RC" -eq 0 ]; then
+        emit_event "ctest_suite_green" PASS "$SUMMARY"
+        emit_test_result "ctest::suite" PASS "$SUMMARY"
+        echo
+        echo "Trace written: $TRACE_FILE"
+        echo "ctest gate: PASS ($SUMMARY)"
+        rm -f "$RESULTS"
+        exit 0
+    elif [ "$INFRA" -gt 0 ]; then
+        SUMMARY="$SUMMARY; $INFRA infra (no verdict, not counted as failure)"
+        emit_event "ctest_suite_green" PASS "$SUMMARY"
+        emit_test_result "ctest::suite" PASS "$SUMMARY"
+        echo
+        echo "Trace written: $TRACE_FILE"
+        echo "ctest gate: PASS ($SUMMARY)"
+        echo "WARNING: $INFRA ctest test(s) could not obtain a verdict (per-test TIMEOUT) — re-run under less contention if this persists." >&2
+        rm -f "$RESULTS"
+        exit 0
+    else
+        DETAIL="$SUMMARY; every parsed testcase is PASS/INFRA but ctest itself exited $CTEST_RC with 0 INFRA to explain it — harness contradiction, not trusted"
+        emit_event "ctest_suite_green" FAIL "$DETAIL"
+        emit_test_result "ctest::suite" FAIL "$DETAIL"
+        echo
+        echo "Trace written: $TRACE_FILE"
+        echo "ctest gate: FAIL ($DETAIL)" >&2
+        rm -f "$RESULTS"
+        exit 1
+    fi
 fi
 
-DETAIL="$SUMMARY; $FAILED failed; $GROUP_FAILURES group(s) failed or absent; ctest exit $CTEST_RC"
+DETAIL="$SUMMARY; $FAILED failed; $INFRA infra; $GROUP_FAILURES group(s) failed or absent; ctest exit $CTEST_RC"
 emit_event "ctest_suite_green" FAIL "$DETAIL"
 emit_test_result "ctest::suite" FAIL "$DETAIL"
 echo

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -23,6 +23,7 @@ export LC_ALL=C LC_CTYPE=C LANG=C
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
 . "$REPO_ROOT/scripts/lib/durable_work_root.sh"
+. "$REPO_ROOT/scripts/lib/harness_outcome.sh"
 if eshkol_durable_enabled; then
     ESHKOL_ICC_WORK="$(eshkol_durable_prepare_dir icc-smoke)" || exit $?
 fi
@@ -134,10 +135,11 @@ print(json.dumps({"kind": "eshkol_smoke", "name": sys.argv[1],
 
 PROBE_TOTAL=0
 PROBE_FAILURES=0
+PROBE_INFRA=0
 
 probe() {
     local probe_id="$1" label="$2" cmd="$3"
-    local out status snippet
+    local out status snippet class
     PROBE_TOTAL=$((PROBE_TOTAL + 1))
     # Capture combined stdout+stderr so the snippet is informative when
     # something fails. Bound the snippet so a multi-MB log doesn't blow
@@ -148,6 +150,26 @@ probe() {
         snippet="${label}: OK"
         emit_event "$probe_id" PASS "$snippet"
         printf '  ✓ %-40s %s\n' "$probe_id" "$label"
+        return
+    fi
+    # A probe body is an ad hoc `eval`'d shell snippet, most of which call
+    # eshkol-run/a compiled binary directly with no timeout wrapper at all —
+    # so today the ONLY exit codes this classifier can recognize as
+    # "harness could not run" rather than "the code is wrong" are the
+    # small, well-known set scripts/lib/harness_outcome.sh defines: a
+    # SIGKILL/SIGTERM/SIGINT the environment sent (137/143/130), or the 124/
+    # 125/142 shapes any probe that DOES wrap itself in
+    # eshkol_outcome_guarded (directly, or transitively through a script
+    # that sources this file) can now produce. Everything else stays FAIL,
+    # per eshkol_outcome_classify_exit's own principle: an unrecognized
+    # nonzero exit is a claim about the CODE until a harness explicitly
+    # says otherwise.
+    class=$(eshkol_outcome_classify_exit "$status")
+    if [ "$class" = INFRA ]; then
+        PROBE_INFRA=$((PROBE_INFRA + 1))
+        snippet=$(printf '%s' "$out" | tail -c 200)
+        emit_event "$probe_id" INFRA "$snippet"
+        printf '  ⚠ %-40s %s (infra, exit %d — no verdict obtained)\n' "$probe_id" "$label" "$status"
     else
         PROBE_FAILURES=$((PROBE_FAILURES + 1))
         snippet=$(printf '%s' "$out" | tail -c 200)
@@ -158,6 +180,22 @@ probe() {
 
 echo "Running ICC smoke probes → $TRACE_FILE"
 echo
+
+# ─────────────────────────────────────────────────────────────────
+# Harness-infra-vs-defect taxonomy (2026-08-25 architecture audit,
+# section 3). scripts/lib/harness_outcome.sh is what every probe() call
+# above/below relies on to keep "the harness could not run" from being
+# reported as "the code is wrong" — this is the regression test proving
+# that distinction is real: it forces a timeout, a missing binary, a
+# genuine wrong-answer exit, and a self-inflicted crash, and asserts each
+# lands in the taxonomy bucket it must. See
+# tests/harness/harness_outcome_taxonomy_test.sh for the full assertion
+# list (17 checks).
+# ─────────────────────────────────────────────────────────────────
+probe harness_outcome_taxonomy \
+    'scripts/lib/harness_outcome.sh distinguishes INFRA (timeout, missing binary — no test_result published, never retried past one attempt) from FAIL (a completed wrong answer or a self-raised crash — always published, never retried)' \
+    'out=$(bash "$REPO_ROOT/tests/harness/harness_outcome_taxonomy_test.sh" 2>&1) || { printf "%s\n" "$out"; exit 1; }
+     printf "%s" "$out" | grep -q "harness_outcome_taxonomy_test.sh: PASS"'
 
 # ─────────────────────────────────────────────────────────────────
 # Compiler-readiness probes
@@ -1017,10 +1055,22 @@ EOF
 
 echo
 echo "Trace written: $TRACE_FILE"
-echo "Probe summary: $((PROBE_TOTAL - PROBE_FAILURES))/$PROBE_TOTAL passed"
+echo "Probe summary: $((PROBE_TOTAL - PROBE_FAILURES - PROBE_INFRA))/$PROBE_TOTAL passed, $PROBE_INFRA infra (no verdict), $PROBE_FAILURES failed"
 echo "Run: python3 ~/Desktop/infinite_context_coder/scripts/codebase_tool.py \\"
 echo "         completion-oracle --repo eshkol_lang \\"
 echo "         --target agent-ffi-ready --trace-dir scripts/icc_traces"
+
+if [ "$PROBE_INFRA" -ne 0 ]; then
+    # Never folded into PROBE_FAILURES (see probe() above / F13, 2026-08-25
+    # architecture audit section 3): a probe with no verdict is not evidence
+    # of a defect, so it must not sink this gate. It IS loud — printed above
+    # per-probe, counted here, and recorded as an explicit "INFRA" value in
+    # $TRACE_FILE (never "PASS"), so a completion-oracle criterion matching
+    # event_values:["PASS"] correctly stays unsatisfied rather than being
+    # spoofed green, and never reads as the false "FAIL" this gate used to
+    # be capable of producing.
+    echo "ICC smoke gate: $PROBE_INFRA probe(s) could not obtain a verdict (infra) — see above" >&2
+fi
 
 if [ "$PROBE_FAILURES" -ne 0 ]; then
     echo "ICC smoke gate: FAIL ($PROBE_FAILURES probe(s) failed)" >&2

--- a/scripts/run_language_coverage.sh
+++ b/scripts/run_language_coverage.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 . "$REPO_ROOT/scripts/lib/durable_work_root.sh"
+. "$REPO_ROOT/scripts/lib/harness_outcome.sh"
 if eshkol_durable_enabled; then
     LANGUAGE_COVERAGE_WORK="$(eshkol_durable_prepare_dir language-coverage)" || exit $?
     TRACE_DIR=${ICC_TRACE_DIR:-"$LANGUAGE_COVERAGE_WORK/traces"}
@@ -14,6 +15,15 @@ else
     TRACE_DIR=${ICC_TRACE_DIR:-"$REPO_ROOT/scripts/icc_traces"}
 fi
 TRACE_FILE=${LANGUAGE_COVERAGE_TRACE:-"$TRACE_DIR/language_surface_coverage.jsonl"}
+# Informational only — never read by language_coverage.py, never gates the
+# floor computation below. Records whether the full-suite/quantum-probe
+# PREREQUISITE runs that generate execution-trace evidence were themselves
+# clean, so a genuine full-suite regression stays visible even though (see
+# "Fresh core/native/VM execution evidence" below) it no longer aborts the
+# coverage measurement itself.
+PREREQ_TRACE="$TRACE_DIR/language_surface_coverage_prereq.jsonl"
+mkdir -p "$TRACE_DIR"
+: > "$PREREQ_TRACE"
 RUNTIME_TRACE_DIRS=${LANGUAGE_COVERAGE_RUNTIME_TRACE_DIRS:-}
 EXTRA_RUNTIME_TRACE_DIRS=${LANGUAGE_COVERAGE_EXTRA_RUNTIME_TRACE_DIRS:-}
 BUILD_DIR=${BUILD_DIR:-build}
@@ -111,16 +121,63 @@ if [ -z "$RUNTIME_TRACE_DIRS" ]; then
     QUANTUM_TRACE="$GENERATED_TRACE_ROOT/quantum"
     mkdir -p "$CORE_TRACE" "$QUANTUM_TRACE"
 
+    # 2026-08-25 architecture audit, section 3 (case b): under this script's
+    # top-level `set -euo pipefail`, a bare nonzero exit from either
+    # prerequisite below used to abort the WHOLE script immediately — before
+    # gen_language_surface.py / language_coverage.py ever ran — even though
+    # run_all_tests.sh (see its own header: "DO NOT use set -e — we need to
+    # continue after suite failures") had already run every suite to
+    # completion and every trace file was already fully written. One
+    # environment-driven flake in one suite, among thousands of tests, made
+    # the coverage-floor probe report exit 1 while a direct re-run gave exit
+    # 0 with 1106/1106 (100.0%), 0 uncovered — the SAME evidence either way,
+    # just never reached the first time. Coverage measurement and full-suite
+    # correctness are different questions answered by different gates
+    # (this vs. scripts/run_ctest_gate.sh / scripts/run_all_tests.sh's own
+    # exit code in CI); capturing the exit code here instead of dying on it
+    # lets this script answer only the one it owns, using whatever execution
+    # evidence the prerequisite already produced. A REAL regression is not
+    # hidden: it is still visible in run_all_tests.sh's own console summary
+    # above, in $PREREQ_TRACE below, and (independently) in the CI-required
+    # ctest gate — this script's job is coverage, not suite health.
     echo "== Fresh core/native/VM execution evidence =="
+    core_rc=0
     ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR="$CORE_TRACE" \
-        BUILD_DIR="$BUILD_DIR_FOR_TESTS" "$REPO_ROOT/scripts/run_all_tests.sh"
+        BUILD_DIR="$BUILD_DIR_FOR_TESTS" "$REPO_ROOT/scripts/run_all_tests.sh" || core_rc=$?
+    if [ "$core_rc" -ne 0 ]; then
+        core_class=$(eshkol_outcome_classify_exit "$core_rc")
+        echo "run_language_coverage: run_all_tests.sh prerequisite exited $core_rc" \
+             "(classified $core_class) — continuing to measure coverage from the" \
+             "execution evidence it already produced; see run_ctest_gate.sh / CI for" \
+             "full-suite pass/fail." >&2
+        eshkol_outcome_emit_event "$PREREQ_TRACE" language_coverage_prereq core_suite "$core_class" \
+            "run_all_tests.sh exited $core_rc"
+    else
+        eshkol_outcome_emit_event "$PREREQ_TRACE" language_coverage_prereq core_suite PASS \
+            "run_all_tests.sh exited 0"
+    fi
 
     echo "== Fresh quantum/PQC execution evidence =="
+    quantum_issues=0
     for test in "$REPO_ROOT"/tests/quantum/*.esk; do
         echo "== ${test#"$REPO_ROOT"/} =="
+        q_rc=0
         ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR="$QUANTUM_TRACE" \
-            "$QUANTUM_RUN" -r "$test" "-L$QUANTUM_BUILD_DIR_PATH"
+            "$QUANTUM_RUN" -r "$test" "-L$QUANTUM_BUILD_DIR_PATH" || q_rc=$?
+        if [ "$q_rc" -ne 0 ]; then
+            q_class=$(eshkol_outcome_classify_exit "$q_rc")
+            quantum_issues=$((quantum_issues + 1))
+            echo "run_language_coverage: ${test#"$REPO_ROOT"/} exited $q_rc" \
+                 "(classified $q_class) — continuing; other quantum probes still" \
+                 "contribute their own execution evidence." >&2
+            eshkol_outcome_emit_event "$PREREQ_TRACE" language_coverage_prereq \
+                "quantum_${test##*/}" "$q_class" "exited $q_rc"
+        fi
     done
+    if [ "$quantum_issues" -eq 0 ]; then
+        eshkol_outcome_emit_event "$PREREQ_TRACE" language_coverage_prereq quantum_suite PASS \
+            "all quantum probes exited 0"
+    fi
 
     # Refuse to publish coverage evidence gathered across a rebuild.
     if ! eshkol_test_toolchain_verify "$BUILD_DIR_PATH" core; then

--- a/scripts/run_metamorphic.sh
+++ b/scripts/run_metamorphic.sh
@@ -9,6 +9,7 @@
 set -u
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/harness_outcome.sh"
 
 TRACE_DIR="$REPO_ROOT/scripts/icc_traces"
 TRACE_FILE="$TRACE_DIR/metamorphic.jsonl"
@@ -69,11 +70,15 @@ JIT_TIMEOUT="${METAMORPHIC_JIT_TIMEOUT:-180}"
 AOT_COMPILE_TIMEOUT="${METAMORPHIC_AOT_COMPILE_TIMEOUT:-300}"
 AOT_RUN_TIMEOUT="${METAMORPHIC_AOT_RUN_TIMEOUT:-90}"
 
-# macOS has no timeout(1); emulate with perl alarm (exit 142 on expiry).
-run_guarded() {
-    LC_ALL=C LANG=C LC_CTYPE=C perl -e 'my $seconds = shift; $SIG{ALRM}=sub{ exit 142 }; alarm $seconds; exec @ARGV; exit 127' \
-        "$1" "${@:2}"
-}
+# Shared guarded-timeout wrapper (scripts/lib/harness_outcome.sh). This
+# used to be a local exec-then-perl-alarm one-liner: `exec` replaces perl's
+# own process image, so the `$SIG{ALRM}` handler set just before it does
+# not survive into the child, and a still-running child at expiry was
+# killed by SIGALRM under ITS default disposition (128+14=142) rather than
+# a controlled code. eshkol_outcome_guarded forks instead, so its alarm
+# handler stays alive in the parent and reports a stable 124 — verdict()
+# below now checks 124 first (with 142 kept recognized for back-compat).
+run_guarded() { eshkol_outcome_guarded "$@"; }
 
 json_escape() {
     printf '%s' "$1" | LC_ALL=C LANG=C LC_CTYPE=C perl -0pe 's/\\/\\\\/g; s/"/\\"/g; s/\n/\\n/g; s/\r/\\r/g; s/\t/\\t/g; s/([\x00-\x08\x0b\x0c\x0e-\x1f])/sprintf("\\u%04x", ord($1))/ge'
@@ -87,7 +92,7 @@ emit_event() {
 
 verdict() {
     local rc="$1" out="$2"
-    if [ "$rc" -eq 142 ]; then
+    if [ "$rc" -eq 124 ] || [ "$rc" -eq 142 ]; then
         echo HANG; return
     fi
     if [ "$rc" -ge 128 ] || printf '%s' "$out" | grep -q "fatal signal"; then

--- a/scripts/run_metaprog_depth.sh
+++ b/scripts/run_metaprog_depth.sh
@@ -28,6 +28,7 @@
 set -u
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/harness_outcome.sh"
 
 # Keep the Perl timeout wrapper independent of host locale availability.
 export LC_ALL=C
@@ -78,12 +79,17 @@ if [ "$REGEN" -eq 1 ]; then
 fi
 [ -f "$MANIFEST" ] || { echo "no manifest at $MANIFEST" >&2; exit 2; }
 
-# macOS has no timeout(1); emulate with perl alarm (exit 124 on expiry).
-run_to() {
-    local secs="$1"; shift
-    perl -e 'my $s=shift; eval { local $SIG{ALRM}=sub{ exit 124 }; alarm $s; exec @ARGV or exit 127; }' \
-        "$secs" "$@"
-}
+# Shared guarded-timeout wrapper (scripts/lib/harness_outcome.sh). This
+# script already intended 124 as its timeout signal — classify_run() below
+# has checked `[ "$ec" -eq 124 ]` from day one — but the local
+# exec-then-`local $SIG{ALRM}` implementation it used to carry could never
+# actually produce it: `exec` replaces the perl process whose handler was
+# just installed, so a still-running child at expiry died from SIGALRM
+# under ITS OWN default disposition (128+14=142) instead. That check was
+# therefore dead code; eshkol_outcome_guarded forks instead of exec'ing, so
+# the alarm fires in the still-alive parent and 124 is what actually comes
+# back.
+run_to() { eshkol_outcome_guarded "$@"; }
 json_escape() {
     printf '%s' "$1" | perl -0pe 's/\\/\\\\/g; s/"/\\"/g; s/\n/\\n/g; s/\r/\\r/g; s/\t/\\t/g; s/([\x00-\x08\x0b\x0c\x0e-\x1f])/sprintf("\\u%04x", ord($1))/ge'
 }

--- a/scripts/run_nesting_depth.sh
+++ b/scripts/run_nesting_depth.sh
@@ -40,6 +40,7 @@
 set -u
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/harness_outcome.sh"
 
 # Keep the Perl timeout wrapper independent of host locale availability.
 export LC_ALL=C
@@ -109,11 +110,11 @@ JIT_TIMEOUT="${JIT_TIMEOUT:-90}"
 AOT_COMPILE_TIMEOUT="${AOT_COMPILE_TIMEOUT:-150}"
 AOT_RUN_TIMEOUT="${AOT_RUN_TIMEOUT:-90}"
 
-# macOS has no timeout(1); emulate with perl alarm (exit 142 on SIGALRM).
-run_guarded() {
-    perl -e 'my $s = shift; alarm $s; exec @ARGV; die "exec failed: $ARGV[0]: $!\n"' \
-        "$1" "${@:2}"
-}
+# Shared guarded-timeout wrapper (scripts/lib/harness_outcome.sh) — see
+# run_recursion_depth.sh for why the local exec-then-alarm one-liner this
+# replaced could report 142 for a plain timeout instead of a controlled
+# code. axis_outcome() below checks 124 first (142 kept for back-compat).
+run_guarded() { eshkol_outcome_guarded "$@"; }
 
 json_escape() {
     printf '%s' "$1" | perl -0pe 's/\\/\\\\/g; s/"/\\"/g; s/\n/\\n/g; s/\r/\\r/g; s/\t/\\t/g; s/([\x00-\x08\x0b\x0c\x0e-\x1f])/sprintf("\\u%04x", ord($1))/ge'
@@ -131,7 +132,7 @@ DIAG_RE="fatal signal|terminating|recursion depth|stack overflow|[Ee]rror:|Unhan
 # axis_outcome rc out  ->  "VAL <n>" | "LIMIT" | "SILENT" | "HANG"
 axis_outcome() {
     local rc="$1" out="$2" numline
-    if [ "$rc" -eq 142 ]; then echo HANG; return; fi
+    if [ "$rc" -eq 124 ] || [ "$rc" -eq 142 ]; then echo HANG; return; fi
     numline=$(printf '%s' "$out" | grep -E '^-?[0-9]+$' | tail -1)
     if [ "$rc" -eq 0 ]; then
         if [ -n "$numline" ]; then echo "VAL $numline"; return; fi

--- a/scripts/run_recursion_depth.sh
+++ b/scripts/run_recursion_depth.sh
@@ -53,6 +53,7 @@
 set -u
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/harness_outcome.sh"
 
 # Keep the Perl timeout wrapper independent of host locale availability.
 export LC_ALL=C
@@ -98,11 +99,14 @@ JIT_TIMEOUT="${JIT_TIMEOUT:-120}"
 AOT_COMPILE_TIMEOUT="${AOT_COMPILE_TIMEOUT:-180}"
 AOT_RUN_TIMEOUT="${AOT_RUN_TIMEOUT:-120}"
 
-# macOS has no `timeout(1)`; emulate with perl alarm (exit 142 on SIGALRM).
-run_guarded() {
-    perl -e 'my $seconds = shift; alarm $seconds; exec @ARGV; die "exec failed: $ARGV[0]: $!\n"' \
-        "$1" "${@:2}"
-}
+# Shared guarded-timeout wrapper (scripts/lib/harness_outcome.sh), replacing
+# a local exec-then-alarm one-liner. `exec` replaced the perl process
+# itself, so its pending alarm delivered SIGALRM to the CHILD under the
+# child's own default disposition (terminate -> 128+14=142), rather than a
+# controlled code a still-alive wrapper chose. eshkol_outcome_guarded forks
+# instead, so the alarm always fires in the parent and reports a stable
+# 124; raw_verdict() below checks 124 first (142 kept for back-compat).
+run_guarded() { eshkol_outcome_guarded "$@"; }
 
 json_escape() {
     printf '%s' "$1" | perl -0pe 's/\\/\\\\/g; s/"/\\"/g; s/\n/\\n/g; s/\r/\\r/g; s/\t/\\t/g; s/([\x00-\x08\x0b\x0c\x0e-\x1f])/sprintf("\\u%04x", ord($1))/ge'
@@ -120,7 +124,7 @@ emit_event() {
 # raw_verdict rc out -> PASS|WRONG-VALUE|CLEAN-LIMIT|SILENT-CRASH|HANG
 raw_verdict() {
     local rc="$1" out="$2"
-    if [ "$rc" -eq 142 ]; then echo HANG; return; fi
+    if [ "$rc" -eq 124 ] || [ "$rc" -eq 142 ]; then echo HANG; return; fi
     if printf '%s' "$out" | grep -q '^WRONG:'; then echo WRONG-VALUE; return; fi
     if [ "$rc" -eq 0 ]; then
         if printf '%s' "$out" | grep -q '^PASS:'; then echo PASS; return; fi
@@ -219,7 +223,7 @@ for path in "$GEN_DIR"/rec_*.esk; do
         if [ "$crc" -ne 0 ] || [ ! -x "$bin" ]; then
             if printf '%s' "$cout" | grep -qiE "maximum recursion depth|[Ee]rror:|fatal signal"; then
                 araw=CLEAN-LIMIT; else araw=SILENT-CRASH; fi
-            [ "$crc" -eq 142 ] && araw=HANG
+            { [ "$crc" -eq 124 ] || [ "$crc" -eq 142 ]; } && araw=HANG
         else
             aout=$(run_guarded "$AOT_RUN_TIMEOUT" "$bin" 2>&1); arc=$?
             araw=$(raw_verdict "$arc" "$aout")

--- a/scripts/run_tensor_collection_depth.sh
+++ b/scripts/run_tensor_collection_depth.sh
@@ -37,6 +37,7 @@ set -u
 export LC_ALL=C LC_CTYPE=C LANG=C
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/harness_outcome.sh"
 
 BUILD_DIR="${BUILD_DIR:-build}"
 case "$BUILD_DIR" in /*) : ;; *) BUILD_DIR="$REPO_ROOT/$BUILD_DIR" ;; esac
@@ -101,12 +102,15 @@ check_disk_cap() {
     fi
 }
 
-# macOS has no timeout(1); emulate with perl alarm (exit 124 on expiry).
-run_to() {
-    local secs="$1"; shift
-    perl -e 'my $s=shift; eval { local $SIG{ALRM}=sub{ exit 124 }; alarm $s; exec @ARGV or exit 127; }' \
-        "$secs" "$@"
-}
+# Shared guarded-timeout wrapper (scripts/lib/harness_outcome.sh). This
+# used to be a local exec-then-`local $SIG{ALRM}` one-liner that could
+# never actually deliver the 124 the classifier below expects: `exec`
+# replaces the perl process whose handler was just installed, so a
+# still-running child at expiry died from SIGALRM under its own default
+# disposition (128+14=142) instead. eshkol_outcome_guarded forks instead of
+# exec'ing, so the alarm fires in the still-alive parent and the classifier
+# now actually sees the 124 it was already written to expect.
+run_to() { eshkol_outcome_guarded "$@"; }
 json_escape() {
     printf '%s' "$1" | perl -0pe 's/\\/\\\\/g; s/"/\\"/g; s/\n/\\n/g; s/\r/\\r/g; s/\t/\\t/g; s/([\x00-\x08\x0b\x0c\x0e-\x1f])/sprintf("\\u%04x", ord($1))/ge'
 }

--- a/scripts/run_vm_parity.sh
+++ b/scripts/run_vm_parity.sh
@@ -55,6 +55,7 @@ export LANG=C
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
 . "$REPO_ROOT/scripts/lib/durable_work_root.sh"
+. "$REPO_ROOT/scripts/lib/harness_outcome.sh"
 if eshkol_durable_enabled; then
     VM_PARITY_WORK="$(eshkol_durable_prepare_dir vm-parity)" || exit $?
     TRACE_DIR="${TRACE_DIR:-$VM_PARITY_WORK/traces}"
@@ -87,11 +88,21 @@ done
 
 TIMEOUT_RUN="${VM_PARITY_TIMEOUT:-60}"
 
-# macOS has no `timeout(1)`; emulate with perl alarm (exit 124 on expiry).
-run_guarded() { # seconds cmd...
-    perl -e 'my $s=shift; eval { local $SIG{ALRM}=sub{ exit 124 }; alarm $s; exec @ARGV or exit 127; }' \
-        "$1" "${@:2}"
-}
+# Real, signal-observing timeout wrapper (scripts/lib/harness_outcome.sh).
+# This replaces an exec-then-perl-alarm one-liner this script used to carry
+# locally: `exec` replaces perl's own process image, so the alarm handler
+# perl installed does not survive into the child, and a child still running
+# when the alarm fires is killed by SIGALRM under ITS OWN default
+# disposition — exit 128+14=142 — instead of a controlled, recognizable 124.
+# That is exactly the F13 audit incident (2026-08-25 architecture audit,
+# section 3): `native -r exited 142` on a 140s cold-start JIT/stdlib compile
+# under load, read as a parity FAIL because nothing downstream could tell a
+# clock fact from a wrong answer. eshkol_outcome_guarded forks instead of
+# exec'ing, so the alarm fires in the still-alive parent and reports a
+# stable 124; a real crash the child raises on its own is still preserved as
+# 128+N (e.g. a genuine SIGSEGV stays 139), so a self-inflicted defect is
+# never masked as infrastructure. See eshkol_outcome_classify_exit below.
+run_guarded() { eshkol_outcome_guarded "$@"; } # seconds cmd...
 
 json_escape() {
     printf '%s' "$1" | perl -0pe 's/\\/\\\\/g; s/"/\\"/g; s/\n/\\n/g; s/\r/\\r/g; s/\t/\\t/g; s/([\x00-\x08\x0b\x0c\x0e-\x1f])/sprintf("\\u%04x", ord($1))/ge'
@@ -113,13 +124,13 @@ emit_test_result() { # name PASS|FAIL snippet
         "$(json_escape "$1")" "$passed" "$(json_escape "$3")" "$(date +%s)" >> "${TRACE_FILE:?}"
 }
 
-pass=0; fail=0
-report() { # PASS|FAIL nodeid event_name snippet
-    if [ "$1" = "PASS" ]; then
-        pass=$((pass+1)); echo "PASSED $2"
-    else
-        fail=$((fail+1)); echo "FAILED $2 — $4"
-    fi
+pass=0; fail=0; infra=0
+report() { # PASS|FAIL|INFRA nodeid event_name snippet
+    case "$1" in
+        PASS)  pass=$((pass+1));  echo "PASSED $2" ;;
+        INFRA) infra=$((infra+1)); echo "INFRA  $2 — $4 (no verdict obtained; not counted as a parity defect)" ;;
+        *)     fail=$((fail+1));  echo "FAILED $2 — $4" ;;
+    esac
     emit_event "$3" "$1" "$4"
 }
 
@@ -161,6 +172,36 @@ fi
 if ! eshkol_durable_enabled; then trap 'rm -rf "$WORK"' EXIT; fi
 export ESHKOL_JIT_CACHE_DIR="$WORK/jit-cache"
 mkdir -p "$ESHKOL_JIT_CACHE_DIR"
+
+# ── JIT-cache warm-up (fix for F13: the 140s cold-start timeout) ────────
+#
+# $ESHKOL_JIT_CACHE_DIR is a fresh directory every invocation of this
+# script, so the FIRST native compile against it always pays the full
+# stdlib load/optimize cost — measured at 140.49s under a load average of
+# 180, versus 0.07s/0.06s on a warm cache (2026-08-25 audit, section 3).
+# TIMEOUT_RUN defaults to 60s, so an unlucky first corpus file used to eat
+# that cold-start cost inside its own timed window and get killed — not
+# because anything was wrong, but because it happened to go first. Paying
+# the cold cost HERE, once, outside any per-file timing window, means every
+# per-file measurement below starts from a warm cache and the 60s budget
+# is measuring the thing it is supposed to measure again.
+#
+# This does not remove the safety net: if the warm-up itself times out
+# (a genuinely pathological host), we log it and continue — the per-file
+# eshkol_outcome_retry_guarded calls below still classify and retry any
+# residual cold-start timeout as INFRA rather than a parity FAIL.
+WARMUP_TIMEOUT="${VM_PARITY_WARMUP_TIMEOUT:-300}"
+WARM_FILE="$WORK/_warmup.esk"
+printf '(display 1)\n(newline)\n' > "$WARM_FILE"
+echo "== warm-up: priming \$ESHKOL_JIT_CACHE_DIR (stdlib compile, budget ${WARMUP_TIMEOUT}s) =="
+if eshkol_outcome_guarded "$WARMUP_TIMEOUT" "$ESHKOL_RUN" -r "$WARM_FILE" \
+        >"$WORK/_warmup.out" 2>"$WORK/_warmup.err"; then
+    echo "warm-up: cache primed"
+else
+    echo "run_vm_parity.sh: warm-up compile did not finish within ${WARMUP_TIMEOUT}s —" \
+         "the corpus loop below may still see a cold first hit under extreme load" \
+         "(see $WORK/_warmup.err); the per-file retry-once still applies." >&2
+fi
 
 # Normalize an output capture:
 #   * strip VM banners, ESKB loader lines, GPU init logs, compiler noise;
@@ -212,18 +253,36 @@ for f in "${corpus_files[@]}"; do
             native_args=(-n -r "$f")
             ;;
     esac
-    run_guarded "$TIMEOUT_RUN" "$ESHKOL_RUN" "${native_args[@]}" >"$d/native.raw" 2>"$d/native.err"
+    # eshkol_outcome_retry_guarded: one attempt, and — IFF that attempt
+    # classifies as INFRA (timeout/OOM/signal-from-outside) — exactly one
+    # retry before we conclude anything. This is the direct fix for F13: a
+    # cold-start timeout gets a second try, at which point the JIT cache the
+    # warm-up (and/or the first attempt itself) populated makes the retry
+    # fast, matching what the audit measured by hand (140.49s once, then
+    # 0.07s, 0.06s). A real wrong-answer FAIL is never retried — only the
+    # clock gets a second chance.
+    eshkol_outcome_retry_guarded "$TIMEOUT_RUN" "$d/native.raw" "$d/native.err" \
+        "$ESHKOL_RUN" "${native_args[@]}"
     nrc=$?
     normalize "$d/native.raw" "$d/native.out"
 
-    ESHKOL_VM_NO_DISASM=1 run_guarded "$TIMEOUT_RUN" "$VM_BIN" "$f" >"$d/vmsrc.raw" 2>"$d/vmsrc.err"
+    ESHKOL_VM_NO_DISASM=1 eshkol_outcome_retry_guarded "$TIMEOUT_RUN" "$d/vmsrc.raw" "$d/vmsrc.err" \
+        "$VM_BIN" "$f"
     vrc=$?
     normalize "$d/vmsrc.raw" "$d/vmsrc.out"
 
     nodeid="tests/vm_parity/corpus/$base.esk"
-    if [ $nrc -ne 0 ]; then
+    nclass=$(eshkol_outcome_classify_exit "$nrc")
+    vclass=$(eshkol_outcome_classify_exit "$vrc")
+    if [ "$nclass" = INFRA ]; then
+        report INFRA "$nodeid::native-vs-vm-src" "corpus_${base}_vmsrc" \
+            "native -r timed out/infra after retry (rc=$nrc) — no parity verdict obtained"
+    elif [ $nrc -ne 0 ]; then
         report FAIL "$nodeid::native-vs-vm-src" "corpus_${base}_vmsrc" \
             "native -r exited $nrc (corpus programs must be green natively)"
+    elif [ "$vclass" = INFRA ]; then
+        report INFRA "$nodeid::native-vs-vm-src" "corpus_${base}_vmsrc" \
+            "vm-src timed out/infra after retry (rc=$vrc) — no parity verdict obtained"
     elif [ $vrc -ne 0 ] || ! vm_stderr_clean "$d/vmsrc.err"; then
         report FAIL "$nodeid::native-vs-vm-src" "corpus_${base}_vmsrc" \
             "vm-src errored (rc=$vrc, stderr: $(head -c 160 "$d/vmsrc.err"))"
@@ -237,18 +296,29 @@ for f in "${corpus_files[@]}"; do
 
     if [ $DO_ESKB -eq 1 ]; then
         eskb="$d/prog.eskb"
-        run_guarded "$TIMEOUT_RUN" "$ESHKOL_RUN" --profile hosted-vm --emit-eskb "$eskb" "$f" \
-            >"$d/eskb.compile.out" 2>"$d/eskb.compile.err"
+        eshkol_outcome_retry_guarded "$TIMEOUT_RUN" "$d/eskb.compile.out" "$d/eskb.compile.err" \
+            "$ESHKOL_RUN" --profile hosted-vm --emit-eskb "$eskb" "$f"
         erc=$?
+        eclass=$(eshkol_outcome_classify_exit "$erc")
+        if [ "$eclass" = INFRA ]; then
+            report INFRA "$nodeid::native-vs-vm-eskb" "corpus_${base}_vmeskb" \
+                "eskb emit timed out/infra after retry (rc=$erc) — no parity verdict obtained"
+            continue
+        fi
         if [ $erc -ne 0 ] || [ ! -f "$eskb" ]; then
             report FAIL "$nodeid::native-vs-vm-eskb" "corpus_${base}_vmeskb" \
                 "eskb emit failed rc=$erc"
             continue
         fi
-        ESHKOL_VM_NO_DISASM=1 run_guarded "$TIMEOUT_RUN" "$VM_BIN" "$eskb" >"$d/vmeskb.raw" 2>"$d/vmeskb.err"
+        ESHKOL_VM_NO_DISASM=1 eshkol_outcome_retry_guarded "$TIMEOUT_RUN" "$d/vmeskb.raw" "$d/vmeskb.err" \
+            "$VM_BIN" "$eskb"
         brc=$?
+        bclass=$(eshkol_outcome_classify_exit "$brc")
         normalize "$d/vmeskb.raw" "$d/vmeskb.out"
-        if [ $brc -ne 0 ] || ! vm_stderr_clean "$d/vmeskb.err"; then
+        if [ "$bclass" = INFRA ]; then
+            report INFRA "$nodeid::native-vs-vm-eskb" "corpus_${base}_vmeskb" \
+                "vm-eskb timed out/infra after retry (rc=$brc) — no parity verdict obtained"
+        elif [ $brc -ne 0 ] || ! vm_stderr_clean "$d/vmeskb.err"; then
             report FAIL "$nodeid::native-vs-vm-eskb" "corpus_${base}_vmeskb" \
                 "vm-eskb errored (rc=$brc, stderr: $(head -c 160 "$d/vmeskb.err"))"
         elif ! cmp -s "$d/native.out" "$d/vmeskb.out"; then
@@ -333,10 +403,22 @@ for f in "${fatal_files[@]}"; do
 done
 
 # ── gate ─────────────────────────────────────────────────────────────────
+#
+# INFRA checks never count toward `fail`: a check that could not obtain a
+# verdict (even after one retry) is not evidence the VM diverges from
+# native — it is evidence the run needs redoing under better conditions.
+# Folding it into `fail` here is exactly the F13 audit defect (a spurious
+# FAIL propagating into INV-dispatch-table-completeness); leaving it out
+# is the "no verdict beats a false FAIL" choice documented in
+# scripts/lib/harness_outcome.sh. It is still loud: printed distinctly
+# above, counted separately, and never silently dropped.
 echo
-echo "vm-parity: $pass passed, $fail failed"
+echo "vm-parity: $pass passed, $fail failed, $infra infra (no verdict)"
+if [ $infra -gt 0 ]; then
+    echo "WARNING: $infra check(s) could not obtain a parity verdict (INFRA) — see trace and re-run under less contention if this persists." >&2
+fi
 if [ $fail -eq 0 ]; then
-    gate_summary="$pass checks green (audit + corpus + oos + fatal)"
+    gate_summary="$pass checks green (audit + corpus + oos + fatal)$([ $infra -gt 0 ] && printf '; %d infra (no verdict)' "$infra")"
     emit_event "vm_parity_gate" "PASS" "$gate_summary"
     # Name the production dispatcher explicitly so ICC can bind this full
     # source+serialized-bytecode parity run to the implementation boundary it

--- a/tests/harness/harness_outcome_taxonomy_test.sh
+++ b/tests/harness/harness_outcome_taxonomy_test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# harness_outcome_taxonomy_test.sh — regression test for
+# scripts/lib/harness_outcome.sh: proves the PASS/FAIL/INFRA distinction is
+# real, not aspirational documentation.
+#
+# WHY THIS EXISTS
+#
+# The 2026-08-25 architecture audit (ESHKOL-ARCHITECTURE-AUDIT-2026-08-25.md,
+# section 3) found two harnesses that could not tell "the code failed" from
+# "the harness could not run" — a 140s cold-start JIT compile killed by a
+# 60s alarm read as a VM-parity defect, and an unrelated flaky test aborting
+# a full-suite prerequisite read as a language-coverage regression. Both
+# incidents have the same shape: a real environmental non-completion
+# (timeout, missing binary) getting reported through the same channel as a
+# genuine wrong answer, with nothing downstream able to tell them apart.
+#
+# This test forces both shapes on purpose and asserts they land in
+# DIFFERENT buckets:
+#   1. An INFRA condition (timeout; missing binary) must classify as INFRA
+#      and — critically — must NOT publish a test_result record, per
+#      harness_outcome.sh's own "WHY INFRA EMITS NO test_result" contract.
+#   2. A genuine wrong answer (the code ran to completion and returned
+#      nonzero, or crashed on a signal it raised itself) must still
+#      classify as FAIL and DOES publish a passed:false test_result.
+#   3. The retry-once policy never gives a real FAIL a second chance, but
+#      does retry a transient INFRA condition exactly once.
+#
+# If a future edit collapses this distinction (e.g. by widening the INFRA
+# exit-code set to swallow a real FAIL, or by making FAIL retry), this test
+# fails.
+set -u
+cd "$(dirname "$0")/../.."
+REPO_ROOT="$(pwd)"
+. "$REPO_ROOT/scripts/lib/harness_outcome.sh"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-harness-outcome-taxonomy-test.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+check() { # description ok(0/1)
+    if [ "$2" -eq 0 ]; then
+        pass=$((pass + 1))
+        echo "PASS: $1"
+    else
+        fail=$((fail + 1))
+        echo "FAIL: $1"
+    fi
+}
+
+# ── 1. timeout classifies as INFRA, not FAIL, and is actually enforced ──
+start=$(date +%s)
+eshkol_outcome_guarded 1 sleep 30
+rc=$?
+elapsed=$(( $(date +%s) - start ))
+check "eshkol_outcome_guarded kills a real hang instead of waiting for it (elapsed=${elapsed}s < 10s)" \
+    "$([ "$elapsed" -lt 10 ] && echo 0 || echo 1)"
+check "a timeout exit code (rc=$rc) is exactly 124" "$([ "$rc" -eq 124 ] && echo 0 || echo 1)"
+check "eshkol_outcome_classify_exit(124) = INFRA" \
+    "$([ "$(eshkol_outcome_classify_exit "$rc")" = INFRA ] && echo 0 || echo 1)"
+
+# ── 2. a missing binary classifies as INFRA (exec-not-found = 127) ──
+eshkol_outcome_guarded 5 "$WORK/this-binary-does-not-exist-$$"
+rc=$?
+check "exec of a missing binary reports 127 (rc=$rc)" "$([ "$rc" -eq 127 ] && echo 0 || echo 1)"
+check "eshkol_outcome_classify_exit(127) = INFRA (missing dependency, per the taxonomy)" \
+    "$([ "$(eshkol_outcome_classify_exit "$rc")" = INFRA ] && echo 0 || echo 1)"
+
+# ── 3. a genuine wrong answer (nonzero, ran to completion) is FAIL ──
+eshkol_outcome_guarded 5 sh -c 'exit 1'
+rc=$?
+check "a completed nonzero exit (rc=$rc) is exactly 1, not folded into a timeout code" \
+    "$([ "$rc" -eq 1 ] && echo 0 || echo 1)"
+check "eshkol_outcome_classify_exit(1) = FAIL" \
+    "$([ "$(eshkol_outcome_classify_exit "$rc")" = FAIL ] && echo 0 || echo 1)"
+
+# ── 4. a self-inflicted crash is still FAIL, never mistaken for our alarm ──
+# This is the exact defect class the audit's own bridging fix documents:
+# the OLD exec-then-perl-alarm pattern could not tell "our alarm fired" from
+# "the child raised a real signal on its own", because exec replaces the
+# process image the alarm handler lived in. eshkol_outcome_guarded forks
+# instead, so a real SIGSEGV the child raises on its own is preserved as
+# 128+11=139, never masked as our 124.
+eshkol_outcome_guarded 5 sh -c 'kill -SEGV $$'
+rc=$?
+check "a self-raised SIGSEGV reports 128+11=139 (rc=$rc), not 124" \
+    "$([ "$rc" -eq 139 ] && echo 0 || echo 1)"
+check "eshkol_outcome_classify_exit(139) = FAIL (a real crash is a defect, not infra)" \
+    "$([ "$(eshkol_outcome_classify_exit "$rc")" = FAIL ] && echo 0 || echo 1)"
+
+# ── 5. INFRA never publishes a test_result; PASS/FAIL always do ──
+trace="$WORK/trace.jsonl"
+: > "$trace"
+eshkol_outcome_emit_test_result "$trace" probe_infra INFRA "should not appear"
+eshkol_outcome_emit_test_result "$trace" probe_fail FAIL "a real wrong answer"
+eshkol_outcome_emit_test_result "$trace" probe_pass PASS "a real correct answer"
+infra_lines=$(grep -c '"name": "probe_infra"' "$trace" 2>/dev/null || true)
+[ -z "$infra_lines" ] && infra_lines=0
+fail_lines=$(grep -c '"name": "probe_fail"' "$trace" 2>/dev/null || true)
+[ -z "$fail_lines" ] && fail_lines=0
+pass_lines=$(grep -c '"name": "probe_pass"' "$trace" 2>/dev/null || true)
+[ -z "$pass_lines" ] && pass_lines=0
+check "INFRA writes NO test_result record (found $infra_lines)" \
+    "$([ "$infra_lines" -eq 0 ] && echo 0 || echo 1)"
+check "a genuine FAIL DOES write a test_result record (found $fail_lines)" \
+    "$([ "$fail_lines" -eq 1 ] && echo 0 || echo 1)"
+check "a genuine PASS DOES write a test_result record (found $pass_lines)" \
+    "$([ "$pass_lines" -eq 1 ] && echo 0 || echo 1)"
+if [ "$fail_lines" -eq 1 ]; then
+    check "the FAIL record's passed field is false" \
+        "$(grep '"name": "probe_fail"' "$trace" | grep -q '"passed": false' && echo 0 || echo 1)"
+fi
+if [ "$pass_lines" -eq 1 ]; then
+    check "the PASS record's passed field is true" \
+        "$(grep '"name": "probe_pass"' "$trace" | grep -q '"passed": true' && echo 0 || echo 1)"
+fi
+
+# ── 6. retry-once: INFRA gets exactly one retry; a real FAIL never does ──
+marker="$WORK/warm-marker"
+rm -f "$marker" "$WORK/attempts-infra"
+cat > "$WORK/cold-then-warm.sh" <<'EOF'
+#!/usr/bin/env bash
+marker="$1"
+if [ ! -e "$marker" ]; then
+    touch "$marker"
+    sleep 30   # first attempt: looks like a hang
+else
+    echo "warm"
+    exit 0     # second attempt: fast and correct
+fi
+EOF
+chmod +x "$WORK/cold-then-warm.sh"
+eshkol_outcome_retry_guarded 1 "$WORK/out.txt" "$WORK/err.txt" \
+    "$WORK/cold-then-warm.sh" "$marker"
+rc=$?
+check "retry_guarded recovers a transient INFRA condition on its one retry (rc=$rc)" \
+    "$([ "$rc" -eq 0 ] && grep -q warm "$WORK/out.txt" && echo 0 || echo 1)"
+
+rm -f "$WORK/attempts-fail"
+eshkol_outcome_retry_guarded 5 "$WORK/out2.txt" "$WORK/err2.txt" \
+    sh -c 'echo x >> "'"$WORK"'/attempts-fail"; exit 1'
+rc=$?
+attempts=$(wc -l < "$WORK/attempts-fail" 2>/dev/null | tr -d ' ')
+check "retry_guarded returns the real FAIL's own exit code (rc=$rc)" \
+    "$([ "$rc" -eq 1 ] && echo 0 || echo 1)"
+check "retry_guarded NEVER retries a real FAIL (ran exactly once, ran $attempts times)" \
+    "$([ "$attempts" = "1" ] && echo 0 || echo 1)"
+
+echo
+echo "harness_outcome_taxonomy_test.sh: $pass passed, $fail failed"
+if [ "$fail" -eq 0 ]; then
+    echo "harness_outcome_taxonomy_test.sh: PASS"
+    exit 0
+fi
+echo "harness_outcome_taxonomy_test.sh: FAIL"
+exit 1


### PR DESCRIPTION
## Summary

Trace-emitting harnesses could not distinguish "the code failed" from "the
harness could not run", and wrote that indistinguishable red into traces
other tools consume. Two measured instances from the 2026-08-25 architecture
audit (section 3):

- **`run_vm_parity.sh`** reported FAIL "2 of 188" — both were `native -r
  exited 142` (SIGALRM) from a 140-second cold-start JIT compile under load
  average 180. Direct re-runs: 140.49s, then 0.07s, 0.06s, exit 0,
  byte-identical output. That spurious FAIL propagated through
  `icc architecture-verify` and turned the HIGH invariant
  `INV-dispatch-table-completeness` red.
- The `language_surface_coverage_floor` smoke probe reported exit 1 while a
  direct run of `run_language_coverage.sh` gave exit 0 with 1106/1106
  (100.0%), 0 uncovered — an unrelated flaky test in a full-suite
  prerequisite aborted the script under `set -e` before coverage was ever
  computed.

## What this does

- **`scripts/lib/harness_outcome.sh`** (new): a shared `PASS`/`FAIL`/`INFRA`/
  `SKIP` vocabulary — a real fork-based timeout wrapper
  (`eshkol_outcome_guarded`), an exit-code classifier
  (`eshkol_outcome_classify_exit`), JSON-L event/`test_result` emitters that
  never publish a false verdict for INFRA, and a retry-once helper
  (`eshkol_outcome_retry_guarded`) for a transient INFRA condition. Chosen
  encoding: **INFRA never publishes a `test_result` record** — ICC's
  `intended-invariant` evaluator (`_check_parity_evidence`) is a two-state
  PASS/FAIL machine with no UNCHECKABLE branch, so a harness cannot publish
  "no verdict" through that channel without it reading exactly like a code
  defect. Emitting nothing leaves any still-valid standing verdict alone
  instead of overwriting it with a false red. The richer domain-specific
  event streams (`vm_parity`, `eshkol_smoke`, `ctest`) DO get an explicit
  `"INFRA"` value, since the `completion-oracle` `runtime_event` matcher only
  ever treats `event_values: ["PASS"]` as satisfying a criterion — INFRA and
  FAIL are equally "not yet satisfied" there, so recording the honest value
  costs nothing and is strictly more informative than overloading FAIL.
- **`run_vm_parity.sh`**: adopts the shared wrapper (fixing the exact
  exec-then-alarm bug that produced the audit's `142`), adds a one-time
  untimed JIT-cache warm-up before the timed per-file loop (the actual root
  cause of the 140s outlier), and retries any residual INFRA classification
  once before concluding. The alarm itself is untouched — a real hang is
  still caught and still kills the process.
- **`run_language_coverage.sh`**: decouples the coverage-floor computation
  from `run_all_tests.sh`'s own exit code. That prerequisite already runs
  every suite to completion regardless of individual failures (its own
  header: "DO NOT use set -e"), so the execution-trace evidence is complete
  by the time it returns nonzero; the bug was this script's own `set -e`
  discarding that evidence before ever measuring coverage. A genuine
  full-suite regression stays visible (console summary, a new informational
  prereq trace, and independently via `run_ctest_gate.sh`).
- **`run_icc_smoke.sh`**: `probe()` now classifies INFRA separately from FAIL
  and never sinks the gate on it.
- **`run_ctest_gate.sh`**: a per-test CTest `TIMEOUT` now classifies INFRA in
  both the JUnit and console-fallback parsers, with a harness-contradiction
  guard if `ctest`'s own exit code disagrees with every parsed verdict for no
  accounted reason.
- **Seven depth/metamorphic/adversarial runners** (`run_metamorphic.sh`,
  `run_recursion_depth.sh`, `run_nesting_depth.sh`, `run_metaprog_depth.sh`,
  `run_ad_depth.sh`, `run_ad_adversarial.sh`,
  `run_tensor_collection_depth.sh`): all carried the same duplicated
  exec-then-perl-alarm bug locally (two of them had already been written to
  check for the correct `124` downstream — dead code until now). All now
  delegate to the shared wrapper; no harness's own PASS/FAIL/HANG/LIMIT
  vocabulary changed, only the bucket assignment became correct.
- **`tests/harness/harness_outcome_taxonomy_test.sh`** (new, 17 checks): the
  regression test proving the distinction is real — forces a timeout, a
  missing binary, a genuine wrong-answer exit, and a self-inflicted crash,
  and asserts each lands in the bucket it must (including that INFRA
  publishes no `test_result` while FAIL/PASS always do, and that only INFRA
  is ever retried). Wired as a new `harness_outcome_taxonomy` probe in
  `run_icc_smoke.sh` and a new high-severity criterion in
  `eshkol-compiler-readiness`.

## Not touched (reviewed, judged safe or out of scope)

- `run_sanitizer_fuzz.sh`'s own guarded wrapper is already fork-based and
  additionally kills the whole process group — left as-is rather than
  downgrading it.
- `run_numeric_depth.sh`'s wrapper has the same imprecise exit-code
  propagation, but its classification never reads the exit code (only
  `PASS`/`WRONG`/`DONE` markers the target program prints itself) — already
  safe by construction.
- The same exec-then-alarm pattern also exists in ~15 other scripts not named
  in scope for this PR (`run_ad_oracle.sh`, `run_differential.sh`,
  `run_wasm_differential.sh`, several `tests/memory/*.sh`, etc.) — same
  defect class, flagged for a follow-up rather than expanded into here.
- An ICC-side gap (the `intended-invariant` evaluator's missing UNCHECKABLE
  state) is filed at `~/.tsotchke/state/feedback/` for the ICC maintainer;
  out of scope for this repo.

## Test plan

- [x] `ctest --test-dir build -j6`: **191/191 passed**
- [x] `run_vm_parity.sh` run twice: **188 passed / 0 failed / 0 infra** both
      times (~108s each) — not flaky
- [x] `run_ctest_gate.sh` end-to-end against the real build: **191/191**,
      all group roll-ups green (confirms the rewritten JUnit parser doesn't
      regress the PASS path)
- [x] `tests/harness/harness_outcome_taxonomy_test.sh`: **17/17 passed**
- [x] `python3 scripts/gate_no_silent_wrong.py --no-trace`: PASS
- [x] `python3 scripts/check_ledger_integrity.py`: PASS
- [x] `python3 scripts/check_oracle_schema.py`: PASS (267/267 criteria valid,
      49/49 for `eshkol-compiler-readiness`)
- [x] `icc register/index/build-memory/guard-diff/pre-commit-check`: all
      clean (`pre-commit-check`: PASS, 0 blockers)