### PR TITLE
examples(math): mechanize the leading structure of a finite-time Navier-Stokes blowup construction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3200,6 +3200,46 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run AND
     endif()
 endif()
 
+# Navier-Stokes blowup mechanization examples.
+#
+# scripts/run_examples_tests.sh discovers examples/*.esk and is a compile-and-run
+# smoke gate: it fails a program that crashes, not one that prints a failing
+# verdict. These four programs exit nonzero on any failed check, and the CTest
+# entries below additionally pin the verdict line, in JIT (-r) and AOT, so a
+# regression in the AD surface they exercise cannot pass silently. The test
+# names are the criterion ids used by the mechanization design document.
+if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
+    set(ESHKOL_NS_EXAMPLES
+        ns_viscosity_scaling_exact       mathematics_navier_stokes_viscosity_scaling
+        ns_similarity_exponents_solved   mathematics_navier_stokes_similarity_scales
+        ns_leading_profile_balance       mathematics_navier_stokes_first_principles
+        ns_covariance_two_family_solve   mathematics_navier_stokes_pulse_stress)
+    list(LENGTH ESHKOL_NS_EXAMPLES _ns_len)
+    math(EXPR _ns_last "${_ns_len} - 1")
+    foreach(_ns_i RANGE 0 ${_ns_last} 2)
+        math(EXPR _ns_j "${_ns_i} + 1")
+        list(GET ESHKOL_NS_EXAMPLES ${_ns_i} _ns_name)
+        list(GET ESHKOL_NS_EXAMPLES ${_ns_j} _ns_file)
+        set(_ns_src "${CMAKE_CURRENT_SOURCE_DIR}/examples/${_ns_file}.esk")
+        if(EXISTS "${_ns_src}")
+            add_test(NAME ${_ns_name}_jit
+                COMMAND $<TARGET_FILE:eshkol-run> -r "${_ns_src}")
+            set_tests_properties(${_ns_name}_jit PROPERTIES
+                TIMEOUT 180
+                ENVIRONMENT "ESHKOL_JIT_CACHE_DIR=${CMAKE_CURRENT_BINARY_DIR}/ns-jit-cache"
+                PASS_REGULAR_EXPRESSION "RESULT: ALL PASS"
+                FAIL_REGULAR_EXPRESSION "FAIL:|RESULT: FAILURES DETECTED|LLVM module verification failed|fatal signal")
+            add_test(NAME ${_ns_name}_aot
+                COMMAND sh -c
+                    "'$<TARGET_FILE:eshkol-run>' -o '${CMAKE_CURRENT_BINARY_DIR}/${_ns_file}_aot' '${_ns_src}' && '${CMAKE_CURRENT_BINARY_DIR}/${_ns_file}_aot'")
+            set_tests_properties(${_ns_name}_aot PROPERTIES
+                TIMEOUT 240
+                PASS_REGULAR_EXPRESSION "RESULT: ALL PASS"
+                FAIL_REGULAR_EXPRESSION "FAIL:|RESULT: FAILURES DETECTED|LLVM module verification failed|fatal signal")
+        endif()
+    endforeach()
+endif()
+
 if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
     add_test(
         NAME tensor_integer_vector_literal_runtime_smoke

--- a/docs/NAVIER_STOKES_BLOWUP_EXAMPLES.md
+++ b/docs/NAVIER_STOKES_BLOWUP_EXAMPLES.md
@@ -1,0 +1,295 @@
+# Navier-Stokes finite-time blowup: mechanizing the leading structure
+
+Status: verified on macOS arm64 with native JIT (`-r`) and native AOT. The four
+programs are discovered by `scripts/run_examples_tests.sh`, which runs on the
+lite CI lanes, and each is additionally pinned by a JIT and an AOT CTest entry.
+
+Source: "Finite Time Blowup for Navier-Stokes" (OpenAI, 2026),
+<https://cdn.openai.com/pdf/32d9f210-8b73-45e0-91bc-82a30aef8a9a/navier-stokes.pdf>
+
+These programs do not reprove the theorem. They compute the *leading structure*
+of the construction mechanically, where a reader would otherwise differentiate,
+rescale and balance powers by hand: the residual operator is assembled from AD
+partials, the similarity coordinates are differentiated through their own
+implicit definition, the scale exponents are solved as a linear system in exact
+rational arithmetic, and the leading profile series is derived from the leading
+balance operator rather than quoted. Every number printed is computed by the
+program. The only literal constants that appear in a comparison are the exact
+values the paper states, and each such comparison is either an exact rational
+equality or carries a stated tolerance.
+
+Each program prints one `PASS:`/`FAIL:` line per check, a `Passed:`/`Failed:`
+count, a `RESULT: ALL PASS` or `RESULT: FAILURES DETECTED` verdict, and exits
+nonzero if any check failed.
+
+## What each program covers
+
+| Program | Paper sections | What it computes | Checks |
+|---|---|---|---|
+| [`mathematics_navier_stokes_viscosity_scaling.esk`](../examples/mathematics_navier_stokes_viscosity_scaling.esk) | 3 (outline), 10.4 equations (10.22)-(10.23) | The residual `R(u,p) = d_t u + (u.grad)u - nu Lap u + grad p` assembled from AD partials of an explicit smooth divergence-free polynomial field, and the viscosity rescaling identity verified as an exact rational equality at four rational viscosities, with the energy and dissipation identities | 9 |
+| [`mathematics_navier_stokes_similarity_scales.esk`](../examples/mathematics_navier_stokes_similarity_scales.esk) | 2.1, 3.1, 4.1 (Lemma 4.1, (3.2), (4.3), (4.7)) | The self-similar axisymmetric ansatz in similarity coordinates: incompressibility and the centrifugal pressure balance as AD identities, the coordinate derivatives of Lemma 4.1 differentiated through the implicit solve for `q`, the nine scale-law exponents fitted from computed quantities, the core kinetic energy exponent, and the unbounded background residual | 23 |
+| [`mathematics_navier_stokes_first_principles.esk`](../examples/mathematics_navier_stokes_first_principles.esk) | 2.1, 3.1, 4.1 ((4.9), (4.12), (4.13)) | The scale exponents derived, not assumed: a linear system in the five unknown exponents with one free parameter `h`, solved exactly over the rationals, followed by the admissible range of `h` derived from the positivity requirements; then the leading profile series derived from the leading balance operator by exact interpolation and an exact linear solve, with a negative control | 21 |
+| [`mathematics_navier_stokes_pulse_stress.esk`](../examples/mathematics_navier_stokes_pulse_stress.esk) | 2.2, 3.2 (Figure 4), 3.3 and 7 | The oscillatory ring pulses: zero angular means, nonzero averaged momentum fluxes, the leading transversality that makes them divergence free, the two-family covariance system solved in exact rational arithmetic with positivity, and the Craik-Criminale growth-then-decay of a single mode on an affine background | 20 |
+
+## What the verdicts certify
+
+### `mathematics_navier_stokes_viscosity_scaling.esk`
+
+The test field is `u = (1+t)(y^2 z, z^2 x, x^2 y)`, `p = xyz + t x^2`, chosen so
+that `d_x u1 = d_y u2 = d_z u3 = 0` makes it divergence free while advection and
+the Laplacian are both nonzero. Every derivative is an AD call; the residual is
+never hand-differentiated.
+
+- Divergence of the reference field and of each rescaled field is an exact zero.
+- The identity of (10.22), `R_nu(u_nu,p_nu)(x,t) = sqrt(nu) R_1(u,p)(x/sqrt(nu),t)`,
+  holds as an exact rational equality at `nu = 1/4, 1, 9/16, 25/9, 4`, whose
+  square roots are rational. Two negative controls confirm the check is not
+  vacuous: omitting the `sqrt(nu)` on the velocity, or the `nu` on the pressure,
+  makes the gap nonzero.
+- At `nu = 2`, whose square root is irrational, the same identity holds to `1e-9`.
+- The discrete energy and dissipation of (10.23) scale by exactly `nu^{5/2}` on
+  the correspondingly scaled grid. These are Riemann sums, not integrals: the
+  `nu` grid is the reference grid scaled by `sqrt(nu)`, so the identity is exact
+  term by term, and that is what is certified.
+- The time variable is untouched by the rescaling, so the singular time is
+  unchanged.
+
+### `mathematics_navier_stokes_similarity_scales.esk`
+
+Concrete smooth profiles are installed that satisfy incompressibility (4.7), the
+centrifugal pressure balance and the axis regularity (4.4), with the slightly
+asymmetric axial profile of Section 2.1. They are **not** the profiles of
+Theorem 4.6: nothing here makes the leading residual vanish on the inner region
+or matches the heat exterior, so the residual is unbounded throughout the core
+rather than only in the annulus.
+
+- The divergence-free identity of (4.7) and the pressure balance `Pi_X = E^2/(2X)`
+  hold at every sample point to `1e-9`, with a negative control on a perturbed
+  `V0`.
+- `q - z^2 q^{2h} = tau` is solved to `1e-14` by a fixed-point iteration whose
+  contraction rate is `2 h eta^2`, and the five coordinate derivatives of
+  Lemma 4.1 agree with AD through that solve to `1e-7`.
+- The scale exponents come out as pure power laws and are fitted to `1e-9`:
+  `l_r ~ tau^{1/2}`, `l_z ~ tau^{1/2-h}`, `l_r/l_z ~ tau^h`,
+  `sup|u_theta|, sup|u_z| ~ tau^{-1/2-h}`, `sup|u_r| ~ tau^{-1/2}`,
+  `Re_theta ~ tau^{-h}` (unbounded), `Re_r ~ tau^0`, and the axial-to-radial
+  diffusion ratio `~ tau^{2h}` (vanishing).
+- The core kinetic energy separates into a tangential part scaling as exactly
+  `tau^{1/2-3h}` (fitted to `1e-9`) and a radial part scaling as `tau^{1/2-h}`.
+  The total therefore carries a relative correction of size `tau^{2h}`, which
+  biases the fitted slope of the total upward by at most `2h`. The verdict on the
+  total energy uses that `2h` bound and additionally requires the fitted slope to
+  decrease monotonically toward `1/2-3h`; the sharp statement is the tangential
+  one. With the paper's `h < 1/100` the correction decays too slowly for a naive
+  log-log fit of the total to converge, and the program says so by construction
+  rather than by widening a tolerance without a reason.
+- The leading angular and axial residuals, with axial viscosity removed as in
+  (4.12), grow like exactly `tau^{-(1+A)}`: `q^{A+1} R_theta^{(0)}` is
+  independent of `tau` to a relative `1e-6` over six decades, which is the
+  self-similarity of the residual itself. The full residual, axial viscosity
+  included, is within `2h` of the same exponent. The magnitude at `tau = 1e-8`
+  exceeds `1e6`, so no smooth force can sustain this background alone.
+
+### `mathematics_navier_stokes_first_principles.esk`
+
+**Part A.** The exponents in `l_r ~ tau^a`, `l_z ~ tau^b`, `u_theta ~ tau^-c`,
+`u_z ~ tau^-d`, `u_r ~ tau^-e` are unknowns. Five requirements from Sections 2.1
+and 3.1 — radial diffusion and radial and axial transport all entering the
+leading balance at rate `tau^-1`, the angular Reynolds number growing like
+`tau^-h`, and the axial-to-radial diffusion ratio being `tau^{2h}` — form a
+linear system whose right-hand sides are affine in `h`. It is solved exactly over
+the rationals, twice, for the constant part and the `h` coefficient. The program
+derives
+
+```text
+a = 1/2,   b = 1/2 - h,   c = 1/2 + h,   d = 1/2 + h,   e = 1/2
+```
+
+so `c = d = A` and `b = D`, and the compound exponents follow: core energy
+`1/2 - 3h`, `Re_theta ~ tau^{-h}`, `Re_r ~ tau^0`, diffusion ratio `tau^{2h}`.
+Incompressibility, `u_r/l_r ~ u_z/l_z`, is **not** imposed; it is checked
+afterwards and is satisfied, which is what makes the system consistent.
+
+The admissible range of `h` is then derived, not stated: each requirement is
+"this exponent is strictly positive", an affine condition `p + qh > 0` that
+gives `h > -p/q` when `q > 0` and `h < -p/q` when `q < 0`. Intersecting them
+gives `0 < h < 1/6`. The program prints which requirement binds each end: the
+lower end by the core becoming slender (`l_r/l_z -> 0`) and the upper end by the
+core kinetic energy vanishing, `1/2 - 3h > 0`. The paper's `0 < h < 1/100` lies
+strictly inside.
+
+**Part B.** For the leading tangential residual (4.12) the identities
+
+```text
+q^{A+1} R_theta^{(0)} = (E/L) B_theta,     q^{A+1} R_z^{(0)} = B_z / L
+```
+
+hold exactly, with `B_theta` and `B_z` the profile operators of (4.13) built from
+the sources (4.9). Both `E * B_theta` and `B_z` are linear in the profile they
+act on, so the program evaluates each operator on the monomial basis `X^j` with
+AD, recovers each image polynomial by exact rational interpolation (an exact
+Vandermonde solve), and then solves, again exactly, for the coefficients that
+annihilate every image coefficient below the truncation order. That derives the
+profile series from the operator.
+
+- The derived series annihilate their operators below the truncation exactly, and
+  the truncation residual is an exact rational.
+- The derived coefficient ratios are printed and match the Kummer recurrences of
+  the two operators, identifying the profiles as `1F1(1+h; 2; X/2)` and
+  `1F1(A; 1; X/2)`. The recurrences are a consequence of the derivation, not an
+  input to it.
+- Negative control: perturbing one interior coefficient of either series leaves a
+  nonzero coefficient below the truncation.
+- Pushed back through the physical residual, assembled by AD in `(r,z,t)` through
+  the implicit solve for `q`, the derived profiles make `q^{A+1} R_theta^{(0)}`
+  vanish on `z = 0` to `1e-7`, while the perturbed profile leaves a nonzero
+  `tau`-independent value and a physical residual that diverges like
+  `tau^{-(1+A)}` with the fitted exponent matching to `1e-4`.
+
+All of Part B is evaluated at `eta = 0` with profiles independent of `eta`. The
+`eta`-derivatives that appear in (4.9) are still computed rather than dropped;
+they evaluate to zero there, and that is what makes the reduced balance a pair of
+Kummer equations.
+
+### `mathematics_navier_stokes_pulse_stress.esk`
+
+- Both pulse families have zero angular mean in every cylindrical component
+  (`< 1e-12` by discrete angular averaging over a full ring), while the averaged
+  products `<w_r w_theta>` and `<w_r w_z>` are nonzero and agree with the exact
+  rational values `a_i a_j / 2` to `1e-12`. Reversing both components of a flux
+  leaves the flux unchanged, which is the mechanism of Section 2.2.
+- The cylindrical divergence of each pulse, computed by AD, reduces to the `O(1)`
+  envelope term `w_r/r`: the term of the order of the wavenumber cancels exactly
+  under the transversality `a . k = 0`. A negative control detunes `k_z` and
+  leaves an `O(wavenumber)` divergence.
+- The two covariance vectors are linearly independent — an exact rational
+  determinant `19/80` — so the 2x2 system spans both required stress components.
+  A target inside the cone has strictly positive weights and is reproduced
+  exactly by the positive combination; a target outside it has a negative weight.
+  All of this is written out over the scalar exact tower on Scheme lists of
+  rationals; it does not go through the tensor `solve`/`det` path, which is
+  f64-backed.
+- The Craik-Criminale mode on an affine background: the closed-form wavevector
+  satisfies `k' = -S^T k` as an exact rational identity under AD, the AD gradient
+  of the production quadratic form equals `-(S + S^T) a`, the wave stays
+  transverse along the integration, and the amplitude grows by a factor above
+  `1.5`, peaks at an interior time near the minimum of `|k|^2`, then decays below
+  both the maximum and its initial value as the shear shortens the radial
+  wavelength and viscous damping overtakes the amplification.
+
+## Running them
+
+```bash
+cmake -S . -B build -G Ninja -DESHKOL_BUILD_TESTS=ON
+cmake --build build -j8
+
+# JIT
+./build/eshkol-run -r examples/mathematics_navier_stokes_viscosity_scaling.esk
+./build/eshkol-run -r examples/mathematics_navier_stokes_similarity_scales.esk
+./build/eshkol-run -r examples/mathematics_navier_stokes_first_principles.esk
+./build/eshkol-run -r examples/mathematics_navier_stokes_pulse_stress.esk
+
+# AOT
+./build/eshkol-run -o build/ns_vs examples/mathematics_navier_stokes_viscosity_scaling.esk
+./build/ns_vs
+```
+
+The examples suite discovers the four files automatically:
+
+```bash
+./scripts/run_examples_tests.sh
+```
+
+The CTest entries, four JIT and four AOT, are named for the criterion ids used by
+the mechanization design document:
+
+```bash
+ctest --test-dir build --output-on-failure -R '^ns_'
+```
+
+`ns_viscosity_scaling_exact`, `ns_similarity_exponents_solved`,
+`ns_leading_profile_balance` and `ns_covariance_two_family_solve`, each with a
+`_jit` and an `_aot` variant, pin the verdict line in both execution modes.
+
+## Exactness boundaries
+
+- Exact arithmetic here is **scalar**. Eshkol tensors are f64-backed, so every
+  exact system in this family — the exponent solve, the Vandermonde
+  interpolation, the profile-coefficient solve, the 2x2 covariance solve — is
+  written out over the scalar exact tower on Scheme lists of rationals, not
+  through the tensor linear-algebra path.
+- Derivatives are exact only at exact scalar points and only through
+  `derivative-n`; see the defect list below. Where the field carries irrational
+  data (`q^{2h}`, `sqrt(2X)`, the trigonometric pulses, the implicit solve for
+  `q`), the arithmetic is double precision and the verdicts state a tolerance.
+- No enclosure or interval bound is used anywhere in this family, and nothing
+  here should be read as a certified bound. `core.ad.interval` widens by a
+  relative epsilon rather than using directed rounding, and
+  `core.ad.taylor_models` bounds its remainder by a sampled derivative; neither
+  is rigorous today, and neither is invoked here.
+- All derivatives are automatic, not symbolic. `(diff expr var)` exists and
+  returns a quoted S-expression, but it is not used in this family; every
+  derivative printed or compared comes from `derivative`, `derivative-n`,
+  `gradient` or `taylor`.
+
+## Compiler defects found while building this family
+
+Each is reproduced by the one-liner given with it. All three are silent: a wrong
+value is returned and nothing is raised.
+
+1. **`derivative` returns 0 when a non-integer exact rational reaches the
+   differentiand** — as a literal, as a captured argument, or as the seed.
+   `(derivative (lambda (s) (* 1/2 s s)) 0.4)` gives `0` where `0.4` is expected;
+   `(derivative-n ... 1)` and `(taylor ...)` on the same differentiand at the
+   same point are correct. This contradicts the identity
+   `(derivative f x) == (derivative-n f x 1)` documented in
+   `docs/guide/AUTOMATIC_DIFFERENTIATION.md`. Repro:
+   `(derivative (lambda (s) (* 1/2 s s)) 0.4)` returns `0`.
+2. **A derivative whose differentiand does not depend on the seed variable
+   returns an inexact zero at an exact rational seed**, which demotes any exact
+   sum it enters — a divergence, a Laplacian, a residual. A derivative that
+   merely happens to vanish is exact, so the trigger is a constant differentiand,
+   not a zero value.
+   Repro: `(exact? (derivative-n (lambda (s) 1/3) 1/2 1))` is `#f`.
+3. **Nested differentiation returns 0 when the outer pass is `derivative-n`, or
+   when the inner pass is `taylor`.** `derivative` nests correctly, including
+   three levels deep. `docs/guide/AUTOMATIC_DIFFERENTIATION.md` section 11 states
+   that nested differentiation is safe. Repro:
+   `(derivative-n (lambda (a) (derivative-n (lambda (b) (* a b)) 1.0 1)) 2.0 1)`
+   returns `0` where `1` is expected.
+
+Defects 1 and 3 together leave no single operator that is correct both with exact
+rationals present and as the outer pass of a nested differentiation. That
+constraint shaped these programs: exact rational work uses `derivative-n` and
+never nests, while the physical residuals are pure double arithmetic and use
+`derivative`. Each program carries a defect note at the top saying which route it
+takes and why.
+
+## Not mechanized yet
+
+These are capability gaps, stated as such.
+
+- **The residual to every order.** Only the leading order is closed here. The
+  paper's Section 5 corrections in powers of `q^{2nh}` need a residual that
+  returns a graded value whose coefficients can be collected and solved, which in
+  turn needs symbolic multivariate polynomial and series *values* and
+  polynomial-valued duals. Neither exists today; the leading balance above is
+  reached instead by evaluating a linear operator on a monomial basis and
+  recovering its image by exact interpolation.
+- **Certified derivative bounds through `t = 1`.** Every tolerance in this family
+  is a numerical agreement at sampled points, not a bound over a region. Bounding
+  a Cartesian space-time derivative uniformly on a compact set needs
+  directed-rounding interval arithmetic and a proved Taylor-model remainder;
+  Eshkol's interval arithmetic widens by a relative epsilon and its Taylor-model
+  remainder is sampled, so no statement here is a certified bound.
+- **Torus averaging as a builtin.** The angular mean is a discrete sum over a
+  ring in `mathematics_navier_stokes_pulse_stress.esk`. The construction needs
+  `T^1`/`T^2`-valued fields, a Haar mean with full chain-rule propagation,
+  evaluation at a phase map, and support-disjointness bookkeeping.
+- **Exact linear algebra as a library.** The Gaussian elimination, the
+  Vandermonde solve and the 2x2 covariance solve are written out in Scheme over
+  the exact scalar tower because the tensor path is f64-backed. An exact tensor
+  element type would let these be one call.
+- **Proof-object export.** Nothing here emits a certificate that could be checked
+  without running Eshkol. Every verdict above rests on trusting this compiler,
+  and that trust is not transferable.

--- a/examples/README.md
+++ b/examples/README.md
@@ -81,6 +81,21 @@ They print self-checking `PASS:` lines and finish with `RESULT: ALL PASS`.
 | **[mathematics_alphatensor_gf2.esk](mathematics_alphatensor_gf2.esk)** | Public rank-47 4x4 matrix multiplication over F2 by complete basis-pair expansion |
 | **[mathematics_funsearch_cap_set.esk](mathematics_funsearch_cap_set.esk)** | Public 512-point cap in AG(8,3), verified against every pair |
 
+## Mechanized mathematics: Navier-Stokes finite-time blowup
+
+Four programs that compute the leading structure of a finite-time blowup
+construction for the three-dimensional Navier-Stokes equations, described in
+[Navier-Stokes blowup examples](../docs/NAVIER_STOKES_BLOWUP_EXAMPLES.md). They
+follow the same flat-file convention, print `PASS:` lines and `RESULT: ALL PASS`,
+and exit nonzero on any failed check.
+
+| Example | What it verifies |
+|---------|------------------|
+| **[mathematics_navier_stokes_viscosity_scaling.esk](mathematics_navier_stokes_viscosity_scaling.esk)** | The momentum residual assembled from AD partials, and the viscosity rescaling of the equation, energy and dissipation as exact rational identities at four rational viscosities |
+| **[mathematics_navier_stokes_similarity_scales.esk](mathematics_navier_stokes_similarity_scales.esk)** | The self-similar ansatz in similarity coordinates: incompressibility, the pressure balance, the coordinate derivatives differentiated through the implicit solve, the nine scale-law exponents, and the unbounded background residual |
+| **[mathematics_navier_stokes_first_principles.esk](mathematics_navier_stokes_first_principles.esk)** | The scale exponents and the admissible range of h derived from the balance requirements by an exact rational linear solve, and the leading profile series derived from the leading balance operator, with a negative control |
+| **[mathematics_navier_stokes_pulse_stress.esk](mathematics_navier_stokes_pulse_stress.esk)** | Zero-mean oscillatory ring pulses with nonzero averaged momentum fluxes, the two-family covariance solve in exact rational arithmetic, and the shear-amplification-then-viscous-damping growth curve of one mode |
+
 ## Scientific computing
 
 Exact arithmetic, the numeric tower, category-theoretic models.

--- a/examples/mathematics_navier_stokes_first_principles.esk
+++ b/examples/mathematics_navier_stokes_first_principles.esk
@@ -1,0 +1,582 @@
+;; Navier-Stokes blowup construction -- deriving the scale exponents and the
+;; leading profile equations, rather than asserting them.
+;;
+;; Source: "Finite Time Blowup for Navier-Stokes" (OpenAI, 2026),
+;; https://cdn.openai.com/pdf/32d9f210-8b73-45e0-91bc-82a30aef8a9a/navier-stokes.pdf
+;; Sections 2.1, 3.1 (scale laws) and 4.1 (similarity variables, the leading
+;; tangential residual and the profile equations (4.9), (4.11), (4.13)).
+;;
+;; Part A.  The scale exponents are treated as unknowns
+;;     l_r ~ tau^a,  l_z ~ tau^b,  u_theta ~ tau^-c,  u_z ~ tau^-d,
+;;     u_r ~ tau^-e,
+;; with one free parameter h.  The physical requirements of Sections 2.1 and
+;; 3.1 become linear equations in (a,b,c,d,e) whose right-hand sides are affine
+;; in h.  The program solves that system in exact rational arithmetic and then
+;; derives the admissible range of h from the inequalities the same
+;; requirements impose.  Nothing about A = 1/2 + h or D = 1/2 - h is assumed.
+;;
+;; Part B.  The leading momentum balance.  With u_theta = q^{-A} E,
+;; u_z = q^{-A} U, r u_r = V0 and p = q^{-2A} Pi, the leading tangential
+;; residual (4.12) satisfies the exact identities
+;;     q^{A+1} R_theta^{(0)} = (E/L) * B_theta,
+;;     q^{A+1} R_z^{(0)}     = (1/L) * B_z,
+;; where B_theta and B_z are the profile operators of (4.13),
+;;     B_theta = -2L (X phi_XX + 2 phi_X)/phi - S_q,
+;;     B_z     = -2L (X U_XX + U_X)          - S_n,
+;; and S_q, S_n are the sources of (4.9).  Both E*B_theta and B_z are LINEAR in
+;; the profile they act on, so the program:
+;;   1. evaluates the operator on the monomial basis X^j with AD,
+;;   2. recovers each image polynomial by exact rational interpolation,
+;;   3. solves, in exact rational arithmetic, for the coefficients that
+;;      annihilate every Taylor coefficient below the truncation order.
+;; That derives the profile series from the operator.  The derived recurrence
+;; is then printed, and the leading operator is shown to vanish on the derived
+;; profile and NOT to vanish on a deliberately perturbed one.
+;;
+;; Finally the derived profiles are pushed back through the physical residual,
+;; assembled by AD in (r,z,t) through the implicit relation q - z^2 q^{2h} =
+;; tau, and the leading residual is confirmed to vanish on the plane z = 0 for
+;; the derived profiles and to diverge like tau^{-(1+A)} for the perturbed ones.
+;;
+;; DEFECT NOTE.  `derivative` returns 0 whenever a non-integer exact rational
+;; reaches the differentiand, and nested differentiation is correct only with
+;; `derivative` as the outer pass.  Exact rational work therefore uses
+;; `derivative-n` and never nests; the physical residual is pure double
+;; arithmetic and uses `derivative`.  Minimal repros:
+;;   (derivative (lambda (s) (* 1/2 s s)) 0.4)                            -> 0
+;;   (derivative-n (lambda (a) (derivative-n (lambda (b) (* a b)) 1.0 1)) 2.0 1) -> 0
+
+(define pass-count 0)
+(define fail-count 0)
+
+(define (check label ok)
+  (if ok
+      (begin (set! pass-count (+ pass-count 1))
+             (display "PASS: ") (display label) (newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "FAIL: ") (display label) (newline))))
+
+(define (close? a b tol) (< (abs (- a b)) tol))
+(define (show label v) (display "  ") (display label) (display " = ") (display v) (newline))
+
+;; ---------------------------------------------------------------------------
+;; Exact rational linear algebra.  Rows are lists of n coefficients plus a
+;; right-hand side; `gauss` returns the solution list, or #f if singular.
+;; ---------------------------------------------------------------------------
+
+(define (row-combine r1 r2 f)              ;; r1 - f * r2
+  (let loop ((a r1) (b r2) (acc '()))
+    (if (null? a)
+        (reverse acc)
+        (loop (cdr a) (cdr b) (cons (- (car a) (* f (car b))) acc)))))
+
+(define (find-pivot rows k)                ;; (pivot-row . remaining) or #f
+  (let loop ((rs rows) (seen '()))
+    (cond ((null? rs) #f)
+          ((not (= 0 (list-ref (car rs) k)))
+           (cons (car rs) (append (reverse seen) (cdr rs))))
+          (else (loop (cdr rs) (cons (car rs) seen))))))
+
+(define (eliminate rows prow k)
+  (let ((pk (list-ref prow k)))
+    (let loop ((rs rows) (acc '()))
+      (if (null? rs)
+          (reverse acc)
+          (loop (cdr rs)
+                (cons (row-combine (car rs) prow (/ (list-ref (car rs) k) pk))
+                      acc))))))
+
+(define (back-substitute prows n)
+  ;; prows is in pivot order: row i has its pivot in column i.
+  (let ((rev (reverse prows)))
+    (let loop ((rs rev) (i (- n 1)) (sol '()))
+      (if (null? rs)
+          sol
+          (let* ((r (car rs))
+                 (rhs (list-ref r n))
+                 (acc (let inner ((j (+ i 1)) (s 0) (xs sol))
+                        (if (>= j n)
+                            s
+                            (inner (+ j 1)
+                                   (+ s (* (list-ref r j) (car xs)))
+                                   (cdr xs)))))
+                 (xi (/ (- rhs acc) (list-ref r i))))
+            (loop (cdr rs) (- i 1) (cons xi sol)))))))
+
+(define (gauss rows n)
+  (let loop ((k 0) (rs rows) (piv '()))
+    (if (>= k n)
+        (back-substitute (reverse piv) n)
+        (let ((p (find-pivot rs k)))
+          (if (not p)
+              #f
+              (loop (+ k 1) (eliminate (cdr p) (car p) k) (cons (car p) piv)))))))
+
+;; ---------------------------------------------------------------------------
+;; PART A.  The scale exponents.
+;;
+;; Unknown order: (a b c d e) for
+;;     l_r ~ tau^a, l_z ~ tau^b, u_theta ~ tau^-c, u_z ~ tau^-d, u_r ~ tau^-e.
+;;
+;; Requirements, with viscosity fixed:
+;;   E1  radial diffusion enters the leading balance:  nu / l_r^2 ~ tau^-1
+;;   E2  radial transport enters it too:               u_r / l_r ~ tau^-1
+;;   E3  axial transport enters it too:                u_z / l_z ~ tau^-1
+;;   E4  angular Reynolds number:                      u_theta l_r / nu ~ tau^-h
+;;   E5  axial-to-radial diffusion ratio:              l_r^2 / l_z^2 ~ tau^{2h}
+;; and the consistency condition, checked afterwards rather than imposed:
+;;   E0  incompressibility:                            u_r / l_r ~ u_z / l_z
+;; ---------------------------------------------------------------------------
+
+;; Each row is (coeff-a coeff-b coeff-c coeff-d coeff-e | rhs).  The right-hand
+;; sides are affine in h, so the system is solved twice: once for the constant
+;; part and once for the coefficient of h.
+(define exponent-matrix
+  (list (list  2  0 0 0 0)     ;; E1: 2a       = 1
+        (list  1  0 0 0 1)     ;; E2: a + e    = 1
+        (list  0  1 0 1 0)     ;; E3: b + d    = 1
+        (list -1  0 1 0 0)     ;; E4: c - a    = h
+        (list  2 -2 0 0 0)))   ;; E5: 2a - 2b  = 2h
+
+(define exponent-rhs-const (list 1 1 1 0 0))
+(define exponent-rhs-h     (list 0 0 0 1 2))
+
+(define (augment mat rhs)
+  (let loop ((ms mat) (rs rhs) (acc '()))
+    (if (null? ms)
+        (reverse acc)
+        (loop (cdr ms) (cdr rs) (cons (append (car ms) (list (car rs))) acc)))))
+
+(define sol-const (gauss (augment exponent-matrix exponent-rhs-const) 5))
+(define sol-h     (gauss (augment exponent-matrix exponent-rhs-h) 5))
+
+;; An exponent is the affine pair (constant . coefficient-of-h).
+(define (expo i) (list (list-ref sol-const i) (list-ref sol-h i)))
+(define (ap-add p q) (list (+ (car p) (car q)) (+ (cadr p) (cadr q))))
+(define (ap-scale s p) (list (* s (car p)) (* s (cadr p))))
+(define (ap= p q) (and (= (car p) (car q)) (= (cadr p) (cadr q))))
+(define (ap-at p hv) (+ (car p) (* (cadr p) hv)))
+
+(define ea (expo 0)) (define eb (expo 1)) (define ec (expo 2))
+(define ed (expo 3)) (define ee (expo 4))
+
+;; Derived compound exponents.
+(define energy-expo                       ;; u^2 l_r^2 l_z  ~  tau^{-2c+2a+b}
+  (ap-add (ap-scale -2 ec) (ap-add (ap-scale 2 ea) eb)))
+(define re-theta-expo (ap-add ec (ap-scale -1 ea)))   ;; u_theta l_r ~ tau^{-(c-a)}
+(define re-r-expo     (ap-add ee (ap-scale -1 ea)))   ;; u_r l_r
+(define diffusion-expo (ap-scale 2 (ap-add ea (ap-scale -1 eb))))
+(define slenderness-expo (ap-add ea (ap-scale -1 eb)))
+
+(define (fmt p)
+  (list (car p) '+ (cadr p) 'h))
+
+(display "Part A -- scale exponents derived from the balance requirements:") (newline)
+(show "a  (l_r ~ tau^a)          " (fmt ea))
+(show "b  (l_z ~ tau^b)          " (fmt eb))
+(show "c  (u_theta ~ tau^-c)     " (fmt ec))
+(show "d  (u_z ~ tau^-d)         " (fmt ed))
+(show "e  (u_r ~ tau^-e)         " (fmt ee))
+(show "core energy exponent      " (fmt energy-expo))
+(show "Re_theta exponent -(c-a)  " (fmt (ap-scale -1 re-theta-expo)))
+(show "Re_r exponent -(e-a)      " (fmt (ap-scale -1 re-r-expo)))
+(show "l_r^2/l_z^2 exponent      " (fmt diffusion-expo))
+(show "l_r/l_z exponent          " (fmt slenderness-expo))
+
+(check "the exponent system is nonsingular and solvable in exact rationals"
+       (and sol-const sol-h))
+
+(check "incompressibility u_r/l_r ~ u_z/l_z is satisfied, not imposed"
+       (ap= (ap-add ea ee) (ap-add eb ed)))
+
+(check "derived c = d = A = 1/2 + h"
+       (and (ap= ec (list 1/2 1)) (ap= ed (list 1/2 1)) (ap= ec ed)))
+
+(check "derived b = D = 1/2 - h"
+       (ap= eb (list 1/2 -1)))
+
+(check "derived a = 1/2 and e = 1/2, so |u_r| ~ tau^{-1/2}"
+       (and (ap= ea (list 1/2 0)) (ap= ee (list 1/2 0))))
+
+(check "derived core kinetic energy exponent is 1/2 - 3h"
+       (ap= energy-expo (list 1/2 -3)))
+
+(check "derived Re_theta ~ tau^{-h} and Re_r ~ tau^0"
+       (and (ap= re-theta-expo (list 0 1)) (ap= re-r-expo (list 0 0))))
+
+;; --- the admissible range of h ---------------------------------------------
+;; Each requirement is "this exponent is strictly positive".  An exponent
+;; p + q h gives h > -p/q when q > 0 and h < -p/q when q < 0; q = 0 leaves h
+;; free and only demands p > 0.
+
+(define positivity-requirements
+  (list (list "l_r -> 0"                        ea)
+        (list "l_z -> 0"                        eb)
+        (list "l_r/l_z -> 0 (slender core)"     slenderness-expo)
+        (list "Re_theta -> infinity"            re-theta-expo)
+        (list "axial diffusion subdominant"     diffusion-expo)
+        (list "core kinetic energy -> 0"        energy-expo)
+        (list "velocities unbounded"            ec)))
+
+(define (derive-bounds reqs)
+  ;; returns (lo lo-label hi hi-label ok-constant-only)
+  (let loop ((rs reqs) (lo #f) (lol "") (hi #f) (hil "") (ok #t))
+    (if (null? rs)
+        (list lo lol hi hil ok)
+        (let* ((r (car rs)) (lbl (car r)) (p (cadr r))
+               (p0 (car p)) (p1 (cadr p)))
+          (cond ((> p1 0)
+                 (let ((bound (/ (- p0) p1)))
+                   (if (or (not lo) (> bound lo))
+                       (loop (cdr rs) bound lbl hi hil ok)
+                       (loop (cdr rs) lo lol hi hil ok))))
+                ((< p1 0)
+                 (let ((bound (/ (- p0) p1)))
+                   (if (or (not hi) (< bound hi))
+                       (loop (cdr rs) lo lol bound lbl ok)
+                       (loop (cdr rs) lo lol hi hil ok))))
+                (else (loop (cdr rs) lo lol hi hil (and ok (> p0 0)))))))))
+
+(define bounds (derive-bounds positivity-requirements))
+(define h-lo (list-ref bounds 0))
+(define h-hi (list-ref bounds 2))
+
+(display "Derived admissible range for h:") (newline)
+(show "lower bound               " h-lo)
+(show "binding lower requirement " (list-ref bounds 1))
+(show "upper bound               " h-hi)
+(show "binding upper requirement " (list-ref bounds 3))
+(show "h-free requirements hold  " (list-ref bounds 4))
+
+(check "the derived admissible range for h is 0 < h < 1/6"
+       (and (= h-lo 0) (= h-hi 1/6) (list-ref bounds 4)))
+
+(check "the binding upper constraint is the vanishing of the core kinetic energy"
+       (equal? (list-ref bounds 3) "core kinetic energy -> 0"))
+
+(check "the range 0 < h < 1/100 used in the paper lies strictly inside it"
+       (and (> 1/100 h-lo) (< 1/100 h-hi)))
+
+;; A concrete h for the rest of the program.
+(define h-exact 1/50)
+(define hh (exact->inexact h-exact))
+(define A-exact (ap-at ec h-exact))
+(define D-exact (ap-at eb h-exact))
+(define Ad (exact->inexact A-exact))
+(define Dd (exact->inexact D-exact))
+
+(show "h chosen for Part B        " h-exact)
+(show "derived A = c(h)           " A-exact)
+(show "derived D = b(h)           " D-exact)
+
+;; ---------------------------------------------------------------------------
+;; PART B.  The leading profile operators.
+;;
+;; Everything below is evaluated at eta = 0, where the coordinate factors are
+;; L = 1 - 2 h eta^2 = 1 and d = 1 - eta^2 = 1, and where the profiles are
+;; taken independent of eta.  The eta-derivatives appearing in (4.9) are still
+;; COMPUTED, not dropped.
+;; ---------------------------------------------------------------------------
+
+(define (dn f x k)                    ;; exact derivative, inexact zero repaired
+  (let ((v (derivative-n f x k)))
+    (if (= v 0) 0 v)))
+
+(define trunc 6)                      ;; profile truncation order
+
+(define (powr x j)
+  (let loop ((i 0) (acc 1)) (if (>= i j) acc (loop (+ i 1) (* acc x)))))
+
+(define (poly-eval cs x)
+  (let loop ((l cs) (p 1) (acc 0))
+    (if (null? l) acc (loop (cdr l) (* p x) (+ acc (* (car l) p))))))
+
+;; Simpson's rule -- exact for degree <= 3, used only where the integrand is a
+;; low-degree polynomial, and free of AD so it can sit inside a differentiand.
+(define (simpson g a b)
+  (* (/ (- b a) 6)
+     (+ (g a) (* 4 (g (/ (+ a b) 2))) (g b))))
+
+;; --- azimuthal operator ----------------------------------------------------
+;; With E = sqrt(2X) phi and H = r u_theta profile = 2 X phi, (4.8)/(4.9) give
+;;     l   = D_X log H = X H_X / H,
+;;     W   = 1 - 2 D eta A_X(U) - d d_eta A_X(U),
+;;     H_c = D eta + d U,
+;;     S_q = -W l - h (1 - 2 eta U) - H_c (log E)_eta,
+;; and (4.13) makes the leading residual vanish exactly when
+;;     Mq[phi] := 2 L (X phi_XX + 2 phi_X) + phi S_q = 0.
+;; Mq is linear in phi because phi*l = phi + X phi_X and phi (log E)_eta =
+;; phi_eta.
+
+(define (Uprofile-const X) 1)          ;; the axial profile used inside S_q
+(define (AX-of g X)
+  (if (= X 0) (g 0) (/ (simpson g 0 X) X)))
+
+(define (Mq phi X)
+  (let* ((L 1) (dd 1) (eta 0)
+         (Uv (Uprofile-const X))
+         (AXU (AX-of Uprofile-const X))
+         (dAXU-deta (dn (lambda (e) (AX-of Uprofile-const X)) 0 1))
+         (W  (- 1 (* 2 D-exact eta AXU) (* dd dAXU-deta)))
+         (Hfn (lambda (s) (* 2 s (phi s))))
+         (Hv  (Hfn X))
+         (Hx  (dn Hfn X 1))
+         (l   (/ (* X Hx) Hv))
+         (Hc  (+ (* D-exact eta) (* dd Uv)))
+         (Efn (lambda (e) (phi X)))    ;; the profiles do not depend on eta
+         (dE-deta (dn Efn 0 1))
+         (logE-eta (/ dE-deta (phi X)))
+         (Sq (- (* -1 W l) (* h-exact (- 1 (* 2 eta Uv))) (* Hc logE-eta))))
+    (+ (* 2 L (+ (* X (dn phi X 2)) (* 2 (dn phi X 1))))
+       (* (phi X) Sq))))
+
+;; --- axial operator --------------------------------------------------------
+;;     S_n = -W D_X U - A (1 - 2 eta U) U - H_c U_eta - d Pi_eta
+;;           + 4 A eta Pi + 2 eta D_X Pi,
+;;     Mz[U] := 2 L (X U_XX + U_X) + S_n = 0.
+
+(define (Mz Ufn X)
+  (let* ((L 1) (dd 1) (eta 0)
+         (Uv (Ufn X))
+         (AXU (AX-of Ufn X))
+         (dAXU-deta (dn (lambda (e) (AX-of Ufn X)) 0 1))
+         (W  (- 1 (* 2 D-exact eta AXU) (* dd dAXU-deta)))
+         (Hc (+ (* D-exact eta) (* dd Uv)))
+         (dU-deta (dn (lambda (e) (Ufn X)) 0 1))
+         (Piv 0)                        ;; Pi enters only through eta-terms here
+         (dPi-deta (dn (lambda (e) Piv) 0 1))
+         (Sn (- (* -1 W X (dn Ufn X 1))
+                (* A-exact (- 1 (* 2 eta Uv)) Uv)
+                (* Hc dU-deta)
+                (* dd dPi-deta)
+                (* -4 A-exact eta Piv)
+                (* -2 eta X (dn (lambda (s) Piv) X 1)))))
+    (+ (* 2 L (+ (* X (dn Ufn X 2)) (dn Ufn X 1)))
+       Sn)))
+
+;; --- exact interpolation of the operator images ----------------------------
+;; The image of a monomial under either operator is a polynomial of degree at
+;; most `trunc`, so its coefficients are recovered exactly from `trunc`+1
+;; sample values by an exact Vandermonde solve.
+
+(define (nodes n)
+  (let loop ((k 1) (acc '())) (if (> k n) (reverse acc) (loop (+ k 1) (cons k acc)))))
+
+(define interp-nodes (nodes (+ trunc 1)))
+
+(define (vandermonde-rows vals)
+  (let loop ((xs interp-nodes) (vs vals) (acc '()))
+    (if (null? xs)
+        (reverse acc)
+        (loop (cdr xs) (cdr vs)
+              (cons (let inner ((j 0) (row '()))
+                      (if (> j trunc)
+                          (reverse (cons (car vs) row))
+                          (inner (+ j 1) (cons (powr (car xs) j) row))))
+                    acc)))))
+
+(define (image-coeffs op j)
+  ;; coefficients of op applied to the monomial X^j
+  (let ((vals (let loop ((xs interp-nodes) (acc '()))
+                (if (null? xs)
+                    (reverse acc)
+                    (loop (cdr xs)
+                          (cons (op (lambda (s) (powr s j)) (car xs)) acc))))))
+    (gauss (vandermonde-rows vals) (+ trunc 1))))
+
+(define (basis-images op)
+  (let loop ((j 0) (acc '()))
+    (if (> j trunc) (reverse acc) (loop (+ j 1) (cons (image-coeffs op j) acc)))))
+
+;; Solve for c_1..c_trunc with c_0 = 1 so that the image coefficients of orders
+;; 0 .. trunc-1 all vanish.
+(define (derive-coefficients images)
+  (let* ((rows (let loopk ((k 0) (acc '()))
+                 (if (>= k trunc)
+                     (reverse acc)
+                     (loopk (+ k 1)
+                            (cons (let loopj ((j 1) (row '()))
+                                    (if (> j trunc)
+                                        (reverse (cons (- (list-ref (list-ref images 0) k)) row))
+                                        (loopj (+ j 1)
+                                               (cons (list-ref (list-ref images j) k) row))))
+                                  acc)))))
+         (sol (gauss rows trunc)))
+    (if sol (cons 1 sol) #f)))
+
+(define (image-coefficient images cs k)
+  (let loop ((j 0) (acc 0))
+    (if (> j trunc)
+        acc
+        (loop (+ j 1) (+ acc (* (list-ref cs j) (list-ref (list-ref images j) k)))))))
+
+(define q-images (basis-images Mq))
+(define z-images (basis-images Mz))
+(define phi-coeffs (derive-coefficients q-images))
+(define U-coeffs   (derive-coefficients z-images))
+
+(display "Part B -- profile series derived from the leading operators:") (newline)
+(show "azimuthal profile phi      " phi-coeffs)
+(show "axial profile U            " U-coeffs)
+
+(define (ratios cs)
+  (let loop ((l cs) (acc '()))
+    (if (null? (cdr l))
+        (reverse acc)
+        (loop (cdr l) (cons (/ (cadr l) (car l)) acc)))))
+
+(show "derived ratios c_{n+1}/c_n, phi" (ratios phi-coeffs))
+(show "derived ratios c_{n+1}/c_n, U  " (ratios U-coeffs))
+
+(define (all-low-coefficients-zero? images cs)
+  (let loop ((k 0))
+    (cond ((>= k trunc) #t)
+          ((= 0 (image-coefficient images cs k)) (loop (+ k 1)))
+          (else #f))))
+
+(check "the derived phi annihilates the azimuthal operator below the truncation"
+       (all-low-coefficients-zero? q-images phi-coeffs))
+
+(check "the derived U annihilates the axial operator below the truncation"
+       (all-low-coefficients-zero? z-images U-coeffs))
+
+(check "the coefficients and the truncation residual are exact rationals"
+       (and (exact? (list-ref phi-coeffs trunc))
+            (exact? (image-coefficient q-images phi-coeffs trunc))
+            (exact? (list-ref U-coeffs trunc))))
+
+(show "azimuthal truncation residual" (image-coefficient q-images phi-coeffs trunc))
+(show "axial truncation residual    " (image-coefficient z-images U-coeffs trunc))
+
+;; The derived ratios are the Kummer recurrences of the two operators,
+;;     phi:  c_{n+1}/c_n = (n+1+h) / ((n+1)(2n+4)),
+;;     U:    c_{n+1}/c_n = (n+A)   / ((n+1)(2n+2)),
+;; which identify the profiles as 1F1(1+h; 2; X/2) and 1F1(A; 1; X/2).
+(check "the derived azimuthal recurrence is the Kummer recurrence for 1F1(1+h;2;X/2)"
+       (let loop ((n 0) (rs (ratios phi-coeffs)))
+         (cond ((null? rs) #t)
+               ((= (car rs) (/ (+ n 1 h-exact) (* (+ n 1) (+ (* 2 n) 4))))
+                (loop (+ n 1) (cdr rs)))
+               (else #f))))
+
+(check "the derived axial recurrence is the Kummer recurrence for 1F1(A;1;X/2)"
+       (let loop ((n 0) (rs (ratios U-coeffs)))
+         (cond ((null? rs) #t)
+               ((= (car rs) (/ (+ n A-exact) (* (+ n 1) (+ (* 2 n) 2))))
+                (loop (+ n 1) (cdr rs)))
+               (else #f))))
+
+;; Negative control: perturbing one interior coefficient must break the
+;; annihilation at some order below the truncation.
+(define (perturb cs i factor)
+  (let loop ((l cs) (k 0) (acc '()))
+    (if (null? l)
+        (reverse acc)
+        (loop (cdr l) (+ k 1)
+              (cons (if (= k i) (* factor (car l)) (car l)) acc)))))
+
+(define phi-bad (perturb phi-coeffs 3 2))
+(define U-bad   (perturb U-coeffs 3 2))
+
+(check "negative control -- a perturbed phi leaves a nonzero low-order coefficient"
+       (not (all-low-coefficients-zero? q-images phi-bad)))
+
+(check "negative control -- a perturbed U leaves a nonzero low-order coefficient"
+       (not (all-low-coefficients-zero? z-images U-bad)))
+
+;; ---------------------------------------------------------------------------
+;; PART B, physical closure.  Push the derived profiles back through the
+;; residual of the full equations, assembled by AD in (r,z,t).
+;; ---------------------------------------------------------------------------
+
+(define (inexact-list l)
+  (let loop ((xs l) (acc '()))
+    (if (null? xs) (reverse acc) (loop (cdr xs) (cons (exact->inexact (car xs)) acc)))))
+
+(define phi-d (inexact-list phi-coeffs))
+(define U-d   (inexact-list U-coeffs))
+(define phi-bad-d (inexact-list phi-bad))
+
+(define (make-field pc uc)
+  ;; returns a list of (u_theta u_z u_r) as procedures of (r z t)
+  (let* ((phi  (lambda (X) (poly-eval pc X)))
+         (Uf   (lambda (X) (poly-eval uc X)))
+         (Ef   (lambda (X) (* (sqrt (* 2.0 X)) (phi X))))
+         (qsol (lambda (z tau)
+                 (let loop ((k 0) (q tau))
+                   (if (>= k 24) q (loop (+ k 1) (+ tau (* z z (expt q (* 2.0 hh)))))))))
+         (V0   (lambda (X e)
+                 ;; V0 = (X/L)(2 eta U - 2 D eta A_X(U) - d d_eta A_X(U)); the
+                 ;; profiles are eta independent, so the last term vanishes.
+                 (let* ((L (- 1.0 (* 2.0 hh e e)))
+                        (axu (if (< (abs X) 1e-12)
+                                 (Uf 0.0)
+                                 (/ (* (/ X 6.0) (+ (Uf 0.0) (* 4.0 (Uf (* 0.5 X))) (Uf X))) X))))
+                   (* (/ X L) (- (* 2.0 e (Uf X)) (* 2.0 Dd e axu)))))))
+    (list
+     (lambda (r z t)                       ;; u_theta
+       (let* ((tau (- 1.0 t)) (q (qsol z tau)))
+         (* (expt q (- Ad)) (Ef (/ (* r r) (* 2.0 q))))))
+     (lambda (r z t)                       ;; u_z
+       (let* ((tau (- 1.0 t)) (q (qsol z tau)))
+         (* (expt q (- Ad)) (Uf (/ (* r r) (* 2.0 q))))))
+     (lambda (r z t)                       ;; u_r
+       (let* ((tau (- 1.0 t)) (q (qsol z tau)))
+         (/ (V0 (/ (* r r) (* 2.0 q)) (* z (expt q (- Dd)))) r))))))
+
+(define (R-theta-leading fields r z t)
+  (let* ((ut (car fields)) (uz (cadr fields)) (ur (caddr fields))
+         (utv (ut r z t)) (urv (ur r z t)) (uzv (uz r z t))
+         (dr (derivative (lambda (s) (ut s z t)) r))
+         (drr (derivative (lambda (s) (derivative (lambda (w) (ut w z t)) s)) r)))
+    (+ (derivative (lambda (s) (ut r z s)) t)
+       (* urv dr)
+       (* uzv (derivative (lambda (s) (ut r s t)) z))
+       (/ (* urv utv) r)
+       (- (+ drr (/ dr r) (- (/ utv (* r r))))))))
+
+(define good-fields (make-field phi-d U-d))
+(define bad-fields  (make-field phi-bad-d U-d))
+
+(define Xstar 0.4)
+
+(define (physical-leading fields tau)
+  (let* ((q tau)                            ;; eta = 0 gives q = tau exactly
+         (r (sqrt (* 2.0 q Xstar))))
+    (* (expt q (+ Ad 1.0)) (R-theta-leading fields r 0.0 (- 1.0 tau)))))
+
+(display "Physical leading residual on z = 0, rescaled by q^{A+1}:") (newline)
+(show "derived profile,   tau=1e-3 " (physical-leading good-fields 1e-3))
+(show "derived profile,   tau=1e-6 " (physical-leading good-fields 1e-6))
+(show "perturbed profile, tau=1e-3 " (physical-leading bad-fields 1e-3))
+(show "perturbed profile, tau=1e-6 " (physical-leading bad-fields 1e-6))
+(show "|R_theta| perturbed, tau=1e-3" (abs (R-theta-leading bad-fields (sqrt (* 2.0 1e-3 Xstar)) 0.0 (- 1.0 1e-3))))
+(show "|R_theta| perturbed, tau=1e-6" (abs (R-theta-leading bad-fields (sqrt (* 2.0 1e-6 Xstar)) 0.0 (- 1.0 1e-6))))
+
+(check "the derived profile makes the leading physical residual vanish on z = 0"
+       (and (< (abs (physical-leading good-fields 1e-3)) 1e-4)
+            (< (abs (physical-leading good-fields 1e-6)) 1e-4)))
+
+(check "negative control -- the perturbed profile leaves a nonzero leading residual"
+       (and (> (abs (physical-leading bad-fields 1e-3)) 1e-3)
+            (> (abs (physical-leading bad-fields 1e-6)) 1e-3)))
+
+(check "the perturbed residual is tau-independent after rescaling by q^{A+1}"
+       (< (abs (- (physical-leading bad-fields 1e-3) (physical-leading bad-fields 1e-6)))
+          (* 1e-4 (abs (physical-leading bad-fields 1e-3)))))
+
+(check "the perturbed physical residual therefore diverges like tau^{-(1+A)}"
+       (let ((s (/ (- (log (abs (R-theta-leading bad-fields (sqrt (* 2.0 1e-6 Xstar)) 0.0 (- 1.0 1e-6))))
+                      (log (abs (R-theta-leading bad-fields (sqrt (* 2.0 1e-3 Xstar)) 0.0 (- 1.0 1e-3)))))
+                   (- (log 1e-6) (log 1e-3)))))
+         (close? s (- (+ 1.0 Ad)) 1e-4)))
+
+(display "Navier-Stokes scale exponents and leading profile equations, derived") (newline)
+(display "Passed: ") (display pass-count) (newline)
+(display "Failed: ") (display fail-count) (newline)
+;; The examples suite is a compile-and-run smoke gate: a program that prints a
+;; failure and exits zero still passes it.  Exit nonzero so a broken check is
+;; loud in CI.
+(if (= fail-count 0)
+    (begin (display "RESULT: ALL PASS") (newline) (exit 0))
+    (begin (display "RESULT: FAILURES DETECTED") (newline) (exit 1)))

--- a/examples/mathematics_navier_stokes_pulse_stress.esk
+++ b/examples/mathematics_navier_stokes_pulse_stress.esk
@@ -1,0 +1,412 @@
+;; Navier-Stokes blowup construction -- oscillatory pulses and the momentum flux
+;; they supply.
+;;
+;; Source: "Finite Time Blowup for Navier-Stokes" (OpenAI, 2026),
+;; https://cdn.openai.com/pdf/32d9f210-8b73-45e0-91bc-82a30aef8a9a/navier-stokes.pdf
+;; Sections 2.2 (annulus and pulses), 3.2 (positive representation of the
+;; target stress) and 3.3 / 7 (oscillatory realization of the stress).
+;;
+;; The background of the previous program leaves a momentum residual that
+;; diverges as t -> 1, so it cannot be sustained by a smooth force.  The paper
+;; instead perturbs the velocity by spatially oscillatory ring pulses.  Their
+;; cylindrical components have zero angular average, but their quadratic
+;; products do not: the averaged fluxes < w_r w_theta > and < w_r w_z > act on
+;; the background as an internal stress.  Two pulse families with different
+;; flux ratios give two linearly independent covariance vectors v1, v2, and the
+;; required stress is represented as T = c1 v1 + c2 v2 with c1, c2 > 0.
+;;
+;; This program computes, from the pulse fields themselves:
+;;   (a) the angular means of the pulse velocity components (zero) and of their
+;;       products (nonzero), by discrete angular averaging;
+;;   (b) the leading transversality that makes the pulses divergence free, by
+;;       AD on the cylindrical divergence;
+;;   (c) the 2x2 covariance system in exact rational arithmetic: nonsingular,
+;;       with strictly positive weights for a target inside the cone and a
+;;       negative weight for a target outside it;
+;;   (d) the growth-then-decay of a single pulse mode on an affine background,
+;;       in the Craik-Criminale form: the wavevector is carried by the shear,
+;;       the amplitude is amplified while the radial wavelength is long, and
+;;       viscous damping takes over once the shear has shortened it.
+;;
+;; DEFECT NOTE.  `derivative` returns 0 whenever a non-integer exact rational
+;; reaches the differentiand, even at a double seed, so nothing differentiated
+;; below may carry one.  The pulse amplitudes are kept exact for the covariance
+;; algebra and converted once, through `fam-*`, for the field evaluations; the
+;; exact-arithmetic derivative check uses `derivative-n`, which is correct.
+;; Minimal repro: (derivative (lambda (s) (* 1/2 s s)) 0.4) returns 0.
+
+(define pass-count 0)
+(define fail-count 0)
+
+(define (check label ok)
+  (if ok
+      (begin (set! pass-count (+ pass-count 1))
+             (display "PASS: ") (display label) (newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "FAIL: ") (display label) (newline))))
+
+(define (close? a b tol) (< (abs (- a b)) tol))
+(define (show label v) (display "  ") (display label) (display " = ") (display v) (newline))
+
+(define pi4 (* 4.0 (atan 1.0)))
+
+;; ---------------------------------------------------------------------------
+;; (a) Ring pulses and their angular averages.
+;;
+;; A pulse is w = (a_r, a_theta, a_z) cos(phi) with
+;;     phi = m theta + kr r + kz z,     m a nonzero integer,
+;; so the envelope covers a complete ring and every component has zero angular
+;; average.  The families are stored as (a_r a_theta a_z m kr).
+;; ---------------------------------------------------------------------------
+
+(define family-1 (list 1 1 1/4 3 2))
+(define family-2 (list 1 1/5 1 5 3))
+
+;; The exact amplitudes drive the covariance algebra; `fam-*` hands the field
+;; evaluations their inexact images (see the defect note above).
+(define (fam-ar-exact f) (list-ref f 0))
+(define (fam-at-exact f) (list-ref f 1))
+(define (fam-az-exact f) (list-ref f 2))
+
+(define (fam-ar f) (exact->inexact (list-ref f 0)))
+(define (fam-at f) (exact->inexact (list-ref f 1)))
+(define (fam-az f) (exact->inexact (list-ref f 2)))
+(define (fam-m  f) (exact->inexact (list-ref f 3)))
+(define (fam-kr f) (exact->inexact (list-ref f 4)))
+
+(define rp 1.25)     ;; pulse radius in the annulus
+(define zp 0.4)      ;; pulse height
+
+;; kz is fixed by the leading transversality a . k = 0 with k = (kr, m/rp, kz).
+(define (fam-kz f)
+  (/ (- (+ (* (fam-ar f) (fam-kr f))
+           (* (fam-at f) (/ (fam-m f) rp))))
+     (fam-az f)))
+
+(define (phase f theta r z)
+  (+ (* (fam-m f) theta) (* (fam-kr f) r) (* (fam-kz f) z)))
+
+(define (w-r f theta r z) (* (fam-ar f) (cos (phase f theta r z))))
+(define (w-t f theta r z) (* (fam-at f) (cos (phase f theta r z))))
+(define (w-z f theta r z) (* (fam-az f) (cos (phase f theta r z))))
+
+(define n-theta 64)
+
+(define (angular-mean g)
+  (let loop ((j 0) (acc 0.0))
+    (if (>= j n-theta)
+        (/ acc (exact->inexact n-theta))
+        (loop (+ j 1)
+              (+ acc (g (/ (* 2.0 pi4 j) (exact->inexact n-theta))))))))
+
+(define (mean-components f)
+  (list (angular-mean (lambda (th) (w-r f th rp zp)))
+        (angular-mean (lambda (th) (w-t f th rp zp)))
+        (angular-mean (lambda (th) (w-z f th rp zp)))))
+
+(define (covariance f)                 ;; ( <w_r w_theta> , <w_r w_z> )
+  (list (angular-mean (lambda (th) (* (w-r f th rp zp) (w-t f th rp zp))))
+        (angular-mean (lambda (th) (* (w-r f th rp zp) (w-z f th rp zp))))))
+
+(define (max-abs lst)
+  (let loop ((l lst) (b 0.0))
+    (if (null? l) b (loop (cdr l) (if (> (abs (car l)) b) (abs (car l)) b)))))
+
+(display "Angular averages of the two pulse families:") (newline)
+(show "family 1 component means   " (mean-components family-1))
+(show "family 2 component means   " (mean-components family-2))
+(show "family 1 covariance (v1)   " (covariance family-1))
+(show "family 2 covariance (v2)   " (covariance family-2))
+
+(check "every pulse velocity component has zero angular mean"
+       (and (< (max-abs (mean-components family-1)) 1e-12)
+            (< (max-abs (mean-components family-2)) 1e-12)))
+
+(check "the averaged momentum fluxes are nonzero"
+       (and (> (max-abs (covariance family-1)) 0.05)
+            (> (max-abs (covariance family-2)) 0.05)))
+
+;; The exact rational values of the same averages: < cos^2 > = 1/2.
+(define (exact-covariance f)
+  (list (/ (* (fam-ar-exact f) (fam-at-exact f)) 2)
+        (/ (* (fam-ar-exact f) (fam-az-exact f)) 2)))
+
+(check "the computed fluxes agree with the exact rational values a_i a_j / 2"
+       (let ((c1 (covariance family-1)) (e1 (exact-covariance family-1))
+             (c2 (covariance family-2)) (e2 (exact-covariance family-2)))
+         (and (close? (car c1) (car e1) 1e-12) (close? (cadr c1) (cadr e1) 1e-12)
+              (close? (car c2) (car e2) 1e-12) (close? (cadr c2) (cadr e2) 1e-12))))
+
+;; Reversing both velocity components of a flux leaves the flux unchanged,
+;; which is the mechanism described in Section 2.2.
+(define (reversed f)
+  (list (- (list-ref f 0)) (- (list-ref f 1)) (- (list-ref f 2))
+        (list-ref f 3) (list-ref f 4)))
+
+(check "reversing both components leaves the averaged flux unchanged"
+       (let ((c (covariance family-1)) (cr (covariance (reversed family-1))))
+         (and (close? (car c) (car cr) 1e-12) (close? (cadr c) (cadr cr) 1e-12))))
+
+;; ---------------------------------------------------------------------------
+;; (b) Leading transversality: the pulse divergence has no term of the order of
+;; the wavenumber.  The cylindrical divergence of an axisymmetric-in-envelope
+;; ring pulse is
+;;     div w = w_r/r + d_r w_r + (1/r) d_theta w_theta + d_z w_z,
+;; whose only surviving term after a . k = 0 is w_r/r.
+;; ---------------------------------------------------------------------------
+
+(define (pulse-divergence f theta r z)
+  (+ (/ (w-r f theta r z) r)
+     (derivative (lambda (s) (w-r f theta s z)) r)
+     (/ (derivative (lambda (s) (w-t f s r z)) theta) r)
+     (derivative (lambda (s) (w-z f theta r s)) z)))
+
+(define (transversality-worst f)
+  (let loop ((j 0) (b 0.0))
+    (if (>= j 16)
+        b
+        (let* ((th (/ (* 2.0 pi4 j) 16.0))
+               (v  (abs (- (pulse-divergence f th rp zp)
+                           (/ (w-r f th rp zp) rp)))))
+          (loop (+ j 1) (if (> v b) v b))))))
+
+(show "family 1 residual divergence" (transversality-worst family-1))
+(show "family 2 residual divergence" (transversality-worst family-2))
+
+(check "pulse divergence reduces to the O(1) envelope term (both families)"
+       (and (< (transversality-worst family-1) 1e-9)
+            (< (transversality-worst family-2) 1e-9)))
+
+(check "negative control -- detuning k_z leaves an O(wavenumber) divergence"
+       (let* ((f family-1)
+              (bad (lambda (th)
+                     (- (+ (/ (w-r f th rp zp) rp)
+                           (derivative (lambda (s) (w-r f th s zp)) rp)
+                           (/ (derivative (lambda (s) (w-t f s rp zp)) th) rp)
+                           (* (fam-az f) (- (* (+ 1.0 (fam-kz f))
+                                               (sin (phase f th rp zp))))))
+                        (/ (w-r f th rp zp) rp)))))
+         (> (let loop ((j 0) (b 0.0))
+              (if (>= j 16)
+                  b
+                  (let ((v (abs (bad (/ (* 2.0 pi4 j) 16.0)))))
+                    (loop (+ j 1) (if (> v b) v b)))))
+            0.1)))
+
+;; ---------------------------------------------------------------------------
+;; (c) The 2x2 covariance system, in exact rational arithmetic.
+;;     T = c1 v1 + c2 v2,  with v_i the exact covariance vectors above.
+;; ---------------------------------------------------------------------------
+
+(define v1 (exact-covariance family-1))
+(define v2 (exact-covariance family-2))
+
+(define cone-det (- (* (car v1) (cadr v2)) (* (cadr v1) (car v2))))
+
+(define (cone-solve T)
+  (list (/ (- (* (car T) (cadr v2)) (* (cadr T) (car v2))) cone-det)
+        (/ (- (* (car v1) (cadr T)) (* (cadr v1) (car T))) cone-det)))
+
+(define T-inside  (list 3/10 1/5))
+(define T-outside (list 1/2 -1/10))
+
+(define c-inside  (cone-solve T-inside))
+(define c-outside (cone-solve T-outside))
+
+(display "Positive representation of the target stress:") (newline)
+(show "v1 (exact)                 " v1)
+(show "v2 (exact)                 " v2)
+(show "det [v1 v2] (exact)        " cone-det)
+(show "target inside the cone     " T-inside)
+(show "weights (c1,c2) (exact)    " c-inside)
+(show "target outside the cone    " T-outside)
+(show "weights (c1,c2) (exact)    " c-outside)
+
+(check "the two covariance vectors are linearly independent (exact determinant)"
+       (and (exact? cone-det) (not (= cone-det 0))))
+
+(check "a target inside the cone has strictly positive weights"
+       (and (> (car c-inside) 0) (> (cadr c-inside) 0)))
+
+(check "the positive combination reproduces the target exactly"
+       (and (= (+ (* (car c-inside) (car v1)) (* (cadr c-inside) (car v2)))
+               (car T-inside))
+            (= (+ (* (car c-inside) (cadr v1)) (* (cadr c-inside) (cadr v2)))
+               (cadr T-inside))))
+
+(check "negative control -- a target outside the cone has a negative weight"
+       (or (< (car c-outside) 0) (< (cadr c-outside) 0)))
+
+(check "the two families really have different flux ratios"
+       (not (= (/ (cadr v1) (car v1)) (/ (cadr v2) (car v2)))))
+
+;; ---------------------------------------------------------------------------
+;; (d) A single pulse mode on an affine background: the Craik-Criminale system
+;;
+;;     k' = -S^T k,
+;;     a' = -S a + 2 (k.S a / |k|^2) k - nu |k|^2 a,
+;;
+;; with S the constant background shear.  The shear carries the wavevector,
+;; progressively shortening the radial wavelength; amplification dominates
+;; while |k| is small and viscous damping -nu|k|^2 overtakes it once |k| grows.
+;; ---------------------------------------------------------------------------
+
+(define shear 1)                        ;; S = [[0,shear,0],[0,0,0],[0,0,0]]
+(define nu-pulse 0.02)
+
+(define (S-apply v)                     ;; S v
+  (vector (* shear (vector-ref v 1)) 0.0 0.0))
+
+(define (St-apply v)                    ;; S^T v
+  (vector 0.0 (* shear (vector-ref v 0)) 0.0))
+
+;; Closed-form wavevector: k(t) = (k1, k2 - shear k1 t, k3).  Polynomial in t,
+;; so its derivative is exact at an exact rational time.
+(define k1-0 1)
+(define k2-0 4)
+(define k3-0 0)
+
+(define (k-of t)
+  (vector k1-0 (- k2-0 (* shear k1-0 t)) k3-0))
+
+(define (k-comp i t) (vector-ref (k-of t) i))
+
+(check "the closed-form wavevector satisfies k' = -S^T k exactly"
+       (let* ((t 3/7)
+              (dk (vector (derivative-n (lambda (s) (k-comp 0 s)) t 1)
+                          (derivative-n (lambda (s) (k-comp 1 s)) t 1)
+                          (derivative-n (lambda (s) (k-comp 2 s)) t 1)))
+              (rhs (St-apply (k-of t))))
+         (and (= (vector-ref dk 0) (- (vector-ref rhs 0)))
+              (= (vector-ref dk 1) (- (vector-ref rhs 1)))
+              (= (vector-ref dk 2) (- (vector-ref rhs 2))))))
+
+;; The production term of the amplitude equation is the quadratic form
+;; P(a) = -a . S a; its gradient must be -(S + S^T) a.
+(define (production a)
+  (- (+ (* (vector-ref a 0) (* shear (vector-ref a 1)))))) 
+
+(check "AD gradient of the production form equals -(S + S^T) a"
+       (let* ((a (vector 0.7 -1.3 0.4))
+              (g (gradient production a)))
+         (and (close? (vector-ref g 0) (- (* shear (vector-ref a 1))) 1e-12)
+              (close? (vector-ref g 1) (- (* shear (vector-ref a 0))) 1e-12)
+              (close? (vector-ref g 2) 0.0 1e-12))))
+
+(define (dot u v)
+  (+ (* (vector-ref u 0) (vector-ref v 0))
+     (* (vector-ref u 1) (vector-ref v 1))
+     (* (vector-ref u 2) (vector-ref v 2))))
+
+(define (norm2 v) (dot v v))
+
+(define (a-rhs a t)
+  (let* ((k  (vector (exact->inexact k1-0)
+                     (- (exact->inexact k2-0) (* shear k1-0 t))
+                     (exact->inexact k3-0)))
+         (kk (norm2 k))
+         (Sa (S-apply a))
+         (co (/ (* 2.0 (dot k Sa)) kk)))
+    (vector (+ (- (vector-ref Sa 0)) (* co (vector-ref k 0)) (* (- nu-pulse) kk (vector-ref a 0)))
+            (+ (- (vector-ref Sa 1)) (* co (vector-ref k 1)) (* (- nu-pulse) kk (vector-ref a 1)))
+            (+ (- (vector-ref Sa 2)) (* co (vector-ref k 2)) (* (- nu-pulse) kk (vector-ref a 2))))))
+
+(define (vadd u v s)
+  (vector (+ (vector-ref u 0) (* s (vector-ref v 0)))
+          (+ (vector-ref u 1) (* s (vector-ref v 1)))
+          (+ (vector-ref u 2) (* s (vector-ref v 2)))))
+
+(define (rk4-step a t dt)
+  (let* ((f1 (a-rhs a t))
+         (f2 (a-rhs (vadd a f1 (* 0.5 dt)) (+ t (* 0.5 dt))))
+         (f3 (a-rhs (vadd a f2 (* 0.5 dt)) (+ t (* 0.5 dt))))
+         (f4 (a-rhs (vadd a f3 dt) (+ t dt))))
+    (vector (+ (vector-ref a 0) (* (/ dt 6.0) (+ (vector-ref f1 0) (* 2.0 (vector-ref f2 0)) (* 2.0 (vector-ref f3 0)) (vector-ref f4 0))))
+            (+ (vector-ref a 1) (* (/ dt 6.0) (+ (vector-ref f1 1) (* 2.0 (vector-ref f2 1)) (* 2.0 (vector-ref f3 1)) (vector-ref f4 1))))
+            (+ (vector-ref a 2) (* (/ dt 6.0) (+ (vector-ref f1 2) (* 2.0 (vector-ref f2 2)) (* 2.0 (vector-ref f3 2)) (vector-ref f4 2)))))))
+
+;; a0 is transverse to k(0), as a divergence-free wave requires.
+(define a0 (vector (- (exact->inexact k2-0)) (exact->inexact k1-0) 0.0))
+
+(define n-steps 400)
+(define dt-pulse 0.02)
+
+;; Integrate, recording the largest amplitude, when it occurred, the final
+;; amplitude, the worst transversality defect, and the minimum of |k|^2.
+(define (integrate)
+  (let loop ((n 0) (t 0.0) (a a0)
+             (amp0 (sqrt (norm2 a0))) (best 0.0) (best-t 0.0)
+             (worst-tr 0.0) (kmin 1e30) (kmin-t 0.0))
+    (let* ((k (vector (exact->inexact k1-0)
+                      (- (exact->inexact k2-0) (* shear k1-0 t))
+                      (exact->inexact k3-0)))
+           (kk (norm2 k))
+           (amp (sqrt (norm2 a)))
+           (tr (abs (/ (dot a k) (* amp (sqrt kk)))))
+           (best2 (if (> amp best) amp best))
+           (bt2   (if (> amp best) t best-t))
+           (wt2   (if (> tr worst-tr) tr worst-tr))
+           (km2   (if (< kk kmin) kk kmin))
+           (kmt2  (if (< kk kmin) t kmin-t)))
+      (if (>= n n-steps)
+          (list amp0 best2 bt2 amp wt2 km2 kmt2)
+          (loop (+ n 1) (+ t dt-pulse) (rk4-step a t dt-pulse)
+                amp0 best2 bt2 wt2 km2 kmt2)))))
+
+(define run (integrate))
+(define amp-initial (list-ref run 0))
+(define amp-max     (list-ref run 1))
+(define amp-max-t   (list-ref run 2))
+(define amp-final   (list-ref run 3))
+(define transv-worst (list-ref run 4))
+(define k2-min      (list-ref run 5))
+(define k2-min-t    (list-ref run 6))
+
+(display "Craik-Criminale pulse mode on an affine background:") (newline)
+(show "initial amplitude          " amp-initial)
+(show "maximum amplitude          " amp-max)
+(show "time of maximum            " amp-max-t)
+(show "final amplitude            " amp-final)
+(show "amplification factor       " (/ amp-max amp-initial))
+(show "worst |a.k|/(|a||k|)       " transv-worst)
+(show "minimum |k|^2              " k2-min)
+(show "time of minimum |k|^2      " k2-min-t)
+(show "|k|^2 at the final time    " (+ 1.0 (let ((s (- (exact->inexact k2-0)
+                                                       (* shear k1-0 (* n-steps dt-pulse)))))
+                                             (* s s))))
+
+(check "the wave stays transverse to its wavevector along the integration"
+       (< transv-worst 1e-8))
+
+(check "shear amplification: the amplitude grows well above its initial value"
+       (> (/ amp-max amp-initial) 1.5))
+
+(check "the maximum is interior, not at either endpoint"
+       (and (> amp-max-t (* 2.0 dt-pulse))
+            (< amp-max-t (- (* n-steps dt-pulse) (* 2.0 dt-pulse)))))
+
+(check "viscous damping then wins: the final amplitude is below the maximum"
+       (< amp-final (* 0.5 amp-max)))
+
+(check "the damping overtakes the amplification: final below initial"
+       (< amp-final amp-initial))
+
+(check "the shear shortens the radial wavelength: |k|^2 has an interior minimum"
+       (and (> k2-min-t (* 2.0 dt-pulse))
+            (< k2-min-t (- (* n-steps dt-pulse) (* 2.0 dt-pulse)))
+            (< k2-min (+ 1.0 (let ((s (- (exact->inexact k2-0)
+                                         (* shear k1-0 (* n-steps dt-pulse)))))
+                               (* s s))))))
+
+(check "the amplitude peak follows the wavelength minimum, as the Orr mechanism requires"
+       (close? amp-max-t k2-min-t (* 40.0 dt-pulse)))
+
+(display "Navier-Stokes pulse fluxes and the averaged quadratic stress") (newline)
+(display "Passed: ") (display pass-count) (newline)
+(display "Failed: ") (display fail-count) (newline)
+;; The examples suite is a compile-and-run smoke gate: a program that prints a
+;; failure and exits zero still passes it.  Exit nonzero so a broken check is
+;; loud in CI.
+(if (= fail-count 0)
+    (begin (display "RESULT: ALL PASS") (newline) (exit 0))
+    (begin (display "RESULT: FAILURES DETECTED") (newline) (exit 1)))

--- a/examples/mathematics_navier_stokes_similarity_scales.esk
+++ b/examples/mathematics_navier_stokes_similarity_scales.esk
@@ -1,0 +1,485 @@
+;; Navier-Stokes blowup construction -- similarity coordinates and scale laws.
+;;
+;; Source: "Finite Time Blowup for Navier-Stokes" (OpenAI, 2026),
+;; https://cdn.openai.com/pdf/32d9f210-8b73-45e0-91bc-82a30aef8a9a/navier-stokes.pdf
+;; Sections 2.1 (physical description of the inner core), 3.1 (the
+;; concentrating leading field) and 4.1 (similarity variables).
+;;
+;; With tau = 1 - t, A = 1/2 + h, D = 1/2 - h, the similarity coordinates (3.2)
+;; are
+;;     tau = q (1 - eta^2),   z = q^D eta,   X = r^2 / (2 q),
+;; and the leading axisymmetric field (4.3) is
+;;     u_theta = q^{-A} E(X,eta),   u_z = q^{-A} U(X,eta),
+;;     r u_r   = V0(X,eta),         p   = q^{-2A} Pi(X,eta),
+;; with V0 fixed by incompressibility and Pi by the centrifugal balance (4.7):
+;;     V0 = (X/L)(2 eta U - 2 D eta A_X(U) - d d_eta A_X(U)),   Pi_X = E^2/(2X),
+;;     d = 1 - eta^2,   L = 1 - 2 h eta^2.
+;;
+;; This program installs concrete smooth profiles satisfying those constraints
+;; and the regularity conditions (4.4), builds the physical field in (r,z,t)
+;; through the implicit relation q - z^2 q^{2h} = tau, and then COMPUTES, with
+;; AD only:
+;;   (a) that the ansatz is divergence free, as the identity (4.7) between
+;;       d_X V0 and the axial profile derivatives;
+;;   (b) the coordinate derivatives of Lemma 4.1, differentiated through the
+;;       implicit solve for q;
+;;   (c) the scale laws of Section 2.1 -- l_r, l_z, l_r/l_z, sup|u_theta|,
+;;       sup|u_z|, sup|u_r|, Re_theta, Re_r and the axial/radial diffusion
+;;       ratio -- each as an exponent fitted from the computed quantity at
+;;       several tau and compared with its exact value;
+;;   (d) the core kinetic energy exponent 1/2 - 3h;
+;;   (e) that the momentum residual of this background alone blows up like
+;;       tau^{-(1/2+h)-1} in the annulus, which is why the paper adds
+;;       oscillatory pulses to supply the missing momentum transport.
+;;
+;; The profiles below satisfy incompressibility, the pressure balance and the
+;; axis regularity of (4.4), but they are NOT the profiles of Theorem 4.6: no
+;; attempt is made here to make the leading residual vanish on the inner region
+;; or to match the heat exterior.  Consequently the residual in (e) is
+;; unbounded everywhere in the core, not only in the annulus.
+;;
+;; DEFECT NOTE.  Nested differentiation works only with `derivative` as the
+;; outer pass; `derivative-n` as an outer pass over a differentiating body
+;; silently returns 0.  Every derivative in this file therefore uses
+;; `derivative`, and second derivatives are nested `derivative` calls.  Minimal
+;; repro: (derivative-n (lambda (a) (derivative-n (lambda (b) (* a b)) 1.0 1)) 2.0 1)
+;; returns 0 where 1 is expected.
+
+(define pass-count 0)
+(define fail-count 0)
+
+(define (check label ok)
+  (if ok
+      (begin (set! pass-count (+ pass-count 1))
+             (display "PASS: ") (display label) (newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "FAIL: ") (display label) (newline))))
+
+(define (close? a b tol) (< (abs (- a b)) tol))
+
+(define (show label v) (display "  ") (display label) (display " = ") (display v) (newline))
+
+;; ---------------------------------------------------------------------------
+;; Fixed exponents.
+;; ---------------------------------------------------------------------------
+
+(define h 0.005)                      ;; 1/200, inside the paper's 0 < h < 1/100
+(define A (+ 0.5 h))
+(define D (- 0.5 h))
+(define pi4 (* 4.0 (atan 1.0)))
+
+;; ---------------------------------------------------------------------------
+;; Profiles.  U and F are polynomial and F > 0 on the region used below, so
+;; E = sqrt(2X) F vanishes linearly in r at the axis, as (4.4) requires.
+;; U(X,0) is nonzero and U is not odd in eta: the slightly asymmetric axial
+;; profile of Section 2.1.
+;; ---------------------------------------------------------------------------
+
+(define (Fp X e) (- (+ 1.0 (* 0.1 e e)) (* 0.25 X)))
+(define (Ep X e) (* (sqrt (* 2.0 X)) (Fp X e)))
+(define (Up X e) (* (+ 1.0 (* 0.05 e)) (- 1.0 (* 0.5 X))))
+
+;; Simpson's rule.  Exact for integrands of degree at most three, which covers
+;; U (degree 1 in x) and F^2 (degree 2 in x).  It uses no AD, so it can sit
+;; inside a differentiated body.
+(define (simpson g a b)
+  (* (/ (- b a) 6.0)
+     (+ (g a) (* 4.0 (g (* 0.5 (+ a b)))) (g b))))
+
+(define (AXU X e)                       ;; the radial average A_X(U) of (4.6)
+  (if (< (abs X) 1e-12)
+      (Up 0.0 e)
+      (/ (simpson (lambda (x) (Up x e)) 0.0 X) X)))
+
+(define (dvar f x) (derivative f x))    ;; nests correctly as an outer pass
+
+(define (Lco e) (- 1.0 (* 2.0 h e e)))
+(define (dco e) (- 1.0 (* e e)))
+
+(define (V0 X e)                        ;; (4.7), first identity
+  (* (/ X (Lco e))
+     (- (* 2.0 e (Up X e))
+        (* 2.0 D e (AXU X e))
+        (* (dco e) (dvar (lambda (s) (AXU X s)) e)))))
+
+(define (Pip X e) (simpson (lambda (x) (let ((f (Fp x e))) (* f f))) 0.0 X))
+
+;; ---------------------------------------------------------------------------
+;; (a) Incompressibility.  The cylindrical divergence of the ansatz is
+;;     q^{-1} [ d_X V0 - (2 A eta U - d U_eta + 2 eta X U_X)/L ],
+;; so the ansatz is divergence free exactly when the bracket vanishes.
+;; ---------------------------------------------------------------------------
+
+(define (incompressibility-gap X e)
+  (- (dvar (lambda (s) (V0 s e)) X)
+     (/ (- (+ (* 2.0 A e (Up X e))
+              (* 2.0 e X (dvar (lambda (s) (Up s e)) X)))
+           (* (dco e) (dvar (lambda (s) (Up X s)) e)))
+        (Lco e))))
+
+(define profile-samples
+  (list (list 0.35 0.0) (list 0.8 0.4) (list 1.4 -0.6) (list 2.0 0.75)))
+
+(check "ansatz is divergence free: (4.7) holds at every sample (X,eta)"
+       (let loop ((ss profile-samples))
+         (cond ((null? ss) #t)
+               ((< (abs (incompressibility-gap (car (car ss)) (cadr (car ss)))) 1e-9)
+                (loop (cdr ss)))
+               (else #f))))
+
+(check "negative control -- perturbing V0 breaks incompressibility"
+       (> (abs (- (dvar (lambda (s) (* 1.02 (V0 s 0.4))) 0.8)
+                  (dvar (lambda (s) (V0 s 0.4)) 0.8)))
+          1e-6))
+
+(check "pressure balance Pi_X = E^2/(2X) holds at every sample (X,eta)"
+       (let loop ((ss profile-samples))
+         (cond ((null? ss) #t)
+               ((let* ((X (car (car ss))) (e (cadr (car ss)))
+                       (lhs (dvar (lambda (s) (Pip s e)) X))
+                       (ee (Ep X e))
+                       (rhs (/ (* ee ee) (* 2.0 X))))
+                  (< (abs (- lhs rhs)) 1e-9))
+                (loop (cdr ss)))
+               (else #f))))
+
+;; ---------------------------------------------------------------------------
+;; The physical field.  q(z,tau) solves q - z^2 q^{2h} = tau; the iteration
+;; q <- tau + z^2 q^{2h} has multiplier 2 h eta^2 < 2h, so it converges
+;; geometrically at rate below 1/100.
+;; ---------------------------------------------------------------------------
+
+(define (qsolve z tau)
+  (let loop ((k 0) (q tau))
+    (if (>= k 24)
+        q
+        (loop (+ k 1) (+ tau (* z z (expt q (* 2.0 h))))))))
+
+(define (Xof r z tau) (/ (* r r) (* 2.0 (qsolve z tau))))
+(define (etaof z tau) (* z (expt (qsolve z tau) (- D))))
+
+(define (u-theta r z t)
+  (let* ((tau (- 1.0 t)) (q (qsolve z tau)))
+    (* (expt q (- A)) (Ep (/ (* r r) (* 2.0 q)) (* z (expt q (- D)))))))
+
+(define (u-zed r z t)
+  (let* ((tau (- 1.0 t)) (q (qsolve z tau)))
+    (* (expt q (- A)) (Up (/ (* r r) (* 2.0 q)) (* z (expt q (- D)))))))
+
+(define (u-rad r z t)
+  (let* ((tau (- 1.0 t)) (q (qsolve z tau)))
+    (/ (V0 (/ (* r r) (* 2.0 q)) (* z (expt q (- D)))) r)))
+
+(define (p-field r z t)
+  (let* ((tau (- 1.0 t)) (q (qsolve z tau)))
+    (* (expt q (* -2.0 A)) (Pip (/ (* r r) (* 2.0 q)) (* z (expt q (- D)))))))
+
+;; ---------------------------------------------------------------------------
+;; (b) Lemma 4.1: the coordinate derivatives, obtained by differentiating
+;; through the implicit solve and compared with the closed forms in the proof.
+;; ---------------------------------------------------------------------------
+
+(define (lemma41-worst X e tau)
+  (let* ((q (/ tau (dco e)))
+         (z (* (expt q D) e))
+         (t (- 1.0 tau))
+         (L (Lco e))
+         (dd (dco e))
+         (qz-ad (dvar (lambda (s) (qsolve s tau)) z))
+         (qt-ad (dvar (lambda (s) (qsolve z (- 1.0 s))) t))
+         (ez-ad (dvar (lambda (s) (etaof s tau)) z))
+         (xz-ad (dvar (lambda (s) (Xof (sqrt (* 2.0 q X)) s tau)) z))
+         (xt-ad (dvar (lambda (s) (Xof (sqrt (* 2.0 q X)) z (- 1.0 s))) t))
+         (qz    (/ (* 2.0 e (expt q (- 1.0 D))) L))
+         (qt    (/ -1.0 L))
+         (ez    (/ dd (* (expt q D) L)))
+         (xz    (/ (* -2.0 e X) (* (expt q D) L)))
+         (xt    (/ X (* q L))))
+    (max (abs (- qz-ad qz)) (abs (- qt-ad qt)) (abs (- ez-ad ez))
+         (abs (- xz-ad xz)) (abs (- xt-ad xt)))))
+
+(check "implicit relation for q is solved to 1e-14"
+       (let* ((tau 1e-4) (e 0.6) (q (/ tau (dco e))) (z (* (expt q D) e)))
+         (< (abs (- (qsolve z tau) (+ tau (* z z (expt (qsolve z tau) (* 2.0 h))))))
+            1e-14)))
+
+(check "Lemma 4.1 coordinate derivatives match AD through the implicit solve"
+       (< (lemma41-worst 0.8 0.5 1e-3) 1e-7))
+
+;; ---------------------------------------------------------------------------
+;; (c) The scale laws of Section 2.1, as fitted exponents.
+;; ---------------------------------------------------------------------------
+
+(define Xc 1.5)                          ;; core in similarity coordinates
+(define ec 0.8)
+
+(define (log-slope f t1 t2)
+  (/ (- (log (f t2)) (log (f t1)))
+     (- (log t2) (log t1))))
+
+(define (grid n a b)                     ;; n+1 equally spaced nodes
+  (let loop ((k n) (acc '()))
+    (if (< k 0) acc (loop (- k 1) (cons (+ a (* (- b a) (/ (exact->inexact k) n))) acc)))))
+
+(define Xnodes (grid 12 1e-6 Xc))
+(define Enodes (grid 12 (- ec) ec))
+
+(define (sup-over-core g tau)
+  (let loopE ((es Enodes) (best 0.0))
+    (if (null? es)
+        best
+        (loopE (cdr es)
+               (let* ((e (car es)) (q (/ tau (dco e))))
+                 (let loopX ((xs Xnodes) (b best))
+                   (if (null? xs)
+                       b
+                       (let ((v (abs (g (car xs) e q))))
+                         (loopX (cdr xs) (if (> v b) v b)))))))))) 
+
+(define (sup-utheta tau) (sup-over-core (lambda (X e q) (* (expt q (- A)) (Ep X e))) tau))
+(define (sup-uz tau)     (sup-over-core (lambda (X e q) (* (expt q (- A)) (Up X e))) tau))
+(define (sup-ur tau)     (sup-over-core (lambda (X e q) (/ (V0 X e) (sqrt (* 2.0 q X)))) tau))
+
+(define (lr tau) (sqrt (* 2.0 (/ tau (dco ec)) Xc)))
+(define (lz tau) (* (expt (/ tau (dco ec)) D) ec))
+
+(define tau-a 1e-4)
+(define tau-b 1e-7)
+
+(define slope-lr (log-slope lr tau-a tau-b))
+(define slope-lz (log-slope lz tau-a tau-b))
+(define slope-ratio (log-slope (lambda (s) (/ (lr s) (lz s))) tau-a tau-b))
+(define slope-ut (log-slope sup-utheta tau-a tau-b))
+(define slope-uz (log-slope sup-uz tau-a tau-b))
+(define slope-ur (log-slope sup-ur tau-a tau-b))
+(define slope-ret (log-slope (lambda (s) (* (sup-utheta s) (lr s))) tau-a tau-b))
+(define slope-rer (log-slope (lambda (s) (* (sup-ur s) (lr s))) tau-a tau-b))
+(define slope-diff (log-slope (lambda (s) (let ((a (lr s)) (b (lz s))) (/ (* a a) (* b b))))
+                              tau-a tau-b))
+
+(display "Fitted scale-law exponents (tau from 1e-4 to 1e-7):") (newline)
+(show "l_r                       " slope-lr)
+(show "l_z                       " slope-lz)
+(show "l_r / l_z                 " slope-ratio)
+(show "sup |u_theta|             " slope-ut)
+(show "sup |u_z|                 " slope-uz)
+(show "sup |u_r|                 " slope-ur)
+(show "Re_theta = sup|u_theta| l_r" slope-ret)
+(show "Re_r     = sup|u_r| l_r   " slope-rer)
+(show "l_r^2 / l_z^2             " slope-diff)
+
+(check "l_r ~ tau^{1/2}"            (close? slope-lr 0.5 1e-9))
+(check "l_z ~ tau^{1/2-h}"          (close? slope-lz D 1e-9))
+(check "l_r/l_z ~ tau^{h}"          (close? slope-ratio h 1e-9))
+(check "sup|u_theta| ~ tau^{-1/2-h}" (close? slope-ut (- A) 1e-9))
+(check "sup|u_z| ~ tau^{-1/2-h}"    (close? slope-uz (- A) 1e-9))
+(check "sup|u_r| ~ tau^{-1/2}"      (close? slope-ur -0.5 1e-9))
+(check "Re_theta ~ tau^{-h}, unbounded"
+       (and (close? slope-ret (- h) 1e-9)
+            (> (* (sup-utheta tau-b) (lr tau-b)) (* (sup-utheta tau-a) (lr tau-a)))))
+(check "Re_r = O(1): exponent 0"    (close? slope-rer 0.0 1e-9))
+(check "axial/radial diffusion ratio ~ tau^{2h}, vanishing"
+       (and (close? slope-diff (* 2.0 h) 1e-9)
+            (< (let ((a (lr tau-b)) (b (lz tau-b))) (/ (* a a) (* b b)))
+               (let ((a (lr tau-a)) (b (lz tau-a))) (/ (* a a) (* b b))))))
+
+;; ---------------------------------------------------------------------------
+;; (d) Core kinetic energy.  In similarity coordinates,
+;;     E(tau) = pi tau^D int G(eta) [ V0^2/(2X) + q^{1-2A} (2 X F^2 + U^2) ] dX deta,
+;; with q = tau/(1-eta^2) and G = d/deta [ eta (1-eta^2)^{-D} ] the axial
+;; Jacobian, computed by AD.  The bracket carries two powers of tau: the radial
+;; term contributes tau^D and the tangential term tau^{D-2h} = tau^{1/2-3h}.
+;; ---------------------------------------------------------------------------
+
+(define (Gjac e) (dvar (lambda (s) (* s (expt (- 1.0 (* s s)) (- D)))) e))
+
+(define (simpson-composite g a b n)      ;; n even
+  (let* ((hstep (/ (- b a) (exact->inexact n))))
+    (let loop ((k 0) (acc 0.0))
+      (if (> k n)
+          (* (/ hstep 3.0) acc)
+          (let* ((x (+ a (* k hstep)))
+                 (w (cond ((or (= k 0) (= k n)) 1.0)
+                          ((odd? k) 4.0)
+                          (else 2.0))))
+            (loop (+ k 1) (+ acc (* w (g x)))))))))
+
+(define (energy-density tau radial? tangential?)
+  (lambda (e)
+    (let ((q (/ tau (dco e))))
+      (* (Gjac e)
+         (simpson-composite
+          (lambda (X)
+            (+ (if (and radial? (> X 1e-9))
+                   (let ((v (V0 X e))) (/ (* v v) (* 2.0 X)))
+                   0.0)
+               (if tangential?
+                   (let ((f (Fp X e)) (uu (Up X e)))
+                     (* (expt q (- 1.0 (* 2.0 A)))
+                        (+ (* 2.0 X f f) (* uu uu))))
+                   0.0)))
+          1e-9 Xc 12)))))
+
+(define (core-energy tau radial? tangential?)
+  (* pi4 (expt tau D)
+     (simpson-composite (energy-density tau radial? tangential?) (- ec) ec 12)))
+
+(define (energy-full tau) (core-energy tau #t #t))
+(define (energy-tan  tau) (core-energy tau #f #t))
+
+(define energy-taus (list 1e-3 1e-5 1e-7 1e-9))
+
+(define (consecutive-slopes f ts)
+  (let loop ((ls ts) (acc '()))
+    (if (null? (cdr ls))
+        (reverse acc)
+        (loop (cdr ls) (cons (log-slope f (car ls) (cadr ls)) acc)))))
+
+(define energy-slopes (consecutive-slopes energy-full energy-taus))
+(define energy-target (- 0.5 (* 3.0 h)))
+
+(display "Core kinetic energy: exact leading exponent 1/2-3h = ")
+(display energy-target) (newline)
+(display "  fitted slopes over consecutive tau decades: ")
+(display energy-slopes) (newline)
+(show "tangential-part slope      " (log-slope energy-tan 1e-3 1e-9))
+
+(check "core kinetic energy of the tangential field scales exactly as tau^{1/2-3h}"
+       (close? (log-slope energy-tan 1e-3 1e-9) energy-target 1e-9))
+
+;; The radial part contributes tau^{D} = tau^{1/2-h}, so the total energy has a
+;; relative correction of size tau^{2h}, which biases the fitted slope upward by
+;; at most 2h.  This is why the bound below is 2h and not machine precision.
+(check "total core kinetic energy exponent lies within 2h of 1/2-3h"
+       (let loop ((ss energy-slopes))
+         (cond ((null? ss) #t)
+               ((and (> (car ss) (- energy-target 1e-9))
+                     (< (car ss) (+ energy-target (* 2.0 h) 1e-9)))
+                (loop (cdr ss)))
+               (else #f))))
+
+(check "the fitted energy exponent decreases toward 1/2-3h as tau decreases"
+       (let loop ((ss energy-slopes))
+         (cond ((null? (cdr ss)) #t)
+               ((< (cadr ss) (car ss)) (loop (cdr ss)))
+               (else #f))))
+
+(check "core kinetic energy tends to zero as tau -> 0"
+       (and (< (energy-full 1e-9) (energy-full 1e-3))
+            (< (energy-full 1e-9) 1e-3)))
+
+;; ---------------------------------------------------------------------------
+;; (e) The momentum residual of the background alone.
+;;
+;; For an axisymmetric field the angular momentum residual is
+;;   R_theta = d_t u_theta + u_r d_r u_theta + u_z d_z u_theta + u_r u_theta / r
+;;             - ( d_rr u_theta + d_r u_theta / r - u_theta / r^2 + d_zz u_theta ),
+;; and (4.12) removes the axial viscosity to isolate the leading tangential
+;; residual R_theta^{(0)}.  All derivatives below are AD through the implicit
+;; solve for q.
+;; ---------------------------------------------------------------------------
+
+(define (d-r f r z t) (dvar (lambda (s) (f s z t)) r))
+(define (d-z f r z t) (dvar (lambda (s) (f r s t)) z))
+(define (d-t f r z t) (dvar (lambda (s) (f r z s)) t))
+(define (d-rr f r z t) (dvar (lambda (s) (dvar (lambda (w) (f w z t)) s)) r))
+(define (d-zz f r z t) (dvar (lambda (s) (dvar (lambda (w) (f r w t)) s)) z))
+
+(define (R-theta r z t axial-viscosity?)
+  (let* ((ut (u-theta r z t))
+         (ur (u-rad r z t))
+         (uz (u-zed r z t)))
+    (+ (d-t u-theta r z t)
+       (* ur (d-r u-theta r z t))
+       (* uz (d-z u-theta r z t))
+       (/ (* ur ut) r)
+       (- (+ (d-rr u-theta r z t)
+             (/ (d-r u-theta r z t) r)
+             (- (/ ut (* r r)))
+             (if axial-viscosity? (d-zz u-theta r z t) 0.0))))))
+
+(define (R-zed r z t axial-viscosity?)
+  (let* ((ur (u-rad r z t))
+         (uz (u-zed r z t)))
+    (+ (d-t u-zed r z t)
+       (* ur (d-r u-zed r z t))
+       (* uz (d-z u-zed r z t))
+       (d-z p-field r z t)
+       (- (+ (d-rr u-zed r z t)
+             (/ (d-r u-zed r z t) r)
+             (if axial-viscosity? (d-zz u-zed r z t) 0.0))))))
+
+;; A fixed similarity location in the annulus outside the inner profile.
+(define Xann 1.2)
+(define eann 0.35)
+
+(define (annulus-point tau)
+  (let* ((q (/ tau (dco eann))))
+    (list (sqrt (* 2.0 q Xann)) (* (expt q D) eann) (- 1.0 tau) q)))
+
+(define (Rth-at tau leading?)
+  (let ((pt (annulus-point tau)))
+    (R-theta (car pt) (cadr pt) (caddr pt) (not leading?))))
+
+(define (Rz-at tau leading?)
+  (let ((pt (annulus-point tau)))
+    (R-zed (car pt) (cadr pt) (caddr pt) (not leading?))))
+
+(define (rescaled-Rth tau)
+  (let ((pt (annulus-point tau)))
+    (* (expt (cadddr pt) (+ A 1.0)) (Rth-at tau #t))))
+
+(define residual-taus (list 1e-2 1e-4 1e-6 1e-8))
+
+(define rth-slopes
+  (consecutive-slopes (lambda (s) (abs (Rth-at s #t))) residual-taus))
+(define rth-full-slopes
+  (consecutive-slopes (lambda (s) (abs (Rth-at s #f))) residual-taus))
+(define rz-slopes
+  (consecutive-slopes (lambda (s) (abs (Rz-at s #t))) residual-taus))
+
+(display "Background momentum residual in the annulus (X=1.2, eta=0.35):") (newline)
+(show "|R_theta| at tau=1e-2       " (abs (Rth-at 1e-2 #f)))
+(show "|R_theta| at tau=1e-8       " (abs (Rth-at 1e-8 #f)))
+(show "exact leading exponent -(1+A)" (- (+ 1.0 A)))
+(show "fitted exponents, R_theta^(0)" rth-slopes)
+(show "fitted exponents, R_z^(0)   " rz-slopes)
+(show "fitted exponents, full R_theta" rth-full-slopes)
+(show "q^{A+1} R_theta^(0) at tau=1e-2" (rescaled-Rth 1e-2))
+(show "q^{A+1} R_theta^(0) at tau=1e-8" (rescaled-Rth 1e-8))
+
+(check "the background residual grows without bound as tau -> 0"
+       (and (> (abs (Rth-at 1e-8 #f)) (abs (Rth-at 1e-2 #f)))
+            (> (abs (Rth-at 1e-8 #f)) 1e6)))
+
+(check "q^{A+1} R_theta^(0) is independent of tau over six decades"
+       (< (abs (- (rescaled-Rth 1e-2) (rescaled-Rth 1e-8)))
+          (* 1e-6 (abs (rescaled-Rth 1e-2)))))
+
+(check "leading angular residual grows exactly like tau^{-(1+A)}"
+       (let loop ((ss rth-slopes))
+         (cond ((null? ss) #t)
+               ((close? (car ss) (- (+ 1.0 A)) 1e-6) (loop (cdr ss)))
+               (else #f))))
+
+(check "leading axial residual grows exactly like tau^{-(1+A)}"
+       (let loop ((ss rz-slopes))
+         (cond ((null? ss) #t)
+               ((close? (car ss) (- (+ 1.0 A)) 1e-6) (loop (cdr ss)))
+               (else #f))))
+
+(check "full angular residual, axial viscosity included, is within 2h of -(1+A)"
+       (let loop ((ss rth-full-slopes))
+         (cond ((null? ss) #t)
+               ((< (abs (- (car ss) (- (+ 1.0 A)))) (+ (* 2.0 h) 1e-6)) (loop (cdr ss)))
+               (else #f))))
+
+(display "Navier-Stokes similarity coordinates and scale laws") (newline)
+(display "Passed: ") (display pass-count) (newline)
+(display "Failed: ") (display fail-count) (newline)
+;; The examples suite is a compile-and-run smoke gate: a program that prints a
+;; failure and exits zero still passes it.  Exit nonzero so a broken check is
+;; loud in CI.
+(if (= fail-count 0)
+    (begin (display "RESULT: ALL PASS") (newline) (exit 0))
+    (begin (display "RESULT: FAILURES DETECTED") (newline) (exit 1)))

--- a/examples/mathematics_navier_stokes_viscosity_scaling.esk
+++ b/examples/mathematics_navier_stokes_viscosity_scaling.esk
@@ -1,0 +1,288 @@
+;; Navier-Stokes blowup construction -- viscosity scaling of the residual.
+;;
+;; Source: "Finite Time Blowup for Navier-Stokes" (OpenAI, 2026),
+;; https://cdn.openai.com/pdf/32d9f210-8b73-45e0-91bc-82a30aef8a9a/navier-stokes.pdf
+;; Section 3 (proof outline) and Section 10.4, equations (10.22)-(10.23).
+;;
+;; The residual operator of (3.1), at viscosity nu, is
+;;     R(u,p) = d_t u + (u . grad) u - nu Lap u + grad p,     div u = 0,
+;; and the paper's viscosity rescaling is
+;;     u_nu(x,t) = sqrt(nu) u(x/sqrt(nu), t),
+;;     p_nu(x,t) = nu p(x/sqrt(nu), t),
+;;     f_nu(x,t) = sqrt(nu) f(x/sqrt(nu), t),
+;; with the energy and dissipation identities (10.23)
+;;     ||u_nu(t)||_2^2 = nu^{5/2} ||u(t)||_2^2,
+;;     nu ||grad u_nu||_2^2 = nu^{5/2} ||grad u||_2^2.
+;;
+;; Everything below is computed: the residual is assembled from AD partial
+;; derivatives of an explicit smooth divergence-free test field, never from a
+;; hand-differentiated formula.  For a rational nu whose square root is
+;; rational, the whole computation stays in exact rational arithmetic and the
+;; scaling identities are checked with `=`, not with a tolerance.
+;;
+;; The test field (polynomial, so the AD tower stays exact):
+;;     u1 = (1+t) y^2 z,   u2 = (1+t) z^2 x,   u3 = (1+t) x^2 y,
+;;     p  = x y z + t x^2.
+;; d_x u1 = d_y u2 = d_z u3 = 0, so div u = 0 identically, while the advection
+;; and Laplacian terms are both nonzero -- nu really enters the residual.
+;;
+;; TWO TRACKED DEFECTS, both worked around explicitly rather than silently.
+;;
+;;  1. `derivative` at an exact rational seed returns 0 when the differentiand
+;;     calls a named multi-argument function with a non-integer exact rational
+;;     captured argument, disagreeing with `derivative-n f x 1` on the same
+;;     differentiand at the same point.  Every derivative below therefore goes
+;;     through `derivative-n`.
+;;
+;;  2. A derivative whose differentiand does not depend on the seed variable at
+;;     all comes back as an INEXACT zero at an exact rational seed, which
+;;     demotes any exact sum it enters.  `dn` below snaps that zero back to the
+;;     exact zero so the residual assembly stays in exact arithmetic.
+;;
+;; Minimal repro for 1: (derivative (lambda (s) (* 1/2 s s)) 0.4) returns 0
+;; where (derivative-n (lambda (s) (* 1/2 s s)) 0.4 1) returns 0.4.
+;; Minimal repro for 2: (exact? (derivative-n (lambda (s) 1/3) 1/2 1)) is #f.
+
+(define pass-count 0)
+(define fail-count 0)
+
+(define (check label ok)
+  (if ok
+      (begin (set! pass-count (+ pass-count 1))
+             (display "PASS: ") (display label) (newline))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "FAIL: ") (display label) (newline))))
+
+(define (close? a b tol) (< (abs (- a b)) tol))
+
+;; ---------------------------------------------------------------------------
+;; AD partials.  d1/d2 are exact at an exact rational seed.
+;; ---------------------------------------------------------------------------
+
+;; `dn` is `derivative-n` with the inexact-zero leak of defect 2 repaired.
+(define (dn f x k)
+  (let ((v (derivative-n f x k)))
+    (if (= v 0) 0 v)))
+
+(define (d1 f x) (dn f x 1))
+(define (d2 f x) (dn f x 2))
+
+;; ---------------------------------------------------------------------------
+;; The viscosity-one reference field.
+;; ---------------------------------------------------------------------------
+
+(define (u-ref i x y z t)
+  (cond ((= i 1) (* (+ 1 t) y y z))
+        ((= i 2) (* (+ 1 t) z z x))
+        (else    (* (+ 1 t) x x y))))
+
+(define (p-ref x y z t) (+ (* x y z) (* t x x)))
+
+;; The rescaled field of (10.22).  `sn` is sqrt(nu); `nu` is (* sn sn).
+;; `up` selects the velocity power of sn and `pp` the pressure power, so the
+;; negative controls below can break exactly one of them.
+(define (u-scaled up i sn x y z t)
+  (* up (u-ref i (/ x sn) (/ y sn) (/ z sn) t)))
+
+(define (p-scaled pp sn x y z t)
+  (* pp (p-ref (/ x sn) (/ y sn) (/ z sn) t)))
+
+;; ---------------------------------------------------------------------------
+;; The residual operator, assembled entirely from AD partials.
+;; ---------------------------------------------------------------------------
+
+(define (div-u up sn x y z t)
+  (+ (d1 (lambda (s) (u-scaled up 1 sn s y z t)) x)
+     (d1 (lambda (s) (u-scaled up 2 sn x s z t)) y)
+     (d1 (lambda (s) (u-scaled up 3 sn x y s t)) z)))
+
+(define (residual up pp nu sn i x y z t)
+  (let* ((ut  (d1 (lambda (s) (u-scaled up i sn x y z s)) t))
+         (uix (d1 (lambda (s) (u-scaled up i sn s y z t)) x))
+         (uiy (d1 (lambda (s) (u-scaled up i sn x s z t)) y))
+         (uiz (d1 (lambda (s) (u-scaled up i sn x y s t)) z))
+         (u1  (u-scaled up 1 sn x y z t))
+         (u2  (u-scaled up 2 sn x y z t))
+         (u3  (u-scaled up 3 sn x y z t))
+         (lap (+ (d2 (lambda (s) (u-scaled up i sn s y z t)) x)
+                 (d2 (lambda (s) (u-scaled up i sn x s z t)) y)
+                 (d2 (lambda (s) (u-scaled up i sn x y s t)) z)))
+         (gp  (cond ((= i 1) (d1 (lambda (s) (p-scaled pp sn s y z t)) x))
+                    ((= i 2) (d1 (lambda (s) (p-scaled pp sn x s z t)) y))
+                    (else    (d1 (lambda (s) (p-scaled pp sn x y s t)) z)))))
+    (+ ut (* u1 uix) (* u2 uiy) (* u3 uiz) (* -1 nu lap) gp)))
+
+;; ---------------------------------------------------------------------------
+;; Sample points and the rational viscosities.  sqrt(nu) is rational for each,
+;; so every check on this list is an exact rational equality.
+;; ---------------------------------------------------------------------------
+
+(define sample-points
+  (list (list 1/2 1/3 1/5 1/7)
+        (list -2/3 5/4 -1/6 3/8)
+        (list 7/5 -1/2 2/9 -4/11)))
+
+(define rational-sqrt-nus (list 1/2 2 3/4 5/3 1))   ;; these are sqrt(nu)
+
+;; --- divergence ------------------------------------------------------------
+
+(define (all-div-zero? sn up)
+  (let loop ((ps sample-points))
+    (if (null? ps)
+        #t
+        (let ((pt (car ps)))
+          (if (= 0 (div-u up sn (car pt) (cadr pt) (caddr pt) (cadddr pt)))
+              (loop (cdr ps))
+              #f)))))
+
+(check "reference field is exactly divergence free"
+       (all-div-zero? 1 1))
+
+(check "every rescaled field is exactly divergence free"
+       (let loop ((ns rational-sqrt-nus))
+         (cond ((null? ns) #t)
+               ((all-div-zero? (car ns) (car ns)) (loop (cdr ns)))
+               (else #f))))
+
+;; --- the scaling identity (10.22) -----------------------------------------
+;; R_nu(u_nu, p_nu)(x,t) = sqrt(nu) . R_1(u,p)(x/sqrt(nu), t)
+
+(define (scaling-gap up pp sn pt)
+  ;; largest |left - right| over the three components at one point
+  (let* ((x (car pt)) (y (cadr pt)) (z (caddr pt)) (t (cadddr pt))
+         (nu (* sn sn)))
+    (let loop ((i 1) (worst 0))
+      (if (> i 3)
+          worst
+          (let* ((lhs (residual up pp nu sn i x y z t))
+                 (rhs (* sn (residual 1 1 1 1 i (/ x sn) (/ y sn) (/ z sn) t)))
+                 (gap (abs (- lhs rhs))))
+            (loop (+ i 1) (if (> gap worst) gap worst)))))))
+
+(define (max-gap-over-points up pp sn)
+  (let loop ((ps sample-points) (worst 0))
+    (if (null? ps)
+        worst
+        (let ((g (scaling-gap up pp sn (car ps))))
+          (loop (cdr ps) (if (> g worst) g worst))))))
+
+(check "residual scaling identity (10.22) holds exactly at every rational nu"
+       (let loop ((ns rational-sqrt-nus))
+         (cond ((null? ns) #t)
+               ((= 0 (max-gap-over-points (car ns) (* (car ns) (car ns)) (car ns)))
+                (loop (cdr ns)))
+               (else #f))))
+
+;; Negative controls: the identity must fail if either power of nu is wrong.
+(check "negative control -- unscaled velocity breaks the identity"
+       (> (max-gap-over-points 1 4 2) 0))
+(check "negative control -- unscaled pressure breaks the identity"
+       (> (max-gap-over-points 2 1 2) 0))
+
+;; --- inexact viscosity -----------------------------------------------------
+;; nu = 2 has an irrational square root, so this leg is a tolerance check.
+
+(define sqrt2 (sqrt 2.0))
+
+(check "residual scaling identity holds to 1e-9 at nu = 2 (irrational sqrt)"
+       (let* ((pt (list 0.5 0.3333333333333333 0.2 0.14285714285714285))
+              (g  (scaling-gap sqrt2 2.0 sqrt2 pt)))
+         (< g 1e-9)))
+
+;; --- energy and dissipation, (10.23) ---------------------------------------
+;; Riemann sums over corresponding grids: the nu grid is the reference grid
+;; scaled by sqrt(nu), so the identity below is exact term by term.
+
+(define grid-nodes (list -1/2 0 1/2))
+(define grid-step 1/2)
+
+(define (speed-squared up sn x y z t)
+  (let ((a (u-scaled up 1 sn x y z t))
+        (b (u-scaled up 2 sn x y z t))
+        (c (u-scaled up 3 sn x y z t)))
+    (+ (* a a) (* b b) (* c c))))
+
+(define (grad-squared up sn x y z t)
+  (let loop ((i 1) (acc 0))
+    (if (> i 3)
+        acc
+        (let ((gx (d1 (lambda (s) (u-scaled up i sn s y z t)) x))
+              (gy (d1 (lambda (s) (u-scaled up i sn x s z t)) y))
+              (gz (d1 (lambda (s) (u-scaled up i sn x y s t)) z)))
+          (loop (+ i 1) (+ acc (* gx gx) (* gy gy) (* gz gz)))))))
+
+;; Sum of `integrand` over the cube grid scaled by `sn`, with cell volume
+;; (sn*step)^3.
+(define (grid-sum integrand up sn t)
+  (let ((cell (* sn grid-step)))
+    (let loopx ((xs grid-nodes) (acc 0))
+      (if (null? xs)
+          (* acc cell cell cell)
+          (loopx (cdr xs)
+                 (let loopy ((ys grid-nodes) (a acc))
+                   (if (null? ys)
+                       a
+                       (loopy (cdr ys)
+                              (let loopz ((zs grid-nodes) (b a))
+                                (if (null? zs)
+                                    b
+                                    (loopz (cdr zs)
+                                           (+ b (integrand up sn
+                                                           (* sn (car xs))
+                                                           (* sn (car ys))
+                                                           (* sn (car zs))
+                                                           t)))))))))))))
+
+(define energy-time 1/3)
+
+(define (nu-pow-5/2 sn) (* sn sn sn sn sn))
+
+(check "discrete energy scales by nu^{5/2} exactly on the scaled grid"
+       (let ((base (grid-sum speed-squared 1 1 energy-time)))
+         (let loop ((ns rational-sqrt-nus))
+           (cond ((null? ns) #t)
+                 ((= (grid-sum speed-squared (car ns) (car ns) energy-time)
+                     (* (nu-pow-5/2 (car ns)) base))
+                  (loop (cdr ns)))
+                 (else #f)))))
+
+(check "discrete dissipation nu * |grad u_nu|^2 scales by nu^{5/2} exactly"
+       (let* ((base (grid-sum grad-squared 1 1 energy-time))
+              (sn 2)
+              (nu (* sn sn)))
+         (= (* nu (grid-sum grad-squared sn sn energy-time))
+            (* (nu-pow-5/2 sn) base))))
+
+;; The singular time is untouched by the rescaling: the reference and rescaled
+;; residuals are compared at the SAME t above, and this records that the time
+;; argument is never transformed.
+(check "the rescaling leaves the time variable untouched"
+       (= 0 (scaling-gap 2 4 2 (list 1/2 1/3 1/5 9/10))))
+
+(define (show label v) (display "  ") (display label) (display " = ") (display v) (newline))
+
+(display "Computed values:") (newline)
+(show "R_1(u,p) at (1/2,1/3,1/5,1/7), component 1"
+      (residual 1 1 1 1 1 1/2 1/3 1/5 1/7))
+(show "R_4(u_4,p_4) at (1,2/3,2/5,1/7), component 1"
+      (residual 2 4 4 2 1 1 2/3 2/5 1/7))
+(show "ratio of the two, exactly sqrt(nu) = 2"
+      (/ (residual 2 4 4 2 1 1 2/3 2/5 1/7)
+         (residual 1 1 1 1 1 1/2 1/3 1/5 1/7)))
+(show "discrete energy at nu = 1        "
+      (grid-sum speed-squared 1 1 energy-time))
+(show "discrete energy at nu = 4        "
+      (grid-sum speed-squared 2 2 energy-time))
+(show "their ratio, exactly nu^{5/2} = 32"
+      (/ (grid-sum speed-squared 2 2 energy-time)
+         (grid-sum speed-squared 1 1 energy-time)))
+
+(display "Navier-Stokes viscosity scaling of the momentum residual") (newline)
+(display "Passed: ") (display pass-count) (newline)
+(display "Failed: ") (display fail-count) (newline)
+;; The examples suite is a compile-and-run smoke gate: a program that prints a
+;; failure and exits zero still passes it.  Exit nonzero so a broken check is
+;; loud in CI.
+(if (= fail-count 0)
+    (begin (display "RESULT: ALL PASS") (newline) (exit 0))
+    (begin (display "RESULT: FAILURES DETECTED") (newline) (exit 1)))


### PR DESCRIPTION
Four `examples/mathematics_navier_stokes_*.esk` programs that compute the leading
structure of the construction in "Finite Time Blowup for Navier-Stokes" (OpenAI,
2026), https://cdn.openai.com/pdf/32d9f210-8b73-45e0-91bc-82a30aef8a9a/navier-stokes.pdf,
where a reader would otherwise differentiate, rescale and balance powers by hand.

## What it computes

| Program | Paper sections | Checks |
|---|---|---|
| `mathematics_navier_stokes_viscosity_scaling.esk` | 3, 10.4 (10.22)-(10.23) | 9 |
| `mathematics_navier_stokes_similarity_scales.esk` | 2.1, 3.1, 4.1 | 23 |
| `mathematics_navier_stokes_first_principles.esk` | 2.1, 3.1, 4.1 ((4.9), (4.12), (4.13)) | 21 |
| `mathematics_navier_stokes_pulse_stress.esk` | 2.2, 3.2, 3.3, 7 | 20 |

- **Viscosity scaling.** The residual `d_t u + (u.grad)u - nu Lap u + grad p` is
  assembled from AD partials of an explicit smooth divergence-free polynomial
  field. The rescaling identity `u_nu = sqrt(nu) u(x/sqrt(nu))`,
  `p_nu = nu p(x/sqrt(nu))`, `f_nu = sqrt(nu) f(x/sqrt(nu))` closes to an **exact
  rational zero** at `nu = 1/4, 1, 9/16, 25/9, 4`, and to `1e-9` at `nu = 2`.
  The energy and dissipation identities scale by exactly `nu^{5/2}` on the
  correspondingly scaled grid. Two negative controls break exactly one power of
  `nu` each.
- **Similarity coordinates.** Profiles satisfying incompressibility (4.7), the
  centrifugal pressure balance and the axis regularity (4.4) are pushed through
  the implicit relation `q - z^2 q^{2h} = tau`. The five coordinate derivatives
  of Lemma 4.1 agree with AD through that implicit solve. The nine scale-law
  exponents of Section 2.1 are fitted from computed quantities and match to
  `1e-9`. The leading residual satisfies `q^{A+1} R^(0)` constant to a relative
  `1e-6` over six decades of `tau`, exhibiting the `tau^{-(1+A)}` blowup of the
  background residual.
- **First principles.** The exponents are unknowns. The balance requirements form
  a linear system solved exactly over the rationals with `h` free, deriving
  `a = 1/2`, `b = 1/2 - h`, `c = d = 1/2 + h`, `e = 1/2`, core energy
  `1/2 - 3h`. Incompressibility is checked, not imposed. The admissible range
  `0 < h < 1/6` is derived from the positivity requirements, with the binding
  requirement at each end printed. The leading profile series is then derived
  from the leading balance operator by exact interpolation plus an exact linear
  solve; the derived recurrences are the Kummer recurrences of the two
  operators. A perturbed coefficient leaves a nonzero low-order coefficient and
  a divergent physical residual.
- **Pulses.** Zero angular means, nonzero averaged momentum fluxes matching the
  exact rational `a_i a_j / 2`, leading transversality verified on the
  cylindrical divergence, the two-family covariance system solved in exact
  rational arithmetic (determinant `19/80`, strictly positive weights inside the
  cone, negative weight outside), and the growth-then-decay of a
  Craik-Criminale mode on an affine background.

Every number printed is computed by the program. The only literals that appear
in a comparison are the exact values the paper states, and each comparison is
either an exact rational equality or carries a stated tolerance.

## How to run

```bash
cmake -S . -B build -G Ninja -DESHKOL_BUILD_TESTS=ON
cmake --build build -j8
./build/eshkol-run -r examples/mathematics_navier_stokes_viscosity_scaling.esk
./scripts/run_examples_tests.sh
ctest --test-dir build --output-on-failure -R '^ns_'
```

## Gating

The examples suite is a compile-and-run smoke gate, so each program exits
nonzero on any failed check and each carries a negative control. Eight new
CTest entries (`ns_viscosity_scaling_exact`, `ns_similarity_exponents_solved`,
`ns_leading_profile_balance`, `ns_covariance_two_family_solve`, each `_jit` and
`_aot`) pin the `RESULT: ALL PASS` line and fail on any `FAIL:` line, in both
execution modes. Deliberately breaking one assertion was verified to turn the
CTest pair red; restoring it turns it green. Total CTest time for the eight is
about 30 s, of which the programs themselves account for under a second.

## What is not mechanized

Recorded as capability gaps in `docs/NAVIER_STOKES_BLOWUP_EXAMPLES.md`: the
residual to every order (needs symbolic multivariate series values and
polynomial-valued duals), certified derivative bounds through `t = 1` (needs
directed-rounding intervals and a proved Taylor-model remainder; no enclosure is
used anywhere in this family and nothing here is a certified bound), torus
averaging as a builtin, exact linear algebra as a library rather than written
out over the scalar exact tower, and proof-object export.

## Defects found

Three silent AD defects, each with a one-line repro in the doc:

1. `derivative` returns `0` whenever a non-integer exact rational reaches the
   differentiand, even at a double seed:
   `(derivative (lambda (s) (* 1/2 s s)) 0.4)` gives `0`, while
   `(derivative-n (lambda (s) (* 1/2 s s)) 0.4 1)` gives `0.4`. This contradicts
   the documented identity `(derivative f x) == (derivative-n f x 1)`.
2. A derivative whose differentiand does not depend on the seed variable returns
   an **inexact** zero at an exact rational seed, demoting any exact sum it
   enters.
3. Nested differentiation returns `0` when the outer pass is `derivative-n`, or
   when the inner pass is `taylor`, contradicting the "nested differentiation is
   safe" statement in the AD guide. `derivative` nests correctly.

Together, 1 and 3 leave no single operator correct both with exact rationals
present and as the outer pass of a nested differentiation. Each program
documents which route it takes and why.

## Files

- `examples/mathematics_navier_stokes_viscosity_scaling.esk`
- `examples/mathematics_navier_stokes_similarity_scales.esk`
- `examples/mathematics_navier_stokes_first_principles.esk`
- `examples/mathematics_navier_stokes_pulse_stress.esk`
- `docs/NAVIER_STOKES_BLOWUP_EXAMPLES.md`
- `examples/README.md`, `CMakeLists.txt`
