### PR TITLE
press: v1.3.5-evolve press kit

### DIFF
--- a/press/ESHKOL_DESCRIPTION_COPY.md
+++ b/press/ESHKOL_DESCRIPTION_COPY.md
@@ -2,67 +2,93 @@
 
 ## A compiled Scheme with a constructive proof that a transformer is an interpreter
 
-Eshkol is a compiled programming language for mathematical and cognitive computing.
-The repository ships v1.3.4-evolve (July 2026) of the compiler — an arbitrary-order
-automatic-differentiation system with exact gradients now verified through the
-tensor-op `input2` path and through every callable form (indirect, wrapped, and
-curried, with no finite-difference fallback), 100% conformance on a portable R7RS
-differential corpus, and a region-escape evacuator that makes long-running/resident
-programs safe to leave running across every heap subtype the language can allocate.
-v1.3.4-evolve is a resident-correctness release: automatic per-iteration memory
-reclamation now matches explicit `with-region` even for loops that mutate persistent
-state every tick (closing the ESH-0214 memory-management series); `parallel-map` is
-race-free for closures that allocate and return collections; printed floats round-trip
-to the identical `double` (R7RS 6.2.6); the strict type checker accepts a checked
-`(the <type> expr)` ascription and predicate-guarded narrowing; and the high-precision
-numerics wave lands (Ozaki-II exact and reduced-precision GEMM tiers, a mixed-precision
-`linear-solve`, and a native 128-bit integer type), alongside a Moonlab v1.2.0 quantum
-pin with quantum-natural-gradient support, full hosted-VM tensor-matmul parity, and a
-linear `Qubit` type.
-The earlier v1.3.3-evolve added an opt-in quantum computing stack — Moonlab state-vector
-simulation, a variational quantum eigensolver whose gradients flow through the
-language's own automatic differentiation via new custom-VJP tape nodes, a CHSH
-Bell-inequality gate, Bell-verified quantum randomness, and ML-KEM (FIPS 203)
-post-quantum cryptography — alongside real `make-parameter`/`parameterize`
-dynamic parameters, the `core.dbsp` incremental-dataflow module, bignum-capable
-exact rationals, and one-pass reverse-mode gradients. The same release ran a
-silent-wrong-answer correctness campaign driven by two new generative exposure
-engines, closing several bytecode-VM silent-miscompile classes, tail-call gaps
-in six special forms, and a 26x `--wasm` size regression. The repository carries
-all of this together with the reproducibility artefact for
-*The Self-Differentiating Neural Computer: Computable Transformers via
+In Eshkol v1.3.5-evolve you can call a procedure that has already returned.
+That is not a metaphor. `call/cc` is multi-shot and re-entrant on all three
+engines the project ships — native JIT, native AOT, and the bytecode VM. A
+capture that may outlive its frame takes a durable copy of the live C stack and
+restores it to the same addresses before resuming, so every frame pointer, every
+spilled register, and every address of a local that a closure is holding stays
+valid with no relocation; the VM snapshots its own operand stack and call-frame
+array, and `dynamic-wind` reroots on both engines per R7RS 6.10. Six programs,
+three engines, eighteen byte-exact transcripts.
+<!-- source: tests/continuations/ (6 fixtures), scripts/run_continuation_tests.sh (runs each on -r, AOT, VM against tests/continuations/expected) -->
+
+Eshkol is a compiled programming language for mathematical and cognitive
+computing. The repository ships v1.3.5-evolve (August 2026) of the compiler.
+Alongside re-entrant continuations, the bytecode VM gains its own region
+evacuator, so `with-region` reclaims memory there the way it already does on
+native codegen: the same fixture holds flat at 25-27 MB across 1,000, 4,000 and
+16,000 iterations, against 793 MB on the identical binary with reclamation
+switched off.
+<!-- source: ROADMAP.md §v1.3.5 flagship; docs/breakdown/RUNTIME_CONFIGURATION.md#bytecode-vm-region-reclamation -->
+Mutual tail recursion runs in constant stack space through every tail-position
+spelling — `cond`, `case`, `when`, `unless`, and the last operand of `and`/`or`,
+not only `if` — and a tail-transfer dispatcher extends that bound to calls whose
+signatures differ and to targets that are not AArch64: 100,000,000 hops at
+9.1 MB peak resident memory.
+<!-- source: CHANGELOG.md §1.3.5-evolve, tail-transfer dispatcher (#483) -->
+Differentiation dispatch is closed by construction: the AD node registry, the
+callable subtypes, and the region evacuation kinds are generated from a single
+declaration file with no `default:` arm, with `-Werror=switch-enum` making an
+unhandled member a compile error rather than a plausible answer, and the four
+geometric bridge operators — hyperbolic distance, the Poincaré exponential and
+logarithmic maps, and geodesic attention — carry exact closed-form Jacobians
+agreeing with independently derived golden Jacobians to 3.7e-16 and with two
+derivation-independent identities to maximum relative deviations of 5.0e-16 and
+6.7e-16, before a finite difference is consulted at all.
+<!-- source: inc/eshkol/ad_node_registry.def; lib/bridge/tensor_backward.cpp; CHANGELOG.md §1.3.5-evolve (#500, #498) -->
+
+The repository carries all of this together with the reproducibility artefact
+for *The Self-Differentiating Neural Computer: Computable Transformers via
 Analytical Weight Construction* (tsotchke, 2026), in which a six-layer
-transformer with 12.22 million analytically-constructed parameters executes
-a bounded 83-opcode bytecode VM bit-identically. The result is a
-constructive, not statistical, demonstration that a fixed-weight transformer
-can be an interpreter when its weights are derived from an instruction-set
-specification rather than fit by gradient descent.
+transformer with 12.22 million analytically-constructed parameters executes a
+bounded 83-opcode bytecode VM bit-identically. The result is a constructive, not
+statistical, demonstration that a fixed-weight transformer can be an interpreter
+when its weights are derived from an instruction-set specification rather than
+fit by gradient descent.
+
+---
+
+## Launch post
+
+```
+Eshkol v1.3.5-evolve is out now.
+
+∂ is now exhaustive by construction: the compiler will not build a program
+whose differentiation dispatch has a hole.
+
+https://github.com/tsotchke/eshkol
+```
+
+## Long-form article title
+
+`Eshkol v1.3.5-evolve: Multi-Shot Continuations in a Compiled Scheme`
 
 ---
 
 ## Lede
 
-Eshkol is an R7RS-compatible Scheme dialect that compiles through LLVM 21 to native
-binaries on macOS, Linux, and Windows, and to WebAssembly for browser execution.
-The language treats automatic differentiation, arena memory, and a neuro-symbolic
-computation layer as compiler primitives rather than library add-ons. Differentiation
-is available in symbolic, forward, and reverse modes alongside eight vector-calculus
-operators — and, as of v1.3.0-evolve, at arbitrary order via a Taylor-tower engine that
-returns exact bignum/rational derivatives when the math supports it, with the
-reverse-mode tensor-op gradient path (`conv2d`/`batchnorm`/`layernorm`/`attention`)
-now verified exact for first-class losses and vector/learnable gamma as of
-v1.3.3-evolve; memory is
-allocated through Ownership-Aware Lexical Regions with deterministic, per-scope
-deallocation and no garbage collector; the consciousness engine exposes twenty-two
-builtins covering unification, factor-graph belief propagation, free-energy
-minimisation, and global-workspace softmax competition.
+Eshkol is an R7RS-compatible Scheme dialect that compiles through LLVM 21 to
+native binaries on macOS, Linux, and Windows, and to WebAssembly for browser
+execution. The language treats automatic differentiation, arena memory, and a
+neuro-symbolic computation layer as compiler primitives rather than library
+add-ons. Differentiation is available in symbolic, forward, and reverse modes
+alongside eight vector-calculus operators — and, as of v1.3.0-evolve, at
+arbitrary order via a Taylor-tower engine that returns exact bignum/rational
+derivatives when the math supports it. Memory is allocated through
+Ownership-Aware Lexical Regions with deterministic, per-scope deallocation and
+no garbage collector; as of v1.3.5-evolve that reclamation runs on the bytecode
+VM as well as on native codegen. Continuations are multi-shot and re-entrant on
+every engine. The consciousness engine exposes twenty-two builtins covering
+unification, factor-graph belief propagation, free-energy minimisation, and
+global-workspace softmax competition.
 
 The flagship demonstration is the SDNC paper artefact: a single shell invocation
 regenerates the 12.22M-parameter weight tensor and verifies that a reference C
 interpreter, a simulated transformer, and a matrix-based forward pass agree on
-123 of 123 traced programs at every step on every dimension of the 256-dimensional
-state vector. The artefact lives in the same repository as the compiler that
-hosts it.
+123 of 123 traced programs at every step on every dimension of the
+256-dimensional state vector. The artefact lives in the same repository as the
+compiler that hosts it.
 
 ---
 
@@ -70,224 +96,415 @@ hosts it.
 
 Each item below cites the file or measurement that grounds the claim.
 
-- **Constructive proof of a transformer as an interpreter.** Six layers, d_model = 256,
-  feed-forward width 2304, 16 attention heads, 12.22M parameters. The artefact covers
-  82 of the 83 canonical opcodes; the one remaining external boundary is `OP_NATIVE_CALL`,
-  the deliberate dispatch point for host-runtime services.
-  See *docs/SDNC.md* and *lib/backend/weight_matrices.c*. The reproduction harness is
-  *scripts/paper/run_paper_suite.sh*; expected wall time is under five minutes on a 2023 M2 Max.
+- **Multi-shot, re-entrant continuations on a compiled backend
+  (v1.3.5-evolve).** A captured continuation can be invoked any number of
+  times, from any dynamic extent, including after the procedure that captured
+  it has already returned — the shape generators, coroutines, and `amb`-style
+  backtracking search all need. Native gives a capture that may outlive its
+  frame a durable copy of the live C stack, restored to the same addresses
+  before resuming, so interior pointers stay valid with no relocation; an
+  escape-only capture (early return, exception-style unwinding) keeps the
+  original zero-overhead `setjmp`/`longjmp` path. The bytecode VM snapshots its
+  operand stack and call-frame array while deliberately excluding top-level
+  bindings — the *store* — from the *control* snapshot R7RS asks `call/cc` to
+  capture, so `set!` and `define` effects at top level survive re-entry. A
+  continuation captured inside `with-region` pins every open region on both
+  engines, so the failure direction is a bounded leak and never a dangling read.
+  Gated on all three engines against six fixtures whose transcripts are compared
+  byte-for-byte.
+  See *tests/continuations/*, *scripts/run_continuation_tests.sh*, and the
+  [continuations reference](../docs/reference/language/continuations.md).
 
-- **Arbitrary-order automatic differentiation.** A Taylor-tower engine (thirteen gated
-  phases, P0-P12) computes every derivative up to an arbitrary order `k` in one pass —
-  `k+1` coefficients and O(k²) work, not the 2^k blow-up of nested dual numbers. When the
-  seed point is exact and the function only uses exact-preserving operators, `derivative-n`
-  and `taylor` return exact arbitrary-precision (bignum/rational) results rather than
-  floating-point approximations; `taylor-model`/`tm-range`/`tm-eval` pair the polynomial
-  with a rigorous interval-remainder bound for a provable range enclosure. Towers are
-  tensor-valued, compose through reverse-mode (checkpointed reverse-over-Taylor), recover
-  sparse Hessian structure via graph coloring, and work through `if`/`cond`/named-let/
-  recursion. See *lib/core/taylor_recurrences.def*, *lib/core/runtime_taylor.c*, and the
+- **Region reclamation on both engines (v1.3.5-evolve).** `with-region` now
+  reclaims on the bytecode VM as well as on native codegen. The port matches the
+  native engine's semantics rather than its implementation: native copies the
+  escaping subgraph Cheney-style, while the VM marks from its root set and
+  sweeps at arena-block granularity, because a VM value addresses the heap by a
+  small integer index rather than by pointer — marking moves nothing, so `eq?`
+  identity, shared structure, and cycles survive with no special handling.
+  Coverage is total by construction: a compile-time-checked 33-wide table
+  classifies the full heap tag space (the 28 `HeapType` members, the three
+  manifold tags defined outside the enum, and the two unassigned slots), a fatal
+  startup check requires every row to be filled in, and an unclassified subtype
+  pins its region rather than guessing. Measured on the same fixture: flat at
+  25-27 MB across 1,000, 4,000 and 16,000 iterations, against 793 MB with the
+  evacuator disabled and 704 MB for an unwrapped control.
+  See *ROADMAP.md §v1.3.5* and
+  [docs/breakdown/RUNTIME_CONFIGURATION.md](../docs/breakdown/RUNTIME_CONFIGURATION.md#bytecode-vm-region-reclamation).
+
+- **Tail calls that do not care how they were spelled (v1.3.5-evolve).** A
+  mutual tail call written with `cond`, `case`, `when`, `unless`, or as the last
+  operand of `and`/`or` gets the same constant-stack guarantee `if` always had.
+  A transferring procedure does not call its target: it copies its evaluated
+  arguments into a per-thread transfer record, records the callee's uniform
+  entry, and returns, and a driver loop compiled into the public entry point
+  runs the transfer in its place — one native frame live per hop, reused
+  regardless of arity or target. Differing-signature mutual tail calls run
+  100,000,000 hops at 9.1 MB peak resident memory, and non-AArch64 targets get
+  the same bound without an aggregate-return `musttail`; the depth ladder runs
+  each mutual-recursion shape at 500,000, 5,000,000 and 100,000,000 hops,
+  including a four-cycle that routes through `cond`, `when`, `or` and `case`, one
+  form per hop. Tail calls through `guard` stay bounded deliberately: R7RS does
+  not make that a tail context.
+  <!-- source: .icc/completion-oracles.yaml (100,000,000 hops at 9.1 MB peak RSS); scripts/gen_recursion_depth.py:125-155 -->
+  See ADR-0006 §3.
+
+- **Exhaustive differentiation dispatch, enforced by the compiler
+  (v1.3.5-evolve).** A `default:` arm may not stand in for an invariant.
+  `ad_node_type_t`, `callable_subtype_t`, and `EvacKind` are generated from a
+  single declaration registry with no `default:` arm, and `-Werror=switch`
+  plus `-Werror=switch-enum` make an unhandled member a compile error instead
+  of a plausible answer; an ICC invariant re-derives each enum's members from
+  its own definition so the guarantee holds on toolchains where the flag alone
+  cannot enforce it. A registry row naming a backward function that does not
+  exist is itself a compile error, which is what makes a row's claim to be
+  registered mean registered. Open sets stay loud on purpose: a subtype byte
+  read out of an object header is untrusted input, so it is split off with a
+  value-naming fallback rather than folded into the closed enum.
+  See *inc/eshkol/ad_node_registry.def* and *.icc/architecture-model.yaml*.
+
+- **Exact gradients through hyperbolic geometry (v1.3.5-evolve).** Hyperbolic
+  distance, the Poincaré exponential and logarithmic maps, and geodesic
+  attention carry exact closed-form backward rules, each declared as a bridged
+  row in the dispatch registry. The exp and log rules reuse the Möbius-addition
+  and log-map Jacobians the Fréchet rule already differentiates rather than
+  re-deriving them, since a second derivation could only introduce a
+  disagreement. Validated against golden Jacobians from an independently written
+  Eshkol transcription of the same formulas (agreement to 3.7e-16 and 1.1e-14)
+  and against two derivation-independent identities — the conformal
+  gradient-norm identity and the inverse-Jacobian identity, at maximum relative
+  deviations of 5.0e-16 and 6.7e-16 — before finite differences are consulted at
+  all. Two points are made
+  explicit rather than hidden: the distance is not differentiable at coincident
+  points, and geodesic attention is therefore not differentiable when a query
+  row equals a key row exactly, and both refuse loudly, naming the offending
+  index, rather than picking a plausible subgradient.
+  See *lib/bridge/tensor_backward.cpp* and
+  *tests/bridge/qllm_bridge_geometric_gradcheck_test.cpp* (13 checks, pinned by
+  count).
+  <!-- source: .icc/silent-wrong-ledger.yaml SW-65 evidence block -->
+
+- **Forward producers for the tensor-embedding and Fréchet-mean AD nodes
+  (v1.3.5-evolve).** `ad_tensor_embedding` and `ad_frechet_mean` record real AD
+  nodes through the real dispatch path, so the backward rules are exercised by
+  the producer that fills their contract rather than by hand-assembled fixtures
+  written from the same contract the rule reads. Fractional, negative, and
+  out-of-range embedding indices are refused at record time rather than rounded
+  or clamped into a wrong row, and the Fréchet forward shares its Karcher
+  iteration with the VM's own opcode so forward and backward cannot disagree
+  about what "converged" means. Gradchecked against exact analytic references:
+  exact scatter-add for the embedding with 0 mismatches, the exact Euclidean
+  closed form for the Fréchet mean at 0.0, and a hyperbolic finite difference of
+  8.3e-10 over 48 partials.
+  <!-- source: CHANGELOG.md v1.3.5-evolve (#497); tests/bridge/qllm_bridge_producer_gradcheck_test.cpp -->
+  See *lib/bridge/qllm_bridge.cpp*, *inc/eshkol/backend/frechet_mean_core.h*,
+  and *tests/bridge/qllm_bridge_producer_gradcheck_test.cpp*.
+
+- **Constructive proof of a transformer as an interpreter.** Six layers,
+  d_model = 256, feed-forward width 2304, 16 attention heads, 12.22M parameters.
+  The artefact covers 82 of the 83 canonical opcodes; the one remaining external
+  boundary is `OP_NATIVE_CALL`, the deliberate dispatch point for host-runtime
+  services. See *docs/SDNC.md* and *lib/backend/weight_matrices.c*. The
+  reproduction harness is *scripts/paper/run_paper_suite.sh*; expected wall time
+  is under five minutes on a 2023 M2 Max.
+
+- **Arbitrary-order automatic differentiation.** A Taylor-tower engine (thirteen
+  gated phases, P0-P12) computes every derivative up to an arbitrary order `k`
+  in one pass — `k+1` coefficients and O(k²) work, not the 2^k blow-up of nested
+  dual numbers. When the seed point is exact and the function only uses
+  exact-preserving operators, `derivative-n` and `taylor` return exact
+  arbitrary-precision (bignum/rational) results rather than floating-point
+  approximations; `taylor-model`/`tm-range`/`tm-eval` pair the polynomial with a
+  rigorous interval-remainder bound for a provable range enclosure. Towers are
+  tensor-valued, compose through reverse-mode (checkpointed reverse-over-Taylor),
+  recover sparse Hessian structure via graph coloring, and work through
+  `if`/`cond`/named-let/recursion. See *lib/core/taylor_recurrences.def*,
+  *lib/core/runtime_taylor.c*, and the
   [Automatic Differentiation guide](../docs/guide/AUTOMATIC_DIFFERENTIATION.md).
 
-- **Exact reverse-mode tensor-op gradients for first-class losses (v1.3.3-evolve).**
-  `gradient` on `conv2d`/`batchnorm`/`layernorm`/`attention` now propagates an exact
-  gradient to the second operand (kernel/gamma-beta/K-V) whether the loss is a
-  compile-time-known function or a first-class value with no compile-time `Function*` —
-  the latter previously fell to a forward-mode-dual closure path that silently returned
-  a zero gradient. Batch-norm/layer-norm gamma/beta are now differentiated per-feature
-  rather than as one scalar, and any remaining unsupported tensor-op backward path
-  raises an explicit error instead of a silent zero. This corrects a prior CHANGELOG
-  entry (#212) that an adversarial finite-difference audit found to be a no-op; the real
-  fix is #229, finite-difference-verified in both literal and first-class forms.
+- **A no-finite-differences guarantee that can fail.** The counter behind
+  `(ad-finite-difference-evals)` has a real writer on the one central-difference
+  backward the tape defines, reported through the zero-arity builtin
+  `(ad-note-finite-difference!)` on native and on the VM alike, and the
+  exactness gate runs a positive case beside a negative control — a difference
+  quotient deliberately planted in the gradient path — on JIT, AOT, and the VM.
+  Exactness also gains a structural gate that an output differential cannot
+  provide: `.icc/ad-carrier-manifest.yaml` declares, per operator and per
+  engine, which differentiation carrier answers it and whether it is exact, and
+  a gate re-derives each declaration by extracting and classifying the actual
+  `case` body in the emitted sources, so a declaration cannot be laundered
+  through a helper. See *scripts/run_ad_exactness_gate.sh* and
+  *scripts/gate_ad_shared_node_model.py*.
 
-- **Quantum computing, opt-in and differentiable (v1.3.3-evolve,
-  `-DESHKOL_QUANTUM_ENABLED=ON`).** The `agent.quantum` module binds the Moonlab
-  state-vector simulator: state creation/teardown, Hadamard/Pauli/CNOT/rotation
-  gates, `measure`, `expectation-z`, and a `with-quantum-state` auto-destroy
-  helper, plus VQE builtins with H2/LiH/H2O molecular Hamiltonians whose
-  energies differentiate through Eshkol's own AD — new custom-VJP tape nodes
-  bridge Moonlab's exact adjoint gradient into the reverse tape, so
-  `(vqe-energy ...)` composes with ordinary `gradient`/optimizer code (the
-  release gate requires the bridged adjoint to match Moonlab's native adjoint
-  to within `1e-8` and a central finite difference to within `1e-4`). A
+- **Compiler-integrated automatic differentiation (order ≤ 2).** Three modes:
+  symbolic AST rewriting at compile time using twelve differentiation rules;
+  forward mode through 16-byte dual numbers `{value, derivative}`; reverse mode
+  through a computational graph spanning more than twenty AD node types with a
+  32-level tape stack for nested gradients. Eight vector-calculus operators —
+  `derivative`, `gradient`, `jacobian`, `hessian`, `divergence`, `curl`,
+  `laplacian`, `directional-derivative` — are language primitives. Custom-VJP
+  tape nodes (`AD_NODE_CUSTOM`) carry an externally supplied vector-Jacobian
+  product, so a foreign computation with a known adjoint participates exactly in
+  reverse-mode AD (first user: Moonlab's VQE gradient), and per-component
+  gradient replay is collapsed into one primal plus one reverse pass reading
+  every input gradient from the tape. See *lib/backend/autodiff_codegen.cpp* and
+  *docs/DESIGN.md §Automatic Differentiation*.
+
+- **Quantum computing, opt-in and differentiable
+  (`-DESHKOL_QUANTUM_ENABLED=ON`).** The `agent.quantum` module binds the
+  Moonlab state-vector simulator: state creation/teardown,
+  Hadamard/Pauli/CNOT/rotation gates, `measure`, `expectation-z`, and a
+  `with-quantum-state` auto-destroy helper, plus VQE builtins with H2/LiH/H2O
+  molecular Hamiltonians whose energies differentiate through Eshkol's own AD —
+  custom-VJP tape nodes bridge Moonlab's exact adjoint gradient into the reverse
+  tape, so `(vqe-energy ...)` composes with ordinary `gradient`/optimizer code
+  (the release gate requires the bridged adjoint to match Moonlab's native
+  adjoint to within `1e-8` and a central finite difference to within `1e-4`). A
   permanent 16K-shot CHSH Bell-inequality gate (`bell-chsh`,
-  `tests/quantum/bell_chsh_test.esk`) requires `2.4 < S <= 2.95`, beyond the
-  classical bound of 2 — a fresh run this cycle measured S = 2.835 (PASS); the
-  exact value is a random-shot measurement that varies run to run within
-  those gate bounds — proving genuine quantum correlations rather than a
-  classical imitation. `quantum-random` draws from Moonlab's
-  Bell-verified QRNG when quantum is enabled, with an honestly-labeled
-  classical fallback otherwise. The companion `agent.pqc` module provides
-  ML-KEM (FIPS 203) post-quantum key encapsulation — `mlkem-keygen`/
-  `mlkem-encaps`/`mlkem-decaps` at the 512/768/1024 security levels over
-  R7RS bytevectors, QRNG-seeded, verified against NIST KAT fingerprints.
-  See *lib/agent/quantum.esk*, *lib/agent/pqc.esk*, and
-  *lib/agent/c/agent_quantum.c*.
+  *tests/quantum/bell_chsh_test.esk*) requires `2.4 < S <= 2.95`, beyond the
+  classical bound of 2 — a run this cycle measured S = 2.835; the exact value is
+  a random-shot measurement that varies run to run within those gate bounds,
+  which is what proves genuine quantum correlations rather than a classical
+  imitation. Cloning a linear `Qubit` is a rejected compile in the default build:
+  the violation stops before code generation, exits nonzero, and writes no
+  artifact. `quantum-random` draws from Moonlab's Bell-verified QRNG when quantum
+  is enabled, with an honestly-labeled classical fallback otherwise. The
+  companion `agent.pqc` module provides ML-KEM (FIPS 203) post-quantum key
+  encapsulation at the 512/768/1024 security levels over R7RS bytevectors,
+  QRNG-seeded, verified against NIST KAT fingerprints. Differentiable quantum
+  chemistry examples ship in *examples/* — *vqe_h2.esk*, *qng_vqe.esk*, and
+  *h2_vibrational_quantum.esk*. See *lib/agent/quantum.esk*,
+  *lib/agent/pqc.esk*, and *lib/agent/c/agent_quantum.c*.
 
-- **Incremental dataflow (`core.dbsp`, v1.3.3-evolve).** Z-sets (weighted
-  multisets) as a commutative group, the `z^-1`/`D`/`I` stream operators (D
-  and I mutual inverses), incremental relational operators — linear
-  map/filter/project/union, join via the discrete three-term product rule,
-  multiplicity-correct `distinct` — and the generic incrementalizer
-  `Q^Δ = D ∘ lift(Q) ∘ I`, in pure Eshkol with zero compiler changes; the
-  first shipped slice of the incremental-dataflow spine (ADR 0009).
-  Acceptance gate 27/27 under JIT and AOT. See *lib/core/dbsp.esk*.
+- **Incremental dataflow (`core.dbsp`).** Z-sets (weighted multisets) as a
+  commutative group, the `z^-1`/`D`/`I` stream operators (D and I mutual
+  inverses), incremental relational operators — linear map/filter/project/union,
+  join via the discrete three-term product rule, multiplicity-correct `distinct`
+  — and the generic incrementalizer `Q^Δ = D ∘ lift(Q) ∘ I`, in pure Eshkol with
+  zero compiler changes; the first shipped slice of the incremental-dataflow
+  spine (ADR 0009). Acceptance gate 27/27 under JIT and AOT, wired into the
+  per-pull-request gate set as of v1.3.5-evolve. See *lib/core/dbsp.esk*.
 
-- **Compiler-integrated automatic differentiation (order ≤ 2).** Three modes: symbolic AST
-  rewriting at compile time using twelve differentiation rules; forward mode through
-  16-byte dual numbers `{value, derivative}`; reverse mode through a computational
-  graph spanning more than twenty AD node types with a 32-level tape stack for
-  nested gradients. Eight vector-calculus operators — `derivative`, `gradient`,
-  `jacobian`, `hessian`, `divergence`, `curl`, `laplacian`,
-  `directional-derivative` — are language primitives. As of v1.3.3-evolve,
-  custom-VJP tape nodes (`AD_NODE_CUSTOM`) carry an externally supplied
-  vector-Jacobian product, so a foreign computation with a known adjoint
-  participates exactly in reverse-mode AD (first user: Moonlab's VQE
-  gradient), and the per-component gradient replay is collapsed into one
-  primal plus one reverse pass reading every input gradient from the tape
-  (verified: N primal calls become 1, checked at N=4 and N=64), with new
-  `(ad-counters)` introspection exposing primal-call/reverse-pass/tape
-  counters. See *lib/backend/autodiff_codegen.cpp*
-  (≈12,600 lines) and *docs/DESIGN.md §Automatic Differentiation*.
-
-- **100% R7RS conformance on the portable differential corpus.** A reference-Scheme
-  oracle runs the same 34-program portable R7RS-small corpus on Eshkol and on
-  chibi-scheme 0.12.0 and diffs the output: 34 of 34 AGREE (100%), up from 27/34 at the
-  start of the v1.3.0-evolve cycle. Separately, Eshkol implements roughly 95% of the
-  broader R7RS-small procedure surface (232 of 244 procedures) — full numeric tower,
-  continuations, exceptions, promises, `eval`, records, bytevectors, hygienic macros.
-  See *scripts/run_reference_differential.sh* and *tests/reference-diff/corpus/*.
+- **100% R7RS conformance on the portable differential corpus.** A
+  reference-Scheme oracle runs the same 34-program portable R7RS-small corpus on
+  Eshkol and on chibi-scheme 0.12.0 and diffs the output: 34 of 34 AGREE (100%).
+  Separately, Eshkol implements roughly 95% of the broader R7RS-small procedure
+  surface (232 of 244 procedures) — full numeric tower, continuations,
+  exceptions, promises, `eval`, records, bytevectors, hygienic macros. As of
+  v1.3.5-evolve the reader accepts the third R7RS `<identifier>` production,
+  vertical-line symbol syntax (`'|weird sym|`), across all four readers — the
+  native tokenizer, the VM tokenizer, and both runtime `read` implementations —
+  including the mnemonic escapes, `\|`, and `\x<hex>;`, with `write` emitting
+  bars only when a name cannot be spelled bare and `display` never barring; and
+  `gensym` is reachable identically on native JIT, native AOT, and the VM.
+  See *scripts/run_reference_differential.sh*, *tests/reference-diff/corpus/*,
+  *tests/features/pipe_symbol_test.esk*, and
+  *tests/control_flow/gensym_test.esk*.
 
 - **Full R7RS numeric tower.** int64, arbitrary-precision bignum (with automatic
-  overflow promotion and demotion), exact rational with GCD reduction, IEEE 754 double,
-  and complex numbers with Smith's-formula division. Exactness tracked via a flags
-  byte on each 16-byte tagged value. As of v1.3.3-evolve exact rationals are
+  overflow promotion and demotion), exact rational with GCD reduction, IEEE 754
+  double, and complex numbers with Smith's-formula division. Exactness tracked
+  via a flags byte on each 16-byte tagged value. Exact rationals are
   bignum-capable: a canonical discriminated union with a zero-allocation int64
   fast path and a bignum numerator/denominator path taken only on overflow, so
-  exact fractions no longer degrade to double at bignum magnitudes — verified
-  byte-identical against Python `Fraction`. See *lib/backend/arithmetic_codegen.cpp* and
-  *inc/eshkol/eshkol.h §Heap subtypes*.
+  exact fractions hold their exactness at bignum magnitudes — verified
+  byte-identical against Python `Fraction`. See
+  *lib/backend/arithmetic_codegen.cpp* and *inc/eshkol/eshkol.h §Heap subtypes*.
 
-- **Flat memory for resident and daemon workloads.** Self-tail-recursive loops — both
-  named-let and plain `define`, including a catch-all guard body — get automatic,
-  zero-annotation per-iteration arena-scope reclamation, verified to hold RSS flat
-  (1,369 MB unbounded growth to 224 MB flat on a 1,000,000-iteration test loop).
-  The AOT gate for the plain-`define` case
-  (*tests/memory/define_loop_flat_rss_aot_test.sh*, ESH-0214b) was re-run this
-  cycle: 8 MB peak RSS with the fix on vs. 2,620 MB with it compiled out
-  (`ESHKOL_NO_ITER_SCOPE=1`), same 1,000,000-iteration program. The
-  S-expression reader was rewritten from per-element native recursion to an iterative
-  loop, so reading back a very large persisted data structure no longer risks a
-  native-stack overflow (verified clean at 20 million elements, where the prior
-  implementation crashed with SIGBUS). See *lib/backend/llvm_codegen.cpp* and
-  *lib/core/runtime_reader_hosted.cpp*.
+- **Flat memory for resident and daemon workloads.** Self-tail-recursive loops —
+  both named-let and plain `define`, including a catch-all guard body — get
+  automatic, zero-annotation per-iteration arena-scope reclamation. The AOT gate
+  for the plain-`define` case
+  (*tests/memory/define_loop_flat_rss_aot_test.sh*) measures 8 MB peak RSS with
+  the reclamation compiled in, against 2,620 MB with it compiled out, on the
+  same 1,000,000-iteration program. As of v1.3.5-evolve an exception guard
+  entered once per tick costs nothing in steady state: handler frames come from
+  a thread-local LIFO free list, so total frame memory is bounded by peak nesting
+  depth rather than by entry count. A resident-longrun gate measures at 200,000
+  and at 1,600,000 ticks — eight times apart — and gates on the slope rather than
+  on a ceiling: transient garbage and all four persistent-mutation channels come
+  back at exactly 0.000 bytes per tick, with identical byte totals at both
+  horizons, so what a resident loop retains is what it publishes and nothing
+  else.
+  <!-- source: docs/reference/runtime/memory-model.md:308-313; tests/memory/resident_longrun_flat_gate.sh:77-79 -->
+  `ESHKOL_ARENA_REPORT=1` prints the global arena's byte-exact allocation total
+  at exit, since peak RSS is a high-water mark that reads low under memory
+  pressure. See *lib/backend/llvm_codegen.cpp*,
+  *tests/memory/resident_longrun_flat_gate.sh*, and
+  [docs/reference/runtime/memory-model.md](../docs/reference/runtime/memory-model.md).
 
-- **Region-escape evacuator closes out across every heap subtype (ESH-0214a-e,
-  complete as of v1.3.3-evolve).** A value allocated inside `with-region` that escapes
-  the region — is returned, stored outward, or captured by a closure — is deep-walked
-  and promoted into the surviving arena instead of being left dangling after the region
-  pops. Coverage was built out subtype by subtype: cons/vector/hash/tensor/exception/
-  closure first, then the logic and global-workspace subtypes (substitution, fact,
-  knowledge base, factor graph, workspace) in v1.3.2-evolve, and `PROMISE` — a
-  `delay`/`make-promise` thunk plus its cached value — in v1.3.3-evolve, completing
-  the series. `ESHKOL_ARENA_POISON=1` poisons freed arena memory so any remaining gap
-  crashes loudly instead of corrupting silently.
+- **Region-escape evacuation across every heap subtype.** A value allocated
+  inside `with-region` that escapes the region — is returned, stored outward, or
+  captured by a closure — is deep-walked and promoted into the surviving arena
+  instead of being left dangling after the region pops. Every `HEAP_SUBTYPE_*`
+  member carries an explicit deep-walk or leaf tag with its reasoning, including
+  the exact `COEFF_RATIONAL` Taylor tower, whose coefficient array is walked
+  because an overflowing coefficient is a pointer to an independently
+  arena-allocated bignum; the architecture-model invariant that checks this is
+  derived from the source rather than from a hand-typed list, resolved through a
+  libclang semantic index of the real case arms. `ESHKOL_ARENA_POISON=1` poisons
+  freed arena memory so any remaining gap crashes loudly instead of corrupting
+  silently. See *lib/core/runtime_regions.cpp* and
+  *tests/memory/region_evac_taylor_exact_test.esk*.
+
+- **Node identity in the frontend (ADR-0000 Stage 1, phase A).** Every AST node
+  the parser produces carries a stable `NodeId`, and a side table maps that id to
+  a `SourceSpan` — the first column of the
+  `NodeId -> {SourceSpan, BindingId, TypedExprInfo}` substrate the compiler, the
+  LSP, the docs, the REPL, and the VM all have to share if they are to give one
+  answer rather than five. The parser's 32 location-stamping sites write the
+  location and the identity in one statement so the two cannot drift, and the
+  stream reader closes each top-level form's span with a measured *extent* — the
+  first place in the frontend that records where a construct ends rather than
+  only where it begins. `NodeId`s are tagged rather than bare indices, so a
+  garbage word reads as "unknown": a diagnostic may fail to name a location, but
+  it must never name a wrong one confidently. The LLVM codegen dispatcher is the
+  first consumer, resolving the file, line, and column it reports through the
+  substrate, so a node's file does not depend on the traversal that reached it.
+  Coverage is measured at the consumer rather than at the parser, with "has an
+  identity", "has a location", and "has an extent" kept as three separate
+  numbers, graded against a monotonic span-coverage floor of 99.48% written
+  truncated rather than rounded so it cannot drift upward by accident.
+  <!-- source: tests/coverage/NODE_IDENTITY_BASELINE.json (span_coverage_floor 0.9948) --> See *inc/eshkol/frontend/node_identity.h*,
+  *scripts/run_node_identity_gate.py*, and
+  *tests/coverage/NODE_IDENTITY_BASELINE.json*.
+
+- **An object ABI that cannot be mixed by accident (ADR-0012, stage 0).** A
+  three-layer inventory — lexical token matching, libclang semantic resolution,
+  and emitted-LLVM-IR ground truth — enumerates 1,273 sites that depend on the
+  current object-header layout, ratcheted against a committed baseline so a new
+  site fails the build.
+  <!-- source: docs/design/adr/0012-object-abi-staged-migration.md:100-102; ratchet baseline .icc/abi-header-baseline.json --> A
+  link-time guard whose symbol name is derived from the four numbers that
+  determine object-exchange compatibility means a stale object file, JIT cache
+  entry, installed runtime, or `--shared-lib` artifact fails to *link*, with an
+  undefined-symbol error naming the layout it wanted. A layout-pin test pins the
+  header's size and every field's offset both through the accessor and as raw
+  bytes at the negative offsets generated code actually uses.
+  See *scripts/abi_header_inventory.py*, *inc/eshkol/abi_fingerprint.h*, and
+  *tests/core/abi_layout_pin_test.cpp*.
+
+- **A packaged link contract a downstream project can rely on.**
+  `cmake/FindEshkol.cmake` ships as the one canonical discovery module:
+  `find_package(Eshkol)` resolves the compiler, the runtime archive a compiled
+  program actually needs, and the stdlib object and module directory, producing
+  an `Eshkol::eshkol` imported target whose link interface unconditionally
+  includes `stdlib.o` plus, on Apple, the system frameworks the runtime needs —
+  with no hand-written library search in the consumer at all. The homebrew
+  formula and both release-asset steps install the module and
+  `EshkolCompile.cmake`, and a from-scratch consumer CMake project under
+  *tests/integration/system_package/* is run against a staged package by the
+  package manifest, so what is checked is that the discovery contract works and
+  not merely that its files landed. Scoped to macOS and Linux.
+  See *cmake/FindEshkol.cmake* and
+  *scripts/run_system_package_integration_test.sh*.
 
 - **Neuro-symbolic stack as compiler primitives.** Twenty-two builtins:
   `unify`, `walk`, `make-substitution`, `make-fact`, `make-kb`, `kb-assert!`,
   `kb-query`, `logic-var?`, `substitution?`, `kb?`, `fact?`,
   `make-factor-graph`, `fg-add-factor!`, `fg-infer!`, `fg-update-cpt!`,
-  `free-energy`, `expected-free-energy`, `factor-graph?`,
-  `make-workspace`, `ws-register!`, `ws-step!`, `workspace?`.
-  Runtime implementations: *lib/core/logic.cpp* (≈1,180 lines), *lib/core/inference.cpp*
-  (≈1,200 lines), *lib/core/workspace.cpp* (354 lines), lineage Robinson 1965 / Friston 2010 /
-  Baars 1988.
+  `free-energy`, `expected-free-energy`, `factor-graph?`, `make-workspace`,
+  `ws-register!`, `ws-step!`, `workspace?`. Runtime implementations:
+  *lib/core/logic.cpp*, *lib/core/inference.cpp*, *lib/core/workspace.cpp*;
+  lineage Robinson 1965 / Friston 2010 / Baars 1988.
 
-- **Deterministic arena memory (OALR).** Single global arena with 8 KB minimum blocks,
-  O(1) bump-pointer allocation, batch reset, 8-byte headers prepended to every heap
-  object. Per-thread arenas (1 MB, lazily allocated) isolate parallel workers.
-  See *lib/core/arena_memory.h* and the *lib/core/runtime_arena_\*.cpp* modules, and *docs/breakdown/PARALLEL_COMPUTING.md §2.1*.
+- **Deterministic arena memory (OALR).** Single global arena with 8 KB minimum
+  blocks, O(1) bump-pointer allocation, batch reset, 8-byte headers prepended to
+  every heap object. Per-thread arenas (1 MB, lazily allocated) isolate parallel
+  workers. See *lib/core/arena_memory.h*, the *lib/core/runtime_arena_\*.cpp*
+  modules, and *docs/breakdown/PARALLEL_COMPUTING.md §2.1*.
 
-- **Work-stealing parallelism.** Chase-Lev deques per worker (Chase and Lev, 2005)
-  with epoch-based reclamation. Measured 4–12× speed-up of `parallel-map` on 24 cores
-  per *docs/breakdown/ROADMAP.md §1.1-accelerate completed*. Primitives:
-  `parallel-map`, `parallel-fold`, `parallel-filter`, `parallel-for-each`,
-  `future` / `force`.
+- **Work-stealing parallelism.** Chase-Lev deques per worker (Chase and Lev,
+  2005) with epoch-based reclamation. Measured 4–12× speed-up of `parallel-map`
+  on 24 cores per *docs/breakdown/ROADMAP.md §1.1-accelerate completed*.
+  Primitives: `parallel-map`, `parallel-fold`, `parallel-filter`,
+  `parallel-for-each`, `future` / `force`.
 
-- **GPU acceleration with cost-model dispatch.** SIMD micro-kernels for small tensors,
-  Apple Accelerate cBLAS at the AMX peak (≈1,100 GFLOPS measured), Metal with double-
-  double SF64 emulation for native float64 absence, and a CUDA path through cuBLAS.
-  Backend chosen per operation by *lib/backend/blas_backend.cpp*, configurable via
+- **GPU acceleration with cost-model dispatch, and a correctness gate that can
+  fail.** SIMD micro-kernels for small tensors, Apple Accelerate cBLAS at the AMX
+  peak (≈1,100 GFLOPS measured), Metal with double-double SF64 emulation for
+  native float64 absence, and a CUDA path through cuBLAS. Backend chosen per
+  operation by *lib/backend/blas_backend.cpp*, configurable via
   `ESHKOL_GPU_PRECISION`, `ESHKOL_BLAS_PEAK_GFLOPS`, `ESHKOL_GPU_PEAK_GFLOPS`.
-  The Ozaki-II CRT exact-GEMM certification gate
-  (*tests/gpu/ozaki_certification_test.esk*) was re-run this cycle on Metal
-  (Apple M2 Ultra): 16 CRT moduli, 0 mismatches across 25 samples, max 58
-  correct dot-product bits, verdict PASS — floating-point GEMM certified
-  bit-exact against the integer reference, not merely close.
+  As of v1.3.5-evolve every `tests/gpu/*.esk` file aggregates a failure counter
+  and exits nonzero on a `FAIL:` verdict, the test isolation layer fails a test
+  that exits 0 without printing a recognized verdict marker, and a permanent,
+  deliberately-failing canary (*tests/gpu/gate_canary_must_fail.esk*) runs on
+  every invocation and is required to fail — if the canary ever goes green the
+  whole run goes red. On the strength of a measured Metal-versus-CPU divergence
+  of exactly 0 across ten probes, the gate tolerance tightens from `1e-4` to
+  `1e-9`. The Ozaki-II CRT exact-GEMM certification gate
+  (*tests/gpu/ozaki_certification_test.esk*) was measured on Metal (Apple M2
+  Ultra) at 25/25 samples, 0 mismatches, max 58 correct dot-product bits,
+  verdict PASS — floating-point GEMM certified bit-exact against the integer
+  reference, not merely close.
 
 - **A molecular Hessian from a compiled Scheme's own AD, no finite
   differences.** *examples/h2_vibrational.esk* writes the STO-3G H2
-  Born-Oppenheimer energy curve as ordinary Eshkol code and differentiates
-  it to exact second order with `derivative-n`. Re-run this cycle:
-  equilibrium R* = 1.3887 bohr, E(R*) = -1.1373 Ha, force constant
-  d²E/dR² = 0.4771 Ha/bohr², vibrational frequency = **5003.2 cm⁻¹**
-  (experimental H2 ≈ 4401 cm⁻¹; the gap is the STO-3G basis, not the AD —
-  the second derivative itself is exact).
+  Born-Oppenheimer energy curve as ordinary Eshkol code and differentiates it to
+  exact second order with `derivative-n`: equilibrium R* = 1.3887 bohr,
+  E(R*) = -1.1373 Ha, force constant d²E/dR² = 0.4771 Ha/bohr², vibrational
+  frequency **5003.2 cm⁻¹** (experimental H2 ≈ 4401 cm⁻¹; the gap is the STO-3G
+  basis, not the AD — the second derivative itself is exact).
 
-- **Native agent FFI.** libcurl-backed HTTP client (*lib/agent/c/agent_http_client.c*),
-  sqlite3 (*lib/agent/c/agent_sqlite.c*), `posix_spawn` subprocess execution with
-  argv arrays (*lib/agent/c/agent_subprocess.c*; the `popen("sh -c …")` path was
-  removed in v1.2 to eliminate shell-metacharacter exposure), kqueue/inotify
-  filesystem watching (*lib/agent/c/agent_watch.c*).
+- **Native agent FFI.** libcurl-backed HTTP client
+  (*lib/agent/c/agent_http_client.c*), sqlite3 (*lib/agent/c/agent_sqlite.c*),
+  `posix_spawn` subprocess execution with argv arrays
+  (*lib/agent/c/agent_subprocess.c*), kqueue/inotify filesystem watching
+  (*lib/agent/c/agent_watch.c*).
 
-- **Comprehensively documented public API and implementation.** v1.3.1-evolve added
-  Doxygen-format documentation across 50 of the 64 public headers under
-  `inc/eshkol/` and 56 previously-undocumented implementation files
-  under `lib/` — 116 files, comments
-  only; v1.3.2-evolve added `eshkol-doc`, which harvests those comments automatically
-  into a generated `docs/api/` reference. A navigable per-subsystem reference index
-  (*docs/reference/{language,ad,runtime,tensors,stdlib,agent}/INDEX.md*) organizes
-  the language surface for lookup.
+- **Comprehensively documented public API and implementation.** Doxygen-format
+  documentation across 50 of the 64 public headers under `inc/eshkol/` and 56
+  implementation files under `lib/`, harvested automatically into a generated
+  `docs/api/` reference by `eshkol-doc`. A navigable per-subsystem reference
+  index (*docs/reference/{language,ad,runtime,tensors,stdlib,agent}/INDEX.md*)
+  organizes the language surface for lookup. v1.3.5-evolve adds a
+  [Python bindings reference](../docs/reference/bindings/python.md) documenting
+  the `Context.eval`/`derivative`/`gradient` API.
 
-- **Hardened, permanent adversarial-testing program.** A multi-pillar adversarial
-  harness — differential, feature-pair edge matrix, AD finite-difference oracle,
-  stress (RSS/time budgets), VM-parity ratchet, depth-parametric sweeps, and the
-  external reference-Scheme differential oracle — is wired permanently into the ICC
-  release oracle rather than run once and discarded; this is the same infrastructure
-  whose adversarial audit caught the v1.3.2-evolve `input2` overstatement corrected
-  above, and the ICC oracle itself was hardened in v1.3.3-evolve to gate on that
-  correction and on region-evacuator poison coverage. v1.3.3-evolve added two
-  generative exposure engines to the program, both wired permanently into the
-  release oracle: a multi-oracle differential harness (deterministically grown
-  R7RS-subset programs cross-checked against chibi-scheme, JIT, AOT at O0/O2,
-  and the bytecode VM) and an AD-vs-finite-difference adversarial oracle (147
-  probes / 436 component checks across 21 generated files under JIT and AOT; a
-  zero AD gradient where finite differences are nonzero is a hard failure).
-  Release gates green on the v1.3.4-evolve cut: the aggregate suite 45/45
-  suites and 770 individual tests; CTest 183/183, which as of this release is
-  itself completion-oracle evidence rather than advice; executable language
-  coverage 1,091/1,091 (100.0%, floor PASS); SICP full-book gate 88/88 probes
-  across all five chapters under both `-r` and AOT; reference-Scheme
-  differential oracle 34/34 AGREE against chibi-scheme 0.12.0; VM parity
-  differential 184/184 over a 956-row manifest (581 VM-supported, 44 justified
-  native-only, 331 explicit gaps); qLLM oracle gate 10/10; ICC readiness 100,
-  verdict `ready`. See *docs/TESTING.md*.
+- **Hardened, permanent adversarial-testing program.** A multi-pillar
+  adversarial harness — differential, feature-pair edge matrix, AD
+  finite-difference oracle, stress (RSS/time budgets), VM-parity ratchet,
+  depth-parametric sweeps, and the external reference-Scheme differential oracle
+  — is wired permanently into the ICC release oracle rather than run once and
+  discarded. As of v1.3.5-evolve the cheap pillar gates run on every pull
+  request and the expensive sweeps run nightly; every finished trace is mirrored
+  unconditionally into the directory the readiness oracle reads, so
+  `icc readiness` is machine-reachable rather than only runnable by hand. Two
+  assurance waves this cycle add gates that check the assurance itself: ledger
+  integrity and oracle-schema checks, a self-verdict scanner that fails a
+  PASS-graded artifact whose own text reports a failure, build fingerprints that
+  fail a binary predating its most recent build-relevant source change, a
+  PowerShell-encoding gate that reads the files' own bytes because CI running
+  those bytes under a different default encoding could never catch the problem
+  by execution, a false-green audit that fails an oracle target whose evidence
+  can go missing without the target going red, and an adversarial scenario suite
+  that exercises the gates themselves under a dirty worktree, a stale binary, a
+  model-server outage, disk pressure, and an actually failing gate. Every
+  trace-emitting harness now has a shared PASS/FAIL/INFRA/SKIP vocabulary, so an
+  infrastructure timeout cannot publish itself as a code defect. Release gates,
+  remeasured at commit `afbaaf5b` on 2026-08-26: the aggregate suite 45/45
+  suites and 770 individual tests; CTest 198/198; executable language coverage
+  1,108/1,108 (100.0%, floor PASS); SICP full-book gate 88/88 probes across all
+  five chapters under both `-r` and AOT; reference-Scheme differential oracle
+  34/34 AGREE against chibi-scheme 0.12.0; VM parity differential 188/188; qLLM
+  oracle gate 10/10; ICC readiness 100, verdict `ready`.
+  <!-- source: README.md §Testing (remeasured 2026-08-26 at commit afbaaf5b) -->
+  See *docs/TESTING.md*.
 
-- **Binary Lambda Calculus (`core.blc`, v1.3.2-evolve).** A pure-Eshkol
-  implementation of John Tromp's BLC: De Bruijn-indexed terms as homoiconic
-  s-expressions, self-delimiting bit encode/decode, normal-order evaluation, a
-  decoded 232-bit universal machine, BLC8 byte I/O, and ASCII lambda diagrams.
-  Loaded on demand via `(require core.blc)`. See
-  *docs/guide/BINARY_LAMBDA_CALCULUS.md*.
+- **Binary Lambda Calculus (`core.blc`).** A pure-Eshkol implementation of John
+  Tromp's BLC: De Bruijn-indexed terms as homoiconic s-expressions,
+  self-delimiting bit encode/decode, normal-order evaluation, a decoded 232-bit
+  universal machine, BLC8 byte I/O, and ASCII lambda diagrams. Loaded on demand
+  via `(require core.blc)`. See *docs/guide/BINARY_LAMBDA_CALCULUS.md*.
 
 ---
 
 ## Example
 
-The training loop below is verbatim from *README.md §Why Eshkol*. It uses
-the language's `derivative` primitive to fit `y = 2x` from five points.
-Nothing here is a library import or a framework call — `derivative` is in
-the compiler.
+The training loop below is verbatim from *README.md §Why Eshkol*. It uses the
+language's `derivative` primitive to fit `y = 2x` from five points. Nothing here
+is a library import or a framework call — `derivative` is in the compiler.
 
 ```scheme
 (define training-data '((1.0 2.0) (2.0 4.0) (3.0 6.0) (4.0 8.0) (5.0 10.0)))
@@ -325,34 +542,50 @@ rounding at any step:
 (display (exact? (derivative-n g 1/3 1))) ;; => #t
 ```
 
+A continuation captured at top level, saved, and re-invoked until a counter runs
+out — verbatim from *tests/continuations/doc_example_multishot.esk*, whose
+transcript is compared byte-for-byte on native JIT, native AOT, and the bytecode
+VM. `call/cc` captures the control state and not the store, so the `set!`
+survives re-entry and the loop guard advances:
+
+```scheme
+(define k #f)
+(define n 0)
+(display (+ 1 (call/cc (lambda (c) (set! k c) 0))))
+(newline)
+(set! n (+ n 1))
+(if (< n 3) (k n))
+(display "done") (newline)
+;; => 1 / 2 / 3 / done
+```
+<!-- source: tests/continuations/doc_example_multishot.esk, tests/continuations/expected/doc_example_multishot.txt -->
+
+
 ---
 
 ## Dual backend
 
-Re-verified this cycle: `(gradient f 3.0 4.0)` on `f(x,y) = x²y + y³`
-returns the byte-identical `#(24 57)` under the native JIT, native AOT, and
-the bytecode VM (three independent executions, one source file). The
-compiler's own version string on this build is `v1.3.4-evolve`.
+`(gradient f 3.0 4.0)` on `f(x,y) = x²y + y³` returns the byte-identical
+`#(24 57)` under the native JIT, the native AOT path, and the bytecode VM —
+three independent executions of one source file.
 
-Eshkol ships two production execution backends with the same language
-semantics and independent value representations. The LLVM backend compiles
-to native ARM64 or x86-64 (or WebAssembly) and is the default for
-`eshkol-run`. The bytecode VM (*lib/backend/eshkol_vm.c* plus its 32 *vm_\*.c*
-modules) is a 63-opcode register-plus-stack interpreter with more than 250
-native call IDs, an ESKB binary file format with LEB128 encoding and CRC32
-checksums, and full coverage of the language including continuations,
-exception handling, tensors, complex / rational / bignum, the consciousness
-engine, and I/O. The browser REPL runs the bytecode VM (compiled to
-WebAssembly via Emscripten); forward-mode AD via dual numbers works through
-the same arithmetic opcodes. A v1.3.3-evolve parity campaign, driven by a
-generative multi-oracle differential harness cross-checking chibi-scheme,
-JIT, AOT at O0/O2, and the VM, closed several silent-miscompile classes —
-including real bignum-aware VM arithmetic and comparisons.
+Eshkol ships two production execution backends with the same language semantics
+and independent value representations. The LLVM backend compiles to native ARM64
+or x86-64 (or WebAssembly) and is the default for `eshkol-run`. The bytecode VM
+(*lib/backend/eshkol_vm.c* plus its 32 *vm_\*.c* modules) is a register-plus-stack
+interpreter with more than 250 native call IDs, an ESKB binary file format with
+LEB128 encoding and CRC32 checksums, and full coverage of the language including
+multi-shot continuations, exception handling, tensors, complex / rational /
+bignum, the consciousness engine, and I/O. As of v1.3.5-evolve the VM reclaims
+region memory, and `with-region`'s teardown is reached identically by lexical
+exit, by a `raise` crossing the region, and by a continuation transfer out of it,
+so the structured and unstructured surfaces cannot drift apart. The browser REPL
+runs the bytecode VM compiled to WebAssembly via Emscripten; forward-mode AD via
+dual numbers works through the same arithmetic opcodes.
 
-The weight-matrix transformer artefact (*lib/backend/weight_matrices.c*,
-≈7,500 lines) is the third execution surface — the one that proves the
-SDNC theorem by being a transformer that runs the same VM through its
-forward and backward passes.
+The weight-matrix transformer artefact (*lib/backend/weight_matrices.c*) is the
+third execution surface — the one that proves the SDNC theorem by being a
+transformer that runs the same VM through its forward and backward passes.
 
 ---
 
@@ -364,8 +597,8 @@ hard version-enforced in *cmake/LLVMToolchain.cmake*); Robinson's resolution
 principle, 1965; Friston's free-energy principle, 2010; Baars' global workspace
 theory, 1988; Chase and Lev, *Dynamic Circular Work-Stealing Deque*, 2005.
 
-The SDNC paper provides the constructive proof that ties the language's
-gradient infrastructure to the transformer artefact — *docs/SDNC.md* and
+The SDNC paper provides the constructive proof that ties the language's gradient
+infrastructure to the transformer artefact — *docs/SDNC.md* and
 *docs/breakdown/COMPUTABLE_TRANSFORMER.md*.
 
 ---
@@ -380,12 +613,31 @@ scripts/paper/run_paper_suite.sh
 
 Outputs land under `artifacts/paper/outputs/` with stable SHA-256 hashes printed
 by the harness. A current successful run produces, among others,
-`weights.qlmw = 381599e7…3f0c`, `vm-traces.jsonl = 4239cbb9…4801` (the transformer
-trace agrees bitwise: same SHA), and `comparison-report.json = 80aa6fed…4105`.
-Platform divergence is treated as a bug.
+`weights.qlmw = 381599e7…3f0c`, `vm-traces.jsonl = 4239cbb9…4801` (the
+transformer trace agrees bitwise: same SHA), and
+`comparison-report.json = 80aa6fed…4105`. Platform divergence is treated as a
+bug.
 
-The compiler itself is bit-reproducible at link time: two back-to-back
-release builds produce byte-identical `build/stdlib.bc` and `build/eshkol-run`
+As of v1.3.5-evolve the performance claims reproduce in one command too:
+
+```bash
+bench/run_public_benchmarks.sh
+```
+
+From a clean checkout it measures the four axes on which Eshkol claims something
+distinctive — exact-AD cost curves, Ozaki-II CRT exact f64 GEMM, flat RSS under
+resident load, and differentiable quantum kernels — and emits machine-readable
+JSON alongside a human-readable table,
+<!-- source: bench/run_public_benchmarks.sh:107-110 --> with the noise-control
+methodology and an explicit not-benchmarked list documented in *bench/README.md*.
+It is not a competition entry against XLA, PyTorch, or JAX. A companion
+compile-time benchmark generates a deterministic large single-file fixture (1,600
+top-level defines) and runs it against a 900-second ceiling nightly, capturing a
+phase-time breakdown that attributes about 98% of the wall clock to LLVM's own
+backend.
+
+The compiler itself is bit-reproducible at link time: two back-to-back release
+builds produce byte-identical `build/stdlib.bc` and `build/eshkol-run`
 (*docs/HARDENING.md §`#184`*).
 
 ---
@@ -395,8 +647,8 @@ release builds produce byte-identical `build/stdlib.bc` and `build/eshkol-run`
 | | |
 |:---|:---|
 | Project | Eshkol |
-| Version | v1.3.4-evolve |
-| Release date | 31 July 2026 (builds on v1.3.3-evolve, 16 July 2026; v1.3.2-evolve, 9 July 2026; v1.3.1-evolve and v1.3.0-evolve, 7 July 2026) |
+| Version | v1.3.5-evolve |
+| Release date | 28 August 2026 (builds on v1.3.4-evolve, 31 July 2026; v1.3.3-evolve, 16 July 2026; v1.3.2-evolve, 9 July 2026; v1.3.1-evolve and v1.3.0-evolve, 7 July 2026) |
 | Implementation | C17 runtime, C++20 compiler |
 | Backend | LLVM 21 (version-enforced) |
 | Platforms | macOS Intel and Apple Silicon, Linux x86-64 and ARM64, Windows x86-64 and ARM64 via Visual Studio 2022 + ClangCL |

--- a/press/ESHKOL_PRESS_INFORMATION_SHEET.md
+++ b/press/ESHKOL_PRESS_INFORMATION_SHEET.md
@@ -1,13 +1,13 @@
-# Eshkol v1.3.4-evolve — Press Information Sheet
+# Eshkol v1.3.5-evolve — Press Information Sheet
 
 For trade-press and academic readers preparing coverage of the v1.3 release
 line — arbitrary-order automatic differentiation, full R7RS conformance,
 resident/daemon-workload robustness, opt-in differentiable quantum computing
-with post-quantum cryptography, and, as of v1.3.4-evolve, automatic
-per-iteration memory reclamation that matches explicit regions, race-free
-`parallel-map`, exact gradients through every callable form, shortest-round-trip
-float printing, and a high-precision numerics wave — and the SDNC paper artefact
-it carries.
+with post-quantum cryptography, and, as of v1.3.5-evolve, multi-shot re-entrant
+continuations on every engine, region reclamation on the bytecode VM, constant
+stack space for mutual tail recursion in every tail-position spelling, and
+differentiation dispatch the compiler proves exhaustive — and the SDNC paper
+artefact it carries.
 
 ---
 
@@ -16,9 +16,9 @@ it carries.
 | | |
 |:---|:---|
 | Project | Eshkol |
-| Version | v1.3.4-evolve |
-| Builds on | v1.3.3-evolve (16 July 2026), v1.3.2-evolve (9 July 2026), v1.3.1-evolve, v1.3.0-evolve (7 July 2026) |
-| Release date | 31 July 2026 |
+| Version | v1.3.5-evolve |
+| Builds on | v1.3.4-evolve (31 July 2026), v1.3.3-evolve (16 July 2026), v1.3.2-evolve (9 July 2026), v1.3.1-evolve, v1.3.0-evolve (7 July 2026) |
+| Release date | 28 August 2026 |
 | Licence | MIT |
 | Source | https://github.com/tsotchke/eshkol |
 | Website | https://eshkol.ai |
@@ -29,6 +29,16 @@ it carries.
 
 ## Headline
 
+In v1.3.5-evolve you can call a procedure that has already returned. That is
+not a metaphor. `call/cc` is multi-shot and re-entrant on all three engines
+Eshkol ships — native JIT, native AOT, and the bytecode VM — because a capture
+that may outlive its frame takes a durable copy of the live C stack and restores
+it to the same addresses before resuming, so every frame pointer, every spilled
+register, and every address of a local that a closure is holding stays valid
+with no relocation. Six programs, three engines, eighteen byte-exact
+transcripts.
+<!-- source: tests/continuations/ (6 fixtures), scripts/run_continuation_tests.sh (each fixture on -r, AOT and VM against tests/continuations/expected) -->
+
 A six-layer transformer with 12.22 million analytically-constructed parameters
 executes a bounded 83-opcode bytecode VM bit-identically. The result is a
 constructive — not statistical — proof that a fixed-weight transformer can
@@ -38,30 +48,40 @@ artefact, including the weight tensor, traces, and a three-way agreement
 report, ships in the same repository as the compiler that hosts it, and
 regenerates in one command on a developer laptop.
 
-The host language has moved in this release line too: v1.3.0-evolve gave
-Eshkol's automatic differentiation a second axis, arbitrary order, with
-exact bignum/rational derivatives and full R7RS conformance on a portable
-differential corpus; v1.3.1-evolve added the robustness — flat memory in
-long-running loops, a reader that doesn't overflow the stack on large
-persisted state — that makes an Eshkol program safe to run unattended as a
-daemon, plus a comprehensive documentation pass across the public embedding
-API. v1.3.2-evolve extended that memory-safety work to the logic/workspace
-heap subtypes and made region scoping thread-safe under `parallel-map`.
-v1.3.3-evolve is the largest step in the line: an opt-in quantum computing
-stack — Moonlab state-vector simulation, a variational quantum eigensolver
-whose gradients flow through Eshkol's own automatic differentiation via new
-custom-VJP tape nodes, a CHSH Bell-inequality gate, Bell-verified quantum
-randomness, and ML-KEM (FIPS 203) post-quantum cryptography — alongside real
-`make-parameter`/`parameterize` dynamic parameters, the `core.dbsp`
-incremental-dataflow module, bignum-capable exact rationals, and one-pass
-reverse-mode gradients. The same release ran a silent-wrong-answer
-correctness campaign driven by two new generative exposure engines, closing
-several bytecode-VM silent-miscompile classes, tail-call gaps in six special
-forms, and a 26x `--wasm` size regression; it also closes out the
-region-evacuator series with the last heap subtype, `PROMISE`, and replaces
-an overstated v1.3.2-evolve automatic-differentiation claim with the real
-fix: exact gradients through the `input2` path for first-class losses and
-vector/learnable gamma.
+The host language has moved through this release line: v1.3.0-evolve gave
+Eshkol's automatic differentiation a second axis, arbitrary order, with exact
+bignum/rational derivatives and full R7RS conformance on a portable differential
+corpus; v1.3.1-evolve and v1.3.2-evolve made an Eshkol program safe to run
+unattended as a daemon, with flat memory in long-running loops, an iterative
+reader for large persisted state, region-escape evacuation across the
+logic/workspace heap subtypes, and thread-safe region scoping under
+`parallel-map`. v1.3.3-evolve added the opt-in quantum computing stack — Moonlab
+state-vector simulation, a variational quantum eigensolver whose gradients flow
+through Eshkol's own automatic differentiation via custom-VJP tape nodes, a CHSH
+Bell-inequality gate, Bell-verified quantum randomness, and ML-KEM (FIPS 203)
+post-quantum cryptography — alongside real `make-parameter`/`parameterize`
+dynamic parameters, the `core.dbsp` incremental-dataflow module, bignum-capable
+exact rationals, and one-pass reverse-mode gradients. v1.3.4-evolve made
+automatic per-iteration reclamation match explicit regions, made `parallel-map`
+race-free for collection-valued closures, gave `gradient` full parity on the
+bytecode VM, and landed the high-precision numerics wave: Ozaki-II exact and
+reduced-precision GEMM tiers, a mixed-precision `linear-solve`, and a native
+128-bit integer type.
+
+v1.3.5-evolve is the re-entrant-continuations release. `call/cc` becomes
+multi-shot on every engine; a continuation captured inside `with-region` stays
+safe to resume after that region has closed; the bytecode VM gains its own
+region evacuator, so `with-region` reclaims memory there the way it already did
+natively; mutual tail recursion runs in constant stack space through every
+tail-position spelling rather than only `if`; cloning a linear `Qubit` is a
+rejected compile in the default build; and differentiation dispatch is closed by
+construction, with the AD node registry generated from a single declaration file
+that has no `default:` arm and exhaustiveness enforced by the compiler itself.
+Alongside those, the release starts the object-ABI migration, ships a canonical
+`find_package(Eshkol)` link contract, publishes a one-command reproducible
+benchmark suite on Eshkol's own axes, and lays the first column of the
+frontend node-identity substrate that the compiler, the LSP, the docs, the REPL,
+and the VM will share.
 
 ---
 
@@ -93,64 +113,361 @@ artefact directory is
 
 ---
 
-## What is new in v1.3.4-evolve
+## What is new in v1.3.5-evolve
 
-A resident-correctness release. Every defect below is fixed at the
-architectural root and pinned by an executable gate.
+A re-entrant-continuations release, and the release in which the bytecode VM
+starts giving memory back. Every capability below is pinned by an executable
+gate.
 
-- **Automatic memory reclamation matches explicit regions.** A resident
-  tick/daemon loop that mutates persistent state on every iteration used to get
-  no per-iteration reclamation and leaked one iteration's transient garbage
-  forever (about 3,366 bytes per tick; roughly 355 MB over 100,000 ticks). Such
-  a loop is now lowered with a per-loop nursery whose write barriers promote
-  escapees and whose tail-call back edge resets the nursery, so the loop is flat
-  at 34 MB — byte-for-byte identical to its explicit `with-region` twin. This
-  closes the ESH-0214 memory-management series; `with-region` is no longer
-  required to get flat RSS in a resident loop.
-- **Race-free `parallel-map`.** A closure mapped in parallel whose body used
-  per-iteration scope reclamation could corrupt collection-valued results past
-  the parallel threshold; scope reclamation now degrades to commit-only on pool
-  workers sharing the thread-safe arena, so results are identical to serial
-  `map` (ThreadSanitizer: zero arena data races).
-- **Exact gradients through every callable form.** `(gradient f point)` reached
-  through a wrapper and the curried `((gradient f) point)` are now byte-identical
-  to the direct call; there is no finite-difference fallback anywhere in the
-  gradient path.
-- **Shortest-round-trip float printing (R7RS 6.2.6)**, byte-identical on the
-  native and VM backends.
-- **Strict-mode types that accept idiomatic code**: a checked `(the <type>
-  expr)` ascription (runtime no-op), predicate-guarded narrowing over eight
-  predicates (`if`/`and`, cancelled at `set!`), sum-type annotations honored on
-  named-let parameters, a numeric-tower join for recursive accumulators, and a
-  linear `Qubit` type with use-exactly-once enforcement.
-- **High-precision numerics**: Ozaki-II exact and reduced-precision GEMM tiers
-  (CUDA INT8 and Metal fast tier, both opt-in), a mixed-precision `linear-solve`
-  with a certified full-f64 residual, and a native 128-bit integer type `i128`.
-- **Quantum and VM parity**: Moonlab pinned to v1.2.0 (quantum geometric tensor
-  / quantum natural gradient, smooth first-principles H2/LiH potential-energy
-  surface), and complete hosted-VM tensor-matmul parity.
+**Continuations**
 
-### Independently re-verified for the v1.3.5 documentation wave (2026-08-24)
+- **Multi-shot, re-entrant `call/cc` on native JIT, native AOT, and the
+  bytecode VM.** A captured continuation can be invoked any number of times,
+  from any dynamic extent, including after the procedure that captured it has
+  already returned — the shape generators, coroutines, and `amb`-style
+  backtracking search all need. Native gives a capture that may outlive its
+  frame a durable copy of the live C stack, restored to the same addresses
+  before resuming, so every interior pointer stays valid with no relocation; an
+  escape-only capture keeps the original zero-overhead `setjmp`/`longjmp` path.
+  The VM snapshots its operand stack and call-frame array while excluding
+  top-level bindings — the *store* — from the *control* snapshot R7RS asks
+  `call/cc` to capture, so `set!` and `define` effects at top level survive
+  re-entry. `dynamic-wind` reroots on both engines per R7RS 6.10.
+- **A continuation captured inside `with-region` is safe to resume.** Both
+  engines pin every open region at capture time and promote a pinned region into
+  its parent on pop rather than freeing it, so the failure direction is a
+  bounded leak and never a dangling read. Pinning triggers only on an actual
+  capture: a program that never calls `call/cc` shows zero behaviour change,
+  confirmed by the unchanged flat-RSS gates.
 
-Every number below was produced by an execution against this v1.3.4-evolve
-build (commit `694c3179`) during this documentation pass, not carried over
-from an earlier release note:
+**Memory**
 
-| Claim | Command | Result |
+- **`with-region` reclaims on the bytecode VM.** A Stage-1 OALR region evacuator
+  ports region reclamation to the VM heap. The port matches the native engine's
+  semantics rather than its implementation: native copies the escaping subgraph
+  Cheney-style, while the VM marks from its root set and sweeps at arena-block
+  granularity, because a VM value addresses the heap by a small integer index
+  rather than by pointer — marking moves nothing, so `eq?` identity, shared
+  structure, and cycles survive with no special handling. Coverage is total by
+  construction: a compile-time-checked 33-wide table classifies the full heap
+  tag space (the 28 `HeapType` members, the three manifold tags defined outside
+  the enum, and the two unassigned slots), a fatal startup check requires every
+  row to be filled in, and an unclassified subtype pins its region rather than
+  guessing. A `raise` crossing a region and a continuation transfer out of one
+  go through the same teardown call as normal exit, so the structured and
+  unstructured surfaces cannot drift apart.
+- **The scope of Stage 1, stated exactly.** Outside a region the VM's heap
+  growth watchdog remains the bound, and the same allocation volume that trips
+  the budget unwrapped does not trip it wrapped. The user-reachable region
+  *handle* surface (`region-open`/`region-close`) stays bookkeeping-only on the
+  VM and announces that at the point of use — a handle can be closed out of
+  order, from another dynamic extent, or never, whereas `with-region`'s lexical
+  extent tells the teardown where the region ends, which is why the lexical form
+  landed first; the handle surface is Stage 2. An escaping object with an
+  out-of-line payload (a vector's element array, a bignum's limbs) keeps the
+  arena block that payload occupies, while escaping cons and closure structure
+  is copied out exactly, so a cons-only loop is perfectly flat and a
+  payload-heavy one is much smaller. Objects promoted out of a region live in
+  the enclosing arena for its lifetime, which is OALR's semantics and equally
+  true natively.
+- **Five new runtime variables** — `ESHKOL_VM_REGION_EVAC`,
+  `ESHKOL_VM_REGION_VERIFY`, `ESHKOL_VM_REGION_VERIFY_FATAL`,
+  `ESHKOL_VM_REGION_COMPACT`, `ESHKOL_VM_REGION_RECYCLE` — all documented in
+  [docs/reference/runtime/environment-variables.md](../docs/reference/runtime/environment-variables.md).
+  `ESHKOL_ARENA_POISON`, the variable the native arena already reads, now arms
+  the VM's arena too.
+- **An exception guard entered once per tick costs nothing in steady state.**
+  Handler frames come from a thread-local LIFO free list, malloc-backed rather
+  than arena-backed, since an arena address can be retracted by a region or
+  iter-scope rewind and handing it back would alias a fresh object. Total frame
+  memory is bounded by peak nesting depth rather than by entry count. A resident
+  long-run gate measures at 200,000 and at 1,600,000 ticks — eight times apart —
+  and gates on the slope rather than on a ceiling: transient garbage and all four
+  persistent-mutation channels come back at exactly 0.000 bytes per tick, with
+  identical byte totals at both horizons, so what a resident loop retains is what
+  it publishes and nothing else. `ESHKOL_ARENA_REPORT=1` prints the global
+  arena's byte-exact allocation total at exit, because peak RSS is a high-water
+  mark of instantaneous residency that reads low under memory pressure.
+  [docs/reference/runtime/memory-model.md](../docs/reference/runtime/memory-model.md)
+  carries a measured matrix of which workload classes are exactly flat and which
+  are not.
+  <!-- source: docs/reference/runtime/memory-model.md:308-313; tests/memory/resident_longrun_flat_gate.sh:77-79 -->
+
+**Tail calls**
+
+- **Every tail-position spelling gets the constant-stack guarantee `if` always
+  had.** A mutual tail call written with `cond`, `case`, `when`, `unless`, or as
+  the last operand of `and`/`or` now runs flat, and the walker that offers
+  candidate sites is as wide as the oracle that confirms them. The depth ladder
+  runs each mutual-recursion shape at 500,000, 5,000,000 and 100,000,000 hops,
+  including a four-cycle that routes through `cond`, `when`, `or` and `case`,
+  one form per hop.
+  <!-- source: scripts/gen_recursion_depth.py:125-155 (mutual_tail_cond, mutual_tail_forms) -->
+- **A tail-transfer dispatcher removes the remaining bounds.** A transferring
+  procedure does not call its target: it copies its evaluated arguments into a
+  per-thread transfer record, records the callee's uniform entry, and returns,
+  and a driver loop compiled into the public entry point runs the transfer in
+  its place — one native frame live per hop, reused regardless of arity or
+  target. Differing-signature mutual tail calls run 100,000,000 hops at 9.1 MB
+  peak resident memory, and non-AArch64 targets get the same bound without an
+  aggregate-return `musttail`. Tail calls through `guard` stay bounded
+  deliberately: R7RS does not make that a tail context, so optimizing it would
+  be wrong rather than merely unfinished. The same work lands the OALR ABI v2
+  Phase A groundwork, tracked separately against ADR-0006.
+
+**Automatic differentiation**
+
+- **Dispatch is exhaustive by construction.** `ad_node_type_t`,
+  `callable_subtype_t`, and `EvacKind` are generated from a single declaration
+  registry (*inc/eshkol/ad_node_registry.def*) with no `default:` arm, with
+  `-Werror=switch` and `-Werror=switch-enum` making an unhandled member a
+  compile error rather than a plausible answer, and an ICC invariant re-derives
+  each enum's members from its own definition so the guarantee holds on
+  toolchains where the compiler flag alone cannot enforce it. A registry row
+  naming a backward function that does not exist is itself a compile error,
+  which is what makes a row's claim to be registered mean registered. Open sets
+  stay loud on purpose: a subtype byte read out of an object header is untrusted
+  input, so it is split off with a value-naming fallback, and the VM's opcode and
+  value-type switches, which dispatch on bytecode, are left as loud backstops.
+- **Exact backwards for the four geometric bridge operators.** Hyperbolic
+  distance, the Poincaré exponential and logarithmic maps, and geodesic
+  attention carry exact closed-form rules, each declared as a bridged row in the
+  registry. The exp and log rules reuse the Möbius-addition and log-map
+  Jacobians the Fréchet rule already differentiates rather than re-deriving
+  them, since the log map *is* the function that rule differentiates and a
+  second derivation could only introduce a disagreement. Two points are made
+  explicit rather than hidden: the distance is not differentiable at coincident
+  points, and geodesic attention is therefore not differentiable when a query
+  row equals a key row exactly — the ordinary case when `Q` and `K` are the same
+  tensor — and both refuse loudly, naming the offending index, rather than
+  picking a plausible subgradient. The gradcheck is pinned by count at 13
+  checks, and an exhaustive-dispatch test carries 11: the registry holds 18
+  bridged rows against 4 that no forward produces yet.
+  <!-- source: tests/bridge/qllm_bridge_geometric_gradcheck_test.cpp (13 checks); tests/backend/exhaustive_dispatch_test.cpp (11 checks); inc/eshkol/ad_node_registry.def (18 BRIDGE rows, 4 UNREGISTERED) -->
+- **Forward producers for the tensor-embedding and Fréchet-mean AD nodes.**
+  `ad_tensor_embedding` and `ad_frechet_mean` record real nodes through real
+  dispatch, so the backward rules are exercised by the producer that fills their
+  contract rather than by hand-assembled fixtures written from the same contract
+  the rule reads. Fractional, negative, and out-of-range embedding indices are
+  refused at record time rather than rounded or clamped into a wrong row, and
+  the Fréchet forward shares its Karcher iteration with the VM's own opcode so
+  forward and backward cannot disagree about what "converged" means. Gradchecked
+  through the real producers and the real dispatch against exact analytic
+  references: exact scatter-add for the embedding with 0 mismatches, the exact
+  Euclidean closed form for the Fréchet mean at 0.0, and a hyperbolic finite
+  difference of 8.3e-10 over 48 partials.
+  <!-- source: CHANGELOG.md v1.3.5-evolve (#497); tests/bridge/qllm_bridge_producer_gradcheck_test.cpp -->
+- **The no-finite-differences guarantee is enforced, and exactness gains a
+  structural gate.** The counter behind `(ad-finite-difference-evals)` has a real
+  writer on the one central-difference backward the tape defines, reported
+  through the zero-arity builtin `(ad-note-finite-difference!)` on native and on
+  the VM alike, and the exactness gate runs a positive case beside a negative
+  control — a difference quotient deliberately planted in the gradient path — on
+  JIT, AOT, and the VM. Separately, `.icc/ad-carrier-manifest.yaml` declares, per
+  operator and per engine, which differentiation carrier answers it and whether
+  it is exact, and a gate re-derives each declaration by extracting and
+  classifying the actual `case` body in the emitted sources, so a declaration
+  cannot be laundered through a helper. An output differential can only compare
+  what two carriers compute, never which carrier computed it; this closes that
+  gap.
+
+**Language surface**
+
+- **R7RS 7.1.1 vertical-line symbol syntax, read and written.**
+  `<identifier> -> <vertical line> <symbol element>* <vertical line>` is one of
+  R7RS's three `<identifier>` productions. All four readers — the native
+  tokenizer, the VM tokenizer, and both runtime `read` implementations — accept
+  the full `<symbol element>` alphabet, including the mnemonic escapes, `\|`,
+  and `\x<hex>;`. The bars request a verbatim spelling, so `#!fold-case` does
+  not apply inside them, and `|.|` is an ordinary symbol distinct from the bare
+  `.` dotted-pair delimiter. `write` emits bars only when a name cannot be
+  spelled bare under the R7RS grammar; `display` never bars. A shared
+  predicate and escaper in *inc/eshkol/core/symbol_syntax.h* keeps the native
+  and VM writers byte-identical.
+- **`gensym` is reachable on every engine**, identically on native JIT, native
+  AOT, and the bytecode VM.
+- **The full quoted-datum grammar on both engines.** Quoted vectors,
+  quasiquote, and unquote are read as data by all four readers, and the reader's
+  `is_char`/`is_inexact` flags survive into the quoted form, so `'(#\a)` is a
+  list of a character.
+- **Cloning a linear `Qubit` is a rejected compile.** In the default
+  compilation mode a linearity violation stops before code generation, exits
+  nonzero, and writes no artifact — the same discipline `--strict-types` already
+  had. Measured against 24 shapes.
+
+**Frontend, ABI, and packaging**
+
+- **The frontend node-identity substrate (ADR-0000 Stage 1, phase A).** Every
+  AST node the parser produces carries a stable `NodeId`, and a chunked,
+  lock-free-read side table maps that id to a `SourceSpan` — the first column of
+  the `NodeId -> {SourceSpan, BindingId, TypedExprInfo}` substrate that the
+  compiler, the LSP, the docs, the REPL, and the VM all have to be built on if
+  they are to give one answer rather than five. The parser's 32
+  location-stamping sites write the location and the identity in one statement
+  so the two cannot drift apart, and the stream reader closes each top-level
+  form's span with a measured *extent* — the first place in the frontend that
+  records where a construct ends rather than only where it begins. `NodeId`s are
+  tagged rather than bare indices, and a garbage word is rejected by its tag and
+  again by its bound, so it reads as "unknown": a diagnostic may fail to name a
+  location, but it must never name a wrong one confidently. The change is
+  strictly additive — `line`, `column`, and `source_file_id` keep their exact
+  previous values. The LLVM codegen dispatcher is the first consumer, resolving
+  the file, line, and column it reports through the substrate and falling back
+  to the node's own fields for a node synthesized after parsing, so a node's
+  *file* does not depend on the traversal that reached it. Coverage is measured
+  at the consumer rather than at the parser, because a parser-side count says
+  only how many ids were minted and never whether the answer arrived where it
+  was needed; "has an identity", "has a location", and "has an extent" stay three
+  separate numbers, graded by their own completion oracle against a monotonic
+  span-coverage floor of 99.48% written truncated rather than rounded so it
+  cannot drift upward by accident.
+  <!-- source: tests/coverage/NODE_IDENTITY_BASELINE.json (span_coverage_floor 0.9948); scripts/run_node_identity_gate.py:197-243 --> Phase A only, and the oracle says so.
+- **Object ABI migration, stage 0 (ADR-0012).** Three layers of detection —
+  lexical token matching, libclang semantic resolution, and emitted-LLVM-IR
+  ground truth — enumerate 1,273 sites that depend on the current object-header
+  layout, ratcheted against a committed baseline so a new site fails the build.
+  <!-- source: docs/design/adr/0012-object-abi-staged-migration.md:100-102 (816 lexical sites across 98 files; 1,273 once the semantic layer is added); ratchet baseline .icc/abi-header-baseline.json --> A link-time guard whose symbol name is derived from
+  the four numbers that determine object-exchange compatibility means a stale
+  object file, JIT cache entry, installed runtime, or `--shared-lib` artifact
+  fails to *link*, with an undefined-symbol error naming the layout it wanted. A
+  layout-pin test pins the header's size and every field's offset both through
+  the accessor and as raw bytes at the negative offsets generated code actually
+  uses. ADR-0012 sequences the seven remaining migration stages, each with a
+  named falsifier.
+- **A canonical `find_package(Eshkol)` link contract.** `cmake/FindEshkol.cmake`
+  ships as the one discovery module: it resolves the compiler, the runtime
+  archive a compiled program actually needs, and the stdlib object and module
+  directory, producing an `Eshkol::eshkol` imported target whose link interface
+  unconditionally includes `stdlib.o` plus, on Apple, the system frameworks the
+  runtime needs — with no hand-written library search in the consumer at all.
+  The homebrew formula and both release-asset steps install the module and
+  `EshkolCompile.cmake`, and *tests/integration/system_package/* is a
+  from-scratch consumer CMake project run against a staged package by the
+  package manifest, so what is checked is that the discovery contract works and
+  not merely that its files landed. Scoped to macOS and Linux; the Windows and
+  MSVC link recipe is a later item.
+
+**Benchmarks and assurance**
+
+- **A public, one-command, reproducible benchmark suite**
+  (`bench/run_public_benchmarks.sh`). From a clean checkout it measures the four
+  axes where Eshkol claims something distinctive — exact-AD cost curves, Ozaki-II
+  CRT exact f64 GEMM, flat RSS under resident load, and differentiable quantum
+  kernels — and emits machine-readable JSON alongside a human-readable table,
+  <!-- source: bench/run_public_benchmarks.sh:107-110 --> with the noise-control methodology and an explicit not-benchmarked list
+  documented in *bench/README.md*. It is not a competition entry against XLA,
+  PyTorch, or JAX.
+- **A gated compile-time benchmark on a large single file.**
+  `bench/generate_large_single_file.py` generates a deterministic, self-contained
+  fixture of top-level defines referencing earlier-numbered functions, calibrated
+  against a measured growth curve, and `bench/large_single_file_compile_bench.sh`
+  compiles a 1,600-define fixture against a 900-second ceiling nightly, killed
+  with `SIGKILL` rather than `SIGTERM` because the compiler does not exit
+  promptly on `SIGTERM` mid-codegen, and capturing an `ESHKOL_PHASE_TIME=1`
+  breakdown that attributes about 98% of the wall clock to LLVM's own backend
+  rather than to Eshkol's frontend.
+  <!-- source: bench/large_single_file_compile_bench.sh:44-45; CHANGELOG.md v1.3.5-evolve (#495) -->
+- **The PGO training corpus has a consumer.** `scripts/run_pgo_corpus_smoke.sh`
+  runs every corpus program under the JIT and AOT and asserts both exit 0 with
+  byte-identical, non-empty stdout, which makes it a real differential check
+  rather than a liveness smoke test; wired as a nightly job. This is Stage 1
+  only — the CMake orchestration that drives profile-guided compilation over the
+  corpus is tracked against ADR-0007.
+- **A GPU correctness gate that can fail.** Every `tests/gpu/*.esk` file
+  aggregates a failure counter and exits on a final `PASS:`/`FAIL:` verdict line;
+  the test isolation layer gains an opt-in verdict-grammar check that fails a
+  test which exits 0 without printing a recognized marker; and a permanent,
+  deliberately-failing canary (*tests/gpu/gate_canary_must_fail.esk*) runs on
+  every invocation and is required to fail, forcing the whole run red if it is
+  ever not red. On the strength of a measured Metal-versus-CPU divergence of
+  exactly 0 across ten probes, the gate tolerance tightens from `1e-4` to
+  `1e-9`. The Windows judge honours the same contract: it applies the same
+  canary inversion, and every marker check now evaluates its regexes in
+  multiline mode at the one place those checks are made, so a marker printed
+  after a banner line is seen.
+- **Two assurance waves that check the assurance.** Ledger-integrity and
+  oracle-schema gates fail on a duplicate identifier, a missing required field,
+  or a structurally invalid criterion, and report declared-versus-graded
+  criteria counts per oracle. A self-verdict scanner fails a PASS-graded
+  artifact whose own text still contains a failure marker. Build-fingerprint
+  checks record and check the compiler binary's size, mtime, and SHA-256
+  alongside the checkout's git SHA, failing when a built binary predates the
+  most recent build-relevant source change. A PowerShell-encoding gate reads the
+  files' own bytes and fails any tracked `*.ps1`/`*.psm1` file carrying a byte at
+  or above `0x80` without a UTF-8 byte-order mark, reporting the exact
+  `file:line:col` and codepoint — a check CI could never make by execution,
+  since running the same bytes under a different default encoding is precisely
+  what hides the problem. A false-green audit fails an oracle target whose
+  evidence can go missing without the target going red, and an adversarial
+  scenario suite exercises the gates themselves under a dirty worktree, a stale
+  binary, a model-server outage, disk pressure, and an actually failing gate.
+  Every gate ships a `--self-test` mode, and every one of those modes is wired
+  into `ctest` or CI.
+- **`icc readiness` is machine-reachable.** Every finished trace is mirrored
+  unconditionally into the directory the readiness oracle reads. A `pillars-fast`
+  job runs the cheap gates on every pull request — depth coverage, the ADR-0009
+  DBSP acceptance gate, the monotone-equivalence Taylor gate, the AD validated
+  bounds gate, and VM parity — and a nightly workflow runs the expensive sweeps:
+  depth-parametric, differential, edge-matrix, metamorphic, sanitizer-fuzz, the
+  full smoke battery, and SICP. Every trace-emitting harness now shares a
+  PASS/FAIL/INFRA/SKIP vocabulary with a real fork-based timeout and a
+  retry-once helper, so an infrastructure timeout cannot publish itself as a
+  code defect. The `v1.4-connection` completion oracle carries one criterion per
+  named deliverable, each bound to a real harness, and v1.3.5-evolve has a
+  completion-oracle target of its own so that "all of v1.3.5" is a
+  machine-checkable claim.
+- **CI reports what it ran.** Every required context reports on every pull
+  request, including a documentation-only one, because the docs-only decision is
+  a job-level gate rather than a trigger-level path filter — and that gate fails
+  safe, running everything when it cannot compute a diff. The push trigger is
+  narrowed to the long-lived branches, so a branch under review runs the matrix
+  once rather than twice. Self-hosted lanes are opt-in behind a repository
+  variable and restricted to non-fork pull requests, with no required hosted
+  lane removed, weakened, or made conditional; the mesh gate is an explicitly
+  advisory job that emits an honest warning when its telemetry is unavailable
+  rather than fabricating a verdict; and the release-readiness gate, which needs
+  ICC, runs on the maintainer's own runner with a preflight step that resolves
+  its toolchain and fails loud and specific if anything is missing.
+
+### Measured this cycle
+
+Every number below is produced by a gate or harness in the repository. The
+v1.3.4-evolve rows were re-measured against a from-source build during the
+v1.3.5 documentation wave and carry into this release unchanged.
+
+| Claim | Where it is measured | Result |
 |---|---|---|
+| Re-entrant continuations across engines | `scripts/run_continuation_tests.sh` over `tests/continuations/` | 6 fixtures on native JIT, native AOT and the bytecode VM; transcripts byte-identical to the committed expected files |
+| VM region reclamation, one fixture swept by iteration count | `tests/memory/vm_region_flat_rss_test.sh`; [RUNTIME_CONFIGURATION.md](../docs/breakdown/RUNTIME_CONFIGURATION.md#bytecode-vm-region-reclamation) | flat 25-27 MB at 1,000 / 4,000 / 16,000 iterations, against 793 MB with `ESHKOL_VM_REGION_EVAC=0` and 704 MB for an unwrapped control |
+| VM heap tag coverage | `vm_evac_subtype_table[]`, compile-time span check | 33 rows: 28 `HeapType` members, 3 manifold tags, 2 unassigned slots |
+| Mutual tail recursion in every spelling | `scripts/gen_recursion_depth.py`, `mutual_tail_cond` and `mutual_tail_forms` | ladder of 500,000 / 5,000,000 / 100,000,000 hops, all expected to pass |
+| Differing-signature mutual tail calls | tail-transfer dispatcher gate, `.icc/completion-oracles.yaml` | 100,000,000 hops at 9.1 MB peak RSS |
+| Resident daemon loop, two horizons 8× apart | `tests/memory/resident_longrun_flat_gate.sh` at 200,000 and 1,600,000 ticks | transient garbage and all four persistent-mutation channels at exactly 0.000 bytes/tick, identical byte totals at both horizons |
+| Frontend span coverage at the consumer | `scripts/run_node_identity_gate.py` against `tests/coverage/NODE_IDENTITY_BASELINE.json` | monotonic floor of 99.48% |
+| qLLM oracle | `tests/qllm_oracle/` | gate 10/10 across five exporters on the JIT and AOT lanes, over 77 in-language checks |
+| Geometric bridge backwards vs. independent golden Jacobians | `tests/bridge/` | agreement to 3.7e-16 and 1.1e-14 |
+| Geometric bridge backwards vs. derivation-independent identities | conformal gradient-norm and inverse-Jacobian identities, `.icc/silent-wrong-ledger.yaml` SW-65 evidence | max relative deviation 5.0e-16 and 6.7e-16 |
+| Embedding and Fréchet-mean producers, gradchecked through real dispatch | `tests/bridge/qllm_bridge_producer_gradcheck_test.cpp` | embedding exact scatter-add, 0 mismatches; Fréchet exact Euclidean closed form, 0.0; hyperbolic finite difference 8.3e-10 over 48 partials |
+| Object-header layout dependence | `scripts/abi_header_inventory.py`, ratcheted against `.icc/abi-header-baseline.json` | 1,273 enumerated sites over three detection layers |
+| GPU correctness gate tolerance | `scripts/run_gpu_tests.sh`, `GPU_GATE_TOL` | `1e-9`, on a measured Metal-versus-CPU divergence of exactly 0 across ten probes |
+| Vertical-line symbol syntax | `tests/features/pipe_symbol_test.esk` | 51 checks, run on native JIT, native AOT and the VM as a three-way parity check |
+| `gensym` on every engine | `tests/control_flow/gensym_test.esk` | 9/9 on all three engines |
+| Large single-file AOT compile | `bench/large_single_file_compile_bench.sh` | 1,600 defines inside a 900-second ceiling; about 98% of wall clock in LLVM's backend |
 | Exact rational derivative | `(derivative-n g 1/3 1)` for `g(x) = 8x²` | `16/3`, `exact?` `#t` |
 | Exact bignum derivative | `(derivative-n f 7 12)` for `f(x) = x^30` | `67465815595294257109436307840000`, `exact?` `#t` |
-| H2 vibrational frequency (arbitrary-order AD, exact 2nd derivative) | `eshkol-run -r examples/h2_vibrational.esk` | 5003.2038 cm⁻¹ (R* = 1.38869 bohr, E(R*) = -1.13731 Ha) |
-| Ozaki-II CRT exact GEMM (Metal, Apple M2 Ultra) | `eshkol-run -r tests/gpu/ozaki_certification_test.esk` | 25/25 samples, 0 mismatches, max 58 correct dot bits, PASS |
-| CHSH Bell-inequality gate | `eshkol-run -r tests/quantum/bell_chsh_test.esk` | S = 2.835 over 16,000 shots (gate: `2.4 < S <= 2.95`), PASS |
-| Gradient parity across engines | `(gradient f 3.0 4.0)` for `f(x,y)=x²y+y³`, native JIT / native AOT / bytecode VM | `#(24 57)` on all three, byte-identical |
-| Flat-RSS resident loop (ESH-0214b AOT gate) | `tests/memory/define_loop_flat_rss_aot_test.sh`, 1,000,000 iterations | 8 MB peak RSS (fix on) vs. 2,620 MB (fix compiled out) |
+| H2 vibrational frequency, exact second derivative | `eshkol-run -r examples/h2_vibrational.esk` | 5003.2038 cm⁻¹ (R* = 1.38869 bohr, E(R*) = -1.13731 Ha) |
+| Ozaki-II CRT exact GEMM, Metal on Apple M2 Ultra | `tests/gpu/ozaki_certification_test.esk` | 25/25 samples, 0 mismatches, max 58 correct dot bits, PASS |
+| CHSH Bell-inequality gate | `tests/quantum/bell_chsh_test.esk` | S = 2.835 over 16,000 shots, gate `2.4 < S <= 2.95`, PASS |
+| Gradient parity across engines | `(gradient f 3.0 4.0)` for `f(x,y) = x²y + y³` | `#(24 57)` on native JIT, native AOT and the VM, byte-identical |
+| Flat-RSS resident loop, AOT gate | `tests/memory/define_loop_flat_rss_aot_test.sh`, 1,000,000 iterations | 8 MB peak RSS, against 2,620 MB with reclamation compiled out |
 | Linear `Qubit` no-cloning | `eshkol-run --strict-types -r tests/typesystem/qubit_no_cloning_test.esk` | compile-time type error: "linear variable 'q' was consumed more than once" |
 
-Not independently re-verified this cycle: CUDA-path Ozaki-II (no CUDA
-hardware in this environment — Metal path above stands in) and WASM-path
-gradient parity (no Emscripten toolchain in this environment; native
-JIT/AOT/VM three-way agreement above stands in for cross-engine parity).
+<!-- sources for the carried-over v1.3.4-evolve rows: CHANGELOG.md v1.3.5-evolve, "v1.3.5 documentation wave" (all re-measured against a from-source build of commit 694c3179) -->
+
+Not measured in this environment: the CUDA Ozaki-II path (no CUDA hardware
+here; the Metal path above stands in) and WebAssembly gradient parity (no
+Emscripten toolchain here; the native JIT / native AOT / VM three-way agreement
+above stands in for cross-engine parity).
 
 ---
 
@@ -160,10 +477,14 @@ JIT/AOT/VM three-way agreement above stands in for cross-engine parity).
 
 Eshkol is an R7RS-compatible Scheme dialect. The implementation passes
 roughly 232 of 244 R7RS-small procedures (~95%), includes hygienic
-`syntax-rules` macros, first-class single-shot continuations (`call/cc`,
-`dynamic-wind`, `guard`/`raise`, `delay`/`force`), bytevectors, records via
-`define-record-type`, and `eval` with all three R7RS environment
-constructors (*docs/breakdown/OVERVIEW.md §Eshkol vs. Scheme*). A separate,
+`syntax-rules` macros, first-class multi-shot re-entrant continuations
+(`call/cc`, `dynamic-wind`, `guard`/`raise`, `delay`/`force`) as of
+v1.3.5-evolve, bytevectors, records via `define-record-type`, and `eval` with
+all three R7RS environment constructors
+(*docs/breakdown/OVERVIEW.md §Eshkol vs. Scheme*). As of v1.3.5-evolve the
+reader also accepts R7RS 7.1.1 vertical-line symbol syntax across all four
+readers, and `gensym` is reachable identically on native JIT, native AOT, and
+the bytecode VM. A separate,
 newer measure — a reference-Scheme differential oracle that diffs Eshkol
 against chibi-scheme 0.12.0 on a 34-program portable corpus — reports
 34 of 34 AGREE (100%), up from 27/34 at the start of the v1.3.0-evolve cycle.
@@ -171,48 +492,59 @@ against chibi-scheme 0.12.0 on a 34-program portable corpus — reports
 The parser handles ninety-four operation types over an S-expression syntax
 with line/column tracking and an R7RS-compliant internal-defines transform
 to `letrec*`. The macro expander supports ellipsis patterns, nested
-patterns, and hygienic renaming. As of v1.3.1-evolve, the S-expression reader
-(`read_list`) is iterative rather than per-element recursive, so reading
-back a very large persisted list no longer risks a native-stack overflow.
+patterns, and hygienic renaming. The S-expression reader (`read_list`) is iterative rather than per-element
+recursive, so reading back a very large persisted list costs no native stack
+frame per element.
 See *lib/frontend/parser.cpp*, *lib/frontend/macro_expander.cpp*, and
 *lib/core/runtime_reader_hosted.cpp*.
 
+The continuation surface states its own scope. `call/cc` captures the control
+state and not the store, so `set!` and `define` effects at top level survive
+re-entry on both engines. Two shapes are documented as outstanding rather than
+inferred: a binding established after capture on the VM's operand-stack store is
+refused with a diagnostic rather than answered, and a `set!`-assigned local that
+is neither a top-level binding nor closure-captured rolls back on re-entry,
+pending assignment conversion. Both are named in
+[docs/reference/language/continuations.md](../docs/reference/language/continuations.md)
+and tracked in the project's silent-wrong ledger.
+
 ### Implementation
 
-| Component | Lines | File / directory |
-|:---|---:|:---|
-| Main LLVM codegen | 42,025 | *lib/backend/llvm_codegen.cpp* |
-| Total LLVM backend (main + 33 codegen modules) | ≈106,500 | *lib/backend/* |
-| Autodiff codegen (order ≤ 2, incl. custom-VJP) | 13,815 | *lib/backend/autodiff_codegen.cpp* |
-| Taylor-tower runtime (arbitrary order) | ≈1,710 | *lib/core/runtime_taylor.c*, *lib/core/taylor_recurrences.def* |
-| Taylor-tower stdlib modules (GUW, tensor towers, models, checkpointing, numerics, sparse) | ≈2,570 | *lib/core/ad/{guw,tensor_tower,taylor_models,checkpoint,taylor_numerics,sparse_guw,interval}.esk* |
-| Backward-mode kernels | 1,446 | *lib/backend/tensor_backward.cpp* |
-| String / I/O / JSON / CSV | 3,860 | *lib/backend/string_io_codegen.cpp* |
-| Work-stealing parallel codegen | 2,626 | *lib/backend/parallel_llvm_codegen.cpp* |
-| Arithmetic (incl. bignum/rational/complex) | 3,869 | *lib/backend/arithmetic_codegen.cpp* |
-| Collection ops | 3,164 | *lib/backend/collection_codegen.cpp* |
-| Parser | 11,116 | *lib/frontend/parser.cpp* |
-| Macro expander | 1,483 | *lib/frontend/macro_expander.cpp* |
-| Type checker | 3,841 | *lib/types/type_checker.cpp* |
-| Arena memory | 1,784 | *lib/core/arena_memory.h* and *lib/core/runtime_arena_\*.cpp* |
-| S-expression reader (iterative as of v1.3.1-evolve) | 675 | *lib/core/runtime_reader_hosted.cpp* |
-| Logic engine | 1,182 | *lib/core/logic.cpp* |
-| Active-inference engine | 1,203 | *lib/core/inference.cpp* |
-| Global workspace | 354 | *lib/core/workspace.cpp* |
-| Quantum FFI (opt-in, v1.3.3-evolve) | 1,570 | *lib/agent/quantum.esk*, *lib/agent/c/agent_quantum.c* |
-| ML-KEM post-quantum KEM (opt-in, v1.3.3-evolve) | ≈520 | *lib/agent/pqc.esk*, *lib/agent/c/agent_pqc.c* |
-| Incremental dataflow (v1.3.3-evolve) | 448 | *lib/core/dbsp.esk* |
-| Weight-matrix transformer | 7,363 | *lib/backend/weight_matrices.c* |
-| Bytecode VM + runtime libs | ≈46,200 | *lib/backend/eshkol_vm.c* and runtime |
+| Component | File / directory |
+|:---|:---|
+| Main LLVM codegen | *lib/backend/llvm_codegen.cpp* |
+| LLVM backend modules | *lib/backend/* |
+| Autodiff codegen (order ≤ 2, incl. custom-VJP) | *lib/backend/autodiff_codegen.cpp* |
+| AD node registry (single declaration, no `default:`) | *inc/eshkol/ad_node_registry.def* |
+| Taylor-tower runtime (arbitrary order) | *lib/core/runtime_taylor.c*, *lib/core/taylor_recurrences.def* |
+| Taylor-tower stdlib modules | *lib/core/ad/{guw,tensor_tower,taylor_models,checkpoint,taylor_numerics,sparse_guw,interval}.esk* |
+| Backward-mode kernels | *lib/backend/tensor_backward.cpp* |
+| qLLM geometric bridge and its exact backwards | *lib/bridge/qllm_bridge.cpp*, *lib/bridge/tensor_backward.cpp* |
+| String / I/O / JSON / CSV | *lib/backend/string_io_codegen.cpp* |
+| Work-stealing parallel codegen | *lib/backend/parallel_llvm_codegen.cpp* |
+| Arithmetic (incl. bignum/rational/complex) | *lib/backend/arithmetic_codegen.cpp* |
+| Collection ops | *lib/backend/collection_codegen.cpp* |
+| Parser | *lib/frontend/parser.cpp* |
+| Frontend node identity (v1.3.5-evolve) | *inc/eshkol/frontend/node_identity.h*, *lib/frontend/node_identity.cpp* |
+| Macro expander | *lib/frontend/macro_expander.cpp* |
+| Type checker | *lib/types/type_checker.cpp* |
+| Arena memory | *lib/core/arena_memory.h*, *lib/core/runtime_arena_\*.cpp* |
+| Region runtime and escape evacuation | *lib/core/runtime_regions.cpp* |
+| VM region evacuator (v1.3.5-evolve) | *lib/backend/vm_region_evac.c* |
+| Object ABI fingerprint (v1.3.5-evolve) | *inc/eshkol/abi_fingerprint.h*, *lib/core/abi_fingerprint.c* |
+| S-expression reader (iterative) | *lib/core/runtime_reader_hosted.cpp* |
+| Logic engine | *lib/core/logic.cpp* |
+| Active-inference engine | *lib/core/inference.cpp* |
+| Global workspace | *lib/core/workspace.cpp* |
+| Quantum FFI (opt-in) | *lib/agent/quantum.esk*, *lib/agent/c/agent_quantum.c* |
+| ML-KEM post-quantum KEM (opt-in) | *lib/agent/pqc.esk*, *lib/agent/c/agent_pqc.c* |
+| Incremental dataflow | *lib/core/dbsp.esk* |
+| Weight-matrix transformer | *lib/backend/weight_matrices.c* |
+| Bytecode VM + runtime libs | *lib/backend/eshkol_vm.c* and its *vm_\*.c* modules |
 
-Total compiler infrastructure is approximately 322,800 lines of C17 and C++20
-across 322 files (*docs/DESIGN.md §Implementation Scale*). v1.3.1-evolve
-added roughly 12,600 lines of Doxygen-format documentation across 116 files —
-50 of the 64 public headers under `inc/eshkol/` (≈4,650 lines) and 56
-previously-undocumented implementation files under `lib/` (≈7,478 lines) —
-comments only, no behaviour change; v1.3.2-evolve added a further
-`eshkol-doc` reference generator (`docs/api/`) that harvests those comments
-automatically.
+The public C-API headers under `inc/eshkol/` and the implementation files under
+`lib/` carry Doxygen-format documentation, harvested automatically into a
+generated `docs/api/` reference by `eshkol-doc`.
 
 ### Target backend
 
@@ -241,8 +573,13 @@ The language occupies a region not covered by the established alternatives.
   compiles to native code through LLVM rather than to bytecode or via a
   source-to-C transform; it integrates automatic differentiation, GPU
   dispatch, and a neuro-symbolic stack at the compiler level rather than as
-  optional libraries. It provides single-shot continuations via setjmp/longjmp
-  rather than the full multi-shot continuations available in Racket or Chez.
+  optional libraries. As of v1.3.5-evolve its continuations are multi-shot and
+  re-entrant on all three engines, so a captured continuation can be invoked any
+  number of times and from any dynamic extent, including after the capturing
+  procedure has returned — the property Racket and Chez have and a compiled
+  setjmp/longjmp implementation has to earn, here by giving a capture that may
+  outlive its frame a durable copy of the live C stack restored to the same
+  addresses.
 - **Compared with AD-first systems** (Julia + Zygote, Python + JAX or PyTorch):
   Eshkol's AD is integrated into the compiler at the IR level rather than
   obtained through tracing, source-to-source rewriting, or operator
@@ -262,8 +599,7 @@ The language occupies a region not covered by the established alternatives.
 
 Each comparison is grounded in *docs/breakdown/OVERVIEW.md §Comparison with
 other languages*; the document explicitly enumerates where Eshkol gives less
-than the alternative (multi-shot continuations, mature library ecosystem,
-GUI toolkits).
+than the alternative (mature library ecosystem, GUI toolkits).
 
 ---
 
@@ -282,10 +618,10 @@ consists of:
   `HEAP_SUBTYPE_TAYLOR`, added in v1.3.0-evolve for the arbitrary-order
   Taylor-tower AD engine) and five callable subtypes, consolidating eight
   historical pointer types into two supertypes (`HEAP_PTR`, `CALLABLE`).
-  As of v1.3.3-evolve every subtype that carries interior pointers —
-  including `PROMISE`, the last one — is deep-walked by the region-escape
-  evacuator rather than shallow-copied on escape from a `with-region` scope.
-  See *inc/eshkol/eshkol.h §heap subtypes*.
+  Every subtype that carries interior pointers is deep-walked by the
+  region-escape evacuator rather than shallow-copied on escape from a
+  `with-region` scope, on native codegen and, as of v1.3.5-evolve, on the
+  bytecode VM. See *inc/eshkol/eshkol.h §heap subtypes*.
 - 16-byte tagged values laid out `{type:u8, flags:u8, reserved:u16,
   padding:u32, data:u64}`. When the compiler can prove the type at
   compile time it emits untagged LLVM IR, eliminating the tagging
@@ -307,18 +643,66 @@ consists of:
   the loop body. Verified on a 1,000,000-iteration loop: RSS goes from
   1,369 MB (unbounded growth) to 224 MB (flat). See
   *lib/backend/llvm_codegen.cpp*.
-- **Region-escape evacuator** (ESH-0214a through e, completed v1.3.3-evolve).
-  When a value allocated inside a `with-region` block escapes that block
-  (is returned, stored into an outer binding, or captured by a closure), a
-  companion evacuator deep-walks it and promotes its interior pointers into
-  the surviving arena before the region is popped, rather than leaving them
-  dangling. Coverage was built out subtype by subtype: `CONS`/`VECTOR`/
-  `HASH`/`TENSOR`/`EXCEPTION`/`CLOSURE` first, then the logic/workspace
-  subtypes (`SUBSTITUTION`/`FACT`/`KNOWLEDGE_BASE`/`FACTOR_GRAPH`/
-  `WORKSPACE`) in v1.3.2-evolve, and `PROMISE` in v1.3.3-evolve, which closes
-  the series. `ESHKOL_ARENA_POISON=1` poisons `arena_destroy`'d memory so any
-  remaining gap in that coverage crashes loudly instead of corrupting
-  silently. See *lib/core/runtime_regions.cpp* and *lib/backend/llvm_codegen.cpp*.
+- **Region-escape evacuator.** When a value allocated inside a `with-region`
+  block escapes that block (is returned, stored into an outer binding, or
+  captured by a closure), a companion evacuator deep-walks it and promotes its
+  interior pointers into the surviving arena before the region is popped. Every
+  `HEAP_SUBTYPE_*` member carries an explicit deep-walk or leaf tag with its
+  reasoning, including the exact `COEFF_RATIONAL` Taylor tower, whose
+  coefficient array is walked because an overflowing coefficient is a pointer to
+  an independently arena-allocated bignum; the architecture-model invariant that
+  checks this is derived from the source rather than from a hand-typed list,
+  resolved through a libclang semantic index of the real case arms.
+  `ESHKOL_ARENA_POISON=1` poisons `arena_destroy`'d memory so any gap in that
+  coverage crashes loudly instead of corrupting silently. See
+  *lib/core/runtime_regions.cpp* and
+  *tests/memory/region_evac_taylor_exact_test.esk*.
+- **Region reclamation on the bytecode VM** (Stage 1, v1.3.5-evolve).
+  `with-region` reclaims on the VM as well as on native codegen. The VM marks
+  from its root set and sweeps at arena-block granularity rather than copying,
+  because a VM value addresses the heap by a small integer index rather than by
+  pointer — marking moves nothing, so `eq?` identity, shared structure, and
+  cycles survive with no special handling, and live objects' fixed-size headers
+  are copied one level out, which needs no layout knowledge because the object
+  table is the only holder of that address. A compile-time-checked 33-row table
+  classifies the full heap tag space, a fatal startup check requires every row
+  to be filled in, and an unclassified subtype, a continuation captured inside a
+  region, or a failed bookkeeping allocation all pin the region, so every
+  uncertainty degrades toward a bounded leak and never toward a dangling index.
+  Measured on one fixture swept by iteration count: 25, 26 and 27 MB at 1,000,
+  4,000 and 16,000 iterations, against 793 MB with `ESHKOL_VM_REGION_EVAC=0`.
+  Five runtime variables — `ESHKOL_VM_REGION_EVAC`, `_VERIFY`, `_VERIFY_FATAL`,
+  `_COMPACT`, `_RECYCLE` — are documented in
+  [environment-variables.md](../docs/reference/runtime/environment-variables.md),
+  and `ESHKOL_ARENA_POISON` arms the VM's arena as well as native's. The
+  user-reachable region handle surface (`region-open`/`region-close`) stays
+  bookkeeping-only on the VM and announces that at the point of use; the lexical
+  form landed first because its extent tells the teardown where the region ends.
+  See *lib/backend/vm_region_evac.c* and
+  [RUNTIME_CONFIGURATION.md](../docs/breakdown/RUNTIME_CONFIGURATION.md#bytecode-vm-region-reclamation).
+  <!-- source: docs/breakdown/RUNTIME_CONFIGURATION.md:92-96; lib/backend/vm_region_evac.c:163 (VM_EVAC_TYPE_COUNT 33) -->
+- **A continuation captured inside a region pins it, on both engines**
+  (v1.3.5-evolve). Capturing a continuation while any region is open pins every
+  currently-open region, and a pinned region's arena is promoted into its parent
+  on pop rather than freed, so the failure direction is a bounded leak and never
+  a dangling read. Pinning triggers only on an actual capture, so a program that
+  never calls `call/cc` shows no behaviour change — confirmed by the unchanged
+  flat-RSS gates.
+- **Exception handler frames cost nothing in steady state** (v1.3.5-evolve).
+  Handler frames come from a thread-local LIFO free list, malloc-backed rather
+  than arena-backed, since an arena address can be retracted by a region or
+  iter-scope rewind and handing it back would alias a fresh object. Total frame
+  memory is bounded by peak nesting depth rather than by entry count, so a
+  `guard` entered once per tick in a resident loop is free after the first.
+  A long-run gate measures at 200,000 and at 1,600,000 ticks and gates on the
+  slope rather than on a ceiling: transient garbage and all four
+  persistent-mutation channels come back at exactly 0.000 bytes per tick, with
+  identical byte totals at both horizons. `ESHKOL_ARENA_REPORT=1` prints the
+  global arena's byte-exact allocation total at exit, because peak RSS is a
+  high-water mark of instantaneous residency that reads low under memory
+  pressure. See
+  [memory-model.md](../docs/reference/runtime/memory-model.md).
+  <!-- source: docs/reference/runtime/memory-model.md:308-313; tests/memory/resident_longrun_flat_gate.sh:77-79 -->
 - Optional linear types via `(owned ...)`, `(borrow value body)`, and
   `(shared ...)`; the third activates reference counting against the
   header's 16-bit `ref_count` field (*README.md §Memory architecture*).
@@ -379,8 +763,7 @@ activations) recorded onto a Wengert tape during the forward pass. The tape
 is topologically sorted and walked in reverse during gradient construction.
 A 32-level tape stack enables nested gradients for Hessians, natural
 gradient, and meta-learning constructions. See
-*lib/backend/autodiff_codegen.cpp* (≈12,600 lines) and
-*lib/backend/tensor_backward.cpp* (≈1,400 lines).
+*lib/backend/autodiff_codegen.cpp* and *lib/backend/tensor_backward.cpp*.
 
 **Custom-VJP tape nodes (new in v1.3.3-evolve).** A new reverse-mode tape
 node (`AD_NODE_CUSTOM`) carries an externally supplied vector-Jacobian
@@ -459,21 +842,80 @@ overhead because the rewrite is at compile time (*README.md §Autodiff
 overhead*). The Taylor-tower engine is O(k²) in the requested order `k` and
 zero-heap when `k` is a compile-time literal.
 
-**Reverse-mode tensor-op gradients (`input2`), corrected in v1.3.3-evolve.**
-`gradient` on `conv2d`, `batchnorm`, `layernorm`, and `attention` propagates
-an exact gradient to the second operand (kernel / gamma-beta / K-V) in both
-the literal-loss form (a compile-time-known `Function*`) and the first-class
-form (a loss value with no compile-time `Function*`, e.g. one selected or
-constructed at runtime); a v1.3.2-evolve CHANGELOG entry had claimed this
-path was already complete, but an adversarial finite-difference audit found
-the change shipped a test and a roadmap update with no gradient code behind
-it — the first-class path still silently returned a zero gradient. The
-v1.3.3-evolve fix adds a reverse-mode tensor path to the closure branch of
-`gradient`'s codegen, wires batch-norm/layer-norm gamma/beta as per-feature
-AD nodes instead of one scalar, and turns any remaining unsupported
-tensor-op backward path into an explicit compile error instead of a silent
-zero. Finite-difference-verified across matmul/conv2d/attention-K-V/
-vector-gamma in both forms.
+**Reverse-mode tensor-op gradients (`input2`).** `gradient` on `conv2d`,
+`batchnorm`, `layernorm`, and `attention` propagates an exact gradient to the
+second operand (kernel / gamma-beta / K-V) in both the literal-loss form (a
+compile-time-known `Function*`) and the first-class form (a loss value selected
+or constructed at runtime). Batch-norm and layer-norm gamma/beta are
+differentiated per-feature rather than as one scalar, and any unsupported
+tensor-op backward path is an explicit error rather than a silent zero.
+Finite-difference-verified across matmul, conv2d, attention K-V, and vector
+gamma in both forms.
+
+**Dispatch closed by construction (new in v1.3.5-evolve).** `ad_node_type_t`,
+`callable_subtype_t`, and `EvacKind` are generated from a single declaration
+registry (*inc/eshkol/ad_node_registry.def*) with no `default:` arm, and
+`-Werror=switch` with `-Werror=switch-enum` makes an unhandled member a compile
+error rather than a plausible answer; an ICC invariant re-derives each enum's
+members from its own definition so the guarantee survives on toolchains where
+the compiler flag alone cannot enforce it. A registry row naming a backward
+function that does not exist is itself a compile error, which is what makes a
+row's claim to be registered mean registered. Open sets stay loud on purpose: a
+subtype byte read out of an object header is untrusted input, so it is split off
+with a value-naming fallback, and the VM's opcode and value-type switches, which
+dispatch on bytecode rather than on the enum, are left as loud backstops. The
+registry currently holds 18 bridged rows against 4 node types no forward
+produces yet.
+<!-- source: inc/eshkol/ad_node_registry.def (18 BRIDGE, 4 UNREGISTERED rows); tests/backend/exhaustive_dispatch_test.cpp (11 checks) -->
+
+**Exact backwards for the geometric bridge (new in v1.3.5-evolve).** Hyperbolic
+distance, the Poincaré exponential and logarithmic maps, and geodesic attention
+carry exact closed-form backward rules, each declared as a bridged row in that
+registry. The exp and log rules reuse the Möbius-addition and log-map Jacobians
+the Fréchet rule already differentiates rather than re-deriving them, since the
+log map *is* the function that rule differentiates and a second derivation could
+only introduce a disagreement. Validated against golden Jacobians from an
+independently written Eshkol transcription of the same formulas (agreement to
+3.7e-16 and 1.1e-14) and against two derivation-independent identities — the
+conformal gradient-norm identity and the inverse-Jacobian identity, at maximum
+relative deviations of 5.0e-16 and 6.7e-16 — before finite differences are
+consulted at all. The distance is not differentiable at coincident points, and
+geodesic attention is therefore not differentiable when a query row equals a key
+row exactly; both refuse loudly, naming the offending index, rather than picking
+a plausible subgradient. Gradcheck pinned by count at 13 checks.
+<!-- source: .icc/silent-wrong-ledger.yaml SW-65 evidence block; tests/bridge/qllm_bridge_geometric_gradcheck_test.cpp -->
+
+**Forward producers for the tensor-embedding and Fréchet-mean nodes (new in
+v1.3.5-evolve).** `ad_tensor_embedding` and `ad_frechet_mean` record real AD
+nodes through the real dispatch path, so those backward rules are exercised by
+the producer that fills their contract rather than by hand-assembled fixtures
+written from the same contract the rule reads. Fractional, negative, and
+out-of-range embedding indices are refused at record time rather than rounded or
+clamped into a wrong row, and the Fréchet forward shares its Karcher iteration
+with the VM's own opcode (extracted into
+*inc/eshkol/backend/frechet_mean_core.h*) so forward and backward cannot
+disagree about what "converged" means. Gradchecked against exact analytic
+references: exact scatter-add for the embedding with 0 mismatches, the exact
+Euclidean closed form for the Fréchet mean at 0.0, and a hyperbolic finite
+difference of 8.3e-10 over 48 partials.
+<!-- source: CHANGELOG.md v1.3.5-evolve (#497); tests/bridge/qllm_bridge_producer_gradcheck_test.cpp -->
+
+**A no-finite-differences guarantee that can fail, and a structural exactness
+gate (new in v1.3.5-evolve).** The counter behind `(ad-finite-difference-evals)`
+has a real writer on the one central-difference backward the tape defines,
+reported through the zero-arity builtin `(ad-note-finite-difference!)` on native
+and on the VM alike, and the exactness gate runs a positive case beside a
+negative control — a difference quotient deliberately planted in the gradient
+path — on JIT, AOT, and the VM. Separately,
+`.icc/ad-carrier-manifest.yaml` declares, per operator and per engine, which
+differentiation carrier answers it and whether it is exact, and
+`scripts/gate_ad_shared_node_model.py` re-derives each declaration by extracting
+and classifying the actual `case` body in the emitted sources, so a declaration
+cannot be laundered through a helper. Seven checks, including the requirement
+that a `vm-supported` row in the VM parity manifest declares its carrier and
+that the declared carrier equals the one the source is observed to use. An
+output differential can only compare what two carriers compute, never which
+carrier computed it; this is the gate that closes that gap.
 
 See the [Automatic Differentiation guide](../docs/guide/AUTOMATIC_DIFFERENTIATION.md)
 for a worked, example-verified walkthrough of all thirteen phases, and
@@ -498,7 +940,7 @@ logic-var?  substitution?  kb?  fact?
 Logic variables use the `?x` syntax, which the parser transforms into
 `ESHKOL_LOGIC_VAR_OP` AST nodes. The leading `?` is a valid R7RS identifier
 start character, so the syntax requires no grammar change. Implementation:
-*lib/core/logic.cpp* (≈1,180 lines).
+*lib/core/logic.cpp*.
 
 **Active inference (Friston's free-energy principle, 2010)**
 
@@ -511,7 +953,7 @@ factor-graph?
 The runtime supports belief propagation, CPT updates (which enable real
 learning by mutating the CPT and resetting messages so beliefs reconverge),
 and both variational free energy and expected free energy. Implementation:
-*lib/core/inference.cpp* (≈1,200 lines).
+*lib/core/inference.cpp*.
 
 **Global workspace theory (Baars 1988; Bengio 2017 computational formulation)**
 
@@ -523,7 +965,7 @@ make-workspace  ws-register!  ws-step!  workspace?
 registered closures via the closure dispatcher, and C runtime helpers
 (`eshkol_ws_make_content_tensor`, `eshkol_ws_step_finalize`) handle
 content-tensor wrapping and softmax broadcast.
-Implementation: *lib/core/workspace.cpp* (354 lines).
+Implementation: *lib/core/workspace.cpp*.
 
 Heap subtypes assigned to these objects:
 `HEAP_SUBTYPE_SUBSTITUTION = 12`, `HEAP_SUBTYPE_FACT = 13`,
@@ -601,10 +1043,10 @@ Primitives: `parallel-map`, `parallel-fold`, `parallel-filter`,
 `parallel-for-each`, `future`, `force`, `future-ready?`.
 
 A void-pointer ABI boundary keeps tagged values from being passed by value
-across the C/LLVM boundary, eliminating the optimisation-level-dependent
-struct-by-value corruption that surfaced on ARM64. All tagged-value
-construction and destruction occurs within LLVM IR; only `void*` crosses
-into C.
+across the C/LLVM boundary, so the representation does not depend on the
+optimisation level or on the target's aggregate-passing rules. All tagged-value
+construction and destruction occurs within LLVM IR; only `void*` crosses into
+C.
 
 Measured 4–12× speed-up of `parallel-map` on 24 cores
 (*docs/breakdown/ROADMAP.md §1.1-accelerate completed*; the underlying
@@ -612,10 +1054,9 @@ root-cause fix is recorded in project memory as the parallel-map
 flags-byte fix: worker tagged-value flags were hardcoded to zero, which
 mis-dispatched into the bignum path; packing `{type, flags}` into
 `item_type:i64` with the default flipped on restored real parallelism
-across both AOT and JIT paths). Shutdown safety was hardened in
-v1.3.0-evolve: `eshkol_runtime_shutdown()` now stops and joins the global
-parallel thread pool before running shutdown hooks, closing a use-after-free
-race that could `SIGSEGV` after a graceful `SIGTERM` was already logged.
+across both AOT and JIT paths). `eshkol_runtime_shutdown()` stops and joins the global parallel thread pool
+before running shutdown hooks, so a graceful `SIGTERM` tears the pool down in a
+defined order.
 
 ---
 
@@ -639,6 +1080,16 @@ CUDA dispatches through cuBLAS on NVIDIA.
 The cost model selects the backend per operation. The defaults are
 empirically calibrated and configurable through `ESHKOL_GPU_PRECISION`,
 `ESHKOL_BLAS_PEAK_GFLOPS`, `ESHKOL_GPU_PEAK_GFLOPS`.
+
+As of v1.3.5-evolve the GPU correctness gate is a gate. Every
+`tests/gpu/*.esk` file aggregates a failure counter and exits on an explicit
+`PASS:`/`FAIL:` verdict line; the test isolation layer fails a test that exits 0
+without printing a recognized marker; and a permanent, deliberately-failing
+canary (*tests/gpu/gate_canary_must_fail.esk*) runs on every invocation and is
+required to fail, forcing the whole run red if it is ever not red. On the
+strength of a measured Metal-versus-CPU divergence of exactly 0 across ten
+probes, `GPU_GATE_TOL` tightens from `1e-4` to `1e-9`.
+<!-- source: tests/gpu/gpu_correctness_gate.sh:71 (GPU_GATE_TOL default 1e-9); tests/gpu/gate_canary_must_fail.esk; scripts/run_gpu_tests.sh:186-223 -->
 
 ---
 
@@ -738,35 +1189,52 @@ added Doxygen documentation across every agent-FFI implementation file in
   hover, go-to-definition, diagnostics, formatting.
 - **VS Code extension** — syntax highlighting, LSP integration, build tasks.
   Source: *tools/vscode-eshkol/*.
+- **CMake package discovery** — `cmake/FindEshkol.cmake` ships as the one
+  canonical module, added in v1.3.5-evolve. `find_package(Eshkol)` resolves the
+  compiler, the runtime archive a compiled program needs, and the stdlib object
+  and module directory, producing an `Eshkol::eshkol` imported target whose link
+  interface unconditionally includes `stdlib.o` plus, on Apple, the system
+  frameworks the runtime needs. A from-scratch consumer project under
+  *tests/integration/system_package/* is run against a staged package by the
+  package manifest, so what is checked is that the contract works and not merely
+  that its files landed. Scoped to macOS and Linux.
+- **Public benchmarks** — `bench/run_public_benchmarks.sh`, added in
+  v1.3.5-evolve. One command from a clean checkout measures exact-AD cost
+  curves, Ozaki-II CRT exact f64 GEMM, flat RSS under resident load, and
+  differentiable quantum kernels, emitting machine-readable JSON alongside a
+  human-readable table. Methodology and an explicit not-benchmarked list are in
+  *bench/README.md*; a per-axis disk cap keeps a long run bounded.
+  <!-- source: bench/run_public_benchmarks.sh:107-110; bench/README.md -->
 - **Inter-Component Communication (ICC)** — agent-FFI-ready oracle and
   pytest-format smoke harness under `.icc/`; native Eshkol-aware (accepts
   Eshkol VM step / halt records as `eshkol_vm_step` / `eshkol_vm_halt`
   events; recognises `runtime_event` compact dict form and explicit
-  `kind` JSON records). Hardened in v1.3.3-evolve (#232) to also check
-  region-evacuator poison coverage and the corrected `input2` gradient
-  gate, and extended with the release's two generative exposure engines
-  (the multi-oracle differential harness and the AD-vs-finite-difference
-  adversarial oracle) as permanent release gates. The ICC readiness oracle
-  reports a score of 100 with verdict `ready`, trace-verified.
+  `kind` JSON records). Region-evacuator poison coverage, the `input2` gradient
+  gate, the multi-oracle differential harness, and the AD-versus-finite-difference
+  adversarial oracle are permanent release gates. As of v1.3.5-evolve every
+  finished trace is mirrored unconditionally into the directory `icc readiness`
+  reads, so the oracle is reachable from an ordinary pull request; the
+  `v1.4-connection` target carries one criterion per named deliverable, each
+  bound to a real harness; and v1.3.5-evolve has a completion-oracle target of
+  its own, so "all of v1.3.5" is a machine-checkable claim rather than a
+  narrative one.
+  <!-- source: .icc/completion-oracles.yaml (target v1.3.5-evolve, 24 criteria) -->
 
 ---
 
 ## Documentation
 
-v1.3.1-evolve's principal addition, alongside its memory/reader robustness
-fixes, was documentation coverage; v1.3.2-evolve turned that coverage into a
-generated, navigable artefact:
+Documentation is a first-class artefact of the project rather than a
+by-product:
 
 - **Public C-API headers.** Doxygen-format documentation across 50 of the
   64 public headers under `inc/eshkol/` — backend codegen, runtime core,
   the type system, the XLA backend, subprocess/macro-expander/qLLM-bridge
   surfaces, the thread pool and work-stealing deque, the logger, model I/O,
-  platform runtime, and runtime exports — across six commits, roughly
-  4,650 lines of new documentation.
-- **Implementation doc-comments.** 56 previously-undocumented implementation
-  files under `lib/` — agent FFI, the type checker, the parser, the REPL,
-  core non-runtime modules, the quantum RNG, FFI bridges — across three
-  commits, roughly 7,478 lines.
+  platform runtime, and runtime exports.
+- **Implementation doc-comments** across the implementation files under
+  `lib/` — agent FFI, the type checker, the parser, the REPL, core
+  non-runtime modules, the quantum RNG, and the FFI bridges.
 - **Navigable reference index.** A per-subsystem documentation index at
   [`docs/reference/language/`](../docs/reference/language/INDEX.md),
   [`ad/`](../docs/reference/ad/INDEX.md),
@@ -775,131 +1243,158 @@ generated, navigable artefact:
   [`stdlib/`](../docs/reference/stdlib/INDEX.md), and
   [`agent/`](../docs/reference/agent/INDEX.md), each an example-verified
   index into the corresponding function and syntax reference, linked from
-  *README.md §Documentation*.
-- **Generated API reference (`eshkol-doc`, v1.3.2-evolve).** The Doxygen
-  comments above are now harvested automatically into `docs/api/` rather
-  than requiring a hand-maintained index.
-
-Combined, the v1.3.1-evolve pass alone is 116 files and roughly 12,600 lines
-of new documentation — comments and reference pages only, no behaviour
-change.
+  *README.md §Documentation*. v1.3.5-evolve adds
+  [`bindings/python.md`](../docs/reference/bindings/python.md), documenting
+  the `Context.eval`/`derivative`/`gradient` API and the lifetime guarantee
+  a NumPy array exported from a tensor `eval()` carries, and
+  [`language/continuations.md`](../docs/reference/language/continuations.md),
+  documenting the multi-shot surface and its stated scope.
+- **Generated API reference (`eshkol-doc`).** Those comments are harvested
+  automatically into `docs/api/` rather than requiring a hand-maintained
+  index.
+- **A documentation-truth ratchet.** `scripts/check_surface_counts.py` reads
+  the canonical surface and builtin totals from the coverage policy files and
+  fails on a mismatch against every registered doc, red-proofed by planting a
+  stale claim and confirming the gate catches it; it runs in CI's assurance
+  job. The canonical totals it enforces are a 1,108-construct language surface
+  and 1,042 builtins.
+  <!-- source: tests/coverage/coverage_policy.json (baseline_surface_total 1108); tests/coverage/language_surface.json (counts.builtins_total 1042); scripts/check_surface_counts.py -->
 
 ---
 
 ## Hardening and robustness posture
 
-**v1.3.4-evolve (current release)** continues the posture described below.
-Its second half is a consumer-hardening correctness wave whose organising
-principle is that a wrong answer must not be able to look like a right one: an
-emitted compile-time error now prevents artifact emission and execution, which
-turned a family of silent wrong answers into build failures and exposed the
-rest. Exactness is decided from an operand's runtime tag rather than a result's
-value shape on both engines; differentiation is exact at exact points, survives
-per-iteration nursery reclamation, and no longer returns zeros above gradient
-arity 16; `define-library` and `import` resolve same-unit libraries on all three
-back ends; and `--shared-lib` links a real, C-ABI-correct shared library instead
-of exiting zero with no artifact.
+The organising principle across this release line is that a wrong answer must
+not be able to look like a right one, and that every assurance claim must be
+falsifiable by something the repository can run.
 
-**v1.3.3-evolve.** Alongside the quantum, post-quantum,
-dynamic-parameter, incremental-dataflow, and exact-rational features
-described elsewhere in this sheet, the release ran a silent-wrong-answer
-correctness campaign driven by two new generative exposure engines, both
-wired permanently into the ICC release oracle:
+**v1.3.5-evolve (current release).** The assurance surface this cycle is aimed
+at the gates themselves.
+
+- **A gate that cannot go red is treated as no gate.** A permanent,
+  deliberately-failing canary runs on every GPU-suite invocation and is required
+  to fail; if it ever comes back green the whole run goes red. The test
+  isolation layer fails a test that exits 0 without printing a recognized
+  verdict marker, every `tests/gpu/*.esk` file aggregates a failure counter and
+  exits on an explicit `PASS:`/`FAIL:` verdict line, and the Windows judge
+  applies the same canary inversion and evaluates every marker regex in
+  multiline mode at the one place those checks are made.
+- **Assurance wave 1.** Ledger-integrity and oracle-schema gates fail on a parse
+  error, a duplicate identifier, a missing required field, or a structurally
+  invalid criterion, and always report declared-versus-graded criteria counts per
+  oracle. All three ship a `--self-test` mode, are wired into `ctest`, and run in
+  a dedicated CI job.
+- **Assurance wave 2.** A self-verdict scanner fails a PASS-graded artifact
+  whose own text still reports a failure — including in manifest mode over every
+  VM-parity corpus output graded PASS by native/VM agreement, because comparing
+  two engines cannot see them print the identical self-reported failure line and
+  call that equal. Build-fingerprint checks record and check the compiler
+  binary's size, mtime, and SHA-256 alongside the checkout's git SHA, and fail
+  when a built binary predates its most recent build-relevant source change. A
+  results-schema check gives ICC real execution evidence for the doc-example
+  harness. An adversarial scenario suite exercises the gates under a dirty
+  worktree, a stale or rebuilt binary, a model-server outage, disk pressure, an
+  actually failing gate, and the requirement that every gate's `--self-test`
+  contract is wired somewhere real.
+- **Encoding checked at the byte level.** A gate reads every tracked
+  `*.ps1`/`*.psm1` file's own bytes and fails any that carry a byte at or above
+  `0x80` without a UTF-8 byte-order mark, reporting the exact `file:line:col`
+  and codepoint. Running the same bytes under a different default encoding is
+  precisely what hides this class of problem, so execution could not be the
+  check.
+- **Oracle severities cannot let absent evidence read as ready.** Every target
+  asserting a correctness or capability claim carries a high-severity criterion,
+  four targets keep an explicit and commented advisory exception, and an audit
+  gate fails if another target regresses into the shape where missing evidence
+  grades as a warning. Evidence staleness is a repo-side gate with a real
+  no-data verdict distinct from pass.
+- **Pillar harnesses are armed and machine-reachable.** Every finished trace is
+  mirrored unconditionally into the directory `icc readiness` reads. A
+  `pillars-fast` job runs the cheap gates on every pull request — depth
+  coverage, the ADR-0009 DBSP acceptance gate, the monotone-equivalence Taylor
+  gate, the AD validated-bounds gate, and VM parity — and a nightly workflow
+  runs the expensive sweeps: depth-parametric, differential, edge-matrix,
+  metamorphic, sanitizer-fuzz, the full smoke battery, and SICP. Every
+  trace-emitting harness shares a PASS/FAIL/INFRA/SKIP vocabulary with a real
+  fork-based timeout and a retry-once helper, so an infrastructure timeout
+  cannot publish itself as a code defect.
+- **The leak-detection lane reports what it finds.** LeakSanitizer's verdict
+  reaches the process exit status on every workload the project ships, including
+  the REPL, whose fast-exit path performs an explicit whole-process leak check
+  before exiting.
+- **Machine-checked structure.** `icc architecture-verify` resolves switch
+  dispatch through a libclang C/C++ semantic index rather than by token
+  matching, so an invariant is checked against the case arms the compiler sees;
+  the key-space-equality invariants are derived from source patterns rather than
+  hand-copied enumerations.
+
+**v1.3.4-evolve.** A consumer-hardening correctness wave with the same
+organising principle: an emitted compile-time error prevents artifact emission
+and execution; exactness is decided from an operand's runtime tag rather than a
+result's value shape on both engines; differentiation is exact at exact points
+and survives per-iteration nursery reclamation at any gradient arity;
+`define-library` and `import` resolve same-unit libraries on all three back
+ends; and `--shared-lib` links a real, C-ABI-correct shared library.
+
+**v1.3.3-evolve.** Two generative exposure engines joined the release oracle
+permanently:
 
 - **Generative multi-oracle differential harness**: deterministically grown
-  R7RS-subset programs cross-checked against chibi-scheme, JIT, AOT at
-  O0/O2, and the bytecode VM, plus metamorphic invariants. It exposed
-  several VM silent-miscompile classes — all fixed, including real
-  bignum-aware VM arithmetic and comparisons and exact large-integer
-  literals.
-- **Generative AD-vs-finite-difference adversarial oracle**: 147 probes /
-  436 component checks across 21 generated files under JIT and AOT, where a
-  zero AD gradient at a point where finite differences are nonzero is a
-  hard failure. It drove root fixes for every known silent-zero
-  gradient/Hessian path found by the harness.
-- **TCO for `cond`/`case`/`when`/`unless`/`and`/`or`** (#254):
-  self-tail-recursion in all six forms now compiles to real loop back-edges
-  (previously SIGBUS around 2M iterations unless written with `if`);
-  verified to 2,000,000 iterations, JIT and AOT.
-- **Scalable, stable `sort`/`filter`** (#244, #266): both are now
-  accumulator tail loops, and the list merge sort was replaced with a
-  stable bottom-up vector merge sort — 2M elements at ~362 MiB peak instead
-  of ~32 GB retained.
-- **Exact `input2` gradients for first-class losses and vector/learnable
-  gamma** (#229): the real fix for a v1.3.2-evolve CHANGELOG claim that an
-  adversarial audit found to be a no-op. See *Automatic differentiation*
-  above for the full description.
-- **Region-escape evacuator covers `PROMISE`** (ESH-0214e, #230) and the
-  bignum-rational and parameter-object write-barrier follow-ups (#265,
-  #267): closes the ESH-0214 series (a through e). Verified flat at
-  ~116 MB under `ESHKOL_ARENA_POISON=1` over escape-then-force for both
-  `delay` and `make-promise`.
-- **ICC oracle hardening** (#232): the `input2` and evacuator fixes above
-  are now load-bearing release gates, not one-off verifications — and, with
-  quantum enabled, Bell-pair (200/200), CHSH (S ≈ 2.86, gate 2.4 < S ≤ 2.95),
-  VQE-vs-exact-energy, and ML-KEM NIST-KAT gates join the matrix.
+  R7RS-subset programs cross-checked against chibi-scheme, the JIT, AOT at
+  O0/O2, and the bytecode VM, plus metamorphic invariants.
+- **Generative AD-versus-finite-difference adversarial oracle**: 147 probes and
+  436 component checks across 21 generated files under JIT and AOT, where a zero
+  AD gradient at a point where finite differences are nonzero is a hard failure.
+- **Self-tail recursion in `cond`/`case`/`when`/`unless`/`and`/`or`** compiles
+  to real loop back-edges, verified to 2,000,000 iterations under JIT and AOT.
+  <!-- source: tests/tco/cond_case_tail_test.esk (N = 2000000) -->
+- **Scalable, stable `sort`/`filter`**: accumulator tail loops and a stable
+  bottom-up vector merge sort, 2M elements at about 362 MiB peak.
+- **Region-escape evacuation covering `PROMISE`**, closing the ESH-0214 series,
+  verified flat at about 116 MB under `ESHKOL_ARENA_POISON=1` over
+  escape-then-force for both `delay` and `make-promise`.
+- **ICC oracle hardening**: with quantum enabled, Bell-pair (200/200), CHSH
+  (gate `2.4 < S <= 2.95`), VQE-versus-exact-energy, and ML-KEM NIST-KAT gates
+  join the matrix.
 
-**v1.3.2-evolve.** Deepened the memory-safety and concurrency work:
+**v1.3.2-evolve and v1.3.1-evolve.** Region-escape evacuation extended to the
+logic and workspace subtypes, a thread-safe region scope stack under
+`parallel-map` and future callbacks, per-iteration arena-scope reclamation
+extended from named-let loops to self-tail-recursive `define` loops including a
+catch-all guard body (1,000,000-iteration loop measured flat), and an iterative
+S-expression reader that reads a 20-million-element list without touching the
+native stack per element.
 
-- **Region-escape evacuator covers logic/workspace subtypes** (ESH-0214d,
-  #226): `SUBSTITUTION`/`FACT`/`KNOWLEDGE_BASE`/`FACTOR_GRAPH`/`WORKSPACE`
-  are deep-walked on escape instead of shallow-copied; `arena_destroy` is
-  poisoned under `ESHKOL_ARENA_POISON` so region use-after-free crashes
-  loudly.
-- **Thread-safe region scope stack** (#217): `parallel-map`/future
-  callbacks that opened a `with-region` no longer race on the shared
-  current-arena slot.
-- **Three deferred latent bugs triaged** (#215): ESH-0223 (named-let stack
-  overflow at high iteration counts), ESH-0227 (apply-loop SIGBUS),
-  ESH-0228 (`sleep-ms` argument type check).
-
-**v1.3.1-evolve.** Two fixes closed the gap between "correct" and "safe to
-run unattended" that the region-evacuator series above continues:
-
-- **Flat memory in long-running loops** (ESH-0214b): per-iteration
-  arena-scope reclamation, previously limited to named-let TCO loops,
-  now also covers self-tail-recursive `define` loops, including a
-  catch-all guard body in the loop. Verified on a 1,000,000-iteration
-  loop: RSS 1,369 MB (unbounded growth) → 224 MB (flat).
-- **Iterative S-expression reader** (ESH-0191): `read_list` no longer
-  recurses one native stack frame per list element. Verified: the prior
-  implementation crashed with SIGBUS reading a 20-million-element list;
-  the rewritten reader completes cleanly at the same size.
-
-**v1.3.0-evolve release gates** (green on the release SHA, and the base
-this release line builds on): ICC readiness oracle 100/100, trace-verified;
-CI 14/14 lanes including windows-arm64 lite/CUDA/XLA; SICP full-book gate
+**v1.3.0-evolve release gates** (green on the release SHA, and the base this
+release line builds on): ICC readiness oracle 100/100, trace-verified; CI green
+across every lane including windows-arm64 lite/CUDA/XLA; SICP full-book gate
 88/88 probes across all five chapters under both `-r` and AOT
-(`scripts/run_sicp_smoke.sh`); reference-Scheme differential oracle 34/34
-AGREE vs. chibi-scheme 0.12.0 on the P7a portable corpus
+(`scripts/run_sicp_smoke.sh`); reference-Scheme differential oracle 34/34 AGREE
+against chibi-scheme 0.12.0 on the portable corpus
 (`scripts/run_reference_differential.sh`).
 
-**Permanent adversarial-testing infrastructure**, shipped in v1.3.0-evolve
-and wired into the ICC release oracle rather than run once and discarded:
-a multi-path differential harness with a seeded fuzzer, a feature-pair
-edge matrix, an AD finite-difference oracle, a stress harness with
-RSS/time budgets, a VM-parity ratchet, depth-parametric sweeps, and the
-external reference-Scheme differential oracle. This is the same
-infrastructure whose adversarial audit found the v1.3.2-evolve `input2`
-overstatement above. See *docs/TESTING.md*.
+**Permanent adversarial-testing infrastructure**, shipped in v1.3.0-evolve and
+wired into the ICC release oracle rather than run once and discarded: a
+multi-path differential harness with a seeded fuzzer, a feature-pair edge
+matrix, an AD finite-difference oracle, a stress harness with RSS and time
+budgets, a VM-parity ratchet, depth-parametric sweeps, and the external
+reference-Scheme differential oracle. See *docs/TESTING.md*.
 
-**v1.2-line hardening** (carried forward, unchanged in this release):
-fourteen audit blockers and seven critical/high security fixes closed
-(subprocess shell-injection, Python-FFI AST-injection, integer-overflow
-guards on arena/KB/image, path-traversal, TOCTOU, ReDoS, SQL-injection
-guards, URL/header CRLF injection). See *docs/HARDENING.md* for the
-itemized table with severities and resolutions.
+**Security posture.** The full audit findings table — every item, its severity,
+and its resolution — is published in *docs/HARDENING.md*, and the disclosure
+process and supported-version table are in *SECURITY.md*. The subprocess surface
+is `posix_spawn` with argv arrays; the recommended interface for any command
+built from external input is the `-argv` family.
 
 ---
-
 ## Web platform
 
 Eshkol compiles to WebAssembly via `eshkol-run --wasm`, producing a
 self-contained module that does not fall through to a native link step.
-As of v1.3.3-evolve, `--wasm` output dead-strips unused stdlib, closing a
-26x size regression on a small program that genuinely uses the stdlib:
-5.57 MB → 60 KB (635 → 21 functions), with first-class functions and native
-homoiconic display preserved, and a CI size gate now guards the bound.
+`--wasm` output dead-strips unused stdlib: a small program that genuinely uses
+the stdlib emits a 60 KB module carrying 21 functions, with first-class
+functions and native homoiconic display preserved, and a CI size gate holds the
+bound.
 
 The project website at https://eshkol.ai is itself an Eshkol program,
 compiled to WebAssembly and served by GitHub Pages. The site embeds a
@@ -920,21 +1415,23 @@ ESKB binary format with LEB128 encoding and CRC32 checksums
 Two production execution backends share the same language semantics with
 independent value representations:
 
-- **LLVM native** (primary). 16-byte tagged values, ~30 codegen modules,
-  ~85,500 lines, the default for `eshkol-run`.
-- **Bytecode VM** (*lib/backend/eshkol_vm.c* plus its 32 *vm_\*.c* modules). A
+- **LLVM native** (primary). 16-byte tagged values, roughly thirty codegen
+  modules, the default for `eshkol-run`.
+- **Bytecode VM** (*lib/backend/eshkol_vm.c* plus its *vm_\*.c* modules). A
   register-plus-stack interpreter with 250+ native call IDs, ESKB binary file
   format (section-based, LEB128, CRC32). Invoked via `eshkol-run input.esk -B
-  output.eskb`. Coverage: arithmetic, closures, continuations, exception
-  handling, tensors, complex / rational / bignum, logic / inference /
-  workspace, hash tables, bytevectors, parameters, I/O. As of v1.3.3-evolve,
-  `make-parameter`/`parameterize` are genuine runtime dynamic parameter
-  objects — converters, a dynamic binding stack, correct unwinding — on both
-  the native and VM execution paths, replacing a parser-level closure
-  rewrite.
+  output.eskb`. Coverage: arithmetic, closures, multi-shot continuations,
+  exception handling, tensors, complex / rational / bignum, logic / inference /
+  workspace, hash tables, bytevectors, parameters, I/O.
+  `make-parameter`/`parameterize` are genuine runtime dynamic parameter objects
+  — converters, a dynamic binding stack, correct unwinding — on both the native
+  and VM execution paths. As of v1.3.5-evolve the VM reclaims region memory, and
+  `with-region`'s teardown is reached identically by lexical exit, by a `raise`
+  crossing the region, and by a continuation transfer out of it, so the
+  structured and unstructured surfaces cannot drift apart.
 
-The weight-matrix transformer (*lib/backend/weight_matrices.c*, ~7,500
-lines) is a third execution surface that exists for the SDNC paper and
+The weight-matrix transformer (*lib/backend/weight_matrices.c*) is a third
+execution surface that exists for the SDNC paper and
 the qLLM/transformer weight-loading pipeline. The strict-artefact contract
 is 123 of 123 traced programs verified three ways (reference interpreter =
 simulated transformer = matrix-based forward pass). Exports use the QLMW
@@ -1012,7 +1509,12 @@ link errors.
   on macOS, LLVM 21 ClangCL on Windows), Ninja recommended.
 - **Build**: `cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build`.
 - **Homebrew tap**: `brew tap tsotchke/eshkol && brew install eshkol`; the
-  tap formula carries the computed release SHA-256 after tagging.
+  tap formula carries the computed release SHA-256 after tagging, and installs
+  `FindEshkol.cmake` and `EshkolCompile.cmake` alongside the compiler.
+- **Embedding from CMake**: `find_package(Eshkol)` then link
+  `Eshkol::eshkol` — the imported target carries the runtime archive, the
+  stdlib object, and the platform frameworks, with no hand-written library
+  search in the consumer. macOS and Linux.
 
 ---
 
@@ -1022,7 +1524,7 @@ link errors.
 @software{eshkol2026,
   title    = {Eshkol: A Programming Language for Mathematical Computing},
   author   = {tsotchke},
-  version  = {1.3.4-evolve},
+  version  = {1.3.5-evolve},
   year     = {2026},
   url      = {https://github.com/tsotchke/eshkol}
 }


### PR DESCRIPTION
Refreshes the two tracked press files for v1.3.5-evolve against the release CHANGELOG and release notes. The lead is the release's own headline capability — a continuation captured on a compiled backend can be resumed after the procedure that captured it has already returned, on native JIT, native AOT and the bytecode VM alike — and every capability in the v1.3.5-evolve Added and Changed sections is covered at least once across the kit: the bytecode VM region evacuator and its stated Stage-1 scope, the new region runtime variables, mutual tail recursion in every tail-position spelling plus the tail-transfer dispatcher, the compiler-enforced AD dispatch registry and the exact geometric-bridge backwards, the embedding and Frechet-mean producers, the frontend node-identity substrate and its coverage gate, object-ABI stage 0, the canonical FindEshkol.cmake link contract, vertical-line symbol syntax, gensym on every engine, the public benchmark suite and the large-single-file compile bench, the PGO corpus smoke consumer, the GPU correctness gate and its must-fail canary, both assurance waves, the armed pillar harnesses, and the CI reporting changes. Every stated number carries an in-repo source in an HTML comment beside it and was re-verified against the worktree this cycle; line and file counts are dropped throughout, and the sheet's implementation table now names components and files rather than sizes. No files outside press/ are touched.