### PR TITLE
fix(codegen): a binding form's names shadow only inside that form

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3649,6 +3649,34 @@ if(ESHKOL_BUILD_TESTS AND TARGET eshkol-run)
             TIMEOUT 300
             PASS_REGULAR_EXPRESSION "PASS: inline_differentiand_loop_capture"
             FAIL_REGULAR_EXPRESSION "FAIL:|LLVM module verification failed|fatal signal")
+    # LE-20: a named-let parameter was reported "Undefined variable" when it was
+    # referenced inside a NESTED named let whose binding form contained a further
+    # named let that rebound the same name. The capture analysis subtracted the
+    # inner form's bound names from the WHOLE free-variable vector, deleting a
+    # capture a sibling init had already recorded, so both native lanes (JIT and
+    # AOT) refused legal code. The bytecode VM always ran these programs.
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/regression/named_let_shadowed_parameter_scope_test.esk")
+        add_test(
+            NAME named_let_shadowed_parameter_scope_jit
+            COMMAND $<TARGET_FILE:eshkol-run> -r
+                    "${CMAKE_CURRENT_SOURCE_DIR}/tests/regression/named_let_shadowed_parameter_scope_test.esk"
+                    -L"${CMAKE_CURRENT_BINARY_DIR}"
+        )
+        set_tests_properties(named_let_shadowed_parameter_scope_jit PROPERTIES
+            TIMEOUT 180
+            ENVIRONMENT "ESHKOL_JIT_CACHE=0"
+            PASS_REGULAR_EXPRESSION "PASS: named-let parameter survives a nested named let that rebinds it"
+            FAIL_REGULAR_EXPRESSION "FAIL:|Undefined variable|LLVM module verification failed|fatal signal")
+        add_test(
+            NAME named_let_shadowed_parameter_scope_aot
+            COMMAND sh -c
+                "'$<TARGET_FILE:eshkol-run>' -o '${CMAKE_CURRENT_BINARY_DIR}/named_let_shadowed_parameter_scope_aot' '${CMAKE_CURRENT_SOURCE_DIR}/tests/regression/named_let_shadowed_parameter_scope_test.esk' -L'${CMAKE_CURRENT_BINARY_DIR}' && '${CMAKE_CURRENT_BINARY_DIR}/named_let_shadowed_parameter_scope_aot'"
+        )
+        set_tests_properties(named_let_shadowed_parameter_scope_aot PROPERTIES
+            TIMEOUT 240
+            PASS_REGULAR_EXPRESSION "PASS: named-let parameter survives a nested named let that rebinds it"
+            FAIL_REGULAR_EXPRESSION "FAIL:|Undefined variable|LLVM module verification failed|fatal signal")
+    endif()
     # ESH-0369: higher-order derivatives through a VARIABLE-BOUND derivative
     # closure. `(define df (derivative f))` then `(derivative df)` returned 0.0
     # (the emitted closure unpacked its argument to a raw double, destroying an
@@ -5898,6 +5926,34 @@ if(ESHKOL_BUILD_TESTS AND NOT WIN32)
                      "${CMAKE_CURRENT_SOURCE_DIR}/tests/vm_parity/found/frame_overflow_exit_zero.esk")
         set_tests_properties(vm_frame_overflow_exit_status PROPERTIES TIMEOUT 120)
     endif()
