### PR TITLE
fix(gpu): close the vacuous GPU correctness gate (SW-67)

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -5943,3 +5943,102 @@ entries:
       consumer can build on. Scope was the GPU harness/test contract only;
       no dispatch-switch code was touched (a parallel lane owns that
       surface).
+
+  - id: SW-71
+    bucket: VACUOUS-ASSURANCE
+    status: closed
+    closed_at: "fix/gpu-correctness-gate-vacuous"
+    closed_by: "branch fix/gpu-correctness-gate-vacuous"
+    title: "Windows judge: ^-anchored FAIL: marker regexes matched only line 1 of captured output; markers after a banner line were invisible on every Windows suite; discovered when the GPU gate canary was judged NO FAIL MARKER"
+    repro: >-
+      On windows-x64-cuda, tests/gpu/gate_canary_must_fail.esk (SW-67's
+      deliberate, permanent-failure canary) exits nonzero and prints a
+      banner line first, then its marker on the SECOND line:
+        === GPU Gate Canary (this test MUST fail) ===
+        FAIL: gate_canary_must_fail (deliberate: expected C[0,0]=999.0, got 19) - this failure is EXPECTED
+      scripts/run_all_tests.ps1's Invoke-SimpleCompileRunSuite grades the
+      canary path with `$FailRegex -and -not ($run.Output -match
+      $FailRegex)` for suites configured with an anchored FailRegex such as
+      "^FAIL:|Failed:\s+[1-9]" (gpu, and the same ^-anchored shape on the
+      bignum/rational/parallel/signal/error_handling/macros/io/benchmark/
+      migration/codegen/numeric suites; Invoke-TimedCompileRunSuite's
+      ASSERTION FAIL check and Invoke-XlaSuite's inline `$run.Output -match
+      "^FAIL:"` share the same construction). PowerShell's bare -match
+      calls .NET regex without RegexOptions::Multiline, so a bare `^`
+      anchors to the START OF THE WHOLE STRING, not each line: because the
+      banner line comes first, `^FAIL:` never matches, and the judge
+      reports "CANARY FAILED WITH NO FAIL MARKER" even though the marker
+      is right there on line 2. windows-x64-cuda failed three consecutive
+      PR #501 runs on this false negative before the anchoring defect
+      itself was identified as the root cause.
+    observed: >-
+      The canary's own FAIL: marker, present verbatim in stdout, was
+      reported as absent - "gate_canary_must_fail.esk (must-fail canary
+      exited nonzero but printed no FAIL: marker)" - purely because it was
+      not the first line of the captured output. The defect is not scoped
+      to the canary: the identical `$run.Output -match $FailRegex`
+      evaluation is also the ASSERTION FAIL path for every ordinary test in
+      every Windows suite listed above, so a genuine `FAIL:` marker printed
+      after any banner, header or diagnostic line was silently invisible to
+      the judge in the OTHER direction too - a real regression whose
+      marker isn't on line 1 would have been graded PASS, not FAIL.
+      -RequirePassMarker's unanchored "PASS" check and the
+      RuntimeErrorRegex "error:" checks carry no `^`/`$` anchor and were
+      not affected by this half of the defect.
+    correct: >-
+      A `^`-anchored marker regex passed to a Windows suite runner means "a
+      line that starts with this marker" - the same semantics the bash
+      judge gets for free from grep's line-by-line matching
+      (scripts/run_gpu_tests.sh, scripts/lib/test_isolation.sh) - not "the
+      first line of the entire captured stream is this marker." Every site
+      that evaluates a FailRegex/RuntimeErrorRegex/RequirePassMarker or ad
+      hoc marker regex against a test process's captured output must apply
+      RegexOptions.Multiline (or equivalent line-splitting) so that `^`/`$`
+      bind per line, defined in exactly one place so the semantics cannot
+      drift back out of sync at a future call site.
+    observed_after: >-
+      Added `Test-OutputMatches -Output $Output -Regex $Regex` (wraps
+      [regex]::IsMatch with RegexOptions.Multiline) as the single choke
+      point for marker-regex evaluation in scripts/run_all_tests.ps1, and
+      routed every FailRegex/RuntimeErrorRegex/RequirePassMarker check in
+      Invoke-SimpleCompileRunSuite and Invoke-TimedCompileRunSuite, plus
+      Invoke-XlaSuite's inline `^FAIL:`/`PASS`/`error:` checks, through it
+      - six call sites total; none of the suites' own FailRegex/
+      RuntimeErrorRegex string literals changed. Verified on the real
+      Windows 10 / PowerShell 5.1 host (desktop-jack-blupc) with a
+      csc.exe-built stub eshkol-run.exe standing in for the compiler: (a)
+      the real canary fixture (banner line, then a FAIL: marker on line 2,
+      exit 1) -> PASS (must-fail canary correctly failed) with 0 failed;
+      (b) an ordinary fixture (a couple of lines, exit 0) -> PASS; (c) the
+      canary forced to exit 0 -> FAIL "did not fail - verdict pipeline is
+      broken"; (d) an ordinary fixture that exits 0 but prints a `FAIL:`
+      marker on line 2 -> now correctly graded FAIL, proving marker
+      detection is live again for normal tests, not just the canary; (e)
+      `[System.Management.Automation.Language.Parser]::ParseFile` reports
+      no syntax errors under PowerShell 5.1.19041.
+    fixed_by: >-
+      branch fix/gpu-correctness-gate-vacuous - Test-OutputMatches helper
+      in scripts/run_all_tests.ps1, applied at every FailRegex/
+      RuntimeErrorRegex/RequirePassMarker/inline-marker evaluation site.
+    evidence: >-
+      scripts/run_all_tests.ps1 (Test-OutputMatches,
+      Invoke-SimpleCompileRunSuite, Invoke-TimedCompileRunSuite,
+      Invoke-XlaSuite) - real-host run on desktop-jack-blupc (Windows 10,
+      PowerShell 5.1.19041) against a csc.exe-built stub compiler plus two
+      fixture executables, results (a)-(e) above; local `pwsh -NoProfile`
+      parse check; python3 scripts/check_ps1_encoding.py PASS (the file
+      stays pure ASCII).
+    caught_by: [windows-x64-cuda-ci, direct-measurement]
+    missed_by: [run_all_tests.ps1 (pre-fix), icc-smoke, icc-readiness]
+    notes: >-
+      Discovered while fixing SW-67's own must-fail canary contract on
+      Windows (commit 0b4ce1ce): the canary went red for the right reason
+      (the must-fail file did fail) but the judge's *reason* for choosing
+      the FAIL branch it took was already wrong, one layer down. A judge
+      that cannot see a marker that IS there is the same shape of defect
+      as a gate that cannot go red at all (SW-67's VACUOUS-ASSURANCE
+      finding) - one degree closer to the reporting layer instead of the
+      test-content layer. Scope is the Windows PowerShell judge only;
+      scripts/run_gpu_tests.sh and scripts/lib/test_isolation.sh's
+      bash-side grep-based marker matching already operate line-by-line
+      and are unaffected.

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -5839,3 +5839,107 @@ entries:
       returns a value where no finite log exists; the backward refuses there
       rather than differentiate the clamp, matching what the Frechet machinery
       already does on the same condition.
+  - id: SW-67
+    bucket: VACUOUS-ASSURANCE
+    status: closed
+    closed_at: "fix/gpu-correctness-gate-vacuous"
+    closed_by: "branch fix/gpu-correctness-gate-vacuous"
+    title: "The GPU correctness gate could not fail: no test program's failed checks reached its process exit code, and four of them emitted no failure-shaped output at all"
+    repro: >-
+      Read tests/gpu/gpu_correctness_gate.esk on unmodified origin/master: it
+      prints ten unlabelled `RESULT <label> <value>` lines and `GATE-DONE`,
+      then falls off the end with no PASS/FAIL/error/mismatch token in any
+      form and no `(exit ...)` call. Same for tests/gpu/gpu_test.esk,
+      sf64_simple_test.esk and sf64_nonuniform_test.esk — all three compute
+      results and display "(expected N)" comments but never compare actual
+      against expected. Every other file under tests/gpu/*.esk (13 of 17,
+      plus the already-compliant ozaki_certification_test.esk) DID print a
+      well-formed `FAIL: <description>` line on a failed check, but NONE of
+      them — not one, checked exhaustively — ever called `exit` with a
+      nonzero status: a failed check only ever produced text, never a
+      process-level signal. scripts/run_gpu_tests.sh's own marker-matching
+      history (scripts/lib/test_isolation.sh's "Honest failure detection"
+      section) already documents a PRIOR near-miss of this same defect
+      class: an anchored `^FAIL:` regex missed every indented `  <case>:
+      FAIL` marker and sf64_primitives_test.esk's colonless `FAIL (got
+      ...`, fixed before this ledger entry by making marker matching
+      unanchored and boundary-based. That fix closed the marker-QUALITY
+      half of the problem; it could not close this half, because a marker
+      regex — however good — has nothing to match in a file that never
+      prints a failure-shaped token, and even where a real `FAIL:` marker
+      existed, this harness's own contract said exit code should be the
+      verdict, which none of these files ever honored.
+    observed: >-
+      A GPU kernel that silently computed the wrong answer for the matmul,
+      elementwise add/mul, transpose round-trip or reduce workload in
+      gpu_correctness_gate.esk would print numbers nobody was checking and
+      exit 0 — scripts/run_gpu_tests.sh would print PASS regardless. For the
+      13 files with FAIL: markers but no exit code, a failed check was
+      visible to a human reading full output but invisible to any judge
+      that graded on exit status alone (as the exit-code-primary contract
+      this fix establishes now requires).
+    correct: >-
+      Every tests/gpu/*.esk program must exit non-zero if and only if a
+      check inside it failed, so the process exit code alone is a
+      sufficient, judge-agnostic verdict. A PASS:/FAIL: marker grammar
+      remains as a diagnostic backstop, not the verdict channel. A test
+      that produces no recognized verdict at all must be graded FAIL, not
+      PASS — absence of evidence that a check ran is not evidence the
+      check passed.
+    observed_after: >-
+      All 17 non-compliant tests/gpu/*.esk files now aggregate a
+      gate-failures counter and call `(exit 0)`/`(exit 1)` on a final
+      PASS:/FAIL: verdict line, matching the strongest pre-existing
+      convention in the suite (tests/gpu/ozaki_certification_test.esk).
+      gpu_correctness_gate.esk gained ten backend-independent self-check
+      invariants (finiteness, exact transpose round-trip, an independent
+      manual reduce-sum cross-check, sum(A+B)==sum(A)+sum(B)) so it has
+      teeth even when run standalone (not through the CPU-vs-GPU
+      differential in gpu_correctness_gate.sh). A canary,
+      tests/gpu/gate_canary_must_fail.esk, is a deliberate permanent
+      failure that scripts/run_gpu_tests.sh runs on every invocation and
+      requires to fail (non-zero exit AND a FAIL: marker); if it ever
+      passes, the whole run is forced red regardless of every other
+      result. tests/gpu/gpu_correctness_gate.sh gained a `--self-test`
+      mode asserting its SKIP path writes no trace record while its
+      FAIL/PASS paths write distinguishable ones (closing the
+      SKIP-must-never-read-as-PASS half of this class at the trace-emission
+      layer, complementing .icc/completion-oracles.yaml's existing
+      severity:high absence-is-FAIL handling for the `gpu-execution`
+      target). Verified red-to-green on both changed target files by
+      corrupting one check in each and confirming a nonzero exit with a
+      FAIL: line, then reverting. Full suite run locally under Metal
+      (Apple M2 Ultra): canary RED, self-test PASS, all 18 real
+      tests/gpu/*.esk files PASS, exit 0. The CPU-vs-GPU differential
+      (tests/gpu/gpu_correctness_gate.sh) was also run end-to-end (fresh
+      GPU-enabled and CPU-only builds) and measured exactly 0 relative
+      divergence across all ten probes, which is also why this fix tightens
+      that script's GPU_GATE_TOL default from 1e-4 to 1e-9 and corrects a
+      stale comment claiming `display` prints only ~6 significant digits —
+      `display` calls the shortest-round-trip formatter
+      (eshkol_dtoa_shortest), confirmed bit-exact by a direct round-trip
+      probe.
+    fixed_by: >-
+      branch fix/gpu-correctness-gate-vacuous — structured exit-code
+      contract across every tests/gpu/*.esk file, ten new self-check
+      invariants in gpu_correctness_gate.esk, tests/gpu/gate_canary_must_fail.esk,
+      a --self-test mode in tests/gpu/gpu_correctness_gate.sh, an additive
+      eshkol_test_output_has_verdict()/eshkol_test_output_has_success_marker()
+      pair in scripts/lib/test_isolation.sh (opt-in, no change to any
+      existing caller's behavior) wired into a new "NO VERDICT" grading
+      branch in scripts/run_gpu_tests.sh, and the VERDICT CONTRACT
+      documentation block at that script's head.
+    evidence: >-
+      tests/gpu/*.esk (17 files changed), tests/gpu/gate_canary_must_fail.esk
+      (new), tests/gpu/gpu_correctness_gate.sh, scripts/run_gpu_tests.sh,
+      scripts/lib/test_isolation.sh — local Metal run captured in this PR's
+      body (canary RED, self-test PASS, 18/18 real tests PASS, differential
+      gate PASS with measured max_rel_diff=0 at the new 1e-9 tolerance).
+    caught_by: [cross-repo-certification-audit, direct-measurement]
+    missed_by: [run_gpu_tests.sh (pre-fix), icc-smoke, icc-readiness]
+    notes: >-
+      Blocks the Eshkol-emits-certified-CUDA-kernels program: a GPU
+      correctness gate that cannot fail is not evidence a certification
+      consumer can build on. Scope was the GPU harness/test contract only;
+      no dispatch-switch code was touched (a parallel lane owns that
+      surface).

--- a/scripts/lib/test_isolation.sh
+++ b/scripts/lib/test_isolation.sh
@@ -578,3 +578,46 @@ eshkol_test_output_has_marker() {
     [ -n "$marker" ] || return 0
     LC_ALL=C grep -Eq -- "$marker" "$file" 2>/dev/null
 }
+
+# ---------------------------------------------------------------------------
+# "No verdict" detection — additive, opt-in (does not change the default
+# behavior any existing caller of eshkol_test_output_has_failure /
+# eshkol_test_output_is_silent gets).
+#
+# eshkol_test_output_is_silent only catches a program that printed NOTHING.
+# It does not catch a program that printed plenty of text — diagnostics,
+# intermediate values, a banner — but never emitted a single PASS/FAIL-shaped
+# verdict token anywhere. That gap is exactly how tests/gpu/gpu_correctness_gate.esk
+# used to pass every run of scripts/run_gpu_tests.sh regardless of whether the
+# numbers it printed were right: it printed only unlabelled "RESULT <label>
+# <value>" lines and exited 0 unconditionally, so eshkol_test_output_has_failure
+# never matched (nothing failure-shaped was ever printed) and
+# eshkol_test_output_is_silent never matched (there was plenty of output) —
+# the only reachable verdict was PASS, no matter what the run actually
+# computed. "It printed things" is not the same claim as "it printed a
+# verdict"; a caller that wants the stronger claim enforced calls
+# eshkol_test_output_has_verdict explicitly.
+ESHKOL_TEST_SUCCESS_REGEX='(^|[^A-Za-z0-9_])(PASS|PASSED|OK)([^A-Za-z0-9_]|$)'
+
+# True when the file contains at least one PASS/PASSED/OK-shaped token,
+# subject to the same verdict-noise filtering eshkol_test_output_has_failure
+# uses (so a "Passed: 0" line does not count).
+eshkol_test_output_has_success_marker() {
+    local file="$1"
+    [ -f "$file" ] || return 1
+    eshkol_test_filter_verdict_noise < "$file" \
+        | LC_ALL=C grep -Eq -- "$ESHKOL_TEST_SUCCESS_REGEX" 2>/dev/null
+}
+
+# True when the file contains ANY recognized verdict token — a failure marker
+# (eshkol_test_output_has_failure) or a success marker
+# (eshkol_test_output_has_success_marker). False means the program produced no
+# evidence either way, which a caller enforcing rule 2's full strength must
+# treat as FAIL, never PASS — absence of evidence that any check ran is not
+# evidence the checks passed. $2 — optional extra failure ERE, passed through.
+eshkol_test_output_has_verdict() {
+    local file="$1"
+    local extra="${2:-}"
+    eshkol_test_output_has_failure "$file" "$extra" \
+        || eshkol_test_output_has_success_marker "$file"
+}

--- a/scripts/run_all_tests.ps1
+++ b/scripts/run_all_tests.ps1
@@ -741,6 +741,15 @@ function Invoke-SimpleCompileRunSuite {
 
     foreach ($testFile in $files) {
         $testName = Split-Path -Leaf $testFile
+        # VERDICT CONTRACT (mirrors scripts/run_gpu_tests.sh's canary handling,
+        # e.g. tests/gpu/gate_canary_must_fail.esk): a test file named
+        # `*_must_fail.esk` is a deliberate, permanent failure used to prove
+        # this harness can still fail a real defect. For that file alone the
+        # verdict is inverted — a nonzero exit (with a matching FAIL: marker,
+        # when this suite configures one) is PASS, and an exit of 0 is FAIL.
+        # $testName is already a leaf name (Split-Path -Leaf above), so this
+        # match is path-separator agnostic on both Windows and POSIX inputs.
+        $isMustFailCanary = $testName -match '_must_fail\.esk$'
         $outputBase = New-OutputBase -TempRoot $script:TempRoot -SuiteName $SuiteName -TestName $testName
         $compile = Invoke-EshkolCompile -EshkolRun $script:EshkolRun -ProjectRoot $script:ProjectRoot -BuildDir $script:BuildDir -TestFile $testFile -OutputBase $outputBase
         if ($compile.TimedOut) {
@@ -762,6 +771,25 @@ function Invoke-SimpleCompileRunSuite {
             Add-Fail $suite "$testName (timeout)"
             continue
         }
+
+        if ($isMustFailCanary) {
+            if ($run.ExitCode -eq 0) {
+                Format-TestStatus $testName "CANARY DID NOT FAIL (exit 0)" Red
+                Show-ProcessFailureDetails -TestName $testName -Phase "runtime" -Result $run
+                Add-Fail $suite "$testName (must-fail canary did not fail — verdict pipeline is broken)"
+                continue
+            }
+            if ($FailRegex -and -not ($run.Output -match $FailRegex)) {
+                Format-TestStatus $testName "CANARY FAILED WITH NO FAIL MARKER" Red
+                Show-ProcessFailureDetails -TestName $testName -Phase "runtime" -Result $run
+                Add-Fail $suite "$testName (must-fail canary exited nonzero but printed no FAIL: marker)"
+                continue
+            }
+            Format-TestStatus $testName ("PASS (must-fail canary correctly failed, exit {0})" -f (Format-ExitCodeLabel $run.ExitCode)) Green
+            Add-Pass $suite
+            continue
+        }
+
         if ($run.ExitCode -ne 0) {
             Format-TestStatus $testName ("RUNTIME FAIL (exit {0})" -f (Format-ExitCodeLabel $run.ExitCode)) Red
             Show-ProcessFailureDetails -TestName $testName -Phase "runtime" -Result $run

--- a/scripts/run_all_tests.ps1
+++ b/scripts/run_all_tests.ps1
@@ -710,6 +710,37 @@ function Format-TestStatus {
     Write-Host ("Testing {0,-50} {1}" -f $TestName, $Status) -ForegroundColor $Color
 }
 
+function Test-OutputMatches {
+    # Single choke point for every FailRegex/PassRegex/marker-regex check run
+    # against a test process's captured (possibly multi-line) stdout+stderr.
+    #
+    # PowerShell's bare -match/-notmatch operators call .NET regex WITHOUT
+    # RegexOptions::Multiline, so a bare "^" anchors to the start of the
+    # WHOLE STRING, not the start of each line. A regex like "^FAIL:" was
+    # written (and mirrors the bash judge's line-by-line grep) to mean "a
+    # line starting with FAIL:", but against a multi-line $Output it only
+    # ever matched when that marker happened to be on the string's very
+    # first line - a marker preceded by even one banner line was invisible.
+    # This is what let tests/gpu/gate_canary_must_fail.esk's second-line
+    # `FAIL:` marker go undetected (judged "CANARY FAILED WITH NO FAIL
+    # MARKER"), and the same anchoring silently affected every other
+    # Windows suite using a `^`-prefixed FailRegex.
+    #
+    # Evaluate with the Multiline option so "^"/"$" bind to line boundaries,
+    # matching the intended (and bash-judge-equivalent) semantics. Every
+    # site in this file that tests captured process output against a
+    # FailRegex, PassRegex, RuntimeErrorRegex, or ad hoc marker regex must
+    # route through here so that behavior is defined in exactly one place.
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Output,
+        [Parameter(Mandatory = $true)]
+        [string]$Regex
+    )
+    return [regex]::IsMatch($Output, $Regex, [System.Text.RegularExpressions.RegexOptions]::Multiline)
+}
+
 function Invoke-SimpleCompileRunSuite {
     param(
         [string]$SuiteName,
@@ -779,7 +810,7 @@ function Invoke-SimpleCompileRunSuite {
                 Add-Fail $suite "$testName (must-fail canary did not fail - verdict pipeline is broken)"
                 continue
             }
-            if ($FailRegex -and -not ($run.Output -match $FailRegex)) {
+            if ($FailRegex -and -not (Test-OutputMatches -Output $run.Output -Regex $FailRegex)) {
                 Format-TestStatus $testName "CANARY FAILED WITH NO FAIL MARKER" Red
                 Show-ProcessFailureDetails -TestName $testName -Phase "runtime" -Result $run
                 Add-Fail $suite "$testName (must-fail canary exited nonzero but printed no FAIL: marker)"
@@ -796,12 +827,12 @@ function Invoke-SimpleCompileRunSuite {
             Add-Fail $suite $testName
             continue
         }
-        if ($FailRegex -and $run.Output -match $FailRegex) {
+        if ($FailRegex -and (Test-OutputMatches -Output $run.Output -Regex $FailRegex)) {
             Format-TestStatus $testName "ASSERTION FAIL" Red
             Add-Fail $suite $testName
             continue
         }
-        if ($RuntimeErrorRegex -and $run.Output -match $RuntimeErrorRegex) {
+        if ($RuntimeErrorRegex -and (Test-OutputMatches -Output $run.Output -Regex $RuntimeErrorRegex)) {
             Format-TestStatus $testName "RUNTIME ERROR" Yellow
             Add-Fail $suite $testName
             continue
@@ -1165,12 +1196,12 @@ function Invoke-TimedCompileRunSuite {
             Add-Fail $suite "$testName (runtime exit $($run.ExitCode))"
             continue
         }
-        if ($FailRegex -and $run.Output -match $FailRegex) {
+        if ($FailRegex -and (Test-OutputMatches -Output $run.Output -Regex $FailRegex)) {
             Write-Host "FAIL" -ForegroundColor Red
             Add-Fail $suite "$testName (wrong result)"
             continue
         }
-        if ($RequirePassMarker -and $run.Output -notmatch "PASS") {
+        if ($RequirePassMarker -and -not (Test-OutputMatches -Output $run.Output -Regex "PASS")) {
             Write-Host "UNKNOWN" -ForegroundColor Yellow
             Add-Fail $suite "$testName (no PASS/FAIL)"
             continue
@@ -1500,7 +1531,7 @@ function Invoke-XlaSuite {
             Format-TestStatus $testName ("RUNTIME FAIL (exit {0})" -f (Format-ExitCodeLabel $run.ExitCode)) Red
             Show-ProcessFailureDetails -TestName $testName -Phase "runtime" -Result $run
             Add-Fail $suite $testName
-        } elseif ($run.Output -match "^FAIL:" -or ($run.Output -notmatch "PASS" -and $run.Output -match "(?i)error:")) {
+        } elseif ((Test-OutputMatches -Output $run.Output -Regex "^FAIL:") -or ((-not (Test-OutputMatches -Output $run.Output -Regex "PASS")) -and (Test-OutputMatches -Output $run.Output -Regex "(?i)error:"))) {
             Format-TestStatus $testName "ASSERTION FAIL" Red
             Show-ProcessFailureDetails -TestName $testName -Phase "runtime" -Result $run
             Add-Fail $suite $testName

--- a/scripts/run_all_tests.ps1
+++ b/scripts/run_all_tests.ps1
@@ -745,7 +745,7 @@ function Invoke-SimpleCompileRunSuite {
         # e.g. tests/gpu/gate_canary_must_fail.esk): a test file named
         # `*_must_fail.esk` is a deliberate, permanent failure used to prove
         # this harness can still fail a real defect. For that file alone the
-        # verdict is inverted — a nonzero exit (with a matching FAIL: marker,
+        # verdict is inverted - a nonzero exit (with a matching FAIL: marker,
         # when this suite configures one) is PASS, and an exit of 0 is FAIL.
         # $testName is already a leaf name (Split-Path -Leaf above), so this
         # match is path-separator agnostic on both Windows and POSIX inputs.
@@ -776,7 +776,7 @@ function Invoke-SimpleCompileRunSuite {
             if ($run.ExitCode -eq 0) {
                 Format-TestStatus $testName "CANARY DID NOT FAIL (exit 0)" Red
                 Show-ProcessFailureDetails -TestName $testName -Phase "runtime" -Result $run
-                Add-Fail $suite "$testName (must-fail canary did not fail — verdict pipeline is broken)"
+                Add-Fail $suite "$testName (must-fail canary did not fail - verdict pipeline is broken)"
                 continue
             }
             if ($FailRegex -and -not ($run.Output -match $FailRegex)) {

--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -2,6 +2,56 @@
 
 # Eshkol GPU Test Suite
 # Runs all GPU and softfloat tests
+#
+# ─────────────────────────────────────────────────────────────────────────
+# VERDICT CONTRACT — read this before touching the marker regexes below or
+# in scripts/lib/test_isolation.sh.
+#
+#   1. EXIT CODE IS THE VERDICT, PRIMARY. Every tests/gpu/*.esk program must
+#      exit non-zero if any check inside it failed, and 0 only if every
+#      check passed. A non-zero exit is always graded RUNTIME FAIL here,
+#      full stop, regardless of what the program printed.
+#
+#   2. Per-check marker grammar — diagnostic, and a backstop, not the
+#      verdict channel: after stripping leading whitespace, a line of the
+#      form
+#          PASS: <description>
+#          FAIL: <description> [... extra detail]
+#      Every tests/gpu/*.esk file emits this so a human (or this script's
+#      own summary) can see WHICH check inside a multi-check file failed.
+#      Matching is intentionally unanchored (grep -E, not `^`-anchored) —
+#      an earlier version of this script anchored `^FAIL:` at column 0 and
+#      missed every indented `  <case>: FAIL` marker; see
+#      scripts/lib/test_isolation.sh's "Honest failure detection" section
+#      for the shared regex and its own history (it also had to stop
+#      requiring a trailing colon, because tests/gpu/sf64_primitives_test.esk
+#      used to print a colonless `FAIL (got ...`). It is also NOT a bare
+#      `grep -i error` — this suite's own large fixtures print benign
+#      "ERROR: Heap limit exceeded" runtime warnings on multi-hundred-MB
+#      tensors that are not failures, and a substring match on "error"
+#      would flag every one of them, which is its own way of becoming a
+#      vacuous gate: a judge nobody can trust cries wolf until nobody reads
+#      the output.
+#
+#   3. NO VERDICT IS A FAIL, NOT A PASS. A test that exits 0 but never
+#      printed a single recognized PASS/FAIL-shaped line — see
+#      eshkol_test_output_has_verdict() in test_isolation.sh — is graded
+#      FAIL, reason "NO VERDICT". Absence of evidence that any check ran is
+#      not evidence the checks passed. This is what closes the historical
+#      gap in tests/gpu/gpu_correctness_gate.esk: that file used to print
+#      only unlabelled `RESULT <label> <value>` lines and exit 0
+#      unconditionally, so this harness reported a hollow PASS every run no
+#      matter what the numbers actually were — the file could not fail.
+#
+#   4. THE CANARY. tests/gpu/gate_canary_must_fail.esk is a deliberate,
+#      permanent failure. This script runs it on every invocation, before
+#      the real suite, and requires it to fail (non-zero exit AND a FAIL:
+#      marker). If it ever passes, the verdict pipeline itself is broken —
+#      wrong binary under test, a stubbed-out check, a judge that stopped
+#      reading exit codes — and this script fails HARD regardless of every
+#      other result: a real regression could be hiding behind exactly the
+#      same kind of silence that let the canary through.
+# ─────────────────────────────────────────────────────────────────────────
 
 set -e
 
@@ -126,6 +176,78 @@ run_ozaki_certification() {
     fi
 }
 
+# The gate canary — see the VERDICT CONTRACT header, item 4. Runs before the
+# main suite and is excluded from it (it is SUPPOSED to fail, so it must not
+# be graded by the normal PASS-required loop below). CANARY_HARD_FAIL forces
+# this script's own exit code to 1 at the very end regardless of every other
+# result: a harness that cannot fail cannot be trusted to have passed.
+CANARY_NAME="gate_canary_must_fail.esk"
+CANARY_HARD_FAIL=0
+run_gate_canary() {
+    local canary_path="tests/gpu/$CANARY_NAME"
+    printf "Canary  %-50s " "$CANARY_NAME (must fail)"
+
+    if [ ! -f "$canary_path" ]; then
+        echo -e "${RED}MISSING${NC}"
+        echo -e "${RED}  >>> cannot prove this harness can still fail a real defect${NC}"
+        CANARY_HARD_FAIL=1
+        return 0
+    fi
+
+    eshkol_test_reset_bin
+    if ! ./"$BUILD_DIR"/eshkol-run "$canary_path" -L./"$BUILD_DIR" -o "$ESHKOL_TEST_BIN" > /dev/null 2>&1; then
+        echo -e "${RED}COMPILE FAIL${NC}"
+        echo -e "${RED}  >>> the canary must compile and then fail at runtime — it did neither${NC}"
+        CANARY_HARD_FAIL=1
+        return 0
+    fi
+
+    local canary_rc=0
+    "$ESHKOL_TEST_BIN" > "$ESHKOL_TEST_OUT" 2>&1 || canary_rc=$?
+
+    if [ "$canary_rc" -eq 0 ]; then
+        echo -e "${RED}DID NOT FAIL (exit 0)${NC}"
+        echo -e "${RED}  >>> VERDICT PIPELINE IS BROKEN: a deliberately-wrong result exited 0${NC}"
+        CANARY_HARD_FAIL=1
+        return 0
+    fi
+
+    if ! eshkol_test_output_has_failure "$ESHKOL_TEST_OUT"; then
+        echo -e "${RED}FAILED WITH NO FAIL: MARKER${NC}"
+        echo -e "${RED}  >>> exit code was non-zero but no FAIL: line was printed —${NC}"
+        echo -e "${RED}  >>> the marker grammar itself is broken${NC}"
+        CANARY_HARD_FAIL=1
+        return 0
+    fi
+
+    echo -e "${GREEN}RED as expected (exit $canary_rc)${NC}"
+    echo -e "${GREEN}  >>> harness confirmed live: a failing kernel does turn this gate red${NC}"
+}
+
+# tests/gpu/gpu_correctness_gate.sh's SKIP path deliberately writes NO trace
+# record to scripts/icc_traces/gpu_execution.jsonl (see its header comment and
+# .icc/completion-oracles.yaml's `gpu-execution` criterion, severity: high) —
+# that silence is what lets the oracle read a GPU-less host as "no evidence
+# yet" instead of a false PASS. Its `--self-test` mode asserts that contract
+# directly (skip() writes nothing; fail()/a PASS record are distinguishable),
+# with no build and no GPU required, so a future edit that makes SKIP look
+# like PASS is caught here rather than by an oracle silently regressing.
+run_gate_self_test() {
+    printf "Canary  %-50s " "gpu_correctness_gate.sh --self-test"
+    if [ ! -x tests/gpu/gpu_correctness_gate.sh ]; then
+        echo -e "${RED}MISSING/NOT EXECUTABLE${NC}"
+        CANARY_HARD_FAIL=1
+        return 0
+    fi
+    if tests/gpu/gpu_correctness_gate.sh --self-test > "$ESHKOL_TEST_OUT" 2>&1; then
+        echo -e "${GREEN}PASS${NC}"
+    else
+        echo -e "${RED}FAIL${NC}"
+        sed 's/^/    /' "$ESHKOL_TEST_OUT"
+        CANARY_HARD_FAIL=1
+    fi
+}
+
 echo "========================================="
 echo "  Eshkol GPU Test Suite"
 echo "========================================="
@@ -149,12 +271,20 @@ fi
 
 echo -e "${GREEN}Using build directory: $BUILD_DIR${NC}"
 echo ""
+
+run_gate_canary
+run_gate_self_test
+echo ""
+
 echo "Testing all files in tests/gpu/ directory..."
 echo ""
 
 # Run each test
 for test_file in tests/gpu/*.esk; do
     test_name=$(basename "$test_file")
+    if [ "$test_name" = "$CANARY_NAME" ]; then
+        continue  # handled by run_gate_canary above, not graded here
+    fi
     if [ "$test_name" = "ozaki_certification_test.esk" ]; then
         run_ozaki_certification
         continue
@@ -187,6 +317,16 @@ for test_file in tests/gpu/*.esk; do
                 # means the program died before saying anything. Not a pass.
                 echo -e "${RED}NO OUTPUT${NC}"
                 FAILED_TESTS+=("$test_name")
+                ((FAIL++)) || true
+            elif ! eshkol_test_output_has_success_marker "$ESHKOL_TEST_OUT"; then
+                # Contract item 3: no verdict is a fail, not a pass. Exited 0
+                # and printed something, but never a single PASS/PASSED/OK
+                # marker — e.g. the pre-fix gpu_correctness_gate.esk, which
+                # printed only unlabelled RESULT lines. Absence of evidence
+                # that any check ran is not evidence the checks passed.
+                echo -e "${RED}NO VERDICT${NC}"
+                echo -e "${RED}  >>> exited 0 with output, but no PASS:/FAIL:-shaped line was printed${NC}"
+                FAILED_TESTS+=("$test_name (no verdict)")
                 ((FAIL++)) || true
             else
                 echo -e "${GREEN}PASS${NC}"
@@ -248,6 +388,12 @@ case "$CERT_STATUS" in
     *)         echo -e "${YELLOW}Ozaki exact-GEMM certification: $CERT_STATUS${NC}" ;;
 esac
 
+if [ "$CANARY_HARD_FAIL" -eq 1 ]; then
+    echo -e "${RED}Gate canary + self-test: at least one verdict-pipeline check FAILED — see above${NC}"
+else
+    echo -e "${GREEN}Gate canary ($CANARY_NAME): confirmed RED, and gpu_correctness_gate.sh --self-test: PASS${NC}"
+fi
+
 echo ""
 
 # Clean up
@@ -255,7 +401,14 @@ echo ""
 # removes wholesale, so it needs no separate unlink here.
 rm -f "$ESHKOL_TEST_OUT" "$ESHKOL_TEST_BIN" "$ESHKOL_TEST_BIN.tmp.o"
 
-# Exit with appropriate code
+# Exit with appropriate code. The canary is checked independently of FAIL: a
+# harness that cannot prove it can fail must not report success regardless of
+# how many real tests passed — see VERDICT CONTRACT item 4.
+if [ "$CANARY_HARD_FAIL" -eq 1 ]; then
+    echo -e "${RED}FATAL: gate canary did not fail — refusing to report this run as trustworthy.${NC}"
+    exit 1
+fi
+
 if [ $FAIL -eq 0 ]; then
     exit 0
 else

--- a/tests/gpu/cuda_host_sync_regression_test.esk
+++ b/tests/gpu/cuda_host_sync_regression_test.esk
@@ -46,3 +46,7 @@
       (display " expected=")
       (display (vector-ref A-data 0))))
 (newline)
+
+(if ok
+    (begin (display "PASS: cuda_host_sync_regression_test") (newline) (exit 0))
+    (begin (display "FAIL: cuda_host_sync_regression_test") (newline) (exit 1)))

--- a/tests/gpu/cuda_ozaki_correctness_test.esk
+++ b/tests/gpu/cuda_ozaki_correctness_test.esk
@@ -88,3 +88,8 @@
         (check r N Ad Bd Cd)))))
 
 (display "SUMMARY total_fail=") (display total-fail) (newline)
+(if (= total-fail 0)
+    (begin (display "PASS: cuda_ozaki_correctness_test") (newline) (exit 0))
+    (begin (display "FAIL: cuda_ozaki_correctness_test (")
+           (display total-fail) (display " regime(s) failed)") (newline)
+           (exit 1)))

--- a/tests/gpu/elementwise_correctness_test.esk
+++ b/tests/gpu/elementwise_correctness_test.esk
@@ -1,5 +1,14 @@
 ;; GPU Elementwise Correctness Tests
 ;; Tests all elementwise operations at small and medium sizes.
+;;
+;; Verdict grammar: each check below prints "PASS: <label>" or
+;; "FAIL: <label> ..." and increments gate-failures on failure (see
+;; scripts/run_gpu_tests.sh header for the full contract). Before this
+;; fix, a FAIL: line was printed but nothing aggregated it into a process
+;; exit code, so this file always exited 0 no matter how many checks
+;; actually failed -- the marker-only harness had to notice the text, and
+;; a differently-shaped judge could not.
+(define gate-failures 0)
 
 ;; --- Small 2x2 tests ---
 (define A (reshape (vector 1.0 2.0 3.0 4.0) 2 2))
@@ -12,7 +21,7 @@
          (= (tensor-get s 1 0) 10.0)
          (= (tensor-get s 1 1) 12.0))
     (display "PASS: elementwise add 2x2")
-    (display "FAIL: elementwise add 2x2"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: elementwise add 2x2")))
 (newline)
 
 ;; SUB
@@ -20,7 +29,7 @@
 (if (and (= (tensor-get d 0 0) -4.0)
          (= (tensor-get d 1 1) -4.0))
     (display "PASS: elementwise sub 2x2")
-    (display "FAIL: elementwise sub 2x2"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: elementwise sub 2x2")))
 (newline)
 
 ;; MUL
@@ -28,14 +37,14 @@
 (if (and (= (tensor-get m 0 0) 5.0)
          (= (tensor-get m 1 1) 32.0))
     (display "PASS: elementwise mul 2x2")
-    (display "FAIL: elementwise mul 2x2"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: elementwise mul 2x2")))
 (newline)
 
 ;; DIV
 (define q (tensor-div A B))
 (if (< (abs (- (tensor-get q 0 0) 0.2)) 1e-10)
     (display "PASS: elementwise div 2x2")
-    (display "FAIL: elementwise div 2x2"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: elementwise div 2x2")))
 (newline)
 
 ;; --- 3x3 tests ---
@@ -48,7 +57,7 @@
          (= (tensor-get cd-add 1 1) 10.0)
          (= (tensor-get cd-add 2 2) 10.0))
     (display "PASS: elementwise add 3x3 all 10s")
-    (display "FAIL: elementwise add 3x3"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: elementwise add 3x3")))
 (newline)
 
 ;; Chaining: (C + D) * C where all of C+D=10
@@ -58,7 +67,7 @@
          (= (tensor-get chain 1 1) 50.0)
          (= (tensor-get chain 2 2) 90.0))
     (display "PASS: chained ops (add+mul) 3x3")
-    (display "FAIL: chained ops 3x3"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: chained ops 3x3")))
 (newline)
 
 ;; --- Commutativity ---
@@ -67,7 +76,7 @@
 (if (and (= (tensor-get sum-ab 0 0) (tensor-get sum-ba 0 0))
          (= (tensor-get sum-ab 1 1) (tensor-get sum-ba 1 1)))
     (display "PASS: tensor-add commutative")
-    (display "FAIL: tensor-add not commutative"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: tensor-add not commutative")))
 (newline)
 
 ;; --- Associativity: (A+B)+C = A+(B+C) ---
@@ -77,5 +86,10 @@
 (if (and (= (tensor-get lhs 0 0) (tensor-get rhs 0 0))
          (= (tensor-get lhs 1 1) (tensor-get rhs 1 1)))
     (display "PASS: tensor-add associative")
-    (display "FAIL: tensor-add not associative"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: tensor-add not associative")))
 (newline)
+
+(if (= gate-failures 0)
+    (begin (display "PASS: elementwise_correctness_test") (newline) (exit 0))
+    (begin (display "FAIL: elementwise_correctness_test (") (display gate-failures) (display " check(s) failed)") (newline)
+           (exit 1)))

--- a/tests/gpu/gate_canary_must_fail.esk
+++ b/tests/gpu/gate_canary_must_fail.esk
@@ -1,0 +1,42 @@
+;; GPU gate canary — a DELIBERATE, PERMANENT failure.
+;;
+;; This file exists to answer one question every invocation of
+;; scripts/run_gpu_tests.sh: if a GPU kernel actually produced a wrong
+;; answer, would this harness notice? Every other file in tests/gpu/ is
+;; expected to pass, so a harness that has quietly stopped being able to
+;; fail (a broken marker regex, a build that silently no-ops, a judge
+;; that only checks "did the process exit") would look identical to a
+;; healthy one — every real test would still print PASS and exit 0,
+;; because a healthy GPU backend truly does compute all of them
+;; correctly right now. Nothing in that picture proves the harness is
+;; still WATCHING.
+;;
+;; This file is the control: an assertion that is deliberately, always
+;; false, using the exact PASS:/FAIL: verdict grammar and exit-code
+;; contract documented in scripts/run_gpu_tests.sh. The harness runs it
+;; EXPECTING a FAIL verdict and a non-zero exit; if it ever observes a
+;; PASS from this file (or an exit code of 0), that means the verdict
+;; pipeline itself has broken — a real defect could hide behind the same
+;; failure — and the harness treats THAT as a hard failure of the whole
+;; gate, independent of what every other test reported.
+;;
+;; Do not "fix" this file. A green canary is not a fixed test — it is a
+;; blind judge.
+
+(display "=== GPU Gate Canary (this test MUST fail) ===") (newline)
+
+;; A trivial, unconditionally false numeric assertion computed through
+;; the same tensor path the real tests exercise, so a build that cannot
+;; even construct a tensor still reaches a FAIL verdict rather than
+;; crashing before printing one.
+(define canary-A (reshape (vector 1.0 2.0 3.0 4.0) 2 2))
+(define canary-B (reshape (vector 5.0 6.0 7.0 8.0) 2 2))
+(define canary-C (matmul canary-A canary-B))
+;; The true value of C[0,0] is 19.0; assert it is 999.0 instead.
+(define canary-ok? (= (tensor-get canary-C 0 0) 999.0))
+
+(if canary-ok?
+    (begin (display "PASS: gate_canary_must_fail (THIS IS A BUG IN THE CANARY ITSELF)") (newline) (exit 0))
+    (begin (display "FAIL: gate_canary_must_fail (deliberate: expected C[0,0]=999.0, got ")
+           (display (tensor-get canary-C 0 0)) (display ") — this failure is EXPECTED") (newline)
+           (exit 1)))

--- a/tests/gpu/gpu_correctness_gate.esk
+++ b/tests/gpu/gpu_correctness_gate.esk
@@ -39,13 +39,16 @@
 (define A (reshape A-data N K))
 (define B (reshape B-data K N))
 
-;; `display` on a float prints with ~6 significant digits (not full
-;; round-trip precision) — that's a separate stdlib formatting
-;; characteristic, not something this gate changes. It's still enough
-;; precision to catch a real GPU-kernel bug (wrong dimensions, transposed
-;; data, NaN/garbage, wrong accumulation) while the harness's tolerance
-;; comparison (tests/gpu/gpu_correctness_gate.sh) absorbs any last-digit
-;; GPU-vs-CPU floating-point summation-order drift.
+;; `display` on a float prints the SHORTEST ROUND-TRIP decimal
+;; (eshkol_dtoa_shortest, lib/core/runtime_display_hosted.cpp) — reading
+;; the printed string back reproduces the exact same bits, confirmed by a
+;; direct round-trip probe. It is not a lossy ~6-significant-digit
+;; formatter; a prior version of this comment claimed otherwise and used
+;; that to justify a loose 1e-4 gate tolerance in
+;; tests/gpu/gpu_correctness_gate.sh, which has since been tightened on
+;; the strength of this correction (see that script's GPU_GATE_TOL
+;; comment for the measured Metal-vs-CPU divergence this workload
+;; actually produces).
 (define (result label val)
   (display "RESULT ") (display label) (display " ") (display val) (newline))
 
@@ -73,3 +76,67 @@
 (result "reduce-max-A" (tensor-max A))
 
 (display "GATE-DONE") (newline)
+
+;; ─────────────────────────────────────────────────────────────────
+;; Self-check invariants — verdict grammar (see scripts/run_gpu_tests.sh
+;; header for the full contract).
+;;
+;; Before this fix, everything above was this file's entire content: a
+;; fixed sequence of `RESULT <label> <value>` lines and nothing else. That
+;; is sufficient for tests/gpu/gpu_correctness_gate.sh's CPU-vs-GPU
+;; differential (it diffs the two RESULT streams itself), but
+;; scripts/run_gpu_tests.sh runs this file directly, ONCE, through
+;; whichever single build it is testing — it never performs that diff. A
+;; run through that harness printed zero PASS/FAIL/error/mismatch-shaped
+;; output no matter what the GPU kernel actually computed, so a
+;; correctness regression on the only build under test was invisible:
+;; the file could not fail on its own.
+;;
+;; These checks are backend-independent invariants — true on a correct
+;; result regardless of whether this run went through CPU, Metal, or
+;; CUDA — so they give the file real, self-contained teeth without
+;; duplicating the differential that gpu_correctness_gate.sh already
+;; owns.
+(define gate-failures 0)
+(define (verify! ok? label)
+  (if ok?
+      (begin (display "PASS: ") (display label) (newline))
+      (begin (display "FAIL: ") (display label) (newline)
+             (set! gate-failures (+ gate-failures 1)))))
+
+(define (finite? x) (and (= x x) (< (abs x) 1e300)))
+
+;; Independent reduce-sum: a manual accumulation over the plain input
+;; vector, not routed through tensor-sum's own reduction path, so a
+;; broken reduce cannot be used to validate itself.
+(define (vector-sum-manual v n)
+  (let loop ((i 0) (acc 0.0))
+    (if (= i n) acc (loop (+ i 1) (+ acc (vector-ref v i))))))
+
+(define sum-A (tensor-sum A))
+(define sum-B (tensor-sum B))
+(define independent-sum-A (vector-sum-manual A-data elems))
+
+(verify! (finite? (tensor-sum C)) "matmul-checksum is finite")
+(verify! (finite? (tensor-get C 0 0)) "matmul-c00 is finite")
+(verify! (finite? (tensor-get C 511 511)) "matmul-clast is finite")
+(verify! (finite? (tensor-sum S)) "add-checksum is finite")
+(verify! (finite? (tensor-sum P)) "mul-checksum is finite")
+(verify! (> (tensor-sum P) 0.0)
+         "mul-checksum is positive (every A/B element is constructed positive)")
+(verify! (= (tensor-get Ct 0 0) (tensor-get C 0 0))
+         "transpose(transpose(C))[0,0] == C[0,0]")
+(verify! (= (tensor-get Ct 511 511) (tensor-get C 511 511))
+         "transpose(transpose(C))[511,511] == C[511,511]")
+(verify! (< (abs (- sum-A independent-sum-A)) (* 1e-6 (abs independent-sum-A)))
+         "reduce-sum-A agrees with an independent manual accumulation")
+(verify! (and (> (tensor-max A) 0.0) (< (tensor-max A) 2.01))
+         "reduce-max-A within the constructed input's theoretical bound (0, 2.01)")
+(verify! (< (abs (- (tensor-sum S) (+ sum-A sum-B))) (* 1e-6 (abs (+ sum-A sum-B))))
+         "sum(A+B) == sum(A) + sum(B)")
+
+(if (= gate-failures 0)
+    (begin (display "PASS: gpu_correctness_gate self-checks") (newline) (exit 0))
+    (begin (display "FAIL: gpu_correctness_gate self-checks (")
+           (display gate-failures) (display " of 10 failed)") (newline)
+           (exit 1)))

--- a/tests/gpu/gpu_correctness_gate.sh
+++ b/tests/gpu/gpu_correctness_gate.sh
@@ -25,10 +25,26 @@
 #   BUILD_DIR_CPU   build dir for the GPU-disabled reference binary (default: build-gpu-gate-cpuref)
 #   REUSE_BUILDS=1  skip (re)configuring/building if eshkol-run already exists
 #                   in both dirs — for CI jobs that cache the build step
-#   GPU_GATE_TOL    relative tolerance for the numeric diff (default: 1e-4;
-#                   loose because eshkol's `display` prints floats with
-#                   ~6 significant digits, not full round-trip precision —
-#                   see the comment in gpu_correctness_gate.esk)
+#   GPU_GATE_TOL    relative tolerance for the numeric diff (default: 1e-9).
+#                   This used to default to 1e-4 on the claim that `display`
+#                   prints only ~6 significant digits — that claim is FALSE:
+#                   `display` calls eshkol_dtoa_shortest()
+#                   (lib/core/runtime_display_hosted.cpp), the same
+#                   shortest-round-trip formatter used everywhere else, and a
+#                   direct round-trip probe (print a double, read it back,
+#                   compare bits) confirms every value comes back bit-exact.
+#                   See the comment in gpu_correctness_gate.esk. Measured
+#                   Metal-vs-CPU divergence on this workload (N=K=512 f64
+#                   matmul/add/mul/transpose/reduce) is exactly 0 across every
+#                   probe — 1e-9 leaves ~4 orders of margin above the
+#                   theoretical floating-point noise floor for a K=512
+#                   accumulation (~K*eps ~= 6e-14) for backends/kernel
+#                   variants (CUDA, other Metal tile configs) that may
+#                   legitimately reorder the reduction, while still catching
+#                   real GPU-kernel bugs, which corrupt results by 1e-2 to
+#                   1e0 (see ozaki_correctness_test.esk's documented CRT
+#                   defect class) — five to nine orders of magnitude looser
+#                   than this tolerance.
 #   LLVM_CONFIG     path to llvm-config (auto-detected via `brew --prefix
 #                   llvm@21` on macOS, or llvm-config-21/llvm-config on
 #                   Linux and Git Bash/MSYS2 Windows, if unset)
@@ -52,7 +68,7 @@ REPO_ROOT="$(pwd)"
 BUILD_DIR_GPU="${BUILD_DIR_GPU:-build-gpu-gate}"
 BUILD_DIR_CPU="${BUILD_DIR_CPU:-build-gpu-gate-cpuref}"
 REUSE_BUILDS="${REUSE_BUILDS:-0}"
-GPU_GATE_TOL="${GPU_GATE_TOL:-1e-4}"
+GPU_GATE_TOL="${GPU_GATE_TOL:-1e-9}"
 GATE_ESK="$REPO_ROOT/tests/gpu/gpu_correctness_gate.esk"
 
 # ICC evidence trace (.icc/completion-oracles.yaml::gpu-execution). Only
@@ -80,6 +96,73 @@ emit_trace() {  # emit_trace <value> <snippet>
 log()  { printf '%s\n' "$*"; }
 skip() { log "SKIP: $*"; exit 0; }
 fail() { log "FAIL: $*"; emit_trace FAIL "$*"; exit 1; }
+
+# ─────────────────────────────────────────────────────────────────
+# --self-test: proves the SKIP/PASS/FAIL-vs-trace contract directly,
+# independent of whether this host actually has a GPU. `skip()` is
+# deliberately the ONE verdict path that never calls emit_trace — that
+# silence is what lets .icc/completion-oracles.yaml's `gpu-execution`
+# criterion (severity: high) read a GPU-less host as "no evidence yet"
+# instead of a false PASS. A judge (or a future edit to this file) that
+# starts calling emit_trace from inside skip() — even with value=SKIP —
+# would let a stale or synthetic trace line satisfy `event_values:
+# ["PASS"]`-style matching depending on how a consumer reads the file, so
+# this asserts the omission holds, on every invocation, in addition to
+# the FAIL and PASS paths actually writing what they claim to write.
+# Exits 0 only if every assertion below holds; runs no build, no GPU.
+if [ "${1:-}" = "--self-test" ]; then
+    st_dir="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-gpu-gate-selftest.XXXXXX")"
+    trap 'rm -rf "$st_dir"' EXIT
+    st_fail=0
+    st_check() {  # st_check <description> <cmd...>
+        local desc="$1"; shift
+        if "$@"; then
+            log "  ok   $desc"
+        else
+            log "  FAIL $desc"
+            st_fail=1
+        fi
+    }
+
+    # 1. skip() must not touch the trace file at all.
+    TRACE_DIR="$st_dir/traces_skip"
+    TRACE_FILE="$TRACE_DIR/gpu_execution.jsonl"
+    ( skip "self-test probe" ) > /dev/null 2>&1
+    st_check "skip() leaves no trace directory" [ ! -e "$TRACE_DIR" ]
+
+    # 2. fail() must write exactly one FAIL-valued trace record.
+    TRACE_DIR="$st_dir/traces_fail"
+    TRACE_FILE="$TRACE_DIR/gpu_execution.jsonl"
+    ( fail "self-test probe" ) > /dev/null 2>&1
+    st_check "fail() creates the trace file" [ -f "$TRACE_FILE" ]
+    st_check "fail() writes a FAIL-valued record" \
+        grep -q '"kind":"gpu_execution".*"value":"FAIL"' "$TRACE_FILE"
+    st_check "fail() writes exactly one record" \
+        [ "$(wc -l < "$TRACE_FILE" | tr -d ' ')" = "1" ]
+
+    # 3. A PASS-shaped emit_trace call must write a PASS-valued record —
+    #    proving the PASS and FAIL paths are distinguishable in the trace
+    #    the same way they are distinguishable at exit-code level.
+    TRACE_DIR="$st_dir/traces_pass"
+    TRACE_FILE="$TRACE_DIR/gpu_execution.jsonl"
+    ( emit_trace PASS "self-test probe" ) > /dev/null 2>&1
+    st_check "emit_trace PASS writes a PASS-valued record" \
+        grep -q '"kind":"gpu_execution".*"value":"PASS"' "$TRACE_FILE"
+    if grep -q '"value":"FAIL"' "$TRACE_FILE" 2>/dev/null; then
+        log "  FAIL a PASS-valued record does not also read as FAIL"
+        st_fail=1
+    else
+        log "  ok   a PASS-valued record does not also read as FAIL"
+    fi
+
+    if [ "$st_fail" -eq 0 ]; then
+        log "PASS: gpu_correctness_gate.sh --self-test (SKIP/PASS/FAIL trace contract holds)"
+        exit 0
+    else
+        log "FAIL: gpu_correctness_gate.sh --self-test (SKIP/PASS/FAIL trace contract is broken — see above)"
+        exit 1
+    fi
+fi
 
 # ─────────────────────────────────────────────────────────────────
 # Step 1: build-time GPU framework detection. No point configuring a

--- a/tests/gpu/gpu_diagnostic_test.esk
+++ b/tests/gpu/gpu_diagnostic_test.esk
@@ -1,5 +1,13 @@
 ;; GPU Diagnostic Test
 ;; Verifies GPU is actually being used for large matrices
+;;
+;; Verdict grammar: each check below prints " PASS"/" FAIL" on the same
+;; line as its measurement, and increments gate-failures on failure (see
+;; scripts/run_gpu_tests.sh header for the full contract). Before this
+;; fix, the FAIL branch printed a marker but nothing aggregated it into a
+;; process exit code, so this file always exited 0 no matter how many
+;; sizes actually failed.
+(define gate-failures 0)
 
 (display "=== GPU Diagnostic Test ===") (newline)
 
@@ -18,7 +26,7 @@
   (display " (expected: ") (display expected) (display ")")
   (if (and (>= result (* expected 0.99)) (<= result (* expected 1.01)))
       (begin (display " PASS") (newline))
-      (begin (display " FAIL") (newline)))
+      (begin (set! gate-failures (+ gate-failures 1)) (display " FAIL") (newline)))
   result)
 
 ;; Small matrices (BLAS/SIMD path, below threshold)
@@ -47,3 +55,8 @@
 (test-matmul-size 53 53.0)   ;; 53 % 4 = 1
 
 (display "=== GPU Diagnostic Test Complete ===") (newline)
+
+(if (= gate-failures 0)
+    (begin (display "PASS: gpu_diagnostic_test") (newline) (exit 0))
+    (begin (display "FAIL: gpu_diagnostic_test (") (display gate-failures) (display " size(s) failed)") (newline)
+           (exit 1)))

--- a/tests/gpu/gpu_large_matmul_test.esk
+++ b/tests/gpu/gpu_large_matmul_test.esk
@@ -64,3 +64,7 @@
     (begin (display "FAIL: Matrix multiply incorrect") (newline)))
 
 (display "=== GPU Large Matrix Test Complete ===") (newline)
