### PR TITLE
fix(exceptions): a handler returning from a non-continuable raise now raises a secondary exception on every engine (SW-84)

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -4227,6 +4227,49 @@ entries:
       was never at fault in any of the three — it recorded is_char, is_inexact and the
       vector origin correctly every time. The loss was always downstream, in a
       consumer that read a subset of what the reader had written down.
+  - id: SW-84
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "c459f292d210fc980c1520e37ed84ff103374e91 + working-tree fix"
+    title: "a with-exception-handler handler that RETURNS from a non-continuable raise swallows the condition on every engine"
+    repro: >-
+      (display (guard (g (#t 'guard-fired))
+        (with-exception-handler (lambda (e) 'ignored)
+                                (lambda () (raise 'esc)))))
+    observed: >-
+      ignored, exit 0, with no diagnostic. The enclosing guard did not fire on
+      native JIT/AOT or either VM route.
+    correct: >-
+      guard-fired. R7RS 6.11 requires that if a handler returns from a
+      non-continuable raise, a secondary exception is raised in the handler's
+      dynamic environment. The secondary object's exact identity is
+      unspecified; the enclosing handler must observe the escape.
+    root_cause: >-
+      Native codegen and both VM compilers treated the handler's returned value
+      as the result of with-exception-handler. They had already removed the
+      handler before calling it, but emitted a normal merge/jump instead of
+      raising the required secondary condition.
+    fix: >-
+      Native codegen now calls eshkol_raise_secondary_exception with the
+      original condition after a returned handler; VM bytecode emits
+      OP_RAISE_SECONDARY after the handler call, and both VM dispatch paths
+      create and dispatch a diagnostic secondary condition after removing the
+      current handler. Enclosing handlers therefore receive it; a handler that
+      raises still propagates its own condition.
+    evidence: >-
+      tests/error_handling/sw84_noncontinuable_handler_test.esk is registered
+      as ctest on native JIT, native AOT -O0, native AOT -O2 and VM source;
+      tests/vm_parity/corpus/74_with_exception_handler_return.esk covers the
+      native-vm-src and native-vm-eskb parity routes. The five-axis output and
+      exit-status transcript is recorded in the task report.
+    caught_by: [guard-coverage-gate]
+    missed_by: [vm-parity, differential, error-handling-suite]
+    notes: >-
+      Copied from origin/test/guard-coverage-esh-0101 and closed here after
+      the root fix. That guard-coverage branch will merge its matching ledger
+      closure. The existing documented raise-continuable limitation remains
+      unchanged in this task.
+
   # ───────────────────────── PARITY-RATCHET ─────────────────────────
 
   - id: PR-01

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5341,6 +5341,48 @@ if(ESHKOL_BUILD_TESTS AND NOT WIN32)
     set_tests_properties(eshkol_vm_standalone_smoke PROPERTIES
         ENVIRONMENT "ESHKOL_VM_NO_DISASM=1")
 
+    # SW-84: R7RS 6.11 requires a secondary exception when a handler returns
+    # from a non-continuable raise. The enclosing guard must observe it; the
+    # old lowering returned the handler value and exited successfully. Keep
+    # native JIT/AOT and VM source execution as separate ctest axes; the VM
+    # parity corpus adds the serialized ESKB route.
+    if(TARGET eshkol-run AND
+       EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/error_handling/sw84_noncontinuable_handler_test.esk")
+        add_test(
+            NAME sw84_noncontinuable_handler_jit_smoke
+            COMMAND $<TARGET_FILE:eshkol-run> -r
+                    "${CMAKE_CURRENT_SOURCE_DIR}/tests/error_handling/sw84_noncontinuable_handler_test.esk")
+        set_tests_properties(sw84_noncontinuable_handler_jit_smoke PROPERTIES
+            TIMEOUT 180
+            PASS_REGULAR_EXPRESSION "PASS: SW-84 non-continuable handler return semantics"
+            FAIL_REGULAR_EXPRESSION "FAIL:|Unhandled exception|LLVM module verification failed|fatal signal")
+        add_test(
+            NAME sw84_noncontinuable_handler_aot_o0_smoke
+            COMMAND sh -c
+                "'$<TARGET_FILE:eshkol-run>' -O0 '${CMAKE_CURRENT_SOURCE_DIR}/tests/error_handling/sw84_noncontinuable_handler_test.esk' -o '${CMAKE_CURRENT_BINARY_DIR}/sw84_noncontinuable_handler_o0' && '${CMAKE_CURRENT_BINARY_DIR}/sw84_noncontinuable_handler_o0'")
+        set_tests_properties(sw84_noncontinuable_handler_aot_o0_smoke PROPERTIES
+            TIMEOUT 180
+            PASS_REGULAR_EXPRESSION "PASS: SW-84 non-continuable handler return semantics"
+            FAIL_REGULAR_EXPRESSION "FAIL:|Unhandled exception|LLVM module verification failed|fatal signal")
+        add_test(
+            NAME sw84_noncontinuable_handler_aot_o2_smoke
+            COMMAND sh -c
+                "'$<TARGET_FILE:eshkol-run>' -O2 '${CMAKE_CURRENT_SOURCE_DIR}/tests/error_handling/sw84_noncontinuable_handler_test.esk' -o '${CMAKE_CURRENT_BINARY_DIR}/sw84_noncontinuable_handler_o2' && '${CMAKE_CURRENT_BINARY_DIR}/sw84_noncontinuable_handler_o2'")
+        set_tests_properties(sw84_noncontinuable_handler_aot_o2_smoke PROPERTIES
+            TIMEOUT 180
+            PASS_REGULAR_EXPRESSION "PASS: SW-84 non-continuable handler return semantics"
+            FAIL_REGULAR_EXPRESSION "FAIL:|Unhandled exception|LLVM module verification failed|fatal signal")
+        add_test(
+            NAME sw84_noncontinuable_handler_vm_src_smoke
+            COMMAND sh -c
+                "cd '${CMAKE_CURRENT_SOURCE_DIR}' && '$<TARGET_FILE:eshkol-vm-standalone-test>' tests/error_handling/sw84_noncontinuable_handler_test.esk")
+        set_tests_properties(sw84_noncontinuable_handler_vm_src_smoke PROPERTIES
+            TIMEOUT 180
+            ENVIRONMENT "ESHKOL_VM_NO_DISASM=1"
+            PASS_REGULAR_EXPRESSION "PASS: SW-84 non-continuable handler return semantics"
+            FAIL_REGULAR_EXPRESSION "FAIL:|ERROR:|fatal runtime error")
+    endif()
+
     # SW-46 gate: the bytecode VM's divergence and curl are EXACT, and cost zero
     # finite-difference evaluations. Both used to compute a central difference at
     # h = 1e-7, so `curl` of a gradient field — whose curl vanishes identically —

--- a/inc/eshkol/eshkol.h
+++ b/inc/eshkol/eshkol.h
@@ -1447,6 +1447,19 @@ void eshkol_exception_set_location(eshkol_exception_t* exc, uint32_t line, uint3
  * @param exception Exception to raise.
  */
 void eshkol_raise(eshkol_exception_t* exception);
+
+/**
+ * @brief Raise the secondary exception required when a non-continuable
+ *        handler returns.
+ * @param original The original condition, used to identify the failure in
+ *        the secondary exception message.
+ *
+ * R7RS 6.11 requires a handler that returns from `raise` to cause a new
+ * exception in the handler's dynamic environment. The handler itself has
+ * already been removed from the active stack when this is called, so an
+ * enclosing handler receives the secondary exception.
+ */
+void eshkol_raise_secondary_exception(eshkol_exception_t* original);
 // R7RS error-object accessors (implemented in runtime_exceptions_hosted.cpp)
 /**
  * @brief R7RS `error-object?` predicate.

--- a/lib/backend/eshkol_compiler.c
+++ b/lib/backend/eshkol_compiler.c
@@ -66,7 +66,15 @@ typedef enum {
     OP_WIND_PUSH=61,    /* push after thunk onto wind stack */
     OP_WIND_POP=62,     /* pop from wind stack */
 
-    OP_COUNT=63
+    /* Keep the standalone/ESKB emitter's numbering aligned with vm_core.c. */
+    OP_VOID=63,
+    OP_LANGUAGE_COVERAGE=64,
+    OP_LANGUAGE_COVERAGE_CALL=65,
+    OP_GLOBAL_MARK=66,
+    /* R7RS secondary exception after a returned non-continuable handler. */
+    OP_RAISE_SECONDARY=67,
+
+    OP_COUNT=68
 } OpCode;
 
 typedef struct { uint8_t op; int32_t operand; } Instr;
@@ -1466,6 +1474,7 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
         compile_expr(c, node->children[1], 0); /* push handler closure */
         chunk_emit(c, OP_GET_EXN, 0);           /* push exn from VM register */
         chunk_emit(c, OP_CALL, 1);
+        chunk_emit(c, OP_RAISE_SECONDARY, 0);
 
         patch(c, end_patch, OP_JUMP, c->code_len);
         return;
@@ -4252,6 +4261,23 @@ static void execute_chunk(FuncChunk* chunk) {
         /* Push current exception value (set by most recent raise) */
         case OP_GET_EXN: {
             PUSH(current_exn);
+            break;
+        }
+
+        /* A returned handler is not a normal result for non-continuable
+         * raise. Re-dispatch the condition after removing this handler so an
+         * enclosing handler observes the secondary exception. */
+        case OP_RAISE_SECONDARY: {
+            if (handler_count <= 0) {
+                printf("ERROR: handler returned from non-continuable raise\n");
+                error = 1;
+                break;
+            }
+            handler_count--;
+            sp = exc_handlers[handler_count].saved_sp;
+            fp = exc_handlers[handler_count].saved_fp;
+            frame_count = exc_handlers[handler_count].saved_frame_count;
+            pc = exc_handlers[handler_count].handler_pc;
             break;
         }
 

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -23401,6 +23401,8 @@ private:
         Function* pop_handler_func = module->getFunction("eshkol_pop_exception_handler");
         Function* setjmp_func = getOrDeclareSetjmpFunc();
         Function* get_raised_func = module->getFunction("eshkol_get_raised_value");
+        Function* get_exception_func = module->getFunction("eshkol_get_current_exception");
+        Function* secondary_raise_func = module->getFunction("eshkol_raise_secondary_exception");
 
         if (!push_handler_func) {
             FunctionType* push_type = FunctionType::get(builder->getVoidTy(), {builder->getPtrTy()}, false);
@@ -23413,6 +23415,21 @@ private:
         if (!get_raised_func) {
             FunctionType* get_raised_type = FunctionType::get(builder->getVoidTy(), {builder->getPtrTy()}, false);
             get_raised_func = Function::Create(get_raised_type, Function::ExternalLinkage, "eshkol_get_raised_value", module.get());
+        }
+        if (!get_exception_func) {
+            FunctionType* get_exception_type = FunctionType::get(
+                builder->getPtrTy(), {}, false);
+            get_exception_func = Function::Create(
+                get_exception_type, Function::ExternalLinkage,
+                "eshkol_get_current_exception", module.get());
+        }
+        if (!secondary_raise_func) {
+            FunctionType* secondary_raise_type = FunctionType::get(
+                builder->getVoidTy(), {builder->getPtrTy()}, false);
+            secondary_raise_func = Function::Create(
+                secondary_raise_type, Function::ExternalLinkage,
+                "eshkol_raise_secondary_exception", module.get());
+            secondary_raise_func->setDoesNotReturn();
         }
 
         Function* current_func = builder->GetInsertBlock()->getParent();
@@ -23460,6 +23477,8 @@ private:
         // Handler block: pop handler, get raised value, call handler closure
         builder->SetInsertPoint(handler_block);
         builder->CreateCall(pop_handler_func, {});
+        Value* original_exception = builder->CreateCall(
+            get_exception_func, {}, "weh_original_exception");
 
         // Get the original raised value (R7RS-compliant)
         IRBuilder<> entry_builder(&current_func->getEntryBlock(), current_func->getEntryBlock().begin());
@@ -23476,8 +23495,8 @@ private:
 
         BasicBlock* handler_exit_block = nullptr;
         if (!handler_terminated) {
-            handler_exit_block = builder->GetInsertBlock();
-            builder->CreateBr(done_block);
+            builder->CreateCall(secondary_raise_func, {original_exception});
+            builder->CreateUnreachable();
         }
 
         // Done block: merge results with PHI

--- a/lib/backend/vm_compiler.c
+++ b/lib/backend/vm_compiler.c
@@ -1472,6 +1472,7 @@ static void compile_form_with_exception_handler(FuncChunk* c, Node* node, int ta
     compile_expr(c, node->children[1], 0); /* push handler closure */
     chunk_emit(c, OP_GET_EXN, 0);           /* push exn from VM register */
     chunk_emit(c, OP_CALL, 1);
+    chunk_emit(c, OP_RAISE_SECONDARY, 0);
 
     patch(c, end_patch, OP_JUMP, c->code_len);
     return;

--- a/lib/backend/vm_core.c
+++ b/lib/backend/vm_core.c
@@ -112,7 +112,12 @@ typedef enum {
      * control state and `set!` mutations are silently undone (SW-52). */
     OP_GLOBAL_MARK = 66,
 
-    OP_COUNT = 67
+    /* A non-continuable with-exception-handler must not accept a returned
+     * handler value. This opcode raises the R7RS secondary condition after
+     * the handler has been removed, so an enclosing handler receives it. */
+    OP_RAISE_SECONDARY = 67,
+
+    OP_COUNT = 68
 } OpCode;
 
 typedef struct { uint8_t op; int32_t operand; } Instr;

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -7234,6 +7234,45 @@ static void vm_dispatch_exception(VM* vm, Value exn) {
     }
 }
 
+/* R7RS 6.11: a handler installed by with-exception-handler is for a
+ * non-continuable raise. If that handler returns, raise a secondary condition
+ * after the original handler has been removed, leaving an enclosing handler
+ * as the only possible catcher. */
+static void vm_raise_secondary_exception(VM* vm) {
+    char original[256];
+    original[0] = '\0';
+    Value exn = vm->current_exception;
+    if (exn.type == VAL_ERROR_OBJ && is_valid_heap_ptr(vm, exn.as.ptr)) {
+        VmError* err = (VmError*)vm->heap.objects[exn.as.ptr]->opaque.ptr;
+        if (err) snprintf(original, sizeof(original), "%s", err->message);
+    } else if ((exn.type == VAL_STRING || exn.type == VAL_SYMBOL) &&
+               is_valid_heap_ptr(vm, exn.as.ptr)) {
+        VmString* str = (VmString*)vm->heap.objects[exn.as.ptr]->opaque.ptr;
+        if (str && str->data) snprintf(original, sizeof(original), "%s", str->data);
+    } else if (exn.type == VAL_INT) {
+        snprintf(original, sizeof(original), "%lld", (long long)exn.as.i);
+    } else if (exn.type == VAL_BOOL) {
+        snprintf(original, sizeof(original), "#%c", exn.as.b ? 't' : 'f');
+    } else {
+        snprintf(original, sizeof(original), "condition");
+    }
+
+    char message[320];
+    snprintf(message, sizeof(message),
+             "handler returned from non-continuable raise: %s", original);
+    VmError* err = vm_error_make(&vm->heap.regions, "error", message, NULL, 0);
+    Value secondary = NIL_VAL;
+    if (err) {
+        int32_t ptr = heap_alloc(&vm->heap);
+        if (ptr >= 0) {
+            vm->heap.objects[ptr]->type = HEAP_ERROR;
+            vm->heap.objects[ptr]->opaque.ptr = err;
+            secondary = (Value){.type = VAL_ERROR_OBJ, .as.ptr = ptr};
+        }
+    }
+    vm_dispatch_exception(vm, secondary);
+}
+
 /*
  * Raise `msg` as a catchable error condition, exactly as `(error msg)` would.
  *

--- a/lib/backend/vm_run.c
+++ b/lib/backend/vm_run.c
@@ -120,6 +120,7 @@ void vm_run(VM* vm) {
         [OP_LANGUAGE_COVERAGE] = &&lbl_LANGUAGE_COVERAGE,
         [OP_LANGUAGE_COVERAGE_CALL] = &&lbl_LANGUAGE_COVERAGE_CALL,
         [OP_GLOBAL_MARK]   = &&lbl_GLOBAL_MARK,
+        [OP_RAISE_SECONDARY] = &&lbl_RAISE_SECONDARY,
     };
 
     #define DISPATCH() do { \
@@ -558,7 +559,13 @@ void vm_run(VM* vm) {
         DISPATCH();
     }
 
-    lbl_CLOSE_UPVALUE: vm_exec_close_upvalue(vm, instr.operand); DISPATCH();
+    lbl_RAISE_SECONDARY:
+        vm_raise_secondary_exception(vm);
+        DISPATCH();
+
+    lbl_CLOSE_UPVALUE:
+        vm_exec_close_upvalue(vm, instr.operand);
+        DISPATCH();
 
     lbl_VEC_CREATE: vm_exec_vec_create(vm, instr.operand); DISPATCH();
 
@@ -1160,6 +1167,7 @@ vm_exit:
         case OP_PUSH_HANDLER: vm_exec_push_handler(vm, instr.operand); break;
         case OP_POP_HANDLER: { if (vm->n_handlers > 0) vm->n_handlers--; break; }
         case OP_GET_EXN: { vm_push(vm, vm->current_exception); break; }
+        case OP_RAISE_SECONDARY: { vm_raise_secondary_exception(vm); break; }
         case OP_PACK_REST: {
             int n_fixed = instr.operand;
             int n_args = vm->sp - vm->fp;

--- a/lib/core/runtime_exceptions_hosted.cpp
+++ b/lib/core/runtime_exceptions_hosted.cpp
@@ -838,6 +838,24 @@ extern "C" void eshkol_raise(eshkol_exception_t* exception) {
     }
 }
 
+extern "C" void eshkol_raise_secondary_exception(eshkol_exception_t* original) {
+    char message[512];
+    const char* original_message =
+        (original && original->message && original->message[0])
+            ? original->message : "unknown condition";
+    std::snprintf(message, sizeof(message),
+                  "handler returned from non-continuable raise: %s",
+                  original_message);
+    eshkol_exception_t* secondary = eshkol_make_exception_with_header(
+        ESHKOL_EXCEPTION_ERROR, message);
+    if (secondary) {
+        eshkol_raise(secondary);
+    }
+    // Allocation failure is itself fatal; do not let a failed secondary raise
+    // turn the original non-continuable raise into a normal return.
+    std::exit(1);
+}
+
 // ───────────────────────────────────────────────────────────────────────────
 // SW-57: HANDLER-FRAME STORAGE IS LIFO, SO ITS ALLOCATOR MUST BE.
 //

--- a/lib/repl/repl_jit.cpp
+++ b/lib/repl/repl_jit.cpp
@@ -1128,6 +1128,7 @@ void ReplJITContext::registerRuntimeSymbols() {
 
     // ===== EXCEPTION HANDLING =====
     ADD_SYMBOL(eshkol_raise);
+    ADD_SYMBOL(eshkol_raise_secondary_exception);
     ADD_SYMBOL(eshkol_make_exception);
     ADD_SYMBOL(eshkol_make_exception_with_header);
     ADD_SYMBOL(eshkol_push_exception_handler);

--- a/scripts/run_error_handling_tests.sh
+++ b/scripts/run_error_handling_tests.sh
@@ -71,6 +71,15 @@ fi
 echo "Found $TEST_COUNT test file(s)"
 echo ""
 
+# An expected-fatal fixture is a deliberate negative control. The marker lives
+# beside the source so the fixture declares its contract and the runner does
+# not need a filename-specific exception. Such a fixture must compile, exit
+# nonzero at runtime, report the required diagnostic, and stop before its
+# MUST-NOT-PRINT sentinel. Any missing part is a real suite failure.
+is_expected_fatal_test() {
+    grep -q '^; EXPECTED-FATAL:' "$1"
+}
+
 # Run each .esk test
 for test_file in "$TEST_DIR"/*.esk; do
     if [ ! -f "$test_file" ]; then
@@ -85,7 +94,27 @@ for test_file in "$TEST_DIR"/*.esk; do
     # Try to compile
     if ./$BUILD_DIR/eshkol-run "$test_file" -L./$BUILD_DIR -o "$ESHKOL_TEST_BIN" > "$ESHKOL_TEST_COMPILE_LOG" 2>&1; then
         # Compilation succeeded, try to run
-        if "$ESHKOL_TEST_BIN" > "$ESHKOL_TEST_OUT" 2>&1; then
+        if is_expected_fatal_test "$test_file"; then
+            if "$ESHKOL_TEST_BIN" > "$ESHKOL_TEST_OUT" 2>&1; then
+                echo -e "${RED}EXPECTED FATAL MISMATCH (exit 0)${NC}"
+                FAILED_TESTS+=("$test_name")
+                ((FAIL++)) || true
+            else
+                exit_code=$?
+                if ! grep -Fq "handler returned from non-continuable raise" "$ESHKOL_TEST_OUT"; then
+                    echo -e "${RED}EXPECTED FATAL MISMATCH (missing secondary diagnostic)${NC}"
+                    FAILED_TESTS+=("$test_name")
+                    ((FAIL++)) || true
+                elif grep -Fq "MUST-NOT-PRINT" "$ESHKOL_TEST_OUT"; then
+                    echo -e "${RED}EXPECTED FATAL MISMATCH (continued after fatal form)${NC}"
+                    FAILED_TESTS+=("$test_name")
+                    ((FAIL++)) || true
+                else
+                    echo -e "${GREEN}EXPECTED FATAL PASS (exit $exit_code)${NC}"
+                    ((PASS++)) || true
+                fi
+            fi
+        elif "$ESHKOL_TEST_BIN" > "$ESHKOL_TEST_OUT" 2>&1; then
             # A failure marker anywhere in the output fails the test — the old
             # `^FAIL`-anchored match never saw the indented `  <case>: FAIL`
             # form that most test programs actually print.

--- a/tests/ad/tape_release_escape_test.esk
+++ b/tests/ad/tape_release_escape_test.esk
@@ -1,0 +1,24 @@
+;; SW-93 / audit P1 counterexample: tape release must not rewind user-visible
+;; allocations made by the differentiated function.
+(define escaped #f)
+(define (f v)
+  (set! escaped (vector 111.0 222.0))
+  (* (vector-ref v 0) (vector-ref v 0)))
+
+(define g (gradient f (vector 3.0)))
+(if (= (vector-ref g 0) 6.0)
+    (display "  ok   gradient value survives tape release\n")
+    (begin (display "FAIL: gradient value\n") (exit 1)))
+;; Force the parent arena to reuse the released tape interval. The escaped
+;; vector must remain unchanged even when subsequent user allocations create
+;; allocator pressure.
+(define pressure #f)
+(let loop ((i 0))
+  (if (< i 2000)
+      (begin (set! pressure (vector i i)) (loop (+ i 1)))
+      #f))
+(if (and (= (vector-ref escaped 0) 111.0)
+         (= (vector-ref escaped 1) 222.0))
+    (display "  ok   escaped user allocation survives tape release\n")
+    (begin (display "FAIL: escaped user allocation was reclaimed\n") (exit 1)))
+(display "PASS: tape release preserves escaped user values\n")

--- a/tests/core/ad_tape_escape_test.cpp
+++ b/tests/core/ad_tape_escape_test.cpp
@@ -1,0 +1,32 @@
+#include "../../lib/core/arena_memory.h"
+
+#include <cstdint>
+#include <cstdio>
+
+int main() {
+    arena_t* arena = get_global_arena();
+    if (!arena) return 1;
+    __repl_shared_arena.store(arena);
+
+    ad_tape_t* tape = arena_allocate_tape(arena, 4);
+    if (!tape) return 1;
+    uint64_t* escaped = (uint64_t*)arena_allocate_aligned(arena, 2 * sizeof(uint64_t), 8);
+    if (!escaped) return 1;
+    escaped[0] = 111;
+    escaped[1] = 222;
+
+    arena_tape_release(tape);
+    for (int i = 0; i < 32; ++i) {
+        uint64_t* pressure = (uint64_t*)arena_allocate_aligned(arena, 2 * sizeof(uint64_t), 8);
+        if (!pressure) return 1;
+        pressure[0] = 9000 + (uint64_t)i;
+        pressure[1] = 9001 + (uint64_t)i;
+    }
+    if (escaped[0] != 111 || escaped[1] != 222) {
+        std::fprintf(stderr, "ad_tape_escape_test: FAIL: escaped allocation was reclaimed\n");
+        return 1;
+    }
+
+    std::printf("ad_tape_escape_test: PASS: escaped allocation survives tape release\n");
+    return 0;
+}

--- a/tests/error_handling/exception_test.esk
+++ b/tests/error_handling/exception_test.esk
@@ -3,11 +3,13 @@
 
 (display "=== Exception Handling Tests ===") (newline)
 
-;; Test 1: with-exception-handler + raise (handler receives raised value)
+;; Test 1: with-exception-handler receives a non-continuable raise and
+;; re-raises it; the enclosing guard performs the legal recovery.
 (display "Test 1 - basic raise/handler: ")
-(display (with-exception-handler
-  (lambda (err) 42)
-  (lambda () (raise "error!"))))
+(display (guard (err (#t 42))
+  (with-exception-handler
+    (lambda (err) (raise err))
+    (lambda () (raise "error!")))))
 (newline)
 
 ;; Test 2: guard expression (R7RS: exn bound to raised value)
@@ -23,14 +25,12 @@
   (lambda () (+ 10 20))))
 (newline)
 
-;; Test 4: Nested exception handlers
+;; Test 4: A handler-raised condition reaches the enclosing guard.
 (display "Test 4 - nested: ")
-(display (with-exception-handler
-  (lambda (err) (+ err 1000))
-  (lambda ()
-    (with-exception-handler
-      (lambda (err) (raise (+ err 100)))
-      (lambda () (raise 5))))))
+(display (guard (err (#t (+ err 1000)))
+  (with-exception-handler
+    (lambda (err) (raise (+ err 100)))
+    (lambda () (raise 5)))))
 (newline)
 
 (display "=== Exception Tests Complete ===") (newline)

--- a/tests/error_handling/sw84_noncontinuable_handler_test.esk
+++ b/tests/error_handling/sw84_noncontinuable_handler_test.esk
@@ -1,0 +1,30 @@
+; SW-84: returning from a non-continuable raise must raise a secondary
+; exception in the handler's dynamic environment. The checks below distinguish
+; recovery by an enclosing handler from the old silent return.
+
+(define direct
+  (guard (g (#t 'guard-fired))
+    (with-exception-handler
+      (lambda (e) 'ignored)
+      (lambda () (raise 'original)))))
+
+(define nested
+  (guard (g (#t 'nested-outer))
+    (with-exception-handler
+      (lambda (outer) 'outer-ignored)
+      (lambda ()
+        (with-exception-handler
+          (lambda (inner) 'inner-ignored)
+          (lambda () (raise 'original)))))))
+
+(define handler-raises
+  (guard (g (#t 'handler-raised))
+    (with-exception-handler
+      (lambda (e) (raise 'from-handler))
+      (lambda () (raise 'original)))))
+
+(if (and (eq? direct 'guard-fired)
+         (eq? nested 'nested-outer)
+         (eq? handler-raises 'handler-raised))
+    (display "PASS: SW-84 non-continuable handler return semantics\n")
+    (display "FAIL: SW-84 non-continuable handler return semantics\n"))

--- a/tests/error_handling/sw84_secondary_exception_unhandled.esk
+++ b/tests/error_handling/sw84_secondary_exception_unhandled.esk
@@ -1,0 +1,6 @@
+; SW-84 negative control: a returned non-continuable handler with no enclosing
+; handler must raise a visible secondary exception and stop before this marker.
+(with-exception-handler
+  (lambda (e) 'ignored)
+  (lambda () (raise 'original-condition)))
+(display "MUST-NOT-PRINT\n")

--- a/tests/error_handling/sw84_secondary_exception_unhandled.esk
+++ b/tests/error_handling/sw84_secondary_exception_unhandled.esk
@@ -1,5 +1,6 @@
 ; SW-84 negative control: a returned non-continuable handler with no enclosing
 ; handler must raise a visible secondary exception and stop before this marker.
+; EXPECTED-FATAL: handler-return-secondary-exception
 (with-exception-handler
   (lambda (e) 'ignored)
   (lambda () (raise 'original-condition)))

--- a/tests/vm_parity/corpus/74_with_exception_handler_return.esk
+++ b/tests/vm_parity/corpus/74_with_exception_handler_return.esk
@@ -1,0 +1,18 @@
+; SW-84: golden semantic result is the enclosing guard's value. This case is
+; also in found/ as the minimal reproducer; the VM parity runner exercises the
+; source and ESKB routes against native.
+(display
+  (guard (g (#t 'guard-fired))
+    (with-exception-handler (lambda (e) 'ignored)
+                            (lambda () (raise 'original)))))
+(newline)
+
+(display
+  (guard (g (#t 'nested-outer))
+    (with-exception-handler
+      (lambda (outer) 'outer-ignored)
+      (lambda ()
+        (with-exception-handler
+          (lambda (inner) 'inner-ignored)
+          (lambda () (raise 'original)))))))
+(newline)

--- a/tests/vm_parity/found/weh_handler_return_swallows_condition.esk
+++ b/tests/vm_parity/found/weh_handler_return_swallows_condition.esk
@@ -1,0 +1,8 @@
+; FOUND by SW-84. R7RS 6.11 requires a secondary exception when this handler
+; returns from a non-continuable raise; before the fix the output was ignored
+; and the process exited 0 on native JIT/AOT and both VM routes.
+(display
+  (guard (g (#t 'guard-fired))
+    (with-exception-handler (lambda (e) 'ignored)
+                            (lambda () (raise 'original)))))
+(newline)

--- a/tests/vm_parity/resolved/README.md
+++ b/tests/vm_parity/resolved/README.md
@@ -29,3 +29,4 @@ The reclassified set is:
 - `tensor_ref_component_oob_native.esk`
 - `tensor_set_oob_silent_native.esk`
 - `write_does_not_quote.esk`
+- `weh_handler_return_swallows_condition.esk`

--- a/tests/vm_parity/resolved/weh_handler_return_swallows_condition.esk
+++ b/tests/vm_parity/resolved/weh_handler_return_swallows_condition.esk
@@ -1,6 +1,7 @@
-; FOUND by SW-84. R7RS 6.11 requires a secondary exception when this handler
+; FILED: SW-84. R7RS 6.11 requires a secondary exception when this handler
 ; returns from a non-continuable raise; before the fix the output was ignored
 ; and the process exited 0 on native JIT/AOT and both VM routes.
+; Reclassified as resolved after the native and VM routes agree on guard-fired.
 (display
   (guard (g (#t 'guard-fired))
     (with-exception-handler (lambda (e) 'ignored)


### PR DESCRIPTION
R7RS 6.11: when a with-exception-handler handler returns from a non-continuable raise, a secondary exception is raised in the handler's dynamic environment. Native codegen, the VM source path and the ESKB path (new OP_RAISE_SECONDARY) all do this now, with the original condition's message in the secondary diagnostic; raise-continuable is unchanged. Tests: nested handlers, handler-raises-inside-handler, VM parity corpus and found cases. Ledger SW-84 closed with five-axis evidence.