### PR TITLE
ci(mesh): ephemeral container runners — pinned image, non-root runner, hardened launcher, least-privilege workflow permissions

### DIFF
--- a/.github/workflows/ci-mesh.yml
+++ b/.github/workflows/ci-mesh.yml
@@ -55,8 +55,8 @@ name: CI (mesh, self-hosted)
 #      default, and the state this file ships in) means every job here is
 #      SKIPPED — it never queues, never occupies a runner, never reports.
 #   2. `mesh-preflight` runs on a HOSTED runner and refuses to fan out when
-#      no runner carrying the `eshkol` label is registered, so switching the
-#      variable on before registering a runner still cannot leave jobs
+#      no runner carrying both the `eshkol` and `linux-mesh` labels is
+#      registered, so switching the variable on before registering a runner still cannot leave jobs
 #      queued against absent labels.
 #   3. Every mesh job carries `timeout-minutes`, so even a runner that
 #      registers and then wedges releases the run.
@@ -82,6 +82,7 @@ on:
 
 permissions:
   contents: read
+  id-token: none
 
 concurrency:
   # Mirrors ci.yml: one group per PR, one per branch for push runs. Mesh
@@ -136,19 +137,19 @@ jobs:
           # reported as unknown and treated as "go ahead" — the per-job
           # timeout-minutes is the backstop in that case, not a guess here.
           online=$(gh api "repos/$REPO/actions/runners" \
-                     --jq '[.runners[] | select(.status == "online") | select([.labels[].name] | index("eshkol"))] | length' \
+                     --jq '[.runners[] | select(.status == "online") | select([.labels[].name] | index("eshkol")) | select([.labels[].name] | index("linux-mesh"))] | length' \
                    2>/dev/null || echo unknown)
 
           if [ "$online" = "0" ]; then
             echo "dispatch=false" >> "$GITHUB_OUTPUT"
-            echo "::warning title=Mesh CI enabled but no runner registered::ESHKOL_MESH_CI is 'on' but no ONLINE self-hosted runner carries the 'eshkol' label. Mesh lanes skipped rather than left queued. See docs/platform/SELF_HOSTED_RUNNERS.md."
-            echo "ESHKOL_MESH_CI is on, but 0 online runners carry the \`eshkol\` label — mesh lanes skipped." \
+            echo "::warning title=Mesh CI enabled but no runner registered::ESHKOL_MESH_CI is 'on' but no ONLINE ephemeral runner carries both the 'eshkol' and 'linux-mesh' labels. Mesh lanes skipped rather than left queued. See docs/platform/SELF_HOSTED_RUNNERS.md."
+            echo "ESHKOL_MESH_CI is on, but 0 online runners carry the \`eshkol,linux-mesh\` labels — mesh lanes skipped." \
               >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
           echo "dispatch=true" >> "$GITHUB_OUTPUT"
-          echo "Mesh lanes dispatching. Online runners carrying \`eshkol\`: $online." \
+          echo "Mesh lanes dispatching. Online ephemeral runners carrying \`eshkol,linux-mesh\`: $online." \
             >> "$GITHUB_STEP_SUMMARY"
 
   # ───────────────────────────────────────────────────────────────────
@@ -158,7 +159,7 @@ jobs:
   # `cuda`); which physical box answers is the runbook's business, so a
   # node can be swapped without editing this file. `self-hosted`, the OS
   # label and the arch label are applied by GitHub automatically at
-  # registration; `eshkol`, `cuda` and `metal` are custom and are assigned
+  # registration; `eshkol`, `linux-mesh`, `cuda` and `metal` are custom and are assigned
   # per docs/platform/SELF_HOSTED_RUNNERS.md § Label taxonomy.
   #
   # These lanes deliberately do NOT apt-get/brew install a toolchain the
@@ -183,7 +184,7 @@ jobs:
       matrix:
         include:
           - name: mesh-linux-x64-lite
-            labels: '["self-hosted", "linux", "x64", "eshkol"]'
+            labels: '["self-hosted", "linux", "x64", "eshkol", "linux-mesh"]'
             build_dir: build-mesh
             xla_enabled: 'OFF'
             gpu_enabled: 'OFF'
@@ -221,6 +222,16 @@ jobs:
             timeout: 120
 
     steps:
+      - name: Require ephemeral container runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${ESHKOL_RUNNER_CONTAINER:-}" != "1" || "${ESHKOL_RUNNER_EPHEMERAL:-}" != "1" ]] || \
+             { [[ ! -f /.dockerenv ]] && [[ ! -f /run/.containerenv ]]; }; then
+            echo "::error::This job requires the pinned ephemeral container runner image; refusing to run on a host runner."
+            exit 1
+          fi
+
       - uses: actions/checkout@v6
 
       # Self-hosted runners keep their workspace between runs, so a lane that
@@ -304,23 +315,18 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          fetchcontent_args=()
-          fetchcontent_cache="$HOME/lanes/_deps"
-          if [[ -f "$fetchcontent_cache/.eshkol-fetchcontent-cache-ready" ]]; then
-            echo "Using shared FetchContent cache: $fetchcontent_cache"
-            fetchcontent_args+=("-DFETCHCONTENT_BASE_DIR=$fetchcontent_cache")
-            fetchcontent_args+=("-DFETCHCONTENT_FULLY_DISCONNECTED=ON")
-          else
-            echo "Shared FetchContent cache is not seeded; retaining network fallback"
-          fi
+          : "${FETCHCONTENT_BASE_DIR:?runner image must set FETCHCONTENT_BASE_DIR}"
+          test "$FETCHCONTENT_BASE_DIR" = /deps
+          test -f /deps/.eshkol-fetchcontent-cache-ready
           cmake -S . -B "${{ matrix.build_dir }}" -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DESHKOL_REQUIRED_LLVM_MAJOR="${LLVM_MAJOR}" \
             -DLLVM_CONFIG_EXECUTABLE="$LLVM_CONFIG" \
