### PR TITLE
fix(ad): structural carrier gate, and exact divergence/curl on the VM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,6 +300,7 @@ jobs:
           python3 scripts/check_oracle_schema.py --self-test
           python3 scripts/audit_oracle_false_green.py --self-test
           python3 scripts/check_evidence_staleness.py --self-test
+          python3 scripts/gate_ad_shared_node_model.py --self-test
 
       - name: No open, unwaived SILENT-WRONG flaw ships
         shell: bash
@@ -320,6 +321,17 @@ jobs:
       - name: No high-severity criterion's evidence is stale (ADR-0010 A13)
         shell: bash
         run: python3 scripts/check_evidence_staleness.py --no-trace
+
+      # Structural, not comparative. The VM-parity differential compares
+      # program output between engines, so two independent AD implementations
+      # agree and it stays green (SW-52); INV-ad-exact-no-finite-differences
+      # checks that an exact constructor is present on the native engine, never
+      # that a finite difference is absent on either (SW-51). This step asks
+      # the question neither could: which carrier actually answers each AD op,
+      # re-derived from the source rather than declared.
+      - name: Every AD op routes through a declared, exact, source-verified carrier
+        shell: bash
+        run: python3 scripts/gate_ad_shared_node_model.py --no-trace
 
   # Moonlab is deliberately opt-in, so keep its networked macOS coverage in a
   # separate advisory job. `continue-on-error` makes the lane informative

--- a/.icc/ad-carrier-manifest.yaml
+++ b/.icc/ad-carrier-manifest.yaml
@@ -1,0 +1,336 @@
+# AD carrier manifest — the structural gate's input.
+#
+# CONTRACT
+#   Eshkol differentiates on more than one substrate. This file is the single
+#   place that says, for every high-level AD operator, WHICH DIFFERENTIATION
+#   CARRIER each substrate uses and whether that carrier is exact. It exists
+#   because the property "the VM and the native backend agree" was previously
+#   asserted only by comparing PROGRAM OUTPUT between the two engines, and an
+#   output comparison is structurally incapable of noticing that the two
+#   answers were produced by two independent implementations — or that one of
+#   them reached its answer by perturbing the input.
+#
+#   `scripts/gate_ad_shared_node_model.py` grades this file. It does NOT
+#   trust a single declaration in it: every `carrier:` claim is re-derived
+#   from the named source by extracting the operator's implementation block
+#   and classifying which carrier symbols it actually touches. A row that
+#   says `vm-dual-forward` over a body that performs a difference quotient is
+#   a FAIL, not a description. You cannot fix the gate by editing the
+#   manifest.
+#
+# INVARIANTS
+#   1. Every AD operator row in tests/vm_parity/PARITY.tsv is covered here,
+#      and every parity row named here exists there. Promoting an AD op to
+#      `vm-supported` without declaring its carrier fails the gate.
+#   2. A `vm-supported` parity row requires an EXACT carrier. Finite
+#      differences may never back a vm-supported AD op.
+#   3. `forked_carrier_budget` is a SHRINK-ONLY ratchet on the number of
+#      operators whose VM carrier is not the shared node model. It records
+#      the size of the fork, caps it, and is lowered — never raised — as the
+#      unification lands. Raising it requires a maintainer ruling in the PR
+#      body.
+#   4. Every finite-difference difference-quotient site inside `fd_scan.paths`
+#      must appear in `fd_allowlist` with an owner, the op it serves, and a
+#      justification. An FD site that is not ledgered is a FAIL.
+#   5. `fd_scan.paths` may not shrink below the union of every file named by
+#      an operator row. Deleting a file from the scan set to silence a finding
+#      fails the coverage check.
+
+schema: eshkol.ad_carrier_manifest.v1
+generated_at: "2026-08-25"
+measured_at_sha: "e65cb5b5"
+measured_with: "build/eshkol-run + build/eshkol-vm-standalone-test (RelWithDebInfo, LLVM 21, arm64-apple-darwin24.1.0)"
+
+# ── Carrier vocabulary ────────────────────────────────────────────────────
+#
+# `exact: true` means the carrier propagates a derivative by the chain rule
+# and returns the derivative the mathematics defines, to within floating-point
+# rounding of the elementary operations. `exact: false` means the carrier
+# approximates the derivative by evaluating the function at perturbed points,
+# so its answer carries a truncation error that depends on a step size.
+#
+# `shared: true` means one implementation serves both substrates.
+
+carriers:
+  shared-node-model:
+    exact: true
+    shared: true
+    description: >-
+      The Wengert reverse tape in lib/backend/vm_autodiff.c (AdTape / AdNode /
+      AdOpType), exported for LLVM codegen at lib/backend/vm_autodiff.c and
+      reached from native Scheme through lib/core/ad_tape_builtins.c's
+      ad_tape_new_owned(). One implementation, both substrates.
+    witnesses: ['\bad_(?:tape_new|const|var|add|sub|mul|div|sin|cos|exp|log|sqrt|neg|abs|relu|sigmoid|tanh|backward|get_value|gradient)\s*\(']
+
+  native-ad-node:
+    exact: true
+    shared: false
+    description: >-
+      The typed reverse-mode graph declared in inc/eshkol/eshkol.h
+      (ad_node_t / ad_tape_t / ad_node_type_t, ~80 node types including
+      AD_NODE_CUSTOM), emitted by lib/backend/autodiff_codegen.cpp and run by
+      lib/core/runtime_autodiff.cpp. NATIVE ONLY — see fork_debt below.
+    witnesses: ['\bAD_NODE_[A-Z0-9_]+', '\barena_allocate_ad_node\w*\s*\(']
+
+  native-jet:
+    exact: true
+    shared: false
+    description: >-
+      The native forward-mode jet with e1/e2/ep perturbation slots and a
+      Taylor tower (createDualNumber / makeDual8 / makeDual4 /
+      seedForwardAndPush in lib/backend/autodiff_codegen.cpp). NATIVE ONLY.
+    witnesses: ['\bseedForwardAndPush\w*\s*\(', '\bcreateDualNumber\s*\(', '\bmakeDual[48]\s*\(']
+
+  vm-dual-forward:
+    exact: true
+    shared: false
+    description: >-
+      The VM's flat forward dual VmDual {primal, tangent}
+      (lib/backend/vm_numeric.h, ops in lib/backend/vm_dual.c). One
+      perturbation, no nesting level, scalar only. VM ONLY — see fork_debt.
+    witnesses:
+      - '\bVM_AD_MAKE_DUAL\s*\('
+      - '\bvm_make_dual_val\s*\('
+      - '\bvm_dual_tangent_of\s*\('
+      - '\bvm_dual_(?:new|make|add|sub|mul|div|sin|cos|exp|log|sqrt|pow|abs|neg|relu|sigmoid|tanh|scale|from_double)\s*\('
+
+  vm-hyperdual-forward:
+    exact: true
+    shared: false
+    description: >-
+      The VM's second-order forward carrier VmHyperDual {f, f1, f2, f12}
+      (lib/backend/vm_hyperdual.c). VM ONLY — see fork_debt.
+    witnesses: ['\bVM_HD_MAKE\w*\s*\(', '\bvm_hd_make\s*\(']
+
+  finite-difference:
+    exact: false
+    shared: false
+    description: >-
+      Not a differentiation carrier at all: the derivative is approximated by
+      re-evaluating the function at perturbed points. Never permitted to back
+      an operator whose parity row reads vm-supported.
+    witnesses: []
+
+# ── Fork debt ─────────────────────────────────────────────────────────────
+#
+# The number of operator rows below whose `vm.carrier` is not
+# `shared-node-model`. SHRINK-ONLY. This is the honest size of the AD
+# implementation fork: each one is an operator the VM answers with its own
+# private carrier rather than the shared node model.
+#
+# Lowering it is the unification work. The blocking item is recorded in
+# fork_debt.blocked_on.
+
+fork_debt:
+  forked_carrier_budget: 9
+  blocked_on: >-
+    The VM has no dual-carrying tensor. VmTensor::data is a bare double*, so a
+    vector field that packs its components into a tensor drops every tangent at
+    construction. That single gap is why the VM's jacobian writes primals into
+    the derivative matrix for tensor-returning fields, and why divergence and
+    curl reached for a difference quotient in the first place. Closing it is a
+    tangent-carrying VmTensor plus the AD_CUSTOM tape extension sketched in
+    docs/reference/ad/architecture.md; until then the budget caps the fork at
+    its current size and this gate refuses to let it grow.
+
+# ── Operators ─────────────────────────────────────────────────────────────
+#
+# `vm.native_call_id` names the `case <id>:` block in `vm.file` that the gate
+# extracts and classifies. `vm.carrier` is CHECKED against that extraction,
+# not believed.
+
+operators:
+  - op: derivative
+    parity_rows: ["op:DERIVATIVE"]
+    native:
+      file: lib/backend/autodiff_codegen.cpp
+      carrier: native-jet
+    vm:
+      file: lib/backend/vm_native.c
+      native_call_id: 393
+      carrier: vm-dual-forward
+    notes: >-
+      First order only. A dual-valued point raises rather than fabricating a
+      zero (ESH-0369); exact points are native-only (ESH-0394). Both are
+      recorded on the PARITY row.
+
+  - op: diff
+    parity_rows: ["op:DIFF"]
+    native:
+      file: lib/backend/autodiff_codegen.cpp
+      carrier: native-jet
+    vm:
+      file: lib/backend/vm_native.c
+      native_call_id: 393
+      carrier: vm-dual-forward
+    notes: >-
+      Aliased to native call 393. Symbolic differentiation of a quoted
+      s-expression is unimplemented on the VM and raises (SW-06).
+
+  - op: gradient
+    parity_rows: ["op:GRADIENT", "gradient"]
+    native:
+      file: lib/backend/autodiff_codegen.cpp
+      carrier: native-jet
+    vm:
+      file: lib/backend/vm_native.c
+      native_call_id: 750
+      helpers: [vm_gradient_compute, vm_ad_arg_slots]
+      carrier: vm-dual-forward
+    notes: >-
+      N forward passes, one seeded variable each. Byte-identical to native
+      across native / vm-src / vm-eskb on the gradient corpus. Exact, and
+      forked: the two engines reach the same numbers through two carriers that
+      share no code.
+
+  - op: jacobian
+    parity_rows: ["op:JACOBIAN", "jacobian"]
+    native:
+      file: lib/backend/autodiff_codegen.cpp
+      carrier: native-jet
+    vm:
+      file: lib/backend/vm_native.c
+      native_call_id: 751
+      carrier: vm-dual-forward
+    notes: >-
+      Exact for scalar-valued f. For a tensor-returning vector field the VM
+      writes F_k(x) where dF_k/dx_i belongs, because VmTensor cannot carry a
+      tangent — booked as a gap on the PARITY row and as fork_debt.blocked_on.
+
+  - op: hessian
+    parity_rows: ["op:HESSIAN"]
+    native:
+      file: lib/backend/autodiff_codegen.cpp
+      carrier: native-jet
+    vm:
+      file: lib/backend/vm_native.c
+      native_call_id: 752
+      carrier: vm-hyperdual-forward
+    notes: Exact second derivative via hyper-dual seeding; no finite differences.
+
+  - op: divergence
+    parity_rows: ["op:DIVERGENCE"]
+    native:
+      file: lib/backend/autodiff_codegen.cpp
+      carrier: native-jet
+    vm:
+      file: lib/backend/vm_native.c
+      native_call_id: 753
+      carrier: vm-dual-forward
+    notes: >-
+      Exact forward-dual trace of the Jacobian. A tensor-returning field cannot
+      carry tangents through VmTensor and now raises a named error instead of
+      falling back to a difference quotient.
+
+  - op: curl
+    parity_rows: ["op:CURL"]
+    native:
+      file: lib/backend/autodiff_codegen.cpp
+      carrier: native-jet
+    vm:
+      file: lib/backend/vm_native.c
+      native_call_id: 754
+      carrier: vm-dual-forward
+    notes: >-
+      Exact forward-dual off-diagonal Jacobian partials. A tensor-returning
+      field raises for the same reason divergence does.
+
+  - op: laplacian
+    parity_rows: ["op:LAPLACIAN"]
+    native:
+      file: lib/backend/autodiff_codegen.cpp
+      carrier: native-jet
+    vm:
+      file: lib/backend/vm_native.c
+      native_call_id: 755
+      carrier: vm-hyperdual-forward
+    notes: Exact trace of the Hessian via hyper-dual seeding.
+
+  - op: directional-derivative
+    parity_rows: ["op:DIRECTIONAL_DERIV"]
+    native:
+      file: lib/backend/autodiff_codegen.cpp
+      carrier: native-jet
+    vm:
+      file: lib/backend/vm_native.c
+      native_call_id: 756
+      carrier: vm-dual-forward
+    notes: One forward pass with the tangent seeded to the direction vector.
+
+  - op: ad-tape
+    parity_rows: ["ad-tape-new", "ad-var", "ad-const", "ad-backward", "ad-gradient"]
+    native:
+      file: lib/backend/vm_autodiff.c
+      carrier: shared-node-model
+    vm:
+      file: lib/backend/vm_native.c
+      native_call_id: 408
+      carrier: shared-node-model
+    notes: >-
+      The Scheme-visible Wengert tape. THE ONE UNFORKED AD SURFACE: both
+      substrates run lib/backend/vm_autodiff.c. This row is the shape every
+      other operator row is being moved toward.
+
+  - op: derivative-n
+    parity_rows: ["op:DERIVATIVE_N"]
+    native:
+      file: lib/backend/autodiff_codegen.cpp
+      carrier: native-jet
+    vm: null
+    notes: >-
+      Arbitrary-order Taylor-tower AD. No VM surface at all; the PARITY row
+      records it as a gap. A null `vm` block asserts the absence, so a future
+      VM implementation cannot appear without a carrier declaration.
+
+# ── Finite-difference scan ────────────────────────────────────────────────
+#
+# The gate reads every path below, strips comments and string literals, and
+# looks for the DIFFERENCE-QUOTIENT SHAPE: an epsilon-valued name that is both
+# added to and subtracted from a base expression, and divided into a
+# difference. That shape — not the magnitude of the constant — is what makes a
+# site a finite difference. Domain-guard clamps
+# (`select(denom < eps, eps, denom)`) and equality tolerances
+# (`fabs(a-b) < eps`) use their epsilon in a comparison only and are correctly
+# not flagged.
+
+fd_scan:
+  paths:
+    - lib/backend/vm_native.c
+    - lib/backend/vm_dual.c
+    - lib/backend/vm_hyperdual.c
+    - lib/backend/vm_autodiff.c
+    - lib/backend/vm_symbolic_ad.c
+    - lib/backend/autodiff_codegen.cpp
+    - lib/core/runtime_autodiff.cpp
+    - lib/core/ad_tape_builtins.c
+    - lib/core/ad/tape.esk
+    - lib/core/ad/checkpoint.esk
+    - lib/core/ad/guw.esk
+    - lib/core/ad/sparse_guw.esk
+    - lib/core/ad/interval.esk
+    - lib/core/ad/taylor_models.esk
+    - lib/core/ad/taylor_numerics.esk
+    - lib/core/ad/tensor_tower.esk
+
+# Every difference-quotient site the scan finds must appear here. `symbol` is
+# the epsilon-valued name; `path` is where it is bound. An unledgered site is
+# a FAIL — that is the whole point of the check.
+
+fd_allowlist:
+  - path: lib/core/ad/tape.esk
+    symbol: tape-fd-eps
+    owner: tsotchke
+    op: record-fd-op!
+    step: "1.0e-6"
+    justification: >-
+      DELIBERATE AND DECLARED. record-fd-op! is the pure-Scheme escape hatch
+      for an opaque forward function that supplies no analytic adjoint — the
+      Scheme-layer analogue of AD_NODE_CUSTOM, which is what a caller reaches
+      for when the adjoint genuinely does not exist in closed form. It is
+      named `record-fd-op!` at the call site, so a program that uses it says
+      so, and it is the only way to get a gradient through such an op at all.
+      It is NOT a fallback on any default gradient path: nothing in
+      lib/core/ad/tape.esk routes an ordinary op through it, and no
+      high-level operator (gradient / jacobian / hessian / divergence / curl /
+      laplacian / directional-derivative) can reach it implicitly. Central,
+      not forward, so the truncation error is O(h^2).

