### PR TITLE
test(model-io): add ESKM v1 cross-engine parity gate

### DIFF
--- a/.icc/completion-oracles.yaml
+++ b/.icc/completion-oracles.yaml
@@ -1661,6 +1661,14 @@ oracles:
         label: 'Engine semantic parity evaluates its measured allowed thresholds: differential construct coverage stays at or above the recorded floor, new divergent programs stay at the allowed count of zero, and VM regressions remain zero (scripts/check_engine_parity_threshold.py)'
         action: python3 scripts/check_engine_parity_threshold.py
 
+      - runtime_event:
+          event_kinds: [eshkol_smoke]
+          event_names: ["eskm_v1_model_load_engine_parity"]
+          event_values: ["PASS"]
+        severity: high
+        label: 'ESKM v1: all 16 producer->consumer engine pairings agree byte-for-byte'
+        action: ./scripts/run_eskm_v1_model_load_parity.sh
+
       - test_evidence: true
         severity: high
         label: 'The v1.3.5 documentation suite inventory is generated from scripts/run_all_tests.sh and its documented suite rows cannot drift (scripts/check_test_coverage.py)'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5609,6 +5609,22 @@ if(ESHKOL_BUILD_TESTS AND NOT WIN32)
     set_tests_properties(eshkol_vm_standalone_smoke PROPERTIES
         ENVIRONMENT "ESHKOL_VM_NO_DISASM=1")
 
