### PR TITLE
build(deps): fetch the pinned Eigen commit from the official GitLab repository where it is reachable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1422,9 +1422,10 @@ if(ESHKOL_BLAS_ENABLED)
         set(EIGEN_BUILD_PKGCONFIG OFF CACHE BOOL "Build Eigen pkg-config metadata" FORCE)
         set(EIGEN_BUILD_CMAKE_PACKAGE OFF CACHE BOOL "Build Eigen CMake package metadata" FORCE)
         FetchContent_Declare(eshkol_eigen
-            # GitHub's eigenteam mirror carries the same pinned commit and is
-            # the stable Windows fetch endpoint when GitLab is unavailable.
-            GIT_REPOSITORY https://github.com/eigenteam/eigen-git-mirror.git
+            # The pinned commit is reachable from refs/heads/5.0 and refs/tags/5.0.1
+            # on the official GitLab repository; the GitHub eigenteam mirror no
+            # longer advertises it, so a fresh node cannot fetch it there.
+            GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
             GIT_TAG bc3b39870ecb690a623a3f49149a358b95c5781d
             GIT_SHALLOW FALSE
         )


### PR DESCRIPTION
FetchContent pins Eigen at bc3b39870ecb690a623a3f49149a358b95c5781d (the 5.0.1 tag). The GitHub eigenteam mirror the pin was fetched from does not advertise that commit (its tags stop at 3.3.7), so a fresh node's FetchContent clone fails; the existing mesh nodes only build because a seeded dependency cache hides it, and the new Windows lane node had to be seeded by hand. The pin now fetches from https://gitlab.com/libeigen/eigen.git, where the commit is reachable from the 5.0 branch and the 5.0.1 tag; the tag hash and GIT_SHALLOW FALSE are unchanged. Verified by resolving the commit on the GitLab remote; the mesh gate exercises the fetch on fresh dependency trees.