### PR TITLE
fix(xla): remove eshkol_tensor ODR violation in xla_runtime.cpp

### DIFF
--- a/docs/breakdown/XLA_BACKEND.md
+++ b/docs/breakdown/XLA_BACKEND.md
@@ -93,8 +93,9 @@ or JIT contexts.
 
 ### 3.1 Core Struct
 
-Tensors in the XLA runtime are represented by `eshkol_tensor_t`
-(`lib/backend/xla/xla_runtime.cpp`):
+Tensors in the XLA runtime are represented by the canonical `eshkol_tensor_t`
+defined in `lib/core/arena_memory.h` and included directly by
+`lib/backend/xla/xla_runtime.cpp` (it does not declare its own copy):
 
 ```c
 typedef struct eshkol_tensor {
@@ -102,6 +103,7 @@ typedef struct eshkol_tensor {
     uint64_t  num_dimensions; // idx 1: rank (0 = scalar, 1 = 1-D, 2 = matrix, ...)
     int64_t*  elements;       // idx 2: doubles stored as int64 bit patterns
     uint64_t  total_elements; // idx 3: product of all dimensions
+    uint64_t  dtype;          // idx 4: eshkol_tensor_dtype_t (0 = f64, the default)
 } eshkol_tensor_t;
 ```
 
@@ -109,6 +111,14 @@ The struct is laid out contiguously in arena memory immediately after an 8-byte 
 (which stores `HEAP_SUBTYPE_TENSOR`). The object header sits at `ptr - 8` relative to the
 tensor struct pointer; this is how `vector-for-each` and similar operations distinguish tensors
 from heterogeneous vectors at runtime.
+
+Every `eshkol_xla_*` entry point in `xla_runtime.cpp` operates purely on `double` data (via the
+BLAS/SIMD/GPU cascade) and explicitly sets `result->dtype = ESHKOL_TENSOR_DTYPE_F64` on every
+tensor it allocates, rather than relying only on `arena_allocate_tensor_full`'s own default.
+`xla_runtime.cpp` carries a `static_assert(sizeof(eshkol_tensor_t) == 40, ...)` immediately after
+including `arena_memory.h`, so a future divergent re-typedef of `struct eshkol_tensor` in that
+file — the historical bug this note used to describe — fails the build instead of silently
+truncating tensors.
 
 ### 3.2 int64 Bit Pattern Encoding
 
@@ -127,19 +137,21 @@ elements can be compared and hashed as integers when needed.
 
 ### 3.3 Arena Allocation
 
-All tensors are allocated from the Eshkol arena via `arena_allocate_tensor_full`:
+All tensors are allocated from the Eshkol arena via `arena_allocate_tensor_full`
+(`lib/core/arena_memory.h` / `lib/core/runtime_tensor_alloc.cpp`), called from `xla_runtime.cpp`
+with the `void* arena` XLA entry points cast to `arena_t*`:
 
 ```c
-extern "C" eshkol_tensor_t* arena_allocate_tensor_full(
-    void* arena, uint64_t num_dims, uint64_t total_elements);
-// lib/backend/xla/xla_runtime.cpp
+eshkol_tensor_t* arena_allocate_tensor_full(
+    arena_t* arena, uint64_t num_dims, uint64_t total_elements);
+// lib/core/arena_memory.h
 ```
 
 This function allocates a single contiguous block containing:
 
 ```
 [8-byte header: HEAP_SUBTYPE_TENSOR tag]
-[eshkol_tensor_t struct: 32 bytes]
+[eshkol_tensor_t struct: 40 bytes]
 [dimensions array: num_dims * 8 bytes]
 [elements array: total_elements * 8 bytes]
 ```

--- a/lib/backend/xla/xla_runtime.cpp
+++ b/lib/backend/xla/xla_runtime.cpp
@@ -38,23 +38,47 @@ static void ensure_gpu_initialized() {
     });
 }
 
