### PR TITLE
fix(build,test): refresh the ABI header baseline for #590 and define the VM standalone test target where its tests are registered

### DIFF
--- a/.icc/abi-header-baseline.json
+++ b/.icc/abi-header-baseline.json
@@ -1,5 +1,5 @@
 {
-  "commit": "11cf759a212c40e75754a697465251e86e4899a9",
+  "commit": "875ca0ac38d5070915985b653bea90357fcf0720",
   "counts": {
     "A_macro_api": {
       "inc/eshkol/eshkol.h": 32,
@@ -28,7 +28,9 @@
       "tests/core/abi_layout_pin_test.cpp": 4,
       "tests/core/runtime_closure_alloc_test.cpp": 2,
       "tests/core/runtime_object_alloc_test.cpp": 1,
-      "tests/core/runtime_regions_test.cpp": 1
+      "tests/core/runtime_regions_test.cpp": 1,
+      "tests/ffi/sqlite_column_roundtrip_test.c": 4,
+      "tests/fuzz/eskm_model_fuzz_probe.cpp": 1
     },
     "B_header_type": {
       "inc/eshkol/abi_fingerprint.h": 4,
@@ -51,7 +53,8 @@
       "lib/core/sexp_to_ast.cpp": 1,
       "lib/core/symbol_intern.cpp": 1,
       "tests/core/abi_layout_pin_test.cpp": 10,
-      "tests/core/memory_abi_v2_test.cpp": 7
+      "tests/core/memory_abi_v2_test.cpp": 7,
+      "tests/ffi/sqlite_column_roundtrip_test.c": 3
     },
     "C_sizeof_header": {
       "inc/eshkol/abi_fingerprint.h": 1,
@@ -141,12 +144,12 @@
       "tests/core/runtime_closure_alloc_test.cpp": 2,
       "tests/core/runtime_deep_equal_test.cpp": 4,
       "tests/core/runtime_object_alloc_test.cpp": 10,
-      "tests/core/runtime_regions_test.cpp": 1
+      "tests/core/runtime_regions_test.cpp": 1,
+      "tests/fuzz/eskm_model_fuzz_probe.cpp": 1
     },
     "F_parallel_header_decl": {
       "inc/eshkol/eshkol.h": 1,
-      "lib/backend/vm_arena.h": 1,
-      "tests/ffi/sqlite_column_roundtrip_test.c": 1
+      "lib/backend/vm_arena.h": 1
     },
     "G_header_field_write": {
       "inc/eshkol/eshkol.h": 1,
@@ -184,7 +187,8 @@
       "lib/core/symbol_intern.cpp": 4,
       "lib/core/workspace.cpp": 1,
       "tests/core/runtime_closure_alloc_test.cpp": 3,
-      "tests/core/runtime_object_alloc_test.cpp": 4
+      "tests/core/runtime_object_alloc_test.cpp": 4,
+      "tests/ffi/sqlite_column_roundtrip_test.c": 5
     },
     "H_wasm_glue": {
       "site/static/eshkol-runtime.js": 17,
@@ -243,16 +247,19 @@
     },
     "S1_clang_header_member": {
       "inc/eshkol/eshkol.h": 1,
-      "lib/agent/c/agent_system_builtins.c": 1
+      "lib/agent/c/agent_system_builtins.c": 1,
+      "tests/ffi/sqlite_column_roundtrip_test.c": 4
     },
     "S2_clang_sizeof": {
       "inc/eshkol/eshkol.h": 2,
       "inc/eshkol/memory_abi_v2.h": 3,
-      "lib/agent/c/agent_system_builtins.c": 1
+      "lib/agent/c/agent_system_builtins.c": 1,
+      "tests/ffi/sqlite_column_roundtrip_test.c": 4
     },
     "S3_clang_header_cast": {
       "inc/eshkol/eshkol.h": 1,
-      "lib/agent/c/agent_system_builtins.c": 1
+      "lib/agent/c/agent_system_builtins.c": 1,
+      "tests/ffi/sqlite_column_roundtrip_test.c": 4
     }
   },
   "generated_by": "scripts/abi_header_inventory.py baseline",
@@ -281,20 +288,20 @@
   "note": "Ratchet baseline for object-header layout dependence. Counts are per (class, file). A commit may not raise any count or add a file. Lowering counts requires an exact, reasoned entry in .icc/abi-header-ratchet-allowlist.json; re-run `baseline` afterwards to tighten the ratchet. Raising one requires an explicit, reasoned re-baseline in the same commit.",
   "schema": 1,
   "totals": {
-    "A_macro_api": 113,
-    "B_header_type": 73,
+    "A_macro_api": 118,
+    "B_header_type": 76,
     "C_sizeof_header": 70,
     "D2_ir_field_offset": 10,
     "D_ir_const_offset": 45,
-    "E_alloc_with_header": 185,
-    "F_parallel_header_decl": 3,
-    "G_header_field_write": 168,
+    "E_alloc_with_header": 186,
+    "F_parallel_header_decl": 2,
+    "G_header_field_write": 173,
     "H_wasm_glue": 34,
     "J_secondary_prefix_abi": 33,
     "K_raw_byte_offset": 10,
     "L_layout_in_prose": 86,
-    "S1_clang_header_member": 2,
-    "S2_clang_sizeof": 6,
-    "S3_clang_header_cast": 2
+    "S1_clang_header_member": 6,
+    "S2_clang_sizeof": 10,
+    "S3_clang_header_cast": 6
   }
 }

