### PR TITLE
fix(compiler): remove a stray merge-conflict marker left in eshkol_compiler.c

### DIFF
--- a/lib/backend/eshkol_compiler.c
+++ b/lib/backend/eshkol_compiler.c
@@ -31,7 +31,6 @@
 #undef HEAP_SIZE
 #undef STACK_SIZE
 #undef MAX_FRAMES
->>>>>>> c3cb4c3a (fix(compiler): dynamic closure capture storage in the hosted compiler; same encoding-bound diagnostic on every engine (review P1))
 
 /* ESKB binary format writer (single-file include pattern) */
 #include "eskb_writer.c"


### PR DESCRIPTION
A literal `>>>>>>> c3cb4c3a` conflict marker was left in `lib/backend/eshkol_compiler.c` by commit 39979021. The file is not in the build glob, so CI did not catch it; this removes the marker so the source is valid C again.