### PR TITLE
ci: the mesh is the primary CI executor — ESHKOL_MESH_PRIMARY routes Linux contexts to self-hosted runners

### DIFF
--- a/.github/workflows/ci-mesh.yml
+++ b/.github/workflows/ci-mesh.yml
@@ -187,7 +187,7 @@ jobs:
     runs-on: ${{ fromJSON(matrix.labels) }}
     timeout-minutes: ${{ matrix.timeout }}
     env:
-      MESH_JOB_BUILD_DIR: ${{ github.workspace }}/.mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}
+      MESH_JOB_BUILD_DIR: .mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}
     strategy:
       fail-fast: false
       # One runner per node; don't let two lanes fight over the same box's

--- a/.github/workflows/ci-mesh.yml
+++ b/.github/workflows/ci-mesh.yml
@@ -3,8 +3,8 @@ name: CI (mesh, self-hosted)
 # ─────────────────────────────────────────────────────────────────────────
 # WHAT THIS IS, AND WHAT IT DELIBERATELY IS NOT
 #
-# This workflow runs a subset of the ci.yml lane batteries on the
-# maintainer's own hardware (the "mesh") instead of GitHub-hosted runners.
+# This workflow runs a legacy advisory subset of the ci.yml lane batteries on
+# the maintainer's own hardware (the "mesh") when primary routing is off.
 # Its purpose is capacity and honesty:
 #
 #   - CAPACITY. The hosted matrix in ci.yml is 14 lanes plus Windows SDK
@@ -21,7 +21,8 @@ name: CI (mesh, self-hosted)
 #     gpu-execution-gate.yml and shares this workflow's `gpu` label — see
 #     the runbook.)
 #
-# IT IS NOT A MERGE GATE, AND MUST NOT BECOME ONE BY ACCIDENT.
+# When ESHKOL_MESH_PRIMARY is on, ci.yml owns the mesh-routed lane names and
+# this advisory matrix is suppressed so a lane never runs twice.
 #
 # Nothing in this file appears in branch protection's required-contexts
 # list, and nothing in this file may be added to it without the maintainer
@@ -54,6 +55,8 @@ name: CI (mesh, self-hosted)
 #   1. Repository variable `ESHKOL_MESH_CI` must equal `on`. Unset (the
 #      default, and the state this file ships in) means every job here is
 #      SKIPPED — it never queues, never occupies a runner, never reports.
+#      `ESHKOL_MESH_PRIMARY=on` also suppresses this legacy workflow's lanes;
+#      the same lane names are then owned by ci.yml.
 #   2. `mesh-preflight` runs on a HOSTED runner and refuses to fan out when
 #      no runner carrying the `eshkol` label is registered, so switching the
 #      variable on before registering a runner still cannot leave jobs
@@ -121,12 +124,20 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           MESH_CI: ${{ vars.ESHKOL_MESH_CI }}
+          MESH_PRIMARY: ${{ vars.ESHKOL_MESH_PRIMARY }}
         run: |
           set -u
 
           if [ "${MESH_CI:-}" != "on" ]; then
             echo "dispatch=false" >> "$GITHUB_OUTPUT"
             echo "Repository variable ESHKOL_MESH_CI is '${MESH_CI:-<unset>}', not 'on'. Mesh lanes stay off." \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [ "${MESH_PRIMARY:-}" = "on" ]; then
+            echo "dispatch=false" >> "$GITHUB_OUTPUT"
+            echo "ESHKOL_MESH_PRIMARY is on; ci.yml owns the primary mesh lanes, so advisory lanes are suppressed." \
               >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
@@ -175,6 +186,8 @@ jobs:
     if: needs.mesh-preflight.outputs.dispatch == 'true'
     runs-on: ${{ fromJSON(matrix.labels) }}
     timeout-minutes: ${{ matrix.timeout }}
+    env:
+      MESH_JOB_BUILD_DIR: ${{ github.workspace }}/.mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}
     strategy:
       fail-fast: false
       # One runner per node; don't let two lanes fight over the same box's
@@ -273,6 +286,7 @@ jobs:
           command -v cmake >/dev/null 2>&1 || note "cmake is not installed on this runner."
           command -v ninja >/dev/null 2>&1 || note "ninja is not installed on this runner."
           command -v python3 >/dev/null 2>&1 || note "python3 is not installed on this runner."
+          command -v jq >/dev/null 2>&1 || note "jq is not installed on this runner."
 
           # `-fuse-ld=lld` (AArch64 Linux codegen) wants an unversioned ld.lld
           # in PATH. ci.yml symlinks it with sudo; a self-hosted runner must
@@ -313,7 +327,7 @@ jobs:
           else
             echo "Shared FetchContent cache is not seeded; retaining network fallback"
           fi
-          cmake -S . -B "${{ matrix.build_dir }}" -G Ninja \
+          cmake -S . -B "$MESH_JOB_BUILD_DIR" -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DESHKOL_REQUIRED_LLVM_MAJOR="${LLVM_MAJOR}" \
             -DLLVM_CONFIG_EXECUTABLE="$LLVM_CONFIG" \
@@ -330,19 +344,19 @@ jobs:
         run: |
           set -euxo pipefail
           python3 scripts/verify_gpu_backend.py \
-            --build-dir "${{ matrix.build_dir }}" \
+            --build-dir "$MESH_JOB_BUILD_DIR" \
             --expected CUDA
 
       - name: Build
         shell: bash
         run: |
           set -euxo pipefail
-          cmake --build "${{ matrix.build_dir }}" --parallel
+          cmake --build "$MESH_JOB_BUILD_DIR" --parallel
 
       - name: Run tests
         shell: bash
         env:
-          BUILD_DIR: ${{ matrix.build_dir }}
+          BUILD_DIR: ${{ env.MESH_JOB_BUILD_DIR }}
         run: |
           set -euxo pipefail
           mkdir -p "$RUNNER_TEMP/eshkol-test-logs"
@@ -382,5 +396,5 @@ jobs:
         shell: bash
         run: |
           set -u
-          rm -rf "${{ matrix.build_dir }}" || true
+          rm -rf "$MESH_JOB_BUILD_DIR" || true
           df -Pk . | awk 'NR==2 {printf "free after reclaim: %d GiB\n", int($4/1048576)}'

--- a/.github/workflows/ci-mesh.yml
+++ b/.github/workflows/ci-mesh.yml
@@ -103,8 +103,21 @@ jobs:
   # not itself depend on that fleet.
   # ───────────────────────────────────────────────────────────────────
   mesh-preflight:
-    name: mesh-preflight (hosted — decides whether the mesh lanes fan out)
-    runs-on: ubuntu-22.04
+    name: mesh-preflight (decides whether the mesh lanes fan out)
+    # `mesh-matrix` is `needs:` this job AND gated on its `dispatch` output, so
+    # a hosted placement here is a single point of failure for the entire
+    # advisory fan-out: when hosted runners cannot be acquired this dies in ~2
+    # seconds with zero steps and `dispatch` is never produced, so every mesh
+    # lane is skipped. The job only reads a repository variable and writes an
+    # output, so it runs anywhere; `["self-hosted", "eshkol"]` lets any eshkol
+    # runner serve it. The hosted fallback is retained for the fork-PR and
+    # mesh-off cases, where the mesh is deliberately not used.
+    runs-on: >-
+      ${{ vars.ESHKOL_MESH_PRIMARY == 'on' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository) &&
+          fromJSON('["self-hosted", "eshkol"]') ||
+          'ubuntu-22.04' }}
     timeout-minutes: 5
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,14 @@
 name: CI
 
 # ─────────────────────────────────────────────────────────────────────────
-# MESH-AS-MERGE-GATE: NOT YET. MAINTAINER DECISION REQUIRED BEFORE THE FLIP.
+# MESH-AS-MERGE-GATE: opt-in through ESHKOL_MESH_PRIMARY.
 #
-# The maintainer's heterogeneous compute mesh (see PR #391 / the
-# `mesh-gate-advisory` job below) can run the same lane batteries as
-# unix-matrix/windows-matrix/wasm-execute-diff on real hardware — including
-# real GPUs, unlike the hosted CUDA lanes — and produce one verdict via
-# `mesh gates run --lane eshkol --ref <sha>`. The eventual intent is for
-# that verdict to replace the equivalent hosted lanes as the actual merge
-# gate.
-#
-# THAT HAS NOT HAPPENED, and must not happen implicitly. The mesh's own
-# telemetry has been dark since at least 2026-08-17 — no fresh verdict, no
-# status endpoint reachable from a hosted GitHub Actions runner. Until the
-# mesh is observed live again AND a maintainer explicitly signs off, every
-# hosted lane below stays exactly as it is today, and every context
-# currently required by branch protection stays required. `mesh-gate-
-# advisory` is advisory-only (continue-on-error, not a required context)
-# and is presently a labeled no-op for exactly that reason — see its own
-# header comment further down.
+# When the repository variable is unset (the default), all runner selections
+# remain hosted. When it is `on`, the owned Linux x64 runner pool becomes the
+# primary executor for the Linux x64, WASM, guard, assurance, and surface lanes;
+# the CUDA lane uses the dedicated CUDA runner. ARM64, macOS, and Windows remain
+# hosted until their label variables are explicitly provisioned. Job names do
+# not change, so the required contexts remain stable.
 # ─────────────────────────────────────────────────────────────────────────
 
 on:
@@ -287,8 +276,8 @@ jobs:
           exit 0
 
   # ─────────────────────────────────────────────────────────────────────
-  # ADVISORY mesh-gate placeholder (see the top-of-file comment above for
-  # the full picture). This job never fails the build and its context must
+  # ADVISORY mesh-gate placeholder (the primary mesh lanes are selected below
+  # by ESHKOL_MESH_PRIMARY). This job never fails the build and its context must
   # never be added to branch protection's required list.
   #
   # `mesh gates run --lane eshkol --ref <sha>` is the maintainer's own
@@ -314,7 +303,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "::warning::mesh telemetry unavailable — the physical compute mesh has had no live, CI-reachable verdict endpoint since at least 2026-08-17. This job is an advisory placeholder: it does not run the mesh's lane batteries and its result does not gate this PR. Flipping any hosted lane's required status to the mesh is a maintainer decision, made only once the mesh is observed live again (see the comment at the top of this file)."
+          echo "::warning::mesh telemetry unavailable — the physical compute mesh verdict endpoint is not used by this advisory placeholder. Primary lane routing is controlled explicitly by ESHKOL_MESH_PRIMARY; this job remains non-blocking."
           echo "mesh-gate-advisory: mesh telemetry unavailable (placeholder, non-blocking)"
 
   # The language-surface manifest is the ground truth the execution-backed
