### PR TITLE
chore: replace internal machine identifiers with capability language

### DIFF
--- a/.icc/modularity-justifications.json
+++ b/.icc/modularity-justifications.json
@@ -76,7 +76,7 @@
     "status": "temporary_legacy_boundary",
     "task_id": "eshkol-v1.4-agent-platform-modularization",
     "reason": "agent_platform.c is the existing portability facade for filesystem, time, path, text-width, encoding, hashing, and security helpers. Its public surface is stable and fully cross-platform tested, but its domains are broader than one ideal module; a release-time textual split would add linkage and platform risk without changing behavior.",
-    "mitigation": "Do not add new domains to this file. During the v1.4 agent-platform boundary pass, extract filesystem/path, time/identity, terminal-text, and encoding/crypto helpers behind focused internal headers while preserving the current exported ABI and validating every extraction on macOS, Linux, and old-donkey Windows."
+    "mitigation": "Do not add new domains to this file. During the v1.4 agent-platform boundary pass, extract filesystem/path, time/identity, terminal-text, and encoding/crypto helpers behind focused internal headers while preserving the current exported ABI and validating every extraction on macOS, Linux, and Windows."
    }
   ]
 }

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -6004,8 +6004,8 @@ entries:
       Invoke-SimpleCompileRunSuite and Invoke-TimedCompileRunSuite, plus
       Invoke-XlaSuite's inline `^FAIL:`/`PASS`/`error:` checks, through it
       - six call sites total; none of the suites' own FailRegex/
-      RuntimeErrorRegex string literals changed. Verified on the real
-      Windows 10 / PowerShell 5.1 host (desktop-jack-blupc) with a
+      RuntimeErrorRegex string literals changed. Verified on a real
+      Windows 10 / PowerShell 5.1 host on the mesh with a
       csc.exe-built stub eshkol-run.exe standing in for the compiler: (a)
       the real canary fixture (banner line, then a FAIL: marker on line 2,
       exit 1) -> PASS (must-fail canary correctly failed) with 0 failed;
@@ -6023,8 +6023,8 @@ entries:
     evidence: >-
       scripts/run_all_tests.ps1 (Test-OutputMatches,
       Invoke-SimpleCompileRunSuite, Invoke-TimedCompileRunSuite,
-      Invoke-XlaSuite) - real-host run on desktop-jack-blupc (Windows 10,
-      PowerShell 5.1.19041) against a csc.exe-built stub compiler plus two
+      Invoke-XlaSuite) - real-host run on a Windows PowerShell 5.1 host on
+      the mesh (Windows 10, PowerShell 5.1.19041) against a csc.exe-built stub compiler plus two
       fixture executables, results (a)-(e) above; local `pwsh -NoProfile`
       parse check; python3 scripts/check_ps1_encoding.py PASS (the file
       stays pure ASCII).

--- a/docs/V1_3_TO_V1_5_DEPENDENCY_PLAN_2026-06-28.md
+++ b/docs/V1_3_TO_V1_5_DEPENDENCY_PLAN_2026-06-28.md
@@ -37,8 +37,8 @@ v1.3 is the self-contained core evolution release. It should ship when these are
 green:
 
 - ICC `readiness --repo eshkol_lang --target v1.3-evolve` is backed by a real
-  smoke command, not only static evidence. Current status is ready/100 on atlas
-  using `scripts/run_v1_3_readiness.sh` and `scripts/icc_traces`.
+  smoke command, not only static evidence. Current status is ready/100 on a
+  macOS node on the mesh using `scripts/run_v1_3_readiness.sh` and `scripts/icc_traces`.
 - SICP gate is part of the normal release smoke. PR #85 landed the corpus,
   smoke harness, and ICC oracle.
 - R7RS library compatibility is not partial. ROADMAP still calls out the full
@@ -149,13 +149,14 @@ The v1.5 artifact path should be:
 ## Ordered Work Plan
 
 1. Finish the v1.3 core gate.
-   - ICC smoke evidence for `v1.3-evolve` is fixed on atlas.
+   - ICC smoke evidence for `v1.3-evolve` is fixed on a macOS node on the mesh.
    - SICP gate is merged in #85; PR #87 removed stale xfails after #86.
    - Windows ARM64 is green after PR #77 / 6d57ab8f.
    - Close ESH-0075 and ESH-0080.
    - Add the static-link capability/env CTest from ESH-0077.
-   - ESH-0087 mesh certification is complete: cosbox, old-donkey, jack-blupc,
-     and xavier all have focused v1.3 feature + AD/input2 PASS evidence.
+   - ESH-0087 mesh certification is complete: two Linux x64 nodes, a Windows
+     node, and a Linux ARM64 node on the mesh all have focused v1.3 feature +
+     AD/input2 PASS evidence.
 
 2. Make Noesis first-party in the release machinery.
    - Add a Noesis v1.5 release gate script under Eshkol orchestration.
