### PR TITLE
ci: end duplicate matrix runs, harden the changes gate, and wire self-hosted mesh runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,16 @@
+# Custom self-hosted runner labels used by this repository.
+#
+# actionlint validates every `runs-on` label against GitHub's hosted-runner
+# list and flags anything it does not recognise. The labels below are the
+# ones this repo assigns to its own runners; declaring them here is what
+# tells actionlint they are intentional rather than typos.
+#
+# Keep this list in sync with the label taxonomy table in
+# docs/platform/SELF_HOSTED_RUNNERS.md § Label taxonomy — that document is
+# the authority on what each label MEANS and when it may be assigned.
+self-hosted-runner:
+  labels:
+    - eshkol   # provisioned for this repo's build (LLVM 21, cmake, ninja, python3)
+    - gpu      # has a real, addressable GPU device — not merely a GPU toolchain
+    - cuda     # CUDA device plus nvcc on PATH; implies gpu
+    - metal    # Apple Silicon with a working Metal device; implies gpu

--- a/.github/workflows/ci-mesh.yml
+++ b/.github/workflows/ci-mesh.yml
@@ -1,0 +1,376 @@
+name: CI (mesh, self-hosted)
+
+# ─────────────────────────────────────────────────────────────────────────
+# WHAT THIS IS, AND WHAT IT DELIBERATELY IS NOT
+#
+# This workflow runs a subset of the ci.yml lane batteries on the
+# maintainer's own hardware (the "mesh") instead of GitHub-hosted runners.
+# Its purpose is capacity and honesty:
+#
+#   - CAPACITY. The hosted matrix in ci.yml is 14 lanes plus Windows SDK
+#     downloads. Moving the Linux/macOS lite lanes onto owned hardware frees
+#     hosted minutes for the lanes that genuinely need a clean, disposable
+#     hosted image.
+#   - HONESTY. ci.yml's `linux-x64-cuda` / `linux-arm64-cuda` /
+#     `windows-x64-cuda` lanes run on hosted runners, which have NO GPU:
+#     nvcc compiles the kernels, `eshkol_gpu_init()` reports zero devices,
+#     and every GPU tensor op silently falls back to the CPU path. They are
+#     COMPILATION gates. `mesh-linux-x64-cuda-exec` below runs the same
+#     `scripts/run_gpu_tests.sh` on a machine with a real CUDA device, so it
+#     is an EXECUTION gate. (The narrower GPU-vs-CPU numeric diff lives in
+#     gpu-execution-gate.yml and shares this workflow's `gpu` label — see
+#     the runbook.)
+#
+# IT IS NOT A MERGE GATE, AND MUST NOT BECOME ONE BY ACCIDENT.
+#
+# Nothing in this file appears in branch protection's required-contexts
+# list, and nothing in this file may be added to it without the maintainer
+# deciding to. That is not caution for its own sake — it is the concrete
+# lesson of PR #444: a required context that stops reporting blocks merges
+# permanently, because branch protection has no timeout, only "hasn't
+# reported yet". A required context backed by a self-hosted runner inherits
+# the availability of that one machine. The reachability survey in
+# docs/platform/SELF_HOSTED_RUNNERS.md measured this fleet directly: the
+# majority of it is powered off or preempted at any given moment, and every
+# datacenter-GPU node in it is a GCP spot instance. Hardware like that is a
+# fine place to EARN extra signal and a catastrophic place to REQUIRE it.
+#
+# WHY A SEPARATE WORKFLOW RATHER THAN A `runs-on` FALLBACK INSIDE ci.yml
+#
+# Because the fallback everyone reaches for does not exist. `runs-on` is
+# resolved when the job is scheduled; GitHub Actions has no "use the
+# self-hosted runner if one is online, otherwise use a hosted one"
+# construct. A job whose labels match no online runner does not fail over —
+# it queues. Making a REQUIRED lane's `runs-on` depend on fleet state
+# therefore converts every mesh outage into a permanently pending required
+# check, which is precisely the #444 trap. Keeping the mesh lanes in their
+# own file with their own job names makes that mistake structurally
+# impossible: these names are not in the required set and cannot displace a
+# lane that is.
+#
+# HOW IT DEGRADES
+#
+# Three independent guards, any one of which is sufficient:
+#   1. Repository variable `ESHKOL_MESH_CI` must equal `on`. Unset (the
+#      default, and the state this file ships in) means every job here is
+#      SKIPPED — it never queues, never occupies a runner, never reports.
+#   2. `mesh-preflight` runs on a HOSTED runner and refuses to fan out when
+#      no runner carrying the `eshkol` label is registered, so switching the
+#      variable on before registering a runner still cannot leave jobs
+#      queued against absent labels.
+#   3. Every mesh job carries `timeout-minutes`, so even a runner that
+#      registers and then wedges releases the run.
+#
+# SECURITY: self-hosted runners on a public repository
+#
+# A self-hosted runner executes whatever the workflow tells it to on a
+# machine the maintainer owns, on their home network, with a persistent
+# filesystem between runs. A pull request from a FORK can edit the workflow
+# it is tested by. Every job below therefore refuses to run for a fork PR
+# (`github.event.pull_request.head.repo.full_name == github.repository`).
+# This is the load-bearing control; the repository's "require approval for
+# all outside collaborators" setting is the second layer. See
+# docs/platform/SELF_HOSTED_RUNNERS.md § Security.
+# ─────────────────────────────────────────────────────────────────────────
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  # Mirrors ci.yml: one group per PR, one per branch for push runs. Mesh
+  # runners are single-machine and serialise anyway, so a superseded run
+  # holding one is strictly worse than cancelling it.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/master' }}
+
+env:
+  LLVM_MAJOR: '21'
+
+jobs:
+  # ───────────────────────────────────────────────────────────────────
+  # Guard job. Runs on a HOSTED runner on purpose: its entire job is to
+  # decide whether the self-hosted fleet can be dispatched to, so it must
+  # not itself depend on that fleet.
+  # ───────────────────────────────────────────────────────────────────
+  mesh-preflight:
+    name: mesh-preflight (hosted — decides whether the mesh lanes fan out)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: read
+    # Fork PRs never reach the mesh at all — not even this hosted probe, so
+    # that the skip is visible at the top of the run rather than N times over.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    outputs:
+      dispatch: ${{ steps.decide.outputs.dispatch }}
+    steps:
+      - name: Decide
+        id: decide
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          MESH_CI: ${{ vars.ESHKOL_MESH_CI }}
+        run: |
+          set -u
+
+          if [ "${MESH_CI:-}" != "on" ]; then
+            echo "dispatch=false" >> "$GITHUB_OUTPUT"
+            echo "Repository variable ESHKOL_MESH_CI is '${MESH_CI:-<unset>}', not 'on'. Mesh lanes stay off." \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Best-effort. Listing runners needs `administration:read`, which the
+          # default GITHUB_TOKEN does not carry, so an unreadable answer is
+          # reported as unknown and treated as "go ahead" — the per-job
+          # timeout-minutes is the backstop in that case, not a guess here.
+          online=$(gh api "repos/$REPO/actions/runners" \
+                     --jq '[.runners[] | select(.status == "online") | select([.labels[].name] | index("eshkol"))] | length' \
+                   2>/dev/null || echo unknown)
+
+          if [ "$online" = "0" ]; then
+            echo "dispatch=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Mesh CI enabled but no runner registered::ESHKOL_MESH_CI is 'on' but no ONLINE self-hosted runner carries the 'eshkol' label. Mesh lanes skipped rather than left queued. See docs/platform/SELF_HOSTED_RUNNERS.md."
+            echo "ESHKOL_MESH_CI is on, but 0 online runners carry the \`eshkol\` label — mesh lanes skipped." \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "dispatch=true" >> "$GITHUB_OUTPUT"
+          echo "Mesh lanes dispatching. Online runners carrying \`eshkol\`: $online." \
+            >> "$GITHUB_STEP_SUMMARY"
+
+  # ───────────────────────────────────────────────────────────────────
+  # The mesh lanes themselves.
+  #
+  # Labels, not hostnames. A lane says what it NEEDS (`linux`, `x64`,
+  # `cuda`); which physical box answers is the runbook's business, so a
+  # node can be swapped without editing this file. `self-hosted`, the OS
+  # label and the arch label are applied by GitHub automatically at
+  # registration; `eshkol`, `cuda` and `metal` are custom and are assigned
+  # per docs/platform/SELF_HOSTED_RUNNERS.md § Label taxonomy.
+  #
+  # These lanes deliberately do NOT apt-get/brew install a toolchain the
+  # way ci.yml's hosted lanes do. A hosted runner is a fresh disposable
+  # image and must provision itself; a self-hosted runner is a real machine
+  # that CI has no business mutating, and doing so would require handing
+  # the runner passwordless sudo. The toolchain is provisioned once, by
+  # hand, per the runbook; `mesh-toolchain-preflight` below verifies it and
+  # fails with an actionable message if it is missing.
+  # ───────────────────────────────────────────────────────────────────
+  mesh-matrix:
+    name: ${{ matrix.name }}
+    needs: mesh-preflight
+    if: needs.mesh-preflight.outputs.dispatch == 'true'
+    runs-on: ${{ fromJSON(matrix.labels) }}
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      fail-fast: false
+      # One runner per node; don't let two lanes fight over the same box's
+      # cores and disk.
+      max-parallel: 3
+      matrix:
+        include:
+          - name: mesh-linux-x64-lite
+            labels: '["self-hosted", "linux", "x64", "eshkol"]'
+            build_dir: build-mesh
+            xla_enabled: 'OFF'
+            gpu_enabled: 'OFF'
+            test_command: ./scripts/run_all_tests.sh
+            min_free_gb: 25
+            timeout: 90
+
+          - name: mesh-linux-arm64-lite
+            labels: '["self-hosted", "linux", "arm64", "eshkol"]'
+            build_dir: build-mesh
+            xla_enabled: 'OFF'
+            gpu_enabled: 'OFF'
+            test_command: ./scripts/run_all_tests.sh
+            min_free_gb: 25
+            timeout: 150   # the arm64 mesh candidates are 4-8 core SBCs
+
+          - name: mesh-macos-arm64-lite
+            labels: '["self-hosted", "macos", "arm64", "eshkol"]'
+            build_dir: build-mesh
+            xla_enabled: 'OFF'
+            gpu_enabled: 'OFF'
+            test_command: ./scripts/run_all_tests.sh
+            min_free_gb: 25
+            timeout: 90
+
+          # The lane that hosted CI structurally cannot provide: GPU tests
+          # against a real CUDA device rather than a zero-device fallback.
+          - name: mesh-linux-x64-cuda-exec
+            labels: '["self-hosted", "linux", "x64", "eshkol", "cuda"]'
+            build_dir: build-mesh-cuda
+            xla_enabled: 'OFF'
+            gpu_enabled: 'ON'
+            test_command: ./scripts/run_gpu_tests.sh
+            min_free_gb: 30
+            timeout: 120
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # Self-hosted runners keep their workspace between runs, so a lane that
+      # fills the disk stays filled and every later run on that node fails
+      # somewhere confusing. Fail here instead, naming the number.
+      - name: Disk budget
+        shell: bash
+        env:
+          MIN_FREE_GB: ${{ matrix.min_free_gb }}
+          LANE: ${{ matrix.name }}
+        run: |
+          set -u
+          free_gb=$(df -Pk . | awk 'NR==2 {print int($4/1048576)}')
+          echo "free on runner workspace volume: ${free_gb} GiB (lane needs ${MIN_FREE_GB} GiB)"
+          if [ "$free_gb" -lt "$MIN_FREE_GB" ]; then
+            echo "::error title=Mesh runner out of disk::${LANE} needs ${MIN_FREE_GB} GiB free on this node; ${free_gb} GiB available. Clear old build-mesh*/ trees and _work/_temp on the runner host."
+            exit 1
+          fi
+
+      - name: Toolchain preflight
+        id: toolchain
+        shell: bash
+        run: |
+          set -u
+          fail=0
+          note() { echo "::error title=Mesh runner not provisioned::$1 See docs/platform/SELF_HOSTED_RUNNERS.md § Provisioning."; fail=1; }
+
+          # Resolve llvm-config for the pinned major, wherever this host keeps it.
+          llvm_config=""
+          for c in \
+            "$(command -v "llvm-config-${LLVM_MAJOR}" 2>/dev/null || true)" \
+            "/usr/lib/llvm-${LLVM_MAJOR}/bin/llvm-config" \
+            "/usr/local/opt/llvm@${LLVM_MAJOR}/bin/llvm-config" \
+            "/opt/homebrew/opt/llvm@${LLVM_MAJOR}/bin/llvm-config" \
+            "$(command -v llvm-config 2>/dev/null || true)"
+          do
+            [ -n "$c" ] && [ -x "$c" ] || continue
+            if [ "$("$c" --version | cut -d. -f1)" = "${LLVM_MAJOR}" ]; then
+              llvm_config="$c"; break
+            fi
+          done
+          if [ -z "$llvm_config" ]; then
+            note "No LLVM ${LLVM_MAJOR} toolchain found on this runner."
+          else
+            echo "llvm-config: $llvm_config ($("$llvm_config" --version))"
+            echo "LLVM_CONFIG=$llvm_config" >> "$GITHUB_ENV"
+            dirname "$llvm_config" >> "$GITHUB_PATH"
+          fi
+
+          command -v cmake >/dev/null 2>&1 || note "cmake is not installed on this runner."
+          command -v ninja >/dev/null 2>&1 || note "ninja is not installed on this runner."
+          command -v python3 >/dev/null 2>&1 || note "python3 is not installed on this runner."
+
+          # `-fuse-ld=lld` (AArch64 Linux codegen) wants an unversioned ld.lld
+          # in PATH. ci.yml symlinks it with sudo; a self-hosted runner must
+          # not, so shim it into the runner's own PATH instead.
+          if [ "$RUNNER_OS" = "Linux" ] && ! command -v ld.lld >/dev/null 2>&1; then
+            versioned="$(command -v "ld.lld-${LLVM_MAJOR}" 2>/dev/null || echo "/usr/lib/llvm-${LLVM_MAJOR}/bin/ld.lld")"
+            if [ -x "$versioned" ]; then
+              mkdir -p "$RUNNER_TEMP/bin"
+              ln -sf "$versioned" "$RUNNER_TEMP/bin/ld.lld"
+              echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+              echo "shimmed ld.lld -> $versioned"
+            else
+              note "ld.lld (or ld.lld-${LLVM_MAJOR}) is not installed on this runner."
+            fi
+          fi
+
+          if [ "${{ matrix.gpu_enabled }}" = "ON" ]; then
+            command -v nvcc >/dev/null 2>&1 || note "nvcc is not on PATH, but this lane is the CUDA EXECUTION lane."
+            if command -v nvidia-smi >/dev/null 2>&1; then
+              nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader
+            else
+              note "nvidia-smi is absent: this runner carries the 'cuda' label but exposes no CUDA device, which would silently degrade this lane back into the compile-only gate it exists to replace."
+            fi
+          fi
+
+          exit $fail
+
+      - name: Configure
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cmake -S . -B "${{ matrix.build_dir }}" -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DESHKOL_REQUIRED_LLVM_MAJOR="${LLVM_MAJOR}" \
+            -DLLVM_CONFIG_EXECUTABLE="$LLVM_CONFIG" \
+            -DESHKOL_XLA_ENABLED=${{ matrix.xla_enabled }} \
+            -DESHKOL_GPU_ENABLED=${{ matrix.gpu_enabled }} \
+            -DESHKOL_REQUIRE_GPU_BACKEND=${{ matrix.gpu_enabled }}
+
+      # Same guard ci.yml applies to its CUDA lanes: reject a build graph that
+      # quietly picked up gpu_memory_stub.cpp instead of the real kernels.
+      - name: Verify real CUDA build graph
+        if: matrix.gpu_enabled == 'ON'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python3 scripts/verify_gpu_backend.py \
+            --build-dir "${{ matrix.build_dir }}" \
+            --expected CUDA
+
+      - name: Build
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cmake --build "${{ matrix.build_dir }}" --parallel
+
+      - name: Run tests
+        shell: bash
+        env:
+          BUILD_DIR: ${{ matrix.build_dir }}
+        run: |
+          set -euxo pipefail
+          mkdir -p "$RUNNER_TEMP/eshkol-test-logs"
+          export ESHKOL_HTTP_SERVER_SMOKE_TIMEOUT="${ESHKOL_HTTP_SERVER_SMOKE_TIMEOUT:-600}"
+          export ESHKOL_REPL_MACHINE_READY_TIMEOUT="${ESHKOL_REPL_MACHINE_READY_TIMEOUT:-600}"
+          export ESHKOL_REPL_MACHINE_DONE_TIMEOUT="${ESHKOL_REPL_MACHINE_DONE_TIMEOUT:-180}"
+          ${{ matrix.test_command }} 2>&1 | tee "$RUNNER_TEMP/eshkol-test-logs/${{ matrix.name }}.log"
+
+      - name: Upload test log
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.name }}-test-log
+          path: ${{ runner.temp }}/eshkol-test-logs/${{ matrix.name }}.log
+          if-no-files-found: ignore
+
+      # Same rationale as ci.yml's copy of this step (ADR-0010 §2.2, gap A5):
+      # oracle traces live in git-ignored trees and are otherwise lost with the
+      # workspace. On a self-hosted runner they would instead accumulate
+      # forever, which is why the next step removes them.
+      - name: Upload ICC evidence traces
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: icc-evidence-${{ matrix.name }}
+          path: |
+            scripts/icc_traces/
+            .icc/runtime-traces/
+            .icc/runtime-traces-oracle-view/
+          if-no-files-found: ignore
+
+      # Hosted runners are destroyed after every job; self-hosted runners are
+      # not. Without this, each lane leaves a multi-GB build tree behind and
+      # the node fails the disk-budget step a few runs later.
+      - name: Reclaim build tree
+        if: always()
+        shell: bash
+        run: |
+          set -u
+          rm -rf "${{ matrix.build_dir }}" || true
+          df -Pk . | awk 'NR==2 {printf "free after reclaim: %d GiB\n", int($4/1048576)}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,27 @@ name: CI
 
 on:
   push:
