### PR TITLE
ci(pgo): wire bench/pgo_corpus/ as a Stage-1 smoke consumer (ADR 0007)

### DIFF
--- a/.github/workflows/adversarial-nightly.yml
+++ b/.github/workflows/adversarial-nightly.yml
@@ -86,6 +86,47 @@ jobs:
           if-no-files-found: ignore
 
   # ---------------------------------------------------------------------------
+  # bench/pgo_corpus/ Stage-1 smoke consumer (ADR 0007). The corpus (5
+  # programs) had zero callers anywhere before this: nothing compiled it,
+  # nothing ran it. Full PGO wiring (eshkol-pgo-train/-merge/-verify driving
+  # -fprofile-instr-generate/-use over this corpus) is a tracked BUILD ITEM
+  # against ADR 0007, targeted v1.5.0 — real orchestration work, not a
+  # one-line follow-up. Until that lands, this job is the floor: every
+  # corpus program must still compile and run clean, under both JIT and
+  # AOT, with identical output between the two. Cheap (no LLVM PGO
+  # instrumentation, just a normal build), so nightly is generous headroom
+  # rather than a runtime-cost necessity — kept out of the PR-blocking path
+  # so a corpus-authoring PR doesn't need a second full build in ci.yml.
+  # ---------------------------------------------------------------------------
+  pgo-corpus-smoke:
+    name: pgo-corpus-smoke (macOS)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install toolchain (macOS)
+        shell: bash
+        run: |
+          set -euxo pipefail
+          brew install llvm@${LLVM_MAJOR} cmake ninja readline pcre2 sqlite
+
+      - name: Configure & build
+        shell: bash
+        run: |
+          set -euxo pipefail
+          LLVM_PREFIX="$(brew --prefix llvm@${LLVM_MAJOR})"
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
+            -DESHKOL_REQUIRED_LLVM_MAJOR="${LLVM_MAJOR}" \
+            -DLLVM_CONFIG_EXECUTABLE="$LLVM_PREFIX/bin/llvm-config"
+          cmake --build build --target eshkol-run stdlib --parallel
+
+      - name: bench/pgo_corpus smoke (JIT + AOT + parity)
+        shell: bash
+        env:
+          BUILD_DIR: build
+        run: bash scripts/run_pgo_corpus_smoke.sh
+
+  # ---------------------------------------------------------------------------
   # Axis 5 nightly: the concurrency corpus under ThreadSanitizer.
   # ---------------------------------------------------------------------------
   concurrency-tsan:

--- a/bench/pgo_corpus/lists.esk
+++ b/bench/pgo_corpus/lists.esk
@@ -5,7 +5,7 @@
 ;; every Eshkol program leans on.
 
 (require core.list.transform)