+
+(if correct
+    (begin (display "PASS: gpu_large_matmul_test") (newline) (exit 0))
+    (begin (display "FAIL: gpu_large_matmul_test") (newline) (exit 1)))

--- a/tests/gpu/gpu_scale_correctness_test.esk
+++ b/tests/gpu/gpu_scale_correctness_test.esk
@@ -112,5 +112,5 @@
 ;; Summary
 ;; =====================================================
 (if (and t1-pass t2-pass t3-pass)
-    (begin (display "PASS: All GPU-scale correctness tests passed") (newline))
-    (begin (display "FAIL: Some GPU-scale correctness tests failed") (newline)))
+    (begin (display "PASS: All GPU-scale correctness tests passed") (newline) (exit 0))
+    (begin (display "FAIL: Some GPU-scale correctness tests failed") (newline) (exit 1)))

--- a/tests/gpu/gpu_test.esk
+++ b/tests/gpu/gpu_test.esk
@@ -1,5 +1,13 @@
 ;; GPU Backend Test
 ;; Tests GPU-accelerated matrix operations
+;;
+;; Previously this file only ever displayed intermediate values and never
+;; asserted anything -- a real accuracy break in A * I could have printed
+;; any garbage and this file would still have said "Complete" and exited 0.
+;; Verdict grammar: "PASS: <label>" / "FAIL: <label> ..." (see
+;; scripts/run_gpu_tests.sh header), aggregated into gate-failures and a
+;; process exit code.
+(define gate-failures 0)
 
 (display "=== GPU Backend Test ===") (newline)
 
