### PR TITLE
feat(examples): AI-driven mathematics results verified in pure Eshkol — Jacobian-conjecture counterexample, AlphaTensor rank-23/47 decompositions, FunSearch 512-cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **AI-driven mathematics examples.** Added four pure Eshkol programs that
+  exactly verify public finite witnesses: the 2026 Jacobian-conjecture
+  counterexample and its fiber geometry, AlphaTensor rank-23 and rank-47
+  matrix-multiplication factorizations over F2, and the FunSearch 512-cap in
+  AG(8,3). The examples are discovered by the existing examples test suite and
+  document the exact arithmetic and AD verification boundaries.
+
 - **ADR-0000 Stage 1, phase A: the frontend node-identity substrate.** Every
   AST node the parser produces now carries a stable `NodeId`, and a side table
   maps that id to a `SourceSpan` — the first column of the

--- a/docs/AI_MATHEMATICS_EXAMPLES.md
+++ b/docs/AI_MATHEMATICS_EXAMPLES.md
@@ -1,0 +1,72 @@
+# AI-driven mathematics examples
+
+Status: verified on the Linux x86-64 lite lane with native AOT, native JIT, and
+the hosted bytecode VM.
+
+These examples reproduce public finite or algebraic witnesses. They do not
+claim to rediscover the results: each program checks the supplied witness with
+exact integer or rational arithmetic, or with AD where the example explicitly
+uses floating-point inputs.
+
+## Jacobian conjecture counterexample
+
+Source: <https://www.ulam.ai/research/jacobian.pdf>
+
+`examples/mathematics_jacobian_counterexample.esk` verifies the map
+
+```text
+A = 1 + xy
+B = A^2 z + y^2(4 + 3xy)
+P = AB
+Q = y + 3xB
+R = 2x - 3x^2y - x^3z
+```
+
+It checks the three rational preimages of `(-1/4,0,0)`, the binary cubic
+`2pS^3 - qS^2T + 2ST^2 - rT^3`, the discriminant fiber-count cases, reverse
+mode AD at multiple double-valued points, and an exact determinant identity.
+The identity check evaluates the explicit rational partial derivatives on a
+`9 x 8 x 3` grid. The determinant has per-variable degree bounds `(8,7,2)`,
+so this grid is larger than the bound in every variable.
+
+The Theorem 5.1 family is also checked for two parameter choices, with the
+predicted determinant `-2c lambda^2`.
+
+The AD checks intentionally use double vectors. Exact-rational vector inputs
+remain tracked by `SW-136`; the program contains the required TODO at the
+replacement point.
+
+## AlphaTensor matrix multiplication
+
+Source: <https://github.com/google-deepmind/alphatensor>
+
+`examples/mathematics_alphatensor_3x3_gf2.esk` and
+`examples/mathematics_alphatensor_gf2.esk` contract the public rank-23 3x3 and
+rank-47 4x4 factorizations over `F_2`. Factor rows and columns are represented
+as exact integer bit masks. Because the map is bilinear, expansion on every
+pair of matrix units is a complete exact tensor check: 81 pairs for 3x3 and
+256 pairs for 4x4.
+
+## FunSearch cap set
+
+Source: <https://github.com/google-deepmind/funsearch>
+
+`examples/mathematics_funsearch_cap_set.esk` implements the public explicit
+construction of 512 points in `AG(8,3)`. It enumerates the 3^8 ambient points,
+selects the four construction classes, and checks every unordered pair against
+the third point on its affine line. The resulting 130,816 exact pair checks
+must find no third point in the set.
+
+## Running the family
+
+The normal examples suite discovers these files automatically because the
+repository's examples convention is a flat set of `.esk` files:
+
+```bash
+./scripts/run_examples_tests.sh
+```
+
+For mode-specific checks, use the same `eshkol-run` binary with its AOT, JIT,
+and VM options as described in the runtime reference. The examples suite is
+part of `scripts/run_all_tests.sh`, so these files run in CI with the other
+public examples.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,8 @@ pages and lets them fan out to their siblings.
 - [QUICKSTART](QUICKSTART.md) — 15-minute hands-on tutorial (lists to closures to tensors to gradients)
 - [Tutorials index](tutorials/README.md) — all 27 tutorials, from first program through full projects
 - [First 5 Minutes](tutorials/00_FIRST_5_MINUTES.md) — install, hello world, five wow moments
