### PR TITLE
ci: gate the matrix on build-impact class and skip verified-equivalent heads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,13 +112,26 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     # Scoped to this job only; the rest of the workflow keeps the repository
-    # default. `pull-requests: read` is what lets the API strategy below work.
+    # default. `pull-requests: read` is what lets the API strategy below work
+    # (and what lets the equivalence label be read live); `actions: read` is
+    # what lets this job ask whether a referenced SHA actually has a passing
+    # run of this workflow, which is the half of the equivalence check the
+    # label cannot assert for itself.
     permissions:
       contents: read
       pull-requests: read
+      actions: read
     outputs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
       impact: ${{ steps.filter.outputs.impact }}
+      # The lane plan (scripts/ci_lane_plan.py) as one delimited string:
+      # `ALL` (every lane active — the fail-safe value), the empty string
+      # (no lane active; the matrix jobs are skipped at the job level and
+      # docs-only-required-context-stubs reports the required contexts), or
+      # `|lane|lane|...|`. Matrix legs read it through their `LANE_ACTIVE`
+      # env; statically-named hosted-macOS jobs read it in their `if:`.
+      active_lanes: ${{ steps.filter.outputs.active_lanes }}
+      equivalent_to: ${{ steps.filter.outputs.equivalent_to }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -139,6 +152,11 @@ jobs:
           MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
           PUSH_BEFORE: ${{ github.event.before }}
           PUSH_SHA: ${{ github.sha }}
+          # This workflow's own display name. The equivalence check requires
+          # a completed successful run of THIS workflow on the referenced
+          # SHA; naming it from the context keeps that tied to the file
+          # rather than to a string typed twice.
+          GITHUB_WORKFLOW_NAME: ${{ github.workflow }}
         run: |
           # NOTE the missing `-e`. Intentional, and the whole point — see the
           # job comment. Nothing in this step may abort the job.
@@ -215,6 +233,8 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
             echo "docs_only=false" | tee -a "$GITHUB_OUTPUT"
             echo "impact=full" | tee -a "$GITHUB_OUTPUT"
+            echo "active_lanes=ALL" | tee -a "$GITHUB_OUTPUT"
+            echo "equivalent_to=" | tee -a "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -230,6 +250,8 @@ jobs:
             echo "::warning title=changes: changed-file set was empty::A strategy reported success with zero files. Reporting impact=full (docs_only=false) rather than trusting an empty diff — the conservative answer."
             echo "docs_only=false" | tee -a "$GITHUB_OUTPUT"
             echo "impact=full" | tee -a "$GITHUB_OUTPUT"
+            echo "active_lanes=ALL" | tee -a "$GITHUB_OUTPUT"
+            echo "equivalent_to=" | tee -a "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -266,29 +288,163 @@ jobs:
             printf '%s\n' "$classifier_json"
           fi
 
+          # ── VERIFIED-EQUIVALENT HEAD ────────────────────────────────────
+          # A rebase or a re-cut changes the head SHA without changing the
+          # content, so every required context has to be produced again for
+          # a change that was already verified. When the maintainer marks a
+          # PR with the label
+          #
+          #     ci-equivalent:<40-hex sha>
+          #
+          # this step may collapse the whole matrix — but ONLY when BOTH of
+          # two independent facts hold, neither of which the label itself
+          # asserts:
+          #
+          #   1. CONTENT. scripts/ci_equivalent_head.py proves, in pure git,
+          #      that this head is the same content as the referenced commit
+          #      — identical trees, or the same `git patch-id --stable`
+          #      relative to each commit's own merge-base with the base
+          #      branch. Nothing about GitHub is involved.
+          #   2. VERIFICATION. The GitHub API says the referenced SHA
+          #      actually has a COMPLETED, SUCCESSFUL run of this workflow.
+          #      Equivalence to a commit that never passed is worth nothing.
+          #
+          # The label is a POINTER, never a permission: if either fact fails
+          # to hold, this falls through to the class the classifier computed
+          # and says so in the summary. Labels are read live from the API
+          # rather than from the event payload so that labelling a PR and
+          # re-running CI is enough — a re-run replays the original payload,
+          # in which the new label does not exist.
+          #
+          # A push after labelling re-evaluates naturally: the head SHA
+          # changes, so equivalence is recomputed against the new content
+          # and a real edit stops matching.
+          equivalent_to=""
+          equivalence_note=""
+          if [[ "$EVENT_NAME" == "pull_request" && -n "${PR_NUMBER:-}" ]]; then
+            pr_labels="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.labels[].name' 2>/dev/null)"
+            candidate="$(printf '%s\n' "$pr_labels" \
+                          | sed -n 's/^ci-equivalent:\([0-9a-fA-F]\{40\}\)$/\1/p' \
+                          | head -n 1)"
+            if [[ -n "$candidate" ]]; then
+              echo "Found equivalence label pointing at $candidate"
+              git fetch --no-tags --quiet origin "$candidate" >/dev/null 2>&1 || true
+              equivalence_json="$(python3 scripts/ci_equivalent_head.py \
+                                    --head "$PR_HEAD_SHA" \
+                                    --reference "$candidate" \
+                                    --base-ref "refs/remotes/origin/${PR_BASE_REF}" \
+                                    --fetch-remote origin 2>/dev/null)"
+              equivalence_status=$?
+              equivalent="false"
+              equivalence_kind="none"
+              if [[ $equivalence_status -eq 0 ]]; then
+                equivalent="$(printf '%s' "$equivalence_json" | python3 -c 'import json,sys; print(str(json.load(sys.stdin)["equivalent"]).lower())' 2>/dev/null || echo false)"
+                equivalence_kind="$(printf '%s' "$equivalence_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["kind"])' 2>/dev/null || echo none)"
+              fi
+              verified_runs="$(gh api "repos/$REPO/actions/runs?head_sha=$candidate&status=success&per_page=100" \
+                                 --jq "[.workflow_runs[] | select(.name == \"$GITHUB_WORKFLOW_NAME\" and .status == \"completed\" and .conclusion == \"success\")] | length" 2>/dev/null || echo 0)"
+              [[ "$verified_runs" =~ ^[0-9]+$ ]] || verified_runs=0
+              if [[ "$equivalent" == "true" && "$verified_runs" -gt 0 ]]; then
+                impact="equivalent"
+                equivalent_to="$candidate"
+                equivalence_note="Equivalent to verified head ${candidate} (${equivalence_kind} identity); matrix skipped"
+                echo "$equivalence_note"
+              else
+                if [[ "$equivalent" != "true" ]]; then
+                  equivalence_note="Equivalence label names ${candidate}, but this head is NOT content-identical to it (${equivalence_kind}); running the normal ${impact} path"
+                else
+                  equivalence_note="Equivalence label names ${candidate}, which has no completed successful ${GITHUB_WORKFLOW_NAME} run; running the normal ${impact} path"
+                fi
+                echo "::warning title=changes: equivalence label not honoured::${equivalence_note}"
+              fi
+            fi
+          fi
+
           # docs_only stays a plain boolean for the jobs already gated on it:
           # true exactly when the heavy matrix should be skipped, i.e. the
           # classifier found neither a build nor a CI/test input among the
-          # changed files (impact `docs` or `non-build`). `impact` (below)
-          # carries the real, finer-grained answer this output collapses.
-          if [[ "$impact" == "docs" || "$impact" == "non-build" ]]; then
+          # changed files (impact `docs` or `non-build`), or this head was
+          # proven equivalent to an already-verified one (`equivalent`).
+          # `impact` (below) carries the real, finer-grained answer this
+          # output collapses.
+          if [[ "$impact" == "docs" || "$impact" == "non-build" || "$impact" == "equivalent" ]]; then
             docs_only=true
           else
             docs_only=false
+          fi
+
+          # ── LANE PLAN ───────────────────────────────────────────────────
+          # scripts/ci_lane_plan.py turns the impact class plus the changed
+          # files into the set of matrix lanes that can actually observe the
+          # change, deriving every lane name and capability flag from this
+          # file's own matrix definitions. `ALL` (every lane) is the
+          # fail-safe answer and is what any failure below produces.
+          # Lanes NOT in this set still INSTANTIATE — their steps are gated
+          # on `LANE_ACTIVE`, not their job — so every required status
+          # context is still reported, which a job-level skip would not do.
+          active_lanes="ALL"
+          lane_plan_json=""
+          if [[ "$impact" != "full" ]]; then
+            lane_plan_json="$(printf '%s\n' "$changed_files" | python3 scripts/ci_lane_plan.py --impact "$impact" 2>/dev/null)"
+            lane_plan_status=$?
+            if [[ $lane_plan_status -eq 0 ]]; then
+              if parsed_active="$(printf '%s' "$lane_plan_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["active"])' 2>/dev/null)"; then
+                active_lanes="$parsed_active"
+              else
+                echo "::warning title=changes: could not parse ci_lane_plan.py output::Falling back to active_lanes=ALL — the conservative answer."
+              fi
+            else
+              echo "::warning title=changes: scripts/ci_lane_plan.py exited $lane_plan_status::Falling back to active_lanes=ALL — the conservative answer."
+              printf '%s\n' "$lane_plan_json"
+            fi
           fi
 
           {
             echo "### changes"
             echo
             echo "Build-impact class: **${impact}** (docs_only=${docs_only})"
+            if [[ -n "$equivalence_note" ]]; then
+              echo
+              echo "${equivalence_note}"
+            fi
+            echo
+            if [[ "$active_lanes" == "ALL" ]]; then
+              echo "Lane decision: **every matrix lane runs**."
+            elif [[ -z "$active_lanes" ]]; then
+              echo "Lane decision: **no matrix lane runs**; \`docs-only-required-context-stubs\` reports each required context."
+            else
+              echo "Lane decision: active = \`${active_lanes}\`. Every other lane still reports its own status context, with its build and test steps skipped — see that lane's log for which lanes were skipped and why."
+            fi
+            echo
+            echo "Changed files (via ${source}):"
+            echo
+            echo '```'
+            printf '%s\n' "$changed_files"
+            echo '```'
+            echo
+            echo "<details><summary>build-impact classification</summary>"
             echo
             echo '```json'
             printf '%s\n' "$classifier_json"
             echo '```'
+            echo
+            echo "</details>"
+            if [[ -n "$lane_plan_json" ]]; then
+              echo
+              echo "<details><summary>lane plan</summary>"
+              echo
+              echo '```json'
+              printf '%s\n' "$lane_plan_json"
+              echo '```'
+              echo
+              echo "</details>"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
           echo "docs_only=$docs_only" | tee -a "$GITHUB_OUTPUT"
           echo "impact=$impact" | tee -a "$GITHUB_OUTPUT"
+          echo "active_lanes=$active_lanes" | tee -a "$GITHUB_OUTPUT"
+          echo "equivalent_to=$equivalent_to" | tee -a "$GITHUB_OUTPUT"
           exit 0
 
   # ─────────────────────────────────────────────────────────────────────
@@ -470,6 +626,8 @@ jobs:
           python3 scripts/gate_ad_shared_node_model.py --self-test
           python3 scripts/check_required_context_consistency.py --self-test
           python3 scripts/ci_change_class.py --self-test
+          python3 scripts/ci_lane_plan.py --self-test
+          python3 scripts/ci_equivalent_head.py --self-test
           python3 scripts/check_package_manifest.py --self-test
           python3 scripts/check_diagnostic_corpus.py --self-test
           python3 scripts/gate_exhaustive_dispatch.py --self-test
@@ -853,10 +1011,23 @@ jobs:
   # separate advisory job. `continue-on-error` makes the lane informative
   # without turning the default required CI set into a Moonlab availability
   # gate; branch-protection configuration must not add this check as required.
+  # ADVISORY, never a required status context, and it runs on a hosted
+  # macOS runner -- the scarcest capacity in this repo's queue. So it is
+  # planned like a matrix lane: `changes` names it in `active_lanes` when
+  # the change can actually reach it (impact `full`, or a `tests-only`
+  # change to a file this job's own steps name). Skipping it is safe in a
+  # way skipping a matrix leg is not: this job has a STATIC name, so even
+  # when it is skipped GitHub reports one correctly-named check run --
+  # see scripts/check_required_context_consistency.py on why that
+  # distinction is load-bearing.
   quantum-macos:
     name: quantum-macos (advisory)
     needs: changes
-    if: github.event_name != 'schedule' && needs.changes.outputs.docs_only == 'false'
+    if: >-
+      github.event_name != 'schedule'
+      && needs.changes.outputs.docs_only == 'false'
+      && (needs.changes.outputs.active_lanes == 'ALL'
+          || contains(needs.changes.outputs.active_lanes, '|quantum-macos|'))
     runs-on: macos-14
     continue-on-error: true
     timeout-minutes: 120
@@ -1016,10 +1187,23 @@ jobs:
   # branch-protection required context that a docs-only PR would need the
   # stub-job trick (immediately below) to satisfy.
   # ─────────────────────────────────────────────────────────────────────
+  # ADVISORY, never a required status context, and it runs on a hosted
+  # macOS runner -- the scarcest capacity in this repo's queue. So it is
+  # planned like a matrix lane: `changes` names it in `active_lanes` when
+  # the change can actually reach it (impact `full`, or a `tests-only`
+  # change to a file this job's own steps name). Skipping it is safe in a
+  # way skipping a matrix leg is not: this job has a STATIC name, so even
+  # when it is skipped GitHub reports one correctly-named check run --
+  # see scripts/check_required_context_consistency.py on why that
+  # distinction is load-bearing.
   bench-smoke:
     name: "bench-smoke (not a measurement)"
     needs: changes
-    if: github.event_name != 'schedule' && needs.changes.outputs.docs_only == 'false'
+    if: >-
+      github.event_name != 'schedule'
+      && needs.changes.outputs.docs_only == 'false'
+      && (needs.changes.outputs.active_lanes == 'ALL'
+          || contains(needs.changes.outputs.active_lanes, '|bench-smoke|'))
     runs-on: macos-14
     continue-on-error: true
     timeout-minutes: 30
@@ -1176,6 +1360,16 @@ jobs:
     timeout-minutes: 120
     env:
       ESHKOL_FETCHCONTENT_BASE_DIR: ${{ github.workspace }}/.ci-cache/fetchcontent
+      # Which lanes this run actually needs, decided by the `changes`
+      # job via scripts/ci_lane_plan.py. `ALL` means every lane (the
+      # fail-safe value); otherwise the lane's own name must appear in
+      # the delimited list. Note this gates STEPS, not the job: the leg
+      # still instantiates and still reports a check run under its own
+      # name, which is what keeps branch protection's required-context
+      # set complete on every impact class. A job-level skip would make
+      # the per-leg contexts ABSENT — the permanent-block failure mode
+      # scripts/check_required_context_consistency.py exists to catch.
+      LANE_ACTIVE: ${{ needs.changes.outputs.active_lanes == 'ALL' || contains(needs.changes.outputs.active_lanes, format('|{0}|', matrix.name)) }}
     strategy:
       fail-fast: false
       matrix:
@@ -1303,9 +1497,32 @@ jobs:
             artifact_name: ''
 
     steps:
+      # Runs on EVERY leg, active or not: this is the check run branch
+      # protection resolves, and its log is where a skipped lane says so.
+      - name: Lane plan
+        shell: bash
+        env:
+          IMPACT: ${{ needs.changes.outputs.impact }}
+          ACTIVE_LANES: ${{ needs.changes.outputs.active_lanes }}
+          LANE: ${{ matrix.name }}
+        run: |
+          set -euo pipefail
+          if [[ "${LANE_ACTIVE}" == "true" ]]; then
+            echo "Lane ${LANE}: ACTIVE (build-impact class '${IMPACT}'). Building and testing normally."
+            exit 0
+          fi
+          reason="the build-impact class is '${IMPACT}', and scripts/ci_lane_plan.py did not select this lane (active lanes: ${ACTIVE_LANES:-none})"
+          echo "Lane ${LANE}: SKIPPED — ${reason}."
+          echo "Every build and test step below is skipped. This check run exists so ${LANE} still reports a status; it is NOT evidence that ${LANE} was exercised."
+          {
+            echo "- \`${LANE}\`: skipped — ${reason}."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/checkout@v6
+        if: env.LANE_ACTIVE == 'true'
 
       - name: Restore pinned source dependency cache
+        if: env.LANE_ACTIVE == 'true'
         uses: actions/cache@v5
         with:
           path: ${{ env.ESHKOL_FETCHCONTENT_BASE_DIR }}
@@ -1323,7 +1540,7 @@ jobs:
       # `apt-get install` in "Install Dependencies (Linux)" below had NO
       # retry at all before this change.
       - name: Add LLVM Repository (Linux)
-        if: runner.os == 'Linux'
+        if: env.LANE_ACTIVE == 'true' && (runner.os == 'Linux')
         shell: bash
         run: |
           set -euxo pipefail
@@ -1336,7 +1553,7 @@ jobs:
             sudo apt-get update -o Acquire::Retries=5 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20
 
       - name: Add NVIDIA CUDA Repository (Linux CUDA)
-        if: runner.os == 'Linux' && matrix.gpu_enabled == 'ON'
+        if: env.LANE_ACTIVE == 'true' && (runner.os == 'Linux' && matrix.gpu_enabled == 'ON')
         shell: bash
         run: |
           set -euxo pipefail
@@ -1354,7 +1571,7 @@ jobs:
             sudo apt-get update -o Acquire::Retries=5 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20
 
       - name: Install Dependencies (Linux)
-        if: runner.os == 'Linux'
+        if: env.LANE_ACTIVE == 'true' && (runner.os == 'Linux')
         shell: bash
         run: |
           set -euxo pipefail
@@ -1388,13 +1605,14 @@ jobs:
           ld.lld --version
 
       - name: Install Dependencies (macOS)
-        if: runner.os == 'macOS'
+        if: env.LANE_ACTIVE == 'true' && (runner.os == 'macOS')
         shell: bash
         run: |
           set -euxo pipefail
           brew install llvm@${LLVM_MAJOR} cmake ninja readline pcre2 sqlite
 
       - name: Configure
+        if: env.LANE_ACTIVE == 'true'
         shell: bash
         run: |
           set -euxo pipefail
@@ -1429,7 +1647,7 @@ jobs:
             ${{ matrix.sanitizer_flags }}
 
       - name: Verify real CUDA build graph
-        if: matrix.gpu_enabled == 'ON'
+        if: env.LANE_ACTIVE == 'true' && (matrix.gpu_enabled == 'ON')
         shell: bash
         run: |
           set -euxo pipefail
@@ -1438,6 +1656,7 @@ jobs:
             --expected CUDA
 
       - name: Build
+        if: env.LANE_ACTIVE == 'true'
         shell: bash
         run: |
           set -euxo pipefail
@@ -1462,7 +1681,7 @@ jobs:
       # don't change the WASM-side surface and their ASan instrumentation
       # confuses the wasm32 codegen path.
       - name: Check WASM env imports
-        if: matrix.xla_enabled == 'OFF' && matrix.gpu_enabled == 'OFF' && matrix.build_dir == 'build'
+        if: env.LANE_ACTIVE == 'true' && (matrix.xla_enabled == 'OFF' && matrix.gpu_enabled == 'OFF' && matrix.build_dir == 'build')
         shell: bash
         env:
           BUILD_DIR: ${{ matrix.build_dir }}
@@ -1475,7 +1694,7 @@ jobs:
       # unused stdlib and stay small + instantiable, rather than pinning the
       # whole stdlib against DCE via the homoiconic display registry.
       - name: Check WASM stdlib dead-strip size
-        if: matrix.xla_enabled == 'OFF' && matrix.gpu_enabled == 'OFF' && matrix.build_dir == 'build'
+        if: env.LANE_ACTIVE == 'true' && (matrix.xla_enabled == 'OFF' && matrix.gpu_enabled == 'OFF' && matrix.build_dir == 'build')
         shell: bash
         env:
           BUILD_DIR: ${{ matrix.build_dir }}
@@ -1490,7 +1709,7 @@ jobs:
       # (not GPU/XLA/sanitizer): span assertions read source text, which is
       # OS/backend-independent, so one lane is enough evidence per PR.
       - name: Diagnostic golden corpus matches its pinned text and span
-        if: matrix.xla_enabled == 'OFF' && matrix.gpu_enabled == 'OFF' && matrix.build_dir == 'build'
+        if: env.LANE_ACTIVE == 'true' && (matrix.xla_enabled == 'OFF' && matrix.gpu_enabled == 'OFF' && matrix.build_dir == 'build')
         shell: bash
         env:
           BUILD_DIR: ${{ matrix.build_dir }}
@@ -1504,7 +1723,7 @@ jobs:
       # broad enough to swallow a real leak is reported as a gate failure
       # here rather than as a suspiciously clean sanitizer run below.
       - name: Leak detection is armed and can still see a real leak
-        if: contains(matrix.sanitizer_flags, 'ESHKOL_ENABLE_ASAN=ON')
+        if: env.LANE_ACTIVE == 'true' && (contains(matrix.sanitizer_flags, 'ESHKOL_ENABLE_ASAN=ON'))
         shell: bash
         env:
           BUILD_DIR: ${{ matrix.build_dir }}
@@ -1523,7 +1742,7 @@ jobs:
       # allocation added to eshkol_runtime_init() and nothing else changed,
       # this step fails and names eshkol_runtime_init as the site.
       - name: No unsuppressed leak in the real workloads
-        if: contains(matrix.sanitizer_flags, 'ESHKOL_ENABLE_ASAN=ON')
+        if: env.LANE_ACTIVE == 'true' && (contains(matrix.sanitizer_flags, 'ESHKOL_ENABLE_ASAN=ON'))
         shell: bash
         env:
           BUILD_DIR: ${{ matrix.build_dir }}
@@ -1537,6 +1756,7 @@ jobs:
           ./tests/memory/leak_audit_gate.sh
 
       - name: Run Tests
+        if: env.LANE_ACTIVE == 'true'
         timeout-minutes: 120
         shell: bash
         env:
@@ -1592,7 +1812,7 @@ jobs:
       # that let one stay dead while the other worked. One Linux and one macOS
       # lane is enough to cover both platforms without paying for it six times.
       - name: AD exactness gate (finite-difference counter is live; matmul tape ratchet)
-        if: matrix.name == 'linux-x64-lite' || matrix.name == 'macos-arm64-lite'
+        if: env.LANE_ACTIVE == 'true' && (matrix.name == 'linux-x64-lite' || matrix.name == 'macos-arm64-lite')
         timeout-minutes: 25
         shell: bash
         env:
@@ -1604,7 +1824,7 @@ jobs:
           ./scripts/run_ad_exactness_gate.sh
 
       - name: Upload Test Logs
-        if: failure() || cancelled()
+        if: env.LANE_ACTIVE == 'true' && (failure() || cancelled())
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.name }}-test-log
@@ -1612,7 +1832,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload Artifacts
-        if: matrix.upload_artifact == 'true'
+        if: env.LANE_ACTIVE == 'true' && (matrix.upload_artifact == 'true')
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
@@ -1634,7 +1854,7 @@ jobs:
       # trace-emitting steps that sibling branches add, so those merge without
       # a conflict here.
       - name: Upload ICC evidence traces