@@ -9,9 +17,39 @@
 (define B (reshape (vector 1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0) 4 4))
 (define C (matmul A B))
 (display "A * I = ") (display C) (newline)
+
+;; A * I must equal A exactly (identity multiply).
+(define (identity-holds? row col)
+  (= (tensor-get C row col) (tensor-get A row col)))
+(define t1-pass
+  (and (identity-holds? 0 0) (identity-holds? 0 3)
+       (identity-holds? 1 1) (identity-holds? 2 2)
+       (identity-holds? 3 0) (identity-holds? 3 3)))
+(if t1-pass
+    (display "PASS: 4x4 A * I = A")
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: 4x4 A * I != A")))
+(newline)
 (newline)
 
 ;; Test 2: Larger matmul (still BLAS for 100x100 = 10K elements)
-(display "Test 2: Matmul complete") (newline)
+(display "Test 2: 100x100 all-ones matmul") (newline)
+(define n2 100)
+(define size2 (* n2 n2))
+(define A2 (reshape (make-vector size2 1.0) n2 n2))
+(define B2 (reshape (make-vector size2 1.0) n2 n2))
+(define C2 (matmul A2 B2))
+;; ones(n) x ones(n) = n everywhere.
+(define t2-pass (= (tensor-get C2 0 0) (exact->inexact n2)))
+(if t2-pass
+    (display "PASS: 100x100 all-ones matmul = 100")
+    (begin (set! gate-failures (+ gate-failures 1))
+           (display "FAIL: 100x100 all-ones matmul != 100, got ")
+           (display (tensor-get C2 0 0))))
+(newline)
 
 (display "=== GPU Test Complete ===") (newline)
+
+(if (= gate-failures 0)
+    (begin (display "PASS: gpu_test") (newline) (exit 0))
+    (begin (display "FAIL: gpu_test (") (display gate-failures) (display " check(s) failed)") (newline)
+           (exit 1)))

--- a/tests/gpu/matmul_correctness_test.esk
+++ b/tests/gpu/matmul_correctness_test.esk
@@ -1,4 +1,13 @@
 ;; GPU Matrix Multiply Correctness Tests
+;;
+;; Verdict grammar: each check below prints "PASS: <label>" or
+;; "FAIL: <label> ..." and increments gate-failures on failure (see
+;; scripts/run_gpu_tests.sh header for the full contract). Before this
+;; fix, a FAIL: line was printed but nothing aggregated it into a process
+;; exit code, so this file always exited 0 no matter how many checks
+;; actually failed -- the marker-only harness had to notice the text, and
+;; a differently-shaped judge could not.
+(define gate-failures 0)
 
 ;; --- Small matmul: 2x2 @ 2x2 ---
 (define A (reshape (vector 1.0 2.0 3.0 4.0) 2 2))
@@ -11,7 +20,7 @@
          (= (tensor-get C 1 0) 43.0)
          (= (tensor-get C 1 1) 50.0))
     (display "PASS: matmul 2x2 correct")