--- a/.icc/architecture-model.yaml
+++ b/.icc/architecture-model.yaml
@@ -470,7 +470,44 @@ invariants:
       default path must construct an exact dual/jet tangent
       (createDualNumber/makeDual8/makeDual4/seedForwardAndPush) — a finite-
       difference fallback would silently degrade every default gradient.
+      SCOPE: this is a presence check over the NATIVE codegen's exact-jet
+      constructors. It answers "is the native default gradient still built on
+      an exact jet", which it answers correctly. It does NOT observe the
+      bytecode VM, and presence of an exact constructor does not exclude a
+      finite difference elsewhere — both held at once while VM curl shipped a
+      central difference at h = 1e-7 (ledger SW-46 / SW-51). Absence of a
+      difference quotient on either engine is enforced by
+      scripts/gate_ad_shared_node_model.py and the criterion below.
     capability: exact_ad_default_gradient
+
+  # 7b. AD carrier declaration, encoded as key-space-equality. Every AD
+  #     operator that carries a VM parity row must also carry a carrier
+  #     declaration, so an op cannot be promoted to vm-supported without
+  #     stating which differentiation carrier answers it on each substrate.
+  #     The declaration itself is re-derived from source by the gate; this
+  #     invariant guards the weaker but cheaper property that the two key
+  #     spaces cannot drift apart. Expected PASS; adding an AD op to
+  #     PARITY.tsv without a manifest row FAILs it.
+  - id: INV-ad-carrier-declared-for-every-vm-op
+    kind: key-space-equality
+    incident: ad-carrier-fork-undeclared
+    severity: high
+    fidelity: grep
+    description: >-
+      Eshkol differentiates on two substrates with carriers that share no node
+      vocabulary. Every AD operator named in the VM parity manifest must have a
+      row in the AD carrier manifest naming its native carrier, its VM carrier
+      and whether each is exact. op:GRADIENT was promoted from gap to
+      vm-supported on an undeclared VM-private forward-dual carrier and no gate
+      could see it, because the only cross-engine check compared program output
+      and two independently correct implementations agree on output.
+    sites:
+      - id: vm-parity-ad-ops
+        path: tests/vm_parity/PARITY.tsv
+        key_pattern: '(op:(?:GRADIENT|JACOBIAN|HESSIAN|DIVERGENCE|CURL|LAPLACIAN|DERIVATIVE_N|DERIVATIVE|DIRECTIONAL_DERIV|DIFF))\b'
+      - id: ad-carrier-manifest-ops
+        path: .icc/ad-carrier-manifest.yaml
+        key_pattern: '(op:(?:GRADIENT|JACOBIAN|HESSIAN|DIVERGENCE|CURL|LAPLACIAN|DERIVATIVE_N|DERIVATIVE|DIRECTIONAL_DERIV|DIFF))\b'
 
   # 8. TCO tail-position coverage, encoded as key-space-equality.  The core
   #    tail-transparent forms (if / let* family / sequence) must each be handled

--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -99,6 +99,36 @@ oracles:
         label: 'Silent-wrong ledger has no duplicate ids across the whole file and every entry has id/bucket/status/title plus closure evidence when not open (scripts/check_ledger_integrity.py)'
         action: python3 scripts/check_ledger_integrity.py
 
