### PR TITLE
test(smoke): the VM large-procedure probe counts the descriptive PASS lines the regression test prints

### DIFF
--- a/scripts/run_icc_smoke.sh
+++ b/scripts/run_icc_smoke.sh
@@ -863,7 +863,7 @@ probe eshkol-vm-large-proc 'a VM procedure calling 32 and 33 distinct top-level 
      vm="$BUILD_DIR_PATH/eshkol-vm-standalone-test";
      [ -x "$vm" ] || exit 1;
      out=$(ESHKOL_VM_NO_DISASM=1 "$vm" tests/vm/closure_upvalue_capacity_surface_regression.esk 2>&1) || exit 1;
-     [ "$(printf "%s" "$out" | grep -c "^PASS$")" -eq 3 ] || exit 1;
+     [ "$(printf "%s" "$out" | grep -c "^PASS")" -eq 3 ] || exit 1;
      printf "%s" "$out" | grep -q "^FAIL$" && exit 1;
      printf "%s" "$out" | grep -q "ERROR:" && exit 1;
      bash tests/closures/closure_upvalue_capacity_overflow_gate.sh "$ESHKOL_RUN" "$vm" "$(mktemp -d)" >/dev/null 2>&1 || exit 1;


### PR DESCRIPTION
The closure upvalue capacity regression test prints three descriptive PASS lines; the smoke probe still counted bare PASS lines and reported the probe red on a passing test. The probe now counts lines beginning with PASS, which is what the test emits.