### PR TITLE
fix(ad): vector-parameter AD over captured locals (LE-06)

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -2938,12 +2938,52 @@ entries:
   - id: LE-06
     bucket: LOUD-ERROR
     subtag: structural
-    status: open
+    status: closed
+    closed_at: "REPLACE_SHA"
+    closed_by: "branch fix/ad-captured-vector-param-le06"
     title: "Vector-param AD op capturing a local function parameter fails LLVM verification (ESH-0097)"
     observed: "PtrToInt source must be pointer, on both -r and AOT"
-    evidence: "tests/ad_oracle/README.md XKNOWN; docs/KNOWN_ISSUES.md:299"
     caught_by: [KNOWN_ISSUES, ad-oracle-xknown]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
+    remeasured: >-
+      DOES NOT REPRODUCE. Re-measured at REPLACE_SHA on a Linux x86-64 lane
+      configured with the ci.yml full-lane flags (Release, LLVM 21, XLA and GPU
+      off). The archived repro,
+      tests/ad_oracle/found/esh0097_local_capture_vector_ad_ptrtoint.esk, prints
+      the "#(4.42 0)" its own header names as the expected value, on the JIT and
+      AOT alike; a 23-check battery over the full shape matrix (see `evidence`)
+      passes 23/23 in both lanes; and the `gradient` slice of that matrix — the
+      part inside the VM subset — agrees byte-for-byte on the bytecode VM. The
+      code was fixed in the AD sweep C wave (autodiff_codegen.cpp:6975-6990 and
+      :11381-11400, docs/design/AUDIT_2026_08_25_RESOLUTION.md item e1); this
+      entry, and the tests/ad_oracle/README.md XKNOWN row it cited as its
+      evidence, were never updated. Both are corrected here.
+    why_it_could_rot: >-
+      The acceptance test docs/KNOWN_ISSUES.md cites as the proof of the fix,
+      tests/ad/sweep_c_regressions_test.esk, was never registered in CTest and
+      is not globbed by scripts/run_autodiff_tests.sh (which globs tests/autodiff/
+      only) — nothing ran it, on any lane, ever. The same unwired-acceptance-test
+      defect ESH-0394 closed for the exact-coefficient Taylor tier. A ledger entry
+      whose closure evidence is a doc row rather than a gate can only be as
+      current as the last person who read the doc.
+    evidence: >-
+      tests/ad/captured_local_vector_param_test.esk — 23 checks, registered in
+      CTest as captured_local_vector_param_ad_runtime_smoke (JIT) and
+      _aot_smoke (AOT), both with FAIL_REGULAR_EXPRESSION naming "PtrToInt source
+      must be pointer" and "LLVM module verification failed" directly, so a
+      recurrence is reported as itself and not as an absent PASS. It covers the
+      axes sweep C does not: the `vref` spelling (codegenTensorVectorRef, a
+      different codegen path from `vector-ref`), a captured VECTOR local read
+      inside the AD lambda in both spellings (the oracle's `capvrefout` axis), a
+      captured `let` binding rather than a parameter, two captures in one lambda,
+      a capture that is inert in the AD-relevant path (the original failure did
+      not require the capture to participate in the derivative), the same builder
+      reused with different captured values, and `curl` — the sixth vector-param
+      operator, absent from sweep C. tests/ad/sweep_c_regressions_test.esk is now
+      registered in CTest on both lanes as well. The captured-local section of
+      tests/vm_parity/corpus/32_gradient_reverse.esk holds the third engine to the
+      same answers; those shapes had no VM counterpart while the native side
+      failed to compile.
 
   - id: LE-07
     bucket: LOUD-ERROR

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -2953,7 +2953,12 @@ entries:
       the "#(4.42 0)" its own header names as the expected value, on the JIT and
       AOT alike; a 22-check battery over the full shape matrix (see `evidence`)
       passes 22/22 in both lanes; and the `gradient` slice of that matrix — the
-      part inside the VM subset — agrees byte-for-byte on the bytecode VM. The
+      part inside the VM subset — agrees byte-for-byte on the bytecode VM
+      (native and vm-src stdout identical after newline normalisation over the
+      whole of tests/vm_parity/corpus/32_gradient_reverse.esk). The five GROUP C
+      regressions in tests/ad/sweep_c_regressions_test.esk pass 27/27 in both
+      native lanes at the same time, which retires the same claim for
+      ESH-0078/0095/0096 as well. The
       code was fixed in the AD sweep C wave (autodiff_codegen.cpp:6975-6990 and
       :11381-11400, docs/design/AUDIT_2026_08_25_RESOLUTION.md item e1); this
       entry, and the tests/ad_oracle/README.md XKNOWN row it cited as its

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -2951,8 +2951,8 @@ entries:
       off). The archived repro,
       tests/ad_oracle/found/esh0097_local_capture_vector_ad_ptrtoint.esk, prints
       the "#(4.42 0)" its own header names as the expected value, on the JIT and