-// Arena allocation functions
-extern "C" void* arena_allocate_aligned(void* arena, size_t size, size_t alignment);
+// Canonical tensor type + arena allocator.
+//
+// This file used to carry its own forward-declared copy of `struct
+// eshkol_tensor` (4 fields, 32 bytes) instead of including the canonical
+// definition in arena_memory.h (5 fields, 40 bytes — dtype was added at idx 4
+// after this file was written and never updated to match). That is an ODR
+// violation: the same struct tag with two different definitions in the same
+// program. It stayed latent here only because every use in this file goes
+// through pointers returned by arena_allocate_tensor_full — whose real,
+// canonical 40-byte layout is what actually gets allocated — with no
+// by-value copy or local sizeof(eshkol_tensor_t)/eshkol_tensor_t-on-the-stack
+// use in this file. It also meant `->dtype` could never be set here, so
+// every XLA result silently depended on arena_allocate_tensor_full's default
+// rather than this file asserting its own dtype.
+//
+// There is no header-cycle or C/C++ linkage reason to avoid the canonical
+// header: it is extern "C"-wrapped throughout and already included from
+// other lib/backend/*.cpp translation units (collection_codegen.cpp,
+// llvm_codegen.cpp, parallel_codegen.cpp, tensor_backward.cpp,
+// tensor_conv_kernel.cpp, thread_pool.cpp). Including it here instead of
+// re-declaring removes the divergent copy outright.
+#include "../../core/arena_memory.h"
 
-// Forward-declare the canonical tensor type and allocator from arena_memory.h
-// struct eshkol_tensor { uint64_t* dimensions, uint64_t num_dimensions,
-//                        int64_t* elements, uint64_t total_elements }
-// arena_allocate_tensor_full allocates tensor struct WITH object header
-// (HEAP_SUBTYPE_TENSOR at ptr-8) + dimensions array + elements array
-typedef struct eshkol_tensor {
-    uint64_t* dimensions;     // idx 0: dimension sizes array
-    uint64_t  num_dimensions; // idx 1: rank
-    int64_t*  elements;       // idx 2: doubles as int64 bit patterns
-    uint64_t  total_elements; // idx 3: product of all dimensions
-} eshkol_tensor_t;
+// Compile-time guard: if this TU's view of eshkol_tensor_t is ever no longer
+// the canonical (dtype-bearing) one — e.g. a local re-typedef creeps back
+// in, or arena_memory.h's own layout assert is bypassed for this TU — fail
+// the build here rather than silently truncating tensors allocated by
+// arena_allocate_tensor_full.
+static_assert(sizeof(eshkol_tensor_t) == 40,
+    "xla_runtime.cpp must use the canonical, dtype-bearing eshkol_tensor_t "
+    "from arena_memory.h (4 core fields + dtype) — do not reintroduce a "
+    "local re-typedef of struct eshkol_tensor");
 
-extern "C" eshkol_tensor_t* arena_allocate_tensor_full(
-    void* arena, uint64_t num_dims, uint64_t total_elements);
+// All eshkol_xla_* entry points below dispatch to the BLAS/SIMD/GPU f64
+// kernels above and only ever read/write `double` data — none of them
+// produce or consume reduced-precision (f32/f16/bf16) or dual-number tensor
+// storage. So every tensor allocated or mutated in this file is logically
+// f64 (ESHKOL_TENSOR_DTYPE_F64). arena_allocate_tensor_full's header
+// allocator already defaults a fresh tensor's dtype to F64, but each
+// function below sets `result->dtype` explicitly too, so this file's
+// correctness does not depend on that default.
 
 // XLA matmul runtime function - called by generated LLVM IR
 // Performs matrix multiplication using the existing BLAS/SIMD backend