@@ -340,9 +329,39 @@ jobs:
   surface-manifest:
     name: surface-manifest
     if: github.event_name != 'schedule'
-    runs-on: ubuntu-22.04
+    runs-on: >-
+      ${{ vars.ESHKOL_MESH_PRIMARY == 'on' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository) &&
+          fromJSON('["self-hosted", "Linux", "X64", "eshkol", "linux-mesh"]') ||
+          'ubuntu-22.04' }}
+    env:
+      MESH_PRIMARY_JOB: ${{ vars.ESHKOL_MESH_PRIMARY == 'on' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'true' || 'false' }}
+      MESH_JOB_BUILD_DIR: ${{ github.workspace }}/.mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-surface-manifest
     steps:
       - uses: actions/checkout@v6
+      - name: Toolchain preflight (primary mesh; provisioned out of band)
+        if: >-
+          vars.ESHKOL_MESH_PRIMARY == 'on' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository)
+        shell: bash
+        run: |
+          set -u
+          mkdir -p "$MESH_JOB_BUILD_DIR"
+          fail=0
+          note() { echo "::error title=Primary mesh runner not provisioned::$1 See docs/platform/SELF_HOSTED_RUNNERS.md § Provisioning."; fail=1; }
+          llvm_config="${LLVM_CONFIG_EXECUTABLE:-/usr/lib/llvm-21/bin/llvm-config}"
+          if [ ! -x "$llvm_config" ] || [ "$("$llvm_config" --version 2>/dev/null | cut -d. -f1)" != "21" ]; then
+            note "LLVM 21 llvm-config is missing; set LLVM_CONFIG_EXECUTABLE or provision /usr/lib/llvm-21/bin/llvm-config."
+          else
+            echo "LLVM_CONFIG_EXECUTABLE=$llvm_config" >> "$GITHUB_ENV"
+          fi
+          command -v cmake >/dev/null 2>&1 || note "cmake is not installed."
+          command -v ninja >/dev/null 2>&1 || note "ninja is not installed."
+          command -v python3 >/dev/null 2>&1 || note "python3 is not installed."
+          command -v jq >/dev/null 2>&1 || note "jq is not installed."
+          exit "$fail"
       - name: Manifest matches the source-extracted surface
         shell: bash
         run: |
@@ -370,6 +389,11 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/test_language_coverage_gate.py -v
+
+      - name: Reclaim per-job build tree
+        if: always()
+        shell: bash
+        run: rm -rf "$MESH_JOB_BUILD_DIR" || true
 
   # v1.3.5 assurance wave 1: three release gates that used to be doctrine
   # living only in prose (a memory file, a script's docstring) rather than
@@ -442,10 +466,46 @@ jobs:
   assurance-gates:
     name: assurance-gates
     if: github.event_name != 'schedule'
-    runs-on: ubuntu-22.04
+    runs-on: >-
+      ${{ vars.ESHKOL_MESH_PRIMARY == 'on' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository) &&
+          fromJSON('["self-hosted", "Linux", "X64", "eshkol", "linux-mesh"]') ||
+          'ubuntu-22.04' }}
+    env:
+      MESH_PRIMARY_JOB: ${{ vars.ESHKOL_MESH_PRIMARY == 'on' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'true' || 'false' }}
+      MESH_JOB_BUILD_DIR: ${{ github.workspace }}/.mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-assurance-gates
     steps:
       - uses: actions/checkout@v6
-      - name: Install PyYAML
+      - name: Toolchain preflight (primary mesh; provisioned out of band)
+        if: >-
+          vars.ESHKOL_MESH_PRIMARY == 'on' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository)
+        shell: bash
+        run: |
+          set -u
+          mkdir -p "$MESH_JOB_BUILD_DIR"
+          fail=0
+          note() { echo "::error title=Primary mesh runner not provisioned::$1 See docs/platform/SELF_HOSTED_RUNNERS.md § Provisioning."; fail=1; }
+          llvm_config="${LLVM_CONFIG_EXECUTABLE:-/usr/lib/llvm-21/bin/llvm-config}"
+          if [ ! -x "$llvm_config" ] || [ "$("$llvm_config" --version 2>/dev/null | cut -d. -f1)" != "21" ]; then
+            note "LLVM 21 llvm-config is missing; set LLVM_CONFIG_EXECUTABLE or provision /usr/lib/llvm-21/bin/llvm-config."
+          else
+            echo "LLVM_CONFIG_EXECUTABLE=$llvm_config" >> "$GITHUB_ENV"
+          fi
+          command -v cmake >/dev/null 2>&1 || note "cmake is not installed."
+          command -v ninja >/dev/null 2>&1 || note "ninja is not installed."
+          command -v python3 >/dev/null 2>&1 || note "python3 is not installed."
+          command -v jq >/dev/null 2>&1 || note "jq is not installed."
+          exit "$fail"
+      - name: Verify PyYAML (primary mesh; provisioned out of band)
+        if: env.MESH_PRIMARY_JOB == 'true'
+        shell: bash
+        run: python3 -c 'import yaml; print("PyYAML is provisioned")'
+
+      - name: Install PyYAML (hosted runner)
+        if: env.MESH_PRIMARY_JOB != 'true'
         shell: bash
         run: python3 -m pip install --quiet --disable-pip-version-check pyyaml
 
@@ -1131,9 +1191,54 @@ jobs:
     name: ${{ matrix.name }}
     needs: changes
     if: github.event_name != 'schedule' && needs.changes.outputs.docs_only == 'false'
-    runs-on: ${{ matrix.runner }}
+    runs-on: >-
+      ${{ vars.ESHKOL_MESH_PRIMARY == 'on' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository) &&
+          matrix.name == 'linux-x64-lite' &&
+          fromJSON('["self-hosted", "Linux", "X64", "eshkol", "linux-mesh"]') ||
+          vars.ESHKOL_MESH_PRIMARY == 'on' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository) &&
+          matrix.name == 'linux-x64-xla' &&
+          fromJSON('["self-hosted", "Linux", "X64", "eshkol", "linux-mesh"]') ||
+          vars.ESHKOL_MESH_PRIMARY == 'on' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository) &&
+          matrix.name == 'linux-x64-cuda' &&
+          fromJSON('["self-hosted", "Linux", "X64", "eshkol", "cuda"]') ||
+          vars.ESHKOL_MESH_PRIMARY == 'on' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository) &&
+          matrix.name == 'linux-x64-asan-ubsan' &&
+          fromJSON('["self-hosted", "Linux", "X64", "eshkol", "linux-mesh"]') ||
+          vars.ESHKOL_MESH_PRIMARY == 'on' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository) &&
+          startsWith(matrix.name, 'linux-arm64-') &&
+          vars.ESHKOL_MESH_ARM64_LABELS != '' &&
+          fromJSON(vars.ESHKOL_MESH_ARM64_LABELS) ||
+          vars.ESHKOL_MESH_PRIMARY == 'on' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository) &&
+          startsWith(matrix.name, 'macos-') &&
+          vars.ESHKOL_MESH_MACOS_LABELS != '' &&
+          fromJSON(vars.ESHKOL_MESH_MACOS_LABELS)[matrix.mesh_arch] ||
+          matrix.runner }}
+    env:
+      MESH_PRIMARY_JOB: >-
+        ${{ vars.ESHKOL_MESH_PRIMARY == 'on' &&
+            (github.event_name != 'pull_request' ||
+             github.event.pull_request.head.repo.full_name == github.repository) &&
+            (matrix.name == 'linux-x64-lite' || matrix.name == 'linux-x64-xla' ||
+             matrix.name == 'linux-x64-cuda' || matrix.name == 'linux-x64-asan-ubsan' ||
+             (startsWith(matrix.name, 'linux-arm64-') && vars.ESHKOL_MESH_ARM64_LABELS != '') ||
+             (startsWith(matrix.name, 'macos-') && vars.ESHKOL_MESH_MACOS_LABELS != '')) &&
+            'true' || 'false' }}
+      MESH_JOB_BUILD_DIR: ${{ github.workspace }}/.mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
         include:
           - name: linux-x64-lite
@@ -1146,6 +1251,7 @@ jobs:
             artifact_name: eshkol-linux-x64
           - name: linux-arm64-lite
             runner: ubuntu-22.04-arm
+            mesh_arch: arm64
             build_dir: build
             xla_enabled: 'OFF'
             gpu_enabled: 'OFF'
@@ -1162,6 +1268,7 @@ jobs:
             artifact_name: ''
           - name: linux-arm64-xla
             runner: ubuntu-22.04-arm
+            mesh_arch: arm64
             build_dir: build-xla
             xla_enabled: 'ON'
             gpu_enabled: 'OFF'
@@ -1178,6 +1285,7 @@ jobs:
             artifact_name: ''
           - name: linux-arm64-cuda
             runner: ubuntu-22.04-arm
+            mesh_arch: arm64
             build_dir: build-cuda
             xla_enabled: 'OFF'
             gpu_enabled: 'ON'
@@ -1186,6 +1294,7 @@ jobs:
             artifact_name: ''
           - name: macos-arm64-lite
             runner: macos-14
+            mesh_arch: arm64
             build_dir: build
             xla_enabled: 'OFF'
             gpu_enabled: 'OFF'
@@ -1194,6 +1303,7 @@ jobs:
             artifact_name: eshkol-macos-arm64
           - name: macos-x64-lite
             runner: macos-15-intel
+            mesh_arch: x64
             build_dir: build
             xla_enabled: 'OFF'
             gpu_enabled: 'OFF'
@@ -1202,6 +1312,7 @@ jobs:
             artifact_name: eshkol-macos-x64
           - name: macos-arm64-xla
             runner: macos-14
+            mesh_arch: arm64
             build_dir: build-xla
             xla_enabled: 'ON'
             gpu_enabled: 'OFF'
@@ -1210,6 +1321,7 @@ jobs:
             artifact_name: ''
           - name: macos-x64-xla
             runner: macos-15-intel
+            mesh_arch: x64
             build_dir: build-xla
             xla_enabled: 'ON'
             gpu_enabled: 'OFF'
