### PR TITLE
test(io): add ESKT tensor-file four-engine cross-reader matrix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5571,6 +5571,16 @@ if(ESHKOL_BUILD_TESTS AND NOT WIN32)
     set_tests_properties(eshkol_vm_standalone_smoke PROPERTIES
         ENVIRONMENT "ESHKOL_VM_NO_DISASM=1")
 
+    if(ESHKOL_PYTHON3_EXECUTABLE AND TARGET eshkol-run)
+        add_test(NAME eskt_tensor_engine_parity
+                 COMMAND ${ESHKOL_PYTHON3_EXECUTABLE}
+                         ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_eskt_engine_parity.py
+                         $<TARGET_FILE:eshkol-run> $<TARGET_FILE:eshkol-vm-standalone-test>
+                         --self-test)
+        set_tests_properties(eskt_tensor_engine_parity PROPERTIES
+            TIMEOUT 1500 LABELS "serialization;parity")
+    endif()
+
     if(TARGET eshkol-run AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/memory/memory_store_durability_test.sh")
         add_test(
             NAME memory_store_cross_engine_durability

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5571,16 +5571,6 @@ if(ESHKOL_BUILD_TESTS AND NOT WIN32)
     set_tests_properties(eshkol_vm_standalone_smoke PROPERTIES
         ENVIRONMENT "ESHKOL_VM_NO_DISASM=1")
 
-    if(ESHKOL_PYTHON3_EXECUTABLE AND TARGET eshkol-run)
-        add_test(NAME eskt_tensor_engine_parity
-                 COMMAND ${ESHKOL_PYTHON3_EXECUTABLE}
-                         ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_eskt_engine_parity.py
-                         $<TARGET_FILE:eshkol-run> $<TARGET_FILE:eshkol-vm-standalone-test>
-                         --self-test)
-        set_tests_properties(eskt_tensor_engine_parity PROPERTIES
-            TIMEOUT 1500 LABELS "serialization;parity")
-    endif()
-
     if(TARGET eshkol-run AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/memory/memory_store_durability_test.sh")
         add_test(
             NAME memory_store_cross_engine_durability
@@ -7786,6 +7776,18 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
         TIMEOUT 1200
         PASS_REGULAR_EXPRESSION "ALL TESTS PASSED!"
         FAIL_REGULAR_EXPRESSION "FAIL -|SOME TESTS FAILED|LLVM module verification failed|fatal signal")
+endif()
+
+# Public ESKT tensor-file parity requires both native and VM test executables.
+if(ESHKOL_BUILD_TESTS AND NOT WIN32 AND ESHKOL_PYTHON3_EXECUTABLE AND
+   TARGET eshkol-run AND TARGET eshkol-vm-standalone-test)
+    add_test(NAME eskt_tensor_engine_parity
+             COMMAND ${ESHKOL_PYTHON3_EXECUTABLE}
+                     ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_eskt_engine_parity.py
+                     $<TARGET_FILE:eshkol-run> $<TARGET_FILE:eshkol-vm-standalone-test>
+                     --self-test)
+    set_tests_properties(eskt_tensor_engine_parity PROPERTIES
+        TIMEOUT 1500 LABELS "serialization;parity")
 endif()
 
 # where to find our CMake modules

--- a/docs/reference/tensors/INDEX.md
+++ b/docs/reference/tensors/INDEX.md
@@ -13,6 +13,7 @@ against their behavior, not hidden.
 | [operations.md](operations.md) | Shape ops, elementwise & unary math, linear algebra + decompositions, reductions, conv1d/2d/3d, pooling, normalization, attention, embedding, activations, the PR-#79 type guards, pixel fills, and save/load — with known-broken ops flagged. |
 | [gpu.md](gpu.md) | Honest GPU-dispatch status: the `gpu-*` builtins, the cost-model threshold, what actually runs on Metal in `-r` vs AOT, and how that squares with ESH-0022/0023. |
 | [ml-modules.md](ml-modules.md) | `ml.optimization`, `core.manifold`, `signal.fft` — every `provide` with signature and a run example. |
+| [eskt-engine-parity.md](eskt-engine-parity.md) | ESKT tensor-file 4 × 4 producer/consumer test, exact byte oracle, and scope. |
 
 ## Two containers at a glance
 

--- a/docs/reference/tensors/eskt-engine-parity.md
+++ b/docs/reference/tensors/eskt-engine-parity.md
@@ -1,0 +1,63 @@
+# ESKT tensor-file engine parity
+
+`scripts/run_eskt_engine_parity.py` tests the public `tensor-save` / `tensor-load`
+path across native JIT, native AOT, VM source, and VM bytecode. Each engine
+produces three files; each of the four consumers loads and rewrites all twelve
+producer files. This is a literal 4 × 4 matrix with 48 consumer rewrites.
+
+The fixture uses small f64 tensors of shapes `(6)`, `(2 3)`, and
+`(1 1 1 1 1 1 1 2)`. Every producer and consumer checks tensor identity, rank,
+dimensions, element count via `vector-length` of `tensor-data`, and f64 dtype.
+Native dtype is a symbol and VM dtype is a string; the fixture accepts those
+representations of the same f64 type. Python independently encodes expected
+files and compares every producer output and consumer rewrite byte for byte,
+including signed zero and fractional payload values. Runtime success requires
+exactly one success marker and no failure marker, as well as a zero exit code.
+
+## Format scope
+
+This tests **ESKT v1 tensor files**, distinct from **ESKM model checkpoints**.
+The current public VM dispatch uses IDs 1820/1821. The older model-I/O helper
+IDs 802/803 do not identify this public path.
+
+The implemented ESKT layout is host-endian: uint32 magic `0x45534B54`, uint32
+version `1`, uint32 rank, one int64 per dimension, then one binary64 per
+element. On little-endian hosts the magic bytes spell `TKSE`. There is no
+dtype field, stored element-count field, or checksum. The oracle uses fixed
+integer widths without alignment padding and the host's byte order, matching
+the existing implementation. It does not assert cross-endian portability or
+preservation of other dtypes.
+
+Only valid modest inputs are read. Scalar/empty tensors, malformed-file
+rejection, fuzzing, resource limits, atomic replacement, and format or API
+changes are outside this test. It supplies the ESKT positive cross-reader
+portion of GK-SER-03, not the entire roadmap packet's negative matrix.
+
+## Run
+
+```sh
+cmake --build build --target eshkol-run eshkol-vm-standalone-test --parallel 2
+python3 scripts/run_eskt_engine_parity.py \
+  build/eshkol-run build/eshkol-vm-standalone-test --self-test
+ctest --test-dir build --output-on-failure -R '^eskt_tensor_engine_parity$'
+```
+
+`--self-test` additionally requires 48 refusals by the byte oracle, one for
+each rewrite, with deliberately incorrect expected payload bytes. It changes
+only Python expectations in memory, never the files consumed by Eshkol.
+CTest includes these controls. Compilation happens once for AOT and bytecode;
+all execution and file outputs use a fresh isolated directory. The runner
+accepts explicit executable paths, `--timeout` per invocation, `--keep`, and
+`ESHKOL_TEST_TMPDIR` / `ESHKOL_TEST_TMP_ROOT` for the temporary parent.
+Failures retain logs and files; successful runs clean up unless retention is
+requested with `--keep` or `ESHKOL_TEST_KEEP_TMPDIR`.
+
+Exit 0 means PASS, 1 means FAIL, and 125 means INFRA (missing executables,
+timeout, interrupted process, or filesystem failure). INFRA does not count as
+a CTest pass or skip. Native Windows is excluded from CTest registration
+because the current native ESKT implementation is disabled there; execution
+on macOS and other platforms must be verified separately.
+
+This test is independent of the ESKM corpus/matrix (#596/#597) and atomic-save
+implementation (#600); it needs none of their fixtures, scripts, or runtime
+changes. It does not emit release or ICC evidence.

--- a/scripts/run_eskt_engine_parity.py
+++ b/scripts/run_eskt_engine_parity.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Valid ESKT 4x4 producer/consumer matrix; no malformed inputs are executed."""
+
+import argparse
+import math
+import os
+from pathlib import Path
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "tests/core/eskt_engine_parity.esk"
+ENGINES = ("jit", "aot", "vm-source", "vm-bytecode")
+CASES = {
+    "vector": ((6,), (1.5, -2.0, 0.0, -0.0, 0.125, 1024.5)),
+    "matrix": ((2, 3), (3.0, -4.5, 8.0, 0.25, -16.0, 2.0)),
+    "rank8": ((1, 1, 1, 1, 1, 1, 1, 2), (-0.5, 7.25)),
+}
+
+
+class Failure(Exception):
+    pass
+
+
+class Infrastructure(Exception):
+    pass
+
+
+def expected_bytes(shape, values):
+    # '=': host byte order, fixed widths, no alignment. ESKT v1 has no dtype
+    # or count field; payload is binary64 and count is the shape product.
+    assert math.prod(shape) == len(values)
+    return (struct.pack("=III", 0x45534B54, 1, len(shape))
+            + struct.pack(f"={len(shape)}q", *shape)
+            + struct.pack(f"={len(values)}d", *values))
+
+
+def verify_bytes(path, expected):
+    if not path.is_file():
+        raise Failure(f"missing output: {path}")
+    actual = path.read_bytes()
+    if actual != expected:
+        raise Failure(f"exact file bytes differ: {path} "
+                      f"(actual {len(actual)}, expected {len(expected)} bytes)")
+
+
+def run(command, directory, label, env, timeout, marker=False):
+    with (directory / f"{label}.stdout").open("w") as out, \
+         (directory / f"{label}.stderr").open("w") as err:
+        try:
+            result = subprocess.run(command, cwd=directory, env=env,
+                                    stdout=out, stderr=err, timeout=timeout)
+        except subprocess.TimeoutExpired as exc:
+            raise Infrastructure(f"{label} timed out after {timeout}s") from exc
+    if result.returncode:
+        if result.returncode in (-9, -2, 125, 127):
+            raise Infrastructure(f"{label} exited {result.returncode}")
+        raise Failure(f"{label} exited {result.returncode}")
+    if marker:
+        lines = (directory / f"{label}.stdout").read_text().splitlines()
+        if lines.count("ESKT-PARITY:PASS") != 1 or any("FAIL" in line for line in lines):
+            raise Failure(f"{label} semantic checks did not pass")
+
+
+def matrix(args, work):
+    compiler, vm = args.compiler.resolve(), args.vm.resolve()
+    for binary in (compiler, vm):
+        if not binary.is_file() or not os.access(binary, os.X_OK):
+            raise Infrastructure(f"missing executable: {binary}")
+    env = dict(os.environ, ESHKOL_VM_NO_DISASM="1")
+    env["ESHKOL_PATH"] = str(ROOT / "lib") + os.pathsep + env.get("ESHKOL_PATH", "")
+    aot, bytecode = work / "fixture-aot", work / "fixture.eskb"
+    run([str(compiler), "--no-stdlib", str(SOURCE), "-o", str(aot),
+         f"-L{compiler.parent}"], work, "compile-aot", env, args.timeout)
+    run([str(compiler), "--profile", "hosted-vm", "--emit-eskb", str(bytecode),
+         str(SOURCE)], work, "compile-bytecode", env, args.timeout)
+    if not aot.is_file() or not bytecode.is_file() or not bytecode.stat().st_size:
+        raise Failure("compiler did not create executable/bytecode")
+    commands = {
+        "jit": [str(compiler), "--no-stdlib", "-r", str(SOURCE), f"-L{compiler.parent}"],
+        "aot": [str(aot)],
+        "vm-source": [str(vm), str(SOURCE)],
+        "vm-bytecode": [str(vm), str(bytecode)],
+    }
+    expected = {name: expected_bytes(*case) for name, case in CASES.items()}
+    for producer in ENGINES:
+        directory = work / f"produce-{producer}"
+        directory.mkdir()
+        run(commands[producer], directory, "produce", dict(env, ESKT_PARITY_MODE="produce"),
+            args.timeout, marker=True)
+        for name, data in expected.items():
+            verify_bytes(directory / f"{name}.eskt", data)
+        print(f"PASS: {producer} producer: 3 exact ESKT files", flush=True)
+
+    negative_count = 0
+    for consumer in ENGINES:
+        directory = work / f"consume-{consumer}"
+        directory.mkdir()
+        for producer in ENGINES:
+            for name in CASES:
+                shutil.copyfile(work / f"produce-{producer}" / f"{name}.eskt",
+                                directory / f"{producer}-{name}.eskt")
+        run(commands[consumer], directory, "consume", dict(env, ESKT_PARITY_MODE="consume"),
+            args.timeout, marker=True)
+        for producer in ENGINES:
+            for name, data in expected.items():
+                # Check the input copy is unchanged, as well as the independently
+                # reserialized loaded tensor. Neither comparison is text based.
+                verify_bytes(directory / f"{producer}-{name}.eskt", data)
+                output = directory / f"rewrite-{producer}-{name}.eskt"
+                verify_bytes(output, data)
+                if args.self_test:
+                    # Change ONLY Python's expectation, never a file given to a reader.
+                    wrong = data[:-1] + bytes([data[-1] ^ 1])
+                    try:
+                        verify_bytes(output, wrong)
+                    except Failure:
+                        negative_count += 1
+                    else:
+                        raise Failure(f"incorrect expected bytes accepted: {output}")
+            print(f"PASS: {producer} -> {consumer}: metadata and 3 exact rewrites", flush=True)
+    if args.self_test:
+        if negative_count != 48:
+            raise Failure(f"incomplete negative controls: {negative_count}/48")
+        print("PASS: 48/48 incorrect expected-byte oracles refused (valid files unchanged)")
+    print("PASS: ESKT producer/consumer matrix 16/16; 12 producer files, 48 rewrites")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("compiler", type=Path, nargs="?", default=ROOT / "build/eshkol-run")
+    parser.add_argument("vm", type=Path, nargs="?", default=ROOT / "build/eshkol-vm-standalone-test")
+    parser.add_argument("--self-test", action="store_true",
+                        help="also require refusal of wrong Python byte expectations")
+    parser.add_argument("--timeout", type=int, default=120, help="seconds per engine invocation")
+    parser.add_argument("--keep", action="store_true", help="retain isolated outputs and logs")
+    args = parser.parse_args()
+    if args.timeout <= 0:
+        parser.error("--timeout must be positive")
+    work = None
+    keep = args.keep or bool(os.environ.get("ESHKOL_TEST_KEEP_TMPDIR"))
+    try:
+        base = os.environ.get("ESHKOL_TEST_TMPDIR") or os.environ.get("ESHKOL_TEST_TMP_ROOT")
+        work = Path(tempfile.mkdtemp(prefix="eshkol-eskt-parity-", dir=base)).resolve()
+        matrix(args, work)
+        return 0
+    except Failure as exc:
+        keep = True
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+    except (Infrastructure, OSError) as exc:
+        keep = True
+        print(f"INFRA: {exc}", file=sys.stderr)
+        return 125
+    finally:
+        if work:
+            if keep:
+                print(f"ESKT artifacts: {work}", file=sys.stderr)
+            else:
+                shutil.rmtree(work)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/core/eskt_engine_parity.esk
+++ b/tests/core/eskt_engine_parity.esk
@@ -1,0 +1,54 @@
+;; Valid ESKT files only. The Python harness independently checks all file bytes.
+(define failures 0)
+(define (rank shape)
+  (if (null? shape) 0 (+ 1 (rank (cdr shape)))))
+(define (check name ok)
+  (if ok #t
+      (begin (set! failures (+ failures 1))
+             (display "FAIL: ") (display name) (newline))))
+
+(define (check-tensor name t shape count)
+  (check name (tensor? t))
+  (if (tensor? t)
+      (begin
+        (check "rank" (= (rank (tensor-shape t)) (rank shape)))
+        (check "dimensions" (equal? (tensor-shape t) shape))
+        (check "element count" (= (vector-length (tensor-data t)) count))
+        ;; Native returns a symbol; VM returns a string for the same dtype.
+        (check "dtype" (or (equal? (tensor-dtype t) 'f64)
+                           (equal? (tensor-dtype t) "f64"))))
+      #f))
+
+(define (produce-one name t shape count)
+  (check-tensor name t shape count)
+  (check "save" (tensor-save (string-append name ".eskt") t)))
+
+(define (consume-one producer name shape count)
+  (let* ((stem (string-append producer "-" name))
+         (t (tensor-load (string-append stem ".eskt"))))
+    (check-tensor stem t shape count)
+    (if (tensor? t)
+        (check "rewrite" (tensor-save (string-append "rewrite-" stem ".eskt") t))
+        #f)))
+
+(define (consume producer)
+  (consume-one producer "vector" '(6) 6)
+  (consume-one producer "matrix" '(2 3) 6)
+  (consume-one producer "rank8" '(1 1 1 1 1 1 1 2) 2))
+
+(if (equal? (getenv "ESKT_PARITY_MODE") "produce")
+    (begin
+      (produce-one "vector" (tensor 6 1.5 -2.0 0.0 -0.0 0.125 1024.5) '(6) 6)
+      (produce-one "matrix" (reshape (tensor 6 3.0 -4.5 8.0 0.25 -16.0 2.0) '(2 3))
+                   '(2 3) 6)
+      (produce-one "rank8" (reshape (tensor 2 -0.5 7.25) '(1 1 1 1 1 1 1 2))
+                   '(1 1 1 1 1 1 1 2) 2))
+    (begin
+      (consume "jit")
+      (consume "aot")
+      (consume "vm-source")
+      (consume "vm-bytecode")))
+
+(if (= failures 0)
+    (begin (display "ESKT-PARITY:PASS") (newline))
+    (begin (display "ESKT-PARITY:FAIL") (newline)))


### PR DESCRIPTION
The public ESKT tensor-file path lacked a literal cross-reader matrix: #600 checks tensor writers and same-engine reads, while #597's 4×4 matrix covers ESKM models. This adds each native JIT, native AOT, VM source, and VM bytecode producer to every consumer, with three small f64 tensors per pair.

Each engine asserts tensor identity, rank, dimensions, element count, and f64 dtype. An independent Python oracle compares all 12 producer files and 48 consumer rewrites against exact expected host-endian ESKT v1 bytes, including signed zero. The runner also verifies that each consumer leaves its input copies unchanged. CTest runs the matrix and 48 negative controls that change only Python's expected bytes; no malformed file is given to any reader.

## Revision and dependencies

- Head: `44b366442f1d60d39dfdb63b2033e7ebbbb0672d` (`codex/eskt-cross-engine-matrix`).
- Base and fetched upstream master: `5ce74beeac25aca56c0c8129083e6db77f96f7dc`.
- No dependency on #596, #597, #600, or their fixtures/runtime changes. Current source inspection confirms public VM tensor I/O IDs 1820/1821, distinct from old model-I/O helper IDs 802/803.
- Five files only: fixture, runner, CTest registration, and reference documentation/index. No reader/writer, policy/API, generated artifacts, ICC, or release-workflow changes.

## Verification

PASS at initial implementation head `0e3c54c2648b7ef7f570e0b5062d87b40a6078b0` on a private Linux Release build with LLVM 21.1.8 / Clang 22.1.6, BLAS/GPU/agent FFI disabled, maximum two compiler jobs:

```sh
cmake --build .scratch/eskt-build --target eshkol-run eshkol-vm-standalone-test \
  model_io_test eshkol-vm-prelude-cache-gen --parallel 2
ctest --test-dir .scratch/eskt-build --output-on-failure \
  -R '^(eskt_tensor_engine_parity|model_io_test|vm_canonical_stdlib_surface_smoke|vm_prelude_cache_is_current)$'
```

- **PASS:** 4/4 focused CTests. Matrix: 16/16 pairs, 12 exact producer files, 48 exact consumer rewrites, 48/48 wrong expected-byte refusals.
- **PASS:** direct runner with `--self-test --keep`, Python compilation, test-coverage inventory, API-doc freshness, `git diff --check`, and read-only harness review.
- **FAIL:** none in final focused verification. Initial setup used the wrong system LLVM, then explicitly selected LLVM 21; the first prelude-cache attempt lacked its generator binary, resolved by building that target. An initial fixture compile needed a local list-rank helper for `--no-stdlib`; the committed fixture passes.
- **NOT RUN:** full repository test battery, macOS/Windows runtime, cross-endian interoperability, required GitHub CI acceptance. Native Windows CTest registration is excluded because current native ESKT I/O is disabled there.

This closes the bounded positive ESKT cross-reader coverage gap in GK-SER-03. It does not claim the entire roadmap packet accepted: ESKT has implicit binary64 dtype and no stored dtype/count fields; scalar/empty tensors, malformed-input rejection, fuzz/resource campaigns, and atomic-save guarantees remain outside this PR.


## Additive CMake compatibility follow-up

Head `44b366442f1d60d39dfdb63b2033e7ebbbb0672d` moves the ESKT registration to its own guarded block near the end of CMakeLists.txt. This removes the shared insertion-anchor conflict with #597/#600 while preserving every test command, timeout, label, and platform condition. The runtime and fixture are unchanged; master remains the base, with no stacked implementation dependency.

**PASS:** CMake reconfiguration and the same four focused CTests (including all 16 matrix pairs and 48 negative controls), plus `git diff --check`. These checks reused the private runtime build described above; no runtime rebuild was needed for this registration-only relocation.

**PASS:** `git merge-tree --write-tree` from the current head against each fetched exact revision (textual merge compatibility only, not combined runtime acceptance):

| Target | Exact SHA |
|---|---|
| master | `5ce74beeac25aca56c0c8129083e6db77f96f7dc` |
| #596 | `5ad058b2bc416c97a76c21f246d6b3bb4044b48f` |
| #597 (original audited head) | `9bf46a4b6b5a795eb0203c4e6d60cebd3606f080` |
| #597 (latest relocation, also PASS) | `fc22ceb200de5919c0476a76d577878a47ad74c6` |
| #598 | `7c88d8648189727b4794a1b18972f06e2b99aea0` |
| #600 | `83467dde5fc6ac427436d457d821af094238a93b` |
| #613 | `2d85dc648d3088ebb75dcfd35f076c9efd7daedc` |
| #614 | `fc2ae7be9f9ca376fde6e402e4adc22d9c916f60` |
| #616 | `2d561aed9edaf77f609b991b15eebbf841a8e05e` |

**FAIL:** none in these final checks. **NOT RUN:** combined runtime builds of those PR pairs, full suite, other platforms, or required GitHub CI acceptance. Inherited generated-document conflicts involving #601/#602 are outside this focused follow-up and were not modified.