-    (display "FAIL: matmul 2x2 incorrect"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: matmul 2x2 incorrect")))
 (newline)
 
 ;; --- Identity matmul: I @ A = A ---
@@ -22,7 +31,7 @@
          (= (tensor-get IA 1 0) 3.0)
          (= (tensor-get IA 1 1) 4.0))
     (display "PASS: I @ A = A")
-    (display "FAIL: I @ A != A"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: I @ A != A")))
 (newline)
 
 ;; --- Non-square: 2x3 @ 3x2 ---
@@ -36,7 +45,7 @@
          (= (tensor-get MN 1 0) 139.0)
          (= (tensor-get MN 1 1) 154.0))
     (display "PASS: matmul 2x3 @ 3x2 correct")
-    (display "FAIL: matmul 2x3 @ 3x2 incorrect"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: matmul 2x3 @ 3x2 incorrect")))
 (newline)
 
 ;; --- Matmul + transpose: (A @ B)^T = B^T @ A^T ---
@@ -47,7 +56,7 @@
          (= (tensor-get ABt 1 0) (tensor-get BtAt 1 0))
          (= (tensor-get ABt 1 1) (tensor-get BtAt 1 1)))
     (display "PASS: (AB)^T = B^T A^T")
-    (display "FAIL: (AB)^T != B^T A^T"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: (AB)^T != B^T A^T")))
 (newline)
 
 ;; --- Chain: A @ B @ A ---
@@ -60,5 +69,10 @@
          (= (tensor-get ABA 1 0) 193.0)
          (= (tensor-get ABA 1 1) 286.0))
     (display "PASS: A @ B @ A chain correct")
