### PR TITLE
fix(memory): deep-walk exact Taylor towers on region escape (SW-65)

### DIFF
--- a/.icc/architecture-model.yaml
+++ b/.icc/architecture-model.yaml
@@ -409,6 +409,23 @@ invariants:
   #    in the region evacuator; the pattern enumerates exactly the deep-walk set
   #    (leaf subtypes like STRING/SYMBOL/BIGNUM are intentionally excluded).
   #    Expected PASS (the ESH-0214d fix added the consciousness/logic cases).
+  #
+  #    2026-08-26 (SW-65): both sites used to be the SAME hand-typed 16-name
+  #    alternation, so the comparison always matched itself regardless of the
+  #    real source -- it silently included DNC/SDNC/TAYLOR (which had neither
+  #    a case in evac_kind_for's switch nor any classification at all) and
+  #    would have stayed green even after TAYLOR's real fix (a `case
+  #    HEAP_SUBTYPE_TAYLOR: return EVAC_TAYLOR;` arm) without anyone updating
+  #    this file by hand. `icc architecture-verify --cxx-backend libclang`
+  #    caught the gap because it resolves each site's identifier set from the
+  #    real source, not the hand-typed pattern. Both sites are now GENERIC,
+  #    self-updating patterns over real source: the enum side reads the
+  #    [DEEPWALK]/[LEAF] classification tag inc/eshkol/eshkol.h's
+  #    HEAP_SUBTYPE_* enum carries on every member, and the evacuator side
+  #    reads every `case HEAP_SUBTYPE_X: return EVAC_...;` arm evac_kind_for
+  #    actually has -- neither side is a maintained list any more. Retagging
+  #    a member without also giving it a real case in that switch (or vice
+  #    versa) is exactly the class of regression this invariant now catches.
   - id: INV-oalr-interior-pointer-deepwalk
     kind: key-space-equality
     incident: region-evac-leaf-copy
@@ -418,15 +435,17 @@ invariants:
       evac_kind_for must map every interior-pointer heap subtype to a deep-walk
       EvacKind; dropping a subtype to a shallow leaf copy leaves dangling
       interior pointers after region evacuation (KB/FACT/SUBSTITUTION/WORKSPACE
-      were the ESH-0214d regression).  The subtype enum and the evacuator switch
-      must resolve the identical deep-walk subtype set.
+      were the ESH-0214d regression; DNC/SDNC/TAYLOR were the SW-65
+      regression class -- never classified at all).  The subtype enum's own
+      [DEEPWALK] tags and the evacuator switch's actual deep-walk case arms
+      must resolve the identical subtype set.
     sites:
       - id: heap-subtype-enum
         path: inc/eshkol/eshkol.h
-        key_pattern: '(HEAP_SUBTYPE_(?:CONS|VECTOR|RECORD|MULTI_VALUE|HASH|TENSOR|EXCEPTION|SUBSTITUTION|FACT|KNOWLEDGE_BASE|FACTOR_GRAPH|WORKSPACE|PROMISE|DNC|SDNC|TAYLOR))'
+        key_pattern: 'HEAP_SUBTYPE_([A-Z0-9_]+)\s*=\s*\d+,\s*//.*\[DEEPWALK\]'
       - id: region-evacuator-switch
         path: lib/core/runtime_regions.cpp
-        key_pattern: '(HEAP_SUBTYPE_(?:CONS|VECTOR|RECORD|MULTI_VALUE|HASH|TENSOR|EXCEPTION|SUBSTITUTION|FACT|KNOWLEDGE_BASE|FACTOR_GRAPH|WORKSPACE|PROMISE|DNC|SDNC|TAYLOR))'
+        key_pattern: 'case\s+HEAP_SUBTYPE_(\w+)\s*:\s*return\s+EVAC_'
 
   # 6b. The SAME invariant for the bytecode VM's Stage-1 evacuator (SW-14).
   #     It matters MORE here than natively: a VM `Value` addresses the heap by a

--- a/.icc/architecture-model.yaml
+++ b/.icc/architecture-model.yaml
@@ -410,7 +410,7 @@ invariants:
   #    (leaf subtypes like STRING/SYMBOL/BIGNUM are intentionally excluded).
   #    Expected PASS (the ESH-0214d fix added the consciousness/logic cases).
   #
-  #    2026-08-26 (SW-65): both sites used to be the SAME hand-typed 16-name
+  #    2026-08-26 (SW-66): both sites used to be the SAME hand-typed 16-name
   #    alternation, so the comparison always matched itself regardless of the
   #    real source -- it silently included DNC/SDNC/TAYLOR (which had neither
   #    a case in evac_kind_for's switch nor any classification at all) and
@@ -435,7 +435,7 @@ invariants:
       evac_kind_for must map every interior-pointer heap subtype to a deep-walk
       EvacKind; dropping a subtype to a shallow leaf copy leaves dangling
       interior pointers after region evacuation (KB/FACT/SUBSTITUTION/WORKSPACE
-      were the ESH-0214d regression; DNC/SDNC/TAYLOR were the SW-65
+      were the ESH-0214d regression; DNC/SDNC/TAYLOR were the SW-66
       regression class -- never classified at all).  The subtype enum's own
       [DEEPWALK] tags and the evacuator switch's actual deep-walk case arms
       must resolve the identical subtype set.

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -4441,7 +4441,7 @@ entries:
     caught_by: [direct-measurement, branch-protection-audit]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
 
-  - id: SW-65
+  - id: SW-66
     bucket: SILENT-WRONG
     subtag: structural
     family: region-evacuator/interior-pointer-deepwalk

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -4440,3 +4440,97 @@ entries:
       this class cannot silently reopen a third time.
     caught_by: [direct-measurement, branch-protection-audit]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+
