### PR TITLE
feat(frontend): ADR-0000 S1 phase A — NodeId identity substrate with span resolution

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -575,6 +575,57 @@ oracles:
         action: python3 scripts/test_language_coverage_gate.py
 
   # ─────────────────────────────────────────────────────────────────
+  # ADR-0000 Stage 1 — the frontend node-identity substrate.
+  #
+  # ADR-0000 sequences fourteen stages and gives each one a falsifiable
+  # gate; Stage 1 is the DAG-roots stage that everything after it waits
+  # on. Its identity half is the substrate ADR-0000 §7 risk 1 calls "the
+  # single most important co-design constraint in the whole program":
+  #
+  #     NodeId -> { SourceSpan, BindingId, TypedExprInfo }
+  #
+  # shared by the compiler, LSP, docs, REPL and VM. ADRs 0004, 0006 and
+  # 0008 are three overlapping frontend rewrites over that one substrate;
+  # specified separately they fork the frontend and the "one answer"
+  # invariant is false by construction.
+  #
+  # This oracle grades PHASE A only, and grades it honestly: the NodeId
+  # key and the SourceSpan column exist, a real consumer resolves through
+  # them, and the coverage is a measured number on a ratchet. It does NOT
+  # claim Stage 1 attainment. Still outstanding for the stage, each in
+  # its own slice and none of them half-built here:
+  #   - BindingId column          -> ADR-0006 slices 1-2
+  #   - TypedExprInfo column      -> ADR-0004 spine part 1
+  #   - one semantic tooling core -> ADR-0008 M0/M1 (the LSP still
+  #                                  counts parentheses by hand)
+  #   - byte-offset canonical spans and the expansion-origin table
+  #   - 0002 Phase A / 0001 Phase A / 0007 Phase 0 / 0009 contract freeze
+  # ─────────────────────────────────────────────────────────────────
+  - name: adr0000-s1-identity
+    aliases: [s1-identity, node-identity, adr0000-stage1]
+    requires:
+      - runtime_event:
+          event_kinds: [runtime_event]
+          event_names: ["node_identity_substrate_present"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'The NodeId -> SourceSpan substrate exists and is consumed: the parser mints ids and a real consumer resolves locations through them'
+        action: python3 scripts/run_node_identity_gate.py
+
+      - runtime_event:
+          event_kinds: [runtime_event]
+          event_names: ["node_identity_span_coverage"]
+          event_values: ["PASS"]
+        severity: high
+        label: Substrate span coverage at the codegen dispatcher holds its monotonic floor (resolved/queried, measured on a mixed corpus)
+        action: python3 scripts/run_node_identity_gate.py
+
+      - test_evidence: true
+        severity: medium
+        label: 'Substrate contract tests are indexed: a garbage or unset NodeId never resolves to a location, ids survive by-value node copies, and the parser demonstrably stamps forms'
+        action: ctest -R node_identity_test
+
+  # ─────────────────────────────────────────────────────────────────
   # Agent-FFI readiness — the contract the eshkol-agent depends on.
   # When this oracle goes green, the agent's three blockers (HTTP,
   # subprocess, session persistence) are all cleared on the eshkol side.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ADR-0000 Stage 1, phase A: the frontend node-identity substrate.** Every
+  AST node the parser produces now carries a stable `NodeId`, and a side table
+  maps that id to a `SourceSpan` — the first column of the
+  `NodeId -> {SourceSpan, BindingId, TypedExprInfo}` substrate that ADR-0000 §7
+  risk 1 calls "the single most important co-design constraint in the whole
+  program", and that ADRs 0004, 0006 and 0008 all have to be built on if the
+  compiler, LSP, docs, REPL and VM are to give one answer rather than five.
+
+  New: `inc/eshkol/frontend/node_identity.h` (the API),
+  `lib/frontend/node_identity.cpp` (a chunked, lock-free-read span table),
+  `eshkol_ast_t::node_id` (the 4-byte key; the payload stays out of line, per
+  ADR-0008 §4.2), and `tests/frontend/node_identity_test.cpp`.
+
+  The parser's 32 location-stamping sites now write the location and the
+  identity in one statement, so the two cannot drift apart, and the stream
+  reader closes each top-level form's span with a measured *extent* — the first
+  place in the frontend that records where a construct ends rather than only
+  where it begins.
+
+  `NodeId`s are tagged, not bare indices, because `eshkol_ast_t` is declared
+  uninitialised in a dozen places (`macro_expander.cpp`, `sexp_to_ast.cpp`,
+  `introspection.cpp`) and an unset field holds garbage. A garbage word is
+  rejected by its tag and again by its bound, so it reads as "unknown" — the
+  same discipline `source_file_id` already follows, for the same reason: a
+  diagnostic may fail to name a location, but it must never name a wrong one
+  confidently.
+
+  Strictly additive. `line`, `column` and `source_file_id` keep their exact
+  previous values and every consumer that has not moved onto the substrate
+  reads what it always read.
+
+- **The LLVM codegen dispatcher resolves diagnostics through the substrate.**
+  `codegenAST` asks `NodeId -> SourceSpan` for the file, line and column it
+  reports, falling back to the node's own fields when the substrate does not
+  know a node (one synthesized after parsing — an import lowered to a `define`
+  alias, a macro expansion). This is the first real consumer, and it is the
+  diagnostics path deliberately: it is where ESH-0364 (a location naming the
+  wrong file) and ESH-0365 (a location on the closing paren) both landed.
+
+  Emitted locations are unchanged — the span was recorded from the same token
+  that set `line`/`column`. What changes is that a node's *file* no longer
+  depends on the traversal that reached it: `source_file_id` is stamped only on
+  top-level forms and every inner node borrowed the ambient context, whereas in
+  the span table each stamped node carries its own file. `ScopedAstProvenance`
+  gained the integer fast path its own comment always claimed, now that it runs
+  per node instead of per top-level form.
+
+- **`scripts/run_node_identity_gate.py` measures substrate coverage.** With
+  `ESHKOL_NODE_IDENTITY_STATS=1` every frontend process prints
+  `eshkol-node-identity: allocated=N queried=N resolved=N located=N extent=N`
+  as it exits. The gate compiles a mixed corpus, aggregates, and emits
+  `node_identity_substrate_present` and `node_identity_span_coverage` as ICC
+  `runtime_event` traces against a monotonic floor in
+  `tests/coverage/NODE_IDENTITY_BASELINE.json`. Graded by the new
+  `adr0000-s1-identity` completion oracle.
+
+  The gated number is measured at a *consumer*, not at the parser: a
+  parser-side count says only how many ids were minted, never whether the
+  answer arrived where it was needed. "Has an identity", "has a location" and
+  "has an extent" stay three separate numbers so none can be read as another.
+  This is what makes the stage falsifiable, which is the whole point of
+  ADR-0000's gates.
+
+  Phase A only, and the oracle says so: `BindingId` (ADR-0006 slices 1-2),
+  `TypedExprInfo` (ADR-0004 spine part 1), the one semantic tooling core
+  (ADR-0008 M0/M1 — the LSP still counts parentheses by hand), byte-offset
+  canonical spans and the expansion-origin table are all still outstanding, and
+  none of them is half-built here.
+
 - **The bytecode VM reclaims memory: a Stage-1 OALR region evacuator ports
   `with-region` reclamation to the VM heap (SW-14, the v1.3.5 flagship item).**
   `(with-region ...)` used to lower to `begin` on the VM. The body ran, its

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2914,6 +2914,21 @@ if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/web/content_
     add_test(NAME content_length_parse_test COMMAND content_length_parse_test)
 endif()
 
+# ===== ADR-0000 Stage 1: frontend node-identity substrate =====
+if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/frontend/node_identity_test.cpp")
+    add_executable(node_identity_test tests/frontend/node_identity_test.cpp)
+    target_compile_features(node_identity_test PRIVATE cxx_std_20)
+    target_include_directories(node_identity_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+    eshkol_target_llvm_includes(node_identity_test)
+    if(LLVM_LIBRARY_DIRS)
+        target_link_directories(node_identity_test PRIVATE ${LLVM_LIBRARY_DIRS})
+    endif()
+    target_link_libraries(node_identity_test PRIVATE eshkol-static ${ESHKOL_EXTRA_LINK_LIBS} ${LLVM_LIBS_LIST} ${LLVM_SYSTEM_LIBS_LIST})
+    add_test(NAME node_identity_test COMMAND node_identity_test)
+    set_tests_properties(node_identity_test PROPERTIES
+        PASS_REGULAR_EXPRESSION "PASS: node identity substrate")
+endif()
+
 if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/core/model_io_test.cpp")
     add_executable(model_io_test tests/core/model_io_test.cpp)
     target_compile_features(model_io_test PRIVATE cxx_std_20)

--- a/docs/design/adr/0000-unified-trajectory.md
+++ b/docs/design/adr/0000-unified-trajectory.md
@@ -228,6 +228,52 @@ is the gate, not the label.
   identical module graph; Z-set reference fixtures (insert / delete / duplicate /
   cancellation / canonical serialization) are byte-stable across regeneration.
 
+#### Stage 1 attainment — phase A of the identity substrate has landed
+
+This subsection records what is in the tree against the stage above. It adds
+evidence; it does not narrow the stage. Everything the stage asks for that is
+not listed as landed is still owed.
+
+**Landed** (`inc/eshkol/frontend/node_identity.h`,
+`lib/frontend/node_identity.cpp`):
+
+- `NodeId` — a stable, dense, tagged identity minted by the parser for every
+  node it gives a location to, carried on `eshkol_ast_t::node_id` as a 4-byte
+  key only, with the payload out of line exactly as §4.2 of ADR-0008 requires
+  during the v1.x migration.
+- `SourceSpan` — the first of the three columns, as a real side table.
+  Top-level forms carry a measured *extent*; inner nodes are points.
+- One consumer moved off its ad-hoc mechanism: the LLVM codegen dispatcher
+  resolves the file, line and column of its diagnostics through
+  `NodeId -> SourceSpan`, falling back to the node's own fields for nodes the
+  substrate does not know. Emitted locations are unchanged — the substrate is
+  additive — but a node's file no longer depends on the traversal that
+  reached it.
+- A number: `scripts/run_node_identity_gate.py` reports substrate coverage at
+  that consumer as an ICC `runtime_event` trace on a monotonic floor, graded by
+  the `adr0000-s1-identity` oracle. First reading 99.49%, floor 99.48%.
+
+**Still owed by Stage 1**, each in its own slice and none of them half-built:
+
+- The `BindingId` column — ADR-0006 slices 1-2 (sequenced into Stage 2).
+- The `TypedExprInfo` column — ADR-0004 spine part 1 (sequenced into Stage 2).
+  Both must key on the *same* `NodeId`; that constraint is now expressible,
+  because the key exists.
+- ADR-0008 M0 proper: `Diagnostic v1`, the semantic-catalog seed, the module
+  resolver extracted from `eshkol-run` behind a shared API, the LLVM-free
+  analysis target, byte-offset canonical spans (the current reader strips line
+  comments before tokenizing, so a token offset is not a file offset and byte
+  spans recorded today would be wrong rather than merely absent), and the
+  expansion-origin table — whose absence is exactly what the coverage gate's
+  ~0.5% of unresolved nodes is made of.
+- The 0002 Phase A, 0001 Phase A, 0007 Phase 0 and 0009 contract-freeze
+  tranches, and the stage gate's counter, region and Z-set clauses.
+
+The risk-1 falsifier — the cross-consumer fixture in which compiler, LSP, docs
+and REPL report an identical identity and span for the same source — is still
+not green, and cannot be until `SymbolId`/`ModuleId` exist. It is, however, now
+*expressible* for the span half, which it was not before.
+
 ### Stage 2 — v1.3.3b: "Binding resolution and interned type terms"
 
 - Theme: kill string-based identity in the frontend before any typed feature stores

--- a/inc/eshkol/eshkol.h
+++ b/inc/eshkol/eshkol.h
@@ -2626,6 +2626,25 @@ typedef struct eshkol_ast {
      * garbage id simply falls outside the table and reads as "unknown"; a
      * garbage pointer would be dereferenced by the diagnostic printer. */
     uint32_t source_file_id;
+
+    /* Stable identity of this node in the frontend node-identity substrate
+     * (ADR-0000 Stage 1; see inc/eshkol/frontend/node_identity.h).
+     *
+     * This is the KEY only. The payload — today a SourceSpan, and by
+     * ADR-0000's end state also a BindingId (ADR-0006) and a TypedExprInfo
+     * (ADR-0004) — lives in side tables keyed on this value, because
+     * ADR-0008 §4.2 settles that the columns must not be fields on this
+     * struct during the v1.x migration, and because the whole point of the
+     * substrate is that five consumers share one table rather than each
+     * growing its own field.
+     *
+     * ESHKOL_NODE_ID_NONE (0) means "no identity", which is what a node
+     * synthesized outside the parser reads as. Like `source_file_id` this is
+     * deliberately an id and not a pointer: nodes are built in places that
+     * do not zero-initialize, so this field can hold garbage, and a garbage
+     * NodeId is rejected by its tag and its bound and reads as unknown —
+     * never as a confident wrong location. */
+    uint32_t node_id;
 } eshkol_ast_t;
 
 // ===== Unified AST Literal Builders =====

--- a/inc/eshkol/frontend/node_identity.h
+++ b/inc/eshkol/frontend/node_identity.h
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) tsotchke
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+#ifndef ESHKOL_FRONTEND_NODE_IDENTITY_H
+#define ESHKOL_FRONTEND_NODE_IDENTITY_H
+
+/**
+ * @file node_identity.h
+ * @brief The frontend node-identity substrate: `NodeId -> SourceSpan`.
+ *
+ * ADR-0000 §7 risk 1 names one artifact as "the single most important
+ * co-design constraint in the whole program": a shared frontend substrate
+ * mapping
+ *
+ *     NodeId -> { SourceSpan, BindingId, TypedExprInfo }
+ *
+ * consumed by the compiler, the LSP, the documentation extractor, the REPL,
+ * and the VM, so that all five answer *one* question with *one* answer.
+ * ADRs 0004 (typed HIR), 0006 (`BindingId` name resolution) and 0008
+ * (`SourceSpan` + workspace resolver) are three overlapping frontend
+ * rewrites over that one substrate; specified separately they fork the
+ * frontend and the "one answer" invariant becomes false by construction.
+ *
+ * This header is ADR-0000 Stage 1 **phase A**: the `NodeId` key itself and
+ * the first of the three side tables, `NodeId -> SourceSpan`. The other two
+ * columns are deliberately absent, not stubbed:
+ *
+ *   - `BindingId`      -> ADR-0006 slices 1-2 (Stage 2)
+ *   - `TypedExprInfo`  -> ADR-0004 spine part 1 (Stage 2)
+ *
+ * When they land they must key on the *same* `eshkol_node_id_t` allocated
+ * here. That is the whole point of allocating the id in the parser rather
+ * than inside any one consumer.
+ *
+ * ## Why a side table and not fields on the node
+ *
+ * ADR-0008 §4.2 settles this: "Adding span fields directly to
+ * `eshkol_ast_t` would change a public struct. During the v1.x migration, a
+ * `ParsedUnit` owns ASTs plus a `NodeId -> SourceSpan` side table and
+ * expansion-origin table." Only the 4-byte key rides on the node; the span
+ * payload, and every future column, lives out of line. A consumer that
+ * wants a location asks the substrate, and every consumer that asks gets
+ * the same answer.
+ *
+ * ## Why ids are tagged
+ *
+ * `eshkol_ast_t` values are built in dozens of places, several of which do
+ * not zero-initialize (this is why `source_file_id` is an id and not a
+ * `const char*` — see its comment in eshkol.h). An unset `node_id` field
+ * therefore holds garbage. A `NodeId` is consequently not a bare index: its
+ * high byte is a fixed tag (::ESHKOL_NODE_ID_TAG), so 255 of every 256
+ * garbage words are rejected outright, and the remaining ones are caught by
+ * the index bound. A rejected id reads as "unknown", exactly as an
+ * out-of-range `source_file_id` does — never as a wrong location.
+ *
+ * ## Thread-safety
+ *
+ * Allocation takes a mutex. Lookup is lock-free: chunk pointers are
+ * published with release stores and the live count with a release store
+ * *after* the payload is written, so any id a reader can name is fully
+ * constructed. Spans are immutable once published, except for
+ * eshkol_node_span_set_extent() which only ever widens the end of a span
+ * whose start is already final.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Stable identity of one frontend AST node.
+ *
+ * Dense within a process: ids are handed out as consecutive indices with a
+ * constant tag in the high byte. ::ESHKOL_NODE_ID_NONE (0) means "this node
+ * has no identity", which is what an unstamped or synthesized node reads as.
+ */
+typedef uint32_t eshkol_node_id_t;
+
+/** @brief The "no identity" NodeId. Never resolves to a span. */
+#define ESHKOL_NODE_ID_NONE ((eshkol_node_id_t)0)
+
+/** @brief High-byte tag every real NodeId carries, so garbage is rejected. */
+#define ESHKOL_NODE_ID_TAG ((uint32_t)0xE5u)
+
+/** @brief Number of NodeIds the substrate can hand out (2^24 - 1). */
+#define ESHKOL_NODE_ID_MAX_INDEX ((uint32_t)0x00FFFFFFu)
+
+/**
+ * @brief A source location, as one value.
+ *
+ * ADR-0008 §4.2 specifies the end-state span as
+ * `{file_id, start_byte, end_byte, expansion_id?}` with UTF-8 byte offsets
+ * as the canonical location and a `SourceManager` projecting them to
+ * line/column on demand. Phase A stores line/column directly, because that
+ * is what the current reader measures: `eshkol_parse_next_ast_from_stream`
+ * strips line comments from the text it hands the tokenizer, so a token's
+ * offset within that text is not an offset into the file, and byte offsets
+ * recorded today would be wrong rather than merely absent. Byte-offset
+ * canonicalization arrives with the lossless token stream in ADR-0008 M0
+ * proper; the struct is the migration point, and consumers already ask it
+ * rather than reading fields off the node.
+ *
+ * `expansion_id` is likewise absent, not stubbed: macro-origin chains are
+ * ADR-0008 M0's expansion table.
+ */
+typedef struct {
+    /** Interned source-file id (see eshkol_intern_source_file). 0 = unknown. */
+    uint32_t file_id;
+    /** 1-based line of the first character of the construct. 0 = unknown. */
+    uint32_t start_line;
+    /** 1-based column of the first character of the construct. 0 = unknown. */
+    uint32_t start_column;
+    /** 1-based line of the last character, when the extent is known. */
+    uint32_t end_line;
+    /** 1-based column of the last character, when the extent is known. */
+    uint32_t end_column;
+    /**
+     * @brief True when `end_*` is a *measured* end of the construct.
+     *
+     * When false, `end_*` mirrors `start_*` and the span is a point, not a
+     * range. Reported separately by eshkol_node_identity_stats() so the
+     * difference between "has a location" and "has an extent" is a number
+     * and not a claim.
+     */
+    bool has_extent;
+} eshkol_source_span_t;
+
+/**
+ * @brief Allocate a NodeId and bind it to a point span.
+ *
+ * @param file_id Interned source-file id, or 0 if unknown.
+ * @param line 1-based line, or 0 if unknown.
+ * @param column 1-based column, or 0 if unknown.
+ * @return A fresh NodeId, or ::ESHKOL_NODE_ID_NONE if the id space is
+ *         exhausted (which reads as "unknown" everywhere, never as wrong).
+ */
+eshkol_node_id_t eshkol_node_id_new(uint32_t file_id, uint32_t line, uint32_t column);
+
+/**
+ * @brief Widen an already-allocated span to end at @p end_line / @p end_column.
+ *
+ * Idempotent and monotone: only ever sets the extent, never moves the start.
+ * A no-op for ::ESHKOL_NODE_ID_NONE and for unresolvable ids.
+ */
+void eshkol_node_span_set_extent(eshkol_node_id_t id, uint32_t end_line, uint32_t end_column);
+
+/**
+ * @brief Resolve a NodeId to its span.
+ *
+ * @param id Candidate id. Garbage, ::ESHKOL_NODE_ID_NONE, and ids from a
+ *        different process all resolve to false.
+ * @param out Filled in only when the function returns true.
+ * @return true when @p id names a span this process allocated.
+ */
+bool eshkol_node_span_lookup(eshkol_node_id_t id, eshkol_source_span_t* out);
+
+/** @brief Count of NodeIds handed out so far. */
+uint64_t eshkol_node_id_count(void);
+
+/**
+ * @brief Substrate-coverage counters, the measurable half of the Stage-1 gate.
+ *
+ * ADR-0000's stages are falsifiable only if attainment is a number. These
+ * are that number's inputs. Consumers that resolve a location through the
+ * substrate call eshkol_node_identity_record_lookup() on every node they
+ * visit; the ratio of @p resolved to @p queried is the fraction of the AST
+ * that the substrate actually covers on a real compile.
+ *
+ * Any out-parameter may be NULL.
+ *
+ * @param queried Nodes a substrate consumer asked about.
+ * @param resolved Of those, nodes whose NodeId resolved to a span.
+ * @param with_location Of those resolved, spans naming a real line.
+ * @param with_extent Of those resolved, spans whose end is measured.
+ * @param allocated Total NodeIds handed out by the parser.
+ */
+void eshkol_node_identity_stats(uint64_t* queried,
+                                uint64_t* resolved,
+                                uint64_t* with_location,
+                                uint64_t* with_extent,
+                                uint64_t* allocated);
+
+/**
+ * @brief Record one consumer lookup against the coverage counters.
+ *
+ * Called by substrate consumers, not by the substrate itself, because the
+ * question the gate asks is "did the consumer get an answer", and only the
+ * consumer knows it asked.
+ */
+void eshkol_node_identity_record_lookup(bool resolved, bool has_location, bool has_extent);
+
+/** @brief Reset the coverage counters (for per-unit measurement and tests). */
+void eshkol_node_identity_reset_stats(void);
+
+/**
+ * @brief Is substrate-coverage reporting requested for this process?
+ *
+ * True when ESHKOL_NODE_IDENTITY_STATS is set to anything but 0/false.
+ * Consumers skip the counter updates entirely when this is false, so the
+ * substrate costs one predicted branch on the codegen hot path.
+ */
+bool eshkol_node_identity_stats_enabled(void);
+
+/**
+ * @brief Write the one-line coverage report to stderr, if enabled.
+ *
+ * Format (single line, stable, machine-readable by scripts/node_identity_gate.py):
+ * `eshkol-node-identity: allocated=N queried=N resolved=N located=N extent=N`
+ */
+void eshkol_node_identity_report(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ESHKOL_FRONTEND_NODE_IDENTITY_H */

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -6,6 +6,7 @@
  */
 #include "eshkol/eshkol.h"
 #include <eshkol/llvm_backend.h>
+#include <eshkol/frontend/node_identity.h>
 #include <eshkol/backend/type_system.h>
 #include <eshkol/backend/function_cache.h>
 #include <eshkol/backend/memory_codegen.h>
@@ -659,16 +660,36 @@ static const std::string& sourceTextForFile(const std::string& path) {
     return g_source_text_by_file.emplace(path, std::move(text)).first->second;
 }
 
-/* Make a top-level form's originating file the ambient source context for the
- * duration of its codegen, restoring the previous one on the way out. Nodes with
- * no provenance (every inner node) and forms from the ambient file itself are a
- * no-op, so the cost on the hot path is one integer compare. */
+/* Id of the file `g_source_filepath` currently names, or 0 when the ambient
+ * context did not come from an interned file. Exists so ScopedAstProvenance
+ * can answer "same file?" without resolving the id to a string.
+ *
+ * This became load-bearing when the node-identity substrate started supplying
+ * a file for EVERY node rather than only for top-level forms: the string
+ * resolution it replaces takes a process-wide mutex, and running that once per
+ * AST node instead of once per top-level form would have made a correctness
+ * improvement pay for itself in contention. Now the common case really is the
+ * one integer compare the class always claimed. */
+static uint32_t g_source_file_id_active = 0;
+
+/* Make a form's originating file the ambient source context for the duration
+ * of its codegen, restoring the previous one on the way out. Nodes with no
+ * provenance and nodes from the ambient file itself are a no-op, so the cost
+ * on the hot path is one integer compare. */
 class ScopedAstProvenance {
 public:
     explicit ScopedAstProvenance(uint32_t source_file_id) {
         if (source_file_id == 0) return;
+        if (source_file_id == g_source_file_id_active) return;
         const char* name = eshkol_source_file_name(source_file_id);
-        if (!name || !*name || g_source_filepath == name) return;
+        if (!name || !*name) return;
+        if (g_source_filepath == name) {
+            // Same file under a different route in. Record the id so the next
+            // node from this file settles on the integer compare above instead
+            // of resolving the name again.
+            g_source_file_id_active = source_file_id;
+            return;
+        }
         // Resolve the text BEFORE rebinding g_source_filepath: sourceTextForFile
         // short-circuits on `path == g_source_filepath` to reuse the ambient
         // text, so assigning the new path first made that test trivially true
@@ -678,20 +699,24 @@ public:
         std::string text = sourceTextForFile(std::string(name));
         saved_path_ = std::move(g_source_filepath);
         saved_text_ = std::move(g_source_text);
+        saved_file_id_ = g_source_file_id_active;
         active_ = true;
         g_source_filepath = name;
         g_source_text = std::move(text);
+        g_source_file_id_active = source_file_id;
     }
     ~ScopedAstProvenance() {
         if (!active_) return;
         g_source_filepath = std::move(saved_path_);
         g_source_text = std::move(saved_text_);
+        g_source_file_id_active = saved_file_id_;
     }
     ScopedAstProvenance(const ScopedAstProvenance&) = delete;
     ScopedAstProvenance& operator=(const ScopedAstProvenance&) = delete;
 private:
     std::string saved_path_;
     std::string saved_text_;
+    uint32_t saved_file_id_ = 0;
     bool active_ = false;
 };
 
@@ -10794,25 +10819,60 @@ private:
     Value* codegenAST(const eshkol_ast_t* ast) {
         if (!ast) return nullptr;
 
+        // ADR-0000 Stage 1: resolve this node's location through the
+        // NodeId -> SourceSpan substrate rather than by reading location
+        // fields off the node.
+        //
+        // This is the first consumer moved onto the substrate, and it is the
+        // diagnostics path on purpose: it is where a location is either right
+        // or actively misleading, and it is the path ESH-0364 and ESH-0365
+        // both landed on. What changes is WHERE the answer comes from. What
+        // does not change is the answer: the span was recorded by the parser
+        // from the same token that set `line`/`column`, so every location this
+        // emits is identical to the one it emitted before — the substrate is
+        // additive, and this consumer proves it is real by depending on it.
+        //
+        // The difference the substrate makes is structural. Today a node's
+        // FILE is knowable only for top-level forms (`source_file_id` is
+        // stamped there and nowhere else) and every inner node borrows the
+        // ambient context of whatever traversal reached it. In the span table
+        // every node the parser stamped carries its own file, so the answer
+        // stops depending on the traversal. The fallback below keeps the
+        // ambient-inheritance behaviour exactly for nodes the substrate does
+        // not know — a node synthesized after parsing, or one carrying a
+        // garbage id the tag check rejected.
+        eshkol_source_span_t span;
+        const bool span_ok = eshkol_node_span_lookup(ast->node_id, &span);
+        if (eshkol_node_identity_stats_enabled()) {
+            eshkol_node_identity_record_lookup(
+                span_ok,
+                span_ok && span.start_line > 0,
+                span_ok && span.has_extent);
+        }
+
         // ESH-0364: adopt this form's originating file as the source context, so
         // `line`/`column` are reported against the file they were measured in.
         // Placed here rather than in the callers because generateLLVMIR walks the
         // top-level array from several loops (externs, function defines, global
         // defines) and createMainWrapper/createLibraryInitFunction walk it again
         // — one scope at the single entry point covers every one of them, and
-        // any future walk, for free. Only top-level forms carry provenance;
-        // inner nodes are 0 and correctly inherit the enclosing form's file.
-        ScopedAstProvenance provenance(ast->source_file_id);
+        // any future walk, for free.
+        ScopedAstProvenance provenance(
+            (span_ok && span.file_id != 0) ? span.file_id : ast->source_file_id);
 
         // Update source location for error context
-        if (ast->line > 0) {
-            current_source_line = ast->line;
-            current_source_column = ast->column;
+        const uint32_t src_line =
+            (span_ok && span.start_line > 0) ? span.start_line : ast->line;
+        const uint32_t src_column =
+            (span_ok && span.start_line > 0) ? span.start_column : ast->column;
+        if (src_line > 0) {
+            current_source_line = src_line;
+            current_source_column = src_column;
             // Mirror into CodegenContext so sub-codegens (e.g. ArithmeticCodegen)
             // can emit a "file:line:col:" prefix on runtime type errors.
             if (ctx_) {
                 ctx_->setCurrentSourceLocation(g_source_filepath,
-                                               ast->line, ast->column);
+                                               src_line, src_column);
             }
         }
 
@@ -41747,6 +41807,11 @@ void eshkol_disable_debug_info(void) {
 void eshkol_set_source_context(const char* filepath, const char* source_text) {
     g_source_filepath = filepath ? filepath : "";
     g_source_text = source_text ? source_text : "";
+    /* The ambient path moved without going through ScopedAstProvenance, so its
+     * memoised id no longer describes it. 0 never equals a real interned id
+     * (they are 1-based), so the next provenance scope re-resolves and
+     * re-memoises rather than trusting a stale match. */
+    g_source_file_id_active = 0;
     eshkol_set_parse_source_context(filepath);
 }
 
@@ -41834,6 +41899,7 @@ LLVMModuleRef eshkol_generate_llvm_ir_with_source(
         ~RestoreSourceContext() {
             g_source_filepath = path;
             g_source_text = text;
+            g_source_file_id_active = 0;  // see eshkol_set_source_context
             eshkol_set_parse_source_context(parse_path.c_str());
         }
     } restore;
@@ -41843,6 +41909,7 @@ LLVMModuleRef eshkol_generate_llvm_ir_with_source(
 
     g_source_filepath = source_path ? source_path : "";
     g_source_text = source_text ? source_text : "";
+    g_source_file_id_active = 0;  // see eshkol_set_source_context
     eshkol_set_parse_source_context(source_path);
 
     try {

--- a/lib/frontend/node_identity.cpp
+++ b/lib/frontend/node_identity.cpp
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) tsotchke
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+/**
+ * @file node_identity.cpp
+ * @brief Storage for the `NodeId -> SourceSpan` substrate (ADR-0000 Stage 1).
+ *
+ * The table is a fixed-size array of chunk pointers, each chunk holding
+ * ::kChunkSpans spans. Allocation appends under a mutex; lookup is lock-free.
+ * A chunk array of ::kMaxChunks entries times ::kChunkSpans spans is exactly
+ * the 2^24 ids the tagged NodeId encoding can name, so the two limits agree
+ * by construction rather than by comment.
+ *
+ * Chunks are never freed. They are process-lifetime for the same reason the
+ * interned source-file table is: an id stamped during parsing must resolve at
+ * codegen time, long after the parse unit that produced it is gone, and a
+ * diagnostic emitted at the very end of a compile must still be able to name
+ * the line it is about.
+ */
+
+#include <eshkol/frontend/node_identity.h>
+
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+
+namespace {
+
+/** Spans per chunk. 4096 * 4096 == 2^24 == ESHKOL_NODE_ID_MAX_INDEX + 1. */
+constexpr uint32_t kChunkSpans = 4096u;
+/** Chunk-pointer slots. */
+constexpr uint32_t kMaxChunks = 4096u;
+
+static_assert((uint64_t)kChunkSpans * (uint64_t)kMaxChunks ==
+                  (uint64_t)ESHKOL_NODE_ID_MAX_INDEX + 1u,
+              "chunked span table must cover exactly the tagged NodeId index space");
+
+std::atomic<eshkol_source_span_t*> g_chunks[kMaxChunks];
+
+/** Number of spans published. Read with acquire, written with release. */
+std::atomic<uint32_t> g_published{0};
+
+/** Number of spans handed out (may briefly exceed g_published mid-append). */
+uint32_t g_allocated = 0;
+
+std::mutex g_alloc_mutex;
+
+/* Coverage counters. Relaxed: these are a measurement, not a synchronizer,
+ * and the gate reads them after the compile has finished. */
+std::atomic<uint64_t> g_queried{0};
+std::atomic<uint64_t> g_resolved{0};
+std::atomic<uint64_t> g_with_location{0};
+std::atomic<uint64_t> g_with_extent{0};
+
+std::once_flag g_atexit_once;
+
+/**
+ * Arrange for the coverage line to be printed on the way out, whatever exit
+ * path the process takes.
+ *
+ * Registered from the substrate rather than from a driver on purpose: every
+ * binary that parses Eshkol (eshkol-run, the REPL, the server, a test rig)
+ * is a measurement site, and a driver-side hook would have to be repeated in
+ * each of them and would be silently missing from the next one.
+ */
+void ensure_report_at_exit();
+
+bool env_flag_enabled(const char* name) {
+    const char* raw = std::getenv(name);
+    return raw && raw[0] != '\0' && std::strcmp(raw, "0") != 0 &&
+           std::strcmp(raw, "false") != 0 && std::strcmp(raw, "FALSE") != 0;
+}
+
+/** Decode a candidate NodeId to a 0-based slot, or return false. */
+inline bool decode(eshkol_node_id_t id, uint32_t* slot_out) {
+    if (id == ESHKOL_NODE_ID_NONE) return false;
+    if ((id >> 24) != ESHKOL_NODE_ID_TAG) return false;  /* garbage word */
+    const uint32_t index = id & ESHKOL_NODE_ID_MAX_INDEX;
+    if (index == 0) return false;                        /* index is 1-based */
+    if (index > g_published.load(std::memory_order_acquire)) return false;
+    *slot_out = index - 1u;
+    return true;
+}
+
+/** Address of a published slot. Caller must have gone through decode(). */
+inline eshkol_source_span_t* slot_ptr(uint32_t slot) {
+    eshkol_source_span_t* chunk =
+        g_chunks[slot / kChunkSpans].load(std::memory_order_acquire);
+    return chunk ? &chunk[slot % kChunkSpans] : nullptr;
+}
+
+void ensure_report_at_exit() {
+    if (!eshkol_node_identity_stats_enabled()) return;
+    std::call_once(g_atexit_once, [] { std::atexit(eshkol_node_identity_report); });
+}
+
+}  // namespace
+
+extern "C" eshkol_node_id_t eshkol_node_id_new(uint32_t file_id,
+                                               uint32_t line,
+                                               uint32_t column) {
+    ensure_report_at_exit();
+    std::lock_guard<std::mutex> lock(g_alloc_mutex);
+
+    if (g_allocated >= ESHKOL_NODE_ID_MAX_INDEX) {
+        /* Id space exhausted. Returning NONE degrades to "unknown location",
+         * which is what the frontend already does for unstamped nodes — never
+         * to a wrong location, and never to a crash. */
+        return ESHKOL_NODE_ID_NONE;
+    }
+
+    const uint32_t slot = g_allocated;
+    const uint32_t chunk_index = slot / kChunkSpans;
+    eshkol_source_span_t* chunk = g_chunks[chunk_index].load(std::memory_order_relaxed);
+    if (chunk == nullptr) {
+        chunk = new (std::nothrow) eshkol_source_span_t[kChunkSpans];
+        if (chunk == nullptr) return ESHKOL_NODE_ID_NONE;
+        std::memset(chunk, 0, sizeof(eshkol_source_span_t) * kChunkSpans);
+        g_chunks[chunk_index].store(chunk, std::memory_order_release);
+    }
+
+    eshkol_source_span_t& span = chunk[slot % kChunkSpans];
+    span.file_id = file_id;
+    span.start_line = line;
+    span.start_column = column;
+    span.end_line = line;
+    span.end_column = column;
+    span.has_extent = false;
+
+    g_allocated = slot + 1u;
+    /* Publish last: a reader that can see this index sees a complete span. */
+    g_published.store(g_allocated, std::memory_order_release);
+
+    return (eshkol_node_id_t)((ESHKOL_NODE_ID_TAG << 24) | (slot + 1u));
+}
+
+extern "C" void eshkol_node_span_set_extent(eshkol_node_id_t id,
+                                            uint32_t end_line,
+                                            uint32_t end_column) {
+    uint32_t slot;
+    if (!decode(id, &slot)) return;
+    eshkol_source_span_t* span = slot_ptr(slot);
+    if (!span) return;
+    if (end_line == 0) return;
+    /* Monotone: never move an extent backwards past the start. */
+    if (end_line < span->start_line) return;
+    if (end_line == span->start_line && end_column < span->start_column) return;
+    span->end_line = end_line;
+    span->end_column = end_column;
+    span->has_extent = true;
+}
+
+extern "C" bool eshkol_node_span_lookup(eshkol_node_id_t id,
+                                        eshkol_source_span_t* out) {
+    uint32_t slot;
+    if (!decode(id, &slot)) return false;
+    const eshkol_source_span_t* span = slot_ptr(slot);
+    if (!span) return false;
+    if (out) *out = *span;
+    return true;
+}
+
+extern "C" uint64_t eshkol_node_id_count(void) {
+    return (uint64_t)g_published.load(std::memory_order_acquire);
+}
+
+extern "C" bool eshkol_node_identity_stats_enabled(void) {
+    /* Resolved once: the gate sets the variable before exec, and a compile
+     * must not change its measurement discipline halfway through. */
+    static const bool enabled = env_flag_enabled("ESHKOL_NODE_IDENTITY_STATS");
+    return enabled;
+}
+
+extern "C" void eshkol_node_identity_record_lookup(bool resolved,
+                                                   bool has_location,
+                                                   bool has_extent) {
+    ensure_report_at_exit();
+    g_queried.fetch_add(1, std::memory_order_relaxed);
+    if (resolved) g_resolved.fetch_add(1, std::memory_order_relaxed);
+    if (has_location) g_with_location.fetch_add(1, std::memory_order_relaxed);
+    if (has_extent) g_with_extent.fetch_add(1, std::memory_order_relaxed);
+}
+
+extern "C" void eshkol_node_identity_stats(uint64_t* queried,
+                                           uint64_t* resolved,
+                                           uint64_t* with_location,
+                                           uint64_t* with_extent,
+                                           uint64_t* allocated) {
+    if (queried) *queried = g_queried.load(std::memory_order_relaxed);
+    if (resolved) *resolved = g_resolved.load(std::memory_order_relaxed);
+    if (with_location) *with_location = g_with_location.load(std::memory_order_relaxed);
+    if (with_extent) *with_extent = g_with_extent.load(std::memory_order_relaxed);
+    if (allocated) *allocated = eshkol_node_id_count();
+}
+
+extern "C" void eshkol_node_identity_reset_stats(void) {
+    g_queried.store(0, std::memory_order_relaxed);
+    g_resolved.store(0, std::memory_order_relaxed);
+    g_with_location.store(0, std::memory_order_relaxed);
+    g_with_extent.store(0, std::memory_order_relaxed);
+}
+
+extern "C" void eshkol_node_identity_report(void) {
+    if (!eshkol_node_identity_stats_enabled()) return;
+    uint64_t queried = 0, resolved = 0, located = 0, extent = 0, allocated = 0;
+    eshkol_node_identity_stats(&queried, &resolved, &located, &extent, &allocated);
+    std::fprintf(stderr,
+                 "eshkol-node-identity: allocated=%llu queried=%llu resolved=%llu "
+                 "located=%llu extent=%llu\n",
+                 (unsigned long long)allocated, (unsigned long long)queried,
+                 (unsigned long long)resolved, (unsigned long long)located,
+                 (unsigned long long)extent);
+    std::fflush(stderr);
+}

--- a/lib/frontend/parser.cpp
+++ b/lib/frontend/parser.cpp
@@ -6,6 +6,7 @@
  */
 #include <eshkol/eshkol.h>
 #include <eshkol/core/logic.h>
+#include <eshkol/frontend/node_identity.h>
 #include <eshkol/core/runtime.h>
 #include <eshkol/core/symbol_syntax.h>
 #include <eshkol/logger.h>
@@ -43,6 +44,31 @@ static thread_local const char* g_parse_source = NULL;
 static thread_local uint32_t g_stream_line = 1;
 static thread_local uint32_t g_stream_column = 1;
 static thread_local bool g_parse_had_error = false;
+
+/**
+ * @brief Give a node its source location AND its substrate identity.
+ *
+ * ADR-0000 Stage 1 (phase A). Every site in this file that used to write
+ * `node.line` / `node.column` writes them through here instead, so a node's
+ * location and its `NodeId` are established in the same statement and cannot
+ * drift apart. The `line`/`column` fields keep their exact previous values —
+ * this is strictly additive, and every consumer that has not moved onto the
+ * substrate yet reads what it always read.
+ *
+ * The file comes from the ambient parse context, which is correct at the
+ * moment of the call: `eshkol_set_parse_source_context` rebinds it around
+ * every unit the driver, the REPL and `(load)` open, so a node stamped while
+ * a required module is being parsed records THAT module. `eshkol_ast_t`'s own
+ * `source_file_id` is stamped only on top-level forms (inner nodes inherit
+ * the ambient file at codegen time); the substrate stamps it on every node it
+ * touches, which is what lets a consumer resolve a location without depending
+ * on where in a traversal it happens to be.
+ */
+static inline void stamp_node(eshkol_ast_t& node, uint32_t line, uint32_t column) {
+    node.line = line;
+    node.column = column;
+    node.node_id = eshkol_node_id_new(g_parse_filename_id, line, column);
+}
 
 /* Emit error with file:line:col + caret underline.
  * Falls back to plain eshkol_error if source text unavailable. */
@@ -1101,8 +1127,7 @@ static eshkol_ast_t make_parser_string_ast(const std::string& value,
                                            uint32_t line,
                                            uint32_t column) {
     eshkol_ast_t ast = {};
-    ast.line = line;
-    ast.column = column;
+    stamp_node(ast, line, column);
     size_t len = value.length();
     char* ptr = new char[len + 1];
     if (ptr) memcpy(ptr, value.c_str(), len + 1);
@@ -1121,8 +1146,7 @@ static eshkol_ast_t make_parser_var_ast(const char* name,
                                         uint32_t column) {
     eshkol_ast_t ast = {};
     ast.type = ESHKOL_VAR;
-    ast.line = line;
-    ast.column = column;
+    stamp_node(ast, line, column);
     size_t len = strlen(name);
     ast.variable.id = new char[len + 1];
     if (ast.variable.id) memcpy(ast.variable.id, name, len + 1);
@@ -1146,8 +1170,7 @@ static eshkol_ast_t make_parser_call_ast(const char* name,
                                          uint32_t column) {
     eshkol_ast_t ast = {};
     ast.type = ESHKOL_OP;
-    ast.line = line;
-    ast.column = column;
+    stamp_node(ast, line, column);
     ast.operation.op = ESHKOL_CALL_OP;
     ast.operation.call_op.func = new eshkol_ast_t;
     *ast.operation.call_op.func = make_parser_var_ast(name, line, column);
@@ -1225,8 +1248,7 @@ static eshkol_ast_t make_parser_quoted_symbol_ast(const std::string& name,
 
     eshkol_ast_t ast = {};
     ast.type = ESHKOL_OP;
-    ast.line = line;
-    ast.column = column;
+    stamp_node(ast, line, column);
     ast.operation.op = ESHKOL_QUOTE_OP;
     ast.operation.call_op.func = nullptr;
     ast.operation.call_op.num_vars = 1;
@@ -1270,8 +1292,7 @@ static eshkol_ast_t make_parser_binding_ast(const char* name,
                                             uint32_t column) {
     eshkol_ast_t binding = {};
     binding.type = ESHKOL_CONS;
-    binding.line = line;
-    binding.column = column;
+    stamp_node(binding, line, column);
     binding.cons_cell.car = new eshkol_ast_t;
     *binding.cons_cell.car = make_parser_var_ast(name, line, column);
     binding.cons_cell.cdr = new eshkol_ast_t;
@@ -1314,8 +1335,7 @@ static eshkol_ast_t wrap_keyword_formal_body(
 
     eshkol_ast_t ast = {};
     ast.type = ESHKOL_OP;
-    ast.line = line;
-    ast.column = column;
+    stamp_node(ast, line, column);
     ast.operation.op = ESHKOL_LET_OP;
     ast.operation.let_op.num_bindings = formals.size();
     ast.operation.let_op.bindings = new eshkol_ast_t[formals.size()];
@@ -1345,8 +1365,7 @@ static eshkol_ast_t wrap_keyword_formal_body(
 
         eshkol_ast_t sequence = {};
         sequence.type = ESHKOL_OP;
-        sequence.line = line;
-        sequence.column = column;
+        stamp_node(sequence, line, column);
         sequence.operation.op = ESHKOL_SEQUENCE_OP;
         sequence.operation.sequence_op.num_expressions = 2;
         sequence.operation.sequence_op.expressions = new eshkol_ast_t[2];
@@ -1507,8 +1526,7 @@ static eshkol_ast_t parse_interpolated_string_token(const Token& token) {
 static eshkol_ast_t parse_atom(const Token& token) {
     eshkol_ast_t ast = {};  // Zero-initialize all fields
     ast.type = ESHKOL_INVALID;
-    ast.line = token.line;
-    ast.column = token.column;
+    stamp_node(ast, token.line, token.column);
 
     switch (token.type) {
         case TOKEN_STRING: {
@@ -1554,8 +1572,7 @@ static eshkol_ast_t parse_atom(const Token& token) {
                         if (s[j] < '0' || s[j] > '9') return false;
                     }
                     memset(node, 0, sizeof(*node));
-                    node->line = token.line;
-                    node->column = token.column;
+                    stamp_node(*node, token.line, token.column);
                     *is_zero = false;
                     try {
                         int64_t v = std::stoll(s);
@@ -2697,8 +2714,7 @@ static eshkol_ast_t parse_quasiquoted_data_with_token(SchemeTokenizer& tokenizer
         eshkol_ast_t inner = parse_expression(tokenizer);
         eshkol_ast_t ast = {};
         ast.type = ESHKOL_OP;
-        ast.line = token.line;
-        ast.column = token.column;
+        stamp_node(ast, token.line, token.column);
         ast.operation.op = ESHKOL_UNQUOTE_OP;
         ast.operation.call_op.func = nullptr;
         ast.operation.call_op.num_vars = 1;
@@ -2713,8 +2729,7 @@ static eshkol_ast_t parse_quasiquoted_data_with_token(SchemeTokenizer& tokenizer
         eshkol_ast_t inner = parse_expression(tokenizer);
         eshkol_ast_t ast = {};
         ast.type = ESHKOL_OP;
-        ast.line = token.line;
-        ast.column = token.column;
+        stamp_node(ast, token.line, token.column);
         ast.operation.op = ESHKOL_UNQUOTE_SPLICING_OP;
         ast.operation.call_op.func = nullptr;
         ast.operation.call_op.num_vars = 1;
@@ -2783,8 +2798,7 @@ static eshkol_ast_t parse_quasiquoted_list_internal(SchemeTokenizer& tokenizer) 
              head.value == "quasiquote" || head.value == "quote")) {
             eshkol_ast_t ast = {};
             ast.type = ESHKOL_OP;
-            ast.line = head.line;
-            ast.column = head.column;
+            stamp_node(ast, head.line, head.column);
             ast.operation.call_op.func = nullptr;
             ast.operation.call_op.num_vars = 1;
             ast.operation.call_op.variables = new eshkol_ast_t[1];
@@ -3314,8 +3328,7 @@ static eshkol_ast_t transformInternalDefinesToLetrec(const std::vector<eshkol_as
             // at the root supertype rather than narrowing it to Null.
             val_ast = eshkol_ast_t{};
             eshkol_ast_make_null(&val_ast);
-            val_ast.line = def.line;
-            val_ast.column = def.column;
+            stamp_node(val_ast, def.line, def.column);
         } else {
             // Simple variable define - use value directly
             val_ast = *def.operation.define_op.value;
@@ -3854,8 +3867,7 @@ static eshkol_ast_t make_sequence_or_null_ast(const std::vector<eshkol_ast_t>& e
                                               uint32_t column) {
     if (exprs.empty()) {
         eshkol_ast_t ast = {};
-        ast.line = line;
-        ast.column = column;
+        stamp_node(ast, line, column);
         eshkol_ast_make_null(&ast);
         return ast;
     }
@@ -3865,8 +3877,7 @@ static eshkol_ast_t make_sequence_or_null_ast(const std::vector<eshkol_ast_t>& e
 
     eshkol_ast_t ast = {};
     ast.type = ESHKOL_OP;
-    ast.line = line;
-    ast.column = column;
+    stamp_node(ast, line, column);
     ast.operation.op = ESHKOL_SEQUENCE_OP;
     ast.operation.sequence_op.num_expressions = exprs.size();
     ast.operation.sequence_op.expressions = new eshkol_ast_t[exprs.size()];
@@ -3932,8 +3943,7 @@ static eshkol_ast_t make_require_ast(const std::vector<std::string>& modules,
                                      uint32_t column) {
     eshkol_ast_t ast = {};
     ast.type = ESHKOL_OP;
-    ast.line = line;
-    ast.column = column;
+    stamp_node(ast, line, column);
     ast.operation.op = ESHKOL_REQUIRE_OP;
     ast.operation.require_op.num_modules = modules.size();
     ast.operation.require_op.module_names = new char*[modules.size()];
@@ -4000,8 +4010,7 @@ static eshkol_ast_t make_define_alias_ast(const std::string& alias,
                                            uint32_t column) {
     eshkol_ast_t ast = {};
     ast.type = ESHKOL_OP;
-    ast.line = line;
-    ast.column = column;
+    stamp_node(ast, line, column);
     ast.operation.op = ESHKOL_DEFINE_OP;
     ast.operation.define_op.name = parser_copy_cstr(alias);
     ast.operation.define_op.value = new eshkol_ast_t;
@@ -4032,8 +4041,7 @@ static eshkol_ast_t make_parser_define_value_ast(const std::string& name,
                                                   uint32_t column) {
     eshkol_ast_t ast = {};
     ast.type = ESHKOL_OP;
-    ast.line = line;
-    ast.column = column;
+    stamp_node(ast, line, column);
     ast.operation.op = ESHKOL_DEFINE_OP;
     ast.operation.define_op.name = copy_parser_string(name);
     ast.operation.define_op.value = new eshkol_ast_t(value);
@@ -4055,8 +4063,7 @@ static eshkol_ast_t make_parser_set_ast(const std::string& name,
                                         uint32_t column) {
     eshkol_ast_t ast = {};
     ast.type = ESHKOL_OP;
-    ast.line = line;
-    ast.column = column;
+    stamp_node(ast, line, column);
     ast.operation.op = ESHKOL_SET_OP;
     ast.operation.set_op.name = copy_parser_string(name);
     ast.operation.set_op.value = new eshkol_ast_t(value);
@@ -4071,8 +4078,7 @@ static eshkol_ast_t make_parser_lambda_ast(const std::vector<std::string>& param
                                            uint32_t column) {
     eshkol_ast_t ast = {};
     ast.type = ESHKOL_OP;
-    ast.line = line;
-    ast.column = column;
+    stamp_node(ast, line, column);
     ast.operation.op = ESHKOL_LAMBDA_OP;
     ast.operation.lambda_op.num_params = params.size();
     ast.operation.lambda_op.parameters = params.empty()
@@ -4103,8 +4109,7 @@ static eshkol_ast_t make_provide_ast(const std::vector<std::string>& exports,
                                      uint32_t column) {
     eshkol_ast_t ast = {};
     ast.type = ESHKOL_OP;
-    ast.line = line;
-    ast.column = column;
+    stamp_node(ast, line, column);
     ast.operation.op = ESHKOL_PROVIDE_OP;
     ast.operation.provide_op.num_exports = exports.size();
     ast.operation.provide_op.export_names = new char*[exports.size()];
@@ -4633,8 +4638,7 @@ static eshkol_ast_t build_let_match_ast(const std::vector<LetMatchBinding>& bind
 
     eshkol_ast_t ast = {};
     ast.type = ESHKOL_OP;
-    ast.line = line;
-    ast.column = column;
+    stamp_node(ast, line, column);
     ast.operation.op = ESHKOL_MATCH_OP;
     ast.operation.match_op.expr = new eshkol_ast_t;
     *ast.operation.match_op.expr = bindings[index].expr;
@@ -4787,8 +4791,7 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
 
     Token token = tokenizer.nextToken();
     // Set source location from first token in the list
-    ast.line = token.line;
-    ast.column = token.column;
+    stamp_node(ast, token.line, token.column);
     
     // Empty list (ESH-0217).
     //
@@ -5064,8 +5067,7 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
 
             std::vector<eshkol_ast_t> lowered;
             eshkol_ast_t false_ast = {};
-            false_ast.line = form_line;
-            false_ast.column = form_column;
+            stamp_node(false_ast, form_line, form_column);
             eshkol_ast_make_bool(&false_ast, false);
             for (const std::string& name : names) {
                 lowered.push_back(make_parser_define_value_ast(
@@ -5109,8 +5111,7 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
                 form_line, form_column);
             eshkol_ast_t invoke = {};
             invoke.type = ESHKOL_OP;
-            invoke.line = form_line;
-            invoke.column = form_column;
+            stamp_node(invoke, form_line, form_column);
             invoke.operation.op = ESHKOL_CALL_WITH_VALUES_OP;
             invoke.operation.call_with_values_op.producer =
                 new eshkol_ast_t(producer_lambda);
@@ -8352,8 +8353,7 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
             size_t n = params.size();
 
             if (n == 0) {
-                body.line = parameterize_line;
-                body.column = parameterize_column;
+                stamp_node(body, parameterize_line, parameterize_column);
                 return body;
             }
 
@@ -8489,8 +8489,7 @@ static eshkol_ast_t parse_list(SchemeTokenizer& tokenizer) {
             *wind.operation.dynamic_wind_op.after = pmMakeLambda(pmMakeSequence(pop_expressions));
 
             ast = pmMakeLet(evaluated_bindings, pmMakeLet(converted_bindings, wind));
-            ast.line = parameterize_line;
-            ast.column = parameterize_column;
+            stamp_node(ast, parameterize_line, parameterize_column);
             return ast;
         }
 
@@ -10857,8 +10856,7 @@ static eshkol_ast_t parse_expression(SchemeTokenizer& tokenizer) {
                                   static_cast<uint32_t>(ESHKOL_TENSOR_OP),
                                   "vector");
             eshkol_ast_t ast = parse_vector_body(tokenizer);
-            ast.line = token.line;
-            ast.column = token.column;
+            stamp_node(ast, token.line, token.column);
             return ast;
         }
 
@@ -10875,8 +10873,7 @@ static eshkol_ast_t parse_expression(SchemeTokenizer& tokenizer) {
             // Create a quote operation
             eshkol_ast_t ast = {};
             ast.type = ESHKOL_OP;
-            ast.line = token.line;
-            ast.column = token.column;
+            stamp_node(ast, token.line, token.column);
             ast.operation.op = ESHKOL_QUOTE_OP;
             ast.operation.call_op.func = nullptr;
             ast.operation.call_op.num_vars = 1;
@@ -10907,8 +10904,7 @@ static eshkol_ast_t parse_expression(SchemeTokenizer& tokenizer) {
             // Create a quasiquote operation
             eshkol_ast_t ast = {};
             ast.type = ESHKOL_OP;
-            ast.line = token.line;
-            ast.column = token.column;
+            stamp_node(ast, token.line, token.column);
             ast.operation.op = ESHKOL_QUASIQUOTE_OP;
             ast.operation.call_op.func = nullptr;
             ast.operation.call_op.num_vars = 1;
@@ -10930,8 +10926,7 @@ static eshkol_ast_t parse_expression(SchemeTokenizer& tokenizer) {
             // Create an unquote operation
             eshkol_ast_t ast = {};
             ast.type = ESHKOL_OP;
-            ast.line = token.line;
-            ast.column = token.column;
+            stamp_node(ast, token.line, token.column);
             ast.operation.op = ESHKOL_UNQUOTE_OP;
             ast.operation.call_op.func = nullptr;
             ast.operation.call_op.num_vars = 1;
@@ -10954,8 +10949,7 @@ static eshkol_ast_t parse_expression(SchemeTokenizer& tokenizer) {
             // Create an unquote-splicing operation
             eshkol_ast_t ast = {};
             ast.type = ESHKOL_OP;
-            ast.line = token.line;
-            ast.column = token.column;
+            stamp_node(ast, token.line, token.column);
             ast.operation.op = ESHKOL_UNQUOTE_SPLICING_OP;
             ast.operation.call_op.func = nullptr;
             ast.operation.call_op.num_vars = 1;
@@ -11189,6 +11183,33 @@ eshkol_ast_t eshkol_parse_next_ast_from_stream(std::istream &in_stream)
              * that assign `line`) gives complete provenance with no chance of a
              * missed site. Inner nodes stay 0 and inherit this form's file. */
             result.source_file_id = g_parse_filename_id;
+
+            /* Close the form's span. This is the one place in the frontend
+             * that knows where a construct ENDS: the tokenizer reports where
+             * each token begins, and only the stream reader, which found this
+             * form's closing delimiter to cut `form_text` in the first place,
+             * has both halves. Recording it here turns the top-level form's
+             * entry from a point into a range, which is what a caret that
+             * underlines a whole form needs — and is measured separately from
+             * "has a location" by the Stage-1 gate, so an extent is never
+             * inferred where none was taken. Inner nodes are points until the
+             * lossless token stream of ADR-0008 M0 gives every node one. */
+            {
+                uint32_t end_line = form_line;
+                uint32_t end_column = form_column;
+                /* Walk PAST each character in [skip, end) so the counters land
+                 * on the position of `input[end]` — the form's last character,
+                 * which is what the span's end names. */
+                for (size_t i = skip; i < end && i < input.size(); ++i) {
+                    if (input[i] == '\n') {
+                        end_line++;
+                        end_column = 1;
+                    } else {
+                        end_column++;
+                    }
+                }
+                eshkol_node_span_set_extent(result.node_id, end_line, end_column);
+            }
 
             if (result.type == ESHKOL_OP && parser_language_coverage_enabled()) {
                 eshkol_language_coverage_accept(

--- a/scripts/run_node_identity_gate.py
+++ b/scripts/run_node_identity_gate.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""ADR-0000 Stage 1 gate: measure the frontend node-identity substrate.
+
+ADR-0000 makes each of its fourteen stages carry a *falsifiable* gate, and
+§7 risk 5 predicts the program fails by scope compression if a stage is
+declared attained on a description rather than a number. Stage 1's identity
+half is the `NodeId -> {SourceSpan, BindingId, TypedExprInfo}` substrate;
+this gate measures the first column of it.
+
+What it measures
+----------------
+`ESHKOL_NODE_IDENTITY_STATS=1` makes every Eshkol frontend process print one
+line to stderr as it exits:
+
+    eshkol-node-identity: allocated=N queried=N resolved=N located=N extent=N
+
+  allocated  NodeIds the parser handed out.
+  queried    Nodes a substrate CONSUMER asked about. The consumer today is
+             the LLVM codegen dispatcher, which resolves the location of
+             every node it visits through the substrate.
+  resolved   Of those, the ones whose NodeId named a real span.
+  located    Of those resolved, the ones whose span names a real line.
+  extent     Of those resolved, the ones whose span end is measured rather
+             than mirroring the start.
+
+The gated number is `resolved / queried`: the fraction of the AST that the
+substrate actually covers on a real compile. It is deliberately measured at
+a consumer and not at the parser, because a parser-side count can only say
+how many ids were minted, not whether the answer arrived where it was
+needed. `located` and `extent` are reported alongside it so "has an
+identity", "has a location" and "has an extent" stay three separate numbers
+and none of them can be mistaken for another.
+
+Ratchet
+-------
+The floor lives in tests/coverage/NODE_IDENTITY_BASELINE.json and may never
+fall. `--update-baseline` rewrites it; CI never passes that flag.
+
+Usage:
+  scripts/run_node_identity_gate.py [--update-baseline] [--corpus GLOB]...
+                                    [--limit N] [--json OUT]
+Exit: 0 green, 1 red, 2 misuse/environment.
+"""
+
+import argparse
+import glob
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASELINE = os.path.join(REPO, "tests", "coverage", "NODE_IDENTITY_BASELINE.json")
+TRACE_DIR = os.environ.get("TRACE_DIR", os.path.join(REPO, "scripts", "icc_traces"))
+TRACE = os.path.join(TRACE_DIR, "node_identity.jsonl")
+
+BUILD = os.environ.get("BUILD_DIR", os.path.join(REPO, "build"))
+if not os.path.isabs(BUILD):
+    BUILD = os.path.join(REPO, BUILD)
+ESHKOL_RUN = os.path.join(BUILD, "eshkol-run")
+
+# A deliberately mixed corpus: plain expressions, control flow, macros,
+# modules and tensor/AD forms, so the measurement is not dominated by one
+# node shape. These are compile-only runs; program behaviour is irrelevant
+# here and is gated everywhere else.
+DEFAULT_CORPUS = [
+    "tests/parser/*.esk",
+    "tests/control_flow/*.esk",
+    "tests/macros/*.esk",
+    "tests/lists/*.esk",
+    "tests/v1_2_edge_cases/*.esk",
+]
+
+REPORT_RE = re.compile(
+    r"^eshkol-node-identity: allocated=(\d+) queried=(\d+) resolved=(\d+) "
+    r"located=(\d+) extent=(\d+)\s*$")
+
+
+def die(msg):
+    sys.stderr.write("run_node_identity_gate: %s\n" % msg)
+    sys.exit(2)
+
+
+def parse_report(stderr_text):
+    """Return the LAST substrate report line in `stderr_text`, or None.
+
+    The last one, not the first: a driver that forks a cache-build child
+    emits the child's line first, and the parent's totals are the ones that
+    describe the compile the caller asked for.
+    """
+    found = None
+    for line in stderr_text.splitlines():
+        match = REPORT_RE.match(line.strip())
+        if match:
+            found = tuple(int(g) for g in match.groups())
+    return found
+
+
+def measure(path, workdir):
+    """Compile one source with substrate stats on; return its counters."""
+    env = dict(os.environ)
+    env["ESHKOL_NODE_IDENTITY_STATS"] = "1"
+    # Compile only. The gate is about the frontend; running the program
+    # would add its runtime's exit behaviour to what we are measuring.
+    out = os.path.join(workdir, "out.o")
+    try:
+        proc = subprocess.run(
+            [ESHKOL_RUN, "-c", path, "-o", out],
+            # Generous on purpose. A source dropped for taking too long would
+            # change the denominator and make the ratchet jitter in its last
+            # digit, which is worse than a slow gate: a floor that moves on its
+            # own cannot tell a regression from a loaded machine.
+            env=env, capture_output=True, text=True, timeout=900)
+    except subprocess.TimeoutExpired:
+        return None
+    return parse_report(proc.stderr or "")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--update-baseline", action="store_true")
+    ap.add_argument("--corpus", action="append", default=None)
+    ap.add_argument("--limit", type=int, default=60)
+    ap.add_argument("--json", default=None)
+    args = ap.parse_args()
+
+    if not os.path.exists(ESHKOL_RUN):
+        die("eshkol-run not found at %s (build first, or set BUILD_DIR)"
+            % ESHKOL_RUN)
+
+    patterns = args.corpus or DEFAULT_CORPUS
+    sources = []
+    for pattern in patterns:
+        sources.extend(sorted(glob.glob(os.path.join(REPO, pattern))))
+    sources = sources[:args.limit]
+    if not sources:
+        die("corpus matched no sources: %s" % ", ".join(patterns))
+
+    allocated = queried = resolved = located = extent = 0
+    measured = 0
+    silent = []
+
+    # Scratch objects go under the build tree, not the system temp dir: the
+    # build tree is where the rest of this gate's inputs already live, and it
+    # survives whatever the machine does to /tmp between runs.
+    scratch_root = os.path.join(BUILD, "node-identity-gate")
+    os.makedirs(scratch_root, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="run-", dir=scratch_root) as workdir:
+        for path in sources:
+            counters = measure(path, workdir)
+            if counters is None:
+                silent.append(os.path.relpath(path, REPO))
+                continue
+            measured += 1
+            allocated += counters[0]
+            queried += counters[1]
+            resolved += counters[2]
+            located += counters[3]
+            extent += counters[4]
+
+    fraction = (resolved / queried) if queried else 0.0
+    located_fraction = (located / queried) if queried else 0.0
+
+    print("ADR-0000 Stage 1 — node-identity substrate coverage")
+    print("  sources compiled with stats on  : %d / %d" % (measured, len(sources)))
+    print("  NodeIds allocated by the parser : %d" % allocated)
+    print("  consumer lookups                : %d" % queried)
+    print("  resolved to a span              : %d  (%.2f%%)  [the gated number]"
+          % (resolved, 100.0 * fraction))
+    print("  span names a real line          : %d  (%.2f%%)"
+          % (located, 100.0 * located_fraction))
+    print("  span end is measured (extent)   : %d" % extent)
+
+    baseline = {"span_coverage_floor": 0.0}
+    if os.path.exists(BASELINE):
+        try:
+            with open(BASELINE, encoding="utf-8") as handle:
+                baseline = json.load(handle)
+        except (OSError, ValueError) as exc:
+            die("baseline %s is unreadable: %s" % (BASELINE, exc))
+    floor = float(baseline.get("span_coverage_floor", 0.0))
+
+    if args.update_baseline:
+        os.makedirs(os.path.dirname(BASELINE), exist_ok=True)
+        with open(BASELINE, "w", encoding="utf-8") as handle:
+            json.dump({
+                "_comment": (
+                    "Ratchet for scripts/run_node_identity_gate.py "
+                    "(ADR-0000 Stage 1, node-identity substrate). "
+                    "span_coverage_floor is resolved/queried at the LLVM "
+                    "codegen dispatcher and may never fall."),
+                # Truncated, never rounded. `round()` can land ABOVE the value
+                # it came from (0.994858 -> 0.9949), and a floor recorded above
+                # the measurement it was taken from fails the very run that
+                # wrote it — a ratchet that no unchanged tree can satisfy.
+                "span_coverage_floor": math.floor(fraction * 10000) / 10000.0,
+            }, handle, indent=2)
+            handle.write("\n")
+        print("  baseline written: floor %.4f" % fraction)
+        return 0
+
+    # A substrate that minted no ids, or one no consumer ever asked, is not
+    # a substrate. Both are separate failures from "coverage fell".
+    substrate_present = allocated > 0 and queried > 0 and resolved > 0
+    coverage_ok = fraction >= floor
+    passed = substrate_present and coverage_ok and not silent
+
+    timestamp = time.time()
+    events = [
+        {
+            "kind": "runtime_event",
+            "event": "node_identity_substrate_present",
+            "name": "node_identity_substrate_present",
+            "value": "PASS" if substrate_present else "FAIL",
+            "status": "PASSED" if substrate_present else "FAILED",
+            "allocated": allocated,
+            "queried": queried,
+            "resolved": resolved,
+            "sources_measured": measured,
+            "sources_silent": silent[:20],
+            "timestamp": timestamp,
+            "confidence": 1.0,
+        },
+        {
+            "kind": "runtime_event",
+            "event": "node_identity_span_coverage",
+            "name": "node_identity_span_coverage",
+            "value": "PASS" if (coverage_ok and substrate_present) else "FAIL",
+            "status": "PASSED" if (coverage_ok and substrate_present) else "FAILED",
+            "covered_fraction": round(fraction, 4),
+            "located_fraction": round(located_fraction, 4),
+            "resolved": resolved,
+            "queried": queried,
+            "located": located,
+            "extent": extent,
+            "threshold": floor,
+            "timestamp": timestamp,
+            "confidence": 1.0,
+        },
+    ]
+
+    os.makedirs(TRACE_DIR, exist_ok=True)
+    with open(TRACE, "w", encoding="utf-8") as handle:
+        for event in events:
+            json.dump(event, handle, sort_keys=True)
+            handle.write("\n")
+
+    if args.json:
+        with open(args.json, "w", encoding="utf-8") as handle:
+            json.dump({
+                "allocated": allocated,
+                "queried": queried,
+                "resolved": resolved,
+                "located": located,
+                "extent": extent,
+                "span_coverage": fraction,
+                "floor": floor,
+                "silent_sources": silent,
+            }, handle, indent=2)
+            handle.write("\n")
+
+    rc = 0
+    if not substrate_present:
+        rc = 1
+        print()
+        print("FAIL: no substrate evidence. allocated=%d queried=%d resolved=%d"
+              % (allocated, queried, resolved))
+        print("      A NodeId nobody mints, or nobody asks for, is not an "
+              "identity substrate.")
+    if silent:
+        rc = 1
+        print()
+        print("FAIL: %d source(s) compiled without emitting a substrate report."
+              % len(silent))
+        print("      Either the frontend did not run, or the report hook is "
+              "not on that path.")
+        for name in silent[:20]:
+            print("  %s" % name)
+    if not coverage_ok:
+        rc = 1
+        print()
+        print("FAIL: span coverage %.2f%% fell below the recorded floor %.2f%%."
+              % (100.0 * fraction, 100.0 * floor))
+        print("      Regenerate deliberately with --update-baseline only when "
+              "the drop is understood.")
+    if rc == 0:
+        print()
+        print("PASS: substrate present; span coverage %.2f%% >= floor %.2f%%."
+              % (100.0 * fraction, 100.0 * floor))
+    print("  trace: %s" % os.path.relpath(TRACE, REPO))
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/coverage/NODE_IDENTITY_BASELINE.json
+++ b/tests/coverage/NODE_IDENTITY_BASELINE.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Ratchet for scripts/run_node_identity_gate.py (ADR-0000 Stage 1, node-identity substrate). span_coverage_floor is resolved/queried at the LLVM codegen dispatcher and may never fall.",
+  "span_coverage_floor": 0.9948
+}

--- a/tests/frontend/node_identity_test.cpp
+++ b/tests/frontend/node_identity_test.cpp
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) tsotchke
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+/**
+ * @file node_identity_test.cpp
+ * @brief Contract tests for the ADR-0000 Stage 1 node-identity substrate.
+ *
+ * Two things are under test, and they are different claims:
+ *
+ *   1. The substrate itself: ids are dense and tagged, a span round-trips
+ *      unchanged, an unset or garbage id NEVER resolves to a location, and
+ *      an id survives the by-value copies the AST is moved around with.
+ *      "Never resolves" is the load-bearing one — the whole reason the id
+ *      is tagged is that `eshkol_ast_t` is built in places that do not
+ *      zero-initialize, so a wrong answer here would be a diagnostic
+ *      pointing confidently at unrelated source.
+ *
+ *   2. The parser really stamps: a form parsed through the public entry
+ *      point comes back carrying a NodeId that resolves to that form's own
+ *      line, column and file. Without this the substrate is an empty table
+ *      with a nice API.
+ */
+
+#include <eshkol/eshkol.h>
+#include <eshkol/frontend/node_identity.h>
+
+#include <cstdio>
+#include <cstring>
+#include <sstream>
+#include <string>
+
+static int g_failures = 0;
+
+static void check(bool condition, const char* what) {
+    if (!condition) {
+        std::printf("  FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+/* ---- 1. substrate contract ------------------------------------------- */
+
+static void test_none_never_resolves() {
+    eshkol_source_span_t span;
+    std::memset(&span, 0xAB, sizeof(span));
+    check(!eshkol_node_span_lookup(ESHKOL_NODE_ID_NONE, &span),
+          "ESHKOL_NODE_ID_NONE must not resolve");
+}
+
+static void test_garbage_never_resolves() {
+    /* Every word whose high byte is not the tag must be rejected outright,
+     * whatever the low bits look like. These are the shapes an
+     * uninitialised field actually takes: zero-ish, all-ones, ASCII debris,
+     * and a small integer that would be a perfectly valid index if the id
+     * were untagged. */
+    const uint32_t garbage[] = {
+        0xFFFFFFFFu, 0x00000001u, 0x0000002Au, 0xDEADBEEFu,
+        0x41414141u, 0x7F7F7F7Fu, 0x80000000u, 0xE4000001u, 0xE6000001u,
+    };
+    for (uint32_t word : garbage) {
+        eshkol_source_span_t span;
+        char label[80];
+        std::snprintf(label, sizeof(label),
+                      "garbage word 0x%08X must not resolve", word);
+        check(!eshkol_node_span_lookup((eshkol_node_id_t)word, &span), label);
+    }
+    /* A correctly tagged but not-yet-issued index must also be rejected:
+     * the tag alone is not authority, the bound is. */
+    const uint32_t beyond =
+        (uint32_t)(ESHKOL_NODE_ID_TAG << 24) | ESHKOL_NODE_ID_MAX_INDEX;
+    eshkol_source_span_t span;
+    check(!eshkol_node_span_lookup((eshkol_node_id_t)beyond, &span),
+          "a tagged id past the issued range must not resolve");
+}
+
+static void test_roundtrip_and_density() {
+    const uint64_t before = eshkol_node_id_count();
+
+    eshkol_node_id_t a = eshkol_node_id_new(7, 12, 34);
+    eshkol_node_id_t b = eshkol_node_id_new(7, 12, 40);
+
+    check(a != ESHKOL_NODE_ID_NONE && b != ESHKOL_NODE_ID_NONE,
+          "fresh ids must not be NONE");
+    check((a >> 24) == ESHKOL_NODE_ID_TAG, "a fresh id carries the tag");
+    check((b & ESHKOL_NODE_ID_MAX_INDEX) == (a & ESHKOL_NODE_ID_MAX_INDEX) + 1,
+          "ids are dense: consecutive allocations get consecutive indices");
+    check(eshkol_node_id_count() == before + 2, "count tracks allocations");
+
+    eshkol_source_span_t span;
+    check(eshkol_node_span_lookup(a, &span), "a fresh id resolves");
+    check(span.file_id == 7 && span.start_line == 12 && span.start_column == 34,
+          "the span round-trips exactly what was stored");
+    check(span.end_line == 12 && span.end_column == 34 && !span.has_extent,
+          "a point span mirrors its start and reports no extent");
+}
+
+static void test_extent_is_monotone() {
+    eshkol_node_id_t id = eshkol_node_id_new(3, 20, 5);
+    eshkol_source_span_t span;
+
+    eshkol_node_span_set_extent(id, 24, 9);
+    check(eshkol_node_span_lookup(id, &span), "extent target resolves");
+    check(span.has_extent && span.end_line == 24 && span.end_column == 9,
+          "setting an extent records it and flags it as measured");
+    check(span.start_line == 20 && span.start_column == 5,
+          "setting an extent never moves the start");
+
+    /* An end before the start is not a span; it is a bug upstream, and the
+     * substrate must refuse it rather than hand a consumer a backwards
+     * range to render a caret from. */
+    eshkol_node_span_set_extent(id, 2, 1);
+    check(eshkol_node_span_lookup(id, &span), "target still resolves");
+    check(span.end_line == 24 && span.end_column == 9,
+          "an end before the start is refused");
+
+    eshkol_node_span_set_extent(ESHKOL_NODE_ID_NONE, 1, 1);  /* must not crash */
+}
+
+static void test_id_survives_node_copy() {
+    /* AST nodes are shuffled between arrays by value all over the frontend
+     * and codegen. Identity that did not survive a copy would be identity
+     * of a storage location, not of a node. */
+    eshkol_ast_t node = {};
+    node.type = ESHKOL_INT64;
+    node.int64_val = 41;
+    node.node_id = eshkol_node_id_new(9, 100, 3);
+
+    eshkol_ast_t assigned = node;
+    eshkol_ast_t blitted;
+    std::memcpy(&blitted, &node, sizeof(blitted));
+
+    eshkol_source_span_t direct, via_assign, via_memcpy;
+    check(eshkol_node_span_lookup(node.node_id, &direct), "origin resolves");
+    check(eshkol_node_span_lookup(assigned.node_id, &via_assign),
+          "id survives struct assignment");
+    check(eshkol_node_span_lookup(blitted.node_id, &via_memcpy),
+          "id survives a raw memcpy");
+    check(direct.start_line == via_assign.start_line &&
+              direct.start_line == via_memcpy.start_line &&
+              direct.start_column == via_memcpy.start_column,
+          "every copy resolves to the same span");
+}
+
+static void test_counters_move() {
+    eshkol_node_identity_reset_stats();
+    uint64_t queried = 0, resolved = 0, located = 0, extent = 0, allocated = 0;
+    eshkol_node_identity_stats(&queried, &resolved, &located, &extent, &allocated);
+    check(queried == 0 && resolved == 0, "reset zeroes the coverage counters");
+
+    eshkol_node_identity_record_lookup(true, true, false);
+    eshkol_node_identity_record_lookup(false, false, false);
+    eshkol_node_identity_stats(&queried, &resolved, &located, &extent, &allocated);
+    check(queried == 2, "every lookup is counted");
+    check(resolved == 1, "only resolved lookups count as resolved");
+    check(located == 1 && extent == 0, "location and extent are counted apart");
+    check(allocated >= 3, "allocation count is cumulative for the process");
+    eshkol_node_identity_reset_stats();
+}
+
+/* ---- 2. the parser really stamps ------------------------------------- */
+
+static void test_parser_stamps_forms() {
+    const char* kSource =
+        "(define (square x)\n"
+        "  (* x x))\n"
+        "\n"
+        "(display (square 7))\n";
+
+    eshkol_set_parse_source_context("node_identity_test.esk");
+    eshkol_reset_parse_line_counter();
+
+    std::istringstream in(kSource);
+
+    eshkol_ast_t first = eshkol_parse_next_ast_from_stream(in);
+    check(first.type != ESHKOL_INVALID, "first form parses");
+
+    eshkol_source_span_t span;
+    check(eshkol_node_span_lookup(first.node_id, &span),
+          "the parser stamped the first form with a resolvable NodeId");
+    if (span.start_line != 0) {
+        check(span.start_line == 1,
+              "the first form's span starts on line 1");
+        check(span.start_column == first.column && span.start_line == first.line,
+              "the span agrees with the node's own line/column fields");
+        const char* name = eshkol_source_file_name(span.file_id);
+        check(name != nullptr &&
+                  std::string(name).find("node_identity_test.esk") != std::string::npos,
+              "the span names the file the form was measured in");
+        check(span.has_extent && span.end_line >= span.start_line,
+              "a top-level form carries a measured extent, not just a point");
+    }
+
+    eshkol_ast_t second = eshkol_parse_next_ast_from_stream(in);
+    check(second.type != ESHKOL_INVALID, "second form parses");
+    eshkol_source_span_t span2;
+    check(eshkol_node_span_lookup(second.node_id, &span2),
+          "the parser stamped the second form too");
+    if (span.start_line != 0 && span2.start_line != 0) {
+        check(span2.start_line == 4,
+              "the second form's span starts on line 4, past the blank line");
+        check(second.node_id != first.node_id,
+              "two distinct forms have distinct identities");
+    }
+}
+
+int main() {
+    std::printf("node_identity_test: ADR-0000 Stage 1 substrate\n");
+
+    test_none_never_resolves();
+    test_garbage_never_resolves();
+    test_roundtrip_and_density();
+    test_extent_is_monotone();
+    test_id_survives_node_copy();
+    test_counters_move();
+    test_parser_stamps_forms();
+
+    if (g_failures == 0) {
+        std::printf("PASS: node identity substrate\n");
+        return 0;
+    }
+    std::printf("FAIL: node identity substrate (%d check(s) failed)\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
ADR-0000 sequences fourteen stages as the project's architectural backbone. The
2026-08-25 architectural audit found **0 satisfied, 2 partial, 12 not started**,
and — the part that matters more than the count — **every one of the twelve
unstarted stages is blocked behind a root that has not landed**. Stage 1 is the
DAG-roots stage. Nothing in v1.4+ is schedulable until it closes.

This PR opens it. It delivers **phase A only**, and is explicit about that
boundary throughout: in the oracle stanza, in the ADR, in the CHANGELOG, and
below.

---

## What Stage 1 requires in full

ADR-0000 §4, Stage 1 — "Instrumentation and identity substrate":

| Tranche | Content |
|---|---|
| **0008 M0** | `SourceSpan`, `Diagnostic v1`, semantic-catalog seed, module resolver extracted from `eshkol-run` behind a shared API, LLVM-free analysis target split from execution targets |
| **0002 Phase A** | `EshkolADCounters` completion, `ad_tape_t::variables`, `arena_tape_zero_gradients`, the FD counter, the `ESHKOL_AD_STRICT` scaffold |
| **0001 Phase A** | `eshkol_memctx_current`/`eshkol_current_arena`; every allocation site off the direct `__global_arena` load; `with-region` mutating only TLS state |
| **0007 Phase 0** | JSON measurement runner, Layer-0 structural counters, an "assert generated code is O3" check |
| **0009** | Z-set contract freeze, deterministic batch-vs-delta oracle harness and corpus format |

Behind all five sits the constraint ADR-0000 §7 risk 1 calls **"the single most
important co-design constraint in the whole program"**: ADRs 0004 (typed HIR),
0006 (`BindingId` resolution) and 0008 (`SourceSpan` + workspace resolver) are
three overlapping frontend rewrites over **one** node-keyed substrate,

```
NodeId -> { SourceSpan, BindingId, TypedExprInfo }
```

shared by the compiler, LSP, docs, REPL and VM. Specified separately, they fork
the frontend into subtly different frontends and the "one answer" invariant
becomes false by construction.

The audit found none of it: `BindingId`, `NodeId`, `SourceSpan`, `TypeRef`,
`NominalTypeId`, `EffectRowRef`, `FlowEnv`, `Diagnostic v1`, `SymbolId`,
`ModuleId` — **zero hits across `lib/ inc/ exe/ tools/`**.

---

## What this PR delivers

### 1. The substrate, as a real data structure

`inc/eshkol/frontend/node_identity.h`, `lib/frontend/node_identity.cpp`.

- **`NodeId`** — stable, dense, minted by the parser for every node it gives a
  location to. It rides on `eshkol_ast_t::node_id` as a **4-byte key only**.
  The payload stays out of line because ADR-0008 §4.2 settles it: *"Adding span
  fields directly to `eshkol_ast_t` would change a public struct. During the
  v1.x migration, a `ParsedUnit` owns ASTs plus a `NodeId -> SourceSpan` side
  table."* Every future column joins the table, not the struct.

- **`SourceSpan`** — `{file_id, start_line, start_column, end_line, end_column,
  has_extent}`, in a chunked table sized to **exactly** the 2^24 ids the id
  encoding can name, so the two limits agree by construction rather than by
  comment. Allocation takes a mutex; lookup is lock-free, with the live count
  published *after* the payload so any id a reader can name is fully
  constructed.

- **Ids are tagged, not bare indices.** `eshkol_ast_t` is declared
  uninitialised in a dozen places — `macro_expander.cpp:181/511/541/563`,
  `sexp_to_ast.cpp:666/789`, `introspection.cpp:1205` among them — which is
  exactly why `source_file_id` is an id and not a `const char*`, and an unset
  `node_id` holds the same garbage. A `NodeId`'s high byte is a fixed tag, so
  255 of every 256 garbage words are rejected outright and the rest are caught
  by the index bound. **A rejected id reads as "unknown", never as a wrong
  location.** A diagnostic may fail to name a place; it must never name the
  wrong place confidently.

The parser's **32** location-stamping sites now write the location and the
identity in one statement, so the two cannot drift apart, and the stream reader
closes each top-level form's span with a **measured extent** — the first place
in the frontend that records where a construct *ends* rather than only where it
begins. (It is the only place that can: the tokenizer reports where each token
begins, and only the reader, which found the closing delimiter to cut the
form's text, holds both halves.)

### 2. A real consumer, moved off its ad-hoc mechanism

`codegenAST` — the LLVM codegen dispatcher — now resolves the file, line and
column of its diagnostics through `NodeId -> SourceSpan`, falling back to the
node's own fields for nodes the substrate does not know.

Diagnostics is the honest choice: it is where a location is either right or
actively misleading, and it is where **ESH-0364** (a diagnostic naming the file
it was *not* measured in) and **ESH-0365** (a location sitting on the form's
closing paren) both landed.

Emitted locations are **unchanged** — the span was recorded by the parser from
the same token that set `line`/`column`. That is the point: the substrate is
additive, and the consumer proves it is real by *depending* on it, not by
changing what it prints. What changes is structural: a node's **file** was
knowable only for top-level forms (`source_file_id` is stamped there and
nowhere else) and every inner node borrowed the ambient context of whatever
traversal reached it. In the span table each stamped node carries its own file,
so the answer stops depending on the traversal.

`ScopedAstProvenance` gained the integer fast path its own comment always
claimed — it now runs per AST node instead of per top-level form, and the
string resolution it guards takes a process-wide mutex.

### 3. The measurement

`ESHKOL_NODE_IDENTITY_STATS=1` makes every Eshkol frontend process print, as it
exits:

```
eshkol-node-identity: allocated=N queried=N resolved=N located=N extent=N
```

`scripts/run_node_identity_gate.py` compiles a mixed corpus, aggregates, and
emits two ICC `runtime_event` traces against a monotonic floor in
`tests/coverage/NODE_IDENTITY_BASELINE.json`.

```
ADR-0000 Stage 1 — node-identity substrate coverage
  sources compiled with stats on  : 60 / 60
  NodeIds allocated by the parser : 1095169
  consumer lookups                : 22171
  resolved to a span              : 22057  (99.49%)  [the gated number]
  span names a real line          : 22057  (99.49%)
  span end is measured (extent)   : 15910

PASS: substrate present; span coverage 99.49% >= floor 99.48%.
```

Three things about that number, because ADR-0000's whole point is that a stage
is attained against a number and not a description:

- It is measured **at a consumer, not at the parser**. A parser-side count says
  only how many ids were minted, never whether the answer arrived where it was
  needed. The denominator is *nodes reaching the LLVM codegen dispatcher*, and
  the gate says so rather than implying the whole AST.
- The **114 misses are real and the gate is meant to see them**: they are nodes
  macro expansion synthesizes, which have no origin in the span table until
  ADR-0008 M0's expansion table lands. Per file the number moves — 100% on
  `tests/macros/no_macro_test.esk`, 97.5% on `macro_in_nested_define_test.esk` —
  so it is discriminating rather than true by construction.
- "Has an identity", "has a location" and "has an extent" stay **three separate
  numbers** so none can be read as another.

The floor is **truncated, never rounded**: `round()` can land above the value it
came from (0.994858 → 0.9949), and a floor recorded above its own measurement
fails the very run that wrote it. Found by running the gate twice.

### 4. The oracle criterion

New target `adr0000-s1-identity` (aliases `s1-identity`, `node-identity`,
`adr0000-stage1`) in `.icc/completion-oracles.yaml`, with a stanza comment that
states it grades **phase A** and lists what is still owed.

```
# Readiness: `adr0000-s1-identity`
Repo: `eshkol-s1-identity`  Status: `ready`  Score: `97`  Oracle: `complete`

| Status | Severity | Criterion               | Evidence |
|--------|----------|-------------------------|----------|
| PASS   | high     | runtime_event           | 1        |   node_identity_substrate_present
| PASS   | high     | runtime_event           | 1        |   node_identity_span_coverage
| PASS   | medium   | tests_or_smoke_recorded | 5        |   node_identity_test
```

---

## What remains of Stage 1 — itemized

Named here, in the ADR, and in the oracle stanza. None of it is half-built in
this PR.

1. **`BindingId` column** — ADR-0006 slices 1-2. Declaration IR, recursive
   `ImportSet`, import algebra, export validation, standard-library catalog;
   stop lowering R7RS imports to value-copying `define` aliases (still three
   separate copies: parser, driver, REPL). Sequenced into Stage 2.
2. **`TypedExprInfo` column** — ADR-0004 spine part 1. Interned
   `NominalTypeId`/`TypeRef`/`IndexRef`/`EffectRowRef`, a typed-HIR side table
   keyed on the *same* `NodeId`, `Dyn` separated from `Any`/`Value`. Sequenced
   into Stage 2. **The key now exists, so the "same NodeId" constraint is
   finally expressible.**
3. **One semantic tooling core** — ADR-0008 M0/M1. `Diagnostic v1`, the
   semantic-catalog seed, the module resolver extracted from `eshkol-run` behind
   a shared API, the LLVM-free analysis target, `eshkol check`. The LSP still
   produces diagnostics by counting parentheses character-by-character and
   extracting symbols with `std::regex` (`tools/lsp/eshkol_lsp.cpp:622-719`,
   `:916`), discarding every parse result. Untouched here.
4. **Byte-offset canonical spans** — ADR-0008 §4.2 wants UTF-8 byte offsets with
   a `SourceManager` projecting to line/column. Phase A stores line/column
   because that is what the current reader measures:
   `eshkol_parse_next_ast_from_stream` strips line comments before handing text
   to the tokenizer, so a token offset **is not** a file offset and byte spans
   recorded today would be *wrong*, not merely absent. Needs the lossless token
   stream. The `eshkol_source_span_t` struct is the migration point, and
   consumers already ask it rather than reading fields off the node.
5. **The expansion-origin table** — `expansion_id`, macro-origin chains. Its
   absence is precisely what the coverage gate's ~0.5% of unresolved nodes is
   made of.
6. **Extents on inner nodes** — only top-level forms carry a measured extent
   today (15910 of 22057 resolved lookups). Same dependency as (4).
7. **Interned type terms** — S2, ADR-0004.
8. **The rest of Stage 1's tranches** — 0002 Phase A (AD counters, the wired FD
   counter, `ESHKOL_AD_STRICT`), 0001 Phase A (OALR memctx; `with-region` still
   writes `__global_arena` at `runtime_regions.cpp:587`), 0007 Phase 0 (JSON
   measurement runner, O-level assertion), 0009 contract freeze.
9. **Risk 1's falsifier** — the cross-consumer fixture in which compiler, LSP,
   docs and REPL report an identical `SymbolId`/`ModuleId`/span for the same
   source. Still not green; cannot be until `SymbolId` and `ModuleId` exist. It
   is now *expressible for the span half*, which it was not before.

**This PR does not claim Stage 1 attainment.** It claims the first column of the
substrate, one consumer on it, and a number that can fall.

---

## Verification

| Gate | Result |
|---|---|
| Build (RelWithDebInfo, LLVM 21, tests/agent-FFI/fixed-point/GPU on) | clean |
| `ctest -j6` | **191/191** (baseline 190/190 on the same tree before the change; +1 is the new test) |
| `scripts/run_vm_tests.sh` | PASS — source tests 73/73 |
| `scripts/run_vm_parity.sh` | PASS — 188 passed, 0 failed |
| `scripts/run_engine_parity_coverage.py` | PASS — 217 programs, 118 both-engines-clean, **0 regressed**, differential construct coverage 13.37% (floor held) |
| `scripts/run_language_coverage.sh` | PASS — **1106/1106 (100.0%)** execution-backed, deficit ratchet 0, high-risk COMPLETE. *The sharpest byte-identity check available for this change: the tracker credits a compile-time form only when a parser-DISPATCH event and a codegen-ACCEPT event share an **exact source position** — the mechanism that surfaced ESH-0365. It still matches on every one of 1106 constructs.* |
| `scripts/gate_no_silent_wrong.py` | PASS |
| `scripts/check_ledger_integrity.py` | PASS |
| `scripts/check_oracle_schema.py` | PASS — 36 oracles, 268/268 criteria graded |
| `scripts/run_node_identity_gate.py` | PASS — 99.49% >= floor 99.48% |
| ICC `guard-diff` | PASS — 0 violations |
| ICC `pre-commit-check` | **PASS** — 0 blockers |
| ICC `readiness --target adr0000-s1-identity` | `ready`, score **97**, oracle **complete** (3/3) |

Additive by construction: `line`, `column` and `source_file_id` keep their exact
previous values; the new field is written and read, never substituted for. The
only paths that changed are the ones that now *ask the substrate first and fall
back to the old fields*, and the substrate's answer is derived from the same
token assignment.

Not merged. Not tagged.

---

## Base

Branched from `origin/master` at `4bf871a0`, which is where every number above
was measured. `master` has since advanced to `73cc7cbb` (#464 docs wave, VM
limits, closure upvalue-capacity tests). The PR is `MERGEABLE` against it and
the moving commits are orthogonal to the frontend identity path, but the gate
table describes `4bf871a0` + this branch and should be re-run on the merge
result before merging.
