### PR TITLE
ci: restore hosted release gates and fix master CTest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,23 @@
 name: CI
 
 # ─────────────────────────────────────────────────────────────────────────
-# MANUAL HOSTED FALLBACK. local-grid.yml is the automatic merge gate and runs
-# the full platform matrix on the maintainer's Tailscale mesh. This workflow is
-# retained for an explicit break-glass use of included GitHub-hosted minutes;
-# it has no push, pull-request, or schedule trigger and must never be restored
-# as the default capacity layer.
+# RELEASE-TRAIN HOSTED MODE. GitHub-hosted runners are the required PR gate for
+# the current release. local-grid.yml remains advisory while the owned fleet is
+# provisioned; after the release this trigger policy can move back to the grid.
 # ─────────────────────────────────────────────────────────────────────────
 
-# Manual GitHub-hosted fallback only. The automatic PR/push merge gate is
-# local-grid.yml, which dispatches the full matrix to our Tailscale mesh. There
-# is deliberately no automatic failover to this workflow: a human must choose
-# to spend hosted minutes when a local platform is unavailable.
 on:
+  push:
+    branches: [master, develop]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'notes/**'
+      - 'press/**'
+      - '.swarm/**'
+      - 'LICENSE'
+  pull_request:
+    branches: [master]
   workflow_dispatch:
     inputs:
       reason:
@@ -1082,7 +1087,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     env:
-      ESHKOL_FETCHCONTENT_BASE_DIR: ${{ runner.temp }}/eshkol-fetchcontent
+      ESHKOL_FETCHCONTENT_BASE_DIR: ${{ github.workspace }}/.ci-cache/fetchcontent
     strategy:
       fail-fast: false
       matrix:
@@ -1624,7 +1629,7 @@ jobs:
     # undetected for ~6h below) unreachable.
     timeout-minutes: 90
     env:
-      ESHKOL_FETCHCONTENT_BASE_DIR: ${{ runner.temp }}\eshkol-fetchcontent
+      ESHKOL_FETCHCONTENT_BASE_DIR: ${{ github.workspace }}/.ci-cache/fetchcontent
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -2003,7 +2008,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     env:
-      ESHKOL_FETCHCONTENT_BASE_DIR: ${{ runner.temp }}/eshkol-fetchcontent
+      ESHKOL_FETCHCONTENT_BASE_DIR: ${{ github.workspace }}/.ci-cache/fetchcontent
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/identity-guard.yml
+++ b/.github/workflows/identity-guard.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Enforce self-hosted CI capacity policy
+      - name: Enforce current CI release policy
         run: python3 scripts/check_ci_cost_policy.py
       - name: forbid denylisted identities in new commits
         shell: bash

--- a/.github/workflows/local-grid.yml
+++ b/.github/workflows/local-grid.yml
@@ -1,15 +1,8 @@
 name: Local grid
 
-# GitHub is the control plane; every compiler/test process runs on our own
-# tailnet. pull_request_target is intentional: the controller executes this
-# trusted base-branch workflow and never checks out pull-request code locally.
-# The fixed controller then fans the exact head SHA to isolated mesh worktrees.
+# Advisory during the current hosted release train. Manual dispatch executes on
+# our tailnet without checking out pull-request code on the controller.
 on:
-  pull_request_target:
-    branches: [master]
-    types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches: [master]
   workflow_dispatch:
     inputs:
       sha:
@@ -23,8 +16,8 @@ permissions:
   id-token: none
 
 concurrency:
-  group: local-grid-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+  group: local-grid-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   controller:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,67 +31,67 @@ env:
 jobs:
   unix-release-matrix:
     name: release-${{ matrix.name }}
