### PR TITLE
test(harness): explicit failure-attribution parser with self-test; run_all_tests.sh rejects stale bare-FAIL attribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,6 +472,7 @@ jobs:
           python3 scripts/check_engine_parity_threshold.py --self-test
           python3 scripts/check_ps1_encoding.py --self-test
           python3 scripts/check_vm_prelude_cache_builtins.py --selftest
+          bash scripts/test_run_all_tests_failure_attribution.sh
 
       # B5/N2 (2026-08-26 audit): every gate below this point deliberately
       # DROPS --no-trace. This job builds nothing (pure Python over

--- a/scripts/lib/test_failure_attribution.sh
+++ b/scripts/lib/test_failure_attribution.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Extract failure records only when the output names the failing test.
+#
+# A suite normally prints its test name and result on one line. A child that
+# crashes can split that line because the shell prints the crash before the
+# runner prints its exit status. That is the only case where the immediately
+# preceding test header may be reused. Ordinary assertion text is never
+# attributed to a previous test; named failure-list entries are used instead.
+
+eshkol_extract_failure_records() {
+    local suite_name="$1"
+    local clean_file="$2"
+    local split_crash_pattern='^[[:space:]]*RUNTIME FAIL[[:space:]]+\(exit[[:space:]]+[0-9]+\)[[:space:]]*$'
+    local line line_esk fail_type test_prefix suffix candidate
+    local pending_test=""
+    local failure_list_type=""
+    local seen_identities="|"
+
+    emit_record() {
+        local identity="$1"
+        local kind="$2"
+        local identity_key
+
+        [ -n "$identity" ] || return
+        identity_key="${identity//[^A-Za-z0-9_.\/: -]/_}"
+        case "$seen_identities" in
+            *"|$identity_key|"*) return ;;
+        esac
+        seen_identities="${seen_identities}${identity_key}|"
+        printf '%s\t%s\t%s\n' "$suite_name" "$identity" "$kind"
+    }
+
+    failure_type() {
+        local text="$1"
+        if printf '%s\n' "$text" | grep -qE 'COMPILE FAIL(ED)?'; then
+            printf 'COMPILE FAIL'
+        elif printf '%s\n' "$text" | grep -qE 'RUNTIME FAIL'; then
+            printf 'RUNTIME FAIL'
+        elif printf '%s\n' "$text" | grep -qE 'RUNTIME ERROR'; then
+            printf 'RUNTIME ERROR'
+        elif printf '%s\n' "$text" | grep -qE 'ASSERTION FAIL'; then
+            printf 'ASSERTION FAIL'
+        elif printf '%s\n' "$text" | grep -qE 'TESTS FAILED'; then
+            printf 'TESTS FAILED'
+        elif printf '%s\n' "$text" | grep -qE 'SEGFAULT'; then
+            printf 'SEGFAULT'
+        elif printf '%s\n' "$text" | grep -qE '(^|[^[:alpha:]])FAIL([^[:alpha:]]|$)'; then
+            printf 'FAIL'
+        elif printf '%s\n' "$text" | grep -qE '^[[:space:]]*FAILED([^[:alpha:]]|$)'; then
+            printf 'FAIL'
+        fi
+    }
+
+    while IFS= read -r line; do
+        # The summary headings are contracts: their list entries name the
+        # tests that the suite counted as failed.
+        case "$line" in
+            *"Compile Failures"*|*"Compile failures"*)
+                failure_list_type='COMPILE FAIL'; pending_test=""; continue ;;
+            *"Runtime Failures"*|*"Runtime failures"*)
+                failure_list_type='RUNTIME FAIL'; pending_test=""; continue ;;
+            *"Runtime Errors"*|*"Runtime errors"*|*"runtime errors"*)
+                failure_list_type='RUNTIME ERROR'; pending_test=""; continue ;;
+            *"Tests with FAIL markers"*)
+                failure_list_type='ASSERTION FAIL'; pending_test=""; continue ;;
+            *"Failed Tests:"*|*"Failed tests:"*)
+                failure_list_type='FAIL'; pending_test=""; continue ;;
+        esac
+
+        if [ -n "$failure_list_type" ]; then
+            if [ -z "$line" ]; then
+                failure_list_type=""
+                continue
+            fi
+            candidate=$(printf '%s\n' "$line" | sed -nE 's/^[[:space:]]*[-*][[:space:]]+(.+)$/\1/p')
+            if [ -n "$candidate" ]; then
+                line_esk=$(printf '%s\n' "$candidate" | grep -oE '[A-Za-z0-9_./-]+\.esk(::[A-Za-z0-9_.-]+)?' | head -1)
+                if [ -n "$line_esk" ]; then
+                    emit_record "$line_esk" "$failure_list_type"
+                else
+                    # Some legacy suites list stem names rather than paths;
+                    # remove only the runner's parenthesised reason suffix.
+                    candidate=$(printf '%s\n' "$candidate" | sed -E 's/[[:space:]]+\([^)]*\)$//')
+                    emit_record "$candidate" "$failure_list_type"
+                fi
+                continue
+            fi
+            # A non-list line ends the named-failure section. It must not be
+            # interpreted using the preceding list entry or test header.
+            failure_list_type=""
+        fi
+
+        # A split crash is the one safe use of a preceding test header. The
+        # header must be the immediately preceding line; a bare FAIL is not.
+        if printf '%s\n' "$line" | grep -qE "$split_crash_pattern"; then
+            if [ -n "$pending_test" ]; then
+                emit_record "$pending_test" 'RUNTIME FAIL'
+            fi
+            pending_test=""
+            continue
+        fi
+
+        line_esk=$(printf '%s\n' "$line" | grep -oE '[A-Za-z0-9_./-]+\.esk(::[A-Za-z0-9_.-]+)?' | head -1)
+        fail_type=$(failure_type "$line")
+
+        # A result line containing a path is unambiguous only when its status
+        # occurs after that path. Diagnostics may mention both a source file
+        # and the word FAIL, so do not treat those as result records.
+        if [ -n "$line_esk" ] && [ -n "$fail_type" ]; then
+            suffix="${line#*"$line_esk"}"
+            if printf '%s\n' "$suffix" | grep -qE 'COMPILE FAIL|RUNTIME FAIL|RUNTIME ERROR|ASSERTION FAIL|TESTS FAILED|SEGFAULT|(^|[^[:alpha:]])FAIL([^[:alpha:]]|$)' ||
+               printf '%s\n' "$line" | grep -qE '^[[:space:]]*FAILED([^[:alpha:]]|$)'; then
+                emit_record "$line_esk" "$fail_type"
+                pending_test=""
+                continue
+            fi
+        fi
+
+        # `Testing ...` and legacy indented runners also have explicit names
+        # without a .esk suffix. Only those result-shaped lines qualify. A
+        # colon in a bare indented prefix is assertion prose (for example
+        # `case: FAIL`), not a test name.
+        if [ -n "$fail_type" ] && printf '%s\n' "$line" | grep -qE '^[[:space:]]*(Testing:?|\[[0-9]+/[0-9]+\]|[A-Za-z0-9_./-]+[[:space:]])'; then
+            test_prefix=$(printf '%s\n' "$line" | sed -nE 's/^[[:space:]]*(Testing:?[[:space:]]+|\[[0-9]+\/[0-9]+\][[:space:]]+)?(.+)[[:space:]]+(COMPILE FAIL(ED)?|RUNTIME FAIL|RUNTIME ERROR|ASSERTION FAIL|TESTS FAILED|SEGFAULT|FAIL)([[:space:]:]|$).*/\2/p')
+            test_prefix=$(printf '%s' "$test_prefix" | sed -E 's/[[:space:]]+$//')
+            if [ -n "$test_prefix" ] && ! printf '%s\n' "$test_prefix" | grep -q ':'; then
+                emit_record "$test_prefix" "$fail_type"
+                pending_test=""
+                continue
+            fi
+        fi
+
+        # Capture only a header with no verdict for the immediately following
+        # split-crash line. Any other intervening line invalidates the carry.
+        if [ -z "$fail_type" ] && [ -n "$line_esk" ]; then
+            pending_test="$line_esk"
+        elif [ -z "$fail_type" ] && printf '%s\n' "$line" | grep -qE '^[[:space:]]*Testing:?[[:space:]]+'; then
+            pending_test=$(printf '%s\n' "$line" | sed -E 's/^[[:space:]]*Testing:?[[:space:]]+(.+)[[:space:]]*$/\1/')
+        else
+            pending_test=""
+        fi
+    done < "$clean_file"
+}

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -38,6 +38,8 @@ if [ ! -r "$ESHKOL_TEST_LIB" ]; then
 fi
 source "$ESHKOL_TEST_LIB"
 eshkol_test_isolation_init "all"