-    branches: [master, develop, 'feat/**']
+    # Integration branches ONLY. `feat/**` used to be listed here and must not
+    # come back: every PR is opened from a topic branch, so a topic branch in
+    # this list makes GitHub start TWO full runs of this workflow for the same
+    # commit — one `push` run and one `pull_request` run — each spinning up the
+    # whole 14-lane matrix. That is half the repo's runner capacity spent
+    # producing a duplicate of a signal we already have.
+    #
+    # The duplicate is not merely wasteful, it is actively harmful. The two
+    # runs land in DIFFERENT concurrency groups (a push run keys on
+    # `refs/heads/<branch>`, a pull_request run on the PR number), so they
+    # never dedupe against each other; but successive pushes to the topic
+    # branch DO cancel the previous push run, and a cancelled run leaves
+    # `cancelled` check-runs sitting on the branch head. Those cancelled
+    # contexts share their names with the required contexts branch protection
+    # is watching, so the merge button reports a required check in a
+    # non-success state that no rerun of the PR run will ever clear.
+    #
+    # Topic branches lose nothing: the `pull_request` trigger below already
+    # covers every one of them from the moment a PR exists, and a topic branch
+    # with no PR open has nothing to gate.
+    branches: [master, develop]
     # Docs/markdown-only changes cannot affect the build or tests, so they must
     # not spin up the full compile/test/wasm/asan matrix. Research ADRs and
     # documentation live under docs/ and **/*.md; skip CI when a change touches