@@ -1243,6 +1355,42 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Toolchain preflight (primary mesh; provisioned out of band)
+        if: env.MESH_PRIMARY_JOB == 'true'
+        shell: bash
+        run: |
+          set -u
+          fail=0
+          note() { echo "::error title=Primary mesh runner not provisioned::$1 See docs/platform/SELF_HOSTED_RUNNERS.md § Provisioning."; fail=1; }
+          llvm_config="${LLVM_CONFIG_EXECUTABLE:-/usr/lib/llvm-21/bin/llvm-config}"
+          if [ ! -x "$llvm_config" ] || [ "$("$llvm_config" --version 2>/dev/null | cut -d. -f1)" != "21" ]; then
+            note "LLVM 21 llvm-config is missing; set LLVM_CONFIG_EXECUTABLE or provision /usr/lib/llvm-21/bin/llvm-config."
+          else
+            echo "LLVM_CONFIG_EXECUTABLE=$llvm_config" >> "$GITHUB_ENV"
+            echo "LLVM_CONFIG=$llvm_config" >> "$GITHUB_ENV"
+          fi
+          command -v cmake >/dev/null 2>&1 || note "cmake is not installed."
+          command -v ninja >/dev/null 2>&1 || note "ninja is not installed."
+          command -v python3 >/dev/null 2>&1 || note "python3 is not installed."
+          command -v jq >/dev/null 2>&1 || note "jq is not installed."
+          if [ "${{ matrix.gpu_enabled }}" = "ON" ]; then
+            command -v nvcc >/dev/null 2>&1 || note "nvcc is not on PATH for the CUDA lane."
+            command -v nvidia-smi >/dev/null 2>&1 || note "nvidia-smi is missing; the cuda runner has no usable GPU."
+            nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader || note "nvidia-smi cannot address a CUDA device."
+          fi
+          if [ "$RUNNER_OS" = "Linux" ] && ! command -v ld.lld >/dev/null 2>&1; then
+            versioned="$(command -v ld.lld-21 2>/dev/null || true)"
+            [ -n "$versioned" ] || versioned="/usr/lib/llvm-21/bin/ld.lld"
+            if [ -x "$versioned" ]; then
+              mkdir -p "$RUNNER_TEMP/bin"
+              ln -sf "$versioned" "$RUNNER_TEMP/bin/ld.lld"
+              echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+            else
+              note "ld.lld (or ld.lld-21) is not installed."
+            fi
+          fi
+          exit "$fail"
+
       # Every network fetch below goes through scripts/ci_retry.sh — the
       # single definition of this repo's CI retry policy (bounded attempts,
       # exponential backoff, explicit per-command timeouts) — rather than a
@@ -1253,7 +1401,7 @@ jobs:
       # `apt-get install` in "Install Dependencies (Linux)" below had NO
       # retry at all before this change.
       - name: Add LLVM Repository (Linux)
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && env.MESH_PRIMARY_JOB != 'true'
         shell: bash
         run: |
           set -euxo pipefail
@@ -1266,7 +1414,7 @@ jobs:
             sudo apt-get update -o Acquire::Retries=5 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20
 
       - name: Add NVIDIA CUDA Repository (Linux CUDA)
-        if: runner.os == 'Linux' && matrix.gpu_enabled == 'ON'
+        if: runner.os == 'Linux' && matrix.gpu_enabled == 'ON' && env.MESH_PRIMARY_JOB != 'true'
         shell: bash
         run: |
           set -euxo pipefail
@@ -1284,7 +1432,7 @@ jobs:
             sudo apt-get update -o Acquire::Retries=5 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20
 
       - name: Install Dependencies (Linux)
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && env.MESH_PRIMARY_JOB != 'true'
         shell: bash
         run: |
           set -euxo pipefail
@@ -1318,7 +1466,7 @@ jobs:
           ld.lld --version
 
       - name: Install Dependencies (macOS)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && env.MESH_PRIMARY_JOB != 'true'
         shell: bash
         run: |
           set -euxo pipefail
@@ -1328,8 +1476,13 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          BUILD_DIR="${{ matrix.build_dir }}"
-          if [[ "$RUNNER_OS" == "macOS" ]]; then
+          BUILD_DIR="$MESH_JOB_BUILD_DIR"
+          build_type=Release
+          build_tests=ON
+          if [[ "$MESH_PRIMARY_JOB" == "true" ]]; then
+            LLVM_CONFIG="${LLVM_CONFIG_EXECUTABLE:?primary mesh preflight did not export LLVM_CONFIG_EXECUTABLE}"
+            build_type=RelWithDebInfo
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
             LLVM_PREFIX="$(brew --prefix llvm@${LLVM_MAJOR})"
             export PATH="$LLVM_PREFIX/bin:$PATH"
             LLVM_CONFIG="$LLVM_PREFIX/bin/llvm-config"
@@ -1338,9 +1491,10 @@ jobs:
           fi
 
           cmake -S . -B "$BUILD_DIR" -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_TYPE="$build_type" \
             -DESHKOL_REQUIRED_LLVM_MAJOR="${LLVM_MAJOR}" \
             -DLLVM_CONFIG_EXECUTABLE="$LLVM_CONFIG" \
+            -DESHKOL_BUILD_TESTS="$build_tests" \
             -DESHKOL_XLA_ENABLED=${{ matrix.xla_enabled }} \
             -DESHKOL_GPU_ENABLED=${{ matrix.gpu_enabled }} \
             -DESHKOL_REQUIRE_GPU_BACKEND=${{ matrix.gpu_enabled }} \
@@ -1353,7 +1507,7 @@ jobs:
         run: |
           set -euxo pipefail
           python3 scripts/verify_gpu_backend.py \
-            --build-dir "${{ matrix.build_dir }}" \
+            --build-dir "$MESH_JOB_BUILD_DIR" \
             --expected CUDA
 
       - name: Build
@@ -1364,7 +1518,7 @@ jobs:
             export ASAN_OPTIONS="${ASAN_OPTIONS:-detect_leaks=0:halt_on_error=1:allocator_may_return_null=1}"
             export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=1:print_stacktrace=1}"
           fi
-          cmake --build "${{ matrix.build_dir }}" --parallel
+          cmake --build "$MESH_JOB_BUILD_DIR" --parallel
 
       # Catches the failure mode where a new C runtime helper
       # (eshkol_intern_symbol_lookup, region_create, …) is added on the
@@ -1380,7 +1534,7 @@ jobs:
         if: matrix.xla_enabled == 'OFF' && matrix.gpu_enabled == 'OFF' && matrix.build_dir == 'build'
         shell: bash
         env:
-          BUILD_DIR: ${{ matrix.build_dir }}
+          BUILD_DIR: ${{ env.MESH_JOB_BUILD_DIR }}
         run: |
           set -euxo pipefail
           python3 scripts/check_wasm_imports.py --build-dir "$BUILD_DIR"
@@ -1393,7 +1547,7 @@ jobs:
         if: matrix.xla_enabled == 'OFF' && matrix.gpu_enabled == 'OFF' && matrix.build_dir == 'build'
         shell: bash
         env:
-          BUILD_DIR: ${{ matrix.build_dir }}
+          BUILD_DIR: ${{ env.MESH_JOB_BUILD_DIR }}
         run: |
           set -euxo pipefail
           python3 scripts/check_wasm_size.py --build-dir "$BUILD_DIR"
@@ -1408,7 +1562,7 @@ jobs:
         if: matrix.xla_enabled == 'OFF' && matrix.gpu_enabled == 'OFF' && matrix.build_dir == 'build'
         shell: bash
         env:
-          BUILD_DIR: ${{ matrix.build_dir }}
+          BUILD_DIR: ${{ env.MESH_JOB_BUILD_DIR }}
         run: |
           set -euxo pipefail
           python3 scripts/check_diagnostic_corpus.py --build-dir "$BUILD_DIR"
@@ -1422,7 +1576,7 @@ jobs:
         if: contains(matrix.sanitizer_flags, 'ESHKOL_ENABLE_ASAN=ON')
         shell: bash
         env:
-          BUILD_DIR: ${{ matrix.build_dir }}
+          BUILD_DIR: ${{ env.MESH_JOB_BUILD_DIR }}
         run: |
           set -euxo pipefail
           ./scripts/check_leak_detection_selftest.sh
@@ -1441,7 +1595,7 @@ jobs:
         if: contains(matrix.sanitizer_flags, 'ESHKOL_ENABLE_ASAN=ON')
         shell: bash
         env:
-          BUILD_DIR: ${{ matrix.build_dir }}
+          BUILD_DIR: ${{ env.MESH_JOB_BUILD_DIR }}
         run: |
           set -euxo pipefail
           ./tests/memory/leak_audit_gate.sh
@@ -1450,7 +1604,7 @@ jobs:
         timeout-minutes: 120
         shell: bash
         env:
-          BUILD_DIR: ${{ matrix.build_dir }}
+          BUILD_DIR: ${{ env.MESH_JOB_BUILD_DIR }}
         run: |
           set -euxo pipefail
           mkdir -p "$RUNNER_TEMP/eshkol-test-logs"
@@ -1478,12 +1632,12 @@ jobs:
             export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=1:print_stacktrace=1}"
           fi
           ${{ matrix.test_command }} 2>&1 | tee "$RUNNER_TEMP/eshkol-test-logs/${{ matrix.name }}.log"
-          test -x "${{ matrix.build_dir }}/eshkol-agent-http-test"
-          "${{ matrix.build_dir }}/eshkol-agent-http-test"
-          test -x "${{ matrix.build_dir }}/eshkol-agent-sse-test"
-          "${{ matrix.build_dir }}/eshkol-agent-sse-test"
-          test -x "${{ matrix.build_dir }}/eshkol-agent-capabilities-test"
-          "${{ matrix.build_dir }}/eshkol-agent-capabilities-test"
+          test -x "$MESH_JOB_BUILD_DIR/eshkol-agent-http-test"
+          "$MESH_JOB_BUILD_DIR/eshkol-agent-http-test"
+          test -x "$MESH_JOB_BUILD_DIR/eshkol-agent-sse-test"
+          "$MESH_JOB_BUILD_DIR/eshkol-agent-sse-test"
+          test -x "$MESH_JOB_BUILD_DIR/eshkol-agent-capabilities-test"
+          "$MESH_JOB_BUILD_DIR/eshkol-agent-capabilities-test"
 
       # The exactness guarantee, gated so that it can fail.
       #
@@ -1506,7 +1660,7 @@ jobs:
         timeout-minutes: 25
         shell: bash
         env:
-          BUILD_DIR: ${{ matrix.build_dir }}
+          BUILD_DIR: ${{ env.MESH_JOB_BUILD_DIR }}
           ESHKOL_JIT_CACHE_DIR: ${{ runner.temp }}/eshkol-ad-exactness-jit-cache
         run: |
           set -euxo pipefail