-    (display "FAIL: A @ B @ A chain incorrect"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: A @ B @ A chain incorrect")))
 (newline)
+
+(if (= gate-failures 0)
+    (begin (display "PASS: matmul_correctness_test") (newline) (exit 0))
+    (begin (display "FAIL: matmul_correctness_test (") (display gate-failures) (display " check(s) failed)") (newline)
+           (exit 1)))

--- a/tests/gpu/ozaki_correctness_test.esk
+++ b/tests/gpu/ozaki_correctness_test.esk
@@ -90,3 +90,8 @@
         (check r N Ad Bd Cd)))))
 
 (display "SUMMARY total_fail=") (display total-fail) (newline)
+(if (= total-fail 0)
+    (begin (display "PASS: ozaki_correctness_test") (newline) (exit 0))
+    (begin (display "FAIL: ozaki_correctness_test (")
+           (display total-fail) (display " regime(s) failed)") (newline)
+           (exit 1)))

--- a/tests/gpu/ozaki_fast_test.esk
+++ b/tests/gpu/ozaki_fast_test.esk
@@ -68,3 +68,8 @@
         (check r N Ad Bd Cd)))))
 
 (display "SUMMARY total_fail=") (display total-fail) (newline)
+(if (= total-fail 0)
+    (begin (display "PASS: ozaki_fast_test") (newline) (exit 0))
+    (begin (display "FAIL: ozaki_fast_test (")
+           (display total-fail) (display " regime(s) failed)") (newline)
+           (exit 1)))

