### PR TITLE
fix(cuda): exclude SM72 from CUDA 13 defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1566,10 +1566,19 @@ if(ESHKOL_GPU_ENABLED)
         # Try CUDA on Linux/Windows
         find_package(CUDAToolkit QUIET)
         if(CUDAToolkit_FOUND)
-            set(ESHKOL_HOST_CUDA_MAJOR "${CUDAToolkit_VERSION_MAJOR}")
+            set(ESHKOL_HOST_CUDA_MAJOR "${CUDAToolkit_VERSION_MAJOR}"
+                CACHE INTERNAL "CUDA toolkit major used by this build" FORCE)
             if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES OR
                "${CMAKE_CUDA_ARCHITECTURES}" STREQUAL "")
-                set(CMAKE_CUDA_ARCHITECTURES "${ESHKOL_CUDA_ARCHITECTURES}"
+                set(_eshkol_cuda_architectures "${ESHKOL_CUDA_ARCHITECTURES}")
+                # CUDA 13 removed offline compilation for architectures below
+                # compute capability 7.5.  Keep SM72 in the portable default
+                # for older toolkits (notably the verified Jetson Xavier path),
+                # but do not pass it to a compiler that no longer accepts it.
+                if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL 13.0)
+                    list(REMOVE_ITEM _eshkol_cuda_architectures "72")
+                endif()
+                set(CMAKE_CUDA_ARCHITECTURES "${_eshkol_cuda_architectures}"
                     CACHE STRING "CUDA architectures" FORCE)
             endif()
             if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND

--- a/scripts/verify_gpu_backend.py
+++ b/scripts/verify_gpu_backend.py
@@ -63,7 +63,17 @@ def verify(build_dir: Path, expected: str) -> list[str]:
             for item in cache.get("CMAKE_CUDA_ARCHITECTURES", "").split(";")
             if item
         }
-        for required_arch in ("72", "86"):
+        try:
+            cuda_major = int(cache.get("ESHKOL_HOST_CUDA_MAJOR", "0"))
+        except ValueError:
+            cuda_major = 0
+            failures.append("ESHKOL_HOST_CUDA_MAJOR is not an integer")
+        required_arches = ("75", "86") if cuda_major >= 13 else ("72", "86")
+        if cuda_major >= 13 and "72" in architectures:
+            failures.append(
+                f"CUDA {cuda_major} does not support portable architecture 72"
+            )
+        for required_arch in required_arches:
             if required_arch not in architectures:
                 failures.append(
                     f"portable CUDA architecture {required_arch} is missing from "

--- a/tests/test_verify_gpu_backend.py
+++ b/tests/test_verify_gpu_backend.py
@@ -27,6 +27,7 @@ class VerifyGpuBackendTests(unittest.TestCase):
             "ESHKOL_GPU_ENABLED:BOOL=ON\n"
             "ESHKOL_REQUIRE_GPU_BACKEND:BOOL=ON\n"
             "ESHKOL_GPU_BACKEND:INTERNAL=CUDA\n"
+            "ESHKOL_HOST_CUDA_MAJOR:INTERNAL=12\n"
             "CMAKE_CUDA_COMPILER:FILEPATH=/usr/local/cuda/bin/nvcc\n"
             "CMAKE_CUDA_ARCHITECTURES:STRING=72;75;80;86;89;90\n",
             "build gpu.o: CUDA_COMPILER gpu_memory_cuda.cpp gpu_cuda_kernels.cu\n",
@@ -38,6 +39,7 @@ class VerifyGpuBackendTests(unittest.TestCase):
             "ESHKOL_GPU_ENABLED:BOOL=ON\n"
             "ESHKOL_REQUIRE_GPU_BACKEND:BOOL=ON\n"
             "ESHKOL_GPU_BACKEND:INTERNAL=CUDA\n"
+            "ESHKOL_HOST_CUDA_MAJOR:INTERNAL=12\n"
             "CMAKE_CUDA_COMPILER:FILEPATH=C:/CUDA/bin/nvcc.exe\n"
             "CMAKE_CUDA_ARCHITECTURES:STRING=72;75;80;86;89;90\n",
             "include CMakeFiles/impl-Release.ninja\n",
@@ -49,6 +51,32 @@ class VerifyGpuBackendTests(unittest.TestCase):
             encoding="utf-8",
         )
         self.assertEqual(verify_gpu_backend.verify(build, "CUDA"), [])
+
+    def test_accepts_cuda_13_portable_graph_without_sm72(self) -> None:
+        build = self.make_build(
+            "ESHKOL_GPU_ENABLED:BOOL=ON\n"
+            "ESHKOL_REQUIRE_GPU_BACKEND:BOOL=ON\n"
+            "ESHKOL_GPU_BACKEND:INTERNAL=CUDA\n"
+            "ESHKOL_HOST_CUDA_MAJOR:INTERNAL=13\n"
+            "CMAKE_CUDA_COMPILER:FILEPATH=/usr/local/cuda/bin/nvcc\n"
+            "CMAKE_CUDA_ARCHITECTURES:STRING=75;80;86;89;90\n",
+            "build gpu.o: CUDA_COMPILER gpu_memory_cuda.cpp gpu_cuda_kernels.cu\n",
+        )
+        self.assertEqual(verify_gpu_backend.verify(build, "CUDA"), [])
+
+    def test_rejects_sm72_for_cuda_13(self) -> None:
+        build = self.make_build(
+            "ESHKOL_GPU_ENABLED:BOOL=ON\n"
+            "ESHKOL_REQUIRE_GPU_BACKEND:BOOL=ON\n"
+            "ESHKOL_GPU_BACKEND:INTERNAL=CUDA\n"
+            "ESHKOL_HOST_CUDA_MAJOR:INTERNAL=13\n"
+            "CMAKE_CUDA_COMPILER:FILEPATH=/usr/local/cuda/bin/nvcc\n"
+            "CMAKE_CUDA_ARCHITECTURES:STRING=72;75;80;86;89;90\n",
+            "build gpu.o: CUDA_COMPILER gpu_memory_cuda.cpp gpu_cuda_kernels.cu\n",
+        )
+        failures = verify_gpu_backend.verify(build, "CUDA")
+        self.assertTrue(any("does not support portable architecture 72" in item
+                            for item in failures))
 
     def test_rejects_cpu_stub_mislabeled_as_cuda(self) -> None:
         build = self.make_build(


### PR DESCRIPTION
## Summary

- keep the existing portable CUDA architecture defaults for toolkits through CUDA 12
- omit SM72 when CUDA 13 or newer is detected, because offline compilation below compute capability 7.5 was removed
- expose the detected toolkit major to the backend verifier
- cover both accepted CUDA 13 defaults and rejected SM72 configurations

Fixes #606

## Verification

```sh
python3 -m unittest discover -s tests -p 'test_verify_gpu_backend.py'
```

All 6 focused verifier tests pass. The change was also validated with CUDA 13 on an SM121 GB10 GPU: configuration, build, GPU smoke test, and backend verification all passed.