### PR TITLE
fix(ledger): renumber the linearity no-cloning entry to SW-53

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -3632,7 +3632,7 @@ entries:
       it makes the project look worse than it is and, more dangerously, trains readers to
       discount the 25 that are still real. Re-running found/ belongs in the parity gate.
 
-  - id: SW-46
+  - id: SW-53
     bucket: SILENT-WRONG
     status: closed
     closed_at: "feat/linearity-complete"


### PR DESCRIPTION
Two parallel lanes each claimed ledger id SW-46: the linearity no-cloning entry (closed by feat/linearity-complete, #482) and the VM curl exactness entry (closed by feat/ad-structural-gate, #487). The keep-both conflict resolution preserved both entries but left the id duplicated, and check_ledger_integrity.py correctly fails on it — assurance-gates is red on master head as a result.

Every external reference to SW-46 (.icc/architecture-model.yaml, .icc/completion-oracles.yaml, CMakeLists.txt, tests/ad/ad_vm_exactness_gate.sh, tests/vm_parity/PARITY.tsv) intends the curl entry, so the curl entry keeps the id and the linearity entry takes the next free id, SW-53. No external file references the linearity entry by id.

check_ledger_integrity.py: exit 0 after the change.