### PR TITLE
fix(dispatch): a `default:` may not stand in for an invariant — closed-enum dispatch is compiler-enforced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,6 +445,7 @@ jobs:
           python3 scripts/check_required_context_consistency.py --self-test
           python3 scripts/check_package_manifest.py --self-test
           python3 scripts/check_diagnostic_corpus.py --self-test
+          python3 scripts/gate_exhaustive_dispatch.py --self-test
 
       # B5/N2 (2026-08-26 audit): every gate below this point deliberately
       # DROPS --no-trace. This job builds nothing (pure Python over
@@ -487,6 +488,21 @@ jobs:
       - name: Every AD op routes through a declared, exact, source-verified carrier
         shell: bash
         run: python3 scripts/gate_ad_shared_node_model.py
+
+      # Source-derived, and it has to be: the PRIMARY enforcement for this
+      # class is the compiler (-Werror=switch -Werror=switch-enum, or
+      # ESHKOL_EXHAUSTIVE_SWITCH_BEGIN per switch), which cannot report
+      # anything here — a build that fails produces an absence, not evidence.
+      # This step is the half that can: it re-derives each closed enum's
+      # members from its own DEFINITION and fails on any registered dispatch
+      # site that carries a `default:`, omits a member, or has had its arming
+      # removed. It runs in THIS job rather than only in ctest so it grades
+      # every PR shape, including docs-only ones where no build runs at all —
+      # a change that deletes eshkol_require_exhaustive_dispatch() from
+      # CMakeLists.txt touches no source file the build matrix would notice.
+      - name: No dispatch switch over a closed enum carries a default (SW-70)
+        shell: bash
+        run: python3 scripts/gate_exhaustive_dispatch.py --no-trace
 
       # --offline deliberately: reading branch-protection settings needs
       # administration:read, which the default workflow token does not

--- a/.icc/abi-header-baseline.json
+++ b/.icc/abi-header-baseline.json
@@ -1,5 +1,5 @@
 {
-  "commit": "892622c0f628f61bc5c829fb63f1cac4606c8553",
+  "commit": "61935eef779b3f1764c36f72208c2bfccea23810",
   "counts": {
     "A_macro_api": {
       "inc/eshkol/eshkol.h": 32,
@@ -161,14 +161,14 @@
       "lib/core/dnc_api.c": 3,
       "lib/core/i128_runtime.cpp": 3,
       "lib/core/inference.cpp": 6,
-      "lib/core/introspection.cpp": 8,
+      "lib/core/introspection.cpp": 10,
       "lib/core/kb_persistence.cpp": 7,
       "lib/core/logic.cpp": 10,
       "lib/core/runtime_autodiff.cpp": 4,
       "lib/core/runtime_closure_alloc.cpp": 4,
       "lib/core/runtime_continuations.cpp": 1,
       "lib/core/runtime_deep_equal.cpp": 7,
-      "lib/core/runtime_display_hosted.cpp": 6,
+      "lib/core/runtime_display_hosted.cpp": 8,
       "lib/core/runtime_exceptions_hosted.cpp": 4,
       "lib/core/runtime_hash_table.cpp": 4,
       "lib/core/runtime_object_alloc.cpp": 20,
@@ -278,7 +278,7 @@
     "D_ir_const_offset": 45,
     "E_alloc_with_header": 182,
     "F_parallel_header_decl": 2,
-    "G_header_field_write": 164,
+    "G_header_field_write": 168,
     "H_wasm_glue": 34,
     "J_secondary_prefix_abi": 33,
     "K_raw_byte_offset": 10,

--- a/.icc/architecture-model.yaml
+++ b/.icc/architecture-model.yaml
@@ -815,3 +815,91 @@ invariants:
     evidence:
       trace_name_pattern: '^abi_layout_pin$'
       max_age_days: 45
+
+  # 14. Closed-enum dispatch exhaustiveness, encoded as intended-invariant with
+  #    a source-derived guard.  THE CLASS: a dispatch switch over a closed enum
+  #    whose `default:` encodes an ASSUMPTION instead of failing, in a language
+  #    where the enum can grow without the switch ever knowing.  PR #498 found
+  #    four tensor-valued AD node types falling into an early `default:` in
+  #    eshkol_tensor_backward_dispatch that did nothing at all — gradients
+  #    exactly 0.0, no diagnostic, exit 0 — behind a comment asserting the case
+  #    was impossible, reasoned from a numeric band of enum values that those
+  #    four node types had already left.  ESH-0214d is the same shape one
+  #    subsystem over.  The primary enforcement is COMPILE-TIME
+  #    (-Werror=switch-enum per translation unit, or
+  #    ESHKOL_EXHAUSTIVE_SWITCH_BEGIN/_END per switch); this invariant is the
+  #    source-derived second half, so the property is re-measured on lanes
+  #    whose toolchain has no such diagnostic (MSVC) and so REMOVING the
+  #    enforcement is itself caught.  Expected PASS; adding a `default:` to any
+  #    registered site, or an enum member no site names, FAILs it.
+  - id: INV-closed-enum-dispatch-exhaustive
+    kind: intended-invariant
+    incident: closed-enum-dispatch-default
+    severity: critical
+    description: >
+      No dispatch switch over a CLOSED enum may carry a `default:`.  The gate
+      re-derives each enum's members from its own DEFINITION (not from a
+      hand-typed list that would drift in exactly the situation being guarded
+      against) and requires every registered dispatch site to name all of them
+      with no default, and to be armed — the translation unit listed in
+      CMakeLists' eshkol_require_exhaustive_dispatch(), or the switch wrapped
+      in ESHKOL_EXHAUSTIVE_SWITCH_BEGIN/_END.  It additionally requires that
+      every ad_node_registry.def row declaring BRIDGE names a backward function
+      that is DEFINED in lib/bridge/tensor_backward.cpp, and that the registry
+      values are dense and equal to their ordinal, because the backward table
+      is a flat array indexed by node type.
+
+      SCOPE, stated so the invariant is not read as more than it is: this
+      covers switches over values the PROGRAM ITSELF produces.  A switch over a
+      value that arrives from outside — a bytecode opcode, a subtype byte read
+      off a header or a file, an integer crossing an FFI boundary — dispatches
+      over an OPEN set whatever the enum declares, keeps its `default:`, and
+      the requirement there is that the default be a LOUD, value-naming abort.
+      Demanding exhaustiveness of those would be enforcing a fiction.
+    invariant_name: closed-enum-dispatch-carries-no-default
+    impl: {path: scripts/gate_exhaustive_dispatch.py, symbol: grade}
+    reference: {path: scripts/gate_exhaustive_dispatch.py, symbol: enum_members}
+    guard:
+      path: scripts/gate_exhaustive_dispatch.py
+      symbol: grade_site
+      # The finding string the check emits. Deliberately a literal rather than
+      # a regex over source structure: this guard's job is to prove the check
+      # itself is still present in grade_site, and a guard written as clever
+      # pattern-matching is one more thing that can quietly stop matching.
+      pattern: 'carries a .default:.'
+    evidence:
+      trace_name_pattern: '^closed_enum_dispatch_exhaustive$'
+      max_age_days: 45
+
+  # 14b. The AD node registry as key-space-equality — the cheap, grep-fidelity
+  #     half of the same property.  A node type may not exist in the enum
+  #     without a registry row declaring what its reverse pass does, because
+  #     the enum IS generated from those rows.  This encodes the requirement so
+  #     a future change that un-generates the enum (returning to a hand-written
+  #     member list) is caught by the key spaces diverging rather than by
+  #     someone noticing.
+  - id: INV-ad-node-declared-in-registry
+    kind: key-space-equality
+    incident: ad-node-type-without-backward-disposition
+    severity: critical
+    fidelity: grep
+    description: >
+      Every AD node type is declared in inc/eshkol/ad_node_registry.def, which
+      states its payload kind and what eshkol_tensor_backward_dispatch does for
+      it — a registered backward, a registered refusal, or an explicit "its
+      adjoint lives on the scalar sweep" — and the enum, the dispatch arms and
+      the backward table are all generated from those rows.  The checkable
+      equality is the one the generation cannot enforce on its own: every row
+      that CLAIMS a bridge backward must name a function that is actually
+      DEFINED, and every backward function that exists must be claimed by a
+      row.  A row naming a missing function already fails to compile; this
+      catches the other direction — a backward rule that exists, works, and is
+      wired to nothing, which is how seven bridge ops sat with correct
+      backwards registered while the dispatcher dropped their gradients.
+    sites:
+      - id: ad-node-registry-bridge-rows
+        path: inc/eshkol/ad_node_registry.def
+        key_pattern: '^ESHKOL_AD_NODE\([^)]*\bBRIDGE,\s*(\w+)\)'
+      - id: bridge-backward-definitions
+        path: lib/bridge/tensor_backward.cpp
+        key_pattern: '^extern "C" void (tensor_\w+_backward)\(ad_node_t\*'

--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -99,6 +99,33 @@ oracles:
         label: 'Silent-wrong ledger has no duplicate ids across the whole file and every entry has id/bucket/status/title plus closure evidence when not open (scripts/check_ledger_integrity.py)'
         action: python3 scripts/check_ledger_integrity.py
 
+      # ── Closed-enum dispatch (2026-08-26, SW-70) ──────────────────────
+      # The two gates above grade a LEDGER: they answer "is every flaw we
+      # already know about closed", which is a question about bookkeeping.
+      # This one grades the SOURCE, and it exists because the defect it
+      # guards was invisible to every ledger-shaped question. PR #498 found
+      # four tensor AD node types falling into a `default:` that did nothing —
+      # gradients exactly 0.0, no diagnostic, exit 0 — behind a comment
+      # asserting the case was impossible. Auditing the class found four MORE
+      # still live, measured directly on master. Nothing could have reported
+      # them: every AD probe asserts the ops it knows about, and the whole
+      # failure mode is an op nobody thought to name.
+      #
+      # The primary enforcement is the compiler (-Werror=switch
+      # -Werror=switch-enum, or ESHKOL_EXHAUSTIVE_SWITCH_BEGIN per switch),
+      # which cannot appear in a readiness score at all: a build that fails
+      # produces no evidence, only an absence. This criterion is the
+      # source-derived half — it re-derives each enum's members from its own
+      # DEFINITION, so it also catches the case the compiler by construction
+      # cannot, which is the enforcement being REMOVED.
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["closed_enum_dispatch_exhaustive"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'No dispatch switch over a closed enum carries a `default:`: every registered site names every member of its enum (re-derived from the enum definition, not from a hand-typed list) and is armed by -Werror=switch-enum or ESHKOL_EXHAUSTIVE_SWITCH_BEGIN; every ad_node_registry.def row declaring BRIDGE names a backward that is actually defined (scripts/gate_exhaustive_dispatch.py)'
+        action: python3 scripts/gate_exhaustive_dispatch.py
+
       # ── AD carrier wave (2026-08-25) ──────────────────────────────────
       # Eshkol differentiates on two substrates. Until now the only check
       # that compared them compared PROGRAM OUTPUT, and two independently

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -2231,6 +2231,150 @@ entries:
       counted as covered. Nested/second-order `derivative` on the VM raises a LOUD,
       honest "not supported on the VM" error today, so no silent path reaches it.
 
+
+  - id: SW-70
+    bucket: SILENT-WRONG
+    status: guarded
+    guarded_by: "branch fix/exhaustive-dispatch"
+    title: "a dispatch switch's `default:` encoded an assumption instead of failing, so four tensor AD node types returned gradients of exactly 0.0 with no diagnostic and exit 0"
+    mechanism: >-
+      THE CLASS, not one bug: a dispatch switch over a CLOSED enum, carrying a
+      `default:` that encodes an ASSUMPTION instead of failing, in a language
+      where the enum can grow without the switch ever knowing.
+
+      The instance PR #498 found: eshkol_tensor_backward_dispatch's `default:`
+      carried the comment "Every TENSOR op (19-32 and the qLLM bridge ops
+      67-80) has an explicit case above, so a tensor-op gradient can never
+      silently fall through this default." That is a proxy — a NUMERIC BAND of
+      enum values — standing in for the property that actually mattered, and
+      it was false the moment a tensor node type was declared outside the
+      band. Four had been. Their gradients came back exactly 0.0, no output,
+      exit 0.
+
+      THE SAME DEFECT IS STILL LIVE ON master IN FOUR MORE NODE TYPES, and
+      this entry is the measurement that found them rather than a restatement
+      of #498. AD_NODE_HYPERBOLIC_DISTANCE (33), AD_NODE_POINCARE_EXP_MAP
+      (34), AD_NODE_POINCARE_LOG_MAP (35) and AD_NODE_GEODESIC_ATTENTION (37)
+      are recorded on the tape as TENSOR nodes by lib/bridge/qllm_bridge.cpp —
+      make_node(tape, AD_NODE_..., out, shape, ...) with a live tensor_value —
+      and autodiff_codegen.cpp's emitted reverse sweep routes ANY node with a
+      non-null tensor_gradient to eshkol_tensor_backward_dispatch. 33-40 is
+      exactly the band the old comment did not cover. Every gradient through
+      a Poincare exp/log map, a hyperbolic distance or a geodesic attention
+      returned zero, silently. (These four DO have an adjoint on the OTHER
+      reverse sweep — codegen emits scalar backward blocks for node types
+      33-40 — which is why the gap survived review: the adjoint exists, just
+      not on the sweep the bridge's tensor nodes actually take.)
+
+      The identical shape is ESH-0214d one subsystem over: evac_kind_for's
+      `default: return EVAC_LEAF` answered "heap subtype I have not thought
+      about" with "self-contained, a memcpy is enough", and
+      KB/FACT/SUBSTITUTION/WORKSPACE were shallow-copied with their interior
+      pointers left aimed into an arena that had already been reclaimed.
+
+      The VACUOUS-ASSURANCE half is the comment. Both defaults were annotated
+      with an argument for why they were unreachable, and in both cases the
+      comment was the ONLY thing enforcing the claim. A comment enforces
+      nothing; it cannot fail, cannot be re-derived, and does not notice an
+      enum growing underneath it. An invariant a human has to re-check on
+      every enum edit is not an invariant.
+    reproducer: >-
+      tests/backend/exhaustive_dispatch_test.cpp —
+      geodesic_attention_backward_refuses, hyperbolic_distance_backward_refuses,
+      poincare_exp_map_backward_refuses, poincare_log_map_backward_refuses
+      (fork death tests), plus ad_node_registry_is_dense and
+      every_bridge_row_resolves_to_a_registered_backward. Each builds a tensor
+      node of that type with a seeded all-ones tensor_gradient and a variable
+      input, and runs eshkol_tensor_backward_dispatch on it.
+
+      MEASURED DIRECTLY ON master (afbaaf5b), not inferred from the source:
+      the same four probes each printed "returned normally; input grad = STILL
+      NULL (nothing propagated)" and the process exited 0. On this branch all
+      four abort with the node type named.
+    observed: "no gradient propagated at all (the input node's tensor_gradient was never even allocated); no stderr output; exit 0"
+    correct: "the exact adjoint, or a loud, named refusal — never a plausible zero"
+    resolution: >-
+      GUARDED, and the distinction matters: the wrong VALUE is gone but four of
+      the eight geometric node types still cannot compute the right one. They
+      are declared UNREGISTERED in inc/eshkol/ad_node_registry.def — an
+      EXPLICIT, written-down refusal — and the dispatcher aborts naming the
+      node type instead of returning zero. Writing exact Riemannian adjoints
+      is AD work with its own correctness bar and belongs to the lane doing
+      it; inventing one to close a dispatch hole is how a wrong gradient
+      ships. The entry stays on the ledger until those adjoints land.
+    fixed_by: >-
+      branch fix/exhaustive-dispatch — the class is closed at the
+      architectural root rather than at the four sites.
+      (1) inc/eshkol/ad_node_registry.def is now the single declaration point
+      for an AD node type: name, value, payload kind, and what
+      eshkol_tensor_backward_dispatch does for it. The ad_node_type_t enum,
+      the dispatcher's homogeneous arms and the bridge backward table are all
+      GENERATED from those rows, so a node type cannot exist without stating
+      its backward disposition, and a row claiming BRIDGE must name a function
+      that exists or lib/bridge/tensor_backward.cpp does not compile.
+      (2) The dispatch switches over ad_node_type_t, heap_subtype_t and
+      callable_subtype_t carry no `default:` and are compiled with
+      -Werror=switch -Werror=switch-enum (per translation unit, via
+      eshkol_require_exhaustive_dispatch in CMakeLists.txt) or wrapped in
+      ESHKOL_EXHAUSTIVE_SWITCH_BEGIN/_END (per switch, inc/eshkol/
+      exhaustive_dispatch.h). Adding an enum member without handling it is now
+      a BUILD FAILURE.
+      (3) Where the dispatched value comes from outside the program — a
+      subtype byte read off an object header — the open half is separated out
+      by eshkol_heap_subtype_is_declared / eshkol_callable_subtype_is_declared
+      and answered by a loud, value-naming fallback, so the closed half can be
+      exhaustive without pretending a corrupt byte is impossible.
+      (4) scripts/gate_exhaustive_dispatch.py re-derives each enum's members
+      from its own DEFINITION and fails on any registered site that carries a
+      default, omits a member, or is not armed. One registered site — the
+      ESH-0214d watchlist in evac_object — lives inside `#ifndef NDEBUG`, so
+      the COMPILER never sees it in the release builds CI actually runs; that
+      site is guarded by this gate alone, which is the concrete reason the
+      source-derived half is not redundant with the flags — the half the compiler cannot
+      provide on MSVC, and the half that catches the enforcement being removed.
+      Wired into ctest (exhaustive_dispatch_gate /
+      exhaustive_dispatch_gate_selftest), the `assurance-gates` CI job — which
+      runs on every PR shape, including docs-only ones where no build happens
+      and a change deleting the CMake arming would otherwise go unmeasured —
+      and the INV-closed-enum-dispatch-exhaustive invariant.
+    evidence: >-
+      COMPILE-TIME RED PROOF, measured on this branch, not asserted. Appending
+      one row to ad_node_registry.def with disposition INLINE and no
+      hand-written arm: "error: enumeration value 'AD_NODE_REDPROOF_NEW_OP'
+      not handled in switch [-Werror,-Wswitch]" — the build stops. Re-adding a
+      `default:` to that same switch and repeating: "error: enumeration value
+      'AD_NODE_REDPROOF_NEW_OP' not explicitly handled in switch
+      [-Werror,-Wswitch-enum]" — the default cannot defeat the flag, which is
+      why both diagnostics are escalated and not just one. Re-adding a
+      `default:` with no new member compiles (the default is then dead code)
+      and is caught instead by the source-derived gate: "carries a `default:`
+      — a default over a closed enum answers 'member I have not thought
+      about' with a plausible value". GATE RED PROOF: six self-test fixtures,
+      including one whose default is annotated with an it-cannot-happen
+      comment — the #498 shape exactly — proving the gate is not fooled by the
+      annotation that fooled review.
+    caught_by: [pr-498-review, architectural-audit-2026-08-26, direct-measurement]
+    missed_by: [icc-smoke, icc-readiness, ad-oracle, vm-parity-differential]
+    notes: >-
+      SCOPE, recorded so this entry is not read as more than it is. 179
+      switches with three or more enum-member case labels were inventoried;
+      they are NOT all this defect. The discriminator is what the default
+      DOES: a default that produces a RESULT (a gradient, an evacuation
+      classification, a type name) silently answers for members nobody
+      considered; a default that REFUSES (kb_persistence's
+      eshkol_error+return false, runtime_taylor's ok-flag refusal) is a
+      partial classification stating its own boundary and is correct as
+      written. Converted here: the AD/tensor dispatch and the evacuator paths
+      in full, plus the heap/callable-subtype dispatch in display,
+      introspection and error formatting. Left as loud backstops, correctly:
+      the VM's OpCode and ValType switches, which dispatch on bytes read from
+      bytecode — an OPEN set whatever the enum declares, where exhaustiveness
+      would be enforcing a fiction. Deferred as a build item with the
+      mechanism proven: lib/core/sexp_to_ast.cpp's heap-subtype switch, whose
+      `default: break` falls through to a null AST rather than refusing, and
+      the ~20 eshkol_op_t switches (113 members) whose conversion is a large
+      mechanical diff that does not belong in the same change as the fix.
+
   # ───────────────────────── IN-FLIGHT ─────────────────────────
 
   - id: IF-01

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2273,6 +2273,71 @@ if(DEFINED ESHKOL_GENERATED_INCLUDE_DIR)
     )
 endif()
 
+# ───────────────────────────────────────────────────────────────────────────
+# EXHAUSTIVE CLOSED-ENUM DISPATCH  (see inc/eshkol/exhaustive_dispatch.h)
+#
+# PR #498 found four tensor-valued AD node types falling into an early
+# `default:` in eshkol_tensor_backward_dispatch that did nothing: gradients
+# exactly 0.0, no diagnostic, exit 0. The default's comment asserted the case
+# was impossible, reasoning from a numeric band of enum values that the four
+# new node types had already left. The same shape produced ESH-0214d, where
+# heap subtypes dropped to a shallow-leaf `default:` in the region evacuator.
+#
+# The files below own dispatch over CLOSED enums — enums the program itself
+# produces every value of — and their switches carry no `default:`. Compiling
+# them with -Werror=switch -Werror=switch-enum turns "someone added an enum
+# member and did not handle it here" from a runtime silence into a build
+# failure. Both flags are needed: -Wswitch is the one that fires for an
+# unhandled member in a default-less switch, and -Wswitch-enum is the one that
+# still fires once someone re-adds a `default:` — which is precisely the move
+# that reopens this class, and precisely where -Wswitch goes quiet.
+#
+# SCOPE IS DELIBERATELY NARROW. This is set per source file, not globally:
+# switches over values that arrive from OUTSIDE the program (bytecode opcodes,
+# serialized subtype bytes, FFI integers) are dispatching over an open set and
+# must keep a default — a LOUD, value-naming abort. Arming those files would
+# force a dishonest exhaustiveness onto genuinely open dispatch. Individual
+# switches inside otherwise-unarmed files use ESHKOL_EXHAUSTIVE_SWITCH_BEGIN /
+# _END from inc/eshkol/exhaustive_dispatch.h instead.
+#
+# MSVC has no equivalent diagnostic; on that toolchain the property is carried
+# by the other compilers in the matrix, and the ICC invariant
+# INV-closed-enum-dispatch-exhaustive re-derives it from source on every lane.
+function(eshkol_require_exhaustive_dispatch)
+    if(ESHKOL_USING_MSVC)
+        return()
+    endif()
+    foreach(_src ${ARGN})
+        get_source_file_property(_existing "${_src}" COMPILE_OPTIONS)
+        if(_existing STREQUAL "NOTFOUND")
+            set(_existing "")
+        endif()
+        # BOTH diagnostics, because they are not redundant and each covers a
+        # hole the other leaves. -Wswitch is what actually fires for a member
+        # unhandled in a switch that has no default (measured: adding an AD
+        # node type with no arm reports under -Wswitch, so escalating only
+        # -Wswitch-enum would have shipped a red-proof that produced a warning
+        # and a green build). -Wswitch-enum is what still fires when someone
+        # re-adds a `default:` — the exact move that reopens this class, and
+        # the one -Wswitch goes silent for.
+        list(APPEND _existing "-Werror=switch" "-Werror=switch-enum")
+        set_source_files_properties("${_src}" PROPERTIES COMPILE_OPTIONS "${_existing}")
+    endforeach()
+endfunction()
+
+eshkol_require_exhaustive_dispatch(
+  # Reverse-mode AD dispatch over ad_node_type_t. The #498 site itself: the
+  # switch is generated-plus-hand-written from inc/eshkol/ad_node_registry.def
+  # and names all 83 node types with no default.
+  lib/backend/tensor_backward.cpp
+  # The bridge backward table, generated from the same registry rows.
+  lib/bridge/tensor_backward.cpp
+  # Region evacuation: heap_subtype_t -> EvacKind classification and the
+  # EvacKind interior-walk switch. The ESH-0214d class — a subtype that falls
+  # to a shallow leaf copy leaves interior pointers in a reclaimed arena.
+  lib/core/runtime_regions.cpp
+)
+
 function(eshkol_apply_common_compile_settings target_name)
     target_include_directories(${target_name} PRIVATE
       "${CMAKE_CURRENT_SOURCE_DIR}/inc/"
@@ -4415,6 +4480,45 @@ endif()
 # layernorm, transpose, sum and attention on identical inputs, plus central
 # finite differences as the tie-breaking oracle. Embedding's bridge-vs-native
 # comparison lives in tensor_embedding_backward_gradcheck_test.cpp above.
+# SW-70: the AD node registry is total and an UNREGISTERED node type refuses
+# rather than returning a plausible zero. The compile-time half of this fix
+# (-Werror=switch -Werror=switch-enum, see eshkol_require_exhaustive_dispatch
+# above) cannot be observed from a test — a build that fails produces no test
+# run at all — so this covers what remains: registry density, name and payload
+# totality, table/disposition agreement, and the four qLLM geometric node
+# types actually refusing under a live upstream gradient.
+if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/backend/exhaustive_dispatch_test.cpp")
+    add_executable(exhaustive_dispatch_test tests/backend/exhaustive_dispatch_test.cpp)
+    target_compile_features(exhaustive_dispatch_test PRIVATE cxx_std_17)
+    target_include_directories(exhaustive_dispatch_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+    eshkol_target_llvm_includes(exhaustive_dispatch_test)
+    if(LLVM_LIBRARY_DIRS)
+        target_link_directories(exhaustive_dispatch_test PRIVATE ${LLVM_LIBRARY_DIRS})
+    endif()
+    target_link_libraries(exhaustive_dispatch_test PRIVATE eshkol-static ${ESHKOL_EXTRA_LINK_LIBS} ${LLVM_LIBS_LIST} ${LLVM_SYSTEM_LIBS_LIST})
+    add_test(NAME exhaustive_dispatch COMMAND exhaustive_dispatch_test)
+    set_tests_properties(exhaustive_dispatch PROPERTIES
+        PASS_REGULAR_EXPRESSION "0 failed")
+endif()
+
+# The source-derived half of the same invariant: no registered dispatch site
+# may carry a `default:`, every enum member must be named, and the arming
+# (CMake flag or ESHKOL_EXHAUSTIVE_SWITCH_BEGIN) must still be in place. This
+# is what catches the enforcement being REMOVED, which the compiler by
+# definition cannot.
+find_program(ESHKOL_PYTHON3_EXECUTABLE NAMES python3 python)
+if(ESHKOL_BUILD_TESTS AND ESHKOL_PYTHON3_EXECUTABLE AND
+   EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/gate_exhaustive_dispatch.py")
+    add_test(NAME exhaustive_dispatch_gate
+             COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                     "${CMAKE_CURRENT_SOURCE_DIR}/scripts/gate_exhaustive_dispatch.py"
+                     --trace-dir "${CMAKE_CURRENT_SOURCE_DIR}/scripts/icc_traces")
+    add_test(NAME exhaustive_dispatch_gate_selftest
+             COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                     "${CMAKE_CURRENT_SOURCE_DIR}/scripts/gate_exhaustive_dispatch.py"
+                     --self-test)
+endif()
+
 if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/backend/tensor_backward_dual_impl_gradcheck_test.cpp")
     add_executable(tensor_backward_dual_impl_gradcheck_test
         tests/backend/tensor_backward_dual_impl_gradcheck_test.cpp)

--- a/docs/design/abi/header-site-inventory.json
+++ b/docs/design/abi/header-site-inventory.json
@@ -1,5 +1,5 @@
 {
-  "commit": "892622c0f628f61bc5c829fb63f1cac4606c8553",
+  "commit": "61935eef779b3f1764c36f72208c2bfccea23810",
   "counts": {
     "A_macro_api": {
       "inc/eshkol/eshkol.h": 32,
@@ -161,14 +161,14 @@
       "lib/core/dnc_api.c": 3,
       "lib/core/i128_runtime.cpp": 3,
       "lib/core/inference.cpp": 6,
-      "lib/core/introspection.cpp": 8,
+      "lib/core/introspection.cpp": 10,
       "lib/core/kb_persistence.cpp": 7,
       "lib/core/logic.cpp": 10,
       "lib/core/runtime_autodiff.cpp": 4,
       "lib/core/runtime_closure_alloc.cpp": 4,
       "lib/core/runtime_continuations.cpp": 1,
       "lib/core/runtime_deep_equal.cpp": 7,
-      "lib/core/runtime_display_hosted.cpp": 6,
+      "lib/core/runtime_display_hosted.cpp": 8,
       "lib/core/runtime_exceptions_hosted.cpp": 4,
       "lib/core/runtime_hash_table.cpp": 4,
       "lib/core/runtime_object_alloc.cpp": 20,
@@ -395,224 +395,224 @@
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 694,
+      "line": 772,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_GET_HEADER(data_ptr) \\"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 698,
+      "line": 776,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_GET_DATA_PTR(header_ptr) \\"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 702,
+      "line": 780,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_GET_SUBTYPE(data_ptr) \\"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 703,
+      "line": 781,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(ESHKOL_GET_HEADER(data_ptr)->subtype)"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 706,
+      "line": 784,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_GET_FLAGS(data_ptr) \\"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 707,
+      "line": 785,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(ESHKOL_GET_HEADER(data_ptr)->flags)"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 710,
+      "line": 788,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_SET_SUBTYPE(data_ptr, st) \\"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 711,
+      "line": 789,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(ESHKOL_GET_HEADER(data_ptr)->subtype = (st))"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 714,
+      "line": 792,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_SET_FLAGS(data_ptr, fl) \\"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 715,
+      "line": 793,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(ESHKOL_GET_HEADER(data_ptr)->flags = (fl))"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 718,
+      "line": 796,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_HAS_FLAG(data_ptr, flag) \\"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 719,
+      "line": 797,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "((ESHKOL_GET_FLAGS(data_ptr) & (flag)) != 0)"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 722,
+      "line": 800,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_ADD_FLAG(data_ptr, flag) \\"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 723,
+      "line": 801,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(ESHKOL_GET_HEADER(data_ptr)->flags |= (flag))"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 726,
+      "line": 804,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_CLEAR_FLAG(data_ptr, flag) \\"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 727,
+      "line": 805,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(ESHKOL_GET_HEADER(data_ptr)->flags &= ~(flag))"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 731,
+      "line": 809,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(ESHKOL_GET_HEADER(data_ptr)->size)"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 735,
+      "line": 813,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(ESHKOL_GET_HEADER(data_ptr)->ref_count)"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 739,
+      "line": 817,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(++(ESHKOL_GET_HEADER(data_ptr)->ref_count))"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 743,
+      "line": 821,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(--(ESHKOL_GET_HEADER(data_ptr)->ref_count))"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 759,
+      "line": 837,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == HEAP_SUBTYPE_CONS))"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 766,
+      "line": 844,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == HEAP_SUBTYPE_STRING))"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 773,
+      "line": 851,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == HEAP_SUBTYPE_VECTOR))"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 780,
+      "line": 858,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == HEAP_SUBTYPE_TENSOR))"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 787,
+      "line": 865,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == HEAP_SUBTYPE_HASH))"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 794,
+      "line": 872,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == HEAP_SUBTYPE_EXCEPTION))"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 800,
+      "line": 878,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == HEAP_SUBTYPE_MULTI_VALUE)"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 806,
+      "line": 884,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == HEAP_SUBTYPE_BIGNUM)"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 813,
+      "line": 891,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == CALLABLE_SUBTYPE_CLOSURE))"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 820,
+      "line": 898,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == CALLABLE_SUBTYPE_LAMBDA_SEXPR))"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 827,
+      "line": 905,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == CALLABLE_SUBTYPE_AD_NODE))"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 1242,
+      "line": 1254,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "eshkol_object_header_t* header = ESHKOL_GET_HEADER((void*)ptr);"
     },