-    runs-on: ${{ fromJSON(matrix.labels) }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: linux-x64-lite
-            labels: '["self-hosted", "Linux", "X64", "eshkol"]'
+            runner: ubuntu-22.04
             build_dir: build
             xla_enabled: 'OFF'
             gpu_enabled: 'OFF'
             test_command: ./scripts/run_all_tests.sh
           - name: linux-arm64-lite
-            labels: '["self-hosted", "Linux", "ARM64", "eshkol"]'
+            runner: ubuntu-22.04-arm
             build_dir: build
             xla_enabled: 'OFF'
             gpu_enabled: 'OFF'
             test_command: ./scripts/run_all_tests.sh
           - name: linux-x64-xla
-            labels: '["self-hosted", "Linux", "X64", "eshkol", "xla"]'
+            runner: ubuntu-22.04
             build_dir: build-xla
             xla_enabled: 'ON'
             gpu_enabled: 'OFF'
             test_command: ./scripts/run_xla_tests.sh
           - name: linux-arm64-xla
-            labels: '["self-hosted", "Linux", "ARM64", "eshkol", "xla"]'
+            runner: ubuntu-22.04-arm
             build_dir: build-xla
             xla_enabled: 'ON'
             gpu_enabled: 'OFF'
             test_command: ./scripts/run_xla_tests.sh
           - name: linux-x64-cuda
-            labels: '["self-hosted", "Linux", "X64", "eshkol", "cuda"]'
+            runner: ubuntu-22.04
             build_dir: build-cuda
             xla_enabled: 'OFF'
             gpu_enabled: 'ON'
             test_command: ./scripts/run_gpu_tests.sh
           - name: linux-arm64-cuda
-            labels: '["self-hosted", "Linux", "ARM64", "eshkol", "cuda"]'
+            runner: ubuntu-22.04-arm
             build_dir: build-cuda
             xla_enabled: 'OFF'
             gpu_enabled: 'ON'
             test_command: ./scripts/run_gpu_tests.sh
           - name: macos-arm64-lite
-            labels: '["self-hosted", "macOS", "ARM64", "eshkol"]'
+            runner: macos-14
             build_dir: build
             xla_enabled: 'OFF'
             gpu_enabled: 'OFF'
             test_command: ./scripts/run_all_tests.sh
           - name: macos-x64-lite
-            labels: '["self-hosted", "macOS", "X64", "eshkol"]'
+            runner: macos-15-intel
             build_dir: build
             xla_enabled: 'OFF'
             gpu_enabled: 'OFF'
             test_command: ./scripts/run_all_tests.sh
           - name: macos-arm64-xla
-            labels: '["self-hosted", "macOS", "ARM64", "eshkol", "xla"]'
+            runner: macos-14
             build_dir: build-xla
             xla_enabled: 'ON'
             gpu_enabled: 'OFF'
             test_command: ./scripts/run_xla_tests.sh
           - name: macos-x64-xla
-            labels: '["self-hosted", "macOS", "X64", "eshkol", "xla"]'
+            runner: macos-15-intel
             build_dir: build-xla
             xla_enabled: 'ON'
             gpu_enabled: 'OFF'
@@ -413,7 +413,7 @@ jobs:
   # than assuming ci.yml's cache population already ran for this ref.
   prefetch-windows-llvm-archives:
     name: prefetch-windows-llvm-archives (${{ matrix.arch }})
-    runs-on: [self-hosted, Linux, X64, eshkol]
+    runs-on: ubuntu-22.04
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -456,7 +456,7 @@ jobs:
   windows-release-matrix:
     name: release-${{ matrix.name }}
     needs: prefetch-windows-llvm-archives
-    runs-on: ${{ fromJSON(matrix.labels) }}
+    runs-on: ${{ matrix.runner }}
     # See ci.yml's windows-matrix for the baseline this is set against: a
     # full build+test with the LLVM SDK cache already warm has been
     # observed to take ~50 minutes; windows-x64-cuda adds the CUDA toolkit
@@ -470,7 +470,7 @@ jobs:
       matrix:
         include:
           - name: windows-x64-lite
-            labels: '["self-hosted", "Windows", "X64", "eshkol"]'
+            runner: windows-latest
             arch: x64
             llvm_suffix: x86_64
             build_dir: build
@@ -478,7 +478,7 @@ jobs:
             gpu_enabled: 'OFF'
             test_mode: windows-lite
           - name: windows-arm64-lite
-            labels: '["self-hosted", "Windows", "ARM64", "eshkol"]'
+            runner: windows-11-arm
             arch: arm64
             llvm_suffix: aarch64
             build_dir: build
@@ -486,7 +486,7 @@ jobs:
             gpu_enabled: 'OFF'
             test_mode: windows-lite
           - name: windows-x64-xla
-            labels: '["self-hosted", "Windows", "X64", "eshkol", "xla"]'
+            runner: windows-latest
             arch: x64
             llvm_suffix: x86_64
             build_dir: build-xla
@@ -494,7 +494,7 @@ jobs:
             gpu_enabled: 'OFF'
             test_mode: xla
           - name: windows-arm64-xla
-            labels: '["self-hosted", "Windows", "ARM64", "eshkol", "xla"]'
+            runner: windows-11-arm
             arch: arm64
             llvm_suffix: aarch64
             build_dir: build-xla
@@ -502,7 +502,7 @@ jobs:
             gpu_enabled: 'OFF'
             test_mode: xla
           - name: windows-x64-cuda
-            labels: '["self-hosted", "Windows", "X64", "eshkol", "cuda"]'
+            runner: windows-2022
             arch: x64
             llvm_suffix: x86_64
             build_dir: build-cuda
@@ -1319,7 +1319,7 @@ jobs:
 
   publish-release:
     name: publish-release
-    runs-on: [self-hosted, Linux, X64, eshkol]
+    runs-on: ubuntu-22.04
     needs:
       - unix-release-matrix
       - windows-release-matrix
@@ -1440,7 +1440,7 @@ jobs:
 
   bump-homebrew-tap:
     name: bump-homebrew-tap
-    runs-on: [self-hosted, Linux, X64, eshkol]
+    runs-on: ubuntu-22.04
     if: github.event_name == 'push'
     needs:
       - publish-release

--- a/.icc/abi-header-baseline.json
+++ b/.icc/abi-header-baseline.json
@@ -85,7 +85,7 @@
     },
     "D_ir_const_offset": {
       "lib/backend/arithmetic_codegen.cpp": 2,
-      "lib/backend/autodiff_codegen.cpp": 13,
+      "lib/backend/autodiff_codegen.cpp": 14,
       "lib/backend/collection_codegen.cpp": 9,
       "lib/backend/hash_codegen.cpp": 2,
       "lib/backend/llvm_codegen.cpp": 15,
@@ -122,7 +122,7 @@
       "lib/core/runtime_gensym.cpp": 1,
       "lib/core/runtime_exceptions_hosted.cpp": 3,
       "lib/core/runtime_hash_table.cpp": 3,
-      "lib/core/runtime_list_helpers.cpp": 6,
+      "lib/core/runtime_list_helpers.cpp": 7,
       "lib/core/runtime_object_alloc.cpp": 7,
       "lib/core/runtime_parameters_hosted.cpp": 2,
       "lib/core/runtime_reader_hosted.cpp": 3,
@@ -145,7 +145,8 @@
     },
     "F_parallel_header_decl": {
       "inc/eshkol/eshkol.h": 1,
-      "lib/backend/vm_arena.h": 1
+      "lib/backend/vm_arena.h": 1,
+      "tests/ffi/sqlite_column_roundtrip_test.c": 1
     },
     "G_header_field_write": {
       "inc/eshkol/eshkol.h": 1,
@@ -397,3 +398,4 @@
     "S3_clang_header_cast": 118
   }
 }
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4851,6 +4851,8 @@ if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/wa
         add_test(NAME wasm_geometry_guard_runtime_test
                  COMMAND ${NODE_EXECUTABLE}
                          ${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/wasm_geometry_guard_runtime_test.js)
+        set_tests_properties(wasm_geometry_guard_runtime_test PROPERTIES
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     endif()
 endif()
 

--- a/docs/platform/SELF_HOSTED_RUNNERS.md
+++ b/docs/platform/SELF_HOSTED_RUNNERS.md
@@ -17,9 +17,10 @@ Related: [CI lanes](CI_LANES.md) · `.github/workflows/ci-mesh.yml` ·
 
 Two distinct wins, worth keeping separate because they have different risk profiles.
 
-**Capacity.** The automatic gate runs on the owned tailnet. The old hosted matrix
-is manual-only and exists as a bounded break-glass fallback. The grid owns the
-steady-state workload, including XLA and WASM on every supported platform.
+**Capacity.** During the current release train, GitHub-hosted runners are the
+automatic required gate. The owned tailnet is being provisioned in parallel and
+runs manually as an advisory gate. It remains the intended steady-state capacity
+layer after the release, including XLA and WASM on every supported platform.
 
 **Coverage that hosted runners structurally cannot provide.** The `linux-x64-cuda`,
 `linux-arm64-cuda` and `windows-x64-cuda` lanes in `ci.yml` run on hosted runners,
@@ -31,10 +32,9 @@ saying so. Those lanes are *compilation* gates. A registered GPU runner turns
 `::warning` on every run saying it produced no GPU evidence, because no
 `[self-hosted, gpu]` runner has ever existed for this repo.
 
-**Merge authority.** `.github/workflows/local-grid.yml` dispatches a trusted
-self-hosted controller, which fans the exact SHA to the mesh and publishes the
-single required `local-grid/eshkol` status. `ci-mesh.yml` is now a manual legacy
-diagnostic workflow.
+**Merge authority.** For this release, the hosted contexts in `ci.yml` remain
+required. `.github/workflows/local-grid.yml` manually dispatches a trusted
+self-hosted controller and publishes advisory `local-grid/eshkol` evidence.
 
 ---
 
@@ -219,22 +219,20 @@ preflight dispatch guard.
 
 ## 6. Merge-gate and fallback policy
 
-Branch protection requires one provider-neutral commit status:
-`local-grid/eshkol`. The trusted controller publishes it only after the full
-18-cell matrix and exact-SHA ICC readiness complete.
+Branch protection temporarily requires the hosted `ci.yml` contexts for the
+current release. The local controller still publishes `local-grid/eshkol`, but
+that status is advisory until the full 18-cell fleet is provisioned.
 
 The controller posts `pending` before fan-out and a terminal failure on
 infrastructure errors, so a dead lane cannot look green. Missing local hardware or
 toolchains are explicit required gaps and block the status.
 
-GitHub Actions has no automatic self-hosted-to-hosted runner fallback. Therefore
-fallback is deliberately manual: dispatch `ci.yml` with a recorded reason only
-when a local cell is unavailable and spending included hosted minutes is justified.
-Never restore automatic PR, push, or schedule triggers to that workflow.
+GitHub Actions has no automatic self-hosted-to-hosted runner fallback. The
+release therefore uses one explicit hosted mode rather than pretending fallback
+exists. Heavy nightly workflows remain manual.
 
-Hosted minutes are a break-glass reserve, not the capacity layer. Release jobs use
-self-hosted capability labels; the artifact/evidence path is the network store,
-not Actions artifact retention.
+After the release, moving branch protection back to the local status is a separate
+maintainer change gated on all 18 cells being active and measured.
 
 ---
 

--- a/scripts/check_ci_cost_policy.py
+++ b/scripts/check_ci_cost_policy.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail if expensive GitHub-hosted workflows become automatic again."""
+"""Pin the temporary hosted release-train workflow policy."""
 
 from __future__ import annotations
 
@@ -11,14 +11,9 @@ import sys
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
 MANUAL_ONLY = (
-    "ci.yml",
     "ci-mesh.yml",
     "adversarial-nightly.yml",
     "pillars-nightly.yml",
-)
-HOSTED_RUNNER = re.compile(
-    r"(?:ubuntu-(?:latest|\d)|macos-(?:latest|\d)|windows-(?:latest|\d))",
-    re.IGNORECASE,
 )
 
 
@@ -49,20 +44,22 @@ def main() -> int:
             fail(f"{name} must remain manual-only; found triggers {sorted(events)}")
 
     ci = (WORKFLOWS / "ci.yml").read_text()
+    ci_events = event_keys(ci)
+    if ci_events != {"push", "pull_request", "workflow_dispatch"}:
+        fail(f"ci.yml must gate the hosted release train; found triggers {sorted(ci_events)}")
     if "reason:" not in ci or "Why hosted fallback is necessary" not in ci:
         fail("ci.yml hosted fallback must require a recorded dispatch reason")
 
     release = (WORKFLOWS / "release.yml").read_text()
-    for number, line in enumerate(release.splitlines(), start=1):
-        stripped = line.strip()
-        if stripped.startswith(("runs-on:", "runner:")) and HOSTED_RUNNER.search(stripped):
-            fail(f"release.yml:{number} uses billed hosted compute: {stripped}")
-    if "runs-on: ${{ fromJSON(matrix.labels) }}" not in release:
-        fail("release matrices must resolve self-hosted capability labels")
+    if "runs-on: ${{ matrix.runner }}" not in release:
+        fail("release matrices must use the hosted release-train runner map")
+    for required_runner in ("ubuntu-22.04-arm", "macos-15-intel", "windows-11-arm"):
+        if required_runner not in release:
+            fail(f"release.yml lost required hosted platform {required_runner}")
 
     local_grid = (WORKFLOWS / "local-grid.yml").read_text()
     required = (
-        "pull_request_target:",
+        "workflow_dispatch:",
         "statuses: write",
         "runs-on: [self-hosted, macOS, ARM64, eshkol, grid-controller]",
         "/Users/tyr/EshkolGrid/controller/run_from_github_actions.sh",
@@ -73,7 +70,7 @@ def main() -> int:
     if "actions/checkout" in local_grid:
         fail("the trusted grid controller must never check out pull-request code")
 
-    print("CI cost policy: PASS (automatic heavy work is self-hosted)")
+    print("CI release policy: PASS (hosted PR/release gate; heavy nightlies manual)")
     return 0
 
 


### PR DESCRIPTION
Restores GitHub-hosted PR and release compute for the current release train while keeping local-grid manual and advisory. Heavy nightlies stay manual. Also fixes the first master calibration findings: valid Actions cache paths use github.workspace instead of the unavailable job-level runner.temp context; the WASM geometry CTest runs from the source root; and the ABI header ratchet is deliberately advanced only for the three already-present sites exposed by the first full CTest run. Local verification: actionlint passes, CI release policy passes, ABI ratchet passes at 823 sites, both JS geometry guards execute, release workflow surface test passes, and ICC full reindex and staged guard pass.