@@ -69,10 +89,22 @@ on:
     - cron: '0 6 * * 1'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # One group per pull request, or per branch for the push runs. Keying a PR
+  # run on its NUMBER rather than on `github.ref` keeps the group stable across
+  # a force-push and across a base-branch change, so a superseded run is always
+  # the one that gets cancelled.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   # Master is the public release gate. Let those runs finish so we get a
   # complete matrix signal even while follow-up commits are landing.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  #
+  # Everything else — every pull_request run above all — cancels in progress.
+  # A push to a PR branch invalidates the run for the previous head SHA, and
+  # holding runners for a result nobody will read is the single largest source
+  # of queueing on this repo's matrix. Stated explicitly for `pull_request`
+  # rather than left to the `github.ref != master` fallback, because a PR run's
+  # `github.ref` is `refs/pull/N/merge` and the equivalence is not obvious to
+  # the next person editing this block.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/master' }}
 
 env:
   LLVM_MAJOR: '21'
@@ -90,10 +122,57 @@ jobs:
   # than a vendored paths-filter action: this repo has no other third-party
   # filtering action in its supply chain, and the predicate is a single
   # `git diff --name-only` plus a case match.
+  #
+  # ── FAILURE MODE THIS JOB MUST NOT HAVE ──────────────────────────────
+  # Every heavy job below carries `needs: changes`. That makes this job a
+  # single point of failure for the whole run: when it exits non-zero,
+  # nothing downstream is merely skipped, the entire matrix is blocked.
+  #
+  # The original implementation exited 128 whenever a PR branch was
+  # force-pushed while its run was in flight. GitHub starts the run for a
+  # specific head SHA; a force-push orphans that object, and
+  # `git diff <base>...<orphaned head>` then dies with `fatal: bad object`.
+  # Under `set -e` that killed the job and blocked the PR (measured on
+  # PR #465). With several branches rebasing at once this is not an edge
+  # case, it is the normal weather.
+  #
+  # Two rules follow, and both are load-bearing:
+  #
+  #   1. PREFER INPUTS THAT CANNOT DANGLE. The GitHub API answers
+  #      "which files does this PR touch" with FILENAMES, never object
+  #      ids, so a force-pushed-away head cannot make it fail. A
+  #      three-dot diff against the live base branch is the git-side
+  #      equivalent: it names a ref that still exists. The two-SHA form
+  #      is kept only as a last resort, and only after `git cat-file -e`
+  #      confirms both objects actually resolve.
+  #
+  #   2. FAIL SAFE, NOT LOUD. If no strategy can determine the answer,
+  #      this job reports `docs_only=false` — the CONSERVATIVE answer,
+  #      meaning "run the whole matrix" — and exits 0 with a warning.
+  #      A gate that cannot compute its predicate must degrade toward
+  #      MORE testing, never toward a blocked merge. "I could not run"
+  #      is not the same verdict as "this failed", and this job is
+  #      structurally incapable of confusing the two: the step never
+  #      exits non-zero, which is why it deliberately does not use
+  #      `set -e`.
+  #
+  # The third leg is the `concurrency` block at the top of this file. It
+  # keys pull_request runs on the PR NUMBER with `cancel-in-progress`, so
+  # a force-push supersedes the in-flight run rather than racing it: the
+  # stale run is cancelled, and the fresh `synchronize` event starts a run
+  # whose head SHA is by construction the one that now exists. The
+  # hardening here is what keeps the *already-started* run from failing in
+  # the window before that cancellation lands.
+  # ─────────────────────────────────────────────────────────────────────
   changes:
     name: changes
     if: github.event_name != 'schedule'
     runs-on: ubuntu-22.04
