### PR TITLE
fix(vm): reject malformed ESKM before materialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3078,6 +3078,27 @@ if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/core/model_i
 endif()
 
 if(ESHKOL_BUILD_TESTS AND NOT WIN32 AND
+   EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/backend/vm_model_io_fail_closed_test.c")
+    add_executable(vm_model_io_fail_closed_test
+        tests/backend/vm_model_io_fail_closed_test.c)
+    target_include_directories(vm_model_io_fail_closed_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/inc
+        ${CMAKE_CURRENT_BINARY_DIR}/generated)
+    eshkol_apply_vm_limit_definitions(vm_model_io_fail_closed_test)
+    if(LLVM_LIBRARY_DIRS)
+        target_link_directories(vm_model_io_fail_closed_test PRIVATE ${LLVM_LIBRARY_DIRS})
+    endif()
+    target_link_libraries(vm_model_io_fail_closed_test PRIVATE
+        eshkol-static
+        ${ESHKOL_EXTRA_LINK_LIBS}
+        ${LLVM_LIBS_LIST}
+        ${LLVM_SYSTEM_LIBS_LIST})
+    add_test(NAME vm_model_io_fail_closed_test COMMAND vm_model_io_fail_closed_test)
+    set_tests_properties(vm_model_io_fail_closed_test PROPERTIES
+        PASS_REGULAR_EXPRESSION "PASS: VM ESKM fail-closed preflight")
+endif()
+
+if(ESHKOL_BUILD_TESTS AND NOT WIN32 AND
    EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/payload_validation_test.sh" AND
    EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/v1_3_edge_cases/payload_validation_test.esk")
     add_test(

--- a/lib/backend/vm_model_io.c
+++ b/lib/backend/vm_model_io.c
@@ -83,7 +83,7 @@ static int vm_model_write_u64(VmModelWriter* writer, uint64_t value, int include
 /** @brief Read a little-endian 32-bit value from @p data at *@p offset
  *         (bounds-checked against @p size), advancing *@p offset by 4. */
 static int vm_model_read_u32(const unsigned char* data, size_t size, size_t* offset, unsigned int* out) {
-    if (!offset || !out || *offset + 4 > size) return 0;
+    if (!offset || !out || *offset > size || size - *offset < 4) return 0;
     *out = (unsigned int)data[*offset] |
            ((unsigned int)data[*offset + 1] << 8) |
            ((unsigned int)data[*offset + 2] << 16) |
@@ -95,7 +95,7 @@ static int vm_model_read_u32(const unsigned char* data, size_t size, size_t* off
 /** @brief Read a little-endian 64-bit value from @p data at *@p offset
  *         (bounds-checked against @p size), advancing *@p offset by 8. */
 static int vm_model_read_u64(const unsigned char* data, size_t size, size_t* offset, uint64_t* out) {
-    if (!offset || !out || *offset + 8 > size) return 0;
+    if (!offset || !out || *offset > size || size - *offset < 8) return 0;
     *out = (uint64_t)data[*offset] |
            ((uint64_t)data[*offset + 1] << 8) |
            ((uint64_t)data[*offset + 2] << 16) |
@@ -111,7 +111,7 @@ static int vm_model_read_u64(const unsigned char* data, size_t size, size_t* off
 /** @brief Read a single byte from @p data at *@p offset (bounds-checked
  *         against @p size), advancing *@p offset by 1. */
 static int vm_model_read_u8(const unsigned char* data, size_t size, size_t* offset, unsigned char* out) {
-    if (!offset || !out || *offset + 1 > size) return 0;
+    if (!offset || !out || *offset >= size) return 0;
     *out = data[*offset];
     *offset += 1;
     return 1;
@@ -135,6 +135,53 @@ static int vm_model_compute_total(const uint64_t* dims, unsigned int ndims, int6
         value *= dims[i];
     }
     *total = (int64_t)value;
+    return 1;
+}
+
+/** A bounds-checked view of one ESKM record. It owns no checkpoint data. */
+typedef struct {
+    const unsigned char* name;
+    unsigned int name_len;
+    unsigned int ndims;
+    uint64_t dims[VM_TENSOR_MAX_DIMS];
+    size_t elements_offset;
+} VmModelRecord;
+
+/**
+ * @brief Parse and validate one complete ESKM tensor record without allocating
+ *        VM objects. On success, advances @p offset past the element payload.
+ */
+static int vm_model_parse_record(const unsigned char* data,
+                                 size_t size,
+                                 size_t* offset,
+                                 VmModelRecord* record) {
+    if (!data || !offset || !record) return 0;
+    if (!vm_model_read_u32(data, size, offset, &record->name_len) ||
+        *offset > size || record->name_len > size - *offset ||
+        record->name_len > (unsigned int)INT_MAX) {
+        return 0;
+    }
+    record->name = data + *offset;
+    *offset += record->name_len;
+
+    if (!vm_model_read_u32(data, size, offset, &record->ndims) ||
+        record->ndims > VM_TENSOR_MAX_DIMS) {
+        return 0;
+    }
+    for (unsigned int i = 0; i < record->ndims; i++) {
+        if (!vm_model_read_u64(data, size, offset, &record->dims[i])) return 0;
+    }
+
+    unsigned char dtype = 0;
+    if (!vm_model_read_u8(data, size, offset, &dtype) || dtype != 0) return 0;
+
+    int64_t total = 0;
+    if (!vm_model_compute_total(record->dims, record->ndims, &total) ||
+        *offset > size || (uint64_t)total > (uint64_t)(size - *offset) / 8u) {
+        return 0;
+    }
+    record->elements_offset = *offset;
+    *offset += (size_t)total * 8u;
     return 1;
 }
 
@@ -429,45 +476,19 @@ static void vm_model_tensor_load(VM* vm) {
         return;
     }
 
-    unsigned int name_len = 0;
-    unsigned int ndims = 0;
-    if (!vm_model_read_u32(data, payload_size, &offset, &name_len) ||
-        offset > payload_size || name_len > payload_size - offset ||
-        name_len > (unsigned int)INT_MAX) {
-        free(data);
-        vm_model_load_failure(vm, "tensor-load");
-        return;
-    }
-    offset += name_len;
-    if (!vm_model_read_u32(data, payload_size, &offset, &ndims)) {
-        free(data);
-        vm_model_load_failure(vm, "tensor-load");
-        return;
-    }
-
-    uint64_t dims[VM_TENSOR_MAX_DIMS];
-    if (ndims > VM_TENSOR_MAX_DIMS) {
-        free(data);
-        vm_model_load_failure(vm, "tensor-load");
-        return;
-    }
-    for (unsigned int i = 0; i < ndims; i++) {
-        if (!vm_model_read_u64(data, payload_size, &offset, &dims[i])) {
-            free(data);
-            vm_model_load_failure(vm, "tensor-load");
-            return;
-        }
-    }
-    unsigned char dtype = 0;
-    if (!vm_model_read_u8(data, payload_size, &offset, &dtype) || dtype != 0) {
-        free(data);
-        vm_model_load_failure(vm, "tensor-load");
-        return;
-    }
-
-    Value tensor_value;
-    if (!vm_model_make_tensor_value(vm, ndims, dims, data, payload_size, &offset, &tensor_value) ||
+    VmModelRecord record;
+    if (!vm_model_parse_record(data, payload_size, &offset, &record) ||
         offset != payload_size) {
+        free(data);
+        vm_model_load_failure(vm, "tensor-load");
+        return;
+    }
+
+    size_t elements_offset = record.elements_offset;
+    Value tensor_value;
+    if (!vm_model_make_tensor_value(vm, record.ndims, record.dims, data,
+                                    payload_size, &elements_offset, &tensor_value) ||
+        elements_offset != payload_size) {
         free(data);
         vm_model_load_failure(vm, "tensor-load");
         return;
@@ -500,44 +521,40 @@ static void vm_model_model_load(VM* vm) {
         return;
     }
 
-    Value list = NIL_VAL;
+    const size_t records_offset = offset;
+    VmModelRecord record;
     for (unsigned int t = 0; t < tensor_count; t++) {
-        unsigned int name_len = 0;
-        unsigned int ndims = 0;
-        if (!vm_model_read_u32(data, payload_size, &offset, &name_len) ||
-            offset > payload_size || name_len > payload_size - offset ||
-            name_len > (unsigned int)INT_MAX) {
+        if (!vm_model_parse_record(data, payload_size, &offset, &record)) {
             free(data);
             vm_model_load_failure(vm, "model-load");
             return;
         }
-        const char* name_ptr = (const char*)(data + offset);
-        offset += name_len;
-        if (!vm_model_read_u32(data, payload_size, &offset, &ndims) || ndims > VM_TENSOR_MAX_DIMS) {
-            free(data);
-            vm_model_load_failure(vm, "model-load");
-            return;
-        }
+    }
+    if (offset != payload_size) {
+        free(data);
+        vm_model_load_failure(vm, "model-load");
+        return;
+    }
 
-        uint64_t dims[VM_TENSOR_MAX_DIMS];
-        for (unsigned int i = 0; i < ndims; i++) {
-            if (!vm_model_read_u64(data, payload_size, &offset, &dims[i])) {
-                free(data);
-                vm_model_load_failure(vm, "model-load");
-                return;
-            }
-        }
-        unsigned char dtype = 0;
-        if (!vm_model_read_u8(data, payload_size, &offset, &dtype) || dtype != 0) {
+    /* Materialize only after every declared record and the exact payload
+     * boundary have passed validation. A malformed suffix must not consume
+     * persistent VM heap before the loader returns NIL. */
+    Value list = NIL_VAL;
+    offset = records_offset;
+    for (unsigned int t = 0; t < tensor_count; t++) {
+        if (!vm_model_parse_record(data, payload_size, &offset, &record)) {
             free(data);
             vm_model_load_failure(vm, "model-load");
             return;
         }
-
+        size_t elements_offset = record.elements_offset;
         Value name_value;
         Value tensor_value;
-        if (!vm_model_make_string_value(vm, name_ptr, (int)name_len, &name_value) ||
-            !vm_model_make_tensor_value(vm, ndims, dims, data, payload_size, &offset, &tensor_value)) {
+        if (!vm_model_make_string_value(vm, (const char*)record.name,
+                                        (int)record.name_len, &name_value) ||
+            !vm_model_make_tensor_value(vm, record.ndims, record.dims, data,
+                                        payload_size, &elements_offset, &tensor_value) ||
+            elements_offset != offset) {
             free(data);
             vm_model_load_failure(vm, "model-load");
             return;
@@ -546,9 +563,9 @@ static void vm_model_model_load(VM* vm) {
         int32_t pair_ptr = heap_alloc(&vm->heap);
         int32_t node_ptr = heap_alloc(&vm->heap);
         if (pair_ptr < 0 || node_ptr < 0) {
-        free(data);
-        vm_model_load_failure(vm, "model-load");
-        return;
+            free(data);
+            vm_model_load_failure(vm, "model-load");
+            return;
         }
         vm->heap.objects[pair_ptr]->type = HEAP_CONS;
         vm->heap.objects[pair_ptr]->cons.car = name_value;
@@ -560,11 +577,12 @@ static void vm_model_model_load(VM* vm) {
     }
 
     free(data);
-    if (offset != payload_size) {
+    Value result = vm_model_reverse_list(vm, list);
+    if (tensor_count > 0 && result.type == VAL_NIL) {
         vm_model_load_failure(vm, "model-load");
         return;
     }
-    vm_push(vm, vm_model_reverse_list(vm, list));
+    vm_push(vm, result);
 }
 
 #endif

--- a/lib/backend/vm_model_io.c
+++ b/lib/backend/vm_model_io.c
@@ -164,8 +164,10 @@ static int vm_model_parse_record(const unsigned char* data,
     record->name = data + *offset;
     *offset += record->name_len;
 
+    /* Match the current VM constructor: scalar and empty tensors cannot be
+     * materialized. Refuse them before any record consumes persistent heap. */
     if (!vm_model_read_u32(data, size, offset, &record->ndims) ||
-        record->ndims > VM_TENSOR_MAX_DIMS) {
+        record->ndims == 0 || record->ndims > VM_TENSOR_MAX_DIMS) {
         return 0;
     }
     for (unsigned int i = 0; i < record->ndims; i++) {
@@ -176,7 +178,7 @@ static int vm_model_parse_record(const unsigned char* data,
     if (!vm_model_read_u8(data, size, offset, &dtype) || dtype != 0) return 0;
 
     int64_t total = 0;
-    if (!vm_model_compute_total(record->dims, record->ndims, &total) ||
+    if (!vm_model_compute_total(record->dims, record->ndims, &total) || total == 0 ||
         *offset > size || (uint64_t)total > (uint64_t)(size - *offset) / 8u) {
         return 0;
     }

--- a/lib/core/model_io.cpp
+++ b/lib/core/model_io.cpp
@@ -213,14 +213,14 @@ struct BufferReader {
 
     /** Read one byte; false if out of bounds. */
     bool read_u8(std::uint8_t* out) {
-        if (!out || offset + 1 > size) return false;
+        if (!out || offset >= size) return false;
         *out = data[offset++];
         return true;
     }
 
     /** Read a little-endian 32-bit value; false if out of bounds. */
     bool read_u32(std::uint32_t* out) {
-        if (!out || offset + 4 > size) return false;
+        if (!out || offset > size || size - offset < 4) return false;
         *out = static_cast<std::uint32_t>(data[offset]) |
                (static_cast<std::uint32_t>(data[offset + 1]) << 8) |
                (static_cast<std::uint32_t>(data[offset + 2]) << 16) |
@@ -231,7 +231,7 @@ struct BufferReader {
 
     /** Read a little-endian 64-bit value; false if out of bounds. */
     bool read_u64(std::uint64_t* out) {
-        if (!out || offset + 8 > size) return false;
+        if (!out || offset > size || size - offset < 8) return false;
         *out = static_cast<std::uint64_t>(data[offset]) |
                (static_cast<std::uint64_t>(data[offset + 1]) << 8) |
                (static_cast<std::uint64_t>(data[offset + 2]) << 16) |
@@ -246,7 +246,7 @@ struct BufferReader {
 
     /** Read exactly @p len raw bytes into @p out as a string; false if out of bounds. */
     bool read_string(std::uint32_t len, std::string* out) {
-        if (!out || offset + len > size) return false;
+        if (!out || offset > size || len > size - offset) return false;
         out->assign(reinterpret_cast<const char*>(data + offset), len);
         offset += len;
         return true;

--- a/tests/backend/vm_model_io_fail_closed_test.c
+++ b/tests/backend/vm_model_io_fail_closed_test.c
@@ -1,0 +1,129 @@
+#define ESHKOL_VM_LIBRARY_MODE 1
+#include "../../lib/backend/eshkol_vm.c"
+
+enum FixtureKind {
+    FIXTURE_VALID_DUPLICATES,
+    FIXTURE_TRAILING_BYTE,
+    FIXTURE_TRUNCATED_SECOND_RECORD
+};
+
+static int write_record(VmModelWriter* writer, const char* name, double value) {
+    union { uint64_t u; double d; } bits;
+    bits.d = value;
+    return vm_model_write_u32(writer, (unsigned int)strlen(name), 1) &&
+           vm_model_write_bytes(writer, name, strlen(name), 1) &&
+           vm_model_write_u32(writer, 1u, 1) &&
+           vm_model_write_u64(writer, 1u, 1) &&
+           vm_model_write_u8(writer, 0u, 1) &&
+           vm_model_write_u64(writer, bits.u, 1);
+}
+
+static int write_fixture(const char* path, enum FixtureKind kind) {
+    VmModelWriter writer = {fopen(path, "wb"), 0u, 1};
+    if (!writer.file) return 0;
+
+    const unsigned int count = kind == FIXTURE_VALID_DUPLICATES ? 2u :
+                               kind == FIXTURE_TRUNCATED_SECOND_RECORD ? 2u : 1u;
+    int ok = vm_model_write_bytes(&writer, VM_MODEL_MAGIC, sizeof(VM_MODEL_MAGIC), 1) &&
+             vm_model_write_u32(&writer, VM_MODEL_VERSION, 1) &&
+             vm_model_write_u32(&writer, count, 1) &&
+             vm_model_write_u32(&writer, 0u, 1) &&
+             write_record(&writer, kind == FIXTURE_VALID_DUPLICATES ? "dup" : "w", 1.0);
+
+    if (kind == FIXTURE_VALID_DUPLICATES) {
+        ok = ok && write_record(&writer, "dup", 2.0);
+    } else if (kind == FIXTURE_TRAILING_BYTE) {
+        ok = ok && vm_model_write_u8(&writer, 0xA5u, 1);
+    } else {
+        ok = ok && vm_model_write_u32(&writer, 8u, 1) &&
+             vm_model_write_u8(&writer, 'x', 1);
+    }
+    ok = ok && vm_model_write_u32(&writer, writer.crc, 0);
+    fclose(writer.file);
+    return ok && writer.ok;
+}
+
+static int reject_without_heap_growth(VM* vm, const char* path, int model_load) {
+    Value path_value;
+    if (!vm_model_make_string_value(vm, path, (int)strlen(path), &path_value)) return 0;
+    VmArena* arena = vm_active_arena(&vm->heap.regions);
+    const int32_t before = vm->heap.next_free;
+    const int32_t free_slots_before = vm->heap.n_free_slots;
+    const size_t arena_used_before = arena->total_used;
+    vm_push(vm, path_value);
+    if (model_load) vm_model_model_load(vm);
+    else vm_model_tensor_load(vm);
+    Value result = vm_pop(vm);
+    return result.type == VAL_NIL && vm->heap.next_free == before &&
+           vm->heap.n_free_slots == free_slots_before &&
+           arena->total_used == arena_used_before;
+}
+
+static int duplicate_model_preserves_order(VM* vm, const char* path) {
+    Value path_value;
+    if (!vm_model_make_string_value(vm, path, (int)strlen(path), &path_value)) return 0;
+    vm_push(vm, path_value);
+    vm_model_model_load(vm);
+    Value list = vm_pop(vm);
+
+    const double expected[] = {1.0, 2.0};
+    for (int i = 0; i < 2; i++) {
+        if (list.type != VAL_PAIR) return 0;
+        HeapObject* node = vm->heap.objects[list.as.ptr];
+        Value entry = node->cons.car;
+        if (entry.type != VAL_PAIR) return 0;
+        HeapObject* pair = vm->heap.objects[entry.as.ptr];
+        int name_len = 0;
+        const char* name = vm_model_string_ptr(vm, pair->cons.car, &name_len);
+        VmTensor* tensor = vm_model_value_tensor(vm, pair->cons.cdr);
+        if (!name || name_len != 3 || memcmp(name, "dup", 3) != 0 ||
+            !tensor || tensor->total != 1 || tensor->data[0] != expected[i]) {
+            return 0;
+        }
+        list = node->cons.cdr;
+    }
+    return list.type == VAL_NIL;
+}
+
+static int expect_case(int condition, const char* label) {
+    if (condition) return 1;
+    fprintf(stderr, "FAIL: %s\n", label);
+    return 0;
+}
+
+int main(void) {
+    VM* vm = vm_create();
+    if (!vm) return 1;
+
+    char valid_path[128];
+    char trailing_path[128];
+    char truncated_path[128];
+    snprintf(valid_path, sizeof(valid_path), ".vm-model-valid-%p.eskm", (void*)vm);
+    snprintf(trailing_path, sizeof(trailing_path), ".vm-model-trailing-%p.eskm", (void*)vm);
+    snprintf(truncated_path, sizeof(truncated_path), ".vm-model-truncated-%p.eskm", (void*)vm);
+
+    int ok = expect_case(write_fixture(valid_path, FIXTURE_VALID_DUPLICATES),
+                         "could not write duplicate-name fixture");
+    ok &= expect_case(write_fixture(trailing_path, FIXTURE_TRAILING_BYTE),
+                      "could not write trailing-byte fixture");
+    ok &= expect_case(write_fixture(truncated_path, FIXTURE_TRUNCATED_SECOND_RECORD),
+                      "could not write truncated-record fixture");
+    ok &= expect_case(reject_without_heap_growth(vm, trailing_path, 0),
+                      "tensor-load materialized a trailing-byte checkpoint");
+    ok &= expect_case(reject_without_heap_growth(vm, trailing_path, 1),
+                      "model-load materialized a trailing-byte checkpoint");
+    ok &= expect_case(reject_without_heap_growth(vm, truncated_path, 1),
+                      "model-load materialized before a malformed later record");
+    ok &= expect_case(duplicate_model_preserves_order(vm, valid_path),
+                      "duplicate-name records lost order or payloads");
+
+    remove(valid_path);
+    remove(trailing_path);
+    remove(truncated_path);
+    vm_free(vm);
+    if (!ok) {
+        return 1;
+    }
+    printf("PASS: VM ESKM fail-closed preflight\n");
+    return 0;
+}

--- a/tests/backend/vm_model_io_fail_closed_test.c
+++ b/tests/backend/vm_model_io_fail_closed_test.c
@@ -4,7 +4,9 @@
 enum FixtureKind {
     FIXTURE_VALID_DUPLICATES,
     FIXTURE_TRAILING_BYTE,
-    FIXTURE_TRUNCATED_SECOND_RECORD
+    FIXTURE_TRUNCATED_SECOND_RECORD,
+    FIXTURE_SCALAR_SECOND_RECORD,
+    FIXTURE_EMPTY_SECOND_RECORD
 };
 
 static int write_record(VmModelWriter* writer, const char* name, double value) {
@@ -22,8 +24,7 @@ static int write_fixture(const char* path, enum FixtureKind kind) {
     VmModelWriter writer = {fopen(path, "wb"), 0u, 1};
     if (!writer.file) return 0;
 
-    const unsigned int count = kind == FIXTURE_VALID_DUPLICATES ? 2u :
-                               kind == FIXTURE_TRUNCATED_SECOND_RECORD ? 2u : 1u;
+    const unsigned int count = kind == FIXTURE_TRAILING_BYTE ? 1u : 2u;
     int ok = vm_model_write_bytes(&writer, VM_MODEL_MAGIC, sizeof(VM_MODEL_MAGIC), 1) &&
              vm_model_write_u32(&writer, VM_MODEL_VERSION, 1) &&
              vm_model_write_u32(&writer, count, 1) &&
@@ -34,9 +35,20 @@ static int write_fixture(const char* path, enum FixtureKind kind) {
         ok = ok && write_record(&writer, "dup", 2.0);
     } else if (kind == FIXTURE_TRAILING_BYTE) {
         ok = ok && vm_model_write_u8(&writer, 0xA5u, 1);
-    } else {
+    } else if (kind == FIXTURE_TRUNCATED_SECOND_RECORD) {
         ok = ok && vm_model_write_u32(&writer, 8u, 1) &&
              vm_model_write_u8(&writer, 'x', 1);
+    } else {
+        /* Valid ESKM shapes that the current VM tensor constructor rejects. */
+        ok = ok && vm_model_write_u32(&writer, 0u, 1) &&
+             vm_model_write_u32(&writer, kind == FIXTURE_SCALAR_SECOND_RECORD ? 0u : 1u, 1);
+        if (kind == FIXTURE_EMPTY_SECOND_RECORD) {
+            ok = ok && vm_model_write_u64(&writer, 0u, 1);
+        }
+        ok = ok && vm_model_write_u8(&writer, 0u, 1);
+        if (kind == FIXTURE_SCALAR_SECOND_RECORD) {
+            ok = ok && vm_model_write_u64(&writer, 0u, 1);
+        }
     }
     ok = ok && vm_model_write_u32(&writer, writer.crc, 0);
     fclose(writer.file);
@@ -116,6 +128,12 @@ int main(void) {
                       "model-load materialized before a malformed later record");
     ok &= expect_case(duplicate_model_preserves_order(vm, valid_path),
                       "duplicate-name records lost order or payloads");
+    ok &= expect_case(write_fixture(truncated_path, FIXTURE_SCALAR_SECOND_RECORD) &&
+                      reject_without_heap_growth(vm, truncated_path, 1),
+                      "model-load materialized before an unsupported scalar record");
+    ok &= expect_case(write_fixture(truncated_path, FIXTURE_EMPTY_SECOND_RECORD) &&
+                      reject_without_heap_growth(vm, truncated_path, 1),
+                      "model-load materialized before an unsupported empty record");
 
     remove(valid_path);
     remove(trailing_path);

--- a/tests/core/model_io_test.cpp
+++ b/tests/core/model_io_test.cpp
@@ -256,6 +256,29 @@ int main() {
         return fail("second model tensor should match");
     }
 
+    eshkol_tagged_value_t duplicate_entries = cons(
+        arena,
+        cons(arena, make_string(arena, "dup"), make_heap_ptr(w1)),
+        cons(arena, cons(arena, make_string(arena, "dup"), make_heap_ptr(b1)), make_null()));
+    eshkol_model_save_tagged(arena, &model_path_value, &duplicate_entries, &save_result);
+    if (save_result.type != ESHKOL_VALUE_BOOL || save_result.data.int_val != 1) {
+        return fail("duplicate-name model-save should succeed");
+    }
+    eshkol_model_load_tagged(arena, &model_path_value, &load_result);
+    if (!is_pair(load_result) || !is_pair(pair_cdr(load_result))) {
+        return fail("duplicate-name model-load should return both records");
+    }
+    const eshkol_tagged_value_t duplicate_first = pair_car(load_result);
+    const eshkol_tagged_value_t duplicate_second = pair_car(pair_cdr(load_result));
+    if (std::string(reinterpret_cast<const char*>(pair_car(duplicate_first).data.ptr_val)) != "dup" ||
+        std::string(reinterpret_cast<const char*>(pair_car(duplicate_second).data.ptr_val)) != "dup" ||
+        !tensor_equals(reinterpret_cast<eshkol_tensor_t*>(pair_cdr(duplicate_first).data.ptr_val),
+                       {2}, {5.0, 6.0}) ||
+        !tensor_equals(reinterpret_cast<eshkol_tensor_t*>(pair_cdr(duplicate_second).data.ptr_val),
+                       {1}, {7.0})) {
+        return fail("duplicate model names should preserve record order and payloads");
+    }
+
     std::fstream corrupt(model_path, std::ios::in | std::ios::out | std::ios::binary);
     corrupt.seekp(0);
     corrupt.write("BAD!", 4);


### PR DESCRIPTION
## Problem and change

VM checkpoint loading could create strings, tensors, and list entries before discovering a rejected later record or trailing bytes. Preflight now validates every record and exact payload consumption before creating VM objects. Native and VM cursor readers use subtraction-based bounds checks. The final correction also refuses rank-zero and zero-element records during preflight because the existing VM constructor already rejects these shapes during materialization.

Scope: `lib/backend/vm_model_io.c`, `lib/core/model_io.cpp`, `tests/backend/vm_model_io_fail_closed_test.c`, `tests/core/model_io_test.cpp`, and focused test registration in `CMakeLists.txt`.

## Dependency and revisions

- Base: `fix/issue-549-payload-validation` at `e737c10a28c34099d502b0b788dba09c89d06875`.
- Head: `e588e1f10c2c4b02d85efd26f943b83e4c05f861`.
- Depends on maintainer PR #555, still OPEN at verification. Keep this PR stacked until #555 lands; retarget/rebase afterward. This PR does not take over #555's registration, format, or payload validation work.
- Related: #596 documents the v1 compatibility contract; #597 addresses the cross-engine fixture matrix.

## Compatibility and limits

ESKM wire version 1 (the v1.2 checkpoint contract) is unchanged. Duplicate names remain accepted in order with their original payloads; native and VM positive controls cover this. Native scalar/empty acceptance is unchanged. VM rank-zero scalars and zero-element tensors such as shape `[0]` remain unsupported: this PR moves their existing refusal before VM allocation, and does **not** establish scalar/empty native/VM acceptance parity.

Preflight uses one fixed-size record view and iteration bounded by validated file contents. It adds no global file-size limit, changes no public API, and does not promise rollback for allocator failure after successful validation. The whole-file temporary buffer still exists before preflight.

## Verification — Linux x86-64

Private copies of the clean prior-head build caches were used; affected VM translation units and executables were rebuilt/relinked against LLVM 21.1.8, with at most two compiler jobs. The native implementation and native positive test are unchanged from the verified prior-head cache. These are incremental builds, not a fresh full build. Tests ran in private working directories. `ESHKOL_PATH` was set to this checkout's `lib` and `LD_LIBRARY_PATH` to the cached LLVM21 library directory.

- PASS: `ctest --test-dir <normal> --output-on-failure -R '^(model_io_test|vm_model_io_fail_closed_test)$'`. Native round trips and both native/VM duplicate-name ordering/payload controls pass. VM rejection checks preserve heap slot and arena usage for trailing bytes, an incomplete later record, and unsupported scalar/empty later records.
- PASS: `ctest --test-dir <normal> --output-on-failure -R '^payload_validation_engine_parity$'` — native JIT, native AOT, and hosted VM bytecode, 91.71 seconds. The initial run without `ESHKOL_PATH` failed module discovery; the corrected environment passed.
- PASS: `ctest --test-dir <sanitize> --output-on-failure -R '^(model_io_test|vm_model_io_fail_closed_test)$'` with ASan + UBSan, `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1`, and `UBSAN_OPTIONS=halt_on_error=1`; 2/2 pass with no sanitizer findings.
- PASS negative control: the two new bounded scalar/empty allocation-state assertions fail against the preceding `b691fe530a587a1e78e2e5fb32e02941f1587892` implementation and pass with the preflight correction. Test commit: `a715a4f3`; correction: `e588e1f1`.
- PASS: `python3 scripts/gen_api_docs.py --check`, `python3 scripts/check_test_coverage.py` (46 suites), and `git diff --check`.
- FAIL, inherited from #555: `vm_prelude_cache_is_current`. The generator emits 5329 instructions / 768 locals / 945 constants, while the committed header records 5340 / 770 / 947. A separately compiled generator using exact base `e737c10a` sources produces byte-identical output to this head. No generated source was changed in this PR.
- NOT RUN: `vm_canonical_stdlib` (no matching test registered at this stacked base), full suite, full sanitized compiler/engine matrix, macOS, Windows, ARM, WASM, GPU/XLA, and resource/fuzz campaigns.

## Remaining acceptance gaps

#555 must land and the inherited prelude-cache failure must be resolved before this stack can satisfy the complete acceptance gate. Native/VM scalar and empty-tensor parity remains a separate compatibility gap. This PR is filed and locally verified as stated above; it is not merged or accepted. No releases, infrastructure, unrelated compiler changes, or generated artifacts are included.