+      # ── AD carrier wave (2026-08-25) ──────────────────────────────────
+      # Eshkol differentiates on two substrates. Until now the only check
+      # that compared them compared PROGRAM OUTPUT, and two independently
+      # correct implementations agree on output — so the differential could
+      # not report that op:GRADIENT had been promoted to vm-supported on a
+      # VM-private forward-dual carrier sharing no code with the native node
+      # model (SW-52). The invariant whose NAME asserts exactness,
+      # INV-ad-exact-no-finite-differences, is a dependency-presence check
+      # over native symbols only: it read PASS for the entire lifetime of a
+      # central difference at h = 1e-7 inside the VM's curl (SW-51, SW-46).
+      # This criterion grades the structural property directly — which
+      # carrier answers each AD op, re-derived from source — and the one
+      # below it grades the behaviour, because a structural check reads text
+      # and a derivative is a number.
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["ad_carrier_model_clean"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'Every AD operator declares its differentiation carrier in .icc/ad-carrier-manifest.yaml, the declaration is re-derived from source rather than believed, a vm-supported AD op is backed by an exact carrier and never a finite difference, the carrier fork does not grow past its shrink-only budget, and every difference-quotient site on either engine is ledgered with an owner and a justification (scripts/gate_ad_shared_node_model.py)'
+        action: python3 scripts/gate_ad_shared_node_model.py
+
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["ad_vm_curl_divergence_exact"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'VM curl of a gradient field returns exactly #(0 0 0) — not the 1.1102230246251565e-09 a central difference at h=1e-7 returned — and (ad-finite-difference-evals) reads 0 rather than 6'
+        action: ./scripts/run_icc_smoke.sh
+
       # This oracle's own definition lives in a YAML file merged the same
       # way the ledger is. PR #429 dropped a list-item opener while adding a
       # criterion and broke the parse outright (icc readiness blocked, score

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -3899,3 +3899,147 @@ entries:
       instrumentation change under a full prelude-bytecode rewrite that no lane
       here can verify, so the new builtin is simply the 29th name the cache does
       not carry, consistent with the 28 before it.
+
+  # ──────────────── AD carrier wave (2026-08-25) ────────────────
+  #
+  # One architectural audit, four entries: the defect, the two checks that
+  # were green while it shipped, and the crash found beside it.
+
+  - id: SW-46
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "feat/ad-structural-gate"
+    closed_by: "branch feat/ad-structural-gate — exact forward-dual curl/divergence in lib/backend/vm_native.c"
+    title: "VM curl is a central difference at h = 1e-7 and returns 1.1e-09 where the curl is exactly zero"
+    repro: "(define (F x y z) (list (* y z) (* x z) (* x y))) (display (curl F (list 1.0 2.0 3.0)))"
+    observed: "#(1.1102230246251565e-09 -3.3306690738754696e-09 0) on build/eshkol-vm-standalone-test"
+    correct: "#(0 0 0) — F is a gradient field, so its curl vanishes identically at every point"
+    cross_engine: >-
+      Not comparable. tests/vm_parity/PARITY.tsv records op:CURL as a gap, so the
+      corpus differential never attempts the comparison, and the native curl
+      operator SIGSEGVs on the same field (booked as LE-12). The defect was
+      therefore invisible to every engine-vs-engine check by construction.
+    observed_after: >-
+      #(0 0 0) exactly, and (ad-finite-difference-evals) reads 0 where it read 6.
+      Measured on the same binary and the same program before and after. Three
+      further fields at the same point: rigid rotation (-y, x, 0) went
+      1.9999999995023998 -> 2; (y^2 z, x z^2, x^2 y) went
+      #(-4.999999990706883 -6.661338147750939e-09 -2.9999999906493713) -> #(-5 0 -3);
+      a transcendental field's divergence was already exact and is byte-identical.
+    fixed_by: >-
+      lib/backend/vm_native.c — case 754 now seeds one forward dual per input
+      variable and reads the tangent of each output component (three closure
+      calls, against the six the difference quotient needed); case 753 drops its
+      finite-difference branch. Both route through the new shared reader
+      vm_ad_field_component_tangent(), so the two operators cannot drift apart
+      in exactness again.
+    evidence: >-
+      Structural: scripts/gate_ad_shared_node_model.py classifies case 753 and
+      754 as `finite-difference` on origin/master and as `vm-dual-forward` after
+      the fix. Behavioural: the ad_vm_curl_divergence_exact ICC smoke probe
+      pins #(0 0 0) and a zero finite-difference counter.
+    caught_by: [architectural-audit-2026-08-25, direct-measurement]
+    missed_by: [vm-parity-differential, icc-smoke, icc-readiness, INV-ad-exact-no-finite-differences]
+    notes: >-
+      A tensor-returning vector field still cannot carry tangents through
+      VmTensor. That shape now raises a named diagnostic instead of falling back
+      to a difference quotient — the ESH-0369 ruling applied to the same class of
+      problem. Closing it needs a tangent-carrying VmTensor; it is recorded as
+      fork_debt.blocked_on in .icc/ad-carrier-manifest.yaml.
+
+  - id: SW-51
+    bucket: VACUOUS-ASSURANCE
+    status: closed
+    closed_at: "feat/ad-structural-gate"
+    closed_by: "branch feat/ad-structural-gate — scripts/gate_ad_shared_node_model.py"
+    title: "INV-ad-exact-no-finite-differences was green while a central difference shipped in the VM"
+    repro: "icc invariants --repo eshkol (INV-ad-exact-no-finite-differences reads PASS at every SHA that contained SW-46)"
+    observed: "PASS, throughout the entire lifetime of the defect"
+    correct: >-
+      The invariant's name asserts that no finite difference backs a derivative.
+      Its mechanism is `kind: dependency-presence`: armed by ESHKOL_DERIVATIVE_OP,
+      it asks only whether one of createDualNumber / makeDual8 / makeDual4 /
+      seedForwardAndPush is PRESENT. All four are native symbols in
+      lib/backend/autodiff_codegen.cpp. Presence of an exact constructor on one
+      engine and presence of a difference quotient on the other are not mutually
+      exclusive, and on this repo both held at once. No VM file was in its site
+      set, so lib/backend/vm_native.c's `double h = 1e-7` was outside its field of
+      view by construction — the check could not have gone red.
+    observed_after: >-
+      The replacement was demonstrated red on unmodified origin/master before the
+      fix landed: it reported case 753 and case 754 as `finite-difference`, named
+      both epsilon sites at lib/backend/vm_native.c:13558 and :13636, and exited
+      1. It goes green only after the operators became exact. Its own --self-test
+      pairs nine red/green fixtures, including a clamp and an equality tolerance
+      at the same magnitude that must NOT be flagged.
+    fixed_by: >-
+      scripts/gate_ad_shared_node_model.py, graded by the ad_carrier_model_clean
+      oracle criterion, run in the assurance-gates CI job, plus the new
+      INV-ad-carrier-declared-for-every-vm-op key-space-equality in
+      .icc/architecture-model.yaml.
+    evidence: "~/.tsotchke/state/ad-unification/gate-red-on-master.txt and gate-green-after-fix.txt"
+    caught_by: [architectural-audit-2026-08-25]
+    missed_by: [icc-invariants, icc-readiness]
+    notes: >-
+      The original invariant is kept. It answers a real and narrower question —
+      is the native default gradient path still built on an exact jet — and it
+      answers it correctly. What changed is that it is no longer the only thing
+      standing behind the sentence "Eshkol's AD is exact".
+
+  - id: SW-52
+    bucket: VACUOUS-ASSURANCE
+    status: closed
+    closed_at: "feat/ad-structural-gate"
+    closed_by: "branch feat/ad-structural-gate — scripts/gate_ad_shared_node_model.py"
+    title: "The VM-parity output differential cannot detect that the two engines run two independent AD implementations"
+    repro: "scripts/run_vm_parity.sh (corpus stage) over tests/vm_parity/corpus/32_gradient_reverse.esk"
+    observed: >-
+      PASS. op:GRADIENT was promoted from gap to vm-supported in v1.3.4 on the
+      strength of it, on a VM-only VmDual carrier that shares no code and no node
+      vocabulary with lib/backend/autodiff_codegen.cpp.
+    correct: >-
+      The differential compares PROGRAM OUTPUT between engines. Two independently
+      correct implementations produce identical output, so agreement is evidence
+      of agreement and nothing else — it is structurally incapable of reporting
+      that the answers came from two implementations. It is also silent on any op
+      whose parity row is `gap`, because a gap row excludes the op from
+      comparison; that is precisely how SW-46 shipped.
+    observed_after: >-
+      The carrier fork is now enumerated, declared per operator and capped:
+      .icc/ad-carrier-manifest.yaml records 9 forked carriers against a
+      shrink-only budget of 9, every declaration is re-derived from source rather
+      than believed, and an op cannot be promoted to vm-supported without a
+      carrier row. The self-test proves the undeclared-promotion case red.
+    fixed_by: "scripts/gate_ad_shared_node_model.py checks C2 (coverage), C3 (source verification) and C5 (shrink-only fork ratchet)"
+    evidence: "~/.tsotchke/state/ad-unification/gate-red-on-master.txt"
+    caught_by: [architectural-audit-2026-08-25]
+    missed_by: [vm-parity-differential]
+    notes: >-
+      The differential is not being replaced. Output agreement remains the right
+      check for whether two engines answer the same; it was simply being read as
+      an answer to a question it never asked.
+
+  - id: LE-12
+    bucket: LOUD-ERROR
+    subtag: structural
+    status: open
+    title: "native curl SIGSEGVs on a list-returning vector field"
+    repro: >-
+      (define (F v) (list (vector-ref v 0) (vector-ref v 1) (vector-ref v 2)))
+      (display (curl F (vector 1.0 2.0 3.0)))
+    observed: >-
+      build/eshkol-run -r prints the field's own value correctly, then
+      "[Eshkol] fatal signal: SIGSEGV (segmentation fault) at address
+      0x0000000000002002" at the curl call. With the components spread across
+      three parameters instead, the LLVM verifier rejects the module with
+      "Incorrect number of arguments passed to called function" — native curl
+      passes the whole point as ONE argument where the VM spreads it into N.
+    correct: "#(0 0 0) for that field, and a diagnostic rather than a crash for an arity it cannot accept"
+    caught_by: [architectural-audit-2026-08-25, direct-measurement]
+    missed_by: [icc-smoke, icc-readiness, vm-parity-differential]
+    notes: >-
+      Found while establishing a cross-engine baseline for SW-46, and the reason
+      no such baseline exists: op:CURL cannot be measured on native at all today.
+      Loud, so not tag-blocking, but it is what keeps op:CURL a gap now that the
+      VM side is exact. Two separable defects: the crash, and the arity-convention
+      divergence between the engines.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4816,6 +4816,29 @@ if(ESHKOL_BUILD_TESTS AND NOT WIN32)
     set_tests_properties(eshkol_vm_standalone_smoke PROPERTIES
         ENVIRONMENT "ESHKOL_VM_NO_DISASM=1")
 
+    # SW-46 gate: the bytecode VM's divergence and curl are EXACT, and cost zero
+    # finite-difference evaluations. Both used to compute a central difference at
+    # h = 1e-7, so `curl` of a gradient field — whose curl vanishes identically —
+    # returned #(1.1102230246251565e-09 -3.3306690738754696e-09 0) with no
+    # diagnostic and exit 0. The parity differential could not see it (op:CURL is
+    # a `gap` row, so the two engines are never compared) and native curl crashes
+    # on the same field (LE-12), so this gate compares against MATHEMATICS: every
+    # field it uses has an exactly representable curl and divergence, and the
+    # assertions are equality rather than tolerance. A tolerance is what let the
+    # defect live.
+    if(TARGET eshkol-run AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/ad/ad_vm_exactness_gate.sh")
+        add_test(NAME ad_vm_exactness_gate
+            COMMAND bash
+                "${CMAKE_CURRENT_SOURCE_DIR}/tests/ad/ad_vm_exactness_gate.sh"
+                "$<TARGET_FILE:eshkol-run>"
+                "$<TARGET_FILE:eshkol-vm-standalone-test>"
+                "${CMAKE_CURRENT_BINARY_DIR}/ad-vm-exactness-gate")
+        set_tests_properties(ad_vm_exactness_gate PROPERTIES
+            TIMEOUT 300
+            PASS_REGULAR_EXPRESSION "PASS: VM divergence and curl are exact"
+            FAIL_REGULAR_EXPRESSION "FAIL:")
+    endif()
+
     # R7RS-small 5.6.1 same-unit library resolution, on the VM.  The VM
     # compiler has its own reader and its own module machinery, so the native
     # front end being fixed proves nothing here: `define-library`, `import`

--- a/docs/reference/ad/architecture.md
+++ b/docs/reference/ad/architecture.md
@@ -26,6 +26,74 @@ Eshkol runs **forward mode** for `derivative` and **reverse mode** for
 
 ---
 
+## Substrates and carriers
+
+The table above describes the **native** engine. Eshkol also differentiates on
+the bytecode VM, and the two substrates reach the same numbers through
+different carriers. Which carrier answers which operator is declared, per
+operator and per substrate, in
+[`.icc/ad-carrier-manifest.yaml`](../../../.icc/ad-carrier-manifest.yaml) and
+enforced by
+[`scripts/gate_ad_shared_node_model.py`](../../../scripts/gate_ad_shared_node_model.py),
+which re-derives every declaration from the source rather than believing it.
+
+| Carrier | Where | Vocabulary | Substrates |
+|---------|-------|------------|------------|
+| `ad_node_t` reverse tape | `inc/eshkol/eshkol.h`, emitted by `autodiff_codegen.cpp` | ~80 typed nodes incl. `AD_NODE_CUSTOM` | native |
+| forward jet | `autodiff_codegen.cpp` (`seedForwardAndPush`) | e1/e2/ep slots + Taylor tower | native |
+| `VmDual {primal, tangent}` | `vm_dual.c` | 16 flat forward-dual ops | VM |
+| `VmHyperDual {f, f1, f2, f12}` | `vm_hyperdual.c` | second-order forward | VM |
+| `AdTape`/`AdNode` Wengert tape | `vm_autodiff.c` | 17 ops, int-indexed | **both** — the Scheme-visible `ad-*` primitives |
+
+Every carrier in that table is **exact**: each propagates derivatives by the
+chain rule. No default AD path on either substrate uses a finite difference.
+The one deliberate difference quotient in the tree is `record-fd-op!` in
+[`lib/core/ad/tape.esk`](../../../lib/core/ad/tape.esk) — the pure-Scheme
+escape hatch for an opaque forward function that supplies no analytic adjoint,
+named at its call site and ledgered in the carrier manifest's `fd_allowlist`.
+
+The forward carriers are scalar. A vector field whose components are packed
+into a `VmTensor` loses its tangents at construction, because `VmTensor::data`
+is a bare `double*`. `divergence` and `curl` therefore accept a field that
+returns a **list or a vector** and raise a named diagnostic for one that
+returns a tensor, rather than approximating it.
+
+### Build item — `AD_NODE_CUSTOM` on the VM
+
+`AD_NODE_CUSTOM` carries an externally supplied vector-Jacobian product (see
+below) and is reachable only from the native `ad_node_t` tape. Four things
+stand between it and the VM's shared Wengert tape:
+
+1. **Vocabulary.** `AdOpType` (`lib/backend/vm_autodiff.c`) has 17 members and
+   no `CUSTOM`.
+2. **Node shape.** `eshkol_custom_vjp_t` lives in `ad_node_t::saved_tensors[0]`.
+   `AdNode` has a single `double saved` slot — no `saved_tensors`, no
+   `num_saved`.
+3. **Input handles.** `eshkol_custom_vjp_t::inputs` is `ad_node**`. `AdNode`
+   addresses parents by index into an array that is relocated on growth, so a
+   stored node pointer would dangle.
+4. **Reverse driver.** `eshkol_ad_node_custom_backward`
+   (`lib/core/runtime_autodiff.cpp`) is hard-typed to `ad_node_t*`, and the
+   VM's `ad_backward` switches on `AdOpType` with no default hook.
+
+The work, in order:
+
+- Make the VM tape's node storage **chunked and never relocated**, so an
+  `AdNode*` stays valid for the tape's lifetime. This also removes a latent
+  hazard for any future pointer-holding node type.
+- Add `AD_CUSTOM` to `AdOpType` and `void** saved; int num_saved;` to `AdNode`.
+- Factor the universal reverse rule
+  (`input_i->gradient += upstream * dy/dx_i`) out of
+  `eshkol_ad_node_custom_backward` into one function parameterised over the
+  accumulate step, and call it from both `ad_backward`'s new `case AD_CUSTOM:`
+  and the native driver — so the two substrates cannot disagree about what a
+  custom VJP means.
+- Route the VM's `(gradient f x)` to the tape when `f` is reverse-mode-marked,
+  so a custom node is reachable at all: today the VM's `gradient` is the
+  forward `VmDual` carrier and builds no tape.
+
+---
+
 ## Forward mode — the 4-component jet
 
 A "dual number" in Eshkol is **not** the classic 2-component `{value,

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -5568,6 +5568,75 @@ static double vm_dual_tangent_of(VM* vm, Value v) {
     return 0.0;
 }
 
+/* ── Vector-field output components, exactly ──
+ *
+ * div(F) and curl(F) are built from the SAME quantity: the tangent of output
+ * component i after F has been called with component j of the point seeded.
+ * Both used to reach that quantity through a central difference at h = 1e-7
+ * — measurably, `curl` returned
+ * #(1.1102230246251565e-09 -3.3306690738754696e-09 0) for a gradient field
+ * whose curl is exactly zero. That is the cancellation noise of the step, not
+ * a derivative.
+ *
+ * The forward dual already carries the answer when F returns a list or a
+ * vector: each element is a VmDual and its tangent IS the partial. A plain
+ * numeric element is equally exact — a component that does not depend on the
+ * seeded variable has partial 0, which is precisely what a non-dual result
+ * means here.
+ *
+ * The one shape the carrier cannot express is a TENSOR-returning field:
+ * VmTensor::data is a bare double*, so packing dual components into a tensor
+ * drops every tangent at construction. That is reported, not approximated —
+ * the same ruling ESH-0369 applied to nested derivatives, for the same
+ * reason: a named limitation is honest and a fabricated number is not.
+ *
+ * @return 1 when @p out_tangent holds the exact partial, 0 when the result
+ *         shape cannot carry a tangent at all.
+ */
+static int vm_ad_field_component_tangent(VM* vm, Value result, int i,
+                                         double* out_tangent) {
+    if (!out_tangent) return 0;
+    *out_tangent = 0.0;
+
+    if (result.type == VAL_PAIR) {
+        Value cur = result;
+        for (int k = 0; k < i && cur.type == VAL_PAIR; k++) {
+            cur = vm->heap.objects[cur.as.ptr]->cons.cdr;
+        }
+        if (cur.type != VAL_PAIR) return 1;   /* short field: absent component is 0 */
+        *out_tangent = vm_dual_tangent_of(vm, vm->heap.objects[cur.as.ptr]->cons.car);
+        return 1;
+    }
+
+    if (result.type == VAL_VECTOR && result.as.ptr >= 0) {
+        VmVector* vv = (VmVector*)vm->heap.objects[result.as.ptr]->opaque.ptr;
+        if (!vv || !vv->items || i >= vv->len) return 1;
+        *out_tangent = vm_dual_tangent_of(vm, vv->items[i]);
+        return 1;
+    }
+
+    if (result.type == VAL_TENSOR) return 0;  /* tangents lost at construction */
+
+    /* Scalar-valued field: only component 0 exists; the rest are 0. */
+    if (i == 0) *out_tangent = vm_dual_tangent_of(vm, result);
+    return 1;
+}
+
+/** @brief The one diagnostic both div and curl raise when the field's result
+ *         shape cannot carry a tangent. Named in one place so the two
+ *         operators cannot drift apart in what they tell a caller. */
+static void vm_ad_raise_tensor_field_unsupported(VM* vm, const char* op) {
+    (void)op;
+    vm_raise_error_msg(vm,
+        "divergence/curl: a vector field that returns a TENSOR cannot be "
+        "differentiated exactly on the VM — the VM's forward dual is a scalar "
+        "carrier and VmTensor holds bare doubles, so every tangent is dropped "
+        "when the components are packed. Return the field's components as a "
+        "list or a vector, or use the native backend. (This used to fall back "
+        "to a finite difference and return an approximation with no "
+        "diagnostic.)");
+}
+
 /* ── AD point extraction: sized by the data, never by a fixed buffer ──
  *
  * Every AD entry point (gradient, jacobian, hessian, divergence, laplacian,
@@ -13533,76 +13602,28 @@ static void vm_dispatch_native(VM* vm, int fid) {
 
         if (n == 0) { vm_push(vm, FLOAT_VAL(0)); break; }
 
-        /* Sum of ∂Fi/∂xi: for each i, seed variable i, extract component i.
-         * Every per-pass buffer is allocated once at the point's arity. */
+        /* Sum of ∂Fi/∂xi: for each i, seed variable i, read the tangent of
+         * output component i. EXACT — one forward dual pass per variable, no
+         * step size anywhere. Every per-pass buffer is allocated once at the
+         * point's arity. */
         double div = 0;
         Value* args = vm_ad_arg_slots(vm, n);
-        double* pt_plus = vm_ad_double_buf(vm, n);
-        double* pt_minus = vm_ad_double_buf(vm, n);
-        Value* ap = vm_ad_arg_slots(vm, n);
-        Value* am = vm_ad_arg_slots(vm, n);
-        if (!args || !pt_plus || !pt_minus || !ap || !am) { vm_push(vm, FLOAT_VAL(0)); break; }
+        if (!args) { vm_push(vm, FLOAT_VAL(0)); break; }
+        int div_ok = 1;
         for (int i = 0; i < n; i++) {
             for (int j = 0; j < n; j++) {
                 VM_AD_MAKE_DUAL(vm, point[j], (j == i) ? 1.0 : 0.0, args[j]);
             }
             Value result = vm_ad_call_closure(vm, f_val, args, n);
-
-            /* Extract the i-th component's tangent */
-            if (result.type == VAL_TENSOR && result.as.ptr >= 0) {
-                /* F returns a tensor — we need the tangent of element i.
-                 * Since the tensor contains primals (doubles), the tangent
-                 * information is lost. We need to use a different approach:
-                 * call F component-wise. But if F returns a tensor of duals,
-                 * we can extract directly. For tensor-returning functions,
-                 * use finite differences as fallback. */
-                VmTensor* rt = (VmTensor*)vm->heap.objects[result.as.ptr]->opaque.ptr;
-                if (rt && rt->data && i < (int)rt->total) {
-                    /* Tensor element — use finite difference for this component */
-                    double fplus, fminus;
-                    double h = 1e-7;
-                    for (int k = 0; k < n; k++) {
-                        pt_plus[k] = point[k] + ((k == i) ? h : 0);
-                        pt_minus[k] = point[k] - ((k == i) ? h : 0);
-                    }
-                    /* F(x + h*ei)[i] */
-                    for (int k = 0; k < n; k++) ap[k] = FLOAT_VAL(pt_plus[k]);
-                    Value rp = vm_ad_call_closure(vm, f_val, ap, n);
-                    fplus = 0;
-                    if (rp.type == VAL_TENSOR && rp.as.ptr >= 0) {
-                        VmTensor* tp = (VmTensor*)vm->heap.objects[rp.as.ptr]->opaque.ptr;
-                        if (tp && tp->data && i < (int)tp->total) fplus = tp->data[i];
-                    }
-                    /* F(x - h*ei)[i] */
-                    for (int k = 0; k < n; k++) am[k] = FLOAT_VAL(pt_minus[k]);
-                    Value rm = vm_ad_call_closure(vm, f_val, am, n);
-                    vm->ad_finite_difference_evals += 2;
-                    fminus = 0;
-                    if (rm.type == VAL_TENSOR && rm.as.ptr >= 0) {
-                        VmTensor* tm = (VmTensor*)vm->heap.objects[rm.as.ptr]->opaque.ptr;
-                        if (tm && tm->data && i < (int)tm->total) fminus = tm->data[i];
-                    }
-                    div += (fplus - fminus) / (2.0 * h);
-                }
-            } else if (result.type == VAL_PAIR) {
-                /* F returns a list — walk to i-th element, extract tangent */
-                Value cur = result;
-                for (int k = 0; k < i && cur.type == VAL_PAIR; k++) {
-                    cur = vm->heap.objects[cur.as.ptr]->cons.cdr;
-                }
-                if (cur.type == VAL_PAIR) {
-                    Value elem = vm->heap.objects[cur.as.ptr]->cons.car;
-                    if (elem.type == VAL_DUAL && elem.as.ptr >= 0) {
-                        VmDual* rd = (VmDual*)vm->heap.objects[elem.as.ptr]->opaque.ptr;
-                        if (rd) div += rd->tangent;
-                    }
-                }
-            } else if (n == 1 && result.type == VAL_DUAL && result.as.ptr >= 0) {
-                /* Scalar function */
-                VmDual* rd = (VmDual*)vm->heap.objects[result.as.ptr]->opaque.ptr;
-                if (rd) div += rd->tangent;
+            double partial = 0.0;
+            if (!vm_ad_field_component_tangent(vm, result, i, &partial)) {
+                vm_ad_raise_tensor_field_unsupported(vm, "divergence");
+                div_ok = 0;
+                break;
             }
+            div += partial;
         }
+        if (!div_ok) break;
         vm_push(vm, FLOAT_VAL(div));
         break;
     }
@@ -13634,50 +13655,38 @@ static void vm_dispatch_native(VM* vm, int fid) {
             break;
         }
 
-        /* Compute the 3×3 Jacobian via central differences:
-         * J[i][j] = ∂Fi/∂xj
-         * curl = (J[2][1] - J[1][2], J[0][2] - J[2][0], J[1][0] - J[0][1]) */
+        /* Compute the 3×3 Jacobian by EXACT forward-mode AD:
+         *   J[i][j] = ∂Fi/∂xj
+         *   curl    = (J[2][1] - J[1][2], J[0][2] - J[2][0], J[1][0] - J[0][1])
+         *
+         * One dual pass per input variable j, seeding xj with tangent 1 and
+         * the other two with 0; the tangent of output component i is J[i][j].
+         * Three closure calls total, against the six a central difference
+         * needed — and every entry is the derivative rather than a quotient
+         * of nearby values. On a gradient field this now returns exactly
+         * #(0 0 0) where the difference quotient returned
+         * #(1.1102230246251565e-09 -3.3306690738754696e-09 0). */
         double jac[3][3];
-        double h = 1e-7;
+        int curl_ok = 1;
 
-        for (int j = 0; j < 3; j++) {
-            /* ∂F/∂xj via central difference */
-            Value ap[3], am[3];
+        for (int j = 0; j < 3 && curl_ok; j++) {
+            Value args[3];
             for (int k = 0; k < 3; k++) {
-                ap[k] = FLOAT_VAL(point[k] + ((k == j) ? h : 0));
-                am[k] = FLOAT_VAL(point[k] - ((k == j) ? h : 0));
+                VM_AD_MAKE_DUAL(vm, point[k], (k == j) ? 1.0 : 0.0, args[k]);
             }
-            Value rp = vm_ad_call_closure(vm, f_val, ap, 3);
-            Value rm = vm_ad_call_closure(vm, f_val, am, 3);
-            vm->ad_finite_difference_evals += 2;
-
-            /* Extract 3 components from each result */
-            double fp[3] = {0,0,0}, fm[3] = {0,0,0};
-            if (rp.type == VAL_TENSOR && rp.as.ptr >= 0) {
-                VmTensor* tp = (VmTensor*)vm->heap.objects[rp.as.ptr]->opaque.ptr;
-                if (tp && tp->data) for (int i = 0; i < 3 && i < (int)tp->total; i++) fp[i] = tp->data[i];
-            } else if (rp.type == VAL_PAIR) {
-                Value cur = rp; int idx = 0;
-                while (cur.type == VAL_PAIR && idx < 3) {
-                    fp[idx++] = as_number_vm(vm, vm->heap.objects[cur.as.ptr]->cons.car);
-                    cur = vm->heap.objects[cur.as.ptr]->cons.cdr;
-                }
-            }
-            if (rm.type == VAL_TENSOR && rm.as.ptr >= 0) {
-                VmTensor* tm = (VmTensor*)vm->heap.objects[rm.as.ptr]->opaque.ptr;
-                if (tm && tm->data) for (int i = 0; i < 3 && i < (int)tm->total; i++) fm[i] = tm->data[i];
-            } else if (rm.type == VAL_PAIR) {
-                Value cur = rm; int idx = 0;
-                while (cur.type == VAL_PAIR && idx < 3) {
-                    fm[idx++] = as_number_vm(vm, vm->heap.objects[cur.as.ptr]->cons.car);
-                    cur = vm->heap.objects[cur.as.ptr]->cons.cdr;
-                }
-            }
+            Value result = vm_ad_call_closure(vm, f_val, args, 3);
 
             for (int i = 0; i < 3; i++) {
-                jac[i][j] = (fp[i] - fm[i]) / (2.0 * h);
+                double partial = 0.0;
+                if (!vm_ad_field_component_tangent(vm, result, i, &partial)) {
+                    vm_ad_raise_tensor_field_unsupported(vm, "curl");
+                    curl_ok = 0;
+                    break;
+                }
+                jac[i][j] = partial;
             }
         }
+        if (!curl_ok) break;
 
         /* curl = (∂F3/∂y - ∂F2/∂z, ∂F1/∂z - ∂F3/∂x, ∂F2/∂x - ∂F1/∂y) */
         double curl_data[3] = {

--- a/scripts/gate_ad_shared_node_model.py
+++ b/scripts/gate_ad_shared_node_model.py
@@ -1,0 +1,903 @@
+#!/usr/bin/env python3
+"""Structural gate: every AD operator's differentiation carrier is declared,
+verified against its source, and exact wherever parity is claimed.
+
+Motivating incident: the 2026-08-25 architectural audit found `op:GRADIENT`
+promoted from `gap` to `vm-supported` on a VM-only forward-dual path
+(`VmDual`, lib/backend/vm_native.c) that shares zero code with the native AD
+node model in lib/backend/autodiff_codegen.cpp. Two independent AD
+implementations existed and every gate stayed green, because the only check
+that compared them compared PROGRAM OUTPUT. Two independently-correct
+implementations agree on output, so an output differential is structurally
+incapable of seeing a fork. The same blindness let `curl` ship as a CENTRAL
+DIFFERENCE at h = 1e-7 -- measured returning
+#(1.1102230246251565e-09 -3.3306690738754696e-09 0) for a field whose curl is
+exactly zero -- while `INV-ad-exact-no-finite-differences` in
+.icc/architecture-model.yaml read PASS. That invariant is
+`kind: dependency-presence`: it asks whether an exact constructor is PRESENT
+in the native codegen, never whether a finite difference is ABSENT, and its
+site set contains no VM file at all. It was green and could not have gone red.
+
+This gate asserts the property BY CONSTRUCTION instead of by comparison. It
+grades .icc/ad-carrier-manifest.yaml against tests/vm_parity/PARITY.tsv and
+against the source itself:
+
+  C1 MANIFEST     the manifest parses, matches its schema, and names carriers
+                  that exist in its own carrier vocabulary.
+  C2 COVERAGE     every AD operator row in PARITY.tsv is covered by exactly
+                  one manifest operator, and every parity row the manifest
+                  names exists in PARITY.tsv. An AD op cannot become
+                  `vm-supported` without declaring which carrier answers it.
+  C3 VERIFICATION the declared VM carrier is RE-DERIVED from source: the
+                  operator's `case <native_call_id>:` block is extracted from
+                  its declared file, comments and literals are stripped, and
+                  the block is classified by which carrier witnesses it
+                  actually touches. Declared must equal observed. The manifest
+                  cannot lie, and editing it cannot fix a red gate.
+  C4 EXACTNESS    a parity row reading `vm-supported` requires an exact
+                  carrier. A finite difference may never back a vm-supported
+                  AD op.
+  C5 RATCHET      the number of operators whose VM carrier is not the shared
+                  node model may not exceed `fork_debt.forked_carrier_budget`.
+                  Shrink-only: the fork is capped at its measured size.
+  C6 FD LEDGER    every difference-quotient site in `fd_scan.paths` appears in
+                  `fd_allowlist` with an owner, the op it serves and a
+                  justification. An unledgered finite difference is a FAIL.
+  C7 SCAN SCOPE   `fd_scan.paths` covers every file any operator names, so a
+                  finding cannot be silenced by deleting a path.
+
+WHAT COUNTS AS A FINITE DIFFERENCE
+    The magnitude of a constant proves nothing: lib/backend/autodiff_codegen.cpp
+    uses 1e-7 six times as a domain-guard clamp on a Poincare-ball divisor
+    (`select(denom < eps, eps, denom)`), and lib/backend/vm_dual.c uses 1e-12
+    as an equality tolerance. Neither is a derivative approximation. What makes
+    a site a finite difference is the DIFFERENCE-QUOTIENT SHAPE: an
+    epsilon-valued name that is added to a base expression, subtracted from the
+    same base, and divided into the resulting difference. A clamp or a
+    tolerance only ever reaches its epsilon through a comparison. This gate
+    detects the shape, not the number.
+
+Grading
+    PASS  C1-C7 all hold.
+    FAIL  any check fails, or the manifest / PARITY.tsv / a scanned source
+          file is absent or unreadable.
+
+The gate FAILS CLOSED. A missing manifest is not evidence that no AD fork
+exists, and it is the exact class of false green this gate was added to end.
+
+Usage
+    python3 scripts/gate_ad_shared_node_model.py
+    python3 scripts/gate_ad_shared_node_model.py --manifest path/to/file.yaml
+    python3 scripts/gate_ad_shared_node_model.py --format json
+    python3 scripts/gate_ad_shared_node_model.py --self-test
+
+Exit status is 0 on PASS and 1 on FAIL, so the script also works as a plain
+CI step without ICC.
+
+Copyright (C) tsotchke
+SPDX-License-Identifier: MIT
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_MANIFEST = os.path.join(REPO_ROOT, ".icc", "ad-carrier-manifest.yaml")
+DEFAULT_PARITY = os.path.join(REPO_ROOT, "tests", "vm_parity", "PARITY.tsv")
+DEFAULT_TRACE_DIR = os.path.join(REPO_ROOT, "scripts", "icc_traces")
+TRACE_BASENAME = "ad_carrier_gate.jsonl"
+
+EXPECTED_SCHEMA = "eshkol.ad_carrier_manifest.v1"
+PROBE_ID = "ad_carrier_model_clean"
+
+FD_CARRIER = "finite-difference"
+SHARED_CARRIER = "shared-node-model"
+
+# PARITY.tsv statuses that assert the VM answers this op.
+VM_SUPPORTED = "vm-supported"
+
+
+class GateError(Exception):
+    """Any condition that makes the gate ungradeable. Always a FAIL."""
+
+
+# ───────────────────────────── loading ─────────────────────────────
+
+def _load_yaml(path: str) -> dict:
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:  # pragma: no cover - environment problem
+        raise GateError(f"PyYAML is required to grade the AD carrier manifest: {exc}")
+    if not os.path.isfile(path):
+        raise GateError(f"AD carrier manifest not found at {path}")
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+    except Exception as exc:
+        raise GateError(f"AD carrier manifest at {path} is unparseable: {exc}")
+    if not isinstance(data, dict):
+        raise GateError(f"AD carrier manifest at {path} is not a mapping")
+    return data
+
+
+def load_parity(path: str) -> dict[str, str]:
+    """Return {name: status} for every non-comment row of PARITY.tsv."""
+    if not os.path.isfile(path):
+        raise GateError(f"VM parity manifest not found at {path}")
+    rows: dict[str, str] = {}
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 2:
+                continue
+            rows[fields[0].strip()] = fields[1].strip()
+    if not rows:
+        raise GateError(f"VM parity manifest at {path} yielded no rows")
+    return rows
+
+
+# ───────────────────────── source normalisation ─────────────────────────
+
+_C_LIKE = (".c", ".cpp", ".cc", ".h", ".hpp")
+
+
+def strip_noise(text: str, path: str) -> str:
+    """Remove comments and string/char literals, preserving line structure.
+
+    Prose matters here: lib/backend/vm_native.c documents its own finite
+    differences in a comment ("Compute the 3x3 Jacobian via central
+    differences"). A scanner that read comments would grade the documentation
+    rather than the code, and could be silenced by deleting an honest comment.
+    Newlines are preserved so reported line numbers stay true to the file.
+    """
+    if path.endswith(".esk") or path.endswith(".scm"):
+        out = []
+        for line in text.split("\n"):
+            # A `;` inside a string is not a comment; strings are rare in the
+            # AD modules and are removed first.
+            line = re.sub(r'"(?:[^"\\]|\\.)*"', '""', line)
+            idx = line.find(";")
+            out.append(line[:idx] if idx >= 0 else line)
+        return "\n".join(out)
+
+    def _blank(match: re.Match) -> str:
+        return re.sub(r"[^\n]", " ", match.group(0))
+
+    text = re.sub(r"/\*.*?\*/", _blank, text, flags=re.S)
+    text = re.sub(r"//[^\n]*", _blank, text)
+    text = re.sub(r'"(?:[^"\\\n]|\\.)*"', '""', text)
+    text = re.sub(r"'(?:[^'\\\n]|\\.)'", "' '", text)
+    return text
+
+
+def read_source(path: str) -> str:
+    if not os.path.isfile(path):
+        raise GateError(f"declared AD source file is missing: {path}")
+    with open(path, "r", encoding="utf-8", errors="replace") as handle:
+        return handle.read()
+
+
+def extract_case_block(text: str, case_id: int) -> str:
+    """Return the brace-balanced body of `case <case_id>:` in normalised text.
+
+    The VM dispatches native calls from one switch, so an operator's whole
+    implementation is exactly one case block. Extracting it -- rather than
+    grepping the 14k-line file -- is what makes the carrier classification
+    per-operator instead of per-file.
+    """
+    match = re.search(r"(?m)^[ \t]*case\s+%d\s*:" % case_id, text)
+    if not match:
+        raise GateError(f"no `case {case_id}:` found in the declared VM source")
+    start = text.find("{", match.end())
+    if start < 0:
+        raise GateError(f"`case {case_id}:` has no block body")
+    depth = 0
+    for pos in range(start, len(text)):
+        ch = text[pos]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : pos + 1]
+    raise GateError(f"`case {case_id}:` block is unbalanced")
+
+
+def extract_function_block(text: str, name: str) -> str:
+    """Return the brace-balanced body of function `name` in normalised text.
+
+    An operator may delegate its whole implementation to a helper -- case 750
+    is one line, `vm_push(vm, vm_gradient_compute(vm, f_val, x_val))`. Without
+    this, delegation would launder a carrier past the classifier, which is the
+    single most obvious way to defeat a case-block gate. A helper must be
+    DECLARED in the manifest, so the audit trail names it too.
+    """
+    pattern = re.compile(
+        r"(?m)^[A-Za-z_][\w\s\*&:<>,]*?\b" + re.escape(name) + r"\s*\([^;{)]*\)\s*\{"
+    )
+    match = pattern.search(text)
+    if not match:
+        raise GateError(f"declared helper {name!r} has no definition in the declared VM source")
+    start = text.rindex("{", match.start(), match.end())
+    depth = 0
+    for pos in range(start, len(text)):
+        ch = text[pos]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : pos + 1]
+    raise GateError(f"helper {name!r} has an unbalanced body")
+
+
+# ─────────────────── finite-difference shape detection ───────────────────
+
+# An epsilon-looking numeric literal: scientific notation with a negative
+# exponent of 3 or more, or a small plain decimal. Below 1e-3 nothing in this
+# codebase is a step size, and above it nothing is a tolerance.
+EPS_LITERAL = r"(?<![\w.])\d+(?:\.\d+)?[eE]-0*(?:[3-9]|[1-9]\d)(?![\w.])"
+EPS_DECIMAL = r"(?<![\w.])0\.0{2,}\d+(?![\w.])"
+EPS_ANY = f"(?:{EPS_LITERAL}|{EPS_DECIMAL})"
+
+# `->`, `++`, `--` and the `e-` of an exponent all contain `+`/`-` characters
+# that mean nothing arithmetically. They are neutralised before the shape test
+# so a member access next to an epsilon cannot read as a perturbation.
+#
+# Every substitution is LENGTH-PRESERVING on purpose: bindings are located in
+# the original text and the shape test runs over the neutralised copy, so the
+# two must agree on offsets. (Neutralising first would also destroy the very
+# `1e-7` the binding scan is looking for.)
+_NEUTRALISE = [
+    (re.compile(r"->"), "_a"),
+    (re.compile(r"\+\+"), "_p"),
+    (re.compile(r"--"), "_m"),
+    (re.compile(r"([0-9])([eE])-([0-9])"), r"\1\2_\3"),
+]
+
+
+def _neutralise(text: str) -> str:
+    for pattern, repl in _NEUTRALISE:
+        text = pattern.sub(repl, text)
+    return text
+
+
+def _block_around(text: str, pos: int, path: str) -> str:
+    """Return the innermost brace block containing offset `pos`.
+
+    Scheme is scoped differently and deliberately handled differently: an
+    epsilon in an AD module is a top-level `(define tape-fd-eps 1.0e-6)` whose
+    uses are in a sibling procedure, so the enclosing form is the define
+    itself and tells us nothing. For .esk the whole module is the scope.
+    """
+    if path.endswith((".esk", ".scm")):
+        return text
+    opener, closer = "{", "}"
+    depth = 0
+    start = 0
+    for i in range(pos, -1, -1):
+        ch = text[i]
+        if ch == closer:
+            depth += 1
+        elif ch == opener:
+            if depth == 0:
+                start = i
+                break
+            depth -= 1
+    depth = 0
+    end = len(text)
+    for i in range(start, len(text)):
+        ch = text[i]
+        if ch == opener:
+            depth += 1
+        elif ch == closer:
+            depth -= 1
+            if depth == 0:
+                end = i + 1
+                break
+    return text[start:end]
+
+
+def _bindings(text: str, path: str) -> list[tuple[str, int]]:
+    """Find (name, offset) for every name bound to an epsilon-looking value."""
+    found: list[tuple[str, int]] = []
+    if path.endswith((".esk", ".scm")):
+        for m in re.finditer(r"\(define\s+([A-Za-z_][\w!?*+/<>=-]*)\s+" + EPS_ANY, text):
+            found.append((m.group(1), m.start()))
+        return found
+    # `double h = 1e-7;`, `llvm::Value* eps = ConstantFP::get(ty, 1e-7);`
+    for m in re.finditer(r"([A-Za-z_]\w*)\s*=\s*[^;=\n]*?" + EPS_ANY, text):
+        found.append((m.group(1), m.start()))
+    # `#define AD_EPS 1e-10`
+    for m in re.finditer(r"#\s*define\s+([A-Za-z_]\w*)\s+" + EPS_ANY, text):
+        found.append((m.group(1), m.start()))
+    return found
+
+
+def _has_shape(block: str, name: str) -> tuple[bool, bool, bool]:
+    """(added, subtracted, divided-into) for `name` within `block`."""
+    esc = re.escape(name)
+    near = r"[^;\n]{0,60}"
+    added = bool(re.search(r"\+" + near + r"(?<![\w])" + esc + r"(?![\w])", block))
+    subtracted = bool(re.search(r"-" + near + r"(?<![\w])" + esc + r"(?![\w])", block))
+    divided = bool(re.search(r"/" + near + r"(?<![\w])" + esc + r"(?![\w])", block))
+    return added, subtracted, divided
+
+
+def find_fd_sites(text: str, path: str) -> list[dict]:
+    """Return every difference-quotient site in normalised `text`.
+
+    A site qualifies when an epsilon-valued name is DIVIDED INTO a quantity and
+    is also ADDED to a base expression -- the signature of `(f(x+h) - f(x))/h`
+    -- and is classified `central` when it is subtracted as well. A name that
+    only ever appears in a comparison (a clamp, a tolerance) reaches none of
+    these and is correctly not a site.
+    """
+    flat = _neutralise(text)
+    sites: list[dict] = []
+    seen: set[tuple[str, int]] = set()
+    for name, pos in _bindings(text, path):
+        block = _block_around(flat, pos, path)
+        added, subtracted, divided = _has_shape(block, name)
+        if not (divided and added):
+            continue
+        line = flat.count("\n", 0, pos) + 1
+        key = (name, line)
+        if key in seen:
+            continue
+        seen.add(key)
+        sites.append(
+            {
+                "path": path,
+                "symbol": name,
+                "line": line,
+                "kind": "central" if subtracted else "forward",
+            }
+        )
+    return sites
+
+
+# ───────────────────── carrier classification ─────────────────────
+
+def classify_carrier(block: str, carriers: dict, path: str) -> str:
+    """Return the carrier a block ACTUALLY uses.
+
+    Finite difference wins over everything: a block that seeds duals and then
+    falls back to a difference quotient for some shapes is a finite-difference
+    block, because the answer a caller receives can be the approximated one.
+    That precedence is the whole reason `divergence` was classified honestly.
+    """
+    if find_fd_sites(block, path):
+        return FD_CARRIER
+    # Most specific first: a hyper-dual block also mentions dual helpers.
+    order = ["vm-hyperdual-forward", "vm-dual-forward", "native-jet", "native-ad-node", SHARED_CARRIER]
+    for name in order:
+        spec = carriers.get(name)
+        if not isinstance(spec, dict):
+            continue
+        for witness in spec.get("witnesses") or []:
+            if re.search(witness, block):
+                return name
+    return "unclassified"
+
+
+# ───────────────────────────── the audit ─────────────────────────────
+
+AD_PARITY_ROW = re.compile(
+    r"^(?:op:(?:GRADIENT|JACOBIAN|HESSIAN|DIVERGENCE|CURL|LAPLACIAN|DERIVATIVE"
+    r"|DERIVATIVE_N|DIFF|DIRECTIONAL_DERIV)"
+    r"|gradient|jacobian|hessian|divergence|curl|laplacian|derivative"
+    r"|directional-derivative|ad-tape-new|ad-var|ad-const|ad-backward|ad-gradient)$"
+)
+
+
+def audit(manifest: dict, parity: dict[str, str], repo_root: str) -> dict:
+    errors: list[str] = []
+    findings: list[dict] = []
+
+    # ── C1 manifest well-formed ────────────────────────────────────────
+    if manifest.get("schema") != EXPECTED_SCHEMA:
+        errors.append(
+            f"C1 manifest schema is {manifest.get('schema')!r}, expected {EXPECTED_SCHEMA!r}"
+        )
+    carriers = manifest.get("carriers")
+    if not isinstance(carriers, dict) or not carriers:
+        raise GateError("C1 manifest has no `carriers` vocabulary")
+    operators = manifest.get("operators")
+    if not isinstance(operators, list) or not operators:
+        raise GateError("C1 manifest has no `operators` list")
+    fork_debt = manifest.get("fork_debt") or {}
+    budget = fork_debt.get("forked_carrier_budget")
+    if not isinstance(budget, int):
+        raise GateError("C1 manifest has no integer `fork_debt.forked_carrier_budget`")
+    fd_scan = manifest.get("fd_scan") or {}
+    scan_paths = fd_scan.get("paths")
+    if not isinstance(scan_paths, list) or not scan_paths:
+        raise GateError("C1 manifest has no `fd_scan.paths` list")
+    allowlist = manifest.get("fd_allowlist") or []
+    if not isinstance(allowlist, list):
+        raise GateError("C1 manifest `fd_allowlist` is not a list")
+
+    # ── C2 coverage in both directions ─────────────────────────────────
+    covered_rows: dict[str, str] = {}
+    for entry in operators:
+        op = entry.get("op")
+        for row in entry.get("parity_rows") or []:
+            if row in covered_rows:
+                errors.append(
+                    f"C2 parity row {row!r} is claimed by two operators "
+                    f"({covered_rows[row]!r} and {op!r})"
+                )
+            covered_rows[row] = op
+            if row not in parity:
+                errors.append(
+                    f"C2 operator {op!r} names parity row {row!r}, which does not "
+                    f"exist in the parity manifest"
+                )
+    for row in sorted(parity):
+        if AD_PARITY_ROW.match(row) and row not in covered_rows:
+            errors.append(
+                f"C2 AD parity row {row!r} (status {parity[row]!r}) has no operator "
+                f"in the carrier manifest -- an AD op cannot claim a VM status "
+                f"without declaring which carrier answers it"
+            )
+
+    # ── C3 / C4 / C5 per operator ──────────────────────────────────────
+    forked = 0
+    for entry in operators:
+        op = entry.get("op")
+        rows = entry.get("parity_rows") or []
+        statuses = {parity.get(r) for r in rows if r in parity}
+        claims_vm = VM_SUPPORTED in statuses
+
+        for side in ("native", "vm"):
+            spec = entry.get(side)
+            if spec is None:
+                if side == "vm" and claims_vm:
+                    errors.append(
+                        f"C2 operator {op!r} declares no VM implementation but a "
+                        f"parity row reads {VM_SUPPORTED}"
+                    )
+                continue
+            declared = spec.get("carrier")
+            if declared not in carriers:
+                errors.append(
+                    f"C1 operator {op!r} {side} carrier {declared!r} is not in the "
+                    f"carrier vocabulary"
+                )
+                continue
+            if side == "vm" and declared != SHARED_CARRIER:
+                forked += 1
+
+        vm = entry.get("vm")
+        if not isinstance(vm, dict):
+            continue
+        case_id = vm.get("native_call_id")
+        vm_path = vm.get("file")
+        declared = vm.get("carrier")
+        if case_id is None or not vm_path:
+            errors.append(
+                f"C3 operator {op!r} VM block needs both `file` and `native_call_id` "
+                f"so its carrier can be re-derived from source"
+            )
+            continue
+        abs_path = os.path.join(repo_root, vm_path)
+        helpers = vm.get("helpers") or []
+        try:
+            normalised = strip_noise(read_source(abs_path), vm_path)
+            block = extract_case_block(normalised, int(case_id))
+            for helper in helpers:
+                block += "\n" + extract_function_block(normalised, helper)
+        except GateError as exc:
+            errors.append(f"C3 operator {op!r}: {exc}")
+            continue
+        observed = classify_carrier(block, carriers, vm_path)
+        findings.append(
+            {
+                "op": op,
+                "native_call_id": case_id,
+                "helpers": helpers,
+                "declared_carrier": declared,
+                "observed_carrier": observed,
+                "parity_rows": {r: parity.get(r, "<absent>") for r in rows},
+                "claims_vm_supported": claims_vm,
+            }
+        )
+        if observed != declared:
+            errors.append(
+                f"C3 operator {op!r} (case {case_id} in {vm_path}) declares carrier "
+                f"{declared!r} but its source classifies as {observed!r}"
+            )
+        effective = observed if observed != "unclassified" else declared
+        exact = bool((carriers.get(effective) or {}).get("exact"))
+        if claims_vm and not exact:
+            errors.append(
+                f"C4 operator {op!r} has a {VM_SUPPORTED} parity row but its VM "
+                f"carrier {effective!r} is not exact -- a finite difference may "
+                f"never back a vm-supported AD op"
+            )
+        if claims_vm and observed == "unclassified":
+            errors.append(
+                f"C4 operator {op!r} claims {VM_SUPPORTED} but case {case_id} touches "
+                f"no known carrier witness -- an unclassifiable AD path cannot be "
+                f"graded exact"
+            )
+
+    if forked > budget:
+        errors.append(
+            f"C5 {forked} operators run a VM carrier that is not the shared node "
+            f"model, over the shrink-only budget of {budget} -- the AD fork grew"
+        )
+
+    # ── C7 scan scope, then C6 FD ledger ───────────────────────────────
+    declared_files = set()
+    for entry in operators:
+        for side in ("native", "vm"):
+            spec = entry.get(side)
+            if isinstance(spec, dict) and spec.get("file"):
+                declared_files.add(spec["file"])
+    for path in sorted(declared_files - set(scan_paths)):
+        errors.append(
+            f"C7 {path} backs an operator but is not in fd_scan.paths -- the scan "
+            f"set may not exclude a file the manifest itself relies on"
+        )
+
+    ledgered: dict[tuple[str, str], dict] = {}
+    for item in allowlist:
+        if not isinstance(item, dict):
+            errors.append("C6 fd_allowlist contains a non-mapping entry")
+            continue
+        missing = [f for f in ("path", "symbol", "owner", "op", "justification") if not item.get(f)]
+        if missing:
+            errors.append(
+                f"C6 fd_allowlist entry {item.get('symbol') or '<unnamed>'} is missing "
+                f"{', '.join(missing)} -- a ledgered finite difference states who owns "
+                f"it, which op it serves and why it is not a defect"
+            )
+            continue
+        ledgered[(item["path"], item["symbol"])] = item
+
+    fd_sites: list[dict] = []
+    for rel in scan_paths:
+        abs_path = os.path.join(repo_root, rel)
+        try:
+            normalised = strip_noise(read_source(abs_path), rel)
+        except GateError as exc:
+            errors.append(f"C6 {exc}")
+            continue
+        for site in find_fd_sites(normalised, rel):
+            site["ledgered"] = (site["path"], site["symbol"]) in ledgered
+            fd_sites.append(site)
+            if not site["ledgered"]:
+                errors.append(
+                    f"C6 unledgered {site['kind']} finite difference: {site['path']}:"
+                    f"{site['line']} steps by {site['symbol']!r} on an AD path"
+                )
+
+    for key in sorted(ledgered):
+        if not any(s["path"] == key[0] and s["symbol"] == key[1] for s in fd_sites):
+            errors.append(
+                f"C6 fd_allowlist entry {key[1]!r} in {key[0]} matches no site the scan "
+                f"found -- a stale waiver hides the next real one"
+            )
+
+    return {
+        "passed": not errors,
+        "errors": errors,
+        "operators": findings,
+        "fd_sites": fd_sites,
+        "forked_carriers": forked,
+        "forked_carrier_budget": budget,
+    }
+
+
+# ───────────────────────────── reporting ─────────────────────────────
+
+def emit_trace(trace_dir: str, status: str, snippet: str) -> str:
+    os.makedirs(trace_dir, exist_ok=True)
+    path = os.path.join(trace_dir, TRACE_BASENAME)
+    event = {
+        "kind": "eshkol_smoke",
+        "name": PROBE_ID,
+        "value": status,
+        "snippet": snippet[:2000],
+        "confidence": 1.0,
+    }
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+    return path
+
+
+# ───────────────────────────── self-test ─────────────────────────────
+#
+# Every fixture below is a RED fixture paired with the GREEN one it was
+# derived from. A gate that has only ever been observed green is
+# indistinguishable from a gate that cannot go red, which is the defect this
+# file exists to end -- so the gate refuses to be trusted until it has
+# demonstrated the opposite on each check it claims to enforce.
+
+_GOOD_SOURCE = """
+switch (fid) {
+case 750: { /* gradient */
+    double point[8];
+    VM_AD_MAKE_DUAL(vm, point[0], 1.0, dual_arg);
+    Value result = vm_call_closure_from_native(vm, f_val, &dual_arg, 1);
+    break;
+}
+case 754: { /* curl */
+    VM_AD_MAKE_DUAL(vm, point[j], 1.0, args[j]);
+    jac[i][j] = rd->tangent;
+    break;
+}
+}
+"""
+
+# The real defect, reduced: a central difference at h = 1e-7 inside the curl
+# case, with prose that honestly describes it. This is what shipped.
+_FD_SOURCE = """
+switch (fid) {
+case 750: { /* gradient */
+    VM_AD_MAKE_DUAL(vm, point[0], 1.0, dual_arg);
+    break;
+}
+case 754: { /* curl via central differences */
+    double h = 1e-7;
+    for (int j = 0; j < 3; j++) {
+        ap[k] = FLOAT_VAL(point[k] + ((k == j) ? h : 0));
+        am[k] = FLOAT_VAL(point[k] - ((k == j) ? h : 0));
+        jac[i][j] = (fp[i] - fm[i]) / (2.0 * h);
+    }
+    break;
+}
+}
+"""
+
+# The clamp and the tolerance: the same order of magnitude, used only in a
+# comparison. Must NOT be flagged, or the gate is noise and gets disabled.
+_CLAMP_SOURCE = """
+switch (fid) {
+case 750: {
+    VM_AD_MAKE_DUAL(vm, point[0], 1.0, dual_arg);
+    llvm::Value* eps = llvm::ConstantFP::get(ctx_.doubleType(), 1e-7);
+    llvm::Value* safe = ctx_.builder().CreateSelect(
+        ctx_.builder().CreateFCmpOLT(denom, eps), eps, denom);
+    double tol = 1e-12;
+    if (fabs(a - b) < tol) { return 1; }
+    break;
+}
+case 754: {
+    VM_AD_MAKE_DUAL(vm, point[j], 1.0, args[j]);
+    break;
+}
+}
+"""
+
+_BASE_MANIFEST = {
+    "schema": EXPECTED_SCHEMA,
+    "carriers": {
+        SHARED_CARRIER: {"exact": True, "shared": True, "witnesses": [r"\bad_add\s*\("]},
+        "vm-dual-forward": {"exact": True, "shared": False, "witnesses": [r"\bVM_AD_MAKE_DUAL\s*\("]},
+        "native-jet": {"exact": True, "shared": False, "witnesses": [r"\bseedForwardAndPush\s*\("]},
+        FD_CARRIER: {"exact": False, "shared": False, "witnesses": []},
+    },
+    "fork_debt": {"forked_carrier_budget": 2},
+    "fd_scan": {"paths": ["vm.c"]},
+    "fd_allowlist": [],
+    "operators": [
+        {
+            "op": "gradient",
+            "parity_rows": ["op:GRADIENT"],
+            "native": {"file": "vm.c", "carrier": "native-jet"},
+            "vm": {"file": "vm.c", "native_call_id": 750, "carrier": "vm-dual-forward"},
+        },
+        {
+            "op": "curl",
+            "parity_rows": ["op:CURL"],
+            "native": {"file": "vm.c", "carrier": "native-jet"},
+            "vm": {"file": "vm.c", "native_call_id": 754, "carrier": "vm-dual-forward"},
+        },
+    ],
+}
+
+_PARITY_GREEN = "# name\tstatus\nop:GRADIENT\tvm-supported\t\nop:CURL\tvm-supported\t\n"
+
+
+def _deep_copy(obj):
+    return json.loads(json.dumps(obj))
+
+
+def _write_case(tmp_dir: str, name: str, source: str, manifest: dict, parity: str) -> tuple[dict, str, dict]:
+    case_dir = os.path.join(tmp_dir, name)
+    os.makedirs(case_dir, exist_ok=True)
+    with open(os.path.join(case_dir, "vm.c"), "w", encoding="utf-8") as handle:
+        handle.write(source)
+    parity_path = os.path.join(case_dir, "PARITY.tsv")
+    with open(parity_path, "w", encoding="utf-8") as handle:
+        handle.write(parity)
+    return manifest, case_dir, load_parity(parity_path)
+
+
+def self_test() -> bool:
+    cases: list[tuple[str, str, dict, str, bool, str]] = []
+
+    # GREEN baseline -- exact duals on both ops, nothing to flag.
+    cases.append(("green_exact_duals", _GOOD_SOURCE, _deep_copy(_BASE_MANIFEST), _PARITY_GREEN, True,
+                  "exact dual carriers, declared == observed"))
+
+    # RED C3/C4/C6 -- the shipped defect: a vm-supported op backed by a
+    # central difference while the manifest claims a dual.
+    cases.append(("red_central_difference_under_vm_supported", _FD_SOURCE, _deep_copy(_BASE_MANIFEST),
+                  _PARITY_GREEN, False,
+                  "central difference at h=1e-7 backing a vm-supported op"))
+
+    # GREEN -- a clamp and an equality tolerance at the same magnitude must
+    # not be mistaken for a step size.
+    cases.append(("green_clamp_and_tolerance_are_not_fd", _CLAMP_SOURCE, _deep_copy(_BASE_MANIFEST),
+                  _PARITY_GREEN, True,
+                  "1e-7 clamp and 1e-12 tolerance are comparisons, not steps"))
+
+    # GREEN -- the same finite difference, ledgered with an owner and a
+    # justification. A declared FD escape hatch is allowed to exist.
+    ledgered = _deep_copy(_BASE_MANIFEST)
+    ledgered["fd_allowlist"] = [{
+        "path": "vm.c", "symbol": "h", "owner": "tsotchke", "op": "curl",
+        "justification": "self-test fixture: a deliberately ledgered FD site",
+    }]
+    ledgered["operators"][1]["vm"]["carrier"] = FD_CARRIER
+    ledgered["operators"][1]["parity_rows"] = ["op:CURL"]
+    cases.append(("green_ledgered_fd_on_a_gap_row", _FD_SOURCE, ledgered,
+                  "# name\tstatus\nop:GRADIENT\tvm-supported\t\nop:CURL\tgap\tledgered FD\n", True,
+                  "ledgered FD backing a `gap` row is permitted"))
+
+    # RED C4 -- the same ledgered FD, but the op now claims vm-supported.
+    # Ledgering an FD does not license claiming parity on it.
+    ledgered_claimed = _deep_copy(ledgered)
+    cases.append(("red_ledgered_fd_cannot_claim_vm_supported", _FD_SOURCE, ledgered_claimed,
+                  _PARITY_GREEN, False,
+                  "a ledgered FD still may not back a vm-supported op"))
+
+    # RED C2 -- a new AD op appears in PARITY.tsv as vm-supported with no
+    # manifest row at all. This is the exact shape of the v1.3.4 promotion.
+    cases.append(("red_undeclared_vm_supported_ad_op", _GOOD_SOURCE, _deep_copy(_BASE_MANIFEST),
+                  _PARITY_GREEN + "op:HESSIAN\tvm-supported\t\n", False,
+                  "an AD op promoted to vm-supported with no carrier declaration"))
+
+    # RED C3 -- the manifest is edited to claim the shared node model over a
+    # body that plainly uses the private dual carrier. Proves the declaration
+    # is verified, not believed.
+    lying = _deep_copy(_BASE_MANIFEST)
+    lying["operators"][0]["vm"]["carrier"] = SHARED_CARRIER
+    cases.append(("red_manifest_claims_shared_model_falsely", _GOOD_SOURCE, lying, _PARITY_GREEN, False,
+                  "declaring shared-node-model over a VmDual body"))
+
+    # RED C5 -- the fork grows past its shrink-only budget.
+    over = _deep_copy(_BASE_MANIFEST)
+    over["operators"].append({
+        "op": "laplacian",
+        "parity_rows": ["op:LAPLACIAN"],
+        "native": {"file": "vm.c", "carrier": "native-jet"},
+        "vm": {"file": "vm.c", "native_call_id": 750, "carrier": "vm-dual-forward"},
+    })
+    cases.append(("red_fork_budget_exceeded", _GOOD_SOURCE, over,
+                  _PARITY_GREEN + "op:LAPLACIAN\tvm-supported\t\n", False,
+                  "a third forked carrier over a shrink-only budget of two"))
+
+    # RED C7 -- silencing a finding by dropping the file from the scan set.
+    narrowed = _deep_copy(_BASE_MANIFEST)
+    narrowed["fd_scan"]["paths"] = ["PARITY.tsv"]
+    cases.append(("red_scan_set_narrowed_to_hide_a_site", _FD_SOURCE, narrowed, _PARITY_GREEN, False,
+                  "removing the scanned file to hide the difference quotient"))
+
+    all_ok = True
+    print("gate_ad_shared_node_model.py self-test:")
+    with tempfile.TemporaryDirectory(dir=REPO_ROOT, prefix=".selftest-ad-carrier-") as tmp_dir:
+        for name, source, manifest, parity, expect_passed, description in cases:
+            manifest, case_dir, parity_rows = _write_case(tmp_dir, name, source, manifest, parity)
+            try:
+                result = audit(manifest, parity_rows, case_dir)
+            except GateError as exc:
+                result = {"passed": False, "errors": [str(exc)]}
+            ok = result["passed"] == expect_passed
+            all_ok = all_ok and ok
+            verdict = "OK" if ok else "GATE IS BROKEN"
+            arrow = "PASS" if expect_passed else "FAIL"
+            print(f"  [{verdict}] {name}: expected {arrow} -- {description}")
+            if not result["passed"]:
+                for err in result["errors"][:3]:
+                    print(f"            {err}")
+
+    if all_ok:
+        print("self-test: PASS -- the gate goes red on an undeclared vm-supported AD op, "
+              "on a false carrier declaration, on an unledgered difference quotient, on a "
+              "ledgered one that claims parity, on a grown fork and on a narrowed scan set; "
+              "and stays green on exact duals, on clamps and on tolerances")
+    else:
+        print("self-test: FAIL -- the gate did not discriminate red input from green input",
+              file=sys.stderr)
+    return all_ok
+
+
+# ───────────────────────────── entry point ─────────────────────────────
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--manifest", default=os.environ.get("ESHKOL_AD_MANIFEST", DEFAULT_MANIFEST))
+    parser.add_argument("--parity", default=DEFAULT_PARITY)
+    parser.add_argument("--repo-root", default=REPO_ROOT)
+    parser.add_argument("--trace-dir", default=DEFAULT_TRACE_DIR)
+    parser.add_argument("--no-trace", action="store_true", help="grade only, write no trace")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--self-test", action="store_true", help="run built-in red/green fixtures and exit")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return 0 if self_test() else 1
+
+    try:
+        manifest = _load_yaml(args.manifest)
+        parity = load_parity(args.parity)
+        result = audit(manifest, parity, args.repo_root)
+    except GateError as exc:
+        snippet = f"AD carrier model ungradeable: {exc}"
+        if not args.no_trace:
+            emit_trace(args.trace_dir, "FAIL", snippet)
+        if args.format == "json":
+            print(json.dumps({"status": "FAIL", "error": str(exc)}, indent=2))
+        else:
+            print(f"{PROBE_ID}: FAIL -- {exc}", file=sys.stderr)
+        return 1
+
+    status = "PASS" if result["passed"] else "FAIL"
+    if result["passed"]:
+        snippet = (
+            f"{len(result['operators'])} AD operators: every declared carrier re-derived from "
+            f"source and matched; {result['forked_carriers']}/{result['forked_carrier_budget']} "
+            f"forked carriers; {len(result['fd_sites'])} finite-difference site(s), all ledgered"
+        )
+    else:
+        snippet = f"{len(result['errors'])} finding(s): " + "; ".join(result["errors"][:4])
+
+    if not args.no_trace:
+        emit_trace(args.trace_dir, status, snippet)
+
+    if args.format == "json":
+        print(json.dumps({"status": status, **result}, indent=2))
+    else:
+        print(f"{PROBE_ID}: {status}")
+        print(f"  manifest    : {args.manifest}")
+        print(f"  parity      : {args.parity}")
+        print(f"  fork        : {result['forked_carriers']} forked carrier(s), "
+              f"budget {result['forked_carrier_budget']} (shrink-only)")
+        print()
+        header = f"{'operator':<24} {'fid':>5}  {'declared':<22} {'observed':<22} {'vm-supported':<12}"
+        print(header)
+        print("-" * len(header))
+        for f in result["operators"]:
+            mark = "" if f["declared_carrier"] == f["observed_carrier"] else "   <-- MISMATCH"
+            print(
+                f"{f['op']:<24} {str(f['native_call_id']):>5}  {str(f['declared_carrier']):<22} "
+                f"{f['observed_carrier']:<22} {str(f['claims_vm_supported']):<12}{mark}"
+            )
+        if result["fd_sites"]:
+            print("\n  finite-difference sites:")
+            for s in result["fd_sites"]:
+                tag = "ledgered" if s["ledgered"] else "UNLEDGERED"
+                print(f"    [{tag}] {s['path']}:{s['line']} {s['kind']} step {s['symbol']!r}")
+        if result["errors"]:
+            print("\n  ERRORS:")
+            for error in result["errors"]:
+                print(f"    - {error}")
+
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -980,6 +980,41 @@ probe no_open_silent_wrong \
     'No open, unwaived SILENT-WRONG flaw in .icc/silent-wrong-ledger.yaml (wrong value / wrong derivative / wrong memory outcome with no diagnostic and exit 0 is tag-blocking)' \
     'cd "$REPO_ROOT"; python3 scripts/gate_no_silent_wrong.py --no-trace'
 
+# ───────────────────────────────────────────────────────────────────
+# AD carrier gates. The first is structural: every AD operator's
+# differentiation carrier is declared in .icc/ad-carrier-manifest.yaml
+# and re-derived from source, so an op cannot claim VM parity on an
+# undeclared carrier and cannot claim it at all on a finite difference.
+# The second is behavioural, and exists because a structural check
+# grades text: it runs a gradient field through the VM and demands both
+# the exact answer and a zero finite-difference counter. Structure
+# without behaviour is how SW-51 stayed green; behaviour without
+# structure is how SW-52 did.
+# ───────────────────────────────────────────────────────────────────
+probe ad_carrier_model_clean \
+    'Every AD op declared vm-supported routes through a declared, source-verified, exact carrier and no unledgered finite difference exists on either engine' \
+    'cd "$REPO_ROOT"; python3 scripts/gate_ad_shared_node_model.py --no-trace'
+
+probe ad_vm_curl_divergence_exact \
+    'VM curl of a gradient field is exactly #(0 0 0) and costs zero finite-difference evaluations' \
+    'vmbin="$BUILD_DIR/eshkol-vm-standalone-test";
+     if [ ! -x "$vmbin" ]; then echo "VM standalone binary not built: $vmbin"; exit 1; fi;
+     tmp=$(mktemp).esk;
+     cat > "$tmp" <<EOF
+(ad-reset-counters!)
+(define (F x y z) (list (* y z) (* x z) (* x y)))
+(display "CURL=") (display (curl F (list 1.0 2.0 3.0)))
+(display "|DIV=") (display (divergence F (list 1.0 2.0 3.0)))
+(display "|FD=") (display (ad-finite-difference-evals))
+EOF
+     out=$("$vmbin" "$tmp" 2>&1); rc=$?; rm -f "$tmp";
+     if [ $rc -ne 0 ]; then printf "%s" "$out" | tail -c 300; exit 1; fi;
+     flat=$(printf "%s" "$out" | tr -d "\n");
+     case "$flat" in
+       *"CURL=#(0 0 0)|DIV=0|FD=0"*) exit 0 ;;
+       *) printf "%s" "$flat" | grep -o "CURL=.*FD=[0-9]*"; exit 1 ;;
+     esac'
+
 echo
 echo "Trace written: $TRACE_FILE"
 echo "Probe summary: $((PROBE_TOTAL - PROBE_FAILURES))/$PROBE_TOTAL passed"

--- a/tests/ad/ad_vm_exactness_gate.sh
+++ b/tests/ad/ad_vm_exactness_gate.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# SW-46 gate: the bytecode VM's divergence and curl are EXACT.
+#
+# Both operators used to reach their answer through a central difference at
+# h = 1e-7 (lib/backend/vm_native.c, cases 753 and 754). The error that
+# introduces is small, plausible and completely silent: `curl` of a gradient
+# field — whose curl vanishes identically at every point — returned
+#
+#     #(1.1102230246251565e-09 -3.3306690738754696e-09 0)
+#
+# instead of #(0 0 0). No diagnostic, exit 0. Nothing could see it: the VM
+# parity differential compares program OUTPUT between engines and op:CURL is a
+# `gap` row, so the comparison is never attempted; and native curl SIGSEGVs on
+# the same field (ledger LE-12), so there was no other side to compare against.
+#
+# This gate therefore compares against MATHEMATICS rather than against the
+# other engine. Every field below has a curl and a divergence that is exactly
+# representable in binary floating point, so the assertions are equality, not
+# tolerance — a tolerance is what let the defect live.
+#
+# It also asserts (ad-finite-difference-evals) reads 0. The counter is the
+# structural half of the claim: an exact answer produced by six extra function
+# evaluations is not exact AD, it is a difference quotient that happened to
+# land. Before the fix this program printed FD=6.
+#
+# Usage: ad_vm_exactness_gate.sh <eshkol-run> <eshkol-vm|none> <workdir>
+#
+# Copyright (C) tsotchke
+# SPDX-License-Identifier: MIT
+
+set -u
+
+ESHKOL_RUN="${1:?usage: ad_vm_exactness_gate.sh <eshkol-run> <eshkol-vm|none> <workdir>}"
+ESHKOL_VM="${2:-none}"
+WORKDIR="${3:?workdir required}"
+
+# Fails closed. An absent VM binary is not evidence that the VM's AD is exact,
+# and a gate that passes when its subject is missing is the shape this whole
+# wave exists to remove (ledger SW-51).
+if [ "$ESHKOL_VM" = "none" ] || [ ! -x "$ESHKOL_VM" ]; then
+    echo "FAIL: bytecode VM binary not available ('$ESHKOL_VM') — cannot certify VM AD exactness"
+    exit 1
+fi
+
+mkdir -p "$WORKDIR" || { echo "FAIL: cannot create $WORKDIR"; exit 1; }
+PROG="$WORKDIR/ad_vm_exactness.esk"
+
+cat > "$PROG" <<'ESK'
+(ad-reset-counters!)
+
+;; F1 = grad(xyz): a gradient field, so curl F1 = (0 0 0) identically,
+;; and div F1 = 0 at every point.
+(define (F1 x y z) (list (* y z) (* x z) (* x y)))
+
+;; F2 = rigid rotation about z: curl = (0 0 2) everywhere, div = 0.
+(define (F2 x y z) (list (- y) x (* 0.0 z)))
+
+;; F3: div = 2x + 2y + 2z = 12 at (1 2 3); curl = (0 0 0).
+(define (F3 x y z) (list (* x x) (* y y) (* z z)))
+
+;; F4 = (y^2 z, x z^2, x^2 y): at (1 2 3)
+;;   curl = (x^2 - 2xz, y^2 - 2xy, z^2 - 2yz) = (-5 0 -3); div = 0.
+(define (F4 x y z) (list (* y (* y z)) (* x (* z z)) (* x (* x y))))
+
+(define P (list 1.0 2.0 3.0))
+
+(display "C1=") (display (curl F1 P))
+(display "|C2=") (display (curl F2 P))
+(display "|C3=") (display (curl F3 P))
+(display "|C4=") (display (curl F4 P))
+(display "|D1=") (display (divergence F1 P))
+(display "|D2=") (display (divergence F2 P))
+(display "|D3=") (display (divergence F3 P))
+(display "|D4=") (display (divergence F4 P))
+(display "|FD=") (display (ad-finite-difference-evals))
+(display "|END")
+ESK
+
+OUT=$("$ESHKOL_VM" "$PROG" 2>&1)
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "FAIL: VM exited $RC"
+    printf '%s\n' "$OUT" | tail -20
+    exit 1
+fi
+
+# The VM appends a newline per `display` call (a filed, normalized quirk:
+# tests/vm_parity/found/display_newline_per_call.esk), so flatten before
+# matching.
+FLAT=$(printf '%s' "$OUT" | tr -d '\n')
+
+fail=0
+expect() {
+    local key="$1" want="$2" got
+    got=$(printf '%s' "$FLAT" | sed -n "s/.*|\{0,1\}${key}=\(.*\)/\1/p" | sed 's/|.*//')
+    if [ "$got" != "$want" ]; then
+        echo "FAIL: ${key} = '${got}', expected exactly '${want}'"
+        fail=1
+    else
+        echo "  ok  ${key} = ${want}"
+    fi
+}
+
+case "$FLAT" in
+    *"|END"*) ;;
+    *) echo "FAIL: program did not run to completion"; printf '%s\n' "$OUT" | tail -20; exit 1 ;;
+esac
+
+# Exact equality, deliberately. Each of these is representable.
+expect C1 "#(0 0 0)"
+expect C3 "#(0 0 0)"
+expect C4 "#(-5 0 -3)"
+expect D1 "0"
+expect D2 "0"
+expect D3 "12"
+expect D4 "0"
+expect FD "0"
+
+# curl F2 is (0 0 2); the x and y components may carry a signed zero, which is
+# numerically equal to 0 and is not a derivative error. The z component is the
+# load-bearing one and must be exactly 2 — the difference quotient returned
+# 1.9999999995023998.
+case "$FLAT" in
+    *"C2=#(0 0 2)"*|*"C2=#(0 -0.0 2)"*|*"C2=#(-0.0 0 2)"*|*"C2=#(-0.0 -0.0 2)"*)
+        echo "  ok  C2 z-component = 2 exactly" ;;
+    *)
+        got=$(printf '%s' "$FLAT" | sed -n 's/.*C2=\(.*\)/\1/p' | sed 's/|.*//')
+        echo "FAIL: C2 = '${got}', expected the z-component to be exactly 2"
+        fail=1 ;;
+esac
+
+if [ "$fail" -ne 0 ]; then
+    echo "FAIL: VM divergence/curl are not exact"
+    # The VM echoes its whole bytecode listing before running, so report only
+    # the result segment rather than 100 KB of disassembly.
+    printf 'observed: %s\n' "$(printf '%s' "$FLAT" | sed -n 's/.*\(C1=.*|END\).*/\1/p')"
+    exit 1
+fi
+
+echo "PASS: VM divergence and curl are exact (0 finite-difference evaluations)"
+exit 0