-      AOT alike; a 23-check battery over the full shape matrix (see `evidence`)
-      passes 23/23 in both lanes; and the `gradient` slice of that matrix — the
+      AOT alike; a 22-check battery over the full shape matrix (see `evidence`)
+      passes 22/22 in both lanes; and the `gradient` slice of that matrix — the
       part inside the VM subset — agrees byte-for-byte on the bytecode VM. The
       code was fixed in the AD sweep C wave (autodiff_codegen.cpp:6975-6990 and
       :11381-11400, docs/design/AUDIT_2026_08_25_RESOLUTION.md item e1); this
@@ -2967,7 +2967,7 @@ entries:
       whose closure evidence is a doc row rather than a gate can only be as
       current as the last person who read the doc.
     evidence: >-
-      tests/ad/captured_local_vector_param_test.esk — 23 checks, registered in
+      tests/ad/captured_local_vector_param_test.esk — 22 checks, registered in
       CTest as captured_local_vector_param_ad_runtime_smoke (JIT) and
       _aot_smoke (AOT), both with FAIL_REGULAR_EXPRESSION naming "PtrToInt source
       must be pointer" and "LLVM module verification failed" directly, so a

--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -2939,14 +2939,14 @@ entries:
     bucket: LOUD-ERROR
     subtag: structural
     status: closed
-    closed_at: "REPLACE_SHA"
+    closed_at: "e7f2c685"
     closed_by: "branch fix/ad-captured-vector-param-le06"
     title: "Vector-param AD op capturing a local function parameter fails LLVM verification (ESH-0097)"
     observed: "PtrToInt source must be pointer, on both -r and AOT"
     caught_by: [KNOWN_ISSUES, ad-oracle-xknown]
     missed_by: [icc-correctness-chain, icc-smoke, icc-readiness]
     remeasured: >-
-      DOES NOT REPRODUCE. Re-measured at REPLACE_SHA on a Linux x86-64 lane
+      DOES NOT REPRODUCE. Re-measured at e7f2c685 (origin/master) on a Linux x86-64 lane
       configured with the ci.yml full-lane flags (Release, LLVM 21, XLA and GPU
       off). The archived repro,
       tests/ad_oracle/found/esh0097_local_capture_vector_ad_ptrtoint.esk, prints

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3812,6 +3812,68 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
             TIMEOUT 600
             PASS_REGULAR_EXPRESSION "PASS: exact-coefficient Taylor tier"
             FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
+    # LE-06 / ESH-0072 / ESH-0097: a vector-parameter AD operator whose
+    # differentiated lambda captures a LOCAL binding of the enclosing function.
+    # The defect this gates was a COMPILE-TIME one -- "PtrToInt source must be
+    # pointer (ptrtoint %eshkol_tagged_value %a to i64)", a module verification
+    # failure that killed the whole translation unit on BOTH -r and AOT -- so
+    # the FAIL_REGULAR_EXPRESSION names the verifier message directly and a
+    # regression is reported as itself rather than as an absent PASS. The two
+    # lanes are not redundant: the JIT and AOT reach the closure-environment
+    # unpack through different paths, and the original defect was present in
+    # both. The pre-existing regression (tests/ad/sweep_c_regressions_test.esk)
+    # was never wired into CTest -- it is registered below -- and covers only
+    # the `vector-ref` spelling with a captured SCALAR parameter; this file adds
+    # the `vref` path, captured VECTOR locals, let-bound captures, inert
+    # captures, capture reuse, and `curl`.
+    add_test(
+        NAME captured_local_vector_param_ad_runtime_smoke
+        COMMAND $<TARGET_FILE:eshkol-run>
+                -r "${CMAKE_CURRENT_SOURCE_DIR}/tests/ad/captured_local_vector_param_test.esk"
+                -L"${CMAKE_CURRENT_BINARY_DIR}"
+    )
+    set_tests_properties(captured_local_vector_param_ad_runtime_smoke
+        PROPERTIES
+            TIMEOUT 300
+            PASS_REGULAR_EXPRESSION "PASS: vector-parameter AD over captured locals"
+            FAIL_REGULAR_EXPRESSION "\\[FAIL\\]|FAIL:|LLVM module verification failed|PtrToInt source must be pointer|fatal signal")
+    add_test(
+        NAME captured_local_vector_param_ad_aot_smoke
+        COMMAND sh -c
+            "'$<TARGET_FILE:eshkol-run>' -o '${CMAKE_CURRENT_BINARY_DIR}/captured_local_vector_param_aot' '${CMAKE_CURRENT_SOURCE_DIR}/tests/ad/captured_local_vector_param_test.esk' -L'${CMAKE_CURRENT_BINARY_DIR}' && '${CMAKE_CURRENT_BINARY_DIR}/captured_local_vector_param_aot'"
+    )
+    set_tests_properties(captured_local_vector_param_ad_aot_smoke
+        PROPERTIES
+            TIMEOUT 600
+            PASS_REGULAR_EXPRESSION "PASS: vector-parameter AD over captured locals"
+            FAIL_REGULAR_EXPRESSION "\\[FAIL\\]|FAIL:|LLVM module verification failed|PtrToInt source must be pointer|fatal signal")
+    # The GROUP C release-blocking AD regressions (ESH-0078 nested named-inner
+    # gradient, ESH-0096 vector-param gradient-of-gradient, ESH-0095
+    # hessian/laplacian on tensor points, ESH-0072/0097 captured-local AD,
+    # R->R^n vector-valued derivative) are the acceptance tests docs/KNOWN_ISSUES
+    # cites as the evidence those five are fixed -- and nothing ran them. Same
+    # unwired-acceptance-test defect as ESH-0394 above. Both lanes.
+    add_test(
+        NAME ad_sweep_c_regressions_runtime_smoke
+        COMMAND $<TARGET_FILE:eshkol-run>
+                -r "${CMAKE_CURRENT_SOURCE_DIR}/tests/ad/sweep_c_regressions_test.esk"
+                -L"${CMAKE_CURRENT_BINARY_DIR}"
+    )
+    set_tests_properties(ad_sweep_c_regressions_runtime_smoke
+        PROPERTIES
+            TIMEOUT 300
+            PASS_REGULAR_EXPRESSION "Failed: 0"
+            FAIL_REGULAR_EXPRESSION "\\[FAIL\\]|LLVM module verification failed|PtrToInt source must be pointer|fatal signal")
+    add_test(
+        NAME ad_sweep_c_regressions_aot_smoke
+        COMMAND sh -c
+            "'$<TARGET_FILE:eshkol-run>' -o '${CMAKE_CURRENT_BINARY_DIR}/ad_sweep_c_regressions_aot' '${CMAKE_CURRENT_SOURCE_DIR}/tests/ad/sweep_c_regressions_test.esk' -L'${CMAKE_CURRENT_BINARY_DIR}' && '${CMAKE_CURRENT_BINARY_DIR}/ad_sweep_c_regressions_aot'"
+    )
+    set_tests_properties(ad_sweep_c_regressions_aot_smoke
+        PROPERTIES
+            TIMEOUT 600
+            PASS_REGULAR_EXPRESSION "Failed: 0"
+            FAIL_REGULAR_EXPRESSION "\\[FAIL\\]|LLVM module verification failed|PtrToInt source must be pointer|fatal signal")
     # SW-66: HEAP_SUBTYPE_TAYLOR's exact (COEFF_RATIONAL) representation
     # carries interior bignum/rational HEAP_PTRs in its coefficient array that
     # evac_kind_for (lib/core/runtime_regions.cpp) dropped to a shallow leaf