+            -DFETCHCONTENT_BASE_DIR="$FETCHCONTENT_BASE_DIR" \
+            -DFETCHCONTENT_FULLY_DISCONNECTED=ON \
             -DESHKOL_XLA_ENABLED=${{ matrix.xla_enabled }} \
             -DESHKOL_GPU_ENABLED=${{ matrix.gpu_enabled }} \
-            -DESHKOL_REQUIRE_GPU_BACKEND=${{ matrix.gpu_enabled }} \
-            "${fetchcontent_args[@]}"
+            -DESHKOL_REQUIRE_GPU_BACKEND=${{ matrix.gpu_enabled }}
 
       # Same guard ci.yml applies to its CUDA lanes: reject a build graph that
       # quietly picked up gpu_memory_stub.cpp instead of the real kernels.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,10 @@ on:
     # llvm-sdk-cache-keepalive runs on it.
     - cron: '0 6 * * 1'
 
+permissions:
+  contents: read
+  id-token: none
+
 concurrency:
   # One group per pull request, or per branch for the push runs. Keying a PR
   # run on its NUMBER rather than on `github.ref` keeps the group stable across
@@ -168,6 +172,7 @@ jobs:
     name: changes
     if: github.event_name != 'schedule'
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     # Scoped to this job only; the rest of the workflow keeps the repository
     # default. `pull-requests: read` is what lets the API strategy below work.
     permissions:
@@ -308,6 +313,7 @@ jobs:
     name: mesh-gate-advisory (advisory, no-op)
     if: github.event_name != 'schedule'
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     continue-on-error: true
     steps:
       - name: Report mesh verdict (placeholder)
@@ -341,6 +347,7 @@ jobs:
     name: surface-manifest
     if: github.event_name != 'schedule'
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: Manifest matches the source-extracted surface
@@ -443,6 +450,7 @@ jobs:
     name: assurance-gates
     if: github.event_name != 'schedule'
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - name: Install PyYAML
@@ -1106,6 +1114,7 @@ jobs:
     needs: changes
     if: github.event_name != 'schedule' && needs.changes.outputs.docs_only == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     strategy:
       matrix:
         name:
@@ -1132,6 +1141,7 @@ jobs:
     needs: changes
     if: github.event_name != 'schedule' && needs.changes.outputs.docs_only == 'false'
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -1574,6 +1584,7 @@ jobs:
     needs: changes
     if: github.event_name != 'schedule' && needs.changes.outputs.docs_only == 'false'
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     continue-on-error: true
     strategy:
       fail-fast: false

--- a/docs/platform/README.md
+++ b/docs/platform/README.md
@@ -81,6 +81,8 @@ Use the remaining docs as operational references while implementation proceeds.
   - contract between `eshkol` and `eshkol-kernel`
 - [DECISIONS.md](DECISIONS.md)
   - append-only architecture and governance decision log
+- [SELF_HOSTED_RUNNERS.md](SELF_HOSTED_RUNNERS.md)
+  - safe ephemeral container runners, cache setup, and operator security checklist
 
 ## Current Status
 

--- a/docs/platform/SELF_HOSTED_RUNNERS.md
+++ b/docs/platform/SELF_HOSTED_RUNNERS.md
@@ -1,7 +1,8 @@
 # Self-hosted runners (the mesh)
 
-How to attach the maintainer's own machines to this repository as GitHub Actions
-runners, what each label means, and what changes once a runner is online.
+How to attach the maintainer's own machines to this repository as safe, ephemeral
+GitHub Actions runners, what each label means, and what changes once a runner is
+online.
 
 Everything here is something **only the repository owner can do** — registering a
 runner requires a registration token, which requires repo-admin rights. Nothing in
@@ -43,19 +44,21 @@ removed: `self-hosted`, an OS label (`Linux` / `macOS` / `Windows`), and an
 architecture label (`X64` / `ARM64` / `ARM`). Label matching is case-insensitive,
 which is why the workflows spell them lowercase.
 
-On top of those, this repository defines exactly four custom labels. Keep the set
+On top of those, this repository defines exactly five custom labels. Keep the set
 small: a label is a contract a lane relies on, and an unmet contract is a lane that
 either queues forever or lies.
 
 | label | meaning — assign it only if this is true | consumed by |
 |---|---|---|
 | `eshkol` | This runner is provisioned for **this repository's** build: LLVM 21, cmake, ninja, python3, and (Linux) `ld.lld`. Every mesh lane requires it. | `ci-mesh.yml` (all lanes), `mesh-preflight`'s online-runner probe |
+| `linux-mesh` | The runner is the pinned Ubuntu CI image launched by `launch_ephemeral_runners.sh`; it is not a persistent host runner. | `ci-mesh.yml`'s containerized Linux lane and `mesh-preflight` |
 | `gpu` | The host has a **real, addressable GPU device** — not merely a GPU toolchain. `nvidia-smi` lists a device, or the host is Apple Silicon with a working Metal device. | `gpu-execution-gate.yml` (`runs-on: [self-hosted, gpu]`) |
 | `cuda` | The host has a CUDA device *and* `nvcc` on `PATH`. Implies `gpu`; assign both. | `mesh-linux-x64-cuda-exec` |
 | `metal` | Apple Silicon host with a working Metal device. Implies `gpu`; assign both. Reserved for a future Metal execution lane. | (none yet) |
 
-So a full label set looks like `--labels eshkol` for a plain build node, or
-`--labels eshkol,gpu,cuda` for the CUDA execution node.
+The supplied launcher registers `eshkol,linux-mesh`. GPU labels are intentionally
+not added by that launcher: a GPU execution image needs a separate device-aware
+deployment and must not be implied by a CPU-only container.
 
 **Do not** assign `gpu` to a host that only has the CUDA *toolkit* installed. That
 is precisely the failure the GPU execution gate exists to expose, and a mislabelled
@@ -80,143 +83,122 @@ this machine. That volatility is the reason for §6.
 
 ---
 
