### PR TITLE
ci(mesh): shared FetchContent source cache for self-hosted builds

### DIFF
--- a/.github/workflows/ci-mesh.yml
+++ b/.github/workflows/ci-mesh.yml
@@ -304,13 +304,23 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
+          fetchcontent_args=()
+          fetchcontent_cache="$HOME/lanes/_deps"
+          if [[ -f "$fetchcontent_cache/.eshkol-fetchcontent-cache-ready" ]]; then
+            echo "Using shared FetchContent cache: $fetchcontent_cache"
+            fetchcontent_args+=("-DFETCHCONTENT_BASE_DIR=$fetchcontent_cache")
+            fetchcontent_args+=("-DFETCHCONTENT_FULLY_DISCONNECTED=ON")
+          else
+            echo "Shared FetchContent cache is not seeded; retaining network fallback"
+          fi
           cmake -S . -B "${{ matrix.build_dir }}" -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DESHKOL_REQUIRED_LLVM_MAJOR="${LLVM_MAJOR}" \
             -DLLVM_CONFIG_EXECUTABLE="$LLVM_CONFIG" \
             -DESHKOL_XLA_ENABLED=${{ matrix.xla_enabled }} \
             -DESHKOL_GPU_ENABLED=${{ matrix.gpu_enabled }} \
-            -DESHKOL_REQUIRE_GPU_BACKEND=${{ matrix.gpu_enabled }}
+            -DESHKOL_REQUIRE_GPU_BACKEND=${{ matrix.gpu_enabled }} \
+            "${fetchcontent_args[@]}"
 
       # Same guard ci.yml applies to its CUDA lanes: reject a build graph that
       # quietly picked up gpu_memory_stub.cpp instead of the real kernels.

--- a/docs/platform/BUILD_NOTES.md
+++ b/docs/platform/BUILD_NOTES.md
@@ -13,6 +13,24 @@ cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
 ```
 
+## Reliable FetchContent builds on the mesh
+
+Self-hosted Linux runners share a seeded source cache at
+`$HOME/lanes/_deps`. Seed it once with
+`scripts/mesh/seed_fetchcontent_cache.sh`, then configure lanes with:
+
+```sh
+cmake -S . -B build -G Ninja \
+  -DFETCHCONTENT_BASE_DIR="$HOME/lanes/_deps" \
+  -DFETCHCONTENT_FULLY_DISCONNECTED=ON
+```
+
+`FETCHCONTENT_BASE_DIR` makes the pinned dependency sources and their
+FetchContent sub-builds reusable across lane build directories. The fully
+disconnected flag makes a seeded build fail immediately if the cache is
+incomplete instead of stalling on a network fetch. If the cache marker is
+absent, mesh CI omits both flags and falls back to the normal network path.
+
 Useful targets: `eshkol-run` (compiler/JIT driver), `eshkol-repl`,
 `eshkol-vm-standalone`, and `stdlib` (precompiled standard library object).
 

--- a/docs/platform/SELF_HOSTED_RUNNERS.md
+++ b/docs/platform/SELF_HOSTED_RUNNERS.md
@@ -211,6 +211,13 @@ answer yes.
 
 `ci-mesh.yml` ships **off**. After at least one runner is online:
 
+Before enabling lanes, seed the shared FetchContent source cache on each Linux
+runner with `scripts/mesh/seed_fetchcontent_cache.sh`. The script populates
+`$HOME/lanes/_deps`; subsequent lane configurations use
+`-DFETCHCONTENT_BASE_DIR="$HOME/lanes/_deps"` and
+`-DFETCHCONTENT_FULLY_DISCONNECTED=ON` when the cache marker is present. If
+the marker is absent, CI retains its normal network-fetch fallback.
+
 ```bash
 gh variable set ESHKOL_MESH_CI --repo tsotchke/eshkol --body on
 ```

--- a/scripts/mesh/seed_fetchcontent_cache.sh
+++ b/scripts/mesh/seed_fetchcontent_cache.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Seed the shared FetchContent source tree used by self-hosted Linux runners.
+# Run this from a checked-out Eshkol revision, preferably origin/master.
+set -euo pipefail
+
+source_dir="${ESHKOL_SOURCE_DIR:-$PWD}"
+cache_dir="${FETCHCONTENT_CACHE_DIR:-$HOME/lanes/_deps}"
+build_dir="${FETCHCONTENT_SEED_BUILD_DIR:-$PWD/build-fetchcontent-cache}"
+marker="$cache_dir/.eshkol-fetchcontent-cache-ready"
+
+if [[ ! -f "$source_dir/CMakeLists.txt" ]]; then
+  echo "error: source directory does not contain CMakeLists.txt: $source_dir" >&2
+  exit 1
+fi
+
+mkdir -p "$cache_dir"
+cmake_args=(
+  -S "$source_dir"
+  -B "$build_dir"
+  -G Ninja
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo
+  -DFETCHCONTENT_BASE_DIR="$cache_dir"
+  -DESHKOL_REQUIRED_LLVM_MAJOR=21
+  -DLLVM_CONFIG_EXECUTABLE=/usr/lib/llvm-21/bin/llvm-config
+  -DESHKOL_XLA_ENABLED=OFF
+  -DESHKOL_GPU_ENABLED=OFF
+  -DESHKOL_REQUIRE_GPU_BACKEND=OFF
+  -DESHKOL_BUILD_TESTS=ON
+  -DESHKOL_BUILD_AGENT_FFI=ON
+  -DESHKOL_QUANTUM_ENABLED=ON
+)
+
+if [[ -f "$marker" ]]; then
+  cmake_args+=("-DFETCHCONTENT_FULLY_DISCONNECTED=ON")
+  echo "Revalidating existing FetchContent cache: $cache_dir"
+else
+  echo "Seeding FetchContent cache: $cache_dir"
+fi
+
+cmake "${cmake_args[@]}"
+touch "$marker"
+echo "FetchContent cache ready: $cache_dir"


### PR DESCRIPTION
Adds scripts/mesh/seed_fetchcontent_cache.sh (idempotent) that pre-populates a shared FetchContent source cache on a build node, and points the mesh CI lanes at it via FETCHCONTENT_BASE_DIR with a network fallback when the cache is absent; documents the offline/reliable-build recipe (FETCHCONTENT_BASE_DIR + FETCHCONTENT_FULLY_DISCONNECTED) in SELF_HOSTED_RUNNERS.md and BUILD_NOTES.md. Verified: a fresh configure against the seeded cache succeeds fully disconnected.