--- a/tests/ad/captured_local_vector_param_test.esk
+++ b/tests/ad/captured_local_vector_param_test.esk
@@ -1,0 +1,139 @@
+;;; tests/ad/captured_local_vector_param_test.esk
+;;; LE-06 / ESH-0072 / ESH-0097 regression: a vector-parameter AD operator whose
+;;; differentiated lambda CAPTURES A LOCAL BINDING of the enclosing function.
+;;;
+;;; The historical defect was a compile-time one — the module failed LLVM
+;;; verification with
+;;;     PtrToInt source must be pointer
+;;;     %N = ptrtoint %eshkol_tagged_value %a to i64
+;;; on BOTH `-r` (JIT) and AOT, because the captured value reached the AD
+;;; closure-unpack path as an already-unpacked tagged value where the
+;;; environment loader expected a pointer. A compile-time failure kills the whole
+;;; translation unit, so this file must be able to COMPILE before any check in
+;;; it can run: the ctest FAIL_REGULAR_EXPRESSION matches the verifier message
+;;; directly, so a regression is reported as itself and not as a missing PASS.
+;;;
+;;; The pre-existing regression (tests/ad/sweep_c_regressions_test.esk:57-69)
+;;; covers the `vector-ref` spelling with a captured SCALAR parameter only. This
+;;; file covers the axes it does not:
+;;;   * the `vref` spelling (a different codegen path: codegenTensorVectorRef)
+;;;   * a captured VECTOR local, read inside the AD lambda (the `capvrefout`
+;;;     axis of tests/ad_oracle/gen_ad_oracle.py) — both spellings
+;;;   * a captured LET binding rather than a parameter
+;;;   * two captured locals in one AD lambda
+;;;   * a capture that is present but inert in the AD-relevant path
+;;;   * `curl` (the sixth vector-param operator, absent from sweep C)
+;;;   * the same builder invoked repeatedly with different captured values
+(define pass 0)(define fail 0)
+(define (approx= a b) (< (abs (- a b)) 1e-9))
+;; hessian/laplacian on arity-1 vector functions use a central-difference
+;; stencil (O(1e-8) error) — same tolerance split as sweep C.
+(define (approx2= a b) (< (abs (- a b)) 1e-5))
+(define (chk label v)
+  (display "  [")(display (if v "PASS" "FAIL"))(display "] ")(display label)(newline)
+  (if v (set! pass (+ pass 1)) (set! fail (+ fail 1))))
+
+;; ── the found/ repro shape, verbatim ────────────────────────────────────
+;; tests/ad_oracle/found/esh0097_local_capture_vector_ad_ptrtoint.esk:
+;; f(v) = a*v0^2, grad = (2*a*v0, 0); a=1.7 at (1.3,-0.7) -> (4.42, 0).
+(define (mk-vref a)
+  (gradient (lambda (v) (* a (* (vref v 0) (vref v 0)))) (vector 1.3 -0.7)))
+(define r-vref (mk-vref 1.7))
+(chk "gradient / vref / captured scalar param [0] = 4.42" (approx= (vector-ref r-vref 0) 4.42))
+(chk "gradient / vref / captured scalar param [1] = 0"    (approx= (vector-ref r-vref 1) 0.0))
+
+;; ── same shape through the vector-ref spelling ──────────────────────────
+(define (mk-vecref a)
+  (gradient (lambda (v) (* a (* (vector-ref v 0) (vector-ref v 0)))) (vector 1.3 -0.7)))
+(define r-vecref (mk-vecref 1.7))
+(chk "gradient / vector-ref / captured scalar param [0] = 4.42" (approx= (vector-ref r-vecref 0) 4.42))
+(chk "gradient / vector-ref / captured scalar param [1] = 0"    (approx= (vector-ref r-vecref 1) 0.0))
+
+;; ── captured VECTOR local (`capvrefout`), read with vector-ref and vref ──
+(define (mk-capvec-vecref w)
+  (gradient (lambda (v) (* (vector-ref w 0) (* (vref v 0) (vref v 0)))) (vector 1.3 -0.7)))
+(chk "gradient / captured vector local via vector-ref [0] = 4.42"
+     (approx= (vector-ref (mk-capvec-vecref (vector 1.7 0.3)) 0) 4.42))
+(define (mk-capvec-vref w)
+  (gradient (lambda (v) (* (vref w 0) (* (vref v 0) (vref v 0)))) (vector 1.3 -0.7)))
+(chk "gradient / captured vector local via vref [0] = 4.42"
+     (approx= (vector-ref (mk-capvec-vref (vector 1.7 0.3)) 0) 4.42))
+
+;; ── captured LET binding rather than a parameter ────────────────────────
+;; b = 2a; f(v) = b*v0^2, grad_0 = 2*b*v0 = 5.2 at a=1.0, v0=1.3.
+(define (mk-let a)
+  (let ((b (* a 2.0)))
+    (gradient (lambda (v) (* b (* (vref v 0) (vref v 0)))) (vector 1.3 -0.7))))
+(chk "gradient / captured let binding [0] = 5.2" (approx= (vector-ref (mk-let 1.0) 0) 5.2))
+
+;; ── two captured locals in one AD lambda ────────────────────────────────
+(define (mk-two a b)
+  (gradient (lambda (v) (* (+ a b) (* (vref v 0) (vref v 0)))) (vector 1.3 -0.7)))
+(chk "gradient / two captured locals [0] = 5.2" (approx= (vector-ref (mk-two 1.0 1.0) 0) 5.2))
+
+;; ── a capture that is inert in the AD-relevant path ─────────────────────
+;; The historical failure did not require the capture to participate in the
+;; derivative; it only had to be captured. f(v) = 0*a + v0^2 -> grad_0 = 2.6.
+(define (mk-inert a)
+  (gradient (lambda (v) (+ (* 0.0 a) (* (vref v 0) (vref v 0)))) (vector 1.3 -0.7)))
+(chk "gradient / inert captured local [0] = 2.6" (approx= (vector-ref (mk-inert 1.7) 0) 2.6))
+
+;; ── the same builder reused with different captured values ──────────────
+;; A capture cached across calls would return the first answer twice.
+(chk "gradient / capture reuse a=1.0 [0] = 2.6" (approx= (vector-ref (mk-vref 1.0) 0) 2.6))
+(chk "gradient / capture reuse a=3.0 [0] = 7.8" (approx= (vector-ref (mk-vref 3.0) 0) 7.8))
+
+;; ── jacobian ────────────────────────────────────────────────────────────
+;; F(v) = (a*v0, v1); J = [[a,0],[0,1]]; a=2 -> J[0][0]=2, J[1][1]=1.
+(define (mk-jac a)
+  (jacobian (lambda (v) (vector (* a (vref v 0)) (vref v 1))) (vector 3.0 4.0)))
+(define j-local (mk-jac 2.0))
+(chk "jacobian / captured scalar param [0][0] = 2" (approx= (tensor-ref j-local 0 0) 2.0))
+(chk "jacobian / captured scalar param [1][1] = 1" (approx= (tensor-ref j-local 1 1) 1.0))
+(define (mk-jac-w w)
+  (jacobian (lambda (v) (vector (* (vector-ref w 0) (vref v 0)) (vref v 1))) (vector 3.0 4.0)))
+(chk "jacobian / captured vector local [0][0] = 2"
+     (approx= (tensor-ref (mk-jac-w (vector 2.0 9.0)) 0 0) 2.0))
+
+;; ── hessian ─────────────────────────────────────────────────────────────
+;; f(v) = a*v0^2; H[0][0] = 2a = 4 at a=2.
+(define (mk-hess a)
+  (hessian (lambda (v) (* a (* (vref v 0) (vref v 0)))) (vector 3.0 4.0)))
+(chk "hessian / captured scalar param [0][0] = 4" (approx2= (tensor-ref (mk-hess 2.0) 0 0) 4.0))
+(define (mk-hess-w w)
+  (hessian (lambda (v) (* (vector-ref w 0) (* (vref v 0) (vref v 0)))) (vector 3.0 4.0)))
+(chk "hessian / captured vector local [0][0] = 4"
+     (approx2= (tensor-ref (mk-hess-w (vector 2.0 9.0)) 0 0) 4.0))
+
+;; ── divergence ──────────────────────────────────────────────────────────
+;; F(v) = (a*v0, a*v1); div = 2a = 4 at a=2.
+(define (mk-div a)
+  (divergence (lambda (v) (vector (* a (vref v 0)) (* a (vref v 1)))) (vector 3.0 4.0)))
+(chk "divergence / captured scalar param = 4" (approx= (mk-div 2.0) 4.0))
+(define (mk-div-w w)
+  (divergence (lambda (v) (vector (* (vector-ref w 0) (vref v 0))
+                                  (* (vector-ref w 0) (vref v 1)))) (vector 3.0 4.0)))
+(chk "divergence / captured vector local = 4" (approx= (mk-div-w (vector 2.0 9.0)) 4.0))
+
+;; ── laplacian ───────────────────────────────────────────────────────────
+;; f(v) = a*v0^2; lap = 2a = 4 at a=2.
+(define (mk-lap a)
+  (laplacian (lambda (v) (* a (* (vref v 0) (vref v 0)))) (vector 3.0 4.0)))
+(chk "laplacian / captured scalar param = 4" (approx2= (mk-lap 2.0) 4.0))
+(define (mk-lap-w w)
+  (laplacian (lambda (v) (* (vector-ref w 0) (* (vref v 0) (vref v 0)))) (vector 3.0 4.0)))
+(chk "laplacian / captured vector local = 4" (approx2= (mk-lap-w (vector 2.0 9.0)) 4.0))
+
+;; ── curl ────────────────────────────────────────────────────────────────
+;; F(v) = (a*v1*v2, 0, 0); curl = (0, a*v1, -a*v2); a=2 at (1,2,3) -> (0,4,-6).
+(define (mk-curl a)
+  (curl (lambda (v) (vector (* a (* (vref v 1) (vref v 2))) 0.0 0.0)) (vector 1.0 2.0 3.0)))
+(define c-local (mk-curl 2.0))
+(chk "curl / captured scalar param [1] = 4"  (approx2= (vector-ref c-local 1) 4.0))
+(chk "curl / captured scalar param [2] = -6" (approx2= (vector-ref c-local 2) -6.0))
+
+(display "Passed: ")(display pass)(newline)
+(display "Failed: ")(display fail)(newline)
+(if (= fail 0)
+    (begin (display "PASS: vector-parameter AD over captured locals")(newline))
+    (begin (display "FAIL: vector-parameter AD over captured locals")(newline)))

