### PR TITLE
ci(disclosure): allowlist the Glorot initializer names, which are public ML vocabulary

### DIFF
--- a/scripts/disclosure_allow.txt
+++ b/scripts/disclosure_allow.txt
@@ -33,3 +33,9 @@ rng-uniform!
 Jetson Xavier
 xavier-normal!
 xavier-uniform!
+
+# Glorot ("Xavier") weight initialization: standard ML vocabulary, public builtin names and their codegen methods.
+xavier-uniform!
+xavier-normal!
+xavierUniform
+xavierNormal


### PR DESCRIPTION
The disclosure gate's private layer flags the public builtins xavier-uniform! and xavier-normal! and their codegen methods. Glorot initialization is standard machine-learning vocabulary and these names are part of the documented language surface, so the allowlist now carries the four phrases; the gate keeps failing on any hit outside them.