--- a/tests/vm_parity/PARITY.tsv
+++ b/tests/vm_parity/PARITY.tsv
@@ -517,7 +517,7 @@ op:CASE_LAMBDA	gap	wrong clause selected (found/case_lambda_wrong_clause.esk)
 op:COMPOSE	gap	compose undefined in VM
 op:COND	vm-supported	vm_compiler special-form dispatch
 op:COND_EXPAND	native-only-justified	parse-time form handled by the native front-end
-op:CURL	gap	AD surface diverges in VM
+op:CURL	gap	The VM side is now EXACT: case 754 in lib/backend/vm_native.c seeds one forward dual per input variable and reads the tangent of each output component, so a gradient field returns #(0 0 0) exactly where the previous central difference at h=1e-7 returned #(1.1102230246251565e-09 -3.3306690738754696e-09 0), and (ad-finite-difference-evals) reads 0 where it read 6 (ledger SW-46). The row stays a gap because the two engines cannot be COMPARED: native curl SIGSEGVs on a list-returning arity-1 vector field and the LLVM verifier rejects the N-arg-spread shape, since native curl passes the whole point as ONE argument where the VM spreads it into N (ledger LE-12). Two separable items block promotion — the native crash, and the arity convention. A tensor-returning field is exact on neither: VmTensor holds bare doubles and drops every tangent at construction, so the VM now raises a named diagnostic for that shape rather than approximating it.
 op:DEFINE	vm-supported	vm_compiler special-form dispatch
 op:DEFINE_RECORD_TYPE	vm-supported	verified 2026-07
 op:DEFINE_SYNTAX	gap	simple rewrite macros work; recursive and set!-mutating macros diverge (found/recursive_macro_zero.esk, found/macro_set_top_level.esk)
