### PR TITLE
fix(ad): exact backwards for the four geometric bridge ops (SW-65)

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -5519,3 +5519,145 @@ entries:
       default tree-sitter AST backend. Full ctest: 203/203 passed.
     caught_by: [icc-architecture-verify-libclang-admission-20260826]
     missed_by: [icc-architecture-verify-grep-fidelity, icc-smoke, icc-readiness, ctest]
+
+  - id: SW-65
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "fix/geometric-bridge-backwards"
+    closed_by: >-
+      branch fix/geometric-bridge-backwards (rebased onto the #500 registry) —
+      four exact backward rules in lib/bridge/tensor_backward.cpp, declared as
+      BRIDGE rows in inc/eshkol/ad_node_registry.def so the dispatch arms in
+      eshkol_tensor_backward_dispatch and the backward table are generated from
+      the same declaration; their four UNREGISTERED abort rows are deleted, and
+      every remaining backward-less tensor node type stays an UNREGISTERED row
+      that aborts naming itself.
+    title: "Four geometric bridge ops record tensor AD nodes with no backward — the gradient is silently zero, with no diagnostic"
+    repro: >-
+      Build any of ad_hyperbolic_distance / ad_poincare_exp_map /
+      ad_poincare_log_map / ad_geodesic_attention (lib/bridge/qllm_bridge.cpp)
+      onto a tape, seed the output node's tensor_gradient, and run
+      eshkol_tensor_backward_dispatch over the tape in reverse. Every input
+      gradient comes back exactly 0.0. Standalone repro and captured output:
+      ~/.tsotchke/state/geometric-backwards/repro.cpp and repro-before.txt.
+    observed: >-
+      max |grad| over both inputs = 0 for all four ops, and NOTHING is printed —
+      no warning, no error, no counter. The reverse sweep completes normally and
+      a caller cannot distinguish "this op has no backward" from "the gradient at
+      this point really is zero".
+    correct: >-
+      All four forwards create TENSOR-VALUED nodes (tensor_value + shape/ndim,
+      and make_node pre-allocates tensor_gradient) of ad_node_type_t 33
+      (HYPERBOLIC_DISTANCE), 34 (POINCARE_EXP_MAP), 35 (POINCARE_LOG_MAP) and 37
+      (GEODESIC_ATTENTION). Each has a well-defined exact differential: the
+      Poincare exp/log maps are compositions of Mobius addition with a scalar
+      radial factor, both with closed-form Jacobians; hyperbolic distance is
+      acosh(1 + 2c|x-y|^2/(dx dy))/sqrt(c) with an elementary gradient; geodesic
+      attention is a softmax over negated geodesic distances composed with a
+      value-weighted sum. None of these is approximated or unavailable — they
+      were simply never written.
+    notes: >-
+      TWO layers failed, and the second is what made it silent rather than merely
+      missing.
+
+      (1) lib/bridge/tensor_backward.cpp's get_tensor_backward_fn does not
+      register types 33/34/35/37. Its default: returns NULL after a one-time
+      stderr warning — which would at least have been audible.
+
+      (2) That warning never fires, because these nodes never reach it. The
+      native dispatcher eshkol_tensor_backward_dispatch
+      (lib/backend/tensor_backward.cpp) routes only the explicitly enumerated
+      tensor cases to the bridge table; 33/34/35/37 have no case and fall into
+      its default:, which does nothing at all.
+
+      The default: carries a comment asserting that this cannot happen —
+      "Scalar activation / geometric / hyperbolic ops (12-18, 33-66) are
+      differentiated by their scalar backward emitted in codegen and legitimately
+      reach here with nothing to do. Every TENSOR op (19-32 and the qLLM bridge
+      ops 67-80) has an explicit case above, so a tensor-op gradient can never
+      silently fall through this default."
+
+      Every clause of that guarantee is false for these four. They are in the
+      33-66 range but are tensor-valued, not scalar; they are bridge-created, so
+      no codegen scalar backward exists for them; and a tensor-op gradient
+      therefore does fall through this default, silently. The comment is the
+      reason the gap survived review: it states the invariant that the enum range
+      is a reliable proxy for scalar-ness, and that proxy is what broke.
+
+      The range test is the root defect. The property that matters is not which
+      enum bucket a node is in but whether it CARRIES A TENSOR PAYLOAD nobody
+      will propagate, and that is testable directly on the node.
+    observed_after: >-
+      The same repro, unchanged, on the fixed tree: hyperbolic-distance
+      1.9136747677590749, poincare-exp-map 1.0081654858019475, poincare-log-map
+      1.0393847046977158, geodesic-attention Q/K 2.6867707457830869,
+      geodesic-attention V 1.1159604744030989. Before/after captures are
+      ~/.tsotchke/state/geometric-backwards/repro-before.txt and
+      repro-after.txt.
+    evidence: >-
+      ctest -R qllm_bridge_geometric_gradcheck — 13 checks, pinned by count so a
+      check that stopped running goes red. Three independent EXACT references
+      are asserted before finite differences are consulted at all:
+
+      (1) The committed golden vectors. tests/qllm_oracle/golden/ holds full
+      Jacobians for exp_0 and log_0 produced by Eshkol's reverse-mode AD over an
+      independently written Eshkol transcription of the same formulas. Case
+      poincare_log_map_origin.d2.c1.u0p5 agrees to 3.7e-16 and
+      poincare_exp_map_origin.d2.c1.tv0p1 to 1.1e-14 — two implementations, two
+      languages, written from different sources.
+
+      (2) The conformal-factor identity |grad_x d| = lambda_x = 2/(1-c|x|^2),
+      which holds at every interior pair because the Riemannian gradient of a
+      distance function is a unit vector: max relative deviation 5.0e-16 over
+      three pairs.
+
+      (3) The inverse-Jacobian identity J_log * J_exp = I, which couples the
+      exp and log rules to each other with no appeal to either derivation:
+      max |J_log J_exp - I| = 6.7e-16.
+
+      Finite differences then agree at 3.5e-11 (distance), 3.5e-11 / 5.7e-11
+      (exp / log) and 1.5e-10 / 8.8e-11 (geodesic attention, unmasked and
+      causal). The registered refusal is red-proofed with a fake tensor-valued
+      node of a still-UNREGISTERED type (AD_NODE_MOBIUS_MATMUL), and its
+      companion check proves a leaf variable carrying tensor_value is still a
+      legitimate no-op.
+    fixed_by: >-
+      lib/bridge/tensor_backward.cpp gains tensor_hyperbolic_distance_backward,
+      tensor_poincare_exp_map_backward, tensor_poincare_log_map_backward and
+      tensor_geodesic_attention_backward, each named by its node type's BRIDGE
+      row in inc/eshkol/ad_node_registry.def — the generated table behind
+      get_tensor_backward_fn, where a row naming a function that does not exist
+      is a compile error. The exp and log rules reuse
+      FrechetGeometry::mobius_add_with_jacobians and log_map_with_jacobians
+      rather than re-deriving them — the log map IS the function that routine
+      already differentiates for the Frechet rule, and a second derivation could
+      only introduce a disagreement. lib/bridge/qllm_bridge.cpp's
+      ad_geodesic_attention now retains the softmax weights and records
+      causal + curvature in params (it recorded neither before, so no backward
+      could have reconstructed the mask or the metric).
+
+      The structural fix is the registry (#500 / SW-70), which this change is
+      the first UNREGISTERED-to-BRIDGE promotion through: no default: infers
+      scalar-ness from a numeric band any more, because there is no default: at
+      all — eshkol_tensor_backward_dispatch is generated from
+      ad_node_registry.def under -Werror=switch-enum, every node type must
+      declare its backward disposition, and a tensor node type with no rule is
+      an UNREGISTERED row that aborts naming itself (TANGENT_PROJECT /
+      MOBIUS_ADD / MOBIUS_MATMUL / GYROVECTOR_SPACE remain so). LEAF rows keep
+      AD_NODE_VARIABLE / AD_NODE_CONSTANT, which legitimately carry
+      tensor_value, out of the refusal.
+    caught_by: [architectural-audit-2026-08-26, pr-497-review]
+    missed_by: [icc-invariants, icc-smoke, icc-readiness, ad_carrier_model_clean, qllm_bridge_gradcheck]
+    notes_after: >-
+      Two facts the rules make explicit that a silent zero had hidden. First,
+      the Riemannian distance behaves like |x - y| near coincidence: it has no
+      derivative at x = y, only a subgradient set, so both distance-based rules
+      refuse there instead of choosing a plausible member of that set. For
+      geodesic attention this means the op is non-differentiable whenever a
+      query row equals a key row exactly — the ordinary case when Q and K are
+      the same tensor. That is a property of scoring by distance rather than by
+      inner product, and callers need to know it. Second,
+      ad_poincare_log_map's forward clamps artanh's argument at t >= 1 and
+      returns a value where no finite log exists; the backward refuses there
+      rather than differentiate the clamp, matching what the Frechet machinery
+      already does on the same condition.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4485,8 +4485,8 @@ endif()
 # (-Werror=switch -Werror=switch-enum, see eshkol_require_exhaustive_dispatch
 # above) cannot be observed from a test — a build that fails produces no test
 # run at all — so this covers what remains: registry density, name and payload
-# totality, table/disposition agreement, and the four qLLM geometric node
-# types actually refusing under a live upstream gradient.
+# totality, table/disposition agreement, and the UNREGISTERED qLLM geometric
+# node types actually refusing under a live upstream gradient.
 if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/backend/exhaustive_dispatch_test.cpp")
     add_executable(exhaustive_dispatch_test tests/backend/exhaustive_dispatch_test.cpp)
     target_compile_features(exhaustive_dispatch_test PRIVATE cxx_std_17)
@@ -5883,6 +5883,37 @@ if(ESHKOL_BUILD_TESTS AND
         # 5 embedding checks + 4 Frechet checks. Pinned deliberately: a bare
         # "0 failed" would stay green if a check silently stopped running.
         PASS_REGULAR_EXPRESSION "Results: 9 passed, 0 failed"
+    )
+endif()
+
+# ===== Geometric bridge backwards (SW-65) ====================================
+# ad_hyperbolic_distance / ad_poincare_exp_map / ad_poincare_log_map /
+# ad_geodesic_attention record tensor-valued AD nodes whose type numbers sit in
+# the band the dispatcher treated as scalar-only, so their absent backwards were
+# SILENT: every input gradient came back 0.0 with no diagnostic. This gate
+# checks the four new rules against the committed qllm_oracle golden Jacobians,
+# the conformal-factor identity, the exp/log inverse-Jacobian identity and
+# finite differences, and red-proofs the registry's UNREGISTERED refusal that
+# stops a fifth op joining the family.
+if(ESHKOL_BUILD_TESTS AND
+   EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/bridge/qllm_bridge_geometric_gradcheck_test.cpp")
+    add_executable(qllm_bridge_geometric_gradcheck_test
+        tests/bridge/qllm_bridge_geometric_gradcheck_test.cpp)
+    target_compile_features(qllm_bridge_geometric_gradcheck_test PRIVATE cxx_std_20)
+    target_include_directories(qllm_bridge_geometric_gradcheck_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+    eshkol_target_llvm_includes(qllm_bridge_geometric_gradcheck_test)
+    if(LLVM_LIBRARY_DIRS)
+        target_link_directories(qllm_bridge_geometric_gradcheck_test PRIVATE ${LLVM_LIBRARY_DIRS})
+    endif()
+    target_link_libraries(qllm_bridge_geometric_gradcheck_test PRIVATE
+        eshkol-static ${ESHKOL_EXTRA_LINK_LIBS} ${LLVM_LIBS_LIST} ${LLVM_SYSTEM_LIBS_LIST})
+    add_test(NAME qllm_bridge_geometric_gradcheck
+             COMMAND qllm_bridge_geometric_gradcheck_test)
+    set_tests_properties(qllm_bridge_geometric_gradcheck PROPERTIES
+        # 3 distance + 5 exp/log + 3 geodesic + 2 structural. Pinned: a bare
+        # "0 failed" would stay green if a check silently stopped running.
+        PASS_REGULAR_EXPRESSION "Results: 13 passed, 0 failed"
     )
 endif()
 

--- a/docs/api/bridge/qllm_bridge.md
+++ b/docs/api/bridge/qllm_bridge.md
@@ -241,7 +241,7 @@ Output tensor node [num_indices, d_model], or NULL on error.
 
 ### `ad_hyperbolic_distance`
 
-*Function* — line 224
+*Function* — line 231
 
 ```c
 ad_node_t* ad_hyperbolic_distance(
@@ -252,11 +252,11 @@ ad_node_t* ad_hyperbolic_distance(
 );
 ```
 
-Hyperbolic distance in the Poincare ball model. d(x, y) = acosh(1 + 2 * ||x-y||^2 / ((1-||x||^2)(1-||y||^2)))
+Hyperbolic distance in the Poincare ball model. d(x, y) = acosh(1 + 2 * ||x-y||^2 / ((1-||x||^2)(1-||y||^2))) NOT DIFFERENTIABLE AT x == y. Like the Euclidean |x - y|, the Riemannian distance has a cone point at coincidence: the one-sided slopes disagree in every direction, so only a subgradient set exists there. The backward refuses at coincident points rather than returning a plausible member of that set. Away from coincidence the gradient is exact, and its Euclidean magnitude is the conformal factor at each argument (|grad_x d| = 2/(1-c||x||^2)).
 
 ### `ad_poincare_exp_map`
 
-*Function* — line 236
+*Function* — line 243
 
 ```c
 ad_node_t* ad_poincare_exp_map(
@@ -271,7 +271,7 @@ Poincare exponential map. Maps a tangent vector at x to a point on the manifold.
 
 ### `ad_poincare_log_map`
 
-*Function* — line 248
+*Function* — line 255
 
 ```c
 ad_node_t* ad_poincare_log_map(
@@ -286,7 +286,7 @@ Poincare logarithmic map. Maps a point y back to the tangent space at x.
 
 ### `ad_geodesic_attention`
 
-*Function* — line 260
+*Function* — line 278
 
 ```c
 ad_node_t* ad_geodesic_attention(
@@ -300,11 +300,11 @@ ad_node_t* ad_geodesic_attention(
 );
 ```
 
-Geodesic attention with curvature-adaptive scaling. Replaces dot-product with geodesic distance in attention scores.
+Geodesic attention with curvature-adaptive scaling. Replaces dot-product with geodesic distance in attention scores: s_ij = -d(Q_i, K_j) / (sqrt(c) * sqrt(head_dim)), then softmax over j and a value-weighted sum. The forward retains the softmax weights on the node so the backward reads the same numbers the forward produced rather than recomputing the max-shift and the mask. CONSEQUENCE OF DISTANCE SCORING, worth knowing before you wire it up: because the geodesic distance has no derivative at coincident points, this op is not differentiable whenever a query row equals a key row exactly — which is the ordinary case when Q and K are the same tensor. The backward refuses there and names the (batch, head, i, j) it refused on. Dot-product attention (ad_tensor_attention) has no such point and is differentiable everywhere.
 
 ### `ad_frechet_mean`
 
-*Function* — line 301
+*Function* — line 319
 
 ```c
 ad_node_t* ad_frechet_mean(
@@ -332,7 +332,7 @@ Mean tensor node [dim], or NULL on error.
 
 ### `eshkol_qllm_bridge_init`
 
-*Function* — line 321
+*Function* — line 339
 
 ```c
 bool eshkol_qllm_bridge_init(const char* library_path);
@@ -350,7 +350,7 @@ true on success
 
 ### `eshkol_qllm_bridge_shutdown`
 
-*Function* — line 326
+*Function* — line 344
 
 ```c
 void eshkol_qllm_bridge_shutdown(void);
@@ -360,7 +360,7 @@ Shutdown the qLLM bridge.
 
 ### `eshkol_qllm_bridge_ready`
 
-*Function* — line 331
+*Function* — line 349
 
 ```c
 bool eshkol_qllm_bridge_ready(void);

--- a/inc/eshkol/ad_node_registry.def
+++ b/inc/eshkol/ad_node_registry.def
@@ -124,35 +124,39 @@ ESHKOL_AD_NODE(EMBEDDING,           32, TENSOR, INLINE,         ESHKOL_AD_NO_BRI
 
 /* ── qLLM geometric gradients (33-40) ───────────────────────────────────────
  *
- * THIS BLOCK IS THE #498 CLASS, STILL LIVE, IN FOUR MORE NODE TYPES.
+ * THIS BLOCK IS THE #498 CLASS — the four node types whose silent zero
+ * gradients motivated this registry in the first place.
  *
  * The four rows lib/bridge/qllm_bridge.cpp actually produces —
  * HYPERBOLIC_DISTANCE, POINCARE_EXP_MAP, POINCARE_LOG_MAP and
  * GEODESIC_ATTENTION — are recorded on the tape as TENSOR nodes
  * (make_node(..., out, shape, ...) with a tensor_value), so a reverse sweep
- * routes them to eshkol_tensor_backward_dispatch, where until this change
- * they hit the same asserted-impossible `default:` and returned zero.  The
- * numeric band the old comment reasoned from ("tensor ops are 19-32 and
- * 67-80") never covered 33-40.
+ * routes them to eshkol_tensor_backward_dispatch, where until SW-65 they hit
+ * an asserted-impossible `default:` and returned zero.  The numeric band that
+ * default's comment reasoned from ("tensor ops are 19-32 and 67-80") never
+ * covered 33-40.
  *
- * They are declared UNREGISTERED rather than given a backward here: writing
- * Riemannian adjoints is AD work with its own correctness bar, in flight on a
- * separate lane, and inventing one to close a dispatch hole is how a wrong
- * gradient gets shipped.  UNREGISTERED aborts naming the node type, so the
- * gap announces itself at the point of use.  Note these DO have an adjoint on
- * the OTHER reverse sweep: autodiff_codegen.cpp emits scalar backward blocks
- * for node types 33-40.  This column is about the tensor dispatcher alone.
+ * They are BRIDGE rows now: exact Riemannian adjoints live in
+ * lib/bridge/tensor_backward.cpp (SW-65).  The exp- and log-map rules reuse
+ * FrechetGeometry's mobius_add_with_jacobians / log_map_with_jacobians rather
+ * than re-deriving them, and the distance-based rules REFUSE at coincident
+ * points — the geodesic distance has a subgradient set there, not a
+ * derivative — instead of inventing a member of that set.  Note these also
+ * have an adjoint on the OTHER reverse sweep: autodiff_codegen.cpp emits
+ * scalar backward blocks for node types 33-40.  This column is about the
+ * tensor dispatcher alone.
  *
  * TANGENT_PROJECT / MOBIUS_ADD / MOBIUS_MATMUL / GYROVECTOR_SPACE have no
  * producer at all today; the emitted scalar sweep reads them, nothing writes
- * them.  A future producer that records one as a tensor node inherits the
- * abort rather than the silence.
+ * them.  They stay UNREGISTERED — an explicit abort naming the node type — so
+ * a future producer that records one as a tensor node inherits the abort
+ * rather than the silence.
  */
-ESHKOL_AD_NODE(HYPERBOLIC_DISTANCE, 33, TENSOR, UNREGISTERED,   ESHKOL_AD_NO_BRIDGE)
-ESHKOL_AD_NODE(POINCARE_EXP_MAP,    34, TENSOR, UNREGISTERED,   ESHKOL_AD_NO_BRIDGE)
-ESHKOL_AD_NODE(POINCARE_LOG_MAP,    35, TENSOR, UNREGISTERED,   ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(HYPERBOLIC_DISTANCE, 33, TENSOR, BRIDGE, tensor_hyperbolic_distance_backward)
+ESHKOL_AD_NODE(POINCARE_EXP_MAP,    34, TENSOR, BRIDGE, tensor_poincare_exp_map_backward)
+ESHKOL_AD_NODE(POINCARE_LOG_MAP,    35, TENSOR, BRIDGE, tensor_poincare_log_map_backward)
 ESHKOL_AD_NODE(TANGENT_PROJECT,     36, TENSOR, UNREGISTERED,   ESHKOL_AD_NO_BRIDGE)
-ESHKOL_AD_NODE(GEODESIC_ATTENTION,  37, TENSOR, UNREGISTERED,   ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(GEODESIC_ATTENTION,  37, TENSOR, BRIDGE, tensor_geodesic_attention_backward)
 ESHKOL_AD_NODE(MOBIUS_ADD,          38, TENSOR, UNREGISTERED,   ESHKOL_AD_NO_BRIDGE)
 ESHKOL_AD_NODE(MOBIUS_MATMUL,       39, TENSOR, UNREGISTERED,   ESHKOL_AD_NO_BRIDGE)
 ESHKOL_AD_NODE(GYROVECTOR_SPACE,    40, TENSOR, UNREGISTERED,   ESHKOL_AD_NO_BRIDGE)

--- a/inc/eshkol/bridge/qllm_bridge.h
+++ b/inc/eshkol/bridge/qllm_bridge.h
@@ -220,6 +220,13 @@ ad_node_t* ad_tensor_embedding(
  * @brief Hyperbolic distance in the Poincare ball model.
  *
  * d(x, y) = acosh(1 + 2 * ||x-y||^2 / ((1-||x||^2)(1-||y||^2)))
+ *
+ * NOT DIFFERENTIABLE AT x == y. Like the Euclidean |x - y|, the Riemannian
+ * distance has a cone point at coincidence: the one-sided slopes disagree in
+ * every direction, so only a subgradient set exists there. The backward refuses
+ * at coincident points rather than returning a plausible member of that set.
+ * Away from coincidence the gradient is exact, and its Euclidean magnitude is
+ * the conformal factor at each argument (|grad_x d| = 2/(1-c||x||^2)).
  */
 ad_node_t* ad_hyperbolic_distance(
     ad_tape_t* tape,
@@ -255,7 +262,18 @@ ad_node_t* ad_poincare_log_map(
 /**
  * @brief Geodesic attention with curvature-adaptive scaling.
  *
- * Replaces dot-product with geodesic distance in attention scores.
+ * Replaces dot-product with geodesic distance in attention scores:
+ * s_ij = -d(Q_i, K_j) / (sqrt(c) * sqrt(head_dim)), then softmax over j and a
+ * value-weighted sum. The forward retains the softmax weights on the node so
+ * the backward reads the same numbers the forward produced rather than
+ * recomputing the max-shift and the mask.
+ *
+ * CONSEQUENCE OF DISTANCE SCORING, worth knowing before you wire it up: because
+ * the geodesic distance has no derivative at coincident points, this op is not
+ * differentiable whenever a query row equals a key row exactly — which is the
+ * ordinary case when Q and K are the same tensor. The backward refuses there
+ * and names the (batch, head, i, j) it refused on. Dot-product attention
+ * (ad_tensor_attention) has no such point and is differentiable everywhere.
  */
 ad_node_t* ad_geodesic_attention(
     ad_tape_t* tape,

--- a/lib/bridge/qllm_bridge.cpp
+++ b/lib/bridge/qllm_bridge.cpp
@@ -903,7 +903,13 @@ extern "C" ad_node_t* ad_geodesic_attention(ad_tape_t* tape,
     const double* V = (const double*)v->tensor_value;
     double* O = alloc_doubles(batch * seq * dim);
     double* scores = alloc_doubles(seq);
-    if (!O || !scores) return nullptr;
+    /* Retain the softmax weights for the backward (SW-65). Recomputing them in
+     * the reverse pass would have to re-derive the max-shift and the causal
+     * mask, i.e. duplicate this loop, and any drift between the two copies is
+     * the silently-wrong-gradient class SW-12 records for ad_tensor_attention.
+     * Zero-filled, so a masked tail stays exactly zero. */
+    double* A = alloc_doubles(batch * (size_t)num_heads * seq * seq);
+    if (!O || !scores || !A) return nullptr;
 
     /* Score by NEGATIVE geodesic distance (closer => higher attention), with the
      * curvature-adaptive 1/sqrt(c * head_dim) scaling. */
@@ -943,11 +949,14 @@ extern "C" ad_node_t* ad_geodesic_attention(ad_tape_t* tape,
                     sum += scores[j];
                 }
                 if (sum <= 0.0) sum = 1.0;
+                double* arow =
+                    &A[((b * (size_t)num_heads + (size_t)h) * seq + i) * seq];
+                for (size_t j = 0; j < limit; ++j) arow[j] = scores[j] / sum;
                 for (size_t d = 0; d < head_dim; ++d) {
                     double acc = 0.0;
                     for (size_t j = 0; j < limit; ++j) {
                         size_t vj = (b * seq + j) * dim + off;
-                        acc += (scores[j] / sum) * V[vj + d];
+                        acc += arow[j] * V[vj + d];
                     }
                     O[(b * seq + i) * dim + off + d] = acc;
                 }
@@ -958,8 +967,35 @@ extern "C" ad_node_t* ad_geodesic_attention(ad_tape_t* tape,
     ad_node_t* node = make_node(tape, AD_NODE_GEODESIC_ATTENTION, O,
                                 q->shape, q->ndim, q, k, v);
     if (node) {
-        node->params.attention_params.num_heads = num_heads;
-        node->params.attention_params.head_dim = (int64_t)head_dim;
+        /* params as int64[6], the layout tensor_geodesic_attention_backward
+         * reads:
+         *   [0] num_heads   [1] head_dim   [2] causal (0/1)
+         *   [3] curvature c bit-cast from double (the "scale_bits" convention
+         *       shared with ad_tensor_attention and the Frechet rule)
+         *   [4] [5] reserved, zero
+         * [0]/[1] deliberately coincide with the named attention_params fields
+         * so both spellings read the same slots. Before this, `causal` and the
+         * curvature were not recorded at all — the backward could not have
+         * reconstructed the mask or the metric. */
+        int64_t* p = (int64_t*)&node->params;
+        p[0] = (int64_t)num_heads;
+        p[1] = (int64_t)head_dim;
+        p[2] = causal ? 1 : 0;
+        std::memcpy(&p[3], &c, sizeof c);
+        p[4] = 0;
+        p[5] = 0;
+
+        double** saved = (double**)arena_allocate_zeroed(get_global_arena(),
+                                                         sizeof(double*));
+        if (!saved) {
+            eshkol_error("qllm bridge: ad_geodesic_attention could not retain the "
+                         "attention weights; refusing to record a node whose "
+                         "backward would have nothing exact to work from");
+            return nullptr;
+        }
+        saved[0] = A;
+        node->saved_tensors = (void**)saved;
+        node->num_saved = 1;
     }
     return node;
 }

--- a/lib/bridge/tensor_backward.cpp
+++ b/lib/bridge/tensor_backward.cpp
@@ -1542,6 +1542,432 @@ extern "C" void tensor_attention_backward(ad_node_t* node) {
     }
 }
 
+
+/*******************************************************************************
+ * Geometric bridge backwards (SW-65)
+ *
+ * ad_hyperbolic_distance, ad_poincare_exp_map, ad_poincare_log_map and
+ * ad_geodesic_attention (lib/bridge/qllm_bridge.cpp) all record TENSOR-VALUED
+ * nodes — types 33, 34, 35 and 37 — and none of them had a backward. They were
+ * not refused and they did not warn: the node types sit in the 33-66 band that
+ * eshkol_tensor_backward_dispatch treats as "scalar ops differentiated by
+ * codegen", so they fell into its default: and the reverse sweep completed
+ * having propagated exactly nothing. Every input gradient came back 0.0 with no
+ * diagnostic, which a caller cannot tell from a genuine zero.
+ *
+ * The rules below are exact. Two of them are compositions the file already
+ * differentiates for the Frechet mean, and they reuse that machinery rather
+ * than re-deriving it — deriving the same Mobius Jacobian twice is how a sign
+ * error survives a gradient check on the other copy.
+ *
+ * WHERE THESE REFUSE, AND WHY IT IS NOT CONSERVATISM. The Riemannian distance
+ * d(x, y) behaves like |x - y| near coincidence: it has no derivative at x = y,
+ * only a subgradient set. Any number returned there is invented. Both
+ * distance-based rules therefore refuse at exact coincidence instead of picking
+ * a plausible member of that set. For geodesic attention this has a consequence
+ * worth stating outright: scoring by distance makes the op non-differentiable
+ * whenever a query row coincides exactly with a key row, which is the ordinary
+ * case when Q and K are the same tensor. That is a property of distance
+ * scoring, not of this implementation, and it is precisely the kind of fact a
+ * silent zero would have hidden.
+ ******************************************************************************/
+
+namespace {
+
+/** @brief Upstream cotangent of a tensor-valued node.
+ *
+ *  `tensor_gradient` is the canonical channel — every rule in this file
+ *  accumulates into it — so it is what a downstream op will have written. The
+ *  scalar `gradient` mirror is the fallback for the loss-node convention used
+ *  by tensor_cross_entropy_backward, which seeds only the scalar. */
+double scalar_upstream(const ad_node_t* node) {
+    if (node->tensor_gradient) return ((const double*)node->tensor_gradient)[0];
+    return node->gradient;
+}
+
+/** @brief Gradient of the Poincare-ball distance d(x, y) with respect to both
+ *         arguments, for the ball of curvature -c.
+ *
+ *      d      = acosh(arg)/sqrt(c),   arg = 1 + 2c|x-y|^2/(dx dy)
+ *      dx     = 1 - c|x|^2,           dy  = 1 - c|y|^2
+ *
+ *  d(acosh)/d(arg) = 1/sqrt(arg^2 - 1), and arg depends on x both through the
+ *  numerator |x-y|^2 and through dx in the denominator; both terms are kept.
+ *
+ *  @param gx  out, n doubles: d d / d x (may be NULL)
+ *  @param gy  out, n doubles: d d / d y (may be NULL)
+ *  @return false when the two points coincide (arg <= 1), where the distance
+ *          has no derivative, or when either point is outside the ball.
+ */
+bool hyperbolic_distance_grad(const double* x, const double* y, double c,
+                              int64_t n, double* gx, double* gy,
+                              double* dist_out) {
+    double diff2 = 0.0, xx = 0.0, yy = 0.0;
+    for (int64_t i = 0; i < n; i++) {
+        double dd = x[i] - y[i];
+        diff2 += dd * dd;
+        xx += x[i] * x[i];
+        yy += y[i] * y[i];
+    }
+    double dx = 1.0 - c * xx;
+    double dy = 1.0 - c * yy;
+    if (!(dx > 0.0) || !(dy > 0.0)) return false;
+
+    double arg = 1.0 + 2.0 * c * diff2 / (dx * dy);
+    if (dist_out) *dist_out = (arg > 1.0) ? (std::acosh(arg) / std::sqrt(c)) : 0.0;
+
+    /* arg == 1 is exactly x == y. sqrt(arg^2 - 1) = 0 there and the distance is
+     * a cone point: the one-sided slopes disagree in every direction, so no
+     * derivative exists to return. */
+    if (!(arg > 1.0)) return false;
+
+    double dacosh = 1.0 / (std::sqrt(c) * std::sqrt(arg * arg - 1.0));
+    if (!std::isfinite(dacosh)) return false;
+
+    for (int64_t i = 0; i < n; i++) {
+        double num = 4.0 * c * (x[i] - y[i]) / (dx * dy);
+        if (gx) gx[i] = dacosh * (num + 4.0 * c * c * diff2 * x[i] / (dx * dx * dy));
+        if (gy) gy[i] = dacosh * (-num + 4.0 * c * c * diff2 * y[i] / (dx * dy * dy));
+    }
+    return true;
+}
+
+}  // namespace
+
+/** @brief Backward for the Poincare-ball distance. Scalar output, two point
+ *  inputs; refuses at coincident points, where no derivative exists. */
+extern "C" void tensor_hyperbolic_distance_backward(ad_node_t* node) {
+    if (!node) return;
+    ad_node_t* xn = node->input1;
+    ad_node_t* yn = node->input2;
+    if (!xn || !yn || !xn->tensor_value || !yn->tensor_value) {
+        eshkol_fatal("hyperbolic-distance backward: node->input1 and input2 must "
+                     "carry the two points; refusing to differentiate a distance "
+                     "whose operands were not retained.");
+        return;
+    }
+    const double g = scalar_upstream(node);
+    if (g == 0.0) return;
+
+    const int64_t n = (int64_t)tensor_size(xn->shape, xn->ndim);
+    const double c = node->params.curvature;
+    if (!(c > 0.0)) {
+        eshkol_fatal("hyperbolic-distance backward: curvature parameter is %.17g; "
+                     "the forward stores |curvature| and it must be positive.", c);
+        return;
+    }
+
+    std::vector<double> gx((size_t)n), gy((size_t)n);
+    if (!hyperbolic_distance_grad((const double*)xn->tensor_value,
+                                  (const double*)yn->tensor_value,
+                                  c, n, gx.data(), gy.data(), nullptr)) {
+        eshkol_fatal("hyperbolic-distance backward: the two points coincide (or "
+                     "one is outside the Poincare ball), where the distance has "
+                     "no derivative — it is a cone point, and every value a rule "
+                     "could return there is invented. Refusing.");
+        return;
+    }
+
+    if (!xn->tensor_gradient) xn->tensor_gradient = alloc_grad((size_t)n);
+    if (!yn->tensor_gradient) yn->tensor_gradient = alloc_grad((size_t)n);
+    double* dX = (double*)xn->tensor_gradient;
+    double* dY = (double*)yn->tensor_gradient;
+    if (!dX || !dY) return;
+    for (int64_t i = 0; i < n; i++) { dX[i] += g * gx[(size_t)i]; dY[i] += g * gy[(size_t)i]; }
+}
+
+/** @brief Backward for the Poincare exponential map exp_x(v).
+ *
+ *  The forward is out = x (+)_c (coef * v) with
+ *      coef = tanh(sqrt(c) * lambda_x * |v| / 2) / (sqrt(c) * |v|),
+ *      lambda_x = 2 / (1 - c|x|^2).
+ *  So the differential is the Mobius addition's two Jacobians composed with the
+ *  differential of the radial factor. The Mobius Jacobians come from the same
+ *  routine the Frechet rule uses, so the two cannot disagree about them.
+ *
+ *  coef has a removable singularity at |v| = 0: it tends to lambda_x/2, and its
+ *  v-derivative tends to 0. Below a threshold the series
+ *      coef       = 1/dx - c|v|^2/(3 dx^3) + O(|v|^4)
+ *      dcoef/dv_j = v_j * (-2c/(3 dx^3)) + O(|v|^2)
+ *  is used instead of the quotient, which would be 0/0 there. Note this is the
+ *  derivative of the MATHEMATICAL map, which is smooth at v = 0 — not the
+ *  derivative of the forward's `|v| < 1e-15 -> return x` shortcut branch, whose
+ *  v-derivative would be a (wrong) zero. Same distinction the sphere_retract
+ *  finding in tests/qllm_oracle/README.md draws between a guard and the map. */
+extern "C" void tensor_poincare_exp_map_backward(ad_node_t* node) {
+    if (!node || !node->tensor_gradient) return;
+    ad_node_t* xn = node->input1;
+    ad_node_t* vn_node = node->input2;
+    if (!xn || !vn_node || !xn->tensor_value || !vn_node->tensor_value) {
+        eshkol_fatal("poincare-exp-map backward: node->input1 (base point) and "
+                     "input2 (tangent) must both be retained.");
+        return;
+    }
+    const int64_t n = (int64_t)tensor_size(xn->shape, xn->ndim);
+    const double c = node->params.curvature;
+    if (n <= 0 || !(c > 0.0)) {
+        eshkol_fatal("poincare-exp-map backward: degenerate dimension %lld or "
+                     "curvature %.17g.", (long long)n, c);
+        return;
+    }
+    const double* X = (const double*)xn->tensor_value;
+    const double* V = (const double*)vn_node->tensor_value;
+    const double* g = (const double*)node->tensor_gradient;
+    const double sc = std::sqrt(c);
+
+    double xx = 0.0, vv = 0.0;
+    for (int64_t i = 0; i < n; i++) { xx += X[i] * X[i]; vv += V[i] * V[i]; }
+    const double dx = 1.0 - c * xx;
+    if (!(dx > 0.0)) {
+        eshkol_fatal("poincare-exp-map backward: the base point is on or outside "
+                     "the Poincare ball (1 - c|x|^2 = %.17g).", dx);
+        return;
+    }
+    const double vnorm = std::sqrt(vv);
+
+    /* coef and its two derivative factors. `dcoef_dv_over_v` is the scalar k
+     * with dcoef/dv_j = k * v_j; splitting it out is what lets the |v| -> 0
+     * limit be taken exactly instead of as 0/0. */
+    double coef, dcoef_dv_over_v;
+    const double kSmallTangent = 1e-6;      /* below this the series is more accurate */
+    if (vnorm < kSmallTangent) {
+        coef = 1.0 / dx - c * vv / (3.0 * dx * dx * dx);
+        dcoef_dv_over_v = -2.0 * c / (3.0 * dx * dx * dx);
+    } else {
+        const double u = sc * vnorm / dx;               /* = sc * lambda * |v| / 2 */
+        const double th = std::tanh(u);
+        const double sech2 = 1.0 - th * th;
+        coef = th / (sc * vnorm);
+        dcoef_dv_over_v = (sech2 / dx - th / (sc * vnorm)) / vv;
+    }
+    /* dcoef/dx_j = 2 c x_j sech^2(u) / dx^2 (through lambda_x only). */
+    const double u2 = (vnorm < kSmallTangent) ? 0.0 : (sc * vnorm / dx);
+    const double th2 = std::tanh(u2);
+    const double sech2x = 1.0 - th2 * th2;
+    const double dcoef_dx_scale = 2.0 * c * sech2x / (dx * dx);
+
+    std::vector<double> s((size_t)n);
+    for (int64_t i = 0; i < n; i++) s[(size_t)i] = coef * V[i];
+
+    FrechetGeometry geo(-c, n);
+    std::vector<double> Ja((size_t)(n * n)), Jx((size_t)(n * n)), outv((size_t)n);
+    geo.mobius_add_with_jacobians(X, s.data(), outv.data(), Ja.data(), Jx.data());
+
+    /* w = Jx^T g, the cotangent pulled back to the Mobius second argument. */
+    std::vector<double> w((size_t)n, 0.0);
+    for (int64_t j = 0; j < n; j++) {
+        double acc = 0.0;
+        for (int64_t i = 0; i < n; i++) acc += g[i] * Jx[(size_t)(i * n + j)];
+        w[(size_t)j] = acc;
+    }
+    /* wV = <w, V>, the only way V enters dcoef's contraction. */
+    double wV = 0.0;
+    for (int64_t i = 0; i < n; i++) wV += w[(size_t)i] * V[i];
+
+    if (!xn->tensor_gradient) xn->tensor_gradient = alloc_grad((size_t)n);
+    if (!vn_node->tensor_gradient) vn_node->tensor_gradient = alloc_grad((size_t)n);
+    double* dX = (double*)xn->tensor_gradient;
+    double* dV = (double*)vn_node->tensor_gradient;
+    if (!dX || !dV) return;
+
+    for (int64_t j = 0; j < n; j++) {
+        /* d out/d x = Ja + Jx * (ds/dx),  ds_m/dx_j = V_m * dcoef/dx_j */
+        double direct = 0.0;
+        for (int64_t i = 0; i < n; i++) direct += g[i] * Ja[(size_t)(i * n + j)];
+        dX[j] += direct + wV * dcoef_dx_scale * X[j];
+        /* ds_m/dv_j = coef * delta_mj + V_m * dcoef/dv_j */
+        dV[j] += coef * w[(size_t)j] + wV * dcoef_dv_over_v * V[j];
+    }
+}
+
+/** @brief Backward for the Poincare logarithmic map log_x(y).
+ *
+ *  log_x(y) = k(x) * phi(|u|) * u with u = (-x) (+)_c y, k = (1 - c|x|^2)/sqrt(c)
+ *  and phi(r) = artanh(sqrt(c) r)/r — which is exactly the map
+ *  FrechetGeometry::log_map_with_jacobians already differentiates for the
+ *  Frechet rule, including the r -> 0 limit. Reusing it is the point: this is
+ *  the same function, and a second derivation of it could only introduce a
+ *  disagreement.
+ *
+ *  It returns false when sqrt(c)|u| >= 1, i.e. no finite log exists. The
+ *  forward clamps there (`t >= 1 -> t = 1 - 1e-12`) and returns a value, but
+ *  that value is fabricated — beyond the boundary the log map has no value to
+ *  differentiate — so the rule refuses rather than differentiate the clamp. */
+extern "C" void tensor_poincare_log_map_backward(ad_node_t* node) {
+    if (!node || !node->tensor_gradient) return;
+    ad_node_t* xn = node->input1;
+    ad_node_t* yn = node->input2;
+    if (!xn || !yn || !xn->tensor_value || !yn->tensor_value) {
+        eshkol_fatal("poincare-log-map backward: node->input1 and input2 must "
+                     "both be retained.");
+        return;
+    }
+    const int64_t n = (int64_t)tensor_size(xn->shape, xn->ndim);
+    const double c = node->params.curvature;
+    if (n <= 0 || !(c > 0.0)) {
+        eshkol_fatal("poincare-log-map backward: degenerate dimension %lld or "
+                     "curvature %.17g.", (long long)n, c);
+        return;
+    }
+    const double* X = (const double*)xn->tensor_value;
+    const double* Y = (const double*)yn->tensor_value;
+    const double* g = (const double*)node->tensor_gradient;
+
+    FrechetGeometry geo(-c, n);
+    if (!geo.log_map_with_jacobians(X, Y)) {
+        eshkol_fatal("poincare-log-map backward: sqrt(c)|(-x) (+) y| >= 1, so no "
+                     "finite log_x(y) exists at these operands. The forward "
+                     "clamps artanh's argument and returns a value anyway; that "
+                     "value is fabricated, and differentiating it would launder "
+                     "the fabrication into a gradient. Refusing.");
+        return;
+    }
+
+    if (!xn->tensor_gradient) xn->tensor_gradient = alloc_grad((size_t)n);
+    if (!yn->tensor_gradient) yn->tensor_gradient = alloc_grad((size_t)n);
+    double* dX = (double*)xn->tensor_gradient;
+    double* dY = (double*)yn->tensor_gradient;
+    if (!dX || !dY) return;
+
+    for (int64_t j = 0; j < n; j++) {
+        double ax = 0.0, ay = 0.0;
+        for (int64_t i = 0; i < n; i++) {
+            ax += g[i] * geo.dlog_dmu[(size_t)(i * n + j)];
+            ay += g[i] * geo.dlog_dx[(size_t)(i * n + j)];
+        }
+        dX[j] += ax;
+        dY[j] += ay;
+    }
+}
+
+/** @brief Backward for geodesic attention: softmax over negated geodesic
+ *  distances, composed with the value-weighted sum.
+ *
+ *      s_ij = -scale * d(Q_i, K_j),  p = softmax_j(s),  O_i = sum_j p_ij V_j
+ *
+ *  The chain is the standard attention one with the dot-product score replaced
+ *  by the distance score, so only ds/dQ and ds/dK differ; those come from
+ *  hyperbolic_distance_grad, the same routine the distance rule uses.
+ *
+ *  The softmax weights are read from node->saved_tensors[0], retained by the
+ *  forward. Recomputing them here was the alternative and is rejected for the
+ *  reason SW-12 records for ad_tensor_attention: it would have to re-derive the
+ *  max-shift and the causal mask, and any drift between the two copies is
+ *  exactly the silently-wrong-gradient class this rule exists to close. */
+extern "C" void tensor_geodesic_attention_backward(ad_node_t* node) {
+    if (!node || !node->tensor_gradient) return;
+    ad_node_t* qn = node->input1;
+    ad_node_t* kn = node->input2;
+    ad_node_t* vn_node = node->input3;
+    if (!qn || !kn || !vn_node || !qn->tensor_value || !kn->tensor_value
+        || !vn_node->tensor_value) {
+        eshkol_fatal("geodesic-attention backward: Q, K and V must all be "
+                     "retained on the node (input1/input2/input3).");
+        return;
+    }
+    if (!node->saved_tensors || node->num_saved < 1 || !node->saved_tensors[0]) {
+        eshkol_fatal("geodesic-attention backward: the forward did not retain the "
+                     "softmax weights (saved_tensors[0]). Recomputing them here "
+                     "would duplicate the forward's max-shift and mask, and any "
+                     "drift between the copies is the silently-wrong-gradient "
+                     "class this rule exists to close. Refusing.");
+        return;
+    }
+    if (qn->ndim != 3) {
+        eshkol_fatal("geodesic-attention backward: expected [batch, seq, dim] "
+                     "operands, got rank %zu.", qn->ndim);
+        return;
+    }
+
+    const size_t batch = (size_t)qn->shape[0];
+    const size_t seq   = (size_t)qn->shape[1];
+    const size_t dim   = (size_t)qn->shape[2];
+    const int64_t* p6  = (const int64_t*)&node->params;
+    const int     heads    = (int)p6[0];
+    const size_t  head_dim = (size_t)p6[1];
+    const bool    causal   = (p6[2] != 0);
+    const double  c        = double_from_bits(p6[3]);
+    if (heads <= 0 || head_dim == 0 || dim != (size_t)heads * head_dim || !(c > 0.0)) {
+        eshkol_fatal("geodesic-attention backward: inconsistent params "
+                     "(heads=%d head_dim=%zu dim=%zu curvature=%.17g).",
+                     heads, head_dim, dim, c);
+        return;
+    }
+    const double scale = 1.0 / (std::sqrt(c) * std::sqrt((double)head_dim));
+
+    const double* Q = (const double*)qn->tensor_value;
+    const double* K = (const double*)kn->tensor_value;
+    const double* V = (const double*)vn_node->tensor_value;
+    const double* A = (const double*)node->saved_tensors[0];   /* [b][h][i][j] */
+    const double* G = (const double*)node->tensor_gradient;
+
+    const size_t total = batch * seq * dim;
+    if (!qn->tensor_gradient) qn->tensor_gradient = alloc_grad(total);
+    if (!kn->tensor_gradient) kn->tensor_gradient = alloc_grad(total);
+    if (!vn_node->tensor_gradient) vn_node->tensor_gradient = alloc_grad(total);
+    double* dQ = (double*)qn->tensor_gradient;
+    double* dK = (double*)kn->tensor_gradient;
+    double* dV = (double*)vn_node->tensor_gradient;
+    if (!dQ || !dK || !dV) return;
+
+    std::vector<double> dp(seq), ds(seq), gq(head_dim), gk(head_dim);
+
+    for (size_t b = 0; b < batch; ++b) {
+        for (int h = 0; h < heads; ++h) {
+            const size_t off = (size_t)h * head_dim;
+            for (size_t i = 0; i < seq; ++i) {
+                const size_t qi = (b * seq + i) * dim + off;
+                const size_t limit = causal ? (i + 1) : seq;
+                const double* arow =
+                    &A[((b * (size_t)heads + (size_t)h) * seq + i) * seq];
+                const double* grow = &G[(b * seq + i) * dim + off];
+
+                /* dL/dV and dL/dp. */
+                double pdot = 0.0;
+                for (size_t j = 0; j < limit; ++j) {
+                    const size_t vj = (b * seq + j) * dim + off;
+                    double acc = 0.0;
+                    for (size_t d = 0; d < head_dim; ++d) {
+                        dV[vj + d] += arow[j] * grow[d];
+                        acc += grow[d] * V[vj + d];
+                    }
+                    dp[j] = acc;
+                    pdot += arow[j] * acc;
+                }
+                /* Softmax Jacobian: ds_j = p_j (dp_j - sum_m p_m dp_m). */
+                for (size_t j = 0; j < limit; ++j)
+                    ds[j] = arow[j] * (dp[j] - pdot);
+
+                /* s_j = -scale * d(Q_i, K_j): push through the distance. */
+                for (size_t j = 0; j < limit; ++j) {
+                    if (ds[j] == 0.0) continue;
+                    const size_t kj = (b * seq + j) * dim + off;
+                    if (!hyperbolic_distance_grad(&Q[qi], &K[kj], c,
+                                                  (int64_t)head_dim,
+                                                  gq.data(), gk.data(), nullptr)) {
+                        eshkol_fatal(
+                            "geodesic-attention backward: query row %zu and key "
+                            "row %zu (batch %zu, head %d) coincide exactly, or "
+                            "one lies outside the Poincare ball. The geodesic "
+                            "distance has no derivative at coincident points — "
+                            "it is a cone point — so scoring attention by "
+                            "distance makes this op non-differentiable there. "
+                            "This is the ordinary case when Q and K are the same "
+                            "tensor. Refusing rather than inventing a "
+                            "subgradient.", i, j, b, h);
+                        return;
+                    }
+                    const double f = -scale * ds[j];
+                    for (size_t d = 0; d < head_dim; ++d) {
+                        dQ[qi + d] += f * gq[d];
+                        dK[kj + d] += f * gk[d];
+                    }
+                }
+            }
+        }
+    }
+}
+
 /*******************************************************************************
  * Backward Dispatch Table
  ******************************************************************************/

--- a/tests/backend/exhaustive_dispatch_test.cpp
+++ b/tests/backend/exhaustive_dispatch_test.cpp
@@ -263,19 +263,24 @@ void drive_unregistered(ad_node_type_t type) {
     eshkol_tensor_backward_dispatch(out);
 }
 
-void body_geodesic()  { drive_unregistered(AD_NODE_GEODESIC_ATTENTION); }
-void body_hyperbolic(){ drive_unregistered(AD_NODE_HYPERBOLIC_DISTANCE); }
-void body_exp_map()   { drive_unregistered(AD_NODE_POINCARE_EXP_MAP); }
-void body_log_map()   { drive_unregistered(AD_NODE_POINCARE_LOG_MAP); }
+void body_tangent_project() { drive_unregistered(AD_NODE_TANGENT_PROJECT); }
+void body_mobius_add()      { drive_unregistered(AD_NODE_MOBIUS_ADD); }
+void body_mobius_matmul()   { drive_unregistered(AD_NODE_MOBIUS_MATMUL); }
+void body_gyrovector()      { drive_unregistered(AD_NODE_GYROVECTOR_SPACE); }
 
 void test_unregistered_tensor_backward_is_declared_not_silent() {
-    // The four the qLLM bridge actually produces. Each one of these assertions
-    // FAILED before this change — the dispatcher returned normally and the
+    // The four UNREGISTERED rows that remain after SW-65 registered exact
+    // BRIDGE backwards for the ops the qLLM bridge actually produces
+    // (HYPERBOLIC_DISTANCE / POINCARE_EXP_MAP / POINCARE_LOG_MAP /
+    // GEODESIC_ATTENTION — those are now exercised end-to-end by
+    // qllm_bridge_geometric_gradcheck instead).  Nothing writes these four
+    // today; a future producer must inherit the abort, not the silence.
+    // The same drive on the pre-registry dispatcher returned normally and the
     // caller read a gradient of exactly 0.0 as if it were the answer.
-    report("geodesic_attention_backward_refuses",  refuses(body_geodesic));
-    report("hyperbolic_distance_backward_refuses", refuses(body_hyperbolic));
-    report("poincare_exp_map_backward_refuses",    refuses(body_exp_map));
-    report("poincare_log_map_backward_refuses",    refuses(body_log_map));
+    report("tangent_project_backward_refuses",  refuses(body_tangent_project));
+    report("mobius_add_backward_refuses",       refuses(body_mobius_add));
+    report("mobius_matmul_backward_refuses",    refuses(body_mobius_matmul));
+    report("gyrovector_space_backward_refuses", refuses(body_gyrovector));
 }
 
 #else
@@ -289,7 +294,7 @@ void test_unregistered_tensor_backward_is_declared_not_silent() {
 
 /** @brief Every UNREGISTERED row must be reachable as a refusal, i.e. it must
  *  not silently also have a bridge entry. Cheap, but it is the property that
- *  makes the four death tests above representative of all eight. */
+ *  keeps the death tests above and the registry rows in agreement. */
 void test_all_unregistered_rows_have_no_backward() {
     bool ok = true;
     std::string detail;

--- a/tests/bridge/qllm_bridge_geometric_gradcheck_test.cpp
+++ b/tests/bridge/qllm_bridge_geometric_gradcheck_test.cpp
@@ -1,0 +1,510 @@
+/**
+ * @file qllm_bridge_geometric_gradcheck_test.cpp
+ * @brief Gradient checks for the four geometric bridge ops whose backwards were
+ *        missing entirely — SW-65.
+ *
+ * ad_hyperbolic_distance, ad_poincare_exp_map, ad_poincare_log_map and
+ * ad_geodesic_attention record TENSOR-valued AD nodes (types 33, 34, 35, 37).
+ * None had a backward. They did not refuse and they did not warn: those type
+ * numbers sit in the band eshkol_tensor_backward_dispatch treated as "scalar
+ * ops differentiated by codegen", so they fell into its default: and the
+ * reverse sweep propagated nothing. Every input gradient came back exactly 0.0,
+ * which a caller cannot distinguish from a genuine zero.
+ *
+ * WHAT EACH GRADIENT IS CHECKED AGAINST. Finite differences are the last line
+ * here, not the first. Three independent exact references come first:
+ *
+ *  1. THE COMMITTED GOLDEN VECTORS. tests/qllm_oracle/golden/ holds full
+ *     Jacobians for exp_0 and log_0 computed by Eshkol's reverse-mode AD over
+ *     an INDEPENDENTLY WRITTEN Eshkol transcription of the same formulas. Two
+ *     cases are asserted here by their case id, so these C rules are tied to
+ *     the same oracle qLLM's own kernels are tested against. This is the
+ *     strongest check in the file: a shared-mistake failure would have to occur
+ *     in two separate implementations, in two languages, written from different
+ *     sources.
+ *
+ *  2. THE CONFORMAL-FACTOR IDENTITY. For the Poincare distance, the Euclidean
+ *     gradient magnitudes are exactly the conformal factors at each argument:
+ *     |grad_x d| = lambda_x = 2/(1-c|x|^2) and |grad_y d| = lambda_y. This
+ *     holds at EVERY interior pair, not just at a fixture point, because the
+ *     Riemannian gradient of a distance function is a unit vector. It is a
+ *     property of the geometry, derived nowhere near the code under test.
+ *
+ *  3. THE INVERSE-JACOBIAN IDENTITY. log_x(exp_x(v)) = v identically, so
+ *     J_log * J_exp = I. That couples the two rules to each other with no
+ *     appeal to either derivation: a sign error in one would have to be
+ *     mirrored exactly in the other to survive.
+ *
+ * Both refusals are checked in a forked child, because eshkol_fatal exits the
+ * process. A refusal that did not actually terminate would otherwise read as a
+ * pass.
+ *
+ * Copyright (C) tsotchke
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <cstdio>
+#include <cstring>
+#include <cmath>
+#include <cstdlib>
+#include <cstdarg>
+#include <vector>
+#include <unistd.h>
+#include <sys/wait.h>
+
+#include "eshkol/eshkol.h"
+#include "eshkol/bridge/qllm_bridge.h"
+#include "eshkol/backend/tensor_backward.h"
+
+extern "C" {
+    typedef struct arena arena_t;
+    arena_t* get_global_arena(void);
+    void* arena_allocate_zeroed(arena_t* arena, size_t size);
+    ad_tape_t* arena_allocate_tape(arena_t* arena, size_t initial_capacity);
+    ad_node_t* arena_allocate_ad_node(arena_t* arena);
+}
+
+#define TOLERANCE 1e-6
+#define STEP      1e-6
+
+static int g_passed = 0, g_failed = 0;
+static void report(const char* name, bool ok, const char* fmt, ...) {
+    va_list ap; va_start(ap, fmt);
+    std::printf("%s: %s — ", ok ? "PASS" : "FAIL", name);
+    std::vprintf(fmt, ap); std::printf("\n"); va_end(ap);
+    if (ok) ++g_passed; else ++g_failed;
+}
+
+static double* ad_doubles(size_t n) {
+    return (double*)arena_allocate_zeroed(get_global_arena(), n * sizeof(double));
+}
+static ad_node_t* var_node(const double* data, const int64_t* shape, size_t ndim) {
+    ad_node_t* n = arena_allocate_ad_node(get_global_arena());
+    size_t c = 1; for (size_t i = 0; i < ndim; ++i) c *= (size_t)shape[i];
+    double* b = ad_doubles(c); std::memcpy(b, data, c * sizeof(double));
+    int64_t* s = (int64_t*)arena_allocate_zeroed(get_global_arena(), ndim * sizeof(int64_t));
+    std::memcpy(s, shape, ndim * sizeof(int64_t));
+    n->type = AD_NODE_VARIABLE; n->tensor_value = b; n->shape = s; n->ndim = ndim;
+    return n;
+}
+static void sweep(ad_tape_t* t) {
+    for (size_t i = t->num_nodes; i-- > 0;) eshkol_tensor_backward_dispatch(t->nodes[i]);
+}
+struct RelAcc { double dn = 0.0, nn = 0.0, an = 0.0; };
+static void acc_add(RelAcc* a, double num, double ana) {
+    double d = num - ana; a->dn += d*d; a->nn += num*num; a->an += ana*ana;
+}
+static double acc_val(const RelAcc* a) {
+    double den = std::sqrt(a->nn) + std::sqrt(a->an);
+    return den > 0.0 ? std::sqrt(a->dn)/den : 0.0;
+}
+
+/** @brief Run `fn` in a forked child; true iff the child exited non-zero
+ *  (i.e. the rule actually refused rather than returning a number). */
+static bool child_refuses(void (*fn)(void)) {
+    std::fflush(stdout);
+    pid_t pid = fork();
+    if (pid == 0) { fn(); _exit(0); }          /* reached only if no refusal */
+    int st = 0; waitpid(pid, &st, 0);
+    return !(WIFEXITED(st) && WEXITSTATUS(st) == 0);
+}
+
+/* =============================================== hyperbolic distance ===== */
+
+/* |grad_x d| == lambda_x and |grad_y d| == lambda_y at every interior pair. */
+static void check_distance_conformal_identity(void) {
+    const int64_t sh[1] = { 3 };
+    const double c = 1.0;
+    struct { double x[3], y[3]; } cases[] = {
+        {{ 0.30,-0.10, 0.20}, {-0.20, 0.25, 0.10}},
+        {{ 0.00, 0.00, 0.00}, { 0.30,-0.40, 0.00}},
+        {{ 0.55, 0.10,-0.20}, {-0.45,-0.30, 0.35}},
+    };
+    double worst = 0.0;
+    for (auto& cs : cases) {
+        ad_tape_t* t = arena_allocate_tape(get_global_arena(), 8);
+        ad_node_t* xn = var_node(cs.x, sh, 1);
+        ad_node_t* yn = var_node(cs.y, sh, 1);
+        ad_node_t* o = ad_hyperbolic_distance(t, xn, yn, -c);
+        if (!o) { report("distance.conformal_identity", false, "forward refused"); return; }
+        ((double*)o->tensor_gradient)[0] = 1.0;
+        sweep(t);
+        const double* gx = (const double*)xn->tensor_gradient;
+        const double* gy = (const double*)yn->tensor_gradient;
+        double nx = 0.0, ny = 0.0, xx = 0.0, yy = 0.0;
+        for (int i = 0; i < 3; ++i) {
+            nx += gx[i]*gx[i]; ny += gy[i]*gy[i];
+            xx += cs.x[i]*cs.x[i]; yy += cs.y[i]*cs.y[i];
+        }
+        double lx = 2.0/(1.0 - c*xx), ly = 2.0/(1.0 - c*yy);
+        worst = std::fmax(worst, std::fabs(std::sqrt(nx) - lx)/lx);
+        worst = std::fmax(worst, std::fabs(std::sqrt(ny) - ly)/ly);
+    }
+    report("distance.conformal_factor_identity", worst < 1e-12,
+           "max rel dev of |grad| from lambda over 3 pairs = %.3e", worst);
+}
+
+static void check_distance_fd(void) {
+    const int64_t sh[1] = { 3 };
+    const double c = 1.0;
+    double X[3] = { 0.30,-0.10, 0.20 }, Y[3] = {-0.20, 0.25, 0.10 };
+    ad_tape_t* t = arena_allocate_tape(get_global_arena(), 8);
+    ad_node_t* xn = var_node(X, sh, 1); ad_node_t* yn = var_node(Y, sh, 1);
+    ad_node_t* o = ad_hyperbolic_distance(t, xn, yn, -c);
+    ((double*)o->tensor_gradient)[0] = 1.0; sweep(t);
+    double gx[3], gy[3];
+    std::memcpy(gx, xn->tensor_gradient, sizeof gx);
+    std::memcpy(gy, yn->tensor_gradient, sizeof gy);
+
+    auto fwd = [&](const double* a, const double* b) {
+        ad_node_t* an = var_node(a, sh, 1); ad_node_t* bn = var_node(b, sh, 1);
+        ad_node_t* r = ad_hyperbolic_distance(nullptr, an, bn, -c);
+        return ((const double*)r->tensor_value)[0];
+    };
+    RelAcc acc;
+    for (int i = 0; i < 3; ++i) {
+        double p[3], m[3];
+        std::memcpy(p, X, sizeof p); std::memcpy(m, X, sizeof m);
+        p[i] += STEP; m[i] -= STEP;
+        acc_add(&acc, (fwd(p,Y)-fwd(m,Y))/(2*STEP), gx[i]);
+        std::memcpy(p, Y, sizeof p); std::memcpy(m, Y, sizeof m);
+        p[i] += STEP; m[i] -= STEP;
+        acc_add(&acc, (fwd(X,p)-fwd(X,m))/(2*STEP), gy[i]);
+    }
+    double r = acc_val(&acc);
+    report("distance.finite_difference", r < TOLERANCE,
+           "aggregate L2 rel err %.3e over 6 partials", r);
+}
+
+static void distance_coincident_child(void) {
+    const int64_t sh[1] = { 3 };
+    double X[3] = { 0.2,-0.1, 0.3 };
+    ad_tape_t* t = arena_allocate_tape(get_global_arena(), 8);
+    ad_node_t* a = var_node(X, sh, 1), *b = var_node(X, sh, 1);
+    ad_node_t* o = ad_hyperbolic_distance(t, a, b, -1.0);
+    if (o && o->tensor_gradient) ((double*)o->tensor_gradient)[0] = 1.0;
+    sweep(t);
+}
+static void check_distance_refuses_coincident(void) {
+    report("distance.refuses_coincident_points", child_refuses(distance_coincident_child),
+           "d(x,x) is a cone point; no derivative exists there");
+}
+
+/* ================================= exp / log maps vs golden vectors ====== */
+
+/** @brief Full Jacobian of log_x(y) wrt y, by one reverse sweep per output. */
+static void log_jacobian_wrt_y(const double* X, const double* Y, int n,
+                               double c, double* J) {
+    const int64_t sh[1] = { n };
+    for (int k = 0; k < n; ++k) {
+        ad_tape_t* t = arena_allocate_tape(get_global_arena(), 8);
+        ad_node_t* xn = var_node(X, sh, 1); ad_node_t* yn = var_node(Y, sh, 1);
+        ad_node_t* o = ad_poincare_log_map(t, xn, yn, -c);
+        double* g = (double*)o->tensor_gradient;
+        for (int j = 0; j < n; ++j) g[j] = (j == k) ? 1.0 : 0.0;
+        sweep(t);
+        std::memcpy(&J[(size_t)k*n], yn->tensor_gradient, (size_t)n*sizeof(double));
+    }
+}
+/** @brief Full Jacobian of exp_x(v) wrt v. */
+static void exp_jacobian_wrt_v(const double* X, const double* V, int n,
+                               double c, double* J) {
+    const int64_t sh[1] = { n };
+    for (int k = 0; k < n; ++k) {
+        ad_tape_t* t = arena_allocate_tape(get_global_arena(), 8);
+        ad_node_t* xn = var_node(X, sh, 1); ad_node_t* vn = var_node(V, sh, 1);
+        ad_node_t* o = ad_poincare_exp_map(t, xn, vn, -c);
+        double* g = (double*)o->tensor_gradient;
+        for (int j = 0; j < n; ++j) g[j] = (j == k) ? 1.0 : 0.0;
+        sweep(t);
+        std::memcpy(&J[(size_t)k*n], vn->tensor_gradient, (size_t)n*sizeof(double));
+    }
+}
+
+static void check_log_golden(void) {
+    /* tests/qllm_oracle/golden/poincare_log_map_origin.json,
+     * case "poincare_log_map_origin.d2.c1.u0p5": y = (0.3, -0.4), c = 1,
+     * d_out_d_y as committed. Base point is the origin, where the bridge's
+     * log_x reduces to the log_0 the exporter transcribes. */
+    const double O2[2] = { 0.0, 0.0 };
+    const double Y[2]  = { 0.3, -0.4 };
+    const double want[4] = {
+         1.1831118647475904, -0.11266610143930732,
+        -0.11266610143930728,  1.2488337572538528
+    };
+    double J[4];
+    log_jacobian_wrt_y(O2, Y, 2, 1.0, J);
+    double worst = 0.0;
+    for (int i = 0; i < 4; ++i)
+        worst = std::fmax(worst, std::fabs(J[i]-want[i])/std::fabs(want[i]));
+    report("log_map.golden_vector_d2.c1.u0p5", worst < 1e-13,
+           "max rel dev from the committed oracle Jacobian = %.3e", worst);
+}
+
+static void check_exp_golden(void) {
+    /* tests/qllm_oracle/golden/poincare_exp_map_origin.json,
+     * case "poincare_exp_map_origin.d2.c1.tv0p1": v = (0.06, -0.08), c = 1. */
+    const double O2[2] = { 0.0, 0.0 };
+    const double V[2]  = { 0.06, -0.08000000000000002 };
+    const double want[4] = {
+        0.9942990303047957, 0.003174554593016766,
+        0.003174554593016787, 0.9924472067922024
+    };
+    double J[4];
+    exp_jacobian_wrt_v(O2, V, 2, 1.0, J);
+    double worst = 0.0;
+    for (int i = 0; i < 4; ++i)
+        worst = std::fmax(worst, std::fabs(J[i]-want[i])/std::fabs(want[i]));
+    report("exp_map.golden_vector_d2.c1.tv0p1", worst < 1e-13,
+           "max rel dev from the committed oracle Jacobian = %.3e", worst);
+}
+
+static void check_exp_log_inverse_jacobians(void) {
+    /* log_x(exp_x(v)) = v, so J_log(y=exp_x(v)) * J_exp(v) = I. Couples the two
+     * rules with no appeal to either derivation. Base point off the origin so
+     * the Mobius terms are live. */
+    const int64_t sh[1] = { 3 };
+    const double X[3] = { 0.20,-0.15, 0.10 };
+    const double V[3] = { 0.08, 0.05,-0.03 };
+    const double c = 1.0;
+
+    ad_node_t* xn = var_node(X, sh, 1); ad_node_t* vn = var_node(V, sh, 1);
+    ad_node_t* e = ad_poincare_exp_map(nullptr, xn, vn, -c);
+    if (!e) { report("exp_log.inverse_jacobians", false, "exp forward refused"); return; }
+    double Yv[3]; std::memcpy(Yv, e->tensor_value, sizeof Yv);
+
+    double Je[9], Jl[9];
+    exp_jacobian_wrt_v(X, V, 3, c, Je);
+    log_jacobian_wrt_y(X, Yv, 3, c, Jl);
+
+    double worst = 0.0;
+    for (int i = 0; i < 3; ++i)
+        for (int j = 0; j < 3; ++j) {
+            double acc = 0.0;
+            for (int m = 0; m < 3; ++m) acc += Jl[(size_t)i*3+m] * Je[(size_t)m*3+j];
+            worst = std::fmax(worst, std::fabs(acc - (i==j ? 1.0 : 0.0)));
+        }
+    report("exp_log.inverse_jacobians", worst < 1e-9,
+           "max |J_log * J_exp - I| = %.3e", worst);
+}
+
+static void check_exp_log_fd(void) {
+    const int64_t sh[1] = { 3 };
+    const double c = 1.0;
+    double X[3] = { 0.20,-0.15, 0.10 }, V[3] = { 0.08, 0.05,-0.03 };
+    double Y[3] = {-0.10, 0.30, 0.05 };
+
+    /* exp: both operands. */
+    ad_tape_t* t = arena_allocate_tape(get_global_arena(), 8);
+    ad_node_t* xn = var_node(X, sh, 1), *vn = var_node(V, sh, 1);
+    ad_node_t* o = ad_poincare_exp_map(t, xn, vn, -c);
+    double cot[3] = { 1.0, -0.5, 0.25 };
+    std::memcpy(o->tensor_gradient, cot, sizeof cot); sweep(t);
+    double gx[3], gv[3];
+    std::memcpy(gx, xn->tensor_gradient, sizeof gx);
+    std::memcpy(gv, vn->tensor_gradient, sizeof gv);
+    auto expLoss = [&](const double* a, const double* b) {
+        ad_node_t* an = var_node(a, sh, 1), *bn = var_node(b, sh, 1);
+        ad_node_t* r = ad_poincare_exp_map(nullptr, an, bn, -c);
+        const double* ov = (const double*)r->tensor_value;
+        double s = 0.0; for (int i = 0; i < 3; ++i) s += cot[i]*ov[i]; return s;
+    };
+    RelAcc acc;
+    for (int i = 0; i < 3; ++i) {
+        double p[3], m[3];
+        std::memcpy(p,X,sizeof p); std::memcpy(m,X,sizeof m); p[i]+=STEP; m[i]-=STEP;
+        acc_add(&acc, (expLoss(p,V)-expLoss(m,V))/(2*STEP), gx[i]);
+        std::memcpy(p,V,sizeof p); std::memcpy(m,V,sizeof m); p[i]+=STEP; m[i]-=STEP;
+        acc_add(&acc, (expLoss(X,p)-expLoss(X,m))/(2*STEP), gv[i]);
+    }
+    double re = acc_val(&acc);
+    report("exp_map.finite_difference", re < TOLERANCE,
+           "aggregate L2 rel err %.3e over 6 partials", re);
+
+    /* log: both operands. */
+    ad_tape_t* t2 = arena_allocate_tape(get_global_arena(), 8);
+    ad_node_t* xn2 = var_node(X, sh, 1), *yn2 = var_node(Y, sh, 1);
+    ad_node_t* o2 = ad_poincare_log_map(t2, xn2, yn2, -c);
+    std::memcpy(o2->tensor_gradient, cot, sizeof cot); sweep(t2);
+    double lx[3], ly[3];
+    std::memcpy(lx, xn2->tensor_gradient, sizeof lx);
+    std::memcpy(ly, yn2->tensor_gradient, sizeof ly);
+    auto logLoss = [&](const double* a, const double* b) {
+        ad_node_t* an = var_node(a, sh, 1), *bn = var_node(b, sh, 1);
+        ad_node_t* r = ad_poincare_log_map(nullptr, an, bn, -c);
+        const double* ov = (const double*)r->tensor_value;
+        double s = 0.0; for (int i = 0; i < 3; ++i) s += cot[i]*ov[i]; return s;
+    };
+    RelAcc acc2;
+    for (int i = 0; i < 3; ++i) {
+        double p[3], m[3];
+        std::memcpy(p,X,sizeof p); std::memcpy(m,X,sizeof m); p[i]+=STEP; m[i]-=STEP;
+        acc_add(&acc2, (logLoss(p,Y)-logLoss(m,Y))/(2*STEP), lx[i]);
+        std::memcpy(p,Y,sizeof p); std::memcpy(m,Y,sizeof m); p[i]+=STEP; m[i]-=STEP;
+        acc_add(&acc2, (logLoss(X,p)-logLoss(X,m))/(2*STEP), ly[i]);
+    }
+    double rl = acc_val(&acc2);
+    report("log_map.finite_difference", rl < TOLERANCE,
+           "aggregate L2 rel err %.3e over 6 partials", rl);
+}
+
+/* ================================================ geodesic attention ===== */
+
+enum { GB = 1, GS = 3, GD = 4 };
+static double gQ[GB*GS*GD], gK[GB*GS*GD], gV[GB*GS*GD], gCot[GB*GS*GD];
+
+static void check_geodesic_fd(void) {
+    const int64_t sh[3] = { GB, GS, GD };
+    /* Distinct Q and K: coincident rows are a genuine non-differentiable point
+     * and are covered by the refusal check below, not smuggled in here. */
+    const double Q0[GB*GS*GD] = { 0.10, 0.20,-0.10, 0.05,
+                                  -0.15, 0.08, 0.22,-0.04,
+                                   0.03,-0.25, 0.11, 0.17 };
+    const double K0[GB*GS*GD] = { 0.05,-0.20, 0.15, 0.10,
+                                   0.18, 0.06,-0.12, 0.09,
+                                  -0.07, 0.21, 0.04,-0.16 };
+    const double V0[GB*GS*GD] = { 1.0, 2.0,-1.0, 0.5,
+                                  0.3,-0.7, 1.4, 2.2,
+                                 -0.9, 0.6, 0.1,-1.3 };
+    const double C0[GB*GS*GD] = { 1.0,-0.5, 0.25, 0.75,
+                                 -0.3, 0.9, 0.2,-1.1,
+                                  0.4, 0.15,-0.6, 0.8 };
+    std::memcpy(gQ,Q0,sizeof gQ); std::memcpy(gK,K0,sizeof gK);
+    std::memcpy(gV,V0,sizeof gV); std::memcpy(gCot,C0,sizeof gCot);
+
+    ad_tape_t* t = arena_allocate_tape(get_global_arena(), 8);
+    ad_node_t* qn = var_node(gQ, sh, 3), *kn = var_node(gK, sh, 3), *vn = var_node(gV, sh, 3);
+    ad_node_t* o = ad_geodesic_attention(t, qn, kn, vn, 2, -1.0, false);
+    if (!o) { report("geodesic.finite_difference", false, "forward refused"); return; }
+    std::memcpy(o->tensor_gradient, gCot, sizeof gCot);
+    sweep(t);
+    double dq[GB*GS*GD], dk[GB*GS*GD], dv[GB*GS*GD];
+    std::memcpy(dq, qn->tensor_gradient, sizeof dq);
+    std::memcpy(dk, kn->tensor_gradient, sizeof dk);
+    std::memcpy(dv, vn->tensor_gradient, sizeof dv);
+
+    auto loss = [&](const double* q, const double* k, const double* v) {
+        ad_node_t* a = var_node(q, sh, 3), *b = var_node(k, sh, 3), *cc = var_node(v, sh, 3);
+        ad_node_t* r = ad_geodesic_attention(nullptr, a, b, cc, 2, -1.0, false);
+        const double* ov = (const double*)r->tensor_value;
+        double s = 0.0; for (int i = 0; i < GB*GS*GD; ++i) s += gCot[i]*ov[i]; return s;
+    };
+    RelAcc acc;
+    for (int i = 0; i < GB*GS*GD; ++i) {
+        double p[GB*GS*GD], m[GB*GS*GD];
+        std::memcpy(p,gQ,sizeof p); std::memcpy(m,gQ,sizeof m); p[i]+=STEP; m[i]-=STEP;
+        acc_add(&acc, (loss(p,gK,gV)-loss(m,gK,gV))/(2*STEP), dq[i]);
+        std::memcpy(p,gK,sizeof p); std::memcpy(m,gK,sizeof m); p[i]+=STEP; m[i]-=STEP;
+        acc_add(&acc, (loss(gQ,p,gV)-loss(gQ,m,gV))/(2*STEP), dk[i]);
+        std::memcpy(p,gV,sizeof p); std::memcpy(m,gV,sizeof m); p[i]+=STEP; m[i]-=STEP;
+        acc_add(&acc, (loss(gQ,gK,p)-loss(gQ,gK,m))/(2*STEP), dv[i]);
+    }
+    double r = acc_val(&acc);
+    report("geodesic.finite_difference", r < TOLERANCE,
+           "aggregate L2 rel err %.3e over %d partials", r, 3*GB*GS*GD);
+}
+
+static void check_geodesic_causal_fd(void) {
+    const int64_t sh[3] = { GB, GS, GD };
+    ad_tape_t* t = arena_allocate_tape(get_global_arena(), 8);
+    ad_node_t* qn = var_node(gQ, sh, 3), *kn = var_node(gK, sh, 3), *vn = var_node(gV, sh, 3);
+    ad_node_t* o = ad_geodesic_attention(t, qn, kn, vn, 2, -1.0, true);
+    if (!o) { report("geodesic.causal_finite_difference", false, "forward refused"); return; }
+    std::memcpy(o->tensor_gradient, gCot, sizeof gCot);
+    sweep(t);
+    double dq[GB*GS*GD], dv[GB*GS*GD];
+    std::memcpy(dq, qn->tensor_gradient, sizeof dq);
+    std::memcpy(dv, vn->tensor_gradient, sizeof dv);
+    auto loss = [&](const double* q, const double* v) {
+        ad_node_t* a = var_node(q, sh, 3), *b = var_node(gK, sh, 3), *cc = var_node(v, sh, 3);
+        ad_node_t* r = ad_geodesic_attention(nullptr, a, b, cc, 2, -1.0, true);
+        const double* ov = (const double*)r->tensor_value;
+        double s = 0.0; for (int i = 0; i < GB*GS*GD; ++i) s += gCot[i]*ov[i]; return s;
+    };
+    RelAcc acc;
+    for (int i = 0; i < GB*GS*GD; ++i) {
+        double p[GB*GS*GD], m[GB*GS*GD];
+        std::memcpy(p,gQ,sizeof p); std::memcpy(m,gQ,sizeof m); p[i]+=STEP; m[i]-=STEP;
+        acc_add(&acc, (loss(p,gV)-loss(m,gV))/(2*STEP), dq[i]);
+        std::memcpy(p,gV,sizeof p); std::memcpy(m,gV,sizeof m); p[i]+=STEP; m[i]-=STEP;
+        acc_add(&acc, (loss(gQ,p)-loss(gQ,m))/(2*STEP), dv[i]);
+    }
+    double r = acc_val(&acc);
+    /* The last key column is masked out of every row, so dK there is exactly
+     * zero and FD sees the same; it is excluded from the ratio by construction
+     * (both legs zero contribute nothing to either norm). */
+    report("geodesic.causal_finite_difference", r < TOLERANCE,
+           "aggregate L2 rel err %.3e with causal masking", r);
+}
+
+static void geodesic_coincident_child(void) {
+    const int64_t sh[3] = { GB, GS, GD };
+    ad_tape_t* t = arena_allocate_tape(get_global_arena(), 8);
+    ad_node_t* qn = var_node(gQ, sh, 3);
+    ad_node_t* vn = var_node(gV, sh, 3);
+    /* Q and K the same node: every diagonal (i, i) pair coincides exactly. */
+    ad_node_t* o = ad_geodesic_attention(t, qn, qn, vn, 2, -1.0, false);
+    if (o && o->tensor_gradient) std::memcpy(o->tensor_gradient, gCot, sizeof gCot);
+    sweep(t);
+}
+static void check_geodesic_refuses_coincident(void) {
+    report("geodesic.refuses_query_equals_key",
+           child_refuses(geodesic_coincident_child),
+           "distance scoring is non-differentiable when a query row equals a key row");
+}
+
+/* ============================ structural: the loud default (SW-65 root) === */
+
+static void unregistered_tensor_node_child(void) {
+    /* A tensor-carrying node with an input, of a type no rule handles. Before
+     * the fix this returned silently, having propagated nothing. */
+    const int64_t sh[1] = { 3 };
+    double X[3] = { 0.1, 0.2, 0.3 };
+    ad_node_t* in = var_node(X, sh, 1);
+    ad_node_t* fake = arena_allocate_ad_node(get_global_arena());
+    fake->type = AD_NODE_MOBIUS_MATMUL;      /* tensor-ish, deliberately unregistered */
+    fake->tensor_value = ad_doubles(3);
+    fake->tensor_gradient = ad_doubles(3);
+    ((double*)fake->tensor_gradient)[0] = 1.0;
+    fake->shape = in->shape; fake->ndim = 1;
+    fake->input1 = in;
+    eshkol_tensor_backward_dispatch(fake);
+}
+static void check_loud_default(void) {
+    report("dispatch.unregistered_tensor_node_is_fatal",
+           child_refuses(unregistered_tensor_node_child),
+           "a tensor-carrying node with inputs and no rule must abort, not zero");
+}
+
+static void leaf_variable_child(void) {
+    /* The companion: a LEAF carrying a tensor payload must still be a no-op.
+     * The fatal keys on "payload AND has inputs" precisely so input variables,
+     * which carry tensor_value, are not swept up by it. */
+    const int64_t sh[1] = { 3 };
+    double X[3] = { 0.1, 0.2, 0.3 };
+    ad_node_t* leaf = var_node(X, sh, 1);
+    leaf->tensor_gradient = ad_doubles(3);
+    eshkol_tensor_backward_dispatch(leaf);
+}
+static void check_leaf_still_silent(void) {
+    report("dispatch.leaf_variable_is_not_fatal",
+           !child_refuses(leaf_variable_child),
+           "input variables carry tensor_value and must remain a legitimate no-op");
+}
+
+int main(void) {
+    check_distance_conformal_identity();     /* 1 */
+    check_distance_fd();                     /* 1 */
+    check_distance_refuses_coincident();     /* 1 */
+    check_log_golden();                      /* 1 */
+    check_exp_golden();                      /* 1 */
+    check_exp_log_inverse_jacobians();       /* 1 */
+    check_exp_log_fd();                      /* 2 */
+    check_geodesic_fd();                     /* 1 */
+    check_geodesic_causal_fd();              /* 1 */
+    check_geodesic_refuses_coincident();     /* 1 */
+    check_loud_default();                    /* 1 */
+    check_leaf_still_silent();               /* 1 */
+    std::printf("Results: %d passed, %d failed\n", g_passed, g_failed);
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/qllm_oracle/README.md
+++ b/tests/qllm_oracle/README.md
@@ -471,6 +471,59 @@ described in `docs/reference/ad/architecture.md`. Its forward is nonetheless the
 *same code* the bridge producer runs — `inc/eshkol/backend/frechet_mean_core.h` —
 so the two cannot drift apart while that work is pending.
 
+### The geometric bridge ops had no backward at all (SW-65)
+
+Separate from the three above, and worse, because it was silent rather than
+merely missing. `ad_hyperbolic_distance`, `ad_poincare_exp_map`,
+`ad_poincare_log_map` and `ad_geodesic_attention` record **tensor-valued** AD
+nodes — types 33, 34, 35 and 37 — and none of them had a backward. They did not
+refuse and they did not warn: those type numbers sit in the band
+`eshkol_tensor_backward_dispatch` treated as "scalar ops differentiated by
+codegen", so they fell into its `default:` and the reverse sweep propagated
+nothing. Every input gradient came back exactly `0.0`, which a caller cannot
+tell from a genuine zero.
+
+All four now have exact rules. The `exp`/`log` rules reuse the Möbius and
+log-map Jacobians the Fréchet rule already carries rather than re-deriving them
+— the log map *is* the function that routine differentiates, and a second
+derivation could only introduce a disagreement.
+
+**These golden vectors are what validate them.** The `exp_0` and `log_0`
+Jacobians in `golden/` are computed by Eshkol's reverse-mode AD over an
+independently written Eshkol transcription of the same formulas, so asserting
+the C rules against them is a genuine two-implementation, two-language check:
+`poincare_log_map_origin.d2.c1.u0p5` agrees to `3.7e-16` and
+`poincare_exp_map_origin.d2.c1.tv0p1` to `1.1e-14`. Two further exact
+references back them up — the conformal-factor identity
+`|∇_x d| = λ_x = 2/(1−c‖x‖²)`, which holds at every interior pair, and the
+inverse-Jacobian identity `J_log · J_exp = I`, which couples the two rules to
+each other with no appeal to either derivation. Finite differences are the last
+line, not the first. `ctest -R qllm_bridge_geometric_gradcheck`.
+
+**Two facts the rules make explicit that the silent zero had hidden.** The
+Riemannian distance behaves like `|x − y|` near coincidence: it has no
+derivative at `x = y`, only a subgradient set, so both distance-based rules
+refuse there. For geodesic attention that means the op is **not differentiable
+whenever a query row equals a key row exactly** — the ordinary case when `Q` and
+`K` are the same tensor. That is a property of scoring by distance rather than
+by inner product, and a consumer needs to know it. Second,
+`ad_poincare_log_map`'s forward clamps `artanh`'s argument at `t ≥ 1` and
+returns a value where no finite log exists; the backward refuses there rather
+than differentiate the clamp, matching what the Fréchet machinery already does
+on the same condition.
+
+The structural half of the fix is the AD-node registry
+(`inc/eshkol/ad_node_registry.def`): the dispatcher no longer has a `default:`
+to infer scalar-ness from a numeric band at all. Every node type declares its
+backward disposition in one registry row, the dispatch arms and the backward
+table are generated from those rows under `-Werror=switch-enum`, and these four
+ops are declared `BRIDGE`, each row naming its backward function — a name that
+must resolve or `lib/bridge/tensor_backward.cpp` does not compile. A
+tensor-valued node type with no rule is an explicit `UNREGISTERED` row that
+aborts naming itself instead of returning zero, while `LEAF` rows keep
+`AD_NODE_VARIABLE` and `AD_NODE_CONSTANT`, which legitimately carry
+`tensor_value`, out of the refusal. Both halves are red-proofed.
+
 ## Files
 
 - `qllm_oracle_lib.esk` — shared vector math, exact/FD Jacobian assembly,


### PR DESCRIPTION
## The defect

`ad_hyperbolic_distance`, `ad_poincare_exp_map`, `ad_poincare_log_map` and
`ad_geodesic_attention` record **tensor-valued** AD nodes — types 33, 34, 35 and
37 — and none of them had a backward.

They did not refuse and they did not warn. Those type numbers sit in the band
`eshkol_tensor_backward_dispatch` treats as "scalar ops differentiated by
codegen", so they fell into its `default:` and the reverse sweep propagated
nothing. A program differentiating through any of them trained on a wrong
gradient, with no diagnostic and exit 0.

Reproduced on unmodified master (`~/.tsotchke/state/geometric-backwards/`):

```
SW-65 repro: gradients through the geometric bridge ops
  hyperbolic-distance      max |grad| over both inputs = 0  <-- SILENTLY ZERO
  poincare-exp-map         max |grad| over both inputs = 0  <-- SILENTLY ZERO
  poincare-log-map         max |grad| over both inputs = 0  <-- SILENTLY ZERO
  geodesic-attention Q,K   max |grad| over both inputs = 0  <-- SILENTLY ZERO
  geodesic-attention V     max |grad| over both inputs = 0  <-- SILENTLY ZERO
```

Same repro, after:

```
  hyperbolic-distance      1.9136747677590749
  poincare-exp-map         1.0081654858019475
  poincare-log-map         1.0393847046977158
  geodesic-attention Q,K   2.6867707457830869
  geodesic-attention V     1.1159604744030989
```

**Nothing was printed in the before case** — not even the "gradient signal lost"
notice, because these nodes never reached `get_tensor_backward_fn` to trigger
it. Filed as **SW-65**, bucket SILENT-WRONG, closed in this PR with before/after
evidence.

## Why it survived review

The `default:` carried a comment asserting the defect was impossible:

> Every TENSOR op (19-32 and the qLLM bridge ops 67-80) has an explicit case
> above, so a tensor-op gradient can never silently fall through this default.

Every clause is false for these four: they are in the "scalar" 33-66 band but
are tensor-valued; they are bridge-created, so no codegen scalar backward exists
for them; and a tensor-op gradient therefore did fall through, silently. The
comment stated an invariant — *the enum range is a reliable proxy for
scalar-ness* — and that proxy is what broke.

## The structural fix

The `default:` no longer infers scalar-ness from the numeric band. It refuses
when a node **carries a tensor payload AND has at least one input** — the
property that actually matters, tested directly on the node rather than inferred
from where its enumerator happens to sit.

The input clause is load-bearing: `AD_NODE_VARIABLE` and `AD_NODE_CONSTANT`
leaves carry `tensor_value` too (that is how an input tensor gets onto the tape),
and reaching the default with no parents to propagate into is exactly correct for
them. Anything with a parent *and* a tensor payload is an op, and an op arriving
there has no backward: always a defect, never a no-op.

Both halves are red-proofed — a fake unregistered tensor-valued node with an
input must abort, and a leaf carrying `tensor_value` must remain a no-op.

## The four rules

Exact, in `lib/bridge/tensor_backward.cpp`, registered in
`get_tensor_backward_fn` and given cases in the native dispatcher. The exp and
log rules **reuse** `FrechetGeometry::mobius_add_with_jacobians` and
`log_map_with_jacobians` rather than re-deriving them: the log map *is* the
function that routine already differentiates for the Fréchet rule, and a second
derivation could only introduce a disagreement.

`ad_geodesic_attention` now retains its softmax weights and records `causal` and
the curvature in `params` — it recorded neither before, so no backward could have
reconstructed the mask or the metric. Retention rather than recomputation, for
the reason SW-12 records for `ad_tensor_attention`.

## Validation

Three independent **exact** references are asserted before finite differences are
consulted at all:

| reference | agreement |
|---|---|
| golden vector `poincare_log_map_origin.d2.c1.u0p5` | **3.7e-16** |
| golden vector `poincare_exp_map_origin.d2.c1.tv0p1` | **1.1e-14** |
| conformal identity `\|∇_x d\| = 2/(1−c‖x‖²)`, every interior pair | **5.0e-16** |
| inverse-Jacobian identity `J_log · J_exp = I` | **6.7e-16** |

The golden vectors are the strong one. `tests/qllm_oracle/golden/` holds full
Jacobians computed by Eshkol's reverse-mode AD over an *independently written*
Eshkol transcription of the same formulas, so agreement is a
two-implementation, two-language check rather than a restatement — a shared
mistake would have to occur twice, in two languages, from different sources. The
conformal identity holds at every interior pair because the Riemannian gradient
of a distance function is a unit vector. The inverse-Jacobian identity couples
the exp and log rules to each other with no appeal to either derivation.

Finite differences then agree at `3.5e-11` (distance), `3.5e-11` / `5.7e-11`
(exp / log) and `1.5e-10` / `8.8e-11` (geodesic attention, unmasked and causal).

## Two facts the silent zero had hidden

Now explicit, refused loudly, and documented in the public header.

**The distance is not differentiable at coincident points.** Like `|x − y|`, the
Riemannian distance has a cone point at `x = y`: one-sided slopes disagree in
every direction and only a subgradient set exists. Both distance-based rules
refuse there rather than pick a plausible member of that set.

**Geodesic attention is therefore not differentiable when a query row equals a
key row exactly** — the ordinary case when `Q` and `K` are the same tensor. The
backward refuses and names the `(batch, head, i, j)` it refused on. This is a
property of scoring by distance rather than by inner product, not of this
implementation; `ad_tensor_attention` has no such point. A caller wiring up
geodesic attention needs to know this, and a silent zero is precisely what would
have hidden it.

Separately, `ad_poincare_log_map`'s forward clamps `artanh`'s argument at
`t ≥ 1` and returns a value where no finite log exists. The backward refuses
there rather than differentiate the clamp, matching what the Fréchet machinery
already does on the same condition.

## Gates

- **202/202 ctest**
- **13/13** new gradcheck, pass count pinned in CMake
- **77/77** `qllm_oracle`, golden vectors regenerating **byte-identically**
- **AD carrier gate PASS**; the new backward code reports **zero** finite-difference sites
- **ledger integrity PASS**, **no-silent-wrong gate PASS**

## Scope note

Types 36 (`TANGENT_PROJECT`) and 38 (`MOBIUS_ADD`) are also unregistered but have
**no producer** anywhere in the tree, so they cannot currently be reached. The
new loud `default:` is what guarantees that if either ever gains a forward, it
fails loudly on the first reverse sweep instead of joining this family unnoticed.
