### PR TITLE
feat(repl): EREPL machine-mode protocol v1 with a reference driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **EREPL v1: a versioned, machine-consumable protocol for `eshkol-repl
+  --machine`.** The warm-worker mode's original bare `EREPL READY` /
+  `EREPL DONE` / `EREPL FAIL` framing stays exactly as it was (nothing that
+  watched only those lines breaks), but a `--machine` session now also
+  accepts JSON requests on stdin (`eval`, `complete`, `is_complete`,
+  `reset`, `shutdown`) and answers with `EREPL/1 {...}` JSON response lines
+  on stderr, so a driver can evaluate code, get identifier completions,
+  check whether an input form is complete, and interrupt a runaway
+  evaluation (`SIGINT`/`CTRL_BREAK_EVENT`, aborting cleanly with
+  `error.kind: "interrupted"` and leaving the session usable) without a
+  PTY, without regexing prompts, and without classifying errors by
+  matching this project's error-message wording — every failure carries a
+  structured `error.kind` from a small, closed, stable set instead. An
+  `eval` response reports the form's own value separately from whatever it
+  printed to stdout (embedded directly in the response frame rather than
+  left for a driver to race against the response frame across two
+  independent OS pipes), resolving the original protocol's core ambiguity
+  between a form's auto-echoed result and its own explicit output. See the
+  "Machine mode (EREPL protocol)" section of
+  `docs/reference/runtime/eshkol-repl.md` for the full contract and its
+  compatibility promise, and the new `tools/erepl_client.py` — a
+  stdlib-only Python reference driver with a `--self-test` covering every
+  request type, an interrupted infinite loop, and a structured runtime
+  error, wired into both CTest (`erepl_v1_protocol_self_test`) and
+  `scripts/run_all_tests.sh`.
+
 - **Navier-Stokes blowup mechanization trajectory.** Added
   `docs/design/NAVIER_STOKES_BLOWUP_MECHANIZATION.md`, a step-by-step map from
   the 2026 OpenAI finite-time Navier-Stokes blowup construction to Eshkol

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6567,6 +6567,29 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run AND EXISTS "${CMAKE_CURRENT_SOURCE_D
         PASS_REGULAR_EXPRESSION "PASS: repl stdlib/math shadow")
 endif()
 
