### PR TITLE
test(oracle): run Rosette Wire's Eshkol adapter as an advisory external oracle; emit Rosette receipts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -958,6 +958,65 @@ jobs:
           if-no-files-found: error
 
   # ─────────────────────────────────────────────────────────────────────
+  # rosette-oracle: drives Rosette Wire's own public front-door/eshkol
+  # adapter (github.com/RichardHoekstra/rosette-wire, Apache-2.0) against a
+  # fresh eshkol-run build, so Eshkol's standing as an independently
+  # maintained Rosette Wire backend is continuously checked rather than
+  # something only verified by hand. This is pillar P7 (external oracle):
+  # the ground truth lives entirely in a project this repo does not own.
+  # Deliberately advisory (continue-on-error) — the same reasoning as
+  # quantum-macos above: this depends on a third-party project's own SBCL
+  # toolchain and grading, so it must never become a branch-protection
+  # required context.
+  # ─────────────────────────────────────────────────────────────────────
+  rosette-oracle:
+    name: rosette-oracle (advisory)
+    needs: changes
+    if: github.event_name != 'schedule' && needs.changes.outputs.docs_only == 'false'
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install toolchain (Linux)
+        shell: bash
+        run: |
+          set -euxo pipefail
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_MAJOR} main" | sudo tee /etc/apt/sources.list.d/llvm.list
+          sudo apt-get update -o Acquire::Retries=5
+          sudo apt-get install -y cmake ninja-build sbcl \
+            llvm-${LLVM_MAJOR} llvm-${LLVM_MAJOR}-dev lld-${LLVM_MAJOR} \
+            libreadline-dev pkg-config libssl-dev libncurses-dev \
+            libpcre2-dev libsqlite3-dev git python3
+
+      - name: Run the Rosette Wire external-oracle gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          export ESHKOL_LLVM_CONFIG_EXECUTABLE="/usr/bin/llvm-config-${LLVM_MAJOR}"
+          ./scripts/run_rosette_oracle.sh || true
+
+      - name: Emit the Rosette Wire receipt
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/lib/rosette_receipt.py \
+            --trace scripts/icc_traces/rosette.jsonl \
+            --eshkol-commit "$(git describe --tags --always)" \
+            --out receipt.json || true
+
+      - name: Upload receipt.json
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rosette-receipt
+          path: receipt.json
+          if-no-files-found: warn
+
+  # ─────────────────────────────────────────────────────────────────────
   # bench-smoke: proves bench/run_public_benchmarks.sh still RUNS and
   # produces valid JSON — a harness-correctness check, explicitly NOT the
   # full timing suite (which is far too noisy on a shared hosted runner to

--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -1793,6 +1793,31 @@ oracles:
         label: P12 sparse high-order tensors match dense recovery on tractable cases
         action: run_ad_sparse_gate
 
+      # P7 external oracle: Rosette Wire (github.com/RichardHoekstra/
+      # rosette-wire, Apache-2.0, Common Lisp/SBCL) ships its own public
+      # front-door/eshkol adapter that independently gates an admitted
+      # integer-program dialect across its direct evaluator, kernel VM, a
+      # cache-disabled Eshkol JIT run, and a separately compiled Eshkol AOT
+      # artifact, requiring all four to agree. Unlike every other P7
+      # differential oracle in this file, the ground truth here lives in a
+      # project this repo does not own or vendor: scripts/run_rosette_
+      # oracle.sh clones it at a pinned commit into .scratch/rosette-wire,
+      # builds a fresh eshkol-run from this tree, and drives `tools/
+      # test-system front-door/eshkol` plus `examples/external-backends.
+      # lisp eshkol <dir>` against it, emitting one runtime_event per
+      # comparison into scripts/icc_traces/rosette.jsonl. See docs/interop.md
+      # in the rosette-wire tree for the protocol (ROSETTE_ESHKOL_BIN/
+      # ROSETTE_ESHKOL_ID) and scripts/lib/rosette_receipt.py for the
+      # matching urn:rosette-wire:schema:receipt:1 receipt emitter Rose
+      # Studio can render.
+      - runtime_event:
+          event_kinds: [rosette]
+          event_names: ["rosette_front_door_eshkol"]
+          event_values: ["PASS"]
+        severity: high
+        label: Rosette Wire's front-door/eshkol adapter agrees direct/kernel/JIT/AOT on its admitted integer dialect
+        action: ./scripts/run_rosette_oracle.sh
+
   # -----------------------------------------------------------------
   # v1.4-connection readiness — the "resource-sound systems profile"
   # (docs/design/adr/0000-unified-trajectory.md Stage 3 / v1.4.0).