--- a/tests/ad_oracle/README.md
+++ b/tests/ad_oracle/README.md
@@ -78,7 +78,7 @@ operators — the LLVM verifier's `PtrToInt source must be pointer (ptrtoint
 %eshkol_tagged_value %a to i64)` when the AD lambda captured a LOCAL binding).
 Re-measured on both `-r` and AOT and on the bytecode VM: it does not
 reproduce. `found/esh0097_local_capture_vector_ad_ptrtoint.esk` prints the
-`#(4.42 0)` its own header names as the expected value, and the shapes are
+`#(4.42 0)` its own header names as the expected value; the shapes are
 gated by `tests/ad/captured_local_vector_param_test.esk` (CTest, JIT + AOT),
 `tests/ad/sweep_c_regressions_test.esk` and the captured-local section of
 `tests/vm_parity/corpus/32_gradient_reverse.esk`. Ledger entry LE-06.

--- a/tests/ad_oracle/README.md
+++ b/tests/ad_oracle/README.md
@@ -68,12 +68,26 @@ event is consumed by `.icc/completion-oracles.yaml::ad-oracle`.
 
 ## Known-open cells (XKNOWN)
 
+The rows below are the historical record. `CRASH_TASKS` is empty and every
+`xc=` argument in `gen_ad_oracle.py` is `None` — nothing is currently marked
+XKNOWN, so every generated cell is expected to PASS and a regression FAILs
+loudly rather than being absorbed. Keep the table in step with those marks.
+
+**ESH-0097 is closed** (`*.caplocal` / `*.capvrefout` for the vector-param
+operators — the LLVM verifier's `PtrToInt source must be pointer (ptrtoint
+%eshkol_tagged_value %a to i64)` when the AD lambda captured a LOCAL binding).
+Re-measured on both `-r` and AOT and on the bytecode VM: it does not
+reproduce. `found/esh0097_local_capture_vector_ad_ptrtoint.esk` prints the
+`#(4.42 0)` its own header names as the expected value, and the shapes are
+gated by `tests/ad/captured_local_vector_param_test.esk` (CTest, JIT + AOT),
+`tests/ad/sweep_c_regressions_test.esk` and the captured-local section of
+`tests/vm_parity/corpus/32_gradient_reverse.esk`. Ledger entry LE-06.
+
 | task | cell | symptom |
 |------|------|---------|
 | ESH-0078 | `nest.gofg.*.s.named/lamvar` | 2nd-order gradient through a NAMED inner function returns 0 (inline lambda works). NOTE: the ledger marks this merged via #95, but the acceptance shape still returns 0 on master — regressed or never fully fixed. |
 | ESH-0093 | `nest.gofd.*.v2` | vector-param gradient over inner derivative returns zeros (mixed forward/reverse). Fix in flight at time of writing. |
 | ESH-0096 | `nest.gofg.*.v1/v2` | vector-param gradient-of-gradient returns zeros (even the 1-d form documented in AUTODIFF.md). **Found by this oracle.** |
