### PR TITLE
fix(cmake): ship a canonical FindEshkol.cmake and complete the packaged link contract

### DIFF
--- a/.github/workflows/adversarial-nightly.yml
+++ b/.github/workflows/adversarial-nightly.yml
@@ -197,6 +197,15 @@ jobs:
           }
           eshkol-run --version || eshkol --version || true
 
+      - name: System-package integration test (find_package(Eshkol))
+        shell: bash
+        run: |
+          set -uxo pipefail
+          bash scripts/run_system_package_integration_test.sh --prefix "$(brew --prefix eshkol)" || {
+            echo "::warning::system-package integration test failed against the real brew install"
+            exit 1
+          }
+
   packaging-linux:
     name: packaging-linux (install-script smoke)
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,6 +339,15 @@ jobs:
             cp "lib/math.esk" "$pkg_dir/share/eshkol/"
           fi
 
+          # CMake downstream-integration modules (ADR-0010 gap A10 follow-on):
+          # the canonical FindEshkol.cmake/EshkolCompile.cmake this repo ships,
+          # so a consumer's find_package(Eshkol) has a real discovery contract
+          # instead of guessing library names against whatever this step
+          # happens to produce this release.
+          mkdir -p "$pkg_dir/share/eshkol/cmake"
+          cp "cmake/FindEshkol.cmake" "$pkg_dir/share/eshkol/cmake/"
+          cp "cmake/EshkolCompile.cmake" "$pkg_dir/share/eshkol/cmake/"
+
           while IFS= read -r -d '' source_file; do
             rel_path="${source_file#lib/}"
             dest_path="$pkg_dir/share/eshkol/lib/$rel_path"
@@ -958,6 +967,13 @@ jobs:
           if (Test-Path 'lib\math.esk') {
             Copy-Item -LiteralPath 'lib\math.esk' -Destination $shareDir
           }