@@ -1527,10 +1681,10 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: |
-            ${{ matrix.build_dir }}/eshkol-run
-            ${{ matrix.build_dir }}/eshkol-repl
-            ${{ matrix.build_dir }}/stdlib.o
-            ${{ matrix.build_dir }}/stdlib.bc
+            ${{ env.MESH_JOB_BUILD_DIR }}/eshkol-run
+            ${{ env.MESH_JOB_BUILD_DIR }}/eshkol-repl
+            ${{ env.MESH_JOB_BUILD_DIR }}/stdlib.o
+            ${{ env.MESH_JOB_BUILD_DIR }}/stdlib.bc
 
       # Evidence must survive CI (ADR-0010 §2.2; closes AR1 gap A5). Any lane
       # that emits ICC oracle traces — the execution-backed coverage step, the
@@ -1553,6 +1707,13 @@ jobs:
             .icc/runtime-traces/
             .icc/runtime-traces-oracle-view/
           if-no-files-found: ignore
+
+      - name: Reclaim per-job build tree
+        if: always()
+        shell: bash
+        run: |
+          set -u
+          rm -rf "$MESH_JOB_BUILD_DIR" || true
 
   # The Windows lanes' own curl-from-llvm-project path is where the
   # stall/slow-download risk lives (see "Install LLVM SDK" below and
@@ -1617,7 +1778,20 @@ jobs:
     name: ${{ matrix.name }}
     needs: [changes, prefetch-windows-llvm-archives]
     if: github.event_name != 'schedule' && needs.changes.outputs.docs_only == 'false'
-    runs-on: ${{ matrix.runner }}
+    runs-on: >-
+      ${{ vars.ESHKOL_MESH_PRIMARY == 'on' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository) &&
+          vars.ESHKOL_MESH_WINDOWS_LABELS != '' &&
+          fromJSON(vars.ESHKOL_MESH_WINDOWS_LABELS)[matrix.mesh_arch] ||
+          matrix.runner }}
+    env:
+      MESH_PRIMARY_JOB: >-
+        ${{ vars.ESHKOL_MESH_PRIMARY == 'on' &&
+            (github.event_name != 'pull_request' ||
+             github.event.pull_request.head.repo.full_name == github.repository) &&
+            vars.ESHKOL_MESH_WINDOWS_LABELS != '' && 'true' || 'false' }}
+      MESH_JOB_BUILD_DIR: ${{ github.workspace }}/.mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}
     # windows-arm64-lite alone (full build+test, LLVM SDK cache-hit so no
     # extraction) has run ~51 minutes end to end; windows-x64-cuda adds the
     # CUDA toolkit install and GPU build/test on top. 90 minutes leaves that
@@ -1635,6 +1809,7 @@ jobs:
           # is a separate hosted x64 lane below.
           - name: windows-arm64-lite
             runner: windows-11-arm
+            mesh_arch: arm64
             arch: arm64
             llvm_suffix: aarch64
             build_dir: build
@@ -1645,6 +1820,7 @@ jobs:
             artifact_name: eshkol-windows-arm64
           - name: windows-arm64-xla
             runner: windows-11-arm
+            mesh_arch: arm64
             arch: arm64
             llvm_suffix: aarch64
             build_dir: build-xla
@@ -1655,6 +1831,7 @@ jobs:
             artifact_name: ''
           - name: windows-x64-cuda
             runner: windows-2022
+            mesh_arch: x64
             arch: x64
             llvm_suffix: x86_64
             build_dir: build-cuda
@@ -1666,8 +1843,38 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Toolchain preflight (primary mesh; provisioned out of band)
+        if: env.MESH_PRIMARY_JOB == 'true'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          foreach ($tool in @('cmake.exe', 'ninja.exe', 'python.exe', 'jq.exe')) {
+            if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
+              throw "Primary mesh runner is missing $tool. Provision it before registering the runner; CI never installs tools on self-hosted hosts."
+            }
+          }
+          $llvmConfig = if ($env:LLVM_CONFIG_EXECUTABLE) { $env:LLVM_CONFIG_EXECUTABLE } else { (Get-Command llvm-config.exe -ErrorAction SilentlyContinue).Source }
+          if (-not $llvmConfig -or -not (Test-Path $llvmConfig)) {
+            throw "Primary mesh runner is missing LLVM 21 llvm-config. Set LLVM_CONFIG_EXECUTABLE to the provisioned LLVM 21 installation."
+          }
+          $version = (& $llvmConfig --version).Split('.')[0]
+          if ($version -ne '21') { throw "LLVM_CONFIG_EXECUTABLE points to LLVM $version, but LLVM 21 is required." }
+          $llvmHome = Split-Path (Split-Path $llvmConfig -Parent) -Parent
+          $llvmCmakeDir = Join-Path $llvmHome 'lib\cmake\llvm'
+          if (-not (Test-Path (Join-Path $llvmCmakeDir 'LLVMConfig.cmake'))) {
+            throw "LLVMConfig.cmake not found under $llvmCmakeDir."
+          }
+          "LLVM_CONFIG_EXECUTABLE=$llvmConfig" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "LLVM_HOME=$llvmHome" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "LLVM_DIR=$llvmCmakeDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          if ('${{ matrix.gpu_enabled }}' -eq 'ON') {
+            if (-not $env:CUDA_PATH -or -not (Test-Path "$env:CUDA_PATH\bin\nvcc.exe")) {
+              throw "Primary mesh CUDA runner is missing CUDA_PATH or nvcc.exe."
+            }
+          }
+
       - name: Install NVIDIA CUDA Toolkit (Windows x64 CUDA)
-        if: matrix.gpu_enabled == 'ON'
+        if: matrix.gpu_enabled == 'ON' && env.MESH_PRIMARY_JOB != 'true'
         uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76
         with:
           cuda: ${{ env.CUDA_VERSION }}
@@ -1680,6 +1887,7 @@ jobs:
 
       - name: Restore LLVM SDK Cache
         id: llvm-cache
+        if: env.MESH_PRIMARY_JOB != 'true'
         uses: actions/cache/restore@v5
         with:
           path: C:\src\clang+llvm-${{ env.WINDOWS_LLVM_SDK_VERSION }}-${{ matrix.llvm_suffix }}-pc-windows-msvc
@@ -1689,7 +1897,7 @@ jobs:
       # `needs:`. On a hit, "Install LLVM SDK" below extracts straight from
       # this file and never calls curl at all.
       - name: Restore prefetched LLVM SDK archive
-        if: steps.llvm-cache.outputs.cache-hit != 'true'
+        if: steps.llvm-cache.outputs.cache-hit != 'true' && env.MESH_PRIMARY_JOB != 'true'
         id: archive-cache
         uses: actions/cache/restore@v5
         with:
@@ -1698,7 +1906,7 @@ jobs:
           enableCrossOsArchive: true
 
       - name: Install LLVM SDK
-        if: steps.llvm-cache.outputs.cache-hit != 'true'
+        if: steps.llvm-cache.outputs.cache-hit != 'true' && env.MESH_PRIMARY_JOB != 'true'
         shell: pwsh
         # Pure extraction of an already-local archive should never come
         # close to this. If it does, something is genuinely stuck and
@@ -1777,6 +1985,7 @@ jobs:
           Write-Host "LLVM $llvmVersion ${{ matrix.arch }} ready at $llvmRoot"
 
       - name: Resolve LLVM SDK
+        if: env.MESH_PRIMARY_JOB != 'true'
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -1794,7 +2003,7 @@ jobs:
           "$llvmRoot\bin"             | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Save LLVM SDK Cache
-        if: steps.llvm-cache.outputs.cache-hit != 'true'
+        if: steps.llvm-cache.outputs.cache-hit != 'true' && env.MESH_PRIMARY_JOB != 'true'
         uses: actions/cache/save@v5
         with:
           path: C:\src\clang+llvm-${{ env.WINDOWS_LLVM_SDK_VERSION }}-${{ matrix.llvm_suffix }}-pc-windows-msvc