-(require core.list.fold)
+(require core.list.higher_order)
 
 ;; Build a list [1..n] without relying on iota (keep it self-contained).
 (define (range n)

--- a/scripts/run_pgo_corpus_smoke.sh
+++ b/scripts/run_pgo_corpus_smoke.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+#
+# run_pgo_corpus_smoke.sh — Stage-1 consumer for bench/pgo_corpus/ (ADR 0007).
+#
+# ADR 0007 names bench/pgo_corpus/ (5 programs) as the training corpus for the
+# eventual eshkol-pgo-train/-merge/-verify orchestration (Phase 1 of the PGO
+# ADR). That orchestration does not exist yet (BUILD ITEM, targeted v1.5.0 —
+# see the ADR's 2026-08-25 attainment note). Until it lands, this corpus had
+# ZERO callers anywhere: nothing compiled it, nothing ran it, so a program
+# could silently bit-rot (stale builtin, broken syntax) for months and no one
+# would notice until someone tried to actually wire PGO training against it.
+#
+# This script is deliberately NOT full PGO wiring. It is the Stage-1 smoke
+# consumer the corpus was missing: for every bench/pgo_corpus/*.esk file it
+#   1. runs the program under the JIT (`eshkol-run -r`),
+#   2. compiles + runs the program AOT (`eshkol-run -o`),
+#   3. asserts both modes exit 0, produce non-empty output, and produce
+#      BYTE-IDENTICAL stdout — a JIT/AOT divergence on this corpus is exactly
+#      the kind of codegen bug PGO training would otherwise bake in silently.
+#
+# What full PGO wiring still needs (tracked against ADR 0007, not this
+# script): the eshkol-pgo-train/-merge/-verify CMake targets that actually
+# drive `-fprofile-instr-generate` -> `llvm-profdata merge` ->
+# `-fprofile-instr-use` over this corpus, plus the Phase 0 O3-assertion
+# runner across every build mode (currently O2, and only for artifact
+# builds). That is a real orchestration project, not a one-line follow-up.
+#
+# Honours $BUILD_DIR (CI passes it via the matrix).
+#
+# Exit codes:
+#   0 — every corpus file passed (JIT ok, AOT ok, outputs match, non-empty).
+#   1 — at least one corpus file failed one of those checks.
+#   2 — infrastructure problem (binary missing, or the corpus itself is
+#       empty/missing — NO_DATA is graded as a hard failure, never a silent
+#       pass: a gate with nothing to check proves nothing).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+BUILD_DIR="${BUILD_DIR:-build}"
+RUN="$BUILD_DIR/eshkol-run"
+CORPUS_DIR="bench/pgo_corpus"
+
+export ESHKOL_PATH="$PROJECT_ROOT/lib${ESHKOL_PATH:+:$ESHKOL_PATH}"
+
+if [ ! -x "$RUN" ]; then
+    echo "ERROR: $RUN not found or not executable (set BUILD_DIR?)." >&2
+    exit 2
+fi
+
+ESHKOL_TEST_ISOLATION_NO_TRAP=1
+ESHKOL_TEST_LIB="$SCRIPT_DIR/lib/test_isolation.sh"
+if [ ! -r "$ESHKOL_TEST_LIB" ]; then
+    echo "FATAL: cannot read $ESHKOL_TEST_LIB" >&2
+    echo "       (the shared test isolation and disk-cleanup prelude)." >&2
+    echo "       Refusing to run: without it this suite has no scratch isolation" >&2
+    echo "       and no bounded disk footprint." >&2
+    exit 2
+fi
+source "$ESHKOL_TEST_LIB"
+eshkol_test_isolation_init "pgo-corpus-smoke"
+trap eshkol_test_isolation_cleanup EXIT
+
+echo "========================================="
+echo "  bench/pgo_corpus smoke consumer (ADR 0007, Stage 1)"
+echo "========================================="
+
+if [ ! -d "$CORPUS_DIR" ]; then
+    echo "NO_DATA: $CORPUS_DIR does not exist." >&2
+    exit 2
+fi
+
+CORPUS_FILES=()
+while IFS= read -r -d '' f; do
+    CORPUS_FILES+=("$f")
+done < <(find "$CORPUS_DIR" -maxdepth 1 -name '*.esk' -print0 | sort -z)
+
+if [ "${#CORPUS_FILES[@]}" -eq 0 ]; then
+    echo "NO_DATA: $CORPUS_DIR contains no .esk files — nothing to smoke-test." >&2
+    echo "         (This is graded as a FAILURE, not a pass: an empty corpus" >&2
+    echo "         means the gate certifies nothing.)" >&2
+    exit 2
+fi
+
+FAILURES=0
+JIT_OUT="$ESHKOL_TEST_TMPDIR/jit.out"
+AOT_OUT="$ESHKOL_TEST_TMPDIR/aot.out"
+AOT_BIN="$ESHKOL_TEST_TMPDIR/pgo_corpus_aot"
+
+for f in "${CORPUS_FILES[@]}"; do
+    name="$(basename "$f")"
+    echo ""
+    echo "--- $name ---------------------------------"
+
+    file_ok=1
+
+    # stdout and stderr are captured SEPARATELY here (unlike the AOT run
+    # below, where the compiled binary emits no compiler diagnostics at
+    # runtime). `eshkol-run -r` compiles and runs in one process, and a
+    # cold LLVM JIT compile of this file prints "remark:"/"warning:"
+    # vectorizer diagnostics to stderr — real, but not part of the
+    # program's own output, and not reproducible run-to-run (a warm
+    # on-disk JIT cache suppresses them on a recompile-free rerun). Folding
+    # them into stdout via 2>&1 made the JIT/AOT parity check below flag a
+    # false divergence on every cold-cache run. Only stdout is compared.
+    if "$RUN" -r "$f" > "$JIT_OUT" 2>"$ESHKOL_TEST_TMPDIR/jit_stderr.log"; then
+        if [ ! -s "$JIT_OUT" ]; then
+            echo "$name: FAIL (JIT produced no output)"
+            cat "$ESHKOL_TEST_TMPDIR/jit_stderr.log"
+            file_ok=0
+        fi
+    else
+        cat "$JIT_OUT" "$ESHKOL_TEST_TMPDIR/jit_stderr.log"
+        echo "$name: FAIL (JIT exited non-zero)"
+        file_ok=0
+    fi
+
+    if "$RUN" -o "$AOT_BIN" "$f" > "$ESHKOL_TEST_TMPDIR/compile.log" 2>&1; then
+        # Same stdout/stderr split as the JIT run above: the tensor corpus
+        # program's first Metal GPU dispatch logs verbose pipeline-calibration
+        # diagnostics to stderr (interleaved with the program's own
+        # `display` output when merged), so only stdout is compared for
+        # parity.
+        if "$AOT_BIN" > "$AOT_OUT" 2>"$ESHKOL_TEST_TMPDIR/aot_run_stderr.log"; then
+            if [ ! -s "$AOT_OUT" ]; then
+                echo "$name: FAIL (AOT produced no output)"
+                cat "$ESHKOL_TEST_TMPDIR/aot_run_stderr.log"
+                file_ok=0
+            fi
+        else
+            cat "$AOT_OUT" "$ESHKOL_TEST_TMPDIR/aot_run_stderr.log"
+            echo "$name: FAIL (AOT binary exited non-zero)"
+            file_ok=0
+        fi
+    else
+        cat "$ESHKOL_TEST_TMPDIR/compile.log"
+        echo "$name: FAIL (AOT compile failed)"
+        file_ok=0
+    fi
+    # `eshkol-run -o <bin>` also leaves a `<bin>.tmp.o` object file sibling
+    # to the binary on every compile — remove both, not just the binary,
+    # or five corpus files' worth of intermediate objects accumulate for
+    # the whole run (disk-budget rule: every harness cleans up after
+    # itself).
+    rm -f -- "$AOT_BIN" "$AOT_BIN.tmp.o"
+
+    if [ "$file_ok" -eq 1 ]; then
+        if ! diff -u "$JIT_OUT" "$AOT_OUT" > "$ESHKOL_TEST_TMPDIR/diff.txt"; then
+            echo "$name: FAIL (JIT and AOT output diverge)"
+            cat "$ESHKOL_TEST_TMPDIR/diff.txt" | sed 's/^/  /'
+            file_ok=0
+        fi
+    fi
+
+    if [ "$file_ok" -eq 1 ]; then
+        echo "$name: PASS"
+        cat "$JIT_OUT" | sed 's/^/  /'
+    else
+        FAILURES=$((FAILURES + 1))
+    fi
+done
+
+echo ""
+echo "========================================="
+if [ "$FAILURES" -eq 0 ]; then
+    echo "pgo-corpus-smoke: PASS (${#CORPUS_FILES[@]} corpus file(s), JIT+AOT+parity)"
+    exit 0
+else
+    echo "pgo-corpus-smoke: FAIL ($FAILURES of ${#CORPUS_FILES[@]} corpus file(s) failed)"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Closes the R8 finding for `bench/pgo_corpus/`: the PGO training corpus (5 programs, ADR 0007) had **zero callers anywhere** — nothing compiled it, nothing ran it. That is not hypothetical: the audit was correct that this rots silently, and it already had. `lists.esk` `(require core.list.fold)` — that module does not exist; `map`/`fold-left` actually live in `core.list.higher_order`. Nobody would have noticed until someone tried to wire real PGO training against this corpus and hit a broken program on day one.

The other two zero-caller gates named in the same sweep — `scripts/run_dbsp_gate.sh` and `scripts/check_depth_coverage.py` — are already wired by #470 (`ci/arm-pillar-harnesses`, in flight): both appear verbatim in that branch's `assurance-gates`/`pillars-fast` job in `ci.yml`. Not duplicated here; verified against that branch's current diff before writing this PR.

## What changed

1. **`bench/pgo_corpus/lists.esk`** — fixed the broken `(require core.list.fold)` → `(require core.list.higher_order)` (the actual module providing `map`/`fold-left`). This is the exact kind of drift a zero-caller asset accumulates; the smoke consumer below is what would have caught it immediately instead of never.
2. **`scripts/run_pgo_corpus_smoke.sh`** (new) — Stage-1 consumer. For every `bench/pgo_corpus/*.esk` file: runs it under the JIT (`eshkol-run -r`), compiles + runs it AOT (`eshkol-run -o`), and asserts both exit 0, produce non-empty stdout, and produce byte-identical stdout between the two modes. A JIT/AOT divergence on this corpus is exactly the kind of codegen bug PGO training would otherwise bake in silently, so this doubles as a real differential check, not just a liveness smoke test. Compiler diagnostics (LLVM loop-vectorizer remarks on a cold JIT compile, Metal GPU pipeline-calibration logging on first GPU dispatch) are captured on stderr, separately from the program's own stdout — folding them together produced a false JIT/AOT divergence on every cold-cache/cold-GPU run during development; fixed before landing.
3. **`.github/workflows/adversarial-nightly.yml`** — new `pgo-corpus-smoke` job (macOS, nightly cron + `workflow_dispatch`), building `eshkol-run`+`stdlib` and running the script above. Kept out of the PR-blocking path: no PGO instrumentation is involved (this is a normal build), so the runtime cost isn't the reason — a corpus-authoring PR simply shouldn't need a second full compiler build in `ci.yml`.

## What this is NOT

This is explicitly Stage-1, not full PGO wiring. ADR 0007 §"Attainment as of `4bf871a0`" already names the real gap precisely: the `eshkol-pgo-train`/`-merge`/`-verify` CMake orchestration targets that drive `-fprofile-instr-generate` → `llvm-profdata merge` → `-fprofile-instr-use` over this corpus don't exist yet, and building them is a real project (tracked against ADR 0007, targeted v1.5.0), not a one-line follow-up. This PR does not touch the `pgo_pipeline_works` ICC oracle criterion (that one grades the actual instrumented-binary pipeline via `run_icc_smoke.sh`, a separate and already-tracked ADR-0007 gap) — conflating the two would misrepresent what Stage-1 proves.

## Red-proof

Ran the new gate against a deliberate violation and confirmed it fails, then reverted:

```
--- arithmetic.esk ---------------------------------
arithmetic.esk: FAIL (JIT exited non-zero)
...
arithmetic.esk: FAIL (AOT compile failed)
...
pgo-corpus-smoke: FAIL (1 of 5 corpus file(s) failed)
```

(injected `(bogus-undefined-function 1 2 3)` into `arithmetic.esk`; reverted after capture — `git diff` on the corpus is clean except for the `lists.esk` fix above)

Also verified the NO_DATA path is graded as a hard failure, not a vacuous pass: with the corpus directory emptied, the script exits 2 with an explicit `NO_DATA:` message rather than exiting 0.

Clean run (current `bench/pgo_corpus/`, after the `lists.esk` fix):

```
pgo-corpus-smoke: PASS (5 corpus file(s), JIT+AOT+parity)
```

## Runtime cost

~10s wall for the smoke script itself on a warm build (5 files × JIT+AOT+parity); the job's dominant cost is the one-time `eshkol-run`+`stdlib` build (~2 min), matching the existing `bench-smoke` job's shape. Nightly, not PR-blocking.

## Disk

The script's own scratch (JIT/AOT output captures, the AOT binary and its `.tmp.o` compile artifact) lives under the shared `test_isolation.sh` per-run tmpdir and is removed via its `EXIT` trap; the AOT binary + `.tmp.o` sibling are also removed per-corpus-file inside the loop rather than accumulating for the whole run.

## Build + test

Ran the standard local build (RelWithDebInfo, LLVM 21, tests/agent-FFI/fixed-point/GPU on, quantum off) and full `ctest`; both green (details in the PR thread once posted). This change touches no C/C++ source.