@@ -91,8 +115,9 @@ extern "C" void* eshkol_xla_matmul(
 
     // Allocate result tensor with object header (HEAP_SUBTYPE_TENSOR)
     // arena_allocate_tensor_full gives us: header + tensor struct + dims + elements
-    eshkol_tensor_t* result = arena_allocate_tensor_full(arena, 2, M * N);
+    eshkol_tensor_t* result = arena_allocate_tensor_full(reinterpret_cast<arena_t*>(arena), 2, M * N);
     if (!result) return nullptr;
+    result->dtype = ESHKOL_TENSOR_DTYPE_F64;
 
     // Set dimension sizes
     result->dimensions[0] = M;
@@ -145,8 +170,9 @@ extern "C" void* eshkol_xla_elementwise(
     if (total_elements <= 0 || !a_data) return nullptr;
 
     eshkol_tensor_t* result = arena_allocate_tensor_full(
-        arena, static_cast<uint64_t>(rank), static_cast<uint64_t>(total_elements));
+        reinterpret_cast<arena_t*>(arena), static_cast<uint64_t>(rank), static_cast<uint64_t>(total_elements));
     if (!result) return nullptr;
+    result->dtype = ESHKOL_TENSOR_DTYPE_F64;
 
     // Copy shape
     for (int64_t i = 0; i < rank; i++) {
@@ -249,8 +275,9 @@ extern "C" void* eshkol_xla_reduce(
 
     if (axis == -1) {
         // Reduce all — result is a scalar tensor (rank 1, 1 element)
-        eshkol_tensor_t* result = arena_allocate_tensor_full(arena, 1, 1);
+        eshkol_tensor_t* result = arena_allocate_tensor_full(reinterpret_cast<arena_t*>(arena), 1, 1);
         if (!result) return nullptr;
+        result->dtype = ESHKOL_TENSOR_DTYPE_F64;
         result->dimensions[0] = 1;
 
         double* out = reinterpret_cast<double*>(result->elements);
@@ -325,8 +352,9 @@ extern "C" void* eshkol_xla_reduce(
     }
     if (j == 0) { out_dims[0] = 1; out_total = 1; }
 
-    eshkol_tensor_t* result = arena_allocate_tensor_full(arena, out_rank, out_total);
+    eshkol_tensor_t* result = arena_allocate_tensor_full(reinterpret_cast<arena_t*>(arena), out_rank, out_total);
     if (!result) return nullptr;
+    result->dtype = ESHKOL_TENSOR_DTYPE_F64;
     for (uint64_t i = 0; i < out_rank; i++) result->dimensions[i] = out_dims[i];
 
     double* out = reinterpret_cast<double*>(result->elements);
@@ -418,8 +446,9 @@ extern "C" void* eshkol_xla_softmax(
 
     // Allocate result tensor with same shape
     uint64_t out_rank = static_cast<uint64_t>(rank);
-    eshkol_tensor_t* result = arena_allocate_tensor_full(arena, out_rank, static_cast<uint64_t>(total_elements));
+    eshkol_tensor_t* result = arena_allocate_tensor_full(reinterpret_cast<arena_t*>(arena), out_rank, static_cast<uint64_t>(total_elements));
     if (!result) return nullptr;
+    result->dtype = ESHKOL_TENSOR_DTYPE_F64;
     for (int64_t i = 0; i < rank; i++) result->dimensions[i] = shape[i];
 
     double* out = reinterpret_cast<double*>(result->elements);
@@ -530,9 +559,10 @@ extern "C" void* eshkol_xla_normalize(
     if (axis < 0 || axis >= rank) return nullptr;
 
     // Allocate result tensor with same shape
-    eshkol_tensor_t* result = arena_allocate_tensor_full(arena,
+    eshkol_tensor_t* result = arena_allocate_tensor_full(reinterpret_cast<arena_t*>(arena),
         static_cast<uint64_t>(rank), static_cast<uint64_t>(total_elements));
     if (!result) return nullptr;
+    result->dtype = ESHKOL_TENSOR_DTYPE_F64;
     for (int64_t i = 0; i < rank; i++) result->dimensions[i] = shape[i];
 
     double* out = reinterpret_cast<double*>(result->elements);
@@ -605,8 +635,9 @@ extern "C" void* eshkol_xla_argreduce(
 
     if (axis == -1) {
         // Argreduce all — return scalar tensor with flattened index as double
-        eshkol_tensor_t* result = arena_allocate_tensor_full(arena, 1, 1);
+        eshkol_tensor_t* result = arena_allocate_tensor_full(reinterpret_cast<arena_t*>(arena), 1, 1);
         if (!result) return nullptr;
+        result->dtype = ESHKOL_TENSOR_DTYPE_F64;
         result->dimensions[0] = 1;
 
         int64_t best_idx = 0;
@@ -638,8 +669,9 @@ extern "C" void* eshkol_xla_argreduce(
     }
     if (j == 0) { out_dims[0] = 1; out_total = 1; }
 
-    eshkol_tensor_t* result = arena_allocate_tensor_full(arena, out_rank, out_total);
+    eshkol_tensor_t* result = arena_allocate_tensor_full(reinterpret_cast<arena_t*>(arena), out_rank, out_total);
     if (!result) return nullptr;
+    result->dtype = ESHKOL_TENSOR_DTYPE_F64;
     for (uint64_t i = 0; i < out_rank; i++) result->dimensions[i] = out_dims[i];
 
     double* out = reinterpret_cast<double*>(result->elements);
@@ -689,8 +721,9 @@ extern "C" void* eshkol_xla_reduce_gradient(
     if (!grad_data || !input_data || total_input <= 0) return nullptr;
 
     eshkol_tensor_t* result = arena_allocate_tensor_full(
-        arena, static_cast<uint64_t>(input_rank), static_cast<uint64_t>(total_input));
+        reinterpret_cast<arena_t*>(arena), static_cast<uint64_t>(input_rank), static_cast<uint64_t>(total_input));
     if (!result) return nullptr;
+    result->dtype = ESHKOL_TENSOR_DTYPE_F64;
     for (int64_t i = 0; i < input_rank; i++) {
         result->dimensions[i] = input_shape[i];
     }
@@ -827,8 +860,9 @@ extern "C" void* eshkol_xla_transpose(
     }
 
     eshkol_tensor_t* result = arena_allocate_tensor_full(
-        arena, static_cast<uint64_t>(rank), total);
+        reinterpret_cast<arena_t*>(arena), static_cast<uint64_t>(rank), total);
     if (!result) return nullptr;
+    result->dtype = ESHKOL_TENSOR_DTYPE_F64;
     for (int64_t i = 0; i < rank; i++) result->dimensions[i] = out_shape[i];
 
     double* out = reinterpret_cast<double*>(result->elements);
@@ -924,8 +958,9 @@ extern "C" void* eshkol_xla_broadcast(
     for (int64_t i = 0; i < tgt_rank; i++) total *= tgt_shape[i];
 
     eshkol_tensor_t* result = arena_allocate_tensor_full(
-        arena, static_cast<uint64_t>(tgt_rank), total);
+        reinterpret_cast<arena_t*>(arena), static_cast<uint64_t>(tgt_rank), total);
     if (!result) return nullptr;
+    result->dtype = ESHKOL_TENSOR_DTYPE_F64;
     for (int64_t i = 0; i < tgt_rank; i++) result->dimensions[i] = tgt_shape[i];
 
     double* out = reinterpret_cast<double*>(result->elements);
@@ -994,8 +1029,9 @@ extern "C" void* eshkol_xla_slice(
     }
 
     eshkol_tensor_t* result = arena_allocate_tensor_full(
-        arena, static_cast<uint64_t>(rank), total);
+        reinterpret_cast<arena_t*>(arena), static_cast<uint64_t>(rank), total);
     if (!result) return nullptr;
+    result->dtype = ESHKOL_TENSOR_DTYPE_F64;
     for (int64_t i = 0; i < rank; i++) result->dimensions[i] = out_shape[i];
 
     double* out = reinterpret_cast<double*>(result->elements);

--- a/tests/xla/xla_codegen_test.cpp
+++ b/tests/xla/xla_codegen_test.cpp
@@ -77,6 +77,14 @@ struct EshkolTensor {
     uint64_t  total_elements; // idx 3: product of all dimensions
 };
 
+// Dtype accessor (defined in lib/core/runtime_tensor_dtype.cpp) — the one
+// dtype-consuming path exercised by test_xla_result_dtype_roundtrip below.
+// ESHKOL_TENSOR_DTYPE_F64 == 0 (lib/core/arena_memory.h: eshkol_tensor_dtype_t);
+// referenced here as a plain constant rather than re-declaring the enum, to
+// avoid adding yet another divergent copy of tensor-related types to this TU.
+extern "C" int64_t eshkol_tensor_dtype_code(void* tensor_ptr);
+constexpr int64_t kDtypeF64 = 0;
+
 // Global test arena
 static arena_t* g_test_arena = nullptr;
 
@@ -182,6 +190,39 @@ bool test_xla_matmul_2x2() {
         TEST_ASSERT_NEAR(read_element(tensor, i), expected[i], 1e-10,
             "Result value mismatch at index " + std::to_string(i));
     }
+
+    std::cout << "PASS" << std::endl;
+    return true;
+}
+
+// ===== Test: XLA Result Dtype Round-Trip =====
+// Regression for the eshkol_tensor ODR bug (xla_runtime.cpp used to carry a
+// forward-declared 4-field/32-byte copy of `struct eshkol_tensor` that
+// diverged from arena_memory.h's canonical 5-field/40-byte, dtype-bearing
+// definition, so `->dtype` could never be set from this file). This exercises
+// the dtype end-to-end through the one dtype-consuming ABI path available
+// (eshkol_tensor_dtype_code) against a tensor the XLA runtime actually
+// produced, rather than just inspecting field offsets.
+bool test_xla_result_dtype_roundtrip() {
+    std::cout << "Test: XLA Result Dtype Round-Trip... ";
+
+    double a_data[] = {1.0, 2.0, 3.0, 4.0};
+    double b_data[] = {5.0, 6.0, 7.0, 8.0};
+    int64_t a_shape[] = {2, 2};
+    int64_t b_shape[] = {2, 2};
+
+    void* result = eshkol_xla_matmul(
+        g_test_arena,
+        a_data, b_data,
+        a_shape, b_shape,
+        2, 2);
+
+    TEST_ASSERT(result != nullptr, "Matmul should return non-null result");
+
+    int64_t dtype = eshkol_tensor_dtype_code(result);
+    TEST_ASSERT(dtype == kDtypeF64,
+        "XLA matmul result dtype must round-trip as F64 (0) through "
+        "eshkol_tensor_dtype_code");
 
     std::cout << "PASS" << std::endl;
     return true;
@@ -451,6 +492,7 @@ int main() {
 
     // Matmul tests
     run_test(test_xla_matmul_2x2);
+    run_test(test_xla_result_dtype_roundtrip);
     run_test(test_xla_matmul_3x2_2x4);
     run_test(test_xla_matmul_dim_mismatch);
     run_test(test_xla_matmul_invalid_rank);


### PR DESCRIPTION
## Summary

- `lib/backend/xla/xla_runtime.cpp` forward-declared its own copy of `struct eshkol_tensor` (4 fields, 32 bytes) instead of including the canonical definition in `lib/core/arena_memory.h` (5 fields, 40 bytes — `dtype` was added at idx 4 after this file was written and never updated to match). Two non-identical definitions of the same struct tag linked into one program is a One Definition Rule (ODR) violation.
- `icc odr-audit` on current master (`e65cb5b5`) confirms it: **2 high-severity collisions** (`eshkol_tensor`, `eshkol_tensor_t`), first divergent member `<missing> ↔ uint64_t dtype`. After this fix: **0 high**, findings 18→16 (the 16 remaining `medium` findings are pre-existing, unrelated struct-name collisions elsewhere in the tree, unchanged by this PR).
- Fix: include `arena_memory.h` directly (six other `lib/backend/*.cpp` TUs already do), cast the `void* arena` XLA entry points take to `arena_t*` at each of the 12 `arena_allocate_tensor_full` call sites, set `result->dtype = ESHKOL_TENSOR_DTYPE_F64` explicitly on every tensor this file allocates (previously impossible — the local struct had no `dtype` field to set), and add a `static_assert(sizeof(eshkol_tensor_t) == 40, ...)` so a future re-typedef fails the build instead of silently drifting again.
- Adds a regression test, `test_xla_result_dtype_roundtrip`, that drives an actual XLA-produced tensor (from `eshkol_xla_matmul`) through `eshkol_tensor_dtype_code()` to verify F64 round-trips end-to-end, not just a field-offset check.
- Updates `docs/breakdown/XLA_BACKEND.md` to describe the canonical include instead of the removed local typedef, and to correct the documented struct/allocator signatures (32→40 bytes, `void*`→`arena_t*`).

## Why this doesn't need a SILENT-WRONG ledger entry

The `.icc/silent-wrong-ledger.yaml` contract requires a SILENT-WRONG entry when "the compiler, the VM, or the runtime produces a wrong value, a wrong derivative, or a wrong memory outcome with no diagnostic." This defect doesn't currently meet that bar: every access in this file goes through pointers returned by `arena_allocate_tensor_full`, which already defaults a fresh tensor's `dtype` to `ESHKOL_TENSOR_DTYPE_F64` in `arena_allocate_tensor_with_header` (`lib/core/runtime_tensor_alloc.cpp`) regardless of this file's stale local type — there is no `sizeof(eshkol_tensor_t)` use, by-value copy, or stack instance of the local type anywhere in the file. So no wrong value has ever actually been observed at runtime; this was a real, ICC-flagged ODR/UB defect (ill-formed, no diagnostic required, per the C++ standard) fixed preventively before a future change (a by-value copy added here, or a change to the allocator's own default) could combine with it to become an active silent-wrong.

## Test plan

- [x] `-DESHKOL_XLA_ENABLED=ON`: full build green, `ctest -j6` 191/191 (1 unrelated transient failure — `eshkol-pkg-command-injection` — confirmed a flake by a clean rerun; machine was under heavy concurrent load from unrelated builds)
- [x] `-DESHKOL_XLA_ENABLED=OFF`: full build green, `ctest -j6` 191/191 (same story — `assoc_eval_test` flaked once, passed clean on rerun)
- [x] `./scripts/run_xla_tests.sh`: 14/14 (12 C++ unit tests incl. the new dtype round-trip test, plus the `.esk`-level XLA test suite)
- [x] `icc odr-audit --repo eshkol`: high-severity findings 2 → 0 for `eshkol_tensor`/`eshkol_tensor_t`
- [x] ICC gates: `guard-diff --staged` (0 violations), `pre-commit-check` (PASS), `check_oracle_schema.py`, `check_ledger_integrity.py` (PASS, 88 entries), `gate_no_silent_wrong.py` (PASS, no open SILENT-WRONG)

Base flags used for both builds: `-G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLLVM_CONFIG_EXECUTABLE=/opt/homebrew/opt/llvm@21/bin/llvm-config -DBUILD_TESTING=ON -DESHKOL_BUILD_TESTS=ON -DESHKOL_BUILD_AGENT_FFI=ON -DESHKOL_FIXED_POINT_ENGINE=ON -DESHKOL_GPU_ENABLED=ON -DESHKOL_QUANTUM_ENABLED=OFF`, XLA lane toggled via `-DESHKOL_XLA_ENABLED`.