-        if: always()
+        if: env.LANE_ACTIVE == 'true' && (always())
         uses: actions/upload-artifact@v7
         with:
           name: icc-evidence-${{ matrix.name }}
@@ -1718,6 +1938,16 @@ jobs:
     timeout-minutes: 90
     env:
       ESHKOL_FETCHCONTENT_BASE_DIR: ${{ github.workspace }}/.ci-cache/fetchcontent
+      # Which lanes this run actually needs, decided by the `changes`
+      # job via scripts/ci_lane_plan.py. `ALL` means every lane (the
+      # fail-safe value); otherwise the lane's own name must appear in
+      # the delimited list. Note this gates STEPS, not the job: the leg
+      # still instantiates and still reports a check run under its own
+      # name, which is what keeps branch protection's required-context
+      # set complete on every impact class. A job-level skip would make
+      # the per-leg contexts ABSENT — the permanent-block failure mode
+      # scripts/check_required_context_consistency.py exists to catch.
+      LANE_ACTIVE: ${{ needs.changes.outputs.active_lanes == 'ALL' || contains(needs.changes.outputs.active_lanes, format('|{0}|', matrix.name)) }}
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -1757,9 +1987,32 @@ jobs:
             upload_artifact: 'false'
             artifact_name: ''
     steps:
+      # Runs on EVERY leg, active or not: this is the check run branch
+      # protection resolves, and its log is where a skipped lane says so.
+      - name: Lane plan
+        shell: bash
+        env:
+          IMPACT: ${{ needs.changes.outputs.impact }}
+          ACTIVE_LANES: ${{ needs.changes.outputs.active_lanes }}
+          LANE: ${{ matrix.name }}
+        run: |
+          set -euo pipefail
+          if [[ "${LANE_ACTIVE}" == "true" ]]; then
+            echo "Lane ${LANE}: ACTIVE (build-impact class '${IMPACT}'). Building and testing normally."
+            exit 0
+          fi
+          reason="the build-impact class is '${IMPACT}', and scripts/ci_lane_plan.py did not select this lane (active lanes: ${ACTIVE_LANES:-none})"
+          echo "Lane ${LANE}: SKIPPED — ${reason}."
+          echo "Every build and test step below is skipped. This check run exists so ${LANE} still reports a status; it is NOT evidence that ${LANE} was exercised."
+          {
+            echo "- \`${LANE}\`: skipped — ${reason}."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/checkout@v6
+        if: env.LANE_ACTIVE == 'true'
 
       - name: Restore pinned source dependency cache
+        if: env.LANE_ACTIVE == 'true'
         uses: actions/cache@v5
         with:
           path: ${{ env.ESHKOL_FETCHCONTENT_BASE_DIR }}
@@ -1768,7 +2021,7 @@ jobs:
             eshkol-fetchcontent-v1-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install NVIDIA CUDA Toolkit (Windows x64 CUDA)
-        if: matrix.gpu_enabled == 'ON'
+        if: env.LANE_ACTIVE == 'true' && (matrix.gpu_enabled == 'ON')
         uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76
         with:
           cuda: ${{ env.CUDA_VERSION }}
@@ -1780,6 +2033,7 @@ jobs:
           log-file-suffix: ci-${{ matrix.name }}
 
       - name: Restore LLVM SDK Cache
+        if: env.LANE_ACTIVE == 'true'
         id: llvm-cache
         uses: actions/cache/restore@v5
         with:
@@ -1790,7 +2044,7 @@ jobs:
       # `needs:`. On a hit, "Install LLVM SDK" below extracts straight from
       # this file and never calls curl at all.
       - name: Restore prefetched LLVM SDK archive
-        if: steps.llvm-cache.outputs.cache-hit != 'true'
+        if: env.LANE_ACTIVE == 'true' && (steps.llvm-cache.outputs.cache-hit != 'true')
         id: archive-cache
         uses: actions/cache/restore@v5
         with:
@@ -1799,7 +2053,7 @@ jobs:
           enableCrossOsArchive: true
 
       - name: Install LLVM SDK
-        if: steps.llvm-cache.outputs.cache-hit != 'true'
+        if: env.LANE_ACTIVE == 'true' && (steps.llvm-cache.outputs.cache-hit != 'true')
         shell: pwsh
         # Pure extraction of an already-local archive should never come
         # close to this. If it does, something is genuinely stuck and
@@ -1878,6 +2132,7 @@ jobs:
           Write-Host "LLVM $llvmVersion ${{ matrix.arch }} ready at $llvmRoot"
 
       - name: Resolve LLVM SDK
+        if: env.LANE_ACTIVE == 'true'
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -1895,13 +2150,14 @@ jobs:
           "$llvmRoot\bin"             | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Save LLVM SDK Cache
-        if: steps.llvm-cache.outputs.cache-hit != 'true'
+        if: env.LANE_ACTIVE == 'true' && (steps.llvm-cache.outputs.cache-hit != 'true')
         uses: actions/cache/save@v5
         with:
           path: C:\src\clang+llvm-${{ env.WINDOWS_LLVM_SDK_VERSION }}-${{ matrix.llvm_suffix }}-pc-windows-msvc
           key: windows-llvm-sdk-${{ matrix.arch }}-${{ env.WINDOWS_LLVM_SDK_VERSION }}
 
       - name: Configure
+        if: env.LANE_ACTIVE == 'true'
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -2007,7 +2263,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Verify real CUDA build graph
-        if: matrix.gpu_enabled == 'ON'
+        if: env.LANE_ACTIVE == 'true' && (matrix.gpu_enabled == 'ON')
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -2018,6 +2274,7 @@ jobs:
             --expected CUDA
 
       - name: Build
+        if: env.LANE_ACTIVE == 'true'
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -2028,6 +2285,7 @@ jobs:
           cmake --build '${{ matrix.build_dir }}' --config Release --target @($targets) --parallel
 
       - name: Run Tests
+        if: env.LANE_ACTIVE == 'true'
         timeout-minutes: 120
         shell: pwsh
         run: |
@@ -2053,7 +2311,7 @@ jobs:
           }
 
       - name: Upload Test Logs
