### PR TITLE
One canonical wrong-arity diagnostic and one arity fact across native and VM

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -6,6 +6,21 @@
 
 ## Resolved in v1.3.5-evolve
 
+- **A wrong-arity call to a builtin is refused with the same sentence on every
+  engine.** Both the native LLVM backend and the bytecode VM already *refused*
+  a call like `(ceiling)`; they just said so differently. The VM printed
+  `Arity mismatch: ceiling expects 1 argument but got 0`, while native lowering
+  printed `ceil requires exactly 1 argument` — naming the LLVM intrinsic rather
+  than the procedure, and announcing no contract at all — one of roughly two
+  hundred private per-lowering sentences. The class marker and the canonical
+  wording now live in one place
+  (`inc/eshkol/core/arity_contract.h`) that both engines render, and the arity
+  NUMBER comes from the one table both engines already consulted
+  (`BUILTINS[]`), instead of a second hand-maintained copy inside
+  `llvm_codegen.cpp`. The P8 axis-3 ratchet had been reporting `ceiling`,
+  `char->integer`, `exact->inexact`, `numerator` and `tanh` as native-vs-VM
+  divergences purely on the strength of that wording.
+
 - **Resident-loop retention with persistent mutation.** A tail-recursive loop
   that mutates persistent state (a knowledge base, workspace, or growing list)
   on every iteration used to get no automatic per-iteration reclamation and
@@ -330,6 +345,22 @@ v1.3.4-evolve correctness wave are tracked as build items for v1.3.5. None
 block ordinary use.
 
 **Found during the v1.3.4-evolve correctness wave (new, honest knowns)**
