### PR TITLE
ci(quantum): the coverage gate sees the srand48 execution trace deterministically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -973,6 +973,37 @@ jobs:
           mkdir -p "$ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR"
           ./scripts/run_all_tests.sh
 
+      # run_all_tests.sh's suite list does not include the ctest-registered
+      # tests/rng/seed_parity_test.sh (rng_seed_parity_cross_engine in
+      # CMakeLists.txt), which is ctest-only and this job never runs ctest.
+      # scripts/run_language_coverage.sh closes exactly this gap for callers
+      # that let it self-generate fresh evidence (its own "Fresh RNG
+      # cross-engine execution evidence" section) — but that path is
+      # conditioned on the caller NOT pre-supplying runtime trace
+      # directories, and the step below does exactly that
+      # (LANGUAGE_COVERAGE_RUNTIME_TRACE_DIRS), so it never fires here. The
+      # net effect was that srand48 had no execution evidence on this lane at
+      # all: tests/v1_2_edge_cases/prng_seeding_test.esk (run above, inside
+      # run_v1_2_edge_cases_tests.sh) only reaches srand48 indirectly through
+      # the stdlib's set-random-seed! wrapper, and that indirect call earns
+      # set-random-seed! its own coverage credit but — verified locally by
+      # diffing language_coverage.py's covered_names with and without this
+      # step — never credits srand48 itself. Run the cross-engine RNG driver
+      # directly, into the same core trace directory, so this lane produces
+      # the same real evidence release.yml's (unconditioned) coverage run
+      # already does.
+      - name: Run RNG cross-engine execution evidence
+        shell: bash
+        env:
+          ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR: ${{ runner.temp }}/eshkol-language-coverage/core
+        run: |
+          set -euxo pipefail
+          mkdir -p "$ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR"
+          bash tests/rng/seed_parity_test.sh \
+            "$PWD/build-quantum/eshkol-run" \
+            "$PWD/build-quantum/eshkol-vm-standalone-test" \
+            "$PWD"
+
       # The build-free half of this gate (policy floor / deficit ratchet /
       # "can the gate actually go red" self-test) now also runs, unconditional
       # and required, in the surface-manifest job. What stays here is the part


### PR DESCRIPTION
## Summary

- The quantum-macos advisory lane's language-coverage gate step pre-supplies its runtime trace directories to `scripts/run_language_coverage.sh`, which short-circuits the script's own fresh-evidence branch — the only place that runs the RNG cross-engine driver (`tests/rng/seed_parity_test.sh`, ctest's `rng_seed_parity_cross_engine`) that produces execution evidence for `srand48`/`random`/`set-random-seed!`. `run_all_tests.sh`'s suite list never wires that driver in either, so this lane never produced its own trace for `srand48`.
- `tests/v1_2_edge_cases/prng_seeding_test.esk` exercises `srand48` only indirectly, through the stdlib's `set-random-seed!` wrapper; that credits `set-random-seed!` but, confirmed by a local repro diffing `language_coverage.py`'s `covered_names` with and without the RNG driver's trace, never credits `srand48` itself. Once `srand48` joined the required 1110/1110 baseline, this lane's policy-floor and deficit-ratchet checks failed deterministically.
- Fix: run the RNG cross-engine driver directly against the quantum build, into the same core trace directory the rest of this lane's evidence already lands in — mirroring both the ctest registration and `run_language_coverage.sh`'s own fresh-evidence path.

## Test plan

- [x] `python3 scripts/test_language_coverage_gate.py -v` — 17/17 pass
- [x] Built `build-quantum` locally (Release, `-DESHKOL_QUANTUM_ENABLED=ON -DESHKOL_BUILD_TESTS=ON`) and ran the full core corpus (`scripts/run_all_tests.sh`), the quantum probe corpus (`tests/quantum/*.esk`), and the new RNG cross-engine step, feeding the same trace directories the CI job uses
- [x] Ran the exact coverage-gate command `ci.yml` invokes three times against that evidence: all three report `1110/1110 (100.0%)`, `0 deficit`, identical runtime-event counts
- [x] Confirmed the root cause directly: `srand48` is absent from `covered_names` with only `prng_seeding_test.esk`'s evidence, present once the RNG cross-engine driver's trace is added