### PR TITLE
fix(vm): exact quotient overflow rounding and apply 16-argument truncation (SW-107, SW-108)

### DIFF
--- a/.icc/silent-wrong-ledger.yaml
+++ b/.icc/silent-wrong-ledger.yaml
@@ -6884,3 +6884,30 @@ entries:
       correctness contract is value equality with the corresponding inexact
       coordinates. Exact scalar points use the exact Taylor tier where the
       carrier can preserve exact coefficients.
+  - id: SW-107
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "4b88413cbb19fe9f0d8db6d6b186f74007e58196 (post-fix working tree)"
+    title: "VM quotient rounds an exact near-INT64_MAX dividend through double"
+    repro: "tests/vm_parity/corpus/75_integer_boundary_quotient.esk"
+    observed: "VM printed -4611686018427387904 for (quotient 9223372036854775806 2), exited 0."
+    correct: "4611686018427387903, an exact integer"
+    cross_engine: "The native LLVM engine was correct; the VM was silently wrong."
+    fixed_by: "lib/backend/vm_native.c case 38 divides VAL_INT operands directly and handles INT64_MIN/-1 through bignum."
+    evidence: "The corpus case prints the same exact value on native and VM after the fix; the pre-fix VM run was wrong with exit 0."
+    caught_by: [engine-parity-threshold-gate, direct-measurement]
+    missed_by: [vm-parity-curated-corpus, icc-readiness]
+
+  - id: SW-108
+    bucket: SILENT-WRONG
+    status: closed
+    closed_at: "4b88413cbb19fe9f0d8db6d6b186f74007e58196 (post-fix working tree)"
+    title: "VM apply silently truncates proper argument lists at sixteen values"
+    repro: "tests/vm_parity/corpus/76_parallel_map_large_apply.esk"
+    observed: "VM exited 0 and returned 1240 instead of 332833500 for the 1000-element case."
+    correct: "apply passes the complete proper list and returns 332833500."
+    cross_engine: "The native LLVM engine was correct; the VM was silently wrong."
+    fixed_by: "lib/backend/vm_native.c case 70 unpacks until the VM stack is full and errors instead of truncating."
+    evidence: "The corpus case prints 1000 and 332833500 identically on native and VM after the fix; the pre-fix VM run truncated the result."
+    caught_by: [engine-parity-threshold-gate, direct-measurement]
+    missed_by: [vm-parity-curated-corpus, icc-readiness]

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -7688,6 +7688,23 @@ static void vm_dispatch_native(VM* vm, int fid) {
         vm_push(vm, INT_VAL(ia%ib)); break; }
     case 38: { Value b = vm_pop(vm); Value a = vm_pop(vm);
         if (vm_either_bignum(a,b)) { vm_bignum_arith(vm,a,b,'q'); break; }
+        /* Exact fixnums must stay in the integer domain.  Converting them
+         * through double first rounds values near INT64_MAX to 2^63; the
+         * implementation-defined conversion back to int64_t then turns a
+         * positive dividend into INT64_MIN.  That made quotient silently
+         * return -4611686018427387904 for
+         * (quotient 9223372036854775806 2). */
+        if (a.type == VAL_INT && b.type == VAL_INT) {
+            if (b.as.i == 0) { fprintf(stderr, "DIVIDE BY ZERO\n"); vm->error=1; break; }
+            if (a.as.i == INT64_MIN && b.as.i == -1) {
+                /* The exact quotient does not fit a fixnum; promote it to
+                 * the VM's arbitrary-precision integer representation. */
+                vm_bignum_arith(vm, a, b, 'q');
+                break;
+            }
+            vm_push(vm, INT_VAL(a.as.i / b.as.i));
+            break;
+        }
         int64_t ia=(int64_t)as_number(a), ib=(int64_t)as_number(b);
         if (ib==0){ fprintf(stderr, "DIVIDE BY ZERO\n"); vm->error=1; break; }
         vm_push(vm, INT_VAL(ia/ib)); break; }
@@ -7780,10 +7797,20 @@ static void vm_dispatch_native(VM* vm, int fid) {
         vm_push(vm, func);
         int argc = 0;
         Value cur = args_list;
-        while (cur.type == VAL_PAIR && argc < 16) {
+        /* `apply` has no language-level sixteen-argument limit.  The old
+         * fixed cap silently dropped the tail of a proper argument list, so
+         * (apply + (list ...)) returned a plausible partial sum with exit 0.
+         * Use the VM stack as the actual finite resource and fail loudly if
+         * the caller asks for more arguments than this invocation can hold. */
+        while (cur.type == VAL_PAIR && vm->sp < STACK_SIZE) {
             vm_push(vm, vm->heap.objects[cur.as.ptr]->cons.car);
             cur = vm->heap.objects[cur.as.ptr]->cons.cdr;
             argc++;
+        }
+        if (cur.type == VAL_PAIR) {
+            fprintf(stderr, "ERROR: apply: argument list exceeds VM stack capacity\n");
+            vm->error = 1;
+            break;
         }
         HeapObject* cl70 = vm->heap.objects[func.as.ptr];
         if (vm->frame_count >= MAX_FRAMES) { vm->error = 1; break; }

--- a/tests/vm_parity/corpus/75_integer_boundary_quotient.esk
+++ b/tests/vm_parity/corpus/75_integer_boundary_quotient.esk
@@ -1,0 +1,4 @@
+; Exact fixnum quotient must not round through double at the top of int64.
+; R7RS exact arithmetic requires the positive result to remain exact.
+(display (quotient 9223372036854775806 2))
+(newline)

--- a/tests/vm_parity/corpus/76_parallel_map_large_apply.esk
+++ b/tests/vm_parity/corpus/76_parallel_map_large_apply.esk
@@ -1,0 +1,14 @@
+; apply must pass every element of a proper list to its procedure.  This also
+; pins parallel-map's documented ordered-result contract at a size that uses
+; the VM pool path.
+(define (range n)
+  (let loop ((i 0) (acc '()))
+    (if (>= i n)
+        (reverse acc)
+        (loop (+ i 1) (cons i acc)))))
+
+(define squares (parallel-map (lambda (x) (* x x)) (range 1000)))
+(display (length squares))
+(newline)
+(display (apply + squares))
+(newline)


### PR DESCRIPTION
VM parity backlog round 2: the VM's exact quotient rounded at the i64 overflow boundary instead of promoting, and apply silently truncated argument lists beyond 16 entries; both fixed at the root in vm_native.c with parity corpus cases 75 and 76 and closed ledger entries SW-107/SW-108. vm-parity 215/215; engine_semantic_parity_threshold PASS.