-| ESH-0097 | `*.caplocal / *.capvrefout` for vector-param ops (xc files) | LLVM verifier: `PtrToInt source must be pointer (ptrtoint %eshkol_tagged_value %a to i64)` on both -r and AOT when the AD lambda captures a LOCAL function parameter. **Found by this oracle.** |
 
 When a task is fixed, its probes print `PASS: … (fixed: ESH-NNNN)` and the
 xknown count drops — no oracle change needed. Then delete the task id from

--- a/tests/ad_oracle/found/esh0097_local_capture_vector_ad_ptrtoint.esk
+++ b/tests/ad_oracle/found/esh0097_local_capture_vector_ad_ptrtoint.esk
@@ -1,17 +1,27 @@
 ;; ESH-0097 minimal repro (found by the AD composition oracle, P3).
-;; ANY vector-param AD operator (gradient, jacobian, hessian, divergence,
-;; curl, laplacian) whose lambda captures a LOCAL function parameter fails
-;; LLVM module verification on BOTH -r and AOT:
+;; WAS: ANY vector-param AD operator (gradient, jacobian, hessian,
+;; divergence, curl, laplacian) whose lambda captured a LOCAL function
+;; parameter failed LLVM module verification on BOTH -r and AOT:
 ;;   ERROR: LLVM module verification failed: PtrToInt source must be pointer
 ;;     %N = ptrtoint %eshkol_tagged_value %a to i64