@@ -527,7 +527,7 @@ op:DERIVATIVE_N	gap	arbitrary-order Taylor-tower AD operator not implemented on 
 op:DIFF	gap	AD surface diverges in VM
 op:DIRECTIONAL_DERIV	gap	AD surface diverges in VM
 op:DIV	vm-supported	OP_DIV bytecode (exact-rational result diverges: see / gap row)
-op:DIVERGENCE	gap	AD surface diverges in VM
+op:DIVERGENCE	gap	The VM side is now EXACT for list- and vector-returning fields: case 753 in lib/backend/vm_native.c reads the tangent of output component i after seeding input i, and its finite-difference fallback branch (h=1e-7) is gone. Measured byte-identical to the analytic divergence on four polynomial fields and one transcendental field. The row stays a gap for the same reason op:CURL does — native divergence builds its Jacobian through the same operator path that crashes for curl (ledger LE-12), so no cross-engine comparison exists yet. A tensor-returning field raises a named diagnostic instead of falling back to a difference quotient; closing that needs a tangent-carrying VmTensor (.icc/ad-carrier-manifest.yaml fork_debt.blocked_on).
 op:DNC_ALLOC_WEIGHTS	gap	core.dnc has no VM fids
 op:DNC_CONTENT_ADDR	gap	core.dnc has no VM fids
 op:DNC_LOC_ADDR	gap	core.dnc has no VM fids