--- a/tests/gpu/reduce_correctness_test.esk
+++ b/tests/gpu/reduce_correctness_test.esk
@@ -1,5 +1,14 @@
 ;; GPU Reduce Correctness Tests
 ;; Tests full-tensor reduce and axis-specific reduce.
+;;
+;; Verdict grammar: each check below prints "PASS: <label>" or
+;; "FAIL: <label> ..." and increments gate-failures on failure (see
+;; scripts/run_gpu_tests.sh header for the full contract). Before this
+;; fix, a FAIL: line was printed but nothing aggregated it into a process
+;; exit code, so this file always exited 0 no matter how many checks
+;; actually failed -- the marker-only harness had to notice the text, and
+;; a differently-shaped judge could not.
+(define gate-failures 0)
 
 ;; --- Full-tensor reduce ---
 (define A (reshape (vector 1.0 2.0 3.0 4.0 5.0 6.0) 2 3))
@@ -8,28 +17,28 @@
 (define s (tensor-sum A))
 (if (< (abs (- s 21.0)) 1e-10)
     (display "PASS: tensor-sum all = 21")
-    (begin (display "FAIL: tensor-sum all = ") (display s)))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: tensor-sum all = ") (display s)))
 (newline)
 
 ;; Max all: 6
 (define mx (tensor-max A))
 (if (< (abs (- mx 6.0)) 1e-10)
     (display "PASS: tensor-max all = 6")
-    (begin (display "FAIL: tensor-max all = ") (display mx)))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: tensor-max all = ") (display mx)))
 (newline)
 
 ;; Min all: 1
 (define mn (tensor-min A))
 (if (< (abs (- mn 1.0)) 1e-10)
     (display "PASS: tensor-min all = 1")
-    (begin (display "FAIL: tensor-min all = ") (display mn)))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: tensor-min all = ") (display mn)))
 (newline)
 
 ;; Mean all: 21/6 = 3.5
 (define avg (tensor-mean A))
 (if (< (abs (- avg 3.5)) 1e-10)
     (display "PASS: tensor-mean all = 3.5")
-    (begin (display "FAIL: tensor-mean all = ") (display avg)))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: tensor-mean all = ") (display avg)))
 (newline)
 
 ;; --- Axis-specific reduce ---
@@ -40,7 +49,7 @@
          (< (abs (- (tensor-get col-sum 1) 7.0)) 1e-10)
          (< (abs (- (tensor-get col-sum 2) 9.0)) 1e-10))
     (display "PASS: tensor-sum axis=0 = [5,7,9]")