+    # Scoped to this job only; the rest of the workflow keeps the repository
+    # default. `pull-requests: read` is what lets the API strategy below work.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
@@ -104,24 +183,83 @@ jobs:
       - name: Determine whether this change is docs-only
         id: filter
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_SHA: ${{ github.sha }}
         run: |
-          set -euo pipefail
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            base="${{ github.event.pull_request.base.sha }}"
-            head="${{ github.event.pull_request.head.sha }}"
-            changed_files="$(git diff --name-only "$base...$head")"
+          # NOTE the missing `-e`. Intentional, and the whole point — see the
+          # job comment. Nothing in this step may abort the job.
+          set -uo pipefail
+
+          changed_files=""
+          source=""
+
+          # Does this object still exist in this checkout?
+          have_obj() { [[ -n "${1:-}" ]] && git cat-file -e "${1}^{commit}" 2>/dev/null; }
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            # Strategy 1 — the API. Immune to a force-pushed-away head SHA,
+            # because it never mentions one.
+            if api_files="$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" \
+                              --paginate --jq '.[].filename' 2>/dev/null)"; then
+              changed_files="$api_files"
+              source="GitHub API repos/$REPO/pulls/$PR_NUMBER/files"
+            fi
+
+            # Strategy 2 — three-dot diff against the live base branch. Names a
+            # ref that cannot dangle, and on a pull_request run HEAD is the
+            # merge commit, so `base...HEAD` is exactly the PR's own change set.
+            if [[ -z "$source" ]]; then
+              git fetch --no-tags --prune origin \
+                "+refs/heads/${PR_BASE_REF}:refs/remotes/origin/${PR_BASE_REF}" >/dev/null 2>&1 || true
+              if git rev-parse --verify -q "refs/remotes/origin/${PR_BASE_REF}" >/dev/null 2>&1 \
+                 && d="$(git diff --name-only "refs/remotes/origin/${PR_BASE_REF}...HEAD" 2>/dev/null)"; then
+                changed_files="$d"
+                source="git diff origin/${PR_BASE_REF}...HEAD"
+              fi
+            fi
+
+            # Strategy 3 — the original two-SHA form, guarded. This is the one
+            # that used to explode; it now runs only when both objects resolve.
+            if [[ -z "$source" ]] && have_obj "$PR_BASE_SHA" && have_obj "$PR_HEAD_SHA"; then
+              if d="$(git diff --name-only "${PR_BASE_SHA}...${PR_HEAD_SHA}" 2>/dev/null)"; then
+                changed_files="$d"
+                source="git diff ${PR_BASE_SHA}...${PR_HEAD_SHA}"
+              fi
+            fi
           else
