### PR TITLE
fix(vm): compile the geometric path — Riemannian builtins no longer fall back to Euclidean stubs (SW-73)

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -6042,3 +6042,197 @@ entries:
       scripts/run_gpu_tests.sh and scripts/lib/test_isolation.sh's
       bash-side grep-based marker matching already operate line-by-line
       and are unaffected.
+
+  - id: SW-73
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "fix/vm-geometric-enabled"
+    closed_by: "branch fix/vm-geometric-enabled"
+    title: "the VM's Riemannian geometry builtins computed their EUCLIDEAN counterparts on every shipped build: geodesic-distance was the L2 chord, mobius-add was vector addition, parallel-transport was the identity, exp/log maps were +/-, each accepting a curvature argument it discarded"
+    mechanism: >-
+      lib/backend/vm_geometric.c carries two dispatch bodies for the same 62
+      builtin names (ids 804-861), selected by ESHKOL_GEOMETRIC_ENABLED. The
+      `#if defined` body calls out to libsemiclassical_qllm, an out-of-tree
+      library. The `#if !defined` body is a self-contained "portable
+      constant-curvature fallback".
+
+      NO TARGET IN THE REPOSITORY DEFINED THAT MACRO, and until this branch
+      nothing in the build system could: there was no option, no
+      target_compile_definitions, no cache variable — `grep -rn
+      ESHKOL_GEOMETRIC_ENABLED` found hits only inside vm_geometric.c itself.
+      MEASURED while writing this entry: the linked-library body does not even
+      COMPILE against a current libsemiclassical_qllm. A syntax-only pass of
+      lib/backend/eshkol_vm.c with -DESHKOL_GEOMETRIC_ENABLED and that library's
+      include directory reports 19 errors inside vm_geometric.c — changed
+      arities across qllm_hyperbolic_exp_map/_log_map/_distance/
+      _parallel_transport/_mobius_add/_mobius_scalar, qllm_hyperbolic_project
+      now taking a qllm_tensor_t* where the call passes a float*, and the
+      SO(3)/SE(3) arms naming types the library no longer declares. So the
+      unreachable body was not a working implementation waiting to be switched
+      on; it was stale against the API it names, which is why "just define the
+      macro" was never the fix.
+      So the portable body was the one every CI lane, every release binary and
+      the WASM playground compiled, and the linked-library body was unreachable
+      from every configuration of this repository. That is a defensible
+      arrangement for an out-of-tree dependency; what made it a silent-wrong is
+      what the portable body actually computed.
+
+      It computed the FLAT answer under the curved name, for every value of the
+      curvature argument:
+
+        hyperbolic-exp-map / manifold-exp-map / retraction (809, 842)
+            base + tangent
+        hyperbolic-log-map / manifold-log-map (810)
+            point - base
+        spherical-log / spherical-log-map (822)
+            point - base
+        spherical-exp / spherical-exp-map (821)
+            normalize(base + tangent) — a retraction, right geodesic, wrong arc
+            length (atan|v| instead of |v|)
+        geodesic-distance / manifold-distance / poincare-distance (811, 816)
+            the L2 distance
+        parallel-transport / manifold-parallel-transport / vector-transport
+        (812, 843)
+            the identity on v, with the two endpoints popped and discarded
+        mobius-add (814)
+            x + y
+        mobius-scalar-mul (815)
+            r * x
+        manifold-project (813)
+            a copy
+        riemannian-grad (841)
+            a copy of the Euclidean gradient, with the point discarded
+        riemannian-sgd-step (839)
+            point - lr*grad
+        riemannian-adam-step / riemannian-adam-step! (840, 861)
+            point + adam_delta, an ambient vector addition
+        geodesic-attention-scores / geodesic-attention-forward (844, 847)
+            scored by the ambient L2 distance
+        exterior-derivative (835)
+            a zero tensor of the input's shape
+        hodge-star (836)
+            its argument, unchanged
+
+      Every one of these ops except 821/822/835/836 ACCEPTS A CURVATURE
+      ARGUMENT AND DROPPED IT. That is the same class the Frechet mean carried
+      before it was fixed, and inc/eshkol/backend/frechet_mean_core.h states it
+      exactly: "A result that carries a curvature parameter it ignores is the
+      plausible-wrong-number case: nothing in the output shows the argument was
+      dropped." A Euclidean number returned under the name geodesic-distance is
+      not an approximation of the geodesic distance — on the Poincare ball the
+      chord is bounded by the ball diameter while the geodesic distance
+      diverges at the boundary, so the two disagree without bound.
+
+      This is the FORWARD half of the surface SW-70 records the backward half
+      of. SW-70 found that AD_NODE_HYPERBOLIC_DISTANCE, AD_NODE_POINCARE_EXP_MAP,
+      AD_NODE_POINCARE_LOG_MAP and AD_NODE_GEODESIC_ATTENTION propagated exactly
+      0.0 through eshkol_tensor_backward_dispatch. The same four operations, on
+      the VM engine, were also returning the wrong VALUE — so a program using
+      them got a Euclidean answer and, if it differentiated, a zero gradient of
+      it.
+    repro: >-
+      tests/vm/geometric_riemannian_surface_regression.esk, run by
+      scripts/run_vm_surface_tests.sh (picked up by that script's
+      tests/vm/*_surface_regression.esk glob and by
+      scripts/language_coverage.py's CI_VM_SURFACE_GLOBS).
+
+      The headline case, measured: two points of the unit Poincare ball one
+      tenth of a unit inside the boundary,
+
+        (geodesic-distance #tensor(0.9 0.0) #tensor(-0.9 0.0) -1.0)
+
+      The correct answer is 4 artanh(0.9) = 5.8888779583328814. The op
+      returned 1.8, the L2 chord — a factor of 3.27 low, with no diagnostic and
+      exit 0, and the error is unbounded as the points approach the boundary.
+    observed: >-
+      geodesic-distance/poincare-distance at K = -1 returned the L2 chord
+      (1.8 where the geodesic distance is 5.8888779583328814); mobius-add
+      returned a COMMUTATIVE result (x+y), erasing the gyrogroup structure the
+      name denotes; parallel-transport returned its input unchanged, which is
+      the assertion that the holonomy of the connection is trivial, i.e. that
+      the manifold is flat; riemannian-grad returned the Euclidean gradient
+      unscaled, asserting the metric is the identity; riemannian-sgd-step and
+      riemannian-adam-step produced iterates that leave the ball entirely for a
+      large enough step. All silently, exit 0.
+
+      The committed regressions had ENCODED the wrong answers as expectations:
+      tests/vm/geometric_fallback_numeric_regression.esk asserted
+      (riemannian-sgd-step p p 0.25 -1.0) = 0.75 with p = (1.0, 1.0) — a point
+      of norm sqrt(2), which is not in the Poincare ball of radius 1 at all —
+      and tests/vm/riemannian_adam_state_regression.esk asserted the ambient
+      Adam update at curvature -1.0 for the same out-of-ball point. Both passed
+      only because the ops ignored the curvature.
+    correct: >-
+      The closed forms of constant-curvature geometry, in f64, with the
+      curvature argument read as the SECTIONAL curvature K: K < 0 is the
+      Poincare ball of radius 1/sqrt(-K), K = 0 is Euclidean (where the flat
+      forms are EXACTLY right, which is why the old bodies were correct for
+      that one value and wrong for every other), K > 0 is the sphere of radius
+      1/sqrt(K). Where a closed form does not exist for the data the op is
+      given, a loud named refusal — never a flat number under a curved name.
+    observed_after: >-
+      inc/eshkol/backend/riemannian_core.h — Mobius addition and scalar
+      multiplication, exp and log maps, geodesic distance, parallel transport
+      (via the gyration lambda_x/lambda_y * gyr[y,-x]v), projection, and the
+      Euclidean-to-Riemannian gradient conversion, for all three curvature
+      signs. The formulas are the ones lib/bridge/qllm_bridge.cpp already
+      computes for the AD tape (ad_hyperbolic_distance, ad_poincare_exp_map,
+      ad_poincare_log_map, ad_geodesic_attention), so the VM engine and the AD
+      bridge now agree on what these operations mean.
+
+      Measured after the fix, same call: 5.8888779583328814, matching
+      4 artanh(0.9) to 1e-15. mobius-add is measurably non-commutative
+      (x(+)y = (-0.23947750362844705, 0.12336719883889698) vs
+      y(+)x = (-0.24238026124818576, 0.11756168359941946)); parallel transport
+      moves (0.2, 0.4) to (0.16314844574304069, 0.31281259638016379) while
+      preserving Riemannian length to 1e-15; every op reduces EXACTLY to its
+      flat form at K = 0.
+
+      exterior-derivative and hodge-star are NOT implemented on the VM engine
+      and now raise a catchable condition naming themselves. Neither can be
+      computed from what it is handed: a form's coefficient array at a single
+      point carries no derivative information, and a flat coefficient array
+      does not record the degree the star depends on. Refusing names the
+      missing input; returning zeros asserted that every form is closed, and
+      returning the argument asserted that the star is trivial.
+    fixed_by: >-
+      branch fix/vm-geometric-enabled. inc/eshkol/backend/riemannian_core.h is
+      the single source of the closed forms (a header for the same reason
+      frechet_mean_core.h is one: vm_geometric.c is a unity-build include and
+      eshkol-vm-standalone-test compiles it as one TU, so there is no object
+      file to call into). CMakeLists.txt gains ESHKOL_GEOMETRIC_QLLM, which is
+      the first way any configuration of this repository can select the
+      linked-library body at all; it is OFF by default and FATAL_ERRORs at
+      configure time when the headers it names are absent, so it cannot
+      silently degrade to the portable body and report success.
+    evidence: >-
+      tests/vm/geometric_riemannian_surface_regression.esk (42 assertions, each
+      chosen so the flat answer FAILS it: near-boundary geodesic distance,
+      mobius non-commutativity, exp/log mutual inversion, the Riemannian length
+      identity lambda_x|log_x(y)| = d(x,y), transport-is-not-the-identity
+      together with transport-preserves-Riemannian-length, the K = 0
+      reductions, the sphere branch, and the refusal paths). Plus the two
+      pre-existing regressions repaired to stop asserting the Euclidean answers:
+      tests/vm/geometric_fallback_numeric_regression.esk and
+      tests/vm/riemannian_adam_state_regression.esk.
+    caught_by: [direct-measurement, docs-audit-pr-509]
+    missed_by: [run_vm_surface_tests.sh (pre-fix), run_vm_parity.sh, icc-readiness]
+    notes: >-
+      The parity differential could not have found this and still cannot: these
+      62 names are on the VM surface ONLY (they are absent from
+      lib/backend/llvm_codegen.cpp and from the native builtin closure table in
+      lib/backend/eshkol_compiler.c), so tests/vm_parity's native-vs-VM axes
+      never compare them and no PARITY.tsv row governs them. The gate that had
+      to catch it is the self-checking one — a probe that asserts against
+      MATHEMATICS inside a single run, which is the property
+      scripts/run_vm_surface_tests.sh's own header calls out. The pre-existing
+      geometric probes were arity/resolution probes ("these names resolve and
+      are stack-safe"), which is a real property and not this one.
+
+      PR #509's docs/reference/stdlib/geometry.md described the flat behaviour
+      accurately rather than overclaiming it — the page says in as many words
+      which ops "are flat (Euclidean) approximations that ignore the curvature
+      argument they accept". Documenting a silent-wrong precisely does not stop
+      it being one: the caller reading `(geodesic-distance x y -1.0)` in a
+      program still gets a number that is not the geodesic distance. That
+      section of the page is updated to describe what the code now computes.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,59 @@ option(ESHKOL_QLLM_ENABLED
 set(ESHKOL_QLLM_ROOT "" CACHE PATH
     "Root of an installed libsemiclassical_qllm; expects include/semiclassical_qllm and build/lib or lib")
 
+# lib/backend/vm_geometric.c carries two dispatch bodies for the same 62 VM
+# builtins, selected by ESHKOL_GEOMETRIC_ENABLED.  Until this option existed NO
+# target defined that macro and nothing in the build system could: the
+# linked-library body was unreachable from every configuration of this
+# repository, so the portable body was the one every CI lane, every release
+# binary and the WASM playground compiled.  That is a supportable arrangement --
+# semiclassical_qllm is an out-of-tree library and Eshkol cannot require it --
+# but it has to be a CHOICE the build makes and states, not an accident of a
+# macro nobody defines.  The portable body is therefore the SHIPPED
+# implementation and is held to the same closed forms as the linked one
+# (inc/eshkol/backend/riemannian_core.h, gated by
+# tests/vm/geometric_riemannian_surface_regression.esk).
+#
+# Turning this ON is an out-of-tree opt-in.  It is refused at configure time
+# rather than at compile time when the headers are not where it says, because a
+# silent fall-through to the portable body would make the option a no-op that
+# reports success.
+#
+# MEASURED, so that nobody turns this on expecting it to work: against a current
+# libsemiclassical_qllm checkout the linked-library body does NOT COMPILE.  A
+# syntax-only pass of lib/backend/eshkol_vm.c with -DESHKOL_GEOMETRIC_ENABLED and
+# that library's include directory reports 19 errors inside vm_geometric.c alone
+# -- changed arities on qllm_hyperbolic_exp_map / _log_map / _distance /
+# _parallel_transport / _mobius_add / _mobius_scalar, qllm_hyperbolic_project now
+# taking a qllm_tensor_t* where the call passes a float*, and the SO(3)/SE(3) arms
+# naming types (qllm_so3_algebra_t, qllm_so3_t) the library no longer declares.
+# That is the real reason this path was never selectable: it is not merely
+# unselected, it is stale against the API it names, and a build system option
+# could not have hidden that.  Bringing it back is its own change against the
+# current qLLM ABI; the portable body is what this repository tests and ships.
+option(ESHKOL_GEOMETRIC_QLLM
+       "Dispatch the VM geometric builtins (ids 804-861) through libsemiclassical_qllm instead of the portable closed forms (defines ESHKOL_GEOMETRIC_ENABLED)" OFF)
+
+if(ESHKOL_GEOMETRIC_QLLM)
+    if(NOT ESHKOL_QLLM_ROOT)
+        message(FATAL_ERROR
+            "ESHKOL_GEOMETRIC_QLLM=ON needs ESHKOL_QLLM_ROOT set to a root "
+            "containing include/semiclassical_qllm/manifold.h. Leave it OFF to "
+            "use the portable closed-form geometry, which is what every shipped "
+            "build uses.")
+    endif()
+    if(NOT EXISTS "${ESHKOL_QLLM_ROOT}/include/semiclassical_qllm/manifold.h")
+        message(FATAL_ERROR
+            "ESHKOL_GEOMETRIC_QLLM=ON but "
+            "${ESHKOL_QLLM_ROOT}/include/semiclassical_qllm/manifold.h does not "
+            "exist. Refusing to configure a build whose geometric dispatch would "
+            "silently fall back to the portable body.")
+    endif()
+    message(STATUS "VM geometric dispatch: libsemiclassical_qllm (${ESHKOL_QLLM_ROOT})")
+else()
+    message(STATUS "VM geometric dispatch: portable closed forms (riemannian_core.h)")
+endif()
+
 # Moonlab is deliberately opt-in: normal Eshkol builds neither fetch nor link
 # the simulator.  c613234cd8498804428f3838aa46dd730b1de810 is pinned by object
 # SHA (rather than the mutable v1.1.0-rc name) for reproducible builds.  At the
@@ -2015,6 +2068,13 @@ function(eshkol_apply_vm_limit_definitions target_name)
         ESHKOL_VM_MAX_CONSTS=${ESHKOL_VM_MAX_CONSTS}
         ESHKOL_VM_MAX_CODE=${ESHKOL_VM_MAX_CODE}
     )
+    # The geometric dispatch selector (see the ESHKOL_GEOMETRIC_QLLM option).
+    # It belongs on exactly the targets that compile the VM unity build, which
+    # is exactly the set this function is called for.
+    if(ESHKOL_GEOMETRIC_QLLM)
+        target_compile_definitions(${target_name} PRIVATE ESHKOL_GEOMETRIC_ENABLED)
+        target_include_directories(${target_name} PRIVATE "${ESHKOL_QLLM_ROOT}/include")
+    endif()
 endfunction()
 
 set(ESHKOL_VM_UNITY_SRC)

--- a/docs/reference/stdlib/geometry.md
+++ b/docs/reference/stdlib/geometry.md
@@ -1,0 +1,1004 @@
+# Geometric builtins — Riemannian manifolds, Lie groups, forms and geodesic attention
+
+**Name table**: [`lib/backend/eshkol_vm.c`](../../../lib/backend/eshkol_vm.c) `BUILTINS[]`, native ids 804-861.
+**Implementation**: [`lib/backend/vm_geometric.c`](../../../lib/backend/vm_geometric.c).
+**Weighted Fréchet mean core**: [`inc/eshkol/backend/frechet_mean_core.h`](../../../inc/eshkol/backend/frechet_mean_core.h).
+**Surface record**: `tests/coverage/language_surface.json`, category `geometry`.
+**Regression**: [`tests/vm/geometric_surface_regression.esk`](../../../tests/vm/geometric_surface_regression.esk), run by `scripts/run_vm_surface_tests.sh`.
+
+This page documents the **62 geometric builtin names** the bytecode VM registers
+under native ids 804-861. They are a different surface from the pure-Scheme
+[`core.manifold`](manifold.md) module, which shares six of their spellings — see
+[Name collisions with `core.manifold`](#name-collisions-with-coremanifold) before
+using either.
+
+## Provenance of this page
+
+Every signature, arity, argument order, return type and closed form below is read
+directly from `lib/backend/eshkol_vm.c` (the name/id/arity table) and
+`lib/backend/vm_geometric.c` (the dispatch bodies), at the revision this page was
+written against. Unlike the other pages in this directory, **the examples carry no
+stamped output**: these ops execute only on the bytecode VM, and no output was
+captured for this revision. What is asserted instead is each op's *closed form*,
+which is a source fact and can be checked by reading the cited case label. The call
+shapes are the ones the committed regression exercises, so they are known to resolve
+and to be stack-balanced.
+
+## Engine availability
+
+| Engine | Available |
+|---|---|
+| Bytecode VM (`--profile hosted-vm`, `.eskb` modules, the WASM playground's VM) | Yes — all 62 names |
+| Native AOT (`eshkol-run file.esk`) | **No** |
+| Native REPL/JIT (`eshkol-run -r`) | **No** |
+
+These names appear in the VM builtin table only. They are absent from the native
+LLVM dispatch (`lib/backend/llvm_codegen.cpp`) and from the native builtin closure
+table (`lib/backend/eshkol_compiler.c`), so calling one from a natively compiled
+program is an unknown-function error, not a slow path. `tests/coverage/language_surface.json`
+records `"backends": ["vm"]` for every one of them.
+
+To run a program that uses them, compile it to a bytecode module and execute that
+module on the VM:
+
+```sh
+eshkol-run --profile hosted-vm --emit-eskb geo.eskb geo.esk
+# then execute geo.eskb on the VM (build tree: ./build/eshkol-vm-standalone-test geo.eskb)
+```
+
+See [`../runtime/eshkol-run.md`](../runtime/eshkol-run.md) for `--profile` and
+`--emit-eskb`.
+
+## What the shipped build computes
+
+`vm_geometric.c` has two dispatch bodies, selected at compile time by
+`ESHKOL_GEOMETRIC_ENABLED`:
+
+- **`#if !defined(ESHKOL_GEOMETRIC_ENABLED)`** — a self-contained,
+  constant-curvature implementation that allocates its manifolds in the VM arena.
+- **`#if defined(ESHKOL_GEOMETRIC_ENABLED)`** — calls out to the
+  `semiclassical_qllm` library (`<semiclassical_qllm/manifold.h>` and friends).
+
+**The portable path is the shipped implementation.** `ESHKOL_GEOMETRIC_ENABLED` is
+defined only when the `ESHKOL_GEOMETRIC_QLLM` CMake option is turned ON, which
+requires `ESHKOL_QLLM_ROOT` to point at an installed `libsemiclassical_qllm` and
+`FATAL_ERROR`s at configure time if the headers are not there. It is OFF by default,
+so every CI lane, every release binary and the WASM playground take the portable
+path, and that is the path documented here. The linked-library path is an
+out-of-tree opt-in and is *not* covered by this page or by any gate in this
+repository — and, measured against a current `libsemiclassical_qllm`, it does not
+currently compile: the arities of `qllm_hyperbolic_exp_map` and its siblings have
+moved and the SO(3)/SE(3) arms name types the library no longer declares. Bringing
+it back is its own change against the current qLLM ABI.
+
+The portable path computes the **closed forms of constant-curvature geometry in
+f64**, in `inc/eshkol/backend/riemannian_core.h`. It is not an approximation of the
+linked-library path: it is the same mathematics the AD bridge computes
+(`lib/bridge/qllm_bridge.cpp`: `ad_hyperbolic_distance`, `ad_poincare_exp_map`,
+`ad_poincare_log_map`, `ad_geodesic_attention`), so the VM engine and the AD tape
+agree on what these operations mean.
+
+This used not to be true, and the difference is worth stating because a reader of an
+older build's output needs to know. Before `SW-73` these ops computed their **flat
+(Euclidean) counterparts and discarded the curvature argument they accept**:
+`hyperbolic-exp-map` was vector addition, `hyperbolic-log-map` subtraction,
+`geodesic-distance` and `poincare-distance` the L2 distance, `mobius-add` addition,
+`parallel-transport` and `riemannian-grad` the identity. At K = 0 those forms are
+exactly right — every op below reduces to its flat form there — and at every other
+curvature they were wrong without bound: two points of the unit ball a tenth of a
+unit inside the boundary are 1.8 apart in L2 and 5.8888779583328814 apart in the
+metric the name promises. `tests/vm/geometric_riemannian_surface_regression.esk`
+pins each of these against its closed form, with every assertion chosen so that the
+flat answer fails it.
+
+Two ops are **not implemented on the VM engine** and raise rather than return a
+plausible value: `exterior-derivative` and `hodge-star`. See
+[Engine availability per builtin](#engine-availability-per-builtin).
+
+## Error convention
+
+**Shape and type failures return `()`.** An argument of the wrong type, a shape
+mismatch, a non-positive dimension or an allocation failure pushes the empty list
+`()` and execution continues; an unhandled id falls through to a `default:` arm that
+pops `vm_geometric_arity(fid)` arguments and pushes `()`, so the stack stays balanced
+either way. Check for `(null? result)` if you need to distinguish a failure from a
+value.
+
+**Domain failures raise a catchable Scheme condition** (via `vm_raise_error_msg`, so
+`guard` can catch it), naming the builtin, the reason and the curvature. They raise
+rather than return a number because the alternative is the case this whole surface
+exists to exclude — a plausible value the caller cannot tell from a real one. The
+conditions a caller can hit:
+
+- a point that is not **strictly inside** the Poincaré ball of radius `1/√−K`, for
+  any op taking K < 0;
+- a point that is not **on** the sphere of radius `1/√K`, for any op taking K > 0
+  (`manifold-project` is the op that moves it there);
+- `log`, when the two points are too far apart in hyperbolic distance for the
+  ambient ball coordinates to separate them — roughly 19 units, reachable from two
+  points each strictly inside the ball. No finite log exists there, and clamping the
+  argument would return a fabricated magnitude;
+- `mobius-add` and `mobius-scalar-mul` with K > 0: they are the gyrogroup operations
+  of the ball and are not defined on the sphere;
+- `frechet-mean`, when the Karcher iteration has not reached stationarity. A mean
+  that has not is exactly the input whose implicit derivative is a plausible wrong
+  gradient;
+- `exterior-derivative` and `hodge-star`, always: they are not implemented on the VM
+  engine.
+
+## Engine availability per builtin
+
+Sixty of the sixty-two names execute on the bytecode VM. Two do not, and say so:
+
+| Name | Id | Status on the VM engine |
+|---|---:|---|
+| `exterior-derivative` | 835 | **Raises `not implemented on the VM engine`.** The argument is a form's coefficient array at a single point, which carries no derivative information; computing `d` needs the coefficients as differentiable functions of position. It previously returned zeros of the input's shape, which asserts that every form handed to it is closed. |
+| `hodge-star` | 836 | **Raises `not implemented on the VM engine`.** The star of a k-form depends on k and on the dimension, and a flat coefficient array records neither, so the op cannot tell which duality is being asked for. It previously returned its argument unchanged, which asserts that the star is trivial. |
+
+Neither has a native AOT or REPL/JIT implementation either — see
+[Engine availability](#engine-availability) above, which applies to all 62 names.
+
+## Data model
+
+- **Points, tangent vectors, forms, quaternions, twists, poses, Q/K/V matrices** are
+  all **tensors** (`(make-tensor '(shape) fill)`, or any op that returns one). They
+  are *not* Scheme vectors — `vm_get_tensor` returns NULL for a non-tensor, and the
+  op then pushes `()`.
+- **A manifold** is an opaque heap handle (`VAL_MANIFOLD`, heap type
+  `HEAP_MANIFOLD`) wrapping `{int type; int dim; double curvature;}`. Construct it
+  only with the four constructors; inspect it with `manifold-type`,
+  `manifold-dim` and `get-curvature`.
+- **Manifold type codes** are integers, not symbols: `0` euclidean, `1` hyperbolic,
+  `2` spherical, `3` product.
+- **A Riemannian-Adam state** is an opaque handle (`VAL_RIEMANNIAN_ADAM_STATE`)
+  holding the first- and second-moment buffers plus a step counter.
+- Manifold and optimizer-state memory is VM-arena memory owned by the VM region
+  stack. `manifold-destroy!` invalidates the handle logically (it nulls the heap
+  object's payload pointer); it does not free arena memory.
+
+## The 62 names
+
+Aliases share an id and are therefore the same op. `→` gives the result type:
+`tensor`, `float`, `int`, `manifold`, `state`, or `()`.
+
+| Name | Id | Arity | → | Shipped (portable) behaviour |
+|---|---:|---:|---|---|
+| `make-euclidean-manifold` | 804 | 1 | manifold | type 0, K = 0.0 |
+| `make-hyperbolic-manifold` | 805 | 2 | manifold | type 1, K as given |
+| `make-spherical-manifold` | 806 | 1 | manifold | type 2, K = 1.0 |
+| `make-product-manifold` | 807 | 2 | manifold | type 3, dim = d1+d2, K = mean of the two |
+| `manifold-curvature` | 808 | 1 | float | stored K |
+| `hyperbolic-exp-map` / `manifold-exp-map` | 809 | 3 | tensor | exp_base(tangent): Möbius (K<0) / great-circle (K>0) / `base + tangent` (K=0) |
+| `hyperbolic-log-map` / `manifold-log-map` | 810 | 3 | tensor | log_base(point), the inverse of 809; `point - base` at K=0 |
+| `geodesic-distance` / `manifold-distance` | 811 | 3 | float | `arccosh(…)/√c` (K<0) / `R·acos` (K>0) / L2 (K=0) |
+| `parallel-transport` / `manifold-parallel-transport` | 812 | 4 | tensor | `(λ_x/λ_y)·gyr[y,−x]v` (K<0) / geodesic rotation (K>0) / identity (K=0) |
+| `manifold-project` | 813 | 2 | tensor | rescales onto the ball (K<0) or the sphere (K>0); a copy at K=0 |
+| `mobius-add` | 814 | 3 | tensor | the gyrogroup sum `x ⊕_c y`; `x + y` at K=0; **raises for K>0** |
+| `mobius-scalar-mul` | 815 | 3 | tensor | `(1/√c)·tanh(r·artanh(√c‖x‖))·x/‖x‖`; `r·x` at K=0; **raises for K>0** |
+| `poincare-distance` | 816 | 3 | float | the geodesic distance (same op as 811) |
+| `frechet-mean` | 817 | 3 | tensor | **real** weighted Karcher mean, gated; raises |
+| `great-circle-distance` | 819 | 2 | float | `acos` of the clamped normalised dot |
+| `slerp` | 820 | 3 | tensor | normalised `(1-t)x + t y` |
+| `spherical-exp` / `spherical-exp-map` | 821 | 2 | tensor | `cos‖v‖·base + sin‖v‖·v/‖v‖` on the unit sphere |
+| `spherical-log` / `spherical-log-map` | 822 | 2 | tensor | `θ·u/‖u‖`, `u = point − cosθ·base`, on the unit sphere |
+| `spherical-project` | 823 | 1 | tensor | L2-normalised copy |
+| `so3-exp` | 824 | 1 | tensor | axis-angle → unit quaternion, shape `(4)` |
+| `so3-log` | 825 | 1 | tensor | quaternion → axis-angle, shape `(3)` |
+| `se3-exp` | 826 | 1 | tensor | twist → pose, shape `(7)` |
+| `se3-log` | 827 | 1 | tensor | pose → twist, shape `(6)` |
+| `quaternion-mul` | 828 | 2 | tensor | Hamilton product, shape `(4)` |
+| `metric-tensor` | 829 | 1 | tensor | `dim × dim` identity |
+| `christoffel` | 830 | 2 | tensor | `dim³` closed form, see entry |
+| `riemann-curvature` | 831 | 1 | float | stored K (same case as 808) |
+| `ricci-scalar` | 832 | 1 | float | `dim·(dim-1)·K` |
+| `sectional-curvature` | 833 | 3 | float | stored K (u, v discarded) |
+| `wedge-product` | 834 | 2 | tensor | the `n(n-1)/2` 2×2 minors |
+| `exterior-derivative` | 835 | 1 | tensor | **not implemented on the VM engine — raises** |
+| `hodge-star` | 836 | 2 | tensor | **not implemented on the VM engine — raises** |
+| `interior-product` | 837 | 2 | tensor | shape `(1)` holding the dot product |
+| `pullback` | 838 | 2 | tensor | `formᵀ · jacobian`, shape `(cols)` |
+| `riemannian-sgd-step` | 839 | 4 | tensor | `exp_point(−lr·grad)`; `point − lr·grad` at K=0 |
+| `riemannian-adam-step` | 840 | 6 | tensor | Adam delta retracted with `exp`, moment transported, **implicit pooled state** |
+| `riemannian-grad` | 841 | 3 | tensor | `((1−c‖x‖²)²/4)·grad` (K<0) / tangent projection (K>0) / a copy (K=0) |
+| `retraction` | 842 | 3 | tensor | the exponential map (same op as 809) |
+| `vector-transport` | 843 | 4 | tensor | parallel transport (same op as 812) |
+| `geodesic-attention-scores` | 844 | 3 | tensor | `−d_K(q_i, k_j)`, shape `(nq nk)` |
+| `geodesic-attention-values` | 845 | 3 | tensor | score-weighted average of `V`'s rows |
+| `curvature-softmax` | 846 | 2 | tensor | softmax scaled by `1/√|K|` |
+| `geodesic-attention-forward` | 847 | 4 | tensor | softmax over `−d_K/(√c·√dim)` then a weighted sum of `V`, shape `(nq vdim)` |
+| `set-curvature!` | 850 | 2 | manifold | mutates K, returns the manifold |
+| `get-curvature` | 851 | 1 | float | stored K (same case as 808) |
+| `curvature-gradient` | 852 | 2 | float | sum of the gradient's elements |
+| `transition-geometry!` | 853 | 3 | float | K ← K + rate·(target − K); returns new K |
+| `manifold-interpolate` | 854 | 3 | float | `(1-t)·K₁ + t·K₂` — a **curvature**, not a manifold |
+| `curvature-hessian` | 855 | 2 | float | `0.0` |
+| `adaptive-curvature-step` | 856 | 2 | manifold | K ← K − 0.01·Σgrad; returns the manifold |
+| `manifold-type` | 857 | 1 | int | 0/1/2/3 |
+| `manifold-dim` / `manifold-dimension` | 858 | 1 | int | stored dim |
+| `manifold-destroy!` | 859 | 1 | `()` | invalidates the handle |
+| `make-riemannian-adam-state` | 860 | 1 | state | zeroed moments shaped like the point |
+| `riemannian-adam-step!` | 861 | 7 | tensor | same as 840 with an **explicit** state |
+
+Ids 818, 848 and 849 have no name bound to them.
+
+`vector-transport` (843) is a geometric op, but
+`tests/coverage/language_surface.json` files it under the `vector` category rather
+than `geometry`, because `scripts/gen_language_surface.py` categorises by name
+prefix. The `geometry` category therefore reports 61 while the family is 62. The
+count is not affected — the builtin is registered and covered either way.
+
+---
+
+## Manifold handles
+
+### `(make-euclidean-manifold dim)` — id 804
+
+`dim` integer. Returns a manifold of type 0 with K = 0.0, or `()` if `dim <= 0` or
+the arena allocation fails.
+
+```scheme
+(define m (make-euclidean-manifold 2))
+(display (manifold-type m)) (newline)   ; 0
+```
+
+### `(make-hyperbolic-manifold dim curvature)` — id 805
+
+`dim` integer, `curvature` real. Returns a manifold of type 1 carrying the curvature
+you pass — it is *not* forced to −1. Note the arity: unlike its
+[`core.manifold`](manifold.md) namesake, this constructor takes two arguments.
+
+```scheme
+(define h (make-hyperbolic-manifold 2 -1.0))
+```
+
+### `(make-spherical-manifold dim)` — id 806
+
+`dim` integer. Returns a manifold of type 2 with K = 1.0.
+
+```scheme
+(define s (make-spherical-manifold 2))
+```
+
+### `(make-product-manifold m1 m2)` — id 807
+
+Two manifolds. Returns a manifold of type 3 whose dimension is `d1 + d2` and whose
+curvature is the arithmetic mean `0.5·(K₁ + K₂)`. `()` if either argument is not a
+manifold.
+
+```scheme
+(display (manifold-dim (make-product-manifold (make-euclidean-manifold 2)
+                                              (make-hyperbolic-manifold 3 -1.0))))
+(newline)                                ; 5
+```
+
+### `(manifold-type m)` — id 857
+
+Returns the integer type code: `0` euclidean, `1` hyperbolic, `2` spherical, `3`
+product. `()` if `m` is not a manifold. This is an **integer**, where
+`core.manifold`'s `manifold-type` returns a symbol.
+
+```scheme
+(display (manifold-type (make-spherical-manifold 2))) (newline)   ; 2
+```
+
+### `(manifold-dim m)` / `(manifold-dimension m)` — id 858
+
+Returns the stored integer dimension, or `()` if `m` is not a manifold.
+
+```scheme
+(display (manifold-dim (make-euclidean-manifold 7))) (newline)    ; 7
+```
+
+### `(manifold-curvature m)` / `(get-curvature m)` / `(riemann-curvature m)` — id 808 / 851 / 831
+
+Three distinct names dispatching to one case. All return the manifold's stored
+constant curvature as a float, `()` if `m` is not a manifold. `riemann-curvature`
+returns a **scalar**, not a rank-4 tensor, despite the name.
+
+```scheme
+(display (get-curvature (make-hyperbolic-manifold 2 -1.0))) (newline)
+```
+
+### `(set-curvature! m k)` — id 850
+
+Mutates the manifold's stored curvature to `k` and returns the manifold itself
+(`()` if `m` is not a manifold).
+
+```scheme
+(define h (make-hyperbolic-manifold 2 -1.0))
+(set-curvature! h -0.5)
+(display (get-curvature h)) (newline)
+```
+
+### `(manifold-destroy! m)` — id 859
+
+Nulls the heap object's manifold pointer, so every later op on that handle sees "not
+a manifold" and returns `()`. Returns `()`. Arena memory is **not** freed here — it
+belongs to the VM region stack and is reclaimed when the region is popped.
+
+```scheme
+(define h (make-hyperbolic-manifold 2 -1.0))
+(manifold-destroy! h)
+(display (null? (manifold-dim h))) (newline)   ; #t
+```
+
+---
+
+## Maps, distances and gyrovector operations
+
+Every op in this group takes a trailing `curvature` argument, read as the
+**sectional curvature K**: `K < 0` is the Poincaré ball of radius `1/√−K`, `K = 0` is
+Euclidean space, `K > 0` is the sphere of radius `1/√K`. Each op reduces **exactly**
+to its flat form at `K = 0`. Arguments must lie on the manifold the curvature names —
+strictly inside the ball for `K < 0`, on the sphere for `K > 0` — or the op raises;
+see [Error convention](#error-convention).
+
+### `(hyperbolic-exp-map base tangent curvature)` / `(manifold-exp-map …)` / `(retraction base tangent curvature)` — id 809 / 842
+
+`base`, `tangent` tensors of equal total size; `curvature` real. Returns
+`exp_base(tangent)`, the point reached by following the geodesic from `base` in the
+direction `tangent` for the Riemannian length of `tangent`; `()` on a shape mismatch.
+`retraction` is a second name on the same op — and it is a true exponential map, not
+merely a retraction.
+
+- `K < 0`: `base ⊕_c tanh(√c·λ·‖v‖/2)·v/(√c‖v‖)` with `λ = 2/(1−c‖base‖²)`, `c = −K`.
+- `K = 0`: `base + tangent`, exactly.
+- `K > 0`: `cos(‖v‖/R)·base + R·sin(‖v‖/R)·v/‖v‖` with `R = 1/√K`; `v` must be
+  tangent (`⟨base, v⟩ = 0`).
+
+```scheme
+(define base (make-tensor '(2) 0.0))
+(tensor-set! base 0 0.3)
+(define v (make-tensor '(2) 0.2))
+(hyperbolic-exp-map base v -1.0)
+```
+
+### `(hyperbolic-log-map base point curvature)` / `(manifold-log-map …)` — id 810
+
+Returns `log_base(point)`, the inverse of id 809: the tangent vector at `base`
+whose exponential map is `point`. Its **Riemannian** length `λ_base·‖log‖` is the
+geodesic distance; its ambient Euclidean length is not.
+
+- `K < 0`: `(2/(√c·λ))·artanh(√c‖u‖)·u/‖u‖` with `u = (−base) ⊕_c point`.
+- `K = 0`: `point − base`, exactly.
+- `K > 0`: `θR·u/‖u‖` with `u = point − cos θ·base`, `θ = acos(⟨base,point⟩/R²)`.
+
+Raises when no finite log exists — see [Error convention](#error-convention).
+
+```scheme
+(define base (make-tensor '(2) 0.0))
+(tensor-set! base 0 0.3)
+(define p (make-tensor '(2) 0.0))
+(tensor-set! p 0 -0.5)
+(hyperbolic-log-map base p -1.0)
+```
+
+### `(geodesic-distance x y curvature)` / `(manifold-distance …)` / `(poincare-distance x y curvature)` — id 811 / 816
+
+Returns the geodesic distance as a float; `()` unless both arguments are tensors of
+the same total size. `poincare-distance` is a second name on the same op, and it IS
+the Poincaré metric.
+
+- `K < 0`: `arccosh(1 + 2c‖x−y‖²/((1−c‖x‖²)(1−c‖y‖²)))/√c`, the same closed form
+  `ad_hyperbolic_distance` computes on the AD tape.
+- `K = 0`: `‖x − y‖`, exactly.
+- `K > 0`: `R·acos(⟨x,y⟩/R²)`, the great-circle distance.
+
+The hyperbolic distance is not bounded by the ball diameter the way the chord is: it
+diverges as either point approaches the boundary.
+
+```scheme
+(define a (make-tensor '(2) 0.0))
+(tensor-set! a 0 0.9)
+(define b (make-tensor '(2) 0.0))
+(tensor-set! b 0 -0.9)
+(display (geodesic-distance a b -1.0)) (newline)   ; 5.888877958332881
+(display (geodesic-distance a b 0.0)) (newline)    ; 1.8
+```
+
+### `(parallel-transport x y v curvature)` / `(manifold-parallel-transport …)` / `(vector-transport x y v curvature)` — id 812 / 843
+
+Transports the tangent vector `v` from `x` to `y` along the connecting geodesic.
+
+- `K < 0`: `(λ_x/λ_y)·gyr[y, −x]v`, the gyration expanded through Möbius addition as
+  `gyr[u,w]z = (−(u ⊕ w)) ⊕ (u ⊕ (w ⊕ z))`.
+- `K = 0`: the identity, exactly.
+- `K > 0`: the component of `v` along the geodesic direction rotated by the arc
+  angle.
+
+Transport is an isometry of the Riemannian metric — `λ_y‖P v‖ = λ_x‖v‖` — even
+though it changes the ambient components. Transport from a point to itself is the
+identity.
+
+```scheme
+(define x (make-tensor '(2) 0.0)) (tensor-set! x 0 0.3)
+(define y (make-tensor '(2) 0.0)) (tensor-set! y 0 -0.5)
+(define v (make-tensor '(2) 0.2))
+(parallel-transport x y v -1.0)
+```
+
+### `(manifold-project x curvature)` — id 813
+
+Moves `x` onto the manifold of curvature `K`.
+
+- `K < 0`: rescales onto the open ball of radius `1/√−K` when `x` is on or outside
+  it; interior points are returned unchanged. The result is **strictly** inside, so
+  that `λ` stays finite and the log map does not degenerate.
+- `K = 0`: a copy.
+- `K > 0`: rescales to radius `1/√K`. Raises for the origin, which has no projection.
+
+This is the op to call when a point may have drifted off the manifold: every other op
+in this group refuses an off-manifold argument rather than projecting silently.
+
+```scheme
+(manifold-project (make-tensor '(2) 3.0) -1.0)
+```
+
+### `(mobius-add x y curvature)` — id 814
+
+The gyrovector addition of the Poincaré ball model, `c = −K`:
+
+```
+x ⊕_c y = ((1 + 2c⟨x,y⟩ + c‖y‖²)x + (1 − c‖x‖²)y) / (1 + 2c⟨x,y⟩ + c²‖x‖²‖y‖²)
+```
+
+It is **neither commutative nor associative** — `gyr[x,y]` is exactly the failure of
+commutativity, and it is what `parallel-transport` is built from. At `K = 0` it is
+`x + y`, exactly. It **raises for `K > 0`**: Möbius addition is the gyrogroup
+operation of the ball and is not defined on the sphere.
+
+```scheme
+(define x (make-tensor '(2) 0.1))
+(define y (make-tensor '(2) 0.2))
+(mobius-add x y -1.0)     ; not equal to (mobius-add y x -1.0)
+```
+
+### `(mobius-scalar-mul r x curvature)` — id 815
+
+Note the argument order: the **scalar comes first**. Returns the gyrovector scalar
+multiple `(1/√c)·tanh(r·artanh(√c‖x‖))·x/‖x‖`, which agrees with `mobius-add` — for
+example `2 ⊗ x = x ⊕ x`. Because `tanh` is bounded, the result cannot leave the ball
+for any `r`, which `r · x` does. At `K = 0` it is `r · x`, exactly. It **raises for
+`K > 0`**, for the same reason `mobius-add` does.
+
+```scheme
+(mobius-scalar-mul 0.5 (make-tensor '(2) 0.4) -1.0)
+```
+
+### `(frechet-mean points weights curvature)` — id 817
+
+The one genuinely Riemannian op in the portable path, and the only one that raises.
+
+- `points` — a tensor. Rank ≥ 2 is read as `(n_points dim)`; a rank-1 tensor is read
+  as a single point of dimension `total`.
+- `weights` — a tensor of `n_points` non-negative weights. They need not be
+  normalised; only their positive sum matters. `()` weights are treated as absent.
+- `curvature` — real, and **must be ≤ 0**: the op is the hyperbolic/Euclidean
+  Karcher mean, and a positive curvature is rejected.
+- Returns a tensor of shape `(dim)`.
+
+The forward pass is `eshkol_frechet_mean_compute` in
+[`inc/eshkol/backend/frechet_mean_core.h`](../../../inc/eshkol/backend/frechet_mean_core.h),
+shared with the AD bridge producer so that the opcode and the derivative can never
+compute different means. It iterates at most `ESHKOL_FRECHET_MAX_ITERS` = 256 times
+and accepts the result only when the relative stationarity residual of
+`Σᵢ wᵢ log_μ(xᵢ) = 0` falls to `ESHKOL_FRECHET_RESID_TOL` = `1e-9` or below.
+
+If it cannot, the op raises a catchable error naming the cause, the point count, the
+dimension, the curvature, the achieved residual and the tolerance. The refusals are
+explicit in the core header: fewer than one point or a non-positive dimension, a
+positive curvature, a NaN weight, a negative weight, a non-positive total weight, a
+NaN coordinate, a point outside the Poincaré ball, an iterate that reached the ball
+boundary, a `log_μ(xᵢ)` with no finite f64 value, and failure to reach stationarity.
+
+```scheme
+(define pts (make-tensor '(2 2) 0.1))
+(define w   (make-tensor '(2) 1.0))
+(frechet-mean pts w -1.0)
+```
+
+Catch the refusal rather than let it propagate if the inputs are user data:
+
+```scheme
+(guard (e (#t (display "frechet-mean refused") (newline)))
+  (frechet-mean pts (make-tensor '(2) 0.0) -1.0))   ; total weight 0 → raises
+```
+
+---
+
+## Sphere, rotation and rigid-motion groups
+
+### `(great-circle-distance x y)` — id 819
+
+Two tensors of equal total size. Returns `acos(clamp(⟨x,y⟩ / (‖x‖‖y‖), −1, 1))`, and
+`0.0` if either norm is zero. `()` on a size mismatch.
+
+```scheme
+(define x (make-tensor '(3) 1.0))
+(display (great-circle-distance x x)) (newline)
+```
+
+### `(slerp x y t)` — id 820
+
+Returns the L2-normalised linear blend `normalize((1−t)·x + t·y)`. This is normalised
+lerp ("nlerp"), not the constant-angular-velocity spherical interpolation the name
+usually denotes; the two agree in direction but not in parameterisation.
+
+```scheme
+(slerp (make-tensor '(3) 1.0) (make-tensor '(3) 2.0) 0.5)
+```
+
+### `(spherical-exp base tangent)` / `(spherical-exp-map …)` — id 821
+
+Two tensors. Returns the exponential map on the **unit sphere** (K = +1):
+`cos‖v‖·base + sin‖v‖·v/‖v‖`. `base` must lie on the unit sphere and `v` must be
+tangent to it (`⟨base, v⟩ = 0`), or the op raises.
+
+It used to return `normalize(base + tangent)`, a retraction: the right geodesic at
+the wrong arc length (`atan‖v‖` instead of `‖v‖`), so it agreed to first order and
+disagreed at every order after.
+
+```scheme
+(define e1 (make-tensor '(3) 0.0)) (tensor-set! e1 0 1.0)
+(define v  (make-tensor '(3) 0.0)) (tensor-set! v  1 1.0)
+(spherical-exp e1 v)   ; (0.5403023058681398 0.8414709848078965 0)
+```
+
+### `(spherical-log base point)` / `(spherical-log-map …)` — id 822
+
+Returns the logarithmic map on the **unit sphere**, the inverse of id 821:
+`θ·u/‖u‖` with `u = point − cos θ·base` and `θ = acos⟨base, point⟩`, so its length is
+the great-circle angle. Shares a case with id 810 but takes **two** arguments, not
+three — the curvature is fixed at K = +1. Both arguments must lie on the unit sphere.
+Antipodal points raise: the log is not single-valued there.
+
+```scheme
+(define e1 (make-tensor '(3) 0.0)) (tensor-set! e1 0 1.0)
+(define e2 (make-tensor '(3) 0.0)) (tensor-set! e2 1 1.0)
+(spherical-log e1 e2)   ; length pi/2
+```
+
+### `(spherical-project x)` — id 823
+
+Returns an L2-normalised copy of `x` (unchanged if its norm is zero).
+
+```scheme
+(spherical-project (make-tensor '(3) 2.0))
+```
+
+### `(so3-exp omega)` — id 824
+
+`omega` a tensor with at least 3 elements, read as an axis-angle rotation vector.
+Returns a unit quaternion of shape `(4)` in `(w x y z)` order:
+`w = cos(θ/2)`, `(x y z) = ω·sin(θ/2)/θ` where `θ = ‖ω‖`. For `θ ≤ 1e-12` it returns
+the identity quaternion `(1 0 0 0)`. `()` if the input has fewer than 3 elements.
+
+```scheme
+(so3-exp (make-tensor '(3) 0.0))    ; → (1 0 0 0)
+```
+
+### `(so3-log q)` — id 825
+
+`q` a tensor with at least 4 elements. Normalises it, then returns the axis-angle
+vector of shape `(3)`: `θ = 2·atan2(‖v‖, w)`, direction `v/‖v‖`. Returns zeros for a
+zero-norm input or a vector part below `1e-12`. `()` if the input has fewer than 4
+elements.
+
+```scheme
+(so3-log (so3-exp (make-tensor '(3) 0.0)))
+```
+
+### `(se3-exp twist)` — id 826
+
+`twist` a tensor with at least 6 elements: rotation part in `0..2`, translation part
+in `3..5`. Returns a pose of shape `(7)` — the quaternion from the rotation part
+followed by the translation copied through unchanged. `()` if fewer than 6 elements.
+
+```scheme
+(se3-exp (make-tensor '(6) 0.0))
+```
+
+### `(se3-log pose)` — id 827
+
+`pose` a tensor with at least 7 elements: quaternion in `0..3`, translation in
+`4..6`. Returns a twist of shape `(6)`, the inverse of `se3-exp`. `()` if fewer than
+7 elements.
+
+```scheme
+(se3-log (se3-exp (make-tensor '(6) 0.0)))
+```
+
+### `(quaternion-mul q1 q2)` — id 828
+
+Two tensors with at least 4 elements each, in `(w x y z)` order. Returns their
+Hamilton product as a tensor of shape `(4)`. `()` if either has fewer than 4
+elements.
+
+```scheme
+(quaternion-mul (so3-exp (make-tensor '(3) 0.0))
+                (so3-exp (make-tensor '(3) 0.0)))
+```
+
+---
+
+## Metric, connection and curvature queries
+
+### `(metric-tensor m)` — id 829
+
+Returns the `dim × dim` identity tensor — the metric of a constant-curvature space
+at this level of approximation. `()` unless `0 < dim ≤ 256`.
+
+```scheme
+(metric-tensor (make-hyperbolic-manifold 2 -1.0))
+```
+
+### `(christoffel m point)` — id 830
+
+`m` a manifold, `point` a tensor. Returns the rank-3 connection tensor of shape
+`(dim dim dim)`, indexed `[k][i][j]`, with entries
+
+`Γ = K · ( δᵢⱼ·xₖ − δⱼₖ·xᵢ − δᵢₖ·xⱼ )`
+
+The working dimension is the manifold's `dim`, clamped down to `point`'s element
+count. `()` if `point` is not a tensor, if the manifold lookup fails, or if the
+working dimension is not in `1..64`.
+
+```scheme
+(christoffel (make-hyperbolic-manifold 2 -1.0) (make-tensor '(2) 0.1))
+```
+
+### `(ricci-scalar m)` — id 832
+
+Returns the scalar curvature `dim·(dim−1)·K` as a float. `()` if the manifold lookup
+fails or `dim <= 0`.
+
+```scheme
+(display (ricci-scalar (make-spherical-manifold 3))) (newline)   ; 3*2*1.0
+```
+
+### `(sectional-curvature m u v)` — id 833
+
+Pops and discards the two tangent vectors and returns the manifold's constant
+curvature. `()` if `m` is not a manifold.
+
+```scheme
+(define t (make-tensor '(2) 1.0))
+(display (sectional-curvature (make-hyperbolic-manifold 2 -1.0) t t)) (newline)
+```
+
+---
+
+## Differential forms
+
+### `(wedge-product a b)` — id 834
+
+Two tensors. With `n = min(total_a, total_b)`, returns a tensor of shape
+`(n(n−1)/2)` holding the 2×2 minors `aᵢbⱼ − aⱼbᵢ` for `i < j`, in row-major `(i, j)`
+order. For `n ≤ 1` the result has shape `(1)` and is zero. `()` if either argument
+is not a tensor.
+
+```scheme
+(wedge-product (make-tensor '(3) 1.0) (make-tensor '(3) 2.0))
+```
+
+### `(exterior-derivative form)` — id 835
+
+**Not implemented on the VM engine.** Raises a catchable condition naming itself.
+
+`form` is a coefficient array evaluated at a single point, and `d` is a derivative:
+it cannot be computed from the values of the coefficients, only from the coefficients
+as differentiable functions of position. Nothing in this op's arguments carries that.
+
+It used to return a zero tensor of the input's shape, which is not "no information
+available" — it is the assertion that `d(form) = 0`, i.e. that every form handed to
+it is closed, made without examining one.
+
+```scheme
+(guard (e (#t 'not-implemented))
+  (exterior-derivative (make-tensor '(3) 1.0)))
+```
+
+### `(hodge-star form metric)` — id 836
+
+**Not implemented on the VM engine.** Raises a catchable condition naming itself.
+
+The star of a k-form depends on `k` and on the ambient dimension. A flat coefficient
+array records neither, so the op has no way to tell which duality is being asked for.
+
+It used to return its argument unchanged, which is the Hodge star only for a
+self-dual middle-degree form in a Euclidean metric — the identity map presented under
+the name of a duality.
+
+```scheme
+(guard (e (#t 'not-implemented))
+  (hodge-star (make-tensor '(3) 1.0) (make-tensor '(3 3) 0.0)))
+```
+
+### `(interior-product vector form)` — id 837
+
+Contraction `ι_v ω`. Both arguments must be tensors of the same total size. Returns
+a tensor of shape `(1)` holding their dot product — a rank-0 result boxed as a
+one-element tensor, not a float. `()` on a size mismatch.
+
+```scheme
+(interior-product (make-tensor '(3) 1.0) (make-tensor '(3) 2.0))
+```
+
+### `(pullback form jacobian)` — id 838
+
+Returns `formᵀ · jacobian` as a tensor of shape `(cols)`. When `jacobian` has rank ≥
+2 its shape supplies `(rows, cols)`; otherwise `rows` is taken from `form`'s element
+count and `cols` inferred by division. `()` if the shapes cannot be reconciled
+(`rows·cols` exceeding the jacobian's element count, or `rows` exceeding the form's).
+
+```scheme
+(pullback (make-tensor '(2) 1.0) (make-tensor '(2 3) 1.0))
+```
+
+---
+
+## Riemannian optimizers
+
+All three step ops read their trailing curvature argument and **retract onto the
+manifold with the exponential map**, so the iterate cannot leave it. `gradient` is
+the **Riemannian** gradient — a tangent vector; `riemannian-grad` is the op that
+converts a Euclidean one, which is why they are separate names. At `K = 0` every step
+reduces exactly to the ambient update.
+
+### `(riemannian-sgd-step point gradient lr curvature)` — id 839
+
+Returns `exp_point(−lr · gradient)` as a fresh tensor; `point − lr · gradient` at
+`K = 0`. `()` on a shape mismatch, and raises if `point` is not on the manifold.
+
+```scheme
+(define p (make-tensor '(2) 0.25))
+(define g (make-tensor '(2) 0.5))
+(riemannian-sgd-step p g 0.25 -1.0)
+```
+
+### `(riemannian-adam-step point gradient lr beta1 beta2 curvature)` — id 840
+
+Bias-corrected Adam with `ε = 1e-8`. `beta1` outside `[0, 1)` falls back to `0.9`,
+`beta2` outside `[0, 1)` to `0.999`, and a negative `lr` is negated. The Adam delta is
+formed in the tangent space, retracted with `exp_point`, and the **first moment is
+parallel-transported** to the new point — it is a tangent vector at the old one and
+is meaningless at the new one until it is moved. The second moment is a
+per-coordinate scale rather than a tangent vector and is left as is, which is the
+same choice `geoopt`'s `RiemannianAdam` makes.
+
+The optimizer state is **implicit and pooled**. `vm_default_riemannian_adam_state`
+keeps 16 VM-lifetime slots and hands back the first whose shape matches `point`,
+creating one in the first empty slot otherwise — and **overwriting slot 0 when all 16
+are occupied by other shapes**. Two independent optimisation loops over
+same-shaped parameters therefore share one moment estimate. Use
+`make-riemannian-adam-state` and `riemannian-adam-step!` when you need the state to
+belong to one loop.
+
+```scheme
+(define p (make-tensor '(4) 1.0))
+(define g (make-tensor '(4) 0.5))
+(riemannian-adam-step p g 0.01 0.9 0.999 -1.0)
+```
+
+### `(make-riemannian-adam-state point)` — id 860
+
+Allocates a zeroed state (first and second moment buffers shaped like `point`, step
+counter 0) and returns the handle. This state is **region-scoped**, unlike the pooled
+states id 840 creates, which are VM-lifetime. `()` if `point` is not a usable tensor.
+
+```scheme
+(define st (make-riemannian-adam-state (make-tensor '(4) 1.0)))
+```
+
+### `(riemannian-adam-step! state point gradient lr beta1 beta2 curvature)` — id 861
+
+The same update as id 840 against an explicit `state`. Despite the `!`, the returned
+value is a **new** tensor — `point` is not mutated; what is mutated is `state`'s
+moment buffers and step counter. `()` if the state's shape does not match `point`.
+
+```scheme
+(define p  (make-tensor '(4) 1.0))
+(define g  (make-tensor '(4) 0.5))
+(define st (make-riemannian-adam-state p))
+(riemannian-adam-step! st p g 0.01 0.9 0.999 -1.0)
+```
+
+### `(riemannian-grad euclidean-grad point curvature)` — id 841
+
+Converts a Euclidean gradient at `point` into the Riemannian one.
+
+- `K < 0`: `((1 − c‖x‖²)² / 4) · grad`. The ball's metric is conformal with factor
+  `λ_x = 2/(1 − c‖x‖²)`, so the Riemannian gradient is `grad / λ_x²`; the factor goes
+  to zero at the boundary.
+- `K = 0`: a copy, exactly.
+- `K > 0`: the ambient gradient projected onto the tangent space at `point`.
+
+```scheme
+(define p (make-tensor '(2) 0.0)) (tensor-set! p 0 0.3) (tensor-set! p 1 -0.1)
+(define g (make-tensor '(2) 0.0)) (tensor-set! g 0 1.0)
+(riemannian-grad g p -1.0)   ; (0.2025 0)
+```
+
+---
+
+## Geodesic attention
+
+### `(geodesic-attention-scores Q K curvature)` — id 844
+
+`Q` and `K` tensors. A rank-≥2 tensor is read as `(n, d)`; a rank-1 tensor is read as
+a single row of dimension `total`. The two feature dimensions must agree. Returns a
+tensor of shape `(nq nk)` whose entries are the **negated geodesic distances**
+`−d_K(qᵢ, kⱼ)` — closer keys score higher — which is the convention
+`ad_geodesic_attention` uses on the AD tape. `()` if either argument is not a tensor
+or the dimensions disagree; raises if a row is off the manifold.
+
+```scheme
+(geodesic-attention-scores (make-tensor '(2 3) 0.1) (make-tensor '(2 3) 0.2) -1.0)
+```
+
+### `(geodesic-attention-values scores V curvature)` — id 845
+
+`V` must have rank ≥ 2, read as `(n, dim)`. Returns a tensor of shape `(dim)`: the
+average of `V`'s rows weighted by the leading `n` entries of `scores`, divided by
+their sum (or left unnormalised if that sum is exactly zero). The scores are used
+**raw** — pass them through `curvature-softmax` first if you want a probability
+weighting.
+
+```scheme
+(define v (make-tensor '(2 3) 1.0))
+(define s (make-tensor '(2) 0.5))
+(geodesic-attention-values s v -1.0)
+```
+
+### `(curvature-softmax scores curvature)` — id 846
+
+Numerically stable softmax (maximum subtracted before exponentiating) with the
+logits scaled by `1/√|K|`, or by `1.0` when `K` is exactly zero. Returns a tensor of
+the input's shape. `()` if `scores` is not a non-empty tensor.
+
+```scheme
+(curvature-softmax (make-tensor '(4) 0.25) -1.0)
+```
+
+### `(geodesic-attention-forward Q K V curvature)` — id 847
+
+The fused path. `Q`, `K` and `V` must all have rank ≥ 2; `K`'s feature dimension must
+equal `Q`'s and `V` must have at least as many rows as `K`. Returns a tensor of shape
+`(nq vdim)` where row `i` is the average of `V`'s rows weighted by the softmax of
+`−d_K(qᵢ, kⱼ)/(√c·√dim)`, the curvature-adaptive scaling `ad_geodesic_attention`
+applies. The maximum is subtracted before exponentiating. The aggregation of `V` is a
+Euclidean weighted sum, which is what the AD bridge also computes — only the SCORES
+carry the metric. Note this is still **not** the composition of ids 844/846/845,
+whose scalings differ.
+
+```scheme
+(geodesic-attention-forward (make-tensor '(2 3) 0.1)
+                            (make-tensor '(2 3) 0.2)
+                            (make-tensor '(2 3) 0.3) -1.0)
+```
+
+---
+
+## Curvature control
+
+These four ops treat curvature as a learnable scalar on the manifold handle.
+
+### `(curvature-gradient m loss-grad)` — id 852
+
+Returns the plain sum of `loss-grad`'s elements as a float. `()` if `m` is not a
+manifold or `loss-grad` is not a tensor. This is a placeholder reduction, not a
+derivative of anything with respect to `K`.
+
+```scheme
+(display (curvature-gradient (make-hyperbolic-manifold 2 -1.0)
+                             (make-tensor '(4) 0.25)))
+(newline)
+```
+
+### `(transition-geometry! m target rate)` — id 853
+
+Moves the stored curvature one exponential step toward `target`:
+`K ← K + rate·(target − K)`. Mutates `m` and returns the **new curvature** as a
+float, not the manifold. `()` if `m` is not a manifold.
+
+```scheme
+(define h (make-hyperbolic-manifold 2 -1.0))
+(display (transition-geometry! h 0.0 0.1)) (newline)
+```
+
+### `(manifold-interpolate m1 m2 t)` — id 854
+
+Returns the interpolated **curvature** `(1−t)·K₁ + t·K₂` as a float. It does not
+build a manifold, and it ignores both dimensions. `()` if either argument is not a
+manifold.
+
+```scheme
+(display (manifold-interpolate (make-hyperbolic-manifold 2 -1.0)
+                               (make-spherical-manifold 2) 0.5))
+(newline)
+```
+
+### `(curvature-hessian m grad)` — id 855
+
+Pops and discards `grad` and returns `0.0` for any manifold, `()` otherwise. A
+constant, not a measurement.
+
+```scheme
+(display (curvature-hessian (make-hyperbolic-manifold 2 -1.0)
+                            (make-tensor '(4) 0.25)))
+(newline)
+```
+
+### `(adaptive-curvature-step m grad)` — id 856
+
+Applies one fixed-rate curvature update `K ← K − 0.01·Σgrad`, mutating `m`, and
+returns the manifold. `()` if `m` is not a manifold or `grad` is not a tensor.
+
+```scheme
+(define h (make-hyperbolic-manifold 2 -1.0))
+(adaptive-curvature-step h (make-tensor '(4) 0.25))
+(display (get-curvature h)) (newline)
+```
+
+---
+
+## Name collisions with `core.manifold`
+
+Six spellings exist in both surfaces, and they are **not** the same functions:
+
+| Spelling | This page (VM builtin) | [`core.manifold`](manifold.md) (Scheme) |
+|---|---|---|
+| `make-euclidean-manifold` | arity 1, opaque handle | arity 1, `#(type dim)` vector |
+| `make-hyperbolic-manifold` | **arity 2** — `(dim curvature)` | **arity 1** — `(dim)`, K fixed at −1 |
+| `make-spherical-manifold` | arity 1, opaque handle | arity 1, `#(type dim)` vector |
+| `manifold-exp-map` / `-log-map` | tensors; closed-form Möbius / great-circle | Scheme vectors; closed-form Möbius / great-circle |
+| `manifold-distance` | tensors; Poincaré `arccosh` / spherical `acos` | Scheme vectors; Poincaré `arccosh` / spherical `acos` |
+| `manifold-type` / `manifold-dimension` | integer type code | symbol type, integer dimension |
+
+Which one a call reaches depends on whether `core.manifold` has been loaded.
+`core.manifold` is auto-loaded by `(require stdlib)` (it is in `lib/stdlib.esk`'s
+`require` chain), and the VM reaches builtins through ordinary global-variable
+lookup rather than a compiler intercept — `lib/backend/vm_compiler.c` says so
+explicitly: *"Any function in the `BUILTINS[]` array in `eshkol_vm.c` is accessible
+via normal global variable lookup and should NOT appear in this compiler"*, precisely
+so that *"user-defined functions with the same name"* are not silently bypassed. A
+`define` of one of these six names therefore rebinds the global, and a module that
+pulls in the stdlib gets the Scheme implementations. **Do not rely on that to resolve
+the ambiguity for you** — pick one surface per program deliberately, and note that
+the two disagree on arity for `make-hyperbolic-manifold`, so a program that reaches
+the wrong one fails at the call rather than quietly.
+
+`core.manifold` is the better default when portability across engines is what you
+need: it runs on native AOT and REPL/JIT as well as the VM, and its points are
+ordinary Scheme vectors. Both surfaces now compute the same closed forms, so the
+choice is about engine reach and data representation rather than about correctness —
+note that `core.manifold` fixes K at −1 for the hyperbolic case while these builtins
+take K as an argument. Reach for these builtins when you need the tensor-shaped
+surface, the
+Lie-group ops (`so3-*`, `se3-*`, `quaternion-mul`), the differential forms, the
+optimizers, geodesic attention, or the gated `frechet-mean` — none of which
+`core.manifold` provides.
+
+## Automatic differentiation
+
+None of these builtins is differentiable through Eshkol's AD operators: they are VM
+natives, and AD is a native-engine facility. The qLLM bridge
+(`lib/bridge/qllm_bridge.cpp`) is the differentiable route to the same geometry — and
+it is now the same geometry in the strict sense: the closed forms these opcodes
+compute live in `inc/eshkol/backend/riemannian_core.h` and are the ones the bridge's
+`ad_hyperbolic_distance`, `ad_poincare_exp_map`, `ad_poincare_log_map` and
+`ad_geodesic_attention` evaluate, so a value computed on the VM and a value computed
+on the tape agree. The
+the exact backwards it registers are documented in
+[`../ad/architecture.md`](../ad/architecture.md) and
+[`../ad/support-matrix.md`](../ad/support-matrix.md). `frechet-mean`'s forward pass is
+literally shared between the two — the same
+`inc/eshkol/backend/frechet_mean_core.h` — so that the opcode and the derivative can
+never disagree about what the mean is.
+
+## See also
+
+- [`manifold.md`](manifold.md) — the pure-Scheme `core.manifold` module.
+- [`../ad/INDEX.md`](../ad/INDEX.md) — automatic differentiation reference.
+- [`../ad/tape.md`](../ad/tape.md) — the explicit reverse-mode tape builtins.
+- [`INDEX.md`](INDEX.md) — the stdlib module map.

--- a/inc/eshkol/backend/riemannian_core.h
+++ b/inc/eshkol/backend/riemannian_core.h
@@ -1,0 +1,476 @@
+/**
+ * @file riemannian_core.h
+ * @brief Closed-form constant-curvature geometry (Poincare ball, Euclidean
+ *        space, round sphere) in f64, shared by the VM's geometric opcodes.
+ *
+ * WHY THIS FILE EXISTS. `lib/backend/vm_geometric.c` used to implement the
+ * curved operations as their FLAT counterparts: `hyperbolic-exp-map` was vector
+ * addition, `hyperbolic-log-map` subtraction, `geodesic-distance` and
+ * `poincare-distance` the L2 distance, `mobius-add` addition, `mobius-scalar-mul`
+ * a scale, `parallel-transport` and `riemannian-grad` the identity. Each of them
+ * accepted a curvature argument and discarded it. No target in the repository
+ * defines ESHKOL_GEOMETRIC_ENABLED, so that portable body is the one every
+ * shipped VM build compiles — every CI lane, every release binary, the WASM
+ * playground. The result was Euclidean answers returned under Riemannian names,
+ * with nothing in the output showing the argument had been dropped: the same
+ * plausible-wrong-number class `frechet_mean_core.h` documents for the Euclidean
+ * weighted average that used to stand in for the Frechet mean.
+ *
+ * WHY A HEADER AND NOT A LIBRARY TU. Identical reason to
+ * `inc/eshkol/backend/frechet_mean_core.h`: `lib/backend/vm_geometric.c` is a
+ * unity-build include consumed by `lib/backend/eshkol_vm.c`, which is also built
+ * as a single translation unit on its own (the `eshkol-vm-standalone-test`
+ * target), so a call to an external symbol would not link there. Static
+ * functions in a header give every caller ONE source of truth with no link edge.
+ *
+ * CURVATURE CONVENTION. Every entry point below takes @c K, the SECTIONAL
+ * CURVATURE, and dispatches on its sign:
+ *
+ *   K < 0   Poincare ball of curvature K, i.e. ball parameter c = -K and
+ *           Euclidean radius 1/sqrt(c). This is the convention every in-tree
+ *           call site already uses -- `(make-hyperbolic-manifold 2 -1.0)`,
+ *           `(poincare-distance x y -1.0)` -- and the one
+ *           `eshkol_frechet_mean_compute` takes, so `frechet-mean` and the ops
+ *           around it now read their curvature argument the same way.
+ *   K = 0   Euclidean space. Every operation reduces to its flat form EXACTLY
+ *           (exp is addition, log is subtraction, distance is L2, transport is
+ *           the identity), which is not an approximation but the c -> 0 limit of
+ *           the formulas below. The old flat bodies were therefore right for
+ *           this one value of the argument and wrong for every other.
+ *   K > 0   Round sphere of radius R = 1/sqrt(K), points required to lie ON it.
+ *
+ * RELATION TO THE AD BRIDGE. `lib/bridge/qllm_bridge.cpp` (`ad_hyperbolic_distance`,
+ * `ad_poincare_exp_map`, `ad_poincare_log_map`, `ad_geodesic_attention`) is the
+ * reference semantics for the hyperbolic case, and the formulas here are the
+ * same ones: Mobius addition with the same denominator floor, exp with
+ * coefficient tanh(sqrt(c) lambda_x |v| / 2)/(sqrt(c)|v|), log with
+ * (2/(sqrt(c) lambda_x)) artanh(sqrt(c)|u|)/|u|, distance as
+ * arccosh(1 + 2c|x-y|^2 / ((1-c|x|^2)(1-c|y|^2)))/sqrt(c). The bridge takes its
+ * argument as `c = (curvature == 0) ? 1 : |curvature|` because its callers pass a
+ * ball parameter; passing THIS file's K = -c to those entry points yields
+ * bit-comparable results on the hyperbolic branch, which is what the VM's ops
+ * are checked against.
+ *
+ * ONE DELIBERATE DIVERGENCE FROM THE BRIDGE. `ad_poincare_log_map` clamps
+ * sqrt(c)|u| to 1 - 1e-12 when it reaches 1. That substitutes a fabricated log
+ * magnitude (~13.8) for one that does not exist, which is exactly what
+ * `eshkol_frechet_log_map` refuses to do and says why. This file refuses too:
+ * `eshkol_rm_log_map` returns a reason and the VM raises a catchable condition.
+ * The bridge's clamp is a separate defect on a separate surface and is left for
+ * its own change rather than altered from here.
+ *
+ * Copyright (C) tsotchke
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef ESHKOL_BACKEND_RIEMANNIAN_CORE_H
+#define ESHKOL_BACKEND_RIEMANNIAN_CORE_H
+
+#include <math.h>
+#include <string.h>
+
+/* Below this Euclidean norm a tangent vector is treated as zero: exp returns its
+ * base point and log returns the zero vector. Matches the bridge's 1e-15. */
+#define ESHKOL_RM_ZERO_NORM 1e-15
+
+/* Floor on the MAGNITUDE of the Mobius denominator. Not a perturbation of an
+ * input and not a difference quotient: the Mobius quotient is undefined where
+ * the denominator vanishes, and this keeps the value finite with the sign the
+ * expression had. Same constant and same convention as `kMobiusDenFloor` in
+ * lib/bridge/qllm_bridge.cpp and the Poincare-ball divisor clamps in
+ * lib/backend/autodiff_codegen.cpp. */
+#define ESHKOL_RM_MOBIUS_DEN_FLOOR 1e-15
+
+/* Relative tolerance on |x| = R for a point claimed to lie on the sphere of
+ * radius R. A point off the sphere has no geodesic relation to another point on
+ * it, so the ops refuse rather than project silently; `manifold-project` is the
+ * op that moves a point onto the manifold. */
+#define ESHKOL_RM_SPHERE_TOL 1e-9
+
+static double eshkol_rm_dot(const double* a, const double* b, int n) {
+    double s = 0.0;
+    for (int i = 0; i < n; i++) s += a[i] * b[i];
+    return s;
+}
+
+static double eshkol_rm_norm(const double* a, int n) {
+    return sqrt(eshkol_rm_dot(a, a, n));
+}
+
+/**
+ * @brief Mobius addition on the Poincare ball of ball parameter @p c > 0:
+ *
+ *   x (+)_c y = ((1 + 2c<x,y> + c|y|^2) x + (1 - c|x|^2) y)
+ *               / (1 + 2c<x,y> + c^2 |x|^2 |y|^2)
+ *
+ * At c = 0 this is x + y, which is why the Euclidean branch of every caller is
+ * the same code with c = 0 rather than a separate special case.
+ */
+static void eshkol_rm_mobius_add(const double* x, const double* y, double c,
+                                 int n, double* out) {
+    double xy = eshkol_rm_dot(x, y, n);
+    double x2 = eshkol_rm_dot(x, x, n);
+    double y2 = eshkol_rm_dot(y, y, n);
+    double num_x = 1.0 + 2.0 * c * xy + c * y2;
+    double num_y = 1.0 - c * x2;
+    double den_raw = 1.0 + 2.0 * c * xy + c * c * x2 * y2;
+    double den = den_raw;
+    if (fabs(den_raw) < ESHKOL_RM_MOBIUS_DEN_FLOOR)
+        den = (den_raw < 0.0) ? -ESHKOL_RM_MOBIUS_DEN_FLOOR : ESHKOL_RM_MOBIUS_DEN_FLOOR;
+    for (int i = 0; i < n; i++) out[i] = (num_x * x[i] + num_y * y[i]) / den;
+}
+
+/**
+ * @brief Mobius scalar multiplication r (x)_c x
+ *      = (1/sqrt(c)) tanh(r artanh(sqrt(c)|x|)) x/|x|.
+ *
+ * @return NULL, or a reason when @p x is not strictly inside the ball (artanh
+ *         has no value at or beyond the boundary).
+ */
+static const char* eshkol_rm_mobius_scalar(double r, const double* x, double c,
+                                           int n, double* out) {
+    double xn = eshkol_rm_norm(x, n);
+    if (c == 0.0) {
+        for (int i = 0; i < n; i++) out[i] = r * x[i];
+        return NULL;
+    }
+    if (xn < ESHKOL_RM_ZERO_NORM) {
+        for (int i = 0; i < n; i++) out[i] = 0.0;
+        return NULL;
+    }
+    double s = sqrt(c);
+    double t = s * xn;
+    if (!(t < 1.0))
+        return "the point is on or outside the Poincare ball boundary, where "
+               "artanh has no value";
+    double coef = tanh(r * atanh(t)) / (s * xn);
+    for (int i = 0; i < n; i++) out[i] = coef * x[i];
+    return NULL;
+}
+
+/**
+ * @brief Check that @p x is a legal point of the manifold of curvature @p K.
+ * @return NULL when it is, else a reason naming what is wrong.
+ */
+static const char* eshkol_rm_check_point(const double* x, double K, int n) {
+    if (!(K == K)) return "curvature is NaN";
+    for (int i = 0; i < n; i++)
+        if (!(x[i] == x[i])) return "a coordinate is NaN";
+    if (K < 0.0) {
+        double c = -K;
+        if (!(c * eshkol_rm_dot(x, x, n) < 1.0))
+            return "the point must lie strictly inside the Poincare ball of "
+                   "radius 1/sqrt(-K)";
+    } else if (K > 0.0) {
+        double R = 1.0 / sqrt(K);
+        double xn = eshkol_rm_norm(x, n);
+        if (!(fabs(xn - R) <= ESHKOL_RM_SPHERE_TOL * R))
+            return "the point must lie ON the sphere of radius 1/sqrt(K) "
+                   "(use manifold-project to move it there)";
+    }
+    return NULL;
+}
+
+/**
+ * @brief Geodesic distance between @p x and @p y on the manifold of curvature
+ *        @p K, into *@p out.
+ *
+ * Hyperbolic: arccosh(1 + 2c|x-y|^2 / ((1-c|x|^2)(1-c|y|^2))) / sqrt(c), the
+ * form `ad_hyperbolic_distance` computes. Spherical: R arccos(<x,y>/R^2).
+ * Euclidean: |x-y|.
+ *
+ * @return NULL on success, else a reason.
+ */
+static const char* eshkol_rm_distance(const double* x, const double* y, double K,
+                                      int n, double* out) {
+    const char* why = eshkol_rm_check_point(x, K, n);
+    if (why) return why;
+    why = eshkol_rm_check_point(y, K, n);
+    if (why) return why;
+
+    if (K == 0.0) {
+        double s = 0.0;
+        for (int i = 0; i < n; i++) { double d = x[i] - y[i]; s += d * d; }
+        *out = sqrt(s);
+        return NULL;
+    }
+    if (K < 0.0) {
+        double c = -K;
+        double diff2 = 0.0;
+        for (int i = 0; i < n; i++) { double d = x[i] - y[i]; diff2 += d * d; }
+        double dx = 1.0 - c * eshkol_rm_dot(x, x, n);
+        double dy = 1.0 - c * eshkol_rm_dot(y, y, n);
+        double arg = 1.0 + 2.0 * c * diff2 / (dx * dy);
+        if (arg < 1.0) arg = 1.0;   /* only reachable by rounding below 1 */
+        *out = acosh(arg) / sqrt(c);
+        return NULL;
+    }
+    {
+        double R = 1.0 / sqrt(K);
+        double cs = eshkol_rm_dot(x, y, n) / (R * R);
+        if (cs > 1.0) cs = 1.0;
+        if (cs < -1.0) cs = -1.0;
+        *out = R * acos(cs);
+        return NULL;
+    }
+}
+
+/**
+ * @brief Exponential map exp_x(v) on the manifold of curvature @p K.
+ *
+ * @param scratch n doubles.
+ * @return NULL on success, else a reason.
+ */
+static const char* eshkol_rm_exp_map(const double* x, const double* v, double K,
+                                     int n, double* out, double* scratch) {
+    const char* why = eshkol_rm_check_point(x, K, n);
+    if (why) return why;
+    for (int i = 0; i < n; i++)
+        if (!(v[i] == v[i])) return "a tangent-vector component is NaN";
+
+    double vn = eshkol_rm_norm(v, n);
+    if (vn < ESHKOL_RM_ZERO_NORM) {
+        memcpy(out, x, (size_t)n * sizeof(double));
+        return NULL;
+    }
+    if (K == 0.0) {
+        for (int i = 0; i < n; i++) out[i] = x[i] + v[i];
+        return NULL;
+    }
+    if (K < 0.0) {
+        double c = -K;
+        double s = sqrt(c);
+        double lam = 2.0 / (1.0 - c * eshkol_rm_dot(x, x, n));
+        double coef = tanh(s * lam * vn / 2.0) / (s * vn);
+        for (int i = 0; i < n; i++) scratch[i] = coef * v[i];
+        eshkol_rm_mobius_add(x, scratch, c, n, out);
+        return NULL;
+    }
+    {
+        /* Sphere of radius R: exp_x(v) = cos(|v|/R) x + R sin(|v|/R) v/|v|.
+         * The tangency of v is not assumed -- a v with a radial component would
+         * leave the sphere, so it is rejected rather than silently projected. */
+        double R = 1.0 / sqrt(K);
+        double radial = eshkol_rm_dot(x, v, n) / R;
+        if (!(fabs(radial) <= ESHKOL_RM_SPHERE_TOL * (vn + R)))
+            return "the tangent vector is not tangent to the sphere (<x,v> must "
+                   "vanish)";
+        double th = vn / R;
+        double ca = cos(th), sa = sin(th);
+        for (int i = 0; i < n; i++) out[i] = ca * x[i] + R * sa * v[i] / vn;
+        return NULL;
+    }
+}
+
+/**
+ * @brief Logarithmic map log_x(y) on the manifold of curvature @p K, the inverse
+ *        of eshkol_rm_exp_map().
+ *
+ * @param scratch 2n doubles.
+ * @return NULL on success, else a reason. The hyperbolic branch REFUSES when
+ *         sqrt(c)|(-x) (+)_c y| reaches 1: no finite log exists there, and
+ *         clamping the argument would return a fabricated magnitude the caller
+ *         cannot distinguish from a real one. Reachable from two points each
+ *         strictly inside the ball -- |u| is formed by cancellation, so points
+ *         about 19 units of hyperbolic distance apart drive it to 1 in f64.
+ */
+static const char* eshkol_rm_log_map(const double* x, const double* y, double K,
+                                     int n, double* out, double* scratch) {
+    const char* why = eshkol_rm_check_point(x, K, n);
+    if (why) return why;
+    why = eshkol_rm_check_point(y, K, n);
+    if (why) return why;
+
+    if (K == 0.0) {
+        for (int i = 0; i < n; i++) out[i] = y[i] - x[i];
+        return NULL;
+    }
+    if (K < 0.0) {
+        double c = -K;
+        double s = sqrt(c);
+        double* neg = scratch;
+        double* u   = scratch + n;
+        for (int i = 0; i < n; i++) neg[i] = -x[i];
+        eshkol_rm_mobius_add(neg, y, c, n, u);
+        double un = eshkol_rm_norm(u, n);
+        if (un < ESHKOL_RM_ZERO_NORM) {
+            for (int i = 0; i < n; i++) out[i] = 0.0;
+            return NULL;
+        }
+        double t = s * un;
+        if (!(t < 1.0))
+            return "log has no finite value here: the two points are too far "
+                   "apart in hyperbolic distance for the ambient ball "
+                   "coordinates to separate them (refusing rather than "
+                   "substituting a fabricated log magnitude)";
+        double lam = 2.0 / (1.0 - c * eshkol_rm_dot(x, x, n));
+        double coef = (2.0 / (s * lam)) * atanh(t) / un;
+        for (int i = 0; i < n; i++) out[i] = coef * u[i];
+        return NULL;
+    }
+    {
+        /* Sphere: log_x(y) = theta R * u/|u| with u = y - (<x,y>/R^2) x. */
+        double R = 1.0 / sqrt(K);
+        double cs = eshkol_rm_dot(x, y, n) / (R * R);
+        if (cs > 1.0) cs = 1.0;
+        if (cs < -1.0) cs = -1.0;
+        double* u = scratch;
+        for (int i = 0; i < n; i++) u[i] = y[i] - cs * x[i];
+        double un = eshkol_rm_norm(u, n);
+        double th = acos(cs);
+        if (un < ESHKOL_RM_ZERO_NORM) {
+            if (th > 1.0) return "the two points are antipodal: log is not "
+                                 "single-valued there";
+            for (int i = 0; i < n; i++) out[i] = 0.0;
+            return NULL;
+        }
+        double coef = th * R / un;
+        for (int i = 0; i < n; i++) out[i] = coef * u[i];
+        return NULL;
+    }
+}
+
+/**
+ * @brief Parallel transport of tangent vector @p v from @p x to @p y along the
+ *        connecting geodesic.
+ *
+ * Hyperbolic: P_{x->y}(v) = (lambda_x / lambda_y) gyr[y, -x] v, with the
+ * gyration expanded through Mobius addition as
+ * gyr[u,w]z = (-(u (+) w)) (+) (u (+) (w (+) z)). Spherical: rotation of the
+ * component of v along the geodesic direction by the arc angle. Euclidean: the
+ * identity -- which is what this op used to return for EVERY curvature.
+ *
+ * @param scratch 5n doubles.
+ * @return NULL on success, else a reason.
+ */
+static const char* eshkol_rm_transport(const double* x, const double* y,
+                                       const double* v, double K, int n,
+                                       double* out, double* scratch) {
+    const char* why = eshkol_rm_check_point(x, K, n);
+    if (why) return why;
+    why = eshkol_rm_check_point(y, K, n);
+    if (why) return why;
+    for (int i = 0; i < n; i++)
+        if (!(v[i] == v[i])) return "a tangent-vector component is NaN";
+
+    if (K == 0.0) {
+        memcpy(out, v, (size_t)n * sizeof(double));
+        return NULL;
+    }
+    if (K < 0.0) {
+        double c  = -K;
+        double* negx = scratch;
+        double* t1   = scratch + n;
+        double* t2   = scratch + 2 * n;
+        double* t3   = scratch + 3 * n;
+        double* negt1 = scratch + 4 * n;
+        for (int i = 0; i < n; i++) negx[i] = -x[i];
+        eshkol_rm_mobius_add(y, negx, c, n, t1);       /* y (+) (-x)          */
+        eshkol_rm_mobius_add(negx, v, c, n, t2);       /* (-x) (+) v          */
+        eshkol_rm_mobius_add(y, t2, c, n, t3);         /* y (+) ((-x) (+) v)  */
+        for (int i = 0; i < n; i++) negt1[i] = -t1[i];
+        eshkol_rm_mobius_add(negt1, t3, c, n, out);    /* gyr[y,-x] v         */
+        double lam_x = 2.0 / (1.0 - c * eshkol_rm_dot(x, x, n));
+        double lam_y = 2.0 / (1.0 - c * eshkol_rm_dot(y, y, n));
+        double ratio = lam_x / lam_y;
+        for (int i = 0; i < n; i++) out[i] *= ratio;
+        return NULL;
+    }
+    {
+        double R = 1.0 / sqrt(K);
+        double* lg = scratch;                 /* log_x(y), needs 2n scratch    */
+        const char* e = eshkol_rm_log_map(x, y, K, n, lg, scratch + n);
+        if (e) return e;
+        double d = eshkol_rm_norm(lg, n);
+        if (d < ESHKOL_RM_ZERO_NORM) {
+            memcpy(out, v, (size_t)n * sizeof(double));
+            return NULL;
+        }
+        double th = d / R;
+        double* u = scratch + 3 * n;
+        for (int i = 0; i < n; i++) u[i] = lg[i] / d;   /* unit initial direction */
+        double vu = eshkol_rm_dot(v, u, n);
+        double ca = cos(th), sa = sin(th);
+        for (int i = 0; i < n; i++)
+            out[i] = v[i] + vu * ((ca - 1.0) * u[i] - sa * x[i] / R);
+        return NULL;
+    }
+}
+
+/**
+ * @brief Project @p x onto the manifold of curvature @p K.
+ *
+ * Hyperbolic: rescale onto the open ball of radius 1/sqrt(c) when @p x is on or
+ * outside it, leaving interior points untouched. Spherical: rescale to radius
+ * 1/sqrt(K). Euclidean: a copy.
+ *
+ * @return NULL on success, else a reason (only when the input cannot be scaled,
+ *         i.e. it is the origin on a sphere).
+ */
+static const char* eshkol_rm_project(const double* x, double K, int n, double* out) {
+    for (int i = 0; i < n; i++)
+        if (!(x[i] == x[i])) return "a coordinate is NaN";
+    if (K == 0.0) {
+        memcpy(out, x, (size_t)n * sizeof(double));
+        return NULL;
+    }
+    double xn = eshkol_rm_norm(x, n);
+    if (K < 0.0) {
+        double R = 1.0 / sqrt(-K);
+        /* Leave a margin so the projected point is STRICTLY inside: a point
+         * exactly on the boundary makes lambda infinite and every log map
+         * degenerate to zero, which is the failure mode frechet_mean_core.h
+         * refuses to let look like convergence. */
+        double limit = R * (1.0 - 1e-12);
+        if (xn <= limit) {
+            memcpy(out, x, (size_t)n * sizeof(double));
+            return NULL;
+        }
+        double s = limit / xn;
+        for (int i = 0; i < n; i++) out[i] = s * x[i];
+        return NULL;
+    }
+    {
+        double R = 1.0 / sqrt(K);
+        if (xn < ESHKOL_RM_ZERO_NORM)
+            return "the origin has no projection onto the sphere";
+        double s = R / xn;
+        for (int i = 0; i < n; i++) out[i] = s * x[i];
+        return NULL;
+    }
+}
+
+/**
+ * @brief Convert a Euclidean gradient @p g at @p x into the Riemannian gradient.
+ *
+ * Hyperbolic: the ball metric is conformal, g_x = lambda_x^2 <.,.>, so the
+ * Riemannian gradient is g / lambda_x^2 = ((1 - c|x|^2)^2 / 4) g. Spherical: the
+ * ambient gradient projected onto the tangent space at @p x. Euclidean: a copy
+ * -- which is what this op used to return for every curvature.
+ *
+ * @return NULL on success, else a reason.
+ */
+static const char* eshkol_rm_egrad_to_rgrad(const double* g, const double* x,
+                                            double K, int n, double* out) {
+    const char* why = eshkol_rm_check_point(x, K, n);
+    if (why) return why;
+    if (K == 0.0) {
+        memcpy(out, g, (size_t)n * sizeof(double));
+        return NULL;
+    }
+    if (K < 0.0) {
+        double c = -K;
+        double f = 1.0 - c * eshkol_rm_dot(x, x, n);
+        double s = (f * f) / 4.0;
+        for (int i = 0; i < n; i++) out[i] = s * g[i];
+        return NULL;
+    }
+    {
+        double R = 1.0 / sqrt(K);
+        double gx = eshkol_rm_dot(g, x, n) / (R * R);
+        for (int i = 0; i < n; i++) out[i] = g[i] - gx * x[i];
+        return NULL;
+    }
+}
+
+#endif /* ESHKOL_BACKEND_RIEMANNIAN_CORE_H */

--- a/lib/backend/vm_geometric.c
+++ b/lib/backend/vm_geometric.c
@@ -75,6 +75,47 @@ static void vm_raise_error_msg(VM* vm, const char* msg);
  * Riemannian units. */
 #include "eshkol/backend/frechet_mean_core.h"
 
+#if !defined(ESHKOL_GEOMETRIC_ENABLED)
+/* Closed-form constant-curvature geometry (Poincare ball / Euclidean / sphere)
+ * in f64. Same reason as the header above for being a header: this file is a
+ * unity-build include and `eshkol-vm-standalone-test` compiles it as one TU, so
+ * there is no object file for it to call into. See that header for the K-sign
+ * convention and for what these ops used to return.
+ *
+ * Scoped to the portable body because the linked-library body reaches the same
+ * geometry through semiclassical_qllm; including it there would leave every
+ * function in it unused. Migrating that body onto these forms too (it is fp32,
+ * and its manifold-dim returns 0) is a separate change on a surface no gate in
+ * this repository covers. */
+#include "eshkol/backend/riemannian_core.h"
+
+/* Scratch for the closed forms below. The widest requirement is
+ * eshkol_rm_transport's 5n doubles; the +2 keeps the tiny-n case from
+ * degenerating to a zero-byte request. */
+#define VM_GEOMETRIC_SCRATCH_MULT 5
+
+/** @brief Allocate @p mult * @p n doubles of region-scoped scratch for the
+ *         closed-form geometry routines. */
+static double* vm_geometric_scratch(VM* vm, int n, int mult) {
+    if (n <= 0) return NULL;
+    return (double*)vm_alloc(&vm->heap.regions,
+                             (size_t)((int64_t)n * mult + 2) * sizeof(double));
+}
+
+/** @brief Raise a catchable condition naming the builtin and the reason a
+ *         constant-curvature op refused. Like every other raise in the VM this
+ *         restores the handler's stack pointer, so the caller must `break`
+ *         WITHOUT pushing a result. */
+static void vm_geometric_raise(VM* vm, const char* op, const char* why, double K) {
+    char msg[320];
+    snprintf(msg, sizeof msg,
+             "%s: %s (sectional curvature K = %.17g; K < 0 is the Poincare ball "
+             "of radius 1/sqrt(-K), K = 0 is Euclidean, K > 0 is the sphere of "
+             "radius 1/sqrt(K))", op, why, K);
+    vm_raise_error_msg(vm, msg);
+}
+#endif /* !ESHKOL_GEOMETRIC_ENABLED */
+
 /**
  * @brief Shared implementation of native id 817 for both the portable and the
  *        linked-library builds: pops (points, weights, curvature), pushes the
@@ -290,21 +331,60 @@ static VmTensor* vm_riemannian_adam_delta(VM* vm, const VmTensor* grad,
     return delta;
 }
 
-/** @brief Apply one Euclidean (flat-manifold) Adam step: compute the
- *         update delta via vm_riemannian_adam_delta() and add it to
- *         @p point. */
-static VmTensor* vm_riemannian_adam_euclidean_step(VM* vm, const VmTensor* point,
-                                                   const VmTensor* grad,
-                                                   VmRiemannianAdamState* st,
-                                                   double lr, double beta1,
-                                                   double beta2) {
-    if (!point || !grad || point->total != grad->total ||
+#if !defined(ESHKOL_GEOMETRIC_ENABLED)
+/**
+ * @brief Apply one Riemannian-Adam step on the manifold of curvature @p K:
+ *        form the Adam delta in the tangent space at @p point, RETRACT along
+ *        the geodesic with the exponential map, and parallel-transport the
+ *        first-moment buffer to the new point.
+ *
+ * This used to be `point + delta`, an ambient vector addition. On the ball that
+ * is not a point of the manifold for a large enough step -- the iterate simply
+ * leaves the space -- and it discarded the curvature argument the op accepts,
+ * so an optimizer named Riemannian ran plain Adam.
+ *
+ * The first moment is a tangent vector at the OLD point and is meaningless at
+ * the new one until transported; this is the transport geoopt's RiemannianAdam
+ * performs. The second moment is a per-coordinate scale, not a tangent vector,
+ * and is left as is -- the same choice, and stated here rather than left to be
+ * inferred from the absence of code.
+ *
+ * @return NULL on allocation/shape failure, or when @p why_out is set (in which
+ *         case the caller raises). @p why_out is set only on a geometry
+ *         refusal.
+ */
+static VmTensor* vm_riemannian_adam_geodesic_step(VM* vm, const VmTensor* point,
+                                                  const VmTensor* grad,
+                                                  VmRiemannianAdamState* st,
+                                                  double lr, double beta1,
+                                                  double beta2, double K,
+                                                  const char** why_out) {
+    if (why_out) *why_out = NULL;
+    if (!point || !grad || point->total != grad->total || point->total <= 0 ||
         !vm_riemannian_adam_state_matches(st, point))
         return NULL;
     VmTensor* delta = vm_riemannian_adam_delta(vm, grad, st, lr, beta1, beta2);
     if (!delta) return NULL;
-    return vm_tensor_linear_combo_for_geometry(vm, point, 1.0, delta, 1.0);
+    if (K == 0.0)
+        return vm_tensor_linear_combo_for_geometry(vm, point, 1.0, delta, 1.0);
+
+    int n = (int)point->total;
+    VmTensor* out = vm_tensor_zeros(&vm->heap.regions, point->shape, point->n_dims);
+    double* scratch = vm_geometric_scratch(vm, n, VM_GEOMETRIC_SCRATCH_MULT);
+    double* moved   = vm_geometric_scratch(vm, n, 1);
+    if (!out || !scratch || !moved) return NULL;
+
+    const char* why = eshkol_rm_exp_map(point->data, delta->data, K, n,
+                                        out->data, scratch);
+    if (why) { if (why_out) *why_out = why; return NULL; }
+
+    why = eshkol_rm_transport(point->data, out->data, st->m, K, n, moved, scratch);
+    if (why) { if (why_out) *why_out = why; return NULL; }
+    memcpy(st->m, moved, (size_t)n * sizeof(double));
+    return out;
 }
+#endif /* !ESHKOL_GEOMETRIC_ENABLED — the linked-library body has its own
+          * Adam cases, which retract through qllm_hyperbolic_exp_map. */
 
 /** @brief Whether @p mv is a manifold Value wrapping a non-null handle. */
 static int vm_manifold_has_value(VM* vm, Value mv) {
@@ -587,53 +667,155 @@ static void vm_dispatch_geometric_fallback(VM* vm, int fid) {
     }
 
     case 809: case 842: { /* exp-map/retraction(base, tangent, curvature) */
-        (void)as_number(vm_pop(vm));
+        /* Was `base + tangent` for every curvature. That is exp_x(v) only at
+         * K = 0; on the ball the geodesic is a circular arc orthogonal to the
+         * boundary and the endpoint is a Mobius sum, not a vector sum. */
+        double K = as_number(vm_pop(vm));
         VmTensor* tangent = vm_get_tensor(vm, vm_pop(vm));
         VmTensor* base = vm_get_tensor(vm, vm_pop(vm));
-        vm_push_tensor_or_nil(vm, vm_tensor_linear_combo_for_geometry(vm, base, 1.0, tangent, 1.0));
+        if (!base || !tangent || !base->data || !tangent->data ||
+            base->total != tangent->total || base->total <= 0) {
+            vm_push(vm, NIL_VAL); break;
+        }
+        int n = (int)base->total;
+        VmTensor* out = vm_tensor_zeros(&vm->heap.regions, base->shape, base->n_dims);
+        double* scratch = vm_geometric_scratch(vm, n, VM_GEOMETRIC_SCRATCH_MULT);
+        if (!out || !scratch) { vm_push(vm, NIL_VAL); break; }
+        const char* why = eshkol_rm_exp_map(base->data, tangent->data, K, n,
+                                            out->data, scratch);
+        if (why) { vm_geometric_raise(vm, fid == 842 ? "retraction" : "exp-map", why, K); break; }
+        VM_PUSH_TENSOR(vm, out);
         break;
     }
     case 810: case 822: { /* log-map(base, point, curvature) / spherical-log(base, point) */
-        if (fid == 810) (void)as_number(vm_pop(vm));
+        /* Was `point - base` for every curvature, i.e. the K = 0 answer under
+         * both names. `spherical-log` carries no curvature argument: it is the
+         * unit sphere, K = +1. */
+        double K = 1.0;
+        if (fid == 810) K = as_number(vm_pop(vm));
         VmTensor* point = vm_get_tensor(vm, vm_pop(vm));
         VmTensor* base = vm_get_tensor(vm, vm_pop(vm));
-        vm_push_tensor_or_nil(vm, vm_tensor_linear_combo_for_geometry(vm, point, 1.0, base, -1.0));
+        if (!base || !point || !base->data || !point->data ||
+            base->total != point->total || base->total <= 0) {
+            vm_push(vm, NIL_VAL); break;
+        }
+        int n = (int)base->total;
+        VmTensor* out = vm_tensor_zeros(&vm->heap.regions, base->shape, base->n_dims);
+        double* scratch = vm_geometric_scratch(vm, n, VM_GEOMETRIC_SCRATCH_MULT);
+        if (!out || !scratch) { vm_push(vm, NIL_VAL); break; }
+        const char* why = eshkol_rm_log_map(base->data, point->data, K, n,
+                                            out->data, scratch);
+        if (why) { vm_geometric_raise(vm, fid == 822 ? "spherical-log" : "log-map", why, K); break; }
+        VM_PUSH_TENSOR(vm, out);
         break;
     }
     case 811: case 816: { /* geodesic-distance/poincare-distance(x, y, curvature) */
-        (void)as_number(vm_pop(vm));
+        /* Was the L2 distance for every curvature. On the ball the L2 chord is
+         * bounded by the ball diameter while the geodesic distance diverges at
+         * the boundary, so the two disagree without bound: at K = -1 the points
+         * (0.9, 0) and (-0.9, 0) are 1.8 apart in L2 and 5.9 apart in the
+         * metric the name promises. */
+        double K = as_number(vm_pop(vm));
         VmTensor* y = vm_get_tensor(vm, vm_pop(vm));
         VmTensor* x = vm_get_tensor(vm, vm_pop(vm));
-        if (x && y && x->total == y->total) vm_push_float(vm, vm_tensor_distance_for_geometry(x, y));
-        else vm_push(vm, NIL_VAL);
+        if (!x || !y || !x->data || !y->data || x->total != y->total || x->total <= 0) {
+            vm_push(vm, NIL_VAL); break;
+        }
+        double d = 0.0;
+        const char* why = eshkol_rm_distance(x->data, y->data, K, (int)x->total, &d);
+        if (why) {
+            vm_geometric_raise(vm, fid == 816 ? "poincare-distance" : "geodesic-distance", why, K);
+            break;
+        }
+        vm_push_float(vm, d);
         break;
     }
     case 812: case 843: { /* parallel/vector transport(x, y, v, curvature) */
-        (void)as_number(vm_pop(vm));
+        /* Was the identity on v, with x and y popped and discarded. Holonomy is
+         * the whole content of the op: on a curved manifold transporting a
+         * vector around a closed loop rotates it, and the identity map reports
+         * that curvature is zero. */
+        double K = as_number(vm_pop(vm));
         VmTensor* v = vm_get_tensor(vm, vm_pop(vm));
-        (void)vm_pop(vm); /* y */
-        (void)vm_pop(vm); /* x */
-        vm_push_tensor_or_nil(vm, vm_tensor_copy_for_geometry(vm, v));
+        VmTensor* y = vm_get_tensor(vm, vm_pop(vm));
+        VmTensor* x = vm_get_tensor(vm, vm_pop(vm));
+        if (!x || !y || !v || !x->data || !y->data || !v->data ||
+            x->total != y->total || x->total != v->total || x->total <= 0) {
+            vm_push(vm, NIL_VAL); break;
+        }
+        int n = (int)x->total;
+        VmTensor* out = vm_tensor_zeros(&vm->heap.regions, v->shape, v->n_dims);
+        double* scratch = vm_geometric_scratch(vm, n, VM_GEOMETRIC_SCRATCH_MULT);
+        if (!out || !scratch) { vm_push(vm, NIL_VAL); break; }
+        const char* why = eshkol_rm_transport(x->data, y->data, v->data, K, n,
+                                               out->data, scratch);
+        if (why) {
+            vm_geometric_raise(vm, fid == 843 ? "vector-transport" : "parallel-transport", why, K);
+            break;
+        }
+        VM_PUSH_TENSOR(vm, out);
         break;
     }
     case 813: { /* manifold-project(x, curvature) */
-        (void)as_number(vm_pop(vm));
+        /* Was a copy, so a point outside the ball stayed outside and every op
+         * downstream inherited an argument off the manifold. */
+        double K = as_number(vm_pop(vm));
         VmTensor* x = vm_get_tensor(vm, vm_pop(vm));
-        vm_push_tensor_or_nil(vm, vm_tensor_copy_for_geometry(vm, x));
+        if (!x || !x->data || x->total <= 0) { vm_push(vm, NIL_VAL); break; }
+        VmTensor* out = vm_tensor_zeros(&vm->heap.regions, x->shape, x->n_dims);
+        if (!out) { vm_push(vm, NIL_VAL); break; }
+        const char* why = eshkol_rm_project(x->data, K, (int)x->total, out->data);
+        if (why) { vm_geometric_raise(vm, "manifold-project", why, K); break; }
+        VM_PUSH_TENSOR(vm, out);
         break;
     }
     case 814: { /* mobius-add(x, y, curvature) */
-        (void)as_number(vm_pop(vm));
+        /* Was x + y for every curvature. Mobius addition is NOT commutative and
+         * NOT associative -- gyr[x,y] is exactly the failure of commutativity --
+         * so a commutative stand-in erases the structure the op names. */
+        double K = as_number(vm_pop(vm));
         VmTensor* y = vm_get_tensor(vm, vm_pop(vm));
         VmTensor* x = vm_get_tensor(vm, vm_pop(vm));
-        vm_push_tensor_or_nil(vm, vm_tensor_linear_combo_for_geometry(vm, x, 1.0, y, 1.0));
+        if (!x || !y || !x->data || !y->data || x->total != y->total || x->total <= 0) {
+            vm_push(vm, NIL_VAL); break;
+        }
+        if (K > 0.0) {
+            vm_geometric_raise(vm, "mobius-add",
+                               "Mobius addition is the gyrogroup operation of the "
+                               "Poincare ball and is defined for K <= 0 only", K);
+            break;
+        }
+        const char* why = eshkol_rm_check_point(x->data, K, (int)x->total);
+        if (!why) why = eshkol_rm_check_point(y->data, K, (int)y->total);
+        if (why) { vm_geometric_raise(vm, "mobius-add", why, K); break; }
+        VmTensor* out = vm_tensor_zeros(&vm->heap.regions, x->shape, x->n_dims);
+        if (!out) { vm_push(vm, NIL_VAL); break; }
+        eshkol_rm_mobius_add(x->data, y->data, -K, (int)x->total, out->data);
+        VM_PUSH_TENSOR(vm, out);
         break;
     }
     case 815: { /* mobius-scalar-mul(r, x, curvature) */
-        (void)as_number(vm_pop(vm));
+        /* Was r*x for every curvature, which leaves the ball for |r| large
+         * enough -- the real operation cannot, because it is
+         * (1/sqrt(c)) tanh(r artanh(sqrt(c)|x|)) x/|x| and tanh is bounded. */
+        double K = as_number(vm_pop(vm));
         VmTensor* x = vm_get_tensor(vm, vm_pop(vm));
         double r = as_number(vm_pop(vm));
-        vm_push_tensor_or_nil(vm, vm_tensor_scale_for_geometry(vm, x, r));
+        if (!x || !x->data || x->total <= 0) { vm_push(vm, NIL_VAL); break; }
+        if (K > 0.0) {
+            vm_geometric_raise(vm, "mobius-scalar-mul",
+                               "Mobius scalar multiplication is the gyrovector "
+                               "operation of the Poincare ball and is defined for "
+                               "K <= 0 only", K);
+            break;
+        }
+        const char* why = eshkol_rm_check_point(x->data, K, (int)x->total);
+        if (why) { vm_geometric_raise(vm, "mobius-scalar-mul", why, K); break; }
+        VmTensor* out = vm_tensor_zeros(&vm->heap.regions, x->shape, x->n_dims);
+        if (!out) { vm_push(vm, NIL_VAL); break; }
+        why = eshkol_rm_mobius_scalar(r, x->data, -K, (int)x->total, out->data);
+        if (why) { vm_geometric_raise(vm, "mobius-scalar-mul", why, K); break; }
+        VM_PUSH_TENSOR(vm, out);
         break;
     }
     case 817: /* frechet-mean(points, weights, curvature) */
@@ -666,11 +848,24 @@ static void vm_dispatch_geometric_fallback(VM* vm, int fid) {
         break;
     }
     case 821: { /* spherical-exp(base, tangent) */
+        /* Was normalize(base + tangent), a RETRACTION and not the exponential
+         * map: it lands on the right geodesic but at the wrong arc length
+         * (atan|v| instead of |v|), so it is first-order correct and wrong at
+         * every order after. */
         VmTensor* tangent = vm_get_tensor(vm, vm_pop(vm));
         VmTensor* base = vm_get_tensor(vm, vm_pop(vm));
-        VmTensor* out = vm_tensor_linear_combo_for_geometry(vm, base, 1.0, tangent, 1.0);
-        vm_tensor_normalize_for_geometry(out);
-        vm_push_tensor_or_nil(vm, out);
+        if (!base || !tangent || !base->data || !tangent->data ||
+            base->total != tangent->total || base->total <= 0) {
+            vm_push(vm, NIL_VAL); break;
+        }
+        int n = (int)base->total;
+        VmTensor* out = vm_tensor_zeros(&vm->heap.regions, base->shape, base->n_dims);
+        double* scratch = vm_geometric_scratch(vm, n, VM_GEOMETRIC_SCRATCH_MULT);
+        if (!out || !scratch) { vm_push(vm, NIL_VAL); break; }
+        const char* why = eshkol_rm_exp_map(base->data, tangent->data, 1.0, n,
+                                             out->data, scratch);
+        if (why) { vm_geometric_raise(vm, "spherical-exp", why, 1.0); break; }
+        VM_PUSH_TENSOR(vm, out);
         break;
     }
     case 823: { /* spherical-project(x) */
@@ -837,16 +1032,36 @@ static void vm_dispatch_geometric_fallback(VM* vm, int fid) {
         break;
     }
     case 835: { /* exterior-derivative(form) */
-        VmTensor* form = vm_get_tensor(vm, vm_pop(vm));
-        if (!form) { vm_push(vm, NIL_VAL); break; }
-        VmTensor* out = vm_tensor_zeros(&vm->heap.regions, form->shape, form->n_dims);
-        vm_push_tensor_or_nil(vm, out);
+        /* Returned a zero tensor of the input's shape for every input, which
+         * reads as "d(this form) = 0", i.e. that every form handed to it is
+         * closed. That is a statement about the form, and it was made without
+         * looking at one: the argument is a coefficient array AT A POINT and
+         * carries no derivative information at all, so no value of d can be
+         * computed from it. Refusing names the missing input instead of
+         * asserting closedness. */
+        (void)vm_pop(vm);
+        vm_raise_error_msg(vm,
+            "exterior-derivative: not implemented on the VM engine. The argument "
+            "is a form's coefficient array at a single point, which carries no "
+            "derivative information; computing d needs the coefficients as "
+            "differentiable functions of position. This op previously returned "
+            "zeros, which asserts that every form is closed.");
         break;
     }
     case 836: { /* hodge-star(form, metric) */
+        /* Returned its input unchanged, which is the Hodge star only for a
+         * self-dual middle-degree form in a Euclidean metric -- and the op does
+         * not know the form's degree, because a flat coefficient array does not
+         * record it. Without the degree the star is not determined, so this
+         * refuses rather than returning the identity under the name of a
+         * duality. */
         (void)vm_pop(vm);
-        VmTensor* form = vm_get_tensor(vm, vm_pop(vm));
-        vm_push_tensor_or_nil(vm, vm_tensor_copy_for_geometry(vm, form));
+        (void)vm_pop(vm);
+        vm_raise_error_msg(vm,
+            "hodge-star: not implemented on the VM engine. The star of a k-form "
+            "depends on k and on the dimension, and a flat coefficient array "
+            "records neither; the op has no way to tell which duality is being "
+            "asked for. This op previously returned its argument unchanged.");
         break;
     }
     case 837: { /* interior-product(vector, form) */
@@ -866,23 +1081,43 @@ static void vm_dispatch_geometric_fallback(VM* vm, int fid) {
     }
 
     case 839: { /* riemannian-sgd-step(point, gradient, lr, curvature) */
-        (void)as_number(vm_pop(vm));
+        /* Was point - lr*grad, which is the K = 0 update and leaves the ball
+         * outright for a large enough step. The step is now a geodesic one:
+         * exp_point(-lr * gradient). `gradient` is the RIEMANNIAN gradient (a
+         * tangent vector); `riemannian-grad` is the op that converts a Euclidean
+         * one, which is why they are separate names. */
+        double K = as_number(vm_pop(vm));
         double lr = as_number(vm_pop(vm));
         VmTensor* grad = vm_get_tensor(vm, vm_pop(vm));
         VmTensor* point = vm_get_tensor(vm, vm_pop(vm));
-        vm_push_tensor_or_nil(vm, vm_tensor_linear_combo_for_geometry(vm, point, 1.0, grad, -lr));
+        if (!point || !grad || !point->data || !grad->data ||
+            point->total != grad->total || point->total <= 0) {
+            vm_push(vm, NIL_VAL); break;
+        }
+        int n = (int)point->total;
+        VmTensor* step = vm_tensor_scale_for_geometry(vm, grad, -lr);
+        VmTensor* out = vm_tensor_zeros(&vm->heap.regions, point->shape, point->n_dims);
+        double* scratch = vm_geometric_scratch(vm, n, VM_GEOMETRIC_SCRATCH_MULT);
+        if (!step || !out || !scratch) { vm_push(vm, NIL_VAL); break; }
+        const char* why = eshkol_rm_exp_map(point->data, step->data, K, n,
+                                             out->data, scratch);
+        if (why) { vm_geometric_raise(vm, "riemannian-sgd-step", why, K); break; }
+        VM_PUSH_TENSOR(vm, out);
         break;
     }
     case 840: { /* riemannian-adam-step(point, gradient, lr, beta1, beta2, curvature) */
-        (void)as_number(vm_pop(vm));
+        double K = as_number(vm_pop(vm));
         double beta2 = as_number(vm_pop(vm));
         double beta1 = as_number(vm_pop(vm));
         double lr = as_number(vm_pop(vm));
         VmTensor* grad = vm_get_tensor(vm, vm_pop(vm));
         VmTensor* point = vm_get_tensor(vm, vm_pop(vm));
         VmRiemannianAdamState* st = vm_default_riemannian_adam_state(vm, point);
-        vm_push_tensor_or_nil(vm, vm_riemannian_adam_euclidean_step(
-            vm, point, grad, st, lr, beta1, beta2));
+        const char* why = NULL;
+        VmTensor* out = vm_riemannian_adam_geodesic_step(
+            vm, point, grad, st, lr, beta1, beta2, K, &why);
+        if (why) { vm_geometric_raise(vm, "riemannian-adam-step", why, K); break; }
+        vm_push_tensor_or_nil(vm, out);
         break;
     }
     case 860: { /* make-riemannian-adam-state(point) */
@@ -891,27 +1126,44 @@ static void vm_dispatch_geometric_fallback(VM* vm, int fid) {
         break;
     }
     case 861: { /* riemannian-adam-step!(state, point, gradient, lr, beta1, beta2, curvature) */
-        (void)as_number(vm_pop(vm));
+        double K = as_number(vm_pop(vm));
         double beta2 = as_number(vm_pop(vm));
         double beta1 = as_number(vm_pop(vm));
         double lr = as_number(vm_pop(vm));
         VmTensor* grad = vm_get_tensor(vm, vm_pop(vm));
         VmTensor* point = vm_get_tensor(vm, vm_pop(vm));
         VmRiemannianAdamState* st = vm_riemannian_adam_state_from_value(vm, vm_pop(vm));
-        vm_push_tensor_or_nil(vm, vm_riemannian_adam_euclidean_step(
-            vm, point, grad, st, lr, beta1, beta2));
+        const char* why = NULL;
+        VmTensor* out = vm_riemannian_adam_geodesic_step(
+            vm, point, grad, st, lr, beta1, beta2, K, &why);
+        if (why) { vm_geometric_raise(vm, "riemannian-adam-step!", why, K); break; }
+        vm_push_tensor_or_nil(vm, out);
         break;
     }
     case 841: { /* riemannian-grad(euclidean_grad, point, curvature) */
-        (void)as_number(vm_pop(vm));
-        (void)vm_pop(vm);
+        /* Was a copy of the Euclidean gradient, with the point popped and
+         * discarded -- i.e. it asserted the metric is the identity everywhere.
+         * On the ball the metric is conformal with factor lambda_x, so the
+         * Riemannian gradient is ((1 - c|x|^2)^2 / 4) times the Euclidean one,
+         * a factor that goes to zero at the boundary. */
+        double K = as_number(vm_pop(vm));
+        VmTensor* point = vm_get_tensor(vm, vm_pop(vm));
         VmTensor* grad = vm_get_tensor(vm, vm_pop(vm));
-        vm_push_tensor_or_nil(vm, vm_tensor_copy_for_geometry(vm, grad));
+        if (!grad || !point || !grad->data || !point->data ||
+            grad->total != point->total || grad->total <= 0) {
+            vm_push(vm, NIL_VAL); break;
+        }
+        VmTensor* out = vm_tensor_zeros(&vm->heap.regions, grad->shape, grad->n_dims);
+        if (!out) { vm_push(vm, NIL_VAL); break; }
+        const char* why = eshkol_rm_egrad_to_rgrad(grad->data, point->data, K,
+                                                    (int)grad->total, out->data);
+        if (why) { vm_geometric_raise(vm, "riemannian-grad", why, K); break; }
+        VM_PUSH_TENSOR(vm, out);
         break;
     }
 
     case 844: { /* geodesic-attention-scores(Q, K, curvature) */
-        (void)as_number(vm_pop(vm));
+        double Kc = as_number(vm_pop(vm));
         VmTensor* k = vm_get_tensor(vm, vm_pop(vm));
         VmTensor* q = vm_get_tensor(vm, vm_pop(vm));
         if (!q || !k || !q->data || !k->data) { vm_push(vm, NIL_VAL); break; }
@@ -923,14 +1175,18 @@ static void vm_dispatch_geometric_fallback(VM* vm, int fid) {
         int64_t shape[2] = {nq, nk};
         VmTensor* out = vm_tensor_zeros(&vm->heap.regions, shape, 2);
         if (!out) { vm_push(vm, NIL_VAL); break; }
+        /* Scored by the NEGATIVE GEODESIC distance, the same convention as
+         * `ad_geodesic_attention` in lib/bridge/qllm_bridge.cpp. This used to be
+         * the negative L2 distance for every curvature, so "geodesic attention"
+         * on the ball ranked keys by the ambient chord. */
         for (int i = 0; i < nq; i++) {
             for (int j = 0; j < nk; j++) {
-                double sum = 0.0;
-                for (int d = 0; d < qdim; d++) {
-                    double diff = q->data[i * qdim + d] - k->data[j * kdim + d];
-                    sum += diff * diff;
-                }
-                out->data[i * nk + j] = -sqrt(sum);
+                double dist = 0.0;
+                const char* why = eshkol_rm_distance(q->data + (int64_t)i * qdim,
+                                                     k->data + (int64_t)j * kdim,
+                                                     Kc, qdim, &dist);
+                if (why) { vm_geometric_raise(vm, "geodesic-attention-scores", why, Kc); return; }
+                out->data[i * nk + j] = -dist;
             }
         }
         VM_PUSH_TENSOR(vm, out);
@@ -974,7 +1230,7 @@ static void vm_dispatch_geometric_fallback(VM* vm, int fid) {
         break;
     }
     case 847: { /* geodesic-attention-forward(Q, K, V, curvature) */
-        (void)as_number(vm_pop(vm));
+        double Kc = as_number(vm_pop(vm));
         VmTensor* values = vm_get_tensor(vm, vm_pop(vm));
         VmTensor* k = vm_get_tensor(vm, vm_pop(vm));
         VmTensor* q = vm_get_tensor(vm, vm_pop(vm));
@@ -987,20 +1243,35 @@ static void vm_dispatch_geometric_fallback(VM* vm, int fid) {
         int64_t shape[2] = {nq, vdim};
         VmTensor* out = vm_tensor_zeros(&vm->heap.regions, shape, 2);
         if (!out) { vm_push(vm, NIL_VAL); break; }
+        /* Softmax over the NEGATIVE GEODESIC distance, scaled by
+         * 1/(sqrt(c) sqrt(dim)), then a Euclidean weighted sum of the value
+         * rows -- the aggregation `ad_geodesic_attention` performs. Two things
+         * changed here: the distance was the ambient L2 for every curvature, and
+         * the weights were exp() with no max-shift, which overflows to inf for
+         * strongly negative scores and then divides inf by inf. */
+        double sc = (Kc < 0.0) ? sqrt(-Kc) : 1.0;
+        double scale = 1.0 / (sc * sqrt((double)dim));
+        double* row = vm_geometric_scratch(vm, nk, 1);
+        if (!row) { vm_push(vm, NIL_VAL); break; }
         for (int i = 0; i < nq; i++) {
-            double wsum = 0.0;
+            double mx = -HUGE_VAL;
             for (int j = 0; j < nk; j++) {
-                double dist2 = 0.0;
-                for (int d = 0; d < dim; d++) {
-                    double diff = q->data[i * dim + d] - k->data[j * dim + d];
-                    dist2 += diff * diff;
-                }
-                double w = exp(-sqrt(dist2));
-                wsum += w;
-                for (int d = 0; d < vdim; d++) out->data[i * vdim + d] += w * values->data[j * vdim + d];
+                double dist = 0.0;
+                const char* why = eshkol_rm_distance(q->data + (int64_t)i * dim,
+                                                     k->data + (int64_t)j * dim,
+                                                     Kc, dim, &dist);
+                if (why) { vm_geometric_raise(vm, "geodesic-attention-forward", why, Kc); return; }
+                row[j] = -dist * scale;
+                if (row[j] > mx) mx = row[j];
             }
-            if (wsum != 0.0)
-                for (int d = 0; d < vdim; d++) out->data[i * vdim + d] /= wsum;
+            double wsum = 0.0;
+            for (int j = 0; j < nk; j++) { row[j] = exp(row[j] - mx); wsum += row[j]; }
+            if (wsum <= 0.0) wsum = 1.0;
+            for (int j = 0; j < nk; j++) {
+                double w = row[j] / wsum;
+                for (int d = 0; d < vdim; d++)
+                    out->data[i * vdim + d] += w * values->data[j * vdim + d];
+            }
         }
         VM_PUSH_TENSOR(vm, out);
         break;

--- a/tests/vm/geometric_fallback_numeric_regression.esk
+++ b/tests/vm/geometric_fallback_numeric_regression.esk
@@ -34,8 +34,27 @@
 (define interior (interior-product p p))
 (display (if (= (tensor-ref interior 0) 2.0) "PASS" "FAIL")) (display ": interior product") (newline)
 
-(define step (riemannian-sgd-step p p 0.25 -1.0))
-(display (if (= (tensor-ref step 0) 0.75) "PASS" "FAIL")) (display ": riemannian sgd") (newline)
+;; riemannian-sgd-step USED to be asserted here as `p - 0.25*p = 0.75` at
+;; curvature -1.0 -- with p = (1.0, 1.0), a point whose norm is sqrt(2) and which
+;; therefore is not in the Poincare ball of radius 1 at all. The assertion held
+;; only because the op ignored its curvature argument and did the flat update. It
+;; is now two assertions: the flat update at K = 0, where it is exactly right,
+;; and the geodesic update on the ball, where it is not the flat one.
+(define step (riemannian-sgd-step p p 0.25 0.0))
+(display (if (= (tensor-ref step 0) 0.75) "PASS" "FAIL")) (display ": riemannian sgd at K = 0") (newline)
+
+(define ball-p (make-tensor '(2) 0.25))
+(define ball-g (make-tensor '(2) 0.5))
+(define curved-step (riemannian-sgd-step ball-p ball-g 0.25 -1.0))
+(define flat-step 0.125)   ; 0.25 - 0.25*0.5, the answer the old body gave
+(display (if (> (abs (- (tensor-ref curved-step 0) flat-step)) 0.001) "PASS" "FAIL"))
+(display ": riemannian sgd on the ball is not the flat update") (newline)
+
+;; The step stays inside the ball, which the flat update does not guarantee.
+(display (if (< (+ (* (tensor-ref curved-step 0) (tensor-ref curved-step 0))
+                   (* (tensor-ref curved-step 1) (tensor-ref curved-step 1))) 1.0)
+             "PASS" "FAIL"))
+(display ": riemannian sgd stays on the manifold") (newline)
 
 (define probs (curvature-softmax (make-tensor '(2) 0.0) -1.0))
 (display (if (= (tensor-ref probs 0) 0.5) "PASS" "FAIL")) (display ": curvature softmax 0") (newline)

--- a/tests/vm/geometric_riemannian_surface_regression.esk
+++ b/tests/vm/geometric_riemannian_surface_regression.esk
@@ -1,0 +1,194 @@
+;; Standalone VM Riemannian-geometry numeric regression (SW-73).
+;;
+;; The geometric builtins used to compute their FLAT counterparts on every
+;; engine that ships: `hyperbolic-exp-map` was vector addition,
+;; `hyperbolic-log-map` subtraction, `geodesic-distance` and `poincare-distance`
+;; the L2 distance, `mobius-add` addition, `mobius-scalar-mul` a scale,
+;; `parallel-transport` and `riemannian-grad` the identity. Each accepted a
+;; curvature argument and discarded it, so the results were Euclidean answers
+;; returned under Riemannian names with nothing in the output to show it.
+;;
+;; Every assertion below is chosen so that THE FLAT ANSWER FAILS IT. The
+;; expected values are the closed forms in inc/eshkol/backend/riemannian_core.h,
+;; which are the same formulas the AD bridge computes
+;; (lib/bridge/qllm_bridge.cpp: ad_hyperbolic_distance, ad_poincare_exp_map,
+;; ad_poincare_log_map). Curvature is the SECTIONAL curvature K: K < 0 is the
+;; Poincare ball of radius 1/sqrt(-K), K = 0 is Euclidean, K > 0 is the sphere
+;; of radius 1/sqrt(K).
+
+(define (near? a b) (< (abs (- a b)) 0.000000001))
+(define (far? a b) (> (abs (- a b)) 0.001))
+(define (report ok name)
+  (display (if ok "PASS" "FAIL")) (display ": ") (display name) (newline))
+
+(define (vec2 a b)
+  (let ((t (make-tensor '(2) 0.0)))
+    (tensor-set! t 0 a)
+    (tensor-set! t 1 b)
+    t))
+
+(define (vec3 a b c)
+  (let ((t (make-tensor '(3) 0.0)))
+    (tensor-set! t 0 a)
+    (tensor-set! t 1 b)
+    (tensor-set! t 2 c)
+    t))
+
+;; ── geodesic distance is not the chord ───────────────────────────────────────
+;; Two points 1.8 apart in L2, one tenth of a unit inside the boundary of the
+;; unit ball. The hyperbolic distance between them is 4 artanh(0.9) = 5.8889 —
+;; more than three times the flat answer, and it diverges as the points approach
+;; the boundary while the chord stays bounded by the diameter.
+(define near-a (vec2 0.9 0.0))
+(define near-b (vec2 -0.9 0.0))
+(define d-boundary (geodesic-distance near-a near-b -1.0))
+(report (near? d-boundary 5.8888779583328814) "geodesic-distance near the ball boundary")
+(report (far? d-boundary 1.8) "geodesic-distance is not the L2 chord")
+
+;; poincare-distance is the same op under its other name.
+(report (near? (poincare-distance near-a near-b -1.0) 5.8888779583328814)
+        "poincare-distance agrees with geodesic-distance")
+
+;; At K = 0 the geodesic distance IS the chord, exactly. The old body was right
+;; for this one value of the argument and wrong for every other.
+(report (near? (geodesic-distance near-a near-b 0.0) 1.8)
+        "geodesic-distance reduces to L2 at K = 0")
+
+;; ── exp and log are mutually inverse, and neither is +/- ─────────────────────
+(define px (vec2 0.3 -0.1))
+(define py (vec2 -0.5 0.2))
+(define lg (hyperbolic-log-map px py -1.0))
+(report (near? (tensor-ref lg 0) -0.78553136001518009) "log-map component 0")
+(report (near? (tensor-ref lg 1) 0.28694063523451202) "log-map component 1")
+(report (far? (tensor-ref lg 0) -0.8) "log-map is not the difference y - x")
+
+(define back (hyperbolic-exp-map px lg -1.0))
+(report (near? (tensor-ref back 0) -0.5) "exp-map inverts log-map, component 0")
+(report (near? (tensor-ref back 1) 0.2) "exp-map inverts log-map, component 1")
+
+;; The Riemannian length of log_x(y) is the geodesic distance: the tangent space
+;; carries the conformal metric lambda_x^2 <.,.>, lambda_x = 2/(1 - |x|^2).
+(define lam-x (/ 2.0 (- 1.0 (+ (* 0.3 0.3) (* 0.1 0.1)))))
+(define lg-len (sqrt (+ (* (tensor-ref lg 0) (tensor-ref lg 0))
+                        (* (tensor-ref lg 1) (tensor-ref lg 1)))))
+(report (near? (* lam-x lg-len) (geodesic-distance px py -1.0))
+        "lambda_x * |log_x(y)| equals the geodesic distance")
+
+;; ── Mobius addition is not commutative ───────────────────────────────────────
+;; This is the whole content of the gyrogroup structure: gyr[x,y] is exactly the
+;; failure of commutativity. Plain vector addition, the old body, commutes.
+(define xy (mobius-add px py -1.0))
+(define yx (mobius-add py px -1.0))
+(report (near? (tensor-ref xy 0) -0.23947750362844705) "mobius-add component 0")
+(report (near? (tensor-ref xy 1) 0.12336719883889698) "mobius-add component 1")
+(report (far? (tensor-ref xy 1) (tensor-ref yx 1)) "mobius-add is NOT commutative")
+(report (far? (tensor-ref xy 0) (+ 0.3 -0.5)) "mobius-add is not vector addition")
+
+;; 2 (x) x = x (+) x — the gyrovector scalar multiple agrees with the addition.
+(define twice (mobius-scalar-mul 2.0 px -1.0))
+(define selfsum (mobius-add px px -1.0))
+(report (near? (tensor-ref twice 0) (tensor-ref selfsum 0)) "2 (x) x = x (+) x, component 0")
+(report (near? (tensor-ref twice 1) (tensor-ref selfsum 1)) "2 (x) x = x (+) x, component 1")
+(report (far? (tensor-ref twice 0) 0.6) "mobius-scalar-mul is not r*x")
+
+;; ── parallel transport is not the identity ───────────────────────────────────
+;; It was, for every curvature. Transport IS the holonomy of the connection: the
+;; identity map is the statement that the manifold is flat.
+(define tv (vec2 0.2 0.4))
+(define pt (parallel-transport px py tv -1.0))
+(report (near? (tensor-ref pt 0) 0.16314844574304069) "parallel-transport component 0")
+(report (near? (tensor-ref pt 1) 0.31281259638016379) "parallel-transport component 1")
+(report (far? (tensor-ref pt 0) 0.2) "parallel-transport is NOT the identity")
+
+;; Transport is an isometry of the Riemannian metric even though it changes the
+;; ambient components: lambda_y |P v| = lambda_x |v|.
+(define lam-y (/ 2.0 (- 1.0 (+ (* 0.5 0.5) (* 0.2 0.2)))))
+(define v-len (sqrt (+ (* 0.2 0.2) (* 0.4 0.4))))
+(define pt-len (sqrt (+ (* (tensor-ref pt 0) (tensor-ref pt 0))
+                        (* (tensor-ref pt 1) (tensor-ref pt 1)))))
+(report (near? (* lam-y pt-len) (* lam-x v-len))
+        "parallel-transport preserves Riemannian length")
+
+;; Transporting from a point to itself is the identity.
+(define pt-self (parallel-transport px px tv -1.0))
+(report (near? (tensor-ref pt-self 0) 0.2) "parallel-transport x -> x is the identity")
+
+;; At K = 0 transport IS the identity, exactly.
+(define pt-flat (parallel-transport px py tv 0.0))
+(report (near? (tensor-ref pt-flat 0) 0.2) "parallel-transport is the identity at K = 0")
+
+;; ── riemannian-grad rescales by the metric ───────────────────────────────────
+;; Was a copy of the Euclidean gradient with the point discarded. On the ball the
+;; conversion factor is (1 - |x|^2)^2 / 4, which vanishes at the boundary.
+(define eg (vec2 1.0 0.0))
+(define rg (riemannian-grad eg px -1.0))
+(report (near? (tensor-ref rg 0) 0.2025) "riemannian-grad applies the inverse metric")
+(report (far? (tensor-ref rg 0) 1.0) "riemannian-grad is not a copy")
+(report (near? (tensor-ref (riemannian-grad eg px 0.0) 0) 1.0)
+        "riemannian-grad is a copy at K = 0")
+
+;; ── manifold-project puts a point back on the manifold ───────────────────────
+;; Was a copy, so a point outside the ball stayed outside.
+(define outside (vec2 3.0 4.0))
+(define projected (manifold-project outside -1.0))
+(report (near? (tensor-ref projected 0) 0.59999999999940001) "manifold-project component 0")
+(report (< (sqrt (+ (* (tensor-ref projected 0) (tensor-ref projected 0))
+                    (* (tensor-ref projected 1) (tensor-ref projected 1)))) 1.0)
+        "manifold-project lands strictly inside the ball")
+
+;; ── the SGD step follows the geodesic ────────────────────────────────────────
+;; Was point - lr*grad, which leaves the ball for a large enough step.
+(define sgd (riemannian-sgd-step px tv 0.5 -1.0))
+(report (near? (tensor-ref sgd 0) 0.2166917684430178) "riemannian-sgd-step component 0")
+(report (near? (tensor-ref sgd 1) -0.30456057908269812) "riemannian-sgd-step component 1")
+(report (far? (tensor-ref sgd 0) 0.2) "riemannian-sgd-step is not the flat update")
+(report (near? (tensor-ref (riemannian-sgd-step px tv 0.5 0.0) 0) 0.2)
+        "riemannian-sgd-step is the flat update at K = 0")
+
+;; ── the sphere branch is the round sphere, not a normalization ───────────────
+;; spherical-exp was normalize(base + tangent), a retraction that lands on the
+;; right geodesic at the wrong arc length: atan|v| instead of |v|.
+(define e1 (vec3 1.0 0.0 0.0))
+(define e2 (vec3 0.0 1.0 0.0))
+(define unit-tangent (vec3 0.0 1.0 0.0))
+(define sph (spherical-exp e1 unit-tangent))
+(report (near? (tensor-ref sph 0) 0.54030230586813977) "spherical-exp is cos|v| x + sin|v| v/|v|")
+(report (near? (tensor-ref sph 1) 0.8414709848078965) "spherical-exp arc length is |v|")
+(report (far? (tensor-ref sph 0) 0.70710678118654746) "spherical-exp is not normalize(x + v)")
+
+(define slog (spherical-log e1 e2))
+(report (near? (sqrt (+ (* (tensor-ref slog 0) (tensor-ref slog 0))
+                        (* (tensor-ref slog 1) (tensor-ref slog 1))
+                        (* (tensor-ref slog 2) (tensor-ref slog 2))))
+               1.5707963267948966)
+        "spherical-log length is the great-circle angle")
+(report (far? (tensor-ref slog 0) -1.0) "spherical-log is not the difference")
+
+(report (near? (geodesic-distance e1 e2 1.0) 1.5707963267948966)
+        "geodesic-distance on the unit sphere is the great-circle distance")
+
+;; ── refusals name the builtin instead of returning a flat answer ─────────────
+;; A point outside the ball has no geodesic relation to one inside it. The op
+;; raises a catchable condition rather than falling back to the chord.
+(define outside-guarded
+  (guard (e (#t 'refused))
+    (geodesic-distance outside near-a -1.0)))
+(report (eq? outside-guarded 'refused) "geodesic-distance refuses a point outside the ball")
+
+(define mobius-sphere-guarded
+  (guard (e (#t 'refused))
+    (mobius-add px py 1.0)))
+(report (eq? mobius-sphere-guarded 'refused) "mobius-add refuses positive curvature")
+
+;; exterior-derivative and hodge-star are NOT implemented on the VM engine: the
+;; data they receive (a coefficient array at one point, with no degree recorded)
+;; does not determine an answer. They refuse by name rather than returning zeros
+;; and the identity, which is what they used to do.
+(define d-guarded (guard (e (#t 'refused)) (exterior-derivative px)))
+(report (eq? d-guarded 'refused) "exterior-derivative refuses instead of returning zeros")
+
+(define star-guarded (guard (e (#t 'refused)) (hodge-star px py)))
+(report (eq? star-guarded 'refused) "hodge-star refuses instead of returning its argument")
+
+(display "PASS: Riemannian geometry numeric regression complete")
+(newline)

--- a/tests/vm/geometric_surface_regression.esk
+++ b/tests/vm/geometric_surface_regression.esk
@@ -28,11 +28,22 @@
 (frechet-mean frechet-pts frechet-w -1.0)
 (great-circle-distance t t)
 (slerp t t 0.5)
-(spherical-exp t t)
-(spherical-exp-map t t)
-(spherical-log t t)
-(spherical-log-map t t)
-(spherical-project t)
+;; The spherical ops are the UNIT SPHERE (K = +1), so their base point must lie
+;; ON it and their tangent vector must be tangent to it -- `t` is the origin,
+;; which is on no sphere. They used to accept it because they were
+;; normalize(base + tangent) and (point - base), which have no domain. Same
+;; reason the frechet-mean probe above takes in-domain arguments.
+(define sphere-base (make-tensor '(2) 0.0))
+(tensor-set! sphere-base 0 1.0)
+(define sphere-other (make-tensor '(2) 0.0))
+(tensor-set! sphere-other 1 1.0)
+(define sphere-tangent (make-tensor '(2) 0.0))
+(tensor-set! sphere-tangent 1 0.5)
+(spherical-exp sphere-base sphere-tangent)
+(spherical-exp-map sphere-base sphere-tangent)
+(spherical-log sphere-base sphere-other)
+(spherical-log-map sphere-base sphere-other)
+(spherical-project sphere-base)
 (so3-exp t)
 (so3-log t)
 (se3-exp t)
@@ -44,8 +55,13 @@
 (ricci-scalar h)
 (sectional-curvature h t t)
 (wedge-product t t)
-(exterior-derivative t)
-(hodge-star t t)
+;; exterior-derivative and hodge-star are NOT implemented on the VM engine and
+;; raise a catchable condition naming themselves. They used to return zeros and
+;; the identity respectively, which asserted that every form is closed and that
+;; the star is trivial. Probed here through `guard` so this file stays an
+;; arity/resolution probe.
+(guard (e (#t 'refused)) (exterior-derivative t))
+(guard (e (#t 'refused)) (hodge-star t t))
 (interior-product t t)
 (pullback t t)
 (riemannian-sgd-step t t 0.01 -1.0)

--- a/tests/vm/riemannian_adam_state_regression.esk
+++ b/tests/vm/riemannian_adam_state_regression.esk
@@ -9,17 +9,37 @@
 
 (display (if st "PASS" "FAIL")) (display ": make-riemannian-adam-state") (newline)
 
-(define step1 (riemannian-adam-step! st p g 0.1 0.9 0.999 -1.0))
+;; These three assertions used to pass CURVATURE -1.0 with p = (1.0, 1.0), a
+;; point of norm sqrt(2) that is not in the Poincare ball of radius 1 -- they
+;; held only because the step ignored the curvature and added the Adam delta in
+;; the ambient space. The moment bookkeeping they actually test is curvature-
+;; independent, so they now say K = 0, where the ambient addition IS the
+;; exponential map and the expected values are unchanged.
+(define step1 (riemannian-adam-step! st p g 0.1 0.9 0.999 0.0))
 (display (if (near? (tensor-ref step1 0) 0.9) "PASS" "FAIL"))
 (display ": adam stateful first step") (newline)
 
-(define step2 (riemannian-adam-step! st step1 g 0.1 0.9 0.999 -1.0))
+(define step2 (riemannian-adam-step! st step1 g 0.1 0.9 0.999 0.0))
 (display (if (near? (tensor-ref step2 0) 0.8) "PASS" "FAIL"))
 (display ": adam stateful second step keeps moments") (newline)
 
-(define legacy1 (riemannian-adam-step p g 0.1 0.9 0.999 -1.0))
+(define legacy1 (riemannian-adam-step p g 0.1 0.9 0.999 0.0))
 (display (if (near? (tensor-ref legacy1 0) 0.9) "PASS" "FAIL"))
 (display ": legacy riemannian-adam-step uses Adam update") (newline)
+
+;; On the ball the step is a geodesic one: the delta is retracted with the
+;; exponential map and the first moment is parallel-transported to the new point.
+;; The iterate must differ from the ambient sum and must stay in the ball.
+(define ball-p (make-tensor '(2) 0.25))
+(define ball-g (make-tensor '(2) 0.5))
+(define ball-st (make-riemannian-adam-state ball-p))
+(define curved (riemannian-adam-step! ball-st ball-p ball-g 0.1 0.9 0.999 -1.0))
+(display (if (> (abs (- (tensor-ref curved 0) 0.15)) 0.0001) "PASS" "FAIL"))
+(display ": adam on the ball is not the ambient update") (newline)
+(display (if (< (+ (* (tensor-ref curved 0) (tensor-ref curved 0))
+                   (* (tensor-ref curved 1) (tensor-ref curved 1))) 1.0)
+             "PASS" "FAIL"))
+(display ": adam on the ball stays on the manifold") (newline)
 
 (display "PASS: Riemannian Adam state regression complete")
 (newline)


### PR DESCRIPTION
## What was wrong

`lib/backend/vm_geometric.c` carries two dispatch bodies for the same 62 builtin names (ids 804-861), selected by `ESHKOL_GEOMETRIC_ENABLED`. **No target defined that macro, and nothing in the build system could** — no option, no `target_compile_definitions`, no cache variable. So the portable body was the one every CI lane, every release binary and the WASM playground compiled, and the linked-library body was unreachable from every configuration of this repository.

What the shipped body computed was the **flat answer under the curved name**, for every value of the curvature argument:

| builtin | ids | what it computed |
|---|---|---|
| `hyperbolic-exp-map` / `manifold-exp-map` / `retraction` | 809, 842 | `base + tangent` |
| `hyperbolic-log-map` / `manifold-log-map` | 810 | `point - base` |
| `spherical-log` / `spherical-log-map` | 822 | `point - base` |
| `spherical-exp` / `spherical-exp-map` | 821 | `normalize(base + tangent)` — a retraction at the wrong arc length |
| `geodesic-distance` / `poincare-distance` | 811, 816 | the L2 distance |
| `parallel-transport` / `vector-transport` | 812, 843 | the identity, endpoints popped and discarded |
| `mobius-add` | 814 | `x + y` |
| `mobius-scalar-mul` | 815 | `r * x` |
| `manifold-project` | 813 | a copy |
| `riemannian-grad` | 841 | a copy, point discarded |
| `riemannian-sgd-step` | 839 | `point - lr*grad` |
| `riemannian-adam-step` / `riemannian-adam-step!` | 840, 861 | `point + delta`, an ambient addition |
| `geodesic-attention-scores` / `-forward` | 844, 847 | scored by the ambient L2 distance |
| `exterior-derivative` | 835 | zeros of the input's shape |
| `hodge-star` | 836 | its argument, unchanged |

Every one of those except the two exterior-calculus ops **accepted a curvature argument and dropped it**. That is exactly the case `inc/eshkol/backend/frechet_mean_core.h` already names for the Fréchet mean: *"A result that carries a curvature parameter it ignores is the plausible-wrong-number case: nothing in the output shows the argument was dropped."*

It is not an approximation either. Two points of the unit Poincaré ball a tenth of a unit inside the boundary:

```scheme
(geodesic-distance #(0.9 0.0) #(-0.9 0.0) -1.0)
;; was      1.8                  (the L2 chord)
;; correct  5.888877958332881    (= 4 artanh 0.9)
```

The chord is bounded by the ball diameter; the geodesic distance diverges at the boundary, so the error is unbounded. No diagnostic, exit 0.

## Why "just turn the enabled path on" was never the fix

Measured, not assumed. A syntax-only pass of `lib/backend/eshkol_vm.c` with `-DESHKOL_GEOMETRIC_ENABLED` against a current `libsemiclassical_qllm` include directory reports **19 errors inside `vm_geometric.c`**: moved arities across `qllm_hyperbolic_exp_map` / `_log_map` / `_distance` / `_parallel_transport` / `_mobius_add` / `_mobius_scalar`, `qllm_hyperbolic_project` now taking a `qllm_tensor_t*` where the call passes a `float*`, and the SO(3)/SE(3) arms naming types (`qllm_so3_algebra_t`, `qllm_so3_t`) the library no longer declares.

The unreachable body is **stale against the API it names**, not a working implementation waiting for a switch. And it is fp32, which `frechet_mean_core.h` already documents as unable to satisfy the exact-derivative gate. So the shipped body is made to deliver the mathematics instead.

## What this does

**`inc/eshkol/backend/riemannian_core.h`** — the closed forms of constant-curvature geometry in f64: Möbius addition and scalar multiplication, exp and log maps, geodesic distance, parallel transport through the gyration `(λ_x/λ_y)·gyr[y,−x]v`, projection, and the Euclidean→Riemannian gradient conversion. A header for the same reason `frechet_mean_core.h` is one: `vm_geometric.c` is a unity-build include and `eshkol-vm-standalone-test` compiles it as a single TU, so there is no object file to call into.

The curvature argument is read as the **sectional curvature K** throughout, which is what every in-tree call site already passes (`(make-hyperbolic-manifold 2 -1.0)`, `(poincare-distance … -1.0)`) and what `eshkol_frechet_mean_compute` already takes: `K < 0` is the Poincaré ball of radius `1/√−K`, `K = 0` is Euclidean, `K > 0` is the sphere of radius `1/√K`. **Every op reduces exactly to its flat form at `K = 0`** — the old bodies were right for that one value of the argument and wrong for every other.

The formulas are the ones `lib/bridge/qllm_bridge.cpp` computes for the AD tape (`ad_hyperbolic_distance`, `ad_poincare_exp_map`, `ad_poincare_log_map`, `ad_geodesic_attention`), so the VM engine and the AD bridge now agree on what these operations mean.

**Domain violations raise** a catchable condition naming the builtin, the reason and the curvature, rather than returning a number: a point outside the ball, a point off the sphere, a log with no finite value, `mobius-add` at positive curvature. `log` refuses rather than clamping `√c|u|` to `1−1e−12`, for the reason `eshkol_frechet_log_map` already gives — a clamp substitutes a fabricated magnitude for one that does not exist.

**`exterior-derivative` and `hodge-star` raise `not implemented on the VM engine`.** Neither can be computed from what it is handed: a form's coefficient array at a single point carries no derivative information, and a flat array does not record the degree the star depends on. Returning zeros asserted that every form is closed; returning the argument asserted that the star is trivial. Listed as build items below.

**`CMakeLists.txt` gains `ESHKOL_GEOMETRIC_QLLM`** — the first way any configuration of this repository can select the linked-library body at all. OFF by default, and a `FATAL_ERROR` at configure time when `ESHKOL_QLLM_ROOT` is unset or its headers are absent, so the option cannot silently degrade to the portable body and report success.

## Tests

`tests/vm/geometric_riemannian_surface_regression.esk` — **42 assertions, each chosen so the flat answer fails it**: the near-boundary geodesic distance, Möbius non-commutativity, exp/log mutual inversion, the Riemannian length identity `λ_x‖log_x(y)‖ = d(x,y)`, transport-is-not-the-identity together with transport-preserves-Riemannian-length, the `K = 0` reductions, the sphere branch, and every refusal path. Picked up automatically by `run_vm_surface_tests.sh`'s `*_surface_regression` glob and by `language_coverage.py`'s `CI_VM_SURFACE_GLOBS`.

Two committed regressions had **encoded the wrong answers as expectations** and are repaired:

- `geometric_fallback_numeric_regression.esk` asserted `(riemannian-sgd-step p p 0.25 -1.0) = 0.75` with `p = (1.0, 1.0)` — a point of norm `√2`, not in the Poincaré ball of radius 1 at all;
- `riemannian_adam_state_regression.esk` asserted the ambient Adam update at curvature `-1.0` for the same out-of-ball point.

Both held only because the ops ignored the curvature. They now assert the flat update at `K = 0`, where it is exactly right, plus curved cases the flat answer fails. `geometric_surface_regression.esk` gets in-domain arguments for the spherical ops (their base must lie **on** the sphere) and guards around the two refusing ops.

**No `PARITY.tsv` row changes.** These 62 names are on the VM surface only — absent from `llvm_codegen.cpp` and from `eshkol_compiler.c`'s native builtin table — so the native-vs-VM differential never compares them and the ratchet governs none of them. That is also why this survived: the gate that had to catch it is the self-checking one, a probe asserting against mathematics inside a single run, which is the property `run_vm_surface_tests.sh`'s own header calls out.

## Gates

```
scripts/run_vm_surface_tests.sh          Passed: 58   Failed: 0
scripts/run_vm_parity.sh --audit-only    1 passed, 0 failed
scripts/check_ledger_integrity.py        ledger_integrity_clean: PASS (118 entries)
scripts/check_ledger_integrity.py --self-test   PASS
scripts/gate_no_silent_wrong.py --no-trace      no_open_silent_wrong: PASS
```

The full `run_vm_parity.sh` reports **189 passed, 2 failed** — both failures are `tests/vm_parity/corpus/42_iota_srfi1.esk`, a **pre-existing** native-side divergence where native `iota` ignores the SRFI-1 optional start/step and the VM honours them. `iota` lives in `lib/core/list/generate.esk` and the VM prelude, neither of which this branch touches.

## Ledger

**SW-73**, bucket `SILENT-WRONG`, **status `closed`**, evidence the new regression.

This is the **forward half** of the surface SW-70 records the backward half of: `AD_NODE_HYPERBOLIC_DISTANCE`, `AD_NODE_POINCARE_EXP_MAP`, `AD_NODE_POINCARE_LOG_MAP` and `AD_NODE_GEODESIC_ATTENTION` propagated exactly `0.0` through `eshkol_tensor_backward_dispatch`. The same four operations on the VM engine were also returning the wrong *value*, so a program using them got a Euclidean answer and, if it differentiated, a zero gradient of it.

## Coordination with #509

`docs/reference/stdlib/geometry.md` does not exist on master — it is #509's page. It is carried here **with the corrections applied on top of #509's content**, so whichever PR lands second resolves a conflict at exactly the lines that changed rather than merging a page that states `geodesic-distance` is the L2 distance. #509's page was honest about the old behaviour; it is now wrong in the other direction, which is why it could not be left alone.

## Build items (not fixed here)

1. **`exterior-derivative` (835)** — needs the form's coefficients as differentiable functions of position, not values at a point. Currently raises.
2. **`hodge-star` (836)** — needs the form's degree, which a flat coefficient array does not record. Currently raises.
3. **The `ESHKOL_GEOMETRIC_ENABLED` body is stale** — 19 compile errors against the current qLLM ABI, and it is fp32 throughout. Bringing it back (or deleting it) is its own change; no gate in this repository covers it.
4. **`ad_poincare_log_map` in `lib/bridge/qllm_bridge.cpp` clamps** `√c|u|` to `1−1e−12` instead of refusing — the same fabricated-magnitude defect `eshkol_frechet_log_map` refuses and `eshkol_rm_log_map` now refuses. Left for the AD lane rather than changed from the VM side.
5. **`spherical-project` (823)** returns the zero vector for a zero-norm input, which is not a point of the sphere. Minor, pre-existing, untouched.
6. **`curvature-gradient` (852), `curvature-hessian` (855), `adaptive-curvature-step` (856)** remain heuristics (a gradient sum, a constant `0.0`, a fixed-rate update). They do not carry a curvature argument they discard, so they are not in this defect's class, but they are not measurements either.
7. **`tests/vm_parity/corpus/42_iota_srfi1.esk`** is red on master — native `iota` drops the SRFI-1 optional arguments. Separate lane.