-    (display "FAIL: tensor-sum axis=0 incorrect"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: tensor-sum axis=0 incorrect")))
 (newline)
 
 ;; Sum along axis 1 (rows): [6, 15]
@@ -48,7 +57,7 @@
 (if (and (< (abs (- (tensor-get row-sum 0) 6.0)) 1e-10)
          (< (abs (- (tensor-get row-sum 1) 15.0)) 1e-10))
     (display "PASS: tensor-sum axis=1 = [6,15]")
-    (display "FAIL: tensor-sum axis=1 incorrect"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: tensor-sum axis=1 incorrect")))
 (newline)
 
 ;; Max along axis 0: [4, 5, 6]
@@ -57,7 +66,7 @@
          (< (abs (- (tensor-get col-max 1) 5.0)) 1e-10)
          (< (abs (- (tensor-get col-max 2) 6.0)) 1e-10))
     (display "PASS: tensor-max axis=0 = [4,5,6]")
-    (display "FAIL: tensor-max axis=0 incorrect"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: tensor-max axis=0 incorrect")))
 (newline)
 
 ;; Min along axis 1: [1, 4]
@@ -65,7 +74,7 @@
 (if (and (< (abs (- (tensor-get row-min 0) 1.0)) 1e-10)
          (< (abs (- (tensor-get row-min 1) 4.0)) 1e-10))
     (display "PASS: tensor-min axis=1 = [1,4]")
-    (display "FAIL: tensor-min axis=1 incorrect"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: tensor-min axis=1 incorrect")))
 (newline)
 
 ;; Mean along axis 0: [2.5, 3.5, 4.5]
@@ -74,7 +83,7 @@
          (< (abs (- (tensor-get col-mean 1) 3.5)) 1e-10)
          (< (abs (- (tensor-get col-mean 2) 4.5)) 1e-10))
     (display "PASS: tensor-mean axis=0 = [2.5,3.5,4.5]")
-    (display "FAIL: tensor-mean axis=0 incorrect"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: tensor-mean axis=0 incorrect")))
 (newline)
 
 ;; Negative axis: axis=-1 should be same as axis=1 for 2D
@@ -82,7 +91,7 @@
 (if (and (< (abs (- (tensor-get neg-sum 0) 6.0)) 1e-10)
          (< (abs (- (tensor-get neg-sum 1) 15.0)) 1e-10))
     (display "PASS: tensor-sum axis=-1 = tensor-sum axis=1")
-    (display "FAIL: tensor-sum axis=-1 incorrect"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: tensor-sum axis=-1 incorrect")))
 (newline)
 
 ;; 1D reduce
@@ -90,7 +99,7 @@
 (define vs (tensor-sum v))
 (if (< (abs (- vs 60.0)) 1e-10)
     (display "PASS: 1D tensor-sum = 60")
-    (begin (display "FAIL: 1D tensor-sum = ") (display vs)))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: 1D tensor-sum = ") (display vs)))
 (newline)
 
 ;; arange reduce
@@ -99,5 +108,10 @@
 ;; sum 0..99 = 99*100/2 = 4950
 (if (< (abs (- seq-sum 4950.0)) 1e-10)
     (display "PASS: arange(100) sum = 4950")
-    (begin (display "FAIL: arange(100) sum = ") (display seq-sum)))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: arange(100) sum = ") (display seq-sum)))
 (newline)
+
+(if (= gate-failures 0)
+    (begin (display "PASS: reduce_correctness_test") (newline) (exit 0))
+    (begin (display "FAIL: reduce_correctness_test (") (display gate-failures) (display " check(s) failed)") (newline)
+           (exit 1)))

--- a/tests/gpu/sf64_nonuniform_test.esk
+++ b/tests/gpu/sf64_nonuniform_test.esk
@@ -1,4 +1,17 @@
 ;; Test sf64 with non-uniform values
+;;
+;; Previously every "expected" value here was printed as a comment/label
+;; but never compared against the actual result -- this file could not
+;; fail regardless of what matmul returned. Verdict grammar: "PASS:
+;; <label>" / "FAIL: <label> ..." (see scripts/run_gpu_tests.sh header),
+;; aggregated into gate-failures and a process exit code.
+(define gate-failures 0)
+(define (check! ok? label)
+  (if ok?
+      (begin (display "PASS: ") (display label) (newline))
+      (begin (set! gate-failures (+ gate-failures 1))
+             (display "FAIL: ") (display label) (newline))))
+
 (display "=== Non-Uniform Value Test ===") (newline)
 
 ;; Test 1: 2x2 with different values
@@ -18,6 +31,9 @@
 (display "C[0,1]=") (display (vector-ref Cd 1)) (display " (exp 22)") (newline)
 (display "C[1,0]=") (display (vector-ref Cd 2)) (display " (exp 43)") (newline)
 (display "C[1,1]=") (display (vector-ref Cd 3)) (display " (exp 50)") (newline)
+(check! (and (= (vector-ref Cd 0) 19.0) (= (vector-ref Cd 1) 22.0)
+             (= (vector-ref Cd 2) 43.0) (= (vector-ref Cd 3) 50.0))
+        "2x2 non-uniform matmul = #(19 22 43 50)")
 
 ;; Test 2: 3x3 identity test
 ;; [[1,0,0],[0,2,0],[0,0,3]] * [[1,0,0],[0,1,0],[0,0,1]] should = [[1,0,0],[0,2,0],[0,0,3]]
@@ -28,12 +44,15 @@
 (define DId (tensor-data DI))
 (display "diag(1,2,3) * I = ") (display DId) (newline)
 (display "Expected: #(1 0 0 0 2 0 0 0 3)") (newline)
+(check! (and (= (vector-ref DId 0) 1.0) (= (vector-ref DId 1) 0.0) (= (vector-ref DId 2) 0.0)
+             (= (vector-ref DId 3) 0.0) (= (vector-ref DId 4) 2.0) (= (vector-ref DId 5) 0.0)
+             (= (vector-ref DId 6) 0.0) (= (vector-ref DId 7) 0.0) (= (vector-ref DId 8) 3.0))
+        "3x3 diagonal * identity = #(1 0 0 0 2 0 0 0 3)")
 
 ;; Test 3: Large non-uniform (GPU path, 50x50)
-;; Create matrix with A[i,j] = i+j+1, multiply by ones matrix
-;; Result C[i,j] = sum over k of (i+k+1) = sum_{k=0}^{n-1}(i+k+1) = n*i + n(n-1)/2 + n = n*i + n(n+1)/2
-;; For n=50, C[0,j] = 50*0 + 50*51/2 = 1275
-;; C[1,j] = 50*1 + 1275 = 1325
+;; Create matrix with A[i,j] = i+1 (constant across row), multiply by ones
+;; matrix. Result C[i,0] = sum_{k=0}^{n-1} A[i,k]*1 = n*(i+1).
+;; For n=50: C[0,0]=50, C[1,0]=100, C[2,0]=150, C[49,0]=2500.
 (display "--- 50x50 GPU path non-uniform ---") (newline)
 (define n 50)
 (define size (* n n))
@@ -69,5 +88,14 @@
 (display "C[1,0] = ") (display (vector-ref Clarge-data n)) (display " (expected 100)") (newline)
 (display "C[2,0] = ") (display (vector-ref Clarge-data (* 2 n))) (display " (expected 150)") (newline)
 (display "C[49,0] = ") (display (vector-ref Clarge-data (* 49 n))) (display " (expected 2500)") (newline)
+(check! (= (vector-ref Clarge-data 0) 50.0) "50x50 non-uniform C[0,0] = 50")
+(check! (= (vector-ref Clarge-data n) 100.0) "50x50 non-uniform C[1,0] = 100")
+(check! (= (vector-ref Clarge-data (* 2 n)) 150.0) "50x50 non-uniform C[2,0] = 150")
+(check! (= (vector-ref Clarge-data (* 49 n)) 2500.0) "50x50 non-uniform C[49,0] = 2500")
 
 (display "=== Done ===") (newline)
+
+(if (= gate-failures 0)
+    (begin (display "PASS: sf64_nonuniform_test") (newline) (exit 0))
+    (begin (display "FAIL: sf64_nonuniform_test (") (display gate-failures) (display " check(s) failed)") (newline)
+           (exit 1)))

--- a/tests/gpu/sf64_primitives_test.esk
+++ b/tests/gpu/sf64_primitives_test.esk
@@ -4,6 +4,16 @@
 
 (display "=== SF64 Primitives Test ===") (newline)
 
+;; Verdict grammar: every check below prints "PASS: <name>" or
+;; "FAIL: <name> ..." (see scripts/run_gpu_tests.sh header for the full
+;; contract) and increments sf64-failures on failure. Previously the FAIL
+;; branches printed a colonless "FAIL (got ..." — a colon-anchored marker
+;; scan (e.g. `^FAIL:`) matched none of them, and nothing here ever
+;; aggregated a failure into a process exit code either, so this file
+;; could not fail no matter how many checks were actually wrong.
+(define sf64-failures 0)
+(define (note-fail!) (set! sf64-failures (+ sf64-failures 1)))
+
 ;; Helper to create 2x2 matmul test with specific values
 ;; For matrices [[a,b],[c,d]] * [[e,f],[g,h]] = [[ae+bg, af+bh],[ce+dg, cf+dh]]
 (define (test-2x2-matmul name a b c d e f g h expected-00 expected-01 expected-10 expected-11)
@@ -17,12 +27,12 @@
   (define c01 (vector-ref C-data 1))
   (define c10 (vector-ref C-data 2))
   (define c11 (vector-ref C-data 3))
-  (display "  ") (display name) (display ": ")
   (define pass (and (= c00 expected-00) (= c01 expected-01)
                     (= c10 expected-10) (= c11 expected-11)))
   (if pass
-      (begin (display "PASS") (newline))
-      (begin (display "FAIL") (newline)
+      (begin (display "PASS: ") (display name) (newline))
+      (begin (note-fail!)
+             (display "FAIL: ") (display name) (newline)
              (display "    Got: [") (display c00) (display ", ") (display c01)
              (display ", ") (display c10) (display ", ") (display c11) (display "]") (newline)
              (display "    Expected: [") (display expected-00) (display ", ") (display expected-01)
@@ -38,11 +48,11 @@
   (define C (matmul A B))
   (define C-data (tensor-data C))
   (define result (vector-ref C-data 0))
-  (display "  ") (display name) (display ": ")
   (define pass (= result expected))
   (if pass
-      (begin (display result) (display " PASS") (newline))
-      (begin (display "FAIL (got ") (display result)
+      (begin (display "PASS: ") (display name) (display " (") (display result) (display ")") (newline))
+      (begin (note-fail!)
+             (display "FAIL: ") (display name) (display " (got ") (display result)
              (display ", expected ") (display expected) (display ")") (newline)))
   pass)
 
@@ -60,11 +70,11 @@
   (define C (matmul A B))
   (define C-data (tensor-data C))
   (define result (vector-ref C-data 0))
-  (display "  ") (display name) (display ": ")
   (define pass (approx= result expected))
   (if pass
-      (begin (display result) (display " PASS") (newline))
-      (begin (display "FAIL (got ") (display result)
+      (begin (display "PASS: ") (display name) (display " (") (display result) (display ")") (newline))
+      (begin (note-fail!)
+             (display "FAIL: ") (display name) (display " (got ") (display result)
              (display ", expected ") (display expected) (display ")") (newline)))
   pass)
 
@@ -102,11 +112,11 @@
   (define C (matmul A B))
   (define C-data (tensor-data C))
   (define result (vector-ref C-data 0))
-  (display "  ") (display name) (display ": ")
   (define pass (approx= result expected))
   (if pass
-      (begin (display result) (display " PASS") (newline))
-      (begin (display "FAIL (got ") (display result)
+      (begin (display "PASS: ") (display name) (display " (") (display result) (display ")") (newline))
+      (begin (note-fail!)
+             (display "FAIL: ") (display name) (display " (got ") (display result)
              (display ", expected ") (display expected) (display ")") (newline)))
   pass)
 
@@ -127,11 +137,11 @@
   (define C (matmul A B))
   (define C-data (tensor-data C))
   (define result (vector-ref C-data 0))
-  (display "  ") (display name) (display ": ")
   (define pass (approx= result expected))
   (if pass
-      (begin (display result) (display " PASS") (newline))
-      (begin (display "FAIL (got ") (display result)
+      (begin (display "PASS: ") (display name) (display " (") (display result) (display ")") (newline))
+      (begin (note-fail!)
+             (display "FAIL: ") (display name) (display " (got ") (display result)
              (display ", expected ") (display expected) (display ")") (newline)))
   pass)
 
@@ -166,11 +176,11 @@
   (define c01 (vector-ref C-data 1))
   (define c10 (vector-ref C-data 2))
   (define c11 (vector-ref C-data 3))
-  (display "  ") (display name) (display " * I: ")
   (define pass (and (= c00 a) (= c01 b) (= c10 c) (= c11 d)))
   (if pass
-      (begin (display "PASS") (newline))
-      (begin (display "FAIL") (newline)))
+      (begin (display "PASS: ") (display name) (display " * I") (newline))
+      (begin (note-fail!)
+             (display "FAIL: ") (display name) (display " * I") (newline)))
   pass)
 
 (test-identity-2x2 "[[1,2],[3,4]]" 1.0 2.0 3.0 4.0)
@@ -208,10 +218,11 @@
               #f))
         pass))
   (define pass (check-diagonal 0 #t))
-  (display "  ") (display n) (display "x") (display n) (display " diagonal: ")
+  (define label (string-append (number->string n) "x" (number->string n) " diagonal"))
   (if pass
-      (begin (display "PASS") (newline))
-      (begin (display "FAIL") (newline)))
+      (begin (display "PASS: ") (display label) (newline))
+      (begin (note-fail!)
+             (display "FAIL: ") (display label) (newline)))
   pass)
 
 (test-matmul-correctness 32)  ;; 32768 ops - BLAS path
@@ -220,3 +231,9 @@
 (test-matmul-correctness 50)  ;; 125000 ops - GPU path
 
 (display "=== SF64 Primitives Test Complete ===") (newline)
+(display "Results: ") (display sf64-failures) (display " failed") (newline)
+(if (= sf64-failures 0)
+    (begin (display "PASS: sf64_primitives_test") (newline) (exit 0))
+    (begin (display "FAIL: sf64_primitives_test (")
+           (display sf64-failures) (display " check(s) failed)") (newline)
+           (exit 1)))

--- a/tests/gpu/sf64_simple_test.esk
+++ b/tests/gpu/sf64_simple_test.esk
@@ -1,26 +1,52 @@
 ;; Simple SF64 Test
+;;
+;; Previously every "expected" value here was printed but never compared
+;; against the actual result -- this file could not fail regardless of
+;; what matmul returned. Verdict grammar: "PASS: <label>" / "FAIL: <label>
+;; ..." (see scripts/run_gpu_tests.sh header), aggregated into
+;; gate-failures and a process exit code.
+(define gate-failures 0)
+(define (check! ok? label)
+  (if ok?
+      (begin (display "PASS: ") (display label) (newline))
+      (begin (set! gate-failures (+ gate-failures 1))
+             (display "FAIL: ") (display label) (newline))))
+
 (display "=== SF64 Simple Test ===") (newline)
 
 ;; Test 1: Basic 1x1 multiplication
 (define A1 (reshape (vector 2.0) 1 1))
 (define B1 (reshape (vector 3.0) 1 1))
 (define C1 (matmul A1 B1))
-(display "2.0 * 3.0 = ") (display (vector-ref (tensor-data C1) 0)) (newline)
+(define r1 (vector-ref (tensor-data C1) 0))
+(display "2.0 * 3.0 = ") (display r1) (newline)
+(check! (= r1 6.0) "2.0 * 3.0 = 6.0")
 
 ;; Test 2: Identity 2x2
 (define A2 (reshape (vector 1.0 2.0 3.0 4.0) 2 2))
 (define I2 (reshape (vector 1.0 0.0 0.0 1.0) 2 2))
 (define C2 (matmul A2 I2))
+(define C2-data (tensor-data C2))
 (display "[[1,2],[3,4]] * I = ")
-(display (tensor-data C2)) (newline)
+(display C2-data) (newline)
+(check! (and (= (vector-ref C2-data 0) 1.0) (= (vector-ref C2-data 1) 2.0)
+             (= (vector-ref C2-data 2) 3.0) (= (vector-ref C2-data 3) 4.0))
+        "[[1,2],[3,4]] * I = [[1,2],[3,4]]")
 
 ;; Test 3: GPU path (50x50)
 (define size50 (* 50 50))
 (define A50 (reshape (make-vector size50 1.0) 50 50))
 (define B50 (reshape (make-vector size50 1.0) 50 50))
 (define C50 (matmul A50 B50))
+(define r50 (vector-ref (tensor-data C50) 0))
 (display "50x50 ones matmul C[0,0] = ")
-(display (vector-ref (tensor-data C50) 0))
+(display r50)
 (display " (expected 50)") (newline)
+(check! (= r50 50.0) "50x50 ones matmul C[0,0] = 50")
 
 (display "=== Done ===") (newline)
+
+(if (= gate-failures 0)
+    (begin (display "PASS: sf64_simple_test") (newline) (exit 0))
+    (begin (display "FAIL: sf64_simple_test (") (display gate-failures) (display " check(s) failed)") (newline)
+           (exit 1)))

--- a/tests/gpu/softmax_normalize_test.esk
+++ b/tests/gpu/softmax_normalize_test.esk
@@ -1,4 +1,13 @@
 ;; GPU Softmax and Normalization Tests
+;;
+;; Verdict grammar: each check below prints "PASS: <label>" or
+;; "FAIL: <label> ..." and increments gate-failures on failure (see
+;; scripts/run_gpu_tests.sh header for the full contract). Before this
+;; fix, a FAIL: line was printed but nothing aggregated it into a process
+;; exit code, so this file always exited 0 no matter how many checks
+;; actually failed -- the marker-only harness had to notice the text, and
+;; a differently-shaped judge could not.
+(define gate-failures 0)
 
 ;; --- Softmax correctness (global) ---
 ;; softmax([0,0,0,0]) = [0.25, 0.25, 0.25, 0.25]
@@ -6,14 +15,14 @@
 (define sm-uniform (softmax uniform))
 (if (< (abs (- (tensor-get sm-uniform 0) 0.25)) 1e-10)
     (display "PASS: softmax uniform = 0.25")
-    (begin (display "FAIL: softmax uniform = ") (display (tensor-get sm-uniform 0))))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: softmax uniform = ") (display (tensor-get sm-uniform 0))))
 (newline)
 
 ;; softmax should sum to 1.0
 (define sm-sum (tensor-sum sm-uniform))
 (if (< (abs (- sm-sum 1.0)) 1e-10)
     (display "PASS: softmax sum = 1.0")
-    (begin (display "FAIL: softmax sum = ") (display sm-sum)))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: softmax sum = ") (display sm-sum)))
 (newline)
 
 ;; --- Softmax with varying values ---
@@ -25,13 +34,13 @@
          (> (tensor-get sm-vals 1 0) 0.0)
          (> (tensor-get sm-vals 1 1) 0.0))
     (display "PASS: softmax all positive")
-    (display "FAIL: softmax has non-positive values"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: softmax has non-positive values")))
 (newline)
 
 ;; Larger value -> larger softmax
 (if (< (tensor-get sm-vals 0 0) (tensor-get sm-vals 1 1))
     (display "PASS: softmax preserves ordering")
-    (display "FAIL: softmax does not preserve ordering"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: softmax does not preserve ordering")))
 (newline)
 
 ;; --- Axis-aware softmax: each row sums to ~1.0 ---
@@ -42,7 +51,7 @@
               (+ (tensor-get sm-rows 0 1) (tensor-get sm-rows 0 2))))
 (if (< (abs (- r0 1.0)) 1e-6)
     (display "PASS: softmax axis=1 row0 sums to 1.0")
-    (begin (display "FAIL: softmax axis=1 row0 sum = ") (display r0)))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: softmax axis=1 row0 sum = ") (display r0)))
 (newline)
 
 ;; Row 1: softmax([4,5,6]) -> should sum to 1
@@ -50,7 +59,7 @@
               (+ (tensor-get sm-rows 1 1) (tensor-get sm-rows 1 2))))
 (if (< (abs (- r1 1.0)) 1e-6)
     (display "PASS: softmax axis=1 row1 sums to 1.0")
-    (begin (display "FAIL: softmax axis=1 row1 sum = ") (display r1)))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: softmax axis=1 row1 sum = ") (display r1)))
 (newline)
 
 ;; --- Softmax numerical stability (large values) ---
@@ -59,5 +68,10 @@
 (define sm-big-sum (tensor-sum sm-big))
 (if (< (abs (- sm-big-sum 1.0)) 1e-6)
     (display "PASS: softmax large values sum = 1.0")
-    (begin (display "FAIL: softmax large values sum = ") (display sm-big-sum)))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: softmax large values sum = ") (display sm-big-sum)))
 (newline)
+
+(if (= gate-failures 0)
+    (begin (display "PASS: softmax_normalize_test") (newline) (exit 0))
+    (begin (display "FAIL: softmax_normalize_test (") (display gate-failures) (display " check(s) failed)") (newline)
+           (exit 1)))

--- a/tests/gpu/transpose_correctness_test.esk
+++ b/tests/gpu/transpose_correctness_test.esk
@@ -1,4 +1,13 @@
 ;; GPU Transpose Correctness Tests
+;;
+;; Verdict grammar: each check below prints "PASS: <label>" or
+;; "FAIL: <label> ..." and increments gate-failures on failure (see
+;; scripts/run_gpu_tests.sh header for the full contract). Before this
+;; fix, a FAIL: line was printed but nothing aggregated it into a process
+;; exit code, so this file always exited 0 no matter how many checks
+;; actually failed -- the marker-only harness had to notice the text, and
+;; a differently-shaped judge could not.
+(define gate-failures 0)
 
 ;; --- Small 2x3 transpose ---
 (define A (reshape (vector 1.0 2.0 3.0 4.0 5.0 6.0) 2 3))
@@ -12,7 +21,7 @@
          (= (tensor-get AT 2 0) 3.0)
          (= (tensor-get AT 2 1) 6.0))
     (display "PASS: transpose 2x3 values correct")
-    (display "FAIL: transpose 2x3 values incorrect"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: transpose 2x3 values incorrect")))
 (newline)
 
 ;; --- Double transpose: (A^T)^T = A ---
@@ -24,7 +33,7 @@
          (= (tensor-get ATT 1 1) 5.0)
          (= (tensor-get ATT 1 2) 6.0))
     (display "PASS: double transpose = original")
-    (display "FAIL: double transpose != original"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: double transpose != original")))
 (newline)
 
 ;; --- Square matrix transpose ---
@@ -37,7 +46,7 @@
          (= (tensor-get ST 1 0) 2.0)
          (= (tensor-get ST 1 1) 4.0))
     (display "PASS: transpose 2x2 square correct")
-    (display "FAIL: transpose 2x2 square incorrect"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: transpose 2x2 square incorrect")))
 (newline)
 
 ;; --- Medium size transpose (50x100) ---
@@ -55,7 +64,7 @@
          (= (tensor-get M2T 1 0) 1.0)
          (= (tensor-get M2T 0 1) 100.0))
     (display "PASS: transpose 50x100 values correct")
-    (display "FAIL: transpose 50x100 values incorrect"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: transpose 50x100 values incorrect")))
 (newline)
 
 ;; --- Transpose preserves element count ---
@@ -64,5 +73,10 @@
 (define sum-after (tensor-sum M2T))
 (if (< (abs (- sum-before sum-after)) 1e-6)
     (display "PASS: transpose preserves element sum")
-    (display "FAIL: transpose changes element sum"))
+    (begin (set! gate-failures (+ gate-failures 1)) (display "FAIL: transpose changes element sum")))
 (newline)
+
+(if (= gate-failures 0)
+    (begin (display "PASS: transpose_correctness_test") (newline) (exit 0))
+    (begin (display "FAIL: transpose_correctness_test (") (display gate-failures) (display " check(s) failed)") (newline)
+           (exit 1)))


### PR DESCRIPTION
## What was broken

The GPU correctness gate could not fail.

- `tests/gpu/gpu_correctness_gate.esk` printed only unlabelled `RESULT <label> <value>` lines and exited 0 unconditionally — no `PASS`, `FAIL`, `error`, or `mismatch`-shaped output in any form, and no way for a judge (marker-based or exit-code-based) to ever fail it.
- `tests/gpu/gpu_test.esk`, `sf64_simple_test.esk`, and `sf64_nonuniform_test.esk` had the same shape: they computed results and displayed `(expected N)` comments but never actually compared actual against expected. An audit of every `tests/gpu/*.esk` file's failure vocabulary found these four files (not just the one originally named) emitted zero failure-shaped output.
- The other 13 files (plus the already-compliant `ozaki_certification_test.esk`) did print well-formed `FAIL: <description>` markers on a failed check, but **none of them ever called `exit` with a nonzero status**. A failed check only ever produced text, never a process-level signal — so any judge that (correctly) treats exit code as authoritative saw green regardless of what a GPU kernel actually computed.

`scripts/lib/test_isolation.sh` already documents a prior near-miss of this exact defect class (an anchored `^FAIL:` regex that missed indented markers and `sf64_primitives_test.esk`'s colonless `FAIL (got ...`), fixed by making marker matching unanchored. That fix closed the marker-*quality* half of the problem; it could not close the exit-code half, which is what this PR does.

## The fix

**1. Structured contract, exit codes primary.** Every `tests/gpu/*.esk` file now aggregates a failure counter and calls `(exit 0)`/`(exit 1)` on a final `PASS:`/`FAIL:` verdict line, matching the strongest pre-existing convention in the suite (`ozaki_certification_test.esk`). `gpu_correctness_gate.esk` additionally gained ten backend-independent self-check invariants (finiteness of every RESULT value, exact transpose round-trip, an independent manual reduce-sum cross-check that never touches `tensor-sum`'s own reduction path, and algebraic identities like `sum(A+B) == sum(A) + sum(B)`), so it has real teeth even when run standalone through `scripts/run_gpu_tests.sh` — not just through the CPU-vs-GPU differential in `gpu_correctness_gate.sh`.

**2. Marker alignment as backstop.** `scripts/run_gpu_tests.sh` now documents ONE verdict grammar at its head (`PASS: <description>` / `FAIL: <description>`), and `scripts/lib/test_isolation.sh` gains an additive, opt-in `eshkol_test_output_has_verdict()` / `eshkol_test_output_has_success_marker()` pair — no change to any existing caller's behavior — wired into a new "NO VERDICT" grading branch: a test that exits 0 but never printed a single recognized PASS/FAIL line is graded **FAIL**, not PASS. Absence of evidence that a check ran is not evidence the check passed (the same principle #472's oracle fix used).

**3. The canary.** `tests/gpu/gate_canary_must_fail.esk` is a deliberate, permanent failure. `run_gpu_tests.sh` runs it on every invocation, outside the normal PASS-required loop, and requires it to fail (non-zero exit AND a `FAIL:` marker). If it ever passes, the whole run is forced red regardless of every other result — a real regression could be hiding behind exactly the same kind of silence that let the canary through. `gpu_correctness_gate.sh` separately gained a `--self-test` mode (mirroring `check_ledger_integrity.py`'s convention) that asserts its `SKIP` path writes **no** trace record to `scripts/icc_traces/gpu_execution.jsonl`, while its `FAIL`/`PASS` paths write distinguishable ones — closing the "a skipped lane must never read as a pass" gap at the trace-emission layer, on top of `.icc/completion-oracles.yaml`'s existing `severity: high` absence-is-FAIL handling for the `gpu-execution` target.

**4. Stale-comment / tolerance correction.** A comment in both `gpu_correctness_gate.esk` and `.sh` claimed `display` prints only ~6 significant digits, used to justify a loose `1e-4` tolerance. That claim is false: `display` calls `eshkol_dtoa_shortest` (`lib/core/runtime_display_hosted.cpp`), the same shortest-round-trip formatter used everywhere else — confirmed bit-exact by a direct round-trip probe (print a double, parse it back, compare bits: exact match on 8 varied test values including subnormal-adjacent and full-mantissa-precision cases). `GPU_GATE_TOL` is tightened from `1e-4` to `1e-9` on the strength of that correction plus a real measured Metal-vs-CPU divergence of **exactly 0** across all ten probes on this workload (see evidence below) — five to nine orders of magnitude looser than the corruption a real GPU-kernel bug produces (per `ozaki_correctness_test.esk`'s documented CRT-defect class).

**5. Ledger.** Filed and closed `SW-67` (bucket `VACUOUS-ASSURANCE`) in `.icc/silent-wrong-ledger.yaml`. Verified against every open PR branch on the remote before filing — `SW-65`/`SW-66` are taken by `fix/geometric-bridge-backwards` (#498) and `fix/evac-subtypes-dnc-sdnc-taylor` (#499). `check_ledger_integrity.py` passes (108 entries, no duplicate IDs).

## Local proof (Metal, Apple M2 Ultra)

Canary red-proof, then the full suite, run via `./scripts/run_gpu_tests.sh`:

```
Canary  gate_canary_must_fail.esk (must fail)              RED as expected (exit 1)
  >>> harness confirmed live: a failing kernel does turn this gate red
Canary  gpu_correctness_gate.sh --self-test                PASS

Testing all files in tests/gpu/ directory...

Testing cuda_host_sync_regression_test.esk                 PASS
Testing cuda_ozaki_correctness_test.esk                    PASS
Testing elementwise_correctness_test.esk                   PASS
Testing gpu_correctness_gate.esk                           PASS
Testing gpu_diagnostic_test.esk                            PASS
Testing gpu_large_matmul_test.esk                          PASS
Testing gpu_scale_correctness_test.esk                     PASS
Testing gpu_test.esk                                       PASS
Testing matmul_correctness_test.esk                        PASS
Testing ozaki_certification_test.esk                       PASS
    PASS: JIT and AOT both prove Accelerate mismatch>0 in BLAS mode (JIT:23 AOT:23) and fixed-N16 Metal exact mismatch=0
Testing ozaki_correctness_test.esk                         PASS
Testing ozaki_fast_test.esk                                PASS
Testing reduce_correctness_test.esk                        PASS
Testing sf64_nonuniform_test.esk                           PASS
Testing sf64_primitives_test.esk                           PASS
Testing sf64_simple_test.esk                                PASS
Testing softmax_normalize_test.esk                         PASS
Testing transpose_correctness_test.esk                     PASS

Total Tests: 18   Passed: 18   Failed: 0   Pass Rate: 100%
Ozaki exact-GEMM certification: VERIFIED (JIT+AOT, CPU-BLAS mismatch vs Metal exact mismatches=0)
Gate canary: confirmed RED, and gpu_correctness_gate.sh --self-test: PASS
```

Red-proof on both structurally-central files, corrupt-then-revert: injecting a wrong expected value into `sf64_primitives_test.esk` and `gpu_correctness_gate.esk` each produced a nonzero exit with a `FAIL:` line; reverted before commit.

The full CPU-vs-GPU differential (`gpu_correctness_gate.sh`, fresh GPU-enabled + CPU-only builds, not `run_gpu_tests.sh`'s standalone pass) was also run end-to-end at the new `1e-9` tolerance:

```
Diffing GPU vs CPU RESULT lines (relative tolerance 1e-9)...
  ok       matmul-checksum: GPU=135255870.36117578 CPU=135255870.36117578 rel_diff=0
  ok       matmul-c00: GPU=642.7586144782134 CPU=642.7586144782134 rel_diff=0
  ok       matmul-cmid: GPU=219.0769892244969 CPU=219.0769892244969 rel_diff=0
  ok       matmul-clast: GPU=52.81408417220773 CPU=52.81408417220773 rel_diff=0
  ok       add-checksum: GPU=526312.6631015609 CPU=526312.6631015609 rel_diff=0
  ok       mul-checksum: GPU=260851.59076217725 CPU=260851.59076217725 rel_diff=0
  ok       transpose-roundtrip-c00: GPU=642.7586144782134 CPU=642.7586144782134 rel_diff=0
  ok       transpose-roundtrip-clast: GPU=52.81408417220773 CPU=52.81408417220773 rel_diff=0
  ok       reduce-sum-A: GPU=263348.73874376045 CPU=263348.73874376045 rel_diff=0
  ok       reduce-max-A: GPU=2.0000999998864146 CPU=2.0000999998864146 rel_diff=0

Max relative diff across all probes: 0 (tolerance 1e-9)
PASS: GPU execution matches CPU reference within tolerance (1e-9) on Darwin
```

## Mesh / CUDA lane

`.github/workflows/ci-mesh.yml`'s advisory lane should pick this branch up on the self-hosted CUDA runner. Not yet confirmed at the time of opening this PR — will report the run result as a follow-up comment.

## Scope

The GPU harness/test contract only (`tests/gpu/`, `scripts/run_gpu_tests.sh`, `scripts/lib/test_isolation.sh`, the ledger). No dispatch-switch code touched — that is a separate, parallel lane's surface.

This closes a blocker for the engine-kernel certification program: a GPU correctness gate that cannot fail is not evidence a certification consumer can build on.

## Test plan

- [x] `./scripts/run_gpu_tests.sh` — 18/18 PASS, canary RED, self-test PASS, exit 0
- [x] `tests/gpu/gpu_correctness_gate.sh` — full GPU-vs-CPU differential PASS at the new `1e-9` tolerance, measured `max_rel_diff=0`
- [x] `tests/gpu/gpu_correctness_gate.sh --self-test` — PASS
- [x] Red-proof: corrupted-then-reverted checks in `sf64_primitives_test.esk` and `gpu_correctness_gate.esk` both produced nonzero exit + `FAIL:` line
- [x] `python3 scripts/check_ledger_integrity.py` — PASS, no duplicate IDs
- [ ] Self-hosted CUDA mesh lane (`ci-mesh.yml`) — pending confirmation