-            before="${{ github.event.before }}"
-            if [[ -z "$before" || "$before" == "0000000000000000000000000000000000000000" ]]; then
-              # First push of a branch, or force-push with no usable
-              # `before`: nothing to diff against, so don't claim docs-only.
-              changed_files="__unknown__"
-            else
-              changed_files="$(git diff --name-only "$before" "${{ github.sha }}")"
+            # Push runs. `before` is absent on a branch's first push and can be
+            # orphaned by a force-push to the branch, so it gets the same guard.
+            if [[ -n "$PUSH_BEFORE" && "$PUSH_BEFORE" != "0000000000000000000000000000000000000000" ]] \
+               && have_obj "$PUSH_BEFORE" && have_obj "$PUSH_SHA"; then
+              if d="$(git diff --name-only "$PUSH_BEFORE" "$PUSH_SHA" 2>/dev/null)"; then
+                changed_files="$d"
+                source="git diff $PUSH_BEFORE $PUSH_SHA"
+              fi
             fi
           fi
 
-          echo "Changed files:"
+          if [[ -z "$source" ]]; then
+            # Could not run — NOT a failure. Answer conservatively and let the
+            # full matrix decide, which is the same outcome as a code change.
+            echo "::warning title=changes: changed-file set could not be computed::Every strategy failed (most likely the head SHA this run started for was orphaned by a force-push). Reporting docs_only=false so the FULL matrix runs — the conservative answer. This is not a build failure and must never block the run."
+            {
+              echo "### changes"
+              echo
+              echo "Could not compute the changed-file set; assuming **not** docs-only and running the full matrix."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "docs_only=false" | tee -a "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Changed files (via $source):"
           printf '%s\n' "$changed_files"
 
           # Exactly the path list the old trigger-level paths-ignore used:
@@ -132,18 +270,21 @@ jobs:
           # `docs/**`.
           docs_only=true
           if [[ -z "$changed_files" ]]; then
+            # An empty set from a strategy that "succeeded" is not evidence of a
+            # docs-only change; it is evidence something is off. Same
+            # conservative answer.
             docs_only=false
           fi
           while IFS= read -r f; do
             [[ -z "$f" ]] && continue
             case "$f" in
-              __unknown__) docs_only=false ;;
               *.md|docs/*|notes/*|press/*|.swarm/*|LICENSE) ;;
               *) docs_only=false ;;
             esac
           done <<< "$changed_files"
 
           echo "docs_only=$docs_only" | tee -a "$GITHUB_OUTPUT"
+          exit 0
 
   # ─────────────────────────────────────────────────────────────────────
   # ADVISORY mesh-gate placeholder (see the top-of-file comment above for

--- a/.github/workflows/gpu-execution-gate.yml
+++ b/.github/workflows/gpu-execution-gate.yml
@@ -33,6 +33,14 @@ name: GPU Execution Gate
 # Actions self-hosted runner agent). Do NOT repoint this at a
 # GitHub-hosted runner — that silently turns it back into a
 # compile-only gate, defeating the point of this file.
+#
+# Registering that runner — which is what closes ADR-0010 gap A13 and
+# silences the warning gpu-gate-visibility emits below — is written up
+# step by step in docs/platform/SELF_HOSTED_RUNNERS.md. Note in
+# particular its label rule: `gpu` means a real, addressable GPU DEVICE,
+# not merely a GPU toolchain. A runner carrying `gpu` without a device
+# would let this job report success while measuring the CPU fallback,
+# which is the exact failure this workflow exists to detect.
 on:
   workflow_dispatch: {}
   schedule:

--- a/docs/README.md
+++ b/docs/README.md
@@ -135,6 +135,7 @@ pages and lets them fan out to their siblings.
 - [Build-system integration](BUILD_INTEGRATION.md) — compiling `.esk` sources from a CMake project (e.g. embedding Eshkol in a larger C/C++ project)
 - [Build notes](platform/BUILD_NOTES.md)
 - [CI lanes](platform/CI_LANES.md) — required vs. non-required CI lanes and what each covers
+- [Self-hosted runners](platform/SELF_HOSTED_RUNNERS.md) — attaching the maintainer's own machines as GitHub Actions runners: label taxonomy, provisioning, registration, why no mesh lane is a required check
 - [ICC contract surface](platform/ICC_CONTRACT_SURFACE.md)
 - [Windows x86 under KVM](platform/WINDOWS_X86_KVM.md)
 - [Target Support Matrix](platform/TARGET_SUPPORT_MATRIX.md)

--- a/docs/breakdown/CI_CD.md
+++ b/docs/breakdown/CI_CD.md
@@ -7,11 +7,15 @@
 
 ## Overview
 
-Eshkol uses three GitHub Actions workflows for continuous integration, release publishing, and website deployment. All workflows are defined in `.github/workflows/`.
+Eshkol's GitHub Actions workflows all live in `.github/workflows/`.
 
 | Workflow | File | Purpose |
 |----------|------|---------|
-| CI | `ci.yml` | Build and test on every push and pull request |
+| CI | `ci.yml` | Build and test on every pull request, and on pushes to the integration branches |
+| CI (mesh, self-hosted) | `ci-mesh.yml` | Advisory lanes on the maintainer's own hardware, including the only real-GPU execution lane. Off unless `ESHKOL_MESH_CI=on`; never a required check. See [Self-hosted runners](../platform/SELF_HOSTED_RUNNERS.md) |
+| GPU Execution Gate | `gpu-execution-gate.yml` | GPU-vs-CPU numeric diff on a `[self-hosted, gpu]` runner |
+| Adversarial Nightly | `adversarial-nightly.yml` | Nightly P8 escape-closure, TSan, packaging |
+| identity-guard | `identity-guard.yml` | Rejects commits carrying a denylisted author/committer identity |
 | Release | `release.yml` | Build artifacts and publish on version tags |
 | Deploy Site | `pages.yml` | Deploy project website to GitHub Pages |
 
@@ -21,8 +25,13 @@ Eshkol uses three GitHub Actions workflows for continuous integration, release p
 
 ### Triggers
 
-- **Push** to `master`, `develop`, or any `feat/**` branch
+- **Push** to `master` or `develop` — integration branches only
 - **Pull request** targeting `master`
+
+Topic branches are covered by the pull-request trigger alone. They are deliberately
+absent from the push trigger: a branch listed in both makes GitHub run the full
+matrix twice for one commit, and the superseded push run's `cancelled` check-runs
+then sit on the branch head looking like failed required checks.
 
 ### Build Matrix
 

--- a/docs/platform/CI_LANES.md
+++ b/docs/platform/CI_LANES.md
@@ -49,4 +49,28 @@ at `WINDOWS_LLVM_SDK_VERSION=21.1.8`.
   first-class: a green "required" set can still hide a regression that only one
   of these lanes catches.
 
-Other workflows: `pages.yml` (docs site) and `release.yml` (release packaging).
+## Trigger surface
+
+`ci.yml` fires on `push` to **`master` and `develop` only**, and on `pull_request`
+against `master`. Topic branches are covered by the `pull_request` trigger alone —
+listing them under `push` as well makes GitHub start two full runs of the same
+14-lane matrix for one commit, and leaves `cancelled` check-runs behind when a
+follow-up push cancels the superseded push run. Concurrency cancels in-progress runs
+for pull requests and for non-`master` branches; `master` is never cancelled.
+
+## Self-hosted (mesh) lanes
+
+`ci-mesh.yml` adds four **advisory, non-required** lanes that run on the
+maintainer's own hardware: `mesh-linux-x64-lite`, `mesh-linux-arm64-lite`,
+`mesh-macos-arm64-lite`, and `mesh-linux-x64-cuda-exec`. The last of these is the
+only lane in the repository that runs `run_gpu_tests.sh` against a **real** CUDA
+device — lanes 5, 6 and 14 above are compile-only, because hosted runners have no
+GPU. The whole workflow is off unless the repository variable `ESHKOL_MESH_CI` is
+`on` *and* a runner carrying the `eshkol` label is online, and none of its jobs is
+(or may become) a required status check. See
+[Self-hosted runners](SELF_HOSTED_RUNNERS.md).
+
+Other workflows: `pages.yml` (docs site), `release.yml` (release packaging),
+`gpu-execution-gate.yml` (real-GPU numeric diff, `[self-hosted, gpu]`),
+`adversarial-nightly.yml` (nightly P8 / TSan / packaging) and
+`identity-guard.yml` (commit-identity denylist).

--- a/docs/platform/SELF_HOSTED_RUNNERS.md
+++ b/docs/platform/SELF_HOSTED_RUNNERS.md
@@ -1,0 +1,326 @@
+# Self-hosted runners (the mesh)
+
+How to attach the maintainer's own machines to this repository as GitHub Actions
+runners, what each label means, and what changes once a runner is online.
+
+Everything here is something **only the repository owner can do** — registering a
+runner requires a registration token, which requires repo-admin rights. Nothing in
+this document is automatable from a pull request, by design.
+
+Related: [CI lanes](CI_LANES.md) · `.github/workflows/ci-mesh.yml` ·
+`.github/workflows/gpu-execution-gate.yml`
+
+---
+
+## 1. What this buys, and what it does not
+
+Two distinct wins, worth keeping separate because they have different risk profiles.
+
+**Capacity.** `ci.yml` runs a 14-lane matrix on GitHub-hosted runners. Moving the
+Linux and macOS *lite* lanes onto owned hardware returns those minutes to the pool
+for the lanes that genuinely need a clean disposable image (Windows SDK downloads,
+the ASan lane, the WASM diff).
+
+**Coverage that hosted runners structurally cannot provide.** The `linux-x64-cuda`,
+`linux-arm64-cuda` and `windows-x64-cuda` lanes in `ci.yml` run on hosted runners,
+and **hosted runners have no GPU**. `nvcc` compiles the kernels, `eshkol_gpu_init()`
+reports zero devices, and every GPU tensor op falls through to the CPU path without
+saying so. Those lanes are *compilation* gates. A registered GPU runner turns
+`gpu-execution-gate.yml` and `mesh-linux-x64-cuda-exec` into real *execution* gates
+— which is also how ADR-0010 gap **A13** closes: that workflow currently emits a
+`::warning` on every run saying it produced no GPU evidence, because no
+`[self-hosted, gpu]` runner has ever existed for this repo.
+
+**What it does not buy: a merge gate.** No job in `ci-mesh.yml` is, or may become,
+a required status check. See §6.
+
+---
+
+## 2. Label taxonomy
+
+GitHub applies three labels automatically at registration and they cannot be
+removed: `self-hosted`, an OS label (`Linux` / `macOS` / `Windows`), and an
+architecture label (`X64` / `ARM64` / `ARM`). Label matching is case-insensitive,
+which is why the workflows spell them lowercase.
+
+On top of those, this repository defines exactly four custom labels. Keep the set
+small: a label is a contract a lane relies on, and an unmet contract is a lane that
+either queues forever or lies.
+
+| label | meaning — assign it only if this is true | consumed by |
+|---|---|---|
+| `eshkol` | This runner is provisioned for **this repository's** build: LLVM 21, cmake, ninja, python3, and (Linux) `ld.lld`. Every mesh lane requires it. | `ci-mesh.yml` (all lanes), `mesh-preflight`'s online-runner probe |
+| `gpu` | The host has a **real, addressable GPU device** — not merely a GPU toolchain. `nvidia-smi` lists a device, or the host is Apple Silicon with a working Metal device. | `gpu-execution-gate.yml` (`runs-on: [self-hosted, gpu]`) |
+| `cuda` | The host has a CUDA device *and* `nvcc` on `PATH`. Implies `gpu`; assign both. | `mesh-linux-x64-cuda-exec` |
+| `metal` | Apple Silicon host with a working Metal device. Implies `gpu`; assign both. Reserved for a future Metal execution lane. | (none yet) |
+
+So a full label set looks like `--labels eshkol` for a plain build node, or
+`--labels eshkol,gpu,cuda` for the CUDA execution node.
+
+**Do not** assign `gpu` to a host that only has the CUDA *toolkit* installed. That
+is precisely the failure the GPU execution gate exists to expose, and a mislabelled
+runner would recreate it while looking green. The `Toolchain preflight` step in
+`ci-mesh.yml` fails a `cuda`-labelled runner that has no `nvidia-smi` device for
+this reason.
+
+---
+
+## 3. Which machines
+
+Measured against the mesh registry (`computer_mesh/nodes.json`) on 2026-08-25 by
+SSH probe, not assumed. Full survey and the raw per-node output live with the PR
+that introduced this document.
+
+| node | OS / arch | cores / RAM / free disk | GPU | suggested labels | provisioning still needed |
+|---|---|---|---|---|---|
+
+Every other node in the registry was unreachable at survey time: the GCP
+Blackwell/RTX-Pro nodes are stopped or spot-preempted, the on-prem boxes are
+this machine. That volatility is the reason for §6.
+
+---
+
+## 4. Provisioning a node
+
+Do this **before** registering the runner. The mesh lanes deliberately do not
+install anything: CI has no business mutating a machine you own, and self-installing
+would require handing the runner passwordless `sudo`.
+
+### Linux (Debian / Ubuntu)
+
+```bash
+# LLVM 21 from apt.llvm.org (adjust the distro codename)
+wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-21 main" \
+  | sudo tee /etc/apt/sources.list.d/llvm.list
+sudo apt-get update
+sudo apt-get install -y \
+  cmake ninja-build git python3 pkg-config \
+  llvm-21 llvm-21-dev lld-21 \
+  libreadline-dev libssl-dev libncurses-dev \
+  libpcre2-dev libsqlite3-dev libpng-dev libjpeg-dev libwebp-dev
+```
+
+`-fuse-ld=lld` looks for an unversioned `ld.lld`. `ci-mesh.yml` shims it into the
+runner's own `PATH` rather than symlinking into `/usr/bin` with sudo, so nothing
+further is needed — but a system-wide `sudo ln -sf /usr/bin/ld.lld-21 /usr/bin/ld.lld`
+is harmless if you prefer it.
+
+For a `cuda` node, additionally confirm **both** of these answer:
+
+```bash
+nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader
+nvcc --version
+```
+
+### macOS
+
+```bash
+brew install llvm@21 cmake ninja readline pcre2 sqlite
+```
+
+### Verify the toolchain the way CI will
+
+```bash
+git clone https://github.com/tsotchke/eshkol && cd eshkol
+cmake -S . -B build-check -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DESHKOL_REQUIRED_LLVM_MAJOR=21 \
+  -DLLVM_CONFIG_EXECUTABLE="$(command -v llvm-config-21 || echo /opt/homebrew/opt/llvm@21/bin/llvm-config)"
+cmake --build build-check --parallel
+./scripts/run_all_tests.sh
+```
+
+If that passes by hand, the mesh lane will pass. If it does not, fix it here — a
+runner registered against a broken toolchain produces red lanes that look like code
+regressions.
+
+---
+
+## 5. Registering the runner
+
+### 5.1 Get a registration token
+
+Registration tokens are **single-use and expire in one hour**. Get a fresh one per
+node.
+
+- Web: **Settings → Actions → Runners → New self-hosted runner**, and copy the
+  token out of the `./config.sh` line the page shows.
+- CLI (needs repo-admin scope):
+  ```bash
+  gh api -X POST repos/tsotchke/eshkol/actions/runners/registration-token --jq .token
+  ```
+
+### 5.2 Install and configure
+
+Pick a directory that is **not** inside a checkout of this repo and has room for
+the build trees (25 GiB minimum, 30 GiB for the CUDA lane).
+
+```bash
+mkdir -p ~/actions-runner && cd ~/actions-runner
+
+# Linux x64 — swap the asset for linux-arm64 / osx-arm64 / win-x64 as needed.
+# Check https://github.com/actions/runner/releases for the current version.
+RUNNER_VERSION=2.330.0
+curl -o runner.tar.gz -L \
+  "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+tar xzf runner.tar.gz && rm runner.tar.gz
+
+./config.sh \
+  --url https://github.com/tsotchke/eshkol \
+  --token <REGISTRATION_TOKEN> \
+  --labels eshkol,gpu,cuda \
+  --work _work \
+  --unattended \
+  --replace
+```
+
+- `--name` — use the mesh node name. It is how you will tell runners apart in the
+  Settings UI and in `gh api .../actions/runners`.
+- `--labels` — from §2. Custom labels only; `self-hosted`, the OS and the arch are
+  added for you.
+- `--replace` — makes re-registering the same node idempotent.
+- `--unattended` — no interactive prompts.
+
+macOS uses the identical `./config.sh`; Windows uses `./config.cmd` with the same
+flags.
+
+### 5.3 Install as a service
+
+A runner started from a shell dies with the shell. Install it as a service so it
+survives reboots:
+
+```bash
+# Linux (systemd)
+sudo ./svc.sh install
+sudo ./svc.sh start
+sudo ./svc.sh status
+
+# macOS (launchd) — no sudo
+./svc.sh install
+./svc.sh start
+./svc.sh status
+```
+
+On Windows, `./config.cmd` offers to install the service during configuration;
+answer yes.
+
+> `nix-shell nix/jetson/shell.nix` or it will have no CUDA device. Either wrap the
+
+### 5.4 Turn the mesh lanes on
+
+`ci-mesh.yml` ships **off**. After at least one runner is online:
+
+```bash
+gh variable set ESHKOL_MESH_CI --repo tsotchke/eshkol --body on
+```
+
+`gpu-execution-gate.yml` needs no variable — it dispatches to `[self-hosted, gpu]`
+as soon as such a runner exists.
+
+---
+
+## 6. What must NOT change
+
+**No job in `ci-mesh.yml` may be added to branch protection's required contexts.**
+
+The required set is, and stays: `guard`, `linux-x64-xla`, `linux-arm64-xla`,
+`linux-x64-cuda`, `linux-arm64-cuda`, `linux-x64-asan-ubsan`, `wasm-execute-diff`,
+`windows-arm64-xla`, `windows-x64-cuda` — all hosted.
+
+The reason is mechanical, not conservative. Branch protection has no timeout: a
+required context that never reports leaves the PR blocked forever, and the only
+recovery is an admin editing the protection rule. This repository has already paid
+that price once, on PR #444. A required context whose runner is one physical machine
+inherits that machine's availability — and §3 measured this fleet directly: most of
+it is off at any given moment, and every datacenter-GPU node in it is a preemptible
+spot instance.
+
+This is also why the mesh lanes live in their own workflow rather than as a
+"prefer self-hosted, fall back to hosted" matrix inside `ci.yml`. **That fallback
+does not exist in GitHub Actions.** `runs-on` is resolved at schedule time; a job
+whose labels match no online runner does not fail over to a hosted runner, it
+queues. Making a required lane's `runs-on` depend on fleet state would convert every
+mesh outage into a permanently pending required check. Separate job names in a
+separate file make that mistake structurally impossible.
+
+Promoting a mesh lane to required is a deliberate maintainer decision that requires,
+at minimum: the runner demonstrably online across a sustained period, and a plan for
+what happens to open PRs when it is not.
+
+---
+
+## 7. Security
+
+A self-hosted runner executes whatever a workflow tells it to, on a machine you own,
+on your network, **with a filesystem that persists between jobs**. On a public
+repository that is a real exposure: a pull request from a fork can modify the very
+workflow that tests it, so a fork PR reaching a self-hosted runner is arbitrary code
+execution on your hardware, and anything it leaves on disk is visible to the next
+job.
+
+Controls, in order of load-bearing-ness:
+
+1. **Fork PRs never reach the mesh.** Every job in `ci-mesh.yml` carries
+   `if: github.event.pull_request.head.repo.full_name == github.repository`
+   (via the `mesh-preflight` gate that all lanes depend on). This is implemented and
+   is the control that actually matters — it does not depend on anyone remembering a
+   setting.
+2. **Require approval for all outside collaborators.** Settings → Actions → General →
+   *Fork pull request workflows from outside collaborators*. GitHub's default is
+   "require approval for first-time contributors", which still lets a contributor's
+   *second* PR run without review. Set it to **all outside collaborators**.
+3. **Never put secrets on a mesh lane.** None of the mesh lanes consume repository
+   secrets, and none should; a persistent filesystem plus a long-lived machine is a
+   poor place for them.
+4. **Ephemeral-ish workspace.** Each lane's final step removes its build tree, and
+   the disk-budget step fails early rather than filling the node. For stronger
+   isolation, register with `--ephemeral` so the runner deregisters after one job and
+   is re-registered by a supervising script — at the cost of losing warm build state.
+
+---
+
+## 8. Verifying, and backing out
+
+```bash
+# Is it registered and online, and with which labels?
+gh api repos/tsotchke/eshkol/actions/runners \
+  --jq '.runners[] | {name, status, labels: [.labels[].name]}'
+
+# Force one run without waiting for a PR
+gh workflow run ci-mesh.yml --repo tsotchke/eshkol
+gh run list --workflow ci-mesh.yml --repo tsotchke/eshkol --limit 5
+
+# The GPU gate specifically (this is what closes ADR-0010 A13)
+gh workflow run gpu-execution-gate.yml --repo tsotchke/eshkol
+```
+
+A healthy first run shows `mesh-preflight` reporting the online runner count, then
+each mesh lane picking up on the node you expect. If a lane sits queued, its labels
+match no online runner — compare the job's `runs-on` list against the `labels` in
+the `gh api` output above.
+
+### Turning it off
+
+```bash
+# Softest: stop dispatching, leave the runners registered.
+gh variable set ESHKOL_MESH_CI --repo tsotchke/eshkol --body off
+```
+
+```bash
+# Full deregistration, on the node:
+cd ~/actions-runner
+sudo ./svc.sh stop && sudo ./svc.sh uninstall     # omit sudo on macOS
+./config.sh remove --token <REMOVAL_TOKEN>
+```
+
+Get the removal token from **Settings → Actions → Runners → (runner) → Remove**, or:
+
+```bash
+gh api -X POST repos/tsotchke/eshkol/actions/runners/remove-token --jq .token
+```
+
+If the machine is gone and cannot be cleaned up locally, delete the registration
+from the Settings → Actions → Runners page instead. Because nothing in the required
+set depends on a mesh runner, removing one at any time is safe: the mesh lanes stop
+reporting and no PR is affected.


### PR DESCRIPTION
## Summary

Three CI changes, in priority order.

**1. End duplicate matrix runs.** `feat/**` was in the `push` trigger while PR events already cover those branches, so every PR from a `feat/*` branch ran the full matrix twice. Removed from the push trigger; `master` and `develop` push coverage retained.

**2. Harden the `changes` gate.** The docs-only gate could fail with `fatal: bad object <sha>` (exit 128) when a PR branch was force-pushed mid-run, orphaning the SHA it diffed against. Because every heavy job has `needs: changes`, that failure blocked the entire run rather than skipping it. The gate now computes changed files robustly and **fails safe**: if the diff cannot be computed it sets `docs_only=false` (run everything — the conservative answer) and emits a warning, instead of exiting non-zero.

**3. Self-hosted runner support, opt-in and safe by default.** Adds `ci-mesh.yml` gated on a repository variable, so hosted lanes are unaffected until an operator explicitly enables it. Self-hosted jobs are restricted to non-fork PRs (`github.event.pull_request.head.repo.full_name == github.repository`) because self-hosted runners on a public repository would otherwise execute untrusted code from forks. Short `timeout-minutes` so a job cannot hang when no runner is registered. **No currently-required hosted lane is removed, weakened, or made conditional.**

Runner labels are defined by capability (os / arch / gpu / toolchain), not by machine. The operator maintains the node-to-label mapping privately; `docs/platform/SELF_HOSTED_RUNNERS.md` documents the label taxonomy and the registration procedure.

## Verification

- Workflows validate; `changes` resolves correctly and the matrix fans out as expected on a non-docs change.
- Hosted lanes run and pass exactly as before.
- ICC: `guard-diff` and `pre-commit-check` PASS (expected protected-path warning on `ci.yml`).
