### PR TITLE
test(model-io): add deterministic ESKM fuzz gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1192,6 +1192,17 @@ jobs:
           # consumes — without it architecture-verify false-FAILs.
           cmake --build build --parallel
 
+          # Keep the ESKM release oracle isolated from the main product build:
+          # configure fuzz support separately and build only its bounded probe.
+          cmake -S . -B build-fuzz -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DESHKOL_REQUIRED_LLVM_MAJOR="${LLVM_MAJOR}" \
+            -DLLVM_CONFIG_EXECUTABLE="$LLVM_CONFIG" \
+            -DESHKOL_BUILD_TESTS=ON \
+            -DESHKOL_BUILD_AGENT_FFI=OFF \
+            -DESHKOL_ENABLE_FUZZ=ON
+          cmake --build build-fuzz --target eskm_model_fuzz_probe --parallel
+
       # B3 (2026-08-26 audit): scripts/run_language_coverage.sh hard-requires
       # a quantum-enabled runner (agent.quantum/agent.pqc are part of "100%
       # language coverage" — see run_language_coverage.sh's own
@@ -1306,16 +1317,16 @@ jobs:
           if-no-files-found: ignore
 
       # A hosted runner is destroyed after the job; this self-hosted node is
-      # not, and this job leaves two full build trees behind (build,
-      # build-quantum). Reclaim them so a shared node doesn't fill up over
-      # successive release attempts — same rationale as mesh-matrix's
+      # not, and this job leaves three build trees behind (build,
+      # build-quantum, build-fuzz). Reclaim them so a shared node doesn't fill
+      # up over successive release attempts — same rationale as mesh-matrix's
       # "Reclaim build tree" step in ci-mesh.yml.
       - name: Reclaim build trees
         if: always()
         shell: bash
         run: |
           set -u
-          rm -rf build build-quantum || true
+          rm -rf build build-quantum build-fuzz || true
 
   publish-release:
     name: publish-release