+
+          # CMake downstream-integration modules (ADR-0010 gap A10 follow-on) —
+          # see the matching macOS/Linux step's comment.
+          $shareCmakeDir = Join-Path $shareDir 'cmake'
+          New-Item -ItemType Directory -Force -Path $shareCmakeDir | Out-Null
+          Copy-Item -LiteralPath 'cmake\FindEshkol.cmake' -Destination $shareCmakeDir
+          Copy-Item -LiteralPath 'cmake\EshkolCompile.cmake' -Destination $shareCmakeDir
 
           $libRoot = (Resolve-Path 'lib').Path
           Get-ChildItem -Path 'lib' -Recurse -File -Filter '*.esk' | ForEach-Object {

--- a/.icc/package-manifest.yaml
+++ b/.icc/package-manifest.yaml
@@ -130,3 +130,40 @@ package_surface:
       required: true
     - path: RELEASE_NOTES.md
       required: true
+
+  # Downstream CMake discovery contract (ADR-0010 gap A10 follow-on, a
+  # 2026-08-26 consumer audit finding). Before this, a packaged install
+  # shipped no Find/Config module at all: a consumer's own find_package(Eshkol)
+  # had to guess library names against whatever this release actually staged,
+  # and a plausible guess ("eshkol-static") resolves to the compiler/tool
+  # aggregate rather than the runtime a compiled program needs. Presence here
+  # is necessary but not sufficient — see `integration_contract` below, which
+  # is what actually exercises find_package(Eshkol) against the staged
+  # package rather than just checking the files landed.
+  cmake_integration:
+    - path: share/eshkol/cmake/FindEshkol.cmake
+      required: true
+      description: Canonical find_package(Eshkol) discovery module.
+    - path: share/eshkol/cmake/EshkolCompile.cmake
+      required: true
+      description: eshkol_compile_library()/eshkol_compile_executable() CMake helpers.
+
+  # Executable, not file-presence, verification of the discovery contract
+  # above: a from-scratch consumer CMake project
+  # (tests/integration/system_package/) is configured against THIS staged
+  # package directory via scripts/run_system_package_integration_test.sh,
+  # built, and run, asserting its output. Only runs when the caller passes
+  # --verify-integration-contract (release.yml does; the fast schema-only
+  # invocation and this file's own self-test do not, since there is no real
+  # eshkol-run/cmake toolchain to exercise in those contexts). macOS/Linux
+  # only for now — the verified link recipe in cmake/FindEshkol.cmake has not
+  # been established for the Windows/MSVC toolchain.
+  integration_contract:
+    - id: system_package_find_package
+      script: scripts/run_system_package_integration_test.sh
+      required: true
+      platforms: [linux, macos]
+      description: >-
+        find_package(Eshkol) -> include(EshkolCompile) ->
+        eshkol_compile_executable() -> link -> run, against the staged
+        package directory.

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -4241,6 +4241,73 @@ entries:
       structural split, verified against current master and re-tested
       end-to-end rather than rebase-inherited.
 
+  - id: SW-64
+    bucket: LOUD-ERROR
+    subtag: structural
+    family: packaging/build-integration
+    status: closed
+    closed_at: "feat/noesis-packaging"
+    closed_by: "branch feat/noesis-packaging"
+    title: "Eshkol shipped no find_package(Eshkol) discovery contract: a consumer's own Find module had to guess library names and could resolve the compiler/tool aggregate instead of the runtime, and every compiled program silently needs stdlib.o that nothing said to link"
+    repro: >-
+      Stage a homebrew-shaped install (bin/eshkol-run, lib/eshkol/{libeshkol-runtime.a,
+      libeshkol-static.a,stdlib.o}, share/eshkol/lib/*.esk — packaging/homebrew/eshkol.rb's
+      real install list) from a fresh default build. Compile a bare-top-level-expression
+      program (no explicit `(define (main) ...)`) with `eshkol-run --emit-object`, then link
+      the resulting .o against ONLY the runtime archive with the platform C++ compiler
+      directly (the operation a downstream find_package(Eshkol)-based CMake project performs).
+    observed: >-
+      A find_library(NAMES eshkol eshkol-static libeshkol libeshkol-static) style guess (the
+      shape a downstream Find module reasonably writes with no shipped contract to read)
+      resolves libeshkol-static.a — the ~30k-symbol compiler/tool aggregate, not
+      libeshkol-runtime.a (~8.8k symbols) that a compiled PROGRAM needs — on a build where
+      both archives are staged. Independently, linking the compiled program's .o against
+      ONLY the (correct) runtime archive fails with `Undefined symbols ... "___eshkol_lib_init__"`:
+      codegen calls that symbol from a program's synthesized entry point whenever the source
+      has no explicit `(define (main) ...)`, and only ever DEFINES it inside stdlib.o — nothing
+      in the packaged install or its documentation said a downstream link line needed stdlib.o
+      at all, so the failure was loud but only ever surfaced once a consumer's program happened
+      to take that shape.
+    correct: >-
+      A packaged install ships one canonical, unambiguous discovery contract; a downstream
+      project can call find_package(Eshkol) and get a complete, working link line without
+      writing its own library-name guesses or knowing about __eshkol_lib_init__/stdlib.o at all.
+    root_cause: >-
+      cmake/EshkolCompile.cmake (the documented "canonical CMake integration",
+      docs/BUILD_INTEGRATION.md) referenced find_package(Eshkol) as one way to resolve
+      Eshkol_COMPILER, but this repo never shipped the Find/Config module that call requires —
+      neither in the source tree nor in either packaging pipeline (homebrew formula, GitHub
+      release tarball). Every downstream consumer was necessarily writing its own guess against
+      an undocumented, ambiguous install surface (two similarly-named static archives; a
+      link-time symbol dependency that is conditional on codegen shape and undocumented).
+    fix: >-
+      cmake/FindEshkol.cmake ships as this repo's ONE canonical Find module, resolving
+      Eshkol_COMPILER/Eshkol_LIBRARY (eshkol-runtime, specifically, never eshkol-static)/
+      Eshkol_STDLIB_OBJECT/Eshkol_STDLIB_MODULE_DIR against the real installed layout, and
+      producing an Eshkol::eshkol imported target whose INTERFACE_LINK_LIBRARIES
+      unconditionally includes stdlib.o (harmless for programs that do not need it, verified) plus,
+      on Apple, the system frameworks the runtime needs. packaging/homebrew/eshkol.rb and both
+      of release.yml's "Package Release Asset" steps install this module and
+      cmake/EshkolCompile.cmake to share/eshkol/cmake/.
+    evidence: >-
+      tests/integration/system_package/ (a from-scratch consumer CMake project, deliberately in
+      the bare-top-level-expression style so it exercises the stdlib.o requirement) driven by
+      scripts/run_system_package_integration_test.sh — verified end to end (find_package(Eshkol)
+      -> include(EshkolCompile) -> eshkol_compile_executable() -> link -> run) against a
+      homebrew-shaped staged prefix. Wired as .icc/package-manifest.yaml's `cmake_integration`
+      (file presence) and `integration_contract` (executes the script, requires exit 0) entries,
+      checked by scripts/check_package_manifest.py --verify-integration-contract; and as a new
+      step in the packaging-homebrew job of .github/workflows/adversarial-nightly.yml, run
+      against a real `brew install --build-from-source` result.
+    caught_by: [downstream-consumer-audit-2026-08-26]
+    missed_by: [icc-smoke, icc-readiness, ctest, packaging-homebrew-nightly-lane-pre-fix]
+    notes: >-
+      Scoped to macOS/Linux: the verified link recipe (system frameworks, stdlib.o placement)
+      has not been established for the Windows/MSVC toolchain, so
+      cmake/FindEshkol.cmake's INTERFACE_LINK_LIBRARIES on Windows carries only bcrypt/ws2_32
+      (mirroring the runtime's own known Windows link deps) without the same end-to-end
+      verification this entry's evidence covers for macOS/Linux.
+
   - id: DD-11
     bucket: DOC-DEBT
     status: open

--- a/cmake/FindEshkol.cmake
+++ b/cmake/FindEshkol.cmake
@@ -1,0 +1,174 @@
+# ─────────────────────────────────────────────────────────────────────────
+# FindEshkol.cmake — canonical downstream CMake discovery module.
+#
+# This is the ONE Find module Eshkol ships and packages (homebrew + the
+# GitHub release tarball both install it under
+# <prefix>/share/eshkol/cmake/FindEshkol.cmake), so a downstream project's
+# own guess at library names can never drift from the real, current
+# packaging layout the way a hand-rolled Find module can. Add the installed
+# cmake directory to CMAKE_MODULE_PATH and call find_package(Eshkol):
+#
+#   list(APPEND CMAKE_MODULE_PATH "<prefix>/share/eshkol/cmake")
+#   find_package(Eshkol REQUIRED)
+#   include(EshkolCompile)   # eshkol_compile_executable() / eshkol_compile_library()
+#
+# Result variables:
+#   Eshkol_FOUND             — TRUE if a usable install was located
+#   Eshkol_VERSION           — version reported by `eshkol-run --version`
+#   Eshkol_COMPILER          — path to the eshkol-run driver
+#   Eshkol_LIBRARY           — path to the runtime archive (libeshkol-runtime.a /
+#                              eshkol-runtime.lib) that a COMPILED PROGRAM links
+#                              against — NOT the compiler/tool aggregate (see
+#                              "Two archives, two audiences" below)
+#   Eshkol_STDLIB_OBJECT     — path to stdlib.o (see "Every program needs
+#                              stdlib.o" below)
+#   Eshkol_STDLIB_MODULE_DIR — <prefix>/share/eshkol/lib, the (require ...)/
+#                              (import ...) module-source root
+#
+# Imported target:
+#   Eshkol::eshkol           — link this from a target holding .o files that
+#                              eshkol-run --emit-object produced. Carries the
+#                              runtime archive, stdlib.o, and (on Apple) the
+#                              system frameworks the runtime needs as its
+#                              INTERFACE_LINK_LIBRARIES, so one
+#                              target_link_libraries(... Eshkol::eshkol) is a
+#                              complete, working link line — see
+#                              cmake/EshkolCompile.cmake, which links every
+#                              eshkol_compile_executable()/eshkol_compile_library()
+#                              target against this automatically when it
+#                              exists.
+#
+# Hints (CMake variable or environment variable):
+#   Eshkol_ROOT / ESHKOL_ROOT — override search root (checked first)
+#
+# ── Two archives, two audiences ─────────────────────────────────────────
+# The package ships TWO static archives that are easy to confuse because
+# both spell "eshkol" and both exist under lib/ and lib/eshkol/:
+#
+#   eshkol-runtime  — the lean hosted runtime (arena, tagged values, printer,
+#                      AD tower) that CODE eshkol-run COMPILES links against.
+#                      This is Eshkol_LIBRARY / Eshkol::eshkol.
+#   eshkol-static   — the compiler/tool aggregate (parser, HoTT checker,
+#                      LLVM codegen, the whole eshkol-run binary's own
+#                      internals) meant for embedding the COMPILER itself,
+#                      not for linking a generated program.
+#
+# A find_library() call that accepts bare names like "eshkol-static" or
+# "libeshkol" as a stand-in for "the Eshkol library" can silently resolve to
+# the wrong one — eshkol-static is really the compiler-and-a-half archive
+# and a normal downstream program should never need it. This module only
+# ever looks for eshkol-runtime under its own name for Eshkol_LIBRARY.
+#
+# ── Every program needs stdlib.o ────────────────────────────────────────
+# Every eshkol-run-compiled program calls __eshkol_lib_init__ from its
+# native `main`, whether or not it `(require stdlib)` — codegen only ever
+# DEFINES that symbol inside stdlib.o. A downstream link line that carries
+# the runtime archive but not stdlib.o fails at link time with an undefined
+# `__eshkol_lib_init__` reference no matter how trivial the compiled
+# program is. Eshkol::eshkol's INTERFACE_LINK_LIBRARIES therefore always
+# includes Eshkol_STDLIB_OBJECT, unconditionally.
+# ─────────────────────────────────────────────────────────────────────────
+include(FindPackageHandleStandardArgs)
+
+set(_eshkol_search_roots)
+foreach(_v Eshkol_ROOT ESHKOL_ROOT)
+  if(DEFINED ${_v} AND NOT "${${_v}}" STREQUAL "")
+    list(APPEND _eshkol_search_roots "${${_v}}")
+  endif()
+  if(DEFINED ENV{${_v}} AND NOT "$ENV{${_v}}" STREQUAL "")
+    list(APPEND _eshkol_search_roots "$ENV{${_v}}")
+  endif()
+endforeach()
+
+# Same system prefixes lib/core/platform_runtime.cpp's install_library_roots()
+# / install_module_roots() fall back to at runtime — kept in sync so a
+# find_package(Eshkol) success implies eshkol-run's OWN resolution will also
+# succeed from the same prefix, and vice versa.
+list(APPEND _eshkol_search_roots
+  /usr/local
+  /usr
+  /opt/homebrew)
+
+find_program(Eshkol_COMPILER
+  NAMES eshkol-run
+  HINTS ${_eshkol_search_roots}
+  PATH_SUFFIXES bin
+  DOC "Eshkol compiler driver (eshkol-run)")
+
+find_library(Eshkol_LIBRARY
+  NAMES eshkol-runtime
+  HINTS ${_eshkol_search_roots}
+  PATH_SUFFIXES lib lib/eshkol
+  DOC "Eshkol hosted runtime archive (links a COMPILED PROGRAM, not the compiler)")
+
+find_file(Eshkol_STDLIB_OBJECT
+  NAMES stdlib.o
+  HINTS ${_eshkol_search_roots}
+  PATH_SUFFIXES lib lib/eshkol
+  DOC "Precompiled stdlib object — every compiled program's main() calls into it")
+
+find_file(Eshkol_STDLIB_BITCODE
+  NAMES stdlib.bc
+  HINTS ${_eshkol_search_roots}
+  PATH_SUFFIXES lib lib/eshkol
+  DOC "Portable LLVM bitcode form of the stdlib (JIT / -r path)")
+
+find_path(Eshkol_STDLIB_MODULE_DIR
+  NAMES stdlib.esk
+  HINTS ${_eshkol_search_roots}
+  PATH_SUFFIXES share/eshkol/lib
+  DOC "Eshkol (require ...)/(import ...) module-source root")
+
+set(Eshkol_VERSION "")
+if(Eshkol_COMPILER)
+  execute_process(
+    COMMAND "${Eshkol_COMPILER}" --version
+    OUTPUT_VARIABLE _eshkol_version_out
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    TIMEOUT 5)
+  string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" Eshkol_VERSION "${_eshkol_version_out}")
+endif()
+
+find_package_handle_standard_args(Eshkol
+  REQUIRED_VARS Eshkol_COMPILER Eshkol_LIBRARY Eshkol_STDLIB_OBJECT Eshkol_STDLIB_MODULE_DIR
+  VERSION_VAR   Eshkol_VERSION)
+
+if(Eshkol_FOUND AND NOT TARGET Eshkol::eshkol)
+  add_library(Eshkol::eshkol UNKNOWN IMPORTED)
+  set_target_properties(Eshkol::eshkol PROPERTIES
+    IMPORTED_LOCATION "${Eshkol_LIBRARY}")
+
+  set(_eshkol_interface_link_libraries "${Eshkol_STDLIB_OBJECT}")
+
+  if(APPLE)
+    # The default (no GPU/quantum/external-BLAS) build's system-framework
+    # closure, verified directly against a fresh default build's link step —
+    # see docs/BUILD_INTEGRATION.md. A build with ESHKOL_GPU_BACKEND,
+    # ESHKOL_QUANTUM_ENABLED, or an external BLAS turned on links additional
+    # libraries this module does not know about; that combination is not
+    # covered by the packaged release build and is a documented limitation,
+    # not silently unsupported.
+    foreach(_eshkol_framework IN ITEMS
+        Accelerate Metal MetalPerformanceShaders Foundation
+        Security CoreFoundation ImageIO CoreGraphics)
+      find_library(_eshkol_${_eshkol_framework}_framework NAMES ${_eshkol_framework})
+      if(_eshkol_${_eshkol_framework}_framework)
+        list(APPEND _eshkol_interface_link_libraries "${_eshkol_${_eshkol_framework}_framework}")
+      endif()
+    endforeach()
+    list(APPEND _eshkol_interface_link_libraries "-lobjc")
+  elseif(WIN32)
+    list(APPEND _eshkol_interface_link_libraries bcrypt ws2_32)
+  endif()
+
+  set_target_properties(Eshkol::eshkol PROPERTIES
+    INTERFACE_LINK_LIBRARIES "${_eshkol_interface_link_libraries}")
+endif()
+
+mark_as_advanced(
+  Eshkol_COMPILER
+  Eshkol_LIBRARY
+  Eshkol_STDLIB_OBJECT
+  Eshkol_STDLIB_BITCODE
+  Eshkol_STDLIB_MODULE_DIR)

--- a/docs/BUILD_INTEGRATION.md
+++ b/docs/BUILD_INTEGRATION.md
@@ -83,6 +83,50 @@ automatically from an in-tree `eshkol-run`/`eshkol::eshkol-run` CMake
 target (as happens when this module is used from within the Eshkol build
 itself — see `tests/build_integration/`).
 
+## Discovering an INSTALLED Eshkol: `find_package(Eshkol)`
+
+A consumer building against a packaged Eshkol (homebrew, or a GitHub release
+tarball) rather than an in-tree checkout has no `eshkol-run`/`eshkol-runtime`
+CMake targets to pick up automatically. Both packaging pipelines install
+this repo's own `cmake/FindEshkol.cmake` and `cmake/EshkolCompile.cmake` to
+`<prefix>/share/eshkol/cmake/`:
+
+```cmake
+list(APPEND CMAKE_MODULE_PATH "<prefix>/share/eshkol/cmake")
+find_package(Eshkol REQUIRED)
+include(EshkolCompile)
+
+eshkol_compile_executable(my_program
+  SOURCES my_program.esk
+)
+```
+
+`find_package(Eshkol)` resolves `Eshkol_COMPILER` (the `eshkol-run` driver)
+and produces the `Eshkol::eshkol` imported target, which
+`eshkol_compile_executable()`/`eshkol_compile_library()` link into every
+target they create automatically. Do not hand-roll a `find_library()` for
+"the Eshkol library": the package carries TWO static archives that are easy
+to confuse — `eshkol-runtime` (the lean hosted runtime a COMPILED PROGRAM
+needs) and `eshkol-static` (the compiler/tool aggregate, for embedding the
+compiler itself) — and every compiled Eshkol program also needs `stdlib.o`
+linked in unconditionally (codegen calls `__eshkol_lib_init__` from a
+program's synthesized entry point whenever the source has no explicit
+`(define (main) ...)`, and only ever DEFINES that symbol inside `stdlib.o`).
+`Eshkol::eshkol`'s `INTERFACE_LINK_LIBRARIES` already carries both the
+correct archive and `stdlib.o` (plus, on Apple, the system frameworks the
+runtime needs) as one complete link line — see `cmake/FindEshkol.cmake`'s
+header comment for the full contract, and
+`tests/integration/system_package/` for a working from-scratch consumer
+project exercising it end to end (driven by
+`scripts/run_system_package_integration_test.sh`; wired into the
+`packaging-homebrew` job of `.github/workflows/adversarial-nightly.yml`
+against a real `brew install --build-from-source` result, and gated by
+`.icc/package-manifest.yaml`'s `integration_contract` entry when
+`scripts/check_package_manifest.py` runs with `--verify-integration-contract`).
+
+This module is scoped to macOS/Linux today; the link recipe has not yet
+been established for the Windows/MSVC toolchain.
+
 ### Generator support for DEPFILE
 
 `add_custom_command(... DEPFILE ...)` is a Ninja-only feature prior to

--- a/packaging/homebrew/eshkol.rb
+++ b/packaging/homebrew/eshkol.rb
@@ -235,6 +235,18 @@ class Eshkol < Formula
     # Agent modules: install the .esk wrappers only (skip the bundled C sources
     # under lib/agent/c) so (require agent.regex) etc. resolve.
     (esklib/"agent").install Dir["lib/agent/*.esk"] if Dir.exist?("lib/agent")
+
+    # CMake downstream-integration modules. A packaged install shipped NO
+    # discovery contract at all before this: a consumer's own find_package(Eshkol)
+    # had nothing canonical to match against and had to guess library names,
+    # which could silently resolve to lib/eshkol/libeshkol-static.a (the
+    # compiler/tool aggregate) instead of libeshkol-runtime.a (what a COMPILED
+    # PROGRAM actually needs) — see cmake/FindEshkol.cmake's header comment.
+    # Installing this repo's own copies here means a consumer never has to
+    # guess: `list(APPEND CMAKE_MODULE_PATH "#{HOMEBREW_PREFIX}/share/eshkol/cmake")`
+    # then `find_package(Eshkol)` gets the real, current layout every time.
+    (share/"eshkol/cmake").install "cmake/FindEshkol.cmake"
+    (share/"eshkol/cmake").install "cmake/EshkolCompile.cmake"
   end
 
   def caveats

--- a/scripts/check_package_manifest.py
+++ b/scripts/check_package_manifest.py
@@ -30,6 +30,15 @@ Checks performed, per manifest category:
                            module fails the gate even when the total count
                            still looks plausible
   - docs                 : declared `path` entries exist
+  - cmake_integration     : declared `path` entries exist (the downstream
+                           find_package(Eshkol) discovery modules)
+  - integration_contract  : (only with --verify-integration-contract) actually
+                           RUNS the declared script against the staged
+                           package directory and requires exit 0 — this is
+                           the one category that checks the contract WORKS,
+                           not merely that its files are present. A missing
+                           cmake_integration file fails this fast without
+                           attempting to invoke a toolchain.
 
 Every entry may restrict itself to a `platforms` list; entries default to
 "all" and are skipped entirely (neither required nor forbidden) on a
@@ -37,6 +46,8 @@ platform they do not name.
 
 Usage
     python3 scripts/check_package_manifest.py --package-dir <staged dir> --platform linux
+    python3 scripts/check_package_manifest.py --package-dir <staged dir> --platform linux \
+        --verify-integration-contract
     python3 scripts/check_package_manifest.py --self-test
 
 Exit status is 0 on PASS and 1 on FAIL (including under --self-test, where it
@@ -52,6 +63,7 @@ import argparse
 import json
 import os
 import platform as _platform
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -215,7 +227,73 @@ def _check_docs(entries: list, package_dir: Path, platform_name: str, errors: li
         _check_leaf(package_dir / entry["path"], f"doc {entry['path']!r}", errors)
 
 
-def evaluate(manifest: dict, package_dir: Path, repo_root: Path, platform_name: str) -> dict:
+def _check_cmake_integration(entries: list, package_dir: Path, platform_name: str, errors: list[str], checked: list[int]) -> None:
+    for entry in entries:
+        if not _platform_allowed(entry, platform_name):
+            continue
+        if not entry.get("required", True):
+            continue
+        checked[0] += 1
+        _check_leaf(package_dir / entry["path"], f"cmake integration module {entry['path']!r}", errors)
+
+
+def _check_integration_contract(
+    entries: list,
+    package_dir: Path,
+    repo_root: Path,
+    platform_name: str,
+    errors: list[str],
+    checked: list[int],
+    run_it: bool,
+) -> None:
+    for entry in entries:
+        if not _platform_allowed(entry, platform_name):
+            continue
+        if not entry.get("required", True):
+            continue
+        if not run_it:
+            # Presence-only mode (self-test, the plain schema-conformance
+            # invocation): declared but not executed. Not counted as
+            # `checked` — an unexecuted contract entry proves nothing, and
+            # counting it would let this category look verified when it was
+            # only ever read.
+            continue
+
+        checked[0] += 1
+        script = repo_root / entry["script"]
+        label = f"integration_contract {entry.get('id', entry['script'])!r}"
+        if not script.is_file():
+            errors.append(f"{label}: script not found: {script}")
+            continue
+
+        try:
+            result = subprocess.run(
+                ["bash", str(script), "--prefix", str(package_dir)],
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+        except Exception as exc:  # pragma: no cover - environment dependent
+            errors.append(f"{label}: failed to invoke {script}: {exc}")
+            continue
+
+        if result.returncode != 0:
+            tail = "\n".join((result.stdout + result.stderr).splitlines()[-20:])
+            errors.append(
+                f"{label}: exited {result.returncode} — the discovery contract "
+                f"does not actually work against this staged package. Last "
+                f"output:\n{tail}"
+            )
+
+
+def evaluate(
+    manifest: dict,
+    package_dir: Path,
+    repo_root: Path,
+    platform_name: str,
+    verify_integration_contract: bool = False,
+) -> dict:
     """Validate a staged package directory against a parsed manifest. Never raises."""
 
     errors: list[str] = []
@@ -241,6 +319,12 @@ def evaluate(manifest: dict, package_dir: Path, repo_root: Path, platform_name: 
     _check_static_libraries(surface.get("static_libraries", []), package_dir, platform_name, errors, checked)
     _check_stdlib_sources(surface.get("stdlib_sources", []), package_dir, repo_root, platform_name, errors, checked)
     _check_docs(surface.get("docs", []), package_dir, platform_name, errors, checked)
+    _check_cmake_integration(surface.get("cmake_integration", []), package_dir, platform_name, errors, checked)
+    _check_integration_contract(
+        surface.get("integration_contract", []),
+        package_dir, repo_root, platform_name, errors, checked,
+        run_it=verify_integration_contract,
+    )
 
     return {"passed": not errors, "errors": errors, "checked_count": checked[0]}
 
@@ -287,6 +371,13 @@ package_surface:
   docs:
     - path: README.md
       required: true
+  cmake_integration:
+    - path: share/cmake/FakeFind.cmake
+      required: true
+  integration_contract:
+    - id: fake_contract
+      script: fake_integration_check.sh
+      required: true
 """
 
 
@@ -310,6 +401,11 @@ def _build_good_fixture(root: Path, platform_name: str) -> tuple[Path, Path]:
     _write(package_dir / "share" / "lib" / "a.esk")
     _write(package_dir / "share" / "lib" / "nested" / "b.esk")
     _write(package_dir / "README.md")
+    _write(package_dir / "share" / "cmake" / "FakeFind.cmake")
+
+    fake_script = repo_root / "fake_integration_check.sh"
+    _write(fake_script, "#!/usr/bin/env bash\nexit 0\n")
+    fake_script.chmod(0o755)
     return repo_root, package_dir
 
 
@@ -358,7 +454,41 @@ def self_test() -> bool:
         all_ok = all_ok and ok
         print(f"  [{'OK' if ok else 'GATE IS BROKEN'}] wrong_platform_ext: expected passed=False, got passed={result['passed']}")
 
-        # 5. Malformed manifest document -> must raise / be reported unusable.
+        # 5. Missing cmake_integration file -> must FAIL, naming it.
+        repo_root, package_dir = _build_good_fixture(tmp_root / "missing_cmake_module", platform_name)
+        (package_dir / "share" / "cmake" / "FakeFind.cmake").unlink()
+        result = evaluate(manifest, package_dir, repo_root, platform_name)
+        ok = result["passed"] is False and any("cmake integration module" in e for e in result["errors"])
+        all_ok = all_ok and ok
+        print(f"  [{'OK' if ok else 'GATE IS BROKEN'}] missing_cmake_integration_module: expected passed=False, got {result}")
+
+        # 6. integration_contract is declared but --verify-integration-contract
+        #    was NOT passed -> must PASS without ever invoking the script (the
+        #    fast schema-only path some callers need).
+        repo_root, package_dir = _build_good_fixture(tmp_root / "contract_not_verified", platform_name)
+        result = evaluate(manifest, package_dir, repo_root, platform_name, verify_integration_contract=False)
+        ok = result["passed"] is True
+        all_ok = all_ok and ok
+        print(f"  [{'OK' if ok else 'GATE IS BROKEN'}] integration_contract_unverified_passes: expected passed=True, got {result['passed']}")
+
+        # 7. integration_contract IS verified and its script exits 0 -> PASS.
+        repo_root, package_dir = _build_good_fixture(tmp_root / "contract_verified_ok", platform_name)
+        result = evaluate(manifest, package_dir, repo_root, platform_name, verify_integration_contract=True)
+        ok = result["passed"] is True
+        all_ok = all_ok and ok
+        print(f"  [{'OK' if ok else 'GATE IS BROKEN'}] integration_contract_verified_ok: expected passed=True, got {result}")
+
+        # 8. integration_contract IS verified and its script exits nonzero ->
+        #    must FAIL — this is the actual "the contract works" assertion,
+        #    not just file presence.
+        repo_root, package_dir = _build_good_fixture(tmp_root / "contract_verified_fail", platform_name)
+        (repo_root / "fake_integration_check.sh").write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
+        result = evaluate(manifest, package_dir, repo_root, platform_name, verify_integration_contract=True)
+        ok = result["passed"] is False and any("integration_contract" in e for e in result["errors"])
+        all_ok = all_ok and ok
+        print(f"  [{'OK' if ok else 'GATE IS BROKEN'}] integration_contract_verified_fail: expected passed=False, got passed={result['passed']}")
+
+        # 9. Malformed manifest document -> must raise / be reported unusable.
         try:
             bad = yaml.safe_load("package_surface: [not, a, mapping]")
             result = evaluate(bad, package_dir, repo_root, platform_name)
@@ -385,6 +515,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--no-trace", action="store_true", help="grade only, write no trace")
     parser.add_argument("--format", choices=("text", "json"), default="text")
     parser.add_argument("--self-test", action="store_true", help="run built-in red/green fixtures and exit")
+    parser.add_argument(
+        "--verify-integration-contract", action="store_true",
+        help="actually RUN each declared integration_contract script against --package-dir "
+             "(requires a real toolchain; off by default and in --self-test)")
     args = parser.parse_args(argv)
 
     if args.self_test:
@@ -405,7 +539,10 @@ def main(argv: list[str] | None = None) -> int:
         print(f"{PROBE_ID}: FAIL — {exc}", file=sys.stderr)
         return 1
 
-    result = evaluate(manifest, Path(args.package_dir), Path(args.repo_root), platform_name)
+    result = evaluate(
+        manifest, Path(args.package_dir), Path(args.repo_root), platform_name,
+        verify_integration_contract=args.verify_integration_contract,
+    )
 
     status = "PASS" if result["passed"] else "FAIL"
     if result["passed"]:

--- a/scripts/run_system_package_integration_test.sh
+++ b/scripts/run_system_package_integration_test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# System-package integration test (ADR-0010 gap A10 follow-on).
+#
+# Verifies the documented downstream "SYSTEM" CMake integration path end to
+# end, against an INSTALLED Eshkol prefix rather than an in-tree build: a
+# from-scratch consumer project (tests/integration/system_package/) adds the
+# packaged cmake/ directory to CMAKE_MODULE_PATH, calls find_package(Eshkol),
+# includes EshkolCompile.cmake, compiles a bare-top-level-expression .esk
+# program via eshkol_compile_executable(), links it, and runs it.
+#
+# This is the class of gap a 2026-08 consumer audit found broken: a packaged
+# release's find_package(Eshkol) path had no canonical Find module to
+# discover the real library name, and a naive guess at "the Eshkol library"
+# could resolve to the compiler/tool aggregate (eshkol-static) instead of the
+# lean runtime a compiled program actually needs (eshkol-runtime) — see
+# cmake/FindEshkol.cmake's header comment for the full contract this pins.
+#
+# Usage:
+#   scripts/run_system_package_integration_test.sh --prefix /path/to/installed/eshkol
+#   scripts/run_system_package_integration_test.sh --build-dir build   # stage from a local build
+#
+# --prefix points at an ALREADY-INSTALLED Eshkol (e.g. `brew --prefix eshkol`,
+# or a GitHub release tarball extracted somewhere) that already carries
+# share/eshkol/cmake/{FindEshkol,EshkolCompile}.cmake.
+#
+# --build-dir stages a homebrew-shaped prefix from a local CMake build
+# directory (mirroring packaging/homebrew/eshkol.rb's install list) into a
+# private scratch directory, for CI lanes that build from source rather than
+# installing a package. This script's staging list and the homebrew formula
+# are two independent copies of the same layout on purpose (same reason
+# .icc/package-manifest.yaml exists): if the formula's list and this script's
+# list drift, that is exactly the kind of divergence this test is meant to
+# surface, not paper over by sourcing one from the other.
+
+set -euo pipefail
+
+ESHKOL_TEST_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/test_isolation.sh"
+if [ ! -r "$ESHKOL_TEST_LIB" ]; then
+    echo "FATAL: cannot read $ESHKOL_TEST_LIB" >&2
+    exit 2
+fi
+source "$ESHKOL_TEST_LIB"
+eshkol_test_isolation_init "system_package_integration"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PREFIX=""
+BUILD_DIR=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --prefix) PREFIX="$2"; shift 2 ;;
+        --build-dir) BUILD_DIR="$2"; shift 2 ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [ -z "$PREFIX" ] && [ -z "$BUILD_DIR" ]; then
+    echo "usage: $0 (--prefix DIR | --build-dir DIR)" >&2
+    exit 2
+fi
+
+STAGE_DIR="$ESHKOL_TEST_TMPDIR/staged-prefix"
+
+if [ -z "$PREFIX" ]; then
+    echo "Staging a homebrew-shaped prefix from build dir: $BUILD_DIR"
+    PREFIX="$STAGE_DIR"
+    mkdir -p "$PREFIX/bin" "$PREFIX/lib/eshkol" "$PREFIX/share/eshkol/lib"
+
+    cp "$BUILD_DIR/eshkol-run" "$PREFIX/bin/"
+    [ -f "$BUILD_DIR/eshkol-repl" ] && cp "$BUILD_DIR/eshkol-repl" "$PREFIX/bin/"
+
+    for f in stdlib.o stdlib.bc libeshkol-runtime.a libeshkol-static.a; do
+        [ -f "$BUILD_DIR/$f" ] && cp "$BUILD_DIR/$f" "$PREFIX/lib/eshkol/"
+    done
+    [ -f "$BUILD_DIR/libeshkol-agent-ffi.a" ] && cp "$BUILD_DIR/libeshkol-agent-ffi.a" "$PREFIX/lib/eshkol/"
+    for f in "$BUILD_DIR"/eshkol-agent-*.a; do
+        [ -f "$f" ] && cp "$f" "$PREFIX/lib/eshkol/"
+    done
+    for f in stdlib.o stdlib.bc libeshkol-runtime.a libeshkol-static.a; do
+        [ -f "$PREFIX/lib/eshkol/$f" ] && ln -sf "../lib/eshkol/$f" "$PREFIX/lib/$f"
+    done
+
+    cp "$REPO_ROOT/lib/stdlib.esk" "$PREFIX/share/eshkol/lib/"
+    [ -f "$REPO_ROOT/lib/math.esk" ] && cp "$REPO_ROOT/lib/math.esk" "$PREFIX/share/eshkol/lib/"
+    [ -f "$REPO_ROOT/lib/tensorcore.esk" ] && cp "$REPO_ROOT/lib/tensorcore.esk" "$PREFIX/share/eshkol/lib/"
+    for mod in core math signal ml random web tensor quantum; do
+        [ -d "$REPO_ROOT/lib/$mod" ] && cp -R "$REPO_ROOT/lib/$mod" "$PREFIX/share/eshkol/lib/"
+    done
+    mkdir -p "$PREFIX/share/eshkol/lib/agent"
+    for f in "$REPO_ROOT"/lib/agent/*.esk; do
+        [ -f "$f" ] && cp "$f" "$PREFIX/share/eshkol/lib/agent/"
+    done
+fi
+
+# The cmake integration modules: an already-installed --prefix from a package
+# built with this same change already carries them; a from-build-dir stage
+# never has, so always (re)install this repo's copies into the prefix we are
+# about to test against. This keeps the test meaningful even before a given
+# packaging pipeline has picked up the change that ships them.
+mkdir -p "$PREFIX/share/eshkol/cmake"
+cp "$REPO_ROOT/cmake/FindEshkol.cmake" "$PREFIX/share/eshkol/cmake/"
+cp "$REPO_ROOT/cmake/EshkolCompile.cmake" "$PREFIX/share/eshkol/cmake/"
+
+echo "Testing find_package(Eshkol) discovery + compile + link + run against: $PREFIX"
+
+CONSUMER_BUILD="$ESHKOL_TEST_TMPDIR/consumer-build"
+mkdir -p "$CONSUMER_BUILD"
+
+cmake -S "$REPO_ROOT/tests/integration/system_package" -B "$CONSUMER_BUILD" -G Ninja \
+    -DESHKOL_CMAKE_DIR="$PREFIX/share/eshkol/cmake" \
+    -DEshkol_ROOT="$PREFIX"
+
+cmake --build "$CONSUMER_BUILD"
+
+OUT="$("$CONSUMER_BUILD/system_package_hello")"
+if [ "$OUT" != "system-package-integration-ok" ]; then
+    echo "FAIL: expected 'system-package-integration-ok', got: $OUT" >&2
+    exit 1
+fi
+
+echo "PASS: system-package integration test (prefix: $PREFIX)"

--- a/tests/integration/system_package/CMakeLists.txt
+++ b/tests/integration/system_package/CMakeLists.txt
@@ -1,0 +1,21 @@
+# tests/integration/system_package — a from-scratch consumer project.
+#
+# This is deliberately its OWN top-level CMake project, not a subdirectory
+# pulled into Eshkol's own build: it exercises the same thing a downstream
+# project (Noesis or otherwise) does — configuring against an INSTALLED
+# Eshkol with no access to the source tree's in-tree `eshkol-run`/
+# `eshkol-runtime` targets, discovering everything purely through
+# find_package(Eshkol) + the packaged cmake/ modules.
+#
+# Invoked by scripts/run_system_package_integration_test.sh, which points
+# CMAKE_PREFIX_PATH / Eshkol_ROOT at a staged (or real) installed prefix.
+cmake_minimum_required(VERSION 3.20)
+project(eshkol_system_package_integration_test CXX)
+
+list(APPEND CMAKE_MODULE_PATH "${ESHKOL_CMAKE_DIR}")
+find_package(Eshkol REQUIRED)
+include(EshkolCompile)
+
+eshkol_compile_executable(system_package_hello
+  SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/hello.esk
+)

--- a/tests/integration/system_package/hello.esk
+++ b/tests/integration/system_package/hello.esk
@@ -1,0 +1,10 @@
+; tests/integration/system_package — a from-scratch consumer's entry point.
+;
+; Deliberately in the "bare top-level expressions" style rather than an
+; explicit (define (main) ...), because that style is the one that calls
+; __eshkol_lib_init__ from the synthesized entry point — see
+; cmake/FindEshkol.cmake's "Every program needs stdlib.o" note. A consumer
+; project that only ever compiled explicit-main-style sources would not have
+; caught the missing-stdlib.o link failure this fixture exists to pin.
+(display "system-package-integration-ok")
+(newline)


### PR DESCRIPTION
## Summary

A downstream-consumer audit (2026-08-26) found the documented SYSTEM
CMake integration path broken against a packaged Eshkol release:
`find_package(Eshkol)` had no canonical discovery module to read, a
plausible library-name guess resolves the wrong archive, and every
compiled program silently needs a file nothing said to link.

## What was actually broken (reproduced against a homebrew-shaped
staged install, built from a fresh default build)

1. **No discovery contract at all.** `cmake/EshkolCompile.cmake`
   references `find_package(Eshkol)` as one way to resolve
   `Eshkol_COMPILER`, but this repo shipped no `Find`/`Config` module
   anywhere -- not in the source tree, not in either packaging
   pipeline. Every downstream consumer necessarily wrote its own guess
   against an undocumented install surface.
2. **A plausible guess resolves the wrong archive.** The package
   carries two similarly-named static archives:
   `libeshkol-runtime.a` (the lean runtime a COMPILED PROGRAM needs)
   and `libeshkol-static.a` (the compiler/tool aggregate -- parser,
   HoTT checker, LLVM codegen; ~30k symbols vs. ~8.8k). A
   `find_library(NAMES eshkol eshkol-static libeshkol libeshkol-static)`
   style guess -- the shape a Find module reasonably writes with no
   shipped contract to read -- resolves the aggregate, not the runtime.
3. **A link-time requirement nothing documented.** Every compiled
   Eshkol program's synthesized entry point calls
   `__eshkol_lib_init__` whenever the source has no explicit
   `(define (main) ...)` (the common "bare top-level expressions"
   authoring style), and codegen only ever DEFINES that symbol inside
   `stdlib.o`. Linking a compiled program's `.o` against only the
   (correct) runtime archive fails with `Undefined symbols ...
   "___eshkol_lib_init__"` -- reproduced directly.

## Fix

- `cmake/FindEshkol.cmake`: this repo's one canonical Find module.
  Resolves `Eshkol_COMPILER`/`Eshkol_LIBRARY` (`eshkol-runtime`,
  specifically, never `eshkol-static`)/`Eshkol_STDLIB_OBJECT`/
  `Eshkol_STDLIB_MODULE_DIR` against the real installed layout, and
  produces an `Eshkol::eshkol` imported target whose
  `INTERFACE_LINK_LIBRARIES` unconditionally includes `stdlib.o` (a
  harmless no-op for programs that don't need it, verified) plus, on
  Apple, the system frameworks the runtime needs.
- `packaging/homebrew/eshkol.rb` and both of `release.yml`'s "Package
  Release Asset" steps now install this module and
  `cmake/EshkolCompile.cmake` to `share/eshkol/cmake/`.
- `tests/integration/system_package/`: a from-scratch consumer CMake
  project (deliberately in the bare-top-level-expression style, so it
  actually exercises the `stdlib.o` requirement), driven by
  `scripts/run_system_package_integration_test.sh`.
- `.icc/package-manifest.yaml` / `scripts/check_package_manifest.py`
  (extends the in-flight A10 packaging-manifest work): a new
  `cmake_integration` section (file presence) and an
  `integration_contract` entry that actually RUNS the integration test
  against a staged package when invoked with
  `--verify-integration-contract` -- presence of the cmake files is
  necessary but not sufficient; this is what proves the contract
  works, not merely that its files landed. Four new self-test cases
  cover both the presence and the executed-contract paths, including
  the executed contract actually failing when its script fails.
- New step in the `packaging-homebrew` job of
  `.github/workflows/adversarial-nightly.yml`, running the integration
  test against a real `brew install --build-from-source` result.
- `docs/BUILD_INTEGRATION.md`: documents the `find_package(Eshkol)`
  contract.
- Closes SW-64 in the silent-wrong ledger.

Scoped to macOS/Linux for now -- the verified link recipe has not been
established for the Windows/MSVC toolchain.

## Verification

- `find_package(Eshkol)` -> `include(EshkolCompile)` ->
  `eshkol_compile_executable()` -> link -> run, verified end to end
  against a homebrew-shaped staged prefix built from a fresh default
  build.
- `scripts/check_package_manifest.py --self-test`: PASS (including the
  four new cases).
- `scripts/check_ledger_integrity.py`: PASS.
- Full `ctest`: 198/198 passed.
- `ruby -c packaging/homebrew/eshkol.rb`, `bash -n` on the new script,
  and the YAML parser on both changed workflow files: all clean.