-;; Notes:
-;;  * scalar `derivative` with the same local capture works fine
-;;  * capturing a GLOBAL works fine
-;;  * the capture does not even have to be used in an AD-relevant way
-;;  * capturing a vector param and using (vector-ref w 0) fails the same way
+;; What the triage established at the time:
+;;  * scalar `derivative` with the same local capture worked fine
+;;  * capturing a GLOBAL worked fine
+;;  * the capture did not even have to be used in an AD-relevant way
+;;  * capturing a vector param and using (vector-ref w 0) failed the same way
+;;
+;; STATUS: FIXED. Re-measured at e7f2c685 on both -r and AOT — this file now
+;; prints #(4.42 0), and the same shapes agree on the bytecode VM. The fix is
+;; in autodiff_codegen.cpp: a captured local parameter resolves to that
+;; parameter's llvm::Argument, which carries the eshkol_tagged_value STRUCT
+;; type rather than a pointer type, and the mutable-capture path ran
+;; CreatePtrToInt on it unconditionally. Value-typed captures now funnel
+;; through a temp alloca. Kept as the acceptance test of ESH-0097 / ledger
+;; LE-06; the shape matrix is gated by
+;; tests/ad/captured_local_vector_param_test.esk (CTest, JIT + AOT).
 ;;
 ;; Run: build/eshkol-run -r tests/ad_oracle/found/esh0097_local_capture_vector_ad_ptrtoint.esk
-;; Expected: #(4.42 0). Actual: compile-time IR verification failure.
+;; Expected: #(4.42 0).
 (define (mk a)
   (gradient (lambda (v) (* a (vref v 0) (vref v 0))) (vector 1.3 -0.7)))
 (display (mk 1.7))

--- a/tests/ad_oracle/gen_ad_oracle.py
+++ b/tests/ad_oracle/gen_ad_oracle.py
@@ -25,15 +25,17 @@ First-order stencils use h=1e-5 (atol 1e-6); second-order stencils (hessian
 diagonals/cross terms, laplacian) use h=1e-4 (atol 1e-5) because the eps/h^2
 round-off term dominates at h=1e-5.
 