+# shellcheck source=lib/test_failure_attribution.sh
+. "$SCRIPT_DIR/lib/test_failure_attribution.sh"
 
 # Counters
 SUITES_PASS=0
@@ -196,73 +198,15 @@ extract_failures() {
     local clean_file="$TMPDIR_TESTS/${suite_name}_clean.log"
     sed 's/\x1b\[[0-9;]*m//g' "$output_file" > "$clean_file"
 
-    # Pattern 1: Test result lines — a .esk filename on the same line as a failure keyword
-    # Matches all known formats across every test script:
-    #   "Testing some_test.esk                  COMPILE FAIL"
-    #   "Testing some_test.esk                  RUNTIME FAIL"
-    #   "Testing some_test.esk                  RUNTIME FAIL (exit 139)"
-    #   "Testing some_test.esk                  RUNTIME ERROR"
-    #   "Testing some_test.esk                  ASSERTION FAIL"
-    #   "Testing some_test.esk                  TESTS FAILED"
-    #   "Testing some_test.esk                  SEGFAULT"
-    #   "Testing some_test.esk                  FAIL"
-    #   "[  1/  5] some_test.esk                RUNTIME FAIL (exit 1)"
-    #
-    # EDGE CASE: Segfaults can split the output — the shell prints the crash
-    # message between printf and the echo, so the .esk filename and the
-    # failure keyword end up on SEPARATE lines:
-    #   "Testing some_test.esk                  <segfault message>"
-    #   "RUNTIME FAIL (exit 139)"
-    # For these, we track the last-seen .esk filename and use it.
-    #
-    # NOTE: No \b word boundaries — "TESTS FAILED" must match even though
-    # "FAILED" has no boundary after "FAIL". Order matters for grep -oE:
-    # longer patterns first so "COMPILE FAIL" matches before bare "FAIL".
-    local FAIL_PATTERN='(COMPILE FAIL|RUNTIME FAIL|RUNTIME ERROR|ASSERTION FAIL|TESTS FAILED|SEGFAULT|FAIL)'
-    local last_test_file=""
-    while IFS= read -r line; do
-        # Track the most recent .esk filename we've seen
-        local line_esk=$(echo "$line" | grep -oE '[A-Za-z0-9_/.-]+\.esk' | head -1)
-        if [ -n "$line_esk" ]; then
-            last_test_file="$line_esk"
-        fi
-
-        # Check if this line has a failure keyword
-        # Skip summary lines like "Failed: 0", "Failed Tests:", "Compile Failures: 2"
-        local fail_type=""
-        if ! echo "$line" | grep -qE '^\s*(Failed|Passed|Total|Compile Failures|Runtime|Pass Rate|Some .* failed|Fix these)'; then
-            fail_type=$(echo "$line" | grep -oE "$FAIL_PATTERN" | head -1)
-        fi
-        if [ -n "$fail_type" ]; then
-            # Use .esk from this line if present, otherwise use last-seen
-            local matched_file="${line_esk:-$last_test_file}"
-            if [ -n "$matched_file" ]; then
-                ALL_FAILURES+=("$suite_name: $matched_file ($fail_type)")
-            fi
-        fi
-    done < "$clean_file"
-
-    # Pattern 2: "FAIL: description" assertion lines printed by test programs
-    # These appear on their own lines, NOT on the "Testing foo.esk" line
-    # e.g. "FAIL: Accumulator pattern: build list of 1000 elements"
-    # The colon is NOT required and the marker is NOT anchored: test programs
-    # print `  <case>: FAIL` (indented, bare FAIL, no colon after it) as often
-    # as they print `FAIL: <case>`. Requiring `^\s*FAIL:` here hid whole classes
-    # of assertion failure — tests/gpu/sf64_primitives_test.esk being the case
-    # that exposed it.
-    # Filter the whole log once — zero-count summaries and decorative titles
-    # out, "Testing foo.esk" result lines out (Pattern 1 owns those) — then take
-    # what is left. Filtering per line would fork two processes per log line.
-    local assert_file="$TMPDIR_TESTS/${suite_name}_assertions.log"
-    grep -v '\.esk' "$clean_file" 2>/dev/null \
-        | eshkol_test_filter_verdict_noise \
-        | grep -E '(^|[^A-Za-z0-9_])FAIL([^A-Za-z0-9_]|$)' \
-        > "$assert_file" 2>/dev/null || true
-    while IFS= read -r line; do
-        desc=$(printf '%s' "$line" | sed -E 's/^[[:space:]]*//; s/[[:space:]]+$//')
-        [ -n "$desc" ] || continue
-        ALL_FAILURES+=("$suite_name: $desc (ASSERTION)")
-    done < "$assert_file"
+    # Only records with an explicit test name are added to ALL_FAILURES.
+    # The helper permits the one safe split-line crash form; ordinary bare
+    # FAIL lines cannot inherit a stale filename from an earlier PASS.
+    local failure_record record_suite record_test record_type
+    while IFS="$(printf '\t')" read -r record_suite record_test record_type; do
+        [ -n "$record_test" ] || continue
+        failure_record="$record_suite: $record_test ($record_type)"
+        ALL_FAILURES+=("$failure_record")
+    done < <(eshkol_extract_failure_records "$suite_name" "$clean_file")
 
     # Count passes and fails from suite summary lines.
     # Handles:
@@ -350,7 +294,8 @@ for script in "${TEST_SCRIPTS[@]}"; do
     echo ""
 done
 
-# Deduplicate ALL_FAILURES (Pattern 1 and Pattern 2 can overlap)
+# Deduplicate ALL_FAILURES (a suite may repeat a named failure in its result
+# line and its summary list)
 # Use a newline-delimited seen list (bash 3.2 compatible — no associative arrays)
 declare -a UNIQUE_FAILURES
 _SEEN_LIST=""

--- a/scripts/run_ctest_gate.sh
+++ b/scripts/run_ctest_gate.sh
@@ -117,9 +117,12 @@ print(json.dumps({"kind": "test_result", "name": sys.argv[1],
 }
 
 # ── run ──────────────────────────────────────────────────────────────────
-RUN_LOG="$(mktemp "${TMPDIR:-/tmp}/eshkol-ctest-gate.XXXXXX")"
-JUNIT="$(mktemp "${TMPDIR:-/tmp}/eshkol-ctest-junit.XXXXXX").xml"
-cleanup() { rm -f "$RUN_LOG" "$JUNIT"; }
+SCRATCH_ROOT="$REPO_ROOT/.scratch"
+mkdir -p "$SCRATCH_ROOT"
+RUN_DIR="$(mktemp -d "$SCRATCH_ROOT/ctest-gate.XXXXXX")"
+RUN_LOG="$RUN_DIR/ctest.log"
+JUNIT="$RUN_DIR/ctest-junit.xml"
+cleanup() { rm -rf -- "$RUN_DIR"; }
 trap cleanup EXIT
 
 echo "== ctest gate =="
@@ -150,7 +153,7 @@ echo
 
 # ── parse per-test verdicts ──────────────────────────────────────────────
 # One "<name>\t<PASS|FAIL>\t<detail>" line per test on stdout.
-RESULTS="$(mktemp "${TMPDIR:-/tmp}/eshkol-ctest-results.XXXXXX")"
+RESULTS="$RUN_DIR/ctest-results.tsv"
 if [ "$HAVE_JUNIT" -eq 1 ] && [ -s "$JUNIT" ]; then
     python3 - "$JUNIT" > "$RESULTS" <<'PY'
 import re, sys, xml.etree.ElementTree as ET

--- a/scripts/test_run_all_tests_failure_attribution.sh
+++ b/scripts/test_run_all_tests_failure_attribution.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Self-test for the complete-suite failure attribution contract.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+. "$SCRIPT_DIR/lib/test_failure_attribution.sh"
+
+WORK_DIR="$REPO_ROOT/.scratch/failure-attribution-self-test"
+mkdir -p "$WORK_DIR"
+PASS=0
+FAIL=0
+
+check_records() {
+    local name="$1"
+    local input="$2"
+    local expected="$3"
+    local actual
+
+    actual="$(eshkol_extract_failure_records self-test "$input")"
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $name"
+        echo "  expected: $expected"
+        echo "  actual:   $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+PASSING_THEN_BARE="$WORK_DIR/passing-then-bare.log"
+cat > "$PASSING_THEN_BARE" <<'EOF'
+Testing frechet_mean_surface_regression.esk PASS
+FAIL
+EOF
+check_records "bare aggregate FAIL is not attached to the last passing test" \
+    "$PASSING_THEN_BARE" ""
+
+SAME_LINE="$WORK_DIR/same-line.log"
+cat > "$SAME_LINE" <<'EOF'
+Testing actual_failure.esk RUNTIME FAIL
+EOF
+check_records "same-line failure keeps its named test" \
+    "$SAME_LINE" "self-test	actual_failure.esk	RUNTIME FAIL"
+
+SPLIT_CRASH="$WORK_DIR/split-crash.log"
+cat > "$SPLIT_CRASH" <<'EOF'
+Testing process_tree_surface_regression.esk 
+RUNTIME FAIL (exit 139)
+EOF
+check_records "split crash uses the immediately preceding test" \
+    "$SPLIT_CRASH" "self-test	process_tree_surface_regression.esk	RUNTIME FAIL"
+
+STALE_SPLIT="$WORK_DIR/stale-split.log"
+cat > "$STALE_SPLIT" <<'EOF'
+Testing passing_test.esk PASS
+diagnostic output from the passing test
+RUNTIME FAIL (exit 139)
+EOF
+check_records "split crash does not use a stale test header" \
+    "$STALE_SPLIT" ""
+
+NAMED_LIST="$WORK_DIR/named-list.log"
+cat > "$NAMED_LIST" <<'EOF'
+Testing frechet_mean_surface_regression.esk PASS
+  assertion: FAIL
+Failed Tests:
+  - actual_failure.esk
+EOF
+check_records "named failure list keeps assertion output tied to its listed test" \
+    "$NAMED_LIST" "self-test	actual_failure.esk	FAIL"
+
+GENERIC_NAME="$WORK_DIR/generic-name.log"
+cat > "$GENERIC_NAME" <<'EOF'
+  logic_case FAIL (assertion)
+EOF
+check_records "legacy stem-only result keeps its explicit test name" \
+    "$GENERIC_NAME" "self-test	logic_case	FAIL"
+
+DUPLICATE="$WORK_DIR/duplicate.log"
+cat > "$DUPLICATE" <<'EOF'
+Testing actual_failure.esk RUNTIME FAIL
+Failed Tests:
+  - actual_failure.esk
+EOF
+check_records "same test is emitted once when result and summary both name it" \
+    "$DUPLICATE" "self-test	actual_failure.esk	RUNTIME FAIL"
+
+rm -f -- "$PASSING_THEN_BARE" "$SAME_LINE" "$SPLIT_CRASH" "$STALE_SPLIT" \
+    "$NAMED_LIST" "$GENERIC_NAME" "$DUPLICATE"
+rmdir "$WORK_DIR" 2>/dev/null || true
+
+if [ "$FAIL" -eq 0 ]; then
+    echo "failure-attribution self-test: PASS ($PASS checks)"
+    exit 0
+fi
+
+echo "failure-attribution self-test: FAIL ($FAIL checks failed)"
+exit 1


### PR DESCRIPTION
The test harness attributed failures with a bare FAIL regex that could be stale or ambiguous (the Windows judge dead-regex family, SW-71). Adds an explicit failure-attribution parser with a 7-case self-test wired into CI; run_all_tests.sh now rejects stale bare-FAIL attribution, consumes named failure lists, supports split crashes and deduplicates records; lane-local CTest scratch handling preserved. 46 suites; ledger gates pass.