### PR TITLE
fix(memory): strict-types accumulator split in memory-fold-lww

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -3939,6 +3939,71 @@ entries:
       that holds on one engine and silently does not on the other — so it was
       fixed rather than documented.
 
+  - id: SW-63
+    bucket: LOUD-ERROR
+    subtag: cheap-fix
+    status: closed
+    closed_at: "feat/noesis-blockers"
+    closed_by: "branch feat/noesis-blockers"
+    family: type-system/stdlib
+    title: "core.memory's memory-fold-lww rejected under --strict-types: a named-let accumulator seeded #f then reassigned to an lww-register Vector, a genuine Boolean/Vector unification conflict HoTT was right to refuse"
+    repro: >-
+      (require core.memory) (define log (make-memory-log 'x))
+      (memory-append! log 'value (cons 'answer 42))
+      (display (memory-fold-lww log 'answer)) — compiled with
+      --strict-types --emit-object. Also filed by a downstream consumer as
+      bug-UU (core.memory strict-lww-register), independently reproduced
+      this session.
+    observed: >-
+      pre-fix (measured at afbaaf5b, current master before this branch):
+      `eshkol-run --strict-types --emit-object` on the repro above exits 1
+      with `[ERROR] Type error: argument 3 of 'loop': expected Boolean, got
+      Vector (line 126:24)` then `HoTT: 1 type errors detected (strict
+      mode)`. Under gradual typing (no --strict-types) the same program ran
+      correctly and printed 42 — so the checker's rejection was not
+      protecting against a real defect, and a strict-mode consumer had no
+      way to get the correct, already-working behavior gradual typing gave
+      everyone else.
+    correct: >-
+      The program computes the right answer (42) either way; --strict-types
+      should accept it, not merely fail loudly at a program that was never
+      wrong.
+    root_cause: >-
+      lib/core/memory.esk's memory-fold-lww used one named-let loop with a
+      single accumulator `reg`, seeded `#f` (Boolean) and reassigned on the
+      first matching event to `(make-lww-register ...)` (a Vector). HoTT
+      unifies a tail-recursive loop parameter's type across every one of its
+      call sites within the loop, so a parameter that is genuinely Boolean
+      on the seed call and Vector on every subsequent call is a real
+      Boolean/Vector conflict as written — not a checker false positive.
+      The loud rejection was doing its job on the source AS WRITTEN; the
+      source's own shape was the defect.
+    fix: >-
+      Split the fold into two functions so each named-let's accumulator has
+      ONE fixed shape for its entire lifetime: memory-lww-key-present? is
+      Boolean-only (never touches a register, so nothing to conflict), and
+      memory-fold-lww-vector is called only once a match is already known to
+      exist, seeding its accumulator with a real (harmless,
+      immediately-overwritten) lww-register instead of #f so it stays
+      Vector-shaped throughout. memory-fold-lww composes the two: check
+      presence, then fold only if present, else #f.
+    evidence: >-
+      tests/typesystem/memory_fold_lww_accumulator_test.esk (EXPECT-MODE
+      strict-types, EXPECT-COMPILE ok), wired into
+      scripts/run_typesystem_tests.sh's existing tests/typesystem/*.esk
+      sweep. Verified directly across engines: native AOT
+      (--strict-types --emit-object), native JIT (--strict-types -r), and
+      VM bytecode emission (--strict-types --profile hosted-vm --emit-eskb)
+      all compile clean with no HoTT diagnostics; default gradual mode is
+      unchanged (still prints 42).
+    caught_by: [downstream-consumer-audit-2026-08-26]
+    missed_by: [icc-smoke, icc-readiness, ctest, run_typesystem_tests]
+    notes: >-
+      A WIP fix for this existed unmerged on an old-master-based branch
+      (codex/memory-fold-lww-strict); this entry's fix re-derives the same
+      structural split, verified against current master and re-tested
+      end-to-end rather than rebase-inherited.
+
   - id: DD-11
     bucket: DOC-DEBT
     status: open

--- a/lib/core/memory.esk
+++ b/lib/core/memory.esk
@@ -113,17 +113,46 @@
 
 ;; Fold 'value-type events for `key` into an LWW register; payload = (key . value).
 ;; Append order is the LWW timestamp (events are totally ordered, incl. post-merge).
-(define (memory-fold-lww log key)
-  (let loop ((evs (memory-events log)) (ts 0) (reg #f))
+;;
+;; Split in two so the named-let accumulator in each loop has ONE fixed shape
+;; across every iteration, not two (Boolean-then-Vector), which is what HoTT
+;; rejects under --strict-types: a tail-recursive loop parameter is unified
+;; across all of its call sites, and seeding it as `#f` only to reassign it to
+;; an `lww-register` vector on the first match makes that unification a real
+;; Boolean/Vector conflict, not a false positive the checker invented — the
+;; loop parameter's static type genuinely varies across iterations as written.
+;;
+;; `memory-lww-key-present?` stays Boolean-only: it never touches a register,
+;; so its own recursion carries no accumulator to conflict. `memory-fold-lww-
+;; vector` is called only once a match is already known to exist, so its
+;; accumulator can start as a real (harmless, immediately-overwritten) LWW
+;; register instead of `#f` and stay Vector-shaped for its entire lifetime.
+(define (memory-lww-key-present? evs key)
+  (if (null? evs)
+      #f
+      (let ((ev (car evs)))
+        (if (and (eq? (memory-event-type ev) (quote value))
+                 (pair? (memory-event-payload ev))
+                 (equal? (car (memory-event-payload ev)) key))
+            #t
+            (memory-lww-key-present? (cdr evs) key)))))
+
+(define (memory-fold-lww-vector evs key)
+  (let loop ((evs evs) (ts 0)
+             (reg (make-lww-register #f -1 (quote memory-fold-lww))))
     (if (null? evs)
-        (if reg (lww-register-value reg) #f)
+        (lww-register-value reg)
         (let ((ev (car evs)))
           (if (and (eq? (memory-event-type ev) (quote value))
                    (pair? (memory-event-payload ev))
                    (equal? (car (memory-event-payload ev)) key))
               (let ((v (cdr (memory-event-payload ev))))
                 (loop (cdr evs) (+ ts 1)
-                      (if reg
-                          (lww-register-set reg v ts (memory-event-node ev))
-                          (make-lww-register v ts (memory-event-node ev)))))
+                      (lww-register-set reg v ts (memory-event-node ev))))
               (loop (cdr evs) (+ ts 1) reg))))))
+
+(define (memory-fold-lww log key)
+  (let ((evs (memory-events log)))
+    (if (memory-lww-key-present? evs key)
+        (memory-fold-lww-vector evs key)
+        #f)))

--- a/tests/typesystem/memory_fold_lww_accumulator_test.esk
+++ b/tests/typesystem/memory_fold_lww_accumulator_test.esk
@@ -1,0 +1,31 @@
+;; Type System Test: core.memory's memory-fold-lww accumulator is strict-types
+;; clean (SW-63).
+;;
+;; `memory-fold-lww` used to seed a named-let accumulator as `#f` (Boolean)
+;; and reassign it to an `lww-register` (Vector) on the first matching event.
+;; HoTT unifies a tail-recursive loop parameter's type across every call site,
+;; so that reassignment was a genuine Boolean/Vector conflict under
+;; --strict-types, not a false positive — the fix restructures the fold so
+;; each loop's accumulator has one fixed shape for its entire lifetime (see
+;; lib/core/memory.esk).
+;; EXPECT-MODE: strict-types
+;; EXPECT-COMPILE: ok
+;; EXPECT-NO-STDERR: [ERROR]
+;; EXPECT-NO-STDERR: [WARN]
+
+(require stdlib)
+(require core.memory)
+
+(define log (make-memory-log (quote strict-lww-check)))
+(memory-append! log (quote value) (cons (quote answer) 42))
+(memory-append! log (quote value) (cons (quote answer) 43))
+
+(define observed (memory-fold-lww log (quote answer)))
+(define missing  (memory-fold-lww log (quote nonexistent)))
+
+(display observed) (newline)
+(display missing) (newline)
+
+(if (and (= observed 43) (eq? missing #f))
+    (display "ok\n")
+    (error "core.memory strict-types LWW fold regressed"))


### PR DESCRIPTION
## Summary

Fixes the one open compiler defect blocking a large downstream consumer
(the reference consumer's audit, 2026-08-26): `core.memory`'s
`memory-fold-lww` was rejected under `--strict-types` because its
named-let accumulator was seeded `#f` (Boolean) and reassigned to an
`lww-register` (Vector) on the first matching event. HoTT unifies a
tail-recursive loop parameter's type across every call site, so that was
a genuine Boolean/Vector conflict — the checker was right to refuse the
program as written; the source's own shape was the defect.

## Changes

- `lib/core/memory.esk`: split the fold into two functions so each
  named-let's accumulator has one fixed shape for its entire lifetime.
  `memory-lww-key-present?` stays Boolean-only (never touches a
  register). `memory-fold-lww-vector` (called only once a match is
  already known to exist) seeds its accumulator with a real
  `lww-register` instead of `#f`, so it stays Vector-shaped throughout.
  `memory-fold-lww` composes the two.
- `tests/typesystem/memory_fold_lww_accumulator_test.esk`: regression
  fixture wired into the existing `tests/typesystem/*.esk` sweep
  (`scripts/run_typesystem_tests.sh`).
- `.icc/silent-wrong-ledger.yaml`: closes SW-63.

## Verification

- Reproduced the pre-fix rejection directly against current master
  (`--strict-types --emit-object` exits 1 with `expected Boolean, got
  Vector`).
- Post-fix, verified across engines: native AOT (`--strict-types
  --emit-object`), native JIT (`--strict-types -r`), and VM bytecode
  emission (`--strict-types --profile hosted-vm --emit-eskb`) all
  compile clean with no HoTT diagnostics and produce the correct
  runtime output; default gradual-typing mode is unchanged.
- `scripts/run_typesystem_tests.sh`: 56/56 passed.
- `scripts/run_memory_tests.sh`: 23/23 passed.
- Full `ctest`: 201/201 passed.
- `scripts/check_ledger_integrity.py`: PASS.

A WIP fix for this existed unmerged on an old-master-based branch; this
PR re-derives the same structural split against current master and
re-verifies it end to end rather than rebase-inheriting stale content.