+    if(TARGET eshkol-run AND
+       EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_eskm_v1_model_load_parity.sh")
+        add_test(
+            NAME eskm_v1_model_load_engine_parity
+            COMMAND bash
+                    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_eskm_v1_model_load_parity.sh"
+                    "$<TARGET_FILE:eshkol-run>"
+                    "$<TARGET_FILE:eshkol-vm-standalone-test>"
+        )
+        set_tests_properties(eskm_v1_model_load_engine_parity
+            PROPERTIES
+                TIMEOUT 900
+                PASS_REGULAR_EXPRESSION "PASS: ESKM v1 model-load parity"
+                FAIL_REGULAR_EXPRESSION "FAIL:")
+    endif()
+
     if(TARGET eshkol-run AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/memory/memory_store_durability_test.sh")
         add_test(
             NAME memory_store_cross_engine_durability

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5609,36 +5609,6 @@ if(ESHKOL_BUILD_TESTS AND NOT WIN32)
     set_tests_properties(eshkol_vm_standalone_smoke PROPERTIES
         ENVIRONMENT "ESHKOL_VM_NO_DISASM=1")
 
-    if(TARGET eshkol-run AND
-       EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_eskm_v1_model_load_parity.sh")
-        add_test(
-            NAME eskm_v1_model_load_engine_parity
-            COMMAND bash
-                    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_eskm_v1_model_load_parity.sh"
-                    "$<TARGET_FILE:eshkol-run>"
-                    "$<TARGET_FILE:eshkol-vm-standalone-test>"
-        )
-        set_tests_properties(eskm_v1_model_load_engine_parity
-            PROPERTIES
-                TIMEOUT 900
-                PASS_REGULAR_EXPRESSION "PASS: ESKM v1 model-load parity"
-                FAIL_REGULAR_EXPRESSION "FAIL:")
-
-        add_test(
-            NAME eskm_v1_model_load_engine_parity_selftest
-            COMMAND bash
-                    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_eskm_v1_model_load_parity.sh"
-                    --self-test
-                    "$<TARGET_FILE:eshkol-run>"
-                    "$<TARGET_FILE:eshkol-vm-standalone-test>"
-        )
-        set_tests_properties(eskm_v1_model_load_engine_parity_selftest
-            PROPERTIES
-                TIMEOUT 900
-                PASS_REGULAR_EXPRESSION "PASS: ESKM v1 matrix negative controls"
-                FAIL_REGULAR_EXPRESSION "FAIL:")
-    endif()
-
     if(TARGET eshkol-run AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/memory/memory_store_durability_test.sh")
         add_test(
             NAME memory_store_cross_engine_durability
@@ -5964,6 +5934,37 @@ endif()
                 PASS_REGULAR_EXPRESSION "PASS: operator rebinding shadows builtin dispatch"
                 FAIL_REGULAR_EXPRESSION "FAIL:|undefined variable|fatal runtime error")
     endif()
+endif()
+
+if(ESHKOL_BUILD_TESTS AND NOT WIN32 AND
+   TARGET eshkol-run AND TARGET eshkol-vm-standalone-test AND
+   EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_eskm_v1_model_load_parity.sh")
+    add_test(
+        NAME eskm_v1_model_load_engine_parity
+        COMMAND bash
+                "${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_eskm_v1_model_load_parity.sh"
+                "$<TARGET_FILE:eshkol-run>"
+                "$<TARGET_FILE:eshkol-vm-standalone-test>"
+    )
+    set_tests_properties(eskm_v1_model_load_engine_parity
+        PROPERTIES
+            TIMEOUT 900
+            PASS_REGULAR_EXPRESSION "PASS: ESKM v1 model-load parity"
+            FAIL_REGULAR_EXPRESSION "FAIL:")
+
+    add_test(
+        NAME eskm_v1_model_load_engine_parity_selftest
+        COMMAND bash
+                "${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_eskm_v1_model_load_parity.sh"
+                --self-test
+                "$<TARGET_FILE:eshkol-run>"
+                "$<TARGET_FILE:eshkol-vm-standalone-test>"
+    )
+    set_tests_properties(eskm_v1_model_load_engine_parity_selftest
+        PROPERTIES
+            TIMEOUT 900
+            PASS_REGULAR_EXPRESSION "PASS: ESKM v1 matrix negative controls"
+            FAIL_REGULAR_EXPRESSION "FAIL:")
 endif()
 
 # R7RS-small 5.6.1: a `define-library` in the compilation unit being compiled

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5623,6 +5623,20 @@ if(ESHKOL_BUILD_TESTS AND NOT WIN32)
                 TIMEOUT 900
                 PASS_REGULAR_EXPRESSION "PASS: ESKM v1 model-load parity"
                 FAIL_REGULAR_EXPRESSION "FAIL:")
+
+        add_test(
+            NAME eskm_v1_model_load_engine_parity_selftest
+            COMMAND bash
+                    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_eskm_v1_model_load_parity.sh"
+                    --self-test
+                    "$<TARGET_FILE:eshkol-run>"
+                    "$<TARGET_FILE:eshkol-vm-standalone-test>"
+        )
+        set_tests_properties(eskm_v1_model_load_engine_parity_selftest
+            PROPERTIES
+                TIMEOUT 900
+                PASS_REGULAR_EXPRESSION "PASS: ESKM v1 matrix negative controls"
+                FAIL_REGULAR_EXPRESSION "FAIL:")
     endif()
 
     if(TARGET eshkol-run AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/memory/memory_store_durability_test.sh")

--- a/docs/reference/tensors/eskm-v1.md
+++ b/docs/reference/tensors/eskm-v1.md
@@ -122,22 +122,32 @@ python3 scripts/check_eskm_v1_fixtures.py
 python3 scripts/check_eskm_v1_fixtures.py --self-test
 ```
 
-With Eshkol and the standalone VM built, exercise the backend-common model
-loader subset through native JIT, native AOT, VM source, and VM bytecode:
+With Eshkol and the standalone VM built, exercise the backend-common model-I/O
+subset through native JIT, native AOT, VM source, and VM bytecode:
 
 ```bash
 scripts/run_eskm_v1_model_load_parity.sh
 scripts/run_eskm_v1_model_load_parity.sh --self-test
 ```
 
-The parity gate checks `ordinary-2x3.eskm`, `rank8.eskm`, and
-`multi-tensor.eskm`, plus every rejected fixture. It also rewrites each
-accepted input through `model-save` and requires byte-for-byte identity, which
-checks payload bits that cannot be observed through numeric equality (including
-negative zero and the NaN payload). The scalar and zero-extent fixtures remain
-format-checker cases rather than cross-engine runtime cases because the current
-VM cannot materialize those shapes; this is an implementation limit described
-above, not a different wire-format rule.
+The parity gate is a literal 4 producer x 4 consumer matrix. Each engine writes
+the same ordered two-tensor model, and the harness first requires all four
+outputs to be byte-identical to the historical `multi-tensor.eskm` fixture.
+Each engine then loads every producer's output and checks record names and
+order, rank and dimensions, f64 dtype, element count where the engine exposes
+it, and every payload value. Every consumer also rewrites every producer's
+file, and the harness requires byte-for-byte identity. Thus all 16
+producer-to-consumer cells are executed rather than inferred from independent
+reads of one canonical file.
+
+Each consumer additionally checks `ordinary-2x3.eskm`, `rank8.eskm`, and
+`multi-tensor.eskm`, rejects every malformed fixture, and exactly rewrites the
+accepted inputs. The byte comparisons cover payload properties that numeric
+equality cannot observe, including negative zero and the NaN payload. The
+scalar and zero-extent fixtures remain format-checker cases rather than
+cross-engine runtime cases because the current VM cannot materialize those
+shapes; this is an implementation limit described above, not a different
+wire-format rule.
 
 The checker's 64 KiB per-file ceiling is an immutable-corpus policy, not an
 ESKM format size limit. The checked-in corpus is 9,160 bytes total and its
@@ -146,7 +156,10 @@ largest file is 8,237 bytes. `large-32x32.eskm` covers a bounded larger payload:
 `0 <= i < 1024`. Its exact bit patterns are recorded in the manifest, alongside
 the scalar, zero-extent, ordinary, rank-8, and multi-tensor cases.
 
-The self-test copies the corpus to a temporary directory, changes a scalar
-payload bit, recomputes its CRC-32 and manifest SHA-256, and requires the normal
-checker to reject the changed bit pattern. It never modifies the committed
-fixtures.
+The fixture checker's self-test copies the corpus to a temporary directory,
+changes a scalar payload bit, recomputes its CRC-32 and manifest SHA-256, and
+requires the normal checker to reject the changed bit pattern. The runtime
+matrix self-test separately substitutes a valid but structurally wrong
+producer file and a valid file where a malformed fixture is expected. Every
+consumer must reject both controls with exit status 1 and the exact named
+failure. Neither self-test modifies the committed fixtures.

--- a/docs/reference/tensors/eskm-v1.md
+++ b/docs/reference/tensors/eskm-v1.md
@@ -122,6 +122,23 @@ python3 scripts/check_eskm_v1_fixtures.py
 python3 scripts/check_eskm_v1_fixtures.py --self-test
 ```
 
+With Eshkol and the standalone VM built, exercise the backend-common model
+loader subset through native JIT, native AOT, VM source, and VM bytecode:
+
+```bash
+scripts/run_eskm_v1_model_load_parity.sh
+scripts/run_eskm_v1_model_load_parity.sh --self-test
+```
+
+The parity gate checks `ordinary-2x3.eskm`, `rank8.eskm`, and
+`multi-tensor.eskm`, plus every rejected fixture. It also rewrites each
+accepted input through `model-save` and requires byte-for-byte identity, which
+checks payload bits that cannot be observed through numeric equality (including
+negative zero and the NaN payload). The scalar and zero-extent fixtures remain
+format-checker cases rather than cross-engine runtime cases because the current
+VM cannot materialize those shapes; this is an implementation limit described
+above, not a different wire-format rule.
+
 The checker's 64 KiB per-file ceiling is an immutable-corpus policy, not an
 ESKM format size limit. The checked-in corpus is 9,160 bytes total and its
 largest file is 8,237 bytes. `large-32x32.eskm` covers a bounded larger payload:

--- a/docs/reference/tensors/eskm-v1.md
+++ b/docs/reference/tensors/eskm-v1.md
@@ -140,13 +140,14 @@ file, and the harness requires byte-for-byte identity. Thus all 16
 producer-to-consumer cells are executed rather than inferred from independent
 reads of one canonical file.
 
-Each consumer additionally checks `ordinary-2x3.eskm`, `rank8.eskm`, and
-`multi-tensor.eskm`, rejects every malformed fixture, and exactly rewrites the
-accepted inputs. The byte comparisons cover payload properties that numeric
-equality cannot observe, including negative zero and the NaN payload. The
-scalar and zero-extent fixtures remain format-checker cases rather than
-cross-engine runtime cases because the current VM cannot materialize those
-shapes; this is an implementation limit described above, not a different
+Each consumer additionally checks `ordinary-2x3.eskm`, `large-32x32.eskm`,
+`rank8.eskm`, and `multi-tensor.eskm`, rejects every malformed fixture, and
+exactly rewrites the accepted inputs. The byte comparisons cover payload
+properties that numeric equality cannot observe, including negative zero and
+the NaN payload. The 32-by-32 fixture also checks every one of its 1,024 finite
+payload values. The scalar and zero-extent fixtures remain format-checker
+cases rather than cross-engine runtime cases because the current VM cannot
+materialize those shapes; this is an implementation limit described above, not a different
 wire-format rule.
 
 The checker's 64 KiB per-file ceiling is an immutable-corpus policy, not an
@@ -162,4 +163,7 @@ requires the normal checker to reject the changed bit pattern. The runtime
 matrix self-test separately substitutes a valid but structurally wrong
 producer file and a valid file where a malformed fixture is expected. Every
 consumer must reject both controls with exit status 1 and the exact named
-failure. Neither self-test modifies the committed fixtures.
+failure. A third control changes only the expected final value of the larger
+fixture. Every consumer must report that payload mismatch, proving the payload
+callback executes independently of the exact byte comparisons. Neither
+self-test modifies the committed fixtures.

--- a/scripts/run_eskm_v1_model_load_parity.sh
+++ b/scripts/run_eskm_v1_model_load_parity.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Run the ESKM v1 model-load oracle through native JIT/AOT and VM source/ESKB.
+# Gate the literal ESKM v1 4-producer x 4-consumer engine matrix.
 
 set -u
 
@@ -12,6 +12,17 @@ VM="${2:-$BUILD_DIR/eshkol-vm-standalone-test}"
 SOURCE="$ROOT_DIR/tests/core/eskm_v1_model_load_parity.esk"
 FIXTURES="$ROOT_DIR/tests/core/fixtures/eskm-v1"
 TIMEOUT_SECONDS="${ESKM_PARITY_TIMEOUT:-120}"
+ENGINES=(jit aot vm-source vm-bytecode)
+
+absolute_path() {
+    case "$1" in
+        /*) printf '%s\n' "$1" ;;
+        *) printf '%s/%s\n' "$(cd "$(dirname "$1")" && pwd)" "$(basename "$1")" ;;
+    esac
+}
+
+ESHKOL_RUN="$(absolute_path "$ESHKOL_RUN")"
+VM="$(absolute_path "$VM")"
 
 if [ ! -x "$ESHKOL_RUN" ] || [ ! -x "$VM" ]; then
     echo "INFRA: expected executable eshkol-run and VM paths" >&2
@@ -24,8 +35,29 @@ if ! python3 "$ROOT_DIR/scripts/check_eskm_v1_fixtures.py"; then
 fi
 
 source "$ROOT_DIR/scripts/lib/harness_outcome.sh"
-WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-eskm-v1.XXXXXX")" || exit 125
-trap 'rm -rf -- "$WORK_DIR"' EXIT HUP INT TERM
+# shellcheck source=lib/durable_work_root.sh
+source "$ROOT_DIR/scripts/lib/durable_work_root.sh"
+if [ -n "${ESHKOL_TEST_TMPDIR:-}" ]; then
+    WORK_DIR="$(mktemp -d "$ESHKOL_TEST_TMPDIR/eshkol-eskm-v1.XXXXXX")" || exit 125
+elif eshkol_durable_enabled; then
+    WORK_DIR="$(eshkol_durable_prepare_dir eskm-v1-model-io-parity)" || exit $?
+else
+    TMP_BASE="${ESHKOL_TEST_TMP_ROOT:-${TMPDIR:-/tmp}}"
+    WORK_DIR="$(mktemp -d "$TMP_BASE/eshkol-eskm-v1.XXXXXX")" || exit 125
+fi
+
+cleanup() {
+    if [ -z "${ESHKOL_TEST_KEEP_TMPDIR:-}" ] &&
+       [ -z "${ESHKOL_DURABLE_WORK_ROOT:-}" ]; then
+        rm -rf -- "$WORK_DIR"
+    else
+        echo "ESKM parity artifacts retained at $WORK_DIR" >&2
+    fi
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 report_failure() {
     local rc="$1" outcome
@@ -34,81 +66,184 @@ report_failure() {
     echo "$outcome: $* (rc=$rc)" >&2
 }
 
-prepare_axis() {
-    local axis_dir="$WORK_DIR/$1"
-    mkdir "$axis_dir" || return 1
-    cp "$FIXTURES"/*.eskm "$axis_dir/" || return 1
-    if [ "$SELF_TEST" -eq 1 ]; then
-        cp "$axis_dir/bad-magic.eskm" "$axis_dir/ordinary-2x3.eskm" || return 1
-    fi
+show_output() {
+    local axis_dir="$1"
+    sed -n '1,100p' "$axis_dir/stdout" >&2
+    sed -n '1,100p' "$axis_dir/stderr" >&2
 }
-
-run_axis() {
-    local axis="$1" axis_dir rc
-    axis_dir="$WORK_DIR/$axis"
-    shift
-    prepare_axis "$axis" || { echo "INFRA: $axis setup failed" >&2; return 125; }
-    if (cd "$axis_dir" && eshkol_outcome_guarded "$TIMEOUT_SECONDS" "$@") \
-            >"$axis_dir/stdout" 2>"$axis_dir/stderr"; then
-        rc=0
-    else
-        rc=$?
-    fi
-
-    if [ "$SELF_TEST" -eq 1 ]; then
-        if [ "$rc" -eq 1 ] && grep -q '^ESKM-V1-MODEL-LOAD:FAIL$' "$axis_dir/stdout"; then
-            echo "PASS: $axis negative control made the oracle fail"
-            return 0
-        fi
-        report_failure "$rc" "$axis negative control was not detected"
-    elif [ "$rc" -eq 0 ] &&
-         [ "$(grep -c '^ESKM-V1-MODEL-LOAD:PASS$' "$axis_dir/stdout")" -eq 1 ] &&
-         ! grep -q '^FAIL:' "$axis_dir/stdout" &&
-         cmp -s "$axis_dir/ordinary-2x3.eskm" "$axis_dir/actual-ordinary-2x3.eskm" &&
-         cmp -s "$axis_dir/rank8.eskm" "$axis_dir/actual-rank8.eskm" &&
-         cmp -s "$axis_dir/multi-tensor.eskm" "$axis_dir/actual-multi-tensor.eskm"; then
-        echo "PASS: $axis accepted, rejected, and exactly rewrote the expected fixtures"
-        return 0
-    else
-        report_failure "$rc" "$axis compatibility oracle failed"
-    fi
-    sed -n '1,80p' "$axis_dir/stdout" >&2
-    sed -n '1,80p' "$axis_dir/stderr" >&2
-    return 1
-}
-
-FAILED=0
-run_axis jit "$ESHKOL_RUN" --no-stdlib -r "$SOURCE" || FAILED=1
 
 AOT_BIN="$WORK_DIR/eskm-v1-aot"
 if eshkol_outcome_guarded "$TIMEOUT_SECONDS" "$ESHKOL_RUN" --no-stdlib \
-        "$SOURCE" -o "$AOT_BIN" >"$WORK_DIR/aot-compile.out" 2>"$WORK_DIR/aot-compile.err"; then
-    run_axis aot "$AOT_BIN" || FAILED=1
+        "$SOURCE" -o "$AOT_BIN" >"$WORK_DIR/aot-compile.out" \
+        2>"$WORK_DIR/aot-compile.err"; then
+    :
 else
     rc=$?
     report_failure "$rc" "AOT compile failed"
-    sed -n '1,80p' "$WORK_DIR/aot-compile.err" >&2
-    FAILED=1
+    sed -n '1,100p' "$WORK_DIR/aot-compile.err" >&2
+    exit 1
 fi
-
-export ESHKOL_VM_NO_DISASM=1
-run_axis vm-source "$VM" "$SOURCE" || FAILED=1
 
 ESKB="$WORK_DIR/eskm-v1.eskb"
-if eshkol_outcome_guarded "$TIMEOUT_SECONDS" "$ESHKOL_RUN" --profile hosted-vm \
-        --emit-eskb "$ESKB" "$SOURCE" >"$WORK_DIR/eskb-compile.out" 2>"$WORK_DIR/eskb-compile.err" &&
-        [ -s "$ESKB" ]; then
-    run_axis vm-bytecode "$VM" "$ESKB" || FAILED=1
+if eshkol_outcome_guarded "$TIMEOUT_SECONDS" "$ESHKOL_RUN" \
+        --profile hosted-vm --emit-eskb "$ESKB" "$SOURCE" \
+        >"$WORK_DIR/eskb-compile.out" 2>"$WORK_DIR/eskb-compile.err"; then
+    if [ ! -s "$ESKB" ]; then
+        echo "FAIL: ESKB compile wrote no bytecode" >&2
+        exit 1
+    fi
 else
     rc=$?
-    report_failure "$rc" "ESKB compile failed or wrote no bytecode"
-    sed -n '1,80p' "$WORK_DIR/eskb-compile.err" >&2
-    FAILED=1
+    report_failure "$rc" "ESKB compile failed"
+    sed -n '1,100p' "$WORK_DIR/eskb-compile.err" >&2
+    exit 1
 fi
 
+run_engine() {
+    local engine="$1" axis_dir="$2" mode="$3"
+    (
+        cd "$axis_dir" || exit 125
+        export ESKM_PARITY_MODE="$mode"
+        export ESKM_PARITY_ENGINE="$engine"
+        export ESHKOL_VM_NO_DISASM=1
+        case "$engine" in
+            jit)
+                eshkol_outcome_guarded "$TIMEOUT_SECONDS" \
+                    "$ESHKOL_RUN" --no-stdlib -r "$SOURCE"
+                ;;
+            aot)
+                eshkol_outcome_guarded "$TIMEOUT_SECONDS" "$AOT_BIN"
+                ;;
+            vm-source)
+                eshkol_outcome_guarded "$TIMEOUT_SECONDS" "$VM" "$SOURCE"
+                ;;
+            vm-bytecode)
+                eshkol_outcome_guarded "$TIMEOUT_SECONDS" "$VM" "$ESKB"
+                ;;
+            *)
+                echo "INFRA: unknown ESKM parity engine: $engine" >&2
+                exit 125
+                ;;
+        esac
+    )
+}
+
+run_captured() {
+    local engine="$1" axis_dir="$2" mode="$3"
+    if run_engine "$engine" "$axis_dir" "$mode" \
+            >"$axis_dir/stdout" 2>"$axis_dir/stderr"; then
+        return 0
+    else
+        return $?
+    fi
+}
+
+has_exact_success() {
+    local axis_dir="$1" marker="$2"
+    [ "$(grep -c "^${marker}$" "$axis_dir/stdout")" -eq 1 ] &&
+        ! grep -q '^FAIL:' "$axis_dir/stdout"
+}
+
+PRODUCERS="$WORK_DIR/producers"
+mkdir "$PRODUCERS" || exit 125
+FAILED=0
+
+for producer in "${ENGINES[@]}"; do
+    axis_dir="$WORK_DIR/produce-$producer"
+    mkdir "$axis_dir" || exit 125
+    if run_captured "$producer" "$axis_dir" produce; then rc=0; else rc=$?; fi
+    output="$axis_dir/producer.eskm"
+    if [ "$rc" -eq 0 ] &&
+       has_exact_success "$axis_dir" "ESKM-V1-PRODUCE:PASS" &&
+       [ -s "$output" ] &&
+       cmp -s "$FIXTURES/multi-tensor.eskm" "$output"; then
+        cp "$output" "$PRODUCERS/producer-$producer.eskm" || exit 125
+        echo "PASS: $producer produced canonical ESKM v1 bytes"
+    else
+        report_failure "$rc" "$producer producer oracle failed"
+        show_output "$axis_dir"
+        FAILED=1
+    fi
+done
+
 if [ "$FAILED" -ne 0 ]; then exit 1; fi
+
+prepare_consumer() {
+    local axis_dir="$1" producer
+    mkdir "$axis_dir" || return 1
+    cp "$FIXTURES"/*.eskm "$axis_dir/" || return 1
+    for producer in "${ENGINES[@]}"; do
+        cp "$PRODUCERS/producer-$producer.eskm" "$axis_dir/" || return 1
+    done
+}
+
+check_rewrites() {
+    local axis_dir="$1" producer
+    cmp -s "$FIXTURES/ordinary-2x3.eskm" \
+        "$axis_dir/rewrite-ordinary-2x3.eskm" || return 1
+    cmp -s "$FIXTURES/rank8.eskm" \
+        "$axis_dir/rewrite-rank8.eskm" || return 1
+    cmp -s "$FIXTURES/multi-tensor.eskm" \
+        "$axis_dir/rewrite-multi-tensor.eskm" || return 1
+    for producer in "${ENGINES[@]}"; do
+        cmp -s "$PRODUCERS/producer-$producer.eskm" \
+            "$axis_dir/rewrite-producer-$producer.eskm" || return 1
+    done
+}
+
+run_negative_control() {
+    local consumer="$1" kind="$2" expected="$3" axis_dir rc
+    axis_dir="$WORK_DIR/self-test-$kind-$consumer"
+    prepare_consumer "$axis_dir" || return 125
+    case "$kind" in
+        producer)
+            cp "$FIXTURES/ordinary-2x3.eskm" \
+                "$axis_dir/producer-vm-bytecode.eskm" || return 125
+            ;;
+        malformed)
+            cp "$FIXTURES/ordinary-2x3.eskm" \
+                "$axis_dir/bad-magic.eskm" || return 125
+            ;;
+    esac
+    if run_captured "$consumer" "$axis_dir" consume; then rc=0; else rc=$?; fi
+    if [ "$rc" -eq 1 ] &&
+       [ "$(grep -c '^ESKM-V1-CONSUME:FAIL$' "$axis_dir/stdout")" -eq 1 ] &&
+       ! grep -q '^ESKM-V1-CONSUME:PASS$' "$axis_dir/stdout" &&
+       grep -Fqx "FAIL: $expected" "$axis_dir/stdout"; then
+        echo "PASS: $consumer detected the $kind negative control"
+        return 0
+    fi
+    report_failure "$rc" "$consumer missed the $kind negative control"
+    show_output "$axis_dir"
+    return 1
+}
+
 if [ "$SELF_TEST" -eq 1 ]; then
-    echo "PASS: ESKM v1 parity negative control"
-else
-    echo "PASS: ESKM v1 model-load parity (jit/aot/vm-source/vm-bytecode)"
+    for consumer in "${ENGINES[@]}"; do
+        run_negative_control "$consumer" producer \
+            "producer vm-bytecode list structure" || FAILED=1
+        run_negative_control "$consumer" malformed \
+            "reject bad-magic.eskm" || FAILED=1
+    done
+    if [ "$FAILED" -ne 0 ]; then exit 1; fi
+    echo "PASS: ESKM v1 matrix negative controls (model metadata and malformed rejection)"
+    exit 0
 fi
+
+for consumer in "${ENGINES[@]}"; do
+    axis_dir="$WORK_DIR/consume-$consumer"
+    prepare_consumer "$axis_dir" || exit 125
+    if run_captured "$consumer" "$axis_dir" consume; then rc=0; else rc=$?; fi
+    if [ "$rc" -eq 0 ] &&
+       has_exact_success "$axis_dir" "ESKM-V1-CONSUME:PASS" &&
+       check_rewrites "$axis_dir"; then
+        echo "PASS: $consumer loaded and exactly rewrote all four producer outputs"
+    else
+        report_failure "$rc" "$consumer compatibility oracle failed"
+        show_output "$axis_dir"
+        FAILED=1
+    fi
+done
+
+if [ "$FAILED" -ne 0 ]; then exit 1; fi
+echo "PASS: ESKM v1 model-load parity (4 producers x 4 consumers; 16 cells)"

--- a/scripts/run_eskm_v1_model_load_parity.sh
+++ b/scripts/run_eskm_v1_model_load_parity.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Run the ESKM v1 model-load oracle through native JIT/AOT and VM source/ESKB.
+
+set -u
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-$ROOT_DIR/build}"
+SELF_TEST=0
+if [ "${1:-}" = "--self-test" ]; then SELF_TEST=1; shift; fi
+ESHKOL_RUN="${1:-$BUILD_DIR/eshkol-run}"
+VM="${2:-$BUILD_DIR/eshkol-vm-standalone-test}"
+SOURCE="$ROOT_DIR/tests/core/eskm_v1_model_load_parity.esk"
+FIXTURES="$ROOT_DIR/tests/core/fixtures/eskm-v1"
+TIMEOUT_SECONDS="${ESKM_PARITY_TIMEOUT:-120}"
+
+if [ ! -x "$ESHKOL_RUN" ] || [ ! -x "$VM" ]; then
+    echo "INFRA: expected executable eshkol-run and VM paths" >&2
+    exit 127
+fi
+
+if ! python3 "$ROOT_DIR/scripts/check_eskm_v1_fixtures.py"; then
+    echo "FAIL: ESKM v1 fixture integrity check failed" >&2
+    exit 1
+fi
+
+source "$ROOT_DIR/scripts/lib/harness_outcome.sh"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/eshkol-eskm-v1.XXXXXX")" || exit 125
+trap 'rm -rf -- "$WORK_DIR"' EXIT HUP INT TERM
+
+report_failure() {
+    local rc="$1" outcome
+    shift
+    outcome="$(eshkol_outcome_classify_exit "$rc")"
+    echo "$outcome: $* (rc=$rc)" >&2
+}
+
+prepare_axis() {
+    local axis_dir="$WORK_DIR/$1"
+    mkdir "$axis_dir" || return 1
+    cp "$FIXTURES"/*.eskm "$axis_dir/" || return 1
+    if [ "$SELF_TEST" -eq 1 ]; then
+        cp "$axis_dir/bad-magic.eskm" "$axis_dir/ordinary-2x3.eskm" || return 1
+    fi
+}
+
+run_axis() {
+    local axis="$1" axis_dir rc
+    axis_dir="$WORK_DIR/$axis"
+    shift
+    prepare_axis "$axis" || { echo "INFRA: $axis setup failed" >&2; return 125; }
+    if (cd "$axis_dir" && eshkol_outcome_guarded "$TIMEOUT_SECONDS" "$@") \
+            >"$axis_dir/stdout" 2>"$axis_dir/stderr"; then
+        rc=0
+    else
+        rc=$?
+    fi
+
+    if [ "$SELF_TEST" -eq 1 ]; then
+        if [ "$rc" -eq 1 ] && grep -q '^ESKM-V1-MODEL-LOAD:FAIL$' "$axis_dir/stdout"; then
+            echo "PASS: $axis negative control made the oracle fail"
+            return 0
+        fi
+        report_failure "$rc" "$axis negative control was not detected"
+    elif [ "$rc" -eq 0 ] &&
+         [ "$(grep -c '^ESKM-V1-MODEL-LOAD:PASS$' "$axis_dir/stdout")" -eq 1 ] &&
+         ! grep -q '^FAIL:' "$axis_dir/stdout" &&
+         cmp -s "$axis_dir/ordinary-2x3.eskm" "$axis_dir/actual-ordinary-2x3.eskm" &&
+         cmp -s "$axis_dir/rank8.eskm" "$axis_dir/actual-rank8.eskm" &&
+         cmp -s "$axis_dir/multi-tensor.eskm" "$axis_dir/actual-multi-tensor.eskm"; then
+        echo "PASS: $axis accepted, rejected, and exactly rewrote the expected fixtures"
+        return 0
+    else
+        report_failure "$rc" "$axis compatibility oracle failed"
+    fi
+    sed -n '1,80p' "$axis_dir/stdout" >&2
+    sed -n '1,80p' "$axis_dir/stderr" >&2
+    return 1
+}
+
+FAILED=0
+run_axis jit "$ESHKOL_RUN" --no-stdlib -r "$SOURCE" || FAILED=1
+
+AOT_BIN="$WORK_DIR/eskm-v1-aot"
+if eshkol_outcome_guarded "$TIMEOUT_SECONDS" "$ESHKOL_RUN" --no-stdlib \
+        "$SOURCE" -o "$AOT_BIN" >"$WORK_DIR/aot-compile.out" 2>"$WORK_DIR/aot-compile.err"; then
+    run_axis aot "$AOT_BIN" || FAILED=1
+else
+    rc=$?
+    report_failure "$rc" "AOT compile failed"
+    sed -n '1,80p' "$WORK_DIR/aot-compile.err" >&2
+    FAILED=1
+fi
+
+export ESHKOL_VM_NO_DISASM=1
+run_axis vm-source "$VM" "$SOURCE" || FAILED=1
+
+ESKB="$WORK_DIR/eskm-v1.eskb"
+if eshkol_outcome_guarded "$TIMEOUT_SECONDS" "$ESHKOL_RUN" --profile hosted-vm \
+        --emit-eskb "$ESKB" "$SOURCE" >"$WORK_DIR/eskb-compile.out" 2>"$WORK_DIR/eskb-compile.err" &&
+        [ -s "$ESKB" ]; then
+    run_axis vm-bytecode "$VM" "$ESKB" || FAILED=1
+else
+    rc=$?
+    report_failure "$rc" "ESKB compile failed or wrote no bytecode"
+    sed -n '1,80p' "$WORK_DIR/eskb-compile.err" >&2
+    FAILED=1
+fi
+
+if [ "$FAILED" -ne 0 ]; then exit 1; fi
+if [ "$SELF_TEST" -eq 1 ]; then
+    echo "PASS: ESKM v1 parity negative control"
+else
+    echo "PASS: ESKM v1 model-load parity (jit/aot/vm-source/vm-bytecode)"
+fi

--- a/scripts/run_eskm_v1_model_load_parity.sh
+++ b/scripts/run_eskm_v1_model_load_parity.sh
@@ -62,8 +62,25 @@ trap 'exit 143' TERM
 report_failure() {
     local rc="$1" outcome
     shift
-    outcome="$(eshkol_outcome_classify_exit "$rc")"
+    if [ "$rc" -eq 0 ]; then
+        outcome=FAIL
+    else
+        outcome="$(eshkol_outcome_classify_exit "$rc")"
+    fi
     echo "$outcome: $* (rc=$rc)" >&2
+}
+
+record_failure() {
+    if [ "$(eshkol_outcome_classify_exit "$1")" = "INFRA" ]; then
+        INFRA=1
+    else
+        FAILED=1
+    fi
+}
+
+exit_if_incomplete() {
+    if [ "$FAILED" -ne 0 ]; then exit 1; fi
+    if [ "$INFRA" -ne 0 ]; then exit 125; fi
 }
 
 show_output() {
@@ -81,6 +98,7 @@ else
     rc=$?
     report_failure "$rc" "AOT compile failed"
     sed -n '1,100p' "$WORK_DIR/aot-compile.err" >&2
+    if [ "$(eshkol_outcome_classify_exit "$rc")" = "INFRA" ]; then exit 125; fi
     exit 1
 fi
 
@@ -96,6 +114,7 @@ else
     rc=$?
     report_failure "$rc" "ESKB compile failed"
     sed -n '1,100p' "$WORK_DIR/eskb-compile.err" >&2
+    if [ "$(eshkol_outcome_classify_exit "$rc")" = "INFRA" ]; then exit 125; fi
     exit 1
 fi
 
@@ -147,6 +166,7 @@ has_exact_success() {
 PRODUCERS="$WORK_DIR/producers"
 mkdir "$PRODUCERS" || exit 125
 FAILED=0
+INFRA=0
 
 for producer in "${ENGINES[@]}"; do
     axis_dir="$WORK_DIR/produce-$producer"
@@ -162,11 +182,11 @@ for producer in "${ENGINES[@]}"; do
     else
         report_failure "$rc" "$producer producer oracle failed"
         show_output "$axis_dir"
-        FAILED=1
+        record_failure "$rc"
     fi
 done
 
-if [ "$FAILED" -ne 0 ]; then exit 1; fi
+exit_if_incomplete
 
 prepare_consumer() {
     local axis_dir="$1" producer
@@ -215,17 +235,24 @@ run_negative_control() {
     fi
     report_failure "$rc" "$consumer missed the $kind negative control"
     show_output "$axis_dir"
+    if [ "$(eshkol_outcome_classify_exit "$rc")" = "INFRA" ]; then return 125; fi
     return 1
 }
 
 if [ "$SELF_TEST" -eq 1 ]; then
     for consumer in "${ENGINES[@]}"; do
-        run_negative_control "$consumer" producer \
-            "producer vm-bytecode list structure" || FAILED=1
-        run_negative_control "$consumer" malformed \
-            "reject bad-magic.eskm" || FAILED=1
+        if run_negative_control "$consumer" producer \
+                "producer vm-bytecode list structure"; then :; else
+            rc=$?
+            record_failure "$rc"
+        fi
+        if run_negative_control "$consumer" malformed \
+                "reject bad-magic.eskm"; then :; else
+            rc=$?
+            record_failure "$rc"
+        fi
     done
-    if [ "$FAILED" -ne 0 ]; then exit 1; fi
+    exit_if_incomplete
     echo "PASS: ESKM v1 matrix negative controls (model metadata and malformed rejection)"
     exit 0
 fi
@@ -241,9 +268,9 @@ for consumer in "${ENGINES[@]}"; do
     else
         report_failure "$rc" "$consumer compatibility oracle failed"
         show_output "$axis_dir"
-        FAILED=1
+        record_failure "$rc"
     fi
 done
 
-if [ "$FAILED" -ne 0 ]; then exit 1; fi
+exit_if_incomplete
 echo "PASS: ESKM v1 model-load parity (4 producers x 4 consumers; 16 cells)"

--- a/scripts/run_eskm_v1_model_load_parity.sh
+++ b/scripts/run_eskm_v1_model_load_parity.sh
@@ -201,6 +201,8 @@ check_rewrites() {
     local axis_dir="$1" producer
     cmp -s "$FIXTURES/ordinary-2x3.eskm" \
         "$axis_dir/rewrite-ordinary-2x3.eskm" || return 1
+    cmp -s "$FIXTURES/large-32x32.eskm" \
+        "$axis_dir/rewrite-large-32x32.eskm" || return 1
     cmp -s "$FIXTURES/rank8.eskm" \
         "$axis_dir/rewrite-rank8.eskm" || return 1
     cmp -s "$FIXTURES/multi-tensor.eskm" \
@@ -225,7 +227,11 @@ run_negative_control() {
                 "$axis_dir/bad-magic.eskm" || return 125
             ;;
     esac
-    if run_captured "$consumer" "$axis_dir" consume; then rc=0; else rc=$?; fi
+    if ESKM_PARITY_CONTROL="$kind" run_captured "$consumer" "$axis_dir" consume; then
+        rc=0
+    else
+        rc=$?
+    fi
     if [ "$rc" -eq 1 ] &&
        [ "$(grep -c '^ESKM-V1-CONSUME:FAIL$' "$axis_dir/stdout")" -eq 1 ] &&
        ! grep -q '^ESKM-V1-CONSUME:PASS$' "$axis_dir/stdout" &&
@@ -251,9 +257,14 @@ if [ "$SELF_TEST" -eq 1 ]; then
             rc=$?
             record_failure "$rc"
         fi
+        if run_negative_control "$consumer" payload \
+                "large-32x32 payload values"; then :; else
+            rc=$?
+            record_failure "$rc"
+        fi
     done
     exit_if_incomplete
-    echo "PASS: ESKM v1 matrix negative controls (model metadata and malformed rejection)"
+    echo "PASS: ESKM v1 matrix negative controls (model metadata, payload and malformed rejection)"
     exit 0
 fi
 

--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -381,6 +381,11 @@ probe model_serialization_round_trip "tensor save/load round-trips bit-exact" \
 EOF
      "$ESHKOL_RUN" -r "$tmp" 2>&1; rc=$?; rm -f "$tmp" "$f"; exit $rc'
 
+probe eskm_v1_model_load_engine_parity \
+    "ESKM v1 all 16 producer-to-consumer engine pairings load and rewrite byte-identically" \
+    'cd "$REPO_ROOT"; "$REPO_ROOT/scripts/run_eskm_v1_model_load_parity.sh" \
+        "$ESHKOL_RUN" "$BUILD_DIR_PATH/eshkol-vm-standalone-test"'
+
 probe image_io_works "image-read returns a tensor of expected shape" \
     'tmp=$(mktemp).esk; img=$(mktemp).png;
      printf "\\x89PNG\\r\\n\\x1a\\n" > "$img";  ## just a header — image-read should error gracefully

--- a/tests/core/eskm_v1_model_load_parity.esk
+++ b/tests/core/eskm_v1_model_load_parity.esk
@@ -1,0 +1,88 @@
+;; ESKM v1 model-load compatibility over the backend-common shape subset.
+
+(define failures 0)
+
+(define (fail name)
+  (set! failures (+ failures 1))
+  (display "FAIL: ")
+  (display name)
+  (newline))
+
+(define (check name condition)
+  (if condition #t (fail name)))
+
+(define (single-record label loaded shape values)
+  (if (and (pair? loaded) (null? (cdr loaded)))
+      (let* ((entry (car loaded))
+             (name (car entry))
+             (tensor (cdr entry)))
+        (check (string-append label " name") (equal? name ""))
+        (check (string-append label " tensor") (tensor? tensor))
+        (if (tensor? tensor)
+            (begin
+              (check (string-append label " shape")
+                     (equal? (tensor-shape tensor) shape))
+              (check (string-append label " payload") (values tensor)))
+            #f))
+      (fail label)))
+
+(define ordinary (model-load "ordinary-2x3.eskm"))
+(single-record
+  "ordinary-2x3 metadata and finite payload"
+  ordinary
+  '(2 3)
+  (lambda (tensor)
+    (and (= (tensor-ref tensor 0) 1.0)
+         (= (tensor-ref tensor 1) -2.5)
+         (= (tensor-ref tensor 2) 0.0))))
+(check "ordinary-2x3 exact rewrite"
+       (and (pair? ordinary)
+            (model-save "actual-ordinary-2x3.eskm" ordinary)))
+
+(define rank8 (model-load "rank8.eskm"))
+(single-record
+  "rank8 metadata and payload"
+  rank8
+  '(1 1 1 1 1 1 1 1)
+  (lambda (tensor) (= (tensor-ref tensor 0) 3.141592653589793)))
+(check "rank8 exact rewrite"
+       (and (pair? rank8) (model-save "actual-rank8.eskm" rank8)))
+
+(define multi (model-load "multi-tensor.eskm"))
+(if (and (pair? multi) (pair? (cdr multi)) (null? (cdr (cdr multi))))
+    (let* ((weights-entry (car multi))
+           (bias-entry (car (cdr multi)))
+           (weights (cdr weights-entry))
+           (bias (cdr bias-entry)))
+      (check "multi-tensor names, order, metadata, and payload"
+             (and (equal? (car weights-entry) "weights")
+                  (equal? (car bias-entry) "bias")))
+      (check "multi-tensor values are tensors"
+             (and (tensor? weights) (tensor? bias)))
+      (if (and (tensor? weights) (tensor? bias))
+          (begin
+            (check "multi-tensor shapes"
+                   (and (equal? (tensor-shape weights) '(2))
+                        (equal? (tensor-shape bias) '(1))))
+            (check "multi-tensor payload"
+                   (and (= (tensor-ref weights 0) 5.0)
+                        (= (tensor-ref weights 1) 6.0)
+                        (= (tensor-ref bias 0) 7.0))))
+          #f))
+    (fail "multi-tensor list structure"))
+(check "multi-tensor exact rewrite"
+       (and (pair? multi) (model-save "actual-multi-tensor.eskm" multi)))
+
+(define (expect-rejection path)
+  (check path (null? (model-load path))))
+
+(expect-rejection "bad-magic.eskm")
+(expect-rejection "unsupported-version.eskm")
+(expect-rejection "unsupported-dtype.eskm")
+(expect-rejection "trailing-byte.eskm")
+(expect-rejection "crc-mismatch.eskm")
+(expect-rejection "truncated-footer.eskm")
+
+(if (= failures 0)
+    (begin (display "ESKM-V1-MODEL-LOAD:PASS") (newline) (exit 0))
+    (begin (display "ESKM-V1-MODEL-LOAD:FAIL") (newline) (exit 1)))

--- a/tests/core/eskm_v1_model_load_parity.esk
+++ b/tests/core/eskm_v1_model_load_parity.esk
@@ -1,88 +1,140 @@
-;; ESKM v1 model-load compatibility over the backend-common shape subset.
+;; ESKM v1 producer/consumer compatibility over the backend-common subset.
 
 (define failures 0)
 
 (define (fail name)
   (set! failures (+ failures 1))
-  (display "FAIL: ")
-  (display name)
+  (display (string-append "FAIL: " name))
   (newline))
 
 (define (check name condition)
   (if condition #t (fail name)))
 
-(define (single-record label loaded shape values)
+(define (label base suffix)
+  (string-append base suffix))
+
+(define (f64-dtype? tensor)
+  (let ((dtype (tensor-dtype tensor)))
+    (or (equal? dtype 'f64) (equal? dtype "f64"))))
+
+(define engine (or (getenv "ESKM_PARITY_ENGINE") "jit"))
+(define native-engine?
+  (or (string=? engine "jit") (string=? engine "aot")))
+
+(define (check-tensor base tensor shape length values)
+  (check (label base " is a tensor") (tensor? tensor))
+  (if (tensor? tensor)
+      (begin
+        (check (label base " rank/dimensions")
+               (equal? (tensor-shape tensor) shape))
+        (check (label base " dtype") (f64-dtype? tensor))
+        (if native-engine?
+            (check (label base " element count")
+                   (= (tensor-length tensor) length))
+            #t)
+        (check (label base " payload values") (values tensor)))
+      #f))
+
+(define (check-matrix-model base path rewrite-path)
+  (let ((loaded (model-load path)))
+    (if (and (pair? loaded)
+             (pair? (cdr loaded))
+             (null? (cdr (cdr loaded))))
+        (let* ((weights-entry (car loaded))
+               (bias-entry (car (cdr loaded)))
+               (weights (cdr weights-entry))
+               (bias (cdr bias-entry)))
+          (check (label base " names/order")
+                 (and (equal? (car weights-entry) "weights")
+                      (equal? (car bias-entry) "bias")))
+          (check-tensor
+            (label base " weights") weights '(2) 2
+            (lambda (tensor)
+              (and (= (tensor-ref tensor 0) 5.0)
+                   (= (tensor-ref tensor 1) 6.0))))
+          (check-tensor
+            (label base " bias") bias '(1) 1
+            (lambda (tensor) (= (tensor-ref tensor 0) 7.0)))
+          (check (label base " exact rewrite")
+                 (model-save rewrite-path loaded)))
+        (fail (label base " list structure")))))
+
+(define (single-record label-text loaded shape length values)
   (if (and (pair? loaded) (null? (cdr loaded)))
       (let* ((entry (car loaded))
              (name (car entry))
              (tensor (cdr entry)))
-        (check (string-append label " name") (equal? name ""))
-        (check (string-append label " tensor") (tensor? tensor))
-        (if (tensor? tensor)
-            (begin
-              (check (string-append label " shape")
-                     (equal? (tensor-shape tensor) shape))
-              (check (string-append label " payload") (values tensor)))
-            #f))
-      (fail label)))
+        (check (label label-text " empty name") (equal? name ""))
+        (check-tensor label-text tensor shape length values))
+      (fail (label label-text " list structure"))))
 
-(define ordinary (model-load "ordinary-2x3.eskm"))
-(single-record
-  "ordinary-2x3 metadata and finite payload"
-  ordinary
-  '(2 3)
-  (lambda (tensor)
-    (and (= (tensor-ref tensor 0) 1.0)
-         (= (tensor-ref tensor 1) -2.5)
-         (= (tensor-ref tensor 2) 0.0))))
-(check "ordinary-2x3 exact rewrite"
-       (and (pair? ordinary)
-            (model-save "actual-ordinary-2x3.eskm" ordinary)))
+(define (check-accepted-fixtures)
+  (let ((ordinary (model-load "ordinary-2x3.eskm")))
+    (single-record
+      "ordinary-2x3" ordinary '(2 3) 6
+      (lambda (tensor)
+        (and (= (tensor-ref tensor 0) 1.0)
+             (= (tensor-ref tensor 1) -2.5)
+             (= (tensor-ref tensor 2) 0.0))))
+    (check "ordinary-2x3 exact rewrite"
+           (and (pair? ordinary)
+                (model-save "rewrite-ordinary-2x3.eskm" ordinary))))
 
-(define rank8 (model-load "rank8.eskm"))
-(single-record
-  "rank8 metadata and payload"
-  rank8
-  '(1 1 1 1 1 1 1 1)
-  (lambda (tensor) (= (tensor-ref tensor 0) 3.141592653589793)))
-(check "rank8 exact rewrite"
-       (and (pair? rank8) (model-save "actual-rank8.eskm" rank8)))
+  (let ((rank8 (model-load "rank8.eskm")))
+    (single-record
+      "rank8" rank8 '(1 1 1 1 1 1 1 1) 1
+      (lambda (tensor) (= (tensor-ref tensor 0) 3.141592653589793)))
+    (check "rank8 exact rewrite"
+           (and (pair? rank8) (model-save "rewrite-rank8.eskm" rank8))))
 
-(define multi (model-load "multi-tensor.eskm"))
-(if (and (pair? multi) (pair? (cdr multi)) (null? (cdr (cdr multi))))
-    (let* ((weights-entry (car multi))
-           (bias-entry (car (cdr multi)))
-           (weights (cdr weights-entry))
-           (bias (cdr bias-entry)))
-      (check "multi-tensor names, order, metadata, and payload"
-             (and (equal? (car weights-entry) "weights")
-                  (equal? (car bias-entry) "bias")))
-      (check "multi-tensor values are tensors"
-             (and (tensor? weights) (tensor? bias)))
-      (if (and (tensor? weights) (tensor? bias))
-          (begin
-            (check "multi-tensor shapes"
-                   (and (equal? (tensor-shape weights) '(2))
-                        (equal? (tensor-shape bias) '(1))))
-            (check "multi-tensor payload"
-                   (and (= (tensor-ref weights 0) 5.0)
-                        (= (tensor-ref weights 1) 6.0)
-                        (= (tensor-ref bias 0) 7.0))))
-          #f))
-    (fail "multi-tensor list structure"))
-(check "multi-tensor exact rewrite"
-       (and (pair? multi) (model-save "actual-multi-tensor.eskm" multi)))
+  (check-matrix-model
+    "historical multi-tensor" "multi-tensor.eskm" "rewrite-multi-tensor.eskm"))
 
 (define (expect-rejection path)
-  (check path (null? (model-load path))))
+  (check (label "reject " path) (null? (model-load path))))
 
-(expect-rejection "bad-magic.eskm")
-(expect-rejection "unsupported-version.eskm")
-(expect-rejection "unsupported-dtype.eskm")
-(expect-rejection "trailing-byte.eskm")
-(expect-rejection "crc-mismatch.eskm")
-(expect-rejection "truncated-footer.eskm")
+(define (check-malformed-fixtures)
+  (expect-rejection "bad-magic.eskm")
+  (expect-rejection "unsupported-version.eskm")
+  (expect-rejection "unsupported-dtype.eskm")
+  (expect-rejection "trailing-byte.eskm")
+  (expect-rejection "crc-mismatch.eskm")
+  (expect-rejection "truncated-footer.eskm"))
+
+(define (produce)
+  (let ((model
+          (list
+            (cons "weights" (tensor 2 5.0 6.0))
+            (cons "bias" (tensor 1 7.0)))))
+    (check "producer model-save" (model-save "producer.eskm" model))))
+
+(define (consume)
+  (check-matrix-model
+    "producer jit" "producer-jit.eskm" "rewrite-producer-jit.eskm")
+  (check-matrix-model
+    "producer aot" "producer-aot.eskm" "rewrite-producer-aot.eskm")
+  (check-matrix-model
+    "producer vm-source" "producer-vm-source.eskm"
+    "rewrite-producer-vm-source.eskm")
+  (check-matrix-model
+    "producer vm-bytecode" "producer-vm-bytecode.eskm"
+    "rewrite-producer-vm-bytecode.eskm")
+  (check-accepted-fixtures)
+  (check-malformed-fixtures))
+
+(define mode (or (getenv "ESKM_PARITY_MODE") "consume"))
+(if (string=? mode "produce") (produce) (consume))
 
 (if (= failures 0)
-    (begin (display "ESKM-V1-MODEL-LOAD:PASS") (newline) (exit 0))
-    (begin (display "ESKM-V1-MODEL-LOAD:FAIL") (newline) (exit 1)))
+    (begin
+      (display (if (string=? mode "produce")
+                   "ESKM-V1-PRODUCE:PASS"
+                   "ESKM-V1-CONSUME:PASS"))
+      (newline)
+      (exit 0))
+    (begin
+      (display (if (string=? mode "produce")
+                   "ESKM-V1-PRODUCE:FAIL"
+                   "ESKM-V1-CONSUME:FAIL"))
+      (newline)
+      (exit 1)))

--- a/tests/core/eskm_v1_model_load_parity.esk
+++ b/tests/core/eskm_v1_model_load_parity.esk
@@ -20,8 +20,10 @@
 (define engine (or (getenv "ESKM_PARITY_ENGINE") "jit"))
 (define native-engine?
   (or (string=? engine "jit") (string=? engine "aot")))
+(define payload-control?
+  (equal? (getenv "ESKM_PARITY_CONTROL") "payload"))
 
-(define (check-tensor base tensor shape length values)
+(define (check-tensor base tensor shape length payload-check)
   (check (label base " is a tensor") (tensor? tensor))
   (if (tensor? tensor)
       (begin
@@ -32,7 +34,7 @@
             (check (label base " element count")
                    (= (tensor-length tensor) length))
             #t)
-        (check (label base " payload values") (values tensor)))
+        (check (label base " payload values") (payload-check tensor)))
       #f))
 
 (define (check-matrix-model base path rewrite-path)
@@ -59,14 +61,24 @@
                  (model-save rewrite-path loaded)))
         (fail (label base " list structure")))))
 
-(define (single-record label-text loaded shape length values)
+(define (single-record label-text loaded shape length payload-check)
   (if (and (pair? loaded) (null? (cdr loaded)))
       (let* ((entry (car loaded))
              (name (car entry))
              (tensor (cdr entry)))
         (check (label label-text " empty name") (equal? name ""))
-        (check-tensor label-text tensor shape length values))
+        (check-tensor label-text tensor shape length payload-check))
       (fail (label label-text " list structure"))))
+
+(define (large-payload-range? tensor start end)
+  (if (= (- end start) 1)
+      (= (tensor-ref tensor start)
+         (if (and payload-control? (= start 1023))
+             0.0
+             (/ (- start 512) 8.0)))
+      (let ((middle (quotient (+ start end) 2)))
+        (and (large-payload-range? tensor start middle)
+             (large-payload-range? tensor middle end)))))
 
 (define (check-accepted-fixtures)
   (let ((ordinary (model-load "ordinary-2x3.eskm")))
@@ -79,6 +91,13 @@
     (check "ordinary-2x3 exact rewrite"
            (and (pair? ordinary)
                 (model-save "rewrite-ordinary-2x3.eskm" ordinary))))
+
+  (let ((large (model-load "large-32x32.eskm")))
+    (single-record
+      "large-32x32" large '(32 32) 1024
+      (lambda (tensor) (large-payload-range? tensor 0 1024)))
+    (check "large-32x32 exact rewrite"
+           (and (pair? large) (model-save "rewrite-large-32x32.eskm" large))))
 
   (let ((rank8 (model-load "rank8.eskm")))
     (single-record


### PR DESCRIPTION
Carries #597 by @Gabriel-Kahen rebased onto current master so it runs current CI. Original commits and authorship preserved. Supersedes #597 on merge.