-Probes print "PASS: <id>" / "FAIL: <id> ad=<v> fd=<v>". Cells that are
-known-open compiler bugs print "XKNOWN: <id> (<ESH-task>) ..." instead of
-FAIL so the gate stays green while the bug is tracked:
+Probes print "PASS: <id>" / "FAIL: <id> ad=<v> fd=<v>". A cell marked `xc=`
+prints "XKNOWN: <id> (<ESH-task>) ..." instead of FAIL, so the gate stays
+green while a bug is tracked. No cell carries such a mark today — sweep C
+cleared the last of them — so every generated cell is expected to PASS and a
+regression FAILs loudly. The historical set, kept for orientation:
 
   ESH-0078  2nd-order gradient through a NAMED-function inner gradient
   ESH-0093  vector-param gradient over an inner derivative (mixed mode)
   ESH-0095  hessian/laplacian SIGSEGV on tensor-literal points  (found by
-            this oracle; crash cells live in their own ad_oracle_xc_* files
-            so one crash cannot mask other probes)
+            this oracle; crash cells lived in their own ad_oracle_xc_* files
+            so one crash could not mask other probes) -- fixed in sweep C
   ESH-0096  vector-param gradient-of-gradient returns zeros (found by this
             oracle)
   ESH-0097  vector-param AD op (gradient/jacobian/hessian/divergence/curl/
@@ -41,7 +43,9 @@ FAIL so the gate stays green while the bug is tracked:
             fails LLVM verification: "PtrToInt source must be pointer
             (ptrtoint %eshkol_tagged_value %a to i64)" on BOTH -r and AOT
             (found by this oracle; compile-time failure kills the whole
-            translation unit, so these cells also live in xc_* files)
+            translation unit, so these cells also lived in xc_* files) --
+            fixed in sweep C, re-measured and closed as ledger LE-06; the
+            shapes are gated by tests/ad/captured_local_vector_param_test.esk
 
 Output: tests/ad_oracle/generated/ad_oracle_<section>_<NN>.esk (~15 probes
 per file), plus ad_oracle_xc_<task>_<NN>.esk single-probe expected-crash

--- a/tests/vm_parity/corpus/32_gradient_reverse.esk
+++ b/tests/vm_parity/corpus/32_gradient_reverse.esk
@@ -52,3 +52,22 @@
     (if (= i n) s
         (loop (+ i 1) (+ s (vref (gradient qloss (vector 1.0 2.0)) 0))))))
 (display (loopsum 500)) (newline)                               ; 1000