--- a/scripts/lib/rosette_receipt.py
+++ b/scripts/lib/rosette_receipt.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""rosette_receipt.py — turn an Eshkol ICC trace into a Rosette Wire receipt.
+
+Reads a `kind:"rosette"` runtime_event trace (produced by
+scripts/run_rosette_oracle.sh through scripts/lib/harness_outcome.sh, one
+event per backend comparison) and writes a receipt.json that conforms to
+Rosette Wire's own protocol schema `urn:rosette-wire:schema:receipt:1`
+(rosette-wire/src/compiler/wire/wire-graph/src/graph.lisp: wire-receipt->value;
+decoded and strictly validated by wire-receipt-from-value in decode.lisp in
+the same tree). Rose Studio (or any consumer of `bin/rosette describe
+<receipt.json>`) can render this exactly like a receipt Rosette Wire produced
+of one of its own graph runs.
+
+Required top-level fields, matching the Lisp decoder's `%decode-fields`
+allow/require list exactly (extra or missing fields are both refused):
+    schema     "urn:rosette-wire:schema:receipt:1"           (constant)
+    kind       one of the wire-receipt kinds this project's own runtime uses:
+               "validation" | "execution" | "verification" | "certification"
+    verdict    "pass" | "fail"
+    graph      {"digest": "sha256:<64 lowercase hex>"}         (%require-digest)
+    violations [{"stage","path","code","detail"}, ...]         (each a string)
+    stepOrder  [string, ...]
+    outputs    arbitrary JSON object (frozen, not otherwise validated)
+    evidence   arbitrary JSON object (frozen, not otherwise validated)
+
+Validate a receipt against the real Rosette Wire decoder with:
+    <rosette-wire-clone>/bin/rosette describe receipt.json
+which loads wire-graph and round-trips the receipt through the same strict
+decoder gate/certify/validate/run all share, exiting 0 on success and
+nonzero (via the wire-error path) the moment any field is wrong.
+"""
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+SCHEMA = "urn:rosette-wire:schema:receipt:1"
+STEP_ORDER = ["rosette_front_door_eshkol", "rosette_external_backends_eshkol"]
+
+
+def _digest(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _read_trace(trace_path: Path):
+    events = {}
+    if not trace_path.exists():
+        return events
+    with trace_path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if record.get("kind") != "rosette":
+                continue
+            name = record.get("name")
+            if name in STEP_ORDER:
+                # Rosette Wire's canonical-json rejects a bare JSON float
+                # anywhere in the document (an "untyped-float" wire-error —
+                # see canonical-json.lisp): drop harness_outcome.sh's numeric
+                # `confidence` field rather than embed a float this schema
+                # refuses. Trace is append-only; a later line for the same
+                # name is the more recent run, so let it win.
+                events[name] = {k: v for k, v in record.items() if k != "confidence"}
+    return events
+
+
+def build_receipt(trace_path: Path, eshkol_commit: str) -> dict:
+    events = _read_trace(trace_path)
+
+    violations = []
+    outputs = {}
+    for name in STEP_ORDER:
+        record = events.get(name)
+        if record is None:
+            violations.append(
+                {
+                    "stage": "collection",
+                    "path": f"$.{name}",
+                    "code": "missing_event",
+                    "detail": f"no {name} event found in {trace_path}",
+                }
+            )
+            outputs[name] = {"value": "MISSING", "snippet": ""}
+            continue
+        value = record.get("value")
+        snippet = record.get("snippet", "")
+        outputs[name] = {"value": value, "snippet": snippet}
+        if value != "PASS":
+            violations.append(
+                {
+                    "stage": "execution",
+                    "path": f"$.{name}",
+                    "code": "backend_disagreement" if value == "FAIL" else "no_verdict",
+                    "detail": snippet or f"{name} reported {value}",
+                }
+            )
+
+    verdict = "pass" if not violations else "fail"
+    graph_digest = _digest(
+        json.dumps(
+            {"eshkol_commit": eshkol_commit, "step_order": STEP_ORDER},
+            sort_keys=True,
+        )
+    )
+
+    return {
+        "schema": SCHEMA,
+        "kind": "verification",
+        "verdict": verdict,
+        "graph": {"digest": graph_digest},
+        "violations": violations,
+        "stepOrder": STEP_ORDER,
+        "outputs": outputs,
+        "evidence": {
+            "eshkolCommit": eshkol_commit,
+            "traceFile": str(trace_path),
+            "events": events,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--trace",
+        default="scripts/icc_traces/rosette.jsonl",
+        help="path to the rosette.jsonl ICC trace",
+    )
+    parser.add_argument(
+        "--eshkol-commit",
+        default="unknown",
+        help="`git describe` (or similar) identity of the Eshkol build under test",
+    )
+    parser.add_argument(
+        "--out",
+        default="receipt.json",
+        help="path to write the receipt JSON to",
+    )
+    args = parser.parse_args()
+
+    receipt = build_receipt(Path(args.trace), args.eshkol_commit)
+    out_path = Path(args.out)
+    out_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"wrote {out_path} (verdict={receipt['verdict']})")
+    return 0 if receipt["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_rosette_oracle.sh
+++ b/scripts/run_rosette_oracle.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# run_rosette_oracle.sh — Rosette Wire external-oracle gate for Eshkol.
+#
+# Rosette Wire (https://github.com/RichardHoekstra/rosette-wire, Apache-2.0,
+# Common Lisp/SBCL) ships a public `front-door/eshkol` adapter that lowers an
+# admitted integer-program dialect through its direct evaluator, its kernel
+# VM, a cache-disabled Eshkol JIT run, and a separately compiled Eshkol AOT
+# artifact, then requires all four to agree. This script drives that adapter
+# against a freshly built `eshkol-run` from THIS repository and records the
+# result as an ICC runtime_event, so Eshkol counts as a first-class,
+# independently maintained Rosette Wire backend (docs/interop.md in the
+# Rosette Wire tree) rather than an untracked side effect of someone running
+# its examples by hand.
+#
+# This is pillar P7 (external oracle): the ground truth here is not another
+# Eshkol harness, it is an independent project's own four-way agreement gate.
+#
+# Requirements: SBCL on PATH.
+#   macOS:            brew install sbcl
+#   CI / Debian/Ubuntu: apt-get install -y sbcl
+#
+# Known macOS gap (observed, not fixed here): Rosette Wire's isolated-worker
+# wraps every probed/executed command in `prlimit` (util-linux; Linux-only),
+# so `eshkol-available-p`/campaign runs on a macOS host without a `prlimit`
+# on PATH fail closed with a LAUNCH-ERROR at the :availability stage (visible
+# as `... = :UNAVAILABLE` from examples/external-backends.lisp) even when
+# eshkol-run itself is fine. This is upstream behavior in the read-only
+# clone, out of scope to patch. CI (ubuntu-22.04, this repo's own workflow)
+# has `prlimit` from util-linux by default, so this gap is CI-irrelevant.
+#
+# Hard rule: nothing here ever touches /tmp or /private/tmp. All scratch,
+# clone, build and evidence output live under <repo>/.scratch/. Every path
+# THIS script passes to Rosette tooling (the clone location, the evidence
+# output directory) is under .scratch/. tools/test-system and
+# examples/external-backends.lisp additionally hardcode their own ASDF
+# fasl-cache output-translations to /tmp/rosette-contributor-cache and
+# /tmp/rosette-example-cache respectively inside Rosette Wire's own source —
+# that is upstream code in the read-only clone, not a path this script
+# supplies, and it is out of scope to patch a vendored, unmodified clone.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# shellcheck source=lib/harness_outcome.sh
+source "${SCRIPT_DIR}/lib/harness_outcome.sh"
+
+SCRATCH_DIR="${REPO_ROOT}/.scratch"
+ROSETTE_DIR="${SCRATCH_DIR}/rosette-wire"
+# Canonical upstream — this is what CI (and any machine without a private
+# local mirror) clones from.
+ROSETTE_UPSTREAM_URL="https://github.com/RichardHoekstra/rosette-wire.git"
+# ROSETTE_LOCAL_SOURCE_OVERRIDE lets a developer point this at an existing
+# local checkout instead of fetching over the network (e.g. a read-only
+# contributor clone already on disk). Optional; unset in CI.
+ROSETTE_LOCAL_SOURCE="${ROSETTE_LOCAL_SOURCE_OVERRIDE:-}"
+#
+# Pinned commit: this repo's rosette-wire dependency is frozen at the exact
+# SHA that was HEAD of the upstream repository when this gate was authored.
+# Bump it deliberately (re-pin + re-run this script + re-commit) rather than
+# floating.
+ROSETTE_PIN_SHA="bb34bbe7536f2ea9829dc302c6a578e9fdd877a0"
+
+BUILD_DIR="${ESHKOL_ROSETTE_BUILD_DIR:-${REPO_ROOT}/build}"
+NATIVE_DIR="${SCRATCH_DIR}/rosette-native"
+TRACE_FILE="${REPO_ROOT}/scripts/icc_traces/rosette.jsonl"
+
+mkdir -p "${SCRATCH_DIR}" "${NATIVE_DIR}" "$(dirname "${TRACE_FILE}")"
+
+fail_event() { # name snippet
+    local name="$1" snippet="$2"
+    eshkol_outcome_emit_event "${TRACE_FILE}" rosette "${name}" FAIL "${snippet}"
+    eshkol_outcome_emit_test_result "${TRACE_FILE}" "${name}" FAIL "${snippet}"
+}
+
+pass_event() { # name snippet
+    local name="$1" snippet="$2"
+    eshkol_outcome_emit_event "${TRACE_FILE}" rosette "${name}" PASS "${snippet}"
+    eshkol_outcome_emit_test_result "${TRACE_FILE}" "${name}" PASS "${snippet}"
+}
+
+# ── 1. SBCL availability ────────────────────────────────────────────────
+if ! command -v sbcl >/dev/null 2>&1; then
+    echo "sbcl not found on PATH." >&2
+    echo "  macOS: brew install sbcl" >&2
+    echo "  CI / Debian/Ubuntu: apt-get install -y sbcl" >&2
+    fail_event rosette_front_door_eshkol "sbcl not installed"
+    fail_event rosette_external_backends_eshkol "sbcl not installed"
+    exit 1
+fi
+
+# ── 2. Pinned clone of rosette-wire ──────────────────────────────────────
+if [ ! -d "${ROSETTE_DIR}/.git" ]; then
+    if [ -n "${ROSETTE_LOCAL_SOURCE}" ]; then
+        if [ ! -d "${ROSETTE_LOCAL_SOURCE}" ]; then
+            msg="ROSETTE_LOCAL_SOURCE_OVERRIDE=${ROSETTE_LOCAL_SOURCE} is absent"
+            echo "${msg}" >&2
+            fail_event rosette_front_door_eshkol "${msg}"
+            fail_event rosette_external_backends_eshkol "${msg}"
+            exit 1
+        fi
+        CLONE_FROM="${ROSETTE_LOCAL_SOURCE}"
+    else
+        CLONE_FROM="${ROSETTE_UPSTREAM_URL}"
+    fi
+    if ! git clone "${CLONE_FROM}" "${ROSETTE_DIR}"; then
+        msg="git clone of rosette-wire from ${CLONE_FROM} failed"
+        fail_event rosette_front_door_eshkol "${msg}"
+        fail_event rosette_external_backends_eshkol "${msg}"
+        exit 1
+    fi
+fi
+if ! git -C "${ROSETTE_DIR}" checkout --quiet "${ROSETTE_PIN_SHA}"; then
+    msg="git checkout of pinned rosette-wire commit ${ROSETTE_PIN_SHA} failed"
+    fail_event rosette_front_door_eshkol "${msg}"
+    fail_event rosette_external_backends_eshkol "${msg}"
+    exit 1
+fi
+
+# ── 3. eshkol-run: build fresh, or accept an already-built binary ──────
+# ESHKOL_RUN_BIN_OVERRIDE lets a caller point this gate at an already-built
+# eshkol-run (e.g. to avoid a long local rebuild during development) instead
+# of configuring/building this checkout. CI always builds fresh from THIS
+# tree so the oracle actually exercises the commit under test.
+if [ -n "${ESHKOL_RUN_BIN_OVERRIDE:-}" ]; then
+    if [ ! -x "${ESHKOL_RUN_BIN_OVERRIDE}" ]; then
+        msg="ESHKOL_RUN_BIN_OVERRIDE=${ESHKOL_RUN_BIN_OVERRIDE} is not an executable file"
+        fail_event rosette_front_door_eshkol "${msg}"
+        fail_event rosette_external_backends_eshkol "${msg}"
+        exit 1
+    fi
+    ESHKOL_RUN_BIN="${ESHKOL_RUN_BIN_OVERRIDE}"
+else
+    LLVM_MAJOR="${LLVM_MAJOR:-21}"
+    CMAKE_EXTRA_ARGS=()
+    if [ -n "${ESHKOL_LLVM_CONFIG_EXECUTABLE:-}" ] && [ -x "${ESHKOL_LLVM_CONFIG_EXECUTABLE}" ]; then
+        # CI (Linux): llvm-config-<major> is on PATH via apt, but not as the
+        # bare `llvm-config` CMake looks for by default — point at it explicitly.
+        CMAKE_EXTRA_ARGS+=("-DLLVM_CONFIG_EXECUTABLE=${ESHKOL_LLVM_CONFIG_EXECUTABLE}")
+    elif command -v brew >/dev/null 2>&1; then
+        LLVM_PREFIX="$(brew --prefix "llvm@${LLVM_MAJOR}" 2>/dev/null || true)"
+        if [ -n "${LLVM_PREFIX}" ] && [ -x "${LLVM_PREFIX}/bin/llvm-config" ]; then
+            export PATH="${LLVM_PREFIX}/bin:${PATH}"
+            CMAKE_EXTRA_ARGS+=("-DLLVM_CONFIG_EXECUTABLE=${LLVM_PREFIX}/bin/llvm-config")
+        fi
+    fi
+
+    if [ ! -d "${BUILD_DIR}" ]; then
+        # NOTE: ESHKOL_BUILD_AGENT_FFI cannot be turned off here even though this
+        # gate does not exercise agent FFI itself — eshkol-run's REPL JIT
+        # unconditionally registers qllm_ffi_*/qllm_process_* runtime symbols
+        # (lib/backend/repl_jit.cpp), so an AGENT_FFI=OFF configure fails to
+        # link eshkol-run. A first configure on a machine with no prior build/
+        # therefore pulls the (large, network-fetched) tree-sitter grammar set
+        # this option also gates; that is unavoidable without changing the
+        # compiler's own link closure, so it is accepted as one-time setup cost.
+        if ! nice -n 19 cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DESHKOL_REQUIRED_LLVM_MAJOR="${LLVM_MAJOR}" \
+            "${CMAKE_EXTRA_ARGS[@]}"; then
+            msg="cmake configure failed"
+            fail_event rosette_front_door_eshkol "${msg}"
+            fail_event rosette_external_backends_eshkol "${msg}"
+            exit 1
+        fi
+    fi
+    if ! nice -n 19 cmake --build "${BUILD_DIR}" --target eshkol-run --parallel; then
+        msg="eshkol-run build failed"
+        fail_event rosette_front_door_eshkol "${msg}"
+        fail_event rosette_external_backends_eshkol "${msg}"
+        exit 1
+    fi
+
+    ESHKOL_RUN_BIN="${BUILD_DIR}/eshkol-run"
+    if [ ! -x "${ESHKOL_RUN_BIN}" ]; then
+        msg="built eshkol-run binary not found at ${ESHKOL_RUN_BIN}"
+        fail_event rosette_front_door_eshkol "${msg}"
+        fail_event rosette_external_backends_eshkol "${msg}"
+        exit 1
+    fi
+fi
+
+export ROSETTE_ESHKOL_BIN="${ESHKOL_RUN_BIN}"
+export ROSETTE_ESHKOL_ID="$(cd "${REPO_ROOT}" && git describe --tags --always)"
+# eshkol-run resolves its standard library relative to ESHKOL_PATH; without
+# it a binary built into a different tree (or invoked from Rosette Wire's
+# own working directory) cannot find lib/. ESHKOL_PATH_OVERRIDE lets a
+# caller point this at a prebuilt tree's lib/ directory (paired with
+# ESHKOL_RUN_BIN_OVERRIDE above); otherwise default to this repo's own lib/.
+export ESHKOL_PATH="${ESHKOL_PATH_OVERRIDE:-${REPO_ROOT}/lib}"
+
+ASDF_CACHE_DIR="${SCRATCH_DIR}/asdf-cache"
+mkdir -p "${ASDF_CACHE_DIR}"
+
+# ── 4. tools/test-system front-door/eshkol ──────────────────────────────
+TEST_SYSTEM_OUT="${SCRATCH_DIR}/rosette-test-system.out"
+TEST_SYSTEM_ERR="${SCRATCH_DIR}/rosette-test-system.err"
+(
+    cd "${ROSETTE_DIR}" && \
+    nice -n 19 sbcl --script tools/test-system front-door/eshkol
+) >"${TEST_SYSTEM_OUT}" 2>"${TEST_SYSTEM_ERR}"
+TEST_SYSTEM_RC=$?
+
+if [ "${TEST_SYSTEM_RC}" -eq 0 ]; then
+    VERDICT_LINE="$(grep -Ei 'passed|success|[0-9]+ tests?, [0-9]+ failures?|ok' "${TEST_SYSTEM_OUT}" | tail -1)"
+    [ -n "${VERDICT_LINE}" ] || VERDICT_LINE="$(tail -1 "${TEST_SYSTEM_OUT}")"
+    pass_event rosette_front_door_eshkol "${VERDICT_LINE}"
+else
+    VERDICT_LINE="$(tail -5 "${TEST_SYSTEM_ERR}" "${TEST_SYSTEM_OUT}" 2>/dev/null | tr '\n' ' ')"
+    fail_event rosette_front_door_eshkol "exit ${TEST_SYSTEM_RC}: ${VERDICT_LINE}"
+fi
+
+# ── 5. examples/external-backends.lisp eshkol <dir> ─────────────────────
+EXT_OUT="${SCRATCH_DIR}/rosette-external-backends.out"
+EXT_ERR="${SCRATCH_DIR}/rosette-external-backends.err"
+(
+    cd "${ROSETTE_DIR}" && \
+    nice -n 19 sbcl --script examples/external-backends.lisp eshkol "${NATIVE_DIR}"
+) >"${EXT_OUT}" 2>"${EXT_ERR}"
+EXT_RC=$?
+
+if [ "${EXT_RC}" -eq 0 ]; then
+    VERDICT_LINE="$(grep -E '^eshkol: PASS' "${EXT_OUT}" | tail -1)"
+    [ -n "${VERDICT_LINE}" ] || VERDICT_LINE="$(tail -1 "${EXT_OUT}")"
+    pass_event rosette_external_backends_eshkol "${VERDICT_LINE}"
+else
+    VERDICT_LINE="$(grep -E 'External execution refused' "${EXT_ERR}" | tail -1)"
+    [ -n "${VERDICT_LINE}" ] || VERDICT_LINE="$(tail -5 "${EXT_ERR}" "${EXT_OUT}" 2>/dev/null | tr '\n' ' ')"
+    fail_event rosette_external_backends_eshkol "exit ${EXT_RC}: ${VERDICT_LINE}"
+fi
+
+echo "--- tools/test-system front-door/eshkol ---"
+cat "${TEST_SYSTEM_OUT}"
+echo "--- examples/external-backends.lisp eshkol ---"
+cat "${EXT_OUT}"
+
+if [ "${TEST_SYSTEM_RC}" -eq 0 ] && [ "${EXT_RC}" -eq 0 ]; then
+    exit 0
+fi
+exit 1


### PR DESCRIPTION
Rosette Wire (RichardHoekstra/rosette-wire, Apache-2.0) carries an Eshkol adapter that runs an admitted program dialect through its direct evaluator, its kernel VM, Eshkol's cache-disabled JIT and a separately compiled AOT artifact, and refuses on disagreement. This makes it a P7 external oracle for the release:

- scripts/run_rosette_oracle.sh clones Rosette at a pinned commit, points ROSETTE_ESHKOL_BIN at a fresh eshkol-run, runs tools/test-system front-door/eshkol and examples/external-backends.lisp, and emits one ICC runtime event per comparison (never SKIP: a missing SBCL or a Rosette refusal is FAIL with the reason).
- scripts/lib/rosette_receipt.py writes a Rosette receipt from an ICC trace so Rose Workbench can render a gate run; bin/rosette describe accepts it and refuses a forged schema.
- Criterion rosette_front_door_eshkol on the v1.3.5-evolve oracle; advisory rosette-oracle CI job (ubuntu, continue-on-error, not a required context).

Observed: front-door 30 passes 0 failures; external-backends PASS (native execution, saved evidence, native replay, tamper refusal); a wrapped eshkol-run returning 721 for 30 is refused and the gate exits 1. Rosette's isolated worker uses prlimit, so the lane is Linux-only by design; documented in the script header.