@@ -689,42 +689,42 @@
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 218,
+      "line": 219,
       "path": "lib/core/introspection.cpp",
       "snippet": "ESHKOL_GET_HEADER(reinterpret_cast<void*>(value.data.ptr_val));"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 288,
+      "line": 289,
       "path": "lib/core/introspection.cpp",
       "snippet": "eshkol_object_header_t* header = ESHKOL_GET_HEADER(reinterpret_cast<void*>(ptr));"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 367,
+      "line": 368,
       "path": "lib/core/introspection.cpp",
       "snippet": "eshkol_object_header_t* header = ESHKOL_GET_HEADER(ptr);"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 672,
+      "line": 673,
       "path": "lib/core/introspection.cpp",
       "snippet": "eshkol_object_header_t* header = ESHKOL_GET_HEADER(ptr);"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 1307,
+      "line": 1308,
       "path": "lib/core/introspection.cpp",
       "snippet": "eshkol_object_header_t* header = ESHKOL_GET_HEADER(ptr);"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 1378,
+      "line": 1414,
       "path": "lib/core/introspection.cpp",
       "snippet": "eshkol_object_header_t* header = ESHKOL_GET_HEADER(ptr);"
     },
@@ -864,21 +864,21 @@
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 321,
+      "line": 322,
       "path": "lib/core/runtime_display_hosted.cpp",
       "snippet": "eshkol_object_header_t* header = ESHKOL_GET_HEADER(data_ptr);"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 420,
+      "line": 460,
       "path": "lib/core/runtime_display_hosted.cpp",
       "snippet": "eshkol_object_header_t* header = ESHKOL_GET_HEADER(data_ptr);"
     },
     {
       "cls": "A_macro_api",
       "detector": "A_macro_api",
-      "line": 647,
+      "line": 690,
       "path": "lib/core/runtime_display_hosted.cpp",
       "snippet": "eshkol_object_header_t* hdr = ESHKOL_GET_HEADER(cdr_ptr);"
     },
@@ -1200,14 +1200,14 @@
     {
       "cls": "B_header_type",
       "detector": "B_header_type",
-      "line": 494,
+      "line": 496,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "typedef struct eshkol_object_header {"
     },
     {
       "cls": "B_header_type",
       "detector": "B_header_type",
-      "line": 499,
+      "line": 501,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "} eshkol_object_header_t;"
     },
@@ -1361,7 +1361,7 @@
     {
       "cls": "B_header_type",
       "detector": "B_header_type",
-      "line": 217,
+      "line": 218,
       "path": "lib/core/introspection.cpp",
       "snippet": "eshkol_object_header_t* hdr ="
     },
@@ -1431,21 +1431,21 @@
     {
       "cls": "B_header_type",
       "detector": "B_header_type",
-      "line": 1085,
+      "line": 1086,
       "path": "lib/core/runtime_regions.cpp",
       "snippet": "const auto* h = (const eshkol_object_header_t*)"
     },
     {
       "cls": "B_header_type",
       "detector": "B_header_type",
-      "line": 1255,
+      "line": 1305,
       "path": "lib/core/runtime_regions.cpp",
       "snippet": "const auto* dh = (const eshkol_object_header_t*)"
     },
     {
       "cls": "B_header_type",
       "detector": "B_header_type",
-      "line": 2266,
+      "line": 2356,
       "path": "lib/core/runtime_regions.cpp",
       "snippet": "const auto* hdr = (const eshkol_object_header_t*)"
     },
@@ -1690,21 +1690,21 @@
     {
       "cls": "C_sizeof_header",
       "detector": "C_sizeof_header",
-      "line": 502,
+      "line": 504,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_STATIC_ASSERT(sizeof(eshkol_object_header_t) == 8,"
     },
     {
       "cls": "C_sizeof_header",
       "detector": "C_sizeof_header",
-      "line": 695,
+      "line": 773,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "((eshkol_object_header_t*)((uint8_t*)(data_ptr) - sizeof(eshkol_object_header_t)))"
     },
     {
       "cls": "C_sizeof_header",
       "detector": "C_sizeof_header",
-      "line": 699,
+      "line": 777,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "((void*)((uint8_t*)(header_ptr) + sizeof(eshkol_object_header_t)))"
     },
@@ -1977,42 +1977,42 @@
     {
       "cls": "C_sizeof_header",
       "detector": "C_sizeof_header",
-      "line": 1086,
+      "line": 1087,
       "path": "lib/core/runtime_regions.cpp",
       "snippet": "((const uint8_t*)old_data - sizeof(eshkol_object_header_t));"
     },
     {
       "cls": "C_sizeof_header",
       "detector": "C_sizeof_header",
-      "line": 1215,
+      "line": 1265,
       "path": "lib/core/runtime_regions.cpp",
       "snippet": "auto* h = (eshkol_object_header_t*)((uint8_t*)old_data - sizeof(eshkol_object_header_t));"
     },
     {
       "cls": "C_sizeof_header",
       "detector": "C_sizeof_header",
-      "line": 1216,
+      "line": 1266,
       "path": "lib/core/runtime_regions.cpp",
       "snippet": "const size_t total = sizeof(eshkol_object_header_t) + h->size;"
     },
     {
       "cls": "C_sizeof_header",
       "detector": "C_sizeof_header",
-      "line": 1238,
+      "line": 1288,
       "path": "lib/core/runtime_regions.cpp",
       "snippet": "void* new_data = (uint8_t*)raw + sizeof(eshkol_object_header_t);"
     },
     {
       "cls": "C_sizeof_header",
       "detector": "C_sizeof_header",
-      "line": 1256,
+      "line": 1306,
       "path": "lib/core/runtime_regions.cpp",
       "snippet": "((const uint8_t*)new_data - sizeof(eshkol_object_header_t));"
     },
     {
       "cls": "C_sizeof_header",
       "detector": "C_sizeof_header",
-      "line": 2267,
+      "line": 2357,
       "path": "lib/core/runtime_regions.cpp",
       "snippet": "((const uint8_t*)(uintptr_t)v->data.ptr_val - sizeof(eshkol_object_header_t));"
     },
@@ -2656,7 +2656,7 @@
     {
       "cls": "E_alloc_with_header",
       "detector": "E_alloc_with_header",
-      "line": 1407,
+      "line": 1419,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "eshkol_exception_t* eshkol_make_exception_with_header(eshkol_exception_type_t type, const char* message);"
     },
@@ -2964,14 +2964,14 @@
     {
       "cls": "E_alloc_with_header",
       "detector": "E_alloc_with_header",
-      "line": 243,
+      "line": 244,
       "path": "lib/core/introspection.cpp",
       "snippet": "arena_tagged_cons_cell_t* cell = arena_allocate_cons_with_header(a);"
     },
     {
       "cls": "E_alloc_with_header",
       "detector": "E_alloc_with_header",
-      "line": 546,
+      "line": 547,
       "path": "lib/core/introspection.cpp",
       "snippet": "char* str_copy = arena_allocate_string_with_header(a, len);"
     },
@@ -3216,7 +3216,7 @@
     {
       "cls": "E_alloc_with_header",
       "detector": "E_alloc_with_header",
-      "line": 211,
+      "line": 212,
       "path": "lib/core/runtime_display_hosted.cpp",
       "snippet": "char* str = (char*)arena_allocate_with_header("
     },
@@ -3398,7 +3398,7 @@
     {
       "cls": "E_alloc_with_header",
       "detector": "E_alloc_with_header",
-      "line": 863,
+      "line": 864,
       "path": "lib/core/runtime_regions.cpp",
       "snippet": "auto* copy = (char*)arena_allocate_string_with_header(region_escape_target(current), len);"
     },
@@ -3790,7 +3790,7 @@
     {
       "cls": "F_parallel_header_decl",
       "detector": "F_parallel_header_decl",
-      "line": 494,
+      "line": 496,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "eshkol_object_header_t: typedef struct eshkol_object_header {"
     },
@@ -3804,7 +3804,7 @@
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 1243,
+      "line": 1255,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "if (header->subtype != CALLABLE_SUBTYPE_CLOSURE) {"
     },
@@ -3986,28 +3986,28 @@
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 219,
+      "line": 220,
       "path": "lib/core/introspection.cpp",
       "snippet": "return hdr && hdr->subtype == HEAP_SUBTYPE_SYMBOL;"
     },
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 289,
+      "line": 290,
       "path": "lib/core/introspection.cpp",
       "snippet": "return header && header->subtype == CALLABLE_SUBTYPE_PRIMITIVE;"
     },
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 368,
+      "line": 369,
       "path": "lib/core/introspection.cpp",
       "snippet": "if (header && header->subtype == CALLABLE_SUBTYPE_CONTINUATION) {"
     },
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 673,
+      "line": 674,
       "path": "lib/core/introspection.cpp",
       "snippet": "if (header && header->subtype == CALLABLE_SUBTYPE_PRIMITIVE) {"
     },
@@ -4016,28 +4016,42 @@
       "detector": "G_header_field_write",
       "line": 1309,
       "path": "lib/core/introspection.cpp",
-      "snippet": "switch (header->subtype) {"
+      "snippet": "if (header && !eshkol_heap_subtype_is_declared(header->subtype)) {"
     },
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 1365,
+      "line": 1313,
       "path": "lib/core/introspection.cpp",
-      "snippet": "eshkol_warn(\"unknown heap subtype: %d\", header->subtype);"
+      "snippet": "eshkol_warn(\"undeclared heap subtype: %d\", header->subtype);"
     },
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 1380,
+      "line": 1322,
       "path": "lib/core/introspection.cpp",
-      "snippet": "switch (header->subtype) {"
+      "snippet": "switch ((heap_subtype_t)header->subtype) {"
     },
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 1397,
+      "line": 1415,
       "path": "lib/core/introspection.cpp",
-      "snippet": "eshkol_warn(\"unknown callable subtype: %d\", header->subtype);"
+      "snippet": "if (header && !eshkol_callable_subtype_is_declared(header->subtype)) {"
+    },
+    {
+      "cls": "G_header_field_write",
+      "detector": "G_header_field_write",
+      "line": 1416,
+      "path": "lib/core/introspection.cpp",
+      "snippet": "eshkol_warn(\"undeclared callable subtype: %d\", header->subtype);"
+    },
+    {
+      "cls": "G_header_field_write",
+      "detector": "G_header_field_write",
+      "line": 1420,
+      "path": "lib/core/introspection.cpp",
+      "snippet": "switch ((callable_subtype_t)header->subtype) {"
     },
     {
       "cls": "G_header_field_write",
@@ -4273,42 +4287,56 @@
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 322,
+      "line": 323,
       "path": "lib/core/runtime_display_hosted.cpp",
-      "snippet": "switch (header->subtype) {"
+      "snippet": "if (!eshkol_heap_subtype_is_declared(header->subtype)) {"
     },
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 336,
-      "path": "lib/core/runtime_display_hosted.cpp",
-      "snippet": "size_t payload = (header->size > 0) ? (size_t)header->size - 1 : 0;"
-    },
-    {
-      "cls": "G_header_field_write",
-      "detector": "G_header_field_write",
-      "line": 407,
+      "line": 327,
       "path": "lib/core/runtime_display_hosted.cpp",
       "snippet": "fprintf(get_output(opts), \"#<heap:%d>\", header->subtype);"
     },
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 421,
+      "line": 337,
       "path": "lib/core/runtime_display_hosted.cpp",
-      "snippet": "switch (header->subtype) {"
+      "snippet": "switch ((heap_subtype_t)header->subtype) {"
     },
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 438,
+      "line": 351,
+      "path": "lib/core/runtime_display_hosted.cpp",
+      "snippet": "size_t payload = (header->size > 0) ? (size_t)header->size - 1 : 0;"
+    },
+    {
+      "cls": "G_header_field_write",
+      "detector": "G_header_field_write",
+      "line": 461,
+      "path": "lib/core/runtime_display_hosted.cpp",
+      "snippet": "if (!eshkol_callable_subtype_is_declared(header->subtype)) {"
+    },
+    {
+      "cls": "G_header_field_write",
+      "detector": "G_header_field_write",
+      "line": 462,
       "path": "lib/core/runtime_display_hosted.cpp",
       "snippet": "fprintf(get_output(opts), \"#<callable:%d>\", header->subtype);"
     },
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 648,
+      "line": 466,
+      "path": "lib/core/runtime_display_hosted.cpp",
+      "snippet": "switch ((callable_subtype_t)header->subtype) {"
+    },
+    {
+      "cls": "G_header_field_write",
+      "detector": "G_header_field_write",
+      "line": 691,
       "path": "lib/core/runtime_display_hosted.cpp",
       "snippet": "if (hdr->subtype == HEAP_SUBTYPE_CONS) {"
     },
@@ -4511,35 +4539,35 @@
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 1087,
+      "line": 1088,
       "path": "lib/core/runtime_regions.cpp",
       "snippet": "const uint8_t sub = h->subtype;"
     },
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 1217,
+      "line": 1267,
       "path": "lib/core/runtime_regions.cpp",
       "snippet": "if (h->size == 0) return old_data;  // nothing to copy; leave in place"
     },
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 1225,
+      "line": 1275,
       "path": "lib/core/runtime_regions.cpp",
       "snippet": "if (h->size > (uint32_t)0x10000000u) {  // 256MB: far above any real object"
     },
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 1228,
+      "line": 1278,
       "path": "lib/core/runtime_regions.cpp",
       "snippet": "(unsigned)h->size, old_data);"
     },
     {
       "cls": "G_header_field_write",
       "detector": "G_header_field_write",
-      "line": 2268,
+      "line": 2358,
       "path": "lib/core/runtime_regions.cpp",
       "snippet": "if (hdr->subtype == HEAP_SUBTYPE_STRING) {"
     },