+# EREPL v1 machine-mode protocol self-test, run through the reference
+# Python driver (tools/erepl_client.py --self-test). This is the versioned
+# JSON request/response contract on top of eshkol-repl --machine
+# (docs/reference/runtime/eshkol-repl.md, "Machine mode (EREPL protocol)"),
+# distinct from the legacy bare-form framing repl_machine_mode_protocol_test
+# (tests/v1_2_edge_cases/, run via scripts/run_v1_2_edge_cases_tests.sh
+# rather than ctest) checks. --binary points the driver at THIS build's
+# eshkol-repl directly via a generator expression, matching the
+# ESHKOL_PYTHON_MODULE_DIR pattern used for python_bindings_capsule_lifetime
+# above rather than guessing a relative build directory.
+if(ESHKOL_BUILD_TESTS AND TARGET eshkol-repl AND ESHKOL_PYTHON3_EXECUTABLE AND
+   EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tools/erepl_client.py")
+    add_test(NAME erepl_v1_protocol_self_test
+             COMMAND "${ESHKOL_PYTHON3_EXECUTABLE}"
+                     "${CMAKE_CURRENT_SOURCE_DIR}/tools/erepl_client.py"
+                     --self-test
+                     --binary "$<TARGET_FILE:eshkol-repl>")
+    set_tests_properties(erepl_v1_protocol_self_test PROPERTIES
+        TIMEOUT 300
+        PASS_REGULAR_EXPRESSION "PASS: EREPL v1 self-test"
+        FAIL_REGULAR_EXPRESSION "^FAIL:")
+endif()
+
 if(ESHKOL_BUILD_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/toolchain/windows_suite_surface_test.cpp")
     add_executable(windows_suite_surface_test tests/toolchain/windows_suite_surface_test.cpp)
     target_compile_features(windows_suite_surface_test PRIVATE cxx_std_17)

--- a/docs/reference/runtime/eshkol-repl.md
+++ b/docs/reference/runtime/eshkol-repl.md
@@ -23,41 +23,338 @@ evaluated, and results printed. See `repl_utils.h` for the built-in help topics
 
 `--machine` turns the REPL into a warm worker: it loads the stdlib and JIT once,
 then evaluates forms sent on stdin without ever paying the cold-start cost again.
-Framing sentinels go to **stderr** so the program's own output on **stdout**
-stays clean.
+Framing goes to **stderr** so the program's own output on **stdout** stays
+clean. As of protocol version 1 ("EREPL v1"), a `--machine` session also
+accepts a versioned JSON request/response protocol on top of that framing,
+so a driver — a Jupyter-style kernel, a language-server backend, a sister
+project's test harness — can talk to `eshkol-repl` without a PTY, without
+regexing prompts, and without classifying errors by matching this project's
+error-message wording. `tools/erepl_client.py` is a complete, stdlib-only
+Python reference implementation of everything in this section; treat it as
+the executable form of this contract, and keep the two in sync.
 
-### Protocol
+### Backward compatibility
 
-1. Spawn `eshkol-repl --machine`.
-2. Read **stderr** until `EREPL READY` — the JIT and stdlib are warm. This is
-   emitted exactly **once** after initialization.
-3. Send one top-level form on **stdin** (newline-terminated, balanced parens).
-4. Read the form's output on **stdout** until you see `EREPL DONE` (success) or
-   `EREPL FAIL` (error) on **stderr**. One of these is emitted **once per
-   top-level form**.
-5. Repeat step 3-4 for each subsequent form.
+The original bare-line framing is unchanged and always emitted, whether or
+not a session ever sends a JSON request:
 
-Each sentinel ends with `\n` and an explicit flush. `EREPL FAIL` is emitted when
-a form raises or fails to parse; the `DONE`/`FAIL` sentinel is written *after*
-cleanup so any exception text has already flushed to stdout.
+- `EREPL READY` — once, after the JIT and stdlib have warmed up.
+- `EREPL DONE` / `EREPL FAIL` — once per evaluated top-level form (bare
+  legacy input *or* a `"op":"eval"` JSON request), before that form's
+  structured response frame (see below).
 
-### Example session (conceptual)
+A client that only ever watches those three lines and reads stdout between
+them keeps working exactly as before. EREPL v1 is additive: everything
+below is new frames and a new stdin input shape, layered on top of the
+original protocol rather than replacing it.
+
+### Frame grammar
+
+Two kinds of line appear on **stdin** (requests) and **stderr** (framing +
+responses); **stdout** carries only bytes an evaluated program itself wrote
+via `display`/`write`/`print`/etc. — never protocol framing, and, for a
+JSON `"op":"eval"` request, never an implicit echo of the form's own return
+value either (see `value` under eval, below). This is the one property the
+whole protocol exists to guarantee: a driver never has to guess which
+stdout bytes are "the answer" and which are the program's own output,
+because the answer is never on stdout at all — it is always the response
+frame's `value` field.
+
+- **Legacy bare form** (stdin): a Scheme form, newline-terminated with
+  balanced parens (multi-line input accumulates exactly as it does
+  interactively). Evaluated with the original auto-display behavior: a
+  non-definition form's result is printed to stdout via an implicit
+  `display`, indistinguishable there from anything the form printed itself.
+  Kept only for compatibility with the original, pre-v1 protocol; new
+  clients should use the JSON `"op":"eval"` request instead, which reports
+  the value separately from stdout and gives it a structured type.
+- **EREPL v1 JSON request** (stdin): one line whose first non-whitespace
+  character is `{`. No Eshkol source form can start with `{`, so this can
+  never collide with a legacy bare form. A request is exactly one JSON
+  object with string-valued fields (`{"id": "...", "op": "...", ...}`); it
+  is always exactly one stdin line — embedded newlines in a `code` field
+  travel JSON-escaped, not raw, and the request is dispatched as soon as
+  the line is read (it does not go through the legacy multi-line
+  accumulator).
+- **EREPL v1 response frame** (stderr): one line, `EREPL/1 ` followed by a
+  single-line JSON object, `\n`-terminated with an explicit flush — as with
+  every stderr line in this protocol. Every response frame that answers a
+  request whose JSON carried an `"id"` echoes that id back verbatim in its
+  own `"id"` field; a request with no `"id"` (or an empty one) gets `"id":
+  null` back. This is what lets a driver pair requests with responses on a
+  single stderr stream even when, in principle, more than one is ever
+  in flight (v1 itself is a strict one-at-a-time request/response cycle —
+  see "Concurrency", below — but the id is there so a driver never has to
+  assume that stays true forever).
+
+### `ready` — protocol handshake
+
+Emitted once, immediately after `EREPL READY`, before the session reads its
+first line of input:
+
+```json
+{"type":"ready","protocol_version":1,"pid":12345,"eshkol_version":"1.3.5-evolve"}
+```
+
+- `protocol_version` (integer) — the EREPL protocol version this build
+  speaks. A driver should refuse to proceed with the JSON protocol (falling
+  back to the legacy bare-form protocol, or failing outright) if this is
+  not a version it understands.
+- `pid` (integer) — the child process's own process id, for `interrupt()`
+  (see below) and for a driver's own process bookkeeping. Never assume this
+  equals the pid the driver's own spawn call returned; on some platforms —
+  and always if the driver has gone through a shell — they can differ.
+- `eshkol_version` (string) — `eshkol --version`'s version string, for
+  diagnostics; not part of the compatibility contract (see below).
+
+### `"op":"eval"` — evaluate one top-level form
+
+Request:
+
+```json
+{"id":"1","op":"eval","code":"(+ 1 2)"}
+```
+
+`code` must parse as exactly one top-level Eshkol form. Evaluation does
+**not** auto-display a result to stdout the way the legacy bare-form
+protocol does: stdout receives only what the form's own code explicitly
+writes, and the form's own value is reported separately, in `write` form
+(quoted strings, `#t`/`#f`, etc. — never `display` form, which is
+ambiguous for strings vs. symbols).
+
+Before the response frame, the legacy `EREPL DONE` / `EREPL FAIL` bare line
+is still emitted (see "Backward compatibility"), so a driver watching only
+the old sentinel still sees a form complete.
+
+Success response:
+
+```json
+{"type":"result","id":"1","ok":true,"stdout":"","value":"3","value_type":"integer"}
+```
+
+- `stdout` (string) — exactly the bytes this evaluation wrote to stdout,
+  embedded directly in the frame rather than left for the driver to read
+  off the raw stdout pipe. This is deliberate, not a convenience: stdout
+  and stderr are two independent OS pipes, and nothing guarantees a reader
+  observes "the stdout bytes are available" and "the stderr response frame
+  is available" in the order this process produced them, even though it
+  always finishes writing an evaluation's stdout before flushing that
+  evaluation's response frame. Relying on frame order removes the race
+  instead of asking every driver, on every platform, to get a two-pipe race
+  right. (The same bytes are also replayed to the real stdout pipe once
+  capture ends, so a plain pipe-tailing consumer — a human, a log —
+  still sees them; just after the form finishes rather than incrementally
+  while it runs.)
+- `value` / `value_type` — the form's own value, and its coarse runtime
+  type name (`integer`, `real`, `boolean`, `string`, `pair`, `symbol`,
+  `procedure`, `vector`, `null` for an unspecified/no-value result, etc. —
+  the same classification the language exposes as `type-of`). A definition
+  form (`define`, ...) evaluates to an unspecified value, reported as
+  `value_type: "null"`.
+
+Failure response:
+
+```json
+{"type":"result","id":"2","ok":false,"stdout":"","error":{
+  "kind":"type-error",
+  "message":"car: argument is not a pair",
+  "line":null,
+  "column":null,
+  "filename":null,
+  "printed":"type-error: car: argument is not a pair",
+  "irritants":[]
+}}
+```
+
+`error.kind` is a member of a small, closed, stable set — this is the field
+a driver should classify on, never `error.message`, which is prose and can
+change wording across releases without notice:
+
+| kind | meaning |
+| --- | --- |
+| `error` | generic R7RS `error`/condition |
+| `type-error` | type mismatch |
+| `file-error` | file operation failed |
+| `read-error` | read/parse error raised by running code (e.g. `read`) |
+| `syntax-error` | syntax error raised by running code |
+| `range-error` | index/value out of range |
+| `arity-error` | wrong number of arguments |
+| `divide-by-zero` | division by zero |
+| `user-exception` | a user-defined condition type (`raise`/`error` with a custom type) |
+| `parse-error` | `code` itself failed to parse as one top-level form (never reached evaluation) |
+| `interrupted` | the evaluation was aborted by `interrupt()` — see below |
+| `crash` | a native crash (segfault, floating-point exception, ...) during evaluation, recovered the same way the interactive REPL recovers from one |
+| `internal-error` | an unexpected internal (C++-level) failure outside normal Eshkol condition handling |
+
+`error.line` / `error.column` / `error.filename` are `null` when the
+underlying condition carries no source location (most runtime errors, all
+of `parse-error`/`interrupted`/`crash`/`internal-error`); `error.printed`
+is the same human-readable one-line summary the interactive REPL would
+print, for logging; `error.irritants` is the condition's R7RS irritants
+(additional data attached via `error`/`raise`), each in `write` form —
+empty for conditions that carry none.
+
+### `"op":"complete"` — identifier completion
+
+```json
+{"id":"3","op":"complete","prefix":"str-"}
+```
+```json
+{"type":"completion","id":"3","matches":["string-append","string-length",...]}
+```
+
+`matches` is every builtin and session-defined identifier starting with
+`prefix`, sorted and deduplicated — the same candidate set interactive tab
+completion draws from.
+
+### `"op":"is_complete"` — does this text form a complete expression?
+
+```json
+{"id":"4","op":"is_complete","code":"(display 1"}
+```
+```json
+{"type":"is_complete","id":"4","status":"incomplete"}
+```
+
+`status` is one of `"complete"`, `"incomplete"` (more input needed — e.g. an
+editor should keep accepting lines rather than submit), or `"invalid"` (an
+unmatched closing paren; no amount of further input fixes it). This uses
+exactly the same paren/string/comment scan the interactive multi-line
+editor uses to decide when to submit, so it can never drift from what
+submitting the same text interactively would actually do.
+
+### `"op":"reset"` — clear session bookkeeping
+
+```json
+{"id":"5","op":"reset"}
+```
+```json
+{"type":"reset","id":"5","ok":true}
+```
+
+Clears this session's tracked-definitions list (used for completion and
+duplicate-definition detection). Per-session JIT symbols are **not**
+undone — the same caveat the interactive `:reset` command documents; there
+is no way to unload a JIT-compiled definition.
+
+### `"op":"shutdown"` — end the session cleanly
+
+```json
+{"id":"6","op":"shutdown"}
+```
+```json
+{"type":"shutdown","id":"6","ok":true}
+```
+
+The response frame is flushed, and the process then exits through the same
+ordered teardown as `:quit` / EOF (joins JIT worker threads, runs runtime
+shutdown hooks) rather than a bare `exit()`. Prefer this over closing stdin
+or killing the process: it avoids a spurious abort on some platforms if
+JIT worker threads are still holding runtime locks.
+
+### Interrupting a running evaluation
+
+There is deliberately no `"op":"interrupt"` request: while a form is
+evaluating, the session's stdin reader is blocked inside that evaluation
+and cannot see a new request frame arrive. Interrupt is instead delivered
+out-of-band, as a signal — `SIGINT` on POSIX, `CTRL_BREAK_EVENT` (via
+`GenerateConsoleCtrlEvent`) on Windows, sent to the child's `pid` (from the
+`ready` frame). This aborts the in-flight evaluation and returns its
+`"op":"eval"` response with `error.kind: "interrupted"`; the session
+remains fully usable for the next request. Sending it while the session is
+idle (no evaluation in flight) is a no-op with no response owed, matching
+the semantics a Jupyter-style kernel's own interrupt already has.
+
+### Malformed requests and unrecognized operations
+
+A stdin line that starts with `{` but is not valid EREPL v1 JSON, or whose
+`"op"` is not one of the operations above, never reaches evaluation at all.
+It gets a distinct frame type instead of `"result"`, so a driver never has
+to infer "nothing was evaluated" from context:
+
+```json
+{"type":"error","id":null,"error":{"kind":"protocol-error","message":"unknown op: bogus", ...}}
+```
+
+### Concurrency
+
+EREPL v1 is a strict request/response cycle: send one request, wait for its
+response, then send the next. There is no request pipelining, and (aside
+from `interrupt()`, which is out-of-band by design — see above) no way to
+cancel or overlap two in-flight requests. A driver that wants concurrent
+evaluation should run multiple `eshkol-repl --machine` child processes
+rather than multiplex one.
+
+### Compatibility promise
+
+- Within protocol version 1, fields are **never removed or repurposed**
+  from a response frame's JSON shape once shipped; new fields may be
+  added, and existing clients must ignore fields they don't recognize.
+  `error.kind`'s enumerated set gains new members only — an existing value
+  keeps its exact meaning.
+- A breaking change (removing/repurposing a field, changing a request's
+  required shape, changing `error.kind`'s meaning for an existing value)
+  requires a new protocol version, announced as a new `protocol_version` in
+  the `ready` frame and a new frame prefix (`EREPL/2 ` alongside, not
+  instead of, `EREPL/1 ` for as long as v1 clients are expected to keep
+  working) — mirroring how this version was introduced additively on top of
+  the original bare-line framing rather than replacing it.
+- `eshkol_version` is diagnostic only and never part of this contract;
+  don't branch on it.
+
+### Example transcripts
+
+Success:
 
 ```
 spawn:   eshkol-repl --machine
 stderr:  EREPL READY
-stdin:   (display (* 6 7))(newline)
+stderr:  EREPL/1 {"type":"ready","protocol_version":1,"pid":12345,"eshkol_version":"1.3.5-evolve"}
+stdin:   {"id":"1","op":"eval","code":"(display (* 6 7))"}
 stdout:  42
 stderr:  EREPL DONE
-stdin:   (car '())
-stdout:  <error text>
+stderr:  EREPL/1 {"type":"result","id":"1","ok":true,"stdout":"42","value":"()","value_type":"null"}
+```
+
+Runtime error:
+
+```
+stdin:   {"id":"2","op":"eval","code":"(car (quote ()))"}
 stderr:  EREPL FAIL
+stderr:  EREPL/1 {"type":"result","id":"2","ok":false,"stdout":"","error":{"kind":"type-error","message":"car: argument is not a pair","line":null,"column":null,"filename":null,"printed":"type-error: car: argument is not a pair","irritants":[]}}
+```
+
+Interrupt (a runaway evaluation, aborted mid-flight, session still usable
+afterward):
+
+```
+stdin:      {"id":"3","op":"eval","code":"(let loop () (loop))"}
+  (out-of-band: driver sends SIGINT to the child's pid)
+stderr:     EREPL FAIL
+stderr:     EREPL/1 {"type":"result","id":"3","ok":false,"stdout":"","error":{"kind":"interrupted","message":"evaluation interrupted","line":null,"column":null,"filename":null,"printed":"evaluation interrupted","irritants":[]}}
+stdin:      {"id":"4","op":"eval","code":"(+ 40 2)"}
+stderr:     EREPL DONE
+stderr:     EREPL/1 {"type":"result","id":"4","ok":true,"stdout":"","value":"42","value_type":"integer"}
 ```
 
 This is the mechanism that answers the JIT cold-start cost for embedding
 projects: cold `eshkol-run -r` re-pays JIT setup each invocation, whereas a
 persistent `eshkol-repl --machine` worker has a marginal per-form cost of
-roughly zero.
+roughly zero — and, as of EREPL v1, a driver can consume that worker
+directly, on any platform pipes work on, without a PTY.
+
+### Reference client
+
+`tools/erepl_client.py` is a stdlib-only Python reference driver
+(`EReplClient`: `execute`, `interrupt`, `complete`, `is_complete`,
+`reset`, `shutdown`) implementing everything on this page, plus a
+`--self-test` that spawns a built `eshkol-repl` and exercises every request
+type, including an interrupted infinite loop and a structured runtime
+error:
+
+```sh
+python3 tools/erepl_client.py --self-test --binary build/eshkol-repl
+```
 
 ## Related
 

--- a/exe/eshkol-repl.cpp
+++ b/exe/eshkol-repl.cpp
@@ -13,17 +13,40 @@
 #include "../lib/repl/repl_jit.h"
 #include "../lib/repl/repl_utils.h"
 
+#include <eshkol/core/introspection.h>
+
 #include <iostream>
 #include <fstream>
 #include <sstream>
 #include <string>
 #include <vector>
+#include <unordered_map>
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <cstdio>
+#include <cctype>
 #include <csignal>
 #include <chrono>
 #include <iomanip>
 #include <setjmp.h>
+
+#ifdef _WIN32
+#include <process.h>
+#include <io.h>
+#define ESHKOL_GETPID() _getpid()
+#define ESHKOL_FILENO(f) _fileno(f)
+#define ESHKOL_DUP(fd) _dup(fd)
+#define ESHKOL_DUP2(oldfd, newfd) _dup2(oldfd, newfd)
+#define ESHKOL_CLOSE_FD(fd) _close(fd)
+#else
+#include <unistd.h>
+#define ESHKOL_GETPID() getpid()
+#define ESHKOL_FILENO(f) fileno(f)
+#define ESHKOL_DUP(fd) dup(fd)
+#define ESHKOL_DUP2(oldfd, newfd) dup2(oldfd, newfd)
+#define ESHKOL_CLOSE_FD(fd) close(fd)
+#endif
 
 using namespace eshkol::repl;
 
@@ -84,9 +107,23 @@ volatile sig_atomic_t g_interrupted = 0;
 static std::string g_last_loaded_file;
 static std::vector<std::string> g_defined_symbols;
 
-// Signal handler for Ctrl+C
+// Signal handler for Ctrl+C.
+//
+// Outside a JIT-executing form this is the original behavior: set a flag the
+// read loop notices between lines. While a form IS executing (g_in_jit, the
+// same flag crash_handler below already uses), Ctrl+C -- or, in --machine
+// mode, an EREPL client sending SIGINT to abort a hung evaluation -- instead
+// aborts the evaluation right away via the same longjmp path crash_handler
+// uses, so a runaway `(let loop () (loop))` can be interrupted without
+// killing the process. g_crash_signal is left as SIGINT so both the legacy
+// crash-recovery message and the machine-mode structured error can tell an
+// interrupt apart from an actual crash.
 void sigint_handler(int sig) {
     (void)sig;
+    if (g_in_jit) {
+        g_crash_signal = SIGINT;
+        ESHKOL_SIGLONGJMP(g_crash_jmp_buf, 1);
+    }
     g_interrupted = 1;
 }
 
@@ -134,26 +171,36 @@ const char* crash_signal_message(int sig) {
 #ifdef SIGBUS
         case SIGBUS:  return "Bus error - memory access issue";
 #endif
+        case SIGINT:  return "Evaluation interrupted";
         default:      return "Unknown runtime error";
     }
+}
+
+// Stable, wording-independent name for an exception's category. Shared by
+// the human-readable display_exception() below and the machine-mode
+// structured error payload (EREPL_JSON_HELPERS), so both agree on the exact
+// same closed set of `kind` strings -- classification never depends on the
+// prose in `message`.
+static const char* exception_type_name(eshkol_exception_type_t type) {
+    switch (type) {
+        case ESHKOL_EXCEPTION_ERROR: return "error";
+        case ESHKOL_EXCEPTION_TYPE_ERROR: return "type-error";
+        case ESHKOL_EXCEPTION_FILE_ERROR: return "file-error";
+        case ESHKOL_EXCEPTION_READ_ERROR: return "read-error";
+        case ESHKOL_EXCEPTION_SYNTAX_ERROR: return "syntax-error";
+        case ESHKOL_EXCEPTION_RANGE_ERROR: return "range-error";
+        case ESHKOL_EXCEPTION_ARITY_ERROR: return "arity-error";
+        case ESHKOL_EXCEPTION_DIVIDE_BY_ZERO: return "divide-by-zero";
+        case ESHKOL_EXCEPTION_USER_DEFINED: return "user-exception";
+    }
+    return "error";
 }
 
 // Display an exception with nice formatting
 void display_exception(eshkol_exception_t* exc) {
     using namespace color;
 
-    const char* type_name = "error";
-    switch (exc->type) {
-        case ESHKOL_EXCEPTION_ERROR: type_name = "error"; break;
-        case ESHKOL_EXCEPTION_TYPE_ERROR: type_name = "type-error"; break;
-        case ESHKOL_EXCEPTION_FILE_ERROR: type_name = "file-error"; break;
-        case ESHKOL_EXCEPTION_READ_ERROR: type_name = "read-error"; break;
-        case ESHKOL_EXCEPTION_SYNTAX_ERROR: type_name = "syntax-error"; break;
-        case ESHKOL_EXCEPTION_RANGE_ERROR: type_name = "range-error"; break;
-        case ESHKOL_EXCEPTION_ARITY_ERROR: type_name = "arity-error"; break;
-        case ESHKOL_EXCEPTION_DIVIDE_BY_ZERO: type_name = "divide-by-zero"; break;
-        case ESHKOL_EXCEPTION_USER_DEFINED: type_name = "user-exception"; break;
-    }
+    const char* type_name = exception_type_name(exc->type);
 
     std::cerr << error() << type_name << reset() << ": ";
     if (exc->message) {
@@ -760,19 +807,598 @@ bool handle_command(const std::string& input, eshkol::ReplJITContext& repl_ctx) 
     return false;
 }
 
-// --machine mode framing markers (Noesis warm-worker support, 2026-05-07).
+// --machine mode framing markers (Noesis warm-worker support, 2026-05-07;
+// versioned as EREPL protocol v1, 2026-09-10 -- see the block just below
+// and docs/reference/runtime/eshkol-repl.md for the full contract).
 // Sentinels go to STDERR so user program output on stdout stays clean.
 // Clients drive eshkol-repl as a long-running JIT-warm worker:
 //   1. Spawn `eshkol-repl --machine`
-//   2. Read stderr until "EREPL READY" — JIT + stdlib are warm
-//   3. Send a form on stdin (terminated by newline + balanced parens)
-//   4. Read stdout until you see "EREPL DONE" / "EREPL FAIL" on stderr
-//   5. Repeat for each new form, never paying the cold-start cost again
-// EREPL_READY emits exactly once after init; EREPL_DONE / EREPL_FAIL
-// emits once per top-level form. Both end with \n and an explicit fflush.
+//   2. Read stderr until "EREPL READY" — JIT + stdlib are warm. v1 clients
+//      then read one more stderr line, `EREPL/1 {"type":"ready",...}`,
+//      which announces protocol_version/pid/eshkol_version.
+//   3a. Legacy: send a bare form on stdin (newline + balanced parens).
+//       Read stdout until "EREPL DONE" / "EREPL FAIL" appears on stderr.
+//   3b. v1: send one JSON line on stdin, e.g.
+//       {"id":"1","op":"eval","code":"(+ 1 2)"}. Read stdout for whatever
+//       the form itself wrote, and stderr for the matching
+//       `EREPL/1 {"type":"result","id":"1",...}` frame (preceded, for
+//       op=eval, by the same bare DONE/FAIL line legacy clients watch).
+//   4. Repeat for each new form/request, never paying the cold-start cost
+//      again. op=shutdown ends the session cleanly.
+// EREPL_READY emits exactly once after init; EREPL_DONE / EREPL_FAIL emits
+// once per evaluated form (legacy or op=eval). Both end with \n and an
+// explicit fflush, as does every EREPL/1 frame.
 static constexpr const char* EREPL_READY = "EREPL READY\n";
 static constexpr const char* EREPL_DONE  = "EREPL DONE\n";
 static constexpr const char* EREPL_FAIL  = "EREPL FAIL\n";
+
+// =============================================================================
+// EREPL v1 -- machine-mode JSON request/response protocol.
+//
+// See docs/reference/runtime/eshkol-repl.md ("Machine mode (EREPL protocol)")
+// for the full contract. Summary: a --machine session still emits the
+// original bare `EREPL READY` / `EREPL DONE` / `EREPL FAIL` lines on stderr
+// unchanged (nothing that watched only those breaks), but now additionally
+// accepts JSON request lines on stdin (any line whose first non-whitespace
+// character is '{' -- no Eshkol source form starts with '{', so this can
+// never collide with a bare Scheme form) and answers with one JSON line per
+// response, tagged `EREPL/1 ` on stderr. stdout carries only bytes the
+// evaluated program itself wrote (explicit display/write/print calls) --
+// never protocol framing and never an auto-echoed result -- so a driver
+// never has to guess which stdout bytes are "the answer" versus program
+// output; the answer is always the structured frame's `value` field.
+// =============================================================================
+
+static constexpr int EREPL_PROTOCOL_VERSION = 1;
+
+// ---- JSON string escaping/parsing -----------------------------------------
+//
+// Hand-rolled rather than pulling in a JSON dependency: every EREPL v1 frame
+// this file emits or accepts is a flat object whose values are plain JSON
+// strings (or, for a handful of response fields, numbers/booleans/null the
+// code below writes directly) -- there is no nesting deep enough, and no
+// non-string request field, to justify a general parser.
+
+// Escapes `s` for use as a JSON string body (the caller supplies the quotes).
+// Raw UTF-8 bytes above 0x7F are passed through unchanged -- valid inside a
+// JSON string and cheaper than re-encoding through \u escapes.
+static std::string json_escape(const std::string& s) {
+    std::string out;
+    out.reserve(s.size() + 8);
+    for (unsigned char c : s) {
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\b': out += "\\b"; break;
+            case '\f': out += "\\f"; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default:
+                if (c < 0x20) {
+                    char buf[8];
+                    std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+                    out += buf;
+                } else {
+                    out += static_cast<char>(c);
+                }
+        }
+    }
+    return out;
+}
+
+// Parses one JSON string literal starting at s[i] == '"' (decoding escapes,
+// including \uXXXX and UTF-16 surrogate pairs into UTF-8). On success leaves
+// i just past the closing quote. Used only by json_parse_flat_object below.
+static bool json_parse_string(const std::string& s, size_t& i, std::string& out) {
+    if (i >= s.size() || s[i] != '"') return false;
+    ++i;
+    out.clear();
+    auto hex4 = [&](size_t pos, unsigned& v) -> bool {
+        if (pos + 4 > s.size()) return false;
+        v = 0;
+        for (int k = 0; k < 4; ++k) {
+            char h = s[pos + k];
+            v <<= 4;
+            if (h >= '0' && h <= '9') v |= static_cast<unsigned>(h - '0');
+            else if (h >= 'a' && h <= 'f') v |= static_cast<unsigned>(h - 'a' + 10);
+            else if (h >= 'A' && h <= 'F') v |= static_cast<unsigned>(h - 'A' + 10);
+            else return false;
+        }
+        return true;
+    };
+    auto append_utf8 = [&](unsigned cp) {
+        if (cp < 0x80) {
+            out += static_cast<char>(cp);
+        } else if (cp < 0x800) {
+            out += static_cast<char>(0xC0 | (cp >> 6));
+            out += static_cast<char>(0x80 | (cp & 0x3F));
+        } else if (cp < 0x10000) {
+            out += static_cast<char>(0xE0 | (cp >> 12));
+            out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+            out += static_cast<char>(0x80 | (cp & 0x3F));
+        } else {
+            out += static_cast<char>(0xF0 | (cp >> 18));
+            out += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+            out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+            out += static_cast<char>(0x80 | (cp & 0x3F));
+        }
+    };
+    while (i < s.size()) {
+        char c = s[i];
+        if (c == '"') { ++i; return true; }
+        if (c == '\\') {
+            ++i;
+            if (i >= s.size()) return false;
+            char e = s[i];
+            switch (e) {
+                case '"':  out += '"';  ++i; break;
+                case '\\': out += '\\'; ++i; break;
+                case '/':  out += '/';  ++i; break;
+                case 'b':  out += '\b'; ++i; break;
+                case 'f':  out += '\f'; ++i; break;
+                case 'n':  out += '\n'; ++i; break;
+                case 'r':  out += '\r'; ++i; break;
+                case 't':  out += '\t'; ++i; break;
+                case 'u': {
+                    unsigned cp = 0;
+                    if (!hex4(i + 1, cp)) return false;
+                    i += 5;
+                    if (cp >= 0xD800 && cp <= 0xDBFF && i + 1 < s.size() &&
+                        s[i] == '\\' && s[i + 1] == 'u') {
+                        unsigned lo = 0;
+                        if (hex4(i + 2, lo) && lo >= 0xDC00 && lo <= 0xDFFF) {
+                            cp = 0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00);
+                            i += 6;
+                        }
+                    }
+                    append_utf8(cp);
+                    break;
+                }
+                default:
+                    return false;
+            }
+        } else {
+            out += c;
+            ++i;
+        }
+    }
+    return false; // unterminated string
+}
+
+// Parses a flat JSON object `{"k":"v", ...}` -- every value must itself be a
+// JSON string, which covers every field EREPL v1 requests use (id, op,
+// code, prefix). A non-string value is a malformed request, not something
+// to silently coerce.
+static bool json_parse_flat_object(const std::string& s,
+                                    std::unordered_map<std::string, std::string>& out,
+                                    std::string& err) {
+    size_t i = 0;
+    auto skip_ws = [&]() { while (i < s.size() && std::isspace(static_cast<unsigned char>(s[i]))) ++i; };
+    skip_ws();
+    if (i >= s.size() || s[i] != '{') { err = "expected '{'"; return false; }
+    ++i;
+    skip_ws();
+    if (i < s.size() && s[i] == '}') { ++i; return true; }
+    while (true) {
+        skip_ws();
+        std::string key;
+        if (!json_parse_string(s, i, key)) { err = "expected a string key"; return false; }
+        skip_ws();
+        if (i >= s.size() || s[i] != ':') { err = "expected ':' after \"" + key + "\""; return false; }
+        ++i;
+        skip_ws();
+        if (i >= s.size() || s[i] != '"') { err = "expected a string value for \"" + key + "\""; return false; }
+        std::string value;
+        if (!json_parse_string(s, i, value)) { err = "malformed string value for \"" + key + "\""; return false; }
+        out[key] = value;
+        skip_ws();
+        if (i < s.size() && s[i] == ',') { ++i; continue; }
+        if (i < s.size() && s[i] == '}') { ++i; return true; }
+        err = "expected ',' or '}'";
+        return false;
+    }
+}
+
+// ---- Result-value capture ---------------------------------------------------
+
+// Portable in-memory capture of a tagged value's R7RS `write` representation
+// (strings quoted, #t/#f, etc.) -- the machine-mode `value` field always
+// uses `write` form so a driver never has to guess whether a bare word came
+// back as a string or a symbol.
+static std::string capture_written_value(const eshkol_tagged_value_t& tv) {
+#ifdef _WIN32
+    FILE* fp = std::tmpfile();
+    if (!fp) return std::string();
+    eshkol_write_value_to_port(&tv, fp);
+    std::fflush(fp);
+    long len = std::ftell(fp);
+    if (len <= 0) { std::fclose(fp); return std::string(); }
+    std::rewind(fp);
+    std::string out(static_cast<size_t>(len), '\0');
+    size_t got = std::fread(&out[0], 1, static_cast<size_t>(len), fp);
+    out.resize(got);
+    std::fclose(fp);
+    return out;
+#else
+    char* buf = nullptr;
+    size_t size = 0;
+    FILE* fp = open_memstream(&buf, &size);
+    if (!fp) return std::string();
+    eshkol_write_value_to_port(&tv, fp);
+    std::fflush(fp);
+    std::string out(buf, size);
+    std::fclose(fp);
+    std::free(buf);
+    return out;
+#endif
+}
+
+// Coarse type name for the machine-mode `value_type` field, via the same
+// `type-of` classification exposed to user code -- so the field is never a
+// wording guess, it is a name the runtime already commits to elsewhere.
+static std::string describe_value_type(const eshkol_tagged_value_t& tv) {
+    eshkol_tagged_value_t name = eshkol_type_of(tv);
+    std::string s = capture_written_value(name);
+    return s.empty() ? std::string("unknown") : s;
+}
+
+// ---- stdout capture for a JSON eval request ---------------------------------
+//
+// The legacy bare-form path leaves stdout exactly as it always was: the
+// program's own output streams to the real pipe in real time, and a client
+// has to read it and separately watch stderr for DONE/FAIL. That works for
+// a human but not for a driver -- two independent OS pipes (this process's
+// stdout and its stderr) give a reader no ordering guarantee between "the
+// stdout bytes are readable" and "the stderr response frame is readable",
+// even though this process always writes stdout before flushing the
+// response frame. Rather than ask every driver to race two pipes (and get
+// it right on every platform), a JSON eval's own stdout is captured here
+// and embedded verbatim in its response frame as the single source of
+// truth; the same bytes are then replayed to the real stdout once capture
+// ends, so a plain pipe-tailing consumer still sees them -- just after the
+// form finishes rather than incrementally while it runs.
+class StdoutCapture {
+public:
+    StdoutCapture() {
+        std::fflush(stdout);
+        capture_file_ = std::tmpfile();
+        if (!capture_file_) return;
+        int cap_fd = ESHKOL_FILENO(capture_file_);
+        saved_fd_ = ESHKOL_DUP(ESHKOL_FILENO(stdout));
+        if (saved_fd_ == -1) return;
+        if (ESHKOL_DUP2(cap_fd, ESHKOL_FILENO(stdout)) == -1) {
+            ESHKOL_CLOSE_FD(saved_fd_);
+            saved_fd_ = -1;
+            return;
+        }
+        active_ = true;
+    }
+
+    ~StdoutCapture() {
+        if (active_) finish();
+        if (capture_file_) std::fclose(capture_file_);
+    }
+
+    StdoutCapture(const StdoutCapture&) = delete;
+    StdoutCapture& operator=(const StdoutCapture&) = delete;
+
+    // Ends capture, restores the real stdout, replays the captured bytes to
+    // it, and returns them. Idempotent: a second call returns "".
+    std::string finish() {
+        if (!active_) return std::string();
+        active_ = false;
+        std::fflush(stdout);
+        ESHKOL_DUP2(saved_fd_, ESHKOL_FILENO(stdout));
+        ESHKOL_CLOSE_FD(saved_fd_);
+        saved_fd_ = -1;
+
+        std::string out;
+        std::fflush(capture_file_);
+        long len = std::ftell(capture_file_);
+        if (len > 0) {
+            std::rewind(capture_file_);
+            out.resize(static_cast<size_t>(len));
+            size_t got = std::fread(&out[0], 1, static_cast<size_t>(len), capture_file_);
+            out.resize(got);
+        }
+        if (!out.empty()) {
+            std::fwrite(out.data(), 1, out.size(), stdout);
+            std::fflush(stdout);
+        }
+        return out;
+    }
+
+private:
+    FILE* capture_file_ = nullptr;
+    int saved_fd_ = -1;
+    bool active_ = false;
+};
+
+// ---- Frame emission ---------------------------------------------------------
+
+static void emit_frame(const std::string& body) {
+    std::fputs("EREPL/1 ", stderr);
+    std::fputs(body.c_str(), stderr);
+    std::fputc('\n', stderr);
+    std::fflush(stderr);
+}
+
+// Bare requests, or a request whose "id" field is missing/empty, echo back
+// JSON null -- a driver that cares about pairing responses always sends a
+// non-empty id, so null unambiguously means "none was supplied".
+static std::string json_id_field(const std::string& id) {
+    if (id.empty()) return "null";
+    return "\"" + json_escape(id) + "\"";
+}
+
+static std::string build_error_object(const std::string& kind,
+                                       const std::string& message,
+                                       long line, long column,
+                                       const std::string* filename,
+                                       const std::string& printed,
+                                       const std::vector<std::string>& irritants) {
+    std::ostringstream o;
+    o << "{\"kind\":\"" << json_escape(kind) << "\""
+      << ",\"message\":\"" << json_escape(message) << "\""
+      << ",\"line\":" << (line > 0 ? std::to_string(line) : std::string("null"))
+      << ",\"column\":" << (column > 0 ? std::to_string(column) : std::string("null"))
+      << ",\"filename\":" << (filename ? ("\"" + json_escape(*filename) + "\"") : std::string("null"))
+      << ",\"printed\":\"" << json_escape(printed) << "\""
+      << ",\"irritants\":[";
+    for (size_t k = 0; k < irritants.size(); ++k) {
+        if (k) o << ",";
+        o << "\"" << json_escape(irritants[k]) << "\"";
+    }
+    o << "]}";
+    return o.str();
+}
+
+// `stdout_text` is this call's captured output (see StdoutCapture above) --
+// embedded directly in the frame so a driver never has to correlate it
+// against the raw stdout pipe. Non-eval callers (protocol errors, requests
+// that never reached execution) always pass "".
+static void emit_result_ok(const std::string& id, const eshkol_tagged_value_t& tv,
+                            const std::string& stdout_text) {
+    std::string value = capture_written_value(tv);
+    std::string vtype = describe_value_type(tv);
+    std::ostringstream body;
+    body << "{\"type\":\"result\",\"id\":" << json_id_field(id)
+         << ",\"ok\":true,\"stdout\":\"" << json_escape(stdout_text)
+         << "\",\"value\":\"" << json_escape(value)
+         << "\",\"value_type\":\"" << json_escape(vtype) << "\"}";
+    emit_frame(body.str());
+}
+
+static void emit_result_error(const std::string& id, const std::string& error_obj,
+                               const std::string& stdout_text) {
+    std::ostringstream body;
+    body << "{\"type\":\"result\",\"id\":" << json_id_field(id)
+         << ",\"ok\":false,\"stdout\":\"" << json_escape(stdout_text)
+         << "\",\"error\":" << error_obj << "}";
+    emit_frame(body.str());
+}
+
+static void emit_result_error_simple(const std::string& id, const std::string& kind,
+                                      const std::string& message,
+                                      const std::string& stdout_text = std::string()) {
+    emit_result_error(id, build_error_object(kind, message, -1, -1, nullptr, message, {}),
+                       stdout_text);
+}
+
+// Builds the structured error object for a real Eshkol exception (as opposed
+// to a parse failure, an interrupt, or a native crash, which have no
+// eshkol_exception_t and go through emit_result_error_simple instead).
+static void emit_result_error_from_exception(const std::string& id, eshkol_exception_t* exc,
+                                              const std::string& stdout_text) {
+    if (!exc) {
+        emit_result_error_simple(id, "error", "unknown runtime error", stdout_text);
+        return;
+    }
+    std::string kind = exception_type_name(exc->type);
+    std::string message = exc->message ? exc->message : "";
+    std::vector<std::string> irritants;
+    irritants.reserve(exc->num_irritants);
+    for (uint32_t k = 0; k < exc->num_irritants; ++k) {
+        irritants.push_back(capture_written_value(exc->irritants[k]));
+    }
+    std::ostringstream printed;
+    printed << kind << ": " << message;
+    if (exc->line > 0) {
+        printed << " at line " << exc->line;
+        if (exc->column > 0) printed << ", column " << exc->column;
+    }
+    std::string filename_storage;
+    const std::string* filename_ptr = nullptr;
+    if (exc->filename) {
+        filename_storage = exc->filename;
+        filename_ptr = &filename_storage;
+    }
+    emit_result_error(id, build_error_object(kind, message, exc->line, exc->column,
+                                              filename_ptr, printed.str(), irritants),
+                       stdout_text);
+}
+
+// A frame for a request that never reached evaluation at all (malformed
+// JSON, or an unrecognized "op") -- distinct from `result` so a driver never
+// has to infer "no evaluation happened" from context. Never carries a
+// "stdout" field: by construction nothing was ever evaluated.
+static void emit_protocol_error(const std::string& id, const std::string& message) {
+    std::ostringstream body;
+    body << "{\"type\":\"error\",\"id\":" << json_id_field(id)
+         << ",\"error\":" << build_error_object("protocol-error", message, -1, -1, nullptr, message, {})
+         << "}";
+    emit_frame(body.str());
+}
+
+// ---- Request handling --------------------------------------------------------
+
+static void track_defined_symbol(const eshkol_ast_t& ast) {
+    const char* defined_name = get_defined_name(ast);
+    if (!defined_name) return;
+    for (const auto& sym : g_defined_symbols) {
+        if (sym == defined_name) return;
+    }
+    g_defined_symbols.push_back(defined_name);
+}
+
+// Candidates for a "complete" request: builtins plus every symbol this
+// session has defined, sorted and deduplicated -- the same universe
+// interactive tab completion (symbol_generator, above) draws from.
+static std::vector<std::string> complete_prefix(const std::string& prefix) {
+    std::vector<std::string> matches;
+    for (const auto& sym : get_builtin_symbols()) {
+        if (sym.compare(0, prefix.size(), prefix) == 0) matches.push_back(sym);
+    }
+    for (const auto& sym : g_defined_symbols) {
+        if (sym.compare(0, prefix.size(), prefix) == 0) matches.push_back(sym);
+    }
+    std::sort(matches.begin(), matches.end());
+    matches.erase(std::unique(matches.begin(), matches.end()), matches.end());
+    return matches;
+}
+
+// "is_complete": does `code` form a complete top-level expression? Uses the
+// exact same paren/string/comment scan the interactive multi-line editor
+// uses (get_paren_depth, above) -- "complete" here means precisely what it
+// means to the accumulation loop, never a second, drifting notion of it.
+static const char* is_complete_status(const std::string& code) {
+    int depth = get_paren_depth(code);
+    if (depth < 0) return "invalid";
+    if (depth > 0) return "incomplete";
+    return "complete";
+}
+
+// Handles a JSON "eval" request: parses `code` as exactly one top-level
+// form and evaluates it via executeTagged() (NOT the display-wrapping path
+// the legacy bare-form protocol uses below) so stdout receives only bytes
+// the form's own code explicitly writes; the form's own value is reported
+// separately in the structured response. Mirrors the legacy path's crash/
+// exception/signal handling (see the near-identical block in main()) so an
+// error, a crash, or an interrupt during a JSON eval behaves the same as
+// during a legacy one -- just reported structurally instead of by text.
+static void handle_eval_request(const std::string& id, const std::string& code,
+                                 eshkol::ReplJITContext& repl_ctx) {
+    if (code.empty()) {
+        emit_result_error_simple(id, "parse-error", "empty code");
+        return;
+    }
+
+    try {
+        eshkol_ast_t ast = parse_string(code);
+        if (ast.type == ESHKOL_INVALID) {
+            emit_result_error_simple(id, "parse-error", "failed to parse input");
+            return;
+        }
+
+        track_defined_symbol(ast);
+
+        eshkol_tagged_value_t tv{};
+        bool had_error = false;
+        const char* synthetic_kind = nullptr;
+
+        // Captures exactly the bytes this evaluation writes to stdout (see
+        // StdoutCapture above); constructed before the setjmp span so it is
+        // never itself skipped by a longjmp out of a crash or an interrupt.
+        StdoutCapture stdout_capture;
+
+        g_in_jit = 1;
+        if (ESHKOL_SIGSETJMP(g_crash_jmp_buf) == 0) {
+            eshkol_push_exception_handler(&g_repl_exception_jmp_buf);
+            if (setjmp(g_repl_exception_jmp_buf) == 0) {
+                tv = repl_ctx.executeTagged(&ast);
+            } else {
+                had_error = true; // g_current_exception is set
+            }
+            eshkol_pop_exception_handler();
+        } else {
+            had_error = true;
+            synthetic_kind = (g_crash_signal == SIGINT) ? "interrupted" : "crash";
+            // Re-install the correct handler for the signal that fired --
+            // the legacy path below needs the identical fix (see main()).
+            signal(g_crash_signal, (g_crash_signal == SIGINT) ? sigint_handler : crash_handler);
+        }
+        g_in_jit = 0;
+
+        std::string captured_stdout = stdout_capture.finish();
+
+        if (had_error) {
+            std::fputs(EREPL_FAIL, stderr);
+            std::fflush(stderr);
+            if (synthetic_kind) {
+                emit_result_error_simple(id, synthetic_kind,
+                    std::string(synthetic_kind) == "interrupted"
+                        ? "evaluation interrupted"
+                        : crash_signal_message(g_crash_signal),
+                    captured_stdout);
+            } else {
+                emit_result_error_from_exception(id, g_current_exception, captured_stdout);
+            }
+        } else {
+            std::fputs(EREPL_DONE, stderr);
+            std::fflush(stderr);
+            emit_result_ok(id, tv, captured_stdout);
+        }
+        eshkol_ast_clean(&ast);
+    } catch (const std::exception& e) {
+        g_in_jit = 0;
+        std::fflush(stdout);
+        std::fputs(EREPL_FAIL, stderr);
+        std::fflush(stderr);
+        emit_result_error_simple(id, "internal-error", e.what());
+    }
+}
+
+// Top-level dispatch for one machine-mode JSON request line.
+static void handle_json_request(const std::string& line, eshkol::ReplJITContext& repl_ctx) {
+    std::unordered_map<std::string, std::string> fields;
+    std::string err;
+    if (!json_parse_flat_object(line, fields, err)) {
+        emit_protocol_error(std::string(), "malformed JSON request: " + err);
+        return;
+    }
+
+    std::string id = fields.count("id") ? fields["id"] : std::string();
+    std::string op = fields.count("op") ? fields["op"] : std::string();
+
+    if (op == "eval") {
+        handle_eval_request(id, fields.count("code") ? fields["code"] : std::string(), repl_ctx);
+    } else if (op == "complete") {
+        std::string prefix = fields.count("prefix") ? fields["prefix"] : std::string();
+        auto matches = complete_prefix(prefix);
+        std::ostringstream body;
+        body << "{\"type\":\"completion\",\"id\":" << json_id_field(id) << ",\"matches\":[";
+        for (size_t k = 0; k < matches.size(); ++k) {
+            if (k) body << ",";
+            body << "\"" << json_escape(matches[k]) << "\"";
+        }
+        body << "]}";
+        emit_frame(body.str());
+    } else if (op == "is_complete") {
+        std::string code = fields.count("code") ? fields["code"] : std::string();
+        std::ostringstream body;
+        body << "{\"type\":\"is_complete\",\"id\":" << json_id_field(id)
+             << ",\"status\":\"" << is_complete_status(code) << "\"}";
+        emit_frame(body.str());
+    } else if (op == "reset") {
+        g_defined_symbols.clear();
+        std::ostringstream body;
+        body << "{\"type\":\"reset\",\"id\":" << json_id_field(id) << ",\"ok\":true}";
+        emit_frame(body.str());
+    } else if (op == "shutdown") {
+        std::ostringstream body;
+        body << "{\"type\":\"shutdown\",\"id\":" << json_id_field(id) << ",\"ok\":true}";
+        emit_frame(body.str());
+        repl_clean_exit(0);
+    } else {
+        emit_protocol_error(id, "unknown op: " + op);
+    }
+}
+
+// --machine mode framing markers: see the EREPL_READY/EREPL_DONE/EREPL_FAIL
+// constants and their doc comment above, right before the "EREPL v1" block
+// (moved there so the request handlers in that block, which reference them,
+// don't need a forward declaration).
 
 int main(int argc, char** argv) {
     // Parse command-line arguments
@@ -790,8 +1416,12 @@ int main(int argc, char** argv) {
             std::cout << "Options:\n";
             std::cout << "  --stdlib, -s    Load standard library on startup\n";
             std::cout << "  --machine, -m   Machine-driven mode: emits EREPL READY/DONE/FAIL\n";
-            std::cout << "                  framing on stderr; suppresses banner / prompts;\n";
-            std::cout << "                  implies --stdlib (warm-worker for sister projects).\n";
+            std::cout << "                  framing on stderr plus a versioned JSON protocol\n";
+            std::cout << "                  (EREPL v1: eval/complete/is_complete/reset/shutdown\n";
+            std::cout << "                  requests on stdin, EREPL/1 {...} responses on\n";
+            std::cout << "                  stderr; see docs/reference/runtime/eshkol-repl.md).\n";
+            std::cout << "                  Suppresses banner / prompts; implies --stdlib\n";
+            std::cout << "                  (warm-worker for sister projects).\n";
             std::cout << "  --help, -h      Show this help message\n";
             return 0;
         }
@@ -847,6 +1477,11 @@ int main(int argc, char** argv) {
     if (machine_mode) {
         std::fputs(EREPL_READY, stderr);
         std::fflush(stderr);
+        std::ostringstream ready_body;
+        ready_body << "{\"type\":\"ready\",\"protocol_version\":" << EREPL_PROTOCOL_VERSION
+                   << ",\"pid\":" << static_cast<long long>(ESHKOL_GETPID())
+                   << ",\"eshkol_version\":\"" << json_escape(ESHKOL_VERSION_STRING) << "\"}";
+        emit_frame(ready_body.str());
     }
 
     while (true) {
@@ -882,6 +1517,21 @@ int main(int argc, char** argv) {
                     std::cout << "\n" << color::dim() << "Goodbye!" << color::reset() << "\n";
                 }
                 repl_clean_exit(0);
+            }
+
+            // EREPL v1: a machine-mode line beginning with '{' is a JSON
+            // request, dispatched immediately as its own unit. No Eshkol
+            // source form starts with '{', so this can never collide with
+            // the legacy bare-form protocol, and it deliberately bypasses
+            // the paren-depth multi-line accumulator below -- a JSON
+            // request is always exactly one stdin line; embedded newlines
+            // in a "code" field travel JSON-escaped, not raw.
+            if (machine_mode && first_line && input[0] == '{') {
+                std::string json_line(input);
+                free(input);
+                handle_json_request(json_line, repl_ctx);
+                input_str.clear();
+                break;
             }
 
             // Empty continuation line - remove last line or cancel
@@ -1050,11 +1700,16 @@ int main(int argc, char** argv) {
 
                 eshkol_pop_exception_handler();
             } else {
-                // Crash occurred - display error and continue
+                // Crash, OR an interrupt delivered mid-evaluation (see
+                // sigint_handler above -- both longjmp here and are told
+                // apart by g_crash_signal) - display error and continue.
                 had_error = true;
                 print_error("Runtime error", crash_signal_message(g_crash_signal));
-                // Re-install signal handler after a crash so the REPL can continue.
-                signal(g_crash_signal, crash_handler);
+                // Re-install the handler for whichever signal fired so the
+                // REPL can continue: SIGINT must get sigint_handler back
+                // (not crash_handler), or a second Ctrl+C / interrupt would
+                // be treated as a crash instead of aborting cleanly again.
+                signal(g_crash_signal, (g_crash_signal == SIGINT) ? sigint_handler : crash_handler);
             }
             g_in_jit = 0;
 

--- a/tests/v1_2_edge_cases/erepl_client_self_test.sh
+++ b/tests/v1_2_edge_cases/erepl_client_self_test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# erepl_client_self_test.sh — EREPL v1 protocol self-test, run through the
+# reference Python driver (tools/erepl_client.py --self-test) against a
+# live `eshkol-repl --machine` child process over plain pipes (no PTY).
+#
+# Exercises every EREPL v1 request type (eval, complete, is_complete,
+# reset, shutdown), a structured runtime-error payload (kind/message/
+# line/column/filename/printed/irritants, never wording-matched), and an
+# interrupted infinite loop that leaves the session usable afterward. See
+# docs/reference/runtime/eshkol-repl.md ("Machine mode (EREPL protocol)")
+# for the protocol this exercises, and the sibling
+# repl_machine_mode_protocol_test.sh for the legacy bare-form framing this
+# protocol stays backward compatible with.
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PYTHON3="${ESHKOL_PYTHON3:-python3}"
+
+if ! command -v "$PYTHON3" >/dev/null 2>&1; then
+    echo "SKIP: $PYTHON3 not available"
+    exit 0
+fi
+
+cd "$ROOT" || exit 1
+BUILD_DIR="${BUILD_DIR:-build}" "$PYTHON3" tools/erepl_client.py --self-test
+exit $?

--- a/tools/erepl_client.py
+++ b/tools/erepl_client.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) tsotchke
+#
+# SPDX-License-Identifier: MIT
+#
+"""Reference driver for the eshkol-repl EREPL v1 machine-mode protocol.
+
+Stdlib-only: no third-party dependencies, no PTY. Talks to a
+`eshkol-repl --machine` child process purely over its stdin/stdout/stderr
+pipes -- the same mechanism on macOS, Linux, and Windows. See
+docs/reference/runtime/eshkol-repl.md ("Machine mode (EREPL protocol)") for
+the full wire contract this module implements: EReplClient is a direct,
+literal translation of that contract into Python, so anything that changes
+here should change there too (and vice versa).
+
+Library usage:
+
+    from erepl_client import EReplClient
+
+    with EReplClient("/path/to/eshkol-repl") as client:
+        result = client.execute("(+ 1 2)")
+        # {"stdout": "", "stderr": "", "value": "3", "value_type": "integer",
+        #  "error": None}
+
+Self-test (spawns the built eshkol-repl and exercises every request type,
+including an interrupted infinite loop and a structured runtime error):
+
+    python3 tools/erepl_client.py --self-test [--binary /path/to/eshkol-repl]
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import os
+import queue
+import signal
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any, Optional
+
+
+class EReplError(RuntimeError):
+    """The protocol itself misbehaved (process died, timed out, a frame
+    could not be parsed). A Scheme-level error from evaluated code is NOT
+    this -- execute() reports that in its returned dict's "error" field
+    instead of raising, exactly as the wire protocol reports it: structured,
+    never by matching text."""
+
+
+class EReplClient:
+    """Drives one `eshkol-repl --machine` child process over plain pipes.
+
+    One EReplClient owns one child process for its whole lifetime -- start()
+    spawns it and blocks until the EREPL v1 "ready" frame arrives, and every
+    other method sends exactly one JSON request line and waits for the
+    response frame carrying the same request id. Safe to use from a single
+    thread at a time; concurrent callers must serialize their own calls (the
+    protocol itself is a strict request/response cycle, not a pipeline).
+    """
+
+    def __init__(self, binary: str, args: Optional[list] = None,
+                 ready_timeout: float = 120.0):
+        self._binary = binary
+        self._args = list(args or [])
+        self._ready_timeout = ready_timeout
+        self._proc: Optional[subprocess.Popen] = None
+        self._id_counter = itertools.count(1)
+        self._lock = threading.Lock()
+        self._stdout_buf: list[str] = []
+        self._stderr_diag_buf: list[str] = []
+        self._pending: dict[str, "queue.Queue[dict]"] = {}
+        self._ready_event = threading.Event()
+        self.ready_info: Optional[dict] = None
+        self._closed = False
+
+    # ---- lifecycle ----------------------------------------------------
+
+    def start(self) -> dict:
+        """Spawns the child and waits for its EREPL v1 ready frame. Returns
+        that frame (protocol_version / pid / eshkol_version)."""
+        popen_kwargs: dict[str, Any] = dict(
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            encoding="utf-8",
+            errors="replace",
+        )
+        if sys.platform == "win32":
+            # Own process group so interrupt() can target this child alone
+            # with CTRL_BREAK_EVENT without also signaling the driver.
+            popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            popen_kwargs["preexec_fn"] = os.setsid  # noqa: PLW1509 -- POSIX-only, no threads yet
+        self._proc = subprocess.Popen(
+            [self._binary, "--machine", *self._args], **popen_kwargs
+        )
+
+        threading.Thread(target=self._read_stdout, daemon=True).start()
+        threading.Thread(target=self._read_stderr, daemon=True).start()
+
+        if not self._ready_event.wait(self._ready_timeout):
+            self._close()
+            raise EReplError("timed out waiting for the EREPL v1 ready frame")
+        assert self.ready_info is not None
+        return self.ready_info
+
+    def shutdown(self, timeout: float = 10.0) -> None:
+        """Asks the session to exit cleanly (op=shutdown), then closes the
+        pipes and waits for the process. Safe to call more than once."""
+        if self._closed:
+            return
+        try:
+            if self._proc is not None and self._proc.poll() is None:
+                self._request("shutdown", {}, timeout=timeout)
+        except EReplError:
+            pass
+        finally:
+            self._close()
+
+    def _close(self) -> None:
+        self._closed = True
+        if self._proc is None:
+            return
+        try:
+            if self._proc.stdin:
+                self._proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            self._proc.wait(timeout=5)
+        except Exception:
+            try:
+                self._proc.kill()
+            except Exception:
+                pass
+
+    def __enter__(self) -> "EReplClient":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.shutdown()
+
+    # ---- reader threads -------------------------------------------------
+    #
+    # Both stdout and stderr must be drained continuously and off the main
+    # thread: the child flushes after every frame, and an unread pipe fills
+    # up and blocks the child's write -- which would otherwise deadlock a
+    # caller that is itself blocked waiting for that same write to finish.
+
+    def _read_stdout(self) -> None:
+        f = self._proc.stdout
+        assert f is not None
+        for line in iter(f.readline, ""):
+            with self._lock:
+                self._stdout_buf.append(line)
+
+    def _read_stderr(self) -> None:
+        f = self._proc.stderr
+        assert f is not None
+        for line in iter(f.readline, ""):
+            stripped = line.rstrip("\n")
+            if stripped == "EREPL READY":
+                continue  # legacy sentinel; the v1 "ready" frame carries the detail
+            if stripped in ("EREPL DONE", "EREPL FAIL"):
+                continue  # legacy per-eval sentinel; superseded by the result frame
+            if stripped.startswith("EREPL/1 "):
+                self._dispatch_frame(stripped[len("EREPL/1 "):])
+                continue
+            # Anything else is REPL diagnostic text (stdlib load banners,
+            # a runtime warning, ...), not protocol framing.
+            with self._lock:
+                self._stderr_diag_buf.append(line)
+
+    def _dispatch_frame(self, body: str) -> None:
+        try:
+            frame = json.loads(body)
+        except json.JSONDecodeError:
+            return  # a malformed frame from the REPL itself; nothing to pair it to
+        if frame.get("type") == "ready":
+            self.ready_info = frame
+            self._ready_event.set()
+            return
+        req_id = frame.get("id")
+        with self._lock:
+            q = self._pending.get(req_id)
+        if q is not None:
+            q.put(frame)
+
+    # ---- request/response -----------------------------------------------
+
+    def _next_id(self) -> str:
+        return str(next(self._id_counter))
+
+    def _request(self, op: str, fields: dict, timeout: float) -> dict:
+        if self._proc is None or self._proc.poll() is not None:
+            raise EReplError("the eshkol-repl process is not running")
+        req_id = self._next_id()
+        q: "queue.Queue[dict]" = queue.Queue(maxsize=1)
+        with self._lock:
+            self._pending[req_id] = q
+        payload = {"id": req_id, "op": op}
+        payload.update(fields)
+        line = json.dumps(payload)
+        try:
+            assert self._proc.stdin is not None
+            self._proc.stdin.write(line + "\n")
+            self._proc.stdin.flush()
+        except (BrokenPipeError, OSError) as e:
+            raise EReplError(f"eshkol-repl closed its stdin: {e}") from e
+        try:
+            frame = q.get(timeout=timeout)
+        except queue.Empty as e:
+            raise EReplError(
+                f"timed out waiting for a response to {op!r} (id={req_id})"
+            ) from e
+        finally:
+            with self._lock:
+                self._pending.pop(req_id, None)
+        return frame
+
+    # ---- public API -------------------------------------------------------
+
+    def execute(self, code: str, timeout: float = 30.0) -> dict:
+        """Evaluates exactly one top-level Eshkol form.
+
+        Returns {"stdout": str, "stderr": str, "value": str | None,
+        "value_type": str | None, "error": dict | None}. "value" is the
+        form's own return value in R7RS `write` form (never conflated with
+        anything the form printed itself, which lands in "stdout" instead).
+        "error", when the form raised or failed to evaluate, is
+        {"kind", "message", "line", "column", "filename", "printed",
+        "irritants"} -- see the docs for the full, closed set of "kind"
+        values (never wording).
+
+        "stdout" comes straight from the response frame's own "stdout"
+        field, NOT from racing the raw stdout pipe against the stderr
+        response frame -- those are two independent OS pipes with no
+        ordering guarantee between them, even though the server always
+        writes stdout before its response frame. "stderr" is best-effort:
+        any REPL diagnostic lines (not protocol frames) seen on the single,
+        inherently-ordered stderr stream since the previous call returned.
+        """
+        with self._lock:
+            stderr_start = len(self._stderr_diag_buf)
+        frame = self._request("eval", {"code": code}, timeout=timeout)
+        with self._lock:
+            stderr = "".join(self._stderr_diag_buf[stderr_start:])
+        stdout = frame.get("stdout", "")
+        if frame.get("ok"):
+            return {
+                "stdout": stdout,
+                "stderr": stderr,
+                "value": frame.get("value"),
+                "value_type": frame.get("value_type"),
+                "error": None,
+            }
+        return {
+            "stdout": stdout,
+            "stderr": stderr,
+            "value": None,
+            "value_type": None,
+            "error": frame.get("error"),
+        }
+
+    def interrupt(self) -> None:
+        """Aborts whatever evaluation is currently in flight (a no-op if the
+        session is idle). Delivered out-of-band as a signal -- SIGINT on
+        POSIX, CTRL_BREAK_EVENT on Windows -- because the child's stdin
+        reader is blocked inside the evaluation and cannot be reached by a
+        request frame; the aborted execute() call returns normally with
+        error.kind == "interrupted", and the session stays usable for the
+        next request."""
+        if self._proc is None or self._proc.poll() is not None:
+            return
+        if sys.platform == "win32":
+            self._proc.send_signal(signal.CTRL_BREAK_EVENT)
+        else:
+            os.kill(self._proc.pid, signal.SIGINT)
+
+    def complete(self, prefix: str, timeout: float = 10.0) -> list:
+        """Returns candidate identifier names (builtins plus this session's
+        own definitions) starting with `prefix`, sorted and deduplicated."""
+        frame = self._request("complete", {"prefix": prefix}, timeout=timeout)
+        return frame.get("matches", [])
+
+    def is_complete(self, code: str, timeout: float = 10.0) -> str:
+        """Returns "complete", "incomplete", or "invalid"."""
+        frame = self._request("is_complete", {"code": code}, timeout=timeout)
+        return frame.get("status", "invalid")
+
+    def reset(self, timeout: float = 10.0) -> bool:
+        """Clears this session's tracked-definitions bookkeeping (tab
+        completion, etc). Per-session JIT symbols are NOT undone -- same
+        caveat as the interactive `:reset` command."""
+        frame = self._request("reset", {}, timeout=timeout)
+        return bool(frame.get("ok"))
+
+
+# =============================================================================
+# Self-test
+# =============================================================================
+
+def _default_binary() -> str:
+    repo_root = Path(__file__).resolve().parent.parent
+    build_dir = os.environ.get("BUILD_DIR", "build")
+    exe_name = "eshkol-repl.exe" if sys.platform == "win32" else "eshkol-repl"
+    return str(repo_root / build_dir / exe_name)
+
+
+class _Check:
+    def __init__(self):
+        self.count = 0
+
+    def __call__(self, condition: bool, description: str, detail: str = "") -> None:
+        self.count += 1
+        if not condition:
+            msg = f"FAIL: {description}"
+            if detail:
+                msg += f"\n  {detail}"
+            print(msg)
+            sys.exit(1)
+
+
+def _self_test(binary: str) -> int:
+    if not os.path.exists(binary):
+        print(f"SKIP: {binary} not built")
+        return 0
+
+    check = _Check()
+    client = EReplClient(binary)
+    ready = client.start()
+    check(ready.get("protocol_version") == 1, "ready frame announces protocol_version 1",
+          repr(ready))
+    check(isinstance(ready.get("pid"), int) and ready["pid"] > 0,
+          "ready frame announces a pid", repr(ready))
+
+    try:
+        # -- basic eval: value distinct from stdout -----------------------
+        r = client.execute("(+ 1 2)")
+        check(r["error"] is None and r["value"] == "3" and r["value_type"] == "integer",
+              "(+ 1 2) evaluates to value=3/integer with no error", repr(r))
+        check(r["stdout"] == "", "(+ 1 2) writes nothing to stdout", repr(r))
+
+        r = client.execute('(display (* 6 7))')
+        check(r["error"] is None, "(display (* 6 7)) evaluates without error", repr(r))
+        check(r["stdout"] == "42", "explicit display output lands in stdout, exactly",
+              repr(r))
+
+        # -- structured runtime error, classified by kind, not wording ----
+        r = client.execute("(car (quote ()))")
+        check(r["error"] is not None and r["error"]["kind"] == "type-error",
+              "(car '()) fails with a structured kind=type-error payload", repr(r))
+        check("message" in r["error"] and "printed" in r["error"] and
+              "irritants" in r["error"],
+              "the error payload carries message/printed/irritants fields", repr(r))
+
+        # -- parse error -----------------------------------------------------
+        r = client.execute(")))")
+        check(r["error"] is not None and r["error"]["kind"] == "parse-error",
+              "malformed source fails with kind=parse-error", repr(r))
+
+        # -- is_complete -------------------------------------------------
+        check(client.is_complete("(display 1") == "incomplete",
+              "is_complete detects an unbalanced open form")
+        check(client.is_complete("(display 1)") == "complete",
+              "is_complete detects a balanced form")
+        check(client.is_complete(")))") == "invalid",
+              "is_complete detects an unmatched closing paren")
+
+        # -- completion ----------------------------------------------------
+        matches = client.complete("string-appe")
+        check("string-append" in matches,
+              "complete() finds a builtin by prefix", repr(matches))
+
+        r = client.execute("(define erepl-self-test-var 42)")
+        check(r["error"] is None, "defining a variable succeeds", repr(r))
+        matches = client.complete("erepl-self-test-")
+        check("erepl-self-test-var" in matches,
+              "complete() finds a session-defined symbol", repr(matches))
+
+        # -- reset -----------------------------------------------------------
+        check(client.reset() is True, "reset() acknowledges ok")
+
+        # -- interrupt: abort a runaway evaluation, session stays usable ----
+        result_box: dict = {}
+
+        def run_infinite_loop():
+            result_box["result"] = client.execute(
+                "(let loop () (loop))", timeout=60.0
+            )
+
+        t = threading.Thread(target=run_infinite_loop)
+        t.start()
+        t.join(timeout=2.0)  # give the loop time to actually start spinning
+        client.interrupt()
+        t.join(timeout=30.0)
+        check(not t.is_alive(), "an interrupted infinite loop returns rather than hanging")
+        r = result_box.get("result")
+        check(r is not None and r["error"] is not None and
+              r["error"]["kind"] == "interrupted",
+              "interrupt() aborts the loop with kind=interrupted", repr(r))
+
+        # Session must still be usable after the interrupt.
+        r = client.execute("(+ 40 2)")
+        check(r["error"] is None and r["value"] == "42",
+              "the session evaluates normally again after an interrupt", repr(r))
+    finally:
+        client.shutdown()
+
+    print(f"PASS: EREPL v1 self-test ({check.count} checks)")
+    return 0
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                      formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--binary", default=None,
+                         help="Path to the eshkol-repl executable "
+                              "(default: <repo>/$BUILD_DIR/eshkol-repl, BUILD_DIR defaults to 'build')")
+    parser.add_argument("--self-test", action="store_true",
+                         help="Run the built-in protocol self-test against --binary and exit")
+    args = parser.parse_args(argv)
+
+    binary = args.binary or _default_binary()
+
+    if args.self_test:
+        return _self_test(binary)
+
+    parser.error("nothing to do: pass --self-test, or import EReplClient as a library")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Versions `eshkol-repl --machine`'s warm-worker framing: the original bare `EREPL READY` / `EREPL DONE` / `EREPL FAIL` sentinels are unchanged and always emitted, and a session now additionally accepts JSON request lines on stdin (`eval`, `complete`, `is_complete`, `reset`, `shutdown`) and answers with versioned `EREPL/1 {...}` JSON response lines on stderr.
- An `eval` response reports the form's own value separately from whatever it printed to stdout — embedded directly in the response frame rather than left for a driver to race two independent OS pipes — and every failure carries a structured `error.kind` from a small, closed set instead of prose. A runaway evaluation can be interrupted out-of-band (`SIGINT` / `CTRL_BREAK_EVENT`), returning `error.kind: "interrupted"` with the session still usable afterward.
- Adds `tools/erepl_client.py`, a stdlib-only Python reference driver (`EReplClient`: `execute`, `interrupt`, `complete`, `is_complete`, `reset`, `shutdown`) with a `--self-test` covering every request type, a structured runtime error, and an interrupted infinite loop.
- Rewrites the "Machine mode (EREPL protocol)" section of `docs/reference/runtime/eshkol-repl.md` as the versioned contract: frame grammar, every request/response, the error payload schema, and the compatibility promise (fields added-only within v1, a breaking change requires a new `protocol_version`).

## Test plan

- [x] `ctest -R "repl|erepl|machine"` — 4/4 passed
- [x] `python3 tools/erepl_client.py --self-test` — run 3x, all green (19 checks each)
- [x] `./scripts/run_all_tests.sh` — 46/46 suites, 849/849 tests passed
- [x] `python3 scripts/gen_api_docs.py --check` / `gen_language_surface.py --check` — up to date, no regeneration needed
- [x] `python3 scripts/check_wasm_imports.py --build-dir build` — OK (no WASM-reachable surface touched)
- [x] Merged current `master` in; no conflicts outside a clean auto-merge in `CMakeLists.txt`