@@ -219,5 +220,5 @@ v1.7 should be distributed intelligence:
 - ESH-0084: attention/GeoRefine `qllm_bundle.json` integration gate.
 - ESH-0085: crypto symbol hygiene for Noesis recursive/session gates.
 - ESH-0086 and ESH-0087 are done locally: ICC smoke evidence is fixed and mesh
-  certification has PASS evidence on Linux, Windows, and xavier Nix paths.
+  certification has PASS evidence on Linux, Windows, and Linux ARM64 Nix paths.
 - Continue existing ESH-0075, ESH-0076, ESH-0077, ESH-0080, and ESH-0081.

--- a/docs/internal/ESHKOL_LANGUAGE_UPDATE_BRIEF.md
+++ b/docs/internal/ESHKOL_LANGUAGE_UPDATE_BRIEF.md
@@ -5,13 +5,14 @@
 **Date:** 2026-06-17
 **Mandate:** Completely update the language. Eshkol is being adopted as the
 compute + control substrate for running **Kimi K2.6 as a fast, lossless,
-general-purpose LLM** on modest hardware (old-donkey: RTX 3050 6 GB + CPU + disk
-streaming), accelerated by MoThRA and geometric inference. This work stressed
-Eshkol against a real, heavy GPU workload and surfaced concrete gaps. This brief
-is the punch-list to make Eshkol a first-class GPU-LLM language.
+general-purpose LLM** on modest hardware (a self-hosted Linux CUDA node on the
+mesh: RTX 3050 6 GB + CPU + disk streaming), accelerated by MoThRA and
+geometric inference. This work stressed Eshkol against a real, heavy GPU
+workload and surfaced concrete gaps. This brief is the punch-list to make
+Eshkol a first-class GPU-LLM language.
 
 Everything below was found empirically against **v1.2.3-scale** built with CUDA
-(`-DESHKOL_GPU_ENABLED=ON`, sm_86, cuBLAS) on old-donkey. Repro snippets are real.
+(`-DESHKOL_GPU_ENABLED=ON`, sm_86, cuBLAS) on that node. Repro snippets are real.
 
 ---
 
@@ -126,9 +127,10 @@ decode where startup dwarfs the GEMM.
   in the **runtime link of compiled programs**. The runtime/support lib appears to
   leak LLVM codegen symbols — **separate `libeshkol-runtime` (no LLVM) from the
   compiler lib** so compiled `a.out`s never need LLVM at link.
-- **Version drift:** old-donkey shipped v1.2.1 while we needed v1.2.3 (`gpu-matmul`,
-  etc.). Tag releases and make `--version` + a `eshkol features` introspection
-  command authoritative so deploys can assert capability.
+- **Version drift:** a self-hosted Linux CUDA node on the mesh shipped v1.2.1
+  while we needed v1.2.3 (`gpu-matmul`, etc.). Tag releases and make `--version`
+  + a `eshkol features` introspection command authoritative so deploys can
+  assert capability.
 
 ---
 

--- a/docs/platform/TEST_AND_CI_PLAN.md
+++ b/docs/platform/TEST_AND_CI_PLAN.md
@@ -34,10 +34,10 @@ Current guard:
   - runs the Windows CTest surface guard and
     `scripts/run_all_tests.ps1 -Mode windows-lite`
   - supports `--suite-only` for maintained cached local Windows builds such as
-    Jack's MSYS/UCRT checkout, avoiding hosted runner use for routine x86_64
-    Windows smoke validation
-  - Jack gate example:
-    `scripts/remote_windows_verify.sh jack-blupc --build-dir build-jack-msys-ucrt --suite-only`
+    a mesh Windows host's MSYS/UCRT checkout, avoiding hosted runner use for
+    routine x86_64 Windows smoke validation
+  - Windows gate example:
+    `scripts/remote_windows_verify.sh <windows-host> --build-dir build-msys-ucrt --suite-only`
 - `tests/toolchain/remote_windows_verify_surface_test.cpp`
   - keeps the remote Windows verifier tied to the bounded Windows suite and
     prevents it from becoming destructive

--- a/docs/platform/WINDOWS_X86_KVM.md
+++ b/docs/platform/WINDOWS_X86_KVM.md
@@ -1,25 +1,28 @@
-# Windows 11 x64 test VM on Linux KVM (old-donkey / cosbox)
+# Windows 11 x64 test VM on Linux KVM (self-hosted mesh nodes)
 