-## 4. Provisioning a node
+## 4. Provisioning the container runner
 
-Do this **before** registering the runner. The mesh lanes deliberately do not
-install anything: CI has no business mutating a machine you own, and self-installing
-would require handing the runner passwordless `sudo`.
+The host only runs Docker and the launcher. The compiler toolchain, Python gate
+dependencies, pinned Actions runner, and pinned Emscripten SDK are inside
+`scripts/mesh/runner/Dockerfile`. The image uses a non-root `runner` account and
+contains no SSH client or cloud credentials.
 
-### Linux (Debian / Ubuntu)
-
-```bash
-# LLVM 21 from apt.llvm.org (adjust the distro codename)
-wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-21 main" \
-  | sudo tee /etc/apt/sources.list.d/llvm.list
-sudo apt-get update
-sudo apt-get install -y \
-  cmake ninja-build git python3 pkg-config \
-  llvm-21 llvm-21-dev lld-21 \
-  libreadline-dev libssl-dev libncurses-dev \
-  libpcre2-dev libsqlite3-dev libpng-dev libjpeg-dev libwebp-dev
-```
-
-`-fuse-ld=lld` looks for an unversioned `ld.lld`. `ci-mesh.yml` shims it into the
-runner's own `PATH` rather than symlinking into `/usr/bin` with sudo, so nothing
-further is needed — but a system-wide `sudo ln -sf /usr/bin/ld.lld-21 /usr/bin/ld.lld`
-is harmless if you prefer it.
-
-For a `cuda` node, additionally confirm **both** of these answer:
+Build and inspect it from a checkout:
 
 ```bash
-nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader
-nvcc --version
+docker build --tag eshkol-ci-runner:local scripts/mesh/runner
+docker run --rm --entrypoint /usr/local/bin/eshkol-toolchain-self-check \
+  eshkol-ci-runner:local
 ```
 
-### macOS
+Seed the shared FetchContent cache on the host before starting jobs. The seed
+script uses the lane's `_deps` area, and the launcher exposes it read-only as
+`/deps`; the workflow sets `-DFETCHCONTENT_BASE_DIR=/deps` and refuses to run
+without the cache marker.
 
 ```bash
-brew install llvm@21 cmake ninja readline pcre2 sqlite
+scripts/mesh/seed_fetchcontent_cache.sh
 ```
 
-### Verify the toolchain the way CI will
+The image is Linux x64. It registers only the `eshkol,linux-mesh` capability
+labels, so it cannot accidentally claim an ARM, macOS, or GPU lane.
+
+## 5. Registering ephemeral containers
+
+### 5.1 Create the registration credential
+
+Create a fine-grained personal access token at **Profile picture → Settings →
+Developer settings → Fine-grained personal access tokens → Generate new token**.
+Choose only this repository, grant **Administration: Read and write**, and set the
+expiration to **90 days**. This is the long-lived credential used only to mint
+one-shot runner registration tokens; it is not placed in the image or workflow.
+
+### 5.2 Store the credential and configure the launcher
+
+Use a host-only file with mode `600`, and a separate mode-`600` container
+environment file copied from `scripts/mesh/runner/runner.env.example`:
 
 ```bash
-git clone https://github.com/tsotchke/eshkol && cd eshkol
-cmake -S . -B build-check -G Ninja \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DESHKOL_REQUIRED_LLVM_MAJOR=21 \
-  -DLLVM_CONFIG_EXECUTABLE="$(command -v llvm-config-21 || echo /opt/homebrew/opt/llvm@21/bin/llvm-config)"
-cmake --build build-check --parallel
-./scripts/run_all_tests.sh
+export ESHKOL_RUNNER_TOKEN_FILE="$HOME/.config/eshkol/runner-token"
+export ESHKOL_RUNNER_ENV_FILE="$HOME/.config/eshkol/runner-container.env"
+export ESHKOL_FETCHCONTENT_CACHE="$HOME/lanes/_deps"
+export ESHKOL_RUNNER_REPOSITORY='OWNER/REPOSITORY'
+export ESHKOL_RUNNER_URL='https://github.com/OWNER/REPOSITORY'
+export ESHKOL_RUNNER_API_URL='https://api.github.com'
+export ESHKOL_RUNNER_IMAGE='eshkol-ci-runner:local'
+export ESHKOL_RUNNER_PREFIX='eshkol-mesh'
+export ESHKOL_RUNNER_LOG_FILE="$HOME/.local/state/eshkol/runner.log"
+
+install -D -m 600 /dev/null "$ESHKOL_RUNNER_TOKEN_FILE"
+IFS= read -r -s RUNNER_PAT
+printf '%s' "$RUNNER_PAT" > "$ESHKOL_RUNNER_TOKEN_FILE"
+unset RUNNER_PAT
+install -D -m 600 scripts/mesh/runner/runner.env.example "$ESHKOL_RUNNER_ENV_FILE"
 ```
 