### PR DESCRIPTION
Extends #474.

#474 gave `eshkol_ad_count_fd()` a write end and gated the one-pass gradient path with a negative control, so `(= (ad-finite-difference-evals) 0)` is now an assertion that can fail. This PR extends that guarantee to the operators #474 did not reach, and adds the structural half a counter cannot supply.

## What a counter cannot see

Eshkol differentiates on two substrates. The only check that compared them compared **program output** — and two independently correct implementations agree on output, so an output differential is structurally incapable of reporting which carrier produced either answer. A `gap` parity row removes an operator from the comparison entirely, which is how `op:CURL` was never compared at all.

`INV-ad-exact-no-finite-differences` is `kind: dependency-presence`. It asks whether one of `createDualNumber` / `makeDual8` / `makeDual4` / `seedForwardAndPush` is **present**; all four are native symbols in `lib/backend/autodiff_codegen.cpp`. Measured on this branch with a central difference planted into `vm_native.c` case 756:

```
$ icc architecture-verify --repo eshkol-adcarrier --model .icc/architecture-model.yaml
INV-ad-exact-no-finite-differences -> PASS
  | armed capability constructs its dependency
    (createDualNumber|makeDual8|makeDual4|seedForwardAndPush)
    at ['lib/backend/autodiff_codegen.cpp']
```