-Status as of 2026-07-03: **scaffolding provisioned on old-donkey; awaiting a
-Windows 11 installer ISO** (manual download step below). No VM has been booted
-yet.
+Status as of 2026-07-03: **scaffolding provisioned on the primary Linux KVM
+host; awaiting a Windows 11 installer ISO** (manual download step below). No
+VM has been booted yet.
 
-The mesh has no native Windows x64 CI runner. jack-blupc covers Windows x64
-bare-metal, but a KVM guest on the Linux x64 nodes gives us a reproducible,
-snapshotable Windows environment for release testing.
+The mesh has no native Windows x64 CI runner. A dedicated Windows x64
+bare-metal host covers that case, but a KVM guest on the Linux x64 nodes gives
+us a reproducible, snapshotable Windows environment for release testing.
 
 ## Host inventory
 
+Two Linux x64 nodes on the mesh are KVM-capable; this doc refers to them as
+**Host A** (primary) and **Host B** (fallback).
+
 | Host | KVM | QEMU | OVMF (secure boot) | swtpm | Free disk | Fit |
 |------|-----|------|--------------------|-------|-----------|-----|
-| old-donkey | yes (user in `kvm`,`libvirt`) | 8.2.2 | yes (`OVMF_*_4M.ms.fd`) | yes | 358 G | **primary** |
-| cosbox | yes (device present, user NOT in `kvm` group) | 8.2.2 + virt-install | yes | untested | 21 G (96% full) | fallback only |
+| Host A | yes (user in `kvm`,`libvirt`) | 8.2.2 | yes (`OVMF_*_4M.ms.fd`) | yes | 358 G | **primary** |
+| Host B | yes (device present, user NOT in `kvm` group) | 8.2.2 + virt-install | yes | untested | 21 G (96% full) | fallback only |
 
-old-donkey note: outbound HTTPS to `github.com` and `vlscppe.microsoft.com`
+Host A note: outbound HTTPS to `github.com` and `vlscppe.microsoft.com`
 is blocked from this host; general internet (e.g. `microsoft.com`) works.
 Transfer files over SSH/scp from another mesh node when needed.
 
-## What is already provisioned (old-donkey)
+## What is already provisioned (Host A)
 
 ```
 ~/vms/win11-x64/
@@ -41,21 +44,21 @@ port 22222 and serves the console on VNC display `:11` (localhost only).
    - Visit <https://www.microsoft.com/en-us/software-download/windows11>
    - Select "Windows 11 (multi-edition ISO for x64 devices)", language
      "English (United States)", and download (~6.5 GB).
-   - Copy it to the host: `scp Win11_*.iso old-donkey:~/vms/win11-x64/`
+   - Copy it to the host: `scp Win11_*.iso host-a:~/vms/win11-x64/`
 2. **First boot / install**:
    ```