+  - id: SW-65
+    bucket: SILENT-WRONG
+    subtag: structural
+    family: region-evacuator/interior-pointer-deepwalk
+    status: closed
+    closed_at: "fix/evac-subtypes-dnc-sdnc-taylor"
+    closed_by: "branch fix/evac-subtypes-dnc-sdnc-taylor"
+    title: "evac_kind_for never classified HEAP_SUBTYPE_DNC/SDNC/TAYLOR at all; the exact (COEFF_RATIONAL) Taylor tower genuinely carries interior bignum pointers a shallow leaf copy leaves dangling into a freed region arena"
+    repro: >-
+      `icc architecture-verify --cxx-backend libclang` (the new C/C++
+      semantic-index backend) resolved lib/core/runtime_regions.cpp's
+      evac_kind_for switch precisely and found HEAP_SUBTYPE_DNC, _SDNC and
+      _TAYLOR present in inc/eshkol/eshkol.h's enum but absent from the
+      switch's real deep-walk arms — invisible to the prior grep-fidelity
+      INV-oalr-interior-pointer-deepwalk invariant, which matched the whole
+      FILE's token set (all three names appear elsewhere in the file: a
+      debug-only watchlist warn block and doc comments) rather than the
+      function body. tests/memory/region_evac_taylor_exact_test.esk
+      differentiates x^30/x^22/x^10 at exact integer points with the
+      differentiated body wrapped in `(with-region ...)`, forcing the exact
+      tower's bignum-scale coefficients to be allocated in the region arena
+      and escape it via with-region's own return-value evacuation.
+    observed: >-
+      Layout investigation (not blind pattern-matching) showed a THREE-WAY
+      split, not one uniform gap: DncHandle.{mem,usage} (lib/core/dnc_api.c)
+      and SdncHandle.w (lib/core/sdnc_api.c) are calloc'd on the plain C
+      heap, never arena-allocated, so a shallow copy of either handle is
+      genuinely correct — they were undertagged but not actually buggy.
+      HEAP_SUBTYPE_TAYLOR is different: its EXACT (COEFF_RATIONAL)
+      representation reinterprets c[] as an eshkol_tagged_value_t array
+      (lib/core/runtime_taylor.c), and any coefficient that overflows int64
+      is a HEAP_PTR to an independently arena-allocated HEAP_SUBTYPE_BIGNUM
+      object. Under ESHKOL_ARENA_POISON=1, the pre-fix runtime read that
+      dangling bignum pointer and, in this fixture, first hit a size-sanity
+      guard ("arena_allocate_with_header: data_size=27353046632 exceeds
+      UINT32_MAX") and then returned 0 instead of the true derivative value
+      (e.g. 7^30 = 22539340290692258087863249) -- 5 of 7 checks failed.
+      Without poison the same defect is genuinely silent: the freed bytes
+      had not yet been overwritten, so the stale-but-still-valid bignum read
+      back correct by luck.
+    correct: >-
+      Every interior-pointer-carrying heap subtype is either deep-walked on
+      region escape or is a reviewed, verified LEAF exemption backed by its
+      actual struct layout -- never an unclassified gap that happens to look
+      safe today.
+    root_cause: >-
+      DNC/SDNC/TAYLOR were added to the HEAP_SUBTYPE_* enum after ESH-0214d
+      closed the KB/FACT/SUBSTITUTION/WORKSPACE class, and evac_kind_for's
+      switch was never revisited for any of the three: no case arm, no
+      review comment, no ledger entry. The prior architecture-model.yaml
+      invariant sites were a hand-typed 16-name alternation duplicated on
+      both the enum and the switch side, so the comparison always matched
+      itself regardless of what either file actually contained -- neither a
+      human nor `icc architecture-verify --cxx-backend none` (grep/whole-
+      file scope) could see that TAYLOR's real switch treatment (falling to
+      `default: return EVAC_LEAF;`) diverged from its true interior-pointer
+      shape.
+    fix: >-
+      lib/core/runtime_regions.cpp: added a new EVAC_TAYLOR EvacKind and an
+      explicit `case HEAP_SUBTYPE_TAYLOR: return EVAC_TAYLOR;` arm; the
+      worklist handler walks the tower's coefficient array with evac_value()
+      only when flags carry ESH_TAYLOR_COEFF_MASK == ESH_TAYLOR_COEFF_RATIONAL
+      (a COEFF_F64 tower's c[] is raw doubles, walked as a cheap no-op,
+      mirroring EVAC_RATIONAL's is_big==0 fast path). DNC/SDNC were left on
+      the `default: return EVAC_LEAF;` path (verified correct, not a
+      regression) but the debug-only watchlist guard was renamed and kept as
+      a live regression trap on their handle layouts. inc/eshkol/eshkol.h:
+      every HEAP_SUBTYPE_* member now carries an explicit [DEEPWALK]/[LEAF]
+      classification tag with the per-member reasoning, so
+      INV-oalr-interior-pointer-deepwalk's sites (.icc/architecture-model.yaml)
+      are now GENERIC source-derived patterns -- the enum side reads the
+      [DEEPWALK] tags, the switch side reads every real
+      `case HEAP_SUBTYPE_X: return EVAC_...;` arm -- instead of a hand-typed
+      list duplicated on both sides. The bytecode VM was investigated and
+      found to have NO HEAP_DNC/HEAP_SDNC/HEAP_TAYLOR tags and no
+      derivative-n/taylor/dnc/sdnc op codegen in vm_compiler.c at all (a live
+      probe under --profile hosted-vm reports `derivative-n` as an undefined
+      variable); there is no VM-side parity gap to fix because the feature
+      is not implemented on that engine.
+    evidence: >-
+      tests/memory/region_evac_taylor_exact_test.esk (7 checks; wired into
+      ctest as region_evac_taylor_exact_runtime_smoke and
+      region_evac_taylor_exact_aot_smoke, both under
+      ESHKOL_ARENA_POISON=1) -- 5/7 fail on the pre-fix switch, 7/7 pass
+      post-fix, on both the JIT and AOT engines. `icc architecture-verify
+      --repo eshkol --model .icc/architecture-model.yaml` on
+      INV-oalr-interior-pointer-deepwalk: FAIL with `divergent=['TAYLOR']`
+      against the pre-fix switch (tags applied, case arm reverted), PASS
+      (`all sites resolve the same identifier space`, 15/15 tokens) against
+      the fixed source, confirmed under both --cxx-backend none and the
+      default tree-sitter AST backend. Full ctest: 203/203 passed.
+    caught_by: [icc-architecture-verify-libclang-admission-20260826]
+    missed_by: [icc-architecture-verify-grep-fidelity, icc-smoke, icc-readiness, ctest]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3744,6 +3744,38 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
             TIMEOUT 600
             PASS_REGULAR_EXPRESSION "PASS: exact-coefficient Taylor tier"
             FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
+    # SW-65: HEAP_SUBTYPE_TAYLOR's exact (COEFF_RATIONAL) representation
+    # carries interior bignum/rational HEAP_PTRs in its coefficient array that
+    # evac_kind_for (lib/core/runtime_regions.cpp) dropped to a shallow leaf
+    # copy on region escape -- the same defect class ESH-0214d closed for the
+    # logic/workspace subtypes and the rational-bignum fix closed for
+    # HEAP_SUBTYPE_RATIONAL. Run under ESHKOL_ARENA_POISON=1 so the freed
+    # region arena is 0xCB-stamped and a missed interior pointer cannot pass
+    # by luck (without poison the same defect is genuinely silent: the freed
+    # bytes have not yet been overwritten).
+    add_test(
+        NAME region_evac_taylor_exact_runtime_smoke
+        COMMAND $<TARGET_FILE:eshkol-run>
+                -r "${CMAKE_CURRENT_SOURCE_DIR}/tests/memory/region_evac_taylor_exact_test.esk"
+                -L"${CMAKE_CURRENT_BINARY_DIR}"
+    )
+    set_tests_properties(region_evac_taylor_exact_runtime_smoke
+        PROPERTIES
+            TIMEOUT 300
+            ENVIRONMENT "ESHKOL_ARENA_POISON=1"
+            PASS_REGULAR_EXPRESSION "PASS: region-evac exact-Taylor deep-walk"
+            FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
+    add_test(
+        NAME region_evac_taylor_exact_aot_smoke
+        COMMAND sh -c
+            "'$<TARGET_FILE:eshkol-run>' -o '${CMAKE_CURRENT_BINARY_DIR}/region_evac_taylor_exact_aot' '${CMAKE_CURRENT_SOURCE_DIR}/tests/memory/region_evac_taylor_exact_test.esk' -L'${CMAKE_CURRENT_BINARY_DIR}' && '${CMAKE_CURRENT_BINARY_DIR}/region_evac_taylor_exact_aot'"
+    )
+    set_tests_properties(region_evac_taylor_exact_aot_smoke
+        PROPERTIES
+            TIMEOUT 600
+            ENVIRONMENT "ESHKOL_ARENA_POISON=1"
+            PASS_REGULAR_EXPRESSION "PASS: region-evac exact-Taylor deep-walk"
+            FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
     # `hessian` over a lambda that CAPTURES free variables. A capturing lambda
     # is lowered with one extra pointer parameter per capture; the scalar
     # Hessian arm called it with the seeded jet ALONE, so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3744,7 +3744,7 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
             TIMEOUT 600
             PASS_REGULAR_EXPRESSION "PASS: exact-coefficient Taylor tier"
             FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
-    # SW-65: HEAP_SUBTYPE_TAYLOR's exact (COEFF_RATIONAL) representation
+    # SW-66: HEAP_SUBTYPE_TAYLOR's exact (COEFF_RATIONAL) representation
     # carries interior bignum/rational HEAP_PTRs in its coefficient array that
     # evac_kind_for (lib/core/runtime_regions.cpp) dropped to a shallow leaf
     # copy on region escape -- the same defect class ESH-0214d closed for the

--- a/inc/eshkol/eshkol.h
+++ b/inc/eshkol/eshkol.h
@@ -525,7 +525,7 @@ ESHKOL_STATIC_ASSERT(sizeof(eshkol_object_header_t) == 8,
  * neuro-symbolic/AD structures added for the consciousness engine and
  * Taylor-tower AD) that share the single consolidated HEAP_PTR type tag.
  */
-// Interior-pointer classification tags (SW-65, 2026-08-26 libclance
+// Interior-pointer classification tags (SW-66, 2026-08-26 libclance
 // architecture-verify admission).  Every member below carries a trailing
 // [DEEPWALK] or [LEAF] marker: DEEPWALK means the region evacuator
 // (lib/core/runtime_regions.cpp, evac_kind_for) MUST walk this subtype's
@@ -566,9 +566,9 @@ typedef enum {
     HEAP_SUBTYPE_PROMISE         = 18,  // Lazy promise (delay/force with memoization) [DEEPWALK]
     HEAP_SUBTYPE_RATIONAL        = 19,  // Exact rational number (numerator/denominator) [DEEPWALK] -- the bignum-backed path carries raw bignum pointers
     HEAP_SUBTYPE_PRNG            = 20,  // Isolated pseudo-random number generator state [LEAF] -- self-contained state words, no interior pointers
-    HEAP_SUBTYPE_DNC             = 21,  // Differentiable external memory (NTM/DNC head) [LEAF] -- VERIFIED SW-65: DncHandle.{mem,usage} (lib/core/dnc_api.c) are calloc'd on the C heap, never arena-allocated; a shallow copy preserves both pointers exactly, so they cannot dangle when the region's arena is freed
-    HEAP_SUBTYPE_SDNC            = 22,  // SDNC weight-program handle (bytecode-VM-as-transformer θ) [LEAF] -- VERIFIED SW-65: SdncHandle.w (lib/core/sdnc_api.c) is calloc'd on the C heap (not arena-allocated) and .pe[][] is inline scalar data; same reasoning as DNC
-    HEAP_SUBTYPE_TAYLOR          = 23,  // Truncated-Taylor tower for arbitrary-order AD (ESH-0186) [DEEPWALK] -- SW-65: a COEFF_RATIONAL (exact) tower's c[] is an array of eshkol_tagged_value_t that can hold HEAP_PTRs to arena-resident HEAP_SUBTYPE_BIGNUM/HEAP_SUBTYPE_RATIONAL coefficients (lib/core/runtime_taylor.c); a COEFF_F64 tower's c[] is raw doubles (nothing to walk, the walk is a cheap no-op)
+    HEAP_SUBTYPE_DNC             = 21,  // Differentiable external memory (NTM/DNC head) [LEAF] -- VERIFIED SW-66: DncHandle.{mem,usage} (lib/core/dnc_api.c) are calloc'd on the C heap, never arena-allocated; a shallow copy preserves both pointers exactly, so they cannot dangle when the region's arena is freed
+    HEAP_SUBTYPE_SDNC            = 22,  // SDNC weight-program handle (bytecode-VM-as-transformer θ) [LEAF] -- VERIFIED SW-66: SdncHandle.w (lib/core/sdnc_api.c) is calloc'd on the C heap (not arena-allocated) and .pe[][] is inline scalar data; same reasoning as DNC
+    HEAP_SUBTYPE_TAYLOR          = 23,  // Truncated-Taylor tower for arbitrary-order AD (ESH-0186) [DEEPWALK] -- SW-66: a COEFF_RATIONAL (exact) tower's c[] is an array of eshkol_tagged_value_t that can hold HEAP_PTRs to arena-resident HEAP_SUBTYPE_BIGNUM/HEAP_SUBTYPE_RATIONAL coefficients (lib/core/runtime_taylor.c); a COEFF_F64 tower's c[] is raw doubles (nothing to walk, the walk is a cheap no-op)
     HEAP_SUBTYPE_PARAMETER       = 24,  // R7RS dynamic parameter object (make-parameter/parameterize) [LEAF] -- current native evac_kind_for treatment; UNLIKE the other LEAF members above, this one is NOT a reviewed, documented exemption in runtime_regions.cpp, and the bytecode VM's own region evacuator (lib/backend/vm_region_evac.c) already deep-walks its parameter row (current_value/converter/save_stack) -- tracked as ledger IF-08 pending a native-side decision, not silently matched to today's code by coincidence
     HEAP_SUBTYPE_I128            = 25,  // Native fixed-width 128-bit integer (wraps; OFF the numeric tower) [LEAF] -- flat {lo,hi} POD, no interior pointers
     // Reserved: 26-255 for future heap types

--- a/inc/eshkol/eshkol.h
+++ b/inc/eshkol/eshkol.h
@@ -525,34 +525,52 @@ ESHKOL_STATIC_ASSERT(sizeof(eshkol_object_header_t) == 8,
  * neuro-symbolic/AD structures added for the consciousness engine and
  * Taylor-tower AD) that share the single consolidated HEAP_PTR type tag.
  */
+// Interior-pointer classification tags (SW-65, 2026-08-26 libclance
+// architecture-verify admission).  Every member below carries a trailing
+// [DEEPWALK] or [LEAF] marker: DEEPWALK means the region evacuator
+// (lib/core/runtime_regions.cpp, evac_kind_for) MUST walk this subtype's
+// interior tagged values/pointers when it escapes a dying region; LEAF means
+// a contiguous header+payload copy is sound because the subtype holds no
+// interior REGION pointer (a raw non-arena C-heap pointer is fine to
+// shallow-copy, since it never dangles when the region's arena is freed).
+// This is the source side of INV-oalr-interior-pointer-deepwalk
+// (.icc/architecture-model.yaml), graded against a source-derived pattern
+// over evac_kind_for's actual `case HEAP_SUBTYPE_X: return EVAC_...;` arms:
+// adding a member here without also giving it a real case in that switch is
+// exactly the class of regression the invariant exists to catch
+// (KB/FACT/SUBSTITUTION/WORKSPACE were dropped to a shallow leaf copy this
+// way before ESH-0214d; DNC/SDNC/TAYLOR were never given the tag OR the
+// case at all before this fix, so the invariant could not see them). Keep
+// both sides honest: retag a member the moment its actual evac_kind_for
+// treatment changes.
 typedef enum {
-    HEAP_SUBTYPE_CONS        = 0,   // Cons cell (pair/list node)
-    HEAP_SUBTYPE_STRING      = 1,   // String (UTF-8 with length)
-    HEAP_SUBTYPE_VECTOR      = 2,   // Heterogeneous vector
-    HEAP_SUBTYPE_TENSOR      = 3,   // N-dimensional numeric tensor
-    HEAP_SUBTYPE_MULTI_VALUE = 4,   // Multiple return values container
-    HEAP_SUBTYPE_HASH        = 5,   // Hash table / dictionary
-    HEAP_SUBTYPE_EXCEPTION   = 6,   // Exception object
-    HEAP_SUBTYPE_RECORD      = 7,   // User-defined record type
-    HEAP_SUBTYPE_BYTEVECTOR  = 8,   // Raw byte vector (R7RS)
-    HEAP_SUBTYPE_PORT        = 9,   // I/O port
-    HEAP_SUBTYPE_SYMBOL      = 10,  // Interned symbol (distinct from string)
-    HEAP_SUBTYPE_BIGNUM      = 11,  // Arbitrary-precision integer (R7RS exact)
+    HEAP_SUBTYPE_CONS        = 0,   // Cons cell (pair/list node) [DEEPWALK]
+    HEAP_SUBTYPE_STRING      = 1,   // String (UTF-8 with length) [LEAF] -- self-contained payload
+    HEAP_SUBTYPE_VECTOR      = 2,   // Heterogeneous vector [DEEPWALK]
+    HEAP_SUBTYPE_TENSOR      = 3,   // N-dimensional numeric tensor [DEEPWALK]
+    HEAP_SUBTYPE_MULTI_VALUE = 4,   // Multiple return values container [DEEPWALK]
+    HEAP_SUBTYPE_HASH        = 5,   // Hash table / dictionary [DEEPWALK]
+    HEAP_SUBTYPE_EXCEPTION   = 6,   // Exception object [DEEPWALK]
+    HEAP_SUBTYPE_RECORD      = 7,   // User-defined record type [DEEPWALK] -- records allocate as vectors
+    HEAP_SUBTYPE_BYTEVECTOR  = 8,   // Raw byte vector (R7RS) [LEAF] -- self-contained payload
+    HEAP_SUBTYPE_PORT        = 9,   // I/O port [LEAF] -- wraps an OS fd/FILE*; handle intentionally shared, not copied
+    HEAP_SUBTYPE_SYMBOL      = 10,  // Interned symbol (distinct from string) [LEAF] -- self-contained payload
+    HEAP_SUBTYPE_BIGNUM      = 11,  // Arbitrary-precision integer (R7RS exact) [LEAF] -- self-contained payload
     // Neuro-symbolic consciousness engine types
-    HEAP_SUBTYPE_SUBSTITUTION    = 12,  // Immutable binding map {var_id -> tagged_value}
-    HEAP_SUBTYPE_FACT            = 13,  // Predicate + arguments: (pred arg1 arg2 ...)
+    HEAP_SUBTYPE_SUBSTITUTION    = 12,  // Immutable binding map {var_id -> tagged_value} [DEEPWALK]
+    HEAP_SUBTYPE_FACT            = 13,  // Predicate + arguments: (pred arg1 arg2 ...) [DEEPWALK]
     // Reserved: 14 for RULE (v1.2 backward chaining)
-    HEAP_SUBTYPE_KNOWLEDGE_BASE  = 15,  // Collection of facts with query support
-    HEAP_SUBTYPE_FACTOR_GRAPH    = 16,  // Factor graph for probabilistic inference
-    HEAP_SUBTYPE_WORKSPACE       = 17,  // Global workspace for cognitive competition
-    HEAP_SUBTYPE_PROMISE         = 18,  // Lazy promise (delay/force with memoization)
-    HEAP_SUBTYPE_RATIONAL        = 19,  // Exact rational number (numerator/denominator)
-    HEAP_SUBTYPE_PRNG            = 20,  // Isolated pseudo-random number generator state
-    HEAP_SUBTYPE_DNC             = 21,  // Differentiable external memory (NTM/DNC head)
-    HEAP_SUBTYPE_SDNC            = 22,  // SDNC weight-program handle (bytecode-VM-as-transformer θ)
-    HEAP_SUBTYPE_TAYLOR          = 23,  // Truncated-Taylor tower for arbitrary-order AD (ESH-0186)
-    HEAP_SUBTYPE_PARAMETER       = 24,  // R7RS dynamic parameter object (make-parameter/parameterize)
-    HEAP_SUBTYPE_I128            = 25,  // Native fixed-width 128-bit integer (wraps; OFF the numeric tower)
+    HEAP_SUBTYPE_KNOWLEDGE_BASE  = 15,  // Collection of facts with query support [DEEPWALK]
+    HEAP_SUBTYPE_FACTOR_GRAPH    = 16,  // Factor graph for probabilistic inference [DEEPWALK]
+    HEAP_SUBTYPE_WORKSPACE       = 17,  // Global workspace for cognitive competition [DEEPWALK]
+    HEAP_SUBTYPE_PROMISE         = 18,  // Lazy promise (delay/force with memoization) [DEEPWALK]
+    HEAP_SUBTYPE_RATIONAL        = 19,  // Exact rational number (numerator/denominator) [DEEPWALK] -- the bignum-backed path carries raw bignum pointers
+    HEAP_SUBTYPE_PRNG            = 20,  // Isolated pseudo-random number generator state [LEAF] -- self-contained state words, no interior pointers
+    HEAP_SUBTYPE_DNC             = 21,  // Differentiable external memory (NTM/DNC head) [LEAF] -- VERIFIED SW-65: DncHandle.{mem,usage} (lib/core/dnc_api.c) are calloc'd on the C heap, never arena-allocated; a shallow copy preserves both pointers exactly, so they cannot dangle when the region's arena is freed
+    HEAP_SUBTYPE_SDNC            = 22,  // SDNC weight-program handle (bytecode-VM-as-transformer θ) [LEAF] -- VERIFIED SW-65: SdncHandle.w (lib/core/sdnc_api.c) is calloc'd on the C heap (not arena-allocated) and .pe[][] is inline scalar data; same reasoning as DNC
+    HEAP_SUBTYPE_TAYLOR          = 23,  // Truncated-Taylor tower for arbitrary-order AD (ESH-0186) [DEEPWALK] -- SW-65: a COEFF_RATIONAL (exact) tower's c[] is an array of eshkol_tagged_value_t that can hold HEAP_PTRs to arena-resident HEAP_SUBTYPE_BIGNUM/HEAP_SUBTYPE_RATIONAL coefficients (lib/core/runtime_taylor.c); a COEFF_F64 tower's c[] is raw doubles (nothing to walk, the walk is a cheap no-op)
+    HEAP_SUBTYPE_PARAMETER       = 24,  // R7RS dynamic parameter object (make-parameter/parameterize) [LEAF] -- current native evac_kind_for treatment; UNLIKE the other LEAF members above, this one is NOT a reviewed, documented exemption in runtime_regions.cpp, and the bytecode VM's own region evacuator (lib/backend/vm_region_evac.c) already deep-walks its parameter row (current_value/converter/save_stack) -- tracked as ledger IF-08 pending a native-side decision, not silently matched to today's code by coincidence
+    HEAP_SUBTYPE_I128            = 25,  // Native fixed-width 128-bit integer (wraps; OFF the numeric tower) [LEAF] -- flat {lo,hi} POD, no interior pointers
     // Reserved: 26-255 for future heap types
 } heap_subtype_t;
 

--- a/lib/core/runtime_regions.cpp
+++ b/lib/core/runtime_regions.cpp
@@ -926,6 +926,12 @@ enum EvacKind : uint8_t {
     EVAC_WORKSPACE,      // eshkol_workspace_t: content buffer + per-module name/process_fn
     EVAC_PROMISE,        // [forced:i64][thunk:tagged @8][cached:tagged @24] (delay/force)
     EVAC_RATIONAL,       // eshkol_rational_t: big_num/big_den raw bignum pointers (is_big==1 only)
+    // SW-65: an EXACT-COEFFICIENT (COEFF_RATIONAL) Taylor tower's c[] is an
+    // array of eshkol_tagged_value_t that can hold HEAP_PTRs to arena-
+    // resident bignum/rational coefficients (see runtime_taylor.c). A
+    // COEFF_F64 tower's c[] is raw doubles -- nothing to walk, same shape as
+    // EVAC_RATIONAL's is_big==0 fast path being a cheap no-op.
+    EVAC_TAYLOR,         // esh_taylor_t: c[] tagged-value array (COEFF_RATIONAL only)
 };
 
 using EvacFwdMap = std::unordered_map<const void*, void*>;
@@ -1096,6 +1102,16 @@ static EvacKind evac_kind_for(const eshkol_tagged_value_t& v, const void* old_da
         // logic/workspace subtypes. Always dispatched through EVAC_RATIONAL;
         // the is_big==0 case is a cheap no-op there (nothing to walk).
         case HEAP_SUBTYPE_RATIONAL:       return EVAC_RATIONAL;
+        // SW-65 (2026-08-26 libclang architecture-verify admission): only the
+        // EXACT-COEFFICIENT (COEFF_RATIONAL) representation of a Taylor tower
+        // carries interior region pointers -- its c[] is reinterpreted as an
+        // eshkol_tagged_value_t array, and any entry can be a HEAP_PTR to a
+        // bignum/rational coefficient allocated in the same (possibly dying)
+        // region (see the exact-tower path in runtime_taylor.c). A COEFF_F64
+        // tower's c[] is raw doubles. Always dispatched through EVAC_TAYLOR;
+        // the F64 case is a cheap no-op there, mirroring EVAC_RATIONAL's
+        // is_big==0 fast path just above.
+        case HEAP_SUBTYPE_TAYLOR:         return EVAC_TAYLOR;
         // STRING / SYMBOL / BIGNUM / BYTEVECTOR / I128: self-contained payloads
         // -> a contiguous leaf copy fully preserves them. I128 in particular is
         // a flat 16-byte {lo,hi} POD with no interior pointers, so the default
@@ -1107,12 +1123,21 @@ static EvacKind evac_kind_for(const eshkol_tagged_value_t& v, const void* old_da
         // are not observed to escape a region by mutation):
         //   PORT      - wraps an OS fd/FILE*; handle intentionally shared, not copied.
         //   PRNG      - self-contained state words, no interior pointers.
-        //   DNC/SDNC  - large differentiable weight/program buffers; escaping a
-        //               region by mutation is not a supported pattern.
-        //   TAYLOR    - truncated-Taylor tower; rational-coeff interior not traversed.
+        //   DNC/SDNC  - VERIFIED SW-65 by reading both handle layouts:
+        //               DncHandle.{mem,usage} (lib/core/dnc_api.c) and
+        //               SdncHandle.w (lib/core/sdnc_api.c) are calloc'd on
+        //               the plain C heap, never arena-allocated
+        //               (SdncHandle.pe[][] is inline scalar data with no
+        //               pointer at all). A shallow copy preserves those raw
+        //               pointer VALUES exactly; they cannot dangle when the
+        //               region's arena is freed, because they never pointed
+        //               into it in the first place. This is a confirmed
+        //               property of the current handle layouts, not an
+        //               assumption -- see the debug guard just below.
         // A guarded assert below (region_evacuate leaf handler) fires under a debug
-        // build if any such subtype is actually seen escaping, so a real escape is
-        // discovered instead of silently corrupting.
+        // build if either subtype's handle layout ever changes to hold a real
+        // arena pointer without this switch being updated to match, so a real
+        // regression is discovered instead of silently corrupting.
         default:                       return EVAC_LEAF;
     }
 }
@@ -1167,20 +1192,26 @@ static void* evac_object(EvacState& st, void* old_data, const eshkol_tagged_valu
 
     EvacKind k = evac_kind_for(v, old_data);
 #ifndef NDEBUG
-    // ESH-0214d: a subtype that carries interior region pointers must NOT be
-    // leaf-copied. These are the ones we deliberately left leaf but expect to
-    // never actually escape a region by mutation; warn loudly if one does, so a
-    // real escape is discovered instead of silently corrupting interior state.
+    // SW-65 (formerly the ESH-0214d watchlist): DNC/SDNC are VERIFIED leaf --
+    // their only pointer-shaped fields are calloc'd C-heap buffers, never
+    // arena-resident (see the case-arm comment in evac_kind_for above) -- but
+    // that verification is a property of TODAY's handle layout, not a law.
+    // If a future change ever makes DncHandle/SdncHandle hold a real arena
+    // pointer without updating evac_kind_for to match, this guard is what
+    // catches it: warn loudly instead of silently corrupting interior state.
+    // TAYLOR is NOT listed here any more -- it is no longer ever classified
+    // EVAC_LEAF (see EVAC_TAYLOR above), so this branch is structurally
+    // unreachable for it now.
     if (k == EVAC_LEAF) {
         const auto* dh = (const eshkol_object_header_t*)
             ((const uint8_t*)new_data - sizeof(eshkol_object_header_t));
         switch (dh->subtype) {
             case HEAP_SUBTYPE_DNC:
             case HEAP_SUBTYPE_SDNC:
-            case HEAP_SUBTYPE_TAYLOR:
                 eshkol_warn("region evacuate: subtype %u escaped a region as a "
-                            "SHALLOW leaf copy (ESH-0214d watchlist); interior "
-                            "pointers may dangle -- deep coverage needed.",
+                            "SHALLOW leaf copy (SW-65 verified-leaf guard); if "
+                            "this fires, the handle's layout changed and this "
+                            "subtype needs a real evac_kind_for case.",
                             (unsigned)dh->subtype);
                 break;
             default: break;
@@ -1487,6 +1518,32 @@ static eshkol_tagged_value_t region_evacuate_value(eshkol_tagged_value_t val,
                 if (r->is_big) {
                     if (r->big_num) r->big_num = (eshkol_bignum_t*)evac_object_ptr(st, r->big_num);
                     if (r->big_den) r->big_den = (eshkol_bignum_t*)evac_object_ptr(st, r->big_den);
+                }
+                break;
+            }
+            case EVAC_TAYLOR: {
+                // SW-65: only a COEFF_RATIONAL (exact) tower's c[] holds
+                // interior tagged values -- reinterpret it exactly the way
+                // runtime_taylor.c's taylor_exact_c()/taylor_exact_c_const()
+                // do, and evac_value() each of the order_k+1 entries (most
+                // are plain int64 scalars needing no work; any that are
+                // HEAP_PTRs to a bignum/rational allocated in this same
+                // region get walked and repointed, exactly like a vector's
+                // element array). A COEFF_F64 tower's c[] is raw doubles,
+                // already fully preserved by the contiguous header+payload
+                // copy above -- nothing to do.
+                //
+                // The seed-tangent half (ESH_TAYLOR_TANGENT_FLAG) is never
+                // combined with COEFF_RATIONAL by any producer in
+                // runtime_taylor.c (the tangent series is only ever built
+                // alongside COEFF_F64 towers), so it is deliberately not
+                // considered here; if that combination is ever introduced,
+                // its storage doubling would need its own case.
+                auto* t = (esh_taylor_t*)nd;
+                if ((t->flags & ESH_TAYLOR_COEFF_MASK) == ESH_TAYLOR_COEFF_RATIONAL) {
+                    auto* c = (eshkol_tagged_value_t*)(void*)t->c;
+                    const size_t ncoeff = (size_t)t->order_k + 1;
+                    for (size_t i = 0; i < ncoeff; ++i) c[i] = evac_value(st, c[i]);
                 }
                 break;
             }

--- a/lib/core/runtime_regions.cpp
+++ b/lib/core/runtime_regions.cpp
@@ -926,7 +926,7 @@ enum EvacKind : uint8_t {
     EVAC_WORKSPACE,      // eshkol_workspace_t: content buffer + per-module name/process_fn
     EVAC_PROMISE,        // [forced:i64][thunk:tagged @8][cached:tagged @24] (delay/force)
     EVAC_RATIONAL,       // eshkol_rational_t: big_num/big_den raw bignum pointers (is_big==1 only)
-    // SW-65: an EXACT-COEFFICIENT (COEFF_RATIONAL) Taylor tower's c[] is an
+    // SW-66: an EXACT-COEFFICIENT (COEFF_RATIONAL) Taylor tower's c[] is an
     // array of eshkol_tagged_value_t that can hold HEAP_PTRs to arena-
     // resident bignum/rational coefficients (see runtime_taylor.c). A
     // COEFF_F64 tower's c[] is raw doubles -- nothing to walk, same shape as
@@ -1102,7 +1102,7 @@ static EvacKind evac_kind_for(const eshkol_tagged_value_t& v, const void* old_da
         // logic/workspace subtypes. Always dispatched through EVAC_RATIONAL;
         // the is_big==0 case is a cheap no-op there (nothing to walk).
         case HEAP_SUBTYPE_RATIONAL:       return EVAC_RATIONAL;
-        // SW-65 (2026-08-26 libclang architecture-verify admission): only the
+        // SW-66 (2026-08-26 libclang architecture-verify admission): only the
         // EXACT-COEFFICIENT (COEFF_RATIONAL) representation of a Taylor tower
         // carries interior region pointers -- its c[] is reinterpreted as an
         // eshkol_tagged_value_t array, and any entry can be a HEAP_PTR to a
@@ -1123,7 +1123,7 @@ static EvacKind evac_kind_for(const eshkol_tagged_value_t& v, const void* old_da
         // are not observed to escape a region by mutation):
         //   PORT      - wraps an OS fd/FILE*; handle intentionally shared, not copied.
         //   PRNG      - self-contained state words, no interior pointers.
-        //   DNC/SDNC  - VERIFIED SW-65 by reading both handle layouts:
+        //   DNC/SDNC  - VERIFIED SW-66 by reading both handle layouts:
         //               DncHandle.{mem,usage} (lib/core/dnc_api.c) and
         //               SdncHandle.w (lib/core/sdnc_api.c) are calloc'd on
         //               the plain C heap, never arena-allocated
@@ -1192,7 +1192,7 @@ static void* evac_object(EvacState& st, void* old_data, const eshkol_tagged_valu
 
     EvacKind k = evac_kind_for(v, old_data);
 #ifndef NDEBUG
-    // SW-65 (formerly the ESH-0214d watchlist): DNC/SDNC are VERIFIED leaf --
+    // SW-66 (formerly the ESH-0214d watchlist): DNC/SDNC are VERIFIED leaf --
     // their only pointer-shaped fields are calloc'd C-heap buffers, never
     // arena-resident (see the case-arm comment in evac_kind_for above) -- but
     // that verification is a property of TODAY's handle layout, not a law.
@@ -1209,7 +1209,7 @@ static void* evac_object(EvacState& st, void* old_data, const eshkol_tagged_valu
             case HEAP_SUBTYPE_DNC:
             case HEAP_SUBTYPE_SDNC:
                 eshkol_warn("region evacuate: subtype %u escaped a region as a "
-                            "SHALLOW leaf copy (SW-65 verified-leaf guard); if "
+                            "SHALLOW leaf copy (SW-66 verified-leaf guard); if "
                             "this fires, the handle's layout changed and this "
                             "subtype needs a real evac_kind_for case.",
                             (unsigned)dh->subtype);
@@ -1522,7 +1522,7 @@ static eshkol_tagged_value_t region_evacuate_value(eshkol_tagged_value_t val,
                 break;
             }
             case EVAC_TAYLOR: {
-                // SW-65: only a COEFF_RATIONAL (exact) tower's c[] holds
+                // SW-66: only a COEFF_RATIONAL (exact) tower's c[] holds
                 // interior tagged values -- reinterpret it exactly the way
                 // runtime_taylor.c's taylor_exact_c()/taylor_exact_c_const()
                 // do, and evac_value() each of the order_k+1 entries (most

--- a/tests/memory/region_evac_taylor_exact_test.esk
+++ b/tests/memory/region_evac_taylor_exact_test.esk
@@ -1,0 +1,81 @@
+;;; tests/memory/region_evac_taylor_exact_test.esk — region evacuator
+;;; HEAP_SUBTYPE_TAYLOR (exact/COEFF_RATIONAL) subtype-coverage correctness
+;;; fixture (SW-65).
+;;;
+;;; evac_kind_for (lib/core/runtime_regions.cpp) classified HEAP_SUBTYPE_TAYLOR
+;;; as EVAC_LEAF (a shallow header+payload copy) unconditionally. That is
+;;; correct for the ordinary COEFF_F64 representation (c[] is raw doubles,
+;;; nothing to walk), but WRONG for the EXACT (COEFF_RATIONAL) representation
+;;; introduced by ESH-0191/P6: there, c[] is reinterpreted as an array of
+;;; eshkol_tagged_value_t, and any coefficient that overflows int64 is a
+;;; HEAP_PTR to an independently arena-allocated HEAP_SUBTYPE_BIGNUM object
+;;; (see the exact-pow recurrence in lib/core/runtime_taylor.c) — exactly the
+;;; same "raw pointer to another arena-resident header-prefixed object" shape
+;;; ESH-0214d closed for KB/FACT/SUBSTITUTION/WORKSPACE and the RATIONAL
+;;; bignum-path fix closed for HEAP_SUBTYPE_RATIONAL.
+;;;
+;;; This fixture differentiates a bignum-scale power function (x^30 at an
+;;; exact integer point) with the entire tower-producing arithmetic wrapped in
+;;; a `(with-region ...)` body, so the exact tower `expt` allocates is built
+;;; entirely inside the region's arena and then escapes it via with-region's
+;;; own return-value evacuation. `derivative-n`'s driver then reads the
+;;; escaped tower's coefficient directly. A shallow leaf copy leaves any
+;;; bignum-valued coefficient's pointer aimed into the region arena that
+;;; `with-region` is about to free: under ESHKOL_ARENA_POISON=1, the
+;;; subsequent exact arithmetic needed to convert that coefficient into the
+;;; returned derivative value reads 0xCB-poisoned memory and produces a
+;;; corrupted result (observed on the pre-fix runtime: a spurious "arena
+;;; allocation exceeds UINT32_MAX" diagnostic followed by a wrong answer of
+;;; 0, in place of the true bignum value) instead of the exact answer.
+;;; Without poison the same defect is genuinely SILENT: the freed bytes have
+;;; not yet been overwritten, so the stale-but-still-valid bignum reads back
+;;; correct by luck.
+
+(define npass 0)
+(define nfail 0)
+
+(define (check-exact-eq name got expect)
+  (if (and (exact? got) (= got expect))
+      (set! npass (+ npass 1))
+      (begin (set! nfail (+ nfail 1))
+             (display "FAIL ") (display name)
+             (display " got=") (display got) (display " exact?=") (display (exact? got))
+             (display " expect=") (display expect) (newline))))
+
+;; f(x) = x^30. Wrapping the WHOLE differentiated body in a with-region forces
+;; every intermediate exact tower `expt`'s recurrence builds — including the
+;; final result tower whose coefficients are bignum-scale for x0=7 — to live
+;; in the region's arena, then escape it as the with-region body's return
+;; value (region_escape_tagged_value_impl -> region_evacuate_value ->
+;; evac_object -> evac_kind_for).
+(define (x30-region x) (with-region 'x30r (expt x 30)))
+(define (x30-plain x) (expt x 30))
+
+;; f^(0)(7) = 7^30 (~2.25e25, genuinely bignum-scale: exceeds int64 at n=0).
+(check-exact-eq "x^30 region n=0" (derivative-n x30-region 7 0) (derivative-n x30-plain 7 0))
+;; f^(1)(7) = 30 * 7^29 (also bignum-scale).
+(check-exact-eq "x^30 region n=1" (derivative-n x30-region 7 1) (derivative-n x30-plain 7 1))
+;; f^(5)(7) = P(30,5) * 7^25 (bignum-scale; exercises a higher tower order so
+;; more than one coefficient of the escaped tower is a bignum HEAP_PTR).
+(check-exact-eq "x^30 region n=5" (derivative-n x30-region 7 5) (derivative-n x30-plain 7 5))
+
+;; A second base/exponent pair (x0=11), so the fixture is not tied to one
+;; specific bignum bit pattern.
+(define (x22-region x) (with-region 'x22r (expt x 22)))
+(define (x22-plain x) (expt x 22))
+(check-exact-eq "x^22 region n=0" (derivative-n x22-region 11 0) (derivative-n x22-plain 11 0))
+(check-exact-eq "x^22 region n=3" (derivative-n x22-region 11 3) (derivative-n x22-plain 11 3))
+
+;; A tower built from PRODUCT (not expt's dedicated exact-pow recurrence) also
+;; exercises the ordinary Cauchy-convolution exact multiply path.
+(define (mul10-region x) (with-region 'mulr (* x x x x x x x x x x)))
+(define (mul10-plain x) (* x x x x x x x x x x))
+(check-exact-eq "x^10(mul) region n=0" (derivative-n mul10-region 9 0) (derivative-n mul10-plain 9 0))
+(check-exact-eq "x^10(mul) region n=2" (derivative-n mul10-region 9 2) (derivative-n mul10-plain 9 2))
+
+(display "----") (newline)
+(display "region-evac-taylor-exact tests: ") (display npass) (display " passed, ")
+(display nfail) (display " failed") (newline)
+(if (= nfail 0)
+    (begin (display "PASS: region-evac exact-Taylor deep-walk") (newline))
+    (begin (display "FAIL: region-evac exact-Taylor deep-walk") (newline)))

--- a/tests/memory/region_evac_taylor_exact_test.esk
+++ b/tests/memory/region_evac_taylor_exact_test.esk
@@ -1,6 +1,6 @@
 ;;; tests/memory/region_evac_taylor_exact_test.esk — region evacuator
 ;;; HEAP_SUBTYPE_TAYLOR (exact/COEFF_RATIONAL) subtype-coverage correctness
-;;; fixture (SW-65).
+;;; fixture (SW-66).
 ;;;
 ;;; evac_kind_for (lib/core/runtime_regions.cpp) classified HEAP_SUBTYPE_TAYLOR
 ;;; as EVAC_LEAF (a shallow header+payload copy) unconditionally. That is


### PR DESCRIPTION
## Summary

`icc architecture-verify`'s new libclang C/C++ resolution backend found that `evac_kind_for` (`lib/core/runtime_regions.cpp`) never classified `HEAP_SUBTYPE_DNC`, `HEAP_SUBTYPE_SDNC`, or `HEAP_SUBTYPE_TAYLOR` at all. The prior `INV-oalr-interior-pointer-deepwalk` invariant graded a false PASS because it grepped the whole file for those tokens (which appear elsewhere, in a debug-only watchlist warn block) instead of resolving the switch's real case arms.

Reading each subtype's actual allocation layout gave a three-way split:

- **DNC / SDNC — genuinely safe as LEAF.** `DncHandle.{mem,usage}` (`lib/core/dnc_api.c`) and `SdncHandle.w` (`lib/core/sdnc_api.c`) are `calloc`'d on the plain C heap, never arena-allocated, so a shallow copy preserves their pointer values exactly — they can never dangle when a region's arena is freed. Given an explicit, verified `[LEAF]` tag instead of an unreviewed fallthrough to `default`.
- **TAYLOR — a real bug.** The EXACT (`COEFF_RATIONAL`) representation reinterprets the coefficient array as `eshkol_tagged_value_t`, and any coefficient overflowing int64 is a `HEAP_PTR` to an independently arena-allocated bignum (`lib/core/runtime_taylor.c`). A tower built and escaped from inside a `with-region` body left that pointer aimed into the region's arena after `region_pop` freed it — silently correct until the freed bytes are reused, and garbage under `ESHKOL_ARENA_POISON=1`.

## Fix

- Add `EVAC_TAYLOR` and an explicit `case HEAP_SUBTYPE_TAYLOR: return EVAC_TAYLOR;` arm; the worklist handler walks the coefficient array only when the tower is `COEFF_RATIONAL` (a `COEFF_F64` tower's `c[]` is raw doubles, a no-op mirroring `EVAC_RATIONAL`'s int64 fast path).
- Every `HEAP_SUBTYPE_*` member in `inc/eshkol/eshkol.h` now carries an explicit `[DEEPWALK]`/`[LEAF]` tag with its reasoning.
- `INV-oalr-interior-pointer-deepwalk`'s sites in `.icc/architecture-model.yaml` are rewritten as generic, source-derived patterns (enum side reads the tags, switch side reads every real deep-walk case arm) instead of a hand-typed 16-name list duplicated on both sides — the shape that let this gap hide. Verified FAIL (`divergent=['TAYLOR']`) against the pre-fix switch and PASS against the fix, under both `--cxx-backend none` and tree-sitter.
- Confirmed the bytecode VM has no `HEAP_DNC`/`HEAP_SDNC`/`HEAP_TAYLOR` tags and no `derivative-n`/`taylor`/`dnc`/`sdnc` op codegen at all (live-probed under `--profile hosted-vm`, which reports `derivative-n` as an undefined variable) — no VM-side parity gap for this family.
- `SW-65` filed in `.icc/silent-wrong-ledger.yaml`; `check_ledger_integrity.py` passes.

## Test plan

- [x] `tests/memory/region_evac_taylor_exact_test.esk` reproduces the defect: differentiates `x^30`/`x^22`/`x^10` at exact integer points with the differentiated body wrapped in `(with-region ...)`, forcing the escaped tower's bignum coefficients into the region arena. 5/7 checks fail pre-fix, 7/7 pass post-fix, on both JIT and AOT, confirmed empirically by toggling the fix.
- [x] Wired into ctest (`region_evac_taylor_exact_runtime_smoke`, `region_evac_taylor_exact_aot_smoke`) under `ESHKOL_ARENA_POISON=1`.
- [x] Full ctest: 203/203 passed.
- [x] `tests/memory/region_evac_subtype_coverage_test.sh`, `tests/memory/vm_region_evac_subtype_coverage_test.sh`, and the other region/memory RSS gates all pass.
- [x] `icc architecture-verify` on `INV-oalr-interior-pointer-deepwalk`: FAIL pre-fix, PASS post-fix.