### PR TITLE
test(ffi): sqlite column round-trip test reads the object header through ESHKOL_GET_HEADER

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7613,6 +7613,8 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-agent-ffi AND
    EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/ffi/sqlite_column_roundtrip_test.c")
     add_executable(eshkol-agent-sqlite-column-roundtrip
         tests/ffi/sqlite_column_roundtrip_test.c)
+    target_include_directories(eshkol-agent-sqlite-column-roundtrip PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/inc")
     target_compile_definitions(eshkol-agent-sqlite-column-roundtrip PRIVATE
         ESHKOL_SQLITE_TEST_USE_RUNTIME=1)
     target_link_libraries(eshkol-agent-sqlite-column-roundtrip PRIVATE

--- a/tests/ffi/sqlite_column_roundtrip_test.c
+++ b/tests/ffi/sqlite_column_roundtrip_test.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <eshkol/eshkol.h>
 
 int64_t eshkol_sqlite_open(const char* path);
 void eshkol_sqlite_close(int64_t handle);
@@ -18,21 +19,14 @@ int64_t eshkol_sqlite_column_bytes(int64_t handle, int index);
 int eshkol_sqlite_column_text(int64_t handle, int index, char* buf, size_t size);
 int eshkol_sqlite_column_type(int64_t handle, int index);
 
-typedef struct {
-    uint8_t subtype;
-    uint8_t flags;
-    uint16_t ref_count;
-    uint32_t size;
-} EshkolStringHeader;
-
 /* Match the runtime's header-based length query for this standalone ABI test.
  * The CMake target uses the real runtime helper; the direct harness build
  * supplies this small equivalent so it can run without the full agent archive. */
 #ifndef ESHKOL_SQLITE_TEST_USE_RUNTIME
 int64_t eshkol_string_byte_length(const char* value) {
     if (!value) return 0;
-    const EshkolStringHeader* header =
-        (const EshkolStringHeader*)((const unsigned char*)value - sizeof(*header));
+    const eshkol_object_header_t* header =
+        (const eshkol_object_header_t*)ESHKOL_GET_HEADER((void*)value);
     if (header->subtype == 1 && header->size > 0) return (int64_t)header->size - 1;
     return (int64_t)strlen(value);
 }
@@ -41,8 +35,8 @@ extern int64_t eshkol_string_byte_length(const char* value);
 #endif
 
 static char* make_string(const char* bytes, size_t length) {
-    EshkolStringHeader* header =
-        (EshkolStringHeader*)malloc(sizeof(*header) + length + 1);
+    eshkol_object_header_t* header =
+        (eshkol_object_header_t*)malloc(sizeof(*header) + length + 1);
     if (!header) return NULL;
     header->subtype = 1;
     header->flags = 0;
@@ -124,9 +118,9 @@ int main(void) {
     ok &= expect(eshkol_sqlite_step(query) == SQLITE_DONE_CODE, "query done");
     eshkol_sqlite_finalize(query);
     eshkol_sqlite_close(db);
-    free(((EshkolStringHeader*)large) - 1);
-    free(((EshkolStringHeader*)embedded) - 1);
-    free(((EshkolStringHeader*)empty) - 1);
+    free(ESHKOL_GET_HEADER((void*)large));
+    free(ESHKOL_GET_HEADER((void*)embedded));
+    free(ESHKOL_GET_HEADER((void*)empty));
     puts(ok ? "sqlite-column-roundtrip: PASS" : "sqlite-column-roundtrip: FAIL");
     return ok ? 0 : 1;
 }


### PR DESCRIPTION
The standalone sqlite column round-trip test carried its own copy of the object header layout (a hand-rolled EshkolStringHeader struct) and computed the header offset itself, which the ABI header-inventory ratchet counts as a raw layout dependence. The test now includes the public header, uses eshkol_object_header_t with ESHKOL_GET_HEADER for every header access (length query, allocation, and the three frees), and the CMake target gets the inc/ include directory. Both compile modes of the file (standalone helper and ESHKOL_SQLITE_TEST_USE_RUNTIME=1) are syntax-clean; the target itself is exercised by the ctest battery.