+
+; --- LE-06 / ESH-0097: the differentiated lambda CAPTURES A LOCAL binding ---
+; This shape used to fail LLVM verification on native ("PtrToInt source must be
+; pointer") and so had no VM counterpart to compare against. Both engines must
+; now answer identically. f(v) = a*v0^2 -> grad = (2*a*v0, 0).
+(define (mk-cap a)
+  (gradient (lambda (v) (* a (* (vref v 0) (vref v 0)))) (vector 1.3 -0.7)))
+(display (mk-cap 1.7)) (newline)                                ; #(4.42 0)
+; the same builder reused with a different captured value
+(display (mk-cap 3.0)) (newline)                                ; #(7.8 0)
+; captured VECTOR local, read inside the AD lambda
+(define (mk-cap-vec w)
+  (gradient (lambda (v) (* (vector-ref w 0) (* (vref v 0) (vref v 0)))) (vector 1.3 -0.7)))
+(display (mk-cap-vec (vector 1.7 0.3))) (newline)               ; #(4.42 0)
+; captured LET binding rather than a parameter: b = 2a, grad_0 = 2*b*v0
+(define (mk-cap-let a)
+  (let ((b (* a 2.0)))
+    (gradient (lambda (v) (* b (* (vref v 0) (vref v 0)))) (vector 1.3 -0.7))))
+(display (mk-cap-let 1.0)) (newline)                            ; #(5.2 0)


### PR DESCRIPTION
## What this is

A measurement, and the gate that should have made it unnecessary.

Ledger `LE-06` carried `status: open` for a compile-time defect (ESH-0072 / ESH-0097): a vector-parameter AD operator whose differentiated lambda captures a **local** binding of the enclosing function failed LLVM module verification with

```
PtrToInt source must be pointer
%N = ptrtoint %eshkol_tagged_value %a to i64
```

on both `-r` and AOT. Meanwhile `docs/KNOWN_ISSUES.md`, `docs/reference/ad/operators.md` (as edited in the docs train) and the AD-oracle generator all recorded it fixed. Three sources against one; nothing had run the test that would settle it.

**It does not reproduce.** Re-measured at `e7f2c685` on a Linux x86-64 lane configured with the `ci.yml` full-lane flags (Release, LLVM 21, XLA and GPU off):

| lane | result |
|---|---|
| `found/esh0097_local_capture_vector_ad_ptrtoint.esk`, JIT | `#(4.42 0)` — the value its own header names as expected |
| same, AOT | `#(4.42 0)` |
| 22-check shape battery, JIT | 22/22 |
| 22-check shape battery, AOT | 22/22 |
| `gradient` slice (the part inside the VM subset), bytecode VM | byte-identical to native |
| `sweep_c_regressions_test.esk` (ESH-0078 / 0095 / 0096 / 0072-0097 / R→Rⁿ), JIT and AOT | 27/27 each |

The code fix is real and was already in the tree, from the AD sweep C wave. `autodiff_codegen.cpp` `resolveGradientCaptures` (~`:6975`) and the autodiff helper capture path (~`:11381`): a lambda capturing a local function parameter resolves the free variable's `storage` to that parameter's `llvm::Argument`, which carries the `eshkol_tagged_value` **struct** type rather than a pointer type. The mutable-capture path then ran `CreatePtrToInt` on it unconditionally — precisely the invalid IR the verifier named. Both sites now funnel a value-typed capture through a temp alloca and reserve `ptrtoint` for a genuine pointer storage.

## Why it could rot

The acceptance test `docs/KNOWN_ISSUES.md` cites as the evidence of the fix — `tests/ad/sweep_c_regressions_test.esk` — **was never registered in CTest**, and `tests/ad/` is not globbed by `scripts/run_autodiff_tests.sh` (which globs `tests/autodiff/` only). Nothing ran it, on any lane, ever. That is the same unwired-acceptance-test defect ESH-0394 closed for the exact-coefficient Taylor tier. A ledger entry whose closure evidence is a documentation row rather than a gate can only ever be as current as the last person who read the row.

That is the part worth fixing, and it is what most of this diff is.

## Changes

**`tests/ad/captured_local_vector_param_test.esk`** (new, 22 checks) covers the axes sweep C does not:

- the `vref` spelling — `codegenTensorVectorRef`, a different codegen path from `vector-ref`, and the spelling the archived repro actually uses
- a captured **vector** local read inside the AD lambda, in both spellings (the oracle's `capvrefout` axis)
- a captured `let` binding rather than a parameter
- two captures in one lambda
- a capture that is **inert** in the AD-relevant path — the original failure did not require the capture to participate in the derivative, only to be captured
- the same builder invoked repeatedly with different captured values, so a capture cached across calls would show
- `curl` — the sixth vector-param operator, absent from sweep C

Registered in CTest on both lanes: the JIT and AOT reach the closure-environment unpack through different paths and the original defect was present in both. The `FAIL_REGULAR_EXPRESSION` names `PtrToInt source must be pointer` and `LLVM module verification failed` directly, so a recurrence — a compile-time failure that kills the whole translation unit — is reported as itself rather than as an absent PASS.

**`tests/ad/sweep_c_regressions_test.esk`** is now registered in CTest, JIT and AOT, so the five GROUP C regressions it asserts (ESH-0078, ESH-0095, ESH-0096, ESH-0072/0097, R→Rⁿ) are actually run.

**`tests/vm_parity/corpus/32_gradient_reverse.esk`** gains the captured-local shapes, holding the third engine to the same answers. Those shapes had no VM counterpart while the native side failed to compile. Extending the existing corpus file rather than adding a new one keeps `ENGINE_PARITY_BASELINE.json`'s ratchet untouched.

**`tests/ad_oracle/README.md` and `gen_ad_oracle.py`** drop the stale ESH-0097 XKNOWN row. `CRASH_TASKS` is empty and every `xc=` argument in the generator is `None` — no cell is classified XKNOWN at all any more, so the README's "Known-open cells" section was describing a classification that no longer exists. It now says so.

**`.icc/silent-wrong-ledger.yaml`** closes LE-06 with the measurement as `remeasured:`, the gates as `evidence:`, and a `why_it_could_rot:` field naming the unwired acceptance test.

## Verification

Built and run on a Linux x86-64 lane at `c5ea3f12` (Release, LLVM 21, XLA and GPU off — the `linux-x64-lite` configure):

- `ctest -R "captured_local_vector_param|ad_sweep_c_regressions"` — **4/4 passed**, the four new entries
- `ctest -R "ad|autodiff|gradient|taylor|tensor"` — **58/58 passed**, the whole AD-adjacent subset
- `scripts/run_vm_parity.sh` — **191 passed, 0 failed, 0 infra**, including `32_gradient_reverse.esk` on both the `native-vs-vm-src` and `native-vs-vm-eskb` axes with the new captured-local section in it
- `found/esh0097_local_capture_vector_ad_ptrtoint.esk` — `#(4.42 0)` on `-r` and AOT
- `scripts/check_ledger_integrity.py` — PASS (117 entries); `--self-test` — PASS (fails every broken fixture, passes the well-formed one)
- `scripts/gate_no_silent_wrong.py --no-trace` — PASS
- `scripts/check_surface_counts.py --no-trace` — PASS
- `ctest -N` — 222 tests (was 218)

## Notes for the release train

- `docs/reference/ad/{operators,support-matrix,INDEX}.md` carry the same stale ESH-0097 claim. They are **left alone here** — PR #513 already edits all three, and this measurement confirms that its edit is the correct one.
- The CTest total moves 218 → 222. `scripts/check_surface_counts.py` grades that figure only when handed a `--ctest-log`, which CI does not do, so nothing goes red; the README figure is on the release checklist to be re-stamped from the final battery either way.