-If that passes by hand, the mesh lane will pass. If it does not, fix it here — a
-runner registered against a broken toolchain produces red lanes that look like code
-regressions.
-
----
-
-## 5. Registering the runner
-
-### 5.1 Get a registration token
-
-Registration tokens are **single-use and expire in one hour**. Get a fresh one per
-node.
-
-- Web: **Settings → Actions → Runners → New self-hosted runner**, and copy the
-  token out of the `./config.sh` line the page shows.
-- CLI (needs repo-admin scope):
-  ```bash
-  gh api -X POST repos/tsotchke/eshkol/actions/runners/registration-token --jq .token
-  ```
-
-### 5.2 Install and configure
-
-Pick a directory that is **not** inside a checkout of this repo and has room for
-the build trees (25 GiB minimum, 30 GiB for the CUDA lane).
+For the user service, put the same non-secret launcher settings in its host-only
+environment file (including the absolute paths selected above):
 
 ```bash
-mkdir -p ~/actions-runner && cd ~/actions-runner
-
-# Linux x64 — swap the asset for linux-arm64 / osx-arm64 / win-x64 as needed.
-# Check https://github.com/actions/runner/releases for the current version.
-RUNNER_VERSION=2.330.0
-curl -o runner.tar.gz -L \
-  "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
-tar xzf runner.tar.gz && rm runner.tar.gz
-
-./config.sh \
-  --url https://github.com/tsotchke/eshkol \
-  --token <REGISTRATION_TOKEN> \
-  --labels eshkol,gpu,cuda \
-  --work _work \
-  --unattended \
-  --replace
+export ESHKOL_RUNNER_LAUNCHER_ENV="$HOME/.config/eshkol/runner-launcher.env"
+install -D -m 600 /dev/null "$ESHKOL_RUNNER_LAUNCHER_ENV"
+{
+  printf '%s\n' "ESHKOL_RUNNER_TOKEN_FILE=$ESHKOL_RUNNER_TOKEN_FILE"
+  printf '%s\n' "ESHKOL_RUNNER_ENV_FILE=$ESHKOL_RUNNER_ENV_FILE"
+  printf '%s\n' "ESHKOL_FETCHCONTENT_CACHE=$ESHKOL_FETCHCONTENT_CACHE"
+  printf '%s\n' "ESHKOL_RUNNER_REPOSITORY=$ESHKOL_RUNNER_REPOSITORY"
+  printf '%s\n' "ESHKOL_RUNNER_URL=$ESHKOL_RUNNER_URL"
+  printf '%s\n' "ESHKOL_RUNNER_API_URL=$ESHKOL_RUNNER_API_URL"
+  printf '%s\n' "ESHKOL_RUNNER_IMAGE=$ESHKOL_RUNNER_IMAGE"
+  printf '%s\n' "ESHKOL_RUNNER_PREFIX=$ESHKOL_RUNNER_PREFIX"
+  printf '%s\n' "ESHKOL_RUNNER_LOG_FILE=$ESHKOL_RUNNER_LOG_FILE"
+} > "$ESHKOL_RUNNER_LAUNCHER_ENV"
+chmod 600 "$ESHKOL_RUNNER_LAUNCHER_ENV"
 ```
 
-- `--name` — use the mesh node name. It is how you will tell runners apart in the
-  Settings UI and in `gh api .../actions/runners`.
-- `--labels` — from §2. Custom labels only; `self-hosted`, the OS and the arch are
-  added for you.
-- `--replace` — makes re-registering the same node idempotent.
-- `--unattended` — no interactive prompts.
+The launcher reads the credential only on the host, uses it to mint a fresh
+registration token for each slot, and passes that short-lived token only as the
+`--token` argument to `config.sh` at container start. It never mounts the
+credential file.
 
-macOS uses the identical `./config.sh`; Windows uses `./config.cmd` with the same
-flags.
+### 5.3 Start and keep the launcher alive
 
-### 5.3 Install as a service
-
-A runner started from a shell dies with the shell. Install it as a service so it
-survives reboots:
+Start one or more slots from the checkout:
 
 ```bash
-# Linux (systemd)
-sudo ./svc.sh install
-sudo ./svc.sh start
-sudo ./svc.sh status
-
-# macOS (launchd) — no sudo
-./svc.sh install
-./svc.sh start
-./svc.sh status
+scripts/mesh/runner/launch_ephemeral_runners.sh N
 ```
 
-On Windows, `./config.cmd` offers to install the service during configuration;
-answer yes.
+Each slot uses `--ephemeral`, `--rm`, a read-only image root, resource caps, no
+privileges or Docker socket, the default Docker network, a read-only `/deps` bind,
+and a per-slot `/work` volume. The volume is removed whenever that container
+exits. The default cap is 16 CPUs and 32 GiB of memory per slot; operators may
+lower either cap with `ESHKOL_RUNNER_CPUS` and `ESHKOL_RUNNER_MEMORY`. The launcher
+prints the exact systemd --user commands for restart-on-login:
 
-> `nix-shell nix/jetson/shell.nix` or it will have no CUDA device. Either wrap the
+```bash
+install -D -m 600 scripts/mesh/runner/eshkol-mesh-runner.service \
+  "$HOME/.config/systemd/user/eshkol-mesh-runner.service"
+systemctl --user daemon-reload
+systemctl --user enable --now eshkol-mesh-runner.service
+```
+
+The service reads the launcher variables from
+`$HOME/.config/eshkol/runner-launcher.env`; keep that file host-only and do not
+put credentials other than the token-file path in it.
 
 ### 5.4 Turn the mesh lanes on
 
