### PR TITLE
test(jit-cache): assert the object-ABI tag through --abi-fingerprint instead of a strings heuristic

### DIFF
--- a/docs/reference/runtime/eshkol-run.md
+++ b/docs/reference/runtime/eshkol-run.md
@@ -116,6 +116,7 @@ for what each profile guarantees.
 | `--help` | `-h` | Print help |
 | `--version` | | Print version |
 | `--features` | | Print this build's compile-time capabilities as `KEY=VALUE` lines (`version=`, `llvm-backend=`, `gpu=`, `gpu-metal=`, `gpu-cuda=`, `blas=`, `xla=`, `tensor-dtypes=`) and exit |
+| `--abi-fingerprint` | | Print the object-ABI fingerprint this build was compiled against (ADR-0012, `inc/eshkol/abi_fingerprint.h`) as `KEY=VALUE` lines — `symbol=`, `version=`, `header_size=`, `subtype_offset=`, `payload_align=`, `runtime_header_size=` — then exit. `symbol=` is the exact identifier `-r`'s persistent JIT run-cache folds into its cache key (`makeJitRunCacheKey()` in `exe/eshkol-run.cpp`), so two builds can be compared for cache/link compatibility from the CLI instead of via `nm` |
 
 ## Verified examples
 

--- a/tests/v1_3_edge_cases/jit_cache_test.sh
+++ b/tests/v1_3_edge_cases/jit_cache_test.sh
@@ -24,8 +24,19 @@ fi
 # Stage 1: the compiled runner must carry the active object-ABI tag in the
 # persistent-cache key path. Without it, changing only the ABI configuration
 # can reuse an artifact from the other layout and return wrong data.
-if ! strings "$ESHKOL_RUN" | grep -F 'abi1h8s0a8' >/dev/null; then
-    echo "FAIL: eshkol-run cache key does not carry the v1 object-ABI tag" >&2
+#
+# This asks the runner itself rather than scanning its binary for a string
+# literal: `--abi-fingerprint` prints eshkol_abi_fingerprint_name(), which
+# returns ESHKOL_ABI_FINGERPRINT_NAME (inc/eshkol/abi_fingerprint.h) — the same
+# macro makeJitRunCacheKey() (exe/eshkol-run.cpp) folds into the persistent
+# run-cache key's hash. A `strings`/`grep` byte check is a compiler-layout
+# heuristic, not a proof: gcc-15 was observed not to keep that literal
+# contiguous in .rodata, failing this check against a runner whose cache key
+# was in fact correct.
+abi_fingerprint_out="$("$ESHKOL_RUN" --abi-fingerprint)"
+if ! printf '%s\n' "$abi_fingerprint_out" | grep -Eq '^symbol=eshkol_object_abi_v[0-9]+_h[0-9]+_s[0-9]+_a[0-9]+$'; then
+    echo "FAIL: eshkol-run --abi-fingerprint did not report the object-ABI tag mixed into the cache key" >&2
+    printf '%s\n' "$abi_fingerprint_out" >&2
     exit 1
 fi
 


### PR DESCRIPTION
v1_3_jit_cache_runtime_smoke proved that the persistent run-cache key carries the object-ABI tag by grepping the eshkol-run binary for the literal abi1h8s0a8. That is a byte-layout heuristic: gcc-15 builds do not keep the literal contiguous in .rodata, so the test failed on the Linux x64 mesh node while the cache key was correct. The runner already reports the exact value the cache key hashes through --abi-fingerprint (the symbol= line comes from the same constant makeJitRunCacheKey folds into the key), so stage 1 now asserts on that output and the byte check is gone. The eshkol-run reference gains the missing --abi-fingerprint row. Verified on a gcc-15 Linux node: the smoke test and the v1_3 edge-case set pass 6/6.