@@ -5372,287 +5400,287 @@
     {
       "cls": "I_public_abi",
       "detector": "L_layout_in_prose",
-      "line": 486,
+      "line": 488,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "* @brief 8-byte header prepended to every heap-allocated object."
     },
     {
       "cls": "I_public_abi",
       "detector": "B_header_type",
-      "line": 494,
+      "line": 496,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "typedef struct eshkol_object_header {"
     },
     {
       "cls": "I_public_abi",
       "detector": "B_header_type",
-      "line": 499,
+      "line": 501,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "} eshkol_object_header_t;"
     },
     {
       "cls": "I_public_abi",
       "detector": "C_sizeof_header",
-      "line": 502,
+      "line": 504,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_STATIC_ASSERT(sizeof(eshkol_object_header_t) == 8,"
     },
     {
       "cls": "I_public_abi",
       "detector": "L_layout_in_prose",
-      "line": 690,
+      "line": 768,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "// Memory layout: [header (8 bytes)][object data (variable)]"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 694,
+      "line": 772,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_GET_HEADER(data_ptr) \\"
     },
     {
       "cls": "I_public_abi",
       "detector": "C_sizeof_header",
-      "line": 695,
+      "line": 773,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "((eshkol_object_header_t*)((uint8_t*)(data_ptr) - sizeof(eshkol_object_header_t)))"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 698,
+      "line": 776,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_GET_DATA_PTR(header_ptr) \\"
     },
     {
       "cls": "I_public_abi",
       "detector": "C_sizeof_header",
-      "line": 699,
+      "line": 777,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "((void*)((uint8_t*)(header_ptr) + sizeof(eshkol_object_header_t)))"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 702,
+      "line": 780,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_GET_SUBTYPE(data_ptr) \\"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 703,
+      "line": 781,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(ESHKOL_GET_HEADER(data_ptr)->subtype)"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 706,
+      "line": 784,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_GET_FLAGS(data_ptr) \\"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 707,
+      "line": 785,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(ESHKOL_GET_HEADER(data_ptr)->flags)"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 710,
+      "line": 788,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_SET_SUBTYPE(data_ptr, st) \\"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 711,
+      "line": 789,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(ESHKOL_GET_HEADER(data_ptr)->subtype = (st))"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 714,
+      "line": 792,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_SET_FLAGS(data_ptr, fl) \\"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 715,
+      "line": 793,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(ESHKOL_GET_HEADER(data_ptr)->flags = (fl))"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 718,
+      "line": 796,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_HAS_FLAG(data_ptr, flag) \\"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 719,
+      "line": 797,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "((ESHKOL_GET_FLAGS(data_ptr) & (flag)) != 0)"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 722,
+      "line": 800,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_ADD_FLAG(data_ptr, flag) \\"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 723,
+      "line": 801,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(ESHKOL_GET_HEADER(data_ptr)->flags |= (flag))"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 726,
+      "line": 804,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "#define ESHKOL_CLEAR_FLAG(data_ptr, flag) \\"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 727,
+      "line": 805,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(ESHKOL_GET_HEADER(data_ptr)->flags &= ~(flag))"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 731,
+      "line": 809,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(ESHKOL_GET_HEADER(data_ptr)->size)"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 735,
+      "line": 813,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(ESHKOL_GET_HEADER(data_ptr)->ref_count)"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 739,
+      "line": 817,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(++(ESHKOL_GET_HEADER(data_ptr)->ref_count))"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 743,
+      "line": 821,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "(--(ESHKOL_GET_HEADER(data_ptr)->ref_count))"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 759,
+      "line": 837,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == HEAP_SUBTYPE_CONS))"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 766,
+      "line": 844,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == HEAP_SUBTYPE_STRING))"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 773,
+      "line": 851,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == HEAP_SUBTYPE_VECTOR))"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 780,
+      "line": 858,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == HEAP_SUBTYPE_TENSOR))"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 787,
+      "line": 865,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == HEAP_SUBTYPE_HASH))"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 794,
+      "line": 872,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == HEAP_SUBTYPE_EXCEPTION))"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 800,
+      "line": 878,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == HEAP_SUBTYPE_MULTI_VALUE)"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 806,
+      "line": 884,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == HEAP_SUBTYPE_BIGNUM)"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 813,
+      "line": 891,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == CALLABLE_SUBTYPE_CLOSURE))"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 820,
+      "line": 898,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == CALLABLE_SUBTYPE_LAMBDA_SEXPR))"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 827,
+      "line": 905,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "ESHKOL_GET_SUBTYPE((void*)(val).data.ptr_val) == CALLABLE_SUBTYPE_AD_NODE))"
     },
     {
       "cls": "I_public_abi",
       "detector": "A_macro_api",
-      "line": 1242,
+      "line": 1254,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "eshkol_object_header_t* header = ESHKOL_GET_HEADER((void*)ptr);"
     },
     {
       "cls": "I_public_abi",
       "detector": "G_header_field_write",
-      "line": 1243,
+      "line": 1255,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "if (header->subtype != CALLABLE_SUBTYPE_CLOSURE) {"
     },
     {
       "cls": "I_public_abi",
       "detector": "E_alloc_with_header",
-      "line": 1407,
+      "line": 1419,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "eshkol_exception_t* eshkol_make_exception_with_header(eshkol_exception_type_t type, const char* message);"
     },
@@ -6044,14 +6072,14 @@
     {
       "cls": "K_raw_byte_offset",
       "detector": "K_raw_byte_offset",
-      "line": 212,
+      "line": 213,
       "path": "lib/core/runtime_errors_hosted.cpp",
       "snippet": "uint8_t sub = *((uint8_t*)p - 8);"
     },
     {
       "cls": "K_raw_byte_offset",
       "detector": "K_raw_byte_offset",
-      "line": 222,
+      "line": 236,
       "path": "lib/core/runtime_errors_hosted.cpp",
       "snippet": "uint8_t sub = *((uint8_t*)p - 8);"
     },
@@ -6282,14 +6310,14 @@
     {
       "cls": "L_layout_in_prose",
       "detector": "L_layout_in_prose",
-      "line": 486,
+      "line": 488,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "* @brief 8-byte header prepended to every heap-allocated object."
     },
     {
       "cls": "L_layout_in_prose",
       "detector": "L_layout_in_prose",
-      "line": 690,
+      "line": 768,
       "path": "inc/eshkol/eshkol.h",
       "snippet": "// Memory layout: [header (8 bytes)][object data (variable)]"
     },
@@ -6703,7 +6731,7 @@
       "D_ir_const_offset": 45,
       "E_alloc_with_header": 182,
       "F_parallel_header_decl": 2,
-      "G_header_field_write": 164,
+      "G_header_field_write": 168,
       "H_wasm_glue": 34,
       "I_public_abi": 84,
       "J_secondary_prefix_abi": 33,
@@ -6712,7 +6740,7 @@
       "M_cache_key_without_abi": 2
     },
     "files": 99,
-    "sites": 816,
-    "sites_including_public_view": 900
+    "sites": 820,
+    "sites_including_public_view": 904
   }
 }

--- a/docs/design/abi/header-site-inventory.txt
+++ b/docs/design/abi/header-site-inventory.txt
@@ -1,9 +1,9 @@
 Object-header layout dependence — machine inventory
 ==================================================================
 
-commit        892622c0f628f61bc5c829fb63f1cac4606c8553
+commit        61935eef779b3f1764c36f72208c2bfccea23810
 layout pin    OK
-total sites   816
+total sites   820
 files         99
 semantic      not requested (--clang)
 
@@ -37,7 +37,7 @@ Class breakdown
       what: Struct declarations that structurally duplicate the canonical header under a different name.
       how:  Parse every `typedef struct { ... } Name;` and `struct Name { ... };` body in the tree and compare its field sequence — types and names in order — against the canonical header's. A structural match under a different name is a second definition of the ABI that no search for the canonical type name will ever find, and that will not be updated when the canonical one is.
 
-  G_header_field_write         164 sites   36 files  [lexical]
+  G_header_field_write         168 sites   36 files  [lexical]
       what: Direct writes to header fields through a pointer whose name suggests a header.
       how:  Stripped regex for `<ident>->{subtype,flags,ref_count,size}` where <ident> matches a header-ish name (hdr, header, h, obj_header, ...). Heuristic by design; the semantic layer supersedes it when libclang is available.
 
@@ -216,14 +216,14 @@ Per-file counts
   G_header_field_write
         20  lib/core/runtime_object_alloc.cpp
         18  lib/core/runtime_taylor.c
+        10  lib/core/introspection.cpp
         10  lib/core/logic.cpp
         10  lib/core/runtime_tensor_alloc.cpp
-         8  lib/core/introspection.cpp
+         8  lib/core/runtime_display_hosted.cpp
          7  lib/core/kb_persistence.cpp
          7  lib/core/runtime_deep_equal.cpp
          7  lib/core/runtime_tensor_index.cpp
          6  lib/core/inference.cpp
-         6  lib/core/runtime_display_hosted.cpp
          5  lib/core/runtime_regions.cpp
          5  lib/core/sdnc_api.c
          4  lib/backend/vm_arena.h