-`ci-mesh.yml` ships **off**. After at least one runner is online:
-
-Before enabling lanes, seed the shared FetchContent source cache on each Linux
-runner with `scripts/mesh/seed_fetchcontent_cache.sh`. The script populates
-`$HOME/lanes/_deps`; subsequent lane configurations use
-`-DFETCHCONTENT_BASE_DIR="$HOME/lanes/_deps"` and
-`-DFETCHCONTENT_FULLY_DISCONNECTED=ON` when the cache marker is present. If
-the marker is absent, CI retains its normal network-fetch fallback.
+`ci-mesh.yml` ships **off**. After at least one runner is online, confirm the
+container self-check passed, the cache marker exists, and the runner list shows
+only ephemeral containers carrying both `eshkol` and `linux-mesh`.
 
 ```bash
 gh variable set ESHKOL_MESH_CI --repo tsotchke/eshkol --body on
@@ -259,31 +241,67 @@ what happens to open PRs when it is not.
 
 ## 7. Security
 
-A self-hosted runner executes whatever a workflow tells it to, on a machine you own,
-on your network, **with a filesystem that persists between jobs**. On a public
-repository that is a real exposure: a pull request from a fork can modify the very
-workflow that tests it, so a fork PR reaching a self-hosted runner is arbitrary code
-execution on your hardware, and anything it leaves on disk is visible to the next
-job.
+An untrusted pull request can modify the workflow that tests it. If that workflow
+reaches a self-hosted runner, it has arbitrary code execution inside the runner's
+security boundary. The assets at risk are the host filesystem, Docker control,
+registration credentials, network access, and data left by an earlier job.
 
-Controls, in order of load-bearing-ness:
+Controls, in order of importance:
 
-1. **Fork PRs never reach the mesh.** Every job in `ci-mesh.yml` carries
-   `if: github.event.pull_request.head.repo.full_name == github.repository`
-   (via the `mesh-preflight` gate that all lanes depend on). This is implemented and
-   is the control that actually matters — it does not depend on anyone remembering a
-   setting.
-2. **Require approval for all outside collaborators.** Settings → Actions → General →
-   *Fork pull request workflows from outside collaborators*. GitHub's default is
-   "require approval for first-time contributors", which still lets a contributor's
-   *second* PR run without review. Set it to **all outside collaborators**.
-3. **Never put secrets on a mesh lane.** None of the mesh lanes consume repository
-   secrets, and none should; a persistent filesystem plus a long-lived machine is a
-   poor place for them.
-4. **Ephemeral-ish workspace.** Each lane's final step removes its build tree, and
-   the disk-budget step fails early rather than filling the node. For stronger
-   isolation, register with `--ephemeral` so the runner deregisters after one job and
-   is re-registered by a supervising script — at the cost of losing warm build state.
+1. **Fork PRs never reach the mesh.** The hosted `mesh-preflight` gate rejects fork
+   pull requests before any self-hosted job can be dispatched. Every self-hosted job
+   also checks the container markers before checkout.
+2. **Require approval for all outside collaborators.** In the repository UI, go to
+   **Settings → Actions → General**. Under **Approval for running fork pull request
+   workflows from contributors**, select **Require approval for all external
+   contributors**, then click **Save**. Review proposed workflow changes before
+   approving a fork workflow.
+3. **Ephemeral containers and no host mounts.** The launcher uses `--rm`, a read-only
+   root, dropped capabilities, no privileged mode, no Docker socket, resource caps,
+   the default network, and only a read-only `/deps` cache plus a per-slot `/work`
+   volume. The work volume is removed after every container exit.
+4. **Least-privilege registration credential.** The token file is host-only, mode
+   `600`, and never mounted into the container. The launcher uses it only to mint a
+   one-shot registration token and redacts that token from its log.
+5. **No secrets on self-hosted jobs.** No self-hosted job references repository
+   secrets. Workflow permissions default to `contents: read` and `id-token: none`.
+
+### Operator checklist
+
+Before enabling `ESHKOL_MESH_CI`:
+
+- Build the pinned image and run `eshkol-toolchain-self-check`.
+- Seed the shared FetchContent cache with
+  `scripts/mesh/seed_fetchcontent_cache.sh`; expose that directory read-only as
+  `/deps`.
+- Copy `runner.env.example` to a host-only runner environment file. Keep
+  `FETCHCONTENT_BASE_DIR=/deps`; do not put credentials in this file.
+- Create a fine-grained personal access token through **Profile picture → Settings
+  → Developer settings → Fine-grained personal access tokens → Generate new token**.
+  Select only this repository, **Administration: Read and write**, and a **90-day
+  expiration**.
+- Store only that token in `ESHKOL_RUNNER_TOKEN_FILE`, set its mode to `600`, and
+  confirm the file is not in the checkout or the cache.
+- Install the supplied user unit, start the launcher, and confirm the GitHub runner
+  list shows only ephemeral `eshkol,linux-mesh` runners.
+- Enable the repository variable `ESHKOL_MESH_CI=on` only after the checks above pass.
+
+The launcher prints the exact `systemctl --user` commands for persistent startup.
+Install `eshkol-mesh-runner.service` as a user unit before running those commands.
+
+### Credential rotation
+
+1. Turn `ESHKOL_MESH_CI` off and stop the user service. Existing ephemeral
+   containers finish or can be allowed to exit; do not reuse their registration
+   tokens.
+2. In **Settings → Actions → Runners**, remove any stale runner registrations.
+3. Revoke the old token from the account's fine-grained token settings.
+4. Create a replacement with the same repository-only scope, **Administration: Read
+   and write** permission, and a new 90-day expiration.
+5. Replace the contents of the mode-`600` token file without adding it to the
+   repository, run the image self-check, and restart the launcher.
+6. Confirm that a fresh job uses a new ephemeral registration, then set
+   `ESHKOL_MESH_CI=on` again.
 
 ---
 
@@ -315,19 +333,12 @@ gh variable set ESHKOL_MESH_CI --repo tsotchke/eshkol --body off
 ```
 
 ```bash
-# Full deregistration, on the node:
-cd ~/actions-runner
-sudo ./svc.sh stop && sudo ./svc.sh uninstall     # omit sudo on macOS
-./config.sh remove --token <REMOVAL_TOKEN>
+# Stop the supervisor. Each container is --rm and each runner is --ephemeral.
+systemctl --user disable --now eshkol-mesh-runner.service
 ```
 
-Get the removal token from **Settings → Actions → Runners → (runner) → Remove**, or:
-
-```bash
-gh api -X POST repos/tsotchke/eshkol/actions/runners/remove-token --jq .token
-```
-
-If the machine is gone and cannot be cleaned up locally, delete the registration
-from the Settings → Actions → Runners page instead. Because nothing in the required
-set depends on a mesh runner, removing one at any time is safe: the mesh lanes stop
-reporting and no PR is affected.
+If a container was interrupted before Docker could remove it, the launcher cleanup
+removes only the named containers and per-slot volumes it created. If a stale
+registration remains in **Settings → Actions → Runners**, remove that registration
+there. Because nothing in the required set depends on a mesh runner, stopping it is
+safe: the mesh lanes stop reporting and no PR is affected.

