### PR TITLE
docs(design): remove two stray markup lines from the Navier-Stokes mechanization note

### DIFF
--- a/docs/design/NAVIER_STOKES_BLOWUP_MECHANIZATION.md
+++ b/docs/design/NAVIER_STOKES_BLOWUP_MECHANIZATION.md
@@ -457,5 +457,3 @@ Ready to paste; the release cut owns `RELEASE_NOTES.md`.
 > bignum arithmetic, Taylor towers whose coefficients stay exact, forward and
 > reverse differentiation, and validated enclosures — so an identity that is
 > supposed to cancel closes to exact zero rather than to a tolerance.
-</content>
-</invoke>


### PR DESCRIPTION
Two literal closing-tag lines were left at the end of docs/design/NAVIER_STOKES_BLOWUP_MECHANIZATION.md by #625. This removes them; no other change.