### PR TITLE
ci: linux-x64-debug lane (Debug build, assertions, switch warnings, focused CTest, exhaustive_dispatch) as a required context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1110,6 +1110,7 @@ jobs:
       matrix:
         name:
           - linux-x64-xla
+          - linux-x64-debug
           - linux-arm64-xla
           - linux-x64-cuda
           - linux-arm64-cuda
@@ -1144,6 +1145,24 @@ jobs:
             test_command: ./scripts/run_all_tests.sh
             upload_artifact: 'true'
             artifact_name: eshkol-linux-x64
+          # This is the assertion-enabled compilation axis. Keep it as a
+          # separate matrix leg so the check-run name is a branch-protection
+          # candidate and the docs-only stub can report it when the matrix is
+          # skipped.
+          - name: linux-x64-debug
+            runner: ubuntu-22.04
+            build_dir: build-debug
+            build_type: Debug
+            switch_werror: 'ON'
+            xla_enabled: 'OFF'
+            gpu_enabled: 'OFF'
+            test_command: >-
+              ctest --test-dir build-debug --output-on-failure
+              -R '^runtime_(arena_core|arena_cpp|object_alloc|regions|tagged_cons)_test$'
+              && ctest --test-dir build-debug --output-on-failure
+              -R '^exhaustive_dispatch$'
+            upload_artifact: 'false'
+            artifact_name: ''
           - name: linux-arm64-lite
             runner: ubuntu-22.04-arm
             build_dir: build
@@ -1337,14 +1356,25 @@ jobs:
             LLVM_CONFIG="/usr/bin/llvm-config-${LLVM_MAJOR}"
           fi
 
+          CMAKE_ARGS=(
+            "-DCMAKE_BUILD_TYPE=${{ matrix.build_type || 'Release' }}"
+            "-DESHKOL_REQUIRED_LLVM_MAJOR=${LLVM_MAJOR}"
+            "-DLLVM_CONFIG_EXECUTABLE=$LLVM_CONFIG"
+            "-DESHKOL_XLA_ENABLED=${{ matrix.xla_enabled }}"
+            "-DESHKOL_GPU_ENABLED=${{ matrix.gpu_enabled }}"
+            "-DESHKOL_REQUIRE_GPU_BACKEND=${{ matrix.gpu_enabled }}"
+            -DCUDAToolkit_ROOT=/usr/local/cuda-12.4
+          )
+          if [[ "${{ matrix.switch_werror }}" == "ON" ]]; then
+            # Debug must compile the NDEBUG-guarded source and turn the
+            # closed-enum dispatch diagnostics into hard failures.
+            CMAKE_ARGS+=(
+              '-DCMAKE_C_FLAGS=-UNDEBUG'
+              '-DCMAKE_CXX_FLAGS=-UNDEBUG -Werror=switch -Werror=switch-enum -Wno-error=switch -Wno-error=switch-enum'
+            )
+          fi
           cmake -S . -B "$BUILD_DIR" -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DESHKOL_REQUIRED_LLVM_MAJOR="${LLVM_MAJOR}" \
-            -DLLVM_CONFIG_EXECUTABLE="$LLVM_CONFIG" \
-            -DESHKOL_XLA_ENABLED=${{ matrix.xla_enabled }} \
-            -DESHKOL_GPU_ENABLED=${{ matrix.gpu_enabled }} \
-            -DESHKOL_REQUIRE_GPU_BACKEND=${{ matrix.gpu_enabled }} \
-            -DCUDAToolkit_ROOT=/usr/local/cuda-12.4 \
+            "${CMAKE_ARGS[@]}" \
             ${{ matrix.sanitizer_flags }}
 
       - name: Verify real CUDA build graph

--- a/.icc/required-status-contexts.json
+++ b/.icc/required-status-contexts.json
@@ -4,9 +4,10 @@
   "branch": "master",
   "as_of": "2026-08-25",
   "source": "gh api repos/tsotchke/eshkol/branches/master/protection --jq '.required_status_checks.contexts'",