--- a/scripts/mesh/runner/Dockerfile
+++ b/scripts/mesh/runner/Dockerfile
@@ -1,0 +1,57 @@
+FROM ubuntu:26.04
+
+ARG RUNNER_VERSION=2.334.0
+ARG RUNNER_SHA256=048024cd2c848eb6f14d5646d56c13a4def2ae7ee3ad12122bee960c56f3d271
+ARG EMSDK_VERSION=4.0.22
+ARG EMSDK_REF=15915cad554b707837024dc2758b6a1c5b94b036
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends --yes \
+        ca-certificates clang-21 cmake curl g++ gcc git jq lld-21 \
+        libblas-dev libicu-dev libjpeg-dev libncurses-dev libopenblas-dev libpcre2-dev \
+        libpng-dev libreadline-dev libsqlite3-dev libssl-dev libwebp-dev libxml2-dev \
+        libzstd-dev llvm-21 llvm-21-dev ninja-build nodejs pkg-config python3 \
+        python3-numpy python3-venv tar unzip wget xz-utils zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /usr/bin/ld.lld-21 /usr/local/bin/ld.lld \
+    && ln -s /usr/lib/llvm-21/bin/llvm-config /usr/local/bin/llvm-config
+
+RUN python3 -m venv --system-site-packages /opt/venv \
+    && /opt/venv/bin/python -m pip install --no-cache-dir --disable-pip-version-check \
+        'PyYAML==6.0.2'
+
+RUN mkdir -p /runner /runner-image \
+    && curl --fail --location --retry 3 --output /runner-download.tar.gz \
+        "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" \
+    && echo "${RUNNER_SHA256}  /runner-download.tar.gz" | sha256sum --check --strict \
+    && tar --extract --gzip --file /runner-download.tar.gz --directory /runner-image \
+    && cp --archive /runner-image/. /runner/ \
+    && rm --force /runner-download.tar.gz \
+    && /runner-image/bin/installdependencies.sh \
+    && git clone --depth 1 https://github.com/emscripten-core/emsdk.git /opt/emsdk \
+    && git -C /opt/emsdk fetch --depth 1 origin "${EMSDK_REF}" \
+    && git -C /opt/emsdk checkout --detach "${EMSDK_REF}" \
+    && /opt/emsdk/emsdk install "${EMSDK_VERSION}" \
+    && /opt/emsdk/emsdk activate "${EMSDK_VERSION}" \
+    && test -x /opt/emsdk/upstream/emscripten/emcc \
+    && test -x /opt/emsdk/upstream/emscripten/em++ \
+    && groupadd --gid 10001 runner \
+    && useradd --uid 10001 --gid 10001 --create-home --shell /bin/bash runner \
+    && mkdir -p /home/runner /work /deps \
+    && chown --recursive runner:runner /home/runner /runner /runner-image /work /opt/emsdk
+
+COPY --chmod=0755 runner-entrypoint.sh /usr/local/bin/runner-entrypoint
+COPY --chmod=0755 toolchain-self-check.sh /usr/local/bin/eshkol-toolchain-self-check
+
+ENV PATH=/opt/venv/bin:/opt/emsdk:/opt/emsdk/upstream/emscripten:/usr/lib/llvm-21/bin:/usr/local/bin:$PATH \
+    HOME=/home/runner \
+    ESHKOL_RUNNER_CONTAINER=1 \
+    ESHKOL_RUNNER_EPHEMERAL=1 \
+    FETCHCONTENT_BASE_DIR=/deps \
+    LLVM_CONFIG_EXECUTABLE=/usr/lib/llvm-21/bin/llvm-config
+
+WORKDIR /runner
+USER runner
+ENTRYPOINT ["/usr/local/bin/runner-entrypoint"]

--- a/scripts/mesh/runner/eshkol-mesh-runner.service
+++ b/scripts/mesh/runner/eshkol-mesh-runner.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Eshkol ephemeral container runner supervisor
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+WorkingDirectory=%h
+EnvironmentFile=%h/.config/eshkol/runner-launcher.env
+ExecStart=%h/eshkol/scripts/mesh/runner/launch_ephemeral_runners.sh 1
+Restart=always
+RestartSec=15
+NoNewPrivileges=true
+
+[Install]
+WantedBy=default.target