The tool prints its own reason. Presence of an exact constructor on one engine and presence of a difference quotient on the other are not mutually exclusive, and on `master` both held at once.

## The carrier manifest and the gate

`.icc/ad-carrier-manifest.yaml` declares, for every AD operator and every substrate, which differentiation carrier answers it and whether that carrier is exact. `scripts/gate_ad_shared_node_model.py` grades it and **believes none of it**: each declaration is re-derived by extracting the operator's `case <native_call_id>:` block — plus any declared helper, so delegation cannot launder a carrier — from the named source, stripping comments and literals, and classifying which carrier witnesses the body actually touches.

Seven checks:

| | |
|---|---|
| C1 | manifest well-formedness, carriers drawn from its own vocabulary |
| C2 | coverage in both directions against `tests/vm_parity/PARITY.tsv` — an AD op cannot be promoted to `vm-supported` without declaring its carrier |
| C3 | every declaration re-derived from source; declared must equal observed |
| C4 | a `vm-supported` row requires an exact carrier; a finite difference may never back one |
| C5 | shrink-only ratchet on the size of the carrier fork (9 today) |
| C6 | every difference-quotient site ledgered with an owner, the op it serves and a justification |
| C7 | the scan set covers every file the manifest relies on, so a finding cannot be silenced by dropping a path |