--- a/.icc/abi-header-ratchet-allowlist.json
+++ b/.icc/abi-header-ratchet-allowlist.json
@@ -1,4 +1,12 @@
 {
   "schema": 1,
-  "entries": []
+  "entries": [
+    {
+      "class": "F_parallel_header_decl",
+      "path": "tests/ffi/sqlite_column_roundtrip_test.c",
+      "from": 1,
+      "to": 0,
+      "reason": "#590 (99773a83) rewrote this test to read the object header through the sanctioned ESHKOL_GET_HEADER accessor and eshkol_object_header_t instead of a hand-rolled parallel header struct, so the parallel-declaration site it used to carry is gone. The remaining A_macro_api/B_header_type/G_header_field_write sites the same commit added are legitimate, sanctioned header access and are captured by re-running `baseline`."
+    }
+  ]
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4599,7 +4599,13 @@ endif()
 # ceiling the program never reaches leaves it byte-for-byte unaffected.
 if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run AND
    EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/limits/resource_limits_enforcement_gate.sh")
-    if(TARGET eshkol-vm-standalone-test)
+    # `if(TARGET eshkol-vm-standalone-test)` would be evaluated here, before
+    # the target's own add_executable() further down this file, and CMake
+    # only recognizes a target "already... invoked" — so that check always
+    # reads false regardless of platform, silently dropping the VM half of
+    # this gate everywhere, not just on Windows. Mirror the exact condition
+    # that governs the target's own definition (NOT WIN32) instead.
+    if(NOT WIN32)
         set(ESHKOL_LIMITS_GATE_VM "$<TARGET_FILE:eshkol-vm-standalone-test>")
     else()
         set(ESHKOL_LIMITS_GATE_VM "none")
@@ -4621,7 +4627,11 @@ endif()
 # definition both execute without silent stack corruption.
 if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run AND
    EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/closures/closure_upvalue_capacity_overflow_gate.sh")
-    if(TARGET eshkol-vm-standalone-test)
+    # See the matching comment above resource_limits_enforcement_gate: an
+    # `if(TARGET eshkol-vm-standalone-test)` probe here would run before that
+    # target's add_executable() later in this file and always read false, on
+    # every platform. Use the target's own gating condition instead.
+    if(NOT WIN32)
         set(ESHKOL_UV_GATE_VM "$<TARGET_FILE:eshkol-vm-standalone-test>")
     else()
         set(ESHKOL_UV_GATE_VM "none")
@@ -4647,7 +4657,11 @@ endif()
 # refused every qubit program would otherwise pass.
 if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run AND
    EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/typesystem/qubit_linearity_engine_parity_gate.sh")
-    if(TARGET eshkol-vm-standalone-test)
+    # See the matching comment above resource_limits_enforcement_gate: an
+    # `if(TARGET eshkol-vm-standalone-test)` probe here would run before that
+    # target's add_executable() later in this file and always read false, on
+    # every platform. Use the target's own gating condition instead.
+    if(NOT WIN32)
         set(ESHKOL_LINEAR_PARITY_VM "$<TARGET_FILE:eshkol-vm-standalone-test>")
     else()
         set(ESHKOL_LINEAR_PARITY_VM "none")


### PR DESCRIPTION
## Summary

- Regenerate `.icc/abi-header-baseline.json` (and add a reasoned decrease entry to `.icc/abi-header-ratchet-allowlist.json`) so `abi_header_inventory_ratchet`, `abi_header_inventory_semantic_ratchet`, and `abi_header_inventory_selftest` go green again. The baseline was stale since 232ee14d; #590 rewrote `tests/ffi/sqlite_column_roundtrip_test.c` to read the object header through the sanctioned `ESHKOL_GET_HEADER` accessor (retiring a hand-rolled parallel struct), and #555 added `tests/fuzz/eskm_model_fuzz_probe.cpp` (also sanctioned access). Both are legitimate new dependence, not a layout-dependence leak.
- Fix an order-dependent CMake bug behind the reported Windows configure failure: `resource_limits_enforcement_gate`, `closure_upvalue_capacity_overflow_gate`, and `qubit_linearity_engine_parity_gate` guarded their optional VM argument with `if(TARGET eshkol-vm-standalone-test)`, evaluated *before* that target's own `add_executable()` later in the file. CMake's `if(TARGET ...)` only recognizes a target already invoked, so the check always read false regardless of platform — confirmed via the generated `CTestTestfile.cmake` on macOS, all three gates were silently passed `"none"` for the VM argument. Replaced with `if(NOT WIN32)`, the same condition that actually governs the target's existence.

## Verification

- `ctest --test-dir build -R 'abi_header|vm_'` — 26/26 pass.
- `ctest --test-dir build -R 'resource_limits_enforcement_gate|closure_upvalue_capacity_overflow_gate|qubit_linearity_engine_parity_gate'` — 3/3 pass, now actually exercising the VM binary instead of `"none"`.
- `cmake --build build --target eshkol-vm-standalone-test` succeeds.
- `python3 scripts/gen_api_docs.py --check` and `python3 scripts/gen_language_surface.py --check` — clean.

## Test plan

- [x] `abi_header_inventory_ratchet` / `_semantic_ratchet` / `_selftest` pass
- [x] `vm_*` ctest subset passes (26/26)
- [x] Previously order-broken VM gates now pass with the real VM path wired in
- [x] Doc-generation checks clean