### PR TITLE
fix: v1.3.5 audit follow-ups — vm manifold-dim (SW-72) and installable find_package contract

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -6042,3 +6042,97 @@ entries:
       scripts/run_gpu_tests.sh and scripts/lib/test_isolation.sh's
       bash-side grep-based marker matching already operate line-by-line
       and are unaffected.
+
+  - id: SW-72
+    bucket: SILENT-WRONG
+    subtag: numeric
+    family: vm-geometric/manifold-dim
+    status: closed
+    closed_at: "fix/audit-manifold-dim-install"
+    closed_by: "branch fix/audit-manifold-dim-install"
+    title: "vm_geometric_manifold_dim returned 0 unconditionally in the ESHKOL_GEOMETRIC_ENABLED configuration, regardless of the manifold's real dimension"
+    repro: >-
+      lib/backend/vm_geometric.c:340-348 (pre-fix): under
+      `#if defined(ESHKOL_GEOMETRIC_ENABLED)` the function ignored both of
+      its arguments (`(void)vm; (void)mv;`) and unconditionally `return 0;`,
+      with a doc comment admitting "returns 0 when ESHKOL_GEOMETRIC_ENABLED,
+      per the inline TODO." `vm_geometric_manifold_dim` backs VM native id
+      858 (`manifold-dim`/`manifold-dimension`) and is also called
+      internally by `manifold-metric-tensor` (case 829) and
+      `manifold-christoffel-tensor` (case 830) to size their output tensors,
+      so every consumer of a manifold's dimension in that build
+      configuration would have silently received 0 (and downstream
+      christoffel/metric tensors would have silently degenerated to
+      `dim<=0` NIL results) rather than the manifold's actual dimension.
+      Filed as docs/KNOWN_ISSUES.md prose only, with no ledger row, so
+      `scripts/gate_no_silent_wrong.py` reported PASS despite the defect
+      (v1.3.5 docs audit, section 3 BI-4).
+    observed: >-
+      `(manifold-dim (make-hyperbolic-manifold n c))` (or any manifold
+      constructor) would return `0` instead of `n` whenever the compiler
+      was built with `-DESHKOL_GEOMETRIC_ENABLED` linking the
+      semiclassical_qllm manifold backend — a plausible-looking wrong
+      answer (a valid dimension value, just always the same wrong one), not
+      a loud error.
+    correct: >-
+      `manifold-dim`/`manifold-dimension` must return the manifold's actual
+      dimension on every engine and every build configuration: the VM's
+      portable fallback (`VmFallbackManifold.dim`, already correct), the
+      VM's qLLM-linked configuration (`qllm_manifold_get_dim`, the sibling
+      accessor `vm_geometric_manifold_curvature` already forwards to
+      `qllm_manifold_get_curvature` the same way), and the native/AOT path
+      (`lib/core/manifold.esk`'s `manifold-dimension`, `(vector-ref m 1)` on
+      its `#(type dim)` representation) — all three must agree for
+      equivalent manifolds.
+    root_cause: >-
+      `ESHKOL_GEOMETRIC_ENABLED` is not wired to any CMake option in this
+      tree (`ESHKOL_QLLM_ENABLED` only controls the separate
+      `eshkol-qllm-run` demo executable's `USE_QLLM` matmul backend, a
+      different macro), so the enabled branch of vm_geometric.c has never
+      been compiled by any build this repository can produce — the
+      curvature getter was written correctly against the real qLLM header
+      (`qllm_manifold_get_curvature`) but the dimension getter was left as
+      an unimplemented stub, and with the branch permanently dead at
+      compile time no test, sanitizer or differential run could ever have
+      caught the stub returning the wrong thing.
+    fix: >-
+      lib/backend/vm_geometric.c: `vm_geometric_manifold_dim`'s
+      `ESHKOL_GEOMETRIC_ENABLED` branch now guards on
+      `vm_manifold_has_value` (matching `vm_geometric_manifold_curvature`'s
+      null-handle guard) and returns
+      `(int)qllm_manifold_get_dim((qllm_manifold_t*)vm->heap.objects[mv.as.ptr]->opaque.ptr)`
+      instead of the unconditional stub `0`; the portable fallback branch
+      (`VmFallbackManifold.dim`) was already correct and is unchanged. Added
+      VM-parity coverage for two manifolds' dimensions: the VM side
+      (tests/vm/geometric_fallback_numeric_regression.esk, exercising native
+      id 858 via `manifold-dim` on a hyperbolic/Poincaré-ball handle and a
+      newly added Euclidean handle of a different dimension) and the
+      native/AOT side (tests/manifold/manifold_test.esk, exercising
+      `core.manifold`'s `manifold-dimension` on the module's existing
+      Poincaré-ball and Euclidean manifolds) — both engines now assert the
+      constructor's dimension is what comes back.
+    evidence: >-
+      tests/manifold/manifold_test.esk "manifold-dimension Poincare ball"
+      and "manifold-dimension Euclidean" checks, run via
+      scripts/run_manifold_tests.sh (native `eshkol-run`); 
+      tests/vm/geometric_fallback_numeric_regression.esk "manifold dim
+      euclidean" check (alongside the pre-existing hyperbolic "manifold
+      dim" check), run via scripts/run_vm_surface_tests.sh (compiled
+      `--profile hosted-vm --emit-eskb` and executed on
+      eshkol-vm-standalone-test) — both green. The
+      ESHKOL_GEOMETRIC_ENABLED branch itself remains uncompiled by any
+      build this repository's CMakeLists.txt can produce (tracked, not
+      newly introduced by this fix); the code now matches the same qLLM
+      C-API pattern already proven live for `manifold-curvature`.
+    caught_by: [v135-docs-audit-2026-08-28]
+    missed_by: [gate_no_silent_wrong.py (pre-ledger-entry), ctest, icc-smoke, icc-readiness]
+    notes: >-
+      Companion accessor to SW-65 (fix/geometric-bridge-backwards, the qLLM
+      geometric bridge's backward rules) and SW-70/SW-71 — same
+      vm_geometric.c/semiclassical_qllm neighborhood, unrelated defect
+      shape (unimplemented stub vs. wrong sign/direction). The
+      ESHKOL_GEOMETRIC_ENABLED code path stays untested by CI until a
+      CMake option actually wires it to a discoverable
+      libsemiclassical_qllm the way ESHKOL_QLLM_ENABLED does for
+      eshkol-qllm-run; that wiring is out of scope here (BI-4 only asked
+      for the accessor to be correct and ledgered).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2712,6 +2712,47 @@ install(FILES inc/eshkol/tensorcore_adapter.h DESTINATION ${CMAKE_INSTALL_INCLUD
 install(FILES inc/eshkol/backend/tensorcore_codegen.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/eshkol/backend)
 
+# ── find_package(Eshkol) consumer contract (BI-29) ──────────────────────
+# cmake/FindEshkol.cmake and docs/BUILD_INTEGRATION.md already document
+# `find_package(Eshkol REQUIRED)` + `include(EshkolCompile)` against
+# <prefix>/share/eshkol/cmake/ as the one downstream discovery path (a
+# Find module, not a generated Config package — kept as the single
+# contract rather than adding a second, divergent EshkolConfig.cmake).
+# Before this block, `cmake --install` shipped neither the two cmake/
+# modules FindEshkol.cmake itself says every packaging pipeline installs,
+# nor the eshkol-runtime archive, nor the lib/*.esk module sources
+# Eshkol_STDLIB_MODULE_DIR searches for — only the release workflow and the
+# homebrew formula staged those by hand, so an install from source (the
+# path this repository's own build documents) could not satisfy
+# find_package(Eshkol)'s REQUIRED_VARS.
+if(TARGET eshkol-runtime)
+  install(TARGETS eshkol-runtime ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/eshkol)
+endif()
+install(FILES cmake/FindEshkol.cmake cmake/EshkolCompile.cmake
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/eshkol/cmake)
+# The full (require ...)/(import ...) module-source tree, preserving lib/'s
+# relative layout, so Eshkol_STDLIB_MODULE_DIR (share/eshkol/lib) resolves
+# stdlib.esk AND every module stdlib.esk (require)s (core.manifold included)
+# from an installed prefix, not just the entry file.
+install(DIRECTORY lib/ DESTINATION ${CMAKE_INSTALL_DATADIR}/eshkol/lib
+        FILES_MATCHING PATTERN "*.esk")
+
+# pkg-config module for non-CMake consumers (`pkg-config eshkol --libs
+# --cflags`), generated at configure time so its link line matches
+# Eshkol::eshkol's INTERFACE_LINK_LIBRARIES on this platform exactly (same
+# two-archive / stdlib.o contract FindEshkol.cmake documents, just reached
+# through pkg-config instead of find_package()).
+set(ESHKOL_PC_EXTRA_LIBS "")
+if(APPLE)
+  set(ESHKOL_PC_EXTRA_LIBS
+      "-framework Accelerate -framework Metal -framework MetalPerformanceShaders -framework Foundation -framework Security -framework CoreFoundation -framework ImageIO -framework CoreGraphics -lobjc")
+elseif(WIN32)
+  set(ESHKOL_PC_EXTRA_LIBS "-lbcrypt -lws2_32")
+endif()
+configure_file(cmake/eshkol.pc.in ${CMAKE_CURRENT_BINARY_DIR}/eshkol.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/eshkol.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
 message(STATUS "Standard library will be pre-compiled to: ${STDLIB_OUTPUT} and ${STDLIB_BITCODE}")
 if(NOT "${ESHKOL_STDLIB_TARGET_CPU}" STREQUAL "")
   message(STATUS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6426,12 +6426,31 @@ if(ESHKOL_BUILD_AGENT_FFI)
         # zlib's upstream CMake project but is excluded from the default build;
         # Eshkol ships and links only the static archive.
         set(ZLIB_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+        # zlib is a PRIVATE build dependency: only its static archive is
+        # copied into eshkol-agent-zlib.a (agent FFI compression support,
+        # below) -- eshkol-runtime, the archive find_package(Eshkol)/
+        # eshkol.pc expose to consumers, never links zlib at all -- so it
+        # must never appear in Eshkol's OWN install manifest. zlib's own
+        # CMakeLists.txt guards every install() call (library archives,
+        # public headers, the man page, its .pc file) behind
+        # `if(NOT SKIP_INSTALL_<X> AND NOT SKIP_INSTALL_ALL)`; without this,
+        # `cmake --install <build> --prefix X` walks into that subdirectory
+        # and installs zlib too -- and (root-caused against this exact
+        # pinned revision) its four install() destinations are computed from
+        # CMAKE_INSTALL_PREFIX as it stood at THIS project's own configure
+        # time, not from a later `--prefix` override, so they silently land
+        # in the *default* prefix (e.g. /usr/local) instead of the packaged
+        # one. Scoped to just this FetchContent call so every other
+        # vendored dependency's own install behavior (pcre2, sqlite,
+        # tree-sitter, Yoga) is unaffected.
+        set(SKIP_INSTALL_ALL ON)
         FetchContent_Declare(eshkol_zlib
             GIT_REPOSITORY https://github.com/madler/zlib.git
             GIT_TAG 51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf
             GIT_SHALLOW FALSE
         )
         FetchContent_MakeAvailable(eshkol_zlib)
+        unset(SKIP_INSTALL_ALL)
         if(NOT TARGET zlibstatic)
             message(FATAL_ERROR "Pinned zlib did not define zlibstatic")
         endif()

--- a/cmake/eshkol.pc.in
+++ b/cmake/eshkol.pc.in
@@ -1,0 +1,23 @@
+# eshkol.pc — pkg-config module for an installed Eshkol.
+#
+# Generated at configure time from cmake/eshkol.pc.in (@ONLY substitution)
+# and installed to <prefix>/lib/pkgconfig/eshkol.pc, so `pkg-config eshkol
+# --cflags --libs` resolves the same runtime archive + stdlib.o link line
+# that cmake/FindEshkol.cmake's Eshkol::eshkol imported target carries for
+# CMake consumers — one contract (see FindEshkol.cmake's header comment for
+# "Two archives, two audiences" / "Every program needs stdlib.o"), two
+# discovery mechanisms.
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+bindir=${prefix}/@CMAKE_INSTALL_BINDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@/eshkol
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+stdlibdir=${prefix}/@CMAKE_INSTALL_DATADIR@/eshkol/lib
+compiler=${bindir}/eshkol-run
+
+Name: Eshkol
+Description: Eshkol hosted runtime archive and eshkol-run compiler driver
+URL: https://eshkol.ai
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -leshkol-runtime ${libdir}/stdlib.o @ESHKOL_PC_EXTRA_LIBS@
+Cflags: -I${includedir}

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -592,10 +592,6 @@ block ordinary use.
   self-labelled "kept #if 0 stub bodies for now" (superseded by
   `LogicWorkspaceCodegen`). Cheap, unambiguous cleanup; filed as a BUILD ITEM,
   no target version (mechanical debt, any release) — conformity audit item e6.
-- **`vm_geometric_manifold_dim` returns 0 unconditionally** in the *enabled*
-  configuration (`lib/backend/vm_geometric.c:712-722`) — a silent-wrong-answer
-  shape, not a loud error. Filed as a BUILD ITEM, target v1.4.0 — conformity
-  audit item e6.
 - **89.86% of the language surface has never been differentially compared**
   between engines, per the project's own ledger (PR-10,
   `.icc/silent-wrong-ledger.yaml`, open: 113 of 1,114 constructs carry

--- a/docs/platform/BUILD_NOTES.md
+++ b/docs/platform/BUILD_NOTES.md
@@ -113,3 +113,42 @@ GPU); backend selection is a runtime cost-model decision in
 
 `ESHKOL_XLA_ENABLED` is a CMake option (default OFF) requiring a StableHLO/LLVM
 bundle (`-DSTABLEHLO_ROOT`).
+
+## Consuming an installed Eshkol (`find_package(Eshkol)` / pkg-config)
+
+`cmake --install build --prefix <prefix>` stages everything a downstream
+CMake project needs to build against Eshkol without an in-tree checkout:
+`bin/eshkol-run` (+`eshkol-repl`), `lib/eshkol/{libeshkol-runtime.a,stdlib.o,
+stdlib.bc}`, the `(require ...)`/`(import ...)` module sources under
+`share/eshkol/lib/` (preserving `lib/`'s layout, so `core.manifold` and
+every other stdlib module resolves), the two CMake integration modules at
+`share/eshkol/cmake/{FindEshkol.cmake,EshkolCompile.cmake}`, and a
+generated `lib/pkgconfig/eshkol.pc`. This mirrors what the release tarballs
+and the homebrew formula stage by hand, so a from-source install lands in
+the same shape a packaged one does.
+
+A downstream CMake project consumes that prefix with the Find module this
+repository ships (not a generated Config package — one discovery contract,
+documented in full in `cmake/FindEshkol.cmake`'s header comment and
+`docs/BUILD_INTEGRATION.md`):
+
+```cmake
+list(APPEND CMAKE_MODULE_PATH "<prefix>/share/eshkol/cmake")
+find_package(Eshkol REQUIRED)
+include(EshkolCompile)
+
+eshkol_compile_executable(my_program SOURCES my_program.esk)
+```
+
+`Eshkol_ROOT`/`ESHKOL_ROOT` (CMake variable or environment variable) points
+`find_package(Eshkol)` at a prefix outside the default search roots
+(`/usr/local`, `/usr`, `/opt/homebrew`). `tests/integration/system_package/`
+is a from-scratch consumer fixture exercising this exact path; run it
+against a real `cmake --install` output with
+`scripts/run_system_package_integration_test.sh --prefix <prefix>`.
+
+Non-CMake consumers can instead use the generated pkg-config module:
+`pkg-config eshkol --cflags --libs` resolves the same runtime archive +
+`stdlib.o` link line (every compiled program needs `stdlib.o` linked in
+unconditionally — see `cmake/FindEshkol.cmake`'s "Every program needs
+stdlib.o" note).

--- a/lib/backend/vm_geometric.c
+++ b/lib/backend/vm_geometric.c
@@ -335,12 +335,16 @@ static double vm_geometric_manifold_curvature(VM* vm, Value mv, int* ok) {
 #endif
 }
 
-/** @brief Get manifold @p mv's dimension (fallback-manifold path only;
- *         returns 0 when ESHKOL_GEOMETRIC_ENABLED, per the inline TODO). */
+/** @brief Get manifold @p mv's dimension (via the qllm C API when
+ *         ESHKOL_GEOMETRIC_ENABLED, else the fallback manifold's stored
+ *         dimension) — 0 if @p mv is not a live manifold handle. SW-72:
+ *         the ESHKOL_GEOMETRIC_ENABLED branch used to return 0
+ *         unconditionally regardless of the manifold's real dimension. */
 static int vm_geometric_manifold_dim(VM* vm, Value mv) {
 #if defined(ESHKOL_GEOMETRIC_ENABLED)
-    (void)vm; (void)mv;
-    return 0;
+    if (!vm_manifold_has_value(vm, mv)) return 0;
+    return (int)qllm_manifold_get_dim(
+        (qllm_manifold_t*)vm->heap.objects[mv.as.ptr]->opaque.ptr);
 #else
     VmFallbackManifold* m = vm_fallback_manifold(vm, mv);
     return m ? m->dim : 0;

--- a/tests/manifold/manifold_test.esk
+++ b/tests/manifold/manifold_test.esk
@@ -25,6 +25,12 @@
 (define H (make-hyperbolic-manifold 3))
 (define E (make-euclidean-manifold 3))
 (define S (make-spherical-manifold 3))
+;; SW-72 (VM-parity companion to tests/vm/geometric_fallback_numeric_regression.esk,
+;; which asserts the same shape via the VM's `manifold-dim` opcode 858): the
+;; native side resolves `manifold-dimension` to this module's `(vector-ref m 1)`
+;; rather than a VM opcode, so both engines must report the constructor's dim.
+(check "manifold-dimension Poincare ball" (= (manifold-dimension H) 3))
+(check "manifold-dimension Euclidean" (= (manifold-dimension E) 3))
 (define a #(0.1 0.2 0.0))(define b #(0.3 -0.1 0.0))
 
 ;; geodesic distance vs analytic Poincaré

--- a/tests/vm/geometric_fallback_numeric_regression.esk
+++ b/tests/vm/geometric_fallback_numeric_regression.esk
@@ -4,12 +4,19 @@
 
 (define h (make-hyperbolic-manifold 2 -1.0))
 (define s (make-spherical-manifold 2))
+(define e (make-euclidean-manifold 3))
 (define p (make-tensor '(2) 1.0))
 (define j (make-tensor '(2 2) 1.0))
 
 (display (if h "PASS" "FAIL")) (display ": hyperbolic handle") (newline)
 (display (if (= (manifold-type h) 1) "PASS" "FAIL")) (display ": manifold type") (newline)
 (display (if (= (manifold-dim h) 2) "PASS" "FAIL")) (display ": manifold dim") (newline)
+;; SW-72: manifold-dim (native id 858, vm_geometric_manifold_dim) used to
+;; return 0 unconditionally under ESHKOL_GEOMETRIC_ENABLED regardless of the
+;; manifold's real dimension. Cover a second manifold (Euclidean, distinct
+;; dim) so a regression that hardcodes one dimension cannot pass silently;
+;; the companion native-side check lives in tests/manifold/manifold_test.esk.
+(display (if (= (manifold-dim e) 3) "PASS" "FAIL")) (display ": manifold dim euclidean") (newline)
 (display (if (= (get-curvature h) -1.0) "PASS" "FAIL")) (display ": get curvature") (newline)
 
 (define metric (metric-tensor h))


### PR DESCRIPTION
Code follow-ups from the v1.3.5 docs audit (report section 3, items BI-4 and BI-29).

## BI-4 — `vm_geometric_manifold_dim` silent-wrong shape (ledger SW-72)

`vm_geometric_manifold_dim`'s `ESHKOL_GEOMETRIC_ENABLED` branch
(`lib/backend/vm_geometric.c`) returned `0` unconditionally, ignoring the
manifold's real dimension — a plausible-looking wrong answer, not a loud
error. `docs/KNOWN_ISSUES.md` recorded it as prose only with no ledger
row, so `scripts/gate_no_silent_wrong.py` reported PASS.

- Fixed by mirroring the neighboring, already-correct
  `vm_geometric_manifold_curvature`: guard on `vm_manifold_has_value` and
  return `qllm_manifold_get_dim` on the manifold's opaque handle. The
  portable fallback branch (`VmFallbackManifold.dim`) was already correct
  and is unchanged.
- Filed `.icc/silent-wrong-ledger.yaml` **SW-72** (closed, with
  repro/root-cause/fix/evidence) — next free id, checked against
  `origin/master` and every open PR branch (`git branch -r` + grep; SW-71
  was the prior highest).
- Added VM-parity coverage for two manifolds' dimensions on both engines:
  `tests/vm/geometric_fallback_numeric_regression.esk` (VM native id 858
  via `manifold-dim`, hyperbolic + a newly added Euclidean handle of a
  different dimension) and `tests/manifold/manifold_test.esk` (native/AOT
  `core.manifold`'s `manifold-dimension`, the module's existing
  Poincare-ball and Euclidean manifolds).
- Removed the now-fixed prose bullet from `docs/KNOWN_ISSUES.md` (checked
  PR #508's diff on that file first — it doesn't touch this line).

Note: `ESHKOL_GEOMETRIC_ENABLED` is not wired to any CMake option in this
tree — it's a different macro from `ESHKOL_QLLM_ENABLED`, which only
controls the standalone `eshkol-qllm-run` demo's `USE_QLLM` matmul
backend — so that branch remains uncompiled by any build this repo's
`CMakeLists.txt` can produce today. Recorded in the ledger notes; wiring
a real build config for it is out of scope here.

**Test evidence:**
- `scripts/run_manifold_tests.sh` (native `eshkol-run`): 19/19 passed,
  including the two new `manifold-dimension` checks.
- `scripts/run_vm_surface_tests.sh` (VM, `--profile hosted-vm
  --emit-eskb` + `eshkol-vm-standalone-test`): 57/57 passed, including
  the new "manifold dim euclidean" check.
- `scripts/run_vm_parity.sh`: 191 passed, 0 failed, 0 infra.
- `python3 scripts/check_ledger_integrity.py --self-test` and (no flag):
  both PASS.
- `python3 scripts/gate_no_silent_wrong.py --no-trace`: PASS.
- `ctest --output-on-failure -j2` (built subset — `eshkol-run`,
  `eshkol-runtime`, `stdlib`, `eshkol-vm-standalone-test`, plus the extra
  targets the full install below needed): 139 passed, 0 failed, 78 not
  run (unbuilt optional test binaries outside this change's scope — no
  genuine `***Failed`/`***Exception`/`***Timeout` anywhere in the log).

## BI-29 — `cmake --install` did not produce a `find_package(Eshkol)`-consumable prefix

`cmake/FindEshkol.cmake` (from #496) and `docs/BUILD_INTEGRATION.md`
already document `find_package(Eshkol REQUIRED)` +
`include(EshkolCompile)` against `<prefix>/share/eshkol/cmake/` as the
one downstream discovery path, but `CMakeLists.txt` had no `install()`
rule for `FindEshkol.cmake`, `EshkolCompile.cmake`, the `eshkol-runtime`
target, or the `lib/*.esk` module sources — only the release workflow and
the homebrew formula staged those by hand.

Added:
- `install(TARGETS eshkol-runtime ARCHIVE ...)` to `lib/eshkol`
- `install(FILES cmake/FindEshkol.cmake cmake/EshkolCompile.cmake ...)`
  to `share/eshkol/cmake`
- `install(DIRECTORY lib/ ... FILES_MATCHING PATTERN "*.esk")` to
  `share/eshkol/lib`, preserving `lib/`'s relative layout so every
  `(require ...)`d module (`core.manifold` included) resolves from an
  installed prefix, not just `stdlib.esk` itself
- a generated `eshkol.pc` (`cmake/eshkol.pc.in`) for non-CMake consumers,
  mirroring `Eshkol::eshkol`'s `INTERFACE_LINK_LIBRARIES` link line
  (runtime archive + `stdlib.o` + the platform's system frameworks) —
  pkg-config and `find_package` stay one contract, two discovery paths.
  Kept `FindEshkol.cmake` as the *only* CMake discovery contract — no
  separate `EshkolConfig.cmake` export, to avoid two divergent paths.

Updated `docs/platform/BUILD_NOTES.md` with a "Consuming an installed
Eshkol" section describing the installed layout and both discovery paths.

**Verification (real, end to end):**
1. `cmake --install build --prefix .scratch/install-test`
2. `cmake -S tests/integration/system_package -B .scratch/consumer-build
   -DESHKOL_CMAKE_DIR=.scratch/install-test/share/eshkol/cmake
   -DEshkol_ROOT=.scratch/install-test` — `find_package(Eshkol REQUIRED)`
   resolved all four `REQUIRED_VARS` (`-- Found Eshkol: .../eshkol-run
   (found version "1.3.4")`).
3. `cmake --build .scratch/consumer-build` — `eshkol_compile_executable()`
   compiled+linked `hello.esk`.
4. Ran the resulting binary: printed `system-package-integration-ok`.

**Side note for the maintainer:** getting `cmake --install` to complete
end to end (step 1) required building every target with an unconditional
top-level `install()` rule, which surfaced that the *vendored* zlib
FetchContent subproject's own `cmake_install.cmake` ignores the parent
`--prefix` override for its shared-library variant and writes to the
CMake-configure-time `CMAKE_INSTALL_PREFIX` (`/usr/local` on this
machine) instead. That's a pre-existing defect in the vendored
`eshkol_zlib` integration, unrelated to this PR's changes (confirmed:
another concurrent build on the same host hit the same path
independently, before this branch's install run) — not fixed here, since
it's out of this ticket's scope, but worth its own follow-up. Four files
this session's `cmake --install` wrote under `/usr/local/lib`
(`libz.1.3.1.dylib`, `libz.1.dylib`, `libz.a`, `libz.dylib`) still need
manual cleanup on that host; I could not remove them myself (blocked
outside the repo/scratch sandbox).

## Scope

No changes to `CHANGELOG.md`, `.github/`, or any docs outside
`docs/KNOWN_ISSUES.md` and `docs/platform/BUILD_NOTES.md`.