--- a/inc/eshkol/ad_node_registry.def
+++ b/inc/eshkol/ad_node_registry.def
@@ -1,0 +1,226 @@
+/* ad_node_registry.def — the single declaration site for every AD tape node type.
+ *
+ * WHY THIS FILE EXISTS
+ *   PR #498 found four tensor-valued AD node types reaching an early `default:`
+ *   in eshkol_tensor_backward_dispatch that did nothing at all: gradients came
+ *   back exactly 0.0, with no diagnostic and exit 0.  That default carried a
+ *   comment asserting the case was impossible, reasoning from a numeric band of
+ *   enum values ("every tensor op is 19-32 or 67-80") that four new node types
+ *   had already invalidated.  The comment was the only thing enforcing the
+ *   claim, and a comment enforces nothing.
+ *
+ *   The class is general: a dispatch switch over a closed enum whose `default:`
+ *   encodes an assumption instead of failing, in a language where the enum can
+ *   grow without the switch ever knowing.  The fix is to make the assumption a
+ *   compile-time property.  This registry is where an AD node type is DECLARED,
+ *   once; the enum, the tensor-dispatch grouping and the bridge backward table
+ *   are all generated from these rows, so a node type cannot exist without
+ *   stating what its reverse pass does.
+ *
+ * ROW FORMAT
+ *   ESHKOL_AD_NODE(NAME, VALUE, PAYLOAD, TENSOR_BACKWARD, BRIDGE_FN)
+ *
+ *   NAME    Enum member spelling without the AD_NODE_ prefix.  AD_NODE_##NAME
+ *           is generated in inc/eshkol/eshkol.h.
+ *
+ *   VALUE   The node type's numeric value.  Stated explicitly and asserted to
+ *           equal the row's ordinal (see ESHKOL_AD_NODE_REGISTRY_ROWS), because
+ *           these values are an ABI: emitted LLVM IR compares node->type
+ *           against integer literals, and serialized tapes carry them.
+ *
+ *   PAYLOAD What the node's forward value is.
+ *             SCALAR  node->value holds the result; tensor_value is NULL.
+ *             TENSOR  node->tensor_value holds the result buffer.
+ *           A TENSOR row is one that CAN reach eshkol_tensor_backward_dispatch
+ *           with a live upstream gradient; a SCALAR row normally cannot,
+ *           because the dispatcher returns early on a NULL tensor_gradient.
+ *
+ *   TENSOR_BACKWARD  What eshkol_tensor_backward_dispatch must do for this row.
+ *           This column is ONLY about the runtime tensor dispatcher.  Eshkol
+ *           has a second reverse sweep — the one autodiff_codegen.cpp emits as
+ *           LLVM IR — and a row may have an adjoint there and none here.
+ *
+ *             LEAF           Graph leaf (constant / variable).  No adjoint; the
+ *                            reverse sweep stops.
+ *             SCALAR_ADJOINT The adjoint is emitted inline by the codegen's
+ *                            scalar reverse sweep.  The tensor dispatcher has
+ *                            nothing to do.  Generated into one shared no-op
+ *                            arm — a new row lands there only by SAYING so.
+ *             INLINE         A hand-written arm of eshkol_tensor_backward_dispatch
+ *                            reconstructs shapes/params and calls an
+ *                            eshkol_backward_* kernel.  NOT generated: the arm
+ *                            is bespoke, and -Werror=switch-enum on that
+ *                            translation unit is what proves it exists.
+ *             BRIDGE         Handled by the generated table in
+ *                            lib/bridge/tensor_backward.cpp.  BRIDGE_FN names
+ *                            the function; if it does not exist, that TU does
+ *                            not compile.  That is registration completeness.
+ *             CUSTOM_VJP     External adjoint supplied by the caller.
+ *             UNREGISTERED   An EXPLICIT REGISTERED REFUSAL.  No exact backward
+ *                            exists for this node in the tensor dispatcher, and
+ *                            rather than return a plausible zero it aborts,
+ *                            naming the node type.  This is a declaration, not
+ *                            an oversight: the row had to be written.
+ *
+ *   BRIDGE_FN  For BRIDGE rows, the backward function symbol.  Every other row
+ *              passes ESHKOL_AD_NO_BRIDGE.
+ *
+ * ADDING A NODE TYPE
+ *   Append a row here.  Three things then hold without further action:
+ *     - AD_NODE_<NAME> and AD_NODE_TYPE_COUNT are correct by construction;
+ *     - a static assertion proves VALUE == ordinal, so the dense dispatch
+ *       tables indexed by node type stay valid;
+ *     - the tensor dispatcher either handles it (SCALAR_ADJOINT / BRIDGE /
+ *       LEAF / CUSTOM_VJP / UNREGISTERED are all generated) or refuses to
+ *       compile until a hand-written INLINE arm is added.
+ *   What is NOT possible is adding one and having its gradient silently vanish.
+ *
+ * Copyright (C) tsotchke
+ * SPDX-License-Identifier: MIT
+ */
+
+/* clang-format off */
+
+/* ── Core operations (0-11) ─────────────────────────────────────────────── */
+ESHKOL_AD_NODE(CONSTANT,             0, SCALAR, LEAF,           ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(VARIABLE,             1, SCALAR, LEAF,           ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(ADD,                  2, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(SUB,                  3, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(MUL,                  4, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(DIV,                  5, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(SIN,                  6, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(COS,                  7, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(EXP,                  8, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(LOG,                  9, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(POW,                 10, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(NEG,                 11, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+
+/* ── Activation gradients (12-18) ───────────────────────────────────────── */
+ESHKOL_AD_NODE(RELU,                12, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(SIGMOID,             13, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(SOFTMAX,             14, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(TANH,                15, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(GELU,                16, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(LEAKY_RELU,          17, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(SILU,                18, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+
+/* ── Tensor operation gradients (19-28) ─────────────────────────────────── */
+ESHKOL_AD_NODE(CONV2D,              19, TENSOR, INLINE,         ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(MAXPOOL2D,           20, TENSOR, INLINE,         ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(AVGPOOL2D,           21, TENSOR, INLINE,         ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(BATCHNORM,           22, TENSOR, INLINE,         ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(LAYERNORM,           23, TENSOR, INLINE,         ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(MATMUL,              24, TENSOR, INLINE,         ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(TRANSPOSE,           25, TENSOR, INLINE,         ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(RESHAPE,             26, TENSOR, INLINE,         ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(SUM,                 27, TENSOR, INLINE,         ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(MEAN,                28, TENSOR, INLINE,         ESHKOL_AD_NO_BRIDGE)
+
+/* ── Transformer gradients (29-32) ──────────────────────────────────────── */
+ESHKOL_AD_NODE(ATTENTION,           29, TENSOR, INLINE,         ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(MULTIHEAD_ATTENTION, 30, TENSOR, INLINE,         ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(POSITIONAL_ENCODING, 31, TENSOR, INLINE,         ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(EMBEDDING,           32, TENSOR, INLINE,         ESHKOL_AD_NO_BRIDGE)
+
+/* ── qLLM geometric gradients (33-40) ───────────────────────────────────────
+ *
+ * THIS BLOCK IS THE #498 CLASS, STILL LIVE, IN FOUR MORE NODE TYPES.
+ *
+ * The four rows lib/bridge/qllm_bridge.cpp actually produces —
+ * HYPERBOLIC_DISTANCE, POINCARE_EXP_MAP, POINCARE_LOG_MAP and
+ * GEODESIC_ATTENTION — are recorded on the tape as TENSOR nodes
+ * (make_node(..., out, shape, ...) with a tensor_value), so a reverse sweep
+ * routes them to eshkol_tensor_backward_dispatch, where until this change
+ * they hit the same asserted-impossible `default:` and returned zero.  The
+ * numeric band the old comment reasoned from ("tensor ops are 19-32 and
+ * 67-80") never covered 33-40.
+ *
+ * They are declared UNREGISTERED rather than given a backward here: writing
+ * Riemannian adjoints is AD work with its own correctness bar, in flight on a
+ * separate lane, and inventing one to close a dispatch hole is how a wrong
+ * gradient gets shipped.  UNREGISTERED aborts naming the node type, so the
+ * gap announces itself at the point of use.  Note these DO have an adjoint on
+ * the OTHER reverse sweep: autodiff_codegen.cpp emits scalar backward blocks
+ * for node types 33-40.  This column is about the tensor dispatcher alone.
+ *
+ * TANGENT_PROJECT / MOBIUS_ADD / MOBIUS_MATMUL / GYROVECTOR_SPACE have no
+ * producer at all today; the emitted scalar sweep reads them, nothing writes
+ * them.  A future producer that records one as a tensor node inherits the
+ * abort rather than the silence.
+ */
+ESHKOL_AD_NODE(HYPERBOLIC_DISTANCE, 33, TENSOR, UNREGISTERED,   ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(POINCARE_EXP_MAP,    34, TENSOR, UNREGISTERED,   ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(POINCARE_LOG_MAP,    35, TENSOR, UNREGISTERED,   ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(TANGENT_PROJECT,     36, TENSOR, UNREGISTERED,   ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(GEODESIC_ATTENTION,  37, TENSOR, UNREGISTERED,   ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(MOBIUS_ADD,          38, TENSOR, UNREGISTERED,   ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(MOBIUS_MATMUL,       39, TENSOR, UNREGISTERED,   ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(GYROVECTOR_SPACE,    40, TENSOR, UNREGISTERED,   ESHKOL_AD_NO_BRIDGE)
+
+/* ── Additional math operations (41-45) ─────────────────────────────────── */
+ESHKOL_AD_NODE(SQRT,                41, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(ABS,                 42, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(SQUARE,              43, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(MAX,                 44, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(MIN,                 45, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+
+/* ── Phase 4 activation gradients (46-53) ───────────────────────────────── */
+ESHKOL_AD_NODE(ELU,                 46, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(SELU,                47, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(MISH,                48, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(HARDSWISH,           49, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(HARDSIGMOID,         50, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(SOFTPLUS,            51, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(DROPOUT,             52, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(CELU,                53, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+
+/* ── Complete math function gradients (54-66) ───────────────────────────── */
+ESHKOL_AD_NODE(TAN,                 54, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(ASIN,                55, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(ACOS,                56, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(ATAN,                57, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(SINH,                58, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(COSH,                59, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(ASINH,               60, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(ACOSH,               61, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(ATANH,               62, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(LOG10,               63, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(LOG2,                64, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(EXP2,                65, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+ESHKOL_AD_NODE(CBRT,                66, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+
+/* ── Tensor AD nodes for the qLLM bridge (67-80) ────────────────────────────
+ * Each BRIDGE row names the backward function that answers it.  The names
+ * resolve inside lib/bridge/tensor_backward.cpp, where the dispatch table is
+ * generated from these rows: a row naming a function that does not exist is a
+ * compile error, which is what makes "registered" mean registered.
+ */
+ESHKOL_AD_NODE(TENSOR_MATMUL,        67, TENSOR, BRIDGE, tensor_matmul_backward)
+ESHKOL_AD_NODE(TENSOR_SOFTMAX,       68, TENSOR, BRIDGE, tensor_softmax_backward)
+ESHKOL_AD_NODE(TENSOR_LAYERNORM,     69, TENSOR, BRIDGE, tensor_layernorm_backward)
+ESHKOL_AD_NODE(TENSOR_RMSNORM,       70, TENSOR, BRIDGE, tensor_rmsnorm_backward)
+ESHKOL_AD_NODE(TENSOR_ATTENTION,     71, TENSOR, BRIDGE, tensor_attention_backward)
+ESHKOL_AD_NODE(TENSOR_GELU,          72, TENSOR, BRIDGE, tensor_gelu_backward)
+ESHKOL_AD_NODE(TENSOR_SILU,          73, TENSOR, BRIDGE, tensor_silu_backward)
+ESHKOL_AD_NODE(TENSOR_TRANSPOSE,     74, TENSOR, BRIDGE, tensor_transpose_backward)
+ESHKOL_AD_NODE(TENSOR_SUM,           75, TENSOR, BRIDGE, tensor_sum_backward)
+ESHKOL_AD_NODE(TENSOR_BROADCAST_ADD, 76, TENSOR, BRIDGE, tensor_broadcast_add_backward)
+ESHKOL_AD_NODE(TENSOR_BROADCAST_MUL, 77, TENSOR, BRIDGE, tensor_broadcast_mul_backward)
+ESHKOL_AD_NODE(TENSOR_EMBEDDING,     78, TENSOR, BRIDGE, tensor_embedding_backward)
+ESHKOL_AD_NODE(TENSOR_CROSS_ENTROPY, 79, TENSOR, BRIDGE, tensor_cross_entropy_backward)
+/* The Riemannian center of mass is defined implicitly, as the stationary point
+ * of the weighted variance, so its rule differentiates that condition rather
+ * than the iteration that solves it. */
+ESHKOL_AD_NODE(FRECHET_MEAN,         80, TENSOR, BRIDGE, tensor_frechet_mean_backward)
+
+/* ── Binary atan2 (81) ──────────────────────────────────────────────────── */
+ESHKOL_AD_NODE(ATAN2,               81, SCALAR, SCALAR_ADJOINT, ESHKOL_AD_NO_BRIDGE)
+
+/* ── Custom vector-Jacobian product (82) ────────────────────────────────────
+ * An opaque scalar-valued primitive y = f(x_0..x_{n-1}) whose reverse-mode
+ * adjoint is supplied externally rather than by a hardcoded formula (e.g. a
+ * Moonlab VQE circuit), composed inside Eshkol's own reverse-mode tape.
+ */
+ESHKOL_AD_NODE(CUSTOM,              82, SCALAR, CUSTOM_VJP,     ESHKOL_AD_NO_BRIDGE)
+
+/* clang-format on */

--- a/inc/eshkol/backend/tensor_backward.h
+++ b/inc/eshkol/backend/tensor_backward.h
@@ -20,6 +20,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -356,6 +357,30 @@ void eshkol_seed_tensor_gradient(void* ad_node_ptr);
  * @param ad_node_ptr AD node whose backward pass should be dispatched (as eshkol_ad_node_t*, opaque here)
  */
 void eshkol_tensor_backward_dispatch(void* ad_node_ptr);
+
+/**
+ * @brief Spell an AD node type for diagnostics, e.g. "AD_NODE_TENSOR_MATMUL".
+ *
+ * Generated from inc/eshkol/ad_node_registry.def, so every node type has a
+ * name and no node type can be added without one.  Returns a static string;
+ * never NULL.  Out-of-range values return "<out-of-range AD node type>".
+ *
+ * @param node_type An ad_node_type_t value, passed as int for C ABI stability.
+ */
+const char* eshkol_ad_node_type_name(int node_type);
+
+/**
+ * @brief Does this AD node type carry a TENSOR payload (rather than a scalar)?
+ *
+ * Generated from the same registry rows.  This is the declared property, not
+ * an observation of a particular node: it answers whether a value of this type
+ * is ever expected to reach eshkol_tensor_backward_dispatch with a live
+ * gradient, which is what separates a normal tensor reverse pass from a node
+ * that should never have been tensor-valued in the first place.
+ *
+ * @param node_type An ad_node_type_t value, passed as int for C ABI stability.
+ */
+bool eshkol_ad_node_type_is_tensor(int node_type);
 
 #ifdef __cplusplus
 }

--- a/inc/eshkol/eshkol.h
+++ b/inc/eshkol/eshkol.h
@@ -22,6 +22,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "eshkol/exhaustive_dispatch.h"
+
 // ═══════════════════════════════════════════════════════════════════════════
 // CROSS-PLATFORM STATIC ASSERTION MACRO
 // _Static_assert is C11, static_assert is C++11. GCC in C++ mode doesn't
@@ -575,6 +577,63 @@ typedef enum {
     // Reserved: 26-255 for future heap types
 } heap_subtype_t;
 
+/**
+ * @brief Is @p sub a DECLARED member of heap_subtype_t?
+ *
+ * The one predicate that separates the two halves of every heap-subtype
+ * dispatch.  A subtype byte read out of an object header is untrusted input —
+ * a corrupt pointer, a foreign object, a headerless allocation — so a switch
+ * over it is dispatching on an OPEN set no matter how closed the enum is.
+ * Ask this first: false means "not one of ours", which every caller answers
+ * with a loud, value-naming fallback; true means the value IS a declared
+ * member, and the switch that follows can then be exhaustive with no
+ * `default:` at all, so the compiler catches a subtype nobody handled.
+ *
+ * Splitting the question this way is what lets both halves be honest at once.
+ * The single `default:` those switches used to carry answered "corrupt byte"
+ * and "enum member added last week" with the same shrug — which is how
+ * KB / FACT / SUBSTITUTION / WORKSPACE were shallow-copied by the region
+ * evacuator (ESH-0214d) and how four tensor AD node types came back with
+ * gradients of exactly zero (PR #498).
+ *
+ * This switch is itself exhaustive and has no default, so adding a member to
+ * heap_subtype_t without listing it here is a compile error.
+ */
+static inline bool eshkol_heap_subtype_is_declared(uint8_t sub) {
+    ESHKOL_EXHAUSTIVE_SWITCH_BEGIN
+    switch ((heap_subtype_t)sub) {
+        case HEAP_SUBTYPE_CONS:
+        case HEAP_SUBTYPE_STRING:
+        case HEAP_SUBTYPE_VECTOR:
+        case HEAP_SUBTYPE_TENSOR:
+        case HEAP_SUBTYPE_MULTI_VALUE:
+        case HEAP_SUBTYPE_HASH:
+        case HEAP_SUBTYPE_EXCEPTION:
+        case HEAP_SUBTYPE_RECORD:
+        case HEAP_SUBTYPE_BYTEVECTOR:
+        case HEAP_SUBTYPE_PORT:
+        case HEAP_SUBTYPE_SYMBOL:
+        case HEAP_SUBTYPE_BIGNUM:
+        case HEAP_SUBTYPE_SUBSTITUTION:
+        case HEAP_SUBTYPE_FACT:
+        case HEAP_SUBTYPE_KNOWLEDGE_BASE:
+        case HEAP_SUBTYPE_FACTOR_GRAPH:
+        case HEAP_SUBTYPE_WORKSPACE:
+        case HEAP_SUBTYPE_PROMISE:
+        case HEAP_SUBTYPE_RATIONAL:
+        case HEAP_SUBTYPE_PRNG:
+        case HEAP_SUBTYPE_DNC:
+        case HEAP_SUBTYPE_SDNC:
+        case HEAP_SUBTYPE_TAYLOR:
+        case HEAP_SUBTYPE_PARAMETER:
+        case HEAP_SUBTYPE_I128:
+            return true;
+    }
+    ESHKOL_EXHAUSTIVE_SWITCH_END
+    return false;  /* value 14 (reserved for RULE) and 26-255 */
+}
+
+
 // ───────────────────────────────────────────────────────────────────────────
 // CALLABLE SUBTYPES (type = ESHKOL_VALUE_CALLABLE = 9)
 // Function-like objects that can be invoked
@@ -595,6 +654,24 @@ typedef enum {
     CALLABLE_SUBTYPE_CONTINUATION = 4,  // First-class continuation (future)
     // Reserved: 5-255 for future callable types
 } callable_subtype_t;
+
+/**
+ * @brief Is @p sub a DECLARED member of callable_subtype_t?  See
+ *        eshkol_heap_subtype_is_declared for why this predicate exists.
+ */
+static inline bool eshkol_callable_subtype_is_declared(uint8_t sub) {
+    ESHKOL_EXHAUSTIVE_SWITCH_BEGIN
+    switch ((callable_subtype_t)sub) {
+        case CALLABLE_SUBTYPE_CLOSURE:
+        case CALLABLE_SUBTYPE_LAMBDA_SEXPR:
+        case CALLABLE_SUBTYPE_AD_NODE:
+        case CALLABLE_SUBTYPE_PRIMITIVE:
+        case CALLABLE_SUBTYPE_CONTINUATION:
+            return true;
+    }
+    ESHKOL_EXHAUSTIVE_SWITCH_END
+    return false;
+}
 
 // ───────────────────────────────────────────────────────────────────────────
 // HANDLE SUBTYPES (type = ESHKOL_VALUE_HANDLE = 16, future multimedia)
@@ -905,118 +982,52 @@ static inline double eshkol_dual_derivative(const eshkol_dual_number_t* d) {
  * AD_NODE_TYPE_COUNT is a sentinel for bounds-checked dispatch tables and is
  * not itself a valid node type.
  */
+/*
+ * GENERATED FROM inc/eshkol/ad_node_registry.def — do not add members here.
+ *
+ * Every member below is one ESHKOL_AD_NODE row in that file, which also states
+ * the node's payload kind (scalar or tensor) and what its reverse pass does in
+ * eshkol_tensor_backward_dispatch.  Declaring the node type and declaring its
+ * backward disposition are the same act, so a node type cannot enter this enum
+ * without saying what happens when a gradient reaches it.  This is the fix for
+ * the #498 class: a dispatch switch whose `default:` asserted, in a comment,
+ * that no tensor node could reach it, while four already did — and returned
+ * gradients of exactly 0.0 with no diagnostic and exit 0.  See the header of
+ * ad_node_registry.def for the full argument and for how to add a node type.
+ *
+ * The numeric values are an ABI (emitted LLVM IR compares node->type against
+ * integer literals), so each row states its value explicitly and the assertion
+ * below proves the set stays dense — dense is what the node-type-indexed
+ * dispatch tables rely on.
+ */
 typedef enum {
-    // Core operations (0-11)
-    AD_NODE_CONSTANT,
-    AD_NODE_VARIABLE,
-    AD_NODE_ADD,
-    AD_NODE_SUB,
-    AD_NODE_MUL,
-    AD_NODE_DIV,
-    AD_NODE_SIN,
-    AD_NODE_COS,
-    AD_NODE_EXP,
-    AD_NODE_LOG,
-    AD_NODE_POW,
-    AD_NODE_NEG,
-
-    // Activation gradients (12-18)
-    AD_NODE_RELU,
-    AD_NODE_SIGMOID,
-    AD_NODE_SOFTMAX,
-    AD_NODE_TANH,
-    AD_NODE_GELU,
-    AD_NODE_LEAKY_RELU,
-    AD_NODE_SILU,
-
-    // Tensor operation gradients (19-28)
-    AD_NODE_CONV2D,
-    AD_NODE_MAXPOOL2D,
-    AD_NODE_AVGPOOL2D,
-    AD_NODE_BATCHNORM,
-    AD_NODE_LAYERNORM,
-    AD_NODE_MATMUL,
-    AD_NODE_TRANSPOSE,
-    AD_NODE_RESHAPE,
-    AD_NODE_SUM,
-    AD_NODE_MEAN,
-
-    // Transformer gradients (29-32)
-    AD_NODE_ATTENTION,
-    AD_NODE_MULTIHEAD_ATTENTION,
-    AD_NODE_POSITIONAL_ENCODING,
-    AD_NODE_EMBEDDING,
-
-    // qLLM Geometric gradients (33-40)
-    AD_NODE_HYPERBOLIC_DISTANCE,
-    AD_NODE_POINCARE_EXP_MAP,
-    AD_NODE_POINCARE_LOG_MAP,
-    AD_NODE_TANGENT_PROJECT,
-    AD_NODE_GEODESIC_ATTENTION,
-    AD_NODE_MOBIUS_ADD,
-    AD_NODE_MOBIUS_MATMUL,
-    AD_NODE_GYROVECTOR_SPACE,
-
-    // Additional math operations (41-44)
-    AD_NODE_SQRT,
-    AD_NODE_ABS,
-    AD_NODE_SQUARE,
-    AD_NODE_MAX,
-    AD_NODE_MIN,
-
-    // Phase 4 activation gradients (46-53)
-    AD_NODE_ELU = 46,
-    AD_NODE_SELU,
-    AD_NODE_MISH,
-    AD_NODE_HARDSWISH,
-    AD_NODE_HARDSIGMOID,
-    AD_NODE_SOFTPLUS,
-    AD_NODE_DROPOUT,
-    AD_NODE_CELU,
-
-    // Complete math function gradients (54-66)
-    AD_NODE_TAN = 54,
-    AD_NODE_ASIN,
-    AD_NODE_ACOS,
-    AD_NODE_ATAN,
-    AD_NODE_SINH,
-    AD_NODE_COSH,
-    AD_NODE_ASINH,
-    AD_NODE_ACOSH,
-    AD_NODE_ATANH,
-    AD_NODE_LOG10,
-    AD_NODE_LOG2,
-    AD_NODE_EXP2,
-    AD_NODE_CBRT,
-
-    // Tensor AD nodes for qLLM bridge (67-79)
-    AD_NODE_TENSOR_MATMUL = 67,       // dL/dA = dL/dC @ B^T, dL/dB = A^T @ dL/dC
-    AD_NODE_TENSOR_SOFTMAX,            // Jacobian-vector product
-    AD_NODE_TENSOR_LAYERNORM,          // Chain rule through mean/variance
-    AD_NODE_TENSOR_RMSNORM,            // Chain rule through RMS
-    AD_NODE_TENSOR_ATTENTION,          // 5-step chain rule through scaled dot-product
-    AD_NODE_TENSOR_GELU,               // GELU backward
-    AD_NODE_TENSOR_SILU,               // SiLU/Swish backward
-    AD_NODE_TENSOR_TRANSPOSE,          // Permutation backward
-    AD_NODE_TENSOR_SUM,                // Broadcast backward
-    AD_NODE_TENSOR_BROADCAST_ADD,      // Sum-reduce backward
-    AD_NODE_TENSOR_BROADCAST_MUL,      // Product-rule backward
-    AD_NODE_TENSOR_EMBEDDING,          // Sparse update backward
-    AD_NODE_TENSOR_CROSS_ENTROPY,      // Numerically stable backward
-    AD_NODE_FRECHET_MEAN,              // Riemannian center of mass backward
-    AD_NODE_ATAN2,                     // Binary atan2(y, x) backward
-
-    // Custom vector-Jacobian-product node (external adjoint). The reverse pass
-    // invokes a user-supplied backward callback stored in saved_tensors[0] as an
-    // eshkol_custom_vjp_t; it accumulates the callback's per-input gradients into
-    // this node's input variable nodes. Used to differentiate through opaque
-    // primitives that supply their own exact adjoint (e.g. a Moonlab VQE circuit),
-    // composed inside Eshkol's reverse-mode AD tape.
-    AD_NODE_CUSTOM,
+#define ESHKOL_AD_NODE(NAME, VALUE, PAYLOAD, TENSOR_BACKWARD, BRIDGE_FN) \
+    AD_NODE_##NAME = (VALUE),
+#include "eshkol/ad_node_registry.def"
+#undef ESHKOL_AD_NODE
 
     // Sentinel for bounds checking
     AD_NODE_TYPE_COUNT
 } ad_node_type_t;
+
+/** @brief Number of rows in ad_node_registry.def. */
+enum {
+    ESHKOL_AD_NODE_REGISTRY_ROWS = 0
+#define ESHKOL_AD_NODE(NAME, VALUE, PAYLOAD, TENSOR_BACKWARD, BRIDGE_FN) + 1
+#include "eshkol/ad_node_registry.def"
+#undef ESHKOL_AD_NODE
+};
+
+/* Row count == AD_NODE_TYPE_COUNT proves the registry's declared values are
+ * dense with no gaps and no duplicates: AD_NODE_TYPE_COUNT is one past the
+ * LAST row's value, so a gap makes rows fewer and a duplicate makes them more.
+ * Density is not cosmetic — the backward dispatch table in lib/bridge is a
+ * flat array indexed by node type, and a gap would make it index a hole. */
+/* Cast to int on both sides: these are two DIFFERENT enum types (the row
+ * counter is its own anonymous enum), and C++20 deprecates comparing them. */
+ESHKOL_STATIC_ASSERT((int)ESHKOL_AD_NODE_REGISTRY_ROWS == (int)AD_NODE_TYPE_COUNT,
+    "ad_node_registry.def values must be dense: one row per value, "
+    "0..AD_NODE_TYPE_COUNT-1, no gaps and no duplicates");
 
 /**
  * Custom vector-Jacobian-product descriptor for AD_NODE_CUSTOM.

--- a/inc/eshkol/exhaustive_dispatch.h
+++ b/inc/eshkol/exhaustive_dispatch.h
@@ -1,0 +1,84 @@
+/**
+ * @file exhaustive_dispatch.h
+ * @brief Make a dispatch switch's exhaustiveness a compile-time property.
+ *
+ * THE DEFECT CLASS THIS EXISTS TO END
+ *   A dispatch switch over a closed enum, carrying a `default:` that encodes
+ *   an ASSUMPTION instead of failing, in a language where the enum can grow
+ *   without the switch ever knowing.  PR #498 found the shape at its worst:
+ *   four tensor-valued AD node types fell into an early `default:` in
+ *   eshkol_tensor_backward_dispatch that did nothing at all.  Gradients came
+ *   back exactly 0.0, no diagnostic, exit 0.  The default's own comment
+ *   asserted the case was impossible, reasoning from a numeric band of enum
+ *   values that the four new node types had already stepped outside of.  The
+ *   comment was the only thing enforcing the claim, and a comment enforces
+ *   nothing.  The identical shape produced the ESH-0214d region-evacuator bug,
+ *   where heap subtypes fell to a shallow-leaf `default:` and left interior
+ *   pointers aimed into a reclaimed arena.
+ *
+ *   The lesson is not "write better defaults".  It is that an invariant a
+ *   human has to re-check on every enum edit is not an invariant.  Give the
+ *   switch no `default:`, name every member, and let the compiler carry it.
+ *
+ * HOW TO USE THIS
+ *   Two mechanisms, for two situations.
+ *
+ *   1. WHOLE TRANSLATION UNIT.  When a file's switches are all closed-enum
+ *      dispatch, arm the file in CMakeLists.txt via
+ *      eshkol_require_exhaustive_dispatch(<sources...>), which adds
+ *      -Werror=switch-enum.  Preferred: it covers switches nobody remembered
+ *      to annotate, which is exactly the set this class hides in.
+ *
+ *   2. ONE SWITCH.  When a file legitimately mixes closed-enum dispatch with
+ *      switches over open sets — a tag byte read off a serialized value, a
+ *      masked type field, a switch that deliberately answers "everything else"
+ *      — wrap just the dispatch switch:
+ *
+ *          ESHKOL_EXHAUSTIVE_SWITCH_BEGIN
+ *          switch (subtype) {
+ *              case HEAP_SUBTYPE_CONS: ...
+ *              ...                      // every member, no default:
+ *          }
+ *          ESHKOL_EXHAUSTIVE_SWITCH_END
+ *
+ *      Omitting any member is then an error at that switch, and only there.
+ *
+ * WHAT THIS DOES NOT COVER
+ *   A switch whose value comes from OUTSIDE the program — a bytecode opcode,
+ *   a subtype byte read from a file, an integer crossing an FFI boundary — is
+ *   dispatching over an OPEN set no matter what the enum declares, because the
+ *   input can be anything.  The compiler cannot help there and pretending it
+ *   can is its own vacuous assurance.  Those keep a `default:`, and that
+ *   default must be a LOUD abort naming the offending value — never a no-op,
+ *   never a plausible zero.  Exhaustiveness is for values the program itself
+ *   produced; a loud backstop is for values it merely received.
+ *
+ * Copyright (C) tsotchke
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef ESHKOL_EXHAUSTIVE_DISPATCH_H
+#define ESHKOL_EXHAUSTIVE_DISPATCH_H
+
+#if defined(__GNUC__) || defined(__clang__)
+
+/* -Wswitch-enum fires on any enum member the switch does not name, whether or
+ * not a default: is present — which is what makes it, and not -Wswitch, the
+ * right diagnostic: -Wswitch goes quiet the moment a default appears, and a
+ * default is the very thing this class hides behind. */
+#define ESHKOL_EXHAUSTIVE_SWITCH_BEGIN                                 \
+    _Pragma("GCC diagnostic push")                                     \
+    _Pragma("GCC diagnostic error \"-Wswitch-enum\"")                  \
+    _Pragma("GCC diagnostic error \"-Wswitch\"")
+
+#define ESHKOL_EXHAUSTIVE_SWITCH_END                                   \
+    _Pragma("GCC diagnostic pop")
+
+#else  /* MSVC and anything else: no equivalent diagnostic to raise. */
+
+#define ESHKOL_EXHAUSTIVE_SWITCH_BEGIN
+#define ESHKOL_EXHAUSTIVE_SWITCH_END
+
+#endif
+
+#endif /* ESHKOL_EXHAUSTIVE_DISPATCH_H */

--- a/lib/backend/tensor_backward.cpp
+++ b/lib/backend/tensor_backward.cpp
@@ -1034,6 +1034,44 @@ static int64_t compute_total_elements(const int64_t* shape, size_t ndim) {
     return total;
 }
 
+/** @brief Spell an AD node type, for diagnostics.
+ *
+ *  GENERATED from inc/eshkol/ad_node_registry.def, so a node type cannot exist
+ *  without a name here.  This matters more than it looks: the abort messages
+ *  below are the entire user-visible surface of a missing backward, and
+ *  "node type 37" is a number a reader has to go decode, while
+ *  "AD_NODE_GEODESIC_ATTENTION" is an answer. */
+extern "C" const char* eshkol_ad_node_type_name(int node_type) {
+    switch ((ad_node_type_t)node_type) {
+#define ESHKOL_AD_NODE(NAME, VALUE, PAYLOAD, TENSOR_BACKWARD, BRIDGE_FN) \
+    case AD_NODE_##NAME: return "AD_NODE_" #NAME;
+#include "eshkol/ad_node_registry.def"
+#undef ESHKOL_AD_NODE
+    case AD_NODE_TYPE_COUNT: return "AD_NODE_TYPE_COUNT (sentinel, not a node type)";
+    }
+    return "<out-of-range AD node type>";
+}
+
+/** @brief Is this node type declared TENSOR-payload in the registry?
+ *
+ *  GENERATED.  Answers "should a value of this type ever carry a
+ *  tensor_gradient", which is the question that decides whether reaching the
+ *  tensor dispatcher is normal or is itself the bug. */
+extern "C" bool eshkol_ad_node_type_is_tensor(int node_type) {
+#define ESHKOL_AD_PAYLOAD_IS_TENSOR_SCALAR false
+#define ESHKOL_AD_PAYLOAD_IS_TENSOR_TENSOR true
+    switch ((ad_node_type_t)node_type) {
+#define ESHKOL_AD_NODE(NAME, VALUE, PAYLOAD, TENSOR_BACKWARD, BRIDGE_FN) \
+    case AD_NODE_##NAME: return ESHKOL_AD_PAYLOAD_IS_TENSOR_##PAYLOAD;
+#include "eshkol/ad_node_registry.def"
+#undef ESHKOL_AD_NODE
+    case AD_NODE_TYPE_COUNT: return false;
+    }
+    return false;
+#undef ESHKOL_AD_PAYLOAD_IS_TENSOR_SCALAR
+#undef ESHKOL_AD_PAYLOAD_IS_TENSOR_TENSOR
+}
+
 /** @brief Central reverse-mode AD dispatcher for tensor operation nodes:
  *         switches on @p ad_node_ptr's node type (conv2d, pooling, norm
  *         layers, matmul, transpose, reshape, reductions, attention,
@@ -1043,8 +1081,16 @@ static int64_t compute_total_elements(const int64_t* shape, size_t ndim) {
  *         AD_NODE_TENSOR_* ops), and accumulates the resulting input
  *         gradients via eshkol_accumulate_tensor_grad(). All temporary
  *         gradient buffers are allocated from an arena scope that is popped
- *         before returning; node types without a backward implementation
- *         silently drop the gradient. */
+ *         before returning.
+ *
+ *         THE SWITCH BELOW HAS NO `default:`, DELIBERATELY, and this
+ *         translation unit is compiled with -Werror=switch -Werror=switch-enum
+ *         (see CMakeLists.txt, eshkol_require_exhaustive_dispatch).  Adding a
+ *         member to ad_node_type_t without deciding what its reverse pass does
+ *         is a COMPILE ERROR here, not a runtime silence.  The arms that are the
+ *         same for a whole class of node types (bridge-table, no-adjoint-here,
+ *         explicit refusal) are generated from inc/eshkol/ad_node_registry.def
+ *         so they cannot drift from the declarations they implement. */
 extern "C" void eshkol_tensor_backward_dispatch(void* ad_node_ptr) {
     if (!ad_node_ptr) return;
 
@@ -1360,53 +1406,133 @@ extern "C" void eshkol_tensor_backward_dispatch(void* ad_node_ptr) {
         break;
     }
 
-    /* ===== qLLM Bridge Tensor Ops (67-79) =====
-     * These delegate to the self-contained backward functions in
-     * lib/bridge/tensor_backward.cpp. Each function reads the node's
-     * tensor_value, tensor_gradient, input1/input2 and propagates
-     * gradients internally — no manual buffer management needed.  */
-
-    case AD_NODE_TENSOR_MATMUL:
-    case AD_NODE_TENSOR_SOFTMAX:
-    case AD_NODE_TENSOR_LAYERNORM:
-    case AD_NODE_TENSOR_RMSNORM:
-    case AD_NODE_TENSOR_GELU:
-    case AD_NODE_TENSOR_SILU:
-    case AD_NODE_TENSOR_CROSS_ENTROPY:
-    /* Previously these fell into a "gradient passthrough" case that silently
-     * dropped the gradient even though get_tensor_backward_fn HAS a registered
-     * backward for each. Route them through the dispatch table like the ops
-     * above. attention/embedding backends now raise an explicit unsupported-op
-     * error instead of returning a plausible-but-wrong gradient (hard
-     * constraint: exact AD or an explicit error, never a silent zero). */
-    case AD_NODE_TENSOR_ATTENTION:
-    case AD_NODE_TENSOR_TRANSPOSE:
-    case AD_NODE_TENSOR_SUM:
-    case AD_NODE_TENSOR_BROADCAST_ADD:
-    case AD_NODE_TENSOR_BROADCAST_MUL:
-    case AD_NODE_TENSOR_EMBEDDING:
-    /* The Riemannian center of mass is defined implicitly, as the stationary
-     * point of the weighted variance, so its rule differentiates that condition
-     * rather than the iteration that solves it. Lives with the other bridge
-     * geometry in lib/bridge/tensor_backward.cpp. */
-    case AD_NODE_FRECHET_MEAN: {
-        /* Use the bridge dispatch table to find the right backward fn */
+    /* ── Rows the registry declares BRIDGE ─────────────────────────────────
+     * GENERATED from inc/eshkol/ad_node_registry.def.  Each of these delegates
+     * to the self-contained backward function that row names, in
+     * lib/bridge/tensor_backward.cpp: it reads the node's tensor_value,
+     * tensor_gradient and input1..input3 and propagates gradients internally,
+     * so there is no manual buffer management here.
+     *
+     * The case labels are generated rather than typed, so this arm and the
+     * table it calls into cannot disagree about which node types are bridged.
+     * They previously could, and did: seven of these were once listed in a
+     * "gradient passthrough" case that silently dropped the gradient even
+     * though the table HAD a backward registered for every one of them. */
+#define ESHKOL_AD_DISPATCH_CASE_BRIDGE(NAME)         case AD_NODE_##NAME:
+#define ESHKOL_AD_DISPATCH_CASE_LEAF(NAME)
+#define ESHKOL_AD_DISPATCH_CASE_SCALAR_ADJOINT(NAME)
+#define ESHKOL_AD_DISPATCH_CASE_INLINE(NAME)
+#define ESHKOL_AD_DISPATCH_CASE_CUSTOM_VJP(NAME)
+#define ESHKOL_AD_DISPATCH_CASE_UNREGISTERED(NAME)
+#define ESHKOL_AD_NODE(NAME, VALUE, PAYLOAD, TENSOR_BACKWARD, BRIDGE_FN) \
+    ESHKOL_AD_DISPATCH_CASE_##TENSOR_BACKWARD(NAME)
+#include "eshkol/ad_node_registry.def"
+#undef ESHKOL_AD_NODE
+#undef ESHKOL_AD_DISPATCH_CASE_BRIDGE
+#undef ESHKOL_AD_DISPATCH_CASE_LEAF
+#undef ESHKOL_AD_DISPATCH_CASE_SCALAR_ADJOINT
+#undef ESHKOL_AD_DISPATCH_CASE_INLINE
+#undef ESHKOL_AD_DISPATCH_CASE_CUSTOM_VJP
+#undef ESHKOL_AD_DISPATCH_CASE_UNREGISTERED
+    {
         bridge_backward_fn_t fn = get_tensor_backward_fn((int)node->type);
         if (!fn) {
-            eshkol_fatal("unsupported AD op: no backward registered for tensor "
-                         "bridge node type %d; refusing to drop the gradient "
-                         "silently", (int)node->type);
+            /* Unreachable by construction — a BRIDGE row names its function and
+             * the table is generated from the same rows — so if it ever fires,
+             * the generation itself is broken and a zero would be a lie. */
+            eshkol_fatal("AD backward dispatch: node type %d (%s) is declared "
+                         "BRIDGE in ad_node_registry.def but the generated "
+                         "backward table has no entry; refusing to drop the "
+                         "gradient silently",
+                         (int)node->type, eshkol_ad_node_type_name(node->type));
         }
         fn(node);
         break;
     }
 
-    default:
-        /* Scalar activation / geometric / hyperbolic ops (12-18, 33-66) are
-         * differentiated by their scalar backward emitted in codegen and
-         * legitimately reach here with nothing to do. Every TENSOR op
-         * (19-32 and the qLLM bridge ops 67-80) has an explicit case above, so
-         * a tensor-op gradient can never silently fall through this default. */
+    /* ── Rows the registry declares UNREGISTERED ───────────────────────────
+     * GENERATED.  An explicit, written-down refusal: these node types are
+     * tensor-valued and have NO exact backward in this dispatcher, so they
+     * abort naming themselves instead of returning a gradient of zero.
+     *
+     * This is the arm that carries the whole point of the change.  These eight
+     * geometric node types (33-40) are exactly what the old `default:` claimed
+     * could not reach it — its comment reasoned from a numeric band, "every
+     * TENSOR op is 19-32 or 67-80", which was simply not true of 33-40 — and
+     * four of them (HYPERBOLIC_DISTANCE, POINCARE_EXP_MAP, POINCARE_LOG_MAP,
+     * GEODESIC_ATTENTION) are produced as tensor nodes by
+     * lib/bridge/qllm_bridge.cpp today.  Every gradient through one of them
+     * came back exactly 0.0, with no output and exit 0.
+     *
+     * The right end state is exact Riemannian adjoints, which is AD work with
+     * its own correctness bar and belongs to the lane writing them, not to a
+     * dispatch fix.  Until then the honest answer is a loud one. */
+#define ESHKOL_AD_DISPATCH_CASE_UNREGISTERED(NAME)   case AD_NODE_##NAME:
+#define ESHKOL_AD_DISPATCH_CASE_BRIDGE(NAME)
+#define ESHKOL_AD_DISPATCH_CASE_LEAF(NAME)
+#define ESHKOL_AD_DISPATCH_CASE_SCALAR_ADJOINT(NAME)
+#define ESHKOL_AD_DISPATCH_CASE_INLINE(NAME)
+#define ESHKOL_AD_DISPATCH_CASE_CUSTOM_VJP(NAME)
+#define ESHKOL_AD_NODE(NAME, VALUE, PAYLOAD, TENSOR_BACKWARD, BRIDGE_FN) \
+    ESHKOL_AD_DISPATCH_CASE_##TENSOR_BACKWARD(NAME)
+#include "eshkol/ad_node_registry.def"
+#undef ESHKOL_AD_NODE
+#undef ESHKOL_AD_DISPATCH_CASE_BRIDGE
+#undef ESHKOL_AD_DISPATCH_CASE_LEAF
+#undef ESHKOL_AD_DISPATCH_CASE_SCALAR_ADJOINT
+#undef ESHKOL_AD_DISPATCH_CASE_INLINE
+#undef ESHKOL_AD_DISPATCH_CASE_CUSTOM_VJP
+#undef ESHKOL_AD_DISPATCH_CASE_UNREGISTERED
+        backward_scope_end(bwd_arena);
+        eshkol_fatal("AD backward dispatch: no exact backward is registered for "
+                     "tensor node type %d (%s). ad_node_registry.def declares it "
+                     "UNREGISTERED, which means this gap is known and stated, not "
+                     "discovered here. Refusing to return a gradient of zero for "
+                     "an operation that has one.",
+                     (int)node->type, eshkol_ad_node_type_name(node->type));
+        break;
+
+    /* ── Rows whose reverse pass is not this dispatcher's job ──────────────
+     * GENERATED: LEAF ends the sweep (constants and variables have no parents),
+     * SCALAR_ADJOINT is differentiated by the scalar backward that
+     * autodiff_codegen.cpp emits as LLVM IR, and CUSTOM_VJP is answered by the
+     * caller-supplied adjoint on that same scalar path.  All three are scalar
+     * payloads, and a scalar node normally cannot reach this switch at all: we
+     * returned early above on a NULL tensor_gradient.
+     *
+     * THIS IS NOT A `default:`.  A default here would accept any future enum
+     * member into "nothing to do", which is precisely how four tensor ops came
+     * to return zero gradients in silence.  This arm accepts only node types
+     * whose registry row SAYS their adjoint lives elsewhere; -Werror=switch-enum
+     * on this translation unit turns any member that says nothing into a
+     * compile error rather than a wrong number. */
+#define ESHKOL_AD_DISPATCH_CASE_LEAF(NAME)           case AD_NODE_##NAME:
+#define ESHKOL_AD_DISPATCH_CASE_SCALAR_ADJOINT(NAME) case AD_NODE_##NAME:
+#define ESHKOL_AD_DISPATCH_CASE_CUSTOM_VJP(NAME)     case AD_NODE_##NAME:
+#define ESHKOL_AD_DISPATCH_CASE_BRIDGE(NAME)
+#define ESHKOL_AD_DISPATCH_CASE_INLINE(NAME)
+#define ESHKOL_AD_DISPATCH_CASE_UNREGISTERED(NAME)
+#define ESHKOL_AD_NODE(NAME, VALUE, PAYLOAD, TENSOR_BACKWARD, BRIDGE_FN) \
+    ESHKOL_AD_DISPATCH_CASE_##TENSOR_BACKWARD(NAME)
+#include "eshkol/ad_node_registry.def"
+#undef ESHKOL_AD_NODE
+#undef ESHKOL_AD_DISPATCH_CASE_BRIDGE
+#undef ESHKOL_AD_DISPATCH_CASE_LEAF
+#undef ESHKOL_AD_DISPATCH_CASE_SCALAR_ADJOINT
+#undef ESHKOL_AD_DISPATCH_CASE_INLINE
+#undef ESHKOL_AD_DISPATCH_CASE_CUSTOM_VJP
+#undef ESHKOL_AD_DISPATCH_CASE_UNREGISTERED
+        break;
+
+    case AD_NODE_TYPE_COUNT:
+        /* The sentinel is not a node type. It is listed only so that this
+         * switch names every member of ad_node_type_t and needs no default;
+         * reaching it means node->type was never initialised or the tape was
+         * corrupted, and a wrong gradient built on that is worse than a stop. */
+        backward_scope_end(bwd_arena);
+        eshkol_fatal("AD backward dispatch: node->type is the AD_NODE_TYPE_COUNT "
+                     "sentinel (%d), not a node type; the tape is corrupt",
+                     (int)node->type);
         break;
     }
 

--- a/lib/bridge/tensor_backward.cpp
+++ b/lib/bridge/tensor_backward.cpp
@@ -1548,46 +1548,52 @@ extern "C" void tensor_attention_backward(ad_node_t* node) {
 
 typedef void (*backward_fn_t)(ad_node_t*);
 
-/** @brief Looks up the backward-pass function for a given AD tensor node
- *  type. Returns NULL (after a one-time stderr warning) for node types with
- *  no registered backward, so the caller can skip gradient propagation for
- *  genuinely non-AD node types (CONSTANT / VARIABLE) as well as any
- *  op whose forward codegen has no matching backward implementation. */
+/* The backward-function table, GENERATED from inc/eshkol/ad_node_registry.def.
+ *
+ * This replaces a hand-written switch with a `default:` that returned NULL and
+ * warned once.  A default cannot tell "this node has no adjoint by design" from
+ * "someone added a node type and forgot this table", so it answered both with
+ * the same shrug; the caller's NULL handling then turned the second case into a
+ * silently dropped gradient.  Now every row of the registry contributes exactly
+ * one entry, and the disposition it declared decides what that entry is:
+ *
+ *   BRIDGE   -> the function the row names.  If that symbol does not exist,
+ *               THIS FILE DOES NOT COMPILE.  That is what makes "registered"
+ *               a fact rather than an intention: a registry row cannot claim a
+ *               backward it does not have.
+ *   anything -> nullptr, because the row said so — LEAF and SCALAR_ADJOINT
+ *   else        genuinely have nothing here, CUSTOM_VJP is answered elsewhere,
+ *               and UNREGISTERED is an explicit refusal the dispatcher turns
+ *               into an abort rather than a zero.
+ *
+ * The array is sized AD_NODE_TYPE_COUNT and indexed by node type, which is
+ * sound because eshkol.h statically asserts the registry's values are dense.
+ */
+#define ESHKOL_AD_NO_BRIDGE nullptr
+#define ESHKOL_AD_BRIDGE_ENTRY_BRIDGE(FN)         FN
+#define ESHKOL_AD_BRIDGE_ENTRY_LEAF(FN)           nullptr
+#define ESHKOL_AD_BRIDGE_ENTRY_SCALAR_ADJOINT(FN) nullptr
+#define ESHKOL_AD_BRIDGE_ENTRY_INLINE(FN)         nullptr
+#define ESHKOL_AD_BRIDGE_ENTRY_CUSTOM_VJP(FN)     nullptr
+#define ESHKOL_AD_BRIDGE_ENTRY_UNREGISTERED(FN)   nullptr
+
+static backward_fn_t const kTensorBackwardTable[AD_NODE_TYPE_COUNT] = {
+#define ESHKOL_AD_NODE(NAME, VALUE, PAYLOAD, TENSOR_BACKWARD, BRIDGE_FN) \
+    ESHKOL_AD_BRIDGE_ENTRY_##TENSOR_BACKWARD(BRIDGE_FN),
+#include "eshkol/ad_node_registry.def"
+#undef ESHKOL_AD_NODE
+};
+
+/** @brief Look up the backward-pass function for an AD tensor node type.
+ *
+ *  Returns the registered function, or nullptr when the node's registry row
+ *  declared no bridge backward.  nullptr is NOT a judgement about whether a
+ *  gradient may be dropped — the caller decides that from the row's declared
+ *  disposition — it only says this table does not answer this node type.
+ *  Out-of-range values (a corrupt or foreign tape) return nullptr; the caller
+ *  reports them.
+ */
 extern "C" backward_fn_t get_tensor_backward_fn(int node_type) {
-    switch ((ad_node_type_t)node_type) {
-        case AD_NODE_TENSOR_MATMUL:          return tensor_matmul_backward;
-        case AD_NODE_TENSOR_SOFTMAX:         return tensor_softmax_backward;
-        case AD_NODE_TENSOR_LAYERNORM:       return tensor_layernorm_backward;
-        case AD_NODE_TENSOR_RMSNORM:         return tensor_rmsnorm_backward;
-        case AD_NODE_TENSOR_GELU:            return tensor_gelu_backward;
-        case AD_NODE_TENSOR_SILU:            return tensor_silu_backward;
-        case AD_NODE_TENSOR_CROSS_ENTROPY:   return tensor_cross_entropy_backward;
-        case AD_NODE_TENSOR_TRANSPOSE:       return tensor_transpose_backward;
-        case AD_NODE_TENSOR_SUM:             return tensor_sum_backward;
-        case AD_NODE_TENSOR_BROADCAST_ADD:   return tensor_broadcast_add_backward;
-        case AD_NODE_TENSOR_BROADCAST_MUL:   return tensor_broadcast_mul_backward;
-        case AD_NODE_TENSOR_EMBEDDING:       return tensor_embedding_backward;
-        case AD_NODE_TENSOR_ATTENTION:       return tensor_attention_backward;
-        case AD_NODE_FRECHET_MEAN:           return tensor_frechet_mean_backward;
-        default:
-            /* Previously: return NULL → silent zero-gradient. That
-             * meant any op whose forward codegen was emitted without a
-             * matching backward silently corrupted the tape. Now we
-             * log once per process so developers see the mismatch
-             * immediately. The caller still handles NULL by skipping
-             * the node, so existing behaviour is preserved for
-             * genuinely non-AD node types (CONSTANT / VARIABLE). */
-            {
-                static int warned[AD_NODE_TYPE_COUNT] = {0};
-                if (node_type >= 0 && node_type < AD_NODE_TYPE_COUNT
-                    && !warned[node_type]) {
-                    warned[node_type] = 1;
-                    fprintf(stderr,
-                        "tensor_backward: no backward for AD_NODE type %d — "
-                        "gradient signal lost on this op\n",
-                        node_type);
-                }
-            }
-            return NULL;
-    }
+    if (node_type < 0 || node_type >= AD_NODE_TYPE_COUNT) return nullptr;
+    return kTensorBackwardTable[node_type];
 }

--- a/lib/core/introspection.cpp
+++ b/lib/core/introspection.cpp
@@ -15,6 +15,7 @@
 #include <eshkol/core/eval_bridge.h>
 #include <eshkol/llvm_backend.h>
 #include <eshkol/logger.h>
+#include <eshkol/exhaustive_dispatch.h>
 #include "arena_memory.h"
 
 // NOTE: repl_jit.h is deliberately NOT included here. introspection.cpp
@@ -1305,8 +1306,20 @@ eshkol_tagged_value_t eshkol_type_of(eshkol_tagged_value_t value) {
             void* ptr = get_ptr(value);
             if (ptr) {
                 eshkol_object_header_t* header = ESHKOL_GET_HEADER(ptr);
-                if (header) {
-                    switch (header->subtype) {
+                if (header && !eshkol_heap_subtype_is_declared(header->subtype)) {
+                    // Open-set half: the subtype byte is not a declared member
+                    // at all. Loud, and named, because it means the header is
+                    // not one of ours.
+                    eshkol_warn("undeclared heap subtype: %d", header->subtype);
+                    type_name = "heap-object";
+                } else if (header) {
+                    // Closed-set half: exhaustive, no default. `type-of` is the
+                    // program's answer to "what is this"; a subtype absorbed by
+                    // a default answers "heap-object", which is not wrong so
+                    // much as uninformative in exactly the case where the
+                    // information mattered.
+                    ESHKOL_EXHAUSTIVE_SWITCH_BEGIN
+                    switch ((heap_subtype_t)header->subtype) {
                         case HEAP_SUBTYPE_CONS:
                             type_name = "pair";
                             break;
@@ -1361,11 +1374,34 @@ eshkol_tagged_value_t eshkol_type_of(eshkol_tagged_value_t value) {
                         case HEAP_SUBTYPE_PARAMETER:
                             type_name = "parameter";
                             break;
-                        default:
-                            eshkol_warn("unknown heap subtype: %d", header->subtype);
-                            type_name = "heap-object";
+                        case HEAP_SUBTYPE_MULTI_VALUE:
+                            type_name = "values";
+                            break;
+                        case HEAP_SUBTYPE_RECORD:
+                            // Records allocate through the vector allocator, so
+                            // a live record normally arrives stamped VECTOR and
+                            // answers "vector" above. Named so a future record
+                            // allocator stamping subtype 7 does not silently
+                            // start answering "heap-object".
+                            type_name = "record";
+                            break;
+                        case HEAP_SUBTYPE_PROMISE:
+                            type_name = "promise";
+                            break;
+                        case HEAP_SUBTYPE_DNC:
+                            type_name = "dnc";
+                            break;
+                        case HEAP_SUBTYPE_SDNC:
+                            type_name = "sdnc";
+                            break;
+                        case HEAP_SUBTYPE_TAYLOR:
+                            type_name = "taylor";
+                            break;
+                        case HEAP_SUBTYPE_I128:
+                            type_name = "i128";
                             break;
                     }
+                    ESHKOL_EXHAUSTIVE_SWITCH_END
                 }
             }
             if (!type_name) type_name = "heap-object";
@@ -1376,8 +1412,12 @@ eshkol_tagged_value_t eshkol_type_of(eshkol_tagged_value_t value) {
             void* ptr = get_ptr(value);
             if (ptr) {
                 eshkol_object_header_t* header = ESHKOL_GET_HEADER(ptr);
-                if (header) {
-                    switch (header->subtype) {
+                if (header && !eshkol_callable_subtype_is_declared(header->subtype)) {
+                    eshkol_warn("undeclared callable subtype: %d", header->subtype);
+                    type_name = "procedure";
+                } else if (header) {
+                    ESHKOL_EXHAUSTIVE_SWITCH_BEGIN
+                    switch ((callable_subtype_t)header->subtype) {
                         case CALLABLE_SUBTYPE_CLOSURE:
                             type_name = "closure";
                             break;
@@ -1393,11 +1433,8 @@ eshkol_tagged_value_t eshkol_type_of(eshkol_tagged_value_t value) {
                         case CALLABLE_SUBTYPE_CONTINUATION:
                             type_name = "continuation";
                             break;
-                        default:
-                            eshkol_warn("unknown callable subtype: %d", header->subtype);
-                            type_name = "procedure";
-                            break;
                     }
+                    ESHKOL_EXHAUSTIVE_SWITCH_END
                 }
             }
             if (!type_name) type_name = "procedure";

--- a/lib/core/runtime_display_hosted.cpp
+++ b/lib/core/runtime_display_hosted.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "arena_memory.h"
+#include "../../inc/eshkol/exhaustive_dispatch.h"
 #include "../../inc/eshkol/core/bignum.h"
 #include "../../inc/eshkol/core/logic.h"
 #include "../../inc/eshkol/core/inference.h"
@@ -319,7 +320,21 @@ void eshkol_display_value_opts(const eshkol_tagged_value_t* value, eshkol_displa
                 break;
             }
             eshkol_object_header_t* header = ESHKOL_GET_HEADER(data_ptr);
-            switch (header->subtype) {
+            if (!eshkol_heap_subtype_is_declared(header->subtype)) {
+                // Open-set half: a subtype byte that is not a declared member
+                // at all (corrupt header, foreign object, headerless
+                // allocation). Named loudly rather than absorbed.
+                fprintf(get_output(opts), "#<heap:%d>", header->subtype);
+                break;
+            }
+            // Closed-set half. Exhaustive over heap_subtype_t, no default. `display` is where a
+            // value tells the user what it is; a subtype that falls through a
+            // default prints as "#<heap:23>", a number the reader must go look
+            // up, and nothing anywhere fails when a new subtype starts doing
+            // that. Naming every member means a new one has to be given a
+            // printed form deliberately.
+            ESHKOL_EXHAUSTIVE_SWITCH_BEGIN
+            switch ((heap_subtype_t)header->subtype) {
                 case HEAP_SUBTYPE_CONS:
                     eshkol_display_list(value->data.ptr_val, opts);
                     break;
@@ -403,10 +418,35 @@ void eshkol_display_value_opts(const eshkol_tagged_value_t* value, eshkol_displa
                 case HEAP_SUBTYPE_PARAMETER:
                     fprintf(get_output(opts), "#<parameter>");
                     break;
-                default:
-                    fprintf(get_output(opts), "#<heap:%d>", header->subtype);
+                case HEAP_SUBTYPE_RECORD:
+                    // Records allocate through the vector allocator, so a live
+                    // record normally arrives stamped HEAP_SUBTYPE_VECTOR and
+                    // is printed above. Named here so a future record allocator
+                    // that stamps subtype 7 prints as a record rather than as
+                    // "#<heap:7>".
+                    fprintf(get_output(opts), "#<record>");
+                    break;
+                case HEAP_SUBTYPE_BYTEVECTOR:
+                    fprintf(get_output(opts), "#<bytevector>");
+                    break;
+                case HEAP_SUBTYPE_PORT:
+                    // A port normally rides on HEAP_PTR with the port flag bits
+                    // set and is handled by the flagged-type checks well above
+                    // this switch; reaching here means a port object with no
+                    // flags, which still deserves a name.
+                    fprintf(get_output(opts), "#<port>");
+                    break;
+                case HEAP_SUBTYPE_DNC:
+                    fprintf(get_output(opts), "#<dnc>");
+                    break;
+                case HEAP_SUBTYPE_SDNC:
+                    fprintf(get_output(opts), "#<sdnc>");
+                    break;
+                case HEAP_SUBTYPE_TAYLOR:
+                    fprintf(get_output(opts), "#<taylor>");
                     break;
             }
+            ESHKOL_EXHAUSTIVE_SWITCH_END
             break;
         }
 
@@ -418,7 +458,12 @@ void eshkol_display_value_opts(const eshkol_tagged_value_t* value, eshkol_displa
                 break;
             }
             eshkol_object_header_t* header = ESHKOL_GET_HEADER(data_ptr);
-            switch (header->subtype) {
+            if (!eshkol_callable_subtype_is_declared(header->subtype)) {
+                fprintf(get_output(opts), "#<callable:%d>", header->subtype);
+                break;
+            }
+            ESHKOL_EXHAUSTIVE_SWITCH_BEGIN
+            switch ((callable_subtype_t)header->subtype) {
                 case CALLABLE_SUBTYPE_CLOSURE:
                     eshkol_display_closure(value->data.ptr_val, opts);
                     break;
@@ -434,10 +479,8 @@ void eshkol_display_value_opts(const eshkol_tagged_value_t* value, eshkol_displa
                 case CALLABLE_SUBTYPE_CONTINUATION:
                     fprintf(get_output(opts), "#<continuation>");
                     break;
-                default:
-                    fprintf(get_output(opts), "#<callable:%d>", header->subtype);
-                    break;
             }
+            ESHKOL_EXHAUSTIVE_SWITCH_END
             break;
         }
 

--- a/lib/core/runtime_errors_hosted.cpp
+++ b/lib/core/runtime_errors_hosted.cpp
@@ -13,6 +13,7 @@
 #include <eshkol/core/runtime.h>
 #include <eshkol/eshkol.h>
 #include <eshkol/logger.h>
+#include <eshkol/exhaustive_dispatch.h>
 
 #include <cstdarg>
 #include <cstdio>
@@ -210,17 +211,36 @@ const char* eshkol_format_value_type_tag(eshkol_tagged_value_t v) {
             void* p = (void*)v.data.ptr_val;
             if (!p) return "procedure";
             uint8_t sub = *((uint8_t*)p - 8);
-            switch (sub) {
-                case 2: return "ad-node";
-                case 3: return "continuation";
-                default: return "procedure";
+            // Named enum members, not the raw 2/3 this used to compare against:
+            // a magic number is a second, invisible copy of the enum that no
+            // compiler checks, and CALLABLE_SUBTYPE_CONTINUATION being 3 was
+            // never a fact this file could see. No default over the declared
+            // members either — a new callable subtype must be given a name
+            // here rather than inheriting "procedure" by omission.
+            ESHKOL_EXHAUSTIVE_SWITCH_BEGIN
+            switch ((callable_subtype_t)sub) {
+                case CALLABLE_SUBTYPE_AD_NODE:       return "ad-node";
+                case CALLABLE_SUBTYPE_CONTINUATION:  return "continuation";
+                case CALLABLE_SUBTYPE_CLOSURE:
+                case CALLABLE_SUBTYPE_LAMBDA_SEXPR:
+                case CALLABLE_SUBTYPE_PRIMITIVE:     return "procedure";
             }
+            ESHKOL_EXHAUSTIVE_SWITCH_END
+            // Only reachable for a byte that is not a declared subtype at all
+            // (corrupt or foreign object) — the open-set half.
+            return "procedure";
         }
         case ESHKOL_VALUE_HEAP_PTR: {
             void* p = (void*)v.data.ptr_val;
             if (!p) return "null";
             uint8_t sub = *((uint8_t*)p - 8);
-            switch (sub) {
+            // Exhaustive over heap_subtype_t, no default: this function is the
+            // single source of the type name a runtime error reports, and a
+            // subtype that falls through a default is reported to the user as
+            // the generic "heap-object" — an error message that names the wrong
+            // type is its own quiet wrong answer.
+            ESHKOL_EXHAUSTIVE_SWITCH_BEGIN
+            switch ((heap_subtype_t)sub) {
                 case HEAP_SUBTYPE_CONS:           return "pair";
                 case HEAP_SUBTYPE_STRING:         return "string";
                 case HEAP_SUBTYPE_VECTOR:         return "vector";
@@ -242,8 +262,15 @@ const char* eshkol_format_value_type_tag(eshkol_tagged_value_t v) {
                 case HEAP_SUBTYPE_RATIONAL:       return "rational";
                 case HEAP_SUBTYPE_PRNG:           return "prng";
                 case HEAP_SUBTYPE_PARAMETER:      return "parameter";
-                default:                          return "heap-object";
+                case HEAP_SUBTYPE_DNC:            return "dnc";
+                case HEAP_SUBTYPE_SDNC:           return "sdnc";
+                case HEAP_SUBTYPE_TAYLOR:         return "taylor";
+                case HEAP_SUBTYPE_I128:           return "i128";
             }
+            ESHKOL_EXHAUSTIVE_SWITCH_END
+            // Not a declared subtype: a byte read from a corrupt or foreign
+            // object. Genuinely open, so a backstop rather than exhaustiveness.
+            return "heap-object";
         }
         case ESHKOL_VALUE_CONS_PTR:    return "pair";
         case ESHKOL_VALUE_STRING_PTR:  return "string";

--- a/lib/core/runtime_regions.cpp
+++ b/lib/core/runtime_regions.cpp
@@ -12,6 +12,7 @@
 
 #include "arena_memory.h"
 #include "../../inc/eshkol/logger.h"
+#include "../../inc/eshkol/exhaustive_dispatch.h"
 #include "../../inc/eshkol/core/logic.h"       // eshkol_substitution_t / _fact_t / _knowledge_base_t
 #include "../../inc/eshkol/core/inference.h"   // eshkol_factor_graph_t / _factor_t
 #include "../../inc/eshkol/core/workspace.h"   // eshkol_workspace_t / _workspace_module_t
@@ -1087,7 +1088,21 @@ static EvacKind evac_kind_for(const eshkol_tagged_value_t& v, const void* old_da
     const uint8_t sub = h->subtype;
 
     if (ESHKOL_IS_ANY_CALLABLE_TYPE(type)) {
-        if (sub == CALLABLE_SUBTYPE_CLOSURE) return EVAC_CLOSURE;
+        // An exhaustive switch rather than an if-chain, for the same reason as
+        // the heap-subtype switch below: an if-chain's fallthrough is a default
+        // wearing different syntax, and a new callable subtype would inherit
+        // EVAC_LEAF from it in silence.
+        ESHKOL_EXHAUSTIVE_SWITCH_BEGIN
+        switch ((callable_subtype_t)sub) {
+        case CALLABLE_SUBTYPE_CLOSURE:
+            return EVAC_CLOSURE;
+        case CALLABLE_SUBTYPE_LAMBDA_SEXPR:
+        case CALLABLE_SUBTYPE_PRIMITIVE:
+        case CALLABLE_SUBTYPE_CONTINUATION:
+        case CALLABLE_SUBTYPE_AD_NODE:
+            break;  // handled below
+        }
+        ESHKOL_EXHAUSTIVE_SWITCH_END
         // LAMBDA_SEXPR / AD_NODE / PRIMITIVE / CONTINUATION: their interior
         // reference graph is not confidently traversable here and they almost
         // never escape a region via mutation. Kept shallow (documented).
@@ -1122,7 +1137,7 @@ static EvacKind evac_kind_for(const eshkol_tagged_value_t& v, const void* old_da
         return EVAC_LEAF;
     }
 
-    switch (sub) {
+    switch ((heap_subtype_t)sub) {
         case HEAP_SUBTYPE_CONS:        return EVAC_CONS;
         case HEAP_SUBTYPE_VECTOR:      return EVAC_VECTOR;   // records are vectors too
         case HEAP_SUBTYPE_RECORD:      return EVAC_VECTOR;   // records allocate as vectors;
@@ -1161,17 +1176,36 @@ static EvacKind evac_kind_for(const eshkol_tagged_value_t& v, const void* old_da
         // the F64 case is a cheap no-op there, mirroring EVAC_RATIONAL's
         // is_big==0 fast path just above.
         case HEAP_SUBTYPE_TAYLOR:         return EVAC_TAYLOR;
+        // ── EVAC_LEAF, one subtype at a time ────────────────────────────
+        //
+        // THERE IS NO `default:` HERE, AND THAT IS THE POINT. A default in
+        // this switch would mean "any heap subtype I have not thought about
+        // is self-contained" — which is the ESH-0214d bug stated as a policy.
+        // KB / FACT / SUBSTITUTION / WORKSPACE each carried interior tagged
+        // values, each fell to that default, and each left pointers aimed into
+        // an arena that had already been reclaimed. Listing every member means
+        // a NEW subtype cannot inherit that answer by omission: adding one to
+        // heap_subtype_t without deciding its evacuation is a compile error
+        // (this file is built with -Werror=switch-enum; see
+        // eshkol_require_exhaustive_dispatch in CMakeLists.txt).
+        //
         // STRING / SYMBOL / BIGNUM / BYTEVECTOR / I128: self-contained payloads
         // -> a contiguous leaf copy fully preserves them. I128 in particular is
-        // a flat 16-byte {lo,hi} POD with no interior pointers, so the default
-        // EVAC_LEAF path (a straight memcpy of header+payload) is correct and
-        // complete — no deep walk is needed (confirmed against ESH-0214d).
-        //
+        // a flat 16-byte {lo,hi} POD with no interior pointers, so the leaf
+        // path (a straight memcpy of header+payload) is correct and complete —
+        // no deep walk is needed (confirmed against ESH-0214d).
+        case HEAP_SUBTYPE_STRING:
+        case HEAP_SUBTYPE_SYMBOL:
+        case HEAP_SUBTYPE_BIGNUM:
+        case HEAP_SUBTYPE_BYTEVECTOR:
+        case HEAP_SUBTYPE_I128:
         // Deliberately kept EVAC_LEAF (no interior region pointers, or their
         // interior graph is not confidently/safely traversable here, AND they
         // are not observed to escape a region by mutation):
         //   PORT      - wraps an OS fd/FILE*; handle intentionally shared, not copied.
         //   PRNG      - self-contained state words, no interior pointers.
+        //   PARAMETER - R7RS parameter object; its value is reached through the
+        //               dynamic-environment path, not by walking the object.
         //   DNC/SDNC  - VERIFIED SW-66 by reading both handle layouts:
         //               DncHandle.{mem,usage} (lib/core/dnc_api.c) and
         //               SdncHandle.w (lib/core/sdnc_api.c) are calloc'd on
@@ -1183,12 +1217,28 @@ static EvacKind evac_kind_for(const eshkol_tagged_value_t& v, const void* old_da
         //               into it in the first place. This is a confirmed
         //               property of the current handle layouts, not an
         //               assumption -- see the debug guard just below.
+        //   TAYLOR is NOT in this leaf list -- see its explicit EVAC_TAYLOR
+        //   case above (SW-66's exact-coefficient deep-walk fix).
         // A guarded assert below (region_evacuate leaf handler) fires under a debug
-        // build if either subtype's handle layout ever changes to hold a real
-        // arena pointer without this switch being updated to match, so a real
-        // regression is discovered instead of silently corrupting.
-        default:                       return EVAC_LEAF;
+        // build if any such subtype is ever seen with a real arena pointer or
+        // actually escaping, so a real regression is discovered instead of
+        // silently corrupting.
+        case HEAP_SUBTYPE_PORT:
+        case HEAP_SUBTYPE_PRNG:
+        case HEAP_SUBTYPE_PARAMETER:
+        case HEAP_SUBTYPE_DNC:
+        case HEAP_SUBTYPE_SDNC:
+            return EVAC_LEAF;
     }
+
+    // Unreachable for any DECLARED subtype: the switch above names every
+    // member of heap_subtype_t and the compiler enforces that. This arm exists
+    // for the value that is not a declared subtype at all — a header byte read
+    // out of a corrupted or foreign object. Leaf-copying it would be the same
+    // silent shallow copy this switch exists to prevent, so it is reported.
+    eshkol_warn("region evacuate: undeclared heap subtype %u; leaf-copying, "
+                "interior pointers (if any) will dangle", (unsigned)sub);
+    return EVAC_LEAF;
 }
 
 // Copy a headerless raw buffer (closure env, hash arrays, tensor buffers,
@@ -1254,7 +1304,12 @@ static void* evac_object(EvacState& st, void* old_data, const eshkol_tagged_valu
     if (k == EVAC_LEAF) {
         const auto* dh = (const eshkol_object_header_t*)
             ((const uint8_t*)new_data - sizeof(eshkol_object_header_t));
-        switch (dh->subtype) {
+        // No default: the watchlist is a decision about every subtype, so a
+        // NEW subtype must be placed on it or off it explicitly. A default
+        // would put every future subtype silently in the "not watched" half —
+        // which is how a subtype gets shallow-copied for a release without
+        // anyone hearing about it.
+        switch ((heap_subtype_t)dh->subtype) {
             case HEAP_SUBTYPE_DNC:
             case HEAP_SUBTYPE_SDNC:
                 eshkol_warn("region evacuate: subtype %u escaped a region as a "
@@ -1263,7 +1318,36 @@ static void* evac_object(EvacState& st, void* old_data, const eshkol_tagged_valu
                             "subtype needs a real evac_kind_for case.",
                             (unsigned)dh->subtype);
                 break;
-            default: break;
+            // Not watched: self-contained payloads, or objects whose interior
+            // is reached by a path other than the evacuator (PORT wraps an fd,
+            // PARAMETER is read through the dynamic environment).
+            case HEAP_SUBTYPE_STRING:
+            case HEAP_SUBTYPE_SYMBOL:
+            case HEAP_SUBTYPE_BIGNUM:
+            case HEAP_SUBTYPE_BYTEVECTOR:
+            case HEAP_SUBTYPE_I128:
+            case HEAP_SUBTYPE_PORT:
+            case HEAP_SUBTYPE_PRNG:
+            case HEAP_SUBTYPE_PARAMETER:
+            // Deep-walked above, so reaching the leaf handler at all would mean
+            // evac_kind_for and this watchlist disagree; nothing to warn about
+            // here, because k == EVAC_LEAF already excluded them.
+            case HEAP_SUBTYPE_CONS:
+            case HEAP_SUBTYPE_VECTOR:
+            case HEAP_SUBTYPE_RECORD:
+            case HEAP_SUBTYPE_MULTI_VALUE:
+            case HEAP_SUBTYPE_HASH:
+            case HEAP_SUBTYPE_TENSOR:
+            case HEAP_SUBTYPE_EXCEPTION:
+            case HEAP_SUBTYPE_SUBSTITUTION:
+            case HEAP_SUBTYPE_FACT:
+            case HEAP_SUBTYPE_KNOWLEDGE_BASE:
+            case HEAP_SUBTYPE_FACTOR_GRAPH:
+            case HEAP_SUBTYPE_WORKSPACE:
+            case HEAP_SUBTYPE_PROMISE:
+            case HEAP_SUBTYPE_RATIONAL:
+            case HEAP_SUBTYPE_TAYLOR:
+                break;
         }
     }
 #endif
@@ -1676,7 +1760,13 @@ static eshkol_tagged_value_t region_evacuate_value(eshkol_tagged_value_t val,
                 break;
             }
             case EVAC_LEAF:
-            default:
+                // Never enqueued (region_evacuate only pushes non-leaf kinds),
+                // but named rather than defaulted: this switch has no default,
+                // so a new EvacKind cannot be added without deciding here how
+                // its interior is walked. A default would let one be added and
+                // silently walk nothing — which, for a kind added precisely
+                // because it HAS interior pointers, is the ESH-0214d bug back
+                // at the other end of the same pipeline.
                 break;
         }
     }

--- a/scripts/gate_exhaustive_dispatch.py
+++ b/scripts/gate_exhaustive_dispatch.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python3
+"""Release gate: no dispatch switch over a closed enum may carry a `default:`.
+
+THE DEFECT CLASS
+    PR #498 found four tensor-valued AD node types falling into an early
+    `default:` in eshkol_tensor_backward_dispatch that did nothing at all:
+    gradients came back exactly 0.0, with no diagnostic and exit 0.  That
+    default's comment asserted the case was impossible, reasoning from a
+    numeric band of enum values ("every tensor op is 19-32 or 67-80") that four
+    newer node types had already stepped outside of.  The comment was the only
+    thing enforcing the claim.  ESH-0214d is the same shape one subsystem over:
+    heap subtypes carrying interior pointers fell to a shallow-leaf `default:`
+    in the region evacuator and left those pointers aimed into a reclaimed
+    arena.
+
+    The fix is compile-time — no `default:`, plus -Werror=switch-enum (whole
+    file) or ESHKOL_EXHAUSTIVE_SWITCH_BEGIN/_END (one switch).  This gate is
+    the second, source-derived half: it re-derives the enum's members from
+    their DEFINITION and checks each registered dispatch site against them, so
+    the property is re-measured on every lane including the ones whose
+    toolchain (MSVC) has no such diagnostic, and so removing the enforcement
+    is itself caught.
+
+WHAT IS CHECKED
+    For every site in SITES:
+      1. the switch names EVERY member of its enum, derived from the enum's
+         own definition — not from a hand-typed list that could drift;
+      2. the switch contains NO `default:` label;
+      3. the enforcement is actually armed: the file is listed in CMakeLists'
+         eshkol_require_exhaustive_dispatch(), or the switch is wrapped in
+         ESHKOL_EXHAUSTIVE_SWITCH_BEGIN/_END.
+    Plus, for the AD node registry specifically:
+      4. one registry row per ad_node_type_t member, values dense and equal to
+         their ordinal (the dispatch tables are indexed by node type);
+      5. every row declaring BRIDGE names a backward function that is DEFINED
+         in lib/bridge/tensor_backward.cpp.
+
+WHAT IS NOT CHECKED, ON PURPOSE
+    Switches over values that arrive from outside the program — bytecode
+    opcodes, subtype bytes read off a header or a file, integers crossing an
+    FFI boundary — are dispatching over an OPEN set whatever the enum declares.
+    Those keep a `default:`, and it must be a loud, value-naming abort.  A gate
+    that demanded exhaustiveness there would be enforcing a fiction.
+
+Usage
+    python3 scripts/gate_exhaustive_dispatch.py
+    python3 scripts/gate_exhaustive_dispatch.py --format json
+    python3 scripts/gate_exhaustive_dispatch.py --self-test
+
+Exit status is 0 on PASS and 1 on FAIL, so this also works as a plain CI step.
+
+Copyright (C) tsotchke
+SPDX-License-Identifier: MIT
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_TRACE_DIR = os.path.join(REPO_ROOT, "scripts", "icc_traces")
+TRACE_BASENAME = "exhaustive_dispatch_gate.jsonl"
+PROBE_ID = "closed_enum_dispatch_exhaustive"
+
+AD_REGISTRY = os.path.join("inc", "eshkol", "ad_node_registry.def")
+BRIDGE_IMPL = os.path.join("lib", "bridge", "tensor_backward.cpp")
+CMAKELISTS = "CMakeLists.txt"
+
+# Each site names a dispatch switch that MUST be exhaustive over a closed enum.
+#   file       source file holding the switch
+#   func       enclosing function, used only to locate the switch
+#   enum       enum whose members the switch must name in full
+#   enum_file  where that enum is DEFINED; the member set is parsed from there
+#   armed_by   "cmake"  -> file listed in eshkol_require_exhaustive_dispatch()
+#              "pragma" -> switch wrapped in ESHKOL_EXHAUSTIVE_SWITCH_BEGIN/_END
+SITES = [
+    {
+        "file": os.path.join("lib", "backend", "tensor_backward.cpp"),
+        "func": "eshkol_tensor_backward_dispatch",
+        "enum": "ad_node_type_t",
+        "enum_file": os.path.join("inc", "eshkol", "eshkol.h"),
+        "armed_by": "cmake",
+        "why": "the PR #498 site: a tensor node reaching a default returned a "
+               "gradient of exactly 0.0 with no diagnostic",
+    },
+    {
+        "file": os.path.join("lib", "backend", "tensor_backward.cpp"),
+        "func": "eshkol_ad_node_type_name",
+        "enum": "ad_node_type_t",
+        "enum_file": os.path.join("inc", "eshkol", "eshkol.h"),
+        "armed_by": "cmake",
+        "why": "an unnamed node type makes every abort message below it a "
+               "number the reader has to go decode",
+    },
+    {
+        "file": os.path.join("lib", "backend", "tensor_backward.cpp"),
+        "func": "eshkol_ad_node_type_is_tensor",
+        "enum": "ad_node_type_t",
+        "enum_file": os.path.join("inc", "eshkol", "eshkol.h"),
+        "armed_by": "cmake",
+        "why": "payload kind decides whether reaching the tensor dispatcher is "
+               "normal or is itself the bug",
+    },
+    {
+        "file": os.path.join("lib", "core", "runtime_regions.cpp"),
+        "func": "evac_kind_for",
+        "enum": "heap_subtype_t",
+        "enum_file": os.path.join("inc", "eshkol", "eshkol.h"),
+        "armed_by": "cmake",
+        "why": "ESH-0214d: a subtype falling to a shallow leaf copy leaves "
+               "interior pointers in a reclaimed arena",
+    },
+    {
+        "file": os.path.join("inc", "eshkol", "eshkol.h"),
+        "func": "eshkol_heap_subtype_is_declared",
+        "enum": "heap_subtype_t",
+        "enum_file": os.path.join("inc", "eshkol", "eshkol.h"),
+        "armed_by": "pragma",
+        "why": "the predicate that separates the closed half of every "
+               "heap-subtype dispatch from the open half",
+    },
+    {
+        "file": os.path.join("inc", "eshkol", "eshkol.h"),
+        "func": "eshkol_callable_subtype_is_declared",
+        "enum": "callable_subtype_t",
+        "enum_file": os.path.join("inc", "eshkol", "eshkol.h"),
+        "armed_by": "pragma",
+        "why": "same split for callable subtypes",
+    },
+    {
+        # This one is inside `#ifndef NDEBUG`, so the COMPILER never sees it in
+        # a release build — which is precisely why it needs a source-derived
+        # check. -Werror=switch-enum on this file cannot protect a switch the
+        # preprocessor removed before the build CI actually runs.
+        "file": os.path.join("lib", "core", "runtime_regions.cpp"),
+        "func": "evac_object",
+        "enum": "heap_subtype_t",
+        "enum_file": os.path.join("inc", "eshkol", "eshkol.h"),
+        "armed_by": "cmake",
+        "why": "the ESH-0214d watchlist: a decision about every subtype, so a "
+               "new one must be placed on it or off it explicitly",
+    },
+    {
+        "file": os.path.join("lib", "core", "runtime_errors_hosted.cpp"),
+        "func": "eshkol_format_value_type_tag",
+        "enum": "heap_subtype_t",
+        "enum_file": os.path.join("inc", "eshkol", "eshkol.h"),
+        "armed_by": "pragma",
+        "why": "the single source of the type name a runtime error reports; a "
+               "defaulted subtype tells the user the wrong type",
+    },
+]
+
+CMAKE_ARM_FUNCTION = "eshkol_require_exhaustive_dispatch"
+
+
+class GateError(Exception):
+    """A registered site could not be read or located."""
+
+
+# ───────────────────────────── source parsing ─────────────────────────────
+
+def _strip_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//[^\n]*", "", text)
+
+
+def enum_members(source: str, enum_name: str) -> list:
+    """Member names of `enum_name`, parsed from its own definition.
+
+    Deriving this from the DEFINITION rather than a list in this file is the
+    whole point: a hand-maintained expected-set would drift out of date in
+    exactly the situation the gate exists to catch (someone adds a member).
+    """
+    src = _strip_comments(source)
+    # [^{}]* rather than .*? — a lazy dot still crosses intervening `}` and
+    # would splice two unrelated enums into one member set.
+    m = re.search(r"typedef\s+enum\s*\{([^{}]*)\}\s*" + re.escape(enum_name) + r"\s*;",
+                  src, re.S)
+    if not m:
+        raise GateError("enum %s not found in its declared definition file" % enum_name)
+    body = m.group(1)
+    members = []
+    for line in body.split(","):
+        mm = re.match(r"\s*([A-Za-z_]\w*)", line)
+        if mm:
+            members.append(mm.group(1))
+    # X-macro-generated enums expand at compile time; recover their members
+    # from the .def the enum includes, so this gate reads what the compiler
+    # reads rather than the macro text.
+    inc = re.search(r'#\s*include\s+"([^"]*\.def)"', body)
+    if inc:
+        def_path = os.path.join(REPO_ROOT, "inc", inc.group(1))
+        if not os.path.exists(def_path):
+            def_path = os.path.join(REPO_ROOT, inc.group(1))
+        with open(def_path, encoding="utf-8") as handle:
+            rows = registry_rows(handle.read())
+        # Keep only the enum's own trailing members (the sentinel), not the
+        # macro's parameter names, which the naive comma split also picks up.
+        generated = ["AD_NODE_" + r["name"] for r in rows]
+        trailing = [m for m in members if m.startswith("AD_NODE_")]
+        members = generated + trailing
+    return members
+
+
+def function_body(source: str, func_name: str) -> str:
+    """Text of `func_name`'s body, brace-matched from its opening brace."""
+    m = re.search(r"\b" + re.escape(func_name) + r"\s*\([^;{]*\)\s*\{", source, re.S)
+    if not m:
+        raise GateError("function %s not found" % func_name)
+    i = source.index("{", m.start())
+    depth = 0
+    for j in range(i, len(source)):
+        if source[j] == "{":
+            depth += 1
+        elif source[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[i:j + 1]
+    raise GateError("unbalanced braces in %s" % func_name)
+
+
+def switch_on_enum(body: str, members: list) -> str:
+    """The one switch inside `body` that dispatches on this enum.
+
+    A function may hold several switches — the outer one over value tags, the
+    inner one over heap subtypes — and grading the whole function body would
+    flag the outer switch's legitimate default as if it were the inner
+    switch's. Pick the switch whose case labels actually belong to the enum in
+    question, and grade only that one.
+    """
+    member_set = set(members)
+    best, best_hits = None, 0
+    for m in re.finditer(r"\bswitch\s*\(", body):
+        i = body.find("{", m.end())
+        if i < 0:
+            continue
+        depth, end = 0, None
+        for j in range(i, len(body)):
+            if body[j] == "{":
+                depth += 1
+            elif body[j] == "}":
+                depth -= 1
+                if depth == 0:
+                    end = j + 1
+                    break
+        if end is None:
+            continue
+        text = body[i:end]
+        hits = len(member_set & set(re.findall(r"\bcase\s+([A-Za-z_]\w*)\s*:", text)))
+        # Ties go to the SMALLEST switch: an outer switch textually contains
+        # its nested ones, so it scores every inner hit too. Innermost is the
+        # switch that actually dispatches on this enum.
+        if hits > best_hits or (hits and hits == best_hits and len(text) < len(best)):
+            best, best_hits = text, hits
+    if best is None:
+        raise GateError("no switch over the target enum found")
+    return best
+
+
+def registry_rows(text: str) -> list:
+    rows = []
+    for m in re.finditer(
+            r"^ESHKOL_AD_NODE\(\s*(\w+)\s*,\s*(\d+)\s*,\s*(\w+)\s*,\s*(\w+)\s*,\s*(\w+)\s*\)",
+            text, re.M):
+        rows.append({
+            "name": m.group(1), "value": int(m.group(2)), "payload": m.group(3),
+            "backward": m.group(4), "bridge_fn": m.group(5),
+        })
+    return rows
+
+
+# ───────────────────────────── grading ─────────────────────────────
+
+def grade_site(site: dict, repo_root: str) -> dict:
+    path = os.path.join(repo_root, site["file"])
+    with open(path, encoding="utf-8") as handle:
+        source = handle.read()
+    enum_path = os.path.join(repo_root, site["enum_file"])
+    with open(enum_path, encoding="utf-8") as handle:
+        enum_source = handle.read()
+
+    members = enum_members(enum_source, site["enum"])
+    func = function_body(source, site["func"])
+    generated = "ad_node_registry.def" in func
+    # A generated dispatch expands its case labels from the .def at compile
+    # time, so there are no `case` tokens in the source to match on; grade the
+    # whole function body in that case.
+    body = func if generated else switch_on_enum(_strip_comments(func), members)
+    body_nc = _strip_comments(body)
+
+    findings = []
+
+    if re.search(r"\bdefault\s*:", body_nc):
+        findings.append(
+            "carries a `default:` — a default over a closed enum answers "
+            "'member I have not thought about' with a plausible value")
+
+    labelled = set(re.findall(r"\bcase\s+([A-Za-z_]\w*)\s*:", body_nc))
+    missing = []
+    for member in members:
+        if member.endswith("_TYPE_COUNT"):
+            continue
+        if member not in labelled and not generated:
+            missing.append(member)
+    if missing:
+        findings.append("does not name %d enum member(s): %s"
+                        % (len(missing), ", ".join(sorted(missing)[:12])))
+
+    if site["armed_by"] == "pragma":
+        if "ESHKOL_EXHAUSTIVE_SWITCH_BEGIN" not in func:
+            findings.append(
+                "is not wrapped in ESHKOL_EXHAUSTIVE_SWITCH_BEGIN/_END, so "
+                "nothing raises -Wswitch-enum at this switch")
+    else:
+        with open(os.path.join(repo_root, CMAKELISTS), encoding="utf-8") as handle:
+            cmake = handle.read()
+        m = re.search(re.escape(CMAKE_ARM_FUNCTION) + r"\((.*?)\)", cmake, re.S)
+        armed = m and site["file"].replace(os.sep, "/") in _strip_comments(m.group(1))
+        if not armed:
+            findings.append(
+                "translation unit is not listed in %s(), so -Werror=switch-enum "
+                "is not applied to it" % CMAKE_ARM_FUNCTION)
+
+    return {
+        "site": "%s:%s" % (site["file"], site["func"]),
+        "enum": site["enum"],
+        "members": len(members),
+        "generated_arms": generated,
+        "findings": findings,
+    }
+
+
+def grade_ad_registry(repo_root: str) -> dict:
+    with open(os.path.join(repo_root, AD_REGISTRY), encoding="utf-8") as handle:
+        rows = registry_rows(handle.read())
+    with open(os.path.join(repo_root, BRIDGE_IMPL), encoding="utf-8") as handle:
+        bridge_src = _strip_comments(handle.read())
+
+    findings = []
+    if not rows:
+        findings.append("registry has no rows at all")
+
+    for ordinal, row in enumerate(rows):
+        if row["value"] != ordinal:
+            findings.append(
+                "row %s declares value %d but is at ordinal %d — the dispatch "
+                "tables are indexed by node type and assume the two agree"
+                % (row["name"], row["value"], ordinal))
+            break
+
+    names = [r["name"] for r in rows]
+    dupes = sorted({n for n in names if names.count(n) > 1})
+    if dupes:
+        findings.append("duplicate registry rows: %s" % ", ".join(dupes))
+
+    valid = {"LEAF", "SCALAR_ADJOINT", "INLINE", "BRIDGE", "CUSTOM_VJP", "UNREGISTERED"}
+    for row in rows:
+        if row["backward"] not in valid:
+            findings.append("row %s declares unknown disposition %s"
+                            % (row["name"], row["backward"]))
+        if row["backward"] == "BRIDGE":
+            fn = row["bridge_fn"]
+            if fn == "ESHKOL_AD_NO_BRIDGE":
+                findings.append("row %s declares BRIDGE but names no function" % row["name"])
+            elif not re.search(r"\b" + re.escape(fn) + r"\s*\(\s*ad_node_t\s*\*", bridge_src):
+                findings.append(
+                    "row %s declares BRIDGE and names %s, which is not defined "
+                    "in %s — a registration that registers nothing"
+                    % (row["name"], fn, BRIDGE_IMPL))
+        elif row["bridge_fn"] != "ESHKOL_AD_NO_BRIDGE":
+            findings.append("row %s is %s but names a bridge function"
+                            % (row["name"], row["backward"]))
+
+    by_disposition = {}
+    for row in rows:
+        by_disposition[row["backward"]] = by_disposition.get(row["backward"], 0) + 1
+
+    return {
+        "site": AD_REGISTRY,
+        "rows": len(rows),
+        "by_disposition": by_disposition,
+        "findings": findings,
+    }
+
+
+def grade(repo_root: str = REPO_ROOT) -> dict:
+    results = []
+    failed = 0
+    try:
+        for site in SITES:
+            r = grade_site(site, repo_root)
+            results.append(r)
+            failed += len(r["findings"])
+        reg = grade_ad_registry(repo_root)
+        results.append(reg)
+        failed += len(reg["findings"])
+    except (GateError, OSError) as exc:
+        return {
+            "status": "FAIL",
+            "results": results,
+            "error": str(exc),
+            "summary": "gate could not read a registered dispatch site: %s" % exc,
+        }
+    return {
+        "status": "FAIL" if failed else "PASS",
+        "results": results,
+        "error": None,
+        "summary": ("%d finding(s) across %d registered dispatch sites"
+                    % (failed, len(SITES)) if failed
+                    else "%d registered dispatch sites are exhaustive over their "
+                         "closed enums and carry no default" % len(SITES)),
+    }
+
+
+# ───────────────────────────── reporting ─────────────────────────────
+
+def emit_trace(trace_dir: str, status: str, snippet: str) -> str:
+    os.makedirs(trace_dir, exist_ok=True)
+    path = os.path.join(trace_dir, TRACE_BASENAME)
+    event = {
+        "kind": "eshkol_smoke",
+        "name": PROBE_ID,
+        "value": status,
+        "snippet": snippet[:2000],
+        "confidence": 1.0,
+    }
+    # Rewritten, never appended: a stale PASS must not survive a regression.
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+    return path
+
+
+def render(report: dict) -> str:
+    lines = ["closed-enum dispatch exhaustiveness: %s" % report["status"], ""]
+    for r in report["results"]:
+        head = r["site"]
+        if "enum" in r:
+            head += "  [%s, %d members%s]" % (
+                r["enum"], r["members"], ", generated arms" if r["generated_arms"] else "")
+        else:
+            head += "  [%d rows: %s]" % (
+                r["rows"], ", ".join("%s=%d" % kv for kv in sorted(r["by_disposition"].items())))
+        lines.append(("  FAIL  " if r["findings"] else "  ok    ") + head)
+        for f in r["findings"]:
+            lines.append("          - " + f)
+    lines += ["", report["summary"]]
+    return "\n".join(lines)
+
+
+# ───────────────────────────── self-test ─────────────────────────────
+#
+# "A gate that cannot fail is not a gate." Each fixture feeds the graders
+# deliberately-broken input and asserts the finding actually appears.
+
+_ENUM_FIXTURE = """
+typedef enum {
+    THING_A,
+    THING_B,
+    THING_C
+} thing_t;
+"""
+
+_GOOD_SWITCH = """
+static int classify(thing_t t) {
+    ESHKOL_EXHAUSTIVE_SWITCH_BEGIN
+    switch (t) {
+        case THING_A: return 1;
+        case THING_B: return 2;
+        case THING_C: return 3;
+    }
+    ESHKOL_EXHAUSTIVE_SWITCH_END
+    return 0;
+}
+"""
+
+_DEFAULTED_SWITCH = """
+static int classify(thing_t t) {
+    ESHKOL_EXHAUSTIVE_SWITCH_BEGIN
+    switch (t) {
+        case THING_A: return 1;
+        case THING_B: return 2;
+        case THING_C: return 3;
+        default: return 0;   /* the whole defect class, in one line */
+    }
+    ESHKOL_EXHAUSTIVE_SWITCH_END
+}
+"""
+
+_INCOMPLETE_SWITCH = """
+static int classify(thing_t t) {
+    ESHKOL_EXHAUSTIVE_SWITCH_BEGIN
+    switch (t) {
+        case THING_A: return 1;
+        case THING_B: return 2;
+    }
+    ESHKOL_EXHAUSTIVE_SWITCH_END
+    return 0;
+}
+"""
+
+_UNARMED_SWITCH = """
+static int classify(thing_t t) {
+    switch (t) {
+        case THING_A: return 1;
+        case THING_B: return 2;
+        case THING_C: return 3;
+    }
+    return 0;
+}
+"""
+
+_COMMENT_ONLY_SWITCH = """
+static int classify(thing_t t) {
+    ESHKOL_EXHAUSTIVE_SWITCH_BEGIN
+    switch (t) {
+        case THING_A: return 1;
+        case THING_B: return 2;
+        case THING_C: return 3;
+        /* Every member is handled above, so this cannot be reached. */
+        default: return 0;
+    }
+    ESHKOL_EXHAUSTIVE_SWITCH_END
+}
+"""
+
+
+def _fixture_findings(tmpdir: str, switch_src: str) -> list:
+    os.makedirs(os.path.join(tmpdir, "lib", "core"), exist_ok=True)
+    src = os.path.join("lib", "core", "fixture.c")
+    with open(os.path.join(tmpdir, src), "w", encoding="utf-8") as handle:
+        handle.write(_ENUM_FIXTURE + switch_src)
+    site = {"file": src, "func": "classify", "enum": "thing_t",
+            "enum_file": src, "armed_by": "pragma", "why": "self-test"}
+    return grade_site(site, tmpdir)["findings"]
+
+
+def self_test() -> int:
+    import tempfile
+    failures = []
+    cases = []
+    with tempfile.TemporaryDirectory(dir=os.path.join(REPO_ROOT, ".scratch")
+                                     if os.path.isdir(os.path.join(REPO_ROOT, ".scratch"))
+                                     else None) as tmp:
+        cases = [
+            ("exhaustive+armed is clean", _GOOD_SWITCH, 0, None),
+            ("a default: is caught", _DEFAULTED_SWITCH, 1, "default"),
+            ("a missing member is caught", _INCOMPLETE_SWITCH, 1, "THING_C"),
+            ("an unarmed switch is caught", _UNARMED_SWITCH, 1, "ESHKOL_EXHAUSTIVE_SWITCH_BEGIN"),
+            # The exact shape of #498: the default is not merely present, it is
+            # ANNOTATED with a comment asserting it cannot be reached. A comment
+            # is not enforcement, and the gate must not be fooled by one.
+            ("a default with an it-cannot-happen comment is still caught",
+             _COMMENT_ONLY_SWITCH, 1, "default"),
+        ]
+        for name, src, want, needle in cases:
+            found = _fixture_findings(tmp, src)
+            if want == 0 and found:
+                failures.append("%s: expected clean, got %s" % (name, found))
+            elif want and not found:
+                failures.append("%s: expected a finding, got none" % name)
+            elif want and needle and not any(needle in f for f in found):
+                failures.append("%s: finding did not mention %r: %s" % (name, needle, found))
+
+    # A registry row claiming a backward function that does not exist must FAIL.
+    rows = registry_rows("ESHKOL_AD_NODE(FAKE, 0, TENSOR, BRIDGE, no_such_backward)\n")
+    if len(rows) != 1 or rows[0]["bridge_fn"] != "no_such_backward":
+        failures.append("registry row parser did not read a BRIDGE row correctly")
+
+    for f in failures:
+        print("SELF-TEST FAIL: " + f)
+    if failures:
+        return 1
+    # Count the fixtures rather than hardcoding the number: a hardcoded count
+    # that stops matching the list is the same shape of stale assertion this
+    # whole gate exists to prevent.
+    print("SELF-TEST PASS: %d fixtures" % (len(cases) + 1))
+    return 0
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--format", choices=("text", "json"), default="text")
+    ap.add_argument("--trace-dir", default=DEFAULT_TRACE_DIR)
+    ap.add_argument("--no-trace", action="store_true")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    report = grade()
+    text = render(report)
+    if args.format == "json":
+        print(json.dumps(report, indent=2))
+    else:
+        print(text)
+    if not args.no_trace:
+        emit_trace(args.trace_dir, report["status"], text)
+    return 0 if report["status"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/backend/exhaustive_dispatch_test.cpp
+++ b/tests/backend/exhaustive_dispatch_test.cpp
@@ -1,0 +1,323 @@
+/**
+ * @file exhaustive_dispatch_test.cpp
+ * @brief SW-70: the AD node registry is total, and a node type with no
+ *        registered backward REFUSES rather than returning a plausible zero.
+ *
+ * WHAT THIS GUARDS
+ *   PR #498 found four tensor-valued AD node types falling into an early
+ *   `default:` in eshkol_tensor_backward_dispatch that did nothing at all —
+ *   gradients exactly 0.0, no diagnostic, exit 0 — behind a comment asserting
+ *   the case was impossible, reasoned from a numeric band of enum values that
+ *   those four node types had already stepped outside of. Auditing the class
+ *   found four MORE still live on master: AD_NODE_HYPERBOLIC_DISTANCE,
+ *   AD_NODE_POINCARE_EXP_MAP, AD_NODE_POINCARE_LOG_MAP and
+ *   AD_NODE_GEODESIC_ATTENTION are recorded as TENSOR nodes by
+ *   lib/bridge/qllm_bridge.cpp and land in the same default.
+ *
+ *   The primary fix is a COMPILE-TIME one: no `default:`, plus
+ *   -Werror=switch -Werror=switch-enum, so an unhandled node type is a build
+ *   failure. This file guards the parts a compiler cannot see:
+ *
+ *     1. the registry is DENSE — one row per value, 0..COUNT-1, no gaps and
+ *        no duplicates. The backward table is a flat array indexed by node
+ *        type; a gap would make it index a hole;
+ *     2. every node type has a NAME, because the abort messages are the whole
+ *        user-visible surface of a missing backward;
+ *     3. the payload declarations are consistent — every disposition that only
+ *        makes sense for a tensor node is on a TENSOR row;
+ *     4. every row declaring BRIDGE resolves to a real registered function,
+ *        and every row that does NOT declare BRIDGE resolves to nothing, so
+ *        the table and the dispositions cannot drift apart;
+ *     5. an UNREGISTERED node type with a live upstream gradient REFUSES.
+ *        This is the assertion that would have failed before the fix: the old
+ *        dispatcher returned normally and left every gradient at 0.0.
+ *
+ * Copyright (C) tsotchke
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <cstdio>
+#include <cstring>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "eshkol/eshkol.h"
+#include "eshkol/backend/tensor_backward.h"
+
+#if !defined(_WIN32)
+#include <sys/wait.h>
+#include <unistd.h>
+#define ESHKOL_HAVE_FORK_DEATH_TESTS 1
+#endif
+
+extern "C" {
+    typedef struct arena arena_t;
+    arena_t* get_global_arena(void);
+    void* arena_allocate_zeroed(arena_t* arena, size_t size);
+    ad_node_t* arena_allocate_ad_node(arena_t* arena);
+    typedef void (*backward_fn_t)(ad_node_t*);
+    backward_fn_t get_tensor_backward_fn(int node_type);
+}
+
+namespace {
+
+int g_passed = 0;
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = std::string()) {
+    std::printf("  %-58s %s", name, ok ? "PASS" : "FAIL");
+    if (!detail.empty()) std::printf("   [%s]", detail.c_str());
+    std::printf("\n");
+    if (ok) ++g_passed; else ++g_failed;
+}
+
+/* ── The registry, read back in C++ from the same rows the compiler used ──
+ * Not a second copy of the table: the SAME .def, expanded again. A drift
+ * between this and the dispatch is impossible by construction, which is the
+ * point — the test can then check properties OF the rows rather than trying
+ * to re-state them. */
+enum Disposition { LEAF, SCALAR_ADJOINT, INLINE_ARM, BRIDGE, CUSTOM_VJP, UNREGISTERED };
+
+struct Row {
+    const char* name;
+    int value;
+    bool tensor_payload;
+    Disposition disposition;
+};
+
+#define ESHKOL_AD_NO_BRIDGE 0
+#define ESHKOL_AD_TEST_PAYLOAD_SCALAR false
+#define ESHKOL_AD_TEST_PAYLOAD_TENSOR true
+#define ESHKOL_AD_TEST_DISP_LEAF           LEAF
+#define ESHKOL_AD_TEST_DISP_SCALAR_ADJOINT SCALAR_ADJOINT
+#define ESHKOL_AD_TEST_DISP_INLINE         INLINE_ARM
+#define ESHKOL_AD_TEST_DISP_BRIDGE         BRIDGE
+#define ESHKOL_AD_TEST_DISP_CUSTOM_VJP     CUSTOM_VJP
+#define ESHKOL_AD_TEST_DISP_UNREGISTERED   UNREGISTERED
+
+const Row kRegistry[] = {
+#define ESHKOL_AD_NODE(NAME, VALUE, PAYLOAD, TENSOR_BACKWARD, BRIDGE_FN) \
+    { "AD_NODE_" #NAME, (VALUE), ESHKOL_AD_TEST_PAYLOAD_##PAYLOAD,       \
+      ESHKOL_AD_TEST_DISP_##TENSOR_BACKWARD },
+#include "eshkol/ad_node_registry.def"
+#undef ESHKOL_AD_NODE
+};
+
+const size_t kRegistryRows = sizeof(kRegistry) / sizeof(kRegistry[0]);
+
+/* ───────────────────────────── 1. density ───────────────────────────── */
+
+void test_registry_is_dense() {
+    bool ok = (kRegistryRows == (size_t)AD_NODE_TYPE_COUNT);
+    std::string detail = std::to_string(kRegistryRows) + " rows, COUNT=" +
+                         std::to_string((int)AD_NODE_TYPE_COUNT);
+    for (size_t i = 0; ok && i < kRegistryRows; ++i) {
+        if (kRegistry[i].value != (int)i) {
+            ok = false;
+            detail = std::string(kRegistry[i].name) + " declares value " +
+                     std::to_string(kRegistry[i].value) + " at ordinal " +
+                     std::to_string(i);
+        }
+    }
+    report("ad_node_registry_is_dense", ok, detail);
+}
+
+/* ───────────────────────────── 2. names ───────────────────────────── */
+
+void test_every_node_type_has_a_name() {
+    bool ok = true;
+    std::string detail;
+    std::set<std::string> seen;
+    for (size_t i = 0; i < kRegistryRows; ++i) {
+        const char* got = eshkol_ad_node_type_name(kRegistry[i].value);
+        if (!got || std::strcmp(got, kRegistry[i].name) != 0) {
+            ok = false;
+            detail = std::string("value ") + std::to_string(kRegistry[i].value) +
+                     " named " + (got ? got : "(null)") + ", expected " +
+                     kRegistry[i].name;
+            break;
+        }
+        if (!seen.insert(got).second) {
+            ok = false;
+            detail = std::string("duplicate name ") + got;
+            break;
+        }
+    }
+    report("every_node_type_has_a_unique_name", ok, detail);
+
+    // Out of range must not read past the table.
+    const char* oob = eshkol_ad_node_type_name((int)AD_NODE_TYPE_COUNT + 4096);
+    report("out_of_range_node_type_is_named_not_indexed",
+           oob != nullptr && std::strstr(oob, "out-of-range") != nullptr,
+           oob ? oob : "(null)");
+}
+
+/* ─────────────────────── 3. payload consistency ─────────────────────── */
+
+void test_payload_declarations_are_consistent() {
+    bool ok = true;
+    std::string detail;
+    for (size_t i = 0; i < kRegistryRows; ++i) {
+        const Row& r = kRegistry[i];
+        const bool needs_tensor = (r.disposition == INLINE_ARM ||
+                                   r.disposition == BRIDGE ||
+                                   r.disposition == UNREGISTERED);
+        if (needs_tensor && !r.tensor_payload) {
+            ok = false;
+            detail = std::string(r.name) + " has a tensor-only disposition on a SCALAR payload";
+            break;
+        }
+        if (eshkol_ad_node_type_is_tensor(r.value) != r.tensor_payload) {
+            ok = false;
+            detail = std::string(r.name) + ": generated payload predicate disagrees with its row";
+            break;
+        }
+    }
+    report("payload_declarations_are_consistent", ok, detail);
+}
+
+/* ──────────────────── 4. the bridge table is total ──────────────────── */
+
+void test_every_bridge_row_resolves_to_a_registered_backward() {
+    bool ok = true;
+    std::string detail;
+    int bridged = 0;
+    for (size_t i = 0; i < kRegistryRows; ++i) {
+        const Row& r = kRegistry[i];
+        backward_fn_t fn = get_tensor_backward_fn(r.value);
+        if (r.disposition == BRIDGE) {
+            ++bridged;
+            if (!fn) {
+                ok = false;
+                detail = std::string(r.name) + " declares BRIDGE but the table has no entry";
+                break;
+            }
+        } else if (fn) {
+            ok = false;
+            detail = std::string(r.name) + " is not BRIDGE but the table has an entry";
+            break;
+        }
+    }
+    if (ok && bridged == 0) {
+        ok = false;
+        detail = "no BRIDGE rows at all — the table would be vacuously total";
+    }
+    report("every_bridge_row_resolves_to_a_registered_backward", ok,
+           ok ? (std::to_string(bridged) + " bridged") : detail);
+
+    // A node type outside the enum must not index the flat table.
+    report("out_of_range_node_type_does_not_index_the_table",
+           get_tensor_backward_fn(-1) == nullptr &&
+           get_tensor_backward_fn((int)AD_NODE_TYPE_COUNT) == nullptr);
+}
+
+/* ─────────── 5. an UNREGISTERED node refuses, never returns 0.0 ─────────── */
+
+#if defined(ESHKOL_HAVE_FORK_DEATH_TESTS)
+
+/** @brief True iff running @p body in a forked child terminates abnormally or
+ *  exits nonzero — i.e. it REFUSED rather than returning. */
+bool refuses(void (*body)()) {
+    std::fflush(stdout);
+    std::fflush(stderr);
+    pid_t pid = fork();
+    if (pid < 0) return false;
+    if (pid == 0) {
+        FILE* devnull = std::freopen("/dev/null", "w", stderr);
+        (void)devnull;
+        body();
+        std::_Exit(0);   /* reached only if the call did NOT refuse */
+    }
+    int status = 0;
+    if (waitpid(pid, &status, 0) < 0) return false;
+    if (WIFSIGNALED(status)) return true;
+    return WIFEXITED(status) && WEXITSTATUS(status) != 0;
+}
+
+/** @brief Build a tensor node of @p type with a live upstream gradient and a
+ *  variable input, then run the reverse dispatch on it. Before this change
+ *  every UNREGISTERED type returned from here having done nothing, leaving
+ *  the input gradient at exactly 0.0. */
+void drive_unregistered(ad_node_type_t type) {
+    arena_t* a = get_global_arena();
+    const size_t n = 4;
+    static int64_t shape[1];
+    shape[0] = (int64_t)n;
+
+    ad_node_t* in = arena_allocate_ad_node(a);
+    in->type = AD_NODE_VARIABLE;
+    in->tensor_value = arena_allocate_zeroed(a, n * sizeof(double));
+    in->shape = shape;
+    in->ndim = 1;
+
+    ad_node_t* out = arena_allocate_ad_node(a);
+    out->type = type;
+    out->tensor_value = arena_allocate_zeroed(a, n * sizeof(double));
+    out->tensor_gradient = arena_allocate_zeroed(a, n * sizeof(double));
+    for (size_t i = 0; i < n; ++i) ((double*)out->tensor_gradient)[i] = 1.0;
+    out->shape = shape;
+    out->ndim = 1;
+    out->input1 = in;
+
+    eshkol_tensor_backward_dispatch(out);
+}
+
+void body_geodesic()  { drive_unregistered(AD_NODE_GEODESIC_ATTENTION); }
+void body_hyperbolic(){ drive_unregistered(AD_NODE_HYPERBOLIC_DISTANCE); }
+void body_exp_map()   { drive_unregistered(AD_NODE_POINCARE_EXP_MAP); }
+void body_log_map()   { drive_unregistered(AD_NODE_POINCARE_LOG_MAP); }
+
+void test_unregistered_tensor_backward_is_declared_not_silent() {
+    // The four the qLLM bridge actually produces. Each one of these assertions
+    // FAILED before this change — the dispatcher returned normally and the
+    // caller read a gradient of exactly 0.0 as if it were the answer.
+    report("geodesic_attention_backward_refuses",  refuses(body_geodesic));
+    report("hyperbolic_distance_backward_refuses", refuses(body_hyperbolic));
+    report("poincare_exp_map_backward_refuses",    refuses(body_exp_map));
+    report("poincare_log_map_backward_refuses",    refuses(body_log_map));
+}
+
+#else
+
+void test_unregistered_tensor_backward_is_declared_not_silent() {
+    std::printf("  %-58s SKIP  [no fork()]\n",
+                "unregistered_tensor_backward_refuses");
+}
+
+#endif
+
+/** @brief Every UNREGISTERED row must be reachable as a refusal, i.e. it must
+ *  not silently also have a bridge entry. Cheap, but it is the property that
+ *  makes the four death tests above representative of all eight. */
+void test_all_unregistered_rows_have_no_backward() {
+    bool ok = true;
+    std::string detail;
+    int count = 0;
+    for (size_t i = 0; i < kRegistryRows; ++i) {
+        if (kRegistry[i].disposition != UNREGISTERED) continue;
+        ++count;
+        if (get_tensor_backward_fn(kRegistry[i].value) != nullptr) {
+            ok = false;
+            detail = std::string(kRegistry[i].name) +
+                     " is UNREGISTERED but a backward is registered for it";
+            break;
+        }
+    }
+    report("all_unregistered_rows_have_no_backward", ok,
+           ok ? (std::to_string(count) + " unregistered") : detail);
+}
+
+}  // namespace
+
+int main() {
+    std::printf("SW-70 closed-enum dispatch exhaustiveness\n");
+    test_registry_is_dense();
+    test_every_node_type_has_a_name();
+    test_payload_declarations_are_consistent();
+    test_every_bridge_row_resolves_to_a_registered_backward();
+    test_all_unregistered_rows_have_no_backward();
+    test_unregistered_tensor_backward_is_declared_not_silent();
+    std::printf("\n%d passed, %d failed\n", g_passed, g_failed);
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## The class, not the four sites

PR #498 found four tensor-valued AD node types falling into an early `default:` in `eshkol_tensor_backward_dispatch` that did **nothing at all**: gradients came back exactly `0.0`, no diagnostic, exit 0. That default's comment asserted the case was impossible, reasoning from a **numeric band of enum values** — *"every TENSOR op (19-32 and the qLLM bridge ops 67-80) has an explicit case above, so a tensor-op gradient can never silently fall through this default"* — a proxy that four newer node types had already stepped outside of. The comment was the only thing enforcing the claim, and a comment enforces nothing.

The shape is general: **a dispatch switch over a closed enum, carrying a `default:` that encodes an assumption instead of failing, in a language where the enum can grow without the switch ever knowing.** ESH-0214d is the same defect one subsystem over — heap subtypes carrying interior pointers fell to a shallow-leaf `default:` in the region evacuator and left those pointers aimed into a reclaimed arena.

### The same defect is still live on master, in four more node types

Not inferred from reading the source — **measured against master's own library (`afbaaf5b`)**:

```
master (afbaaf5b): reverse pass through qLLM geometric tensor nodes
  AD_NODE_HYPERBOLIC_DISTANCE  returned normally; input grad = STILL NULL (nothing propagated)
  AD_NODE_POINCARE_EXP_MAP     returned normally; input grad = STILL NULL (nothing propagated)
  AD_NODE_POINCARE_LOG_MAP     returned normally; input grad = STILL NULL (nothing propagated)
  AD_NODE_GEODESIC_ATTENTION   returned normally; input grad = STILL NULL (nothing propagated)
exit 0
```

`lib/bridge/qllm_bridge.cpp` records all four as **tensor** nodes (`make_node(tape, AD_NODE_..., out, shape, ...)` with a live `tensor_value`), and the reverse sweep `autodiff_codegen.cpp` emits routes *any* node with a non-null `tensor_gradient` to this dispatcher. `33-40` is exactly the band the comment did not cover. Every gradient through a Poincaré exp/log map, a hyperbolic distance or a geodesic attention returned zero, silently.

They survived review because the adjoint *does* exist — codegen emits scalar backward blocks for node types 33-40. It just is not on the sweep the bridge's tensor nodes actually take.

---

## Inventory

180 switches with three or more enum-member case labels were classified. **They are not all this defect.** The discriminator is what the default *does*:

| default arm | count | verdict |
|---|---:|---|
| **produces** — answers with a value | 120 | candidate: a member nobody considered gets a plausible answer |
| **refuses** — `eshkol_error` / `return false` / `*ok = 0` | 20 | correct as written: a partial classification stating its own boundary |
| **no default** | 40 | already exhaustive |

Of the 120 "produces", by enum:

| enum | sites | disposition here |
|---|---:|---|
| `eshkol_op_t` (113 members) | 24 | **deferred** — codegen dispatch; large mechanical diff |
| `eshkol_type_t` (22) | 21 | **deferred** |
| `ValType` / `OpCode` / `HeapType` (VM) | 31 | **loud backstop, correct** — dispatches on bytes read from bytecode |
| `hott_type_kind_t`, `pattern_type_t`, `TokenType`, … | ~42 | **deferred** |
| `eshkol_value_type_t` (24) | 10 | **deferred** — tag byte carries flag bits; partly open |
| `heap_subtype_t` | 2 | 1 **converted**, 1 **deferred** (`sexp_to_ast.cpp`) |
| `ad_node_type_t`, `callable_subtype_t`, `EvacKind` | — | **converted in full** |

**Converted (compiler-enforced, no `default:`):**

| site | enum |
|---|---|
| `lib/backend/tensor_backward.cpp` · `eshkol_tensor_backward_dispatch` | `ad_node_type_t` (83) |
| `lib/backend/tensor_backward.cpp` · `eshkol_ad_node_type_name`, `…_is_tensor` | `ad_node_type_t` |
| `lib/bridge/tensor_backward.cpp` · `get_tensor_backward_fn` | generated table, switch removed |
| `lib/core/runtime_regions.cpp` · `evac_kind_for` | `heap_subtype_t` (25) + `callable_subtype_t` (5) |
| `lib/core/runtime_regions.cpp` · interior-walk worklist | `EvacKind` (15) |
| `lib/core/runtime_regions.cpp` · ESH-0214d debug watchlist | `heap_subtype_t` |
| `lib/core/runtime_errors_hosted.cpp` · `eshkol_format_value_type_tag` | `heap_subtype_t`, `callable_subtype_t` |
| `lib/core/runtime_display_hosted.cpp` · `display` | `heap_subtype_t`, `callable_subtype_t` |
| `lib/core/introspection.cpp` · `eshkol_type_of` | `heap_subtype_t`, `callable_subtype_t` |
| `inc/eshkol/eshkol.h` · `eshkol_{heap,callable}_subtype_is_declared` | both |

**Left as loud backstops, deliberately:** the VM's `OpCode` / `ValType` / `HeapType` switches. A value that arrives from *outside* the program is an open set whatever the enum declares; demanding exhaustiveness there enforces a fiction. `lib/backend/vm_region_evac.c` already carries the registry pattern (a coverage table with a startup assertion, `INV-vm-region-evac-subtype-total`).

**Deferred as build items, mechanism proven:** `lib/core/sexp_to_ast.cpp`'s heap-subtype switch, whose `default: break` falls through to a null AST rather than refusing — same class, different subsystem; and the ~20 `eshkol_op_t` switches, whose conversion is a large mechanical diff that does not belong in the same change as the fix. Both recorded in SW-66 `notes`.

---

## The fix

**1 · Registry.** `inc/eshkol/ad_node_registry.def` is now the single declaration point for an AD node type: `ESHKOL_AD_NODE(NAME, VALUE, PAYLOAD, TENSOR_BACKWARD, BRIDGE_FN)`. The `ad_node_type_t` enum, the dispatcher's homogeneous arms, and the bridge backward table are all **generated** from these rows. A node type cannot exist without stating its backward disposition. A row claiming `BRIDGE` names a function; if that symbol does not exist, `lib/bridge/tensor_backward.cpp` does not compile — that is what makes *registered* a fact rather than an intention.

Values are unchanged (they are an ABI: emitted IR compares `node->type` against integer literals) and a static assertion proves the set stays dense, which the node-type-indexed table relies on.

**2 · Compiler enforcement.** No `default:`, plus `-Werror=switch -Werror=switch-enum` — per translation unit via `eshkol_require_exhaustive_dispatch()`, or per switch via `ESHKOL_EXHAUSTIVE_SWITCH_BEGIN/_END` (`inc/eshkol/exhaustive_dispatch.h`) where a file legitimately mixes closed dispatch with open. Both flags, because they are not redundant: `-Wswitch` is what fires for an unhandled member in a default-less switch; `-Wswitch-enum` is what *still* fires once someone re-adds a `default:` — the exact move that reopens this class, and precisely where `-Wswitch` goes quiet.

**3 · Open sets stay loud.** `eshkol_heap_subtype_is_declared` / `eshkol_callable_subtype_is_declared` split the open half off — a subtype byte read out of an object header is untrusted input — and each caller answers it with a value-naming fallback. That lets the closed half be exhaustive without pretending a corrupt byte is impossible. The single `default:` those switches used to carry answered *"corrupt byte"* and *"enum member added last week"* with the same shrug.

**4 · Refusal, not invention.** The eight geometric node types are declared `UNREGISTERED` — an explicit, written-down refusal — and the dispatcher aborts naming the node type. Writing exact Riemannian adjoints is AD work with its own correctness bar and belongs to the lane doing it; inventing one to close a dispatch hole is how a wrong gradient ships. **The four qLLM ops go from silently zero to loudly absent.**

**5 · ICC invariant.** `INV-closed-enum-dispatch-exhaustive` + `scripts/gate_exhaustive_dispatch.py` re-derive each enum's members **from its own definition** (not a hand-typed list, which would drift in exactly the situation being guarded) and fail on any registered site that carries a default, omits a member, or is not armed. It is the half the compiler cannot provide on MSVC — and the half that catches the enforcement being *removed*. Plus `INV-ad-node-declared-in-registry` as key-space equality between registry `BRIDGE` rows and the backward functions actually defined, catching the other direction: a backward rule that exists, works, and is wired to nothing (which is how seven bridge ops sat with correct backwards registered while the dispatcher dropped their gradients).

---

## Red proofs (measured, not asserted)

**Compile-time — new member, no arm:**
```
error: enumeration value 'AD_NODE_REDPROOF_NEW_OP' not handled in switch [-Werror,-Wswitch]
make[3]: *** [CMakeFiles/…/tensor_backward.cpp.o] Error 1
```

**Compile-time — new member with a `default:` restored (the #498 shape exactly):**
```
error: enumeration value 'AD_NODE_REDPROOF_NEW_OP' not explicitly handled in switch [-Werror,-Wswitch-enum]
```
The default cannot defeat the flag. This is why both diagnostics are escalated.

**A `default:` re-added alone** compiles (it is then dead code) and is caught by the gate instead:
```
FAIL  lib/backend/tensor_backward.cpp:eshkol_tensor_backward_dispatch  [ad_node_type_t, 84 members]
        - carries a `default:` — a default over a closed enum answers 'member I have not
          thought about' with a plausible value
```

**Gate self-test:** 5 fixtures, including one whose `default:` is annotated with an it-cannot-happen comment — the shape that fooled review — proving the gate is not fooled by the annotation.

All three were run and then reverted; the tree is clean.

---

## Gates

| gate | result |
|---|---|
| `ctest` (full) | **204/204 passed**, including the 3 new tests |
| `exhaustive_dispatch` (new) | 11/11 — registry density, name/payload totality, table↔disposition agreement, and 4 fork death tests proving the qLLM ops refuse |
| `exhaustive_dispatch_gate` + `_selftest` (new) | PASS |
| arena-poison suite (`ad_tape_region_growth`, `parallel_map_scope_reclaim`, `runtime_regions`, `parameter_region_barrier`) | PASS under `ESHKOL_ARENA_POISON=1` |
| `vm_parity_audit.py` | OK — every codegen symbol VM-supported or waived |
| `gate_ad_shared_node_model.py` | `ad_carrier_model_clean: PASS` |
| `check_ledger_integrity.py` | PASS |
| `gate_no_silent_wrong.py` | PASS |
| `check_oracle_schema.py` | PASS |

Ledger: **SW-66**, bucket SILENT-WRONG, status `guarded` — the wrong *value* is gone, but four of the eight geometric node types still cannot compute the right one, so the entry stays open until the Riemannian adjoints land.

---

## Coordination

- `.worktrees/evac-subtypes` (DNC/SDNC/TAYLOR deep-walk) currently touches only `.icc/architecture-model.yaml`. This PR's evac change is **structural only** — `default:` removal and explicit case labels; DNC/SDNC/TAYLOR keep their present `EVAC_LEAF` classification and their ESH-0214d watchlist entry. If that lane lands first, the conflict is three case labels moving from the leaf list to deep-walk kinds, and the exhaustiveness structure makes that change *easier* to verify, not harder.
- `.worktrees/abi-v2-stage1` is untouched.
- The qLLM geometric-backwards lane: this PR does not implement any adjoint. When those land, the four rows move from `UNREGISTERED` to `BRIDGE` with a named function, and the generated arms follow automatically.