@@ -1815,9 +2024,9 @@ jobs:
           }
           $cmakeArgs = @(
             '-S', '.',
-            '-B', '${{ matrix.build_dir }}',
+            '-B', $env:MESH_JOB_BUILD_DIR,
             '-DBUILD_REPL=ON',
-            '-DESHKOL_BUILD_TESTS=OFF',
+            "-DESHKOL_BUILD_TESTS=$(if ($env:MESH_PRIMARY_JOB -eq 'true') { 'ON' } else { 'OFF' })",
             '-DESHKOL_REQUIRED_LLVM_MAJOR=${{ env.LLVM_MAJOR }}',
             "-DESHKOL_HOST_CXX_COMPILER=$hostCxx",
             '-DESHKOL_XLA_ENABLED=${{ matrix.xla_enabled }}',
@@ -1913,7 +2122,7 @@ jobs:
           & "$env:CUDA_PATH\bin\nvcc.exe" --version
           if ($LASTEXITCODE -ne 0) { throw "nvcc version probe failed" }
           python scripts/verify_gpu_backend.py `
-            --build-dir '${{ matrix.build_dir }}' `
+            --build-dir "$env:MESH_JOB_BUILD_DIR" `
             --expected CUDA
 
       - name: Build
@@ -1924,7 +2133,7 @@ jobs:
           if ('${{ matrix.test_mode }}' -eq 'xla') {
             $targets += 'xla_codegen_test'
           }
-          cmake --build '${{ matrix.build_dir }}' --config Release --target @($targets) --parallel
+          cmake --build "$env:MESH_JOB_BUILD_DIR" --config Release --target @($targets) --parallel
 
       - name: Run Tests
         timeout-minutes: 120
@@ -1932,15 +2141,15 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP\eshkol-test-logs" | Out-Null
-          & .\scripts\run_all_tests.ps1 -BuildDir ".\${{ matrix.build_dir }}" -SkipConfigureBuild -Mode '${{ matrix.test_mode }}' *>&1 |
+          & .\scripts\run_all_tests.ps1 -BuildDir "$env:MESH_JOB_BUILD_DIR" -SkipConfigureBuild -Mode '${{ matrix.test_mode }}' *>&1 |
             Tee-Object -FilePath "$env:RUNNER_TEMP\eshkol-test-logs\${{ matrix.name }}.log"
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
-          $agentNativeTest = Join-Path '${{ matrix.build_dir }}' 'Release\eshkol-windows-agent-test.exe'
-          $agentHttpTest = Join-Path '${{ matrix.build_dir }}' 'Release\eshkol-agent-http-test.exe'
-          $agentSseTest = Join-Path '${{ matrix.build_dir }}' 'Release\eshkol-agent-sse-test.exe'
-          $agentCapabilitiesTest = Join-Path '${{ matrix.build_dir }}' 'Release\eshkol-agent-capabilities-test.exe'
+          $agentNativeTest = Join-Path $env:MESH_JOB_BUILD_DIR 'Release\eshkol-windows-agent-test.exe'
+          $agentHttpTest = Join-Path $env:MESH_JOB_BUILD_DIR 'Release\eshkol-agent-http-test.exe'
+          $agentSseTest = Join-Path $env:MESH_JOB_BUILD_DIR 'Release\eshkol-agent-sse-test.exe'
+          $agentCapabilitiesTest = Join-Path $env:MESH_JOB_BUILD_DIR 'Release\eshkol-agent-capabilities-test.exe'
           foreach ($test in @($agentNativeTest, $agentHttpTest, $agentSseTest, $agentCapabilitiesTest)) {
             if (-not (Test-Path $test -PathType Leaf)) {
               throw "Required native agent contract test is missing: $test"
@@ -1965,10 +2174,16 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: |
-            ${{ matrix.build_dir }}/Release/eshkol-run.exe
-            ${{ matrix.build_dir }}/Release/eshkol-repl.exe
-            ${{ matrix.build_dir }}/stdlib.o
-            ${{ matrix.build_dir }}/stdlib.bc
+            ${{ env.MESH_JOB_BUILD_DIR }}/Release/eshkol-run.exe
+            ${{ env.MESH_JOB_BUILD_DIR }}/Release/eshkol-repl.exe
+            ${{ env.MESH_JOB_BUILD_DIR }}/stdlib.o
+            ${{ env.MESH_JOB_BUILD_DIR }}/stdlib.bc
+
+      - name: Reclaim per-job build tree
+        if: always()
+        shell: pwsh
+        run: |
+          Remove-Item -LiteralPath $env:MESH_JOB_BUILD_DIR -Recurse -Force -ErrorAction SilentlyContinue
 
   # ─────────────────────────────────────────────────────────────────────
   # WASM execute-and-diff lane.  Closes the WASM-correctness cell in the
@@ -1992,10 +2207,50 @@ jobs:
     name: wasm-execute-diff
     needs: changes
     if: github.event_name != 'schedule' && needs.changes.outputs.docs_only == 'false'
-    runs-on: ubuntu-22.04
+    runs-on: >-
+      ${{ vars.ESHKOL_MESH_PRIMARY == 'on' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository) &&
+          fromJSON('["self-hosted", "Linux", "X64", "eshkol", "linux-mesh"]') ||
+          'ubuntu-22.04' }}
     timeout-minutes: 45
+    env:
+      MESH_PRIMARY_JOB: ${{ vars.ESHKOL_MESH_PRIMARY == 'on' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'true' || 'false' }}
+      MESH_JOB_BUILD_DIR: ${{ github.workspace }}/.mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-wasm-execute-diff
     steps:
       - uses: actions/checkout@v6
+
+      - name: Toolchain preflight (primary mesh; provisioned out of band)
+        if: env.MESH_PRIMARY_JOB == 'true'
+        shell: bash
+        run: |
+          set -u
+          fail=0
+          note() { echo "::error title=Primary mesh runner not provisioned::$1 See docs/platform/SELF_HOSTED_RUNNERS.md § Provisioning, including the emsdk requirement."; fail=1; }
+          llvm_config="${LLVM_CONFIG_EXECUTABLE:-/usr/lib/llvm-21/bin/llvm-config}"
+          if [ ! -x "$llvm_config" ] || [ "$("$llvm_config" --version 2>/dev/null | cut -d. -f1)" != "21" ]; then
+            note "LLVM 21 llvm-config is missing; set LLVM_CONFIG_EXECUTABLE or provision /usr/lib/llvm-21/bin/llvm-config."
+          else
+            echo "LLVM_CONFIG_EXECUTABLE=$llvm_config" >> "$GITHUB_ENV"
+          fi
+          command -v cmake >/dev/null 2>&1 || note "cmake is not installed."
+          command -v ninja >/dev/null 2>&1 || note "ninja is not installed."
+          command -v python3 >/dev/null 2>&1 || note "python3 is not installed."
+          command -v jq >/dev/null 2>&1 || note "jq is not installed."
+          command -v emcc >/dev/null 2>&1 || note "emcc is missing. Provision emsdk under ~/emsdk and put its active upstream toolchain on PATH."
+          command -v node >/dev/null 2>&1 || note "node is not installed (required by the WASM execute-and-diff gate)."
+          if [ "$RUNNER_OS" = "Linux" ] && ! command -v ld.lld >/dev/null 2>&1; then
+            versioned="$(command -v ld.lld-21 2>/dev/null || true)"
+            [ -n "$versioned" ] || versioned="/usr/lib/llvm-21/bin/ld.lld"
+            if [ -x "$versioned" ]; then
+              mkdir -p "$RUNNER_TEMP/bin"
+              ln -sf "$versioned" "$RUNNER_TEMP/bin/ld.lld"
+              echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+            else
+              note "ld.lld (or ld.lld-21) is not installed."
+            fi
+          fi
+          exit "$fail"
 
       # See the unix-matrix job's identical-in-spirit step for why every
       # fetch here goes through scripts/ci_retry.sh. This block's prior
@@ -2006,6 +2261,7 @@ jobs:
       # the retry policy has one definition and a real failure is still
       # terminal.
       - name: Add LLVM Repository (Linux)
+        if: env.MESH_PRIMARY_JOB != 'true'
         shell: bash
         run: |
           set -euxo pipefail
@@ -2018,6 +2274,7 @@ jobs:
             sudo apt-get update -o Acquire::Retries=5 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20
 
       - name: Install Dependencies (Linux)
+        if: env.MESH_PRIMARY_JOB != 'true'
         shell: bash
         run: |
           set -euxo pipefail
@@ -2031,12 +2288,14 @@ jobs:
           sudo ln -sf "/usr/bin/ld.lld-${LLVM_MAJOR}" /usr/bin/ld.lld
 
       - name: Setup Emscripten
+        if: env.MESH_PRIMARY_JOB != 'true'
         uses: mymindstorm/setup-emsdk@v14
         with:
           version: 4.0.22
           actions-cache-folder: emsdk-cache-4.0.22
 
       - name: Setup Node
+        if: env.MESH_PRIMARY_JOB != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -2045,22 +2304,30 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          cmake -S . -B build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
+          build_type=Release
+          llvm_config="/usr/bin/llvm-config-${LLVM_MAJOR}"
+          if [[ "$MESH_PRIMARY_JOB" == "true" ]]; then
+            build_type=RelWithDebInfo
+            llvm_config="${LLVM_CONFIG_EXECUTABLE:?primary mesh preflight did not export LLVM_CONFIG_EXECUTABLE}"
+          fi
+          cmake -S . -B "$MESH_JOB_BUILD_DIR" -G Ninja \
+            -DCMAKE_BUILD_TYPE="$build_type" \
             -DESHKOL_BUILD_TESTS=OFF \
             -DESHKOL_XLA_ENABLED=OFF \
-            -DESHKOL_GPU_ENABLED=OFF
+            -DESHKOL_GPU_ENABLED=OFF \
+            -DESHKOL_REQUIRE_GPU_BACKEND=OFF \
+            -DLLVM_CONFIG_EXECUTABLE="$llvm_config"
 
       - name: Build eshkol-run + stdlib
         shell: bash
         run: |
           set -euxo pipefail
-          cmake --build build --target eshkol-run stdlib --parallel
+          cmake --build "$MESH_JOB_BUILD_DIR" --target eshkol-run stdlib --parallel
 
       - name: Run WASM execute-and-diff
         shell: bash
         env:
-          BUILD_DIR: build
+          BUILD_DIR: ${{ env.MESH_JOB_BUILD_DIR }}
         run: |
           set -euxo pipefail
           emcc --version
@@ -2074,6 +2341,13 @@ jobs:
           name: wasm-execute-diff-trace
           path: scripts/icc_traces/wasm_parity.jsonl
           if-no-files-found: ignore
+
+      - name: Reclaim per-job build tree
+        if: always()
+        shell: bash
+        run: |
+          set -u
+          rm -rf "$MESH_JOB_BUILD_DIR" || true
 
   # actions/cache evicts entries that go unaccessed for 7 days, and the
   # windows-llvm-sdk-* caches only get touched by pushes/PRs that actually

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,7 @@ jobs:
           'ubuntu-22.04' }}
     env:
       MESH_PRIMARY_JOB: ${{ vars.ESHKOL_MESH_PRIMARY == 'on' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'true' || 'false' }}
-      MESH_JOB_BUILD_DIR: ${{ github.workspace }}/.mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-surface-manifest
+      MESH_JOB_BUILD_DIR: .mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-surface-manifest
     steps:
       - uses: actions/checkout@v6
       - name: Toolchain preflight (primary mesh; provisioned out of band)
@@ -474,7 +474,7 @@ jobs:
           'ubuntu-22.04' }}
     env:
       MESH_PRIMARY_JOB: ${{ vars.ESHKOL_MESH_PRIMARY == 'on' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'true' || 'false' }}
-      MESH_JOB_BUILD_DIR: ${{ github.workspace }}/.mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-assurance-gates
+      MESH_JOB_BUILD_DIR: .mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-assurance-gates
     steps:
       - uses: actions/checkout@v6
       - name: Toolchain preflight (primary mesh; provisioned out of band)
@@ -1235,7 +1235,7 @@ jobs:
              (startsWith(matrix.name, 'linux-arm64-') && vars.ESHKOL_MESH_ARM64_LABELS != '') ||
              (startsWith(matrix.name, 'macos-') && vars.ESHKOL_MESH_MACOS_LABELS != '')) &&
             'true' || 'false' }}
-      MESH_JOB_BUILD_DIR: ${{ github.workspace }}/.mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}
+      MESH_JOB_BUILD_DIR: .mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -1791,7 +1791,7 @@ jobs:
             (github.event_name != 'pull_request' ||
              github.event.pull_request.head.repo.full_name == github.repository) &&
             vars.ESHKOL_MESH_WINDOWS_LABELS != '' && 'true' || 'false' }}
-      MESH_JOB_BUILD_DIR: ${{ github.workspace }}/.mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}
+      MESH_JOB_BUILD_DIR: .mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}
     # windows-arm64-lite alone (full build+test, LLVM SDK cache-hit so no
     # extraction) has run ~51 minutes end to end; windows-x64-cuda adds the
     # CUDA toolkit install and GPU build/test on top. 90 minutes leaves that
@@ -2216,7 +2216,7 @@ jobs:
     timeout-minutes: 45
     env:
       MESH_PRIMARY_JOB: ${{ vars.ESHKOL_MESH_PRIMARY == 'on' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'true' || 'false' }}
-      MESH_JOB_BUILD_DIR: ${{ github.workspace }}/.mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-wasm-execute-diff
+      MESH_JOB_BUILD_DIR: .mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-wasm-execute-diff
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,24 @@ jobs:
   changes:
     name: changes
     if: github.event_name != 'schedule'
-    runs-on: ubuntu-22.04
+    # ENTRY POINT. Ten jobs `needs:` this one, so wherever it runs decides
+    # whether the workflow runs at all. It was left on a hosted runner while
+    # every lane below it moved to the mesh, which is the one placement that
+    # cannot work under the condition this whole PR exists to survive: when
+    # hosted runners cannot be acquired the job dies in ~2 seconds with zero
+    # steps executed, and all ten dependents are skipped. The mesh lanes would
+    # then be correctly routed and never dispatched.
+    #
+    # It is a path-filter and nothing else — no build, no toolchain — so the
+    # broad `["self-hosted", "eshkol"]` selector is deliberate: any eshkol
+    # runner of any platform can serve it, and it lands on whichever is free
+    # rather than queueing behind a busy lane node.
+    runs-on: >-
+      ${{ vars.ESHKOL_MESH_PRIMARY == 'on' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository) &&
+          fromJSON('["self-hosted", "eshkol"]') ||
+          'ubuntu-22.04' }}
     # Scoped to this job only; the rest of the workflow keeps the repository
     # default. `pull-requests: read` is what lets the API strategy below work.
     permissions:
@@ -1165,7 +1182,21 @@ jobs:
     name: ${{ matrix.name }}
     needs: changes
     if: github.event_name != 'schedule' && needs.changes.outputs.docs_only == 'true'
-    runs-on: ubuntu-22.04
+    # On a docs-only PR this job is the ONLY producer of the required
+    # contexts — the real matrices are gated on the opposite condition and
+    # never instantiate. So if it cannot acquire a runner, every required
+    # context is absent rather than failing, and branch protection blocks
+    # forever with nothing to re-run; with enforce_admins that blocks
+    # everyone. That is the exact failure PR #455 closed, and leaving this
+    # job hosted while the lanes moved to the mesh would have reopened it
+    # through a different door. It emits a check run and does no work, so
+    # any eshkol runner can serve it.
+    runs-on: >-
+      ${{ vars.ESHKOL_MESH_PRIMARY == 'on' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository) &&
+          fromJSON('["self-hosted", "eshkol"]') ||
+          'ubuntu-22.04' }}
     strategy:
       matrix:
         name:

--- a/.github/workflows/identity-guard.yml
+++ b/.github/workflows/identity-guard.yml
@@ -14,9 +14,49 @@ permissions:
 
 jobs:
   guard:
-    runs-on: ubuntu-latest
+    # The primary mesh is used only for trusted-branch/ref runs. A fork PR
+    # remains on a hosted runner, so unreviewed fork-controlled workflow data
+    # never executes on persistent maintainer hardware.
+    runs-on: >-
+      ${{ vars.ESHKOL_MESH_PRIMARY == 'on' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository) &&
+          fromJSON('["self-hosted", "Linux", "X64", "eshkol", "linux-mesh"]') ||
+          'ubuntu-latest' }}
+    env:
+      MESH_JOB_BUILD_DIR: ${{ github.workspace }}/.mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-guard
     timeout-minutes: 5
     steps:
+      - name: Toolchain preflight (primary mesh; provisioned out of band)
+        if: >-
+          vars.ESHKOL_MESH_PRIMARY == 'on' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository)
+        shell: bash
+        run: |
+          set -u
+          mkdir -p "$MESH_JOB_BUILD_DIR"
+          fail=0
+          note() {
+            echo "::error title=Primary mesh runner not provisioned::$1 See docs/platform/SELF_HOSTED_RUNNERS.md § Provisioning."
+            fail=1
+          }
+
+          llvm_config="${LLVM_CONFIG_EXECUTABLE:-}"
+          if [ -z "$llvm_config" ] || [ ! -x "$llvm_config" ]; then
+            llvm_config="/usr/lib/llvm-21/bin/llvm-config"
+          fi
+          if [ ! -x "$llvm_config" ] || [ "$("$llvm_config" --version 2>/dev/null | cut -d. -f1)" != "21" ]; then
+            note "LLVM 21 llvm-config is missing; set LLVM_CONFIG_EXECUTABLE or provision /usr/lib/llvm-21/bin/llvm-config."
+          else
+            echo "LLVM_CONFIG_EXECUTABLE=$llvm_config"
+          fi
+          command -v cmake >/dev/null 2>&1 || note "cmake is not installed."
+          command -v ninja >/dev/null 2>&1 || note "ninja is not installed."
+          command -v python3 >/dev/null 2>&1 || note "python3 is not installed."
+          command -v jq >/dev/null 2>&1 || note "jq is not installed."
+          exit "$fail"
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -51,3 +91,8 @@ jobs:
             exit 1
           fi
           echo "identity-guard: clean"
+
+      - name: Reclaim per-job build tree
+        if: always()
+        shell: bash
+        run: rm -rf "$MESH_JOB_BUILD_DIR" || true

--- a/.github/workflows/identity-guard.yml
+++ b/.github/workflows/identity-guard.yml
@@ -24,7 +24,7 @@ jobs:
           fromJSON('["self-hosted", "Linux", "X64", "eshkol", "linux-mesh"]') ||
           'ubuntu-latest' }}
     env:
-      MESH_JOB_BUILD_DIR: ${{ github.workspace }}/.mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-guard
+      MESH_JOB_BUILD_DIR: .mesh-build-${{ github.run_id }}-${{ github.run_attempt }}-guard
     timeout-minutes: 5
     steps:
       - name: Toolchain preflight (primary mesh; provisioned out of band)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -352,3 +352,25 @@ skipped (satisfying branch protection); a PR touching any non-doc file
 still runs the full matrix exactly as before. `paths-ignore` remains on
 the `push` trigger, where it only reduces CI load rather than blocking a
 merge.
+
+## CI: primary mesh execution
+
+The repository variable `ESHKOL_MESH_PRIMARY` is unset by default. When it is
+`on`, the required `guard`, `assurance-gates`, and `surface-manifest` jobs,
+`linux-x64-lite`, `linux-x64-xla`, `linux-x64-asan-ubsan`, and
+`wasm-execute-diff` run on `[self-hosted, Linux, X64, eshkol, linux-mesh]`.
+`linux-x64-cuda` runs on `[self-hosted, Linux, X64, eshkol, cuda]`.
+
+The four Linux x64 runner registrations provide up to four concurrent jobs;
+the CUDA registration provides one job at a time. Every mesh build uses a
+unique directory under the runner's workspace and removes it in an
+`always()` cleanup step. The mesh preflight only discovers provisioned
+`LLVM_CONFIG_EXECUTABLE` (falling back to `/usr/lib/llvm-21/bin/llvm-config`),
+cmake, ninja, python3, jq, and, for WASM, emcc and node. It never installs
+packages or uses sudo. A missing `emcc` is a hard failure with a provisioning
+message; provision emsdk under `~/emsdk` before enabling the variable.
+
+The `linux-arm64-*`, macOS, and Windows lanes remain hosted until their
+corresponding label variables are set. Fork pull requests remain hosted even
+when primary routing is on, and the repository Actions policy must require
+approval for all outside collaborators before self-hosted execution is enabled.

--- a/docs/platform/CI_LANES.md
+++ b/docs/platform/CI_LANES.md
@@ -60,14 +60,15 @@ for pull requests and for non-`master` branches; `master` is never cancelled.
 
 ## Self-hosted (mesh) lanes
 
-`ci-mesh.yml` adds four **advisory, non-required** lanes that run on the
-maintainer's own hardware: `mesh-linux-x64-lite`, `mesh-linux-arm64-lite`,
-`mesh-macos-arm64-lite`, and `mesh-linux-x64-cuda-exec`. The last of these is the
-only lane in the repository that runs `run_gpu_tests.sh` against a **real** CUDA
-device — lanes 5, 6 and 14 above are compile-only, because hosted runners have no
-GPU. The whole workflow is off unless the repository variable `ESHKOL_MESH_CI` is
-`on` *and* a runner carrying the `eshkol` label is online, and none of its jobs is
-(or may become) a required status check. See
+`ci-mesh.yml` retains four **advisory, non-required** lanes for compatibility:
+`mesh-linux-x64-lite`, `mesh-linux-arm64-lite`, `mesh-macos-arm64-lite`, and
+`mesh-linux-x64-cuda-exec`. It is suppressed when `ESHKOL_MESH_PRIMARY=on`, so
+the primary `ci.yml` lanes do not run twice. With primary routing enabled,
+`ci.yml` sends the Linux x64 required lanes to `[self-hosted, Linux, X64,
+eshkol, linux-mesh]` and `linux-x64-cuda` to `[self-hosted, Linux, X64, eshkol,
+cuda]`; the four x64 runners allow four concurrent jobs and the CUDA runner
+allows one. The whole advisory workflow is off unless `ESHKOL_MESH_CI` is `on`
+and a runner carrying `eshkol` is online. See
 [Self-hosted runners](SELF_HOSTED_RUNNERS.md).
 
 Other workflows: `pages.yml` (docs site), `release.yml` (release packaging),

--- a/docs/platform/SELF_HOSTED_RUNNERS.md
+++ b/docs/platform/SELF_HOSTED_RUNNERS.md
@@ -14,25 +14,17 @@ Related: [CI lanes](CI_LANES.md) · `.github/workflows/ci-mesh.yml` ·
 
 ## 1. What this buys, and what it does not
 
-Two distinct wins, worth keeping separate because they have different risk profiles.
+`ci.yml` remains the single source of required check names. With the repository
+variable `ESHKOL_MESH_PRIMARY=on`, its required Linux x64 matrix build/test
+lanes and build-free guard jobs execute on the owned mesh, while ARM64, macOS,
+and Windows remain hosted until their label variables are provisioned. With the
+variable unset (the default), the existing hosted routing is unchanged.
 
-**Capacity.** `ci.yml` runs a 14-lane matrix on GitHub-hosted runners. Moving the
-Linux and macOS *lite* lanes onto owned hardware returns those minutes to the pool
-for the lanes that genuinely need a clean disposable image (Windows SDK downloads,
-the ASan lane, the WASM diff).
-
-**Coverage that hosted runners structurally cannot provide.** The `linux-x64-cuda`,
-`linux-arm64-cuda` and `windows-x64-cuda` lanes in `ci.yml` run on hosted runners,
-and **hosted runners have no GPU**. `nvcc` compiles the kernels, `eshkol_gpu_init()`
-reports zero devices, and every GPU tensor op falls through to the CPU path without
-saying so. Those lanes are *compilation* gates. A registered GPU runner turns
-`gpu-execution-gate.yml` and `mesh-linux-x64-cuda-exec` into real *execution* gates
-— which is also how ADR-0010 gap **A13** closes: that workflow currently emits a
-`::warning` on every run saying it produced no GPU evidence, because no
-`[self-hosted, gpu]` runner has ever existed for this repo.
-
-**What it does not buy: a merge gate.** No job in `ci-mesh.yml` is, or may become,
-a required status check. See §6.
+The primary switch is explicit and fail-closed: a fork pull request is never
+selected for a self-hosted runner. A fork PR uses the hosted fallback, and the
+Actions setting requiring approval for all outside-collaborator workflows remains
+mandatory. `ci-mesh.yml` is only the legacy advisory matrix; it suppresses its
+lanes when primary routing is on so the same work is not run twice.
 
 ---
 
@@ -43,19 +35,20 @@ removed: `self-hosted`, an OS label (`Linux` / `macOS` / `Windows`), and an
 architecture label (`X64` / `ARM64` / `ARM`). Label matching is case-insensitive,
 which is why the workflows spell them lowercase.
 
-On top of those, this repository defines exactly four custom labels. Keep the set
+On top of those, this repository defines exactly five custom labels. Keep the set
 small: a label is a contract a lane relies on, and an unmet contract is a lane that
 either queues forever or lies.
 
 | label | meaning — assign it only if this is true | consumed by |
 |---|---|---|
-| `eshkol` | This runner is provisioned for **this repository's** build: LLVM 21, cmake, ninja, python3, and (Linux) `ld.lld`. Every mesh lane requires it. | `ci-mesh.yml` (all lanes), `mesh-preflight`'s online-runner probe |
+| `eshkol` | This runner is provisioned for **this repository's** build: LLVM 21, cmake, ninja, python3, jq, and (Linux) `ld.lld`. Every mesh lane requires it. | `ci.yml`, `ci-mesh.yml`, `mesh-preflight` |
+| `linux-mesh` | Linux x64 primary-build capacity. It is present on the four primary x64 runners. | `ci.yml` Linux x64, WASM, guard, assurance, and surface lanes |
 | `gpu` | The host has a **real, addressable GPU device** — not merely a GPU toolchain. `nvidia-smi` lists a device, or the host is Apple Silicon with a working Metal device. | `gpu-execution-gate.yml` (`runs-on: [self-hosted, gpu]`) |
-| `cuda` | The host has a CUDA device *and* `nvcc` on `PATH`. Implies `gpu`; assign both. | `mesh-linux-x64-cuda-exec` |
+| `cuda` | The host has a CUDA device *and* `nvcc` on `PATH`; the primary CUDA lane also verifies `nvidia-smi`. | `ci.yml` `linux-x64-cuda`, `mesh-linux-x64-cuda-exec` |
 | `metal` | Apple Silicon host with a working Metal device. Implies `gpu`; assign both. Reserved for a future Metal execution lane. | (none yet) |
 
-So a full label set looks like `--labels eshkol` for a plain build node, or
-`--labels eshkol,gpu,cuda` for the CUDA execution node.
+So a full label set looks like `--labels eshkol,linux-mesh` for a plain Linux
+x64 build node, or `--labels eshkol,cuda` for the CUDA execution node.
 
 **Do not** assign `gpu` to a host that only has the CUDA *toolkit* installed. That
 is precisely the failure the GPU execution gate exists to expose, and a mislabelled
@@ -71,12 +64,16 @@ Measured against the mesh registry (`computer_mesh/nodes.json`) on 2026-08-25 by
 SSH probe, not assumed. Full survey and the raw per-node output live with the PR
 that introduced this document.
 
-| node | OS / arch | cores / RAM / free disk | GPU | suggested labels | provisioning still needed |
+| node | OS / arch | capacity | GPU | registered labels | provisioning still needed |
 |---|---|---|---|---|---|
+| `mesh-linux-x64-01..04` | Linux x64 | 88 cores shared across four runner instances; about 450 GB free | None usable for CUDA CI | `self-hosted`, `Linux`, `X64`, `eshkol`, `linux-mesh` | LLVM 21, cmake, ninja, python3, jq, `ld.lld`; Node.js for WASM; emsdk for `emcc` |
+| `mesh-cuda-01` | Linux x64 | Shared; one runner/job at a time | CUDA 12.4 device | `self-hosted`, `Linux`, `X64`, `eshkol`, `cuda` | LLVM 21, cmake, ninja, python3, jq, `ld.lld`, CUDA toolkit/driver and `nvidia-smi` |
 
-Every other node in the registry was unreachable at survey time: the GCP
-Blackwell/RTX-Pro nodes are stopped or spot-preempted, the on-prem boxes are
-this machine. That volatility is the reason for §6.
+The four `mesh-linux-x64-*` registrations are the primary Linux x64 capacity;
+GitHub can run at most four such jobs in parallel. `mesh-cuda-01` is deliberately
+single-job capacity. Do not assume the CUDA node can satisfy the Linux x64
+`linux-mesh` label: its separate `cuda` label is what keeps ordinary builds off
+the shared GPU host.
 
 ---
 
@@ -95,7 +92,7 @@ echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -
   | sudo tee /etc/apt/sources.list.d/llvm.list
 sudo apt-get update
 sudo apt-get install -y \
-  cmake ninja-build git python3 pkg-config \
+  cmake ninja-build git python3 jq nodejs pkg-config \
   llvm-21 llvm-21-dev lld-21 \
   libreadline-dev libssl-dev libncurses-dev \
   libpcre2-dev libsqlite3-dev libpng-dev libjpeg-dev libwebp-dev
@@ -112,6 +109,22 @@ For a `cuda` node, additionally confirm **both** of these answer:
 nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader
 nvcc --version
 ```
+
+For the four `linux-mesh` nodes, provision Emscripten without `sudo` and make
+the active SDK available to the runner service account. The WASM lane fails
+loudly if `emcc` is absent; it does not install or activate an SDK in CI:
+
+```bash
+git clone https://github.com/emscripten-core/emsdk.git ~/emsdk
+cd ~/emsdk
+./emsdk install 4.0.22
+./emsdk activate 4.0.22
+echo 'source "$HOME/emsdk/emsdk_env.sh" >/dev/null' >> ~/.bashrc
+```
+
+The service environment must also contain the activated SDK's `emcc` and
+`node` on `PATH`; verify with `command -v emcc`, `emcc --version`, and
+`node --version` from the account that runs the GitHub Actions service.
 
 ### macOS
 
@@ -131,9 +144,13 @@ cmake --build build-check --parallel
 ./scripts/run_all_tests.sh
 ```
 
-If that passes by hand, the mesh lane will pass. If it does not, fix it here — a
-runner registered against a broken toolchain produces red lanes that look like code
-regressions.
+The primary Linux x64 CI configure contract is `RelWithDebInfo`, tests enabled,
+`-DESHKOL_XLA_ENABLED=OFF`, `-DESHKOL_GPU_ENABLED=OFF`, and
+`-DESHKOL_REQUIRE_GPU_BACKEND=OFF` for the lite lane. XLA and CUDA lanes retain
+their matrix-specific feature flags. CI only discovers the provisioned tools;
+it never runs `apt-get`, `sudo`, or a package manager on self-hosted runners.
+If the checks above fail by hand, fix the node before registering it: a broken
+toolchain produces red lanes that look like code regressions.
 
 ---
 
@@ -169,11 +186,17 @@ tar xzf runner.tar.gz && rm runner.tar.gz
 ./config.sh \
   --url https://github.com/tsotchke/eshkol \
   --token <REGISTRATION_TOKEN> \
-  --labels eshkol,gpu,cuda \
+  --name mesh-linux-x64-01 \
+  --labels eshkol,linux-mesh \
   --work _work \
   --unattended \
   --replace
 ```
+
+Use names `mesh-linux-x64-01` through `mesh-linux-x64-04` with
+`--labels eshkol,linux-mesh`. Register the CUDA host as `mesh-cuda-01` with
+`--labels eshkol,cuda`; the automatic `self-hosted`, `Linux`, and `X64` labels
+complete the exact `runs-on` selector used by `linux-x64-cuda`.
 
 - `--name` — use the mesh node name. It is how you will tell runners apart in the
   Settings UI and in `gh api .../actions/runners`.
@@ -207,9 +230,10 @@ answer yes.
 
 > `nix-shell nix/jetson/shell.nix` or it will have no CUDA device. Either wrap the
 
-### 5.4 Turn the mesh lanes on
+### 5.4 Turn primary routing on
 
-`ci-mesh.yml` ships **off**. After at least one runner is online:
+After the four Linux x64 runners and the CUDA runner are online and their
+preflight commands pass, the maintainer flips the primary executor with:
 
 Before enabling lanes, seed the shared FetchContent source cache on each Linux
 runner with `scripts/mesh/seed_fetchcontent_cache.sh`. The script populates
@@ -219,41 +243,61 @@ runner with `scripts/mesh/seed_fetchcontent_cache.sh`. The script populates
 the marker is absent, CI retains its normal network-fetch fallback.
 
 ```bash
-gh variable set ESHKOL_MESH_CI --repo tsotchke/eshkol --body on
+gh variable set ESHKOL_MESH_PRIMARY --repo tsotchke/eshkol --body on
+gh variable set ESHKOL_MESH_CI --repo tsotchke/eshkol --body off
 ```
 
-`gpu-execution-gate.yml` needs no variable — it dispatches to `[self-hosted, gpu]`
-as soon as such a runner exists.
+The second command explicitly disables the old advisory switch. It is safe if
+that variable is already unset. To return to hosted routing:
+
+```bash
+gh variable set ESHKOL_MESH_PRIMARY --repo tsotchke/eshkol --body off
+```
+
+Future platform flips use JSON label variables. Linux ARM64 takes one full
+label array; macOS and Windows take an object with `arm64` and `x64` arrays:
+
+```bash
+gh variable set ESHKOL_MESH_ARM64_LABELS --repo tsotchke/eshkol --body '["self-hosted","Linux","ARM64","eshkol","linux-arm64-mesh"]'
+gh variable set ESHKOL_MESH_MACOS_LABELS --repo tsotchke/eshkol --body '{"arm64":["self-hosted","macOS","ARM64","eshkol","macos-mesh"],"x64":["self-hosted","macOS","X64","eshkol","macos-mesh"]}'
+gh variable set ESHKOL_MESH_WINDOWS_LABELS --repo tsotchke/eshkol --body '{"arm64":["self-hosted","Windows","ARM64","eshkol","windows-mesh"],"x64":["self-hosted","Windows","X64","eshkol","windows-mesh"]}'
+```
+
+Those variables are ignored unless `ESHKOL_MESH_PRIMARY=on`. Each value must
+name labels actually present on a runner; malformed JSON fails runner
+selection rather than silently using a different platform.
 
 ---
 
-## 6. What must NOT change
+## 6. Primary routing and required contexts
 
-**No job in `ci-mesh.yml` may be added to branch protection's required contexts.**
+The 16 required check names do not change and are not renamed by the routing
+switch:
 
-The required set is, and stays: `guard`, `linux-x64-xla`, `linux-arm64-xla`,
-`linux-x64-cuda`, `linux-arm64-cuda`, `linux-x64-asan-ubsan`, `wasm-execute-diff`,
-`windows-arm64-xla`, `windows-x64-cuda` — all hosted.
+`guard`, `assurance-gates`, `surface-manifest`, `linux-x64-xla`,
+`linux-arm64-xla`, `linux-x64-cuda`, `linux-arm64-cuda`,
+`linux-x64-asan-ubsan`, `wasm-execute-diff`, `windows-arm64-xla`,
+`windows-x64-cuda`, `windows-arm64-lite`, `macos-arm64-xla`, `macos-x64-xla`,
+`macos-arm64-lite`, `macos-x64-lite`.
 
-The reason is mechanical, not conservative. Branch protection has no timeout: a
-required context that never reports leaves the PR blocked forever, and the only
-recovery is an admin editing the protection rule. This repository has already paid
-that price once, on PR #444. A required context whose runner is one physical machine
-inherits that machine's availability — and §3 measured this fleet directly: most of
-it is off at any given moment, and every datacenter-GPU node in it is a preemptible
-spot instance.
+With `ESHKOL_MESH_PRIMARY=on`, the routing table is:
 
-This is also why the mesh lanes live in their own workflow rather than as a
-"prefer self-hosted, fall back to hosted" matrix inside `ci.yml`. **That fallback
-does not exist in GitHub Actions.** `runs-on` is resolved at schedule time; a job
-whose labels match no online runner does not fail over to a hosted runner, it
-queues. Making a required lane's `runs-on` depend on fleet state would convert every
-mesh outage into a permanently pending required check. Separate job names in a
-separate file make that mistake structurally impossible.
+| context or lane | `runs-on` labels |
+|---|---|
+| `guard` | `self-hosted`, `Linux`, `X64`, `eshkol`, `linux-mesh` |
+| `assurance-gates`, `surface-manifest` | `self-hosted`, `Linux`, `X64`, `eshkol`, `linux-mesh` |
+| `linux-x64-lite`, `linux-x64-xla`, `linux-x64-asan-ubsan` | `self-hosted`, `Linux`, `X64`, `eshkol`, `linux-mesh` |
+| `linux-x64-cuda` | `self-hosted`, `Linux`, `X64`, `eshkol`, `cuda` |
+| `wasm-execute-diff` | `self-hosted`, `Linux`, `X64`, `eshkol`, `linux-mesh` |
+| `linux-arm64-*` | hosted until `ESHKOL_MESH_ARM64_LABELS` is set |
+| macOS lanes | hosted until `ESHKOL_MESH_MACOS_LABELS` is set |
+| Windows lanes | hosted until `ESHKOL_MESH_WINDOWS_LABELS` is set |
 
-Promoting a mesh lane to required is a deliberate maintainer decision that requires,
-at minimum: the runner demonstrably online across a sustained period, and a plan for
-what happens to open PRs when it is not.
+The four Linux x64 runner registrations permit up to four concurrent jobs;
+`unix-matrix` advertises `max-parallel: 4`. The CUDA registration is one
+runner/job at a time. GitHub's runner matching is not failover: if a selected
+label set has no online runner, the required context queues. Keep the primary
+variable off until the selected fleet is online and provisioned.
 
 ---
 
@@ -276,7 +320,19 @@ Controls, in order of load-bearing-ness:
 2. **Require approval for all outside collaborators.** Settings → Actions → General →
    *Fork pull request workflows from outside collaborators*. GitHub's default is
    "require approval for first-time contributors", which still lets a contributor's
-   *second* PR run without review. Set it to **all outside collaborators**.
+   *second* PR run without review. Set it to **all outside collaborators**. This
+   repository setting must be verified by an owner before enabling primary routing;
+   do not change it from a pull request. The workflow-permission API currently
+   reports `default_workflow_permissions` as `read`:
+
+   ```bash
+   gh api repos/tsotchke/eshkol/actions/permissions/workflow
+   # {"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}
+   ```
+
+   That API result does not prove the fork-approval policy. The required policy is
+   still **Require approval for all outside collaborators**, plus the workflow's
+   same-repository runner-selection guard.
 3. **Never put secrets on a mesh lane.** None of the mesh lanes consume repository
    secrets, and none should; a persistent filesystem plus a long-lived machine is a
    poor place for them.

--- a/scripts/lib/test_isolation.sh
+++ b/scripts/lib/test_isolation.sh
@@ -274,7 +274,7 @@ eshkol_test_reset_bin() {
 #       directory.  Point the suite's ESHKOL_RUN at it and a concurrent rebuild
 #       cannot touch what is under test.  Only usable by suites that address the
 #       compiler through an absolute path variable — suites hardcoding
-#       `./$BUILD_DIR/eshkol-run` need the repo-relative build dir and must use
+#       `$BUILD_DIR/eshkol-run` need the runner-relative build dir and must use
 #       the fingerprint guard instead.
 #
 #   eshkol_test_toolchain_snapshot <build_dir> / eshkol_test_toolchain_verify

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -174,8 +174,9 @@ require_regular_executable "eshkol-run" "$BUILD_DIR/eshkol-run"
 # Pin the compiler for the duration of the run.
 #
 # This aggregator runs for tens of minutes and delegates to sub-suites whose
-# BUILD_DIR contract is repository-relative (`./$BUILD_DIR/eshkol-run`), so we
-# cannot redirect them at a private copy without changing that interface. What
+# BUILD_DIR contract is runner-relative (`$BUILD_DIR/eshkol-run` from the
+# checked-out workspace), so we cannot redirect them at a private copy without
+# changing that interface. What
 # we can do is refuse to report results gathered across a rebuild: a run that
 # straddled two relinks once reported "93% pass, 6 failures including SEGFAULT
 # in examples/autodiff.esk" — every one of which passes on a stable build. The

--- a/scripts/run_gpu_tests.sh
+++ b/scripts/run_gpu_tests.sh
@@ -195,7 +195,7 @@ run_gate_canary() {
     fi
 
     eshkol_test_reset_bin
-    if ! ./"$BUILD_DIR"/eshkol-run "$canary_path" -L./"$BUILD_DIR" -o "$ESHKOL_TEST_BIN" > /dev/null 2>&1; then
+    if ! "$ESHKOL_RUN" "$canary_path" -L"$BUILD_DIR" -o "$ESHKOL_TEST_BIN" > /dev/null 2>&1; then
         echo -e "${RED}COMPILE FAIL${NC}"
         echo -e "${RED}  >>> the canary must compile and then fail at runtime — it did neither${NC}"
         CANARY_HARD_FAIL=1
@@ -256,6 +256,7 @@ echo ""
 # Determine which build directory to use
 # Override with: BUILD_DIR=build-cuda ./scripts/run_gpu_tests.sh
 BUILD_DIR="${BUILD_DIR:-build}"
+ESHKOL_RUN="$BUILD_DIR/eshkol-run"
 
 # Ensure build directory exists
 if [ ! -d "$BUILD_DIR" ]; then
@@ -294,7 +295,7 @@ for test_file in tests/gpu/*.esk; do
     # Clean up stale temp files before each test
     eshkol_test_reset_bin
     # Try to compile
-    if ./"$BUILD_DIR"/eshkol-run "$test_file" -L./"$BUILD_DIR" -o "$ESHKOL_TEST_BIN" > /dev/null 2>&1; then
+    if "$ESHKOL_RUN" "$test_file" -L"$BUILD_DIR" -o "$ESHKOL_TEST_BIN" > /dev/null 2>&1; then
         # Compilation succeeded, try to run
         if [ "$test_name" = "cuda_host_sync_regression_test.esk" ]; then
             runtime_cmd=(env ESHKOL_GPU_THRESHOLD=1 ESHKOL_GPU_VERBOSE=1 "$ESHKOL_TEST_BIN")

--- a/scripts/run_language_coverage.sh
+++ b/scripts/run_language_coverage.sh
@@ -44,7 +44,8 @@ ESHKOL_VM="$BUILD_DIR_PATH/eshkol-vm-standalone-test"
 QUANTUM_RUN="$QUANTUM_BUILD_DIR_PATH/eshkol-run"
 
 # The complete-suite harness delegates to older scripts whose BUILD_DIR
-# contract is repository-relative (they invoke ./$BUILD_DIR/eshkol-run).
+# contract is runner-relative (they invoke ./$BUILD_DIR/eshkol-run from the
+# checked-out workspace).
 # Accept either spelling at this boundary, but normalize an absolute path
 # beneath the repository before crossing into that legacy interface.
 case "$BUILD_DIR_PATH" in
@@ -76,7 +77,7 @@ if [ -z "$RUNTIME_TRACE_DIRS" ]; then
     # of either tree mid-run makes the coverage evidence a mixture of two
     # compilers, and a single relink was enough to manufacture a SEGFAULT
     # verdict for a test that passes on a stable build. run_all_tests.sh is
-    # invoked with a repository-relative BUILD_DIR (its interface), so the guard
+    # invoked with a runner-relative BUILD_DIR (its interface), so the guard
     # here is a start/end fingerprint of every relinkable artifact in both trees
     # rather than a redirect at a private copy.
     ESHKOL_TEST_ISOLATION_NO_TRAP=1


### PR DESCRIPTION
With the repository variable ESHKOL_MESH_PRIMARY=on, the Linux x64 contexts (xla, asan/ubsan, wasm, lite, guard, assurance-gates, surface-manifest) run on the self-hosted linux-mesh runners and linux-x64-cuda on the CUDA node; job names are unchanged so the required checks keep working. Mesh-routed jobs use a fail-loud toolchain preflight (no apt-get), per-job build directories cleaned at the end, and no sudo. Reserved variables route macOS, Windows and ARM64 lanes to the mesh once such runners are registered; hosted runners remain only for platforms the mesh lacks. Advisory mesh lanes are deduplicated against primary ones. Fork-PR approval requirements documented in SELF_HOSTED_RUNNERS.md.