-        if: failure() || cancelled()
+        if: env.LANE_ACTIVE == 'true' && (failure() || cancelled())
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.name }}-test-log
@@ -2061,7 +2319,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload Artifacts
-        if: matrix.upload_artifact == 'true'
+        if: env.LANE_ACTIVE == 'true' && (matrix.upload_artifact == 'true')
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,9 @@ tests/generative-diff/corpus/
 # committed reference numbers live at bench/reference-run/, which is NOT
 # ignored — see bench/README.md.
 bench/results/
+
+# Throwaway working space for self-tests that need a real filesystem (e.g.
+# scripts/ci_equivalent_head.py --self-test builds git repositories here).
+# Deliberately inside the repository rather than a system temp directory,
+# which is not durable on every machine this is developed on.
+.scratch/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5407,6 +5407,33 @@ if(ESHKOL_BUILD_TESTS)
         )
         set_tests_properties(required_context_consistency_gate required_context_consistency_gate_selftest PROPERTIES TIMEOUT 60)
     endif()
+    # The two halves of ci.yml's cost gating: which lanes a change actually
+    # needs (derived from ci.yml's own matrix definitions), and whether a
+    # head is content-identical to an already-verified commit. Both are
+    # decisions that skip verification, so both must be able to fail —
+    # ci_lane_plan's self-test asserts the required contexts stay reportable
+    # on every impact class, and ci_equivalent_head's proves tree identity,
+    # patch identity and a negative case against throwaway repositories.
+    if(ESHKOL_PYTHON3_EXECUTABLE AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/ci_lane_plan.py")
+        add_test(
+            NAME ci_lane_plan_selftest
+            COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/ci_lane_plan.py"
+                    --self-test
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+        set_tests_properties(ci_lane_plan_selftest PROPERTIES TIMEOUT 60)
+    endif()
+    if(ESHKOL_PYTHON3_EXECUTABLE AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/ci_equivalent_head.py")
+        add_test(
+            NAME ci_equivalent_head_selftest
+            COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/ci_equivalent_head.py"
+                    --self-test
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+        set_tests_properties(ci_equivalent_head_selftest PROPERTIES TIMEOUT 120)
+    endif()
     # scripts/ci_retry.sh is the single reusable definition of ci.yml's
     # network-retry policy (apt-get/wget in the Linux/CUDA setup steps).
     # Self-test proves it both retries a flaky command to success and gives

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -448,8 +448,8 @@ list, it classifies the change as one of:
   CI actually runs as a test (discovered from real `add_test`/
   `add_custom_target` COMMAND arguments in `CMakeLists.txt` and real
   workflow `test_command`/`run:` references — never a hand-typed list).
-  Informational only for now: the full matrix still runs, so a change to
-  a test's own correctness is never skipped.
+  This class now drives a REDUCED lane set rather than the full matrix —
+  see "CI: the lane plan" below.
 - **`full`** — anything else, including every `.github/workflows/**`
   change unconditionally.
 
@@ -479,11 +479,142 @@ build-input set and fails loud on a gap — see
 against a synthetic fixture tree.
 
 The `changes` job wires this in without changing any existing job's `if:`
-condition: `docs_only` is now `true` for `docs` **or** `non-build` impact
-(the two classes where the heavy matrix has nothing to gain from running),
-and the job additionally exposes the raw `impact` class as its own output
-and in the run's step summary. `docs-only-required-context-stubs`
-therefore now also covers non-build PRs, using the exact same stub-matrix
-mechanism described above — it needs no changes of its own, and
-`check_required_context_consistency.py` continues to grade the same
-`docs_only == 'true'`/`'false'` conditions it always has.
+condition: `docs_only` is `true` for `docs` **or** `non-build` impact (the
+classes where the heavy matrix has nothing to gain from running, joined
+later by `equivalent` — see below), and the job additionally exposes the
+raw `impact` class as its own output and in the run's step summary.
+`docs-only-required-context-stubs` therefore also covers non-build PRs,
+using the exact same stub-matrix mechanism described above — it needs no
+changes of its own.
+
+## CI: the lane plan — a `tests-only` change runs only the lanes that can see it
+
+Status: SHIPPED.
+
+`tests-only` was, at first, informational: the class was computed and
+reported, and the full 25-job matrix ran anyway. `scripts/ci_lane_plan.py`
+turns it into a decision. Given the impact class and the changed-file
+list, it emits the set of matrix lanes that can actually observe the
+change, and the `changes` job publishes that set as its `active_lanes`
+output.
+
+Every lane name, runner and capability flag the plan reasons about is
+re-derived from `.github/workflows/ci.yml`'s own matrix definitions on
+each run. There is no second lane list to keep in sync — the same
+discipline the build-impact classifier applies to `CMakeLists.txt`.
+
+The rules, in the order they are applied:
+
+- **Direct reference** — a changed file whose exact path appears in a
+  lane's `test_command` (or in an advisory job's own steps) activates that
+  lane. An edit to `scripts/run_gpu_tests.sh` reaches exactly the lanes
+  that run it.
+- **`tests/gpu/**`** — the lanes declaring `gpu_enabled: 'ON'`, and
+  nothing else.
+- **`tests/xla/**`** — the lanes declaring `xla_enabled: 'ON'`.
+- **`tests/vm_parity/**`** — that corpus is executed by `pillars-fast`
+  (via `scripts/run_vm_parity.sh`), which is not matrix-gated and runs on
+  every non-inert PR regardless; one portable lane is added alongside it
+  so the corpus is also exercised against a real compiler build.
+- **Anything else under `tests/`** — the first portable ("lite") lane of
+  each OS family in declaration order: today `linux-x64-lite`,
+  `macos-arm64-lite` and `windows-arm64-lite`, each of which runs the
+  whole `scripts/run_all_tests.sh` suite on its platform.
+
+The two advisory jobs that occupy hosted macOS runners
+(`quantum-macos`, `bench-smoke`) are planned the same way, and are
+skipped on a `tests-only` change that cannot reach them.
+
+### Why the lanes are gated per STEP, not per JOB
+
+This is the load-bearing detail, and it is the one place where the
+obvious implementation is the wrong one. A lane that is not selected
+still INSTANTIATES as a matrix leg; only its build and test steps are
+skipped, via a `LANE_ACTIVE` job-level `env` the leg computes from
+`active_lanes`. Its first step always runs and states in the log, and in
+the run summary, that the lane was skipped and why.
+
+Skipping the JOB instead would be a permanent merge block. A skipped
+matrix job never instantiates its per-leg names: they collapse to a
+single check run under the literal, unresolved `${{ matrix.name }}`
+string, so every required context that leg would have reported is ABSENT
+from the head SHA — and branch protection cannot resolve a required
+context that no check run ever reports. That is precisely the failure
+`docs-only-required-context-stubs` exists to work around for the
+docs-only path. Gating steps keeps the entire required-context set intact
+by construction, on every impact class, with no stub list to maintain.
+
+`scripts/check_required_context_consistency.py` enforces this rather than
+trusting it: a MATRIX job whose job-level `if:` references
+`needs.changes.outputs.impact` or `needs.changes.outputs.active_lanes` is
+held to the same stub-coverage requirement as a `docs_only`-gated one,
+and its self-test carries a red fixture that writes the lane gate the
+wrong way round and must fail. That gate now also grades every build-
+impact class in turn (`docs`, `non-build`, `tests-only`, `full`,
+`equivalent`), and cross-checks the classes `ci.yml` maps to
+`docs_only=true` against the classes the lane plan treats as inert, so
+adding a class to one and not the other fails a build instead of
+blocking a merge.
+
+## CI: skipping a head that is already verified
+
+Status: SHIPPED.
+
+A rebase, a re-cut onto a fresh base, or a cherry-pick into a new PR
+changes the head SHA without changing the content. Every required context
+then has to be produced again for a change that was already verified,
+which is the single largest avoidable cost in this repo's queue.
+
+The maintainer can mark such a PR with a label:
+
+```
+ci-equivalent:<40-hex sha>
+```
+
+The `changes` job honours it only when BOTH of two independent facts
+hold, neither of which the label itself asserts:
+
+1. **Content.** `scripts/ci_equivalent_head.py` proves, in pure git, that
+   the PR head is the same content as the referenced commit — either
+   **tree identity** (`git rev-parse <sha>^{tree}` equal, so the two
+   checkouts are byte-identical) or **patch identity** (`git diff
+   <merge-base(base, sha)> <sha> | git patch-id --stable` equal for both,
+   the same test `git rebase` uses to recognise an already-applied
+   commit). Nothing about GitHub is involved.
+2. **Verification.** The GitHub API confirms the referenced SHA has a
+   COMPLETED, SUCCESSFUL run of this workflow. Equivalence to a commit
+   that never passed CI is worth nothing.
+
+Only then does `impact` become `equivalent`, which gates exactly like
+`docs`: the heavy matrix is skipped at the job level and
+`docs-only-required-context-stubs` reports every required context. The
+summary states `Equivalent to verified head <sha> (tree|patch identity);
+matrix skipped`. If either fact fails to hold, the run falls through to
+the class the classifier computed and says so, as a warning, in the
+summary — the label is a POINTER, never a permission.
+
+Labels are read live from the API rather than from the event payload, so
+labelling a PR and re-running CI is enough; a re-run replays the original
+payload, in which a newly-added label does not exist.
+
+Rules for using it:
+
+- Only the maintainer sets this label, and only for a rebase or a re-cut
+  whose CONTENT is unchanged. It is not a way to wave through a change
+  that "looks the same".
+- The referenced SHA must be a commit that really has a green CI run —
+  which the job verifies, so a wrong SHA costs a full matrix run, not a
+  false green.
+- A push to the PR after labelling re-evaluates naturally: the head SHA
+  changes, equivalence is recomputed against the new content, and a real
+  edit stops matching.
+
+Both scripts carry `--self-test` (`python3 scripts/ci_lane_plan.py
+--self-test`, `python3 scripts/ci_equivalent_head.py --self-test`), both
+run in the `assurance-gates` job on every PR, and both are registered as
+ctest entries (`ci_lane_plan_selftest`, `ci_equivalent_head_selftest`).
+The equivalence self-test builds throwaway git repositories under
+`.scratch/` and proves tree identity, patch identity across different
+bases, and a negative case, including that its rebase fixture really does
+have a different tree so the patch-identity case is not silently proving
+the tree path twice.

--- a/scripts/check_required_context_consistency.py
+++ b/scripts/check_required_context_consistency.py
@@ -136,6 +136,7 @@ import sys
 import tempfile
 import urllib.error
 import urllib.request
+from pathlib import Path
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEFAULT_WORKFLOWS = [
@@ -152,6 +153,16 @@ DEFAULT_BRANCH = "master"
 
 DOCS_ONLY_FALSE_RE = re.compile(r"docs_only\s*==\s*'false'")
 DOCS_ONLY_TRUE_RE = re.compile(r"docs_only\s*==\s*'true'")
+# A job gated on the finer-grained build-impact outputs (`impact`, or the
+# `active_lanes` lane plan) rather than on `docs_only`. For a STATIC-named
+# job that is harmless -- it still reports one correctly-named `skipped`
+# check run. For a MATRIX job it is the exact defect this gate exists to
+# catch, so such a job is held to the same stub-coverage requirement as a
+# docs_only-gated one. This is why lane selection is implemented as a
+# per-STEP `LANE_ACTIVE` condition inside the matrix jobs instead of a
+# job-level `if:`: the legs must keep instantiating so their per-leg names
+# keep being reported.
+PLAN_GATED_RE = re.compile(r"outputs\.(?:impact|active_lanes)")
 MATRIX_NAME_TEMPLATE = "${{ matrix.name }}"
 
 
@@ -271,7 +282,7 @@ def classify_workflow(doc: dict) -> dict:
 
         if DOCS_ONLY_TRUE_RE.search(cond_str):
             stub.update(names)
-        elif DOCS_ONLY_FALSE_RE.search(cond_str):
+        elif DOCS_ONLY_FALSE_RE.search(cond_str) or PLAN_GATED_RE.search(cond_str):
             if is_matrix:
                 skippable_matrix.update(names)
             else:
@@ -533,6 +544,133 @@ def check(required_contexts: list[str], reportable: dict) -> dict:
     }
 
 
+# ───────────── per-build-impact-class coverage (the second half) ─────────────
+#
+# The SUBSET-OF rule above grades one PR shape: docs-only versus everything
+# else. Since PR #624's build-impact classifier and the lane plan that
+# followed it, `changes` distinguishes more shapes than that -- `docs`,
+# `non-build`, `tests-only`, `full`, and `equivalent` (a head proven
+# identical to an already-verified commit). Each is a DIFFERENT PR shape,
+# and "the required contexts are all reportable" has to hold on every one
+# of them, not just on the two the original rule knew about.
+#
+# Two things are checked here, and both are cross-checks between two
+# artifacts that a person could otherwise let drift apart:
+#
+#   1. Every class maps to a `docs_only` value that `.github/workflows/
+#      ci.yml` really assigns. The list of classes that set
+#      `docs_only=true` is read out of the `changes` job's own shell, and
+#      compared against `scripts/ci_lane_plan.py`'s `INERT_CLASSES`. Adding
+#      a class to one and not the other is the drift this catches.
+#   2. On every class, the graded required contexts are all reportable --
+#      using the stub-covered rule for the classes where the matrix jobs
+#      are skipped at the job level, and the "matrix instantiates" rule for
+#      the classes where they run (however few of their steps do).
+
+LANE_PLAN_SCRIPT = os.path.join(REPO_ROOT, "scripts", "ci_lane_plan.py")
+DOCS_ONLY_TRUE_CLASS_RE = re.compile(r'"\$impact"\s*==\s*"([a-z-]+)"')
+
+
+def _load_lane_plan_module():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("ci_lane_plan", LANE_PLAN_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise ConsistencyError(f"cannot load {LANE_PLAN_SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def docs_only_true_classes(ci_path: str) -> list[str]:
+    """The impact classes the `changes` job itself maps to docs_only=true.
+
+    Read out of the job's shell rather than assumed, so this gate grades
+    the workflow that exists rather than the one it remembers.
+    """
+
+    try:
+        with open(ci_path, "r", encoding="utf-8") as handle:
+            lines = handle.read().splitlines()
+    except OSError as exc:
+        raise ConsistencyError(f"cannot read {ci_path}: {exc}") from exc
+
+    for index, line in enumerate(lines):
+        if line.strip() != "docs_only=true":
+            continue
+        for candidate in reversed(lines[max(0, index - 3):index]):
+            if "$impact" in candidate:
+                found = DOCS_ONLY_TRUE_CLASS_RE.findall(candidate)
+                if found:
+                    return found
+    raise ConsistencyError(
+        "could not find the `changes` job's docs_only=true assignment in "
+        f"{ci_path} -- this gate cannot grade the impact classes without it")
+
+
+def check_impact_classes(required_contexts: list[str], reportable: dict,
+                         ci_path: str) -> dict:
+    """Grade every build-impact class, not just docs-only-versus-everything."""
+
+    try:
+        lane_plan = _load_lane_plan_module()
+        workflow = lane_plan.load_workflow(Path(ci_path))
+    except Exception as exc:  # noqa: BLE001 - fails closed, like every gate here
+        return {
+            "passed": False,
+            "rows": [],
+            "problems": [f"could not derive the lane plan from {ci_path}: {exc}"],
+        }
+
+    stub_rule = (reportable["unconditional"] | reportable["skippable_static"]
+                 | (reportable["skippable_matrix"] & reportable["stub"]))
+    matrix_runs_rule = (reportable["unconditional"] | reportable["skippable_static"]
+                        | reportable["skippable_matrix"])
+
+    problems: list[str] = []
+    try:
+        workflow_inert = sorted(docs_only_true_classes(ci_path))
+    except ConsistencyError as exc:
+        return {"passed": False, "rows": [], "problems": [str(exc)]}
+
+    plan_inert = sorted(lane_plan.INERT_CLASSES)
+    if workflow_inert != plan_inert:
+        problems.append(
+            "the classes ci.yml maps to docs_only=true "
+            f"({workflow_inert}) are not the classes scripts/ci_lane_plan.py "
+            f"treats as inert ({plan_inert}) -- one of the two was changed "
+            "without the other, and a class that skips the matrix without "
+            "the stub job knowing is a permanent merge block")
+
+    declared_lanes = {leg["name"] for leg in workflow["lanes"]}
+    rows: list[dict] = []
+    for impact_class in lane_plan.KNOWN_CLASSES:
+        inert = impact_class in plan_inert
+        rule = stub_rule if inert else matrix_runs_rule
+        missing = [c for c in required_contexts if c not in rule]
+        plan_result = lane_plan.plan(impact_class, ["tests/lists/a_test.esk"], workflow)
+        planned = set(plan_result["active_lanes"]) | set(plan_result["skipped_lanes"])
+        lost = sorted(declared_lanes - planned)
+        rows.append({
+            "class": impact_class,
+            "docs_only": inert,
+            "matrix_jobs": "skipped at the job level" if inert else "instantiated",
+            "active_lanes": plan_result["active_lanes"],
+            "unreportable": missing,
+            "lanes_not_accounted_for": lost,
+        })
+        if missing:
+            problems.append(
+                f"impact class {impact_class!r}: {missing} would not be "
+                "reported on that PR shape")
+        if lost:
+            problems.append(
+                f"impact class {impact_class!r}: lanes {lost} appear in "
+                "neither the active nor the skipped set of the plan")
+
+    return {"passed": not problems, "rows": rows, "problems": problems}
+
+
 def emit_trace(trace_dir: str, status: str, snippet: str) -> str:
     os.makedirs(trace_dir, exist_ok=True)
     path = os.path.join(trace_dir, TRACE_BASENAME)
@@ -625,12 +763,66 @@ _MISSING_STUB_REQUIRED = ["guard", "alpha", "beta"]
 # emit (mirrors an admin adding a required context that names no job).
 _UNKNOWN_REQUIRED = ["guard", "alpha", "beta", "totally-imaginary-context"]
 
+# Red case (c): the mistake the LANE PLAN could introduce. Selecting which
+# matrix lanes run must never be done with a job-level `if:` on the plan
+# outputs — that skips the whole job, and a skipped matrix job's per-leg
+# names are ABSENT, exactly as in red case (a). The real workflow selects
+# lanes with a per-STEP `LANE_ACTIVE` condition instead, so the legs keep
+# instantiating and keep reporting. This fixture writes it the wrong way
+# round and must FAIL.
+_PLAN_GATED_MATRIX_CI_YML = """
+jobs:
+  changes:
+    name: changes
+    if: "github.event_name != 'schedule'"
+    runs-on: ubuntu-22.04
+  docs-only-required-context-stubs:
+    name: ${{ matrix.name }}
+    if: "github.event_name != 'schedule' && needs.changes.outputs.docs_only == 'true'"
+    strategy:
+      matrix:
+        name: [alpha]
+  unix-matrix:
+    name: ${{ matrix.name }}
+    if: "contains(needs.changes.outputs.active_lanes, matrix.name)"
+    strategy:
+      matrix:
+        name: [alpha, beta]
+"""
+_PLAN_GATED_MATRIX_REQUIRED = ["guard", "alpha", "beta"]
+
+# The same shape for a STATIC-named job (the advisory hosted-macOS jobs).
+# A static job skipped by the plan still reports one correctly-named
+# `skipped` check run, so this must PASS with no stub entry at all.
+_PLAN_GATED_STATIC_CI_YML = """
+jobs:
+  changes:
+    name: changes
+    if: "github.event_name != 'schedule'"
+    runs-on: ubuntu-22.04
+  bench-smoke:
+    name: bench-smoke
+    if: "contains(needs.changes.outputs.active_lanes, '|bench-smoke|')"
+    runs-on: macos-14
+"""
+_PLAN_GATED_STATIC_REQUIRED = ["guard", "bench-smoke"]
+
 _MALFORMED_YAML = """
 jobs:
   changes:
     name: changes
     if: "github.event_name != 'schedule'
     runs-on: ubuntu-22.04
+"""
+
+# For the `docs_only_true_classes` unit case: the shape of the `changes`
+# job's own assignment, with a class list this gate must read back exactly.
+_DOCS_ONLY_ASSIGNMENT_FIXTURE = """
+          if [[ "$impact" == "docs" || "$impact" == "non-build" || "$impact" == "equivalent" ]]; then
+            docs_only=true
+          else
+            docs_only=false
+          fi
 """
 
 
@@ -669,6 +861,11 @@ def self_test() -> bool:
              _MISSING_STUB_REQUIRED, False),
             ("red_b_unknown_required_context", _GOOD_CI_YML, _GOOD_IDENTITY_YML,
              _UNKNOWN_REQUIRED, False),
+            ("red_c_matrix_job_gated_on_the_lane_plan", _PLAN_GATED_MATRIX_CI_YML,
+             _GOOD_IDENTITY_YML, _PLAN_GATED_MATRIX_REQUIRED, False),
+            ("static_job_gated_on_the_lane_plan_needs_no_stub",
+             _PLAN_GATED_STATIC_CI_YML, _GOOD_IDENTITY_YML,
+             _PLAN_GATED_STATIC_REQUIRED, True),
             ("malformed_yaml", _MALFORMED_YAML, _GOOD_IDENTITY_YML, _GOOD_REQUIRED, False),
         ]
         for name, ci_text, identity_text, required, expect_pass in cases:
@@ -743,6 +940,60 @@ def self_test() -> bool:
                       f"{result_live_only['passed']}, union passed={result_target_union['passed']}")
                 all_ok = False
 
+    # The build-impact-class half: the class list is read out of the
+    # `changes` job's own shell, and it must agree with the lane plan's
+    # notion of which classes skip the matrix. Both halves are checked --
+    # the reader against a fixture, and the agreement against the real,
+    # committed ci.yml (the artifact that actually decides merges).
+    with tempfile.TemporaryDirectory(dir=REPO_ROOT, prefix=".selftest-context-gate-impact-") as tmp_dir:
+        fixture = os.path.join(tmp_dir, "ci.yml")
+        _write(fixture, _DOCS_ONLY_ASSIGNMENT_FIXTURE)
+        try:
+            classes = docs_only_true_classes(fixture)
+        except ConsistencyError as exc:
+            print(f"  [GATE IS BROKEN] docs_only_class_reader: {exc}")
+            all_ok = False
+        else:
+            expected = ["docs", "non-build", "equivalent"]
+            if classes == expected:
+                print("  [OK] docs_only_class_reader: read "
+                      f"{classes} out of the assignment")
+            else:
+                print(f"  [GATE IS BROKEN] docs_only_class_reader: expected "
+                      f"{expected}, got {classes}")
+                all_ok = False
+
+        empty = os.path.join(tmp_dir, "no-assignment.yml")
+        _write(empty, "jobs:\n  changes:\n    name: changes\n")
+        try:
+            docs_only_true_classes(empty)
+        except ConsistencyError:
+            print("  [OK] docs_only_class_reader_fails_closed: a workflow with no "
+                  "docs_only assignment is an error, not a silent empty list")
+        else:
+            print("  [GATE IS BROKEN] docs_only_class_reader_fails_closed: "
+                  "returned a verdict for a workflow with no assignment")
+            all_ok = False
+
+    real_ci = os.path.join(REPO_ROOT, ".github", "workflows", "ci.yml")
+    if os.path.exists(real_ci):
+        try:
+            reportable = compute_reportable(DEFAULT_WORKFLOWS)
+            target = load_target(DEFAULT_TARGET_FILE)
+            impact = check_impact_classes(target, reportable, real_ci)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  [GATE IS BROKEN] real_workflow_impact_classes: {exc}")
+            all_ok = False
+        else:
+            if impact["passed"]:
+                graded = ", ".join(row["class"] for row in impact["rows"])
+                print(f"  [OK] real_workflow_impact_classes: every intended required "
+                      f"context is reportable on each of {graded}")
+            else:
+                print("  [GATE IS BROKEN] real_workflow_impact_classes: "
+                      + "; ".join(impact["problems"]))
+                all_ok = False
+
     if all_ok:
         print("self-test: PASS — the gate fails on every broken fixture, passes the well-formed ones, "
               "NO_DATA is reachable and distinct from TARGET_ONLY/PASS, and grading target UNION live "
@@ -805,17 +1056,36 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     result = check(required_contexts, reportable)
+
+    # The same question, asked once per build-impact class rather than once
+    # for "docs-only versus everything else". Graded against ci.yml itself,
+    # so it is skipped only when ci.yml is not among the workflows checked
+    # (a caller grading some other file).
+    ci_path = next((path for path in workflows
+                    if os.path.basename(path) == "ci.yml"), None)
+    if ci_path is not None:
+        impact = check_impact_classes(required_contexts, reportable, ci_path)
+        result["impact_classes"] = impact["rows"]
+        result["impact_class_problems"] = impact["problems"]
+        result["passed"] = result["passed"] and impact["passed"]
+    else:
+        impact = {"passed": True, "rows": [], "problems": []}
+
     status = "PASS" if result["passed"] else "FAIL"
 
     if result["passed"]:
         snippet = (
             f"[{mode}] {result['required_count']} graded contexts, all reportable on every "
-            f"PR shape ({result['reportable_count']} contexts reportable overall)"
+            f"PR shape ({result['reportable_count']} contexts reportable overall; "
+            f"{len(impact['rows'])} build-impact classes graded)"
         )
-    else:
+    elif result["missing"]:
         snippet = f"[{mode}] {len(result['missing'])} graded context(s) unreportable: " + "; ".join(
             f"{m['context']!r} ({m['reason_kind']})" for m in result["missing"][:5]
         )
+    else:
+        snippet = f"[{mode}] build-impact class coverage failed: " + "; ".join(
+            impact["problems"][:3])
 
     if not args.no_trace:
         emit_trace(args.trace_dir, status, snippet)
@@ -828,10 +1098,19 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  note: {note}")
         print(f"  graded contexts   : {result['required_count']}")
         print(f"  reportable always : {result['reportable_count']}")
+        if impact["rows"]:
+            print("  build-impact classes:")
+            for row in impact["rows"]:
+                lanes = (", ".join(row["active_lanes"]) if row["active_lanes"]
+                         else "none")
+                print(f"    - {row['class']:<11} docs_only={str(row['docs_only']).lower():<5} "
+                      f"matrix {row['matrix_jobs']}; active lanes: {lanes}")
         if result["missing"]:
             print("  UNREPORTABLE REQUIRED CONTEXTS:")
             for m in result["missing"]:
                 print(f"    - {m['context']!r}: {m['reason']} [{m['reason_kind']}]")
+        for problem in impact["problems"]:
+            print(f"    - BUILD-IMPACT CLASS COVERAGE: {problem}")
 
     return 0 if result["passed"] else 1
 

--- a/scripts/ci_equivalent_head.py
+++ b/scripts/ci_equivalent_head.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""Decide whether a PR head is CONTENT-IDENTICAL to an already-verified commit.
+
+Motivating case: a branch is rebased, re-cut onto a fresh base, or
+cherry-picked into a new PR after its original PR was closed. The commit
+SHA changes, so every required status context has to be produced again for
+the new head -- the full cross-platform matrix runs a second time over a
+change whose content nothing has altered. On this repo the macOS runner
+pool is the throughput bottleneck, so those re-runs are the single largest
+avoidable cost in the queue.
+
+This script answers ONE narrow question, in terms git itself can settle:
+
+    is <head> the same CONTENT as <reference>?
+
+and it answers it two ways, in decreasing strength:
+
+  tree   `git rev-parse <sha>^{tree}` is equal for both commits. The two
+         commits have byte-identical working trees. Nothing a build or a
+         test could observe differs -- this is the strongest possible
+         statement and it is completely independent of history shape,
+         author, message, parentage or base.
+
+  patch  `git diff <merge-base(base, sha)> <sha> | git patch-id --stable`
+         is equal for both commits. The two commits introduce the same
+         change relative to their own bases. This is what `git rebase`
+         and `git cherry` use to recognise "already applied" commits, and
+         `--stable` makes the id independent of diff ordering. Weaker than
+         tree identity -- the two BASES may differ, so the resulting trees
+         can differ -- which is why it is reported as its own `kind` and
+         why the caller is expected to pair it with proof that the
+         reference itself passed CI on a base that is an ancestor of the
+         current one.
+
+  none   neither holds. The two commits are not known to be equivalent.
+         This is also the answer whenever anything could not be computed
+         (an object that does not resolve, an empty diff, a git failure):
+         "I could not tell" and "they differ" collapse to the same
+         CONSERVATIVE outcome, because the only thing a caller may do with
+         a `none` verdict is run the full verification.
+
+What this script deliberately does NOT do
+    It never consults GitHub, never reads a PR label, and never decides
+    whether the reference commit was actually verified. Equivalence to a
+    commit that never passed CI is worth nothing, so the caller
+    (`.github/workflows/ci.yml`'s `changes` job) must independently
+    confirm that the reference SHA has a completed, successful `CI`
+    workflow run before acting on a `true` verdict here. Keeping the two
+    halves separate is the point: this half is pure git and is fully
+    testable offline; that half is pure GitHub API and cannot be faked by
+    anything in the diff.
+
+Usage
+    python3 scripts/ci_equivalent_head.py --head <sha> --reference <sha>
+    python3 scripts/ci_equivalent_head.py --head HEAD --reference abc123 \\
+        --base-ref origin/master
+    python3 scripts/ci_equivalent_head.py --head <sha> --reference <sha> \\
+        --fetch-remote origin
+    python3 scripts/ci_equivalent_head.py --self-test
+
+Output: one JSON object on stdout --
+
+    {"equivalent": bool,
+     "kind": "tree" | "patch" | "none",
+     "reason": "<human sentence>",
+     "head": "<resolved sha or null>",
+     "reference": "<resolved sha or null>",
+     "checks": {"tree": {...}, "patch": {...}}}
+
+Exit status: 0 whenever a verdict was produced (equivalent or not), 1 on a
+usage error or a failing `--self-test`. A `none` verdict is NOT an error
+exit -- the caller's fall-through path is a normal, expected outcome.
+
+Scratch space: `--self-test` builds throwaway git repositories under
+`<repo>/.scratch/` (never a system temp directory, which this machine
+wipes on reboot) and removes them again on the way out.
+
+Copyright (C) tsotchke
+SPDX-License-Identifier: MIT
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRATCH_ROOT = REPO_ROOT / ".scratch"
+
+KIND_TREE = "tree"
+KIND_PATCH = "patch"
+KIND_NONE = "none"
+
+
+def _git(args: list[str], cwd: Path) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _rev_parse(rev: str, cwd: Path) -> str | None:
+    code, out, _ = _git(["rev-parse", "--verify", "--quiet", f"{rev}^{{commit}}"], cwd)
+    if code != 0:
+        return None
+    resolved = out.strip()
+    return resolved or None
+
+
+def _tree_of(rev: str, cwd: Path) -> str | None:
+    code, out, _ = _git(["rev-parse", "--verify", "--quiet", f"{rev}^{{tree}}"], cwd)
+    if code != 0:
+        return None
+    resolved = out.strip()
+    return resolved or None
+
+
+def _merge_base(a: str, b: str, cwd: Path) -> str | None:
+    code, out, _ = _git(["merge-base", a, b], cwd)
+    if code != 0:
+        return None
+    resolved = out.strip()
+    return resolved or None
+
+
+def _patch_id(base: str, tip: str, cwd: Path) -> str | None:
+    """The `--stable` patch id of `base..tip`, or None if there isn't one.
+
+    An EMPTY diff has no patch id (git prints nothing), and two empty
+    diffs must never be called "the same patch" -- that would make every
+    no-op commit equivalent to every other one. None here therefore means
+    "no usable evidence", and the caller treats it as `none`.
+    """
+
+    diff = subprocess.run(
+        ["git", "diff", "--full-index", "--binary", base, tip],
+        cwd=str(cwd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if diff.returncode != 0 or not diff.stdout.strip():
+        return None
+    ident = subprocess.run(
+        ["git", "patch-id", "--stable"],
+        cwd=str(cwd),
+        input=diff.stdout,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if ident.returncode != 0:
+        return None
+    text = ident.stdout.decode("utf-8", "replace").strip()
+    if not text:
+        return None
+    return text.split()[0]
+
+
+def _try_fetch(remote: str, sha: str, cwd: Path) -> None:
+    """Best-effort: make `sha` resolvable in a shallow/partial checkout.
+
+    Never raises. A fetch that fails simply leaves the object missing,
+    which the caller reports as `none` -- the conservative answer.
+    """
+
+    _git(["fetch", "--no-tags", "--quiet", remote, sha], cwd)
+
+
+def evaluate(
+    head: str,
+    reference: str,
+    repo_dir: Path,
+    base_ref: str = "origin/master",
+    fetch_remote: str | None = None,
+) -> dict:
+    """Compute the equivalence verdict. Never raises on git-level problems."""
+
+    checks: dict[str, dict] = {}
+
+    head_sha = _rev_parse(head, repo_dir)
+    if head_sha is None and fetch_remote:
+        _try_fetch(fetch_remote, head, repo_dir)
+        head_sha = _rev_parse(head, repo_dir)
+
+    reference_sha = _rev_parse(reference, repo_dir)
+    if reference_sha is None and fetch_remote:
+        _try_fetch(fetch_remote, reference, repo_dir)
+        reference_sha = _rev_parse(reference, repo_dir)
+
+    if head_sha is None or reference_sha is None:
+        missing = []
+        if head_sha is None:
+            missing.append(f"head {head!r}")
+        if reference_sha is None:
+            missing.append(f"reference {reference!r}")
+        return {
+            "equivalent": False,
+            "kind": KIND_NONE,
+            "reason": (
+                "could not resolve " + " and ".join(missing)
+                + " in this checkout; treating the two commits as different"
+            ),
+            "head": head_sha,
+            "reference": reference_sha,
+            "checks": checks,
+        }
+
+    if head_sha == reference_sha:
+        # Same commit. Trivially the same tree; report it as tree identity
+        # rather than inventing a third kind.
+        checks["tree"] = {"head": _tree_of(head_sha, repo_dir),
+                          "reference": _tree_of(reference_sha, repo_dir),
+                          "equal": True}
+        return {
+            "equivalent": True,
+            "kind": KIND_TREE,
+            "reason": f"head and reference are the same commit ({head_sha})",
+            "head": head_sha,
+            "reference": reference_sha,
+            "checks": checks,
+        }
+
+    head_tree = _tree_of(head_sha, repo_dir)
+    reference_tree = _tree_of(reference_sha, repo_dir)
+    checks["tree"] = {
+        "head": head_tree,
+        "reference": reference_tree,
+        "equal": bool(head_tree and reference_tree and head_tree == reference_tree),
+    }
+    if checks["tree"]["equal"]:
+        return {
+            "equivalent": True,
+            "kind": KIND_TREE,
+            "reason": (
+                f"tree identity: {head_sha} and {reference_sha} have the same "
+                f"tree {head_tree} -- the two checkouts are byte-identical"
+            ),
+            "head": head_sha,
+            "reference": reference_sha,
+            "checks": checks,
+        }
+
+    head_base = _merge_base(base_ref, head_sha, repo_dir)
+    reference_base = _merge_base(base_ref, reference_sha, repo_dir)
+    head_patch = _patch_id(head_base, head_sha, repo_dir) if head_base else None
+    reference_patch = (
+        _patch_id(reference_base, reference_sha, repo_dir) if reference_base else None
+    )
+    checks["patch"] = {
+        "base_ref": base_ref,
+        "head_merge_base": head_base,
+        "reference_merge_base": reference_base,
+        "head_patch_id": head_patch,
+        "reference_patch_id": reference_patch,
+        "equal": bool(head_patch and reference_patch and head_patch == reference_patch),
+    }
+    if checks["patch"]["equal"]:
+        return {
+            "equivalent": True,
+            "kind": KIND_PATCH,
+            "reason": (
+                f"patch identity: {head_sha} and {reference_sha} both introduce "
+                f"patch-id {head_patch} relative to their own merge-base with "
+                f"{base_ref}"
+            ),
+            "head": head_sha,
+            "reference": reference_sha,
+            "checks": checks,
+        }
+
+    detail = "trees differ"
+    if head_patch is None or reference_patch is None:
+        detail += " and no usable patch-id could be computed for both commits"
+    else:
+        detail += " and the two patch-ids differ"
+    return {
+        "equivalent": False,
+        "kind": KIND_NONE,
+        "reason": (
+            f"{head_sha} is not equivalent to {reference_sha}: {detail}"
+        ),
+        "head": head_sha,
+        "reference": reference_sha,
+        "checks": checks,
+    }
+
+
+# ───────────────────────────────── self-test ─────────────────────────────────
+
+def _run(args: list[str], cwd: Path, env: dict | None = None) -> None:
+    proc = subprocess.run(
+        args, cwd=str(cwd),
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        env=env,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"{' '.join(args)} failed:\n{proc.stdout}")
+
+
+def _fixture_env() -> dict:
+    env = dict(os.environ)
+    env.update({
+        "GIT_AUTHOR_NAME": "selftest",
+        "GIT_AUTHOR_EMAIL": "selftest@example.invalid",
+        "GIT_COMMITTER_NAME": "selftest",
+        "GIT_COMMITTER_EMAIL": "selftest@example.invalid",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    })
+    return env
+
+
+def _build_fixture(root: Path) -> dict:
+    """A throwaway repo containing all three cases this script must separate.
+
+        master:   b0 -- b1 -- b2            (b2 is the current base tip)
+        rebased:  b2 -- R      (the same change as O, re-cut onto b2)
+        original: b1 -- O      (verified earlier, on the older base)
+        copy:     b1 -- C      (identical content to O, different commit)
+        other:    b2 -- X      (a genuinely different change)
+
+    `C` vs `O` proves TREE identity across distinct commits; `R` vs `O`
+    proves PATCH identity across different bases; `X` vs `O` is the
+    negative case.
+    """
+
+    env = _fixture_env()
+    _run(["git", "init", "--quiet", "--initial-branch=master", "."], root, env)
+
+    def commit(message: str) -> str:
+        _run(["git", "add", "-A"], root, env)
+        _run(["git", "commit", "--quiet", "--no-gpg-sign", "-m", message], root, env)
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=str(root),
+            stdout=subprocess.PIPE, text=True, env=env,
+        ).stdout.strip()
+
+    (root / "base.txt").write_text("base 0\n")
+    commit("b0")
+    (root / "base.txt").write_text("base 1\n")
+    b1 = commit("b1")
+    (root / "base.txt").write_text("base 2\n")
+    b2 = commit("b2")
+
+    # The originally verified head, cut from b1.
+    _run(["git", "checkout", "--quiet", "-b", "original", b1], root, env)
+    (root / "feature.txt").write_text("feature payload\n")
+    original = commit("feature")
+
+    # A byte-identical re-commit of the same content, also on b1.
+    _run(["git", "checkout", "--quiet", "-b", "copy", b1], root, env)
+    (root / "feature.txt").write_text("feature payload\n")
+    copy = commit("feature (recommitted, different message metadata)")
+
+    # The same change rebased onto the newer base b2.
+    _run(["git", "checkout", "--quiet", "-b", "rebased", b2], root, env)
+    (root / "feature.txt").write_text("feature payload\n")
+    rebased = commit("feature")
+
+    # A genuinely different change on the same base.
+    _run(["git", "checkout", "--quiet", "-b", "other", b2], root, env)
+    (root / "feature.txt").write_text("a different payload entirely\n")
+    other = commit("other feature")
+
+    _run(["git", "checkout", "--quiet", "master"], root, env)
+    return {"b1": b1, "b2": b2, "original": original, "copy": copy,
+            "rebased": rebased, "other": other}
+
+
+def self_test(scratch_dir: Path | None = None) -> bool:
+    print("ci_equivalent_head.py self-test:")
+    root_dir = scratch_dir or SCRATCH_ROOT
+    root_dir.mkdir(parents=True, exist_ok=True)
+    work = Path(tempfile.mkdtemp(prefix="ci_equivalent_head_", dir=str(root_dir)))
+    ok = True
+    try:
+        repo = work / "repo"
+        repo.mkdir()
+        shas = _build_fixture(repo)
+
+        cases = [
+            # name, head, reference, expect_equivalent, expect_kind
+            ("tree_identity_across_distinct_commits",
+             shas["copy"], shas["original"], True, KIND_TREE),
+            ("patch_identity_after_rebase_onto_newer_base",
+             shas["rebased"], shas["original"], True, KIND_PATCH),
+            ("negative_a_different_change_is_not_equivalent",
+             shas["other"], shas["original"], False, KIND_NONE),
+            ("negative_an_unresolvable_reference_is_not_equivalent",
+             shas["rebased"], "0" * 40, False, KIND_NONE),
+            ("same_commit_is_tree_identical",
+             shas["original"], shas["original"], True, KIND_TREE),
+        ]
+
+        for name, head, reference, want_equivalent, want_kind in cases:
+            verdict = evaluate(head, reference, repo, base_ref="master")
+            got = (verdict["equivalent"], verdict["kind"])
+            want = (want_equivalent, want_kind)
+            if got == want:
+                print(f"  PASS {name}: {verdict['kind']} "
+                      f"(equivalent={verdict['equivalent']})")
+            else:
+                ok = False
+                print(f"  FAIL {name}: expected {want}, got {got} "
+                      f"-- {verdict['reason']}")
+
+        # The patch-identity case must NOT be reachable by tree identity --
+        # otherwise the "patch" case above would be silently proving the
+        # "tree" path a second time instead of the code it names.
+        rebased_tree = _tree_of(shas["rebased"], repo)
+        original_tree = _tree_of(shas["original"], repo)
+        if rebased_tree == original_tree:
+            ok = False
+            print("  FAIL fixture_integrity: the rebased and original commits "
+                  "share a tree, so the patch-identity case never exercised "
+                  "the patch-id path")
+        else:
+            print("  PASS fixture_integrity: the rebased commit really does "
+                  "have a different tree than the original")
+    except Exception as exc:  # noqa: BLE001 - a self-test reports, never crashes
+        ok = False
+        print(f"  FAIL self-test raised: {exc}")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+    print("  RESULT:", "PASS" if ok else "FAIL")
+    return ok
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Decide whether a PR head is content-identical to an "
+                    "already-verified commit.")
+    parser.add_argument("--head", help="the PR head commit-ish")
+    parser.add_argument("--reference", help="the already-verified commit-ish")
+    parser.add_argument("--base-ref", default="origin/master",
+                        help="branch both commits are measured against for "
+                             "patch identity (default: origin/master)")
+    parser.add_argument("--repo-dir", default=".",
+                        help="git repository to evaluate in (default: cwd)")
+    parser.add_argument("--fetch-remote", default=None,
+                        help="best-effort `git fetch <remote> <sha>` when an "
+                             "object does not resolve locally")
+    parser.add_argument("--self-test", action="store_true",
+                        help="prove both equivalence kinds and a negative case")
+    parser.add_argument("--scratch-dir", default=None,
+                        help="where --self-test builds its throwaway repos "
+                             "(default: <repo>/.scratch)")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        scratch = Path(args.scratch_dir).resolve() if args.scratch_dir else None
+        return 0 if self_test(scratch) else 1
+
+    if not args.head or not args.reference:
+        parser.error("--head and --reference are both required "
+                     "(or pass --self-test)")
+
+    verdict = evaluate(
+        args.head,
+        args.reference,
+        Path(args.repo_dir).resolve(),
+        base_ref=args.base_ref,
+        fetch_remote=args.fetch_remote,
+    )
+    json.dump(verdict, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    print(verdict["reason"], file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci_lane_plan.py
+++ b/scripts/ci_lane_plan.py
@@ -1,0 +1,696 @@
+#!/usr/bin/env python3
+"""Decide WHICH CI lanes a change actually needs, from the lanes themselves.
+
+`scripts/ci_change_class.py` answers "how much could this change possibly
+affect" (docs / non-build / tests-only / full). For the two inert classes
+the answer is already actionable -- skip the heavy matrix, let
+`docs-only-required-context-stubs` report the required contexts. For
+`tests-only` it was, until this script existed, purely informational: a
+one-line edit to a single `.esk` test still ran all 25 cross-platform
+lanes, six of them on hosted macOS runners, which are this repo's
+throughput bottleneck.
+
+This script turns that class into a lane decision. It never contains a
+hand-written lane list: every lane name, every lane's runner, and every
+lane's capability flags are re-derived from `.github/workflows/ci.yml`
+itself on each run, so a lane added, renamed or removed there is picked up
+with nothing to keep in sync. (The same discipline
+`scripts/check_required_context_consistency.py` and
+`scripts/ci_change_class.py` already apply: derive from the real artifact,
+never maintain a second copy of it.)
+
+Lane selection for `tests-only`
+    Every rule below is a statement about what the changed files can
+    reach, and each is derived from lane metadata rather than typed out:
+
+      * DIRECT REFERENCE -- a changed file whose exact path appears in a
+        lane's `test_command` (or in an aux job's `run:` block) activates
+        that lane. This is how an edit to `scripts/run_gpu_tests.sh`
+        reaches exactly the lanes that run it.
+      * GPU tests -- a change under a `tests/` directory named after a
+        capability flag (`tests/gpu`) activates the lanes declaring that
+        capability (`gpu_enabled: 'ON'`), and nothing else.
+      * XLA tests -- likewise for `tests/xla` and `xla_enabled: 'ON'`.
+      * VM-parity tests -- `tests/vm_parity` is executed by the
+        `pillars-fast` job (`scripts/run_vm_parity.sh`), which is not
+        matrix-gated and runs on every non-inert PR regardless. One
+        portable lane is added alongside it so the corpus is also
+        exercised through a real compiler build.
+      * ANYTHING ELSE under `tests/` -- the cheapest portable ("lite")
+        lane of each OS family, in the order `ci.yml` declares them:
+        the first lane per family with `xla_enabled: 'OFF'`,
+        `gpu_enabled: 'OFF'`, no sanitizer flags and the default build
+        directory. Today that resolves to linux-x64-lite,
+        macos-arm64-lite and windows-arm64-lite -- one per OS, each
+        running the full `scripts/run_all_tests.sh` suite.
+
+    Every lane NOT selected still instantiates as a matrix leg and still
+    reports a check run under its own name (its steps are gated on the
+    `LANE_ACTIVE` job env this script's output feeds). That is
+    load-bearing: a lane whose job never instantiates at all reports
+    NOTHING, and a required status context with no check run blocks a PR
+    forever -- the failure mode
+    `scripts/check_required_context_consistency.py` exists to prevent.
+    Skipping steps rather than skipping jobs keeps the entire required-
+    context set intact by construction, for every class.
+
+Output contract
+    A JSON object on stdout:
+
+      {"impact": "<class>",
+       "active": "ALL" | "|lane|lane|...|" | "",
+       "active_lanes": [...], "skipped_lanes": [...],
+       "aux_jobs": [...], "skipped_aux_jobs": [...],
+       "rules": ["<why each lane was selected>", ...],
+       "summary": "<one line>",
+       "derivation": {...}}
+
+    `active` is the exact string `.github/workflows/ci.yml` consumes.
+    "ALL" means "every lane active" and is the fail-safe value -- the
+    workflow treats it, and any value it cannot make sense of, as
+    "run everything".
+
+Usage
+    git diff --name-only origin/master...HEAD \\
+        | python3 scripts/ci_lane_plan.py --impact tests-only
+    python3 scripts/ci_lane_plan.py --impact full
+    python3 scripts/ci_lane_plan.py --impact tests-only tests/gpu/x.esk
+    python3 scripts/ci_lane_plan.py --self-test
+
+Exit status: 0 on a successful plan or a passing `--self-test`; 1 on a
+usage error, an unparseable workflow, or a failing `--self-test`.
+
+Copyright (C) tsotchke
+SPDX-License-Identifier: MIT
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+MATRIX_NAME_TEMPLATE = "${{ matrix.name }}"
+DOCS_ONLY_FALSE_RE = re.compile(r"docs_only\s*==\s*'false'")
+DOCS_ONLY_TRUE_RE = re.compile(r"docs_only\s*==\s*'true'")
+
+# Classes for which the heavy matrix is skipped at the JOB level (the
+# `docs_only == 'true'` path), so no lane is active and the stub job
+# reports the required contexts.
+INERT_CLASSES = ("docs", "non-build", "equivalent")
+# Classes that run every lane.
+FULL_CLASSES = ("full",)
+CLASS_TESTS_ONLY = "tests-only"
+KNOWN_CLASSES = INERT_CLASSES + FULL_CLASSES + (CLASS_TESTS_ONLY,)
+
+ALL_LANES = "ALL"
+
+# `tests/<dir>` -> the lane capability flag that directory's tests need.
+# Both halves are real: the directory is checked against the repository's
+# own tests tree, and the flag against the lane definitions in ci.yml.
+CAPABILITY_DIRS = {
+    "gpu": "gpu_enabled",
+    "xla": "xla_enabled",
+}
+# `tests/<dir>` -> a non-matrix job that already executes that corpus.
+# `pillars-fast` runs scripts/run_vm_parity.sh unconditionally on every
+# non-inert PR, so a vm_parity change is covered there; one portable lane
+# is added so it is also exercised against a real compiler build.
+CORPUS_COVERED_ELSEWHERE = {
+    "vm_parity": "pillars-fast",
+}
+
+
+class LanePlanError(Exception):
+    """The workflow could not be read well enough to plan anything."""
+
+
+# ─────────────────────────── ci.yml (line) parsing ───────────────────────────
+#
+# Deliberately dependency-free. This script runs in the `changes` job,
+# which is the single point of failure for the whole workflow and is kept
+# to a bare checkout plus stock `python3` -- exactly like
+# `scripts/ci_change_class.py`, which parses the same workflow files the
+# same way and for the same reason. The structures parsed here are the
+# three the file actually uses, and `--self-test` asserts the parse
+# against the real, committed `ci.yml` rather than fixtures alone.
+
+def _split_jobs(text: str) -> dict[str, list[str]]:
+    lines = text.splitlines()
+    try:
+        start = next(i for i, line in enumerate(lines) if line.rstrip() == "jobs:")
+    except StopIteration as exc:
+        raise LanePlanError("workflow has no top-level `jobs:` block") from exc
+
+    jobs: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in lines[start + 1:]:
+        if line and not line.startswith(" ") and not line.startswith("#"):
+            break  # a new top-level key ends the jobs block
+        match = re.match(r"^  ([A-Za-z0-9_.\-]+):\s*$", line)
+        if match:
+            current = match.group(1)
+            jobs[current] = []
+            continue
+        if current is not None:
+            jobs[current].append(line)
+    if not jobs:
+        raise LanePlanError("workflow's `jobs:` block contained no jobs")
+    return jobs
+
+
+def _job_scalar(block: list[str], key: str) -> str | None:
+    """A job-level scalar, inline or as a folded/literal block.
+
+    `if:` conditions in this workflow are long enough that some are written
+    as `if: >-` over several lines; reading only the first line would see
+    the fold indicator instead of the condition and silently mis-bucket the
+    job, so the continuation is joined here.
+    """
+
+    pattern = re.compile(rf"^    {re.escape(key)}:\s*(.*)$")
+    for index, line in enumerate(block):
+        match = pattern.match(line)
+        if not match:
+            continue
+        value = match.group(1).strip()
+        if value not in (">", ">-", ">+", "|", "|-", "|+"):
+            return _unquote(value)
+        parts: list[str] = []
+        for continuation in block[index + 1:]:
+            if not continuation.strip():
+                continue
+            if not continuation.startswith("      "):
+                break
+            parts.append(continuation.strip())
+        return " ".join(parts)
+    return None
+
+
+def _unquote(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
+        return value[1:-1]
+    return value
+
+
+def _matrix_block(block: list[str]) -> list[str]:
+    """The lines under `strategy: matrix:` for one job, or []."""
+
+    out: list[str] = []
+    inside = False
+    for line in block:
+        if re.match(r"^      matrix:\s*$", line):
+            inside = True
+            continue
+        if inside:
+            if line.strip() and not line.startswith("        "):
+                break
+            out.append(line)
+    return out
+
+
+def _parse_include_legs(matrix_lines: list[str]) -> list[dict[str, str]]:
+    """`include:` entries as flat {key: scalar} dicts.
+
+    Handles the two scalar shapes this workflow uses: an inline value and
+    a folded block scalar (`>-`), which `linux-x64-debug`'s multi-command
+    `test_command` needs.
+    """
+
+    legs: list[dict[str, str]] = []
+    inside = False
+    current: dict[str, str] | None = None
+    pending_key: str | None = None
+    pending: list[str] = []
+
+    def flush_pending() -> None:
+        nonlocal pending_key, pending
+        if current is not None and pending_key is not None:
+            current[pending_key] = " ".join(part.strip() for part in pending).strip()
+        pending_key = None
+        pending = []
+
+    for line in matrix_lines:
+        if re.match(r"^        include:\s*$", line):
+            inside = True
+            continue
+        if not inside:
+            continue
+        if line.strip() and not line.startswith("          "):
+            break
+
+        entry = re.match(r"^          - ([A-Za-z0-9_]+):\s*(.*)$", line)
+        if entry:
+            flush_pending()
+            if current is not None:
+                legs.append(current)
+            current = {}
+            key, value = entry.group(1), entry.group(2)
+            if value.strip() in (">", ">-", "|", "|-"):
+                pending_key = key
+            else:
+                current[key] = _unquote(value)
+            continue
+
+        field = re.match(r"^            ([A-Za-z0-9_]+):\s*(.*)$", line)
+        if field and current is not None:
+            flush_pending()
+            key, value = field.group(1), field.group(2)
+            if value.strip() in (">", ">-", "|", "|-"):
+                pending_key = key
+            else:
+                current[key] = _unquote(value)
+            continue
+
+        if pending_key is not None and line.strip() and not line.lstrip().startswith("#"):
+            pending.append(line)
+
+    flush_pending()
+    if current is not None:
+        legs.append(current)
+    return [leg for leg in legs if "name" in leg]
+
+
+def _parse_name_list(matrix_lines: list[str]) -> list[str]:
+    """A plain `name:` sequence (the stub job's matrix)."""
+
+    names: list[str] = []
+    inside = False
+    for line in matrix_lines:
+        if re.match(r"^        name:\s*$", line):
+            inside = True
+            continue
+        if not inside:
+            continue
+        if line.strip() and not line.startswith("          "):
+            break
+        entry = re.match(r"^          - ([A-Za-z0-9_.\-]+)\s*$", line)
+        if entry:
+            names.append(entry.group(1))
+    return names
+
+
+def load_workflow(path: Path | None = None) -> dict:
+    """Everything this script needs to know about ci.yml, derived."""
+
+    workflow_path = path or CI_WORKFLOW
+    try:
+        text = workflow_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise LanePlanError(f"cannot read {workflow_path}: {exc}") from exc
+
+    jobs = _split_jobs(text)
+
+    lanes: list[dict[str, str]] = []
+    lane_job_ids: list[str] = []
+    stub_names: list[str] = []
+    aux_jobs: list[dict[str, str]] = []
+    job_text: dict[str, str] = {}
+
+    for job_id, block in jobs.items():
+        job_text[job_id] = "\n".join(block)
+        name = _job_scalar(block, "name")
+        cond = _job_scalar(block, "if") or ""
+        runs_on = _job_scalar(block, "runs-on") or ""
+        matrix_lines = _matrix_block(block)
+
+        if name is not None and name.strip() == MATRIX_NAME_TEMPLATE:
+            if DOCS_ONLY_TRUE_RE.search(cond):
+                stub_names.extend(_parse_name_list(matrix_lines))
+            elif DOCS_ONLY_FALSE_RE.search(cond):
+                legs = _parse_include_legs(matrix_lines)
+                if legs:
+                    lane_job_ids.append(job_id)
+                for leg in legs:
+                    leg = dict(leg)
+                    leg["_job"] = job_id
+                    lanes.append(leg)
+            continue
+
+        # A statically-named heavy job on a hosted macOS runner. These are
+        # advisory (never required contexts), and hosted macOS runners are
+        # the scarce resource, so they are planned alongside the lanes.
+        if DOCS_ONLY_FALSE_RE.search(cond) and runs_on.startswith("macos"):
+            aux_jobs.append({"job": job_id, "name": name or job_id,
+                             "runner": runs_on})
+
+    if not lanes:
+        raise LanePlanError(
+            "no matrix lanes found in the workflow -- refusing to plan a "
+            "reduction from an empty lane set")
+
+    return {
+        "path": str(workflow_path),
+        "lanes": lanes,
+        "lane_job_ids": lane_job_ids,
+        "stub_names": stub_names,
+        "aux_jobs": aux_jobs,
+        "job_text": job_text,
+    }
+
+
+# ───────────────────────────────── planning ─────────────────────────────────
+
+def _os_family(runner: str) -> str:
+    if runner.startswith("ubuntu"):
+        return "linux"
+    if runner.startswith("macos"):
+        return "macos"
+    if runner.startswith("windows"):
+        return "windows"
+    return "other"
+
+
+def _is_lite(leg: dict[str, str]) -> bool:
+    return (
+        leg.get("xla_enabled") == "OFF"
+        and leg.get("gpu_enabled") == "OFF"
+        and not leg.get("sanitizer_flags")
+        and leg.get("build_dir") == "build"
+    )
+
+
+def lite_lane_per_family(lanes: list[dict[str, str]]) -> dict[str, str]:
+    """First portable lane of each OS family, in declaration order."""
+
+    chosen: dict[str, str] = {}
+    for leg in lanes:
+        if not _is_lite(leg):
+            continue
+        family = _os_family(leg.get("runner", ""))
+        chosen.setdefault(family, leg["name"])
+    return chosen
+
+
+def _result(impact: str, active_lanes: list[str], skipped_lanes: list[str],
+            aux_active: list[str], aux_skipped: list[str],
+            rules: list[str], workflow: dict,
+            active: str | None = None) -> dict:
+    """Assemble the output document, including the `active` string ci.yml reads."""
+
+    if active is None:
+        tokens = active_lanes + aux_active
+        active = "|" + "|".join(tokens) + "|" if tokens else ""
+    if active_lanes and not skipped_lanes and active != "":
+        active = ALL_LANES
+    summary = (
+        f"impact {impact}: {len(active_lanes)}/"
+        f"{len(active_lanes) + len(skipped_lanes)} matrix lanes active"
+        + (f", aux {', '.join(aux_active)}" if aux_active else ", no aux job")
+    )
+    return {
+        "impact": impact,
+        "active": active,
+        "active_lanes": active_lanes,
+        "skipped_lanes": skipped_lanes,
+        "aux_jobs": aux_active,
+        "skipped_aux_jobs": aux_skipped,
+        "rules": rules,
+        "summary": summary,
+        "derivation": {
+            "workflow": workflow["path"],
+            "lane_jobs": workflow["lane_job_ids"],
+            "lanes_declared": [leg["name"] for leg in workflow["lanes"]],
+            "stub_matrix": workflow["stub_names"],
+            "aux_jobs_declared": [aux["job"] for aux in workflow["aux_jobs"]],
+        },
+    }
+
+
+def plan(impact: str, changed_files: list[str], workflow: dict) -> dict:
+    lanes = workflow["lanes"]
+    lane_names = [leg["name"] for leg in lanes]
+    aux_names = [aux["job"] for aux in workflow["aux_jobs"]]
+
+    if impact in INERT_CLASSES:
+        return _result(
+            impact, [], lane_names, [], aux_names,
+            ["no lane runs: the matrix jobs are skipped at the job level for "
+             f"impact '{impact}'; docs-only-required-context-stubs reports "
+             "every required context"],
+            workflow, active="")
+
+    if impact not in KNOWN_CLASSES or impact in FULL_CLASSES:
+        reason = (f"impact '{impact}' runs every lane"
+                  if impact in FULL_CLASSES
+                  else f"unrecognised impact '{impact}' -- running every lane "
+                       "(the conservative answer)")
+        return _result(impact, lane_names, [], aux_names, [], [reason],
+                       workflow, active=ALL_LANES)
+
+    # ---- tests-only ---------------------------------------------------
+    selected: set[str] = set()
+    selected_aux: set[str] = set()
+    rules: list[str] = []
+
+    lite = lite_lane_per_family(lanes)
+    by_name = {leg["name"]: leg for leg in lanes}
+
+    generic_test_change = False
+    for path in changed_files:
+        parts = path.split("/")
+        matched_rule = False
+
+        # DIRECT REFERENCE -- a lane or aux job that literally names this file.
+        for leg in lanes:
+            command = " ".join(
+                value for key, value in leg.items()
+                if key in ("test_command", "test_mode"))
+            if path and path in command:
+                selected.add(leg["name"])
+                rules.append(f"{path}: named by lane {leg['name']}'s test command")
+                matched_rule = True
+        for aux in workflow["aux_jobs"]:
+            if path and path in workflow["job_text"].get(aux["job"], ""):
+                selected_aux.add(aux["job"])
+                rules.append(f"{path}: named by the {aux['job']} job")
+                matched_rule = True
+
+        if len(parts) >= 2 and parts[0] == "tests":
+            group = parts[1]
+            if group in CAPABILITY_DIRS:
+                flag = CAPABILITY_DIRS[group]
+                capable = [leg["name"] for leg in lanes if leg.get(flag) == "ON"]
+                if capable:
+                    selected.update(capable)
+                    rules.append(
+                        f"{path}: tests/{group} needs {flag}=ON -- "
+                        f"{', '.join(sorted(capable))}")
+                    matched_rule = True
+            elif group in CORPUS_COVERED_ELSEWHERE:
+                job = CORPUS_COVERED_ELSEWHERE[group]
+                portable = lite.get("linux") or (lane_names[0] if lane_names else None)
+                if portable:
+                    selected.add(portable)
+                rules.append(
+                    f"{path}: tests/{group} is executed by the {job} job "
+                    f"(not matrix-gated); {portable} added for a real "
+                    "compiler build")
+                matched_rule = True
+            else:
+                generic_test_change = True
+                matched_rule = True
+
+        if not matched_rule:
+            # A tests-only file this script cannot place (a test script CI
+            # runs, most often). Treat it like a generic test change rather
+            # than assuming it is covered.
+            generic_test_change = True
+
+    if generic_test_change:
+        trio = [name for _, name in sorted(lite.items()) if name in by_name]
+        selected.update(trio)
+        rules.append(
+            "generic tests/ change: the first portable lane of each OS family "
+            f"-- {', '.join(sorted(trio))}")
+
+    if not selected:
+        selected.update(name for name in lite.values())
+        rules.append("no rule matched: falling back to the portable lane of "
+                     "each OS family")
+
+    active = [name for name in lane_names if name in selected]
+    skipped = [name for name in lane_names if name not in selected]
+    aux_active = [name for name in aux_names if name in selected_aux]
+    aux_skipped = [name for name in aux_names if name not in selected_aux]
+    return _result(impact, active, skipped, aux_active, aux_skipped, rules,
+                   workflow)
+
+
+# ───────────────────────────────── self-test ─────────────────────────────────
+
+def self_test() -> bool:
+    print("ci_lane_plan.py self-test:")
+    ok = True
+
+    try:
+        workflow = load_workflow()
+    except LanePlanError as exc:
+        print(f"  FAIL parse_real_ci_yml: {exc}")
+        print("  RESULT: FAIL")
+        return False
+
+    lane_names = [leg["name"] for leg in workflow["lanes"]]
+    print(f"  INFO parsed {len(lane_names)} lanes from {workflow['path']}: "
+          f"{', '.join(lane_names)}")
+
+    def check(name: str, condition: bool, detail: str = "") -> None:
+        nonlocal ok
+        if condition:
+            print(f"  PASS {name}")
+        else:
+            ok = False
+            print(f"  FAIL {name}{': ' + detail if detail else ''}")
+
+    # The parse must find real lanes, real stub names, and real aux jobs.
+    check("lanes_parsed", len(lane_names) >= 10,
+          f"only {len(lane_names)} lanes parsed")
+    check("lane_flags_parsed",
+          any(leg.get("gpu_enabled") == "ON" for leg in workflow["lanes"])
+          and any(leg.get("xla_enabled") == "ON" for leg in workflow["lanes"]),
+          "no lane declared gpu_enabled/xla_enabled -- the flag parse is broken")
+    check("stub_matrix_parsed", len(workflow["stub_names"]) >= 10,
+          f"stub matrix parsed as {workflow['stub_names']}")
+    check("aux_jobs_parsed", len(workflow["aux_jobs"]) >= 1,
+          "no hosted-macOS aux job found")
+
+    # Every stub name must be a real lane name: the stub job exists only to
+    # stand in for lanes, so a stub entry naming nothing is drift.
+    unknown_stubs = [n for n in workflow["stub_names"] if n not in lane_names]
+    check("stub_names_are_real_lanes", not unknown_stubs,
+          f"stub entries naming no lane: {unknown_stubs}")
+
+    lite = lite_lane_per_family(workflow["lanes"])
+    check("one_portable_lane_per_os_family",
+          {"linux", "macos", "windows"} <= set(lite),
+          f"resolved portable lanes: {lite}")
+
+    # ---- class behaviour ------------------------------------------------
+    for inert in INERT_CLASSES:
+        result = plan(inert, ["docs/README.md"], workflow)
+        check(f"inert_{inert}_activates_no_lane",
+              result["active"] == "" and not result["active_lanes"],
+              f"got {result['active']!r}")
+
+    full = plan("full", ["lib/backend/llvm_codegen.cpp"], workflow)
+    check("full_runs_every_lane",
+          full["active"] == ALL_LANES and not full["skipped_lanes"],
+          f"got {full['active']!r} with skipped={full['skipped_lanes']}")
+
+    unknown = plan("something-new", ["whatever"], workflow)
+    check("unknown_class_falls_back_to_every_lane",
+          unknown["active"] == ALL_LANES,
+          f"got {unknown['active']!r}")
+
+    gpu = plan(CLASS_TESTS_ONLY, ["tests/gpu/gpu_diagnostic_test.esk"], workflow)
+    gpu_lanes = [leg["name"] for leg in workflow["lanes"]
+                 if leg.get("gpu_enabled") == "ON"]
+    check("gpu_tests_select_exactly_the_gpu_lanes",
+          sorted(gpu["active_lanes"]) == sorted(gpu_lanes),
+          f"got {gpu['active_lanes']}, expected {gpu_lanes}")
+    check("gpu_tests_skip_the_portable_lanes",
+          all(name not in gpu["active_lanes"] for name in lite.values()),
+          f"got {gpu['active_lanes']}")
+
+    generic = plan(CLASS_TESTS_ONLY, ["tests/lists/append_test.esk"], workflow)
+    check("generic_tests_select_one_lane_per_os_family",
+          sorted(generic["active_lanes"]) == sorted(lite.values()),
+          f"got {generic['active_lanes']}, expected {sorted(lite.values())}")
+    check("generic_tests_skip_the_rest",
+          len(generic["skipped_lanes"]) == len(lane_names) - len(lite),
+          f"got {generic['skipped_lanes']}")
+
+    parity = plan(CLASS_TESTS_ONLY, ["tests/vm_parity/PARITY.tsv"], workflow)
+    check("vm_parity_selects_one_portable_lane",
+          parity["active_lanes"] == [lite["linux"]],
+          f"got {parity['active_lanes']}")
+
+    mixed = plan(CLASS_TESTS_ONLY,
+                 ["tests/gpu/gpu_diagnostic_test.esk",
+                  "tests/lists/append_test.esk"], workflow)
+    check("mixed_change_unions_both_rules",
+          set(gpu_lanes) <= set(mixed["active_lanes"])
+          and set(lite.values()) <= set(mixed["active_lanes"]),
+          f"got {mixed['active_lanes']}")
+
+    # A changed file a lane's test_command literally names must reach that
+    # lane even though it is not under tests/.
+    referenced = None
+    for leg in workflow["lanes"]:
+        command = leg.get("test_command", "")
+        found = re.search(r"(?:\./)?(scripts/[A-Za-z0-9_./-]+\.sh)", command)
+        if found:
+            referenced = (found.group(1), leg["name"])
+            break
+    if referenced is None:
+        check("direct_reference_activates_the_lane", False,
+              "no lane test_command names a scripts/*.sh file")
+    else:
+        script, lane = referenced
+        direct = plan(CLASS_TESTS_ONLY, [script], workflow)
+        check("direct_reference_activates_the_lane",
+              lane in direct["active_lanes"],
+              f"{script} did not activate {lane}: {direct['active_lanes']}")
+
+    # The whole point of step-gating rather than job-gating: on EVERY
+    # class, every lane the stub matrix stands in for is either active or
+    # still instantiated (and therefore still reports its own context).
+    for cls in KNOWN_CLASSES:
+        result = plan(cls, ["tests/lists/append_test.esk"], workflow)
+        if cls in INERT_CLASSES:
+            covered = set(workflow["stub_names"])
+        else:
+            covered = set(result["active_lanes"]) | set(result["skipped_lanes"])
+        missing = [n for n in workflow["stub_names"] if n not in covered]
+        check(f"required_contexts_reportable_for_{cls}", not missing,
+              f"unreportable: {missing}")
+
+    print("  RESULT:", "PASS" if ok else "FAIL")
+    return ok
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Decide which CI lanes a change actually needs.")
+    parser.add_argument("--impact", help="build-impact class from "
+                                         "scripts/ci_change_class.py")
+    parser.add_argument("--workflow", default=None,
+                        help="workflow file to derive lanes from "
+                             "(default: .github/workflows/ci.yml)")
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("files", nargs="*",
+                        help="changed files (default: read from stdin)")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return 0 if self_test() else 1
+
+    if not args.impact:
+        parser.error("--impact is required (or pass --self-test)")
+
+    files = list(args.files)
+    if not files and not sys.stdin.isatty():
+        files = [line.strip() for line in sys.stdin.read().splitlines()
+                 if line.strip()]
+
+    try:
+        workflow = load_workflow(Path(args.workflow) if args.workflow else None)
+    except LanePlanError as exc:
+        print(f"ci_lane_plan: {exc}", file=sys.stderr)
+        return 1
+
+    result = plan(args.impact, files, workflow)
+    json.dump(result, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    print(result["summary"], file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two mechanisms against the same waste: hosted CI runs spent re-verifying a
change whose verification already exists. macOS runner capacity is the
throughput bottleneck of the queue, so that is where the savings are counted.

## 1. Gate the matrix on the build-impact class

`changes` already computed an `impact` class (`docs` / `non-build` /
`tests-only` / `full`) from `scripts/ci_change_class.py`, and already collapsed
`docs` and `non-build` into `docs_only=true`. `tests-only` was informational:
a one-line edit to a single test still ran all 25 cross-platform lanes.

`scripts/ci_lane_plan.py` turns that class into a lane decision, publishing the
result as the `changes` job's `active_lanes` output. Every lane name, runner and
capability flag it reasons about is re-derived from `ci.yml`'s own matrix
definitions on each run, so there is no second lane list to keep in sync — the
same discipline `ci_change_class.py` applies to `CMakeLists.txt`.

The rules for `tests-only`:

- a changed file named verbatim in a lane's `test_command` activates that lane,
  so an edit to a test runner reaches exactly the lanes that run it;
- `tests/gpu/**` selects the `gpu_enabled` lanes; `tests/xla/**` the
  `xla_enabled` lanes;
- `tests/vm_parity/**` is executed by `pillars-fast`, which is not matrix-gated
  and runs regardless; one portable lane is added alongside it;
- anything else under `tests/` selects the first portable lane of each OS family
  — `linux-x64-lite`, `macos-arm64-lite`, `windows-arm64-lite` — each of which
  runs the whole suite on its platform;
- the two advisory hosted-macOS jobs (`quantum-macos`, `bench-smoke`) are planned
  the same way and skipped when the change cannot reach them.

`docs`, `non-build` and the new `equivalent` class run only the stub matrix,
exactly as `docs_only` already did. `full` is unchanged. The step summary always
prints the class, the changed files, and the lane decision.

### Lanes are gated per step, not per job

This is the load-bearing detail. A lane that is not selected still
**instantiates** as a matrix leg and still reports a check run under its own
name; only its build and test steps are skipped, via a `LANE_ACTIVE` job-level
`env`. Its first step always runs and states in the log and the run summary that
the lane was skipped and why.

Skipping the job instead would be a permanent merge block: a skipped matrix job
never instantiates its per-leg names — they collapse to one check run under the
unresolved `${{ matrix.name }}` string — so every required context that leg would
have reported is absent from the head SHA, which is precisely the failure
`docs-only-required-context-stubs` exists to work around. Gating steps keeps the
entire required-context set intact by construction, on every class, with no stub
list to extend.

`scripts/check_required_context_consistency.py` now enforces this rather than
trusting it:

- a MATRIX job gated at the job level on `needs.changes.outputs.impact` or
  `needs.changes.outputs.active_lanes` is held to the same stub-coverage
  requirement as a `docs_only`-gated one, with a red fixture that writes the lane
  gate the wrong way round and must fail;
- it grades every build-impact class in turn (`docs`, `non-build`, `tests-only`,
  `full`, `equivalent`) rather than only docs-only-versus-everything;
- it reads the classes `ci.yml` maps to `docs_only=true` out of the `changes`
  job's own shell and cross-checks them against the classes the lane plan treats
  as inert, so adding a class to one and not the other fails a build instead of
  blocking a merge.

## 2. Skip a head that is already verified

A rebase, a re-cut onto a fresh base, or a cherry-pick changes the head SHA
without changing the content, and every required context has to be produced
again. The maintainer can mark such a PR with a label:

```
ci-equivalent:<40-hex sha>
```

The `changes` job honours it only when **both** independent facts hold:

1. **Content** — `scripts/ci_equivalent_head.py` proves, in pure git, that the
   head is the same content as the referenced commit: equal trees (byte-identical
   checkouts), or equal `git diff <merge-base> <sha> | git patch-id --stable` for
   both commits. Nothing about GitHub is involved.
2. **Verification** — the API confirms the referenced SHA has a completed,
   successful run of this workflow. Equivalence to a commit that never passed is
   worth nothing.

Only then does `impact` become `equivalent`, which gates exactly like `docs`, and
the summary states `Equivalent to verified head <sha> (tree|patch identity);
matrix skipped`. If either fact fails, the run falls through to the computed class
with a warning in the summary — the label is a pointer, never a permission.
Labels are read live from the API rather than from the event payload, so labelling
plus a re-run works (a re-run replays the original payload). A push after
labelling re-evaluates naturally: the head SHA changes, equivalence is recomputed,
and a real edit stops matching.

The label is set only by the maintainer, and only for a rebase or re-cut whose
content is unchanged.

## How this was verified

Behaviour, not intent:

- `python3 scripts/ci_change_class.py --self-test` — PASS (unchanged).
- `python3 scripts/ci_lane_plan.py --self-test` — PASS. 23 assertions against the
  real, committed `ci.yml`: 15 lanes parsed with their flags; the stub matrix
  names are all real lanes; one portable lane resolves per OS family; each inert
  class activates no lane; `full` and any unrecognised class activate every lane;
  `tests/gpu` selects exactly the GPU lanes and none of the portable ones; a
  generic test change selects exactly the three portable lanes; `tests/vm_parity`
  selects one; a mixed change unions both rules; a directly referenced runner
  script activates its lane; and, for every class, every stub-covered name is
  either active or still instantiated.
- `python3 scripts/ci_equivalent_head.py --self-test` — PASS. Builds throwaway git
  repositories under `.scratch/` (never a system temp directory) and proves tree
  identity across distinct commits, patch identity after a rebase onto a newer
  base, a genuinely different change as negative, an unresolvable reference as
  negative, and that the rebase fixture really does have a different tree so the
  patch case is not silently re-proving the tree path.
- `python3 scripts/check_required_context_consistency.py --self-test` — PASS,
  including the two new fixtures and a live check that all 17 intended required
  contexts are reportable on each of the five impact classes.
- `python3 scripts/check_required_context_consistency.py --offline --no-trace` —
  PASS, 17 graded contexts, per-class table printed.
- `python3 scripts/check_ci_cost_policy.py` — PASS (trigger policy unchanged).
- The other assurance-gate self-tests (`gate_no_silent_wrong`,
  `check_ledger_integrity`, `check_oracle_schema`, `check_oracle_bindings`,
  `audit_oracle_false_green`, `check_evidence_staleness`, `check_package_manifest`,
  `check_surface_counts`, `check_self_verdicts`) — all PASS.
- `actionlint .github/workflows/*.yml` — no workflow-syntax or expression errors;
  the shellcheck-info set is byte-identical to the same run against `origin/master`
  (no new findings from the added shell), and `python3 -c "import yaml; ..."` parses
  the workflow.
- Every `if:` touched was re-read in the diff: 21 existing conditions were wrapped
  as `env.LANE_ACTIVE == 'true' && (<original>)` — parenthesised so an `||`
  condition cannot change meaning, and the status functions (`always()`,
  `failure() || cancelled()`) are preserved inside the expression so the implicit
  `success()` still does not apply — and 12 steps that had no condition gained one.
- End-to-end: the `changes` step's shell was extracted and executed against a
  stub API over six scenarios. Label on a verified equivalent head →
  `impact=equivalent, docs_only=true, active_lanes=`; label with no successful run
  → falls through with a warning; label naming a different commit → falls through
  with a warning; a generic test change → `|linux-x64-lite|macos-arm64-lite|
  windows-arm64-lite|`; a `tests/gpu` change → the three CUDA lanes; a compiler
  source change → `ALL`.

Both new scripts are wired into `assurance-gates` and registered as ctest entries
(`ci_lane_plan_selftest`, `ci_equivalent_head_selftest`). Documented in
`docs/TESTING.md`.

## Required-context risk

The intended required-context set is unchanged and every path still emits all of
it. The one residual risk is the standing one this repo already carries: the
`docs`/`non-build`/`equivalent` path still depends on
`docs-only-required-context-stubs`' hand-maintained name list, which is now
cross-checked against the real lane list by `ci_lane_plan.py --self-test` (every
stub entry must name a real lane) but is still a list a person edits. The
`tests-only` path does not depend on it at all, by design.