-   ssh old-donkey
+   ssh host-a
    cd ~/vms/win11-x64
    ./start-win11.sh ~/vms/win11-x64/Win11_*.iso
    ```
-   Tunnel VNC from your workstation: `ssh -L 5911:localhost:5911 old-donkey`,
+   Tunnel VNC from your workstation: `ssh -L 5911:localhost:5911 host-a`,
    then connect a VNC client to `localhost:5911`. Press a key at the "Press any
    key to boot from CD" prompt.
 3. **Inside Windows**: complete setup (a local account is fine), then
    - `Settings > System > Optional features > OpenSSH Server` (or
      `Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0`), start the
      `sshd` service and set it to automatic. The guest is then reachable with
-     `ssh -p 22222 <user>@localhost` from old-donkey.
+     `ssh -p 22222 <user>@localhost` from Host A.
 4. **Toolchain for Eshkol CI-equivalent runs** (mirrors `.github/workflows/ci.yml`):
    - Visual Studio 2022 Build Tools with the "Desktop development with C++"
      workload, CMake, Git.
@@ -72,8 +75,8 @@ port 22222 and serves the console on VNC display `:11` (localhost only).
 6. **Snapshot before experiments**: `qemu-img snapshot -c clean-install
    ~/vms/win11-x64/win11.qcow2` (with the VM shut down).
 
-## cosbox caveats
+## Host B caveats
 
-cosbox has the QEMU/OVMF stack but `tyr` is not in the `kvm` group (needs
-`sudo usermod -aG kvm tyr` + re-login) and the disk is 96% full — clear space
-before hosting a VM there.
+Host B has the QEMU/OVMF stack but the configured user is not in the `kvm`
+group (needs `sudo usermod -aG kvm <user>` + re-login) and the disk is 96%
+full — clear space before hosting a VM there.

--- a/exe/eshkol-run.cpp
+++ b/exe/eshkol-run.cpp
@@ -240,7 +240,8 @@ static std::string captureCommandOutput(const std::string& command) {
 // time. That baked path (e.g. /opt/homebrew/Cellar/llvm/21.1.7/lib) does not
 // exist on a host whose LLVM is a different patch/prefix, so the link fails
 // with "search path '...' not found" / "library 'LLVM-NN' not found" and the
-// binary can't JIT off-builder (Noesis hit this copying atlas's binary to enki).
+// binary can't JIT off-builder (Noesis hit this copying one mesh node's
+// binary to another).
 //
 // We try `llvm-config --libdir` (and the versioned `llvm-config-NN`) from PATH,
 // then common prefixes. Returns empty if nothing resolves, in which case the
@@ -4225,7 +4226,7 @@ int main(int argc, char **argv)
             /* Authoritative capability introspection (GPU-LLM brief §5).
              * Machine-parseable KEY=VALUE lines so a mesh deploy can assert
              * a build has the capabilities a workload needs BEFORE scheduling
-             * it — the version-drift failure (old-donkey shipped a build
+             * it — the version-drift failure (a mesh node shipped a build
              * without gpu-matmul) becomes a one-line precondition check:
              *   eshkol-run --features | grep -q '^gpu=on'
              * Values are compile-time facts about THIS binary. */

--- a/lib/repl/jitlink_branch26_range_extension.h
+++ b/lib/repl/jitlink_branch26_range_extension.h
@@ -117,7 +117,8 @@ public:
     // pipeline runs its own PostPrune stub/GOT builders whose materialization
     // our extra pass perturbs, wedging in-process JIT materialization
     // (lookupLinkerMangled -> pthread_cond_wait). ELF/COFF are the real,
-    // tested problem scope (xavier = arm64-Linux/ELF). Gate on object format,
+    // tested problem scope (a Linux ARM64 node on the mesh = arm64-Linux/ELF).
+    // Gate on object format,
     // not just arch.
     if (TT.getObjectFormat() != llvm::Triple::ELF &&
         TT.getObjectFormat() != llvm::Triple::COFF)

--- a/scripts/platform/start-win11-kvm.sh
+++ b/scripts/platform/start-win11-kvm.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# Launch the Windows 11 x64 KVM guest on old-donkey (or any Linux KVM host
-# with OVMF + swtpm installed). First boot: pass the installer ISO as $1.
+# Launch the Windows 11 x64 KVM guest on the primary Linux KVM host on the
+# mesh (or any Linux KVM host with OVMF + swtpm installed). First boot: pass
+# the installer ISO as $1.
 #
 #   ./start-win11.sh ~/vms/win11-x64/Win11_25H2_English_x64.iso   # install
 #   ./start-win11.sh                                              # normal boot
 #
-# Console: VNC on localhost:5911 (tunnel with `ssh -L 5911:localhost:5911 old-donkey`).
+# Console: VNC on localhost:5911 (tunnel with `ssh -L 5911:localhost:5911 host-a`).
 # After install, enable OpenSSH Server inside Windows for headless use.
 set -euo pipefail
 

--- a/tests/v1_2_edge_cases/msgpack_test.esk
+++ b/tests/v1_2_edge_cases/msgpack_test.esk
@@ -73,13 +73,13 @@
   (lambda ()
     (let* ((wire (msgpack-encode
                    (msgpack-map
-                     (list (list "node" "atlas")
+                     (list (list "node" "node-a")
                            (list "clock" 7)))))
            (decoded (msgpack-decode wire))
            (entries (msgpack-map-entries decoded)))
       (check-true (msgpack-map? decoded))
       (check-equal? (length entries) 2)
-      (check-equal? (car entries) (list "node" "atlas"))
+      (check-equal? (car entries) (list "node" "node-a"))
       (check-equal? (cadr entries) (list "clock" 7)))))
 
 (register-test "prefix decode returns cursor and full decode rejects trailing data"


### PR DESCRIPTION
Rewords internal mesh hostnames, tailnet-style host references, and one test fixture's placeholder string that had leaked into tracked docs, YAML/JSON, and code comments on master, replacing each with capability language (e.g. "a Windows PowerShell 5.1 host on the mesh", "a Linux ARM64 node on the mesh") that preserves the original technical meaning without naming a specific host. No entries in .icc/silent-wrong-ledger.yaml were added, removed, or renumbered — wording only. Legitimate hardware/product names (e.g. NVIDIA Jetson AGX Xavier) and unrelated ML terminology (xavier-uniform!/xavier-normal! weight initializers) were left untouched.