--- a/scripts/mesh/runner/launch_ephemeral_runners.sh
+++ b/scripts/mesh/runner/launch_ephemeral_runners.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+usage() {
+    echo "usage: $0 N" >&2
+    exit 64
+}
+
+is_safe_name() {
+    [[ "$1" =~ ^[A-Za-z0-9._-]+$ ]]
+}
+
+(( $# == 1 )) || usage
+slots="$1"
+[[ "$slots" =~ ^[1-9][0-9]*$ ]] || usage
+
+: "${ESHKOL_RUNNER_TOKEN_FILE:?ESHKOL_RUNNER_TOKEN_FILE must name the host-only token file}"
+: "${ESHKOL_RUNNER_REPOSITORY:?ESHKOL_RUNNER_REPOSITORY must be owner/repository}"
+: "${ESHKOL_RUNNER_URL:?ESHKOL_RUNNER_URL must be the repository web URL}"
+: "${ESHKOL_RUNNER_API_URL:?ESHKOL_RUNNER_API_URL must be the GitHub API base URL}"
+: "${ESHKOL_FETCHCONTENT_CACHE:?ESHKOL_FETCHCONTENT_CACHE must name the shared FetchContent cache directory}"
+: "${ESHKOL_RUNNER_ENV_FILE:?ESHKOL_RUNNER_ENV_FILE must name the host-only runner env file}"
+
+image="${ESHKOL_RUNNER_IMAGE:-eshkol-ci-runner:local}"
+prefix="${ESHKOL_RUNNER_PREFIX:-eshkol-mesh}"
+cpus="${ESHKOL_RUNNER_CPUS:-16}"
+memory="${ESHKOL_RUNNER_MEMORY:-32g}"
+pids_limit="${ESHKOL_RUNNER_PIDS_LIMIT:-4096}"
+log_file="${ESHKOL_RUNNER_LOG_FILE:-./eshkol-mesh-runners.log}"
+
+is_safe_name "$prefix" || { echo "error: ESHKOL_RUNNER_PREFIX is unsafe" >&2; exit 64; }
+[[ -f "$ESHKOL_RUNNER_TOKEN_FILE" && -r "$ESHKOL_RUNNER_TOKEN_FILE" ]] || {
+    echo "error: token file is not a readable regular file" >&2
+    exit 1
+}
+[[ -f "$ESHKOL_FETCHCONTENT_CACHE" ]] && {
+    echo "error: FetchContent cache must be a directory" >&2
+    exit 1
+}
+[[ -d "$ESHKOL_FETCHCONTENT_CACHE" ]] || { echo "error: FetchContent cache directory is missing" >&2; exit 1; }
+[[ -f "$ESHKOL_RUNNER_ENV_FILE" ]] || { echo "error: runner env file is missing" >&2; exit 1; }
+
+token_mode="$(stat -c '%a' "$ESHKOL_RUNNER_TOKEN_FILE" 2>/dev/null || stat -f '%Lp' "$ESHKOL_RUNNER_TOKEN_FILE")"
+[[ "$token_mode" == 600 ]] || {
+    echo "error: ESHKOL_RUNNER_TOKEN_FILE must have mode 600" >&2
+    exit 1
+}
+
+env_mode="$(stat -c '%a' "$ESHKOL_RUNNER_ENV_FILE" 2>/dev/null || stat -f '%Lp' "$ESHKOL_RUNNER_ENV_FILE")"
+[[ "$env_mode" == 600 ]] || {
+    echo "error: ESHKOL_RUNNER_ENV_FILE must have mode 600" >&2
+    exit 1
+}
+
+[[ "$ESHKOL_RUNNER_REPOSITORY" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || {
+    echo "error: ESHKOL_RUNNER_REPOSITORY must be owner/repository" >&2
+    exit 64
+}
+[[ "$ESHKOL_RUNNER_URL" == https://* ]] || {
+    echo "error: ESHKOL_RUNNER_URL must use https" >&2
+    exit 64
+}
+[[ "$ESHKOL_RUNNER_API_URL" == https://* ]] || {
+    echo "error: ESHKOL_RUNNER_API_URL must use https" >&2
+    exit 64
+}
+
+validate_runner_env() {
+    local line key found=0
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        [[ -z "$line" || "$line" == \#* ]] && continue
+        [[ "$line" == *=* ]] || {
+            echo "error: runner env file contains a line without KEY=VALUE" >&2
+            return 1
+        }
+        key="${line%%=*}"
+        [[ "$key" == FETCHCONTENT_BASE_DIR ]] || {
+            echo "error: runner env file may contain only FETCHCONTENT_BASE_DIR" >&2
+            return 1
+        }
+        [[ "$line" == FETCHCONTENT_BASE_DIR=/deps ]] || {
+            echo "error: runner env file must set FETCHCONTENT_BASE_DIR=/deps" >&2
+            return 1
+        }
+        found=1
+    done < "$ESHKOL_RUNNER_ENV_FILE"
+    (( found == 1 )) || {
+        echo "error: runner env file must set FETCHCONTENT_BASE_DIR=/deps" >&2
+        return 1
+    }
+}
+
+validate_runner_env || exit 1
+
+mkdir -p "$(dirname "$log_file")"
+touch "$log_file"
+chmod 600 "$log_file"
+
+log() {
+    printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" >> "$log_file"
+}
+
+redact_stream() {
+    local secret="$1" line
+    while IFS= read -r line; do
+        line="${line//"$secret"/[REDACTED]}"
+        printf '%s\n' "$line" >> "$log_file"
+    done
+}
+
+mint_token() {
+    local api_token response
+    api_token="$(< "$ESHKOL_RUNNER_TOKEN_FILE")"
+    [[ -n "$api_token" && "$api_token" != *$'\n'* ]] || {
+        echo "error: token file is empty or contains a newline" >&2
+        return 1
+    }
+    response="$(curl --fail --silent --show-error --location \
+        --connect-timeout 20 --max-time 60 --retry 3 --retry-all-errors \
+        --header 'Accept: application/vnd.github+json' \
+        --header 'X-GitHub-Api-Version: 2022-11-28' \
+        --header "Authorization: Bearer $api_token" \
+        --request POST \
+        "${ESHKOL_RUNNER_API_URL%/}/repos/${ESHKOL_RUNNER_REPOSITORY}/actions/runners/registration-token")"
+    jq -er '.token | select(type == "string" and length > 0)' <<< "$response"
+}
+
+ensure_no_stale_container() {
+    local container_name="$1"
+    if docker container inspect "$container_name" >/dev/null 2>&1; then
+        echo "error: Docker container $container_name already exists; refusing to remove an unknown container" >&2
+        exit 1
+    fi
+}
+
+run_slot() {
+    local slot="$1" container_name volume_name registration_token rc
+    container_name="${prefix}-${slot}"
+    volume_name="${prefix}-work-${slot}-$$"
+    ensure_no_stale_container "$container_name"
+
+    while :; do
+        registration_token="$(mint_token)" || {
+            log "slot=$slot token mint failed; retrying in 15s"
+            sleep 15
+            continue
+        }
+        docker volume create "$volume_name" >/dev/null
+
+        log "slot=$slot starting ephemeral container"
+        set +e
+        docker run --rm --init \
+            --cpus "$cpus" --memory "$memory" --pids-limit "$pids_limit" \
+            --network bridge \
+            --read-only --security-opt no-new-privileges:true --cap-drop ALL \
+            --tmpfs /tmp:rw,nosuid,nodev \
+            --tmpfs /run:rw,nosuid,nodev,mode=0755 \
+            --tmpfs /home/runner:rw,nosuid,nodev,uid=10001,gid=10001,mode=0700 \
+            --tmpfs /runner:rw,nosuid,nodev,exec,uid=10001,gid=10001,mode=0755 \
+            --mount "type=volume,source=$volume_name,target=/work" \
+            --mount "type=bind,source=$ESHKOL_FETCHCONTENT_CACHE,target=/deps,readonly" \
+            --env-file "$ESHKOL_RUNNER_ENV_FILE" \
+            --env ESHKOL_RUNNER_CONTAINER=1 \
+            --env ESHKOL_RUNNER_EPHEMERAL=1 \
+            --workdir /runner \
+            --name "$container_name" \
+            "$image" --url "$ESHKOL_RUNNER_URL" --token "$registration_token" --name "$container_name" 2>&1 \
+            | redact_stream "$registration_token"
+        rc="${PIPESTATUS[0]}"
+        set -e
+        docker volume rm "$volume_name" >/dev/null 2>&1 || true
+        log "slot=$slot container exit=$rc; requesting a fresh registration token"
+        sleep 2
+    done
+}
+
+worker_pids=()
+container_names=()
+volume_names=()
+cleanup() {
+    local pid container volume
+    trap - TERM INT EXIT
+    for container in "${container_names[@]}"; do
+        docker stop --time 10 "$container" >/dev/null 2>&1 || true
+    done
+    for pid in "${worker_pids[@]}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+    wait || true
+    for volume in "${volume_names[@]}"; do
+        docker volume rm "$volume" >/dev/null 2>&1 || true
+    done
+}
+trap cleanup TERM INT EXIT
+
+for ((slot = 1; slot <= slots; slot++)); do
+    container_names+=("${prefix}-${slot}")
+    volume_names+=("${prefix}-work-${slot}-$$")
+    run_slot "$slot" &
+    worker_pids+=("$!")
+done
+
+cat >&2 <<'EOF'
+Launcher is running. The token is read only on the host and redacted from the log.
+For restart-on-login, install the supplied user unit and run exactly:
+  systemctl --user daemon-reload
+  systemctl --user enable --now eshkol-mesh-runner.service
+EOF
+
+wait

--- a/scripts/mesh/runner/runner-entrypoint.sh
+++ b/scripts/mesh/runner/runner-entrypoint.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+    echo "usage: runner-entrypoint --url URL --token TOKEN --name NAME" >&2
+    exit 64
+}
+
+runner_url=""
+registration_token=""
+runner_name=""
+while (($#)); do
+    case "$1" in
+        --url)
+            (($# >= 2)) || usage
+            runner_url="$2"
+            shift 2
+            ;;
+        --token)
+            (($# >= 2)) || usage
+            registration_token="$2"
+            shift 2
+            ;;
+        --name)
+            (($# >= 2)) || usage
+            runner_name="$2"
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+[[ -n "$runner_url" && -n "$registration_token" && -n "$runner_name" ]] || usage
+[[ "$runner_name" =~ ^[A-Za-z0-9._-]+$ ]] || {
+    echo "error: runner name contains unsupported characters" >&2
+    exit 64
+}
+
+if [[ ! -x /runner/run.sh ]]; then
+    cp --recursive /runner-image/. /runner/
+fi
+
+cd /runner
+./config.sh \
+    --url "$runner_url" \
+    --token "$registration_token" \
+    --ephemeral \
+    --unattended \
+    --replace \
+    --name "$runner_name" \
+    --labels eshkol,linux-mesh \
+    --work /work
+
+exec ./run.sh

--- a/scripts/mesh/runner/runner.env.example
+++ b/scripts/mesh/runner/runner.env.example
@@ -1,0 +1,4 @@
+# Copy this file to a host-only environment file, set mode 600, and keep it
+# limited to this one non-secret container setting. The launcher rejects every
+# other key so an operator cannot accidentally pass host credentials to a job.
+FETCHCONTENT_BASE_DIR=/deps

--- a/scripts/mesh/runner/toolchain-self-check.sh
+++ b/scripts/mesh/runner/toolchain-self-check.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+echo "llvm-config: $(llvm-config --version)"
+echo "clang: $(clang-21 --version | head -n 1)"
+echo "lld: $(ld.lld --version | head -n 1)"
+echo "gcc: $(g++ --version | head -n 1)"
+echo "cmake: $(cmake --version | head -n 1)"
+echo "ninja: $(ninja --version)"
+echo "python: $(python3 --version)"
+echo "numpy: $(python3 -c 'import numpy; print(numpy.__version__)')"
+echo "jq: $(jq --version)"
+echo "emcc: $(emcc --version | head -n 1)"
+echo "node: $(node --version)"
+
+if command -v ssh >/dev/null 2>&1; then
+    echo "error: an SSH client is present in the CI image" >&2
+    exit 1
+fi
+
+[[ "${ESHKOL_RUNNER_CONTAINER:-}" == 1 ]] || {
+    echo "error: ESHKOL_RUNNER_CONTAINER is not set" >&2
+    exit 1
+}
+[[ "${ESHKOL_RUNNER_EPHEMERAL:-}" == 1 ]] || {
+    echo "error: ESHKOL_RUNNER_EPHEMERAL is not set" >&2
+    exit 1
+}
+echo "container marker: ESHKOL_RUNNER_CONTAINER=1"
+echo "ephemeral marker: ESHKOL_RUNNER_EPHEMERAL=1"


### PR DESCRIPTION
Safe self-hosted runner design for the mesh: a pinned Ubuntu 26.04 image (LLVM 21, Emscripten, runner tarball) running as a non-root user; a launcher that mints one-shot registration tokens from a host-only token file, redacts them from logs, and starts --rm containers with a read-only root, isolated /work, read-only /deps cache and resource limits; workflow permissions default to contents: read / id-token: none with per-job timeouts and concurrency; fork PRs never reach the mesh (hosted mesh-preflight gate). Runbook docs/platform/SELF_HOSTED_RUNNERS.md with an operator rotation checklist. The hosted ci.yml changes are permissions and timeouts only. No hosts, addresses or credentials are published.