+
+- **The bytecode VM refuses some legal short calls that native accepts.**
+  `(make-string 3)`, `(append)`, `(append lst)`, `(substring s 1)`,
+  `(string-pad-left s n)`, `(string-index-of s c)` and `(read-line)` compile and
+  run on native and are refused by the VM with
+  `Arity mismatch: … expects N arguments but got M`. The cause is structural:
+  the `arity` column of `BUILTINS[]` is the **opcode's operand count**, not the
+  caller's obligation, and the VM's under-arity check falls back to it whenever
+  a row leaves `min_arity` unset — which is nearly every row. The `min_arity`
+  column exists for exactly this (`hash-ref` uses it) but has only been filled
+  in where someone noticed. Giving the table a real caller-minimum column is
+  the fix and is tracked as a build item; until then the native engine
+  deliberately does **not** import the same rule (see
+  [VM_PARITY.md](VM_PARITY.md)), because doing so would spread the defect
+  rather than close it. The P8 axis-3 sweep does not see this class: it only
+  ever shortens a call by one argument from the table's own number.
 
 - **The two forward AD carriers now compose (fixed, ESH-0402).** Eshkol carries
   forward-mode derivatives in two representations — the 8-jet (`derivative`,

--- a/docs/VM_PARITY.md
+++ b/docs/VM_PARITY.md
@@ -28,6 +28,43 @@ to miss.
   refusal are both `FATAL:arity`; neither is allowed to become a value or a
   swallowed `ERR`. Timeouts remain explicitly unmeasured and cannot erase a
   prior baseline entry.
+- **One canonical arity diagnostic, one arity fact.** `FATAL:arity` above is a
+  claim about the text an engine prints, so the text has a single source:
+  `inc/eshkol/core/arity_contract.h` owns the class marker
+  (`Arity mismatch: `) and the canonical sentence
+  (`<procedure> expects N argument(s) but got M`). The bytecode VM's compiler
+  renders it, the LLVM backend renders it, and
+  `eshkol_arity_error_current()` prepends the marker to the ~200 lowering
+  guards that have something more specific to say
+  (`string->utf8 requires 1 to 3 arguments`). Native lowering used to answer
+  `(ceiling)` with `ceil requires exactly 1 argument` — the LLVM intrinsic's
+  name, no contract named — so the ratchet could not tell that both engines
+  had refused the call, and `ceiling`, `char->integer`, `exact->inexact`,
+  `numerator` and `tanh` read as native-vs-VM divergences over behaviour that
+  was already identical.
+
+  The *number* is single-sourced too. `BUILTINS[]` in
+  `lib/backend/eshkol_vm.c` is the one arity table — it is also what
+  `scripts/gen_language_surface.py` turns into
+  `tests/coverage/language_surface.json` — and both engines read it through
+  `eshkol_builtin_min_arity()`. `llvm_codegen.cpp` no longer transcribes those
+  numbers into a map of its own; it names only the builtins whose lowering has
+  no arity guard, and `scripts/check_builtin_min_arity.py` fails the build if
+  one of those names stops being backed by the table.
+
+  That scope is a subset of the table on purpose. `arity` in `BUILTINS[]` is
+  the OPCODE'S OPERAND COUNT, not the caller's obligation, and the VM applies
+  it only where the call actually reaches the raw op: a name the VM compiler
+  special-cases (`make-vector`, `round`, `string->utf8`) or that the Scheme
+  prelude rebinds (`append`) never does. Applying the row to every name on
+  native would refuse `(make-vector 3)`, `(substring s 1)` and `(append)` —
+  legal calls the VM accepts — i.e. it would manufacture divergence. Widening
+  the scope requires giving the table a real caller-minimum column first; that
+  is a tracked build item, not a line to delete. The same gap is why the VM
+  currently refuses `(make-string 3)`, `(append)`, `(substring s 1)`,
+  `(string-pad-left s n)` and `(read-line)` while native accepts them — a
+  pre-existing divergence in the opposite direction, unaffected by the arity
+  probes because they only ever shorten a call by one argument.
 - **Canonical gap evidence (PR-05).** Every `gap` row in `PARITY.tsv` has a
   matching row in `tests/vm_parity/GAP_DISPOSITIONS.tsv`. The sidecar records
   an explicit disposition, a live `found/` reproducer when one exists, or the

--- a/inc/eshkol/core/arity_contract.h
+++ b/inc/eshkol/core/arity_contract.h
@@ -1,0 +1,93 @@
+/**
+ * @file arity_contract.h
+ * @brief The one wording every engine uses to refuse a wrong-arity call.
+ *
+ * WHY THIS EXISTS. A wrong-arity call to a builtin must be refused the same
+ * way on every engine — that is the P8 axis-3 contract
+ * (scripts/p8/p8_arity_sweep.py, diagnostic_class()), and the escape it closes
+ * is a call that one engine rejects while the other quietly executes it.
+ *
+ * Refusing was not enough. Both engines already refused `(ceiling)`, but the
+ * bytecode VM said "Arity mismatch: ceiling expects 1 argument but got 0"
+ * while native lowering said "ceil requires exactly 1 argument" — a private
+ * per-handler sentence, one of ~200 spread across the backend, naming the
+ * LLVM intrinsic rather than the procedure the programmer wrote. A reader
+ * (and the parity ratchet) could not tell that the two engines had reached
+ * the same verdict, so five builtins reported as native-vs-VM divergences
+ * when their behaviour was in fact identical.
+ *
+ * So the CLASS MARKER lives here, in one place, and every arity refusal on
+ * every engine carries it:
+ *
+ *     Arity mismatch: <detail>
+ *
+ * eshkol_format_arity_mismatch() renders the canonical detail for the common
+ * case (a fixed minimum the caller undershot). A backend guard with something
+ * more specific to say (`1 to 3 arguments`, `at least 2`) keeps its own
+ * sentence and still gets the marker, because eshkol_arity_error_current()
+ * prepends it centrally — see lib/core/logger.cpp.
+ *
+ * Header-only on purpose: lib/backend/eshkol_vm.c is compiled standalone for
+ * the hosted-VM test binary and for the WASM lane, so the shared wording must
+ * cost no link-time dependency.
+ */
+#ifndef ESHKOL_CORE_ARITY_CONTRACT_H
+#define ESHKOL_CORE_ARITY_CONTRACT_H
+
+#include <stdio.h>
+
+/** The canonical class marker. Anything an engine prints to refuse a call for
+ *  argument-count reasons starts with this, and nothing else does. */
+#define ESHKOL_ARITY_MISMATCH_PREFIX "Arity mismatch: "
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Render the canonical wrong-arity diagnostic into @p buf.
+ * @param buf      Destination buffer.
+ * @param buf_size Its size in bytes.
+ * @param name     The PUBLIC procedure name the programmer wrote — never the
+ *                 internal lowering or intrinsic spelling.
+ * @param expected The minimum number of arguments the callee requires.
+ * @param got      The number the call supplied.
+ * @return The snprintf() return value.
+ */
+static inline int eshkol_format_arity_mismatch(char* buf, size_t buf_size,
+                                               const char* name,
+                                               int expected, long long got) {
+    return snprintf(buf, buf_size,
+                    ESHKOL_ARITY_MISMATCH_PREFIX
+                    "%s expects %d argument%s but got %lld",
+                    name ? name : "<procedure>", expected,
+                    expected == 1 ? "" : "s", got);
+}
+
+/**
+ * @brief The minimum number of arguments a BUILTIN requires — the ONE arity
+ *        fact both engines consult.
+ *
+ * Implemented over BUILTINS[] in lib/backend/eshkol_vm.c, which is also what
+ * scripts/gen_language_surface.py turns into
+ * tests/coverage/language_surface.json. The native LLVM backend and the
+ * bytecode VM compiler both call this rather than keeping their own copy, so
+ * neither can drift into refusing a call the other accepts.
+ *
+ * @param name Public procedure name.
+ * @return The minimum argument count, or -1 when the table makes no claim:
+ *         an unregistered name, or a row the table declares variadic in the
+ *         native lowering (`gcd`, `lcm`), where there is no minimum to
+ *         enforce and a refusal would reject a legal call.
+ *
+ * @note Native Windows builds have no bytecode VM (lib/backend/eshkol_vm_stub.c)
+ *       and therefore no parity obligation; the stub answers -1 and the
+ *       backend's own per-lowering guards remain the only refusal there.
+ */
+int eshkol_builtin_min_arity(const char* name);
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
+#endif /* ESHKOL_CORE_ARITY_CONTRACT_H */

--- a/inc/eshkol/logger.h
+++ b/inc/eshkol/logger.h
@@ -310,6 +310,22 @@ void eshkol_set_diagnostic_source_location(const char* file,
 void eshkol_arity_error_current(const char* msg, ...);
 
 /**
+ * @brief Emit the CANONICAL wrong-arity diagnostic for @p name at the current
+ *        AST span.
+ *
+ * The wording lives in eshkol_format_arity_mismatch()
+ * (<eshkol/core/arity_contract.h>), which the bytecode VM's compiler uses too,
+ * so both engines refuse a short call with byte-identical text apart from the
+ * source span. Pass the PUBLIC procedure name — the spelling the programmer
+ * wrote — not the intrinsic a lowering happens to share.
+ *
+ * @param name     Public procedure name.
+ * @param expected Minimum argument count the callee requires.
+ * @param got      Argument count the call supplied.
+ */
+void eshkol_arity_error_named(const char* name, int expected, long long got);
+
+/**
  * @brief Convenience macros wrapping eshkol_printf() for each severity
  *        level; each forwards its arguments as a printf-style format
  *        string and varargs (e.g. eshkol_error("failed: %d", code)).

--- a/lib/backend/eshkol_vm.c
+++ b/lib/backend/eshkol_vm.c
@@ -85,6 +85,7 @@
 #endif
 #endif
 
+#include "eshkol/core/arity_contract.h"
 #include "eshkol/backend/vm_limits.h"
 #include "eshkol/core/resource_limits.h"
 #include "eshkol/core/unicode.h"
@@ -960,6 +961,21 @@ static const BuiltinDef BUILTINS[] = {
     {NULL, 0, 0}
 };
 
+/* The caller obligation carried by ONE BuiltinDef row, in one place.
+ *
+ * `arity` is the opcode's operand SHAPE; `min_arity` overrides it when the row
+ * shares a longer sibling's opcode (0 = unset, so the minimum IS `arity`) and
+ * declares the row variadic when negative. Every engine's wrong-arity refusal
+ * derives from this function, so none of them can invent a second reading of
+ * the same row. */
+static int vm_builtin_row_min_arity(const BuiltinDef* def) {
+    int declared_min = def->min_arity;
+    if (declared_min < 0) return -1;   /* variadic in native — no claim to make */
+    return declared_min ? declared_min : def->arity;
+}
+
+static int vm_builtin_count(void);
+
 /**
  * @brief Declared arity of the raw BUILTINS[] op bound at top-level local
  *        @p local_index under @p name, or -1 when that local is not a
@@ -989,11 +1005,7 @@ static const BuiltinDef BUILTINS[] = {
  * a lambda parameter all shadow by resolving somewhere else.
  */
 static int vm_builtin_arity_at_index(int local_index, const char* name) {
-    static int n_builtins = -1;
-    if (n_builtins < 0) {
-        n_builtins = 0;
-        while (BUILTINS[n_builtins].name) n_builtins++;
-    }
+    int n_builtins = vm_builtin_count();
     if (local_index < 0 || local_index >= n_builtins || !name || !*name) return -1;
     if (strcmp(BUILTINS[local_index].name, name) != 0) return -1;
     /* The MINIMUM, not the opcode's operand count: a builtin that shares a
@@ -1001,9 +1013,32 @@ static int vm_builtin_arity_at_index(int local_index, const char* name) {
      * there means the two are the same. Refusing on the operand count would
      * reject `(hash-ref table key)`, which is the documented two-argument
      * form. */
-    int declared_min = BUILTINS[local_index].min_arity;
-    if (declared_min < 0) return -1;   /* variadic in native — no claim to make */
-    return declared_min ? declared_min : BUILTINS[local_index].arity;
+    return vm_builtin_row_min_arity(&BUILTINS[local_index]);
+}
+
+/* THE SHARED ARITY FACT — see inc/eshkol/core/arity_contract.h.
+ *
+ * BUILTINS[] is the single source: scripts/gen_language_surface.py GENERATES
+ * tests/coverage/language_surface.json from it, and
+ * scripts/check_builtin_min_arity.py fails the build when the two drift. The
+ * native LLVM backend used to keep a SECOND, hand-maintained copy of the same
+ * fact — a 34-name `fixed_arity` map in lib/backend/llvm_codegen.cpp — which
+ * covered a hand-picked subset and could not be kept in step with this table
+ * by anything but vigilance. It consults this function instead, so a builtin
+ * cannot be fixed-arity on one engine and something else on the other.
+ *
+ * Returns the minimum argument count the named builtin requires, or -1 when
+ * the table makes NO claim: an unknown name, or a row declared variadic in the
+ * native lowering (`gcd`, `lcm`).
+ */
+int eshkol_builtin_min_arity(const char* name) {
+    if (!name || !*name) return -1;
+    int n_builtins = vm_builtin_count();
+    for (int i = 0; i < n_builtins; i++) {
+        if (strcmp(BUILTINS[i].name, name) == 0)
+            return vm_builtin_row_min_arity(&BUILTINS[i]);
+    }
+    return -1;
 }
 
 static int vm_language_coverage_compilation_enabled(void) {

--- a/lib/backend/eshkol_vm_stub.c
+++ b/lib/backend/eshkol_vm_stub.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 
 #include "eshkol/backend/vm.h"
+#include "eshkol/core/arity_contract.h"
 
 int eshkol_vm_get_profile_limits(EshkolVmProfileLimits* out) {
     if (!out) return -1;
@@ -126,5 +127,14 @@ void eshkol_vm_destroy(EshkolVmHandle* h) {
 int eshkol_vm_top_int64(EshkolVmHandle* h, int64_t* out) {
     (void)h;
     (void)out;
+    return -1;
+}
+
+/* No bytecode VM on this platform means no BUILTINS[] table to read and no
+ * native-vs-VM parity claim to keep, so the shared arity fact makes no claim
+ * either. The LLVM backend's own per-lowering guards still refuse malformed
+ * calls here; they simply are not cross-checked against a second engine. */
+int eshkol_builtin_min_arity(const char* name) {
+    (void)name;
     return -1;
 }

--- a/lib/backend/llvm_codegen.cpp
+++ b/lib/backend/llvm_codegen.cpp
@@ -47,6 +47,7 @@
 #include <eshkol/frontend/macro_expander.h>
 #include <eshkol/build_config.h>
 #include <eshkol/logger.h>
+#include <eshkol/core/arity_contract.h>
 #include <eshkol/platform_runtime.h>
 #include <eshkol/runtime_exports.h>
 #include <eshkol/core/runtime.h>
@@ -13483,67 +13484,88 @@ private:
             }
         }
 
-        // PR-03: direct builtin lowering must enforce the same fixed arity as
-        // the first-class builtin closure and the VM preamble. Several unary
-        // predicates and the comparison/collection fast paths used to index
-        // variables[0] (or silently ignore surplus variables) without a
-        // common check. That made native JIT and native AOT disagree with the
-        // VM's observable contract. Keep this table limited to fixed-arity
-        // direct handlers; variadic arithmetic and special forms validate in
-        // their own lowering paths.
+        // THE ARITY NUMBER COMES FROM ONE TABLE. THIS SITE ONLY SAYS WHERE
+        // TO APPLY IT.
+        //
+        // PR-03 gave this dispatch a `fixed_arity` map so direct builtin
+        // lowering would refuse a wrong-arity call the way the first-class
+        // builtin closure and the VM preamble do: several unary predicates and
+        // the comparison/collection fast paths indexed variables[0] with no
+        // check at all. That map ALSO transcribed each builtin's arity — a
+        // second, hand-maintained copy of a fact that already lives in
+        // BUILTINS[] (lib/backend/eshkol_vm.c), which is what the VM enforces
+        // and what scripts/gen_language_surface.py turns into the documented
+        // language surface. Two copies of one number, kept in step by nothing
+        // but vigilance.
+        //
+        // The numbers are gone. eshkol_builtin_min_arity() reads the same row
+        // vm_builtin_arity_at_index() reads, with the same interpretation of
+        // min_arity and the same -1 for a row that makes no claim, so the two
+        // engines cannot disagree about how many arguments a builtin needs.
+        // scripts/check_builtin_min_arity.py fails the build if a name listed
+        // below stops being backed by that table.
+        //
+        // WHY THIS IS A NAMED SUBSET RATHER THAN EVERY BUILTIN. The table's
+        // `arity` is the OPCODE'S OPERAND COUNT, not the caller's obligation,
+        // and the VM's own refusal is scoped accordingly: a name the VM
+        // compiler special-cases (`make-vector`, `round`, `string->utf8`) or
+        // that the Scheme prelude rebinds (`append`) never reaches the raw op,
+        // so the VM never applies the row to it. Applying the row to every
+        // name here would refuse `(make-vector 3)`, `(substring s 1)` and
+        // `(append)` on native — all legal, all accepted by the VM — i.e. it
+        // would MANUFACTURE divergence rather than remove it. The subset is
+        // exactly the builtins whose lowering has no arity guard of its own
+        // and whose row is the public procedure. Widening it means giving the
+        // table a real caller-minimum column first (tracked build item), not
+        // deleting these lines.
         {
             // R7RS 6.2.6 makes the order predicates VARIADIC with a minimum of
             // two: `(<= 1 2 2 3 3)` is legal and codegenComparison lowers it as
-            // the chain `(and (<= x1 x2) (<= x2 x3) …)`. Enforcing "exactly 2"
-            // here made that lowering unreachable and refused a documented-legal
-            // call at compile time. A minimum is a different obligation from a
-            // fixed operand count and is checked separately.
-            static const std::unordered_map<std::string, unsigned> minimum_arity = {
-                {"<", 2}, {">", 2}, {"<=", 2}, {">=", 2}, {"=", 2},
+            // the chain `(and (<= x1 x2) (<= x2 x3) …)`. Enforcing the operand
+            // count as an exact arity made that lowering unreachable and
+            // refused a documented-legal call at compile time. A minimum is a
+            // different obligation from a fixed operand count.
+            static const std::unordered_set<std::string> minimum_arity_builtins = {
+                "<", ">", "<=", ">=", "=",
             };
-            auto min_it = minimum_arity.find(func_name);
-            if (min_it != minimum_arity.end() &&
-                op->call_op.num_vars < min_it->second) {
-                eshkol_error_at(
-                    g_source_filepath.empty() ? nullptr : g_source_filepath.c_str(),
-                    current_source_line, current_source_column,
-                    g_source_text.empty() ? nullptr : g_source_text.c_str(),
-                    "Arity mismatch: %s requires at least %u argument%s but got %llu",
-                    func_name.c_str(), min_it->second,
-                    min_it->second == 1 ? "" : "s",
-                    (unsigned long long)op->call_op.num_vars);
-                markFatalCodegenError();
-                co_return nullptr;
-            }
-
-            static const std::unordered_map<std::string, unsigned> fixed_arity = {
-                {"bytevector-length", 1}, {"bytevector-u8-ref", 2},
-                {"bytevector-u8-set!", 3}, {"bytevector?", 1},
-                {"hash-values", 1}, {"hash-keys", 1},
-                {"hash-table-clear!", 1}, {"hash-table-keys", 1},
-                {"hash-table-values", 1}, {"rational?", 1},
-                {"number?", 1}, {"integer?", 1}, {"real?", 1},
-                {"exact?", 1}, {"inexact?", 1}, {"exact-integer?", 1},
-                {"boolean?", 1}, {"char?", 1}, {"string?", 1},
-                {"symbol?", 1}, {"pair?", 1}, {"list?", 1},
-                {"vector?", 1}, {"procedure?", 1}, {"null?", 1},
-                {"finite?", 1}, {"infinite?", 1}, {"nan?", 1},
-                {"zero?", 1}, {"positive?", 1}, {"negative?", 1},
-                {"even?", 1}, {"odd?", 1}, {"not", 1},
+            static const std::unordered_set<std::string> fixed_arity_builtins = {
+                "bytevector-length", "bytevector-u8-ref",
+                "bytevector-u8-set!", "bytevector?",
+                "hash-values", "hash-keys",
+                "hash-table-clear!", "hash-table-keys",
+                "hash-table-values", "rational?",
+                "number?", "integer?", "real?",
+                "exact?", "inexact?",
+                "boolean?", "char?", "string?",
+                "symbol?", "pair?", "list?",
+                "vector?", "procedure?", "null?",
+                "finite?", "infinite?", "nan?",
+                "zero?", "positive?", "negative?",
+                "even?", "odd?", "not",
             };
-            auto arity_it = fixed_arity.find(func_name);
-            if (arity_it != fixed_arity.end() &&
-                op->call_op.num_vars != arity_it->second) {
-                eshkol_error_at(
-                    g_source_filepath.empty() ? nullptr : g_source_filepath.c_str(),
-                    current_source_line, current_source_column,
-                    g_source_text.empty() ? nullptr : g_source_text.c_str(),
-                    "Arity mismatch: %s requires exactly %u argument%s but got %llu",
-                    func_name.c_str(), arity_it->second,
-                    arity_it->second == 1 ? "" : "s",
-                    (unsigned long long)op->call_op.num_vars);
-                markFatalCodegenError();
-                co_return nullptr;
+            const bool is_minimum = minimum_arity_builtins.count(func_name) != 0;
+            const bool is_fixed = fixed_arity_builtins.count(func_name) != 0;
+            if (is_minimum || is_fixed) {
+                // Every name above has a BUILTINS[] row —
+                // scripts/check_builtin_min_arity.py fails the build if one
+                // stops having it, so a -1 here cannot go unnoticed. A
+                // native-only builtin with no row (exact-integer?) guards
+                // itself at its own lowering, with the same canonical wording.
+                const int shared_arity = eshkol_builtin_min_arity(func_name.c_str());
+                const long long got = (long long)op->call_op.num_vars;
+                const bool too_short = shared_arity > 0 && got < (long long)shared_arity;
+                const bool wrong_count =
+                    is_fixed && shared_arity > 0 && got != (long long)shared_arity;
+                if (too_short || wrong_count) {
+                    // The canonical wording — the same sentence the VM
+                    // compiler renders for the same refusal, from the same
+                    // formatter in <eshkol/core/arity_contract.h>. The span is
+                    // already published by
+                    // CodegenContext::setCurrentSourceLocation().
+                    eshkol_arity_error_named(func_name.c_str(), shared_arity, got);
+                    markFatalCodegenError();
+                    co_return nullptr;
+                }
             }
         }
 
@@ -14386,6 +14408,18 @@ private:
         }
         // R7RS exact-integer?: true if exact and integer (int64 or bignum)
         if (func_name == "exact-integer?") {
+            // Guarded here rather than by the shared-table check above:
+            // exact-integer? is a NATIVE-ONLY predicate with no BUILTINS[]
+            // row (the language surface records it with backends
+            // ["native_llvm"] and arity None), so eshkol_builtin_min_arity()
+            // rightly makes no claim about it and there is no second engine to
+            // agree with. The refusal still carries the canonical wording.
+            if (op->call_op.num_vars != 1) {
+                eshkol_arity_error_named(func_name.c_str(), 1,
+                                         (long long)op->call_op.num_vars);
+                markFatalCodegenError();
+                co_return nullptr;
+            }
             TypedValue tv = (co_await codegenTypedASTTask(&op->call_op.variables[0]));
             if (!tv.llvm_value) co_return nullptr;
             Value* arg = typedValueToTaggedValue(tv);
@@ -20328,9 +20362,29 @@ private:
     }
     
     
+    /** The spelling the PROGRAMMER wrote for this call, for diagnostics.
+     *
+     *  Lowering names and public names are not the same word: `(ceiling)` is
+     *  lowered by codegenMathFunction(op, "ceil") and `(truncate)` by
+     *  codegenMathFunction(op, "trunc"). Reporting the lowering name told the
+     *  reader about an intrinsic they never wrote. Falls back to the lowering
+     *  name for a synthesized call with no variable callee. */
+    static std::string publicCalleeName(const eshkol_operations_t* op,
+                                        const std::string& lowering_name) {
+        if (op && op->call_op.func && op->call_op.func->type == ESHKOL_VAR &&
+            op->call_op.func->variable.id && *op->call_op.func->variable.id) {
+            return std::string(op->call_op.func->variable.id);
+        }
+        return lowering_name;
+    }
+
     Value* codegenMathFunction(const eshkol_operations_t* op, const std::string& func_name) {
         if (op->call_op.num_vars != 1) {
-            eshkol_arity_error_current("%s requires exactly 1 argument", func_name.c_str());
+            // Name the procedure, not the intrinsic: `(ceiling)` must say
+            // "ceiling", the same word the bytecode VM's refusal uses, or the
+            // two engines' diagnostics cannot be read as the same verdict.
+            eshkol_arity_error_named(publicCalleeName(op, func_name).c_str(), 1,
+                                     (long long)op->call_op.num_vars);
             return nullptr;
         }
 

--- a/lib/backend/vm_compiler.c
+++ b/lib/backend/vm_compiler.c
@@ -6047,11 +6047,14 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
              * them; refusing the call here would break working programs
              * instead of closing it. */
             if (decl_arity >= 0 && argc < decl_arity) {
+                /* The wording is the SHARED one (arity_contract.h), not a
+                 * private snprintf: native lowering renders the same sentence
+                 * for the same refusal, which is what lets the P8 axis-3
+                 * ratchet see the two engines agree instead of reading two
+                 * unrelated fatals. */
                 char arity_msg[192];
-                snprintf(arity_msg, sizeof(arity_msg),
-                         "Arity mismatch: %s expects %d argument%s but got %d",
-                         head->symbol, decl_arity, decl_arity == 1 ? "" : "s",
-                         argc);
+                eshkol_format_arity_mismatch(arity_msg, sizeof(arity_msg),
+                                             head->symbol, decl_arity, argc);
                 vm_compile_error(arity_msg, NULL);
             }
         }

--- a/lib/core/logger.cpp
+++ b/lib/core/logger.cpp
@@ -8,6 +8,7 @@
  * Supports TEXT (human-readable) and JSON (structured) output formats.
  */
 #include <eshkol/logger.h>
+#include <eshkol/core/arity_contract.h>
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -785,11 +786,42 @@ void eshkol_arity_error_current(const char* msg, ...) {
     vsnprintf(rendered, sizeof(rendered), msg, ap);
     va_end(ap);
 
+    /* THE CLASS MARKER IS ADDED HERE, ONCE, FOR EVERY ARITY GUARD.
+     *
+     * Roughly two hundred backend lowerings call this function, each with its
+     * own sentence ("ceil requires exactly 1 argument", "string->utf8
+     * requires 1 to 3 arguments"). Those sentences carry real information and
+     * are worth keeping, but none of them announced WHICH CONTRACT had been
+     * violated, so a reader — and the P8 axis-3 parity ratchet — could not
+     * tell a native arity refusal apart from any other fatal. The bytecode VM
+     * did announce it, so the two engines read as disagreeing about builtins
+     * they both, in fact, refused.
+     *
+     * Prefixing centrally is what makes the class canonical without editing
+     * two hundred call sites into a single phrasing they do not all fit. A
+     * message that already carries the marker (the shared formatter in
+     * <eshkol/core/arity_contract.h>, or a guard that renders it itself) is
+     * passed through untouched, so the marker never doubles. */
+    const size_t marker_len = sizeof(ESHKOL_ARITY_MISMATCH_PREFIX) - 1;
+    const char* body = rendered;
+    char canonical[2048 + sizeof(ESHKOL_ARITY_MISMATCH_PREFIX)];
+    if (strncmp(rendered, ESHKOL_ARITY_MISMATCH_PREFIX, marker_len) != 0) {
+        snprintf(canonical, sizeof(canonical), "%s%s",
+                 ESHKOL_ARITY_MISMATCH_PREFIX, rendered);
+        body = canonical;
+    }
+
     eshkol_error_at(g_diagnostic_source_file.empty()
                         ? nullptr : g_diagnostic_source_file.c_str(),
                     g_diagnostic_source_line,
                     g_diagnostic_source_column,
-                    nullptr, "%s", rendered);
+                    nullptr, "%s", body);
+}
+
+void eshkol_arity_error_named(const char* name, int expected, long long got) {
+    char rendered[512];
+    eshkol_format_arity_mismatch(rendered, sizeof(rendered), name, expected, got);
+    eshkol_arity_error_current("%s", rendered);
 }
 
 } // extern "C"

--- a/scripts/check_builtin_min_arity.py
+++ b/scripts/check_builtin_min_arity.py
@@ -30,9 +30,18 @@ answer a zero-argument call (`num_vars == 0`) before folding over `num_vars` —
 which is what makes `(gcd)` and `(gcd 3)` legal on native. A pin nobody
 verifies is how the surface and the table drift apart in the first place.
 
+The LLVM backend used to carry its own transcription of the same numbers — a
+`fixed_arity` map in lib/backend/llvm_codegen.cpp listing 34 builtins and the
+arity each one takes. Two copies of one fact, kept in step by nothing but
+vigilance, is how the surfaces drift apart; the map now lists only WHICH names
+that dispatch checks and reads every number from BUILTINS[] at run time. This
+script closes the loop: each name the backend scopes must still be a row in
+BUILTINS[], or the check silently stops firing for it.
+
 Exit 0 iff no builtin refuses a documented-legal call, no unpinned
-permissiveness gap has appeared, and every variadic claim is borne out by its
-native handler.
+permissiveness gap has appeared, every variadic claim is borne out by its
+native handler, and every builtin the LLVM dispatch scopes is backed by the
+shared table.
 """
 
 import json
@@ -108,6 +117,25 @@ def variadic_handler_answers_zero_args(text, handler):
         i += 1
     body = text[m.end():i]
     return re.search(r"num_vars\s*==\s*0", body) is not None
+
+
+SCOPE_SET = re.compile(
+    r"static const std::unordered_set<std::string>\s+(minimum|fixed)_arity_builtins\s*=\s*\{(.*?)\};",
+    re.S)
+
+
+def llvm_scoped_builtins(text):
+    """Return {"minimum": {names}, "fixed": {names}} from llvm_codegen.cpp.
+
+    Reads the two scope sets the builtin dispatch declares. They carry NAMES
+    ONLY — the arity each one requires is read from BUILTINS[] at run time —
+    so this is the whole of what the backend still says about arity, and it is
+    what has to stay backed by the shared table.
+    """
+    found = {"minimum": set(), "fixed": set()}
+    for kind, body in SCOPE_SET.findall(text):
+        found[kind] = set(re.findall(r'"((?:[^"\\]|\\.)*)"', body))
+    return found
 
 
 def main():
@@ -199,6 +227,30 @@ def main():
                 f"so the VM must not stop refusing short calls to it."
             )
             rc = 1
+    # The LLVM dispatch names the builtins it checks; the ARITY comes from
+    # BUILTINS[] via eshkol_builtin_min_arity(). A scoped name with no row is a
+    # check that has quietly stopped firing.
+    table_names = {name for name, _arity, _minimum in entries}
+    for kind, scoped in sorted(llvm_scoped_builtins(llvm_text).items()):
+        if not scoped:
+            print(
+                f"FAIL: could not find the {kind}_arity_builtins set in "
+                f"{LLVM_CPP.name} — the LLVM dispatch's arity scope must stay "
+                f"readable from here, or nothing checks that it is backed by "
+                f"BUILTINS[]."
+            )
+            rc = 1
+            continue
+        for name in sorted(scoped - table_names):
+            print(
+                f"FAIL: {name} is in {LLVM_CPP.name}'s {kind}_arity_builtins but "
+                f"has no BUILTINS[] row — eshkol_builtin_min_arity() answers -1 "
+                f"for it, so the native arity check never fires. Add the row, "
+                f"or drop the name and guard the builtin at its own lowering "
+                f"the way exact-integer? does."
+            )
+            rc = 1
+
     for name in sorted(KNOWN_PERMISSIVE):
         entry = next((e for e in entries if e[0] == name), None)
         if entry is None:

--- a/tests/diagnostics/arity_canonical_marker_builtin/expected.json
+++ b/tests/diagnostics/arity_canonical_marker_builtin/expected.json
@@ -1,0 +1,10 @@
+{
+  "description": "A wrong-arity call to a BUILTIN is refused with the canonical class marker and the PUBLIC procedure name, byte-identical to the bytecode VM's refusal. Native lowering used to say 'ceil requires exactly 1 argument' — naming the LLVM intrinsic, announcing no contract — so the P8 axis-3 ratchet read two agreeing refusals as a native-vs-VM divergence (ceiling, char->integer, exact->inexact, numerator, tanh). The marker now comes from one place (inc/eshkol/core/arity_contract.h) on every engine.",
+  "compile": "fail",
+  "diagnostics": [
+    {
+      "contains": "Arity mismatch: ceiling expects 1 argument but got 0",
+      "span": {"file": "input.esk", "line": 10, "col": 11}
+    }
+  ]
+}

--- a/tests/diagnostics/arity_canonical_marker_builtin/input.esk
+++ b/tests/diagnostics/arity_canonical_marker_builtin/input.esk
@@ -1,0 +1,11 @@
+;; Diagnostic corpus case: the canonical wrong-arity class marker.
+;; A wrong-arity call to a BUILTIN must be refused with the same class
+;; marker on every engine — the bytecode VM already said
+;; "Arity mismatch: ceiling expects 1 argument but got 0" while native
+;; lowering said "ceil requires exactly 1 argument", naming the LLVM
+;; intrinsic and announcing no contract at all, so the P8 axis-3 parity
+;; ratchet read two agreeing refusals as a native-vs-VM divergence.
+;; See inc/eshkol/core/arity_contract.h.
+
+(display (ceiling))
+(newline)

--- a/tests/diagnostics/backend_arity_control/expected.json
+++ b/tests/diagnostics/backend_arity_control/expected.json
@@ -1,10 +1,14 @@
 {
-  "description": "Control-flow builtin arity failures carry the source span.",
+  "description": "Control-flow builtin arity failures carry the source span, the canonical class marker, and the public procedure name. The wording is the shared one (inc/eshkol/core/arity_contract.h) that the bytecode VM renders for the same refusal — it used to be a phrasing private to llvm_codegen.cpp's own arity map.",
   "compile": "fail",
   "diagnostics": [
     {
-      "contains": "not requires exactly 1 argument but got 2",
-      "span": {"file": "input.esk", "line": 2, "col": 2}
+      "contains": "Arity mismatch: not expects 1 argument but got 2",
+      "span": {
+        "file": "input.esk",
+        "line": 2,
+        "col": 2
+      }
     }
   ]
 }


### PR DESCRIPTION
## What P8 axis 3 was actually reporting

The escape-matrix arity sweep flagged five NEW native-vs-VM divergences against the committed baseline:

| probe | native (JIT & AOT) | hosted VM |
|---|---|---|
| `ceiling::warity` | `ceil requires exactly 1 argument` → `FATAL:fatal` | `Arity mismatch: ceiling expects 1 argument but got 0` → `FATAL:arity` |
| `char->integer::warity` | `char->integer requires exactly 1 argument` → `FATAL:fatal` | `Arity mismatch: …` → `FATAL:arity` |
| `exact->inexact::warity` | `exact->inexact requires exactly 1 argument` → `FATAL:fatal` | `Arity mismatch: …` → `FATAL:arity` |
| `numerator::warity` | `numerator requires exactly 1 argument` → `FATAL:fatal` | `Arity mismatch: …` → `FATAL:arity` |
| `tanh::warity` | `tanh requires exactly 1 argument` → `FATAL:fatal` | `Arity mismatch: …` → `FATAL:arity` |

**No behavioural divergence existed.** Both engines refused the short call, on all three routes (JIT, AOT, VM). They described the refusal differently, and `diagnostic_class()` in `scripts/p8/p8_arity_sweep.py` recognises only `arity mismatch` / `wrong number of arguments` — so two agreeing refusals were recorded as a parity gap. The native sentence also named the LLVM intrinsic (`ceil`) rather than the procedure the programmer wrote (`ceiling`).

### Root cause

Native had **no canonical arity refusal**. It has ~200 private per-lowering sentences plus one 34-name `fixed_arity` map added by PR-03 (`llvm_codegen.cpp`) that *did* render the canonical form. Whether a builtin's refusal was machine-recognisable therefore depended on whether someone had transcribed that builtin into the map. `3b7ae685` ("refuse wrong-arity calls to raw builtins") closed the value-vs-refusal gap for exactly these five and opened the wording gap; the sampled sweep saw the five, and the same defect covered every fixed-arity builtin outside the 34 (`floor`, `round`, `sin`, `inexact->exact`, … all diverge the same way, they simply are not in the seed-8803 sample of 30).

## The fix — nothing is special-cased by name

**One wording.** New `inc/eshkol/core/arity_contract.h` owns the class marker (`Arity mismatch: `) and the canonical sentence (`<procedure> expects N argument(s) but got M`). Header-only, so `eshkol_vm.c` still compiles standalone for the hosted-VM test binary and the WASM lane.

- `vm_compiler.c` renders it instead of its own `snprintf`.
- `llvm_codegen.cpp` renders it through the new `eshkol_arity_error_named()`.
- `eshkol_arity_error_current()` prepends the marker **centrally**, so all ~200 lowering guards announce the contract they enforce without being flattened into one phrasing they do not all fit (`string->utf8 requires 1 to 3 arguments` keeps its detail). A message already carrying the marker passes through untouched, so it never doubles. Every caller of that function was audited: all are arity guards.
- `codegenMathFunction` now reports the **public** callee spelling, so `(ceiling)` says `ceiling`, not `ceil`.

**One number.** `BUILTINS[]` in `lib/backend/eshkol_vm.c` is the single arity table — it is also what `gen_language_surface.py` turns into `tests/coverage/language_surface.json`. Both engines now read it through the new `eshkol_builtin_min_arity()`, which shares its row→minimum derivation with `vm_builtin_arity_at_index()`. `llvm_codegen.cpp`'s map keeps only the **names** it checks; every arity number it used to carry is deleted. `scripts/check_builtin_min_arity.py` now fails the build if one of those names stops being backed by the table, so the second copy cannot silently reappear. (Windows has no bytecode VM; `eshkol_vm_stub.c` answers −1 and the per-lowering guards remain, which is honest — there is no second engine there to agree with.)

## Why the native check stays a named subset of the table

This was measured, not assumed. `arity` in `BUILTINS[]` is the **opcode's operand count**, not the caller's obligation, and the VM applies it only where a call actually reaches the raw op — a name the VM compiler special-cases (`make-vector`, `round`, `string->utf8`) or that the prelude rebinds (`append`) never does. Applying the row to every name on native refuses:

```
(make-vector 3)  (make-string 3)  (append)  (append lst)
(substring "hello" 1)  (string-pad-left "a" 3)  (read-line)
```

— all legal, all accepted by the VM. That would **manufacture** divergence, so it is not done.

The same table gap already makes the **VM** refuse those calls today while native accepts them: a pre-existing divergence in the opposite direction, invisible to the axis-3 sweep because it only ever shortens a call by one argument from the table's own number. It is filed as a build item in `docs/KNOWN_ISSUES.md` (give the table a real caller-minimum column), with the rationale for not importing the rule recorded in `docs/VM_PARITY.md`. `exact-integer?` has no `BUILTINS[]` row (native-only, `arity: null` in the manifest) and guards itself at its own lowering with the same wording.

## Evidence

Axis 3, quick lane (`--sample 30 --seed 8803`), **baseline JSON untouched**:

```
before:  tested=30 builtins, divergences=42 (baseline=368), NEW=5   -> FAIL
after:   tested=30 builtins, divergences=27 (baseline=368), NEW=0   -> PASS
```

Per-probe, all five now agree on all three routes:

```
ceiling::warity          JIT=FATAL:arity  AOT=FATAL:arity  VM=FATAL:arity
char->integer::warity    JIT=FATAL:arity  AOT=FATAL:arity  VM=FATAL:arity
exact->inexact::warity   JIT=FATAL:arity  AOT=FATAL:arity  VM=FATAL:arity
numerator::warity        JIT=FATAL:arity  AOT=FATAL:arity  VM=FATAL:arity
tanh::warity             JIT=FATAL:arity  AOT=FATAL:arity  VM=FATAL:arity
```

The 15 resolved divergences in the sample are builtins whose two engines already agreed and are now *seen* to agree (`cos`, `denominator`, `truncate`, `integer->char`, …). **The baseline file is not modified** — the ratchet is shrink-only and can be regenerated separately; nothing here is hidden by editing it.

Native behaviour is unchanged for legal calls, re-checked directly: `(make-vector 3)`, `(make-string 3)`, `(append)`, `(substring "hello" 1)`, `(round 2.5)`, `(<= 1 2 3)`, `(null? 1)`, `(gcd)` all still answer, and `(not #t #f)` / `(exact-integer?)` still refuse.

### Gates

| gate | result |
|---|---|
| `run_p8_escape.sh --quick` axis 3 | PASS (no NEW divergence) |
| `scripts/check_builtin_min_arity.py` | PASS (742 rows; drift guard verified against a doctored source) |
| `ctest -R "arity\|p8\|vm_parity\|escape\|diagnostic"` | 21/21 |
| `scripts/run_all_tests.sh` | 46/46 suites, 895 tests, 0 failures |
| `scripts/check_diagnostic_corpus.py` | 16/16 |
| `scripts/check_wasm_imports.py --build-dir build` | OK |
| `scripts/gen_language_surface.py --check` | OK |
| `scripts/check_surface_counts.py` | OK |

Axis 6 (five-way surface) fails on this branch with 7 `native_missing::*` entries — reproduced identically on an unmodified tree at the integration head, so it is pre-existing and unrelated.

## Regression pins

- `tests/diagnostics/arity_canonical_marker_builtin/` — new: `(ceiling)` must produce `Arity mismatch: ceiling expects 1 argument but got 0` at the exact span. Pins the marker, the public name and the location together.
- `tests/diagnostics/backend_arity_control/expected.json` — golden text moves to the canonical sentence (this case went through the deleted map). The other `backend_arity_*` cases assert substrings that survive the prefix unchanged.