-- [Examples](../examples/README.md) — twenty runnable programs (AD, parallelism, consciousness engine, streaming, simulation, quantum chemistry)
+- [Examples](../examples/README.md) — the runnable example collection (AD, parallelism, consciousness engine, streaming, simulation, quantum chemistry, and exact mathematics)
+- [AI-driven mathematics examples](AI_MATHEMATICS_EXAMPLES.md) — exact and AD-verified public witnesses, including the Jacobian counterexample, AlphaTensor factorizations, and a FunSearch cap set
 - [FAQ](FAQ.md) — installation, troubleshooting, common questions
 - [Getting Started (breakdown)](breakdown/GETTING_STARTED.md) — installation and first programs, implementation-level detail
 - [Overview](breakdown/OVERVIEW.md) — design philosophy and competitive positioning, start here for "why Eshkol"

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Eshkol Examples
 
-Twenty runnable programs spanning the language's load-bearing capabilities — automatic differentiation, parallel work-stealing, symbolic computation, the consciousness engine, real-time streaming, and physical simulation. Every example in this directory compiles cleanly, runs in well under a minute, and produces output you can actually inspect.
+A runnable program collection spanning the language's load-bearing capabilities — automatic differentiation, parallel work-stealing, symbolic computation, the consciousness engine, real-time streaming, physical simulation, and exact verification of public mathematical witnesses. Every public example in this directory compiles cleanly, runs in well under a minute, and produces output you can inspect.
 
 ```bash
 # Compile and run any example in one command:
@@ -67,6 +67,19 @@ The consciousness engine: logic programming, active inference, global workspace.
 | Example | What it shows | LOC |
 |---------|--------------|----:|
 | **[bayesian_diagnosis.esk](bayesian_diagnosis.esk)** | Medical triage agent that combines a symbolic KB with a 3-variable factor graph; tracks free energy across three observation regimes | 110 |
+
+## AI-driven mathematics
+
+The public finite witnesses in [AI-driven mathematics examples](../docs/AI_MATHEMATICS_EXAMPLES.md)
+are flat files so the existing examples test target discovers them automatically.
+They print self-checking `PASS:` lines and finish with `RESULT: ALL PASS`.
+
+| Example | What it verifies |
+|---------|------------------|
+| **[mathematics_jacobian_counterexample.esk](mathematics_jacobian_counterexample.esk)** | The 2026 polynomial Keller map, rational fibers, cubic/discriminant geometry, exact determinant identity, AD, and two Theorem 5.1 family instances |
+| **[mathematics_alphatensor_3x3_gf2.esk](mathematics_alphatensor_3x3_gf2.esk)** | Public rank-23 3x3 matrix multiplication over F2 by complete basis-pair expansion |
+| **[mathematics_alphatensor_gf2.esk](mathematics_alphatensor_gf2.esk)** | Public rank-47 4x4 matrix multiplication over F2 by complete basis-pair expansion |
+| **[mathematics_funsearch_cap_set.esk](mathematics_funsearch_cap_set.esk)** | Public 512-point cap in AG(8,3), verified against every pair |
 
 ## Scientific computing
 

--- a/examples/mathematics_alphatensor_3x3_gf2.esk
+++ b/examples/mathematics_alphatensor_3x3_gf2.esk
@@ -1,0 +1,66 @@
+;; Recent result and public witness: https://github.com/google-deepmind/alphatensor
+;; A rank-23 factorization for 3x3 matrix multiplication over F_2.
+;; Exact expansion is checked on all 9 x 9 pairs of matrix units.
+
+(define pass-count 0)
+(define fail-count 0)
+(define (check label ok)
+  (if ok
+      (begin (set! pass-count (+ pass-count 1))
+             (display "PASS: ") (display label) (newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "FAIL: ") (display label) (newline))))
+
+(define rank 23)
+(define u-masks (vector 65 325 195 69 6 22 54 5 30 27 40 9 32 288 416 8 128 16 360 432 64 424 18))
+(define v-masks (vector 73 64 8 77 8 333 448 5 133 149 128 146 256 434 178 4 146 32 2 48 4 130 365))
+(define w-masks (vector 1048729 38256 1048734 2771840 2769920 2425856 5373993 167936 1142784))
+
+(define (f2 n) (modulo n 2))
+(define (dot-mask mask bits) (f2 (popcount (bitwise-and mask bits))))
+(define (h-at i a b)
+  (f2 (* (dot-mask (vref u-masks i) a)
+         (dot-mask (vref v-masks i) b))))
+(define (h-list i a b)
+  (if (= i rank) '()
+      (cons (h-at i a b) (h-list (+ i 1) a b))))
+(define (w-contract mask hs i acc)
+  (if (= i rank) (f2 acc)
+      (w-contract mask hs (+ i 1)
+                  (if (= (bitwise-and mask (expt 2 i)) 0)
+                      acc (+ acc (list-ref hs i))))))
+(define (result-mask a b)
+  (let ((hs (h-list 0 a b)))
+    (+ (if (= (w-contract (vref w-masks 0) hs 0 0) 1) 1 0)
+       (if (= (w-contract (vref w-masks 1) hs 0 0) 1) 2 0)
+       (if (= (w-contract (vref w-masks 2) hs 0 0) 1) 4 0)
+       (if (= (w-contract (vref w-masks 3) hs 0 0) 1) 8 0)
+       (if (= (w-contract (vref w-masks 4) hs 0 0) 1) 16 0)
+       (if (= (w-contract (vref w-masks 5) hs 0 0) 1) 32 0)
+       (if (= (w-contract (vref w-masks 6) hs 0 0) 1) 64 0)
+       (if (= (w-contract (vref w-masks 7) hs 0 0) 1) 128 0)
+       (if (= (w-contract (vref w-masks 8) hs 0 0) 1) 256 0))))
+(define (expected-mask ai bi)
+  (let ((ar (quotient ai 3)) (ac (modulo ai 3))
+        (br (quotient bi 3)) (bc (modulo bi 3)))
+    ;; W is indexed in the column-major output order used by the
+    ;; published contraction: c.reshape(n,m).T.
+    (if (= ac br) (expt 2 (+ (* bc 3) ar)) 0)))
+(define (check-row ai bi)
+  (if (= bi 9) #t
+      (and (= (result-mask (expt 2 ai) (expt 2 bi))
+              (expected-mask ai bi))
+           (check-row ai (+ bi 1)))))
+(define (check-all ai)
+  (if (= ai 9) #t (and (check-row ai 0) (check-all (+ ai 1)))))
+
+(check "rank-23 factorization has 23 bilinear products" (= rank 23))
+(check "rank-23 tensor expands to 3x3 multiplication over F2"
+       (check-all 0))
+(display "AlphaTensor rank-23 F2 matrix multiplication") (newline)
+(display "Basis pairs checked: 81") (newline)
+(display "Passed: ") (display pass-count) (newline)
+(display "Failed: ") (display fail-count) (newline)
+(if (= fail-count 0)
+    (begin (display "RESULT: ALL PASS") (newline))
+    (begin (display "RESULT: FAILURES DETECTED") (newline)))

--- a/examples/mathematics_alphatensor_gf2.esk
+++ b/examples/mathematics_alphatensor_gf2.esk
@@ -1,0 +1,105 @@
+;; Recent result: https://github.com/google-deepmind/alphatensor
+;; The public 4x4 matrix-multiplication factorization has rank 47 over F_2.
+;; This program performs the tensor contraction with exact integer bitsets.
+;; Bilinearity makes all 16 x 16 matrix-unit pairs a rigorous expansion check.
+
+(define pass-count 0)
+(define fail-count 0)
+(define (check label ok)
+  (if ok
+      (begin (set! pass-count (+ pass-count 1))
+             (display "PASS: ") (display label) (newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "FAIL: ") (display label) (newline))))
+
+(define rank 47)
+
+;; Each U/V entry is a 16-bit mask.  Each W row is a 47-bit mask.  A mask
+;; contracts with a bitset by parity(popcount(mask AND input)).
+(define u-masks
+  (vector 4 100 84 68 1 257 1281 871 12290 24578 8194 12375 25863 4096
+          36872 32776 769 39432 2568 2056 32 168 49160 49240 18472 1024
+          136 152 27144 49320 8 3080 4368 12456 34944 3176 17472 8736 2
+          3224 16384 16 920 4744 512 33816 38152))
+(define v-masks
+  (vector 256 2192 1029 3477 1 923 770 144 69 800 885 5 768 12358
+          12290 29698 152 12288 12320 47136 22720 20544 21504 1024
+          22560 39426 53320 36872 32 20480 4096 38912 14 64 57344 2048
+          3584 224 16 36864 22048 37900 8 12360 12456 37890 2))
+(define w-masks
+  (vector 275951648785 2200301469711 17595441676400 1375467529984
+          70370086769217 36956646440960 70371999891456 1100858441728
+          10215229716 2200849874944 121517711220736 10206896128
+          5260395479170 587541250048 22543344599040 26552381079552))
+
+(define (f2 n) (modulo n 2))
+(define (dot-mask mask bits)
+  (f2 (popcount (bitwise-and mask bits))))
+(define (h-at i a b)
+  (f2 (* (dot-mask (vref u-masks i) a)
+         (dot-mask (vref v-masks i) b))))
+(define (h-list i a b)
+  (if (= i rank)
+      '()
+      (cons (h-at i a b) (h-list (+ i 1) a b))))
+(define (w-contract mask hs i acc)
+  (if (= i rank)
+      (f2 acc)
+      (w-contract mask hs (+ i 1)
+                  (if (= (bitwise-and mask (expt 2 i)) 0)
+                      acc
+                      (+ acc (list-ref hs i))))))
+(define (result-mask a b)
+  (let ((hs (h-list 0 a b)))
+    (+ (if (= (w-contract (vref w-masks 0) hs 0 0) 1) 1 0)
+       (if (= (w-contract (vref w-masks 1) hs 0 0) 1) 2 0)
+       (if (= (w-contract (vref w-masks 2) hs 0 0) 1) 4 0)
+       (if (= (w-contract (vref w-masks 3) hs 0 0) 1) 8 0)
+       (if (= (w-contract (vref w-masks 4) hs 0 0) 1) 16 0)
+       (if (= (w-contract (vref w-masks 5) hs 0 0) 1) 32 0)
+       (if (= (w-contract (vref w-masks 6) hs 0 0) 1) 64 0)
+       (if (= (w-contract (vref w-masks 7) hs 0 0) 1) 128 0)
+       (if (= (w-contract (vref w-masks 8) hs 0 0) 1) 256 0)
+       (if (= (w-contract (vref w-masks 9) hs 0 0) 1) 512 0)
+       (if (= (w-contract (vref w-masks 10) hs 0 0) 1) 1024 0)
+       (if (= (w-contract (vref w-masks 11) hs 0 0) 1) 2048 0)
+       (if (= (w-contract (vref w-masks 12) hs 0 0) 1) 4096 0)
+       (if (= (w-contract (vref w-masks 13) hs 0 0) 1) 8192 0)
+       (if (= (w-contract (vref w-masks 14) hs 0 0) 1) 16384 0)
+       (if (= (w-contract (vref w-masks 15) hs 0 0) 1) 32768 0))))
+
+(define (expected-mask ai bi)
+  (let ((ar (quotient ai 4))
+        (ac (modulo ai 4))
+        (br (quotient bi 4))
+        (bc (modulo bi 4)))
+    (if (= ac br)
+        ;; W is indexed in the column-major output order used by the
+        ;; published contraction: c.reshape(n,m).T.
+        (expt 2 (+ (* bc 4) ar))
+        0)))
+
+(define (check-basis-ai ai bi)
+  (if (= bi 16)
+      #t
+      (and (= (result-mask (expt 2 ai) (expt 2 bi))
+              (expected-mask ai bi))
+           (check-basis-ai ai (+ bi 1)))))
+(define (check-basis-ai-all ai)
+  (if (= ai 16)
+      #t
+      (and (check-basis-ai ai 0) (check-basis-ai-all (+ ai 1)))))
+
+(check "rank-47 factorization has 47 bilinear products" (= rank 47))
+(check "rank-47 tensor expands to 4x4 multiplication over F2"
+       (check-basis-ai-all 0))
+(check "nontrivial sample multiplication is exact over F2"
+       (= (result-mask 43690 3855) 0))
+
+(display "AlphaTensor rank-47 F2 matrix multiplication") (newline)
+(display "Basis pairs checked: 256") (newline)
+(display "Passed: ") (display pass-count) (newline)
+(display "Failed: ") (display fail-count) (newline)
+(if (= fail-count 0)
+    (begin (display "RESULT: ALL PASS") (newline))
+    (begin (display "RESULT: FAILURES DETECTED") (newline)))

--- a/examples/mathematics_funsearch_cap_set.esk
+++ b/examples/mathematics_funsearch_cap_set.esk
@@ -1,0 +1,138 @@
+;; Recent result and public witness: https://github.com/google-deepmind/funsearch
+;; The checked-in n8_size512.txt witness is an explicit 512-cap in AG(8,3).
+;; This is the compact explicit construction from the accompanying notebook,
+;; followed by an exhaustive exact no-three-collinear check.
+
+(define pass-count 0)
+(define fail-count 0)
+(define (check label ok)
+  (if ok
+      (begin (set! pass-count (+ pass-count 1))
+             (display "PASS: ") (display label) (newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "FAIL: ") (display label) (newline))))
+
+(define (contains? x xs)
+  (if (null? xs) #f
+      (if (equal? x (car xs)) #t (contains? x (cdr xs)))))
+
+(define (decode-base3 n)
+  (let ((v (make-vector 8 0)))
+    (define (loop i q)
+      (if (= i -1)
+          v
+          (begin (vector-set! v i (modulo q 3))
+                 (loop (- i 1) (quotient q 3)))))
+    (loop 7 n)))
+
+(define (support-loop v i out)
+  (if (= i 8)
+      (reverse out)
+      (support-loop v (+ i 1)
+                    (if (= (vector-ref v i) 0) out (cons i out)))))
+(define (support v) (support-loop v 0 '()))
+
+(define (reflections-loop v i count)
+  (if (= i 4)
+      count
+      (reflections-loop v (+ i 1)
+                        (if (= (vector-ref v i) (vector-ref v (- 8 i)))
+                            (+ count 1) count))))
+(define (reflections v) (reflections-loop v 1 0))
+
+(define supports-16
+  (list (list 0 1 2 3) (list 0 1 2 5) (list 0 3 6 7)
+        (list 0 5 6 7) (list 1 3 4 6) (list 1 4 5 6)
+        (list 2 3 4 7) (list 2 4 5 7)))
+(define supports-8
+  (list (list 0 1 2 7) (list 0 1 2 6) (list 0 1 3 7)
+        (list 0 1 6 7) (list 0 1 5 7) (list 0 2 3 6)
+        (list 0 2 6 7) (list 0 2 5 6) (list 1 2 4 7)
+        (list 1 2 4 6) (list 1 3 4 7) (list 1 4 6 7)
+        (list 1 4 5 7) (list 2 3 4 6) (list 2 4 6 7)
+        (list 2 4 5 6)))
+(define allowed-zeros
+  (list (list 0 4 7) (list 0 2 4) (list 0 1 4) (list 0 4 6)
+        (list 1 2 6) (list 2 6 7) (list 1 2 7) (list 1 6 7)))
+
+(define (weight8? v)
+  (and (= (length (support v)) 8) (>= (reflections v) 2)))
+(define (weight4a? v)
+  (and (= (length (support v)) 4)
+       (contains? (support v) supports-16)))
+(define (weight4b? v)
+  (and (= (length (support v)) 4)
+       (contains? (support v) supports-8)
+       (= (reflections v) 1)))
+;; The zero-support predicate is spelled separately to keep the construction
+;; readable and to avoid depending on an implementation-specific set type.
+(define (zero-support v)
+  (let ((out '()))
+    (define (loop i acc)
+      (if (= i 8) (reverse acc)
+          (loop (+ i 1)
+                (if (= (vector-ref v i) 0) (cons i acc) acc))))
+    (loop 0 out)))
+(define (weight5-clean? v)
+  (and (contains? (zero-support v) allowed-zeros)
+       (<= (reflections v) 1)
+       (not (= (modulo (* (vector-ref v 1) (vector-ref v 7)) 3) 1))
+       (not (= (modulo (* (vector-ref v 2) (vector-ref v 6)) 3) 1))))
+
+(define (in-construction? v)
+  (or (weight8? v) (weight4a? v) (weight4b? v) (weight5-clean? v)))
+
+;; A loop avoids building the 6561-element ambient list.  It is the same exact
+;; enumeration as the public construction and stays within the bytecode VM's
+;; fixed frame budget.
+(define cap
+  (do ((i 0 (+ i 1))
+       (out '() (let ((v (decode-base3 i)))
+                  (if (in-construction? v) (cons v out) out))))
+      ((= i 6561) (reverse out))))
+
+(define (encode v)
+  (let ((out 0))
+    (define (loop i acc)
+      (if (= i 8) acc
+          (loop (+ i 1) (+ (* acc 3) (vector-ref v i)))))
+    (loop 0 out)))
+(define membership (make-vector 6561 0))
+(define (mark xs)
+  (if (null? xs) #t
+      (begin (vector-set! membership (encode (car xs)) 1)
+             (mark (cdr xs)))))
+(mark cap)
+
+(define (third-point a b)
+  (let ((out (make-vector 8 0)))
+    (define (loop i)
+      (if (= i 8) out
+          (begin (vector-set! out i
+                             (modulo (- 0 (+ (vector-ref a i)
+                                             (vector-ref b i))) 3))
+                 (loop (+ i 1)))))
+    (loop 0)))
+
+(define (cap-check cap n)
+  (let ((ok #t))
+    (do ((i 0 (+ i 1)))
+        ((= i n) ok)
+      (do ((j (+ i 1) (+ j 1)))
+          ((= j n))
+        (let ((a (list-ref cap i)) (b (list-ref cap j)))
+          (if (not (= (vector-ref membership (encode (third-point a b))) 0))
+              (set! ok #f)))))))
+
+(check "explicit construction has 512 points" (= (length cap) 512))
+(check "ambient AG(8,3) has 3^8 exact vectors" (= (expt 3 8) 6561))
+(check "512-point witness is a cap in AG(8,3)"
+       (cap-check cap (length cap)))
+
+(display "FunSearch 512-cap in AG(8,3)") (newline)
+(display "Exact pair checks: 130816") (newline)
+(display "Passed: ") (display pass-count) (newline)
+(display "Failed: ") (display fail-count) (newline)
+(if (= fail-count 0)
+    (begin (display "RESULT: ALL PASS") (newline))
+    (begin (display "RESULT: FAILURES DETECTED") (newline)))

--- a/examples/mathematics_jacobian_counterexample.esk
+++ b/examples/mathematics_jacobian_counterexample.esk
@@ -1,0 +1,214 @@
+;; Recent result: https://www.ulam.ai/research/jacobian.pdf
+;; Exact rational verification of the polynomial Keller map in Theorem 3.1,
+;; its cubic fiber description, discriminant fiber counts, and Theorem 5.1.
+;;
+;; SW-136: gradient with an exact-rational vector is currently silently wrong.
+;; The AD checks therefore use double vectors.  Exact rational checks use the
+;; explicit partial derivatives below.  TODO(SW-136): replace detJ-exact with
+;; exact AD once the tracked defect is fixed.  SW-135 (gradient through a
+;; closure factory) is avoided by keeping the differentiands named and direct.
+
+(define pass-count 0)
+(define fail-count 0)
+
+(define (check label ok)
+  (if ok
+      (begin (set! pass-count (+ pass-count 1))
+             (display "PASS: ") (display label) (newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "FAIL: ") (display label) (newline))))
+
+(define (close? a b)
+  (< (abs (- a b)) 1e-9))
+
+(define (A x y) (+ 1 (* x y)))
+(define (B x y z)
+  (+ (* (A x y) (A x y) z)
+     (* y y (+ 4 (* 3 x y)))))
+(define (P x y z) (* (A x y) (B x y z)))
+(define (Q x y z) (+ y (* 3 x (B x y z))))
+(define (R x y z) (- (* 2 x) (* 3 x x y) (* x x x z)))
+
+(define (Pv v) (P (vref v 0) (vref v 1) (vref v 2)))
+(define (Qv v) (Q (vref v 0) (vref v 1) (vref v 2)))
+(define (Rv v) (R (vref v 0) (vref v 1) (vref v 2)))
+
+(define (det3 a b c)
+  (- (+ (* (vref a 0)
+           (- (* (vref b 1) (vref c 2))
+              (* (vref b 2) (vref c 1))))
+        (* (vref a 2)
+           (- (* (vref b 0) (vref c 1))
+              (* (vref b 1) (vref c 0)))))
+     (* (vref a 1)
+        (- (* (vref b 0) (vref c 2))
+           (* (vref b 2) (vref c 0))))))
+
+(define (detJ-ad v)
+  (det3 (gradient Pv v) (gradient Qv v) (gradient Rv v)))
+
+;; Exact partials.  These are the same polynomial derivatives that AD returns.
+(define (Bx x y z)
+  (+ (* 2 (A x y) y z) (* 3 y y y)))
+(define (By x y z)
+  (+ (* 2 (A x y) x z) (* 8 y) (* 9 x y y)))
+(define (Bz x y z) (* (A x y) (A x y)))
+(define (Px x y z) (+ (* y (B x y z)) (* (A x y) (Bx x y z))))
+(define (Py x y z) (+ (* x (B x y z)) (* (A x y) (By x y z))))
+(define (Pz x y z) (* (A x y) (Bz x y z)))
+(define (Qx x y z) (+ (* 3 (B x y z)) (* 3 x (Bx x y z))))
+(define (Qy x y z) (+ 1 (* 3 x (By x y z))))
+(define (Qz x y z) (* 3 x (Bz x y z)))
+(define (Rx x y z) (- 2 (* 6 x y) (* 3 x x z)))
+(define (Ry x y z) (* -3 x x))
+(define (Rz x y z) (* -1 x x x))
+
+(define (detJ-exact x y z)
+  (det3 (vector (Px x y z) (Py x y z) (Pz x y z))
+         (vector (Qx x y z) (Qy x y z) (Qz x y z))
+         (vector (Rx x y z) (Ry x y z) (Rz x y z))))
+
+(define (same-image? v p q r)
+  (and (= (P (vref v 0) (vref v 1) (vref v 2)) p)
+       (= (Q (vref v 0) (vref v 1) (vref v 2)) q)
+       (= (R (vref v 0) (vref v 1) (vref v 2)) r)))
+
+(define target-p -1/4)
+(define target-q 0)
+(define target-r 0)
+(define witness-0 (vector 0 0 -1/4))
+(define witness-1 (vector 1 -3/2 13/2))
+(define witness-2 (vector -1 3/2 13/2))
+(check "three rational preimages share (-1/4,0,0)"
+       (and (same-image? witness-0 target-p target-q target-r)
+            (same-image? witness-1 target-p target-q target-r)
+            (same-image? witness-2 target-p target-q target-r)))
+
+(define (fiber-point p q s r)
+  (let* ((D (+ 1 (* -1 q s) (* 3 p s s)))
+         (y (- q (* 3 p s)))
+         (x (/ s D))
+         (z (- (* p D D D)
+               (* y y (- 4 (* s y)) D))))
+    (vector x y z)))
+
+(check "binary cubic roots 0,2,-2 recover the three points"
+       (and (equal? (fiber-point target-p target-q 0 target-r) witness-0)
+            (equal? (fiber-point target-p target-q 2 target-r) witness-2)
+            (equal? (fiber-point target-p target-q -2 target-r) witness-1)))
+
+(define (delta p q r)
+  (+ (* q q) (* -16 p) (* -1 q q q r)
+     (* 18 p q r) (* -27 p p r r)))
+
+(define (on-gamma? p q r)
+  (and (= (- (* 12 p) (* q q)) 0)
+       (= (- (* 3 q r) 4) 0)))
+
+(define (fiber-count p q r)
+  (if (not (= (delta p q r) 0))
+      3
+      (if (on-gamma? p q r) 0 1)))
+
+(check "discriminant gives a three-point generic fiber"
+       (= (fiber-count 1 0 0) 3))
+(check "discriminant gives one point on the branch surface"
+       (= (fiber-count 0 0 0) 1))
+(check "gamma gives an empty fiber"
+       (= (fiber-count 1/3 2 2/3) 0))
+(check "target discriminant is nonzero with three simple roots"
+       (and (not (= (delta target-p target-q target-r) 0))
+            (not (on-gamma? target-p target-q target-r))
+            (= (fiber-count target-p target-q target-r) 3)))
+
+(define (ad-ok? x y z)
+  (and (close? (vref (gradient Pv (vector (exact->inexact x)
+                                          (exact->inexact y)
+                                          (exact->inexact z))) 0)
+                (exact->inexact (Px x y z)))
+       (close? (vref (gradient Pv (vector (exact->inexact x)
+                                          (exact->inexact y)
+                                          (exact->inexact z))) 1)
+                (exact->inexact (Py x y z)))
+       (close? (vref (gradient Pv (vector (exact->inexact x)
+                                          (exact->inexact y)
+                                          (exact->inexact z))) 2)
+                (exact->inexact (Pz x y z)))))
+
+(check "reverse-mode AD agrees with exact partials at many points"
+       (and (ad-ok? 0 0 -1/4)
+            (ad-ok? 1 -3/2 13/2)
+            (ad-ok? -1 3/2 13/2)
+            (ad-ok? 5/2 -7/10 39/10)
+            (ad-ok? -31/10 2/5 12)))
+(check "AD determinant is -2 at many double points"
+       (and (close? (detJ-ad (vector 0.0 0.0 -0.25)) -2.0)
+            (close? (detJ-ad (vector 1.0 -1.5 6.5)) -2.0)
+            (close? (detJ-ad (vector -1.0 1.5 6.5)) -2.0)
+            (close? (detJ-ad (vector 2.5 -0.7 3.9)) -2.0)
+            (close? (detJ-ad (vector -3.1 0.4 12.0)) -2.0)))
+
+;; Degree bounds for det(Jac F) in (x,y,z) are (8,7,2):
+;; deg_x(P,Q,R) <= (3,3,3), deg_y(P,Q,R) <= (4,3,1), and
+;; deg_z(P,Q,R) <= (1,1,1), and a 3x3 Jacobian term lowers one bound.
+;; The 9 x 8 x 3 exact rational grid is therefore larger than the degree
+;; in every variable, so vanishing on it is a rigorous identity check.
+(define xs (list -2 -1 0 1 2 3 4 5 6))
+(define ys (list -3/2 -1 -1/2 0 1/2 1 3/2 2))
+(define zs (list -1 -1/4 2))
+
+(define (all-z? x y zs)
+  (if (null? zs)
+      #t
+      (and (= (detJ-exact x y (car zs)) -2)
+           (all-z? x y (cdr zs)))))
+(define (all-y? x ys)
+  (if (null? ys)
+      #t
+      (and (all-z? x (car ys) zs)
+           (all-y? x (cdr ys)))))
+(define (all-x? xs)
+  (if (null? xs)
+      #t
+      (and (all-y? (car xs) ys)
+           (all-x? (cdr xs)))))
+(check "exact determinant is identically -2 on the degree grid"
+       (all-x? xs))
+
+;; Theorem 5.1 family, checked at two parameter choices with exact rational
+;; partials.  The base map above is the AD demonstration; this parameterized
+;; family is checked with exact rational evaluation so its determinant claim
+;; does not depend on the known closure-factory limitation.
+(define (FH-det-exact x y z lambda a c)
+  (let* ((aa (+ lambda (* x y)))
+         (w (+ (* c z) (+ x (* 2 y))))
+         (k (/ 3 (* a lambda lambda)))
+         (b (+ (* aa aa w) (* k y y (+ (* 4 lambda) (* 3 x y)))))
+         (bx (+ (* 2 aa y w) (* aa aa) (* 3 k y y y)))
+         (by (+ (* 2 aa x w) (* 2 aa aa)
+                (* k (+ (* 8 lambda y) (* 9 x y y)))))
+         (bz (* aa aa c))
+         (px (+ (* y b) (* aa bx)))
+         (py (+ (* x b) (* aa by)))
+         (pz (* aa bz))
+         (qx (* a (+ b (* x bx))))
+         (qy (+ 1 (* a x by)))
+         (qz (* a x bz))
+         (rx (- (- (/ 2 lambda) (* 6 (/ 1 (* lambda lambda)) x y))
+                (* a x x w) (* (/ a 3) x x x)))
+         (ry (- (* -3 (/ 1 (* lambda lambda)) x x)
+                (* (/ (* 2 a) 3) x x x)))
+         (rz (* -1 (/ (* a c) 3) x x x)))
+    (det3 (vector px py pz) (vector qx qy qz) (vector rx ry rz))))
+
+(check "Theorem 5.1 family determinant lambda=2,a=1,c=3"
+       (= (FH-det-exact 7/10 -4/5 11/10 2 1 3) -24))
+(check "Theorem 5.1 family determinant lambda=-1,a=2,c=1"
+       (= (FH-det-exact -3/5 9/10 7/4 -1 2 1) -2))
+
+(display "Jacobian counterexample and fiber geometry") (newline)
+(display "Passed: ") (display pass-count) (newline)
+(display "Failed: ") (display fail-count) (newline)
+(if (= fail-count 0)
+    (begin (display "RESULT: ALL PASS") (newline))
+    (begin (display "RESULT: FAILURES DETECTED") (newline)))


### PR DESCRIPTION
New examples/mathematics family, CI-run (examples target 20/20 on native AOT, JIT and hosted VM): Alpöge's counterexample to the Jacobian conjecture (exact rational fibers, det Jac = -2 via AD, degree-grid identity check, discriminant fiber counts, Theorem 5.1 family); AlphaTensor rank-23 and rank-47 exact F2 matrix-multiplication decompositions verified by exact expansion; FunSearch 512-element cap set in AG(8,3) verified exactly. Sources cited in each file; docs page and CHANGELOG entry added. AD parts use double inputs with TODO(SW-136) markers; exact-rational AD follows once #568 merges.