--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -1537,6 +1537,14 @@ oracles:
         label: 'LeakSanitizer failure path is live end to end (__lsan_default_options no longer forces exitcode=0; the REPL calls __lsan_do_leak_check() before _Exit); every leak the now-live lane found is fixed'
         action: ASAN_OPTIONS=detect_leaks=1 LSAN_OPTIONS= ./scripts/run_sanitizer_fuzz.sh --quick
 
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["eskm_model_fuzz_smoke"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'ESKM v1 model loader: 70 deterministic mutations complete without crash, hang, resource escape, or materialization mismatch against the independent payload oracle'
+        action: python3 scripts/run_eskm_model_fuzz.py --smoke --self-test --probe build-fuzz/tests/fuzz/eskm_model_fuzz_probe
+
       # #480: gensym reachable on every engine (native JIT/AOT + VM),
       # previously wired into no dispatch table anywhere.
       - test_evidence: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,8 +176,8 @@ option(ESHKOL_ENABLE_UBSAN "Enable Undefined Behavior Sanitizer" OFF)
 option(ESHKOL_ENABLE_TSAN "Enable Thread Sanitizer"              OFF)
 option(ESHKOL_ENABLE_MSAN "Enable Memory Sanitizer"              OFF)
 option(ESHKOL_ENABLE_LSAN "Enable Leak Sanitizer (standalone)"   OFF)
-option(ESHKOL_ENABLE_FUZZ "Build fuzz harnesses (reader_fuzz: any compiler; libFuzzer targets: clang only)" OFF)
-option(ESHKOL_FUZZ_ASAN "Build reader_fuzz (and the runtime it exercises) with ASan+UBSan" OFF)
+option(ESHKOL_ENABLE_FUZZ "Build seeded probes (any compiler) and libFuzzer targets (clang only)" OFF)
+option(ESHKOL_FUZZ_ASAN "Build seeded reader/ESKM fuzz probes and their runtime with ASan+UBSan" OFF)
 option(ESHKOL_TENSORCORE_ENABLED
        "Enable the canonical Eshkol adapter against an installed TensorCore package" OFF)
 set(ESHKOL_TENSORCORE_MIN_VERSION "0.1.22" CACHE STRING

--- a/scripts/run_eskm_model_fuzz.py
+++ b/scripts/run_eskm_model_fuzz.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""Deterministic, resource-bounded ESKM mutation campaign."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import random
+import signal
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+import zlib
+from collections import Counter
+from pathlib import Path
+from typing import Callable, Sequence
+
+
+FNV_OFFSET = 14695981039346656037
+FNV_PRIME = 1099511628211
+ARTIFACT_BUDGET = 8 * 1024 * 1024
+DEFAULT_SEED = 0x5EED5EED
+CATEGORIES = (
+    "valid-single",
+    "valid-multi",
+    "valid-scalar",
+    "valid-empty",
+    "valid-rank32",
+    "valid-long-name",
+    "valid-many",
+    "bad-magic",
+    "bad-version",
+    "bad-flags",
+    "count-overclaim",
+    "name-overclaim",
+    "rank-overclaim",
+    "second-rank-overclaim",
+    "shape-overflow",
+    "bad-dtype",
+    "truncated",
+    "trailing",
+    "bad-crc",
+    "valid-payload-mutation",
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class Record:
+    name: bytes
+    dims: tuple[int, ...]
+    bits: tuple[int, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class Case:
+    ordinal: int
+    category: str
+    data: bytes
+    records: tuple[Record, ...] | None
+
+    @property
+    def case_id(self) -> str:
+        return f"{self.ordinal:06d}-{self.category}"
+
+
+@dataclasses.dataclass
+class RunResult:
+    kind: str
+    detail: str
+    stdout: str = ""
+    stderr: str = ""
+    returncode: int | None = None
+
+
+def u32(value: int) -> bytes:
+    return struct.pack("<I", value & 0xFFFFFFFF)
+
+
+def u64(value: int) -> bytes:
+    return struct.pack("<Q", value & 0xFFFFFFFFFFFFFFFF)
+
+
+def encode(records: Sequence[Record], *, version: int = 1, flags: int = 0) -> bytes:
+    payload = bytearray(b"ESKM" + u32(version) + u32(len(records)) + u32(flags))
+    for record in records:
+        payload += u32(len(record.name)) + record.name + u32(len(record.dims))
+        for dim in record.dims:
+            payload += u64(dim)
+        payload.append(0)
+        for bits in record.bits:
+            payload += u64(bits)
+    return bytes(payload) + u32(zlib.crc32(payload))
+
+
+def with_crc(payload: bytes | bytearray) -> bytes:
+    raw = bytes(payload)
+    return raw + u32(zlib.crc32(raw))
+
+
+def put_u32(payload: bytearray, offset: int, value: int) -> None:
+    payload[offset : offset + 4] = u32(value)
+
+
+def put_u64(payload: bytearray, offset: int, value: int) -> None:
+    payload[offset : offset + 8] = u64(value)
+
+
+def fnv_bytes(value: int, data: bytes) -> int:
+    for byte in data:
+        value ^= byte
+        value = (value * FNV_PRIME) & 0xFFFFFFFFFFFFFFFF
+    return value
+
+
+def tensor_digest(record: Record) -> str:
+    value = fnv_bytes(FNV_OFFSET, u32(len(record.dims)))
+    for dim in record.dims:
+        value = fnv_bytes(value, u64(dim))
+    value = fnv_bytes(value, u64(len(record.bits)))
+    for bits in record.bits:
+        value = fnv_bytes(value, u64(bits))
+    return f"{value:016x}"
+
+
+def model_digest(records: Sequence[Record]) -> str:
+    value = FNV_OFFSET
+    for record in records:
+        value = fnv_bytes(value, u32(len(record.name)))
+        value = fnv_bytes(value, record.name)
+        value = fnv_bytes(value, u32(len(record.dims)))
+        for dim in record.dims:
+            value = fnv_bytes(value, u64(dim))
+        value = fnv_bytes(value, u64(len(record.bits)))
+        for bits in record.bits:
+            value = fnv_bytes(value, u64(bits))
+    value = fnv_bytes(value, u32(len(records)))
+    return f"{value:016x}"
+
+
+def expected_line(case: Case) -> str:
+    if case.records is None:
+        return "model=reject tensor=reject"
+    model = f"model=accept:{model_digest(case.records)}"
+    if len(case.records) == 1:
+        tensor = f"tensor=accept:{tensor_digest(case.records[0])}"
+    else:
+        tensor = "tensor=reject"
+    return f"{model} {tensor}"
+
+
+def random_record(rng: random.Random, ordinal: int, suffix: str = "") -> Record:
+    dims = (rng.randint(1, 3), rng.randint(1, 3))
+    name = f"tensor-{ordinal}-{suffix or 'a'}".encode("ascii")
+    return record_with_dims(rng, name, dims)
+
+
+def record_with_dims(rng: random.Random, name: bytes, dims: tuple[int, ...]) -> Record:
+    count = 1
+    for dim in dims:
+        count *= dim
+    bits = tuple(rng.getrandbits(64) for _ in range(count))
+    return Record(name, dims, bits)
+
+
+def encoded_record_size(record: Record) -> int:
+    return 4 + len(record.name) + 4 + 8 * len(record.dims) + 1 + 8 * len(record.bits)
+
+
+def mutate_case(seed: int, ordinal: int) -> Case:
+    category = CATEGORIES[ordinal % len(CATEGORIES)]
+    rng = random.Random(seed ^ (ordinal * 0x9E3779B97F4A7C15))
+    first = random_record(rng, ordinal)
+    records: tuple[Record, ...] = (first,)
+
+    if category == "valid-multi":
+        records = (first, random_record(rng, ordinal, "b"))
+        return Case(ordinal, category, encode(records), records)
+    if category == "valid-single":
+        return Case(ordinal, category, encode(records), records)
+    if category == "valid-scalar":
+        records = (record_with_dims(rng, b"scalar", ()),)
+        return Case(ordinal, category, encode(records), records)
+    if category == "valid-empty":
+        records = (record_with_dims(rng, b"empty", (0, 3)),)
+        return Case(ordinal, category, encode(records), records)
+    if category == "valid-rank32":
+        records = (record_with_dims(rng, b"rank32", (1,) * 32),)
+        return Case(ordinal, category, encode(records), records)
+    if category == "valid-long-name":
+        records = (record_with_dims(rng, b"n" * (64 * 1024), (1,)),)
+        return Case(ordinal, category, encode(records), records)
+    if category == "valid-many":
+        records = tuple(record_with_dims(rng, f"item-{i}".encode(), (1,)) for i in range(128))
+        return Case(ordinal, category, encode(records), records)
+    if category == "second-rank-overclaim":
+        records = (first, random_record(rng, ordinal, "b"))
+
+    data = encode(records)
+    payload = bytearray(data[:-4])
+    name_length = len(first.name)
+    rank_offset = 20 + name_length
+    dims_offset = rank_offset + 4
+    dtype_offset = dims_offset + 8 * len(first.dims)
+    element_offset = dtype_offset + 1
+
+    if category == "bad-magic":
+        payload[0] ^= 0x80
+    elif category == "bad-version":
+        put_u32(payload, 4, 2 + rng.randrange(0xFFFF))
+    elif category == "bad-flags":
+        put_u32(payload, 12, 1 << rng.randrange(32))
+    elif category == "count-overclaim":
+        put_u32(payload, 8, 0xFFFFFFFF)
+    elif category == "name-overclaim":
+        put_u32(payload, 16, 0xFFFFFFFF)
+    elif category == "rank-overclaim":
+        put_u32(payload, rank_offset, 0xFFFFFFFF)
+    elif category == "second-rank-overclaim":
+        second_rank = 16 + encoded_record_size(first) + 4 + len(records[1].name)
+        put_u32(payload, second_rank, 0xFFFFFFFF)
+    elif category == "shape-overflow":
+        put_u64(payload, dims_offset, 1 << 63)
+        put_u64(payload, dims_offset + 8, 3)
+    elif category == "bad-dtype":
+        payload[dtype_offset] = rng.randint(1, 255)
+    elif category == "truncated":
+        cut = rng.choice((1, 4, 8, max(1, len(payload) - element_offset)))
+        del payload[-min(cut, len(payload) - 1) :]
+    elif category == "trailing":
+        payload += bytes((rng.randrange(256),))
+    elif category == "bad-crc":
+        corrupted = bytearray(data)
+        corrupted[-1] ^= 0x80
+        return Case(ordinal, category, bytes(corrupted), None)
+    elif category == "valid-payload-mutation":
+        mask = 1 << rng.randrange(64)
+        changed = first.bits[0] ^ mask
+        put_u64(payload, element_offset, changed)
+        updated = Record(first.name, first.dims, (changed,) + first.bits[1:])
+        return Case(ordinal, category, with_crc(payload), (updated,))
+    else:
+        raise AssertionError(category)
+    return Case(ordinal, category, with_crc(payload), None)
+
+
+def child_limits(memory_mb: int) -> Callable[[], None] | None:
+    if os.name != "posix":
+        return None
+
+    def apply() -> None:
+        import resource
+
+        resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+        if memory_mb > 0:
+            limit = memory_mb * 1024 * 1024
+            resource.setrlimit(resource.RLIMIT_AS, (limit, limit))
+
+    return apply
+
+
+def decoded_output(value: str | bytes | None) -> str:
+    return value.decode(errors="replace") if isinstance(value, bytes) else value or ""
+
+
+def run_command(command: Sequence[str], timeout: float, memory_mb: int = 0) -> RunResult:
+    child_env = dict(os.environ)
+    ubsan = [item for item in child_env.get("UBSAN_OPTIONS", "").split(":")
+             if item and not item.startswith("halt_on_error=")]
+    child_env["UBSAN_OPTIONS"] = ":".join(("halt_on_error=1", *ubsan))
+    try:
+        completed = subprocess.run(
+            command,
+            env=child_env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            preexec_fn=child_limits(memory_mb),
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return RunResult("hang", f"timeout after {timeout:g}s",
+                         decoded_output(exc.stdout), decoded_output(exc.stderr))
+    except OSError as exc:
+        return RunResult("infra", str(exc))
+
+    if completed.returncode < 0:
+        sig = -completed.returncode
+        return RunResult("crash", f"signal {sig} ({signal.strsignal(sig)})",
+                         completed.stdout, completed.stderr, completed.returncode)
+    if completed.returncode != 0:
+        return RunResult("exit", f"exit {completed.returncode}", completed.stdout,
+                         completed.stderr, completed.returncode)
+    return RunResult("ok", "exit 0", completed.stdout, completed.stderr, completed.returncode)
+
+
+def run_case(probe: Sequence[str], case: Case, scratch: Path, timeout: float,
+             memory_mb: int) -> RunResult:
+    path = scratch / f"{case.case_id}.eskm"
+    path.write_bytes(case.data)
+    try:
+        result = run_command((*probe, str(path)), timeout, memory_mb)
+        if result.kind != "ok":
+            return result
+        actual = result.stdout.strip()
+        expected = expected_line(case)
+        if actual != expected:
+            return RunResult("oracle", f"expected {expected!r}, got {actual!r}",
+                             result.stdout, result.stderr, result.returncode)
+        return result
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def retain_failure(artifact_dir: Path, case: Case, result: RunResult, seed: int,
+                   used_bytes: int) -> int:
+    metadata = {
+        "case": case.case_id,
+        "category": case.category,
+        "seed": seed,
+        "ordinal": case.ordinal,
+        "result": result.kind,
+        "detail": result.detail,
+        "expected": expected_line(case),
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+    meta = json.dumps(metadata, indent=2, sort_keys=True).encode() + b"\n"
+    needed = len(case.data) + len(meta)
+    if used_bytes + needed > ARTIFACT_BUDGET:
+        return used_bytes
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    (artifact_dir / f"{case.case_id}.eskm").write_bytes(case.data)
+    (artifact_dir / f"{case.case_id}.json").write_bytes(meta)
+    return used_bytes + needed
+
+
+def internal_self_test(timeout: float) -> bool:
+    with tempfile.TemporaryDirectory(prefix="eshkol-eskm-fuzz-selftest-") as raw:
+        root = Path(raw)
+        fake = root / "fake_probe.py"
+        fake.write_text(
+            "import os, sys, time\n"
+            "mode = sys.argv[1]\n"
+            "if mode == 'crash': os.abort()\n"
+            "if mode == 'hang': print('partial', flush=True); time.sleep(60)\n"
+            "if mode == 'env': print(os.environ.get('UBSAN_OPTIONS', '')); sys.exit()\n"
+            "print('model=accept:wrong tensor=reject')\n",
+            encoding="utf-8",
+        )
+        crash = run_command((sys.executable, str(fake), "crash"), timeout)
+        hang = run_command((sys.executable, str(fake), "hang"), 0.05)
+        sanitizer = run_command((sys.executable, str(fake), "env"), timeout)
+        wrong_case = mutate_case(DEFAULT_SEED, 0)
+        wrong = run_case((sys.executable, str(fake)), wrong_case, root, timeout, 0)
+        deterministic = all(mutate_case(DEFAULT_SEED, i) == mutate_case(DEFAULT_SEED, i)
+                            for i in range(len(CATEGORIES) * 2))
+        abnormal = crash.kind == ("crash" if os.name == "posix" else "exit")
+        timeout_output = hang.kind == "hang" and hang.stdout.strip() == "partial"
+        sanitizer_halts = "halt_on_error=1" in sanitizer.stdout.strip().split(":")
+        oracle_detected = wrong.kind == "oracle"
+        finding_dir = root / "findings"
+        retained = retain_failure(finding_dir, wrong_case, hang, DEFAULT_SEED, 0)
+        finding = json.loads((finding_dir / f"{wrong_case.case_id}.json").read_text())
+        artifact_ok = retained > 0 and finding["stdout"].strip() == "partial"
+        cleaned = not (root / f"{wrong_case.case_id}.eskm").exists()
+        ok = all((abnormal, timeout_output, sanitizer_halts, oracle_detected,
+                  deterministic, artifact_ok, cleaned))
+        print(f"self-test abnormal-exit: {'PASS' if abnormal else 'FAIL'}")
+        print(f"self-test timeout-output: {'PASS' if timeout_output else 'FAIL'}")
+        print(f"self-test ubsan-halt: {'PASS' if sanitizer_halts else 'FAIL'}")
+        print(f"self-test broken-oracle: {'PASS' if oracle_detected else 'FAIL'}")
+        print(f"self-test deterministic-replay: {'PASS' if deterministic else 'FAIL'}")
+        print(f"self-test artifact-retention: {'PASS' if artifact_ok else 'FAIL'}")
+        print(f"self-test scratch-input-cleanup: {'PASS' if cleaned else 'FAIL'}")
+        return ok
+
+
+def parse_int(text: str) -> int:
+    return int(text, 0)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--smoke", action="store_true", help="run the 70-case CI-sized campaign")
+    mode.add_argument("--full", action="store_true", help="run the 700-case local campaign")
+    parser.add_argument("--probe", type=Path, help="path to eskm_model_fuzz_probe")
+    parser.add_argument("--seed", type=parse_int, default=DEFAULT_SEED)
+    parser.add_argument("--count", type=int, help="override the mode's generated-case count")
+    parser.add_argument("--replay", type=int, metavar="ORDINAL", help="run exactly one ordinal")
+    parser.add_argument("--timeout", type=float, default=2.0, help="seconds per process")
+    parser.add_argument("--memory-mb", type=int, default=256,
+                        help="POSIX address-space cap per probe; use 0 for sanitizer builds")
+    parser.add_argument("--artifact-dir", type=Path, help="retain only failing cases here")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.self_test and not internal_self_test(args.timeout):
+        return 1
+    if args.self_test and not args.probe:
+        print("PASS: ESKM fuzz harness negative controls")
+        return 0
+    if not args.probe:
+        parser.error("--probe is required unless only --self-test is requested")
+    if args.timeout <= 0 or args.memory_mb < 0:
+        parser.error("--timeout must be positive and --memory-mb non-negative")
+
+    ok = True
+    if args.probe:
+        probe = args.probe.resolve()
+        if not probe.is_file() or not os.access(probe, os.X_OK):
+            parser.error(f"probe is not executable: {probe}")
+        count = args.count if args.count is not None else (700 if args.full else 70)
+        if count <= 0:
+            parser.error("--count must be positive")
+        ordinals = (args.replay,) if args.replay is not None else range(count)
+        categories: Counter[str] = Counter()
+        failures = 0
+        artifact_bytes = 0
+        started = time.monotonic()
+        with tempfile.TemporaryDirectory(prefix="eshkol-eskm-fuzz-") as raw:
+            scratch = Path(raw)
+            artifact_dir = args.artifact_dir or (scratch / "findings")
+            for ordinal in ordinals:
+                if ordinal is None or ordinal < 0:
+                    parser.error("--replay must be non-negative")
+                case = mutate_case(args.seed, ordinal)
+                categories[case.category] += 1
+                result = run_case((str(probe),), case, scratch, args.timeout, args.memory_mb)
+                if result.kind != "ok":
+                    failures += 1
+                    artifact_bytes = retain_failure(artifact_dir, case, result, args.seed, artifact_bytes)
+                    print(f"FAIL: {case.case_id}: {result.kind}: {result.detail}", file=sys.stderr)
+        elapsed = time.monotonic() - started
+        total = sum(categories.values())
+        print(f"ESKM fuzz seed={args.seed} cases={total} failures={failures} elapsed={elapsed:.2f}s")
+        print("categories: " + ", ".join(f"{name}={categories[name]}" for name in CATEGORIES))
+        print(f"artifact-bytes={artifact_bytes} budget={ARTIFACT_BUDGET}")
+        ok = ok and failures == 0
+
+    print(f"RESULT: {'OK' if ok else 'FAIL'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_eskm_model_fuzz.py
+++ b/scripts/run_eskm_model_fuzz.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import hashlib
 import json
 import os
 import random
+import re
 import signal
 import struct
 import subprocess
@@ -24,6 +26,11 @@ FNV_OFFSET = 14695981039346656037
 FNV_PRIME = 1099511628211
 ARTIFACT_BUDGET = 8 * 1024 * 1024
 DEFAULT_SEED = 0x5EED5EED
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_TRACE_FILE = REPO_ROOT / "scripts" / "icc_traces" / "eskm_model_fuzz.jsonl"
+ORACLE_FILE = REPO_ROOT / ".icc" / "completion-oracles.yaml"
+RELEASE_EVENT_KIND = "eshkol_smoke"
+RELEASE_EVENT_NAME = "eskm_model_fuzz_smoke"
 CATEGORIES = (
     "valid-single",
     "valid-multi",
@@ -339,6 +346,78 @@ def retain_failure(artifact_dir: Path, case: Case, result: RunResult, seed: int,
     return used_bytes + needed
 
 
+def release_event(status: str, snippet: str, probe: Path | None = None) -> dict[str, object]:
+    event: dict[str, object] = {
+        "kind": RELEASE_EVENT_KIND,
+        "name": RELEASE_EVENT_NAME,
+        "value": status,
+        "snippet": snippet[:2000],
+        "confidence": 1.0,
+        "timestamp": int(time.time()),
+    }
+    if probe and probe.is_file():
+        event["probe_sha256"] = hashlib.sha256(probe.read_bytes()).hexdigest()
+    try:
+        head = subprocess.run(("git", "-C", str(REPO_ROOT), "rev-parse", "HEAD"),
+                              text=True, capture_output=True, check=False)
+        if head.returncode == 0:
+            event["git_sha"] = head.stdout.strip()
+    except OSError:
+        pass
+    return event
+
+
+def write_release_event(path: Path, status: str, snippet: str,
+                        probe: Path | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(release_event(status, snippet, probe), ensure_ascii=False) + "\n",
+                    encoding="utf-8")
+
+
+def release_criterion(path: Path = ORACLE_FILE) -> tuple[set[str], set[str], set[str]]:
+    text = path.read_text(encoding="utf-8")
+    start = re.search(r"(?m)^  - name: v1\.3\.5-evolve\s*$", text)
+    if not start:
+        raise ValueError("v1.3.5-evolve oracle is missing")
+    end = re.search(r"(?m)^  - name: ", text[start.end():])
+    target = text[start.end():start.end() + end.start()] if end else text[start.end():]
+
+    def values(block: str, key: str) -> set[str]:
+        match = re.search(rf"(?m)^\s+{key}:\s*\[([^]]*)\]\s*$", block)
+        if not match:
+            return set()
+        return {item.strip().strip("'\"") for item in match.group(1).split(",") if item.strip()}
+
+    for block in re.split(r"(?m)(?=^      - runtime_event:\s*$)", target):
+        names = values(block, "event_names")
+        if RELEASE_EVENT_NAME in names:
+            return values(block, "event_kinds"), names, values(block, "event_values")
+    raise ValueError(f"{RELEASE_EVENT_NAME} criterion is missing from v1.3.5-evolve")
+
+
+def trace_satisfies_release_criterion(
+        path: Path, criterion: tuple[set[str], set[str], set[str]]) -> bool:
+    if not path.is_file():
+        return False
+    kinds, names, values = criterion
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if (event.get("kind") in kinds and event.get("name") in names and
+                event.get("value") in values):
+            return True
+    return False
+
+
+def release_run_eligible(*, self_test: bool, replay: int | None, count: int,
+                         timeout: float, memory_mb: int,
+                         supports_limits: bool) -> bool:
+    return (supports_limits and self_test and replay is None and count >= 70 and
+            timeout <= 2.0 and memory_mb == 256)
+
+
 def internal_self_test(timeout: float) -> bool:
     with tempfile.TemporaryDirectory(prefix="eshkol-eskm-fuzz-selftest-") as raw:
         root = Path(raw)
@@ -368,8 +447,44 @@ def internal_self_test(timeout: float) -> bool:
         finding = json.loads((finding_dir / f"{wrong_case.case_id}.json").read_text())
         artifact_ok = retained > 0 and finding["stdout"].strip() == "partial"
         cleaned = not (root / f"{wrong_case.case_id}.eskm").exists()
+        try:
+            criterion = release_criterion()
+            criterion_wired = criterion == (
+                {RELEASE_EVENT_KIND}, {RELEASE_EVENT_NAME}, {"PASS"})
+        except (OSError, ValueError):
+            criterion = (set(), set(), set())
+            criterion_wired = False
+        trace = root / "trace.jsonl"
+        missing_event_rejected = not trace_satisfies_release_criterion(trace, criterion)
+        trace.write_text("\n".join(json.dumps(event) for event in (
+            {"kind": "wrong", "name": RELEASE_EVENT_NAME, "value": "PASS"},
+            {"kind": RELEASE_EVENT_KIND, "name": "wrong", "value": "PASS"},
+            {"kind": RELEASE_EVENT_KIND, "name": RELEASE_EVENT_NAME, "value": "FAIL"},
+        )) + "\n", encoding="utf-8")
+        wrong_events_rejected = not trace_satisfies_release_criterion(trace, criterion)
+        write_release_event(trace, "PASS", "self-test")
+        exact_event_accepted = trace_satisfies_release_criterion(trace, criterion)
+        partial_runs_rejected = all(not release_run_eligible(**shape) for shape in (
+            {"self_test": False, "replay": None, "count": 70,
+             "timeout": 2.0, "memory_mb": 256, "supports_limits": True},
+            {"self_test": True, "replay": None, "count": 69,
+             "timeout": 2.0, "memory_mb": 256, "supports_limits": True},
+            {"self_test": True, "replay": 37, "count": 70,
+             "timeout": 2.0, "memory_mb": 256, "supports_limits": True},
+            {"self_test": True, "replay": None, "count": 70,
+             "timeout": 3.0, "memory_mb": 256, "supports_limits": True},
+            {"self_test": True, "replay": None, "count": 70,
+             "timeout": 2.0, "memory_mb": 0, "supports_limits": True},
+            {"self_test": True, "replay": None, "count": 70,
+             "timeout": 2.0, "memory_mb": 256, "supports_limits": False},
+        ))
+        release_shape_accepted = release_run_eligible(
+            self_test=True, replay=None, count=70, timeout=2.0, memory_mb=256,
+            supports_limits=True)
         ok = all((abnormal, timeout_output, sanitizer_halts, oracle_detected,
-                  deterministic, artifact_ok, cleaned))
+                  deterministic, artifact_ok, cleaned, missing_event_rejected,
+                  wrong_events_rejected, exact_event_accepted,
+                  partial_runs_rejected, release_shape_accepted, criterion_wired))
         print(f"self-test abnormal-exit: {'PASS' if abnormal else 'FAIL'}")
         print(f"self-test timeout-output: {'PASS' if timeout_output else 'FAIL'}")
         print(f"self-test ubsan-halt: {'PASS' if sanitizer_halts else 'FAIL'}")
@@ -377,6 +492,12 @@ def internal_self_test(timeout: float) -> bool:
         print(f"self-test deterministic-replay: {'PASS' if deterministic else 'FAIL'}")
         print(f"self-test artifact-retention: {'PASS' if artifact_ok else 'FAIL'}")
         print(f"self-test scratch-input-cleanup: {'PASS' if cleaned else 'FAIL'}")
+        print(f"self-test release-event-missing: {'PASS' if missing_event_rejected else 'FAIL'}")
+        print(f"self-test release-event-wrong: {'PASS' if wrong_events_rejected else 'FAIL'}")
+        print(f"self-test release-event-exact: {'PASS' if exact_event_accepted else 'FAIL'}")
+        print(f"self-test release-event-partial-run: {'PASS' if partial_runs_rejected else 'FAIL'}")
+        print(f"self-test release-event-canonical-run: {'PASS' if release_shape_accepted else 'FAIL'}")
+        print(f"self-test release-oracle-wiring: {'PASS' if criterion_wired else 'FAIL'}")
         return ok
 
 
@@ -397,27 +518,44 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--memory-mb", type=int, default=256,
                         help="POSIX address-space cap per probe; use 0 for sanitizer builds")
     parser.add_argument("--artifact-dir", type=Path, help="retain only failing cases here")
+    parser.add_argument("--trace-file", type=Path, default=DEFAULT_TRACE_FILE,
+                        help="ICC JSON-L release-evidence path")
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args(argv)
 
+    if args.timeout <= 0 or args.memory_mb < 0:
+        parser.error("--timeout must be positive and --memory-mb non-negative")
+    count = args.count if args.count is not None else (700 if args.full else 70)
+    if count <= 0:
+        parser.error("--count must be positive")
+    if args.replay is not None and args.replay < 0:
+        parser.error("--replay must be non-negative")
+    release_run = bool(args.probe) and release_run_eligible(
+        self_test=args.self_test,
+        replay=args.replay,
+        count=count,
+        timeout=args.timeout,
+        memory_mb=args.memory_mb,
+        supports_limits=os.name == "posix",
+    )
+    if release_run:
+        args.trace_file.parent.mkdir(parents=True, exist_ok=True)
+        args.trace_file.write_text("", encoding="utf-8")
     if args.self_test and not internal_self_test(args.timeout):
+        if release_run:
+            write_release_event(args.trace_file, "FAIL", "fuzz harness negative control failed")
         return 1
     if args.self_test and not args.probe:
         print("PASS: ESKM fuzz harness negative controls")
         return 0
     if not args.probe:
         parser.error("--probe is required unless only --self-test is requested")
-    if args.timeout <= 0 or args.memory_mb < 0:
-        parser.error("--timeout must be positive and --memory-mb non-negative")
 
     ok = True
     if args.probe:
         probe = args.probe.resolve()
         if not probe.is_file() or not os.access(probe, os.X_OK):
             parser.error(f"probe is not executable: {probe}")
-        count = args.count if args.count is not None else (700 if args.full else 70)
-        if count <= 0:
-            parser.error("--count must be positive")
         ordinals = (args.replay,) if args.replay is not None else range(count)
         categories: Counter[str] = Counter()
         failures = 0
@@ -427,8 +565,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             scratch = Path(raw)
             artifact_dir = args.artifact_dir or (scratch / "findings")
             for ordinal in ordinals:
-                if ordinal is None or ordinal < 0:
-                    parser.error("--replay must be non-negative")
+                assert ordinal is not None
                 case = mutate_case(args.seed, ordinal)
                 categories[case.category] += 1
                 result = run_case((str(probe),), case, scratch, args.timeout, args.memory_mb)
@@ -442,6 +579,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("categories: " + ", ".join(f"{name}={categories[name]}" for name in CATEGORIES))
         print(f"artifact-bytes={artifact_bytes} budget={ARTIFACT_BUDGET}")
         ok = ok and failures == 0
+        if release_run:
+            write_release_event(
+                args.trace_file,
+                "PASS" if ok else "FAIL",
+                f"seed={args.seed} cases={total} failures={failures} artifact-bytes={artifact_bytes}",
+                probe,
+            )
 
     print(f"RESULT: {'OK' if ok else 'FAIL'}")
     return 0 if ok else 1

--- a/scripts/run_v1_3_readiness.sh
+++ b/scripts/run_v1_3_readiness.sh
@@ -32,6 +32,9 @@ if ! eshkol_durable_enabled; then trap 'rm -f -- "${READINESS_JSON:?}"' EXIT; fi
 
 BUILD_DIR="${BUILD_DIR:-build}" TRACE_DIR="$TRACE_DIR" \
   scripts/run_mono_equiv_ad_taylor_gate.sh
+python3 scripts/run_eskm_model_fuzz.py --smoke --self-test \
+  --probe "${ESKM_FUZZ_BUILD_DIR:-build-fuzz}/tests/fuzz/eskm_model_fuzz_probe" \
+  --trace-file "$TRACE_DIR/eskm_model_fuzz.jsonl"
 scripts/run_icc_smoke.sh
 
 # Emit a fresh, runtime-backed architecture verdict. Readiness consumes only

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -5,6 +5,9 @@
 #                      isolation harness for the hosted S-expression
 #                      reader (eshkol_read_sexpr). Plain executable,
 #                      any compiler, no libFuzzer runtime required.
+#   eskm_model_fuzz — deterministic ESKM generator/mutator driving the
+#                      public model/tensor loaders through a bounded child
+#                      probe. Plain executable + Python driver, any compiler.
 #   fuzz_parser     — libFuzzer driver: feeds arbitrary bytes into the
 #                      frontend Scheme source parser. Requires clang
 #                      (`-fsanitize=fuzzer`); gcc/AppleClang builds skip it.
@@ -34,25 +37,62 @@ if(TARGET eshkol-runtime)
     )
     target_link_libraries(reader_fuzz PRIVATE eshkol-runtime)
     if(ESHKOL_FUZZ_ASAN)
-        set(READER_FUZZ_ASAN_FLAGS -fsanitize=address,undefined -fno-omit-frame-pointer -g)
-        target_compile_options(reader_fuzz PRIVATE ${READER_FUZZ_ASAN_FLAGS})
-        target_link_options(reader_fuzz PRIVATE ${READER_FUZZ_ASAN_FLAGS})
+        set(ESHKOL_SEEDED_FUZZ_ASAN_FLAGS -fsanitize=address,undefined -fno-omit-frame-pointer -g)
+        target_compile_options(reader_fuzz PRIVATE ${ESHKOL_SEEDED_FUZZ_ASAN_FLAGS})
+        target_link_options(reader_fuzz PRIVATE ${ESHKOL_SEEDED_FUZZ_ASAN_FLAGS})
         # ASan needs the reader/runtime objects instrumented too, or heap
         # overflows inside them go undetected.
         if(TARGET eshkol-runtime-hosted-obj)
-            target_compile_options(eshkol-runtime-hosted-obj PRIVATE ${READER_FUZZ_ASAN_FLAGS})
+            target_compile_options(eshkol-runtime-hosted-obj PRIVATE ${ESHKOL_SEEDED_FUZZ_ASAN_FLAGS})
         endif()
         if(TARGET eshkol-runtime-core-obj)
-            target_compile_options(eshkol-runtime-core-obj PRIVATE ${READER_FUZZ_ASAN_FLAGS})
+            target_compile_options(eshkol-runtime-core-obj PRIVATE ${ESHKOL_SEEDED_FUZZ_ASAN_FLAGS})
         endif()
         if(TARGET eshkol-runtime-support-obj)
-            target_compile_options(eshkol-runtime-support-obj PRIVATE ${READER_FUZZ_ASAN_FLAGS})
+            target_compile_options(eshkol-runtime-support-obj PRIVATE ${ESHKOL_SEEDED_FUZZ_ASAN_FLAGS})
         endif()
         message(STATUS "Fuzz: reader_fuzz built with ASan+UBSan (ESHKOL_FUZZ_ASAN=ON)")
     endif()
     message(STATUS "Fuzz: enabled — reader_fuzz target (seeded adversarial reader harness)")
+
+    add_executable(eskm_model_fuzz_probe eskm_model_fuzz_probe.cpp)
+    target_compile_features(eskm_model_fuzz_probe PRIVATE cxx_std_17)
+    target_include_directories(eskm_model_fuzz_probe PRIVATE
+        ${PROJECT_SOURCE_DIR}/inc
+        ${PROJECT_SOURCE_DIR}/lib/core
+    )
+    target_link_libraries(eskm_model_fuzz_probe PRIVATE eshkol-runtime)
+    if(ESHKOL_FUZZ_ASAN)
+        target_compile_options(eskm_model_fuzz_probe PRIVATE ${ESHKOL_SEEDED_FUZZ_ASAN_FLAGS})
+        target_link_options(eskm_model_fuzz_probe PRIVATE ${ESHKOL_SEEDED_FUZZ_ASAN_FLAGS})
+    endif()
+    message(STATUS "Fuzz: enabled — eskm_model_fuzz_probe target (seeded ESKM campaign)")
+
+    if(ESHKOL_BUILD_TESTS AND ESHKOL_PYTHON3_EXECUTABLE)
+        set(ESHKOL_ESKM_FUZZ_MEMORY_MB 256)
+        if(ESHKOL_FUZZ_ASAN OR ESHKOL_ENABLE_ASAN OR ESHKOL_ENABLE_TSAN OR
+           ESHKOL_ENABLE_MSAN OR ESHKOL_ENABLE_LSAN)
+            # Memory-checking sanitizers reserve large virtual address ranges,
+            # so RLIMIT_AS cannot be combined with them. Ordinary builds carry
+            # the memory cap; sanitizer builds retain per-process timeouts.
+            set(ESHKOL_ESKM_FUZZ_MEMORY_MB 0)
+        endif()
+        add_test(
+            NAME eskm_model_fuzz_smoke
+            COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                    "${PROJECT_SOURCE_DIR}/scripts/run_eskm_model_fuzz.py"
+                    --smoke --self-test
+                    --probe $<TARGET_FILE:eskm_model_fuzz_probe>
+                    --memory-mb "${ESHKOL_ESKM_FUZZ_MEMORY_MB}"
+        )
+        set_tests_properties(eskm_model_fuzz_smoke PROPERTIES
+            LABELS "fuzz;model-io;security"
+            TIMEOUT 180
+            PASS_REGULAR_EXPRESSION "RESULT: OK"
+        )
+    endif()
 else()
-    message(WARNING "Fuzz: eshkol-runtime target not available; skipping reader_fuzz")
+    message(WARNING "Fuzz: eshkol-runtime target not available; skipping seeded fuzz probes")
 endif()
 
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang"

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -76,6 +76,14 @@ python3 scripts/run_eskm_model_fuzz.py --replay 37 --seed 0x5eed5eed \
     --probe build-fuzz/tests/fuzz/eskm_model_fuzz_probe
 ```
 
+A successful ESKM campaign refreshes
+`scripts/icc_traces/eskm_model_fuzz.jsonl` with the
+`eshkol_smoke/eskm_model_fuzz_smoke=PASS` event consumed by the high-severity
+v1.3.5 release-readiness criterion. A failed campaign records `FAIL`; a run that
+cannot start leaves no matching event. Use `--trace-file PATH` to redirect the
+event during isolated testing. Replay, reduced-count, uncapped sanitizer, and
+harness-self-test-free runs never publish release evidence.
+
 Or invoke the binary directly once built:
 
 ```

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -1,6 +1,6 @@
 # Eshkol Fuzzing Harnesses
 
-Two kinds of harness live here:
+Three kinds of harness live here:
 
 - **`reader_fuzz`** — a plain executable with a seeded PRNG that
   *generates* specific adversarial S-expression categories (long flat
@@ -14,12 +14,17 @@ Two kinds of harness live here:
   libFuzzer binaries that exercise one parser/loader/validator in a
   tight loop under ASan+UBSan instrumentation, coverage-guided. Clang
   only.
+- **`eskm_model_fuzz_probe`** — a small out-of-process consumer for the
+  public ESKM model/tensor loaders. `scripts/run_eskm_model_fuzz.py`
+  generates grammar-aware mutations, checks exact materialized-value
+  digests, and classifies rejection, crash, timeout, or oracle drift.
 
 ## Build
 
 ```
 cmake -S . -B build-fuzz -DESHKOL_ENABLE_FUZZ=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build build-fuzz --target reader_fuzz
+cmake --build build-fuzz --target eskm_model_fuzz_probe
 ```
 
 `reader_fuzz` builds with any compiler (including AppleClang) and links
@@ -36,7 +41,7 @@ cmake --build build-fuzz --target fuzz_parser
 Only clang supports `-fsanitize=fuzzer`; gcc/AppleClang skip that
 target with a warning (`reader_fuzz` is unaffected).
 
-For an ASan+UBSan pass over the reader itself (not just the driver),
+For an ASan+UBSan pass over both seeded probes and their runtime,
 configure with `-DESHKOL_FUZZ_ASAN=ON`:
 
 ```
@@ -44,8 +49,10 @@ cmake -S . -B build-fuzz-asan -DCMAKE_BUILD_TYPE=Debug \
     -DESHKOL_ENABLE_FUZZ=ON -DESHKOL_FUZZ_ASAN=ON \
     -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang \
     -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++
-cmake --build build-fuzz-asan --target reader_fuzz
+cmake --build build-fuzz-asan --target reader_fuzz eskm_model_fuzz_probe
 ASAN_OPTIONS=detect_leaks=0 ./build-fuzz-asan/tests/fuzz/reader_fuzz --full
+python3 scripts/run_eskm_model_fuzz.py --full --memory-mb 0 \
+    --probe build-fuzz-asan/tests/fuzz/eskm_model_fuzz_probe
 ```
 
 ## Run
@@ -60,6 +67,13 @@ scripts/run_reader_fuzz.sh --full       # full seeded sweep (~10-30s):
                                          # pathologies, arena exhaustion, ...
 scripts/run_reader_fuzz.sh --regression # just the fixed depth-guard /
                                          # bounded-stack assertions
+
+python3 scripts/run_eskm_model_fuzz.py --smoke --self-test \
+    --probe build-fuzz/tests/fuzz/eskm_model_fuzz_probe
+python3 scripts/run_eskm_model_fuzz.py --full --seed 0x5eed5eed \
+    --probe build-fuzz/tests/fuzz/eskm_model_fuzz_probe
+python3 scripts/run_eskm_model_fuzz.py --replay 37 --seed 0x5eed5eed \
+    --probe build-fuzz/tests/fuzz/eskm_model_fuzz_probe
 ```
 
 Or invoke the binary directly once built:
@@ -68,15 +82,20 @@ Or invoke the binary directly once built:
 ./build-fuzz/tests/fuzz/reader_fuzz --full --artifact-dir /tmp/reader-fuzz-artifacts
 ```
 
-Every case runs in a forked child with `RLIMIT_CORE=0`, a bounded
+Every `reader_fuzz` case runs in a forked child with `RLIMIT_CORE=0`, a bounded
 `RLIMIT_AS`, and a `SIGALRM` watchdog, so one crashing/hanging case
 doesn't take the rest of the sweep down with it — a single run reports
 every distinct finding. Findings are deterministic and replayable: the
 same fixed seed set always produces the same case sequence, and the
 exact triggering input is saved as an artifact (see disk budget below).
 
-Exit code is 0 iff no crash/hang was observed and the regression
+Its exit code is 0 iff no crash/hang was observed and the regression
 assertions held.
+
+The ESKM Python driver instead launches one probe subprocess per input and
+fails on a crash, timeout, nonzero exit, infrastructure error, or digest-oracle
+mismatch. Its generated case is replayable by seed and ordinal. On POSIX, probes
+use a 256 MB address-space cap.
 
 ### libFuzzer harnesses (fuzz_parser, ...)
 
@@ -110,6 +129,12 @@ no unbounded corpus/artifact growth, ever.
 - libFuzzer corpus directories (`corpus-parser/` etc.) are unbounded by
   libFuzzer itself; prune them manually if a long local session grows
   one past a few tens of MB.
+- The ESKM campaign writes cases to a fresh system temporary directory,
+  deletes passing inputs, and retains only failures when `--artifact-dir`
+  is supplied. Retained input plus metadata is capped at 8 MB per run.
+  Its ordinary smoke gate gives each probe a 256 MB POSIX address-space
+  ceiling and a two-second timeout. Use `--memory-mb 0` under ASan because
+  ASan reserves a large virtual address range; the timeout remains active.
 
 ## Adding a new libFuzzer harness
 
@@ -126,6 +151,6 @@ Current harnesses:
 |---|---|---|
 | `reader_fuzz` | `eshkol_read_sexpr` (hosted S-expression reader / `(read)`) | landed |
 | `fuzz_parser` | `eshkol_parse_next_ast_from_stream` (frontend source parser) | landed |
+| `eskm_model_fuzz_probe` | public ESKM model/tensor checkpoint loaders | landed |
 | `fuzz_bitcode` | stdlib.bc loader | TODO |
-| `fuzz_eskb` | `.eshkol-model` loader | TODO |
 | `fuzz_json` | core.json reader | TODO |

--- a/tests/fuzz/eskm_model_fuzz_probe.cpp
+++ b/tests/fuzz/eskm_model_fuzz_probe.cpp
@@ -1,0 +1,208 @@
+/*
+ * Load one ESKM input through the public native model/tensor entry points and
+ * print a stable digest of every successfully materialized value.  The seeded
+ * driver runs this probe out of process so malformed files cannot take down the
+ * campaign.
+ */
+
+#include <eshkol/model_io.h>
+
+#include "arena_memory.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace {
+
+constexpr std::size_t kArenaBytes = 32u * 1024u * 1024u;
+constexpr std::size_t kMaxObservedRecords = 4096;
+constexpr std::size_t kMaxObservedName = 1024u * 1024u;
+constexpr std::uint64_t kFnvOffset = 14695981039346656037ULL;
+constexpr std::uint64_t kFnvPrime = 1099511628211ULL;
+
+struct Observation {
+    bool accepted = false;
+    bool malformed_result = false;
+    std::uint64_t digest = kFnvOffset;
+};
+
+eshkol_tagged_value_t make_heap_ptr(void* ptr) {
+    eshkol_tagged_value_t value{};
+    value.type = ESHKOL_VALUE_HEAP_PTR;
+    value.data.ptr_val = reinterpret_cast<std::uint64_t>(ptr);
+    return value;
+}
+
+eshkol_tagged_value_t make_path(arena_t* arena, const std::string& path) {
+    char* bytes = arena_allocate_string_with_header(arena, path.size());
+    if (!bytes) return {};
+    std::memcpy(bytes, path.data(), path.size());
+    bytes[path.size()] = '\0';
+    return make_heap_ptr(bytes);
+}
+
+void hash_bytes(std::uint64_t& hash, const void* data, std::size_t size) {
+    const auto* bytes = static_cast<const unsigned char*>(data);
+    for (std::size_t i = 0; i < size; ++i) {
+        hash ^= bytes[i];
+        hash *= kFnvPrime;
+    }
+}
+
+void hash_u32(std::uint64_t& hash, std::uint32_t value) {
+    unsigned char bytes[4];
+    for (unsigned i = 0; i < 4; ++i) bytes[i] = static_cast<unsigned char>(value >> (8u * i));
+    hash_bytes(hash, bytes, sizeof(bytes));
+}
+
+void hash_u64(std::uint64_t& hash, std::uint64_t value) {
+    unsigned char bytes[8];
+    for (unsigned i = 0; i < 8; ++i) bytes[i] = static_cast<unsigned char>(value >> (8u * i));
+    hash_bytes(hash, bytes, sizeof(bytes));
+}
+
+bool is_pair(const eshkol_tagged_value_t& value) {
+    return ESHKOL_IS_CONS_COMPAT(value);
+}
+
+const arena_tagged_cons_cell_t* as_pair(const eshkol_tagged_value_t& value) {
+    if (!is_pair(value) || value.data.ptr_val == 0) return nullptr;
+    return reinterpret_cast<const arena_tagged_cons_cell_t*>(value.data.ptr_val);
+}
+
+bool tagged_name(const eshkol_tagged_value_t& value, const char** data, std::size_t* size) {
+    if (!data || !size || value.type != ESHKOL_VALUE_HEAP_PTR || value.data.ptr_val == 0) return false;
+    const auto* ptr = reinterpret_cast<const void*>(value.data.ptr_val);
+    const auto subtype = ESHKOL_GET_SUBTYPE(ptr);
+    if (subtype != HEAP_SUBTYPE_STRING && subtype != HEAP_SUBTYPE_SYMBOL) return false;
+    const auto* chars = reinterpret_cast<const char*>(ptr);
+    std::size_t length = 0;
+    while (length <= kMaxObservedName && chars[length] != '\0') ++length;
+    if (length > kMaxObservedName) return false;
+    *data = chars;
+    *size = length;
+    return true;
+}
+
+const eshkol_tensor_t* tagged_tensor(const eshkol_tagged_value_t& value) {
+    if (!ESHKOL_IS_TENSOR_COMPAT(value) || value.data.ptr_val == 0) return nullptr;
+    return reinterpret_cast<const eshkol_tensor_t*>(value.data.ptr_val);
+}
+
+bool hash_tensor(std::uint64_t& hash, const eshkol_tensor_t* tensor) {
+    if (!tensor) return false;
+    if (tensor->dtype != ESHKOL_TENSOR_DTYPE_F64) return false;
+    if (tensor->num_dimensions > 0 && !tensor->dimensions) return false;
+    if (tensor->total_elements > 0 && !tensor->elements) return false;
+    hash_u32(hash, static_cast<std::uint32_t>(tensor->num_dimensions));
+    for (std::uint64_t i = 0; i < tensor->num_dimensions; ++i) {
+        hash_u64(hash, tensor->dimensions[i]);
+    }
+    hash_u64(hash, tensor->total_elements);
+    for (std::uint64_t i = 0; i < tensor->total_elements; ++i) {
+        hash_u64(hash, static_cast<std::uint64_t>(tensor->elements[i]));
+    }
+    return true;
+}
+
+Observation observe_model(const std::string& path) {
+    Observation observation;
+    arena_t* arena = arena_create_bounded(kArenaBytes);
+    if (!arena) {
+        observation.malformed_result = true;
+        return observation;
+    }
+    const eshkol_tagged_value_t path_value = make_path(arena, path);
+    eshkol_tagged_value_t result{};
+    eshkol_model_load_tagged(arena, &path_value, &result);
+    if (result.type == ESHKOL_VALUE_NULL) {
+        arena_destroy(arena);
+        return observation;
+    }
+
+    eshkol_tagged_value_t cursor = result;
+    std::uint32_t count = 0;
+    while (is_pair(cursor) && count < kMaxObservedRecords) {
+        const auto* list_node = as_pair(cursor);
+        const eshkol_tagged_value_t entry = list_node->car;
+        const auto* entry_pair = as_pair(entry);
+        if (!entry_pair) {
+            observation.malformed_result = true;
+            break;
+        }
+        const char* name = nullptr;
+        std::size_t name_size = 0;
+        if (!tagged_name(entry_pair->car, &name, &name_size) || name_size > UINT32_MAX) {
+            observation.malformed_result = true;
+            break;
+        }
+        hash_u32(observation.digest, static_cast<std::uint32_t>(name_size));
+        hash_bytes(observation.digest, name, name_size);
+        if (!hash_tensor(observation.digest, tagged_tensor(entry_pair->cdr))) {
+            observation.malformed_result = true;
+            break;
+        }
+        ++count;
+        cursor = list_node->cdr;
+    }
+    if (cursor.type != ESHKOL_VALUE_NULL) {
+        observation.malformed_result = true;
+    }
+    if (!observation.malformed_result) {
+        hash_u32(observation.digest, count);
+        observation.accepted = true;
+    }
+    arena_destroy(arena);
+    return observation;
+}
+
+Observation observe_tensor(const std::string& path) {
+    Observation observation;
+    arena_t* arena = arena_create_bounded(kArenaBytes);
+    if (!arena) {
+        observation.malformed_result = true;
+        return observation;
+    }
+    const eshkol_tagged_value_t path_value = make_path(arena, path);
+    eshkol_tagged_value_t result{};
+    eshkol_tensor_load_tagged(arena, &path_value, &result);
+    if (result.type == ESHKOL_VALUE_NULL) {
+        arena_destroy(arena);
+        return observation;
+    }
+    const auto* tensor = tagged_tensor(result);
+    if (!tensor || !hash_tensor(observation.digest, tensor)) {
+        observation.malformed_result = true;
+    } else {
+        observation.accepted = true;
+    }
+    arena_destroy(arena);
+    return observation;
+}
+
+std::string render(const Observation& observation) {
+    if (observation.malformed_result) return "malformed";
+    if (!observation.accepted) return "reject";
+    std::ostringstream out;
+    out << "accept:" << std::hex << std::setw(16) << std::setfill('0') << observation.digest;
+    return out.str();
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        std::fprintf(stderr, "usage: %s INPUT.eskm\n", argv[0]);
+        return 2;
+    }
+    const std::string path = argv[1];
+    const Observation model = observe_model(path);
+    const Observation tensor = observe_tensor(path);
+    std::cout << "model=" << render(model) << " tensor=" << render(tensor) << '\n';
+    return (model.malformed_result || tensor.malformed_result) ? 3 : 0;
+}


### PR DESCRIPTION
Depends on #555. This PR remains deliberately stacked on fix/issue-549-payload-validation so its review diff contains only the fuzz/resource and release-oracle work.

## Problem

The ESKM v1 loader had no deterministic, resource-bounded campaign that could detect crashes, hangs, hostile allocation declarations, or incorrect materialized bits. A CTest-only fuzz smoke would also be invisible to the release readiness verdict.

## Scope

- add a deterministic ESKM generator/mutator and native probe
- exercise headers, counts, dimensions, names, payloads, checksums, truncation, later-record corruption, scalar/empty/rank-32/large-name and multi-record cases
- compare accepted materialization against an independent FNV-1a oracle
- isolate every input in a bounded subprocess with timeout, address-space, artifact, and cleanup limits
- provide fixed-seed smoke/full modes and exact replay
- register the 70-case smoke in CTest
- emit provenance-bearing JSON-L release evidence only from the canonical bounded campaign
- add the high-severity v1.3.5-evolve completion-oracle criterion and ensure the readiness workflow builds and runs the dedicated probe

No loader, VM, public API, or wire-format implementation change is included beyond the #555 base.

## Fail-closed release evidence

Replay, reduced-count, relaxed-timeout, disabled-self-test, uncapped, and non-POSIX runs cannot write a release-satisfying PASS event. Events include timestamp, probe digest, and Git SHA. Missing, wrong, partial, stale, or deliberately failing evidence does not satisfy the criterion.

## Verification

PASS:

- LLVM 21.1.8 focused build
- model_io_test and eskm_model_fuzz_smoke: 2/2
- canonical 70-case smoke: zero failures
- deliberately failing campaign emitted FAIL
- replay did not overwrite release evidence
- harness negative controls
- completion-oracle schema: 346/346 criteria
- action bindings: 236 tests and 277 bindings
- false-green and evidence-staleness checks
- test inventory: 46 suites
- VM prelude and generated API checks
- Python, shell, workflow syntax, and git diff --check
- independent final review

NOT RUN:

- the external icc readiness binary, which is unavailable on this host
- macOS or Windows runtime execution
- full repository test battery
- dedicated TSan, MSan, or standalone LSan builds

## Out of scope

- changing ESKM v1 bytes or loader acceptance policy
- automatic delta debugging
- cross-engine parity, which remains in #597
- resolving or modifying #555

## Assignment verification update — 2026-09-07

Head reviewed: `c148e32243803a231ac2fb22700e19b3311516a9`; dependency #555 remains open. No source changes were needed for this verification update.

PASS (existing completed local logs, inspected after execution):

- Focused native `model_io_test` and ASan+UBSan `model_io_test`.
- Ordinary fixed-seed smoke: 70 cases, zero failures; full: 700 cases, zero failures.
- ASan+UBSan fixed-seed smoke: 70 cases, zero failures; full: 700 cases, zero failures. Leak detection was enabled for this run; this is not a standalone LSan build.
- All 13 harness self-checks in each completed smoke/full log.

These are local diagnostic results, not canonical release evidence. Ordinary runs used the existing 256 MiB address-space limit; sanitizer runs omitted that address-space cap for shadow-memory compatibility and retained the existing per-input timeout, arena and artifact budgets. Do not infer a sanitizer address-space-bound result.

The task then stopped with a platform security restriction. No further campaign execution was attempted after that restriction. Remaining verification was not completed; in particular, the earlier verification section above is historical and is not a claim that every generated/oracle check or the full repository battery was rerun in this update. Exact-source private build logs and six result logs are retained locally under `/tmp/eskm-601-verification-b29a/`. Maintainer review and #555 integration remain outstanding.