+    endif()
+    # LE-20 VM lane: the same shape the native regression covers
+    # (tests/regression/named_let_shadowed_parameter_scope_test.esk). The VM
+    # already ran these programs before the native capture-analysis fix, so this
+    # is the reference side of the cross-engine differential.
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/vm_parity/corpus/82_named_let_shadowed_parameter_scope.esk")
+        add_test(
+            NAME named_let_shadowed_parameter_scope_vm_source_smoke
+            COMMAND $<TARGET_FILE:eshkol-vm-standalone-test>
+                    "${CMAKE_CURRENT_SOURCE_DIR}/tests/vm_parity/corpus/82_named_let_shadowed_parameter_scope.esk"
+        )
+        set_tests_properties(named_let_shadowed_parameter_scope_vm_source_smoke
+            PROPERTIES
+                TIMEOUT 240
+                ENVIRONMENT "ESHKOL_VM_NO_DISASM=1"
+                PASS_REGULAR_EXPRESSION "PASS: named let shadowed parameter scope"
+                FAIL_REGULAR_EXPRESSION "FAIL:|Undefined variable|fatal signal")
+        add_test(
+            NAME named_let_shadowed_parameter_scope_vm_eskb_smoke
+            COMMAND sh -c
+                "'$<TARGET_FILE:eshkol-run>' --profile hosted-vm --emit-eskb '${CMAKE_CURRENT_BINARY_DIR}/named_let_shadowed_parameter_scope.eskb' '${CMAKE_CURRENT_SOURCE_DIR}/tests/vm_parity/corpus/82_named_let_shadowed_parameter_scope.esk' && '$<TARGET_FILE:eshkol-vm-standalone-test>' '${CMAKE_CURRENT_BINARY_DIR}/named_let_shadowed_parameter_scope.eskb'"
+        )
+        set_tests_properties(named_let_shadowed_parameter_scope_vm_eskb_smoke
+            PROPERTIES
+                TIMEOUT 240
+                ENVIRONMENT "ESHKOL_VM_NO_DISASM=1"
+                PASS_REGULAR_EXPRESSION "PASS: named let shadowed parameter scope"
+                FAIL_REGULAR_EXPRESSION "FAIL:|Undefined variable|fatal signal")
     endif()
     add_test(
         NAME ad_jacobian_counterexample_vm_source_smoke

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -28305,7 +28305,23 @@ private:
                         break;
                     case ESHKOL_LET_OP: {
                         // CRITICAL: Handle let expressions to find free variables in bindings and body
-                        // First, collect let-bound variable names (they shadow outer scope)
+                        //
+                        // LE-20 (SHADOWED-BINDING SCOPE FIX): a binding form's names are
+                        // bound in its BODY ONLY, so they must be pushed onto `bound_vars`
+                        // for the body walk — never subtracted from `free_vars` afterwards.
+                        // The old code walked the body with the enclosing bound set and then
+                        // erased every let-bound name from the WHOLE `free_vars` vector. That
+                        // erase is not scoped: it also deleted a capture that a SIBLING
+                        // sub-expression, walked earlier, had legitimately recorded. Concretely
+                        //     (let try ((a 0))
+                        //       (let* ((acc1 (* acc 2))                 ; records `acc` — correct
+                        //              (acc2 (let loop ((k 0) (acc acc1)) ...))))  ; erased it
+                        // dropped `acc` (a parameter of the enclosing named let) from `try`'s
+                        // capture list, and codegenVariable then reported
+                        // "Undefined variable: acc" at the legal reference `(* acc 2)`.
+                        // Walking with a per-scope bound set makes the inner rebinding invisible
+                        // to everything outside the inner form, which is the R7RS rule and what
+                        // the bytecode VM already implements.
                         std::vector<std::string> let_bound_names;
                         for (uint64_t i = 0; i < op->let_op.num_bindings; i++) {
                             const eshkol_ast_t* binding = &op->let_op.bindings[i];
@@ -28317,7 +28333,10 @@ private:
                             }
                         }
 
-                        // Search binding VALUE expressions (they can reference outer scope)
+                        // Search binding VALUE expressions. R7RS 4.2.2/4.2.4: the inits of
+                        // `let` and of a named `let` are evaluated in the scope OUTSIDE the
+                        // binding form, so they are walked with the enclosing bound set —
+                        // a name the form itself binds does NOT shadow them.
                         for (uint64_t i = 0; i < op->let_op.num_bindings; i++) {
                             const eshkol_ast_t* binding = &op->let_op.bindings[i];
                             if (binding->type == ESHKOL_CONS && binding->cons_cell.cdr) {
@@ -28325,32 +28344,41 @@ private:
                             }
                         }
 
-                        // Search let body - but let-bound variables should be treated as parameters
-                        // Create extended parameter list including let-bound names
+                        // Search let body with the new names bound. For a named let the loop
+                        // name is bound in the body too (it names the loop procedure).
                         if (op->let_op.body) {
-                            // We need to pass let-bound names as "virtual parameters" so they're not captured
-                            // For simplicity, just search the body and filter out let-bound names after
-                            findFreeVariablesImpl(op->let_op.body, current_scope, parameters, num_params, free_vars, bound_vars);
-
-                            // Remove any let-bound names that were incorrectly added as free vars
-                            for (const std::string& let_var : let_bound_names) {
-                                free_vars.erase(std::remove(free_vars.begin(), free_vars.end(), let_var), free_vars.end());
+                            std::unordered_set<std::string> body_bound_vars = bound_vars;
+                            body_bound_vars.insert(let_bound_names.begin(), let_bound_names.end());
+                            if (op->let_op.name) {
+                                body_bound_vars.insert(op->let_op.name);
                             }
+                            findFreeVariablesImpl(op->let_op.body, current_scope, parameters, num_params, free_vars, body_bound_vars);
                         }
                         break;
                     }
                     case ESHKOL_LET_STAR_OP:
                     case ESHKOL_LETREC_OP:
                     case ESHKOL_LETREC_STAR_OP: {
-                        // Handle let*, letrec, and letrec* expressions the same way as let
-                        std::vector<std::string> let_bound_names;
+                        // Handle let*, letrec, and letrec* — same per-scope rule as `let`
+                        // (see the LE-20 note above), but with each form's own init scoping:
+                        //   let*    — init i sees bindings 0..i-1
+                        //   letrec/letrec* — every init sees every name in the group
+                        std::vector<std::string> binding_names(op->let_op.num_bindings);
                         for (uint64_t i = 0; i < op->let_op.num_bindings; i++) {
                             const eshkol_ast_t* binding = &op->let_op.bindings[i];
                             if (binding->type == ESHKOL_CONS && binding->cons_cell.car) {
                                 const eshkol_ast_t* var_ast = binding->cons_cell.car;
                                 if (var_ast->type == ESHKOL_VAR && var_ast->variable.id) {
-                                    let_bound_names.push_back(var_ast->variable.id);
+                                    binding_names[i] = var_ast->variable.id;
                                 }
+                            }
+                        }
+
+                        const bool inits_see_whole_group = (op->op != ESHKOL_LET_STAR_OP);
+                        std::unordered_set<std::string> init_bound_vars = bound_vars;
+                        if (inits_see_whole_group) {
+                            for (const std::string& name : binding_names) {
+                                if (!name.empty()) init_bound_vars.insert(name);
                             }
                         }
 
@@ -28358,18 +28386,24 @@ private:
                         for (uint64_t i = 0; i < op->let_op.num_bindings; i++) {
                             const eshkol_ast_t* binding = &op->let_op.bindings[i];
                             if (binding->type == ESHKOL_CONS && binding->cons_cell.cdr) {
-                                findFreeVariablesImpl(binding->cons_cell.cdr, current_scope, parameters, num_params, free_vars, bound_vars);
+                                findFreeVariablesImpl(binding->cons_cell.cdr, current_scope, parameters, num_params, free_vars, init_bound_vars);
+                            }
+                            // let*: this binding is in scope for every LATER init.
+                            if (!inits_see_whole_group && !binding_names[i].empty()) {
+                                init_bound_vars.insert(binding_names[i]);
                             }
                         }
 
-                        // Search let body
+                        // Search let body with the whole group bound
                         if (op->let_op.body) {
-                            findFreeVariablesImpl(op->let_op.body, current_scope, parameters, num_params, free_vars, bound_vars);
-
-                            // Remove let-bound names from free vars
-                            for (const std::string& let_var : let_bound_names) {
-                                free_vars.erase(std::remove(free_vars.begin(), free_vars.end(), let_var), free_vars.end());
+                            std::unordered_set<std::string> body_bound_vars = bound_vars;
+                            for (const std::string& name : binding_names) {
+                                if (!name.empty()) body_bound_vars.insert(name);
                             }
+                            if (op->let_op.name) {
+                                body_bound_vars.insert(op->let_op.name);
+                            }
+                            findFreeVariablesImpl(op->let_op.body, current_scope, parameters, num_params, free_vars, body_bound_vars);
                         }
                         break;
                     }

--- a/tests/regression/named_let_shadowed_parameter_scope_test.esk
+++ b/tests/regression/named_let_shadowed_parameter_scope_test.esk
@@ -1,0 +1,196 @@
+;; LE-20: a named-let parameter reported "Undefined variable" when a binding
+;; form inside a NESTED named let contains a further named let that rebinds
+;; the same name.
+;;
+;; The capture analysis for the inner named let walked its binding form, then
+;; deleted every name that form bound from the WHOLE free-variable vector --
+;; including the capture a sibling init expression, walked earlier, had
+;; legitimately recorded. `acc` therefore vanished from the intermediate named
+;; let's capture list and codegenVariable refused the legal reference
+;; `(* acc 2)`. Both native lanes (JIT and AOT) stopped; the bytecode VM,
+;; whose scope handling is per-form, always ran these programs correctly.
+;;
+;; Minimized from .scratch/math-stream-repros/scope_shadow{2,3,4,5,6}.esk and
+;; scope_shadow_named_let.esk.
+
+(define failures 0)
+
+(define (check name got want)
+  (if (equal? got want)
+      #t
+      (begin
+        (set! failures (+ failures 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (display want)
+        (display " got ") (display got) (newline)
+        #f)))
+
+(define (all? pred xs)
+  (cond ((null? xs) #t)
+        ((pred (car xs)) (all? pred (cdr xs)))
+        (else #f)))
+
+;; ---------------------------------------------------------------- shape 1
+;; Outer named let `dfs` carries `acc`; nested named let `try`; a `let*` whose
+;; first init reads `acc` and whose second init is a named let rebinding `acc`.
+;; A lambda sits in the `if` test, so the walk crosses a closure boundary too.
+(define (shape-lambda-test n)
+  (let ((total (vector 0)))
+    (let dfs ((e 0) (acc 1))
+      (if (= e n)
+          (vector-set! total 0 (+ (vector-ref total 0) acc))
+          (let try ((a 0))
+            (if (< a 2)
+                (begin
+                  (if (all? (lambda (x) (< x 10)) (list a e))
+                      (let* ((acc1 (* acc 2))
+                             (acc2 (let loop ((k 0) (acc acc1))
+                                     (if (= k 2) acc (loop (+ k 1) (+ acc 1))))))
+                        (dfs (+ e 1) acc2)))
+                  (try (+ a 1)))))))
+    (vector-ref total 0)))
+
+;; ---------------------------------------------------------------- shape 2
+;; Same, with no lambda anywhere: the two-level named let plus the rebinding
+;; inner named let is on its own sufficient.
+(define (shape-no-lambda n)
+  (let ((total (vector 0)))
+    (let dfs ((e 0) (acc 1))
+      (if (= e n)
+          (vector-set! total 0 (+ (vector-ref total 0) acc))
+          (let try ((a 0))
+            (if (< a 2)
+                (begin
+                  (if (< (+ a e) 10)
+                      (let* ((acc1 (* acc 2))
+                             (acc2 (let loop ((k 0) (acc acc1))
+                                     (if (= k 2) acc (loop (+ k 1) (+ acc 1))))))
+                        (dfs (+ e 1) acc2)))
+                  (try (+ a 1)))))))
+    (vector-ref total 0)))
+
+;; ---------------------------------------------------------------- shape 3
+;; Plain `let`, and the outer `acc` is read from inside the INIT of the inner
+;; named let that rebinds it: `(let loop ((k 0) (acc (* acc 2))) ...)`.
+;; R7RS 4.2.4: that init is evaluated in the enclosing scope, so it means the
+;; outer `acc`.
+(define (shape-init-self-shadow n)
+  (let ((total (vector 0)))
+    (let dfs ((e 0) (acc 1))
+      (if (= e n)
+          (vector-set! total 0 (+ (vector-ref total 0) acc))
+          (let try ((a 0))
+            (if (< a 2)
+                (begin
+                  (if (< (+ a e) 10)
+                      (let ((acc2 (let loop ((k 0) (acc (* acc 2)))
+                                    (if (= k 2) acc (loop (+ k 1) (+ acc 1))))))
+                        (dfs (+ e 1) acc2)))
+                  (try (+ a 1)))))))
+    (vector-ref total 0)))
+
+;; ------------------------------------------------------------ control 1
+;; Identical to shape 2 with the inner loop's variable renamed: this always
+;; compiled, and must keep the same answer.
+(define (control-renamed-inner n)
+  (let ((total (vector 0)))
+    (let dfs ((e 0) (acc 1))
+      (if (= e n)
+          (vector-set! total 0 (+ (vector-ref total 0) acc))
+          (let try ((a 0))
+            (if (< a 2)
+                (begin
+                  (if (< (+ a e) 10)
+                      (let* ((acc1 (* acc 2))
+                             (acc2 (let loop ((k 0) (s acc1))
+                                     (if (= k 2) s (loop (+ k 1) (+ s 1))))))
+                        (dfs (+ e 1) acc2)))
+                  (try (+ a 1)))))))
+    (vector-ref total 0)))
+
+;; ------------------------------------------------------------ control 2
+;; Identical to shape 2 with the intermediate named let removed (the body is
+;; inlined twice to keep the same iteration count): this always compiled.
+(define (control-no-intermediate n)
+  (let ((total (vector 0)))
+    (let dfs ((e 0) (acc 1))
+      (if (= e n)
+          (vector-set! total 0 (+ (vector-ref total 0) acc))
+          (begin
+            (if (< e 10)
+                (let* ((acc1 (* acc 2))
+                       (acc2 (let loop ((k 0) (acc acc1))
+                               (if (= k 2) acc (loop (+ k 1) (+ acc 1))))))
+                  (dfs (+ e 1) acc2)))
+            (if (< e 10)
+                (let* ((acc1 (* acc 2))
+                       (acc2 (let loop ((k 0) (acc acc1))
+                               (if (= k 2) acc (loop (+ k 1) (+ acc 1))))))
+                  (dfs (+ e 1) acc2))))))
+    (vector-ref total 0)))
+
+;; ------------------------------------------------------------ control 3
+;; One level only: the rebinding inner named let sits directly in the outer
+;; named let's own body, so no capture is involved at all.
+(define (control-single-level n)
+  (let outer ((i 0) (acc 1))
+    (if (= i n)
+        acc
+        (let* ((a1 (* acc 2))
+               (a2 (let loop ((k 0) (acc a1))
+                     (if (= k 2) acc (loop (+ k 1) (+ acc 1))))))
+          (outer (+ i 1) a2)))))
+
+;; ------------------------------------------------- binding-form scope rules
+;; The fix replaced a post-hoc subtraction from the capture list with a
+;; per-scope bound set, so the scoping rule of each binding form is now load
+;; bearing. These pin the three rules down through a closure boundary, where
+;; a wrong capture is what shows up.
+
+;; `let`: an enclosing binding read from a binding init must be captured, and
+;; it must still be captured when a LATER init of the same group introduces an
+;; inner named let. (This deliberately does not shadow `v`: both engines bind
+;; plain `let` sequentially today, and that separate deviation is not what
+;; this regression is about.)
+(define (rule-let-init-reads-outer)
+  (let ((v 10))
+    (let ((f (lambda ()
+               (let ((a (+ v 1))       ; 11, from the captured v
+                     (b (let loop ((k 0) (v (* v 2)))
+                          (if (= k 2) v (loop (+ k 1) (+ v 1))))))  ; 22
+                 (+ a b)))))           ; 33
+      (f))))
+
+;; `let*`: init i sees bindings 0..i-1, and the first init still reads outer.
+(define (rule-let-star-inits-are-sequential)
+  (let ((v 10))
+    (let ((f (lambda ()
+               (let* ((v (+ v 1))      ; 11, from the outer v
+                      (w (* v 2)))     ; 22, from the let*-bound v
+                 (+ v w)))))           ; 33
+      (f))))
+
+;; `letrec`: the whole group is in scope in every init, so the inner `v` is
+;; the letrec's own binding and the outer `v` is not captured by the body.
+(define (rule-letrec-group-is-visible)
+  (let ((v 10))
+    (let ((f (lambda ()
+               (letrec ((v (lambda () 7))
+                        (w (lambda () (+ (v) 1))))
+                 (+ (v) (w))))))       ; 15
+      (f))))
+
+(check "shape-lambda-test"                    (shape-lambda-test 3)              176)
+(check "shape-no-lambda"                      (shape-no-lambda 3)                176)
+(check "shape-init-self-shadow"               (shape-init-self-shadow 3)         176)
+(check "control-renamed-inner"                (control-renamed-inner 3)          176)
+(check "control-no-intermediate"              (control-no-intermediate 3)        176)
+(check "control-single-level"                 (control-single-level 3)           22)
+(check "rule-let-init-reads-outer"            (rule-let-init-reads-outer)        33)
+(check "rule-let-star-inits-are-sequential"   (rule-let-star-inits-are-sequential) 33)
+(check "rule-letrec-group-is-visible"         (rule-letrec-group-is-visible)     15)
+
+(if (= failures 0)
+    (begin (display "PASS: named-let parameter survives a nested named let that rebinds it") (newline))
+    (begin (display "FAIL: ") (display failures) (display " scope checks failed") (newline)
+           (exit 1)))

--- a/tests/vm_parity/corpus/82_named_let_shadowed_parameter_scope.esk
+++ b/tests/vm_parity/corpus/82_named_let_shadowed_parameter_scope.esk
@@ -1,0 +1,130 @@
+; LE-20: cross-engine parity for a named-let parameter referenced inside a
+; NESTED named let whose binding form contains a further named let that
+; rebinds the same name.
+;
+; The native capture analysis walked the inner binding form and then deleted
+; every name that form bound from the whole free-variable vector, dropping the
+; capture a sibling init had already recorded. `acc` fell out of the
+; intermediate loop's capture list and native compilation stopped with
+; "Undefined variable: acc" at the legal reference `(* acc 2)`; the bytecode
+; VM, whose scope handling is per-form, ran the same program correctly. This
+; program puts both engines on the differential gate for that shape.
+
+(define (all? pred xs)
+  (cond ((null? xs) #t)
+        ((pred (car xs)) (all? pred (cdr xs)))
+        (else #f)))
+
+; nested named let + a lambda in the test + let* whose later init rebinds acc
+(define (shape-lambda-test n)
+  (let ((total (vector 0)))
+    (let dfs ((e 0) (acc 1))
+      (if (= e n)
+          (vector-set! total 0 (+ (vector-ref total 0) acc))
+          (let try ((a 0))
+            (if (< a 2)
+                (begin
+                  (if (all? (lambda (x) (< x 10)) (list a e))
+                      (let* ((acc1 (* acc 2))
+                             (acc2 (let loop ((k 0) (acc acc1))
+                                     (if (= k 2) acc (loop (+ k 1) (+ acc 1))))))
+                        (dfs (+ e 1) acc2)))
+                  (try (+ a 1)))))))
+    (vector-ref total 0)))
+
+; same with no lambda anywhere
+(define (shape-no-lambda n)
+  (let ((total (vector 0)))
+    (let dfs ((e 0) (acc 1))
+      (if (= e n)
+          (vector-set! total 0 (+ (vector-ref total 0) acc))
+          (let try ((a 0))
+            (if (< a 2)
+                (begin
+                  (if (< (+ a e) 10)
+                      (let* ((acc1 (* acc 2))
+                             (acc2 (let loop ((k 0) (acc acc1))
+                                     (if (= k 2) acc (loop (+ k 1) (+ acc 1))))))
+                        (dfs (+ e 1) acc2)))
+                  (try (+ a 1)))))))
+    (vector-ref total 0)))
+
+; the outer acc read from inside the INIT of the inner named let that rebinds
+; it -- R7RS 4.2.4 evaluates that init in the enclosing scope
+(define (shape-init-self-shadow n)
+  (let ((total (vector 0)))
+    (let dfs ((e 0) (acc 1))
+      (if (= e n)
+          (vector-set! total 0 (+ (vector-ref total 0) acc))
+          (let try ((a 0))
+            (if (< a 2)
+                (begin
+                  (if (< (+ a e) 10)
+                      (let ((acc2 (let loop ((k 0) (acc (* acc 2)))
+                                    (if (= k 2) acc (loop (+ k 1) (+ acc 1))))))
+                        (dfs (+ e 1) acc2)))
+                  (try (+ a 1)))))))
+    (vector-ref total 0)))
+
+; control: inner loop variable renamed (always compiled)
+(define (control-renamed-inner n)
+  (let ((total (vector 0)))
+    (let dfs ((e 0) (acc 1))
+      (if (= e n)
+          (vector-set! total 0 (+ (vector-ref total 0) acc))
+          (let try ((a 0))
+            (if (< a 2)
+                (begin
+                  (if (< (+ a e) 10)
+                      (let* ((acc1 (* acc 2))
+                             (acc2 (let loop ((k 0) (s acc1))
+                                     (if (= k 2) s (loop (+ k 1) (+ s 1))))))
+                        (dfs (+ e 1) acc2)))
+                  (try (+ a 1)))))))
+    (vector-ref total 0)))
+
+; control: single level, no capture involved
+(define (control-single-level n)
+  (let outer ((i 0) (acc 1))
+    (if (= i n)
+        acc
+        (let* ((a1 (* acc 2))
+               (a2 (let loop ((k 0) (acc a1))
+                     (if (= k 2) acc (loop (+ k 1) (+ acc 1))))))
+          (outer (+ i 1) a2)))))
+
+; let* init sequencing, and a letrec group, across a closure boundary
+(define (rule-let-star-inits-are-sequential)
+  (let ((v 10))
+    (let ((f (lambda ()
+               (let* ((v (+ v 1))
+                      (w (* v 2)))
+                 (+ v w)))))
+      (f))))
+
+(define (rule-letrec-group-is-visible)
+  (let ((v 10))
+    (let ((f (lambda ()
+               (letrec ((v (lambda () 7))
+                        (w (lambda () (+ (v) 1))))
+                 (+ (v) (w))))))
+      (f))))
+
+(display (shape-lambda-test 3)) (newline)
+(display (shape-no-lambda 3)) (newline)
+(display (shape-init-self-shadow 3)) (newline)
+(display (control-renamed-inner 3)) (newline)
+(display (control-single-level 3)) (newline)
+(display (rule-let-star-inits-are-sequential)) (newline)
+(display (rule-letrec-group-is-visible)) (newline)
+
+(if (and (= (shape-lambda-test 3) 176)
+         (= (shape-no-lambda 3) 176)
+         (= (shape-init-self-shadow 3) 176)
+         (= (control-renamed-inner 3) 176)
+         (= (control-single-level 3) 22)
+         (= (rule-let-star-inits-are-sequential) 33)
+         (= (rule-letrec-group-is-visible) 15))
+    (begin (display "PASS: named let shadowed parameter scope") (newline))
+    (begin (display "FAIL: named let shadowed parameter scope") (newline)
+           (exit 1)))


### PR DESCRIPTION
## The defect

A named-let parameter was reported `Undefined variable` on legal code when it was referenced inside a **nested named let** whose binding form contained a further named let that rebound the same name:

```scheme
(let dfs ((e 0) (acc 1)) ...
  (let try ((a 0)) ...
    (let* ((acc1 (* acc 2))
           (acc2 (let loop ((k 0) (acc acc1)) ...)))
      (dfs (+ e 1) acc2)) ...))
```

Compilation stopped at the reference `(* acc 2)` and no artifact was written. Renaming the inner loop's variable compiled; removing the intermediate named let compiled; a plain `let` failed the same way at the init `(acc (* acc 2))`, which R7RS 4.2.4 evaluates in the enclosing scope.

## Root cause

`findFreeVariablesImpl` computed the capture list for a binding form by walking its inits and body with the **enclosing** bound set, then erasing every name the form bound from the whole free-variable vector. That erase is not scoped to the form: it also deleted a capture a sibling sub-expression, walked earlier, had legitimately recorded. The inner `(let loop ((k 0) (acc acc1)) ...)` erased the `acc` that the preceding init `(* acc 2)` had correctly recorded, `acc` fell out of the intermediate named let's capture list, no capture parameter was emitted, and `codegenVariable` fell through to the undefined-variable diagnostic. The intermediate named let is what makes the shape reachable — without it the reference resolves against the enclosing function's own parameter and no capture is involved.

## The fix

Carry a per-scope bound set instead of subtracting after the fact. A form's names are pushed onto `bound_vars` for the walk of the scope they actually cover, so an inner rebinding is invisible outside the inner form and no other subtree's capture can be collaterally deleted. Each form's scoping rule is now explicit:

- `let` and named `let` — inits walked in the enclosing scope (R7RS 4.2.2 / 4.2.4); body with the bound names, plus the loop name for a named let
- `let*` — init `i` walked with bindings `0..i-1` bound
- `letrec` / `letrec*` — every init and the body see the whole group

No name is special-cased.

## Engines

| engine | before | after |
|---|---|---|
| JIT (`eshkol-run -r`) | `Undefined variable: acc`, 3 of 6 probes | 6 of 6 correct |
| AOT (`eshkol-run -o`) | same failure, same 3 probes | 6 of 6 correct |
| bytecode VM | already correct on all 6 | unchanged |

The VM's per-form scope handling was the reference; both native lanes now agree with it on every probe.

## Tests

- `tests/regression/named_let_shadowed_parameter_scope_test.esk` — the three failing shapes (lambda in the test, no lambda, and the outer name read from inside the inner named let's own init), the three controls that always compiled, and the three binding-form scope rules across a closure boundary. Wired for JIT and AOT.
- `tests/vm_parity/corpus/82_named_let_shadowed_parameter_scope.esk` — the same program on the VM lane, wired for both the source and the `.eskb` path.

## Verification

- `ctest -R "named_let_shadowed"` — 4/4 pass
- `ctest -R "let|scope|closure|named|vm_parity"` — 16/16 pass
- `./scripts/run_all_tests.sh` — 46/46 suites, 848/848 individual tests, 0 failures
- `python3 scripts/check_wasm_imports.py --build-dir build` — OK
- `python3 scripts/gen_language_surface.py --check` — OK
- `python3 scripts/check_ledger_integrity.py` — OK

## Note

Ledger entry `LE-20` is filed on a separate open branch, so this PR references it rather than duplicating the id; its status should move to resolved when that entry lands.

Separately observed while writing the scope-rule tests, **not** addressed here: both engines bind plain `let` **sequentially** (a later init sees an earlier binding of the same group), so `(let ((v 10)) (let ((v (+ v 1)) (w (* v 2))) (+ v w)))` yields `33` where R7RS 4.2.2 gives `31`. The two engines agree, so it is not a parity break, and it is out of scope for this fix — worth a ledger entry of its own.