### PR TITLE
feat(gpu): WebGPU backend for the WASM target inside the ordinary GPU dispatch (with explicit CPU fallback and refusal)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1363,6 +1363,14 @@ jobs:
           set -euxo pipefail
           python3 scripts/check_wasm_imports.py --build-dir "$BUILD_DIR"
 
+      # Browser-independent WebGPU glue contracts belong in the ordinary
+      # WASM/lite lane: the no-GPU path must refuse GPU dispatch and still
+      # produce the CPU reference result.
+      - name: WebGPU regression contracts (CPU/lite path)
+        if: matrix.xla_enabled == 'OFF' && matrix.gpu_enabled == 'OFF' && matrix.build_dir == 'build'
+        shell: bash
+        run: node tests/webgpu/webgpu_regressions_test.mjs
+
       # Guards the stdlib dead-strip on the --wasm path (issue #240 follow-up):
       # a stdlib-using program compiled WITHOUT --no-stdlib must dead-strip the
       # unused stdlib and stay small + instantiable, rather than pinning the

--- a/.github/workflows/gpu-execution-gate.yml
+++ b/.github/workflows/gpu-execution-gate.yml
@@ -99,6 +99,18 @@ jobs:
           fi
           exit "$rc"
 
+      - name: Run browser WebGPU dispatch regressions
+        shell: bash
+        run: |
+          set +e
+          node scripts/lib/webgpu_diff_runner.mjs --regressions
+          rc=$?
+          if [ "$rc" -eq 77 ]; then
+            echo 'webgpu_diff_runner: SKIP - browser WebGPU regression evidence is unavailable on this runner'
+            exit 0
+          fi
+          exit "$rc"
+
       - name: Upload gate logs
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/gpu-execution-gate.yml
+++ b/.github/workflows/gpu-execution-gate.yml
@@ -52,6 +52,10 @@ on:
       - 'lib/backend/gpu/**'
       - 'lib/backend/vm_gpu_dispatch.h'
       - 'tests/gpu/gpu_correctness_gate.*'
+      - 'web/**'
+      - 'site/static/eshkol-webgpu.js'
+      - 'site/static/eshkol-runtime.js'
+      - 'scripts/lib/webgpu_diff_runner.mjs'
       - '.github/workflows/gpu-execution-gate.yml'
 
 concurrency:
@@ -78,8 +82,22 @@ jobs:
           # Fresh build every run — correctness is the point, not build
           # caching. Self-hosted runners can set REUSE_BUILDS=1 in their
           # own environment if they persist build-gpu-gate*/ between runs.
-          GPU_GATE_TOL: '1e-4'
+          GPU_GATE_TOL: '1e-9'
         run: ./tests/gpu/gpu_correctness_gate.sh
+
+      - name: Run browser WebGPU differential gate
+        shell: bash
+        env:
+          GPU_GATE_TOL: '1e-9'
+        run: |
+          set +e
+          node scripts/lib/webgpu_diff_runner.mjs
+          rc=$?
+          if [ "$rc" -eq 77 ]; then
+            echo 'webgpu_diff_runner: SKIP - browser WebGPU evidence is unavailable on this runner'
+            exit 0
+          fi
+          exit "$rc"
 
       - name: Upload gate logs
         if: always()

--- a/.github/workflows/gpu-execution-gate.yml
+++ b/.github/workflows/gpu-execution-gate.yml
@@ -56,6 +56,7 @@ on:
       - 'site/static/eshkol-webgpu.js'
       - 'site/static/eshkol-runtime.js'
       - 'scripts/lib/webgpu_diff_runner.mjs'
+      - 'tests/webgpu/webgpu_live_test.mjs'
       - '.github/workflows/gpu-execution-gate.yml'
 
 concurrency:
@@ -98,6 +99,10 @@ jobs:
             exit 0
           fi
           exit "$rc"
+
+      - name: Run live WebGPU Chrome contracts
+        shell: bash
+        run: node tests/webgpu/webgpu_live_test.mjs
 
       - name: Run browser WebGPU dispatch regressions
         shell: bash

--- a/.icc/architecture-model.yaml
+++ b/.icc/architecture-model.yaml
@@ -142,6 +142,30 @@ components:
     entry_points:
       - {path: scripts/language_coverage.py, symbol: main}
 
+  - id: gpu-path
+    role: backend
+    description: >
+      Ordinary GPU dispatch seam shared by generated tensor code, native Metal
+      and CUDA backends, and the Emscripten WebGPU backend. Browser WGSL uses
+      explicit f32/df32 kernels and refuses precision or operations it cannot
+      certify at the GPU correctness gate tolerance.
+    modules:
+      - inc/eshkol/backend/gpu/gpu_memory.h
+      - lib/backend/gpu/gpu_memory.mm
+      - lib/backend/gpu/gpu_memory_cuda.cpp
+      - lib/backend/gpu/gpu_memory_stub.cpp
+      - lib/backend/gpu/gpu_memory_webgpu.cpp
+      - lib/backend/gpu/wgsl/double_float.wgsl
+      - lib/backend/gpu/wgsl/matmul_f32.wgsl
+      - lib/backend/gpu/wgsl/matmul_df32.wgsl
+      - lib/backend/gpu/wgsl/elementwise_f32.wgsl
+      - lib/backend/gpu/wgsl/elementwise_df32.wgsl
+      - lib/backend/gpu/wgsl/reduce_df32.wgsl
+      - web/eshkol-webgpu.js
+      - scripts/lib/webgpu_diff_runner.mjs
+    entry_points:
+      - {path: lib/backend/gpu/gpu_memory_webgpu.cpp, symbol: eshkol_matmul_dispatch}
+
   - id: wasm-path
     role: backend
     description: >
@@ -212,6 +236,18 @@ dataflows:
       JS glue stub in BOTH glue files (site/static/eshkol-runtime.js and
       web/eshkol-repl.js); a stub added to one but not the other is the drift
       that took the live site down.
+
+  - id: gpu_dispatch_seam
+    producer: llvm-codegen
+    consumer: gpu-path
+    produces: [gpu_dispatch_call]
+    consumes: [gpu_dispatch_call]
+    key_space: {kind: c_symbol, identifier: "eshkol_matmul_dispatch / eshkol_gpu_*"}
+    description: >
+      Generated tensor operations enter the same GPU dispatch symbols on every
+      target. WebGPU is selected by the target backend, not by a browser-only
+      codegen path; an unavailable adapter or uncertified precision falls back
+      explicitly to CPU.
 
 # --------------------------------------------------------------------------
 # CAPABILITIES — feature -> entry points -> arming -> dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1514,7 +1514,9 @@ if(ESHKOL_GPU_ENABLED)
         # web/eshkol-webgpu.js through EM_ASYNC_JS, so there is nothing to
         # find — the "device" is whatever the hosting page published. The
         # Emscripten WebGPU port supplies webgpu.h and the browser bindings;
-        # Asyncify is required because the C API remains synchronous.
+        # Asyncify is required because the C API remains synchronous. The
+        # browser-side direct WASM import path additionally requires JSPI and
+        # wraps every callable export with WebAssembly.promising.
         set(GPU_FOUND TRUE)
         set(ESHKOL_GPU_BACKEND "WEBGPU" CACHE INTERNAL
             "Resolved Eshkol GPU backend (NONE, METAL, CUDA, or WEBGPU)" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1490,10 +1490,13 @@ option(ESHKOL_GPU_ENABLED "Enable GPU acceleration for tensor operations" ON)
 option(ESHKOL_REQUIRE_GPU_BACKEND
     "Fail configuration when GPU acceleration is requested but no real backend is available"
     OFF)
+option(ESHKOL_WEBGPU_ASYNCIFY
+    "Enable Emscripten Asyncify for synchronous WASM calls into WebGPU"
+    ON)
 set(ESHKOL_CUDA_ARCHITECTURES "72;75;80;86;89;90" CACHE STRING
     "CUDA architectures for portable Eshkol GPU binaries")
 set(ESHKOL_GPU_BACKEND "NONE" CACHE INTERNAL
-    "Resolved Eshkol GPU backend (NONE, METAL, or CUDA)" FORCE)
+    "Resolved Eshkol GPU backend (NONE, METAL, CUDA, or WEBGPU)" FORCE)
 
 if(ESHKOL_REQUIRE_GPU_BACKEND AND NOT ESHKOL_GPU_ENABLED)
     message(FATAL_ERROR
@@ -1506,7 +1509,25 @@ if(ESHKOL_GPU_ENABLED)
     set(GPU_SOURCES "")
     set(ESHKOL_CUDA_RUNTIME_LINK_NAMES "")
 
-    if(APPLE)
+    if(EMSCRIPTEN)
+        # Browser WebGPU (wasm target). Compute is dispatched into
+        # web/eshkol-webgpu.js through EM_ASYNC_JS, so there is nothing to
+        # find — the "device" is whatever the hosting page published. The
+        # Emscripten WebGPU port supplies webgpu.h and the browser bindings;
+        # Asyncify is required because the C API remains synchronous.
+        set(GPU_FOUND TRUE)
+        set(ESHKOL_GPU_BACKEND "WEBGPU" CACHE INTERNAL
+            "Resolved Eshkol GPU backend (NONE, METAL, CUDA, or WEBGPU)" FORCE)
+        add_compile_definitions(ESHKOL_GPU_WEBGPU_ENABLED)
+        set(GPU_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/lib/backend/gpu/gpu_memory_webgpu.cpp")
+        # Emscripten 4.x replaced -sUSE_WEBGPU=1 with the Dawn port. The port
+        # supplies webgpu/webgpu.h and the browser WebGPU bindings.
+        add_link_options("--use-port=emdawnwebgpu")
+        if(ESHKOL_WEBGPU_ASYNCIFY)
+            add_link_options("-sASYNCIFY")
+        endif()
+        message(STATUS "GPU: WebGPU (browser compute, wasm target)")
+    elseif(APPLE)
         # Use Apple Metal framework (macOS/iOS)
         find_library(METAL_FRAMEWORK Metal)
         find_library(MPS_FRAMEWORK MetalPerformanceShaders)
@@ -1515,7 +1536,7 @@ if(ESHKOL_GPU_ENABLED)
         if(METAL_FRAMEWORK AND MPS_FRAMEWORK)
             set(GPU_FOUND TRUE)
             set(ESHKOL_GPU_BACKEND "METAL" CACHE INTERNAL
-                "Resolved Eshkol GPU backend (NONE, METAL, or CUDA)" FORCE)
+                "Resolved Eshkol GPU backend (NONE, METAL, CUDA, or WEBGPU)" FORCE)
             set(GPU_LIBRARIES ${METAL_FRAMEWORK} ${MPS_FRAMEWORK} ${FOUNDATION_FRAMEWORK})
             add_compile_definitions(ESHKOL_GPU_METAL_ENABLED)
             message(STATUS "GPU: Apple Metal (unified memory)")
@@ -1567,7 +1588,7 @@ if(ESHKOL_GPU_ENABLED)
 
             set(GPU_FOUND TRUE)
             set(ESHKOL_GPU_BACKEND "CUDA" CACHE INTERNAL
-                "Resolved Eshkol GPU backend (NONE, METAL, or CUDA)" FORCE)
+                "Resolved Eshkol GPU backend (NONE, METAL, CUDA, or WEBGPU)" FORCE)
             set(GPU_LIBRARIES CUDA::cudart CUDA::cublas)
             set(ESHKOL_CUDA_RUNTIME_LINK_NAMES cudart cublas)
             if(TARGET CUDA::cublasLt)

--- a/docs/FEATURE_MATRIX.md
+++ b/docs/FEATURE_MATRIX.md
@@ -636,6 +636,10 @@ from the manifest again.
 | Reduce operations | Yes | CUDA | Custom kernels |
 | Softmax | Yes | CUDA | Numerically stable |
 | Transpose | Yes | CUDA | cuBLAS transpose |
+| **WebGPU (Emscripten/wasm)** |
+| Ordinary GPU dispatch seam | Partial | WebGPU/WGSL | Browser adapter selected at runtime; CPU fallback when unavailable; headless gate evidence required before COMPLETE |
+| Matmul, algebraic elementwise, and reductions | Partial | WebGPU/WGSL | `high` has df32 kernels but currently refuses dispatch until the adapter meets `GPU_GATE_TOL=1e-9`; unsupported work uses CPU |
+| Exact IEEE f64 / Ozaki path | Unsupported | CPU fallback | WGSL has no f64; no exact WebGPU claim is made |
 | **Dispatch** |
 | Automatic CPU/GPU selection | Yes | Runtime | Cost model based |
 | Threshold-based dispatch | Yes | Runtime | XLA → cBLAS → SIMD → scalar |

--- a/docs/breakdown/COMPILATION_GUIDE.md
+++ b/docs/breakdown/COMPILATION_GUIDE.md
@@ -147,7 +147,8 @@ cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
 | Option | Default | Description |
 |--------|---------|-------------|
 | `ESHKOL_BLAS_ENABLED` | `ON` | BLAS acceleration (Accelerate on macOS, OpenBLAS on Linux) |
-| `ESHKOL_GPU_ENABLED` | `ON` | GPU acceleration (Metal on macOS, CUDA on Linux) |
+| `ESHKOL_GPU_ENABLED` | `ON` | GPU acceleration (Metal on macOS, CUDA on Linux, WebGPU on Emscripten/wasm) |
+| `ESHKOL_WEBGPU_ASYNCIFY` | `ON` | Emscripten wasm only: add `-sASYNCIFY` so synchronous GPU dispatch can wait for browser readback |
 | `ESHKOL_XLA_ENABLED` | `OFF` | XLA/StableHLO backend for tensor fusion |
 | `ESHKOL_ENABLE_ASAN` | `OFF` | Address Sanitizer |
 | `ESHKOL_ENABLE_UBSAN` | `OFF` | Undefined Behavior Sanitizer |

--- a/docs/breakdown/GPU_ACCELERATION.md
+++ b/docs/breakdown/GPU_ACCELERATION.md
@@ -25,15 +25,48 @@ if the chosen backend fails, execution falls through to the next-best option.
 | File | Lines | Role |
 |------|-------|------|
 | `lib/backend/blas_backend.cpp` | 1,281 | Cost model, dispatch, SIMD/BLAS |
-| `lib/backend/gpu/gpu_memory.mm` | 4,485 | Metal compute pipeline (Obj-C++) |
+| `lib/backend/gpu/gpu_memory.mm` | 4,486 | Metal compute pipeline (Obj-C++) |
 | `lib/backend/gpu/metal_softfloat.h` | 4,469 | SF64 IEEE 754 f64 emulation (MSL) |
-| `lib/backend/gpu/gpu_memory_cuda.cpp` | 1,576 | CUDA backend (cuBLAS + kernels) |
+| `lib/backend/gpu/gpu_memory_cuda.cpp` | 1,577 | CUDA backend (cuBLAS + kernels) |
 | `lib/backend/gpu/gpu_cuda_kernels.cu` | 800 | CUDA kernel implementations |
-| `lib/backend/gpu/gpu_memory_stub.cpp` | 449 | No-op stub for platforms without GPU |
+| `lib/backend/gpu/gpu_memory_stub.cpp` | 450 | No-op stub for platforms without GPU |
+| `lib/backend/gpu/gpu_memory_webgpu.cpp` | wasm target | WebGPU C seam and CPU fallback |
+| `lib/backend/gpu/wgsl/` | wasm target | Canonical f32/df32 matmul, elementwise, and reduction kernels |
 
 Build-time flags select the backend: `ESHKOL_GPU_METAL_ENABLED` (macOS),
-`ESHKOL_GPU_CUDA_ENABLED` (Linux/Windows), or the stub (no GPU). The stub logs
+`ESHKOL_GPU_CUDA_ENABLED` (Linux/Windows), `ESHKOL_GPU_WEBGPU_ENABLED`
+(Emscripten/wasm), or the stub (no GPU). The stub logs
 actionable errors via `eshkol_error()` (`gpu_memory_stub.cpp`).
+
+### WebGPU (Emscripten/wasm)
+
+WebGPU is part of the same `eshkol_gpu_*` and `eshkol_matmul_dispatch` seam as
+Metal and CUDA. CMake selects `gpu_memory_webgpu.cpp` when `EMSCRIPTEN` is
+true, enables the Emscripten Dawn WebGPU port with
+`--use-port=emdawnwebgpu` (the current replacement for `-sUSE_WEBGPU=1`), and enables
+`-sASYNCIFY` by default through `ESHKOL_WEBGPU_ASYNCIFY`. The page loads
+`eshkol-webgpu.js` and calls `initWebGPU()` before WASM instantiation. If
+`navigator.gpu`, an adapter, Asyncify, or a live device is absent, the active
+backend is `ESHKOL_GPU_NONE` and the ordinary CPU path runs.
+
+WGSL has no f64 type. The browser backend therefore has these explicit tiers:
+
+| Tier | WebGPU behavior | Claim |
+|---|---|---|
+| `exact` | Refuses GPU and falls back to CPU | IEEE f64 correctness remains a CPU/native-backend claim |
+| `high` | df32 `(hi, lo)` f32 emulation | Present but currently refuses browser dispatch until `GPU_GATE_TOL` (default `1e-9`) is met |
+| `fast` | f32 kernels | Never used by the 1e-9 correctness gate; callers must opt into its lower-precision contract |
+
+The `two_sum` and `two_prod` compensation terms in
+`lib/backend/gpu/wgsl/double_float.wgsl` use a zero-valued storage read as an
+opaque barrier. This is required because WGSL has no precise-math attribute
+and an optimizer may otherwise fold the error term away. The barrier is bound
+by each df32 pipeline and is checked by the browser differential runner.
+
+The verified browser scope is matmul, algebraic elementwise operations, and
+sum/min/max/mean reductions. Transpose, softmax, normalization, and backward
+GPU kernels remain CPU fallbacks until they have their own WGSL implementation
+and a correctness witness; they are not advertised as WebGPU-complete.
 
 ---
 
@@ -954,7 +987,7 @@ are then set to `nil` in order.
 
 ### Implementation Scope
 
-The CUDA backend (`lib/backend/gpu/gpu_memory_cuda.cpp`, 1,576 lines) is a
+The CUDA backend (`lib/backend/gpu/gpu_memory_cuda.cpp`, 1,577 lines) is a
 fully functional GPU acceleration path for NVIDIA hardware. Unlike the Metal
 backend which requires SF64 software emulation, CUDA provides native f64
 hardware, so no precision emulation is needed.
@@ -1045,7 +1078,7 @@ Metal and CUDA coexist via compile-time guards and runtime detection:
   `ESHKOL_GPU_CUDA_ENABLED` (Linux/Windows builds) are set by CMake.
   `gpu_memory.mm` is compiled as Objective-C++ on macOS;
   `gpu_memory_cuda.cpp` is compiled as standard C++ on Linux/Windows.
-  A stub file (`gpu_memory_stub.cpp`, 449 lines) provides no-op
+  A stub file (`gpu_memory_stub.cpp`, 450 lines) provides no-op
   implementations when neither backend is available.
 
 - **Runtime**: `eshkol_gpu_init` (`gpu_memory_cuda.cpp`) tries CUDA

--- a/docs/breakdown/GPU_ACCELERATION.md
+++ b/docs/breakdown/GPU_ACCELERATION.md
@@ -57,7 +57,7 @@ WGSL has no f64 type. The browser backend therefore has these explicit tiers:
 |---|---|---|
 | `exact` | Refuses GPU and falls back to CPU | IEEE f64 correctness remains a CPU/native-backend claim |
 | `high` | df32 `(hi, lo)` f32 emulation | Refuses browser dispatch until the live differential gate certifies the compensation path at `GPU_GATE_TOL` (default `1e-9`) |
-| `fast` | f32 kernels | Refused by the 1e-9 gate; callers must explicitly provide a looser `gateTolerance` contract |
+| `fast` | f32 kernels | Refused by the 1e-9 gate; callers must explicitly opt in with `precision: "fast"` and provide `gateTolerance >= 1e-6` |
 
 The `two_sum` and `two_prod` compensation terms in
 `lib/backend/gpu/wgsl/double_float.wgsl` use a zero-valued storage read as an

--- a/docs/breakdown/GPU_ACCELERATION.md
+++ b/docs/breakdown/GPU_ACCELERATION.md
@@ -44,9 +44,11 @@ WebGPU is part of the same `eshkol_gpu_*` and `eshkol_matmul_dispatch` seam as
 Metal and CUDA. CMake selects `gpu_memory_webgpu.cpp` when `EMSCRIPTEN` is
 true, enables the Emscripten Dawn WebGPU port with
 `--use-port=emdawnwebgpu` (the current replacement for `-sUSE_WEBGPU=1`), and enables
-`-sASYNCIFY` by default through `ESHKOL_WEBGPU_ASYNCIFY`. The page loads
-`eshkol-webgpu.js` and calls `initWebGPU()` before WASM instantiation. If
-`navigator.gpu`, an adapter, Asyncify, or a live device is absent, the active
+`-sASYNCIFY` by default through `ESHKOL_WEBGPU_ASYNCIFY` for the C-side
+`EM_ASYNC_JS` bridge. The page loads `eshkol-webgpu.js`, requires the paired
+`WebAssembly.Suspending`/`WebAssembly.promising` JSPI API, and calls
+`initWebGPU()` before WASM instantiation. If `navigator.gpu`, an adapter,
+Asyncify, JSPI, or a live device is absent, the active
 backend is `ESHKOL_GPU_NONE` and the ordinary CPU path runs.
 
 WGSL has no f64 type. The browser backend therefore has these explicit tiers:
@@ -54,8 +56,8 @@ WGSL has no f64 type. The browser backend therefore has these explicit tiers:
 | Tier | WebGPU behavior | Claim |
 |---|---|---|
 | `exact` | Refuses GPU and falls back to CPU | IEEE f64 correctness remains a CPU/native-backend claim |
-| `high` | df32 `(hi, lo)` f32 emulation | Present but currently refuses browser dispatch until `GPU_GATE_TOL` (default `1e-9`) is met |
-| `fast` | f32 kernels | Never used by the 1e-9 correctness gate; callers must opt into its lower-precision contract |
+| `high` | df32 `(hi, lo)` f32 emulation | Refuses browser dispatch until the live differential gate certifies the compensation path at `GPU_GATE_TOL` (default `1e-9`) |
+| `fast` | f32 kernels | Refused by the 1e-9 gate; callers must explicitly provide a looser `gateTolerance` contract |
 
 The `two_sum` and `two_prod` compensation terms in
 `lib/backend/gpu/wgsl/double_float.wgsl` use a zero-valued storage read as an
@@ -63,8 +65,9 @@ opaque barrier. This is required because WGSL has no precise-math attribute
 and an optimizer may otherwise fold the error term away. The barrier is bound
 by each df32 pipeline and is checked by the browser differential runner.
 
-The verified browser scope is matmul, algebraic elementwise operations, and
-sum/min/max/mean reductions. Transpose, softmax, normalization, and backward
+The browser gate exercises matmul, algebraic elementwise operations, and
+sum/min/max/mean reductions. These remain CPU fallbacks until the live gate
+produces a correctness witness. Transpose, softmax, normalization, and backward
 GPU kernels remain CPU fallbacks until they have their own WGSL implementation
 and a correctness witness; they are not advertised as WebGPU-complete.
 

--- a/docs/breakdown/RUNTIME_CONFIGURATION.md
+++ b/docs/breakdown/RUNTIME_CONFIGURATION.md
@@ -143,7 +143,8 @@ The maximum recursion depth (`ESHKOL_MAX_STACK` / `ESHKOL_DEFAULT_MAX_STACK_DEPT
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ESHKOL_GPU_MATMUL_THRESHOLD` | 100000 | Element count threshold for GPU matmul dispatch. Set to `1` to force all matmul through GPU. |
-| `ESHKOL_GPU_PRECISION` | `exact` | GPU precision mode: `exact` (sf64, 53-bit), `high` (df64, ~48-bit), `fast` (f32, 24-bit). |
+| `ESHKOL_GPU_PRECISION` | `exact` | GPU precision mode: native backends support `exact` (sf64, 53-bit), `high` (df64, ~48-bit), and `fast` (f32, 24-bit); WebGPU supports `high`/`fast` only and refuses `exact` to CPU. |
+| `ESHKOL_WEBGPU_ASYNCIFY` | `ON` | Emscripten CMake option: enable Asyncify for WebGPU readback. Disable only when WebGPU dispatch is not linked. |
 | `ESHKOL_SF64_KERNEL` | `v2` | Software float64 kernel version: `v1` (original) or `v2` (deferred rounding). |
 
 ### Debug and Diagnostics

--- a/inc/eshkol/backend/gpu/gpu_memory.h
+++ b/inc/eshkol/backend/gpu/gpu_memory.h
@@ -4,6 +4,7 @@
  * Provides unified interface for GPU memory management across:
  * - Metal (macOS/iOS) with unified memory architecture
  * - CUDA (Linux/Windows) with discrete GPU memory
+ * - WebGPU (Emscripten/wasm) with staged browser buffers
  *
  * Design principles:
  * - Zero-copy for unified memory (Metal on Apple Silicon)
@@ -11,8 +12,6 @@
  * - Automatic device selection and fallback
  * - Integration with Eshkol's OALR memory model
  *
- * Copyright (C) tsotchke
- * SPDX-License-Identifier: MIT
  */
 
 #ifndef ESHKOL_GPU_MEMORY_H
@@ -34,7 +33,11 @@ typedef enum {
     ESHKOL_GPU_NONE = 0,    // CPU only
     ESHKOL_GPU_METAL = 1,   // Apple Metal (unified memory)
     ESHKOL_GPU_CUDA = 2,    // NVIDIA CUDA
-    ESHKOL_GPU_VULKAN = 3   // Vulkan compute (future)
+    ESHKOL_GPU_VULKAN = 3,  // Vulkan compute (future)
+    // Browser WebGPU (wasm target). Compute runs in WGSL, which has no f64,
+    // so the f64 entry points are served by the df32 (~48-bit) tier or fall
+    // back to CPU — see lib/backend/gpu/gpu_memory_webgpu.cpp.
+    ESHKOL_GPU_WEBGPU = 4
 } EshkolGPUBackend;
 
 typedef enum {
@@ -73,7 +76,7 @@ typedef struct EshkolGPUBuffer {
  * Initialize GPU subsystem and detect available backends.
  * Call once at program startup. Idempotent — subsequent calls are no-ops.
  *
- * @return 1 if a GPU backend (Metal or CUDA) was initialised and is now
+ * @return 1 if a GPU backend (Metal, CUDA, or WebGPU) was initialised and is now
  *         active, 0 if no GPU is available (library falls back to CPU).
  *
  * NOTE: This is a BOOLEAN return, not a device count. The convention is
@@ -155,6 +158,7 @@ int eshkol_gpu_has_fp64(void);
  *
  * For Metal: Uses MTLBuffer with shared storage mode (unified memory).
  * For CUDA: Uses cudaMallocHost (pinned) or cudaMalloc (device).
+ * For WebGPU: Uses a wasm-heap view; the JS bridge stages it into GPUBuffer.
  *
  * @param size_bytes Size to allocate
  * @param mem_type Type of memory to allocate

--- a/inc/eshkol/backend/gpu/gpu_memory.h
+++ b/inc/eshkol/backend/gpu/gpu_memory.h
@@ -145,7 +145,9 @@ int eshkol_gpu_supports_f64(void);
  * `ESHKOL_GPU_PRECISION=default` in the precision-tier docs. On CUDA
  * this returns 1 (same as `eshkol_gpu_supports_f64`). On Metal this
  * returns 1 whenever GPU init succeeded (SF64 is always available).
- * Returns 0 only when no GPU backend is active at all.
+ * WebGPU returns 0 because WGSL has no correct-to-ULP f64 path; it is a
+ * compute backend for the explicitly gated df32/fast tiers, not an fp64
+ * capability. Other backends return 0 when no fp64 path is active.
  *
  * @return 1 if any fp64 path is usable (native or emulated), 0 otherwise.
  */

--- a/lib/backend/gpu/gpu_memory.mm
+++ b/lib/backend/gpu/gpu_memory.mm
@@ -3711,6 +3711,7 @@ const char* eshkol_gpu_backend_name(EshkolGPUBackend backend) {
         case ESHKOL_GPU_NONE: return "CPU (no GPU)";
         case ESHKOL_GPU_METAL: return "Apple Metal";
         case ESHKOL_GPU_CUDA: return "NVIDIA CUDA";
+        case ESHKOL_GPU_WEBGPU: return "WebGPU (not available on Metal host)";
         case ESHKOL_GPU_VULKAN: return "Vulkan";
     }
     return "Unknown";

--- a/lib/backend/gpu/gpu_memory_cuda.cpp
+++ b/lib/backend/gpu/gpu_memory_cuda.cpp
@@ -893,6 +893,7 @@ const char* eshkol_gpu_backend_name(EshkolGPUBackend backend) {
         case ESHKOL_GPU_NONE: return "CPU (no GPU)";
         case ESHKOL_GPU_METAL: return "Apple Metal (not available on Linux)";
         case ESHKOL_GPU_CUDA: return "NVIDIA CUDA";
+        case ESHKOL_GPU_WEBGPU: return "WebGPU (not available on CUDA host)";
         case ESHKOL_GPU_VULKAN: return "Vulkan";
     }
     return "Unknown";

--- a/lib/backend/gpu/gpu_memory_stub.cpp
+++ b/lib/backend/gpu/gpu_memory_stub.cpp
@@ -43,6 +43,7 @@ const char* eshkol_gpu_backend_name(EshkolGPUBackend backend) {
         case ESHKOL_GPU_METAL:  return "Apple Metal (not available)";
         case ESHKOL_GPU_CUDA:   return "NVIDIA CUDA (not available)";
         case ESHKOL_GPU_VULKAN: return "Vulkan (not available)";
+        case ESHKOL_GPU_WEBGPU: return "WebGPU (not available)";
         default:                return "Unknown";
     }
 }

--- a/lib/backend/gpu/gpu_memory_webgpu.cpp
+++ b/lib/backend/gpu/gpu_memory_webgpu.cpp
@@ -148,6 +148,17 @@ EM_JS(void, eshkol_webgpu_js_set_threshold, (double threshold), {
     if (be && typeof be.setThreshold === "function") be.setThreshold(threshold);
 });
 
+/** @brief Mirror the JS operation-eligibility predicate. The C side cannot
+ *         infer the selected precision tier or an adapter's fused-fma result;
+ *         consulting the same backend object prevents C from reporting a GPU
+ *         dispatch that the browser glue will immediately refuse. */
+EM_JS(int, eshkol_webgpu_js_should_use, (double num_elements), {
+    var be = (typeof Module !== "undefined" && Module["eshkolWebGPUBackend"]) ||
+             globalThis.eshkolWebGPUBackend ||
+             (globalThis.EshkolWebGPU && globalThis.EshkolWebGPU.backend);
+    return (be && typeof be.shouldUse === "function" && be.shouldUse(num_elements)) ? 1 : 0;
+});
+
 /*
  * Asynchronous compute entry points. Each mirrors the matching method of the
  * EshkolWebGPU class in web/eshkol-webgpu.js one-for-one: pointers are wasm
@@ -169,8 +180,10 @@ EM_ASYNC_JS(int, eshkol_webgpu_js_matmul, (void* aPtr, void* bPtr, void* cPtr,
     if (typeof be.supportsOperation === "function" && !be.supportsOperation("matmul")) return 2;
     try {
         be.setMemory(wasmMemory);
-        await be.matmulF64(aPtr, bPtr, cPtr, M, K, N);
-        return 0;
+        var before = Number(be.executionMarker) || 0;
+        var marker = await be.matmulF64(aPtr, bPtr, cPtr, M, K, N);
+        return (Number.isSafeInteger(marker) && marker > before &&
+                be.executionMarker === marker && be.lastExecutionMarker === marker) ? 0 : 3;
     } catch (e) {
         if (be.diagnostics) be.diagnostics.push("gemm failed, CPU fallback: " + e);
         return 3;
@@ -190,8 +203,10 @@ EM_ASYNC_JS(int, eshkol_webgpu_js_elementwise, (void* aPtr, void* bPtr,
     if (typeof be.supportsOperation === "function" && !be.supportsOperation("elementwise", op)) return 2;
     try {
         be.setMemory(wasmMemory);
-        await be.elementwiseF64(aPtr, bPtr, outPtr, n, op);
-        return 0;
+        var before = Number(be.executionMarker) || 0;
+        var marker = await be.elementwiseF64(aPtr, bPtr, outPtr, n, op);
+        return (Number.isSafeInteger(marker) && marker > before &&
+                be.executionMarker === marker && be.lastExecutionMarker === marker) ? 0 : 3;
     } catch (e) {
         if (be.diagnostics) be.diagnostics.push("elementwise failed, CPU fallback: " + e);
         return 3;
@@ -211,8 +226,10 @@ EM_ASYNC_JS(int, eshkol_webgpu_js_reduce, (void* inPtr, void* outPtr,
     if (typeof be.supportsOperation === "function" && !be.supportsOperation("reduce", op)) return 2;
     try {
         be.setMemory(wasmMemory);
-        await be.reduceF64(inPtr, outPtr, n, op);
-        return 0;
+        var before = Number(be.executionMarker) || 0;
+        var marker = await be.reduceF64(inPtr, outPtr, n, op);
+        return (Number.isSafeInteger(marker) && marker > before &&
+                be.executionMarker === marker && be.lastExecutionMarker === marker) ? 0 : 3;
     } catch (e) {
         if (be.diagnostics) be.diagnostics.push("reduce failed, CPU fallback: " + e);
         return 3;
@@ -457,12 +474,14 @@ size_t eshkol_gpu_get_threshold(void) {
 
 /** @brief Decide whether an operation of `num_elements` elements should go to
  *         the GPU: an active backend plus at-or-above the threshold. The JS
- *         side applies one further test (the `exact` precision tier declines
- *         everything), which surfaces here as a bridge fallback, not as a
- *         different answer from this predicate.
+ *         side applies the precision-tier certification test as well;
+ *         unverified `high` and `exact` tiers decline everything, which
+ *         surfaces here as a bridge fallback rather than a different answer
+ *         from this predicate.
  *  @return 1 to use the GPU, 0 for CPU. */
 int eshkol_gpu_should_use(size_t num_elements) {
-    return (g_active_backend != ESHKOL_GPU_NONE && num_elements >= g_gpu_threshold) ? 1 : 0;
+    if (g_active_backend == ESHKOL_GPU_NONE || num_elements < g_gpu_threshold) return 0;
+    return eshkol_webgpu_js_should_use(static_cast<double>(num_elements));
 }
 
 // ============================================================================

--- a/lib/backend/gpu/gpu_memory_webgpu.cpp
+++ b/lib/backend/gpu/gpu_memory_webgpu.cpp
@@ -1,0 +1,735 @@
+/*
+ * Eshkol GPU backend — WebGPU (browser compute, wasm target)
+ *
+ * This is the wasm-target sibling of lib/backend/gpu/gpu_memory.mm (Metal)
+ * and lib/backend/gpu/gpu_memory_cuda.cpp (CUDA). It implements the same
+ * 31-function surface declared in inc/eshkol/backend/gpu/gpu_memory.h, so a
+ * program compiled to wasm reaches the GPU through the ORDINARY dispatch
+ * predicate (eshkol_gpu_should_use: active backend + element-count
+ * threshold), not through a browser-special path.
+ *
+ * PRECISION. WGSL has no f64 of any kind — not native, not an extension — so
+ * the f64 entry points cannot be served natively. The backend slots into the
+ * existing ESHKOL_GPU_PRECISION tier vocabulary (see
+ * docs/breakdown/RUNTIME_CONFIGURATION.md) as implemented by
+ * web/eshkol-webgpu.js:
+ *
+ *   exact : IEEE f64, correct to ULP. NOT AVAILABLE on WebGPU. The JS backend
+ *           declines every dispatch in this tier and this file takes the CPU
+ *           path. (An sf64/Ozaki-II WGSL port is a named follow-up.)
+ *   high  : df32 — each f64 carried as an unevaluated (hi, lo) pair of f32
+ *           with Dekker/Knuth double-float arithmetic. About 48 bits of
+ *           mantissa against f64's 53. THIS IS THE WebGPU DEFAULT.
+ *   fast  : plain f32, about 24 bits.
+ *
+ * Because no tier here is correct-to-ULP, eshkol_gpu_has_fp64() returns 0 —
+ * unlike Metal, where sf64/Ozaki-II emulation makes it return 1. That is a
+ * deliberate honesty constraint: df32 is close, not exact, and a caller that
+ * needs exactness must be able to detect the difference.
+ *
+ * ASYNC. WebGPU readback is unavoidably asynchronous (GPUBuffer.mapAsync).
+ * Eshkol's runtime is synchronous C compiled to wasm32. The bridge is
+ * EM_ASYNC_JS, which requires the module be built with -sASYNCIFY (or
+ * -sJSPI on browsers that support the JavaScript Promise Integration
+ * proposal). Without one of those the EM_ASYNC_JS calls cannot suspend and
+ * the module will trap; a build that cannot enable either should compile
+ * gpu_memory_stub.cpp instead.
+ *
+ * PAGE CONTRACT. web/eshkol-webgpu.js publishes `globalThis.EshkolWebGPU` and
+ * its `create()` resolves to a backend object. The page (or loader) must
+ * publish that object where this file can find it, in the first of:
+ *
+ *   Module.eshkolWebGPUBackend
+ *   globalThis.eshkolWebGPUBackend
+ *   globalThis.EshkolWebGPU.backend
+ *
+ * When none of those is present, or the backend has lost its device, every
+ * bridge function returns nonzero and the C side takes its CPU fallback — a
+ * missing device is never a failed program, only a slower one.
+ *
+ */
+
+#ifdef __EMSCRIPTEN__
+
+#include <eshkol/backend/gpu/gpu_memory.h>
+#include <eshkol/logger.h>
+#include <emscripten.h>
+#include <webgpu/webgpu.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cmath>
+
+/* Including webgpu.h makes the Emscripten WebGPU port a build dependency. The
+ * actual browser device is acquired by web/eshkol-webgpu.js before WASM
+ * instantiation; the C API type is intentionally opaque at this seam. */
+/* Keep the Emscripten WebGPU type at this seam even though ownership belongs
+ * to the page. The JS bridge is the only code that submits work; this handle
+ * is an ABI marker for builds that enable the Emscripten Dawn WebGPU port. */
+static WGPUDevice g_webgpu_device_handle = nullptr;
+
+/* Forward declaration: dispatched matmul from blas_backend.cpp */
+extern "C" void eshkol_matmul_f64(const double*, const double*, double*,
+                                   uint64_t, uint64_t, uint64_t);
+
+/* Forward declaration: CPU batched matmul from blas_backend.cpp */
+extern "C" void eshkol_batch_matmul_f64(const double*, const double*, double*,
+                                        int64_t, int64_t, int64_t, int64_t);
+
+/* CPU fallbacks in this file must not call eshkol_matmul_f64(): that ordinary
+ * dispatcher can select this backend again for a very large operation. Keep a
+ * local scalar fallback so an exact-tier refusal is fail-closed and cannot
+ * recurse. */
+static void webgpu_cpu_matmul(const double* A, const double* B, double* C,
+                              uint64_t M, uint64_t K, uint64_t N) {
+    for (uint64_t i = 0; i < M; ++i) {
+        for (uint64_t j = 0; j < N; ++j) {
+            double sum = 0.0;
+            for (uint64_t k = 0; k < K; ++k)
+                sum += A[i * K + k] * B[k * N + j];
+            C[i * N + j] = sum;
+        }
+    }
+}
+
+// ============================================================================
+// Global State
+// ============================================================================
+
+/* GPU threshold (elements) — default 100K, same as all native backends. */
+size_t g_gpu_threshold = 100000;
+
+/* Active backend, mirroring gpu_memory.mm. Single-threaded on the main wasm
+ * thread, so a plain static is sufficient (no atomics needed). */
+static EshkolGPUBackend g_active_backend = ESHKOL_GPU_NONE;
+static bool g_gpu_initialized = false;
+
+/* Buffer flag bits (mirrors the Metal backend's convention). */
+enum {
+    ESHKOL_WEBGPU_FLAG_EXTERNAL = 1u  /* bit 0: memory is externally owned */
+};
+
+/* Bridge status codes shared by every EM_ASYNC_JS body below.
+ * 0 = the GPU served the call and the result is already in wasm memory.
+ * Anything else means the C side must run its CPU fallback. */
+enum {
+    ESHKOL_WEBGPU_OK        = 0,
+    ESHKOL_WEBGPU_NO_DEVICE = 1,  /* no backend object, or its device is gone */
+    ESHKOL_WEBGPU_DECLINED  = 2,  /* backend.shouldUse() false (tier `exact`) */
+    ESHKOL_WEBGPU_THREW     = 3   /* kernel or readback raised */
+};
+
+// ============================================================================
+// JavaScript Bridge
+// ============================================================================
+
+/*
+ * Synchronous queries. These never suspend: web/eshkol-webgpu.js acquires the
+ * device before the wasm module is instantiated, so by the time C code runs
+ * the answer is already known.
+ */
+
+/** @brief Report whether the page published a WebGPU backend with a live
+ *         device. Returns 1 when GPU dispatch is possible, 0 otherwise. */
+EM_JS(int, eshkol_webgpu_js_device_ready, (void), {
+    var be = (typeof Module !== "undefined" && Module["eshkolWebGPUBackend"]) ||
+             globalThis.eshkolWebGPUBackend ||
+             (globalThis.EshkolWebGPU && globalThis.EshkolWebGPU.backend);
+    return (be && be.device) ? 1 : 0;
+});
+
+/** @brief Push the C-side dispatch threshold into the JS backend so both
+ *         sides agree on when the GPU is worth using. No-op without a
+ *         backend. */
+EM_JS(void, eshkol_webgpu_js_set_threshold, (double threshold), {
+    var be = (typeof Module !== "undefined" && Module["eshkolWebGPUBackend"]) ||
+             globalThis.eshkolWebGPUBackend ||
+             (globalThis.EshkolWebGPU && globalThis.EshkolWebGPU.backend);
+    if (be && typeof be.setThreshold === "function") be.setThreshold(threshold);
+});
+
+/*
+ * Asynchronous compute entry points. Each mirrors the matching method of the
+ * EshkolWebGPU class in web/eshkol-webgpu.js one-for-one: pointers are wasm
+ * heap byte offsets holding f64, dimensions are plain counts. The backend is
+ * handed the live WebAssembly.Memory first, because a heap growth invalidates
+ * any typed-array view it cached earlier.
+ */
+
+/** @brief Bridge to EshkolWebGPU.matmulF64: C = A * B, row-major f64 at wasm
+ *         heap byte offsets. Returns 0 on success, nonzero to request the
+ *         CPU fallback. */
+EM_ASYNC_JS(int, eshkol_webgpu_js_matmul, (void* aPtr, void* bPtr, void* cPtr,
+                                           double M, double K, double N), {
+    var be = (typeof Module !== "undefined" && Module["eshkolWebGPUBackend"]) ||
+             globalThis.eshkolWebGPUBackend ||
+             (globalThis.EshkolWebGPU && globalThis.EshkolWebGPU.backend);
+    if (!be || !be.device) return 1;
+    if (typeof be.shouldUse === "function" && !be.shouldUse(M * N)) return 2;
+    if (typeof be.supportsOperation === "function" && !be.supportsOperation("matmul")) return 2;
+    try {
+        be.setMemory(wasmMemory);
+        await be.matmulF64(aPtr, bPtr, cPtr, M, K, N);
+        return 0;
+    } catch (e) {
+        if (be.diagnostics) be.diagnostics.push("gemm failed, CPU fallback: " + e);
+        return 3;
+    }
+});
+
+/** @brief Bridge to EshkolWebGPU.elementwiseF64. `bPtr` may be 0 for unary
+ *         ops. Returns 0 on success, nonzero to request the CPU fallback. */
+EM_ASYNC_JS(int, eshkol_webgpu_js_elementwise, (void* aPtr, void* bPtr,
+                                                void* outPtr, double n,
+                                                int op), {
+    var be = (typeof Module !== "undefined" && Module["eshkolWebGPUBackend"]) ||
+             globalThis.eshkolWebGPUBackend ||
+             (globalThis.EshkolWebGPU && globalThis.EshkolWebGPU.backend);
+    if (!be || !be.device) return 1;
+    if (typeof be.shouldUse === "function" && !be.shouldUse(n)) return 2;
+    if (typeof be.supportsOperation === "function" && !be.supportsOperation("elementwise", op)) return 2;
+    try {
+        be.setMemory(wasmMemory);
+        await be.elementwiseF64(aPtr, bPtr, outPtr, n, op);
+        return 0;
+    } catch (e) {
+        if (be.diagnostics) be.diagnostics.push("elementwise failed, CPU fallback: " + e);
+        return 3;
+    }
+});
+
+/** @brief Bridge to EshkolWebGPU.reduceF64: full reduction of `n` f64
+ *         elements to the single f64 at `outPtr`. Returns 0 on success,
+ *         nonzero to request the CPU fallback. */
+EM_ASYNC_JS(int, eshkol_webgpu_js_reduce, (void* inPtr, void* outPtr,
+                                           double n, int op), {
+    var be = (typeof Module !== "undefined" && Module["eshkolWebGPUBackend"]) ||
+             globalThis.eshkolWebGPUBackend ||
+             (globalThis.EshkolWebGPU && globalThis.EshkolWebGPU.backend);
+    if (!be || !be.device) return 1;
+    if (typeof be.shouldUse === "function" && !be.shouldUse(n)) return 2;
+    if (typeof be.supportsOperation === "function" && !be.supportsOperation("reduce", op)) return 2;
+    try {
+        be.setMemory(wasmMemory);
+        await be.reduceF64(inPtr, outPtr, n, op);
+        return 0;
+    } catch (e) {
+        if (be.diagnostics) be.diagnostics.push("reduce failed, CPU fallback: " + e);
+        return 3;
+    }
+});
+
+// ============================================================================
+// Device Management
+// ============================================================================
+
+/** @brief Initialise the WebGPU backend: applies the ESHKOL_GPU_THRESHOLD
+ *         environment override, then asks the page whether it published a
+ *         backend with a live device. Idempotent.
+ *  @return 1 if the WebGPU backend is now active, 0 if the program will run
+ *          on the CPU (BOOLEAN, not a device count — see gpu_memory.h). */
+int eshkol_gpu_init(void) {
+    if (g_gpu_initialized) {
+        return (g_active_backend != ESHKOL_GPU_NONE) ? 1 : 0;
+    }
+
+    /* Allow override of GPU dispatch threshold via environment variable.
+     * Under Emscripten getenv() reads the module's ENV object, so a page can
+     * set this the same way a shell would. */
+    if (const char* env = std::getenv("ESHKOL_GPU_THRESHOLD")) {
+        size_t val = static_cast<size_t>(std::atol(env));
+        if (val > 0) g_gpu_threshold = val;
+    }
+
+    if (eshkol_webgpu_js_device_ready()) {
+        g_active_backend = ESHKOL_GPU_WEBGPU;
+        g_gpu_initialized = true;
+        /* Keep the JS-side predicate in step with the C-side threshold. */
+        eshkol_webgpu_js_set_threshold(static_cast<double>(g_gpu_threshold));
+        return 1;
+    }
+
+    g_active_backend = ESHKOL_GPU_NONE;
+    g_gpu_initialized = true;
+    return 0;
+}
+
+/** @brief Shut down the WebGPU backend. The GPUDevice belongs to the page,
+ *         not to this module, so nothing is destroyed here — only the
+ *         C-side active-backend state is cleared. */
+void eshkol_gpu_shutdown(void) {
+    g_active_backend = ESHKOL_GPU_NONE;
+    g_gpu_initialized = false;
+}
+
+/** @brief Get the active GPU backend (ESHKOL_GPU_WEBGPU once init succeeded,
+ *         ESHKOL_GPU_NONE otherwise). */
+EshkolGPUBackend eshkol_gpu_get_backend(void) {
+    return g_active_backend;
+}
+
+/** @brief Human-readable name for a GPU backend enum value. In a wasm build
+ *         only WebGPU can ever be present, so the native backends are
+ *         annotated "(not available)". */
+const char* eshkol_gpu_backend_name(EshkolGPUBackend backend) {
+    switch (backend) {
+        case ESHKOL_GPU_NONE:   return "CPU only";
+        case ESHKOL_GPU_METAL:  return "Apple Metal (not available)";
+        case ESHKOL_GPU_CUDA:   return "NVIDIA CUDA (not available)";
+        case ESHKOL_GPU_VULKAN: return "Vulkan (not available)";
+        case ESHKOL_GPU_WEBGPU: return "WebGPU (browser compute)";
+        default:                return "Unknown";
+    }
+}
+
+/** @brief Check whether a specific backend is the one currently active.
+ *  @return 1 if `backend` is active, 0 otherwise. */
+int eshkol_gpu_backend_available(EshkolGPUBackend backend) {
+    return (g_active_backend != ESHKOL_GPU_NONE && g_active_backend == backend) ? 1 : 0;
+}
+
+/** @brief Native hardware f64 support: always 0. WGSL has no f64 type at
+ *         all, so no WebGPU device can offer one. */
+int eshkol_gpu_supports_f64(void) {
+    return 0;
+}
+
+/** @brief Any correct-to-ULP f64 path, native or emulated: always 0. The
+ *         df32 tier carries about 48 mantissa bits against f64's 53, so it
+ *         is close but NOT exact; reporting 1 here would mislead callers that
+ *         specifically need IEEE f64 results. Those callers get the CPU
+ *         path. */
+int eshkol_gpu_has_fp64(void) {
+    return 0;
+}
+
+// ============================================================================
+// Memory Allocation
+// ============================================================================
+
+/** @brief Allocate a GPU-accessible buffer. On wasm the linear heap IS the
+ *         memory the WebGPU bridge reads from (kernels are fed heap byte
+ *         offsets), so this is a malloc-backed allocation with host_ptr and
+ *         device_ptr aliased. Zeroes `*out_buffer` on failure.
+ *  @return 0 on success, -1 on failure. */
+int eshkol_gpu_alloc(size_t size_bytes, EshkolMemoryType mem_type,
+                     EshkolGPUBuffer* out_buffer) {
+    if (!out_buffer) return -1;
+    memset(out_buffer, 0, sizeof(*out_buffer));
+    if (size_bytes == 0) {
+        eshkol_error("GPU allocation failed: zero-size request");
+        return -1;
+    }
+    void* p = malloc(size_bytes);
+    if (!p) {
+        eshkol_error("GPU allocation failed: out of wasm heap (%zu bytes)", size_bytes);
+        return -1;
+    }
+    out_buffer->host_ptr = p;
+    out_buffer->device_ptr = p;   /* unified: the wasm heap is the device view */
+    out_buffer->size_bytes = size_bytes;
+    out_buffer->mem_type = mem_type;
+    out_buffer->backend = ESHKOL_GPU_WEBGPU;
+    out_buffer->flags = 0;        /* owned here — eshkol_gpu_free() releases it */
+    out_buffer->backend_data = nullptr;
+    return 0;
+}
+
+/** @brief Allocate a GPU-accessible buffer with a specific alignment.
+ *         Uses aligned_alloc() with the size rounded up to a multiple of
+ *         `alignment`, as the C standard requires.
+ *  @return 0 on success, -1 on failure. */
+int eshkol_gpu_alloc_aligned(size_t size_bytes, size_t alignment,
+                              EshkolMemoryType mem_type,
+                              EshkolGPUBuffer* out_buffer) {
+    if (!out_buffer) return -1;
+    if (alignment == 0 || (alignment & (alignment - 1)) != 0) {
+        memset(out_buffer, 0, sizeof(*out_buffer));
+        eshkol_error("GPU aligned allocation failed: alignment %zu is not a power of 2",
+                     alignment);
+        return -1;
+    }
+    if (alignment <= sizeof(void*)) {
+        return eshkol_gpu_alloc(size_bytes, mem_type, out_buffer);
+    }
+    memset(out_buffer, 0, sizeof(*out_buffer));
+    if (size_bytes == 0) {
+        eshkol_error("GPU aligned allocation failed: zero-size request");
+        return -1;
+    }
+    size_t rounded = ((size_bytes + alignment - 1) / alignment) * alignment;
+    void* p = aligned_alloc(alignment, rounded);
+    if (!p) {
+        eshkol_error("GPU aligned allocation failed: out of wasm heap (%zu bytes, align %zu)",
+                     rounded, alignment);
+        return -1;
+    }
+    out_buffer->host_ptr = p;
+    out_buffer->device_ptr = p;
+    out_buffer->size_bytes = size_bytes;
+    out_buffer->mem_type = mem_type;
+    out_buffer->backend = ESHKOL_GPU_WEBGPU;
+    out_buffer->flags = 0;
+    out_buffer->backend_data = nullptr;
+    return 0;
+}
+
+/** @brief Free a GPU buffer. Memory is released only when flag bit 0
+ *         (externally owned) is clear; the descriptor is zeroed either
+ *         way, so a wrapped pointer is never double-freed. */
+void eshkol_gpu_free(EshkolGPUBuffer* buffer) {
+    if (!buffer) return;
+    if (buffer->host_ptr && (buffer->flags & ESHKOL_WEBGPU_FLAG_EXTERNAL) == 0) {
+        free(buffer->host_ptr);
+    }
+    memset(buffer, 0, sizeof(*buffer));
+}
+
+/** @brief Wrap an existing host pointer for GPU use. On wasm there is no
+ *         separate device allocation to make — the pointer already IS a heap
+ *         byte offset the WebGPU bridge can read — so this only fills in the
+ *         descriptor and sets flag bit 0 so eshkol_gpu_free() will not free
+ *         memory it does not own.
+ *  @return 0 on success, -1 on failure. */
+int eshkol_gpu_wrap_host(void* host_ptr, size_t size_bytes,
+                          EshkolGPUBuffer* out_buffer) {
+    if (!out_buffer) return -1;
+    memset(out_buffer, 0, sizeof(*out_buffer));
+    if (!host_ptr) {
+        eshkol_error("GPU wrap_host failed: null host pointer");
+        return -1;
+    }
+    out_buffer->host_ptr = host_ptr;
+    out_buffer->device_ptr = host_ptr;
+    out_buffer->size_bytes = size_bytes;
+    out_buffer->mem_type = ESHKOL_MEM_UNIFIED;
+    out_buffer->backend = ESHKOL_GPU_WEBGPU;
+    out_buffer->flags = ESHKOL_WEBGPU_FLAG_EXTERNAL;  /* do not free */
+    out_buffer->backend_data = nullptr;
+    return 0;
+}
+
+// ============================================================================
+// Data Transfer
+// ============================================================================
+
+/** @brief Synchronise a buffer between host and device. No-op on wasm: the
+ *         linear heap is the only copy, and the WebGPU bridge stages its own
+ *         GPU-side buffers per dispatch.
+ *  @return 0 always. */
+int eshkol_gpu_sync(EshkolGPUBuffer* buffer, EshkolSyncDirection direction) {
+    (void)buffer;
+    (void)direction;
+    return 0;  /* unified memory — nothing to copy */
+}
+
+/** @brief Asynchronous variant of eshkol_gpu_sync(). Also a no-op; there is
+ *         no stream object on this backend, so `stream_handle` is ignored.
+ *  @return 0 always. */
+int eshkol_gpu_sync_async(EshkolGPUBuffer* buffer, EshkolSyncDirection direction,
+                           void* stream_handle) {
+    (void)stream_handle;
+    return eshkol_gpu_sync(buffer, direction);
+}
+
+/** @brief Wait for pending operations on a buffer. No-op: every GPU call on
+ *         this backend already suspends until readback completes, so nothing
+ *         is ever in flight when control returns to C. */
+void eshkol_gpu_wait(EshkolGPUBuffer* buffer) {
+    (void)buffer;
+}
+
+// ============================================================================
+// Threshold Configuration
+// ============================================================================
+
+/** @brief Set the minimum element count at which GPU dispatch is used, and
+ *         mirror it into the JS backend so both predicates agree. */
+void eshkol_gpu_set_threshold(size_t threshold) {
+    g_gpu_threshold = threshold;
+    eshkol_webgpu_js_set_threshold(static_cast<double>(threshold));
+}
+
+/** @brief Get the current GPU dispatch threshold. */
+size_t eshkol_gpu_get_threshold(void) {
+    return g_gpu_threshold;
+}
+
+/** @brief Decide whether an operation of `num_elements` elements should go to
+ *         the GPU: an active backend plus at-or-above the threshold. The JS
+ *         side applies one further test (the `exact` precision tier declines
+ *         everything), which surfaces here as a bridge fallback, not as a
+ *         different answer from this predicate.
+ *  @return 1 to use the GPU, 0 for CPU. */
+int eshkol_gpu_should_use(size_t num_elements) {
+    return (g_active_backend != ESHKOL_GPU_NONE && num_elements >= g_gpu_threshold) ? 1 : 0;
+}
+
+// ============================================================================
+// Matrix Operations
+// ============================================================================
+
+/** @brief GPU matrix multiplication C = A * B over f64 buffers. Attempts the
+ *         WGSL GEMM kernel (df32 or f32 tier) when the dispatch predicate
+ *         says the work is large enough; on any refusal or kernel error falls
+ *         back to the CPU BLAS/SIMD eshkol_matmul_f64(), which is the same
+ *         arithmetic the stub backend performs.
+ *  @return 0 on success, -1 on invalid arguments. */
+int eshkol_gpu_matmul_f64(EshkolGPUBuffer* A, EshkolGPUBuffer* B,
+                           EshkolGPUBuffer* C,
+                           uint64_t M, uint64_t K, uint64_t N) {
+    if (!A || !B || !C) return -1;
+    const double* a = static_cast<const double*>(A->host_ptr);
+    const double* b = static_cast<const double*>(B->host_ptr);
+    double* c = static_cast<double*>(C->host_ptr);
+    if (!a || !b || !c) return -1;
+
+    if (eshkol_gpu_should_use(static_cast<size_t>(M) * static_cast<size_t>(N))) {
+        int rc = eshkol_webgpu_js_matmul(
+            const_cast<double*>(a), const_cast<double*>(b), c,
+            static_cast<double>(M), static_cast<double>(K), static_cast<double>(N));
+        if (rc == ESHKOL_WEBGPU_OK) return 0;
+        /* rc != 0: no device, tier `exact`, or a kernel error — CPU fallback. */
+    }
+
+    /* Refuse explicitly. The ordinary matmul dispatcher owns the CPU
+     * fallback; returning success here would make an unsupported WebGPU tier
+     * look like a GPU result. */
+    return -1;
+}
+
+/** @brief Single-precision matmul. There is no f32 WGSL entry point on the
+ *         JS side yet (the f32 GEMM kernel is reached only through the f64
+ *         path's `fast` tier, which encodes from f64 storage), so this runs
+ *         the stub backend's naive triple-loop scalar implementation on the
+ *         host pointers.
+ *         FOLLOW-UP: a native f32 WGSL GEMM entry point that skips the
+ *         f64-encode step entirely.
+ *  @return 0 on success, -1 on null host pointers. */
+int eshkol_gpu_matmul_f32(EshkolGPUBuffer* A, EshkolGPUBuffer* B,
+                           EshkolGPUBuffer* C,
+                           uint64_t M, uint64_t K, uint64_t N) {
+    if (!A || !B || !C) return -1;
+
+    const float* a = (const float*)A->host_ptr;
+    const float* b = (const float*)B->host_ptr;
+    float* c = (float*)C->host_ptr;
+    if (!a || !b || !c) {
+        eshkol_error("GPU matmul_f32 failed: null host pointers");
+        return -1;
+    }
+
+    (void)a; (void)b; (void)c; (void)M; (void)K; (void)N;
+    return -1;  /* no certified WebGPU f32 C API path */
+}
+
+// ============================================================================
+// Elementwise / Reduce / Transpose
+// ============================================================================
+
+/** @brief GPU elementwise op over f64 arrays. Attempts the WGSL elementwise
+ *         kernel when the dispatch predicate allows it (the JS side routes
+ *         transcendentals to the f32 kernel, since df32 has no closed form
+ *         for them, and records that precision cliff in its diagnostics); on
+ *         refusal or error falls back to the stub backend's CPU scalar loop,
+ *         including its missing-`b` identity convention (0 for add/sub,
+ *         1 for mul/div).
+ *  @return 0 on success, -1 on invalid arguments. */
+int eshkol_gpu_elementwise_f64(EshkolGPUBuffer* a, EshkolGPUBuffer* b,
+                                EshkolGPUBuffer* out, uint64_t n,
+                                EshkolElementwiseOp op) {
+    if (!a || !out || n == 0) return -1;
+    const double* ap = static_cast<const double*>(a->host_ptr);
+    const double* bp = (b && b->host_ptr) ? static_cast<const double*>(b->host_ptr) : nullptr;
+    double* cp = static_cast<double*>(out->host_ptr);
+    if (!ap || !cp) return -1;
+
+    if (eshkol_gpu_should_use(static_cast<size_t>(n))) {
+        int rc = eshkol_webgpu_js_elementwise(
+            const_cast<double*>(ap), const_cast<double*>(bp), cp,
+            static_cast<double>(n), static_cast<int>(op));
+        if (rc == ESHKOL_WEBGPU_OK) return 0;
+    }
+
+    (void)ap; (void)bp; (void)cp; (void)n; (void)op;
+    return -1;  /* ordinary callers own the CPU fallback */
+}
+
+/** @brief GPU full reduction over an f64 array. Attempts the WGSL df32
+ *         reduction (whose in-workgroup tree combine makes GPU and CPU agree
+ *         to tolerance, not bitwise — as on Metal and CUDA); on refusal or
+ *         error falls back to the stub backend's sequential CPU accumulation.
+ *  @return 0 on success, -1 on invalid arguments. */
+int eshkol_gpu_reduce_f64(EshkolGPUBuffer* in, EshkolGPUBuffer* out,
+                           uint64_t n, EshkolReduceOp op) {
+    if (!in || !out || n == 0) return -1;
+    const double* inp = static_cast<const double*>(in->host_ptr);
+    double* outp = static_cast<double*>(out->host_ptr);
+    if (!inp || !outp) return -1;
+
+    if (eshkol_gpu_should_use(static_cast<size_t>(n))) {
+        int rc = eshkol_webgpu_js_reduce(const_cast<double*>(inp), outp,
+                                         static_cast<double>(n),
+                                         static_cast<int>(op));
+        if (rc == ESHKOL_WEBGPU_OK) return 0;
+    }
+
+    (void)inp; (void)outp; (void)n; (void)op;
+    return -1;  /* ordinary callers own the CPU fallback */
+}
+
+/** @brief Axis reduction over an f64 N-D tensor. Refused until a WGSL kernel
+ *         is certified; callers own the CPU fallback.
+ *  @return -1 while unsupported. */
+int eshkol_gpu_reduce_axis_f64(EshkolGPUBuffer* in, EshkolGPUBuffer* out,
+                                uint64_t rank, const uint64_t* shape,
+                                uint64_t axis, EshkolReduceOp op) {
+    (void)in; (void)out; (void)shape; (void)rank; (void)axis; (void)op;
+    return -1;  /* no certified WebGPU axis-reduction kernel */
+}
+
+/** @brief 2-D transpose of an f64 matrix. Refused until a WGSL kernel is
+ *         certified; callers own the CPU fallback.
+ *  @return -1 while unsupported. */
+int eshkol_gpu_transpose_f64(EshkolGPUBuffer* in, EshkolGPUBuffer* out,
+                              uint64_t rows, uint64_t cols) {
+    (void)in; (void)out; (void)rows; (void)cols;
+    return -1;  /* no certified WebGPU transpose kernel */
+}
+
+// ============================================================================
+// Softmax / Normalize
+// ============================================================================
+
+/** @brief Numerically-stable softmax over contiguous slices. Refused until a
+ *         WGSL kernel is certified; callers own the CPU fallback.
+ *  @return -1 while unsupported. */
+int eshkol_gpu_softmax_f64(EshkolGPUBuffer* in, EshkolGPUBuffer* out,
+                            uint64_t num_slices, uint64_t slice_len) {
+    (void)in; (void)out; (void)num_slices; (void)slice_len;
+    return -1;  /* no certified WebGPU softmax kernel */
+}
+
+/** @brief Layer normalisation over contiguous slices. Refused until a WGSL
+ *         kernel is certified; callers own the CPU fallback.
+ *  @return -1 while unsupported. */
+int eshkol_gpu_normalize_f64(EshkolGPUBuffer* in, EshkolGPUBuffer* out,
+                              uint64_t num_slices, uint64_t slice_len,
+                              double gamma, double beta, double epsilon) {
+    (void)in; (void)out; (void)num_slices; (void)slice_len;
+    (void)gamma; (void)beta; (void)epsilon;
+    return -1;  /* no certified WebGPU normalization kernel */
+}
+
+// ============================================================================
+// Runtime Integration
+// ============================================================================
+
+/** @brief Runtime matmul entry point used by generated code. Same shape as
+ *         the Metal backend: lazy init, threshold check, GPU attempt through
+ *         wrapped host buffers, CPU fallback on any failure. `dtype` is
+ *         ignored — there is no tensor-core path in WGSL, and storage is
+ *         already precision-reduced for the logical dtype, so plain f64
+ *         matmul stays correct. */
+void eshkol_matmul_dispatch(const double* A, const double* B, double* C,
+                             uint64_t M, uint64_t K, uint64_t N, int32_t /*dtype*/) {
+    /* Lazy GPU init — ensures g_active_backend is set before threshold check */
+    if (!g_gpu_initialized) {
+        eshkol_gpu_init();
+    }
+
+    size_t num_elements = static_cast<size_t>(M) * static_cast<size_t>(N);
+
+    if (eshkol_gpu_should_use(num_elements)) {
+        EshkolGPUBuffer buf_a, buf_b, buf_c;
+        if (eshkol_gpu_wrap_host((void*)A, M * K * sizeof(double), &buf_a) == 0 &&
+            eshkol_gpu_wrap_host((void*)B, K * N * sizeof(double), &buf_b) == 0 &&
+            eshkol_gpu_wrap_host((void*)C, M * N * sizeof(double), &buf_c) == 0) {
+
+            /* eshkol_gpu_matmul_f64() attempts the WGSL GEMM and, if the
+             * device declines or the kernel errors, runs the CPU path itself
+             * — so a 0 here means C is written either way. Wrapping is
+             * zero-copy on wasm (host_ptr aliases the caller's pointer), so
+             * no copy-back is needed, unlike the Metal backend. */
+            int rc = eshkol_gpu_matmul_f64(&buf_a, &buf_b, &buf_c, M, K, N);
+
+            eshkol_gpu_free(&buf_a);
+            eshkol_gpu_free(&buf_b);
+            eshkol_gpu_free(&buf_c);
+
+            if (rc == 0) return;
+        }
+        /* Wrapping or dispatch failed — fall through to CPU. */
+    }
+
+    /* CPU fallback. Do not re-enter eshkol_matmul_f64(): the ordinary
+     * dispatcher may select WebGPU again for a very large exact-tier call. */
+    webgpu_cpu_matmul(A, B, C, M, K, N);
+}
+
+/** @brief Runtime batched-matmul entry point used by generated code. There
+ *         is no batched WGSL GEMM kernel yet, so this dispatches to the CPU
+ *         batched f64 path. `dtype` is ignored (storage already
+ *         precision-reduced for the logical dtype).
+ *         FOLLOW-UP: a batched WGSL GEMM that issues one dispatch for all
+ *         `batch` products. */
+void eshkol_batch_matmul_dispatch(const double* a, const double* b, double* c,
+                                  int64_t batch, int64_t M, int64_t K, int64_t N,
+                                  int32_t /*dtype*/) {
+    eshkol_batch_matmul_f64(a, b, c, batch, M, K, N);
+}
+
+// ============================================================================
+// Backward Pass GPU Operations
+// ============================================================================
+
+/** @brief conv2d input-gradient backward pass: no WGSL kernel on this
+ *         backend, so it always fails and callers must take a CPU AD path.
+ *  @return -1 always. */
+int eshkol_gpu_conv2d_backward_input_f64(
+    EshkolGPUBuffer*, EshkolGPUBuffer*, EshkolGPUBuffer*,
+    uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+    uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) {
+    return -1;  // No WebGPU conv2d backward kernel
+}
+
+/** @brief conv2d kernel-gradient backward pass: no WGSL kernel on this
+ *         backend, so it always fails.
+ *  @return -1 always. */
+int eshkol_gpu_conv2d_backward_kernel_f64(
+    EshkolGPUBuffer*, EshkolGPUBuffer*, EshkolGPUBuffer*,
+    uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+    uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) {
+    return -1;
+}
+
+/** @brief batch-norm backward pass: no WGSL kernel on this backend, so it
+ *         always fails.
+ *  @return -1 always. */
+int eshkol_gpu_batchnorm_backward_f64(
+    EshkolGPUBuffer*, EshkolGPUBuffer*, EshkolGPUBuffer*,
+    EshkolGPUBuffer*, EshkolGPUBuffer*, EshkolGPUBuffer*,
+    EshkolGPUBuffer*, EshkolGPUBuffer*, uint64_t, uint64_t) {
+    return -1;
+}
+
+/** @brief layer-norm backward pass: no WGSL kernel on this backend, so it
+ *         always fails.
+ *  @return -1 always. */
+int eshkol_gpu_layernorm_backward_f64(
+    EshkolGPUBuffer*, EshkolGPUBuffer*, EshkolGPUBuffer*,
+    EshkolGPUBuffer*, EshkolGPUBuffer*, EshkolGPUBuffer*,
+    uint64_t, uint64_t) {
+    return -1;
+}
+
+#else  /* !__EMSCRIPTEN__ */
+
+/* This backend exists only for the Emscripten/wasm target; CMake selects it
+ * solely under `if(EMSCRIPTEN)`. Reaching here means a stray build picked the
+ * file up on a native host, where gpu_memory.mm, gpu_memory_cuda.cpp or
+ * gpu_memory_stub.cpp already provides the same symbols — so contribute
+ * nothing rather than producing duplicate definitions. */
+typedef int eshkol_gpu_webgpu_requires_emscripten;
+
+#endif /* __EMSCRIPTEN__ */

--- a/lib/backend/gpu/wgsl/double_float.wgsl
+++ b/lib/backend/gpu/wgsl/double_float.wgsl
@@ -1,0 +1,39 @@
+/* Canonical WGSL double-float helpers used by the WebGPU f64 emulation tier.
+ * OPAQUE is a per-invocation storage scratch array initialized by the host.
+ * The read-back is intentional: WGSL has no precise-math attribute, and a
+ * compiler may otherwise fold TwoSum's compensation term to zero. */
+@group(0) @binding(4) var<storage, read_write> OPAQUE: array<f32>;
+
+fn opaque_f32(x: f32, slot: u32) -> f32 {
+    OPAQUE[slot] = x;
+    return OPAQUE[slot];
+}
+
+fn two_sum(a: f32, b: f32, slot: u32) -> vec2<f32> {
+    let aa = opaque_f32(a, slot);
+    let bb0 = opaque_f32(b, slot);
+    let s = opaque_f32(aa + bb0, slot);
+    let bb = s - aa;
+    let err = opaque_f32((aa - (s - bb)) + (bb0 - bb), slot);
+    return vec2<f32>(s, err);
+}
+
+fn two_prod(a: f32, b: f32, slot: u32) -> vec2<f32> {
+    let aa = opaque_f32(a, slot);
+    let bb = opaque_f32(b, slot);
+    let p = opaque_f32(aa * bb, slot);
+    let e = opaque_f32(fma(aa, bb, -p), slot);
+    return vec2<f32>(p, e);
+}
+
+fn df_add(a: vec2<f32>, b: vec2<f32>, slot: u32) -> vec2<f32> {
+    let s = two_sum(a.x, b.x, slot);
+    let e = s.y + (a.y + b.y);
+    return two_sum(s.x, e, slot);
+}
+
+fn df_mul(a: vec2<f32>, b: vec2<f32>, slot: u32) -> vec2<f32> {
+    let p = two_prod(a.x, b.x, slot);
+    let e = p.y + fma(a.x, b.y, a.y * b.x);
+    return two_sum(p.x, e, slot);
+}

--- a/lib/backend/gpu/wgsl/elementwise_df32.wgsl
+++ b/lib/backend/gpu/wgsl/elementwise_df32.wgsl
@@ -1,0 +1,15 @@
+struct Params { n:u32, op:u32, pad0:u32, pad1:u32 };
+@group(0) @binding(0) var<storage,read> A:array<vec2<f32>>;
+@group(0) @binding(1) var<storage,read> B:array<vec2<f32>>;
+@group(0) @binding(2) var<storage,read_write> OUT:array<vec2<f32>>;
+@group(0) @binding(3) var<uniform> p:Params;
+@group(0) @binding(4) var<storage,read_write> OPAQUE:array<f32>;
+fn opaque_f32(x:f32,s:u32)->f32{OPAQUE[s]=x;return OPAQUE[s];}
+fn two_sum(a:f32,b:f32,s:u32)->vec2<f32>{let aa=opaque_f32(a,s);let bb=opaque_f32(b,s);let z=opaque_f32(aa+bb,s);let q=z-aa;return vec2<f32>(z,opaque_f32((aa-(z-q))+(bb-q),s));}
+fn two_prod(a:f32,b:f32,s:u32)->vec2<f32>{let aa=opaque_f32(a,s);let bb=opaque_f32(b,s);let q=opaque_f32(aa*bb,s);return vec2<f32>(q,opaque_f32(fma(aa,bb,-q),s));}
+fn add(a:vec2<f32>,b:vec2<f32>,s:u32)->vec2<f32>{let q=two_sum(a.x,b.x,s);return two_sum(q.x,q.y+a.y+b.y,s);}
+fn mul(a:vec2<f32>,b:vec2<f32>,s:u32)->vec2<f32>{let q=two_prod(a.x,b.x,s);return two_sum(q.x,q.y+fma(a.x,b.y,a.y*b.x),s);}
+fn neg(a:vec2<f32>)->vec2<f32>{return vec2<f32>(-a.x,-a.y);}
+fn div(a:vec2<f32>,b:vec2<f32>,s:u32)->vec2<f32>{let q=a.x/b.x;let r=add(a,neg(mul(vec2<f32>(q,0.0),b,s)),s);return two_sum(q,r.x/b.x,s);}
+@compute @workgroup_size(1,1,1)
+fn main(@builtin(global_invocation_id) gid:vec3<u32>){let i=gid.x;if(i>=p.n){return;}let a=A[i];let b=B[i];var r=vec2<f32>(0.0,0.0);switch(p.op){case 0u:{r=add(a,b,i);}case 1u:{r=add(a,neg(b),i);}case 2u:{r=mul(a,b,i);}case 3u:{r=div(a,b,i);}case 4u:{r=neg(a);}case 5u:{if(a.x<0.0){r=neg(a);}else{r=a;}}default:{r=vec2<f32>(0.0,0.0);}}OUT[i]=r;}

--- a/lib/backend/gpu/wgsl/elementwise_f32.wgsl
+++ b/lib/backend/gpu/wgsl/elementwise_f32.wgsl
@@ -1,0 +1,23 @@
+struct Params { n: u32, op: u32, pad0: u32, pad1: u32 };
+@group(0) @binding(0) var<storage, read> A: array<f32>;
+@group(0) @binding(1) var<storage, read> B: array<f32>;
+@group(0) @binding(2) var<storage, read_write> OUT: array<f32>;
+@group(0) @binding(3) var<uniform> p: Params;
+
+@compute @workgroup_size(64, 1, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x; if (i >= p.n) { return; }
+    let a = A[i]; let b = B[i]; var r: f32 = 0.0;
+    switch (p.op) {
+        case 0u: { r = a + b; } case 1u: { r = a - b; }
+        case 2u: { r = a * b; } case 3u: { r = a / b; }
+        case 4u: { r = -a; } case 5u: { r = abs(a); }
+        case 6u: { r = exp(a); } case 7u: { r = log(a); }
+        case 8u: { r = sin(a); } case 9u: { r = cos(a); }
+        case 10u: { r = tanh(a); } case 11u: { r = max(a, 0.0); }
+        case 12u: { r = 1.0 / (1.0 + exp(-a)); }
+        case 13u: { r = sqrt(a); } case 14u: { r = 1.0 / a; }
+        default: { r = 0.0; }
+    }
+    OUT[i] = r;
+}

--- a/lib/backend/gpu/wgsl/matmul_df32.wgsl
+++ b/lib/backend/gpu/wgsl/matmul_df32.wgsl
@@ -9,5 +9,5 @@ fn two_sum(a:f32,b:f32,s:u32)->vec2<f32>{let aa=opaque_f32(a,s);let bb0=opaque_f
 fn two_prod(a:f32,b:f32,s:u32)->vec2<f32>{let aa=opaque_f32(a,s);let bb=opaque_f32(b,s);let p=opaque_f32(aa*bb,s);return vec2<f32>(p,opaque_f32(fma(aa,bb,-p),s));}
 fn df_add(a:vec2<f32>,b:vec2<f32>,s:u32)->vec2<f32>{let z=two_sum(a.x,b.x,s);return two_sum(z.x,z.y+a.y+b.y,s);}
 fn df_mul(a:vec2<f32>,b:vec2<f32>,s:u32)->vec2<f32>{let p=two_prod(a.x,b.x,s);return two_sum(p.x,p.y+fma(a.x,b.y,a.y*b.x),s);}
-@compute @workgroup_size(1,1,1)
+@compute @workgroup_size(8,8,1)
 fn main(@builtin(global_invocation_id) gid:vec3<u32>){let row=gid.y;let col=gid.x;if(row>=d.M||col>=d.N){return;}let s=row*d.N+col;var acc=vec2<f32>(0.0,0.0);for(var k=0u;k<d.K;k=k+1u){acc=df_add(acc,df_mul(A[row*d.K+k],B[k*d.N+col],s),s);}C[row*d.N+col]=acc;}

--- a/lib/backend/gpu/wgsl/matmul_df32.wgsl
+++ b/lib/backend/gpu/wgsl/matmul_df32.wgsl
@@ -1,0 +1,13 @@
+struct Dims { M: u32, K: u32, N: u32, pad: u32 };
+@group(0) @binding(0) var<storage, read> A: array<vec2<f32>>;
+@group(0) @binding(1) var<storage, read> B: array<vec2<f32>>;
+@group(0) @binding(2) var<storage, read_write> C: array<vec2<f32>>;
+@group(0) @binding(3) var<uniform> d: Dims;
+@group(0) @binding(4) var<storage, read_write> OPAQUE: array<f32>;
+fn opaque_f32(x: f32, slot: u32) -> f32 { OPAQUE[slot] = x; return OPAQUE[slot]; }
+fn two_sum(a:f32,b:f32,s:u32)->vec2<f32>{let aa=opaque_f32(a,s);let bb0=opaque_f32(b,s);let z=opaque_f32(aa+bb0,s);let q=z-aa;return vec2<f32>(z,opaque_f32((aa-(z-q))+(bb0-q),s));}
+fn two_prod(a:f32,b:f32,s:u32)->vec2<f32>{let aa=opaque_f32(a,s);let bb=opaque_f32(b,s);let p=opaque_f32(aa*bb,s);return vec2<f32>(p,opaque_f32(fma(aa,bb,-p),s));}
+fn df_add(a:vec2<f32>,b:vec2<f32>,s:u32)->vec2<f32>{let z=two_sum(a.x,b.x,s);return two_sum(z.x,z.y+a.y+b.y,s);}
+fn df_mul(a:vec2<f32>,b:vec2<f32>,s:u32)->vec2<f32>{let p=two_prod(a.x,b.x,s);return two_sum(p.x,p.y+fma(a.x,b.y,a.y*b.x),s);}
+@compute @workgroup_size(1,1,1)
+fn main(@builtin(global_invocation_id) gid:vec3<u32>){let row=gid.y;let col=gid.x;if(row>=d.M||col>=d.N){return;}let s=row*d.N+col;var acc=vec2<f32>(0.0,0.0);for(var k=0u;k<d.K;k=k+1u){acc=df_add(acc,df_mul(A[row*d.K+k],B[k*d.N+col],s),s);}C[row*d.N+col]=acc;}

--- a/lib/backend/gpu/wgsl/matmul_f32.wgsl
+++ b/lib/backend/gpu/wgsl/matmul_f32.wgsl
@@ -1,0 +1,17 @@
+struct Dims { M: u32, K: u32, N: u32, pad: u32 };
+@group(0) @binding(0) var<storage, read> A: array<f32>;
+@group(0) @binding(1) var<storage, read> B: array<f32>;
+@group(0) @binding(2) var<storage, read_write> C: array<f32>;
+@group(0) @binding(3) var<uniform> d: Dims;
+
+@compute @workgroup_size(8, 8, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let row = gid.y;
+    let col = gid.x;
+    if (row >= d.M || col >= d.N) { return; }
+    var acc: f32 = 0.0;
+    for (var k: u32 = 0u; k < d.K; k = k + 1u) {
+        acc = acc + A[row * d.K + k] * B[k * d.N + col];
+    }
+    C[row * d.N + col] = acc;
+}

--- a/lib/backend/gpu/wgsl/reduce_df32.wgsl
+++ b/lib/backend/gpu/wgsl/reduce_df32.wgsl
@@ -1,0 +1,16 @@
+/* Deterministic one-invocation partial reduction. The host combines the
+ * partial df32 values in f64 and refuses any operation outside its gate
+ * tolerance contract. */
+@group(0) @binding(0) var<storage,read> IN:array<vec2<f32>>;
+@group(0) @binding(1) var<storage,read_write> OUT:array<vec2<f32>>;
+struct Params{n:u32,op:u32,per_group:u32,pad:u32};
+@group(0) @binding(2) var<uniform> p:Params;
+@group(0) @binding(4) var<storage,read_write> OPAQUE:array<f32>;
+fn opaque(x:f32,s:u32)->f32{OPAQUE[s]=x;return OPAQUE[s];}
+fn ts(a:f32,b:f32,s:u32)->vec2<f32>{let aa=opaque(a,s);let bb=opaque(b,s);let z=opaque(aa+bb,s);let q=z-aa;return vec2<f32>(z,opaque((aa-(z-q))+(bb-q),s));}
+fn add(a:vec2<f32>,b:vec2<f32>,s:u32)->vec2<f32>{let q=ts(a.x,b.x,s);return ts(q.x,q.y+a.y+b.y,s);}
+fn mul(a:vec2<f32>,b:vec2<f32>,s:u32)->vec2<f32>{let aa=opaque(a.x,s);let bb=opaque(b.x,s);let p0=opaque(aa*bb,s);let e=opaque(fma(aa,bb,-p0),s);return ts(p0,e+fma(a.x,b.y,a.y*b.x),s);}
+fn ident(op:u32)->vec2<f32>{switch(op){case 1u:{return vec2<f32>(1.0,0.0);}case 2u:{return vec2<f32>(3.4028235e38,0.0);}case 3u:{return vec2<f32>(-3.4028235e38,0.0);}default:{return vec2<f32>(0.0,0.0);}}}
+fn combine(op:u32,a:vec2<f32>,b:vec2<f32>,s:u32)->vec2<f32>{switch(op){case 1u:{return mul(a,b,s);}case 2u:{if(b.x<a.x){return b;}return a;}case 3u:{if(b.x>a.x){return b;}return a;}default:{return add(a,b,s);}}}
+@compute @workgroup_size(1,1,1)
+fn main(@builtin(global_invocation_id) gid:vec3<u32>){let g=gid.x;let start=g*p.per_group;var end=start+p.per_group;if(end>p.n){end=p.n;}var acc=ident(p.op);var i=start;while(i<end){acc=combine(p.op,acc,IN[i],g);i=i+1u;}OUT[g]=acc;}

--- a/scripts/lib/webgpu_diff_runner.mjs
+++ b/scripts/lib/webgpu_diff_runner.mjs
@@ -54,17 +54,17 @@ const CORRUPTIONS = {
         'acc = acc + A[row * d.K + k] * B[col * d.K + k];',
     ],
     gemm_df32: [
-        /acc = df_add\(acc, df_mul\(A\[row \* d\.K \+ k\], B\[k \* d\.N \+ col\]\)\);/,
-        'acc = df_add(acc, df_mul(A[row * d.K + k], B[col * d.K + k]));',
+        /acc = df_add\(acc, df_mul\(A\[row \* d\.K \+ k\], B\[k \* d\.N \+ col\], slot\), slot\);/,
+        'acc = df_add(acc, df_mul(A[row * d.K + k], B[col * d.K + k], slot), slot);',
     ],
     /* Elementwise: make ADD compute a - b. */
     elem: [/case 0u:  \{ r = a \+ b; \}/, 'case 0u:  { r = a - b; }'],
-    elem_df32: [/case 0u: \{ r = df_add\(a, b\); \}/, 'case 0u: { r = df_add(a, df_neg(b)); }'],
-    /* Reduction: drop the last lane from the tree combine. */
-    reduce: [/while \(stride > 0u\) \{/, 'while (stride > 1u) {'],
+    elem_df32: [/case 0u: \{ r = df_add\(a, b, i\); \}/, 'case 0u: { r = df_add(a, df_neg(b), i); }'],
+    /* Reduction: make every partial block empty, producing a wrong identity. */
+    reduce: [/var hi = block_start \+ p\.per_group;/, 'var hi = block_start;'],
     /* Double-float core: break two_prod's error term, which silently degrades
      * df32 to f32 -- the subtlest realistic corruption of the set. */
-    two_prod: [/let e = fma\(a, b, -p\);/, 'let e = 0.0;'],
+    two_prod: [/let e = opaque_f32\(fma\(aa, bb, -p\), slot\);/, 'let e = opaque_f32(0.0, slot);'],
 };
 
 function loadModuleSource() {

--- a/scripts/lib/webgpu_diff_runner.mjs
+++ b/scripts/lib/webgpu_diff_runner.mjs
@@ -1,0 +1,338 @@
+/*
+ * WebGPU differential runner.
+ *
+ * Drives headless Chrome (Playwright, channel=chrome -> Metal-backed WebGPU on
+ * macOS) and diffs every WGSL kernel in web/eshkol-webgpu.js against the CPU
+ * reference in the same module, over data laid out in a real WebAssembly.Memory
+ * so the pointer path under test is the one generated code actually uses.
+ *
+ * Two properties make this a gate rather than a demo:
+ *
+ *   1. NON-VACUITY. The backend counts GPU dispatches. A run where the GPU
+ *      served zero cases is reported FAIL, not PASS -- the failure mode where a
+ *      "GPU gate" silently measured the CPU against itself.
+ *
+ *   2. RED-PROOF. --corrupt=<kernel> rewrites one WGSL kernel before the module
+ *      is injected, so the gate can be shown to go red on a deliberately broken
+ *      kernel. The corruption lives here in the harness, never in the shipped
+ *      module.
+ *
+ * The page is served over http://localhost because WebGPU requires a secure
+ * context; a data: or file: URL reports navigator.gpu === undefined.
+ *
+ */
+
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, '..', '..');
+const MODULE_PATH = path.join(REPO, 'web', 'eshkol-webgpu.js');
+
+/* ---- args ---- */
+const argv = process.argv.slice(2);
+const opt = (name, dflt) => {
+    const hit = argv.find((a) => a.startsWith('--' + name + '='));
+    return hit ? hit.slice(name.length + 3) : dflt;
+};
+const CORRUPT = opt('corrupt', null);
+const JSON_OUT = argv.includes('--json');
+const HEADED = argv.includes('--headed');
+
+/* ---- kernel corruptions for the red-proof ----
+ * Each entry is a [pattern, replacement] applied to the module source. They are
+ * deliberately small and plausible -- a wrong index, a dropped term -- rather
+ * than syntax errors, so the gate is shown to catch WRONG RESULTS and not
+ * merely a shader that fails to compile. */
+const CORRUPTIONS = {
+    /* GEMM f32/df32 share this indexing line; swapping B's stride transposes
+     * the second operand. */
+    gemm: [
+        /acc = acc \+ A\[row \* d\.K \+ k\] \* B\[k \* d\.N \+ col\];/,
+        'acc = acc + A[row * d.K + k] * B[col * d.K + k];',
+    ],
+    gemm_df32: [
+        /acc = df_add\(acc, df_mul\(A\[row \* d\.K \+ k\], B\[k \* d\.N \+ col\]\)\);/,
+        'acc = df_add(acc, df_mul(A[row * d.K + k], B[col * d.K + k]));',
+    ],
+    /* Elementwise: make ADD compute a - b. */
+    elem: [/case 0u:  \{ r = a \+ b; \}/, 'case 0u:  { r = a - b; }'],
+    elem_df32: [/case 0u: \{ r = df_add\(a, b\); \}/, 'case 0u: { r = df_add(a, df_neg(b)); }'],
+    /* Reduction: drop the last lane from the tree combine. */
+    reduce: [/while \(stride > 0u\) \{/, 'while (stride > 1u) {'],
+    /* Double-float core: break two_prod's error term, which silently degrades
+     * df32 to f32 -- the subtlest realistic corruption of the set. */
+    two_prod: [/let e = fma\(a, b, -p\);/, 'let e = 0.0;'],
+};
+
+function loadModuleSource() {
+    let src = fs.readFileSync(MODULE_PATH, 'utf8');
+    if (!CORRUPT) return { src, applied: null };
+    const c = CORRUPTIONS[CORRUPT];
+    if (!c) {
+        console.error(`unknown corruption "${CORRUPT}"; known: ${Object.keys(CORRUPTIONS).join(', ')}`);
+        process.exit(2);
+    }
+    if (!c[0].test(src)) {
+        console.error(`corruption "${CORRUPT}" did not match the module source -- ` +
+                      'the kernel it targets has changed. Fix the pattern in ' +
+                      'scripts/lib/webgpu_diff_runner.mjs rather than skipping the red-proof.');
+        process.exit(2);
+    }
+    src = src.replace(c[0], c[1]);
+    return { src, applied: CORRUPT };
+}
+
+/* ---- the in-page differential ----
+ * Runs entirely inside the browser: builds a WebAssembly.Memory, writes the
+ * operands at real byte offsets, runs the WGSL kernel and the module's own CPU
+ * reference over the same bytes, and returns both results. */
+async function runInPage(page, cases) {
+    return page.evaluate(async ({ cases }) => {
+        const G = globalThis.EshkolWebGPU;
+        if (!G) return { fatal: 'eshkol-webgpu.js did not load' };
+        if (!navigator.gpu) return { skip: 'navigator.gpu unavailable' };
+
+        const created = await G.create({ precision: 'high', threshold: 1 });
+        if (!created.ok) {
+            return created.unsupported
+                ? { unsupported: created.reason }
+                : { skip: created.reason };
+        }
+        const be = created.backend;
+        if (!be.supportsOperation('matmul')) {
+            return { unsupported: 'UNSUPPORTED: WebGPU df32 matmul is not certified at GPU_GATE_TOL=1e-9' };
+        }
+
+        /* 16 MB of linear memory: enough for every small shape below, and the
+         * same object type generated wasm hands the runtime. */
+        const memory = new WebAssembly.Memory({ initial: 256 });
+        be.setMemory(memory);
+        const fakeMem = { buffer: memory.buffer };
+
+        const results = [];
+        let bump = 64;
+        const alloc = (n) => { const p = bump; bump += n * 8; bump = (bump + 15) & ~15; return p; };
+        const rng = (seed) => { let s = seed >>> 0; return () => { s = (s * 1664525 + 1013904223) >>> 0; return s / 4294967296; }; };
+
+        for (const c of cases) {
+            bump = 64;
+            const r = rng(c.seed || 12345);
+            be.precision = c.tier;
+            const before = be.dispatchCount;
+            let entry = { name: c.name, tier: c.tier, kind: c.kind };
+
+            try {
+                if (c.kind === 'gemm') {
+                    const { M, K, N } = c;
+                    const aP = alloc(M * K), bP = alloc(K * N);
+                    const gP = alloc(M * N), cP = alloc(M * N);
+                    const A = new Float64Array(memory.buffer, aP, M * K);
+                    const B = new Float64Array(memory.buffer, bP, K * N);
+                    for (let i = 0; i < M * K; i++) A[i] = r() * 2 - 1;
+                    for (let i = 0; i < K * N; i++) B[i] = r() * 2 - 1;
+                    await be.matmulF64(aP, bP, gP, M, K, N);
+                    G.cpu.matmul(fakeMem, aP, bP, cP, M, K, N);
+                    entry.gpu = Array.from(new Float64Array(memory.buffer, gP, M * N));
+                    entry.cpu = Array.from(new Float64Array(memory.buffer, cP, M * N));
+                } else if (c.kind === 'elementwise') {
+                    const n = c.n;
+                    const aP = alloc(n), bP = alloc(n), gP = alloc(n), cP = alloc(n);
+                    const A = new Float64Array(memory.buffer, aP, n);
+                    const B = new Float64Array(memory.buffer, bP, n);
+                    for (let i = 0; i < n; i++) A[i] = r() * 4 - 2;
+                    /* keep the divisor away from zero so DIV is well conditioned */
+                    for (let i = 0; i < n; i++) B[i] = (r() * 2 - 1) + (r() > 0.5 ? 1.5 : -1.5);
+                    await be.elementwiseF64(aP, bP, gP, n, c.op);
+                    G.cpu.elementwise(fakeMem, aP, bP, cP, n, c.op);
+                    entry.gpu = Array.from(new Float64Array(memory.buffer, gP, n));
+                    entry.cpu = Array.from(new Float64Array(memory.buffer, cP, n));
+                } else if (c.kind === 'reduce') {
+                    const n = c.n;
+                    const iP = alloc(n), gP = alloc(1), cP = alloc(1);
+                    const I = new Float64Array(memory.buffer, iP, n);
+                    for (let i = 0; i < n; i++) {
+                        I[i] = c.op === 1 ? (0.98 + r() * 0.04) : (r() * 2 - 1);
+                    }
+                    await be.reduceF64(iP, gP, n, c.op);
+                    G.cpu.reduce(fakeMem, iP, cP, n, c.op);
+                    entry.gpu = Array.from(new Float64Array(memory.buffer, gP, 1));
+                    entry.cpu = Array.from(new Float64Array(memory.buffer, cP, 1));
+                }
+                entry.dispatched = be.dispatchCount - before;
+            } catch (e) {
+                entry.error = String(e);
+            }
+            results.push(entry);
+        }
+
+        return {
+            results,
+            dispatchCount: be.dispatchCount,
+            fallbackCount: be.fallbackCount,
+            fmaFused: be.fmaFused,
+            diagnostics: be.diagnostics,
+            adapter: created.adapter && created.adapter.info
+                ? `${created.adapter.info.vendor}/${created.adapter.info.architecture}`
+                : 'unknown',
+        };
+    }, { cases });
+}
+
+/* ---- gate tolerance ----
+ * This runner is the browser counterpart of tests/gpu/gpu_correctness_gate.sh.
+ * It has one contract: a GPU result is acceptable only at GPU_GATE_TOL. The
+ * f32 tier is intentionally not included because it cannot promise 1e-9. */
+const GPU_GATE_TOL = Number(process.env.GPU_GATE_TOL || '1e-9');
+if (!Number.isFinite(GPU_GATE_TOL) || GPU_GATE_TOL <= 0) {
+    console.error('webgpu_diff_runner: invalid GPU_GATE_TOL=' + process.env.GPU_GATE_TOL);
+    process.exit(2);
+}
+const TOL = { high: GPU_GATE_TOL };
+
+function compare(entry) {
+    if (entry.error) return { ok: false, why: 'threw: ' + entry.error };
+    if (!entry.gpu || !entry.cpu) return { ok: false, why: 'no result produced' };
+    if (entry.dispatched !== 1) {
+        return { ok: false, why: `expected exactly 1 GPU dispatch, saw ${entry.dispatched} ` +
+                                 '(a case served by the CPU proves nothing)' };
+    }
+    let worst = 0, at = -1;
+    let scale = 0;
+    for (let i = 0; i < entry.cpu.length; i++) scale = Math.max(scale, Math.abs(entry.cpu[i]));
+    const denom = Math.max(scale, 1e-12);
+    for (let i = 0; i < entry.cpu.length; i++) {
+        const g = entry.gpu[i], c = entry.cpu[i];
+        if (!Number.isFinite(g) || !Number.isFinite(c)) {
+            if (g !== c) return { ok: false, why: `non-finite mismatch at ${i}: ${g} vs ${c}` };
+            continue;
+        }
+        const e = Math.abs(g - c) / denom;
+        if (e > worst) { worst = e; at = i; }
+    }
+    const tol = TOL[entry.tier];
+    return {
+        ok: worst <= tol,
+        worst, at, tol,
+        why: worst <= tol ? '' :
+            `rel err ${worst.toExponential(3)} at [${at}] exceeds ${entry.tier} tolerance ${tol.toExponential(1)}`,
+    };
+}
+
+/* ---- case matrix (small shapes only: this runs in a browser under the RSS
+ * discipline, and correctness of the kernel does not need large N) ---- */
+const CASES = [];
+for (const tier of ['high']) {
+    /* Shapes deliberately include non-multiples of the 8x8 workgroup tile so
+     * the bounds guards in the kernel are exercised. */
+    for (const [M, K, N] of [[8, 8, 8], [16, 32, 16], [33, 17, 9], [1, 64, 1]]) {
+        CASES.push({ name: `gemm_${M}x${K}x${N}`, kind: 'gemm', tier, M, K, N, seed: M * 131 + K * 17 + N });
+    }
+    for (const [op, nm] of [[0, 'add'], [1, 'sub'], [2, 'mul'], [3, 'div'], [4, 'neg'], [5, 'abs']]) {
+        CASES.push({ name: `elem_${nm}`, kind: 'elementwise', tier, n: 1000, op, seed: 900 + op });
+    }
+    for (const [op, nm] of [[0, 'sum'], [1, 'prod'], [2, 'min'], [3, 'max'], [4, 'mean']]) {
+        CASES.push({ name: `reduce_${nm}`, kind: 'reduce', tier, n: 4096, op, seed: 700 + op });
+    }
+}
+
+/* ---- main ---- */
+let playwright;
+try {
+    playwright = await import('playwright');
+} catch {
+    try {
+        playwright = await import(path.join(REPO, '.scratch', 'node_modules', 'playwright', 'index.js'));
+    } catch {
+        console.error('webgpu_diff_runner: SKIP - playwright is not installed.');
+        console.error('  npm install playwright   (channel=chrome uses the system Chrome; no browser download)');
+        process.exit(77);
+    }
+}
+
+const { src, applied } = loadModuleSource();
+
+const server = http.createServer((req, res) => {
+    if (req.url.startsWith('/eshkol-webgpu.js')) {
+        res.writeHead(200, { 'Content-Type': 'text/javascript' });
+        res.end(src);
+        return;
+    }
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end('<!doctype html><html><head><meta charset="utf-8">' +
+            '<script src="/eshkol-webgpu.js"></script></head><body></body></html>');
+});
+await new Promise((r) => server.listen(0, 'localhost', r));
+const port = server.address().port;
+
+let browser, out;
+try {
+    browser = await playwright.chromium.launch({
+        channel: 'chrome',
+        headless: !HEADED,
+        args: ['--enable-unsafe-webgpu'],
+    });
+    const page = await browser.newPage();
+    const consoleErrors = [];
+    page.on('pageerror', (e) => consoleErrors.push(String(e)));
+    /* localhost is a secure context; WebGPU is unavailable on data:/file:. */
+    await page.goto(`http://localhost:${port}/`);
+    out = await runInPage(page, CASES);
+    if (consoleErrors.length) out.pageErrors = consoleErrors;
+} catch (e) {
+    console.error('webgpu_diff_runner: SKIP - could not drive Chrome: ' + e);
+    process.exit(77);
+} finally {
+    if (browser) await browser.close();
+    server.close();
+}
+
+if (out.skip) {
+    console.error('webgpu_diff_runner: SKIP - ' + out.skip);
+    process.exit(77);
+}
+if (out.unsupported) {
+    console.log('UNSUPPORTED webgpu_diff - ' + out.unsupported);
+    process.exit(77);
+}
+if (out.fatal) {
+    console.error('webgpu_diff_runner: ERROR - ' + out.fatal);
+    process.exit(2);
+}
+
+const report = { adapter: out.adapter, corrupted: applied, cases: [], dispatchCount: out.dispatchCount };
+let failed = 0;
+for (const e of out.results) {
+    const v = compare(e);
+    report.cases.push({ name: e.name, tier: e.tier, ok: v.ok, worst: v.worst, tol: v.tol,
+                        at: v.at, gpu: v.at >= 0 ? e.gpu?.[v.at] : undefined,
+                        cpu: v.at >= 0 ? e.cpu?.[v.at] : undefined, why: v.why });
+    if (!v.ok) failed++;
+    const id = `webgpu_diff/${e.tier}/${e.name}`;
+    if (v.ok) console.log(`PASSED ${id} (rel err ${Number(v.worst).toExponential(2)} <= ${v.tol.toExponential(1)})`);
+    else console.log(`FAILED ${id} - ${v.why}`);
+}
+
+/* Non-vacuity: a run in which the GPU served nothing is a failed gate. */
+if (out.dispatchCount === 0) {
+    console.log('FAILED webgpu_diff/non_vacuity - zero GPU dispatches; ' +
+                'the CPU was compared against itself');
+    failed++;
+} else {
+    console.log(`PASSED webgpu_diff/non_vacuity (${out.dispatchCount} GPU dispatches, ` +
+                `${out.fallbackCount} CPU fallbacks)`);
+}
+if (!out.fmaFused) {
+    console.log('NOTE webgpu_diff/fma - fma() is not fused on this adapter; df32 tier was downgraded');
+}
+for (const d of out.diagnostics || []) console.log('NOTE ' + d);
+if (out.pageErrors) for (const e of out.pageErrors) console.log('NOTE page error: ' + e);
+
+report.failed = failed;
+if (JSON_OUT) console.log('JSON ' + JSON.stringify(report));
+
+console.log(`\nadapter=${out.adapter} cases=${out.results.length} failed=${failed}` +
+            (applied ? ` corrupted=${applied}` : ''));
+process.exit(failed === 0 ? 0 : 1);

--- a/scripts/lib/webgpu_diff_runner.mjs
+++ b/scripts/lib/webgpu_diff_runner.mjs
@@ -40,6 +40,8 @@ const opt = (name, dflt) => {
 const CORRUPT = opt('corrupt', null);
 const JSON_OUT = argv.includes('--json');
 const HEADED = argv.includes('--headed');
+const REGRESSIONS = argv.includes('--regressions');
+const FAST_REGRESSION_TOL = 1e-4;
 
 /* ---- kernel corruptions for the red-proof ----
  * Each entry is a [pattern, replacement] applied to the module source. They are
@@ -90,12 +92,16 @@ function loadModuleSource() {
  * operands at real byte offsets, runs the WGSL kernel and the module's own CPU
  * reference over the same bytes, and returns both results. */
 async function runInPage(page, cases) {
-    return page.evaluate(async ({ cases }) => {
+    return page.evaluate(async ({ cases, regression, gateTolerance }) => {
         const G = globalThis.EshkolWebGPU;
         if (!G) return { fatal: 'eshkol-webgpu.js did not load' };
         if (!navigator.gpu) return { skip: 'navigator.gpu unavailable' };
 
-        const created = await G.create({ precision: 'high', threshold: 1 });
+        const created = await G.create({
+            precision: regression ? 'fast' : 'high',
+            gateTolerance,
+            threshold: 1
+        });
         if (!created.ok) {
             return created.unsupported
                 ? { unsupported: created.reason }
@@ -103,7 +109,9 @@ async function runInPage(page, cases) {
         }
         const be = created.backend;
         if (!be.supportsOperation('matmul')) {
-            return { unsupported: 'UNSUPPORTED: WebGPU df32 matmul is not certified at GPU_GATE_TOL=1e-9' };
+            return { unsupported: regression
+                ? 'UNSUPPORTED: WebGPU fast matmul opt-in is not available at gateTolerance=' + gateTolerance
+                : 'UNSUPPORTED: WebGPU df32 matmul is not certified at GPU_GATE_TOL=1e-9' };
         }
 
         /* 16 MB of linear memory: enough for every small shape below, and the
@@ -131,8 +139,8 @@ async function runInPage(page, cases) {
                     const gP = alloc(M * N), cP = alloc(M * N);
                     const A = new Float64Array(memory.buffer, aP, M * K);
                     const B = new Float64Array(memory.buffer, bP, K * N);
-                    for (let i = 0; i < M * K; i++) A[i] = r() * 2 - 1;
-                    for (let i = 0; i < K * N; i++) B[i] = r() * 2 - 1;
+                    for (let i = 0; i < M * K; i++) A[i] = c.values === 'ones' ? 1 : r() * 2 - 1;
+                    for (let i = 0; i < K * N; i++) B[i] = c.values === 'ones' ? 1 : r() * 2 - 1;
                     await be.matmulF64(aP, bP, gP, M, K, N);
                     G.cpu.matmul(fakeMem, aP, bP, cP, M, K, N);
                     entry.gpu = Array.from(new Float64Array(memory.buffer, gP, M * N));
@@ -178,19 +186,21 @@ async function runInPage(page, cases) {
                 ? `${created.adapter.info.vendor}/${created.adapter.info.architecture}`
                 : 'unknown',
         };
-    }, { cases });
+    }, { cases, regression: REGRESSIONS, gateTolerance: REGRESSIONS ? FAST_REGRESSION_TOL : GPU_GATE_TOL });
 }
 
 /* ---- gate tolerance ----
  * This runner is the browser counterpart of tests/gpu/gpu_correctness_gate.sh.
  * It has one contract: a GPU result is acceptable only at GPU_GATE_TOL. The
- * f32 tier is intentionally not included because it cannot promise 1e-9. */
+ * The normal matrix excludes f32 because it cannot promise 1e-9; the
+ * --regressions matrix separately exercises its explicit reduced-precision
+ * contract. */
 const GPU_GATE_TOL = Number(process.env.GPU_GATE_TOL || '1e-9');
 if (!Number.isFinite(GPU_GATE_TOL) || GPU_GATE_TOL <= 0) {
     console.error('webgpu_diff_runner: invalid GPU_GATE_TOL=' + process.env.GPU_GATE_TOL);
     process.exit(2);
 }
-const TOL = { high: GPU_GATE_TOL };
+const TOL = { high: GPU_GATE_TOL, fast: FAST_REGRESSION_TOL };
 
 function compare(entry) {
     if (entry.error) return { ok: false, why: 'threw: ' + entry.error };
@@ -224,17 +234,23 @@ function compare(entry) {
 /* ---- case matrix (small shapes only: this runs in a browser under the RSS
  * discipline, and correctness of the kernel does not need large N) ---- */
 const CASES = [];
-for (const tier of ['high']) {
+for (const tier of REGRESSIONS ? ['fast'] : ['high']) {
     /* Shapes deliberately include non-multiples of the 8x8 workgroup tile so
      * the bounds guards in the kernel are exercised. */
     for (const [M, K, N] of [[8, 8, 8], [16, 32, 16], [33, 17, 9], [1, 64, 1]]) {
         CASES.push({ name: `gemm_${M}x${K}x${N}`, kind: 'gemm', tier, M, K, N, seed: M * 131 + K * 17 + N });
     }
-    for (const [op, nm] of [[0, 'add'], [1, 'sub'], [2, 'mul'], [3, 'div'], [4, 'neg'], [5, 'abs']]) {
-        CASES.push({ name: `elem_${nm}`, kind: 'elementwise', tier, n: 1000, op, seed: 900 + op });
+    if (REGRESSIONS) {
+        CASES.unshift({ name: 'gemm_fast_8x8_8_ones', kind: 'gemm', tier,
+                        M: 8, K: 8, N: 8, values: 'ones', seed: 1 });
     }
-    for (const [op, nm] of [[0, 'sum'], [1, 'prod'], [2, 'min'], [3, 'max'], [4, 'mean']]) {
-        CASES.push({ name: `reduce_${nm}`, kind: 'reduce', tier, n: 4096, op, seed: 700 + op });
+    if (!REGRESSIONS) {
+        for (const [op, nm] of [[0, 'add'], [1, 'sub'], [2, 'mul'], [3, 'div'], [4, 'neg'], [5, 'abs']]) {
+            CASES.push({ name: `elem_${nm}`, kind: 'elementwise', tier, n: 1000, op, seed: 900 + op });
+        }
+        for (const [op, nm] of [[0, 'sum'], [1, 'prod'], [2, 'min'], [3, 'max'], [4, 'mean']]) {
+            CASES.push({ name: `reduce_${nm}`, kind: 'reduce', tier, n: 4096, op, seed: 700 + op });
+        }
     }
 }
 
@@ -308,11 +324,17 @@ for (const e of out.results) {
     const v = compare(e);
     report.cases.push({ name: e.name, tier: e.tier, ok: v.ok, worst: v.worst, tol: v.tol,
                         at: v.at, gpu: v.at >= 0 ? e.gpu?.[v.at] : undefined,
-                        cpu: v.at >= 0 ? e.cpu?.[v.at] : undefined, why: v.why });
+                        cpu: v.at >= 0 ? e.cpu?.[v.at] : undefined,
+                        nonzero: e.gpu ? e.gpu.filter((value) => value !== 0).length : undefined,
+                        first: e.gpu ? e.gpu.slice(0, 8) : undefined, why: v.why });
     if (!v.ok) failed++;
     const id = `webgpu_diff/${e.tier}/${e.name}`;
     if (v.ok) console.log(`PASSED ${id} (rel err ${Number(v.worst).toExponential(2)} <= ${v.tol.toExponential(1)})`);
     else console.log(`FAILED ${id} - ${v.why}`);
+    if (REGRESSIONS && e.name === 'gemm_fast_8x8_8_ones') {
+        console.log(`DETAIL ${id} nonzero=${e.gpu?.filter((value) => value !== 0).length}/${e.gpu?.length} ` +
+                    `first=[${e.gpu?.slice(0, 8).join(',')}]`);
+    }
 }
 
 /* Non-vacuity: a run in which the GPU served nothing is a failed gate. */

--- a/site/static/eshkol-runtime.js
+++ b/site/static/eshkol-runtime.js
@@ -42,6 +42,18 @@ class EshkolRuntime {
         return { rawInstance: instance, exports };
     }
 
+    // Export facades do not wrap function-table entries. Browser callbacks
+    // therefore apply the JSPI promising wrapper at the callback boundary.
+    invokeWasmCallback(callbackFuncPtr, ...args) {
+        const table = this.instance?.exports?.__indirect_function_table;
+        const fn = table && table.get(callbackFuncPtr);
+        if (typeof fn !== 'function') throw new Error('missing WASM callback ' + callbackFuncPtr);
+        const G = (typeof globalThis !== 'undefined') && globalThis.EshkolWebGPU;
+        const entry = G && typeof G.promisingEntry === 'function'
+            ? G.promisingEntry(fn) : fn;
+        return entry(...args);
+    }
+
     // === Handle System ===
 
     createHandle(obj) {
@@ -1171,11 +1183,19 @@ class EshkolRuntime {
                     const el = rt.getHandle(elHandle);
                     if (!el || !rt.instance) return 0;
                     const eventName = rt.readString(eventPtr);
-                    const fn = rt.instance.exports.__indirect_function_table.get(callbackFuncPtr);
-                    if (!fn) return 0;
                     const handler = (e) => {
                         const eventHandle = rt.createHandle(e);
-                        try { fn(eventHandle); } catch(err) { console.error('Event handler error:', err); }
+                        try {
+                            const result = rt.invokeWasmCallback(callbackFuncPtr, eventHandle);
+                            if (result && typeof result.then === 'function') {
+                                result.catch((err) => console.error('Event handler error:', err))
+                                    .finally(() => rt.releaseHandle(eventHandle));
+                                return;
+                            }
+                        } catch (err) {
+                            console.error('Event handler error:', err);
+                        }
+                        rt.releaseHandle(eventHandle);
                     };
                     el.addEventListener(eventName, handler);
                     return 1;
@@ -1280,14 +1300,26 @@ class EshkolRuntime {
                 // Timers & Animation
                 web_set_timeout: (callbackFuncPtr, ms) => {
                     if (!rt.instance) return 0;
-                    const fn = rt.instance.exports.__indirect_function_table.get(callbackFuncPtr);
-                    return setTimeout(() => { try { fn(0); } catch(e) { console.error(e); } }, ms);
+                    return setTimeout(() => {
+                        try {
+                            const result = rt.invokeWasmCallback(callbackFuncPtr, 0);
+                            if (result && typeof result.then === 'function') {
+                                result.catch((e) => console.error('Timeout callback error:', e));
+                            }
+                        } catch(e) { console.error('Timeout callback error:', e); }
+                    }, ms);
                 },
 
                 web_set_interval: (callbackFuncPtr, ms) => {
                     if (!rt.instance) return 0;
-                    const fn = rt.instance.exports.__indirect_function_table.get(callbackFuncPtr);
-                    return setInterval(() => { try { fn(0); } catch(e) { console.error(e); } }, ms);
+                    return setInterval(() => {
+                        try {
+                            const result = rt.invokeWasmCallback(callbackFuncPtr, 0);
+                            if (result && typeof result.then === 'function') {
+                                result.catch((e) => console.error('Interval callback error:', e));
+                            }
+                        } catch(e) { console.error('Interval callback error:', e); }
+                    }, ms);
                 },
 
                 web_clear_interval: (id) => { clearInterval(id); return 0; },
@@ -1295,8 +1327,14 @@ class EshkolRuntime {
 
                 web_request_animation_frame: (callbackFuncPtr) => {
                     if (!rt.instance) return 0;
-                    const fn = rt.instance.exports.__indirect_function_table.get(callbackFuncPtr);
-                    return requestAnimationFrame((ts) => { try { fn(ts | 0); } catch(e) { console.error(e); } });
+                    return requestAnimationFrame((ts) => {
+                        try {
+                            const result = rt.invokeWasmCallback(callbackFuncPtr, ts | 0);
+                            if (result && typeof result.then === 'function') {
+                                result.catch((e) => console.error('RAF callback error:', e));
+                            }
+                        } catch(e) { console.error('RAF callback error:', e); }
+                    });
                 },
 
                 // Fetch API
@@ -1304,11 +1342,15 @@ class EshkolRuntime {
                     const url = rt.readString(urlPtr);
                     fetch(url).then(r => r.text()).then(text => {
                         if (rt.instance) {
-                            const fn = rt.instance.exports.__indirect_function_table.get(callbackFuncPtr);
                             // Write response to WASM memory
                             const ptr = rt.createImports().env.arena_allocate(0, text.length + 1);
                             rt.writeString(ptr, text, text.length + 1);
-                            try { fn(ptr); } catch(e) { console.error(e); }
+                            try {
+                                const result = rt.invokeWasmCallback(callbackFuncPtr, ptr);
+                                if (result && typeof result.then === 'function') {
+                                    result.catch((e) => console.error('Fetch callback error:', e));
+                                }
+                            } catch(e) { console.error('Fetch callback error:', e); }
                         }
                     }).catch(e => console.error('fetch error:', e));
                     return 0;

--- a/site/static/eshkol-runtime.js
+++ b/site/static/eshkol-runtime.js
@@ -35,6 +35,13 @@ class EshkolRuntime {
         this.memory = instance.exports.memory || this._importedMemory;
     }
 
+    wrapInstance(instance) {
+        const G = (typeof globalThis !== 'undefined') && globalThis.EshkolWebGPU;
+        const exports = G && typeof G.promisingExports === 'function'
+            ? G.promisingExports(instance.exports) : instance.exports;
+        return { rawInstance: instance, exports };
+    }
+
     // === Handle System ===
 
     createHandle(obj) {
@@ -541,6 +548,7 @@ class EshkolRuntime {
                 // INV-wasm-import-glue-equality invariant in
                 // .icc/architecture-model.yaml is critical-severity.
                 eshkol_matmul_dispatch: gpu.eshkol_matmul_dispatch,
+                eshkol_batch_matmul_dispatch: gpu.eshkol_batch_matmul_dispatch,
                 eshkol_gpu_elementwise_f64: gpu.eshkol_gpu_elementwise_f64,
                 eshkol_gpu_reduce_f64: gpu.eshkol_gpu_reduce_f64,
                 eshkol_gpu_init: gpu.eshkol_gpu_init,

--- a/site/static/eshkol-runtime.js
+++ b/site/static/eshkol-runtime.js
@@ -308,14 +308,115 @@ class EshkolRuntime {
         return html;
     }
 
+    // === WebGPU compute backend ===
+
+    /**
+     * Acquire a WebGPU device, if this browser has one. Must be awaited
+     * BEFORE createImports() — the GPU env entries are built once, and
+     * whether they are GPU-backed or CPU-backed is decided at that moment.
+     *
+     * Resolves to a result object rather than throwing: no WebGPU, no JSPI,
+     * or no adapter all mean "run on the CPU", never "fail to load".
+     */
+    async initWebGPU(opts) {
+        const G = (typeof globalThis !== 'undefined') && globalThis.EshkolWebGPU;
+        if (!G) {
+            this._webgpuStatus = { ok: false, reason: 'eshkol-webgpu.js not loaded' };
+            return this._webgpuStatus;
+        }
+        if (!G.jspiAvailable()) {
+            // WebGPU readback is async and the wasm runtime is synchronous;
+            // without JSPI there is no way to suspend, so the CPU path is the
+            // only correct one. Say so rather than pretending the GPU ran.
+            this._webgpuStatus = { ok: false, reason: 'JSPI unavailable (WebAssembly.Suspending missing)' };
+            return this._webgpuStatus;
+        }
+        const res = await G.create(opts || {});
+        this._webgpuBackend = res.ok ? res.backend : null;
+        this.__gpuEnv = null;
+        if (res.ok && typeof globalThis !== 'undefined') {
+            // gpu_memory_webgpu.cpp consults this ordinary backend seam from
+            // its EM_ASYNC_JS bridge. Publish the page-owned device before
+            // the linked wasm runtime performs its first dispatch.
+            globalThis.eshkolWebGPUBackend = res.backend;
+        }
+        this._webgpuStatus = res;
+        return res;
+    }
+
+    /** The WebGPU backend object, or null when running on the CPU path. */
+    get webgpuBackend() { return this._webgpuBackend || null; }
+
+    /**
+     * Build (once) the GPU/tensor env entries. Uses the shared WebGPU module
+     * when it is present, and a compact CPU implementation otherwise, so the
+     * loader keeps working if eshkol-webgpu.js is not on the page.
+     */
+    _gpuEnv() {
+        if (this.__gpuEnv) return this.__gpuEnv;
+        const rt = this;
+        const memRef = () => rt.memory || rt._importedMemory;
+        const G = (typeof globalThis !== 'undefined') && globalThis.EshkolWebGPU;
+        this.__gpuEnv = G
+            ? G.makeImports(rt._webgpuBackend || null, memRef)
+            : EshkolRuntime._cpuOnlyGpuEnv(memRef);
+        return this.__gpuEnv;
+    }
+
+    /** CPU-only GPU env, used when eshkol-webgpu.js is absent. */
+    static _cpuOnlyGpuEnv(memRef) {
+        const f64 = (p, n) => new Float64Array(memRef().buffer, p, n);
+        return {
+            eshkol_matmul_dispatch: (aP, bP, cP, M, K, N) => {
+                M = Number(M); K = Number(K); N = Number(N);
+                const A = f64(aP, M * K), B = f64(bP, K * N), C = f64(cP, M * N);
+                for (let i = 0; i < M; i++)
+                    for (let j = 0; j < N; j++) {
+                        let s = 0;
+                        for (let k = 0; k < K; k++) s += A[i * K + k] * B[k * N + j];
+                        C[i * N + j] = s;
+                    }
+            },
+            eshkol_batch_matmul_dispatch: (aP, bP, cP, batch, M, K, N) => {
+                batch = Number(batch); M = Number(M); K = Number(K); N = Number(N);
+                const aStride = M * K, bStride = K * N, cStride = M * N;
+                for (let q = 0; q < batch; q++) {
+                    const A = f64(aP + q * aStride * 8, aStride);
+                    const B = f64(bP + q * bStride * 8, bStride);
+                    const C = f64(cP + q * cStride * 8, cStride);
+                    for (let i = 0; i < M; i++) for (let j = 0; j < N; j++) {
+                        let s = 0;
+                        for (let k = 0; k < K; k++) s += A[i * K + k] * B[k * N + j];
+                        C[i * N + j] = s;
+                    }
+                }
+            },
+            eshkol_gpu_elementwise_f64: () => -1,
+            eshkol_gpu_reduce_f64: () => -1,
+            eshkol_gpu_init: () => 0,
+            eshkol_gpu_shutdown: () => {},
+            eshkol_gpu_get_backend: () => 0,
+            eshkol_gpu_backend_available: () => 0,
+            eshkol_gpu_supports_f64: () => 0,
+            eshkol_gpu_has_fp64: () => 0,
+            eshkol_gpu_should_use: () => 0,
+            eshkol_gpu_set_threshold: () => {},
+            eshkol_gpu_get_threshold: () => 100000
+        };
+    }
+
     // === WASM Imports ===
 
     createImports() {
         const rt = this;
+        if (!rt._importedMemory) {
+            rt._importedMemory = new WebAssembly.Memory({ initial: 256, maximum: 1024 });
+        }
+        const gpu = rt._gpuEnv();
         return {
             env: {
                 // Memory
-                __linear_memory: rt._importedMemory = new WebAssembly.Memory({ initial: 256, maximum: 1024 }),
+                __linear_memory: rt._importedMemory,
                 // WASM linker globals (required by LLVM static relocation)
                 __stack_pointer: new WebAssembly.Global({ value: 'i32', mutable: true }, 1048576), // 1MB stack
                 __indirect_function_table: new WebAssembly.Table({ initial: 256, element: 'anyfunc' }),
@@ -427,6 +528,31 @@ class EshkolRuntime {
                 eshkol_tensor_matrix_operand_checked: () => 0,
                 eshkol_tensor_counts_checked: () => {},
                 eshkol_tensor_axis_checked: (axis) => axis,
+
+                // GPU compute (WebGPU). These are the ordinary GPU dispatch
+                // seam — the same symbols the native Metal/CUDA backends
+                // define in lib/backend/gpu/ — not a browser-special path.
+                // eshkol_matmul_dispatch is what codegenMatmul emits; the
+                // rest mirror the gpu_memory.h surface so a program can query
+                // and steer dispatch. Values come from _gpuEnv(): a
+                // WebAssembly.Suspending wrapper when WebGPU+JSPI are both
+                // present, a plain synchronous CPU function otherwise.
+                // Keep these keys IDENTICAL to web/eshkol-repl.js — the
+                // INV-wasm-import-glue-equality invariant in
+                // .icc/architecture-model.yaml is critical-severity.
+                eshkol_matmul_dispatch: gpu.eshkol_matmul_dispatch,
+                eshkol_gpu_elementwise_f64: gpu.eshkol_gpu_elementwise_f64,
+                eshkol_gpu_reduce_f64: gpu.eshkol_gpu_reduce_f64,
+                eshkol_gpu_init: gpu.eshkol_gpu_init,
+                eshkol_gpu_shutdown: gpu.eshkol_gpu_shutdown,
+                eshkol_gpu_get_backend: gpu.eshkol_gpu_get_backend,
+                eshkol_gpu_backend_available: gpu.eshkol_gpu_backend_available,
+                eshkol_gpu_supports_f64: gpu.eshkol_gpu_supports_f64,
+                eshkol_gpu_has_fp64: gpu.eshkol_gpu_has_fp64,
+                eshkol_gpu_should_use: gpu.eshkol_gpu_should_use,
+                eshkol_gpu_set_threshold: gpu.eshkol_gpu_set_threshold,
+                eshkol_gpu_get_threshold: gpu.eshkol_gpu_get_threshold,
+
                 eshkol_format_double: () => 0,
                 eshkol_fprint_double: () => 0,
                 eshkol_set_error_location: () => {},

--- a/site/static/eshkol-webgpu.js
+++ b/site/static/eshkol-webgpu.js
@@ -16,7 +16,8 @@
  *           the CPU path. (An sf64/Ozaki-II WGSL port is a named follow-up.)
  *   high  : df32 -- each f64 carried as an unevaluated (hi, lo) pair of f32,
  *           Dekker/Knuth double-float arithmetic. ~48 bits of mantissa against
- *           f64's 53. THIS IS THE WebGPU DEFAULT.
+ *           f64's 53. THIS IS THE WebGPU DEFAULT and is admitted only when the
+ *           fused-fma probe succeeds.
  *   fast  : plain f32, ~24 bits.
  *
  * Defaulting to `high` rather than `exact` is a deliberate, documented
@@ -62,6 +63,7 @@
     const REDUCE_WORKGROUP = 256;
     const GEMM_TILE = 8;
     const ELEM_WORKGROUP = 64;
+    const GPU_GATE_TOL = 1e-9;
 
     /* ===================== WGSL ===================== */
 
@@ -158,7 +160,7 @@ struct Params { n: u32, op: u32, pad0: u32, pad1: u32 };
 @group(0) @binding(2) var<storage, read_write> OUT: array<f32>;
 @group(0) @binding(3) var<uniform> p: Params;
 
-@compute @workgroup_size(1, 1, 1)
+@compute @workgroup_size(${ELEM_WORKGROUP}, 1, 1)
 fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let i = gid.x;
     if (i >= p.n) { return; }
@@ -325,11 +327,16 @@ fn main() {
             this.threshold = (typeof o.threshold === 'number' && o.threshold > 0)
                 ? o.threshold : DEFAULT_THRESHOLD;
             this.precision = o.precision || 'high';
+            this.gateTolerance = (typeof o.gateTolerance === 'number' &&
+                                  Number.isFinite(o.gateTolerance) &&
+                                  o.gateTolerance > 0) ? o.gateTolerance : GPU_GATE_TOL;
             this.pipelines = new Map();
             this.uniformPool = [];
             /* Non-vacuity telemetry: a differential gate asserts these move. */
             this.dispatchCount = 0;
             this.fallbackCount = 0;
+            this.executionMarker = 0;
+            this.lastExecutionMarker = 0;
             this.lastPath = 'none';
             this.fmaFused = true;
             this.memory = null;
@@ -430,21 +437,29 @@ fn main() {
          * element-count threshold. The `exact` tier has no WGSL implementation,
          * so it reports false and the caller takes the CPU path. */
         shouldUse(numElements) {
-            if (!this.device) return false;
-            if (this.precision === 'exact') return false;
+            if (!this.device || this.precision === 'exact') return false;
+            /* The checked-in df32 shader is intentionally fail-closed until
+             * the browser differential gate certifies its compensation path.
+             * Selection and operation support must agree: neither may claim
+             * that the unverified high tier is GPU-capable. */
+            if (this.precision === 'high') return false;
+            if (this.precision === 'fast' && this.gateTolerance <= GPU_GATE_TOL) return false;
             return numElements >= this.threshold;
         }
 
         supportsOperation(kind, op) {
-            /* The checked-in df32 path is present, but this browser/runtime
-             * has not met the repository's 1e-9 gate. Refuse it until a
-             * verified precise-math or Ozaki implementation is available. */
-            if (!this.device || this.precision === 'exact' || this.precision === 'high' || !this.fmaFused) return false;
-            if (this.precision === 'fast') return true;
+            if (!this.device || this.precision === 'exact') return false;
+            if (this.precision === 'high') return false;
+            if (this.precision === 'fast') {
+                /* f32 is never admitted to the 1e-9 gate. It is available only
+                 * when the caller explicitly supplies a looser contract, and
+                 * reductions remain unsupported because their kernel is df32. */
+                return this.gateTolerance > GPU_GATE_TOL &&
+                    ['matmul', 'elementwise'].includes(kind);
+            }
             if (kind === 'elementwise') return Number(op) <= ELEM.ABS;
             if (kind === 'reduce') {
-                return this.precision !== 'fast' &&
-                    [REDUCE.SUM, REDUCE.MIN, REDUCE.MAX, REDUCE.MEAN].includes(Number(op));
+                return [REDUCE.SUM, REDUCE.MIN, REDUCE.MAX, REDUCE.MEAN].includes(Number(op));
             }
             return kind === 'matmul';
         }
@@ -500,22 +515,41 @@ fn main() {
             return buf;
         }
 
+        _recordExecution(path) {
+            const marker = ++this.executionMarker;
+            this.lastExecutionMarker = marker;
+            this.dispatchCount++;
+            this.lastPath = path;
+            return marker;
+        }
+
+        _destroyBuffers(...buffers) {
+            for (const buffer of buffers) if (buffer) buffer.destroy();
+        }
+
         /* The single async boundary. Everything above is synchronous JS;
          * only the readback suspends, and JSPI carries the wasm stack across
          * exactly this await. */
         async _readback(gpuBuf, bytes) {
-            const read = this.device.createBuffer({
-                size: bytes,
-                usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
-            });
-            const enc = this.device.createCommandEncoder();
-            enc.copyBufferToBuffer(gpuBuf, 0, read, 0, bytes);
-            this.device.queue.submit([enc.finish()]);
-            await read.mapAsync(GPUMapMode.READ);
-            const copy = read.getMappedRange().slice(0);
-            read.unmap();
-            read.destroy();
-            return copy;
+            let read = null;
+            let mapped = false;
+            try {
+                read = this.device.createBuffer({
+                    size: bytes,
+                    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+                });
+                const enc = this.device.createCommandEncoder();
+                enc.copyBufferToBuffer(gpuBuf, 0, read, 0, bytes);
+                this.device.queue.submit([enc.finish()]);
+                await read.mapAsync(GPUMapMode.READ);
+                mapped = true;
+                return read.getMappedRange().slice(0);
+            } finally {
+                if (read) {
+                    if (mapped) read.unmap();
+                    read.destroy();
+                }
+            }
         }
 
         /* ---------------- GEMM ---------------- */
@@ -531,43 +565,42 @@ fn main() {
             const encB = df ? encodeDf32(B, K * N) : encodeF32(B, K * N);
             const outBytes = M * N * (df ? 8 : 4);
 
-            const bufA = this._storage(encA);
-            const bufB = this._storage(encB);
-            const bufC = this._outStorage(outBytes);
-            const dims = this._uniform([M, K, N, 0]);
-            const opaque = df ? this._opaque(M * N) : null;
+            let bufA = null, bufB = null, bufC = null, dims = null, opaque = null;
+            try {
+                bufA = this._storage(encA);
+                bufB = this._storage(encB);
+                bufC = this._outStorage(outBytes);
+                dims = this._uniform([M, K, N, 0]);
+                opaque = df ? this._opaque(M * N) : null;
 
-            const pipe = this._pipeline(df ? 'gemm_df32' : 'gemm_f32',
-                                        df ? WGSL_GEMM_DF32 : WGSL_GEMM_F32);
-            const bg = this.device.createBindGroup({
-                layout: pipe.getBindGroupLayout(0),
-                entries: [
-                    { binding: 0, resource: { buffer: bufA } },
-                    { binding: 1, resource: { buffer: bufB } },
-                    { binding: 2, resource: { buffer: bufC } },
-                    { binding: 3, resource: { buffer: dims } },
-                    ...(opaque ? [{ binding: 4, resource: { buffer: opaque } }] : [])
-                ]
-            });
-            const enc = this.device.createCommandEncoder();
-            const pass = enc.beginComputePass();
-            pass.setPipeline(pipe);
-            pass.setBindGroup(0, bg);
-            pass.dispatchWorkgroups(
-                N, M, 1);
-            pass.end();
-            this.device.queue.submit([enc.finish()]);
+                const pipe = this._pipeline(df ? 'gemm_df32' : 'gemm_f32',
+                                            df ? WGSL_GEMM_DF32 : WGSL_GEMM_F32);
+                const bg = this.device.createBindGroup({
+                    layout: pipe.getBindGroupLayout(0),
+                    entries: [
+                        { binding: 0, resource: { buffer: bufA } },
+                        { binding: 1, resource: { buffer: bufB } },
+                        { binding: 2, resource: { buffer: bufC } },
+                        { binding: 3, resource: { buffer: dims } },
+                        ...(opaque ? [{ binding: 4, resource: { buffer: opaque } }] : [])
+                    ]
+                });
+                const enc = this.device.createCommandEncoder();
+                const pass = enc.beginComputePass();
+                pass.setPipeline(pipe);
+                pass.setBindGroup(0, bg);
+                pass.dispatchWorkgroups(Math.ceil(N / GEMM_TILE), Math.ceil(M / GEMM_TILE), 1);
+                pass.end();
+                this.device.queue.submit([enc.finish()]);
 
-            const raw = await this._readback(bufC, outBytes);
-            const C = this._f64View(cPtr, M * N);
-            if (df) decodeDf32(new Float32Array(raw), C, M * N);
-            else { const f = new Float32Array(raw); for (let i = 0; i < M * N; i++) C[i] = f[i]; }
-
-            bufA.destroy(); bufB.destroy(); bufC.destroy(); dims.destroy();
-            if (opaque) opaque.destroy();
-            this.dispatchCount++;
-            this.lastPath = df ? 'webgpu:gemm_df32' : 'webgpu:gemm_f32';
-            return 0;
+                const raw = await this._readback(bufC, outBytes);
+                const C = this._f64View(cPtr, M * N);
+                if (df) decodeDf32(new Float32Array(raw), C, M * N);
+                else { const f = new Float32Array(raw); for (let i = 0; i < M * N; i++) C[i] = f[i]; }
+                return this._recordExecution(df ? 'webgpu:gemm_df32' : 'webgpu:gemm_f32');
+            } finally {
+                this._destroyBuffers(bufA, bufB, bufC, dims, opaque);
+            }
         }
 
         /* ---------------- elementwise ---------------- */
@@ -605,42 +638,42 @@ fn main() {
             }
 
             const bytes = n * (df ? 8 : 4);
-            const bufA = this._storage(encA);
-            const bufB = this._storage(encB);
-            const bufO = this._outStorage(bytes);
-            const params = this._uniform([n, op, 0, 0]);
-            const opaque = df ? this._opaque(n) : null;
+            let bufA = null, bufB = null, bufO = null, params = null, opaque = null;
+            try {
+                bufA = this._storage(encA);
+                bufB = this._storage(encB);
+                bufO = this._outStorage(bytes);
+                params = this._uniform([n, op, 0, 0]);
+                opaque = df ? this._opaque(n) : null;
 
-            const pipe = this._pipeline(df ? 'elem_df32' : 'elem_f32',
-                                        df ? WGSL_ELEM_DF32 : WGSL_ELEM_F32);
-            const bg = this.device.createBindGroup({
-                layout: pipe.getBindGroupLayout(0),
-                entries: [
-                    { binding: 0, resource: { buffer: bufA } },
-                    { binding: 1, resource: { buffer: bufB } },
-                    { binding: 2, resource: { buffer: bufO } },
-                    { binding: 3, resource: { buffer: params } },
-                    ...(opaque ? [{ binding: 4, resource: { buffer: opaque } }] : [])
-                ]
-            });
-            const enc = this.device.createCommandEncoder();
-            const pass = enc.beginComputePass();
-            pass.setPipeline(pipe);
-            pass.setBindGroup(0, bg);
-            pass.dispatchWorkgroups(n, 1, 1);
-            pass.end();
-            this.device.queue.submit([enc.finish()]);
+                const pipe = this._pipeline(df ? 'elem_df32' : 'elem_f32',
+                                            df ? WGSL_ELEM_DF32 : WGSL_ELEM_F32);
+                const bg = this.device.createBindGroup({
+                    layout: pipe.getBindGroupLayout(0),
+                    entries: [
+                        { binding: 0, resource: { buffer: bufA } },
+                        { binding: 1, resource: { buffer: bufB } },
+                        { binding: 2, resource: { buffer: bufO } },
+                        { binding: 3, resource: { buffer: params } },
+                        ...(opaque ? [{ binding: 4, resource: { buffer: opaque } }] : [])
+                    ]
+                });
+                const enc = this.device.createCommandEncoder();
+                const pass = enc.beginComputePass();
+                pass.setPipeline(pipe);
+                pass.setBindGroup(0, bg);
+                pass.dispatchWorkgroups(Math.ceil(n / ELEM_WORKGROUP), 1, 1);
+                pass.end();
+                this.device.queue.submit([enc.finish()]);
 
-            const raw = await this._readback(bufO, bytes);
-            const O = this._f64View(outPtr, n);
-            if (df) decodeDf32(new Float32Array(raw), O, n);
-            else { const f = new Float32Array(raw); for (let i = 0; i < n; i++) O[i] = f[i]; }
-
-            bufA.destroy(); bufB.destroy(); bufO.destroy(); params.destroy();
-            if (opaque) opaque.destroy();
-            this.dispatchCount++;
-            this.lastPath = df ? 'webgpu:elem_df32' : 'webgpu:elem_f32';
-            return 0;
+                const raw = await this._readback(bufO, bytes);
+                const O = this._f64View(outPtr, n);
+                if (df) decodeDf32(new Float32Array(raw), O, n);
+                else { const f = new Float32Array(raw); for (let i = 0; i < n; i++) O[i] = f[i]; }
+                return this._recordExecution(df ? 'webgpu:elem_df32' : 'webgpu:elem_f32');
+            } finally {
+                this._destroyBuffers(bufA, bufB, bufO, params, opaque);
+            }
         }
 
         /* ---------------- reduction ---------------- */
@@ -660,57 +693,57 @@ fn main() {
             const groups = Math.min(64, Math.max(1, Math.ceil(n / REDUCE_WORKGROUP)));
             const perGroup = Math.ceil(n / groups);
 
-            const bufIn = this._storage(enc0);
-            const bufOut = this._outStorage(groups * 8);
-            const params = this._uniform([n, kernelOp, perGroup, 0]);
-            const opaque = this._opaque(groups);
+            let bufIn = null, bufOut = null, params = null, opaque = null;
+            try {
+                bufIn = this._storage(enc0);
+                bufOut = this._outStorage(groups * 8);
+                params = this._uniform([n, kernelOp, perGroup, 0]);
+                opaque = this._opaque(groups);
 
-            const pipe = this._pipeline('reduce_df32', WGSL_REDUCE_DF32);
-            const bg = this.device.createBindGroup({
-                layout: pipe.getBindGroupLayout(0),
-                entries: [
-                    { binding: 0, resource: { buffer: bufIn } },
-                    { binding: 1, resource: { buffer: bufOut } },
-                    { binding: 2, resource: { buffer: params } },
-                    { binding: 4, resource: { buffer: opaque } }
-                ]
-            });
-            const enc = this.device.createCommandEncoder();
-            const pass = enc.beginComputePass();
-            pass.setPipeline(pipe);
-            pass.setBindGroup(0, bg);
-            pass.dispatchWorkgroups(groups, 1, 1);
-            pass.end();
-            this.device.queue.submit([enc.finish()]);
+                const pipe = this._pipeline('reduce_df32', WGSL_REDUCE_DF32);
+                const bg = this.device.createBindGroup({
+                    layout: pipe.getBindGroupLayout(0),
+                    entries: [
+                        { binding: 0, resource: { buffer: bufIn } },
+                        { binding: 1, resource: { buffer: bufOut } },
+                        { binding: 2, resource: { buffer: params } },
+                        { binding: 4, resource: { buffer: opaque } }
+                    ]
+                });
+                const enc = this.device.createCommandEncoder();
+                const pass = enc.beginComputePass();
+                pass.setPipeline(pipe);
+                pass.setBindGroup(0, bg);
+                pass.dispatchWorkgroups(groups, 1, 1);
+                pass.end();
+                this.device.queue.submit([enc.finish()]);
 
-            const raw = await this._readback(bufOut, groups * 8);
-            const partials = new Float32Array(raw);
+                const raw = await this._readback(bufOut, groups * 8);
+                const partials = new Float32Array(raw);
 
-            /* Final cross-group combine on the host in full f64. */
-            let acc;
-            switch (kernelOp) {
-                case REDUCE.PROD: acc = 1; break;
-                case REDUCE.MIN: acc = Infinity; break;
-                case REDUCE.MAX: acc = -Infinity; break;
-                default: acc = 0; break;
-            }
-            for (let g = 0; g < groups; g++) {
-                const v = partials[g * 2] + partials[g * 2 + 1];
+                /* Final cross-group combine on the host in full f64. */
+                let acc;
                 switch (kernelOp) {
-                    case REDUCE.PROD: acc *= v; break;
-                    case REDUCE.MIN: acc = v < acc ? v : acc; break;
-                    case REDUCE.MAX: acc = v > acc ? v : acc; break;
-                    default: acc += v; break;
+                    case REDUCE.PROD: acc = 1; break;
+                    case REDUCE.MIN: acc = Infinity; break;
+                    case REDUCE.MAX: acc = -Infinity; break;
+                    default: acc = 0; break;
                 }
+                for (let g = 0; g < groups; g++) {
+                    const v = partials[g * 2] + partials[g * 2 + 1];
+                    switch (kernelOp) {
+                        case REDUCE.PROD: acc *= v; break;
+                        case REDUCE.MIN: acc = v < acc ? v : acc; break;
+                        case REDUCE.MAX: acc = v > acc ? v : acc; break;
+                        default: acc += v; break;
+                    }
+                }
+                if (op === REDUCE.MEAN) acc /= n;
+                this._f64View(outPtr, 1)[0] = acc;
+                return this._recordExecution('webgpu:reduce_df32');
+            } finally {
+                this._destroyBuffers(bufIn, bufOut, params, opaque);
             }
-            if (op === REDUCE.MEAN) acc /= n;
-            this._f64View(outPtr, 1)[0] = acc;
-
-            bufIn.destroy(); bufOut.destroy(); params.destroy();
-            if (opaque) opaque.destroy();
-            this.dispatchCount++;
-            this.lastPath = 'webgpu:reduce_df32';
-            return 0;
         }
     }
 
@@ -800,12 +833,18 @@ fn main() {
      * the program correctly, just on the CPU.
      */
     function makeImports(backend, memoryRef) {
-        const jspi = (typeof WebAssembly.Suspending === 'function');
+        const jspi = jspiAvailable();
         const mem = () => (backend && backend.memory) || memoryRef();
 
         function sync(fn) { return fn; }
         function suspending(fn) {
             return jspi ? new WebAssembly.Suspending(fn) : null;
+        }
+
+        function verified(marker, before) {
+            return Number.isSafeInteger(marker) && marker > before &&
+                   backend.executionMarker === marker &&
+                   backend.lastExecutionMarker === marker;
         }
 
         /* Each entry: if the GPU can serve this call, suspend into the async
@@ -822,7 +861,12 @@ fn main() {
                     M = Number(M); K = Number(K); N = Number(N);
                     backend.setMemory(mem());
                     if (backend.shouldUse(M * N) && backend.supportsOperation('matmul')) {
-                        try { return void (await backend.matmulF64(aPtr, bPtr, cPtr, M, K, N)); }
+                        const before = backend.executionMarker;
+                        try {
+                            const marker = await backend.matmulF64(aPtr, bPtr, cPtr, M, K, N);
+                            if (verified(marker, before)) return 0;
+                            throw new Error('missing WebGPU execution marker');
+                        }
                         catch (e) { backend.diagnostics.push('gemm failed, CPU fallback: ' + e); }
                     }
                     if (backend.shouldUse(M * N)) backend.diagnostics.push('UNSUPPORTED: matmul refused before GPU_GATE_TOL certification');
@@ -836,7 +880,12 @@ fn main() {
                     n = Number(n); op = Number(op);
                     backend.setMemory(mem());
                     if (backend.shouldUse(n) && backend.supportsOperation('elementwise', op)) {
-                        try { await backend.elementwiseF64(aPtr, bPtr, outPtr, n, op); return 0; }
+                        const before = backend.executionMarker;
+                        try {
+                            const marker = await backend.elementwiseF64(aPtr, bPtr, outPtr, n, op);
+                            if (verified(marker, before)) return 0;
+                            throw new Error('missing WebGPU execution marker');
+                        }
                         catch (e) { backend.diagnostics.push('elementwise failed, CPU fallback: ' + e); }
                     }
                     if (backend.shouldUse(n)) backend.diagnostics.push('UNSUPPORTED: elementwise operation refused before GPU_GATE_TOL certification');
@@ -851,7 +900,12 @@ fn main() {
                     n = Number(n); op = Number(op);
                     backend.setMemory(mem());
                     if (backend.shouldUse(n) && backend.supportsOperation('reduce', op)) {
-                        try { await backend.reduceF64(inPtr, outPtr, n, op); return 0; }
+                        const before = backend.executionMarker;
+                        try {
+                            const marker = await backend.reduceF64(inPtr, outPtr, n, op);
+                            if (verified(marker, before)) return 0;
+                            throw new Error('missing WebGPU execution marker');
+                        }
                         catch (e) { backend.diagnostics.push('reduce failed, CPU fallback: ' + e); }
                     }
                     if (backend.shouldUse(n)) backend.diagnostics.push('UNSUPPORTED: reduction refused before GPU_GATE_TOL certification');
@@ -880,7 +934,7 @@ fn main() {
         /* Batched matmul has no browser WGSL kernel yet. Keep the import
          * callable and route it through the CPU reference; it must never be
          * mistaken for a GPU dispatch. */
-        entries.eshkol_batch_matmul_dispatch = (aPtr, bPtr, cPtr, batch, M, K, N) =>
+        entries.eshkol_batch_matmul_dispatch = (aPtr, bPtr, cPtr, batch, M, K, N, dtype) =>
             cpu.batchMatmul(mem(), aPtr, bPtr, cPtr,
                             Number(batch), Number(M), Number(K), Number(N));
 
@@ -910,6 +964,20 @@ fn main() {
         return fn;
     }
 
+    /* A WebAssembly.Instance exports object is not replaceable in place. Build
+     * a public export facade so every synchronous wasm entry that can reach a
+     * suspending GPU import is paired with WebAssembly.promising. Keeping the
+     * non-function exports (memory, tables, globals) intact preserves the
+     * loader ABI. */
+    function promisingExports(exports) {
+        if (!jspiAvailable()) return exports;
+        const wrapped = {};
+        for (const [name, value] of Object.entries(exports)) {
+            wrapped[name] = typeof value === 'function' ? promisingEntry(value) : value;
+        }
+        return wrapped;
+    }
+
     function jspiAvailable() {
         return typeof WebAssembly.Suspending === 'function' &&
                typeof WebAssembly.promising === 'function';
@@ -920,6 +988,7 @@ fn main() {
         create: EshkolWebGPU.create,
         makeImports,
         promisingEntry,
+        promisingExports,
         jspiAvailable,
         cpu,
         ELEM,

--- a/site/static/eshkol-webgpu.js
+++ b/site/static/eshkol-webgpu.js
@@ -64,6 +64,10 @@
     const GEMM_TILE = 8;
     const ELEM_WORKGROUP = 64;
     const GPU_GATE_TOL = 1e-9;
+    /* Plain f32 has about seven decimal digits of relative precision. A
+     * tolerance just above the df32 gate is not an honest f32 contract. */
+    const FAST_GATE_TOL = 1e-6;
+    const PRECISION_TIERS = new Set(['exact', 'high', 'fast']);
 
     /* ===================== WGSL ===================== */
 
@@ -116,7 +120,7 @@ struct Dims { M: u32, K: u32, N: u32, pad: u32 };
 @group(0) @binding(2) var<storage, read_write> C: array<f32>;
 @group(0) @binding(3) var<uniform> d: Dims;
 
-@compute @workgroup_size(1, 1, 1)
+@compute @workgroup_size(${GEMM_TILE}, ${GEMM_TILE}, 1)
 fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let row = gid.y;
     let col = gid.x;
@@ -326,7 +330,9 @@ fn main() {
             this.device = device;
             this.threshold = (typeof o.threshold === 'number' && o.threshold > 0)
                 ? o.threshold : DEFAULT_THRESHOLD;
-            this.precision = o.precision || 'high';
+            const requestedPrecision = o.precision === undefined ? 'high' : o.precision;
+            this.precision = requestedPrecision;
+            this.precisionKnown = PRECISION_TIERS.has(requestedPrecision);
             this.gateTolerance = (typeof o.gateTolerance === 'number' &&
                                   Number.isFinite(o.gateTolerance) &&
                                   o.gateTolerance > 0) ? o.gateTolerance : GPU_GATE_TOL;
@@ -342,6 +348,16 @@ fn main() {
             this.memory = null;
             this.log = o.log || function () {};
             this.diagnostics = [];
+            if (!this.precisionKnown) {
+                this.diagnostics.push('UNSUPPORTED: unknown WebGPU precision tier ' +
+                                       String(requestedPrecision));
+                this.log('[WebGPU] ' + this.diagnostics[this.diagnostics.length - 1]);
+            } else if (this.precision === 'fast') {
+                const optIn = 'explicit reduced-precision opt-in: fast tier, ' +
+                    'gate tolerance=' + this.gateTolerance;
+                this.diagnostics.push(optIn);
+                this.log('[WebGPU] ' + optIn);
+            }
         }
 
         /* Async device acquisition. Done once, before the wasm module is
@@ -386,7 +402,10 @@ fn main() {
 
         async _probeFma() {
             try {
-                const out = this.device.createBuffer({
+                let out = null;
+                let read = null;
+                let mapped = false;
+                out = this.device.createBuffer({
                     size: 4,
                     usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
                 });
@@ -403,17 +422,21 @@ fn main() {
                 pass.setBindGroup(0, bg);
                 pass.dispatchWorkgroups(1);
                 pass.end();
-                const read = this.device.createBuffer({
+                read = this.device.createBuffer({
                     size: 4,
                     usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
                 });
                 enc.copyBufferToBuffer(out, 0, read, 0, 4);
                 this.device.queue.submit([enc.finish()]);
                 await read.mapAsync(GPUMapMode.READ);
+                mapped = true;
                 const v = new Float32Array(read.getMappedRange().slice(0))[0];
                 read.unmap();
+                mapped = false;
                 read.destroy();
+                read = null;
                 out.destroy();
+                out = null;
                 this.fmaFused = (v !== 0);
                 if (!this.fmaFused) {
                     this.diagnostics.push(
@@ -423,6 +446,12 @@ fn main() {
             } catch (e) {
                 this.fmaFused = false;
                 this.diagnostics.push('fma probe failed: ' + e);
+            } finally {
+                if (read) {
+                    if (mapped) read.unmap();
+                    read.destroy();
+                }
+                if (out) out.destroy();
             }
         }
 
@@ -433,28 +462,34 @@ fn main() {
         setThreshold(t) { if (t > 0) this.threshold = t; }
         getThreshold() { return this.threshold; }
 
+        fastAdmitted() {
+            return this.precision === 'fast' && this.precisionKnown &&
+                this.gateTolerance >= FAST_GATE_TOL;
+        }
+
         /* Mirrors eshkol_gpu_should_use(): active backend AND at or above the
          * element-count threshold. The `exact` tier has no WGSL implementation,
          * so it reports false and the caller takes the CPU path. */
         shouldUse(numElements) {
-            if (!this.device || this.precision === 'exact') return false;
+            if (!this.device || !this.precisionKnown || this.precision === 'exact') return false;
             /* The checked-in df32 shader is intentionally fail-closed until
              * the browser differential gate certifies its compensation path.
              * Selection and operation support must agree: neither may claim
              * that the unverified high tier is GPU-capable. */
             if (this.precision === 'high') return false;
-            if (this.precision === 'fast' && this.gateTolerance <= GPU_GATE_TOL) return false;
+            if (this.precision === 'fast' && !this.fastAdmitted()) return false;
             return numElements >= this.threshold;
         }
 
         supportsOperation(kind, op) {
-            if (!this.device || this.precision === 'exact') return false;
+            if (!this.device || !this.precisionKnown || this.precision === 'exact') return false;
             if (this.precision === 'high') return false;
             if (this.precision === 'fast') {
                 /* f32 is never admitted to the 1e-9 gate. It is available only
-                 * when the caller explicitly supplies a looser contract, and
+                 * when the caller explicitly opts into a contract no tighter
+                 * than the f32 floor, and
                  * reductions remain unsupported because their kernel is df32. */
-                return this.gateTolerance > GPU_GATE_TOL &&
+                return this.fastAdmitted() &&
                     ['matmul', 'elementwise'].includes(kind);
             }
             if (kind === 'elementwise') return Number(op) <= ELEM.ABS;
@@ -994,6 +1029,8 @@ fn main() {
         ELEM,
         REDUCE,
         DEFAULT_THRESHOLD,
+        GPU_GATE_TOL,
+        FAST_GATE_TOL,
         ESHKOL_GPU_WEBGPU
     };
 });

--- a/site/static/eshkol-webgpu.js
+++ b/site/static/eshkol-webgpu.js
@@ -114,7 +114,10 @@ fn df_mul(a: vec2<f32>, b: vec2<f32>, slot: u32) -> vec2<f32> {
      * (lib/backend/gpu/gpu_memory_stub.cpp:171-179), so the only divergence
      * from CPU is the working precision, not the summation order. */
     const WGSL_GEMM_F32 = `
-struct Dims { M: u32, K: u32, N: u32, pad: u32 };
+struct Dims {
+    M: u32, K: u32, N: u32, pad: u32,
+    base_x: u32, base_y: u32, pad2: u32, pad3: u32
+};
 @group(0) @binding(0) var<storage, read> A: array<f32>;
 @group(0) @binding(1) var<storage, read> B: array<f32>;
 @group(0) @binding(2) var<storage, read_write> C: array<f32>;
@@ -122,8 +125,8 @@ struct Dims { M: u32, K: u32, N: u32, pad: u32 };
 
 @compute @workgroup_size(${GEMM_TILE}, ${GEMM_TILE}, 1)
 fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
-    let row = gid.y;
-    let col = gid.x;
+    let row = gid.y + d.base_y;
+    let col = gid.x + d.base_x;
     if (row >= d.M || col >= d.N) { return; }
     var acc: f32 = 0.0;
     for (var k: u32 = 0u; k < d.K; k = k + 1u) {
@@ -134,7 +137,10 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
 `;
 
     const WGSL_GEMM_DF32 = `
-struct Dims { M: u32, K: u32, N: u32, pad: u32 };
+struct Dims {
+    M: u32, K: u32, N: u32, pad: u32,
+    base_x: u32, base_y: u32, pad2: u32, pad3: u32
+};
 @group(0) @binding(0) var<storage, read> A: array<vec2<f32>>;
 @group(0) @binding(1) var<storage, read> B: array<vec2<f32>>;
 @group(0) @binding(2) var<storage, read_write> C: array<vec2<f32>>;
@@ -142,8 +148,8 @@ struct Dims { M: u32, K: u32, N: u32, pad: u32 };
 ${WGSL_DF32}
 @compute @workgroup_size(${GEMM_TILE}, ${GEMM_TILE}, 1)
 fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
-    let row = gid.y;
-    let col = gid.x;
+    let row = gid.y + d.base_y;
+    let col = gid.x + d.base_x;
     if (row >= d.M || col >= d.N) { return; }
     var acc = vec2<f32>(0.0, 0.0);
     for (var k: u32 = 0u; k < d.K; k = k + 1u) {
@@ -330,6 +336,10 @@ fn main() {
             this.device = device;
             this.threshold = (typeof o.threshold === 'number' && o.threshold > 0)
                 ? o.threshold : DEFAULT_THRESHOLD;
+            const deviceLimit = device && device.limits &&
+                Number(device.limits.maxComputeWorkgroupsPerDimension);
+            this.maxComputeWorkgroupsPerDimension = Number.isSafeInteger(deviceLimit) &&
+                deviceLimit > 0 ? deviceLimit : 65535;
             const requestedPrecision = o.precision === undefined ? 'high' : o.precision;
             this.precision = requestedPrecision;
             this.precisionKnown = PRECISION_TIERS.has(requestedPrecision);
@@ -343,6 +353,7 @@ fn main() {
             this.fallbackCount = 0;
             this.executionMarker = 0;
             this.lastExecutionMarker = 0;
+            this.dispatchHistory = [];
             this.lastPath = 'none';
             this.fmaFused = true;
             this.memory = null;
@@ -401,10 +412,10 @@ fn main() {
         }
 
         async _probeFma() {
+            let out = null;
+            let read = null;
+            let mapped = false;
             try {
-                let out = null;
-                let read = null;
-                let mapped = false;
                 out = this.device.createBuffer({
                     size: 4,
                     usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
@@ -420,14 +431,12 @@ fn main() {
                 const pass = enc.beginComputePass();
                 pass.setPipeline(pipe);
                 pass.setBindGroup(0, bg);
-                pass.dispatchWorkgroups(1);
-                pass.end();
                 read = this.device.createBuffer({
                     size: 4,
                     usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
                 });
-                enc.copyBufferToBuffer(out, 0, read, 0, 4);
-                this.device.queue.submit([enc.finish()]);
+                await this._submitDispatch(enc, pass, 1, 1, 1, 'fma probe',
+                    () => enc.copyBufferToBuffer(out, 0, read, 0, 4));
                 await read.mapAsync(GPUMapMode.READ);
                 mapped = true;
                 const v = new Float32Array(read.getMappedRange().slice(0))[0];
@@ -543,7 +552,7 @@ fn main() {
 
         _uniform(u32s) {
             const buf = this.device.createBuffer({
-                size: 16,
+                size: Math.max(16, u32s.length * 4),
                 usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
             });
             this.device.queue.writeBuffer(buf, 0, new Uint32Array(u32s));
@@ -560,6 +569,31 @@ fn main() {
 
         _destroyBuffers(...buffers) {
             for (const buffer of buffers) if (buffer) buffer.destroy();
+        }
+
+        async _submitDispatch(encoder, pass, x, y, z, label, afterPass) {
+            let scopeOpen = true;
+            this.device.pushErrorScope('validation');
+            try {
+                pass.dispatchWorkgroups(x, y, z);
+                pass.end();
+                if (afterPass) afterPass();
+                this.device.queue.submit([encoder.finish()]);
+                const error = await this.device.popErrorScope();
+                scopeOpen = false;
+                if (error) {
+                    const detail = error.message || String(error);
+                    const failure = new Error('WebGPU validation error during ' + label + ': ' + detail);
+                    failure.webgpuValidation = true;
+                    throw failure;
+                }
+                this.dispatchHistory.push({ x, y, z, label });
+            } catch (e) {
+                if (scopeOpen) {
+                    try { await this.device.popErrorScope(); } catch (_) {}
+                }
+                throw e;
+            }
         }
 
         /* The single async boundary. Everything above is synchronous JS;
@@ -600,33 +634,46 @@ fn main() {
             const encB = df ? encodeDf32(B, K * N) : encodeF32(B, K * N);
             const outBytes = M * N * (df ? 8 : 4);
 
-            let bufA = null, bufB = null, bufC = null, dims = null, opaque = null;
+            let bufA = null, bufB = null, bufC = null, opaque = null;
+            const dims = [];
             try {
                 bufA = this._storage(encA);
                 bufB = this._storage(encB);
                 bufC = this._outStorage(outBytes);
-                dims = this._uniform([M, K, N, 0]);
                 opaque = df ? this._opaque(M * N) : null;
 
                 const pipe = this._pipeline(df ? 'gemm_df32' : 'gemm_f32',
                                             df ? WGSL_GEMM_DF32 : WGSL_GEMM_F32);
-                const bg = this.device.createBindGroup({
-                    layout: pipe.getBindGroupLayout(0),
-                    entries: [
-                        { binding: 0, resource: { buffer: bufA } },
-                        { binding: 1, resource: { buffer: bufB } },
-                        { binding: 2, resource: { buffer: bufC } },
-                        { binding: 3, resource: { buffer: dims } },
-                        ...(opaque ? [{ binding: 4, resource: { buffer: opaque } }] : [])
-                    ]
-                });
-                const enc = this.device.createCommandEncoder();
-                const pass = enc.beginComputePass();
-                pass.setPipeline(pipe);
-                pass.setBindGroup(0, bg);
-                pass.dispatchWorkgroups(Math.ceil(N / GEMM_TILE), Math.ceil(M / GEMM_TILE), 1);
-                pass.end();
-                this.device.queue.submit([enc.finish()]);
+                const layout = pipe.getBindGroupLayout(0);
+                const groupsX = Math.ceil(N / GEMM_TILE);
+                const groupsY = Math.ceil(M / GEMM_TILE);
+                const limit = this.maxComputeWorkgroupsPerDimension;
+                for (let baseY = 0; baseY < groupsY; baseY += limit) {
+                    const y = Math.min(limit, groupsY - baseY);
+                    for (let baseX = 0; baseX < groupsX; baseX += limit) {
+                        const x = Math.min(limit, groupsX - baseX);
+                        const tileDims = this._uniform([
+                            M, K, N, 0, baseX * GEMM_TILE, baseY * GEMM_TILE, 0, 0
+                        ]);
+                        dims.push(tileDims);
+                        const bg = this.device.createBindGroup({
+                            layout,
+                            entries: [
+                                { binding: 0, resource: { buffer: bufA } },
+                                { binding: 1, resource: { buffer: bufB } },
+                                { binding: 2, resource: { buffer: bufC } },
+                                { binding: 3, resource: { buffer: tileDims } },
+                                ...(opaque ? [{ binding: 4, resource: { buffer: opaque } }] : [])
+                            ]
+                        });
+                        const enc = this.device.createCommandEncoder();
+                        const pass = enc.beginComputePass();
+                        pass.setPipeline(pipe);
+                        pass.setBindGroup(0, bg);
+                        await this._submitDispatch(enc, pass, x, y, 1,
+                            'gemm ' + x + 'x' + y + ' workgroups');
+                    }
+                }
 
                 const raw = await this._readback(bufC, outBytes);
                 const C = this._f64View(cPtr, M * N);
@@ -634,7 +681,7 @@ fn main() {
                 else { const f = new Float32Array(raw); for (let i = 0; i < M * N; i++) C[i] = f[i]; }
                 return this._recordExecution(df ? 'webgpu:gemm_df32' : 'webgpu:gemm_f32');
             } finally {
-                this._destroyBuffers(bufA, bufB, bufC, dims, opaque);
+                this._destroyBuffers(bufA, bufB, bufC, ...dims, opaque);
             }
         }
 
@@ -697,9 +744,8 @@ fn main() {
                 const pass = enc.beginComputePass();
                 pass.setPipeline(pipe);
                 pass.setBindGroup(0, bg);
-                pass.dispatchWorkgroups(Math.ceil(n / ELEM_WORKGROUP), 1, 1);
-                pass.end();
-                this.device.queue.submit([enc.finish()]);
+                await this._submitDispatch(enc, pass, Math.ceil(n / ELEM_WORKGROUP), 1, 1,
+                    'elementwise ' + n + ' elements');
 
                 const raw = await this._readback(bufO, bytes);
                 const O = this._f64View(outPtr, n);
@@ -749,9 +795,8 @@ fn main() {
                 const pass = enc.beginComputePass();
                 pass.setPipeline(pipe);
                 pass.setBindGroup(0, bg);
-                pass.dispatchWorkgroups(groups, 1, 1);
-                pass.end();
-                this.device.queue.submit([enc.finish()]);
+                await this._submitDispatch(enc, pass, groups, 1, 1,
+                    'reduction ' + groups + ' workgroups');
 
                 const raw = await this._readback(bufOut, groups * 8);
                 const partials = new Float32Array(raw);
@@ -902,7 +947,14 @@ fn main() {
                             if (verified(marker, before)) return 0;
                             throw new Error('missing WebGPU execution marker');
                         }
-                        catch (e) { backend.diagnostics.push('gemm failed, CPU fallback: ' + e); }
+                        catch (e) {
+                            if (e && e.webgpuValidation) {
+                                backend.diagnostics.push(e.message);
+                                backend.lastPath = 'webgpu:error';
+                                throw e;
+                            }
+                            backend.diagnostics.push('gemm failed, CPU fallback: ' + e);
+                        }
                     }
                     if (backend.shouldUse(M * N)) backend.diagnostics.push('UNSUPPORTED: matmul refused before GPU_GATE_TOL certification');
                     backend.fallbackCount++;
@@ -921,7 +973,14 @@ fn main() {
                             if (verified(marker, before)) return 0;
                             throw new Error('missing WebGPU execution marker');
                         }
-                        catch (e) { backend.diagnostics.push('elementwise failed, CPU fallback: ' + e); }
+                        catch (e) {
+                            if (e && e.webgpuValidation) {
+                                backend.diagnostics.push(e.message);
+                                backend.lastPath = 'webgpu:error';
+                                throw e;
+                            }
+                            backend.diagnostics.push('elementwise failed, CPU fallback: ' + e);
+                        }
                     }
                     if (backend.shouldUse(n)) backend.diagnostics.push('UNSUPPORTED: elementwise operation refused before GPU_GATE_TOL certification');
                     backend.fallbackCount++;
@@ -941,7 +1000,14 @@ fn main() {
                             if (verified(marker, before)) return 0;
                             throw new Error('missing WebGPU execution marker');
                         }
-                        catch (e) { backend.diagnostics.push('reduce failed, CPU fallback: ' + e); }
+                        catch (e) {
+                            if (e && e.webgpuValidation) {
+                                backend.diagnostics.push(e.message);
+                                backend.lastPath = 'webgpu:error';
+                                throw e;
+                            }
+                            backend.diagnostics.push('reduce failed, CPU fallback: ' + e);
+                        }
                     }
                     if (backend.shouldUse(n)) backend.diagnostics.push('UNSUPPORTED: reduction refused before GPU_GATE_TOL certification');
                     backend.fallbackCount++;

--- a/site/static/eshkol-webgpu.js
+++ b/site/static/eshkol-webgpu.js
@@ -1,0 +1,930 @@
+/*
+ * Eshkol WebGPU compute backend.
+ *
+ * This is the WASM-target sibling of lib/backend/gpu/gpu_memory.mm (Metal) and
+ * lib/backend/gpu/gpu_memory_cuda.cpp (CUDA). It implements the same dispatch
+ * seam that generated code calls -- eshkol_matmul_dispatch and the
+ * eshkol_gpu_*_f64 compute entry points -- so a WASM program reaches the GPU
+ * through the ORDINARY dispatch predicate (eshkol_gpu_should_use: active
+ * backend + element-count threshold), not through a browser-special path.
+ *
+ * PRECISION. WGSL has no f64 of any kind, so the f64 entry points cannot be
+ * served natively. This backend slots into the existing ESHKOL_GPU_PRECISION
+ * tier vocabulary (see docs/breakdown/RUNTIME_CONFIGURATION.md):
+ *
+ *   exact : IEEE f64, correct to ULP. NOT AVAILABLE on WebGPU -- falls back to
+ *           the CPU path. (An sf64/Ozaki-II WGSL port is a named follow-up.)
+ *   high  : df32 -- each f64 carried as an unevaluated (hi, lo) pair of f32,
+ *           Dekker/Knuth double-float arithmetic. ~48 bits of mantissa against
+ *           f64's 53. THIS IS THE WebGPU DEFAULT.
+ *   fast  : plain f32, ~24 bits.
+ *
+ * Defaulting to `high` rather than `exact` is a deliberate, documented
+ * departure from the native backends, which default to exact. It is reported
+ * by eshkol_gpu_has_fp64() returning 0 (no correct-to-ULP path) and logged at
+ * init. Callers that require exactness set precision to "exact" and get the
+ * CPU path.
+ *
+ * ASYNC. WebGPU readback is unavoidably asynchronous (mapAsync). Eshkol's
+ * runtime is synchronous C compiled to wasm32. The bridge is JSPI
+ * (WebAssembly.Suspending / WebAssembly.promising): the GPU imports are marked
+ * suspending and the entry export is marked promising, so wasm blocks on the
+ * GPU without any rewriting of the module. See attachTo() below. Where JSPI is
+ * absent the GPU imports are installed as synchronous CPU implementations and
+ * dispatchCount stays 0 -- callers detect that and report SKIP, never a silent
+ * pass.
+ *
+ */
+
+(function (root, factory) {
+    'use strict';
+    const mod = factory();
+    if (typeof module === 'object' && module.exports) module.exports = mod;
+    root.EshkolWebGPU = mod;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    /* Must match EshkolGPUBackend in inc/eshkol/backend/gpu/gpu_memory.h */
+    const ESHKOL_GPU_NONE = 0;
+    const ESHKOL_GPU_WEBGPU = 4;
+
+    /* Must match EshkolElementwiseOp in gpu_memory.h */
+    const ELEM = {
+        ADD: 0, SUB: 1, MUL: 2, DIV: 3, NEG: 4, ABS: 5, EXP: 6, LOG: 7,
+        SIN: 8, COS: 9, TANH: 10, RELU: 11, SIGMOID: 12, SQRT: 13, RECIPROCAL: 14
+    };
+    /* Must match EshkolReduceOp in gpu_memory.h */
+    const REDUCE = { SUM: 0, PROD: 1, MIN: 2, MAX: 3, MEAN: 4 };
+
+    /* Same default as g_gpu_threshold in all three native backends. */
+    const DEFAULT_THRESHOLD = 100000;
+
+    const REDUCE_WORKGROUP = 256;
+    const GEMM_TILE = 8;
+    const ELEM_WORKGROUP = 64;
+
+    /* ===================== WGSL ===================== */
+
+    /* Double-float (df32) helpers. Each logical f64 is an (hi, lo) f32 pair
+     * with |lo| <= ulp(hi)/2. WGSL optimizers are allowed to reassociate
+     * ordinary arithmetic, which would fold the TwoSum residual to zero. The
+     * storage write/read below is a deliberate opaque barrier: each invocation
+     * owns one scratch slot, so the shader compiler cannot fold the
+     * error-free transforms into ordinary reassociated f32 arithmetic. */
+    const WGSL_DF32 = `
+@group(0) @binding(4) var<storage, read_write> OPAQUE: array<f32>;
+fn opaque_f32(x: f32, slot: u32) -> f32 {
+    OPAQUE[slot] = x;
+    return OPAQUE[slot];
+}
+fn two_sum(a: f32, b: f32, slot: u32) -> vec2<f32> {
+    let aa = opaque_f32(a, slot);
+    let bb0 = opaque_f32(b, slot);
+    let s = opaque_f32(aa + bb0, slot);
+    let bb = s - aa;
+    let err = opaque_f32((aa - (s - bb)) + (bb0 - bb), slot);
+    return vec2<f32>(s, err);
+}
+fn two_prod(a: f32, b: f32, slot: u32) -> vec2<f32> {
+    let aa = opaque_f32(a, slot);
+    let bb = opaque_f32(b, slot);
+    let p = opaque_f32(aa * bb, slot);
+    let e = opaque_f32(fma(aa, bb, -p), slot);
+    return vec2<f32>(p, e);
+}
+fn df_add(a: vec2<f32>, b: vec2<f32>, slot: u32) -> vec2<f32> {
+    let s = two_sum(a.x, b.x, slot);
+    let e = s.y + (a.y + b.y);
+    return two_sum(s.x, e, slot);
+}
+fn df_mul(a: vec2<f32>, b: vec2<f32>, slot: u32) -> vec2<f32> {
+    let p = two_prod(a.x, b.x, slot);
+    let e = p.y + fma(a.x, b.y, a.y * b.x);
+    return two_sum(p.x, e, slot);
+}
+`;
+
+    /* GEMM. Accumulation is in the same k order as the CPU triple loop
+     * (lib/backend/gpu/gpu_memory_stub.cpp:171-179), so the only divergence
+     * from CPU is the working precision, not the summation order. */
+    const WGSL_GEMM_F32 = `
+struct Dims { M: u32, K: u32, N: u32, pad: u32 };
+@group(0) @binding(0) var<storage, read> A: array<f32>;
+@group(0) @binding(1) var<storage, read> B: array<f32>;
+@group(0) @binding(2) var<storage, read_write> C: array<f32>;
+@group(0) @binding(3) var<uniform> d: Dims;
+
+@compute @workgroup_size(1, 1, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let row = gid.y;
+    let col = gid.x;
+    if (row >= d.M || col >= d.N) { return; }
+    var acc: f32 = 0.0;
+    for (var k: u32 = 0u; k < d.K; k = k + 1u) {
+        acc = acc + A[row * d.K + k] * B[k * d.N + col];
+    }
+    C[row * d.N + col] = acc;
+}
+`;
+
+    const WGSL_GEMM_DF32 = `
+struct Dims { M: u32, K: u32, N: u32, pad: u32 };
+@group(0) @binding(0) var<storage, read> A: array<vec2<f32>>;
+@group(0) @binding(1) var<storage, read> B: array<vec2<f32>>;
+@group(0) @binding(2) var<storage, read_write> C: array<vec2<f32>>;
+@group(0) @binding(3) var<uniform> d: Dims;
+${WGSL_DF32}
+@compute @workgroup_size(${GEMM_TILE}, ${GEMM_TILE}, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let row = gid.y;
+    let col = gid.x;
+    if (row >= d.M || col >= d.N) { return; }
+    var acc = vec2<f32>(0.0, 0.0);
+    for (var k: u32 = 0u; k < d.K; k = k + 1u) {
+        let slot = row * d.N + col;
+        acc = df_add(acc, df_mul(A[row * d.K + k], B[k * d.N + col], slot), slot);
+    }
+    C[row * d.N + col] = acc;
+}
+`;
+
+    /* Elementwise. Op numbering is EshkolElementwiseOp verbatim. Unary ops
+     * ignore B. Missing-B identity handling matches the stub backend:
+     * 0 for add/sub, 1 for mul/div -- the host side supplies that operand. */
+    const WGSL_ELEM_F32 = `
+struct Params { n: u32, op: u32, pad0: u32, pad1: u32 };
+@group(0) @binding(0) var<storage, read> A: array<f32>;
+@group(0) @binding(1) var<storage, read> B: array<f32>;
+@group(0) @binding(2) var<storage, read_write> OUT: array<f32>;
+@group(0) @binding(3) var<uniform> p: Params;
+
+@compute @workgroup_size(1, 1, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    if (i >= p.n) { return; }
+    let a = A[i];
+    let b = B[i];
+    var r: f32 = 0.0;
+    switch (p.op) {
+        case 0u:  { r = a + b; }
+        case 1u:  { r = a - b; }
+        case 2u:  { r = a * b; }
+        case 3u:  { r = a / b; }
+        case 4u:  { r = -a; }
+        case 5u:  { r = abs(a); }
+        case 6u:  { r = exp(a); }
+        case 7u:  { r = log(a); }
+        case 8u:  { r = sin(a); }
+        case 9u:  { r = cos(a); }
+        case 10u: { r = tanh(a); }
+        case 11u: { r = max(a, 0.0); }
+        case 12u: { r = 1.0 / (1.0 + exp(-a)); }
+        case 13u: { r = sqrt(a); }
+        case 14u: { r = 1.0 / a; }
+        default:  { r = 0.0; }
+    }
+    OUT[i] = r;
+}
+`;
+
+    /* df32 elementwise covers only the ops that are exactly representable in
+     * double-float arithmetic (add/sub/mul/div/neg/abs). The transcendentals
+     * have no df32 closed form here, so the high tier refuses them and uses
+     * the CPU fallback. The lower-precision fast tier is an explicit opt-in,
+     * outside the 1e-9 correctness gate. */
+    const WGSL_ELEM_DF32 = `
+struct Params { n: u32, op: u32, pad0: u32, pad1: u32 };
+@group(0) @binding(0) var<storage, read> A: array<vec2<f32>>;
+@group(0) @binding(1) var<storage, read> B: array<vec2<f32>>;
+@group(0) @binding(2) var<storage, read_write> OUT: array<vec2<f32>>;
+@group(0) @binding(3) var<uniform> p: Params;
+${WGSL_DF32}
+fn df_neg(a: vec2<f32>) -> vec2<f32> { return vec2<f32>(-a.x, -a.y); }
+fn df_div(a: vec2<f32>, b: vec2<f32>, slot: u32) -> vec2<f32> {
+    let q1 = a.x / b.x;
+    let r = df_add(a, df_neg(df_mul(vec2<f32>(q1, 0.0), b, slot)), slot);
+    let q2 = r.x / b.x;
+    return two_sum(q1, q2, slot);
+}
+@compute @workgroup_size(${ELEM_WORKGROUP}, 1, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    if (i >= p.n) { return; }
+    let a = A[i];
+    let b = B[i];
+    var r = vec2<f32>(0.0, 0.0);
+    switch (p.op) {
+        case 0u: { r = df_add(a, b, i); }
+        case 1u: { r = df_add(a, df_neg(b), i); }
+        case 2u: { r = df_mul(a, b, i); }
+        case 3u: { r = df_div(a, b, i); }
+        case 4u: { r = df_neg(a); }
+        case 5u: { if (a.x < 0.0) { r = df_neg(a); } else { r = a; } }
+        default: { r = vec2<f32>(0.0, 0.0); }
+    }
+    OUT[i] = r;
+}
+`;
+
+    /* Reduction. One workgroup (one invocation) produces one partial block.
+     * Keeping the partial loop sequential makes the f64-vs-df32 comparison
+     * deterministic and avoids a workgroup tree whose identity/bounds logic
+     * can hide an empty block as a successful zero. */
+    const WGSL_REDUCE_DF32 = `
+struct Params { n: u32, op: u32, per_group: u32, pad: u32 };
+@group(0) @binding(0) var<storage, read> IN: array<vec2<f32>>;
+@group(0) @binding(1) var<storage, read_write> OUT: array<vec2<f32>>;
+@group(0) @binding(2) var<uniform> p: Params;
+${WGSL_DF32}
+fn ident(op: u32) -> vec2<f32> {
+    switch (op) {
+        case 1u: { return vec2<f32>(1.0, 0.0); }
+        case 2u: { return vec2<f32>(3.4028235e38, 0.0); }
+        case 3u: { return vec2<f32>(-3.4028235e38, 0.0); }
+        default: { return vec2<f32>(0.0, 0.0); }
+    }
+}
+fn combine(op: u32, a: vec2<f32>, b: vec2<f32>, slot: u32) -> vec2<f32> {
+    switch (op) {
+        case 1u: { return df_mul(a, b, slot); }
+        case 2u: { if (b.x < a.x) { return b; } else { return a; } }
+        case 3u: { if (b.x > a.x) { return b; } else { return a; } }
+        default: { return df_add(a, b, slot); }
+    }
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let op = p.op;
+    let group = gid.x;
+    let block_start = group * p.per_group;
+    var acc = ident(op);
+    var hi = block_start + p.per_group;
+    if (hi > p.n) { hi = p.n; }
+    var i = block_start;
+    while (i < hi) {
+        acc = combine(op, acc, IN[i], group);
+        i = i + 1u;
+    }
+    OUT[group] = acc;
+}
+`;
+
+    /* Probe: confirm fma() is fused. If a * b + c is computed with two
+     * roundings, two_prod's error term is garbage and df32 silently degrades
+     * to f32. Rather than let that pass unnoticed the backend downgrades the
+     * advertised tier and says so. */
+    const WGSL_FMA_PROBE = `
+@group(0) @binding(0) var<storage, read_write> OUT: array<f32>;
+@compute @workgroup_size(1, 1, 1)
+fn main() {
+    // a * b is not representable in f32; the fused residual must be nonzero.
+    let a: f32 = 1.0000001;
+    let b: f32 = 1.0000002;
+    let p = a * b;
+    OUT[0] = fma(a, b, -p);
+}
+`;
+
+    /* ===================== helpers ===================== */
+
+    function splitDf32(v) {
+        const hi = Math.fround(v);
+        return [hi, Math.fround(v - hi)];
+    }
+
+    function encodeDf32(src, count) {
+        const out = new Float32Array(count * 2);
+        for (let i = 0; i < count; i++) {
+            const hi = Math.fround(src[i]);
+            out[i * 2] = hi;
+            out[i * 2 + 1] = Math.fround(src[i] - hi);
+        }
+        return out;
+    }
+
+    function decodeDf32(buf, dst, count, offset) {
+        const o = offset || 0;
+        for (let i = 0; i < count; i++) {
+            dst[o + i] = buf[i * 2] + buf[i * 2 + 1];
+        }
+    }
+
+    function encodeF32(src, count) {
+        const out = new Float32Array(count);
+        for (let i = 0; i < count; i++) out[i] = src[i];
+        return out;
+    }
+
+    /* ===================== backend ===================== */
+
+    class EshkolWebGPU {
+        constructor(device, opts) {
+            const o = opts || {};
+            this.device = device;
+            this.threshold = (typeof o.threshold === 'number' && o.threshold > 0)
+                ? o.threshold : DEFAULT_THRESHOLD;
+            this.precision = o.precision || 'high';
+            this.pipelines = new Map();
+            this.uniformPool = [];
+            /* Non-vacuity telemetry: a differential gate asserts these move. */
+            this.dispatchCount = 0;
+            this.fallbackCount = 0;
+            this.lastPath = 'none';
+            this.fmaFused = true;
+            this.memory = null;
+            this.log = o.log || function () {};
+            this.diagnostics = [];
+        }
+
+        /* Async device acquisition. Done once, before the wasm module is
+         * instantiated, so eshkol_gpu_init() on the C side is a synchronous
+         * query of an already-resolved device -- no suspension at init. */
+        static async create(opts) {
+            const o = opts || {};
+            if (typeof navigator === 'undefined' || !navigator.gpu) {
+                return { ok: false, reason: 'navigator.gpu unavailable (no WebGPU in this browser)' };
+            }
+            let adapter;
+            try {
+                adapter = await navigator.gpu.requestAdapter(
+                    o.adapterOptions || { powerPreference: 'high-performance' });
+            } catch (e) {
+                return { ok: false, reason: 'requestAdapter threw: ' + e };
+            }
+            if (!adapter) return { ok: false, reason: 'no WebGPU adapter (headless without a GPU?)' };
+            let device;
+            try {
+                device = await adapter.requestDevice();
+            } catch (e) {
+                return { ok: false, reason: 'requestDevice threw: ' + e };
+            }
+            if (!device) return { ok: false, reason: 'requestDevice returned null' };
+
+            const be = new EshkolWebGPU(device, o);
+            device.lost.then((info) => {
+                be.diagnostics.push('device lost: ' + info.message);
+                be.device = null;
+            });
+            await be._probeFma();
+            if (!be.fmaFused && be.precision === 'high') {
+                return { ok: false, unsupported: true,
+                    reason: 'UNSUPPORTED: WebGPU adapter does not provide fused fma; df32 cannot meet GPU_GATE_TOL' };
+            }
+            be.log('[WebGPU] backend active, precision tier=' + be.precision +
+                   ', threshold=' + be.threshold +
+                   ', fma fused=' + be.fmaFused);
+            return { ok: true, backend: be, adapter: adapter };
+        }
+
+        async _probeFma() {
+            try {
+                const out = this.device.createBuffer({
+                    size: 4,
+                    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
+                });
+                const pipe = this._pipeline('fma_probe', WGSL_FMA_PROBE, [
+                    { binding: 0, resource: { buffer: out } }
+                ]);
+                const bg = this.device.createBindGroup({
+                    layout: pipe.getBindGroupLayout(0),
+                    entries: [{ binding: 0, resource: { buffer: out } }]
+                });
+                const enc = this.device.createCommandEncoder();
+                const pass = enc.beginComputePass();
+                pass.setPipeline(pipe);
+                pass.setBindGroup(0, bg);
+                pass.dispatchWorkgroups(1);
+                pass.end();
+                const read = this.device.createBuffer({
+                    size: 4,
+                    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+                });
+                enc.copyBufferToBuffer(out, 0, read, 0, 4);
+                this.device.queue.submit([enc.finish()]);
+                await read.mapAsync(GPUMapMode.READ);
+                const v = new Float32Array(read.getMappedRange().slice(0))[0];
+                read.unmap();
+                read.destroy();
+                out.destroy();
+                this.fmaFused = (v !== 0);
+                if (!this.fmaFused) {
+                    this.diagnostics.push(
+                        'UNSUPPORTED: fma() is not fused; refusing df32 dispatch because it cannot meet GPU_GATE_TOL');
+                    this.log('[WebGPU] ' + this.diagnostics[this.diagnostics.length - 1]);
+                }
+            } catch (e) {
+                this.fmaFused = false;
+                this.diagnostics.push('fma probe failed: ' + e);
+            }
+        }
+
+        /* ---- the dispatch predicate, same shape as the native backends ---- */
+
+        getBackend() { return this.device ? ESHKOL_GPU_WEBGPU : ESHKOL_GPU_NONE; }
+        backendName() { return this.device ? 'WebGPU (browser compute)' : 'CPU only'; }
+        setThreshold(t) { if (t > 0) this.threshold = t; }
+        getThreshold() { return this.threshold; }
+
+        /* Mirrors eshkol_gpu_should_use(): active backend AND at or above the
+         * element-count threshold. The `exact` tier has no WGSL implementation,
+         * so it reports false and the caller takes the CPU path. */
+        shouldUse(numElements) {
+            if (!this.device) return false;
+            if (this.precision === 'exact') return false;
+            return numElements >= this.threshold;
+        }
+
+        supportsOperation(kind, op) {
+            /* The checked-in df32 path is present, but this browser/runtime
+             * has not met the repository's 1e-9 gate. Refuse it until a
+             * verified precise-math or Ozaki implementation is available. */
+            if (!this.device || this.precision === 'exact' || this.precision === 'high' || !this.fmaFused) return false;
+            if (this.precision === 'fast') return true;
+            if (kind === 'elementwise') return Number(op) <= ELEM.ABS;
+            if (kind === 'reduce') {
+                return this.precision !== 'fast' &&
+                    [REDUCE.SUM, REDUCE.MIN, REDUCE.MAX, REDUCE.MEAN].includes(Number(op));
+            }
+            return kind === 'matmul';
+        }
+
+        supportsF64() { return false; }   /* no native hardware f64 in WGSL */
+        hasFp64() { return false; }       /* and no correct-to-ULP emulation yet */
+
+        setMemory(mem) { this.memory = mem; }
+
+        _f64View(ptr, count) {
+            return new Float64Array(this.memory.buffer, ptr, count);
+        }
+
+        _pipeline(key, wgsl) {
+            let p = this.pipelines.get(key);
+            if (!p) {
+                const mod = this.device.createShaderModule({ code: wgsl });
+                p = this.device.createComputePipeline({
+                    layout: 'auto',
+                    compute: { module: mod, entryPoint: 'main' }
+                });
+                this.pipelines.set(key, p);
+            }
+            return p;
+        }
+
+        _storage(data) {
+            const buf = this.device.createBuffer({
+                size: Math.max(data.byteLength, 4),
+                usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC
+            });
+            this.device.queue.writeBuffer(buf, 0, data);
+            return buf;
+        }
+
+        _outStorage(bytes) {
+            return this.device.createBuffer({
+                size: Math.max(bytes, 4),
+                usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
+            });
+        }
+
+        _opaque(count) {
+            return this._storage(new Float32Array(Math.max(1, count || 1)));
+        }
+
+        _uniform(u32s) {
+            const buf = this.device.createBuffer({
+                size: 16,
+                usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+            });
+            this.device.queue.writeBuffer(buf, 0, new Uint32Array(u32s));
+            return buf;
+        }
+
+        /* The single async boundary. Everything above is synchronous JS;
+         * only the readback suspends, and JSPI carries the wasm stack across
+         * exactly this await. */
+        async _readback(gpuBuf, bytes) {
+            const read = this.device.createBuffer({
+                size: bytes,
+                usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+            });
+            const enc = this.device.createCommandEncoder();
+            enc.copyBufferToBuffer(gpuBuf, 0, read, 0, bytes);
+            this.device.queue.submit([enc.finish()]);
+            await read.mapAsync(GPUMapMode.READ);
+            const copy = read.getMappedRange().slice(0);
+            read.unmap();
+            read.destroy();
+            return copy;
+        }
+
+        /* ---------------- GEMM ---------------- */
+
+        /* C = A * B, all row-major, pointers are byte offsets into wasm memory
+         * holding f64. Mirrors eshkol_gpu_matmul_f64 / eshkol_matmul_dispatch. */
+        async matmulF64(aPtr, bPtr, cPtr, M, K, N) {
+            const df = (this.precision === 'high');
+            const A = this._f64View(aPtr, M * K);
+            const B = this._f64View(bPtr, K * N);
+
+            const encA = df ? encodeDf32(A, M * K) : encodeF32(A, M * K);
+            const encB = df ? encodeDf32(B, K * N) : encodeF32(B, K * N);
+            const outBytes = M * N * (df ? 8 : 4);
+
+            const bufA = this._storage(encA);
+            const bufB = this._storage(encB);
+            const bufC = this._outStorage(outBytes);
+            const dims = this._uniform([M, K, N, 0]);
+            const opaque = df ? this._opaque(M * N) : null;
+
+            const pipe = this._pipeline(df ? 'gemm_df32' : 'gemm_f32',
+                                        df ? WGSL_GEMM_DF32 : WGSL_GEMM_F32);
+            const bg = this.device.createBindGroup({
+                layout: pipe.getBindGroupLayout(0),
+                entries: [
+                    { binding: 0, resource: { buffer: bufA } },
+                    { binding: 1, resource: { buffer: bufB } },
+                    { binding: 2, resource: { buffer: bufC } },
+                    { binding: 3, resource: { buffer: dims } },
+                    ...(opaque ? [{ binding: 4, resource: { buffer: opaque } }] : [])
+                ]
+            });
+            const enc = this.device.createCommandEncoder();
+            const pass = enc.beginComputePass();
+            pass.setPipeline(pipe);
+            pass.setBindGroup(0, bg);
+            pass.dispatchWorkgroups(
+                N, M, 1);
+            pass.end();
+            this.device.queue.submit([enc.finish()]);
+
+            const raw = await this._readback(bufC, outBytes);
+            const C = this._f64View(cPtr, M * N);
+            if (df) decodeDf32(new Float32Array(raw), C, M * N);
+            else { const f = new Float32Array(raw); for (let i = 0; i < M * N; i++) C[i] = f[i]; }
+
+            bufA.destroy(); bufB.destroy(); bufC.destroy(); dims.destroy();
+            if (opaque) opaque.destroy();
+            this.dispatchCount++;
+            this.lastPath = df ? 'webgpu:gemm_df32' : 'webgpu:gemm_f32';
+            return 0;
+        }
+
+        /* ---------------- elementwise ---------------- */
+
+        async elementwiseF64(aPtr, bPtr, outPtr, n, op) {
+            if (!this.supportsOperation('elementwise', op)) {
+                throw new Error('UNSUPPORTED: WebGPU elementwise op cannot meet GPU_GATE_TOL');
+            }
+            /* df32 has closed forms only for the algebraic ops; the
+             * transcendentals fall to the f32 kernel (tier `fast` semantics)
+             * because a df32 exp/log/sin is not implemented. That is a
+             * precision cliff, so it is recorded rather than hidden. */
+            const algebraic = (op <= ELEM.ABS);
+            const df = (this.precision === 'high') && algebraic;
+            if (this.precision === 'high' && !algebraic) {
+                this.diagnostics.push(
+                    'elementwise op ' + op + ' has no df32 kernel; ran at f32 precision');
+            }
+
+            const A = this._f64View(aPtr, n);
+            const encA = df ? encodeDf32(A, n) : encodeF32(A, n);
+
+            /* Binary ops read B; unary ops get the identity operand the stub
+             * backend uses so the kernel needs no separate unary variant. */
+            let encB;
+            if (bPtr !== 0 && op <= ELEM.DIV) {
+                const B = this._f64View(bPtr, n);
+                encB = df ? encodeDf32(B, n) : encodeF32(B, n);
+            } else {
+                const ident = (op === ELEM.MUL || op === ELEM.DIV) ? 1 : 0;
+                encB = df ? new Float32Array(n * 2) : new Float32Array(n);
+                if (ident === 1) {
+                    for (let i = 0; i < n; i++) encB[df ? i * 2 : i] = 1;
+                }
+            }
+
+            const bytes = n * (df ? 8 : 4);
+            const bufA = this._storage(encA);
+            const bufB = this._storage(encB);
+            const bufO = this._outStorage(bytes);
+            const params = this._uniform([n, op, 0, 0]);
+            const opaque = df ? this._opaque(n) : null;
+
+            const pipe = this._pipeline(df ? 'elem_df32' : 'elem_f32',
+                                        df ? WGSL_ELEM_DF32 : WGSL_ELEM_F32);
+            const bg = this.device.createBindGroup({
+                layout: pipe.getBindGroupLayout(0),
+                entries: [
+                    { binding: 0, resource: { buffer: bufA } },
+                    { binding: 1, resource: { buffer: bufB } },
+                    { binding: 2, resource: { buffer: bufO } },
+                    { binding: 3, resource: { buffer: params } },
+                    ...(opaque ? [{ binding: 4, resource: { buffer: opaque } }] : [])
+                ]
+            });
+            const enc = this.device.createCommandEncoder();
+            const pass = enc.beginComputePass();
+            pass.setPipeline(pipe);
+            pass.setBindGroup(0, bg);
+            pass.dispatchWorkgroups(n, 1, 1);
+            pass.end();
+            this.device.queue.submit([enc.finish()]);
+
+            const raw = await this._readback(bufO, bytes);
+            const O = this._f64View(outPtr, n);
+            if (df) decodeDf32(new Float32Array(raw), O, n);
+            else { const f = new Float32Array(raw); for (let i = 0; i < n; i++) O[i] = f[i]; }
+
+            bufA.destroy(); bufB.destroy(); bufO.destroy(); params.destroy();
+            if (opaque) opaque.destroy();
+            this.dispatchCount++;
+            this.lastPath = df ? 'webgpu:elem_df32' : 'webgpu:elem_f32';
+            return 0;
+        }
+
+        /* ---------------- reduction ---------------- */
+
+        async reduceF64(inPtr, outPtr, n, op) {
+            if (!this.supportsOperation('reduce', op)) {
+                throw new Error('UNSUPPORTED: WebGPU reduction cannot meet GPU_GATE_TOL');
+            }
+            /* Reductions always run df32: a f32 reduction over a large array
+             * loses far more than a f32 elementwise op, and the extra cost is
+             * one f32 lane. MEAN reduces as SUM then divides on the host,
+             * matching the stub backend. */
+            const kernelOp = (op === REDUCE.MEAN) ? REDUCE.SUM : op;
+            const IN = this._f64View(inPtr, n);
+            const enc0 = encodeDf32(IN, n);
+
+            const groups = Math.min(64, Math.max(1, Math.ceil(n / REDUCE_WORKGROUP)));
+            const perGroup = Math.ceil(n / groups);
+
+            const bufIn = this._storage(enc0);
+            const bufOut = this._outStorage(groups * 8);
+            const params = this._uniform([n, kernelOp, perGroup, 0]);
+            const opaque = this._opaque(groups);
+
+            const pipe = this._pipeline('reduce_df32', WGSL_REDUCE_DF32);
+            const bg = this.device.createBindGroup({
+                layout: pipe.getBindGroupLayout(0),
+                entries: [
+                    { binding: 0, resource: { buffer: bufIn } },
+                    { binding: 1, resource: { buffer: bufOut } },
+                    { binding: 2, resource: { buffer: params } },
+                    { binding: 4, resource: { buffer: opaque } }
+                ]
+            });
+            const enc = this.device.createCommandEncoder();
+            const pass = enc.beginComputePass();
+            pass.setPipeline(pipe);
+            pass.setBindGroup(0, bg);
+            pass.dispatchWorkgroups(groups, 1, 1);
+            pass.end();
+            this.device.queue.submit([enc.finish()]);
+
+            const raw = await this._readback(bufOut, groups * 8);
+            const partials = new Float32Array(raw);
+
+            /* Final cross-group combine on the host in full f64. */
+            let acc;
+            switch (kernelOp) {
+                case REDUCE.PROD: acc = 1; break;
+                case REDUCE.MIN: acc = Infinity; break;
+                case REDUCE.MAX: acc = -Infinity; break;
+                default: acc = 0; break;
+            }
+            for (let g = 0; g < groups; g++) {
+                const v = partials[g * 2] + partials[g * 2 + 1];
+                switch (kernelOp) {
+                    case REDUCE.PROD: acc *= v; break;
+                    case REDUCE.MIN: acc = v < acc ? v : acc; break;
+                    case REDUCE.MAX: acc = v > acc ? v : acc; break;
+                    default: acc += v; break;
+                }
+            }
+            if (op === REDUCE.MEAN) acc /= n;
+            this._f64View(outPtr, 1)[0] = acc;
+
+            bufIn.destroy(); bufOut.destroy(); params.destroy();
+            if (opaque) opaque.destroy();
+            this.dispatchCount++;
+            this.lastPath = 'webgpu:reduce_df32';
+            return 0;
+        }
+    }
+
+    /* ===================== CPU reference =====================
+     * Byte-for-byte the arithmetic of lib/backend/gpu/gpu_memory_stub.cpp.
+     * This is the fallback below threshold / without WebGPU, AND the
+     * reference side of the differential gate. */
+
+    const cpu = {
+        matmul(mem, aPtr, bPtr, cPtr, M, K, N) {
+            const A = new Float64Array(mem.buffer, aPtr, M * K);
+            const B = new Float64Array(mem.buffer, bPtr, K * N);
+            const C = new Float64Array(mem.buffer, cPtr, M * N);
+            for (let i = 0; i < M; i++) {
+                for (let j = 0; j < N; j++) {
+                    let s = 0;
+                    for (let k = 0; k < K; k++) s += A[i * K + k] * B[k * N + j];
+                    C[i * N + j] = s;
+                }
+            }
+        },
+        elementwise(mem, aPtr, bPtr, outPtr, n, op) {
+            const A = new Float64Array(mem.buffer, aPtr, n);
+            const B = bPtr ? new Float64Array(mem.buffer, bPtr, n) : null;
+            const O = new Float64Array(mem.buffer, outPtr, n);
+            for (let i = 0; i < n; i++) {
+                const a = A[i];
+                const b = B ? B[i] : ((op === ELEM.MUL || op === ELEM.DIV) ? 1 : 0);
+                switch (op) {
+                    case ELEM.ADD: O[i] = a + b; break;
+                    case ELEM.SUB: O[i] = a - b; break;
+                    case ELEM.MUL: O[i] = a * b; break;
+                    case ELEM.DIV: O[i] = a / b; break;
+                    case ELEM.NEG: O[i] = -a; break;
+                    case ELEM.ABS: O[i] = Math.abs(a); break;
+                    case ELEM.EXP: O[i] = Math.exp(a); break;
+                    case ELEM.LOG: O[i] = Math.log(a); break;
+                    case ELEM.SIN: O[i] = Math.sin(a); break;
+                    case ELEM.COS: O[i] = Math.cos(a); break;
+                    case ELEM.TANH: O[i] = Math.tanh(a); break;
+                    case ELEM.RELU: O[i] = a > 0 ? a : 0; break;
+                    case ELEM.SIGMOID: O[i] = 1 / (1 + Math.exp(-a)); break;
+                    case ELEM.SQRT: O[i] = Math.sqrt(a); break;
+                    case ELEM.RECIPROCAL: O[i] = 1 / a; break;
+                }
+            }
+        },
+        reduce(mem, inPtr, outPtr, n, op) {
+            const I = new Float64Array(mem.buffer, inPtr, n);
+            let r;
+            switch (op) {
+                case REDUCE.PROD: r = 1; break;
+                case REDUCE.MIN: r = Infinity; break;
+                case REDUCE.MAX: r = -Infinity; break;
+                default: r = 0; break;
+            }
+            for (let i = 0; i < n; i++) {
+                switch (op) {
+                    case REDUCE.PROD: r *= I[i]; break;
+                    case REDUCE.MIN: r = I[i] < r ? I[i] : r; break;
+                    case REDUCE.MAX: r = I[i] > r ? I[i] : r; break;
+                    default: r += I[i]; break;
+                }
+            }
+            if (op === REDUCE.MEAN) r /= n;
+            new Float64Array(mem.buffer, outPtr, 1)[0] = r;
+        },
+        batchMatmul(mem, aPtr, bPtr, cPtr, batch, M, K, N) {
+            const aStride = M * K, bStride = K * N, cStride = M * N;
+            for (let q = 0; q < batch; q++) {
+                cpu.matmul(mem, aPtr + q * aStride * 8,
+                           bPtr + q * bStride * 8,
+                           cPtr + q * cStride * 8, M, K, N);
+            }
+        }
+    };
+
+    /* ===================== import installation =====================
+     *
+     * Produces the `env` entries the generated wasm imports. Call this from
+     * BOTH loaders (web/eshkol-repl.js and site/static/eshkol-runtime.js):
+     * scripts/check_wasm_imports.py fails the build if either one lacks an
+     * import the codegen emits.
+     *
+     * `backend` may be null -- then every entry is the synchronous CPU
+     * implementation and nothing suspends, so a JSPI-less browser still runs
+     * the program correctly, just on the CPU.
+     */
+    function makeImports(backend, memoryRef) {
+        const jspi = (typeof WebAssembly.Suspending === 'function');
+        const mem = () => (backend && backend.memory) || memoryRef();
+
+        function sync(fn) { return fn; }
+        function suspending(fn) {
+            return jspi ? new WebAssembly.Suspending(fn) : null;
+        }
+
+        /* Each entry: if the GPU can serve this call, suspend into the async
+         * kernel; otherwise run the CPU version synchronously. When JSPI is
+         * unavailable we cannot suspend at all, so we install the CPU version
+         * outright. */
+        const useGpu = backend && backend.device && jspi;
+
+        const entries = {};
+
+        if (useGpu) {
+            entries.eshkol_matmul_dispatch = suspending(
+                async (aPtr, bPtr, cPtr, M, K, N, dtype) => {
+                    M = Number(M); K = Number(K); N = Number(N);
+                    backend.setMemory(mem());
+                    if (backend.shouldUse(M * N) && backend.supportsOperation('matmul')) {
+                        try { return void (await backend.matmulF64(aPtr, bPtr, cPtr, M, K, N)); }
+                        catch (e) { backend.diagnostics.push('gemm failed, CPU fallback: ' + e); }
+                    }
+                    if (backend.shouldUse(M * N)) backend.diagnostics.push('UNSUPPORTED: matmul refused before GPU_GATE_TOL certification');
+                    backend.fallbackCount++;
+                    backend.lastPath = 'cpu:gemm';
+                    cpu.matmul(mem(), aPtr, bPtr, cPtr, M, K, N);
+                });
+
+            entries.eshkol_gpu_elementwise_f64 = suspending(
+                async (aPtr, bPtr, outPtr, n, op) => {
+                    n = Number(n); op = Number(op);
+                    backend.setMemory(mem());
+                    if (backend.shouldUse(n) && backend.supportsOperation('elementwise', op)) {
+                        try { await backend.elementwiseF64(aPtr, bPtr, outPtr, n, op); return 0; }
+                        catch (e) { backend.diagnostics.push('elementwise failed, CPU fallback: ' + e); }
+                    }
+                    if (backend.shouldUse(n)) backend.diagnostics.push('UNSUPPORTED: elementwise operation refused before GPU_GATE_TOL certification');
+                    backend.fallbackCount++;
+                    backend.lastPath = 'cpu:elem';
+                    cpu.elementwise(mem(), aPtr, bPtr, outPtr, n, op);
+                    return 0;
+                });
+
+            entries.eshkol_gpu_reduce_f64 = suspending(
+                async (inPtr, outPtr, n, op) => {
+                    n = Number(n); op = Number(op);
+                    backend.setMemory(mem());
+                    if (backend.shouldUse(n) && backend.supportsOperation('reduce', op)) {
+                        try { await backend.reduceF64(inPtr, outPtr, n, op); return 0; }
+                        catch (e) { backend.diagnostics.push('reduce failed, CPU fallback: ' + e); }
+                    }
+                    if (backend.shouldUse(n)) backend.diagnostics.push('UNSUPPORTED: reduction refused before GPU_GATE_TOL certification');
+                    backend.fallbackCount++;
+                    backend.lastPath = 'cpu:reduce';
+                    cpu.reduce(mem(), inPtr, outPtr, n, op);
+                    return 0;
+                });
+        } else {
+            entries.eshkol_matmul_dispatch = sync(
+                (aPtr, bPtr, cPtr, M, K, N, dtype) => {
+                    cpu.matmul(mem(), aPtr, bPtr, cPtr, Number(M), Number(K), Number(N));
+                });
+            entries.eshkol_gpu_elementwise_f64 = sync(
+                (aPtr, bPtr, outPtr, n, op) => {
+                    cpu.elementwise(mem(), aPtr, bPtr, outPtr, Number(n), Number(op));
+                    return 0;
+                });
+            entries.eshkol_gpu_reduce_f64 = sync(
+                (inPtr, outPtr, n, op) => {
+                    cpu.reduce(mem(), inPtr, outPtr, Number(n), Number(op));
+                    return 0;
+                });
+        }
+
+        /* Batched matmul has no browser WGSL kernel yet. Keep the import
+         * callable and route it through the CPU reference; it must never be
+         * mistaken for a GPU dispatch. */
+        entries.eshkol_batch_matmul_dispatch = (aPtr, bPtr, cPtr, batch, M, K, N) =>
+            cpu.batchMatmul(mem(), aPtr, bPtr, cPtr,
+                            Number(batch), Number(M), Number(K), Number(N));
+
+        /* Query surface -- the C-side predicate mirrored for generated code
+         * and for host tooling. Always synchronous. */
+        entries.eshkol_gpu_init = () => (backend && backend.device) ? 1 : 0;
+        entries.eshkol_gpu_shutdown = () => {};
+        entries.eshkol_gpu_get_backend = () => backend ? backend.getBackend() : ESHKOL_GPU_NONE;
+        entries.eshkol_gpu_backend_available = (b) =>
+            (Number(b) === ESHKOL_GPU_WEBGPU && backend && backend.device) ? 1 : 0;
+        entries.eshkol_gpu_supports_f64 = () => 0;
+        entries.eshkol_gpu_has_fp64 = () => 0;
+        entries.eshkol_gpu_should_use = (n) =>
+            (backend && backend.shouldUse(Number(n))) ? 1 : 0;
+        entries.eshkol_gpu_set_threshold = (t) => { if (backend) backend.setThreshold(Number(t)); };
+        entries.eshkol_gpu_get_threshold = () => backend ? backend.threshold : DEFAULT_THRESHOLD;
+
+        return entries;
+    }
+
+    /* Wrap an instantiated module's entry export so JSPI can suspend inside
+     * it. Without this the suspending imports throw on first call. */
+    function promisingEntry(fn) {
+        if (typeof WebAssembly.promising === 'function') {
+            return WebAssembly.promising(fn);
+        }
+        return fn;
+    }
+
+    function jspiAvailable() {
+        return typeof WebAssembly.Suspending === 'function' &&
+               typeof WebAssembly.promising === 'function';
+    }
+
+    return {
+        EshkolWebGPU,
+        create: EshkolWebGPU.create,
+        makeImports,
+        promisingEntry,
+        jspiAvailable,
+        cpu,
+        ELEM,
+        REDUCE,
+        DEFAULT_THRESHOLD,
+        ESHKOL_GPU_WEBGPU
+    };
+});

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -51,6 +51,7 @@
     <p class="loading-sub">This website is written in Eshkol, compiled to WebAssembly.</p>
   </div>
   <script src="eshkol-runtime.js"></script>
+  <script src="eshkol-webgpu.js"></script>
   <script src="eshkol-vm.js"></script>
   <script>
     // ─── GitHub Pages SPA redirect ─────────────────────────────────────
@@ -71,6 +72,7 @@
       const loadingEl = document.getElementById('loading');
       try {
         const runtime = new EshkolRuntime();
+        await runtime.initWebGPU();
         const response = await fetch('eshkol-site.wasm');
         const { instance } = await WebAssembly.instantiate(
           await response.arrayBuffer(),

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -74,10 +74,11 @@
         const runtime = new EshkolRuntime();
         await runtime.initWebGPU();
         const response = await fetch('eshkol-site.wasm');
-        const { instance } = await WebAssembly.instantiate(
+        const { instance: rawInstance } = await WebAssembly.instantiate(
           await response.arrayBuffer(),
           runtime.createImports()
         );
+        const instance = runtime.wrapInstance(rawInstance);
         runtime.setInstance(instance);
         if (loadingEl) loadingEl.remove();
 
@@ -93,9 +94,9 @@
           if (anchor) anchor.scrollIntoView();
         };
 
-        const navigate = () => {
+        const navigate = async () => {
           if (instance.exports.scheme_main) {
-            instance.exports.scheme_main(0);
+            await instance.exports.scheme_main(0);
           }
           scrollToFragment();
           if (window.location.pathname === '/downloads' ||
@@ -106,12 +107,12 @@
 
         // Initial render
         if (instance.exports.main) {
-          instance.exports.main(0, 0);
+          await instance.exports.main(0, 0);
         }
         scrollToFragment();
 
         // Back / forward
-        window.addEventListener('popstate', navigate);
+        window.addEventListener('popstate', () => { navigate().catch(console.error); });
 
         // ─── Single unified click handler ──────────────────────────────
         // Priority order prevents interference between handlers:

--- a/tests/webgpu/webgpu_live_test.mjs
+++ b/tests/webgpu/webgpu_live_test.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+/* Live browser contract for the WebGPU bridge. This deliberately uses the
+ * installed Chrome channel and a real WebGPU device; a missing device is a
+ * test failure, not a green CPU-only result. */
+
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SOURCE = fs.readFileSync(path.join(ROOT, 'web', 'eshkol-webgpu.js'), 'utf8');
+let chromium;
+try {
+    ({ chromium } = await import('playwright'));
+} catch {
+    try {
+        ({ chromium } = await import(path.join(ROOT, '.scratch', 'node_modules',
+                                               'playwright', 'index.js')));
+    } catch (error) {
+        console.error('webgpu_live_test: Playwright is unavailable: ' + error);
+        process.exit(2);
+    }
+}
+
+const server = http.createServer((req, res) => {
+    if (req.url === '/eshkol-webgpu.js') {
+        res.writeHead(200, { 'Content-Type': 'text/javascript' });
+        res.end(SOURCE);
+        return;
+    }
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end('<!doctype html><script src="/eshkol-webgpu.js"></script>');
+});
+
+await new Promise((resolve) => server.listen(0, 'localhost', resolve));
+const port = server.address().port;
+let browser;
+try {
+    browser = await chromium.launch({ channel: 'chrome', headless: true,
+                                      args: ['--enable-unsafe-webgpu'] });
+    const page = await browser.newPage();
+    await page.goto(`http://localhost:${port}/`);
+    const result = await page.evaluate(async () => {
+        const assert = (condition, message) => {
+            if (!condition) throw new Error(message);
+        };
+        assert.equal = (actual, expected, message) => assert(
+            Object.is(actual, expected), message || `${actual} !== ${expected}`);
+        const G = globalThis.EshkolWebGPU;
+        assert(G, 'EshkolWebGPU did not load');
+        assert(navigator.gpu, 'navigator.gpu is unavailable');
+
+        const created = await G.create({ precision: 'fast', gateTolerance: 1e-4,
+                                         threshold: 1 });
+        assert(created.ok, created.reason || 'WebGPU initialization failed');
+        const backend = created.backend;
+        const limit = backend.maxComputeWorkgroupsPerDimension;
+        assert(Number.isSafeInteger(limit) && limit > 0,
+               'device workgroup limit was not captured');
+
+        const memory = new WebAssembly.Memory({ initial: 256 });
+        backend.setMemory(memory);
+        const fakeMem = { buffer: memory.buffer };
+        let bump = 64;
+        const alloc = (count) => {
+            const ptr = bump;
+            bump = (bump + count * 8 + 15) & ~15;
+            return ptr;
+        };
+
+        async function gemm(M, K, N, aValue, bValue) {
+            bump = 64;
+            const aPtr = alloc(M * K), bPtr = alloc(K * N);
+            const gpuPtr = alloc(M * N), cpuPtr = alloc(M * N);
+            const A = new Float64Array(memory.buffer, aPtr, M * K);
+            const B = new Float64Array(memory.buffer, bPtr, K * N);
+            A.set(Array.from({ length: M * K }, (_, i) => aValue(i)));
+            B.set(Array.from({ length: K * N }, (_, i) => bValue(i)));
+            const before = backend.dispatchHistory.length;
+            await backend.matmulF64(aPtr, bPtr, gpuPtr, M, K, N);
+            G.cpu.matmul(fakeMem, aPtr, bPtr, cpuPtr, M, K, N);
+            const gpu = new Float64Array(memory.buffer, gpuPtr, M * N);
+            const cpu = new Float64Array(memory.buffer, cpuPtr, M * N);
+            for (let i = 0; i < gpu.length; i++) {
+                assert(Object.is(gpu[i], cpu[i]),
+                       `GEMM mismatch at ${i}: ${gpu[i]} !== ${cpu[i]}`);
+            }
+            return backend.dispatchHistory.slice(before);
+        }
+
+        const small = await gemm(8, 8, 8, () => 1, () => 1);
+        const nonsquare = await gemm(3, 5, 7, (i) => (i % 5) - 2,
+                                     (i) => (i % 7) - 3);
+
+        async function boundary(N) {
+            bump = 64;
+            const aPtr = alloc(1), bPtr = alloc(N), gpuPtr = alloc(N);
+            new Float64Array(memory.buffer, aPtr, 1)[0] = 1;
+            new Float64Array(memory.buffer, bPtr, N).fill(1);
+            const before = backend.dispatchHistory.length;
+            await backend.matmulF64(aPtr, bPtr, gpuPtr, 1, 1, N);
+            const output = new Float64Array(memory.buffer, gpuPtr, N);
+            for (const value of output) assert.equal(value, 1);
+            return backend.dispatchHistory.slice(before);
+        }
+
+        const atLimit = await boundary((limit * 8));
+        const overLimit = await boundary((limit * 8) + 1);
+        assert.equal(atLimit.length, 1);
+        assert.equal(atLimit[0].x, limit);
+        assert.equal(overLimit.length, 2);
+        assert.equal(overLimit[0].x, limit);
+        assert.equal(overLimit[1].x, 1);
+        for (const dispatch of [...small, ...nonsquare, ...atLimit, ...overLimit]) {
+            assert(dispatch.x <= limit && dispatch.y <= limit && dispatch.z <= limit,
+                   `oversized dispatch: ${JSON.stringify(dispatch)}`);
+        }
+
+        /* A real WASM table entry reaches a suspending import and is then
+         * wrapped at its JavaScript callback boundary. */
+        const wasm = new Uint8Array([
+            0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+            0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+            0x02, 0x0f, 0x01, 0x03, 0x65, 0x6e, 0x76, 0x07, 0x73,
+            0x75, 0x73, 0x70, 0x65, 0x6e, 0x64, 0x00, 0x00,
+            0x03, 0x02, 0x01, 0x00,
+            0x04, 0x04, 0x01, 0x70, 0x00, 0x01,
+            0x07, 0x14, 0x02, 0x05, 0x74, 0x61, 0x62, 0x6c, 0x65,
+            0x01, 0x00, 0x08, 0x63, 0x61, 0x6c, 0x6c, 0x62, 0x61,
+            0x63, 0x6b, 0x00, 0x01,
+            0x09, 0x07, 0x01, 0x00, 0x41, 0x00, 0x0b, 0x01, 0x01,
+            0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00, 0x0b
+        ]);
+        const imported = new WebAssembly.Suspending(async () => 7);
+        const instance = await WebAssembly.instantiate(wasm, { env: { suspend: imported } });
+        const callback = G.promisingEntry(instance.instance.exports.table.get(0));
+        assert.equal(await callback(), 7);
+
+        return {
+            limit,
+            fmaFused: backend.fmaFused,
+            smallDispatches: small.length,
+            nonsquareDispatches: nonsquare.length,
+            boundaryDispatches: `${atLimit.length}/${overLimit.length}`,
+            callback: 7,
+            dispatchCount: backend.dispatchCount,
+            diagnostics: backend.diagnostics
+        };
+    });
+    console.log('LIVE WebGPU initialization complete fmaFused=' + result.fmaFused +
+                ' maxComputeWorkgroupsPerDimension=' + result.limit);
+    console.log('LIVE GEMM 8x8 exact CPU reference dispatches=' + result.smallDispatches);
+    console.log('LIVE GEMM 3x5*5x7 exact CPU reference dispatches=' + result.nonsquareDispatches);
+    console.log('LIVE dispatch boundary 65535/65536 workgroups=' + result.boundaryDispatches);
+    console.log('LIVE JSPI table callback suspension result=' + result.callback);
+    console.log('PASS WebGPU live Chrome contracts dispatchCount=' + result.dispatchCount);
+} finally {
+    if (browser) await browser.close();
+    server.close();
+}

--- a/tests/webgpu/webgpu_regressions_test.mjs
+++ b/tests/webgpu/webgpu_regressions_test.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const module = await import(path.join(ROOT, 'web', 'eshkol-webgpu.js'));
+const G = module.default || module;
+
+function installMockJSPI() {
+    const oldSuspending = WebAssembly.Suspending;
+    const oldPromising = WebAssembly.promising;
+    WebAssembly.Suspending = function (fn) { return fn; };
+    WebAssembly.promising = function (fn) {
+        return (...args) => Promise.resolve(fn(...args));
+    };
+    return () => {
+        if (oldSuspending === undefined) delete WebAssembly.Suspending;
+        else WebAssembly.Suspending = oldSuspending;
+        if (oldPromising === undefined) delete WebAssembly.promising;
+        else WebAssembly.promising = oldPromising;
+    };
+}
+
+function testPrecisionContracts() {
+    const device = {};
+    const high = new G.EshkolWebGPU(device, { threshold: 1 });
+    assert.equal(high.shouldUse(1), false);
+    assert.equal(high.supportsOperation('matmul'), false);
+    assert.equal(high.supportsOperation('elementwise', G.ELEM.ADD), false);
+    assert.equal(high.supportsOperation('elementwise', G.ELEM.EXP), false);
+    assert.equal(high.supportsOperation('reduce', G.REDUCE.SUM), false);
+    assert.equal(high.supportsOperation('reduce', G.REDUCE.PROD), false);
+
+    const exact = new G.EshkolWebGPU(device, { precision: 'exact', threshold: 1 });
+    assert.equal(exact.shouldUse(1), false);
+    assert.equal(exact.supportsOperation('matmul'), false);
+
+    const fast = new G.EshkolWebGPU(device, { precision: 'fast', threshold: 1 });
+    assert.equal(fast.shouldUse(1), false);
+    assert.equal(fast.supportsOperation('matmul'), false);
+    const explicitlyLoose = new G.EshkolWebGPU(device, {
+        precision: 'fast', threshold: 1, gateTolerance: 1e-4
+    });
+    assert.equal(explicitlyLoose.shouldUse(1), true);
+    assert.equal(explicitlyLoose.supportsOperation('matmul'), true);
+    assert.equal(explicitlyLoose.supportsOperation('reduce', G.REDUCE.SUM), false);
+}
+
+async function testExecutionMarkerAndCPUFallback() {
+    const restore = installMockJSPI();
+    try {
+        const memory = new WebAssembly.Memory({ initial: 1 });
+        const backend = {
+            device: {},
+            executionMarker: 0,
+            lastExecutionMarker: 0,
+            threshold: 1,
+            diagnostics: [],
+            fallbackCount: 0,
+            precision: 'high',
+            shouldUse: () => true,
+            supportsOperation: () => true,
+            setMemory: () => {},
+            async elementwiseF64() {
+                const marker = ++this.executionMarker;
+                this.lastExecutionMarker = marker;
+                return marker;
+            }
+        };
+        const imports = G.makeImports(backend, () => memory);
+        const markerStatus = await imports.eshkol_gpu_elementwise_f64(0, 16, 32, 2, G.ELEM.ADD);
+        assert.equal(markerStatus, 0);
+        assert.equal(backend.executionMarker, 1);
+
+        const A = new Float64Array(memory.buffer, 0, 2);
+        const B = new Float64Array(memory.buffer, 16, 2);
+        A.set([1, 2]);
+        B.set([3, 4]);
+        backend.elementwiseF64 = async () => 0;
+        const fallbackStatus = await imports.eshkol_gpu_elementwise_f64(0, 16, 32, 2, G.ELEM.ADD);
+        assert.equal(fallbackStatus, 0);
+        assert.deepEqual(Array.from(new Float64Array(memory.buffer, 32, 2)), [4, 6]);
+        assert.equal(backend.executionMarker, 1);
+        assert.equal(backend.lastPath, 'cpu:elem');
+        assert.equal(backend.fallbackCount, 1);
+    } finally {
+        restore();
+    }
+}
+
+async function testPromisingExports() {
+    const restore = installMockJSPI();
+    try {
+        const wrapped = G.promisingExports({ main: () => 7, run_program: () => 9, memory: {} });
+        assert.equal(await wrapped.main(), 7);
+        assert.equal(await wrapped.run_program(), 9);
+        assert.equal(wrapped.memory.constructor, Object);
+    } finally {
+        restore();
+    }
+}
+
+function testIntegrationContracts() {
+    const webgpu = fs.readFileSync(path.join(ROOT, 'web', 'eshkol-webgpu.js'), 'utf8');
+    const siteWebgpu = fs.readFileSync(path.join(ROOT, 'site', 'static', 'eshkol-webgpu.js'), 'utf8');
+    const repl = fs.readFileSync(path.join(ROOT, 'web', 'eshkol-repl.js'), 'utf8');
+    const runtime = fs.readFileSync(path.join(ROOT, 'site', 'static', 'eshkol-runtime.js'), 'utf8');
+    const workflow = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'gpu-execution-gate.yml'), 'utf8');
+
+    assert.equal(siteWebgpu, webgpu);
+    assert.match(webgpu, /@workgroup_size\(\$\{ELEM_WORKGROUP\}, 1, 1\)/);
+    assert.match(webgpu, /dispatchWorkgroups\(Math\.ceil\(n \/ ELEM_WORKGROUP\), 1, 1\)/);
+    assert.match(webgpu, /executionMarker/);
+    assert.match(webgpu, /lastExecutionMarker/);
+    assert.match(repl, /eshkol_batch_matmul_dispatch: gpu\.eshkol_batch_matmul_dispatch/);
+    assert.match(runtime, /eshkol_batch_matmul_dispatch: gpu\.eshkol_batch_matmul_dispatch/);
+    assert.match(repl, /G\.promisingExports\(instance\.exports\)/);
+    assert.match(runtime, /G\.promisingExports\(instance\.exports\)/);
+    assert.match(workflow, /GPU_GATE_TOL: '1e-9'/);
+    assert.match(workflow, /node scripts\/lib\/webgpu_diff_runner\.mjs/);
+}
+
+testPrecisionContracts();
+await testExecutionMarkerAndCPUFallback();
+await testPromisingExports();
+testIntegrationContracts();
+console.log('PASS webgpu regression contracts');

--- a/tests/webgpu/webgpu_regressions_test.mjs
+++ b/tests/webgpu/webgpu_regressions_test.mjs
@@ -26,7 +26,8 @@ function installMockJSPI() {
 
 function testPrecisionContracts() {
     const device = {};
-    const high = new G.EshkolWebGPU(device, { threshold: 1 });
+    const logs = [];
+    const high = new G.EshkolWebGPU(device, { threshold: 1, log: (msg) => logs.push(msg) });
     assert.equal(high.shouldUse(1), false);
     assert.equal(high.supportsOperation('matmul'), false);
     assert.equal(high.supportsOperation('elementwise', G.ELEM.ADD), false);
@@ -41,12 +42,57 @@ function testPrecisionContracts() {
     const fast = new G.EshkolWebGPU(device, { precision: 'fast', threshold: 1 });
     assert.equal(fast.shouldUse(1), false);
     assert.equal(fast.supportsOperation('matmul'), false);
+    const almostGate = new G.EshkolWebGPU(device, {
+        precision: 'fast', threshold: 1, gateTolerance: 1.000001e-9
+    });
+    assert.equal(almostGate.shouldUse(1), false);
+    assert.equal(almostGate.supportsOperation('matmul'), false);
     const explicitlyLoose = new G.EshkolWebGPU(device, {
-        precision: 'fast', threshold: 1, gateTolerance: 1e-4
+        precision: 'fast', threshold: 1, gateTolerance: 1e-4,
+        log: (msg) => logs.push(msg)
     });
     assert.equal(explicitlyLoose.shouldUse(1), true);
     assert.equal(explicitlyLoose.supportsOperation('matmul'), true);
     assert.equal(explicitlyLoose.supportsOperation('reduce', G.REDUCE.SUM), false);
+    assert.match(explicitlyLoose.diagnostics.join('\n'), /explicit reduced-precision opt-in/);
+    assert.match(logs.find((msg) => msg.includes('explicit reduced-precision opt-in')) || '',
+                 /fast tier/);
+
+    for (const precision of ['default', 'auto', 'bogus']) {
+        const unknown = new G.EshkolWebGPU(device, { precision, threshold: 1 });
+        assert.equal(unknown.shouldUse(1), false);
+        assert.equal(unknown.supportsOperation('matmul'), false);
+        assert.equal(unknown.supportsOperation('elementwise', G.ELEM.ADD), false);
+    }
+}
+
+function testCpuReferenceShape() {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const M = 3, K = 5, N = 7;
+    const aPtr = 0, bPtr = 128, cPtr = 512;
+    const A = new Float64Array(memory.buffer, aPtr, M * K);
+    const B = new Float64Array(memory.buffer, bPtr, K * N);
+    A.set(Array.from({ length: M * K }, (_, i) => (i - 7) / 3));
+    B.set(Array.from({ length: K * N }, (_, i) => (11 - i) / 5));
+    G.cpu.matmul({ buffer: memory.buffer }, aPtr, bPtr, cPtr, M, K, N);
+
+    const expected = [];
+    for (let i = 0; i < M; i++) {
+        for (let j = 0; j < N; j++) {
+            let sum = 0;
+            for (let k = 0; k < K; k++) sum += A[i * K + k] * B[k * N + j];
+            expected.push(sum);
+        }
+    }
+    assert.deepEqual(Array.from(new Float64Array(memory.buffer, cPtr, M * N)), expected);
+}
+
+function testHeadlessCpuPathFailsClosed() {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const imports = G.makeImports(null, () => memory);
+    assert.equal(imports.eshkol_gpu_init(), 0);
+    assert.equal(imports.eshkol_gpu_should_use(1), 0);
+    assert.equal(imports.eshkol_gpu_backend_available(G.ESHKOL_GPU_WEBGPU), 0);
 }
 
 async function testExecutionMarkerAndCPUFallback() {
@@ -111,6 +157,8 @@ function testIntegrationContracts() {
     const workflow = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'gpu-execution-gate.yml'), 'utf8');
 
     assert.equal(siteWebgpu, webgpu);
+    assert.match(webgpu, /@workgroup_size\(\$\{GEMM_TILE\}, \$\{GEMM_TILE\}, 1\)/);
+    assert.match(webgpu, /dispatchWorkgroups\(Math\.ceil\(N \/ GEMM_TILE\), Math\.ceil\(M \/ GEMM_TILE\), 1\)/);
     assert.match(webgpu, /@workgroup_size\(\$\{ELEM_WORKGROUP\}, 1, 1\)/);
     assert.match(webgpu, /dispatchWorkgroups\(Math\.ceil\(n \/ ELEM_WORKGROUP\), 1, 1\)/);
     assert.match(webgpu, /executionMarker/);
@@ -119,11 +167,17 @@ function testIntegrationContracts() {
     assert.match(runtime, /eshkol_batch_matmul_dispatch: gpu\.eshkol_batch_matmul_dispatch/);
     assert.match(repl, /G\.promisingExports\(instance\.exports\)/);
     assert.match(runtime, /G\.promisingExports\(instance\.exports\)/);
+    assert.match(repl, /promisingEntry\(fn\)/);
+    assert.match(runtime, /promisingEntry\(fn\)/);
+    assert.doesNotMatch(repl, /__indirect_function_table\.get\(callbackFuncPtr\)\(/);
+    assert.doesNotMatch(runtime, /__indirect_function_table\.get\(callbackFuncPtr\)\(/);
     assert.match(workflow, /GPU_GATE_TOL: '1e-9'/);
     assert.match(workflow, /node scripts\/lib\/webgpu_diff_runner\.mjs/);
 }
 
 testPrecisionContracts();
+testCpuReferenceShape();
+testHeadlessCpuPathFailsClosed();
 await testExecutionMarkerAndCPUFallback();
 await testPromisingExports();
 testIntegrationContracts();

--- a/tests/webgpu/webgpu_regressions_test.mjs
+++ b/tests/webgpu/webgpu_regressions_test.mjs
@@ -132,6 +132,17 @@ async function testExecutionMarkerAndCPUFallback() {
         assert.equal(backend.executionMarker, 1);
         assert.equal(backend.lastPath, 'cpu:elem');
         assert.equal(backend.fallbackCount, 1);
+
+        backend.elementwiseF64 = async () => {
+            const error = new Error('dispatch exceeded device limit');
+            error.webgpuValidation = true;
+            throw error;
+        };
+        await assert.rejects(
+            imports.eshkol_gpu_elementwise_f64(0, 16, 32, 2, G.ELEM.ADD),
+            /dispatch exceeded device limit/);
+        assert.equal(backend.fallbackCount, 1);
+        assert.equal(backend.lastPath, 'webgpu:error');
     } finally {
         restore();
     }
@@ -158,9 +169,13 @@ function testIntegrationContracts() {
 
     assert.equal(siteWebgpu, webgpu);
     assert.match(webgpu, /@workgroup_size\(\$\{GEMM_TILE\}, \$\{GEMM_TILE\}, 1\)/);
-    assert.match(webgpu, /dispatchWorkgroups\(Math\.ceil\(N \/ GEMM_TILE\), Math\.ceil\(M \/ GEMM_TILE\), 1\)/);
+    assert.match(webgpu, /maxComputeWorkgroupsPerDimension/);
+    assert.match(webgpu, /baseX \* GEMM_TILE, baseY \* GEMM_TILE/);
+    assert.match(webgpu, /_submitDispatch\(enc, pass, x, y, 1/);
+    assert.match(webgpu, /pushErrorScope\('validation'\)/);
+    assert.match(webgpu, /webgpuValidation/);
     assert.match(webgpu, /@workgroup_size\(\$\{ELEM_WORKGROUP\}, 1, 1\)/);
-    assert.match(webgpu, /dispatchWorkgroups\(Math\.ceil\(n \/ ELEM_WORKGROUP\), 1, 1\)/);
+    assert.match(webgpu, /await this\._submitDispatch\(enc, pass, Math\.ceil\(n \/ ELEM_WORKGROUP\), 1, 1/);
     assert.match(webgpu, /executionMarker/);
     assert.match(webgpu, /lastExecutionMarker/);
     assert.match(repl, /eshkol_batch_matmul_dispatch: gpu\.eshkol_batch_matmul_dispatch/);

--- a/web/eshkol-repl.js
+++ b/web/eshkol-repl.js
@@ -215,6 +215,10 @@ class EshkolRepl {
      * @returns {Object} - { instance, exports }
      */
     async instantiate(module) {
+        if (this._webgpuStatus === undefined &&
+            typeof globalThis !== 'undefined' && globalThis.EshkolWebGPU) {
+            await this.initWebGPU();
+        }
         // Create import object with runtime functions
         const imports = this.createImports();
 
@@ -242,6 +246,102 @@ class EshkolRepl {
         }
     }
 
+    // === WebGPU compute backend ===
+
+    /**
+     * Acquire a WebGPU device, if this browser has one. Must be awaited
+     * BEFORE createImports() — the GPU env entries are built once, and
+     * whether they are GPU-backed or CPU-backed is decided at that moment.
+     *
+     * Resolves to a result object rather than throwing: no WebGPU, no JSPI,
+     * or no adapter all mean "run on the CPU", never "fail to load".
+     */
+    async initWebGPU(opts) {
+        const G = (typeof globalThis !== 'undefined') && globalThis.EshkolWebGPU;
+        if (!G) {
+            this._webgpuStatus = { ok: false, reason: 'eshkol-webgpu.js not loaded' };
+            return this._webgpuStatus;
+        }
+        if (!G.jspiAvailable()) {
+            // WebGPU readback is async and the wasm runtime is synchronous;
+            // without JSPI there is no way to suspend, so the CPU path is the
+            // only correct one. Say so rather than pretending the GPU ran.
+            this._webgpuStatus = { ok: false, reason: 'JSPI unavailable (WebAssembly.Suspending missing)' };
+            return this._webgpuStatus;
+        }
+        const res = await G.create(opts || {});
+        this._webgpuBackend = res.ok ? res.backend : null;
+        this.__gpuEnv = null;
+        if (res.ok && typeof globalThis !== 'undefined') {
+            // gpu_memory_webgpu.cpp consults this ordinary backend seam from
+            // its EM_ASYNC_JS bridge. Keep the page-owned device visible to
+            // the linked wasm runtime before its first dispatch.
+            globalThis.eshkolWebGPUBackend = res.backend;
+        }
+        this._webgpuStatus = res;
+        return res;
+    }
+
+    /** The WebGPU backend object, or null when running on the CPU path. */
+    get webgpuBackend() { return this._webgpuBackend || null; }
+
+    /**
+     * Build (once) the GPU/tensor env entries. Uses the shared WebGPU module
+     * when it is present, and a compact CPU implementation otherwise, so the
+     * loader keeps working if eshkol-webgpu.js is not on the page.
+     */
+    _gpuEnv() {
+        if (this.__gpuEnv) return this.__gpuEnv;
+        const memRef = () => this.memory;
+        const G = (typeof globalThis !== 'undefined') && globalThis.EshkolWebGPU;
+        this.__gpuEnv = G
+            ? G.makeImports(this._webgpuBackend || null, memRef)
+            : EshkolRepl._cpuOnlyGpuEnv(memRef);
+        return this.__gpuEnv;
+    }
+
+    /** CPU-only GPU env, used when eshkol-webgpu.js is absent. */
+    static _cpuOnlyGpuEnv(memRef) {
+        const f64 = (p, n) => new Float64Array(memRef().buffer, p, n);
+        return {
+            eshkol_matmul_dispatch: (aP, bP, cP, M, K, N) => {
+                M = Number(M); K = Number(K); N = Number(N);
+                const A = f64(aP, M * K), B = f64(bP, K * N), C = f64(cP, M * N);
+                for (let i = 0; i < M; i++)
+                    for (let j = 0; j < N; j++) {
+                        let s = 0;
+                        for (let k = 0; k < K; k++) s += A[i * K + k] * B[k * N + j];
+                        C[i * N + j] = s;
+                    }
+            },
+            eshkol_batch_matmul_dispatch: (aP, bP, cP, batch, M, K, N) => {
+                batch = Number(batch); M = Number(M); K = Number(K); N = Number(N);
+                const aStride = M * K, bStride = K * N, cStride = M * N;
+                for (let q = 0; q < batch; q++) {
+                    const A = f64(aP + q * aStride * 8, aStride);
+                    const B = f64(bP + q * bStride * 8, bStride);
+                    const C = f64(cP + q * cStride * 8, cStride);
+                    for (let i = 0; i < M; i++) for (let j = 0; j < N; j++) {
+                        let s = 0;
+                        for (let k = 0; k < K; k++) s += A[i * K + k] * B[k * N + j];
+                        C[i * N + j] = s;
+                    }
+                }
+            },
+            eshkol_gpu_elementwise_f64: () => -1,
+            eshkol_gpu_reduce_f64: () => -1,
+            eshkol_gpu_init: () => 0,
+            eshkol_gpu_shutdown: () => {},
+            eshkol_gpu_get_backend: () => 0,
+            eshkol_gpu_backend_available: () => 0,
+            eshkol_gpu_supports_f64: () => 0,
+            eshkol_gpu_has_fp64: () => 0,
+            eshkol_gpu_should_use: () => 0,
+            eshkol_gpu_set_threshold: () => {},
+            eshkol_gpu_get_threshold: () => 100000
+        };
+    }
+
     /**
      * Create WebAssembly import object with runtime functions
      * @returns {Object} - Import object for WebAssembly.instantiate
@@ -251,6 +351,7 @@ class EshkolRepl {
         if (!this.memory) {
             this.memory = new WebAssembly.Memory({ initial: 256, maximum: 4096 });
         }
+        const gpu = this._gpuEnv();
 
         return {
             env: {
@@ -387,6 +488,31 @@ class EshkolRepl {
                 eshkol_tensor_matrix_operand_checked: () => 0,
                 eshkol_tensor_counts_checked: () => {},
                 eshkol_tensor_axis_checked: (axis) => axis,
+
+                // GPU compute (WebGPU). These are the ordinary GPU dispatch
+                // seam — the same symbols the native Metal/CUDA backends
+                // define in lib/backend/gpu/ — not a browser-special path.
+                // eshkol_matmul_dispatch is what codegenMatmul emits; the
+                // rest mirror the gpu_memory.h surface so a program can query
+                // and steer dispatch. Values come from _gpuEnv(): a
+                // WebAssembly.Suspending wrapper when WebGPU+JSPI are both
+                // present, a plain synchronous CPU function otherwise.
+                // Keep these keys IDENTICAL to site/static/eshkol-runtime.js —
+                // the INV-wasm-import-glue-equality invariant in
+                // .icc/architecture-model.yaml is critical-severity.
+                eshkol_matmul_dispatch: gpu.eshkol_matmul_dispatch,
+                eshkol_gpu_elementwise_f64: gpu.eshkol_gpu_elementwise_f64,
+                eshkol_gpu_reduce_f64: gpu.eshkol_gpu_reduce_f64,
+                eshkol_gpu_init: gpu.eshkol_gpu_init,
+                eshkol_gpu_shutdown: gpu.eshkol_gpu_shutdown,
+                eshkol_gpu_get_backend: gpu.eshkol_gpu_get_backend,
+                eshkol_gpu_backend_available: gpu.eshkol_gpu_backend_available,
+                eshkol_gpu_supports_f64: gpu.eshkol_gpu_supports_f64,
+                eshkol_gpu_has_fp64: gpu.eshkol_gpu_has_fp64,
+                eshkol_gpu_should_use: gpu.eshkol_gpu_should_use,
+                eshkol_gpu_set_threshold: gpu.eshkol_gpu_set_threshold,
+                eshkol_gpu_get_threshold: gpu.eshkol_gpu_get_threshold,
+
                 eshkol_format_double: () => 0,
                 eshkol_fprint_double: () => 0,
                 eshkol_set_error_location: () => {},

--- a/web/eshkol-repl.js
+++ b/web/eshkol-repl.js
@@ -224,10 +224,17 @@ class EshkolRepl {
 
         try {
             const instance = await WebAssembly.instantiate(module, imports);
-            this.instances.push(instance);
+            const G = (typeof globalThis !== 'undefined') && globalThis.EshkolWebGPU;
+            const publicExports = G && typeof G.promisingExports === 'function'
+                ? G.promisingExports(instance.exports) : instance.exports;
+            /* WebAssembly.Instance exports are immutable as a property of the
+             * instance. Keep the raw instance available while exposing the
+             * JSPI-promising export facade to every REPL caller. */
+            const publicInstance = { rawInstance: instance, exports: publicExports };
+            this.instances.push(publicInstance);
 
             // Register exports as symbols
-            for (const [name, value] of Object.entries(instance.exports)) {
+            for (const [name, value] of Object.entries(publicExports)) {
                 if (typeof value === 'function') {
                     this.symbols.set(name, {
                         func: value,
@@ -237,8 +244,8 @@ class EshkolRepl {
             }
 
             return {
-                instance: instance,
-                exports: instance.exports
+                instance: publicInstance,
+                exports: publicExports
             };
         } catch (e) {
             console.error('Instantiation failed:', e);
@@ -501,6 +508,7 @@ class EshkolRepl {
                 // the INV-wasm-import-glue-equality invariant in
                 // .icc/architecture-model.yaml is critical-severity.
                 eshkol_matmul_dispatch: gpu.eshkol_matmul_dispatch,
+                eshkol_batch_matmul_dispatch: gpu.eshkol_batch_matmul_dispatch,
                 eshkol_gpu_elementwise_f64: gpu.eshkol_gpu_elementwise_f64,
                 eshkol_gpu_reduce_f64: gpu.eshkol_gpu_reduce_f64,
                 eshkol_gpu_init: gpu.eshkol_gpu_init,

--- a/web/eshkol-repl.js
+++ b/web/eshkol-repl.js
@@ -253,6 +253,20 @@ class EshkolRepl {
         }
     }
 
+    /* Function-table entries are not part of the export facade, so a browser
+     * callback must wrap the raw table entry at its JS entry point too. This
+     * pairs callback-side GPU suspensions with JSPI just like direct exports. */
+    invokeWasmCallback(callbackFuncPtr, ...args) {
+        const current = this.instances[this.instances.length - 1];
+        const table = current?.exports?.__indirect_function_table;
+        const fn = table && table.get(callbackFuncPtr);
+        if (typeof fn !== 'function') throw new Error('missing WASM callback ' + callbackFuncPtr);
+        const G = (typeof globalThis !== 'undefined') && globalThis.EshkolWebGPU;
+        const entry = G && typeof G.promisingEntry === 'function'
+            ? G.promisingEntry(fn) : fn;
+        return entry(...args);
+    }
+
     // === WebGPU compute backend ===
 
     /**
@@ -1383,14 +1397,18 @@ class EshkolRepl {
                         const callback = (e) => {
                             // Store event data for access from WASM
                             const eventHandle = this.createHandle(e);
+                            let releaseAfterPromise = false;
                             try {
                                 // Call the WASM function
-                                const fn = this.instances[this.instances.length - 1]?.exports;
-                                if (fn && fn.__indirect_function_table) {
-                                    fn.__indirect_function_table.get(callbackFuncPtr)(eventHandle);
+                                const result = this.invokeWasmCallback(callbackFuncPtr, eventHandle);
+                                if (result && typeof result.then === 'function') {
+                                    releaseAfterPromise = true;
+                                    result.catch((error) => console.error('Event callback error:', error))
+                                        .finally(() => this.releaseHandle(eventHandle));
+                                    return;
                                 }
                             } finally {
-                                this.releaseHandle(eventHandle);
+                                if (!releaseAfterPromise) this.releaseHandle(eventHandle);
                             }
                         };
                         el.addEventListener(event, callback);
@@ -1461,9 +1479,9 @@ class EshkolRepl {
                 web_set_timeout: (callbackFuncPtr, delayMs) => {
                     const id = setTimeout(() => {
                         try {
-                            const fn = this.instances[this.instances.length - 1]?.exports;
-                            if (fn && fn.__indirect_function_table) {
-                                fn.__indirect_function_table.get(callbackFuncPtr)();
+                            const result = this.invokeWasmCallback(callbackFuncPtr);
+                            if (result && typeof result.then === 'function') {
+                                result.catch((error) => console.error('Timeout callback error:', error));
                             }
                         } catch (e) {
                             console.error('Timeout callback error:', e);
@@ -1474,9 +1492,9 @@ class EshkolRepl {
                 web_set_interval: (callbackFuncPtr, delayMs) => {
                     const id = setInterval(() => {
                         try {
-                            const fn = this.instances[this.instances.length - 1]?.exports;
-                            if (fn && fn.__indirect_function_table) {
-                                fn.__indirect_function_table.get(callbackFuncPtr)();
+                            const result = this.invokeWasmCallback(callbackFuncPtr);
+                            if (result && typeof result.then === 'function') {
+                                result.catch((error) => console.error('Interval callback error:', error));
                             }
                         } catch (e) {
                             console.error('Interval callback error:', e);
@@ -1493,9 +1511,9 @@ class EshkolRepl {
                 web_request_animation_frame: (callbackFuncPtr) => {
                     return requestAnimationFrame((timestamp) => {
                         try {
-                            const fn = this.instances[this.instances.length - 1]?.exports;
-                            if (fn && fn.__indirect_function_table) {
-                                fn.__indirect_function_table.get(callbackFuncPtr)(timestamp);
+                            const result = this.invokeWasmCallback(callbackFuncPtr, timestamp);
+                            if (result && typeof result.then === 'function') {
+                                result.catch((error) => console.error('RAF callback error:', error));
                             }
                         } catch (e) {
                             console.error('RAF callback error:', e);

--- a/web/eshkol-webgpu.js
+++ b/web/eshkol-webgpu.js
@@ -16,7 +16,8 @@
  *           the CPU path. (An sf64/Ozaki-II WGSL port is a named follow-up.)
  *   high  : df32 -- each f64 carried as an unevaluated (hi, lo) pair of f32,
  *           Dekker/Knuth double-float arithmetic. ~48 bits of mantissa against
- *           f64's 53. THIS IS THE WebGPU DEFAULT.
+ *           f64's 53. THIS IS THE WebGPU DEFAULT and is admitted only when the
+ *           fused-fma probe succeeds.
  *   fast  : plain f32, ~24 bits.
  *
  * Defaulting to `high` rather than `exact` is a deliberate, documented
@@ -62,6 +63,7 @@
     const REDUCE_WORKGROUP = 256;
     const GEMM_TILE = 8;
     const ELEM_WORKGROUP = 64;
+    const GPU_GATE_TOL = 1e-9;
 
     /* ===================== WGSL ===================== */
 
@@ -158,7 +160,7 @@ struct Params { n: u32, op: u32, pad0: u32, pad1: u32 };
 @group(0) @binding(2) var<storage, read_write> OUT: array<f32>;
 @group(0) @binding(3) var<uniform> p: Params;
 
-@compute @workgroup_size(1, 1, 1)
+@compute @workgroup_size(${ELEM_WORKGROUP}, 1, 1)
 fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let i = gid.x;
     if (i >= p.n) { return; }
@@ -325,11 +327,16 @@ fn main() {
             this.threshold = (typeof o.threshold === 'number' && o.threshold > 0)
                 ? o.threshold : DEFAULT_THRESHOLD;
             this.precision = o.precision || 'high';
+            this.gateTolerance = (typeof o.gateTolerance === 'number' &&
+                                  Number.isFinite(o.gateTolerance) &&
+                                  o.gateTolerance > 0) ? o.gateTolerance : GPU_GATE_TOL;
             this.pipelines = new Map();
             this.uniformPool = [];
             /* Non-vacuity telemetry: a differential gate asserts these move. */
             this.dispatchCount = 0;
             this.fallbackCount = 0;
+            this.executionMarker = 0;
+            this.lastExecutionMarker = 0;
             this.lastPath = 'none';
             this.fmaFused = true;
             this.memory = null;
@@ -430,21 +437,29 @@ fn main() {
          * element-count threshold. The `exact` tier has no WGSL implementation,
          * so it reports false and the caller takes the CPU path. */
         shouldUse(numElements) {
-            if (!this.device) return false;
-            if (this.precision === 'exact') return false;
+            if (!this.device || this.precision === 'exact') return false;
+            /* The checked-in df32 shader is intentionally fail-closed until
+             * the browser differential gate certifies its compensation path.
+             * Selection and operation support must agree: neither may claim
+             * that the unverified high tier is GPU-capable. */
+            if (this.precision === 'high') return false;
+            if (this.precision === 'fast' && this.gateTolerance <= GPU_GATE_TOL) return false;
             return numElements >= this.threshold;
         }
 
         supportsOperation(kind, op) {
-            /* The checked-in df32 path is present, but this browser/runtime
-             * has not met the repository's 1e-9 gate. Refuse it until a
-             * verified precise-math or Ozaki implementation is available. */
-            if (!this.device || this.precision === 'exact' || this.precision === 'high' || !this.fmaFused) return false;
-            if (this.precision === 'fast') return true;
+            if (!this.device || this.precision === 'exact') return false;
+            if (this.precision === 'high') return false;
+            if (this.precision === 'fast') {
+                /* f32 is never admitted to the 1e-9 gate. It is available only
+                 * when the caller explicitly supplies a looser contract, and
+                 * reductions remain unsupported because their kernel is df32. */
+                return this.gateTolerance > GPU_GATE_TOL &&
+                    ['matmul', 'elementwise'].includes(kind);
+            }
             if (kind === 'elementwise') return Number(op) <= ELEM.ABS;
             if (kind === 'reduce') {
-                return this.precision !== 'fast' &&
-                    [REDUCE.SUM, REDUCE.MIN, REDUCE.MAX, REDUCE.MEAN].includes(Number(op));
+                return [REDUCE.SUM, REDUCE.MIN, REDUCE.MAX, REDUCE.MEAN].includes(Number(op));
             }
             return kind === 'matmul';
         }
@@ -500,22 +515,41 @@ fn main() {
             return buf;
         }
 
+        _recordExecution(path) {
+            const marker = ++this.executionMarker;
+            this.lastExecutionMarker = marker;
+            this.dispatchCount++;
+            this.lastPath = path;
+            return marker;
+        }
+
+        _destroyBuffers(...buffers) {
+            for (const buffer of buffers) if (buffer) buffer.destroy();
+        }
+
         /* The single async boundary. Everything above is synchronous JS;
          * only the readback suspends, and JSPI carries the wasm stack across
          * exactly this await. */
         async _readback(gpuBuf, bytes) {
-            const read = this.device.createBuffer({
-                size: bytes,
-                usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
-            });
-            const enc = this.device.createCommandEncoder();
-            enc.copyBufferToBuffer(gpuBuf, 0, read, 0, bytes);
-            this.device.queue.submit([enc.finish()]);
-            await read.mapAsync(GPUMapMode.READ);
-            const copy = read.getMappedRange().slice(0);
-            read.unmap();
-            read.destroy();
-            return copy;
+            let read = null;
+            let mapped = false;
+            try {
+                read = this.device.createBuffer({
+                    size: bytes,
+                    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+                });
+                const enc = this.device.createCommandEncoder();
+                enc.copyBufferToBuffer(gpuBuf, 0, read, 0, bytes);
+                this.device.queue.submit([enc.finish()]);
+                await read.mapAsync(GPUMapMode.READ);
+                mapped = true;
+                return read.getMappedRange().slice(0);
+            } finally {
+                if (read) {
+                    if (mapped) read.unmap();
+                    read.destroy();
+                }
+            }
         }
 
         /* ---------------- GEMM ---------------- */
@@ -531,43 +565,42 @@ fn main() {
             const encB = df ? encodeDf32(B, K * N) : encodeF32(B, K * N);
             const outBytes = M * N * (df ? 8 : 4);
 
-            const bufA = this._storage(encA);
-            const bufB = this._storage(encB);
-            const bufC = this._outStorage(outBytes);
-            const dims = this._uniform([M, K, N, 0]);
-            const opaque = df ? this._opaque(M * N) : null;
+            let bufA = null, bufB = null, bufC = null, dims = null, opaque = null;
+            try {
+                bufA = this._storage(encA);
+                bufB = this._storage(encB);
+                bufC = this._outStorage(outBytes);
+                dims = this._uniform([M, K, N, 0]);
+                opaque = df ? this._opaque(M * N) : null;
 
-            const pipe = this._pipeline(df ? 'gemm_df32' : 'gemm_f32',
-                                        df ? WGSL_GEMM_DF32 : WGSL_GEMM_F32);
-            const bg = this.device.createBindGroup({
-                layout: pipe.getBindGroupLayout(0),
-                entries: [
-                    { binding: 0, resource: { buffer: bufA } },
-                    { binding: 1, resource: { buffer: bufB } },
-                    { binding: 2, resource: { buffer: bufC } },
-                    { binding: 3, resource: { buffer: dims } },
-                    ...(opaque ? [{ binding: 4, resource: { buffer: opaque } }] : [])
-                ]
-            });
-            const enc = this.device.createCommandEncoder();
-            const pass = enc.beginComputePass();
-            pass.setPipeline(pipe);
-            pass.setBindGroup(0, bg);
-            pass.dispatchWorkgroups(
-                N, M, 1);
-            pass.end();
-            this.device.queue.submit([enc.finish()]);
+                const pipe = this._pipeline(df ? 'gemm_df32' : 'gemm_f32',
+                                            df ? WGSL_GEMM_DF32 : WGSL_GEMM_F32);
+                const bg = this.device.createBindGroup({
+                    layout: pipe.getBindGroupLayout(0),
+                    entries: [
+                        { binding: 0, resource: { buffer: bufA } },
+                        { binding: 1, resource: { buffer: bufB } },
+                        { binding: 2, resource: { buffer: bufC } },
+                        { binding: 3, resource: { buffer: dims } },
+                        ...(opaque ? [{ binding: 4, resource: { buffer: opaque } }] : [])
+                    ]
+                });
+                const enc = this.device.createCommandEncoder();
+                const pass = enc.beginComputePass();
+                pass.setPipeline(pipe);
+                pass.setBindGroup(0, bg);
+                pass.dispatchWorkgroups(Math.ceil(N / GEMM_TILE), Math.ceil(M / GEMM_TILE), 1);
+                pass.end();
+                this.device.queue.submit([enc.finish()]);
 
-            const raw = await this._readback(bufC, outBytes);
-            const C = this._f64View(cPtr, M * N);
-            if (df) decodeDf32(new Float32Array(raw), C, M * N);
-            else { const f = new Float32Array(raw); for (let i = 0; i < M * N; i++) C[i] = f[i]; }
-
-            bufA.destroy(); bufB.destroy(); bufC.destroy(); dims.destroy();
-            if (opaque) opaque.destroy();
-            this.dispatchCount++;
-            this.lastPath = df ? 'webgpu:gemm_df32' : 'webgpu:gemm_f32';
-            return 0;
+                const raw = await this._readback(bufC, outBytes);
+                const C = this._f64View(cPtr, M * N);
+                if (df) decodeDf32(new Float32Array(raw), C, M * N);
+                else { const f = new Float32Array(raw); for (let i = 0; i < M * N; i++) C[i] = f[i]; }
+                return this._recordExecution(df ? 'webgpu:gemm_df32' : 'webgpu:gemm_f32');
+            } finally {
+                this._destroyBuffers(bufA, bufB, bufC, dims, opaque);
+            }
         }
 
         /* ---------------- elementwise ---------------- */
@@ -605,42 +638,42 @@ fn main() {
             }
 
             const bytes = n * (df ? 8 : 4);
-            const bufA = this._storage(encA);
-            const bufB = this._storage(encB);
-            const bufO = this._outStorage(bytes);
-            const params = this._uniform([n, op, 0, 0]);
-            const opaque = df ? this._opaque(n) : null;
+            let bufA = null, bufB = null, bufO = null, params = null, opaque = null;
+            try {
+                bufA = this._storage(encA);
+                bufB = this._storage(encB);
+                bufO = this._outStorage(bytes);
+                params = this._uniform([n, op, 0, 0]);
+                opaque = df ? this._opaque(n) : null;
 
-            const pipe = this._pipeline(df ? 'elem_df32' : 'elem_f32',
-                                        df ? WGSL_ELEM_DF32 : WGSL_ELEM_F32);
-            const bg = this.device.createBindGroup({
-                layout: pipe.getBindGroupLayout(0),
-                entries: [
-                    { binding: 0, resource: { buffer: bufA } },
-                    { binding: 1, resource: { buffer: bufB } },
-                    { binding: 2, resource: { buffer: bufO } },
-                    { binding: 3, resource: { buffer: params } },
-                    ...(opaque ? [{ binding: 4, resource: { buffer: opaque } }] : [])
-                ]
-            });
-            const enc = this.device.createCommandEncoder();
-            const pass = enc.beginComputePass();
-            pass.setPipeline(pipe);
-            pass.setBindGroup(0, bg);
-            pass.dispatchWorkgroups(n, 1, 1);
-            pass.end();
-            this.device.queue.submit([enc.finish()]);
+                const pipe = this._pipeline(df ? 'elem_df32' : 'elem_f32',
+                                            df ? WGSL_ELEM_DF32 : WGSL_ELEM_F32);
+                const bg = this.device.createBindGroup({
+                    layout: pipe.getBindGroupLayout(0),
+                    entries: [
+                        { binding: 0, resource: { buffer: bufA } },
+                        { binding: 1, resource: { buffer: bufB } },
+                        { binding: 2, resource: { buffer: bufO } },
+                        { binding: 3, resource: { buffer: params } },
+                        ...(opaque ? [{ binding: 4, resource: { buffer: opaque } }] : [])
+                    ]
+                });
+                const enc = this.device.createCommandEncoder();
+                const pass = enc.beginComputePass();
+                pass.setPipeline(pipe);
+                pass.setBindGroup(0, bg);
+                pass.dispatchWorkgroups(Math.ceil(n / ELEM_WORKGROUP), 1, 1);
+                pass.end();
+                this.device.queue.submit([enc.finish()]);
 
-            const raw = await this._readback(bufO, bytes);
-            const O = this._f64View(outPtr, n);
-            if (df) decodeDf32(new Float32Array(raw), O, n);
-            else { const f = new Float32Array(raw); for (let i = 0; i < n; i++) O[i] = f[i]; }
-
-            bufA.destroy(); bufB.destroy(); bufO.destroy(); params.destroy();
-            if (opaque) opaque.destroy();
-            this.dispatchCount++;
-            this.lastPath = df ? 'webgpu:elem_df32' : 'webgpu:elem_f32';
-            return 0;
+                const raw = await this._readback(bufO, bytes);
+                const O = this._f64View(outPtr, n);
+                if (df) decodeDf32(new Float32Array(raw), O, n);
+                else { const f = new Float32Array(raw); for (let i = 0; i < n; i++) O[i] = f[i]; }
+                return this._recordExecution(df ? 'webgpu:elem_df32' : 'webgpu:elem_f32');
+            } finally {
+                this._destroyBuffers(bufA, bufB, bufO, params, opaque);
+            }
         }
 
         /* ---------------- reduction ---------------- */
@@ -660,57 +693,57 @@ fn main() {
             const groups = Math.min(64, Math.max(1, Math.ceil(n / REDUCE_WORKGROUP)));
             const perGroup = Math.ceil(n / groups);
 
-            const bufIn = this._storage(enc0);
-            const bufOut = this._outStorage(groups * 8);
-            const params = this._uniform([n, kernelOp, perGroup, 0]);
-            const opaque = this._opaque(groups);
+            let bufIn = null, bufOut = null, params = null, opaque = null;
+            try {
+                bufIn = this._storage(enc0);
+                bufOut = this._outStorage(groups * 8);
+                params = this._uniform([n, kernelOp, perGroup, 0]);
+                opaque = this._opaque(groups);
 
-            const pipe = this._pipeline('reduce_df32', WGSL_REDUCE_DF32);
-            const bg = this.device.createBindGroup({
-                layout: pipe.getBindGroupLayout(0),
-                entries: [
-                    { binding: 0, resource: { buffer: bufIn } },
-                    { binding: 1, resource: { buffer: bufOut } },
-                    { binding: 2, resource: { buffer: params } },
-                    { binding: 4, resource: { buffer: opaque } }
-                ]
-            });
-            const enc = this.device.createCommandEncoder();
-            const pass = enc.beginComputePass();
-            pass.setPipeline(pipe);
-            pass.setBindGroup(0, bg);
-            pass.dispatchWorkgroups(groups, 1, 1);
-            pass.end();
-            this.device.queue.submit([enc.finish()]);
+                const pipe = this._pipeline('reduce_df32', WGSL_REDUCE_DF32);
+                const bg = this.device.createBindGroup({
+                    layout: pipe.getBindGroupLayout(0),
+                    entries: [
+                        { binding: 0, resource: { buffer: bufIn } },
+                        { binding: 1, resource: { buffer: bufOut } },
+                        { binding: 2, resource: { buffer: params } },
+                        { binding: 4, resource: { buffer: opaque } }
+                    ]
+                });
+                const enc = this.device.createCommandEncoder();
+                const pass = enc.beginComputePass();
+                pass.setPipeline(pipe);
+                pass.setBindGroup(0, bg);
+                pass.dispatchWorkgroups(groups, 1, 1);
+                pass.end();
+                this.device.queue.submit([enc.finish()]);
 
-            const raw = await this._readback(bufOut, groups * 8);
-            const partials = new Float32Array(raw);
+                const raw = await this._readback(bufOut, groups * 8);
+                const partials = new Float32Array(raw);
 
-            /* Final cross-group combine on the host in full f64. */
-            let acc;
-            switch (kernelOp) {
-                case REDUCE.PROD: acc = 1; break;
-                case REDUCE.MIN: acc = Infinity; break;
-                case REDUCE.MAX: acc = -Infinity; break;
-                default: acc = 0; break;
-            }
-            for (let g = 0; g < groups; g++) {
-                const v = partials[g * 2] + partials[g * 2 + 1];
+                /* Final cross-group combine on the host in full f64. */
+                let acc;
                 switch (kernelOp) {
-                    case REDUCE.PROD: acc *= v; break;
-                    case REDUCE.MIN: acc = v < acc ? v : acc; break;
-                    case REDUCE.MAX: acc = v > acc ? v : acc; break;
-                    default: acc += v; break;
+                    case REDUCE.PROD: acc = 1; break;
+                    case REDUCE.MIN: acc = Infinity; break;
+                    case REDUCE.MAX: acc = -Infinity; break;
+                    default: acc = 0; break;
                 }
+                for (let g = 0; g < groups; g++) {
+                    const v = partials[g * 2] + partials[g * 2 + 1];
+                    switch (kernelOp) {
+                        case REDUCE.PROD: acc *= v; break;
+                        case REDUCE.MIN: acc = v < acc ? v : acc; break;
+                        case REDUCE.MAX: acc = v > acc ? v : acc; break;
+                        default: acc += v; break;
+                    }
+                }
+                if (op === REDUCE.MEAN) acc /= n;
+                this._f64View(outPtr, 1)[0] = acc;
+                return this._recordExecution('webgpu:reduce_df32');
+            } finally {
+                this._destroyBuffers(bufIn, bufOut, params, opaque);
             }
-            if (op === REDUCE.MEAN) acc /= n;
-            this._f64View(outPtr, 1)[0] = acc;
-
-            bufIn.destroy(); bufOut.destroy(); params.destroy();
-            if (opaque) opaque.destroy();
-            this.dispatchCount++;
-            this.lastPath = 'webgpu:reduce_df32';
-            return 0;
         }
     }
 
@@ -800,12 +833,18 @@ fn main() {
      * the program correctly, just on the CPU.
      */
     function makeImports(backend, memoryRef) {
-        const jspi = (typeof WebAssembly.Suspending === 'function');
+        const jspi = jspiAvailable();
         const mem = () => (backend && backend.memory) || memoryRef();
 
         function sync(fn) { return fn; }
         function suspending(fn) {
             return jspi ? new WebAssembly.Suspending(fn) : null;
+        }
+
+        function verified(marker, before) {
+            return Number.isSafeInteger(marker) && marker > before &&
+                   backend.executionMarker === marker &&
+                   backend.lastExecutionMarker === marker;
         }
 
         /* Each entry: if the GPU can serve this call, suspend into the async
@@ -822,7 +861,12 @@ fn main() {
                     M = Number(M); K = Number(K); N = Number(N);
                     backend.setMemory(mem());
                     if (backend.shouldUse(M * N) && backend.supportsOperation('matmul')) {
-                        try { return void (await backend.matmulF64(aPtr, bPtr, cPtr, M, K, N)); }
+                        const before = backend.executionMarker;
+                        try {
+                            const marker = await backend.matmulF64(aPtr, bPtr, cPtr, M, K, N);
+                            if (verified(marker, before)) return 0;
+                            throw new Error('missing WebGPU execution marker');
+                        }
                         catch (e) { backend.diagnostics.push('gemm failed, CPU fallback: ' + e); }
                     }
                     if (backend.shouldUse(M * N)) backend.diagnostics.push('UNSUPPORTED: matmul refused before GPU_GATE_TOL certification');
@@ -836,7 +880,12 @@ fn main() {
                     n = Number(n); op = Number(op);
                     backend.setMemory(mem());
                     if (backend.shouldUse(n) && backend.supportsOperation('elementwise', op)) {
-                        try { await backend.elementwiseF64(aPtr, bPtr, outPtr, n, op); return 0; }
+                        const before = backend.executionMarker;
+                        try {
+                            const marker = await backend.elementwiseF64(aPtr, bPtr, outPtr, n, op);
+                            if (verified(marker, before)) return 0;
+                            throw new Error('missing WebGPU execution marker');
+                        }
                         catch (e) { backend.diagnostics.push('elementwise failed, CPU fallback: ' + e); }
                     }
                     if (backend.shouldUse(n)) backend.diagnostics.push('UNSUPPORTED: elementwise operation refused before GPU_GATE_TOL certification');
@@ -851,7 +900,12 @@ fn main() {
                     n = Number(n); op = Number(op);
                     backend.setMemory(mem());
                     if (backend.shouldUse(n) && backend.supportsOperation('reduce', op)) {
-                        try { await backend.reduceF64(inPtr, outPtr, n, op); return 0; }
+                        const before = backend.executionMarker;
+                        try {
+                            const marker = await backend.reduceF64(inPtr, outPtr, n, op);
+                            if (verified(marker, before)) return 0;
+                            throw new Error('missing WebGPU execution marker');
+                        }
                         catch (e) { backend.diagnostics.push('reduce failed, CPU fallback: ' + e); }
                     }
                     if (backend.shouldUse(n)) backend.diagnostics.push('UNSUPPORTED: reduction refused before GPU_GATE_TOL certification');
@@ -880,7 +934,7 @@ fn main() {
         /* Batched matmul has no browser WGSL kernel yet. Keep the import
          * callable and route it through the CPU reference; it must never be
          * mistaken for a GPU dispatch. */
-        entries.eshkol_batch_matmul_dispatch = (aPtr, bPtr, cPtr, batch, M, K, N) =>
+        entries.eshkol_batch_matmul_dispatch = (aPtr, bPtr, cPtr, batch, M, K, N, dtype) =>
             cpu.batchMatmul(mem(), aPtr, bPtr, cPtr,
                             Number(batch), Number(M), Number(K), Number(N));
 
@@ -910,6 +964,20 @@ fn main() {
         return fn;
     }
 
+    /* A WebAssembly.Instance exports object is not replaceable in place. Build
+     * a public export facade so every synchronous wasm entry that can reach a
+     * suspending GPU import is paired with WebAssembly.promising. Keeping the
+     * non-function exports (memory, tables, globals) intact preserves the
+     * loader ABI. */
+    function promisingExports(exports) {
+        if (!jspiAvailable()) return exports;
+        const wrapped = {};
+        for (const [name, value] of Object.entries(exports)) {
+            wrapped[name] = typeof value === 'function' ? promisingEntry(value) : value;
+        }
+        return wrapped;
+    }
+
     function jspiAvailable() {
         return typeof WebAssembly.Suspending === 'function' &&
                typeof WebAssembly.promising === 'function';
@@ -920,6 +988,7 @@ fn main() {
         create: EshkolWebGPU.create,
         makeImports,
         promisingEntry,
+        promisingExports,
         jspiAvailable,
         cpu,
         ELEM,

--- a/web/eshkol-webgpu.js
+++ b/web/eshkol-webgpu.js
@@ -64,6 +64,10 @@
     const GEMM_TILE = 8;
     const ELEM_WORKGROUP = 64;
     const GPU_GATE_TOL = 1e-9;
+    /* Plain f32 has about seven decimal digits of relative precision. A
+     * tolerance just above the df32 gate is not an honest f32 contract. */
+    const FAST_GATE_TOL = 1e-6;
+    const PRECISION_TIERS = new Set(['exact', 'high', 'fast']);
 
     /* ===================== WGSL ===================== */
 
@@ -116,7 +120,7 @@ struct Dims { M: u32, K: u32, N: u32, pad: u32 };
 @group(0) @binding(2) var<storage, read_write> C: array<f32>;
 @group(0) @binding(3) var<uniform> d: Dims;
 
-@compute @workgroup_size(1, 1, 1)
+@compute @workgroup_size(${GEMM_TILE}, ${GEMM_TILE}, 1)
 fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let row = gid.y;
     let col = gid.x;
@@ -326,7 +330,9 @@ fn main() {
             this.device = device;
             this.threshold = (typeof o.threshold === 'number' && o.threshold > 0)
                 ? o.threshold : DEFAULT_THRESHOLD;
-            this.precision = o.precision || 'high';
+            const requestedPrecision = o.precision === undefined ? 'high' : o.precision;
+            this.precision = requestedPrecision;
+            this.precisionKnown = PRECISION_TIERS.has(requestedPrecision);
             this.gateTolerance = (typeof o.gateTolerance === 'number' &&
                                   Number.isFinite(o.gateTolerance) &&
                                   o.gateTolerance > 0) ? o.gateTolerance : GPU_GATE_TOL;
@@ -342,6 +348,16 @@ fn main() {
             this.memory = null;
             this.log = o.log || function () {};
             this.diagnostics = [];
+            if (!this.precisionKnown) {
+                this.diagnostics.push('UNSUPPORTED: unknown WebGPU precision tier ' +
+                                       String(requestedPrecision));
+                this.log('[WebGPU] ' + this.diagnostics[this.diagnostics.length - 1]);
+            } else if (this.precision === 'fast') {
+                const optIn = 'explicit reduced-precision opt-in: fast tier, ' +
+                    'gate tolerance=' + this.gateTolerance;
+                this.diagnostics.push(optIn);
+                this.log('[WebGPU] ' + optIn);
+            }
         }
 
         /* Async device acquisition. Done once, before the wasm module is
@@ -386,7 +402,10 @@ fn main() {
 
         async _probeFma() {
             try {
-                const out = this.device.createBuffer({
+                let out = null;
+                let read = null;
+                let mapped = false;
+                out = this.device.createBuffer({
                     size: 4,
                     usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
                 });
@@ -403,17 +422,21 @@ fn main() {
                 pass.setBindGroup(0, bg);
                 pass.dispatchWorkgroups(1);
                 pass.end();
-                const read = this.device.createBuffer({
+                read = this.device.createBuffer({
                     size: 4,
                     usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
                 });
                 enc.copyBufferToBuffer(out, 0, read, 0, 4);
                 this.device.queue.submit([enc.finish()]);
                 await read.mapAsync(GPUMapMode.READ);
+                mapped = true;
                 const v = new Float32Array(read.getMappedRange().slice(0))[0];
                 read.unmap();
+                mapped = false;
                 read.destroy();
+                read = null;
                 out.destroy();
+                out = null;
                 this.fmaFused = (v !== 0);
                 if (!this.fmaFused) {
                     this.diagnostics.push(
@@ -423,6 +446,12 @@ fn main() {
             } catch (e) {
                 this.fmaFused = false;
                 this.diagnostics.push('fma probe failed: ' + e);
+            } finally {
+                if (read) {
+                    if (mapped) read.unmap();
+                    read.destroy();
+                }
+                if (out) out.destroy();
             }
         }
 
@@ -433,28 +462,34 @@ fn main() {
         setThreshold(t) { if (t > 0) this.threshold = t; }
         getThreshold() { return this.threshold; }
 
+        fastAdmitted() {
+            return this.precision === 'fast' && this.precisionKnown &&
+                this.gateTolerance >= FAST_GATE_TOL;
+        }
+
         /* Mirrors eshkol_gpu_should_use(): active backend AND at or above the
          * element-count threshold. The `exact` tier has no WGSL implementation,
          * so it reports false and the caller takes the CPU path. */
         shouldUse(numElements) {
-            if (!this.device || this.precision === 'exact') return false;
+            if (!this.device || !this.precisionKnown || this.precision === 'exact') return false;
             /* The checked-in df32 shader is intentionally fail-closed until
              * the browser differential gate certifies its compensation path.
              * Selection and operation support must agree: neither may claim
              * that the unverified high tier is GPU-capable. */
             if (this.precision === 'high') return false;
-            if (this.precision === 'fast' && this.gateTolerance <= GPU_GATE_TOL) return false;
+            if (this.precision === 'fast' && !this.fastAdmitted()) return false;
             return numElements >= this.threshold;
         }
 
         supportsOperation(kind, op) {
-            if (!this.device || this.precision === 'exact') return false;
+            if (!this.device || !this.precisionKnown || this.precision === 'exact') return false;
             if (this.precision === 'high') return false;
             if (this.precision === 'fast') {
                 /* f32 is never admitted to the 1e-9 gate. It is available only
-                 * when the caller explicitly supplies a looser contract, and
+                 * when the caller explicitly opts into a contract no tighter
+                 * than the f32 floor, and
                  * reductions remain unsupported because their kernel is df32. */
-                return this.gateTolerance > GPU_GATE_TOL &&
+                return this.fastAdmitted() &&
                     ['matmul', 'elementwise'].includes(kind);
             }
             if (kind === 'elementwise') return Number(op) <= ELEM.ABS;
@@ -994,6 +1029,8 @@ fn main() {
         ELEM,
         REDUCE,
         DEFAULT_THRESHOLD,
+        GPU_GATE_TOL,
+        FAST_GATE_TOL,
         ESHKOL_GPU_WEBGPU
     };
 });

--- a/web/eshkol-webgpu.js
+++ b/web/eshkol-webgpu.js
@@ -114,7 +114,10 @@ fn df_mul(a: vec2<f32>, b: vec2<f32>, slot: u32) -> vec2<f32> {
      * (lib/backend/gpu/gpu_memory_stub.cpp:171-179), so the only divergence
      * from CPU is the working precision, not the summation order. */
     const WGSL_GEMM_F32 = `
-struct Dims { M: u32, K: u32, N: u32, pad: u32 };
+struct Dims {
+    M: u32, K: u32, N: u32, pad: u32,
+    base_x: u32, base_y: u32, pad2: u32, pad3: u32
+};
 @group(0) @binding(0) var<storage, read> A: array<f32>;
 @group(0) @binding(1) var<storage, read> B: array<f32>;
 @group(0) @binding(2) var<storage, read_write> C: array<f32>;
@@ -122,8 +125,8 @@ struct Dims { M: u32, K: u32, N: u32, pad: u32 };
 
 @compute @workgroup_size(${GEMM_TILE}, ${GEMM_TILE}, 1)
 fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
-    let row = gid.y;
-    let col = gid.x;
+    let row = gid.y + d.base_y;
+    let col = gid.x + d.base_x;
     if (row >= d.M || col >= d.N) { return; }
     var acc: f32 = 0.0;
     for (var k: u32 = 0u; k < d.K; k = k + 1u) {
@@ -134,7 +137,10 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
 `;
 
     const WGSL_GEMM_DF32 = `
-struct Dims { M: u32, K: u32, N: u32, pad: u32 };
+struct Dims {
+    M: u32, K: u32, N: u32, pad: u32,
+    base_x: u32, base_y: u32, pad2: u32, pad3: u32
+};
 @group(0) @binding(0) var<storage, read> A: array<vec2<f32>>;
 @group(0) @binding(1) var<storage, read> B: array<vec2<f32>>;
 @group(0) @binding(2) var<storage, read_write> C: array<vec2<f32>>;
@@ -142,8 +148,8 @@ struct Dims { M: u32, K: u32, N: u32, pad: u32 };
 ${WGSL_DF32}
 @compute @workgroup_size(${GEMM_TILE}, ${GEMM_TILE}, 1)
 fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
-    let row = gid.y;
-    let col = gid.x;
+    let row = gid.y + d.base_y;
+    let col = gid.x + d.base_x;
     if (row >= d.M || col >= d.N) { return; }
     var acc = vec2<f32>(0.0, 0.0);
     for (var k: u32 = 0u; k < d.K; k = k + 1u) {
@@ -330,6 +336,10 @@ fn main() {
             this.device = device;
             this.threshold = (typeof o.threshold === 'number' && o.threshold > 0)
                 ? o.threshold : DEFAULT_THRESHOLD;
+            const deviceLimit = device && device.limits &&
+                Number(device.limits.maxComputeWorkgroupsPerDimension);
+            this.maxComputeWorkgroupsPerDimension = Number.isSafeInteger(deviceLimit) &&
+                deviceLimit > 0 ? deviceLimit : 65535;
             const requestedPrecision = o.precision === undefined ? 'high' : o.precision;
             this.precision = requestedPrecision;
             this.precisionKnown = PRECISION_TIERS.has(requestedPrecision);
@@ -343,6 +353,7 @@ fn main() {
             this.fallbackCount = 0;
             this.executionMarker = 0;
             this.lastExecutionMarker = 0;
+            this.dispatchHistory = [];
             this.lastPath = 'none';
             this.fmaFused = true;
             this.memory = null;
@@ -401,10 +412,10 @@ fn main() {
         }
 
         async _probeFma() {
+            let out = null;
+            let read = null;
+            let mapped = false;
             try {
-                let out = null;
-                let read = null;
-                let mapped = false;
                 out = this.device.createBuffer({
                     size: 4,
                     usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
@@ -420,14 +431,12 @@ fn main() {
                 const pass = enc.beginComputePass();
                 pass.setPipeline(pipe);
                 pass.setBindGroup(0, bg);
-                pass.dispatchWorkgroups(1);
-                pass.end();
                 read = this.device.createBuffer({
                     size: 4,
                     usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
                 });
-                enc.copyBufferToBuffer(out, 0, read, 0, 4);
-                this.device.queue.submit([enc.finish()]);
+                await this._submitDispatch(enc, pass, 1, 1, 1, 'fma probe',
+                    () => enc.copyBufferToBuffer(out, 0, read, 0, 4));
                 await read.mapAsync(GPUMapMode.READ);
                 mapped = true;
                 const v = new Float32Array(read.getMappedRange().slice(0))[0];
@@ -543,7 +552,7 @@ fn main() {
 
         _uniform(u32s) {
             const buf = this.device.createBuffer({
-                size: 16,
+                size: Math.max(16, u32s.length * 4),
                 usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
             });
             this.device.queue.writeBuffer(buf, 0, new Uint32Array(u32s));
@@ -560,6 +569,31 @@ fn main() {
 
         _destroyBuffers(...buffers) {
             for (const buffer of buffers) if (buffer) buffer.destroy();
+        }
+
+        async _submitDispatch(encoder, pass, x, y, z, label, afterPass) {
+            let scopeOpen = true;
+            this.device.pushErrorScope('validation');
+            try {
+                pass.dispatchWorkgroups(x, y, z);
+                pass.end();
+                if (afterPass) afterPass();
+                this.device.queue.submit([encoder.finish()]);
+                const error = await this.device.popErrorScope();
+                scopeOpen = false;
+                if (error) {
+                    const detail = error.message || String(error);
+                    const failure = new Error('WebGPU validation error during ' + label + ': ' + detail);
+                    failure.webgpuValidation = true;
+                    throw failure;
+                }
+                this.dispatchHistory.push({ x, y, z, label });
+            } catch (e) {
+                if (scopeOpen) {
+                    try { await this.device.popErrorScope(); } catch (_) {}
+                }
+                throw e;
+            }
         }
 
         /* The single async boundary. Everything above is synchronous JS;
@@ -600,33 +634,46 @@ fn main() {
             const encB = df ? encodeDf32(B, K * N) : encodeF32(B, K * N);
             const outBytes = M * N * (df ? 8 : 4);
 
-            let bufA = null, bufB = null, bufC = null, dims = null, opaque = null;
+            let bufA = null, bufB = null, bufC = null, opaque = null;
+            const dims = [];
             try {
                 bufA = this._storage(encA);
                 bufB = this._storage(encB);
                 bufC = this._outStorage(outBytes);
-                dims = this._uniform([M, K, N, 0]);
                 opaque = df ? this._opaque(M * N) : null;
 
                 const pipe = this._pipeline(df ? 'gemm_df32' : 'gemm_f32',
                                             df ? WGSL_GEMM_DF32 : WGSL_GEMM_F32);
-                const bg = this.device.createBindGroup({
-                    layout: pipe.getBindGroupLayout(0),
-                    entries: [
-                        { binding: 0, resource: { buffer: bufA } },
-                        { binding: 1, resource: { buffer: bufB } },
-                        { binding: 2, resource: { buffer: bufC } },
-                        { binding: 3, resource: { buffer: dims } },
-                        ...(opaque ? [{ binding: 4, resource: { buffer: opaque } }] : [])
-                    ]
-                });
-                const enc = this.device.createCommandEncoder();
-                const pass = enc.beginComputePass();
-                pass.setPipeline(pipe);
-                pass.setBindGroup(0, bg);
-                pass.dispatchWorkgroups(Math.ceil(N / GEMM_TILE), Math.ceil(M / GEMM_TILE), 1);
-                pass.end();
-                this.device.queue.submit([enc.finish()]);
+                const layout = pipe.getBindGroupLayout(0);
+                const groupsX = Math.ceil(N / GEMM_TILE);
+                const groupsY = Math.ceil(M / GEMM_TILE);
+                const limit = this.maxComputeWorkgroupsPerDimension;
+                for (let baseY = 0; baseY < groupsY; baseY += limit) {
+                    const y = Math.min(limit, groupsY - baseY);
+                    for (let baseX = 0; baseX < groupsX; baseX += limit) {
+                        const x = Math.min(limit, groupsX - baseX);
+                        const tileDims = this._uniform([
+                            M, K, N, 0, baseX * GEMM_TILE, baseY * GEMM_TILE, 0, 0
+                        ]);
+                        dims.push(tileDims);
+                        const bg = this.device.createBindGroup({
+                            layout,
+                            entries: [
+                                { binding: 0, resource: { buffer: bufA } },
+                                { binding: 1, resource: { buffer: bufB } },
+                                { binding: 2, resource: { buffer: bufC } },
+                                { binding: 3, resource: { buffer: tileDims } },
+                                ...(opaque ? [{ binding: 4, resource: { buffer: opaque } }] : [])
+                            ]
+                        });
+                        const enc = this.device.createCommandEncoder();
+                        const pass = enc.beginComputePass();
+                        pass.setPipeline(pipe);
+                        pass.setBindGroup(0, bg);
+                        await this._submitDispatch(enc, pass, x, y, 1,
+                            'gemm ' + x + 'x' + y + ' workgroups');
+                    }
+                }
 
                 const raw = await this._readback(bufC, outBytes);
                 const C = this._f64View(cPtr, M * N);
@@ -634,7 +681,7 @@ fn main() {
                 else { const f = new Float32Array(raw); for (let i = 0; i < M * N; i++) C[i] = f[i]; }
                 return this._recordExecution(df ? 'webgpu:gemm_df32' : 'webgpu:gemm_f32');
             } finally {
-                this._destroyBuffers(bufA, bufB, bufC, dims, opaque);
+                this._destroyBuffers(bufA, bufB, bufC, ...dims, opaque);
             }
         }
 
@@ -697,9 +744,8 @@ fn main() {
                 const pass = enc.beginComputePass();
                 pass.setPipeline(pipe);
                 pass.setBindGroup(0, bg);
-                pass.dispatchWorkgroups(Math.ceil(n / ELEM_WORKGROUP), 1, 1);
-                pass.end();
-                this.device.queue.submit([enc.finish()]);
+                await this._submitDispatch(enc, pass, Math.ceil(n / ELEM_WORKGROUP), 1, 1,
+                    'elementwise ' + n + ' elements');
 
                 const raw = await this._readback(bufO, bytes);
                 const O = this._f64View(outPtr, n);
@@ -749,9 +795,8 @@ fn main() {
                 const pass = enc.beginComputePass();
                 pass.setPipeline(pipe);
                 pass.setBindGroup(0, bg);
-                pass.dispatchWorkgroups(groups, 1, 1);
-                pass.end();
-                this.device.queue.submit([enc.finish()]);
+                await this._submitDispatch(enc, pass, groups, 1, 1,
+                    'reduction ' + groups + ' workgroups');
 
                 const raw = await this._readback(bufOut, groups * 8);
                 const partials = new Float32Array(raw);
@@ -902,7 +947,14 @@ fn main() {
                             if (verified(marker, before)) return 0;
                             throw new Error('missing WebGPU execution marker');
                         }
-                        catch (e) { backend.diagnostics.push('gemm failed, CPU fallback: ' + e); }
+                        catch (e) {
+                            if (e && e.webgpuValidation) {
+                                backend.diagnostics.push(e.message);
+                                backend.lastPath = 'webgpu:error';
+                                throw e;
+                            }
+                            backend.diagnostics.push('gemm failed, CPU fallback: ' + e);
+                        }
                     }
                     if (backend.shouldUse(M * N)) backend.diagnostics.push('UNSUPPORTED: matmul refused before GPU_GATE_TOL certification');
                     backend.fallbackCount++;
@@ -921,7 +973,14 @@ fn main() {
                             if (verified(marker, before)) return 0;
                             throw new Error('missing WebGPU execution marker');
                         }
-                        catch (e) { backend.diagnostics.push('elementwise failed, CPU fallback: ' + e); }
+                        catch (e) {
+                            if (e && e.webgpuValidation) {
+                                backend.diagnostics.push(e.message);
+                                backend.lastPath = 'webgpu:error';
+                                throw e;
+                            }
+                            backend.diagnostics.push('elementwise failed, CPU fallback: ' + e);
+                        }
                     }
                     if (backend.shouldUse(n)) backend.diagnostics.push('UNSUPPORTED: elementwise operation refused before GPU_GATE_TOL certification');
                     backend.fallbackCount++;
@@ -941,7 +1000,14 @@ fn main() {
                             if (verified(marker, before)) return 0;
                             throw new Error('missing WebGPU execution marker');
                         }
-                        catch (e) { backend.diagnostics.push('reduce failed, CPU fallback: ' + e); }
+                        catch (e) {
+                            if (e && e.webgpuValidation) {
+                                backend.diagnostics.push(e.message);
+                                backend.lastPath = 'webgpu:error';
+                                throw e;
+                            }
+                            backend.diagnostics.push('reduce failed, CPU fallback: ' + e);
+                        }
                     }
                     if (backend.shouldUse(n)) backend.diagnostics.push('UNSUPPORTED: reduction refused before GPU_GATE_TOL certification');
                     backend.fallbackCount++;

--- a/web/eshkol-webgpu.js
+++ b/web/eshkol-webgpu.js
@@ -1,0 +1,930 @@
+/*
+ * Eshkol WebGPU compute backend.
+ *
+ * This is the WASM-target sibling of lib/backend/gpu/gpu_memory.mm (Metal) and
+ * lib/backend/gpu/gpu_memory_cuda.cpp (CUDA). It implements the same dispatch
+ * seam that generated code calls -- eshkol_matmul_dispatch and the
+ * eshkol_gpu_*_f64 compute entry points -- so a WASM program reaches the GPU
+ * through the ORDINARY dispatch predicate (eshkol_gpu_should_use: active
+ * backend + element-count threshold), not through a browser-special path.
+ *
+ * PRECISION. WGSL has no f64 of any kind, so the f64 entry points cannot be
+ * served natively. This backend slots into the existing ESHKOL_GPU_PRECISION
+ * tier vocabulary (see docs/breakdown/RUNTIME_CONFIGURATION.md):
+ *
+ *   exact : IEEE f64, correct to ULP. NOT AVAILABLE on WebGPU -- falls back to
+ *           the CPU path. (An sf64/Ozaki-II WGSL port is a named follow-up.)
+ *   high  : df32 -- each f64 carried as an unevaluated (hi, lo) pair of f32,
+ *           Dekker/Knuth double-float arithmetic. ~48 bits of mantissa against
+ *           f64's 53. THIS IS THE WebGPU DEFAULT.
+ *   fast  : plain f32, ~24 bits.
+ *
+ * Defaulting to `high` rather than `exact` is a deliberate, documented
+ * departure from the native backends, which default to exact. It is reported
+ * by eshkol_gpu_has_fp64() returning 0 (no correct-to-ULP path) and logged at
+ * init. Callers that require exactness set precision to "exact" and get the
+ * CPU path.
+ *
+ * ASYNC. WebGPU readback is unavoidably asynchronous (mapAsync). Eshkol's
+ * runtime is synchronous C compiled to wasm32. The bridge is JSPI
+ * (WebAssembly.Suspending / WebAssembly.promising): the GPU imports are marked
+ * suspending and the entry export is marked promising, so wasm blocks on the
+ * GPU without any rewriting of the module. See attachTo() below. Where JSPI is
+ * absent the GPU imports are installed as synchronous CPU implementations and
+ * dispatchCount stays 0 -- callers detect that and report SKIP, never a silent
+ * pass.
+ *
+ */
+
+(function (root, factory) {
+    'use strict';
+    const mod = factory();
+    if (typeof module === 'object' && module.exports) module.exports = mod;
+    root.EshkolWebGPU = mod;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    /* Must match EshkolGPUBackend in inc/eshkol/backend/gpu/gpu_memory.h */
+    const ESHKOL_GPU_NONE = 0;
+    const ESHKOL_GPU_WEBGPU = 4;
+
+    /* Must match EshkolElementwiseOp in gpu_memory.h */
+    const ELEM = {
+        ADD: 0, SUB: 1, MUL: 2, DIV: 3, NEG: 4, ABS: 5, EXP: 6, LOG: 7,
+        SIN: 8, COS: 9, TANH: 10, RELU: 11, SIGMOID: 12, SQRT: 13, RECIPROCAL: 14
+    };
+    /* Must match EshkolReduceOp in gpu_memory.h */
+    const REDUCE = { SUM: 0, PROD: 1, MIN: 2, MAX: 3, MEAN: 4 };
+
+    /* Same default as g_gpu_threshold in all three native backends. */
+    const DEFAULT_THRESHOLD = 100000;
+
+    const REDUCE_WORKGROUP = 256;
+    const GEMM_TILE = 8;
+    const ELEM_WORKGROUP = 64;
+
+    /* ===================== WGSL ===================== */
+
+    /* Double-float (df32) helpers. Each logical f64 is an (hi, lo) f32 pair
+     * with |lo| <= ulp(hi)/2. WGSL optimizers are allowed to reassociate
+     * ordinary arithmetic, which would fold the TwoSum residual to zero. The
+     * storage write/read below is a deliberate opaque barrier: each invocation
+     * owns one scratch slot, so the shader compiler cannot fold the
+     * error-free transforms into ordinary reassociated f32 arithmetic. */
+    const WGSL_DF32 = `
+@group(0) @binding(4) var<storage, read_write> OPAQUE: array<f32>;
+fn opaque_f32(x: f32, slot: u32) -> f32 {
+    OPAQUE[slot] = x;
+    return OPAQUE[slot];
+}
+fn two_sum(a: f32, b: f32, slot: u32) -> vec2<f32> {
+    let aa = opaque_f32(a, slot);
+    let bb0 = opaque_f32(b, slot);
+    let s = opaque_f32(aa + bb0, slot);
+    let bb = s - aa;
+    let err = opaque_f32((aa - (s - bb)) + (bb0 - bb), slot);
+    return vec2<f32>(s, err);
+}
+fn two_prod(a: f32, b: f32, slot: u32) -> vec2<f32> {
+    let aa = opaque_f32(a, slot);
+    let bb = opaque_f32(b, slot);
+    let p = opaque_f32(aa * bb, slot);
+    let e = opaque_f32(fma(aa, bb, -p), slot);
+    return vec2<f32>(p, e);
+}
+fn df_add(a: vec2<f32>, b: vec2<f32>, slot: u32) -> vec2<f32> {
+    let s = two_sum(a.x, b.x, slot);
+    let e = s.y + (a.y + b.y);
+    return two_sum(s.x, e, slot);
+}
+fn df_mul(a: vec2<f32>, b: vec2<f32>, slot: u32) -> vec2<f32> {
+    let p = two_prod(a.x, b.x, slot);
+    let e = p.y + fma(a.x, b.y, a.y * b.x);
+    return two_sum(p.x, e, slot);
+}
+`;
+
+    /* GEMM. Accumulation is in the same k order as the CPU triple loop
+     * (lib/backend/gpu/gpu_memory_stub.cpp:171-179), so the only divergence
+     * from CPU is the working precision, not the summation order. */
+    const WGSL_GEMM_F32 = `
+struct Dims { M: u32, K: u32, N: u32, pad: u32 };
+@group(0) @binding(0) var<storage, read> A: array<f32>;
+@group(0) @binding(1) var<storage, read> B: array<f32>;
+@group(0) @binding(2) var<storage, read_write> C: array<f32>;
+@group(0) @binding(3) var<uniform> d: Dims;
+
+@compute @workgroup_size(1, 1, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let row = gid.y;
+    let col = gid.x;
+    if (row >= d.M || col >= d.N) { return; }
+    var acc: f32 = 0.0;
+    for (var k: u32 = 0u; k < d.K; k = k + 1u) {
+        acc = acc + A[row * d.K + k] * B[k * d.N + col];
+    }
+    C[row * d.N + col] = acc;
+}
+`;
+
+    const WGSL_GEMM_DF32 = `
+struct Dims { M: u32, K: u32, N: u32, pad: u32 };
+@group(0) @binding(0) var<storage, read> A: array<vec2<f32>>;
+@group(0) @binding(1) var<storage, read> B: array<vec2<f32>>;
+@group(0) @binding(2) var<storage, read_write> C: array<vec2<f32>>;
+@group(0) @binding(3) var<uniform> d: Dims;
+${WGSL_DF32}
+@compute @workgroup_size(${GEMM_TILE}, ${GEMM_TILE}, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let row = gid.y;
+    let col = gid.x;
+    if (row >= d.M || col >= d.N) { return; }
+    var acc = vec2<f32>(0.0, 0.0);
+    for (var k: u32 = 0u; k < d.K; k = k + 1u) {
+        let slot = row * d.N + col;
+        acc = df_add(acc, df_mul(A[row * d.K + k], B[k * d.N + col], slot), slot);
+    }
+    C[row * d.N + col] = acc;
+}
+`;
+
+    /* Elementwise. Op numbering is EshkolElementwiseOp verbatim. Unary ops
+     * ignore B. Missing-B identity handling matches the stub backend:
+     * 0 for add/sub, 1 for mul/div -- the host side supplies that operand. */
+    const WGSL_ELEM_F32 = `
+struct Params { n: u32, op: u32, pad0: u32, pad1: u32 };
+@group(0) @binding(0) var<storage, read> A: array<f32>;
+@group(0) @binding(1) var<storage, read> B: array<f32>;
+@group(0) @binding(2) var<storage, read_write> OUT: array<f32>;
+@group(0) @binding(3) var<uniform> p: Params;
+
+@compute @workgroup_size(1, 1, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    if (i >= p.n) { return; }
+    let a = A[i];
+    let b = B[i];
+    var r: f32 = 0.0;
+    switch (p.op) {
+        case 0u:  { r = a + b; }
+        case 1u:  { r = a - b; }
+        case 2u:  { r = a * b; }
+        case 3u:  { r = a / b; }
+        case 4u:  { r = -a; }
+        case 5u:  { r = abs(a); }
+        case 6u:  { r = exp(a); }
+        case 7u:  { r = log(a); }
+        case 8u:  { r = sin(a); }
+        case 9u:  { r = cos(a); }
+        case 10u: { r = tanh(a); }
+        case 11u: { r = max(a, 0.0); }
+        case 12u: { r = 1.0 / (1.0 + exp(-a)); }
+        case 13u: { r = sqrt(a); }
+        case 14u: { r = 1.0 / a; }
+        default:  { r = 0.0; }
+    }
+    OUT[i] = r;
+}
+`;
+
+    /* df32 elementwise covers only the ops that are exactly representable in
+     * double-float arithmetic (add/sub/mul/div/neg/abs). The transcendentals
+     * have no df32 closed form here, so the high tier refuses them and uses
+     * the CPU fallback. The lower-precision fast tier is an explicit opt-in,
+     * outside the 1e-9 correctness gate. */
+    const WGSL_ELEM_DF32 = `
+struct Params { n: u32, op: u32, pad0: u32, pad1: u32 };
+@group(0) @binding(0) var<storage, read> A: array<vec2<f32>>;
+@group(0) @binding(1) var<storage, read> B: array<vec2<f32>>;
+@group(0) @binding(2) var<storage, read_write> OUT: array<vec2<f32>>;
+@group(0) @binding(3) var<uniform> p: Params;
+${WGSL_DF32}
+fn df_neg(a: vec2<f32>) -> vec2<f32> { return vec2<f32>(-a.x, -a.y); }
+fn df_div(a: vec2<f32>, b: vec2<f32>, slot: u32) -> vec2<f32> {
+    let q1 = a.x / b.x;
+    let r = df_add(a, df_neg(df_mul(vec2<f32>(q1, 0.0), b, slot)), slot);
+    let q2 = r.x / b.x;
+    return two_sum(q1, q2, slot);
+}
+@compute @workgroup_size(${ELEM_WORKGROUP}, 1, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    if (i >= p.n) { return; }
+    let a = A[i];
+    let b = B[i];
+    var r = vec2<f32>(0.0, 0.0);
+    switch (p.op) {
+        case 0u: { r = df_add(a, b, i); }
+        case 1u: { r = df_add(a, df_neg(b), i); }
+        case 2u: { r = df_mul(a, b, i); }
+        case 3u: { r = df_div(a, b, i); }
+        case 4u: { r = df_neg(a); }
+        case 5u: { if (a.x < 0.0) { r = df_neg(a); } else { r = a; } }
+        default: { r = vec2<f32>(0.0, 0.0); }
+    }
+    OUT[i] = r;
+}
+`;
+
+    /* Reduction. One workgroup (one invocation) produces one partial block.
+     * Keeping the partial loop sequential makes the f64-vs-df32 comparison
+     * deterministic and avoids a workgroup tree whose identity/bounds logic
+     * can hide an empty block as a successful zero. */
+    const WGSL_REDUCE_DF32 = `
+struct Params { n: u32, op: u32, per_group: u32, pad: u32 };
+@group(0) @binding(0) var<storage, read> IN: array<vec2<f32>>;
+@group(0) @binding(1) var<storage, read_write> OUT: array<vec2<f32>>;
+@group(0) @binding(2) var<uniform> p: Params;
+${WGSL_DF32}
+fn ident(op: u32) -> vec2<f32> {
+    switch (op) {
+        case 1u: { return vec2<f32>(1.0, 0.0); }
+        case 2u: { return vec2<f32>(3.4028235e38, 0.0); }
+        case 3u: { return vec2<f32>(-3.4028235e38, 0.0); }
+        default: { return vec2<f32>(0.0, 0.0); }
+    }
+}
+fn combine(op: u32, a: vec2<f32>, b: vec2<f32>, slot: u32) -> vec2<f32> {
+    switch (op) {
+        case 1u: { return df_mul(a, b, slot); }
+        case 2u: { if (b.x < a.x) { return b; } else { return a; } }
+        case 3u: { if (b.x > a.x) { return b; } else { return a; } }
+        default: { return df_add(a, b, slot); }
+    }
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let op = p.op;
+    let group = gid.x;
+    let block_start = group * p.per_group;
+    var acc = ident(op);
+    var hi = block_start + p.per_group;
+    if (hi > p.n) { hi = p.n; }
+    var i = block_start;
+    while (i < hi) {
+        acc = combine(op, acc, IN[i], group);
+        i = i + 1u;
+    }
+    OUT[group] = acc;
+}
+`;
+
+    /* Probe: confirm fma() is fused. If a * b + c is computed with two
+     * roundings, two_prod's error term is garbage and df32 silently degrades
+     * to f32. Rather than let that pass unnoticed the backend downgrades the
+     * advertised tier and says so. */
+    const WGSL_FMA_PROBE = `
+@group(0) @binding(0) var<storage, read_write> OUT: array<f32>;
+@compute @workgroup_size(1, 1, 1)
+fn main() {
+    // a * b is not representable in f32; the fused residual must be nonzero.
+    let a: f32 = 1.0000001;
+    let b: f32 = 1.0000002;
+    let p = a * b;
+    OUT[0] = fma(a, b, -p);
+}
+`;
+
+    /* ===================== helpers ===================== */
+
+    function splitDf32(v) {
+        const hi = Math.fround(v);
+        return [hi, Math.fround(v - hi)];
+    }
+
+    function encodeDf32(src, count) {
+        const out = new Float32Array(count * 2);
+        for (let i = 0; i < count; i++) {
+            const hi = Math.fround(src[i]);
+            out[i * 2] = hi;
+            out[i * 2 + 1] = Math.fround(src[i] - hi);
+        }
+        return out;
+    }
+
+    function decodeDf32(buf, dst, count, offset) {
+        const o = offset || 0;
+        for (let i = 0; i < count; i++) {
+            dst[o + i] = buf[i * 2] + buf[i * 2 + 1];
+        }
+    }
+
+    function encodeF32(src, count) {
+        const out = new Float32Array(count);
+        for (let i = 0; i < count; i++) out[i] = src[i];
+        return out;
+    }
+
+    /* ===================== backend ===================== */
+
+    class EshkolWebGPU {
+        constructor(device, opts) {
+            const o = opts || {};
+            this.device = device;
+            this.threshold = (typeof o.threshold === 'number' && o.threshold > 0)
+                ? o.threshold : DEFAULT_THRESHOLD;
+            this.precision = o.precision || 'high';
+            this.pipelines = new Map();
+            this.uniformPool = [];
+            /* Non-vacuity telemetry: a differential gate asserts these move. */
+            this.dispatchCount = 0;
+            this.fallbackCount = 0;
+            this.lastPath = 'none';
+            this.fmaFused = true;
+            this.memory = null;
+            this.log = o.log || function () {};
+            this.diagnostics = [];
+        }
+
+        /* Async device acquisition. Done once, before the wasm module is
+         * instantiated, so eshkol_gpu_init() on the C side is a synchronous
+         * query of an already-resolved device -- no suspension at init. */
+        static async create(opts) {
+            const o = opts || {};
+            if (typeof navigator === 'undefined' || !navigator.gpu) {
+                return { ok: false, reason: 'navigator.gpu unavailable (no WebGPU in this browser)' };
+            }
+            let adapter;
+            try {
+                adapter = await navigator.gpu.requestAdapter(
+                    o.adapterOptions || { powerPreference: 'high-performance' });
+            } catch (e) {
+                return { ok: false, reason: 'requestAdapter threw: ' + e };
+            }
+            if (!adapter) return { ok: false, reason: 'no WebGPU adapter (headless without a GPU?)' };
+            let device;
+            try {
+                device = await adapter.requestDevice();
+            } catch (e) {
+                return { ok: false, reason: 'requestDevice threw: ' + e };
+            }
+            if (!device) return { ok: false, reason: 'requestDevice returned null' };
+
+            const be = new EshkolWebGPU(device, o);
+            device.lost.then((info) => {
+                be.diagnostics.push('device lost: ' + info.message);
+                be.device = null;
+            });
+            await be._probeFma();
+            if (!be.fmaFused && be.precision === 'high') {
+                return { ok: false, unsupported: true,
+                    reason: 'UNSUPPORTED: WebGPU adapter does not provide fused fma; df32 cannot meet GPU_GATE_TOL' };
+            }
+            be.log('[WebGPU] backend active, precision tier=' + be.precision +
+                   ', threshold=' + be.threshold +
+                   ', fma fused=' + be.fmaFused);
+            return { ok: true, backend: be, adapter: adapter };
+        }
+
+        async _probeFma() {
+            try {
+                const out = this.device.createBuffer({
+                    size: 4,
+                    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
+                });
+                const pipe = this._pipeline('fma_probe', WGSL_FMA_PROBE, [
+                    { binding: 0, resource: { buffer: out } }
+                ]);
+                const bg = this.device.createBindGroup({
+                    layout: pipe.getBindGroupLayout(0),
+                    entries: [{ binding: 0, resource: { buffer: out } }]
+                });
+                const enc = this.device.createCommandEncoder();
+                const pass = enc.beginComputePass();
+                pass.setPipeline(pipe);
+                pass.setBindGroup(0, bg);
+                pass.dispatchWorkgroups(1);
+                pass.end();
+                const read = this.device.createBuffer({
+                    size: 4,
+                    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+                });
+                enc.copyBufferToBuffer(out, 0, read, 0, 4);
+                this.device.queue.submit([enc.finish()]);
+                await read.mapAsync(GPUMapMode.READ);
+                const v = new Float32Array(read.getMappedRange().slice(0))[0];
+                read.unmap();
+                read.destroy();
+                out.destroy();
+                this.fmaFused = (v !== 0);
+                if (!this.fmaFused) {
+                    this.diagnostics.push(
+                        'UNSUPPORTED: fma() is not fused; refusing df32 dispatch because it cannot meet GPU_GATE_TOL');
+                    this.log('[WebGPU] ' + this.diagnostics[this.diagnostics.length - 1]);
+                }
+            } catch (e) {
+                this.fmaFused = false;
+                this.diagnostics.push('fma probe failed: ' + e);
+            }
+        }
+
+        /* ---- the dispatch predicate, same shape as the native backends ---- */
+
+        getBackend() { return this.device ? ESHKOL_GPU_WEBGPU : ESHKOL_GPU_NONE; }
+        backendName() { return this.device ? 'WebGPU (browser compute)' : 'CPU only'; }
+        setThreshold(t) { if (t > 0) this.threshold = t; }
+        getThreshold() { return this.threshold; }
+
+        /* Mirrors eshkol_gpu_should_use(): active backend AND at or above the
+         * element-count threshold. The `exact` tier has no WGSL implementation,
+         * so it reports false and the caller takes the CPU path. */
+        shouldUse(numElements) {
+            if (!this.device) return false;
+            if (this.precision === 'exact') return false;
+            return numElements >= this.threshold;
+        }
+
+        supportsOperation(kind, op) {
+            /* The checked-in df32 path is present, but this browser/runtime
+             * has not met the repository's 1e-9 gate. Refuse it until a
+             * verified precise-math or Ozaki implementation is available. */
+            if (!this.device || this.precision === 'exact' || this.precision === 'high' || !this.fmaFused) return false;
+            if (this.precision === 'fast') return true;
+            if (kind === 'elementwise') return Number(op) <= ELEM.ABS;
+            if (kind === 'reduce') {
+                return this.precision !== 'fast' &&
+                    [REDUCE.SUM, REDUCE.MIN, REDUCE.MAX, REDUCE.MEAN].includes(Number(op));
+            }
+            return kind === 'matmul';
+        }
+
+        supportsF64() { return false; }   /* no native hardware f64 in WGSL */
+        hasFp64() { return false; }       /* and no correct-to-ULP emulation yet */
+
+        setMemory(mem) { this.memory = mem; }
+
+        _f64View(ptr, count) {
+            return new Float64Array(this.memory.buffer, ptr, count);
+        }
+
+        _pipeline(key, wgsl) {
+            let p = this.pipelines.get(key);
+            if (!p) {
+                const mod = this.device.createShaderModule({ code: wgsl });
+                p = this.device.createComputePipeline({
+                    layout: 'auto',
+                    compute: { module: mod, entryPoint: 'main' }
+                });
+                this.pipelines.set(key, p);
+            }
+            return p;
+        }
+
+        _storage(data) {
+            const buf = this.device.createBuffer({
+                size: Math.max(data.byteLength, 4),
+                usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC
+            });
+            this.device.queue.writeBuffer(buf, 0, data);
+            return buf;
+        }
+
+        _outStorage(bytes) {
+            return this.device.createBuffer({
+                size: Math.max(bytes, 4),
+                usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
+            });
+        }
+
+        _opaque(count) {
+            return this._storage(new Float32Array(Math.max(1, count || 1)));
+        }
+
+        _uniform(u32s) {
+            const buf = this.device.createBuffer({
+                size: 16,
+                usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+            });
+            this.device.queue.writeBuffer(buf, 0, new Uint32Array(u32s));
+            return buf;
+        }
+
+        /* The single async boundary. Everything above is synchronous JS;
+         * only the readback suspends, and JSPI carries the wasm stack across
+         * exactly this await. */
+        async _readback(gpuBuf, bytes) {
+            const read = this.device.createBuffer({
+                size: bytes,
+                usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+            });
+            const enc = this.device.createCommandEncoder();
+            enc.copyBufferToBuffer(gpuBuf, 0, read, 0, bytes);
+            this.device.queue.submit([enc.finish()]);
+            await read.mapAsync(GPUMapMode.READ);
+            const copy = read.getMappedRange().slice(0);
+            read.unmap();
+            read.destroy();
+            return copy;
+        }
+
+        /* ---------------- GEMM ---------------- */
+
+        /* C = A * B, all row-major, pointers are byte offsets into wasm memory
+         * holding f64. Mirrors eshkol_gpu_matmul_f64 / eshkol_matmul_dispatch. */
+        async matmulF64(aPtr, bPtr, cPtr, M, K, N) {
+            const df = (this.precision === 'high');
+            const A = this._f64View(aPtr, M * K);
+            const B = this._f64View(bPtr, K * N);
+
+            const encA = df ? encodeDf32(A, M * K) : encodeF32(A, M * K);
+            const encB = df ? encodeDf32(B, K * N) : encodeF32(B, K * N);
+            const outBytes = M * N * (df ? 8 : 4);
+
+            const bufA = this._storage(encA);
+            const bufB = this._storage(encB);
+            const bufC = this._outStorage(outBytes);
+            const dims = this._uniform([M, K, N, 0]);
+            const opaque = df ? this._opaque(M * N) : null;
+
+            const pipe = this._pipeline(df ? 'gemm_df32' : 'gemm_f32',
+                                        df ? WGSL_GEMM_DF32 : WGSL_GEMM_F32);
+            const bg = this.device.createBindGroup({
+                layout: pipe.getBindGroupLayout(0),
+                entries: [
+                    { binding: 0, resource: { buffer: bufA } },
+                    { binding: 1, resource: { buffer: bufB } },
+                    { binding: 2, resource: { buffer: bufC } },
+                    { binding: 3, resource: { buffer: dims } },
+                    ...(opaque ? [{ binding: 4, resource: { buffer: opaque } }] : [])
+                ]
+            });
+            const enc = this.device.createCommandEncoder();
+            const pass = enc.beginComputePass();
+            pass.setPipeline(pipe);
+            pass.setBindGroup(0, bg);
+            pass.dispatchWorkgroups(
+                N, M, 1);
+            pass.end();
+            this.device.queue.submit([enc.finish()]);
+
+            const raw = await this._readback(bufC, outBytes);
+            const C = this._f64View(cPtr, M * N);
+            if (df) decodeDf32(new Float32Array(raw), C, M * N);
+            else { const f = new Float32Array(raw); for (let i = 0; i < M * N; i++) C[i] = f[i]; }
+
+            bufA.destroy(); bufB.destroy(); bufC.destroy(); dims.destroy();
+            if (opaque) opaque.destroy();
+            this.dispatchCount++;
+            this.lastPath = df ? 'webgpu:gemm_df32' : 'webgpu:gemm_f32';
+            return 0;
+        }
+
+        /* ---------------- elementwise ---------------- */
+
+        async elementwiseF64(aPtr, bPtr, outPtr, n, op) {
+            if (!this.supportsOperation('elementwise', op)) {
+                throw new Error('UNSUPPORTED: WebGPU elementwise op cannot meet GPU_GATE_TOL');
+            }
+            /* df32 has closed forms only for the algebraic ops; the
+             * transcendentals fall to the f32 kernel (tier `fast` semantics)
+             * because a df32 exp/log/sin is not implemented. That is a
+             * precision cliff, so it is recorded rather than hidden. */
+            const algebraic = (op <= ELEM.ABS);
+            const df = (this.precision === 'high') && algebraic;
+            if (this.precision === 'high' && !algebraic) {
+                this.diagnostics.push(
+                    'elementwise op ' + op + ' has no df32 kernel; ran at f32 precision');
+            }
+
+            const A = this._f64View(aPtr, n);
+            const encA = df ? encodeDf32(A, n) : encodeF32(A, n);
+
+            /* Binary ops read B; unary ops get the identity operand the stub
+             * backend uses so the kernel needs no separate unary variant. */
+            let encB;
+            if (bPtr !== 0 && op <= ELEM.DIV) {
+                const B = this._f64View(bPtr, n);
+                encB = df ? encodeDf32(B, n) : encodeF32(B, n);
+            } else {
+                const ident = (op === ELEM.MUL || op === ELEM.DIV) ? 1 : 0;
+                encB = df ? new Float32Array(n * 2) : new Float32Array(n);
+                if (ident === 1) {
+                    for (let i = 0; i < n; i++) encB[df ? i * 2 : i] = 1;
+                }
+            }
+
+            const bytes = n * (df ? 8 : 4);
+            const bufA = this._storage(encA);
+            const bufB = this._storage(encB);
+            const bufO = this._outStorage(bytes);
+            const params = this._uniform([n, op, 0, 0]);
+            const opaque = df ? this._opaque(n) : null;
+
+            const pipe = this._pipeline(df ? 'elem_df32' : 'elem_f32',
+                                        df ? WGSL_ELEM_DF32 : WGSL_ELEM_F32);
+            const bg = this.device.createBindGroup({
+                layout: pipe.getBindGroupLayout(0),
+                entries: [
+                    { binding: 0, resource: { buffer: bufA } },
+                    { binding: 1, resource: { buffer: bufB } },
+                    { binding: 2, resource: { buffer: bufO } },
+                    { binding: 3, resource: { buffer: params } },
+                    ...(opaque ? [{ binding: 4, resource: { buffer: opaque } }] : [])
+                ]
+            });
+            const enc = this.device.createCommandEncoder();
+            const pass = enc.beginComputePass();
+            pass.setPipeline(pipe);
+            pass.setBindGroup(0, bg);
+            pass.dispatchWorkgroups(n, 1, 1);
+            pass.end();
+            this.device.queue.submit([enc.finish()]);
+
+            const raw = await this._readback(bufO, bytes);
+            const O = this._f64View(outPtr, n);
+            if (df) decodeDf32(new Float32Array(raw), O, n);
+            else { const f = new Float32Array(raw); for (let i = 0; i < n; i++) O[i] = f[i]; }
+
+            bufA.destroy(); bufB.destroy(); bufO.destroy(); params.destroy();
+            if (opaque) opaque.destroy();
+            this.dispatchCount++;
+            this.lastPath = df ? 'webgpu:elem_df32' : 'webgpu:elem_f32';
+            return 0;
+        }
+
+        /* ---------------- reduction ---------------- */
+
+        async reduceF64(inPtr, outPtr, n, op) {
+            if (!this.supportsOperation('reduce', op)) {
+                throw new Error('UNSUPPORTED: WebGPU reduction cannot meet GPU_GATE_TOL');
+            }
+            /* Reductions always run df32: a f32 reduction over a large array
+             * loses far more than a f32 elementwise op, and the extra cost is
+             * one f32 lane. MEAN reduces as SUM then divides on the host,
+             * matching the stub backend. */
+            const kernelOp = (op === REDUCE.MEAN) ? REDUCE.SUM : op;
+            const IN = this._f64View(inPtr, n);
+            const enc0 = encodeDf32(IN, n);
+
+            const groups = Math.min(64, Math.max(1, Math.ceil(n / REDUCE_WORKGROUP)));
+            const perGroup = Math.ceil(n / groups);
+
+            const bufIn = this._storage(enc0);
+            const bufOut = this._outStorage(groups * 8);
+            const params = this._uniform([n, kernelOp, perGroup, 0]);
+            const opaque = this._opaque(groups);
+
+            const pipe = this._pipeline('reduce_df32', WGSL_REDUCE_DF32);
+            const bg = this.device.createBindGroup({
+                layout: pipe.getBindGroupLayout(0),
+                entries: [
+                    { binding: 0, resource: { buffer: bufIn } },
+                    { binding: 1, resource: { buffer: bufOut } },
+                    { binding: 2, resource: { buffer: params } },
+                    { binding: 4, resource: { buffer: opaque } }
+                ]
+            });
+            const enc = this.device.createCommandEncoder();
+            const pass = enc.beginComputePass();
+            pass.setPipeline(pipe);
+            pass.setBindGroup(0, bg);
+            pass.dispatchWorkgroups(groups, 1, 1);
+            pass.end();
+            this.device.queue.submit([enc.finish()]);
+
+            const raw = await this._readback(bufOut, groups * 8);
+            const partials = new Float32Array(raw);
+
+            /* Final cross-group combine on the host in full f64. */
+            let acc;
+            switch (kernelOp) {
+                case REDUCE.PROD: acc = 1; break;
+                case REDUCE.MIN: acc = Infinity; break;
+                case REDUCE.MAX: acc = -Infinity; break;
+                default: acc = 0; break;
+            }
+            for (let g = 0; g < groups; g++) {
+                const v = partials[g * 2] + partials[g * 2 + 1];
+                switch (kernelOp) {
+                    case REDUCE.PROD: acc *= v; break;
+                    case REDUCE.MIN: acc = v < acc ? v : acc; break;
+                    case REDUCE.MAX: acc = v > acc ? v : acc; break;
+                    default: acc += v; break;
+                }
+            }
+            if (op === REDUCE.MEAN) acc /= n;
+            this._f64View(outPtr, 1)[0] = acc;
+
+            bufIn.destroy(); bufOut.destroy(); params.destroy();
+            if (opaque) opaque.destroy();
+            this.dispatchCount++;
+            this.lastPath = 'webgpu:reduce_df32';
+            return 0;
+        }
+    }
+
+    /* ===================== CPU reference =====================
+     * Byte-for-byte the arithmetic of lib/backend/gpu/gpu_memory_stub.cpp.
+     * This is the fallback below threshold / without WebGPU, AND the
+     * reference side of the differential gate. */
+
+    const cpu = {
+        matmul(mem, aPtr, bPtr, cPtr, M, K, N) {
+            const A = new Float64Array(mem.buffer, aPtr, M * K);
+            const B = new Float64Array(mem.buffer, bPtr, K * N);
+            const C = new Float64Array(mem.buffer, cPtr, M * N);
+            for (let i = 0; i < M; i++) {
+                for (let j = 0; j < N; j++) {
+                    let s = 0;
+                    for (let k = 0; k < K; k++) s += A[i * K + k] * B[k * N + j];
+                    C[i * N + j] = s;
+                }
+            }
+        },
+        elementwise(mem, aPtr, bPtr, outPtr, n, op) {
+            const A = new Float64Array(mem.buffer, aPtr, n);
+            const B = bPtr ? new Float64Array(mem.buffer, bPtr, n) : null;
+            const O = new Float64Array(mem.buffer, outPtr, n);
+            for (let i = 0; i < n; i++) {
+                const a = A[i];
+                const b = B ? B[i] : ((op === ELEM.MUL || op === ELEM.DIV) ? 1 : 0);
+                switch (op) {
+                    case ELEM.ADD: O[i] = a + b; break;
+                    case ELEM.SUB: O[i] = a - b; break;
+                    case ELEM.MUL: O[i] = a * b; break;
+                    case ELEM.DIV: O[i] = a / b; break;
+                    case ELEM.NEG: O[i] = -a; break;
+                    case ELEM.ABS: O[i] = Math.abs(a); break;
+                    case ELEM.EXP: O[i] = Math.exp(a); break;
+                    case ELEM.LOG: O[i] = Math.log(a); break;
+                    case ELEM.SIN: O[i] = Math.sin(a); break;
+                    case ELEM.COS: O[i] = Math.cos(a); break;
+                    case ELEM.TANH: O[i] = Math.tanh(a); break;
+                    case ELEM.RELU: O[i] = a > 0 ? a : 0; break;
+                    case ELEM.SIGMOID: O[i] = 1 / (1 + Math.exp(-a)); break;
+                    case ELEM.SQRT: O[i] = Math.sqrt(a); break;
+                    case ELEM.RECIPROCAL: O[i] = 1 / a; break;
+                }
+            }
+        },
+        reduce(mem, inPtr, outPtr, n, op) {
+            const I = new Float64Array(mem.buffer, inPtr, n);
+            let r;
+            switch (op) {
+                case REDUCE.PROD: r = 1; break;
+                case REDUCE.MIN: r = Infinity; break;
+                case REDUCE.MAX: r = -Infinity; break;
+                default: r = 0; break;
+            }
+            for (let i = 0; i < n; i++) {
+                switch (op) {
+                    case REDUCE.PROD: r *= I[i]; break;
+                    case REDUCE.MIN: r = I[i] < r ? I[i] : r; break;
+                    case REDUCE.MAX: r = I[i] > r ? I[i] : r; break;
+                    default: r += I[i]; break;
+                }
+            }
+            if (op === REDUCE.MEAN) r /= n;
+            new Float64Array(mem.buffer, outPtr, 1)[0] = r;
+        },
+        batchMatmul(mem, aPtr, bPtr, cPtr, batch, M, K, N) {
+            const aStride = M * K, bStride = K * N, cStride = M * N;
+            for (let q = 0; q < batch; q++) {
+                cpu.matmul(mem, aPtr + q * aStride * 8,
+                           bPtr + q * bStride * 8,
+                           cPtr + q * cStride * 8, M, K, N);
+            }
+        }
+    };
+
+    /* ===================== import installation =====================
+     *
+     * Produces the `env` entries the generated wasm imports. Call this from
+     * BOTH loaders (web/eshkol-repl.js and site/static/eshkol-runtime.js):
+     * scripts/check_wasm_imports.py fails the build if either one lacks an
+     * import the codegen emits.
+     *
+     * `backend` may be null -- then every entry is the synchronous CPU
+     * implementation and nothing suspends, so a JSPI-less browser still runs
+     * the program correctly, just on the CPU.
+     */
+    function makeImports(backend, memoryRef) {
+        const jspi = (typeof WebAssembly.Suspending === 'function');
+        const mem = () => (backend && backend.memory) || memoryRef();
+
+        function sync(fn) { return fn; }
+        function suspending(fn) {
+            return jspi ? new WebAssembly.Suspending(fn) : null;
+        }
+
+        /* Each entry: if the GPU can serve this call, suspend into the async
+         * kernel; otherwise run the CPU version synchronously. When JSPI is
+         * unavailable we cannot suspend at all, so we install the CPU version
+         * outright. */
+        const useGpu = backend && backend.device && jspi;
+
+        const entries = {};
+
+        if (useGpu) {
+            entries.eshkol_matmul_dispatch = suspending(
+                async (aPtr, bPtr, cPtr, M, K, N, dtype) => {
+                    M = Number(M); K = Number(K); N = Number(N);
+                    backend.setMemory(mem());
+                    if (backend.shouldUse(M * N) && backend.supportsOperation('matmul')) {
+                        try { return void (await backend.matmulF64(aPtr, bPtr, cPtr, M, K, N)); }
+                        catch (e) { backend.diagnostics.push('gemm failed, CPU fallback: ' + e); }
+                    }
+                    if (backend.shouldUse(M * N)) backend.diagnostics.push('UNSUPPORTED: matmul refused before GPU_GATE_TOL certification');
+                    backend.fallbackCount++;
+                    backend.lastPath = 'cpu:gemm';
+                    cpu.matmul(mem(), aPtr, bPtr, cPtr, M, K, N);
+                });
+
+            entries.eshkol_gpu_elementwise_f64 = suspending(
+                async (aPtr, bPtr, outPtr, n, op) => {
+                    n = Number(n); op = Number(op);
+                    backend.setMemory(mem());
+                    if (backend.shouldUse(n) && backend.supportsOperation('elementwise', op)) {
+                        try { await backend.elementwiseF64(aPtr, bPtr, outPtr, n, op); return 0; }
+                        catch (e) { backend.diagnostics.push('elementwise failed, CPU fallback: ' + e); }
+                    }
+                    if (backend.shouldUse(n)) backend.diagnostics.push('UNSUPPORTED: elementwise operation refused before GPU_GATE_TOL certification');
+                    backend.fallbackCount++;
+                    backend.lastPath = 'cpu:elem';
+                    cpu.elementwise(mem(), aPtr, bPtr, outPtr, n, op);
+                    return 0;
+                });
+
+            entries.eshkol_gpu_reduce_f64 = suspending(
+                async (inPtr, outPtr, n, op) => {
+                    n = Number(n); op = Number(op);
+                    backend.setMemory(mem());
+                    if (backend.shouldUse(n) && backend.supportsOperation('reduce', op)) {
+                        try { await backend.reduceF64(inPtr, outPtr, n, op); return 0; }
+                        catch (e) { backend.diagnostics.push('reduce failed, CPU fallback: ' + e); }
+                    }
+                    if (backend.shouldUse(n)) backend.diagnostics.push('UNSUPPORTED: reduction refused before GPU_GATE_TOL certification');
+                    backend.fallbackCount++;
+                    backend.lastPath = 'cpu:reduce';
+                    cpu.reduce(mem(), inPtr, outPtr, n, op);
+                    return 0;
+                });
+        } else {
+            entries.eshkol_matmul_dispatch = sync(
+                (aPtr, bPtr, cPtr, M, K, N, dtype) => {
+                    cpu.matmul(mem(), aPtr, bPtr, cPtr, Number(M), Number(K), Number(N));
+                });
+            entries.eshkol_gpu_elementwise_f64 = sync(
+                (aPtr, bPtr, outPtr, n, op) => {
+                    cpu.elementwise(mem(), aPtr, bPtr, outPtr, Number(n), Number(op));
+                    return 0;
+                });
+            entries.eshkol_gpu_reduce_f64 = sync(
+                (inPtr, outPtr, n, op) => {
+                    cpu.reduce(mem(), inPtr, outPtr, Number(n), Number(op));
+                    return 0;
+                });
+        }
+
+        /* Batched matmul has no browser WGSL kernel yet. Keep the import
+         * callable and route it through the CPU reference; it must never be
+         * mistaken for a GPU dispatch. */
+        entries.eshkol_batch_matmul_dispatch = (aPtr, bPtr, cPtr, batch, M, K, N) =>
+            cpu.batchMatmul(mem(), aPtr, bPtr, cPtr,
+                            Number(batch), Number(M), Number(K), Number(N));
+
+        /* Query surface -- the C-side predicate mirrored for generated code
+         * and for host tooling. Always synchronous. */
+        entries.eshkol_gpu_init = () => (backend && backend.device) ? 1 : 0;
+        entries.eshkol_gpu_shutdown = () => {};
+        entries.eshkol_gpu_get_backend = () => backend ? backend.getBackend() : ESHKOL_GPU_NONE;
+        entries.eshkol_gpu_backend_available = (b) =>
+            (Number(b) === ESHKOL_GPU_WEBGPU && backend && backend.device) ? 1 : 0;
+        entries.eshkol_gpu_supports_f64 = () => 0;
+        entries.eshkol_gpu_has_fp64 = () => 0;
+        entries.eshkol_gpu_should_use = (n) =>
+            (backend && backend.shouldUse(Number(n))) ? 1 : 0;
+        entries.eshkol_gpu_set_threshold = (t) => { if (backend) backend.setThreshold(Number(t)); };
+        entries.eshkol_gpu_get_threshold = () => backend ? backend.threshold : DEFAULT_THRESHOLD;
+
+        return entries;
+    }
+
+    /* Wrap an instantiated module's entry export so JSPI can suspend inside
+     * it. Without this the suspending imports throw on first call. */
+    function promisingEntry(fn) {
+        if (typeof WebAssembly.promising === 'function') {
+            return WebAssembly.promising(fn);
+        }
+        return fn;
+    }
+
+    function jspiAvailable() {
+        return typeof WebAssembly.Suspending === 'function' &&
+               typeof WebAssembly.promising === 'function';
+    }
+
+    return {
+        EshkolWebGPU,
+        create: EshkolWebGPU.create,
+        makeImports,
+        promisingEntry,
+        jspiAvailable,
+        cpu,
+        ELEM,
+        REDUCE,
+        DEFAULT_THRESHOLD,
+        ESHKOL_GPU_WEBGPU
+    };
+});

--- a/web/examples/hello-web.html
+++ b/web/examples/hello-web.html
@@ -101,7 +101,7 @@
 
                 // Call main if it exists
                 if (instance.exports.main) {
-                    instance.exports.main();
+                    await instance.exports.main();
                 }
 
                 // Remove status element since page will be rebuilt


### PR DESCRIPTION
Adds an ESHKOL_GPU_WEBGPU dispatch seam selected by the same runtime dispatch that picks Metal and CUDA, with Emscripten backend selection, a WebGPU C backend, WGSL kernels for the ops the GPU correctness gate covers, and explicit CPU fallback or refusal where a kernel cannot meet the gate tolerance. JS glue stubs for every new runtime function; docs and feature matrix updated to the verified status.