-  "note": "The INTENDED full required-context set for scripts/check_required_context_consistency.py -- graded ALWAYS, not only as a fallback, specifically so a live branch-protection set that is temporarily (or by mistake) narrower than intended cannot make that gate agree nothing is missing. As of this file's introduction, live branch protection is temporarily narrowed to 11 contexts (missing the 5 macOS/windows-arm64-lite matrix-derived names) while this fix ships; restoring the full 16 here is what the fix is FOR. Update this file by hand whenever the intended policy changes (a context added/removed on purpose) -- do not narrow it just because live is temporarily narrower, and do not treat a live/target mismatch reported by the gate as this file being wrong without checking which side is out of date.",
+  "note": "The INTENDED full required-context set for scripts/check_required_context_consistency.py -- graded ALWAYS, not only as a fallback, specifically so a live branch-protection set that is temporarily (or by mistake) narrower than intended cannot make that gate agree nothing is missing. As of this file's introduction, live branch protection is temporarily narrowed to 11 contexts (missing the 5 macOS/windows-arm64-lite matrix-derived names) while this fix ships; this target records the full 17 intended contexts, including the assertion-enabled linux-x64-debug candidate. Update this file by hand whenever the intended policy changes (a context added/removed on purpose) -- do not narrow it just because live is temporarily narrower, and do not treat a live/target mismatch reported by the gate as this file being wrong without checking which side is out of date.",
   "contexts": [
     "guard",
+    "linux-x64-debug",
     "linux-x64-xla",
     "linux-arm64-xla",
     "linux-x64-cuda",

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -337,6 +337,25 @@ as `ctest` entries next to the repo's other Python-based validators, and
 run in a fast `assurance-gates` CI job (pure Python over checked-out
 files, no build step) modeled on the existing surface-manifest job.
 
+## CI: assertion-enabled Debug lane
+
+`linux-x64-debug` is the assertion-enabled Linux x64 compilation axis. It
+configures `-DCMAKE_BUILD_TYPE=Debug`, explicitly removes `NDEBUG`, and treats
+both `-Werror=switch` and `-Werror=switch-enum` as hard errors for the
+registered closed-enum dispatch translation units. The lane builds the full
+test-enabled tree, then runs the focused runtime CTest subset and the
+closed-enum dispatch test separately:
+
+```bash
+ctest --test-dir build-debug --output-on-failure \
+  -R '^runtime_(arena_core|arena_cpp|object_alloc|regions|tagged_cons)_test$'
+ctest --test-dir build-debug --output-on-failure -R '^exhaustive_dispatch$'
+```
+
+The exact matrix name is also present in `docs-only-required-context-stubs`,
+so it is a branch-protection candidate that remains reportable for a docs-only
+pull request.
+
 ## CI: docs-only PRs now actually report required contexts (#455)
 
 `paths-ignore` on the `pull_request` trigger meant GitHub never started

--- a/docs/platform/CI_LANES.md
+++ b/docs/platform/CI_LANES.md
@@ -1,35 +1,38 @@
 # CI Lane Matrix
 
 Continuous integration for Eshkol runs from `.github/workflows/ci.yml`. All
-**14 lanes** live in two matrix jobs: `unix-matrix` (11 lanes) and
+**15 lanes** live in two matrix jobs: `unix-matrix` (12 lanes) and
 `windows-matrix` (3 lanes). Global env pins `LLVM_MAJOR=21` and the Windows SDK
 at `WINDOWS_LLVM_SDK_VERSION=21.1.8`.
 
 | # | Lane | Runner (OS/arch) | build dir | XLA | GPU | What it does |
 |---|------|------------------|-----------|-----|-----|--------------|
 | 1 | `linux-x64-lite` | ubuntu-22.04 (x64) | `build` | off | off | Full AOT+JIT suite (`run_all_tests.sh`), WASM-import check, uploads `eshkol-linux-x64` |
-| 2 | `linux-arm64-lite` | ubuntu-22.04-arm | `build` | off | off | `run_all_tests.sh`, WASM check, uploads `eshkol-linux-arm64` |
-| 3 | `linux-x64-xla` | ubuntu-22.04 | `build-xla` | on | off | `run_xla_tests.sh` |
-| 4 | `linux-arm64-xla` | ubuntu-22.04-arm | `build-xla` | on | off | `run_xla_tests.sh` |
-| 5 | `linux-x64-cuda` | ubuntu-22.04 | `build-cuda` | off | on | `run_gpu_tests.sh` (CUDA) |
-| 6 | `linux-arm64-cuda` | ubuntu-22.04-arm | `build-cuda` | off | on | `run_gpu_tests.sh` (CUDA) |
-| 7 | `macos-arm64-lite` | macos-14 (Apple Silicon) | `build` | off | off | `run_all_tests.sh`, WASM check, uploads `eshkol-macos-arm64` |
-| 8 | `macos-x64-lite` | macos-15-intel (x86_64) | `build` | off | off | `run_all_tests.sh`, WASM check, uploads `eshkol-macos-x64` |
-| 9 | `macos-arm64-xla` | macos-14 | `build-xla` | on | off | `run_xla_tests.sh` |
-| 10 | `macos-x64-xla` | macos-15-intel | `build-xla` | on | off | `run_xla_tests.sh` |
-| 11 | `linux-x64-asan-ubsan` | ubuntu-22.04 | `build-asan` | off | off | ASan+UBSan build, `run_v1_2_edge_cases_tests.sh` (TSan/MSan deferred) |
-| 12 | `windows-arm64-lite` | windows-11-arm | `build` | off | off | VS2022 `-A ARM64 -T ClangCL`, `run_all_tests.ps1 -Mode windows-lite`, uploads `eshkol-windows-arm64` |
-| 13 | `windows-arm64-xla` | windows-11-arm | `build-xla` | on | off | builds `xla_codegen_test`, `-Mode xla` |
-| 14 | `windows-x64-cuda` | windows-2022 (x64) | `build-cuda` | off | on | installs CUDA 12.4, verifies real CUDA sources, then runs `-Mode gpu` |
+| 2 | `linux-x64-debug` | ubuntu-22.04 (x64) | `build-debug` | off | off | Full Debug build with assertions and `-Werror=switch`/`-Werror=switch-enum`; focused runtime CTest subset plus `exhaustive_dispatch` |
+| 3 | `linux-arm64-lite` | ubuntu-22.04-arm | `build` | off | off | `run_all_tests.sh`, WASM check, uploads `eshkol-linux-arm64` |
+| 4 | `linux-x64-xla` | ubuntu-22.04 | `build-xla` | on | off | `run_xla_tests.sh` |
+| 5 | `linux-arm64-xla` | ubuntu-22.04-arm | `build-xla` | on | off | `run_xla_tests.sh` |
+| 6 | `linux-x64-cuda` | ubuntu-22.04 | `build-cuda` | off | on | `run_gpu_tests.sh` (CUDA) |
+| 7 | `linux-arm64-cuda` | ubuntu-22.04-arm | `build-cuda` | off | on | `run_gpu_tests.sh` (CUDA) |
+| 8 | `macos-arm64-lite` | macos-14 (Apple Silicon) | `build` | off | off | `run_all_tests.sh`, WASM check, uploads `eshkol-macos-arm64` |
+| 9 | `macos-x64-lite` | macos-15-intel (x86_64) | `build` | off | off | `run_all_tests.sh`, WASM check, uploads `eshkol-macos-x64` |
+| 10 | `macos-arm64-xla` | macos-14 | `build-xla` | on | off | `run_xla_tests.sh` |
+| 11 | `macos-x64-xla` | macos-15-intel | `build-xla` | on | off | `run_xla_tests.sh` |
+| 12 | `linux-x64-asan-ubsan` | ubuntu-22.04 | `build-asan` | off | off | ASan+UBSan build, `run_v1_2_edge_cases_tests.sh` (TSan/MSan deferred) |
+| 13 | `windows-arm64-lite` | windows-11-arm | `build` | off | off | VS2022 `-A ARM64 -T ClangCL`, `run_all_tests.ps1 -Mode windows-lite`, uploads `eshkol-windows-arm64` |
+| 14 | `windows-arm64-xla` | windows-11-arm | `build-xla` | on | off | builds `xla_codegen_test`, `-Mode xla` |
+| 15 | `windows-x64-cuda` | windows-2022 (x64) | `build-cuda` | off | on | installs CUDA 12.4, verifies real CUDA sources, then runs `-Mode gpu` |
 
 ## Lane groups
 
-- **lite** (1,2,7,8,12) — the baseline AOT + JIT test suite per OS/arch; these
+- **lite** (1,3,8,9,13) — the baseline AOT + JIT test suite per OS/arch; these
   are the lanes that upload release binaries.
-- **xla** (3,4,9,10,13) — build with `-DESHKOL_XLA_ENABLED=ON` and run the XLA
+- **debug** (2) — assertion-enabled x64 build; focused runtime CTest plus the
+  exhaustive closed-enum dispatch test.
+- **xla** (4,5,10,11,14) — build with `-DESHKOL_XLA_ENABLED=ON` and run the XLA
   codegen/runtime tests.
-- **cuda** (5,6,14) — build with the CUDA backend and run GPU tests.
-- **asan-ubsan** (11) — sanitizer build over the v1.2 edge-case suite.
+- **cuda** (6,7,15) — build with the CUDA backend and run GPU tests.
+- **asan-ubsan** (12) — sanitizer build over the v1.2 edge-case suite.
 
 ## Notes and gotchas
 
@@ -45,6 +48,9 @@ at `WINDOWS_LLVM_SDK_VERSION=21.1.8`.
   `-fuse-ld=lld` for AArch64 Linux links.
 - Concurrency **does not cancel on `master`** — the release gate wants the full
   matrix signal even when commits land quickly.
+- `linux-x64-debug` is a required-context candidate. Add that exact check name
+  to branch protection after the first green run; the docs-only stub matrix
+  already reports it when the real matrix is skipped.
 - Per the project rule, treat the non-required xla/asan/cuda lanes as
   first-class: a green "required" set can still hide a regression that only one
   of these lanes catches.
@@ -54,7 +60,7 @@ at `WINDOWS_LLVM_SDK_VERSION=21.1.8`.
 `ci.yml` fires on `push` to **`master` and `develop` only**, and on `pull_request`
 against `master`. Topic branches are covered by the `pull_request` trigger alone —
 listing them under `push` as well makes GitHub start two full runs of the same
-14-lane matrix for one commit, and leaves `cancelled` check-runs behind when a
+15-lane matrix for one commit, and leaves `cancelled` check-runs behind when a
 follow-up push cancels the superseded push run. Concurrency cancels in-progress runs
 for pull requests and for non-`master` branches; `master` is never cancelled.
 

--- a/lib/core/resource_limits.cpp
+++ b/lib/core/resource_limits.cpp
@@ -709,6 +709,8 @@ int eshkol_limit_exit_code(eshkol_limit_error_t error) {
 /** The environment variable that configures each limit, for the diagnostic. */
 static const char* limit_env_var(eshkol_limit_error_t error) {
     switch (error) {
+        case ESHKOL_LIMIT_OK:
+            return "ESHKOL_ENFORCE_LIMITS";
         case ESHKOL_LIMIT_HEAP_HARD:
         case ESHKOL_LIMIT_HEAP_SOFT:      return "ESHKOL_MAX_HEAP";
         case ESHKOL_LIMIT_STACK_OVERFLOW: return "ESHKOL_MAX_STACK";
@@ -723,6 +725,9 @@ static const char* limit_env_var(eshkol_limit_error_t error) {
 static void format_limit_ceiling(eshkol_limit_error_t error,
                                  char* out, size_t out_size) {
     switch (error) {
+        case ESHKOL_LIMIT_OK:
+            snprintf(out, out_size, "n/a");
+            break;
         case ESHKOL_LIMIT_HEAP_HARD:
         case ESHKOL_LIMIT_HEAP_SOFT:
             snprintf(out, out_size, "%zu bytes", g_limits.max_heap_bytes);

--- a/scripts/check_required_context_consistency.py
+++ b/scripts/check_required_context_consistency.py
@@ -76,9 +76,14 @@ Which required-context set is graded, and why LIVE alone is not enough
     best-effort and folded into the graded set too (the union of target
     and live — so an ungoverned addition to live that nobody added to the
     target file is *also* checked, not silently skipped), and the
-    difference between the two is always reported, never silently
-    resolved one way. Update the target file by hand whenever the intended
-    policy changes; this script does not write it.
+difference between the two is always reported, never silently
+resolved one way. Update the target file by hand whenever the intended
+policy changes; this script does not write it.
+
+The target may intentionally carry a required-context candidate before the
+administrator adds it to live branch protection. `linux-x64-debug` is such a
+candidate: it is graded now so its docs-only stub coverage is proven before
+the one-click branch-protection change.
 
 Modes
     TARGET_ONLY        `--offline`, or no token/`gh` available: grades the
@@ -704,7 +709,8 @@ def self_test() -> bool:
 
         # THE decisive regression case for this incident: branch protection
         # was measured live-narrower than intended (11 required, temporarily
-        # missing 5 matrix-derived contexts) specifically BECAUSE this gate's
+        # missing 5 matrix-derived contexts; the debug candidate is also
+        # target-only) specifically BECAUSE this gate's
         # own fix had not shipped yet. A gate that graded live alone would
         # have read that narrowed set as complete and said nothing. Simulate
         # "live" by union-ing the target file with a narrower set by hand


### PR DESCRIPTION
Adds a Debug-configuration CI lane so assertion-only and Debug-only diagnostics run on every PR: full Debug build with -Wswitch, focused CTest, and the exhaustive_dispatch gate; required-context and docs-only stub coverage added; Debug-only enum warnings in resource_limits.cpp fixed; all NDEBUG blocks audited and compiled in both configurations; CI lane and testing docs updated. Follow-up: the mesh-primary workflow (#529) must add the same context.