Finite differences are detected by **shape**, not magnitude. The six `1e-7` constants in `autodiff_codegen.cpp` are Poincaré-ball divisor clamps (`select(denom < eps, eps, denom)`) and the `1e-12` in `vm_dual.c` is an equality tolerance — neither is a step size. A step size is added to a base expression, subtracted from it, and divided into the difference. `lib/core/ad/tape.esk`'s `record-fd-op!` at `tape-fd-eps` = 1.0e-6 is the one deliberate site, allowlisted with the justification that it is the Scheme-layer analogue of `AD_NODE_CUSTOM` — the escape hatch for an opaque forward function with no analytic adjoint, named at its call site, and unreachable from any default gradient path.

## Proof the gate goes red

**On real code, at `f1c21648`, with #474 fully in place.** Same tree, same build, three gates:

```
$ ./scripts/run_ad_exactness_gate.sh                    # #474's gate
  fd-counter  AOT  PASS (12 checks)
  fd-counter  VM   PASS
  AD exactness gate: PASS                                 exit 0

$ python3 scripts/gate_ad_shared_node_model.py           # this PR's gate
  ad_carrier_model_clean: FAIL
  divergence  753  vm-dual-forward  finite-difference    <-- MISMATCH
  curl        754  vm-dual-forward  finite-difference    <-- MISMATCH
  finite-difference sites:
    [UNLEDGERED] lib/backend/vm_native.c:13563 central step 'h'
    [UNLEDGERED] lib/backend/vm_native.c:13641 central step 'h'
    [ledgered]   lib/core/ad/tape.esk:150 central step 'tape-fd-eps'
                                                          exit 1

$ bash tests/ad/ad_vm_exactness_gate.sh …                # this PR's ctest
  FAIL: C1 = '#(1.1102230246251565e-09 -3.3306690738754696e-09 0)', expected exactly '#(0 0 0)'
  FAIL: C4 = '#(-4.999999990706883 -6.661338147750939e-09 -2.9999999906493713)', expected exactly '#(-5 0 -3)'
  FAIL: FD = '24', expected exactly '0'
  FAIL: C2 = '#(0 0 1.9999999995023998)', expected the z-component to be exactly 2
                                                          exit 1
```

**On a planted epsilon.** A central difference at `h = 1e-7` inserted into case 756 (`directional-derivative`), an operator that is otherwise clean:

```
directional-derivative  756  vm-dual-forward  finite-difference   <-- MISMATCH
[UNLEDGERED] lib/backend/vm_native.c:13781 central step 'h'
C3 operator 'directional-derivative' declares carrier 'vm-dual-forward' but its source classifies as 'finite-difference'
```

`INV-ad-exact-no-finite-differences` read `PASS` on that same tree. `./scripts/run_ad_exactness_gate.sh` cannot see it either — the planted path is never executed, and an execution gate grades what runs.

**On a deliberately forked op.** `INV-ad-carrier-declared-for-every-vm-op`, added to the architecture model, and the gate's C2, both go red when `op:VECTOR_GRADIENT vm-supported` is appended to `PARITY.tsv` with no carrier row:

```
INV-ad-carrier-declared-for-every-vm-op -> FAIL | sites resolve DIFFERENT identifier spaces
ad_carrier_model_clean: FAIL
  C2 AD parity row 'op:VECTOR_GRADIENT' (status 'vm-supported') has no operator in the carrier manifest
```

**`--self-test`, wired into the assurance-gates job**, pairs nine fixtures: an undeclared `vm-supported` AD op, a false carrier declaration, an unledgered difference quotient, a ledgered one that claims parity, a grown fork, a narrowed scan set — all red; exact duals, a `1e-7` clamp and a `1e-12` tolerance — all green.

## Exact divergence and curl

Case 754 seeded no duals at all. It built its 3×3 Jacobian from central differences, so a gradient field — whose curl vanishes identically at every point — answered `#(1.1102230246251565e-09 -3.3306690738754696e-09 0)`. Case 753 fell back to the same quotient for a tensor-returning field.

Both now seed one forward dual per input variable and read the tangent of each output component, through one shared reader (`vm_ad_field_component_tangent`) so the two operators cannot drift apart in exactness again. Measured on the same binary and the same program, before and after:

| field at (1, 2, 3) | before | after | exact |
|---|---|---|---|
| `curl` grad(xyz) | `#(1.1102230246251565e-09 -3.3306690738754696e-09 0)` | `#(0 0 0)` | (0, 0, 0) |
| `curl` (−y, x, 0) | `#(0 0 1.9999999995023998)` | z exactly `2` | (0, 0, 2) |
| `curl` (y²z, xz², x²y) | `#(-4.999999990706883 -6.661338147750939e-09 -2.9999999906493713)` | `#(-5 0 -3)` | (−5, 0, −3) |
| `divergence`, five fields | already exact | byte-identical | — |
| `(ad-finite-difference-evals)` | `24` | `0` | — |

Curl now costs three closure calls where the quotient needed six.

A tensor-returning vector field cannot carry tangents through `VmTensor`, whose `data` is a bare `double*`. That shape raises a named diagnostic rather than approximating — the ESH-0369 ruling applied to the same class of problem. Closing it needs a tangent-carrying `VmTensor`; it is recorded as `fork_debt.blocked_on`, and it is the same missing carrier behind `op:JACOBIAN`'s vector-output row.

## The fork, enumerated and capped

Nine operators run a VM carrier that is not the shared node model. That is now a number in a file with a shrink-only budget, rather than an unstated property of the codebase:

```
operator                   fid  declared               observed               vm-supported
derivative                 393  vm-dual-forward        vm-dual-forward        True
diff                       393  vm-dual-forward        vm-dual-forward        False
gradient                   750  vm-dual-forward        vm-dual-forward        True
jacobian                   751  vm-dual-forward        vm-dual-forward        False
hessian                    752  vm-hyperdual-forward   vm-hyperdual-forward   False
divergence                 753  vm-dual-forward        vm-dual-forward        False
curl                       754  vm-dual-forward        vm-dual-forward        False
laplacian                  755  vm-hyperdual-forward   vm-hyperdual-forward   False
directional-derivative     756  vm-dual-forward        vm-dual-forward        False
ad-tape                    408  shared-node-model      shared-node-model      True
```

`ad-tape` is the shape the rest are moving toward: `lib/backend/vm_autodiff.c` is exported for LLVM codegen and reached from native Scheme through `ad_tape_new_owned()`, so the Scheme-visible `ad-*` primitives are one implementation on both substrates.

`AD_NODE_CUSTOM` cannot cross to the VM today. `docs/reference/ad/architecture.md` now carries the substrate carrier map and the four concrete blockers — vocabulary (`AdOpType` has no `CUSTOM`), node shape (one `double saved` slot against `saved_tensors` + `num_saved`), input handles (`ad_node**` against relocatable indices), and the reverse driver (`eshkol_ad_node_custom_backward` is hard-typed to `ad_node_t*`) — with the ordered work to close each.

## Also

- `tests/ad/ad_vm_exactness_gate.sh` + ctest `ad_vm_exactness_gate`. It compares against **mathematics**, not against the other engine, because the other engine cannot be reached here (see LE-12). Every field has an exactly representable curl and divergence, so the assertions are equality — a tolerance is what let this live.
- ICC smoke probes `ad_carrier_model_clean` and `ad_vm_curl_divergence_exact`, with `severity: high` oracle criteria.
- `INV-ad-carrier-declared-for-every-vm-op` in the architecture model; the scope of `INV-ad-exact-no-finite-differences` recorded on the invariant itself. The original is kept and unweakened — it answers a narrower question correctly.
- Ledger: **SW-46** (the curl defect, the id #474 reserved), **SW-51** and **SW-52** in #474's `VACUOUS-ASSURANCE` bucket, **LE-12** (native `curl` SIGSEGVs on a list-returning vector field, found while looking for a cross-engine baseline and the reason none exists). `check_ledger_integrity.py` PASS at 96 entries.
- `PARITY.tsv` rows for `op:CURL` and `op:DIVERGENCE` record that the VM side is now exact and name the two items that still block promotion.

## Verification

| | |
|---|---|
| `ctest` | 194/194 |
| `scripts/run_vm_parity.sh` | 188 passed, 0 failed |
| `scripts/run_ad_oracle.sh` | 88/88 |
| `scripts/run_autodiff_tests.sh` | 60/60 |
| `scripts/run_ad_exactness_gate.sh` (#474's) | PASS, unmodified |
| `gate_ad_shared_node_model.py --self-test` | 9/9 fixtures discriminate |
| `check_ledger_integrity.py` / `gate_no_silent_wrong.py` / `check_oracle_schema.py` / `audit_oracle_false_green.py` | PASS |
| `icc architecture-verify` | 11 invariants graded, both AD invariants PASS |

RelWithDebInfo, LLVM 21, arm64-apple-darwin24.1.0.
